### PR TITLE
AArch64 ~~TSO~~ SC implementation

### DIFF
--- a/External/FEXCore/Source/Common/SoftFloat.h
+++ b/External/FEXCore/Source/Common/SoftFloat.h
@@ -205,7 +205,9 @@ struct X80SoftFloat {
   }
 
   X80SoftFloat(extFloat80_t rhs) {
-    memcpy(this, &rhs, sizeof(*this));
+    Significand = rhs.signif;
+    Exponent = rhs.signExp & 0x7FFF;
+    Sign = rhs.signExp >> 15;
   }
 
   X80SoftFloat(const float rhs) {
@@ -229,11 +231,16 @@ struct X80SoftFloat {
   }
 
   void operator=(extFloat80_t rhs) {
-    memcpy(this, &rhs, sizeof(*this));
+    Significand = rhs.signif;
+    Exponent = rhs.signExp & 0x7FFF;
+    Sign = rhs.signExp >> 15;
   }
 
   operator extFloat80_t() const {
-    return *(extFloat80_t*)this;
+    extFloat80_t Result{};
+    Result.signif = Significand;
+    Result.signExp = Exponent | (Sign << 15);
+    return Result;
   }
 
   static bool IsNan(X80SoftFloat const &lhs) {

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -572,7 +572,8 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
             *Data = Arg;
             break;
           }
-          case IR::OP_LOADMEM: {
+          case IR::OP_LOADMEM:
+          case IR::OP_LOADMEMTSO: {
             auto Op = IROp->C<IR::IROp_LoadMem>();
             void const *Data{};
             if (Thread->CTX->Config.UnifiedMemory) {
@@ -601,7 +602,8 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
               Data, Op->Header.ElementSize);
             break;
           }
-          case IR::OP_STOREMEM: {
+          case IR::OP_STOREMEM:
+          case IR::OP_STOREMEMTSO: {
             #define STORE_DATA(x, y) \
               case x: { \
                 y *Data{}; \

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -286,6 +286,7 @@ JITCore::JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadSt
   , State {Thread}
   , InitialCodeBuffer {Buffer}
 {
+  CurrentCodeBuffer = &InitialCodeBuffer;
   auto Features = vixl::CPUFeatures::InferFromOS();
   SupportsAtomics = Features.Has(vixl::CPUFeatures::Feature::kAtomics);
 
@@ -495,7 +496,7 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
 
   // Fairly excessive buffer range to make sure we don't overflow
   uint32_t BufferRange = SSACount * 16;
-  if ((GetCursorOffset() + BufferRange) > MAX_CODE_SIZE) {
+  if ((GetCursorOffset() + BufferRange) > CurrentCodeBuffer->Size) {
     State->CTX->ClearCodeCache(State, HeaderOp->Entry);
   }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -231,6 +231,61 @@ void JITCore::FreeCodeBuffer(CodeBuffer Buffer) {
   munmap(Buffer.Ptr, Buffer.Size);
 }
 
+bool JITCore::HandleSIGBUS(int Signal, void *info, void *ucontext) {
+  ucontext_t* _context = (ucontext_t*)ucontext;
+  mcontext_t* _mcontext = &_context->uc_mcontext;
+  uint32_t *PC = (uint32_t*)_mcontext->pc;
+  uint32_t Instr = PC[0];
+
+  auto Buffer = GetBuffer();
+  uint64_t CodeBase = Buffer->GetOffsetAddress<uint64_t>(0);
+  uint64_t CodeEnd = CodeBase + Buffer->GetCapacity();
+
+  if (_mcontext->pc < CodeBase &&
+      _mcontext->pc > CodeEnd) {
+    // Wasn't a sigbus in JIT code
+    return false;
+  }
+
+  // 1 = 16bit
+  // 2 = 32bit
+  // 3 = 64bit
+  uint32_t Size = (Instr & 0xC000'0000) >> 30;
+  uint32_t AddrReg = (Instr >> 5) & 0x1F;
+  uint32_t DataReg = Instr & 0x1F;
+  uint32_t DMB = 0b1101'0101'0000'0011'0011'0000'1011'1111 |
+    0b1011'0000'0000; // Inner shareable all
+  if ((Instr & 0x3F'FF'FC'00) == 0x08'9F'7C'00) {
+    // STLLR*
+    uint32_t STR = 0b0011'1000'0011'1111'0110'1000'0000'0000;
+    STR |= Size << 30;
+    STR |= AddrReg << 5;
+    STR |= DataReg;
+    PC[-1] = DMB;
+    PC[0] = STR;
+    PC[1] = DMB;
+  }
+  else if ((Instr & 0x3F'FF'FC'00) == 0x08'DF'7C'00) {
+    // LDLLR*
+    uint32_t LDR = 0b0011'1000'0111'1111'0110'1000'0000'0000;
+    LDR |= Size << 30;
+    LDR |= AddrReg << 5;
+    LDR |= DataReg;
+    PC[-1] = DMB;
+    PC[0] = LDR;
+    PC[1] = DMB;
+  }
+  else {
+    LogMan::Msg::E("Unhandled JIT SIGBUS: PC: %p Instruction: 0x%08x", PC, PC[0]);
+    return false;
+  }
+
+  // Back up one instruction and have another go
+  _mcontext->pc -= 4;
+  vixl::aarch64::CPU::EnsureIAndDCacheCoherency(&PC[-1], 16);
+  return true;
+}
+
 JITCore::JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread, CodeBuffer Buffer)
   : vixl::aarch64::MacroAssembler(Buffer.Ptr, Buffer.Size, vixl::aarch64::PositionDependentCode)
   , CTX {ctx}
@@ -304,6 +359,11 @@ JITCore::JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadSt
   CTX->SignalDelegation.RegisterHostSignalHandler(SIGILL, [](FEXCore::Core::InternalThreadState *Thread, int Signal, void *info, void *ucontext) -> bool {
     JITCore *Core = reinterpret_cast<JITCore*>(Thread->CPUBackend.get());
     return Core->HandleSIGILL(Signal, info, ucontext);
+  });
+
+  CTX->SignalDelegation.RegisterHostSignalHandler(SIGBUS, [](FEXCore::Core::InternalThreadState *Thread, int Signal, void *info, void *ucontext) -> bool {
+    JITCore *Core = reinterpret_cast<JITCore*>(Thread->CPUBackend.get());
+    return Core->HandleSIGBUS(Signal, info, ucontext);
   });
 
   auto GuestSignalHandler = [](FEXCore::Core::InternalThreadState *Thread, int Signal, void *info, void *ucontext, SignalDelegator::GuestSigAction *GuestAction, stack_t *GuestStack) -> bool {

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -96,6 +96,7 @@ public:
   void ClearCache() override;
 
   bool HandleSIGILL(int Signal, void *info, void *ucontext);
+  bool HandleSIGBUS(int Signal, void *info, void *ucontext);
   bool HandleGuestSignal(int Signal, void *info, void *ucontext, SignalDelegator::GuestSigAction *GuestAction, stack_t *GuestStack);
 
   static constexpr size_t INITIAL_CODE_SIZE = 1024 * 1024 * 16;

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -330,6 +330,8 @@ private:
   DEF_OP(StoreFlag);
   DEF_OP(LoadMem);
   DEF_OP(StoreMem);
+  DEF_OP(LoadMemTSO);
+  DEF_OP(StoreMemTSO);
   DEF_OP(VLoadMemElement);
   DEF_OP(VStoreMemElement);
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -427,32 +427,11 @@ DEF_OP(LoadMemTSO) {
     MemSrc = MemOperand(TMP1);
   }
 
-  if (!SupportsAtomics && Op->Class == FEXCore::IR::GPRClass) {
-    // ARMv8.0 doesn't support atomic memory ops or LORegion ops, so we need to fall down the DMB path
-    auto Dst = GetReg<RA_64>(Node);
-    dmb(InnerShareable, BarrierAll);
-    switch (Op->Size) {
-      case 1:
-        ldrb(Dst, MemSrc);
-        break;
-      case 2:
-        ldrh(Dst, MemSrc);
-        break;
-      case 4:
-        ldr(Dst.W(), MemSrc);
-        break;
-      case 8:
-        ldr(Dst, MemSrc);
-        break;
-      default:  LogMan::Msg::A("Unhandled LoadMem size: %d", Op->Size);
-    }
-    dmb(InnerShareable, BarrierAll);
-  }
-  else if (Op->Class == FEXCore::IR::GPRClass) {
+  if (Op->Class == FEXCore::IR::GPRClass) {
     if (Op->Size == 1) {
       // 8bit load is always aligned to natural alignment
       auto Dst = GetReg<RA_64>(Node);
-      ldlarb(Dst, MemSrc);
+      ldarb(Dst, MemSrc);
     }
     else {
       // Aligned
@@ -460,13 +439,13 @@ DEF_OP(LoadMemTSO) {
       nop();
       switch (Op->Size) {
         case 2:
-          ldlarh(Dst, MemSrc);
+          ldarh(Dst, MemSrc);
           break;
         case 4:
-          ldlar(Dst.W(), MemSrc);
+          ldar(Dst.W(), MemSrc);
           break;
         case 8:
-          ldlar(Dst, MemSrc);
+          ldar(Dst, MemSrc);
           break;
         default:  LogMan::Msg::A("Unhandled LoadMem size: %d", Op->Size);
       }
@@ -552,42 +531,22 @@ DEF_OP(StoreMemTSO) {
     MemSrc = MemOperand(TMP1);
   }
 
-  if (!SupportsAtomics && Op->Class == FEXCore::IR::GPRClass) {
-    // ARMv8.0 doesn't support atomic memory ops or LORegion ops, so we need to fall down the DMB path
-    dmb(InnerShareable, BarrierAll);
-    switch (Op->Size) {
-      case 1:
-        strb(GetReg<RA_64>(Op->Header.Args[1].ID()), MemSrc);
-        break;
-      case 2:
-        strh(GetReg<RA_64>(Op->Header.Args[1].ID()), MemSrc);
-        break;
-      case 4:
-        str(GetReg<RA_32>(Op->Header.Args[1].ID()), MemSrc);
-        break;
-      case 8:
-        str(GetReg<RA_64>(Op->Header.Args[1].ID()), MemSrc);
-        break;
-      default:  LogMan::Msg::A("Unhandled StoreMem size: %d", Op->Size);
-    }
-    dmb(InnerShareable, BarrierAll);
-  }
-  else if (Op->Class == FEXCore::IR::GPRClass) {
+  if (Op->Class == FEXCore::IR::GPRClass) {
     if (Op->Size == 1) {
       // 8bit load is always aligned to natural alignment
-      stllrb(GetReg<RA_64>(Op->Header.Args[1].ID()), MemSrc);
+      stlrb(GetReg<RA_64>(Op->Header.Args[1].ID()), MemSrc);
     }
     else {
       nop();
       switch (Op->Size) {
         case 2:
-          stllrh(GetReg<RA_64>(Op->Header.Args[1].ID()), MemSrc);
+          stlrh(GetReg<RA_64>(Op->Header.Args[1].ID()), MemSrc);
           break;
         case 4:
-          stllr(GetReg<RA_32>(Op->Header.Args[1].ID()), MemSrc);
+          stlr(GetReg<RA_32>(Op->Header.Args[1].ID()), MemSrc);
           break;
         case 8:
-          stllr(GetReg<RA_64>(Op->Header.Args[1].ID()), MemSrc);
+          stlr(GetReg<RA_64>(Op->Header.Args[1].ID()), MemSrc);
           break;
         default:  LogMan::Msg::A("Unhandled StoreMem size: %d", Op->Size);
       }

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -1828,7 +1828,8 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
           mov (Dst, rax);
           break;
         }
-        case IR::OP_LOADMEM: {
+        case IR::OP_LOADMEM:
+        case IR::OP_LOADMEMTSO: {
           auto Op = IROp->C<IR::IROp_LoadMem>();
           uint64_t Memory = CTX->MemoryMapper.GetBaseOffset<uint64_t>(0);
 
@@ -1899,7 +1900,8 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
           }
           break;
         }
-        case IR::OP_STOREMEM: {
+        case IR::OP_STOREMEM:
+        case IR::OP_STOREMEMTSO: {
           auto Op = IROp->C<IR::IROp_StoreMem>();
           uint64_t Memory = CTX->MemoryMapper.GetBaseOffset<uint64_t>(0);
 

--- a/External/FEXCore/Source/Interface/Core/LLVMJIT/LLVMCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/LLVMJIT/LLVMCore.cpp
@@ -3998,7 +3998,8 @@ void LLVMJITCore::HandleIR(FEXCore::IR::IRListView<true> const *IR, IR::NodeWrap
       SetDest(*WrapperOp, Result);
     break;
     }
-    case IR::OP_LOADMEM: {
+    case IR::OP_LOADMEM:
+    case IR::OP_LOADMEMTSO: {
       auto Op = IROp->C<IR::IROp_LoadMem>();
       auto Src = GetSrc(Op->Header.Args[0]);
 
@@ -4011,7 +4012,8 @@ void LLVMJITCore::HandleIR(FEXCore::IR::IRListView<true> const *IR, IR::NodeWrap
       SetDest(*WrapperOp, Result);
     break;
     }
-    case IR::OP_STOREMEM: {
+    case IR::OP_STOREMEM:
+    case IR::OP_STOREMEMTSO: {
       auto Op = IROp->C<IR::IROp_StoreMem>();
 
       auto Dst = GetSrc(Op->Header.Args[0]);

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -1844,7 +1844,7 @@ void OpDispatchBuilder::BTOp(OpcodeArgs) {
 
     // Now add the addresses together and load the memory
     OrderedNode *MemoryLocation = _Add(Dest, Src);
-    Result = _LoadMem(GPRClass, 1, MemoryLocation, 1);
+    Result = _LoadMemTSO(GPRClass, 1, MemoryLocation, 1);
 
     // Now shift in to the correct bit location
     Result = _Lshr(Result, BitSelect);
@@ -1889,14 +1889,14 @@ void OpDispatchBuilder::BTROp(OpcodeArgs) {
 
     // Now add the addresses together and load the memory
     OrderedNode *MemoryLocation = _Add(Dest, Src);
-    OrderedNode *Value = _LoadMem(GPRClass, 1, MemoryLocation, 1);
+    OrderedNode *Value = _LoadMemTSO(GPRClass, 1, MemoryLocation, 1);
 
     // Now shift in to the correct bit location
     Result = _Lshr(Value, BitSelect);
     OrderedNode *BitMask = _Lshl(_Constant(1), BitSelect);
     BitMask = _Not(BitMask);
     Value = _And(Value, BitMask);
-    _StoreMem(GPRClass, 1, MemoryLocation, Value, 1);
+    _StoreMemTSO(GPRClass, 1, MemoryLocation, Value, 1);
   }
   SetRFLAG<FEXCore::X86State::RFLAG_CF_LOC>(Result);
 }
@@ -1937,13 +1937,13 @@ void OpDispatchBuilder::BTSOp(OpcodeArgs) {
 
     // Now add the addresses together and load the memory
     OrderedNode *MemoryLocation = _Add(Dest, Src);
-    OrderedNode *Value = _LoadMem(GPRClass, 1, MemoryLocation, 1);
+    OrderedNode *Value = _LoadMemTSO(GPRClass, 1, MemoryLocation, 1);
 
     // Now shift in to the correct bit location
     Result = _Lshr(Value, BitSelect);
     OrderedNode *BitMask = _Lshl(_Constant(1), BitSelect);
     Value = _Or(Value, BitMask);
-    _StoreMem(GPRClass, 1, MemoryLocation, Value, 1);
+    _StoreMemTSO(GPRClass, 1, MemoryLocation, Value, 1);
   }
   SetRFLAG<FEXCore::X86State::RFLAG_CF_LOC>(Result);
 }
@@ -1983,13 +1983,13 @@ void OpDispatchBuilder::BTCOp(OpcodeArgs) {
 
     // Now add the addresses together and load the memory
     OrderedNode *MemoryLocation = _Add(Dest, Src);
-    OrderedNode *Value = _LoadMem(GPRClass, 1, MemoryLocation, 1);
+    OrderedNode *Value = _LoadMemTSO(GPRClass, 1, MemoryLocation, 1);
 
     // Now shift in to the correct bit location
     Result = _Lshr(Value, BitSelect);
     OrderedNode *BitMask = _Lshl(_Constant(1), BitSelect);
     Value = _Xor(Value, BitMask);
-    _StoreMem(GPRClass, 1, MemoryLocation, Value, 1);
+    _StoreMemTSO(GPRClass, 1, MemoryLocation, Value, 1);
   }
   SetRFLAG<FEXCore::X86State::RFLAG_CF_LOC>(Result);
 }
@@ -2187,7 +2187,7 @@ void OpDispatchBuilder::XLATOp(OpcodeArgs) {
   }
   Src = _Add(Src, Offset);
 
-  auto Res = _LoadMem(GPRClass, 1, Src, 1);
+  auto Res = _LoadMemTSO(GPRClass, 1, Src, 1);
 
   _StoreContext(GPRClass, 1, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RAX]), Res);
 }
@@ -2335,7 +2335,7 @@ void OpDispatchBuilder::STOSOp(OpcodeArgs) {
     OrderedNode *Dest = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RDI]), GPRClass);
 
     // Store to memory where RDI points
-    _StoreMem(GPRClass, Size, Dest, Src, Size);
+    _StoreMemTSO(GPRClass, Size, Dest, Src, Size);
 
     auto SizeConst = _Constant(Size);
     auto NegSizeConst = _Constant(-Size);
@@ -2383,7 +2383,7 @@ void OpDispatchBuilder::STOSOp(OpcodeArgs) {
         OrderedNode *Dest = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RDI]), GPRClass);
 
         // Store to memory where RDI points
-        _StoreMem(GPRClass, Size, Dest, Src, Size);
+        _StoreMemTSO(GPRClass, Size, Dest, Src, Size);
 
         OrderedNode *TailCounter = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RCX]), GPRClass);
         OrderedNode *TailDest = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RDI]), GPRClass);
@@ -2456,10 +2456,10 @@ void OpDispatchBuilder::MOVSOp(OpcodeArgs) {
         OrderedNode *Src = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RSI]), GPRClass);
         OrderedNode *Dest = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RDI]), GPRClass);
 
-        Src = _LoadMem(GPRClass, Size, Src, Size);
+        Src = _LoadMemTSO(GPRClass, Size, Src, Size);
 
         // Store to memory where RDI points
-        _StoreMem(GPRClass, Size, Dest, Src, Size);
+        _StoreMemTSO(GPRClass, Size, Dest, Src, Size);
 
         OrderedNode *TailCounter = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RCX]), GPRClass);
 
