### PR TITLE
Fixes the getaffinity syscall

### DIFF
--- a/External/FEXCore/Source/Interface/HLE/Syscalls/Sched.cpp
+++ b/External/FEXCore/Source/Interface/HLE/Syscalls/Sched.cpp
@@ -25,13 +25,19 @@ namespace FEXCore::HLE {
     SYSCALL_ERRNO();
   }
 
-  uint64_t Sched_Setaffinity(FEXCore::Core::InternalThreadState *Thread, pid_t pid, size_t cpusetsize, const cpu_set_t *mask) {
+  uint64_t Sched_Setaffinity(FEXCore::Core::InternalThreadState *Thread, pid_t pid, size_t cpusetsize, const unsigned long *mask) {
     return 0;
   }
 
-  uint64_t Sched_Getaffinity(FEXCore::Core::InternalThreadState *Thread, pid_t pid, size_t cpusetsize, cpu_set_t *mask) {
+  uint64_t Sched_Getaffinity(FEXCore::Core::InternalThreadState *Thread, pid_t pid, size_t cpusetsize, unsigned long *mask) {
+    // If we don't have at least one byte in the resulting structure
+    // then we need to return -EINVAL
+    if (cpusetsize < 1) {
+      return -EINVAL;
+    }
     // Claim 1 CPU core
-    CPU_SET(0, mask);
-    return 0;
+    mask[0] |= 1;
+    // Returns the number of bytes written in to mask
+    return 1;
   }
 }

--- a/External/FEXCore/Source/Interface/HLE/Syscalls/Sched.h
+++ b/External/FEXCore/Source/Interface/HLE/Syscalls/Sched.h
@@ -10,6 +10,6 @@ namespace FEXCore::HLE {
   uint64_t Sched_Yield(FEXCore::Core::InternalThreadState *Thread);
   uint64_t Getpriority(FEXCore::Core::InternalThreadState *Thread, int which, int who);
   uint64_t Setpriority(FEXCore::Core::InternalThreadState *Thread, int which, int who, int prio);
-  uint64_t Sched_Setaffinity(FEXCore::Core::InternalThreadState *Thread, pid_t pid, size_t cpusetsize, const cpu_set_t *mask);
-  uint64_t Sched_Getaffinity(FEXCore::Core::InternalThreadState *Thread, pid_t pid, size_t cpusetsize, cpu_set_t *mask);
+  uint64_t Sched_Setaffinity(FEXCore::Core::InternalThreadState *Thread, pid_t pid, size_t cpusetsize, const unsigned long *mask);
+  uint64_t Sched_Getaffinity(FEXCore::Core::InternalThreadState *Thread, pid_t pid, size_t cpusetsize, unsigned long *mask);
 }


### PR DESCRIPTION
This was implemented with the glibc API originally which was incorrect.
The syscall API is just a simple bitmask of for the affinity of the
number of CPU cores and a size check that the resulting structure is
large enough to store the number of bits.