### PR TITLE
Implements LODS instruction

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -2415,6 +2415,104 @@ void OpDispatchBuilder::CMPSOp(OpcodeArgs) {
   }
 }
 
+void OpDispatchBuilder::LODSOp(OpcodeArgs) {
+  LogMan::Throw::A(!(Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_ADDRESS_SIZE), "Can't handle adddress size\n");
+  LogMan::Throw::A(!(Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_FS_PREFIX), "Can't handle FS\n");
+  LogMan::Throw::A(!(Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_GS_PREFIX), "Can't handle GS\n");
+  LogMan::Throw::A(!(Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_REPNE_PREFIX), "LODS doesn't support REPNE");
+
+  auto Size = GetSrcSize(Op);
+  bool Repeat = Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_REP_PREFIX;
+
+  if (!Repeat) {
+    OrderedNode *Dest_RSI = _LoadContext(8, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RSI]), GPRClass);
+
+    auto Src = _LoadMem(GPRClass, Size, Dest_RSI, Size);
+
+    StoreResult(GPRClass, Op, Src, -1);
+
+    auto SizeConst = _Constant(Size);
+    auto NegSizeConst = _Constant(-Size);
+
+    auto DF = GetRFLAG(FEXCore::X86State::RFLAG_DF_LOC);
+    auto PtrDir = _Select(FEXCore::IR::COND_EQ,
+        DF, _Constant(0),
+        SizeConst, NegSizeConst);
+
+    // Offset the pointer
+    OrderedNode *TailDest_RSI = _LoadContext(8, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RSI]), GPRClass);
+    TailDest_RSI = _Add(TailDest_RSI, PtrDir);
+    _StoreContext(GPRClass, 8, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RSI]), TailDest_RSI);
+  }
+  else {
+    // XXX: Theoretically LODS could be optimized to
+    // RSI += {-}(RCX * Size)
+    // RAX = [RSI - Size]
+    // But this might violate the case of an application scanning pages for read permission and catching the fault
+    // May or may not matter
+    auto JumpStart = _Jump();
+    // Make sure to start a new block after ending this one
+      auto LoopStart = CreateNewCodeBlock();
+      SetJumpTarget(JumpStart, LoopStart);
+      SetCurrentCodeBlock(LoopStart);
+
+        auto ZeroConst = _Constant(0);
+        auto OneConst = _Constant(1);
+
+        OrderedNode *Counter = _LoadContext(8, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RCX]), GPRClass);
+
+        // Can we end the block?
+        OrderedNode *CanLeaveCond = _Select(FEXCore::IR::COND_EQ,
+          Counter, ZeroConst,
+          OneConst, ZeroConst);
+
+      // We leave if RCX = 0
+      auto CondJump = _CondJump(CanLeaveCond);
+
+      auto LoopTail = CreateNewCodeBlock();
+      SetFalseJumpTarget(CondJump, LoopTail);
+      SetCurrentCodeBlock(LoopTail);
+
+      // Working loop
+      {
+        OrderedNode *Dest_RSI = _LoadContext(8, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RSI]), GPRClass);
+
+        auto Src = _LoadMem(GPRClass, Size, Dest_RSI, Size);
+
+        StoreResult(GPRClass, Op, Src, -1);
+
+        OrderedNode *TailCounter = _LoadContext(8, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RCX]), GPRClass);
+        OrderedNode *TailDest_RSI = _LoadContext(8, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RSI]), GPRClass);
+
+        // Decrement counter
+        TailCounter = _Sub(TailCounter, _Constant(1));
+
+        // Store the counter so we don't have to deal with PHI here
+        _StoreContext(GPRClass, 8, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RCX]), TailCounter);
+
+        auto SizeConst = _Constant(Size);
+        auto NegSizeConst = _Constant(-Size);
+
+        auto DF = GetRFLAG(FEXCore::X86State::RFLAG_DF_LOC);
+        auto PtrDir = _Select(FEXCore::IR::COND_EQ,
+            DF, _Constant(0),
+            SizeConst, NegSizeConst);
+
+        // Offset the pointer
+        TailDest_RSI = _Add(TailDest_RSI, PtrDir);
+        _StoreContext(GPRClass, 8, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RSI]), TailDest_RSI);
+
+        // Jump back to the start, we have more work to do
+        _Jump(LoopStart);
+    }
+    // Make sure to start a new block after ending this one
+    auto LoopEnd = CreateNewCodeBlock();
+    SetTrueJumpTarget(CondJump, LoopEnd);
+    SetCurrentCodeBlock(LoopEnd);
+  }
+}
+
+
 void OpDispatchBuilder::SCASOp(OpcodeArgs) {
   LogMan::Throw::A(!(Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_ADDRESS_SIZE), "Can't handle adddress size\n");
   LogMan::Throw::A(!(Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_FS_PREFIX), "Can't handle FS\n");
@@ -6626,6 +6724,7 @@ void InstallOpcodeHandlers(Context::OperatingMode Mode) {
     {0xA6, 2, &OpDispatchBuilder::CMPSOp},
     {0xA8, 2, &OpDispatchBuilder::TESTOp<0>},
     {0xAA, 2, &OpDispatchBuilder::STOSOp},
+    {0xAC, 2, &OpDispatchBuilder::LODSOp},
     {0xAE, 2, &OpDispatchBuilder::SCASOp},
     {0xB0, 16, &OpDispatchBuilder::MOVGPROp<0>},
     {0xC2, 2, &OpDispatchBuilder::RETOp},

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -172,6 +172,7 @@ public:
   void STOSOp(OpcodeArgs);
   void MOVSOp(OpcodeArgs);
   void CMPSOp(OpcodeArgs);
+  void LODSOp(OpcodeArgs);
   void SCASOp(OpcodeArgs);
   void BSWAPOp(OpcodeArgs);
   void PUSHFOp(OpcodeArgs);

--- a/External/FEXCore/Source/Interface/Core/X86Tables/BaseTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/BaseTables.cpp
@@ -166,8 +166,8 @@ void InitializeBaseTables(Context::OperatingMode Mode) {
     {0xA9, 1, X86InstInfo{"TEST",   TYPE_INST, FLAGS_SF_DST_RAX | FLAGS_SRC_SEXT | FLAGS_DISPLACE_SIZE_DIV_2,                4, nullptr}},
     {0xAA, 1, X86InstInfo{"STOS",   TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_DEBUG_MEM_ACCESS  | FLAGS_SUPPORTS_REP | FLAGS_SF_SRC_RAX,                   0, nullptr}},
     {0xAB, 1, X86InstInfo{"STOS",   TYPE_INST, FLAGS_DEBUG_MEM_ACCESS | FLAGS_SUPPORTS_REP | FLAGS_SF_SRC_RAX,                                   0, nullptr}},
-    {0xAC, 1, X86InstInfo{"LODS",   TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_DEBUG_MEM_ACCESS | FLAGS_SUPPORTS_REP,                                                      0, nullptr}},
-    {0xAD, 1, X86InstInfo{"LODS",   TYPE_INST, FLAGS_DEBUG_MEM_ACCESS | FLAGS_SUPPORTS_REP,                                                      0, nullptr}},
+    {0xAC, 1, X86InstInfo{"LODS",   TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_SF_DST_RAX | FLAGS_DEBUG_MEM_ACCESS | FLAGS_SUPPORTS_REP,                                                      0, nullptr}},
+    {0xAD, 1, X86InstInfo{"LODS",   TYPE_INST, FLAGS_SF_DST_RAX | FLAGS_DEBUG_MEM_ACCESS | FLAGS_SUPPORTS_REP,                                                      0, nullptr}},
     {0xAE, 1, X86InstInfo{"SCAS",   TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_DEBUG_MEM_ACCESS | FLAGS_SUPPORTS_REP | FLAGS_SF_SRC_RAX,                                   0, nullptr}},
     {0xAF, 1, X86InstInfo{"SCAS",   TYPE_INST, FLAGS_DEBUG_MEM_ACCESS | FLAGS_SUPPORTS_REP | FLAGS_SF_SRC_RAX,                                   0, nullptr}},
 

--- a/unittests/ASM/Primary/Primary_AC.asm
+++ b/unittests/ASM/Primary/Primary_AC.asm
@@ -1,0 +1,37 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x41",
+    "RSI": "0xE0000008"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rdx + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [rdx + 8 * 1], rax
+mov rax, 0x0
+mov [rdx + 8 * 2], rax
+mov [rdx + 8 * 3], rax
+
+lea rsi, [rdx + 8 * 0]
+
+cld
+mov rax, 0xFF
+lodsb
+lodsb
+lodsb
+lodsb
+
+lodsb
+lodsb
+lodsb
+lodsb
+
+hlt

--- a/unittests/ASM/Primary/Primary_AC_REP.asm
+++ b/unittests/ASM/Primary/Primary_AC_REP.asm
@@ -1,0 +1,30 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x41",
+    "RSI": "0xE0000008"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rdx + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [rdx + 8 * 1], rax
+mov rax, 0x0
+mov [rdx + 8 * 2], rax
+mov [rdx + 8 * 3], rax
+
+lea rsi, [rdx + 8 * 0]
+
+cld
+mov rax, 0xFF
+mov rcx, 8
+rep lodsb
+
+hlt

--- a/unittests/ASM/Primary/Primary_AC_REP_down.asm
+++ b/unittests/ASM/Primary/Primary_AC_REP_down.asm
@@ -1,0 +1,30 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x57",
+    "RSI": "0xE0000008"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rdx + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [rdx + 8 * 1], rax
+mov rax, 0x0
+mov [rdx + 8 * 2], rax
+mov [rdx + 8 * 3], rax
+
+lea rsi, [rdx + 8 * 2]
+
+std
+mov rax, 0xFF
+mov rcx, 8
+rep lodsb
+
+hlt

--- a/unittests/ASM/Primary/Primary_AD_REP_dword.asm
+++ b/unittests/ASM/Primary/Primary_AD_REP_dword.asm
@@ -1,0 +1,33 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x71727374",
+    "RSI": "0xE0000020"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rdx + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [rdx + 8 * 1], rax
+mov rax, 0x6162636465666768
+mov [rdx + 8 * 2], rax
+mov rax, 0x7172737475767778
+mov [rdx + 8 * 3], rax
+mov rax, 0x0
+mov [rdx + 8 * 4], rax
+
+lea rsi, [rdx + 8 * 0]
+
+cld
+mov rax, 0xFF
+mov rcx, 8
+rep lodsd
+
+hlt

--- a/unittests/ASM/Primary/Primary_AD_REP_dword_down.asm
+++ b/unittests/ASM/Primary/Primary_AD_REP_dword_down.asm
@@ -1,0 +1,33 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x41424344",
+    "RSI": "0xE0000000"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rdx + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [rdx + 8 * 1], rax
+mov rax, 0x6162636465666768
+mov [rdx + 8 * 2], rax
+mov rax, 0x7172737475767778
+mov [rdx + 8 * 3], rax
+mov rax, 0x0
+mov [rdx + 8 * 4], rax
+
+lea rsi, [rdx + 8 * 4]
+
+std
+mov rax, 0xFF
+mov rcx, 8
+rep lodsd
+
+hlt

--- a/unittests/ASM/Primary/Primary_AD_REP_qword.asm
+++ b/unittests/ASM/Primary/Primary_AD_REP_qword.asm
@@ -1,0 +1,41 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0xB1B2B3B4B5B6B7B8",
+    "RSI": "0xE0000040"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rdx + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [rdx + 8 * 1], rax
+mov rax, 0x6162636465666768
+mov [rdx + 8 * 2], rax
+mov rax, 0x7172737475767778
+mov [rdx + 8 * 3], rax
+mov rax, 0x8182838485868788
+mov [rdx + 8 * 4], rax
+mov rax, 0x9192939495969798
+mov [rdx + 8 * 5], rax
+mov rax, 0xA1A2A3A4A5A6A7A8
+mov [rdx + 8 * 6], rax
+mov rax, 0xB1B2B3B4B5B6B7B8
+mov [rdx + 8 * 7], rax
+mov rax, 0x0
+mov [rdx + 8 * 8], rax
+
+lea rsi, [rdx + 8 * 0]
+
+cld
+mov rax, 0xFF
+mov rcx, 8
+rep lodsq
+
+hlt

--- a/unittests/ASM/Primary/Primary_AD_REP_qword_down.asm
+++ b/unittests/ASM/Primary/Primary_AD_REP_qword_down.asm
@@ -1,0 +1,41 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x5152535455565758",
+    "RSI": "0xE0000000"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rdx + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [rdx + 8 * 1], rax
+mov rax, 0x6162636465666768
+mov [rdx + 8 * 2], rax
+mov rax, 0x7172737475767778
+mov [rdx + 8 * 3], rax
+mov rax, 0x8182838485868788
+mov [rdx + 8 * 4], rax
+mov rax, 0x9192939495969798
+mov [rdx + 8 * 5], rax
+mov rax, 0xA1A2A3A4A5A6A7A8
+mov [rdx + 8 * 6], rax
+mov rax, 0xB1B2B3B4B5B6B7B8
+mov [rdx + 8 * 7], rax
+mov rax, 0x0
+mov [rdx + 8 * 8], rax
+
+lea rsi, [rdx + 8 * 8]
+
+std
+mov rax, 0xFF
+mov rcx, 8
+rep lodsq
+
+hlt

--- a/unittests/ASM/Primary/Primary_AD_REP_word.asm
+++ b/unittests/ASM/Primary/Primary_AD_REP_word.asm
@@ -1,0 +1,30 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x5152",
+    "RSI": "0xE0000010"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rdx + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [rdx + 8 * 1], rax
+mov rax, 0x0
+mov [rdx + 8 * 2], rax
+mov [rdx + 8 * 3], rax
+
+lea rsi, [rdx + 8 * 0]
+
+cld
+mov rax, 0xFF
+mov rcx, 8
+rep lodsw
+
+hlt

--- a/unittests/ASM/Primary/Primary_AD_REP_word_down.asm
+++ b/unittests/ASM/Primary/Primary_AD_REP_word_down.asm
@@ -1,0 +1,30 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x4546",
+    "RSI": "0xE0000000"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rdx + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [rdx + 8 * 1], rax
+mov rax, 0x0
+mov [rdx + 8 * 2], rax
+mov [rdx + 8 * 3], rax
+
+lea rsi, [rdx + 8 * 2]
+
+std
+mov rax, 0xFF
+mov rcx, 8
+rep lodsw
+
+hlt

--- a/unittests/ASM/Primary/Primary_AD_dword.asm
+++ b/unittests/ASM/Primary/Primary_AD_dword.asm
@@ -1,0 +1,40 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x71727374",
+    "RSI": "0xE0000020"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rdx + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [rdx + 8 * 1], rax
+mov rax, 0x6162636465666768
+mov [rdx + 8 * 2], rax
+mov rax, 0x7172737475767778
+mov [rdx + 8 * 3], rax
+mov rax, 0x0
+mov [rdx + 8 * 4], rax
+
+lea rsi, [rdx + 8 * 0]
+
+cld
+mov rax, 0xFF
+lodsd
+lodsd
+lodsd
+lodsd
+
+lodsd
+lodsd
+lodsd
+lodsd
+
+hlt

--- a/unittests/ASM/Primary/Primary_AD_qword.asm
+++ b/unittests/ASM/Primary/Primary_AD_qword.asm
@@ -1,0 +1,48 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0xB1B2B3B4B5B6B7B8",
+    "RSI": "0xE0000040"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rdx + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [rdx + 8 * 1], rax
+mov rax, 0x6162636465666768
+mov [rdx + 8 * 2], rax
+mov rax, 0x7172737475767778
+mov [rdx + 8 * 3], rax
+mov rax, 0x8182838485868788
+mov [rdx + 8 * 4], rax
+mov rax, 0x9192939495969798
+mov [rdx + 8 * 5], rax
+mov rax, 0xA1A2A3A4A5A6A7A8
+mov [rdx + 8 * 6], rax
+mov rax, 0xB1B2B3B4B5B6B7B8
+mov [rdx + 8 * 7], rax
+mov rax, 0x0
+mov [rdx + 8 * 8], rax
+
+lea rsi, [rdx + 8 * 0]
+
+cld
+mov rax, 0xFF
+lodsq
+lodsq
+lodsq
+lodsq
+
+lodsq
+lodsq
+lodsq
+lodsq
+
+hlt

--- a/unittests/ASM/Primary/Primary_AD_word.asm
+++ b/unittests/ASM/Primary/Primary_AD_word.asm
@@ -1,0 +1,37 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x5152",
+    "RSI": "0xE0000010"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rdx + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [rdx + 8 * 1], rax
+mov rax, 0x0
+mov [rdx + 8 * 2], rax
+mov [rdx + 8 * 3], rax
+
+lea rsi, [rdx + 8 * 0]
+
+cld
+mov rax, 0xFF
+lodsw
+lodsw
+lodsw
+lodsw
+
+lodsw
+lodsw
+lodsw
+lodsw
+
+hlt


### PR DESCRIPTION
Theoretically the REP case can be optimized if it is known not to fault,
but that is one legitimate use case of this instruction.
This is just to ensure that we have this instruction covered, it hasn't
been encountered in a real program yet.