### PR TITLE
Ensures a process that has forked won't shutdown the other process

### DIFF
--- a/External/FEXCore/Source/Interface/HLE/Syscalls/Thread.cpp
+++ b/External/FEXCore/Source/Interface/HLE/Syscalls/Thread.cpp
@@ -80,6 +80,17 @@ namespace FEXCore::HLE {
       // update the internal TID
       Thread->State.ThreadManager.TID = ::gettid();
       Thread->State.ThreadManager.PID = ::getpid();
+      Thread->State.ThreadManager.clear_child_tid = nullptr;
+
+      // Clear all the other threads that are being tracked
+      for (auto &DeadThread : Thread->CTX->Threads) {
+        if (DeadThread == Thread) {
+          continue;
+        }
+
+        // Setting running to false ensures that when they shutdown we won't send signals to kill them
+        DeadThread->State.RunningEvents.Running = false;
+      }
 
       // only a  single thread running so no need to remove anything from the thread array
 


### PR DESCRIPTION
Since we track the PID and TID of the threads for signaling purposes, we
had the problem that if a process forked and the child then shuts down.
It was still tracking the parent thread as executing, thus it would send
it a tgkill to shut it down.

This was unintended behaviour and is now stopped