### PR TITLE
Adds unit tests for the CMPS instruction family

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -1954,70 +1954,109 @@ void OpDispatchBuilder::CMPSOp(OpcodeArgs) {
 
   auto Size = GetSrcSize(Op);
 
-  auto JumpStart = _Jump();
-  // Make sure to start a new block after ending this one
-    auto LoopStart = CreateNewCodeBlock();
-    SetJumpTarget(JumpStart, LoopStart);
-    SetCurrentCodeBlock(LoopStart);
+  bool Repeat = Op->Flags & (FEXCore::X86Tables::DecodeFlags::FLAG_REPNE_PREFIX | FEXCore::X86Tables::DecodeFlags::FLAG_REP_PREFIX);
+  if (!Repeat) {
+    OrderedNode *Dest_RDI = _LoadContext(8, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RDI]), GPRClass);
+    OrderedNode *Dest_RSI = _LoadContext(8, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RSI]), GPRClass);
 
-    OrderedNode *Counter = _LoadContext(8, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RCX]), GPRClass);
+    auto Src1 = _LoadMem(GPRClass, Size, Dest_RDI, Size);
+    auto Src2 = _LoadMem(GPRClass, Size, Dest_RSI, Size);
 
-    // Can we end the block?
-    OrderedNode *CanLeaveCond = _Select(FEXCore::IR::COND_EQ,
-      Counter, _Constant(0),
-      _Constant(1), _Constant(0));
+    auto ALUOp = _Sub(Src1, Src2);
+    GenerateFlags_SUB(Op, _Bfe(Size * 8, 0, ALUOp), _Bfe(Size * 8, 0, Src1), _Bfe(Size * 8, 0, Src2));
 
-    auto CondJump = _CondJump(CanLeaveCond);
-    IRPair<IROp_CondJump> InternalCondJump;
+    auto DF = GetRFLAG(FEXCore::X86State::RFLAG_DF_LOC);
+    auto PtrDir = _Select(FEXCore::IR::COND_EQ,
+        DF, _Constant(0),
+        _Constant(Size), _Constant(-Size));
 
-    auto LoopTail = CreateNewCodeBlock();
-    SetFalseJumpTarget(CondJump, LoopTail);
-    SetCurrentCodeBlock(LoopTail);
+    // Offset the pointer
+    Dest_RDI = _Add(Dest_RDI, PtrDir);
+    _StoreContext(GPRClass, 8, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RDI]), Dest_RDI);
 
-    // Working loop
-    {
-      OrderedNode *Dest_RDI = _LoadContext(8, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RDI]), GPRClass);
-      OrderedNode *Dest_RSI = _LoadContext(8, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RSI]), GPRClass);
+    // Offset second pointer
+    Dest_RSI = _Add(Dest_RSI, PtrDir);
+    _StoreContext(GPRClass, 8, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RSI]), Dest_RSI);
+  }
+  else {
+    bool REPE = Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_REP_PREFIX;
 
-      auto Src1 = _LoadMem(GPRClass, Size, Dest_RDI, Size);
-      auto Src2 = _LoadMem(GPRClass, Size, Dest_RSI, Size);
+    auto JumpStart = _Jump();
+    // Make sure to start a new block after ending this one
+      auto LoopStart = CreateNewCodeBlock();
+      SetJumpTarget(JumpStart, LoopStart);
+      SetCurrentCodeBlock(LoopStart);
 
-      auto ALUOp = _Sub(Src1, Src2);
-      GenerateFlags_SUB(Op, _Bfe(Size * 8, 0, ALUOp), _Bfe(Size * 8, 0, Src1), _Bfe(Size * 8, 0, Src2));
+      OrderedNode *Counter = _LoadContext(8, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RCX]), GPRClass);
 
-      OrderedNode *TailCounter = _LoadContext(8, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RCX]), GPRClass);
+      // Can we end the block?
+      OrderedNode *CanLeaveCond = _Select(FEXCore::IR::COND_EQ,
+        Counter, _Constant(0),
+        _Constant(1), _Constant(0));
 
