### PR TITLE
Removes 64bit size from frontend when in 32bit mode

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Frontend.cpp
+++ b/External/FEXCore/Source/Interface/Core/Frontend.cpp
@@ -250,9 +250,10 @@ bool Decoder::NormalOp(FEXCore::X86Tables::X86InstInfo const *Info, uint16_t Op)
       DecodeInst->Flags |= DecodeFlags::GenSizeDstSize(DecodeFlags::SIZE_16BIT);
       DestSize = 2;
     }
-    else if (DecodeInst->Flags & DecodeFlags::FLAG_REX_WIDENING ||
+    else if (CTX->Config.Is64BitMode &&
+      (DecodeInst->Flags & DecodeFlags::FLAG_REX_WIDENING ||
       DstSizeFlag == FEXCore::X86Tables::InstFlags::SIZE_64BIT ||
-      DstSizeFlag == FEXCore::X86Tables::InstFlags::SIZE_64BITDEF) {
+      DstSizeFlag == FEXCore::X86Tables::InstFlags::SIZE_64BITDEF)) {
       DecodeInst->Flags |= DecodeFlags::GenSizeDstSize(DecodeFlags::SIZE_64BIT);
       DestSize = 8;
     }
@@ -278,9 +279,10 @@ bool Decoder::NormalOp(FEXCore::X86Tables::X86InstInfo const *Info, uint16_t Op)
       // If the default operating mode is 32bit and we have the operand size flag then the operating size drops to 16bit
       DecodeInst->Flags |= DecodeFlags::GenSizeSrcSize(DecodeFlags::SIZE_16BIT);
     }
-    else if (DecodeInst->Flags & DecodeFlags::FLAG_REX_WIDENING ||
+    else if (CTX->Config.Is64BitMode &&
+      (DecodeInst->Flags & DecodeFlags::FLAG_REX_WIDENING ||
       SrcSizeFlag == FEXCore::X86Tables::InstFlags::SIZE_64BIT ||
-      SrcSizeFlag == FEXCore::X86Tables::InstFlags::SIZE_64BITDEF) {
+      SrcSizeFlag == FEXCore::X86Tables::InstFlags::SIZE_64BITDEF)) {
       DecodeInst->Flags |= DecodeFlags::GenSizeSrcSize(DecodeFlags::SIZE_64BIT);
     }
     else {


### PR DESCRIPTION
64bit mode doesn't exist when we are operating in 32bit mode, so this
needs to be disabled.
This forces a fallback to a 32bit size for those ops