### PR TITLE
More 32bit fixes

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Frontend.cpp
+++ b/External/FEXCore/Source/Interface/Core/Frontend.cpp
@@ -477,7 +477,7 @@ bool Decoder::NormalOp(FEXCore::X86Tables::X86InstInfo const *Info, uint16_t Op)
   if (Bytes != 0) {
     LogMan::Throw::A(Bytes <= 8, "Number of bytes should be <= 8 for literal src");
 
-    DecodeInst->Src[CurrentSrc].TypeLiteral.Size = DestSize;
+    DecodeInst->Src[CurrentSrc].TypeLiteral.Size = Bytes;
 
     uint64_t Literal {0};
     Literal = ReadData(Bytes);
@@ -493,6 +493,7 @@ bool Decoder::NormalOp(FEXCore::X86Tables::X86InstInfo const *Info, uint16_t Op)
       else {
         Literal = static_cast<int32_t>(Literal);
       }
+      DecodeInst->Src[CurrentSrc].TypeLiteral.Size = DestSize;
     }
 
     Bytes = 0;

--- a/External/FEXCore/Source/Interface/Core/Frontend.cpp
+++ b/External/FEXCore/Source/Interface/Core/Frontend.cpp
@@ -365,12 +365,13 @@ bool Decoder::NormalOp(FEXCore::X86Tables::X86InstInfo const *Info, uint16_t Op)
   if ((Info->Flags & FEXCore::X86Tables::InstFlags::FLAGS_DISPLACE_SIZE_MUL_2) && HasWideningDisplacement) {
     Bytes <<= 1;
   }
