### PR TITLE
 Lets the IR validation pass validate RA

### DIFF
--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -26,6 +26,9 @@ namespace CPU {
 
 namespace FEXCore::IR {
   class RegisterAllocationPass;
+namespace Validation {
+  class IRValidation;
+}
 }
 
 namespace FEXCore::Context {
@@ -37,6 +40,7 @@ namespace FEXCore::Context {
   struct Context {
     friend class FEXCore::SyscallHandler;
     friend class FEXCore::CPU::JITCore;
+    friend class FEXCore::IR::Validation::IRValidation;
 
     struct {
       bool Multiblock {false};
@@ -121,6 +125,7 @@ namespace FEXCore::Context {
 
   protected:
     IR::RegisterAllocationPass *GetRegisterAllocatorPass();
+    bool HasRegisterAllocationPass() const { return RAPass != nullptr; }
 
   private:
     void WaitForIdle();

--- a/External/FEXCore/Source/Interface/IR/PassManager.cpp
+++ b/External/FEXCore/Source/Interface/IR/PassManager.cpp
@@ -18,9 +18,9 @@ void PassManager::AddDefaultPasses() {
 
 void PassManager::AddDefaultValidationPasses() {
 #ifndef NDEBUG
-  Passes.emplace_back(std::unique_ptr<FEXCore::IR::Pass>(Validation::CreatePhiValidation()));
-  Passes.emplace_back(std::unique_ptr<FEXCore::IR::Pass>(Validation::CreateIRValidation()));
-  Passes.emplace_back(std::unique_ptr<FEXCore::IR::Pass>(Validation::CreateValueDominanceValidation()));
+  ValidationPasses.emplace_back(std::unique_ptr<FEXCore::IR::Pass>(Validation::CreatePhiValidation()));
+  ValidationPasses.emplace_back(std::unique_ptr<FEXCore::IR::Pass>(Validation::CreateIRValidation()));
+  ValidationPasses.emplace_back(std::unique_ptr<FEXCore::IR::Pass>(Validation::CreateValueDominanceValidation()));
 #endif
 }
 
@@ -29,6 +29,13 @@ bool PassManager::Run(OpDispatchBuilder *Disp) {
   for (auto const &Pass : Passes) {
     Changed |= Pass->Run(Disp);
   }
+
+#ifndef NDEBUG
+  for (auto const &Pass : ValidationPasses) {
+    Changed |= Pass->Run(Disp);
+  }
+#endif
+
   return Changed;
 }
 

--- a/External/FEXCore/Source/Interface/IR/PassManager.h
+++ b/External/FEXCore/Source/Interface/IR/PassManager.h
@@ -25,6 +25,9 @@ public:
 
 private:
   std::vector<std::unique_ptr<Pass>> Passes;
+#ifndef NDEBUG
+  std::vector<std::unique_ptr<Pass>> ValidationPasses;
+#endif
 };
 }
 


### PR DESCRIPTION
Adds some additional validation that an IR op is generating RA for ops
that set a destination.
Ensuring correct register class and that there is a physical register
assigned

Relies on #106 to be merged first!