### PR TITLE
Implements RCR and RCL x86 ops 

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -887,7 +887,25 @@ DEF_OP(Rev) {
 }
 
 DEF_OP(Bfi) {
-  LogMan::Msg::D("Unimplemented");
+  auto Op = IROp->C<IR::IROp_Bfi>();
+  uint8_t OpSize = IROp->Size;
+  switch (OpSize) {
+    case 1:
+    case 2:
+    case 4: {
+      auto Dst = GetReg<RA_32>(Node);
+      mov(TMP1.W(), GetReg<RA_32>(Op->Header.Args[0].ID()));
+      bfi(TMP1.W(), GetReg<RA_32>(Op->Header.Args[1].ID()), Op->lsb, Op->Width);
+      ubfx(Dst, TMP1.W(), 0, OpSize * 8);
+      break;
+    }
+    case 8:
+      mov(TMP1, GetReg<RA_64>(Op->Header.Args[0].ID()));
+      bfi(TMP1, GetReg<RA_64>(Op->Header.Args[1].ID()), Op->lsb, Op->Width);
+      mov(GetReg<RA_64>(Node), TMP1);
+      break;
+    default: LogMan::Msg::A("Unknown BFI size: %d", OpSize); break;
+  }
 }
 
 DEF_OP(Bfe) {

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -494,6 +494,24 @@ DEF_OP(Ror) {
   }
 }
 
+DEF_OP(Extr) {
+  auto Op = IROp->C<IR::IROp_Extr>();
+  uint8_t OpSize = IROp->Size;
+
+  switch (OpSize) {
+    case 4: {
+      extr(GetReg<RA_32>(Node), GetReg<RA_32>(Op->Header.Args[0].ID()), GetReg<RA_32>(Op->Header.Args[1].ID()), Op->LSB);
+    break;
+    }
+    case 8: {
+      extr(GetReg<RA_64>(Node), GetReg<RA_64>(Op->Header.Args[0].ID()), GetReg<RA_64>(Op->Header.Args[1].ID()), Op->LSB);
+    break;
+    }
+
+    default: LogMan::Msg::A("Unhandled EXTR size: %d", OpSize);
+  }
+}
+
 DEF_OP(LDiv) {
   auto Op = IROp->C<IR::IROp_LDiv>();
   uint8_t OpSize = IROp->Size;
@@ -1069,6 +1087,7 @@ void JITCore::RegisterALUHandlers() {
   REGISTER_OP(ASHR,              Ashr);
   REGISTER_OP(ROL,               Rol);
   REGISTER_OP(ROR,               Ror);
+  REGISTER_OP(EXTR,              Extr);
   REGISTER_OP(LDIV,              LDiv);
   REGISTER_OP(LUDIV,             LUDiv);
   REGISTER_OP(LREM,              LRem);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -261,6 +261,7 @@ private:
   DEF_OP(Ashr);
   DEF_OP(Rol);
   DEF_OP(Ror);
+  DEF_OP(Extr);
   DEF_OP(LDiv);
   DEF_OP(LUDiv);
   DEF_OP(LRem);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -1619,6 +1619,28 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
           mov(GetDst<RA_64>(Node), rax);
           break;
         }
+        case IR::OP_EXTR: {
+          auto Op = IROp->C<IR::IROp_Extr>();
+
+          switch (OpSize) {
+            case 4: {
+              mov(eax, GetSrc<RA_32>(Op->Header.Args[0].ID()));
+              mov(ecx, GetSrc<RA_32>(Op->Header.Args[1].ID()));
+              shrd(ecx, eax, Op->LSB);
+              mov(GetDst<RA_32>(Node), ecx);
+              break;
+            }
+            case 8: {
+              mov(rax, GetSrc<RA_64>(Op->Header.Args[0].ID()));
+              mov(rcx, GetSrc<RA_64>(Op->Header.Args[1].ID()));
+              shrd(rcx, rax, Op->LSB);
+              mov(GetDst<RA_64>(Node), rcx);
+              break;
+            }
+          }
+          break;
+        }
+
         case IR::OP_MUL: {
           auto Op = IROp->C<IR::IROp_Mul>();
           auto Dst = GetDst<RA_64>(Node);

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -162,6 +162,13 @@ public:
   template<bool Is1Bit>
   void ROLOp(OpcodeArgs);
   void ROLImmediateOp(OpcodeArgs);
+  void RCROp1Bit(OpcodeArgs);
+  void RCROp8x1Bit(OpcodeArgs);
+  void RCROp(OpcodeArgs);
+  void RCRSmallerOp(OpcodeArgs);
+  void RCLOp1Bit(OpcodeArgs);
+  void RCLOp(OpcodeArgs);
+  void RCLSmallerOp(OpcodeArgs);
   template<uint32_t SrcIndex>
   void BTOp(OpcodeArgs);
   template<uint32_t SrcIndex>

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -807,6 +807,22 @@
       "SSAArgs": "2"
     },
 
+    "Extr": {
+      "Desc": ["Concats the two GPRs to create a value that is the size of the full two GPRs",
+               "It then extracts a bitfield width that size of a GPR from the LSB",
+               "Valid LSB range is 0-31 for 32bit and 0-63 for 64bit",
+               "<Size * 2> ConcatValue = src0:src1",
+               "Result = ConcatValue<LSB+Size - 1: LSB>"
+              ],
+      "OpClass": "ALU",
+      "HasDest": true,
+      "DestClass": "GPR",
+      "SSAArgs": "2",
+      "Args": [
+        "uint8_t", "LSB"
+      ]
+    },
+
     "LDiv": {
       "Desc": ["Integer long signed division returning lower bits",
                "The Lower and Upper registers will be concated together to generate a dividend twice the size",

--- a/unittests/ASM/PrimaryGroup/2_C0_02.asm
+++ b/unittests/ASM/PrimaryGroup/2_C0_02.asm
@@ -1,0 +1,49 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RBX": "0x06",
+    "RCX": "0x04",
+    "RDX": "0x02",
+    "RSI": "0x00",
+    "R8":  "0x0",
+    "R9":  "0x0",
+    "R10": "0x1",
+    "R11": "0x1"
+  }
+}
+%endif
+
+mov rbx, 0x01
+mov rcx, 0x01
+mov rdx, 0x40
+mov rsi, 0x40
+
+stc
+rcl bl, 2
+lahf
+mov r8w, ax
+shr r8, 8
+and r8, 1 ; We only care about carry flag here
+
+clc
+rcl cl, 2
+lahf
+mov r9w, ax
+shr r9, 8
+and r9, 1 ; We only care about carry flag here
+
+stc
+rcl dl, 2
+lahf
+mov r10w, ax
+shr r10, 8
+and r10, 1 ; We only care about carry flag here
+
+clc
+rcl sil, 2
+lahf
+mov r11w, ax
+shr r11, 8
+and r11, 1 ; We only care about carry flag here
+
+hlt

--- a/unittests/ASM/PrimaryGroup/2_C0_02_2.asm
+++ b/unittests/ASM/PrimaryGroup/2_C0_02_2.asm
@@ -1,0 +1,49 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RBX": "0x0006",
+    "RCX": "0x0004",
+    "RDX": "0x0002",
+    "RSI": "0x0000",
+    "R8":  "0x0",
+    "R9":  "0x0",
+    "R10": "0x1",
+    "R11": "0x1"
+  }
+}
+%endif
+
+mov rbx, 0x0001
+mov rcx, 0x0001
+mov rdx, 0x4000
+mov rsi, 0x4000
+
+stc
+rcl bx, 2
+lahf
+mov r8w, ax
+shr r8, 8
+and r8, 1 ; We only care about carry flag here
+
+clc
+rcl cx, 2
+lahf
+mov r9w, ax
+shr r9, 8
+and r9, 1 ; We only care about carry flag here
+
+stc
+rcl dx, 2
+lahf
+mov r10w, ax
+shr r10, 8
+and r10, 1 ; We only care about carry flag here
+
+clc
+rcl si, 2
+lahf
+mov r11w, ax
+shr r11, 8
+and r11, 1 ; We only care about carry flag here
+
+hlt