-  if ((Info->Flags & FEXCore::X86Tables::InstFlags::FLAGS_DISPLACE_SIZE_DIV_2) &&
-      (Info->Flags & FEXCore::X86Tables::InstFlags::FLAGS_MEM_OFFSET) &&
-      (DecodeInst->Flags & DecodeFlags::FLAG_ADDRESS_SIZE)) {
+  if ((Info->Flags & FEXCore::X86Tables::InstFlags::FLAGS_DISPLACE_SIZE_DIV_2) && HasNarrowingDisplacement) {
     Bytes >>= 1;
   }
-  else if ((Info->Flags & FEXCore::X86Tables::InstFlags::FLAGS_DISPLACE_SIZE_DIV_2) && HasNarrowingDisplacement) {
+
+  if ((Info->Flags & FEXCore::X86Tables::InstFlags::FLAGS_MEM_OFFSET) &&
+      (DecodeInst->Flags & DecodeFlags::FLAG_ADDRESS_SIZE)) {
+    // If we have a memory offset and have the address size override then divide it just like narrowing displacement
     Bytes >>= 1;
   }
 

--- a/External/FEXCore/Source/Interface/Core/Frontend.cpp
+++ b/External/FEXCore/Source/Interface/Core/Frontend.cpp
@@ -424,7 +424,7 @@ bool Decoder::NormalOp(FEXCore::X86Tables::X86InstInfo const *Info, uint16_t Op)
           Bytes -= 4;
 
           NonGPR.TypeRIPLiteral.Type = DecodedOperand::TYPE_RIP_RELATIVE;
-          NonGPR.TypeRIPLiteral.Literal = Literal;
+          NonGPR.TypeRIPLiteral.Literal.u = Literal;
         }
         else {
           // Register-direct addressing

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -4505,11 +4505,11 @@ OrderedNode *OpDispatchBuilder::LoadSource_WithOpSize(FEXCore::IR::RegisterClass
   }
   else if (Operand.TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_RIP_RELATIVE) {
     if (CTX->Config.Is64BitMode) {
-      Src = _Constant(GPRSize * 8, Operand.TypeRIPLiteral.Literal + Op->PC + Op->InstSize);
+      Src = _Constant(GPRSize * 8, Operand.TypeRIPLiteral.Literal.s + Op->PC + Op->InstSize);
     }
     else {
       // 32bit this isn't RIP relative but instead absolute
-      Src = _Constant(GPRSize * 8, Operand.TypeRIPLiteral.Literal);
+      Src = _Constant(GPRSize * 8, Operand.TypeRIPLiteral.Literal.u);
     }
 
     LoadableType = true;
@@ -4637,11 +4637,11 @@ void OpDispatchBuilder::StoreResult_WithOpSize(FEXCore::IR::RegisterClassType Cl
   }
   else if (Operand.TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_RIP_RELATIVE) {
     if (CTX->Config.Is64BitMode) {
-      MemStoreDst = _Constant(GPRSize * 8, Operand.TypeRIPLiteral.Literal + Op->PC + Op->InstSize);
+      MemStoreDst = _Constant(GPRSize * 8, Operand.TypeRIPLiteral.Literal.s + Op->PC + Op->InstSize);
     }
     else {
       // 32bit this isn't RIP relative but instead absolute
-      MemStoreDst = _Constant(GPRSize * 8, Operand.TypeRIPLiteral.Literal);
+      MemStoreDst = _Constant(GPRSize * 8, Operand.TypeRIPLiteral.Literal.u);
     }
     MemStore = true;
   }

--- a/External/FEXCore/Source/Interface/Core/X86Tables/BaseTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/BaseTables.cpp
@@ -149,10 +149,10 @@ void InitializeBaseTables(Context::OperatingMode Mode) {
     {0x9E, 1, X86InstInfo{"SAHF",   TYPE_INST, FLAGS_NONE,                              0, nullptr}},
     {0x9F, 1, X86InstInfo{"LAHF",   TYPE_INST, FLAGS_NONE,                              0, nullptr}},
 
-    {0xA4, 1, X86InstInfo{"MOVSB",  TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_MEM_OFFSET  | FLAGS_SUPPORTS_REP,                                            0, nullptr}},
-    {0xA5, 1, X86InstInfo{"MOVS",   TYPE_INST, FLAGS_MEM_OFFSET | FLAGS_SUPPORTS_REP,                                                            0, nullptr}},
-    {0xA6, 1, X86InstInfo{"CMPSB",  TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_MEM_OFFSET  | FLAGS_SUPPORTS_REP,                                            0, nullptr}},
-    {0xA7, 1, X86InstInfo{"CMPS",   TYPE_INST, FLAGS_MEM_OFFSET | FLAGS_SUPPORTS_REP,                                                            0, nullptr}},
+    {0xA4, 1, X86InstInfo{"MOVSB",  TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_SUPPORTS_REP,                                            0, nullptr}},
+    {0xA5, 1, X86InstInfo{"MOVS",   TYPE_INST, FLAGS_SUPPORTS_REP,                                                            0, nullptr}},
+    {0xA6, 1, X86InstInfo{"CMPSB",  TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_SUPPORTS_REP,                                            0, nullptr}},
+    {0xA7, 1, X86InstInfo{"CMPS",   TYPE_INST, FLAGS_SUPPORTS_REP,                                                            0, nullptr}},
 
     {0xA8, 1, X86InstInfo{"TEST",   TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_SF_DST_RAX ,                                             1, nullptr}},
     {0xA9, 1, X86InstInfo{"TEST",   TYPE_INST, FLAGS_SF_DST_RAX | FLAGS_SRC_SEXT | FLAGS_DISPLACE_SIZE_DIV_2,                4, nullptr}},
@@ -241,20 +241,20 @@ void InitializeBaseTables(Context::OperatingMode Mode) {
   const U8U8InfoStruct BaseOpTable_64[] = {
     // REX
     {0x40, 16, X86InstInfo{"", TYPE_REX_PREFIX, FLAGS_NONE,        0, nullptr}},
-    {0xA0, 1, X86InstInfo{"MOV",    TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_SF_DST_RAX | FLAGS_DISPLACE_SIZE_DIV_2 | FLAGS_MEM_OFFSET, 8, nullptr}},
-    {0xA2, 1, X86InstInfo{"MOV",    TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_SF_SRC_RAX | FLAGS_DISPLACE_SIZE_DIV_2 | FLAGS_MEM_OFFSET, 8, nullptr}},
-    {0xA1, 1, X86InstInfo{"MOV",    TYPE_INST, FLAGS_SF_DST_RAX | FLAGS_DISPLACE_SIZE_DIV_2 | FLAGS_MEM_OFFSET, 8, nullptr}},
-    {0xA3, 1, X86InstInfo{"MOV",    TYPE_INST, FLAGS_SF_SRC_RAX | FLAGS_DISPLACE_SIZE_DIV_2 | FLAGS_MEM_OFFSET, 8, nullptr}},
+    {0xA0, 1, X86InstInfo{"MOV",    TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_SF_DST_RAX | FLAGS_MEM_OFFSET, 8, nullptr}},
+    {0xA2, 1, X86InstInfo{"MOV",    TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_SF_SRC_RAX | FLAGS_MEM_OFFSET, 8, nullptr}},
+    {0xA1, 1, X86InstInfo{"MOV",    TYPE_INST, FLAGS_SF_DST_RAX | FLAGS_MEM_OFFSET, 8, nullptr}},
+    {0xA3, 1, X86InstInfo{"MOV",    TYPE_INST, FLAGS_SF_SRC_RAX | FLAGS_MEM_OFFSET, 8, nullptr}},
 
   };
 
   const U8U8InfoStruct BaseOpTable_32[] = {
     {0x40, 8, X86InstInfo{"INC", TYPE_INST, FLAGS_SF_REX_IN_BYTE,        0, nullptr}},
     {0x48, 8, X86InstInfo{"DEC", TYPE_INST, FLAGS_SF_REX_IN_BYTE,        0, nullptr}},
-    {0xA0, 1, X86InstInfo{"MOV",    TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_SF_DST_RAX | FLAGS_DISPLACE_SIZE_DIV_2 | FLAGS_MEM_OFFSET, 4, nullptr}},
-    {0xA2, 1, X86InstInfo{"MOV",    TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_SF_SRC_RAX | FLAGS_DISPLACE_SIZE_DIV_2 | FLAGS_MEM_OFFSET, 4, nullptr}},
-    {0xA1, 1, X86InstInfo{"MOV",    TYPE_INST, FLAGS_SF_DST_RAX | FLAGS_DISPLACE_SIZE_DIV_2 | FLAGS_MEM_OFFSET, 4, nullptr}},
-    {0xA3, 1, X86InstInfo{"MOV",    TYPE_INST, FLAGS_SF_SRC_RAX | FLAGS_DISPLACE_SIZE_DIV_2 | FLAGS_MEM_OFFSET, 4, nullptr}},
+    {0xA0, 1, X86InstInfo{"MOV",    TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_SF_DST_RAX | FLAGS_MEM_OFFSET, 4, nullptr}},
+    {0xA2, 1, X86InstInfo{"MOV",    TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_SF_SRC_RAX | FLAGS_MEM_OFFSET, 4, nullptr}},
+    {0xA1, 1, X86InstInfo{"MOV",    TYPE_INST, FLAGS_SF_DST_RAX | FLAGS_MEM_OFFSET, 4, nullptr}},
+    {0xA3, 1, X86InstInfo{"MOV",    TYPE_INST, FLAGS_SF_SRC_RAX | FLAGS_MEM_OFFSET, 4, nullptr}},
   };
 
   GenerateTable(BaseOps, BaseOpTable, sizeof(BaseOpTable) / sizeof(BaseOpTable[0]));

--- a/External/FEXCore/include/FEXCore/Debug/X86Tables.h
+++ b/External/FEXCore/include/FEXCore/Debug/X86Tables.h
@@ -128,7 +128,10 @@ union DecodedOperand {
 
   struct {
     uint8_t Type;
-    int32_t Literal;
+    union {
+      int32_t s;
+      uint32_t u;
+    } Literal;
   } TypeRIPLiteral;
 
   struct {

--- a/Source/Tests/HarnessHelpers.h
+++ b/Source/Tests/HarnessHelpers.h
@@ -389,7 +389,7 @@ namespace FEX::HarnessHelper {
 
       // Map in the memory region for the test file
       size_t Length = AlignUp(RawFile.size(), PAGE_SIZE);
-      Code_start_page = reinterpret_cast<uint64_t>(Mapper(Code_start_page, Length, true, true));
+      Code_start_page = reinterpret_cast<uint64_t>(Mapper(Code_start_page, Length, true, false));
       mprotect(reinterpret_cast<void*>(Code_start_page), Length, PROT_READ | PROT_WRITE | PROT_EXEC);
       RIP = Code_start_page;
 
@@ -418,7 +418,7 @@ namespace FEX::HarnessHelper {
   private:
     constexpr static uint64_t STACK_SIZE = PAGE_SIZE;
     // Zero is special case to know when we are done
-    uint64_t Code_start_page = 0x0'1000;
+    uint64_t Code_start_page = 0x1'0000;
     uint64_t RIP {};
     uint64_t MemoryBase{};
 

--- a/unittests/32Bit_ASM/CMakeLists.txt
+++ b/unittests/32Bit_ASM/CMakeLists.txt
@@ -23,7 +23,7 @@ foreach(ASM_SRC ${ASM_SOURCES})
     DEPENDS "${OUTPUT_ASM_FOLDER}"
     DEPENDS "${ASM_SRC}"
     COMMAND "cp" ARGS "${ASM_SRC}" "${TMP_FILE}"
-    COMMAND "sed" ARGS "-i" "-e" "\'1s;^;BITS 32\\n;\'" "-e" "\'\$\$a\\ret\\n\'" "${TMP_FILE}"
+    COMMAND "sed" ARGS "-i" "-e" "\'1s;^;BITS 32\\norg 10000h\\n;\'" "-e" "\'\$\$a\\ret\\n\'" "${TMP_FILE}"
     )
 
   set(OUTPUT_NAME "${OUTPUT_ASM_FOLDER}/${ASM_NAME}.bin")

--- a/unittests/32Bit_ASM/Primary/Primary_A0.asm
+++ b/unittests/32Bit_ASM/Primary/Primary_A0.asm
@@ -1,0 +1,37 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RCX": "0xFFFF0042",
+    "RDX": "0x42"
+  },
+  "Mode": "32BIT"
+}
+%endif
+
+mov edx, 0xe0000000
+mov eax, 0x42
+mov [edx], eax
+
+mov eax, -1
+; mov eax, [0xe0000000]
+db 0xA1
+dd 0xe0000000
+mov edx, eax
+
+mov eax, -1
+; mov ax, [0xe0000000]
+db 0x66
+db 0xA1
+dd 0xe0000000
+mov ecx, eax
+
+; We can't actually test this one since we can't allocate memory in the lower 16bits
+;mov eax, -1
+;; mov ax, [0xe00]
+;db 0x67
+;db 0x66
+;db 0xA1
+;dw 0xe00
+;mov ebx, eax
+
+hlt

--- a/unittests/32Bit_ASM/Primary/Primary_A2.asm
+++ b/unittests/32Bit_ASM/Primary/Primary_A2.asm
@@ -1,0 +1,39 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RCX": "0x43",
+    "RDX": "0x42"
+  },
+  "Mode": "32BIT"
+}
+%endif
+
+mov eax, 0x42
+; mov [0xe0000000], eax
+db 0xA3
+dd 0xe0000000
+
+mov edx, 0xe0000000
+mov edx, [edx]
+
+mov eax, 0xFFFF0043
+; mov [0xe0000000], ax
+db 0x66
+db 0xA3
+dd 0xe0000000
+
+mov ecx, 0xe0000000
+mov ecx, [ecx]
+
+; We can't actually test this one since we can't allocate memory in the lower 16bits
+;mov eax, 0xFFFF0044
+;; mov [0xe000], ax
+;db 0x57
+;db 0x66
+;db 0xA3
+;dw 0xe000
+;
+;mov ebx, 0xe000
+;mov ebx, [ebx]
+
+hlt

--- a/unittests/32Bit_ASM/PrimaryGroup/5_FF_02.asm
+++ b/unittests/32Bit_ASM/PrimaryGroup/5_FF_02.asm
@@ -1,0 +1,35 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x41424344"
+  },
+  "Mode": "32BIT"
+}
+%endif
+
+mov edi, 0xe0000000
+lea esp, [edi + 8 * 4]
+
+mov eax, 0x41424344
+mov [edi + 8 * 0], eax
+mov eax, 0x51525354
+mov [edi + 8 * 1], eax
+
+lea ebx, [rel .call_tgt]
+mov [edi + 8 * 2], ebx
+
+mov eax, 0
+call dword [edi + 8 * 2]
+jmp .end
+
+.call_tgt:
+mov eax, [edi + 8 * 0]
+ret
+
+; Couple things that could catch failure
+mov eax, 0
+jmp .end
+mov eax, 0
+
+.end:
+hlt

--- a/unittests/32Bit_ASM/PrimaryGroup/5_FF_02_2.asm
+++ b/unittests/32Bit_ASM/PrimaryGroup/5_FF_02_2.asm
@@ -1,0 +1,37 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x41424344"
+  },
+  "Mode": "32BIT"
+}
+%endif
+
+mov edi, 0xe0000000
+lea esp, [edi + 8 * 4]
+
+mov eax, 0x41424344
+mov [edi + 8 * 0], eax
+mov eax, 0x51525354
+mov [edi + 8 * 1], eax
+
+mov eax, 0
+db 0xFF
+db 0x15
+dd .jmp_data
+jmp .end
+
+.call_tgt:
+mov eax, [edi + 8 * 0]
+ret
+
+; Couple things that could catch failure
+mov eax, 0
+jmp .end
+mov eax, 0
+
+.end:
+hlt
+
+.jmp_data:
+dd .call_tgt

