### PR TITLE
Adds a WARN_ONCE macro

### DIFF
--- a/External/SonicUtils/include/SonicUtils/LogManager.h
+++ b/External/SonicUtils/include/SonicUtils/LogManager.h
@@ -96,6 +96,14 @@ static inline void ERR(const char *fmt, ...) {
   va_end(args);
 }
 
+#define WARN_ONCE(...) \
+  do { \
+    static bool Warned{}; \
+    if (!Warned) { \
+      LogMan::Msg::D(__VA_ARGS__); \
+      Warned = true; \
+    } \
+  } while (0);
 
 } // namespace Msg
 } // namespace LogMan


### PR DESCRIPTION
There are cases where a WARN_ONCE macro that warns about one thing is
very nice to have.
Add the macro so we can use it later