### PR TITLE
Fixes crash that occurs when the x86-64 JIT code cache gets full

### DIFF
--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -131,6 +131,7 @@ namespace FEXCore::Context {
   protected:
     IR::RegisterAllocationPass *GetRegisterAllocatorPass();
     bool HasRegisterAllocationPass() const { return RAPass != nullptr; }
+    void ClearCodeCache(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP);
 
   private:
     void WaitForIdle();

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -458,6 +458,16 @@ namespace FEXCore::Context {
     return BlockMapPtr;
   }
 
+  void Context::ClearCodeCache(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP) {
+    Thread->BlockCache->ClearCache();
+    Thread->CPUBackend->ClearCache();
+    if (GuestRIP != 0) {
+      auto IR = Thread->IRLists.find(GuestRIP)->second.release();
+      Thread->IRLists.clear();
+      Thread->IRLists.try_emplace(GuestRIP, IR);
+    }
+  }
+
   uintptr_t Context::CompileBlock(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP) {
     // XXX: Threaded mutex hack until we support proper threaded compilation. Issue #13
     static std::mutex SyscallMutex;

--- a/External/FEXCore/include/FEXCore/Core/CPUBackend.h
+++ b/External/FEXCore/include/FEXCore/Core/CPUBackend.h
@@ -73,6 +73,8 @@ class LLVMCore;
     virtual bool HasCustomDispatch() const { return false; }
 
     virtual void ExecuteCustomDispatch(FEXCore::Core::ThreadState *Thread) {}
+
+    virtual void ClearCache() {}
   };
 
 }


### PR DESCRIPTION
Need to clear the other caches in the cases the x86 cache needs to be
wiped.
Not optimal but will improve once we get multiple tiers of code cache