### PR TITLE
Moves FEXCore install target to the FEXCore/Source directory

### DIFF
--- a/External/FEXCore/CMakeLists.txt
+++ b/External/FEXCore/CMakeLists.txt
@@ -50,14 +50,6 @@ include_directories(${CMAKE_SOURCE_DIR}/External/SonicUtils/include/SonicUtils)
 add_subdirectory(Source/)
 add_subdirectory(Examples/)
 
-install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_shared
-  LIBRARY
-    DESTINATION lib
-    COMPONENT Libraries
-  ARCHIVE
-    DESTINATION lib
-    COMPONENT Libraries)
-
 install (DIRECTORY include/FEXCore ${CMAKE_BINARY_DIR}/include/FEXCore
   DESTINATION include
   COMPONENT Development)

--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -169,4 +169,13 @@ endfunction()
 
 AddLibrary(${PROJECT_NAME} STATIC)
 AddLibrary(${PROJECT_NAME}_shared SHARED)
+
+install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_shared
+  LIBRARY
+    DESTINATION lib
+    COMPONENT Libraries
+  ARCHIVE
+    DESTINATION lib
+    COMPONENT Libraries)
+
 add_subdirectory(Test/)


### PR DESCRIPTION
This fixes an issue with older cmake versions where it throws an error
if the install target was declared in a different cmake file

Newer cmake doesn't seem to care