### PR TITLE
Implements MMX PMOVMSKB 

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -7700,6 +7700,7 @@ void InstallOpcodeHandlers(Context::OperatingMode Mode) {
     {0xD3, 1, &OpDispatchBuilder::PSRLDOp<8, true, 0>},
     {0xD4, 1, &OpDispatchBuilder::PADDQOp<8>},
     {0xD5, 1, &OpDispatchBuilder::PMULOp<2, true>},
+    {0xD7, 1, &OpDispatchBuilder::MOVMSKOp<1>}, // PMOVMSKB
     {0xD8, 1, &OpDispatchBuilder::PSUBSOp<1, false>},
     {0xD9, 1, &OpDispatchBuilder::PSUBSOp<2, false>},
     {0xDA, 1, &OpDispatchBuilder::PMINUOp<1>},

--- a/External/FEXCore/Source/Interface/Core/X86Tables/SecondaryTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/SecondaryTables.cpp
@@ -204,7 +204,7 @@ void InitializeSecondaryTables() {
     {0xD4, 1, X86InstInfo{"PADDQ",    TYPE_INST, GenFlagsSameSize(SIZE_64BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS | FLAGS_SF_MMX,                                      0, nullptr}},
     {0xD5, 1, X86InstInfo{"PMULLW",   TYPE_INST, GenFlagsSameSize(SIZE_64BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS | FLAGS_SF_MMX,                                      0, nullptr}},
     {0xD6, 1, X86InstInfo{"",         TYPE_INVALID, FLAGS_NONE,                                                                                         0, nullptr}},
-    {0xD7, 1, X86InstInfo{"PMOVMSKB", TYPE_INST, GenFlagsSameSize(SIZE_64BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS | FLAGS_SF_DST_GPR,                                  0, nullptr}},
+    {0xD7, 1, X86InstInfo{"PMOVMSKB", TYPE_INST, GenFlagsSizes(SIZE_32BIT, SIZE_64BIT) | FLAGS_MODRM | FLAGS_SF_MOD_REG_ONLY | FLAGS_XMM_FLAGS | FLAGS_SF_DST_GPR | FLAGS_SF_MMX_SRC,                                  0, nullptr}},
     {0xD8, 1, X86InstInfo{"PSUBUSB",  TYPE_INST, GenFlagsSameSize(SIZE_64BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS | FLAGS_SF_MMX,                                      0, nullptr}},
     {0xD9, 1, X86InstInfo{"PSUBUSW",  TYPE_INST, GenFlagsSameSize(SIZE_64BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS | FLAGS_SF_MMX,                                      0, nullptr}},
     {0xDA, 1, X86InstInfo{"PMINUB",   TYPE_INST, GenFlagsSameSize(SIZE_64BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS | FLAGS_SF_MMX,                                      0, nullptr}},

--- a/unittests/ASM/TwoByte/0F_D7.asm
+++ b/unittests/ASM/TwoByte/0F_D7.asm
@@ -1,0 +1,38 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0xFF",
+    "RBX": "0x00",
+    "RCX": "0x00",
+    "RDX": "0xF0"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x8080808080808080
+mov [rdx + 8 * 0], rax
+mov rax, 0x0000000000000000
+mov [rdx + 8 * 1], rax
+mov rax, 0x7070707070707070
+mov [rdx + 8 * 2], rax
+mov rax, 0x8080808000000000
+mov [rdx + 8 * 3], rax
+
+movq mm0, [rdx + 8 * 0]
+movq mm1, [rdx + 8 * 1]
+movq mm2, [rdx + 8 * 2]
+movq mm3, [rdx + 8 * 3]
+
+mov rax, -1
+mov rbx, -1
+mov rcx, -1
+mov rdx, -1
+
+pmovmskb eax, mm0
+pmovmskb ebx, mm1
+pmovmskb ecx, mm2
+pmovmskb edx, mm3
+
+hlt


### PR DESCRIPTION
Only pulls out 8 bits of data then zero extends the result to 32bits for the GPR