@@ -2499,10 +2499,10 @@ void OpDispatchBuilder::MOVSOp(OpcodeArgs) {
     OrderedNode *RSI = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RSI]), GPRClass);
     OrderedNode *RDI = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RDI]), GPRClass);
 
-    auto Src = _LoadMem(GPRClass, Size, RSI, Size);
+    auto Src = _LoadMemTSO(GPRClass, Size, RSI, Size);
 
     // Store to memory where RDI points
-    _StoreMem(GPRClass, Size, RDI, Src, Size);
+    _StoreMemTSO(GPRClass, Size, RDI, Src, Size);
 
     auto SizeConst = _Constant(Size);
     auto NegSizeConst = _Constant(-Size);
@@ -2535,8 +2535,8 @@ void OpDispatchBuilder::CMPSOp(OpcodeArgs) {
     OrderedNode *Dest_RDI = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RDI]), GPRClass);
     OrderedNode *Dest_RSI = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RSI]), GPRClass);
 
-    auto Src1 = _LoadMem(GPRClass, Size, Dest_RDI, Size);
-    auto Src2 = _LoadMem(GPRClass, Size, Dest_RSI, Size);
+    auto Src1 = _LoadMemTSO(GPRClass, Size, Dest_RDI, Size);
+    auto Src2 = _LoadMemTSO(GPRClass, Size, Dest_RSI, Size);
 
     auto ALUOp = _Sub(Src1, Src2);
     GenerateFlags_SUB(Op, _Bfe(Size * 8, 0, ALUOp), _Bfe(Size * 8, 0, Src1), _Bfe(Size * 8, 0, Src2));
