### PR TITLE
AArch64 TSO loadstore ops

### DIFF
--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -122,6 +122,7 @@ set (SRCS
   Interface/Core/Frontend.cpp
   Interface/Core/GdbServer.cpp
   Interface/Core/OpcodeDispatcher.cpp
+  Interface/Core/SignalDelegator.cpp
   Interface/Core/X86Tables.cpp
   Interface/Core/X86DebugInfo.cpp
   Interface/Core/Interpreter/InterpreterCore.cpp

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -3,6 +3,7 @@
 #include "Interface/Core/CPUID.h"
 #include "Interface/Core/Frontend.h"
 #include "Interface/Core/InternalThreadState.h"
+#include "Interface/Core/SignalDelegator.h"
 #include "Interface/HLE/Syscalls.h"
 #include "Interface/Memory/MemMapper.h"
 #include "Interface/IR/PassManager.h"
@@ -83,11 +84,11 @@ namespace FEXCore::Context {
     CustomCPUFactoryType FallbackCPUFactory;
     std::function<void(uint64_t ThreadId, FEXCore::Context::ExitReason)> CustomExitHandler;
 
-
-
 #ifdef BLOCKSTATS
     std::unique_ptr<FEXCore::BlockSamplingData> BlockData;
 #endif
+
+    SignalDelegator SignalDelegation;
 
     Context();
     ~Context();
@@ -161,6 +162,5 @@ namespace FEXCore::Context {
 #if ENABLE_JITSYMBOLS
     FEXCore::JITSymbols Symbols;
 #endif
-
   };
 }

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -124,7 +124,8 @@ namespace DefaultFallbackCore {
 }
 
 namespace FEXCore::Context {
-  Context::Context() {
+  Context::Context()
+    : SignalDelegation {this} {
     FallbackCPUFactory = FEXCore::Core::DefaultFallbackCore::CPUCreationFactory;
 #ifdef BLOCKSTATS
     BlockData = std::make_unique<FEXCore::BlockSamplingData>();
@@ -679,6 +680,7 @@ namespace FEXCore::Context {
 
     // Let's do some initial bookkeeping here
     Thread->State.ThreadManager.TID = ::gettid();
+    SignalDelegation.RegisterTLSState(Thread);
     ++IdleWaitRefCount;
 
     LogMan::Msg::D("[%d] Waiting to run", Thread->State.ThreadManager.TID.load());

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -561,7 +561,8 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
             *Data = Arg;
             break;
           }
-          case IR::OP_LOADMEM: {
+          case IR::OP_LOADMEM:
+          case IR::OP_LOADMEMTSO: {
             auto Op = IROp->C<IR::IROp_LoadMem>();
             void const *Data{};
             if (Thread->CTX->Config.UnifiedMemory) {
@@ -590,7 +591,8 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
               Data, Op->Header.ElementSize);
             break;
           }
-          case IR::OP_STOREMEM: {
+          case IR::OP_STOREMEM:
+          case IR::OP_STOREMEMTSO: {
             #define STORE_DATA(x, y) \
               case x: { \
                 y *Data{}; \

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
@@ -25,10 +25,8 @@ DEF_OP(GuestReturn) {
 }
 
 DEF_OP(ExitFunction) {
-  if (SpillSlots) {
-    add(sp, sp, SpillSlots * 16);
-  }
-
+  ldp(TMP1, lr, MemOperand(sp, 16, PostIndex));
+  add(sp, TMP1, 0); // Move that supports SP
   ret();
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -369,7 +369,13 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
   }
 
   if (SpillSlots) {
+    add(TMP1, sp, 0); // Move that supports SP
     sub(sp, sp, SpillSlots * 16);
+    stp(TMP1, lr, MemOperand(sp, -16, PreIndex));
+  }
+  else {
+    add(TMP1, sp, 0); // Move that supports SP
+    stp(TMP1, lr, MemOperand(sp, -16, PreIndex));
   }
 
   IR::OrderedNode *BlockNode = HeaderOp->Blocks.GetNode(ListBegin);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -310,6 +310,8 @@ private:
   DEF_OP(StoreFlag);
   DEF_OP(LoadMem);
   DEF_OP(StoreMem);
+  DEF_OP(LoadMemTSO);
+  DEF_OP(StoreMemTSO);
   DEF_OP(VLoadMemElement);
   DEF_OP(VStoreMemElement);
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -102,6 +102,9 @@ public:
 
   void ClearCache() override;
 
+  bool HandleSIGBUS(int Signal, void *info, void *ucontext);
+  bool HandleSIGSEGV(int Signal, void *info, void *ucontext);
+
 private:
   FEXCore::Context::Context *CTX;
   FEXCore::Core::InternalThreadState *State;

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -299,7 +299,7 @@ DEF_OP(StoreContextIndexed) {
 DEF_OP(SpillRegister) {
   auto Op = IROp->C<IR::IROp_SpillRegister>();
   uint8_t OpSize = IROp->Size;
-  uint32_t SlotOffset = Op->Slot * 16;
+  uint32_t SlotOffset = Op->Slot * 16 + 16;
   switch (OpSize) {
   case 1: {
     strb(GetReg<RA_64>(Op->Header.Args[0].ID()), MemOperand(sp, SlotOffset));
@@ -328,7 +328,7 @@ DEF_OP(SpillRegister) {
 DEF_OP(FillRegister) {
   auto Op = IROp->C<IR::IROp_FillRegister>();
   uint8_t OpSize = IROp->Size;
-  uint32_t SlotOffset = Op->Slot * 16;
+  uint32_t SlotOffset = Op->Slot * 16 + 16;
   switch (OpSize) {
   case 1: {
     ldrb(GetReg<RA_64>(Node), MemOperand(sp, SlotOffset));

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -1828,7 +1828,8 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
           mov (Dst, rax);
           break;
         }
-        case IR::OP_LOADMEM: {
+        case IR::OP_LOADMEM:
+        case IR::OP_LOADMEMTSO: {
           auto Op = IROp->C<IR::IROp_LoadMem>();
           uint64_t Memory = CTX->MemoryMapper.GetBaseOffset<uint64_t>(0);
 
@@ -1899,7 +1900,8 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
           }
           break;
         }
-        case IR::OP_STOREMEM: {
+        case IR::OP_STOREMEM:
+        case IR::OP_STOREMEMTSO: {
           auto Op = IROp->C<IR::IROp_StoreMem>();
           uint64_t Memory = CTX->MemoryMapper.GetBaseOffset<uint64_t>(0);
 

--- a/External/FEXCore/Source/Interface/Core/LLVMJIT/LLVMCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/LLVMJIT/LLVMCore.cpp
@@ -3961,7 +3961,8 @@ void LLVMJITCore::HandleIR(FEXCore::IR::IRListView<true> const *IR, IR::NodeWrap
       SetDest(*WrapperOp, Result);
     break;
     }
-    case IR::OP_LOADMEM: {
+    case IR::OP_LOADMEM:
+    case IR::OP_LOADMEMTSO: {
       auto Op = IROp->C<IR::IROp_LoadMem>();
       auto Src = GetSrc(Op->Header.Args[0]);
 
@@ -3974,7 +3975,8 @@ void LLVMJITCore::HandleIR(FEXCore::IR::IRListView<true> const *IR, IR::NodeWrap
       SetDest(*WrapperOp, Result);
     break;
     }
-    case IR::OP_STOREMEM: {
+    case IR::OP_STOREMEM:
+    case IR::OP_STOREMEMTSO: {
       auto Op = IROp->C<IR::IROp_StoreMem>();
 
       auto Dst = GetSrc(Op->Header.Args[0]);

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -1799,7 +1799,7 @@ void OpDispatchBuilder::BTOp(OpcodeArgs) {
 
     // Now add the addresses together and load the memory
     OrderedNode *MemoryLocation = _Add(Dest, Src);
-    Result = _LoadMem(GPRClass, 1, MemoryLocation, 1);
+    Result = _LoadMemTSO(GPRClass, 1, MemoryLocation, 1);
 
     // Now shift in to the correct bit location
     Result = _Lshr(Result, BitSelect);
@@ -1844,14 +1844,14 @@ void OpDispatchBuilder::BTROp(OpcodeArgs) {
 
     // Now add the addresses together and load the memory
     OrderedNode *MemoryLocation = _Add(Dest, Src);
-    OrderedNode *Value = _LoadMem(GPRClass, 1, MemoryLocation, 1);
+    OrderedNode *Value = _LoadMemTSO(GPRClass, 1, MemoryLocation, 1);
 
     // Now shift in to the correct bit location
     Result = _Lshr(Value, BitSelect);
     OrderedNode *BitMask = _Lshl(_Constant(1), BitSelect);
     BitMask = _Not(BitMask);
     Value = _And(Value, BitMask);
-    _StoreMem(GPRClass, 1, MemoryLocation, Value, 1);
+    _StoreMemTSO(GPRClass, 1, MemoryLocation, Value, 1);
   }
   SetRFLAG<FEXCore::X86State::RFLAG_CF_LOC>(Result);
 }
@@ -1892,13 +1892,13 @@ void OpDispatchBuilder::BTSOp(OpcodeArgs) {
 
     // Now add the addresses together and load the memory
     OrderedNode *MemoryLocation = _Add(Dest, Src);
-    OrderedNode *Value = _LoadMem(GPRClass, 1, MemoryLocation, 1);
+    OrderedNode *Value = _LoadMemTSO(GPRClass, 1, MemoryLocation, 1);
 
     // Now shift in to the correct bit location
     Result = _Lshr(Value, BitSelect);
     OrderedNode *BitMask = _Lshl(_Constant(1), BitSelect);
     Value = _Or(Value, BitMask);
-    _StoreMem(GPRClass, 1, MemoryLocation, Value, 1);
+    _StoreMemTSO(GPRClass, 1, MemoryLocation, Value, 1);
   }
   SetRFLAG<FEXCore::X86State::RFLAG_CF_LOC>(Result);
 }
@@ -1938,13 +1938,13 @@ void OpDispatchBuilder::BTCOp(OpcodeArgs) {
 
     // Now add the addresses together and load the memory
     OrderedNode *MemoryLocation = _Add(Dest, Src);
-    OrderedNode *Value = _LoadMem(GPRClass, 1, MemoryLocation, 1);
+    OrderedNode *Value = _LoadMemTSO(GPRClass, 1, MemoryLocation, 1);
 
     // Now shift in to the correct bit location
     Result = _Lshr(Value, BitSelect);
     OrderedNode *BitMask = _Lshl(_Constant(1), BitSelect);
     Value = _Xor(Value, BitMask);
-    _StoreMem(GPRClass, 1, MemoryLocation, Value, 1);
+    _StoreMemTSO(GPRClass, 1, MemoryLocation, Value, 1);
   }
   SetRFLAG<FEXCore::X86State::RFLAG_CF_LOC>(Result);
 }
@@ -2142,7 +2142,7 @@ void OpDispatchBuilder::XLATOp(OpcodeArgs) {
   }
   Src = _Add(Src, Offset);
 
-  auto Res = _LoadMem(GPRClass, 1, Src, 1);
+  auto Res = _LoadMemTSO(GPRClass, 1, Src, 1);
 
   _StoreContext(GPRClass, 1, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RAX]), Res);
 }
@@ -2290,7 +2290,7 @@ void OpDispatchBuilder::STOSOp(OpcodeArgs) {
     OrderedNode *Dest = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RDI]), GPRClass);
 
     // Store to memory where RDI points
-    _StoreMem(GPRClass, Size, Dest, Src, Size);
+    _StoreMemTSO(GPRClass, Size, Dest, Src, Size);
 
     auto SizeConst = _Constant(Size);
     auto NegSizeConst = _Constant(-Size);
@@ -2338,7 +2338,7 @@ void OpDispatchBuilder::STOSOp(OpcodeArgs) {
         OrderedNode *Dest = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RDI]), GPRClass);
 
         // Store to memory where RDI points
-        _StoreMem(GPRClass, Size, Dest, Src, Size);
+        _StoreMemTSO(GPRClass, Size, Dest, Src, Size);
 
         OrderedNode *TailCounter = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RCX]), GPRClass);
         OrderedNode *TailDest = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RDI]), GPRClass);
@@ -2411,10 +2411,10 @@ void OpDispatchBuilder::MOVSOp(OpcodeArgs) {
         OrderedNode *Src = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RSI]), GPRClass);
         OrderedNode *Dest = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RDI]), GPRClass);
 
-        Src = _LoadMem(GPRClass, Size, Src, Size);
+        Src = _LoadMemTSO(GPRClass, Size, Src, Size);
 
         // Store to memory where RDI points
-        _StoreMem(GPRClass, Size, Dest, Src, Size);
+        _StoreMemTSO(GPRClass, Size, Dest, Src, Size);
 
         OrderedNode *TailCounter = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RCX]), GPRClass);
 