--- a/unittests/32Bit_ASM/PrimaryGroup/5_FF_02_3.asm
+++ b/unittests/32Bit_ASM/PrimaryGroup/5_FF_02_3.asm
@@ -1,0 +1,39 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x41424344"
+  },
+  "MemoryRegions": {
+    "0x80000000": "4096"
+  },
+  "Mode": "32BIT"
+}
+%endif
+
+mov edi, 0xe0000000
+lea esp, [edi + 8 * 4]
+
+; Before we do anything, copy the code to an address that can be zexted
+mov eax, dword [.inst_data]
+mov [0x80000000], eax
+mov eax, dword [.inst_data2]
+mov [0x80000004], eax
+
+mov eax, 0x41424344
+mov [edi + 8 * 0], eax
+mov eax, 0x51525354
+mov [edi + 8 * 1], eax
+
+mov eax, 0
+db 0xFF
+db 0x15
+dd 0x80000004
+hlt
+
+.inst_data:
+; mov eax, dword [edi]
+; retn
+db `\x8B\x07\xC3`
+db 0
+.inst_data2:
+dd 0x80000000


### PR DESCRIPTION
Fixes an issue where unit test loader would load a test in to high 64bits memory space.
Fixes "RIP Literal" needing to be treated as unsigned rather than signed
Fixes MEM_OFFSET instructions having their offset modified by operand size override, when it should have been modified by address size override.
Adds some 32bit unit tests to verify these.