-      // Decrement counter
-      TailCounter = _Sub(TailCounter, _Constant(1));
+      auto CondJump = _CondJump(CanLeaveCond);
+      IRPair<IROp_CondJump> InternalCondJump;
 
-      // Store the counter so we don't have to deal with PHI here
-      _StoreContext(GPRClass, 8, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RCX]), TailCounter);
+      auto LoopTail = CreateNewCodeBlock();
+      SetFalseJumpTarget(CondJump, LoopTail);
+      SetCurrentCodeBlock(LoopTail);
 
-      auto DF = GetRFLAG(FEXCore::X86State::RFLAG_DF_LOC);
-      auto PtrDir = _Select(FEXCore::IR::COND_EQ,
-          DF, _Constant(0),
-          _Constant(Size), _Constant(-Size));
+      // Working loop
+      {
+        OrderedNode *Dest_RDI = _LoadContext(8, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RDI]), GPRClass);
+        OrderedNode *Dest_RSI = _LoadContext(8, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RSI]), GPRClass);
 
-      // Offset the pointer
-      Dest_RDI = _Add(Dest_RDI, PtrDir);
-      _StoreContext(GPRClass, 8, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RDI]), Dest_RDI);
+        auto Src1 = _LoadMem(GPRClass, Size, Dest_RDI, Size);
+        auto Src2 = _LoadMem(GPRClass, Size, Dest_RSI, Size);
 
-      // Offset second pointer
-      Dest_RSI = _Add(Dest_RSI, PtrDir);
-      _StoreContext(GPRClass, 8, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RSI]), Dest_RSI);
+        auto ALUOp = _Sub(Src1, Src2);
+        GenerateFlags_SUB(Op, _Bfe(Size * 8, 0, ALUOp), _Bfe(Size * 8, 0, Src1), _Bfe(Size * 8, 0, Src2));
 
-      OrderedNode *ZF = GetRFLAG(FEXCore::X86State::RFLAG_ZF_LOC);
-      InternalCondJump = _CondJump(ZF);
+        OrderedNode *TailCounter = _LoadContext(8, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RCX]), GPRClass);
 
-      // Jump back to the start if we have more work to do
-      SetTrueJumpTarget(InternalCondJump, LoopStart);
+        // Decrement counter
+        TailCounter = _Sub(TailCounter, _Constant(1));
+
+        // Store the counter so we don't have to deal with PHI here
+        _StoreContext(GPRClass, 8, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RCX]), TailCounter);
+
+        auto DF = GetRFLAG(FEXCore::X86State::RFLAG_DF_LOC);
+        auto PtrDir = _Select(FEXCore::IR::COND_EQ,
+            DF, _Constant(0),
+            _Constant(Size), _Constant(-Size));
+
+        // Offset the pointer
+        Dest_RDI = _Add(Dest_RDI, PtrDir);
+        _StoreContext(GPRClass, 8, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RDI]), Dest_RDI);
+
+        // Offset second pointer
+        Dest_RSI = _Add(Dest_RSI, PtrDir);
+        _StoreContext(GPRClass, 8, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RSI]), Dest_RSI);
+
+        OrderedNode *ZF = GetRFLAG(FEXCore::X86State::RFLAG_ZF_LOC);
+        InternalCondJump = _CondJump(ZF);
+
+        if (REPE) {
+          // Jump back to the start if we have more work to do
+          SetTrueJumpTarget(InternalCondJump, LoopStart);
+        }
+        else {
+          // Jump back to the start if we have more work to do
+          SetFalseJumpTarget(InternalCondJump, LoopStart);
+        }
+      }
+
+    // Make sure to start a new block after ending this one
+    auto LoopEnd = CreateNewCodeBlock();
+    SetTrueJumpTarget(CondJump, LoopEnd);
+    if (REPE) {
+      SetFalseJumpTarget(InternalCondJump, LoopEnd);
     }