@@ -2454,10 +2454,10 @@ void OpDispatchBuilder::MOVSOp(OpcodeArgs) {
     OrderedNode *RSI = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RSI]), GPRClass);
     OrderedNode *RDI = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RDI]), GPRClass);
 
-    auto Src = _LoadMem(GPRClass, Size, RSI, Size);
+    auto Src = _LoadMemTSO(GPRClass, Size, RSI, Size);
 
     // Store to memory where RDI points
-    _StoreMem(GPRClass, Size, RDI, Src, Size);
+    _StoreMemTSO(GPRClass, Size, RDI, Src, Size);
 
     auto SizeConst = _Constant(Size);
     auto NegSizeConst = _Constant(-Size);
@@ -2490,8 +2490,8 @@ void OpDispatchBuilder::CMPSOp(OpcodeArgs) {
     OrderedNode *Dest_RDI = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RDI]), GPRClass);
     OrderedNode *Dest_RSI = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RSI]), GPRClass);
 
-    auto Src1 = _LoadMem(GPRClass, Size, Dest_RDI, Size);
-    auto Src2 = _LoadMem(GPRClass, Size, Dest_RSI, Size);
+    auto Src1 = _LoadMemTSO(GPRClass, Size, Dest_RDI, Size);
+    auto Src2 = _LoadMemTSO(GPRClass, Size, Dest_RSI, Size);
 
     auto ALUOp = _Sub(Src1, Src2);
     GenerateFlags_SUB(Op, _Bfe(Size * 8, 0, ALUOp), _Bfe(Size * 8, 0, Src1), _Bfe(Size * 8, 0, Src2));
