### PR TITLE
Adds support for interpreter fallback

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -54,7 +54,8 @@ private:
 };
 
 static void InterpreterExecution(FEXCore::Core::InternalThreadState *Thread) {
-  InterpreterCore *Core = reinterpret_cast<InterpreterCore*>(Thread->CPUBackend.get());
+  // IntBackend will always point to this interpreter object
+  InterpreterCore *Core = reinterpret_cast<InterpreterCore*>(Thread->IntBackend.get());
   Core->ExecuteCode(Thread);
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -235,6 +235,10 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
   auto HeaderOp = HeaderNode->Op(DataBegin)->CW<FEXCore::IR::IROp_IRHeader>();
   LogMan::Throw::A(HeaderOp->Header.Op == IR::OP_IRHEADER, "First op wasn't IRHeader");
 
+  if (HeaderOp->ShouldInterpret) {
+    return ThreadState->IntBackend->CompileCode(IR, DebugData);
+  }
+
   // Fairly excessive buffer range to make sure we don't overflow
   uint32_t BufferRange = SSACount * 16;
   if ((getSize() + BufferRange) > MAX_CODE_SIZE) {

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -3338,7 +3338,8 @@ void OpDispatchBuilder::CreateJumpBlocks(std::vector<FEXCore::Frontend::Decoder:
 
 void OpDispatchBuilder::BeginFunction(uint64_t RIP, std::vector<FEXCore::Frontend::Decoder::DecodedBlocks> const *Blocks) {
   Entry = RIP;
-  auto IRHeader = _IRHeader(InvalidNode, RIP, 0);
+  auto IRHeader = _IRHeader(InvalidNode, RIP, 0, false);
+  Current_Header = IRHeader.first;
   CreateJumpBlocks(Blocks);
 
   auto Block = GetNewJumpBlock(RIP);

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -343,6 +343,7 @@ public:
 
 private:
   bool DecodeFailure{false};
+  FEXCore::IR::IROp_IRHeader *Current_Header{};
 
   OrderedNode *LoadSource(FEXCore::IR::RegisterClassType Class, FEXCore::X86Tables::DecodedOp const& Op, FEXCore::X86Tables::DecodedOperand const& Operand, uint32_t Flags, int8_t Align, bool LoadData = true, bool ForceLoad = false);
   OrderedNode *LoadSource_WithOpSize(FEXCore::IR::RegisterClassType Class, FEXCore::X86Tables::DecodedOp const& Op, FEXCore::X86Tables::DecodedOperand const& Operand, uint8_t OpSize, uint32_t Flags, int8_t Align, bool LoadData = true, bool ForceLoad = false);

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -54,7 +54,8 @@
       ],
       "Args": [
         "uint64_t", "Entry",
-        "uint32_t", "BlockCount"
+        "uint32_t", "BlockCount",
+        "bool", "ShouldInterpret"
       ]
     },
     "CodeBlock": {

--- a/External/FEXCore/Source/Interface/IR/Passes/IRCompaction.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/IRCompaction.cpp
@@ -61,7 +61,7 @@ bool IRCompaction::Run(IREmitter *IREmit) {
 
   // Zero is always zero(invalid)
   OldToNewRemap[0] = 0;
-  auto LocalHeaderOp = LocalBuilder._IRHeader(OrderedNodeWrapper::WrapOffset(0).GetNode(ListBegin), HeaderOp->Entry, HeaderOp->BlockCount);
+  auto LocalHeaderOp = LocalBuilder._IRHeader(OrderedNodeWrapper::WrapOffset(0).GetNode(ListBegin), HeaderOp->Entry, HeaderOp->BlockCount, HeaderOp->ShouldInterpret);
   OldToNewRemap[HeaderNode->Wrapped(ListBegin).ID()] = LocalHeaderOp.Node->Wrapped(LocalListBegin).ID();
 
   struct CodeBlockData {

--- a/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -1220,6 +1220,21 @@ namespace FEXCore::IR {
   bool ConstrainedRAPass::Run(IREmitter *IREmit) {
     bool Changed = false;
 
+    auto IR = IREmit->ViewIR();
+    uintptr_t ListBegin = IR.GetListData();
+    uintptr_t DataBegin = IR.GetData();
+
+    auto Begin = IR.begin();
+    auto Op = Begin();
+
+    IR::OrderedNode *RealNode = Op->GetNode(ListBegin);
+    auto HeaderOp = RealNode->Op(DataBegin)->CW<FEXCore::IR::IROp_IRHeader>();
+    LogMan::Throw::A(HeaderOp->Header.Op == IR::OP_IRHEADER, "First op wasn't IRHeader");
+
+    if (HeaderOp->ShouldInterpret) {
+      return false;
+    }
+
     SpillSlotCount = 0;
     Graph->SpillStack.clear();
 

--- a/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
+++ b/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
@@ -49,7 +49,8 @@ namespace FEXCore::Core {
 
     std::unique_ptr<FEXCore::IR::OpDispatchBuilder> OpDispatcher;
 
-    std::unique_ptr<FEXCore::CPU::CPUBackend> CPUBackend;
+    std::shared_ptr<FEXCore::CPU::CPUBackend> CPUBackend;
+    std::shared_ptr<FEXCore::CPU::CPUBackend> IntBackend;
     std::unique_ptr<FEXCore::CPU::CPUBackend> FallbackBackend;
 
     std::unique_ptr<FEXCore::BlockCache> BlockCache;

--- a/Source/Tests/IRLoader/Loader.cpp
+++ b/Source/Tests/IRLoader/Loader.cpp
@@ -363,7 +363,7 @@ namespace FEX::IRLoader {
       if (!CheckPrintError(Def, CodeBlockCount.first)) return false;
 
       EntryRIP = Entry.second;
-      IRHeader = _IRHeader(InvalidNode, Entry.second, CodeBlockCount.second);
+      IRHeader = _IRHeader(InvalidNode, Entry.second, CodeBlockCount.second, false);
     }
 
     // Spin through the blocks and generate basic block ops


### PR DESCRIPTION
The IRHeader itself contains a flag for if a block should fallback to
the interpreter.
This is necessary for the case that an IR is loaded and the Frontend
object no longer has the data necessary to know if it should do an
interpreter fallback.
This is super useful for bisecting JIT versus Intepreter failures, and
also cases where falling back to intepreter for compatibility is a lot
more simple than wiring things through the JIT (ala x87)

This isn't currently utilized, but will be once x87 work lands