### PR TITLE
Implements OpDispatcher ops for host flag conversion ops

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -274,7 +274,7 @@ public:
   void MOVDDUPOp(OpcodeArgs);
   template<size_t DstElementSize, bool Signed>
   void CVTGPR_To_FPR(OpcodeArgs);
-  template<size_t SrcElementSize, bool Signed>
+  template<size_t SrcElementSize, bool Signed, bool HostRoundingMode>
   void CVTFPR_To_GPR(OpcodeArgs);
   template<size_t SrcElementSize, bool Signed, bool Widen>
   void Vector_CVT_Int_To_Float(OpcodeArgs);
@@ -282,7 +282,7 @@ public:
   void Scalar_CVT_Float_To_Float(OpcodeArgs);
   template<size_t DstElementSize, size_t SrcElementSize>
   void Vector_CVT_Float_To_Float(OpcodeArgs);
-  template<size_t SrcElementSize, bool Signed, bool Narrow>
+  template<size_t SrcElementSize, bool Signed, bool Narrow, bool HostRoundingMode>
   void Vector_CVT_Float_To_Int(OpcodeArgs);
   template<size_t SrcElementSize, bool Signed, bool Widen>
   void MMX_To_XMM_Vector_CVT_Int_To_Float(OpcodeArgs);

--- a/unittests/ASM/OpSize/66_5B.asm
+++ b/unittests/ASM/OpSize/66_5B.asm
@@ -27,6 +27,11 @@ mov [rdx + 8 * 4], rax
 mov rax, 0x5152535455565758
 mov [rdx + 8 * 5], rax
 
+; Set up MXCSR to truncate
+mov eax, 0x7F80
+mov [rdx + 8 * 6], eax
+ldmxcsr [rdx + 8 * 6]
+
 movapd xmm0, [rdx + 8 * 4]
 movapd xmm1, [rdx + 8 * 4]
 

--- a/unittests/ASM/REP/F3_2C.asm
+++ b/unittests/ASM/REP/F3_2C.asm
@@ -6,7 +6,7 @@
     "RCX": "0x3",
     "RDX": "0x4",
     "RBP": "0xFFFFFFFE",
-    "RSI": "0xFFFFFFFC"
+    "RSI": "0xFFFFFFFFFFFFFFFC"
   },
   "MemoryRegions": {
     "0x100000000": "4096"

--- a/unittests/ASM/REP/F3_2D.asm
+++ b/unittests/ASM/REP/F3_2D.asm
@@ -2,9 +2,9 @@
 {
   "RegData": {
     "RAX": "0x1",
-    "RBX": "0xFFFFFFFF",
+    "RBX": "0xFFFFFFFFFFFFFFFF",
     "RCX": "0xFFFFFFFE",
-    "RDX": "0xFFFFFFFC"
+    "RDX": "0xFFFFFFFFFFFFFFFC"
   },
   "MemoryRegions": {
     "0x100000000": "4096"


### PR DESCRIPTION
These rely on the host flag being correct. Which will match what is set
through the regular host flag setting routines

This needs to be rebased once #416 is merged