### PR TITLE
Enables SSSE3 in CPUID

### DIFF
--- a/External/FEXCore/Source/Interface/Core/CPUID.cpp
+++ b/External/FEXCore/Source/Interface/Core/CPUID.cpp
@@ -48,7 +48,7 @@ CPUIDEmu::FunctionResults CPUIDEmu::Function_01h() {
     (0 <<  6) | // SMX
     (0 <<  7) | // Intel SpeedStep
     (0 <<  8) | // Thermal Monitor 2
-    (0 <<  9) | // SSSE3
+    (1 <<  9) | // SSSE3
     (0 << 10) | // L1 context ID
     (0 << 11) | // Silicon debug
     (0 << 12) | // FMA3


### PR DESCRIPTION
Needs #432, #433, #434, #435, and #436 enabled first.

Everything is implemented to enable SSSE3 support once those are merged.