### PR TITLE
Fixes address size override prefix

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -126,16 +126,14 @@ void OpDispatchBuilder::LEAOp(OpcodeArgs) {
   if (CTX->Config.Is64BitMode) {
     uint32_t DstSize = X86Tables::DecodeFlags::GetOpAddr(Op->Flags, 0) == X86Tables::DecodeFlags::FLAG_OPERAND_SIZE_LAST ? 2 :
       X86Tables::DecodeFlags::GetOpAddr(Op->Flags, 0) == X86Tables::DecodeFlags::FLAG_WIDENING_SIZE_LAST ? 8 : 4;
-    uint32_t SrcSize = (Op->Flags & X86Tables::DecodeFlags::FLAG_ADDRESS_SIZE) ? 4 : 8;
 
-    OrderedNode *Src = LoadSource_WithOpSize(GPRClass, Op, Op->Src[0], SrcSize, Op->Flags, -1, false);
+    OrderedNode *Src = LoadSource_WithOpSize(GPRClass, Op, Op->Src[0], GetSrcSize(Op), Op->Flags, -1, false);
     StoreResult_WithOpSize(GPRClass, Op, Op->Dest, Src, DstSize, -1);
   }
   else {
     uint32_t DstSize = X86Tables::DecodeFlags::GetOpAddr(Op->Flags, 0) == X86Tables::DecodeFlags::FLAG_OPERAND_SIZE_LAST ? 2 : 4;
-    uint32_t SrcSize = (Op->Flags & X86Tables::DecodeFlags::FLAG_ADDRESS_SIZE) ? 2 : 4;
 
-    OrderedNode *Src = LoadSource_WithOpSize(GPRClass, Op, Op->Src[0], SrcSize, Op->Flags, -1, false);
+    OrderedNode *Src = LoadSource_WithOpSize(GPRClass, Op, Op->Src[0], GetSrcSize(Op), Op->Flags, -1, false);
     StoreResult_WithOpSize(GPRClass, Op, Op->Dest, Src, DstSize, -1);
   }
 }
@@ -4153,6 +4151,7 @@ OrderedNode *OpDispatchBuilder::LoadSource_WithOpSize(FEXCore::IR::RegisterClass
   bool LoadableType = false;
   bool StackAccess = false;
   uint8_t GPRSize = CTX->Config.Is64BitMode ? 8 : 4;
+  uint32_t AddrSize = (Op->Flags & X86Tables::DecodeFlags::FLAG_ADDRESS_SIZE) ? (GPRSize >> 1) : GPRSize;
 
   if (Operand.TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL) {
     uint64_t constant = Operand.TypeLiteral.Literal;
@@ -4176,12 +4175,12 @@ OrderedNode *OpDispatchBuilder::LoadSource_WithOpSize(FEXCore::IR::RegisterClass
     }
   }
   else if (Operand.TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_GPR_DIRECT) {
-    Src = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[Operand.TypeGPR.GPR]), GPRClass);
+    Src = _LoadContext(AddrSize, offsetof(FEXCore::Core::CPUState, gregs[Operand.TypeGPR.GPR]), GPRClass);
     LoadableType = true;
     StackAccess = Operand.TypeGPR.GPR == FEXCore::X86State::REG_RSP;
   }
   else if (Operand.TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_GPR_INDIRECT) {
-    auto GPR = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[Operand.TypeGPRIndirect.GPR]), GPRClass);
+    auto GPR = _LoadContext(AddrSize, offsetof(FEXCore::Core::CPUState, gregs[Operand.TypeGPRIndirect.GPR]), GPRClass);
     auto Constant = _Constant(GPRSize * 8, Operand.TypeGPRIndirect.Displacement);
 
 		Src = _Add(GPR, Constant);
