### PR TITLE
Fixes a crash that can occur when the config exists but has nothing

### DIFF
--- a/Source/Common/Config.cpp
+++ b/Source/Common/Config.cpp
@@ -62,6 +62,9 @@ namespace FEX::Config {
       }
       ConfigFile.close();
     }
+    else {
+      return false;
+    }
 
     return true;
   }


### PR DESCRIPTION
Common when I'm testing and wiping the config away