### PR TITLE
Refactor the IR Interface to prevent "foot-shooting"

### DIFF
--- a/External/FEXCore/Scripts/json_ir_generator.py
+++ b/External/FEXCore/Scripts/json_ir_generator.py
@@ -302,7 +302,6 @@ def print_ir_allocator_helpers(ops, defines):
 
     output_file.write("\tuint8_t GetOpSize(OrderedNode *Op) const {\n")
     output_file.write("\t\tauto HeaderOp = Op->Header.Value.GetNode(Data.Begin());\n")
-    output_file.write("\t\tLogMan::Throw::A(HeaderOp->HasDest, \"Op %s has no dest\\n\", GetName(HeaderOp->Op));\n")
     output_file.write("\t\treturn HeaderOp->Size;\n")
     output_file.write("\t}\n\n")
 

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -105,8 +105,7 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
 #define GD *GetDest<uint64_t*>(SSAData, WrapperOp)
 #define GDP GetDest<void*>(SSAData, WrapperOp)
   auto GetOpSize = [&](IR::OrderedNodeWrapper Node) {
-    FEXCore::IR::OrderedNode const *RealNode = Node.GetNode(ListBegin);
-    FEXCore::IR::IROp_Header const *IROp = RealNode->Op(DataBegin);
+    auto IROp = CurrentIR->GetOp<FEXCore::IR::IROp_Header>(Node);
     return IROp->Size;
   };
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
@@ -6,14 +6,6 @@ using namespace vixl;
 using namespace vixl::aarch64;
 #define DEF_OP(x) void JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
 
