### PR TITLE
Implements MASKMOVQ and MASKMOVDQU

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -286,6 +286,7 @@ public:
   void Vector_CVT_Float_To_Int(OpcodeArgs);
   template<size_t SrcElementSize, bool Signed, bool Widen>
   void MMX_To_XMM_Vector_CVT_Int_To_Float(OpcodeArgs);
+  void MASKMOVOp(OpcodeArgs);
   void MOVBetweenGPR_FPR(OpcodeArgs);
   void TZCNT(OpcodeArgs);
   void MOVSSOp(OpcodeArgs);

--- a/External/FEXCore/Source/Interface/Core/X86Tables/SecondaryTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/SecondaryTables.cpp
@@ -238,7 +238,7 @@ void InitializeSecondaryTables() {
     {0xF4, 1, X86InstInfo{"PMULUDQ",  TYPE_INST, GenFlagsSameSize(SIZE_64BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS | FLAGS_SF_MMX,                                      0, nullptr}},
     {0xF5, 1, X86InstInfo{"PMADDWD",  TYPE_INST, GenFlagsSameSize(SIZE_64BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS | FLAGS_SF_MMX,                                      0, nullptr}},
     {0xF6, 1, X86InstInfo{"PSADBW",   TYPE_INST, GenFlagsSameSize(SIZE_64BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS | FLAGS_SF_MMX,                                      0, nullptr}},
-    {0xF7, 1, X86InstInfo{"MASKMOVQ", TYPE_MMX, GenFlagsSameSize(SIZE_64BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS | FLAGS_SF_MMX,                                       0, nullptr}},
+    {0xF7, 1, X86InstInfo{"MASKMOVQ", TYPE_INST, GenFlagsSameSize(SIZE_64BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS | FLAGS_SF_MMX,                                      0, nullptr}},
     {0xF8, 1, X86InstInfo{"PSUBB",    TYPE_INST, GenFlagsSameSize(SIZE_64BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS | FLAGS_SF_MMX,                                      0, nullptr}},
     {0xF9, 1, X86InstInfo{"PSUBW",    TYPE_INST, GenFlagsSameSize(SIZE_64BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS | FLAGS_SF_MMX,                                      0, nullptr}},
     {0xFA, 1, X86InstInfo{"PSUBD",    TYPE_INST, GenFlagsSameSize(SIZE_64BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS | FLAGS_SF_MMX,                                      0, nullptr}},

--- a/unittests/ASM/OpSize/66_F7.asm
+++ b/unittests/ASM/OpSize/66_F7.asm
@@ -1,0 +1,66 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x4142434445464748",
+    "RBX": "0x5152535455565758",
+    "RCX": "0x41424344FFFFFFFF",
+    "RSP": "0x51525354FFFFFFFF",
+    "RSI": "0xFFFFFFFFFFFFFFFF",
+    "RDI": "0xFFFFFFFFFFFFFFFF"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rdx + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [rdx + 8 * 1], rax
+
+mov rax, 0x8080808080808080
+mov [rdx + 8 * 2], rax
+mov [rdx + 8 * 3], rax
+
+mov rax, 0x8080808000000000
+mov [rdx + 8 * 4], rax
+mov [rdx + 8 * 5], rax
+
+mov rax, 0
+mov [rdx + 8 * 6], rax
+mov [rdx + 8 * 7], rax
+
+mov rax, -1
+mov [rdx + 8 * 8], rax
+mov [rdx + 8 * 9], rax
+
+mov [rdx + 8 * 10], rax
+mov [rdx + 8 * 11], rax
+
+mov [rdx + 8 * 12], rax
+mov [rdx + 8 * 13], rax
+
+movaps xmm0, [rdx + 8 * 0]
+movaps xmm1, [rdx + 8 * 2]
+movaps xmm2, [rdx + 8 * 4]
+movaps xmm3, [rdx + 8 * 6]
+
+lea rdi, [rdx + 8 * 8]
+maskmovdqu xmm0, xmm1
+
+lea rdi, [rdx + 8 * 10]
+maskmovdqu xmm0, xmm2
+
+lea rdi, [rdx + 8 * 12]
+maskmovdqu xmm0, xmm3
+
+mov rax, qword [rdx + 8 * 8]
+mov rbx, qword [rdx + 8 * 9]
+
+mov rcx, qword [rdx + 8 * 10]
+mov rsp, qword [rdx + 8 * 11]
+
+mov rsi, qword [rdx + 8 * 12]
+mov rdi, qword [rdx + 8 * 13]
+
+hlt

--- a/unittests/ASM/TwoByte/0F_F7.asm
+++ b/unittests/ASM/TwoByte/0F_F7.asm
@@ -1,0 +1,44 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x4142434445464748",
+    "RBX": "0x41424344FFFFFFFF",
+    "RCX": "0xFFFFFFFFFFFFFFFF"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rdx + 8 * 0], rax
+mov rax, 0x8080808080808080
+mov [rdx + 8 * 1], rax
+mov rax, 0x8080808000000000
+mov [rdx + 8 * 2], rax
+mov rax, 0
+mov [rdx + 8 * 3], rax
+mov rax, -1
+mov [rdx + 8 * 4], rax
+mov [rdx + 8 * 5], rax
+mov [rdx + 8 * 6], rax
+
+movq mm0, [rdx + 8 * 0]
+movq mm1, [rdx + 8 * 1]
+movq mm2, [rdx + 8 * 2]
+movq mm3, [rdx + 8 * 3]
+
+lea rdi, [rdx + 8 * 4]
+maskmovq mm0, mm1
+
+lea rdi, [rdx + 8 * 5]
+maskmovq mm0, mm2
+
+lea rdi, [rdx + 8 * 6]
+maskmovq mm0, mm3
+
+mov rax, qword [rdx + 8 * 4]
+mov rbx, qword [rdx + 8 * 5]
+mov rcx, qword [rdx + 8 * 6]
+
+hlt


### PR DESCRIPTION
Without supporting phis this entire loop needs to be unrolled.

I just found out while reading the x86 documentation that this
instruction is explicitly a weakly ordered memory operation.
So this operation can be changed over to a couple vector conditional
loadstores soon after merging