### PR TITLE
Fixes AtomicSwap IR op on x86

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -4095,22 +4095,25 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
             mov(MemReg, Memory);
             add(MemReg, GetSrc<RA_64>(Op->Header.Args[0].ID()));
           }
-          lock();
           switch (Op->Size) {
           case 1:
             mov(GetDst<RA_8>(Node), GetSrc<RA_8>(Op->Header.Args[1].ID()));
+            lock();
             xchg(byte [MemReg], GetDst<RA_8>(Node));
           break;
           case 2:
             mov(GetDst<RA_16>(Node), GetSrc<RA_16>(Op->Header.Args[1].ID()));
+            lock();
             xchg(word [MemReg], GetDst<RA_8>(Node));
           break;
           case 4:
             mov(GetDst<RA_32>(Node), GetSrc<RA_32>(Op->Header.Args[1].ID()));
+            lock();
             xchg(dword [MemReg], GetDst<RA_8>(Node));
           break;
           case 8:
             mov(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Header.Args[1].ID()));
+            lock();
             xchg(qword [MemReg], GetDst<RA_8>(Node));
           break;
           default:  LogMan::Msg::A("Unhandled AtomicAdd size: %d", Op->Size);


### PR DESCRIPTION
lock prefix needed to go before the xchg, not before the move that was
there