### PR TITLE
Implements ioperm syscall as no permissions

### DIFF
--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -153,6 +153,7 @@ set (SRCS
   Interface/HLE/Syscalls/FD.cpp
   Interface/HLE/Syscalls/FS.cpp
   Interface/HLE/Syscalls/Info.cpp
+  Interface/HLE/Syscalls/IO.cpp
   Interface/HLE/Syscalls/Ioctl.cpp
   Interface/HLE/Syscalls/Memory.cpp
   Interface/HLE/Syscalls/Sched.cpp

--- a/External/FEXCore/Source/Interface/HLE/Syscalls/IO.cpp
+++ b/External/FEXCore/Source/Interface/HLE/Syscalls/IO.cpp
@@ -1,0 +1,16 @@
+#include "Interface/HLE/Syscalls.h"
+#include "Interface/HLE/x64/Syscalls.h"
+
+namespace FEXCore::Core {
+struct InternalThreadState;
+}
+
+namespace FEXCore::HLE {
+
+  void RegisterIO() {
+    REGISTER_SYSCALL_IMPL(ioperm, [](FEXCore::Core::InternalThreadState *Thread, unsigned long from, unsigned long num, int turn_on) -> uint64_t {
+        // ioperm not available on our architecture
+        return -EPERM;
+    });
+  }
+}

--- a/External/FEXCore/Source/Interface/HLE/Syscalls/Stubs.cpp
+++ b/External/FEXCore/Source/Interface/HLE/Syscalls/Stubs.cpp
@@ -188,10 +188,6 @@ namespace FEXCore::HLE {
       SYSCALL_STUB(iopl);
     });
 
-    REGISTER_SYSCALL_IMPL(ioperm, [](FEXCore::Core::InternalThreadState *Thread, unsigned long from, unsigned long num, int turn_on) -> uint64_t {
-      SYSCALL_STUB(ioperm);
-    });
-
     REGISTER_SYSCALL_IMPL(init_module, [](FEXCore::Core::InternalThreadState *Thread, void *module_image, unsigned long len, const char *param_values) -> uint64_t {
       SYSCALL_STUB(init_module);
     });

--- a/External/FEXCore/Source/Interface/HLE/x64/Syscalls.cpp
+++ b/External/FEXCore/Source/Interface/HLE/x64/Syscalls.cpp
@@ -10,6 +10,7 @@ namespace FEXCore::HLE {
     void RegisterFD();
     void RegisterFS();
     void RegisterInfo();
+    void RegisterIO();
     void RegisterIoctl();
     void RegisterMemory();
     void RegisterNuma();
@@ -131,6 +132,7 @@ namespace FEXCore::HLE::x64 {
     RegisterFD();
     RegisterFS();
     RegisterInfo();
+    RegisterIO();
     RegisterIoctl();
     RegisterMemory();
     RegisterSched();


### PR DESCRIPTION
This syscall requires the application to have root and will fail with
-EPERM otherwise.
Implementing this as just an -EPERM return allows Crispy Doom to run