### PR TITLE
Implements ABM's LZCNT instruction

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -1195,6 +1195,47 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
             }
             break;
           }
+          case IR::OP_COUNTLEADINGZEROES: {
+            auto Op = IROp->C<IR::IROp_CountLeadingZeroes>();
+            switch (OpSize) {
+              case 1: {
+                uint32_t Src = *GetSrc<uint8_t*>(SSAData, Op->Header.Args[0]);
+                Src <<= 24;
+                if (Src)
+                  GD = __builtin_clz(Src);
+                else
+                  GD = 8;
+                break;
+              }
+              case 2: {
+                uint32_t Src = *GetSrc<uint16_t*>(SSAData, Op->Header.Args[0]);
+                Src <<= 16;
+                if (Src)
+                  GD = __builtin_clz(Src);
+                else
+                  GD = 16;
+                break;
+              }
+              case 4: {
+                auto Src = *GetSrc<uint32_t*>(SSAData, Op->Header.Args[0]);
+                if (Src)
+                  GD = __builtin_clz(Src);
+                else
+                  GD = sizeof(Src) * 8;
+                break;
+              }
+              case 8: {
+                auto Src = *GetSrc<uint64_t*>(SSAData, Op->Header.Args[0]);
+                if (Src)
+                  GD = __builtin_clzll(Src);
+                else
+                  GD = sizeof(Src) * 8;
+                break;
+              }
+              default: LogMan::Msg::A("Unknown size: %d", OpSize); break;
+            }
+            break;
+          }
           case IR::OP_BFI: {
             auto Op = IROp->C<IR::IROp_Bfi>();
             uint64_t SourceMask = (1ULL << Op->Width) - 1;

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -890,6 +890,25 @@ DEF_OP(FindTrailingZeros) {
   }
 }
 