--- a/unittests/ASM/PrimaryGroup/2_C0_02_3.asm
+++ b/unittests/ASM/PrimaryGroup/2_C0_02_3.asm
@@ -1,0 +1,49 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RBX": "0x00000006",
+    "RCX": "0x00000004",
+    "RDX": "0x00000002",
+    "RSI": "0x00000000",
+    "R8":  "0x0",
+    "R9":  "0x0",
+    "R10": "0x1",
+    "R11": "0x1"
+  }
+}
+%endif
+
+mov rbx, 0x00000001
+mov rcx, 0x00000001
+mov rdx, 0x40000000
+mov rsi, 0x40000000
+
+stc
+rcl ebx, 2
+lahf
+mov r8w, ax
+shr r8, 8
+and r8, 1 ; We only care about carry flag here
+
+clc
+rcl ecx, 2
+lahf
+mov r9w, ax
+shr r9, 8
+and r9, 1 ; We only care about carry flag here
+
+stc
+rcl edx, 2
+lahf
+mov r10w, ax
+shr r10, 8
+and r10, 1 ; We only care about carry flag here
+
+clc
+rcl esi, 2
+lahf
+mov r11w, ax
+shr r11, 8
+and r11, 1 ; We only care about carry flag here
+
+hlt

--- a/unittests/ASM/PrimaryGroup/2_C0_02_4.asm
+++ b/unittests/ASM/PrimaryGroup/2_C0_02_4.asm
@@ -1,0 +1,49 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RBX": "0x0000000000000006",
+    "RCX": "0x0000000000000004",
+    "RDX": "0x0000000000000002",
+    "RSI": "0x0000000000000000",
+    "R8":  "0x0",
+    "R9":  "0x0",
+    "R10": "0x1",
+    "R11": "0x1"
+  }
+}
+%endif
+
+mov rbx, 0x0000000000000001
+mov rcx, 0x0000000000000001
+mov rdx, 0x4000000000000000
+mov rsi, 0x4000000000000000
+
+stc
+rcl rbx, 2
+lahf
+mov r8w, ax
+shr r8, 8
+and r8, 1 ; We only care about carry flag here
+
+clc
+rcl rcx, 2
+lahf
+mov r9w, ax
+shr r9, 8
+and r9, 1 ; We only care about carry flag here
+
+stc
+rcl rdx, 2
+lahf
+mov r10w, ax
+shr r10, 8
+and r10, 1 ; We only care about carry flag here
+
+clc
+rcl rsi, 2
+lahf
+mov r11w, ax
+shr r11, 8
+and r11, 1 ; We only care about carry flag here
+
+hlt

--- a/unittests/ASM/PrimaryGroup/2_C0_03.asm
+++ b/unittests/ASM/PrimaryGroup/2_C0_03.asm
@@ -1,0 +1,49 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RBX": "0x40",
+    "RCX": "0x00",
+    "RDX": "0x60",
+    "RSI": "0x20",
+    "R8":  "0x1",
+    "R9":  "0x1",
+    "R10": "0x0",
+    "R11": "0x0"
+  }
+}
+%endif
+
+mov rbx, 0x02
+mov rcx, 0x02
+mov rdx, 0x80
+mov rsi, 0x80
+
+stc
+rcr bl, 2
+lahf
+mov r8w, ax
+shr r8, 8
+and r8, 1 ; We only care about carry flag here
+
+clc
+rcr cl, 2
+lahf
+mov r9w, ax
+shr r9, 8
+and r9, 1 ; We only care about carry flag here
+
+stc
+rcr dl, 2
+lahf
+mov r10w, ax
+shr r10, 8
+and r10, 1 ; We only care about carry flag here
+
+clc
+rcr sil, 2
+lahf
+mov r11w, ax
+shr r11, 8
+and r11, 1 ; We only care about carry flag here
+
+hlt

--- a/unittests/ASM/PrimaryGroup/2_C0_03_2.asm
+++ b/unittests/ASM/PrimaryGroup/2_C0_03_2.asm
@@ -1,0 +1,49 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RBX": "0x4000",
+    "RCX": "0x0000",
+    "RDX": "0x6000",
+    "RSI": "0x2000",
+    "R8":  "0x1",
+    "R9":  "0x1",
+    "R10": "0x0",
+    "R11": "0x0"
+  }
+}
+%endif
+
+mov rbx, 0x0002
+mov rcx, 0x0002
+mov rdx, 0x8000
+mov rsi, 0x8000
+
+stc
+rcr bx, 2
+lahf
+mov r8w, ax
+shr r8, 8
+and r8, 1 ; We only care about carry flag here
+
+clc
+rcr cx, 2
+lahf
+mov r9w, ax
+shr r9, 8
+and r9, 1 ; We only care about carry flag here
+
+stc
+rcr dx, 2
+lahf
+mov r10w, ax
+shr r10, 8
+and r10, 1 ; We only care about carry flag here
+
+clc
+rcr si, 2
+lahf
+mov r11w, ax
+shr r11, 8
+and r11, 1 ; We only care about carry flag here
+
+hlt

