### PR TITLE
Adds multi-stage building for Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:20.04
+# --- Stage 1: Builder ---
+FROM ubuntu:20.04 as builder
 
 RUN DEBIAN_FRONTEND="noninteractive" apt-get update
 RUN DEBIAN_FRONTEND="noninteractive" apt install -y cmake \
@@ -15,6 +16,15 @@ ARG CC=clang-10
 ARG CXX=clang++-10
 RUN cmake -G Ninja .. -DCMAKE_BUILD_TYPE=Release
 RUN ninja
-RUN echo "PATH=\$PATH:/opt/FEX/build/Bin" >> ~/.bashrc
+
+# --- Stage 2: Runner ---
+FROM ubuntu:20.04
+
+RUN DEBIAN_FRONTEND="noninteractive" apt-get update
+RUN DEBIAN_FRONTEND="noninteractive" apt install -y libboost-dev \
+libnuma-dev libcap-dev libglfw3-dev libepoxy-dev
+
+COPY --from=builder /opt/FEX/build/Bin/* /usr/bin/
+COPY --from=builder /opt/FEX/build/External/SonicUtils/libSonicUtils.so /usr/lib/
 
 WORKDIR /root


### PR DESCRIPTION
Multi-stage building separates the building process from the actual usable environment, removing any unnecessary packages and files and only keeps what is actually needed to run the target application, significantly decreasing the final image size. In this case the image size was reduced from 1.24GBs to 490MBs. There is possibly still room for improvement though.

For now, the compiled executables are moved to `/usr/bin` (but maybe they should go to `usr/local/bin` instead?), and libSonicUtils.so to `/usr/lib` (but maybe they should go to `usr/local/lib` instead?). The rest of the Externals are statically linked. so libSonicUtils seems to be the only compiled library that needs to be kept.