@@ -2582,7 +2582,7 @@ void OpDispatchBuilder::CMPSOp(OpcodeArgs) {
         OrderedNode *Dest_RDI = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RDI]), GPRClass);
         OrderedNode *Dest_RSI = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RSI]), GPRClass);
 
-        auto Src1 = _LoadMem(GPRClass, Size, Dest_RDI, Size);
+        auto Src1 = _LoadMemTSO(GPRClass, Size, Dest_RDI, Size);
         auto Src2 = _LoadMem(GPRClass, Size, Dest_RSI, Size);
 
         auto ALUOp = _Sub(Src1, Src2);
@@ -2649,7 +2649,7 @@ void OpDispatchBuilder::LODSOp(OpcodeArgs) {
   if (!Repeat) {
     OrderedNode *Dest_RSI = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RSI]), GPRClass);
 
-    auto Src = _LoadMem(GPRClass, Size, Dest_RSI, Size);
+    auto Src = _LoadMemTSO(GPRClass, Size, Dest_RSI, Size);
 
     StoreResult(GPRClass, Op, Src, -1);
 
@@ -2699,7 +2699,7 @@ void OpDispatchBuilder::LODSOp(OpcodeArgs) {
       {
         OrderedNode *Dest_RSI = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RSI]), GPRClass);
 