--- a/unittests/ASM/PrimaryGroup/2_C0_03_3.asm
+++ b/unittests/ASM/PrimaryGroup/2_C0_03_3.asm
@@ -1,0 +1,49 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RBX": "0x40000000",
+    "RCX": "0x00000000",
+    "RDX": "0x60000000",
+    "RSI": "0x20000000",
+    "R8":  "0x1",
+    "R9":  "0x1",
+    "R10": "0x0",
+    "R11": "0x0"
+  }
+}
+%endif
+
+mov rbx, 0x00000002
+mov rcx, 0x00000002
+mov rdx, 0x80000000
+mov rsi, 0x80000000
+
+stc
+rcr ebx, 2
+lahf
+mov r8w, ax
+shr r8, 8
+and r8, 1 ; We only care about carry flag here
+
+clc
+rcr ecx, 2
+lahf
+mov r9w, ax
+shr r9, 8
+and r9, 1 ; We only care about carry flag here
+
+stc
+rcr edx, 2
+lahf
+mov r10w, ax
+shr r10, 8
+and r10, 1 ; We only care about carry flag here
+
+clc
+rcr esi, 2
+lahf
+mov r11w, ax
+shr r11, 8
+and r11, 1 ; We only care about carry flag here
+
+hlt

--- a/unittests/ASM/PrimaryGroup/2_C0_03_4.asm
+++ b/unittests/ASM/PrimaryGroup/2_C0_03_4.asm
@@ -1,0 +1,49 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RBX": "0x4000000000000000",
+    "RCX": "0x0000000000000000",
+    "RDX": "0x6000000000000000",
+    "RSI": "0x2000000000000000",
+    "R8":  "0x1",
+    "R9":  "0x1",
+    "R10": "0x0",
+    "R11": "0x0"
+  }
+}
+%endif
+
+mov rbx, 0x0000000000000002
+mov rcx, 0x0000000000000002
+mov rdx, 0x8000000000000000
+mov rsi, 0x8000000000000000
+
+stc
+rcr rbx, 2
+lahf
+mov r8w, ax
+shr r8, 8
+and r8, 1 ; We only care about carry flag here
+
+clc
+rcr rcx, 2
+lahf
+mov r9w, ax
+shr r9, 8
+and r9, 1 ; We only care about carry flag here
+
+stc
+rcr rdx, 2
+lahf
+mov r10w, ax
+shr r10, 8
+and r10, 1 ; We only care about carry flag here
+
+clc
+rcr rsi, 2
+lahf
+mov r11w, ax
+shr r11, 8
+and r11, 1 ; We only care about carry flag here
+
+hlt

--- a/unittests/ASM/PrimaryGroup/2_D0_02.asm
+++ b/unittests/ASM/PrimaryGroup/2_D0_02.asm
@@ -1,0 +1,49 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RBX": "0x03",
+    "RCX": "0x02",
+    "RDX": "0x81",
+    "RSI": "0x00",
+    "R8":  "0x0",
+    "R9":  "0x0",
+    "R10": "0x0",
+    "R11": "0x1"
+  }
+}
+%endif
+
+mov rbx, 0x01
+mov rcx, 0x01
+mov rdx, 0x40
+mov rsi, 0x80
+
+stc
+rcl bl, 1
+lahf
+mov r8w, ax
+shr r8, 8
+and r8, 1 ; We only care about carry flag here
+
+clc
+rcl cl, 1
+lahf
+mov r9w, ax
+shr r9, 8
+and r9, 1 ; We only care about carry flag here
+
+stc
+rcl dl, 1
+lahf
+mov r10w, ax
+shr r10, 8
+and r10, 1 ; We only care about carry flag here
+
+clc
+rcl sil, 1
+lahf
+mov r11w, ax
+shr r11, 8
+and r11, 1 ; We only care about carry flag here
+
+hlt

--- a/unittests/ASM/PrimaryGroup/2_D0_02_2.asm
+++ b/unittests/ASM/PrimaryGroup/2_D0_02_2.asm
@@ -1,0 +1,42 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RBX": "0x03",
+    "RCX": "0x02",
+    "RDX": "0x81",
+    "RSI": "0x00",
+    "R8":  "0x0",
+    "R9":  "0x0",
+    "R10": "0x1",
+    "R11": "0x1"
+  }
+}
+%endif
+
+mov rbx, 0x01
+mov rcx, 0x01
+mov rdx, 0x40
+mov rsi, 0x80
+mov r15, 1
+
+stc
+rcl bl, 1
+mov r8, 0
+cmovo r8, r15 ; We only care about OF here
+
+clc
+rcl cl, 1
+mov r9, 0
+cmovo r9, r15 ; We only care about OF here
+
+stc
+rcl dl, 1
+mov r10, 0
+cmovo r10, r15 ; We only care about OF here
+
+clc
+rcl sil, 1
+mov r11, 0
+cmovo r11, r15 ; We only care about OF here
+
+hlt

--- a/unittests/ASM/PrimaryGroup/2_D0_03.asm
+++ b/unittests/ASM/PrimaryGroup/2_D0_03.asm
@@ -1,0 +1,49 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RBX": "0x80",
+    "RCX": "0x00",
+    "RDX": "0xC0",
+    "RSI": "0x40",
+    "R8":  "0x1",
+    "R9":  "0x1",
+    "R10": "0x0",
+    "R11": "0x0"
+  }
+}
+%endif
+
+mov rbx, 0x01
+mov rcx, 0x01
+mov rdx, 0x80
+mov rsi, 0x80
+
+stc
+rcr bl, 1
+lahf
+mov r8w, ax
+shr r8, 8
+and r8, 1 ; We only care about carry flag here
+
+clc
+rcr cl, 1
+lahf
+mov r9w, ax
+shr r9, 8
+and r9, 1 ; We only care about carry flag here
+
+stc
+rcr dl, 1
+lahf
+mov r10w, ax
+shr r10, 8
+and r10, 1 ; We only care about carry flag here
+
+clc
+rcr sil, 1
+lahf
+mov r11w, ax
+shr r11, 8
+and r11, 1 ; We only care about carry flag here
+
+hlt

--- a/unittests/ASM/PrimaryGroup/2_D0_03_2.asm
+++ b/unittests/ASM/PrimaryGroup/2_D0_03_2.asm
@@ -1,0 +1,42 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RBX": "0x80",
+    "RCX": "0x00",
+    "RDX": "0xC0",
+    "RSI": "0x40",
+    "R8":  "0x1",
+    "R9":  "0x0",
+    "R10": "0x0",
+    "R11": "0x1"
+  }
+}
+%endif
+
+mov rbx, 0x01
+mov rcx, 0x01
+mov rdx, 0x80
+mov rsi, 0x80
+mov r15, 1
+
+stc
+rcr bl, 1
+mov r8, 0
+cmovo r8, r15 ; We only care about OF here
+
+clc
+rcr cl, 1
+mov r9, 0
+cmovo r9, r15 ; We only care about OF here
+
+stc
+rcr dl, 1
+mov r10, 0
+cmovo r10, r15 ; We only care about OF here
+
+clc
+rcr sil, 1
+mov r11, 0
+cmovo r11, r15 ; We only care about OF here
+
+hlt

