### PR TITLE
Misc Optimisation and IR cleanup

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -690,8 +690,6 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
             auto Func = [](auto a, auto b) { return a + b; };
 
             switch (OpSize) {
-              DO_OP(1, uint8_t,  Func)
-              DO_OP(2, uint16_t, Func)
               DO_OP(4, uint32_t, Func)
               DO_OP(8, uint64_t, Func)
               default: LogMan::Msg::A("Unknown Size: %d", OpSize); break;
@@ -705,8 +703,6 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
             auto Func = [](auto a, auto b) { return a - b; };
 
             switch (OpSize) {
-              DO_OP(1, uint8_t,  Func)
-              DO_OP(2, uint16_t, Func)
               DO_OP(4, uint32_t, Func)
               DO_OP(8, uint64_t, Func)
               default: LogMan::Msg::A("Unknown Size: %d", OpSize); break;
@@ -717,12 +713,6 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
             auto Op = IROp->C<IR::IROp_Neg>();
             uint64_t Src = *GetSrc<int64_t*>(Op->Header.Args[0]);
             switch (OpSize) {
-              case 1:
-                GD = -static_cast<int8_t>(Src);
-                break;
-              case 2:
-                GD = -static_cast<int16_t>(Src);
-                break;
               case 4:
                 GD = -static_cast<int32_t>(Src);
                 break;
@@ -784,7 +774,15 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
             uint64_t Src1 = *GetSrc<uint64_t*>(Op->Header.Args[0]);
             uint64_t Src2 = *GetSrc<uint64_t*>(Op->Header.Args[1]);
             uint8_t Mask = OpSize * 8 - 1;
-            GD = Src1 << (Src2 & Mask);
+            switch (OpSize) {
+              case 4:
+                GD = static_cast<int32_t>(Src1) << (Src2 & Mask);
+                break;
+              case 8:
+                GD = static_cast<int64_t>(Src1) << (Src2 & Mask);
+                break;
+              default: LogMan::Msg::A("Unknown LSHL Size: %d\n", OpSize); break;
+            };
             break;
           }
           case IR::OP_LSHR: {

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -1214,7 +1214,7 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
             LogMan::Throw::A(OpSize < 16, "OpSize is too large for BFE: %d", OpSize);
             int64_t Src = *GetSrc<int64_t*>(Op->Header.Args[0]);
             uint64_t ShiftLeftAmount = (64 - (Op->Width + Op->lsb));
-            uint64_t ShiftRightAmount = ShiftLeftAmount - Op->lsb;
+            uint64_t ShiftRightAmount = ShiftLeftAmount + Op->lsb;
             Src <<= ShiftLeftAmount;
             Src >>= ShiftRightAmount;
             GD = Src;

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -1220,24 +1220,13 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
           }
           case IR::OP_BFE: {
             auto Op = IROp->C<IR::IROp_Bfe>();
-            LogMan::Throw::A(OpSize <= 16, "OpSize is too large for BFE: %d", OpSize);
-            if (OpSize == 16) {
-              LogMan::Throw::A(Op->Width <= 64, "Can't extract width of %d", Op->Width);
-              __uint128_t SourceMask = (1ULL << Op->Width) - 1;
-              if (Op->Width == 64)
-                SourceMask = ~0ULL;
-              SourceMask <<= Op->lsb;
-              __uint128_t Src = (*GetSrc<__uint128_t*>(Op->Header.Args[0]) & SourceMask) >> Op->lsb;
-              memcpy(GDP, &Src, OpSize);
-            }
-            else {
-              uint64_t SourceMask = (1ULL << Op->Width) - 1;
-              if (Op->Width == 64)
-                SourceMask = ~0ULL;
-              SourceMask <<= Op->lsb;
-              uint64_t Src = *GetSrc<uint64_t*>(Op->Header.Args[0]);
-              GD = (Src & SourceMask) >> Op->lsb;
-            }
+            LogMan::Throw::A(OpSize <= 8, "OpSize is too large for BFE: %d", OpSize);
+            uint64_t SourceMask = (1ULL << Op->Width) - 1;
+            if (Op->Width == 64)
+              SourceMask = ~0ULL;
+            SourceMask <<= Op->lsb;
+            uint64_t Src = *GetSrc<uint64_t*>(Op->Header.Args[0]);
+            GD = (Src & SourceMask) >> Op->lsb;
             break;
           }
           case IR::OP_SELECT: {

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -893,32 +893,11 @@ DEF_OP(Bfi) {
 DEF_OP(Bfe) {
   auto Op = IROp->C<IR::IROp_Bfe>();
   uint8_t OpSize = IROp->Size;
-  LogMan::Throw::A(OpSize <= 16, "OpSize is too large for BFE: %d", OpSize);
+  LogMan::Throw::A(OpSize <= 8, "OpSize is too large for BFE: %d", OpSize);
   LogMan::Throw::A(Op->Width != 0, "Invalid BFE width of 0");
 
   auto Dst = GetReg<RA_64>(Node);
-  if (OpSize == 16) {
-    LogMan::Throw::A(!(Op->lsb < 64 && (Op->lsb + Op->Width > 64)), "Trying to BFE an XMM across the 64bit split: Beginning at %d, ending at %d", Op->lsb, Op->lsb + Op->Width);
-    uint8_t Offset = Op->lsb;
-    if (Offset < 64) {
-      mov(Dst, GetSrc(Op->Header.Args[0].ID()).D(), 0);
-    }
-    else {
-      mov(Dst, GetSrc(Op->Header.Args[0].ID()).D(), 1);
-      Offset -= 64;
-    }
-
-    if (Offset) {
-      lsr(Dst, Dst, Offset);
-    }
-
-    if (Op->Width != 64) {
-      ubfx(Dst, Dst, 0, Op->Width);
-    }
-  }
-  else {
-    ubfx(Dst, GetReg<RA_64>(Op->Header.Args[0].ID()), Op->lsb, Op->Width);
-  }
+  ubfx(Dst, GetReg<RA_64>(Op->Header.Args[0].ID()), Op->lsb, Op->Width);
 }
 
 DEF_OP(Sbfe) {

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -61,12 +61,29 @@ DEF_OP(CycleCounter) {
 
 DEF_OP(Add) {
   auto Op = IROp->C<IR::IROp_Add>();
-  add(GetReg<RA_64>(Node), GetReg<RA_64>(Op->Header.Args[0].ID()), GetReg<RA_64>(Op->Header.Args[1].ID()));
+  switch (IROp->Size;) {
+    case 4:
+      add(GetReg<RA_32>(Node), GetReg<RA_32>(Op->Header.Args[0].ID()), GetReg<RA_32>(Op->Header.Args[1].ID()));
+      break;
+    case 8:
+      add(GetReg<RA_64>(Node), GetReg<RA_64>(Op->Header.Args[0].ID()), GetReg<RA_64>(Op->Header.Args[1].ID()));
+      break;
+    default: LogMan::Msg::A("Unsupported Add size: %d", OpSize);
+  }
 }
 
 DEF_OP(Sub) {
   auto Op = IROp->C<IR::IROp_Sub>();
-  sub(GetReg<RA_64>(Node), GetReg<RA_64>(Op->Header.Args[0].ID()), GetReg<RA_64>(Op->Header.Args[1].ID()));
+  switch (IROp->Size;) {
+    case 4:
+      sub(GetReg<RA_32>(Node), GetReg<RA_32>(Op->Header.Args[0].ID()), GetReg<RA_32>(Op->Header.Args[1].ID()));
+      break;
+    case 8:
+      sub(GetReg<RA_64>(Node), GetReg<RA_64>(Op->Header.Args[0].ID()), GetReg<RA_64>(Op->Header.Args[1].ID()));
+      break;
+    default: LogMan::Msg::A("Unsupported Sub size: %d", OpSize);
+  }
+
 }
 
 DEF_OP(Neg) {

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -520,11 +520,13 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
           else {
             switch (OpSize) {
             case 1: {
-              pinsrb(GetDst(Node), byte [STATE + Op->Offset], 0);
+              movzx(rax, byte [STATE + Op->Offset]);
+              vmovq(GetDst(Node), rax);
             }
             break;
             case 2: {
-              pinsrw(GetDst(Node), word [STATE + Op->Offset], 0);
+              movzx(rax, word [STATE + Op->Offset]);
+              vmovq(GetDst(Node), rax);
             }
             break;
             case 4: {
@@ -594,10 +596,12 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
               lea(rax, dword [STATE + Op->BaseOffset]);
               switch (size) {
               case 1:
-                pinsrb(GetDst(Node), byte [rax + index * Op->Stride], 0);
+                movzx(eax, byte [rax + index * Op->Stride]);
+                vmovd(GetDst(Node), eax);
                 break;
               case 2:
-                pinsrw(GetDst(Node), word [rax + index * Op->Stride], 0);
+                movzx(eax, word [rax + index * Op->Stride]);
+                vmovd(GetDst(Node), eax);
                 break;
               case 4:
                 vmovd(GetDst(Node),  dword [rax + index * Op->Stride]);
@@ -1871,11 +1875,13 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
 
             switch (Op->Size) {
               case 1: {
-                pinsrb(Dst, byte [MemReg], 0);
+                movzx(eax, byte [MemReg]);
+                vmovd(Dst, eax);
               }
               break;
               case 2: {
-                pinsrw(Dst, word [MemReg], 0);
+                movzx(eax, byte [MemReg]);
+                vmovd(Dst, eax);
               }
               break;
               case 4: {

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -851,20 +851,6 @@
       ]
     },
 
-    "Zext": {
-      "Desc": ["Integer zero extension",
-               "Extends from the source bitsize to the next byte size up from that size"
-              ],
-      "OpClass": "ALU",
-      "HasDest": true,
-      "DestClass": "Complex",
-      "DestSize": "SrcSize / 4",
-      "SSAArgs": "1",
-      "Args": [
-        "uint8_t", "SrcSize"
-      ]
-    },
-
     "Sext": {
       "Desc": ["Integer sign extension",
                "Extends from the source bitsize to the next byte size up from that size"
@@ -983,8 +969,14 @@
       "OpClass": "ALU",
       "HasDest": true,
       "DestClass": "GPR",
-      "DestSize": "GetOpSize(ssa0)",
+      "DestSize": "DestSize != 0 ? DestSize : GetOpSize(ssa0)",
       "SSAArgs": "1",
+      "SSANames": [
+        "Src"
+      ],
+      "HelperArgs": [
+        "uint8_t", "DestSize"
+      ],
       "Args": [
         "uint8_t", "Width",
         "uint8_t", "lsb"

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -1391,13 +1391,17 @@
     },
 
     "VMov": {
+      "Desc" : ["Copy vector register",
+                "When Register size is smaller than Source register size,",
+                "this op is defined to truncate and zero extend"
+               ],
       "OpClass": "Vector",
       "HasDest": true,
       "DestClass": "FPR",
       "DestSize": "RegisterSize",
       "SSAArgs": "1",
       "SSANames": [
-        "Vector"
+        "Source"
       ],
       "HelperArgs": [
         "uint8_t", "RegisterSize"

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -615,29 +615,35 @@
     },
 
     "Add": {
-      "Desc": [ "Integer Add"
+      "Desc": [ "Integer Add",
+                "Will truncate to 64 or 32bits"
               ],
       "OpClass": "ALU",
       "HasDest": true,
       "DestClass": "GPR",
+      "DestSize": "std::max<uint8_t>(4, std::max(GetOpSize(ssa0), GetOpSize(ssa1)))",
       "SSAArgs": "2"
     },
 
     "Sub": {
-      "Desc": [ "Integer Sub"
+      "Desc": [ "Integer Sub",
+                "Will truncate to 64 or 32bits"
               ],
       "OpClass": "ALU",
       "HasDest": true,
+      "DestSize": "std::max<uint8_t>(4, std::max(GetOpSize(ssa0), GetOpSize(ssa1)))",
       "DestClass": "GPR",
       "SSAArgs": "2"
     },
 
     "Neg": {
       "Desc": ["Integer negation",
-               "Dest = -Src"
+               "Dest = -Src",
+               "Will truncate to 64 or 32bits"
               ],
       "OpClass": "ALU",
       "HasDest": true,
+      "DestSize": "std::max<uint8_t>(4, GetOpSize(ssa0))",
       "DestClass": "GPR",
       "SSAArgs": "1"
     },
@@ -647,6 +653,7 @@
               ],
       "OpClass": "ALU",
       "HasDest": true,
+      "DestSize": "std::max<uint8_t>(4, std::max(GetOpSize(ssa0), GetOpSize(ssa1)))",
       "DestClass": "GPR",
       "SSAArgs": "2"
     },
@@ -656,6 +663,7 @@
               ],
       "OpClass": "ALU",
       "HasDest": true,
+      "DestSize": "std::max<uint8_t>(4, std::max(GetOpSize(ssa0), GetOpSize(ssa1)))",
       "DestClass": "GPR",
       "SSAArgs": "2"
     },
@@ -752,6 +760,7 @@
               ],
       "OpClass": "ALU",
       "HasDest": true,
+      "DestSize": "std::max<uint8_t>(4, std::max(GetOpSize(ssa0), GetOpSize(ssa1)))",
       "DestClass": "GPR",
       "SSAArgs": "2"
     },
@@ -997,6 +1006,7 @@
       "OpClass": "ALU",
       "HasDest": true,
       "DestClass": "GPR",
+      "DestSize": "8",
       "SSAArgs": "1",
       "Args": [
         "uint8_t", "Width",

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -354,7 +354,9 @@
     "StoreContext": {
       "HasSideEffects": true,
       "Desc": ["Stores a value to the context with offset",
-               "Ctx[Offset] = Value"
+               "Ctx[Offset] = Value",
+               "Zero Extends if value's type is too small",
+               "Truncates if value's type is too large"
               ],
       "OpClass": "Memory",
       "SSAArgs": "1",
@@ -518,6 +520,10 @@
     },
 
     "StoreMem": {
+      "Desc": [ "Stores a value to memory.",
+                "Zero Extends if value's type is too small",
+                "Truncates if value's type is too large"
+              ],
       "HasSideEffects": true,
       "OpClass": "Memory",
       "SSAArgs": "2",
@@ -2450,6 +2456,7 @@
     },
 
     "VBitcast": {
+      "Dest": ["Workaround for issue with LLVM breaking when loading scalar elements to vectors"],
       "OpClass": "Vector",
       "HasDest": true,
       "DestClass": "FPR",

--- a/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -196,19 +196,6 @@ bool ConstProp::Run(IREmitter *IREmit) {
           Changed = true;
         }
 
-        break;
-      }
-      case OP_ZEXT: {
-        auto Op = IROp->C<IR::IROp_Zext>();
-        uint64_t Constant;
-        if (Op->SrcSize != 64 &&
-            IREmit->IsValueConstant(Op->Header.Args[0], &Constant)) {
-          uint64_t NewConstant = Constant & ((1ULL << Op->SrcSize) - 1);
-          IREmit->SetWriteCursor(CodeNode);
-          auto ConstantVal = IREmit->_Constant(NewConstant);
-          IREmit->ReplaceAllUsesWithInclusive(CodeNode, ConstantVal, CodeBegin, CodeLast);
-          Changed = true;
-        }
       break;
       }
       case OP_MUL: {

--- a/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -8,6 +8,12 @@ public:
   bool Run(IREmitter *IREmit) override;
 };
 
+template<typename T>
+static uint64_t getMask(T Op) {
+  uint64_t NumBits = Op->Header.Size * 8;
+  return (~0ULL) >> (64 - NumBits);
+}
+
 bool ConstProp::Run(IREmitter *IREmit) {
   bool Changed = false;
   auto CurrentIR = IREmit->ViewIR();
@@ -88,7 +94,7 @@ bool ConstProp::Run(IREmitter *IREmit) {
 
         if (IREmit->IsValueConstant(Op->Header.Args[0], &Constant1) &&
             IREmit->IsValueConstant(Op->Header.Args[1], &Constant2)) {
-          uint64_t NewConstant = Constant1 + Constant2;
+          uint64_t NewConstant = (Constant1 + Constant2) & getMask(Op) ;
           IREmit->SetWriteCursor(CodeNode);
           auto ConstantVal = IREmit->_Constant(NewConstant);
           IREmit->ReplaceAllUsesWithInclusive(CodeNode, ConstantVal, CodeBegin, CodeLast);
@@ -103,7 +109,7 @@ bool ConstProp::Run(IREmitter *IREmit) {
 
         if (IREmit->IsValueConstant(Op->Header.Args[0], &Constant1) &&
             IREmit->IsValueConstant(Op->Header.Args[1], &Constant2)) {
-          uint64_t NewConstant = Constant1 - Constant2;
+          uint64_t NewConstant = (Constant1 - Constant2) & getMask(Op) ;
           IREmit->SetWriteCursor(CodeNode);
           auto ConstantVal = IREmit->_Constant(NewConstant);
           IREmit->ReplaceAllUsesWithInclusive(CodeNode, ConstantVal, CodeBegin, CodeLast);
@@ -118,7 +124,7 @@ bool ConstProp::Run(IREmitter *IREmit) {
 
         if (IREmit->IsValueConstant(Op->Header.Args[0], &Constant1) &&
             IREmit->IsValueConstant(Op->Header.Args[1], &Constant2)) {
-          uint64_t NewConstant = Constant1 & Constant2;
+          uint64_t NewConstant = (Constant1 & Constant2) & getMask(Op) ;
           IREmit->SetWriteCursor(CodeNode);
           auto ConstantVal = IREmit->_Constant(NewConstant);
           IREmit->ReplaceAllUsesWithInclusive(CodeNode, ConstantVal, CodeBegin, CodeLast);
@@ -163,7 +169,7 @@ bool ConstProp::Run(IREmitter *IREmit) {
 
         if (IREmit->IsValueConstant(Op->Header.Args[0], &Constant1) &&
             IREmit->IsValueConstant(Op->Header.Args[1], &Constant2)) {
-          uint64_t NewConstant = Constant1 << Constant2;
+          uint64_t NewConstant = (Constant1 << Constant2) & getMask(Op);
           IREmit->SetWriteCursor(CodeNode);
           auto ConstantVal = IREmit->_Constant(NewConstant);
           IREmit->ReplaceAllUsesWithInclusive(CodeNode, ConstantVal, CodeBegin, CodeLast);
@@ -205,7 +211,7 @@ bool ConstProp::Run(IREmitter *IREmit) {
 
         if (IREmit->IsValueConstant(Op->Header.Args[0], &Constant1) &&
             IREmit->IsValueConstant(Op->Header.Args[1], &Constant2)) {
-          uint64_t NewConstant = Constant1 * Constant2;
+          uint64_t NewConstant = (Constant1 * Constant2) & getMask(Op);
           IREmit->SetWriteCursor(CodeNode);
           auto ConstantVal = IREmit->_Constant(NewConstant);
           IREmit->ReplaceAllUsesWithInclusive(CodeNode, ConstantVal, CodeBegin, CodeLast);

--- a/External/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
@@ -456,7 +456,7 @@ bool RCLSE::RedundantStoreLoadElimination(FEXCore::IR::IREmitter *IREmit) {
     auto CodeLast = CurrentIR.at(BlockIROp->Last);
 
     auto OpSize = [&](OrderedNode *node) {
-      return node->Op(ListBegin)->Size;
+      return node->Op(DataBegin)->Size;
     };
 
     while (1) {
@@ -513,7 +513,7 @@ bool RCLSE::RedundantStoreLoadElimination(FEXCore::IR::IREmitter *IREmit) {
             else if (RegClass == GPRPairClass)
               LastNode = IREmit->_TruncElementPair(LastNode, TruncateSize);
             else if (RegClass == GPRClass)
-              LastNode = IREmit->_Bfe(TruncateSize * 8, 0, LastNode);
+              LastNode = IREmit->_Bfe(IROp->Size, TruncateSize * 8, 0, LastNode);
           }
 
           // If the last store matches this load value then we can replace the loaded value with the previous valid one

--- a/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -238,18 +238,6 @@ namespace {
         return Op->Class;
         break;
       }
-      case IR::OP_ZEXT: {
-        auto Op = IROp->C<IR::IROp_Zext>();
-        LogMan::Throw::A(Op->SrcSize <= 64, "Can't support Zext of size: %ld", Op->SrcSize);
-
-        if (Op->SrcSize == 64) {
-          return FEXCore::IR::FPRClass;
-        }
-        else {
-          return FEXCore::IR::GPRClass;
-        }
-        break;
-      }
       case IR::OP_PHIVALUE: {
         // Unwrap the PHIValue to get the class
         auto Op = IROp->C<IR::IROp_PhiValue>();

--- a/External/FEXCore/include/FEXCore/IR/IREmitter.h
+++ b/External/FEXCore/include/FEXCore/IR/IREmitter.h
@@ -62,7 +62,10 @@ friend class FEXCore::IR::PassManager;
     return _StoreContext(ssa0, Offset, Class, Size);
   }
   IRPair<IROp_Bfe> _Bfe(uint8_t Width, uint8_t lsb, OrderedNode *ssa0) {
-    return _Bfe(ssa0, Width, lsb);
+    return _Bfe(ssa0, Width, lsb, 0);
+  }
+  IRPair<IROp_Bfe> _Bfe(uint8_t DestSize, int8_t Width, uint8_t lsb, OrderedNode *ssa0) {
+    return _Bfe(ssa0, Width, lsb, DestSize);
   }
   IRPair<IROp_Sbfe> _Sbfe(uint8_t Width, uint8_t lsb, OrderedNode *ssa0) {
     return _Sbfe(ssa0, Width, lsb);
@@ -93,9 +96,6 @@ friend class FEXCore::IR::PassManager;
   }
   IRPair<IROp_Sext> _Sext(uint8_t SrcSize, OrderedNode *ssa0) {
     return _Sext(ssa0, SrcSize);
-  }
-  IRPair<IROp_Zext> _Zext(uint8_t SrcSize, OrderedNode *ssa0) {
-    return _Zext(ssa0, SrcSize);
   }
   IRPair<IROp_VInsElement> _VInsElement(uint8_t RegisterSize, uint8_t ElementSize, uint8_t DestIdx, uint8_t SrcIdx, OrderedNode *ssa0, OrderedNode *ssa1) {
     return _VInsElement(ssa0, ssa1, DestIdx, SrcIdx, RegisterSize, ElementSize);

--- a/unittests/IR/Basic/Sbfe.ir
+++ b/unittests/IR/Basic/Sbfe.ir
@@ -1,0 +1,41 @@
+;%ifdef CONFIG
+;{
+;  "RegData": {
+;    "RAX": "0xffffffffffffff80",
+;    "RBX": "0xffffffffffff8080",
+;    "RCX": "0xffffffff80008080",
+;    "RDX": "0xfffffffffffffff0",
+;    "RSI": "0xfffffffffffffffc"
+;  },
+;  "MemoryRegions": {
+;    "0x1000000": "4096"
+;  },
+;  "MemoryData": {
+;    "0x1000000": "0x0000000080008080",
+;    "0x1000008": "0x0000000000000030"
+;  }
+;}
+;%endif
+
+(%ssa1) IRHeader #0x1000, %ssa2, #0
+  (%ssa2) CodeBlock %start, %end, %ssa1
+    (%start i0) Dummy
+    %Addr1 i64 = Constant #0x1000000
+    %Val i64 = LoadMem %Addr1 i64, #0x8, #0x8, GPR
+; Test aligned special cases
+    %Res1 i64 = Sbfe %Val, #0x8, #0x0
+    (%Store1 i64) StoreContext %Res1 i64, #0x08, GPR
+    %Res2 i64 = Sbfe %Val, #0x10, #0x0
+    (%Store2 i64) StoreContext %Res2 i64, #0x10, GPR
+    %Res3 i64 = Sbfe %Val, #0x20, #0x0
+    (%Store3 i64) StoreContext %Res3 i64, #0x18, GPR
+    %Addr2 i64 = Constant #0x1000008
+; Test non special width
+    %Val2 i64 = LoadMem %Addr2 i64, #0x8, #0x8, GPR
+    %Res4 i64 = Sbfe %Val2, #0x6, #0x0
+    (%Store4 i64) StoreContext %Res4 i64, #0x20, GPR
+; Test with + shift
+    %Res5 i64 = Sbfe %Val2, #0x4, #0x2
+    (%Store5 i64) StoreContext %Res5 i64, #0x28, GPR
+    (%brk i0) Break #4, #4
+    (%end i0) EndBlock #0x0

--- a/unittests/IR/CMakeLists.txt
+++ b/unittests/IR/CMakeLists.txt
@@ -20,13 +20,10 @@ foreach(IR_SRC ${IR_SOURCES})
 
   list(APPEND IR_DEPENDS "${OUTPUT_CONFIG_NAME}")
 
+  # Since we pass in raw IR, we don't need to worry about various IR gen options
   set(TEST_ARGS
-    "-c irint -n 1"      "ir_int_1"
-    "-c irint -n 500"    "ir_int_500"
-    "-c irint -n 500 -m" "ir_int_500_m"
-    "-c irjit -n 1"      "ir_jit_1"
-    "-c irjit -n 500"    "ir_jit_500"
-    "-c irjit -n 500 -m" "ir_jit_500_m"
+    "-c irint -n 500" "ir_int"
+    "-c irjit -n 500" "ir_jit"
     )
 
   list(LENGTH TEST_ARGS ARG_COUNT)

--- a/unittests/IR/Correctness/AddTruncate.ir
+++ b/unittests/IR/Correctness/AddTruncate.ir
@@ -1,0 +1,38 @@
+;%ifdef CONFIG
+;{
+;  "RegData": {
+;    "RAX": "0x00000000fffffff9",
+;    "RBX": "0xfffffffffffffff9",
+;    "RCX": "0x00000000fffffff9",
+;    "RDX": "0xfffffffffffffff9"
+;  },
+;  "MemoryRegions": {
+;    "0x1000000": "4096"
+;  },
+;  "MemoryData": {
+;    "0x1000000": "0xaaaaaaaaaaaaaaa8",
+;    "0x1000010": "51 55 55 55 55 55 55 55"
+;  }
+;}
+;%endif
+
+(%ssa1) IRHeader #0x1000, %ssa2, #0
+  (%ssa2) CodeBlock %ssa6, %ssa12, %ssa1
+    (%ssa6 i0) Dummy
+    %AddrA i64 = Constant #0x1000000
+    %MemValueA i64 = LoadMem %AddrA i64, #0x8, #0x8, GPR
+    %AddrB i64 = Constant #0x1000010
+    %MemValueB i64 = LoadMem %AddrB i64, #0x8, #0x8, GPR
+    %ResultA i32 = Add %MemValueA, %MemValueB
+    %ResultB i64 = Add %MemValueA, %MemValueB
+    (%Store i64) StoreContext %ResultA i64, #0x08, GPR
+    (%Store i64) StoreContext %ResultB i64, #0x10, GPR
+;  Constant optimisable version
+    %ValueC i64 = Constant #0xaaaaaaaaaaaaaaa8
+    %ValueD i64 = Constant #0x5555555555555551
+    %ResultC i32 = Add %ValueC, %ValueD
+    %ResultD i64 = Add %ValueC, %ValueD
+    (%Store i64) StoreContext %ResultC i64, #0x18, GPR
+    (%Store i64) StoreContext %ResultD i64, #0x20, GPR
+    (%ssa7 i0) Break #4, #4
+    (%ssa12 i0) EndBlock #0x0

--- a/unittests/IR/Correctness/FPRStoreTruncate.ir
+++ b/unittests/IR/Correctness/FPRStoreTruncate.ir
@@ -1,0 +1,49 @@
+;%ifdef CONFIG
+;{
+;  "RegData": {
+;    "XMM4": ["0x2726252423222120","0x0000000000000000"],
+;    "XMM5": ["0x0000000023222120","0x0000000000000000"],
+;    "XMM6": ["0x0000000000002120","0x0000000000000000"],
+;    "XMM7": ["0x0000000000000020","0x0000000000000000"]
+;  },
+;  "MemoryRegions": {
+;    "0x1000000": "4096"
+;  },
+;  "MemoryData": {
+;    "0x1000000": "20 21 22 23 24 25 26 27 28 29 2a 2b 2c 2d 2e 2f",
+;    "0x1000010": "11 11 11 11 11 11 11 11 11 11 11 11 11 11 11 11"
+;  }
+;}
+;%endif
+
+
+
+(%ssa1) IRHeader #0x1000, %ssa2, #0
+  (%ssa2) CodeBlock %ssa6, %end, %begin
+    (%begin i0) Dummy
+; Clear registers
+    %AddrB i64 = Constant #0x1000010
+    %ClearVal i128 = LoadMem %AddrB i64, #0x10, #0x10, FPR
+    (%Clear1 i128) StoreContext %ClearVal i128, #0x90, FPR
+    (%Clear2 i128) StoreContext %ClearVal i128, #0xa0, FPR
+    (%Clear3 i128) StoreContext %ClearVal i128, #0xb0, FPR
+    (%Clear4 i128) StoreContext %ClearVal i128, #0xc0, FPR
+
+    %AddrA i64 = Constant #0x1000000
+    %MemValueA i128 = LoadMem %AddrA i64, #0x10, #0x10, FPR
+
+    (%Store1 i64) StoreContext %MemValueA i128, #0x90, FPR
+    (%Store2 i32) StoreContext %MemValueA i128, #0xa0, FPR
+    (%Store3 i16) StoreContext %MemValueA i128, #0xb0, FPR
+    (%Store4 i8)  StoreContext %MemValueA i128, #0xc0, FPR
+    %Truncated64 i64 = LoadContext #0x90, FPR
+    %Truncated32 i32 = LoadContext #0xa0, FPR
+    %Truncated16 i16 = LoadContext #0xb0, FPR
+    %Truncated8  i8 = LoadContext #0xc0, FPR
+    (%Store5 i128) StoreContext %Truncated64 i128, #0xd0, FPR
+    (%Store6 i128) StoreContext %Truncated32 i128, #0xe0, FPR
+    (%Store7 i128) StoreContext %Truncated16 i128, #0xf0, FPR
+    (%Store8 i128)  StoreContext %Truncated8 i128, #0x100, FPR
+    (%Store9 i128)  StoreContext %MemValueA i128, #0x110, FPR
+    (%ssa7 i0) Break #4, #4
+    (%end i0) EndBlock #0x0

--- a/unittests/IR/Correctness/LeftShiftTruncate.ir
+++ b/unittests/IR/Correctness/LeftShiftTruncate.ir
@@ -1,0 +1,36 @@
+;%ifdef CONFIG
+;{
+;  "RegData": {
+;    "RAX": "0x000000000eca8642",
+;    "RBX": "0x000000010eca8642",
+;    "RCX": "0x000000000eca8642",
+;    "RDX": "0x000000010eca8642"
+;  },
+;  "MemoryRegions": {
+;    "0x1000000": "4096"
+;  },
+;  "MemoryData": {
+;    "0x1000000": "0x87654321",
+;    "0x1000010": "51 55 55 55 55 55 55 55"
+;  }
+;}
+;%endif
+
+(%ssa1) IRHeader #0x1000, %ssa2, #0
+  (%ssa2) CodeBlock %ssa6, %ssa12, %ssa1
+    (%ssa6 i0) Dummy
+    %AddrA i64 = Constant #0x1000000
+    %MemValueA i32 = LoadMem %AddrA i64, #0x4, #0x4, GPR
+    %Shift i64 = Constant #0x1
+    %ResultA i32 = Lshl %MemValueA, %Shift
+    %ResultB i64 = Lshl %MemValueA, %Shift
+    (%Store i64) StoreContext %ResultA i64, #0x08, GPR
+    (%Store i64) StoreContext %ResultB i64, #0x10, GPR
+;  Constant optimisable version
+    %ValueB i64 = Constant #0x87654321
+    %ResultC i32 = Lshl %ValueB, %Shift
+    %ResultD i64 = Lshl %ValueB, %Shift
+    (%Store i64) StoreContext %ResultC i64, #0x18, GPR
+    (%Store i64) StoreContext %ResultD i64, #0x20, GPR
+    (%ssa7 i0) Break #4, #4
+    (%ssa12 i0) EndBlock #0x0

--- a/unittests/IR/Correctness/SubTruncate.ir
+++ b/unittests/IR/Correctness/SubTruncate.ir
@@ -1,0 +1,38 @@
+;%ifdef CONFIG
+;{
+;  "RegData": {
+;    "RAX": "0x0000000055555557",
+;    "RBX": "0x5555555555555557",
+;    "RCX": "0x0000000055555557",
+;    "RDX": "0x5555555555555557"
+;  },
+;  "MemoryRegions": {
+;    "0x1000000": "4096"
+;  },
+;  "MemoryData": {
+;    "0x1000000": "0xaaaaaaaaaaaaaaa8",
+;    "0x1000010": "51 55 55 55 55 55 55 55"
+;  }
+;}
+;%endif
+
+(%ssa1) IRHeader #0x1000, %ssa2, #0
+  (%ssa2) CodeBlock %ssa6, %ssa12, %ssa1
+    (%ssa6 i0) Dummy
+    %AddrA i64 = Constant #0x1000000
+    %MemValueA i64 = LoadMem %AddrA i64, #0x8, #0x8, GPR
+    %AddrB i64 = Constant #0x1000010
+    %MemValueB i64 = LoadMem %AddrB i64, #0x8, #0x8, GPR
+    %ResultA i32 = Sub %MemValueA, %MemValueB
+    %ResultB i64 = Sub %MemValueA, %MemValueB
+    (%Store i64) StoreContext %ResultA i64, #0x08, GPR
+    (%Store i64) StoreContext %ResultB i64, #0x10, GPR
+;  Constant optimisable version
+    %ValueC i64 = Constant #0xaaaaaaaaaaaaaaa8
+    %ValueD i64 = Constant #0x5555555555555551
+    %ResultC i32 = Sub %ValueC, %ValueD
+    %ResultD i64 = Sub %ValueC, %ValueD
+    (%Store i64) StoreContext %ResultC i64, #0x18, GPR
+    (%Store i64) StoreContext %ResultD i64, #0x20, GPR
+    (%ssa7 i0) Break #4, #4
+    (%ssa12 i0) EndBlock #0x0


### PR DESCRIPTION
This branch started as optimisation but kind of gained a bunch of IR cleanup too.  

### IR Cleanup highlights:

 * `Zext` and `Sext` opcode are gone. Use `Bfe` and `Sbfe` instead.
 * `Sbfe` has actually been implemented
 * `Bfe` has lost it's responsibly for handling extraction FPRs.
 * General IR semantics have been changed:
   * IR Ops are not allowed to any bits higher than their defined size.  
For example, `%ssa5 i32 = Add Constant(0xffffffff), Constant(0x1)` will result in zero.
   * Some sizes of some IR ops that don't exist on arm are now banned.  
For example 8 and 16bit `Add`/`Sub`/`Mul`. OpcodeDecoder is expected to generate a 32bit `Op` followed by a `Bfe`
   * Due to this, GPR IR Ops are allowed to assume they can Zero Extend their inputs upto 64bits for free. 
   * Same with FPR IR Ops, which can Zero Extend upto 128bits. 
 * `StoreContext` (and `StoreMem`) have been explictly defined to truncate and zero extend.

This means `StoreContext` can be used instead of a `Bfe` 

For example, a 8bit Add can now be implemented as

```asm
%ssa1 i8 = LoadContext #0x10, GPR
%ssa2 i8 = LoadContext #0x18, GPR
%ssa3 i32 = Add ssa1 i8, ssa2 i8 ; zero extends it's inputs for free, since upper bits are guaranteed to be zero
(%ssa4 i8) = StoreContext  %ssa3 i32, #0x10, GPR ; truncates ssa3 by the nature of being
                                                 ; implemented as a 8 bit store instruction
```

and x64's famous 32bit ops that always zero extend to 64bits can be implemented as:

```asm
%ssa1 i32 = LoadContext #0x10, GPR
%ssa2 i32 = LoadContext #0x18, GPR
%ssa3 i32 = Add ssa1 i32, ssa2 i32
(%ssa4 i64) = StoreContext  %ssa3 i32, #0x10, GPR ; Outputs a 64bit store instruction, 
                                                  ; which gets a free zero-extend because the
                                                  ; upper bits of the 32bit add are empty 
```

------------------

This does complicate the DCSE pass a little. Now it sometimes needs to insert `Bfes` to preserve truncation/zext semantics

for example, this:

```asm
%ssa3 i32 = Add ssa1 i32, ssa2 i32
(%ssa4 i8) = StoreContext  %ssa3 i32, #0x10, GPR ; Truncates to 8 bits
%ssa5 i64 = LoadContext #0x10, GPR
```

Needs to be optimised to:
```asm
%ssa3 i32 = Add ssa1 i32, ssa2 i32
%ssa5 i64 = Bfe %ssa3 i32, #0x8, #0x0 ; Truncates to 8 bits
```

But the advantage of this scheme is that the number of explicit `Bfes` are minimised and our jits produce more optimal code.


### Optimisation

All focused around limiting context loads and Zexts/BFEs. 

 * Most `LoadContexts` are now eliminated unless they load a wider value than the corresponding `StoreContext`
 * Lots of unnecessary BFEs have been elimiated
 * x86 only: the implement of BFE for common 8bit, 16bit, 32bit extracts has been optimised.. 

In the FTL resource load Benchmark this PR:

 * Cuts time on my c630 by 10% to 45 seconds. 
 * Cuts time on my 3900x 18% to 15 seconds.  

Interestingly, native load time is 1.5 seconds, so our x86 jit is just 10x slower than native. 

------------------------------

Once again, here are IR Dumps of FTL's inner PNG decoding loop:

<details>
<summary>Before Optimisation</summary>

```
IR 0x6f0190:
        (%ssa1) IRHeader #0x6f0190, %ssa2, #0
        (%ssa2) CodeBlock %ssa4, %ssa234, %ssa3
                (%ssa4 i0) Dummy
                %ssa5(GPR0) i64 = LoadContext #0x10, GPR
                %ssa6(GPR1) i64 = LoadContext #0x20, GPR
                %ssa7(GPR2) i64 = Add %ssa5(GPR0) i64, %ssa6(GPR1) i64
                %ssa8(GPR2) i8 = LoadMemTSO %ssa7(GPR2) i64, #0x1, #0x1, GPR
                %ssa9(GPR2) i16 = Zext %ssa8(GPR2) i8, #0x8
                %ssa10(GPR2) i64 = Zext %ssa9(GPR2) i16, #0x20
                (%ssa11 i64) StoreContext %ssa10(GPR2) i64, #0x48, GPR
                %ssa12(GPR2) i64 = Constant #0x1
                %ssa13(GPR1) i64 = Add %ssa6(GPR1) i64, %ssa12(GPR2) i64
                (%ssa14 i64) StoreContext %ssa13(GPR1) i64, #0x20, GPR
                %ssa15(GPR2) i64 = LoadContext #0x28, GPR
                %ssa16(GPR0) i64 = Add %ssa5(GPR0) i64, %ssa15(GPR2) i64
                (%ssa17 i64) SpillRegister %ssa15(GPR2) i64, #0x0, GPR
                %ssa18(GPR0) i8 = LoadMemTSO %ssa16(GPR0) i64, #0x1, #0x1, GPR
                %ssa19(GPR0) i16 = Zext %ssa18(GPR0) i8, #0x8
                %ssa20(GPR0) i64 = Zext %ssa19(GPR0) i16, #0x20
                (%ssa21 i64) StoreContext %ssa20(GPR0) i64, #0x30, GPR
                %ssa22(GPR0) i64 = Constant #0xffffffffffffffff
                %ssa23(GPR0) i64 = Add %ssa13(GPR1) i64, %ssa22(GPR0) i64
                %ssa24(GPR0) i8 = LoadMemTSO %ssa23(GPR0) i64, #0x1, #0x1, GPR
                %ssa25(GPR0) i16 = Zext %ssa24(GPR0) i8, #0x8
                %ssa26(GPR0) i64 = Zext %ssa25(GPR0) i16, #0x20
                (%ssa27 i64) StoreContext %ssa26(GPR0) i64, #0x60, GPR
                %ssa28(GPR0) i32 = LoadContext #0x30, GPR
                %ssa29(GPR0) i64 = Zext %ssa28(GPR0) i32, #0x20
                (%ssa30 i64) StoreContext %ssa29(GPR0) i64, #0x50, GPR
                %ssa31(GPR0) i32 = LoadContext #0x60, GPR
                %ssa32(GPR0) i64 = Zext %ssa31(GPR0) i32, #0x20
                (%ssa33 i64) StoreContext %ssa32(GPR0) i64, #0x58, GPR
                %ssa34(GPR0) i32 = LoadContext #0x48, GPR
                %ssa35(GPR1) i32 = LoadContext #0x50, GPR
                %ssa36(GPR0) i32 = Sub %ssa35(GPR1) i32, %ssa34(GPR0) i32
                %ssa37(GPR0) i64 = Zext %ssa36(GPR0) i32, #0x20
                (%ssa38 i64) StoreContext %ssa37(GPR0) i64, #0x50, GPR
                %ssa39(GPR0) i32 = LoadContext #0x48, GPR
                %ssa40(GPR1) i32 = LoadContext #0x58, GPR
                %ssa41(GPR0) i32 = Sub %ssa40(GPR1) i32, %ssa39(GPR0) i32
                %ssa42(GPR0) i64 = Zext %ssa41(GPR0) i32, #0x20
                (%ssa43 i64) StoreContext %ssa42(GPR0) i64, #0x58, GPR
                %ssa44(GPR0) i32 = LoadContext #0x50, GPR
                %ssa45(GPR0) i64 = Zext %ssa44(GPR0) i32, #0x20
                (%ssa46 i64) StoreContext %ssa45(GPR0) i64, #0x68, GPR
                %ssa47(GPR0) i32 = LoadContext #0x58, GPR
                %ssa48(GPR0) i64 = Zext %ssa47(GPR0) i32, #0x20
                (%ssa49 i64) StoreContext %ssa48(GPR0) i64, #0x8, GPR
                %ssa50(GPR0) i32 = LoadContext #0x68, GPR
                %ssa51(GPR1) i32 = Constant #0x1f
                %ssa52(GPR0) i32 = Ashr %ssa50(GPR0) i32, %ssa51(GPR1) i32
                %ssa53(GPR0) i64 = Zext %ssa52(GPR0) i32, #0x20
                (%ssa54 i64) StoreContext %ssa53(GPR0) i64, #0x68, GPR
                %ssa55(GPR0) i32 = LoadContext #0x8, GPR
                %ssa56(GPR1) i32 = Constant #0x1f
                %ssa57(GPR0) i32 = Ashr %ssa55(GPR0) i32, %ssa56(GPR1) i32
                %ssa58(GPR0) i64 = Zext %ssa57(GPR0) i32, #0x20
                (%ssa59 i64) StoreContext %ssa58(GPR0) i64, #0x8, GPR
                %ssa60(GPR0) i32 = LoadContext #0x8, GPR
                %ssa61(GPR0) i64 = Zext %ssa60(GPR0) i32, #0x20
                (%ssa62 i64) StoreContext %ssa61(GPR0) i64, #0x18, GPR
                %ssa63(GPR0) i32 = LoadContext #0x58, GPR
                %ssa64(GPR1) i32 = LoadContext #0x18, GPR
                %ssa65(GPR0) i32 = Xor %ssa64(GPR1) i32, %ssa63(GPR0) i32
                %ssa66(GPR0) i64 = Zext %ssa65(GPR0) i32, #0x20
                (%ssa67 i64) StoreContext %ssa66(GPR0) i64, #0x18, GPR
                %ssa68(GPR0) i32 = LoadContext #0x8, GPR
                %ssa69(GPR1) i32 = LoadContext #0x18, GPR
                %ssa70(GPR0) i32 = Sub %ssa69(GPR1) i32, %ssa68(GPR0) i32
                %ssa71(GPR0) i64 = Zext %ssa70(GPR0) i32, #0x20
                (%ssa72 i64) StoreContext %ssa71(GPR0) i64, #0x18, GPR
                %ssa73(GPR0) i32 = LoadContext #0x68, GPR
                %ssa74(GPR0) i64 = Zext %ssa73(GPR0) i32, #0x20
                (%ssa75 i64) StoreContext %ssa74(GPR0) i64, #0x8, GPR
                %ssa76(GPR0) i32 = LoadContext #0x50, GPR
                %ssa77(GPR1) i32 = LoadContext #0x8, GPR
                %ssa78(GPR0) i32 = Xor %ssa77(GPR1) i32, %ssa76(GPR0) i32
                %ssa79(GPR0) i64 = Zext %ssa78(GPR0) i32, #0x20
                (%ssa80 i64) StoreContext %ssa79(GPR0) i64, #0x8, GPR
                %ssa81(GPR0) i32 = LoadContext #0x58, GPR
                %ssa82(GPR1) i32 = LoadContext #0x50, GPR
                %ssa83(GPR0) i32 = Add %ssa82(GPR1) i32, %ssa81(GPR0) i32
                %ssa84(GPR0) i64 = Zext %ssa83(GPR0) i32, #0x20
                (%ssa85 i64) StoreContext %ssa84(GPR0) i64, #0x50, GPR
                %ssa86(GPR0) i32 = LoadContext #0x68, GPR
                %ssa87(GPR1) i32 = LoadContext #0x8, GPR
                %ssa88(GPR0) i32 = Sub %ssa87(GPR1) i32, %ssa86(GPR0) i32
                %ssa89(GPR0) i64 = Zext %ssa88(GPR0) i32, #0x20
                (%ssa90 i64) StoreContext %ssa89(GPR0) i64, #0x8, GPR
                %ssa91(GPR0) i32 = LoadContext #0x8, GPR
                %ssa92(GPR1) i32 = LoadContext #0x18, GPR
                %ssa93(GPR2) i32 = Sub %ssa92(GPR1) i32, %ssa91(GPR0) i32
                %ssa94(GPR2) i32 = Bfe %ssa93(GPR2) i32, #0x20, #0x0
                %ssa95(GPR1) i32 = Bfe %ssa92(GPR1) i32, #0x20, #0x0
                %ssa96(GPR0) i32 = Bfe %ssa91(GPR0) i32, #0x20, #0x0
                %ssa97(GPR3) i64 = Constant #0x1f
                %ssa98(GPR3) i64 = Lshr %ssa94(GPR2) i32, %ssa97(GPR3) i64
                %ssa99(GPR4) i64 = Constant #0x0
                %ssa100(GPR5) i64 = Constant #0x1
                %ssa101(GPR6) i32 = Bfe %ssa94(GPR2) i32, #0x20, #0x0
                %ssa102(GPR4) i64 = Select %ssa101(GPR6) i32, %ssa99(GPR4) i64, %ssa100(GPR5) i64, %ssa99(GPR4) i64, EQ
                %ssa103(GPR0) i32 = Xor %ssa95(GPR1) i32, %ssa96(GPR0) i32
                %ssa104(GPR1) i32 = Xor %ssa94(GPR2) i32, %ssa95(GPR1) i32
                %ssa105(GPR0) i32 = And %ssa103(GPR0) i32, %ssa104(GPR1) i32
                %ssa106(GPR0) i32 = Bfe %ssa105(GPR0) i32, #0x1, #0x1f
                %ssa107(GPR1) i64 = Constant #0x0
                %ssa108(GPR2) i64 = Constant #0x1
                %ssa109(GPR5) i32 = LoadContext #0x60, GPR
                %ssa110(GPR6) i32 = LoadContext #0x30, GPR
                %ssa111(GPR7) i64 = Bfe %ssa102(GPR4) i64, #0x1, #0x0
                %ssa112(GPR8) i64 = Bfe %ssa98(GPR3) i64, #0x1, #0x0
                (%ssa113 i64) SpillRegister %ssa98(GPR3) i64, #0x1, GPR
                %ssa114(GPR3) i32 = Bfe %ssa106(GPR0) i32, #0x1, #0x0
                %ssa115(GPR7) i64 = Select %ssa111(GPR7) i64, %ssa107(GPR1) i64, %ssa108(GPR2) i64, %ssa107(GPR1) i64, EQ
                %ssa116(GPR1) i64 = Select %ssa112(GPR8) i64, %ssa114(GPR3) i32, %ssa108(GPR2) i64, %ssa107(GPR1) i64, EQ
                %ssa117(GPR1) i64 = And %ssa115(GPR7) i64, %ssa116(GPR1) i64
                %ssa118(GPR1) i64 = Select %ssa117(GPR1) i64, %ssa108(GPR2) i64, %ssa109(GPR5) i32, %ssa110(GPR6) i32, EQ
                %ssa119(GPR1) i64 = Zext %ssa118(GPR1) i64, #0x20
                (%ssa120 i64) StoreContext %ssa119(GPR1) i64, #0x30, GPR
                %ssa121(GPR1) i32 = LoadContext #0x50, GPR
                %ssa122(GPR1) i64 = Zext %ssa121(GPR1) i32, #0x20
                (%ssa123 i64) StoreContext %ssa122(GPR1) i64, #0x60, GPR
                %ssa124(GPR1) i64 = Constant #0x0
                %ssa125(GPR2) i64 = Constant #0x1
                %ssa126(GPR3) i32 = LoadContext #0x18, GPR
                %ssa127(GPR5) i32 = LoadContext #0x8, GPR
                %ssa128(GPR4) i64 = Select %ssa102(GPR4) i64, %ssa125(GPR2) i64, %ssa125(GPR2) i64, %ssa124(GPR1) i64, EQ
                %ssa129(GPR6) i64 = FillRegister #0x1, GPR
                %ssa130(GPR0) i64 = Select %ssa129(GPR6) i64, %ssa106(GPR0) i32, %ssa125(GPR2) i64, %ssa124(GPR1) i64, NEQ
                %ssa131(GPR0) i64 = Or %ssa128(GPR4) i64, %ssa130(GPR0) i64
                %ssa132(GPR0) i64 = Select %ssa131(GPR0) i64, %ssa125(GPR2) i64, %ssa126(GPR3) i32, %ssa127(GPR5) i32, EQ
                %ssa133(GPR0) i64 = Zext %ssa132(GPR0) i64, #0x20
                (%ssa134 i64) StoreContext %ssa133(GPR0) i64, #0x8, GPR
                %ssa135(GPR0) i32 = LoadContext #0x60, GPR
                %ssa136(GPR1) i32 = Constant #0x1f
                %ssa137(GPR0) i32 = Ashr %ssa135(GPR0) i32, %ssa136(GPR1) i32
                %ssa138(GPR0) i64 = Zext %ssa137(GPR0) i32, #0x20
                (%ssa139 i64) StoreContext %ssa138(GPR0) i64, #0x60, GPR
                %ssa140(GPR0) i32 = LoadContext #0x60, GPR
                %ssa141(GPR1) i32 = LoadContext #0x50, GPR
                %ssa142(GPR0) i32 = Xor %ssa141(GPR1) i32, %ssa140(GPR0) i32
                %ssa143(GPR0) i64 = Zext %ssa142(GPR0) i32, #0x20
                (%ssa144 i64) StoreContext %ssa143(GPR0) i64, #0x50, GPR
                %ssa145(GPR0) i32 = LoadContext #0x60, GPR
                %ssa146(GPR1) i32 = LoadContext #0x50, GPR
                %ssa147(GPR0) i32 = Sub %ssa146(GPR1) i32, %ssa145(GPR0) i32
                %ssa148(GPR0) i64 = Zext %ssa147(GPR0) i32, #0x20
                (%ssa149 i64) StoreContext %ssa148(GPR0) i64, #0x50, GPR
                %ssa150(GPR0) i32 = LoadContext #0x50, GPR
                %ssa151(GPR1) i32 = LoadContext #0x8, GPR
                %ssa152(GPR2) i32 = Sub %ssa151(GPR1) i32, %ssa150(GPR0) i32
                %ssa153(GPR2) i32 = Bfe %ssa152(GPR2) i32, #0x20, #0x0
                %ssa154(GPR1) i32 = Bfe %ssa151(GPR1) i32, #0x20, #0x0
                %ssa155(GPR0) i32 = Bfe %ssa150(GPR0) i32, #0x20, #0x0
                %ssa156(GPR3) i64 = Constant #0x1f
                %ssa157(GPR3) i64 = Lshr %ssa153(GPR2) i32, %ssa156(GPR3) i64
                %ssa158(GPR4) i64 = Constant #0x0
                %ssa159(GPR5) i64 = Constant #0x1
                %ssa160(GPR6) i32 = Bfe %ssa153(GPR2) i32, #0x20, #0x0
                %ssa161(GPR4) i64 = Select %ssa160(GPR6) i32, %ssa158(GPR4) i64, %ssa159(GPR5) i64, %ssa158(GPR4) i64, EQ
                %ssa162(GPR0) i32 = Xor %ssa154(GPR1) i32, %ssa155(GPR0) i32
                %ssa163(GPR1) i32 = Xor %ssa153(GPR2) i32, %ssa154(GPR1) i32
                %ssa164(GPR0) i32 = And %ssa162(GPR0) i32, %ssa163(GPR1) i32
                %ssa165(GPR0) i32 = Bfe %ssa164(GPR0) i32, #0x1, #0x1f
                %ssa166(GPR1) i64 = FillRegister #0x0, GPR
                %ssa167(GPR2) i8 = LoadMemTSO %ssa166(GPR1) i64, #0x1, #0x1, GPR
                %ssa168(GPR2) i16 = Zext %ssa167(GPR2) i8, #0x8
                %ssa169(GPR2) i64 = Zext %ssa168(GPR2) i16, #0x20
                (%ssa170 i64) StoreContext %ssa169(GPR2) i64, #0x8, GPR
                %ssa171(GPR2) i64 = Constant #0x0
                %ssa172(GPR5) i64 = Constant #0x1
                %ssa173(GPR6) i32 = LoadContext #0x48, GPR
                %ssa174(GPR7) i32 = LoadContext #0x30, GPR
                %ssa175(GPR4) i64 = Bfe %ssa161(GPR4) i64, #0x1, #0x0
                %ssa176(GPR3) i64 = Bfe %ssa157(GPR3) i64, #0x1, #0x0
                %ssa177(GPR0) i32 = Bfe %ssa165(GPR0) i32, #0x1, #0x0
                %ssa178(GPR4) i64 = Select %ssa175(GPR4) i64, %ssa171(GPR2) i64, %ssa172(GPR5) i64, %ssa171(GPR2) i64, EQ
                %ssa179(GPR0) i64 = Select %ssa176(GPR3) i64, %ssa177(GPR0) i32, %ssa172(GPR5) i64, %ssa171(GPR2) i64, EQ
                %ssa180(GPR0) i64 = And %ssa178(GPR4) i64, %ssa179(GPR0) i64
                %ssa181(GPR0) i64 = Select %ssa180(GPR0) i64, %ssa172(GPR5) i64, %ssa173(GPR6) i32, %ssa174(GPR7) i32, EQ
                %ssa182(GPR0) i64 = Zext %ssa181(GPR0) i64, #0x20
                (%ssa183 i64) StoreContext %ssa182(GPR0) i64, #0x30, GPR
                %ssa184(GPR0) i64 = Constant #0x1
                %ssa185(GPR0) i64 = Add %ssa166(GPR1) i64, %ssa184(GPR0) i64
                (%ssa186 i64) StoreContext %ssa185(GPR0) i64, #0x28, GPR
                %ssa187(GPR1) i32 = LoadContext #0x8, GPR
                %ssa188(GPR2) i32 = LoadContext #0x30, GPR
                %ssa189(GPR1) i32 = Add %ssa188(GPR2) i32, %ssa187(GPR1) i32
                %ssa190(GPR1) i64 = Zext %ssa189(GPR1) i32, #0x20
                (%ssa191 i64) StoreContext %ssa190(GPR1) i64, #0x30, GPR
                %ssa192(GPR1) i64 = LoadContext #0x38, GPR
                %ssa193(GPR2) i64 = Sub %ssa185(GPR0) i64, %ssa192(GPR1) i64
                %ssa194(GPR2) i64 = Bfe %ssa193(GPR2) i64, #0x40, #0x0
                %ssa195(GPR3) i64 = Bfe %ssa185(GPR0) i64, #0x40, #0x0
                %ssa196(GPR1) i64 = Bfe %ssa192(GPR1) i64, #0x40, #0x0
                %ssa197(GPR4) i64 = Xor %ssa195(GPR3) i64, %ssa196(GPR1) i64
                %ssa198(GPR4) i64 = Xor %ssa197(GPR4) i64, %ssa194(GPR2) i64
                %ssa199(GPR4) i64 = Bfe %ssa198(GPR4) i64, #0x1, #0x4
                (%ssa200 i0) StoreFlag %ssa199(GPR4) i64, #0x4
                %ssa201(GPR4) i64 = Constant #0x3f
                %ssa202(GPR4) i64 = Lshr %ssa194(GPR2) i64, %ssa201(GPR4) i64
                (%ssa203 i0) StoreFlag %ssa202(GPR4) i64, #0x7
                %ssa204(GPR4) i64 = Constant #0xff
                %ssa205(GPR4) i64 = And %ssa194(GPR2) i64, %ssa204(GPR4) i64
                %ssa206(GPR4) i64 = Popcount %ssa205(GPR4) i64
                %ssa207(GPR5) i64 = Constant #0x1
                %ssa208(GPR4) i64 = Xor %ssa206(GPR4) i64, %ssa207(GPR5) i64
                (%ssa209 i0) StoreFlag %ssa208(GPR4) i64, #0x2
                %ssa210(GPR4) i64 = Constant #0x0
                %ssa211(GPR5) i64 = Constant #0x1
                %ssa212(GPR6) i64 = Bfe %ssa194(GPR2) i64, #0x40, #0x0
                %ssa213(GPR4) i64 = Select %ssa212(GPR6) i64, %ssa210(GPR4) i64, %ssa211(GPR5) i64, %ssa210(GPR4) i64, EQ
                (%ssa214 i0) StoreFlag %ssa213(GPR4) i64, #0x6
                %ssa215(GPR5) i64 = Constant #0x0
                %ssa216(GPR6) i64 = Constant #0x1
                %ssa217(GPR5) i64 = Select %ssa195(GPR3) i64, %ssa196(GPR1) i64, %ssa216(GPR6) i64, %ssa215(GPR5) i64, ULT
                (%ssa218 i0) StoreFlag %ssa217(GPR5) i64, #0x0
                %ssa219(GPR1) i64 = Xor %ssa195(GPR3) i64, %ssa196(GPR1) i64
                %ssa220(GPR2) i64 = Xor %ssa194(GPR2) i64, %ssa195(GPR3) i64
                %ssa221(GPR1) i64 = And %ssa219(GPR1) i64, %ssa220(GPR2) i64
                %ssa222(GPR1) i64 = Bfe %ssa221(GPR1) i64, #0x1, #0x3f
                (%ssa223 i0) StoreFlag %ssa222(GPR1) i64, #0xb
                %ssa224(GPR1) i8 = LoadContext #0x30, GPR
                %ssa225(GPR2) i64 = Constant #0xffffffffffffffff
                %ssa226(GPR0) i64 = Add %ssa185(GPR0) i64, %ssa225(GPR2) i64
                (%ssa227 i0) StoreMemTSO %ssa226(GPR0) i64, %ssa224(GPR1) i8, #0x1, #0x1, GPR
                %ssa228(GPR0) i64 = Constant #0x0
                %ssa229(GPR1) i64 = Constant #0x1
                %ssa230(GPR2) i64 = Constant #0x0
                %ssa231(GPR3) i64 = Bfe %ssa213(GPR4) i64, #0x1, #0x0
                %ssa232(GPR0) i64 = Select %ssa231(GPR3) i64, %ssa228(GPR0) i64, %ssa229(GPR1) i64, %ssa230(GPR2) i64, EQ
                (%ssa233 i0) CondJump %ssa232(GPR0) i64, %ssa24294967295), %ssa34294967295)
                (%ssa234 i0) EndBlock #0x0
        (%ssa3) CodeBlock %ssa235, %ssa239, %ssa0
                (%ssa235 i0) Dummy
                %ssa236(GPR0) i64 = Constant #0x6f01fd
                (%ssa237 i64) StoreContext %ssa236(GPR0) i64, #0x0, GPR
                (%ssa238 i0) ExitFunction
                (%ssa239 i0) EndBlock #0x0
```

</details>

<details>

<summary>After Optimisation</summary>

```
IR 0x6f0190:
        (%ssa1) IRHeader #0x6f0190, %ssa2, #0
        (%ssa2) CodeBlock %ssa4, %ssa181, %ssa3
                (%ssa4 i0) Dummy
                %ssa5(GPR0) i64 = LoadContext #0x10, GPR
                %ssa6(GPR1) i64 = LoadContext #0x20, GPR
                %ssa7(GPR2) i64 = Add %ssa5(GPR0) i64, %ssa6(GPR1) i64
                %ssa8(GPR2) i8 = LoadMemTSO %ssa7(GPR2) i64, #0x1, #0x1, GPR
                (%ssa9 i64) StoreContext %ssa8(GPR2) i8, #0x48, GPR
                %ssa10(GPR3) i64 = Constant #0x1
                %ssa11(GPR1) i64 = Add %ssa6(GPR1) i64, %ssa10(GPR3) i64
                (%ssa12 i64) StoreContext %ssa11(GPR1) i64, #0x20, GPR
                %ssa13(GPR3) i64 = LoadContext #0x28, GPR
                %ssa14(GPR0) i64 = Add %ssa5(GPR0) i64, %ssa13(GPR3) i64
                (%ssa15 i64) SpillRegister %ssa13(GPR3) i64, #0x0, GPR
                %ssa16(GPR0) i8 = LoadMemTSO %ssa14(GPR0) i64, #0x1, #0x1, GPR
                (%ssa17 i64) StoreContext %ssa16(GPR0) i8, #0x30, GPR
                %ssa18(GPR3) i64 = Constant #0xffffffffffffffff
                %ssa19(GPR1) i64 = Add %ssa11(GPR1) i64, %ssa18(GPR3) i64
                %ssa20(GPR1) i8 = LoadMemTSO %ssa19(GPR1) i64, #0x1, #0x1, GPR
                (%ssa21 i64) StoreContext %ssa20(GPR1) i8, #0x60, GPR
                (%ssa22 i64) StoreContext %ssa16(GPR0) i8, #0x50, GPR
                (%ssa23 i64) StoreContext %ssa20(GPR1) i8, #0x58, GPR
                %ssa24(GPR0) i32 = Sub %ssa16(GPR0) i8, %ssa8(GPR2) i8
                (%ssa25 i64) StoreContext %ssa24(GPR0) i32, #0x50, GPR
                %ssa26(GPR2) i32 = LoadContext #0x48, GPR
                %ssa27(GPR1) i32 = Sub %ssa20(GPR1) i8, %ssa26(GPR2) i32
                (%ssa28 i64) StoreContext %ssa27(GPR1) i32, #0x58, GPR
                (%ssa29 i64) StoreContext %ssa24(GPR0) i32, #0x68, GPR
                (%ssa30 i64) StoreContext %ssa27(GPR1) i32, #0x8, GPR
                %ssa31(GPR2) i32 = Constant #0x1f
                %ssa32(GPR0) i32 = Ashr %ssa24(GPR0) i32, %ssa31(GPR2) i32
                (%ssa33 i64) StoreContext %ssa32(GPR0) i32, #0x68, GPR
                %ssa34(GPR2) i32 = Constant #0x1f
                %ssa35(GPR1) i32 = Ashr %ssa27(GPR1) i32, %ssa34(GPR2) i32
                (%ssa36 i64) StoreContext %ssa35(GPR1) i32, #0x8, GPR
                (%ssa37 i64) StoreContext %ssa35(GPR1) i32, #0x18, GPR
                %ssa38(GPR2) i32 = LoadContext #0x58, GPR
                %ssa39(GPR1) i32 = Xor %ssa35(GPR1) i32, %ssa38(GPR2) i32
                (%ssa40 i64) StoreContext %ssa39(GPR1) i32, #0x18, GPR
                %ssa41(GPR2) i32 = LoadContext #0x8, GPR
                %ssa42(GPR1) i32 = Sub %ssa39(GPR1) i32, %ssa41(GPR2) i32
                (%ssa43 i64) StoreContext %ssa42(GPR1) i32, #0x18, GPR
                (%ssa44 i64) StoreContext %ssa32(GPR0) i32, #0x8, GPR
                %ssa45(GPR2) i32 = LoadContext #0x50, GPR
                %ssa46(GPR0) i32 = Xor %ssa32(GPR0) i32, %ssa45(GPR2) i32
                (%ssa47 i64) StoreContext %ssa46(GPR0) i32, #0x8, GPR
                %ssa48(GPR2) i32 = LoadContext #0x58, GPR
                %ssa49(GPR3) i32 = LoadContext #0x50, GPR
                %ssa50(GPR2) i32 = Add %ssa49(GPR3) i32, %ssa48(GPR2) i32
                (%ssa51 i64) StoreContext %ssa50(GPR2) i32, #0x50, GPR
                %ssa52(GPR3) i32 = LoadContext #0x68, GPR
                %ssa53(GPR0) i32 = Sub %ssa46(GPR0) i32, %ssa52(GPR3) i32
                (%ssa54 i64) StoreContext %ssa53(GPR0) i32, #0x8, GPR
                %ssa55(GPR3) i32 = Sub %ssa42(GPR1) i32, %ssa53(GPR0) i32
                %ssa56(GPR1) i32 = Bfe %ssa42(GPR1) i32, #0x20, #0x0
                %ssa57(GPR0) i32 = Bfe %ssa53(GPR0) i32, #0x20, #0x0
                %ssa58(GPR4) i64 = Constant #0x1f
                %ssa59(GPR4) i64 = Lshr %ssa55(GPR3) i32, %ssa58(GPR4) i64
                %ssa60(GPR5) i64 = Constant #0x0
                %ssa61(GPR6) i64 = Constant #0x1
                %ssa62(GPR7) i32 = Bfe %ssa55(GPR3) i32, #0x20, #0x0
                %ssa63(GPR5) i64 = Select %ssa62(GPR7) i32, %ssa60(GPR5) i64, %ssa61(GPR6) i64, %ssa60(GPR5) i64, EQ
                %ssa64(GPR0) i32 = Xor %ssa56(GPR1) i32, %ssa57(GPR0) i32
                %ssa65(GPR1) i32 = Xor %ssa55(GPR3) i32, %ssa56(GPR1) i32
                %ssa66(GPR0) i32 = And %ssa64(GPR0) i32, %ssa65(GPR1) i32
                %ssa67(GPR0) i32 = Bfe %ssa66(GPR0) i32, #0x1, #0x1f
                %ssa68(GPR1) i64 = Constant #0x0
                %ssa69(GPR3) i64 = Constant #0x1
                %ssa70(GPR6) i32 = LoadContext #0x60, GPR
                %ssa71(GPR7) i32 = LoadContext #0x30, GPR
                %ssa72(GPR8) i64 = Bfe %ssa63(GPR5) i64, #0x1, #0x0
                (%ssa73 i64) SpillRegister %ssa63(GPR5) i64, #0x1, GPR
                %ssa74(GPR5) i64 = Bfe %ssa59(GPR4) i64, #0x1, #0x0
                (%ssa75 i64) SpillRegister %ssa59(GPR4) i64, #0x2, GPR
                %ssa76(GPR4) i32 = Bfe %ssa67(GPR0) i32, #0x1, #0x0
                %ssa77(GPR8) i64 = Select %ssa72(GPR8) i64, %ssa68(GPR1) i64, %ssa69(GPR3) i64, %ssa68(GPR1) i64, EQ
                %ssa78(GPR1) i64 = Select %ssa74(GPR5) i64, %ssa76(GPR4) i32, %ssa69(GPR3) i64, %ssa68(GPR1) i64, EQ
                %ssa79(GPR1) i64 = And %ssa77(GPR8) i64, %ssa78(GPR1) i64
                %ssa80(GPR1) i64 = Select %ssa79(GPR1) i64, %ssa69(GPR3) i64, %ssa70(GPR6) i32, %ssa71(GPR7) i32, EQ
                %ssa81(GPR1) i32 = Bfe %ssa80(GPR1) i64, #0x20, #0x0
                (%ssa82 i64) StoreContext %ssa81(GPR1) i32, #0x30, GPR
                (%ssa83 i64) StoreContext %ssa50(GPR2) i32, #0x60, GPR
                %ssa84(GPR3) i64 = Constant #0x0
                %ssa85(GPR4) i64 = Constant #0x1
                %ssa86(GPR5) i32 = LoadContext #0x18, GPR
                %ssa87(GPR6) i32 = LoadContext #0x8, GPR
                %ssa88(GPR7) i64 = FillRegister #0x1, GPR
                %ssa89(GPR7) i64 = Select %ssa88(GPR7) i64, %ssa85(GPR4) i64, %ssa85(GPR4) i64, %ssa84(GPR3) i64, EQ
                %ssa90(GPR8) i64 = FillRegister #0x2, GPR
                %ssa91(GPR0) i64 = Select %ssa90(GPR8) i64, %ssa67(GPR0) i32, %ssa85(GPR4) i64, %ssa84(GPR3) i64, NEQ
                %ssa92(GPR0) i64 = Or %ssa89(GPR7) i64, %ssa91(GPR0) i64
                %ssa93(GPR0) i64 = Select %ssa92(GPR0) i64, %ssa85(GPR4) i64, %ssa86(GPR5) i32, %ssa87(GPR6) i32, EQ
                %ssa94(GPR0) i32 = Bfe %ssa93(GPR0) i64, #0x20, #0x0
                (%ssa95 i64) StoreContext %ssa94(GPR0) i32, #0x8, GPR
                %ssa96(GPR3) i32 = Constant #0x1f
                %ssa97(GPR2) i32 = Ashr %ssa50(GPR2) i32, %ssa96(GPR3) i32
                (%ssa98 i64) StoreContext %ssa97(GPR2) i32, #0x60, GPR
                %ssa99(GPR3) i32 = LoadContext #0x50, GPR
                %ssa100(GPR2) i32 = Xor %ssa99(GPR3) i32, %ssa97(GPR2) i32
                (%ssa101 i64) StoreContext %ssa100(GPR2) i32, #0x50, GPR
                %ssa102(GPR3) i32 = LoadContext #0x60, GPR
                %ssa103(GPR2) i32 = Sub %ssa100(GPR2) i32, %ssa102(GPR3) i32
                (%ssa104 i64) StoreContext %ssa103(GPR2) i32, #0x50, GPR
                %ssa105(GPR3) i32 = Sub %ssa94(GPR0) i32, %ssa103(GPR2) i32
                %ssa106(GPR0) i32 = Bfe %ssa94(GPR0) i32, #0x20, #0x0
                %ssa107(GPR2) i32 = Bfe %ssa103(GPR2) i32, #0x20, #0x0
                %ssa108(GPR4) i64 = Constant #0x1f
                %ssa109(GPR4) i64 = Lshr %ssa105(GPR3) i32, %ssa108(GPR4) i64
                %ssa110(GPR5) i64 = Constant #0x0
                %ssa111(GPR6) i64 = Constant #0x1
                %ssa112(GPR7) i32 = Bfe %ssa105(GPR3) i32, #0x20, #0x0
                %ssa113(GPR5) i64 = Select %ssa112(GPR7) i32, %ssa110(GPR5) i64, %ssa111(GPR6) i64, %ssa110(GPR5) i64, EQ
                %ssa114(GPR2) i32 = Xor %ssa106(GPR0) i32, %ssa107(GPR2) i32
                %ssa115(GPR0) i32 = Xor %ssa105(GPR3) i32, %ssa106(GPR0) i32
                %ssa116(GPR0) i32 = And %ssa114(GPR2) i32, %ssa115(GPR0) i32
                %ssa117(GPR0) i32 = Bfe %ssa116(GPR0) i32, #0x1, #0x1f
                %ssa118(GPR2) i64 = FillRegister #0x0, GPR
                %ssa119(GPR3) i8 = LoadMemTSO %ssa118(GPR2) i64, #0x1, #0x1, GPR
                (%ssa120 i64) StoreContext %ssa119(GPR3) i8, #0x8, GPR
                (%ssa121 i8) SpillRegister %ssa119(GPR3) i8, #0x3, GPR
                %ssa122(GPR3) i64 = Constant #0x0
                %ssa123(GPR6) i64 = Constant #0x1
                %ssa124(GPR7) i32 = LoadContext #0x48, GPR
                %ssa125(GPR5) i64 = Bfe %ssa113(GPR5) i64, #0x1, #0x0
                %ssa126(GPR4) i64 = Bfe %ssa109(GPR4) i64, #0x1, #0x0
                %ssa127(GPR0) i32 = Bfe %ssa117(GPR0) i32, #0x1, #0x0
                %ssa128(GPR5) i64 = Select %ssa125(GPR5) i64, %ssa122(GPR3) i64, %ssa123(GPR6) i64, %ssa122(GPR3) i64, EQ
                %ssa129(GPR0) i64 = Select %ssa126(GPR4) i64, %ssa127(GPR0) i32, %ssa123(GPR6) i64, %ssa122(GPR3) i64, EQ
                %ssa130(GPR0) i64 = And %ssa128(GPR5) i64, %ssa129(GPR0) i64
                %ssa131(GPR0) i64 = Select %ssa130(GPR0) i64, %ssa123(GPR6) i64, %ssa124(GPR7) i32, %ssa81(GPR1) i32, EQ
                %ssa132(GPR0) i32 = Bfe %ssa131(GPR0) i64, #0x20, #0x0
                (%ssa133 i64) StoreContext %ssa132(GPR0) i32, #0x30, GPR
                %ssa134(GPR1) i64 = Constant #0x1
                %ssa135(GPR1) i64 = Add %ssa118(GPR2) i64, %ssa134(GPR1) i64
                (%ssa136 i64) StoreContext %ssa135(GPR1) i64, #0x28, GPR
                %ssa137(GPR2) i8 = FillRegister #0x3, GPR
                %ssa138(GPR0) i32 = Add %ssa132(GPR0) i32, %ssa137(GPR2) i8
                (%ssa139 i64) StoreContext %ssa138(GPR0) i32, #0x30, GPR
                %ssa140(GPR2) i64 = LoadContext #0x38, GPR
                %ssa141(GPR3) i64 = Sub %ssa135(GPR1) i64, %ssa140(GPR2) i64
                %ssa142(GPR4) i64 = Bfe %ssa135(GPR1) i64, #0x40, #0x0
                %ssa143(GPR2) i64 = Bfe %ssa140(GPR2) i64, #0x40, #0x0
                %ssa144(GPR5) i64 = Xor %ssa142(GPR4) i64, %ssa143(GPR2) i64
                %ssa145(GPR5) i64 = Xor %ssa144(GPR5) i64, %ssa141(GPR3) i64
                %ssa146(GPR5) i64 = Bfe %ssa145(GPR5) i64, #0x1, #0x4
                (%ssa147 i0) StoreFlag %ssa146(GPR5) i64, #0x4
                %ssa148(GPR5) i64 = Constant #0x3f
                %ssa149(GPR5) i64 = Lshr %ssa141(GPR3) i64, %ssa148(GPR5) i64
                (%ssa150 i0) StoreFlag %ssa149(GPR5) i64, #0x7
                %ssa151(GPR5) i64 = Constant #0xff
                %ssa152(GPR5) i64 = And %ssa141(GPR3) i64, %ssa151(GPR5) i64
                %ssa153(GPR5) i64 = Popcount %ssa152(GPR5) i64
                %ssa154(GPR6) i64 = Constant #0x1
                %ssa155(GPR5) i64 = Xor %ssa153(GPR5) i64, %ssa154(GPR6) i64
                (%ssa156 i0) StoreFlag %ssa155(GPR5) i64, #0x2
                %ssa157(GPR5) i64 = Constant #0x0
                %ssa158(GPR6) i64 = Constant #0x1
                %ssa159(GPR7) i64 = Bfe %ssa141(GPR3) i64, #0x40, #0x0
                %ssa160(GPR5) i64 = Select %ssa159(GPR7) i64, %ssa157(GPR5) i64, %ssa158(GPR6) i64, %ssa157(GPR5) i64, EQ
                (%ssa161 i0) StoreFlag %ssa160(GPR5) i64, #0x6
                %ssa162(GPR6) i64 = Constant #0x0
                %ssa163(GPR7) i64 = Constant #0x1
                %ssa164(GPR6) i64 = Select %ssa142(GPR4) i64, %ssa143(GPR2) i64, %ssa163(GPR7) i64, %ssa162(GPR6) i64, ULT
                (%ssa165 i0) StoreFlag %ssa164(GPR6) i64, #0x0
                %ssa166(GPR2) i64 = Xor %ssa142(GPR4) i64, %ssa143(GPR2) i64
                %ssa167(GPR3) i64 = Xor %ssa141(GPR3) i64, %ssa142(GPR4) i64
                %ssa168(GPR2) i64 = And %ssa166(GPR2) i64, %ssa167(GPR3) i64
                %ssa169(GPR2) i64 = Bfe %ssa168(GPR2) i64, #0x1, #0x3f
                (%ssa170 i0) StoreFlag %ssa169(GPR2) i64, #0xb
                %ssa171(GPR0) i8 = Bfe %ssa138(GPR0) i32, #0x8, #0x0
                %ssa172(GPR2) i64 = Constant #0xffffffffffffffff
                %ssa173(GPR1) i64 = Add %ssa135(GPR1) i64, %ssa172(GPR2) i64
                (%ssa174 i0) StoreMemTSO %ssa173(GPR1) i64, %ssa171(GPR0) i8, #0x1, #0x1, GPR
                %ssa175(GPR0) i64 = Constant #0x0
                %ssa176(GPR1) i64 = Constant #0x1
                %ssa177(GPR2) i64 = Constant #0x0
                %ssa178(GPR3) i64 = Bfe %ssa160(GPR5) i64, #0x1, #0x0
                %ssa179(GPR0) i64 = Select %ssa178(GPR3) i64, %ssa175(GPR0) i64, %ssa176(GPR1) i64, %ssa177(GPR2) i64, EQ
                (%ssa180 i0) CondJump %ssa179(GPR0) i64, %ssa24294967295), %ssa34294967295)
                (%ssa181 i0) EndBlock #0x0
        (%ssa3) CodeBlock %ssa182, %ssa186, %ssa0
                (%ssa182 i0) Dummy
                %ssa183(GPR0) i64 = Constant #0x6f01fd
                (%ssa184 i64) StoreContext %ssa183(GPR0) i64, #0x0, GPR
                (%ssa185 i0) ExitFunction
                (%ssa186 i0) EndBlock #0x0
```

</details>
