### PR TITLE
Fixes crashes when code cache is cleared

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -468,6 +468,12 @@ namespace FEXCore::Context {
     auto BlockMapPtr = Thread->BlockCache->AddBlockMapping(Address, Ptr);
     if (BlockMapPtr == 0) {
       Thread->BlockCache->ClearCache();
+
+      // Pull out the current IR we added and store it back after we cleared the rest of the list
+      // Needed in the case the the block mapping has aliased
+      auto IR = Thread->IRLists.find(Address)->second.release();
+      Thread->IRLists.clear();
+      Thread->IRLists.try_emplace(Address, IR);
       BlockMapPtr = Thread->BlockCache->AddBlockMapping(Address, Ptr);
       LogMan::Throw::A(BlockMapPtr, "Couldn't add mapping after clearing mapping cache");
     }

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -601,6 +601,10 @@ namespace FEXCore::Context {
     }
     else {
       IRList = IR->second.get();
+      auto Debugit = Thread->DebugData.find(GuestRIP);
+      if (Debugit != Thread->DebugData.end()) {
+        DebugData = &Debugit->second;
+      }
     }
 
     // Attempt to get the CPU backend to compile this code

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -110,7 +110,6 @@ void *InterpreterCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true
 
 void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
   auto IR = Thread->IRLists.find(Thread->State.State.rip);
-  auto DebugData = Thread->DebugData.find(Thread->State.State.rip);
   CurrentIR = IR->second.get();
 
   TmpOffset = 0; // Reset where we are in the temp data range
@@ -3838,7 +3837,10 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
     }
   }
 
-  Thread->Stats.InstructionsExecuted.fetch_add(DebugData->second.GuestInstructionCount);
+  auto DebugData = Thread->DebugData.find(Thread->State.State.rip);
+  if (DebugData != Thread->DebugData.end()) {
+    Thread->Stats.InstructionsExecuted.fetch_add(DebugData->second.GuestInstructionCount);
+  }
 }
 
 FEXCore::CPU::CPUBackend *CreateInterpreterCore(FEXCore::Context::Context *ctx) {

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -4465,7 +4465,9 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
 
   ready();
 
-  DebugData->HostCodeSize = reinterpret_cast<uintptr_t>(Exit) - reinterpret_cast<uintptr_t>(Entry);
+  if (DebugData) {
+    DebugData->HostCodeSize = reinterpret_cast<uintptr_t>(Exit) - reinterpret_cast<uintptr_t>(Entry);
+  }
   return Entry;
 }
 


### PR DESCRIPTION
If the code cache is cleared then we would have the case where the IR data would remain.
Which could result in stale IR data when aliasing.
And if the IR existed then we wouldn't grab DebugData for that code block which would cause the interpreter and x86 JIT to crash.