--- a/unittests/ASM/PrimaryGroup/2_D1_02.asm
+++ b/unittests/ASM/PrimaryGroup/2_D1_02.asm
@@ -1,0 +1,49 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RBX": "0x0003",
+    "RCX": "0x0002",
+    "RDX": "0x0001",
+    "RSI": "0x0000",
+    "R8":  "0x0",
+    "R9":  "0x0",
+    "R10": "0x1",
+    "R11": "0x1"
+  }
+}
+%endif
+
+mov rbx, 0x0001
+mov rcx, 0x0001
+mov rdx, 0x8000
+mov rsi, 0x8000
+
+stc
+rcl bx, 1
+lahf
+mov r8w, ax
+shr r8, 8
+and r8, 1 ; We only care about carry flag here
+
+clc
+rcl cx, 1
+lahf
+mov r9w, ax
+shr r9, 8
+and r9, 1 ; We only care about carry flag here
+
+stc
+rcl dx, 1
+lahf
+mov r10w, ax
+shr r10, 8
+and r10, 1 ; We only care about carry flag here
+
+clc
+rcl si, 1
+lahf
+mov r11w, ax
+shr r11, 8
+and r11, 1 ; We only care about carry flag here
+
+hlt

--- a/unittests/ASM/PrimaryGroup/2_D1_02_2.asm
+++ b/unittests/ASM/PrimaryGroup/2_D1_02_2.asm
@@ -1,0 +1,50 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RBX": "0x00000003",
+    "RCX": "0x00000002",
+    "RDX": "0x00000001",
+    "RSI": "0x00000000",
+    "R8":  "0x0",
+    "R9":  "0x0",
+    "R10": "0x1",
+    "R11": "0x1"
+  }
+}
+%endif
+
+mov rbx, 0x00000001
+mov rcx, 0x00000001
+mov rdx, 0x80000000
+mov rsi, 0x80000000
+
+stc
+rcl ebx, 1
+lahf
+mov r8w, ax
+shr r8, 8
+and r8, 1 ; We only care about carry flag here
+
+clc
+rcl ecx, 1
+lahf
+mov r9w, ax
+shr r9, 8
+and r9, 1 ; We only care about carry flag here
+
+stc
+rcl edx, 1
+lahf
+mov r10w, ax
+shr r10, 8
+and r10, 1 ; We only care about carry flag here
+
+clc
+rcl esi, 1
+lahf
+mov r11w, ax
+shr r11, 8
+and r11, 1 ; We only care about carry flag here
+
+hlt
+

--- a/unittests/ASM/PrimaryGroup/2_D1_02_3.asm
+++ b/unittests/ASM/PrimaryGroup/2_D1_02_3.asm
@@ -1,0 +1,50 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RBX": "0x0000000000000003",
+    "RCX": "0x0000000000000002",
+    "RDX": "0x0000000000000001",
+    "RSI": "0x0000000000000000",
+    "R8":  "0x0",
+    "R9":  "0x0",
+    "R10": "0x1",
+    "R11": "0x1"
+  }
+}
+%endif
+
+mov rbx, 0x0000000000000001
+mov rcx, 0x0000000000000001
+mov rdx, 0x8000000000000000
+mov rsi, 0x8000000000000000
+
+stc
+rcl rbx, 1
+lahf
+mov r8w, ax
+shr r8, 8
+and r8, 1 ; We only care about carry flag here
+
+clc
+rcl rcx, 1
+lahf
+mov r9w, ax
+shr r9, 8
+and r9, 1 ; We only care about carry flag here
+
+stc
+rcl rdx, 1
+lahf
+mov r10w, ax
+shr r10, 8
+and r10, 1 ; We only care about carry flag here
+
+clc
+rcl rsi, 1
+lahf
+mov r11w, ax
+shr r11, 8
+and r11, 1 ; We only care about carry flag here
+
+hlt
+

--- a/unittests/ASM/PrimaryGroup/2_D1_02_4.asm
+++ b/unittests/ASM/PrimaryGroup/2_D1_02_4.asm
@@ -1,0 +1,42 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RBX": "0x0003",
+    "RCX": "0x0002",
+    "RDX": "0x0001",
+    "RSI": "0x0000",
+    "R8":  "0x0",
+    "R9":  "0x0",
+    "R10": "0x1",
+    "R11": "0x1"
+  }
+}
+%endif
+
+mov rbx, 0x0001
+mov rcx, 0x0001
+mov rdx, 0x8000
+mov rsi, 0x8000
+mov r15, 1
+
+stc
+rcl bx, 1
+mov r8, 0
+cmovo r8, r15 ; We only care about OF here
+
+clc
+rcl cx, 1
+mov r9, 0
+cmovo r9, r15 ; We only care about OF here
+
+stc
+rcl dx, 1
+mov r10, 0
+cmovo r10, r15 ; We only care about OF here
+
+clc
+rcl si, 1
+mov r11, 0
+cmovo r11, r15 ; We only care about OF here
+
+hlt

--- a/unittests/ASM/PrimaryGroup/2_D1_02_5.asm
+++ b/unittests/ASM/PrimaryGroup/2_D1_02_5.asm
@@ -1,0 +1,42 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RBX": "0x00000003",
+    "RCX": "0x00000002",
+    "RDX": "0x00000001",
+    "RSI": "0x00000000",
+    "R8":  "0x0",
+    "R9":  "0x0",
+    "R10": "0x1",
+    "R11": "0x1"
+  }
+}
+%endif
+
+mov rbx, 0x00000001
+mov rcx, 0x00000001
+mov rdx, 0x80000000
+mov rsi, 0x80000000
+mov r15, 1
+
+stc
+rcl ebx, 1
+mov r8, 0
+cmovo r8, r15 ; We only care about OF here
+
+clc
+rcl ecx, 1
+mov r9, 0
+cmovo r9, r15 ; We only care about OF here
+
+stc
+rcl edx, 1
+mov r10, 0
+cmovo r10, r15 ; We only care about OF here
+
+clc
+rcl esi, 1
+mov r11, 0
+cmovo r11, r15 ; We only care about OF here
+
+hlt

