### PR TITLE
Adds new IR ops for supporting host rounding mode conversion

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -1032,6 +1032,22 @@ DEF_OP(Float_ToGPR_ZS) {
   }
 }
 
+DEF_OP(Float_ToGPR_U) {
+  LogMan::Msg::D("Unimplemented");
+}
+
+DEF_OP(Float_ToGPR_S) {
+  auto Op = IROp->C<IR::IROp_Float_ToGPR_S>();
+  if (Op->Header.ElementSize == 8) {
+    frinti(VTMP1.D(), GetSrc(Op->Header.Args[0].ID()).D());
+    fcvtzs(GetReg<RA_64>(Node), VTMP1.D());
+  }
+  else {
+    frinti(VTMP1.S(), GetSrc(Op->Header.Args[0].ID()).S());
+    fcvtzs(GetReg<RA_32>(Node), VTMP1.S());
+  }
+}
+
 DEF_OP(FCmp) {
   auto Op = IROp->C<IR::IROp_FCmp>();
 
@@ -1110,6 +1126,8 @@ void JITCore::RegisterALUHandlers() {
   REGISTER_OP(VEXTRACTTOGPR,     VExtractToGPR);
   REGISTER_OP(FLOAT_TOGPR_ZU,    Float_ToGPR_ZU);
   REGISTER_OP(FLOAT_TOGPR_ZS,    Float_ToGPR_ZS);
+  REGISTER_OP(FLOAT_TOGPR_U,     Float_ToGPR_U);
+  REGISTER_OP(FLOAT_TOGPR_S,     Float_ToGPR_S);
   REGISTER_OP(FCMP,              FCmp);
   REGISTER_OP(F80CMP,            F80Cmp);
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ConversionOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ConversionOps.cpp
@@ -132,6 +132,36 @@ DEF_OP(Vector_FToZS) {
   }
 }
 
+DEF_OP(Vector_FToU) {
+  auto Op = IROp->C<IR::IROp_Vector_FToU>();
+  switch (Op->Header.ElementSize) {
+    case 4:
+      frinti(GetDst(Node).V4S(), GetSrc(Op->Header.Args[0].ID()).V4S());
+      fcvtzu(GetDst(Node).V4S(), GetDst(Node).V4S());
+    break;
+    case 8:
+      frinti(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D());
+      fcvtzu(GetDst(Node).V2D(), GetDst(Node).V2D());
+    break;
+    default: LogMan::Msg::A("Unknown castGPR element size: %d", Op->Header.ElementSize);
+  }
+}
+
+DEF_OP(Vector_FToS) {
+  auto Op = IROp->C<IR::IROp_Vector_FToS>();
+  switch (Op->Header.ElementSize) {
+    case 4:
+      frinti(GetDst(Node).V4S(), GetSrc(Op->Header.Args[0].ID()).V4S());
+      fcvtzs(GetDst(Node).V4S(), GetDst(Node).V4S());
+    break;
+    case 8:
+      frinti(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D());
+      fcvtzs(GetDst(Node).V2D(), GetDst(Node).V2D());
+    break;
+    default: LogMan::Msg::A("Unknown castGPR element size: %d", Op->Header.ElementSize);
+  }
+}
+
 DEF_OP(Vector_FToF) {
   auto Op = IROp->C<IR::IROp_Vector_FToF>();
   uint16_t Conv = (Op->Header.ElementSize << 8) | Op->SrcElementSize;
@@ -161,6 +191,8 @@ void JITCore::RegisterConversionHandlers() {
   REGISTER_OP(VECTOR_STOF,     Vector_SToF);
   REGISTER_OP(VECTOR_FTOZU,    Vector_FToZU);
   REGISTER_OP(VECTOR_FTOZS,    Vector_FToZS);
+  REGISTER_OP(VECTOR_FTOU,     Vector_FToU);
+  REGISTER_OP(VECTOR_FTOS,     Vector_FToS);
   REGISTER_OP(VECTOR_FTOF,     Vector_FToF);
 #undef REGISTER_OP
 }

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -280,6 +280,8 @@ private:
   DEF_OP(VExtractToGPR);
   DEF_OP(Float_ToGPR_ZU);
   DEF_OP(Float_ToGPR_ZS);
+  DEF_OP(Float_ToGPR_U);
+  DEF_OP(Float_ToGPR_S);
   DEF_OP(FCmp);
   DEF_OP(F80Cmp);
 
@@ -323,6 +325,8 @@ private:
   DEF_OP(Vector_SToF);
   DEF_OP(Vector_FToZU);
   DEF_OP(Vector_FToZS);
+  DEF_OP(Vector_FToU);
+  DEF_OP(Vector_FToS);
   DEF_OP(Vector_FToF);
 
   ///< Flag ops
@@ -353,6 +357,8 @@ private:
   DEF_OP(Phi);
   DEF_OP(PhiValue);
   DEF_OP(Print);
+  DEF_OP(GetRoundingMode);
+  DEF_OP(SetRoundingMode);
 
   ///< Move ops
   DEF_OP(ExtractElementPair);

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -40,7 +40,13 @@
 
     "static constexpr FEXCore::IR::FenceType Fence_Load      {0}",
     "static constexpr FEXCore::IR::FenceType Fence_Store     {1}",
-    "static constexpr FEXCore::IR::FenceType Fence_LoadStore {2}"
+    "static constexpr FEXCore::IR::FenceType Fence_LoadStore {2}",
+
+    "constexpr static uint8_t ROUND_MODE_NEAREST           = 0",
+    "constexpr static uint8_t ROUND_MODE_NEGATIVE_INFINITY = 1",
+    "constexpr static uint8_t ROUND_MODE_POSITIVE_INFINITY = 2",
+    "constexpr static uint8_t ROUND_MODE_TOWARDS_ZERO      = 3",
+    "constexpr static uint8_t ROUND_MODE_FLUSH_TO_ZERO     = 1 << 2"
   ],
 
   "Ops": {
@@ -258,6 +264,28 @@
       ],
       "Args": [
         "uint8_t", "Size"
+      ]
+    },
+
+    "GetRoundingMode": {
+      "Desc": ["Gets the current rounding mode options"
+              ],
+      "OpClass": "Misc",
+      "HasDest": true,
+      "DestClass": "GPR",
+      "FixedDestSize": "4"
+    },
+
+    "SetRoundingMode": {
+      "Desc": ["Sets the current rounding mode options for the thread"
+              ],
+      "HasSideEffects": true,
+      "OpClass": "Misc",
+      "HasDest": false,
+      "DestClass": "GPR",
+      "SSAArgs": "1",
+      "SSANames": [
+        "RoundMode"
       ]
     },
 
