### PR TITLE
Ensure that anything opened with openat is tracked in our FD map

### DIFF
--- a/External/FEXCore/Source/Interface/HLE/FileManagement.cpp
+++ b/External/FEXCore/Source/Interface/HLE/FileManagement.cpp
@@ -140,11 +140,11 @@ uint64_t FileManager::Openat([[maybe_unused]] int dirfs, const char *pathname, i
 
     if (fd == -1)
       fd = ::openat(dirfs, pathname, flags, mode);
-
-    return fd;
   }
 
-  FDToNameMap[fd] = pathname;
+  if (fd != -1)
+    FDToNameMap[fd] = pathname;
+
   return fd;
 }
 


### PR DESCRIPTION
Missing this was an accident, this was how it was supposed to be.
It's very helpful to map FDs to filenames when tracking mmap mappings