### PR TITLE
Adds support for RCPC load instructions

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -378,6 +378,7 @@ JITCore::JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadSt
   CurrentCodeBuffer = &InitialCodeBuffer;
   auto Features = vixl::CPUFeatures::InferFromOS();
   SupportsAtomics = Features.Has(vixl::CPUFeatures::Feature::kAtomics);
+  SupportsRCPC = Features.Has(vixl::CPUFeatures::Feature::kRCpc);
 
   if (SupportsAtomics) {
     // Hypervisor can hide this on the c630?

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -283,7 +283,8 @@ bool JITCore::HandleSIGBUS(int Signal, void *info, void *ucontext) {
   uint32_t DataReg = Instr & 0x1F;
   uint32_t DMB = 0b1101'0101'0000'0011'0011'0000'1011'1111 |
     0b1011'0000'0000; // Inner shareable all
-  if ((Instr & 0x3F'FF'FC'00) == 0x08'DF'FC'00) { // LDAR*
+  if ((Instr & 0x3F'FF'FC'00) == 0x08'DF'FC'00 || // LDAR*
+      (Instr & 0x3F'FF'FC'00) == 0x38'BF'C0'00) { // LDAPR*
     uint32_t LDR = 0b0011'1000'0111'1111'0110'1000'0000'0000;
     LDR |= Size << 30;
     LDR |= AddrReg << 5;

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -154,6 +154,7 @@ private:
 #endif
   vixl::aarch64::CPU CPU;
   bool SupportsAtomics{};
+  bool SupportsRCPC{};
 
   void EmplaceNewCodeBuffer(CodeBuffer Buffer) {
     CurrentCodeBuffer = &CodeBuffers.emplace_back(Buffer);


### PR DESCRIPTION
If the host CPU supports RCPC instructions then it'll use those
instruction of atomics for LoadMemTSO ops.

This pushed my worst case FTL test from 16FPS to 17FPS .

There is another extension to RCPC to add short immediate offset support
which the c630 doesn't support any way. For future optimization on
hardware we can use that.