### PR TITLE
Removes the dumb timer wait for idle

### DIFF
--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -65,6 +65,11 @@ namespace FEXCore::Context {
     FEXCore::Core::InternalThreadState* ParentThread;
     std::vector<FEXCore::Core::InternalThreadState*> Threads;
     std::atomic_bool ShouldStop{};
+
+    std::mutex IdleWaitMutex;
+    std::condition_variable IdleWaitCV;
+    std::atomic<uint32_t> IdleWaitRefCount{};
+
     Event PauseWait;
     bool Running{};
     CoreRunningMode RunningMode {CoreRunningMode::MODE_RUN};


### PR DESCRIPTION
Turns out my Threadripper stomps these tests so the arbitrary wait time
actually slows down my unit test time.
Don't want to make it shorter since `strace -f` becomes ugly at that
point.
Instead set up a semaphore style waiting structure that waits until
there are no longer any participants in the atomic