-        auto Src = _LoadMem(GPRClass, Size, Dest_RSI, Size);
+        auto Src = _LoadMemTSO(GPRClass, Size, Dest_RSI, Size);
 
         StoreResult(GPRClass, Op, Src, -1);
 
@@ -2747,7 +2747,7 @@ void OpDispatchBuilder::SCASOp(OpcodeArgs) {
     OrderedNode *Dest_RDI = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RDI]), GPRClass);
 
     auto Src1 = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
-    auto Src2 = _LoadMem(GPRClass, Size, Dest_RDI, Size);
+    auto Src2 = _LoadMemTSO(GPRClass, Size, Dest_RDI, Size);
 
     auto ALUOp = _Sub(Src1, Src2);
 
@@ -2798,7 +2798,7 @@ void OpDispatchBuilder::SCASOp(OpcodeArgs) {
         OrderedNode *Dest_RDI = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RDI]), GPRClass);
 
         auto Src1 = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
-        auto Src2 = _LoadMem(GPRClass, Size, Dest_RDI, Size);
+        auto Src2 = _LoadMemTSO(GPRClass, Size, Dest_RDI, Size);
 
         auto ALUOp = _Sub(Src1, Src2);
         GenerateFlags_SUB(Op, _Bfe(Size * 8, 0, ALUOp), _Bfe(Size * 8, 0, Src1), _Bfe(Size * 8, 0, Src2));
