### PR TITLE
Fixes stack alignment in x86_64 JIT

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -223,7 +223,10 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
   }
 
   if (SpillSlots) {
-    sub(rsp, SpillSlots * 16);
+    sub(rsp, SpillSlots * 16 + 8);
+  }
+  else {
+    sub(rsp, 8);
   }
 
   auto HeaderIterator = CurrentIR->begin();
@@ -277,7 +280,10 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
 
   auto RegularExit = [&]() {
     if (SpillSlots) {
-      add(rsp, SpillSlots * 16);
+      add(rsp, SpillSlots * 16 + 8);
+    }
+    else {
+      add(rsp, 8);
     }
 
     if (!CustomDispatchGenerated) {


### PR DESCRIPTION
SystemV ABI mandates that the stack frame is aligned to 16bytes.
Once the call instruction happens then it is offset by 8bytes, so it is
on the callee's hands to realign the stack pointer to 16bytes.
We rely on the assumption that the stack is aligned to 16bytes for spill
slots and other function calls