### PR TITLE
Fixes 32bit SHLD and SHRD by zero

### DIFF
--- a/unittests/ASM/TwoByte/0F_A4_2.asm
+++ b/unittests/ASM/TwoByte/0F_A4_2.asm
@@ -10,16 +10,15 @@
 }
 %endif
 
-mov cl, 0
 mov r15, -1
 mov r14, 0x4141414141410000
 mov r13, 0
 mov r12, 0
 mov r11, -1
 
-shld r14w, r15w, cl
-shld r13d, r15d, cl
-shld r12, r15, cl
-shld r11d, r15d, cl
+shld r14w, r15w, 0
+shld r13d, r15d, 0
+shld r12, r15, 0
+shld r11d, r15d, 0
 
 hlt

--- a/unittests/ASM/TwoByte/0F_AC_2.asm
+++ b/unittests/ASM/TwoByte/0F_AC_2.asm
@@ -10,16 +10,15 @@
 }
 %endif
 
-mov cl, 0
 mov r15, -1
 mov r14, 0x4141414141410000
 mov r13, 0
 mov r12, 0
 mov r11, -1
 
-shld r14w, r15w, cl
-shld r13d, r15d, cl
-shld r12, r15, cl
-shld r11d, r15d, cl
+shrd r14w, r15w, 0
+shrd r13d, r15d, 0
+shrd r12, r15, 0
+shrd r11d, r15d, 0
 
 hlt

--- a/unittests/ASM/TwoByte/0F_AD_2.asm
+++ b/unittests/ASM/TwoByte/0F_AD_2.asm
@@ -4,7 +4,8 @@
     "R15": "0xFFFFFFFFFFFFFFFF",
     "R14": "0x4141414141410000",
     "R13": "0",
-    "R12": "0"
+    "R12": "0",
+    "R11": "0x00000000FFFFFFFF"
   }
 }
 %endif
@@ -14,9 +15,11 @@ mov r15, -1
 mov r14, 0x4141414141410000
 mov r13, 0
 mov r12, 0
+mov r11, -1
 
 shrd r14w, r15w, cl
 shrd r13d, r15d, cl
 shrd r12, r15, cl
+shrd r11d, r15d, cl
 
 hlt


### PR DESCRIPTION
Even though it doesn't update the flags, it still needs to zext the GPR in this instance.