--- a/unittests/ASM/PrimaryGroup/2_D1_02_6.asm
+++ b/unittests/ASM/PrimaryGroup/2_D1_02_6.asm
@@ -1,0 +1,42 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RBX": "0x0000000000000003",
+    "RCX": "0x0000000000000002",
+    "RDX": "0x0000000000000001",
+    "RSI": "0x0000000000000000",
+    "R8":  "0x0",
+    "R9":  "0x0",
+    "R10": "0x1",
+    "R11": "0x1"
+  }
+}
+%endif
+
+mov rbx, 0x0000000000000001
+mov rcx, 0x0000000000000001
+mov rdx, 0x8000000000000000
+mov rsi, 0x8000000000000000
+mov r15, 1
+
+stc
+rcl rbx, 1
+mov r8, 0
+cmovo r8, r15 ; We only care about OF here
+
+clc
+rcl rcx, 1
+mov r9, 0
+cmovo r9, r15 ; We only care about OF here
+
+stc
+rcl rdx, 1
+mov r10, 0
+cmovo r10, r15 ; We only care about OF here
+
+clc
+rcl rsi, 1
+mov r11, 0
+cmovo r11, r15 ; We only care about OF here
+
+hlt

--- a/unittests/ASM/PrimaryGroup/2_D1_03.asm
+++ b/unittests/ASM/PrimaryGroup/2_D1_03.asm
@@ -1,0 +1,49 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RBX": "0x8000",
+    "RCX": "0x0000",
+    "RDX": "0xC000",
+    "RSI": "0x4000",
+    "R8":  "0x1",
+    "R9":  "0x1",
+    "R10": "0x0",
+    "R11": "0x0"
+  }
+}
+%endif
+
+mov rbx, 0x0001
+mov rcx, 0x0001
+mov rdx, 0x8000
+mov rsi, 0x8000
+
+stc
+rcr bx, 1
+lahf
+mov r8w, ax
+shr r8, 8
+and r8, 1 ; We only care about carry flag here
+
+clc
+rcr cx, 1
+lahf
+mov r9w, ax
+shr r9, 8
+and r9, 1 ; We only care about carry flag here
+
+stc
+rcr dx, 1
+lahf
+mov r10w, ax
+shr r10, 8
+and r10, 1 ; We only care about carry flag here
+
+clc
+rcr si, 1
+lahf
+mov r11w, ax
+shr r11, 8
+and r11, 1 ; We only care about carry flag here
+
+hlt

--- a/unittests/ASM/PrimaryGroup/2_D1_03_2.asm
+++ b/unittests/ASM/PrimaryGroup/2_D1_03_2.asm
@@ -1,0 +1,49 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RBX": "0x80000000",
+    "RCX": "0x00000000",
+    "RDX": "0xC0000000",
+    "RSI": "0x40000000",
+    "R8":  "0x1",
+    "R9":  "0x1",
+    "R10": "0x0",
+    "R11": "0x0"
+  }
+}
+%endif
+
+mov rbx, 0x00000001
+mov rcx, 0x00000001
+mov rdx, 0x80000000
+mov rsi, 0x80000000
+
+stc
+rcr ebx, 1
+lahf
+mov r8w, ax
+shr r8, 8
+and r8, 1 ; We only care about carry flag here
+
+clc
+rcr ecx, 1
+lahf
+mov r9w, ax
+shr r9, 8
+and r9, 1 ; We only care about carry flag here
+
+stc
+rcr edx, 1
+lahf
+mov r10w, ax
+shr r10, 8
+and r10, 1 ; We only care about carry flag here
+
+clc
+rcr esi, 1
+lahf
+mov r11w, ax
+shr r11, 8
+and r11, 1 ; We only care about carry flag here
+
+hlt

--- a/unittests/ASM/PrimaryGroup/2_D1_03_3.asm
+++ b/unittests/ASM/PrimaryGroup/2_D1_03_3.asm
@@ -1,0 +1,49 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RBX": "0x8000000000000000",
+    "RCX": "0x0000000000000000",
+    "RDX": "0xC000000000000000",
+    "RSI": "0x4000000000000000",
+    "R8":  "0x1",
+    "R9":  "0x1",
+    "R10": "0x0",
+    "R11": "0x0"
+  }
+}
+%endif
+
+mov rbx, 0x0000000000000001
+mov rcx, 0x0000000000000001
+mov rdx, 0x8000000000000000
+mov rsi, 0x8000000000000000
+
+stc
+rcr rbx, 1
+lahf
+mov r8w, ax
+shr r8, 8
+and r8, 1 ; We only care about carry flag here
+
+clc
+rcr rcx, 1
+lahf
+mov r9w, ax
+shr r9, 8
+and r9, 1 ; We only care about carry flag here
+
+stc
+rcr rdx, 1
+lahf
+mov r10w, ax
+shr r10, 8
+and r10, 1 ; We only care about carry flag here
+
+clc
+rcr rsi, 1
+lahf
+mov r11w, ax
+shr r11, 8
+and r11, 1 ; We only care about carry flag here
+
+hlt

--- a/unittests/ASM/PrimaryGroup/2_D1_03_4.asm
+++ b/unittests/ASM/PrimaryGroup/2_D1_03_4.asm
@@ -1,0 +1,42 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RBX": "0x8000",
+    "RCX": "0x0000",
+    "RDX": "0xC000",
+    "RSI": "0x4000",
+    "R8":  "0x1",
+    "R9":  "0x0",
+    "R10": "0x0",
+    "R11": "0x1"
+  }
+}
+%endif
+
+mov rbx, 0x0001
+mov rcx, 0x0001
+mov rdx, 0x8000
+mov rsi, 0x8000
+mov r15, 1
+
+stc
+rcr bx, 1
+mov r8, 0
+cmovo r8, r15 ; We only care about OF here
+
+clc
+rcr cx, 1
+mov r9, 0
+cmovo r9, r15 ; We only care about OF here
+
+stc
+rcr dx, 1
+mov r10, 0
+cmovo r10, r15 ; We only care about OF here
+
+clc
+rcr si, 1
+mov r11, 0
+cmovo r11, r15 ; We only care about OF here
+
+hlt

--- a/unittests/ASM/PrimaryGroup/2_D1_03_5.asm
+++ b/unittests/ASM/PrimaryGroup/2_D1_03_5.asm
@@ -1,0 +1,42 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RBX": "0x80000000",
+    "RCX": "0x00000000",
+    "RDX": "0xC0000000",
+    "RSI": "0x40000000",
+    "R8":  "0x1",
+    "R9":  "0x0",
+    "R10": "0x0",
+    "R11": "0x1"
+  }
+}
+%endif
+
+mov rbx, 0x00000001
+mov rcx, 0x00000001
+mov rdx, 0x80000000
+mov rsi, 0x80000000
+mov r15, 1
+
+stc
+rcr ebx, 1
+mov r8, 0
+cmovo r8, r15 ; We only care about OF here
+
+clc
+rcr ecx, 1
+mov r9, 0
+cmovo r9, r15 ; We only care about OF here
+
+stc
+rcr edx, 1
+mov r10, 0
+cmovo r10, r15 ; We only care about OF here
+
+clc
+rcr esi, 1
+mov r11, 0
+cmovo r11, r15 ; We only care about OF here
+
+hlt

