### PR TITLE
Fixes FindTrailingZeros IR op in x86 JIT

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -3548,7 +3548,18 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
         }
         case IR::OP_FINDTRAILINGZEROS: {
           auto Op = IROp->C<IR::IROp_FindTrailingZeros>();
-          tzcnt(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()));
+          switch (OpSize) {
+            case 2:
+              tzcnt(GetDst<RA_16>(Node), GetSrc<RA_16>(Op->Header.Args[0].ID()));
+            break;
+            case 4:
+              tzcnt(GetDst<RA_32>(Node), GetSrc<RA_32>(Op->Header.Args[0].ID()));
+              break;
+            case 8:
+              tzcnt(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()));
+              break;
+            default: LogMan::Msg::A("Unknown size: %d", OpSize); break;
+          }
           break;
         }
         case IR::OP_DUMMY:

--- a/unittests/ASM/REP/F3_BC.asm
+++ b/unittests/ASM/REP/F3_BC.asm
@@ -7,7 +7,9 @@
     "RDX": "0x40",
     "RSI": "0x0",
     "R14": "0x0",
-    "R13": "0x0"
+    "R13": "0x0",
+    "R12": "0x20",
+    "R11": "0x10"
   },
   "MemoryRegions": {
     "0x100000000": "4096"
@@ -32,7 +34,11 @@ tzcnt ebx, dword [rdx + 8 * 1]
 tzcnt rcx, qword [rdx + 8 * 2]
 
 mov r15, 0
+mov r12, 0
+mov r11, 0
 tzcnt rdx, r15
+tzcnt r12d, r15d
+tzcnt r11w, r15w
 
 mov r15, 0xFFFFFFFFFFFFFFFF
 tzcnt esi, r15d


### PR DESCRIPTION
In the case that we were TZCNT was passed a zero input and the register size was <64bit then we were returning a wrong value.
Makes the x86 JIT handle the smaller sizes.
Updates the unit test so it tests that case.