### PR TITLE
Fixes memory allocation

### DIFF
--- a/External/FEXCore/Source/Interface/Memory/SharedMem.cpp
+++ b/External/FEXCore/Source/Interface/Memory/SharedMem.cpp
@@ -13,7 +13,7 @@ namespace FEXCore::SHM {
     uintptr_t PtrOffset = reinterpret_cast<uintptr_t>(SHM->Object.Ptr) + Offset;
 
     void *Ptr = mmap(reinterpret_cast<void*>(PtrOffset), Size, flags,
-      MAP_PRIVATE | (Fixed ? MAP_FIXED : 0), SHM->SHMFD, Offset);
+      MAP_NORESERVE | MAP_PRIVATE | (Fixed ? MAP_FIXED : 0), SHM->SHMFD, Offset);
     if (Ptr == MAP_FAILED) {
       LogMan::Msg::A("Failed to map memory region [0x%lx, 0x%lx)", Offset, Offset + Size);
       return nullptr;

--- a/Source/Tests/ELFLoader.cpp
+++ b/Source/Tests/ELFLoader.cpp
@@ -101,7 +101,7 @@ int main(int argc, char **argv, char **const envp) {
   FEX::HarnessHelper::ELFCodeLoader Loader{Args[0], LDPath(), Args, ParsedArgs, envp};
 
   FEXCore::Context::InitializeStaticTables();
-  auto SHM = FEXCore::SHM::AllocateSHMRegion(1ULL << 32);
+  auto SHM = FEXCore::SHM::AllocateSHMRegion(1ULL << 36);
   auto CTX = FEXCore::Context::CreateNewContext();
   FEXCore::Context::InitializeContext(CTX);
   FEXCore::Context::SetApplicationFile(CTX, std::filesystem::canonical(Args[0]));


### PR DESCRIPTION
4GB virtual memory is too small and causes things to fault.
Previously we were at `1 << 36` but it caused oom issues on devices with
smaller amounts of memory.
This time ensure the the SHM memory is allocated with MEM_NORESERVE so
devices can actually allocate the virtual memory region.