@@ -1320,6 +1348,42 @@
       ],
       "Args": [
         "uint8_t", "Idx"
+      ]
+    },
+
+    "Float_ToGPR_U": {
+      "Desc": ["Moves the scalar element to a GPR with conversion",
+               "Converts the 32bit or 64bit float to an unsigned integer",
+               "Rounding mode determined by host flag's rounding mode"
+              ],
+      "OpClass": "ALU",
+      "HasDest": true,
+      "DestClass": "GPR",
+      "DestSize": "ElementSize",
+      "SSAArgs": "1",
+      "SSANames": [
+        "Scalar"
+      ],
+      "Args": [
+        "uint8_t", "ElementSize"
+      ]
+    },
+
+    "Float_ToGPR_S": {
+      "Desc": ["Moves the scalar element to a GPR with conversion",
+               "Converts the 32bit or 64bit float to an signed integer",
+               "Rounding mode determined by host flag's rounding mode"
+              ],
+      "OpClass": "ALU",
+      "HasDest": true,
+      "DestClass": "GPR",
+      "DestSize": "ElementSize",
+      "SSAArgs": "1",
+      "SSANames": [
+        "Scalar"
+      ],
+      "Args": [
+        "uint8_t", "ElementSize"
       ]
     },
 
@@ -2764,6 +2828,44 @@
     "Vector_SToF": {
       "OpClass": "Conv",
       "Desc": "Vector op: Converts signed integer to same size float",
+      "HasDest": true,
+      "DestClass": "FPR",
+      "DestSize": "RegisterSize",
+      "NumElements": "RegisterSize / ElementSize",
+      "SSAArgs": "1",
+      "SSANames": [
+        "Vector"
+      ],
+      "HelperArgs": [
+        "uint8_t", "RegisterSize",
+        "uint8_t", "ElementSize"
+      ]
+    },
+
+    "Vector_FToU": {
+      "OpClass": "Conv",
+      "Desc": ["Vector op: Converts float to unsigned integer",
+               "Rounding mode determined by host rounding mode"
+              ],
+      "HasDest": true,
+      "DestClass": "FPR",
+      "DestSize": "RegisterSize",
+      "NumElements": "RegisterSize / ElementSize",
+      "SSAArgs": "1",
+      "SSANames": [
+        "Vector"
+      ],
+      "HelperArgs": [
+        "uint8_t", "RegisterSize",
+        "uint8_t", "ElementSize"
+      ]
+    },
+
+    "Vector_FToS": {
+      "OpClass": "Conv",
+      "Desc": ["Vector op: Converts float to signed integer, rounding towards zero",
+               "Rounding mode determined by host rounding mode"
+              ],
       "HasDest": true,
       "DestClass": "FPR",
       "DestSize": "RegisterSize",


### PR DESCRIPTION
Interpreter might not be quite correct here (Could end up doing truncate or host flags depending on how it compiles)
But until we have the unit tests in place it's hard to ensure atm.