### PR TITLE
Disables fast fail in github workflow

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -20,6 +20,7 @@ jobs:
     strategy:
       matrix:
         arch: [[self-hosted, x64], [self-hosted, ARMv8.0], [self-hosted, ARMv8.2]]
+      fail-fast: false
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
We want to see the output from all of our runners.
Usually the x86 runner quickly spins through things and then we never see the ARM results if that side failed.