@@ -2537,7 +2537,7 @@ void OpDispatchBuilder::CMPSOp(OpcodeArgs) {
         OrderedNode *Dest_RDI = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RDI]), GPRClass);
         OrderedNode *Dest_RSI = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RSI]), GPRClass);
 
-        auto Src1 = _LoadMem(GPRClass, Size, Dest_RDI, Size);
+        auto Src1 = _LoadMemTSO(GPRClass, Size, Dest_RDI, Size);
         auto Src2 = _LoadMem(GPRClass, Size, Dest_RSI, Size);
 
         auto ALUOp = _Sub(Src1, Src2);
@@ -2604,7 +2604,7 @@ void OpDispatchBuilder::LODSOp(OpcodeArgs) {
   if (!Repeat) {
     OrderedNode *Dest_RSI = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RSI]), GPRClass);
 
-    auto Src = _LoadMem(GPRClass, Size, Dest_RSI, Size);
+    auto Src = _LoadMemTSO(GPRClass, Size, Dest_RSI, Size);
 
     StoreResult(GPRClass, Op, Src, -1);
 
@@ -2654,7 +2654,7 @@ void OpDispatchBuilder::LODSOp(OpcodeArgs) {
       {
         OrderedNode *Dest_RSI = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RSI]), GPRClass);
 
