### PR TITLE
Add a compile define for choosing CPUID manufacturer id

### DIFF
--- a/External/FEXCore/Source/Interface/Core/CPUID.cpp
+++ b/External/FEXCore/Source/Interface/Core/CPUID.cpp
@@ -1,15 +1,23 @@
 #include "Interface/Core/CPUID.h"
 
 namespace FEXCore {
+//#define CPUID_AMD
 
 CPUIDEmu::FunctionResults CPUIDEmu::Function_0h() {
   CPUIDEmu::FunctionResults Res{};
 
-  Res.Res[0] = 0x16; // Let's say we are a Skylake
   // EBX, EDX, ECX become the manufacturer id string
-  Res.Res[1] = 0x756E6547; // "Genu"
-  Res.Res[2] = 0x49656E69; // "ineI"
-  Res.Res[3] = 0x6C65746E; // "ntel"
+#ifdef CPUID_AMD
+  Res.Res[0] = 0x0D; // Let's say we are a Zen+
+  Res.Res[1] = CPUID_VENDOR_AMD1;
+  Res.Res[2] = CPUID_VENDOR_AMD2;
+  Res.Res[3] = CPUID_VENDOR_AMD3;
+#else
+  Res.Res[0] = 0x16; // Let's say we are a Skylake
+  Res.Res[1] = CPUID_VENDOR_INTEL1;
+  Res.Res[2] = CPUID_VENDOR_INTEL2;
+  Res.Res[3] = CPUID_VENDOR_INTEL3;
+#endif
   return Res;
 }
 

--- a/External/FEXCore/Source/Interface/Core/CPUID.h
+++ b/External/FEXCore/Source/Interface/Core/CPUID.h
@@ -7,6 +7,15 @@
 namespace FEXCore {
 
 class CPUIDEmu final {
+private:
+  constexpr static uint32_t CPUID_VENDOR_INTEL1 = 0x756E6547; // "Genu"
+  constexpr static uint32_t CPUID_VENDOR_INTEL2 = 0x49656E69; // "ineI"
+  constexpr static uint32_t CPUID_VENDOR_INTEL3 = 0x6C65746E; // "ntel"
+
+  constexpr static uint32_t CPUID_VENDOR_AMD1 = 0x68747541; // "Auth"
+  constexpr static uint32_t CPUID_VENDOR_AMD2 = 0x69746E65; // "enti"
+  constexpr static uint32_t CPUID_VENDOR_AMD3 = 0x444D4163; // "cAMD"
+
 public:
   void Init();
 


### PR DESCRIPTION
This can prove useful for applications that change some of their checks
depending what the vendor is