### PR TITLE
Binfmt_misc support

### DIFF
--- a/Source/Tests/CMakeLists.txt
+++ b/Source/Tests/CMakeLists.txt
@@ -22,6 +22,22 @@ install(TARGETS ${NAME}
     DESTINATION bin
     COMPONENT runtime)
 
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+  add_custom_target(binfmt_misc
+    COMMAND ${CMAKE_COMMAND} -E
+    echo "Attempting to remove FEX-x86_64 misc prior to install. Ignore permission denied"
+    COMMAND ${CMAKE_COMMAND} -E
+    echo -1 > /proc/sys/fs/binfmt_misc/FEX-x86_64 || (exit 0)
+    COMMAND ${CMAKE_COMMAND} -E
+    echo "Attempting to install FEX-x86_64 misc now."
+    COMMAND ${CMAKE_COMMAND} -E
+      echo
+      ':FEX-x86_64:M:0:\\x7fELF\\x02\\x01\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x02\\x00\\x3e\\x00:\\xff\\xff\\xff\\xff\\xff\\xfe\\xfe\\x00\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xfe\\xff\\xff\\xff:${CMAKE_INSTALL_PREFIX}/bin/${NAME}:CF' > /proc/sys/fs/binfmt_misc/register
+    COMMAND ${CMAKE_COMMAND} -E
+    echo "binfmt_misc FEX installed"
+      )
+endif()
+
 set(NAME TestHarness)
 set(SRCS TestHarness.cpp)
 

--- a/Source/Tests/CMakeLists.txt
+++ b/Source/Tests/CMakeLists.txt
@@ -17,6 +17,11 @@ target_include_directories(${NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/External/
 
 target_link_libraries(${NAME} ${LIBS})
 
+install(TARGETS ${NAME}
+  RUNTIME
+    DESTINATION bin
+    COMPONENT runtime)
+
 set(NAME TestHarness)
 set(SRCS TestHarness.cpp)
 

--- a/Source/Tests/CMakeLists.txt
+++ b/Source/Tests/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 
 
 set(LIBS FEXCore Common CommonCore SonicUtils pthread)
-set(NAME ELFLoader)
+set(NAME FEXLoader)
 set(SRCS ELFLoader.cpp)
 
 add_executable(${NAME} ${SRCS})


### PR DESCRIPTION
This renames ELFLoader to FEXLoader to come more in line with what an installed target should be (Otherwise what would a random ELFLoader be in /usr/bin?). Letting people know that this is FEX.
Adds a new cmake install target for installing FEXLoader.
Also adds a new cmake custom target for installing the binfmt_misc registry `sudo ninja binfmt_misc`

This just ends up executing the command 
`echo ":FEX-x86_64:M:0:\x7fELF\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x3e\x00:\xff\xff\xff\xff\xff\xfe\xfe\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff:/usr/bin/FEXLoader:CF" > /proc/sys/fs/binfmt_misc/register`
Which is all that is required for registering with binfmt_misc