### PR TITLE
Fixes LLVM multiblock

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -6932,9 +6932,16 @@ void OpDispatchBuilder::PSADBW(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::UnimplementedOp(OpcodeArgs) {
+  uint8_t GPRSize = CTX->Config.Is64BitMode ? 8 : 4;
+
   // We don't actually support this instruction
   // Multiblock may hit it though
+  _StoreContext(GPRClass, GPRSize, offsetof(FEXCore::Core::CPUState, rip), _Constant(Op->PC));
   _Break(0, 0);
+  BlockSetRIP = true;
+
+  auto NextBlock = CreateNewCodeBlock();
+  SetCurrentCodeBlock(NextBlock);
 }
 
 #undef OpcodeArgs


### PR DESCRIPTION
The break ir op is actually a block ender and it happened that in
regular code paths they were already ending the blocks correctly.

This enforces block ending in the Unimplemented op so multiblock still
generates the invalid code path correctly and it compiles.
We hit these a few times in multiblock for times in the code where it is
checking for CPU features and choosing a code path depending on CPUID
results.

Potentially these could be made in to no-ops since we'll never hit these
codepaths in practice, but it is nicer to break in case we actually do
hit one of these paths.