### PR TITLE
SMC: Add --smc-full-checks, implement frontend, irint, irjit, unit test

### DIFF
--- a/External/FEXCore/Source/Interface/Config/Config.cpp
+++ b/External/FEXCore/Source/Interface/Config/Config.cpp
@@ -36,6 +36,9 @@ namespace FEXCore::Config {
     case FEXCore::Config::CONFIG_TSO_ENABLED:
       CTX->Config.TSOEnabled = Config != 0;
     break;
+    case FEXCore::Config::CONFIG_SMC_CHECKS:
+      CTX->Config.SMCChecks = Config != 0;
+    break;
     default: LogMan::Msg::A("Unknown configuration option");
     }
   }
@@ -82,6 +85,9 @@ namespace FEXCore::Config {
     break;
     case FEXCore::Config::CONFIG_TSO_ENABLED:
       return CTX->Config.TSOEnabled;
+    break;
+    case FEXCore::Config::CONFIG_SMC_CHECKS:
+      return CTX->Config.SMCChecks;
     break;
     default: LogMan::Msg::A("Unknown configuration option");
     }

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -60,6 +60,7 @@ namespace FEXCore::Context {
       bool Is64BitMode {true};
       uint64_t EmulatedCPUCores{1};
       bool TSOEnabled {true};
+      bool SMCChecks {false};
     } Config;
 
     FEXCore::Memory::MemMapper MemoryMapper;
