### PR TITLE
Use the correct float vector op for Vector_FToZS on x86

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -2837,10 +2837,10 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
           auto Op = IROp->C<IR::IROp_Vector_FToZS>();
           switch (Op->ElementSize) {
             case 4:
-              cvtps2dq(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
+              cvttps2dq(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
             break;
             case 8:
-              cvtpd2dq(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
+              cvttpd2dq(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
             break;
             default: LogMan::Msg::A("Unknown castGPR element size: %d", Op->ElementSize);
           }


### PR DESCRIPTION
This IR op is supposed to be explicitly truncating, where the previous op chooses mode based on MXCSR