### PR TITLE
Adds an x86 generated code helper class

### DIFF
--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -125,6 +125,7 @@ set (SRCS
   Interface/Core/SignalDelegator.cpp
   Interface/Core/X86Tables.cpp
   Interface/Core/X86DebugInfo.cpp
+  Interface/Core/X86HelperGen.cpp
   Interface/Core/Interpreter/InterpreterCore.cpp
   Interface/Core/LLVMJIT/LLVMCore.cpp
   Interface/Core/LLVMJIT/LLVMMemoryManager.cpp

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -4,6 +4,7 @@
 #include "Interface/Core/Frontend.h"
 #include "Interface/Core/InternalThreadState.h"
 #include "Interface/Core/SignalDelegator.h"
+#include "Interface/Core/X86HelperGen.h"
 #include "Interface/HLE/Syscalls.h"
 #include "Interface/Memory/MemMapper.h"
 #include "Interface/IR/PassManager.h"
@@ -93,6 +94,7 @@ namespace FEXCore::Context {
 #endif
 
     SignalDelegator SignalDelegation;
+    X86GeneratedCode X86CodeGen;
 
     Context();
     ~Context();

--- a/External/FEXCore/Source/Interface/Core/X86HelperGen.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86HelperGen.cpp
@@ -1,0 +1,26 @@
+#include "Interface/Core/X86HelperGen.h"
+
+#include <cstring>
+#include <stdlib.h>
+#include <vector>
+
+namespace FEXCore {
+X86GeneratedCode::X86GeneratedCode() {
+  // Allocate a page for our emulated guest
+  CodePtr = malloc(0x1000);
+
+  SignalReturn = reinterpret_cast<uint64_t>(CodePtr);
+
+  const std::vector<uint8_t> SignalReturnCode = {
+    0x0F, 0x36, // SIGRET FEX instruction
+  };
+
+  memcpy(CodePtr, &SignalReturnCode.at(0), SignalReturnCode.size());
+}
+
+X86GeneratedCode::~X86GeneratedCode() {
+  free(CodePtr);
+}
+
+}
+

--- a/External/FEXCore/Source/Interface/Core/X86HelperGen.h
+++ b/External/FEXCore/Source/Interface/Core/X86HelperGen.h
@@ -1,0 +1,14 @@
+#pragma once
+#include <stdint.h>
+
+namespace FEXCore {
+class X86GeneratedCode final {
+public:
+  X86GeneratedCode();
+  ~X86GeneratedCode();
+
+  uint64_t SignalReturn{};
+private:
+  void *CodePtr{};
+};
+}


### PR DESCRIPTION
Just generates some context level x86 code space for our guest to jump
in to.
This is only currently used for sigret but will become more important as
we come to support vdso.