### PR TITLE
Ensures the JIT constructor's don't reallocate RA

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -122,19 +122,22 @@ JITCore::JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadSt
   , ThreadState {Thread} {
   Stack.resize(9000 * 16 * 64);
 
+  bool HadRA = CTX->HasRegisterAllocationPass();
   RAPass = CTX->GetRegisterAllocatorPass();
 
-  RAPass->AllocateRegisterSet(RegisterCount, RegisterClasses);
-  RAPass->AddRegisters(FEXCore::IR::GPRClass, NumGPRs);
-  RAPass->AddRegisters(FEXCore::IR::FPRClass, NumXMMs);
-  RAPass->AddRegisters(FEXCore::IR::GPRPairClass, NumGPRPairs);
+  if (!HadRA) {
+    RAPass->AllocateRegisterSet(RegisterCount, RegisterClasses);
+    RAPass->AddRegisters(FEXCore::IR::GPRClass, NumGPRs);
+    RAPass->AddRegisters(FEXCore::IR::FPRClass, NumXMMs);
+    RAPass->AddRegisters(FEXCore::IR::GPRPairClass, NumGPRPairs);
 
-  RAPass->AllocateRegisterConflicts(FEXCore::IR::GPRClass, NumGPRs);
-  RAPass->AllocateRegisterConflicts(FEXCore::IR::GPRPairClass, NumGPRs);
+    RAPass->AllocateRegisterConflicts(FEXCore::IR::GPRClass, NumGPRs);
+    RAPass->AllocateRegisterConflicts(FEXCore::IR::GPRPairClass, NumGPRs);
 
-  for (uint32_t i = 0; i < NumGPRPairs; ++i) {
-    RAPass->AddRegisterConflict(FEXCore::IR::GPRClass, i * 2,     FEXCore::IR::GPRPairClass, i);
-    RAPass->AddRegisterConflict(FEXCore::IR::GPRClass, i * 2 + 1, FEXCore::IR::GPRPairClass, i);
+    for (uint32_t i = 0; i < NumGPRPairs; ++i) {
+      RAPass->AddRegisterConflict(FEXCore::IR::GPRClass, i * 2,     FEXCore::IR::GPRPairClass, i);
+      RAPass->AddRegisterConflict(FEXCore::IR::GPRClass, i * 2 + 1, FEXCore::IR::GPRPairClass, i);
+    }
   }
 
   CreateCustomDispatch(Thread);


### PR DESCRIPTION
Currently RA is shared between threads(!).
If the RA had been previously allocated then don't allocate it again.
Fixes a race condition when multiple threads are spinning up and one is
compiling code

Relies on #112 to be merged first!