### PR TITLE
Minor optimization in vsqxtun for x86

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -2353,8 +2353,6 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
         }
         case IR::OP_VSQXTUN: {
           auto Op = IROp->C<IR::IROp_VSQXTUN>();
-          // Zero the lower bits
-          vpxor(xmm15, xmm15, xmm15);
           switch (Op->ElementSize) {
             case 2:
               packuswb(xmm15, GetSrc(Op->Header.Args[0].ID()));


### PR DESCRIPTION
No need to zero the register when we are going to logical shift the
upper 64bits to the lower 64bits anyway