### PR TITLE
Ensures eflags matches real state

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -250,6 +250,7 @@ namespace FEXCore::Context {
     memset(NewThreadState.flags, 0, 32);
     NewThreadState.gs = 0;
     NewThreadState.flags[1] = 1;
+    NewThreadState.flags[9] = 1;
 
     FEXCore::Core::InternalThreadState *Thread = CreateThread(&NewThreadState, 0);
 

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -3431,12 +3431,18 @@ void OpDispatchBuilder::POPFOp(OpcodeArgs) {
 
   auto OldSP = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RSP]), GPRClass);
 
-  auto Src = _LoadMem(GPRClass, Size, OldSP, Size);
+  OrderedNode *Src = _LoadMem(GPRClass, Size, OldSP, Size);
 
   auto NewSP = _Add(OldSP, Constant);
 
   // Store the new stack pointer
   _StoreContext(GPRClass, GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RSP]), NewSP);
+
+  // Add back our flag constants
+  // Bit 1 is always 1
+  // Bit 9 is always 1 because we always have interrupts enabled
+
+  Src = _Or(Src, _Constant(Size * 8, 0x202));
 
   SetPackedRFLAG(false, Src);
 }

--- a/unittests/ASM/Primary/Primary_9C.asm
+++ b/unittests/ASM/Primary/Primary_9C.asm
@@ -1,8 +1,8 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "RAX": "0x2",
-    "RBX": "0x2"
+    "RAX": "0x202",
+    "RBX": "0x202"
   },
   "MemoryRegions": {
     "0x100000000": "4096"
@@ -11,6 +11,11 @@
 %endif
 
 mov rsp, 0xe0000010
+
+; Setup to default state
+mov rax, 0
+push rax
+popfq
 
 ; These pushes will end up being the default rflags initialization value
 pushfq

--- a/unittests/ASM/Primary/Primary_9D.asm
+++ b/unittests/ASM/Primary/Primary_9D.asm
@@ -1,8 +1,8 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "RAX": "0x2",
-    "RBX": "0x2"
+    "RAX": "0x202",
+    "RBX": "0x202"
   },
   "MemoryRegions": {
     "0x100000000": "4096"
@@ -13,6 +13,11 @@
 mov rax, 0x0
 mov rbx, 0x0
 mov rsp, 0xe0000010
+
+; Setup to default state
+mov rax, 0
+push rax
+popfq
 
 ; These pushes will end up being the default rflags initialization value
 pushfq


### PR DESCRIPTION
0x2 is the default state for hardware boot, but it isn't the state we
boot applications in.

When an application boots under Linux it is actually set to 0x202
because interrupts have been enabled.
Since we can't disable interrupts we will just always have at least
0x202 in the eflags.

This modifies the unit tests to first clear the full eflags state then
loads it so we hit "default". Once we hit the unit test runner we won't
have known the eflags state at that point, so we need to clear it
initially.