### PR TITLE
Implements JRCXZ in the OpcodeDispatcher 

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -118,6 +118,7 @@ public:
   void CALLOp(OpcodeArgs);
   void CALLAbsoluteOp(OpcodeArgs);
   void CondJUMPOp(OpcodeArgs);
+  void CondJUMPRCXOp(OpcodeArgs);
   void JUMPOp(OpcodeArgs);
   void JUMPAbsoluteOp(OpcodeArgs);
   template<uint32_t SrcIndex>

--- a/unittests/ASM/Primary/Primary_E3.asm
+++ b/unittests/ASM/Primary/Primary_E3.asm
@@ -1,0 +1,44 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x10",
+    "RBX": "0x10"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rax, 0
+mov rcx, 0x10
+
+jmp .head
+
+.top:
+
+add rax, 1
+sub rcx, 1
+
+.head:
+
+jrcxz .next
+jmp .top
+.next:
+
+; Second test
+mov rbx, 0
+mov rcx, 0xFFFFFFFF00000010
+jmp .head2
+
+.top2:
+add rbx, 1
+sub rcx, 1
+
+.head2:
+jecxz .next2
+jmp .top2
+
+.next2:
+
+hlt


### PR DESCRIPTION
This only operates on 64bit and 32bit RCX register. the 16bit encoding isn't possible in 64bit mode.

Saw this when running some game