### PR TITLE
Fixes 128bit divisions on AArch64 

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -84,6 +84,30 @@ static uint64_t SyscallThunk(FEXCore::SyscallHandler *Handler, FEXCore::Core::In
   return FEXCore::HandleSyscall(Handler, Thread, Args);
 }
 
+static uint64_t LUDIV(uint64_t SrcHigh, uint64_t SrcLow, uint64_t Divisor) {
+  __uint128_t Source = (static_cast<__uint128_t>(SrcHigh) << 64) | SrcLow;
+  __uint128_t Res = Source / Divisor;
+  return Res;
+}
+
+static int64_t LDIV(int64_t SrcHigh, int64_t SrcLow, int64_t Divisor) {
+  __int128_t Source = (static_cast<__int128_t>(SrcHigh) << 64) | SrcLow;
+  __int128_t Res = Source / Divisor;
+  return Res;
+}
+
+static uint64_t LUREM(uint64_t SrcHigh, uint64_t SrcLow, uint64_t Divisor) {
+  __uint128_t Source = (static_cast<__uint128_t>(SrcHigh) << 64) | SrcLow;
+  __uint128_t Res = Source % Divisor;
+  return Res;
+}
+
+static int64_t LREM(int64_t SrcHigh, int64_t SrcLow, int64_t Divisor) {
+  __int128_t Source = (static_cast<__int128_t>(SrcHigh) << 64) | SrcLow;
+  __int128_t Res = Source % Divisor;
+  return Res;
+}
+
 static FEXCore::CPUIDEmu::FunctionResults CPUIDThunk(FEXCore::CPUIDEmu *CPUID, uint64_t Function) {
   return CPUID->RunFunction(Function);
 }
@@ -1987,7 +2011,41 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
         break;
         }
         case 8: {
-          udiv(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()), GetSrc<RA_64>(Op->Header.Args[2].ID()));
+          uint64_t SPOffset = AlignUp((RA64.size() + 1) * 8, 16);
+
+          sub(sp, sp, SPOffset);
+          int i = 0;
+          for (auto RA : RA64) {
+            str(RA, MemOperand(sp, i * 8));
+            i++;
+          }
+          str(lr,       MemOperand(sp, RA64.size() * 8 + 0 * 8));
+
+          mov(x0, GetSrc<RA_64>(Op->Header.Args[1].ID()));
+          mov(x1, GetSrc<RA_64>(Op->Header.Args[0].ID()));
+          mov(x2, GetSrc<RA_64>(Op->Header.Args[2].ID()));
+
+#if _M_X86_64
+          CallRuntime(LUDIV);
+#else
+          LoadConstant(x3, reinterpret_cast<uint64_t>(LUDIV));
+          blr(x3);
+#endif
+
+          // Result is now in x0
+          // Fix the stack and any values that were stepped on
+          i = 0;
+          for (auto RA : RA64) {
+            ldr(RA, MemOperand(sp, i * 8));
+            i++;
+          }
+
+          // Move result to its destination register
+          mov(GetDst<RA_64>(Node), x0);
+
+          ldr(lr,       MemOperand(sp, RA64.size() * 8 + 0 * 8));
+
+          add(sp, sp, SPOffset);
         break;
         }
         default: LogMan::Msg::A("Unknown LUDIV Size: %d", Size); break;
@@ -2014,7 +2072,41 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
         break;
         }
         case 8: {
-          sdiv(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()), GetSrc<RA_64>(Op->Header.Args[2].ID()));
+          uint64_t SPOffset = AlignUp((RA64.size() + 1) * 8, 16);
+
+          sub(sp, sp, SPOffset);
+          int i = 0;
+          for (auto RA : RA64) {
+            str(RA, MemOperand(sp, i * 8));
+            i++;
+          }
+          str(lr,       MemOperand(sp, RA64.size() * 8 + 0 * 8));
+
+          mov(x0, GetSrc<RA_64>(Op->Header.Args[1].ID()));
+          mov(x1, GetSrc<RA_64>(Op->Header.Args[0].ID()));
+          mov(x2, GetSrc<RA_64>(Op->Header.Args[2].ID()));
+
+#if _M_X86_64
+          CallRuntime(LDIV);
+#else
+          LoadConstant(x3, reinterpret_cast<uint64_t>(LDIV));
+          blr(x3);
+#endif
+
+          // Result is now in x0
+          // Fix the stack and any values that were stepped on
+          i = 0;
+          for (auto RA : RA64) {
+            ldr(RA, MemOperand(sp, i * 8));
+            i++;
+          }
+
+          // Move result to its destination register
+          mov(GetDst<RA_64>(Node), x0);
+
+          ldr(lr,       MemOperand(sp, RA64.size() * 8 + 0 * 8));
+
+          add(sp, sp, SPOffset);
         break;
         }
         default: LogMan::Msg::A("Unknown LDIV Size: %d", Size); break;
