### PR TITLE
Fixes 32bit Float_FromGPR_S IR op in x86 JIT

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -3747,7 +3747,7 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
             cvtsi2sd(GetDst(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()));
           }
           else
-            cvtsi2ss(GetDst(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()));
+            cvtsi2ss(GetDst(Node), GetSrc<RA_32>(Op->Header.Args[0].ID()));
           break;
         }
         case IR::OP_FLOAT_TOGPR_ZS: {

--- a/unittests/ASM/REP/F3_2A.asm
+++ b/unittests/ASM/REP/F3_2A.asm
@@ -4,7 +4,9 @@
     "XMM0":  ["0x414243443f800000", "0x5152535455565758"],
     "XMM1":  ["0x4142434440000000", "0x5152535455565758"],
     "XMM2":  ["0x4142434440400000", "0x5152535455565758"],
-    "XMM3":  ["0x4142434440800000", "0x5152535455565758"]
+    "XMM3":  ["0x4142434440800000", "0x5152535455565758"],
+    "XMM4":  ["0x41424344C0800000", "0x5152535455565758"],
+    "XMM5":  ["0x41424344C0800000", "0x5152535455565758"]
   },
   "MemoryRegions": {
     "0x100000000": "4096"
@@ -28,10 +30,16 @@ mov [rdx + 8 * 4], rax
 mov rax, 0x4
 mov [rdx + 8 * 5], rax
 
+; Stick something in the top 32bits to ensure correctness
+mov rax, 0x7fc00000FFFFFFFC
+mov [rdx + 8 * 6], rax
+
 movapd xmm0, [rdx + 8 * 0]
 movapd xmm1, [rdx + 8 * 0]
 movapd xmm2, [rdx + 8 * 0]
 movapd xmm3, [rdx + 8 * 0]
+movapd xmm4, [rdx + 8 * 0]
+movapd xmm5, [rdx + 8 * 0]
 
 mov rax, [rdx + 8 * 2]
 mov rbx, [rdx + 8 * 3]
@@ -41,5 +49,10 @@ cvtsi2ss xmm1, ebx
 
 cvtsi2ss xmm2, dword [rdx + 8 * 4]
 cvtsi2ss xmm3, qword [rdx + 8 * 5]
+
+mov rbx, [rdx + 8 * 6]
+
+cvtsi2ss xmm4, ebx
+cvtsi2ss xmm5, dword [rdx + 8 * 6]
 
 hlt


### PR DESCRIPTION
x86's cvtsi2ss can take a 32bit or 64bit input and convert it to a 32bit
float.
This ensures the register passed in is 32bit so it uses the 32bit
instruction
