### PR TITLE
Interpreter based x87 support!

### DIFF
--- a/External/FEXCore/Source/Common/SoftFloat.h
+++ b/External/FEXCore/Source/Common/SoftFloat.h
@@ -111,7 +111,9 @@ struct X80SoftFloat {
   static X80SoftFloat F2XM1(X80SoftFloat const &lhs) {
     WARN_ONCE("x87: Application used F2XM1 which may have accuracy problems");
     BIGFLOAT Src1_d = lhs;
-    return exp2l(Src1_d) - 1.0;
+    BIGFLOAT Result = exp2l(Src1_d);
+    Result -= 1.0;
+    return Result;
   }
 
   static X80SoftFloat FYL2X(X80SoftFloat const &lhs, X80SoftFloat const &rhs) {

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -288,11 +288,70 @@ public:
   // X87 Ops
   template<size_t width>
   void FLD(OpcodeArgs);
+  template<uint64_t Lower, uint32_t Upper>
+  void FLD_Const(OpcodeArgs);
+
+  template<size_t width>
+  void FILD(OpcodeArgs);
 
   template<size_t width, bool pop>
   void FST(OpcodeArgs);
 
+  template<bool pop>
+  void FST(OpcodeArgs);
+
+  template<size_t width, bool pop>
+  void FIST(OpcodeArgs);
+
+  enum class OpResult {
+    RES_ST0,
+    RES_STI,
+  };
+  template<size_t width, bool Integer, OpResult ResInST0>
   void FADD(OpcodeArgs);
+  template<size_t width, bool Integer, OpResult ResInST0>
+  void FMUL(OpcodeArgs);
+  template<size_t width, bool Integer, bool reverse, OpResult ResInST0>
+  void FDIV(OpcodeArgs);
+  template<size_t width, bool Integer, bool reverse, OpResult ResInST0>
+  void FSUB(OpcodeArgs);
+  void FCHS(OpcodeArgs);
+  void FABS(OpcodeArgs);
+  void FTST(OpcodeArgs);
+  void FRNDINT(OpcodeArgs);
+  void FXTRACT(OpcodeArgs);
+  void FNINIT(OpcodeArgs);
+
+  template<FEXCore::IR::IROps IROp>
+  void X87UnaryOp(OpcodeArgs);
+  template<FEXCore::IR::IROps IROp>
+  void X87BinaryOp(OpcodeArgs);
+  template<bool Inc>
+  void X87ModifySTP(OpcodeArgs);
+  void X87SinCos(OpcodeArgs);
+  template<bool Plus1>
+  void X87FYL2X(OpcodeArgs);
+  void X87TAN(OpcodeArgs);
+  void X87ATAN(OpcodeArgs);
+  void X87LDENV(OpcodeArgs);
+  void X87FNSTENV(OpcodeArgs);
+  void X87FSTCW(OpcodeArgs);
+  void X87LDSW(OpcodeArgs);
+  void X87FNSTSW(OpcodeArgs);
+  void X87FNSAVE(OpcodeArgs);
+  void X87FRSTOR(OpcodeArgs);
+  void X87FXAM(OpcodeArgs);
+  void X87FCMOV(OpcodeArgs);
+
+  void FXCH(OpcodeArgs);
+
+  enum class FCOMIFlags {
+    FLAGS_X87,
+    FLAGS_RFLAGS,
+  };
+  template<size_t width, bool Integer, FCOMIFlags whichflags, bool pop>
+  void FCOMI(OpcodeArgs);
+
   void FXSaveOp(OpcodeArgs);
   void FXRStoreOp(OpcodeArgs);
 

--- a/External/FEXCore/Source/Interface/Core/X86Tables/X87Tables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/X87Tables.cpp
@@ -8,14 +8,14 @@ void InitializeX87Tables() {
 #define OPDReg(op, reg) (((op - 0xD8) << 8) | (reg << 3))
   const U16U8InfoStruct X87OpTable[] = {
     // 0xD8
-    {OPDReg(0xD8, 0), 1, X86InstInfo{"FADD",  TYPE_X87, FLAGS_NONE, 0, nullptr}},
+    {OPDReg(0xD8, 0), 1, X86InstInfo{"FADD",  TYPE_X87, FLAGS_MODRM, 0, nullptr}},
     {OPDReg(0xD8, 1), 1, X86InstInfo{"FMUL",  TYPE_X87, FLAGS_MODRM, 0, nullptr}},
-    {OPDReg(0xD8, 2), 1, X86InstInfo{"FCOM",  TYPE_X87, FLAGS_NONE, 0, nullptr}},
-    {OPDReg(0xD8, 3), 1, X86InstInfo{"FCOMP", TYPE_X87, FLAGS_NONE, 0, nullptr}},
-    {OPDReg(0xD8, 4), 1, X86InstInfo{"FSUB",  TYPE_X87, FLAGS_NONE, 0, nullptr}},
-    {OPDReg(0xD8, 5), 1, X86InstInfo{"FSUBR", TYPE_X87, FLAGS_NONE, 0, nullptr}},
-    {OPDReg(0xD8, 6), 1, X86InstInfo{"FDIV",  TYPE_X87, FLAGS_NONE, 0, nullptr}},
-    {OPDReg(0xD8, 7), 1, X86InstInfo{"FDIVR", TYPE_X87, FLAGS_NONE, 0, nullptr}},
+    {OPDReg(0xD8, 2), 1, X86InstInfo{"FCOM",  TYPE_X87, FLAGS_MODRM, 0, nullptr}},
+    {OPDReg(0xD8, 3), 1, X86InstInfo{"FCOMP", TYPE_X87, FLAGS_MODRM | FLAGS_POP, 0, nullptr}},
+    {OPDReg(0xD8, 4), 1, X86InstInfo{"FSUB",  TYPE_X87, FLAGS_MODRM, 0, nullptr}},
+    {OPDReg(0xD8, 5), 1, X86InstInfo{"FSUBR", TYPE_X87, FLAGS_MODRM, 0, nullptr}},
+    {OPDReg(0xD8, 6), 1, X86InstInfo{"FDIV",  TYPE_X87, FLAGS_MODRM, 0, nullptr}},
+    {OPDReg(0xD8, 7), 1, X86InstInfo{"FDIVR", TYPE_X87, FLAGS_MODRM, 0, nullptr}},
       //  / 0
       {OPD(0xD8, 0xC0), 8, X86InstInfo{"FADD", TYPE_X87, FLAGS_NONE, 0, nullptr}},
       //  / 1
@@ -35,7 +35,7 @@ void InitializeX87Tables() {
     // 0xD9
     {OPDReg(0xD9, 0), 1, X86InstInfo{"FLD",     TYPE_INST, FLAGS_MODRM, 0, nullptr}},
     {OPDReg(0xD9, 1), 1, X86InstInfo{"",        TYPE_INVALID, FLAGS_NONE, 0, nullptr}},
-    {OPDReg(0xD9, 2), 1, X86InstInfo{"FST",     TYPE_X87, FLAGS_NONE, 0, nullptr}},
+    {OPDReg(0xD9, 2), 1, X86InstInfo{"FST",     TYPE_X87, FLAGS_MODRM | FLAGS_SF_MOD_DST, 0, nullptr}},
     {OPDReg(0xD9, 3), 1, X86InstInfo{"FSTP",    TYPE_X87, FLAGS_MODRM | FLAGS_SF_MOD_DST, 0, nullptr}},
     {OPDReg(0xD9, 4), 1, X86InstInfo{"FLDENV",  TYPE_X87, FLAGS_MODRM, 0, nullptr}},
     {OPDReg(0xD9, 5), 1, X86InstInfo{"FLDCW",   TYPE_X87, GenFlagsSameSize(SIZE_16BIT) | FLAGS_MODRM, 0, nullptr}},
@@ -73,8 +73,8 @@ void InitializeX87Tables() {
       {OPD(0xD9, 0xF3), 1, X86InstInfo{"FPATAN", TYPE_X87, FLAGS_NONE, 0, nullptr}},
       {OPD(0xD9, 0xF4), 1, X86InstInfo{"FXTRACT", TYPE_X87, FLAGS_NONE, 0, nullptr}},
       {OPD(0xD9, 0xF5), 1, X86InstInfo{"FPREM1", TYPE_X87, FLAGS_NONE, 0, nullptr}},
-      {OPD(0xD9, 0xF6), 1, X86InstInfo{"FDECSTP", TYPE_X87, FLAGS_NONE, 0, nullptr}},
-      {OPD(0xD9, 0xF7), 1, X86InstInfo{"FINCSTP", TYPE_X87, FLAGS_NONE, 0, nullptr}},
+      {OPD(0xD9, 0xF6), 1, X86InstInfo{"FDECSTP", TYPE_X87, FLAGS_POP, 0, nullptr}},
+      {OPD(0xD9, 0xF7), 1, X86InstInfo{"FINCSTP", TYPE_X87, FLAGS_POP, 0, nullptr}},
       //  / 7
       {OPD(0xD9, 0xF8), 1, X86InstInfo{"FPREM", TYPE_X87, FLAGS_NONE, 0, nullptr}},
       {OPD(0xD9, 0xF9), 1, X86InstInfo{"FYL2XP1", TYPE_X87, FLAGS_NONE, 0, nullptr}},
@@ -105,7 +105,7 @@ void InitializeX87Tables() {
       {OPD(0xDA, 0xE0), 8, X86InstInfo{"", TYPE_INVALID, FLAGS_NONE, 0, nullptr}},
       //  / 5
       {OPD(0xDA, 0xE8), 1, X86InstInfo{"", TYPE_INVALID, FLAGS_NONE, 0, nullptr}},
-      {OPD(0xDA, 0xE9), 1, X86InstInfo{"FUCOMPP", TYPE_X87, FLAGS_NONE, 0, nullptr}},
+      {OPD(0xDA, 0xE9), 1, X86InstInfo{"FUCOMPP", TYPE_X87, FLAGS_POP, 0, nullptr}},
       {OPD(0xDA, 0xEA), 6, X86InstInfo{"", TYPE_INVALID, FLAGS_NONE, 0, nullptr}},
       //  / 6
       {OPD(0xDA, 0xF0), 8, X86InstInfo{"", TYPE_INVALID, FLAGS_NONE, 0, nullptr}},
@@ -113,13 +113,13 @@ void InitializeX87Tables() {
       {OPD(0xDA, 0xF8), 8, X86InstInfo{"", TYPE_INVALID, FLAGS_NONE, 0, nullptr}},
     // 0xDB
     {OPDReg(0xDB, 0), 1, X86InstInfo{"FILD",   TYPE_X87,   FLAGS_MODRM, 0, nullptr}},
-    {OPDReg(0xDB, 1), 1, X86InstInfo{"FISTTP", TYPE_X87,   FLAGS_NONE, 0, nullptr}},
-    {OPDReg(0xDB, 2), 1, X86InstInfo{"FIST",   TYPE_X87,   FLAGS_NONE, 0, nullptr}},
-    {OPDReg(0xDB, 3), 1, X86InstInfo{"FISTP",  TYPE_X87,   FLAGS_NONE, 0, nullptr}},
+    {OPDReg(0xDB, 1), 1, X86InstInfo{"FISTTP", TYPE_X87,   FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_POP, 0, nullptr}},
+    {OPDReg(0xDB, 2), 1, X86InstInfo{"FIST",   TYPE_X87,   FLAGS_MODRM | FLAGS_SF_MOD_DST, 0, nullptr}},
+    {OPDReg(0xDB, 3), 1, X86InstInfo{"FISTP",  TYPE_X87,   FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_POP, 0, nullptr}},
     {OPDReg(0xDB, 4), 1, X86InstInfo{"",       TYPE_INVALID, FLAGS_NONE, 0, nullptr}},
     {OPDReg(0xDB, 5), 1, X86InstInfo{"FLD",    TYPE_X87,    FLAGS_MODRM, 0, nullptr}},
     {OPDReg(0xDB, 6), 1, X86InstInfo{"",       TYPE_INVALID, FLAGS_NONE, 0, nullptr}},
-    {OPDReg(0xDB, 7), 1, X86InstInfo{"FSTP",   TYPE_X87,   FLAGS_MODRM | FLAGS_SF_MOD_DST, 0, nullptr}},
+    {OPDReg(0xDB, 7), 1, X86InstInfo{"FSTP",   TYPE_X87,   FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_POP, 0, nullptr}},
       //  / 0
       {OPD(0xDB, 0xC0), 8, X86InstInfo{"FCMOVNB", TYPE_X87, FLAGS_NONE, 0, nullptr}},
       //  / 1
@@ -166,10 +166,10 @@ void InitializeX87Tables() {
       {OPD(0xDC, 0xF8), 8, X86InstInfo{"FDIV", TYPE_X87, FLAGS_NONE, 0, nullptr}},
     // 0xDD
     {OPDReg(0xDD, 0), 1, X86InstInfo{"FLD", TYPE_X87, FLAGS_MODRM, 0, nullptr}},
-    {OPDReg(0xDD, 1), 1, X86InstInfo{"FISTTP", TYPE_X87, FLAGS_NONE, 0, nullptr}},
-    {OPDReg(0xDD, 2), 1, X86InstInfo{"FST", TYPE_X87, FLAGS_NONE, 0, nullptr}},
-    {OPDReg(0xDD, 3), 1, X86InstInfo{"FSTP", TYPE_X87, FLAGS_MODRM | FLAGS_SF_MOD_DST, 0, nullptr}},
-    {OPDReg(0xDD, 4), 1, X86InstInfo{"FRSTOR", TYPE_X87, FLAGS_NONE, 0, nullptr}},
+    {OPDReg(0xDD, 1), 1, X86InstInfo{"FISTTP", TYPE_X87, FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_POP, 0, nullptr}},
+    {OPDReg(0xDD, 2), 1, X86InstInfo{"FST", TYPE_X87, FLAGS_MODRM | FLAGS_SF_MOD_DST, 0, nullptr}},
+    {OPDReg(0xDD, 3), 1, X86InstInfo{"FSTP", TYPE_X87, FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_POP, 0, nullptr}},
+    {OPDReg(0xDD, 4), 1, X86InstInfo{"FRSTOR", TYPE_X87, FLAGS_MODRM, 0, nullptr}},
     {OPDReg(0xDD, 5), 1, X86InstInfo{"", TYPE_INVALID, FLAGS_NONE, 0, nullptr}},
     {OPDReg(0xDD, 6), 1, X86InstInfo{"FNSAVE", TYPE_X87, FLAGS_MODRM | FLAGS_SF_MOD_DST, 0, nullptr}},
     {OPDReg(0xDD, 7), 1, X86InstInfo{"FNSTSW", TYPE_X87, GenFlagsSameSize(SIZE_16BIT) | FLAGS_MODRM | FLAGS_SF_MOD_DST, 0, nullptr}},
@@ -178,13 +178,13 @@ void InitializeX87Tables() {
       //  / 1
       {OPD(0xDD, 0xC8), 8, X86InstInfo{"", TYPE_INVALID, FLAGS_NONE, 0, nullptr}},
       //  / 2
-      {OPD(0xDD, 0xD0), 8, X86InstInfo{"FST", TYPE_INST, FLAGS_NONE, 0, nullptr}},
+      {OPD(0xDD, 0xD0), 8, X86InstInfo{"FST", TYPE_INST, FLAGS_SF_MOD_DST, 0, nullptr}},
       //  / 3
-      {OPD(0xDD, 0xD8), 8, X86InstInfo{"FSTP", TYPE_X87, FLAGS_NONE, 0, nullptr}},
+      {OPD(0xDD, 0xD8), 8, X86InstInfo{"FSTP", TYPE_X87, FLAGS_SF_MOD_DST | FLAGS_POP, 0, nullptr}},
       //  / 4
       {OPD(0xDD, 0xE0), 8, X86InstInfo{"FUCOM", TYPE_X87, FLAGS_NONE, 0, nullptr}},
       //  / 5
-      {OPD(0xDD, 0xE8), 8, X86InstInfo{"FUCOMP", TYPE_X87, FLAGS_NONE, 0, nullptr}},
+      {OPD(0xDD, 0xE8), 8, X86InstInfo{"FUCOMP", TYPE_X87, FLAGS_POP, 0, nullptr}},
       //  / 6
       {OPD(0xDD, 0xF0), 8, X86InstInfo{"", TYPE_INVALID, FLAGS_NONE, 0, nullptr}},
       //  / 7
@@ -206,25 +206,25 @@ void InitializeX87Tables() {
       {OPD(0xDE, 0xD0), 8, X86InstInfo{"", TYPE_INVALID, FLAGS_NONE, 0, nullptr}},
       //  / 3
       {OPD(0xDE, 0xD8), 1, X86InstInfo{"", TYPE_INVALID, FLAGS_NONE, 0, nullptr}},
-      {OPD(0xDE, 0xD9), 1, X86InstInfo{"FCOMPP", TYPE_X87, FLAGS_NONE, 0, nullptr}},
+      {OPD(0xDE, 0xD9), 1, X86InstInfo{"FCOMPP", TYPE_X87, FLAGS_POP, 0, nullptr}},
       {OPD(0xDE, 0xDA), 6, X86InstInfo{"", TYPE_INVALID, FLAGS_NONE, 0, nullptr}},
       //  / 4
-      {OPD(0xDE, 0xE0), 8, X86InstInfo{"FSUBRP", TYPE_X87, FLAGS_NONE, 0, nullptr}},
+      {OPD(0xDE, 0xE0), 8, X86InstInfo{"FSUBRP", TYPE_X87, FLAGS_POP, 0, nullptr}},
       //  / 5
-      {OPD(0xDE, 0xE8), 8, X86InstInfo{"FSUBP", TYPE_X87, FLAGS_NONE, 0, nullptr}},
+      {OPD(0xDE, 0xE8), 8, X86InstInfo{"FSUBP", TYPE_X87, FLAGS_POP, 0, nullptr}},
       //  / 6
-      {OPD(0xDE, 0xF0), 8, X86InstInfo{"FDIVRP", TYPE_X87, FLAGS_NONE, 0, nullptr}},
+      {OPD(0xDE, 0xF0), 8, X86InstInfo{"FDIVRP", TYPE_X87, FLAGS_POP, 0, nullptr}},
       //  / 7
-      {OPD(0xDE, 0xF8), 8, X86InstInfo{"FDIVP", TYPE_X87, FLAGS_NONE, 0, nullptr}},
+      {OPD(0xDE, 0xF8), 8, X86InstInfo{"FDIVP", TYPE_X87, FLAGS_POP, 0, nullptr}},
     // 0xDF
     {OPDReg(0xDF, 0), 1, X86InstInfo{"FILD", TYPE_X87, FLAGS_MODRM, 0, nullptr}},
-    {OPDReg(0xDF, 1), 1, X86InstInfo{"FISTTP", TYPE_X87, FLAGS_NONE, 0, nullptr}},
-    {OPDReg(0xDF, 2), 1, X86InstInfo{"FIST", TYPE_X87, FLAGS_NONE, 0, nullptr}},
-    {OPDReg(0xDF, 3), 1, X86InstInfo{"FISTP", TYPE_X87, FLAGS_NONE, 0, nullptr}},
-    {OPDReg(0xDF, 4), 1, X86InstInfo{"FBLD", TYPE_X87, FLAGS_NONE, 0, nullptr}},
+    {OPDReg(0xDF, 1), 1, X86InstInfo{"FISTTP", TYPE_X87, FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_POP, 0, nullptr}},
+    {OPDReg(0xDF, 2), 1, X86InstInfo{"FIST", TYPE_X87, FLAGS_MODRM | FLAGS_SF_MOD_DST, 0, nullptr}},
+    {OPDReg(0xDF, 3), 1, X86InstInfo{"FISTP", TYPE_X87, FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_POP, 0, nullptr}},
+    {OPDReg(0xDF, 4), 1, X86InstInfo{"FBLD", TYPE_X87, FLAGS_MODRM, 0, nullptr}},
     {OPDReg(0xDF, 5), 1, X86InstInfo{"FILD", TYPE_X87, FLAGS_MODRM, 0, nullptr}},
-    {OPDReg(0xDF, 6), 1, X86InstInfo{"FBSTP", TYPE_X87, FLAGS_NONE, 0, nullptr}},
-    {OPDReg(0xDF, 7), 1, X86InstInfo{"FISTP", TYPE_X87, FLAGS_NONE, 0, nullptr}},
+    {OPDReg(0xDF, 6), 1, X86InstInfo{"FBSTP", TYPE_X87, FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_POP, 0, nullptr}},
+    {OPDReg(0xDF, 7), 1, X86InstInfo{"FISTP", TYPE_X87, FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_POP, 0, nullptr}},
       //  / 0
       {OPD(0xDF, 0xC0), 8, X86InstInfo{"",        TYPE_INVALID, FLAGS_NONE, 0, nullptr}},
       //  / 1
@@ -237,9 +237,9 @@ void InitializeX87Tables() {
       {OPD(0xDF, 0xE0), 1, X86InstInfo{"FNSTSW",  TYPE_INST, GenFlagsSameSize(SIZE_16BIT) | FLAGS_SF_DST_RAX, 0, nullptr}},
       {OPD(0xDF, 0xE1), 7, X86InstInfo{"",        TYPE_INVALID, FLAGS_NONE, 0, nullptr}},
       //  / 5
-      {OPD(0xDF, 0xE8), 8, X86InstInfo{"FUCOMIP", TYPE_INST,    FLAGS_NONE, 0, nullptr}},
+      {OPD(0xDF, 0xE8), 8, X86InstInfo{"FUCOMIP", TYPE_INST,    FLAGS_POP, 0, nullptr}},
       //  / 6
-      {OPD(0xDF, 0xF0), 8, X86InstInfo{"FCOMIP",  TYPE_X87,   FLAGS_NONE, 0, nullptr}},
+      {OPD(0xDF, 0xF0), 8, X86InstInfo{"FCOMIP",  TYPE_X87,   FLAGS_POP, 0, nullptr}},
       //  / 7
       {OPD(0xDF, 0xF8), 8, X86InstInfo{"",        TYPE_INVALID, FLAGS_NONE, 0, nullptr}},
   };

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -514,6 +514,47 @@
       ]
     },
 
+    "VLoadMemElement": {
+      "OpClass": "Memory",
+      "HasDest": true,
+      "DestClass": "FPR",
+      "DestSize": "RegisterSize",
+      "NumElements": "RegisterSize / ElementSize",
+      "SSAArgs": "2",
+      "SSANames": [
+        "Addr",
+        "Value"
+      ],
+      "HelperArgs": [
+        "uint8_t", "RegisterSize",
+        "uint8_t", "ElementSize"
+      ],
+      "Args": [
+        "uint8_t", "Align",
+        "uint8_t", "Index"
+      ]
+    },
+
+    "VStoreMemElement": {
+      "HasSideEffects": true,
+      "OpClass": "Memory",
+      "SSAArgs": "2",
+      "DestSize": "ElementSize",
+      "NumElements": "RegisterSize / ElementSize",
+      "SSANames": [
+        "Addr",
+        "Value"
+      ],
+      "HelperArgs": [
+        "uint8_t", "RegisterSize",
+        "uint8_t", "ElementSize"
+      ],
+      "Args": [
+        "uint8_t", "Index",
+        "uint8_t", "Align"
+      ]
+    },
+
     "Add": {
       "Desc": [ "Integer Add"
               ],
@@ -1792,6 +1833,24 @@
       ]
     },
 
+    "VBSL": {
+      "Desc": ["Does a vector bitwise select.",
+               "If the bit in the field is 1 then the corresponding bit is pulled from VectorTrue",
+               "If the bit in the field is 0 then the corresponding bit is pulled from VectorFalse"
+              ],
+      "OpClass": "Vector",
+      "HasDest": true,
+      "DestClass": "FPR",
+      "DestSize": "16",
+      "NumElements": "1",
+      "SSAArgs": "3",
+      "SSANames": [
+        "VectorMask",
+        "VectorTrue",
+        "VectorFalse"
+      ]
+    },
+
     "VCMPEQ": {
       "OpClass": "Vector",
       "HasDest": true,
@@ -2719,6 +2778,297 @@
       ],
       "Args": [
         "uint8_t", "Flag"
+      ]
+    },
+
+    "F80Add": {
+      "OpClass": "Vector",
+      "HasDest": true,
+      "DestClass": "FPR",
+      "DestSize": "16",
+      "NumElements": "1",
+      "SSAArgs": "2",
+      "SSANames": [
+        "X80Src1",
+        "X80Src2"
+      ]
+    },
+
+    "F80Sub": {
+      "OpClass": "Vector",
+      "HasDest": true,
+      "DestClass": "FPR",
+      "DestSize": "16",
+      "NumElements": "1",
+      "SSAArgs": "2",
+      "SSANames": [
+        "X80Src1",
+        "X80Src2"
+      ]
+    },
+
+    "F80Mul": {
+      "OpClass": "Vector",
+      "HasDest": true,
+      "DestClass": "FPR",
+      "DestSize": "16",
+      "NumElements": "1",
+      "SSAArgs": "2",
+      "SSANames": [
+        "X80Src1",
+        "X80Src2"
+      ]
+    },
+
+    "F80Div": {
+      "OpClass": "Vector",
+      "HasDest": true,
+      "DestClass": "FPR",
+      "DestSize": "16",
+      "NumElements": "1",
+      "SSAArgs": "2",
+      "SSANames": [
+        "X80Src1",
+        "X80Src2"
+      ]
+    },
+
+    "F80ATAN": {
+      "OpClass": "Vector",
+      "HasDest": true,
+      "DestClass": "FPR",
+      "DestSize": "16",
+      "NumElements": "1",
+      "SSAArgs": "2",
+      "SSANames": [
+        "X80Src1",
+        "X80Src2"
+      ]
+    },
+
+    "F80FPREM": {
+      "OpClass": "Vector",
+      "HasDest": true,
+      "DestClass": "FPR",
+      "DestSize": "16",
+      "NumElements": "1",
+      "SSAArgs": "2",
+      "SSANames": [
+        "X80Src1",
+        "X80Src2"
+      ]
+    },
+
+    "F80FPREM1": {
+      "OpClass": "Vector",
+      "HasDest": true,
+      "DestClass": "FPR",
+      "DestSize": "16",
+      "NumElements": "1",
+      "SSAArgs": "2",
+      "SSANames": [
+        "X80Src1",
+        "X80Src2"
+      ]
+    },
+
+    "F80SCALE": {
+      "OpClass": "Vector",
+      "HasDest": true,
+      "DestClass": "FPR",
+      "DestSize": "16",
+      "NumElements": "1",
+      "SSAArgs": "2",
+      "SSANames": [
+        "X80Src1",
+        "X80Src2"
+      ]
+    },
+
+    "F80CVT": {
+      "OpClass": "Vector",
+      "HasDest": true,
+      "DestClass": "FPR",
+      "DestSize": "Size",
+      "NumElements": "1",
+      "SSAArgs": "1",
+      "SSANames": [
+        "X80Src"
+      ],
+      "HelperArgs": [
+        "uint8_t", "Size"
+      ]
+    },
+
+    "F80CVTInt": {
+      "OpClass": "Vector",
+      "HasDest": true,
+      "DestClass": "GPR",
+      "DestSize": "Size",
+      "NumElements": "1",
+      "SSAArgs": "1",
+      "SSANames": [
+        "X80Src"
+      ],
+      "HelperArgs": [
+        "uint8_t", "Size"
+      ]
+    },
+
+    "F80CVTTo": {
+      "OpClass": "Vector",
+      "HasDest": true,
+      "DestClass": "FPR",
+      "DestSize": "16",
+      "NumElements": "1",
+      "SSAArgs": "1",
+      "SSANames": [
+        "X80Src"
+      ],
+      "Args": [
+        "uint8_t", "Size"
+      ]
+    },
+
+    "F80CVTToInt": {
+      "OpClass": "Vector",
+      "HasDest": true,
+      "DestClass": "FPR",
+      "DestSize": "16",
+      "NumElements": "1",
+      "SSAArgs": "1",
+      "SSANames": [
+        "X80Src"
+      ],
+      "Args": [
+        "uint8_t", "Size"
+      ]
+    },
+
+    "F80Round": {
+      "OpClass": "Vector",
+      "HasDest": true,
+      "DestClass": "FPR",
+      "DestSize": "16",
+      "NumElements": "1",
+      "SSAArgs": "1",
+      "SSANames": [
+        "X80Src"
+      ]
+    },
+
+    "F80F2XM1": {
+      "OpClass": "Vector",
+      "HasDest": true,
+      "DestClass": "FPR",
+      "DestSize": "16",
+      "NumElements": "1",
+      "SSAArgs": "1",
+      "SSANames": [
+        "X80Src"
+      ]
+    },
+
+    "F80FYL2X": {
+      "OpClass": "Vector",
+      "HasDest": true,
+      "DestClass": "FPR",
+      "DestSize": "16",
+      "NumElements": "1",
+      "SSAArgs": "2",
+      "SSANames": [
+        "X80Src1",
+        "X80Src2"
+      ]
+    },
+
+    "F80TAN": {
+      "OpClass": "Vector",
+      "HasDest": true,
+      "DestClass": "FPR",
+      "DestSize": "16",
+      "NumElements": "1",
+      "SSAArgs": "1",
+      "SSANames": [
+        "X80Src"
+      ]
+    },
+
+    "F80SQRT": {
+      "OpClass": "Vector",
+      "HasDest": true,
+      "DestClass": "FPR",
+      "DestSize": "16",
+      "NumElements": "1",
+      "SSAArgs": "1",
+      "SSANames": [
+        "X80Src"
+      ]
+    },
+
+    "F80SIN": {
+      "OpClass": "Vector",
+      "HasDest": true,
+      "DestClass": "FPR",
+      "DestSize": "16",
+      "NumElements": "1",
+      "SSAArgs": "1",
+      "SSANames": [
+        "X80Src"
+      ]
+    },
+
+    "F80COS": {
+      "OpClass": "Vector",
+      "HasDest": true,
+      "DestClass": "FPR",
+      "DestSize": "16",
+      "NumElements": "1",
+      "SSAArgs": "1",
+      "SSANames": [
+        "X80Src"
+      ]
+    },
+
+    "F80XTRACT_EXP": {
+      "OpClass": "Vector",
+      "HasDest": true,
+      "DestClass": "FPR",
+      "DestSize": "16",
+      "NumElements": "1",
+      "SSAArgs": "1",
+      "SSANames": [
+        "X80Src"
+      ]
+    },
+
+    "F80XTRACT_SIG": {
+      "OpClass": "Vector",
+      "HasDest": true,
+      "DestClass": "FPR",
+      "DestSize": "16",
+      "NumElements": "1",
+      "SSAArgs": "1",
+      "SSANames": [
+        "X80Src"
+      ]
+    },
+
+    "F80Cmp": {
+      "Desc": ["Does a scalar unordered compare and stores the asked for flags in to a GPR",
+               "Ordering flag result is true if either float input is NaN"
+              ],
+      "OpClass": "ALU",
+      "HasDest": true,
+      "DestClass": "GPR",
+      "DestSize": "4",
+      "SSAArgs": "2",
+      "SSANames": [
+        "X80Src1",
+        "X80Src2"
+      ],
+      "Args": [
+        "uint32_t", "Flags"
       ]
     },
 

--- a/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
@@ -42,7 +42,7 @@ bool IRValidation::Run(IREmitter *IREmit) {
 
   OrderedNode *BlockNode = HeaderOp->Blocks.GetNode(ListBegin);
   IR::RegisterAllocationPass * RAPass{};
-  if (Manager->HasRAPass()) {
+  if (Manager->HasRAPass() && !HeaderOp->ShouldInterpret) {
     RAPass = Manager->GetRAPass();
   }
 

--- a/External/FEXCore/include/FEXCore/IR/IREmitter.h
+++ b/External/FEXCore/include/FEXCore/IR/IREmitter.h
@@ -64,14 +64,23 @@ friend class FEXCore::IR::PassManager;
   IRPair<IROp_Bfe> _Bfe(uint8_t Width, uint8_t lsb, OrderedNode *ssa0) {
     return _Bfe(ssa0, Width, lsb);
   }
+  IRPair<IROp_Sbfe> _Sbfe(uint8_t Width, uint8_t lsb, OrderedNode *ssa0) {
+    return _Sbfe(ssa0, Width, lsb);
+  }
   IRPair<IROp_Bfi> _Bfi(uint8_t Width, uint8_t lsb, OrderedNode *ssa0, OrderedNode *ssa1) {
     return _Bfi(ssa0, ssa1, Width, lsb);
   }
   IRPair<IROp_StoreMem> _StoreMem(FEXCore::IR::RegisterClassType Class, uint8_t Size, OrderedNode *ssa0, OrderedNode *ssa1, uint8_t Align = 1) {
     return _StoreMem(ssa0, ssa1, Size, Align, Class);
   }
+  IRPair<IROp_VStoreMemElement> _VStoreMemElement(uint8_t RegisterSize, uint8_t ElementSize, OrderedNode *ssa0, OrderedNode *ssa1, uint8_t Index, uint8_t Align = 1) {
+    return _VStoreMemElement(ssa0, ssa1, Index, Align, RegisterSize, ElementSize);
+  }
   IRPair<IROp_LoadMem> _LoadMem(FEXCore::IR::RegisterClassType Class, uint8_t Size, OrderedNode *ssa0, uint8_t Align = 1) {
     return _LoadMem(ssa0, Size, Align, Class);
+  }
+  IRPair<IROp_VLoadMemElement> _VLoadMemElement(uint8_t RegisterSize, uint8_t ElementSize, OrderedNode *ssa0, OrderedNode *ssa1, uint8_t Index, uint8_t Align = 1) {
+    return _VLoadMemElement(ssa0, ssa1, Index, Align, RegisterSize, ElementSize);
   }
   IRPair<IROp_Select> _Select(uint8_t Cond, OrderedNode *ssa0, OrderedNode *ssa1, OrderedNode *ssa2, OrderedNode *ssa3) {
     return _Select(ssa0, ssa1, ssa2, ssa3, {Cond});

--- a/Scripts/testharness_runner.py
+++ b/Scripts/testharness_runner.py
@@ -2,25 +2,35 @@
 import sys
 import subprocess
 
-# Args: <Known Failures file> <TestName> <Test Harness Executable> <Args>...
+# Args: <Known Failures file> <DisabledTestsFile> <TestName> <Test Harness Executable> <Args>...
 
-if (len(sys.argv) < 4):
+if (len(sys.argv) < 5):
     sys.exit()
 
 known_failures = {}
+disabled_tests = {}
 known_failures_file = sys.argv[1]
+disabled_tests_file = sys.argv[2]
 
-current_test = sys.argv[2]
+current_test = sys.argv[3]
 
 # Open the known failures file and add it to a dictionary
 with open(known_failures_file) as kff:
     for line in kff:
         known_failures[line.strip()] = 1
 
-RunnerArgs = ["catchsegv", sys.argv[3]]
+with open(disabled_tests_file) as dtf:
+    for line in dtf:
+        disabled_tests[line.strip()] = 1
+
+RunnerArgs = ["catchsegv", sys.argv[4]]
 # Add the rest of the arguments
-for i in range(len(sys.argv) - 4):
-    RunnerArgs.append(sys.argv[4 + i])
+for i in range(len(sys.argv) - 5):
+    RunnerArgs.append(sys.argv[5 + i])
+
+if (disabled_tests.get(current_test)):
+    print("Skipping", current_test)
+    sys.exit(0)
 
 # Run the test and wait for it to end to get the result
 Process = subprocess.Popen(RunnerArgs)

--- a/unittests/ASM/CMakeLists.txt
+++ b/unittests/ASM/CMakeLists.txt
@@ -55,6 +55,7 @@ foreach(ASM_SRC ${ASM_SOURCES})
     add_test(NAME ${TEST_NAME}
       COMMAND "python3" "${CMAKE_SOURCE_DIR}/Scripts/testharness_runner.py"
       "${CMAKE_SOURCE_DIR}/unittests/ASM/Known_Failures"
+      "${CMAKE_SOURCE_DIR}/unittests/ASM/Disabled_Tests"
       "Test_${ASM_NAME}"
       "${CMAKE_BINARY_DIR}/Bin/TestHarnessRunner"
       ${ARGS_LIST} "${OUTPUT_NAME}" "${OUTPUT_CONFIG_NAME}")

--- a/unittests/ASM/Disabled_Tests
+++ b/unittests/ASM/Disabled_Tests
@@ -1,0 +1,1 @@
+Test_D9_F2.asm

--- a/unittests/ASM/Known_Failures
+++ b/unittests/ASM/Known_Failures
@@ -1,4 +1,4 @@
 Test_14_XX_02.asm
 Test_0F_2E.asm
 Test_0F_2F.asm
-Test_fld.asm
+Test_D9_FD.asm

--- a/unittests/ASM/X87/D8_00.asm
+++ b/unittests/ASM/X87/D8_00.asm
@@ -1,0 +1,21 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM7":  ["0xc000000000000000", "0x4000"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov rax, 0x40000000 ; 2.0
+mov [rdx + 8 * 1], rax
+
+fld qword [rdx + 8 * 0]
+fadd dword [rdx + 8 * 1]
+hlt

--- a/unittests/ASM/X87/D8_01.asm
+++ b/unittests/ASM/X87/D8_01.asm
@@ -1,0 +1,21 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM7":  ["0x8000000000000000", "0x4000"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov rax, 0x40000000 ; 2.0
+mov [rdx + 8 * 1], rax
+
+fld qword [rdx + 8 * 0]
+fmul dword [rdx + 8 * 1]
+hlt

--- a/unittests/ASM/X87/D8_04.asm
+++ b/unittests/ASM/X87/D8_04.asm
@@ -1,0 +1,21 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM7":  ["0x8000000000000000", "0xBFFF"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov rax, 0x40000000 ; 2.0
+mov [rdx + 8 * 1], rax
+
+fld qword [rdx + 8 * 0]
+fsub dword [rdx + 8 * 1]
+hlt

--- a/unittests/ASM/X87/D8_05.asm
+++ b/unittests/ASM/X87/D8_05.asm
@@ -1,0 +1,21 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM7":  ["0x8000000000000000", "0x3FFF"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov rax, 0x40000000 ; 2.0
+mov [rdx + 8 * 1], rax
+
+fld qword [rdx + 8 * 0]
+fsubr dword [rdx + 8 * 1]
+hlt

--- a/unittests/ASM/X87/D8_06.asm
+++ b/unittests/ASM/X87/D8_06.asm
@@ -1,0 +1,21 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM7":  ["0x8000000000000000", "0x3FFE"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov rax, 0x40000000 ; 2.0
+mov [rdx + 8 * 1], rax
+
+fld qword [rdx + 8 * 0]
+fdiv dword [rdx + 8 * 1]
+hlt

--- a/unittests/ASM/X87/D8_07.asm
+++ b/unittests/ASM/X87/D8_07.asm
@@ -1,0 +1,21 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM7":  ["0x8000000000000000", "0x4000"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov rax, 0x40000000 ; 2.0
+mov [rdx + 8 * 1], rax
+
+fld qword [rdx + 8 * 0]
+fdivr dword [rdx + 8 * 1]
+hlt

--- a/unittests/ASM/X87/D8_C0.asm
+++ b/unittests/ASM/X87/D8_C0.asm
@@ -1,0 +1,26 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM6":  ["0xC000000000000000", "0x4000"],
+    "MM7":  ["0x8000000000000000", "0x3FFF"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov rax, 0x4000000000000000 ; 2.0
+mov [rdx + 8 * 1], rax
+
+fld qword [rdx + 8 * 0]
+fld qword [rdx + 8 * 1]
+
+; fadd st(0), st(i)
+fadd st0, st1
+
+hlt

--- a/unittests/ASM/X87/D8_C8.asm
+++ b/unittests/ASM/X87/D8_C8.asm
@@ -1,0 +1,19 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM7":  ["0x8000000000000000", "0x4001"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4000000000000000 ; 2.0
+mov [rdx + 8 * 0], rax
+
+fld qword [rdx + 8 * 0]
+fmul st0, st0
+hlt

--- a/unittests/ASM/X87/D8_E0.asm
+++ b/unittests/ASM/X87/D8_E0.asm
@@ -1,0 +1,23 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM6":  ["0x8000000000000000", "0xBFFF"],
+    "MM7":  ["0x8000000000000000", "0x4000"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4000000000000000 ; 2.0
+mov [rdx + 8 * 0], rax
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 1], rax
+
+fld qword [rdx + 8 * 0]
+fld qword [rdx + 8 * 1]
+fsub st0, st1
+hlt

--- a/unittests/ASM/X87/D8_E8.asm
+++ b/unittests/ASM/X87/D8_E8.asm
@@ -1,0 +1,23 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM6":  ["0x8000000000000000", "0x3FFF"],
+    "MM7":  ["0x8000000000000000", "0x4000"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4000000000000000 ; 2.0
+mov [rdx + 8 * 0], rax
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 1], rax
+
+fld qword [rdx + 8 * 0]
+fld qword [rdx + 8 * 1]
+fsubr st0, st1
+hlt

--- a/unittests/ASM/X87/D8_F0.asm
+++ b/unittests/ASM/X87/D8_F0.asm
@@ -1,0 +1,19 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM7":  ["0x8000000000000000", "0x3FFF"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4000000000000000 ; 2.0
+mov [rdx + 8 * 0], rax
+
+fld qword [rdx + 8 * 0]
+fdiv st0, st0
+hlt

--- a/unittests/ASM/X87/D8_F8.asm
+++ b/unittests/ASM/X87/D8_F8.asm
@@ -1,0 +1,24 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM6":  ["0x8000000000000000", "0x3FFE"],
+    "MM7":  ["0x8000000000000000", "0x4000"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4000000000000000 ; 2.0
+mov [rdx + 8 * 0], rax
+mov rax, 0x4010000000000000 ; 4.0
+mov [rdx + 8 * 1], rax
+
+fld qword [rdx + 8 * 0]
+fld qword [rdx + 8 * 1]
+
+fdivr st0, st1
+hlt

--- a/unittests/ASM/X87/D9_00.asm
+++ b/unittests/ASM/X87/D9_00.asm
@@ -1,0 +1,18 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM7":  ["0x8000000000000000", "0x3fff"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov eax, 0x3f800000 ; 1.0
+mov [rdx + 8 * 0], eax
+
+fld dword [rdx + 8 * 0]
+hlt

--- a/unittests/ASM/X87/D9_02.asm
+++ b/unittests/ASM/X87/D9_02.asm
@@ -1,0 +1,25 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x3F800000",
+    "MM7": ["0x8000000000000000", "0x3fff"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov eax, 0x3f800000 ; 1.0
+mov [rdx + 8 * 0], eax
+mov eax, 0x0
+mov [rdx + 8 * 1], eax
+
+fld dword [rdx + 8 * 0]
+fst dword [rdx + 8 * 1]
+
+mov eax, [rdx + 8 * 1]
+
+hlt

--- a/unittests/ASM/X87/D9_03.asm
+++ b/unittests/ASM/X87/D9_03.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x3F800000",
+    "MM7": ["0x8000000000000000", "0x4000"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov eax, 0x3f800000 ; 1.0
+mov [rdx + 8 * 0], eax
+mov eax, 0x40000000 ; 2.0
+mov [rdx + 8 * 1], eax
+mov eax, 0x0 ; 1.0
+mov [rdx + 8 * 2], eax
+
+fld dword [rdx + 8 * 0]
+fstp dword [rdx + 8 * 2]
+fld dword [rdx + 8 * 1]
+
+mov eax, [rdx + 8 * 2]
+
+hlt

--- a/unittests/ASM/X87/D9_05.asm
+++ b/unittests/ASM/X87/D9_05.asm
@@ -1,0 +1,10 @@
+%ifdef CONFIG
+{
+}
+%endif
+
+mov rdx, 0xe0000000
+; Just to ensure execution
+fldcw [rdx]
+
+hlt

--- a/unittests/ASM/X87/D9_06.asm
+++ b/unittests/ASM/X87/D9_06.asm
@@ -1,0 +1,51 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM5":  ["0x0000000000000000", "0x0000"],
+    "MM6":  ["0x8000000000000000", "0x4000"],
+    "MM7":  ["0x8000000000000000", "0x3fff"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov eax, 0x3f800000 ; 1.0
+mov [rdx + 8 * 0], eax
+mov eax, 0x40000000 ; 2.0
+mov [rdx + 8 * 1], eax
+mov eax, 0x40800000 ; 4.0
+mov [rdx + 8 * 2], eax
+
+fld dword [rdx + 8 * 0]
+o16 fstenv [rdx + 8 * 3]
+fld dword [rdx + 8 * 2]
+o16 fldenv [rdx + 8 * 3]
+
+; This will overwrite the previous load
+; This is since the control word is stored and reloaded
+fld dword [rdx + 8 * 1]
+
+; 14 bytes for 16bit
+; 2 Bytes : FCW
+; 2 Bytes : FSW
+; 2 bytes : FTW
+; 2 bytes : Instruction offset
+; 2 bytes : Instruction CS selector
+; 2 bytes : Data offset
+; 2 bytes : Data selector
+
+; 28 bytes for 32bit
+; 4 bytes : FCW
+; 4 bytes : FSW
+; 4 bytes : FTW
+; 4 bytes : Instruction pointer
+; 2 bytes : instruction pointer selector
+; 2 bytes : Opcode
+; 4 bytes : data pointer offset
+; 4 bytes : data pointer selector
+
+hlt

--- a/unittests/ASM/X87/D9_06_2.asm
+++ b/unittests/ASM/X87/D9_06_2.asm
@@ -1,0 +1,51 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM5":  ["0x0000000000000000", "0x0000"],
+    "MM6":  ["0x8000000000000000", "0x4000"],
+    "MM7":  ["0x8000000000000000", "0x3fff"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov eax, 0x3f800000 ; 1.0
+mov [rdx + 8 * 0], eax
+mov eax, 0x40000000 ; 2.0
+mov [rdx + 8 * 1], eax
+mov eax, 0x40800000 ; 4.0
+mov [rdx + 8 * 2], eax
+
+fld dword [rdx + 8 * 0]
+o32 fstenv [rdx + 8 * 3]
+fld dword [rdx + 8 * 2]
+o32 fldenv [rdx + 8 * 3]
+
+; This will overwrite the previous load
+; This is since the control word is stored and reloaded
+fld dword [rdx + 8 * 1]
+
+; 14 bytes for 16bit
+; 2 Bytes : FCW
+; 2 Bytes : FSW
+; 2 bytes : FTW
+; 2 bytes : Instruction offset
+; 2 bytes : Instruction CS selector
+; 2 bytes : Data offset
+; 2 bytes : Data selector
+
+; 28 bytes for 32bit
+; 4 bytes : FCW
+; 4 bytes : FSW
+; 4 bytes : FTW
+; 4 bytes : Instruction pointer
+; 2 bytes : instruction pointer selector
+; 2 bytes : Opcode
+; 4 bytes : data pointer offset
+; 4 bytes : data pointer selector
+
+hlt

--- a/unittests/ASM/X87/D9_07.asm
+++ b/unittests/ASM/X87/D9_07.asm
@@ -1,0 +1,17 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x37F"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+fnstcw [rdx]
+mov eax, 0
+mov ax, [rdx]
+
+hlt

--- a/unittests/ASM/X87/D9_C0.asm
+++ b/unittests/ASM/X87/D9_C0.asm
@@ -1,0 +1,30 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM5":  ["0x8000000000000000", "0x4000"],
+    "MM6":  ["0x8000000000000000", "0x4000"],
+    "MM7":  ["0x8000000000000000", "0x3FFF"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+lea rdx, [rel data2]
+fld tword [rdx + 8 * 0]
+
+fld st1
+
+hlt
+
+align 8
+data:
+  dt 1.0
+  dq 0
+data2:
+  dt 2.0
+  dq 0

--- a/unittests/ASM/X87/D9_C8.asm
+++ b/unittests/ASM/X87/D9_C8.asm
@@ -1,0 +1,25 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM6": ["0x8000000000000000", "0x3FFF"],
+    "MM7": ["0x8000000000000000", "0x4000"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov eax, 0x3f800000 ; 1.0
+mov [rdx + 8 * 0], eax
+mov eax, 0x40000000 ; 2.0
+mov [rdx + 8 * 1], eax
+
+fld dword [rdx + 8 * 0]
+fld dword [rdx + 8 * 1]
+
+fxch
+
+hlt

--- a/unittests/ASM/X87/D9_D0.asm
+++ b/unittests/ASM/X87/D9_D0.asm
@@ -1,0 +1,8 @@
+%ifdef CONFIG
+{
+}
+%endif
+
+; Just to ensure execution
+fnop
+hlt

--- a/unittests/ASM/X87/D9_E0.asm
+++ b/unittests/ASM/X87/D9_E0.asm
@@ -1,0 +1,29 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM6":  ["0x8000000000000000", "0x3FFF"],
+    "MM7":  ["0x8000000000000000", "0xC000"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+fchs
+
+lea rdx, [rel data2]
+fld tword [rdx + 8 * 0]
+fchs
+
+hlt
+
+align 8
+data:
+  dt 2.0
+  dq 0
+data2:
+  dt -1.0
+  dq 0

--- a/unittests/ASM/X87/D9_E1.asm
+++ b/unittests/ASM/X87/D9_E1.asm
@@ -1,0 +1,29 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM6":  ["0x8000000000000000", "0x3FFF"],
+    "MM7":  ["0x8000000000000000", "0x4000"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+fabs
+
+lea rdx, [rel data2]
+fld tword [rdx + 8 * 0]
+fabs
+
+hlt
+
+align 8
+data:
+  dt 2.0
+  dq 0
+data2:
+  dt -1.0
+  dq 0

--- a/unittests/ASM/X87/D9_E8.asm
+++ b/unittests/ASM/X87/D9_E8.asm
@@ -1,0 +1,11 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM7": ["0x8000000000000000", "0x3FFF"]
+  }
+}
+%endif
+
+fld1
+
+hlt

--- a/unittests/ASM/X87/D9_E9.asm
+++ b/unittests/ASM/X87/D9_E9.asm
@@ -1,0 +1,11 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM7": ["0xD49A784BCD1B8AFE", "0x4000"]
+  }
+}
+%endif
+
+fldl2t
+
+hlt

--- a/unittests/ASM/X87/D9_EA.asm
+++ b/unittests/ASM/X87/D9_EA.asm
@@ -1,0 +1,11 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM7": ["0xB8AA3B295C17F0BC", "0x3FFF"]
+  }
+}
+%endif
+
+fldl2e
+
+hlt

--- a/unittests/ASM/X87/D9_EB.asm
+++ b/unittests/ASM/X87/D9_EB.asm
@@ -1,0 +1,11 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM7": ["0xC90FDAA22168C235", "0x4000"]
+  }
+}
+%endif
+
+fldpi
+
+hlt

--- a/unittests/ASM/X87/D9_EC.asm
+++ b/unittests/ASM/X87/D9_EC.asm
@@ -1,0 +1,11 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM7": ["0x9A209A84FBCFF799", "0x3FFD"]
+  }
+}
+%endif
+
+fldlg2
+
+hlt

--- a/unittests/ASM/X87/D9_ED.asm
+++ b/unittests/ASM/X87/D9_ED.asm
@@ -1,0 +1,11 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM7": ["0xB17217F7D1CF79AC", "0x3FFE"]
+  }
+}
+%endif
+
+fldln2
+
+hlt

--- a/unittests/ASM/X87/D9_EE.asm
+++ b/unittests/ASM/X87/D9_EE.asm
@@ -1,0 +1,11 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM7": ["0", "0"]
+  }
+}
+%endif
+
+fldz
+
+hlt

--- a/unittests/ASM/X87/D9_F0.asm
+++ b/unittests/ASM/X87/D9_F0.asm
@@ -1,0 +1,21 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM7":  ["0xC000000000000000", "0x4000"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+f2xm1
+
+hlt
+
+align 8
+data:
+  dt 2.0
+  dq 0

--- a/unittests/ASM/X87/D9_F1.asm
+++ b/unittests/ASM/X87/D9_F1.asm
@@ -1,0 +1,31 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM6":  ["0x8000000000000000", "0x3FFF"],
+    "MM7":  ["0x8000000000000000", "0x4002"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+lea rdx, [rel data2]
+fld tword [rdx + 8 * 0]
+
+fyl2x
+fld1
+
+hlt
+
+align 8
+data:
+  dt 16.0
+  dq 0
+
+data2:
+  dt 2.0
+  dq 0

--- a/unittests/ASM/X87/D9_F2.asm
+++ b/unittests/ASM/X87/D9_F2.asm
@@ -1,0 +1,23 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM6":  ["0x8000000000000000", "0x3FFF"],
+    "MM7":  ["0xC75922E5F71D2DC6", "0x3FFF"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+fptan
+
+hlt
+
+align 8
+data:
+  dt 1.0
+  dq 0

--- a/unittests/ASM/X87/D9_F3.asm
+++ b/unittests/ASM/X87/D9_F3.asm
@@ -1,0 +1,30 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM6":  ["0x8000000000000000", "0x3FFF"],
+    "MM7":  ["0xC90FDAA22168C235", "0x3FFF"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+lea rdx, [rel data2]
+fld tword [rdx + 8 * 0]
+
+fpatan
+fld1
+
+hlt
+
+align 8
+data:
+  dt 7.0
+  dq 0
+data2:
+  dt 0.0
+  dq 0

--- a/unittests/ASM/X87/D9_F4.asm
+++ b/unittests/ASM/X87/D9_F4.asm
@@ -1,0 +1,23 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM6":  ["0xF000000000000000", "0xBFFF"],
+    "MM7":  ["0xC000000000000000", "0x4000"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+fxtract
+
+hlt
+
+align 8
+data:
+  dt -15.0
+  dq 0

--- a/unittests/ASM/X87/D9_F5.asm
+++ b/unittests/ASM/X87/D9_F5.asm
@@ -1,0 +1,29 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM6":  ["0xE666666666666668", "0xBFFE"],
+    "MM7":  ["0xC000000000000000", "0x4000"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+lea rdx, [rel data2]
+fld tword [rdx + 8 * 0]
+
+fprem1
+
+hlt
+
+align 8
+data:
+  dt 3.0
+  dq 0
+data2:
+  dt 5.1
+  dq 0

--- a/unittests/ASM/X87/D9_F6.asm
+++ b/unittests/ASM/X87/D9_F6.asm
@@ -1,0 +1,29 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM4":  ["0x8000000000000000", "0x4001"],
+    "MM5":  ["0x0000000000000000", "0x0000"],
+    "MM6":  ["0x8000000000000000", "0x4000"],
+    "MM7":  ["0x8000000000000000", "0x3FFF"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov rax, 0x4000000000000000 ; 2.0
+mov [rdx + 8 * 1], rax
+mov rax, 0x4010000000000000 ; 4.0
+mov [rdx + 8 * 2], rax
+
+fld qword [rdx + 8 * 0]
+fld qword [rdx + 8 * 1]
+fdecstp
+fld qword [rdx + 8 * 2]
+
+hlt

--- a/unittests/ASM/X87/D9_F7.asm
+++ b/unittests/ASM/X87/D9_F7.asm
@@ -1,0 +1,27 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM6":  ["0x8000000000000000", "0x4001"],
+    "MM7":  ["0x8000000000000000", "0x3FFF"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov rax, 0x4000000000000000 ; 2.0
+mov [rdx + 8 * 1], rax
+mov rax, 0x4010000000000000 ; 4.0
+mov [rdx + 8 * 2], rax
+
+fld qword [rdx + 8 * 0]
+fld qword [rdx + 8 * 1]
+fincstp
+fld qword [rdx + 8 * 2] ; Overwrites previous value
+
+hlt

--- a/unittests/ASM/X87/D9_F8.asm
+++ b/unittests/ASM/X87/D9_F8.asm
@@ -1,0 +1,29 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM6":  ["0x8666666666666666", "0x4000"],
+    "MM7":  ["0xC000000000000000", "0x4000"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+lea rdx, [rel data2]
+fld tword [rdx + 8 * 0]
+
+fprem
+
+hlt
+
+align 8
+data:
+  dt 3.0
+  dq 0
+data2:
+  dt 5.1
+  dq 0

--- a/unittests/ASM/X87/D9_F9.asm
+++ b/unittests/ASM/X87/D9_F9.asm
@@ -1,0 +1,31 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM6":  ["0x8000000000000000", "0x3FFF"],
+    "MM7":  ["0x8000000000000000", "0x4002"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+lea rdx, [rel data2]
+fld tword [rdx + 8 * 0]
+
+fyl2xp1
+fld1
+
+hlt
+
+align 8
+data:
+  dt 15.0
+  dq 0
+
+data2:
+  dt 2.0
+  dq 0

--- a/unittests/ASM/X87/D9_FA.asm
+++ b/unittests/ASM/X87/D9_FA.asm
@@ -1,0 +1,22 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM7":  ["0x8000000000000000", "0x4001"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+fsqrt
+
+hlt
+
+align 8
+data:
+  dt 16.0
+  dq 0

--- a/unittests/ASM/X87/D9_FB.asm
+++ b/unittests/ASM/X87/D9_FB.asm
@@ -1,0 +1,23 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM6":  ["0x8A51407DA8345C92", "0x3FFE"],
+    "MM7":  ["0xD76AA47848677021", "0x3FFE"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+fsincos
+
+hlt
+
+align 8
+data:
+  dt 1.0
+  dq 0

--- a/unittests/ASM/X87/D9_FC.asm
+++ b/unittests/ASM/X87/D9_FC.asm
@@ -1,0 +1,21 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM7": ["0x8000000000000000", "0x3fff"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov eax, 0x3f834241 ; 1.02546
+mov [rdx + 8 * 0], eax
+
+fld dword [rdx + 8 * 0]
+
+frndint
+
+hlt

--- a/unittests/ASM/X87/D9_FD.asm
+++ b/unittests/ASM/X87/D9_FD.asm
@@ -1,0 +1,30 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM6":  ["0x8000000000000000", "0x4006"],
+    "MM7":  ["0xB000000000000000", "0x4001"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+lea rdx, [rel data2]
+fld tword [rdx + 8 * 0]
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+fscale
+
+hlt
+
+align 8
+data:
+  dt 4.0
+  dq 0
+
+data2:
+  dt 5.5
+  dq 0

--- a/unittests/ASM/X87/D9_FE.asm
+++ b/unittests/ASM/X87/D9_FE.asm
@@ -1,0 +1,22 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM7":  ["0xD76AA47848677021", "0x3FFE"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+fsin
+
+hlt
+
+align 8
+data:
+  dt 1.0
+  dq 0

--- a/unittests/ASM/X87/D9_FF.asm
+++ b/unittests/ASM/X87/D9_FF.asm
@@ -1,0 +1,22 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM7":  ["0xD51132BA9B902522", "0xBFFD"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+fcos
+
+hlt
+
+align 8
+data:
+  dt 2.0
+  dq 0

--- a/unittests/ASM/X87/DA_00.asm
+++ b/unittests/ASM/X87/DA_00.asm
@@ -1,0 +1,21 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM7":  ["0xc000000000000000", "0x4000"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov eax, 2
+mov [rdx + 8 * 1], eax
+
+fld qword [rdx + 8 * 0]
+fiadd dword [rdx + 8 * 1]
+hlt

--- a/unittests/ASM/X87/DA_01.asm
+++ b/unittests/ASM/X87/DA_01.asm
@@ -1,0 +1,21 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM7":  ["0x8000000000000000", "0x4000"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov eax, 2
+mov [rdx + 8 * 1], eax
+
+fld qword [rdx + 8 * 0]
+fimul dword [rdx + 8 * 1]
+hlt

--- a/unittests/ASM/X87/DA_04.asm
+++ b/unittests/ASM/X87/DA_04.asm
@@ -1,0 +1,21 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM7":  ["0x8000000000000000", "0xBFFF"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov eax, 2
+mov [rdx + 8 * 1], eax
+
+fld qword [rdx + 8 * 0]
+fisub dword [rdx + 8 * 1]
+hlt

--- a/unittests/ASM/X87/DA_05.asm
+++ b/unittests/ASM/X87/DA_05.asm
@@ -1,0 +1,21 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM7":  ["0x8000000000000000", "0x3FFF"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov eax, 2
+mov [rdx + 8 * 1], eax
+
+fld qword [rdx + 8 * 0]
+fisubr dword [rdx + 8 * 1]
+hlt

--- a/unittests/ASM/X87/DA_06.asm
+++ b/unittests/ASM/X87/DA_06.asm
@@ -1,0 +1,21 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM7":  ["0x8000000000000000", "0x3FFE"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov eax, 2
+mov [rdx + 8 * 1], eax
+
+fld qword [rdx + 8 * 0]
+fidiv dword [rdx + 8 * 1]
+hlt

--- a/unittests/ASM/X87/DA_07.asm
+++ b/unittests/ASM/X87/DA_07.asm
@@ -1,0 +1,21 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM7":  ["0x8000000000000000", "0x4000"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov eax, 2
+mov [rdx + 8 * 1], eax
+
+fld qword [rdx + 8 * 0]
+fidivr dword [rdx + 8 * 1]
+hlt

--- a/unittests/ASM/X87/DA_C0.asm
+++ b/unittests/ASM/X87/DA_C0.asm
@@ -1,0 +1,31 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM5":  ["0x0000000000000000", "0x0000"],
+    "MM6":  ["0x8000000000000000", "0x3FFF"],
+    "MM7":  ["0x8000000000000000", "0x3FFF"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov eax, 0x3f800000 ; 1.0
+mov [rdx + 8 * 0], eax
+
+fld1
+fldz
+
+mov eax, 2
+cmp eax, 1
+
+fcmovb st0, st1
+
+fldz
+cmp eax, 3
+fcmovb st0, st2
+
+hlt

--- a/unittests/ASM/X87/DA_C8.asm
+++ b/unittests/ASM/X87/DA_C8.asm
@@ -1,0 +1,31 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM5":  ["0x0000000000000000", "0x0000"],
+    "MM6":  ["0x8000000000000000", "0x3FFF"],
+    "MM7":  ["0x8000000000000000", "0x3FFF"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov eax, 0x3f800000 ; 1.0
+mov [rdx + 8 * 0], eax
+
+fld1
+fldz
+
+mov eax, 1
+cmp eax, 1
+
+fcmove st0, st1
+
+fldz
+cmp eax, 0
+fcmove st0, st2
+
+hlt

--- a/unittests/ASM/X87/DA_D0.asm
+++ b/unittests/ASM/X87/DA_D0.asm
@@ -1,0 +1,31 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM5":  ["0x0000000000000000", "0x0000"],
+    "MM6":  ["0x8000000000000000", "0x3FFF"],
+    "MM7":  ["0x8000000000000000", "0x3FFF"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov eax, 0x3f800000 ; 1.0
+mov [rdx + 8 * 0], eax
+
+fld1
+fldz
+
+mov eax, 2
+cmp eax, 2
+
+fcmovbe st0, st1
+
+fldz
+cmp eax, 0
+fcmovbe st0, st2
+
+hlt

--- a/unittests/ASM/X87/DA_D8.asm
+++ b/unittests/ASM/X87/DA_D8.asm
@@ -1,0 +1,31 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM5":  ["0x8000000000000000", "0x3FFF"],
+    "MM6":  ["0x0000000000000000", "0x0000"],
+    "MM7":  ["0x8000000000000000", "0x3FFF"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov eax, 0x3f800000 ; 1.0
+mov [rdx + 8 * 0], eax
+
+fld1
+fldz
+
+mov eax, 0x0
+cmp eax, -1
+
+fcmovu st0, st1
+
+fldz
+cmp eax, 1
+fcmovu st0, st2
+
+hlt

--- a/unittests/ASM/X87/DB_00.asm
+++ b/unittests/ASM/X87/DB_00.asm
@@ -1,0 +1,19 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM7": ["0x8000000000000000", "0x4009"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov eax, 1024
+mov [rdx + 8 * 0], eax
+
+fild dword [rdx + 8 * 0]
+
+hlt

--- a/unittests/ASM/X87/DB_01.asm
+++ b/unittests/ASM/X87/DB_01.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x400",
+    "MM7": ["0x8000000000000000", "0x3FFF"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov eax, 0x44800000 ; 1024.0
+mov [rdx + 8 * 0], eax
+mov eax, 0
+mov [rdx + 8 * 1], eax
+
+fld dword [rdx + 8 * 0]
+
+fisttp dword [rdx + 8 * 1]
+
+fld1
+
+mov eax, [rdx + 8 * 1]
+
+hlt

--- a/unittests/ASM/X87/DB_02.asm
+++ b/unittests/ASM/X87/DB_02.asm
@@ -1,0 +1,29 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x400",
+    "MM6": ["0x8000000000000000", "0x3FFF"],
+    "MM7": ["0x8000000000000000", "0x4009"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov eax, 0x44800000 ; 1024.0
+mov [rdx + 8 * 0], eax
+mov eax, 0
+mov [rdx + 8 * 1], eax
+
+fld dword [rdx + 8 * 0]
+
+fist dword [rdx + 8 * 1]
+
+fld1
+
+mov eax, [rdx + 8 * 1]
+
+hlt

--- a/unittests/ASM/X87/DB_03.asm
+++ b/unittests/ASM/X87/DB_03.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x400",
+    "MM7": ["0x8000000000000000", "0x3FFF"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov eax, 0x44800000 ; 1024.0
+mov [rdx + 8 * 0], eax
+mov eax, 0
+mov [rdx + 8 * 1], eax
+
+fld dword [rdx + 8 * 0]
+
+fistp dword [rdx + 8 * 1]
+
+fld1
+
+mov eax, [rdx + 8 * 1]
+
+hlt

--- a/unittests/ASM/X87/DB_05.asm
+++ b/unittests/ASM/X87/DB_05.asm
@@ -1,0 +1,20 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM7":  ["0x8000000000000000", "0x4000"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+lea rdx, [rel data]
+
+fld tword [rdx + 8 * 0]
+hlt
+
+align 8
+data:
+  dt 2.0
+  dq 0

--- a/unittests/ASM/X87/DB_07.asm
+++ b/unittests/ASM/X87/DB_07.asm
@@ -1,0 +1,27 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM7":  ["0x8000000000000000", "0x4000"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+lea rdx, [rel data2]
+fstp tword [rdx + 8 * 0]
+fld tword [rdx + 8 * 0]
+
+hlt
+
+align 8
+data:
+  dt 2.0
+  dq 0
+data2:
+  dt 0.0
+  dq 0

--- a/unittests/ASM/X87/DB_C0.asm
+++ b/unittests/ASM/X87/DB_C0.asm
@@ -1,0 +1,31 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM5":  ["0x8000000000000000", "0x3FFF"],
+    "MM6":  ["0x0000000000000000", "0x0000"],
+    "MM7":  ["0x8000000000000000", "0x3FFF"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov eax, 0x3f800000 ; 1.0
+mov [rdx + 8 * 0], eax
+
+fld1
+fldz
+
+mov eax, 2
+cmp eax, 1
+
+fcmovnb st0, st1
+
+fldz
+cmp eax, 3
+fcmovnb st0, st2
+
+hlt

--- a/unittests/ASM/X87/DB_C8.asm
+++ b/unittests/ASM/X87/DB_C8.asm
@@ -1,0 +1,31 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM5":  ["0x8000000000000000", "0x3FFF"],
+    "MM6":  ["0x0000000000000000", "0x0000"],
+    "MM7":  ["0x8000000000000000", "0x3FFF"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov eax, 0x3f800000 ; 1.0
+mov [rdx + 8 * 0], eax
+
+fld1
+fldz
+
+mov eax, 1
+cmp eax, 1
+
+fcmovne st0, st1
+
+fldz
+cmp eax, 0
+fcmovne st0, st2
+
+hlt

--- a/unittests/ASM/X87/DB_D0.asm
+++ b/unittests/ASM/X87/DB_D0.asm
@@ -1,0 +1,31 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM5":  ["0x8000000000000000", "0x3FFF"],
+    "MM6":  ["0x0000000000000000", "0x0000"],
+    "MM7":  ["0x8000000000000000", "0x3FFF"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov eax, 0x3f800000 ; 1.0
+mov [rdx + 8 * 0], eax
+
+fld1
+fldz
+
+mov eax, 2
+cmp eax, 2
+
+fcmovnbe st0, st1
+
+fldz
+cmp eax, 0
+fcmovnbe st0, st2
+
+hlt

--- a/unittests/ASM/X87/DB_D8.asm
+++ b/unittests/ASM/X87/DB_D8.asm
@@ -1,0 +1,31 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM5":  ["0x0000000000000000", "0x0000"],
+    "MM6":  ["0x8000000000000000", "0x3FFF"],
+    "MM7":  ["0x8000000000000000", "0x3FFF"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov eax, 0x3f800000 ; 1.0
+mov [rdx + 8 * 0], eax
+
+fld1
+fldz
+
+mov eax, 0x0
+cmp eax, -1
+
+fcmovnu st0, st1
+
+fldz
+cmp eax, 1
+fcmovnu st0, st2
+
+hlt

--- a/unittests/ASM/X87/DC_00.asm
+++ b/unittests/ASM/X87/DC_00.asm
@@ -1,0 +1,25 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM7":  ["0xC000000000000000", "0x4000"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+lea rdx, [rel data2]
+fadd qword [rdx + 8 * 0]
+
+hlt
+
+align 8
+data:
+  dt 1.0
+  dq 0
+data2:
+  dq 2.0

--- a/unittests/ASM/X87/DC_01.asm
+++ b/unittests/ASM/X87/DC_01.asm
@@ -1,0 +1,25 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM7":  ["0x8000000000000000", "0x4000"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+lea rdx, [rel data2]
+fmul qword [rdx + 8 * 0]
+
+hlt
+
+align 8
+data:
+  dt 1.0
+  dq 0
+data2:
+  dq 2.0

--- a/unittests/ASM/X87/DC_04.asm
+++ b/unittests/ASM/X87/DC_04.asm
@@ -1,0 +1,25 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM7":  ["0x8000000000000000", "0xBFFF"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+lea rdx, [rel data2]
+fsub qword [rdx + 8 * 0]
+
+hlt
+
+align 8
+data:
+  dt 1.0
+  dq 0
+data2:
+  dq 2.0

--- a/unittests/ASM/X87/DC_05.asm
+++ b/unittests/ASM/X87/DC_05.asm
@@ -1,0 +1,25 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM7":  ["0x8000000000000000", "0x3FFF"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+lea rdx, [rel data2]
+fsubr qword [rdx + 8 * 0]
+
+hlt
+
+align 8
+data:
+  dt 1.0
+  dq 0
+data2:
+  dq 2.0

--- a/unittests/ASM/X87/DC_06.asm
+++ b/unittests/ASM/X87/DC_06.asm
@@ -1,0 +1,25 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM7":  ["0x8000000000000000", "0x3FFE"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+lea rdx, [rel data2]
+fdiv qword [rdx + 8 * 0]
+
+hlt
+
+align 8
+data:
+  dt 1.0
+  dq 0
+data2:
+  dq 2.0

--- a/unittests/ASM/X87/DC_07.asm
+++ b/unittests/ASM/X87/DC_07.asm
@@ -1,0 +1,25 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM7":  ["0x8000000000000000", "0x4001"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+lea rdx, [rel data2]
+fdivr qword [rdx + 8 * 0]
+
+hlt
+
+align 8
+data:
+  dt 2.0
+  dq 0
+data2:
+  dq 8.0

--- a/unittests/ASM/X87/DC_C0.asm
+++ b/unittests/ASM/X87/DC_C0.asm
@@ -1,0 +1,30 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM5":  ["0x8000000000000000", "0x4001"],
+    "MM6":  ["0x8000000000000000", "0x4000"],
+    "MM7":  ["0xA000000000000000", "0x4001"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov rax, 0x4000000000000000 ; 2.0
+mov [rdx + 8 * 1], rax
+mov rax, 0x4010000000000000 ; 4.0
+mov [rdx + 8 * 2], rax
+
+fld qword [rdx + 8 * 0]
+fld qword [rdx + 8 * 1]
+fld qword [rdx + 8 * 2]
+
+; fadd st(i), st(0)
+fadd st2, st0
+
+hlt

--- a/unittests/ASM/X87/DC_C8.asm
+++ b/unittests/ASM/X87/DC_C8.asm
@@ -1,0 +1,29 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM6":  ["0x8000000000000000", "0x4001"],
+    "MM7":  ["0x8000000000000000", "0x4002"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+lea rdx, [rel data2]
+fld tword [rdx + 8 * 0]
+
+fmul st1, st0
+
+hlt
+
+align 8
+data:
+  dt 2.0
+  dq 0
+data2:
+  dt 4.0
+  dq 0

--- a/unittests/ASM/X87/DC_E0.asm
+++ b/unittests/ASM/X87/DC_E0.asm
@@ -1,0 +1,29 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM6":  ["0x8000000000000000", "0x4000"],
+    "MM7":  ["0x8000000000000000", "0x3FFF"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+lea rdx, [rel data2]
+fld tword [rdx + 8 * 0]
+
+fsubr st1, st0
+
+hlt
+
+align 8
+data:
+  dt 1.0
+  dq 0
+data2:
+  dt 2.0
+  dq 0

--- a/unittests/ASM/X87/DC_E8.asm
+++ b/unittests/ASM/X87/DC_E8.asm
@@ -1,0 +1,29 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM6":  ["0x8000000000000000", "0x4000"],
+    "MM7":  ["0x8000000000000000", "0xBFFF"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+lea rdx, [rel data2]
+fld tword [rdx + 8 * 0]
+
+fsub st1, st0
+
+hlt
+
+align 8
+data:
+  dt 1.0
+  dq 0
+data2:
+  dt 2.0
+  dq 0

--- a/unittests/ASM/X87/DC_F0.asm
+++ b/unittests/ASM/X87/DC_F0.asm
@@ -1,0 +1,29 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM6":  ["0x8000000000000000", "0x3FFF"],
+    "MM7":  ["0x8000000000000000", "0x3FFE"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+lea rdx, [rel data2]
+fld tword [rdx + 8 * 0]
+
+fdivr st1, st0
+
+hlt
+
+align 8
+data:
+  dt 2.0
+  dq 0
+data2:
+  dt 1.0
+  dq 0

--- a/unittests/ASM/X87/DC_F8.asm
+++ b/unittests/ASM/X87/DC_F8.asm
@@ -1,0 +1,29 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM6":  ["0x8000000000000000", "0x4000"],
+    "MM7":  ["0x8000000000000000", "0x4001"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+lea rdx, [rel data2]
+fld tword [rdx + 8 * 0]
+
+fdiv st1, st0
+
+hlt
+
+align 8
+data:
+  dt 8.0
+  dq 0
+data2:
+  dt 2.0
+  dq 0

--- a/unittests/ASM/X87/DD_00.asm
+++ b/unittests/ASM/X87/DD_00.asm
@@ -1,0 +1,18 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM7":  ["0x8000000000000000", "0x4000"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4000000000000000 ; 2.0
+mov [rdx + 8 * 0], rax
+
+fld qword [rdx + 8 * 0]
+hlt

--- a/unittests/ASM/X87/DD_01.asm
+++ b/unittests/ASM/X87/DD_01.asm
@@ -1,0 +1,35 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x2",
+    "MM7": ["0x8000000000000000", "0x3FFF"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+lea rdx, [rel data3]
+fisttp qword [rdx + 8 * 0]
+
+mov rax, [rdx + 8 * 0]
+
+lea rdx, [rel data2]
+fld tword [rdx + 8 * 0]
+
+hlt
+
+align 8
+data:
+  dt 2.0
+  dq 0
+data2:
+  dt 1.0
+  dq 0
+data3:
+  dq 0
+  dq 0

--- a/unittests/ASM/X87/DD_02.asm
+++ b/unittests/ASM/X87/DD_02.asm
@@ -1,0 +1,36 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x4000000000000000",
+    "MM6": ["0x8000000000000000", "0x3FFF"],
+    "MM7": ["0x8000000000000000", "0x4000"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+lea rdx, [rel data3]
+fst qword [rdx + 8 * 0]
+
+mov rax, [rdx + 8 * 0]
+
+lea rdx, [rel data2]
+fld tword [rdx + 8 * 0]
+
+hlt
+
+align 8
+data:
+  dt 2.0
+  dq 0
+data2:
+  dt 1.0
+  dq 0
+data3:
+  dq 0
+  dq 0

--- a/unittests/ASM/X87/DD_03.asm
+++ b/unittests/ASM/X87/DD_03.asm
@@ -1,0 +1,35 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x4000000000000000",
+    "MM7": ["0x8000000000000000", "0x3FFF"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+lea rdx, [rel data3]
+fstp qword [rdx + 8 * 0]
+
+mov rax, [rdx + 8 * 0]
+
+lea rdx, [rel data2]
+fld tword [rdx + 8 * 0]
+
+hlt
+
+align 8
+data:
+  dt 2.0
+  dq 0
+data2:
+  dt 1.0
+  dq 0
+data3:
+  dq 0
+  dq 0

--- a/unittests/ASM/X87/DD_04.asm
+++ b/unittests/ASM/X87/DD_04.asm
@@ -1,0 +1,97 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "XMM0": ["0xc90fdaa22168c235", "0x4000"],
+    "XMM1": ["0x8000000000000000", "0x4005"],
+    "XMM2": ["0x8000000000000000", "0x4004"],
+    "XMM3": ["0x8000000000000000", "0x4003"],
+    "XMM4": ["0x8000000000000000", "0x4002"],
+    "XMM5": ["0x8000000000000000", "0x4001"],
+    "XMM6": ["0x8000000000000000", "0x4000"],
+    "XMM7": ["0x0000000000000000", "0x0000"],
+    "MM0":  ["0xc90fdaa22168c235", "0x4000"],
+    "MM1":  ["0x8000000000000000", "0x4005"],
+    "MM2":  ["0x8000000000000000", "0x4004"],
+    "MM3":  ["0x8000000000000000", "0x4003"],
+    "MM4":  ["0x8000000000000000", "0x4002"],
+    "MM5":  ["0x8000000000000000", "0x4001"],
+    "MM6":  ["0x8000000000000000", "0x4000"],
+    "MM7":  ["0x0000000000000000", "0x0000"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 2
+mov [rdx + 2 * 1], rax
+mov rax, 4
+mov [rdx + 2 * 2], rax
+mov rax, 8
+mov [rdx + 2 * 3], rax
+mov rax, 16
+mov [rdx + 2 * 4], rax
+mov rax, 32
+mov [rdx + 2 * 5], rax
+mov rax, 64
+mov [rdx + 2 * 6], rax
+
+fldz
+fild word [rdx + 2 * 1]
+fild word [rdx + 2 * 2]
+fild word [rdx + 2 * 3]
+fild word [rdx + 2 * 4]
+fild word [rdx + 2 * 5]
+fild word [rdx + 2 * 6]
+fldpi
+
+o32 fnsave [rdx]
+
+fldpi
+fldpi
+fldpi
+fldpi
+fldpi
+fldpi
+fldpi
+fldpi
+
+o32 frstor [rdx]
+
+movups xmm0, [rdx + (0x1C + 10 * 0)]
+movups xmm1, [rdx + (0x1C + 10 * 1)]
+movups xmm2, [rdx + (0x1C + 10 * 2)]
+movups xmm3, [rdx + (0x1C + 10 * 3)]
+movups xmm4, [rdx + (0x1C + 10 * 4)]
+movups xmm5, [rdx + (0x1C + 10 * 5)]
+movups xmm6, [rdx + (0x1C + 10 * 6)]
+movups xmm7, [rdx + (0x1C + 10 * 7)]
+
+pslldq xmm0, 6
+psrldq xmm0, 6
+
+pslldq xmm1, 6
+psrldq xmm1, 6
+
+pslldq xmm2, 6
+psrldq xmm2, 6
+
+pslldq xmm3, 6
+psrldq xmm3, 6
+
+pslldq xmm4, 6
+psrldq xmm4, 6
+
+pslldq xmm5, 6
+psrldq xmm5, 6
+
+pslldq xmm6, 6
+psrldq xmm6, 6
+
+pslldq xmm7, 6
+psrldq xmm7, 6
+
+hlt

--- a/unittests/ASM/X87/DD_04_2.asm
+++ b/unittests/ASM/X87/DD_04_2.asm
@@ -1,0 +1,97 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "XMM0": ["0xc90fdaa22168c235", "0x4000"],
+    "XMM1": ["0x8000000000000000", "0x4005"],
+    "XMM2": ["0x8000000000000000", "0x4004"],
+    "XMM3": ["0x8000000000000000", "0x4003"],
+    "XMM4": ["0x8000000000000000", "0x4002"],
+    "XMM5": ["0x8000000000000000", "0x4001"],
+    "XMM6": ["0x8000000000000000", "0x4000"],
+    "XMM7": ["0x0000000000000000", "0x0000"],
+    "MM0":  ["0xc90fdaa22168c235", "0x4000"],
+    "MM1":  ["0x8000000000000000", "0x4005"],
+    "MM2":  ["0x8000000000000000", "0x4004"],
+    "MM3":  ["0x8000000000000000", "0x4003"],
+    "MM4":  ["0x8000000000000000", "0x4002"],
+    "MM5":  ["0x8000000000000000", "0x4001"],
+    "MM6":  ["0x8000000000000000", "0x4000"],
+    "MM7":  ["0x0000000000000000", "0x0000"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 2
+mov [rdx + 2 * 1], rax
+mov rax, 4
+mov [rdx + 2 * 2], rax
+mov rax, 8
+mov [rdx + 2 * 3], rax
+mov rax, 16
+mov [rdx + 2 * 4], rax
+mov rax, 32
+mov [rdx + 2 * 5], rax
+mov rax, 64
+mov [rdx + 2 * 6], rax
+
+fldz
+fild word [rdx + 2 * 1]
+fild word [rdx + 2 * 2]
+fild word [rdx + 2 * 3]
+fild word [rdx + 2 * 4]
+fild word [rdx + 2 * 5]
+fild word [rdx + 2 * 6]
+fldpi
+
+o16 fnsave [rdx]
+
+fldpi
+fldpi
+fldpi
+fldpi
+fldpi
+fldpi
+fldpi
+fldpi
+
+o16 frstor [rdx]
+
+movups xmm0, [rdx + (0xE + 10 * 0)]
+movups xmm1, [rdx + (0xE + 10 * 1)]
+movups xmm2, [rdx + (0xE + 10 * 2)]
+movups xmm3, [rdx + (0xE + 10 * 3)]
+movups xmm4, [rdx + (0xE + 10 * 4)]
+movups xmm5, [rdx + (0xE + 10 * 5)]
+movups xmm6, [rdx + (0xE + 10 * 6)]
+movups xmm7, [rdx + (0xE + 10 * 7)]
+
+pslldq xmm0, 6
+psrldq xmm0, 6
+
+pslldq xmm1, 6
+psrldq xmm1, 6
+
+pslldq xmm2, 6
+psrldq xmm2, 6
+
+pslldq xmm3, 6
+psrldq xmm3, 6
+
+pslldq xmm4, 6
+psrldq xmm4, 6
+
+pslldq xmm5, 6
+psrldq xmm5, 6
+
+pslldq xmm6, 6
+psrldq xmm6, 6
+
+pslldq xmm7, 6
+psrldq xmm7, 6
+
+hlt

--- a/unittests/ASM/X87/DD_07.asm
+++ b/unittests/ASM/X87/DD_07.asm
@@ -1,0 +1,27 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0xFFFFFFFFFFFF3800",
+    "RBX": "0xFFFFFFFFFFFF0000"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov eax, 0x3f800000 ; 1.0
+mov [rdx + 8 * 0], eax
+
+mov rax, -1
+mov rbx, -1
+fnstsw [rdx + 8 * 1]
+
+fld dword [rdx + 8 * 0]
+fnstsw [rdx + 8 * 2]
+mov ax, word [rdx + 8 * 2]
+mov bx, word [rdx + 8 * 1]
+
+hlt

--- a/unittests/ASM/X87/DD_C0.asm
+++ b/unittests/ASM/X87/DD_C0.asm
@@ -1,0 +1,15 @@
+%ifdef CONFIG
+{
+}
+%endif
+
+; Just to ensure execution
+ffree st0
+ffree st1
+ffree st2
+ffree st3
+ffree st4
+ffree st5
+ffree st6
+ffree st7
+hlt

--- a/unittests/ASM/X87/DD_D0.asm
+++ b/unittests/ASM/X87/DD_D0.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM6": ["0x8000000000000000", "0x3FFF"],
+    "MM7": ["0x8000000000000000", "0x3FFF"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+lea rdx, [rel data2]
+fld tword [rdx + 8 * 0]
+fst st1
+
+hlt
+
+align 8
+data:
+  dt 2.0
+  dq 0
+data2:
+  dt 1.0
+  dq 0

--- a/unittests/ASM/X87/DD_D8.asm
+++ b/unittests/ASM/X87/DD_D8.asm
@@ -1,0 +1,35 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM6": ["0x8000000000000000", "0x4001"],
+    "MM7": ["0x8000000000000000", "0x3FFF"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+lea rdx, [rel data2]
+fld tword [rdx + 8 * 0]
+fstp st1
+
+lea rdx, [rel data3]
+fld tword [rdx + 8 * 0]
+
+hlt
+
+align 8
+data:
+  dt 2.0
+  dq 0
+data2:
+  dt 1.0
+  dq 0
+data3:
+  dt 4.0
+  dq 0
+

--- a/unittests/ASM/X87/DE_00.asm
+++ b/unittests/ASM/X87/DE_00.asm
@@ -1,0 +1,21 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM7":  ["0xc000000000000000", "0x4000"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov ax, 2
+mov [rdx + 8 * 1], ax
+
+fld qword [rdx + 8 * 0]
+fiadd word [rdx + 8 * 1]
+hlt

--- a/unittests/ASM/X87/DE_01.asm
+++ b/unittests/ASM/X87/DE_01.asm
@@ -1,0 +1,21 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM7":  ["0x8000000000000000", "0x4000"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov ax, 2
+mov [rdx + 8 * 1], ax
+
+fld qword [rdx + 8 * 0]
+fimul word [rdx + 8 * 1]
+hlt

--- a/unittests/ASM/X87/DE_04.asm
+++ b/unittests/ASM/X87/DE_04.asm
@@ -1,0 +1,21 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM7":  ["0x8000000000000000", "0xBFFF"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov ax, 2
+mov [rdx + 8 * 1], ax
+
+fld qword [rdx + 8 * 0]
+fisub word [rdx + 8 * 1]
+hlt

--- a/unittests/ASM/X87/DE_05.asm
+++ b/unittests/ASM/X87/DE_05.asm
@@ -1,0 +1,21 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM7":  ["0x8000000000000000", "0x3FFF"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov ax, 2
+mov [rdx + 8 * 1], ax
+
+fld qword [rdx + 8 * 0]
+fisubr word [rdx + 8 * 1]
+hlt

--- a/unittests/ASM/X87/DE_06.asm
+++ b/unittests/ASM/X87/DE_06.asm
@@ -1,0 +1,21 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM7":  ["0x8000000000000000", "0x3FFE"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov ax, 2
+mov [rdx + 8 * 1], ax
+
+fld qword [rdx + 8 * 0]
+fidiv word [rdx + 8 * 1]
+hlt

--- a/unittests/ASM/X87/DE_07.asm
+++ b/unittests/ASM/X87/DE_07.asm
@@ -1,0 +1,21 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM7":  ["0x8000000000000000", "0x4000"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov ax, 2
+mov [rdx + 8 * 1], ax
+
+fld qword [rdx + 8 * 0]
+fidivr word [rdx + 8 * 1]
+hlt

--- a/unittests/ASM/X87/DE_C0.asm
+++ b/unittests/ASM/X87/DE_C0.asm
@@ -1,0 +1,35 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM6": ["0x8000000000000000", "0x4001"],
+    "MM7": ["0xC000000000000000", "0x4000"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+lea rdx, [rel data2]
+fld tword [rdx + 8 * 0]
+faddp st1, st0
+
+lea rdx, [rel data3]
+fld tword [rdx + 8 * 0]
+
+hlt
+
+align 8
+data:
+  dt 2.0
+  dq 0
+data2:
+  dt 1.0
+  dq 0
+data3:
+  dt 4.0
+  dq 0
+

--- a/unittests/ASM/X87/DE_C8.asm
+++ b/unittests/ASM/X87/DE_C8.asm
@@ -1,0 +1,34 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM6": ["0x8000000000000000", "0x4001"],
+    "MM7": ["0x8000000000000000", "0x4002"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+lea rdx, [rel data2]
+fld tword [rdx + 8 * 0]
+fmulp st1, st0
+
+lea rdx, [rel data3]
+fld tword [rdx + 8 * 0]
+
+hlt
+
+align 8
+data:
+  dt 2.0
+  dq 0
+data2:
+  dt 4.0
+  dq 0
+data3:
+  dt 4.0
+  dq 0

--- a/unittests/ASM/X87/DE_E0.asm
+++ b/unittests/ASM/X87/DE_E0.asm
@@ -1,0 +1,34 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM6": ["0x8000000000000000", "0x4001"],
+    "MM7": ["0x8000000000000000", "0x4000"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+lea rdx, [rel data2]
+fld tword [rdx + 8 * 0]
+fsubrp st1, st0
+
+lea rdx, [rel data3]
+fld tword [rdx + 8 * 0]
+
+hlt
+
+align 8
+data:
+  dt 2.0
+  dq 0
+data2:
+  dt 4.0
+  dq 0
+data3:
+  dt 4.0
+  dq 0

--- a/unittests/ASM/X87/DE_E8.asm
+++ b/unittests/ASM/X87/DE_E8.asm
@@ -1,0 +1,34 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM6": ["0x8000000000000000", "0x4001"],
+    "MM7": ["0x8000000000000000", "0xC000"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+lea rdx, [rel data2]
+fld tword [rdx + 8 * 0]
+fsubp st1, st0
+
+lea rdx, [rel data3]
+fld tword [rdx + 8 * 0]
+
+hlt
+
+align 8
+data:
+  dt 2.0
+  dq 0
+data2:
+  dt 4.0
+  dq 0
+data3:
+  dt 4.0
+  dq 0

--- a/unittests/ASM/X87/DE_F0.asm
+++ b/unittests/ASM/X87/DE_F0.asm
@@ -1,0 +1,34 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM6": ["0x8000000000000000", "0x4001"],
+    "MM7": ["0x8000000000000000", "0x4000"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+lea rdx, [rel data2]
+fld tword [rdx + 8 * 0]
+fdivrp st1, st0
+
+lea rdx, [rel data3]
+fld tword [rdx + 8 * 0]
+
+hlt
+
+align 8
+data:
+  dt 2.0
+  dq 0
+data2:
+  dt 4.0
+  dq 0
+data3:
+  dt 4.0
+  dq 0

--- a/unittests/ASM/X87/DE_F8.asm
+++ b/unittests/ASM/X87/DE_F8.asm
@@ -1,0 +1,37 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM6": ["0x8000000000000000", "0x4001"],
+    "MM7": ["0x8000000000000000", "0x3FFE"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+lea rdx, [rel data2]
+fld tword [rdx + 8 * 0]
+
+; fdivp 2.0, 4.0
+; == st1 = 2.0 / 4.0
+fdivp st1, st0
+
+lea rdx, [rel data3]
+fld tword [rdx + 8 * 0]
+
+hlt
+
+align 8
+data:
+  dt 2.0
+  dq 0
+data2:
+  dt 4.0
+  dq 0
+data3:
+  dt 4.0
+  dq 0

--- a/unittests/ASM/X87/DF_00.asm
+++ b/unittests/ASM/X87/DF_00.asm
@@ -1,0 +1,21 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM7": ["0x8000000000000000", "0x4009"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov eax, 1024
+mov [rdx + 8 * 0], eax
+mov eax, -1
+mov [rdx + 8 * 0 + 2], eax
+
+fild word [rdx + 8 * 0]
+
+hlt

--- a/unittests/ASM/X87/DF_01.asm
+++ b/unittests/ASM/X87/DF_01.asm
@@ -1,0 +1,35 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x2",
+    "MM7": ["0x8000000000000000", "0x3FFF"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+lea rdx, [rel data3]
+fisttp word [rdx + 8 * 0]
+
+mov ax, word [rdx + 8 * 0]
+
+lea rdx, [rel data2]
+fld tword [rdx + 8 * 0]
+
+hlt
+
+align 8
+data:
+  dt 2.0
+  dq 0
+data2:
+  dt 1.0
+  dq 0
+data3:
+  dq -1
+  dq -1

--- a/unittests/ASM/X87/DF_02.asm
+++ b/unittests/ASM/X87/DF_02.asm
@@ -1,0 +1,30 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x400",
+    "MM6": ["0x8000000000000000", "0x3FFF"],
+    "MM7": ["0x8000000000000000", "0x4009"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov eax, 0x44800000 ; 1024.0
+mov [rdx + 8 * 0], eax
+mov eax, -1
+mov [rdx + 8 * 1], eax
+
+fld dword [rdx + 8 * 0]
+
+fist word [rdx + 8 * 1]
+
+fld1
+
+mov eax, 0
+mov ax, word [rdx + 8 * 1]
+
+hlt

--- a/unittests/ASM/X87/DF_03.asm
+++ b/unittests/ASM/X87/DF_03.asm
@@ -1,0 +1,29 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x400",
+    "MM7": ["0x8000000000000000", "0x3FFF"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov eax, 0x44800000 ; 1024.0
+mov [rdx + 8 * 0], eax
+mov eax, -1
+mov [rdx + 8 * 1], eax
+
+fld dword [rdx + 8 * 0]
+
+fistp word [rdx + 8 * 1]
+
+fld1
+
+mov eax, 0
+mov ax, word [rdx + 8 * 1]
+
+hlt

--- a/unittests/ASM/X87/DF_05.asm
+++ b/unittests/ASM/X87/DF_05.asm
@@ -1,0 +1,19 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM7": ["0x8000000000000000", "0x4009"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 1024
+mov [rdx + 8 * 0], rax
+
+fild qword [rdx + 8 * 0]
+
+hlt

--- a/unittests/ASM/X87/DF_07.asm
+++ b/unittests/ASM/X87/DF_07.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x400",
+    "MM7": ["0x8000000000000000", "0x3FFF"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov eax, 0x44800000 ; 1024.0
+mov [rdx + 8 * 0], eax
+mov rax, -1
+mov [rdx + 8 * 1], rax
+
+fld dword [rdx + 8 * 0]
+
+fistp qword [rdx + 8 * 1]
+
+fld1
+
+mov rax, qword [rdx + 8 * 1]
+
+hlt

--- a/unittests/ASM/X87/DF_E0.asm
+++ b/unittests/ASM/X87/DF_E0.asm
@@ -1,0 +1,26 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0xFFFFFFFFFFFF3800",
+    "RBX": "0xFFFFFFFFFFFF0000"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov eax, 0x3f800000 ; 1.0
+mov [rdx + 8 * 0], eax
+
+mov rax, -1
+mov rbx, -1
+fnstsw ax
+mov bx, ax
+
+fld dword [rdx + 8 * 0]
+fnstsw ax
+
+hlt

--- a/unittests/IR/CMakeLists.txt
+++ b/unittests/IR/CMakeLists.txt
@@ -46,6 +46,7 @@ foreach(IR_SRC ${IR_SOURCES})
     add_test(NAME ${TEST_NAME}
       COMMAND "python3" "${CMAKE_SOURCE_DIR}/Scripts/testharness_runner.py"
       "${CMAKE_SOURCE_DIR}/unittests/IR/Known_Failures"
+      "${CMAKE_SOURCE_DIR}/unittests/IR/Disabled_Tests"
       "Test_${IR_NAME}"
       "${CMAKE_BINARY_DIR}/Bin/IRLoader"
       ${ARGS_LIST} "${IR_SRC}" "${OUTPUT_CONFIG_NAME}")

--- a/unittests/POSIX/Known_Failures
+++ b/unittests/POSIX/Known_Failures
@@ -8,7 +8,6 @@ conformance-interfaces-clock_settime-17-1.test
 conformance-interfaces-clock_settime-17-2.test
 conformance-interfaces-clock_settime-20-1.test
 conformance-interfaces-clock_settime-6-1.test
-conformance-interfaces-difftime-1-1.test
 conformance-interfaces-kill-1-1.test
 conformance-interfaces-killpg-1-1.test
 conformance-interfaces-mlockall-8-1.test


### PR DESCRIPTION
This implements support for 130 of the 132 x87 ops as interpreter
fallbacks.

The two missing ops are the BCD load and BCD store instructions and can
be implemented another time.

This allows us to no longer have to rely on a libstdc++ modification to
handle their usage of long double. This instead works entirely through
using `long double` directly in the interpreter. Which will either use
real x87 on an x86 host. Or in the case of ARM devices, fall down
glibc's long double soft float path.

This doesn't necessarily need to be quick right now. It's more important
to have the compatibility improvement from this.