### PR TITLE
Complex address generation for Load/StoreMem

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -253,7 +253,6 @@ namespace FEXCore::Context {
     NewThreadState.flags[9] = 1;
 
     FEXCore::Core::InternalThreadState *Thread = CreateThread(&NewThreadState, 0);
-
     if (Is64Bit) {
       // Set up all of our memory mappings
       NewThreadState.fs = reinterpret_cast<uint64_t>(MapRegion(Thread, FS_OFFSET, FS_SIZE, true, false));

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -902,15 +902,15 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
             auto Op = IROp->C<IR::IROp_LoadMem>();
             uint8_t const *Data{};
             if (Thread->CTX->Config.UnifiedMemory) {
-              Data = *GetSrc<uint8_t const**>(SSAData, Op->Header.Args[0]);
+              Data = *GetSrc<uint8_t const**>(SSAData, Op->Addr);
             }
             else {
-              Data = Thread->CTX->MemoryMapper.GetPointer<uint8_t const*>(*GetSrc<uint64_t*>(SSAData, Op->Header.Args[0]));
-              LogMan::Throw::A(Data != nullptr, "Couldn't Map pointer to 0x%lx\n", *GetSrc<uint64_t*>(SSAData, Op->Header.Args[0]));
+              Data = Thread->CTX->MemoryMapper.GetPointer<uint8_t const*>(*GetSrc<uint64_t*>(SSAData, Op->Addr));
+              LogMan::Throw::A(Data != nullptr, "Couldn't Map pointer to 0x%lx\n", *GetSrc<uint64_t*>(SSAData, Op->Addr));
             }
 
-            if (!Op->Header.Args[2].IsInvalid()) {
-              auto Offset = *GetSrc<uintptr_t const*>(SSAData, Op->Header.Args[1]) * Op->OffsetScale;
+            if (!Op->Offset.IsInvalid()) {
+              auto Offset = *GetSrc<uintptr_t const*>(SSAData, Op->Offset) * Op->OffsetScale;
 
               switch(Op->OffsetType) {
                 case MEM_OFFSET_SXTX: Data +=  Offset; break;
@@ -944,14 +944,14 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
               case x: { \
                 uint8_t *Data{}; \
                 if (Thread->CTX->Config.UnifiedMemory) { \
-                  Data = *GetSrc<uint8_t**>(SSAData, Op->Header.Args[0]); \
+                  Data = *GetSrc<uint8_t**>(SSAData, Op->Addr); \
                 } \
                 else { \
-                  Data = Thread->CTX->MemoryMapper.GetPointer<uint8_t*>(*GetSrc<uint64_t*>(SSAData, Op->Header.Args[0])); \
-                  LogMan::Throw::A(Data != nullptr, "Couldn't Map pointer to 0x%lx\n", *GetSrc<uint64_t*>(SSAData, Op->Header.Args[0])); \
+                  Data = Thread->CTX->MemoryMapper.GetPointer<uint8_t*>(*GetSrc<uint64_t*>(SSAData, Op->Addr)); \
+                  LogMan::Throw::A(Data != nullptr, "Couldn't Map pointer to 0x%lx\n", *GetSrc<uint64_t*>(SSAData, Op->Addr)); \
                 } \
-                if (!Op->Header.Args[2].IsInvalid()) {\
-                  auto Offset = *GetSrc<uintptr_t const*>(SSAData, Op->Header.Args[2]) * Op->OffsetScale;\
+                if (!Op->Offset.IsInvalid()) {\
+                  auto Offset = *GetSrc<uintptr_t const*>(SSAData, Op->Offset) * Op->OffsetScale;\
                   \
                   switch(Op->OffsetType) {\
                     case MEM_OFFSET_SXTX: Data +=  Offset; break;\
@@ -959,7 +959,7 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
                     case MEM_OFFSET_SXTW: Data += (int32_t)Offset; break;\
                   }\
                 }\
-                memcpy((y*)Data, GetSrc<y*>(SSAData, Op->Header.Args[1]), sizeof(y)); \
+                memcpy((y*)Data, GetSrc<y*>(SSAData, Op->Value), sizeof(y)); \
                 break; \
               }
 

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -912,10 +912,10 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
             if (!Op->Offset.IsInvalid()) {
               auto Offset = *GetSrc<uintptr_t const*>(SSAData, Op->Offset) * Op->OffsetScale;
 
-              switch(Op->OffsetType) {
-                case MEM_OFFSET_SXTX: Data +=  Offset; break;
-                case MEM_OFFSET_UXTW: Data += (uint32_t)Offset; break;
-                case MEM_OFFSET_SXTW: Data += (int32_t)Offset; break;
+              switch(Op->OffsetType.Val) {
+                case MEM_OFFSET_SXTX.Val: Data +=  Offset; break;
+                case MEM_OFFSET_UXTW.Val: Data += (uint32_t)Offset; break;
+                case MEM_OFFSET_SXTW.Val: Data += (int32_t)Offset; break;
               }
             }
 
@@ -953,10 +953,10 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
                 if (!Op->Offset.IsInvalid()) {\
                   auto Offset = *GetSrc<uintptr_t const*>(SSAData, Op->Offset) * Op->OffsetScale;\
                   \
-                  switch(Op->OffsetType) {\
-                    case MEM_OFFSET_SXTX: Data +=  Offset; break;\
-                    case MEM_OFFSET_UXTW: Data += (uint32_t)Offset; break;\
-                    case MEM_OFFSET_SXTW: Data += (int32_t)Offset; break;\
+                  switch(Op->OffsetType.Val) {\
+                    case MEM_OFFSET_SXTX.Val: Data +=  Offset; break;\
+                    case MEM_OFFSET_UXTW.Val: Data += (uint32_t)Offset; break;\
+                    case MEM_OFFSET_SXTW.Val: Data += (int32_t)Offset; break;\
                   }\
                 }\
                 memcpy((y*)Data, GetSrc<y*>(SSAData, Op->Value), sizeof(y)); \

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -350,6 +350,7 @@ private:
   DEF_OP(FillRegister);
   DEF_OP(LoadFlag);
   DEF_OP(StoreFlag);
+  MemOperand GenerateMemOperand(uint8_t AccessSize, aarch64::Register Base, IR::OrderedNodeWrapper Offset, uint8_t OffsetType, uint8_t OffsetScale);
   DEF_OP(LoadMem);
   DEF_OP(StoreMem);
   DEF_OP(LoadMemTSO);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -350,7 +350,7 @@ private:
   DEF_OP(FillRegister);
   DEF_OP(LoadFlag);
   DEF_OP(StoreFlag);
-  MemOperand GenerateMemOperand(uint8_t AccessSize, aarch64::Register Base, IR::OrderedNodeWrapper Offset, uint8_t OffsetType, uint8_t OffsetScale);
+  MemOperand GenerateMemOperand(uint8_t AccessSize, aarch64::Register Base, IR::OrderedNodeWrapper Offset, IR::MemOffsetType OffsetType, uint8_t OffsetScale);
   DEF_OP(LoadMem);
   DEF_OP(StoreMem);
   DEF_OP(LoadMemTSO);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -148,6 +148,8 @@ private:
   aarch64::VRegister GetSrc(uint32_t Node);
   aarch64::VRegister GetDst(uint32_t Node);
 
+  MemOperand GenerateMemOperand(uint8_t AccessSize, aarch64::Register Base, IR::OrderedNodeWrapper Offset, IR::MemOffsetType OffsetType, uint8_t OffsetScale);
+
   bool IsInlineConstant(const IR::OrderedNodeWrapper& Node, uint64_t* Value = nullptr);
 
   struct LiveRange {
@@ -350,7 +352,6 @@ private:
   DEF_OP(FillRegister);
   DEF_OP(LoadFlag);
   DEF_OP(StoreFlag);
-  MemOperand GenerateMemOperand(uint8_t AccessSize, aarch64::Register Base, IR::OrderedNodeWrapper Offset, IR::MemOffsetType OffsetType, uint8_t OffsetScale);
   DEF_OP(LoadMem);
   DEF_OP(StoreMem);
   DEF_OP(LoadMemTSO);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -694,8 +694,8 @@ void JITCore::RegisterMemoryHandlers() {
     REGISTER_OP(STOREMEMTSO,         StoreMemTSO);
   }
   else {
-    REGISTER_OP(LOADMEMTSO,          LoadMem);
-    REGISTER_OP(STOREMEMTSO,         StoreMem);
+    REGISTER_OP(LOADMEMTSO,          Unhandled);
+    REGISTER_OP(STOREMEMTSO,         Unhandled);
   }
   REGISTER_OP(VLOADMEMELEMENT,     VLoadMemElement);
   REGISTER_OP(VSTOREMEMELEMENT,    VStoreMemElement);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -404,14 +404,18 @@ DEF_OP(StoreFlag) {
 DEF_OP(LoadMem) {
   auto Op = IROp->C<IR::IROp_LoadMem>();
 
-  auto MemSrc = MemOperand(GetReg<RA_64>(Op->Header.Args[0].ID()));
+  auto MemReg = GetReg<RA_64>(Op->Header.Args[0].ID());
+
   if (!CTX->Config.UnifiedMemory) {
-    LoadConstant(TMP1, (uint64_t)CTX->MemoryMapper.GetMemoryBase());
-    MemSrc = MemOperand(TMP1, GetReg<RA_64>(Op->Header.Args[0].ID()));
+    MemReg = TMP1;
+    LoadConstant(MemReg, (uint64_t)CTX->MemoryMapper.GetMemoryBase());
+    add(MemReg, MemReg, GetReg<RA_64>(Op->Header.Args[0].ID()));
   }
 
+  auto MemSrc = MemOperand(MemReg);
+
   if (!Op->Header.Args[1].IsInvalid()) {
-    MemSrc = MemOperand(GetReg<RA_64>(Op->Header.Args[0].ID()), GetReg<RA_64>(Op->Header.Args[1].ID()));
+    MemSrc = MemOperand(MemReg, GetReg<RA_64>(Op->Header.Args[1].ID()));
   }
 
   if (Op->Class == FEXCore::IR::GPRClass) {
@@ -539,16 +543,20 @@ DEF_OP(LoadMemTSO) {
 
 DEF_OP(StoreMem) {
   auto Op = IROp->C<IR::IROp_StoreMem>();
-  auto MemSrc = MemOperand(GetReg<RA_64>(Op->Header.Args[0].ID()));
+  
+  auto MemReg = GetReg<RA_64>(Op->Header.Args[0].ID());
+
   if (!CTX->Config.UnifiedMemory) {
-    LoadConstant(TMP1, (uint64_t)CTX->MemoryMapper.GetMemoryBase());
-    MemSrc = MemOperand(TMP1, GetReg<RA_64>(Op->Header.Args[0].ID()));
+    MemReg = TMP1;
+    LoadConstant(MemReg, (uint64_t)CTX->MemoryMapper.GetMemoryBase());
+    add(MemReg, MemReg, GetReg<RA_64>(Op->Header.Args[0].ID()));
   }
+
+  auto MemSrc = MemOperand(MemReg);
 
   if (!Op->Header.Args[2].IsInvalid()) {
-    MemSrc = MemOperand(GetReg<RA_64>(Op->Header.Args[0].ID()), GetReg<RA_64>(Op->Header.Args[2].ID()));
+    MemSrc = MemOperand(MemReg, GetReg<RA_64>(Op->Header.Args[2].ID()));
   }
-
   if (Op->Class == FEXCore::IR::GPRClass) {
     switch (Op->Size) {
       case 1:

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -700,14 +700,8 @@ void JITCore::RegisterMemoryHandlers() {
   REGISTER_OP(STOREFLAG,           StoreFlag);
   REGISTER_OP(LOADMEM,             LoadMem);
   REGISTER_OP(STOREMEM,            StoreMem);
-  if (CTX->Config.TSOEnabled) {
-    REGISTER_OP(LOADMEMTSO,          LoadMemTSO);
-    REGISTER_OP(STOREMEMTSO,         StoreMemTSO);
-  }
-  else {
-    REGISTER_OP(LOADMEMTSO,          Unhandled);
-    REGISTER_OP(STOREMEMTSO,         Unhandled);
-  }
+  REGISTER_OP(LOADMEMTSO,          LoadMemTSO);
+  REGISTER_OP(STOREMEMTSO,         StoreMemTSO);
   REGISTER_OP(VLOADMEMELEMENT,     VLoadMemElement);
   REGISTER_OP(VSTOREMEMELEMENT,    VStoreMemElement);
 #undef REGISTER_OP

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -415,12 +415,16 @@ DEF_OP(LoadMem) {
   auto MemSrc = MemOperand(MemReg);
 
   if (!Op->Header.Args[1].IsInvalid()) {
-    auto MemOffset = GetReg<RA_64>(Op->Header.Args[1].ID());
-
-    switch(Op->OffsetType) {
-      case IR::MEM_OFFSET_SXTX: MemSrc = MemOperand(MemReg, MemOffset, Extend::SXTX, (int)std::log2(Op->OffsetScale) ); break;
-      case IR::MEM_OFFSET_UXTW: MemSrc = MemOperand(MemReg, MemOffset.W(), Extend::UXTW, (int)std::log2(Op->OffsetScale) ); break;
-      case IR::MEM_OFFSET_SXTW: MemSrc = MemOperand(MemReg, MemOffset.W(), Extend::SXTW, (int)std::log2(Op->OffsetScale) ); break;
+    uint64_t Const;
+    if (IsInlineConstant(Op->Header.Args[1], &Const)) {
+        MemSrc = MemOperand(MemReg, Const);
+    } else {
+      auto MemOffset = GetReg<RA_64>(Op->Header.Args[1].ID());
+      switch(Op->OffsetType) {
+        case IR::MEM_OFFSET_SXTX: MemSrc = MemOperand(MemReg, MemOffset, Extend::SXTX, (int)std::log2(Op->OffsetScale) ); break;
+        case IR::MEM_OFFSET_UXTW: MemSrc = MemOperand(MemReg, MemOffset.W(), Extend::UXTW, (int)std::log2(Op->OffsetScale) ); break;
+        case IR::MEM_OFFSET_SXTW: MemSrc = MemOperand(MemReg, MemOffset.W(), Extend::SXTW, (int)std::log2(Op->OffsetScale) ); break;
+      }
     }
   }
 
@@ -561,15 +565,19 @@ DEF_OP(StoreMem) {
   auto MemSrc = MemOperand(MemReg);
 
   if (!Op->Header.Args[2].IsInvalid()) {
-    auto MemOffset = GetReg<RA_64>(Op->Header.Args[2].ID());
-
-    switch(Op->OffsetType) {
-      case IR::MEM_OFFSET_SXTX: MemSrc = MemOperand(MemReg, MemOffset, Extend::SXTX, (int)std::log2(Op->OffsetScale) ); break;
-      case IR::MEM_OFFSET_UXTW: MemSrc = MemOperand(MemReg, MemOffset.W(), Extend::UXTW, (int)std::log2(Op->OffsetScale) ); break;
-      case IR::MEM_OFFSET_SXTW: MemSrc = MemOperand(MemReg, MemOffset.W(), Extend::SXTW, (int)std::log2(Op->OffsetScale) ); break;
+    uint64_t Const;
+    if (IsInlineConstant(Op->Header.Args[2], &Const)) {
+        MemSrc = MemOperand(MemReg, Const);
+    } else {
+      auto MemOffset = GetReg<RA_64>(Op->Header.Args[2].ID());
+      switch(Op->OffsetType) {
+        case IR::MEM_OFFSET_SXTX: MemSrc = MemOperand(MemReg, MemOffset, Extend::SXTX, (int)std::log2(Op->OffsetScale) ); break;
+        case IR::MEM_OFFSET_UXTW: MemSrc = MemOperand(MemReg, MemOffset.W(), Extend::UXTW, (int)std::log2(Op->OffsetScale) ); break;
+        case IR::MEM_OFFSET_SXTW: MemSrc = MemOperand(MemReg, MemOffset.W(), Extend::SXTW, (int)std::log2(Op->OffsetScale) ); break;
+      }
     }
   }
-  
+
   if (Op->Class == FEXCore::IR::GPRClass) {
     switch (Op->Size) {
       case 1:

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -415,7 +415,13 @@ DEF_OP(LoadMem) {
   auto MemSrc = MemOperand(MemReg);
 
   if (!Op->Header.Args[1].IsInvalid()) {
-    MemSrc = MemOperand(MemReg, GetReg<RA_64>(Op->Header.Args[1].ID()));
+    auto MemOffset = GetReg<RA_64>(Op->Header.Args[1].ID());
+
+    switch(Op->OffsetType) {
+      case IR::MEM_OFFSET_SXTX: MemSrc = MemOperand(MemReg, MemOffset, Extend::SXTX, (int)std::log2(Op->OffsetScale) ); break;
+      case IR::MEM_OFFSET_UXTW: MemSrc = MemOperand(MemReg, MemOffset.W(), Extend::UXTW, (int)std::log2(Op->OffsetScale) ); break;
+      case IR::MEM_OFFSET_SXTW: MemSrc = MemOperand(MemReg, MemOffset.W(), Extend::SXTW, (int)std::log2(Op->OffsetScale) ); break;
+    }
   }
 
   if (Op->Class == FEXCore::IR::GPRClass) {
@@ -555,8 +561,15 @@ DEF_OP(StoreMem) {
   auto MemSrc = MemOperand(MemReg);
 
   if (!Op->Header.Args[2].IsInvalid()) {
-    MemSrc = MemOperand(MemReg, GetReg<RA_64>(Op->Header.Args[2].ID()));
+    auto MemOffset = GetReg<RA_64>(Op->Header.Args[2].ID());
+
+    switch(Op->OffsetType) {
+      case IR::MEM_OFFSET_SXTX: MemSrc = MemOperand(MemReg, MemOffset, Extend::SXTX, (int)std::log2(Op->OffsetScale) ); break;
+      case IR::MEM_OFFSET_UXTW: MemSrc = MemOperand(MemReg, MemOffset.W(), Extend::UXTW, (int)std::log2(Op->OffsetScale) ); break;
+      case IR::MEM_OFFSET_SXTW: MemSrc = MemOperand(MemReg, MemOffset.W(), Extend::SXTW, (int)std::log2(Op->OffsetScale) ); break;
+    }
   }
+  
   if (Op->Class == FEXCore::IR::GPRClass) {
     switch (Op->Size) {
       case 1:

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -401,7 +401,7 @@ DEF_OP(StoreFlag) {
   strb(TMP1, MemOperand(STATE, offsetof(FEXCore::Core::CPUState, flags[0]) + Op->Flag));
 }
 
-MemOperand JITCore::GenerateMemOperand(uint8_t AccessSize, aarch64::Register Base, IR::OrderedNodeWrapper Offset, uint8_t OffsetType, uint8_t OffsetScale) {
+MemOperand JITCore::GenerateMemOperand(uint8_t AccessSize, aarch64::Register Base, IR::OrderedNodeWrapper Offset, IR::MemOffsetType OffsetType, uint8_t OffsetScale) {
   if (Offset.IsInvalid()) {
     return MemOperand(Base);
   } else {
@@ -413,12 +413,12 @@ MemOperand JITCore::GenerateMemOperand(uint8_t AccessSize, aarch64::Register Bas
         return MemOperand(Base, Const);
     } else {
       auto RegOffset = GetReg<RA_64>(Offset.ID());
-      switch(OffsetType) {
-        case IR::MEM_OFFSET_SXTX: return MemOperand(Base, RegOffset, Extend::SXTX, (int)std::log2(OffsetScale) );
-        case IR::MEM_OFFSET_UXTW: return MemOperand(Base, RegOffset.W(), Extend::UXTW, (int)std::log2(OffsetScale) );
-        case IR::MEM_OFFSET_SXTW: return MemOperand(Base, RegOffset.W(), Extend::SXTW, (int)std::log2(OffsetScale) );
+      switch(OffsetType.Val) {
+        case IR::MEM_OFFSET_SXTX.Val: return MemOperand(Base, RegOffset, Extend::SXTX, (int)std::log2(OffsetScale) );
+        case IR::MEM_OFFSET_UXTW.Val: return MemOperand(Base, RegOffset.W(), Extend::UXTW, (int)std::log2(OffsetScale) );
+        case IR::MEM_OFFSET_SXTW.Val: return MemOperand(Base, RegOffset.W(), Extend::SXTW, (int)std::log2(OffsetScale) );
 
-        default: LogMan::Msg::A("Unhandled GenerateMemOperand OffsetType: %d", OffsetType); break;
+        default: LogMan::Msg::A("Unhandled GenerateMemOperand OffsetType: %d", OffsetType.Val); break;
       }
     }
   }

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -410,6 +410,10 @@ DEF_OP(LoadMem) {
     MemSrc = MemOperand(TMP1, GetReg<RA_64>(Op->Header.Args[0].ID()));
   }
 
+  if (!Op->Header.Args[1].IsInvalid()) {
+    MemSrc = MemOperand(GetReg<RA_64>(Op->Header.Args[0].ID()), GetReg<RA_64>(Op->Header.Args[1].ID()));
+  }
+
   if (Op->Class == FEXCore::IR::GPRClass) {
     auto Dst = GetReg<RA_64>(Node);
     switch (Op->Size) {
@@ -539,6 +543,10 @@ DEF_OP(StoreMem) {
   if (!CTX->Config.UnifiedMemory) {
     LoadConstant(TMP1, (uint64_t)CTX->MemoryMapper.GetMemoryBase());
     MemSrc = MemOperand(TMP1, GetReg<RA_64>(Op->Header.Args[0].ID()));
+  }
+
+  if (!Op->Header.Args[2].IsInvalid()) {
+    MemSrc = MemOperand(GetReg<RA_64>(Op->Header.Args[0].ID()), GetReg<RA_64>(Op->Header.Args[2].ID()));
   }
 
   if (Op->Class == FEXCore::IR::GPRClass) {

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -290,7 +290,7 @@ private:
   DEF_OP(FillRegister);
   DEF_OP(LoadFlag);
   DEF_OP(StoreFlag);
-  Xbyak::RegExp GenerateModRM(Xbyak::Reg Base, IR::OrderedNodeWrapper Offset, uint8_t OffsetType, uint8_t OffsetScale);
+  Xbyak::RegExp GenerateModRM(Xbyak::Reg Base, IR::OrderedNodeWrapper Offset, IR::MemOffsetType OffsetType, uint8_t OffsetScale);
   DEF_OP(LoadMem);
   DEF_OP(StoreMem);
   DEF_OP(VLoadMemElement);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -115,6 +115,8 @@ private:
   Xbyak::Xmm GetSrc(uint32_t Node);
   Xbyak::Xmm GetDst(uint32_t Node);
 
+  Xbyak::RegExp GenerateModRM(Xbyak::Reg Base, IR::OrderedNodeWrapper Offset, IR::MemOffsetType OffsetType, uint8_t OffsetScale);
+
   bool IsInlineConstant(const IR::OrderedNodeWrapper& Node, uint64_t* Value = nullptr);
 
   void CreateCustomDispatch(FEXCore::Core::InternalThreadState *Thread);
@@ -290,7 +292,6 @@ private:
   DEF_OP(FillRegister);
   DEF_OP(LoadFlag);
   DEF_OP(StoreFlag);
-  Xbyak::RegExp GenerateModRM(Xbyak::Reg Base, IR::OrderedNodeWrapper Offset, IR::MemOffsetType OffsetType, uint8_t OffsetScale);
   DEF_OP(LoadMem);
   DEF_OP(StoreMem);
   DEF_OP(VLoadMemElement);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -290,6 +290,7 @@ private:
   DEF_OP(FillRegister);
   DEF_OP(LoadFlag);
   DEF_OP(StoreFlag);
+  Xbyak::RegExp GenerateModRM(Xbyak::Reg Base, IR::OrderedNodeWrapper Offset, uint8_t OffsetType, uint8_t OffsetScale);
   DEF_OP(LoadMem);
   DEF_OP(StoreMem);
   DEF_OP(VLoadMemElement);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/MemoryOps.cpp
@@ -636,14 +636,8 @@ void JITCore::RegisterMemoryHandlers() {
   REGISTER_OP(STOREFLAG,           StoreFlag);
   REGISTER_OP(LOADMEM,             LoadMem);
   REGISTER_OP(STOREMEM,            StoreMem);
-  if (CTX->Config.TSOEnabled) {
-    REGISTER_OP(LOADMEMTSO,        LoadMem);
-    REGISTER_OP(STOREMEMTSO,       StoreMem);
-  }
-  else {
-    REGISTER_OP(LOADMEMTSO,        Unhandled);
-    REGISTER_OP(STOREMEMTSO,       Unhandled);
-  }
+  REGISTER_OP(LOADMEMTSO,          LoadMem);
+  REGISTER_OP(STOREMEMTSO,         StoreMem);
   REGISTER_OP(VLOADMEMELEMENT,     VLoadMemElement);
   REGISTER_OP(VSTOREMEMELEMENT,    VStoreMemElement);
 #undef REGISTER_OP

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/MemoryOps.cpp
@@ -457,7 +457,7 @@ DEF_OP(StoreFlag) {
   mov(byte [STATE + (offsetof(FEXCore::Core::CPUState, flags[0]) + Op->Flag)], al);
 }
 
-Xbyak::RegExp JITCore::GenerateModRM(Xbyak::Reg Base, IR::OrderedNodeWrapper Offset, uint8_t OffsetType, uint8_t OffsetScale) {
+Xbyak::RegExp JITCore::GenerateModRM(Xbyak::Reg Base, IR::OrderedNodeWrapper Offset, IR::MemOffsetType OffsetType, uint8_t OffsetScale) {
   if (Offset.IsInvalid()) {
     return Base;
   } else {
@@ -466,7 +466,7 @@ Xbyak::RegExp JITCore::GenerateModRM(Xbyak::Reg Base, IR::OrderedNodeWrapper Off
     }
 
     if (OffsetType != IR::MEM_OFFSET_SXTX) {
-      LogMan::Msg::A("Unhandled GenerateModRM OffsetType: %d", OffsetType);
+      LogMan::Msg::A("Unhandled GenerateModRM OffsetType: %d", OffsetType.Val);
     }
 
     uint64_t Const;

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/MemoryOps.cpp
@@ -643,8 +643,14 @@ void JITCore::RegisterMemoryHandlers() {
   REGISTER_OP(STOREFLAG,           StoreFlag);
   REGISTER_OP(LOADMEM,             LoadMem);
   REGISTER_OP(STOREMEM,            StoreMem);
-  REGISTER_OP(LOADMEMTSO,          LoadMem);
-  REGISTER_OP(STOREMEMTSO,         StoreMem);
+  if (CTX->Config.TSOEnabled) {
+    REGISTER_OP(LOADMEMTSO,        LoadMem);
+    REGISTER_OP(STOREMEMTSO,       StoreMem);
+  }
+  else {
+    REGISTER_OP(LOADMEMTSO,        Unhandled);
+    REGISTER_OP(STOREMEMTSO,       Unhandled);
+  }
   REGISTER_OP(VLOADMEMELEMENT,     VLoadMemElement);
   REGISTER_OP(VSTOREMEMELEMENT,    VStoreMemElement);
 #undef REGISTER_OP

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/MemoryOps.cpp
@@ -467,24 +467,29 @@ DEF_OP(LoadMem) {
     mov(MemReg, Memory);
     add(MemReg, GetSrc<RA_64>(Op->Header.Args[0].ID()));
   }
+
+  auto MemPtr = MemReg + 0;
+  if (!Op->Header.Args[1].IsInvalid())
+    MemPtr = MemReg + GetSrc<RA_64>(Op->Header.Args[1].ID());
+
   if (Op->Class.Val == 0) {
     auto Dst = GetDst<RA_64>(Node);
 
     switch (Op->Size) {
       case 1: {
-        movzx (Dst, byte [MemReg]);
+        movzx (Dst, byte [MemPtr]);
       }
       break;
       case 2: {
-        movzx (Dst, word [MemReg]);
+        movzx (Dst, word [MemPtr]);
       }
       break;
       case 4: {
-        mov(Dst.cvt32(), dword [MemReg]);
+        mov(Dst.cvt32(), dword [MemPtr]);
       }
       break;
       case 8: {
-        mov(Dst, qword [MemReg]);
+        mov(Dst, qword [MemPtr]);
       }
       break;
       default:  LogMan::Msg::A("Unhandled LoadMem size: %d", Op->Size);
@@ -496,28 +501,28 @@ DEF_OP(LoadMem) {
 
     switch (Op->Size) {
       case 1: {
-        movzx(eax, byte [MemReg]);
+        movzx(eax, byte [MemPtr]);
         vmovd(Dst, eax);
       }
       break;
       case 2: {
-        movzx(eax, byte [MemReg]);
+        movzx(eax, word [MemPtr]);
         vmovd(Dst, eax);
       }
       break;
       case 4: {
-        vmovd(Dst, dword [MemReg]);
+        vmovd(Dst, dword [MemPtr]);
       }
       break;
       case 8: {
-        vmovq(Dst, qword [MemReg]);
+        vmovq(Dst, qword [MemPtr]);
       }
       break;
       case 16: {
          if (Op->Size == Op->Align)
-           movups(GetDst(Node), xword [MemReg]);
+           movups(GetDst(Node), xword [MemPtr]);
          else
-           movups(GetDst(Node), xword [MemReg]);
+           movups(GetDst(Node), xword [MemPtr]);
          if (MemoryDebug) {
            movq(rcx, GetDst(Node));
          }
@@ -541,19 +546,23 @@ DEF_OP(StoreMem) {
     add(MemReg, GetSrc<RA_64>(Op->Header.Args[0].ID()));
   }
 
+  auto MemPtr = MemReg + 0;
+  if (!Op->Header.Args[2].IsInvalid())
+    MemPtr = MemReg + GetSrc<RA_64>(Op->Header.Args[2].ID());
+
   if (Op->Class.Val == 0) {
     switch (Op->Size) {
     case 1:
-      mov(byte [MemReg], GetSrc<RA_8>(Op->Header.Args[1].ID()));
+      mov(byte [MemPtr], GetSrc<RA_8>(Op->Header.Args[1].ID()));
     break;
     case 2:
-      mov(word [MemReg], GetSrc<RA_16>(Op->Header.Args[1].ID()));
+      mov(word [MemPtr], GetSrc<RA_16>(Op->Header.Args[1].ID()));
     break;
     case 4:
-      mov(dword [MemReg], GetSrc<RA_32>(Op->Header.Args[1].ID()));
+      mov(dword [MemPtr], GetSrc<RA_32>(Op->Header.Args[1].ID()));
     break;
     case 8:
-      mov(qword [MemReg], GetSrc<RA_64>(Op->Header.Args[1].ID()));
+      mov(qword [MemPtr], GetSrc<RA_64>(Op->Header.Args[1].ID()));
     break;
     default:  LogMan::Msg::A("Unhandled StoreMem size: %d", Op->Size);
     }
@@ -561,22 +570,22 @@ DEF_OP(StoreMem) {
   else {
     switch (Op->Size) {
     case 1:
-      pextrb(byte [MemReg], GetSrc(Op->Header.Args[1].ID()), 0);
+      pextrb(byte [MemPtr], GetSrc(Op->Header.Args[1].ID()), 0);
     break;
     case 2:
-      pextrw(word [MemReg], GetSrc(Op->Header.Args[1].ID()), 0);
+      pextrw(word [MemPtr], GetSrc(Op->Header.Args[1].ID()), 0);
     break;
     case 4:
-      vmovd(dword [MemReg], GetSrc(Op->Header.Args[1].ID()));
+      vmovd(dword [MemPtr], GetSrc(Op->Header.Args[1].ID()));
     break;
     case 8:
-      vmovq(qword [MemReg], GetSrc(Op->Header.Args[1].ID()));
+      vmovq(qword [MemPtr], GetSrc(Op->Header.Args[1].ID()));
     break;
     case 16:
       if (Op->Size == Op->Align)
-        movups(xword [MemReg], GetSrc(Op->Header.Args[1].ID()));
+        movups(xword [MemPtr], GetSrc(Op->Header.Args[1].ID()));
       else
-        movups(xword [MemReg], GetSrc(Op->Header.Args[1].ID()));
+        movups(xword [MemPtr], GetSrc(Op->Header.Args[1].ID()));
     break;
     default:  LogMan::Msg::A("Unhandled StoreMem size: %d", Op->Size);
     }

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -2257,7 +2257,7 @@ void OpDispatchBuilder::BTOp(OpcodeArgs) {
 
     // Now add the addresses together and load the memory
     OrderedNode *MemoryLocation = _Add(Dest, Src);
-    Result = _LoadMemTSO(GPRClass, 1, MemoryLocation, 1);
+    Result = _LoadMemAutoTSO(GPRClass, 1, MemoryLocation, 1);
 
     // Now shift in to the correct bit location
     Result = _Lshr(Result, BitSelect);
@@ -2321,14 +2321,14 @@ void OpDispatchBuilder::BTROp(OpcodeArgs) {
 
     // Now add the addresses together and load the memory
     OrderedNode *MemoryLocation = _Add(Dest, Src);
-    OrderedNode *Value = _LoadMemTSO(GPRClass, 1, MemoryLocation, 1);
+    OrderedNode *Value = _LoadMemAutoTSO(GPRClass, 1, MemoryLocation, 1);
 
     // Now shift in to the correct bit location
     Result = _Lshr(Value, BitSelect);
     OrderedNode *BitMask = _Lshl(_Constant(1), BitSelect);
     BitMask = _Not(BitMask);
     Value = _And(Value, BitMask);
-    _StoreMemTSO(GPRClass, 1, MemoryLocation, Value, 1);
+    _StoreMemAutoTSO(GPRClass, 1, MemoryLocation, Value, 1);
   }
   SetRFLAG<FEXCore::X86State::RFLAG_CF_LOC>(Result);
 }
@@ -2388,13 +2388,13 @@ void OpDispatchBuilder::BTSOp(OpcodeArgs) {
 
     // Now add the addresses together and load the memory
     OrderedNode *MemoryLocation = _Add(Dest, Src);
-    OrderedNode *Value = _LoadMemTSO(GPRClass, 1, MemoryLocation, 1);
+    OrderedNode *Value = _LoadMemAutoTSO(GPRClass, 1, MemoryLocation, 1);
 
     // Now shift in to the correct bit location
     Result = _Lshr(Value, BitSelect);
     OrderedNode *BitMask = _Lshl(_Constant(1), BitSelect);
     Value = _Or(Value, BitMask);
-    _StoreMemTSO(GPRClass, 1, MemoryLocation, Value, 1);
+    _StoreMemAutoTSO(GPRClass, 1, MemoryLocation, Value, 1);
   }
   SetRFLAG<FEXCore::X86State::RFLAG_CF_LOC>(Result);
 }
@@ -2453,13 +2453,13 @@ void OpDispatchBuilder::BTCOp(OpcodeArgs) {
 
     // Now add the addresses together and load the memory
     OrderedNode *MemoryLocation = _Add(Dest, Src);
-    OrderedNode *Value = _LoadMemTSO(GPRClass, 1, MemoryLocation, 1);
+    OrderedNode *Value = _LoadMemAutoTSO(GPRClass, 1, MemoryLocation, 1);
 
     // Now shift in to the correct bit location
     Result = _Lshr(Value, BitSelect);
     OrderedNode *BitMask = _Lshl(_Constant(1), BitSelect);
     Value = _Xor(Value, BitMask);
-    _StoreMemTSO(GPRClass, 1, MemoryLocation, Value, 1);
+    _StoreMemAutoTSO(GPRClass, 1, MemoryLocation, Value, 1);
   }
   SetRFLAG<FEXCore::X86State::RFLAG_CF_LOC>(Result);
 }
@@ -2651,7 +2651,7 @@ void OpDispatchBuilder::XLATOp(OpcodeArgs) {
 
   Src = _Add(Src, Offset);
 
-  auto Res = _LoadMemTSO(GPRClass, 1, Src, 1);
+  auto Res = _LoadMemAutoTSO(GPRClass, 1, Src, 1);
 
   _StoreContext(GPRClass, 1, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RAX]), Res);
 }
@@ -2804,7 +2804,7 @@ void OpDispatchBuilder::STOSOp(OpcodeArgs) {
     Dest = AppendSegmentOffset(Dest, Op->Flags, FEXCore::X86Tables::DecodeFlags::FLAG_ES_PREFIX, true);
 
     // Store to memory where RDI points
-    _StoreMemTSO(GPRClass, Size, Dest, Src, Size);
+    _StoreMemAutoTSO(GPRClass, Size, Dest, Src, Size);
 
     auto SizeConst = _Constant(Size);
     auto NegSizeConst = _Constant(-Size);
@@ -2855,7 +2855,7 @@ void OpDispatchBuilder::STOSOp(OpcodeArgs) {
         Dest = AppendSegmentOffset(Dest, Op->Flags, FEXCore::X86Tables::DecodeFlags::FLAG_ES_PREFIX, true);
 
         // Store to memory where RDI points
-        _StoreMemTSO(GPRClass, Size, Dest, Src, Size);
+        _StoreMemAutoTSO(GPRClass, Size, Dest, Src, Size);
 
         OrderedNode *TailCounter = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RCX]), GPRClass);
         OrderedNode *TailDest = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RDI]), GPRClass);
@@ -2928,10 +2928,10 @@ void OpDispatchBuilder::MOVSOp(OpcodeArgs) {
         Dest = AppendSegmentOffset(Dest, Op->Flags, FEXCore::X86Tables::DecodeFlags::FLAG_ES_PREFIX, true);
         Src = AppendSegmentOffset(Src, Op->Flags, FEXCore::X86Tables::DecodeFlags::FLAG_DS_PREFIX);
 
-        Src = _LoadMemTSO(GPRClass, Size, Src, Size);
+        Src = _LoadMemAutoTSO(GPRClass, Size, Src, Size);
 
         // Store to memory where RDI points
-        _StoreMemTSO(GPRClass, Size, Dest, Src, Size);
+        _StoreMemAutoTSO(GPRClass, Size, Dest, Src, Size);
 
         OrderedNode *TailCounter = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RCX]), GPRClass);
 
@@ -2973,10 +2973,10 @@ void OpDispatchBuilder::MOVSOp(OpcodeArgs) {
     RDI= AppendSegmentOffset(RDI, Op->Flags, FEXCore::X86Tables::DecodeFlags::FLAG_ES_PREFIX, true);
     RSI = AppendSegmentOffset(RSI, Op->Flags, FEXCore::X86Tables::DecodeFlags::FLAG_DS_PREFIX);
 
-    auto Src = _LoadMemTSO(GPRClass, Size, RSI, Size);
+    auto Src = _LoadMemAutoTSO(GPRClass, Size, RSI, Size);
 
     // Store to memory where RDI points
-    _StoreMemTSO(GPRClass, Size, RDI, Src, Size);
+    _StoreMemAutoTSO(GPRClass, Size, RDI, Src, Size);
 
     auto SizeConst = _Constant(Size);
     auto NegSizeConst = _Constant(-Size);
@@ -3011,8 +3011,8 @@ void OpDispatchBuilder::CMPSOp(OpcodeArgs) {
     // Default DS prefix
     Dest_RSI = AppendSegmentOffset(Dest_RSI, Op->Flags, FEXCore::X86Tables::DecodeFlags::FLAG_DS_PREFIX);
 
-    auto Src1 = _LoadMemTSO(GPRClass, Size, Dest_RDI, Size);
-    auto Src2 = _LoadMemTSO(GPRClass, Size, Dest_RSI, Size);
+    auto Src1 = _LoadMemAutoTSO(GPRClass, Size, Dest_RDI, Size);
+    auto Src2 = _LoadMemAutoTSO(GPRClass, Size, Dest_RSI, Size);
 
     OrderedNode* Result = _Sub(Src2, Src1);
     if (Size < 4)
@@ -3066,7 +3066,7 @@ void OpDispatchBuilder::CMPSOp(OpcodeArgs) {
         // Default DS prefix
         Dest_RSI = AppendSegmentOffset(Dest_RSI, Op->Flags, FEXCore::X86Tables::DecodeFlags::FLAG_DS_PREFIX);
 
-        auto Src1 = _LoadMemTSO(GPRClass, Size, Dest_RDI, Size);
+        auto Src1 = _LoadMemAutoTSO(GPRClass, Size, Dest_RDI, Size);
         auto Src2 = _LoadMem(GPRClass, Size, Dest_RSI, Size);
 
         OrderedNode* Result = _Sub(Src2, Src1);
@@ -3135,7 +3135,7 @@ void OpDispatchBuilder::LODSOp(OpcodeArgs) {
     OrderedNode *Dest_RSI = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RSI]), GPRClass);
     Dest_RSI = AppendSegmentOffset(Dest_RSI, Op->Flags, FEXCore::X86Tables::DecodeFlags::FLAG_DS_PREFIX);
 
-    auto Src = _LoadMemTSO(GPRClass, Size, Dest_RSI, Size);
+    auto Src = _LoadMemAutoTSO(GPRClass, Size, Dest_RSI, Size);
 
     StoreResult(GPRClass, Op, Src, -1);
 
@@ -3186,7 +3186,7 @@ void OpDispatchBuilder::LODSOp(OpcodeArgs) {
         OrderedNode *Dest_RSI = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RSI]), GPRClass);
         Dest_RSI = AppendSegmentOffset(Dest_RSI, Op->Flags, FEXCore::X86Tables::DecodeFlags::FLAG_DS_PREFIX);
 
-        auto Src = _LoadMemTSO(GPRClass, Size, Dest_RSI, Size);
+        auto Src = _LoadMemAutoTSO(GPRClass, Size, Dest_RSI, Size);
 
         StoreResult(GPRClass, Op, Src, -1);
 
@@ -3234,7 +3234,7 @@ void OpDispatchBuilder::SCASOp(OpcodeArgs) {
     Dest_RDI = AppendSegmentOffset(Dest_RDI, Op->Flags, FEXCore::X86Tables::DecodeFlags::FLAG_ES_PREFIX, true);
 
     auto Src1 = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
-    auto Src2 = _LoadMemTSO(GPRClass, Size, Dest_RDI, Size);
+    auto Src2 = _LoadMemAutoTSO(GPRClass, Size, Dest_RDI, Size);
 
     OrderedNode* Result = _Sub(Src1, Src2);
     if (Size < 4)
@@ -3288,7 +3288,7 @@ void OpDispatchBuilder::SCASOp(OpcodeArgs) {
         Dest_RDI = AppendSegmentOffset(Dest_RDI, Op->Flags, FEXCore::X86Tables::DecodeFlags::FLAG_ES_PREFIX, true);
 
         auto Src1 = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
-        auto Src2 = _LoadMemTSO(GPRClass, Size, Dest_RDI, Size);
+        auto Src2 = _LoadMemAutoTSO(GPRClass, Size, Dest_RDI, Size);
 
         OrderedNode* Result = _Sub(Src1, Src2);
         if (Size < 4)
@@ -4494,7 +4494,7 @@ OrderedNode *OpDispatchBuilder::LoadSource_WithOpSize(FEXCore::IR::RegisterClass
       Src = _LoadMem(Class, OpSize, Src, Align == -1 ? OpSize : Align);
     }
     else {
-      Src = _LoadMemTSO(Class, OpSize, Src, Align == -1 ? OpSize : Align);
+      Src = _LoadMemAutoTSO(Class, OpSize, Src, Align == -1 ? OpSize : Align);
     }
   }
   return Src;
@@ -4627,7 +4627,7 @@ void OpDispatchBuilder::StoreResult_WithOpSize(FEXCore::IR::RegisterClassType Cl
         _StoreMem(Class, OpSize, MemStoreDst, Src, Align == -1 ? OpSize : Align);
       }
       else {
-        _StoreMemTSO(Class, OpSize, MemStoreDst, Src, Align == -1 ? OpSize : Align);
+        _StoreMemAutoTSO(Class, OpSize, MemStoreDst, Src, Align == -1 ? OpSize : Align);
       }
     }
   }
@@ -6005,7 +6005,7 @@ void OpDispatchBuilder::MASKMOVOp(OpcodeArgs) {
       {
         auto DestByte = _Bfe(8, 8 * Select, DestElement);
         auto MemLocation = _Add(MemDest, _Constant(Element * 8 + Select));
-        _StoreMemTSO(GPRClass, 1, MemLocation, DestByte, 1);
+        _StoreMemAutoTSO(GPRClass, 1, MemLocation, DestByte, 1);
       }
       auto Jump = _Jump();
       auto NextJumpTarget = CreateNewCodeBlock();

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -514,22 +514,18 @@ private:
   bool Multiblock{};
   uint64_t Entry;
 
-  IRPair<IROp_StoreMemTSO> _StoreMemTSO(FEXCore::IR::RegisterClassType Class, uint8_t Size, OrderedNode *ssa0, OrderedNode *ssa1, uint8_t Align = 1) {
+  OrderedNode* _StoreMemAutoTSO(FEXCore::IR::RegisterClassType Class, uint8_t Size, OrderedNode *ssa0, OrderedNode *ssa1, uint8_t Align = 1) {
     if (CTX->Config.TSOEnabled)
-    	return IREmitter::_StoreMemTSO(ssa0, ssa1, Invalid(), Size, Align, Class, MEM_OFFSET_SXTX, 1);
-    else {
-        auto rv=_StoreMem(ssa0, ssa1, Invalid(), Size, Align, Class, MEM_OFFSET_SXTX, 1);
-        return (IRPair<IROp_StoreMemTSO>&)rv;
-    }
+    	return _StoreMemTSO(ssa0, ssa1, Invalid(), Size, Align, Class, MEM_OFFSET_SXTX, 1);
+    else
+      return _StoreMem(ssa0, ssa1, Invalid(), Size, Align, Class, MEM_OFFSET_SXTX, 1);
   }
 
-  IRPair<IROp_LoadMemTSO> _LoadMemTSO(FEXCore::IR::RegisterClassType Class, uint8_t Size, OrderedNode *ssa0, uint8_t Align = 1) {
+  OrderedNode* _LoadMemAutoTSO(FEXCore::IR::RegisterClassType Class, uint8_t Size, OrderedNode *ssa0, uint8_t Align = 1) {
     if (CTX->Config.TSOEnabled)
-        return IREmitter::_LoadMemTSO(ssa0, Invalid(), Size, Align, Class, MEM_OFFSET_SXTX, 1);
-    else {
-        auto rv=_LoadMem(ssa0, Invalid(), Size, Align, Class, MEM_OFFSET_SXTX, 1);
-        return (IRPair<IROp_LoadMemTSO>&)rv;
-    }
+      return _LoadMemTSO(ssa0, Invalid(), Size, Align, Class, MEM_OFFSET_SXTX, 1);
+    else
+      return _LoadMem(ssa0, Invalid(), Size, Align, Class, MEM_OFFSET_SXTX, 1);
   }
 
 

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -513,6 +513,26 @@ private:
 
   bool Multiblock{};
   uint64_t Entry;
+
+  IRPair<IROp_StoreMemTSO> _StoreMemTSO(FEXCore::IR::RegisterClassType Class, uint8_t Size, OrderedNode *ssa0, OrderedNode *ssa1, uint8_t Align = 1) {
+    if (CTX->Config.TSOEnabled)
+    	return IREmitter::_StoreMemTSO(ssa0, ssa1, Invalid(), Size, Align, Class, MEM_OFFSET_SXTX, 1);
+    else {
+        auto rv=_StoreMem(ssa0, ssa1, Invalid(), Size, Align, Class, MEM_OFFSET_SXTX, 1);
+        return (IRPair<IROp_StoreMemTSO>&)rv;
+    }
+  }
+
+  IRPair<IROp_LoadMemTSO> _LoadMemTSO(FEXCore::IR::RegisterClassType Class, uint8_t Size, OrderedNode *ssa0, uint8_t Align = 1) {
+    if (CTX->Config.TSOEnabled)
+        return IREmitter::_LoadMemTSO(ssa0, Invalid(), Size, Align, Class, MEM_OFFSET_SXTX, 1);
+    else {
+        auto rv=_LoadMem(ssa0, Invalid(), Size, Align, Class, MEM_OFFSET_SXTX, 1);
+        return (IRPair<IROp_LoadMemTSO>&)rv;
+    }
+  }
+
+
 };
 
 void InstallOpcodeHandlers(Context::OperatingMode Mode);

--- a/External/FEXCore/Source/Interface/IR/IR.cpp
+++ b/External/FEXCore/Source/Interface/IR/IR.cpp
@@ -40,6 +40,16 @@ static void PrintArg(std::stringstream *out, [[maybe_unused]] IRListView<false> 
   *out << CondNames[Arg];
 }
 
+static void PrintArg(std::stringstream *out, [[maybe_unused]] IRListView<false> const* IR, MemOffsetType Arg) {
+  std::array<std::string, 3> Names = {
+    "SXTX",
+    "UXTW",
+    "SXTW",
+  };
+
+  *out << Names[Arg];
+}
+
 static void PrintArg(std::stringstream *out, [[maybe_unused]] IRListView<false> const* IR, RegisterClassType Arg) {
   if (Arg == 0)
     *out << "GPR";

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -616,9 +616,10 @@
       "HasDest": true,
       "DestClass": "Complex",
       "DestSize": "Size",
-      "SSAArgs": "1",
+      "SSAArgs": "2",
       "SSANames": [
-        "Addr"
+        "Addr",
+        "Offset"
       ],
       "Args": [
         "uint8_t", "Size",
@@ -634,10 +635,11 @@
               ],
       "HasSideEffects": true,
       "OpClass": "Memory",
-      "SSAArgs": "2",
+      "SSAArgs": "3",
       "SSANames": [
         "Addr",
-        "Value"
+        "Value",
+        "Offset"
       ],
       "Args": [
         "uint8_t", "Size",
@@ -647,15 +649,16 @@
     },
 
     "LoadMemTSO": {
-      "Desc": ["Does a x86 TSO compatible load from memory."
+      "Desc": ["Does a x86 TSO compatible load from memory. Offset must be Invalid()."
               ],
       "OpClass": "Memory",
       "HasDest": true,
       "DestClass": "Complex",
       "DestSize": "Size",
-      "SSAArgs": "1",
+      "SSAArgs": "2",
       "SSANames": [
-        "Addr"
+        "Addr",
+        "Offset"
       ],
       "Args": [
         "uint8_t", "Size",
@@ -665,14 +668,15 @@
     },
 
     "StoreMemTSO": {
-      "Desc": ["Does a x86 TSO compatible store to memory."
+      "Desc": ["Does a x86 TSO compatible store to memory. Offset must be Invalid()."
               ],
       "HasSideEffects": true,
       "OpClass": "Memory",
-      "SSAArgs": "2",
+      "SSAArgs": "3",
       "SSANames": [
         "Addr",
-        "Value"
+        "Value",
+        "Offset"
       ],
       "Args": [
         "uint8_t", "Size",

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -48,9 +48,9 @@
     "constexpr static uint8_t ROUND_MODE_TOWARDS_ZERO      = 3",
     "constexpr static uint8_t ROUND_MODE_FLUSH_TO_ZERO     = 1 << 2",
 
-    "constexpr static uint8_t MEM_OFFSET_SXTX              = 0",
-    "constexpr static uint8_t MEM_OFFSET_UXTW              = 1",
-    "constexpr static uint8_t MEM_OFFSET_SXTW              = 2"
+    "constexpr static FEXCore::IR::MemOffsetType MEM_OFFSET_SXTX {0};",
+    "constexpr static FEXCore::IR::MemOffsetType MEM_OFFSET_UXTW {1};",
+    "constexpr static FEXCore::IR::MemOffsetType MEM_OFFSET_SXTW {2};"
   ],
 
   "Ops": {
@@ -629,7 +629,7 @@
         "uint8_t", "Size",
         "uint8_t", "Align",
         "RegisterClassType", "Class",
-        "uint8_t", "OffsetType",
+        "MemOffsetType", "OffsetType",
         "uint8_t", "OffsetScale"
       ]
     },
@@ -651,7 +651,7 @@
         "uint8_t", "Size",
         "uint8_t", "Align",
         "RegisterClassType", "Class",
-        "uint8_t", "OffsetType",
+        "MemOffsetType", "OffsetType",
         "uint8_t", "OffsetScale"
       ]
     },
@@ -672,7 +672,7 @@
         "uint8_t", "Size",
         "uint8_t", "Align",
         "RegisterClassType", "Class",
-        "uint8_t", "OffsetType",
+        "MemOffsetType", "OffsetType",
         "uint8_t", "OffsetScale"
       ]
     },
@@ -692,7 +692,7 @@
         "uint8_t", "Size",
         "uint8_t", "Align",
         "RegisterClassType", "Class",
-        "uint8_t", "OffsetType",
+        "MemOffsetType", "OffsetType",
         "uint8_t", "OffsetScale"
       ]
     },

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -46,7 +46,11 @@
     "constexpr static uint8_t ROUND_MODE_NEGATIVE_INFINITY = 1",
     "constexpr static uint8_t ROUND_MODE_POSITIVE_INFINITY = 2",
     "constexpr static uint8_t ROUND_MODE_TOWARDS_ZERO      = 3",
-    "constexpr static uint8_t ROUND_MODE_FLUSH_TO_ZERO     = 1 << 2"
+    "constexpr static uint8_t ROUND_MODE_FLUSH_TO_ZERO     = 1 << 2",
+
+    "constexpr static uint8_t MEM_OFFSET_SXTX              = 0",
+    "constexpr static uint8_t MEM_OFFSET_UXTW              = 1",
+    "constexpr static uint8_t MEM_OFFSET_SXTW              = 2"
   ],
 
   "Ops": {
@@ -624,7 +628,9 @@
       "Args": [
         "uint8_t", "Size",
         "uint8_t", "Align",
-        "RegisterClassType", "Class"
+        "RegisterClassType", "Class",
+        "uint8_t", "OffsetType",
+        "uint8_t", "OffsetScale"
       ]
     },
 
@@ -644,7 +650,9 @@
       "Args": [
         "uint8_t", "Size",
         "uint8_t", "Align",
-        "RegisterClassType", "Class"
+        "RegisterClassType", "Class",
+        "uint8_t", "OffsetType",
+        "uint8_t", "OffsetScale"
       ]
     },
 
@@ -663,7 +671,9 @@
       "Args": [
         "uint8_t", "Size",
         "uint8_t", "Align",
-        "RegisterClassType", "Class"
+        "RegisterClassType", "Class",
+        "uint8_t", "OffsetType",
+        "uint8_t", "OffsetScale"
       ]
     },
 
@@ -681,7 +691,9 @@
       "Args": [
         "uint8_t", "Size",
         "uint8_t", "Align",
-        "RegisterClassType", "Class"
+        "RegisterClassType", "Class",
+        "uint8_t", "OffsetType",
+        "uint8_t", "OffsetScale"
       ]
     },
 

--- a/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -95,12 +95,14 @@ bool ConstProp::Run(IREmitter *IREmit) {
     break;
     }
 */
+/*
     case OP_LOADMEMTSO:
+*/
     case OP_LOADMEM: {
-      auto Op = IROp->CW<IR::IROp_LoadMem>();
+      auto Op = IROp->C<IR::IROp_LoadMem>();
       auto AddressHeader = IREmit->GetOpHeader(Op->Header.Args[0]);
 
-      if (AddressHeader->Op == OP_ADD && !Header->ShouldInterpret) {
+      if (AddressHeader->Op == OP_ADD && AddressHeader->Size == 8 && !Header->ShouldInterpret) {
 
         // use offset addressing
         IREmit->ReplaceNodeArgument(CodeNode, 0, IREmit->UnwarpNode(AddressHeader->Args[0]));
@@ -110,13 +112,14 @@ bool ConstProp::Run(IREmitter *IREmit) {
       }
       break;
     }
-
+/*
     case OP_STOREMEMTSO:
+*/
     case OP_STOREMEM: {
-      auto Op = IROp->CW<IR::IROp_LoadMem>();
+      auto Op = IROp->C<IR::IROp_LoadMem>();
       auto AddressHeader = IREmit->GetOpHeader(Op->Header.Args[0]);
 
-      if (AddressHeader->Op == OP_ADD && !Header->ShouldInterpret) {
+      if (AddressHeader->Op == OP_ADD && AddressHeader->Size == 8 && !Header->ShouldInterpret) {
 
         // use offset addressing
         IREmit->ReplaceNodeArgument(CodeNode, 0, IREmit->UnwarpNode(AddressHeader->Args[0]));

--- a/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -62,10 +62,10 @@ std::tuple<MemOffsetType, uint8_t, OrderedNode*, OrderedNode*> MemExtendedAddres
       if (IREmit->IsValueConstant(Src0Header->Args[1], &Scale)) {
         if (IsMemoryScale(Scale, AccessSize)) {
           // remove mul as it can be folded to the mem op
-          return { MEM_OFFSET_SXTX, (uint8_t)Scale, IREmit->UnwarpNode(AddressHeader->Args[1]), IREmit->UnwarpNode(Src0Header->Args[0]) };
+          return { MEM_OFFSET_SXTX, (uint8_t)Scale, IREmit->UnwrapNode(AddressHeader->Args[1]), IREmit->UnwrapNode(Src0Header->Args[0]) };
         } else if (Scale == 1) {
           // remove nop mul
-          return { MEM_OFFSET_SXTX, 1, IREmit->UnwarpNode(AddressHeader->Args[1]), IREmit->UnwarpNode(Src0Header->Args[0]) };
+          return { MEM_OFFSET_SXTX, 1, IREmit->UnwrapNode(AddressHeader->Args[1]), IREmit->UnwrapNode(Src0Header->Args[0]) };
         }
       }
     }
@@ -76,10 +76,10 @@ std::tuple<MemOffsetType, uint8_t, OrderedNode*, OrderedNode*> MemExtendedAddres
         uint64_t Scale = 1<<Constant2;
         if (IsMemoryScale(Scale, AccessSize)) {
           // remove shift as it can be folded to the mem op
-          return { MEM_OFFSET_SXTX, Scale, IREmit->UnwarpNode(AddressHeader->Args[1]), IREmit->UnwarpNode(Src0Header->Args[0]) };
+          return { MEM_OFFSET_SXTX, Scale, IREmit->UnwrapNode(AddressHeader->Args[1]), IREmit->UnwrapNode(Src0Header->Args[0]) };
         } else if (Scale == 1) {
           // remove nop shift
-          return { MEM_OFFSET_SXTX, 1, IREmit->UnwarpNode(AddressHeader->Args[1]), IREmit->UnwarpNode(Src0Header->Args[0]) };
+          return { MEM_OFFSET_SXTX, 1, IREmit->UnwrapNode(AddressHeader->Args[1]), IREmit->UnwrapNode(Src0Header->Args[0]) };
         }
       }
     }
@@ -89,7 +89,7 @@ std::tuple<MemOffsetType, uint8_t, OrderedNode*, OrderedNode*> MemExtendedAddres
       auto Bfe = Src0Header->C<IROp_Bfe>();
       if (Bfe->lsb == 0 && Bfe->Width == 32) {
         //todo: arm can also scale here
-        return { MEM_OFFSET_UXTW, 1, IREmit->UnwarpNode(AddressHeader->Args[1]), IREmit->UnwarpNode(Src0Header->Args[0]) };
+        return { MEM_OFFSET_UXTW, 1, IREmit->UnwrapNode(AddressHeader->Args[1]), IREmit->UnwrapNode(Src0Header->Args[0]) };
       }
     }
     //Try to optimize: Base + (s32)Offset
@@ -97,14 +97,14 @@ std::tuple<MemOffsetType, uint8_t, OrderedNode*, OrderedNode*> MemExtendedAddres
       auto Sbfe = Src0Header->C<IROp_Sbfe>();
       if (Sbfe->lsb == 0 && Sbfe->Width == 32) {
         //todo: arm can also scale here
-        return { MEM_OFFSET_SXTW, 1, IREmit->UnwarpNode(AddressHeader->Args[1]), IREmit->UnwarpNode(Src0Header->Args[0]) };
+        return { MEM_OFFSET_SXTW, 1, IREmit->UnwrapNode(AddressHeader->Args[1]), IREmit->UnwrapNode(Src0Header->Args[0]) };
       }
     }
 #endif
   }
 
   // no match anywhere, just add
-  return { MEM_OFFSET_SXTX, 1, IREmit->UnwarpNode(AddressHeader->Args[0]), IREmit->UnwarpNode(AddressHeader->Args[1]) };
+  return { MEM_OFFSET_SXTX, 1, IREmit->UnwrapNode(AddressHeader->Args[0]), IREmit->UnwrapNode(AddressHeader->Args[1]) };
 }
 
 bool ConstProp::Run(IREmitter *IREmit) {

--- a/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -41,8 +41,10 @@ static bool IsImmMemory(uint64_t imm, uint8_t Op_Size) {
 	return true;
   else if ( (imm & (Op_Size-1)) == 0 &&  imm/Op_Size <= 4095 )
 	return true;
-  else
-	return false;
+  else {
+    //printf("Rejected MemImm %ld, %d\n", imm, Op_Size);
+	  return false;
+  }
 }
 
 std::tuple<uint8_t, uint8_t, OrderedNode*, OrderedNode*> MemExtendedAddressing(IREmitter *IREmit, uint8_t Op_Size,  IROp_Header* AddressHeader) {
@@ -519,7 +521,7 @@ bool ConstProp::Run(IREmitter *IREmit) {
 
           uint64_t Constant2;
           if (Op->OffsetType == MEM_OFFSET_SXTX && IREmit->IsValueConstant(Op->Header.Args[1], &Constant2)) {
-            if (IsImmMemory(Constant2, IROp->Size)) {
+            if (IsImmMemory(Constant2, Op->Size)) {
               IREmit->SetWriteCursor(CurrentIR.GetNode(Op->Header.Args[1]));
 
               IREmit->ReplaceNodeArgument(CodeNode, 1, IREmit->_InlineConstant(Constant2));
@@ -532,11 +534,11 @@ bool ConstProp::Run(IREmitter *IREmit) {
 
 	case OP_STOREMEM:
         {
-          auto Op = IROp->CW<IR::IROp_LoadMem>();
+          auto Op = IROp->CW<IR::IROp_StoreMem>();
 
           uint64_t Constant2;
           if (Op->OffsetType == MEM_OFFSET_SXTX && IREmit->IsValueConstant(Op->Header.Args[2], &Constant2)) {
-            if (IsImmMemory(Constant2, IROp->Size)) {
+            if (IsImmMemory(Constant2, Op->Size)) {
               IREmit->SetWriteCursor(CurrentIR.GetNode(Op->Header.Args[2]));
 
               IREmit->ReplaceNodeArgument(CodeNode, 2, IREmit->_InlineConstant(Constant2));

--- a/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -28,72 +28,82 @@ static uint64_t getMask(T Op) {
 // very lazy heuristics
 static bool IsImmLogical(uint64_t imm, unsigned width) { return imm < 0x8000'0000; }
 static bool IsImmAddSub(uint64_t imm) { return imm < 0x8000'0000; }
+static bool IsMemoryScale(uint64_t Scale, uint8_t AccessSize) {
+  return Scale  == 1 || Scale  == 2 || Scale  == 4 || Scale  == 8;
+}
 #elif defined(_M_ARM_64)
 //aarch64 heuristics
 static bool IsImmLogical(uint64_t imm, unsigned width) { if (width < 32) width = 32; return vixl::aarch64::Assembler::IsImmLogical(imm, width); }
 static bool IsImmAddSub(uint64_t imm) { return vixl::aarch64::Assembler::IsImmAddSub(imm); }
+static bool IsMemoryScale(uint64_t Scale, uint8_t AccessSize) {
+  return Scale  == AccessSize;
+}
 #else
 #error No inline constant heuristics for this target
 #endif
 
-static bool IsImmMemory(uint64_t imm, uint8_t Op_Size) {
+static bool IsImmMemory(uint64_t imm, uint8_t AccessSize) {
   if ( ((int64_t)imm >= -255) && ((int64_t)imm <= 256) )
-	return true;
-  else if ( (imm & (Op_Size-1)) == 0 &&  imm/Op_Size <= 4095 )
-	return true;
+	  return true;
+  else if ( (imm & (AccessSize-1)) == 0 &&  imm/AccessSize <= 4095 )
+	  return true;
   else {
-    //printf("Rejected MemImm %ld, %d\n", imm, Op_Size);
 	  return false;
   }
 }
 
-std::tuple<uint8_t, uint8_t, OrderedNode*, OrderedNode*> MemExtendedAddressing(IREmitter *IREmit, uint8_t Op_Size,  IROp_Header* AddressHeader) {
+std::tuple<uint8_t, uint8_t, OrderedNode*, OrderedNode*> MemExtendedAddressing(IREmitter *IREmit, uint8_t AccessSize,  IROp_Header* AddressHeader) {
   
-  uint64_t Constant2;
-  uint8_t LSL_Size = Op_Size;
-
   auto Src0Header = IREmit->GetOpHeader(AddressHeader->Args[0]);
   if (Src0Header->Size == 8) {
+    //Try to optimize: Base + MUL(Offset, Scale)
     if (Src0Header->Op == OP_MUL) {
-      uint64_t Constant2;
-      if (IREmit->IsValueConstant(Src0Header->Args[1], &Constant2)) {
-        if (Constant2 == LSL_Size) {
-          //printf("MUL*%d address gen\n", Op_Size);
-          return { MEM_OFFSET_SXTX, LSL_Size, IREmit->UnwarpNode(AddressHeader->Args[1]), IREmit->UnwarpNode(Src0Header->Args[0]) };
-        } else if (Constant2 == 1) {
-          //printf("MUL*1 address gen\n");
+      uint64_t Scale;
+      if (IREmit->IsValueConstant(Src0Header->Args[1], &Scale)) {
+        if (IsMemoryScale(Scale, AccessSize)) {
+          // remove mul as it can be folded to the mem op
+          return { MEM_OFFSET_SXTX, (uint8_t)Scale, IREmit->UnwarpNode(AddressHeader->Args[1]), IREmit->UnwarpNode(Src0Header->Args[0]) };
+        } else if (Scale == 1) {
+          // remove nop mul
           return { MEM_OFFSET_SXTX, 1, IREmit->UnwarpNode(AddressHeader->Args[1]), IREmit->UnwarpNode(Src0Header->Args[0]) };
         }
       }
-    } 
+    }
+    //Try to optimize: Base + LSHL(Offset, Scale)
     else if (Src0Header->Op == OP_LSHL) {
       uint64_t Constant2;
       if (IREmit->IsValueConstant(Src0Header->Args[1], &Constant2)) {
-        if ((1<<Constant2) == LSL_Size) {
-          //printf("LSHL*%d address gen\n", Op_Size);
-          return { MEM_OFFSET_SXTX, LSL_Size, IREmit->UnwarpNode(AddressHeader->Args[1]), IREmit->UnwarpNode(Src0Header->Args[0]) };
-        } else if (Constant2 == 0) {
-          //printf("LSHL<<0 address gen\n");
+        uint64_t Scale = 1<<Constant2;
+        if (IsMemoryScale(Scale, AccessSize)) {
+          // remove shift as it can be folded to the mem op
+          return { MEM_OFFSET_SXTX, Scale, IREmit->UnwarpNode(AddressHeader->Args[1]), IREmit->UnwarpNode(Src0Header->Args[0]) };
+        } else if (Scale == 1) {
+          // remove nop shift
           return { MEM_OFFSET_SXTX, 1, IREmit->UnwarpNode(AddressHeader->Args[1]), IREmit->UnwarpNode(Src0Header->Args[0]) };
         }
       }
-    } else if (Src0Header->Op == OP_BFE) {
+    }
+#if defined(_M_ARM_64) // x86 can't sext or zext on mem ops
+    //Try to optimize: Base + (u32)Offset
+    else if (Src0Header->Op == OP_BFE) {
       auto Bfe = Src0Header->C<IROp_Bfe>();
       if (Bfe->lsb == 0 && Bfe->Width == 32) {
-        //printf("UXTW address gen\n"); // todo: scale
+        //todo: arm can also scale here
         return { MEM_OFFSET_UXTW, 1, IREmit->UnwarpNode(AddressHeader->Args[1]), IREmit->UnwarpNode(Src0Header->Args[0]) };
       }
-    } else if (Src0Header->Op == OP_SBFE) {
+    }
+    //Try to optimize: Base + (s32)Offset
+    else if (Src0Header->Op == OP_SBFE) {
       auto Sbfe = Src0Header->C<IROp_Sbfe>();
       if (Sbfe->lsb == 0 && Sbfe->Width == 32) {
-        //printf("SXTW address gen\n"); // todo: scale
+        //todo: arm can also scale here
         return { MEM_OFFSET_SXTW, 1, IREmit->UnwarpNode(AddressHeader->Args[1]), IREmit->UnwarpNode(Src0Header->Args[0]) };
       }
     }
+#endif
   }
 
   // no match anywhere, just add
-  //printf("SXTX address gen\n");
   return { MEM_OFFSET_SXTX, 1, IREmit->UnwarpNode(AddressHeader->Args[0]), IREmit->UnwarpNode(AddressHeader->Args[1]) };
 }
 
@@ -156,9 +166,7 @@ bool ConstProp::Run(IREmitter *IREmit) {
     break;
     }
 */
-    /*
-    case OP_LOADMEMTSO:
-    */
+
     case OP_LOADMEM: {
       auto Op = IROp->CW<IR::IROp_LoadMem>();
       auto AddressHeader = IREmit->GetOpHeader(Op->Header.Args[0]);
@@ -177,9 +185,6 @@ bool ConstProp::Run(IREmitter *IREmit) {
       break;
     }
 
-    /*
-    case OP_STOREMEMTSO:
-    */
     case OP_STOREMEM: {
       auto Op = IROp->CW<IR::IROp_StoreMem>();
       auto AddressHeader = IREmit->GetOpHeader(Op->Header.Args[0]);

--- a/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -52,7 +52,7 @@ static bool IsImmMemory(uint64_t imm, uint8_t AccessSize) {
   }
 }
 
-std::tuple<uint8_t, uint8_t, OrderedNode*, OrderedNode*> MemExtendedAddressing(IREmitter *IREmit, uint8_t AccessSize,  IROp_Header* AddressHeader) {
+std::tuple<MemOffsetType, uint8_t, OrderedNode*, OrderedNode*> MemExtendedAddressing(IREmitter *IREmit, uint8_t AccessSize,  IROp_Header* AddressHeader) {
   
   auto Src0Header = IREmit->GetOpHeader(AddressHeader->Args[0]);
   if (Src0Header->Size == 8) {

--- a/External/FEXCore/include/FEXCore/IR/IR.h
+++ b/External/FEXCore/include/FEXCore/IR/IR.h
@@ -272,6 +272,19 @@ struct CondClassType final {
   }
 };
 
+struct MemOffsetType final {
+  uint8_t Val;
+  operator uint8_t() {
+    return Val;
+  }
+  int operator ==(const MemOffsetType other) {
+    return Val == other.Val;
+  }
+  int operator !=(const MemOffsetType other) {
+    return Val != other.Val;
+  }
+};
+
 struct TypeDefinition final {
   uint8_t Val;
   operator uint8_t() const {

--- a/External/FEXCore/include/FEXCore/IR/IREmitter.h
+++ b/External/FEXCore/include/FEXCore/IR/IREmitter.h
@@ -74,19 +74,19 @@ friend class FEXCore::IR::PassManager;
     return _Bfi(ssa0, ssa1, Width, lsb);
   }
   IRPair<IROp_StoreMem> _StoreMem(FEXCore::IR::RegisterClassType Class, uint8_t Size, OrderedNode *ssa0, OrderedNode *ssa1, uint8_t Align = 1) {
-    return _StoreMem(ssa0, ssa1, Invalid(), Size, Align, Class);
+    return _StoreMem(ssa0, ssa1, Invalid(), Size, Align, Class, MEM_OFFSET_SXTX, 1);
   }
   IRPair<IROp_StoreMemTSO> _StoreMemTSO(FEXCore::IR::RegisterClassType Class, uint8_t Size, OrderedNode *ssa0, OrderedNode *ssa1, uint8_t Align = 1) {
-    return _StoreMemTSO(ssa0, ssa1, Invalid(), Size, Align, Class);
+    return _StoreMemTSO(ssa0, ssa1, Invalid(), Size, Align, Class, MEM_OFFSET_SXTX, 1);
   }
   IRPair<IROp_VStoreMemElement> _VStoreMemElement(uint8_t RegisterSize, uint8_t ElementSize, OrderedNode *ssa0, OrderedNode *ssa1, uint8_t Index, uint8_t Align = 1) {
     return _VStoreMemElement(ssa0, ssa1, Index, Align, RegisterSize, ElementSize);
   }
   IRPair<IROp_LoadMem> _LoadMem(FEXCore::IR::RegisterClassType Class, uint8_t Size, OrderedNode *ssa0, uint8_t Align = 1) {
-    return _LoadMem(ssa0, Invalid(), Size, Align, Class);
+    return _LoadMem(ssa0, Invalid(), Size, Align, Class, MEM_OFFSET_SXTX, 1);
   }
   IRPair<IROp_LoadMemTSO> _LoadMemTSO(FEXCore::IR::RegisterClassType Class, uint8_t Size, OrderedNode *ssa0, uint8_t Align = 1) {
-    return _LoadMemTSO(ssa0, Invalid(), Size, Align, Class);
+    return _LoadMemTSO(ssa0, Invalid(), Size, Align, Class, MEM_OFFSET_SXTX, 1);
   }
   IRPair<IROp_VLoadMemElement> _VLoadMemElement(uint8_t RegisterSize, uint8_t ElementSize, OrderedNode *ssa0, OrderedNode *ssa1, uint8_t Index, uint8_t Align = 1) {
     return _VLoadMemElement(ssa0, ssa1, Index, Align, RegisterSize, ElementSize);

--- a/External/FEXCore/include/FEXCore/IR/IREmitter.h
+++ b/External/FEXCore/include/FEXCore/IR/IREmitter.h
@@ -74,19 +74,19 @@ friend class FEXCore::IR::PassManager;
     return _Bfi(ssa0, ssa1, Width, lsb);
   }
   IRPair<IROp_StoreMem> _StoreMem(FEXCore::IR::RegisterClassType Class, uint8_t Size, OrderedNode *ssa0, OrderedNode *ssa1, uint8_t Align = 1) {
-    return _StoreMem(ssa0, ssa1, Size, Align, Class);
+    return _StoreMem(ssa0, ssa1, Invalid(), Size, Align, Class);
   }
   IRPair<IROp_StoreMemTSO> _StoreMemTSO(FEXCore::IR::RegisterClassType Class, uint8_t Size, OrderedNode *ssa0, OrderedNode *ssa1, uint8_t Align = 1) {
-    return _StoreMemTSO(ssa0, ssa1, Size, Align, Class);
+    return _StoreMemTSO(ssa0, ssa1, Invalid(), Size, Align, Class);
   }
   IRPair<IROp_VStoreMemElement> _VStoreMemElement(uint8_t RegisterSize, uint8_t ElementSize, OrderedNode *ssa0, OrderedNode *ssa1, uint8_t Index, uint8_t Align = 1) {
     return _VStoreMemElement(ssa0, ssa1, Index, Align, RegisterSize, ElementSize);
   }
   IRPair<IROp_LoadMem> _LoadMem(FEXCore::IR::RegisterClassType Class, uint8_t Size, OrderedNode *ssa0, uint8_t Align = 1) {
-    return _LoadMem(ssa0, Size, Align, Class);
+    return _LoadMem(ssa0, Invalid(), Size, Align, Class);
   }
   IRPair<IROp_LoadMemTSO> _LoadMemTSO(FEXCore::IR::RegisterClassType Class, uint8_t Size, OrderedNode *ssa0, uint8_t Align = 1) {
-    return _LoadMemTSO(ssa0, Size, Align, Class);
+    return _LoadMemTSO(ssa0, Invalid(), Size, Align, Class);
   }
   IRPair<IROp_VLoadMemElement> _VLoadMemElement(uint8_t RegisterSize, uint8_t ElementSize, OrderedNode *ssa0, OrderedNode *ssa1, uint8_t Index, uint8_t Align = 1) {
     return _VLoadMemElement(ssa0, ssa1, Index, Align, RegisterSize, ElementSize);

--- a/Source/Tests/IRLoader/Loader.h
+++ b/Source/Tests/IRLoader/Loader.h
@@ -23,6 +23,7 @@ enum class DecodeFailure {
   DECODE_INVALIDREGISTERCLASS,
   DECODE_UNKNOWN_SSA,
   DECODE_INVALID_CONDFLAG,
+  DECODE_INVALID_MEMOFFSETTYPE,
 };
 
 }
@@ -91,6 +92,10 @@ namespace FEX::IRLoader {
 
       template<>
       std::pair<DecodeFailure, FEXCore::IR::CondClassType>
+      DecodeValue(std::string &Arg);
+
+      template<>
+      std::pair<DecodeFailure, FEXCore::IR::MemOffsetType>
       DecodeValue(std::string &Arg);
 
       template<>

--- a/unittests/IR/Basic/MemoryData.ir
+++ b/unittests/IR/Basic/MemoryData.ir
@@ -16,7 +16,7 @@
   (%ssa2) CodeBlock %start, %end, %ssa1
     (%start i0) Dummy
     %Addr i64 = Constant #0x100000
-    %Val i32 = LoadMem %Addr i64, #0x8, #0x8, GPR
+    %Val i32 = LoadMem %Addr i64, %Invalid, #0x8, #0x8, GPR, SXTX, #0x1
     (%Store i64) StoreContext %Val i64, #0x08, GPR
     (%brk i0) Break #4, #4
     (%end i0) EndBlock #0x0

--- a/unittests/IR/Basic/Sbfe.ir
+++ b/unittests/IR/Basic/Sbfe.ir
@@ -21,7 +21,7 @@
   (%ssa2) CodeBlock %start, %end, %ssa1
     (%start i0) Dummy
     %Addr1 i64 = Constant #0x1000000
-    %Val i64 = LoadMem %Addr1 i64, #0x8, #0x8, GPR
+    %Val i64 = LoadMem %Addr1 i64, %Invalid, #0x8, #0x8, GPR, SXTX, #0x1
 ; Test aligned special cases
     %Res1 i64 = Sbfe %Val, #0x8, #0x0
     (%Store1 i64) StoreContext %Res1 i64, #0x08, GPR
@@ -31,7 +31,7 @@
     (%Store3 i64) StoreContext %Res3 i64, #0x18, GPR
     %Addr2 i64 = Constant #0x1000008
 ; Test non special width
-    %Val2 i64 = LoadMem %Addr2 i64, #0x8, #0x8, GPR
+    %Val2 i64 = LoadMem %Addr2 i64, %Invalid, #0x8, #0x8, GPR, SXTX, #0x1
     %Res4 i64 = Sbfe %Val2, #0x6, #0x0
     (%Store4 i64) StoreContext %Res4 i64, #0x20, GPR
 ; Test with + shift

--- a/unittests/IR/Correctness/AddTruncate.ir
+++ b/unittests/IR/Correctness/AddTruncate.ir
@@ -20,9 +20,9 @@
   (%ssa2) CodeBlock %ssa6, %ssa12, %ssa1
     (%ssa6 i0) Dummy
     %AddrA i64 = Constant #0x1000000
-    %MemValueA i64 = LoadMem %AddrA i64, #0x8, #0x8, GPR
+    %MemValueA i64 = LoadMem %AddrA i64, %Invalid, #0x8, #0x8, GPR, SXTX, #0x1
     %AddrB i64 = Constant #0x1000010
-    %MemValueB i64 = LoadMem %AddrB i64, #0x8, #0x8, GPR
+    %MemValueB i64 = LoadMem %AddrB i64, %Invalid, #0x8, #0x8, GPR, SXTX, #0x1
     %ResultA i32 = Add %MemValueA, %MemValueB
     %ResultB i64 = Add %MemValueA, %MemValueB
     (%Store i64) StoreContext %ResultA i64, #0x08, GPR

--- a/unittests/IR/Correctness/FPRStoreTruncate.ir
+++ b/unittests/IR/Correctness/FPRStoreTruncate.ir
@@ -23,14 +23,14 @@
     (%begin i0) Dummy
 ; Clear registers
     %AddrB i64 = Constant #0x1000010
-    %ClearVal i128 = LoadMem %AddrB i64, #0x10, #0x10, FPR
+    %ClearVal i128 = LoadMem %AddrB i64, %Invalid, #0x10, #0x10, FPR, SXTX, #0x1
     (%Clear1 i128) StoreContext %ClearVal i128, #0x90, FPR
     (%Clear2 i128) StoreContext %ClearVal i128, #0xa0, FPR
     (%Clear3 i128) StoreContext %ClearVal i128, #0xb0, FPR
     (%Clear4 i128) StoreContext %ClearVal i128, #0xc0, FPR
 
     %AddrA i64 = Constant #0x1000000
-    %MemValueA i128 = LoadMem %AddrA i64, #0x10, #0x10, FPR
+    %MemValueA i128 = LoadMem %AddrA i64, %Invalid, #0x10, #0x10, FPR, SXTX, #0x1
 
     (%Store1 i64) StoreContext %MemValueA i128, #0x90, FPR
     (%Store2 i32) StoreContext %MemValueA i128, #0xa0, FPR

--- a/unittests/IR/Correctness/LeftShiftTruncate.ir
+++ b/unittests/IR/Correctness/LeftShiftTruncate.ir
@@ -20,7 +20,7 @@
   (%ssa2) CodeBlock %ssa6, %ssa12, %ssa1
     (%ssa6 i0) Dummy
     %AddrA i64 = Constant #0x1000000
-    %MemValueA i32 = LoadMem %AddrA i64, #0x4, #0x4, GPR
+    %MemValueA i32 = LoadMem %AddrA i64, %Invalid, #0x4, #0x4, GPR, SXTX, #0x1
     %Shift i64 = Constant #0x1
     %ResultA i32 = Lshl %MemValueA, %Shift
     %ResultB i64 = Lshl %MemValueA, %Shift

--- a/unittests/IR/Correctness/SubTruncate.ir
+++ b/unittests/IR/Correctness/SubTruncate.ir
@@ -20,9 +20,9 @@
   (%ssa2) CodeBlock %ssa6, %ssa12, %ssa1
     (%ssa6 i0) Dummy
     %AddrA i64 = Constant #0x1000000
-    %MemValueA i64 = LoadMem %AddrA i64, #0x8, #0x8, GPR
+    %MemValueA i64 = LoadMem %AddrA i64, %Invalid, #0x8, #0x8, GPR, SXTX, #0x1
     %AddrB i64 = Constant #0x1000010
-    %MemValueB i64 = LoadMem %AddrB i64, #0x8, #0x8, GPR
+    %MemValueB i64 = LoadMem %AddrB i64, %Invalid, #0x8, #0x8, GPR, SXTX, #0x1
     %ResultA i32 = Sub %MemValueA, %MemValueB
     %ResultB i64 = Sub %MemValueA, %MemValueB
     (%Store i64) StoreContext %ResultA i64, #0x08, GPR


### PR DESCRIPTION
### Overview

Adds a third argument to Load/StoreMem*, `Offset`, which is by default `Invalid()`. Also adds `OffsetType` (SXTX, SXTW, UXTW, supported options vary by backend), and `OffsetScale` (1, 2, 8, 16, supported options also vary by backend).

Modifies OpDispatcher to not generate TSO opcodes if TSO is disabled.

Modifies IRLoader to support `%Invalid`, extends IRWriter and IRLoader to support `MemOffsetType`.

The ever-more-complex constprop pass does
- Fills `Offset` whenever possible, either with reg or constant
- Detects `Offset = RealOffset * scale` or `Offset = Zext/Sext(RealOffset)` and sets `OffsetType` and `OffsetScale` accordingly
- If `Offset` is a constant, and if it can be inlined, it converts it to an `InlineConstant`.

### Interpreter backend
- Supports Offset Reg
- Doesn't support Offset InlineConstant
- Supports any OffsetScale
- Supports SXTX, SXTW, UXTW

### Arm64 backend
- Supports Offset Reg
- Supports Offset InlineConstant (based on arm64 imm rules)
- Supports OffsetScale of 1 or access size
- Supports SXTX, SXTW, UXTW

### x86 backend
- Supports Offset Reg
- Supports OffsetInlineConstant (simm32)
- Supports OffsetScale of 1, 2, 4 or 8
- Supports only SXTX

### Notes
This modifies LoadMem/LoadMemTSO/StoreMem/StoreMemTSO, as the *TSO variants are assumed to have the same struct in some parts of the code. The optimization is only performed for non-TSO, as arm can't do address generation in TSO opcodes.

Arm64 and x86 backends will assert if any unsupported options are used.

### Further work
- Add detection for scaled SXTW and UXTW
- Add support for write backs (Pre/Post increments). This needs some more extensive IR work.
