### PR TITLE
Forces the primary application thread to be host primary thread

### DIFF
--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -127,6 +127,7 @@ namespace FEXCore::Context {
 
     // Used for thread creation from syscalls
     FEXCore::Core::InternalThreadState* CreateThread(FEXCore::Core::CPUState *NewThreadState, uint64_t ParentTID);
+    void InitializeThreadData(FEXCore::Core::InternalThreadState *Thread);
     void InitializeThread(FEXCore::Core::InternalThreadState *Thread);
     void CopyMemoryMapping(FEXCore::Core::InternalThreadState *ParentThread, FEXCore::Core::InternalThreadState *ChildThread);
     void RunThread(FEXCore::Core::InternalThreadState *Thread);


### PR DESCRIPTION
This is a bit of a peculiar one, we want to ensure a single threaded
application is running on the emulator's primary thread.
This mitigates the problem that an application can do a getpid versus
gettid comparison and notice a problem.
Some games rely on getpid being the actual process ID and will spin
forever if it isn't the case.

This is also necessary for wine bringup since thread creation needs a
bit more finesse there.

Fixes #186