### PR TITLE
Declares new sigret x86 instruction and IR op

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -170,6 +170,14 @@ void OpDispatchBuilder::RETOp(OpcodeArgs) {
   BlockSetRIP = true;
 }
 
+void OpDispatchBuilder::SIGRETOp(OpcodeArgs) {
+  // Store the new RIP
+  _SignalReturn();
+  // This ExitFunction won't actually get hit but needs to exist
+  _ExitFunction();
+  BlockSetRIP = true;
+}
+
 template<uint32_t SrcIndex>
 void OpDispatchBuilder::SecondaryALUOp(OpcodeArgs) {
   FEXCore::IR::IROps IROp;
@@ -7248,6 +7256,9 @@ void InstallOpcodeHandlers(Context::OperatingMode Mode) {
     {0xFC, 1, &OpDispatchBuilder::PADDQOp<1>},
     {0xFD, 1, &OpDispatchBuilder::PADDQOp<2>},
     {0xFE, 1, &OpDispatchBuilder::PADDQOp<4>},
+
+    // FEX reserved instructions
+    {0x36, 1, &OpDispatchBuilder::SIGRETOp},
   };
 
   const std::vector<std::tuple<uint8_t, uint8_t, FEXCore::X86Tables::OpDispatchPtr>> TwoByteOpTable_32 = {

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -104,6 +104,7 @@ public:
   void LEAOp(OpcodeArgs);
   void NOPOp(OpcodeArgs);
   void RETOp(OpcodeArgs);
+  void SIGRETOp(OpcodeArgs);
   template<uint32_t SrcIndex>
   void SecondaryALUOp(OpcodeArgs);
   template<uint32_t SrcIndex>

--- a/External/FEXCore/Source/Interface/Core/X86Tables/SecondaryTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/SecondaryTables.cpp
@@ -53,7 +53,7 @@ void InitializeSecondaryTables() {
     {0x33, 1, X86InstInfo{"RDPMC",      TYPE_PRIV, FLAGS_NO_OVERLAY,                                                                             0, nullptr}},
     {0x34, 1, X86InstInfo{"SYSENTER",   TYPE_PRIV, FLAGS_NO_OVERLAY,                                                                             0, nullptr}},
     {0x35, 1, X86InstInfo{"SYSEXIT",    TYPE_PRIV, FLAGS_NO_OVERLAY,                                                                             0, nullptr}},
-    {0x36, 2, X86InstInfo{"",           TYPE_INVALID, FLAGS_NO_OVERLAY,                                                                          0, nullptr}},
+    {0x37, 1, X86InstInfo{"",           TYPE_INVALID, FLAGS_NO_OVERLAY,                                                                          0, nullptr}},
     {0x38, 1, X86InstInfo{"",           TYPE_0F38_TABLE, FLAGS_NO_OVERLAY,                                                                       0, nullptr}},
     {0x39, 1, X86InstInfo{"",           TYPE_INVALID, FLAGS_NO_OVERLAY,                                                                          0, nullptr}},
     {0x3A, 1, X86InstInfo{"",           TYPE_0F3A_TABLE, FLAGS_NO_OVERLAY,                                                                       0, nullptr}},
@@ -251,7 +251,9 @@ void InitializeSecondaryTables() {
 
     // FEX reserved instructions
     // Unused x86 encoding instruction.
-    
+    // Used by FEX to know when to do a signal return
+    {0x36, 1, X86InstInfo{"SIGRET",       TYPE_INST, FLAGS_BLOCK_END | FLAGS_NO_OVERLAY | FLAGS_SETS_RIP,                                                            0, nullptr}},
+
     // This was originally used by VIA to jump to its alternative instruction set. Used for OP_THUNK
     {0x3F, 1, X86InstInfo{"ALTINST",      TYPE_INST, FLAGS_BLOCK_END | FLAGS_NO_OVERLAY | FLAGS_SETS_RIP,                                                            0, nullptr}},
   };

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -123,6 +123,11 @@
       ]
     },
 
+    "SignalReturn": {
+      "HasSideEffects": true,
+      "OpClass": "Branch"
+    },
+
     "CASPair": {
       "HasSideEffects": true,
       "OpClass": "Atomic",


### PR DESCRIPTION
We are rebranding an x86-64 illegal instruction near VIA's old ALTINST
instruction as an instruction to handle returning from guest signals
cleanly.

If this ever collides with a new x86-64 (unlikely) then we will need to
change the instruction.
This ends up looking similar to what we will do for thunk callbacks