### PR TITLE
Fixes guest default signal handling and pending signals 

### DIFF
--- a/External/FEXCore/Source/Interface/Core/SignalDelegator.h
+++ b/External/FEXCore/Source/Interface/Core/SignalDelegator.h
@@ -97,6 +97,14 @@ namespace Core {
     constexpr static size_t SIGNAL_FOR_PAUSE {63};
 
   private:
+    enum DefaultBehaviour {
+      DEFAULT_TERM,
+      // Core dump based signals are supposed to have a coredump appear
+      // For FEX's behaviour we don't really care right now
+      DEFAULT_COREDUMP = DEFAULT_TERM,
+      DEFAULT_IGNORE,
+    };
+
     struct SignalHandler {
       std::atomic<bool> Installed{};
       struct sigaction HostAction{};
@@ -104,6 +112,7 @@ namespace Core {
       HostSignalDelegatorFunction Handler{};
       HostSignalDelegatorFunctionForGuest GuestHandler{};
       GuestSigAction GuestAction{};
+      DefaultBehaviour DefaultBehaviour {DEFAULT_TERM};
     };
 
     SignalHandler HostHandlers[MAX_SIGNALS + 1]{};

--- a/unittests/POSIX/Disabled_Tests
+++ b/unittests/POSIX/Disabled_Tests
@@ -1,5 +1,8 @@
 # These tests are inconsistent
 conformance-interfaces-mmap-12-1.test
+conformance-interfaces-mmap-6-1.test
+conformance-interfaces-mmap-6-2.test
+conformance-interfaces-mmap-6-3.test
 
 # These tests take too long to run, and might timeout
 conformance-interfaces-clock-1-1.test
@@ -545,3 +548,5 @@ conformance-interfaces-mmap-11-2.test
 conformance-interfaces-munmap-1-1.test
 conformance-interfaces-munmap-1-2.test
 
+conformance-interfaces-killpg-1-2.test # uses rt_sigsuspend
+conformance-interfaces-kill-1-2.test # uses rt_sigtimedwait

--- a/unittests/POSIX/Known_Failures
+++ b/unittests/POSIX/Known_Failures
@@ -11,7 +11,6 @@ conformance-interfaces-munmap-2-1.test
 conformance-interfaces-nanosleep-10000-1.test
 conformance-interfaces-nanosleep-5-1.test
 conformance-interfaces-nanosleep-6-1.test
-conformance-interfaces-raise-1-1.test
 conformance-interfaces-sigpending-1-2.test
 conformance-interfaces-sigpending-1-3.test
 conformance-interfaces-sigprocmask-6-1.test
@@ -46,8 +45,6 @@ conformance-interfaces-sigwaitinfo-8-1.test
 conformance-interfaces-sigwaitinfo-9-1.test
 conformance-interfaces-clock_nanosleep-10-1.test # uses sigabort
 conformance-interfaces-clock_nanosleep-9-1.test # uses sigabort
-conformance-interfaces-kill-1-2.test # uses rt_sigtimedwait
-conformance-interfaces-killpg-1-2.test # uses getpgid, setpgid
 conformance-interfaces-nanosleep-5-2.test # uses sigabort
 conformance-interfaces-nanosleep-7-1.test # uses sigabort
 conformance-interfaces-nanosleep-7-2.test # uses sigabort


### PR DESCRIPTION
glibc raise() actually disables all signals, raises the signal that the
user wants, then reenables the previous signal mask.

On the reenabling of the previous signal mask, that is when the pending
signal fires.
This needs to be accurately handled, so check for pending signals
getting unmasked in sigprocmask

This also then needs to be further fixed to handle default signal
handling, where if a signal was sent that is default ignored (NOT set to
ignore!) then it would just exit the application before.
Now something likg SIGCHLD with the default handler (aka ignore) won't
kill the process