--- a/unittests/ASM/PrimaryGroup/2_D1_03_6.asm
+++ b/unittests/ASM/PrimaryGroup/2_D1_03_6.asm
@@ -1,0 +1,42 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RBX": "0x8000000000000000",
+    "RCX": "0x0000000000000000",
+    "RDX": "0xC000000000000000",
+    "RSI": "0x4000000000000000",
+    "R8":  "0x1",
+    "R9":  "0x0",
+    "R10": "0x0",
+    "R11": "0x1"
+  }
+}
+%endif
+
+mov rbx, 0x0000000000000001
+mov rcx, 0x0000000000000001
+mov rdx, 0x8000000000000000
+mov rsi, 0x8000000000000000
+mov r15, 1
+
+stc
+rcr rbx, 1
+mov r8, 0
+cmovo r8, r15 ; We only care about OF here
+
+clc
+rcr rcx, 1
+mov r9, 0
+cmovo r9, r15 ; We only care about OF here
+
+stc
+rcr rdx, 1
+mov r10, 0
+cmovo r10, r15 ; We only care about OF here
+
+clc
+rcr rsi, 1
+mov r11, 0
+cmovo r11, r15 ; We only care about OF here
+
+hlt

--- a/unittests/ASM/PrimaryGroup/2_D2_02.asm
+++ b/unittests/ASM/PrimaryGroup/2_D2_02.asm
@@ -1,0 +1,50 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RBX": "0x06",
+    "RDI": "0x04",
+    "RDX": "0x02",
+    "RSI": "0x00",
+    "R8":  "0x0",
+    "R9":  "0x0",
+    "R10": "0x1",
+    "R11": "0x1"
+  }
+}
+%endif
+
+mov rbx, 0x01
+mov rdi, 0x01
+mov rdx, 0x40
+mov rsi, 0x40
+mov rcx, 2
+
+stc
+rcl bl, cl
+lahf
+mov r8w, ax
+shr r8, 8
+and r8, 1 ; We only care about carry flag here
+
+clc
+rcl dil, cl
+lahf
+mov r9w, ax
+shr r9, 8
+and r9, 1 ; We only care about carry flag here
+
+stc
+rcl dl, cl
+lahf
+mov r10w, ax
+shr r10, 8
+and r10, 1 ; We only care about carry flag here
+
+clc
+rcl sil, cl
+lahf
+mov r11w, ax
+shr r11, 8
+and r11, 1 ; We only care about carry flag here
+
+hlt

--- a/unittests/ASM/PrimaryGroup/2_D2_02_2.asm
+++ b/unittests/ASM/PrimaryGroup/2_D2_02_2.asm
@@ -1,0 +1,43 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RBX": "0x03",
+    "RDI": "0x02",
+    "RDX": "0x01",
+    "RSI": "0x00",
+    "R8":  "0x0",
+    "R9":  "0x0",
+    "R10": "0x1",
+    "R11": "0x1"
+  }
+}
+%endif
+
+mov rbx, 0x01
+mov rdi, 0x01
+mov rdx, 0x80
+mov rsi, 0x80
+mov rcx, 1
+mov r15, 1
+
+stc
+rcl bl, cl
+mov r8, 0
+cmovo r8, r15 ; We only care about OF here
+
+clc
+rcl dil, cl
+mov r9, 0
+cmovo r9, r15 ; We only care about OF here
+
+stc
+rcl dl, cl
+mov r10, 0
+cmovo r10, r15 ; We only care about OF here
+
+clc
+rcl sil, cl
+mov r11, 0
+cmovo r11, r15 ; We only care about OF here
+
+hlt

--- a/unittests/ASM/PrimaryGroup/2_D2_02_3.asm
+++ b/unittests/ASM/PrimaryGroup/2_D2_02_3.asm
@@ -1,0 +1,50 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RBX": "0x81",
+    "RDI": "0x01",
+    "RDX": "0xC0",
+    "RSI": "0x40",
+    "R8":  "0x0",
+    "R9":  "0x0",
+    "R10": "0x0",
+    "R11": "0x0"
+  }
+}
+%endif
+
+mov rbx, 0x02
+mov rdi, 0x02
+mov rdx, 0x80
+mov rsi, 0x80
+mov rcx, 8 ; Tests wrapping around features
+
+stc
+rcl bl, cl
+lahf
+mov r8w, ax
+shr r8, 8
+and r8, 1 ; We only care about carry flag here
+
+clc
+rcl dil, cl
+lahf
+mov r9w, ax
+shr r9, 8
+and r9, 1 ; We only care about carry flag here
+
+stc
+rcl dl, cl
+lahf
+mov r10w, ax
+shr r10, 8
+and r10, 1 ; We only care about carry flag here
+
+clc
+rcl sil, cl
+lahf
+mov r11w, ax
+shr r11, 8
+and r11, 1 ; We only care about carry flag here
+
+hlt

--- a/unittests/ASM/PrimaryGroup/2_D2_03.asm
+++ b/unittests/ASM/PrimaryGroup/2_D2_03.asm
@@ -1,0 +1,50 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RBX": "0x40",
+    "RDI": "0x00",
+    "RDX": "0x60",
+    "RSI": "0x20",
+    "R8":  "0x1",
+    "R9":  "0x1",
+    "R10": "0x0",
+    "R11": "0x0"
+  }
+}
+%endif
+
+mov rbx, 0x02
+mov rdi, 0x02
+mov rdx, 0x80
+mov rsi, 0x80
+mov rcx, 2
+
+stc
+rcr bl, cl
+lahf
+mov r8w, ax
+shr r8, 8
+and r8, 1 ; We only care about carry flag here
+
+clc
+rcr dil, cl
+lahf
+mov r9w, ax
+shr r9, 8
+and r9, 1 ; We only care about carry flag here
+
+stc
+rcr dl, cl
+lahf
+mov r10w, ax
+shr r10, 8
+and r10, 1 ; We only care about carry flag here
+
+clc
+rcr sil, cl
+lahf
+mov r11w, ax
+shr r11, 8
+and r11, 1 ; We only care about carry flag here
+
+hlt

--- a/unittests/ASM/PrimaryGroup/2_D2_03_2.asm
+++ b/unittests/ASM/PrimaryGroup/2_D2_03_2.asm
@@ -1,0 +1,43 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RBX": "0x80",
+    "RDI": "0x00",
+    "RDX": "0xC0",
+    "RSI": "0x40",
+    "R8":  "0x1",
+    "R9":  "0x0",
+    "R10": "0x0",
+    "R11": "0x1"
+  }
+}
+%endif
+
+mov rbx, 0x01
+mov rdi, 0x01
+mov rdx, 0x80
+mov rsi, 0x80
+mov r15, 1
+mov rcx, 1
+
+stc
+rcr bl, cl
+mov r8, 0
+cmovo r8, r15 ; We only care about OF here
+
+clc
+rcr dil, cl
+mov r9, 0
+cmovo r9, r15 ; We only care about OF here
+
+stc
+rcr dl, cl
+mov r10, 0
+cmovo r10, r15 ; We only care about OF here
+
+clc
+rcr sil, cl
+mov r11, 0
+cmovo r11, r15 ; We only care about OF here
+
+hlt

