### PR TITLE
IR/JIT: Inline constants

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -537,7 +537,7 @@ namespace FEXCore::Context {
     Thread->PassManager->RegisterExitHandler([this]() {
         Stop(false /* Ignore current thread */);
     });
-    Thread->PassManager->AddDefaultPasses();
+    Thread->PassManager->AddDefaultPasses(Config.Core == FEXCore::Config::CONFIG_IRJIT);
     Thread->PassManager->AddDefaultValidationPasses();
     Thread->PassManager->RegisterSyscallHandler(SyscallHandler.get());
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -103,6 +103,7 @@ public:
 private:
   FEXCore::Context::Context *CTX;
   FEXCore::Core::InternalThreadState *State;
+  FEXCore::IR::IRListView<true> const *IR;
 
   std::map<IR::OrderedNodeWrapper::NodeOffsetType, aarch64::Label> JumpTargets;
 
@@ -145,6 +146,8 @@ private:
 
   aarch64::VRegister GetSrc(uint32_t Node);
   aarch64::VRegister GetDst(uint32_t Node);
+
+  bool IsInlineConstant(const IR::OrderedNodeWrapper& Node, uint64_t* Value = nullptr);
 
   struct LiveRange {
     uint32_t Begin;
@@ -241,6 +244,7 @@ private:
   ///< ALU Ops
   DEF_OP(TruncElementPair);
   DEF_OP(Constant);
+  DEF_OP(InlineConstant);
   DEF_OP(CycleCounter);
   DEF_OP(Add);
   DEF_OP(Sub);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -73,6 +73,8 @@ public:
 private:
   FEXCore::Context::Context *CTX;
   FEXCore::Core::InternalThreadState *ThreadState;
+  FEXCore::IR::IRListView<true> const *IR;
+
   std::unordered_map<IR::OrderedNodeWrapper::NodeOffsetType, Label> JumpTargets;
   Xbyak::util::Cpu Features{};
 
@@ -111,6 +113,8 @@ private:
 
   Xbyak::Xmm GetSrc(uint32_t Node);
   Xbyak::Xmm GetDst(uint32_t Node);
+
+  bool IsInlineConstant(const IR::OrderedNodeWrapper& Node, uint64_t* Value = nullptr);
 
   void CreateCustomDispatch(FEXCore::Core::InternalThreadState *Thread);
   IR::RegisterAllocationPass *RAPass;
@@ -180,6 +184,7 @@ private:
   ///< ALU Ops
   DEF_OP(TruncElementPair);
   DEF_OP(Constant);
+  DEF_OP(InlineConstant);
   DEF_OP(CycleCounter);
   DEF_OP(Add);
   DEF_OP(Sub);

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -302,6 +302,14 @@
       ]
     },
 
+    "InlineConstant": {
+      "Desc": ["Generates a 64bit constant to be used directly, non-FPR"],
+      "OpClass": "ALU",
+      "Args": [
+        "uint64_t", "Constant"
+      ]
+    },
+
     "VectorZero": {
       "Desc": ["Generates a vector zero",
                "Useful to generate a zero vector without any previous dependencies"

--- a/External/FEXCore/Source/Interface/IR/PassManager.cpp
+++ b/External/FEXCore/Source/Interface/IR/PassManager.cpp
@@ -4,9 +4,9 @@
 
 namespace FEXCore::IR {
 
-void PassManager::AddDefaultPasses() {
+void PassManager::AddDefaultPasses(bool InlineConstants) {
   InsertPass(CreateContextLoadStoreElimination());
-  InsertPass(CreateConstProp());
+  InsertPass(CreateConstProp(InlineConstants));
   ////// InsertPass(CreateDeadFlagCalculationEliminination());
   InsertPass(CreateDeadFlagStoreElimination());
   InsertPass(CreateSyscallOptimization());

--- a/External/FEXCore/Source/Interface/IR/PassManager.h
+++ b/External/FEXCore/Source/Interface/IR/PassManager.h
@@ -33,7 +33,7 @@ protected:
 class PassManager final {
   friend class SyscallOptimization;
 public:
-  void AddDefaultPasses();
+  void AddDefaultPasses(bool InlineConstants);
   void AddDefaultValidationPasses();
   void InsertPass(Pass *Pass) {
     Pass->RegisterPassManager(this);

--- a/External/FEXCore/Source/Interface/IR/Passes.h
+++ b/External/FEXCore/Source/Interface/IR/Passes.h
@@ -4,7 +4,7 @@ namespace FEXCore::IR {
 class Pass;
 class RegisterAllocationPass;
 
-FEXCore::IR::Pass* CreateConstProp();
+FEXCore::IR::Pass* CreateConstProp(bool InlineConstants);
 FEXCore::IR::Pass* CreateContextLoadStoreElimination();
 FEXCore::IR::Pass* CreateSyscallOptimization();
 FEXCore::IR::Pass* CreateDeadFlagCalculationEliminination();

--- a/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -390,6 +390,7 @@ namespace FEXCore::IR {
         uint8_t NumArgs = IR::GetArgs(IROp->Op);
         for (uint8_t i = 0; i < NumArgs; ++i) {
           if (IROp->Args[i].IsInvalid()) continue;
+          if (IR->GetOp<IROp_Header>(IROp->Args[i])->Op == OP_INLINECONSTANT) continue;
           uint32_t ArgNode = IROp->Args[i].ID();
           // Set the node end to be at least here
           LiveRanges[ArgNode].End = Node;

--- a/External/FEXCore/include/FEXCore/IR/IREmitter.h
+++ b/External/FEXCore/include/FEXCore/IR/IREmitter.h
@@ -421,6 +421,15 @@ friend class FEXCore::IR::PassManager;
      return false;
   }
 
+  bool IsValueInlineConstant(OrderedNodeWrapper ssa) {
+     OrderedNode *RealNode = ssa.GetNode(ListData.Begin());
+     FEXCore::IR::IROp_Header *IROp = RealNode->Op(Data.Begin());
+     if (IROp->Op == OP_INLINECONSTANT) {
+       return true;
+     }
+     return false;
+  }
+
   // Overwrite a node with a constant
   // Depending on what node has been overwritten, there might be some unallocated space around the node
   // Because we are overwriting the node, we don't have to worry about update all the arguments which use it


### PR DESCRIPTION
Based on @phire's idea, Inline constants are constants that can be used as imms in instructions.

This
- Adds OP_INLINECONSTANT to represent them in the IR
- Modifies the ConstProp pass to transform OP_CONSTANT to OP_INLINECONSTANT based on per-platform heuristics
- Modifies RA to ignore OP_INLINECONSTANT uses
- Modifies the backends to use imms
- Supported opcodes: Add, Sub, Lsl, Lsr, Asr, Ror, Rol