### PR TITLE
Adds RA printing to the IR dumping function

### DIFF
--- a/External/FEXCore/Scripts/json_ir_generator.py
+++ b/External/FEXCore/Scripts/json_ir_generator.py
@@ -220,7 +220,7 @@ def print_ir_arg_printer(ops, defines):
                 if (SSAArgs != 0):
                     for i in range(0, SSAArgs):
                         LastArg = (SSAArgs - i - 1) == 0 and not HasArgs
-                        output_file.write("\tPrintArg(out, IR, Op->Header.Args[%d]);\n" % i)
+                        output_file.write("\tPrintArg(out, IR, Op->Header.Args[%d], RAPass);\n" % i)
                         if not (LastArg):
                             output_file.write("\t*out << \", \";\n")
 

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -576,7 +576,7 @@ namespace FEXCore::Context {
       if (Thread->OpDispatcher->ShouldDump) {
         std::stringstream out;
         auto NewIR = Thread->OpDispatcher->ViewIR();
-        FEXCore::IR::Dump(&out, &NewIR);
+        FEXCore::IR::Dump(&out, &NewIR, RAPass);
         printf("IR 0x%lx:\n%s\n@@@@@\n", GuestRIP, out.str().c_str());
       }
 

--- a/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
@@ -235,7 +235,7 @@ bool IRValidation::Run(OpDispatchBuilder *Disp) {
 
   HadWarning = false;
   if (HadError || HadWarning) {
-    FEXCore::IR::Dump(&Out, &CurrentIR);
+    FEXCore::IR::Dump(&Out, &CurrentIR, RAPass);
 
     if (HadError) {
       Out << "Errors:" << std::endl << Errors.str() << std::endl;

--- a/External/FEXCore/Source/Interface/IR/Passes/PhiValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/PhiValidation.cpp
@@ -79,7 +79,7 @@ bool PhiValidation::Run(OpDispatchBuilder *Disp) {
   std::stringstream Out;
 
   if (HadError) {
-    FEXCore::IR::Dump(&Out, &CurrentIR);
+    FEXCore::IR::Dump(&Out, &CurrentIR, nullptr);
 
     Out << "Errors:" << std::endl << Errors.str() << std::endl;
 

--- a/External/FEXCore/Source/Interface/IR/Passes/ValueDominanceValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ValueDominanceValidation.cpp
@@ -239,7 +239,7 @@ bool ValueDominanceValidation::Run(OpDispatchBuilder *Disp) {
   std::stringstream Out;
 
   if (HadError || HadWarning) {
-    FEXCore::IR::Dump(&Out, &CurrentIR);
+    FEXCore::IR::Dump(&Out, &CurrentIR, nullptr);
 
     if (HadError) {
       Out << "Errors:" << std::endl << Errors.str() << std::endl;

--- a/External/FEXCore/include/FEXCore/IR/IR.h
+++ b/External/FEXCore/include/FEXCore/IR/IR.h
@@ -5,6 +5,7 @@
 #include <sstream>
 
 namespace FEXCore::IR {
+class RegisterAllocationPass;
 
 /**
  * @brief The IROp_Header is an dynamically sized array
@@ -342,7 +343,7 @@ struct CondClassType final {
 template<bool>
 class IRListView;
 
-void Dump(std::stringstream *out, IRListView<false> const* IR);
+void Dump(std::stringstream *out, IRListView<false> const* IR, IR::RegisterAllocationPass *RAPass);
 
 template<typename Type>
 inline uint32_t NodeWrapperBase<Type>::ID() const { return NodeOffset / sizeof(IR::OrderedNode); }


### PR DESCRIPTION
If a backend has RA then this'll pass through the RAPass and will dump
the RA alongside the IR. Very useful for debugging.