### PR TITLE
Removes a couple of unnecessary variables to improve reentrancy chances

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -103,7 +103,6 @@ public:
 private:
   FEXCore::Context::Context *CTX;
   FEXCore::Core::InternalThreadState *State;
-  FEXCore::IR::IRListView<true> const *CurrentIR;
 
   std::map<IR::OrderedNodeWrapper::NodeOffsetType, aarch64::Label> JumpTargets;
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -73,10 +73,8 @@ public:
 private:
   FEXCore::Context::Context *CTX;
   FEXCore::Core::InternalThreadState *ThreadState;
-  FEXCore::IR::IRListView<true> const *CurrentIR;
   std::unordered_map<IR::OrderedNodeWrapper::NodeOffsetType, Label> JumpTargets;
 
-  std::vector<uint8_t> Stack;
   bool MemoryDebug = false;
 
   /**


### PR DESCRIPTION
We still aren't 100% reentrant safe in the case that the cores are
interrupted while running, but this is a step in the right direction