-        auto Src = _LoadMem(GPRClass, Size, Dest_RSI, Size);
+        auto Src = _LoadMemTSO(GPRClass, Size, Dest_RSI, Size);
 
         StoreResult(GPRClass, Op, Src, -1);
 
@@ -2702,7 +2702,7 @@ void OpDispatchBuilder::SCASOp(OpcodeArgs) {
     OrderedNode *Dest_RDI = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RDI]), GPRClass);
 
     auto Src1 = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
-    auto Src2 = _LoadMem(GPRClass, Size, Dest_RDI, Size);
+    auto Src2 = _LoadMemTSO(GPRClass, Size, Dest_RDI, Size);
 
     auto ALUOp = _Sub(Src1, Src2);
 
@@ -2753,7 +2753,7 @@ void OpDispatchBuilder::SCASOp(OpcodeArgs) {
         OrderedNode *Dest_RDI = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RDI]), GPRClass);
 
         auto Src1 = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
-        auto Src2 = _LoadMem(GPRClass, Size, Dest_RDI, Size);
+        auto Src2 = _LoadMemTSO(GPRClass, Size, Dest_RDI, Size);
 
         auto ALUOp = _Sub(Src1, Src2);
         GenerateFlags_SUB(Op, _Bfe(Size * 8, 0, ALUOp), _Bfe(Size * 8, 0, Src1), _Bfe(Size * 8, 0, Src2));
@@ -3725,6 +3725,7 @@ OrderedNode *OpDispatchBuilder::LoadSource_WithOpSize(FEXCore::IR::RegisterClass
 
   OrderedNode *Src {nullptr};
   bool LoadableType = false;
+  bool StackAccess = false;
   uint8_t GPRSize = CTX->Config.Is64BitMode ? 8 : 4;
 
   if (Operand.TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL) {
@@ -3744,6 +3745,7 @@ OrderedNode *OpDispatchBuilder::LoadSource_WithOpSize(FEXCore::IR::RegisterClass
   else if (Operand.TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_GPR_DIRECT) {
     Src = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[Operand.TypeGPR.GPR]), GPRClass);
     LoadableType = true;
+    StackAccess = Operand.TypeGPR.GPR == FEXCore::X86State::REG_RSP;
   }
   else if (Operand.TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_GPR_INDIRECT) {
     auto GPR = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[Operand.TypeGPRIndirect.GPR]), GPRClass);
@@ -3752,6 +3754,7 @@ OrderedNode *OpDispatchBuilder::LoadSource_WithOpSize(FEXCore::IR::RegisterClass
 		Src = _Add(GPR, Constant);
 
     LoadableType = true;
+    StackAccess = Operand.TypeGPRIndirect.GPR == FEXCore::X86State::REG_RSP;
   }
   else if (Operand.TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_RIP_RELATIVE) {
     if (CTX->Config.Is64BitMode) {
@@ -3773,6 +3776,7 @@ OrderedNode *OpDispatchBuilder::LoadSource_WithOpSize(FEXCore::IR::RegisterClass
         auto Constant = _Constant(GPRSize * 8, Operand.TypeSIB.Scale);
         Tmp = _Mul(Tmp, Constant);
       }
+      StackAccess |= Operand.TypeSIB.Index == FEXCore::X86State::REG_RSP;
     }
 
     if (Operand.TypeSIB.Base != FEXCore::X86State::REG_INVALID) {
@@ -3784,6 +3788,7 @@ OrderedNode *OpDispatchBuilder::LoadSource_WithOpSize(FEXCore::IR::RegisterClass
       else {
         Tmp = GPR;
       }
+      StackAccess |= Operand.TypeSIB.Base == FEXCore::X86State::REG_RSP;
     }
 
     if (Operand.TypeSIB.Offset) {
@@ -3830,7 +3835,12 @@ OrderedNode *OpDispatchBuilder::LoadSource_WithOpSize(FEXCore::IR::RegisterClass
       }
     }
 
-    Src = _LoadMem(Class, OpSize, Src, Align == -1 ? OpSize : Align);
+    if (StackAccess) {
+      Src = _LoadMem(Class, OpSize, Src, Align == -1 ? OpSize : Align);
+    }
+    else {
+      Src = _LoadMemTSO(Class, OpSize, Src, Align == -1 ? OpSize : Align);
+    }
   }
   return Src;
 }
