### PR TITLE
Fixes CASP IR op on interpreter when unified memory is enabled

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -472,7 +472,7 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
               case 4: {
                 std::atomic<uint64_t> *Data = {};
                 if (Thread->CTX->Config.UnifiedMemory) {
-                  Data = GetSrc<std::atomic<uint64_t> *>(SSAData, Op->Header.Args[2]);
+                  Data = *GetSrc<std::atomic<uint64_t> **>(SSAData, Op->Header.Args[2]);
                 }
                 else {
                   Data = Thread->CTX->MemoryMapper.GetPointer<std::atomic<uint64_t> *>(*GetSrc<uint64_t*>(SSAData, Op->Header.Args[2]));
@@ -490,7 +490,7 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
               case 8: {
                 std::atomic<__uint128_t> *Data = {};
                 if (Thread->CTX->Config.UnifiedMemory) {
-                  Data = GetSrc<std::atomic<__uint128_t> *>(SSAData, Op->Header.Args[2]);
+                  Data = *GetSrc<std::atomic<__uint128_t> **>(SSAData, Op->Header.Args[2]);
                 }
                 else {
                   Data = Thread->CTX->MemoryMapper.GetPointer<std::atomic<__uint128_t> *>(*GetSrc<uint64_t*>(SSAData, Op->Header.Args[2]));

--- a/Source/Tests/ELFLoader.cpp
+++ b/Source/Tests/ELFLoader.cpp
@@ -103,7 +103,6 @@ int main(int argc, char **argv, char **const envp) {
   FEX::Config::Value<bool> MultiblockConfig{"Multiblock", false};
   FEX::Config::Value<bool> GdbServerConfig{"GdbServer", false};
   FEX::Config::Value<uint64_t> ThreadsConfig{"Threads", 1};
-  FEX::Config::Value<bool> UnifiedMemory{"UnifiedMemory", true};
   FEX::Config::Value<std::string> LDPath{"RootFS", ""};
   FEX::Config::Value<std::string> ThunkLibsPath{"ThunkLibs", ""};
   FEX::Config::Value<bool> SilentLog{"SilentLog", false};
@@ -151,7 +150,7 @@ int main(int argc, char **argv, char **const envp) {
   FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_GDBSERVER, GdbServerConfig());
   FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_ROOTFSPATH, LDPath());
   FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_THUNKLIBSPATH, ThunkLibsPath());
-  FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_UNIFIED_MEMORY, UnifiedMemory());
+  FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_UNIFIED_MEMORY, true);
   FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_IS64BIT_MODE, Loader.Is64BitMode());
   FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_EMULATED_CPU_CORES, ThreadsConfig());
   FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_TSO_ENABLED, TSOEnabledConfig());

--- a/Source/Tests/TestHarnessRunner.cpp
+++ b/Source/Tests/TestHarnessRunner.cpp
@@ -73,7 +73,7 @@ int main(int argc, char **argv, char **const envp) {
   FEX::HarnessHelper::HarnessCodeLoader Loader{Args[0], Args[1].c_str()};
 
   FEXCore::Context::SetCustomCPUBackendFactory(CTX, VMFactory::CPUCreationFactory);
-  FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_UNIFIED_MEMORY, 0); // ensure TestHarnessRunner doesn't enable UnifiedMemory.
+  FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_UNIFIED_MEMORY, true);
   FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_DEFAULTCORE, CoreConfig() > 3 ? FEXCore::Config::CONFIG_CUSTOM : CoreConfig());
   FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_MULTIBLOCK, MultiblockConfig());
   FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_SINGLESTEP, SingleStepConfig());


### PR DESCRIPTION
Noticed by Stef on 09/09/2020 as a curious code block that was failing
Forgot about it until now since we couldn't see exactly where it was
wrong

Code block was mixing x87 (Which forces a fallback to Interpreter) and
cmpxchg8b, which caused that code block to fail.

Since this op was broken with Unified Memory + Interpreter it wasn't
picked up by unit tests since those don't run in unified memory

Code block from before
```
   0x00007fece80daa10:    push   rbp
   0x00007fece80daa11:    mov    rbp,rsp
   0x00007fece80daa14:    push   rbx
   0x00007fece80daa15:    fild   QWORD PTR [rdi]
   0x00007fece80daa17:    fistp  QWORD PTR [rbp-0x10]
   0x00007fece80daa1a:    mov    rax,QWORD PTR [rbp-0x10]
   0x00007fece80daa1e:    xchg   ax,ax
   0x00007fece80daa20:    lea    rcx,[rax+rsi*1]
   0x00007fece80daa24:    mov    ebx,ecx
   0x00007fece80daa26:    shr    rcx,0x20
   0x00007fece80daa2a:    lock cmpxchg8b QWORD PTR [rdi]
   0x00007fece80daa2e:    cmp    rdx,rax
   0x00007fece80daa31:    je     0x7fece80daa40
   0x00007fece80daa33:    mov    rax,rdx
   0x00007fece80daa36:    jmp    0x7fece80daa20
   0x00007fece80daa38:    nop    DWORD PTR [rax+rax*1+0x0]
   0x00007fece80daa40:    pop    rbx
   0x00007fece80daa41:    pop    rbp
   0x00007fece80daa42:    ret 
```