@@ -112,6 +113,8 @@ namespace FEXCore::Context {
     void StartGdbServer();
     void StopGdbServer();
     void HandleCallback(uint64_t RIP);
+
+    static void RemoveCodeEntry(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP);
 
     // Debugger interface
     void CompileRIP(FEXCore::Core::InternalThreadState *Thread, uint64_t RIP);

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -138,6 +138,23 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
         uint32_t Node = WrapperOp.ID();
 
         switch (IROp->Op) {
+          case IR::OP_VALIDATECODE: {
+            auto Op = IROp->C<IR::IROp_ValidateCode>();
+
+            if (memcmp((void*)Op->CodePtr, &Op->CodeOriginal, Op->CodeLength) != 0) {
+              GD = 1;
+            } else {
+              GD = 0;
+            }
+            break;
+          }
+          
+          case IR::OP_REMOVECODEENTRY: {
+            auto Op = IROp->C<IR::IROp_RemoveCodeEntry>();
+            CTX->RemoveCodeEntry(Thread, Op->RIP);
+            break;
+          }
+
           case IR::OP_DUMMY:
           case IR::OP_BEGINBLOCK:
             break;

--- a/External/FEXCore/Source/Interface/Core/Interpreter/x86_64Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/x86_64Dispatcher.cpp
@@ -115,6 +115,11 @@ DispatchGenerator::DispatchGenerator(FEXCore::Context::Context *ctx, FEXCore::Co
 
     shl(rax, (int)log2(sizeof(FEXCore::BlockCache::BlockCacheEntry)));
 
+    // check for aliasing
+    mov(rcx, qword [rdi + rax + 8]);
+    cmp(rcx, rdx);
+    jne(NoBlock);
+    
     // Load the block pointer
     mov(rax, qword [rdi + rax]);
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -309,6 +309,8 @@ private:
   DEF_OP(CondJump);
   DEF_OP(Syscall);
   DEF_OP(Thunk);
+  DEF_OP(ValidateCode);
+  DEF_OP(RemoveCodeEntry);
   DEF_OP(CPUID);
 
   ///< Conversion ops

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -86,6 +86,27 @@
       ]
     },
 
+    "ValidateCode": {
+      "HasSideEffects": true,
+      "OpClass": "Misc",
+      "HasDest": true,
+      "DestClass": "GPR",
+      "DestSize": "8",
+      "Args": [
+        "__uint128_t", "CodeOriginal",
+        "uint64_t", "CodePtr",
+        "uint8_t", "CodeLength"
+      ]
+    },
+
+    "RemoveCodeEntry": {
+      "HasSideEffects": true,
+      "OpClass": "Misc",
+      "Args": [
+        "uint64_t", "RIP"
+      ]
+    },
+
     "GuestCallDirect": {
       "OpClass": "Branch",
       "Args": [

--- a/External/FEXCore/include/FEXCore/Config/Config.h
+++ b/External/FEXCore/include/FEXCore/Config/Config.h
@@ -17,6 +17,7 @@ namespace FEXCore::Config {
     CONFIG_IS64BIT_MODE,
     CONFIG_EMULATED_CPU_CORES,
     CONFIG_TSO_ENABLED,
+    CONFIG_SMC_CHECKS
   };
 
   enum ConfigCore {

--- a/Source/Common/ArgumentLoader.cpp
+++ b/Source/Common/ArgumentLoader.cpp
@@ -68,6 +68,12 @@ namespace FEX::ArgLoader {
         .help("Disables TSO IR ops. Highly likely to break any threaded application")
         .set_default(true);
 
+      CPUGroup.add_option("--smc-full-checks")
+        .dest("SMCChecks")
+        .action("store_true")
+        .help("Checks code for modification before execution. Slow.")
+        .set_default(false);
+
       Parser.add_option_group(CPUGroup);
     }
     {
@@ -189,6 +195,11 @@ namespace FEX::ArgLoader {
       if (Options.is_set_by_user("TSOEnabled")) {
         bool TSOEnabled = Options.get("TSOEnabled");
         Config::Add("TSOEnabled", std::to_string(TSOEnabled));
+      }
+      
+      if (Options.is_set_by_user("SMCChecks")) {
+        bool SMCChecks = Options.get("SMCChecks");
+        Config::Add("SMCChecks", std::to_string(SMCChecks));
       }
     }
 

--- a/Source/Common/EnvironmentLoader.cpp
+++ b/Source/Common/EnvironmentLoader.cpp
@@ -81,6 +81,10 @@ namespace FEX::EnvLoader {
       if ((Value = GetVar("FEX_TSO_ENABLED")).size()) {
         if (isdigit(Value[0])) Config::Add("TSOEnabled", Value);
       }
+
+      if ((Value = GetVar("FEX_SMC_CHECKS")).size()) {
+        if (isdigit(Value[0])) Config::Add("SMCChecks", Value);
+      }
     }
 
     {

--- a/Source/Tests/ELFLoader.cpp
+++ b/Source/Tests/ELFLoader.cpp
@@ -110,6 +110,7 @@ int main(int argc, char **argv, char **const envp) {
   FEX::Config::Value<std::string> Environment{"Env", ""};
   FEX::Config::Value<std::string> OutputLog{"OutputLog", "stderr"};
   FEX::Config::Value<bool> TSOEnabledConfig{"TSOEnabled", true};
+  FEX::Config::Value<bool> SMCChecksConfig{"SMCChecks", false};
 
   ::SilentLog = SilentLog();
 
@@ -154,6 +155,8 @@ int main(int argc, char **argv, char **const envp) {
   FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_IS64BIT_MODE, Loader.Is64BitMode());
   FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_EMULATED_CPU_CORES, ThreadsConfig());
   FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_TSO_ENABLED, TSOEnabledConfig());
+  FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_SMC_CHECKS, SMCChecksConfig());
+  
   FEXCore::Context::SetCustomCPUBackendFactory(CTX, VMFactory::CPUCreationFactory);
   // FEXCore::Context::SetFallbackCPUBackendFactory(CTX, VMFactory::CPUCreationFactoryFallback);
 

--- a/Source/Tests/TestHarnessRunner.cpp
+++ b/Source/Tests/TestHarnessRunner.cpp
@@ -60,6 +60,7 @@ int main(int argc, char **argv, char **const envp) {
   FEX::Config::Value<uint64_t> BlockSizeConfig{"MaxInst", 1};
   FEX::Config::Value<bool> SingleStepConfig{"SingleStep", false};
   FEX::Config::Value<bool> MultiblockConfig{"Multiblock", false};
+  FEX::Config::Value<bool> SMCChecksConfig{"SMCChecks", false};
 
   auto Args = FEX::ArgLoader::Get();
 
@@ -78,6 +79,7 @@ int main(int argc, char **argv, char **const envp) {
   FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_SINGLESTEP, SingleStepConfig());
   FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_MAXBLOCKINST, BlockSizeConfig());
   FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_IS64BIT_MODE, Loader.Is64BitMode());
+  FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_SMC_CHECKS, SMCChecksConfig());
   FEXCore::Context::SetCustomCPUBackendFactory(CTX, VMFactory::CPUCreationFactory);
 
   FEXCore::Context::AddGuestMemoryRegion(CTX, SHM);

--- a/unittests/ASM/CMakeLists.txt
+++ b/unittests/ASM/CMakeLists.txt
@@ -61,6 +61,11 @@ foreach(ASM_SRC ${ASM_SOURCES})
 
     set(TEST_NAME "${TEST_DESC}/Test_${REL_TEST_ASM}")
     string(REPLACE " " ";" ARGS_LIST ${ARGS})
+
+    if (TEST_NAME MATCHES "SelfModifyingCode")
+      list(APPEND ARGS_LIST "--smc-full-checks")
+    endif()
+
     add_test(NAME ${TEST_NAME}
       COMMAND "python3" "${CMAKE_SOURCE_DIR}/Scripts/testharness_runner.py"
       "${CMAKE_SOURCE_DIR}/unittests/ASM/Known_Failures"

--- a/unittests/ASM/SelfModifyingCode/DifferentBlock.asm
+++ b/unittests/ASM/SelfModifyingCode/DifferentBlock.asm
@@ -1,0 +1,26 @@
+%ifdef CONFIG
+{
+  "Match": "All",
+  "RegData": {
+    "RAX": "0x20"
+  }
+}
+%endif
+
+jmp main
+
+patched_op:
+mov rax,-1
+ret
+
+main:
+
+; warm up the cache
+call patched_op
+
+mov byte [rel patched_op], 0xC3
+
+mov rax, 32
+call patched_op
+
+hlt

--- a/unittests/ASM/SelfModifyingCode/SameBlock.asm
+++ b/unittests/ASM/SelfModifyingCode/SameBlock.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "Match": "All",
+  "RegData": {
+    "RAX": "0x20"
+  }
+}
+%endif
+
+
+mov rax, 32
+
+; patch mov rax,... to nops
+mov byte [rel patched_op + 0], 0x90
+mov byte [rel patched_op + 1], 0x90
+mov byte [rel patched_op + 2], 0x90
+mov byte [rel patched_op + 3], 0x90
+mov byte [rel patched_op + 4], 0x90
+mov byte [rel patched_op + 5], 0x90
+mov byte [rel patched_op + 6], 0x90
+mov byte [rel patched_op + 7], 0x90
+mov byte [rel patched_op + 8], 0x90
+mov byte [rel patched_op + 9], 0x90
+
+patched_op:
+mov rax,0xFABCFABCFABC0123 ; 10 bytes long
+
+hlt


### PR DESCRIPTION
This is a brute-force solution that can catch any kind of SMC, including modifications to the next instruction

Adds two new IR ops
- ValidateCode that compares current vs original code and returns 0 on same, non zero on different
- RemoveCodeEntry that removes the code entries (via Context::RemoveCodeEntry)

Adds `--smc-full-checks` in FEXLoader and UnitTestHarness

Adds logic to validate code in `Context::CompileBlock` (Core.cpp) if enabled

Adds a unit test to check that SMC detection works, `--smc-full-checks` is passed only for that test

Notes
- ValidateCode can be implemented as a string of Constant/Cmp/Select IR ops, though codegen would be much worse
- When enabled it disables most optimizations as it emits a host-block per guest-op