### PR TITLE
Implements softfloat library for x87

### DIFF
--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -49,6 +49,70 @@ set (SRCS
   Common/Paths.cpp
   Common/JitSymbols.cpp
   Common/NetStream.cpp
+  Common/SoftFloat-3e/extF80_add.c
+  Common/SoftFloat-3e/extF80_div.c
+  Common/SoftFloat-3e/extF80_sub.c
+  Common/SoftFloat-3e/extF80_mul.c
+  Common/SoftFloat-3e/extF80_rem.c
+  Common/SoftFloat-3e/extF80_sqrt.c
+  Common/SoftFloat-3e/s_add128.c
+  Common/SoftFloat-3e/s_sub128.c
+  Common/SoftFloat-3e/s_le128.c
+  Common/SoftFloat-3e/extF80_to_i32.c
+  Common/SoftFloat-3e/extF80_to_i64.c
+  Common/SoftFloat-3e/extF80_to_f32.c
+  Common/SoftFloat-3e/extF80_to_f64.c
+  Common/SoftFloat-3e/i32_to_extF80.c
+  Common/SoftFloat-3e/extF80_to_f128.c
+  Common/SoftFloat-3e/f128_to_extF80.c
+  Common/SoftFloat-3e/s_f128UIToCommonNaN.c
+  Common/SoftFloat-3e/s_commonNaNToF128UI.c
+  Common/SoftFloat-3e/s_shortShiftRight128.c
+  Common/SoftFloat-3e/s_normSubnormalF128Sig.c
+  Common/SoftFloat-3e/s_roundToI32.c
+  Common/SoftFloat-3e/s_roundToI64.c
+  Common/SoftFloat-3e/s_roundPackToF32.c
+  Common/SoftFloat-3e/s_addMagsExtF80.c
+  Common/SoftFloat-3e/s_extF80UIToCommonNaN.c
+  Common/SoftFloat-3e/s_commonNaNToF32UI.c
+  Common/SoftFloat-3e/s_commonNaNToF64UI.c
+  Common/SoftFloat-3e/s_shortShiftRightJam64.c
+  Common/SoftFloat-3e/s_shortShiftRightJam64Extra.c
+  Common/SoftFloat-3e/s_shiftRightJam64Extra.c
+  Common/SoftFloat-3e/s_shortShiftRightJam64Extra.c
+  Common/SoftFloat-3e/s_roundPackToF64.c
+  Common/SoftFloat-3e/s_propagateNaNExtF80UI.c
+  Common/SoftFloat-3e/s_roundPackToExtF80.c
+  Common/SoftFloat-3e/s_normSubnormalExtF80Sig.c
+  Common/SoftFloat-3e/s_shiftRightJam64.c
+  Common/SoftFloat-3e/s_subMagsExtF80.c
+  Common/SoftFloat-3e/s_shiftRightJam32.c
+  Common/SoftFloat-3e/s_shiftRightJam128.c
+  Common/SoftFloat-3e/s_shiftRightJam128Extra.c
+  Common/SoftFloat-3e/s_normRoundPackToExtF80.c
+  Common/SoftFloat-3e/s_shortShiftLeft128.c
+  Common/SoftFloat-3e/s_approxRecip32_1.c
+  Common/SoftFloat-3e/s_approxRecip_1Ks.c
+  Common/SoftFloat-3e/s_approxRecipSqrt32_1.c
+  Common/SoftFloat-3e/s_approxRecipSqrt_1Ks.c
+  Common/SoftFloat-3e/softfloat_raiseFlags.c
+  Common/SoftFloat-3e/softfloat_state.c
+  Common/SoftFloat-3e/f64_to_extF80.c
+  Common/SoftFloat-3e/s_commonNaNToExtF80UI.c
+  Common/SoftFloat-3e/s_normSubnormalF64Sig.c
+  Common/SoftFloat-3e/s_f64UIToCommonNaN.c
+  Common/SoftFloat-3e/extF80_roundToInt.c
+  Common/SoftFloat-3e/extF80_eq.c
+  Common/SoftFloat-3e/extF80_lt.c
+  Common/SoftFloat-3e/s_lt128.c
+  Common/SoftFloat-3e/s_mul64ByShifted32To128.c
+  Common/SoftFloat-3e/s_mul64To128.c
+  Common/SoftFloat-3e/s_countLeadingZeros8.c
+  Common/SoftFloat-3e/s_countLeadingZeros32.c
+  Common/SoftFloat-3e/s_countLeadingZeros64.c
+  Common/SoftFloat-3e/f32_to_extF80.c
+  Common/SoftFloat-3e/s_normSubnormalF32Sig.c
+  Common/SoftFloat-3e/s_f32UIToCommonNaN.c
   Interface/Config/Config.cpp
   Interface/Context/Context.cpp
   Interface/Core/BlockCache.cpp

--- a/External/FEXCore/Source/Common/SoftFloat-3e/extF80_add.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/extF80_add.c
@@ -1,0 +1,69 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "platform.h"
+#include "internals.h"
+#include "softfloat.h"
+
+extFloat80_t extF80_add( extFloat80_t a, extFloat80_t b )
+{
+    union { struct extFloat80M s; extFloat80_t f; } uA;
+    uint_fast16_t uiA64;
+    uint_fast64_t uiA0;
+    bool signA;
+    union { struct extFloat80M s; extFloat80_t f; } uB;
+    uint_fast16_t uiB64;
+    uint_fast64_t uiB0;
+    bool signB;
+    extFloat80_t
+        (*magsFuncPtr)(
+            uint_fast16_t, uint_fast64_t, uint_fast16_t, uint_fast64_t, bool );
+
+    uA.f = a;
+    uiA64 = uA.s.signExp;
+    uiA0  = uA.s.signif;
+    signA = signExtF80UI64( uiA64 );
+    uB.f = b;
+    uiB64 = uB.s.signExp;
+    uiB0  = uB.s.signif;
+    signB = signExtF80UI64( uiB64 );
+    magsFuncPtr =
+        (signA == signB) ? softfloat_addMagsExtF80 : softfloat_subMagsExtF80;
+    return (*magsFuncPtr)( uiA64, uiA0, uiB64, uiB0, signA );
+}
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/extF80_div.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/extF80_div.c
@@ -1,0 +1,203 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "platform.h"
+#include "internals.h"
+#include "specialize.h"
+#include "softfloat.h"
+
+extFloat80_t extF80_div( extFloat80_t a, extFloat80_t b )
+{
+    union { struct extFloat80M s; extFloat80_t f; } uA;
+    uint_fast16_t uiA64;
+    uint_fast64_t uiA0;
+    bool signA;
+    int_fast32_t expA;
+    uint_fast64_t sigA;
+    union { struct extFloat80M s; extFloat80_t f; } uB;
+    uint_fast16_t uiB64;
+    uint_fast64_t uiB0;
+    bool signB;
+    int_fast32_t expB;
+    uint_fast64_t sigB;
+    bool signZ;
+    struct exp32_sig64 normExpSig;
+    int_fast32_t expZ;
+    struct uint128 rem;
+    uint_fast32_t recip32;
+    uint_fast64_t sigZ;
+    int ix;
+    uint_fast64_t q64;
+    uint_fast32_t q;
+    struct uint128 term;
+    uint_fast64_t sigZExtra;
+    struct uint128 uiZ;
+    uint_fast16_t uiZ64;
+    uint_fast64_t uiZ0;
+    union { struct extFloat80M s; extFloat80_t f; } uZ;
+
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    uA.f = a;
+    uiA64 = uA.s.signExp;
+    uiA0  = uA.s.signif;
+    signA = signExtF80UI64( uiA64 );
+    expA  = expExtF80UI64( uiA64 );
+    sigA  = uiA0;
+    uB.f = b;
+    uiB64 = uB.s.signExp;
+    uiB0  = uB.s.signif;
+    signB = signExtF80UI64( uiB64 );
+    expB  = expExtF80UI64( uiB64 );
+    sigB  = uiB0;
+    signZ = signA ^ signB;
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    if ( expA == 0x7FFF ) {
+        if ( sigA & UINT64_C( 0x7FFFFFFFFFFFFFFF ) ) goto propagateNaN;
+        if ( expB == 0x7FFF ) {
+            if ( sigB & UINT64_C( 0x7FFFFFFFFFFFFFFF ) ) goto propagateNaN;
+            goto invalid;
+        }
+        goto infinity;
+    }
+    if ( expB == 0x7FFF ) {
+        if ( sigB & UINT64_C( 0x7FFFFFFFFFFFFFFF ) ) goto propagateNaN;
+        goto zero;
+    }
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    if ( ! expB ) expB = 1;
+    if ( ! (sigB & UINT64_C( 0x8000000000000000 )) ) {
+        if ( ! sigB ) {
+            if ( ! sigA ) goto invalid;
+            softfloat_raiseFlags( softfloat_flag_infinite );
+            goto infinity;
+        }
+        normExpSig = softfloat_normSubnormalExtF80Sig( sigB );
+        expB += normExpSig.exp;
+        sigB = normExpSig.sig;
+    }
+    if ( ! expA ) expA = 1;
+    if ( ! (sigA & UINT64_C( 0x8000000000000000 )) ) {
+        if ( ! sigA ) goto zero;
+        normExpSig = softfloat_normSubnormalExtF80Sig( sigA );
+        expA += normExpSig.exp;
+        sigA = normExpSig.sig;
+    }
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    expZ = expA - expB + 0x3FFF;
+    if ( sigA < sigB ) {
+        --expZ;
+        rem = softfloat_shortShiftLeft128( 0, sigA, 32 );
+    } else {
+        rem = softfloat_shortShiftLeft128( 0, sigA, 31 );
+    }
+    recip32 = softfloat_approxRecip32_1( sigB>>32 );
+    sigZ = 0;
+    ix = 2;
+    for (;;) {
+        q64 = (uint_fast64_t) (uint32_t) (rem.v64>>2) * recip32;
+        q = (q64 + 0x80000000)>>32;
+        --ix;
+        if ( ix < 0 ) break;
+        rem = softfloat_shortShiftLeft128( rem.v64, rem.v0, 29 );
+        term = softfloat_mul64ByShifted32To128( sigB, q );
+        rem = softfloat_sub128( rem.v64, rem.v0, term.v64, term.v0 );
+        if ( rem.v64 & UINT64_C( 0x8000000000000000 ) ) {
+            --q;
+            rem = softfloat_add128( rem.v64, rem.v0, sigB>>32, sigB<<32 );
+        }
+        sigZ = (sigZ<<29) + q;
+    }
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    if ( ((q + 1) & 0x3FFFFF) < 2 ) {
+        rem = softfloat_shortShiftLeft128( rem.v64, rem.v0, 29 );
+        term = softfloat_mul64ByShifted32To128( sigB, q );
+        rem = softfloat_sub128( rem.v64, rem.v0, term.v64, term.v0 );
+        term = softfloat_shortShiftLeft128( 0, sigB, 32 );
+        if ( rem.v64 & UINT64_C( 0x8000000000000000 ) ) {
+            --q;
+            rem = softfloat_add128( rem.v64, rem.v0, term.v64, term.v0 );
+        } else if ( softfloat_le128( term.v64, term.v0, rem.v64, rem.v0 ) ) {
+            ++q;
+            rem = softfloat_sub128( rem.v64, rem.v0, term.v64, term.v0 );
+        }
+        if ( rem.v64 | rem.v0 ) q |= 1;
+    }
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    sigZ = (sigZ<<6) + (q>>23);
+    sigZExtra = (uint64_t) ((uint_fast64_t) q<<41);
+    return
+        softfloat_roundPackToExtF80(
+            signZ, expZ, sigZ, sigZExtra, extF80_roundingPrecision );
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+ propagateNaN:
+    uiZ = softfloat_propagateNaNExtF80UI( uiA64, uiA0, uiB64, uiB0 );
+    uiZ64 = uiZ.v64;
+    uiZ0  = uiZ.v0;
+    goto uiZ;
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+ invalid:
+    softfloat_raiseFlags( softfloat_flag_invalid );
+    uiZ64 = defaultNaNExtF80UI64;
+    uiZ0  = defaultNaNExtF80UI0;
+    goto uiZ;
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+ infinity:
+    uiZ64 = packToExtF80UI64( signZ, 0x7FFF );
+    uiZ0  = UINT64_C( 0x8000000000000000 );
+    goto uiZ;
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+ zero:
+    uiZ64 = packToExtF80UI64( signZ, 0 );
+    uiZ0  = 0;
+ uiZ:
+    uZ.s.signExp = uiZ64;
+    uZ.s.signif  = uiZ0;
+    return uZ.f;
+
+}
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/extF80_eq.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/extF80_eq.c
@@ -1,0 +1,73 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "platform.h"
+#include "internals.h"
+#include "specialize.h"
+#include "softfloat.h"
+
+bool extF80_eq( extFloat80_t a, extFloat80_t b )
+{
+    union { struct extFloat80M s; extFloat80_t f; } uA;
+    uint_fast16_t uiA64;
+    uint_fast64_t uiA0;
+    union { struct extFloat80M s; extFloat80_t f; } uB;
+    uint_fast16_t uiB64;
+    uint_fast64_t uiB0;
+
+    uA.f = a;
+    uiA64 = uA.s.signExp;
+    uiA0  = uA.s.signif;
+    uB.f = b;
+    uiB64 = uB.s.signExp;
+    uiB0  = uB.s.signif;
+    if ( isNaNExtF80UI( uiA64, uiA0 ) || isNaNExtF80UI( uiB64, uiB0 ) ) {
+        if (
+               softfloat_isSigNaNExtF80UI( uiA64, uiA0 )
+            || softfloat_isSigNaNExtF80UI( uiB64, uiB0 )
+        ) {
+            softfloat_raiseFlags( softfloat_flag_invalid );
+        }
+        return false;
+    }
+    return
+           (uiA0 == uiB0)
+        && ((uiA64 == uiB64) || (! uiA0 && ! ((uiA64 | uiB64) & 0x7FFF)));
+
+}
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/extF80_lt.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/extF80_lt.c
@@ -1,0 +1,73 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "platform.h"
+#include "internals.h"
+#include "specialize.h"
+#include "softfloat.h"
+
+bool extF80_lt( extFloat80_t a, extFloat80_t b )
+{
+    union { struct extFloat80M s; extFloat80_t f; } uA;
+    uint_fast16_t uiA64;
+    uint_fast64_t uiA0;
+    union { struct extFloat80M s; extFloat80_t f; } uB;
+    uint_fast16_t uiB64;
+    uint_fast64_t uiB0;
+    bool signA, signB;
+
+    uA.f = a;
+    uiA64 = uA.s.signExp;
+    uiA0  = uA.s.signif;
+    uB.f = b;
+    uiB64 = uB.s.signExp;
+    uiB0  = uB.s.signif;
+    if ( isNaNExtF80UI( uiA64, uiA0 ) || isNaNExtF80UI( uiB64, uiB0 ) ) {
+        softfloat_raiseFlags( softfloat_flag_invalid );
+        return false;
+    }
+    signA = signExtF80UI64( uiA64 );
+    signB = signExtF80UI64( uiB64 );
+    return
+        (signA != signB)
+            ? signA && (((uiA64 | uiB64) & 0x7FFF) | uiA0 | uiB0)
+            : ((uiA64 != uiB64) || (uiA0 != uiB0))
+                  && (signA ^ softfloat_lt128( uiA64, uiA0, uiB64, uiB0 ));
+
+}
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/extF80_mul.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/extF80_mul.c
@@ -1,0 +1,158 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "platform.h"
+#include "internals.h"
+#include "specialize.h"
+#include "softfloat.h"
+
+extFloat80_t extF80_mul( extFloat80_t a, extFloat80_t b )
+{
+    union { struct extFloat80M s; extFloat80_t f; } uA;
+    uint_fast16_t uiA64;
+    uint_fast64_t uiA0;
+    bool signA;
+    int_fast32_t expA;
+    uint_fast64_t sigA;
+    union { struct extFloat80M s; extFloat80_t f; } uB;
+    uint_fast16_t uiB64;
+    uint_fast64_t uiB0;
+    bool signB;
+    int_fast32_t expB;
+    uint_fast64_t sigB;
+    bool signZ;
+    uint_fast64_t magBits;
+    struct exp32_sig64 normExpSig;
+    int_fast32_t expZ;
+    struct uint128 sig128Z, uiZ;
+    uint_fast16_t uiZ64;
+    uint_fast64_t uiZ0;
+    union { struct extFloat80M s; extFloat80_t f; } uZ;
+
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    uA.f = a;
+    uiA64 = uA.s.signExp;
+    uiA0  = uA.s.signif;
+    signA = signExtF80UI64( uiA64 );
+    expA  = expExtF80UI64( uiA64 );
+    sigA  = uiA0;
+    uB.f = b;
+    uiB64 = uB.s.signExp;
+    uiB0  = uB.s.signif;
+    signB = signExtF80UI64( uiB64 );
+    expB  = expExtF80UI64( uiB64 );
+    sigB  = uiB0;
+    signZ = signA ^ signB;
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    if ( expA == 0x7FFF ) {
+        if (
+               (sigA & UINT64_C( 0x7FFFFFFFFFFFFFFF ))
+            || ((expB == 0x7FFF) && (sigB & UINT64_C( 0x7FFFFFFFFFFFFFFF )))
+        ) {
+            goto propagateNaN;
+        }
+        magBits = expB | sigB;
+        goto infArg;
+    }
+    if ( expB == 0x7FFF ) {
+        if ( sigB & UINT64_C( 0x7FFFFFFFFFFFFFFF ) ) goto propagateNaN;
+        magBits = expA | sigA;
+        goto infArg;
+    }
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    if ( ! expA ) expA = 1;
+    if ( ! (sigA & UINT64_C( 0x8000000000000000 )) ) {
+        if ( ! sigA ) goto zero;
+        normExpSig = softfloat_normSubnormalExtF80Sig( sigA );
+        expA += normExpSig.exp;
+        sigA = normExpSig.sig;
+    }
+    if ( ! expB ) expB = 1;
+    if ( ! (sigB & UINT64_C( 0x8000000000000000 )) ) {
+        if ( ! sigB ) goto zero;
+        normExpSig = softfloat_normSubnormalExtF80Sig( sigB );
+        expB += normExpSig.exp;
+        sigB = normExpSig.sig;
+    }
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    expZ = expA + expB - 0x3FFE;
+    sig128Z = softfloat_mul64To128( sigA, sigB );
+    if ( sig128Z.v64 < UINT64_C( 0x8000000000000000 ) ) {
+        --expZ;
+        sig128Z =
+            softfloat_add128(
+                sig128Z.v64, sig128Z.v0, sig128Z.v64, sig128Z.v0 );
+    }
+    return
+        softfloat_roundPackToExtF80(
+            signZ, expZ, sig128Z.v64, sig128Z.v0, extF80_roundingPrecision );
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+ propagateNaN:
+    uiZ = softfloat_propagateNaNExtF80UI( uiA64, uiA0, uiB64, uiB0 );
+    uiZ64 = uiZ.v64;
+    uiZ0  = uiZ.v0;
+    goto uiZ;
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+ infArg:
+    if ( ! magBits ) {
+        softfloat_raiseFlags( softfloat_flag_invalid );
+        uiZ64 = defaultNaNExtF80UI64;
+        uiZ0  = defaultNaNExtF80UI0;
+    } else {
+        uiZ64 = packToExtF80UI64( signZ, 0x7FFF );
+        uiZ0  = UINT64_C( 0x8000000000000000 );
+    }
+    goto uiZ;
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+ zero:
+    uiZ64 = packToExtF80UI64( signZ, 0 );
+    uiZ0  = 0;
+ uiZ:
+    uZ.s.signExp = uiZ64;
+    uZ.s.signif  = uiZ0;
+    return uZ.f;
+
+}
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/extF80_rem.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/extF80_rem.c
@@ -1,0 +1,225 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015, 2016, 2017 The Regents of the
+University of California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "platform.h"
+#include "internals.h"
+#include "specialize.h"
+#include "softfloat.h"
+
+extFloat80_t extF80_rem( extFloat80_t a, extFloat80_t b )
+{
+    union { struct extFloat80M s; extFloat80_t f; } uA;
+    uint_fast16_t uiA64;
+    uint_fast64_t uiA0;
+    bool signA;
+    int_fast32_t expA;
+    uint_fast64_t sigA;
+    union { struct extFloat80M s; extFloat80_t f; } uB;
+    uint_fast16_t uiB64;
+    uint_fast64_t uiB0;
+    int_fast32_t expB;
+    uint_fast64_t sigB;
+    struct exp32_sig64 normExpSig;
+    int_fast32_t expDiff;
+    struct uint128 rem, shiftedSigB;
+    uint_fast32_t q, recip32;
+    uint_fast64_t q64;
+    struct uint128 term, altRem, meanRem;
+    bool signRem;
+    struct uint128 uiZ;
+    uint_fast16_t uiZ64;
+    uint_fast64_t uiZ0;
+    union { struct extFloat80M s; extFloat80_t f; } uZ;
+
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    uA.f = a;
+    uiA64 = uA.s.signExp;
+    uiA0  = uA.s.signif;
+    signA = signExtF80UI64( uiA64 );
+    expA  = expExtF80UI64( uiA64 );
+    sigA  = uiA0;
+    uB.f = b;
+    uiB64 = uB.s.signExp;
+    uiB0  = uB.s.signif;
+    expB  = expExtF80UI64( uiB64 );
+    sigB  = uiB0;
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    if ( expA == 0x7FFF ) {
+        if (
+               (sigA & UINT64_C( 0x7FFFFFFFFFFFFFFF ))
+            || ((expB == 0x7FFF) && (sigB & UINT64_C( 0x7FFFFFFFFFFFFFFF )))
+        ) {
+            goto propagateNaN;
+        }
+        goto invalid;
+    }
+    if ( expB == 0x7FFF ) {
+        if ( sigB & UINT64_C( 0x7FFFFFFFFFFFFFFF ) ) goto propagateNaN;
+        /*--------------------------------------------------------------------
+        | Argument b is an infinity.  Doubling `expB' is an easy way to ensure
+        | that `expDiff' later is less than -1, which will result in returning
+        | a canonicalized version of argument a.
+        *--------------------------------------------------------------------*/
+        expB += expB;
+    }
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    if ( ! expB ) expB = 1;
+    if ( ! (sigB & UINT64_C( 0x8000000000000000 )) ) {
+        if ( ! sigB ) goto invalid;
+        normExpSig = softfloat_normSubnormalExtF80Sig( sigB );
+        expB += normExpSig.exp;
+        sigB = normExpSig.sig;
+    }
+    if ( ! expA ) expA = 1;
+    if ( ! (sigA & UINT64_C( 0x8000000000000000 )) ) {
+        if ( ! sigA ) {
+            expA = 0;
+            goto copyA;
+        }
+        normExpSig = softfloat_normSubnormalExtF80Sig( sigA );
+        expA += normExpSig.exp;
+        sigA = normExpSig.sig;
+    }
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    expDiff = expA - expB;
+    if ( expDiff < -1 ) goto copyA;
+    rem = softfloat_shortShiftLeft128( 0, sigA, 32 );
+    shiftedSigB = softfloat_shortShiftLeft128( 0, sigB, 32 );
+    if ( expDiff < 1 ) {
+        if ( expDiff ) {
+            --expB;
+            shiftedSigB = softfloat_shortShiftLeft128( 0, sigB, 33 );
+            q = 0;
+        } else {
+            q = (sigB <= sigA);
+            if ( q ) {
+                rem =
+                    softfloat_sub128(
+                        rem.v64, rem.v0, shiftedSigB.v64, shiftedSigB.v0 );
+            }
+        }
+    } else {
+        recip32 = softfloat_approxRecip32_1( sigB>>32 );
+        expDiff -= 30;
+        for (;;) {
+            q64 = (uint_fast64_t) (uint32_t) (rem.v64>>2) * recip32;
+            if ( expDiff < 0 ) break;
+            q = (q64 + 0x80000000)>>32;
+            rem = softfloat_shortShiftLeft128( rem.v64, rem.v0, 29 );
+            term = softfloat_mul64ByShifted32To128( sigB, q );
+            rem = softfloat_sub128( rem.v64, rem.v0, term.v64, term.v0 );
+            if ( rem.v64 & UINT64_C( 0x8000000000000000 ) ) {
+                rem =
+                    softfloat_add128(
+                        rem.v64, rem.v0, shiftedSigB.v64, shiftedSigB.v0 );
+            }
+            expDiff -= 29;
+        }
+        /*--------------------------------------------------------------------
+        | (`expDiff' cannot be less than -29 here.)
+        *--------------------------------------------------------------------*/
+        q = (uint32_t) (q64>>32)>>(~expDiff & 31);
+        rem = softfloat_shortShiftLeft128( rem.v64, rem.v0, expDiff + 30 );
+        term = softfloat_mul64ByShifted32To128( sigB, q );
+        rem = softfloat_sub128( rem.v64, rem.v0, term.v64, term.v0 );
+        if ( rem.v64 & UINT64_C( 0x8000000000000000 ) ) {
+            altRem =
+                softfloat_add128(
+                    rem.v64, rem.v0, shiftedSigB.v64, shiftedSigB.v0 );
+            goto selectRem;
+        }
+    }
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    do {
+        altRem = rem;
+        ++q;
+        rem =
+            softfloat_sub128(
+                rem.v64, rem.v0, shiftedSigB.v64, shiftedSigB.v0 );
+    } while ( ! (rem.v64 & UINT64_C( 0x8000000000000000 )) );
+ selectRem:
+    meanRem = softfloat_add128( rem.v64, rem.v0, altRem.v64, altRem.v0 );
+    if (
+        (meanRem.v64 & UINT64_C( 0x8000000000000000 ))
+            || (! (meanRem.v64 | meanRem.v0) && (q & 1))
+    ) {
+        rem = altRem;
+    }
+    signRem = signA;
+    if ( rem.v64 & UINT64_C( 0x8000000000000000 ) ) {
+        signRem = ! signRem;
+        rem = softfloat_sub128( 0, 0, rem.v64, rem.v0 );
+    }
+    return
+        softfloat_normRoundPackToExtF80(
+            signRem, rem.v64 | rem.v0 ? expB + 32 : 0, rem.v64, rem.v0, 80 );
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+ propagateNaN:
+    uiZ = softfloat_propagateNaNExtF80UI( uiA64, uiA0, uiB64, uiB0 );
+    uiZ64 = uiZ.v64;
+    uiZ0  = uiZ.v0;
+    goto uiZ;
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+ invalid:
+    softfloat_raiseFlags( softfloat_flag_invalid );
+    uiZ64 = defaultNaNExtF80UI64;
+    uiZ0  = defaultNaNExtF80UI0;
+    goto uiZ;
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+ copyA:
+    if ( expA < 1 ) {
+        sigA >>= 1 - expA;
+        expA = 0;
+    }
+    uiZ64 = packToExtF80UI64( signA, expA );
+    uiZ0  = sigA;
+ uiZ:
+    uZ.s.signExp = uiZ64;
+    uZ.s.signif  = uiZ0;
+    return uZ.f;
+
+}
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/extF80_roundToInt.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/extF80_roundToInt.c
@@ -1,0 +1,154 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2017 The Regents of the University of
+California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "platform.h"
+#include "internals.h"
+#include "specialize.h"
+#include "softfloat.h"
+
+extFloat80_t
+ extF80_roundToInt( extFloat80_t a, uint_fast8_t roundingMode, bool exact )
+{
+    union { struct extFloat80M s; extFloat80_t f; } uA;
+    uint_fast16_t uiA64, signUI64;
+    int_fast32_t exp;
+    uint_fast64_t sigA;
+    uint_fast16_t uiZ64;
+    uint_fast64_t sigZ;
+    struct exp32_sig64 normExpSig;
+    struct uint128 uiZ;
+    uint_fast64_t lastBitMask, roundBitsMask;
+    union { struct extFloat80M s; extFloat80_t f; } uZ;
+
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    uA.f = a;
+    uiA64 = uA.s.signExp;
+    signUI64 = uiA64 & packToExtF80UI64( 1, 0 );
+    exp = expExtF80UI64( uiA64 );
+    sigA = uA.s.signif;
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    if ( !(sigA & UINT64_C( 0x8000000000000000 )) && (exp != 0x7FFF) ) {
+        if ( !sigA ) {
+            uiZ64 = signUI64;
+            sigZ = 0;
+            goto uiZ;
+        }
+        normExpSig = softfloat_normSubnormalExtF80Sig( sigA );
+        exp += normExpSig.exp;
+        sigA = normExpSig.sig;
+    }
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    if ( 0x403E <= exp ) {
+        if ( exp == 0x7FFF ) {
+            if ( sigA & UINT64_C( 0x7FFFFFFFFFFFFFFF ) ) {
+                uiZ = softfloat_propagateNaNExtF80UI( uiA64, sigA, 0, 0 );
+                uiZ64 = uiZ.v64;
+                sigZ  = uiZ.v0;
+                goto uiZ;
+            }
+            sigZ = UINT64_C( 0x8000000000000000 );
+        } else {
+            sigZ = sigA;
+        }
+        uiZ64 = signUI64 | exp;
+        goto uiZ;
+    }
+    if ( exp <= 0x3FFE ) {
+        if ( exact ) softfloat_exceptionFlags |= softfloat_flag_inexact;
+        switch ( roundingMode ) {
+         case softfloat_round_near_even:
+            if ( !(sigA & UINT64_C( 0x7FFFFFFFFFFFFFFF )) ) break;
+         case softfloat_round_near_maxMag:
+            if ( exp == 0x3FFE ) goto mag1;
+            break;
+         case softfloat_round_min:
+            if ( signUI64 ) goto mag1;
+            break;
+         case softfloat_round_max:
+            if ( !signUI64 ) goto mag1;
+            break;
+#ifdef SOFTFLOAT_ROUND_ODD
+         case softfloat_round_odd:
+            goto mag1;
+#endif
+        }
+        uiZ64 = signUI64;
+        sigZ  = 0;
+        goto uiZ;
+     mag1:
+        uiZ64 = signUI64 | 0x3FFF;
+        sigZ  = UINT64_C( 0x8000000000000000 );
+        goto uiZ;
+    }
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    uiZ64 = signUI64 | exp;
+    lastBitMask = (uint_fast64_t) 1<<(0x403E - exp);
+    roundBitsMask = lastBitMask - 1;
+    sigZ = sigA;
+    if ( roundingMode == softfloat_round_near_maxMag ) {
+        sigZ += lastBitMask>>1;
+    } else if ( roundingMode == softfloat_round_near_even ) {
+        sigZ += lastBitMask>>1;
+        if ( !(sigZ & roundBitsMask) ) sigZ &= ~lastBitMask;
+    } else if (
+        roundingMode == (signUI64 ? softfloat_round_min : softfloat_round_max)
+    ) {
+        sigZ += roundBitsMask;
+    }
+    sigZ &= ~roundBitsMask;
+    if ( !sigZ ) {
+        ++uiZ64;
+        sigZ = UINT64_C( 0x8000000000000000 );
+    }
+    if ( sigZ != sigA ) {
+#ifdef SOFTFLOAT_ROUND_ODD
+        if ( roundingMode == softfloat_round_odd ) sigZ |= lastBitMask;
+#endif
+        if ( exact ) softfloat_exceptionFlags |= softfloat_flag_inexact;
+    }
+ uiZ:
+    uZ.s.signExp = uiZ64;
+    uZ.s.signif = sigZ;
+    return uZ.f;
+
+}
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/extF80_sqrt.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/extF80_sqrt.c
@@ -1,0 +1,176 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015, 2016, 2017 The Regents of the
+University of California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "platform.h"
+#include "internals.h"
+#include "specialize.h"
+#include "softfloat.h"
+
+extFloat80_t extF80_sqrt( extFloat80_t a )
+{
+    union { struct extFloat80M s; extFloat80_t f; } uA;
+    uint_fast16_t uiA64;
+    uint_fast64_t uiA0;
+    bool signA;
+    int_fast32_t expA;
+    uint_fast64_t sigA;
+    struct uint128 uiZ;
+    uint_fast16_t uiZ64;
+    uint_fast64_t uiZ0;
+    struct exp32_sig64 normExpSig;
+    int_fast32_t expZ;
+    uint_fast32_t sig32A, recipSqrt32, sig32Z;
+    struct uint128 rem;
+    uint_fast64_t q, x64, sigZ;
+    struct uint128 y, term;
+    uint_fast64_t sigZExtra;
+    union { struct extFloat80M s; extFloat80_t f; } uZ;
+
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    uA.f = a;
+    uiA64 = uA.s.signExp;
+    uiA0  = uA.s.signif;
+    signA = signExtF80UI64( uiA64 );
+    expA  = expExtF80UI64( uiA64 );
+    sigA  = uiA0;
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    if ( expA == 0x7FFF ) {
+        if ( sigA & UINT64_C( 0x7FFFFFFFFFFFFFFF ) ) {
+            uiZ = softfloat_propagateNaNExtF80UI( uiA64, uiA0, 0, 0 );
+            uiZ64 = uiZ.v64;
+            uiZ0  = uiZ.v0;
+            goto uiZ;
+        }
+        if ( ! signA ) return a;
+        goto invalid;
+    }
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    if ( signA ) {
+        if ( ! sigA ) goto zero;
+        goto invalid;
+    }
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    if ( ! expA ) expA = 1;
+    if ( ! (sigA & UINT64_C( 0x8000000000000000 )) ) {
+        if ( ! sigA ) goto zero;
+        normExpSig = softfloat_normSubnormalExtF80Sig( sigA );
+        expA += normExpSig.exp;
+        sigA = normExpSig.sig;
+    }
+    /*------------------------------------------------------------------------
+    | (`sig32Z' is guaranteed to be a lower bound on the square root of
+    | `sig32A', which makes `sig32Z' also a lower bound on the square root of
+    | `sigA'.)
+    *------------------------------------------------------------------------*/
+    expZ = ((expA - 0x3FFF)>>1) + 0x3FFF;
+    expA &= 1;
+    sig32A = sigA>>32;
+    recipSqrt32 = softfloat_approxRecipSqrt32_1( expA, sig32A );
+    sig32Z = ((uint_fast64_t) sig32A * recipSqrt32)>>32;
+    if ( expA ) {
+        sig32Z >>= 1;
+        rem = softfloat_shortShiftLeft128( 0, sigA, 61 );
+    } else {
+        rem = softfloat_shortShiftLeft128( 0, sigA, 62 );
+    }
+    rem.v64 -= (uint_fast64_t) sig32Z * sig32Z;
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    q = ((uint32_t) (rem.v64>>2) * (uint_fast64_t) recipSqrt32)>>32;
+    x64 = (uint_fast64_t) sig32Z<<32;
+    sigZ = x64 + (q<<3);
+    y = softfloat_shortShiftLeft128( rem.v64, rem.v0, 29 );
+    /*------------------------------------------------------------------------
+    | (Repeating this loop is a rare occurrence.)
+    *------------------------------------------------------------------------*/
+    for (;;) {
+        term = softfloat_mul64ByShifted32To128( x64 + sigZ, q );
+        rem = softfloat_sub128( y.v64, y.v0, term.v64, term.v0 );
+        if ( ! (rem.v64 & UINT64_C( 0x8000000000000000 )) ) break;
+        --q;
+        sigZ -= 1<<3;
+    }
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    q = (((rem.v64>>2) * recipSqrt32)>>32) + 2;
+    x64 = sigZ;
+    sigZ = (sigZ<<1) + (q>>25);
+    sigZExtra = (uint64_t) (q<<39);
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    if ( (q & 0xFFFFFF) <= 2 ) {
+        q &= ~(uint_fast64_t) 0xFFFF;
+        sigZExtra = (uint64_t) (q<<39);
+        term = softfloat_mul64ByShifted32To128( x64 + (q>>27), q );
+        x64 = (uint32_t) (q<<5) * (uint_fast64_t) (uint32_t) q;
+        term = softfloat_add128( term.v64, term.v0, 0, x64 );
+        rem = softfloat_shortShiftLeft128( rem.v64, rem.v0, 28 );
+        rem = softfloat_sub128( rem.v64, rem.v0, term.v64, term.v0 );
+        if ( rem.v64 & UINT64_C( 0x8000000000000000 ) ) {
+            if ( ! sigZExtra ) --sigZ;
+            --sigZExtra;
+        } else {
+            if ( rem.v64 | rem.v0 ) sigZExtra |= 1;
+        }
+    }
+    return
+        softfloat_roundPackToExtF80(
+            0, expZ, sigZ, sigZExtra, extF80_roundingPrecision );
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+ invalid:
+    softfloat_raiseFlags( softfloat_flag_invalid );
+    uiZ64 = defaultNaNExtF80UI64;
+    uiZ0  = defaultNaNExtF80UI0;
+    goto uiZ;
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+ zero:
+    uiZ64 = packToExtF80UI64( signA, 0 );
+    uiZ0  = 0;
+ uiZ:
+    uZ.s.signExp = uiZ64;
+    uZ.s.signif  = uiZ0;
+    return uZ.f;
+
+}
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/extF80_sub.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/extF80_sub.c
@@ -1,0 +1,80 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "platform.h"
+#include "internals.h"
+#include "softfloat.h"
+
+extFloat80_t extF80_sub( extFloat80_t a, extFloat80_t b )
+{
+    union { struct extFloat80M s; extFloat80_t f; } uA;
+    uint_fast16_t uiA64;
+    uint_fast64_t uiA0;
+    bool signA;
+    union { struct extFloat80M s; extFloat80_t f; } uB;
+    uint_fast16_t uiB64;
+    uint_fast64_t uiB0;
+    bool signB;
+#if ! defined INLINE_LEVEL || (INLINE_LEVEL < 2)
+    extFloat80_t
+        (*magsFuncPtr)(
+            uint_fast16_t, uint_fast64_t, uint_fast16_t, uint_fast64_t, bool );
+#endif
+
+    uA.f = a;
+    uiA64 = uA.s.signExp;
+    uiA0  = uA.s.signif;
+    signA = signExtF80UI64( uiA64 );
+    uB.f = b;
+    uiB64 = uB.s.signExp;
+    uiB0  = uB.s.signif;
+    signB = signExtF80UI64( uiB64 );
+#if defined INLINE_LEVEL && (2 <= INLINE_LEVEL)
+    if ( signA == signB ) {
+        return softfloat_subMagsExtF80( uiA64, uiA0, uiB64, uiB0, signA );
+    } else {
+        return softfloat_addMagsExtF80( uiA64, uiA0, uiB64, uiB0, signA );
+    }
+#else
+    magsFuncPtr =
+        (signA == signB) ? softfloat_subMagsExtF80 : softfloat_addMagsExtF80;
+    return (*magsFuncPtr)( uiA64, uiA0, uiB64, uiB0, signA );
+#endif
+
+}
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/extF80_to_f128.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/extF80_to_f128.c
@@ -1,0 +1,75 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "platform.h"
+#include "internals.h"
+#include "specialize.h"
+#include "softfloat.h"
+
+float128_t extF80_to_f128( extFloat80_t a )
+{
+    union { struct extFloat80M s; extFloat80_t f; } uA;
+    uint_fast16_t uiA64;
+    uint_fast64_t uiA0;
+    uint_fast16_t exp;
+    uint_fast64_t frac;
+    struct commonNaN commonNaN;
+    struct uint128 uiZ;
+    bool sign;
+    struct uint128 frac128;
+    union ui128_f128 uZ;
+
+    uA.f = a;
+    uiA64 = uA.s.signExp;
+    uiA0  = uA.s.signif;
+    exp = expExtF80UI64( uiA64 );
+    frac = uiA0 & UINT64_C( 0x7FFFFFFFFFFFFFFF );
+    if ( (exp == 0x7FFF) && frac ) {
+        softfloat_extF80UIToCommonNaN( uiA64, uiA0, &commonNaN );
+        uiZ = softfloat_commonNaNToF128UI( &commonNaN );
+    } else {
+        sign = signExtF80UI64( uiA64 );
+        frac128 = softfloat_shortShiftLeft128( 0, frac, 49 );
+        uiZ.v64 = packToF128UI64( sign, exp, frac128.v64 );
+        uiZ.v0  = frac128.v0;
+    }
+    uZ.ui = uiZ;
+    return uZ.f;
+
+}
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/extF80_to_f32.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/extF80_to_f32.c
@@ -1,0 +1,96 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
+California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "platform.h"
+#include "internals.h"
+#include "specialize.h"
+#include "softfloat.h"
+
+float32_t extF80_to_f32( extFloat80_t a )
+{
+    union { struct extFloat80M s; extFloat80_t f; } uA;
+    uint_fast16_t uiA64;
+    uint_fast64_t uiA0;
+    bool sign;
+    int_fast32_t exp;
+    uint_fast64_t sig;
+    struct commonNaN commonNaN;
+    uint_fast32_t uiZ, sig32;
+    union ui32_f32 uZ;
+
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    uA.f = a;
+    uiA64 = uA.s.signExp;
+    uiA0  = uA.s.signif;
+    sign = signExtF80UI64( uiA64 );
+    exp  = expExtF80UI64( uiA64 );
+    sig  = uiA0;
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    if ( exp == 0x7FFF ) {
+        if ( sig & UINT64_C( 0x7FFFFFFFFFFFFFFF ) ) {
+            softfloat_extF80UIToCommonNaN( uiA64, uiA0, &commonNaN );
+            uiZ = softfloat_commonNaNToF32UI( &commonNaN );
+        } else {
+            uiZ = packToF32UI( sign, 0xFF, 0 );
+        }
+        goto uiZ;
+    }
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    sig32 = softfloat_shortShiftRightJam64( sig, 33 );
+    if ( ! (exp | sig32) ) {
+        uiZ = packToF32UI( sign, 0, 0 );
+        goto uiZ;
+    }
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    exp -= 0x3F81;
+    if ( sizeof (int_fast16_t) < sizeof (int_fast32_t) ) {
+        if ( exp < -0x1000 ) exp = -0x1000;
+    }
+    return softfloat_roundPackToF32( sign, exp, sig32 );
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+ uiZ:
+    uZ.ui = uiZ;
+    return uZ.f;
+
+}
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/extF80_to_f64.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/extF80_to_f64.c
@@ -1,0 +1,96 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
+California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "platform.h"
+#include "internals.h"
+#include "specialize.h"
+#include "softfloat.h"
+
+float64_t extF80_to_f64( extFloat80_t a )
+{
+    union { struct extFloat80M s; extFloat80_t f; } uA;
+    uint_fast16_t uiA64;
+    uint_fast64_t uiA0;
+    bool sign;
+    int_fast32_t exp;
+    uint_fast64_t sig;
+    struct commonNaN commonNaN;
+    uint_fast64_t uiZ;
+    union ui64_f64 uZ;
+
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    uA.f = a;
+    uiA64 = uA.s.signExp;
+    uiA0  = uA.s.signif;
+    sign = signExtF80UI64( uiA64 );
+    exp  = expExtF80UI64( uiA64 );
+    sig  = uiA0;
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    if ( ! (exp | sig) ) {
+        uiZ = packToF64UI( sign, 0, 0 );
+        goto uiZ;
+    }
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    if ( exp == 0x7FFF ) {
+        if ( sig & UINT64_C( 0x7FFFFFFFFFFFFFFF ) ) {
+            softfloat_extF80UIToCommonNaN( uiA64, uiA0, &commonNaN );
+            uiZ = softfloat_commonNaNToF64UI( &commonNaN );
+        } else {
+            uiZ = packToF64UI( sign, 0x7FF, 0 );
+        }
+        goto uiZ;
+    }
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    sig = softfloat_shortShiftRightJam64( sig, 1 );
+    exp -= 0x3C01;
+    if ( sizeof (int_fast16_t) < sizeof (int_fast32_t) ) {
+        if ( exp < -0x1000 ) exp = -0x1000;
+    }
+    return softfloat_roundPackToF64( sign, exp, sig );
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+ uiZ:
+    uZ.ui = uiZ;
+    return uZ.f;
+
+}
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/extF80_to_i32.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/extF80_to_i32.c
@@ -1,0 +1,83 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015, 2016, 2017 The Regents of the
+University of California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "platform.h"
+#include "internals.h"
+#include "specialize.h"
+#include "softfloat.h"
+
+int_fast32_t
+ extF80_to_i32( extFloat80_t a, uint_fast8_t roundingMode, bool exact )
+{
+    union { struct extFloat80M s; extFloat80_t f; } uA;
+    uint_fast16_t uiA64;
+    bool sign;
+    int_fast32_t exp;
+    uint_fast64_t sig;
+    int_fast32_t shiftDist;
+
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    uA.f = a;
+    uiA64 = uA.s.signExp;
+    sign = signExtF80UI64( uiA64 );
+    exp  = expExtF80UI64( uiA64 );
+    sig = uA.s.signif;
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+#if (i32_fromNaN != i32_fromPosOverflow) || (i32_fromNaN != i32_fromNegOverflow)
+    if ( (exp == 0x7FFF) && (sig & UINT64_C( 0x7FFFFFFFFFFFFFFF )) ) {
+#if (i32_fromNaN == i32_fromPosOverflow)
+        sign = 0;
+#elif (i32_fromNaN == i32_fromNegOverflow)
+        sign = 1;
+#else
+        softfloat_raiseFlags( softfloat_flag_invalid );
+        return i32_fromNaN;
+#endif
+    }
+#endif
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    shiftDist = 0x4032 - exp;
+    if ( shiftDist <= 0 ) shiftDist = 1;
+    sig = softfloat_shiftRightJam64( sig, shiftDist );
+    return softfloat_roundToI32( sign, sig, roundingMode, exact );
+
+}
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/extF80_to_i64.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/extF80_to_i64.c
@@ -1,0 +1,89 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015, 2016, 2017 The Regents of the
+University of California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "platform.h"
+#include "internals.h"
+#include "specialize.h"
+#include "softfloat.h"
+
+int_fast64_t
+ extF80_to_i64( extFloat80_t a, uint_fast8_t roundingMode, bool exact )
+{
+    union { struct extFloat80M s; extFloat80_t f; } uA;
+    uint_fast16_t uiA64;
+    bool sign;
+    int_fast32_t exp;
+    uint_fast64_t sig;
+    int_fast32_t shiftDist;
+    uint_fast64_t sigExtra;
+    struct uint64_extra sig64Extra;
+
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    uA.f = a;
+    uiA64 = uA.s.signExp;
+    sign = signExtF80UI64( uiA64 );
+    exp  = expExtF80UI64( uiA64 );
+    sig = uA.s.signif;
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    shiftDist = 0x403E - exp;
+    if ( shiftDist <= 0 ) {
+        /*--------------------------------------------------------------------
+        *--------------------------------------------------------------------*/
+        if ( shiftDist ) {
+            softfloat_raiseFlags( softfloat_flag_invalid );
+            return
+                (exp == 0x7FFF) && (sig & UINT64_C( 0x7FFFFFFFFFFFFFFF ))
+                    ? i64_fromNaN
+                    : sign ? i64_fromNegOverflow : i64_fromPosOverflow;
+        }
+        /*--------------------------------------------------------------------
+        *--------------------------------------------------------------------*/
+        sigExtra = 0;
+    } else {
+        /*--------------------------------------------------------------------
+        *--------------------------------------------------------------------*/
+        sig64Extra = softfloat_shiftRightJam64Extra( sig, 0, shiftDist );
+        sig = sig64Extra.v;
+        sigExtra = sig64Extra.extra;
+    }
+    return softfloat_roundToI64( sign, sig, sigExtra, roundingMode, exact );
+
+}
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/f128_to_extF80.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/f128_to_extF80.c
@@ -1,0 +1,109 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
+California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "platform.h"
+#include "internals.h"
+#include "specialize.h"
+#include "softfloat.h"
+
+extFloat80_t f128_to_extF80( float128_t a )
+{
+    union ui128_f128 uA;
+    uint_fast64_t uiA64, uiA0;
+    bool sign;
+    int_fast32_t exp;
+    uint_fast64_t frac64, frac0;
+    struct commonNaN commonNaN;
+    struct uint128 uiZ;
+    uint_fast16_t uiZ64;
+    uint_fast64_t uiZ0;
+    struct exp32_sig128 normExpSig;
+    struct uint128 sig128;
+    union { struct extFloat80M s; extFloat80_t f; } uZ;
+
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    uA.f = a;
+    uiA64 = uA.ui.v64;
+    uiA0  = uA.ui.v0;
+    sign   = signF128UI64( uiA64 );
+    exp    = expF128UI64( uiA64 );
+    frac64 = fracF128UI64( uiA64 );
+    frac0  = uiA0;
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    if ( exp == 0x7FFF ) {
+        if ( frac64 | frac0 ) {
+            softfloat_f128UIToCommonNaN( uiA64, uiA0, &commonNaN );
+            uiZ = softfloat_commonNaNToExtF80UI( &commonNaN );
+            uiZ64 = uiZ.v64;
+            uiZ0  = uiZ.v0;
+        } else {
+            uiZ64 = packToExtF80UI64( sign, 0x7FFF );
+            uiZ0  = UINT64_C( 0x8000000000000000 );
+        }
+        goto uiZ;
+    }
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    if ( ! exp ) {
+        if ( ! (frac64 | frac0) ) {
+            uiZ64 = packToExtF80UI64( sign, 0 );
+            uiZ0  = 0;
+            goto uiZ;
+        }
+        normExpSig = softfloat_normSubnormalF128Sig( frac64, frac0 );
+        exp   = normExpSig.exp;
+        frac64 = normExpSig.sig.v64;
+        frac0  = normExpSig.sig.v0;
+    }
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    sig128 =
+        softfloat_shortShiftLeft128(
+            frac64 | UINT64_C( 0x0001000000000000 ), frac0, 15 );
+    return softfloat_roundPackToExtF80( sign, exp, sig128.v64, sig128.v0, 80 );
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+ uiZ:
+    uZ.s.signExp = uiZ64;
+    uZ.s.signif  = uiZ0;
+    return uZ.f;
+
+}
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/f32_to_extF80.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/f32_to_extF80.c
@@ -1,0 +1,101 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
+California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "platform.h"
+#include "internals.h"
+#include "specialize.h"
+#include "softfloat.h"
+
+extFloat80_t f32_to_extF80( float32_t a )
+{
+    union ui32_f32 uA;
+    uint_fast32_t uiA;
+    bool sign;
+    int_fast16_t exp;
+    uint_fast32_t frac;
+    struct commonNaN commonNaN;
+    struct uint128 uiZ;
+    uint_fast16_t uiZ64;
+    uint_fast64_t uiZ0;
+    struct exp16_sig32 normExpSig;
+    union { struct extFloat80M s; extFloat80_t f; } uZ;
+
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    uA.f = a;
+    uiA = uA.ui;
+    sign = signF32UI( uiA );
+    exp  = expF32UI( uiA );
+    frac = fracF32UI( uiA );
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    if ( exp == 0xFF ) {
+        if ( frac ) {
+            softfloat_f32UIToCommonNaN( uiA, &commonNaN );
+            uiZ = softfloat_commonNaNToExtF80UI( &commonNaN );
+            uiZ64 = uiZ.v64;
+            uiZ0  = uiZ.v0;
+        } else {
+            uiZ64 = packToExtF80UI64( sign, 0x7FFF );
+            uiZ0  = UINT64_C( 0x8000000000000000 );
+        }
+        goto uiZ;
+    }
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    if ( ! exp ) {
+        if ( ! frac ) {
+            uiZ64 = packToExtF80UI64( sign, 0 );
+            uiZ0  = 0;
+            goto uiZ;
+        }
+        normExpSig = softfloat_normSubnormalF32Sig( frac );
+        exp = normExpSig.exp;
+        frac = normExpSig.sig;
+    }
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    uiZ64 = packToExtF80UI64( sign, exp + 0x3F80 );
+    uiZ0  = (uint_fast64_t) (frac | 0x00800000)<<40;
+ uiZ:
+    uZ.s.signExp = uiZ64;
+    uZ.s.signif  = uiZ0;
+    return uZ.f;
+
+}
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/f64_to_extF80.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/f64_to_extF80.c
@@ -1,0 +1,101 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
+California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "platform.h"
+#include "internals.h"
+#include "specialize.h"
+#include "softfloat.h"
+
+extFloat80_t f64_to_extF80( float64_t a )
+{
+    union ui64_f64 uA;
+    uint_fast64_t uiA;
+    bool sign;
+    int_fast16_t exp;
+    uint_fast64_t frac;
+    struct commonNaN commonNaN;
+    struct uint128 uiZ;
+    uint_fast16_t uiZ64;
+    uint_fast64_t uiZ0;
+    struct exp16_sig64 normExpSig;
+    union { struct extFloat80M s; extFloat80_t f; } uZ;
+
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    uA.f = a;
+    uiA = uA.ui;
+    sign = signF64UI( uiA );
+    exp  = expF64UI( uiA );
+    frac = fracF64UI( uiA );
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    if ( exp == 0x7FF ) {
+        if ( frac ) {
+            softfloat_f64UIToCommonNaN( uiA, &commonNaN );
+            uiZ = softfloat_commonNaNToExtF80UI( &commonNaN );
+            uiZ64 = uiZ.v64;
+            uiZ0  = uiZ.v0;
+        } else {
+            uiZ64 = packToExtF80UI64( sign, 0x7FFF );
+            uiZ0  = UINT64_C( 0x8000000000000000 );
+        }
+        goto uiZ;
+    }
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    if ( ! exp ) {
+        if ( ! frac ) {
+            uiZ64 = packToExtF80UI64( sign, 0 );
+            uiZ0  = 0;
+            goto uiZ;
+        }
+        normExpSig = softfloat_normSubnormalF64Sig( frac );
+        exp = normExpSig.exp;
+        frac = normExpSig.sig;
+    }
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    uiZ64 = packToExtF80UI64( sign, exp + 0x3C00 );
+    uiZ0  = (frac | UINT64_C( 0x0010000000000000 ))<<11;
+ uiZ:
+    uZ.s.signExp = uiZ64;
+    uZ.s.signif  = uiZ0;
+    return uZ.f;
+
+}
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/i32_to_extF80.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/i32_to_extF80.c
@@ -1,0 +1,65 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015, 2016 The Regents of the University of
+California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "platform.h"
+#include "internals.h"
+#include "softfloat.h"
+
+extFloat80_t i32_to_extF80( int32_t a )
+{
+    uint_fast16_t uiZ64;
+    uint_fast32_t absA;
+    bool sign;
+    int_fast8_t shiftDist;
+    union { struct extFloat80M s; extFloat80_t f; } uZ;
+
+    uiZ64 = 0;
+    absA = 0;
+    if ( a ) {
+        sign = (a < 0);
+        absA = sign ? -(uint_fast32_t) a : (uint_fast32_t) a;
+        shiftDist = softfloat_countLeadingZeros32( absA );
+        uiZ64 = packToExtF80UI64( sign, 0x401E - shiftDist );
+        absA <<= shiftDist;
+    }
+    uZ.s.signExp = uiZ64;
+    uZ.s.signif = (uint_fast64_t) absA<<32;
+    return uZ.f;
+
+}
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/internals.h
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/internals.h
@@ -1,0 +1,278 @@
+
+/*============================================================================
+
+This C header file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015, 2016, 2017 The Regents of the
+University of California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#ifndef internals_h
+#define internals_h 1
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "primitives.h"
+#include "softfloat_types.h"
+
+union ui16_f16 { uint16_t ui; float16_t f; };
+union ui32_f32 { uint32_t ui; float32_t f; };
+union ui64_f64 { uint64_t ui; float64_t f; };
+
+#ifdef SOFTFLOAT_FAST_INT64
+union extF80M_extF80 { struct extFloat80M fM; extFloat80_t f; };
+union ui128_f128 { struct uint128 ui; float128_t f; };
+#endif
+
+enum {
+    softfloat_mulAdd_subC    = 1,
+    softfloat_mulAdd_subProd = 2
+};
+
+/*----------------------------------------------------------------------------
+*----------------------------------------------------------------------------*/
+uint_fast32_t softfloat_roundToUI32( bool, uint_fast64_t, uint_fast8_t, bool );
+
+#ifdef SOFTFLOAT_FAST_INT64
+uint_fast64_t
+ softfloat_roundToUI64(
+     bool, uint_fast64_t, uint_fast64_t, uint_fast8_t, bool );
+#else
+uint_fast64_t softfloat_roundMToUI64( bool, uint32_t *, uint_fast8_t, bool );
+#endif
+
+int_fast32_t softfloat_roundToI32( bool, uint_fast64_t, uint_fast8_t, bool );
+
+#ifdef SOFTFLOAT_FAST_INT64
+int_fast64_t
+ softfloat_roundToI64(
+     bool, uint_fast64_t, uint_fast64_t, uint_fast8_t, bool );
+#else
+int_fast64_t softfloat_roundMToI64( bool, uint32_t *, uint_fast8_t, bool );
+#endif
+
+/*----------------------------------------------------------------------------
+*----------------------------------------------------------------------------*/
+#define signF16UI( a ) ((bool) ((uint16_t) (a)>>15))
+#define expF16UI( a ) ((int_fast8_t) ((a)>>10) & 0x1F)
+#define fracF16UI( a ) ((a) & 0x03FF)
+#define packToF16UI( sign, exp, sig ) (((uint16_t) (sign)<<15) + ((uint16_t) (exp)<<10) + (sig))
+
+#define isNaNF16UI( a ) (((~(a) & 0x7C00) == 0) && ((a) & 0x03FF))
+
+struct exp8_sig16 { int_fast8_t exp; uint_fast16_t sig; };
+struct exp8_sig16 softfloat_normSubnormalF16Sig( uint_fast16_t );
+
+float16_t softfloat_roundPackToF16( bool, int_fast16_t, uint_fast16_t );
+float16_t softfloat_normRoundPackToF16( bool, int_fast16_t, uint_fast16_t );
+
+float16_t softfloat_addMagsF16( uint_fast16_t, uint_fast16_t );
+float16_t softfloat_subMagsF16( uint_fast16_t, uint_fast16_t );
+float16_t
+ softfloat_mulAddF16(
+     uint_fast16_t, uint_fast16_t, uint_fast16_t, uint_fast8_t );
+
+/*----------------------------------------------------------------------------
+*----------------------------------------------------------------------------*/
+#define signF32UI( a ) ((bool) ((uint32_t) (a)>>31))
+#define expF32UI( a ) ((int_fast16_t) ((a)>>23) & 0xFF)
+#define fracF32UI( a ) ((a) & 0x007FFFFF)
+#define packToF32UI( sign, exp, sig ) (((uint32_t) (sign)<<31) + ((uint32_t) (exp)<<23) + (sig))
+
+#define isNaNF32UI( a ) (((~(a) & 0x7F800000) == 0) && ((a) & 0x007FFFFF))
+
+struct exp16_sig32 { int_fast16_t exp; uint_fast32_t sig; };
+struct exp16_sig32 softfloat_normSubnormalF32Sig( uint_fast32_t );
+
+float32_t softfloat_roundPackToF32( bool, int_fast16_t, uint_fast32_t );
+float32_t softfloat_normRoundPackToF32( bool, int_fast16_t, uint_fast32_t );
+
+float32_t softfloat_addMagsF32( uint_fast32_t, uint_fast32_t );
+float32_t softfloat_subMagsF32( uint_fast32_t, uint_fast32_t );
+float32_t
+ softfloat_mulAddF32(
+     uint_fast32_t, uint_fast32_t, uint_fast32_t, uint_fast8_t );
+
+/*----------------------------------------------------------------------------
+*----------------------------------------------------------------------------*/
+#define signF64UI( a ) ((bool) ((uint64_t) (a)>>63))
+#define expF64UI( a ) ((int_fast16_t) ((a)>>52) & 0x7FF)
+#define fracF64UI( a ) ((a) & UINT64_C( 0x000FFFFFFFFFFFFF ))
+#define packToF64UI( sign, exp, sig ) ((uint64_t) (((uint_fast64_t) (sign)<<63) + ((uint_fast64_t) (exp)<<52) + (sig)))
+
+#define isNaNF64UI( a ) (((~(a) & UINT64_C( 0x7FF0000000000000 )) == 0) && ((a) & UINT64_C( 0x000FFFFFFFFFFFFF )))
+
+struct exp16_sig64 { int_fast16_t exp; uint_fast64_t sig; };
+struct exp16_sig64 softfloat_normSubnormalF64Sig( uint_fast64_t );
+
+float64_t softfloat_roundPackToF64( bool, int_fast16_t, uint_fast64_t );
+float64_t softfloat_normRoundPackToF64( bool, int_fast16_t, uint_fast64_t );
+
+float64_t softfloat_addMagsF64( uint_fast64_t, uint_fast64_t, bool );
+float64_t softfloat_subMagsF64( uint_fast64_t, uint_fast64_t, bool );
+float64_t
+ softfloat_mulAddF64(
+     uint_fast64_t, uint_fast64_t, uint_fast64_t, uint_fast8_t );
+
+/*----------------------------------------------------------------------------
+*----------------------------------------------------------------------------*/
+#define signExtF80UI64( a64 ) ((bool) ((uint16_t) (a64)>>15))
+#define expExtF80UI64( a64 ) ((a64) & 0x7FFF)
+#define packToExtF80UI64( sign, exp ) ((uint_fast16_t) (sign)<<15 | (exp))
+
+#define isNaNExtF80UI( a64, a0 ) ((((a64) & 0x7FFF) == 0x7FFF) && ((a0) & UINT64_C( 0x7FFFFFFFFFFFFFFF )))
+
+#ifdef SOFTFLOAT_FAST_INT64
+
+/*----------------------------------------------------------------------------
+*----------------------------------------------------------------------------*/
+
+struct exp32_sig64 { int_fast32_t exp; uint64_t sig; };
+struct exp32_sig64 softfloat_normSubnormalExtF80Sig( uint_fast64_t );
+
+extFloat80_t
+ softfloat_roundPackToExtF80(
+     bool, int_fast32_t, uint_fast64_t, uint_fast64_t, uint_fast8_t );
+extFloat80_t
+ softfloat_normRoundPackToExtF80(
+     bool, int_fast32_t, uint_fast64_t, uint_fast64_t, uint_fast8_t );
+
+extFloat80_t
+ softfloat_addMagsExtF80(
+     uint_fast16_t, uint_fast64_t, uint_fast16_t, uint_fast64_t, bool );
+extFloat80_t
+ softfloat_subMagsExtF80(
+     uint_fast16_t, uint_fast64_t, uint_fast16_t, uint_fast64_t, bool );
+
+/*----------------------------------------------------------------------------
+*----------------------------------------------------------------------------*/
+#define signF128UI64( a64 ) ((bool) ((uint64_t) (a64)>>63))
+#define expF128UI64( a64 ) ((int_fast32_t) ((a64)>>48) & 0x7FFF)
+#define fracF128UI64( a64 ) ((a64) & UINT64_C( 0x0000FFFFFFFFFFFF ))
+#define packToF128UI64( sign, exp, sig64 ) (((uint_fast64_t) (sign)<<63) + ((uint_fast64_t) (exp)<<48) + (sig64))
+
+#define isNaNF128UI( a64, a0 ) (((~(a64) & UINT64_C( 0x7FFF000000000000 )) == 0) && (a0 || ((a64) & UINT64_C( 0x0000FFFFFFFFFFFF ))))
+
+struct exp32_sig128 { int_fast32_t exp; struct uint128 sig; };
+struct exp32_sig128
+ softfloat_normSubnormalF128Sig( uint_fast64_t, uint_fast64_t );
+
+float128_t
+ softfloat_roundPackToF128(
+     bool, int_fast32_t, uint_fast64_t, uint_fast64_t, uint_fast64_t );
+float128_t
+ softfloat_normRoundPackToF128(
+     bool, int_fast32_t, uint_fast64_t, uint_fast64_t );
+
+float128_t
+ softfloat_addMagsF128(
+     uint_fast64_t, uint_fast64_t, uint_fast64_t, uint_fast64_t, bool );
+float128_t
+ softfloat_subMagsF128(
+     uint_fast64_t, uint_fast64_t, uint_fast64_t, uint_fast64_t, bool );
+float128_t
+ softfloat_mulAddF128(
+     uint_fast64_t,
+     uint_fast64_t,
+     uint_fast64_t,
+     uint_fast64_t,
+     uint_fast64_t,
+     uint_fast64_t,
+     uint_fast8_t
+ );
+
+#else
+
+/*----------------------------------------------------------------------------
+*----------------------------------------------------------------------------*/
+
+bool
+ softfloat_tryPropagateNaNExtF80M(
+     const struct extFloat80M *,
+     const struct extFloat80M *,
+     struct extFloat80M *
+ );
+void softfloat_invalidExtF80M( struct extFloat80M * );
+
+int softfloat_normExtF80SigM( uint64_t * );
+
+void
+ softfloat_roundPackMToExtF80M(
+     bool, int32_t, uint32_t *, uint_fast8_t, struct extFloat80M * );
+void
+ softfloat_normRoundPackMToExtF80M(
+     bool, int32_t, uint32_t *, uint_fast8_t, struct extFloat80M * );
+
+void
+ softfloat_addExtF80M(
+     const struct extFloat80M *,
+     const struct extFloat80M *,
+     struct extFloat80M *,
+     bool
+ );
+
+int
+ softfloat_compareNonnormExtF80M(
+     const struct extFloat80M *, const struct extFloat80M * );
+
+/*----------------------------------------------------------------------------
+*----------------------------------------------------------------------------*/
+#define signF128UI96( a96 ) ((bool) ((uint32_t) (a96)>>31))
+#define expF128UI96( a96 ) ((int32_t) ((a96)>>16) & 0x7FFF)
+#define fracF128UI96( a96 ) ((a96) & 0x0000FFFF)
+#define packToF128UI96( sign, exp, sig96 ) (((uint32_t) (sign)<<31) + ((uint32_t) (exp)<<16) + (sig96))
+
+bool softfloat_isNaNF128M( const uint32_t * );
+
+bool
+ softfloat_tryPropagateNaNF128M(
+     const uint32_t *, const uint32_t *, uint32_t * );
+void softfloat_invalidF128M( uint32_t * );
+
+int softfloat_shiftNormSigF128M( const uint32_t *, uint_fast8_t, uint32_t * );
+
+void softfloat_roundPackMToF128M( bool, int32_t, uint32_t *, uint32_t * );
+void softfloat_normRoundPackMToF128M( bool, int32_t, uint32_t *, uint32_t * );
+
+void
+ softfloat_addF128M( const uint32_t *, const uint32_t *, uint32_t *, bool );
+void
+ softfloat_mulAddF128M(
+     const uint32_t *,
+     const uint32_t *,
+     const uint32_t *,
+     uint32_t *,
+     uint_fast8_t
+ );
+
+#endif
+
+#endif
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/opts-GCC.h
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/opts-GCC.h
@@ -1,0 +1,114 @@
+
+/*============================================================================
+
+This C header file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2017 The Regents of the University of California.  All rights
+reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#ifndef opts_GCC_h
+#define opts_GCC_h 1
+
+#ifdef INLINE
+
+#include <stdint.h>
+#include "primitiveTypes.h"
+
+#ifdef SOFTFLOAT_BUILTIN_CLZ
+
+INLINE uint_fast8_t softfloat_countLeadingZeros16( uint16_t a )
+    { return a ? __builtin_clz( a ) - 16 : 16; }
+#define softfloat_countLeadingZeros16 softfloat_countLeadingZeros16
+
+INLINE uint_fast8_t softfloat_countLeadingZeros32( uint32_t a )
+    { return a ? __builtin_clz( a ) : 32; }
+#define softfloat_countLeadingZeros32 softfloat_countLeadingZeros32
+
+INLINE uint_fast8_t softfloat_countLeadingZeros64( uint64_t a )
+    { return a ? __builtin_clzll( a ) : 64; }
+#define softfloat_countLeadingZeros64 softfloat_countLeadingZeros64
+
+#endif
+
+#ifdef SOFTFLOAT_INTRINSIC_INT128
+
+INLINE struct uint128 softfloat_mul64ByShifted32To128( uint64_t a, uint32_t b )
+{
+    union { unsigned __int128 ui; struct uint128 s; } uZ;
+    uZ.ui = (unsigned __int128) a * ((uint_fast64_t) b<<32);
+    return uZ.s;
+}
+#define softfloat_mul64ByShifted32To128 softfloat_mul64ByShifted32To128
+
+INLINE struct uint128 softfloat_mul64To128( uint64_t a, uint64_t b )
+{
+    union { unsigned __int128 ui; struct uint128 s; } uZ;
+    uZ.ui = (unsigned __int128) a * b;
+    return uZ.s;
+}
+#define softfloat_mul64To128 softfloat_mul64To128
+
+INLINE
+struct uint128 softfloat_mul128By32( uint64_t a64, uint64_t a0, uint32_t b )
+{
+    union { unsigned __int128 ui; struct uint128 s; } uZ;
+    uZ.ui = ((unsigned __int128) a64<<64 | a0) * b;
+    return uZ.s;
+}
+#define softfloat_mul128By32 softfloat_mul128By32
+
+INLINE
+void
+ softfloat_mul128To256M(
+     uint64_t a64, uint64_t a0, uint64_t b64, uint64_t b0, uint64_t *zPtr )
+{
+    unsigned __int128 z0, mid1, mid, z128;
+    z0 = (unsigned __int128) a0 * b0;
+    mid1 = (unsigned __int128) a64 * b0;
+    mid = mid1 + (unsigned __int128) a0 * b64;
+    z128 = (unsigned __int128) a64 * b64;
+    z128 += (unsigned __int128) (mid < mid1)<<64 | mid>>64;
+    mid <<= 64;
+    z0 += mid;
+    z128 += (z0 < mid);
+    zPtr[indexWord( 4, 0 )] = z0;
+    zPtr[indexWord( 4, 1 )] = z0>>64;
+    zPtr[indexWord( 4, 2 )] = z128;
+    zPtr[indexWord( 4, 3 )] = z128>>64;
+}
+#define softfloat_mul128To256M softfloat_mul128To256M
+
+#endif
+
+#endif
+
+#endif
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/platform.h
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/platform.h
@@ -1,0 +1,47 @@
+
+/*============================================================================
+
+This C header file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015, 2016, 2017 The Regents of the
+University of California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+/*----------------------------------------------------------------------------
+*----------------------------------------------------------------------------*/
+#define LITTLEENDIAN 1
+
+/*----------------------------------------------------------------------------
+*----------------------------------------------------------------------------*/
+#define SOFTFLOAT_BUILTIN_CLZ 1
+#define SOFTFLOAT_INTRINSIC_INT128 1
+#define SOFTFLOAT_FAST_INT64 1
+#include "opts-GCC.h"
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/primitiveTypes.h
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/primitiveTypes.h
@@ -1,0 +1,85 @@
+
+/*============================================================================
+
+This C header file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#ifndef primitiveTypes_h
+#define primitiveTypes_h 1
+
+#include <stdint.h>
+
+#ifdef SOFTFLOAT_FAST_INT64
+
+#ifdef LITTLEENDIAN
+struct uint128 { uint64_t v0, v64; };
+struct uint64_extra { uint64_t extra, v; };
+struct uint128_extra { uint64_t extra; struct uint128 v; };
+#else
+struct uint128 { uint64_t v64, v0; };
+struct uint64_extra { uint64_t v, extra; };
+struct uint128_extra { struct uint128 v; uint64_t extra; };
+#endif
+
+#endif
+
+/*----------------------------------------------------------------------------
+| These macros are used to isolate the differences in word order between big-
+| endian and little-endian platforms.
+*----------------------------------------------------------------------------*/
+#ifdef LITTLEENDIAN
+#define wordIncr 1
+#define indexWord( total, n ) (n)
+#define indexWordHi( total ) ((total) - 1)
+#define indexWordLo( total ) 0
+#define indexMultiword( total, m, n ) (n)
+#define indexMultiwordHi( total, n ) ((total) - (n))
+#define indexMultiwordLo( total, n ) 0
+#define indexMultiwordHiBut( total, n ) (n)
+#define indexMultiwordLoBut( total, n ) 0
+#define INIT_UINTM4( v3, v2, v1, v0 ) { v0, v1, v2, v3 }
+#else
+#define wordIncr -1
+#define indexWord( total, n ) ((total) - 1 - (n))
+#define indexWordHi( total ) 0
+#define indexWordLo( total ) ((total) - 1)
+#define indexMultiword( total, m, n ) ((total) - 1 - (m))
+#define indexMultiwordHi( total, n ) 0
+#define indexMultiwordLo( total, n ) ((total) - (n))
+#define indexMultiwordHiBut( total, n ) 0
+#define indexMultiwordLoBut( total, n ) (n)
+#define INIT_UINTM4( v3, v2, v1, v0 ) { v3, v2, v1, v0 }
+#endif
+
+#endif
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/primitives.h
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/primitives.h
@@ -1,0 +1,1160 @@
+
+/*============================================================================
+
+This C header file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015, 2016, 2017 The Regents of the
+University of California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#ifndef primitives_h
+#define primitives_h 1
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "primitiveTypes.h"
+
+#ifndef softfloat_shortShiftRightJam64
+/*----------------------------------------------------------------------------
+| Shifts 'a' right by the number of bits given in 'dist', which must be in
+| the range 1 to 63.  If any nonzero bits are shifted off, they are "jammed"
+| into the least-significant bit of the shifted value by setting the least-
+| significant bit to 1.  This shifted-and-jammed value is returned.
+*----------------------------------------------------------------------------*/
+#if defined INLINE_LEVEL && (2 <= INLINE_LEVEL)
+INLINE
+uint64_t softfloat_shortShiftRightJam64( uint64_t a, uint_fast8_t dist )
+    { return a>>dist | ((a & (((uint_fast64_t) 1<<dist) - 1)) != 0); }
+#else
+uint64_t softfloat_shortShiftRightJam64( uint64_t a, uint_fast8_t dist );
+#endif
+#endif
+
+#ifndef softfloat_shiftRightJam32
+/*----------------------------------------------------------------------------
+| Shifts 'a' right by the number of bits given in 'dist', which must not
+| be zero.  If any nonzero bits are shifted off, they are "jammed" into the
+| least-significant bit of the shifted value by setting the least-significant
+| bit to 1.  This shifted-and-jammed value is returned.
+|   The value of 'dist' can be arbitrarily large.  In particular, if 'dist' is
+| greater than 32, the result will be either 0 or 1, depending on whether 'a'
+| is zero or nonzero.
+*----------------------------------------------------------------------------*/
+#if defined INLINE_LEVEL && (2 <= INLINE_LEVEL)
+INLINE uint32_t softfloat_shiftRightJam32( uint32_t a, uint_fast16_t dist )
+{
+    return
+        (dist < 31) ? a>>dist | ((uint32_t) (a<<(-dist & 31)) != 0) : (a != 0);
+}
+#else
+uint32_t softfloat_shiftRightJam32( uint32_t a, uint_fast16_t dist );
+#endif
+#endif
+
+#ifndef softfloat_shiftRightJam64
+/*----------------------------------------------------------------------------
+| Shifts 'a' right by the number of bits given in 'dist', which must not
+| be zero.  If any nonzero bits are shifted off, they are "jammed" into the
+| least-significant bit of the shifted value by setting the least-significant
+| bit to 1.  This shifted-and-jammed value is returned.
+|   The value of 'dist' can be arbitrarily large.  In particular, if 'dist' is
+| greater than 64, the result will be either 0 or 1, depending on whether 'a'
+| is zero or nonzero.
+*----------------------------------------------------------------------------*/
+#if defined INLINE_LEVEL && (3 <= INLINE_LEVEL)
+INLINE uint64_t softfloat_shiftRightJam64( uint64_t a, uint_fast32_t dist )
+{
+    return
+        (dist < 63) ? a>>dist | ((uint64_t) (a<<(-dist & 63)) != 0) : (a != 0);
+}
+#else
+uint64_t softfloat_shiftRightJam64( uint64_t a, uint_fast32_t dist );
+#endif
+#endif
+
+/*----------------------------------------------------------------------------
+| A constant table that translates an 8-bit unsigned integer (the array index)
+| into the number of leading 0 bits before the most-significant 1 of that
+| integer.  For integer zero (index 0), the corresponding table element is 8.
+*----------------------------------------------------------------------------*/
+extern const uint_least8_t softfloat_countLeadingZeros8[256];
+
+#ifndef softfloat_countLeadingZeros16
+/*----------------------------------------------------------------------------
+| Returns the number of leading 0 bits before the most-significant 1 bit of
+| 'a'.  If 'a' is zero, 16 is returned.
+*----------------------------------------------------------------------------*/
+#if defined INLINE_LEVEL && (2 <= INLINE_LEVEL)
+INLINE uint_fast8_t softfloat_countLeadingZeros16( uint16_t a )
+{
+    uint_fast8_t count = 8;
+    if ( 0x100 <= a ) {
+        count = 0;
+        a >>= 8;
+    }
+    count += softfloat_countLeadingZeros8[a];
+    return count;
+}
+#else
+uint_fast8_t softfloat_countLeadingZeros16( uint16_t a );
+#endif
+#endif
+
+#ifndef softfloat_countLeadingZeros32
+/*----------------------------------------------------------------------------
+| Returns the number of leading 0 bits before the most-significant 1 bit of
+| 'a'.  If 'a' is zero, 32 is returned.
+*----------------------------------------------------------------------------*/
+#if defined INLINE_LEVEL && (3 <= INLINE_LEVEL)
+INLINE uint_fast8_t softfloat_countLeadingZeros32( uint32_t a )
+{
+    uint_fast8_t count = 0;
+    if ( a < 0x10000 ) {
+        count = 16;
+        a <<= 16;
+    }
+    if ( a < 0x1000000 ) {
+        count += 8;
+        a <<= 8;
+    }
+    count += softfloat_countLeadingZeros8[a>>24];
+    return count;
+}
+#else
+uint_fast8_t softfloat_countLeadingZeros32( uint32_t a );
+#endif
+#endif
+
+#ifndef softfloat_countLeadingZeros64
+/*----------------------------------------------------------------------------
+| Returns the number of leading 0 bits before the most-significant 1 bit of
+| 'a'.  If 'a' is zero, 64 is returned.
+*----------------------------------------------------------------------------*/
+uint_fast8_t softfloat_countLeadingZeros64( uint64_t a );
+#endif
+
+extern const uint16_t softfloat_approxRecip_1k0s[16];
+extern const uint16_t softfloat_approxRecip_1k1s[16];
+
+#ifndef softfloat_approxRecip32_1
+/*----------------------------------------------------------------------------
+| Returns an approximation to the reciprocal of the number represented by 'a',
+| where 'a' is interpreted as an unsigned fixed-point number with one integer
+| bit and 31 fraction bits.  The 'a' input must be "normalized", meaning that
+| its most-significant bit (bit 31) must be 1.  Thus, if A is the value of
+| the fixed-point interpretation of 'a', then 1 <= A < 2.  The returned value
+| is interpreted as a pure unsigned fraction, having no integer bits and 32
+| fraction bits.  The approximation returned is never greater than the true
+| reciprocal 1/A, and it differs from the true reciprocal by at most 2.006 ulp
+| (units in the last place).
+*----------------------------------------------------------------------------*/
+#ifdef SOFTFLOAT_FAST_DIV64TO32
+#define softfloat_approxRecip32_1( a ) ((uint32_t) (UINT64_C( 0x7FFFFFFFFFFFFFFF ) / (uint32_t) (a)))
+#else
+uint32_t softfloat_approxRecip32_1( uint32_t a );
+#endif
+#endif
+
+extern const uint16_t softfloat_approxRecipSqrt_1k0s[16];
+extern const uint16_t softfloat_approxRecipSqrt_1k1s[16];
+
+#ifndef softfloat_approxRecipSqrt32_1
+/*----------------------------------------------------------------------------
+| Returns an approximation to the reciprocal of the square root of the number
+| represented by 'a', where 'a' is interpreted as an unsigned fixed-point
+| number either with one integer bit and 31 fraction bits or with two integer
+| bits and 30 fraction bits.  The format of 'a' is determined by 'oddExpA',
+| which must be either 0 or 1.  If 'oddExpA' is 1, 'a' is interpreted as
+| having one integer bit, and if 'oddExpA' is 0, 'a' is interpreted as having
+| two integer bits.  The 'a' input must be "normalized", meaning that its
+| most-significant bit (bit 31) must be 1.  Thus, if A is the value of the
+| fixed-point interpretation of 'a', it follows that 1 <= A < 2 when 'oddExpA'
+| is 1, and 2 <= A < 4 when 'oddExpA' is 0.
+|   The returned value is interpreted as a pure unsigned fraction, having
+| no integer bits and 32 fraction bits.  The approximation returned is never
+| greater than the true reciprocal 1/sqrt(A), and it differs from the true
+| reciprocal by at most 2.06 ulp (units in the last place).  The approximation
+| returned is also always within the range 0.5 to 1; thus, the most-
+| significant bit of the result is always set.
+*----------------------------------------------------------------------------*/
+uint32_t softfloat_approxRecipSqrt32_1( unsigned int oddExpA, uint32_t a );
+#endif
+
+#ifdef SOFTFLOAT_FAST_INT64
+
+/*----------------------------------------------------------------------------
+| The following functions are needed only when 'SOFTFLOAT_FAST_INT64' is
+| defined.
+*----------------------------------------------------------------------------*/
+
+#ifndef softfloat_eq128
+/*----------------------------------------------------------------------------
+| Returns true if the 128-bit unsigned integer formed by concatenating 'a64'
+| and 'a0' is equal to the 128-bit unsigned integer formed by concatenating
+| 'b64' and 'b0'.
+*----------------------------------------------------------------------------*/
+#if defined INLINE_LEVEL && (1 <= INLINE_LEVEL)
+INLINE
+bool softfloat_eq128( uint64_t a64, uint64_t a0, uint64_t b64, uint64_t b0 )
+    { return (a64 == b64) && (a0 == b0); }
+#else
+bool softfloat_eq128( uint64_t a64, uint64_t a0, uint64_t b64, uint64_t b0 );
+#endif
+#endif
+
+#ifndef softfloat_le128
+/*----------------------------------------------------------------------------
+| Returns true if the 128-bit unsigned integer formed by concatenating 'a64'
+| and 'a0' is less than or equal to the 128-bit unsigned integer formed by
+| concatenating 'b64' and 'b0'.
+*----------------------------------------------------------------------------*/
+#if defined INLINE_LEVEL && (2 <= INLINE_LEVEL)
+INLINE
+bool softfloat_le128( uint64_t a64, uint64_t a0, uint64_t b64, uint64_t b0 )
+    { return (a64 < b64) || ((a64 == b64) && (a0 <= b0)); }
+#else
+bool softfloat_le128( uint64_t a64, uint64_t a0, uint64_t b64, uint64_t b0 );
+#endif
+#endif
+
+#ifndef softfloat_lt128
+/*----------------------------------------------------------------------------
+| Returns true if the 128-bit unsigned integer formed by concatenating 'a64'
+| and 'a0' is less than the 128-bit unsigned integer formed by concatenating
+| 'b64' and 'b0'.
+*----------------------------------------------------------------------------*/
+#if defined INLINE_LEVEL && (2 <= INLINE_LEVEL)
+INLINE
+bool softfloat_lt128( uint64_t a64, uint64_t a0, uint64_t b64, uint64_t b0 )
+    { return (a64 < b64) || ((a64 == b64) && (a0 < b0)); }
+#else
+bool softfloat_lt128( uint64_t a64, uint64_t a0, uint64_t b64, uint64_t b0 );
+#endif
+#endif
+
+#ifndef softfloat_shortShiftLeft128
+/*----------------------------------------------------------------------------
+| Shifts the 128 bits formed by concatenating 'a64' and 'a0' left by the
+| number of bits given in 'dist', which must be in the range 1 to 63.
+*----------------------------------------------------------------------------*/
+#if defined INLINE_LEVEL && (2 <= INLINE_LEVEL)
+INLINE
+struct uint128
+ softfloat_shortShiftLeft128( uint64_t a64, uint64_t a0, uint_fast8_t dist )
+{
+    struct uint128 z;
+    z.v64 = a64<<dist | a0>>(-dist & 63);
+    z.v0 = a0<<dist;
+    return z;
+}
+#else
+struct uint128
+ softfloat_shortShiftLeft128( uint64_t a64, uint64_t a0, uint_fast8_t dist );
+#endif
+#endif
+
+#ifndef softfloat_shortShiftRight128
+/*----------------------------------------------------------------------------
+| Shifts the 128 bits formed by concatenating 'a64' and 'a0' right by the
+| number of bits given in 'dist', which must be in the range 1 to 63.
+*----------------------------------------------------------------------------*/
+#if defined INLINE_LEVEL && (2 <= INLINE_LEVEL)
+INLINE
+struct uint128
+ softfloat_shortShiftRight128( uint64_t a64, uint64_t a0, uint_fast8_t dist )
+{
+    struct uint128 z;
+    z.v64 = a64>>dist;
+    z.v0 = a64<<(-dist & 63) | a0>>dist;
+    return z;
+}
+#else
+struct uint128
+ softfloat_shortShiftRight128( uint64_t a64, uint64_t a0, uint_fast8_t dist );
+#endif
+#endif
+
+#ifndef softfloat_shortShiftRightJam64Extra
+/*----------------------------------------------------------------------------
+| This function is the same as 'softfloat_shiftRightJam64Extra' (below),
+| except that 'dist' must be in the range 1 to 63.
+*----------------------------------------------------------------------------*/
+#if defined INLINE_LEVEL && (2 <= INLINE_LEVEL)
+INLINE
+struct uint64_extra
+ softfloat_shortShiftRightJam64Extra(
+     uint64_t a, uint64_t extra, uint_fast8_t dist )
+{
+    struct uint64_extra z;
+    z.v = a>>dist;
+    z.extra = a<<(-dist & 63) | (extra != 0);
+    return z;
+}
+#else
+struct uint64_extra
+ softfloat_shortShiftRightJam64Extra(
+     uint64_t a, uint64_t extra, uint_fast8_t dist );
+#endif
+#endif
+
+#ifndef softfloat_shortShiftRightJam128
+/*----------------------------------------------------------------------------
+| Shifts the 128 bits formed by concatenating 'a64' and 'a0' right by the
+| number of bits given in 'dist', which must be in the range 1 to 63.  If any
+| nonzero bits are shifted off, they are "jammed" into the least-significant
+| bit of the shifted value by setting the least-significant bit to 1.  This
+| shifted-and-jammed value is returned.
+*----------------------------------------------------------------------------*/
+#if defined INLINE_LEVEL && (3 <= INLINE_LEVEL)
+INLINE
+struct uint128
+ softfloat_shortShiftRightJam128(
+     uint64_t a64, uint64_t a0, uint_fast8_t dist )
+{
+    uint_fast8_t negDist = -dist;
+    struct uint128 z;
+    z.v64 = a64>>dist;
+    z.v0 =
+        a64<<(negDist & 63) | a0>>dist
+            | ((uint64_t) (a0<<(negDist & 63)) != 0);
+    return z;
+}
+#else
+struct uint128
+ softfloat_shortShiftRightJam128(
+     uint64_t a64, uint64_t a0, uint_fast8_t dist );
+#endif
+#endif
+
+#ifndef softfloat_shortShiftRightJam128Extra
+/*----------------------------------------------------------------------------
+| This function is the same as 'softfloat_shiftRightJam128Extra' (below),
+| except that 'dist' must be in the range 1 to 63.
+*----------------------------------------------------------------------------*/
+#if defined INLINE_LEVEL && (3 <= INLINE_LEVEL)
+INLINE
+struct uint128_extra
+ softfloat_shortShiftRightJam128Extra(
+     uint64_t a64, uint64_t a0, uint64_t extra, uint_fast8_t dist )
+{
+    uint_fast8_t negDist = -dist;
+    struct uint128_extra z;
+    z.v.v64 = a64>>dist;
+    z.v.v0 = a64<<(negDist & 63) | a0>>dist;
+    z.extra = a0<<(negDist & 63) | (extra != 0);
+    return z;
+}
+#else
+struct uint128_extra
+ softfloat_shortShiftRightJam128Extra(
+     uint64_t a64, uint64_t a0, uint64_t extra, uint_fast8_t dist );
+#endif
+#endif
+
+#ifndef softfloat_shiftRightJam64Extra
+/*----------------------------------------------------------------------------
+| Shifts the 128 bits formed by concatenating 'a' and 'extra' right by 64
+| _plus_ the number of bits given in 'dist', which must not be zero.  This
+| shifted value is at most 64 nonzero bits and is returned in the 'v' field
+| of the 'struct uint64_extra' result.  The 64-bit 'extra' field of the result
+| contains a value formed as follows from the bits that were shifted off:  The
+| _last_ bit shifted off is the most-significant bit of the 'extra' field, and
+| the other 63 bits of the 'extra' field are all zero if and only if _all_but_
+| _the_last_ bits shifted off were all zero.
+|   (This function makes more sense if 'a' and 'extra' are considered to form
+| an unsigned fixed-point number with binary point between 'a' and 'extra'.
+| This fixed-point value is shifted right by the number of bits given in
+| 'dist', and the integer part of this shifted value is returned in the 'v'
+| field of the result.  The fractional part of the shifted value is modified
+| as described above and returned in the 'extra' field of the result.)
+*----------------------------------------------------------------------------*/
+#if defined INLINE_LEVEL && (4 <= INLINE_LEVEL)
+INLINE
+struct uint64_extra
+ softfloat_shiftRightJam64Extra(
+     uint64_t a, uint64_t extra, uint_fast32_t dist )
+{
+    struct uint64_extra z;
+    if ( dist < 64 ) {
+        z.v = a>>dist;
+        z.extra = a<<(-dist & 63);
+    } else {
+        z.v = 0;
+        z.extra = (dist == 64) ? a : (a != 0);
+    }
+    z.extra |= (extra != 0);
+    return z;
+}
+#else
+struct uint64_extra
+ softfloat_shiftRightJam64Extra(
+     uint64_t a, uint64_t extra, uint_fast32_t dist );
+#endif
+#endif
+
+#ifndef softfloat_shiftRightJam128
+/*----------------------------------------------------------------------------
+| Shifts the 128 bits formed by concatenating 'a64' and 'a0' right by the
+| number of bits given in 'dist', which must not be zero.  If any nonzero bits
+| are shifted off, they are "jammed" into the least-significant bit of the
+| shifted value by setting the least-significant bit to 1.  This shifted-and-
+| jammed value is returned.
+|   The value of 'dist' can be arbitrarily large.  In particular, if 'dist' is
+| greater than 128, the result will be either 0 or 1, depending on whether the
+| original 128 bits are all zeros.
+*----------------------------------------------------------------------------*/
+struct uint128
+ softfloat_shiftRightJam128( uint64_t a64, uint64_t a0, uint_fast32_t dist );
+#endif
+
+#ifndef softfloat_shiftRightJam128Extra
+/*----------------------------------------------------------------------------
+| Shifts the 192 bits formed by concatenating 'a64', 'a0', and 'extra' right
+| by 64 _plus_ the number of bits given in 'dist', which must not be zero.
+| This shifted value is at most 128 nonzero bits and is returned in the 'v'
+| field of the 'struct uint128_extra' result.  The 64-bit 'extra' field of the
+| result contains a value formed as follows from the bits that were shifted
+| off:  The _last_ bit shifted off is the most-significant bit of the 'extra'
+| field, and the other 63 bits of the 'extra' field are all zero if and only
+| if _all_but_the_last_ bits shifted off were all zero.
+|   (This function makes more sense if 'a64', 'a0', and 'extra' are considered
+| to form an unsigned fixed-point number with binary point between 'a0' and
+| 'extra'.  This fixed-point value is shifted right by the number of bits
+| given in 'dist', and the integer part of this shifted value is returned
+| in the 'v' field of the result.  The fractional part of the shifted value
+| is modified as described above and returned in the 'extra' field of the
+| result.)
+*----------------------------------------------------------------------------*/
+struct uint128_extra
+ softfloat_shiftRightJam128Extra(
+     uint64_t a64, uint64_t a0, uint64_t extra, uint_fast32_t dist );
+#endif
+
+#ifndef softfloat_shiftRightJam256M
+/*----------------------------------------------------------------------------
+| Shifts the 256-bit unsigned integer pointed to by 'aPtr' right by the number
+| of bits given in 'dist', which must not be zero.  If any nonzero bits are
+| shifted off, they are "jammed" into the least-significant bit of the shifted
+| value by setting the least-significant bit to 1.  This shifted-and-jammed
+| value is stored at the location pointed to by 'zPtr'.  Each of 'aPtr' and
+| 'zPtr' points to an array of four 64-bit elements that concatenate in the
+| platform's normal endian order to form a 256-bit integer.
+|   The value of 'dist' can be arbitrarily large.  In particular, if 'dist'
+| is greater than 256, the stored result will be either 0 or 1, depending on
+| whether the original 256 bits are all zeros.
+*----------------------------------------------------------------------------*/
+void
+ softfloat_shiftRightJam256M(
+     const uint64_t *aPtr, uint_fast32_t dist, uint64_t *zPtr );
+#endif
+
+#ifndef softfloat_add128
+/*----------------------------------------------------------------------------
+| Returns the sum of the 128-bit integer formed by concatenating 'a64' and
+| 'a0' and the 128-bit integer formed by concatenating 'b64' and 'b0'.  The
+| addition is modulo 2^128, so any carry out is lost.
+*----------------------------------------------------------------------------*/
+#if defined INLINE_LEVEL && (2 <= INLINE_LEVEL)
+INLINE
+struct uint128
+ softfloat_add128( uint64_t a64, uint64_t a0, uint64_t b64, uint64_t b0 )
+{
+    struct uint128 z;
+    z.v0 = a0 + b0;
+    z.v64 = a64 + b64 + (z.v0 < a0);
+    return z;
+}
+#else
+struct uint128
+ softfloat_add128( uint64_t a64, uint64_t a0, uint64_t b64, uint64_t b0 );
+#endif
+#endif
+
+#ifndef softfloat_add256M
+/*----------------------------------------------------------------------------
+| Adds the two 256-bit integers pointed to by 'aPtr' and 'bPtr'.  The addition
+| is modulo 2^256, so any carry out is lost.  The sum is stored at the
+| location pointed to by 'zPtr'.  Each of 'aPtr', 'bPtr', and 'zPtr' points to
+| an array of four 64-bit elements that concatenate in the platform's normal
+| endian order to form a 256-bit integer.
+*----------------------------------------------------------------------------*/
+void
+ softfloat_add256M(
+     const uint64_t *aPtr, const uint64_t *bPtr, uint64_t *zPtr );
+#endif
+
+#ifndef softfloat_sub128
+/*----------------------------------------------------------------------------
+| Returns the difference of the 128-bit integer formed by concatenating 'a64'
+| and 'a0' and the 128-bit integer formed by concatenating 'b64' and 'b0'.
+| The subtraction is modulo 2^128, so any borrow out (carry out) is lost.
+*----------------------------------------------------------------------------*/
+#if defined INLINE_LEVEL && (2 <= INLINE_LEVEL)
+INLINE
+struct uint128
+ softfloat_sub128( uint64_t a64, uint64_t a0, uint64_t b64, uint64_t b0 )
+{
+    struct uint128 z;
+    z.v0 = a0 - b0;
+    z.v64 = a64 - b64;
+    z.v64 -= (a0 < b0);
+    return z;
+}
+#else
+struct uint128
+ softfloat_sub128( uint64_t a64, uint64_t a0, uint64_t b64, uint64_t b0 );
+#endif
+#endif
+
+#ifndef softfloat_sub256M
+/*----------------------------------------------------------------------------
+| Subtracts the 256-bit integer pointed to by 'bPtr' from the 256-bit integer
+| pointed to by 'aPtr'.  The addition is modulo 2^256, so any borrow out
+| (carry out) is lost.  The difference is stored at the location pointed to
+| by 'zPtr'.  Each of 'aPtr', 'bPtr', and 'zPtr' points to an array of four
+| 64-bit elements that concatenate in the platform's normal endian order to
+| form a 256-bit integer.
+*----------------------------------------------------------------------------*/
+void
+ softfloat_sub256M(
+     const uint64_t *aPtr, const uint64_t *bPtr, uint64_t *zPtr );
+#endif
+
+#ifndef softfloat_mul64ByShifted32To128
+/*----------------------------------------------------------------------------
+| Returns the 128-bit product of 'a', 'b', and 2^32.
+*----------------------------------------------------------------------------*/
+#if defined INLINE_LEVEL && (3 <= INLINE_LEVEL)
+INLINE struct uint128 softfloat_mul64ByShifted32To128( uint64_t a, uint32_t b )
+{
+    uint_fast64_t mid;
+    struct uint128 z;
+    mid = (uint_fast64_t) (uint32_t) a * b;
+    z.v0 = mid<<32;
+    z.v64 = (uint_fast64_t) (uint32_t) (a>>32) * b + (mid>>32);
+    return z;
+}
+#else
+struct uint128 softfloat_mul64ByShifted32To128( uint64_t a, uint32_t b );
+#endif
+#endif
+
+#ifndef softfloat_mul64To128
+/*----------------------------------------------------------------------------
+| Returns the 128-bit product of 'a' and 'b'.
+*----------------------------------------------------------------------------*/
+struct uint128 softfloat_mul64To128( uint64_t a, uint64_t b );
+#endif
+
+#ifndef softfloat_mul128By32
+/*----------------------------------------------------------------------------
+| Returns the product of the 128-bit integer formed by concatenating 'a64' and
+| 'a0', multiplied by 'b'.  The multiplication is modulo 2^128; any overflow
+| bits are discarded.
+*----------------------------------------------------------------------------*/
+#if defined INLINE_LEVEL && (4 <= INLINE_LEVEL)
+INLINE
+struct uint128 softfloat_mul128By32( uint64_t a64, uint64_t a0, uint32_t b )
+{
+    struct uint128 z;
+    uint_fast64_t mid;
+    uint_fast32_t carry;
+    z.v0 = a0 * b;
+    mid = (uint_fast64_t) (uint32_t) (a0>>32) * b;
+    carry = (uint32_t) ((uint_fast32_t) (z.v0>>32) - (uint_fast32_t) mid);
+    z.v64 = a64 * b + (uint_fast32_t) ((mid + carry)>>32);
+    return z;
+}
+#else
+struct uint128 softfloat_mul128By32( uint64_t a64, uint64_t a0, uint32_t b );
+#endif
+#endif
+
+#ifndef softfloat_mul128To256M
+/*----------------------------------------------------------------------------
+| Multiplies the 128-bit unsigned integer formed by concatenating 'a64' and
+| 'a0' by the 128-bit unsigned integer formed by concatenating 'b64' and
+| 'b0'.  The 256-bit product is stored at the location pointed to by 'zPtr'.
+| Argument 'zPtr' points to an array of four 64-bit elements that concatenate
+| in the platform's normal endian order to form a 256-bit integer.
+*----------------------------------------------------------------------------*/
+void
+ softfloat_mul128To256M(
+     uint64_t a64, uint64_t a0, uint64_t b64, uint64_t b0, uint64_t *zPtr );
+#endif
+
+#else
+
+/*----------------------------------------------------------------------------
+| The following functions are needed only when 'SOFTFLOAT_FAST_INT64' is not
+| defined.
+*----------------------------------------------------------------------------*/
+
+#ifndef softfloat_compare96M
+/*----------------------------------------------------------------------------
+| Compares the two 96-bit unsigned integers pointed to by 'aPtr' and 'bPtr'.
+| Returns -1 if the first integer (A) is less than the second (B); returns 0
+| if the two integers are equal; and returns +1 if the first integer (A)
+| is greater than the second (B).  (The result is thus the signum of A - B.)
+| Each of 'aPtr' and 'bPtr' points to an array of three 32-bit elements that
+| concatenate in the platform's normal endian order to form a 96-bit integer.
+*----------------------------------------------------------------------------*/
+int_fast8_t softfloat_compare96M( const uint32_t *aPtr, const uint32_t *bPtr );
+#endif
+
+#ifndef softfloat_compare128M
+/*----------------------------------------------------------------------------
+| Compares the two 128-bit unsigned integers pointed to by 'aPtr' and 'bPtr'.
+| Returns -1 if the first integer (A) is less than the second (B); returns 0
+| if the two integers are equal; and returns +1 if the first integer (A)
+| is greater than the second (B).  (The result is thus the signum of A - B.)
+| Each of 'aPtr' and 'bPtr' points to an array of four 32-bit elements that
+| concatenate in the platform's normal endian order to form a 128-bit integer.
+*----------------------------------------------------------------------------*/
+int_fast8_t
+ softfloat_compare128M( const uint32_t *aPtr, const uint32_t *bPtr );
+#endif
+
+#ifndef softfloat_shortShiftLeft64To96M
+/*----------------------------------------------------------------------------
+| Extends 'a' to 96 bits and shifts the value left by the number of bits given
+| in 'dist', which must be in the range 1 to 31.  The result is stored at the
+| location pointed to by 'zPtr'.  Argument 'zPtr' points to an array of three
+| 32-bit elements that concatenate in the platform's normal endian order to
+| form a 96-bit integer.
+*----------------------------------------------------------------------------*/
+#if defined INLINE_LEVEL && (2 <= INLINE_LEVEL)
+INLINE
+void
+ softfloat_shortShiftLeft64To96M(
+     uint64_t a, uint_fast8_t dist, uint32_t *zPtr )
+{
+    zPtr[indexWord( 3, 0 )] = (uint32_t) a<<dist;
+    a >>= 32 - dist;
+    zPtr[indexWord( 3, 2 )] = a>>32;
+    zPtr[indexWord( 3, 1 )] = a;
+}
+#else
+void
+ softfloat_shortShiftLeft64To96M(
+     uint64_t a, uint_fast8_t dist, uint32_t *zPtr );
+#endif
+#endif
+
+#ifndef softfloat_shortShiftLeftM
+/*----------------------------------------------------------------------------
+| Shifts the N-bit unsigned integer pointed to by 'aPtr' left by the number
+| of bits given in 'dist', where N = 'size_words' * 32.  The value of 'dist'
+| must be in the range 1 to 31.  Any nonzero bits shifted off are lost.  The
+| shifted N-bit result is stored at the location pointed to by 'zPtr'.  Each
+| of 'aPtr' and 'zPtr' points to a 'size_words'-long array of 32-bit elements
+| that concatenate in the platform's normal endian order to form an N-bit
+| integer.
+*----------------------------------------------------------------------------*/
+void
+ softfloat_shortShiftLeftM(
+     uint_fast8_t size_words,
+     const uint32_t *aPtr,
+     uint_fast8_t dist,
+     uint32_t *zPtr
+ );
+#endif
+
+#ifndef softfloat_shortShiftLeft96M
+/*----------------------------------------------------------------------------
+| This function or macro is the same as 'softfloat_shortShiftLeftM' with
+| 'size_words' = 3 (N = 96).
+*----------------------------------------------------------------------------*/
+#define softfloat_shortShiftLeft96M( aPtr, dist, zPtr ) softfloat_shortShiftLeftM( 3, aPtr, dist, zPtr )
+#endif
+
+#ifndef softfloat_shortShiftLeft128M
+/*----------------------------------------------------------------------------
+| This function or macro is the same as 'softfloat_shortShiftLeftM' with
+| 'size_words' = 4 (N = 128).
+*----------------------------------------------------------------------------*/
+#define softfloat_shortShiftLeft128M( aPtr, dist, zPtr ) softfloat_shortShiftLeftM( 4, aPtr, dist, zPtr )
+#endif
+
+#ifndef softfloat_shortShiftLeft160M
+/*----------------------------------------------------------------------------
+| This function or macro is the same as 'softfloat_shortShiftLeftM' with
+| 'size_words' = 5 (N = 160).
+*----------------------------------------------------------------------------*/
+#define softfloat_shortShiftLeft160M( aPtr, dist, zPtr ) softfloat_shortShiftLeftM( 5, aPtr, dist, zPtr )
+#endif
+
+#ifndef softfloat_shiftLeftM
+/*----------------------------------------------------------------------------
+| Shifts the N-bit unsigned integer pointed to by 'aPtr' left by the number
+| of bits given in 'dist', where N = 'size_words' * 32.  The value of 'dist'
+| must not be zero.  Any nonzero bits shifted off are lost.  The shifted
+| N-bit result is stored at the location pointed to by 'zPtr'.  Each of 'aPtr'
+| and 'zPtr' points to a 'size_words'-long array of 32-bit elements that
+| concatenate in the platform's normal endian order to form an N-bit integer.
+|   The value of 'dist' can be arbitrarily large.  In particular, if 'dist' is
+| greater than N, the stored result will be 0.
+*----------------------------------------------------------------------------*/
+void
+ softfloat_shiftLeftM(
+     uint_fast8_t size_words,
+     const uint32_t *aPtr,
+     uint32_t dist,
+     uint32_t *zPtr
+ );
+#endif
+
+#ifndef softfloat_shiftLeft96M
+/*----------------------------------------------------------------------------
+| This function or macro is the same as 'softfloat_shiftLeftM' with
+| 'size_words' = 3 (N = 96).
+*----------------------------------------------------------------------------*/
+#define softfloat_shiftLeft96M( aPtr, dist, zPtr ) softfloat_shiftLeftM( 3, aPtr, dist, zPtr )
+#endif
+
+#ifndef softfloat_shiftLeft128M
+/*----------------------------------------------------------------------------
+| This function or macro is the same as 'softfloat_shiftLeftM' with
+| 'size_words' = 4 (N = 128).
+*----------------------------------------------------------------------------*/
+#define softfloat_shiftLeft128M( aPtr, dist, zPtr ) softfloat_shiftLeftM( 4, aPtr, dist, zPtr )
+#endif
+
+#ifndef softfloat_shiftLeft160M
+/*----------------------------------------------------------------------------
+| This function or macro is the same as 'softfloat_shiftLeftM' with
+| 'size_words' = 5 (N = 160).
+*----------------------------------------------------------------------------*/
+#define softfloat_shiftLeft160M( aPtr, dist, zPtr ) softfloat_shiftLeftM( 5, aPtr, dist, zPtr )
+#endif
+
+#ifndef softfloat_shortShiftRightM
+/*----------------------------------------------------------------------------
+| Shifts the N-bit unsigned integer pointed to by 'aPtr' right by the number
+| of bits given in 'dist', where N = 'size_words' * 32.  The value of 'dist'
+| must be in the range 1 to 31.  Any nonzero bits shifted off are lost.  The
+| shifted N-bit result is stored at the location pointed to by 'zPtr'.  Each
+| of 'aPtr' and 'zPtr' points to a 'size_words'-long array of 32-bit elements
+| that concatenate in the platform's normal endian order to form an N-bit
+| integer.
+*----------------------------------------------------------------------------*/
+void
+ softfloat_shortShiftRightM(
+     uint_fast8_t size_words,
+     const uint32_t *aPtr,
+     uint_fast8_t dist,
+     uint32_t *zPtr
+ );
+#endif
+
+#ifndef softfloat_shortShiftRight128M
+/*----------------------------------------------------------------------------
+| This function or macro is the same as 'softfloat_shortShiftRightM' with
+| 'size_words' = 4 (N = 128).
+*----------------------------------------------------------------------------*/
+#define softfloat_shortShiftRight128M( aPtr, dist, zPtr ) softfloat_shortShiftRightM( 4, aPtr, dist, zPtr )
+#endif
+
+#ifndef softfloat_shortShiftRight160M
+/*----------------------------------------------------------------------------
+| This function or macro is the same as 'softfloat_shortShiftRightM' with
+| 'size_words' = 5 (N = 160).
+*----------------------------------------------------------------------------*/
+#define softfloat_shortShiftRight160M( aPtr, dist, zPtr ) softfloat_shortShiftRightM( 5, aPtr, dist, zPtr )
+#endif
+
+#ifndef softfloat_shortShiftRightJamM
+/*----------------------------------------------------------------------------
+| Shifts the N-bit unsigned integer pointed to by 'aPtr' right by the number
+| of bits given in 'dist', where N = 'size_words' * 32.  The value of 'dist'
+| must be in the range 1 to 31.  If any nonzero bits are shifted off, they are
+| "jammed" into the least-significant bit of the shifted value by setting the
+| least-significant bit to 1.  This shifted-and-jammed N-bit result is stored
+| at the location pointed to by 'zPtr'.  Each of 'aPtr' and 'zPtr' points
+| to a 'size_words'-long array of 32-bit elements that concatenate in the
+| platform's normal endian order to form an N-bit integer.
+*----------------------------------------------------------------------------*/
+void
+ softfloat_shortShiftRightJamM(
+     uint_fast8_t, const uint32_t *, uint_fast8_t, uint32_t * );
+#endif
+
+#ifndef softfloat_shortShiftRightJam160M
+/*----------------------------------------------------------------------------
+| This function or macro is the same as 'softfloat_shortShiftRightJamM' with
+| 'size_words' = 5 (N = 160).
+*----------------------------------------------------------------------------*/
+#define softfloat_shortShiftRightJam160M( aPtr, dist, zPtr ) softfloat_shortShiftRightJamM( 5, aPtr, dist, zPtr )
+#endif
+
+#ifndef softfloat_shiftRightM
+/*----------------------------------------------------------------------------
+| Shifts the N-bit unsigned integer pointed to by 'aPtr' right by the number
+| of bits given in 'dist', where N = 'size_words' * 32.  The value of 'dist'
+| must not be zero.  Any nonzero bits shifted off are lost.  The shifted
+| N-bit result is stored at the location pointed to by 'zPtr'.  Each of 'aPtr'
+| and 'zPtr' points to a 'size_words'-long array of 32-bit elements that
+| concatenate in the platform's normal endian order to form an N-bit integer.
+|   The value of 'dist' can be arbitrarily large.  In particular, if 'dist' is
+| greater than N, the stored result will be 0.
+*----------------------------------------------------------------------------*/
+void
+ softfloat_shiftRightM(
+     uint_fast8_t size_words,
+     const uint32_t *aPtr,
+     uint32_t dist,
+     uint32_t *zPtr
+ );
+#endif
+
+#ifndef softfloat_shiftRight96M
+/*----------------------------------------------------------------------------
+| This function or macro is the same as 'softfloat_shiftRightM' with
+| 'size_words' = 3 (N = 96).
+*----------------------------------------------------------------------------*/
+#define softfloat_shiftRight96M( aPtr, dist, zPtr ) softfloat_shiftRightM( 3, aPtr, dist, zPtr )
+#endif
+
+#ifndef softfloat_shiftRightJamM
+/*----------------------------------------------------------------------------
+| Shifts the N-bit unsigned integer pointed to by 'aPtr' right by the number
+| of bits given in 'dist', where N = 'size_words' * 32.  The value of 'dist'
+| must not be zero.  If any nonzero bits are shifted off, they are "jammed"
+| into the least-significant bit of the shifted value by setting the least-
+| significant bit to 1.  This shifted-and-jammed N-bit result is stored
+| at the location pointed to by 'zPtr'.  Each of 'aPtr' and 'zPtr' points
+| to a 'size_words'-long array of 32-bit elements that concatenate in the
+| platform's normal endian order to form an N-bit integer.
+|   The value of 'dist' can be arbitrarily large.  In particular, if 'dist'
+| is greater than N, the stored result will be either 0 or 1, depending on
+| whether the original N bits are all zeros.
+*----------------------------------------------------------------------------*/
+void
+ softfloat_shiftRightJamM(
+     uint_fast8_t size_words,
+     const uint32_t *aPtr,
+     uint32_t dist,
+     uint32_t *zPtr
+ );
+#endif
+
+#ifndef softfloat_shiftRightJam96M
+/*----------------------------------------------------------------------------
+| This function or macro is the same as 'softfloat_shiftRightJamM' with
+| 'size_words' = 3 (N = 96).
+*----------------------------------------------------------------------------*/
+#define softfloat_shiftRightJam96M( aPtr, dist, zPtr ) softfloat_shiftRightJamM( 3, aPtr, dist, zPtr )
+#endif
+
+#ifndef softfloat_shiftRightJam128M
+/*----------------------------------------------------------------------------
+| This function or macro is the same as 'softfloat_shiftRightJamM' with
+| 'size_words' = 4 (N = 128).
+*----------------------------------------------------------------------------*/
+#define softfloat_shiftRightJam128M( aPtr, dist, zPtr ) softfloat_shiftRightJamM( 4, aPtr, dist, zPtr )
+#endif
+
+#ifndef softfloat_shiftRightJam160M
+/*----------------------------------------------------------------------------
+| This function or macro is the same as 'softfloat_shiftRightJamM' with
+| 'size_words' = 5 (N = 160).
+*----------------------------------------------------------------------------*/
+#define softfloat_shiftRightJam160M( aPtr, dist, zPtr ) softfloat_shiftRightJamM( 5, aPtr, dist, zPtr )
+#endif
+
+#ifndef softfloat_addM
+/*----------------------------------------------------------------------------
+| Adds the two N-bit integers pointed to by 'aPtr' and 'bPtr', where N =
+| 'size_words' * 32.  The addition is modulo 2^N, so any carry out is lost.
+| The N-bit sum is stored at the location pointed to by 'zPtr'.  Each of
+| 'aPtr', 'bPtr', and 'zPtr' points to a 'size_words'-long array of 32-bit
+| elements that concatenate in the platform's normal endian order to form an
+| N-bit integer.
+*----------------------------------------------------------------------------*/
+void
+ softfloat_addM(
+     uint_fast8_t size_words,
+     const uint32_t *aPtr,
+     const uint32_t *bPtr,
+     uint32_t *zPtr
+ );
+#endif
+
+#ifndef softfloat_add96M
+/*----------------------------------------------------------------------------
+| This function or macro is the same as 'softfloat_addM' with 'size_words'
+| = 3 (N = 96).
+*----------------------------------------------------------------------------*/
+#define softfloat_add96M( aPtr, bPtr, zPtr ) softfloat_addM( 3, aPtr, bPtr, zPtr )
+#endif
+
+#ifndef softfloat_add128M
+/*----------------------------------------------------------------------------
+| This function or macro is the same as 'softfloat_addM' with 'size_words'
+| = 4 (N = 128).
+*----------------------------------------------------------------------------*/
+#define softfloat_add128M( aPtr, bPtr, zPtr ) softfloat_addM( 4, aPtr, bPtr, zPtr )
+#endif
+
+#ifndef softfloat_add160M
+/*----------------------------------------------------------------------------
+| This function or macro is the same as 'softfloat_addM' with 'size_words'
+| = 5 (N = 160).
+*----------------------------------------------------------------------------*/
+#define softfloat_add160M( aPtr, bPtr, zPtr ) softfloat_addM( 5, aPtr, bPtr, zPtr )
+#endif
+
+#ifndef softfloat_addCarryM
+/*----------------------------------------------------------------------------
+| Adds the two N-bit unsigned integers pointed to by 'aPtr' and 'bPtr', where
+| N = 'size_words' * 32, plus 'carry', which must be either 0 or 1.  The N-bit
+| sum (modulo 2^N) is stored at the location pointed to by 'zPtr', and any
+| carry out is returned as the result.  Each of 'aPtr', 'bPtr', and 'zPtr'
+| points to a 'size_words'-long array of 32-bit elements that concatenate in
+| the platform's normal endian order to form an N-bit integer.
+*----------------------------------------------------------------------------*/
+uint_fast8_t
+ softfloat_addCarryM(
+     uint_fast8_t size_words,
+     const uint32_t *aPtr,
+     const uint32_t *bPtr,
+     uint_fast8_t carry,
+     uint32_t *zPtr
+ );
+#endif
+
+#ifndef softfloat_addComplCarryM
+/*----------------------------------------------------------------------------
+| This function or macro is the same as 'softfloat_addCarryM', except that
+| the value of the unsigned integer pointed to by 'bPtr' is bit-wise completed
+| before the addition.
+*----------------------------------------------------------------------------*/
+uint_fast8_t
+ softfloat_addComplCarryM(
+     uint_fast8_t size_words,
+     const uint32_t *aPtr,
+     const uint32_t *bPtr,
+     uint_fast8_t carry,
+     uint32_t *zPtr
+ );
+#endif
+
+#ifndef softfloat_addComplCarry96M
+/*----------------------------------------------------------------------------
+| This function or macro is the same as 'softfloat_addComplCarryM' with
+| 'size_words' = 3 (N = 96).
+*----------------------------------------------------------------------------*/
+#define softfloat_addComplCarry96M( aPtr, bPtr, carry, zPtr ) softfloat_addComplCarryM( 3, aPtr, bPtr, carry, zPtr )
+#endif
+
+#ifndef softfloat_negXM
+/*----------------------------------------------------------------------------
+| Replaces the N-bit unsigned integer pointed to by 'zPtr' by the
+| 2s-complement of itself, where N = 'size_words' * 32.  Argument 'zPtr'
+| points to a 'size_words'-long array of 32-bit elements that concatenate in
+| the platform's normal endian order to form an N-bit integer.
+*----------------------------------------------------------------------------*/
+void softfloat_negXM( uint_fast8_t size_words, uint32_t *zPtr );
+#endif
+
+#ifndef softfloat_negX96M
+/*----------------------------------------------------------------------------
+| This function or macro is the same as 'softfloat_negXM' with 'size_words'
+| = 3 (N = 96).
+*----------------------------------------------------------------------------*/
+#define softfloat_negX96M( zPtr ) softfloat_negXM( 3, zPtr )
+#endif
+
+#ifndef softfloat_negX128M
+/*----------------------------------------------------------------------------
+| This function or macro is the same as 'softfloat_negXM' with 'size_words'
+| = 4 (N = 128).
+*----------------------------------------------------------------------------*/
+#define softfloat_negX128M( zPtr ) softfloat_negXM( 4, zPtr )
+#endif
+
+#ifndef softfloat_negX160M
+/*----------------------------------------------------------------------------
+| This function or macro is the same as 'softfloat_negXM' with 'size_words'
+| = 5 (N = 160).
+*----------------------------------------------------------------------------*/
+#define softfloat_negX160M( zPtr ) softfloat_negXM( 5, zPtr )
+#endif
+
+#ifndef softfloat_negX256M
+/*----------------------------------------------------------------------------
+| This function or macro is the same as 'softfloat_negXM' with 'size_words'
+| = 8 (N = 256).
+*----------------------------------------------------------------------------*/
+#define softfloat_negX256M( zPtr ) softfloat_negXM( 8, zPtr )
+#endif
+
+#ifndef softfloat_sub1XM
+/*----------------------------------------------------------------------------
+| Subtracts 1 from the N-bit integer pointed to by 'zPtr', where N =
+| 'size_words' * 32.  The subtraction is modulo 2^N, so any borrow out (carry
+| out) is lost.  Argument 'zPtr' points to a 'size_words'-long array of 32-bit
+| elements that concatenate in the platform's normal endian order to form an
+| N-bit integer.
+*----------------------------------------------------------------------------*/
+void softfloat_sub1XM( uint_fast8_t size_words, uint32_t *zPtr );
+#endif
+
+#ifndef softfloat_sub1X96M
+/*----------------------------------------------------------------------------
+| This function or macro is the same as 'softfloat_sub1XM' with 'size_words'
+| = 3 (N = 96).
+*----------------------------------------------------------------------------*/
+#define softfloat_sub1X96M( zPtr ) softfloat_sub1XM( 3, zPtr )
+#endif
+
+#ifndef softfloat_sub1X160M
+/*----------------------------------------------------------------------------
+| This function or macro is the same as 'softfloat_sub1XM' with 'size_words'
+| = 5 (N = 160).
+*----------------------------------------------------------------------------*/
+#define softfloat_sub1X160M( zPtr ) softfloat_sub1XM( 5, zPtr )
+#endif
+
+#ifndef softfloat_subM
+/*----------------------------------------------------------------------------
+| Subtracts the two N-bit integers pointed to by 'aPtr' and 'bPtr', where N =
+| 'size_words' * 32.  The subtraction is modulo 2^N, so any borrow out (carry
+| out) is lost.  The N-bit difference is stored at the location pointed to by
+| 'zPtr'.  Each of 'aPtr', 'bPtr', and 'zPtr' points to a 'size_words'-long
+| array of 32-bit elements that concatenate in the platform's normal endian
+| order to form an N-bit integer.
+*----------------------------------------------------------------------------*/
+void
+ softfloat_subM(
+     uint_fast8_t size_words,
+     const uint32_t *aPtr,
+     const uint32_t *bPtr,
+     uint32_t *zPtr
+ );
+#endif
+
+#ifndef softfloat_sub96M
+/*----------------------------------------------------------------------------
+| This function or macro is the same as 'softfloat_subM' with 'size_words'
+| = 3 (N = 96).
+*----------------------------------------------------------------------------*/
+#define softfloat_sub96M( aPtr, bPtr, zPtr ) softfloat_subM( 3, aPtr, bPtr, zPtr )
+#endif
+
+#ifndef softfloat_sub128M
+/*----------------------------------------------------------------------------
+| This function or macro is the same as 'softfloat_subM' with 'size_words'
+| = 4 (N = 128).
+*----------------------------------------------------------------------------*/
+#define softfloat_sub128M( aPtr, bPtr, zPtr ) softfloat_subM( 4, aPtr, bPtr, zPtr )
+#endif
+
+#ifndef softfloat_sub160M
+/*----------------------------------------------------------------------------
+| This function or macro is the same as 'softfloat_subM' with 'size_words'
+| = 5 (N = 160).
+*----------------------------------------------------------------------------*/
+#define softfloat_sub160M( aPtr, bPtr, zPtr ) softfloat_subM( 5, aPtr, bPtr, zPtr )
+#endif
+
+#ifndef softfloat_mul64To128M
+/*----------------------------------------------------------------------------
+| Multiplies 'a' and 'b' and stores the 128-bit product at the location
+| pointed to by 'zPtr'.  Argument 'zPtr' points to an array of four 32-bit
+| elements that concatenate in the platform's normal endian order to form a
+| 128-bit integer.
+*----------------------------------------------------------------------------*/
+void softfloat_mul64To128M( uint64_t a, uint64_t b, uint32_t *zPtr );
+#endif
+
+#ifndef softfloat_mul128MTo256M
+/*----------------------------------------------------------------------------
+| Multiplies the two 128-bit unsigned integers pointed to by 'aPtr' and
+| 'bPtr', and stores the 256-bit product at the location pointed to by 'zPtr'.
+| Each of 'aPtr' and 'bPtr' points to an array of four 32-bit elements that
+| concatenate in the platform's normal endian order to form a 128-bit integer.
+| Argument 'zPtr' points to an array of eight 32-bit elements that concatenate
+| to form a 256-bit integer.
+*----------------------------------------------------------------------------*/
+void
+ softfloat_mul128MTo256M(
+     const uint32_t *aPtr, const uint32_t *bPtr, uint32_t *zPtr );
+#endif
+
+#ifndef softfloat_remStepMBy32
+/*----------------------------------------------------------------------------
+| Performs a "remainder reduction step" as follows:  Arguments 'remPtr' and
+| 'bPtr' both point to N-bit unsigned integers, where N = 'size_words' * 32.
+| Defining R and B as the values of those integers, the expression (R<<'dist')
+| - B * q is computed modulo 2^N, and the N-bit result is stored at the
+| location pointed to by 'zPtr'.  Each of 'remPtr', 'bPtr', and 'zPtr' points
+| to a 'size_words'-long array of 32-bit elements that concatenate in the
+| platform's normal endian order to form an N-bit integer.
+*----------------------------------------------------------------------------*/
+void
+ softfloat_remStepMBy32(
+     uint_fast8_t size_words,
+     const uint32_t *remPtr,
+     uint_fast8_t dist,
+     const uint32_t *bPtr,
+     uint32_t q,
+     uint32_t *zPtr
+ );
+#endif
+
+#ifndef softfloat_remStep96MBy32
+/*----------------------------------------------------------------------------
+| This function or macro is the same as 'softfloat_remStepMBy32' with
+| 'size_words' = 3 (N = 96).
+*----------------------------------------------------------------------------*/
+#define softfloat_remStep96MBy32( remPtr, dist, bPtr, q, zPtr ) softfloat_remStepMBy32( 3, remPtr, dist, bPtr, q, zPtr )
+#endif
+
+#ifndef softfloat_remStep128MBy32
+/*----------------------------------------------------------------------------
+| This function or macro is the same as 'softfloat_remStepMBy32' with
+| 'size_words' = 4 (N = 128).
+*----------------------------------------------------------------------------*/
+#define softfloat_remStep128MBy32( remPtr, dist, bPtr, q, zPtr ) softfloat_remStepMBy32( 4, remPtr, dist, bPtr, q, zPtr )
+#endif
+
+#ifndef softfloat_remStep160MBy32
+/*----------------------------------------------------------------------------
+| This function or macro is the same as 'softfloat_remStepMBy32' with
+| 'size_words' = 5 (N = 160).
+*----------------------------------------------------------------------------*/
+#define softfloat_remStep160MBy32( remPtr, dist, bPtr, q, zPtr ) softfloat_remStepMBy32( 5, remPtr, dist, bPtr, q, zPtr )
+#endif
+
+#endif
+
+#endif
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/s_add128.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/s_add128.c
@@ -1,0 +1,55 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
+California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdint.h>
+#include "platform.h"
+#include "primitiveTypes.h"
+
+#ifndef softfloat_add128
+
+struct uint128
+ softfloat_add128( uint64_t a64, uint64_t a0, uint64_t b64, uint64_t b0 )
+{
+    struct uint128 z;
+
+    z.v0 = a0 + b0;
+    z.v64 = a64 + b64 + (z.v0 < a0);
+    return z;
+
+}
+
+#endif
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/s_addMagsExtF80.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/s_addMagsExtF80.c
@@ -1,0 +1,156 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "platform.h"
+#include "internals.h"
+#include "specialize.h"
+#include "softfloat.h"
+
+extFloat80_t
+ softfloat_addMagsExtF80(
+     uint_fast16_t uiA64,
+     uint_fast64_t uiA0,
+     uint_fast16_t uiB64,
+     uint_fast64_t uiB0,
+     bool signZ
+ )
+{
+    int_fast32_t expA;
+    uint_fast64_t sigA;
+    int_fast32_t expB;
+    uint_fast64_t sigB;
+    int_fast32_t expDiff;
+    uint_fast16_t uiZ64;
+    uint_fast64_t uiZ0, sigZ, sigZExtra;
+    struct exp32_sig64 normExpSig;
+    int_fast32_t expZ;
+    struct uint64_extra sig64Extra;
+    struct uint128 uiZ;
+    union { struct extFloat80M s; extFloat80_t f; } uZ;
+
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    expA = expExtF80UI64( uiA64 );
+    sigA = uiA0;
+    expB = expExtF80UI64( uiB64 );
+    sigB = uiB0;
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    expDiff = expA - expB;
+    if ( ! expDiff ) {
+        if ( expA == 0x7FFF ) {
+            if ( (sigA | sigB) & UINT64_C( 0x7FFFFFFFFFFFFFFF ) ) {
+                goto propagateNaN;
+            }
+            uiZ64 = uiA64;
+            uiZ0  = uiA0;
+            goto uiZ;
+        }
+        sigZ = sigA + sigB;
+        sigZExtra = 0;
+        if ( ! expA ) {
+            normExpSig = softfloat_normSubnormalExtF80Sig( sigZ );
+            expZ = normExpSig.exp + 1;
+            sigZ = normExpSig.sig;
+            goto roundAndPack;
+        }
+        expZ = expA;
+        goto shiftRight1;
+    }
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    if ( expDiff < 0 ) {
+        if ( expB == 0x7FFF ) {
+            if ( sigB & UINT64_C( 0x7FFFFFFFFFFFFFFF ) ) goto propagateNaN;
+            uiZ64 = packToExtF80UI64( signZ, 0x7FFF );
+            uiZ0  = uiB0;
+            goto uiZ;
+        }
+        expZ = expB;
+        if ( ! expA ) {
+            ++expDiff;
+            sigZExtra = 0;
+            if ( ! expDiff ) goto newlyAligned;
+        }
+        sig64Extra = softfloat_shiftRightJam64Extra( sigA, 0, -expDiff );
+        sigA = sig64Extra.v;
+        sigZExtra = sig64Extra.extra;
+    } else {
+        if ( expA == 0x7FFF ) {
+            if ( sigA & UINT64_C( 0x7FFFFFFFFFFFFFFF ) ) goto propagateNaN;
+            uiZ64 = uiA64;
+            uiZ0  = uiA0;
+            goto uiZ;
+        }
+        expZ = expA;
+        if ( ! expB ) {
+            --expDiff;
+            sigZExtra = 0;
+            if ( ! expDiff ) goto newlyAligned;
+        }
+        sig64Extra = softfloat_shiftRightJam64Extra( sigB, 0, expDiff );
+        sigB = sig64Extra.v;
+        sigZExtra = sig64Extra.extra;
+    }
+ newlyAligned:
+    sigZ = sigA + sigB;
+    if ( sigZ & UINT64_C( 0x8000000000000000 ) ) goto roundAndPack;
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+ shiftRight1:
+    sig64Extra = softfloat_shortShiftRightJam64Extra( sigZ, sigZExtra, 1 );
+    sigZ = sig64Extra.v | UINT64_C( 0x8000000000000000 );
+    sigZExtra = sig64Extra.extra;
+    ++expZ;
+ roundAndPack:
+    return
+        softfloat_roundPackToExtF80(
+            signZ, expZ, sigZ, sigZExtra, extF80_roundingPrecision );
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+ propagateNaN:
+    uiZ = softfloat_propagateNaNExtF80UI( uiA64, uiA0, uiB64, uiB0 );
+    uiZ64 = uiZ.v64;
+    uiZ0  = uiZ.v0;
+ uiZ:
+    uZ.s.signExp = uiZ64;
+    uZ.s.signif  = uiZ0;
+    return uZ.f;
+
+}
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/s_approxRecip32_1.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/s_approxRecip32_1.c
@@ -1,0 +1,66 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015, 2016 The Regents of the University of
+California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdint.h>
+#include "platform.h"
+
+#ifndef softfloat_approxRecip32_1
+
+extern const uint16_t softfloat_approxRecip_1k0s[16];
+extern const uint16_t softfloat_approxRecip_1k1s[16];
+
+uint32_t softfloat_approxRecip32_1( uint32_t a )
+{
+    int index;
+    uint16_t eps, r0;
+    uint32_t sigma0;
+    uint_fast32_t r;
+    uint32_t sqrSigma0;
+
+    index = a>>27 & 0xF;
+    eps = (uint16_t) (a>>11);
+    r0 = softfloat_approxRecip_1k0s[index]
+             - ((softfloat_approxRecip_1k1s[index] * (uint_fast32_t) eps)>>20);
+    sigma0 = ~(uint_fast32_t) ((r0 * (uint_fast64_t) a)>>7);
+    r = ((uint_fast32_t) r0<<16) + ((r0 * (uint_fast64_t) sigma0)>>24);
+    sqrSigma0 = ((uint_fast64_t) sigma0 * sigma0)>>32;
+    r += ((uint32_t) r * (uint_fast64_t) sqrSigma0)>>48;
+    return r;
+
+}
+
+#endif
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/s_approxRecipSqrt32_1.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/s_approxRecipSqrt32_1.c
@@ -1,0 +1,73 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015, 2016 The Regents of the University of
+California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdint.h>
+#include "platform.h"
+
+#ifndef softfloat_approxRecipSqrt32_1
+
+extern const uint16_t softfloat_approxRecipSqrt_1k0s[];
+extern const uint16_t softfloat_approxRecipSqrt_1k1s[];
+
+uint32_t softfloat_approxRecipSqrt32_1( unsigned int oddExpA, uint32_t a )
+{
+    int index;
+    uint16_t eps, r0;
+    uint_fast32_t ESqrR0;
+    uint32_t sigma0;
+    uint_fast32_t r;
+    uint32_t sqrSigma0;
+
+    index = (a>>27 & 0xE) + oddExpA;
+    eps = (uint16_t) (a>>12);
+    r0 = softfloat_approxRecipSqrt_1k0s[index]
+             - ((softfloat_approxRecipSqrt_1k1s[index] * (uint_fast32_t) eps)
+                    >>20);
+    ESqrR0 = (uint_fast32_t) r0 * r0;
+    if ( ! oddExpA ) ESqrR0 <<= 1;
+    sigma0 = ~(uint_fast32_t) (((uint32_t) ESqrR0 * (uint_fast64_t) a)>>23);
+    r = ((uint_fast32_t) r0<<16) + ((r0 * (uint_fast64_t) sigma0)>>25);
+    sqrSigma0 = ((uint_fast64_t) sigma0 * sigma0)>>32;
+    r += ((uint32_t) ((r>>1) + (r>>3) - ((uint_fast32_t) r0<<14))
+              * (uint_fast64_t) sqrSigma0)
+             >>48;
+    if ( ! (r & 0x80000000) ) r = 0x80000000;
+    return r;
+
+}
+
+#endif
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/s_approxRecipSqrt_1Ks.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/s_approxRecipSqrt_1Ks.c
@@ -1,0 +1,49 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015, 2016 The Regents of the University of
+California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdint.h>
+#include "platform.h"
+#include "primitives.h"
+
+const uint16_t softfloat_approxRecipSqrt_1k0s[16] = {
+    0xB4C9, 0xFFAB, 0xAA7D, 0xF11C, 0xA1C5, 0xE4C7, 0x9A43, 0xDA29,
+    0x93B5, 0xD0E5, 0x8DED, 0xC8B7, 0x88C6, 0xC16D, 0x8424, 0xBAE1
+};
+const uint16_t softfloat_approxRecipSqrt_1k1s[16] = {
+    0xA5A5, 0xEA42, 0x8C21, 0xC62D, 0x788F, 0xAA7F, 0x6928, 0x94B6,
+    0x5CC7, 0x8335, 0x52A6, 0x74E2, 0x4A3E, 0x68FE, 0x432B, 0x5EFD
+};
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/s_approxRecip_1Ks.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/s_approxRecip_1Ks.c
@@ -1,0 +1,49 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015, 2016 The Regents of the University of
+California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdint.h>
+#include "platform.h"
+#include "primitives.h"
+
+const uint16_t softfloat_approxRecip_1k0s[16] = {
+    0xFFC4, 0xF0BE, 0xE363, 0xD76F, 0xCCAD, 0xC2F0, 0xBA16, 0xB201,
+    0xAA97, 0xA3C6, 0x9D7A, 0x97A6, 0x923C, 0x8D32, 0x887E, 0x8417
+};
+const uint16_t softfloat_approxRecip_1k1s[16] = {
+    0xF0F1, 0xD62C, 0xBFA1, 0xAC77, 0x9C0A, 0x8DDB, 0x8185, 0x76BA,
+    0x6D3B, 0x64D4, 0x5D5C, 0x56B1, 0x50B6, 0x4B55, 0x4679, 0x4211
+};
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/s_commonNaNToExtF80UI.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/s_commonNaNToExtF80UI.c
@@ -1,0 +1,56 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdint.h>
+#include "platform.h"
+#include "primitives.h"
+#include "specialize.h"
+
+/*----------------------------------------------------------------------------
+| Converts the common NaN pointed to by `aPtr' into an 80-bit extended
+| floating-point NaN, and returns the bit pattern of this value as an unsigned
+| integer.
+*----------------------------------------------------------------------------*/
+struct uint128 softfloat_commonNaNToExtF80UI( const struct commonNaN *aPtr )
+{
+    struct uint128 uiZ;
+
+    uiZ.v64 = (uint_fast16_t) aPtr->sign<<15 | 0x7FFF;
+    uiZ.v0 = UINT64_C( 0xC000000000000000 ) | aPtr->v64>>1;
+    return uiZ;
+
+}
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/s_commonNaNToF128UI.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/s_commonNaNToF128UI.c
@@ -1,0 +1,55 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdint.h>
+#include "platform.h"
+#include "primitives.h"
+#include "specialize.h"
+
+/*----------------------------------------------------------------------------
+| Converts the common NaN pointed to by `aPtr' into a 128-bit floating-point
+| NaN, and returns the bit pattern of this value as an unsigned integer.
+*----------------------------------------------------------------------------*/
+struct uint128 softfloat_commonNaNToF128UI( const struct commonNaN *aPtr )
+{
+    struct uint128 uiZ;
+
+    uiZ = softfloat_shortShiftRight128( aPtr->v64, aPtr->v0, 16 );
+    uiZ.v64 |= (uint_fast64_t) aPtr->sign<<63 | UINT64_C( 0x7FFF800000000000 );
+    return uiZ;
+
+}
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/s_commonNaNToF32UI.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/s_commonNaNToF32UI.c
@@ -1,0 +1,51 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdint.h>
+#include "platform.h"
+#include "specialize.h"
+
+/*----------------------------------------------------------------------------
+| Converts the common NaN pointed to by `aPtr' into a 32-bit floating-point
+| NaN, and returns the bit pattern of this value as an unsigned integer.
+*----------------------------------------------------------------------------*/
+uint_fast32_t softfloat_commonNaNToF32UI( const struct commonNaN *aPtr )
+{
+
+    return (uint_fast32_t) aPtr->sign<<31 | 0x7FC00000 | aPtr->v64>>41;
+
+}
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/s_commonNaNToF64UI.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/s_commonNaNToF64UI.c
@@ -1,0 +1,53 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdint.h>
+#include "platform.h"
+#include "specialize.h"
+
+/*----------------------------------------------------------------------------
+| Converts the common NaN pointed to by `aPtr' into a 64-bit floating-point
+| NaN, and returns the bit pattern of this value as an unsigned integer.
+*----------------------------------------------------------------------------*/
+uint_fast64_t softfloat_commonNaNToF64UI( const struct commonNaN *aPtr )
+{
+
+    return
+        (uint_fast64_t) aPtr->sign<<63 | UINT64_C( 0x7FF8000000000000 )
+            | aPtr->v64>>12;
+
+}
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/s_countLeadingZeros32.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/s_countLeadingZeros32.c
@@ -1,0 +1,64 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
+California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdint.h>
+#include "platform.h"
+
+#ifndef softfloat_countLeadingZeros32
+
+#define softfloat_countLeadingZeros32 softfloat_countLeadingZeros32
+#include "primitives.h"
+
+uint_fast8_t softfloat_countLeadingZeros32( uint32_t a )
+{
+    uint_fast8_t count;
+
+    count = 0;
+    if ( a < 0x10000 ) {
+        count = 16;
+        a <<= 16;
+    }
+    if ( a < 0x1000000 ) {
+        count += 8;
+        a <<= 8;
+    }
+    count += softfloat_countLeadingZeros8[a>>24];
+    return count;
+
+}
+
+#endif
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/s_countLeadingZeros64.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/s_countLeadingZeros64.c
@@ -1,0 +1,73 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
+California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdint.h>
+#include "platform.h"
+
+#ifndef softfloat_countLeadingZeros64
+
+#define softfloat_countLeadingZeros64 softfloat_countLeadingZeros64
+#include "primitives.h"
+
+uint_fast8_t softfloat_countLeadingZeros64( uint64_t a )
+{
+    uint_fast8_t count;
+    uint32_t a32;
+
+    count = 0;
+    a32 = a>>32;
+    if ( ! a32 ) {
+        count = 32;
+        a32 = a;
+    }
+    /*------------------------------------------------------------------------
+    | From here, result is current count + count leading zeros of `a32'.
+    *------------------------------------------------------------------------*/
+    if ( a32 < 0x10000 ) {
+        count += 16;
+        a32 <<= 16;
+    }
+    if ( a32 < 0x1000000 ) {
+        count += 8;
+        a32 <<= 8;
+    }
+    count += softfloat_countLeadingZeros8[a32>>24];
+    return count;
+
+}
+
+#endif
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/s_countLeadingZeros8.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/s_countLeadingZeros8.c
@@ -1,0 +1,59 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdint.h>
+#include "platform.h"
+#include "primitives.h"
+
+const uint_least8_t softfloat_countLeadingZeros8[256] = {
+    8, 7, 6, 6, 5, 5, 5, 5, 4, 4, 4, 4, 4, 4, 4, 4,
+    3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+    2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+};
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/s_extF80UIToCommonNaN.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/s_extF80UIToCommonNaN.c
@@ -1,0 +1,62 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdint.h>
+#include "platform.h"
+#include "specialize.h"
+#include "softfloat.h"
+
+/*----------------------------------------------------------------------------
+| Assuming the unsigned integer formed from concatenating `uiA64' and `uiA0'
+| has the bit pattern of an 80-bit extended floating-point NaN, converts
+| this NaN to the common NaN form, and stores the resulting common NaN at the
+| location pointed to by `zPtr'.  If the NaN is a signaling NaN, the invalid
+| exception is raised.
+*----------------------------------------------------------------------------*/
+void
+ softfloat_extF80UIToCommonNaN(
+     uint_fast16_t uiA64, uint_fast64_t uiA0, struct commonNaN *zPtr )
+{
+
+    if ( softfloat_isSigNaNExtF80UI( uiA64, uiA0 ) ) {
+        softfloat_raiseFlags( softfloat_flag_invalid );
+    }
+    zPtr->sign = uiA64>>15;
+    zPtr->v64  = uiA0<<1;
+    zPtr->v0   = 0;
+
+}
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/s_f128UIToCommonNaN.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/s_f128UIToCommonNaN.c
@@ -1,0 +1,65 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdint.h>
+#include "platform.h"
+#include "primitives.h"
+#include "specialize.h"
+#include "softfloat.h"
+
+/*----------------------------------------------------------------------------
+| Assuming the unsigned integer formed from concatenating `uiA64' and `uiA0'
+| has the bit pattern of a 128-bit floating-point NaN, converts this NaN to
+| the common NaN form, and stores the resulting common NaN at the location
+| pointed to by `zPtr'.  If the NaN is a signaling NaN, the invalid exception
+| is raised.
+*----------------------------------------------------------------------------*/
+void
+ softfloat_f128UIToCommonNaN(
+     uint_fast64_t uiA64, uint_fast64_t uiA0, struct commonNaN *zPtr )
+{
+    struct uint128 NaNSig;
+
+    if ( softfloat_isSigNaNF128UI( uiA64, uiA0 ) ) {
+        softfloat_raiseFlags( softfloat_flag_invalid );
+    }
+    NaNSig = softfloat_shortShiftLeft128( uiA64, uiA0, 16 );
+    zPtr->sign = uiA64>>63;
+    zPtr->v64  = NaNSig.v64;
+    zPtr->v0   = NaNSig.v0;
+
+}
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/s_f32UIToCommonNaN.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/s_f32UIToCommonNaN.c
@@ -1,0 +1,59 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdint.h>
+#include "platform.h"
+#include "specialize.h"
+#include "softfloat.h"
+
+/*----------------------------------------------------------------------------
+| Assuming `uiA' has the bit pattern of a 32-bit floating-point NaN, converts
+| this NaN to the common NaN form, and stores the resulting common NaN at the
+| location pointed to by `zPtr'.  If the NaN is a signaling NaN, the invalid
+| exception is raised.
+*----------------------------------------------------------------------------*/
+void softfloat_f32UIToCommonNaN( uint_fast32_t uiA, struct commonNaN *zPtr )
+{
+
+    if ( softfloat_isSigNaNF32UI( uiA ) ) {
+        softfloat_raiseFlags( softfloat_flag_invalid );
+    }
+    zPtr->sign = uiA>>31;
+    zPtr->v64  = (uint_fast64_t) uiA<<41;
+    zPtr->v0   = 0;
+
+}
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/s_f64UIToCommonNaN.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/s_f64UIToCommonNaN.c
@@ -1,0 +1,59 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdint.h>
+#include "platform.h"
+#include "specialize.h"
+#include "softfloat.h"
+
+/*----------------------------------------------------------------------------
+| Assuming `uiA' has the bit pattern of a 64-bit floating-point NaN, converts
+| this NaN to the common NaN form, and stores the resulting common NaN at the
+| location pointed to by `zPtr'.  If the NaN is a signaling NaN, the invalid
+| exception is raised.
+*----------------------------------------------------------------------------*/
+void softfloat_f64UIToCommonNaN( uint_fast64_t uiA, struct commonNaN *zPtr )
+{
+
+    if ( softfloat_isSigNaNF64UI( uiA ) ) {
+        softfloat_raiseFlags( softfloat_flag_invalid );
+    }
+    zPtr->sign = uiA>>63;
+    zPtr->v64  = uiA<<12;
+    zPtr->v0   = 0;
+
+}
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/s_le128.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/s_le128.c
@@ -1,0 +1,51 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
+California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "platform.h"
+
+#ifndef softfloat_le128
+
+bool softfloat_le128( uint64_t a64, uint64_t a0, uint64_t b64, uint64_t b0 )
+{
+
+    return (a64 < b64) || ((a64 == b64) && (a0 <= b0));
+
+}
+
+#endif
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/s_lt128.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/s_lt128.c
@@ -1,0 +1,51 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
+California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "platform.h"
+
+#ifndef softfloat_lt128
+
+bool softfloat_lt128( uint64_t a64, uint64_t a0, uint64_t b64, uint64_t b0 )
+{
+
+    return (a64 < b64) || ((a64 == b64) && (a0 < b0));
+
+}
+
+#endif
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/s_mul64ByShifted32To128.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/s_mul64ByShifted32To128.c
@@ -1,0 +1,56 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
+California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdint.h>
+#include "platform.h"
+#include "primitiveTypes.h"
+
+#ifndef softfloat_mul64ByShifted32To128
+
+struct uint128 softfloat_mul64ByShifted32To128( uint64_t a, uint32_t b )
+{
+    uint_fast64_t mid;
+    struct uint128 z;
+
+    mid = (uint_fast64_t) (uint32_t) a * b;
+    z.v0 = mid<<32;
+    z.v64 = (uint_fast64_t) (uint32_t) (a>>32) * b + (mid>>32);
+    return z;
+
+}
+
+#endif
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/s_mul64To128.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/s_mul64To128.c
@@ -1,0 +1,66 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
+California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdint.h>
+#include "platform.h"
+#include "primitiveTypes.h"
+
+#ifndef softfloat_mul64To128
+
+struct uint128 softfloat_mul64To128( uint64_t a, uint64_t b )
+{
+    uint32_t a32, a0, b32, b0;
+    struct uint128 z;
+    uint64_t mid1, mid;
+
+    a32 = a>>32;
+    a0 = a;
+    b32 = b>>32;
+    b0 = b;
+    z.v0 = (uint_fast64_t) a0 * b0;
+    mid1 = (uint_fast64_t) a32 * b0;
+    mid = mid1 + (uint_fast64_t) a0 * b32;
+    z.v64 = (uint_fast64_t) a32 * b32;
+    z.v64 += (uint_fast64_t) (mid < mid1)<<32 | mid>>32;
+    mid <<= 32;
+    z.v0 += mid;
+    z.v64 += (z.v0 < mid);
+    return z;
+
+}
+
+#endif
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/s_normRoundPackToExtF80.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/s_normRoundPackToExtF80.c
@@ -1,0 +1,71 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015, 2016 The Regents of the University of
+California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "platform.h"
+#include "internals.h"
+
+extFloat80_t
+ softfloat_normRoundPackToExtF80(
+     bool sign,
+     int_fast32_t exp,
+     uint_fast64_t sig,
+     uint_fast64_t sigExtra,
+     uint_fast8_t roundingPrecision
+ )
+{
+    int_fast8_t shiftDist;
+    struct uint128 sig128;
+
+    if ( ! sig ) {
+        exp -= 64;
+        sig = sigExtra;
+        sigExtra = 0;
+    }
+    shiftDist = softfloat_countLeadingZeros64( sig );
+    exp -= shiftDist;
+    if ( shiftDist ) {
+        sig128 = softfloat_shortShiftLeft128( sig, sigExtra, shiftDist );
+        sig = sig128.v64;
+        sigExtra = sig128.v0;
+    }
+    return
+        softfloat_roundPackToExtF80(
+            sign, exp, sig, sigExtra, roundingPrecision );
+
+}
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/s_normSubnormalExtF80Sig.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/s_normSubnormalExtF80Sig.c
@@ -1,0 +1,52 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015, 2016 The Regents of the University of
+California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdint.h>
+#include "platform.h"
+#include "internals.h"
+
+struct exp32_sig64 softfloat_normSubnormalExtF80Sig( uint_fast64_t sig )
+{
+    int_fast8_t shiftDist;
+    struct exp32_sig64 z;
+
+    shiftDist = softfloat_countLeadingZeros64( sig );
+    z.exp = -shiftDist;
+    z.sig = sig<<shiftDist;
+    return z;
+
+}
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/s_normSubnormalF128Sig.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/s_normSubnormalF128Sig.c
@@ -1,0 +1,65 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015, 2016 The Regents of the University of
+California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdint.h>
+#include "platform.h"
+#include "internals.h"
+
+struct exp32_sig128
+ softfloat_normSubnormalF128Sig( uint_fast64_t sig64, uint_fast64_t sig0 )
+{
+    int_fast8_t shiftDist;
+    struct exp32_sig128 z;
+
+    if ( ! sig64 ) {
+        shiftDist = softfloat_countLeadingZeros64( sig0 ) - 15;
+        z.exp = -63 - shiftDist;
+        if ( shiftDist < 0 ) {
+            z.sig.v64 = sig0>>-shiftDist;
+            z.sig.v0  = sig0<<(shiftDist & 63);
+        } else {
+            z.sig.v64 = sig0<<shiftDist;
+            z.sig.v0  = 0;
+        }
+    } else {
+        shiftDist = softfloat_countLeadingZeros64( sig64 ) - 15;
+        z.exp = 1 - shiftDist;
+        z.sig = softfloat_shortShiftLeft128( sig64, sig0, shiftDist );
+    }
+    return z;
+
+}
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/s_normSubnormalF128SigM.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/s_normSubnormalF128SigM.c
@@ -1,0 +1,61 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015, 2016 The Regents of the University of
+California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdint.h>
+#include "platform.h"
+#include "internals.h"
+
+int softfloat_normSubnormalF128SigM( uint32_t *sigPtr )
+{
+    const uint32_t *ptr;
+    int_fast16_t shiftDist;
+    uint32_t wordSig;
+
+    ptr = sigPtr + indexWordHi( 4 );
+    shiftDist = 0;
+    for (;;) {
+        wordSig = *ptr;
+        if ( wordSig ) break;
+        shiftDist += 32;
+        if ( 128 <= shiftDist ) return 1;
+        ptr -= wordIncr;
+    }
+    shiftDist += softfloat_countLeadingZeros32( wordSig ) - 15;
+    if ( shiftDist ) softfloat_shiftLeft128M( sigPtr, shiftDist, sigPtr );
+    return 1 - shiftDist;
+
+}
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/s_normSubnormalF32Sig.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/s_normSubnormalF32Sig.c
@@ -1,0 +1,52 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015, 2016 The Regents of the University of
+California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdint.h>
+#include "platform.h"
+#include "internals.h"
+
+struct exp16_sig32 softfloat_normSubnormalF32Sig( uint_fast32_t sig )
+{
+    int_fast8_t shiftDist;
+    struct exp16_sig32 z;
+
+    shiftDist = softfloat_countLeadingZeros32( sig ) - 8;
+    z.exp = 1 - shiftDist;
+    z.sig = sig<<shiftDist;
+    return z;
+
+}
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/s_normSubnormalF64Sig.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/s_normSubnormalF64Sig.c
@@ -1,0 +1,52 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015, 2016 The Regents of the University of
+California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdint.h>
+#include "platform.h"
+#include "internals.h"
+
+struct exp16_sig64 softfloat_normSubnormalF64Sig( uint_fast64_t sig )
+{
+    int_fast8_t shiftDist;
+    struct exp16_sig64 z;
+
+    shiftDist = softfloat_countLeadingZeros64( sig ) - 11;
+    z.exp = 1 - shiftDist;
+    z.sig = sig<<shiftDist;
+    return z;
+
+}
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/s_propagateNaNExtF80UI.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/s_propagateNaNExtF80UI.c
@@ -1,0 +1,106 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2018 The Regents of the University of
+California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "platform.h"
+#include "internals.h"
+#include "specialize.h"
+#include "softfloat.h"
+
+/*----------------------------------------------------------------------------
+| Interpreting the unsigned integer formed from concatenating 'uiA64' and
+| 'uiA0' as an 80-bit extended floating-point value, and likewise interpreting
+| the unsigned integer formed from concatenating 'uiB64' and 'uiB0' as another
+| 80-bit extended floating-point value, and assuming at least on of these
+| floating-point values is a NaN, returns the bit pattern of the combined NaN
+| result.  If either original floating-point value is a signaling NaN, the
+| invalid exception is raised.
+*----------------------------------------------------------------------------*/
+struct uint128
+ softfloat_propagateNaNExtF80UI(
+     uint_fast16_t uiA64,
+     uint_fast64_t uiA0,
+     uint_fast16_t uiB64,
+     uint_fast64_t uiB0
+ )
+{
+    bool isSigNaNA, isSigNaNB;
+    uint_fast64_t uiNonsigA0, uiNonsigB0;
+    uint_fast16_t uiMagA64, uiMagB64;
+    struct uint128 uiZ;
+
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    isSigNaNA = softfloat_isSigNaNExtF80UI( uiA64, uiA0 );
+    isSigNaNB = softfloat_isSigNaNExtF80UI( uiB64, uiB0 );
+    /*------------------------------------------------------------------------
+    | Make NaNs non-signaling.
+    *------------------------------------------------------------------------*/
+    uiNonsigA0 = uiA0 | UINT64_C( 0xC000000000000000 );
+    uiNonsigB0 = uiB0 | UINT64_C( 0xC000000000000000 );
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    if ( isSigNaNA | isSigNaNB ) {
+        softfloat_raiseFlags( softfloat_flag_invalid );
+        if ( isSigNaNA ) {
+            if ( isSigNaNB ) goto returnLargerMag;
+            if ( isNaNExtF80UI( uiB64, uiB0 ) ) goto returnB;
+            goto returnA;
+        } else {
+            if ( isNaNExtF80UI( uiA64, uiA0 ) ) goto returnA;
+            goto returnB;
+        }
+    }
+ returnLargerMag:
+    uiMagA64 = uiA64 & 0x7FFF;
+    uiMagB64 = uiB64 & 0x7FFF;
+    if ( uiMagA64 < uiMagB64 ) goto returnB;
+    if ( uiMagB64 < uiMagA64 ) goto returnA;
+    if ( uiA0 < uiB0 ) goto returnB;
+    if ( uiB0 < uiA0 ) goto returnA;
+    if ( uiA64 < uiB64 ) goto returnA;
+ returnB:
+    uiZ.v64 = uiB64;
+    uiZ.v0  = uiNonsigB0;
+    return uiZ;
+ returnA:
+    uiZ.v64 = uiA64;
+    uiZ.v0  = uiNonsigA0;
+    return uiZ;
+
+}
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/s_roundPackToExtF80.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/s_roundPackToExtF80.c
@@ -1,0 +1,256 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015, 2017 The Regents of the University of
+California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "platform.h"
+#include "internals.h"
+#include "softfloat.h"
+
+extFloat80_t
+ softfloat_roundPackToExtF80(
+     bool sign,
+     int_fast32_t exp,
+     uint_fast64_t sig,
+     uint_fast64_t sigExtra,
+     uint_fast8_t roundingPrecision
+ )
+{
+    uint_fast8_t roundingMode;
+    bool roundNearEven;
+    uint_fast64_t roundIncrement, roundMask, roundBits;
+    bool isTiny, doIncrement;
+    struct uint64_extra sig64Extra;
+    union { struct extFloat80M s; extFloat80_t f; } uZ;
+
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    roundingMode = softfloat_roundingMode;
+    roundNearEven = (roundingMode == softfloat_round_near_even);
+    if ( roundingPrecision == 80 ) goto precision80;
+    if ( roundingPrecision == 64 ) {
+        roundIncrement = UINT64_C( 0x0000000000000400 );
+        roundMask = UINT64_C( 0x00000000000007FF );
+    } else if ( roundingPrecision == 32 ) {
+        roundIncrement = UINT64_C( 0x0000008000000000 );
+        roundMask = UINT64_C( 0x000000FFFFFFFFFF );
+    } else {
+        goto precision80;
+    }
+    sig |= (sigExtra != 0);
+    if ( ! roundNearEven && (roundingMode != softfloat_round_near_maxMag) ) {
+        roundIncrement =
+            (roundingMode
+                 == (sign ? softfloat_round_min : softfloat_round_max))
+                ? roundMask
+                : 0;
+    }
+    roundBits = sig & roundMask;
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    if ( 0x7FFD <= (uint32_t) (exp - 1) ) {
+        if ( exp <= 0 ) {
+            /*----------------------------------------------------------------
+            *----------------------------------------------------------------*/
+            isTiny =
+                   (softfloat_detectTininess
+                        == softfloat_tininess_beforeRounding)
+                || (exp < 0)
+                || (sig <= (uint64_t) (sig + roundIncrement));
+            sig = softfloat_shiftRightJam64( sig, 1 - exp );
+            roundBits = sig & roundMask;
+            if ( roundBits ) {
+                if ( isTiny ) softfloat_raiseFlags( softfloat_flag_underflow );
+                softfloat_exceptionFlags |= softfloat_flag_inexact;
+#ifdef SOFTFLOAT_ROUND_ODD
+                if ( roundingMode == softfloat_round_odd ) {
+                    sig |= roundMask + 1;
+                }
+#endif
+            }
+            sig += roundIncrement;
+            exp = ((sig & UINT64_C( 0x8000000000000000 )) != 0);
+            roundIncrement = roundMask + 1;
+            if ( roundNearEven && (roundBits<<1 == roundIncrement) ) {
+                roundMask |= roundIncrement;
+            }
+            sig &= ~roundMask;
+            goto packReturn;
+        }
+        if (
+               (0x7FFE < exp)
+            || ((exp == 0x7FFE) && ((uint64_t) (sig + roundIncrement) < sig))
+        ) {
+            goto overflow;
+        }
+    }
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    if ( roundBits ) {
+        softfloat_exceptionFlags |= softfloat_flag_inexact;
+#ifdef SOFTFLOAT_ROUND_ODD
+        if ( roundingMode == softfloat_round_odd ) {
+            sig = (sig & ~roundMask) | (roundMask + 1);
+            goto packReturn;
+        }
+#endif
+    }
+    sig = (uint64_t) (sig + roundIncrement);
+    if ( sig < roundIncrement ) {
+        ++exp;
+        sig = UINT64_C( 0x8000000000000000 );
+    }
+    roundIncrement = roundMask + 1;
+    if ( roundNearEven && (roundBits<<1 == roundIncrement) ) {
+        roundMask |= roundIncrement;
+    }
+    sig &= ~roundMask;
+    goto packReturn;
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+ precision80:
+    doIncrement = (UINT64_C( 0x8000000000000000 ) <= sigExtra);
+    if ( ! roundNearEven && (roundingMode != softfloat_round_near_maxMag) ) {
+        doIncrement =
+            (roundingMode
+                 == (sign ? softfloat_round_min : softfloat_round_max))
+                && sigExtra;
+    }
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    if ( 0x7FFD <= (uint32_t) (exp - 1) ) {
+        if ( exp <= 0 ) {
+            /*----------------------------------------------------------------
+            *----------------------------------------------------------------*/
+            isTiny =
+                   (softfloat_detectTininess
+                        == softfloat_tininess_beforeRounding)
+                || (exp < 0)
+                || ! doIncrement
+                || (sig < UINT64_C( 0xFFFFFFFFFFFFFFFF ));
+            sig64Extra =
+                softfloat_shiftRightJam64Extra( sig, sigExtra, 1 - exp );
+            exp = 0;
+            sig = sig64Extra.v;
+            sigExtra = sig64Extra.extra;
+            if ( sigExtra ) {
+                if ( isTiny ) softfloat_raiseFlags( softfloat_flag_underflow );
+                softfloat_exceptionFlags |= softfloat_flag_inexact;
+#ifdef SOFTFLOAT_ROUND_ODD
+                if ( roundingMode == softfloat_round_odd ) {
+                    sig |= 1;
+                    goto packReturn;
+                }
+#endif
+            }
+            doIncrement = (UINT64_C( 0x8000000000000000 ) <= sigExtra);
+            if (
+                ! roundNearEven
+                    && (roundingMode != softfloat_round_near_maxMag)
+            ) {
+                doIncrement =
+                    (roundingMode
+                         == (sign ? softfloat_round_min : softfloat_round_max))
+                        && sigExtra;
+            }
+            if ( doIncrement ) {
+                ++sig;
+                sig &=
+                    ~(uint_fast64_t)
+                         (! (sigExtra & UINT64_C( 0x7FFFFFFFFFFFFFFF ))
+                              & roundNearEven);
+                exp = ((sig & UINT64_C( 0x8000000000000000 )) != 0);
+            }
+            goto packReturn;
+        }
+        if (
+               (0x7FFE < exp)
+            || ((exp == 0x7FFE) && (sig == UINT64_C( 0xFFFFFFFFFFFFFFFF ))
+                    && doIncrement)
+        ) {
+            /*----------------------------------------------------------------
+            *----------------------------------------------------------------*/
+            roundMask = 0;
+ overflow:
+            softfloat_raiseFlags(
+                softfloat_flag_overflow | softfloat_flag_inexact );
+            if (
+                   roundNearEven
+                || (roundingMode == softfloat_round_near_maxMag)
+                || (roundingMode
+                        == (sign ? softfloat_round_min : softfloat_round_max))
+            ) {
+                exp = 0x7FFF;
+                sig = UINT64_C( 0x8000000000000000 );
+            } else {
+                exp = 0x7FFE;
+                sig = ~roundMask;
+            }
+            goto packReturn;
+        }
+    }
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    if ( sigExtra ) {
+        softfloat_exceptionFlags |= softfloat_flag_inexact;
+#ifdef SOFTFLOAT_ROUND_ODD
+        if ( roundingMode == softfloat_round_odd ) {
+            sig |= 1;
+            goto packReturn;
+        }
+#endif
+    }
+    if ( doIncrement ) {
+        ++sig;
+        if ( ! sig ) {
+            ++exp;
+            sig = UINT64_C( 0x8000000000000000 );
+        } else {
+            sig &=
+                ~(uint_fast64_t)
+                     (! (sigExtra & UINT64_C( 0x7FFFFFFFFFFFFFFF ))
+                          & roundNearEven);
+        }
+    }
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+ packReturn:
+    uZ.s.signExp = packToExtF80UI64( sign, exp );
+    uZ.s.signif = sig;
+    return uZ.f;
+
+}
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/s_roundPackToF32.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/s_roundPackToF32.c
@@ -1,0 +1,113 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015, 2017 The Regents of the University of
+California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "platform.h"
+#include "internals.h"
+#include "softfloat.h"
+
+float32_t
+ softfloat_roundPackToF32( bool sign, int_fast16_t exp, uint_fast32_t sig )
+{
+    uint_fast8_t roundingMode;
+    bool roundNearEven;
+    uint_fast8_t roundIncrement, roundBits;
+    bool isTiny;
+    uint_fast32_t uiZ;
+    union ui32_f32 uZ;
+
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    roundingMode = softfloat_roundingMode;
+    roundNearEven = (roundingMode == softfloat_round_near_even);
+    roundIncrement = 0x40;
+    if ( ! roundNearEven && (roundingMode != softfloat_round_near_maxMag) ) {
+        roundIncrement =
+            (roundingMode
+                 == (sign ? softfloat_round_min : softfloat_round_max))
+                ? 0x7F
+                : 0;
+    }
+    roundBits = sig & 0x7F;
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    if ( 0xFD <= (unsigned int) exp ) {
+        if ( exp < 0 ) {
+            /*----------------------------------------------------------------
+            *----------------------------------------------------------------*/
+            isTiny =
+                (softfloat_detectTininess == softfloat_tininess_beforeRounding)
+                    || (exp < -1) || (sig + roundIncrement < 0x80000000);
+            sig = softfloat_shiftRightJam32( sig, -exp );
+            exp = 0;
+            roundBits = sig & 0x7F;
+            if ( isTiny && roundBits ) {
+                softfloat_raiseFlags( softfloat_flag_underflow );
+            }
+        } else if ( (0xFD < exp) || (0x80000000 <= sig + roundIncrement) ) {
+            /*----------------------------------------------------------------
+            *----------------------------------------------------------------*/
+            softfloat_raiseFlags(
+                softfloat_flag_overflow | softfloat_flag_inexact );
+            uiZ = packToF32UI( sign, 0xFF, 0 ) - ! roundIncrement;
+            goto uiZ;
+        }
+    }
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    sig = (sig + roundIncrement)>>7;
+    if ( roundBits ) {
+        softfloat_exceptionFlags |= softfloat_flag_inexact;
+#ifdef SOFTFLOAT_ROUND_ODD
+        if ( roundingMode == softfloat_round_odd ) {
+            sig |= 1;
+            goto packReturn;
+        }
+#endif
+    }
+    sig &= ~(uint_fast32_t) (! (roundBits ^ 0x40) & roundNearEven);
+    if ( ! sig ) exp = 0;
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+ packReturn:
+    uiZ = packToF32UI( sign, exp, sig );
+ uiZ:
+    uZ.ui = uiZ;
+    return uZ.f;
+
+}
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/s_roundPackToF64.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/s_roundPackToF64.c
@@ -1,0 +1,117 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015, 2017 The Regents of the University of
+California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "platform.h"
+#include "internals.h"
+#include "softfloat.h"
+
+float64_t
+ softfloat_roundPackToF64( bool sign, int_fast16_t exp, uint_fast64_t sig )
+{
+    uint_fast8_t roundingMode;
+    bool roundNearEven;
+    uint_fast16_t roundIncrement, roundBits;
+    bool isTiny;
+    uint_fast64_t uiZ;
+    union ui64_f64 uZ;
+
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    roundingMode = softfloat_roundingMode;
+    roundNearEven = (roundingMode == softfloat_round_near_even);
+    roundIncrement = 0x200;
+    if ( ! roundNearEven && (roundingMode != softfloat_round_near_maxMag) ) {
+        roundIncrement =
+            (roundingMode
+                 == (sign ? softfloat_round_min : softfloat_round_max))
+                ? 0x3FF
+                : 0;
+    }
+    roundBits = sig & 0x3FF;
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    if ( 0x7FD <= (uint16_t) exp ) {
+        if ( exp < 0 ) {
+            /*----------------------------------------------------------------
+            *----------------------------------------------------------------*/
+            isTiny =
+                (softfloat_detectTininess == softfloat_tininess_beforeRounding)
+                    || (exp < -1)
+                    || (sig + roundIncrement < UINT64_C( 0x8000000000000000 ));
+            sig = softfloat_shiftRightJam64( sig, -exp );
+            exp = 0;
+            roundBits = sig & 0x3FF;
+            if ( isTiny && roundBits ) {
+                softfloat_raiseFlags( softfloat_flag_underflow );
+            }
+        } else if (
+            (0x7FD < exp)
+                || (UINT64_C( 0x8000000000000000 ) <= sig + roundIncrement)
+        ) {
+            /*----------------------------------------------------------------
+            *----------------------------------------------------------------*/
+            softfloat_raiseFlags(
+                softfloat_flag_overflow | softfloat_flag_inexact );
+            uiZ = packToF64UI( sign, 0x7FF, 0 ) - ! roundIncrement;
+            goto uiZ;
+        }
+    }
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    sig = (sig + roundIncrement)>>10;
+    if ( roundBits ) {
+        softfloat_exceptionFlags |= softfloat_flag_inexact;
+#ifdef SOFTFLOAT_ROUND_ODD
+        if ( roundingMode == softfloat_round_odd ) {
+            sig |= 1;
+            goto packReturn;
+        }
+#endif
+    }
+    sig &= ~(uint_fast64_t) (! (roundBits ^ 0x200) & roundNearEven);
+    if ( ! sig ) exp = 0;
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+ packReturn:
+    uiZ = packToF64UI( sign, exp, sig );
+ uiZ:
+    uZ.ui = uiZ;
+    return uZ.f;
+
+}
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/s_roundToI32.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/s_roundToI32.c
@@ -1,0 +1,98 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015, 2016, 2017 The Regents of the
+University of California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "platform.h"
+#include "internals.h"
+#include "specialize.h"
+#include "softfloat.h"
+
+int_fast32_t
+ softfloat_roundToI32(
+     bool sign, uint_fast64_t sig, uint_fast8_t roundingMode, bool exact )
+{
+    uint_fast16_t roundIncrement, roundBits;
+    uint_fast32_t sig32;
+    union { uint32_t ui; int32_t i; } uZ;
+    int_fast32_t z;
+
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    roundIncrement = 0x800;
+    if (
+        (roundingMode != softfloat_round_near_maxMag)
+            && (roundingMode != softfloat_round_near_even)
+    ) {
+        roundIncrement = 0;
+        if ( 
+            sign
+                ? (roundingMode == softfloat_round_min)
+#ifdef SOFTFLOAT_ROUND_ODD
+                      || (roundingMode == softfloat_round_odd)
+#endif
+                : (roundingMode == softfloat_round_max)
+        ) {
+            roundIncrement = 0xFFF;
+        }
+    }
+    roundBits = sig & 0xFFF;
+    sig += roundIncrement;
+    if ( sig & UINT64_C( 0xFFFFF00000000000 ) ) goto invalid;
+    sig32 = sig>>12;
+    if (
+        (roundBits == 0x800) && (roundingMode == softfloat_round_near_even)
+    ) {
+        sig32 &= ~(uint_fast32_t) 1;
+    }
+    uZ.ui = sign ? -sig32 : sig32;
+    z = uZ.i;
+    if ( z && ((z < 0) ^ sign) ) goto invalid;
+    if ( roundBits ) {
+#ifdef SOFTFLOAT_ROUND_ODD
+        if ( roundingMode == softfloat_round_odd ) z |= 1;
+#endif
+        if ( exact ) softfloat_exceptionFlags |= softfloat_flag_inexact;
+    }
+    return z;
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+ invalid:
+    softfloat_raiseFlags( softfloat_flag_invalid );
+    return sign ? i32_fromNegOverflow : i32_fromPosOverflow;
+
+}
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/s_roundToI64.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/s_roundToI64.c
@@ -1,0 +1,101 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015, 2016, 2017 The Regents of the
+University of California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "platform.h"
+#include "internals.h"
+#include "specialize.h"
+#include "softfloat.h"
+
+int_fast64_t
+ softfloat_roundToI64(
+     bool sign,
+     uint_fast64_t sig,
+     uint_fast64_t sigExtra,
+     uint_fast8_t roundingMode,
+     bool exact
+ )
+{
+    union { uint64_t ui; int64_t i; } uZ;
+    int_fast64_t z;
+
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    if (
+        (roundingMode == softfloat_round_near_maxMag)
+            || (roundingMode == softfloat_round_near_even)
+    ) {
+        if ( UINT64_C( 0x8000000000000000 ) <= sigExtra ) goto increment;
+    } else {
+        if (
+            sigExtra
+                && (sign
+                        ? (roundingMode == softfloat_round_min)
+#ifdef SOFTFLOAT_ROUND_ODD
+                              || (roundingMode == softfloat_round_odd)
+#endif
+                        : (roundingMode == softfloat_round_max))
+        ) {
+ increment:
+            ++sig;
+            if ( !sig ) goto invalid;
+            if (
+                (sigExtra == UINT64_C( 0x8000000000000000 ))
+                    && (roundingMode == softfloat_round_near_even)
+            ) {
+                sig &= ~(uint_fast64_t) 1;
+            }
+        }
+    }
+    uZ.ui = sign ? -sig : sig;
+    z = uZ.i;
+    if ( z && ((z < 0) ^ sign) ) goto invalid;
+    if ( sigExtra ) {
+#ifdef SOFTFLOAT_ROUND_ODD
+        if ( roundingMode == softfloat_round_odd ) z |= 1;
+#endif
+        if ( exact ) softfloat_exceptionFlags |= softfloat_flag_inexact;
+    }
+    return z;
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+ invalid:
+    softfloat_raiseFlags( softfloat_flag_invalid );
+    return sign ? i64_fromNegOverflow : i64_fromPosOverflow;
+
+}
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/s_shiftRightJam128.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/s_shiftRightJam128.c
@@ -1,0 +1,69 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015, 2016 The Regents of the University of
+California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdint.h>
+#include "platform.h"
+#include "primitiveTypes.h"
+
+#ifndef softfloat_shiftRightJam128
+
+struct uint128
+ softfloat_shiftRightJam128( uint64_t a64, uint64_t a0, uint_fast32_t dist )
+{
+    uint_fast8_t u8NegDist;
+    struct uint128 z;
+
+    if ( dist < 64 ) {
+        u8NegDist = -dist;
+        z.v64 = a64>>dist;
+        z.v0 =
+            a64<<(u8NegDist & 63) | a0>>dist
+                | ((uint64_t) (a0<<(u8NegDist & 63)) != 0);
+    } else {
+        z.v64 = 0;
+        z.v0 =
+            (dist < 127)
+                ? a64>>(dist & 63)
+                      | (((a64 & (((uint_fast64_t) 1<<(dist & 63)) - 1)) | a0)
+                             != 0)
+                : ((a64 | a0) != 0);
+    }
+    return z;
+
+}
+
+#endif
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/s_shiftRightJam128Extra.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/s_shiftRightJam128Extra.c
@@ -1,0 +1,77 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015, 2016 The Regents of the University of
+California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdint.h>
+#include "platform.h"
+#include "primitiveTypes.h"
+
+#ifndef softfloat_shiftRightJam128Extra
+
+struct uint128_extra
+ softfloat_shiftRightJam128Extra(
+     uint64_t a64, uint64_t a0, uint64_t extra, uint_fast32_t dist )
+{
+    uint_fast8_t u8NegDist;
+    struct uint128_extra z;
+
+    u8NegDist = -dist;
+    if ( dist < 64 ) {
+        z.v.v64 = a64>>dist;
+        z.v.v0 = a64<<(u8NegDist & 63) | a0>>dist;
+        z.extra = a0<<(u8NegDist & 63);
+    } else {
+        z.v.v64 = 0;
+        if ( dist == 64 ) {
+            z.v.v0 = a64;
+            z.extra = a0;
+        } else {
+            extra |= a0;
+            if ( dist < 128 ) {
+                z.v.v0 = a64>>(dist & 63);
+                z.extra = a64<<(u8NegDist & 63);
+            } else {
+                z.v.v0 = 0;
+                z.extra = (dist == 128) ? a64 : (a64 != 0);
+            }
+        }
+    }
+    z.extra |= (extra != 0);
+    return z;
+
+}
+
+#endif
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/s_shiftRightJam32.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/s_shiftRightJam32.c
@@ -1,0 +1,51 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015, 2016 The Regents of the University of
+California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdint.h>
+#include "platform.h"
+
+#ifndef softfloat_shiftRightJam32
+
+uint32_t softfloat_shiftRightJam32( uint32_t a, uint_fast16_t dist )
+{
+
+    return
+        (dist < 31) ? a>>dist | ((uint32_t) (a<<(-dist & 31)) != 0) : (a != 0);
+
+}
+
+#endif
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/s_shiftRightJam64.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/s_shiftRightJam64.c
@@ -1,0 +1,51 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015, 2016 The Regents of the University of
+California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdint.h>
+#include "platform.h"
+
+#ifndef softfloat_shiftRightJam64
+
+uint64_t softfloat_shiftRightJam64( uint64_t a, uint_fast32_t dist )
+{
+
+    return
+        (dist < 63) ? a>>dist | ((uint64_t) (a<<(-dist & 63)) != 0) : (a != 0);
+
+}
+
+#endif
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/s_shiftRightJam64Extra.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/s_shiftRightJam64Extra.c
@@ -1,0 +1,62 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015, 2016 The Regents of the University of
+California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdint.h>
+#include "platform.h"
+#include "primitiveTypes.h"
+
+#ifndef softfloat_shiftRightJam64Extra
+
+struct uint64_extra
+ softfloat_shiftRightJam64Extra(
+     uint64_t a, uint64_t extra, uint_fast32_t dist )
+{
+    struct uint64_extra z;
+
+    if ( dist < 64 ) {
+        z.v = a>>dist;
+        z.extra = a<<(-dist & 63);
+    } else {
+        z.v = 0;
+        z.extra = (dist == 64) ? a : (a != 0);
+    }
+    z.extra |= (extra != 0);
+    return z;
+
+}
+
+#endif
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/s_shortShiftLeft128.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/s_shortShiftLeft128.c
@@ -1,0 +1,55 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015, 2016 The Regents of the University of
+California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdint.h>
+#include "platform.h"
+#include "primitiveTypes.h"
+
+#ifndef softfloat_shortShiftLeft128
+
+struct uint128
+ softfloat_shortShiftLeft128( uint64_t a64, uint64_t a0, uint_fast8_t dist )
+{
+    struct uint128 z;
+
+    z.v64 = a64<<dist | a0>>(-dist & 63);
+    z.v0 = a0<<dist;
+    return z;
+
+}
+
+#endif
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/s_shortShiftRight128.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/s_shortShiftRight128.c
@@ -1,0 +1,55 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015, 2016 The Regents of the University of
+California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdint.h>
+#include "platform.h"
+#include "primitiveTypes.h"
+
+#ifndef softfloat_shortShiftRight128
+
+struct uint128
+ softfloat_shortShiftRight128( uint64_t a64, uint64_t a0, uint_fast8_t dist )
+{
+    struct uint128 z;
+
+    z.v64 = a64>>dist;
+    z.v0 = a64<<(-dist & 63) | a0>>dist;
+    return z;
+
+}
+
+#endif
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/s_shortShiftRightJam64.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/s_shortShiftRightJam64.c
@@ -1,0 +1,50 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015, 2016 The Regents of the University of
+California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdint.h>
+#include "platform.h"
+
+#ifndef softfloat_shortShiftRightJam64
+
+uint64_t softfloat_shortShiftRightJam64( uint64_t a, uint_fast8_t dist )
+{
+
+    return a>>dist | ((a & (((uint_fast64_t) 1<<dist) - 1)) != 0);
+
+}
+
+#endif
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/s_shortShiftRightJam64Extra.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/s_shortShiftRightJam64Extra.c
@@ -1,0 +1,56 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015, 2016 The Regents of the University of
+California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdint.h>
+#include "platform.h"
+#include "primitiveTypes.h"
+
+#ifndef softfloat_shortShiftRightJam64Extra
+
+struct uint64_extra
+ softfloat_shortShiftRightJam64Extra(
+     uint64_t a, uint64_t extra, uint_fast8_t dist )
+{
+    struct uint64_extra z;
+
+    z.v = a>>dist;
+    z.extra = a<<(-dist & 63) | (extra != 0);
+    return z;
+
+}
+
+#endif
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/s_sub128.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/s_sub128.c
@@ -1,0 +1,55 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
+California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdint.h>
+#include "platform.h"
+#include "primitiveTypes.h"
+
+#ifndef softfloat_sub128
+
+struct uint128
+ softfloat_sub128( uint64_t a64, uint64_t a0, uint64_t b64, uint64_t b0 )
+{
+    struct uint128 z;
+
+    z.v0 = a0 - b0;
+    z.v64 = a64 - b64 - (a0 < b0);
+    return z;
+
+}
+
+#endif
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/s_subMagsExtF80.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/s_subMagsExtF80.c
@@ -1,0 +1,158 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
+California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "platform.h"
+#include "internals.h"
+#include "specialize.h"
+#include "softfloat.h"
+
+extFloat80_t
+ softfloat_subMagsExtF80(
+     uint_fast16_t uiA64,
+     uint_fast64_t uiA0,
+     uint_fast16_t uiB64,
+     uint_fast64_t uiB0,
+     bool signZ
+ )
+{
+    int_fast32_t expA;
+    uint_fast64_t sigA;
+    int_fast32_t expB;
+    uint_fast64_t sigB;
+    int_fast32_t expDiff;
+    uint_fast16_t uiZ64;
+    uint_fast64_t uiZ0;
+    int_fast32_t expZ;
+    uint_fast64_t sigExtra;
+    struct uint128 sig128, uiZ;
+    union { struct extFloat80M s; extFloat80_t f; } uZ;
+
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    expA = expExtF80UI64( uiA64 );
+    sigA = uiA0;
+    expB = expExtF80UI64( uiB64 );
+    sigB = uiB0;
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    expDiff = expA - expB;
+    if ( 0 < expDiff ) goto expABigger;
+    if ( expDiff < 0 ) goto expBBigger;
+    if ( expA == 0x7FFF ) {
+        if ( (sigA | sigB) & UINT64_C( 0x7FFFFFFFFFFFFFFF ) ) {
+            goto propagateNaN;
+        }
+        softfloat_raiseFlags( softfloat_flag_invalid );
+        uiZ64 = defaultNaNExtF80UI64;
+        uiZ0  = defaultNaNExtF80UI0;
+        goto uiZ;
+    }
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+    expZ = expA;
+    if ( ! expZ ) expZ = 1;
+    sigExtra = 0;
+    if ( sigB < sigA ) goto aBigger;
+    if ( sigA < sigB ) goto bBigger;
+    uiZ64 =
+        packToExtF80UI64( (softfloat_roundingMode == softfloat_round_min), 0 );
+    uiZ0 = 0;
+    goto uiZ;
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+ expBBigger:
+    if ( expB == 0x7FFF ) {
+        if ( sigB & UINT64_C( 0x7FFFFFFFFFFFFFFF ) ) goto propagateNaN;
+        uiZ64 = packToExtF80UI64( signZ ^ 1, 0x7FFF );
+        uiZ0  = UINT64_C( 0x8000000000000000 );
+        goto uiZ;
+    }
+    if ( ! expA ) {
+        ++expDiff;
+        sigExtra = 0;
+        if ( ! expDiff ) goto newlyAlignedBBigger;
+    }
+    sig128 = softfloat_shiftRightJam128( sigA, 0, -expDiff );
+    sigA = sig128.v64;
+    sigExtra = sig128.v0;
+ newlyAlignedBBigger:
+    expZ = expB;
+ bBigger:
+    signZ = ! signZ;
+    sig128 = softfloat_sub128( sigB, 0, sigA, sigExtra );
+    goto normRoundPack;
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+ expABigger:
+    if ( expA == 0x7FFF ) {
+        if ( sigA & UINT64_C( 0x7FFFFFFFFFFFFFFF ) ) goto propagateNaN;
+        uiZ64 = uiA64;
+        uiZ0  = uiA0;
+        goto uiZ;
+    }
+    if ( ! expB ) {
+        --expDiff;
+        sigExtra = 0;
+        if ( ! expDiff ) goto newlyAlignedABigger;
+    }
+    sig128 = softfloat_shiftRightJam128( sigB, 0, expDiff );
+    sigB = sig128.v64;
+    sigExtra = sig128.v0;
+ newlyAlignedABigger:
+    expZ = expA;
+ aBigger:
+    sig128 = softfloat_sub128( sigA, 0, sigB, sigExtra );
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+ normRoundPack:
+    return
+        softfloat_normRoundPackToExtF80(
+            signZ, expZ, sig128.v64, sig128.v0, extF80_roundingPrecision );
+    /*------------------------------------------------------------------------
+    *------------------------------------------------------------------------*/
+ propagateNaN:
+    uiZ = softfloat_propagateNaNExtF80UI( uiA64, uiA0, uiB64, uiB0 );
+    uiZ64 = uiZ.v64;
+    uiZ0  = uiZ.v0;
+ uiZ:
+    uZ.s.signExp = uiZ64;
+    uZ.s.signif  = uiZ0;
+    return uZ.f;
+
+}
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/softfloat.h
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/softfloat.h
@@ -1,0 +1,372 @@
+
+/*============================================================================
+
+This C header file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015, 2016, 2017 The Regents of the
+University of California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+
+/*============================================================================
+| Note:  If SoftFloat is made available as a general library for programs to
+| use, it is strongly recommended that a platform-specific version of this
+| header, "softfloat.h", be created that folds in "softfloat_types.h" and that
+| eliminates all dependencies on compile-time macros.
+*============================================================================*/
+
+
+#ifndef softfloat_h
+#define softfloat_h 1
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "softfloat_types.h"
+
+#ifndef THREAD_LOCAL
+#define THREAD_LOCAL
+#endif
+
+/*----------------------------------------------------------------------------
+| Software floating-point underflow tininess-detection mode.
+*----------------------------------------------------------------------------*/
+extern THREAD_LOCAL uint_fast8_t softfloat_detectTininess;
+enum {
+    softfloat_tininess_beforeRounding = 0,
+    softfloat_tininess_afterRounding  = 1
+};
+
+/*----------------------------------------------------------------------------
+| Software floating-point rounding mode.  (Mode "odd" is supported only if
+| SoftFloat is compiled with macro 'SOFTFLOAT_ROUND_ODD' defined.)
+*----------------------------------------------------------------------------*/
+extern THREAD_LOCAL uint_fast8_t softfloat_roundingMode;
+enum {
+    softfloat_round_near_even   = 0,
+    softfloat_round_minMag      = 1,
+    softfloat_round_min         = 2,
+    softfloat_round_max         = 3,
+    softfloat_round_near_maxMag = 4,
+    softfloat_round_odd         = 6
+};
+
+/*----------------------------------------------------------------------------
+| Software floating-point exception flags.
+*----------------------------------------------------------------------------*/
+extern THREAD_LOCAL uint_fast8_t softfloat_exceptionFlags;
+enum {
+    softfloat_flag_inexact   =  1,
+    softfloat_flag_underflow =  2,
+    softfloat_flag_overflow  =  4,
+    softfloat_flag_infinite  =  8,
+    softfloat_flag_invalid   = 16
+};
+
+/*----------------------------------------------------------------------------
+| Routine to raise any or all of the software floating-point exception flags.
+*----------------------------------------------------------------------------*/
+void softfloat_raiseFlags( uint_fast8_t );
+
+/*----------------------------------------------------------------------------
+| Integer-to-floating-point conversion routines.
+*----------------------------------------------------------------------------*/
+float16_t ui32_to_f16( uint32_t );
+float32_t ui32_to_f32( uint32_t );
+float64_t ui32_to_f64( uint32_t );
+#ifdef SOFTFLOAT_FAST_INT64
+extFloat80_t ui32_to_extF80( uint32_t );
+float128_t ui32_to_f128( uint32_t );
+#endif
+void ui32_to_extF80M( uint32_t, extFloat80_t * );
+void ui32_to_f128M( uint32_t, float128_t * );
+float16_t ui64_to_f16( uint64_t );
+float32_t ui64_to_f32( uint64_t );
+float64_t ui64_to_f64( uint64_t );
+#ifdef SOFTFLOAT_FAST_INT64
+extFloat80_t ui64_to_extF80( uint64_t );
+float128_t ui64_to_f128( uint64_t );
+#endif
+void ui64_to_extF80M( uint64_t, extFloat80_t * );
+void ui64_to_f128M( uint64_t, float128_t * );
+float16_t i32_to_f16( int32_t );
+float32_t i32_to_f32( int32_t );
+float64_t i32_to_f64( int32_t );
+#ifdef SOFTFLOAT_FAST_INT64
+extFloat80_t i32_to_extF80( int32_t );
+float128_t i32_to_f128( int32_t );
+#endif
+void i32_to_extF80M( int32_t, extFloat80_t * );
+void i32_to_f128M( int32_t, float128_t * );
+float16_t i64_to_f16( int64_t );
+float32_t i64_to_f32( int64_t );
+float64_t i64_to_f64( int64_t );
+#ifdef SOFTFLOAT_FAST_INT64
+extFloat80_t i64_to_extF80( int64_t );
+float128_t i64_to_f128( int64_t );
+#endif
+void i64_to_extF80M( int64_t, extFloat80_t * );
+void i64_to_f128M( int64_t, float128_t * );
+
+/*----------------------------------------------------------------------------
+| 16-bit (half-precision) floating-point operations.
+*----------------------------------------------------------------------------*/
+uint_fast32_t f16_to_ui32( float16_t, uint_fast8_t, bool );
+uint_fast64_t f16_to_ui64( float16_t, uint_fast8_t, bool );
+int_fast32_t f16_to_i32( float16_t, uint_fast8_t, bool );
+int_fast64_t f16_to_i64( float16_t, uint_fast8_t, bool );
+uint_fast32_t f16_to_ui32_r_minMag( float16_t, bool );
+uint_fast64_t f16_to_ui64_r_minMag( float16_t, bool );
+int_fast32_t f16_to_i32_r_minMag( float16_t, bool );
+int_fast64_t f16_to_i64_r_minMag( float16_t, bool );
+float32_t f16_to_f32( float16_t );
+float64_t f16_to_f64( float16_t );
+#ifdef SOFTFLOAT_FAST_INT64
+extFloat80_t f16_to_extF80( float16_t );
+float128_t f16_to_f128( float16_t );
+#endif
+void f16_to_extF80M( float16_t, extFloat80_t * );
+void f16_to_f128M( float16_t, float128_t * );
+float16_t f16_roundToInt( float16_t, uint_fast8_t, bool );
+float16_t f16_add( float16_t, float16_t );
+float16_t f16_sub( float16_t, float16_t );
+float16_t f16_mul( float16_t, float16_t );
+float16_t f16_mulAdd( float16_t, float16_t, float16_t );
+float16_t f16_div( float16_t, float16_t );
+float16_t f16_rem( float16_t, float16_t );
+float16_t f16_sqrt( float16_t );
+bool f16_eq( float16_t, float16_t );
+bool f16_le( float16_t, float16_t );
+bool f16_lt( float16_t, float16_t );
+bool f16_eq_signaling( float16_t, float16_t );
+bool f16_le_quiet( float16_t, float16_t );
+bool f16_lt_quiet( float16_t, float16_t );
+bool f16_isSignalingNaN( float16_t );
+
+/*----------------------------------------------------------------------------
+| 32-bit (single-precision) floating-point operations.
+*----------------------------------------------------------------------------*/
+uint_fast32_t f32_to_ui32( float32_t, uint_fast8_t, bool );
+uint_fast64_t f32_to_ui64( float32_t, uint_fast8_t, bool );
+int_fast32_t f32_to_i32( float32_t, uint_fast8_t, bool );
+int_fast64_t f32_to_i64( float32_t, uint_fast8_t, bool );
+uint_fast32_t f32_to_ui32_r_minMag( float32_t, bool );
+uint_fast64_t f32_to_ui64_r_minMag( float32_t, bool );
+int_fast32_t f32_to_i32_r_minMag( float32_t, bool );
+int_fast64_t f32_to_i64_r_minMag( float32_t, bool );
+float16_t f32_to_f16( float32_t );
+float64_t f32_to_f64( float32_t );
+#ifdef SOFTFLOAT_FAST_INT64
+extFloat80_t f32_to_extF80( float32_t );
+float128_t f32_to_f128( float32_t );
+#endif
+void f32_to_extF80M( float32_t, extFloat80_t * );
+void f32_to_f128M( float32_t, float128_t * );
+float32_t f32_roundToInt( float32_t, uint_fast8_t, bool );
+float32_t f32_add( float32_t, float32_t );
+float32_t f32_sub( float32_t, float32_t );
+float32_t f32_mul( float32_t, float32_t );
+float32_t f32_mulAdd( float32_t, float32_t, float32_t );
+float32_t f32_div( float32_t, float32_t );
+float32_t f32_rem( float32_t, float32_t );
+float32_t f32_sqrt( float32_t );
+bool f32_eq( float32_t, float32_t );
+bool f32_le( float32_t, float32_t );
+bool f32_lt( float32_t, float32_t );
+bool f32_eq_signaling( float32_t, float32_t );
+bool f32_le_quiet( float32_t, float32_t );
+bool f32_lt_quiet( float32_t, float32_t );
+bool f32_isSignalingNaN( float32_t );
+
+/*----------------------------------------------------------------------------
+| 64-bit (double-precision) floating-point operations.
+*----------------------------------------------------------------------------*/
+uint_fast32_t f64_to_ui32( float64_t, uint_fast8_t, bool );
+uint_fast64_t f64_to_ui64( float64_t, uint_fast8_t, bool );
+int_fast32_t f64_to_i32( float64_t, uint_fast8_t, bool );
+int_fast64_t f64_to_i64( float64_t, uint_fast8_t, bool );
+uint_fast32_t f64_to_ui32_r_minMag( float64_t, bool );
+uint_fast64_t f64_to_ui64_r_minMag( float64_t, bool );
+int_fast32_t f64_to_i32_r_minMag( float64_t, bool );
+int_fast64_t f64_to_i64_r_minMag( float64_t, bool );
+float16_t f64_to_f16( float64_t );
+float32_t f64_to_f32( float64_t );
+#ifdef SOFTFLOAT_FAST_INT64
+extFloat80_t f64_to_extF80( float64_t );
+float128_t f64_to_f128( float64_t );
+#endif
+void f64_to_extF80M( float64_t, extFloat80_t * );
+void f64_to_f128M( float64_t, float128_t * );
+float64_t f64_roundToInt( float64_t, uint_fast8_t, bool );
+float64_t f64_add( float64_t, float64_t );
+float64_t f64_sub( float64_t, float64_t );
+float64_t f64_mul( float64_t, float64_t );
+float64_t f64_mulAdd( float64_t, float64_t, float64_t );
+float64_t f64_div( float64_t, float64_t );
+float64_t f64_rem( float64_t, float64_t );
+float64_t f64_sqrt( float64_t );
+bool f64_eq( float64_t, float64_t );
+bool f64_le( float64_t, float64_t );
+bool f64_lt( float64_t, float64_t );
+bool f64_eq_signaling( float64_t, float64_t );
+bool f64_le_quiet( float64_t, float64_t );
+bool f64_lt_quiet( float64_t, float64_t );
+bool f64_isSignalingNaN( float64_t );
+
+/*----------------------------------------------------------------------------
+| Rounding precision for 80-bit extended double-precision floating-point.
+| Valid values are 32, 64, and 80.
+*----------------------------------------------------------------------------*/
+extern THREAD_LOCAL uint_fast8_t extF80_roundingPrecision;
+
+/*----------------------------------------------------------------------------
+| 80-bit extended double-precision floating-point operations.
+*----------------------------------------------------------------------------*/
+#ifdef SOFTFLOAT_FAST_INT64
+uint_fast32_t extF80_to_ui32( extFloat80_t, uint_fast8_t, bool );
+uint_fast64_t extF80_to_ui64( extFloat80_t, uint_fast8_t, bool );
+int_fast32_t extF80_to_i32( extFloat80_t, uint_fast8_t, bool );
+int_fast64_t extF80_to_i64( extFloat80_t, uint_fast8_t, bool );
+uint_fast32_t extF80_to_ui32_r_minMag( extFloat80_t, bool );
+uint_fast64_t extF80_to_ui64_r_minMag( extFloat80_t, bool );
+int_fast32_t extF80_to_i32_r_minMag( extFloat80_t, bool );
+int_fast64_t extF80_to_i64_r_minMag( extFloat80_t, bool );
+float16_t extF80_to_f16( extFloat80_t );
+float32_t extF80_to_f32( extFloat80_t );
+float64_t extF80_to_f64( extFloat80_t );
+float128_t extF80_to_f128( extFloat80_t );
+extFloat80_t extF80_roundToInt( extFloat80_t, uint_fast8_t, bool );
+extFloat80_t extF80_add( extFloat80_t, extFloat80_t );
+extFloat80_t extF80_sub( extFloat80_t, extFloat80_t );
+extFloat80_t extF80_mul( extFloat80_t, extFloat80_t );
+extFloat80_t extF80_div( extFloat80_t, extFloat80_t );
+extFloat80_t extF80_rem( extFloat80_t, extFloat80_t );
+extFloat80_t extF80_sqrt( extFloat80_t );
+bool extF80_eq( extFloat80_t, extFloat80_t );
+bool extF80_le( extFloat80_t, extFloat80_t );
+bool extF80_lt( extFloat80_t, extFloat80_t );
+bool extF80_eq_signaling( extFloat80_t, extFloat80_t );
+bool extF80_le_quiet( extFloat80_t, extFloat80_t );
+bool extF80_lt_quiet( extFloat80_t, extFloat80_t );
+bool extF80_isSignalingNaN( extFloat80_t );
+#endif
+uint_fast32_t extF80M_to_ui32( const extFloat80_t *, uint_fast8_t, bool );
+uint_fast64_t extF80M_to_ui64( const extFloat80_t *, uint_fast8_t, bool );
+int_fast32_t extF80M_to_i32( const extFloat80_t *, uint_fast8_t, bool );
+int_fast64_t extF80M_to_i64( const extFloat80_t *, uint_fast8_t, bool );
+uint_fast32_t extF80M_to_ui32_r_minMag( const extFloat80_t *, bool );
+uint_fast64_t extF80M_to_ui64_r_minMag( const extFloat80_t *, bool );
+int_fast32_t extF80M_to_i32_r_minMag( const extFloat80_t *, bool );
+int_fast64_t extF80M_to_i64_r_minMag( const extFloat80_t *, bool );
+float16_t extF80M_to_f16( const extFloat80_t * );
+float32_t extF80M_to_f32( const extFloat80_t * );
+float64_t extF80M_to_f64( const extFloat80_t * );
+void extF80M_to_f128M( const extFloat80_t *, float128_t * );
+void
+ extF80M_roundToInt(
+     const extFloat80_t *, uint_fast8_t, bool, extFloat80_t * );
+void extF80M_add( const extFloat80_t *, const extFloat80_t *, extFloat80_t * );
+void extF80M_sub( const extFloat80_t *, const extFloat80_t *, extFloat80_t * );
+void extF80M_mul( const extFloat80_t *, const extFloat80_t *, extFloat80_t * );
+void extF80M_div( const extFloat80_t *, const extFloat80_t *, extFloat80_t * );
+void extF80M_rem( const extFloat80_t *, const extFloat80_t *, extFloat80_t * );
+void extF80M_sqrt( const extFloat80_t *, extFloat80_t * );
+bool extF80M_eq( const extFloat80_t *, const extFloat80_t * );
+bool extF80M_le( const extFloat80_t *, const extFloat80_t * );
+bool extF80M_lt( const extFloat80_t *, const extFloat80_t * );
+bool extF80M_eq_signaling( const extFloat80_t *, const extFloat80_t * );
+bool extF80M_le_quiet( const extFloat80_t *, const extFloat80_t * );
+bool extF80M_lt_quiet( const extFloat80_t *, const extFloat80_t * );
+bool extF80M_isSignalingNaN( const extFloat80_t * );
+
+/*----------------------------------------------------------------------------
+| 128-bit (quadruple-precision) floating-point operations.
+*----------------------------------------------------------------------------*/
+#ifdef SOFTFLOAT_FAST_INT64
+uint_fast32_t f128_to_ui32( float128_t, uint_fast8_t, bool );
+uint_fast64_t f128_to_ui64( float128_t, uint_fast8_t, bool );
+int_fast32_t f128_to_i32( float128_t, uint_fast8_t, bool );
+int_fast64_t f128_to_i64( float128_t, uint_fast8_t, bool );
+uint_fast32_t f128_to_ui32_r_minMag( float128_t, bool );
+uint_fast64_t f128_to_ui64_r_minMag( float128_t, bool );
+int_fast32_t f128_to_i32_r_minMag( float128_t, bool );
+int_fast64_t f128_to_i64_r_minMag( float128_t, bool );
+float16_t f128_to_f16( float128_t );
+float32_t f128_to_f32( float128_t );
+float64_t f128_to_f64( float128_t );
+extFloat80_t f128_to_extF80( float128_t );
+float128_t f128_roundToInt( float128_t, uint_fast8_t, bool );
+float128_t f128_add( float128_t, float128_t );
+float128_t f128_sub( float128_t, float128_t );
+float128_t f128_mul( float128_t, float128_t );
+float128_t f128_mulAdd( float128_t, float128_t, float128_t );
+float128_t f128_div( float128_t, float128_t );
+float128_t f128_rem( float128_t, float128_t );
+float128_t f128_sqrt( float128_t );
+bool f128_eq( float128_t, float128_t );
+bool f128_le( float128_t, float128_t );
+bool f128_lt( float128_t, float128_t );
+bool f128_eq_signaling( float128_t, float128_t );
+bool f128_le_quiet( float128_t, float128_t );
+bool f128_lt_quiet( float128_t, float128_t );
+bool f128_isSignalingNaN( float128_t );
+#endif
+uint_fast32_t f128M_to_ui32( const float128_t *, uint_fast8_t, bool );
+uint_fast64_t f128M_to_ui64( const float128_t *, uint_fast8_t, bool );
+int_fast32_t f128M_to_i32( const float128_t *, uint_fast8_t, bool );
+int_fast64_t f128M_to_i64( const float128_t *, uint_fast8_t, bool );
+uint_fast32_t f128M_to_ui32_r_minMag( const float128_t *, bool );
+uint_fast64_t f128M_to_ui64_r_minMag( const float128_t *, bool );
+int_fast32_t f128M_to_i32_r_minMag( const float128_t *, bool );
+int_fast64_t f128M_to_i64_r_minMag( const float128_t *, bool );
+float16_t f128M_to_f16( const float128_t * );
+float32_t f128M_to_f32( const float128_t * );
+float64_t f128M_to_f64( const float128_t * );
+void f128M_to_extF80M( const float128_t *, extFloat80_t * );
+void f128M_roundToInt( const float128_t *, uint_fast8_t, bool, float128_t * );
+void f128M_add( const float128_t *, const float128_t *, float128_t * );
+void f128M_sub( const float128_t *, const float128_t *, float128_t * );
+void f128M_mul( const float128_t *, const float128_t *, float128_t * );
+void
+ f128M_mulAdd(
+     const float128_t *, const float128_t *, const float128_t *, float128_t *
+ );
+void f128M_div( const float128_t *, const float128_t *, float128_t * );
+void f128M_rem( const float128_t *, const float128_t *, float128_t * );
+void f128M_sqrt( const float128_t *, float128_t * );
+bool f128M_eq( const float128_t *, const float128_t * );
+bool f128M_le( const float128_t *, const float128_t * );
+bool f128M_lt( const float128_t *, const float128_t * );
+bool f128M_eq_signaling( const float128_t *, const float128_t * );
+bool f128M_le_quiet( const float128_t *, const float128_t * );
+bool f128M_lt_quiet( const float128_t *, const float128_t * );
+bool f128M_isSignalingNaN( const float128_t * );
+
+#endif
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/softfloat_raiseFlags.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/softfloat_raiseFlags.c
@@ -1,0 +1,52 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include "platform.h"
+#include "softfloat.h"
+
+/*----------------------------------------------------------------------------
+| Raises the exceptions specified by `flags'.  Floating-point traps can be
+| defined here if desired.  It is currently not possible for such a trap
+| to substitute a result value.  If traps are not implemented, this routine
+| should be simply `softfloat_exceptionFlags |= flags;'.
+*----------------------------------------------------------------------------*/
+void softfloat_raiseFlags( uint_fast8_t flags )
+{
+
+    softfloat_exceptionFlags |= flags;
+
+}
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/softfloat_state.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/softfloat_state.c
@@ -1,0 +1,52 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015, 2016 The Regents of the University of
+California.  All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdint.h>
+#include "platform.h"
+#include "internals.h"
+#include "specialize.h"
+#include "softfloat.h"
+
+#ifndef THREAD_LOCAL
+#define THREAD_LOCAL
+#endif
+
+THREAD_LOCAL uint_fast8_t softfloat_roundingMode = softfloat_round_near_even;
+THREAD_LOCAL uint_fast8_t softfloat_detectTininess = init_detectTininess;
+THREAD_LOCAL uint_fast8_t softfloat_exceptionFlags = 0;
+
+THREAD_LOCAL uint_fast8_t extF80_roundingPrecision = 80;
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/softfloat_types.h
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/softfloat_types.h
@@ -1,0 +1,81 @@
+
+/*============================================================================
+
+This C header file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015, 2017 The Regents of the University of
+California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#ifndef softfloat_types_h
+#define softfloat_types_h 1
+
+#include <stdint.h>
+
+/*----------------------------------------------------------------------------
+| Types used to pass 16-bit, 32-bit, 64-bit, and 128-bit floating-point
+| arguments and results to/from functions.  These types must be exactly
+| 16 bits, 32 bits, 64 bits, and 128 bits in size, respectively.  Where a
+| platform has "native" support for IEEE-Standard floating-point formats,
+| the types below may, if desired, be defined as aliases for the native types
+| (typically 'float' and 'double', and possibly 'long double').
+*----------------------------------------------------------------------------*/
+typedef struct { uint16_t v; } float16_t;
+typedef struct { uint32_t v; } float32_t;
+typedef struct { uint64_t v; } float64_t;
+typedef struct { uint64_t v[2]; } float128_t;
+
+/*----------------------------------------------------------------------------
+| The format of an 80-bit extended floating-point number in memory.  This
+| structure must contain a 16-bit field named 'signExp' and a 64-bit field
+| named 'signif'.
+*----------------------------------------------------------------------------*/
+#ifdef LITTLEENDIAN
+struct extFloat80M { uint64_t signif; uint16_t signExp; };
+#else
+struct extFloat80M { uint16_t signExp; uint64_t signif; };
+#endif
+
+/*----------------------------------------------------------------------------
+| The type used to pass 80-bit extended floating-point arguments and
+| results to/from functions.  This type must have size identical to
+| 'struct extFloat80M'.  Type 'extFloat80_t' can be defined as an alias for
+| 'struct extFloat80M'.  Alternatively, if a platform has "native" support
+| for IEEE-Standard 80-bit extended floating-point, it may be possible,
+| if desired, to define 'extFloat80_t' as an alias for the native type
+| (presumably either 'long double' or a nonstandard compiler-intrinsic type).
+| In that case, the 'signif' and 'signExp' fields of 'struct extFloat80M'
+| must align exactly with the locations in memory of the sign, exponent, and
+| significand of the native type.
+*----------------------------------------------------------------------------*/
+typedef struct extFloat80M extFloat80_t;
+
+#endif
+

--- a/External/FEXCore/Source/Common/SoftFloat-3e/specialize.h
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/specialize.h
@@ -1,0 +1,376 @@
+
+/*============================================================================
+
+This C header file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3e, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015, 2016, 2018 The Regents of the
+University of California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#ifndef specialize_h
+#define specialize_h 1
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "primitiveTypes.h"
+#include "softfloat.h"
+
+/*----------------------------------------------------------------------------
+| Default value for 'softfloat_detectTininess'.
+*----------------------------------------------------------------------------*/
+#define init_detectTininess softfloat_tininess_afterRounding
+
+/*----------------------------------------------------------------------------
+| The values to return on conversions to 32-bit integer formats that raise an
+| invalid exception.
+*----------------------------------------------------------------------------*/
+#define ui32_fromPosOverflow 0xFFFFFFFF
+#define ui32_fromNegOverflow 0xFFFFFFFF
+#define ui32_fromNaN         0xFFFFFFFF
+#define i32_fromPosOverflow  (-0x7FFFFFFF - 1)
+#define i32_fromNegOverflow  (-0x7FFFFFFF - 1)
+#define i32_fromNaN          (-0x7FFFFFFF - 1)
+
+/*----------------------------------------------------------------------------
+| The values to return on conversions to 64-bit integer formats that raise an
+| invalid exception.
+*----------------------------------------------------------------------------*/
+#define ui64_fromPosOverflow UINT64_C( 0xFFFFFFFFFFFFFFFF )
+#define ui64_fromNegOverflow UINT64_C( 0xFFFFFFFFFFFFFFFF )
+#define ui64_fromNaN         UINT64_C( 0xFFFFFFFFFFFFFFFF )
+#define i64_fromPosOverflow  (-INT64_C( 0x7FFFFFFFFFFFFFFF ) - 1)
+#define i64_fromNegOverflow  (-INT64_C( 0x7FFFFFFFFFFFFFFF ) - 1)
+#define i64_fromNaN          (-INT64_C( 0x7FFFFFFFFFFFFFFF ) - 1)
+
+/*----------------------------------------------------------------------------
+| "Common NaN" structure, used to transfer NaN representations from one format
+| to another.
+*----------------------------------------------------------------------------*/
+struct commonNaN {
+    bool sign;
+#ifdef LITTLEENDIAN
+    uint64_t v0, v64;
+#else
+    uint64_t v64, v0;
+#endif
+};
+
+/*----------------------------------------------------------------------------
+| The bit pattern for a default generated 16-bit floating-point NaN.
+*----------------------------------------------------------------------------*/
+#define defaultNaNF16UI 0xFE00
+
+/*----------------------------------------------------------------------------
+| Returns true when 16-bit unsigned integer 'uiA' has the bit pattern of a
+| 16-bit floating-point signaling NaN.
+| Note:  This macro evaluates its argument more than once.
+*----------------------------------------------------------------------------*/
+#define softfloat_isSigNaNF16UI( uiA ) ((((uiA) & 0x7E00) == 0x7C00) && ((uiA) & 0x01FF))
+
+/*----------------------------------------------------------------------------
+| Assuming 'uiA' has the bit pattern of a 16-bit floating-point NaN, converts
+| this NaN to the common NaN form, and stores the resulting common NaN at the
+| location pointed to by 'zPtr'.  If the NaN is a signaling NaN, the invalid
+| exception is raised.
+*----------------------------------------------------------------------------*/
+void softfloat_f16UIToCommonNaN( uint_fast16_t uiA, struct commonNaN *zPtr );
+
+/*----------------------------------------------------------------------------
+| Converts the common NaN pointed to by 'aPtr' into a 16-bit floating-point
+| NaN, and returns the bit pattern of this value as an unsigned integer.
+*----------------------------------------------------------------------------*/
+uint_fast16_t softfloat_commonNaNToF16UI( const struct commonNaN *aPtr );
+
+/*----------------------------------------------------------------------------
+| Interpreting 'uiA' and 'uiB' as the bit patterns of two 16-bit floating-
+| point values, at least one of which is a NaN, returns the bit pattern of
+| the combined NaN result.  If either 'uiA' or 'uiB' has the pattern of a
+| signaling NaN, the invalid exception is raised.
+*----------------------------------------------------------------------------*/
+uint_fast16_t
+ softfloat_propagateNaNF16UI( uint_fast16_t uiA, uint_fast16_t uiB );
+
+/*----------------------------------------------------------------------------
+| The bit pattern for a default generated 32-bit floating-point NaN.
+*----------------------------------------------------------------------------*/
+#define defaultNaNF32UI 0xFFC00000
+
+/*----------------------------------------------------------------------------
+| Returns true when 32-bit unsigned integer 'uiA' has the bit pattern of a
+| 32-bit floating-point signaling NaN.
+| Note:  This macro evaluates its argument more than once.
+*----------------------------------------------------------------------------*/
+#define softfloat_isSigNaNF32UI( uiA ) ((((uiA) & 0x7FC00000) == 0x7F800000) && ((uiA) & 0x003FFFFF))
+
+/*----------------------------------------------------------------------------
+| Assuming 'uiA' has the bit pattern of a 32-bit floating-point NaN, converts
+| this NaN to the common NaN form, and stores the resulting common NaN at the
+| location pointed to by 'zPtr'.  If the NaN is a signaling NaN, the invalid
+| exception is raised.
+*----------------------------------------------------------------------------*/
+void softfloat_f32UIToCommonNaN( uint_fast32_t uiA, struct commonNaN *zPtr );
+
+/*----------------------------------------------------------------------------
+| Converts the common NaN pointed to by 'aPtr' into a 32-bit floating-point
+| NaN, and returns the bit pattern of this value as an unsigned integer.
+*----------------------------------------------------------------------------*/
+uint_fast32_t softfloat_commonNaNToF32UI( const struct commonNaN *aPtr );
+
+/*----------------------------------------------------------------------------
+| Interpreting 'uiA' and 'uiB' as the bit patterns of two 32-bit floating-
+| point values, at least one of which is a NaN, returns the bit pattern of
+| the combined NaN result.  If either 'uiA' or 'uiB' has the pattern of a
+| signaling NaN, the invalid exception is raised.
+*----------------------------------------------------------------------------*/
+uint_fast32_t
+ softfloat_propagateNaNF32UI( uint_fast32_t uiA, uint_fast32_t uiB );
+
+/*----------------------------------------------------------------------------
+| The bit pattern for a default generated 64-bit floating-point NaN.
+*----------------------------------------------------------------------------*/
+#define defaultNaNF64UI UINT64_C( 0xFFF8000000000000 )
+
+/*----------------------------------------------------------------------------
+| Returns true when 64-bit unsigned integer 'uiA' has the bit pattern of a
+| 64-bit floating-point signaling NaN.
+| Note:  This macro evaluates its argument more than once.
+*----------------------------------------------------------------------------*/
+#define softfloat_isSigNaNF64UI( uiA ) ((((uiA) & UINT64_C( 0x7FF8000000000000 )) == UINT64_C( 0x7FF0000000000000 )) && ((uiA) & UINT64_C( 0x0007FFFFFFFFFFFF )))
+
+/*----------------------------------------------------------------------------
+| Assuming 'uiA' has the bit pattern of a 64-bit floating-point NaN, converts
+| this NaN to the common NaN form, and stores the resulting common NaN at the
+| location pointed to by 'zPtr'.  If the NaN is a signaling NaN, the invalid
+| exception is raised.
+*----------------------------------------------------------------------------*/
+void softfloat_f64UIToCommonNaN( uint_fast64_t uiA, struct commonNaN *zPtr );
+
+/*----------------------------------------------------------------------------
+| Converts the common NaN pointed to by 'aPtr' into a 64-bit floating-point
+| NaN, and returns the bit pattern of this value as an unsigned integer.
+*----------------------------------------------------------------------------*/
+uint_fast64_t softfloat_commonNaNToF64UI( const struct commonNaN *aPtr );
+
+/*----------------------------------------------------------------------------
+| Interpreting 'uiA' and 'uiB' as the bit patterns of two 64-bit floating-
+| point values, at least one of which is a NaN, returns the bit pattern of
+| the combined NaN result.  If either 'uiA' or 'uiB' has the pattern of a
+| signaling NaN, the invalid exception is raised.
+*----------------------------------------------------------------------------*/
+uint_fast64_t
+ softfloat_propagateNaNF64UI( uint_fast64_t uiA, uint_fast64_t uiB );
+
+/*----------------------------------------------------------------------------
+| The bit pattern for a default generated 80-bit extended floating-point NaN.
+*----------------------------------------------------------------------------*/
+#define defaultNaNExtF80UI64 0xFFFF
+#define defaultNaNExtF80UI0  UINT64_C( 0xC000000000000000 )
+
+/*----------------------------------------------------------------------------
+| Returns true when the 80-bit unsigned integer formed from concatenating
+| 16-bit 'uiA64' and 64-bit 'uiA0' has the bit pattern of an 80-bit extended
+| floating-point signaling NaN.
+| Note:  This macro evaluates its arguments more than once.
+*----------------------------------------------------------------------------*/
+#define softfloat_isSigNaNExtF80UI( uiA64, uiA0 ) ((((uiA64) & 0x7FFF) == 0x7FFF) && ! ((uiA0) & UINT64_C( 0x4000000000000000 )) && ((uiA0) & UINT64_C( 0x3FFFFFFFFFFFFFFF )))
+
+#ifdef SOFTFLOAT_FAST_INT64
+
+/*----------------------------------------------------------------------------
+| The following functions are needed only when 'SOFTFLOAT_FAST_INT64' is
+| defined.
+*----------------------------------------------------------------------------*/
+
+/*----------------------------------------------------------------------------
+| Assuming the unsigned integer formed from concatenating 'uiA64' and 'uiA0'
+| has the bit pattern of an 80-bit extended floating-point NaN, converts
+| this NaN to the common NaN form, and stores the resulting common NaN at the
+| location pointed to by 'zPtr'.  If the NaN is a signaling NaN, the invalid
+| exception is raised.
+*----------------------------------------------------------------------------*/
+void
+ softfloat_extF80UIToCommonNaN(
+     uint_fast16_t uiA64, uint_fast64_t uiA0, struct commonNaN *zPtr );
+
+/*----------------------------------------------------------------------------
+| Converts the common NaN pointed to by 'aPtr' into an 80-bit extended
+| floating-point NaN, and returns the bit pattern of this value as an unsigned
+| integer.
+*----------------------------------------------------------------------------*/
+struct uint128 softfloat_commonNaNToExtF80UI( const struct commonNaN *aPtr );
+
+/*----------------------------------------------------------------------------
+| Interpreting the unsigned integer formed from concatenating 'uiA64' and
+| 'uiA0' as an 80-bit extended floating-point value, and likewise interpreting
+| the unsigned integer formed from concatenating 'uiB64' and 'uiB0' as another
+| 80-bit extended floating-point value, and assuming at least on of these
+| floating-point values is a NaN, returns the bit pattern of the combined NaN
+| result.  If either original floating-point value is a signaling NaN, the
+| invalid exception is raised.
+*----------------------------------------------------------------------------*/
+struct uint128
+ softfloat_propagateNaNExtF80UI(
+     uint_fast16_t uiA64,
+     uint_fast64_t uiA0,
+     uint_fast16_t uiB64,
+     uint_fast64_t uiB0
+ );
+
+/*----------------------------------------------------------------------------
+| The bit pattern for a default generated 128-bit floating-point NaN.
+*----------------------------------------------------------------------------*/
+#define defaultNaNF128UI64 UINT64_C( 0xFFFF800000000000 )
+#define defaultNaNF128UI0  UINT64_C( 0 )
+
+/*----------------------------------------------------------------------------
+| Returns true when the 128-bit unsigned integer formed from concatenating
+| 64-bit 'uiA64' and 64-bit 'uiA0' has the bit pattern of a 128-bit floating-
+| point signaling NaN.
+| Note:  This macro evaluates its arguments more than once.
+*----------------------------------------------------------------------------*/
+#define softfloat_isSigNaNF128UI( uiA64, uiA0 ) ((((uiA64) & UINT64_C( 0x7FFF800000000000 )) == UINT64_C( 0x7FFF000000000000 )) && ((uiA0) || ((uiA64) & UINT64_C( 0x00007FFFFFFFFFFF ))))
+
+/*----------------------------------------------------------------------------
+| Assuming the unsigned integer formed from concatenating 'uiA64' and 'uiA0'
+| has the bit pattern of a 128-bit floating-point NaN, converts this NaN to
+| the common NaN form, and stores the resulting common NaN at the location
+| pointed to by 'zPtr'.  If the NaN is a signaling NaN, the invalid exception
+| is raised.
+*----------------------------------------------------------------------------*/
+void
+ softfloat_f128UIToCommonNaN(
+     uint_fast64_t uiA64, uint_fast64_t uiA0, struct commonNaN *zPtr );
+
+/*----------------------------------------------------------------------------
+| Converts the common NaN pointed to by 'aPtr' into a 128-bit floating-point
+| NaN, and returns the bit pattern of this value as an unsigned integer.
+*----------------------------------------------------------------------------*/
+struct uint128 softfloat_commonNaNToF128UI( const struct commonNaN * );
+
+/*----------------------------------------------------------------------------
+| Interpreting the unsigned integer formed from concatenating 'uiA64' and
+| 'uiA0' as a 128-bit floating-point value, and likewise interpreting the
+| unsigned integer formed from concatenating 'uiB64' and 'uiB0' as another
+| 128-bit floating-point value, and assuming at least on of these floating-
+| point values is a NaN, returns the bit pattern of the combined NaN result.
+| If either original floating-point value is a signaling NaN, the invalid
+| exception is raised.
+*----------------------------------------------------------------------------*/
+struct uint128
+ softfloat_propagateNaNF128UI(
+     uint_fast64_t uiA64,
+     uint_fast64_t uiA0,
+     uint_fast64_t uiB64,
+     uint_fast64_t uiB0
+ );
+
+#else
+
+/*----------------------------------------------------------------------------
+| The following functions are needed only when 'SOFTFLOAT_FAST_INT64' is not
+| defined.
+*----------------------------------------------------------------------------*/
+
+/*----------------------------------------------------------------------------
+| Assuming the 80-bit extended floating-point value pointed to by 'aSPtr' is
+| a NaN, converts this NaN to the common NaN form, and stores the resulting
+| common NaN at the location pointed to by 'zPtr'.  If the NaN is a signaling
+| NaN, the invalid exception is raised.
+*----------------------------------------------------------------------------*/
+void
+ softfloat_extF80MToCommonNaN(
+     const struct extFloat80M *aSPtr, struct commonNaN *zPtr );
+
+/*----------------------------------------------------------------------------
+| Converts the common NaN pointed to by 'aPtr' into an 80-bit extended
+| floating-point NaN, and stores this NaN at the location pointed to by
+| 'zSPtr'.
+*----------------------------------------------------------------------------*/
+void
+ softfloat_commonNaNToExtF80M(
+     const struct commonNaN *aPtr, struct extFloat80M *zSPtr );
+
+/*----------------------------------------------------------------------------
+| Assuming at least one of the two 80-bit extended floating-point values
+| pointed to by 'aSPtr' and 'bSPtr' is a NaN, stores the combined NaN result
+| at the location pointed to by 'zSPtr'.  If either original floating-point
+| value is a signaling NaN, the invalid exception is raised.
+*----------------------------------------------------------------------------*/
+void
+ softfloat_propagateNaNExtF80M(
+     const struct extFloat80M *aSPtr,
+     const struct extFloat80M *bSPtr,
+     struct extFloat80M *zSPtr
+ );
+
+/*----------------------------------------------------------------------------
+| The bit pattern for a default generated 128-bit floating-point NaN.
+*----------------------------------------------------------------------------*/
+#define defaultNaNF128UI96 0xFFFF8000
+#define defaultNaNF128UI64 0
+#define defaultNaNF128UI32 0
+#define defaultNaNF128UI0  0
+
+/*----------------------------------------------------------------------------
+| Assuming the 128-bit floating-point value pointed to by 'aWPtr' is a NaN,
+| converts this NaN to the common NaN form, and stores the resulting common
+| NaN at the location pointed to by 'zPtr'.  If the NaN is a signaling NaN,
+| the invalid exception is raised.  Argument 'aWPtr' points to an array of
+| four 32-bit elements that concatenate in the platform's normal endian order
+| to form a 128-bit floating-point value.
+*----------------------------------------------------------------------------*/
+void
+ softfloat_f128MToCommonNaN( const uint32_t *aWPtr, struct commonNaN *zPtr );
+
+/*----------------------------------------------------------------------------
+| Converts the common NaN pointed to by 'aPtr' into a 128-bit floating-point
+| NaN, and stores this NaN at the location pointed to by 'zWPtr'.  Argument
+| 'zWPtr' points to an array of four 32-bit elements that concatenate in the
+| platform's normal endian order to form a 128-bit floating-point value.
+*----------------------------------------------------------------------------*/
+void
+ softfloat_commonNaNToF128M( const struct commonNaN *aPtr, uint32_t *zWPtr );
+
+/*----------------------------------------------------------------------------
+| Assuming at least one of the two 128-bit floating-point values pointed to by
+| 'aWPtr' and 'bWPtr' is a NaN, stores the combined NaN result at the location
+| pointed to by 'zWPtr'.  If either original floating-point value is a
+| signaling NaN, the invalid exception is raised.  Each of 'aWPtr', 'bWPtr',
+| and 'zWPtr' points to an array of four 32-bit elements that concatenate in
+| the platform's normal endian order to form a 128-bit floating-point value.
+*----------------------------------------------------------------------------*/
+void
+ softfloat_propagateNaNF128M(
+     const uint32_t *aWPtr, const uint32_t *bWPtr, uint32_t *zWPtr );
+
+#endif
+
+#endif
+

--- a/External/FEXCore/Source/Common/SoftFloat.h
+++ b/External/FEXCore/Source/Common/SoftFloat.h
@@ -1,0 +1,253 @@
+#pragma once
+#include "LogManager.h"
+
+#include <cmath>
+#include <cstring>
+#include <stdint.h>
+#include <string>
+#include <sstream>
+
+extern "C" {
+#include "SoftFloat-3e/platform.h"
+#include "SoftFloat-3e/softfloat.h"
+}
+
+struct X80SoftFloat {
+#ifdef _M_X86_64
+#define BIGFLOAT __float128
+#elif defined(_M_ARM_64)
+#define BIGFLOAT long double
+#else
+#error No 128bit float for this target!
+#endif
+  struct __attribute__((packed)) {
+    uint64_t Significand : 64;
+    uint16_t Exponent    : 15;
+    unsigned Sign        : 1;
+  };
+
+  X80SoftFloat() { memset(this, 0, sizeof(*this)); }
+  X80SoftFloat(unsigned _Sign, uint16_t _Exponent, uint64_t _Significand)
+    : Significand {_Significand}
+    , Exponent {_Exponent}
+    , Sign {_Sign}
+    {
+  }
+
+  std::string str() const {
+    std::ostringstream string;
+    string << std::hex << Sign;
+    string << "_" << Exponent;
+    string << "_" << (Significand >> 63);
+    string << "_" << (Significand & ((1ULL << 63) - 1));
+    return string.str();
+  }
+
+  // Ops
+  static X80SoftFloat FADD(X80SoftFloat const &lhs, X80SoftFloat const &rhs) {
+    return extF80_add(lhs, rhs);
+  }
+
+  static X80SoftFloat FSUB(X80SoftFloat const &lhs, X80SoftFloat const &rhs) {
+    return extF80_sub(lhs, rhs);
+  }
+
+  static X80SoftFloat FMUL(X80SoftFloat const &lhs, X80SoftFloat const &rhs) {
+    return extF80_mul(lhs, rhs);
+  }
+
+  static X80SoftFloat FDIV(X80SoftFloat const &lhs, X80SoftFloat const &rhs) {
+    return extF80_div(lhs, rhs);
+  }
+
+  static X80SoftFloat FREM(X80SoftFloat const &lhs, X80SoftFloat const &rhs) {
+    X80SoftFloat Rem = extF80_rem(lhs, rhs);
+    if (SignBit(Rem)) {
+      Rem = extF80_add(Rem, rhs);
+    }
+    else {
+      Rem.Sign = SignBit(lhs);
+    }
+
+    return Rem;
+  }
+
+  static X80SoftFloat FREM1(X80SoftFloat const &lhs, X80SoftFloat const &rhs) {
+    return extF80_rem(lhs, rhs);
+  }
+
+  static X80SoftFloat FRNDINT(X80SoftFloat const &lhs) {
+    return extF80_roundToInt(lhs, softfloat_round_near_even, false);
+  }
+
+  static X80SoftFloat FXTRACT_SIG(X80SoftFloat const &lhs) {
+    X80SoftFloat Tmp = lhs;
+    Tmp.Exponent = 0x3FFF;
+    Tmp.Sign = lhs.Sign;
+    return Tmp;
+  }
+
+  static X80SoftFloat FXTRACT_EXP(X80SoftFloat const &lhs) {
+    int32_t TrueExp = lhs.Exponent - ExponentBias;
+    return i32_to_extF80(TrueExp);
+  }
+
+  static void FCMP(X80SoftFloat const &lhs, X80SoftFloat const &rhs, bool *eq, bool *lt, bool *nan) {
+    *eq = extF80_eq(lhs, rhs);
+    *lt = extF80_lt(lhs, rhs);
+    *nan = IsNan(lhs) || IsNan(rhs);
+  }
+
+  static X80SoftFloat FSCALE(X80SoftFloat const &lhs, X80SoftFloat const &rhs) {
+    WARN_ONCE("x87: Application used FSCALE which may have accuracy problems");
+    X80SoftFloat Int = FRNDINT(rhs);
+    BIGFLOAT Src2_d = Int;
+    Src2_d = exp2l(Src2_d);
+    X80SoftFloat Src2_X80 = Src2_d;
+    X80SoftFloat Result = extF80_mul(lhs, Src2_X80);
+    return Result;
+  }
+
+  static X80SoftFloat F2XM1(X80SoftFloat const &lhs) {
+    WARN_ONCE("x87: Application used F2XM1 which may have accuracy problems");
+    BIGFLOAT Src1_d = lhs;
+    return exp2l(Src1_d) - 1.0;
+  }
+
+  static X80SoftFloat FYL2X(X80SoftFloat const &lhs, X80SoftFloat const &rhs) {
+    WARN_ONCE("x87: Application used FYL2X which may have accuracy problems");
+    BIGFLOAT Src1_d = lhs;
+    BIGFLOAT Src2_d = rhs;
+    BIGFLOAT Tmp = Src2_d * log2l(Src1_d);
+    return Tmp;
+  }
+
+  static X80SoftFloat FATAN(X80SoftFloat const &lhs, X80SoftFloat const &rhs) {
+    WARN_ONCE("x87: Application used FATAN which may have accuracy problems");
+    BIGFLOAT Src1_d = lhs;
+    BIGFLOAT Src2_d = rhs;
+    BIGFLOAT Tmp = atan2l(Src1_d, Src2_d);
+    return Tmp;
+  }
+
+  static X80SoftFloat FTAN(X80SoftFloat const &lhs) {
+    WARN_ONCE("x87: Application used FTAN which may have accuracy problems");
+    BIGFLOAT Src_d = lhs;
+    Src_d = tanl(Src_d);
+    return Src_d;
+  }
+
+  static X80SoftFloat FSIN(X80SoftFloat const &lhs) {
+    WARN_ONCE("x87: Application used FSIN which may have accuracy problems");
+    BIGFLOAT Src_d = lhs;
+    Src_d = sinl(Src_d);
+    return Src_d;
+  }
+
+  static X80SoftFloat FCOS(X80SoftFloat const &lhs) {
+    WARN_ONCE("x87: Application used FCOS which may have accuracy problems");
+    BIGFLOAT Src_d = lhs;
+    Src_d = cosl(Src_d);
+    return Src_d;
+  }
+
+  static X80SoftFloat FSQRT(X80SoftFloat const &lhs) {
+    return extF80_sqrt(lhs);
+  }
+
+  operator float() const {
+    float32_t Result = extF80_to_f32(*this);
+    return *(float*)&Result;
+  }
+
+  operator double() const {
+    float64_t Result = extF80_to_f64(*this);
+    return *(double*)&Result;
+  }
+
+  operator BIGFLOAT() const {
+    float128_t Result = extF80_to_f128(*this);
+    return *(BIGFLOAT*)&Result;
+  }
+
+  operator int16_t() const {
+    return extF80_to_i32(*this, softfloat_round_near_even, false);
+  }
+
+  operator int32_t() const {
+    return extF80_to_i32(*this, softfloat_round_near_even, false);
+  }
+
+  operator int64_t() const {
+    return extF80_to_i64(*this, softfloat_round_near_even, false);
+  }
+
+  void operator=(const float rhs) {
+    *this = f32_to_extF80(*(float32_t*)&rhs);
+  }
+
+  void operator=(const double rhs) {
+    *this = f64_to_extF80(*(float64_t*)&rhs);
+  }
+
+  void operator=(const int16_t rhs) {
+    *this = i32_to_extF80(rhs);
+  }
+
+  void operator=(const int32_t rhs) {
+    *this = i32_to_extF80(rhs);
+  }
+
+  operator void*() {
+    return reinterpret_cast<void*>(this);
+  }
+
+  X80SoftFloat(extFloat80_t rhs) {
+    memcpy(this, &rhs, sizeof(*this));
+  }
+
+  X80SoftFloat(const float rhs) {
+    *this = f32_to_extF80(*(float32_t*)&rhs);
+  }
+
+  X80SoftFloat(const double rhs) {
+    *this = f64_to_extF80(*(float64_t*)&rhs);
+  }
+
+  X80SoftFloat(BIGFLOAT rhs) {
+    *this = f128_to_extF80(*(float128_t*)&rhs);
+  }
+
+  X80SoftFloat(const int16_t rhs) {
+    *this = i32_to_extF80(rhs);
+  }
+
+  X80SoftFloat(const int32_t rhs) {
+    *this = i32_to_extF80(rhs);
+  }
+
+  void operator=(extFloat80_t rhs) {
+    memcpy(this, &rhs, sizeof(*this));
+  }
+
+  operator extFloat80_t() const {
+    return *(extFloat80_t*)this;
+  }
+
+  static bool IsNan(X80SoftFloat const &lhs) {
+    return (lhs.Exponent == 0x7FFF) &&
+      (lhs.Significand & IntegerBit) &&
+      (lhs.Significand & Bottom62Significand);
+  }
+
+  static bool SignBit(X80SoftFloat const &lhs) {
+    return lhs.Sign;
+  }
+
+private:
+  static constexpr uint64_t IntegerBit = (1ULL << 63);
+  static constexpr uint64_t Bottom62Significand = ((1ULL << 62) - 1);
+  static constexpr uint32_t ExponentBias = 16383;
+};
+
+static_assert(sizeof(X80SoftFloat) == 10, "tword must be 10bytes in size");


### PR DESCRIPTION
Comes from http://www.jhauser.us/arithmetic/SoftFloat.html which is under a permissive license that we can use.
Gets most of the x87 implementation out of the way.