### PR TITLE
Config fixes

### DIFF
--- a/External/FEXCore/Source/Common/Paths.cpp
+++ b/External/FEXCore/Source/Common/Paths.cpp
@@ -1,30 +1,50 @@
 #include "Common/Paths.h"
+#include "LogManager.h"
 
 #include <cstdlib>
+#include <filesystem>
 #include <sys/stat.h>
 
 namespace FEXCore::Paths {
-  std::string DataPath;
+  std::string CachePath;
   std::string EntryCache;
 
   void InitializePaths() {
-    char *HomeDir = getenv("HOME");
+    char const *HomeDir = getenv("HOME");
+
+    if (!HomeDir) {
+      HomeDir = getenv("PWD");
+    }
+
+    if (!HomeDir) {
+      HomeDir = "";
+    }
+
     char *XDGDataDir = getenv("XDG_DATA_DIR");
     if (XDGDataDir) {
-      DataPath = XDGDataDir;
+      CachePath = XDGDataDir;
     }
     else {
       if (HomeDir) {
-        DataPath = HomeDir;
+        CachePath = HomeDir;
       }
     }
-    DataPath += "/.fexcore/";
-    EntryCache = DataPath + "/EntryCache/";
-    mkdir(DataPath.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
-    mkdir(EntryCache.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+
+    CachePath += "/.fex-emu/";
+    EntryCache = CachePath + "/EntryCache/";
+
+    // Ensure the folder structure is created for our Data
+    if (!std::filesystem::exists(EntryCache) &&
+        !std::filesystem::create_directories(EntryCache)) {
+      LogMan::Msg::D("Couldn't create EntryCache directory: '%s'", EntryCache.c_str());
+    }
   }
 
-  std::string GetDataPath() {
-    return DataPath;
+  std::string GetCachePath() {
+    return CachePath;
+  }
+
+  std::string GetEntryCachePath() {
+    return EntryCache;
   }
 }

--- a/External/FEXCore/Source/Common/Paths.h
+++ b/External/FEXCore/Source/Common/Paths.h
@@ -3,5 +3,6 @@
 
 namespace FEXCore::Paths {
   void InitializePaths();
-  std::string GetDataPath();
+  std::string GetCachePath();
+  std::string GetEntryCachePath();
 }

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -161,8 +161,8 @@ namespace FEXCore::Context {
     std::string hash_string;
 
     if (GetFilenameHash(Filename, hash_string)) {
-      auto DataPath = FEXCore::Paths::GetDataPath();
-      DataPath += "/EntryCache/Entries_" + hash_string;
+      auto DataPath = FEXCore::Paths::GetEntryCachePath();
+      DataPath += "Entries_" + hash_string;
 
       std::ofstream Output (DataPath.c_str(), std::ios::out | std::ios::binary);
       if (Output.is_open()) {
@@ -179,8 +179,8 @@ namespace FEXCore::Context {
     std::string hash_string;
 
     if (GetFilenameHash(Filename, hash_string)) {
-      auto DataPath = FEXCore::Paths::GetDataPath();
-      DataPath += "/EntryCache/Entries_" + hash_string;
+      auto DataPath = FEXCore::Paths::GetEntryCachePath();
+      DataPath += "Entries_" + hash_string;
 
       std::ifstream Input (DataPath.c_str(), std::ios::in | std::ios::binary | std::ios::ate);
       if (Input.is_open()) {

--- a/Source/Tests/ELFLoader.cpp
+++ b/Source/Tests/ELFLoader.cpp
@@ -99,7 +99,7 @@ int main(int argc, char **argv, char **const envp) {
   FEX::Config::Value<bool> MultiblockConfig{"Multiblock", false};
   FEX::Config::Value<bool> GdbServerConfig{"GdbServer", false};
   FEX::Config::Value<uint64_t> ThreadsConfig{"Threads", 1};
-  FEX::Config::Value<bool> UnifiedMemory{"UnifiedMemory", false};
+  FEX::Config::Value<bool> UnifiedMemory{"UnifiedMemory", true};
   FEX::Config::Value<std::string> LDPath{"RootFS", ""};
   FEX::Config::Value<bool> SilentLog{"SilentLog", false};
 


### PR DESCRIPTION
Ensures that unified memory is enabled by default. I thought this was enabled by default but it must have been missed.
Ensures the EntryCache gets stored in the correct XDG/Home folder
Ensures the Config file gets store in XDG/Home as well.