### PR TITLE
 Implements FFREEP Instruction

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -7884,6 +7884,10 @@ constexpr uint16_t PF_F2 = 3;
     {OPDReg(0xDF, 7) | 0x40, 8, &OpDispatchBuilder::FIST<64, true>},
     {OPDReg(0xDF, 7) | 0x80, 8, &OpDispatchBuilder::FIST<64, true>},
 
+      // XXX: This should also set the x87 tag bits to empty
+      // We don't support this currently, so just pop the stack
+      {OPD(0xDF, 0xC0), 8, &OpDispatchBuilder::X87ModifySTP<true>},
+
       {OPD(0xDF, 0xE0), 8, &OpDispatchBuilder::X87FNSTSW},
       {OPD(0xDF, 0xE8), 8, &OpDispatchBuilder::FCOMI<80, false, OpDispatchBuilder::FCOMIFlags::FLAGS_RFLAGS, true>},
       {OPD(0xDF, 0xF0), 8, &OpDispatchBuilder::FCOMI<80, false, OpDispatchBuilder::FCOMIFlags::FLAGS_RFLAGS, true>},

--- a/External/FEXCore/Source/Interface/Core/X86Tables/X87Tables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/X87Tables.cpp
@@ -226,7 +226,15 @@ void InitializeX87Tables() {
     {OPDReg(0xDF, 6), 1, X86InstInfo{"FBSTP", TYPE_X87, FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_POP, 0, nullptr}},
     {OPDReg(0xDF, 7), 1, X86InstInfo{"FISTP", TYPE_X87, FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_POP, 0, nullptr}},
       //  / 0
-      {OPD(0xDF, 0xC0), 8, X86InstInfo{"",        TYPE_INVALID, FLAGS_NONE, 0, nullptr}},
+      //  This instruction is a bit special. This is an undocumented(Almost) x87 instruction.
+      //  https://en.wikipedia.org/wiki/X86_instruction_listings#Undocumented_x87_instructions
+      //  https://www.pagetable.com/?p=16
+      //  AMD Athlon Processor x86 Code Optimization Guide - `Use FFREEP Macro to Pop One Register from the FPU Stack`
+      //  ISA architecture manuals don't talk about this instruction at all
+      //  At some point the Nvidia OpenGL binary driver uses this instruction.
+      //  GCC may also end up emitting this instruction in some rare edge case!
+      //  Almost all x86 CPUs implement this, and it is expected to be around
+      {OPD(0xDF, 0xC0), 8, X86InstInfo{"FFREEP",  TYPE_X87, FLAGS_NONE, 0, nullptr}},
       //  / 1
       {OPD(0xDF, 0xC8), 8, X86InstInfo{"",        TYPE_INVALID, FLAGS_NONE, 0, nullptr}},
       //  / 2

--- a/unittests/ASM/X87/DF_C0.asm
+++ b/unittests/ASM/X87/DF_C0.asm
@@ -1,0 +1,31 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM6":  ["0x8000000000000000", "0x4001"],
+    "MM7":  ["0x8000000000000000", "0x3FFF"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov rax, 0x4000000000000000 ; 2.0
+mov [rdx + 8 * 1], rax
+mov rax, 0x4010000000000000 ; 4.0
+mov [rdx + 8 * 2], rax
+
+fld qword [rdx + 8 * 0]
+fld qword [rdx + 8 * 1]
+
+; Undocumented x87 instruction
+; Sets the tag register to empty for the stack register
+; Then pops the stack
+ffreep st0
+fld qword [rdx + 8 * 2] ; Overwrites previous value
+
+hlt


### PR DESCRIPTION
There's some history for this instruction. It is not in the official
instruction documentations from AMD or Intel but it is supported on
almost every x87 supporting CPU (I think there was some Cyrix that
missed it?)

This was originally implemented by accident on the Intel 80287 CPU.
It was then periodically documented in random documentation.

The instruction behaves exactly like FFREE but then pops the stack after
the operation.
For our current implementation of FFREE, which is a NOP, we just need to
pop the stack.

This was hardware unit tested on both AMD (Threadripper 2990WX) and Intel (i7-1065G7) to behave the same between the two.