### PR TITLE
Signed multiply fixes

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -1652,8 +1652,7 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
           case 4:
             movsxd(rax, GetSrc<RA_32>(Op->Header.Args[0].ID()));
             imul(GetSrc<RA_32>(Op->Header.Args[1].ID()));
-            movsxd(rax, edx);
-            mov(GetDst<RA_64>(Node), rdx);
+            movsxd(GetDst<RA_64>(Node).cvt64(), edx);
           break;
           case 8:
             mov(rax, GetSrc<RA_64>(Op->Header.Args[0].ID()));

--- a/unittests/ASM/PrimaryGroup/3_F6_05.asm
+++ b/unittests/ASM/PrimaryGroup/3_F6_05.asm
@@ -1,7 +1,8 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "RAX": "0x414243444546FF72"
+    "RAX": "0x414243444546FF72",
+    "RBX": "0xFFFFFFFFFFFF0001"
   },
   "MemoryRegions": {
     "0x100000000": "4096"
@@ -19,6 +20,12 @@ mov [rdx + 8 * 1], rax
 mov al, -2
 imul byte [rdx + 8 * 0 + 1]
 mov word [rdx + 8 * 0], ax
+
+; Ensure upper bits aren't cleared
+mov rax, 0xFFFFFFFFFFFFFF01
+mov rbx, 1
+imul bl
+mov rbx, rax
 
 mov rax, [rdx + 8 * 0]
 

--- a/unittests/ASM/PrimaryGroup/3_F7_05.asm
+++ b/unittests/ASM/PrimaryGroup/3_F7_05.asm
@@ -3,6 +3,8 @@
   "RegData": {
     "RAX": "0x41424344FFDC5C00",
     "RBX": "0xFFFFFFD554D45400",
+    "RCX": "0xFFFFFFFFFFFF0002",
+    "RDX": "0x0000000000000002",
     "RSI": "0x4ECE4DCD4CCC4C00",
     "RSP": "0xFFFFFFFFFFFFFFCF"
   },
@@ -35,6 +37,20 @@ mov rax, -128
 imul qword [r15 + 8 * 2 + 0]
 mov rsi, rax
 mov rsp, rdx
+
+; Ensure correct zext mechanics
+
+; 16bit - inserts
+mov rax, 0xFFFFFFFFFFFF0001
+mov rbx, 2
+imul bl
+mov rcx, rax
+
+; 32bit - Zexts to 64bit
+mov rax, 0xFFFFFFFF00000001
+mov rbx, 2
+imul ebx
+mov rdx, rax
 
 mov rax, [r15 + 8 * 0]
 mov rbx, [r15 + 8 * 1]

--- a/unittests/ASM/PrimaryGroup/3_F7_05_2.asm
+++ b/unittests/ASM/PrimaryGroup/3_F7_05_2.asm
@@ -1,0 +1,87 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "R15": "0"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+; Uses CX and BX and stores result in r15
+; OF:CF
+%macro ofcfmerge 0
+  lahf
+
+  ; Load OF
+  mov rbx, 0
+  seto bl
+
+  shl r15, 1
+  or r15, rbx
+  shl r15, 1
+
+  ; Insert CF
+  shr ax, 8
+  and rax, 1
+  or r15, rax
+%endmacro
+
+mov r8, 0xe0000000
+mov r15, 0
+
+mov rax, -1
+mov [r8 + 8 * 0], rax
+mov rax, -2
+mov [r8 + 8 * 1], rax
+mov rax, -3
+mov [r8 + 8 * 2], rax
+
+mov rax, 1
+mov [r8 + 8 * 3], rax
+mov rax, 2
+mov [r8 + 8 * 4], rax
+mov rax, 3
+mov [r8 + 8 * 5], rax
+
+; Negative * Negative
+mov ax, -128
+imul word [r8 + 8 * 0 + 0]
+ofcfmerge
+
+mov eax, -128
+imul dword [r8 + 8 * 1 + 0]
+ofcfmerge
+
+mov rax, -128
+imul qword [r8 + 8 * 2 + 0]
+ofcfmerge
+
+; Negative * Positive
+mov ax, -128
+imul word [r8 + 8 * 3 + 0]
+ofcfmerge
+
+mov eax, -128
+imul dword [r8 + 8 * 4 + 0]
+ofcfmerge
+
+mov rax, -128
+imul qword [r8 + 8 * 5 + 0]
+ofcfmerge
+
+; Positive * Positive
+mov ax, 128
+imul word [r8 + 8 * 3 + 0]
+ofcfmerge
+
+mov eax, 128
+imul dword [r8 + 8 * 4 + 0]
+ofcfmerge
+
+mov rax, 128
+imul qword [r8 + 8 * 5 + 0]
+ofcfmerge
+
+hlt

--- a/unittests/ASM/TwoByte/0F_AF_2.asm
+++ b/unittests/ASM/TwoByte/0F_AF_2.asm
@@ -1,0 +1,161 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "R15": "0x0000000000c00030"
+  }
+}
+%endif
+
+; Uses CX and BX and stores result in r15
+; OF:CF
+%macro ofcfmerge 0
+  lahf
+
+  ; Load OF
+  mov rbx, 0
+  seto bl
+
+  shl r15, 1
+  or r15, rbx
+  shl r15, 1
+
+  ; Insert CF
+  shr ax, 8
+  and rax, 1
+  or r15, rax
+%endmacro
+
+mov r8, 0xe0000000
+mov r15, 0
+
+; Positive * Positive
+mov rax, 128
+mov rbx, 32
+imul ax, bx
+ofcfmerge
+
+mov rax, 128
+mov rbx, 32
+imul eax, ebx
+ofcfmerge
+
+mov rax, 128
+mov rbx, 32
+imul rax, rbx
+ofcfmerge
+
+; Negative * Positive
+mov rax, -128
+mov rbx, 32
+imul ax, bx
+ofcfmerge
+
+mov rax, -128
+mov rbx, 32
+imul eax, ebx
+ofcfmerge
+
+mov rax, -128
+mov rbx, 32
+imul rax, rbx
+ofcfmerge
+
+; Positive * Negative
+mov rax, 128
+mov rbx, -32
+imul ax, bx
+ofcfmerge
+
+mov rax, 128
+mov rbx, -32
+imul eax, ebx
+ofcfmerge
+
+mov rax, 128
+mov rbx, -32
+imul rax, rbx
+ofcfmerge
+
+; Negative * Negative
+mov rax, -128
+mov rbx, -32
+imul ax, bx
+ofcfmerge
+
+mov rax, -128
+mov rbx, -32
+imul eax, ebx
+ofcfmerge
+
+mov rax, -128
+mov rbx, -32
+imul rax, rbx
+ofcfmerge
+
+; Positive * Positive Overflow
+mov rax, 128
+mov rbx, 256
+imul ax, bx
+ofcfmerge
+
+mov rax, 128
+mov rbx, 256
+imul eax, ebx
+ofcfmerge
+
+mov rax, 128
+mov rbx, 256
+imul rax, rbx
+ofcfmerge
+
+; Negative * Positive Overflow
+mov rax, -128
+mov rbx, 256
+imul ax, bx
+ofcfmerge
+
+mov rax, -128
+mov rbx, 256
+imul eax, ebx
+ofcfmerge
+
+mov rax, -128
+mov rbx, 256
+imul rax, rbx
+ofcfmerge
+
+; Positive * Negative Overflow
+mov rax, 128
+mov rbx, -256
+imul ax, bx
+ofcfmerge
+
+
+; XXX: Claiming this is an overflow
+mov rax, 128
+mov rbx, -256
+imul eax, ebx
+ofcfmerge
+
+mov rax, 128
+mov rbx, -256
+imul rax, rbx
+ofcfmerge
+
+; Negative * Negative Overflow
+mov rax, -128
+mov rbx, -256
+imul ax, bx
+ofcfmerge
+
+mov rax, -128
+mov rbx, -256
+imul eax, ebx
+ofcfmerge
+
+mov rax, -128
+mov rbx, -256
+imul rax, rbx
+ofcfmerge
+
+hlt


### PR DESCRIPTION
Flags calculation was wrong in these and for 32bit sext result we were storing the zext result instead of the sext result.