### PR TITLE
Makes threaded compilation not rely on a global mutex

### DIFF
--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -75,8 +75,6 @@ namespace FEXCore::Context {
     Event PauseWait;
     bool Running{};
     CoreRunningMode RunningMode {CoreRunningMode::MODE_RUN};
-    FEXCore::Frontend::Decoder FrontendDecoder;
-    FEXCore::IR::PassManager PassManager;
 
     FEXCore::CPUIDEmu CPUID;
     std::unique_ptr<FEXCore::SyscallHandler> SyscallHandler;
@@ -133,8 +131,6 @@ namespace FEXCore::Context {
     void RunThread(FEXCore::Core::InternalThreadState *Thread);
 
   protected:
-    IR::RegisterAllocationPass *GetRegisterAllocatorPass();
-    bool HasRegisterAllocationPass() const { return RAPass != nullptr; }
     void ClearCodeCache(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP);
 
   private:
@@ -157,7 +153,6 @@ namespace FEXCore::Context {
     std::set<uint64_t> EntryList;
     std::vector<uint64_t> InitLocations;
     uint64_t StartingRIP;
-    IR::RegisterAllocationPass *RAPass {};
     std::mutex ExitMutex;
     std::unique_ptr<GdbServer> DebugServer;
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -258,8 +258,7 @@ JITCore::JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadSt
   // XXX: Set this to a real minimum feature set in the future
   SetCPUFeatures(vixl::CPUFeatures::All());
 
-  bool HadRA = CTX->HasRegisterAllocationPass();
-  RAPass = CTX->GetRegisterAllocatorPass();
+  RAPass = Thread->PassManager->GetRAPass();
 
   // Just set the entire range as executable
   auto Buffer = GetBuffer();
@@ -285,20 +284,18 @@ JITCore::JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadSt
     UsedRegisterCount -= NumCalleeGPRs + NumCalleeGPRPairs;
   }
 
-  if (!HadRA) {
-    RAPass->AllocateRegisterSet(UsedRegisterCount, RegisterClasses);
+  RAPass->AllocateRegisterSet(UsedRegisterCount, RegisterClasses);
 
-    RAPass->AddRegisters(FEXCore::IR::GPRClass, NumUsedGPRs);
-    RAPass->AddRegisters(FEXCore::IR::FPRClass, NumFPRs);
-    RAPass->AddRegisters(FEXCore::IR::GPRPairClass, NumUsedGPRPairs);
+  RAPass->AddRegisters(FEXCore::IR::GPRClass, NumUsedGPRs);
+  RAPass->AddRegisters(FEXCore::IR::FPRClass, NumFPRs);
+  RAPass->AddRegisters(FEXCore::IR::GPRPairClass, NumUsedGPRPairs);
 
-    RAPass->AllocateRegisterConflicts(FEXCore::IR::GPRClass, NumUsedGPRs);
-    RAPass->AllocateRegisterConflicts(FEXCore::IR::GPRPairClass, NumUsedGPRs);
+  RAPass->AllocateRegisterConflicts(FEXCore::IR::GPRClass, NumUsedGPRs);
+  RAPass->AllocateRegisterConflicts(FEXCore::IR::GPRPairClass, NumUsedGPRs);
 
-    for (uint32_t i = 0; i < NumUsedGPRPairs; ++i) {
-      RAPass->AddRegisterConflict(FEXCore::IR::GPRClass, i * 2,     FEXCore::IR::GPRPairClass, i);
-      RAPass->AddRegisterConflict(FEXCore::IR::GPRClass, i * 2 + 1, FEXCore::IR::GPRPairClass, i);
-    }
+  for (uint32_t i = 0; i < NumUsedGPRPairs; ++i) {
+    RAPass->AddRegisterConflict(FEXCore::IR::GPRClass, i * 2,     FEXCore::IR::GPRPairClass, i);
+    RAPass->AddRegisterConflict(FEXCore::IR::GPRClass, i * 2 + 1, FEXCore::IR::GPRPairClass, i);
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -123,22 +123,19 @@ JITCore::JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadSt
   , ThreadState {Thread} {
   Stack.resize(9000 * 16 * 64);
 
-  bool HadRA = CTX->HasRegisterAllocationPass();
-  RAPass = CTX->GetRegisterAllocatorPass();
+  RAPass = Thread->PassManager->GetRAPass();
 
-  if (!HadRA) {
-    RAPass->AllocateRegisterSet(RegisterCount, RegisterClasses);
-    RAPass->AddRegisters(FEXCore::IR::GPRClass, NumGPRs);
-    RAPass->AddRegisters(FEXCore::IR::FPRClass, NumXMMs);
-    RAPass->AddRegisters(FEXCore::IR::GPRPairClass, NumGPRPairs);
+  RAPass->AllocateRegisterSet(RegisterCount, RegisterClasses);
+  RAPass->AddRegisters(FEXCore::IR::GPRClass, NumGPRs);
+  RAPass->AddRegisters(FEXCore::IR::FPRClass, NumXMMs);
+  RAPass->AddRegisters(FEXCore::IR::GPRPairClass, NumGPRPairs);
 
-    RAPass->AllocateRegisterConflicts(FEXCore::IR::GPRClass, NumGPRs);
-    RAPass->AllocateRegisterConflicts(FEXCore::IR::GPRPairClass, NumGPRs);
+  RAPass->AllocateRegisterConflicts(FEXCore::IR::GPRClass, NumGPRs);
+  RAPass->AllocateRegisterConflicts(FEXCore::IR::GPRPairClass, NumGPRs);
 
-    for (uint32_t i = 0; i < NumGPRPairs; ++i) {
-      RAPass->AddRegisterConflict(FEXCore::IR::GPRClass, i * 2,     FEXCore::IR::GPRPairClass, i);
-      RAPass->AddRegisterConflict(FEXCore::IR::GPRClass, i * 2 + 1, FEXCore::IR::GPRPairClass, i);
-    }
+  for (uint32_t i = 0; i < NumGPRPairs; ++i) {
+    RAPass->AddRegisterConflict(FEXCore::IR::GPRClass, i * 2,     FEXCore::IR::GPRPairClass, i);
+    RAPass->AddRegisterConflict(FEXCore::IR::GPRClass, i * 2 + 1, FEXCore::IR::GPRPairClass, i);
   }
 
   CreateCustomDispatch(Thread);

--- a/External/FEXCore/Source/Interface/IR/PassManager.h
+++ b/External/FEXCore/Source/Interface/IR/PassManager.h
@@ -40,6 +40,7 @@ public:
     Passes.emplace_back(Pass);
   }
   void InsertRAPass(Pass *Pass) {
+    RAPass = Pass;
     InsertPass(Pass);
   }
 

--- a/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
+++ b/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
@@ -14,8 +14,14 @@ namespace FEXCore {
 namespace FEXCore::Context {
   struct Context;
 }
+
+namespace FEXCore::Frontend {
+  class Decoder;
+}
+
 namespace FEXCore::IR{
   class OpDispatchBuilder;
+  class PassManager;
 }
 
 namespace FEXCore::Core {
@@ -57,6 +63,10 @@ namespace FEXCore::Core {
 
     std::map<uint64_t, std::unique_ptr<FEXCore::IR::IRListView<true>>> IRLists;
     std::map<uint64_t, FEXCore::Core::DebugData> DebugData;
+
+    std::unique_ptr<FEXCore::Frontend::Decoder> FrontendDecoder;
+    std::unique_ptr<FEXCore::IR::PassManager> PassManager;
+
     RuntimeStats Stats{};
 
     int StatusCode{};


### PR DESCRIPTION
As we run more threaded applications it is becoming apparent that this
needs to be fixed now.
This duplicates the FrontendDecoder and Passmanager per thread so they
no longer block each other while compiling.
Increases a bit of memory usage but completely worth it.