### PR TITLE
OP_ASR: Fix zext semantics

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -764,16 +764,16 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
             uint8_t Mask = OpSize * 8 - 1;
             switch (OpSize) {
               case 1:
-                GD = static_cast<int8_t>(Src1) >> (Src2 & Mask);
+                GD = (uint8_t)(static_cast<int8_t>(Src1) >> (Src2 & Mask));
                 break;
               case 2:
-                GD = static_cast<int16_t>(Src1) >> (Src2 & Mask);
+                GD = (uint16_t)(static_cast<int16_t>(Src1) >> (Src2 & Mask));
                 break;
               case 4:
-                GD = static_cast<int32_t>(Src1) >> (Src2 & Mask);
+                GD = (uint32_t)(static_cast<int32_t>(Src1) >> (Src2 & Mask));
                 break;
               case 8:
-                GD = static_cast<int64_t>(Src1) >> (Src2 & Mask);
+                GD = (uint64_t)(static_cast<int64_t>(Src1) >> (Src2 & Mask));
                 break;
               default: LogMan::Msg::A("Unknown ASHR Size: %d\n", OpSize); break;
             };

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -413,9 +413,13 @@ DEF_OP(Ashr) {
   uint8_t OpSize = IROp->Size;
   if (OpSize == 8)
     asrv(GetReg<RA_64>(Node), GetReg<RA_64>(Op->Header.Args[0].ID()), GetReg<RA_64>(Op->Header.Args[1].ID()));
+  else if (OpSize == 4) {
+    asrv(GetReg<RA_32>(Node), GetReg<RA_32>(Op->Header.Args[0].ID()), GetReg<RA_32>(Op->Header.Args[1].ID()));
+  }
   else {
     sbfx(TMP1.X(), GetReg<RA_64>(Op->Header.Args[0].ID()), 0, OpSize * 8);
     asrv(GetReg<RA_64>(Node), TMP1.X(), GetReg<RA_64>(Op->Header.Args[1].ID()));
+    ubfx(GetReg<RA_64>(Node),GetReg<RA_64>(Node), 0, OpSize * 8);
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -1513,12 +1513,12 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
           case 1:
             movsx(rax, GetSrc<RA_8>(Op->Header.Args[0].ID()));
             sar(al, cl);
-            movsx(GetDst<RA_64>(Node), al);
+            movzx(GetDst<RA_64>(Node), al);
           break;
           case 2:
             movsx(rax, GetSrc<RA_16>(Op->Header.Args[0].ID()));
             sar(ax, cl);
-            movsx(GetDst<RA_64>(Node), ax);
+            movzx(GetDst<RA_64>(Node), ax);
           break;
           case 4:
             mov(GetDst<RA_32>(Node), GetSrc<RA_32>(Op->Header.Args[0].ID()));

--- a/unittests/ASM/PrimaryGroup/2_D1_07_2.asm
+++ b/unittests/ASM/PrimaryGroup/2_D1_07_2.asm
@@ -1,0 +1,31 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x414141414141FFFF",
+    "RBX": "0x00000000FFFFFFFF",
+    "RDX": "0xFFFFFFFFFFFFFFFF",
+    "RSI": "0x42424242424242FF"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4141414141418000
+mov rbx, 0x80000000
+mov rdx, 0x8000000000000000
+mov rsi, 0x4242424242424280
+
+mov cl, 7
+sar sil, cl
+
+mov cl, 15
+sar ax, cl
+
+mov cl, 31
+sar ebx, cl
+
+mov cl, 63
+sar rdx, cl
+
+hlt


### PR DESCRIPTION
ASR should shift signed for its bit size, but then zext to full register size.