### PR TITLE
Has the github action clean its build folder

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -29,6 +29,9 @@ jobs:
       # Need to update submodules
       run: git submodule update --init --depth 1
 
+    - name: Clean Build Environment
+      run: rm -Rf ${{runner.workspace}}/build
+
     - name: Create Build Environment
       # Some projects don't allow in-source building, so create a separate build directory
       # We'll use this as our working directory for all subsequent commands


### PR DESCRIPTION
We have hit issues where the non-clean folder would end up leaving
artifacts which allowed tests to pass.

Remove the build folder on each run to clean up