### PR TITLE
Fix Neg IR_OP, Add Not IR_OP

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -505,8 +505,22 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
           }
           case IR::OP_NEG: {
             auto Op = IROp->C<IR::IROp_Neg>();
-            uint64_t Src = *GetSrc<uint64_t*>(Op->Header.Args[0]);
-            GD = -Src;
+            uint64_t Src = *GetSrc<int64_t*>(Op->Header.Args[0]);
+            switch (OpSize) {
+              case 1:
+                GD = -static_cast<int8_t>(Src);
+                break;
+              case 2:
+                GD = -static_cast<int16_t>(Src);
+                break;
+              case 4:
+                GD = -static_cast<int32_t>(Src);
+                break;
+              case 8:
+                GD = -static_cast<int64_t>(Src);
+                break;
+              default: LogMan::Msg::A("Unknown NEG Size: %d\n", OpSize); break;
+            };
             break;
           }
           case IR::OP_OR: {
@@ -652,7 +666,8 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
           case IR::OP_NOT: {
             auto Op = IROp->C<IR::IROp_Not>();
             uint64_t Src = *GetSrc<uint64_t*>(Op->Header.Args[0]);
-            GD = ~Src;
+            uint8_t Mask = OpSize * 8 - 1;
+            GD = (~Src) & Mask;
             break;
           }
           case IR::OP_ZEXT: {

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -503,6 +503,12 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
             }
             break;
           }
+          case IR::OP_NEG: {
+            auto Op = IROp->C<IR::IROp_Neg>();
+            uint64_t Src = *GetSrc<uint64_t*>(Op->Header.Args[0]);
+            GD = -Src;
+            break;
+          }
           case IR::OP_OR: {
             auto Op = IROp->C<IR::IROp_Or>();
             void *Src1 = GetSrc<void*>(Op->Header.Args[0]);
@@ -643,8 +649,8 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
             }
             break;
           }
-          case IR::OP_NEG: {
-            auto Op = IROp->C<IR::IROp_Neg>();
+          case IR::OP_NOT: {
+            auto Op = IROp->C<IR::IROp_Not>();
             uint64_t Src = *GetSrc<uint64_t*>(Op->Header.Args[0]);
             GD = ~Src;
             break;

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -907,6 +907,11 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
         }
         break;
       }
+      case IR::OP_NOT: {
+        auto Op = IROp->C<IR::IROp_Not>();
+        mvn(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()));
+        break;
+      }
       case IR::OP_ZEXT: {
         auto Op = IROp->C<IR::IROp_Zext>();
         LogMan::Throw::A(Op->SrcSize <= 64, "Can't support Zext of size: %ld", Op->SrcSize);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -773,7 +773,15 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
       }
       case IR::OP_NEG: {
         auto Op = IROp->C<IR::IROp_Neg>();
-        neg(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()));
+        switch (Op->SrcSize / 8) {
+        case 4:
+          neg(GetDst<RA_32>(Node), GetSrc<RA_32>(Op->Header.Args[0].ID()));
+          break;
+        case 8:
+          neg(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()));
+          break;
+        default: LogMan::Msg::A("Unsupported Not size: %d", Op->SrcSize / 8);
+        }
         break;
       }
       case IR::OP_SUB: {
@@ -909,7 +917,15 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
       }
       case IR::OP_NOT: {
         auto Op = IROp->C<IR::IROp_Not>();
-        mvn(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()));
+        switch (Op->SrcSize / 8) {
+        case 4:
+          mvn(GetDst<RA_32>(Node), GetSrc<RA_32>(Op->Header.Args[0].ID()));
+          break;
+        case 8:
+          mvn(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()));
+          break;
+        default: LogMan::Msg::A("Unsupported Not size: %d", Op->SrcSize / 8);
+        }
         break;
       }
       case IR::OP_ZEXT: {

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -878,6 +878,13 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
           }
           break;
         }
+        case IR::OP_NOT: {
+          auto Op = IROp->C<IR::IROp_Not>();
+          auto Dst = GetDst<RA_64>(Node);
+          mov(Dst, GetSrc<RA_64>(Op->Header.Args[0].ID()));
+          not_(Dst);
+          break;
+        }
         case IR::OP_ZEXT: {
           auto Op = IROp->C<IR::IROp_Zext>();
           LogMan::Throw::A(Op->SrcSize <= 64, "Can't support Zext of size: %ld", Op->SrcSize);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -808,8 +808,29 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
         }
         case IR::OP_NEG: {
           auto Op = IROp->C<IR::IROp_Neg>();
-          auto Dst = GetDst<RA_64>(Node);
-          mov(Dst, GetSrc<RA_64>(Op->Header.Args[0].ID()));
+          Xbyak::Reg Src;
+          Xbyak::Reg Dst;
+          switch (OpSize) {
+          case 1:
+            Src = GetSrc<RA_8>(Op->Header.Args[0].ID());
+            Dst = GetDst<RA_8>(Node);
+            break;
+          case 2:
+            Src = GetSrc<RA_16>(Op->Header.Args[0].ID());
+            Dst = GetDst<RA_16>(Node);
+            break;
+          case 4:
+            Src = GetSrc<RA_32>(Op->Header.Args[0].ID());
+            Dst = GetDst<RA_32>(Node);
+            break;
+          case 8:
+            Src = GetSrc<RA_64>(Op->Header.Args[0].ID());
+            Dst = GetDst<RA_64>(Node);
+            break;
+          default:  LogMan::Msg::A("Unhandled Neg size: %d", OpSize);
+            continue;
+          }
+          mov(Dst, Src);
           neg(Dst);
           break;
         }

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -1405,7 +1405,7 @@ void OpDispatchBuilder::BTROp(OpcodeArgs) {
     OrderedNode *BitSelect = _And(Src, SizeMask);
 
     OrderedNode *BitMask = _Lshl(_Constant(1), BitSelect);
-    BitMask = _Neg(BitMask);
+    BitMask = _Not(BitMask);
     Dest = _And(Dest, BitMask);
     StoreResult(GPRClass, Op, Dest, -1);
   }
@@ -1433,7 +1433,7 @@ void OpDispatchBuilder::BTROp(OpcodeArgs) {
     // Now shift in to the correct bit location
     Result = _Lshr(Value, BitSelect);
     OrderedNode *BitMask = _Lshl(_Constant(1), BitSelect);
-    BitMask = _Neg(BitMask);
+    BitMask = _Not(BitMask);
     Value = _And(Value, BitMask);
     _StoreMem(GPRClass, Size, MemoryLocation, Value, Size);
   }

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -241,6 +241,11 @@
       "SSAArgs": "2"
     },
 
+    "Neg": {
+      "HasDest": true,
+      "SSAArgs": "1"
+    },
+
     "Mul": {
 			"HasDest": true,
       "SSAArgs": "2"
@@ -359,7 +364,7 @@
       ]
     },
 
-    "Neg": {
+    "Not": {
 			"HasDest": true,
       "SSAArgs": "1"
     },


### PR DESCRIPTION
In some places, Neg meant logical one's complement negation.
In others it meant arithmetic two's complement negation.

As both x87 and aarch64 have neg instructions that do two's complement negations, we will standardise on that.

Additionally we will add a Not_IR op for one's complement.