-DEF_OP(EndBlock) {
-  auto Op = IROp->C<IR::IROp_EndBlock>();
-  if (Op->RIPIncrement) {
-    ldr(TMP1, MemOperand(STATE, offsetof(FEXCore::Core::CPUState, rip)));
-    str(TMP1,  MemOperand(STATE, offsetof(FEXCore::Core::CPUState, rip)));
-  }
-}
-
 DEF_OP(Fence) {
   auto Op = IROp->C<IR::IROp_Fence>();
   switch (Op->Fence) {
@@ -67,7 +59,7 @@ void JITCore::RegisterMiscHandlers() {
   REGISTER_OP(IRHEADER,   NoOp);
   REGISTER_OP(CODEBLOCK,  NoOp);
   REGISTER_OP(BEGINBLOCK, NoOp);
-  REGISTER_OP(ENDBLOCK,   EndBlock);
+  REGISTER_OP(ENDBLOCK,   NoOp);
   REGISTER_OP(FENCE,      Fence);
   REGISTER_OP(BREAK,      Break);
   REGISTER_OP(PHI,        NoOp);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
@@ -10,7 +10,6 @@ DEF_OP(EndBlock) {
   auto Op = IROp->C<IR::IROp_EndBlock>();
   if (Op->RIPIncrement) {
     ldr(TMP1, MemOperand(STATE, offsetof(FEXCore::Core::CPUState, rip)));
-    add(TMP1, TMP1, Operand(Op->RIPIncrement));
     str(TMP1,  MemOperand(STATE, offsetof(FEXCore::Core::CPUState, rip)));
   }
 }

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -511,10 +511,9 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
     ret();
   };
 
-  for (auto Block : CurrentIR->getBlocks()) {
+  for (auto [BlockNode, BlockHeader] : CurrentIR->getBlocks()) {
     using namespace FEXCore::IR;
-    auto BlockNode = Block.GetNode(ListBegin);
-    auto BlockIROp = BlockNode->Op(DataBegin)->CW<IROp_CodeBlock>();
+    auto BlockIROp = BlockHeader->CW<IROp_CodeBlock>();
     LogMan::Throw::A(BlockIROp->Header.Op == IR::OP_CODEBLOCK, "IR type failed to be a code block");
 
     // We grab these nodes this way so we can iterate easily

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -509,10 +509,11 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
 
   for (auto [BlockNode, BlockHeader] : CurrentIR->GetBlocks()) {
     using namespace FEXCore::IR;
-    auto BlockIROp = BlockHeader->CW<IROp_CodeBlock>();
-    LogMan::Throw::A(BlockIROp->Header.Op == IR::OP_CODEBLOCK, "IR type failed to be a code block");
 
     {
+      auto BlockIROp = BlockHeader->CW<IROp_CodeBlock>();
+      LogMan::Throw::A(BlockIROp->Header.Op == IR::OP_CODEBLOCK, "IR type failed to be a code block");
+
       uint32_t Node = CurrentIR->GetID(BlockNode);
       auto IsTarget = JumpTargets.find(Node);
       if (IsTarget == JumpTargets.end()) {
@@ -563,21 +564,6 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
       #endif
 
       switch (IROp->Op) {
-        case IR::OP_BEGINBLOCK: {
-          auto IsTarget = JumpTargets.find(Node);
-          if (IsTarget == JumpTargets.end()) {
-            IsTarget = JumpTargets.try_emplace(Node).first;
-          }
-          else {
-          }
-
-          L(IsTarget->second);
-          break;
-        }
-        case IR::OP_ENDBLOCK: {
-          auto Op = IROp->C<IR::IROp_EndBlock>();
-          break;
-        }
         case IR::OP_EXITFUNCTION: {
           RegularExit();
           break;
@@ -4800,6 +4786,8 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
           break;
         }
         case IR::OP_DUMMY:
+        case IR::OP_BEGINBLOCK:
+        case IR::OP_ENDBLOCK:
         case IR::OP_IRHEADER:
         case IR::OP_PHIVALUE:
         case IR::OP_PHI:

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -3658,12 +3658,6 @@ void OpDispatchBuilder::CreateJumpBlocks(std::vector<FEXCore::Frontend::Decoder:
   for (auto &Target : *Blocks) {
     auto CodeNode = CreateCodeNode();
 
-    auto NewNode = _Dummy();
-    SetCodeNodeBegin(CodeNode, NewNode);
-
-    auto EndBlock = _EndBlock(0);
-    SetCodeNodeLast(CodeNode, EndBlock);
-
     JumpTargets.try_emplace(Target.Entry, JumpTargetInfo{CodeNode, false});
 
     if (PrevCodeBlock) {

--- a/External/FEXCore/Source/Interface/IR/IR.cpp
+++ b/External/FEXCore/Source/Interface/IR/IR.cpp
@@ -132,10 +132,9 @@ void Dump(std::stringstream *out, IRListView<false> const* IR, IR::RegisterAlloc
   *out << "%ssa" << HeaderOp->Blocks.ID() << ", ";
   *out << "#" << std::dec << HeaderOp->BlockCount << std::endl;
 
-  for (auto Block : IR->getBlocks()) {
-    auto BlockNode = Block.GetNode(ListBegin);
-    auto BlockIROp = BlockNode->Op(DataBegin)->CW<FEXCore::IR::IROp_CodeBlock>();
-   // LogMan::Throw::A(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
+  for (auto [BlockNode, BlockHeader] : IR->getBlocks()) {
+    auto BlockIROp = BlockHeader->CW<FEXCore::IR::IROp_CodeBlock>();
+    // LogMan::Throw::A(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
 
     // We grab these nodes this way so we can iterate easily
     auto CodeBegin = IR->at(BlockIROp->Begin);

--- a/External/FEXCore/Source/Interface/IR/IR.cpp
+++ b/External/FEXCore/Source/Interface/IR/IR.cpp
@@ -204,14 +204,6 @@ void Dump(std::stringstream *out, IRListView<false> const* IR, IR::RegisterAlloc
           *out << ") ";
         }
         *out << Name;
-        switch (IROp->Op) {
-          case IR::OP_BEGINBLOCK:
-            *out << " %ssa" << std::to_string(ID);
-            break;
-          case IR::OP_ENDBLOCK:
-            break;
-          default: break;
-        }
 
         #define IROP_ARGPRINTER_HELPER
         #include <FEXCore/IR/IRDefines.inc>

--- a/External/FEXCore/Source/Interface/IR/IR.cpp
+++ b/External/FEXCore/Source/Interface/IR/IR.cpp
@@ -132,7 +132,7 @@ void Dump(std::stringstream *out, IRListView<false> const* IR, IR::RegisterAlloc
   *out << "%ssa" << HeaderOp->Blocks.ID() << ", ";
   *out << "#" << std::dec << HeaderOp->BlockCount << std::endl;
 
-  for (auto [BlockNode, BlockHeader] : IR->getBlocks()) {
+  for (auto [BlockNode, BlockHeader] : IR->GetBlocks()) {
     auto BlockIROp = BlockHeader->CW<FEXCore::IR::IROp_CodeBlock>();
     // LogMan::Throw::A(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
 

--- a/External/FEXCore/Source/Interface/IR/IR.cpp
+++ b/External/FEXCore/Source/Interface/IR/IR.cpp
@@ -52,11 +52,7 @@ static void PrintArg(std::stringstream *out, [[maybe_unused]] IRListView<false> 
 }
 
 static void PrintArg(std::stringstream *out, IRListView<false> const* IR, OrderedNodeWrapper Arg, IR::RegisterAllocationPass *RAPass) {
-  uintptr_t Data = IR->GetData();
-  uintptr_t ListBegin = IR->GetListData();
-
-  OrderedNode *RealNode = Arg.GetNode(ListBegin);
-  auto IROp = RealNode->Op(Data);
+  auto [CodeNode, IROp] = IR->at(Arg)();
 
   *out << "%ssa" << std::to_string(Arg.ID());
   if (RAPass) {

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -73,7 +73,14 @@
       ]
     },
     "BeginBlock": {
-      "OpClass": "Misc"
+      "HasSideEffects": true,
+      "OpClass": "Misc",
+      "SwitchGen": false,
+      "SSAArgs": "1",
+      "RAOverride": "0",
+      "SSANames": [
+        "BlockHeader"
+      ]
     },
 
     "EndBlock": {

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -65,12 +65,11 @@
     "CodeBlock": {
       "OpClass": "Misc",
       "SwitchGen": false,
-      "SSAArgs": "3",
+      "SSAArgs": "2",
       "RAOverride": "0",
       "SSANames": [
         "Begin",
-        "Last",
-        "Next"
+        "Last"
       ]
     },
     "BeginBlock": {
@@ -81,8 +80,10 @@
       "HasSideEffects": true,
       "OpClass": "Misc",
       "SwitchGen": false,
-      "Args": [
-        "uint64_t", "RIPIncrement"
+      "SSAArgs": "1",
+      "RAOverride": "0",
+      "SSANames": [
+        "BlockHeader"
       ]
     },
 

--- a/External/FEXCore/Source/Interface/IR/IREmitter.cpp
+++ b/External/FEXCore/Source/Interface/IR/IREmitter.cpp
@@ -11,18 +11,17 @@ void IREmitter::ResetWorkingList() {
   CurrentCodeBlock = nullptr;
 }
 
-void IREmitter::ReplaceAllUsesWithInclusive(OrderedNode *Node, OrderedNode *NewNode, IR::NodeWrapperIterator After, IR::NodeWrapperIterator End) {
+void IREmitter::ReplaceAllUsesWithRange(OrderedNode *Node, OrderedNode *NewNode, AllNodesIterator After, AllNodesIterator End) {
   uintptr_t ListBegin = ListData.Begin();
   uintptr_t DataBegin = Data.Begin();
+  auto NodeId = Node->Wrapped(ListBegin).ID();
 
   while (After != End) {
-    OrderedNodeWrapper *WrapperOp = After();
-    OrderedNode *RealNode = WrapperOp->GetNode(ListBegin);
-    FEXCore::IR::IROp_Header *IROp = RealNode->Op(DataBegin);
+    auto [RealNode, IROp] = After();
 
     uint8_t NumArgs = IR::GetArgs(IROp->Op);
     for (uint8_t i = 0; i < NumArgs; ++i) {
-      if (IROp->Args[i].ID() == Node->Wrapped(ListBegin).ID()) {
+      if (IROp->Args[i].ID() == NodeId) {
         Node->RemoveUse();
         NewNode->AddUse();
         IROp->Args[i].NodeOffset = NewNode->Wrapped(ListBegin).NodeOffset;

--- a/External/FEXCore/Source/Interface/IR/IREmitter.cpp
+++ b/External/FEXCore/Source/Interface/IR/IREmitter.cpp
@@ -13,7 +13,6 @@ void IREmitter::ResetWorkingList() {
 
 void IREmitter::ReplaceAllUsesWithRange(OrderedNode *Node, OrderedNode *NewNode, AllNodesIterator After, AllNodesIterator End) {
   uintptr_t ListBegin = ListData.Begin();
-  uintptr_t DataBegin = Data.Begin();
   auto NodeId = Node->Wrapped(ListBegin).ID();
 
   while (After != End) {

--- a/External/FEXCore/Source/Interface/IR/IREmitter.cpp
+++ b/External/FEXCore/Source/Interface/IR/IREmitter.cpp
@@ -66,15 +66,8 @@ void IREmitter::Remove(OrderedNode *Node) {
 
 IREmitter::IRPair<IROp_CodeBlock> IREmitter::CreateNewCodeBlock() {
   auto OldCursor = GetWriteCursor();
-  SetWriteCursor(CodeBlocks.back());
 
   auto CodeNode = CreateCodeNode();
-
-  auto NewNode = _Dummy();
-  SetCodeNodeBegin(CodeNode, NewNode);
-
-  auto EndBlock = _EndBlock(0);
-  SetCodeNodeLast(CodeNode, EndBlock);
 
   if (CurrentCodeBlock) {
     LinkCodeBlocks(CurrentCodeBlock, CodeNode);

--- a/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -17,8 +17,6 @@ static uint64_t getMask(T Op) {
 bool ConstProp::Run(IREmitter *IREmit) {
   bool Changed = false;
   auto CurrentIR = IREmit->ViewIR();
-  uintptr_t ListBegin = CurrentIR.GetListData();
-  uintptr_t DataBegin = CurrentIR.GetData();
 
   auto OriginalWriteCursor = IREmit->GetWriteCursor();
 
@@ -113,7 +111,7 @@ bool ConstProp::Run(IREmitter *IREmit) {
         Changed = true;
       } else if (Op->Header.Args[0].ID() == Op->Header.Args[1].ID()) {
         // AND with same value results in original value
-        IREmit->ReplaceAllUsesWith(CodeNode, Op->Header.Args[0].GetNode(ListBegin));
+        IREmit->ReplaceAllUsesWith(CodeNode, CurrentIR.GetNode(Op->Header.Args[0]));
         Changed = true;
       }
     break;
@@ -132,7 +130,7 @@ bool ConstProp::Run(IREmitter *IREmit) {
         Changed = true;
       } else if (Op->Header.Args[0].ID() == Op->Header.Args[1].ID()) {
         // OR with same value results in original value
-        IREmit->ReplaceAllUsesWith(CodeNode, Op->Header.Args[0].GetNode(ListBegin));
+        IREmit->ReplaceAllUsesWith(CodeNode, CurrentIR.GetNode(Op->Header.Args[0]));
         Changed = true;
       }
     break;
@@ -173,7 +171,7 @@ bool ConstProp::Run(IREmitter *IREmit) {
       else if (IREmit->IsValueConstant(Op->Header.Args[1], &Constant2) &&
                 Constant2 == 0) {
         IREmit->SetWriteCursor(CodeNode);
-        OrderedNode *Arg = Op->Header.Args[0].GetNode(ListBegin);
+        OrderedNode *Arg = CurrentIR.GetNode(Op->Header.Args[0]);
         IREmit->ReplaceAllUsesWith(CodeNode, Arg);
         Changed = true;
       }
@@ -193,10 +191,10 @@ bool ConstProp::Run(IREmitter *IREmit) {
         auto ConstantVal = IREmit->_Constant(NewConstant);
         IREmit->ReplaceAllUsesWith(CodeNode, ConstantVal);
         Changed = true;
-      } else if (IROp->Size == Op->Header.Args[0].GetNode(ListBegin)->Op(DataBegin)->Size && Op->Width == (IROp->Size * 8) && Op->lsb == 0 ) {
+      } else if (IROp->Size == CurrentIR.GetOp<IROp_Header>(Op->Header.Args[0])->Size && Op->Width == (IROp->Size * 8) && Op->lsb == 0 ) {
         // A BFE that extracts all bits results in original value
   // XXX - This is broken for now - see https://github.com/FEX-Emu/FEX/issues/351
-        // IREmit->ReplaceAllUsesWith(CodeNode, Op->Header.Args[0].GetNode(ListBegin));
+        // IREmit->ReplaceAllUsesWith(CodeNode, CurrentIR.GetNode(Op->Header.Args[0]));
         // Changed = true;
       }
 

--- a/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -20,19 +20,10 @@ bool ConstProp::Run(IREmitter *IREmit) {
   uintptr_t ListBegin = CurrentIR.GetListData();
   uintptr_t DataBegin = CurrentIR.GetData();
 
-  auto Begin = CurrentIR.begin();
-  auto Op = Begin();
-
-  OrderedNode *RealNode = Op->GetNode(ListBegin);
-  auto HeaderOp = RealNode->Op(DataBegin)->CW<FEXCore::IR::IROp_IRHeader>();
-  LogMan::Throw::A(HeaderOp->Header.Op == OP_IRHEADER, "First op wasn't IRHeader");
-
-  OrderedNode *BlockNode = HeaderOp->Blocks.GetNode(ListBegin);
-
   auto OriginalWriteCursor = IREmit->GetWriteCursor();
 
-  while (1) {
-    auto BlockIROp = BlockNode->Op(DataBegin)->CW<FEXCore::IR::IROp_CodeBlock>();
+  for (auto Block : CurrentIR.getBlocks()) {
+    auto BlockIROp = Block.GetNode(ListBegin)->Op(DataBegin)->CW<FEXCore::IR::IROp_CodeBlock>();
     LogMan::Throw::A(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
 
     // We grab these nodes this way so we can iterate easily
@@ -244,12 +235,6 @@ bool ConstProp::Run(IREmitter *IREmit) {
         break;
       }
       ++CodeBegin;
-    }
-
-    if (BlockIROp->Next.ID() == 0) {
-      break;
-    } else {
-      BlockNode = BlockIROp->Next.GetNode(ListBegin);
     }
   }
 

--- a/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -22,219 +22,201 @@ bool ConstProp::Run(IREmitter *IREmit) {
 
   auto OriginalWriteCursor = IREmit->GetWriteCursor();
 
-  for (auto [BlockNode, BlockHeader] : CurrentIR.getBlocks()) {
-    auto BlockIROp = BlockHeader->CW<FEXCore::IR::IROp_CodeBlock>();
-    LogMan::Throw::A(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
+  for (auto [CodeNode, IROp] : CurrentIR.GetAllCode()) {
 
-    // We grab these nodes this way so we can iterate easily
-    auto CodeBegin = CurrentIR.at(BlockIROp->Begin);
-    auto CodeLast = CurrentIR.at(BlockIROp->Last);
-    while (1) {
-      auto CodeOp = CodeBegin();
-      OrderedNode *CodeNode = CodeOp->GetNode(ListBegin);
-      auto IROp = CodeNode->Op(DataBegin);
-      switch (IROp->Op) {
+    switch (IROp->Op) {
 /*
-      case OP_UMUL:
-      case OP_DIV:
-      case OP_UDIV:
-      case OP_REM:
-      case OP_UREM:
-      case OP_MULH:
-      case OP_UMULH:
-      case OP_LSHR:
-      case OP_ASHR:
-      case OP_ROL:
-      case OP_ROR:
-      case OP_LDIV:
-      case OP_LUDIV:
-      case OP_LREM:
-      case OP_LUREM:
-      case OP_BFI:
-      {
-        uint64_t Constant1;
-        uint64_t Constant2;
+    case OP_UMUL:
+    case OP_DIV:
+    case OP_UDIV:
+    case OP_REM:
+    case OP_UREM:
+    case OP_MULH:
+    case OP_UMULH:
+    case OP_LSHR:
+    case OP_ASHR:
+    case OP_ROL:
+    case OP_ROR:
+    case OP_LDIV:
+    case OP_LUDIV:
+    case OP_LREM:
+    case OP_LUREM:
+    case OP_BFI:
+    {
+      uint64_t Constant1;
+      uint64_t Constant2;
 
-        if (IREmit->IsValueConstant(IROp->Args[0], &Constant1) &&
-            IREmit->IsValueConstant(IROp->Args[1], &Constant2)) {
-          LogMan::Msg::A("Could const prop op: %s", std::string(IR::GetName(IROp->Op)).c_str());
-        }
-      break;
+      if (IREmit->IsValueConstant(IROp->Args[0], &Constant1) &&
+          IREmit->IsValueConstant(IROp->Args[1], &Constant2)) {
+        LogMan::Msg::A("Could const prop op: %s", std::string(IR::GetName(IROp->Op)).c_str());
       }
+    break;
+    }
 
-      case OP_SEXT:
-      case OP_NEG:
-      case OP_POPCOUNT:
-      case OP_FINDLSB:
-      case OP_FINDMSB:
-      case OP_REV:
-      case OP_SBFE:
-      {
-        uint64_t Constant1;
+    case OP_SEXT:
+    case OP_NEG:
+    case OP_POPCOUNT:
+    case OP_FINDLSB:
+    case OP_FINDMSB:
+    case OP_REV:
+    case OP_SBFE:
+    {
+      uint64_t Constant1;
 
-        if (IREmit->IsValueConstant(IROp->Args[0], &Constant1)) {
-          LogMan::Msg::A("Could const prop op: %s", std::string(IR::GetName(IROp->Op)).c_str());
-        }
-      break;
+      if (IREmit->IsValueConstant(IROp->Args[0], &Constant1)) {
+        LogMan::Msg::A("Could const prop op: %s", std::string(IR::GetName(IROp->Op)).c_str());
       }
+    break;
+    }
 */
-      case OP_ADD: {
-        auto Op = IROp->C<IR::IROp_Add>();
-        uint64_t Constant1;
-        uint64_t Constant2;
+    case OP_ADD: {
+      auto Op = IROp->C<IR::IROp_Add>();
+      uint64_t Constant1;
+      uint64_t Constant2;
 
-        if (IREmit->IsValueConstant(Op->Header.Args[0], &Constant1) &&
-            IREmit->IsValueConstant(Op->Header.Args[1], &Constant2)) {
-          uint64_t NewConstant = (Constant1 + Constant2) & getMask(Op) ;
-          IREmit->SetWriteCursor(CodeNode);
-          auto ConstantVal = IREmit->_Constant(NewConstant);
-          IREmit->ReplaceAllUsesWithInclusive(CodeNode, ConstantVal, CodeBegin, CodeLast);
-          Changed = true;
-        }
-      break;
+      if (IREmit->IsValueConstant(Op->Header.Args[0], &Constant1) &&
+          IREmit->IsValueConstant(Op->Header.Args[1], &Constant2)) {
+        uint64_t NewConstant = (Constant1 + Constant2) & getMask(Op) ;
+        IREmit->SetWriteCursor(CodeNode);
+        auto ConstantVal = IREmit->_Constant(NewConstant);
+        IREmit->ReplaceAllUsesWith(CodeNode, ConstantVal);
+        Changed = true;
       }
-      case OP_SUB: {
-        auto Op = IROp->C<IR::IROp_Sub>();
-        uint64_t Constant1;
-        uint64_t Constant2;
+    break;
+    }
+    case OP_SUB: {
+      auto Op = IROp->C<IR::IROp_Sub>();
+      uint64_t Constant1;
+      uint64_t Constant2;
 
-        if (IREmit->IsValueConstant(Op->Header.Args[0], &Constant1) &&
-            IREmit->IsValueConstant(Op->Header.Args[1], &Constant2)) {
-          uint64_t NewConstant = (Constant1 - Constant2) & getMask(Op) ;
-          IREmit->SetWriteCursor(CodeNode);
-          auto ConstantVal = IREmit->_Constant(NewConstant);
-          IREmit->ReplaceAllUsesWithInclusive(CodeNode, ConstantVal, CodeBegin, CodeLast);
-          Changed = true;
-        }
-      break;
+      if (IREmit->IsValueConstant(Op->Header.Args[0], &Constant1) &&
+          IREmit->IsValueConstant(Op->Header.Args[1], &Constant2)) {
+        uint64_t NewConstant = (Constant1 - Constant2) & getMask(Op) ;
+        IREmit->SetWriteCursor(CodeNode);
+        auto ConstantVal = IREmit->_Constant(NewConstant);
+        IREmit->ReplaceAllUsesWith(CodeNode, ConstantVal);
+        Changed = true;
       }
-      case OP_AND: {
-        auto Op = IROp->CW<IR::IROp_And>();
-        uint64_t Constant1;
-        uint64_t Constant2;
+    break;
+    }
+    case OP_AND: {
+      auto Op = IROp->CW<IR::IROp_And>();
+      uint64_t Constant1;
+      uint64_t Constant2;
 
-        if (IREmit->IsValueConstant(Op->Header.Args[0], &Constant1) &&
-            IREmit->IsValueConstant(Op->Header.Args[1], &Constant2)) {
-          uint64_t NewConstant = (Constant1 & Constant2) & getMask(Op) ;
-          IREmit->SetWriteCursor(CodeNode);
-          auto ConstantVal = IREmit->_Constant(NewConstant);
-          IREmit->ReplaceAllUsesWithInclusive(CodeNode, ConstantVal, CodeBegin, CodeLast);
-          Changed = true;
-        } else if (Op->Header.Args[0].ID() == Op->Header.Args[1].ID()) {
-          // AND with same value results in original value
-          IREmit->ReplaceAllUsesWithInclusive(CodeNode, Op->Header.Args[0].GetNode(ListBegin), CodeBegin, CodeLast);
-          Changed = true;
-        }
-      break;
+      if (IREmit->IsValueConstant(Op->Header.Args[0], &Constant1) &&
+          IREmit->IsValueConstant(Op->Header.Args[1], &Constant2)) {
+        uint64_t NewConstant = (Constant1 & Constant2) & getMask(Op) ;
+        IREmit->SetWriteCursor(CodeNode);
+        auto ConstantVal = IREmit->_Constant(NewConstant);
+        IREmit->ReplaceAllUsesWith(CodeNode, ConstantVal);
+        Changed = true;
+      } else if (Op->Header.Args[0].ID() == Op->Header.Args[1].ID()) {
+        // AND with same value results in original value
+        IREmit->ReplaceAllUsesWith(CodeNode, Op->Header.Args[0].GetNode(ListBegin));
+        Changed = true;
       }
-      case OP_OR: {
-        auto Op = IROp->CW<IR::IROp_Or>();
-        uint64_t Constant1;
-        uint64_t Constant2;
+    break;
+    }
+    case OP_OR: {
+      auto Op = IROp->CW<IR::IROp_Or>();
+      uint64_t Constant1;
+      uint64_t Constant2;
 
-        if (IREmit->IsValueConstant(Op->Header.Args[0], &Constant1) &&
-            IREmit->IsValueConstant(Op->Header.Args[1], &Constant2)) {
-          uint64_t NewConstant = Constant1 | Constant2;
-          IREmit->SetWriteCursor(CodeNode);
-          auto ConstantVal = IREmit->_Constant(NewConstant);
-          IREmit->ReplaceAllUsesWithInclusive(CodeNode, ConstantVal, CodeBegin, CodeLast);
-          Changed = true;
-        } else if (Op->Header.Args[0].ID() == Op->Header.Args[1].ID()) {
-          // OR with same value results in original value
-          IREmit->ReplaceAllUsesWithInclusive(CodeNode, Op->Header.Args[0].GetNode(ListBegin), CodeBegin, CodeLast);
-          Changed = true;
-        }
-      break;
+      if (IREmit->IsValueConstant(Op->Header.Args[0], &Constant1) &&
+          IREmit->IsValueConstant(Op->Header.Args[1], &Constant2)) {
+        uint64_t NewConstant = Constant1 | Constant2;
+        IREmit->SetWriteCursor(CodeNode);
+        auto ConstantVal = IREmit->_Constant(NewConstant);
+        IREmit->ReplaceAllUsesWith(CodeNode, ConstantVal);
+        Changed = true;
+      } else if (Op->Header.Args[0].ID() == Op->Header.Args[1].ID()) {
+        // OR with same value results in original value
+        IREmit->ReplaceAllUsesWith(CodeNode, Op->Header.Args[0].GetNode(ListBegin));
+        Changed = true;
       }
-      case OP_XOR: {
-        auto Op = IROp->CW<IR::IROp_Xor>();
-        uint64_t Constant1;
-        uint64_t Constant2;
+    break;
+    }
+    case OP_XOR: {
+      auto Op = IROp->C<IR::IROp_Xor>();
+      uint64_t Constant1;
+      uint64_t Constant2;
 
-        if (IREmit->IsValueConstant(Op->Header.Args[0], &Constant1) &&
-            IREmit->IsValueConstant(Op->Header.Args[1], &Constant2)) {
-          uint64_t NewConstant = Constant1 ^ Constant2;
-          IREmit->SetWriteCursor(CodeNode);
-          auto ConstantVal = IREmit->_Constant(NewConstant);
-          IREmit->ReplaceAllUsesWithInclusive(CodeNode, ConstantVal, CodeBegin, CodeLast);
-          Changed = true;
-        } else if (Op->Header.Args[0].ID() == Op->Header.Args[1].ID()) {
-          // XOR with same value results to zero
-          IREmit->SetWriteCursor(CodeNode);
-          IREmit->ReplaceAllUsesWithInclusive(CodeNode, IREmit->_Constant(0), CodeBegin, CodeLast);
-          Changed = true;
-        }
-      break;
+      if (IREmit->IsValueConstant(Op->Header.Args[0], &Constant1) &&
+          IREmit->IsValueConstant(Op->Header.Args[1], &Constant2)) {
+        uint64_t NewConstant = Constant1 ^ Constant2;
+        IREmit->SetWriteCursor(CodeNode);
+        auto ConstantVal = IREmit->_Constant(NewConstant);
+        IREmit->ReplaceAllUsesWith(CodeNode, ConstantVal);
+        Changed = true;
+      } else if (Op->Header.Args[0].ID() == Op->Header.Args[1].ID()) {
+        // XOR with same value results to zero
+        IREmit->SetWriteCursor(CodeNode);
+        IREmit->ReplaceAllUsesWith(CodeNode, IREmit->_Constant(0));
+        Changed = true;
       }
-      case OP_LSHL: {
-        auto Op = IROp->CW<IR::IROp_Lshl>();
-        uint64_t Constant1;
-        uint64_t Constant2;
+    break;
+    }
+    case OP_LSHL: {
+      auto Op = IROp->CW<IR::IROp_Lshl>();
+      uint64_t Constant1;
+      uint64_t Constant2;
 
-        if (IREmit->IsValueConstant(Op->Header.Args[0], &Constant1) &&
-            IREmit->IsValueConstant(Op->Header.Args[1], &Constant2)) {
-          uint64_t NewConstant = (Constant1 << Constant2) & getMask(Op);
-          IREmit->SetWriteCursor(CodeNode);
-          auto ConstantVal = IREmit->_Constant(NewConstant);
-          IREmit->ReplaceAllUsesWithInclusive(CodeNode, ConstantVal, CodeBegin, CodeLast);
-          Changed = true;
-        }
-        else if (IREmit->IsValueConstant(Op->Header.Args[1], &Constant2) &&
-                 Constant2 == 0) {
-          IREmit->SetWriteCursor(CodeNode);
-          OrderedNode *Arg = Op->Header.Args[0].GetNode(ListBegin);
-          IREmit->ReplaceAllUsesWithInclusive(CodeNode, Arg, CodeBegin, CodeLast);
-          Changed = true;
-        }
-      break;
+      if (IREmit->IsValueConstant(Op->Header.Args[0], &Constant1) &&
+          IREmit->IsValueConstant(Op->Header.Args[1], &Constant2)) {
+        uint64_t NewConstant = (Constant1 << Constant2) & getMask(Op);
+        IREmit->SetWriteCursor(CodeNode);
+        auto ConstantVal = IREmit->_Constant(NewConstant);
+        IREmit->ReplaceAllUsesWith(CodeNode, ConstantVal);
+        Changed = true;
       }
-
-
-      case OP_BFE: {
-        auto Op = IROp->CW<IR::IROp_Bfe>();
-        uint64_t Constant;
-        if (IROp->Size <= 8 && IREmit->IsValueConstant(Op->Header.Args[0], &Constant)) {
-          uint64_t SourceMask = (1ULL << Op->Width) - 1;
-          if (Op->Width == 64)
-            SourceMask = ~0ULL;
-          SourceMask <<= Op->lsb;
-
-          uint64_t NewConstant = (Constant & SourceMask) >> Op->lsb;
-          IREmit->SetWriteCursor(CodeNode);
-          auto ConstantVal = IREmit->_Constant(NewConstant);
-          IREmit->ReplaceAllUsesWithInclusive(CodeNode, ConstantVal, CodeBegin, CodeLast);
-          Changed = true;
-        } else if (IROp->Size == Op->Header.Args[0].GetNode(ListBegin)->Op(DataBegin)->Size && Op->Width == (IROp->Size * 8) && Op->lsb == 0 ) {
-          // A BFE that extracts all bits results in original value
-	  // XXX - This is broken for now - see https://github.com/FEX-Emu/FEX/issues/351
-          // IREmit->ReplaceAllUsesWithInclusive(CodeNode, Op->Header.Args[0].GetNode(ListBegin), CodeBegin, CodeLast);
-          // Changed = true;
-        }
-
-      break;
+      else if (IREmit->IsValueConstant(Op->Header.Args[1], &Constant2) &&
+                Constant2 == 0) {
+        IREmit->SetWriteCursor(CodeNode);
+        OrderedNode *Arg = Op->Header.Args[0].GetNode(ListBegin);
+        IREmit->ReplaceAllUsesWith(CodeNode, Arg);
+        Changed = true;
       }
-      case OP_MUL: {
-        auto Op = IROp->C<IR::IROp_Mul>();
-        uint64_t Constant1;
-        uint64_t Constant2;
+    break;
+    }
+    case OP_BFE: {
+      auto Op = IROp->C<IR::IROp_Bfe>();
+      uint64_t Constant;
+      if (IROp->Size <= 8 && IREmit->IsValueConstant(Op->Header.Args[0], &Constant)) {
+        uint64_t SourceMask = (1ULL << Op->Width) - 1;
+        if (Op->Width == 64)
+          SourceMask = ~0ULL;
+        SourceMask <<= Op->lsb;
 
-        if (IREmit->IsValueConstant(Op->Header.Args[0], &Constant1) &&
-            IREmit->IsValueConstant(Op->Header.Args[1], &Constant2)) {
-          uint64_t NewConstant = (Constant1 * Constant2) & getMask(Op);
-          IREmit->SetWriteCursor(CodeNode);
-          auto ConstantVal = IREmit->_Constant(NewConstant);
-          IREmit->ReplaceAllUsesWithInclusive(CodeNode, ConstantVal, CodeBegin, CodeLast);
-          Changed = true;
-        }
-      }
-      default: break;
+        uint64_t NewConstant = (Constant & SourceMask) >> Op->lsb;
+        IREmit->SetWriteCursor(CodeNode);
+        auto ConstantVal = IREmit->_Constant(NewConstant);
+        IREmit->ReplaceAllUsesWith(CodeNode, ConstantVal);
+        Changed = true;
+      } else if (IROp->Size == Op->Header.Args[0].GetNode(ListBegin)->Op(DataBegin)->Size && Op->Width == (IROp->Size * 8) && Op->lsb == 0 ) {
+        // A BFE that extracts all bits results in original value
+  // XXX - This is broken for now - see https://github.com/FEX-Emu/FEX/issues/351
+        // IREmit->ReplaceAllUsesWith(CodeNode, Op->Header.Args[0].GetNode(ListBegin));
+        // Changed = true;
       }
 
-      // CodeLast is inclusive. So we still need to dump the CodeLast op as well
-      if (CodeBegin == CodeLast) {
-        break;
+    break;
+    }
+    case OP_MUL: {
+      auto Op = IROp->C<IR::IROp_Mul>();
+      uint64_t Constant1;
+      uint64_t Constant2;
+
+      if (IREmit->IsValueConstant(Op->Header.Args[0], &Constant1) &&
+          IREmit->IsValueConstant(Op->Header.Args[1], &Constant2)) {
+        uint64_t NewConstant = (Constant1 * Constant2) & getMask(Op);
+        IREmit->SetWriteCursor(CodeNode);
+        auto ConstantVal = IREmit->_Constant(NewConstant);
+        IREmit->ReplaceAllUsesWith(CodeNode, ConstantVal);
+        Changed = true;
       }
-      ++CodeBegin;
+    }
+    default: break;
     }
   }
 

--- a/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -22,8 +22,8 @@ bool ConstProp::Run(IREmitter *IREmit) {
 
   auto OriginalWriteCursor = IREmit->GetWriteCursor();
 
-  for (auto Block : CurrentIR.getBlocks()) {
-    auto BlockIROp = Block.GetNode(ListBegin)->Op(DataBegin)->CW<FEXCore::IR::IROp_CodeBlock>();
+  for (auto [BlockNode, BlockHeader] : CurrentIR.getBlocks()) {
+    auto BlockIROp = BlockHeader->CW<FEXCore::IR::IROp_CodeBlock>();
     LogMan::Throw::A(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
 
     // We grab these nodes this way so we can iterate easily

--- a/External/FEXCore/Source/Interface/IR/Passes/DeadCodeElimination.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/DeadCodeElimination.cpp
@@ -16,38 +16,17 @@ private:
 
 bool DeadCodeElimination::Run(IREmitter *IREmit) {
   auto CurrentIR = IREmit->ViewIR();
-
-  uintptr_t ListBegin = CurrentIR.GetListData();
-  uintptr_t DataBegin = CurrentIR.GetData();
-
   int NumRemoved = 0;
 
-  for (auto [BlockNode, BlockHeader] : CurrentIR.getBlocks()) {
-    auto BlockIROp = BlockHeader->CW<FEXCore::IR::IROp_CodeBlock>();
-    LogMan::Throw::A(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
+  for (auto [CodeNode, IROp] : CurrentIR.GetAllCode()) {
 
-    // We grab these nodes this way so we can iterate easily
-    auto CodeBegin = CurrentIR.at(BlockIROp->Begin);
-    auto CodeLast = CurrentIR.at(BlockIROp->Last);
-
-    while (1) {
-      auto CodeOp = CodeLast();
-      OrderedNode *CodeNode = CodeOp->GetNode(ListBegin);
-      auto IROp = CodeNode->Op(DataBegin);
-
-      // Skip over anything that has side effects
-      // Use count tracking can't safely remove anything with side effects
-      if (!IR::HasSideEffects(IROp->Op)) {
-        if (CodeNode->GetUses() == 0) {
-          NumRemoved++;
-          IREmit->Remove(CodeNode);
-        }
+    // Skip over anything that has side effects
+    // Use count tracking can't safely remove anything with side effects
+    if (!IR::HasSideEffects(IROp->Op)) {
+      if (CodeNode->GetUses() == 0) {
+        NumRemoved++;
+        IREmit->Remove(CodeNode);
       }
-
-      if (CodeLast == CodeBegin) {
-        break;
-      }
-      --CodeLast;
     }
   }
 

--- a/External/FEXCore/Source/Interface/IR/Passes/DeadCodeElimination.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/DeadCodeElimination.cpp
@@ -22,8 +22,8 @@ bool DeadCodeElimination::Run(IREmitter *IREmit) {
 
   int NumRemoved = 0;
 
-  for (auto Block : CurrentIR.getBlocks()) {
-    auto BlockIROp = Block.GetNode(ListBegin)->Op(DataBegin)->CW<FEXCore::IR::IROp_CodeBlock>();
+  for (auto [BlockNode, BlockHeader] : CurrentIR.getBlocks()) {
+    auto BlockIROp = BlockHeader->CW<FEXCore::IR::IROp_CodeBlock>();
     LogMan::Throw::A(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
 
     // We grab these nodes this way so we can iterate easily

--- a/External/FEXCore/Source/Interface/IR/Passes/DeadCodeElimination.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/DeadCodeElimination.cpp
@@ -20,19 +20,10 @@ bool DeadCodeElimination::Run(IREmitter *IREmit) {
   uintptr_t ListBegin = CurrentIR.GetListData();
   uintptr_t DataBegin = CurrentIR.GetData();
 
-  auto Begin = CurrentIR.begin();
-  auto Op = Begin();
-
-  OrderedNode *RealNode = Op->GetNode(ListBegin);
-  auto HeaderOp = RealNode->Op(DataBegin)->CW<FEXCore::IR::IROp_IRHeader>();
-  LogMan::Throw::A(HeaderOp->Header.Op == OP_IRHEADER, "First op wasn't IRHeader");
-
-  OrderedNode *BlockNode = HeaderOp->Blocks.GetNode(ListBegin);
-
   int NumRemoved = 0;
 
-  while (1) {
-    auto BlockIROp = BlockNode->Op(DataBegin)->CW<FEXCore::IR::IROp_CodeBlock>();
+  for (auto Block : CurrentIR.getBlocks()) {
+    auto BlockIROp = Block.GetNode(ListBegin)->Op(DataBegin)->CW<FEXCore::IR::IROp_CodeBlock>();
     LogMan::Throw::A(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
 
     // We grab these nodes this way so we can iterate easily
@@ -57,12 +48,6 @@ bool DeadCodeElimination::Run(IREmitter *IREmit) {
         break;
       }
       --CodeLast;
-    }
-
-    if (BlockIROp->Next.ID() == 0) {
-      break;
-    } else {
-      BlockNode = BlockIROp->Next.GetNode(ListBegin);
     }
   }
 

--- a/External/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
@@ -317,16 +317,8 @@ void RCLSE::CalculateControlFlowInfo(FEXCore::IR::IREmitter *IREmit) {
   uintptr_t ListBegin = CurrentIR.GetListData();
   uintptr_t DataBegin = CurrentIR.GetData();
 
-  auto Begin = CurrentIR.begin();
-  auto Op = Begin();
-
-  OrderedNode *RealNode = Op->GetNode(ListBegin);
-  auto HeaderOp = RealNode->Op(DataBegin)->CW<FEXCore::IR::IROp_IRHeader>();
-  LogMan::Throw::A(HeaderOp->Header.Op == OP_IRHEADER, "First op wasn't IRHeader");
-
-  // Walk the list and calculate the control flow
-  OrderedNode *BlockNode = HeaderOp->Blocks.GetNode(ListBegin);
-  while (1) {
+  for (auto Block : CurrentIR.getBlocks()) {
+    auto BlockNode = Block.GetNode(ListBegin);
     auto BlockIROp = BlockNode->Op(DataBegin)->CW<FEXCore::IR::IROp_CodeBlock>();
     LogMan::Throw::A(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
 
@@ -382,12 +374,6 @@ void RCLSE::CalculateControlFlowInfo(FEXCore::IR::IREmitter *IREmit) {
         break;
       }
       ++CodeBegin;
-    }
-
-    if (BlockIROp->Next.ID() == 0) {
-      break;
-    } else {
-      BlockNode = BlockIROp->Next.GetNode(ListBegin);
     }
   }
 }
@@ -449,8 +435,8 @@ bool RCLSE::RedundantStoreLoadElimination(FEXCore::IR::IREmitter *IREmit) {
 
   ContextInfo LocalInfo = ClassifiedStruct;
 
-  while (1) {
-    auto BlockIROp = BlockNode->Op(DataBegin)->CW<FEXCore::IR::IROp_CodeBlock>();
+  for (auto Block : CurrentIR.getBlocks()) {
+    auto BlockIROp = Block.GetNode(ListBegin)->Op(DataBegin)->CW<FEXCore::IR::IROp_CodeBlock>();
     LogMan::Throw::A(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
 
     ResetClassificationAccesses(&LocalInfo);
@@ -594,12 +580,6 @@ bool RCLSE::RedundantStoreLoadElimination(FEXCore::IR::IREmitter *IREmit) {
         break;
       }
       ++CodeBegin;
-    }
-
-    if (BlockIROp->Next.ID() == 0) {
-      break;
-    } else {
-      BlockNode = BlockIROp->Next.GetNode(ListBegin);
     }
   }
 

--- a/External/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
@@ -317,9 +317,8 @@ void RCLSE::CalculateControlFlowInfo(FEXCore::IR::IREmitter *IREmit) {
   uintptr_t ListBegin = CurrentIR.GetListData();
   uintptr_t DataBegin = CurrentIR.GetData();
 
-  for (auto Block : CurrentIR.getBlocks()) {
-    auto BlockNode = Block.GetNode(ListBegin);
-    auto BlockIROp = BlockNode->Op(DataBegin)->CW<FEXCore::IR::IROp_CodeBlock>();
+  for (auto [BlockNode, BlockHeader] : CurrentIR.getBlocks()) {
+    auto BlockIROp = BlockHeader->CW<FEXCore::IR::IROp_CodeBlock>();
     LogMan::Throw::A(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
 
     BlockInfo *CurrentBlock = &OffsetToBlockMap.try_emplace(BlockNode->Wrapped(ListBegin).ID()).first->second;
@@ -435,8 +434,8 @@ bool RCLSE::RedundantStoreLoadElimination(FEXCore::IR::IREmitter *IREmit) {
 
   ContextInfo LocalInfo = ClassifiedStruct;
 
-  for (auto Block : CurrentIR.getBlocks()) {
-    auto BlockIROp = Block.GetNode(ListBegin)->Op(DataBegin)->CW<FEXCore::IR::IROp_CodeBlock>();
+  for (auto [BlockNode, BlockHeader] : CurrentIR.getBlocks()) {
+    auto BlockIROp = BlockHeader->CW<FEXCore::IR::IROp_CodeBlock>();
     LogMan::Throw::A(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
 
     ResetClassificationAccesses(&LocalInfo);

--- a/External/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
@@ -314,30 +314,18 @@ void RCLSE::CalculateControlFlowInfo(FEXCore::IR::IREmitter *IREmit) {
 
   OffsetToBlockMap.clear();
   auto CurrentIR = IREmit->ViewIR();
-  uintptr_t ListBegin = CurrentIR.GetListData();
-  uintptr_t DataBegin = CurrentIR.GetData();
 
-  for (auto [BlockNode, BlockHeader] : CurrentIR.getBlocks()) {
-    auto BlockIROp = BlockHeader->CW<FEXCore::IR::IROp_CodeBlock>();
-    LogMan::Throw::A(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
+  for (auto [BlockNode, BlockHeader] : CurrentIR.GetBlocks()) {
+    BlockInfo *CurrentBlock = &OffsetToBlockMap.try_emplace(CurrentIR.GetID(BlockNode)).first->second;
 
-    BlockInfo *CurrentBlock = &OffsetToBlockMap.try_emplace(BlockNode->Wrapped(ListBegin).ID()).first->second;
-
-    // We grab these nodes this way so we can iterate easily
-    auto CodeBegin = CurrentIR.at(BlockIROp->Begin);
-    auto CodeLast = CurrentIR.at(BlockIROp->Last);
-
-    while (1) {
-      auto CodeOp = CodeBegin();
-      OrderedNode *CodeNode = CodeOp->GetNode(ListBegin);
-      auto IROp = CodeNode->Op(DataBegin);
+    for (auto [CodeNode, IROp] : CurrentIR.GetCode(BlockNode)) {
 
       switch (IROp->Op) {
         case IR::OP_CONDJUMP: {
           auto Op = IROp->CW<IR::IROp_CondJump>();
 
-          OrderedNode *TrueTargetNode = Op->Header.Args[1].GetNode(ListBegin);
-          OrderedNode *FalseTargetNode = Op->Header.Args[2].GetNode(ListBegin);
+          OrderedNode *TrueTargetNode = CurrentIR.GetNode(Op->Header.Args[1]);
+          OrderedNode *FalseTargetNode = CurrentIR.GetNode(Op->Header.Args[2]);
 
           CurrentBlock->Successors.emplace_back(TrueTargetNode);
           CurrentBlock->Successors.emplace_back(FalseTargetNode);
@@ -356,7 +344,7 @@ void RCLSE::CalculateControlFlowInfo(FEXCore::IR::IREmitter *IREmit) {
         }
         case IR::OP_JUMP: {
           auto Op = IROp->CW<IR::IROp_Jump>();
-          OrderedNode *TargetNode = Op->Header.Args[0].GetNode(ListBegin);
+          OrderedNode *TargetNode = CurrentIR.GetNode(Op->Header.Args[0]);
           CurrentBlock->Successors.emplace_back(TargetNode);
 
           {
@@ -367,12 +355,6 @@ void RCLSE::CalculateControlFlowInfo(FEXCore::IR::IREmitter *IREmit) {
         }
         default: break;
       }
-
-      // CodeLast is inclusive. So we still need to dump the CodeLast op as well
-      if (CodeBegin == CodeLast) {
-        break;
-      }
-      ++CodeBegin;
     }
   }
 }
@@ -418,41 +400,17 @@ bool RCLSE::RedundantStoreLoadElimination(FEXCore::IR::IREmitter *IREmit) {
 
   bool Changed = false;
   auto CurrentIR = IREmit->ViewIR();
-  uintptr_t ListBegin = CurrentIR.GetListData();
-  uintptr_t DataBegin = CurrentIR.GetData();
   auto OriginalWriteCursor = IREmit->GetWriteCursor();
 
-  auto Begin = CurrentIR.begin();
-  auto Op = Begin();
-
-  OrderedNode *RealNode = Op->GetNode(ListBegin);
-  auto HeaderOp = RealNode->Op(DataBegin)->CW<FEXCore::IR::IROp_IRHeader>();
-  LogMan::Throw::A(HeaderOp->Header.Op == OP_IRHEADER, "First op wasn't IRHeader");
-
-  // Walk the list and calculate the control flow
-  OrderedNode *BlockNode = HeaderOp->Blocks.GetNode(ListBegin);
+  // XXX: Walk the list and calculate the control flow
 
   ContextInfo LocalInfo = ClassifiedStruct;
 
-  for (auto [BlockNode, BlockHeader] : CurrentIR.getBlocks()) {
-    auto BlockIROp = BlockHeader->CW<FEXCore::IR::IROp_CodeBlock>();
-    LogMan::Throw::A(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
+  for (auto [BlockNode, BlockHeader] : CurrentIR.GetBlocks()) {
 
     ResetClassificationAccesses(&LocalInfo);
 
-    // We grab these nodes this way so we can iterate easily
-    auto CodeBegin = CurrentIR.at(BlockIROp->Begin);
-    auto CodeLast = CurrentIR.at(BlockIROp->Last);
-
-    auto OpSize = [&](OrderedNode *node) {
-      return node->Op(DataBegin)->Size;
-    };
-
-    while (1) {
-      auto CodeOp = CodeBegin();
-      OrderedNode *CodeNode = CodeOp->GetNode(ListBegin);
-      auto IROp = CodeNode->Op(DataBegin);
-
+    for (auto [CodeNode, IROp] : CurrentIR.GetCode(BlockNode)) {
       if (IROp->Op == OP_STORECONTEXT) {
         auto Op = IROp->CW<IR::IROp_StoreContext>();
         auto Info = FindMemberInfo(&LocalInfo, Op->Offset, IROp->Size);
@@ -461,7 +419,7 @@ bool RCLSE::RedundantStoreLoadElimination(FEXCore::IR::IREmitter *IREmit) {
         uint8_t LastSize = Info->AccessSize;
         LastAccessType LastAccess = Info->Accessed;
         OrderedNode *LastStoreNode = Info->StoreNode;
-        RecordAccess(Info, Op->Class, Op->Offset, IROp->Size, ACCESS_WRITE, Op->Header.Args[0].GetNode(ListBegin), CodeNode);
+        RecordAccess(Info, Op->Class, Op->Offset, IROp->Size, ACCESS_WRITE, CurrentIR.GetNode(Op->Header.Args[0]), CodeNode);
 
         if (LastAccess == ACCESS_WRITE &&
             LastClass == Op->Class &&
@@ -493,17 +451,17 @@ bool RCLSE::RedundantStoreLoadElimination(FEXCore::IR::IREmitter *IREmit) {
 
           IREmit->SetWriteCursor(CodeNode);
 
-          uint8_t TruncateSize = OpSize(LastNode);
+          uint8_t TruncateSize = IREmit->GetOpSize(LastNode);
 
           // Did store context do an implicit truncation?
-          if (OpSize(LastStoreNode) < TruncateSize)
-             TruncateSize = OpSize(LastStoreNode);
+          if (IREmit->GetOpSize(LastStoreNode) < TruncateSize)
+             TruncateSize = IREmit->GetOpSize(LastStoreNode);
 
           // Or are we doing a partial read
           if (IROp->Size < TruncateSize)
              TruncateSize = IROp->Size;
 
-          if (TruncateSize != OpSize(LastNode)) {
+          if (TruncateSize != IREmit->GetOpSize(LastNode)) {
             // We need to insert an explict truncation
             if (LastClass == FPRClass) {
               LastNode = IREmit->_VMov(LastNode, TruncateSize); // Vmov truncates and zexts when register width is smaller than source
@@ -518,7 +476,7 @@ bool RCLSE::RedundantStoreLoadElimination(FEXCore::IR::IREmitter *IREmit) {
             }
           }
 
-          IREmit->ReplaceAllUsesWithInclusive(CodeNode, LastNode, CodeBegin, CodeLast);
+          IREmit->ReplaceAllUsesWith(CodeNode, LastNode);
           RecordAccess(Info, Op->Class, Op->Offset, IROp->Size, ACCESS_READ, LastNode);
           Changed = true;
         }
@@ -528,7 +486,7 @@ bool RCLSE::RedundantStoreLoadElimination(FEXCore::IR::IREmitter *IREmit) {
                  LastSize == IROp->Size &&
                  Info->Accessed == ACCESS_READ) {
           // Did we read and then read again?
-          IREmit->ReplaceAllUsesWithInclusive(CodeNode, LastNode, CodeBegin, CodeLast);
+          IREmit->ReplaceAllUsesWith(CodeNode, LastNode);
           RecordAccess(Info, Op->Class, Op->Offset, IROp->Size, ACCESS_READ, LastNode);
           Changed = true;
         }
@@ -537,7 +495,7 @@ bool RCLSE::RedundantStoreLoadElimination(FEXCore::IR::IREmitter *IREmit) {
         auto Op = IROp->CW<IR::IROp_StoreFlag>();
         auto Info = FindMemberInfo(&LocalInfo, offsetof(FEXCore::Core::CPUState, flags[0]) + Op->Flag, 1);
         auto LastStoreNode = Info->StoreNode;
-        RecordAccess(&LocalInfo, FEXCore::IR::GPRClass, offsetof(FEXCore::Core::CPUState, flags[0]) + Op->Flag, 1, ACCESS_WRITE, Op->Header.Args[0].GetNode(ListBegin), CodeNode);
+        RecordAccess(&LocalInfo, FEXCore::IR::GPRClass, offsetof(FEXCore::Core::CPUState, flags[0]) + Op->Flag, 1, ACCESS_WRITE, CurrentIR.GetNode(Op->Header.Args[0]), CodeNode);
 
         // Flags don't alias, so we can take the simple route here. Kill any flags that have been overwritten
         if (LastStoreNode != nullptr)
@@ -556,12 +514,12 @@ bool RCLSE::RedundantStoreLoadElimination(FEXCore::IR::IREmitter *IREmit) {
           // If the last store matches this load value then we can replace the loaded value with the previous valid one
           IREmit->SetWriteCursor(CodeNode);
           auto Res = IREmit->_Bfe(1, 0, LastNode);
-          IREmit->ReplaceAllUsesWithInclusive(CodeNode, Res, CodeBegin, CodeLast);
+          IREmit->ReplaceAllUsesWith(CodeNode, Res);
           RecordAccess(Info, FEXCore::IR::GPRClass, offsetof(FEXCore::Core::CPUState, flags[0]) + Op->Flag, 1, ACCESS_READ, LastNode);
           Changed = true;
         }
         else if (LastAccess == ACCESS_READ) {
-          IREmit->ReplaceAllUsesWithInclusive(CodeNode, LastNode, CodeBegin, CodeLast);
+          IREmit->ReplaceAllUsesWith(CodeNode, LastNode);
           RecordAccess(Info, FEXCore::IR::GPRClass, offsetof(FEXCore::Core::CPUState, flags[0]) + Op->Flag, 1, ACCESS_READ, LastNode);
           Changed = true;
         }
@@ -573,12 +531,6 @@ bool RCLSE::RedundantStoreLoadElimination(FEXCore::IR::IREmitter *IREmit) {
         // We can't track through these
         ResetClassificationAccesses(&LocalInfo);
       }
-
-      // CodeLast is inclusive. So we still need to dump the CodeLast op as well
-      if (CodeBegin == CodeLast) {
-        break;
-      }
-      ++CodeBegin;
     }
   }
 

--- a/External/FEXCore/Source/Interface/IR/Passes/DeadFlagStoreElimination.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/DeadFlagStoreElimination.cpp
@@ -18,10 +18,10 @@ struct FlagInfo {
  * @brief This is a temporary pass to detect simple multiblock dead flag stores
  *
  * First pass computes which flags are read and written per block
- * 
+ *
  * Second pass computes which flags are stored, but overwritten by the next block(s).
  * It also propagates this information a few times to catch dead flags across multiple blocks.
- * 
+ *
  * Third pass removes the dead stores.
  *
  */
@@ -30,33 +30,13 @@ bool DeadFlagStoreElimination::Run(IREmitter *IREmit) {
 
   bool Changed = false;
   auto CurrentIR = IREmit->ViewIR();
-  uintptr_t ListBegin = CurrentIR.GetListData();
-  uintptr_t DataBegin = CurrentIR.GetData();
-
-  auto Begin = CurrentIR.begin();
-  auto Op = Begin();
-
-  OrderedNode *RealNode = Op->GetNode(ListBegin);
-  auto HeaderOp = RealNode->Op(DataBegin)->CW<FEXCore::IR::IROp_IRHeader>();
-  LogMan::Throw::A(HeaderOp->Header.Op == OP_IRHEADER, "First op wasn't IRHeader");
 
   // Pass 1
   // Compute flags read/writes per block
   // This is conservative and doesn't try to be smart about loads after writes
   {
-    OrderedNode *BlockNode = HeaderOp->Blocks.GetNode(ListBegin);
-
-    while (1) {
-      auto BlockIROp = BlockNode->Op(DataBegin)->CW<FEXCore::IR::IROp_CodeBlock>();
-      LogMan::Throw::A(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
-
-      // We grab these nodes this way so we can iterate easily
-      auto CodeBegin = CurrentIR.at(BlockIROp->Begin);
-      auto CodeLast = CurrentIR.at(BlockIROp->Last);
-      while (1) {
-        auto CodeOp = CodeBegin();
-        OrderedNode *CodeNode = CodeOp->GetNode(ListBegin);
-        auto IROp = CodeNode->Op(DataBegin);
+    for (auto [BlockNode, BlockIROp] : CurrentIR.GetBlocks()) {
+      for (auto [CodeNode, IROp] : CurrentIR.GetCode(BlockNode)) {
 
         if (IROp->Op == OP_STOREFLAG) {
           auto Op = IROp->CW<IR::IROp_StoreFlag>();
@@ -67,17 +47,6 @@ bool DeadFlagStoreElimination::Run(IREmitter *IREmit) {
           FlagMap[BlockNode].reads |= 1 << Op->Flag;
         }
 
-        // CodeLast is inclusive. So we still need to dump the CodeLast op as well
-        if (CodeBegin == CodeLast) {
-          break;
-        }
-        ++CodeBegin;
-      }
-
-      if (BlockIROp->Next.ID() == 0) {
-        break;
-      } else {
-        BlockNode = BlockIROp->Next.GetNode(ListBegin);
       }
     }
   }
@@ -87,23 +56,12 @@ bool DeadFlagStoreElimination::Run(IREmitter *IREmit) {
   // Propagate the information a few times to eliminate more
   for (int i = 0; i < 5; i++)
   {
-    OrderedNode *BlockNode = HeaderOp->Blocks.GetNode(ListBegin);
-
-    while (1) {
-      auto BlockIROp = BlockNode->Op(DataBegin)->CW<FEXCore::IR::IROp_CodeBlock>();
-      LogMan::Throw::A(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
-
-      // We grab these nodes this way so we can iterate easily
-      auto CodeBegin = CurrentIR.at(BlockIROp->Begin);
-      auto CodeLast = CurrentIR.at(BlockIROp->Last);
-      while (1) {
-        auto CodeOp = CodeBegin();
-        OrderedNode *CodeNode = CodeOp->GetNode(ListBegin);
-        auto IROp = CodeNode->Op(DataBegin);
+    for (auto [BlockNode, BlockIROp] : CurrentIR.GetBlocks()) {
+      for (auto [CodeNode, IROp] : CurrentIR.GetCode(BlockNode)) {
 
         if (IROp->Op == OP_JUMP) {
           auto Op = IROp->CW<IR::IROp_Jump>();
-          OrderedNode *TargetNode = Op->Header.Args[0].GetNode(ListBegin);
+          OrderedNode *TargetNode = CurrentIR.GetNode(Op->Header.Args[0]);
 
           // stores to remove are written by the next block but not read
           FlagMap[BlockNode].kill = FlagMap[TargetNode].writes & ~(FlagMap[TargetNode].reads);
@@ -114,8 +72,8 @@ bool DeadFlagStoreElimination::Run(IREmitter *IREmit) {
         else if (IROp->Op == OP_CONDJUMP) {
           auto Op = IROp->CW<IR::IROp_CondJump>();
 
-          OrderedNode *TrueTargetNode = Op->Header.Args[1].GetNode(ListBegin);
-          OrderedNode *FalseTargetNode = Op->Header.Args[2].GetNode(ListBegin);
+          OrderedNode *TrueTargetNode = CurrentIR.GetNode(Op->Header.Args[1]);
+          OrderedNode *FalseTargetNode = CurrentIR.GetNode(Op->Header.Args[2]);
 
           // stores to remove are written by the next blocks but not read
           FlagMap[BlockNode].kill = FlagMap[TrueTargetNode].writes & ~(FlagMap[TrueTargetNode].reads);
@@ -124,18 +82,6 @@ bool DeadFlagStoreElimination::Run(IREmitter *IREmit) {
           // Flags that are written by the next blocks can be considered as written by this block, if not read
           FlagMap[BlockNode].writes |= FlagMap[BlockNode].kill & ~FlagMap[BlockNode].reads;
         }
-
-        // CodeLast is inclusive. So we still need to dump the CodeLast op as well
-        if (CodeBegin == CodeLast) {
-          break;
-        }
-        ++CodeBegin;
-      }
-
-      if (BlockIROp->Next.ID() == 0) {
-        break;
-      } else {
-        BlockNode = BlockIROp->Next.GetNode(ListBegin);
       }
     }
   }
@@ -143,19 +89,8 @@ bool DeadFlagStoreElimination::Run(IREmitter *IREmit) {
   // Pass 3
   // Remove the dead stores
   {
-    OrderedNode *BlockNode = HeaderOp->Blocks.GetNode(ListBegin);
-
-    while (1) {
-      auto BlockIROp = BlockNode->Op(DataBegin)->CW<FEXCore::IR::IROp_CodeBlock>();
-      LogMan::Throw::A(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
-
-      // We grab these nodes this way so we can iterate easily
-      auto CodeBegin = CurrentIR.at(BlockIROp->Begin);
-      auto CodeLast = CurrentIR.at(BlockIROp->Last);
-      while (1) {
-        auto CodeOp = CodeBegin();
-        OrderedNode *CodeNode = CodeOp->GetNode(ListBegin);
-        auto IROp = CodeNode->Op(DataBegin);
+    for (auto [BlockNode, BlockIROp] : CurrentIR.GetBlocks()) {
+      for (auto [CodeNode, IROp] : CurrentIR.GetCode(BlockNode)) {
 
         if (IROp->Op == OP_STOREFLAG) {
           auto Op = IROp->CW<IR::IROp_StoreFlag>();
@@ -166,17 +101,6 @@ bool DeadFlagStoreElimination::Run(IREmitter *IREmit) {
           }
         }
 
-        // CodeLast is inclusive. So we still need to dump the CodeLast op as well
-        if (CodeBegin == CodeLast) {
-          break;
-        }
-        ++CodeBegin;
-      }
-
-      if (BlockIROp->Next.ID() == 0) {
-        break;
-      } else {
-        BlockNode = BlockIROp->Next.GetNode(ListBegin);
       }
     }
   }

--- a/External/FEXCore/Source/Interface/IR/Passes/IRCompaction.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/IRCompaction.cpp
@@ -74,9 +74,8 @@ bool IRCompaction::Run(IREmitter *IREmit) {
   {
     // Generate our codeblocks and link them together
     OrderedNode* PrevCodeBlock{};
-    for (auto Block : CurrentIR.getBlocks()) {
-      auto BlockNode = Block.GetNode(ListBegin);
-      auto BlockIROp = BlockNode->Op(DataBegin)->CW<FEXCore::IR::IROp_CodeBlock>();
+    for (auto [BlockNode, BlockHeader] : CurrentIR.getBlocks()) {
+      auto BlockIROp = BlockHeader->CW<FEXCore::IR::IROp_CodeBlock>();
       LogMan::Throw::A(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
 
       auto LocalBlockIRNode = LocalBuilder._CodeBlock(LocalHeaderOp, LocalHeaderOp); // Use LocalHeaderOp as a dummy arg for now

--- a/External/FEXCore/Source/Interface/IR/Passes/IRCompaction.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/IRCompaction.cpp
@@ -73,7 +73,6 @@ bool IRCompaction::Run(IREmitter *IREmit) {
 
   {
     // Generate our codeblocks and link them together
-    OrderedNode* PrevCodeBlock{};
     for (auto [BlockNode, BlockHeader] : CurrentIR.GetBlocks()) {
       LogMan::Throw::A(BlockHeader->Op == OP_CODEBLOCK, "IR type failed to be a code block");
 
@@ -86,12 +85,14 @@ bool IRCompaction::Run(IREmitter *IREmit) {
     LocalHeaderOp.first->Blocks = GeneratedCodeBlocks[0].NewNode->Wrapped(LocalListBegin);
   }
 
-  // Isolate the nodes from the Block headers
-  LocalBuilder.SetWriteCursor(nullptr);
+
 
   {
     // Copy all of our IR ops over to the new location
     for (auto &Block : GeneratedCodeBlocks) {
+
+      // Isolate block contents from any previous headers/blocks
+      LocalBuilder.SetWriteCursor(nullptr);
 
       CodeBlockData FirstNode{};
       CodeBlockData LastNode{};

--- a/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
@@ -47,9 +47,8 @@ bool IRValidation::Run(IREmitter *IREmit) {
     RAPass = Manager->GetRAPass();
   }
 
-  for (auto Block : CurrentIR.getBlocks()) {
-    auto BlockNode = Block.GetNode(ListBegin);
-    auto BlockIROp = BlockNode->Op(DataBegin)->CW<FEXCore::IR::IROp_CodeBlock>();
+  for (auto [BlockNode, BlockHeader] : CurrentIR.getBlocks()) {
+    auto BlockIROp = BlockHeader->CW<FEXCore::IR::IROp_CodeBlock>();
     LogMan::Throw::A(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
 
     BlockInfo *CurrentBlock = &OffsetToBlockMap.try_emplace(BlockNode->Wrapped(ListBegin).ID()).first->second;

--- a/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
@@ -47,7 +47,7 @@ bool IRValidation::Run(IREmitter *IREmit) {
     RAPass = Manager->GetRAPass();
   }
 
-  for (auto [BlockNode, BlockHeader] : CurrentIR.getBlocks()) {
+  for (auto [BlockNode, BlockHeader] : CurrentIR.GetBlocks()) {
     auto BlockIROp = BlockHeader->CW<FEXCore::IR::IROp_CodeBlock>();
     LogMan::Throw::A(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
 

--- a/External/FEXCore/Source/Interface/IR/Passes/PhiValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/PhiValidation.cpp
@@ -18,17 +18,9 @@ bool PhiValidation::Run(IREmitter *IREmit) {
 
   std::ostringstream Errors;
 
-  auto Begin = CurrentIR.begin();
-  auto Op = Begin();
-
-  OrderedNode *RealNode = Op->GetNode(ListBegin);
-  auto HeaderOp = RealNode->Op(DataBegin)->CW<FEXCore::IR::IROp_IRHeader>();
-  LogMan::Throw::A(HeaderOp->Header.Op == OP_IRHEADER, "First op wasn't IRHeader");
-
   // Walk the list and calculate the control flow
-  OrderedNode *BlockNode = HeaderOp->Blocks.GetNode(ListBegin);
-  while (1) {
-    auto BlockIROp = BlockNode->Op(DataBegin)->CW<FEXCore::IR::IROp_CodeBlock>();
+  for (auto Block : CurrentIR.getBlocks()) {
+    auto BlockIROp = Block.GetNode(ListBegin)->Op(DataBegin)->CW<FEXCore::IR::IROp_CodeBlock>();
     LogMan::Throw::A(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
 
     // We grab these nodes this way so we can iterate easily
@@ -67,12 +59,6 @@ bool PhiValidation::Run(IREmitter *IREmit) {
         break;
       }
       ++CodeBegin;
-    }
-
-    if (BlockIROp->Next.ID() == 0) {
-      break;
-    } else {
-      BlockNode = BlockIROp->Next.GetNode(ListBegin);
     }
   }
 

--- a/External/FEXCore/Source/Interface/IR/Passes/PhiValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/PhiValidation.cpp
@@ -24,8 +24,8 @@ bool PhiValidation::Run(IREmitter *IREmit) {
     for (auto [CodeNode, IROp] : CurrentIR.GetCode(BlockNode)) {
 
       switch (IROp->Op) {
-        // DUMMY doesn't matter for us
-        case IR::OP_DUMMY: break;
+        // BEGINBLOCK doesn't matter for us
+        case IR::OP_BEGINBLOCK: break;
         case IR::OP_PHIVALUE:
         case IR::OP_PHI: {
           if (FoundNonPhi) {

--- a/External/FEXCore/Source/Interface/IR/Passes/PhiValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/PhiValidation.cpp
@@ -19,8 +19,8 @@ bool PhiValidation::Run(IREmitter *IREmit) {
   std::ostringstream Errors;
 
   // Walk the list and calculate the control flow
-  for (auto Block : CurrentIR.getBlocks()) {
-    auto BlockIROp = Block.GetNode(ListBegin)->Op(DataBegin)->CW<FEXCore::IR::IROp_CodeBlock>();
+  for (auto [BlockNode, BlockHeader] : CurrentIR.getBlocks()) {
+    auto BlockIROp = BlockHeader->CW<FEXCore::IR::IROp_CodeBlock>();
     LogMan::Throw::A(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
 
     // We grab these nodes this way so we can iterate easily

--- a/External/FEXCore/Source/Interface/IR/Passes/RedundantFlagCalculationElimination.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/RedundantFlagCalculationElimination.cpp
@@ -27,17 +27,8 @@ bool DeadFlagCalculationEliminination::Run(IREmitter *IREmit) {
   uintptr_t ListBegin = CurrentIR.GetListData();
   uintptr_t DataBegin = CurrentIR.GetData();
 
-  auto Begin = CurrentIR.begin();
-  auto Op = Begin();
-
-  OrderedNode *RealNode = Op->GetNode(ListBegin);
-  auto HeaderOp = RealNode->Op(DataBegin)->CW<FEXCore::IR::IROp_IRHeader>();
-  LogMan::Throw::A(HeaderOp->Header.Op == OP_IRHEADER, "First op wasn't IRHeader");
-
-  OrderedNode *BlockNode = HeaderOp->Blocks.GetNode(ListBegin);
-
-  while (1) {
-    auto BlockIROp = BlockNode->Op(DataBegin)->CW<FEXCore::IR::IROp_CodeBlock>();
+  for (auto Block : CurrentIR.getBlocks()) {
+    auto BlockIROp = Block.GetNode(ListBegin)->Op(DataBegin)->CW<FEXCore::IR::IROp_CodeBlock>();
     LogMan::Throw::A(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
 
     // We grab these nodes this way so we can iterate easily
@@ -63,12 +54,6 @@ bool DeadFlagCalculationEliminination::Run(IREmitter *IREmit) {
         break;
       }
       ++CodeBegin;
-    }
-
-    if (BlockIROp->Next.ID() == 0) {
-      break;
-    } else {
-      BlockNode = BlockIROp->Next.GetNode(ListBegin);
     }
 
     // If any flags are stored but not loaded by the end of the block, then erase them

--- a/External/FEXCore/Source/Interface/IR/Passes/RedundantFlagCalculationElimination.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/RedundantFlagCalculationElimination.cpp
@@ -27,8 +27,8 @@ bool DeadFlagCalculationEliminination::Run(IREmitter *IREmit) {
   uintptr_t ListBegin = CurrentIR.GetListData();
   uintptr_t DataBegin = CurrentIR.GetData();
 
-  for (auto Block : CurrentIR.getBlocks()) {
-    auto BlockIROp = Block.GetNode(ListBegin)->Op(DataBegin)->CW<FEXCore::IR::IROp_CodeBlock>();
+  for (auto [BlockNode, BlockHeader] : CurrentIR.getBlocks()) {
+    auto BlockIROp = BlockHeader->CW<FEXCore::IR::IROp_CodeBlock>();
     LogMan::Throw::A(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
 
     // We grab these nodes this way so we can iterate easily

--- a/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -261,7 +261,7 @@ namespace {
     uintptr_t ListBegin = IR->GetListData();
     uintptr_t DataBegin = IR->GetData();
 
-    for (auto [BlockNode, BlockHeader] : IR->getBlocks()) {
+    for (auto [BlockNode, BlockHeader] : IR->GetBlocks()) {
     auto BlockIROp = BlockHeader->CW<FEXCore::IR::IROp_CodeBlock>();
       LogMan::Throw::A(BlockIROp->Header.Op == FEXCore::IR::OP_CODEBLOCK, "IR type failed to be a code block");
 
@@ -384,7 +384,7 @@ namespace FEXCore::IR {
     uintptr_t DataBegin = IR->GetData();
 
     constexpr uint32_t DEFAULT_REMAT_COST = 1000;
-    for (auto [BlockNode, BlockHeader] : IR->getBlocks()) {
+    for (auto [BlockNode, BlockHeader] : IR->GetBlocks()) {
       auto BlockIROp = BlockHeader->CW<FEXCore::IR::IROp_CodeBlock>();
       LogMan::Throw::A(BlockIROp->Header.Op == IR::OP_CODEBLOCK, "IR type failed to be a code block");
 
@@ -465,7 +465,7 @@ namespace FEXCore::IR {
     using namespace FEXCore;
     uintptr_t ListBegin = IR->GetListData();
 
-    for (auto [BlockNode, BlockHeader] : IR->getBlocks()) {
+    for (auto [BlockNode, BlockHeader] : IR->GetBlocks()) {
       auto BlockIROp = BlockHeader->CW<FEXCore::IR::IROp_CodeBlock>();
       LogMan::Throw::A(BlockIROp->Header.Op == IR::OP_CODEBLOCK, "IR type failed to be a code block");
 
@@ -518,7 +518,7 @@ namespace FEXCore::IR {
     using namespace FEXCore;
     uintptr_t ListBegin = IR->GetListData();
 
-    for (auto [BlockNode, BlockHeader] : IR->getBlocks()) {
+    for (auto [BlockNode, BlockHeader] : IR->GetBlocks()) {
       auto BlockIROp = BlockHeader->CW<FEXCore::IR::IROp_CodeBlock>();
       LogMan::Throw::A(BlockIROp->Header.Op == IR::OP_CODEBLOCK, "IR type failed to be a code block");
 

--- a/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -261,16 +261,8 @@ namespace {
     uintptr_t ListBegin = IR->GetListData();
     uintptr_t DataBegin = IR->GetData();
 
-    auto Begin = IR->begin();
-    auto Op = Begin();
-
-    FEXCore::IR::OrderedNode *RealNode = Op->GetNode(ListBegin);
-    auto HeaderOp = RealNode->Op(DataBegin)->CW<FEXCore::IR::IROp_IRHeader>();
-    LogMan::Throw::A(HeaderOp->Header.Op == FEXCore::IR::OP_IRHEADER, "First op wasn't IRHeader");
-
-    FEXCore::IR::OrderedNode *BlockNode = HeaderOp->Blocks.GetNode(ListBegin);
-
-    while (1) {
+    for (auto Block : IR->getBlocks()) {
+      auto BlockNode = Block.GetNode(ListBegin);
       auto BlockIROp = BlockNode->Op(DataBegin)->CW<FEXCore::IR::IROp_CodeBlock>();
       LogMan::Throw::A(BlockIROp->Header.Op == FEXCore::IR::OP_CODEBLOCK, "IR type failed to be a code block");
 
@@ -293,12 +285,6 @@ namespace {
           break;
         }
         ++CodeBegin;
-      }
-
-      if (BlockIROp->Next.ID() == 0) {
-        break;
-      } else {
-        BlockNode = BlockIROp->Next.GetNode(ListBegin);
       }
     }
   }
@@ -398,17 +384,9 @@ namespace FEXCore::IR {
     uintptr_t ListBegin = IR->GetListData();
     uintptr_t DataBegin = IR->GetData();
 
-    auto Begin = IR->begin();
-    auto Op = Begin();
-
-    IR::OrderedNode *RealNode = Op->GetNode(ListBegin);
-    auto HeaderOp = RealNode->Op(DataBegin)->CW<FEXCore::IR::IROp_IRHeader>();
-    LogMan::Throw::A(HeaderOp->Header.Op == IR::OP_IRHEADER, "First op wasn't IRHeader");
-
-    IR::OrderedNode *BlockNode = HeaderOp->Blocks.GetNode(ListBegin);
-
     constexpr uint32_t DEFAULT_REMAT_COST = 1000;
-    while (1) {
+    for (auto Block : IR->getBlocks()) {
+      auto BlockNode = Block.GetNode(ListBegin);
       auto BlockIROp = BlockNode->Op(DataBegin)->CW<FEXCore::IR::IROp_CodeBlock>();
       LogMan::Throw::A(BlockIROp->Header.Op == IR::OP_CODEBLOCK, "IR type failed to be a code block");
 
@@ -482,12 +460,6 @@ namespace FEXCore::IR {
         }
         ++CodeBegin;
       }
-
-      if (BlockIROp->Next.ID() == 0) {
-        break;
-      } else {
-        BlockNode = BlockIROp->Next.GetNode(ListBegin);
-      }
     }
   }
 
@@ -496,16 +468,8 @@ namespace FEXCore::IR {
     uintptr_t ListBegin = IR->GetListData();
     uintptr_t DataBegin = IR->GetData();
 
-    auto Begin = IR->begin();
-    auto Op = Begin();
-
-    IR::OrderedNode *RealNode = Op->GetNode(ListBegin);
-    auto HeaderOp = RealNode->Op(DataBegin)->CW<FEXCore::IR::IROp_IRHeader>();
-    LogMan::Throw::A(HeaderOp->Header.Op == IR::OP_IRHEADER, "First op wasn't IRHeader");
-
-    IR::OrderedNode *BlockNode = HeaderOp->Blocks.GetNode(ListBegin);
-
-    while (1) {
+    for (auto Block : IR->getBlocks()) {
+      auto BlockNode = Block.GetNode(ListBegin);
       auto BlockIROp = BlockNode->Op(DataBegin)->CW<FEXCore::IR::IROp_CodeBlock>();
       LogMan::Throw::A(BlockIROp->Header.Op == IR::OP_CODEBLOCK, "IR type failed to be a code block");
 
@@ -537,12 +501,6 @@ namespace FEXCore::IR {
         }
         ++CodeBegin;
       }
-
-      if (BlockIROp->Next.ID() == 0) {
-        break;
-      } else {
-        BlockNode = BlockIROp->Next.GetNode(ListBegin);
-      }
     }
   }
 
@@ -565,16 +523,8 @@ namespace FEXCore::IR {
     uintptr_t ListBegin = IR->GetListData();
     uintptr_t DataBegin = IR->GetData();
 
-    auto Begin = IR->begin();
-    auto Op = Begin();
-
-    IR::OrderedNode *RealNode = Op->GetNode(ListBegin);
-    auto HeaderOp = RealNode->Op(DataBegin)->CW<FEXCore::IR::IROp_IRHeader>();
-    LogMan::Throw::A(HeaderOp->Header.Op == IR::OP_IRHEADER, "First op wasn't IRHeader");
-
-    IR::OrderedNode *BlockNode = HeaderOp->Blocks.GetNode(ListBegin);
-
-    while (1) {
+    for (auto Block : IR->getBlocks()) {
+      auto BlockNode = Block.GetNode(ListBegin);
       auto BlockIROp = BlockNode->Op(DataBegin)->CW<FEXCore::IR::IROp_CodeBlock>();
       LogMan::Throw::A(BlockIROp->Header.Op == IR::OP_CODEBLOCK, "IR type failed to be a code block");
 
@@ -623,12 +573,6 @@ namespace FEXCore::IR {
           break;
         }
         ++CodeBegin;
-      }
-
-      if (BlockIROp->Next.ID() == 0) {
-        break;
-      } else {
-        BlockNode = BlockIROp->Next.GetNode(ListBegin);
       }
     }
   }
@@ -1165,12 +1109,6 @@ namespace FEXCore::IR {
           break;
         }
         ++CodeBegin;
-      }
-
-      if (BlockIROp->Next.ID() == 0) {
-        break;
-      } else {
-        BlockNode = BlockIROp->Next.GetNode(ListBegin);
       }
     }
   }

--- a/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -261,9 +261,8 @@ namespace {
     uintptr_t ListBegin = IR->GetListData();
     uintptr_t DataBegin = IR->GetData();
 
-    for (auto Block : IR->getBlocks()) {
-      auto BlockNode = Block.GetNode(ListBegin);
-      auto BlockIROp = BlockNode->Op(DataBegin)->CW<FEXCore::IR::IROp_CodeBlock>();
+    for (auto [BlockNode, BlockHeader] : IR->getBlocks()) {
+    auto BlockIROp = BlockHeader->CW<FEXCore::IR::IROp_CodeBlock>();
       LogMan::Throw::A(BlockIROp->Header.Op == FEXCore::IR::OP_CODEBLOCK, "IR type failed to be a code block");
 
       // We grab these nodes this way so we can iterate easily
@@ -385,9 +384,8 @@ namespace FEXCore::IR {
     uintptr_t DataBegin = IR->GetData();
 
     constexpr uint32_t DEFAULT_REMAT_COST = 1000;
-    for (auto Block : IR->getBlocks()) {
-      auto BlockNode = Block.GetNode(ListBegin);
-      auto BlockIROp = BlockNode->Op(DataBegin)->CW<FEXCore::IR::IROp_CodeBlock>();
+    for (auto [BlockNode, BlockHeader] : IR->getBlocks()) {
+      auto BlockIROp = BlockHeader->CW<FEXCore::IR::IROp_CodeBlock>();
       LogMan::Throw::A(BlockIROp->Header.Op == IR::OP_CODEBLOCK, "IR type failed to be a code block");
 
       // We grab these nodes this way so we can iterate easily
@@ -466,11 +464,9 @@ namespace FEXCore::IR {
   void ConstrainedRAPass::CalculateBlockInterferences(FEXCore::IR::IRListView<false> *IR) {
     using namespace FEXCore;
     uintptr_t ListBegin = IR->GetListData();
-    uintptr_t DataBegin = IR->GetData();
 
-    for (auto Block : IR->getBlocks()) {
-      auto BlockNode = Block.GetNode(ListBegin);
-      auto BlockIROp = BlockNode->Op(DataBegin)->CW<FEXCore::IR::IROp_CodeBlock>();
+    for (auto [BlockNode, BlockHeader] : IR->getBlocks()) {
+      auto BlockIROp = BlockHeader->CW<FEXCore::IR::IROp_CodeBlock>();
       LogMan::Throw::A(BlockIROp->Header.Op == IR::OP_CODEBLOCK, "IR type failed to be a code block");
 
       BlockInterferences *BlockInterferenceVector = &LocalBlockInterferences.try_emplace(BlockNode->Wrapped(ListBegin).ID()).first->second;
@@ -521,11 +517,9 @@ namespace FEXCore::IR {
     };
     using namespace FEXCore;
     uintptr_t ListBegin = IR->GetListData();
-    uintptr_t DataBegin = IR->GetData();
 
-    for (auto Block : IR->getBlocks()) {
-      auto BlockNode = Block.GetNode(ListBegin);
-      auto BlockIROp = BlockNode->Op(DataBegin)->CW<FEXCore::IR::IROp_CodeBlock>();
+    for (auto [BlockNode, BlockHeader] : IR->getBlocks()) {
+      auto BlockIROp = BlockHeader->CW<FEXCore::IR::IROp_CodeBlock>();
       LogMan::Throw::A(BlockIROp->Header.Op == IR::OP_CODEBLOCK, "IR type failed to be a code block");
 
       BlockInterferences *BlockInterferenceVector = &LocalBlockInterferences.try_emplace(BlockNode->Wrapped(ListBegin).ID()).first->second;

--- a/External/FEXCore/Source/Interface/IR/Passes/SyscallOptimization.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/SyscallOptimization.cpp
@@ -18,8 +18,8 @@ bool SyscallOptimization::Run(IREmitter *IREmit) {
   uintptr_t DataBegin = CurrentIR.GetData();
 
 
-  for (auto Block : CurrentIR.getBlocks()) {
-    auto BlockIROp = Block.GetNode(ListBegin)->Op(DataBegin)->CW<FEXCore::IR::IROp_CodeBlock>();
+  for (auto [BlockNode, BlockHeader] : CurrentIR.getBlocks()) {
+    auto BlockIROp = BlockHeader->CW<FEXCore::IR::IROp_CodeBlock>();
     LogMan::Throw::A(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
 
     // We grab these nodes this way so we can iterate easily

--- a/External/FEXCore/Source/Interface/IR/Passes/SyscallOptimization.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/SyscallOptimization.cpp
@@ -17,17 +17,9 @@ bool SyscallOptimization::Run(IREmitter *IREmit) {
   uintptr_t ListBegin = CurrentIR.GetListData();
   uintptr_t DataBegin = CurrentIR.GetData();
 
-  auto Begin = CurrentIR.begin();
-  auto Op = Begin();
 
-  OrderedNode *RealNode = Op->GetNode(ListBegin);
-  auto HeaderOp = RealNode->Op(DataBegin)->CW<FEXCore::IR::IROp_IRHeader>();
-  LogMan::Throw::A(HeaderOp->Header.Op == OP_IRHEADER, "First op wasn't IRHeader");
-
-  OrderedNode *BlockNode = HeaderOp->Blocks.GetNode(ListBegin);
-
-  while (1) {
-    auto BlockIROp = BlockNode->Op(DataBegin)->CW<FEXCore::IR::IROp_CodeBlock>();
+  for (auto Block : CurrentIR.getBlocks()) {
+    auto BlockIROp = Block.GetNode(ListBegin)->Op(DataBegin)->CW<FEXCore::IR::IROp_CodeBlock>();
     LogMan::Throw::A(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
 
     // We grab these nodes this way so we can iterate easily
@@ -61,13 +53,6 @@ bool SyscallOptimization::Run(IREmitter *IREmit) {
       }
       ++CodeBegin;
     }
-
-    if (BlockIROp->Next.ID() == 0) {
-      break;
-    } else {
-      BlockNode = BlockIROp->Next.GetNode(ListBegin);
-    }
-
   }
 
   return Changed;

--- a/External/FEXCore/Source/Interface/IR/Passes/SyscallOptimization.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/SyscallOptimization.cpp
@@ -14,46 +14,28 @@ public:
 bool SyscallOptimization::Run(IREmitter *IREmit) {
   bool Changed = false;
   auto CurrentIR = IREmit->ViewIR();
-  uintptr_t ListBegin = CurrentIR.GetListData();
-  uintptr_t DataBegin = CurrentIR.GetData();
 
 
-  for (auto [BlockNode, BlockHeader] : CurrentIR.getBlocks()) {
-    auto BlockIROp = BlockHeader->CW<FEXCore::IR::IROp_CodeBlock>();
-    LogMan::Throw::A(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
+  for (auto [CodeNode, IROp] : CurrentIR.GetAllCode()) {
 
-    // We grab these nodes this way so we can iterate easily
-    auto CodeBegin = CurrentIR.at(BlockIROp->Begin);
-    auto CodeLast = CurrentIR.at(BlockIROp->Last);
-    while (1) {
-      auto CodeOp = CodeBegin();
-      OrderedNode *CodeNode = CodeOp->GetNode(ListBegin);
-      auto IROp = CodeNode->Op(DataBegin);
-
-      if (IROp->Op == FEXCore::IR::OP_SYSCALL) {
-        // Is the first argument a constant?
-        uint64_t Constant;
-        if (IREmit->IsValueConstant(IROp->Args[0], &Constant)) {
-          auto SyscallDef = Manager->SyscallHandler->GetDefinition(Constant);
-          // XXX: Once we have the ability to do real function calls then we can call directly in to the syscall handler
-          if (SyscallDef->NumArgs < FEXCore::HLE::SyscallArguments::MAX_ARGS) {
-            // If the number of args are less than what the IR op supports then we can remove arg usage
-            // We need +1 since we are still passing in syscall number here
-            for (uint8_t Arg = (SyscallDef->NumArgs + 1); Arg < FEXCore::HLE::SyscallArguments::MAX_ARGS; ++Arg) {
-              IREmit->ReplaceNodeArgument(CodeNode, Arg, IREmit->Invalid());
-            }
-            Changed = true;
+    if (IROp->Op == FEXCore::IR::OP_SYSCALL) {
+      // Is the first argument a constant?
+      uint64_t Constant;
+      if (IREmit->IsValueConstant(IROp->Args[0], &Constant)) {
+        auto SyscallDef = Manager->SyscallHandler->GetDefinition(Constant);
+        // XXX: Once we have the ability to do real function calls then we can call directly in to the syscall handler
+        if (SyscallDef->NumArgs < FEXCore::HLE::SyscallArguments::MAX_ARGS) {
+          // If the number of args are less than what the IR op supports then we can remove arg usage
+          // We need +1 since we are still passing in syscall number here
+          for (uint8_t Arg = (SyscallDef->NumArgs + 1); Arg < FEXCore::HLE::SyscallArguments::MAX_ARGS; ++Arg) {
+            IREmit->ReplaceNodeArgument(CodeNode, Arg, IREmit->Invalid());
           }
+          Changed = true;
         }
       }
-
-      // CodeLast is inclusive. So we still need to dump the CodeLast op as well
-      if (CodeBegin == CodeLast) {
-        break;
-      }
-      ++CodeBegin;
     }
   }
+
 
   return Changed;
 }

--- a/External/FEXCore/Source/Interface/IR/Passes/ValueDominanceValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ValueDominanceValidation.cpp
@@ -30,16 +30,8 @@ bool ValueDominanceValidation::Run(IREmitter *IREmit) {
 
   std::unordered_map<IR::OrderedNodeWrapper::NodeOffsetType, BlockInfo> OffsetToBlockMap;
 
-  auto Begin = CurrentIR.begin();
-  auto Op = Begin();
-
-  OrderedNode *RealNode = Op->GetNode(ListBegin);
-  auto HeaderOp = RealNode->Op(DataBegin)->CW<FEXCore::IR::IROp_IRHeader>();
-  LogMan::Throw::A(HeaderOp->Header.Op == OP_IRHEADER, "First op wasn't IRHeader");
-
-  // Walk the list and calculate the control flow
-  OrderedNode *BlockNode = HeaderOp->Blocks.GetNode(ListBegin);
-  while (1) {
+  for (auto Block : CurrentIR.getBlocks()) {
+    auto BlockNode = Block.GetNode(ListBegin);
     auto BlockIROp = BlockNode->Op(DataBegin)->CW<FEXCore::IR::IROp_CodeBlock>();
     LogMan::Throw::A(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
 
@@ -96,16 +88,10 @@ bool ValueDominanceValidation::Run(IREmitter *IREmit) {
       }
       ++CodeBegin;
     }
-
-    if (BlockIROp->Next.ID() == 0) {
-      break;
-    } else {
-      BlockNode = BlockIROp->Next.GetNode(ListBegin);
-    }
   }
 
-  BlockNode = HeaderOp->Blocks.GetNode(ListBegin);
-  while (1) {
+  for (auto Block : CurrentIR.getBlocks()) {
+    auto BlockNode = Block.GetNode(ListBegin);
     auto BlockIROp = BlockNode->Op(DataBegin)->CW<FEXCore::IR::IROp_CodeBlock>();
     LogMan::Throw::A(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
 
@@ -227,12 +213,6 @@ bool ValueDominanceValidation::Run(IREmitter *IREmit) {
         break;
       }
       ++CodeBegin;
-    }
-
-    if (BlockIROp->Next.ID() == 0) {
-      break;
-    } else {
-      BlockNode = BlockIROp->Next.GetNode(ListBegin);
     }
   }
 

--- a/External/FEXCore/Source/Interface/IR/Passes/ValueDominanceValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ValueDominanceValidation.cpp
@@ -30,9 +30,8 @@ bool ValueDominanceValidation::Run(IREmitter *IREmit) {
 
   std::unordered_map<IR::OrderedNodeWrapper::NodeOffsetType, BlockInfo> OffsetToBlockMap;
 
-  for (auto Block : CurrentIR.getBlocks()) {
-    auto BlockNode = Block.GetNode(ListBegin);
-    auto BlockIROp = BlockNode->Op(DataBegin)->CW<FEXCore::IR::IROp_CodeBlock>();
+  for (auto [BlockNode, BlockHeader] : CurrentIR.getBlocks()) {
+    auto BlockIROp = BlockHeader->CW<FEXCore::IR::IROp_CodeBlock>();
     LogMan::Throw::A(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
 
     BlockInfo *CurrentBlock = &OffsetToBlockMap.try_emplace(BlockNode->Wrapped(ListBegin).ID()).first->second;
@@ -90,9 +89,8 @@ bool ValueDominanceValidation::Run(IREmitter *IREmit) {
     }
   }
 
-  for (auto Block : CurrentIR.getBlocks()) {
-    auto BlockNode = Block.GetNode(ListBegin);
-    auto BlockIROp = BlockNode->Op(DataBegin)->CW<FEXCore::IR::IROp_CodeBlock>();
+  for (auto [BlockNode, BlockHeader] : CurrentIR.getBlocks()) {
+    auto BlockIROp = BlockHeader->CW<FEXCore::IR::IROp_CodeBlock>();
     LogMan::Throw::A(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
 
     // We grab these nodes this way so we can iterate easily

--- a/External/FEXCore/include/FEXCore/IR/IR.h
+++ b/External/FEXCore/include/FEXCore/IR/IR.h
@@ -309,70 +309,7 @@ struct FenceType final {
   constexpr bool operator!=(FenceType const &rhs) const { return !operator==(rhs); }
 };
 
-/**
-* @brief This is our NodeWrapperIterator
-* This stores both the memory base and the provided NodeWrapper to be able to walk the list of nodes directly
-* Only the increment and decrement implementations of this class require understanding the implementation details of OrderedNode
-*/
-class NodeWrapperIterator {
-public:
-	using value_type              = OrderedNodeWrapper;
-	using size_type               = std::size_t;
-	using difference_type         = std::ptrdiff_t;
-	using reference               = value_type&;
-	using const_reference         = const value_type&;
-	using pointer                 = value_type*;
-	using const_pointer           = const value_type*;
-	using iterator                = NodeWrapperIterator;
-	using const_iterator          = const NodeWrapperIterator;
-	using reverse_iterator        = iterator;
-	using const_reverse_iterator  = const_iterator;
-	using iterator_category       = std::bidirectional_iterator_tag;
-
-	using NodeType = value_type;
-	using NodePtr = value_type*;
-	using NodeRef = value_type&;
-
-	NodeWrapperIterator(uintptr_t Base, uintptr_t IRBase) : BaseList {Base}, IRList{ IRBase } {}
-	explicit NodeWrapperIterator(uintptr_t Base, uintptr_t IRBase, NodeType Ptr) : BaseList {Base},  IRList{ IRBase }, Node {Ptr} {}
-
-	bool operator==(const NodeWrapperIterator &rhs) const {
-		return Node.NodeOffset == rhs.Node.NodeOffset;
-	}
-
-	bool operator!=(const NodeWrapperIterator &rhs) const {
-		return !operator==(rhs);
-	}
-
-  NodeWrapperIterator operator++() {
-		OrderedNodeHeader *RealNode = reinterpret_cast<OrderedNodeHeader*>(Node.GetNode(BaseList));
-    Node = RealNode->Next;
-    return *this;
-  }
-
-  NodeWrapperIterator operator--() {
-    OrderedNodeHeader *RealNode = reinterpret_cast<OrderedNodeHeader*>(Node.GetNode(BaseList));
-    Node = RealNode->Previous;
-    return *this;
-  }
-
-	NodeRef operator*() {
-		return Node;
-	}
-
-	NodePtr operator()() {
-		return &Node;
-	}
-
-  static NodeWrapperIterator Invalid() {
-    return NodeWrapperIterator(0, 0);
-  }
-
-protected:
-	uintptr_t BaseList{};
-  uintptr_t IRList{};
-	NodeType Node{};
-};
+class NodeIterator;
 
 /* This iterator can be used to step though nodes.
  * Due to how our IR is laid out, this can be used to either step
@@ -387,8 +324,8 @@ public:
 	using const_reference         = const value_type&;
 	using pointer                 = value_type*;
 	using const_pointer           = const value_type*;
-	using iterator                = NodeWrapperIterator;
-	using const_iterator          = const NodeWrapperIterator;
+	using iterator                = NodeIterator;
+	using const_iterator          = const NodeIterator;
 	using reverse_iterator        = iterator;
 	using const_reverse_iterator  = const_iterator;
 	using iterator_category       = std::bidirectional_iterator_tag;

--- a/External/FEXCore/include/FEXCore/IR/IR.h
+++ b/External/FEXCore/include/FEXCore/IR/IR.h
@@ -443,6 +443,7 @@ class AllNodesIterator : public NodeIterator {
 public:
   AllNodesIterator(uintptr_t Base, uintptr_t IRBase) : NodeIterator(Base, IRBase) {}
 	explicit AllNodesIterator(uintptr_t Base, uintptr_t IRBase, OrderedNodeWrapper Ptr) : NodeIterator(Base, IRBase, Ptr) {}
+  AllNodesIterator(NodeIterator other) : NodeIterator(other) {} // Allow NodeIterator to be upgraded
 
   AllNodesIterator operator++() {
 		OrderedNodeHeader *RealNode = reinterpret_cast<OrderedNodeHeader*>(Node.GetNode(BaseList));
@@ -466,6 +467,10 @@ public:
 	}
 
   AllNodesIterator operator--() = delete;
+
+  static AllNodesIterator Invalid() {
+    return AllNodesIterator(0, 0);
+  }
 };
 
 template<bool>

--- a/External/FEXCore/include/FEXCore/IR/IR.h
+++ b/External/FEXCore/include/FEXCore/IR/IR.h
@@ -89,7 +89,7 @@ static_assert(sizeof(OrderedNodeHeader) == sizeof(uint32_t) * 3);
 * This stores both the memory base and the provided NodeWrapper to be able to walk the list of nodes directly
 * Only the increment and decrement implementations of this class require understanding the implementation details of OrderedNode
 */
-class NodeWrapperIterator final {
+class NodeWrapperIterator {
 public:
 	using value_type              = OrderedNodeWrapper;
 	using size_type               = std::size_t;
@@ -108,8 +108,8 @@ public:
 	using NodePtr = value_type*;
 	using NodeRef = value_type&;
 
-	NodeWrapperIterator(uintptr_t Base) : BaseList {Base} {}
-	explicit NodeWrapperIterator(uintptr_t Base, NodeType Ptr) : BaseList {Base}, Node {Ptr} {}
+	NodeWrapperIterator(uintptr_t Base, uintptr_t IRBase) : BaseList {Base}, IRList{ IRBase } {}
+	explicit NodeWrapperIterator(uintptr_t Base, uintptr_t IRBase, NodeType Ptr) : BaseList {Base},  IRList{ IRBase }, Node {Ptr} {}
 
 	bool operator==(const NodeWrapperIterator &rhs) const {
 		return Node.NodeOffset == rhs.Node.NodeOffset;
@@ -119,17 +119,17 @@ public:
 		return !operator==(rhs);
 	}
 
-	NodeWrapperIterator operator++() {
+  NodeWrapperIterator operator++() {
 		OrderedNodeHeader *RealNode = reinterpret_cast<OrderedNodeHeader*>(Node.GetNode(BaseList));
-		Node = RealNode->Next;
-		return *this;
-	}
+    Node = RealNode->Next;
+    return *this;
+  }
 
-	NodeWrapperIterator operator--() {
-		OrderedNodeHeader *RealNode = reinterpret_cast<OrderedNodeHeader*>(Node.GetNode(BaseList));
-		Node = RealNode->Previous;
-		return *this;
-	}
+  NodeWrapperIterator operator--() {
+    OrderedNodeHeader *RealNode = reinterpret_cast<OrderedNodeHeader*>(Node.GetNode(BaseList));
+    Node = RealNode->Previous;
+    return *this;
+  }
 
 	NodeRef operator*() {
 		return Node;
@@ -140,11 +140,12 @@ public:
 	}
 
   static NodeWrapperIterator Invalid() {
-    return NodeWrapperIterator(0);
+    return NodeWrapperIterator(0, 0);
   }
 
-private:
+protected:
 	uintptr_t BaseList{};
+  uintptr_t IRList{};
 	NodeType Node{};
 };
 

--- a/External/FEXCore/include/FEXCore/IR/IR.h
+++ b/External/FEXCore/include/FEXCore/IR/IR.h
@@ -422,6 +422,10 @@ public:
 		return { RealNode, RealNode->Op(IRList) };
 	}
 
+  uint32_t ID() {
+    return Node.ID();
+  }
+
   static NodeIterator Invalid() {
     return NodeIterator(0, 0);
   }

--- a/External/FEXCore/include/FEXCore/IR/IREmitter.h
+++ b/External/FEXCore/include/FEXCore/IR/IREmitter.h
@@ -466,7 +466,7 @@ friend class FEXCore::IR::PassManager;
 
     SetWriteCursor(nullptr);// Orphan from any future nodes
 
-    auto Begin = _Dummy();
+    auto Begin = _BeginBlock(CodeNode);
     CodeNode.first->Begin = Begin.Node->Wrapped(ListData.Begin());
 
     auto EndBlock = _EndBlock(CodeNode);

--- a/External/FEXCore/include/FEXCore/IR/IREmitter.h
+++ b/External/FEXCore/include/FEXCore/IR/IREmitter.h
@@ -400,25 +400,30 @@ friend class FEXCore::IR::PassManager;
      return false;
   }
 
-  // This is fairly special in how it operates
-  // Since the node is decoupled from the backing op then we can swap out the backing op without much overhead
-  // This can potentially cause problems where multiple nodes are pointing to the same IROp
-  OrderedNode *ReplaceAllUsesWith(OrderedNode *Node, IROp_Header *Op) {
-    RemoveArgUses(Node);
-    Node->Header.Value.SetOffset(Data.Begin(), reinterpret_cast<uintptr_t>(Op));
-    return Node;
+  void ReplaceAllUsesWithRange(OrderedNode *Node, OrderedNode *NewNode, AllNodesIterator After, AllNodesIterator End);
+
+  void ReplaceUsesWithAfter(OrderedNode *Node, OrderedNode *NewNode, AllNodesIterator After) {
+    ReplaceAllUsesWithRange(Node, NewNode, After, AllNodesIterator(ListData.Begin(), Data.Begin()));
   }
 
-  // This is similar to the previous op except that we pass in a node
-  // This takes the op backing in the new node and replaces the node in the other node
-  // Again can cause problems where things are pointing to NewNode and haven't been decoupled
-  OrderedNode *ReplaceAllUsesWith(OrderedNode *Node, OrderedNode *NewNode) {
-    RemoveArgUses(Node);
-    Node->Header.Value.NodeOffset = NewNode->Header.Value.NodeOffset;
-    return Node;
+  void ReplaceUsesWithAfter(OrderedNode *Node, OrderedNode *NewNode, OrderedNode *After) {
+    auto Wrapped = Node->Wrapped(ListData.Begin());
+    AllNodesIterator It = AllNodesIterator(ListData.Begin(), Data.Begin(), Wrapped);
+
+    ReplaceUsesWithAfter(Node, NewNode, It);
   }
 
-  void ReplaceAllUsesWithInclusive(OrderedNode *Node, OrderedNode *NewNode, IR::NodeWrapperIterator After, IR::NodeWrapperIterator End);
+  void ReplaceAllUsesWith(OrderedNode *Node, OrderedNode *NewNode) {
+    auto Start = AllNodesIterator(ListData.Begin(), Data.Begin(), Node->Wrapped(ListData.Begin()));
+
+    ReplaceUsesWithAfter(Node, NewNode, Start);
+
+    LogMan::Throw::A(Node->NumUses == 0, "Node still used");
+
+    // Since we have deleted ALL uses, we can safely delete the node.
+    Remove(Node);
+  }
+
   void ReplaceNodeArgument(OrderedNode *Node, uint8_t Arg, OrderedNode *NewArg);
 
   void Remove(OrderedNode *Node);

--- a/External/FEXCore/include/FEXCore/IR/IntrusiveIRList.h
+++ b/External/FEXCore/include/FEXCore/IR/IntrusiveIRList.h
@@ -117,7 +117,7 @@ private:
 
     Blocks(const IRListView *parent) : view(parent) {};
 
-    using iterator = NodeWrapperIterator;
+    using iterator = NodeIterator;
 
     iterator begin() const noexcept {
       auto Header = view->GetHeader();

--- a/External/FEXCore/include/FEXCore/IR/IntrusiveIRList.h
+++ b/External/FEXCore/include/FEXCore/IR/IntrusiveIRList.h
@@ -117,7 +117,11 @@ public:
   T *GetOp(OrderedNode *Node) const {
     auto OpHeader = Node->Op(GetData());
     auto Op = OpHeader->template CW<T>();
-    LogMan::Throw::A(Op->OPCODE == Op->Header.Op, "Expected Node to be '%s'. Found '%s' instead", GetName(Op->OPCODE), GetName(Op->Header.Op));
+
+    // If we are casting to something narrower than just the header, check the opcode.
+    if constexpr (!std::is_same<T, IROp_Header>::value) {
+      LogMan::Throw::A(Op->OPCODE == Op->Header.Op, "Expected Node to be '%s'. Found '%s' instead", GetName(Op->OPCODE), GetName(Op->Header.Op));
+    }
 
     return Op;
   }
@@ -126,6 +130,10 @@ public:
   T *GetOp(OrderedNodeWrapper Wrapper) const {
     auto Node = Wrapper.GetNode(GetListData());
     return GetOp<T>(Node);
+  }
+
+  OrderedNode* GetNode(OrderedNodeWrapper Wrapper) const {
+    return Wrapper.GetNode(GetListData());
   }
 
 private:
@@ -181,11 +189,11 @@ private:
 
 public:
 
-  BlockRange getBlocks() const {
+  BlockRange GetBlocks() const {
     return BlockRange(this);
   }
 
-  CodeRange getCode(OrderedNode *block) const {
+  CodeRange GetCode(OrderedNode *block) const {
     return CodeRange(this, block->Wrapped(GetListData()));
   }
 

--- a/External/FEXCore/include/FEXCore/IR/IntrusiveIRList.h
+++ b/External/FEXCore/include/FEXCore/IR/IntrusiveIRList.h
@@ -201,7 +201,7 @@ public:
     return AllCodeRange(this);
   }
 
-  using iterator = NodeWrapperIterator;
+  using iterator = NodeIterator;
 
   iterator begin() const noexcept
   {
@@ -226,8 +226,19 @@ public:
    * @brief Convert a OrderedNodeWrapper to an interator that we can iterate over
    * @return Iterator for this op
    */
-  iterator at(OrderedNodeWrapper Node) const noexcept {
-    return iterator(reinterpret_cast<uintptr_t>(ListData), reinterpret_cast<uintptr_t>(IRData), Node);
+  iterator at(OrderedNodeWrapper Wrapped) const noexcept {
+    return iterator(reinterpret_cast<uintptr_t>(ListData), reinterpret_cast<uintptr_t>(IRData), Wrapped);
+  }
+
+  iterator at(uint32_t ID) const noexcept {
+    OrderedNodeWrapper Wrapped;
+    Wrapped.NodeOffset = ID * sizeof(OrderedNode);
+    return iterator(reinterpret_cast<uintptr_t>(ListData), reinterpret_cast<uintptr_t>(IRData), Wrapped);
+  }
+
+  iterator at(OrderedNode *Node) const noexcept {
+    auto Wrapped = Node->Wrapped(reinterpret_cast<uintptr_t>(ListData));
+    return iterator(reinterpret_cast<uintptr_t>(ListData), reinterpret_cast<uintptr_t>(IRData), Wrapped);
   }
 
 private:


### PR DESCRIPTION
This moves most of the internal complexities of our IR inside just a few files:  `IR.h`, `IR.cpp`, `IREmitter.cpp`, `IREmitter.cpp` and `IntrusiveIRList.h`

There are now new iterators for Blocks and Code. 

 