### PR TITLE
Makes sure DCE pass doesn't remove print IR op

### DIFF
--- a/External/FEXCore/Source/Interface/IR/Passes/DeadCodeElimination.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/DeadCodeElimination.cpp
@@ -49,6 +49,7 @@ bool DeadCodeElimination::Run(OpDispatchBuilder *Disp) {
       case OP_STOREFLAG:
       case OP_STOREMEM:
       case OP_CAS:
+      case OP_PRINT:
         // Keep
         break;
       // IO


### PR DESCRIPTION
This is useful for debugging, don't want the DCE pass to remove it