### PR TITLE
Actually unconditionally enable PIE through cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.14)
 project(FEX)
 
 option(BUILD_TESTS "Build unit tests to ensure sanity" TRUE)
@@ -14,6 +14,9 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/Bin)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+cmake_policy(SET CMP0083 NEW) # Follow new PIE policy
+include(CheckPIESupported)
+check_pie_supported()
 
 if (ENABLE_LTO)
   set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)

--- a/External/FEXCore/CMakeLists.txt
+++ b/External/FEXCore/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.14)
 set (PROJECT_NAME FEXCore)
 project(${PROJECT_NAME}
   VERSION 0.01
@@ -7,6 +7,11 @@ project(${PROJECT_NAME}
 option(ENABLE_CLANG_FORMAT "Run clang format over the source" FALSE)
 option(FORCE_AARCH64 "Force AArch64 Target for testing" FALSE)
 option(ENABLE_JITSYMBOLS "Enable visibility of JITSymbols in profiling tools" FALSE)
+
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+cmake_policy(SET CMP0083 NEW) # Follow new PIE policy
+include(CheckPIESupported)
+check_pie_supported()
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 


### PR DESCRIPTION
behaviour around enabling PIC it was only working on one platform.

This follows through with the NEW cmake behaviour required to enable
PIE.
Very specifically you have to set the cmake variable, you have to set
the new policy, AND you have to have an explicit check for pie support.
With any of those three things missing then PIE won't be enabled