--- a/unittests/ASM/PrimaryGroup/2_D2_03_3.asm
+++ b/unittests/ASM/PrimaryGroup/2_D2_03_3.asm
@@ -1,0 +1,50 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RBX": "0x05",
+    "RDI": "0x04",
+    "RDX": "0x01",
+    "RSI": "0x00",
+    "R8":  "0x0",
+    "R9":  "0x0",
+    "R10": "0x1",
+    "R11": "0x1"
+  }
+}
+%endif
+
+mov rbx, 0x02
+mov rdi, 0x02
+mov rdx, 0x80
+mov rsi, 0x80
+mov rcx, 8 ; Tests wrapping around features
+
+stc
+rcr bl, cl
+lahf
+mov r8w, ax
+shr r8, 8
+and r8, 1 ; We only care about carry flag here
+
+clc
+rcr dil, cl
+lahf
+mov r9w, ax
+shr r9, 8
+and r9, 1 ; We only care about carry flag here
+
+stc
+rcr dl, cl
+lahf
+mov r10w, ax
+shr r10, 8
+and r10, 1 ; We only care about carry flag here
+
+clc
+rcr sil, cl
+lahf
+mov r11w, ax
+shr r11, 8
+and r11, 1 ; We only care about carry flag here
+
+hlt

--- a/unittests/ASM/PrimaryGroup/2_D3_02.asm
+++ b/unittests/ASM/PrimaryGroup/2_D3_02.asm
@@ -1,0 +1,50 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RBX": "0x0006",
+    "RDI": "0x0004",
+    "RDX": "0x0002",
+    "RSI": "0x0000",
+    "R8":  "0x0",
+    "R9":  "0x0",
+    "R10": "0x1",
+    "R11": "0x1"
+  }
+}
+%endif
+
+mov rbx, 0x0001
+mov rdi, 0x0001
+mov rdx, 0x4000
+mov rsi, 0x4000
+mov rcx, 2
+
+stc
+rcl bx, cl
+lahf
+mov r8w, ax
+shr r8, 8
+and r8, 1 ; We only care about carry flag here
+
+clc
+rcl di, cl
+lahf
+mov r9w, ax
+shr r9, 8
+and r9, 1 ; We only care about carry flag here
+
+stc
+rcl dx, cl
+lahf
+mov r10w, ax
+shr r10, 8
+and r10, 1 ; We only care about carry flag here
+
+clc
+rcl si, cl
+lahf
+mov r11w, ax
+shr r11, 8
+and r11, 1 ; We only care about carry flag here
+
+hlt

--- a/unittests/ASM/PrimaryGroup/2_D3_02_2.asm
+++ b/unittests/ASM/PrimaryGroup/2_D3_02_2.asm
@@ -1,0 +1,50 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RBX": "0x00000006",
+    "RDI": "0x00000004",
+    "RDX": "0x00000002",
+    "RSI": "0x00000000",
+    "R8":  "0x0",
+    "R9":  "0x0",
+    "R10": "0x1",
+    "R11": "0x1"
+  }
+}
+%endif
+
+mov rbx, 0x00000001
+mov rdi, 0x00000001
+mov rdx, 0x40000000
+mov rsi, 0x40000000
+mov rcx, 2
+
+stc
+rcl ebx, cl
+lahf
+mov r8w, ax
+shr r8, 8
+and r8, 1 ; We only care about carry flag here
+
+clc
+rcl edi, cl
+lahf
+mov r9w, ax
+shr r9, 8
+and r9, 1 ; We only care about carry flag here
+
+stc
+rcl edx, cl
+lahf
+mov r10w, ax
+shr r10, 8
+and r10, 1 ; We only care about carry flag here
+
+clc
+rcl esi, cl
+lahf
+mov r11w, ax
+shr r11, 8
+and r11, 1 ; We only care about carry flag here
+
+hlt

--- a/unittests/ASM/PrimaryGroup/2_D3_02_3.asm
+++ b/unittests/ASM/PrimaryGroup/2_D3_02_3.asm
@@ -1,0 +1,50 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RBX": "0x0000000000000006",
+    "RDI": "0x0000000000000004",
+    "RDX": "0x0000000000000002",
+    "RSI": "0x0000000000000000",
+    "R8":  "0x0",
+    "R9":  "0x0",
+    "R10": "0x1",
+    "R11": "0x1"
+  }
+}
+%endif
+
+mov rbx, 0x0000000000000001
+mov rdi, 0x0000000000000001
+mov rdx, 0x4000000000000000
+mov rsi, 0x4000000000000000
+mov rcx, 2
+
+stc
+rcl rbx, cl
+lahf
+mov r8w, ax
+shr r8, 8
+and r8, 1 ; We only care about carry flag here
+
+clc
+rcl rdi, cl
+lahf
+mov r9w, ax
+shr r9, 8
+and r9, 1 ; We only care about carry flag here
+
+stc
+rcl rdx, cl
+lahf
+mov r10w, ax
+shr r10, 8
+and r10, 1 ; We only care about carry flag here
+
+clc
+rcl rsi, cl
+lahf
+mov r11w, ax
+shr r11, 8
+and r11, 1 ; We only care about carry flag here
+
+hlt

--- a/unittests/ASM/PrimaryGroup/2_D3_03.asm
+++ b/unittests/ASM/PrimaryGroup/2_D3_03.asm
@@ -1,0 +1,50 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RBX": "0x4000",
+    "RDI": "0x0000",
+    "RDX": "0x6000",
+    "RSI": "0x2000",
+    "R8":  "0x1",
+    "R9":  "0x1",
+    "R10": "0x0",
+    "R11": "0x0"
+  }
+}
+%endif
+
+mov rbx, 0x0002
+mov rdi, 0x0002
+mov rdx, 0x8000
+mov rsi, 0x8000
+mov rcx, 2
+
+stc
+rcr bx, cl
+lahf
+mov r8w, ax
+shr r8, 8
+and r8, 1 ; We only care about carry flag here
+
+clc
+rcr di, cl
+lahf
+mov r9w, ax
+shr r9, 8
+and r9, 1 ; We only care about carry flag here
+
+stc
+rcr dx, cl
+lahf
+mov r10w, ax
+shr r10, 8
+and r10, 1 ; We only care about carry flag here
+
+clc
+rcr si, cl
+lahf
+mov r11w, ax
+shr r11, 8
+and r11, 1 ; We only care about carry flag here
+
+hlt

