### PR TITLE
Implements personality syscall

### DIFF
--- a/External/FEXCore/Source/Interface/HLE/Syscalls/Thread.cpp
+++ b/External/FEXCore/Source/Interface/HLE/Syscalls/Thread.cpp
@@ -8,6 +8,7 @@
 #include <linux/futex.h>
 #include <stdint.h>
 #include <sched.h>
+#include <sys/personality.h>
 #include <sys/prctl.h>
 #include <sys/resource.h>
 #include <sys/syscall.h>
@@ -178,6 +179,11 @@ namespace FEXCore::HLE {
 
   uint64_t Getresgid(FEXCore::Core::InternalThreadState *Thread, gid_t *rgid, gid_t *egid, gid_t *sgid) {
     uint64_t Result = ::getresgid(rgid, egid, sgid);
+    SYSCALL_ERRNO();
+  }
+
+  uint64_t Personality(FEXCore::Core::InternalThreadState *Thread, uint64_t persona) {
+    uint64_t Result = ::personality(persona);
     SYSCALL_ERRNO();
   }
 

--- a/External/FEXCore/Source/Interface/HLE/Syscalls/Thread.h
+++ b/External/FEXCore/Source/Interface/HLE/Syscalls/Thread.h
@@ -26,6 +26,7 @@ namespace FEXCore::HLE {
   uint64_t Getresuid(FEXCore::Core::InternalThreadState *Thread, uid_t *ruid, uid_t *euid, uid_t *suid);
   uint64_t Setresgid(FEXCore::Core::InternalThreadState *Thread, gid_t rgid, gid_t egid, gid_t sgid);
   uint64_t Getresgid(FEXCore::Core::InternalThreadState *Thread, gid_t *rgid, gid_t *egid, gid_t *sgid);
+  uint64_t Personality(FEXCore::Core::InternalThreadState *Thread, uint64_t persona);
   uint64_t Prctl(FEXCore::Core::InternalThreadState *Thread, int option, unsigned long arg2, unsigned long arg3, unsigned long arg4, unsigned long arg5);
   uint64_t Arch_Prctl(FEXCore::Core::InternalThreadState *Thread, int code, unsigned long addr);
   uint64_t Gettid(FEXCore::Core::InternalThreadState *Thread);

--- a/External/FEXCore/Source/Interface/HLE/x64/Syscalls.cpp
+++ b/External/FEXCore/Source/Interface/HLE/x64/Syscalls.cpp
@@ -468,6 +468,9 @@ void x64SyscallHandler::Strace(FEXCore::HLE::SyscallArguments *Args, uint64_t Re
       Args->Argument[2], Args->Argument[3],
       Ret);
     break;
+  case SYSCALL_PERSONALITY:
+    LogMan::Msg::D("personality(0x%lx) = %lx", Args->Argument[1], Ret);
+    break;
   case SYSCALL_STATFS:
     LogMan::Msg::D("statfs(\"%s\", {...}) = %ld", reinterpret_cast<char const*>(Args->Argument[1]), Ret);
     break;
@@ -669,6 +672,7 @@ void x64SyscallHandler::RegisterSyscallHandlers() {
     {SYSCALL_GETRESGID,          cvt(&FEXCore::HLE::Getresgid),         3},
     {SYSCALL_SIGALTSTACK,        cvt(&NopSuccess),                      2},
     {SYSCALL_MKNOD,              cvt(&FEXCore::HLE::Mknod),             3},
+    {SYSCALL_PERSONALITY,        cvt(&FEXCore::HLE::Personality),       1},
     {SYSCALL_STATFS,             cvt(&FEXCore::HLE::Statfs),            2},
     {SYSCALL_FSTATFS,            cvt(&FEXCore::HLE::FStatfs),           2},
     {SYSCALL_GETPRIORITY,        cvt(&FEXCore::HLE::Getpriority),       2},

--- a/External/FEXCore/Source/Interface/HLE/x64/Syscalls.h
+++ b/External/FEXCore/Source/Interface/HLE/x64/Syscalls.h
@@ -105,6 +105,7 @@ enum Syscalls {
   SYSCALL_GETRESGID       = 120, ///< __NR_getresgid
   SYSCALL_SIGALTSTACK     = 131, ///< __NR_sigaltstack
   SYSCALL_MKNOD           = 133, ///< __NR_mknod
+  SYSCALL_PERSONALITY     = 135, ///< __NR_personality
   SYSCALL_STATFS          = 137, ///< __NR_statfs
   SYSCALL_FSTATFS         = 138, ///< __NR_fstatfs
   SYSCALL_GETPRIORITY     = 140, ///< __NR_getpriority


### PR DESCRIPTION
Was seen in Reicast doing it for legacy reasons. Might as well as
support it.