### PR TITLE
Support Environment variables passed as arguments

### DIFF
--- a/Source/Common/ArgumentLoader.cpp
+++ b/Source/Common/ArgumentLoader.cpp
@@ -76,6 +76,11 @@ namespace FEX::ArgLoader {
         .action("store_true")
         .help("Enable unified memory for the emulator");
 
+      EmulationGroup.add_option("-E", "--env")
+        .dest("Env")
+        .help("Adds an environment variable")
+        .action("append");
+
       Parser.add_option_group(EmulationGroup);
     }
     {
@@ -113,7 +118,7 @@ namespace FEX::ArgLoader {
 
       Parser.add_option_group(LoggingGroup);
     }
-      
+
     optparse::Values Options = Parser.parse_args(argc, argv);
 
     {
@@ -175,6 +180,12 @@ namespace FEX::ArgLoader {
       if (Options.is_set_by_user("UnifiedMemory")) {
         bool Option = Options.get("UnifiedMemory");
         Config::Add("UnifiedMemory", std::to_string(Option));
+      }
+
+      if (Options.is_set_by_user("Env")) {
+        for (auto iter = Options.all("Env").begin(); iter != Options.all("Env").end(); ++iter) {
+          Config::Append("Env", *iter);
+        }
       }
     }
 

--- a/Source/Common/Config.h
+++ b/Source/Common/Config.h
@@ -3,6 +3,7 @@
 #include "Common/StringConv.h"
 
 #include <cassert>
+#include <list>
 #include <string>
 #include <string_view>
 
@@ -10,55 +11,66 @@
  * @brief This is a singleton for storing global configuration state
  */
 namespace FEX::Config {
+  template<typename T>
+  class Value;
+
   void Init();
   void Shutdown();
 
   void Add(std::string const &Key, std::string_view const Value);
+  void Append(std::string const &Key, std::string_view const Value);
   bool Exists(std::string const &Key);
-  std::string_view Get(std::string const &Key);
-  std::string_view GetIfExists(std::string const &Key, std::string_view const Default = "");
+  Value<std::string> &Get(std::string const &Key);
+  Value<std::string> *GetIfExists(std::string const &Key);
 
   template<typename T>
-  T Get(std::string const &Key) {
-    T Value;
-    if (!FEX::StrConv::Conv(Get(Key), &Value)) {
-      assert(0 && "Attempted to convert invalid value");
-    }
-    return Value;
-  }
+  T Get(std::string const &Key);
 
   template<typename T>
-  T GetIfExists(std::string const &Key, T Default) {
-    T Value;
-    if (Exists(Key) && FEX::StrConv::Conv(FEX::Config::Get(Key), &Value)) {
-      return Value;
-    }
-    else {
-      return Default;
-    }
-  }
+  T GetIfExists(std::string const &Key, T Default);
+
+  void GetListIfExists(std::string const &Key, std::list<std::string> *List);
 
   template<typename T>
   class Value {
   public:
-    Value(std::string const &key, T Default)
-      : Key {key}
-    {
-      ValueData = GetFromConfig(Key, Default);
+    Value(std::string const &key, std::string_view const Value, bool ConfigBacking)
+      : Key {key} {
+      ValueData = Value;
     }
+
+    template <typename TT = T,
+      typename std::enable_if<!std::is_same<TT, std::string>::value, int>::type = 0>
+    Value(std::string const &key, T Default)
+      : Key {key} {
+      ValueData = FEX::Config::GetIfExists<T>(Key, Default);
+    }
+
+    template <typename TT = T,
+      typename std::enable_if<std::is_same<TT, std::string>::value, int>::type = 0>
+    Value(std::string const &key, T Default)
+      : Key {key} {
+      ValueData = FEX::Config::GetIfExists<T>(Key, Default);
+      FEX::Config::GetListIfExists(Key, &AppendList);
+    }
+
     void Set(T NewValue) {
       ValueData = NewValue;
       FEX::Config::Add(Key, std::to_string(NewValue));
     }
 
+    void Append(T NewValue) {
+      AppendList.emplace_back(NewValue);
+    }
+
     T operator()() { return ValueData; }
+    std::list<T> &All() { return AppendList; }
 
   private:
     std::string const Key;
     T ValueData;
-    T GetFromConfig(std::string const &Key, T Default) {
-      return FEX::Config::GetIfExists(Key, Default);
-    }
+    std::list<T> AppendList;
   };
+
 
 }

--- a/Source/Tests/ELFLoader.cpp
+++ b/Source/Tests/ELFLoader.cpp
@@ -102,6 +102,7 @@ int main(int argc, char **argv, char **const envp) {
   FEX::Config::Value<bool> UnifiedMemory{"UnifiedMemory", true};
   FEX::Config::Value<std::string> LDPath{"RootFS", ""};
   FEX::Config::Value<bool> SilentLog{"SilentLog", false};
+  FEX::Config::Value<std::string> Environment{"Env", ""};
 
   ::SilentLog = SilentLog();
 
@@ -110,7 +111,7 @@ int main(int argc, char **argv, char **const envp) {
 
   LogMan::Throw::A(!Args.empty(), "Not enough arguments");
 
-  FEX::HarnessHelper::ELFCodeLoader Loader{Args[0], LDPath(), Args, ParsedArgs, envp};
+  FEX::HarnessHelper::ELFCodeLoader Loader{Args[0], LDPath(), Args, ParsedArgs, envp, &Environment};
 
   FEXCore::Context::InitializeStaticTables(Loader.Is64BitMode() ? FEXCore::Context::MODE_64BIT : FEXCore::Context::MODE_32BIT);
   uint64_t VMemSize = 1ULL << 36;

--- a/Source/Tests/HarnessHelpers.h
+++ b/Source/Tests/HarnessHelpers.h
@@ -385,7 +385,7 @@ namespace FEX::HarnessHelper {
 
 class ELFCodeLoader final : public FEXCore::CodeLoader {
 public:
-  ELFCodeLoader(std::string const &Filename, std::string const &RootFS, [[maybe_unused]] std::vector<std::string> const &args, std::vector<std::string> const &ParsedArgs, char **const envp = nullptr)
+  ELFCodeLoader(std::string const &Filename, std::string const &RootFS, [[maybe_unused]] std::vector<std::string> const &args, std::vector<std::string> const &ParsedArgs, char **const envp = nullptr, FEX::Config::Value<std::string> *AdditionalEnvp = nullptr)
     : File {Filename, RootFS, false}
     , DB {&File}
     , Args {args} {
@@ -402,6 +402,13 @@ public:
         if (envp[i] == nullptr)
           break;
         EnvironmentVariables.emplace_back(envp[i]);
+      }
+    }
+
+    if (!!AdditionalEnvp) {
+      auto EnvpList = AdditionalEnvp->All();
+      for (auto iter = EnvpList.begin(); iter != EnvpList.end(); ++iter) {
+        EnvironmentVariables.emplace_back(*iter);
       }
     }
 


### PR DESCRIPTION
This allows us to pass environment variables that only exist for the guest and don't pollute the host environment.
This can be useful for many reasons, like glibc environment variables that we don't want to be in the host space.

ex. `./Bin/ELFLoader -E DISPLAY=:0 -E GALLIUM_HUD=fps,cpu /usr/bin/glxgears`