### PR TITLE
Removes SSSE3 CPUID feature bit

### DIFF
--- a/External/FEXCore/Source/Interface/Core/CPUID.cpp
+++ b/External/FEXCore/Source/Interface/Core/CPUID.cpp
@@ -40,6 +40,7 @@ CPUIDEmu::FunctionResults CPUIDEmu::Function_01h() {
 
   Res.Res[3]  &= ~(
       (3 << 26) | // Let's say that XSAVE isn't enabled by the OS. Prevents glibc from using XSAVE/XGETBV
+      (1 << 9)  | // Remove SSSE3
       (1 << 19) | // Remove SSE4.1
       (1 << 20) | // Remove SSE4.2
       (1 << 25) | // Remove AES


### PR DESCRIPTION
Dolphin uses this in a couple of places, so until it is fully supported
leave it disabled.