### PR TITLE
Fixes a case of the BT ops failing to test the correct bit

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -1655,12 +1655,9 @@ void OpDispatchBuilder::BTOp(OpcodeArgs) {
   else {
     // Load the address to the memory location
     OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1, false);
-    uint32_t Size = GetSrcSize(Op);
-    uint32_t Mask = Size * 8 - 1;
-    OrderedNode *SizeMask = _Constant(Mask);
 
     // Get the bit selection from the src
-    OrderedNode *BitSelect = _And(Src, SizeMask);
+    OrderedNode *BitSelect = _Bfe(3, 0, Src);
 
     // Address is provided as bits we want BYTE offsets
     // Just shift by 3 to get the offset
@@ -1671,7 +1668,7 @@ void OpDispatchBuilder::BTOp(OpcodeArgs) {
 
     // Now add the addresses together and load the memory
     OrderedNode *MemoryLocation = _Add(Dest, Src);
-    Result = _LoadMem(GPRClass, Size, MemoryLocation, Size);
+    Result = _LoadMem(GPRClass, 1, MemoryLocation, 1);
 
     // Now shift in to the correct bit location
     Result = _Lshr(Result, BitSelect);
@@ -1703,12 +1700,9 @@ void OpDispatchBuilder::BTROp(OpcodeArgs) {
   else {
     // Load the address to the memory location
     OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1, false);
-    uint32_t Size = GetSrcSize(Op);
-    uint32_t Mask = Size * 8 - 1;
-    OrderedNode *SizeMask = _Constant(Mask);
 
     // Get the bit selection from the src
-    OrderedNode *BitSelect = _And(Src, SizeMask);
+    OrderedNode *BitSelect = _Bfe(3, 0, Src);
 
     // Address is provided as bits we want BYTE offsets
     // Just shift by 3 to get the offset
@@ -1719,14 +1713,14 @@ void OpDispatchBuilder::BTROp(OpcodeArgs) {
 
     // Now add the addresses together and load the memory
     OrderedNode *MemoryLocation = _Add(Dest, Src);
-    OrderedNode *Value = _LoadMem(GPRClass, Size, MemoryLocation, Size);
+    OrderedNode *Value = _LoadMem(GPRClass, 1, MemoryLocation, 1);
 
     // Now shift in to the correct bit location
     Result = _Lshr(Value, BitSelect);
     OrderedNode *BitMask = _Lshl(_Constant(1), BitSelect);
     BitMask = _Not(BitMask);
     Value = _And(Value, BitMask);
-    _StoreMem(GPRClass, Size, MemoryLocation, Value, Size);
+    _StoreMem(GPRClass, 1, MemoryLocation, Value, 1);
   }
   SetRFLAG<FEXCore::X86State::RFLAG_CF_LOC>(Result);
 }
@@ -1754,12 +1748,9 @@ void OpDispatchBuilder::BTSOp(OpcodeArgs) {
   else {
     // Load the address to the memory location
     OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1, false);
-    uint32_t Size = GetSrcSize(Op);
-    uint32_t Mask = Size * 8 - 1;
-    OrderedNode *SizeMask = _Constant(Mask);
 
     // Get the bit selection from the src
-    OrderedNode *BitSelect = _And(Src, SizeMask);
+    OrderedNode *BitSelect = _Bfe(3, 0, Src);
 
     // Address is provided as bits we want BYTE offsets
     // Just shift by 3 to get the offset
@@ -1770,13 +1761,13 @@ void OpDispatchBuilder::BTSOp(OpcodeArgs) {
 
     // Now add the addresses together and load the memory
     OrderedNode *MemoryLocation = _Add(Dest, Src);
-    OrderedNode *Value = _LoadMem(GPRClass, Size, MemoryLocation, Size);
+    OrderedNode *Value = _LoadMem(GPRClass, 1, MemoryLocation, 1);
 
     // Now shift in to the correct bit location
     Result = _Lshr(Value, BitSelect);
     OrderedNode *BitMask = _Lshl(_Constant(1), BitSelect);
     Value = _Or(Value, BitMask);
-    _StoreMem(GPRClass, Size, MemoryLocation, Value, Size);
+    _StoreMem(GPRClass, 1, MemoryLocation, Value, 1);
   }
   SetRFLAG<FEXCore::X86State::RFLAG_CF_LOC>(Result);
 }
@@ -1804,12 +1795,8 @@ void OpDispatchBuilder::BTCOp(OpcodeArgs) {
   else {
     // Load the address to the memory location
     OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1, false);
-    uint32_t Size = GetSrcSize(Op);
-    uint32_t Mask = Size * 8 - 1;
-    OrderedNode *SizeMask = _Constant(Mask);
-
     // Get the bit selection from the src
-    OrderedNode *BitSelect = _And(Src, SizeMask);
+    OrderedNode *BitSelect = _Bfe(3, 0, Src);
 
     // Address is provided as bits we want BYTE offsets
     // Just shift by 3 to get the offset
@@ -1820,13 +1807,13 @@ void OpDispatchBuilder::BTCOp(OpcodeArgs) {
 
     // Now add the addresses together and load the memory
     OrderedNode *MemoryLocation = _Add(Dest, Src);
-    OrderedNode *Value = _LoadMem(GPRClass, Size, MemoryLocation, Size);
+    OrderedNode *Value = _LoadMem(GPRClass, 1, MemoryLocation, 1);
 
     // Now shift in to the correct bit location
     Result = _Lshr(Value, BitSelect);
     OrderedNode *BitMask = _Lshl(_Constant(1), BitSelect);
     Value = _Xor(Value, BitMask);
-    _StoreMem(GPRClass, Size, MemoryLocation, Value, Size);
+    _StoreMem(GPRClass, 1, MemoryLocation, Value, 1);
   }
   SetRFLAG<FEXCore::X86State::RFLAG_CF_LOC>(Result);
 }

--- a/unittests/ASM/Secondary/08_XX_04_3.asm
+++ b/unittests/ASM/Secondary/08_XX_04_3.asm
@@ -1,0 +1,36 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "R15": "0x1"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+%macro cfmerge 0
+
+; Get CF
+sbb r14, r14
+and r14, 1
+
+; Merge in to results
+shl r15, 1
+or r15, r14
+
+%endmacro
+
+mov rdx, 0xe0000000
+
+mov rax, 0x0000000100000000
+mov [rdx + 8 * 0], rax
+
+xor r15, r15 ; Will contain our results
+
+bt qword [rdx], 32
+cfmerge
+
+hlt
+
+

--- a/unittests/ASM/Secondary/08_XX_05_3.asm
+++ b/unittests/ASM/Secondary/08_XX_05_3.asm
@@ -1,0 +1,37 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "R15": "0x3"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+%macro cfmerge 0
+
+; Get CF
+sbb r14, r14
+and r14, 1
+
+; Merge in to results
+shl r15, 1
+or r15, r14
+
+%endmacro
+
+mov rdx, 0xe0000000
+
+mov rax, 0x0000000100000000
+mov [rdx + 8 * 0], rax
+
+xor r15, r15 ; Will contain our results
+
+bts qword [rdx], 32
+cfmerge
+
+bt qword [rdx], 32
+cfmerge
+
+hlt

--- a/unittests/ASM/Secondary/08_XX_06_3.asm
+++ b/unittests/ASM/Secondary/08_XX_06_3.asm
@@ -1,0 +1,39 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "R15": "0x2"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+%macro cfmerge 0
+
+; Get CF
+sbb r14, r14
+and r14, 1
+
+; Merge in to results
+shl r15, 1
+or r15, r14
+
+%endmacro
+
+mov rdx, 0xe0000000
+
+mov rax, 0x0000000100000000
+mov [rdx + 8 * 0], rax
+
+xor r15, r15 ; Will contain our results
+
+btr qword [rdx], 32
+cfmerge
+
+bt qword [rdx], 32
+cfmerge
+
+hlt
+
+

--- a/unittests/ASM/Secondary/08_XX_07_3.asm
+++ b/unittests/ASM/Secondary/08_XX_07_3.asm
@@ -1,0 +1,37 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "R15": "0x2"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+%macro cfmerge 0
+
+; Get CF
+sbb r14, r14
+and r14, 1
+
+; Merge in to results
+shl r15, 1
+or r15, r14
+
+%endmacro
+
+mov rdx, 0xe0000000
+
+mov rax, 0x0000000100000000
+mov [rdx + 8 * 0], rax
+
+xor r15, r15 ; Will contain our results
+
+btc qword [rdx], 32
+cfmerge
+
+bt qword [rdx], 32
+cfmerge
+
+hlt


### PR DESCRIPTION
When the `BT mem` operation was accessing memory where the bit offset
wasn't a multiple of the access size, then we were dividing the offset
by bytes and accessing bits at `mem[byteOffset] &= (BitOffset)`.
BitOffset wasn't adjusted to compensate for the access size being added
to the address.
Causing a mismatch of testing the wrong bits. Unit tests didn't capture
this.
Trying to run glxgears on i965/iris showed extensive corruption because
of it though.