### PR TITLE
uname: Should return x86_64, not x64_64

### DIFF
--- a/External/FEXCore/Source/Interface/HLE/Syscalls/Info.cpp
+++ b/External/FEXCore/Source/Interface/HLE/Syscalls/Info.cpp
@@ -27,7 +27,7 @@ namespace FEXCore::HLE {
       strcpy(buf->nodename, "FEXCore");
       strcpy(buf->release, "5.0.0");
       strcpy(buf->version, "#" FEXCORE_VERSION);
-      strcpy(buf->machine, "x64_64");
+      strcpy(buf->machine, "x86_64");
       return 0;
     });
 


### PR DESCRIPTION
Run into this in CS:GO.
With this fix it progresses much further, but still doesn't get to the menu.