@@ -3770,6 +3770,7 @@ OrderedNode *OpDispatchBuilder::LoadSource_WithOpSize(FEXCore::IR::RegisterClass
 
   OrderedNode *Src {nullptr};
   bool LoadableType = false;
+  bool StackAccess = false;
   uint8_t GPRSize = CTX->Config.Is64BitMode ? 8 : 4;
 
   if (Operand.TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL) {
@@ -3789,6 +3790,7 @@ OrderedNode *OpDispatchBuilder::LoadSource_WithOpSize(FEXCore::IR::RegisterClass
   else if (Operand.TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_GPR_DIRECT) {
     Src = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[Operand.TypeGPR.GPR]), GPRClass);
     LoadableType = true;
+    StackAccess = Operand.TypeGPR.GPR == FEXCore::X86State::REG_RSP;
   }
   else if (Operand.TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_GPR_INDIRECT) {
     auto GPR = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[Operand.TypeGPRIndirect.GPR]), GPRClass);
@@ -3797,6 +3799,7 @@ OrderedNode *OpDispatchBuilder::LoadSource_WithOpSize(FEXCore::IR::RegisterClass
 		Src = _Add(GPR, Constant);
 
     LoadableType = true;
+    StackAccess = Operand.TypeGPRIndirect.GPR == FEXCore::X86State::REG_RSP;
   }
   else if (Operand.TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_RIP_RELATIVE) {
     if (CTX->Config.Is64BitMode) {
@@ -3818,6 +3821,7 @@ OrderedNode *OpDispatchBuilder::LoadSource_WithOpSize(FEXCore::IR::RegisterClass
         auto Constant = _Constant(GPRSize * 8, Operand.TypeSIB.Scale);
         Tmp = _Mul(Tmp, Constant);
       }
+      StackAccess |= Operand.TypeSIB.Index == FEXCore::X86State::REG_RSP;
     }
 
     if (Operand.TypeSIB.Base != FEXCore::X86State::REG_INVALID) {
@@ -3829,6 +3833,7 @@ OrderedNode *OpDispatchBuilder::LoadSource_WithOpSize(FEXCore::IR::RegisterClass
       else {
         Tmp = GPR;
       }
+      StackAccess |= Operand.TypeSIB.Base == FEXCore::X86State::REG_RSP;
     }
 
     if (Operand.TypeSIB.Offset) {
@@ -3875,7 +3880,12 @@ OrderedNode *OpDispatchBuilder::LoadSource_WithOpSize(FEXCore::IR::RegisterClass
       }
     }
 
-    Src = _LoadMem(Class, OpSize, Src, Align == -1 ? OpSize : Align);
+    if (StackAccess) {
+      Src = _LoadMem(Class, OpSize, Src, Align == -1 ? OpSize : Align);
+    }
+    else {
+      Src = _LoadMemTSO(Class, OpSize, Src, Align == -1 ? OpSize : Align);
+    }
   }
   return Src;
 }
