### PR TITLE
Supports segment register moving

### DIFF
--- a/External/FEXCore/Source/Interface/Core/LLVMJIT/LLVMCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/LLVMJIT/LLVMCore.cpp
@@ -1267,6 +1267,10 @@ void LLVMJITCore::CreateGlobalVariables(llvm::ExecutionEngine *Engine, llvm::Mod
         ArrayType::get(i64, 16), // Gregs
         i64, // Pad to ensure alignment
         ArrayType::get(i128, 16), // XMMs
+        i16, // es
+        i16, // cs
+        i16, // ss
+        i16, // ds
         i64, i64, // GS, FS
         ArrayType::get(i8, 48), //rflags
         ArrayType::get(i128, 8), // MMs
@@ -1303,17 +1307,33 @@ llvm::Value *LLVMJITCore::CreateContextGEP(uint64_t Offset, uint8_t Size) {
     GEPValues.emplace_back(JITState.IRBuilder->getInt32(3));
     GEPValues.emplace_back(JITState.IRBuilder->getInt32((Offset - offsetof(FEXCore::Core::CPUState, xmm)) / 16));
   }
+  else if (Offset == offsetof(FEXCore::Core::CPUState, es)) {
+    if (Size != 2) return nullptr;
+    GEPValues.emplace_back(JITState.IRBuilder->getInt32(4));
+  }
+  else if (Offset == offsetof(FEXCore::Core::CPUState, cs)) {
+    if (Size != 2) return nullptr;
+    GEPValues.emplace_back(JITState.IRBuilder->getInt32(5));
+  }
+  else if (Offset == offsetof(FEXCore::Core::CPUState, ss)) {
+    if (Size != 2) return nullptr;
+    GEPValues.emplace_back(JITState.IRBuilder->getInt32(6));
+  }
+  else if (Offset == offsetof(FEXCore::Core::CPUState, ds)) {
+    if (Size != 2) return nullptr;
+    GEPValues.emplace_back(JITState.IRBuilder->getInt32(7));
+  }
   else if (Offset == offsetof(FEXCore::Core::CPUState, gs)) {
     if (Size != 8) return nullptr;
-    GEPValues.emplace_back(JITState.IRBuilder->getInt32(4));
+    GEPValues.emplace_back(JITState.IRBuilder->getInt32(8));
   }
   else if (Offset == offsetof(FEXCore::Core::CPUState, fs)) {
     if (Size != 8) return nullptr;
-    GEPValues.emplace_back(JITState.IRBuilder->getInt32(5));
+    GEPValues.emplace_back(JITState.IRBuilder->getInt32(9));
   }
   else if (Offset >= offsetof(FEXCore::Core::CPUState, flags)) {
     if (Size != 1) return nullptr;
-    GEPValues.emplace_back(JITState.IRBuilder->getInt32(6));
+    GEPValues.emplace_back(JITState.IRBuilder->getInt32(10));
     GEPValues.emplace_back(JITState.IRBuilder->getInt32(Offset - offsetof(FEXCore::Core::CPUState, flags[0])));
   }
   else

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -1056,11 +1056,92 @@ void OpDispatchBuilder::FLAGControlOp(OpcodeArgs) {
   SetRFLAG(Result, Flag);
 }
 
+
+template<bool ToSeg>
 void OpDispatchBuilder::MOVSegOp(OpcodeArgs) {
   // In x86-64 mode the accesses to the segment registers end up being constant zero moves
   // Aside from FS/GS
-  LogMan::Msg::A("Wanting reg: %d\n", Op->Src[0].TypeGPR.GPR);
-  //  StoreResult(Op, Src);
+  // In x86-64 mode the accesses to segment registers can actually still touch the segments
+  // These write to the selector portion of the register
+  //
+  // FS and GS are specially handled here though
+  // AMD documentation is /wrong/ in this regard
+  // AMD documentation claims that the MOV to SReg and POP SReg registers will load a 32bit
+  // value in to the HIDDEN portions of the FS and GS registers /OR/ ignored if a null selector is
+  // selected for the registers
+  // This statement is actually untrue, the instructions will /actually/ load 16bits in to the selector portion of the register!
+  // Tested on a Zen+ CPU, the selector is the portion that is modified!
+  // We don't currently support FS/GS selector modifying, so this needs to be asserted out
+  // The loads here also load the selector, NOT the base
+
+  if (ToSeg) {
+    OrderedNode *Src = LoadSource_WithOpSize(GPRClass, Op, Op->Src[0], 2, Op->Flags, -1);
+
+    switch (Op->Dest.TypeGPR.GPR) {
+      case 0: // ES
+        _StoreContext(GPRClass, 2, offsetof(FEXCore::Core::CPUState, es), Src);
+        break;
+      case 1: // DS
+        _StoreContext(GPRClass, 2, offsetof(FEXCore::Core::CPUState, ds), Src);
+        break;
+      case 2: // CS
+        // CPL3 can't write to this
+        _Break(4, 0);
+        break;
+      case 3: // SS
+        _StoreContext(GPRClass, 2, offsetof(FEXCore::Core::CPUState, ss), Src);
+        break;
+      case 6: // GS
+        LogMan::Throw::A(!CTX->Config.Is64BitMode, "We don't support modifying GS selector in 64bit mode!");
+        if (!CTX->Config.Is64BitMode) {
+          _StoreContext(GPRClass, 2, offsetof(FEXCore::Core::CPUState, gs), Src);
+        }
+        break;
+      case 7: // FS
+        LogMan::Throw::A(!CTX->Config.Is64BitMode, "We don't support modifying FS selector in 64bit mode!");
+        if (!CTX->Config.Is64BitMode) {
+          _StoreContext(GPRClass, 2, offsetof(FEXCore::Core::CPUState, fs), Src);
+        }
+        break;
+      default: LogMan::Msg::A("Unknown segment register: %d", Op->Dest.TypeGPR.GPR);
+    }
+  }
+  else {
+    OrderedNode *Segment{};
+
+    switch (Op->Src[0].TypeGPR.GPR) {
+      case 0: // ES
+        Segment = _LoadContext(2, offsetof(FEXCore::Core::CPUState, es), GPRClass);
+        break;
+      case 1: // DS
+        Segment = _LoadContext(2, offsetof(FEXCore::Core::CPUState, ds), GPRClass);
+        break;
+      case 2: // CS
+        Segment = _LoadContext(2, offsetof(FEXCore::Core::CPUState, cs), GPRClass);
+        break;
+      case 3: // SS
+        Segment = _LoadContext(2, offsetof(FEXCore::Core::CPUState, ss), GPRClass);
+        break;
+      case 6: // GS
+        if (CTX->Config.Is64BitMode) {
+          Segment = _Constant(0);
+        }
+        else {
+          Segment = _LoadContext(2, offsetof(FEXCore::Core::CPUState, gs), GPRClass);
+        }
+        break;
+      case 7: // FS
+        if (CTX->Config.Is64BitMode) {
+          Segment = _Constant(0);
+        }
+        else {
+          Segment = _LoadContext(2, offsetof(FEXCore::Core::CPUState, fs), GPRClass);
+        }
+        break;
+      default: LogMan::Msg::A("Unknown segment register: %d", Op->Src[0].TypeGPR.GPR);
+    }
+    StoreResult(GPRClass, Op, Segment, -1);
+  }
 }
 
 void OpDispatchBuilder::MOVOffsetOp(OpcodeArgs) {
@@ -6784,7 +6865,9 @@ void InstallOpcodeHandlers(Context::OperatingMode Mode) {
     {0x86, 2, &OpDispatchBuilder::XCHGOp},
     {0x88, 4, &OpDispatchBuilder::MOVGPROp<0>},
 
+    {0x8C, 1, &OpDispatchBuilder::MOVSegOp<false>},
     {0x8D, 1, &OpDispatchBuilder::LEAOp},
+    {0x8E, 1, &OpDispatchBuilder::MOVSegOp<true>},
     {0x8F, 1, &OpDispatchBuilder::POPOp},
     {0x90, 8, &OpDispatchBuilder::XCHGOp},
 

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -134,6 +134,7 @@ public:
   void XCHGOp(OpcodeArgs);
   void SAHFOp(OpcodeArgs);
   void LAHFOp(OpcodeArgs);
+  template<bool ToSeg>
   void MOVSegOp(OpcodeArgs);
   void FLAGControlOp(OpcodeArgs);
   void MOVOffsetOp(OpcodeArgs);

--- a/External/FEXCore/Source/Interface/Core/X86Tables/BaseTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/BaseTables.cpp
@@ -132,9 +132,9 @@ void InitializeBaseTables(Context::OperatingMode Mode) {
     {0x89, 1, X86InstInfo{"MOV",    TYPE_INST, FLAGS_MODRM | FLAGS_SF_MOD_DST,                         0, nullptr}},
     {0x8A, 1, X86InstInfo{"MOV",    TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_MODRM,         0, nullptr}},
     {0x8B, 1, X86InstInfo{"MOV",    TYPE_INST, FLAGS_MODRM,                         0, nullptr}},
-    {0x8C, 1, X86InstInfo{"MOV",    TYPE_INST, FLAGS_MODRM | FLAGS_SF_MOD_DST,                      0, nullptr}},
+    {0x8C, 1, X86InstInfo{"MOV",    TYPE_INST, GenFlagsSameSize(SIZE_16BIT) | FLAGS_MODRM | FLAGS_SF_MOD_DST,                      0, nullptr}},
     {0x8D, 1, X86InstInfo{"LEA",    TYPE_INST, GenFlagsSameSize(SIZE_64BITDEF) | FLAGS_MODRM,                         0, nullptr}},
-    {0x8E, 1, X86InstInfo{"MOV",    TYPE_INST, FLAGS_MODRM,                      0, nullptr}}, // MOV seg, modrM == invalid on x86-64
+    {0x8E, 1, X86InstInfo{"MOV",    TYPE_INST, GenFlagsSameSize(SIZE_16BIT) | FLAGS_MODRM,                      0, nullptr}},
     {0x8F, 1, X86InstInfo{"POP",    TYPE_INST, GenFlagsSameSize(SIZE_64BITDEF) | FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_DEBUG_MEM_ACCESS, 0, nullptr}},
     {0x90, 8, X86InstInfo{"XCHG",   TYPE_INST, FLAGS_SF_REX_IN_BYTE | FLAGS_SF_SRC_RAX, 0, nullptr}},
     {0x98, 1, X86InstInfo{"CDQE",   TYPE_INST, FLAGS_SF_DST_RAX | FLAGS_SF_SRC_RAX,     0, nullptr}},

--- a/External/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
@@ -29,10 +29,14 @@ namespace {
 
   using ContextInfo = std::vector<ContextMemberInfo>;
 
-  constexpr static std::array<LastAccessType, 9> DefaultAccess = {
+  constexpr static std::array<LastAccessType, 13> DefaultAccess = {
     ACCESS_NONE,
     ACCESS_NONE,
     ACCESS_INVALID, // PAD
+    ACCESS_NONE,
+    ACCESS_NONE,
+    ACCESS_NONE,
+    ACCESS_NONE,
     ACCESS_NONE,
     ACCESS_NONE,
     ACCESS_NONE,
@@ -93,10 +97,47 @@ namespace {
 
     ContextClassification->emplace_back(ContextMemberInfo{
       ContextMemberClassification {
+        offsetof(FEXCore::Core::CPUState, es),
+        sizeof(FEXCore::Core::CPUState::es),
+      },
+      DefaultAccess[5],
+      FEXCore::IR::InvalidClass,
+    });
+
+
+    ContextClassification->emplace_back(ContextMemberInfo{
+      ContextMemberClassification {
+        offsetof(FEXCore::Core::CPUState, cs),
+        sizeof(FEXCore::Core::CPUState::cs),
+      },
+      DefaultAccess[6],
+      FEXCore::IR::InvalidClass,
+    });
+
+    ContextClassification->emplace_back(ContextMemberInfo{
+      ContextMemberClassification {
+        offsetof(FEXCore::Core::CPUState, ss),
+        sizeof(FEXCore::Core::CPUState::ss),
+      },
+      DefaultAccess[7],
+      FEXCore::IR::InvalidClass,
+    });
+
+    ContextClassification->emplace_back(ContextMemberInfo{
+      ContextMemberClassification {
+        offsetof(FEXCore::Core::CPUState, ds),
+        sizeof(FEXCore::Core::CPUState::ds),
+      },
+      DefaultAccess[8],
+      FEXCore::IR::InvalidClass,
+    });
+
+    ContextClassification->emplace_back(ContextMemberInfo{
+      ContextMemberClassification {
         offsetof(FEXCore::Core::CPUState, fs),
         sizeof(FEXCore::Core::CPUState::fs),
       },
-      DefaultAccess[5],
+      DefaultAccess[9],
       FEXCore::IR::InvalidClass,
     });
 
@@ -106,7 +147,7 @@ namespace {
           offsetof(FEXCore::Core::CPUState, flags[0]) + sizeof(FEXCore::Core::CPUState::flags[0]) * i,
           sizeof(FEXCore::Core::CPUState::flags[0]),
         },
-        DefaultAccess[6],
+        DefaultAccess[10],
         FEXCore::IR::InvalidClass,
       });
     }
@@ -117,7 +158,7 @@ namespace {
           offsetof(FEXCore::Core::CPUState, mm[0][0]) + sizeof(FEXCore::Core::CPUState::mm[0]) * i,
           sizeof(FEXCore::Core::CPUState::mm[0]),
         },
-        DefaultAccess[7],
+        DefaultAccess[11],
         FEXCore::IR::InvalidClass,
       });
     }
@@ -129,7 +170,7 @@ namespace {
           offsetof(FEXCore::Core::CPUState, gdt[0]) + sizeof(FEXCore::Core::CPUState::gdt[0]) * i,
           sizeof(FEXCore::Core::CPUState::gdt[0]),
         },
-        DefaultAccess[8],
+        DefaultAccess[12],
         FEXCore::IR::InvalidClass,
       });
     }