@@ -3853,6 +3863,7 @@ void OpDispatchBuilder::StoreResult_WithOpSize(FEXCore::IR::RegisterClassType Cl
   // 32bit ops ZEXT the result to 64bit
   OrderedNode *MemStoreDst {nullptr};
   bool MemStore = false;
+  bool StackAccess = false;
   uint8_t GPRSize = CTX->Config.Is64BitMode ? 8 : 4;
 
   if (Operand.TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL) {
@@ -3882,6 +3893,7 @@ void OpDispatchBuilder::StoreResult_WithOpSize(FEXCore::IR::RegisterClassType Cl
   else if (Operand.TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_GPR_DIRECT) {
     MemStoreDst = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[Operand.TypeGPR.GPR]), GPRClass);
     MemStore = true;
+    StackAccess = Operand.TypeGPR.GPR == FEXCore::X86State::REG_RSP;
   }
   else if (Operand.TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_GPR_INDIRECT) {
     auto GPR = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[Operand.TypeGPRIndirect.GPR]), GPRClass);
@@ -3889,6 +3901,7 @@ void OpDispatchBuilder::StoreResult_WithOpSize(FEXCore::IR::RegisterClassType Cl
 
     MemStoreDst = _Add(GPR, Constant);
     MemStore = true;
+    StackAccess = Operand.TypeGPRIndirect.GPR == FEXCore::X86State::REG_RSP;
   }
   else if (Operand.TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_RIP_RELATIVE) {
     MemStoreDst = _Constant(GPRSize * 8, Operand.TypeRIPLiteral.Literal + Op->PC + Op->InstSize);
@@ -3964,7 +3977,12 @@ void OpDispatchBuilder::StoreResult_WithOpSize(FEXCore::IR::RegisterClassType Cl
       auto DestAddr = _Add(MemStoreDst, _Constant(8));
       _StoreMem(GPRClass, 2, DestAddr, Upper, std::min<uint8_t>(Align, 8));
     } else {
-      _StoreMem(Class, OpSize, MemStoreDst, Src, Align == -1 ? OpSize : Align);
+      if (StackAccess) {
+        _StoreMem(Class, OpSize, MemStoreDst, Src, Align == -1 ? OpSize : Align);
+      }
+      else {
+        _StoreMemTSO(Class, OpSize, MemStoreDst, Src, Align == -1 ? OpSize : Align);
+      }
     }
   }
 }

