### PR TITLE
Fixes LLVM not clearing code cache on ARM platforms

### DIFF
--- a/External/FEXCore/Source/Interface/Core/LLVMJIT/LLVMMemoryManager.cpp
+++ b/External/FEXCore/Source/Interface/Core/LLVMJIT/LLVMMemoryManager.cpp
@@ -2,6 +2,10 @@
 #include "Common/MathUtils.h"
 #include "Interface/Core/LLVMJIT/LLVMMemoryManager.h"
 
+#if defined (_M_ARM_64)
+#include "aarch64/cpu-aarch64.h"
+#endif
+
 #include <sys/mman.h>
 
 namespace FEXCore::CPU {
@@ -33,6 +37,7 @@ uint8_t *LLVMMemoryManager::allocateCodeSection(uintptr_t Size, unsigned Alignme
 
   AllocateOffset = NewEnd;
   LastCodeSize = Size;
+  LastCodeBase = CodeMemory + Base;
   return reinterpret_cast<uint8_t*>(CodeMemory + Base);
 }
 
@@ -55,6 +60,10 @@ uint8_t *LLVMMemoryManager::allocateDataSection(uintptr_t Size, unsigned Alignme
 }
 
 bool LLVMMemoryManager::finalizeMemory([[maybe_unused]] std::string *ErrMsg) {
+#if defined (_M_ARM_64)
+  vixl::aarch64::CPU::EnsureIAndDCacheCoherency(reinterpret_cast<void*>(LastCodeBase), LastCodeSize);
+#endif
+
   return true;
 }
 

--- a/External/FEXCore/Source/Interface/Core/LLVMJIT/LLVMMemoryManager.h
+++ b/External/FEXCore/Source/Interface/Core/LLVMJIT/LLVMMemoryManager.h
@@ -29,6 +29,7 @@ private:
   uintptr_t CodeMemory {};
   size_t AllocateOffset {};
 
+  uintptr_t LastCodeBase {};
   size_t LastCodeSize {};
 };
 }


### PR DESCRIPTION
Surprised this hasn't caused issues before but was picked up on the
SolidRun Honeycomb LX2K