+DEF_OP(CountLeadingZeroes) {
+  auto Op = IROp->C<IR::IROp_CountLeadingZeroes>();
+  uint8_t OpSize = IROp->Size;
+  switch (OpSize) {
+    case 2:
+      lsl(GetReg<RA_32>(Node), GetReg<RA_32>(Op->Header.Args[0].ID()), 16);
+      orr(GetReg<RA_32>(Node), GetReg<RA_32>(Node), 0x8000);
+      clz(GetReg<RA_32>(Node), GetReg<RA_32>(Node));
+    break;
+    case 4:
+      clz(GetReg<RA_32>(Node), GetReg<RA_32>(Op->Header.Args[0].ID()));
+      break;
+    case 8:
+      clz(GetReg<RA_64>(Node), GetReg<RA_64>(Op->Header.Args[0].ID()));
+      break;
+    default: LogMan::Msg::A("Unknown size: %d", OpSize); break;
+  }
+}
+
 DEF_OP(Rev) {
   auto Op = IROp->C<IR::IROp_Rev>();
   uint8_t OpSize = IROp->Size;
@@ -1118,6 +1137,7 @@ void JITCore::RegisterALUHandlers() {
   REGISTER_OP(FINDLSB,           FindLSB);
   REGISTER_OP(FINDMSB,           FindMSB);
   REGISTER_OP(FINDTRAILINGZEROS, FindTrailingZeros);
+  REGISTER_OP(COUNTLEADINGZEROES, CountLeadingZeroes);
   REGISTER_OP(REV,               Rev);
   REGISTER_OP(BFI,               Bfi);
   REGISTER_OP(BFE,               Bfe);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -272,6 +272,7 @@ private:
   DEF_OP(FindLSB);
   DEF_OP(FindMSB);
   DEF_OP(FindTrailingZeros);
+  DEF_OP(CountLeadingZeroes);
   DEF_OP(Rev);
   DEF_OP(Bfi);
   DEF_OP(Bfe);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -9,6 +9,8 @@
 #include "Common/MathUtils.h"
 
 #include <xbyak/xbyak.h>
+#include <xbyak/xbyak_util.h>
+
 using namespace Xbyak;
 
 #include <FEXCore/Core/CPUBackend.h>
@@ -74,6 +76,7 @@ private:
   FEXCore::Context::Context *CTX;
   FEXCore::Core::InternalThreadState *ThreadState;
   std::unordered_map<IR::OrderedNodeWrapper::NodeOffsetType, Label> JumpTargets;
+  Xbyak::util::Cpu Features{};
 
   bool MemoryDebug = false;
 

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -5996,6 +5996,22 @@ void OpDispatchBuilder::TZCNT(OpcodeArgs) {
   SetRFLAG<FEXCore::X86State::RFLAG_ZF_LOC>(_Bfe(1, 0, Src));
 }
 
+void OpDispatchBuilder::LZCNT(OpcodeArgs) {
+  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+
+  auto Res = _CountLeadingZeroes(Src);
+  StoreResult(GPRClass, Op, Res, -1);
+
+  auto Zero = _Constant(0);
+  auto ZFResult = _Select(FEXCore::IR::COND_EQ,
+      Src,  Zero,
+      _Constant(1), Zero);
+
+  // Set flags
+  SetRFLAG<FEXCore::X86State::RFLAG_CF_LOC>(ZFResult);
+  SetRFLAG<FEXCore::X86State::RFLAG_ZF_LOC>(_Bfe(1, GetSrcSize(Op) * 8 - 1, Src));
+}
+
 template<size_t ElementSize, bool Scalar>
 void OpDispatchBuilder::VFCMPOp(OpcodeArgs) {
   auto Size = GetSrcSize(Op);
@@ -7973,7 +7989,8 @@ void InstallOpcodeHandlers(Context::OperatingMode Mode) {
     {0x7E, 1, &OpDispatchBuilder::MOVQOp},
     {0x7F, 1, &OpDispatchBuilder::MOVUPSOp},
     {0xB8, 1, &OpDispatchBuilder::PopcountOp},
-    {0xBC, 2, &OpDispatchBuilder::TZCNT},
+    {0xBC, 1, &OpDispatchBuilder::TZCNT},
+    {0xBD, 1, &OpDispatchBuilder::LZCNT},
     {0xC2, 1, &OpDispatchBuilder::VFCMPOp<4, true>},
     {0xD6, 1, &OpDispatchBuilder::MOVQ2DQ<true>},
     {0xE6, 1, &OpDispatchBuilder::Vector_CVT_Int_To_Float<4, true, true>},

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -289,6 +289,7 @@ public:
   void MASKMOVOp(OpcodeArgs);
   void MOVBetweenGPR_FPR(OpcodeArgs);
   void TZCNT(OpcodeArgs);
+  void LZCNT(OpcodeArgs);
   void MOVSSOp(OpcodeArgs);
   template<size_t ElementSize, bool Scalar>
   void VFCMPOp(OpcodeArgs);

--- a/External/FEXCore/Source/Interface/Core/X86Tables/SecondaryTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/SecondaryTables.cpp
@@ -183,7 +183,7 @@ void InitializeSecondaryTables() {
     {0xBA, 1, X86InstInfo{"",        TYPE_GROUP_8, FLAGS_NONE,                                                                                      0, nullptr}},
     {0xBB, 1, X86InstInfo{"BTC",     TYPE_INST, FLAGS_DEBUG_MEM_ACCESS | FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_NO_OVERLAY,                         0, nullptr}},
     {0xBC, 1, X86InstInfo{"BSF",     TYPE_INST, FLAGS_MODRM | FLAGS_NO_OVERLAY66,                                                                   0, nullptr}},
-    {0xBD, 1, X86InstInfo{"BSR",     TYPE_INST, FLAGS_MODRM | FLAGS_NO_OVERLAY,                                                                     0, nullptr}},
+    {0xBD, 1, X86InstInfo{"BSR",     TYPE_INST, FLAGS_MODRM | FLAGS_NO_OVERLAY66,                                                                   0, nullptr}},
     {0xBE, 1, X86InstInfo{"MOVSX",   TYPE_INST, GenFlagsSrcSize(SIZE_8BIT) | FLAGS_MODRM | FLAGS_NO_OVERLAY,                                        0, nullptr}},
     {0xBF, 1, X86InstInfo{"MOVSX",   TYPE_INST, GenFlagsSrcSize(SIZE_16BIT) | FLAGS_MODRM | FLAGS_NO_OVERLAY,                                       0, nullptr}},
 

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -1012,6 +1012,17 @@
       "SSAArgs": "1"
     },
 
+    "CountLeadingZeroes": {
+      "Desc": ["Counts the number of leading zero bits in a GPR",
+               "Returns the number of bits that are zero leading",
+               "In the case of zero returns the size in bits of the input"
+              ],
+      "OpClass": "ALU",
+      "HasDest": true,
+      "DestClass": "GPR",
+      "SSAArgs": "1"
+    },
+
     "Rev": {
       "Desc": ["Reverses the byte order of the register",
                "Specifically 8bit byte swap size. (Not 16bit or 32bit word swapping)"

--- a/unittests/ASM/REP/F3_BD.asm
+++ b/unittests/ASM/REP/F3_BD.asm
@@ -1,0 +1,106 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0",
+    "RCX": "0x10",
+    "RDX": "0x20",
+    "RSI": "0x40",
+    "RDI": "0",
+    "RBP": "0",
+    "RSP": "0",
+    "R8":  "0x8",
+    "R9":  "0x10",
+    "R10": "0x20",
+    "R15": "0x2A540"
+  }
+}
+%endif
+
+; Uses AX and BX and stores result in r15
+; CF:ZF
+%macro zfcfmerge 0
+  lahf
+
+  ; Shift CF to zero
+  shr ax, 8
+
+  ; Move to a temp
+  mov bx, ax
+  and rbx, 1
+
+  shl r15, 1
+  or r15, rbx
+
+  shl r15, 1
+
+  ; Move to a temp
+  mov bx, ax
+
+  ; Extract ZF
+  shr bx, 6
+  and rbx, 1
+
+  ; Insert ZF
+  or r15, rbx
+%endmacro
+
+mov rax, 0x80000001
+cpuid
+
+shr ecx, 5
+and ecx, 1
+cmp ecx, 1
+je .continue
+
+; We don't support the instruction. Leave
+mov rax, 0xDEADBEEF41414141
+hlt
+
+.continue:
+
+mov rax, 0
+mov rbx, 0
+mov r15, 0
+
+; Test zeroes
+mov rcx, 0
+lzcnt cx, cx
+zfcfmerge
+
+mov rdx, 0
+lzcnt edx, edx
+zfcfmerge
+
+mov rsi, 0
+lzcnt rsi, rsi
+zfcfmerge
+
+; Test highest bit set to 1
+mov rdi, 0x8000
+lzcnt di, di
+zfcfmerge
+
+mov rbp, 0x80000000
+lzcnt ebp, ebp
+zfcfmerge
+
+mov rsp, 0x8000000000000000
+lzcnt rsp, rsp
+zfcfmerge
+
+; Test bit in the middle of the range
+mov r8, 0x0080
+lzcnt r8w, r8w
+zfcfmerge
+
+mov r9, 0x00008000
+lzcnt r9d, r9d
+zfcfmerge
+
+mov r10, 0x00000080000000
+lzcnt r10, r10
+zfcfmerge
+
+mov rax, 0
+
+hlt


### PR DESCRIPTION
This overlaps the previous BSR instruction which is why the table had to
be changed.

We were accidently claiming support for ABM in CPUID before so that
didn't need to be changed.

We now implement both LZCNT and POPCNT so we fully support ABM now.