### PR TITLE
Fixes getpriority syscall

### DIFF
--- a/External/FEXCore/Source/Interface/HLE/Syscalls/Sched.cpp
+++ b/External/FEXCore/Source/Interface/HLE/Syscalls/Sched.cpp
@@ -16,14 +16,14 @@ struct InternalThreadState;
 namespace FEXCore::HLE {
 
   void RegisterSched() {
-      
+
     REGISTER_SYSCALL_IMPL(sched_yield, [](FEXCore::Core::InternalThreadState *Thread) -> uint64_t {
       uint64_t Result = ::sched_yield();
       SYSCALL_ERRNO();
     });
 
     REGISTER_SYSCALL_IMPL(getpriority, [](FEXCore::Core::InternalThreadState *Thread, int which, int who) -> uint64_t {
-      uint64_t Result = ::getpriority(which, who);
+      uint64_t Result = ::syscall(SYS_getpriority, which, who);
       SYSCALL_ERRNO();
     });
 


### PR DESCRIPTION
Just use the syscall directly rather than call through the glibc
interface.

The getpriority syscall biases the return value so it never returns a
negative, while the glibc interface returns [-20,19), so you need to do
some errno juggling for the -1 return.

Just use the syscall directly instead

Fixes some game complaining heavily when getpriority results were wrong