### PR TITLE
32bit and Segment register fixes

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -455,6 +455,8 @@ private:
   bool DecodeFailure{false};
   FEXCore::IR::IROp_IRHeader *Current_Header{};
 
+  OrderedNode *AppendSegmentOffset(OrderedNode *Value, uint32_t Flags, uint32_t DefaultPrefix = 0, bool Override = false);
+
   OrderedNode *LoadSource(FEXCore::IR::RegisterClassType Class, FEXCore::X86Tables::DecodedOp const& Op, FEXCore::X86Tables::DecodedOperand const& Operand, uint32_t Flags, int8_t Align, bool LoadData = true, bool ForceLoad = false);
   OrderedNode *LoadSource_WithOpSize(FEXCore::IR::RegisterClassType Class, FEXCore::X86Tables::DecodedOp const& Op, FEXCore::X86Tables::DecodedOperand const& Operand, uint8_t OpSize, uint32_t Flags, int8_t Align, bool LoadData = true, bool ForceLoad = false);
   void StoreResult_WithOpSize(FEXCore::IR::RegisterClassType Class, FEXCore::X86Tables::DecodedOp Op, FEXCore::X86Tables::DecodedOperand const& Operand, OrderedNode *const Src, uint8_t OpSize, int8_t Align);

--- a/External/FEXCore/Source/Interface/Core/X86Tables/BaseTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/BaseTables.cpp
@@ -149,9 +149,6 @@ void InitializeBaseTables(Context::OperatingMode Mode) {
     {0x9E, 1, X86InstInfo{"SAHF",   TYPE_INST, FLAGS_NONE,                              0, nullptr}},
     {0x9F, 1, X86InstInfo{"LAHF",   TYPE_INST, FLAGS_NONE,                              0, nullptr}},
 
-    {0xA0, 1, X86InstInfo{"MOV",    TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_SF_DST_RAX  | FLAGS_MEM_OFFSET,                                         1, nullptr}},
-    {0xA2, 1, X86InstInfo{"MOV",    TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_SF_SRC_RAX  | FLAGS_MEM_OFFSET,                                         1, nullptr}},
-
     {0xA4, 1, X86InstInfo{"MOVSB",  TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_MEM_OFFSET  | FLAGS_SUPPORTS_REP,                                            0, nullptr}},
     {0xA5, 1, X86InstInfo{"MOVS",   TYPE_INST, FLAGS_MEM_OFFSET | FLAGS_SUPPORTS_REP,                                                            0, nullptr}},
     {0xA6, 1, X86InstInfo{"CMPSB",  TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_MEM_OFFSET  | FLAGS_SUPPORTS_REP,                                            0, nullptr}},
@@ -244,6 +241,8 @@ void InitializeBaseTables(Context::OperatingMode Mode) {
   const U8U8InfoStruct BaseOpTable_64[] = {
     // REX
     {0x40, 16, X86InstInfo{"", TYPE_REX_PREFIX, FLAGS_NONE,        0, nullptr}},
+    {0xA0, 1, X86InstInfo{"MOV",    TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_SF_DST_RAX | FLAGS_DISPLACE_SIZE_DIV_2 | FLAGS_MEM_OFFSET, 8, nullptr}},
+    {0xA2, 1, X86InstInfo{"MOV",    TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_SF_SRC_RAX | FLAGS_DISPLACE_SIZE_DIV_2 | FLAGS_MEM_OFFSET, 8, nullptr}},
     {0xA1, 1, X86InstInfo{"MOV",    TYPE_INST, FLAGS_SF_DST_RAX | FLAGS_DISPLACE_SIZE_DIV_2 | FLAGS_MEM_OFFSET, 8, nullptr}},
     {0xA3, 1, X86InstInfo{"MOV",    TYPE_INST, FLAGS_SF_SRC_RAX | FLAGS_DISPLACE_SIZE_DIV_2 | FLAGS_MEM_OFFSET, 8, nullptr}},
 
@@ -252,6 +251,8 @@ void InitializeBaseTables(Context::OperatingMode Mode) {
   const U8U8InfoStruct BaseOpTable_32[] = {
     {0x40, 8, X86InstInfo{"INC", TYPE_INST, FLAGS_SF_REX_IN_BYTE,        0, nullptr}},
     {0x48, 8, X86InstInfo{"DEC", TYPE_INST, FLAGS_SF_REX_IN_BYTE,        0, nullptr}},
+    {0xA0, 1, X86InstInfo{"MOV",    TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_SF_DST_RAX | FLAGS_DISPLACE_SIZE_DIV_2 | FLAGS_MEM_OFFSET, 4, nullptr}},
+    {0xA2, 1, X86InstInfo{"MOV",    TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_SF_SRC_RAX | FLAGS_DISPLACE_SIZE_DIV_2 | FLAGS_MEM_OFFSET, 4, nullptr}},
     {0xA1, 1, X86InstInfo{"MOV",    TYPE_INST, FLAGS_SF_DST_RAX | FLAGS_DISPLACE_SIZE_DIV_2 | FLAGS_MEM_OFFSET, 4, nullptr}},
     {0xA3, 1, X86InstInfo{"MOV",    TYPE_INST, FLAGS_SF_SRC_RAX | FLAGS_DISPLACE_SIZE_DIV_2 | FLAGS_MEM_OFFSET, 4, nullptr}},
   };

--- a/External/FEXCore/include/FEXCore/Debug/X86Tables.h
+++ b/External/FEXCore/include/FEXCore/Debug/X86Tables.h
@@ -34,6 +34,8 @@ constexpr uint32_t FLAG_SS_PREFIX     = (1 << 13);
 constexpr uint32_t FLAG_DS_PREFIX     = (1 << 14);
 constexpr uint32_t FLAG_FS_PREFIX     = (1 << 15);
 constexpr uint32_t FLAG_GS_PREFIX     = (1 << 16);
+constexpr uint32_t FLAG_SEGMENTS      = (0b11'1111 << 11);
+
 constexpr uint32_t FLAG_REP_PREFIX    = (1 << 17);
 constexpr uint32_t FLAG_REPNE_PREFIX  = (1 << 18);
 // Size flags


### PR DESCRIPTION
Mostly centered around fixing segment register usage in 32bit.
Every instruction that uses segment registers now uses a helper routine to ensure segment registers are used.

Also some other minor 32bit fixes that should make life easier.