--- a/External/FEXCore/Source/Interface/Core/SignalDelegator.cpp
+++ b/External/FEXCore/Source/Interface/Core/SignalDelegator.cpp
@@ -1,0 +1,207 @@
+#include "Interface/Context/Context.h"
+#include "Interface/Core/InternalThreadState.h"
+#include "Interface/Core/SignalDelegator.h"
+#include <LogManager.h>
+
+#include <string.h>
+
+namespace FEXCore {
+  // We can only have one delegator per process
+  static SignalDelegator *GlobalDelegator{};
+
+  struct ThreadState {
+    FEXCore::Core::InternalThreadState *Thread{};
+  };
+
+  thread_local ThreadState ThreadData{};
+
+  static void SignalHandlerThunk(int Signal, siginfo_t *Info, void *UContext) {
+    GlobalDelegator->HandleSignal(Signal, Info, UContext);
+  }
+
+  static bool IsSynchronous(int Signal) {
+    switch (Signal) {
+    case SIGBUS:
+    case SIGFPE:
+    case SIGILL:
+    case SIGSEGV:
+    case SIGTRAP:
+      return true;
+    default: break;
+    };
+    return false;
+  }
+
+  void SignalDelegator::HandleSignal(int Signal, void *Info, void *UContext) {
+    // Let the host take first stab at handling the signal
+
+    auto Thread = ThreadData.Thread;
+    SignalHandler &Handler = HostHandlers[Signal];
+    if (Handler.Handler &&
+        Handler.Handler(Thread, Signal, Info, UContext)) {
+      // If the host handler handled the fault then we can continue now
+      return;
+    }
+
+    if (Signal == SIGCHLD) {
+      // Do some special handling around this signal
+      // If the guest has a signal handler installed with SA_NOCLDSTOP or SA_NOCHLDWAIT then
+      // handle carefully
+      if (Handler.GuestAction.sa_flags & SA_NOCLDSTOP) {
+        // No signal is generated in this case
+        // just safely return
+        // XXX: If this was a child that exited then don't deliver the signal
+        // If called from signal then it still need to be delivered
+        // Handle this
+      }
+
+      if (Handler.GuestAction.sa_flags & SA_NOCLDWAIT) {
+        // Linux will still generate a signal for this
+        // POSIX leaves it unspecific
+        // "do not transform children in to zombies when they terminate"
+        // XXX: Handle this
+      }
+    }
+
+    // XXX: Setup our state to jump back in to the JIT at the guest handler's location
+    // TLS is safe on x86-64 and AArch64 hosts
+    if (!Thread) {
+      LogMan::Msg::E("Thread has received a signal and hasn't registered itself with the delegate! Programming error!");
+    }
+    else {
+      // We have an emulation thread pointer, we can now modify its state
+      if (Handler.GuestAction.sa_handler == SIG_DFL) {
+        // XXX: Maybe this should actually go down guest handler state?
+        signal(Signal, SIG_DFL);
+        return;
+      }
+      else if (Handler.GuestAction.sa_handler == SIG_IGN) {
+        return;
+      }
+      else {
+        // XXX: Handle the guest signal and return here
+        ERROR_AND_DIE("Unhandled guest exception");
+      }
+    }
+
+    // Unhandled crash
+    // Call back in to the previous handler
+    if (Handler.OldAction.sa_flags & SA_SIGINFO) {
+      Handler.OldAction.sa_sigaction(Signal, static_cast<siginfo_t*>(Info), UContext);
+    }
+    else if (Handler.OldAction.sa_handler == SIG_DFL) {
+      signal(Signal, SIG_DFL);
+    }
+    else if (Handler.OldAction.sa_handler == SIG_IGN) {
+    }
+    else {
+      Handler.OldAction.sa_handler(Signal);
+    }
+  }
+
+  void SignalDelegator::InstallHostThunk(int Signal) {
+    // If the host thunk is already installed for this, just return
+    if (HostHandlers[Signal].Installed) {
+      return;
+    }
+
+    // Now install the thunk handler
+    struct sigaction act{};
+    act.sa_sigaction = &SignalHandlerThunk;
+    act.sa_flags = SA_SIGINFO | SA_RESTART;
+
+    // We don't care about the previous handler in this case
+    int Result = sigaction(Signal, &act, &HostHandlers[Signal].OldAction);
+    if (Result < 0) {
+      LogMan::Msg::D("Failed to install host signal thunk for signal %d: %s", Signal, strerror(errno));
+      return;
+    }
+
+    HostHandlers[Signal].Installed = true;
+  }
+
+  SignalDelegator::SignalDelegator(FEXCore::Context::Context *ctx)
+    : CTX {ctx} {
+    // Register this delegate
+    LogMan::Throw::A(!GlobalDelegator, "Can't register global delegator multiple times!");
+    GlobalDelegator = this;
+
+    // XXX: Let's just say that these are installed for now
+    // We can't have the guest capturing these yet so it would do nothing
+    // Resulting in Ctrl-C and Ctrl-\ breaking
+    HostHandlers[SIGINT].Installed = true;
+    HostHandlers[SIGQUIT].Installed = true;
+
+    // glibc reserves these two signals internally
+    // __SIGRTMIN(32) is used for a "cancellation" signal
+    // __SIGRTMIN+1 is used for setuid handling
+    // "Userspace" SIGRTMIN starts at 34 because of this
+    HostHandlers[__SIGRTMIN].Installed   = true;
+    HostHandlers[__SIGRTMIN+1].Installed = true;
+  }
+
+  void SignalDelegator::RegisterTLSState(FEXCore::Core::InternalThreadState *Thread) {
+    ThreadData.Thread = Thread;
+  }
+
+  void SignalDelegator::MaskSignals(int how) {
+    // If we have a helper thread, we need to mask a significant amount of signals so the an errant thread doesn't receive a signal that it shouldn't
+    sigset_t SignalSet{};
+    sigemptyset(&SignalSet);
+
+    for (int i = 0; i < MAX_SIGNALS; ++i) {
+      // If it is a synchronous signal then don't ignore it
+      if (IsSynchronous(i)) {
+        continue;
+      }
+
+      // Add this signal to the ignore list
+      sigaddset(&SignalSet, i);
+    }
+
+    // Be warned, a thread will inherit the signal mask if created from this thread
+    int Result = pthread_sigmask(how, &SignalSet, nullptr);
+    if (Result != 0) {
+      LogMan::Msg::D("Couldn't register thread to mask signals");
+    }
+  }
+
+  void SignalDelegator::MaskThreadSignals() {
+    MaskSignals(SIG_BLOCK);
+  }
+
+  void SignalDelegator::ResetThreadSignalMask() {
+    MaskSignals(SIG_UNBLOCK);
+  }
+
+  void SignalDelegator::RegisterHostSignalHandler(int Signal, HostSignalDelegatorFunction Func) {
+    // Linux signal handlers are per-process rather than per thread
+    // Multiple threads could be calling in to this
+    std::lock_guard<std::mutex> lk(HostDelegatorMutex);
+    HostHandlers[Signal].Handler = Func;
+    InstallHostThunk(Signal);
+  }
+
+  uint64_t SignalDelegator::RegisterGuestSignalHandler(int Signal, const struct sigaction *Action, struct sigaction *OldAction) {
+    std::lock_guard<std::mutex> lk(GuestDelegatorMutex);
+
+    // If we have an old signal set then give it back
+    if (OldAction) {
+      *OldAction = HostHandlers[Signal].GuestAction;
+    }
+
+    // Now assign the new action
+    if (Action) {
+      // These signal dispositions can't be changed on Linux
+      if (Signal == SIGKILL || Signal == SIGSTOP) {
+        return -EINVAL;
+      }
+
+      HostHandlers[Signal].GuestAction = *Action;
+      // Only attempt to install a new thunk handler if we were installing a new guest action
+      InstallHostThunk(Signal);
+    }
+
+    return 0;
+  }
+}

