### PR TITLE
Forces LLVM backend to use the native CPU architecture

### DIFF
--- a/External/FEXCore/Source/Interface/Core/LLVMJIT/LLVMCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/LLVMJIT/LLVMCore.cpp
@@ -790,11 +790,9 @@ private:
   // Target Machines
 #ifdef _M_X86_64
   const std::string arch = "x86-64";
-  const std::string cpu = "skylake";
   const llvm::Triple TargetTriple{"x86_64", "unknown", "linux", "gnu"};
 #else
   const std::string arch = "aarch64";
-  const std::string cpu = "cortex-a76";
   const llvm::Triple TargetTriple{"aarch64", "unknown", "linux", "gnu"};
 #endif
   const llvm::SmallVector<std::string, 0> Attrs;
@@ -816,7 +814,7 @@ LLVMJITCore::LLVMJITCore(FEXCore::Core::InternalThreadState *Thread)
   JITState.MainEngineBuilder->setEngineKind(llvm::EngineKind::JIT);
   LLVMTarget = JITState.MainEngineBuilder->selectTarget(
       TargetTriple,
-      arch, cpu, Attrs);
+      arch, llvm::sys::getHostCPUName(), Attrs);
 
   JITState.MemManager = new LLVMMemoryManager();
   CTX->Config.LLVM_MemoryValidation = false;


### PR DESCRIPTION
Better than relying on a hardcoded CPU target
Should fix a crash on x86 host cpus that don't support BMI1