### PR TITLE
Fixes accessing a stack variable post destruction bug

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -141,9 +141,8 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
 #define GD *GetDest<uint64_t*>(*WrapperOp)
 #define GDP GetDest<void*>(*WrapperOp)
   auto GetOpSize = [&](IR::OrderedNodeWrapper Node) {
-    auto Wrapper = CurrentIR->at(Node)();
-    FEXCore::IR::OrderedNode *RealNode = Wrapper->GetNode(ListBegin);
-    FEXCore::IR::IROp_Header *IROp = RealNode->Op(DataBegin);
+    FEXCore::IR::OrderedNode const *RealNode = Node.GetNode(ListBegin);
+    FEXCore::IR::IROp_Header const *IROp = RealNode->Op(DataBegin);
     return IROp->Size;
   };
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -393,13 +393,6 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
 
   IR::OrderedNode *BlockNode = HeaderOp->Blocks.GetNode(ListBegin);
 
-  auto GetOpSize = [&](IR::OrderedNodeWrapper Node) {
-    auto Wrapper = CurrentIR->at(Node)();
-    FEXCore::IR::OrderedNode *RealNode = Wrapper->GetNode(ListBegin);
-    FEXCore::IR::IROp_Header *IROp = RealNode->Op(DataBegin);
-    return IROp->Size;
-  };
-
   while (1) {
     using namespace FEXCore::IR;
     auto BlockIROp = BlockNode->Op(DataBegin)->CW<FEXCore::IR::IROp_CodeBlock>();


### PR DESCRIPTION
This happened to work with clang-9 but is caught in clang-10 now.
We were constructing an iterator temp then pulling a node through it
past the destruction.

Remove the iterator construction entirely and removes the unused lambda
from the AArch64 JIT that had the same problem.