@@ -163,13 +204,22 @@ namespace {
 
     SetAccess(Offset++, DefaultAccess[4]);
     SetAccess(Offset++, DefaultAccess[5]);
+    SetAccess(Offset++, DefaultAccess[6]);
+    SetAccess(Offset++, DefaultAccess[7]);
+    SetAccess(Offset++, DefaultAccess[8]);
+    SetAccess(Offset++, DefaultAccess[9]);
+
 
     for (size_t i = 0; i < (sizeof(FEXCore::Core::CPUState::flags) / sizeof(FEXCore::Core::CPUState::flags[0])); ++i) {
-      SetAccess(Offset++, DefaultAccess[6]);
+      SetAccess(Offset++, DefaultAccess[10]);
     }
 
     for (size_t i = 0; i < 8; ++i) {
-      SetAccess(Offset++, DefaultAccess[7]);
+      SetAccess(Offset++, DefaultAccess[11]);
+    }
+
+    for (size_t i = 0; i < 32; ++i) {
+      SetAccess(Offset++, DefaultAccess[12]);
     }
   }
 

--- a/External/FEXCore/include/FEXCore/Core/CoreState.h
+++ b/External/FEXCore/include/FEXCore/Core/CoreState.h
@@ -11,6 +11,7 @@ namespace FEXCore::Core {
     uint64_t gregs[16];
     uint64_t : 64;
     uint64_t xmm[16][2];
+    uint16_t es, cs, ss, ds;
     uint64_t gs;
     uint64_t fs;
     uint8_t flags[48];

--- a/unittests/ASM/Primary/Primary_8C.asm
+++ b/unittests/ASM/Primary/Primary_8C.asm
@@ -1,0 +1,34 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x4142",
+    "RBX": "0x4143",
+    "RCX": "0x4144"
+  }
+}
+%endif
+
+; Technically this can result in an invalid selector which can cause faults
+; We currently don't do any selector validation to enforce this
+mov rax, 0x4142
+
+mov es, ax
+
+inc rax
+mov ss, ax
+
+inc rax
+mov ds, ax
+
+; Can't test FS/GS here
+; Behaviour is ill-defined and needs to be worked through
+
+mov rax, 0
+mov rbx, 0
+mov rcx, 0
+
+mov ax, es
+mov bx, ss
+mov cx, ds
+
+hlt


### PR DESCRIPTION
32bit apps are setting GS register that I saw.
64Bit applications can also technically use these instructions but it
has some major limitation that causes applications to never use them