### PR TITLE
Removes XOP frontend handling

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Frontend.cpp
+++ b/External/FEXCore/Source/Interface/Core/Frontend.cpp
@@ -633,21 +633,6 @@ bool Decoder::NormalOpHeader(FEXCore::X86Tables::X86InstInfo const *Info, uint16
     else
       return NormalOp(LocalInfo, Op);
   }
-  else if (Info->Type == FEXCore::X86Tables::TYPE_XOP_TABLE_PREFIX) {
-    LogMan::Msg::A("XOP and POP <modrm> aren't handled!");
-    uint16_t Byte1 = ReadByte();
-    uint16_t Byte2 = ReadByte();
-    uint16_t XOPOp = ReadByte();
-    uint16_t map_select = Byte1 & 0b11111;
-    LogMan::Throw::A(map_select >= 8 && map_select <= 0xA, "We don't understand a map_select of: %d", map_select);
-    uint16_t pp = Byte2 & 0b11;
-    map_select -= 8;
-
-#define OPD(group, pp, opcode) ( (group << 10) | (pp << 8) | (opcode))
-    Op = OPD(map_select, pp, XOPOp);
-    return NormalOp(&XOPTableOps[Op], Op);
-#undef OPD
-  }
   else if (Info->Type == FEXCore::X86Tables::TYPE_GROUP_EVEX) {
     uint8_t P1 = ReadByte();
     uint8_t P2 = ReadByte();

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -5596,6 +5596,7 @@ void InstallOpcodeHandlers(Context::OperatingMode Mode) {
     {0x88, 4, &OpDispatchBuilder::MOVGPROp<0>},
 
     {0x8D, 1, &OpDispatchBuilder::LEAOp},
+    {0x8F, 1, &OpDispatchBuilder::POPOp},
     {0x90, 8, &OpDispatchBuilder::XCHGOp},
 
     {0x98, 1, &OpDispatchBuilder::CDQOp},

--- a/External/FEXCore/Source/Interface/Core/X86Tables/BaseTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/BaseTables.cpp
@@ -138,6 +138,7 @@ void InitializeBaseTables(Context::OperatingMode Mode) {
     {0x8C, 1, X86InstInfo{"MOV",    TYPE_INVALID, FLAGS_MODRM | FLAGS_SF_MOD_DST,                      0, nullptr}},
     {0x8D, 1, X86InstInfo{"LEA",    TYPE_INST, GenFlagsSameSize(SIZE_64BITDEF) | FLAGS_MODRM,                         0, nullptr}},
     {0x8E, 1, X86InstInfo{"MOV",    TYPE_INVALID, FLAGS_MODRM,                      0, nullptr}}, // MOV seg, modrM == invalid on x86-64
+    {0x8F, 1, X86InstInfo{"POP",    TYPE_INST, GenFlagsSameSize(SIZE_64BITDEF) | FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_DEBUG_MEM_ACCESS, 0, nullptr}},
     {0x90, 8, X86InstInfo{"XCHG",   TYPE_INST, FLAGS_SF_REX_IN_BYTE | FLAGS_SF_SRC_RAX, 0, nullptr}},
     {0x98, 1, X86InstInfo{"CDQE",   TYPE_INST, FLAGS_SF_DST_RAX | FLAGS_SF_SRC_RAX,     0, nullptr}},
     {0x99, 1, X86InstInfo{"CQO",    TYPE_INST, FLAGS_SF_DST_RDX | FLAGS_SF_SRC_RAX,     0, nullptr}},
@@ -243,9 +244,6 @@ void InitializeBaseTables(Context::OperatingMode Mode) {
 
     // VEX table
     {0xC4, 2, X86InstInfo{"",   TYPE_VEX_TABLE_PREFIX, FLAGS_NONE, 0, nullptr}},
-
-    // XOP Table
-    {0x8F, 1, X86InstInfo{"",   TYPE_XOP_TABLE_PREFIX, FLAGS_NONE, 0, nullptr}},
   };
 
   GenerateTable(BaseOps, BaseOpTable, sizeof(BaseOpTable) / sizeof(BaseOpTable[0]));


### PR DESCRIPTION
This keeps the XOP instruction tables around but removes the decoding
assert.
This lets us implement the POP instruction that overlapped the XOP
prefix without having to deal with XOP at all.

I don't believe we have any real need to support XOP, but if it is a
thing later then it'll be easy to add back