-
-  // Make sure to start a new block after ending this one
-  auto LoopEnd = CreateNewCodeBlock();
-  SetTrueJumpTarget(CondJump, LoopEnd);
-  SetFalseJumpTarget(InternalCondJump, LoopEnd);
-  SetCurrentCodeBlock(LoopEnd);
+    else {
+      SetTrueJumpTarget(InternalCondJump, LoopEnd);
+    }
+    SetCurrentCodeBlock(LoopEnd);
+  }
 }
 
 void OpDispatchBuilder::SCASOp(OpcodeArgs) {

--- a/unittests/ASM/Primary/Primary_A6.asm
+++ b/unittests/ASM/Primary/Primary_A6.asm
@@ -1,0 +1,42 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x8300",
+    "RDI": "0xE0000009",
+    "RSI": "0xE0000001"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x61
+mov [rdx + 8 * 0], rax
+mov rax, 0x47
+mov [rdx + 8 * 1], rax
+
+lea rdi, [rdx + 8 * 1]
+lea rsi, [rdx + 8 * 0]
+
+cld
+cmpsb ; rdi cmp rsi
+; cmp = 0x47 - 0x61 = 0xE6
+; 0: CF - 00000001
+; 1:    - 00000010
+; 2: PF - 00000000
+; 3:  0 - 00000000
+; 4: AF - 00000000
+; 5:  0 - 00000000
+; 6: ZF - 00000000
+; 7: SF - 10000000
+; ================
+;         10000011
+; OF: LAHF doesn't load - 0
+
+mov rax, 0
+lahf
+
+hlt

--- a/unittests/ASM/Primary/Primary_A6_REP.asm
+++ b/unittests/ASM/Primary/Primary_A6_REP.asm
@@ -1,0 +1,51 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x9300",
+    "RCX": "0x5",
+    "RDX": "0x0",
+    "RDI": "0xE0000005",
+    "RSI": "0xE0000015"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+%macro copy 3
+  ; Dest, Src, Size
+  mov rdi, %1
+  mov rsi, %2
+  mov rcx, %3
+
+  cld
+  rep movsb
+%endmacro
+
+mov rdx, 0xe0000000
+
+lea r15, [rdx + 8 * 0]
+lea r14, [rel .StringOne]
+copy r15, r14, 11
+
+lea r15, [rdx + 8 * 2]
+lea r14, [rel .StringTwo]
+copy r15, r14, 14
+
+lea rdi, [rdx + 8 * 0]
+lea rsi, [rdx + 8 * 2]
+
+cld
+mov rcx, 10 ; Lower String length
+repe cmpsb ; rdi cmp rsi
+mov rax, 0
+lahf
+
+mov rdx, 0
+sete dl
+
+hlt
+
+.StringOne: db "TestString\0"
+.StringTwo: db "TestUnmatched\0"

--- a/unittests/ASM/Primary/Primary_A6_REPNE.asm
+++ b/unittests/ASM/Primary/Primary_A6_REPNE.asm
@@ -1,0 +1,51 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x4600",
+    "RCX": "0x3",
+    "RDX": "0x1",
+    "RDI": "0xE0000007",
+    "RSI": "0xE0000017"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+%macro copy 3
+  ; Dest, Src, Size
+  mov rdi, %1
+  mov rsi, %2
+  mov rcx, %3
+
+  cld
+  rep movsb
+%endmacro
+
+mov rdx, 0xe0000000
+
+lea r15, [rdx + 8 * 0]
+lea r14, [rel .StringOne]
+copy r15, r14, 11
+
+lea r15, [rdx + 8 * 2]
+lea r14, [rel .StringTwo]
+copy r15, r14, 11
+
+lea rdi, [rdx + 8 * 0]
+lea rsi, [rdx + 8 * 2]
+
+cld
+mov rcx, 10 ; Lower String length
+repne cmpsb ; rdi cmp rsi
+mov rax, 0
+lahf
+
+mov rdx, 0
+sete dl
+
+hlt
+
+.StringOne: db "StringTest\0"
+.StringTwo: db "UnmatcTest\0"

--- a/unittests/ASM/Primary/Primary_A6_REP_Equal.asm
+++ b/unittests/ASM/Primary/Primary_A6_REP_Equal.asm
@@ -1,0 +1,51 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x4600",
+    "RCX": "0x0",
+    "RDX": "0x1",
+    "RDI": "0xE000000A",
+    "RSI": "0xE000001A"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+%macro copy 3
+  ; Dest, Src, Size
+  mov rdi, %1
+  mov rsi, %2
+  mov rcx, %3
+
+  cld
+  rep movsb
+%endmacro
+
+mov rdx, 0xe0000000
+
+lea r15, [rdx + 8 * 0]
+lea r14, [rel .StringOne]
+copy r15, r14, 11
+
+lea r15, [rdx + 8 * 2]
+lea r14, [rel .StringTwo]
+copy r15, r14, 11
+
+lea rdi, [rdx + 8 * 0]
+lea rsi, [rdx + 8 * 2]
+
+cld
+mov rcx, 10 ; Lower String length
+repe cmpsb ; rdi cmp rsi
+mov rax, 0
+lahf
+
+mov rdx, 0
+sete dl
+
+hlt
+
+.StringOne: db "TestString\0"
+.StringTwo: db "TestString\0"

--- a/unittests/ASM/Primary/Primary_A6_REP_Smaller.asm
+++ b/unittests/ASM/Primary/Primary_A6_REP_Smaller.asm
@@ -1,0 +1,51 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x9300",
+    "RCX": "0x5",
+    "RDX": "0x0",
+    "RDI": "0xE0000005",
+    "RSI": "0xE0000015"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+%macro copy 3
+  ; Dest, Src, Size
+  mov rdi, %1
+  mov rsi, %2
+  mov rcx, %3
+
+  cld
+  rep movsb
+%endmacro
+
+mov rdx, 0xe0000000
+
+lea r15, [rdx + 8 * 0]
+lea r14, [rel .StringOne]
+copy r15, r14, 11
+
+lea r15, [rdx + 8 * 2]
+lea r14, [rel .StringTwo]
+copy r15, r14, 14
+
+lea rdi, [rdx + 8 * 0]
+lea rsi, [rdx + 8 * 2]
+
+cld
+mov rcx, 10 ; Lower String length
+repe cmpsb ; rdi cmp rsi
+mov rax, 0
+lahf
+
+mov rdx, 0
+sete dl
+
+hlt
+
+.StringOne: db "TestString\0"
+.StringTwo: db "Test\0"

--- a/unittests/ASM/Primary/Primary_A6_REP_down.asm
+++ b/unittests/ASM/Primary/Primary_A6_REP_down.asm
@@ -1,0 +1,51 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x1600",
+    "RCX": "0x9",
+    "RDX": "0x0",
+    "RDI": "0xE000000C",
+    "RSI": "0xE000001C"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+%macro copy 3
+  ; Dest, Src, Size
+  mov rdi, %1
+  mov rsi, %2
+  mov rcx, %3
+
+  cld
+  rep movsb
+%endmacro
+
+mov rdx, 0xe0000000
+
+lea r15, [rdx + 8 * 0]
+lea r14, [rel .StringOne]
+copy r15, r14, 14
+
+lea r15, [rdx + 8 * 2]
+lea r14, [rel .StringTwo]
+copy r15, r14, 14
+
+lea rdi, [rdx + 8 * 0 + 13]
+lea rsi, [rdx + 8 * 2 + 13]
+
+std
+mov rcx, 10 ; Lower String length
+repe cmpsb ; rdi cmp rsi
+mov rax, 0
+lahf
+
+mov rdx, 0
+sete dl
+
+hlt
+
+.StringOne: db "\0\0\0\0TestString"
+.StringTwo: db "\0TestUnmatched"

--- a/unittests/ASM/Primary/Primary_A6_REP_down_Equal.asm
+++ b/unittests/ASM/Primary/Primary_A6_REP_down_Equal.asm
@@ -1,0 +1,51 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x4600",
+    "RCX": "0x0",
+    "RDX": "0x1",
+    "RDI": "0xDFFFFFFF",
+    "RSI": "0xE000000F"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+%macro copy 3
+  ; Dest, Src, Size
+  mov rdi, %1
+  mov rsi, %2
+  mov rcx, %3
+
+  cld
+  rep movsb
+%endmacro
+
+mov rdx, 0xe0000000
+
+lea r15, [rdx + 8 * 0]
+lea r14, [rel .StringOne]
+copy r15, r14, 11
+
+lea r15, [rdx + 8 * 2]
+lea r14, [rel .StringTwo]
+copy r15, r14, 11
+
+lea rdi, [rdx + 8 * 0 + 10]
+lea rsi, [rdx + 8 * 2 + 10]
+
+std
+mov rcx, 11 ; Lower String length
+repe cmpsb ; rdi cmp rsi
+mov rax, 0
+lahf
+
+mov rdx, 0
+sete dl
+
+hlt
+
+.StringOne: db "\0TestString"
+.StringTwo: db "\0TestString"

--- a/unittests/ASM/Primary/Primary_A6_down.asm
+++ b/unittests/ASM/Primary/Primary_A6_down.asm
@@ -1,0 +1,42 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x8300",
+    "RDI": "0xE0000007",
+    "RSI": "0xDFFFFFFF"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x61
+mov [rdx + 8 * 0], rax
+mov rax, 0x47
+mov [rdx + 8 * 1], rax
+
+lea rdi, [rdx + 8 * 1]
+lea rsi, [rdx + 8 * 0]
+
+std
+cmpsb ; rdi cmp rsi
+; cmp = 0x47 - 0x61 = 0xE6
+; 0: CF - 00000001
+; 1:    - 00000010
+; 2: PF - 00000000
+; 3:  0 - 00000000
+; 4: AF - 00000000
+; 5:  0 - 00000000
+; 6: ZF - 00000000
+; 7: SF - 10000000
+; ================
+;         10000011
+; OF: LAHF doesn't load - 0
+
+mov rax, 0
+lahf
+
+hlt

--- a/unittests/ASM/Primary/Primary_A7_dword.asm
+++ b/unittests/ASM/Primary/Primary_A7_dword.asm
@@ -1,0 +1,41 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x8300",
+    "RDI": "0xE000000C",
+    "RSI": "0xE0000004"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x61626364
+mov [rdx + 8 * 0], rax
+mov rax, 0x55565758
+mov [rdx + 8 * 1], rax
+
+lea rdi, [rdx + 8 * 1]
+lea rsi, [rdx + 8 * 0]
+
+cld
+cmpsd ; rdi cmp rsi
+; cmp = 0x55565758 - 0x61626364 = 0xF3F3F3F4
+; 0: CF - 00000001
+; 1:    - 00000010
+; 2: PF - 00000000
+; 3:  0 - 00000000
+; 4: AF - 00000000
+; 5:  0 - 00000000
+; 6: ZF - 00000000
+; 7: SF - 10000000
+; ================
+;         10000011
+; OF: LAHF doesn't load - 0
+mov rax, 0
+lahf
+
+hlt

--- a/unittests/ASM/Primary/Primary_A7_dword_down.asm
+++ b/unittests/ASM/Primary/Primary_A7_dword_down.asm
@@ -1,0 +1,41 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x8300",
+    "RDI": "0xE0000004",
+    "RSI": "0xDFFFFFFC"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x61626364
+mov [rdx + 8 * 0], rax
+mov rax, 0x55565758
+mov [rdx + 8 * 1], rax
+
+lea rdi, [rdx + 8 * 1]
+lea rsi, [rdx + 8 * 0]
+
+std
+cmpsd ; rdi cmp rsi
+; cmp = 0x55565758 - 0x61626364 = 0xF3F3F3F4
+; 0: CF - 00000001
+; 1:    - 00000010
+; 2: PF - 00000000
+; 3:  0 - 00000000
+; 4: AF - 00000000
+; 5:  0 - 00000000
+; 6: ZF - 00000000
+; 7: SF - 10000000
+; ================
+;         10000011
+; OF: LAHF doesn't load - 0
+mov rax, 0
+lahf
+
+hlt

--- a/unittests/ASM/Primary/Primary_A7_qword.asm
+++ b/unittests/ASM/Primary/Primary_A7_qword.asm
@@ -1,0 +1,42 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x0200",
+    "RDI": "0xE0000010",
+    "RSI": "0xE0000008"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x0000000061626364
+mov [rdx + 8 * 0], rax
+mov rax, 0x6162636465666768
+mov [rdx + 8 * 1], rax
+
+lea rdi, [rdx + 8 * 1]
+lea rsi, [rdx + 8 * 0]
+
+cld
+cmpsq ; rdi cmp rsi
+; cmp = 0x6162636465666768- 0x61626364 = 0x6162636404040404
+; 0: CF - 00000000
+; 1:    - 00000010
+; 2: PF - 00000000
+; 3:  0 - 00000000
+; 4: AF - 00000000
+; 5:  0 - 00000000
+; 6: ZF - 00000000
+; 7: SF - 00000000
+; ================
+;         00000010
+; OF: LAHF doesn't load - 0
+
+mov rax, 0
+lahf
+
+hlt

--- a/unittests/ASM/Primary/Primary_A7_qword_down.asm
+++ b/unittests/ASM/Primary/Primary_A7_qword_down.asm
@@ -1,0 +1,42 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x0200",
+    "RDI": "0xE0000000",
+    "RSI": "0xDFFFFFF8"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x0000000061626364
+mov [rdx + 8 * 0], rax
+mov rax, 0x6162636465666768
+mov [rdx + 8 * 1], rax
+
+lea rdi, [rdx + 8 * 1]
+lea rsi, [rdx + 8 * 0]
+
+std
+cmpsq ; rdi cmp rsi
+; cmp = 0x6162636465666768- 0x61626364 = 0x6162636404040404
+; 0: CF - 00000000
+; 1:    - 00000010
+; 2: PF - 00000000
+; 3:  0 - 00000000
+; 4: AF - 00000000
+; 5:  0 - 00000000
+; 6: ZF - 00000000
+; 7: SF - 00000000
+; ================
+;         00000010
+; OF: LAHF doesn't load - 0
+
+mov rax, 0
+lahf
+
+hlt

--- a/unittests/ASM/Primary/Primary_A7_word.asm
+++ b/unittests/ASM/Primary/Primary_A7_word.asm
@@ -1,0 +1,42 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x8700",
+    "RDI": "0xE000000A",
+    "RSI": "0xE0000002"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x6162
+mov [rdx + 8 * 0], rax
+mov rax, 0x4546
+mov [rdx + 8 * 1], rax
+
+lea rdi, [rdx + 8 * 1]
+lea rsi, [rdx + 8 * 0]
+
+cld
+cmpsw ; rdi cmp rsi
+; cmp = 0x4546 - 0x6162 = 0xE3E4
+; 0: CF - 00000001
+; 1:    - 00000010
+; 2: PF - 00000100
+; 3:  0 - 00000000
+; 4: AF - 00000000
+; 5:  0 - 00000000
+; 6: ZF - 00000000
+; 7: SF - 10000000
+; ================
+;         10000111
+; OF: LAHF doesn't load - 0
+
+mov rax, 0
+lahf
+
+hlt

--- a/unittests/ASM/Primary/Primary_A7_word_down.asm
+++ b/unittests/ASM/Primary/Primary_A7_word_down.asm
@@ -1,0 +1,42 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x8700",
+    "RDI": "0xE0000006",
+    "RSI": "0xDFFFFFFE"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x6162
+mov [rdx + 8 * 0], rax
+mov rax, 0x4546
+mov [rdx + 8 * 1], rax
+
+lea rdi, [rdx + 8 * 1]
+lea rsi, [rdx + 8 * 0]
+
+std
+cmpsw ; rdi cmp rsi
+; cmp = 0x4546 - 0x6162 = 0xE3E4
+; 0: CF - 00000001
+; 1:    - 00000010
+; 2: PF - 00000100
+; 3:  0 - 00000000
+; 4: AF - 00000000
+; 5:  0 - 00000000
+; 6: ZF - 00000000
+; 7: SF - 10000000
+; ================
+;         10000111
+; OF: LAHF doesn't load - 0
+
+mov rax, 0
+lahf
+
+hlt


### PR DESCRIPTION
Also implements support for CMPS with no repeat prefix and the REPNE prefix.
Isn't all encompassing for the unit tests, there are still some cases we aren't testing.