--- a/unittests/ASM/PrimaryGroup/2_D3_03_2.asm
+++ b/unittests/ASM/PrimaryGroup/2_D3_03_2.asm
@@ -1,0 +1,50 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RBX": "0x40000000",
+    "RDI": "0x00000000",
+    "RDX": "0x60000000",
+    "RSI": "0x20000000",
+    "R8":  "0x1",
+    "R9":  "0x1",
+    "R10": "0x0",
+    "R11": "0x0"
+  }
+}
+%endif
+
+mov rbx, 0x00000002
+mov rdi, 0x00000002
+mov rdx, 0x80000000
+mov rsi, 0x80000000
+mov rcx, 2
+
+stc
+rcr ebx, cl
+lahf
+mov r8w, ax
+shr r8, 8
+and r8, 1 ; We only care about carry flag here
+
+clc
+rcr edi, cl
+lahf
+mov r9w, ax
+shr r9, 8
+and r9, 1 ; We only care about carry flag here
+
+stc
+rcr edx, cl
+lahf
+mov r10w, ax
+shr r10, 8
+and r10, 1 ; We only care about carry flag here
+
+clc
+rcr esi, cl
+lahf
+mov r11w, ax
+shr r11, 8
+and r11, 1 ; We only care about carry flag here
+
+hlt

--- a/unittests/ASM/PrimaryGroup/2_D3_03_3.asm
+++ b/unittests/ASM/PrimaryGroup/2_D3_03_3.asm
@@ -1,0 +1,50 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RBX": "0x4000000000000000",
+    "RDI": "0x0000000000000000",
+    "RDX": "0x6000000000000000",
+    "RSI": "0x2000000000000000",
+    "R8":  "0x1",
+    "R9":  "0x1",
+    "R10": "0x0",
+    "R11": "0x0"
+  }
+}
+%endif
+
+mov rbx, 0x0000000000000002
+mov rdi, 0x0000000000000002
+mov rdx, 0x8000000000000000
+mov rsi, 0x8000000000000000
+mov rcx, 2
+
+stc
+rcr rbx, cl
+lahf
+mov r8w, ax
+shr r8, 8
+and r8, 1 ; We only care about carry flag here
+
+clc
+rcr rdi, cl
+lahf
+mov r9w, ax
+shr r9, 8
+and r9, 1 ; We only care about carry flag here
+
+stc
+rcr rdx, cl
+lahf
+mov r10w, ax
+shr r10, 8
+and r10, 1 ; We only care about carry flag here
+
+clc
+rcr rsi, cl
+lahf
+mov r11w, ax
+shr r11, 8
+and r11, 1 ; We only care about carry flag here
+
+hlt

--- a/unittests/ASM/PrimaryGroup/2_D3_03_4.asm
+++ b/unittests/ASM/PrimaryGroup/2_D3_03_4.asm
@@ -1,0 +1,43 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RBX": "0x8000",
+    "RDI": "0x0000",
+    "RDX": "0xC000",
+    "RSI": "0x4000",
+    "R8":  "0x1",
+    "R9":  "0x0",
+    "R10": "0x0",
+    "R11": "0x1"
+  }
+}
+%endif
+
+mov rbx, 0x0001
+mov rdi, 0x0001
+mov rdx, 0x8000
+mov rsi, 0x8000
+mov r15, 1
+mov rcx, 1
+
+stc
+rcr bx, cl
+mov r8, 0
+cmovo r8, r15 ; We only care about OF here
+
+clc
+rcr di, cl
+mov r9, 0
+cmovo r9, r15 ; We only care about OF here
+
+stc
+rcr dx, cl
+mov r10, 0
+cmovo r10, r15 ; We only care about OF here
+
+clc
+rcr si, cl
+mov r11, 0
+cmovo r11, r15 ; We only care about OF here
+
+hlt

--- a/unittests/ASM/PrimaryGroup/2_D3_03_5.asm
+++ b/unittests/ASM/PrimaryGroup/2_D3_03_5.asm
@@ -1,0 +1,43 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RBX": "0x80000000",
+    "RDI": "0x00000000",
+    "RDX": "0xC0000000",
+    "RSI": "0x40000000",
+    "R8":  "0x1",
+    "R9":  "0x0",
+    "R10": "0x0",
+    "R11": "0x1"
+  }
+}
+%endif
+
+mov rbx, 0x00000001
+mov rdi, 0x00000001
+mov rdx, 0x80000000
+mov rsi, 0x80000000
+mov r15, 1
+mov rcx, 1
+
+stc
+rcr ebx, cl
+mov r8, 0
+cmovo r8, r15 ; We only care about OF here
+
+clc
+rcr edi, cl
+mov r9, 0
+cmovo r9, r15 ; We only care about OF here
+
+stc
+rcr edx, cl
+mov r10, 0
+cmovo r10, r15 ; We only care about OF here
+
+clc
+rcr esi, cl
+mov r11, 0
+cmovo r11, r15 ; We only care about OF here
+
+hlt

--- a/unittests/ASM/PrimaryGroup/2_D3_03_6.asm
+++ b/unittests/ASM/PrimaryGroup/2_D3_03_6.asm
@@ -1,0 +1,43 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RBX": "0x8000000000000000",
+    "RDI": "0x0000000000000000",
+    "RDX": "0xC000000000000000",
+    "RSI": "0x4000000000000000",
+    "R8":  "0x1",
+    "R9":  "0x0",
+    "R10": "0x0",
+    "R11": "0x1"
+  }
+}
+%endif
+
+mov rbx, 0x0000000000000001
+mov rdi, 0x0000000000000001
+mov rdx, 0x8000000000000000
+mov rsi, 0x8000000000000000
+mov r15, 1
+mov rcx, 1
+
+stc
+rcr rbx, cl
+mov r8, 0
+cmovo r8, r15 ; We only care about OF here
+
+clc
+rcr rdi, cl
+mov r9, 0
+cmovo r9, r15 ; We only care about OF here
+
+stc
+rcr rdx, cl
+mov r10, 0
+cmovo r10, r15 ; We only care about OF here
+
+clc
+rcr rsi, cl
+mov r11, 0
+cmovo r11, r15 ; We only care about OF here
+
+hlt


### PR DESCRIPTION
These are interesting rotate instructions that treats CF as an
additional rotation bit for the source.

So you end up with a 9bit, 17bit, 33bit, or 65bit rotate.
The rotate value is still masked by 0x1F or 0x3F depending on
instruction size.

This ends up with the quirk that this instruction doesn't directly map
to AArch64 rotations  for the smaller register sizes;
So we have to do some manual mirroring in a larger register to pull the
correct view out of the op