### PR TITLE
Fixes the dynamic linker detection

### DIFF
--- a/External/SonicUtils/Source/ELFLoader.cpp
+++ b/External/SonicUtils/Source/ELFLoader.cpp
@@ -15,9 +15,10 @@ ELFContainer::ELFContainer(std::string const &Filename, bool CustomInterpreter) 
   }
 
   if (InterpreterHeader && !CustomInterpreter) {
-    DynamicProgram = true;
     // If we we are dynamic application then we have an interpreter program header
     // We need to load that ELF instead if it exists
+    // We are no longer dynamic since we are executing the interpreter
+    DynamicProgram = false;
     const char *RawString = &RawFile.at(InterpreterHeader->p_offset);
     if (!LoadELF(RawString)) {
       LogMan::Msg::E("Couldn't load dynamic ELF file's interpreter");

--- a/External/SonicUtils/include/SonicUtils/ELFLoader.h
+++ b/External/SonicUtils/include/SonicUtils/ELFLoader.h
@@ -44,6 +44,7 @@ public:
   ELFSymbol const *GetSymbolInRange(RangeType Address);
 
   bool WasDynamic() const { return DynamicProgram; }
+  bool HasDynamicLinker() const { return !DynamicLinker.empty(); }
   std::string &InterpreterLocation() { return DynamicLinker; }
 
   std::vector<char const*> const *GetNecessaryLibs() const { return &NecessaryLibs; }

--- a/Source/Tests/HarnessHelpers.h
+++ b/Source/Tests/HarnessHelpers.h
@@ -386,7 +386,7 @@ public:
     , DB {&File}
     , Args {args} {
 
-    if (File.WasDynamic()) {
+    if (File.HasDynamicLinker()) {
       // If the file isn't static then we need to add the filename of interpreter
       // to the front of the argument list
       Args.emplace(Args.begin(), File.InterpreterLocation());


### PR DESCRIPTION
Fixes #49

Makes it so we no longer have to pass in the ld location to the
ELFLoader application.

Once we switch over to the dynamic linker, the program being executed to
us is no longer a dynamic program.
But the frontend ELF loader also still needs to know that we are
executing the dynamic linker so it can append the linker to the
arguments.