@@ -3898,6 +3908,7 @@ void OpDispatchBuilder::StoreResult_WithOpSize(FEXCore::IR::RegisterClassType Cl
   // 32bit ops ZEXT the result to 64bit
   OrderedNode *MemStoreDst {nullptr};
   bool MemStore = false;
+  bool StackAccess = false;
   uint8_t GPRSize = CTX->Config.Is64BitMode ? 8 : 4;
 
   if (Operand.TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL) {
@@ -3927,6 +3938,7 @@ void OpDispatchBuilder::StoreResult_WithOpSize(FEXCore::IR::RegisterClassType Cl
   else if (Operand.TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_GPR_DIRECT) {
     MemStoreDst = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[Operand.TypeGPR.GPR]), GPRClass);
     MemStore = true;
+    StackAccess = Operand.TypeGPR.GPR == FEXCore::X86State::REG_RSP;
   }
   else if (Operand.TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_GPR_INDIRECT) {
     auto GPR = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[Operand.TypeGPRIndirect.GPR]), GPRClass);
@@ -3934,6 +3946,7 @@ void OpDispatchBuilder::StoreResult_WithOpSize(FEXCore::IR::RegisterClassType Cl
 
     MemStoreDst = _Add(GPR, Constant);
     MemStore = true;
+    StackAccess = Operand.TypeGPRIndirect.GPR == FEXCore::X86State::REG_RSP;
   }
   else if (Operand.TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_RIP_RELATIVE) {
     MemStoreDst = _Constant(GPRSize * 8, Operand.TypeRIPLiteral.Literal + Op->PC + Op->InstSize);
@@ -4009,7 +4022,12 @@ void OpDispatchBuilder::StoreResult_WithOpSize(FEXCore::IR::RegisterClassType Cl
       auto DestAddr = _Add(MemStoreDst, _Constant(8));
       _StoreMem(GPRClass, 2, DestAddr, Upper, std::min<uint8_t>(Align, 8));
     } else {
-      _StoreMem(Class, OpSize, MemStoreDst, Src, Align == -1 ? OpSize : Align);
+      if (StackAccess) {
+        _StoreMem(Class, OpSize, MemStoreDst, Src, Align == -1 ? OpSize : Align);
+      }
+      else {
+        _StoreMemTSO(Class, OpSize, MemStoreDst, Src, Align == -1 ? OpSize : Align);
+      }
     }
   }
 }

