### PR TITLE
Implements an x86Table flag to partially ignore overlays

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Frontend.cpp
+++ b/External/FEXCore/Source/Interface/Core/Frontend.cpp
@@ -704,6 +704,7 @@ bool Decoder::DecodeInstruction(uint64_t PC) {
         // Additionally: If you hit repeat of differnt prefixes then only the LAST one before this one works for subtable selection
 
         bool NoOverlay = (FEXCore::X86Tables::SecondBaseOps[EscapeOp].Flags & InstFlags::FLAGS_NO_OVERLAY) != 0;
+        bool NoOverlay66 = (FEXCore::X86Tables::SecondBaseOps[EscapeOp].Flags & InstFlags::FLAGS_NO_OVERLAY66) != 0;
 
         if (NoOverlay) { // This section of the table ignores prefix extention
           if (NormalOpHeader(&FEXCore::X86Tables::SecondBaseOps[EscapeOp], EscapeOp)) {
@@ -726,7 +727,7 @@ bool Decoder::DecodeInstruction(uint64_t PC) {
             InstructionDecoded = true;
           }
         }
-        else if (DecodeInst->LastEscapePrefix == 0x66) { // Operand Size
+        else if (DecodeInst->LastEscapePrefix == 0x66 && !NoOverlay66) { // Operand Size
           // Remove prefix so it doesn't effect calculations.
           // This is only an escape prefix rather tan modifier now
           DecodeInst->Flags &= ~DecodeFlags::FLAG_OPERAND_SIZE;

--- a/External/FEXCore/Source/Interface/Core/X86Tables/SecondaryTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/SecondaryTables.cpp
@@ -183,7 +183,7 @@ void InitializeSecondaryTables() {
     {0xB9, 1, X86InstInfo{"",        TYPE_GROUP_10, FLAGS_NONE,                                                                                     0, nullptr}},
     {0xBA, 1, X86InstInfo{"",        TYPE_GROUP_8, FLAGS_NONE,                                                                                      0, nullptr}},
     {0xBB, 1, X86InstInfo{"BTC",     TYPE_INST, FLAGS_DEBUG_MEM_ACCESS | FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_NO_OVERLAY,                         0, nullptr}},
-    {0xBC, 1, X86InstInfo{"BSF",     TYPE_INST, FLAGS_MODRM | FLAGS_NO_OVERLAY,                                                                     0, nullptr}},
+    {0xBC, 1, X86InstInfo{"BSF",     TYPE_INST, FLAGS_MODRM | FLAGS_NO_OVERLAY66,                                                                   0, nullptr}},
     {0xBD, 1, X86InstInfo{"BSR",     TYPE_INST, FLAGS_MODRM | FLAGS_NO_OVERLAY,                                                                     0, nullptr}},
     {0xBE, 1, X86InstInfo{"MOVSX",   TYPE_INST, GenFlagsSrcSize(SIZE_8BIT) | FLAGS_MODRM | FLAGS_NO_OVERLAY,                                        0, nullptr}},
     {0xBF, 1, X86InstInfo{"MOVSX",   TYPE_INST, GenFlagsSrcSize(SIZE_16BIT) | FLAGS_MODRM | FLAGS_NO_OVERLAY,                                       0, nullptr}},

--- a/External/FEXCore/include/FEXCore/Debug/X86Tables.h
+++ b/External/FEXCore/include/FEXCore/Debug/X86Tables.h
@@ -256,12 +256,15 @@ constexpr uint32_t FLAGS_MODRM                 = (1 << 16);
 // The secondary Opcode Map uses prefix bytes to overlay more instruction
 // But some instructions need to ignore this overlay and consume these prefixes.
 constexpr uint32_t FLAGS_NO_OVERLAY           = (1 << 20);
+// Some instructions partially ignore overlay
+// Ignore OpSize (0x66) in this case
+constexpr uint32_t FLAGS_NO_OVERLAY66         = (1 << 21);
 
 // x87
-constexpr uint32_t FLAGS_POP                  = (1 << 21);
+constexpr uint32_t FLAGS_POP                  = (1 << 22);
 
 // Only SEXT if the instruction is operating in 64bit operand size
-constexpr uint32_t FLAGS_SRC_SEXT64BIT        = (1 << 22);
+constexpr uint32_t FLAGS_SRC_SEXT64BIT        = (1 << 23);
 
 constexpr uint32_t FLAGS_SIZE_DST_OFF = 26;
 constexpr uint32_t FLAGS_SIZE_SRC_OFF = FLAGS_SIZE_DST_OFF + 3;


### PR DESCRIPTION
Currently only support partially ignoring for overlay 0x66, this means
we only support no overlay at all and 0x66. Using only two bits of flag
space rather than 3.
If we find an instruction family that supports a different one then we
should break it out to three independent flags. Keeping it two until
then

Unit tests to ensure this keeps working is forthcoming