### PR TITLE
Implements rt_sigpending

### DIFF
--- a/External/FEXCore/Source/Interface/Core/SignalDelegator.h
+++ b/External/FEXCore/Source/Interface/Core/SignalDelegator.h
@@ -83,6 +83,7 @@ namespace Core {
     uint64_t RegisterGuestSigAltStack(const stack_t *ss, stack_t *old_ss);
 
     uint64_t GuestSigProcMask(int how, const uint64_t *set, uint64_t *oldset);
+    uint64_t GuestSigPending(uint64_t *set, size_t sigsetsize);
 
     // Called from the thunk handler to handle the signal
     void HandleSignal(int Signal, void *Info, void *UContext);

--- a/External/FEXCore/Source/Interface/HLE/Syscalls/Signals.cpp
+++ b/External/FEXCore/Source/Interface/HLE/Syscalls/Signals.cpp
@@ -21,5 +21,9 @@ namespace FEXCore::HLE {
     REGISTER_SYSCALL_IMPL(sigaltstack, [](FEXCore::Core::InternalThreadState *Thread, const stack_t *ss, stack_t *old_ss) -> uint64_t {
       return Thread->CTX->SignalDelegation.RegisterGuestSigAltStack(ss, old_ss);
     });
+
+    REGISTER_SYSCALL_IMPL(rt_sigpending, [](FEXCore::Core::InternalThreadState *Thread, uint64_t *set, size_t sigsetsize) -> uint64_t {
+      return Thread->CTX->SignalDelegation.GuestSigPending(set, sigsetsize);
+    });
   }
 }

--- a/External/FEXCore/Source/Interface/HLE/Syscalls/Stubs.cpp
+++ b/External/FEXCore/Source/Interface/HLE/Syscalls/Stubs.cpp
@@ -92,10 +92,6 @@ namespace FEXCore::HLE {
       SYSCALL_STUB(capset);
     });
 
-    REGISTER_SYSCALL_IMPL(rt_sigpending, [](FEXCore::Core::InternalThreadState *Thread, sigset_t *set, size_t sigsetsize) -> uint64_t {
-      SYSCALL_STUB(rt_sigpending);
-    });
-
     REGISTER_SYSCALL_IMPL(rt_sigtimedwait, [](FEXCore::Core::InternalThreadState *Thread, sigset_t *set, const struct timespec*, size_t sigsetsize) -> uint64_t {
       SYSCALL_STUB(rt_sigtimedwait);
     });

--- a/unittests/POSIX/Disabled_Tests
+++ b/unittests/POSIX/Disabled_Tests
@@ -537,8 +537,11 @@ conformance-interfaces-raise-2-1.test
 conformance-interfaces-nanosleep-3-2.test
 conformance-behavior-WIFEXITED-1-3.test
 conformance-interfaces-clock_nanosleep-1-5.test
+conformance-interfaces-sigpending-1-1.test
+conformance-interfaces-sigpending-2-1.test
 
 # Causes long timeout with signal change
 conformance-interfaces-mmap-11-2.test
 conformance-interfaces-munmap-1-1.test
 conformance-interfaces-munmap-1-2.test
+

--- a/unittests/POSIX/Known_Failures
+++ b/unittests/POSIX/Known_Failures
@@ -15,12 +15,8 @@ conformance-interfaces-nanosleep-5-1.test
 conformance-interfaces-nanosleep-6-1.test
 conformance-interfaces-raise-1-1.test
 conformance-interfaces-raise-4-1.test
-conformance-interfaces-sigpending-1-1.test
 conformance-interfaces-sigpending-1-2.test
 conformance-interfaces-sigpending-1-3.test
-conformance-interfaces-sigpending-2-1.test
-conformance-interfaces-sigprocmask-4-1.test
-conformance-interfaces-sigprocmask-5-1.test
 conformance-interfaces-sigprocmask-6-1.test
 conformance-interfaces-sigqueue-10-1.test
 conformance-interfaces-sigqueue-11-1.test


### PR DESCRIPTION
Any time a guest signal is blocked, add it to the guest signal mask.
This doesn't use a signal queue so repeat signals can end up being lost.
This is expected behaviour

This doesn't help with implementing the problem of unblocking signals
causing the masked signal to be resent

Fixes the issue of posix unit tests taking five minutes to time out.