@@ -2047,11 +2139,41 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
         break;
         }
         case 8: {
-          auto Dividend = GetSrc<RA_64>(Op->Header.Args[0].ID());
-          auto Divisor = GetSrc<RA_64>(Op->Header.Args[2].ID());
+          uint64_t SPOffset = AlignUp((RA64.size() + 1) * 8, 16);
 
-          udiv(TMP1, Dividend, Divisor);
-          msub(GetDst<RA_64>(Node), TMP1, Divisor, Dividend);
+          sub(sp, sp, SPOffset);
+          int i = 0;
+          for (auto RA : RA64) {
+            str(RA, MemOperand(sp, i * 8));
+            i++;
+          }
+          str(lr,       MemOperand(sp, RA64.size() * 8 + 0 * 8));
+
+          mov(x0, GetSrc<RA_64>(Op->Header.Args[1].ID()));
+          mov(x1, GetSrc<RA_64>(Op->Header.Args[0].ID()));
+          mov(x2, GetSrc<RA_64>(Op->Header.Args[2].ID()));
+
+#if _M_X86_64
+          CallRuntime(LUREM);
+#else
+          LoadConstant(x3, reinterpret_cast<uint64_t>(LUREM));
+          blr(x3);
+#endif
+
+          // Result is now in x0
+          // Fix the stack and any values that were stepped on
+          i = 0;
+          for (auto RA : RA64) {
+            ldr(RA, MemOperand(sp, i * 8));
+            i++;
+          }
+
+          // Move result to its destination register
+          mov(GetDst<RA_64>(Node), x0);
+
+          ldr(lr,       MemOperand(sp, RA64.size() * 8 + 0 * 8));
+
+          add(sp, sp, SPOffset);
         break;
         }
         default: LogMan::Msg::A("Unknown LUREM Size: %d", Size); break;
@@ -2087,11 +2209,41 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
         break;
         }
         case 8: {
-          auto Dividend = GetSrc<RA_64>(Op->Header.Args[0].ID());
-          auto Divisor = GetSrc<RA_64>(Op->Header.Args[2].ID());
+                  uint64_t SPOffset = AlignUp((RA64.size() + 1) * 8, 16);
 
-          sdiv(TMP1, Dividend, Divisor);
-          msub(GetDst<RA_64>(Node), TMP1, Divisor, Dividend);
+          sub(sp, sp, SPOffset);
+          int i = 0;
+          for (auto RA : RA64) {
+            str(RA, MemOperand(sp, i * 8));
+            i++;
+          }
+          str(lr,       MemOperand(sp, RA64.size() * 8 + 0 * 8));
+
+          mov(x0, GetSrc<RA_64>(Op->Header.Args[1].ID()));
+          mov(x1, GetSrc<RA_64>(Op->Header.Args[0].ID()));
+          mov(x2, GetSrc<RA_64>(Op->Header.Args[2].ID()));
+
+#if _M_X86_64
+          CallRuntime(LREM);
+#else
+          LoadConstant(x3, reinterpret_cast<uint64_t>(LREM));
+          blr(x3);
+#endif
+
+          // Result is now in x0
+          // Fix the stack and any values that were stepped on
+          i = 0;
+          for (auto RA : RA64) {
+            ldr(RA, MemOperand(sp, i * 8));
+            i++;
+          }
+
+          // Move result to its destination register
+          mov(GetDst<RA_64>(Node), x0);
+
+          ldr(lr,       MemOperand(sp, RA64.size() * 8 + 0 * 8));
+
+          add(sp, sp, SPOffset);
         break;
         }
         default: LogMan::Msg::A("Unknown LREM Size: %d", Size); break;

--- a/unittests/ASM/PrimaryGroup/3_F7_06.asm
+++ b/unittests/ASM/PrimaryGroup/3_F7_06.asm
@@ -4,7 +4,8 @@
     "RAX": "0x414243442A2A0001",
     "RBX": "0x1C1C1C1C00000001",
     "RSI": "0x0000000000000001",
-    "RSP": "0x1010101010101010"
+    "RSP": "0x1010101010101010",
+    "R11": "0x8000000000000000"
   },
   "MemoryRegions": {
     "0x100000000": "4096"
@@ -38,6 +39,13 @@ cqo
 div qword [r15 + 8 * 2 + 0]
 mov rsi, rax
 mov rsp, rdx
+
+; 128bit divide where we actually care about the upper bits containing real data
+mov rax, 0x0
+mov rdx, 0x1
+mov rcx, 2
+div rcx
+mov r11, rax
 
 mov rax, [r15 + 8 * 0]
 mov rbx, [r15 + 8 * 1]

--- a/unittests/ASM/PrimaryGroup/3_F7_07.asm
+++ b/unittests/ASM/PrimaryGroup/3_F7_07.asm
@@ -12,7 +12,9 @@
     "R8":  "0xFFFFFFFF00000004",
     "R9":  "0x0000000000000002",
     "R10": "0x0000000000000001",
-    "R11": "0x0000000000000000"
+    "R11": "0x0000000000000000",
+    "R12": "0x4000000000000000",
+    "R13": "0x0000000000000000"
   },
   "MemoryRegions": {
     "0x100000000": "4096"
@@ -109,6 +111,14 @@ idiv qword [r15 + 8 * 10 + 0]
 mov qword [r15 + 8 * 10 + 0], rax
 mov qword [r15 + 8 * 11 + 0], rdx
 
+; 128bit divide where we actually care about the upper bits containing real data
+mov rax, 0x0
+mov rdx, 0x1
+mov rcx, 4
+idiv rcx
+mov qword [r15 + 8 * 12 + 0], rax
+mov qword [r15 + 8 * 13 + 0], rdx
+
 ; Positive / Positive results
 mov rax, [r15 + 8 * 0]
 mov rbx, [r15 + 8 * 1]
@@ -126,6 +136,10 @@ mov r8, [r15 + 8 * 8]
 mov r9, [r15 + 8 * 9]
 mov r10, [r15 + 8 * 10]
 mov r11, [r15 + 8 * 11]
+
+; 128bit results
+mov r12, [r15 + 8 * 12]
+mov r13, [r15 + 8 * 13]
 
 hlt
 


### PR DESCRIPTION
These were only doing 64bit divisions.
Function calls are a bit ugly but once the new RA lands we can clean them up