@@ -4203,7 +4202,7 @@ OrderedNode *OpDispatchBuilder::LoadSource_WithOpSize(FEXCore::IR::RegisterClass
   else if (Operand.TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_SIB) {
     OrderedNode *Tmp {};
     if (Operand.TypeSIB.Index != FEXCore::X86State::REG_INVALID) {
-      Tmp = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[Operand.TypeSIB.Index]), GPRClass);
+      Tmp = _LoadContext(AddrSize , offsetof(FEXCore::Core::CPUState, gregs[Operand.TypeSIB.Index]), GPRClass);
 
       if (Operand.TypeSIB.Scale != 1) {
         auto Constant = _Constant(GPRSize * 8, Operand.TypeSIB.Scale);
@@ -4213,7 +4212,7 @@ OrderedNode *OpDispatchBuilder::LoadSource_WithOpSize(FEXCore::IR::RegisterClass
     }
 
     if (Operand.TypeSIB.Base != FEXCore::X86State::REG_INVALID) {
-      auto GPR = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[Operand.TypeSIB.Base]), GPRClass);
+      auto GPR = _LoadContext(AddrSize, offsetof(FEXCore::Core::CPUState, gregs[Operand.TypeSIB.Base]), GPRClass);
 
       if (Tmp != nullptr) {
         Tmp = _Add(Tmp, GPR);
@@ -4298,6 +4297,7 @@ void OpDispatchBuilder::StoreResult_WithOpSize(FEXCore::IR::RegisterClassType Cl
   bool MemStore = false;
   bool StackAccess = false;
   uint8_t GPRSize = CTX->Config.Is64BitMode ? 8 : 4;
+  uint32_t AddrSize = (Op->Flags & X86Tables::DecodeFlags::FLAG_ADDRESS_SIZE) ? (GPRSize >> 1) : GPRSize;
 
   if (Operand.TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL) {
     MemStoreDst = _Constant(Operand.TypeLiteral.Size * 8, Operand.TypeLiteral.Literal);
@@ -4326,12 +4326,12 @@ void OpDispatchBuilder::StoreResult_WithOpSize(FEXCore::IR::RegisterClassType Cl
     }
   }
   else if (Operand.TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_GPR_DIRECT) {
-    MemStoreDst = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[Operand.TypeGPR.GPR]), GPRClass);
+    MemStoreDst = _LoadContext(AddrSize, offsetof(FEXCore::Core::CPUState, gregs[Operand.TypeGPR.GPR]), GPRClass);
     MemStore = true;
     StackAccess = Operand.TypeGPR.GPR == FEXCore::X86State::REG_RSP;
   }
   else if (Operand.TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_GPR_INDIRECT) {
-    auto GPR = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[Operand.TypeGPRIndirect.GPR]), GPRClass);
+    auto GPR = _LoadContext(AddrSize, offsetof(FEXCore::Core::CPUState, gregs[Operand.TypeGPRIndirect.GPR]), GPRClass);
     auto Constant = _Constant(GPRSize * 8, Operand.TypeGPRIndirect.Displacement);
 
     MemStoreDst = _Add(GPR, Constant);
@@ -4345,7 +4345,7 @@ void OpDispatchBuilder::StoreResult_WithOpSize(FEXCore::IR::RegisterClassType Cl
   else if (Operand.TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_SIB) {
     OrderedNode *Tmp {};
     if (Operand.TypeSIB.Index != FEXCore::X86State::REG_INVALID) {
-      Tmp = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[Operand.TypeSIB.Index]), GPRClass);
+      Tmp = _LoadContext(AddrSize, offsetof(FEXCore::Core::CPUState, gregs[Operand.TypeSIB.Index]), GPRClass);
 
       if (Operand.TypeSIB.Scale != 1) {
         auto Constant = _Constant(GPRSize * 8, Operand.TypeSIB.Scale);
@@ -4354,7 +4354,7 @@ void OpDispatchBuilder::StoreResult_WithOpSize(FEXCore::IR::RegisterClassType Cl
     }
 
     if (Operand.TypeSIB.Base != FEXCore::X86State::REG_INVALID) {
-      auto GPR = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[Operand.TypeSIB.Base]), GPRClass);
+      auto GPR = _LoadContext(AddrSize, offsetof(FEXCore::Core::CPUState, gregs[Operand.TypeSIB.Base]), GPRClass);
 
       if (Tmp != nullptr) {
         Tmp = _Add(Tmp, GPR);

--- a/unittests/ASM/Primary/Primary_8D_2.asm
+++ b/unittests/ASM/Primary/Primary_8D_2.asm
@@ -1,0 +1,60 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x00000000FFFFFFFF",
+    "RBX": "0x00000000FFFFFFFF",
+    "RCX": "0x414243444546FFFF",
+    "RDX": "0x414243444546FFFF",
+    "RDI": "0x0000000000000001",
+    "RSI": "0x0000000000000001",
+    "RBP": "0x0",
+    "RSP": "0x0"
+  }
+}
+%endif
+
+mov rax, -1
+mov rbx, -1
+
+lea rax, [ebx]
+
+mov rbx, -1
+mov rcx, -1
+
+lea ebx, [ecx]
+
+mov rcx, 0x4142434445464748
+mov rdx, -1
+
+lea cx, [edx]
+
+mov rdx, 0x4142434445464748
+mov rdi, -1
+
+lea dx, [rdi]
+
+mov rdi, 0x4142434445464748
+mov rsi, 0xFFFFFFFF00000000
+mov rbp, 1
+
+lea rdi, [esi + ebp]
+
+mov rsi, 0x4142434445464748
+mov rbp, 0xFFFFFFFF00000000
+mov rsp, 1
+
+lea esi, [rbp + rsp]
+
+mov rbp, 0x4142434445464748
+mov rsp, 0xFFFFFFFF00000000
+mov r9,  0x0000000200000000
+
+lea ebp, [esp + r9d]
+
+mov rsp, 0x4142434445464748
+mov r9,  0xFFFFFFFF00000000
+mov r10, 0x0000000200000000
+
+lea rsp, [r10d + r9d]
+
+hlt


### PR DESCRIPTION
We were handling this in a completely broken fashion and it only broke
more with the previous zexting changes.

This fixes the EXPLICIT address size override usage.
There are still a few instructions that rely on implicit address size
override support that this doesn't handle