### PR TITLE
Ensure local pushes to a branch don't run through CI

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -2,7 +2,11 @@ name: Build + Test
 
 on:
   push:
+    branches:
+      - master
   pull_request:
+    branches:
+      - master
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)


### PR DESCRIPTION
If someone is pushing to a local branch on the repo, then don't run CI.
Only run once someone pushes a PR if local.
This makes it so we don't run CI for a branch twice over.