--- a/External/FEXCore/Source/Interface/Core/SignalDelegator.h
+++ b/External/FEXCore/Source/Interface/Core/SignalDelegator.h
@@ -82,6 +82,8 @@ namespace Core {
 
     uint64_t RegisterGuestSigAltStack(const stack_t *ss, stack_t *old_ss);
 
+    uint64_t GuestSigProcMask(int how, const uint64_t *set, uint64_t *oldset);
+
     // Called from the thunk handler to handle the signal
     void HandleSignal(int Signal, void *Info, void *UContext);
 

--- a/External/FEXCore/Source/Interface/HLE/Syscalls/Signals.cpp
+++ b/External/FEXCore/Source/Interface/HLE/Syscalls/Signals.cpp
@@ -14,10 +14,8 @@ namespace FEXCore::HLE {
       return Thread->CTX->SignalDelegation.RegisterGuestSignalHandler(signum, act, oldact);
     });
 
-    REGISTER_SYSCALL_IMPL(rt_sigprocmask, [](FEXCore::Core::InternalThreadState *Thread, int how, const sigset_t *set, sigset_t *oldset) -> uint64_t {
-      // XXX: Pass through SignalDelegator
-      uint64_t Result = ::sigprocmask(how, set, oldset);
-      SYSCALL_ERRNO();
+    REGISTER_SYSCALL_IMPL(rt_sigprocmask, [](FEXCore::Core::InternalThreadState *Thread, int how, const uint64_t *set, uint64_t *oldset) -> uint64_t {
+      return Thread->CTX->SignalDelegation.GuestSigProcMask(how, set, oldset);
     });
 
     REGISTER_SYSCALL_IMPL(sigaltstack, [](FEXCore::Core::InternalThreadState *Thread, const stack_t *ss, stack_t *old_ss) -> uint64_t {

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -532,6 +532,41 @@
       ]
     },
 
+    "LoadMemTSO": {
+      "Desc": ["Does a x86 TSO compatible load from memory."
+              ],
+      "OpClass": "Memory",
+      "HasDest": true,
+      "DestClass": "Complex",
+      "DestSize": "Size",
+      "SSAArgs": "1",
+      "SSANames": [
+        "Addr"
+      ],
+      "Args": [
+        "uint8_t", "Size",
+        "uint8_t", "Align",
+        "RegisterClassType", "Class"
+      ]
+    },
+
+    "StoreMemTSO": {
+      "Desc": ["Does a x86 TSO compatible store to memory."
+              ],
+      "HasSideEffects": true,
+      "OpClass": "Memory",
+      "SSAArgs": "2",
+      "SSANames": [
+        "Addr",
+        "Value"
+      ],
+      "Args": [
+        "uint8_t", "Size",
+        "uint8_t", "Align",
+        "RegisterClassType", "Class"
+      ]
+    },
+
     "VLoadMemElement": {
       "OpClass": "Memory",
       "HasDest": true,

--- a/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -227,7 +227,8 @@ namespace {
         return Op->Class;
         break;
       }
-      case IR::OP_LOADMEM: {
+      case IR::OP_LOADMEM:
+      case IR::OP_LOADMEMTSO: {
         auto Op = IROp->C<IR::IROp_LoadMem>();
         return Op->Class;
         break;
@@ -445,7 +446,10 @@ namespace FEXCore::IR {
           case IR::OP_CONSTANT: LiveRanges[Node].RematCost = 1; break;
           case IR::OP_LOADFLAG:
           case IR::OP_LOADCONTEXT: LiveRanges[Node].RematCost = 10; break;
-          case IR::OP_LOADMEM: LiveRanges[Node].RematCost = 100; break;
+          case IR::OP_LOADMEM:
+          case IR::OP_LOADMEMTSO:
+            LiveRanges[Node].RematCost = 100;
+            break;
           case IR::OP_FILLREGISTER: LiveRanges[Node].RematCost = DEFAULT_REMAT_COST + 1; break;
           // We want PHI to be very expensive to spill
           case IR::OP_PHI: LiveRanges[Node].RematCost = DEFAULT_REMAT_COST * 10; break;

--- a/External/FEXCore/include/FEXCore/IR/IREmitter.h
+++ b/External/FEXCore/include/FEXCore/IR/IREmitter.h
@@ -73,11 +73,17 @@ friend class FEXCore::IR::PassManager;
   IRPair<IROp_StoreMem> _StoreMem(FEXCore::IR::RegisterClassType Class, uint8_t Size, OrderedNode *ssa0, OrderedNode *ssa1, uint8_t Align = 1) {
     return _StoreMem(ssa0, ssa1, Size, Align, Class);
   }
+  IRPair<IROp_StoreMemTSO> _StoreMemTSO(FEXCore::IR::RegisterClassType Class, uint8_t Size, OrderedNode *ssa0, OrderedNode *ssa1, uint8_t Align = 1) {
+    return _StoreMemTSO(ssa0, ssa1, Size, Align, Class);
+  }
   IRPair<IROp_VStoreMemElement> _VStoreMemElement(uint8_t RegisterSize, uint8_t ElementSize, OrderedNode *ssa0, OrderedNode *ssa1, uint8_t Index, uint8_t Align = 1) {
     return _VStoreMemElement(ssa0, ssa1, Index, Align, RegisterSize, ElementSize);
   }
   IRPair<IROp_LoadMem> _LoadMem(FEXCore::IR::RegisterClassType Class, uint8_t Size, OrderedNode *ssa0, uint8_t Align = 1) {
     return _LoadMem(ssa0, Size, Align, Class);
+  }
+  IRPair<IROp_LoadMemTSO> _LoadMemTSO(FEXCore::IR::RegisterClassType Class, uint8_t Size, OrderedNode *ssa0, uint8_t Align = 1) {
+    return _LoadMemTSO(ssa0, Size, Align, Class);
   }
   IRPair<IROp_VLoadMemElement> _VLoadMemElement(uint8_t RegisterSize, uint8_t ElementSize, OrderedNode *ssa0, OrderedNode *ssa1, uint8_t Index, uint8_t Align = 1) {
     return _VLoadMemElement(ssa0, ssa1, Index, Align, RegisterSize, ElementSize);


### PR DESCRIPTION
Relies on #294 to be merged first!
Implements ~~TSO~~ SC GPR loadstore ops with ARM's LORegion instructions.
These match x86's loadstore semantics a bit better than atomics but still have limitations.
- LORegion instructions require natural type alignment
- LORegion doesn't have a CMPXCHG8B matching instruction
- This doesn't support atomic memory ops at all.

To work around the natural alignment issue, we emit the LORegion instructions and backpatch to DMB+LoadStore+DMB.
This isn't quite optimal, but works well enough while we research if the half-barrier approach works; Which will allow us to acquire cachelines rather than ensure full cache consistency.