### PR TITLE
Adds hypervisor CPUID function

### DIFF
--- a/External/FEXCore/Source/Interface/Core/CPUID.cpp
+++ b/External/FEXCore/Source/Interface/Core/CPUID.cpp
@@ -155,6 +155,9 @@ void CPUIDEmu::Init() {
   // SoC vendor attribute enumeration
   RegisterFunction(0x17, std::bind(&CPUIDEmu::Function_Reserved, this));
 
+  // Hypervisor vendor string
+  RegisterFunction(0x4000'0000, std::bind(&CPUIDEmu::Function_Reserved, this));
+
   // Largest extended function number
   RegisterFunction(0x8000'0000, std::bind(&CPUIDEmu::Function_8000_0000h, this));
   // Processor vendor


### PR DESCRIPTION
4000'0000h is the hypervisor CPUID information leaf, can just return all
zeroes to imply we aren't running under a hypervisor

EAX: The maximum input value for CPUID supported by the hypervisor.
     - We return zero here to signify no Hypervisor
EBX, ECX, EDX: Vedor ID signature

CPUID 4000'0001h - 4000'000Fh is reserved for hypervisor, which we don't
need to expose since we return zero in EAX