### PR TITLE
Has /proc/cpuinfo generated from CPUID

### DIFF
--- a/External/FEXCore/CMakeLists.txt
+++ b/External/FEXCore/CMakeLists.txt
@@ -41,6 +41,27 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 include_directories(${CMAKE_SOURCE_DIR}/External/SonicUtils/include/SonicUtils)
 
+# Find our git hash
+find_package(Git)
+
+set(GIT_SHORT_HASH "Unknown")
+
+if (GIT_FOUND)
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    OUTPUT_VARIABLE GIT_SHORT_HASH
+    ERROR_QUIET
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+endif()
+
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/git_version.h.in
+  ${CMAKE_BINARY_DIR}/generated/git_version.h)
+
+include_directories(${CMAKE_BINARY_DIR}/generated)
+
 add_subdirectory(Source/)
 
 install (DIRECTORY include/FEXCore ${CMAKE_BINARY_DIR}/include/FEXCore

--- a/External/FEXCore/Source/Interface/Core/CPUID.cpp
+++ b/External/FEXCore/Source/Interface/Core/CPUID.cpp
@@ -1,4 +1,7 @@
 #include "Interface/Core/CPUID.h"
+#include "git_version.h"
+
+#include <cstring>
 
 namespace FEXCore {
 //#define CPUID_AMD
@@ -8,15 +11,15 @@ CPUIDEmu::FunctionResults CPUIDEmu::Function_0h() {
 
   // EBX, EDX, ECX become the manufacturer id string
 #ifdef CPUID_AMD
-  Res.Res[0] = 0x0D; // Let's say we are a Zen+
-  Res.Res[1] = CPUID_VENDOR_AMD1;
-  Res.Res[2] = CPUID_VENDOR_AMD2;
-  Res.Res[3] = CPUID_VENDOR_AMD3;
+  Res.eax = 0x0D; // Let's say we are a Zen+
+  Res.ebx = CPUID_VENDOR_AMD1;
+  Res.edx = CPUID_VENDOR_AMD2;
+  Res.ecx = CPUID_VENDOR_AMD3;
 #else
-  Res.Res[0] = 0x16; // Let's say we are a Skylake
-  Res.Res[1] = CPUID_VENDOR_INTEL1;
-  Res.Res[2] = CPUID_VENDOR_INTEL2;
-  Res.Res[3] = CPUID_VENDOR_INTEL3;
+  Res.eax = 0x16; // Let's say we are a Skylake
+  Res.ebx = CPUID_VENDOR_INTEL1;
+  Res.edx = CPUID_VENDOR_INTEL2;
+  Res.ecx = CPUID_VENDOR_INTEL3;
 #endif
   return Res;
 }
@@ -25,30 +28,90 @@ CPUIDEmu::FunctionResults CPUIDEmu::Function_0h() {
 CPUIDEmu::FunctionResults CPUIDEmu::Function_01h() {
   CPUIDEmu::FunctionResults Res{};
 
-  Res.Res[0] = 0 | // Stepping
+  Res.eax = 0 | // Stepping
     (0 << 4) | // Model
     (0 << 8) | // Family ID
     (0 << 12) | // Processor type
     (0 << 16) | // Extended model ID
     (0 << 20); // Extended family ID
-  Res.Res[1] = 0 | // Brand index
+  Res.ebx = 0 | // Brand index
     (8 << 8) | // Cache line size in bytes
     (8 << 16) | // Number of addressable IDs for the logical cores in the physical CPU
     (0 << 24); // Local APIC ID
-  Res.Res[2] = ~0U; // Let's say we support every feature for fun
-  Res.Res[3] = ~0U; // Let's say we support every feature for fun
+  Res.ecx =
+    (1 <<  0) | // SSE3
+    (0 <<  1) | // PCLMULQDQ
+    (1 <<  2) | // DS area supports 64bit layout
+    (1 <<  3) | // MWait
+    (1 <<  4) | // DS-CPL
+    (0 <<  5) | // VMX
+    (0 <<  6) | // SMX
+    (0 <<  7) | // Intel SpeedStep
+    (0 <<  8) | // Thermal Monitor 2
+    (0 <<  9) | // SSSE3
+    (0 << 10) | // L1 context ID
+    (0 << 11) | // Silicon debug
+    (0 << 12) | // FMA3
+    (1 << 13) | // CMPXCHG16B
+    (0 << 14) | // xTPR update control
+    (0 << 15) | // Perfmon and debug capability
+    (0 << 16) | // Reserved
+    (0 << 17) | // Process-context identifiers
+    (1 << 18) | // Prefetching from memory mapped device
+    (0 << 19) | // SSE4.1
+    (0 << 20) | // SSE4.2
+    (0 << 21) | // X2APIC
+    (1 << 22) | // MOVBE
+    (1 << 23) | // POPCNT
+    (0 << 24) | // APIC TSC-Deadline
+    (0 << 25) | // AES
+    (0 << 26) | // XSAVE
+    (0 << 27) | // OSXSAVE
+    (0 << 28) | // AVX
+    (0 << 29) | // RDRAND
+    (0 << 30) | // RDRAND
+    (0 << 31);  // Always returns zero
 
-  Res.Res[3]  &= ~(
-      (1 << 1) |  // Remove CLMUL
-      (3 << 26) | // Let's say that XSAVE isn't enabled by the OS. Prevents glibc from using XSAVE/XGETBV
-      (1 << 9)  | // Remove SSSE3
-      (1 << 19) | // Remove SSE4.1
-      (1 << 20) | // Remove SSE4.2
-      (1 << 25) | // Remove AES
-      (1 << 28) | // Remove AVX
-      (1 << 30)   // Remove RDRAND
-      );
+  Res.edx =
+    (1 <<  0) | // FPU
+    (1 <<  1) | // Virtual 8086 mode enhancements
+    (0 <<  2) | // Debugging extensions
+    (0 <<  3) | // Page size extension
+    (1 <<  4) | // RDTSC supported
+    (1 <<  5) | // MSR supported
+    (1 <<  6) | // PAE
+    (1 <<  7) | // Machine Check exception
+    (1 <<  8) | // CMPXCHG8B
+    (1 <<  9) | // APIC on-chip
+    (0 << 10) | // Reserved
+    (1 << 11) | // SYSENTER/SYSEXIT
+    (1 << 12) | // Memory Type Range registers, MTRRs are supported
+    (1 << 13) | // Page Global bit
+    (1 << 14) | // Machine Check architecture
+    (1 << 15) | // CMOV
+    (1 << 16) | // Page Attribute Table
+    (1 << 17) | // 36bit page size extension
+    (0 << 18) | // Processor serial number
+    (0 << 19) | // CLFLUSH
+    (0 << 20) | // Reserved
+    (0 << 21) | // Debug store
+    (0 << 22) | // Thermal monitor and software controled clock
+    (1 << 23) | // MMX
+    (1 << 24) | // FXSAVE/FXRSTOR
+    (1 << 25) | // SSE
+    (1 << 26) | // SSE
+    (1 << 27) | // Self Snoop
+    (1 << 28) | // Max APIC IDs reserved field is valid
+    (1 << 29) | // Thermal monitor
+    (0 << 30) | // Reserved
+    (1 << 31);  // Pending break enable
+  return Res;
+}
 
+CPUIDEmu::FunctionResults CPUIDEmu::Function_06h() {
+  CPUIDEmu::FunctionResults Res{};
+  Res.eax = (1 << 2); // Always running APIC
+  Res.ecx = (0 << 3); // Intel performance energy bias preference (EPB)
   return Res;
 }
 
@@ -56,58 +119,229 @@ CPUIDEmu::FunctionResults CPUIDEmu::Function_07h() {
   CPUIDEmu::FunctionResults Res{};
 
   // Number of subfunctions
-  Res.Res[0] = 0x0;
-  Res.Res[1] =
-    (1 << 0) | // FS/GS support
-    (1 << 5) | // AVX2 support
-    (1 << 7)   // SMEP support
-    ;
-  Res.Res[2] = ~0U;
-  Res.Res[3] = ~0U;
+  Res.eax = 0x0;
+  Res.ebx =
+    (1 <<  0) | // FS/GS support
+    (0 <<  1) | // TSC adjust MSR
+    (0 <<  2) | // SGX
+    (0 <<  3) | // BMI1
+    (0 <<  4) | // Intel Hardware Lock Elison
+    (0 <<  5) | // AVX2 support
+    (1 <<  6) | // FPU data pointer updated only on exception
+    (1 <<  7) | // SMEP support
+    (0 <<  8) | // BMI2
+    (0 <<  9) | // Enhanced REP MOVSB/STOSB
+    (1 << 10) | // INVPCID for system software control of process-context
+    (0 << 11) | // Restricted transactional memory
+    (0 << 12) | // Intel resource directory technology Monitoring
+    (1 << 13) | // Deprecates FPU CS and DS
+    (0 << 14) | // Intel MPX
+    (0 << 15) | // Intel Resource Directory Technology Allocation
+    (0 << 16) | // Reserved
+    (0 << 17) | // Reserved
+    (0 << 18) | // RDSEED
+    (0 << 19) | // ADCX and ADOX instructions
+    (0 << 20) | // SMAP Supervisor mode access prevention and CLAC/STAC instructions
+    (0 << 21) | // Reserved
+    (0 << 22) | // Reserved
+    (0 << 23) | // CLFLUSHOPT instruction
+    (0 << 24) | // CLWB instruction
+    (0 << 25) | // Intel processor trace
+    (0 << 26) | // Reserved
+    (0 << 27) | // Reserved
+    (0 << 28) | // Reserved
+    (0 << 29) | // SHA instructions
+    (0 << 30) | // Reserved
+    (0 << 31);  // Reserved
 
-  Res.Res[2] &= ~(
-    (1 << 2)  | // Remove AVX5124VNNIW
-    (1 << 3)  | // Remove AVX5124FMAPS
-    (1 << 8)  | // Remove AVX512VP2INTERSECT
-    (1 << 20)   // we don't support CET indirect branch tracking
-    );
+  Res.ecx =
+    (1 <<  0) | // PREFETCHWT1
+    (0 <<  1) | // AVX512VBMI
+    (0 <<  2) | // Usermode instruction prevention
+    (0 <<  3) | // Protection keys for user mode pages
+    (1 <<  4) | // OS protection keys
+    (0 <<  5) | // waitpkg
+    (0 <<  6) | // AVX512_VBMI2
+    (0 <<  7) | // CET shadow stack
+    (0 <<  8) | // GFNI
+    (0 <<  9) | // VAES
+    (0 << 10) | // VPCLMULQDQ
+    (0 << 11) | // AVX512_VNNI
+    (0 << 12) | // AVX512_BITALG
+    (0 << 13) | // Intel Total Memory Encryption
+    (0 << 14) | // AVX512_VPOPCNTDQ
+    (0 << 15) | // Reserved
+    (0 << 16) | // 5 Level page tables
+    (0 << 17) | // MPX MAWAU
+    (0 << 18) | // MPX MAWAU
+    (0 << 19) | // MPX MAWAU
+    (0 << 20) | // MPX MAWAU
+    (0 << 21) | // MPX MAWAU
+    (0 << 22) | // RDPID Read Processor ID
+    (0 << 23) | // Reserved
+    (0 << 24) | // Reserved
+    (0 << 25) | // CLDEMOTE
+    (0 << 26) | // Reserved
+    (0 << 27) | // MOVDIRI
+    (0 << 28) | // MOVDIR64B
+    (0 << 29) | // Reserved
+    (0 << 30) | // SGX Launch configuration
+    (0 << 31);  // Reserved
 
-  Res.Res[3] &= ~(
-      (1 << 1)  | // Remove AVX512VBMI
-      (1 << 6)  | // Remove AVX512VBMI2
-      (1 << 7)  | // we don't support CET shadow stack features
-      (1 << 11) | // Remove AVX512VNNI
-      (1 << 12) | // Remove AVX512BITALG
-      (1 << 14)   // Remove AVX512VPOPCNTDQ
-      );
+  Res.edx =
+    (0 <<  0) | // Reserved
+    (0 <<  1) | // Reserved
+    (0 <<  2) | // AVX512_4VNNIW
+    (0 <<  3) | // AVX512_4FMAPS
+    (0 <<  4) | // Fast Short Rep Mov
+    (0 <<  5) | // Reserved
+    (0 <<  6) | // Reserved
+    (0 <<  7) | // Reserved
+    (0 <<  8) | // AVX512_VP2INTERSECT
+    (0 <<  9) | // Reserved
+    (0 << 10) | // VERW clears CPU buffers
+    (0 << 11) | // Reserved
+    (0 << 12) | // Reserved
+    (0 << 13) | // Reserved
+    (0 << 14) | // SERIALIZE instruction
+    (0 << 15) | // Reserved
+    (0 << 16) | // Reserved
+    (0 << 17) | // Reserved
+    (0 << 18) | // Intel PCONFIG
+    (0 << 19) | // Intel Architectural LBR
+    (0 << 20) | // Intel CET
+    (0 << 21) | // Reserved
+    (0 << 22) | // Reserved
+    (0 << 23) | // Reserved
+    (0 << 24) | // Reserved
+    (0 << 25) | // Reserved
+    (0 << 26) | // Reserved
+    (0 << 27) | // Reserved
+    (0 << 28) | // L1D Flush
+    (0 << 29) | // Arch capabilities
+    (0 << 30) | // Reserved
+    (0 << 31);  // Reserved
+
   return Res;
 }
 
 // Highest extended function implemented
 CPUIDEmu::FunctionResults CPUIDEmu::Function_8000_0000h() {
   CPUIDEmu::FunctionResults Res{};
-  Res.Res[0] = 0x8000001F;
+  Res.eax = 0x8000001F;
   return Res;
 }
 
 // Extended processor and feature bits
 CPUIDEmu::FunctionResults CPUIDEmu::Function_8000_0001h() {
   CPUIDEmu::FunctionResults Res{};
-  Res.Res[2] = ~0U; // Let's say we support every feature for fun
-  Res.Res[3] = ~0U; // Let's say we support every feature for fun
 
-  Res.Res[3] &= ~(
-    (1 << 6)  | // Remove SSE4a
-    (1 << 11) | // Remove XOP
-    (1 << 16)   // Remove FMA4
-    );
+  Res.eax = 0 | // Stepping
+    (0 << 4) | // Model
+    (0 << 8) | // Family ID
+    (0 << 12) | // Processor type
+    (0 << 16) | // Extended model ID
+    (0 << 20); // Extended family ID
+
+  Res.ecx =
+    (1 <<  0) | // LAHF/SAHF
+    (1 <<  1) | // 0 = Single core product, 1 = multi core product
+    (0 <<  2) | // SVM
+    (1 <<  3) | // Extended APIC register space
+    (0 <<  4) | // LOCK MOV CR0 means MOV CR8
+    (1 <<  5) | // ABM instructions
+    (0 <<  6) | // SSE4a
+    (0 <<  7) | // Misaligned SSE mode
+    (1 <<  8) | // PREFETCHW
+    (0 <<  9) | // OS visible workaround support
+    (0 << 10) | // Instruction based sampling support
+    (0 << 11) | // XOP
+    (0 << 12) | // SKINIT
+    (0 << 13) | // Watchdog timer support
+    (0 << 14) | // Reserved
+    (0 << 15) | // Lightweight profiling support
+    (0 << 16) | // FMA4
+    (1 << 17) | // Translation cache extension
+    (0 << 18) | // Reserved
+    (0 << 19) | // Reserved
+    (0 << 20) | // Reserved
+    (0 << 21) | // Reserved
+    (1 << 22) | // Topology extensions support
+    (1 << 23) | // Core performance counter extensions
+    (1 << 24) | // NB performance counter extensions
+    (0 << 25) | // Reserved
+    (0 << 26) | // Data breakpoints extensions
+    (1 << 27) | // Performance TSC
+    (1 << 28) | // L2 perf counter extensions
+    (0 << 29) | // Reserved
+    (0 << 30) | // Reserved
+    (0 << 31);  // Reserved
+
+  Res.edx =
+    (1 <<  0) | // FPU
+    (1 <<  1) | // Virtual mode extensions
+    (1 <<  2) | // Debugging extensions
+    (1 <<  3) | // Page size extensions
+    (1 <<  4) | // TSC
+    (1 <<  5) | // MSR support
+    (1 <<  6) | // PAE
+    (1 <<  7) | // Machine Check Exception
+    (1 <<  8) | // CMPXCHG8B
+    (1 <<  9) | // APIC
+    (0 << 10) | // Reserved
+    (1 << 11) | // SYSCALL/SYSRET
+    (1 << 12) | // MTRR
+    (1 << 13) | // Page global extension
+    (1 << 14) | // Machine Check architecture
+    (1 << 15) | // CMOV
+    (1 << 16) | // Page attribute table
+    (1 << 17) | // Page-size extensions
+    (0 << 18) | // Reserved
+    (0 << 19) | // Reserved
+    (1 << 20) | // NX
+    (0 << 21) | // Reserved
+    (1 << 22) | // MMXExt
+    (1 << 23) | // MMX
+    (1 << 24) | // FXSAVE/FXRSTOR
+    (1 << 25) | // FXSAVE/FXRSTOR Optimizations
+    (1 << 26) | // 1 gigabit pages
+    (0 << 27) | // RDTSCP
+    (0 << 28) | // Reserved
+    (1 << 29) | // Long Mode
+    (0 << 30) | // 3DNow! Extensions
+    (0 << 31);  // 3DNow!
+  return Res;
+}
+
+constexpr char ProcessorBrand[48] = {
+  "FEX-"
+  GIT_SHORT_HASH
+  "\0"
+};
+
+//Processor brand string
+CPUIDEmu::FunctionResults CPUIDEmu::Function_8000_0002h() {
+  CPUIDEmu::FunctionResults Res{};
+  memcpy(&Res, &ProcessorBrand[0], sizeof(CPUIDEmu::FunctionResults));
+  return Res;
+}
+
+CPUIDEmu::FunctionResults CPUIDEmu::Function_8000_0003h() {
+  CPUIDEmu::FunctionResults Res{};
+  memcpy(&Res, &ProcessorBrand[16], sizeof(CPUIDEmu::FunctionResults));
+  return Res;
+}
+
+CPUIDEmu::FunctionResults CPUIDEmu::Function_8000_0004h() {
+  CPUIDEmu::FunctionResults Res{};
+  memcpy(&Res, &ProcessorBrand[32], sizeof(CPUIDEmu::FunctionResults));
   return Res;
 }
 
 // Advanced power management
 CPUIDEmu::FunctionResults CPUIDEmu::Function_8000_0007h() {
   CPUIDEmu::FunctionResults Res{};
-  Res.Res[0] = (1 << 2); // APIC timer not affected by p-state
+  Res.eax = (1 << 2); // APIC timer not affected by p-state
   return Res;
 }
 
@@ -128,7 +362,7 @@ void CPUIDEmu::Init() {
   // Monitor/mwait
   RegisterFunction(5, std::bind(&CPUIDEmu::Function_Reserved, this));
   // Thermal and power management
-  RegisterFunction(6, std::bind(&CPUIDEmu::Function_Reserved, this));
+  RegisterFunction(6, std::bind(&CPUIDEmu::Function_06h, this));
   // Extended feature flags
   RegisterFunction(7, std::bind(&CPUIDEmu::Function_07h, this));
   // Reserved
@@ -172,11 +406,11 @@ void CPUIDEmu::Init() {
   // Processor vendor
   RegisterFunction(0x8000'0001, std::bind(&CPUIDEmu::Function_8000_0001h, this));
   // Processor brand string
-  RegisterFunction(0x8000'0002, std::bind(&CPUIDEmu::Function_Reserved, this));
+  RegisterFunction(0x8000'0002, std::bind(&CPUIDEmu::Function_8000_0002h, this));
   // Processor brand string continued
-  RegisterFunction(0x8000'0003, std::bind(&CPUIDEmu::Function_Reserved, this));
+  RegisterFunction(0x8000'0003, std::bind(&CPUIDEmu::Function_8000_0003h, this));
   // Processor brand string continued
-  RegisterFunction(0x8000'0004, std::bind(&CPUIDEmu::Function_Reserved, this));
+  RegisterFunction(0x8000'0004, std::bind(&CPUIDEmu::Function_8000_0004h, this));
   // L1 Cache and TLB identifiers
   RegisterFunction(0x8000'0005, std::bind(&CPUIDEmu::Function_Reserved, this));
   // L2 Cache identifiers
@@ -216,6 +450,9 @@ void CPUIDEmu::Init() {
   RegisterFunction(0x8000'001D, std::bind(&CPUIDEmu::Function_Reserved, this));
   // Extended APIC ID
   RegisterFunction(0x8000'001E, std::bind(&CPUIDEmu::Function_Reserved, this));
+  // AMD Secure Encryption
+  RegisterFunction(0x8000'001F, std::bind(&CPUIDEmu::Function_Reserved, this));
+
 }
 }
 

--- a/External/FEXCore/Source/Interface/Core/CPUID.h
+++ b/External/FEXCore/Source/Interface/Core/CPUID.h
@@ -20,8 +20,7 @@ public:
   void Init();
 
   struct FunctionResults {
-    // Results in registers EAX, EBX, EDX, ECX respectively
-    uint32_t Res[4];
+    uint32_t eax, ebx, ecx, edx;
   };
 
   FunctionResults RunFunction(uint32_t Function) {
@@ -40,9 +39,13 @@ private:
   // Functions
   FunctionResults Function_0h();
   FunctionResults Function_01h();
+  FunctionResults Function_06h();
   FunctionResults Function_07h();
   FunctionResults Function_8000_0000h();
   FunctionResults Function_8000_0001h();
+  FunctionResults Function_8000_0002h();
+  FunctionResults Function_8000_0003h();
+  FunctionResults Function_8000_0004h();
   FunctionResults Function_8000_0007h();
 
   FunctionResults Function_Reserved();

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -268,7 +268,7 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
             uint64_t Arg = *GetSrc<uint64_t*>(Op->Header.Args[0]);
 
             auto Results = CTX->CPUID.RunFunction(Arg);
-            memcpy(DstPtr, &Results.Res, sizeof(uint32_t) * 4);
+            memcpy(DstPtr, &Results, sizeof(uint32_t) * 4);
             break;
           }
           case IR::OP_PRINT: {

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -1455,8 +1455,8 @@ void OpDispatchBuilder::CPUIDOp(OpcodeArgs) {
 
   _StoreContext(GPRClass, GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RAX]), _Bfe(32, 0,  Result_Lower));
   _StoreContext(GPRClass, GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RBX]), _Bfe(32, 32, Result_Lower));
-  _StoreContext(GPRClass, GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RDX]), _Bfe(32, 0,  Result_Upper));
-  _StoreContext(GPRClass, GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RCX]), _Bfe(32, 32, Result_Upper));
+  _StoreContext(GPRClass, GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RDX]), _Bfe(32, 32, Result_Upper));
+  _StoreContext(GPRClass, GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RCX]), _Bfe(32, 0,  Result_Upper));
 }
 
 template<bool SHL1Bit>

--- a/External/FEXCore/Source/Interface/HLE/EmulatedFiles/EmulatedFiles.cpp
+++ b/External/FEXCore/Source/Interface/HLE/EmulatedFiles/EmulatedFiles.cpp
@@ -11,6 +11,568 @@ using string = std::string;
 
 namespace FEXCore::EmulatedFile {
 
+  std::string GenerateCPUInfo(FEXCore::Context::Context *ctx, uint32_t CPUCores) {
+    std::ostringstream cpu_stream{};
+    auto res_0 = ctx->CPUID.RunFunction(0);
+    auto res_1 = ctx->CPUID.RunFunction(1);
+    auto res_6 = ctx->CPUID.RunFunction(6);
+    auto res_7 = ctx->CPUID.RunFunction(7);
+    auto res_10 = ctx->CPUID.RunFunction(0x10);
+
+    auto res_8000_0001 = ctx->CPUID.RunFunction(0x8000'0001);
+    auto res_8000_0002 = ctx->CPUID.RunFunction(0x8000'0002);
+    auto res_8000_0003 = ctx->CPUID.RunFunction(0x8000'0003);
+    auto res_8000_0004 = ctx->CPUID.RunFunction(0x8000'0004);
+    auto res_8000_0007 = ctx->CPUID.RunFunction(0x8000'0007);
+    auto res_8000_0008 = ctx->CPUID.RunFunction(0x8000'0008);
+    auto res_8000_000a = ctx->CPUID.RunFunction(0x8000'000a);
+    auto res_8000_001f = ctx->CPUID.RunFunction(0x8000'001f);
+
+    union VendorID {
+      struct {
+        uint32_t id;
+        char Str[13];
+      };
+      struct {
+        FEXCore::CPUIDEmu::FunctionResults cpuid;
+        uint8_t null;
+      };
+    };
+
+    union ModelName {
+      struct {
+        char Str[49];
+      };
+      struct {
+        FEXCore::CPUIDEmu::FunctionResults cpuid_2;
+        FEXCore::CPUIDEmu::FunctionResults cpuid_3;
+        FEXCore::CPUIDEmu::FunctionResults cpuid_4;
+        uint8_t null;
+      };
+    };
+
+    union Info {
+      FEXCore::CPUIDEmu::FunctionResults cpuid;
+      struct {
+        unsigned Stepping   : 4;
+        unsigned Model      : 4;
+        unsigned FamilyID   : 4;
+        unsigned Type       : 4;
+        unsigned ExModelID  : 4;
+        unsigned ExFamilyID : 8;
+        unsigned : 4;
+      };
+    };
+
+    VendorID vendorid {};
+    vendorid.cpuid = {res_0.eax, res_0.ebx, res_0.edx, res_0.ecx};
+    vendorid.null = 0;
+
+    ModelName modelname {};
+    modelname.cpuid_2 = res_8000_0002;
+    modelname.cpuid_3 = res_8000_0003;
+    modelname.cpuid_4 = res_8000_0004;
+    modelname.null = 0;
+
+    Info info {res_1};
+
+    uint32_t Family = info.FamilyID + (info.FamilyID == 0xF ? info.ExFamilyID : 0);
+    for (int i = 0; i < CPUCores; ++i) {
+      cpu_stream << "processor       : " << i << std::endl;
+      cpu_stream << "vendor_id       : " << vendorid.Str << std::endl;
+      cpu_stream << "cpu family      : " << Family  << std::endl;
+      cpu_stream << "model           : " << (info.Model + (info.FamilyID >= 6 ? (info.ExModelID << 4) : 0)) << std::endl;
+      cpu_stream << "model name      : " << modelname.Str << std::endl;
+      cpu_stream << "stepping        : " << info.Stepping << std::endl;
+      cpu_stream << "microcode       : 0x0" << std::endl;
+      cpu_stream << "cpu MHz         : 3000" << std::endl;
+      cpu_stream << "cache size      : 512 KB" << std::endl;
+      cpu_stream << "physical id     : " << i << std::endl;
+      cpu_stream << "siblings        : " << CPUCores << std::endl;
+      cpu_stream << "core id         : " << i << std::endl;
+      cpu_stream << "cpu cores       : " << CPUCores << std::endl;
+      cpu_stream << "apicid          : " << i << std::endl;
+      cpu_stream << "initial apicid  : " << i << std::endl;
+      cpu_stream << "fpu             : " << (res_1.edx & (1 << 0) ? "yes" : "no") << std::endl;
+      cpu_stream << "fpu_exception   : " << (res_1.edx & (1 << 0) ? "yes" : "no") << std::endl;
+      cpu_stream << "cpuid level     : " << vendorid.id << std::endl;
+      cpu_stream << "wp              : yes" << std::endl;
+      cpu_stream << "flags           : ";
+#define FLAG(flag, name) if (flag) { cpu_stream << name << " "; }
+      FLAG(res_1.edx & (1 << 0), "fpu")
+      FLAG(res_1.edx & (1 << 1), "vme")
+      FLAG(res_1.edx & (1 << 2), "de")
+      FLAG(res_1.edx & (1 << 3), "pse")
+      FLAG(res_1.edx & (1 << 4), "tsc")
+      FLAG(res_1.edx & (1 << 5), "msr")
+      FLAG(res_1.edx & (1 << 6), "pae")
+      FLAG(res_1.edx & (1 << 7), "mce")
+      FLAG(res_1.edx & (1 << 8), "cx8")
+      FLAG(res_1.edx & (1 << 9), "apic")
+      FLAG(res_1.edx & (1 << 11), "sep")
+      FLAG(res_1.edx & (1 << 12), "mtrr")
+      FLAG(res_1.edx & (1 << 13), "pge")
+      FLAG(res_1.edx & (1 << 14), "mca")
+      FLAG(res_1.edx & (1 << 15), "cmov")
+      FLAG(res_1.edx & (1 << 16), "pat")
+      FLAG(res_1.edx & (1 << 17), "pse36")
+      FLAG(res_1.edx & (1 << 18), "pn")
+      FLAG(res_1.edx & (1 << 19), "clflush")
+      FLAG(res_1.edx & (1 << 21), "ds") // XXX
+      FLAG(res_1.edx & (1 << 22), "acpi") // XXX
+      FLAG(res_1.edx & (1 << 23), "mmx")
+      FLAG(res_1.edx & (1 << 24), "fxsr")
+      FLAG(res_1.edx & (1 << 25), "sse")
+      FLAG(res_1.edx & (1 << 26), "sse2")
+      FLAG(res_1.edx & (1 << 27), "ss")
+      FLAG(res_1.edx & (1 << 28), "ht")
+      FLAG(res_1.edx & (1 << 29), "tm")
+      FLAG(res_1.edx & (1 << 30), "ia64")
+      FLAG(res_1.edx & (1 << 31), "pbe")
+
+      FLAG(res_8000_0001.edx & (1 << 11),
+        "syscall")
+      FLAG(res_8000_0001.edx & (1 << 19),
+        "mp")
+      FLAG(res_8000_0001.edx & (1 << 20),
+        "nx")
+      FLAG(res_8000_0001.edx & (1 << 22),
+        "mmxext")
+      FLAG(res_8000_0001.edx & (1 << 25),
+        "fxsr_opt")
+      FLAG(res_8000_0001.edx & (1 << 26),
+        "pdpe1gb")
+      FLAG(res_8000_0001.edx & (1 << 27),
+        "rdtscp")
+      FLAG(res_8000_0001.edx & (1 << 29),
+        "lm")
+      FLAG(res_8000_0001.edx & (1 << 31),
+        "3dnow")
+      FLAG(res_8000_0001.edx & (1 << 30),
+        "3dnowext")
+
+      FLAG(res_8000_0007.edx & (1 << 8),
+        "constant_tsc")
+
+      // We are not a uniprocessor running in SMP mode
+      FLAG(false, "up")
+      // Timer is always running
+      FLAG(true, "art")
+      // No Intel perfmon
+      FLAG(false, "arch_perfmon")
+      // No precise event based sampling
+      FLAG(false, "pebs")
+      // No branch trace store
+      FLAG(false, "bts")
+
+      FLAG(true, "rep_good")
+      FLAG(res_8000_0007.edx & (1 << 12),
+        "tm")
+
+      // Always support long nop
+      FLAG(true, "nopl")
+
+      // Always expose topology information
+      FLAG(true, "xtoplogy")
+
+      // Atom/geode only?
+      FLAG(false, "tsc_reliable")
+      FLAG(res_8000_0007.edx & (1 << 8),
+        "nonstop_tsc")
+
+      // We always support CPUID
+      FLAG(true, "cpuid")
+      FLAG(Family > 0x16,
+        "extd_apicid")
+      FLAG(false, "amd_dcm") // Never claim to be a multi node processor
+      FLAG(res_8000_0007.edx & (1 << 11),
+        "aperfmperf")
+
+      // Need to check ARM documentation if we can support this?
+      FLAG(false, "nonstop_tsc_s3")
+
+      // We can calculate this flag on AArch64
+      FLAG(true, "tsc_known_freq")
+
+      FLAG(res_1.ecx & (1 << 0),
+        "pni")
+      FLAG(res_1.ecx & (1 << 1),
+        "pclmulqdq")
+      FLAG(res_1.ecx & (1 << 2),
+        "dtes64")
+      FLAG(res_1.ecx & (1 << 3),
+        "monitor")
+      FLAG(res_1.ecx & (1 << 4),
+        "ds_cpl")
+      FLAG(res_1.ecx & (1 << 5),
+        "vmx")
+      FLAG(res_1.ecx & (1 << 6),
+        "smx")
+      FLAG(res_1.ecx & (1 << 7),
+        "est")
+      FLAG(res_1.ecx & (1 << 8),
+        "tm2")
+      FLAG(res_1.ecx & (1 << 9),
+        "ssse3")
+      FLAG(res_1.ecx & (1 << 11),
+        "sdbg")
+      FLAG(res_1.ecx & (1 << 12),
+        "fma")
+      FLAG(res_1.ecx & (1 << 13),
+        "cx16")
+      FLAG(res_1.ecx & (1 << 14),
+        "xptr")
+      FLAG(res_1.ecx & (1 << 15),
+        "pdcm")
+      FLAG(res_1.ecx & (1 << 17),
+        "pcid")
+      FLAG(res_1.ecx & (1 << 18),
+        "dca")
+      FLAG(res_1.ecx & (1 << 19),
+        "sse4_1")
+      FLAG(res_1.ecx & (1 << 20),
+        "sse4_2")
+      FLAG(res_1.ecx & (1 << 21),
+        "x2apic")
+      FLAG(res_1.ecx & (1 << 22),
+        "movbe")
+      FLAG(res_1.ecx & (1 << 23),
+        "popcnt")
+      FLAG(res_1.ecx & (1 << 24),
+        "tsc_deadline_timer")
+      FLAG(res_1.ecx & (1 << 25),
+        "aes")
+      FLAG(res_1.ecx & (1 << 26),
+        "xsave")
+      FLAG(res_1.ecx & (1 << 28),
+        "avx")
+      FLAG(res_1.ecx & (1 << 29),
+        "f16c")
+      FLAG(res_1.ecx & (1 << 30),
+        "rdrand")
+      FLAG(res_1.ecx & (1 << 31),
+        "hypervisor")
+
+      FLAG(res_8000_0001.ecx & (1 << 0),
+        "lahf_lm")
+      FLAG(res_8000_0001.ecx & (1 << 1),
+        "cmp_legacy")
+      FLAG(res_8000_0001.ecx & (1 << 2),
+        "svm")
+      FLAG(res_8000_0001.ecx & (1 << 3),
+        "extapic")
+      FLAG(res_8000_0001.ecx & (1 << 4),
+        "cr8_legacy")
+      FLAG(res_8000_0001.ecx & (1 << 5),
+        "abm")
+      FLAG(res_8000_0001.ecx & (1 << 6),
+        "sse4a")
+      FLAG(res_8000_0001.ecx & (1 << 7),
+        "misalignsse")
+      FLAG(res_8000_0001.ecx & (1 << 8),
+        "3dnowprefetch")
+      FLAG(res_8000_0001.ecx & (1 << 9),
+        "osvw")
+      FLAG(res_8000_0001.ecx & (1 << 10),
+        "ibs")
+      FLAG(res_8000_0001.ecx & (1 << 11),
+        "xop")
+      FLAG(res_8000_0001.ecx & (1 << 12),
+        "skinit")
+      FLAG(res_8000_0001.ecx & (1 << 13),
+        "wdt")
+      FLAG(res_8000_0001.ecx & (1 << 15),
+        "lwp")
+      FLAG(res_8000_0001.ecx & (1 << 16),
+        "fma4")
+      FLAG(res_8000_0001.ecx & (1 << 17),
+        "tce")
+      FLAG(res_8000_0001.ecx & (1 << 19),
+        "nodeid_msr")
+      FLAG(res_8000_0001.ecx & (1 << 21),
+        "tbm")
+      FLAG(res_8000_0001.ecx & (1 << 22),
+        "topoext")
+      FLAG(res_8000_0001.ecx & (1 << 23),
+        "perfctr_core")
+      FLAG(res_8000_0001.ecx & (1 << 24),
+        "perfctr_nb")
+      FLAG(res_8000_0001.ecx & (1 << 26),
+        "bpext")
+      FLAG(res_8000_0001.ecx & (1 << 27),
+        "ptsc")
+
+      FLAG(res_8000_0001.ecx & (1 << 28),
+        "perfctr_llc")
+      FLAG(res_8000_0001.ecx & (1 << 29),
+        "mwaitx")
+
+      // We don't support ring 3 supporting mwait
+      FLAG(false, "ring3mwait")
+      // We don't support Intel CPUID fault support
+      FLAG(false, "cpuid_fault")
+      FLAG(res_8000_0007.edx & (1 << 9),
+        "cpb")
+      FLAG(res_6.ecx & (1 << 3),
+        "epb")
+      FLAG(res_10.ebx & (1 << 1),
+        "cat_l3")
+      FLAG(res_10.ebx & (1 << 2),
+        "cat_l2")
+      FLAG(false, /* Needs leaf support */
+        "cdp_l3")
+      FLAG(false, "invpcid_single")
+      FLAG(res_8000_0007.edx & (1 << 7),
+        "hw_pstate")
+      FLAG(res_8000_001f.eax & (1 << 0),
+        "sme")
+
+      // Kernel page table isolation.
+      FLAG(false, "pti")
+
+      // We don't support Intel's Protected Processor Inventory Number
+      FLAG(false, "intel_ppin")
+      FLAG(false, /* Needs leaf support */
+        "cdp_l2")
+
+      FLAG(res_8000_0008.ebx & (1 << 6),
+        "mba")
+      FLAG(res_8000_001f.eax & (1 << 1),
+        "sev")
+
+      {
+        // Speculative bug workarounds
+        // We don't claim to have these bugs, so we don't need to claim these flags
+        FLAG(res_7.edx & (1 << 31),
+          "ssbd")
+        FLAG(false, "ibrs")
+        FLAG(false, "ibpb")
+
+        FLAG(res_7.edx & (1 << 27),
+          "stibp")
+
+        FLAG(false, "ibrs_enhanced")
+      }
+
+      // We don't support Intel's TPR Shadow feature
+      FLAG(false, "tpr_shadow")
+      // Intel virtual NMI
+      FLAG(false, "vnmi")
+      // Intel FlexPriority
+      FLAG(false, "flexpriority")
+      // Intel Extended page table
+      FLAG(false, "ept")
+      // Intel virtual processor ID
+      FLAG(false, "vpid")
+
+      // Prefer VMMCall to VMCall
+      FLAG(false, "vmmcall")
+      // Intel extended page table access dirty bit
+      FLAG(false, "ept_ad")
+      FLAG(res_7.ebx & (1 << 0),
+        "fsgsbase")
+      FLAG(res_7.ebx & (1 << 1),
+        "tsc_adjust")
+      FLAG(res_7.ebx & (1 << 3),
+        "bmi1")
+      FLAG(res_7.ebx & (1 << 4),
+        "hle")
+      FLAG(res_7.ebx & (1 << 5),
+        "avx2")
+      FLAG(res_7.ebx & (1 << 7),
+        "smep")
+      FLAG(res_7.ebx & (1 << 8),
+        "bmi2")
+      FLAG(res_7.ebx & (1 << 9),
+        "erms")
+      FLAG(res_7.ebx & (1 << 10),
+        "invpcid")
+      FLAG(res_7.ebx & (1 << 11),
+        "rtm")
+      FLAG(false, // Needs leaf support
+        "cqm")
+      FLAG(res_7.ebx & (1 << 14),
+        "mpx")
+      FLAG(false, // Needs leaf support
+        "rdt_a")
+      FLAG(res_7.ebx & (1 << 16),
+        "avx512f")
+      FLAG(res_7.ebx & (1 << 17),
+        "avx512dq")
+      FLAG(res_7.ebx & (1 << 18),
+        "rdseed")
+      FLAG(res_7.ebx & (1 << 19),
+        "adx")
+      FLAG(res_7.ebx & (1 << 20),
+        "smap")
+      FLAG(res_7.ebx & (1 << 21),
+        "avx512ifma")
+      FLAG(res_7.ebx & (1 << 23),
+        "clflushopt")
+      FLAG(res_7.ebx & (1 << 24),
+        "clwb")
+      FLAG(res_7.ebx & (1 << 25),
+        "intel_pt")
+      FLAG(res_7.ebx & (1 << 26),
+        "avx512pf")
+      FLAG(res_7.ebx & (1 << 27),
+        "avx512er")
+      FLAG(res_7.ebx & (1 << 28),
+        "avx512cd")
+      FLAG(res_7.ebx & (1 << 29),
+        "sha_ni")
+      FLAG(res_7.ebx & (1 << 30),
+        "avx512bw")
+      FLAG(res_7.ebx & (1 << 31),
+        "avx512vl")
+      FLAG(false, /* Needs leaf support */ // res_d.eax & (1 << 0) // Leaf 1h
+        "xsaveopt")
+      FLAG(false, /* Needs leaf support */ // res_d.eax & (1 << 1) // Leaf 1h
+        "xsavec")
+      FLAG(false, /* Needs leaf support */ // res_d.eax & (1 << 2) // Leaf 1h
+        "xgetbv1")
+      FLAG(false, /* Needs leaf support */ // res_d.eax & (1 << 3) // Leaf 1h
+        "xsaves")
+
+      FLAG(false, /* Needs leaf support */
+        "avx512_bf16")
+      FLAG(res_8000_0008.ebx & (1 << 0),
+        "clzero")
+      FLAG(res_8000_0008.ebx & (1 << 1),
+        "irperf")
+      FLAG(res_8000_0008.ebx & (1 << 2),
+        "xsaveerptr")
+
+      // Intel digital thermal sensor
+      FLAG(false, "dtherm")
+      // Intel turbo boost
+      FLAG(false, "ida")
+      FLAG(res_6.eax & (1 << 2),
+        "arat")
+      // Power limit notification controls
+      FLAG(false, "pln")
+      // Intel package thermal status
+      FLAG(false, "pts")
+
+      // Intel Hardware P-state features
+      FLAG(false, "hwp")
+      FLAG(false, "hwp_notify")
+      FLAG(false, "hwp_act_window")
+      FLAG(false, "hwp_epp")
+      FLAG(false, "hwp_pkg_req")
+
+      FLAG(res_8000_000a.ebx & (1 << 0),
+        "npt")
+      FLAG(res_8000_000a.ebx & (1 << 1),
+        "lbrv")
+      FLAG(res_8000_000a.ebx & (1 << 2),
+        "svm_lock")
+      FLAG(res_8000_000a.ebx & (1 << 3),
+        "nrip_save")
+      FLAG(res_8000_000a.ebx & (1 << 4),
+        "tsc_scale")
+      FLAG(res_8000_000a.ebx & (1 << 5),
+        "vmcb_clean")
+      FLAG(res_8000_000a.ebx & (1 << 6),
+        "flushbyasid")
+      FLAG(res_8000_000a.ebx & (1 << 7),
+        "decodeassists")
+      FLAG(res_8000_000a.ebx & (1 << 10),
+        "pausefilter")
+      FLAG(res_8000_000a.ebx & (1 << 12),
+        "pfthreshold")
+      FLAG(res_8000_000a.ebx & (1 << 13),
+        "avic")
+      FLAG(res_8000_000a.ebx & (1 << 15),
+        "v_vmsave_vmload")
+      FLAG(res_8000_000a.ebx & (1 << 16),
+        "vgif")
+
+      FLAG(res_7.ecx & (1 << 1),
+        "avx512vbmi")
+      FLAG(res_7.ecx & (1 << 2),
+        "umip")
+      FLAG(res_7.ecx & (1 << 3),
+        "pku")
+      FLAG(res_7.ecx & (1 << 4),
+        "ospke")
+      FLAG(res_7.ecx & (1 << 5),
+        "waitpkg")
+      FLAG(res_7.ecx & (1 << 6),
+        "avx512_vbmi2")
+      FLAG(res_7.ecx & (1 << 8),
+        "gfni")
+      FLAG(res_7.ecx & (1 << 9),
+        "vaes")
+      FLAG(res_7.ecx & (1 << 10),
+        "vpclmulqdq")
+      FLAG(res_7.ecx & (1 << 11),
+        "avx512_vnni")
+      FLAG(res_7.ecx & (1 << 12),
+        "avx512_bitalg")
+      FLAG(res_7.ecx & (1 << 13),
+        "tme")
+      FLAG(res_7.ecx & (1 << 14),
+        "avx512_vpopcntdq")
+      FLAG(res_7.ecx & (1 << 16),
+        "la57")
+      FLAG(res_7.ecx & (1 << 22),
+        "rdpid")
+      FLAG(res_7.ecx & (1 << 25),
+        "cldemote")
+      FLAG(res_7.ecx & (1 << 27),
+        "movdiri")
+      FLAG(res_7.ecx & (1 << 28),
+        "movdir64b")
+
+      FLAG(res_8000_0007.ebx & (1 << 0),
+        "overflow_recov")
+      FLAG(res_8000_0007.ebx & (1 << 1),
+        "succor")
+      FLAG(res_8000_0007.ebx & (1 << 3),
+        "smca")
+
+      FLAG(res_7.edx & (1 << 2),
+        "avx512_4vnniw")
+      FLAG(res_7.edx & (1 << 3),
+        "avx512_4fmaps")
+      FLAG(res_7.edx & (1 << 4),
+        "fsrm")
+      FLAG(res_7.edx & (1 << 8),
+        "avx512_vp2intersect")
+      FLAG(res_7.edx & (1 << 10),
+        "md_clear")
+      FLAG(res_7.edx & (1 << 14),
+        "serialize")
+      FLAG(res_7.edx & (1 << 18),
+        "pconfig")
+      FLAG(res_7.edx & (1 << 19),
+        "arch_lbr")
+      FLAG(res_7.edx & (1 << 28),
+        "flush_l1d")
+      FLAG(res_7.edx & (1 << 29),
+        "arch_capabilities")
+
+      cpu_stream << std::endl;
+
+      // We don't have any bugs, don't question it
+      cpu_stream << "bugs            : " << std::endl;
+      cpu_stream << "bogomips        : 8000.0" << std::endl;
+      // These next four aren't necessarily correct
+      cpu_stream << "TLB size        : 2560 4K pages" << std::endl;
+      cpu_stream << "clflush size    : 64" << std::endl;
+      cpu_stream << "cache_alignment : 64" << std::endl;
+
+      // Cortex-A is 40 or 44 bits physical, and 48/52 virtual
+      // Choose the lesser configuration
+      cpu_stream << "address sizes   : 40 bits physical, 48 bits virtual" << std::endl;
+
+      cpu_stream << std::endl;
+    }
+
+    return cpu_stream.str();
+  }
+
   EmulatedFDManager::EmulatedFDManager(FEXCore::Context::Context *ctx)
     : CTX {ctx} {
     EmulatedMap.emplace("/proc/cpuinfo");
@@ -43,37 +605,7 @@ namespace FEXCore::EmulatedFile {
       cpus_online += "-" + std::to_string(ctx->Config.EmulatedCPUCores - 1);
     }
 
-    std::ostringstream cpu_stream{};
-    for (uint64_t i = 0; i < ctx->Config.EmulatedCPUCores; ++i) {
-      cpu_stream << "processor       : " << i << std::endl;
-      cpu_stream << "vendor_id       : AuthenticAMD" << std::endl;
-      cpu_stream << "cpu family      : 23" << std::endl;
-      cpu_stream << "model           : 0" << std::endl;
-      cpu_stream << "model name      : AMD Generic Emulation" << std::endl;
-      cpu_stream << "stepping        : 0" << std::endl;
-      cpu_stream << "microcode       : 0x0" << std::endl;
-      cpu_stream << "cpu MHz         : 3000" << std::endl;
-      cpu_stream << "cache size      : 512 KB" << std::endl;
-      cpu_stream << "physical id     : 0" << std::endl;
-      cpu_stream << "siblings        : " << ctx->Config.EmulatedCPUCores << std::endl;
-      cpu_stream << "core id         : " << i << std::endl;
-      cpu_stream << "cpu cores       : " << ctx->Config.EmulatedCPUCores << std::endl;
-      cpu_stream << "apicid          : " << i << std::endl;
-      cpu_stream << "initial apicid  : " << i << std::endl;
-      cpu_stream << "fpu             : yes" << std::endl;
-      cpu_stream << "fpu_exception   : yes" << std::endl;
-      cpu_stream << "cpuid level     : 13" << std::endl;
-      cpu_stream << "wp              : yes" << std::endl;
-      cpu_stream << "flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl nonstop_tsc cpuid extd_apicid amd_dcm aperfmperf pni pclmulqdq monitor ssse3 fma cx16 sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand lahf_lm cmp_legacy svm extapic cr8_legacy abm sse4a m isalignsse 3dnowprefetch osvw skinit wdt tce topoext perfctr_core perfctr_nb bpext perfctr_llc mwaitx cpb hw_pstate sme ssbd sev ibpb vmmcall fsgsbase bmi1 avx2 smep bmi2 rdseed adx smap clflushopt sha_ni xsaveopt xsavec xgetbv1 xsaves clzero irperf xsaveerptr arat npt lbrv svm_lock nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold avic v_vmsave_vmlo ad vgif overflow_recov succor smca" << std::endl;
-      cpu_stream << "bugs            : sysret_ss_attrs null_seg spectre_v1 spectre_v2 spec_store_bypass" << std::endl;
-      cpu_stream << "bogomips        : 8000.0" << std::endl;
-      cpu_stream << "TLB size        : 2560 4K pages" << std::endl;
-      cpu_stream << "clflush size    : 64" << std::endl;
-      cpu_stream << "cache_alignment : 64" << std::endl;
-      cpu_stream << "address sizes   : 43 bits physical, 48 bits virtual" << std::endl;
-    }
-
-    cpu_info = cpu_stream.str();
+    cpu_info = GenerateCPUInfo(ctx, ctx->Config.EmulatedCPUCores);
   }
 
   EmulatedFDManager::~EmulatedFDManager() {

--- a/External/FEXCore/include/git_version.h.in
+++ b/External/FEXCore/include/git_version.h.in
@@ -1,0 +1,3 @@
+#pragma once
+
+#define GIT_SHORT_HASH "@GIT_SHORT_HASH@"


### PR DESCRIPTION
Instead of having this file mostly just copy and pasted, it'll now be
generated.
We end up losing a lot of supported flags with this change, which is for
the best since we wouldn't have actually supported those things.