### PR TITLE
Implements sigsuspend

### DIFF
--- a/External/FEXCore/Source/Interface/Core/SignalDelegator.h
+++ b/External/FEXCore/Source/Interface/Core/SignalDelegator.h
@@ -84,6 +84,7 @@ namespace Core {
 
     uint64_t GuestSigProcMask(int how, const uint64_t *set, uint64_t *oldset);
     uint64_t GuestSigPending(uint64_t *set, size_t sigsetsize);
+    uint64_t GuestSigSuspend(uint64_t *set, size_t sigsetsize);
 
     // Called from the thunk handler to handle the signal
     void HandleSignal(int Signal, void *Info, void *UContext);

--- a/External/FEXCore/Source/Interface/HLE/Syscalls/Signals.cpp
+++ b/External/FEXCore/Source/Interface/HLE/Syscalls/Signals.cpp
@@ -25,5 +25,9 @@ namespace FEXCore::HLE {
     REGISTER_SYSCALL_IMPL(rt_sigpending, [](FEXCore::Core::InternalThreadState *Thread, uint64_t *set, size_t sigsetsize) -> uint64_t {
       return Thread->CTX->SignalDelegation.GuestSigPending(set, sigsetsize);
     });
+
+    REGISTER_SYSCALL_IMPL(rt_sigsuspend, [](FEXCore::Core::InternalThreadState *Thread, uint64_t *unewset, size_t sigsetsize) -> uint64_t {
+      return Thread->CTX->SignalDelegation.GuestSigSuspend(unewset, sigsetsize);
+    });
   }
 }

--- a/External/FEXCore/Source/Interface/HLE/Syscalls/Stubs.cpp
+++ b/External/FEXCore/Source/Interface/HLE/Syscalls/Stubs.cpp
@@ -95,11 +95,6 @@ namespace FEXCore::HLE {
     REGISTER_SYSCALL_IMPL(rt_sigqueueinfo, [](FEXCore::Core::InternalThreadState *Thread, pid_t pid, int sig, siginfo_t *uinfo) -> uint64_t {
       SYSCALL_STUB(rt_sigqueueinfo);
     });
-
-    REGISTER_SYSCALL_IMPL(rt_sigsuspend, [](FEXCore::Core::InternalThreadState *Thread, sigset_t *unewset, size_t sigsetsize) -> uint64_t {
-      SYSCALL_STUB(rt_sigsuspend);
-    });
-
     REGISTER_SYSCALL_IMPL(utime, [](FEXCore::Core::InternalThreadState *Thread, char* filename, const struct utimbuf* times) -> uint64_t {
       SYSCALL_STUB(utime);
     });


### PR DESCRIPTION
This helps out Mono's garbage collector specifically. There is a minor
race that can currently occur with signal 63 but that technically should
only occur on a pause or stop condition.

Might need to change this behaviour if it becomes a problem