--- a/External/FEXCore/Source/Interface/Core/SignalDelegator.h
+++ b/External/FEXCore/Source/Interface/Core/SignalDelegator.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <atomic>
+#include <functional>
+#include <mutex>
+#include <signal.h>
+
+namespace FEXCore {
+namespace Context {
+  struct Context;
+}
+namespace Core {
+  struct InternalThreadState;
+}
+
+  class SignalDelegator {
+  public:
+    // Returns true if the host handled the signal
+    // Arguments are the same as sigaction handler
+    using HostSignalDelegatorFunction = std::function<bool(FEXCore::Core::InternalThreadState *Thread, int Signal, void *info, void *ucontext)>;
+    SignalDelegator(FEXCore::Context::Context *ctx);
+
+    /**
+     * @brief Registers an emulated thread's object to a TLS object
+     *
+     * Required to know which thread has received the signal when it occurs
+     */
+    static void RegisterTLSState(FEXCore::Core::InternalThreadState *Thread);
+
+    /**
+     * @brief Masks a thread from receiving any signals that aren't synchronous
+     *
+     * Any helper thread that is generated needs to call this routine to ensure it doesn't receive errant signals to handle
+     */
+    static void MaskThreadSignals();
+
+    /**
+     * @brief Reallows a thread to receive signals
+     *
+     * Must be careful with this if you're planning on having signals enabled while emulation is running
+     */
+    static void ResetThreadSignalMask();
+
+    /**
+     * @brief Registers a signal handler for the host to handle a signal
+     *
+     * It's a process level signal handler so one must be careful
+     */
+    void RegisterHostSignalHandler(int Signal, HostSignalDelegatorFunction Func);
+    /**
+     * @brief Allows the guest to register a signal handler that is run after the host attempts to resolve the handler first
+     */
+    uint64_t RegisterGuestSignalHandler(int Signal, const struct sigaction *Action, struct sigaction *OldAction);
+
+    // Called from the thunk handler to handle the signal
+    void HandleSignal(int Signal, void *Info, void *UContext);
+
+  private:
+    FEXCore::Context::Context *CTX;
+
+    constexpr static size_t MAX_SIGNALS {64};
+    struct SignalHandler {
+      std::atomic<bool> Installed{};
+      struct sigaction OldAction{};
+      HostSignalDelegatorFunction Handler{};
+      struct sigaction GuestAction{};
+    };
+
+    SignalHandler HostHandlers[MAX_SIGNALS]{};
+    void InstallHostThunk(int Signal);
+
+    std::mutex HostDelegatorMutex;
+    std::mutex GuestDelegatorMutex;
+
+    static void MaskSignals(int how);
+  };
+}

--- a/External/FEXCore/Source/Interface/HLE/Syscalls/Signals.cpp
+++ b/External/FEXCore/Source/Interface/HLE/Syscalls/Signals.cpp
@@ -11,16 +11,17 @@ namespace FEXCore::HLE {
 
   void RegisterSignals() {
     REGISTER_SYSCALL_IMPL(rt_sigaction, [](FEXCore::Core::InternalThreadState *Thread, int signum, const struct sigaction *act, struct sigaction *oldact) -> uint64_t {
-      uint64_t Result = ::sigaction(signum, act, oldact);
-      SYSCALL_ERRNO();
+      return Thread->CTX->SignalDelegation.RegisterGuestSignalHandler(signum, act, oldact);
     });
 
     REGISTER_SYSCALL_IMPL(rt_sigprocmask, [](FEXCore::Core::InternalThreadState *Thread, int how, const sigset_t *set, sigset_t *oldset) -> uint64_t {
+      // XXX: Pass through SignalDelegator
       uint64_t Result = ::sigprocmask(how, set, oldset);
       SYSCALL_ERRNO();
     });
 
     REGISTER_SYSCALL_IMPL(sigaltstack, [](FEXCore::Core::InternalThreadState *Thread, const stack_t *ss, stack_t *old_ss) -> uint64_t {
+      // XXX: Pass through SignalDelegator
       uint64_t Result = ::sigaltstack(ss, old_ss);
       SYSCALL_ERRNO();
     });

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -514,6 +514,41 @@
       ]
     },
 
