### PR TITLE
Make the unit test runner allocate less SHM space

### DIFF
--- a/Source/Tests/TestHarnessRunner.cpp
+++ b/Source/Tests/TestHarnessRunner.cpp
@@ -64,7 +64,7 @@ int main(int argc, char **argv) {
   LogMan::Throw::A(Args.size() > 1, "Not enough arguments");
 
   FEXCore::Context::InitializeStaticTables();
-  auto SHM = FEXCore::SHM::AllocateSHMRegion(1ULL << 36);
+  auto SHM = FEXCore::SHM::AllocateSHMRegion(1ULL << 34);
   auto CTX = FEXCore::Context::CreateNewContext();
 
   FEXCore::Context::SetCustomCPUBackendFactory(CTX, VMFactory::CPUCreationFactory);


### PR DESCRIPTION
It doesn't need 64GB of virtual memory, so knock it down to its minimum
virtual memory required