### PR TITLE
Moves our entire execution model over to signal execution

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,7 +17,7 @@
 [submodule "External/xbyak"]
       shallow = true
 	path = External/xbyak
-	url = https://github.com/herumi/xbyak.git
+	url = https://github.com/FEX-Emu/xbyak.git
 [submodule "External/fex-posixtest-bins"]
 	path = External/fex-posixtest-bins
 	url = https://github.com/FEX-Emu/fex-posixtest-bins.git

--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -182,6 +182,13 @@ set (SRCS
   Interface/IR/Passes/SyscallOptimization.cpp
   )
 
+if (_M_X86_64)
+  list(APPEND SRCS Interface/Core/Interpreter/x86_64Dispatcher.cpp)
+endif()
+if(_M_ARM_64)
+  list(APPEND SRCS Interface/Core/Interpreter/Arm64Dispatcher.cpp)
+endif()
+
 set (JIT_LIBS )
 if (ENABLE_JIT)
   if (_M_X86_64)

--- a/External/FEXCore/Source/Interface/Context/Context.cpp
+++ b/External/FEXCore/Source/Interface/Context/Context.cpp
@@ -88,8 +88,7 @@ namespace FEXCore::Context {
   }
 
   void Stop(FEXCore::Context::Context *CTX) {
-    CTX->ShouldStop = true;
-    CTX->Pause(); // Block until exit
+    CTX->Stop(false);
   }
 
   void SetCustomCPUBackendFactory(FEXCore::Context::Context *CTX, CustomCPUFactoryType Factory) {

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -36,8 +36,8 @@ namespace Validation {
 
 namespace FEXCore::Context {
   enum CoreRunningMode {
-    MODE_RUN,
-    MODE_SINGLESTEP,
+    MODE_RUN        = 0,
+    MODE_SINGLESTEP = 1,
   };
 
   struct Context {
@@ -67,7 +67,7 @@ namespace FEXCore::Context {
     uint64_t ThreadID{};
     FEXCore::Core::InternalThreadState* ParentThread;
     std::vector<FEXCore::Core::InternalThreadState*> Threads;
-    std::atomic_bool ShouldStop{};
+    std::atomic_bool CoreShuttingDown{false};
 
     std::mutex IdleWaitMutex;
     std::condition_variable IdleWaitCV;
@@ -102,6 +102,10 @@ namespace FEXCore::Context {
     void Run();
     void WaitForThreadsToRun();
     void Step();
+    void Stop(bool IgnoreCurrentThread);
+    void WaitForIdle();
+    void StopThread(FEXCore::Core::InternalThreadState *Thread);
+    void SignalThread(FEXCore::Core::InternalThreadState *Thread, FEXCore::Core::SignalEvent Event);
 
     bool GetGdbServerStatus() { return (bool)DebugServer; }
     void StartGdbServer();
@@ -139,13 +143,13 @@ namespace FEXCore::Context {
     void ClearCodeCache(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP);
 
   private:
-    void WaitForIdle();
+    void WaitForIdleWithTimeout();
+
     void *MapRegion(FEXCore::Core::InternalThreadState *Thread, uint64_t Offset, uint64_t Size, bool Fixed = false, bool RelativeToBase = true);
     void *ShmBase();
     void MirrorRegion(FEXCore::Core::InternalThreadState *Thread, void *HostPtr, uint64_t Offset, uint64_t Size);
     void ExecutionThread(FEXCore::Core::InternalThreadState *Thread);
     void NotifyPause();
-    void HandleExit(FEXCore::Core::InternalThreadState *Thread);
 
     uintptr_t AddBlockMapping(FEXCore::Core::InternalThreadState *Thread, uint64_t Address, void *Ptr);
 

--- a/External/FEXCore/Source/Interface/Core/Interpreter/Arm64Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/Arm64Dispatcher.cpp
@@ -1,0 +1,529 @@
+#include "Common/MathUtils.h"
+#include "Interface/Core/Interpreter/InterpreterClass.h"
+#include <FEXCore/Core/X86Enums.h>
+
+#include <cmath>
+
+#include "aarch64/assembler-aarch64.h"
+#include "aarch64/cpu-aarch64.h"
+#include "aarch64/disasm-aarch64.h"
+#include "aarch64/assembler-aarch64.h"
+
+namespace FEXCore::CPU {
+static void SleepThread(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread) {
+  --ctx->IdleWaitRefCount;
+  ctx->IdleWaitCV.notify_all();
+
+  // Go to sleep
+  Thread->StartRunning.Wait();
+
+  Thread->State.RunningEvents.Running = true;
+  ++ctx->IdleWaitRefCount;
+  ctx->IdleWaitCV.notify_all();
+}
+
+using namespace vixl;
+using namespace vixl::aarch64;
+
+#define STATE x28
+static constexpr size_t MAX_DISPATCHER_CODE_SIZE = 4096;
+
+class DispatchGenerator : public vixl::aarch64::Assembler {
+  public:
+    DispatchGenerator(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread);
+    bool HandleGuestSignal(int Signal, void *info, void *ucontext, SignalDelegator::GuestSigAction *GuestAction, stack_t *GuestStack);
+    bool HandleSignalPause(int Signal, void *info, void *ucontext);
+
+  CPUBackend::AsmDispatch DispatchPtr;
+  uint64_t ThreadStopHandlerAddress;
+  uint64_t AbsoluteLoopTopAddress;
+  uint64_t ThreadPauseHandlerAddress;
+  FEXCore::Context::Context *CTX;
+  FEXCore::Core::InternalThreadState *State;
+  private:
+    void StoreThreadState(int Signal, void *ucontext);
+    void RestoreThreadState(void *ucontext);
+    void PushCalleeSavedRegisters();
+    void PopCalleeSavedRegisters();
+    void LoadConstant(vixl::aarch64::Register Reg, uint64_t Constant);
+    std::stack<uint64_t> SignalFrames;
+};
+
+void DispatchGenerator::PushCalleeSavedRegisters() {
+  // We need to save pairs of registers
+  // We save r19-r30
+  MemOperand PairOffset(sp, -16, PreIndex);
+  const std::array<std::pair<vixl::aarch64::XRegister, vixl::aarch64::XRegister>, 6> CalleeSaved = {{
+    {x19, x20},
+    {x21, x22},
+    {x23, x24},
+    {x25, x26},
+    {x27, x28},
+    {x29, x30},
+  }};
+
+  for (auto &RegPair : CalleeSaved) {
+    stp(RegPair.first, RegPair.second, PairOffset);
+  }
+
+  // Additionally we need to store the lower 64bits of v8-v15
+  // Here's a fun thing, we can use two ST4 instructions to store everything
+  // We just need a single sub to sp before that
+  const std::array<
+    std::tuple<vixl::aarch64::VRegister,
+               vixl::aarch64::VRegister,
+               vixl::aarch64::VRegister,
+               vixl::aarch64::VRegister>, 2> FPRs = {{
+    {v8, v9, v10, v11},
+    {v12, v13, v14, v15},
+  }};
+
+  uint32_t VectorSaveSize = sizeof(uint64_t) * 8;
+  sub(sp, sp, VectorSaveSize);
+  // SP supporting move
+  // We just saved x19 so it is safe
+  add(x19, sp, 0);
+
+  MemOperand QuadOffset(x19, 32, PostIndex);
+  for (auto &RegQuad : FPRs) {
+    st4(std::get<0>(RegQuad).D(),
+        std::get<1>(RegQuad).D(),
+        std::get<2>(RegQuad).D(),
+        std::get<3>(RegQuad).D(),
+        0,
+        QuadOffset);
+  }
+}
+
+void DispatchGenerator::PopCalleeSavedRegisters() {
+  const std::array<
+    std::tuple<vixl::aarch64::VRegister,
+               vixl::aarch64::VRegister,
+               vixl::aarch64::VRegister,
+               vixl::aarch64::VRegister>, 2> FPRs = {{
+    {v12, v13, v14, v15},
+    {v8, v9, v10, v11},
+  }};
+
+  MemOperand QuadOffset(sp, 32, PostIndex);
+  for (auto &RegQuad : FPRs) {
+    ld4(std::get<0>(RegQuad).D(),
+        std::get<1>(RegQuad).D(),
+        std::get<2>(RegQuad).D(),
+        std::get<3>(RegQuad).D(),
+        0,
+        QuadOffset);
+  }
+
+  MemOperand PairOffset(sp, 16, PostIndex);
+  const std::array<std::pair<vixl::aarch64::XRegister, vixl::aarch64::XRegister>, 6> CalleeSaved = {{
+    {x29, x30},
+    {x27, x28},
+    {x25, x26},
+    {x23, x24},
+    {x21, x22},
+    {x19, x20},
+  }};
+
+  for (auto &RegPair : CalleeSaved) {
+    ldp(RegPair.first, RegPair.second, PairOffset);
+  }
+}
+
+void DispatchGenerator::LoadConstant(vixl::aarch64::Register Reg, uint64_t Constant) {
+  bool Is64Bit = Reg.IsX();
+  int Segments = Is64Bit ? 4 : 2;
+
+  movz(Reg, (Constant) & 0xFFFF, 0);
+  for (int i = 1; i < Segments; ++i) {
+    uint16_t Part = (Constant >> (i * 16)) & 0xFFFF;
+    if (Part) {
+      movk(Reg, Part, i * 16);
+    }
+  }
+}
+
+DispatchGenerator::DispatchGenerator(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread)
+  : vixl::aarch64::Assembler(MAX_DISPATCHER_CODE_SIZE, vixl::aarch64::PositionDependentCode)
+  , CTX {ctx}
+  , State {Thread} {
+
+  SetAllowAssembler(true);
+  auto Buffer = GetBuffer();
+
+  DispatchPtr = Buffer->GetOffsetAddress<CPUBackend::AsmDispatch>(GetCursorOffset());
+
+  // while (!Thread->State.RunningEvents.ShouldStop.load()) {
+  //    Ptr = FindBlock(RIP)
+  //    if (!Ptr)
+  //      Ptr = CTX->CompileBlock(RIP);
+  //
+  //    if (Ptr)
+  //      Ptr();
+  //    else
+  //    {
+  //      Ptr = FallbackCore->CompileBlock()
+  //      if (Ptr)
+  //        Ptr()
+  //      else {
+  //        ShouldStop = true;
+  //      }
+  //    }
+  // }
+
+  // Push all the register we need to save
+  PushCalleeSavedRegisters();
+
+  // Push our memory base to the correct register
+  // Move our thread pointer to the correct register
+  // This is passed in to parameter 0 (x0)
+  mov(STATE, x0);
+
+  // Save this stack pointer so we can cleanly shutdown the emulation with a long jump
+  // regardless of where we were in the stack
+  add(x0, sp, 0);
+  str(x0, MemOperand(STATE, offsetof(FEXCore::Core::ThreadState, ReturningStackLocation)));
+
+  Label Exit;
+  Label LoopTop;
+  Label NoBlock;
+  Label ThreadPauseHandler;
+  bind(&LoopTop);
+  AbsoluteLoopTopAddress = GetLabelAddress<uint64_t>(&LoopTop);
+
+  // Load in our RIP
+  // Don't modify x2 since it contains our RIP once the block doesn't exist
+  ldr(x2, MemOperand(STATE, offsetof(FEXCore::Core::ThreadState, State.rip)));
+  auto RipReg = x2;
+
+  // Mask the address by the virtual address size so we can check for aliases
+  LoadConstant(x3, Thread->BlockCache->GetVirtualMemorySize() - 1);
+  and_(x3, RipReg, x3);
+
+  {
+    // This is the block cache lookup routine
+    // It matches what is going on it BlockCache.h::FindBlock
+    LoadConstant(x0, Thread->BlockCache->GetPagePointer());
+
+    // Offset the address and add to our page pointer
+    lsr(x1, x3, 12);
+
+    // Load the pointer from the offset
+    ldr(x0, MemOperand(x0, x1, Shift::LSL, 3));
+
+    // If page pointer is zero then we have no block
+    cbz(x0, &NoBlock);
+
+    // Steal the page offset
+    and_(x1, x3, 0x0FFF);
+
+    // Shift the offset by the size of the block cache entry
+    add(x0, x0, Operand(x1, Shift::LSL, (int)log2(sizeof(FEXCore::BlockCache::BlockCacheEntry))));
+
+    // Load the guest address first to ensure it maps to the address we are currently at
+    // This fixes aliasing problems
+    ldr(x1, MemOperand(x0, offsetof(FEXCore::BlockCache::BlockCacheEntry, GuestCode)));
+    cmp(x1, RipReg);
+    b(&NoBlock, Condition::ne);
+
+    // Now load the actual host block to execute if we can
+    ldr(x1, MemOperand(x0, offsetof(FEXCore::BlockCache::BlockCacheEntry, HostCode)));
+    cbz(x1, &NoBlock);
+
+    // If we've made it here then we have a real compiled block
+    {
+      mov(x0, STATE);
+      blr(x1);
+    }
+
+    if (CTX->GetGdbServerStatus()) {
+      // If we have a gdb server running then run in a less efficient mode that checks if we need to exit
+      // This happens when single stepping
+
+      static_assert(sizeof(CTX->Config.RunningMode) == 4, "This is expected to be size of 4");
+      ldr(x0, MemOperand(STATE, offsetof(FEXCore::Core::InternalThreadState, CTX)));
+      ldr(w0, MemOperand(x0, offsetof(FEXCore::Context::Context, Config.RunningMode)));
+      // If the value == 0 then branch to the top
+      cbz(x0, &LoopTop);
+      // Else we need to pause now
+      b(&ThreadPauseHandler);
+    }
+    else {
+      // Unconditionally loop to the top
+      // We will only stop on error when compiling a block or signal
+      b(&LoopTop);
+    }
+  }
+
+  {
+    bind(&Exit);
+    ThreadStopHandlerAddress = Buffer->GetOffsetAddress<uint64_t>(GetCursorOffset());
+    PopCalleeSavedRegisters();
+
+    // Return from the function
+    // LR is set to the correct return location now
+    ret();
+  }
+
+  // Need to create the block
+  {
+    bind(&NoBlock);
+
+    ldr(x0, MemOperand(STATE, offsetof(FEXCore::Core::InternalThreadState, CTX)));
+    mov(x1, STATE);
+
+    using ClassPtrType = uintptr_t (FEXCore::Context::Context::*)(FEXCore::Core::InternalThreadState *, uint64_t);
+    union PtrCast {
+      ClassPtrType ClassPtr;
+      uintptr_t Data;
+    };
+
+    PtrCast Ptr;
+    Ptr.ClassPtr = &FEXCore::Context::Context::CompileBlock;
+    LoadConstant(x3, Ptr.Data);
+
+    // X2 contains our guest RIP
+    blr(x3); // { CTX, ThreadState, RIP}
+
+    b(&LoopTop);
+  }
+
+  {
+    bind(&ThreadPauseHandler);
+    ThreadPauseHandlerAddress = Buffer->GetOffsetAddress<uint64_t>(GetCursorOffset());
+    // We are pausing, this means the frontend should be waiting for this thread to idle
+    // We will have faulted and jumped to this location at this point
+
+    // Call our sleep handler
+    LoadConstant(x0, reinterpret_cast<uintptr_t>(CTX));
+    mov(x1, STATE);
+    LoadConstant(x2, reinterpret_cast<uint64_t>(SleepThread));
+    blr(x2);
+
+    // XXX: Unsupported atm
+    //PauseReturnInstruction = Buffer->GetOffsetAddress<uint64_t>(GetCursorOffset());
+    //// Fault to start running again
+    //hlt(0);
+  }
+
+
+  FinalizeCode();
+  uint64_t CodeEnd = Buffer->GetOffsetAddress<uint64_t>(GetCursorOffset());
+  vixl::aarch64::CPU::EnsureIAndDCacheCoherency(reinterpret_cast<void*>(DispatchPtr), CodeEnd - reinterpret_cast<uint64_t>(DispatchPtr));
+  GetBuffer()->SetExecutable();
+}
+
+
+struct HostCTXHeader {
+  uint32_t Magic;
+  uint32_t Size;
+};
+
+constexpr uint32_t FPR_MAGIC = 0x46508001U;
+
+struct HostFPRState {
+  HostCTXHeader Head;
+  uint32_t FPSR;
+  uint32_t FPCR;
+  __uint128_t FPRs[32];
+};
+
+struct ContextBackup {
+  // Host State
+  uint64_t GPRs[31];
+  uint64_t PrevSP;
+  uint64_t PrevPC;
+  uint64_t PState;
+  uint32_t FPSR;
+  uint32_t FPCR;
+  __uint128_t FPRs[32];
+
+  // Guest state
+  int Signal;
+  FEXCore::Core::CPUState GuestState;
+};
+
+void DispatchGenerator::StoreThreadState(int Signal, void *ucontext) {
+  ucontext_t* _context = (ucontext_t*)ucontext;
+  mcontext_t* _mcontext = &_context->uc_mcontext;
+
+  // We can end up getting a signal at any point in our host state
+  // Jump to a handler that saves all state so we can safely return
+  uint64_t OldSP = _mcontext->sp;
+  uintptr_t NewSP = OldSP;
+
+  size_t StackOffset = sizeof(ContextBackup);
+  NewSP -= StackOffset;
+  NewSP = AlignDown(NewSP, 16);
+
+  ContextBackup *Context = reinterpret_cast<ContextBackup*>(NewSP);
+  memcpy(&Context->GPRs[0], &_mcontext->regs[0], 31 * sizeof(uint64_t));
+  Context->PrevSP = _mcontext->sp;
+  Context->PrevPC = _mcontext->pc;
+  Context->PState = _mcontext->pstate;
+
+  // Host FPR state starts at _mcontext->reserved[0];
+  HostFPRState *HostState = reinterpret_cast<HostFPRState*>(&_mcontext->__reserved[0]);
+  LogMan::Throw::A(HostState->Head.Magic == FPR_MAGIC, "Wrong FPR Magic: 0x%08x", HostState->Head.Magic);
+  Context->FPSR = HostState->FPSR;
+  Context->FPCR = HostState->FPCR;
+  memcpy(&Context->FPRs[0], &HostState->FPRs[0], 32 * sizeof(__uint128_t));
+
+  // Retain the action pointer so we can see it when we return
+  Context->Signal = Signal;
+
+  // Save guest state
+  // We can't guarantee if registers are in context or host GPRs
+  // So we need to save everything
+  memcpy(&Context->GuestState, &State->State, sizeof(FEXCore::Core::CPUState));
+
+  // Set the new SP
+  _mcontext->sp = NewSP;
+}
+
+void DispatchGenerator::RestoreThreadState(void *ucontext) {
+  ucontext_t* _context = (ucontext_t*)ucontext;
+  mcontext_t* _mcontext = &_context->uc_mcontext;
+
+  uint64_t OldSP = _mcontext->sp;
+  uintptr_t NewSP = OldSP;
+  ContextBackup *Context = reinterpret_cast<ContextBackup*>(NewSP);
+
+  // First thing, reset the guest state
+  memcpy(&State->State, &Context->GuestState, sizeof(FEXCore::Core::CPUState));
+
+  // Now restore host state
+  HostFPRState *HostState = reinterpret_cast<HostFPRState*>(&_mcontext->__reserved[0]);
+  LogMan::Throw::A(HostState->Head.Magic == FPR_MAGIC, "Wrong FPR Magic: 0x%08x", HostState->Head.Magic);
+  memcpy(&HostState->FPRs[0], &Context->FPRs[0], 32 * sizeof(__uint128_t));
+  Context->FPCR = HostState->FPCR;
+  Context->FPSR = HostState->FPSR;
+
+  // Restore GPRs and other state
+  _mcontext->pstate = Context->PState;
+  _mcontext->pc = Context->PrevPC;
+  _mcontext->sp = Context->PrevSP;
+  memcpy(&_mcontext->regs[0], &Context->GPRs[0], 31 * sizeof(uint64_t));
+
+  // Restore the previous signal state
+  // This allows recursive signals to properly handle signal masking as we are walking back up the list of signals
+  CTX->SignalDelegation.SetCurrentSignal(Context->Signal);
+}
+
+bool DispatchGenerator::HandleGuestSignal(int Signal, void *info, void *ucontext, SignalDelegator::GuestSigAction *GuestAction, stack_t *GuestStack) {
+  ucontext_t* _context = (ucontext_t*)ucontext;
+  mcontext_t* _mcontext = &_context->uc_mcontext;
+
+  StoreThreadState(Signal, ucontext);
+
+  // Set the new PC
+  _mcontext->pc = AbsoluteLoopTopAddress;
+  // Set x28 (which is our state register) to point to our guest thread data
+  _mcontext->regs[28 /* STATE */] = reinterpret_cast<uint64_t>(State);
+
+  State->State.State.gregs[X86State::REG_RDI] = Signal;
+  uint64_t OldGuestSP = State->State.State.gregs[X86State::REG_RSP];
+  uint64_t NewGuestSP = OldGuestSP;
+
+  if (!!GuestStack->ss_sp) {
+    // If our guest is already inside of the alternative stack
+    // Then that means we are hitting recursive signals and we need to walk back the stack correctly
+    uint64_t AltStackBase = reinterpret_cast<uint64_t>(GuestStack->ss_sp);
+    uint64_t AltStackEnd = AltStackBase + GuestStack->ss_size;
+    if (OldGuestSP >= AltStackBase &&
+        OldGuestSP <= AltStackEnd) {
+      // We are already in the alt stack, the rest of the code will handle adjusting this
+    }
+    else {
+      NewGuestSP = AltStackEnd;
+    }
+  }
+
+  // Back up past the redzone, which is 128bytes
+  // Don't need this offset if we aren't going to be putting siginfo in to it
+  NewGuestSP -= 128;
+
+  if (GuestAction->sa_flags & SA_SIGINFO) {
+    // XXX: siginfo_t(RSI), ucontext (RDX)
+    State->State.State.gregs[X86State::REG_RSI] = 0;
+    State->State.State.gregs[X86State::REG_RDX] = 0;
+    State->State.State.rip = reinterpret_cast<uint64_t>(GuestAction->sigaction_handler.sigaction);
+  }
+  else {
+    State->State.State.rip = reinterpret_cast<uint64_t>(GuestAction->sigaction_handler.handler);
+  }
+
+  // Set up the new SP for stack handling
+  NewGuestSP -= 8;
+  *(uint64_t*)NewGuestSP = CTX->X86CodeGen.SignalReturn;
+  State->State.State.gregs[X86State::REG_RSP] = NewGuestSP;
+
+  return true;
+}
+
+bool DispatchGenerator::HandleSignalPause(int Signal, void *info, void *ucontext) {
+  FEXCore::Core::SignalEvent SignalReason = State->SignalReason.load();
+
+  if (SignalReason == FEXCore::Core::SignalEvent::SIGNALEVENT_PAUSE) {
+    ucontext_t* _context = (ucontext_t*)ucontext;
+    mcontext_t* _mcontext = &_context->uc_mcontext;
+
+    // Store our thread state so we can come back to this
+    StoreThreadState(Signal, ucontext);
+
+    // Set the new PC
+    _mcontext->pc = ThreadPauseHandlerAddress;
+
+    // Set our state register to point to our guest thread data
+    _mcontext->regs[28 /* STATE */] = reinterpret_cast<uint64_t>(State);
+
+    State->SignalReason.store(FEXCore::Core::SIGNALEVENT_NONE);
+    return true;
+  }
+
+  if (SignalReason == FEXCore::Core::SignalEvent::SIGNALEVENT_RETURN) {
+    RestoreThreadState(ucontext);
+
+    State->SignalReason.store(FEXCore::Core::SIGNALEVENT_NONE);
+    return true;
+  }
+
+  if (SignalReason == FEXCore::Core::SignalEvent::SIGNALEVENT_STOP) {
+    ucontext_t* _context = (ucontext_t*)ucontext;
+    mcontext_t* _mcontext = &_context->uc_mcontext;
+
+    // Our thread is stopping
+    // We don't care about anything at this point
+    // Set the stack to our starting location when we entered the JIT and get out safely
+    _mcontext->sp = State->State.ReturningStackLocation;
+
+    // Set the new PC
+    _mcontext->pc = ThreadStopHandlerAddress;
+
+    State->SignalReason.store(FEXCore::Core::SIGNALEVENT_NONE);
+    return true;
+  }
+
+  return false;
+}
+
+void InterpreterCore::CreateAsmDispatch(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread) {
+  Generator = new DispatchGenerator(ctx, Thread);
+  DispatchPtr = Generator->DispatchPtr;
+}
+
+bool InterpreterCore::HandleGuestSignal(int Signal, void *info, void *ucontext, SignalDelegator::GuestSigAction *GuestAction, stack_t *GuestStack) {
+  DispatchGenerator *Gen = Generator;
+  return Gen->HandleGuestSignal(Signal, info, ucontext, GuestAction, GuestStack);
+}
+
+bool InterpreterCore::HandleSignalPause(int Signal, void *info, void *ucontext) {
+  DispatchGenerator *Gen = Generator;
+  return Gen->HandleSignalPause(Signal, info, ucontext);
+}
+
+void InterpreterCore::DeleteAsmDispatch() {
+  delete Generator;
+}
+
+}

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterClass.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterClass.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "Interface/Core/BlockCache.h"
+#include "Interface/Core/InternalThreadState.h"
+
+#include <FEXCore/Core/CPUBackend.h>
+#include <FEXCore/IR/IR.h>
+#include <FEXCore/IR/IntrusiveIRList.h>
+
+namespace FEXCore::CPU {
+class DispatchGenerator;
+
+#define DESTMAP_AS_MAP 0
+#if DESTMAP_AS_MAP
+using DestMapType = std::unordered_map<uint32_t, uint32_t>;
+#else
+using DestMapType = std::vector<uint32_t>;
+#endif
+
+class InterpreterCore final : public CPUBackend {
+public:
+  explicit InterpreterCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread);
+  ~InterpreterCore() override;
+  std::string GetName() override { return "Interpreter"; }
+  void *CompileCode(FEXCore::IR::IRListView<true> const *IR, FEXCore::Core::DebugData *DebugData) override;
+
+  void *MapRegion(void* HostPtr, uint64_t, uint64_t) override { return HostPtr; }
+
+  bool NeedsOpDispatch() override { return true; }
+
+  void ExecuteCode(FEXCore::Core::InternalThreadState *Thread);
+
+  void CreateAsmDispatch(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread);
+  void DeleteAsmDispatch();
+
+private:
+  FEXCore::Context::Context *CTX;
+  FEXCore::Core::InternalThreadState *State;
+
+  uint32_t AllocateTmpSpace(size_t Size);
+  bool HandleSignalPause(int Signal, void *info, void *ucontext);
+  bool HandleGuestSignal(int Signal, void *info, void *ucontext, SignalDelegator::GuestSigAction *GuestAction, stack_t *GuestStack);
+
+  template<typename Res>
+  Res GetDest(IR::OrderedNodeWrapper Op);
+
+  template<typename Res>
+  Res GetSrc(IR::OrderedNodeWrapper Src);
+
+  std::vector<uint8_t> TmpSpace;
+  DestMapType DestMap;
+  size_t TmpOffset{};
+
+  FEXCore::IR::IRListView<true> *CurrentIR;
+
+  DispatchGenerator *Generator{};
+};
+
+}

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.h
@@ -4,9 +4,13 @@ namespace FEXCore::Context {
 struct Context;
 }
 
+namespace FEXCore::Core {
+  struct InternalThreadState;
+}
+
 namespace FEXCore::CPU {
 class CPUBackend;
 
-FEXCore::CPU::CPUBackend *CreateInterpreterCore(FEXCore::Context::Context *ctx);
+FEXCore::CPU::CPUBackend *CreateInterpreterCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread);
 
 }

--- a/External/FEXCore/Source/Interface/Core/Interpreter/x86_64Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/x86_64Dispatcher.cpp
@@ -1,0 +1,402 @@
+#include "Common/MathUtils.h"
+#include "Interface/Core/Interpreter/InterpreterClass.h"
+#include <FEXCore/Core/X86Enums.h>
+
+#include <cmath>
+#include <xbyak/xbyak.h>
+
+namespace FEXCore::CPU {
+static constexpr size_t MAX_DISPATCHER_CODE_SIZE = 4096;
+#define STATE r14
+
+class DispatchGenerator : public Xbyak::CodeGenerator {
+  public:
+    DispatchGenerator(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread);
+    bool HandleGuestSignal(int Signal, void *info, void *ucontext, SignalDelegator::GuestSigAction *GuestAction, stack_t *GuestStack);
+    bool HandleSignalPause(int Signal, void *info, void *ucontext);
+
+  CPUBackend::AsmDispatch DispatchPtr;
+  uint64_t ThreadStopHandlerAddress;
+  uint64_t AbsoluteLoopTopAddress;
+  uint64_t ThreadPauseHandlerAddress;
+  FEXCore::Context::Context *CTX;
+  FEXCore::Core::InternalThreadState *State;
+  private:
+    void StoreThreadState(int Signal, void *ucontext);
+    void RestoreThreadState(void *ucontext);
+    std::stack<uint64_t> SignalFrames;
+};
+
+static void SleepThread(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread) {
+  --ctx->IdleWaitRefCount;
+  ctx->IdleWaitCV.notify_all();
+
+  // Go to sleep
+  Thread->StartRunning.Wait();
+
+  Thread->State.RunningEvents.Running = true;
+  ++ctx->IdleWaitRefCount;
+  ctx->IdleWaitCV.notify_all();
+}
+
+DispatchGenerator::DispatchGenerator(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread)
+  : Xbyak::CodeGenerator(MAX_DISPATCHER_CODE_SIZE)
+  , CTX {ctx}
+  , State {Thread} {
+  using namespace Xbyak;
+  using namespace Xbyak::util;
+  DispatchPtr = getCurr<CPUBackend::AsmDispatch>();
+
+  // while (!Thread->State.RunningEvents.ShouldStop.load()) {
+  //    Ptr = FindBlock(RIP)
+  //    if (!Ptr)
+  //      Ptr = CTX->CompileBlock(RIP);
+  //
+  //    if (Ptr)
+  //      Ptr();
+  //    else
+  //    {
+  //      Ptr = FallbackCore->CompileBlock()
+  //      if (Ptr)
+  //        Ptr()
+  //      else {
+  //        ShouldStop = true;
+  //      }
+  //    }
+  // }
+  // Bunch of exit state stuff
+
+  // x86-64 ABI has the stack aligned when /call/ happens
+  // Which means the destination has a misaligned stack at that point
+  push(rbx);
+  push(rbp);
+  push(r12);
+  push(r13);
+  push(r14);
+  push(r15);
+  sub(rsp, 8);
+
+  mov(STATE, rdi);
+
+  // Save this stack pointer so we can cleanly shutdown the emulation with a long jump
+  // regardless of where we were in the stack
+  mov(qword [rdi + offsetof(FEXCore::Core::ThreadState, ReturningStackLocation)], rsp);
+
+  Label LoopTop;
+  Label NoBlock;
+  Label ExitBlock;
+  Label ThreadPauseHandler;
+
+  L(LoopTop);
+  AbsoluteLoopTopAddress = getCurr<uint64_t>();
+
+  {
+    mov(r13, Thread->BlockCache->GetPagePointer());
+
+    // Load our RIP
+    mov(rdx, qword [STATE + offsetof(FEXCore::Core::CPUState, rip)]);
+
+    mov(rax, rdx);
+    mov(rbx, Thread->BlockCache->GetVirtualMemorySize() - 1);
+    and_(rax, rbx);
+    shr(rax, 12);
+
+    // Load page pointer
+    mov(rdi, qword [r13 + rax * 8]);
+
+    cmp(rdi, 0);
+    je(NoBlock);
+
+    mov (rax, rdx);
+    and_(rax, 0x0FFF);
+
+    shl(rax, (int)log2(sizeof(FEXCore::BlockCache::BlockCacheEntry)));
+
+    // Load the block pointer
+    mov(rax, qword [rdi + rax]);
+
+    cmp(rax, 0);
+    je(NoBlock);
+
+    // Real block if we made it here
+    mov(rdi, STATE);
+    call(rax);
+
+    if (CTX->GetGdbServerStatus()) {
+      // If we have a gdb server running then run in a less efficient mode that checks if we need to exit
+      // This happens when single stepping
+      static_assert(sizeof(CTX->Config.RunningMode) == 4, "This is expected to be size of 4");
+      mov(rax, qword [STATE + (offsetof(FEXCore::Core::InternalThreadState, CTX))]);
+
+      // If the value == 0 then branch to the top
+      cmp(dword [rax + (offsetof(FEXCore::Context::Context, Config.RunningMode))], 0);
+      je(LoopTop);
+      // Else we need to pause now
+      jmp(ThreadPauseHandler);
+      ud2();
+    }
+    else {
+      jmp(LoopTop);
+    }
+  }
+
+  {
+    L(ExitBlock);
+    ThreadStopHandlerAddress = getCurr<uint64_t>();
+
+    add(rsp, 8);
+
+    pop(r15);
+    pop(r14);
+    pop(r13);
+    pop(r12);
+    pop(rbp);
+    pop(rbx);
+
+    ret();
+  }
+
+  // Block creation
+  {
+    L(NoBlock);
+
+    using ClassPtrType = uintptr_t (FEXCore::Context::Context::*)(FEXCore::Core::InternalThreadState *, uint64_t);
+    union PtrCast {
+      ClassPtrType ClassPtr;
+      uintptr_t Data;
+    };
+
+    PtrCast Ptr;
+    Ptr.ClassPtr = &FEXCore::Context::Context::CompileBlock;
+
+    // {rdi, rsi, rdx}
+    mov(rdi, reinterpret_cast<uint64_t>(CTX));
+    mov(rsi, STATE);
+    mov(rax, Ptr.Data);
+
+    call(rax);
+
+    // rdx already contains RIP here
+    jmp(LoopTop);
+  }
+
+  {
+    // Pause handler
+    ThreadPauseHandlerAddress = getCurr<uint64_t>();
+    L(ThreadPauseHandler);
+
+    mov(rdi, reinterpret_cast<uintptr_t>(CTX));
+    mov(rsi, STATE);
+    mov(rax, reinterpret_cast<uint64_t>(SleepThread));
+
+    call(rax);
+
+    // XXX: Unsupported atm
+    // uint64_t PauseReturnInstruction = getCurr<uint64_t>();
+    // ud2();
+  }
+
+  ready();
+}
+
+struct ContextBackup {
+  uint64_t StoredCookie;
+  // Host State
+  // RIP and RSP is stored in GPRs here
+  uint64_t GPRs[NGREG];
+  _libc_fpstate FPRState;
+
+  // Guest state
+  int Signal;
+  FEXCore::Core::CPUState GuestState;
+};
+
+void DispatchGenerator::StoreThreadState(int Signal, void *ucontext) {
+  ucontext_t* _context = (ucontext_t*)ucontext;
+  mcontext_t* _mcontext = &_context->uc_mcontext;
+
+  // We can end up getting a signal at any point in our host state
+  // Jump to a handler that saves all state so we can safely return
+  uint64_t OldSP = _mcontext->gregs[REG_RSP];
+  uintptr_t NewSP = OldSP;
+
+  size_t StackOffset = sizeof(ContextBackup);
+
+  // We need to back up behind the host's red zone
+  // We do this on the guest side as well
+  NewSP -= 128;
+  NewSP -= StackOffset;
+  NewSP = AlignDown(NewSP, 16);
+
+  ContextBackup *Context = reinterpret_cast<ContextBackup*>(NewSP);
+
+  Context->StoredCookie = 0x4142434445464748ULL;
+
+  // Copy the GPRs
+  memcpy(&Context->GPRs[0], &_mcontext->gregs[0], NGREG * sizeof(_mcontext->gregs[0]));
+  // Copy the FPRState
+  memcpy(&Context->FPRState, _mcontext->fpregs, sizeof(_libc_fpstate));
+
+  // XXX: Save 256bit and 512bit AVX register state
+
+  // Retain the action pointer so we can see it when we return
+  Context->Signal = Signal;
+
+  // Save guest state
+  // We can't guarantee if registers are in context or host GPRs
+  // So we need to save everything
+  memcpy(&Context->GuestState, &State->State, sizeof(FEXCore::Core::CPUState));
+
+  // Set the new SP
+  _mcontext->gregs[REG_RSP] = NewSP;
+
+  SignalFrames.push(NewSP);
+}
+
+void DispatchGenerator::RestoreThreadState(void *ucontext) {
+  ucontext_t* _context = (ucontext_t*)ucontext;
+  mcontext_t* _mcontext = &_context->uc_mcontext;
+
+  uint64_t OldSP = SignalFrames.top();
+  SignalFrames.pop();
+  uintptr_t NewSP = OldSP;
+  ContextBackup *Context = reinterpret_cast<ContextBackup*>(NewSP);
+
+  if (Context->StoredCookie != 0x4142434445464748ULL) {
+    LogMan::Msg::D("COOKIE WAS NOT CORRECT!\n");
+    exit(-1);
+  }
+
+  // First thing, reset the guest state
+  memcpy(&State->State, &Context->GuestState, sizeof(FEXCore::Core::CPUState));
+
+  // Now restore host state
+
+  // Copy the GPRs
+  memcpy(&_mcontext->gregs[0], &Context->GPRs[0], NGREG * sizeof(_mcontext->gregs[0]));
+  // Copy the FPRState
+  memcpy(_mcontext->fpregs, &Context->FPRState, sizeof(_libc_fpstate));
+
+  // Restore the previous signal state
+  // This allows recursive signals to properly handle signal masking as we are walking back up the list of signals
+  CTX->SignalDelegation.SetCurrentSignal(Context->Signal);
+}
+
+bool DispatchGenerator::HandleGuestSignal(int Signal, void *info, void *ucontext, SignalDelegator::GuestSigAction *GuestAction, stack_t *GuestStack) {
+  ucontext_t* _context = (ucontext_t*)ucontext;
+  mcontext_t* _mcontext = &_context->uc_mcontext;
+
+  StoreThreadState(Signal, ucontext);
+
+  // Set the new PC
+  _mcontext->gregs[REG_RIP] = AbsoluteLoopTopAddress;
+  // Set our state register to point to our guest thread data
+  _mcontext->gregs[REG_R14] = reinterpret_cast<uint64_t>(State);
+
+  uint64_t OldGuestSP = State->State.State.gregs[X86State::REG_RSP];
+  uint64_t NewGuestSP = OldGuestSP;
+
+  if (!!GuestStack->ss_sp) {
+    // If our guest is already inside of the alternative stack
+    // Then that means we are hitting recursive signals and we need to walk back the stack correctly
+    uint64_t AltStackBase = reinterpret_cast<uint64_t>(GuestStack->ss_sp);
+    uint64_t AltStackEnd = AltStackBase + GuestStack->ss_size;
+    if (OldGuestSP >= AltStackBase &&
+        OldGuestSP <= AltStackEnd) {
+      // We are already in the alt stack, the rest of the code will handle adjusting this
+    }
+    else {
+      NewGuestSP = AltStackEnd;
+    }
+  }
+
+  // Back up past the redzone, which is 128bytes
+  // Don't need this offset if we aren't going to be putting siginfo in to it
+  NewGuestSP -= 128;
+
+  State->State.State.gregs[X86State::REG_RDI] = Signal;
+
+  if (GuestAction->sa_flags & SA_SIGINFO) {
+    // XXX: siginfo_t(RSI), ucontext (RDX)
+    State->State.State.gregs[X86State::REG_RSI] = 0;
+    State->State.State.gregs[X86State::REG_RDX] = 0;
+    State->State.State.rip = reinterpret_cast<uint64_t>(GuestAction->sigaction_handler.sigaction);
+  }
+  else {
+    State->State.State.rip = reinterpret_cast<uint64_t>(GuestAction->sigaction_handler.handler);
+  }
+
+  // Set up the new SP for stack handling
+  NewGuestSP -= 8;
+  *(uint64_t*)NewGuestSP = CTX->X86CodeGen.SignalReturn;
+  State->State.State.gregs[X86State::REG_RSP] = NewGuestSP;
+
+  return true;
+}
+
+bool DispatchGenerator::HandleSignalPause(int Signal, void *info, void *ucontext) {
+  FEXCore::Core::SignalEvent SignalReason = State->SignalReason.load();
+
+  if (SignalReason == FEXCore::Core::SignalEvent::SIGNALEVENT_PAUSE) {
+    ucontext_t* _context = (ucontext_t*)ucontext;
+    mcontext_t* _mcontext = &_context->uc_mcontext;
+
+    // Store our thread state so we can come back to this
+    StoreThreadState(Signal, ucontext);
+
+    // Set the new PC
+    _mcontext->gregs[REG_RIP] = ThreadPauseHandlerAddress;
+
+    // Set our state register to point to our guest thread data
+    _mcontext->gregs[REG_R14] = reinterpret_cast<uint64_t>(State);
+
+    State->SignalReason.store(FEXCore::Core::SIGNALEVENT_NONE);
+    return true;
+  }
+
+  if (SignalReason == FEXCore::Core::SignalEvent::SIGNALEVENT_STOP) {
+    ucontext_t* _context = (ucontext_t*)ucontext;
+    mcontext_t* _mcontext = &_context->uc_mcontext;
+
+    // Our thread is stopping
+    // We don't care about anything at this point
+    // Set the stack to our starting location when we entered the core and get out safely
+    _mcontext->gregs[REG_RSP] = State->State.ReturningStackLocation;
+
+    // Set the new PC
+    _mcontext->gregs[REG_RIP] = ThreadStopHandlerAddress;
+
+    State->SignalReason.store(FEXCore::Core::SIGNALEVENT_NONE);
+    return true;
+  }
+
+  if (SignalReason == FEXCore::Core::SignalEvent::SIGNALEVENT_RETURN) {
+    RestoreThreadState(ucontext);
+
+    State->SignalReason.store(FEXCore::Core::SIGNALEVENT_NONE);
+    return true;
+  }
+
+  return false;
+}
+
+void InterpreterCore::CreateAsmDispatch(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread) {
+  Generator = new DispatchGenerator(ctx, Thread);
+  DispatchPtr = Generator->DispatchPtr;
+}
+
+bool InterpreterCore::HandleGuestSignal(int Signal, void *info, void *ucontext, SignalDelegator::GuestSigAction *GuestAction, stack_t *GuestStack) {
+  DispatchGenerator *Gen = Generator;
+  return Gen->HandleGuestSignal(Signal, info, ucontext, GuestAction, GuestStack);
+}
+
+bool InterpreterCore::HandleSignalPause(int Signal, void *info, void *ucontext) {
+  DispatchGenerator *Gen = Generator;
+  return Gen->HandleSignalPause(Signal, info, ucontext);
+}
+
+void InterpreterCore::DeleteAsmDispatch() {
+  delete Generator;
+}
+
+}

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -479,12 +479,13 @@ void JITCore::ClearCache() {
       Buffer->Reset();
     }
     else {
-      // Resize the code buffer and reallocate our code size
-      CurrentCodeBuffer->Size *= 1.5;
-      CurrentCodeBuffer->Size = std::min(CurrentCodeBuffer->Size, MAX_CODE_SIZE);
-
       FreeCodeBuffer(InitialCodeBuffer);
-      InitialCodeBuffer = JITCore::AllocateNewCodeBuffer(CurrentCodeBuffer->Size);
+
+      // Resize the code buffer and reallocate our code size
+      InitialCodeBuffer.Size *= 1.5;
+      InitialCodeBuffer.Size = std::min(InitialCodeBuffer.Size, MAX_CODE_SIZE);
+
+      InitialCodeBuffer = JITCore::AllocateNewCodeBuffer(InitialCodeBuffer.Size);
       *Buffer = vixl::CodeBuffer(InitialCodeBuffer.Ptr, InitialCodeBuffer.Size);
     }
   }

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -1,126 +1,268 @@
 #include "Interface/Context/Context.h"
-#include "Interface/Core/BlockCache.h"
-#include "Interface/Core/BlockSamplingData.h"
-#include "Interface/Core/InternalThreadState.h"
-#include "Interface/IR/Passes/RegisterAllocationPass.h"
 
-#include "Interface/Core/JIT/x86_64/JIT.h"
-#include <xbyak/xbyak.h>
-using namespace Xbyak;
+#include "Interface/Core/JIT/x86_64/JITClass.h"
+#include <FEXCore/Core/X86Enums.h>
 
-#include <FEXCore/Core/CPUBackend.h>
-#include <FEXCore/IR/IR.h>
-#include <FEXCore/IR/IntrusiveIRList.h>
+#include <cmath>
+
 // #define DEBUG_RA 1
 // #define DEBUG_CYCLES
+
+namespace FEXCore::CPU {
+
+CodeBuffer AllocateNewCodeBuffer(size_t Size) {
+  CodeBuffer Buffer;
+  Buffer.Size = Size;
+  Buffer.Ptr = static_cast<uint8_t*>(
+               mmap(nullptr,
+                    Buffer.Size,
+                    PROT_READ | PROT_WRITE | PROT_EXEC,
+                    MAP_PRIVATE | MAP_ANONYMOUS,
+                    -1, 0));
+  LogMan::Throw::A(!!Buffer.Ptr, "Couldn't allocate code buffer");
+  return Buffer;
+}
+
+void FreeCodeBuffer(CodeBuffer Buffer) {
+  munmap(Buffer.Ptr, Buffer.Size);
+}
+
+}
 
 namespace FEXCore::CPU {
 static void PrintValue(uint64_t Value) {
   LogMan::Msg::D("Value: 0x%lx", Value);
 }
 
-// Temp registers
-// rax, rcx, rdx, rsi, r8, r9,
-// r10, r11
-//
-// Callee Saved
-// rbx, rbp, r12, r13, r14, r15
-//
-// 1St Argument: rdi <ThreadState>
-// XMM:
-// All temp
-#define STATE r14
-#define TMP1 rax
-#define TMP2 rcx
-#define TMP3 rdx
-#define TMP4 rdi
-#define TMP5 rbx
-using namespace Xbyak::util;
-const std::array<Xbyak::Reg, 9> RA64 = { rsi, r8, r9, r10, r11, rbp, r12, r13, r15 };
-const std::array<std::pair<Xbyak::Reg, Xbyak::Reg>, 4> RA64Pair = {{ {rsi, r8}, {r9, r10}, {r11, rbp}, {r12, r13} }};
-const std::array<Xbyak::Reg, 11> RAXMM = { xmm0, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm9, xmm10 };
-const std::array<Xbyak::Xmm, 11> RAXMM_x = { xmm0, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm9, xmm10 };
+struct ContextBackup {
+  uint64_t StoredCookie;
+  // Host State
+  // RIP and RSP is stored in GPRs here
+  uint64_t GPRs[NGREG];
+  _libc_fpstate FPRState;
 
-class JITCore final : public CPUBackend, public Xbyak::CodeGenerator {
-public:
-  explicit JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread);
-  ~JITCore() override;
-  std::string GetName() override { return "JIT"; }
-  void *CompileCode(FEXCore::IR::IRListView<true> const *IR, FEXCore::Core::DebugData *DebugData) override;
-
-  void *MapRegion(void* HostPtr, uint64_t, uint64_t) override { return HostPtr; }
-
-  bool NeedsOpDispatch() override { return true; }
-
-  bool HasCustomDispatch() const override { return CustomDispatchGenerated; }
-
-  void ExecuteCustomDispatch(FEXCore::Core::ThreadState *Thread) override {
-    DispatchPtr(reinterpret_cast<FEXCore::Core::InternalThreadState*>(Thread));
-  }
-
-  void ClearCache() override {
-    reset();
-  }
-
-private:
-  FEXCore::Context::Context *CTX;
-  FEXCore::Core::InternalThreadState *ThreadState;
-  FEXCore::IR::IRListView<true> const *CurrentIR;
-  std::unordered_map<IR::OrderedNodeWrapper::NodeOffsetType, Label> JumpTargets;
-
-  std::vector<uint8_t> Stack;
-  bool MemoryDebug = false;
-
-  /**
-   * @name Register Allocation
-   * @{ */
-  constexpr static uint32_t NumGPRs = RA64.size(); // 4 is the minimum required for GPR ops
-  constexpr static uint32_t NumXMMs = RAXMM.size();
-  constexpr static uint32_t NumGPRPairs = RA64Pair.size();
-  constexpr static uint32_t RegisterCount = NumGPRs + NumXMMs + NumGPRPairs;
-  constexpr static uint32_t RegisterClasses = 3;
-
-  constexpr static uint64_t GPRBase = (0ULL << 32);
-  constexpr static uint64_t XMMBase = (1ULL << 32);
-  constexpr static uint64_t GPRPairBase = (2ULL << 32);
-
-  /**  @} */
-
-  constexpr static uint8_t RA_8 = 0;
-  constexpr static uint8_t RA_16 = 1;
-  constexpr static uint8_t RA_32 = 2;
-  constexpr static uint8_t RA_64 = 3;
-  constexpr static uint8_t RA_XMM = 4;
-
-  uint32_t GetPhys(uint32_t Node);
-
-  template<uint8_t RAType>
-  Xbyak::Reg GetSrc(uint32_t Node);
-  template<uint8_t RAType>
-  std::pair<Xbyak::Reg, Xbyak::Reg> GetSrcPair(uint32_t Node);
-
-  template<uint8_t RAType>
-  Xbyak::Reg GetDst(uint32_t Node);
-
-  Xbyak::Xmm GetSrc(uint32_t Node);
-  Xbyak::Xmm GetDst(uint32_t Node);
-
-  void CreateCustomDispatch(FEXCore::Core::InternalThreadState *Thread);
-  bool CustomDispatchGenerated {false};
-  using CustomDispatch = void(*)(FEXCore::Core::InternalThreadState *Thread);
-  CustomDispatch DispatchPtr{};
-  IR::RegisterAllocationPass *RAPass;
-
-#ifdef BLOCKSTATS
-  bool GetSamplingData {true};
-#endif
-  static constexpr uint32_t MAX_CODE_SIZE = 1024 * 1024 * 32;
+  // Guest state
+  int Signal;
+  FEXCore::Core::CPUState GuestState;
 };
 
-JITCore::JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread)
-  : CodeGenerator(MAX_CODE_SIZE)
+void JITCore::StoreThreadState(int Signal, void *ucontext) {
+  ucontext_t* _context = (ucontext_t*)ucontext;
+  mcontext_t* _mcontext = &_context->uc_mcontext;
+
+  // We can end up getting a signal at any point in our host state
+  // Jump to a handler that saves all state so we can safely return
+  uint64_t OldSP = _mcontext->gregs[REG_RSP];
+  uintptr_t NewSP = OldSP;
+
+  size_t StackOffset = sizeof(ContextBackup);
+
+  // We need to back up behind the host's red zone
+  // We do this on the guest side as well
+  NewSP -= 128;
+  NewSP -= StackOffset;
+  NewSP = AlignDown(NewSP, 16);
+
+  ContextBackup *Context = reinterpret_cast<ContextBackup*>(NewSP);
+
+  Context->StoredCookie = 0x4142434445464748ULL;
+
+  // Copy the GPRs
+  memcpy(&Context->GPRs[0], &_mcontext->gregs[0], NGREG * sizeof(_mcontext->gregs[0]));
+  // Copy the FPRState
+  memcpy(&Context->FPRState, _mcontext->fpregs, sizeof(_libc_fpstate));
+
+  // XXX: Save 256bit and 512bit AVX register state
+
+  // Retain the action pointer so we can see it when we return
+  Context->Signal = Signal;
+
+  // Save guest state
+  // We can't guarantee if registers are in context or host GPRs
+  // So we need to save everything
+  memcpy(&Context->GuestState, &ThreadState->State, sizeof(FEXCore::Core::CPUState));
+
+  // Set the new SP
+  _mcontext->gregs[REG_RSP] = NewSP;
+
+  SignalFrames.push(NewSP);
+}
+
+void JITCore::RestoreThreadState(void *ucontext) {
+  ucontext_t* _context = (ucontext_t*)ucontext;
+  mcontext_t* _mcontext = &_context->uc_mcontext;
+
+  uint64_t OldSP = SignalFrames.top();
+  SignalFrames.pop();
+  uintptr_t NewSP = OldSP;
+  ContextBackup *Context = reinterpret_cast<ContextBackup*>(NewSP);
+
+  if (Context->StoredCookie != 0x4142434445464748ULL) {
+    LogMan::Msg::D("COOKIE WAS NOT CORRECT!\n");
+    exit(-1);
+  }
+
+  // First thing, reset the guest state
+  memcpy(&ThreadState->State, &Context->GuestState, sizeof(FEXCore::Core::CPUState));
+
+  // Now restore host state
+
+  // Copy the GPRs
+  memcpy(&_mcontext->gregs[0], &Context->GPRs[0], NGREG * sizeof(_mcontext->gregs[0]));
+  // Copy the FPRState
+  memcpy(_mcontext->fpregs, &Context->FPRState, sizeof(_libc_fpstate));
+
+  // Restore the previous signal state
+  // This allows recursive signals to properly handle signal masking as we are walking back up the list of signals
+  CTX->SignalDelegation.SetCurrentSignal(Context->Signal);
+}
+
+bool JITCore::HandleGuestSignal(int Signal, void *info, void *ucontext, SignalDelegator::GuestSigAction *GuestAction, stack_t *GuestStack) {
+  ucontext_t* _context = (ucontext_t*)ucontext;
+  mcontext_t* _mcontext = &_context->uc_mcontext;
+
+  StoreThreadState(Signal, ucontext);
+
+  // Set the new PC
+  _mcontext->gregs[REG_RIP] = AbsoluteLoopTopAddress;
+  // Set our state register to point to our guest thread data
+  _mcontext->gregs[REG_R14] = reinterpret_cast<uint64_t>(ThreadState);
+
+  // Ref count our faults
+  // We use this to track if it is safe to clear cache
+  ++SignalHandlerRefCounter;
+
+  uint64_t OldGuestSP = ThreadState->State.State.gregs[X86State::REG_RSP];
+  uint64_t NewGuestSP = OldGuestSP;
+
+  if (!!GuestStack->ss_sp) {
+    // If our guest is already inside of the alternative stack
+    // Then that means we are hitting recursive signals and we need to walk back the stack correctly
+    uint64_t AltStackBase = reinterpret_cast<uint64_t>(GuestStack->ss_sp);
+    uint64_t AltStackEnd = AltStackBase + GuestStack->ss_size;
+    if (OldGuestSP >= AltStackBase &&
+        OldGuestSP <= AltStackEnd) {
+      // We are already in the alt stack, the rest of the code will handle adjusting this
+    }
+    else {
+      NewGuestSP = AltStackEnd;
+    }
+  }
+
+  // Back up past the redzone, which is 128bytes
+  // Don't need this offset if we aren't going to be putting siginfo in to it
+  NewGuestSP -= 128;
+
+  ThreadState->State.State.gregs[X86State::REG_RDI] = Signal;
+
+  if (GuestAction->sa_flags & SA_SIGINFO) {
+    // XXX: siginfo_t(RSI), ucontext (RDX)
+    ThreadState->State.State.gregs[X86State::REG_RSI] = 0;
+    ThreadState->State.State.gregs[X86State::REG_RDX] = 0;
+    ThreadState->State.State.rip = reinterpret_cast<uint64_t>(GuestAction->sigaction_handler.sigaction);
+  }
+  else {
+    ThreadState->State.State.rip = reinterpret_cast<uint64_t>(GuestAction->sigaction_handler.handler);
+  }
+
+  // Set up the new SP for stack handling
+  NewGuestSP -= 8;
+  *(uint64_t*)NewGuestSP = CTX->X86CodeGen.SignalReturn;
+  ThreadState->State.State.gregs[X86State::REG_RSP] = NewGuestSP;
+
+  return true;
+}
+
+bool JITCore::HandleSIGILL(int Signal, void *info, void *ucontext) {
+  ucontext_t* _context = (ucontext_t*)ucontext;
+  mcontext_t* _mcontext = &_context->uc_mcontext;
+
+  if (_mcontext->gregs[REG_RIP] == SignalHandlerReturnAddress) {
+    RestoreThreadState(ucontext);
+
+    // Ref count our faults
+    // We use this to track if it is safe to clear cache
+    --SignalHandlerRefCounter;
+    return true;
+  }
+
+  if (_mcontext->gregs[REG_RIP] == PauseReturnInstruction) {
+    RestoreThreadState(ucontext);
+
+    // Ref count our faults
+    // We use this to track if it is safe to clear cache
+    --SignalHandlerRefCounter;
+    return true;
+  }
+
+  return false;
+}
+
+bool JITCore::HandleSignalPause(int Signal, void *info, void *ucontext) {
+  FEXCore::Core::SignalEvent SignalReason = ThreadState->SignalReason.load();
+
+  if (SignalReason == FEXCore::Core::SignalEvent::SIGNALEVENT_PAUSE) {
+    ucontext_t* _context = (ucontext_t*)ucontext;
+    mcontext_t* _mcontext = &_context->uc_mcontext;
+
+    // Store our thread state so we can come back to this
+    StoreThreadState(Signal, ucontext);
+
+    // Set the new PC
+    _mcontext->gregs[REG_RIP] = ThreadPauseHandlerAddress;
+
+    // Set our state register to point to our guest thread data
+    _mcontext->gregs[REG_R14] = reinterpret_cast<uint64_t>(ThreadState);
+
+    // Ref count our faults
+    // We use this to track if it is safe to clear cache
+    ++SignalHandlerRefCounter;
+
+    ThreadState->SignalReason.store(FEXCore::Core::SIGNALEVENT_NONE);
+    return true;
+  }
+
+  if (SignalReason == FEXCore::Core::SignalEvent::SIGNALEVENT_RETURN) {
+    RestoreThreadState(ucontext);
+
+    // Ref count our faults
+    // We use this to track if it is safe to clear cache
+    --SignalHandlerRefCounter;
+
+    ThreadState->SignalReason.store(FEXCore::Core::SIGNALEVENT_NONE);
+    return true;
+  }
+
+  if (SignalReason == FEXCore::Core::SignalEvent::SIGNALEVENT_STOP) {
+    ucontext_t* _context = (ucontext_t*)ucontext;
+    mcontext_t* _mcontext = &_context->uc_mcontext;
+
+    // Our thread is stopping
+    // We don't care about anything at this point
+    // Set the stack to our starting location when we entered the JIT and get out safely
+    _mcontext->gregs[REG_RSP] = ThreadState->State.ReturningStackLocation;
+
+    // Our ref counting doesn't matter anymore
+    SignalHandlerRefCounter = 0;
+
+    // Set the new PC
+    _mcontext->gregs[REG_RIP] = ThreadStopHandlerAddress;
+
+    ThreadState->SignalReason.store(FEXCore::Core::SIGNALEVENT_NONE);
+    return true;
+  }
+
+  return false;
+}
+
+
+JITCore::JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread, CodeBuffer Buffer)
+  : CodeGenerator(Buffer.Size, Buffer.Ptr, nullptr)
   , CTX {ctx}
-  , ThreadState {Thread} {
+  , ThreadState {Thread}
+  , InitialCodeBuffer {Buffer}
+{
+  CurrentCodeBuffer = &InitialCodeBuffer;
   Stack.resize(9000 * 16 * 64);
 
   RAPass = Thread->PassManager->GetRAPass();
@@ -139,20 +281,74 @@ JITCore::JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadSt
   }
 
   CreateCustomDispatch(Thread);
+
+  // This will register the host signal handler per thread, which is fine
+  CTX->SignalDelegation.RegisterHostSignalHandler(SIGILL, [](FEXCore::Core::InternalThreadState *Thread, int Signal, void *info, void *ucontext) -> bool {
+    JITCore *Core = reinterpret_cast<JITCore*>(Thread->CPUBackend.get());
+    return Core->HandleSIGILL(Signal, info, ucontext);
+  });
+
+  CTX->SignalDelegation.RegisterHostSignalHandler(SignalDelegator::SIGNAL_FOR_PAUSE, [](FEXCore::Core::InternalThreadState *Thread, int Signal, void *info, void *ucontext) -> bool {
+    JITCore *Core = reinterpret_cast<JITCore*>(Thread->CPUBackend.get());
+    return Core->HandleSignalPause(Signal, info, ucontext);
+  });
+
+  auto GuestSignalHandler = [](FEXCore::Core::InternalThreadState *Thread, int Signal, void *info, void *ucontext, SignalDelegator::GuestSigAction *GuestAction, stack_t *GuestStack) -> bool {
+    JITCore *Core = reinterpret_cast<JITCore*>(Thread->CPUBackend.get());
+    return Core->HandleGuestSignal(Signal, info, ucontext, GuestAction, GuestStack);
+  };
+
+  for (uint32_t Signal = 0; Signal < SignalDelegator::MAX_SIGNALS; ++Signal) {
+    CTX->SignalDelegation.RegisterHostSignalHandlerForGuest(Signal, GuestSignalHandler);
+  }
+
 }
 
 JITCore::~JITCore() {
   LogMan::Msg::D("Used %ld bytes for compiling", getCurr<uintptr_t>() - getCode<uintptr_t>());
+  FreeCodeBuffer(DispatcherCodeBuffer);
+  FreeCodeBuffer(InitialCodeBuffer);
 }
 
-static void LoadMem(uint64_t Addr, uint64_t Data, uint8_t Size) {
-  LogMan::Msg::D("Loading from guestmem: 0x%lx (%d)", Addr, Size);
-  LogMan::Msg::D("\tLoading: 0x%016lx", Data);
-}
 
-static void StoreMem(uint64_t Addr, uint64_t Data, uint8_t Size) {
-  LogMan::Msg::D("Storing guestmem: 0x%lx (%d)", Addr, Size);
-  LogMan::Msg::D("\tStoring: 0x%016lx", Data);
+void JITCore::ClearCache() {
+  if (SignalHandlerRefCounter == 0) {
+    if (!CodeBuffers.empty()) {
+      // If we have more than one code buffer we are tracking then walk them and delete
+      // This is a cleanup step
+      for (auto CodeBuffer : CodeBuffers) {
+        FreeCodeBuffer(CodeBuffer);
+      }
+      CodeBuffers.clear();
+
+      // Set the current code buffer to the initial
+      setNewBuffer(InitialCodeBuffer.Ptr, InitialCodeBuffer.Size);
+      CurrentCodeBuffer = &InitialCodeBuffer;
+    }
+
+    if (CurrentCodeBuffer->Size == MAX_CODE_SIZE) {
+      // Rewind to the start of the code cache start
+      reset();
+    }
+    else {
+      // Resize the code buffer and reallocate our code size
+      CurrentCodeBuffer->Size *= 1.5;
+      CurrentCodeBuffer->Size = std::min(CurrentCodeBuffer->Size, MAX_CODE_SIZE);
+
+      FreeCodeBuffer(InitialCodeBuffer);
+      InitialCodeBuffer = AllocateNewCodeBuffer(CurrentCodeBuffer->Size);
+      setNewBuffer(InitialCodeBuffer.Ptr, InitialCodeBuffer.Size);
+    }
+  }
+  else {
+    // We have signal handlers that have generated code
+    // This means that we can not safely clear the code at this point in time
+    // Allocate some new code buffers that we can switch over to instead
+    auto NewCodeBuffer = AllocateNewCodeBuffer(JITCore::INITIAL_CODE_SIZE);
+    CurrentCodeBuffer->Size = JITCore::INITIAL_CODE_SIZE;
+    EmplaceNewCodeBuffer(NewCodeBuffer);
+    setNewBuffer(NewCodeBuffer.Ptr, NewCodeBuffer.Size);
+  }
 }
 
 uint32_t JITCore::GetPhys(uint32_t Node) {
@@ -233,13 +429,13 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
   LogMan::Throw::A(HeaderOp->Header.Op == IR::OP_IRHEADER, "First op wasn't IRHeader");
 
   if (HeaderOp->ShouldInterpret) {
-    return ThreadState->IntBackend->CompileCode(IR, DebugData);
+    return InterpreterFallbackHelperAddress;
   }
 
   // Fairly excessive buffer range to make sure we don't overflow
   uint32_t BufferRange = SSACount * 16;
-  if ((getSize() + BufferRange) > MAX_CODE_SIZE) {
-    LogMan::Msg::D("Gotta clear code cache: 0x%lx is too close to 0x%lx", getSize(), MAX_CODE_SIZE);
+  if ((getSize() + BufferRange) > CurrentCodeBuffer->Size) {
+    LogMan::Msg::D("Gotta clear code cache: 0x%lx is too close to 0x%lx", getSize(), CurrentCodeBuffer->Size);
     ThreadState->CTX->ClearCodeCache(ThreadState, HeaderOp->Entry);
   }
 
@@ -253,16 +449,6 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
   LogMan::Throw::A(RAPass->HasFullRA(), "Needs RA");
 
   uint32_t SpillSlots = RAPass->SpillSlots();
-
-  if (!CustomDispatchGenerated) {
-    push(rbx);
-    push(rbp);
-    push(r12);
-    push(r13);
-    push(r14);
-    push(r15);
-    mov(STATE, rdi);
-  }
 
   if (SpillSlots) {
     sub(rsp, SpillSlots * 16 + 8);
@@ -322,14 +508,6 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
       add(rsp, 8);
     }
 
-    if (!CustomDispatchGenerated) {
-      pop(r15);
-      pop(r14);
-      pop(r13);
-      pop(r12);
-      pop(rbp);
-      pop(rbx);
-    }
 #ifdef BLOCKSTATS
     ExitBlock();
 #endif
@@ -422,6 +600,19 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
           RegularExit();
           break;
         }
+        case IR::OP_SIGNALRETURN: {
+          // Adjust the stack first for a regular return
+          if (SpillSlots) {
+            add(rsp, SpillSlots * 16 + 8 + 8); // + 8 to consume return address
+          }
+          else {
+            add(rsp, 8 + 8); // + 8 to consume return address
+          }
+
+          mov(TMP1, SignalHandlerReturnAddress);
+          jmp(TMP1);
+          break;
+        }
         case IR::OP_BREAK: {
           auto Op = IROp->C<IR::IROp_Break>();
           switch (Op->Reason) {
@@ -429,16 +620,40 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
             case 5: // Guest ud2
               ud2();
             break;
-            case 4: // HLT
+            case 4: { // HLT
+              // Time to quit
+              // Set our stack to the starting stack location
+              mov(rsp, qword [STATE + offsetof(FEXCore::Core::ThreadState, ReturningStackLocation)]);
+
+              // Now we need to jump to the thread stop handler
+              mov(TMP1, ThreadStopHandlerAddress);
+              jmp(TMP1);
+              break;
+            }
             case 6: // INT3
             {
-              mov(al, 1);
-              auto offset = Op->Reason == 4 ?
-                  offsetof(FEXCore::Core::ThreadState, RunningEvents.ShouldStop) // HLT
-                : offsetof(FEXCore::Core::ThreadState, RunningEvents.ShouldPause); // INT3
-              xchg(byte [STATE + offset], al);
+              if (CTX->GetGdbServerStatus()) {
+                // Adjust the stack first for a regular return
+                if (SpillSlots) {
+                  add(rsp, SpillSlots * 16 + 8);
+                }
+                else {
+                  add(rsp, 8);
+                }
 
-              RegularExit();
+                // This jump target needs to be a constant offset here
+                mov(TMP1, ThreadPauseHandlerAddress);
+                jmp(TMP1);
+              }
+              else {
+                // If we don't have a gdb server attached then....crash?
+                // Treat this case like HLT
+                mov(rsp, qword [STATE + offsetof(FEXCore::Core::ThreadState, ReturningStackLocation)]);
+
+                // Now we need to jump to the thread stop handler
+                mov(TMP1, ThreadStopHandlerAddress);
+                jmp(TMP1);
+              }
             break;
             }
             default: LogMan::Msg::A("Unknown Break reason: %d", Op->Reason);
@@ -1966,8 +2181,7 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
           auto Op = IROp->C<IR::IROp_Syscall>();
           // XXX: This is very terrible, but I don't care for right now
 
-          auto NumPush = 1 + RA64.size();
-          push(rdi);
+          auto NumPush = RA64.size();
 
           for (auto &Reg : RA64)
             push(Reg);
@@ -1986,7 +2200,7 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
             ++NumPush;
           }
 
-          mov(rsi, rdi); // Move thread in to rsi
+          mov(rsi, STATE); // Move thread in to rsi
           mov(rdi, reinterpret_cast<uint64_t>(CTX->SyscallHandler.get()));
           mov(rdx, rsp);
 
@@ -1994,7 +2208,7 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
 
           if (NumPush & 1)
             sub(rsp, 8); // Align
-
+    // {rdi, rsi, rdx}
           call(rax);
 
           if (NumPush & 1)
@@ -2009,16 +2223,13 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
           for (uint32_t i = RA64.size(); i > 0; --i)
             pop(RA64[i - 1]);
 
-          pop(rdi);
-
           mov (GetDst<RA_64>(Node), rax);
           break;
         }
         case IR::OP_THUNK: {
           auto Op = IROp->C<IR::IROp_Thunk>();
 
-          auto NumPush = 1 + RA64.size();
-          push(rdi);
+          auto NumPush = RA64.size();
 
           for (auto &Reg : RA64)
             push(Reg);
@@ -2038,7 +2249,6 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
           for (uint32_t i = RA64.size(); i > 0; --i)
             pop(RA64[i - 1]);
 
-          pop(rdi);
           break;
         }
         case IR::OP_VEXTRACTTOGPR: {
@@ -2095,9 +2305,6 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
         case IR::OP_PRINT: {
           auto Op = IROp->C<IR::IROp_Print>();
 
-          push(rdi);
-          push(rdi);
-
           for (auto &Reg : RA64)
             push(Reg);
 
@@ -2116,9 +2323,6 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
 
           for (uint32_t i = RA64.size(); i > 0; --i)
             pop(RA64[i - 1]);
-
-          pop(rdi);
-          pop(rdi);
 
           break;
         }
@@ -2141,21 +2345,23 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
           // Function: rsi
           //
           // Result: RAX, RDX. 4xi32
-          push(rdi);
+
           mov (rsi, GetSrc<RA_64>(Op->Header.Args[0].ID()));
           mov (rdi, reinterpret_cast<uint64_t>(&CTX->CPUID));
 
-          auto NumPush = RA64.size() + 1;
+          auto NumPush = RA64.size();
+
           if (NumPush & 1)
             sub(rsp, 8); // Align
 
           mov(rax, Ptr.Raw);
+
+          // {rdi, rsi, rdx}
+
           call(rax);
 
           if (NumPush & 1)
             add(rsp, 8); // Align
-
-          pop(rdi);
 
           for (uint32_t i = RA64.size(); i > 0; --i)
             pop(RA64[i - 1]);
@@ -4634,10 +4840,36 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
   if (DebugData) {
     DebugData->HostCodeSize = reinterpret_cast<uintptr_t>(Exit) - reinterpret_cast<uintptr_t>(Entry);
   }
+  // LogMan::Msg::D("RIP: 0x%lx ; disas %p,%p", HeaderOp->Entry, Entry, Exit);
   return Entry;
 }
 
+static void SleepThread(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread) {
+  --ctx->IdleWaitRefCount;
+  ctx->IdleWaitCV.notify_all();
+
+  // Go to sleep
+  Thread->StartRunning.Wait();
+
+  Thread->State.RunningEvents.Running = true;
+  ++ctx->IdleWaitRefCount;
+  ctx->IdleWaitCV.notify_all();
+}
+
+static void CookieFailure(uint64_t Cookie) {
+  if (Cookie != 0x3132333435363738ULL) {
+    LogMan::Msg::D("Cookie wasn't correct");
+    std::unexpected();
+  }
+  else {
+    LogMan::Msg::D("[JIT] Cookie was correct");
+  }
+}
+
 void JITCore::CreateCustomDispatch(FEXCore::Core::InternalThreadState *Thread) {
+  DispatcherCodeBuffer = AllocateNewCodeBuffer(MAX_DISPATCHER_CODE_SIZE);
+  setNewBuffer(DispatcherCodeBuffer.Ptr, DispatcherCodeBuffer.Size);
+
 // Temp registers
 // rax, rcx, rdx, rsi, r8, r9,
 // r10, r11
@@ -4648,7 +4880,7 @@ void JITCore::CreateCustomDispatch(FEXCore::Core::InternalThreadState *Thread) {
 // 1St Argument: rdi <ThreadState>
 // XMM:
 // All temp
-  DispatchPtr = getCurr<CustomDispatch>();
+  DispatchPtr = getCurr<CPUBackend::AsmDispatch>();
 
   // while (!Thread->State.RunningEvents.ShouldStop.load()) {
   //    Ptr = FindBlock(RIP)
@@ -4668,63 +4900,92 @@ void JITCore::CreateCustomDispatch(FEXCore::Core::InternalThreadState *Thread) {
   //    }
   // }
   // Bunch of exit state stuff
+
+  // x86-64 ABI has the stack aligned when /call/ happens
+  // Which means the destination has a misaligned stack at that point
   push(rbx);
-  push(rbp);
   push(rbp);
   push(r12);
   push(r13);
   push(r14);
   push(r15);
+  sub(rsp, 8);
 
   mov(STATE, rdi);
 
+  // Save this stack pointer so we can cleanly shutdown the emulation with a long jump
+  // regardless of where we were in the stack
+  mov(qword [STATE + offsetof(FEXCore::Core::ThreadState, ReturningStackLocation)], rsp);
+
   Label LoopTop;
-  L(LoopTop);
-
-  mov(r13, Thread->BlockCache->GetPagePointer());
-
-  // Load our RIP
-  mov(rdx, qword [STATE + offsetof(FEXCore::Core::CPUState, rip)]);
-
-  mov(rax, rdx);
-  shr(rax, 12);
-
-  // Load page pointer
-  mov(rdi, qword [r13 + rax * 8]);
-
   Label NoBlock;
-  cmp(rdi, 0);
-  je(NoBlock);
 
-  mov (rax, rdx);
-  and(rax, 0x0FFF);
+  L(LoopTop);
+  AbsoluteLoopTopAddress = getCurr<uint64_t>();
 
-  // Load the block pointer
-  mov(rax, qword [rdi + rax * 8]);
+  {
+    mov(r13, Thread->BlockCache->GetPagePointer());
 
-  cmp(rax, 0);
-  je(NoBlock);
+    // Load our RIP
+    mov(rdx, qword [STATE + offsetof(FEXCore::Core::CPUState, rip)]);
 
-  // Real block if we made it here
-  push(0);
-  call(rax);
-  add(rsp, 8);
+    mov(rax, rdx);
+    mov(rbx, Thread->BlockCache->GetVirtualMemorySize() - 1);
+    and_(rax, rbx);
+    shr(rax, 12);
 
-  Label ExitCheck;
-  L(ExitCheck);
+    // Load page pointer
+    mov(rdi, qword [r13 + rax * 8]);
 
-  cmp(byte [STATE + offsetof(FEXCore::Core::ThreadState, RunningEvents.ShouldStop)], 0);
-  je(LoopTop);
+    cmp(rdi, 0);
+    je(NoBlock);
 
-  pop(r15);
-  pop(r14);
-  pop(r13);
-  pop(r12);
-  pop(rbp);
-  pop(rbp);
-  pop(rbx);
+    mov (rax, rdx);
+    and(rax, 0x0FFF);
 
-  ret();
+    shl(rax, (int)log2(sizeof(FEXCore::BlockCache::BlockCacheEntry)));
+
+    // Load the block pointer
+    mov(rax, qword [rdi + rax]);
+
+    cmp(rax, 0);
+    je(NoBlock);
+
+    // Real block if we made it here
+    call(rax);
+
+    if (CTX->GetGdbServerStatus()) {
+      // If we have a gdb server running then run in a less efficient mode that checks if we need to exit
+      // This happens when single stepping
+      static_assert(sizeof(CTX->Config.RunningMode) == 4, "This is expected to be size of 4");
+      mov(rax, qword [STATE + (offsetof(FEXCore::Core::InternalThreadState, CTX))]);
+
+      // If the value == 0 then branch to the top
+      cmp(dword [rax + (offsetof(FEXCore::Context::Context, Config.RunningMode))], 0);
+      je(LoopTop);
+      // Else we need to pause now
+      jmp(ThreadPauseHandler);
+      ud2();
+    }
+    else {
+      jmp(LoopTop);
+    }
+  }
+
+  {
+    ThreadStopHandlerAddress = getCurr<uint64_t>();
+
+    add(rsp, 8);
+
+    pop(r15);
+    pop(r14);
+    pop(r13);
+    pop(r12);
+    pop(rbp);
+    pop(rbx);
+
+    ret();
+  }
 
   Label FallbackCore;
   // Block creation
@@ -4744,12 +5005,14 @@ void JITCore::CreateCustomDispatch(FEXCore::Core::InternalThreadState *Thread) {
     mov(rdi, reinterpret_cast<uint64_t>(CTX));
     mov(rsi, STATE);
     mov(rax, Ptr.Data);
+
     call(rax);
+
     // RAX contains nulptr or block ptr here
     cmp(rax, 0);
     je(FallbackCore);
     // rdx already contains RIP here
-    jmp(ExitCheck);
+    jmp(LoopTop);
   }
 
   {
@@ -4757,11 +5020,54 @@ void JITCore::CreateCustomDispatch(FEXCore::Core::InternalThreadState *Thread) {
     ud2();
   }
 
+  {
+    // Interpreter fallback helper code
+    InterpreterFallbackHelperAddress = getCurr<void*>();
+    // This will get called so our stack is now misaligned
+    sub(rsp, 8);
+    mov(rdi, STATE);
+    mov(rax, reinterpret_cast<uint64_t>(ThreadState->IntBackend->CompileCode(nullptr, nullptr)));
+
+    call(rax);
+
+    // Adjust the stack to remove the alignment and also the return address
+    // We will have been called from the ASM dispatcher, so we know where we came from
+    add(rsp, 16);
+
+    jmp(LoopTop);
+  }
+
+  {
+    // Signal return handler
+    SignalHandlerReturnAddress = getCurr<uint64_t>();
+
+    ud2();
+  }
+
+  {
+    // Pause handler
+    ThreadPauseHandlerAddress = getCurr<uint64_t>();
+    L(ThreadPauseHandler);
+
+    mov(rdi, reinterpret_cast<uintptr_t>(CTX));
+    mov(rsi, STATE);
+    mov(rax, reinterpret_cast<uint64_t>(SleepThread));
+
+    call(rax);
+
+    PauseReturnInstruction = getCurr<uint64_t>();
+    ud2();
+  }
+
   ready();
-  // CustomDispatchGenerated = true;
+
+  void *Exit = getCurr<void*>();
+  LogMan::Msg::D("Dispatcher : disas %p,%p", DispatchPtr, Exit);
+
+  setNewBuffer(InitialCodeBuffer.Ptr, InitialCodeBuffer.Size);
 }
 
 FEXCore::CPU::CPUBackend *CreateJITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread) {
-  return new JITCore(ctx, Thread);
+  return new JITCore(ctx, Thread, AllocateNewCodeBuffer(JITCore::INITIAL_CODE_SIZE));
 }
 }

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -1,0 +1,161 @@
+#pragma once
+
+#include "Interface/Core/BlockCache.h"
+#include "Interface/Core/BlockSamplingData.h"
+#include "Interface/Core/InternalThreadState.h"
+#include "Interface/IR/Passes/RegisterAllocationPass.h"
+
+#include "Interface/Core/JIT/x86_64/JIT.h"
+#include "Common/MathUtils.h"
+
+#include <xbyak/xbyak.h>
+using namespace Xbyak;
+
+#include <FEXCore/Core/CPUBackend.h>
+#include <FEXCore/IR/IR.h>
+#include <FEXCore/IR/IntrusiveIRList.h>
+
+namespace FEXCore::CPU {
+struct CodeBuffer {
+  uint8_t *Ptr;
+  size_t Size;
+};
+
+CodeBuffer AllocateNewCodeBuffer(size_t Size);
+void FreeCodeBuffer(CodeBuffer Buffer);
+
+}
+
+namespace FEXCore::CPU {
+
+
+// Temp registers
+// rax, rcx, rdx, rsi, r8, r9,
+// r10, r11
+//
+// Callee Saved
+// rbx, rbp, r12, r13, r14, r15
+//
+// 1St Argument: rdi <ThreadState>
+// XMM:
+// All temp
+#define STATE r14
+#define TMP1 rax
+#define TMP2 rcx
+#define TMP3 rdx
+#define TMP4 rdi
+#define TMP5 rbx
+using namespace Xbyak::util;
+const std::array<Xbyak::Reg, 9> RA64 = { rsi, r8, r9, r10, r11, rbp, r12, r13, r15 };
+const std::array<std::pair<Xbyak::Reg, Xbyak::Reg>, 4> RA64Pair = {{ {rsi, r8}, {r9, r10}, {r11, rbp}, {r12, r13} }};
+const std::array<Xbyak::Reg, 11> RAXMM = { xmm0, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm9, xmm10 };
+const std::array<Xbyak::Xmm, 11> RAXMM_x = { xmm0, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm9, xmm10 };
+
+class JITCore final : public CPUBackend, public Xbyak::CodeGenerator {
+public:
+  explicit JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread, CodeBuffer Buffer);
+  ~JITCore() override;
+  std::string GetName() override { return "JIT"; }
+  void *CompileCode(FEXCore::IR::IRListView<true> const *IR, FEXCore::Core::DebugData *DebugData) override;
+
+  void *MapRegion(void* HostPtr, uint64_t, uint64_t) override { return HostPtr; }
+
+  bool NeedsOpDispatch() override { return true; }
+
+  void ClearCache() override;
+
+  static constexpr size_t INITIAL_CODE_SIZE = 1024 * 1024 * 256;
+
+  bool HandleSIGILL(int Signal, void *info, void *ucontext);
+  bool HandleSignalPause(int Signal, void *info, void *ucontext);
+  bool HandleGuestSignal(int Signal, void *info, void *ucontext, SignalDelegator::GuestSigAction *GuestAction, stack_t *GuestStack);
+
+private:
+  FEXCore::Context::Context *CTX;
+  FEXCore::Core::InternalThreadState *ThreadState;
+  FEXCore::IR::IRListView<true> const *CurrentIR;
+  std::unordered_map<IR::OrderedNodeWrapper::NodeOffsetType, Label> JumpTargets;
+
+  std::vector<uint8_t> Stack;
+  bool MemoryDebug = false;
+
+  /**
+   * @name Register Allocation
+   * @{ */
+  constexpr static uint32_t NumGPRs = RA64.size(); // 4 is the minimum required for GPR ops
+  constexpr static uint32_t NumXMMs = RAXMM.size();
+  constexpr static uint32_t NumGPRPairs = RA64Pair.size();
+  constexpr static uint32_t RegisterCount = NumGPRs + NumXMMs + NumGPRPairs;
+  constexpr static uint32_t RegisterClasses = 3;
+
+  constexpr static uint64_t GPRBase = (0ULL << 32);
+  constexpr static uint64_t XMMBase = (1ULL << 32);
+  constexpr static uint64_t GPRPairBase = (2ULL << 32);
+
+  /**  @} */
+
+  constexpr static uint8_t RA_8 = 0;
+  constexpr static uint8_t RA_16 = 1;
+  constexpr static uint8_t RA_32 = 2;
+  constexpr static uint8_t RA_64 = 3;
+  constexpr static uint8_t RA_XMM = 4;
+
+  uint32_t GetPhys(uint32_t Node);
+
+  template<uint8_t RAType>
+  Xbyak::Reg GetSrc(uint32_t Node);
+  template<uint8_t RAType>
+  std::pair<Xbyak::Reg, Xbyak::Reg> GetSrcPair(uint32_t Node);
+
+  template<uint8_t RAType>
+  Xbyak::Reg GetDst(uint32_t Node);
+
+  Xbyak::Xmm GetSrc(uint32_t Node);
+  Xbyak::Xmm GetDst(uint32_t Node);
+
+  void CreateCustomDispatch(FEXCore::Core::InternalThreadState *Thread);
+  IR::RegisterAllocationPass *RAPass;
+
+  void *InterpreterFallbackHelperAddress;
+
+#ifdef BLOCKSTATS
+  bool GetSamplingData {true};
+#endif
+  static constexpr size_t MAX_CODE_SIZE = 1024 * 1024 * 256;
+
+  static constexpr size_t MAX_DISPATCHER_CODE_SIZE = 4096 * 2;
+
+  void EmplaceNewCodeBuffer(CodeBuffer Buffer) {
+    CurrentCodeBuffer = &CodeBuffers.emplace_back(Buffer);
+  }
+
+  // This is the initial code buffer that we will fall back to
+  // In a program without signals and code clearing, we will typically
+  // only have this code buffer
+  CodeBuffer InitialCodeBuffer{};
+  // This is the array of /additional/ code buffers that we may need to allocate
+  // Allocation only occurs when we've hit signals and need to clear code cache
+  // For code safety we can't delete code buffers until outside of all signals
+  std::vector<CodeBuffer> CodeBuffers{};
+
+  // This is the codebuffer that our dispatcher lives in
+  CodeBuffer DispatcherCodeBuffer{};
+  // This is the current code buffer that we are tracking
+  CodeBuffer *CurrentCodeBuffer{};
+
+  uint64_t AbsoluteLoopTopAddress{};
+  uint64_t ThreadStopHandlerAddress{};
+  uint64_t ThreadPauseHandlerAddress{};
+  Label ThreadPauseHandler{};
+
+  uint64_t SignalHandlerReturnAddress{};
+  uint64_t PauseReturnInstruction{};
+
+  uint32_t SignalHandlerRefCounter{};
+
+  void StoreThreadState(int Signal, void *ucontext);
+  void RestoreThreadState(void *ucontext);
+  std::stack<uint64_t> SignalFrames;
+};
+
+}

--- a/External/FEXCore/Source/Interface/Core/SignalDelegator.h
+++ b/External/FEXCore/Source/Interface/Core/SignalDelegator.h
@@ -92,6 +92,10 @@ namespace Core {
 
     constexpr static size_t MAX_SIGNALS {64};
 
+    // Use the last signal just so we are less likely to ever conflict with something that the guest application is using
+    // 64 is used internally by Valgrind
+    constexpr static size_t SIGNAL_FOR_PAUSE {63};
+
   private:
     struct SignalHandler {
       std::atomic<bool> Installed{};
@@ -102,7 +106,7 @@ namespace Core {
       GuestSigAction GuestAction{};
     };
 
-    SignalHandler HostHandlers[MAX_SIGNALS]{};
+    SignalHandler HostHandlers[MAX_SIGNALS + 1]{};
     bool InstallHostThunk(int Signal);
     void UpdateHostThunk(int Signal);
 

--- a/External/FEXCore/Source/Interface/HLE/Syscalls/Stubs.cpp
+++ b/External/FEXCore/Source/Interface/HLE/Syscalls/Stubs.cpp
@@ -38,10 +38,6 @@ namespace FEXCore::HLE {
       SYSCALL_STUB(pause);
     });
 
-    REGISTER_SYSCALL_IMPL(alarm, [](FEXCore::Core::InternalThreadState *Thread, unsigned int seconds) -> uint64_t {
-      SYSCALL_STUB(alarm);
-    });
-
     REGISTER_SYSCALL_IMPL(sendfile, [](FEXCore::Core::InternalThreadState *Thread, int out_fd, int in_fd, off_t *offset, size_t count) -> uint64_t {
       SYSCALL_STUB(sendfile);
     });

--- a/External/FEXCore/Source/Interface/HLE/Syscalls/Timer.cpp
+++ b/External/FEXCore/Source/Interface/HLE/Syscalls/Timer.cpp
@@ -6,6 +6,7 @@
 #include <signal.h>
 #include <sys/time.h>
 #include <time.h>
+#include <unistd.h>
 
 namespace FEXCore::Core {
 struct InternalThreadState;
@@ -14,6 +15,12 @@ struct InternalThreadState;
 namespace FEXCore::HLE {
 
   void RegisterTimer() {
+
+    REGISTER_SYSCALL_IMPL(alarm, [](FEXCore::Core::InternalThreadState *Thread, unsigned int seconds) -> uint64_t {
+      uint64_t Result = ::alarm(seconds);
+      SYSCALL_ERRNO();
+    });
+
     REGISTER_SYSCALL_IMPL(timer_create, [](FEXCore::Core::InternalThreadState *Thread, clockid_t clockid, struct sigevent *sevp, timer_t *timerid) -> uint64_t {
       uint64_t Result = ::timer_create(clockid, sevp, timerid);
       SYSCALL_ERRNO();

--- a/External/FEXCore/include/FEXCore/Core/CPUBackend.h
+++ b/External/FEXCore/include/FEXCore/Core/CPUBackend.h
@@ -12,6 +12,7 @@ namespace IR {
 namespace Core {
   struct DebugData;
   struct ThreadState;
+  struct InternalThreadState;
 }
 
 namespace CPU {
@@ -70,11 +71,16 @@ class LLVMCore;
      */
     virtual bool NeedsOpDispatch() = 0;
 
-    virtual bool HasCustomDispatch() const { return false; }
-
-    virtual void ExecuteCustomDispatch(FEXCore::Core::ThreadState *Thread) {}
+    void ExecuteDispatch(FEXCore::Core::InternalThreadState *Thread) {
+      DispatchPtr(Thread);
+    }
 
     virtual void ClearCache() {}
+
+    using AsmDispatch = __attribute__((naked)) void(*)(FEXCore::Core::InternalThreadState *Thread);
+
+  protected:
+    AsmDispatch DispatchPtr{};
   };
 
 }

--- a/External/FEXCore/include/FEXCore/Core/CoreState.h
+++ b/External/FEXCore/include/FEXCore/Core/CoreState.h
@@ -30,15 +30,22 @@ namespace FEXCore::Core {
 
     struct {
       std::atomic_bool Running {false};
-      std::atomic_bool ShouldStop {false};
-      std::atomic_bool ShouldPause {false};
       std::atomic_bool WaitingToStart {false};
     } RunningEvents;
+
+    /**
+     * @brief Stack location for the CPU backends to return the stack pointer to
+     *
+     * Allows the CPU cores to do a long jump out of their execution and safely shut down
+     */
+    uint64_t ReturningStackLocation{};
 
     FEXCore::HLE::ThreadManagement ThreadManager;
   };
   static_assert(offsetof(ThreadState, State) == 0, "CPUState must be first member in threadstate");
   static_assert(offsetof(ThreadState, State.rip) == 0, "rip must be zero offset in threadstate");
+
+  static_assert(std::is_standard_layout<ThreadState>::value, "This needs to be standard layout");
 
   constexpr uint64_t PAGE_SIZE = 4096;
 

--- a/Source/CommonCore/VMFactory.cpp
+++ b/Source/CommonCore/VMFactory.cpp
@@ -259,7 +259,6 @@ namespace VMFactory {
 
       // 5 = HLT
       if (ExitReason == 5) {
-        ThreadState->RunningEvents.ShouldStop = true;
       }
 
       // 8 = Shutdown. Due to an unhandled error
@@ -267,18 +266,15 @@ namespace VMFactory {
         LogMan::Msg::E("Unhandled VM Fault");
         VM->Debug();
         CopyGuestCPUToHost();
-        ThreadState->RunningEvents.ShouldStop = true;
       }
 
       // 9 = Failed Entry
       if (ExitReason == 9) {
         LogMan::Msg::E("Failed to enter VM due to: 0x%lx", VM->GetFailEntryReason());
-        ThreadState->RunningEvents.ShouldStop = true;
       }
     }
     else {
       LogMan::Msg::E("VM failed to run");
-      ThreadState->RunningEvents.ShouldStop = true;
     }
   }
 

--- a/Source/Tests/ELFLoader.cpp
+++ b/Source/Tests/ELFLoader.cpp
@@ -173,15 +173,10 @@ int main(int argc, char **argv, char **const envp) {
 
   FEXCore::Context::RunUntilExit(CTX);
 
-  LogMan::Msg::D("Reason we left VM: %d", ShutdownReason);
-  bool Result = ShutdownReason == 0;
-
   auto ProgramStatus = FEXCore::Context::GetProgramStatus(CTX);
 
   FEXCore::Context::DestroyContext(CTX);
   FEXCore::SHM::DestroyRegion(SHM);
-
-  LogMan::Msg::D("Managed to load? %s", Result ? "Yes" : "No");
 
   FEX::Config::Shutdown();
 

--- a/Source/Tests/TestHarnessRunner.cpp
+++ b/Source/Tests/TestHarnessRunner.cpp
@@ -89,8 +89,7 @@ int main(int argc, char **argv, char **const envp) {
   if (!Result1)
     return 1;
 
-  while (FEXCore::Context::RunUntilExit(CTX) == FEXCore::Context::ExitReason::EXIT_DEBUG)
-    ;
+  FEXCore::Context::RunUntilExit(CTX);
 
   // Just re-use compare state. It also checks against the expected values in config.
   FEXCore::Core::CPUState State;

--- a/unittests/POSIX/Expected_Output
+++ b/unittests/POSIX/Expected_Output
@@ -1,6 +1,7 @@
 conformance-behavior-timers-2-1.test 0
 conformance-behavior-WIFEXITED-1-1.test 0
 conformance-behavior-WIFEXITED-1-2.test 0
+conformance-behavior-WIFEXITED-1-3.test 0
 conformance-definitions-errno_h-3-2.test 0
 conformance-definitions-errno_h-4-1.test 0
 conformance-definitions-signal_h-13-1.test 0
@@ -28,6 +29,7 @@ conformance-interfaces-clock_nanosleep-1-1.test 0
 conformance-interfaces-clock_nanosleep-13-1.test 0
 conformance-interfaces-clock_nanosleep-1-3.test 0
 conformance-interfaces-clock_nanosleep-1-4.test 0
+conformance-interfaces-clock_nanosleep-1-5.test 0
 conformance-interfaces-clock_nanosleep-2-1.test 0
 conformance-interfaces-clock_nanosleep-2-2.test 0
 conformance-interfaces-clock_nanosleep-2-3.test 0
@@ -97,6 +99,7 @@ conformance-interfaces-nanosleep-1-2.test 0
 conformance-interfaces-nanosleep-1-3.test 0
 conformance-interfaces-nanosleep-2-1.test 0
 conformance-interfaces-nanosleep-3-1.test 0
+conformance-interfaces-nanosleep-3-2.test 0
 conformance-interfaces-nanosleep-5-1.test 0
 conformance-interfaces-nanosleep-5-2.test 0
 conformance-interfaces-nanosleep-6-1.test 0

--- a/unittests/POSIX/Known_Failures
+++ b/unittests/POSIX/Known_Failures
@@ -6,15 +6,12 @@ conformance-interfaces-clock_settime-17-1.test
 conformance-interfaces-clock_settime-17-2.test
 conformance-interfaces-clock_settime-20-1.test
 conformance-interfaces-clock_settime-6-1.test
-conformance-interfaces-kill-1-1.test
-conformance-interfaces-killpg-1-1.test
 conformance-interfaces-mlockall-8-1.test
 conformance-interfaces-munmap-2-1.test
 conformance-interfaces-nanosleep-10000-1.test
 conformance-interfaces-nanosleep-5-1.test
 conformance-interfaces-nanosleep-6-1.test
 conformance-interfaces-raise-1-1.test
-conformance-interfaces-raise-4-1.test
 conformance-interfaces-sigpending-1-2.test
 conformance-interfaces-sigpending-1-3.test
 conformance-interfaces-sigprocmask-6-1.test
@@ -51,7 +48,6 @@ conformance-interfaces-clock_nanosleep-10-1.test # uses sigabort
 conformance-interfaces-clock_nanosleep-9-1.test # uses sigabort
 conformance-interfaces-kill-1-2.test # uses rt_sigtimedwait
 conformance-interfaces-killpg-1-2.test # uses getpgid, setpgid
-conformance-interfaces-nanosleep-3-1.test # uses sigabort
 conformance-interfaces-nanosleep-5-2.test # uses sigabort
 conformance-interfaces-nanosleep-7-1.test # uses sigabort
 conformance-interfaces-nanosleep-7-2.test # uses sigabort


### PR DESCRIPTION
This requires implementing custom ASM dispatchers for the interpreter
side of things so it works correctly.
Allows all of our CPU backends to safely support signaling.
This is a bit of a nightmare change and requires rethinking logic about
debugging in some instances.