### PR TITLE
Implements missing CVTPD2DQ 

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -7360,6 +7360,7 @@ void InstallOpcodeHandlers(Context::OperatingMode Mode) {
     {0x7D, 1, &OpDispatchBuilder::HSUBP<4>},
     {0xD6, 1, &OpDispatchBuilder::MOVQ2DQ<false>},
     {0xC2, 1, &OpDispatchBuilder::VFCMPOp<8, true>},
+    {0xE6, 1, &OpDispatchBuilder::Vector_CVT_Float_To_Int<8, true, true>},
     {0xF0, 1, &OpDispatchBuilder::MOVVectorOp},
   };
 

--- a/unittests/ASM/REPNE/F2_E6.asm
+++ b/unittests/ASM/REPNE/F2_E6.asm
@@ -1,0 +1,38 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "XMM0":  ["0x0000000200000001", "0x0"],
+    "XMM1":  ["0xFFFFFFFEFFFFFFFF", "0x0"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x3ff0000000000000
+mov [rdx + 8 * 0], rax
+mov rax, 0x4000000000000000
+mov [rdx + 8 * 1], rax
+
+mov rax, 0xbff0000000000000
+mov [rdx + 8 * 2], rax
+mov rax, 0xc000000000000000
+mov [rdx + 8 * 3], rax
+
+mov rax, 0x4142434445464748
+mov [rdx + 8 * 4], rax
+mov rax, 0x5152535455565758
+mov [rdx + 8 * 5], rax
+
+movapd xmm0, [rdx + 8 * 4]
+movapd xmm1, [rdx + 8 * 4]
+
+movapd xmm2, [rdx + 8 * 0]
+
+cvtpd2dq xmm0, xmm2
+cvtpd2dq xmm1, [rdx + 8 * 2]
+
+hlt


### PR DESCRIPTION
Without impementing MXCSR still, this matches the already implemented
CVTTPD2DQ

Rimworld hit this instruction on boot.