### PR TITLE
Initial Callback support

### DIFF
--- a/External/FEXCore/Source/Interface/Context/Context.cpp
+++ b/External/FEXCore/Source/Interface/Context/Context.cpp
@@ -110,6 +110,10 @@ namespace FEXCore::Context {
   void RegisterExternalSyscallVisitor(FEXCore::Context::Context *CTX, [[maybe_unused]] uint64_t Syscall, [[maybe_unused]] FEXCore::HLE::SyscallVisitor *Visitor) {
   }
 
+  void HandleCallback(FEXCore::Context::Context *CTX, uint64_t RIP) {
+    CTX->HandleCallback(RIP);
+  }
+
 namespace Debug {
   void CompileRIP(FEXCore::Context::Context *CTX, uint64_t RIP) {
     CTX->CompileRIP(CTX->ParentThread, RIP);

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -111,6 +111,7 @@ namespace FEXCore::Context {
     bool GetGdbServerStatus() { return (bool)DebugServer; }
     void StartGdbServer();
     void StopGdbServer();
+    void HandleCallback(uint64_t RIP);
 
     // Debugger interface
     void CompileRIP(FEXCore::Core::InternalThreadState *Thread, uint64_t RIP);
@@ -140,6 +141,7 @@ namespace FEXCore::Context {
     void RunThread(FEXCore::Core::InternalThreadState *Thread);
 
     std::vector<FEXCore::Core::InternalThreadState*> *const GetThreads() { return &Threads; }
+
   protected:
     void ClearCodeCache(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP);
 

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterClass.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterClass.h
@@ -33,6 +33,9 @@ public:
   void CreateAsmDispatch(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread);
   void DeleteAsmDispatch();
 
+  using CallbackReturn =  __attribute__((naked)) void(*)(FEXCore::Core::InternalThreadState *Thread, volatile void *Host_RSP);
+  CallbackReturn ReturnPtr;
+
 private:
   FEXCore::Context::Context *CTX;
   FEXCore::Core::InternalThreadState *State;

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -82,6 +82,7 @@ void *InterpreterCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true
 }
 
 void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
+  volatile void* stack = alloca(0);
   auto IR = Thread->IRLists.find(Thread->State.State.rip);
   auto CurrentIR = IR->second.get();
 
@@ -197,6 +198,10 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
           }
           case IR::OP_SIGNALRETURN: {
             SignalReturn(State);
+            break;
+          }
+          case IR::OP_CALLBACKRETURN: {
+            ReturnPtr(State, stack);
             break;
           }
           case IR::OP_SYSCALL: {

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "Interface/Core/BlockCache.h"
-#include "Interface/Core/InternalThreadState.h"
 
 #include "aarch64/assembler-aarch64.h"
 #include "aarch64/cpu-aarch64.h"
@@ -21,6 +20,10 @@
 #define VTMP1 v1
 #define VTMP2 v2
 #define VTMP3 v3
+
+namespace FEXCore::Core {
+  struct InternalThreadState;
+}
 
 namespace FEXCore::CPU {
 using namespace vixl;
@@ -300,6 +303,7 @@ private:
   DEF_OP(GuestCallIndirect);
   DEF_OP(GuestReturn);
   DEF_OP(SignalReturn);
+  DEF_OP(CallbackReturn);
   DEF_OP(ExitFunction);
   DEF_OP(Jump);
   DEF_OP(CondJump);

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -178,6 +178,14 @@ void OpDispatchBuilder::SIGRETOp(OpcodeArgs) {
   BlockSetRIP = true;
 }
 
+void OpDispatchBuilder::CallbackReturnOp(OpcodeArgs) {
+  // Store the new RIP
+  _CallbackReturn();
+  // This ExitFunction won't actually get hit but needs to exist
+  _ExitFunction();
+  BlockSetRIP = true;
+}
+
 void OpDispatchBuilder::SecondaryALUOp(OpcodeArgs) {
   bool RequiresMask = false;
   FEXCore::IR::IROps IROp;
@@ -7195,6 +7203,7 @@ void InstallOpcodeHandlers(Context::OperatingMode Mode) {
 
     // FEX reserved instructions
     {0x36, 1, &OpDispatchBuilder::SIGRETOp},
+    {0x37, 1, &OpDispatchBuilder::CallbackReturnOp},
   };
 
   const std::vector<std::tuple<uint8_t, uint8_t, FEXCore::X86Tables::OpDispatchPtr>> TwoByteOpTable_32 = {

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -107,6 +107,7 @@ public:
   void NOPOp(OpcodeArgs);
   void RETOp(OpcodeArgs);
   void SIGRETOp(OpcodeArgs);
+  void CallbackReturnOp(OpcodeArgs);
   void SecondaryALUOp(OpcodeArgs);
   template<uint32_t SrcIndex>
   void ADCOp(OpcodeArgs);

--- a/External/FEXCore/Source/Interface/Core/X86HelperGen.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86HelperGen.cpp
@@ -10,9 +10,11 @@ X86GeneratedCode::X86GeneratedCode() {
   CodePtr = malloc(0x1000);
 
   SignalReturn = reinterpret_cast<uint64_t>(CodePtr);
+  CallbackReturn = reinterpret_cast<uint64_t>(CodePtr) + 2;
 
   const std::vector<uint8_t> SignalReturnCode = {
     0x0F, 0x36, // SIGRET FEX instruction
+    0x0F, 0x37, // CALLBACKRET FEX Instruction
   };
 
   memcpy(CodePtr, &SignalReturnCode.at(0), SignalReturnCode.size());

--- a/External/FEXCore/Source/Interface/Core/X86HelperGen.h
+++ b/External/FEXCore/Source/Interface/Core/X86HelperGen.h
@@ -8,6 +8,8 @@ public:
   ~X86GeneratedCode();
 
   uint64_t SignalReturn{};
+  uint64_t CallbackReturn{};
+
 private:
   void *CodePtr{};
 };

--- a/External/FEXCore/Source/Interface/Core/X86Tables/SecondaryTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/SecondaryTables.cpp
@@ -53,7 +53,6 @@ void InitializeSecondaryTables() {
     {0x33, 1, X86InstInfo{"RDPMC",      TYPE_PRIV, FLAGS_NO_OVERLAY,                                                                             0, nullptr}},
     {0x34, 1, X86InstInfo{"SYSENTER",   TYPE_PRIV, FLAGS_NO_OVERLAY,                                                                             0, nullptr}},
     {0x35, 1, X86InstInfo{"SYSEXIT",    TYPE_PRIV, FLAGS_NO_OVERLAY,                                                                             0, nullptr}},
-    {0x37, 1, X86InstInfo{"",           TYPE_INVALID, FLAGS_NO_OVERLAY,                                                                          0, nullptr}},
     {0x38, 1, X86InstInfo{"",           TYPE_0F38_TABLE, FLAGS_NO_OVERLAY,                                                                       0, nullptr}},
     {0x39, 1, X86InstInfo{"",           TYPE_INVALID, FLAGS_NO_OVERLAY,                                                                          0, nullptr}},
     {0x3A, 1, X86InstInfo{"",           TYPE_0F3A_TABLE, FLAGS_NO_OVERLAY,                                                                       0, nullptr}},
@@ -253,6 +252,8 @@ void InitializeSecondaryTables() {
     // Unused x86 encoding instruction.
     // Used by FEX to know when to do a signal return
     {0x36, 1, X86InstInfo{"SIGRET",       TYPE_INST, FLAGS_BLOCK_END | FLAGS_NO_OVERLAY | FLAGS_SETS_RIP,                                                            0, nullptr}},
+
+    {0x37, 1, X86InstInfo{"CALLBACKRET",  TYPE_INST, FLAGS_BLOCK_END | FLAGS_NO_OVERLAY | FLAGS_SETS_RIP,                                                                          0, nullptr}},
 
     // This was originally used by VIA to jump to its alternative instruction set. Used for OP_THUNK
     {0x3F, 1, X86InstInfo{"ALTINST",      TYPE_INST, FLAGS_BLOCK_END | FLAGS_NO_OVERLAY | FLAGS_SETS_RIP,                                                            0, nullptr}},

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -128,6 +128,11 @@
       "OpClass": "Branch"
     },
 
+    "CallbackReturn": {
+      "HasSideEffects": true,
+      "OpClass": "Branch"
+    },
+
     "CASPair": {
       "HasSideEffects": true,
       "OpClass": "Atomic",

--- a/External/FEXCore/include/FEXCore/Core/CPUBackend.h
+++ b/External/FEXCore/include/FEXCore/Core/CPUBackend.h
@@ -78,7 +78,9 @@ class LLVMCore;
     virtual void ClearCache() {}
 
     using AsmDispatch = __attribute__((naked)) void(*)(FEXCore::Core::InternalThreadState *Thread);
+    using JITCallback = __attribute__((naked)) void(*)(FEXCore::Core::InternalThreadState *Thread, uint64_t RIP);
 
+    JITCallback CallbackPtr{};
   protected:
     AsmDispatch DispatchPtr{};
   };

--- a/External/FEXCore/include/FEXCore/Core/Context.h
+++ b/External/FEXCore/include/FEXCore/Core/Context.h
@@ -237,4 +237,6 @@ namespace FEXCore::Context {
    */
   void RegisterExternalSyscallVisitor(FEXCore::Context::Context *CTX, uint64_t Syscall, FEXCore::HLE::SyscallVisitor *Visitor);
 
+  void HandleCallback(FEXCore::Context::Context *CTX, uint64_t RIP);
+
 }

--- a/ThunkLibs/GuestLibs/CMakeLists.txt
+++ b/ThunkLibs/GuestLibs/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.14)
 project(guest-thunks)
 
+set(CMAKE_CXX_STANDARD 17)
+
 # These get passed in from the main cmake project
 set (X86_C_COMPILER "x86_64-linux-gnu-gcc" CACHE STRING "c compiler for compiling x86 guest libs")
 set (X86_CXX_COMPILER "x86_64-linux-gnu-g++" CACHE STRING "c++ compiler for compiling x86 guest libs")

--- a/ThunkLibs/HostLibs/CMakeLists.txt
+++ b/ThunkLibs/HostLibs/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.14)
 project(host-thunks)
 
+set(CMAKE_CXX_STANDARD 17)
+
 function(generate NAME)
     foreach(WHAT IN LISTS ARGN)
         set(OUTFILE "${CMAKE_CURRENT_BINARY_DIR}/gen/${NAME}_${WHAT}.inl")

--- a/unittests/POSIX/Disabled_Tests
+++ b/unittests/POSIX/Disabled_Tests
@@ -550,3 +550,10 @@ conformance-interfaces-munmap-1-2.test
 
 conformance-interfaces-killpg-1-2.test # uses rt_sigsuspend
 conformance-interfaces-kill-1-2.test # uses rt_sigtimedwait
+
+# Unstable tests
+conformance-interfaces-clock_nanosleep-10-1.test # uses sigabort
+conformance-interfaces-clock_nanosleep-9-1.test # uses sigabort
+conformance-interfaces-nanosleep-5-2.test # uses sigabort
+conformance-interfaces-nanosleep-7-1.test # uses sigabort
+conformance-interfaces-nanosleep-7-2.test # uses sigabort

--- a/unittests/POSIX/Known_Failures
+++ b/unittests/POSIX/Known_Failures
@@ -43,8 +43,3 @@ conformance-interfaces-sigwaitinfo-6-1.test
 conformance-interfaces-sigwaitinfo-7-1.test
 conformance-interfaces-sigwaitinfo-8-1.test
 conformance-interfaces-sigwaitinfo-9-1.test
-conformance-interfaces-clock_nanosleep-10-1.test # uses sigabort
-conformance-interfaces-clock_nanosleep-9-1.test # uses sigabort
-conformance-interfaces-nanosleep-5-2.test # uses sigabort
-conformance-interfaces-nanosleep-7-1.test # uses sigabort
-conformance-interfaces-nanosleep-7-2.test # uses sigabort


### PR DESCRIPTION
This interface is for native host code to be able to call back in to JIT
to execute guest code.
This is mainly for thunks but could be used for other purposes.
This can cross a couple ABI boundaries so one must be careful when
calling in to this