### PR TITLE
Fixes a typo in the HasSideEffects json generator

### DIFF
--- a/External/FEXCore/Scripts/json_ir_generator.py
+++ b/External/FEXCore/Scripts/json_ir_generator.py
@@ -195,9 +195,9 @@ def print_ir_hassideeffects(ops, defines):
     for op_key, op_vals in ops.items():
         HasSideEffects = False
         if ("HasSideEffects" in op_vals):
-            SSAArgs = op_vals["HasSideEffects"]
+            HasSideEffects = op_vals["HasSideEffects"]
 
-        output_file.write("\t%s,\n" % ("true" if SSAArgs else "false"))
+        output_file.write("\t%s,\n" % ("true" if HasSideEffects else "false"))
 
     output_file.write("};\n\n")
 


### PR DESCRIPTION
This was forcing every op to determine it had side effects, so DCE could
never actually remove any operations.
This fixes the typo which means each op declares side effects correctly
and DCE works again