### PR TITLE
Fixes bug in CBW op

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -834,14 +834,16 @@ void OpDispatchBuilder::XCHGOp(OpcodeArgs) {
 
 void OpDispatchBuilder::CDQOp(OpcodeArgs) {
   OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
-  uint8_t SrcSize = GetSrcSize(Op);
+  uint8_t DstSize = GetDstSize(Op);
+  uint8_t SrcSize = DstSize >> 1;
 
-  Src = _Sext(SrcSize * 4, Src);
-  if (SrcSize == 4) {
-    Src = _Zext(SrcSize * 8, Src);
-    SrcSize *= 2;
+  Src = _Sext(SrcSize * 8, Src);
+  if (SrcSize == 2) {
+    Src = _Zext(DstSize * 8, Src);
+    DstSize *= 2;
   }
-  StoreResult_WithOpSize(GPRClass, Op, Op->Dest, Src, SrcSize * 8, -1);
+
+  StoreResult_WithOpSize(GPRClass, Op, Op->Dest, Src, DstSize, -1);
 }
 
 void OpDispatchBuilder::SAHFOp(OpcodeArgs) {

--- a/unittests/ASM/Primary/Primary_98_2.asm
+++ b/unittests/ASM/Primary/Primary_98_2.asm
@@ -1,0 +1,47 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "R10": "0xFFFFFFFF80000001",
+    "R11": "0x00000000FFFF8001",
+    "R12": "0x414243444546FF81",
+    "R13": "0x0000000000000001",
+    "R14": "0x0000000000000001",
+    "R15": "0x4142434445460001"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+; Positive 8bit
+mov rax, 0x4142434445464701
+cbw
+mov r15, rax
+
+; Positive 16bit
+mov rax, 0x4142434445460001
+cwde
+mov r14, rax
+
+; Positive 32bit
+mov rax, 0x4142434400000001
+cdqe
+mov r13, rax
+
+; Negative 8bit
+mov rax, 0x4142434445464781
+cbw
+mov r12, rax
+
+; Negative 16bit
+mov rax, 0x4142434445468001
+cwde
+mov r11, rax
+
+; Negative 32bit
+mov rax, 0x4142434480000001
+cdqe
+mov r10, rax
+
+hlt

--- a/unittests/ASM/Primary/Primary_99_2.asm
+++ b/unittests/ASM/Primary/Primary_99_2.asm
@@ -1,0 +1,79 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RBP": "0xFFFFFFFFFFFFFFFF",
+    "RSI": "0xFFFFFFFFFFFFFFFF",
+
+    "RDI": "0xFFFFFFFF",
+    "RSP": "0xFFFFFFFF",
+
+    "R8": "0xFFFF",
+    "R9": "0xFFFF",
+
+    "R10": "0x01",
+    "R11": "0x0",
+
+    "R12": "0x01",
+    "R13": "0x0",
+
+    "R14": "0x01",
+    "R15": "0xFFFFFFFFFFFF0000"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+; Positive 16bit
+mov rax, 1
+mov rdx, -1
+cwd
+
+mov r14, rax
+mov r15, rdx
+
+; Positive 32bit
+
+mov rax, 1
+mov rdx, -1
+cdq
+
+mov r12, rax
+mov r13, rdx
+
+; Positive 64bit
+
+mov rax, 1
+mov rdx, -1
+cqo
+
+mov r10, rax
+mov r11, rdx
+
+; Negative 16bit
+mov rax, 0xFFFF
+mov rdx, 0
+cwd
+
+mov r8, rax
+mov r9, rdx
+
+; Negative 32bit
+mov rax, 0xFFFFFFFF
+mov rdx, 0
+cdq
+
+mov rdi, rax
+mov rsp, rdx
+
+; Negative 64bit
+mov rax, -1
+mov rdx, 0
+cqo
+
+mov rbp, rax
+mov rsi, rdx
+
+
+hlt


### PR DESCRIPTION
It was managing to Sext and clear the entire GPR when it was only meant to write to the lower 16bits