### PR TITLE
Implements the COMISS instructions

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -3206,6 +3206,56 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
             memcpy(GDP, Tmp, Op->RegisterSize);
             break;
           }
+          case IR::OP_FCMP: {
+            auto Op = IROp->C<IR::IROp_FCmp>();
+            uint32_t ResultFlags{};
+            if (Op->ElementSize == 4) {
+              float Src1 = *GetSrc<float*>(Op->Header.Args[0]);
+              float Src2 = *GetSrc<float*>(Op->Header.Args[1]);
+              if (Op->Flags & (1 << FCMP_FLAG_LT)) {
+                if (Src1 < Src2) {
+                  ResultFlags |= (1 << FCMP_FLAG_LT);
+                }
+              }
+              if (Op->Flags & (1 << FCMP_FLAG_UNORDERED)) {
+                if (std::isnan(Src1) || std::isnan(Src2)) {
+                  ResultFlags |= (1 << FCMP_FLAG_UNORDERED);
+                }
+              }
+              if (Op->Flags & (1 << FCMP_FLAG_EQ)) {
+                if (Src1 == Src2) {
+                  ResultFlags |= (1 << FCMP_FLAG_EQ);
+                }
+              }
+            }
+            else {
+              double Src1 = *GetSrc<double*>(Op->Header.Args[0]);
+              double Src2 = *GetSrc<double*>(Op->Header.Args[1]);
+              if (Op->Flags & (1 << FCMP_FLAG_LT)) {
+                if (Src1 < Src2) {
+                  ResultFlags |= (1 << FCMP_FLAG_LT);
+                }
+              }
+              if (Op->Flags & (1 << FCMP_FLAG_UNORDERED)) {
+                if (std::isnan(Src1) || std::isnan(Src2)) {
+                  ResultFlags |= (1 << FCMP_FLAG_UNORDERED);
+                }
+              }
+              if (Op->Flags & (1 << FCMP_FLAG_EQ)) {
+                if (Src1 == Src2) {
+                  ResultFlags |= (1 << FCMP_FLAG_EQ);
+                }
+              }
+            }
+
+            GD = ResultFlags;
+            break;
+          }
+          case IR::OP_GETHOSTFLAG: {
+            auto Op = IROp->C<IR::IROp_GetHostFlag>();
+            GD = (*GetSrc<uint64_t*>(Op->Header.Args[0]) >> Op->Flag) & 1;
+            break;
+          }
           #define DO_SCALAR_COMPARE_OP(size, type, type2, func)              \
             case size: {                                      \
             auto *Dst_d  = reinterpret_cast<type2*>(Tmp);  \

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -269,6 +269,8 @@ public:
   void FXRStoreOp(OpcodeArgs);
 
   void PAlignrOp(OpcodeArgs);
+  template<size_t ElementSize>
+  void UCOMISxOp(OpcodeArgs);
   void LDMXCSR(OpcodeArgs);
   void STMXCSR(OpcodeArgs);
 

--- a/External/FEXCore/Source/Interface/Core/X86Tables/SecondaryTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/SecondaryTables.cpp
@@ -44,8 +44,8 @@ void InitializeSecondaryTables() {
     {0x2B, 1, X86InstInfo{"MOVNTPS",    TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_SF_MOD_MEM_ONLY | FLAGS_SF_MOD_DST | FLAGS_XMM_FLAGS,                              0, nullptr}},
     {0x2C, 1, X86InstInfo{"CVTTPS2PI",  TYPE_MMX, GenFlagsSameSize(SIZE_64BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS,                                                   0, nullptr}},
     {0x2D, 1, X86InstInfo{"CVTPS2PI",   TYPE_MMX, GenFlagsSameSize(SIZE_64BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS,                                                   0, nullptr}},
-    {0x2E, 1, X86InstInfo{"UCOMISS",    TYPE_INST, FLAGS_MODRM | FLAGS_XMM_FLAGS,                                                                   0, nullptr}},
-    {0x2F, 1, X86InstInfo{"COMISS",     TYPE_INST, FLAGS_MODRM | FLAGS_XMM_FLAGS,                                                                   0, nullptr}},
+    {0x2E, 1, X86InstInfo{"UCOMISS",    TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS,                                                                   0, nullptr}},
+    {0x2F, 1, X86InstInfo{"COMISS",     TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS,                                                                   0, nullptr}},
 
     {0x30, 1, X86InstInfo{"WRMSR",      TYPE_PRIV, FLAGS_NO_OVERLAY,                                                                             0, nullptr}},
     {0x31, 1, X86InstInfo{"RDTSC",      TYPE_INST, FLAGS_DEBUG | FLAGS_NO_OVERLAY,                                                               0, nullptr}},
@@ -426,8 +426,8 @@ void InitializeSecondaryTables() {
     {0x2B, 1, X86InstInfo{"MOVNTPD",    TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_SF_MOD_MEM_ONLY | FLAGS_SF_MOD_DST | FLAGS_XMM_FLAGS,      0, nullptr}},
     {0x2C, 1, X86InstInfo{"CVTTPD2PI",  TYPE_MMX, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS,                          0, nullptr}},
     {0x2D, 1, X86InstInfo{"CVTPD2PI",   TYPE_MMX, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS,                          0, nullptr}},
-    {0x2E, 1, X86InstInfo{"UCOMISD",    TYPE_INST, GenFlagsSameSize(SIZE_64BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS,                          0, nullptr}},
-    {0x2F, 1, X86InstInfo{"COMISD",     TYPE_INST, GenFlagsSameSize(SIZE_64BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS,                          0, nullptr}},
+    {0x2E, 1, X86InstInfo{"UCOMISD",    TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS,                          0, nullptr}},
+    {0x2F, 1, X86InstInfo{"COMISD",     TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS,                          0, nullptr}},
 
     {0x30, 16, X86InstInfo{"",          TYPE_COPY_OTHER, FLAGS_NONE,                                                            0, nullptr}},
     {0x40, 16, X86InstInfo{"",          TYPE_COPY_OTHER, FLAGS_NONE,                                                            0, nullptr}},

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -15,7 +15,11 @@
     "constexpr static uint8_t COND_SGT  = 12",
     "constexpr static uint8_t COND_SLE  = 13",
     "static constexpr FEXCore::IR::RegisterClassType GPRClass {0}",
-    "static constexpr FEXCore::IR::RegisterClassType FPRClass {1}"
+    "static constexpr FEXCore::IR::RegisterClassType FPRClass {1}",
+
+    "constexpr static uint8_t FCMP_FLAG_EQ        = 0",
+    "constexpr static uint8_t FCMP_FLAG_LT        = 1",
+    "constexpr static uint8_t FCMP_FLAG_UNORDERED = 2"
   ],
 
   "Ops": {
@@ -559,6 +563,24 @@
       "SSAArgs": "1",
       "Args": [
         "uint8_t", "ElementSize"
+      ]
+    },
+
+    "ExtractElement": {
+      "HasDest": true,
+      "DestSize": "GetOpSize(ssa0)",
+      "SSAArgs": "1",
+      "Args": [
+        "uint8_t", "Idx"
+      ]
+    },
+
+    "FCmp": {
+      "HasDest": true,
+      "SSAArgs": "2",
+      "Args": [
+        "uint8_t", "ElementSize",
+        "uint32_t", "Flags"
       ]
     },
 
@@ -1238,6 +1260,22 @@
       "Args": [
         "uint8_t", "RegisterSize",
         "uint8_t", "ElementSize"
+      ]
+    },
+
+    "GetHostFlag": {
+      "HasDest": true,
+      "SSAArgs": "1",
+      "Args": [
+        "uint8_t", "Flag"
+      ]
+    },
+
+    "CreatesFlags": {
+      "HasDest": true,
+      "SSAArgs": "1",
+      "Args": [
+        "uint32_t", "Flags"
       ]
     },
 

--- a/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -238,7 +238,9 @@ namespace {
       return GetRegClassFromNode(ListBegin, DataBegin, Op->PhiBegin);
     }
     default:
-      if (IROp->Op > IR::OP_PRINT)
+      if (IROp->Op >= IR::OP_GETHOSTFLAG)
+        return IR::RegisterAllocationPass::FLAGSClass;
+      else if (IROp->Op > IR::OP_PRINT)
         return IR::RegisterAllocationPass::FPRClass;
       else
         return IR::RegisterAllocationPass::GPRClass;

--- a/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.h
+++ b/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.h
@@ -9,6 +9,7 @@ class RegisterAllocationPass : public FEXCore::IR::Pass {
   public:
     static constexpr uint32_t GPRClass = 0;
     static constexpr uint32_t FPRClass = 1;
+    static constexpr uint32_t FLAGSClass = 2;
 
     bool HasFullRA() const { return HadFullRA; }
     uint32_t SpillSlots() const { return SpillSlotCount; }


### PR DESCRIPTION
These are fairly popular so not having them around is causing headaches.
We will really want these in the future to use the host register, btu
that is more time consuming than I want to dedicate to at the moment.

So the FCMP instruction must be told which flags to generate up front,
then it generates the flags in to a GPR which are then tracked and
pulled out with a specific IR op.

This can be augmented in the future to more easily RA the host flag
register