### PR TITLE
LLVM 9 fixes

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -304,7 +304,33 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
             }
             break;
           }
+          case IR::OP_VEXTRACTELEMENT: {
+            auto Op = IROp->C<IR::IROp_VExtractElement>();
+            LogMan::Throw::A(Op->RegisterSize <= 16, "OpSize is too large for VExtractToGPR: %d", OpSize);
+            if (Op->RegisterSize == 16) {
+              __uint128_t SourceMask = (1ULL << (Op->ElementSize * 8)) - 1;
+              uint64_t Shift = Op->ElementSize * Op->Index * 8;
+              if (Op->ElementSize == 8)
+                SourceMask = ~0ULL;
 
+              __uint128_t Src = *GetSrc<__uint128_t*>(Op->Header.Args[0]);
+              Src >>= Shift;
+              Src &= SourceMask;
+              memcpy(GDP, &Src, Op->ElementSize);
+            }
+            else {
+              uint64_t SourceMask = (1ULL << (Op->ElementSize * 8)) - 1;
+              uint64_t Shift = Op->ElementSize * Op->Index * 8;
+              if (Op->ElementSize == 8)
+                SourceMask = ~0ULL;
+
+              uint64_t Src = *GetSrc<uint64_t*>(Op->Header.Args[0]);
+              Src >>= Shift;
+              Src &= SourceMask;
+              GD = Src;
+            }
+            break;
+          }
           case IR::OP_CONSTANT: {
             auto Op = IROp->C<IR::IROp_Constant>();
             GD = Op->Constant;
@@ -2806,6 +2832,44 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
                 auto *Dst_d  = reinterpret_cast<uint64_t*>(Tmp);
                 auto *Src2_d = reinterpret_cast<uint64_t*>(Src2);
                 Dst_d[Op->DestIdx] = Src2_d[Op->SrcIdx];
+                break;
+              }
+              default: LogMan::Msg::A("Unknown Element Size: %d", Op->ElementSize); break;
+            };
+            memcpy(GDP, Tmp, Op->RegisterSize);
+            break;
+          }
+          case IR::OP_VINSSCALARELEMENT: {
+            auto Op = IROp->C<IR::IROp_VInsScalarElement>();
+            void *Src1 = GetSrc<void*>(Op->Header.Args[0]);
+            void *Src2 = GetSrc<void*>(Op->Header.Args[1]);
+            uint8_t Tmp[16];
+
+            // Copy src1 in to dest
+            memcpy(Tmp, Src1, Op->RegisterSize);
+            switch (Op->ElementSize) {
+              case 1: {
+                auto *Dst_d  = reinterpret_cast<uint8_t*>(Tmp);
+                auto Src2_d = *reinterpret_cast<uint8_t*>(Src2);
+                Dst_d[Op->DestIdx] = Src2_d;
+                break;
+              }
+              case 2: {
+                auto *Dst_d  = reinterpret_cast<uint16_t*>(Tmp);
+                auto Src2_d = *reinterpret_cast<uint16_t*>(Src2);
+                Dst_d[Op->DestIdx] = Src2_d;
+                break;
+              }
+              case 4: {
+                auto *Dst_d  = reinterpret_cast<uint32_t*>(Tmp);
+                auto Src2_d = *reinterpret_cast<uint32_t*>(Src2);
+                Dst_d[Op->DestIdx] = Src2_d;
+                break;
+              }
+              case 8: {
+                auto *Dst_d  = reinterpret_cast<uint64_t*>(Tmp);
+                auto Src2_d = *reinterpret_cast<uint64_t*>(Src2);
+                Dst_d[Op->DestIdx] = Src2_d;
                 break;
               }
               default: LogMan::Msg::A("Unknown Element Size: %d", Op->ElementSize); break;

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -3179,7 +3179,7 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
           case IR::OP_VECTOR_FTOF: {
             auto Op = IROp->C<IR::IROp_Vector_FToF>();
             void *Src = GetSrc<void*>(Op->Header.Args[0]);
-            uint8_t Tmp[16];
+            uint8_t Tmp[16]{};
 
             uint16_t Conv = (Op->DstElementSize << 8) | Op->SrcElementSize;
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -530,6 +530,25 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
         }
         break;
       }
+      case IR::OP_VEXTRACTELEMENT: {
+        auto Op = IROp->C<IR::IROp_VExtractElement>();
+        switch (OpSize) {
+          case 1:
+            mov(GetDst(Node).B(), GetSrc(Op->Header.Args[0].ID()).V16B(), Op->Index);
+          break;
+          case 2:
+            mov(GetDst(Node).H(), GetSrc(Op->Header.Args[0].ID()).V8H(), Op->Index);
+          break;
+          case 4:
+            mov(GetDst(Node).S(), GetSrc(Op->Header.Args[0].ID()).V4S(), Op->Index);
+          break;
+          case 8:
+            mov(GetDst(Node).D(), GetSrc(Op->Header.Args[0].ID()).V2D(), Op->Index);
+          break;
+          default:  LogMan::Msg::A("Unhandled ExtractElementSize: %d", OpSize);
+        }
+        break;
+      }
       case IR::OP_JUMP: {
         auto Op = IROp->C<IR::IROp_Jump>();
 
@@ -2035,6 +2054,31 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
         }
         case 8: {
           mov(VTMP1.V2D(), Op->DestIdx, GetSrc(Op->Header.Args[1].ID()).V2D(), Op->SrcIdx);
+        break;
+        }
+        default: LogMan::Msg::A("Unknown Element Size: %d", Op->ElementSize); break;
+        }
+        mov(GetDst(Node), VTMP1);
+        break;
+      }
+      case IR::OP_VINSSCALARELEMENT: {
+        auto Op = IROp->C<IR::IROp_VInsScalarElement>();
+        mov(VTMP1, GetSrc(Op->Header.Args[0].ID()));
+        switch (Op->ElementSize) {
+        case 1: {
+          mov(VTMP1.V16B(), Op->DestIdx, GetSrc(Op->Header.Args[1].ID()).V16B(), 0);
+        break;
+        }
+        case 2: {
+          mov(VTMP1.V8H(), Op->DestIdx, GetSrc(Op->Header.Args[1].ID()).V8H(), 0);
+        break;
+        }
+        case 4: {
+          mov(VTMP1.V4S(), Op->DestIdx, GetSrc(Op->Header.Args[1].ID()).V4S(), 0);
+        break;
+        }
+        case 8: {
+          mov(VTMP1.V2D(), Op->DestIdx, GetSrc(Op->Header.Args[1].ID()).V2D(), 0);
         break;
         }
         default: LogMan::Msg::A("Unknown Element Size: %d", Op->ElementSize); break;

--- a/External/FEXCore/Source/Interface/Core/LLVMJIT/LLVMCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/LLVMJIT/LLVMCore.cpp
@@ -1267,7 +1267,7 @@ void LLVMJITCore::HandleIR(FEXCore::IR::IRListView<true> const *IR, IR::NodeWrap
       // Our IR assumes defined behaviour for shifting all the bits out of the value
       // So we need to ZEXT to the next size up and then trunc
       auto OriginalType = Src1->getType();
-      auto BiggerType = Type::getIntNTy(*Con, 128);
+      auto BiggerType = Type::getIntNTy(*Con, OriginalType->getPrimitiveSizeInBits() * 2);
       Src1 = JITState.IRBuilder->CreateZExt(Src1, BiggerType);
       Src2 = JITState.IRBuilder->CreateZExtOrTrunc(Src2, BiggerType);
 
@@ -1284,7 +1284,7 @@ void LLVMJITCore::HandleIR(FEXCore::IR::IRListView<true> const *IR, IR::NodeWrap
       // Our IR assumes defined behaviour for shifting all the bits out of the value
       // So we need to ZEXT to the next size up and then trunc
       auto OriginalType = Src1->getType();
-      auto BiggerType = Type::getIntNTy(*Con, 128);
+      auto BiggerType = Type::getIntNTy(*Con, OriginalType->getPrimitiveSizeInBits() * 2);
       Src1 = JITState.IRBuilder->CreateSExt(Src1, BiggerType);
       Src2 = JITState.IRBuilder->CreateZExtOrTrunc(Src2, BiggerType);
 
@@ -1301,7 +1301,7 @@ void LLVMJITCore::HandleIR(FEXCore::IR::IRListView<true> const *IR, IR::NodeWrap
       // Our IR assumes defined behaviour for shifting all the bits out of the value
       // So we need to ZEXT to the next size up and then trunc
       auto OriginalType = Src1->getType();
-      auto BiggerType = Type::getIntNTy(*Con, 128);
+      auto BiggerType = Type::getIntNTy(*Con, OriginalType->getPrimitiveSizeInBits() * 2);
       Src1 = JITState.IRBuilder->CreateZExt(Src1, BiggerType);
       Src2 = JITState.IRBuilder->CreateZExtOrTrunc(Src2, BiggerType);
 

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -2383,7 +2383,7 @@ void OpDispatchBuilder::MOVLPOp(OpcodeArgs) {
   OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, 8);
   if (Op->Dest.TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_GPR) {
     OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, 8, 16);
-    auto Result = _VInsElement(16, 8, 0, 0, Dest, Src);
+    auto Result = _VInsScalarElement(16, 8, 0, Dest, Src);
     StoreResult_WithOpSize(FPRClass, Op, Op->Dest, Result, 8, 16);
   }
   else {
@@ -2406,7 +2406,7 @@ void OpDispatchBuilder::MOVSSOp(OpcodeArgs) {
     // MOVSS xmm1, xmm2
     OrderedNode *Dest = LoadSource_WithOpSize(FPRClass, Op, Op->Dest, 16, Op->Flags, -1);
     OrderedNode *Src = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], 4, Op->Flags, -1);
-    auto Result = _VInsElement(16, 4, 0, 0, Dest, Src);
+    auto Result = _VInsScalarElement(16, 4, 0, Dest, Src);
     StoreResult(FPRClass, Op, Result, -1);
   }
   else if (Op->Dest.TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_GPR) {
@@ -2430,7 +2430,7 @@ void OpDispatchBuilder::MOVSDOp(OpcodeArgs) {
     // xmm1[63:0] <- xmm2[63:0]
     OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
     OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-    auto Result = _VInsElement(16, 8, 0, 0, Dest, Src);
+    auto Result = _VInsScalarElement(16, 8, 0, Dest, Src);
     StoreResult(FPRClass, Op, Result, -1);
   }
   else if (Op->Dest.TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_GPR) {
@@ -2523,7 +2523,7 @@ void OpDispatchBuilder::VectorScalarALUOp(OpcodeArgs) {
   ALUOp.first->Header.Op = IROp;
 
   // Insert the lower bits
-  auto Result = _VInsElement(Size, ElementSize, 0, 0, Dest, ALUOp);
+  auto Result = _VInsScalarElement(Size, ElementSize, 0, Dest, ALUOp);
 
   StoreResult(FPRClass, Op, Result, -1);
 }
@@ -2543,7 +2543,7 @@ void OpDispatchBuilder::VectorUnaryOp(OpcodeArgs) {
 
   if (Scalar) {
     // Insert the lower bits
-    auto Result = _VInsElement(GetSrcSize(Op), ElementSize, 0, 0, Dest, ALUOp);
+    auto Result = _VInsScalarElement(GetSrcSize(Op), ElementSize, 0, Dest, ALUOp);
     StoreResult(FPRClass, Op, Result, -1);
   }
   else {
@@ -4013,7 +4013,7 @@ void OpDispatchBuilder::CVTGPR_To_FPR(OpcodeArgs) {
 
   OrderedNode *Dest = LoadSource_WithOpSize(FPRClass, Op, Op->Dest, 16, Op->Flags, -1);
 
-  Src = _VInsElement(16, DstElementSize, 0, 0, Dest, Src);
+  Src = _VInsScalarElement(16, DstElementSize, 0, Dest, Src);
 
   StoreResult(FPRClass, Op, Src, -1);
 }
@@ -4067,7 +4067,7 @@ void OpDispatchBuilder::Scalar_CVT_Float_To_Float(OpcodeArgs) {
   OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
 
   Src = _Float_FToF(Src, DstElementSize, SrcElementSize);
-  Src = _VInsElement(16, DstElementSize, 0, 0, Dest, Src);
+  Src = _VInsScalarElement(16, DstElementSize, 0, Dest, Src);
 
   StoreResult(FPRClass, Op, Src, -1);
 }

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -332,6 +332,12 @@ public:
   IRPair<IROp_VInsElement> _VInsElement(uint8_t RegisterSize, uint8_t ElementSize, uint8_t DestIdx, uint8_t SrcIdx, OrderedNode *ssa0, OrderedNode *ssa1) {
     return _VInsElement(ssa0, ssa1, RegisterSize, ElementSize, DestIdx, SrcIdx);
   }
+  IRPair<IROp_VInsScalarElement> _VInsScalarElement(uint8_t RegisterSize, uint8_t ElementSize, uint8_t DestIdx, OrderedNode *ssa0, OrderedNode *ssa1) {
+    return _VInsScalarElement(ssa0, ssa1, RegisterSize, ElementSize, DestIdx);
+  }
+  IRPair<IROp_VExtractElement> _VExtractElement(uint8_t RegisterSize, uint8_t ElementSize, OrderedNode *ssa0, uint8_t Index) {
+    return _VExtractElement(ssa0, RegisterSize, ElementSize, Index);
+  }
   IRPair<IROp_VAnd> _VAnd(uint8_t RegisterSize, uint8_t ElementSize, OrderedNode *ssa0, OrderedNode *ssa1) {
     return _VAnd(ssa0, ssa1, RegisterSize, ElementSize);
   }

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -967,6 +967,27 @@
       ]
     },
 
+    "VInsScalarElement": {
+      "HasDest": true,
+      "SSAArgs": "2",
+      "Args": [
+        "uint8_t", "RegisterSize",
+        "uint8_t", "ElementSize",
+        "uint8_t", "DestIdx"
+      ]
+    },
+
+    "VExtractElement": {
+      "HasDest": true,
+      "DestSize": "ElementSize",
+      "SSAArgs": "1",
+      "Args": [
+        "uint8_t", "RegisterSize",
+        "uint8_t", "ElementSize",
+        "uint8_t", "Index"
+      ]
+    },
+
     "VExtr": {
 			"HasDest": true,
       "SSAArgs": "2",


### PR DESCRIPTION
Moving from LLVM 8 to LLVM 9 caused unit tests to fail.
I didn't notice since my desktop was on LLVM 8 while the unit test runner was on LLVM 9.
We will want to keep an eye on LLVM 10 once it releases soon as well.