### PR TITLE
Disables LLVM debug messages

### DIFF
--- a/External/FEXCore/Source/Interface/Core/LLVMJIT/LLVMCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/LLVMJIT/LLVMCore.cpp
@@ -3976,12 +3976,12 @@ void* FEXCore::CPU::LLVMJITCore::CompileCode(FEXCore::IR::IRListView<true> const
 
   raw_ostream &Out = outs();
 
-  // if (CTX->Config.LLVM_PrinterPass)
+  if (CTX->Config.LLVM_PrinterPass)
   {
     MPM.addPass(PrintModulePass(Out));
   }
 
-  // if (CTX->Config.LLVM_IRValidation)
+  if (CTX->Config.LLVM_IRValidation)
   {
     verifyModule(*FunctionModule, &Out);
   }


### PR DESCRIPTION
Oops, forgot I had force enabled these when testing.