### PR TITLE
Fixes epoll_create syscall

### DIFF
--- a/External/FEXCore/Source/Interface/HLE/Syscalls/EPoll.cpp
+++ b/External/FEXCore/Source/Interface/HLE/Syscalls/EPoll.cpp
@@ -8,8 +8,8 @@ struct InternalThreadState;
 }
 
 namespace FEXCore::HLE {
-  uint64_t EPoll_Create(FEXCore::Core::InternalThreadState *Thread, int flags) {
-    uint64_t Result = epoll_create1(flags);
+  uint64_t EPoll_Create(FEXCore::Core::InternalThreadState *Thread, int size) {
+    uint64_t Result = epoll_create(size);
     SYSCALL_ERRNO();
   }
 

--- a/External/FEXCore/Source/Interface/HLE/Syscalls/EPoll.h
+++ b/External/FEXCore/Source/Interface/HLE/Syscalls/EPoll.h
@@ -6,7 +6,7 @@ struct InternalThreadState;
 }
 
 namespace FEXCore::HLE {
-  uint64_t EPoll_Create(FEXCore::Core::InternalThreadState *Thread, int flags);
+  uint64_t EPoll_Create(FEXCore::Core::InternalThreadState *Thread, int size);
   uint64_t EPoll_Wait(FEXCore::Core::InternalThreadState *Thread, int epfd, void *events, int maxevents, int timeout);
   uint64_t EPoll_Ctl(FEXCore::Core::InternalThreadState *Thread, int epfd, int op, int fd, void *event);
   uint64_t EPoll_Pwait(FEXCore::Core::InternalThreadState *Thread, int epfd, void *events, int maxevent, int timeout, const void* sigmask);


### PR DESCRIPTION
Accidently made it behave like epoll_create1. This caused some games to
throw asserts in terminal.