### PR TITLE
Fixes loading EXEC applications in to memory.

### DIFF
--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -134,7 +134,7 @@ namespace FEXCore::Context {
 
   private:
     void WaitForIdle();
-    void *MapRegion(FEXCore::Core::InternalThreadState *Thread, uint64_t Offset, uint64_t Size, bool Fixed = false);
+    void *MapRegion(FEXCore::Core::InternalThreadState *Thread, uint64_t Offset, uint64_t Size, bool Fixed = false, bool RelativeToBase = true);
     void *ShmBase();
     void MirrorRegion(FEXCore::Core::InternalThreadState *Thread, void *HostPtr, uint64_t Offset, uint64_t Size);
     void ExecutionThread(FEXCore::Core::InternalThreadState *Thread);

--- a/External/FEXCore/Source/Interface/Memory/MemMapper.cpp
+++ b/External/FEXCore/Source/Interface/Memory/MemMapper.cpp
@@ -6,12 +6,16 @@
 
 namespace FEXCore::Memory {
 
-  void *MemMapper::MapRegion(uint64_t Offset, size_t Size, bool Fixed) {
-    return MapRegion(Offset, Size, PROT_READ | PROT_WRITE, Fixed);
+  void *MemMapper::MapRegion(uint64_t Offset, size_t Size, bool Fixed, bool RelativeToBase) {
+    return MapRegion(Offset, Size, PROT_READ | PROT_WRITE, Fixed, RelativeToBase);
   }
 
-  void *MemMapper::ChangeMappedRegion(uint64_t Offset, size_t Size, uint32_t Flags, bool Fixed) {
-    uintptr_t PtrOffset = reinterpret_cast<uintptr_t>(SHM->Object.Ptr) + Offset;
+  void *MemMapper::ChangeMappedRegion(uint64_t Offset, size_t Size, uint32_t Flags, bool Fixed, bool RelativeToBase) {
+    uintptr_t PtrOffset = Offset;
+
+    if (RelativeToBase) {
+      PtrOffset = reinterpret_cast<uintptr_t>(SHM->Object.Ptr) + Offset;
+    }
 
     void *Ptr = mmap(reinterpret_cast<void*>(PtrOffset), Size, Flags,
       MAP_POPULATE | MAP_SHARED | (Fixed ? MAP_FIXED : 0), SHM->SHMFD, Offset);
@@ -24,8 +28,12 @@ namespace FEXCore::Memory {
     return Ptr;
   }
 
-  void *MemMapper::MapRegion(uint64_t Offset, size_t Size, uint32_t Flags, bool Fixed) {
-    uintptr_t PtrOffset = reinterpret_cast<uintptr_t>(SHM->Object.Ptr) + Offset;
+  void *MemMapper::MapRegion(uint64_t Offset, size_t Size, uint32_t Flags, bool Fixed, bool RelativeToBase) {
+    uintptr_t PtrOffset = Offset;
+
+    if (RelativeToBase) {
+      PtrOffset = reinterpret_cast<uintptr_t>(SHM->Object.Ptr) + Offset;
+    }
 
     void *Ptr = mmap(reinterpret_cast<void*>(PtrOffset), Size, Flags,
       MAP_SHARED | (Fixed ? MAP_FIXED : 0), SHM->SHMFD, Offset);

--- a/External/FEXCore/Source/Interface/Memory/MemMapper.h
+++ b/External/FEXCore/Source/Interface/Memory/MemMapper.h
@@ -20,9 +20,9 @@ namespace FEXCore::Memory {
       return SHM->Size;
     }
 
-    void *MapRegion(uint64_t Offset, size_t Size, bool Fixed = true);
-    void *MapRegion(uint64_t Offset, size_t Size, uint32_t Flags, bool Fixed = true);
-    void *ChangeMappedRegion(uint64_t Offset, size_t Size, uint32_t Flags, bool Fixed = true);
+    void *MapRegion(uint64_t Offset, size_t Size, bool Fixed = true, bool RelativeToBase = true);
+    void *MapRegion(uint64_t Offset, size_t Size, uint32_t Flags, bool Fixed = true, bool RelativeToBase = true);
+    void *ChangeMappedRegion(uint64_t Offset, size_t Size, uint32_t Flags, bool Fixed = true, bool RelativeToBase = true);
 
     void UnmapRegion(void *Ptr, size_t Size);
 

--- a/External/FEXCore/include/FEXCore/Core/CodeLoader.h
+++ b/External/FEXCore/include/FEXCore/Core/CodeLoader.h
@@ -44,16 +44,6 @@ public:
    */
   virtual void SetMemoryBase(uint64_t Base, bool Unified) {}
 
-  using MemoryLayout = std::tuple<uint64_t, uint64_t, uint64_t>;
-  /**
-   * @brief Gets the default memory layout of the memory object being loaded
-   *
-   * This will be mapped in to the guest memory space automatically
-   *
-   * @return A MemoryLayout object describing the layout of the region
-   */
-  virtual MemoryLayout GetLayout() const = 0;
-
   /**
    * @brief Allows the loader to map memory regions that it needs
    *
@@ -61,7 +51,7 @@ public:
    *
    * @param Mapper Returns the host facing pointer for memory setup if the codfe loader needs to do things to it
    */
-  virtual void MapMemoryRegion(std::function<void*(uint64_t, uint64_t)> Mapper) {}
+  virtual void MapMemoryRegion(std::function<void*(uint64_t, uint64_t, bool, bool)> Mapper) {}
 
   /**
    * @brief Memory writer function for loading code in to guest memory

--- a/External/SonicUtils/Source/ELFLoader.cpp
+++ b/External/SonicUtils/Source/ELFLoader.cpp
@@ -18,7 +18,6 @@ ELFContainer::ELFContainer(std::string const &Filename, std::string const &RootF
     // If we we are dynamic application then we have an interpreter program header
     // We need to load that ELF instead if it exists
     // We are no longer dynamic since we are executing the interpreter
-    DynamicProgram = false;
     const char *RawString = &RawFile.at(InterpreterHeader->p_offset);
     if (!RootFS.empty() && LoadELF(RootFS + RawString)) {
       // Found the interpreter in the rootfs
@@ -29,9 +28,10 @@ ELFContainer::ELFContainer(std::string const &Filename, std::string const &RootF
     }
   }
   else if (InterpreterHeader) {
-    DynamicProgram = true;
     GetDynamicLibs();
   }
+
+  DynamicProgram = Header.e_type != ET_EXEC;
 
   CalculateMemoryLayouts();
   CalculateSymbols();

--- a/External/SonicUtils/include/SonicUtils/ELFSymbolDatabase.h
+++ b/External/SonicUtils/include/SonicUtils/ELFSymbolDatabase.h
@@ -11,7 +11,7 @@ public:
 
   ::ELFLoader::ELFContainer::MemoryLayout GetFileLayout() const;
 
-  void MapMemoryRegions(std::function<void*(uint64_t, uint64_t)> Mapper);
+  void MapMemoryRegions(std::function<void*(uint64_t, uint64_t, bool, bool)> Mapper);
   void WriteLoadableSections(::ELFLoader::ELFContainer::MemoryWriter Writer);
 
   uint64_t DefaultRIP() const;

--- a/Source/Tests/TestSingleStepHardware.cpp
+++ b/Source/Tests/TestSingleStepHardware.cpp
@@ -39,16 +39,10 @@ uint8_t data[] = {
       return RIP;
     }
 
-    MemoryLayout GetLayout() const override {
-      uint64_t CodeSize = 0x500;
-      CodeSize = AlignUp(CodeSize, PAGE_SIZE);
-      return std::make_tuple(0, CodeSize, CodeSize);
-    }
-
-    void MapMemoryRegion(std::function<void*(uint64_t, uint64_t)> Mapper) override {
+    void MapMemoryRegion(std::function<void*(uint64_t, uint64_t, bool, bool)> Mapper) override {
       // XXX: Pull this from the config
-      Mapper(0xe000'0000, 0x1000'0000);
-      Mapper(0x2'0000'0000, 0x1'0000'1000);
+      Mapper(0xe000'0000, 0x1000'0000, true, true);
+      Mapper(0x2'0000'0000, 0x1'0000'1000, true, true);
     }
 
     void LoadMemory(MemoryWriter Writer) override {


### PR DESCRIPTION
If we are loading EXEC then we actually need to start loading in to the
lower 32bits of memory.
This lets the frontend code loader handle the memory base instead of
hiding it behind some core magic instead.

This lets us get EXEC programs working.
So now we support EXEC, DYN, and static applications