+    "LoadMemTSO": {
+      "Desc": ["Does a x86 TSO compatible load from memory."
+              ],
+      "OpClass": "Memory",
+      "HasDest": true,
+      "DestClass": "Complex",
+      "DestSize": "Size",
+      "SSAArgs": "1",
+      "SSANames": [
+        "Addr"
+      ],
+      "Args": [
+        "uint8_t", "Size",
+        "uint8_t", "Align",
+        "RegisterClassType", "Class"
+      ]
+    },
+
+    "StoreMemTSO": {
+      "Desc": ["Does a x86 TSO compatible store to memory."
+              ],
+      "HasSideEffects": true,
+      "OpClass": "Memory",
+      "SSAArgs": "2",
+      "SSANames": [
+        "Addr",
+        "Value"
+      ],
+      "Args": [
+        "uint8_t", "Size",
+        "uint8_t", "Align",
+        "RegisterClassType", "Class"
+      ]
+    },
+
     "VLoadMemElement": {
       "OpClass": "Memory",
       "HasDest": true,

--- a/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -227,7 +227,8 @@ namespace {
         return Op->Class;
         break;
       }
-      case IR::OP_LOADMEM: {
+      case IR::OP_LOADMEM:
+      case IR::OP_LOADMEMTSO: {
         auto Op = IROp->C<IR::IROp_LoadMem>();
         return Op->Class;
         break;
@@ -445,7 +446,10 @@ namespace FEXCore::IR {
           case IR::OP_CONSTANT: LiveRanges[Node].RematCost = 1; break;
           case IR::OP_LOADFLAG:
           case IR::OP_LOADCONTEXT: LiveRanges[Node].RematCost = 10; break;
-          case IR::OP_LOADMEM: LiveRanges[Node].RematCost = 100; break;
+          case IR::OP_LOADMEM:
+          case IR::OP_LOADMEMTSO:
+            LiveRanges[Node].RematCost = 100;
+            break;
           case IR::OP_FILLREGISTER: LiveRanges[Node].RematCost = DEFAULT_REMAT_COST + 1; break;
           // We want PHI to be very expensive to spill
           case IR::OP_PHI: LiveRanges[Node].RematCost = DEFAULT_REMAT_COST * 10; break;

--- a/External/FEXCore/include/FEXCore/IR/IREmitter.h
+++ b/External/FEXCore/include/FEXCore/IR/IREmitter.h
@@ -73,11 +73,17 @@ friend class FEXCore::IR::PassManager;
   IRPair<IROp_StoreMem> _StoreMem(FEXCore::IR::RegisterClassType Class, uint8_t Size, OrderedNode *ssa0, OrderedNode *ssa1, uint8_t Align = 1) {
     return _StoreMem(ssa0, ssa1, Size, Align, Class);
   }
+  IRPair<IROp_StoreMemTSO> _StoreMemTSO(FEXCore::IR::RegisterClassType Class, uint8_t Size, OrderedNode *ssa0, OrderedNode *ssa1, uint8_t Align = 1) {
+    return _StoreMemTSO(ssa0, ssa1, Size, Align, Class);
+  }
   IRPair<IROp_VStoreMemElement> _VStoreMemElement(uint8_t RegisterSize, uint8_t ElementSize, OrderedNode *ssa0, OrderedNode *ssa1, uint8_t Index, uint8_t Align = 1) {
     return _VStoreMemElement(ssa0, ssa1, Index, Align, RegisterSize, ElementSize);
   }
   IRPair<IROp_LoadMem> _LoadMem(FEXCore::IR::RegisterClassType Class, uint8_t Size, OrderedNode *ssa0, uint8_t Align = 1) {
     return _LoadMem(ssa0, Size, Align, Class);
+  }
+  IRPair<IROp_LoadMemTSO> _LoadMemTSO(FEXCore::IR::RegisterClassType Class, uint8_t Size, OrderedNode *ssa0, uint8_t Align = 1) {
+    return _LoadMemTSO(ssa0, Size, Align, Class);
   }
   IRPair<IROp_VLoadMemElement> _VLoadMemElement(uint8_t RegisterSize, uint8_t ElementSize, OrderedNode *ssa0, OrderedNode *ssa1, uint8_t Index, uint8_t Align = 1) {
     return _VLoadMemElement(ssa0, ssa1, Index, Align, RegisterSize, ElementSize);


### PR DESCRIPTION
Relies on #259 to be merged first!

This implements new TSO IR ops for x86 loadstores.
This /improves/ the situation for implementing x86 TSO memory semantics, but doesn't cover it 100%.
A followup PR will fix the issues with unaligned atomicity but that needs to wait a moment