### PR TITLE
Fixes incorrect assuming BT tests

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -2266,16 +2266,35 @@ void OpDispatchBuilder::RCLSmallerOp(OpcodeArgs) {
 template<uint32_t SrcIndex>
 void OpDispatchBuilder::BTOp(OpcodeArgs) {
   OrderedNode *Result;
-  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[SrcIndex], Op->Flags, -1);
+  OrderedNode *Src{};
+  bool AlreadyMasked{};
+
+  uint32_t Size = GetDstSize(Op) * 8;
+  uint32_t Mask = Size - 1;
+
+  if (Op->Src[SrcIndex].TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_GPR) {
+    Src = LoadSource(GPRClass, Op, Op->Src[SrcIndex], Op->Flags, -1);
+  }
+  else {
+    // Can only be an immediate
+    // Masked by operand size
+    Src = _Constant(Size, Op->Src[SrcIndex].TypeLiteral.Literal & Mask);
+    AlreadyMasked = true;
+  }
+
   if (Op->Dest.TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_GPR) {
     OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
 
-    uint32_t Size = GetSrcSize(Op);
-    uint32_t Mask = Size * 8 - 1;
-    OrderedNode *SizeMask = _Constant(Mask);
+    OrderedNode *BitSelect{};
+    if (AlreadyMasked) {
+      BitSelect = Src;
+    }
+    else {
+      OrderedNode *SizeMask = _Constant(Mask);
 
-    // Get the bit selection from the src
-    OrderedNode *BitSelect = _And(Src, SizeMask);
+      // Get the bit selection from the src
+      BitSelect = _And(Src, SizeMask);
+    }
 
     Result = _Lshr(Dest, BitSelect);
   }
@@ -2288,7 +2307,6 @@ void OpDispatchBuilder::BTOp(OpcodeArgs) {
 
     // Address is provided as bits we want BYTE offsets
     // Extract Signed offset
-    uint32_t Size = GetSrcSize(Op) * 8;
     Src = _Sbfe(Size-3,3, Src);
 
     // Get the address offset by shifting out the size of the op (To shift out the bit selection)
@@ -2307,16 +2325,35 @@ void OpDispatchBuilder::BTOp(OpcodeArgs) {
 template<uint32_t SrcIndex>
 void OpDispatchBuilder::BTROp(OpcodeArgs) {
   OrderedNode *Result;
-  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[SrcIndex], Op->Flags, -1);
+  OrderedNode *Src{};
+  bool AlreadyMasked{};
+
+  uint32_t Size = GetDstSize(Op) * 8;
+  uint32_t Mask = Size - 1;
+
+  if (Op->Src[SrcIndex].TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_GPR) {
+    Src = LoadSource(GPRClass, Op, Op->Src[SrcIndex], Op->Flags, -1);
+  }
+  else {
+    // Can only be an immediate
+    // Masked by operand size
+    Src = _Constant(Size, Op->Src[SrcIndex].TypeLiteral.Literal & Mask);
+    AlreadyMasked = true;
+  }
+
   if (Op->Dest.TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_GPR) {
     OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
 
-    uint32_t Size = GetSrcSize(Op);
-    uint32_t Mask = Size * 8 - 1;
-    OrderedNode *SizeMask = _Constant(Mask);
+    OrderedNode *BitSelect{};
+    if (AlreadyMasked) {
+      BitSelect = Src;
+    }
+    else {
+      OrderedNode *SizeMask = _Constant(Mask);
 
-    // Get the bit selection from the src
-    OrderedNode *BitSelect = _And(Src, SizeMask);
+      // Get the bit selection from the src
+      BitSelect = _And(Src, SizeMask);
+    }
 
     Result = _Lshr(Dest, BitSelect);
 
@@ -2334,7 +2371,6 @@ void OpDispatchBuilder::BTROp(OpcodeArgs) {
 
     // Address is provided as bits we want BYTE offsets
     // Extract Signed offset
-    uint32_t Size = GetSrcSize(Op) * 8;
     Src = _Sbfe(Size-3,3, Src);
 
     // Get the address offset by shifting out the size of the op (To shift out the bit selection)
@@ -2357,16 +2393,35 @@ void OpDispatchBuilder::BTROp(OpcodeArgs) {
 template<uint32_t SrcIndex>
 void OpDispatchBuilder::BTSOp(OpcodeArgs) {
   OrderedNode *Result;
-  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[SrcIndex], Op->Flags, -1);
+  OrderedNode *Src{};
+  bool AlreadyMasked{};
+
+  uint32_t Size = GetDstSize(Op) * 8;
+  uint32_t Mask = Size - 1;
+
+  if (Op->Src[SrcIndex].TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_GPR) {
+    Src = LoadSource(GPRClass, Op, Op->Src[SrcIndex], Op->Flags, -1);
+  }
+  else {
+    // Can only be an immediate
+    // Masked by operand size
+    Src = _Constant(Size, Op->Src[SrcIndex].TypeLiteral.Literal & Mask);
+    AlreadyMasked = true;
+  }
+
   if (Op->Dest.TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_GPR) {
     OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
 
-    uint32_t Size = GetSrcSize(Op);
-    uint32_t Mask = Size * 8 - 1;
-    OrderedNode *SizeMask = _Constant(Mask);
+    OrderedNode *BitSelect{};
+    if (AlreadyMasked) {
+      BitSelect = Src;
+    }
+    else {
+      OrderedNode *SizeMask = _Constant(Mask);
 
-    // Get the bit selection from the src
-    OrderedNode *BitSelect = _And(Src, SizeMask);
+      // Get the bit selection from the src
+      BitSelect = _And(Src, SizeMask);
+    }
 
     Result = _Lshr(Dest, BitSelect);
 
@@ -2383,7 +2438,6 @@ void OpDispatchBuilder::BTSOp(OpcodeArgs) {
 
     // Address is provided as bits we want BYTE offsets
     // Extract Signed offset
-    uint32_t Size = GetSrcSize(Op) * 8;
     Src = _Sbfe(Size-3,3, Src);
 
     // Get the address offset by shifting out the size of the op (To shift out the bit selection)
@@ -2405,16 +2459,35 @@ void OpDispatchBuilder::BTSOp(OpcodeArgs) {
 template<uint32_t SrcIndex>
 void OpDispatchBuilder::BTCOp(OpcodeArgs) {
   OrderedNode *Result;
-  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[SrcIndex], Op->Flags, -1);
+  OrderedNode *Src{};
+  bool AlreadyMasked{};
+
+  uint32_t Size = GetDstSize(Op) * 8;
+  uint32_t Mask = Size - 1;
+
+  if (Op->Src[SrcIndex].TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_GPR) {
+    Src = LoadSource(GPRClass, Op, Op->Src[SrcIndex], Op->Flags, -1);
+  }
+  else {
+    // Can only be an immediate
+    // Masked by operand size
+    Src = _Constant(Size, Op->Src[SrcIndex].TypeLiteral.Literal & Mask);
+    AlreadyMasked = true;
+  }
+
   if (Op->Dest.TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_GPR) {
     OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
 
-    uint32_t Size = GetSrcSize(Op);
-    uint32_t Mask = Size * 8 - 1;
-    OrderedNode *SizeMask = _Constant(Mask);
+    OrderedNode *BitSelect{};
+    if (AlreadyMasked) {
+      BitSelect = Src;
+    }
+    else {
+      OrderedNode *SizeMask = _Constant(Mask);
 
-    // Get the bit selection from the src
-    OrderedNode *BitSelect = _And(Src, SizeMask);
+      // Get the bit selection from the src
+      BitSelect = _And(Src, SizeMask);
+    }
 
     Result = _Lshr(Dest, BitSelect);
 
@@ -2430,7 +2503,6 @@ void OpDispatchBuilder::BTCOp(OpcodeArgs) {
 
     // Address is provided as bits we want BYTE offsets
     // Extract Signed offset
-    uint32_t Size = GetSrcSize(Op) * 8;
     Src = _Sbfe(Size-3,3, Src);
 
     // Get the address offset by shifting out the size of the op (To shift out the bit selection)

--- a/unittests/ASM/Secondary/08_66_04.asm
+++ b/unittests/ASM/Secondary/08_66_04.asm
@@ -26,6 +26,7 @@ mov rdx, 0xe0000000
 mov rax, 0xFFFFFFFF80000000
 mov [rdx + 8 * 0], rax
 mov [rdx + 8 * 1], rax
+mov rax, 0x0
 mov [rdx + 8 * 2], rax
 mov rax, 0x01
 mov [rdx + 8 * 3], eax
@@ -34,17 +35,15 @@ mov [rdx + 8 * 3 + 4], eax
 
 xor r15, r15 ; Will contain our results
 
-db 0x66 ; Prefix with 66. Shouldn't change behaviour
 bt word [rdx], 1
 cfmerge
 
 mov r13, 32
-db 0x66 ; Prefix with 66. Shouldn't change behaviour
 bt dword [rdx], r13d
 cfmerge
 
-db 0x66 ; Prefix with 66. Shouldn't change behaviour
-bt qword [rdx], 64 * 3
+; Ensures correct modulo on value
+bt qword [rdx], 64 * 2 + 63
 cfmerge
 
 hlt

--- a/unittests/ASM/Secondary/08_66_04_2.asm
+++ b/unittests/ASM/Secondary/08_66_04_2.asm
@@ -26,6 +26,7 @@ mov rdx, 0xe0000000
 mov rax, 0xFFFFFFFF80000002
 mov [rdx + 8 * 0], rax
 mov [rdx + 8 * 1], rax
+mov rax, 0x0
 mov [rdx + 8 * 2], rax
 mov rax, 0x01
 mov [rdx + 8 * 3], eax
@@ -35,19 +36,16 @@ mov [rdx + 8 * 3 + 4], eax
 xor r15, r15 ; Will contain our results
 
 movzx r12, word [rdx]
-db 0x66 ; Prefix with 66. Shouldn't change behaviour
 bt r12w, 1
 cfmerge
 
 mov r13, 32
 mov r12d, dword [rdx]
 
-db 0x66 ; Prefix with 66. Shouldn't change behaviour
 bt r12d, r13d
 cfmerge
 
 mov r12, qword [rdx]
-db 0x66 ; Prefix with 66. Shouldn't change behaviour
 bt r12, 64 * 3
 cfmerge
 

--- a/unittests/ASM/Secondary/08_F2_04.asm
+++ b/unittests/ASM/Secondary/08_F2_04.asm
@@ -26,6 +26,7 @@ mov rdx, 0xe0000000
 mov rax, 0xFFFFFFFF80000000
 mov [rdx + 8 * 0], rax
 mov [rdx + 8 * 1], rax
+mov rax, 0x0
 mov [rdx + 8 * 2], rax
 mov rax, 0x01
 mov [rdx + 8 * 3], eax
@@ -44,7 +45,7 @@ bt dword [rdx], r13d
 cfmerge
 
 db 0xF2 ; Prefix with F2. Shouldn't change behaviour
-bt qword [rdx], 64 * 3
+bt qword [rdx], 64 * 2 + 63
 cfmerge
 
 hlt

--- a/unittests/ASM/Secondary/08_F2_04_2.asm
+++ b/unittests/ASM/Secondary/08_F2_04_2.asm
@@ -26,6 +26,7 @@ mov rdx, 0xe0000000
 mov rax, 0xFFFFFFFF80000002
 mov [rdx + 8 * 0], rax
 mov [rdx + 8 * 1], rax
+mov rax, 0x0
 mov [rdx + 8 * 2], rax
 mov rax, 0x01
 mov [rdx + 8 * 3], eax

--- a/unittests/ASM/Secondary/08_F3_04.asm
+++ b/unittests/ASM/Secondary/08_F3_04.asm
@@ -44,7 +44,7 @@ bt dword [rdx], r13d
 cfmerge
 
 db 0xF3 ; Prefix with F3. Shouldn't change behaviour
-bt qword [rdx], 64 * 3
+bt qword [rdx], 64 * 2 + 63
 cfmerge
 
 hlt

--- a/unittests/ASM/Secondary/08_XX_04.asm
+++ b/unittests/ASM/Secondary/08_XX_04.asm
@@ -26,6 +26,7 @@ mov rdx, 0xe0000000
 mov rax, 0xFFFFFFFF80000000
 mov [rdx + 8 * 0], rax
 mov [rdx + 8 * 1], rax
+mov rax, 0x0
 mov [rdx + 8 * 2], rax
 mov rax, 0x01
 mov [rdx + 8 * 3], eax
@@ -41,7 +42,7 @@ mov r13, 32
 bt dword [rdx], r13d
 cfmerge
 
-bt qword [rdx], 64 * 3
+bt qword [rdx], 64 * 2 + 63
 cfmerge
 
 hlt

--- a/unittests/ASM/Secondary/08_XX_04_2.asm
+++ b/unittests/ASM/Secondary/08_XX_04_2.asm
@@ -26,6 +26,7 @@ mov rdx, 0xe0000000
 mov rax, 0xFFFFFFFF80000002
 mov [rdx + 8 * 0], rax
 mov [rdx + 8 * 1], rax
+mov rax, 0x0
 mov [rdx + 8 * 2], rax
 mov rax, 0x01
 mov [rdx + 8 * 3], eax

--- a/unittests/ASM/Secondary/08_XX_05.asm
+++ b/unittests/ASM/Secondary/08_XX_05.asm
@@ -26,6 +26,7 @@ mov rdx, 0xe0000000
 mov rax, 0xFFFFFFFF80000000
 mov [rdx + 8 * 0], rax
 mov [rdx + 8 * 1], rax
+mov rax, 0x0
 mov [rdx + 8 * 2], rax
 mov rax, 0x01
 mov [rdx + 8 * 3], eax
@@ -49,10 +50,10 @@ cfmerge
 bt dword [rdx], r13d
 cfmerge
 
-bts qword [rdx], 64 * 3
+bts qword [rdx], 64 * 2 + 63
 cfmerge
 
-bt qword [rdx], 64 * 3
+bt qword [rdx], 64 * 2 + 63
 cfmerge
 
 hlt

--- a/unittests/ASM/Secondary/08_XX_05_2.asm
+++ b/unittests/ASM/Secondary/08_XX_05_2.asm
@@ -26,6 +26,7 @@ mov rdx, 0xe0000000
 mov rax, 0xFFFFFFFF80000002
 mov [rdx + 8 * 0], rax
 mov [rdx + 8 * 1], rax
+mov rax, 0x0
 mov [rdx + 8 * 2], rax
 mov rax, 0x01
 mov [rdx + 8 * 3], eax

--- a/unittests/ASM/Secondary/08_XX_06.asm
+++ b/unittests/ASM/Secondary/08_XX_06.asm
@@ -26,6 +26,7 @@ mov rdx, 0xe0000000
 mov rax, 0xFFFFFFFF80000000
 mov [rdx + 8 * 0], rax
 mov [rdx + 8 * 1], rax
+mov rax, 0x0
 mov [rdx + 8 * 2], rax
 mov rax, 0x01
 mov [rdx + 8 * 3], eax
@@ -49,10 +50,10 @@ cfmerge
 bt dword [rdx], r13d
 cfmerge
 
-btr qword [rdx], 64 * 3
+btr qword [rdx], 64 * 2 + 63
 cfmerge
 
-bt qword [rdx], 64 * 3
+bt qword [rdx], 64 * 2 + 63
 cfmerge
 
 hlt

--- a/unittests/ASM/Secondary/08_XX_06_2.asm
+++ b/unittests/ASM/Secondary/08_XX_06_2.asm
@@ -26,6 +26,7 @@ mov rdx, 0xe0000000
 mov rax, 0xFFFFFFFF80000002
 mov [rdx + 8 * 0], rax
 mov [rdx + 8 * 1], rax
+mov rax, 0x0
 mov [rdx + 8 * 2], rax
 mov rax, 0x01
 mov [rdx + 8 * 3], eax

--- a/unittests/ASM/Secondary/08_XX_07.asm
+++ b/unittests/ASM/Secondary/08_XX_07.asm
@@ -26,6 +26,7 @@ mov rdx, 0xe0000000
 mov rax, 0xFFFFFFFF80000000
 mov [rdx + 8 * 0], rax
 mov [rdx + 8 * 1], rax
+mov rax, 0x0
 mov [rdx + 8 * 2], rax
 mov rax, 0x01
 mov [rdx + 8 * 3], eax
@@ -49,10 +50,10 @@ cfmerge
 bt dword [rdx], r13d
 cfmerge
 
-btc qword [rdx], 64 * 3
+btc qword [rdx], 64 * 2 + 63
 cfmerge
 
-bt qword [rdx], 64 * 3
+bt qword [rdx], 64 * 2 + 63
 cfmerge
 
 hlt

--- a/unittests/ASM/Secondary/08_XX_07_2.asm
+++ b/unittests/ASM/Secondary/08_XX_07_2.asm
@@ -26,6 +26,7 @@ mov rdx, 0xe0000000
 mov rax, 0xFFFFFFFF80000002
 mov [rdx + 8 * 0], rax
 mov [rdx + 8 * 1], rax
+mov rax, 0x0
 mov [rdx + 8 * 2], rax
 mov rax, 0x01
 mov [rdx + 8 * 3], eax


### PR DESCRIPTION
66 prefix /does/ change behaviour because that is the operand size
prefix.

Additionally the immediate variant will also modulo the result.
So that needs to be checked for

Confirmed with manual on upcoming host-side unit test runner