### PR TITLE
Fixes guest disabling sigaltstack.

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/Arm64Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/Arm64Dispatcher.cpp
@@ -425,7 +425,7 @@ bool DispatchGenerator::HandleGuestSignal(int Signal, void *info, void *ucontext
   uint64_t OldGuestSP = State->State.State.gregs[X86State::REG_RSP];
   uint64_t NewGuestSP = OldGuestSP;
 
-  if (!!GuestStack->ss_sp) {
+  if (!(GuestStack->ss_flags & SS_DISABLE)) {
     // If our guest is already inside of the alternative stack
     // Then that means we are hitting recursive signals and we need to walk back the stack correctly
     uint64_t AltStackBase = reinterpret_cast<uint64_t>(GuestStack->ss_sp);

--- a/External/FEXCore/Source/Interface/Core/Interpreter/x86_64Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/x86_64Dispatcher.cpp
@@ -296,7 +296,7 @@ bool DispatchGenerator::HandleGuestSignal(int Signal, void *info, void *ucontext
   uint64_t OldGuestSP = State->State.State.gregs[X86State::REG_RSP];
   uint64_t NewGuestSP = OldGuestSP;
 
-  if (!!GuestStack->ss_sp) {
+  if (!(GuestStack->ss_flags & SS_DISABLE)) {
     // If our guest is already inside of the alternative stack
     // Then that means we are hitting recursive signals and we need to walk back the stack correctly
     uint64_t AltStackBase = reinterpret_cast<uint64_t>(GuestStack->ss_sp);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -211,7 +211,7 @@ bool JITCore::HandleGuestSignal(int Signal, void *info, void *ucontext, SignalDe
   uint64_t OldGuestSP = State->State.State.gregs[X86State::REG_RSP];
   uint64_t NewGuestSP = OldGuestSP;
 
-  if (!!GuestStack->ss_sp) {
+  if (!(GuestStack->ss_flags & SS_DISABLE)) {
     // If our guest is already inside of the alternative stack
     // Then that means we are hitting recursive signals and we need to walk back the stack correctly
     uint64_t AltStackBase = reinterpret_cast<uint64_t>(GuestStack->ss_sp);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -135,7 +135,7 @@ bool JITCore::HandleGuestSignal(int Signal, void *info, void *ucontext, SignalDe
   uint64_t OldGuestSP = ThreadState->State.State.gregs[X86State::REG_RSP];
   uint64_t NewGuestSP = OldGuestSP;
 
-  if (!!GuestStack->ss_sp) {
+  if (!(GuestStack->ss_flags & SS_DISABLE)) {
     // If our guest is already inside of the alternative stack
     // Then that means we are hitting recursive signals and we need to walk back the stack correctly
     uint64_t AltStackBase = reinterpret_cast<uint64_t>(GuestStack->ss_sp);


### PR DESCRIPTION
Previously we never checked for SS_DISABLE.
We were also only ever checking for ss_sp being a valid memory range
when we should have been checking for the absense of SS_DISABLE.

Fixes #326