### PR TITLE
More 32bit related fixes

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -116,7 +116,13 @@ public:
   void SBBOp(OpcodeArgs);
   void PUSHOp(OpcodeArgs);
   void PUSHREGOp(OpcodeArgs);
+  void PUSHAOp(OpcodeArgs);
+  template<uint32_t SegmentReg>
+  void PUSHSegmentOp(OpcodeArgs);
   void POPOp(OpcodeArgs);
+  void POPAOp(OpcodeArgs);
+  template<uint32_t SegmentReg>
+  void POPSegmentOp(OpcodeArgs);
   void LEAVEOp(OpcodeArgs);
   void CALLOp(OpcodeArgs);
   void CALLAbsoluteOp(OpcodeArgs);

--- a/External/FEXCore/Source/Interface/Core/X86Tables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables.cpp
@@ -30,8 +30,8 @@ X86InstInfo XOPTableGroupOps[MAX_XOP_GROUP_TABLE_SIZE];
 X86InstInfo EVEXTableOps[MAX_EVEX_TABLE_SIZE];
 
 void InitializeBaseTables(Context::OperatingMode Mode);
-void InitializeSecondaryTables();
-void InitializePrimaryGroupTables();
+void InitializeSecondaryTables(Context::OperatingMode Mode);
+void InitializePrimaryGroupTables(Context::OperatingMode Mode);
 void InitializeSecondaryGroupTables();
 void InitializeSecondaryModRMTables();
 void InitializeX87Tables();
@@ -87,8 +87,8 @@ void InitializeInfoTables(Context::OperatingMode Mode) {
       BaseOp = UnknownOp;
 
   InitializeBaseTables(Mode);
-  InitializeSecondaryTables();
-  InitializePrimaryGroupTables();
+  InitializeSecondaryTables(Mode);
+  InitializePrimaryGroupTables(Mode);
   InitializeSecondaryGroupTables();
   InitializeSecondaryModRMTables();
   InitializeX87Tables();

--- a/External/FEXCore/Source/Interface/Core/X86Tables/BaseTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/BaseTables.cpp
@@ -31,7 +31,6 @@ void InitializeBaseTables(Context::OperatingMode Mode) {
     {0x04, 1, X86InstInfo{"ADD",    TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_SF_DST_RAX  ,                              1, nullptr}},
     {0x05, 1, X86InstInfo{"ADD",    TYPE_INST, FLAGS_SF_DST_RAX | FLAGS_SRC_SEXT | FLAGS_DISPLACE_SIZE_DIV_2, 4, nullptr}},
 
-    {0x06, 2, X86InstInfo{"[INV]",  TYPE_INVALID, FLAGS_NONE,                                                                     0, nullptr}},
     {0x08, 1, X86InstInfo{"OR",     TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_MODRM | FLAGS_SF_MOD_DST,                                                   0, nullptr}},
     {0x09, 1, X86InstInfo{"OR",     TYPE_INST, FLAGS_MODRM | FLAGS_SF_MOD_DST,                                                                   0, nullptr}},
     {0x0A, 1, X86InstInfo{"OR",     TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_MODRM,                                                   0, nullptr}},
@@ -39,7 +38,6 @@ void InitializeBaseTables(Context::OperatingMode Mode) {
     {0x0C, 1, X86InstInfo{"OR",     TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_SF_DST_RAX ,                              1, nullptr}},
     {0x0D, 1, X86InstInfo{"OR",     TYPE_INST, FLAGS_SF_DST_RAX | FLAGS_SRC_SEXT | FLAGS_DISPLACE_SIZE_DIV_2, 4, nullptr}},
 
-    {0x0E, 1, X86InstInfo{"[INV]",  TYPE_INVALID, FLAGS_NONE,                                                                     0, nullptr}},
     {0x10, 1, X86InstInfo{"ADC",    TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_MODRM | FLAGS_SF_MOD_DST,                                                   0, nullptr}},
     {0x11, 1, X86InstInfo{"ADC",    TYPE_INST, FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_DISPLACE_SIZE_DIV_2,                                       0, nullptr}},
     {0x12, 1, X86InstInfo{"ADC",    TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_MODRM,                                                   0, nullptr}},
@@ -47,7 +45,6 @@ void InitializeBaseTables(Context::OperatingMode Mode) {
     {0x14, 1, X86InstInfo{"ADC",    TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_SF_DST_RAX  ,                              1, nullptr}},
     {0x15, 1, X86InstInfo{"ADC",    TYPE_INST, FLAGS_SF_DST_RAX | FLAGS_SRC_SEXT | FLAGS_DISPLACE_SIZE_DIV_2, 4, nullptr}},
 
-    {0x16, 2, X86InstInfo{"[INV]",  TYPE_INVALID, FLAGS_NONE,                                                                     0, nullptr}},
     {0x18, 1, X86InstInfo{"SBB",    TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_MODRM | FLAGS_SF_MOD_DST,                                                   0, nullptr}},
     {0x19, 1, X86InstInfo{"SBB",    TYPE_INST, FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_DISPLACE_SIZE_DIV_2,                                       0, nullptr}},
     {0x1A, 1, X86InstInfo{"SBB",    TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_MODRM,                                                   0, nullptr}},
@@ -55,7 +52,6 @@ void InitializeBaseTables(Context::OperatingMode Mode) {
     {0x1C, 1, X86InstInfo{"SBB",    TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_SF_DST_RAX  ,                              1, nullptr}},
     {0x1D, 1, X86InstInfo{"SBB",    TYPE_INST, FLAGS_SF_DST_RAX | FLAGS_SRC_SEXT | FLAGS_DISPLACE_SIZE_DIV_2, 4, nullptr}},
 
-    {0x1E, 2, X86InstInfo{"[INV]",  TYPE_INVALID, FLAGS_NONE,                                                                     0, nullptr}},
     {0x20, 1, X86InstInfo{"AND",    TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_MODRM | FLAGS_SF_MOD_DST,                                                   0, nullptr}},
     {0x21, 1, X86InstInfo{"AND",    TYPE_INST, FLAGS_MODRM | FLAGS_SF_MOD_DST,                                                                   0, nullptr}},
     {0x22, 1, X86InstInfo{"AND",    TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_MODRM,                                                   0, nullptr}},
@@ -63,7 +59,6 @@ void InitializeBaseTables(Context::OperatingMode Mode) {
     {0x24, 1, X86InstInfo{"AND",    TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_SF_DST_RAX  ,                              1, nullptr}},
     {0x25, 1, X86InstInfo{"AND",    TYPE_INST, FLAGS_SF_DST_RAX | FLAGS_SRC_SEXT | FLAGS_DISPLACE_SIZE_DIV_2, 4, nullptr}},
 
-    {0x27, 1, X86InstInfo{"[INV]",  TYPE_INVALID, FLAGS_NONE,                                                                     0, nullptr}},
     {0x28, 1, X86InstInfo{"SUB",    TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_MODRM | FLAGS_SF_MOD_DST,                                                   0, nullptr}},
     {0x29, 1, X86InstInfo{"SUB",    TYPE_INST, FLAGS_MODRM | FLAGS_SF_MOD_DST,                                                                   0, nullptr}},
     {0x2A, 1, X86InstInfo{"SUB",    TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_MODRM,                                                   0, nullptr}},
@@ -71,7 +66,6 @@ void InitializeBaseTables(Context::OperatingMode Mode) {
     {0x2C, 1, X86InstInfo{"SUB",    TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_SF_DST_RAX ,                              1, nullptr}},
     {0x2D, 1, X86InstInfo{"SUB",    TYPE_INST, FLAGS_SF_DST_RAX | FLAGS_SRC_SEXT | FLAGS_DISPLACE_SIZE_DIV_2, 4, nullptr}},
 
-    {0x2F, 1, X86InstInfo{"[INV]",  TYPE_INVALID, FLAGS_NONE,                                                                     0, nullptr}},
     {0x30, 1, X86InstInfo{"XOR",    TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_MODRM | FLAGS_SF_MOD_DST,                                                   0, nullptr}},
     {0x31, 1, X86InstInfo{"XOR",    TYPE_INST, FLAGS_MODRM | FLAGS_SF_MOD_DST,                                                                   0, nullptr}},
     {0x32, 1, X86InstInfo{"XOR",    TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_MODRM,                                                   0, nullptr}},
@@ -79,7 +73,6 @@ void InitializeBaseTables(Context::OperatingMode Mode) {
     {0x34, 1, X86InstInfo{"XOR",    TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_SF_DST_RAX  ,                              1, nullptr}},
     {0x35, 1, X86InstInfo{"XOR",    TYPE_INST, FLAGS_SF_DST_RAX | FLAGS_SRC_SEXT | FLAGS_DISPLACE_SIZE_DIV_2, 4, nullptr}},
 
-    {0x37, 1, X86InstInfo{"[INV]",  TYPE_INVALID, FLAGS_NONE,                                                                     0, nullptr}},
     {0x38, 1, X86InstInfo{"CMP",    TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_MODRM | FLAGS_SF_MOD_DST,                                                   0, nullptr}},
     {0x39, 1, X86InstInfo{"CMP",    TYPE_INST, FLAGS_MODRM | FLAGS_SF_MOD_DST,                                                                   0, nullptr}},
     {0x3A, 1, X86InstInfo{"CMP",    TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_MODRM,                                                   0, nullptr}},
@@ -87,17 +80,14 @@ void InitializeBaseTables(Context::OperatingMode Mode) {
     {0x3C, 1, X86InstInfo{"CMP",    TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_SF_DST_RAX  ,                              1, nullptr}},
     {0x3D, 1, X86InstInfo{"CMP",    TYPE_INST, FLAGS_SF_DST_RAX | FLAGS_SRC_SEXT | FLAGS_DISPLACE_SIZE_DIV_2, 4, nullptr}},
 
-    {0x3F, 1, X86InstInfo{"[INV]",  TYPE_INVALID, FLAGS_NONE,                                                                     0, nullptr}},
     {0x50, 8, X86InstInfo{"PUSH",   TYPE_INST, GenFlagsSameSize(SIZE_64BITDEF) | FLAGS_SF_REX_IN_BYTE | FLAGS_DEBUG_MEM_ACCESS ,                    0, nullptr}},
     {0x58, 8, X86InstInfo{"POP",    TYPE_INST, GenFlagsSameSize(SIZE_64BITDEF) | FLAGS_SF_REX_IN_BYTE | FLAGS_DEBUG_MEM_ACCESS ,                    0, nullptr}},
 
-    {0x60, 2, X86InstInfo{"[INV]",  TYPE_INVALID, FLAGS_NONE,                                                                           0, nullptr}},
     {0x62, 1, X86InstInfo{"",       TYPE_GROUP_EVEX, FLAGS_NONE,                                                                           0, nullptr}},
-    {0x63, 1, X86InstInfo{"MOVSXD", TYPE_INST, GenFlagsDstSize(SIZE_64BIT) | FLAGS_MODRM,                                                                         0, nullptr}},
 
     {0x68, 1, X86InstInfo{"PUSH",   TYPE_INST, GenFlagsSameSize(SIZE_64BITDEF) | FLAGS_DEBUG_MEM_ACCESS | FLAGS_DISPLACE_SIZE_DIV_2 | FLAGS_SRC_SEXT, 4, nullptr}},
     {0x69, 1, X86InstInfo{"IMUL",   TYPE_INST, FLAGS_MODRM | FLAGS_SRC_SEXT | FLAGS_DISPLACE_SIZE_DIV_2,        4, nullptr}},
-    {0x6A, 1, X86InstInfo{"PUSH",   TYPE_INST, GenFlagsSameSize(SIZE_64BIT) | FLAGS_DEBUG_MEM_ACCESS | FLAGS_SRC_SEXT ,            1, nullptr}},
+    {0x6A, 1, X86InstInfo{"PUSH",   TYPE_INST, GenFlagsSameSize(SIZE_64BITDEF) | FLAGS_DEBUG_MEM_ACCESS | FLAGS_SRC_SEXT ,            1, nullptr}},
     {0x6B, 1, X86InstInfo{"IMUL",   TYPE_INST, FLAGS_MODRM | FLAGS_SRC_SEXT ,                                    1, nullptr}},
 
     // This should just throw a GP
@@ -139,7 +129,6 @@ void InitializeBaseTables(Context::OperatingMode Mode) {
     {0x90, 8, X86InstInfo{"XCHG",   TYPE_INST, FLAGS_SF_REX_IN_BYTE | FLAGS_SF_SRC_RAX, 0, nullptr}},
     {0x98, 1, X86InstInfo{"CDQE",   TYPE_INST, FLAGS_SF_DST_RAX | FLAGS_SF_SRC_RAX,     0, nullptr}},
     {0x99, 1, X86InstInfo{"CQO",    TYPE_INST, FLAGS_SF_DST_RDX | FLAGS_SF_SRC_RAX,     0, nullptr}},
-    {0x9A, 1, X86InstInfo{"[INV]",  TYPE_INVALID, FLAGS_NONE,                           0, nullptr}},
 
     // These three are all X87 instructions
     {0x9B, 1, X86InstInfo{"FWAIT",  TYPE_INST, FLAGS_NONE,                              0, nullptr}},
@@ -173,10 +162,9 @@ void InitializeBaseTables(Context::OperatingMode Mode) {
     {0xCA, 2, X86InstInfo{"RETF",   TYPE_PRIV, GenFlagsSameSize(SIZE_64BIT) | FLAGS_SETS_RIP | FLAGS_BLOCK_END,                                                              0, nullptr}},
     {0xCC, 1, X86InstInfo{"INT3",   TYPE_INST, FLAGS_DEBUG,                                                                                      0, nullptr}},
     {0xCD, 1, X86InstInfo{"INT",    TYPE_INST, FLAGS_DEBUG ,                                                                  1, nullptr}},
-    {0xCE, 1, X86InstInfo{"[INV]",  TYPE_INVALID, FLAGS_NONE,                                                                                    0, nullptr}},
     {0xCF, 1, X86InstInfo{"IRET",   TYPE_INST, FLAGS_SETS_RIP | FLAGS_BLOCK_END,                                                                                    0, nullptr}},
 
-    {0xD4, 3, X86InstInfo{"[INV]",  TYPE_INVALID, FLAGS_NONE,                                                                                    0, nullptr}},
+    {0xD6, 1, X86InstInfo{"[INV]",  TYPE_INVALID, FLAGS_NONE,                                                                                    0, nullptr}},
     {0xD7, 1, X86InstInfo{"XLAT",   TYPE_INST, FLAGS_DEBUG_MEM_ACCESS,                                                                           0, nullptr}},
 
     {0xE0, 1, X86InstInfo{"LOOPNE", TYPE_INST, GenFlagsSameSize(SIZE_64BIT) | FLAGS_SETS_RIP | FLAGS_SRC_SEXT | FLAGS_SF_SRC_RCX,                             1, nullptr}},
@@ -190,7 +178,6 @@ void InitializeBaseTables(Context::OperatingMode Mode) {
 
     {0xE8, 1, X86InstInfo{"CALL",   TYPE_INST, GenFlagsSameSize(SIZE_64BIT) | FLAGS_SETS_RIP | FLAGS_SRC_SEXT | FLAGS_DISPLACE_SIZE_DIV_2 | FLAGS_BLOCK_END , 4, nullptr}},
     {0xE9, 1, X86InstInfo{"JMP",    TYPE_INST, GenFlagsSameSize(SIZE_64BIT) | FLAGS_SETS_RIP | FLAGS_SRC_SEXT | FLAGS_DISPLACE_SIZE_DIV_2 | FLAGS_BLOCK_END , 4, nullptr}},
-    {0xEA, 1, X86InstInfo{"[INV]",  TYPE_INVALID, FLAGS_NONE,                                                                                                      0, nullptr}},
     {0xEB, 1, X86InstInfo{"JMP",    TYPE_INST, GenFlagsSameSize(SIZE_64BIT) | FLAGS_SETS_RIP | FLAGS_SRC_SEXT | FLAGS_BLOCK_END ,                             1, nullptr}},
 
     // Should just throw GP
@@ -239,22 +226,57 @@ void InitializeBaseTables(Context::OperatingMode Mode) {
   };
 
   const U8U8InfoStruct BaseOpTable_64[] = {
+    {0x06, 2, X86InstInfo{"[INV]",  TYPE_INVALID, FLAGS_NONE,                                                                     0, nullptr}},
+    {0x0E, 1, X86InstInfo{"[INV]",  TYPE_INVALID, FLAGS_NONE,                                                                     0, nullptr}},
+    {0x16, 2, X86InstInfo{"[INV]",  TYPE_INVALID, FLAGS_NONE,                                                                     0, nullptr}},
+    {0x1E, 2, X86InstInfo{"[INV]",  TYPE_INVALID, FLAGS_NONE,                                                                     0, nullptr}},
+    {0x27, 1, X86InstInfo{"[INV]",  TYPE_INVALID, FLAGS_NONE,                                                                     0, nullptr}},
+    {0x2F, 1, X86InstInfo{"[INV]",  TYPE_INVALID, FLAGS_NONE,                                                                     0, nullptr}},
+    {0x37, 1, X86InstInfo{"[INV]",  TYPE_INVALID, FLAGS_NONE,                                                                     0, nullptr}},
+    {0x3F, 1, X86InstInfo{"[INV]",  TYPE_INVALID, FLAGS_NONE,                                                                     0, nullptr}},
+
     // REX
     {0x40, 16, X86InstInfo{"", TYPE_REX_PREFIX, FLAGS_NONE,        0, nullptr}},
+    {0x60, 2, X86InstInfo{"[INV]",  TYPE_INVALID, FLAGS_NONE,                                                                           0, nullptr}},
+    {0x63, 1, X86InstInfo{"MOVSXD", TYPE_INST, GenFlagsDstSize(SIZE_64BIT) | FLAGS_MODRM,                                                                         0, nullptr}},
+    {0x9A, 1, X86InstInfo{"[INV]",  TYPE_INVALID, FLAGS_NONE,                           0, nullptr}},
     {0xA0, 1, X86InstInfo{"MOV",    TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_SF_DST_RAX | FLAGS_MEM_OFFSET, 8, nullptr}},
     {0xA2, 1, X86InstInfo{"MOV",    TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_SF_SRC_RAX | FLAGS_MEM_OFFSET, 8, nullptr}},
     {0xA1, 1, X86InstInfo{"MOV",    TYPE_INST, FLAGS_SF_DST_RAX | FLAGS_MEM_OFFSET, 8, nullptr}},
     {0xA3, 1, X86InstInfo{"MOV",    TYPE_INST, FLAGS_SF_SRC_RAX | FLAGS_MEM_OFFSET, 8, nullptr}},
-
+    {0xCE, 1, X86InstInfo{"[INV]",  TYPE_INVALID, FLAGS_NONE,                                                                                    0, nullptr}},
+    {0xD4, 2, X86InstInfo{"[INV]",  TYPE_INVALID, FLAGS_NONE,                                                                                    0, nullptr}},
+    {0xEA, 1, X86InstInfo{"[INV]",  TYPE_INVALID, FLAGS_NONE,                                                                                                      0, nullptr}},
   };
 
   const U8U8InfoStruct BaseOpTable_32[] = {
-    {0x40, 8, X86InstInfo{"INC", TYPE_INST, FLAGS_SF_REX_IN_BYTE,        0, nullptr}},
-    {0x48, 8, X86InstInfo{"DEC", TYPE_INST, FLAGS_SF_REX_IN_BYTE,        0, nullptr}},
+    {0x06, 1, X86InstInfo{"PUSH ES",  TYPE_INST, GenFlagsSrcSize(SIZE_16BIT) | FLAGS_DEBUG_MEM_ACCESS,            0, nullptr}},
+    {0x07, 1, X86InstInfo{"POP ES",   TYPE_INST, GenFlagsSizes(SIZE_16BIT, SIZE_DEF) | FLAGS_DEBUG_MEM_ACCESS,    0, nullptr}},
+    {0x0E, 1, X86InstInfo{"PUSH CS",  TYPE_INST, GenFlagsSrcSize(SIZE_16BIT) | FLAGS_DEBUG_MEM_ACCESS,            0, nullptr}},
+    {0x16, 1, X86InstInfo{"PUSH SS",  TYPE_INST, GenFlagsSrcSize(SIZE_16BIT) | FLAGS_DEBUG_MEM_ACCESS,            0, nullptr}},
+    {0x17, 1, X86InstInfo{"POP SS",   TYPE_INST, GenFlagsSizes(SIZE_16BIT, SIZE_DEF) | FLAGS_DEBUG_MEM_ACCESS,    0, nullptr}},
+    {0x1E, 1, X86InstInfo{"PUSH DS",  TYPE_INST, GenFlagsSrcSize(SIZE_16BIT) | FLAGS_DEBUG_MEM_ACCESS,            0, nullptr}},
+    {0x1F, 1, X86InstInfo{"POP DS",   TYPE_INST, GenFlagsSizes(SIZE_16BIT, SIZE_DEF) | FLAGS_DEBUG_MEM_ACCESS,    0, nullptr}},
+    {0x27, 1, X86InstInfo{"DAA",      TYPE_INST, FLAGS_NONE,                                                      0, nullptr}},
+    {0x2F, 1, X86InstInfo{"DAS",      TYPE_INST, FLAGS_NONE,                                                      0, nullptr}},
+    {0x37, 1, X86InstInfo{"AAA",      TYPE_INST, FLAGS_NONE,                                                      0, nullptr}},
+    {0x3F, 1, X86InstInfo{"AAS",      TYPE_INST, FLAGS_NONE,                                                      0, nullptr}},
+
+    {0x40, 8, X86InstInfo{"INC",    TYPE_INST, FLAGS_SF_REX_IN_BYTE,                                              0, nullptr}},
+    {0x48, 8, X86InstInfo{"DEC",    TYPE_INST, FLAGS_SF_REX_IN_BYTE,                                              0, nullptr}},
+    {0x60, 1, X86InstInfo{"PUSHA",  TYPE_INST, FLAGS_DEBUG_MEM_ACCESS,                                            0, nullptr}},
+    {0x61, 1, X86InstInfo{"POPA",   TYPE_INST, FLAGS_DEBUG_MEM_ACCESS,                                            0, nullptr}},
+    {0x63, 1, X86InstInfo{"ARPL",   TYPE_INVALID, FLAGS_NONE,                                                     0, nullptr}},
+
+    {0x9A, 1, X86InstInfo{"CALLF",  TYPE_INST, FLAGS_NONE,                                                        0, nullptr}},
     {0xA0, 1, X86InstInfo{"MOV",    TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_SF_DST_RAX | FLAGS_MEM_OFFSET, 4, nullptr}},
     {0xA2, 1, X86InstInfo{"MOV",    TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_SF_SRC_RAX | FLAGS_MEM_OFFSET, 4, nullptr}},
-    {0xA1, 1, X86InstInfo{"MOV",    TYPE_INST, FLAGS_SF_DST_RAX | FLAGS_MEM_OFFSET, 4, nullptr}},
-    {0xA3, 1, X86InstInfo{"MOV",    TYPE_INST, FLAGS_SF_SRC_RAX | FLAGS_MEM_OFFSET, 4, nullptr}},
+    {0xA1, 1, X86InstInfo{"MOV",    TYPE_INST, FLAGS_SF_DST_RAX | FLAGS_MEM_OFFSET,                               4, nullptr}},
+    {0xA3, 1, X86InstInfo{"MOV",    TYPE_INST, FLAGS_SF_SRC_RAX | FLAGS_MEM_OFFSET,                               4, nullptr}},
+    {0xCE, 1, X86InstInfo{"INTO",   TYPE_INST, FLAGS_NONE,                                                        0, nullptr}},
+    {0xD4, 1, X86InstInfo{"AAM",    TYPE_INST, FLAGS_NONE,                                                        1, nullptr}},
+    {0xD5, 1, X86InstInfo{"AAD",    TYPE_INST, FLAGS_NONE,                                                        1, nullptr}},
+    {0xEA, 1, X86InstInfo{"JMPF",   TYPE_INST, FLAGS_NONE,                                                        0, nullptr}},
   };
 
   GenerateTable(BaseOps, BaseOpTable, sizeof(BaseOpTable) / sizeof(BaseOpTable[0]));

--- a/External/FEXCore/Source/Interface/Core/X86Tables/PrimaryGroupTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/PrimaryGroupTables.cpp
@@ -3,7 +3,7 @@
 namespace FEXCore::X86Tables {
 using namespace InstFlags;
 
-void InitializePrimaryGroupTables() {
+void InitializePrimaryGroupTables(Context::OperatingMode Mode) {
 #define OPD(group, prefix, Reg) (((group - FEXCore::X86Tables::TYPE_GROUP_1) << 6) | (prefix) << 3 | (Reg))
   const U16U8InfoStruct PrimaryGroupOpTable[] = {
     // GROUP_1 | 0x80 | reg
@@ -24,9 +24,6 @@ void InitializePrimaryGroupTables() {
     {OPD(TYPE_GROUP_1, OpToIndex(0x81), 5), 1, X86InstInfo{"SUB",  TYPE_INST, FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_SRC_SEXT64BIT | FLAGS_DISPLACE_SIZE_DIV_2,                          4, nullptr}},
     {OPD(TYPE_GROUP_1, OpToIndex(0x81), 6), 1, X86InstInfo{"XOR",  TYPE_INST, FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_SRC_SEXT64BIT | FLAGS_DISPLACE_SIZE_DIV_2,                          4, nullptr}},
     {OPD(TYPE_GROUP_1, OpToIndex(0x81), 7), 1, X86InstInfo{"CMP",  TYPE_INST, FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_SRC_SEXT64BIT | FLAGS_DISPLACE_SIZE_DIV_2,                          4, nullptr}},
-
-    // Invalid in 64bit mode
-    {OPD(TYPE_GROUP_1, OpToIndex(0x82), 0), 8, X86InstInfo{"",     TYPE_INVALID, FLAGS_NONE,                                                        0, nullptr}},
 
     {OPD(TYPE_GROUP_1, OpToIndex(0x83), 0), 1, X86InstInfo{"ADD",  TYPE_INST, FLAGS_SRC_SEXT | FLAGS_MODRM | FLAGS_SF_MOD_DST,                                     1, nullptr}},
     {OPD(TYPE_GROUP_1, OpToIndex(0x83), 1), 1, X86InstInfo{"OR",   TYPE_INST, FLAGS_SRC_SEXT | FLAGS_MODRM | FLAGS_SF_MOD_DST,                                     1, nullptr}},
@@ -132,9 +129,34 @@ void InitializePrimaryGroupTables() {
     {OPD(TYPE_GROUP_11, OpToIndex(0xC7), 0), 1, X86InstInfo{"MOV",  TYPE_INST, FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_SRC_SEXT | FLAGS_DISPLACE_SIZE_DIV_2,                                   4, nullptr}},
     {OPD(TYPE_GROUP_11, OpToIndex(0xC7), 1), 6, X86InstInfo{"",     TYPE_INVALID, FLAGS_NONE,                                                       0, nullptr}},
   };
+
+  const U16U8InfoStruct PrimaryGroupOpTable_64[] = {
+    // Invalid in 64bit mode
+    {OPD(TYPE_GROUP_1, OpToIndex(0x82), 0), 8, X86InstInfo{"",     TYPE_INVALID, FLAGS_NONE,                                                        0, nullptr}},
+  };
+
+  const U16U8InfoStruct PrimaryGroupOpTable_32[] = {
+    // Duplicates the 0x80 opcode group
+    {OPD(TYPE_GROUP_1, OpToIndex(0x82), 0), 1, X86InstInfo{"ADD",  TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_MODRM | FLAGS_SF_MOD_DST,                                      1, nullptr}},
+    {OPD(TYPE_GROUP_1, OpToIndex(0x82), 1), 1, X86InstInfo{"OR",   TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_MODRM | FLAGS_SF_MOD_DST,                                      1, nullptr}},
+    {OPD(TYPE_GROUP_1, OpToIndex(0x82), 2), 1, X86InstInfo{"ADC",  TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_MODRM | FLAGS_SF_MOD_DST,                                      1, nullptr}},
+    {OPD(TYPE_GROUP_1, OpToIndex(0x82), 3), 1, X86InstInfo{"SBB",  TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_MODRM | FLAGS_SF_MOD_DST,                                      1, nullptr}},
+    {OPD(TYPE_GROUP_1, OpToIndex(0x82), 4), 1, X86InstInfo{"AND",  TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_MODRM | FLAGS_SF_MOD_DST,                                      1, nullptr}},
+    {OPD(TYPE_GROUP_1, OpToIndex(0x82), 5), 1, X86InstInfo{"SUB",  TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_MODRM | FLAGS_SF_MOD_DST,                                      1, nullptr}},
+    {OPD(TYPE_GROUP_1, OpToIndex(0x82), 6), 1, X86InstInfo{"XOR",  TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_MODRM | FLAGS_SF_MOD_DST,                                      1, nullptr}},
+    {OPD(TYPE_GROUP_1, OpToIndex(0x82), 7), 1, X86InstInfo{"CMP",  TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_MODRM | FLAGS_SF_MOD_DST,                                      1, nullptr}},
+  };
+
 #undef OPD
 
   GenerateTable(PrimaryInstGroupOps, PrimaryGroupOpTable, sizeof(PrimaryGroupOpTable) / sizeof(PrimaryGroupOpTable[0]));
+  if (Mode == Context::MODE_64BIT) {
+    GenerateTable(PrimaryInstGroupOps, PrimaryGroupOpTable_64, sizeof(PrimaryGroupOpTable_64) / sizeof(PrimaryGroupOpTable_64[0]));
+  }
+  else {
+    GenerateTable(PrimaryInstGroupOps, PrimaryGroupOpTable_32, sizeof(PrimaryGroupOpTable_32) / sizeof(PrimaryGroupOpTable_32[0]));
+  }
+
 }
 
 }

--- a/External/FEXCore/Source/Interface/Core/X86Tables/SecondaryTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/SecondaryTables.cpp
@@ -3,7 +3,7 @@
 namespace FEXCore::X86Tables {
 using namespace InstFlags;
 
-void InitializeSecondaryTables() {
+void InitializeSecondaryTables(Context::OperatingMode Mode) {
   const U8U8InfoStruct TwoByteOpTable[] = {
     // Instructions
     {0x00, 1, X86InstInfo{"",           TYPE_GROUP_6, FLAGS_NO_OVERLAY,                                                                                 0, nullptr}},
@@ -154,15 +154,11 @@ void InitializeSecondaryTables() {
     {0x9E, 1, X86InstInfo{"SETLE",   TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_NO_OVERLAY,                        0, nullptr}},
     {0x9F, 1, X86InstInfo{"SETNLE",  TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_NO_OVERLAY,                        0, nullptr}},
 
-    {0xA0, 1, X86InstInfo{"PUSH",    TYPE_INVALID,  FLAGS_NO_OVERLAY,                                                                               0, nullptr}},
-    {0xA1, 1, X86InstInfo{"POP FS",  TYPE_INVALID,  FLAGS_NO_OVERLAY,                                                                               0, nullptr}},
     {0xA2, 1, X86InstInfo{"CPUID",   TYPE_INST,     FLAGS_DEBUG | FLAGS_SF_SRC_RAX | FLAGS_NO_OVERLAY,                                              0, nullptr}},
     {0xA3, 1, X86InstInfo{"BT",      TYPE_INST,     FLAGS_DEBUG_MEM_ACCESS | FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_NO_OVERLAY,                     0, nullptr}},
     {0xA4, 1, X86InstInfo{"SHLD",    TYPE_INST,     FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_NO_OVERLAY,                                              1, nullptr}},
     {0xA5, 1, X86InstInfo{"SHLD",    TYPE_INST,     FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_SF_SRC_RCX | FLAGS_NO_OVERLAY,                           0, nullptr}},
     {0xA6, 2, X86InstInfo{"",        TYPE_INVALID,  FLAGS_NO_OVERLAY,                                                                               0, nullptr}},
-    {0xA8, 1, X86InstInfo{"PUSH",    TYPE_INVALID,  FLAGS_NO_OVERLAY,                                                                               0, nullptr}},
-    {0xA9, 1, X86InstInfo{"POP GS",  TYPE_INVALID,  FLAGS_NO_OVERLAY,                                                                               0, nullptr}},
     {0xAA, 1, X86InstInfo{"RSM",     TYPE_PRIV,     FLAGS_NO_OVERLAY,                                                                               0, nullptr}},
     {0xAB, 1, X86InstInfo{"BTS",     TYPE_INST,     FLAGS_DEBUG_MEM_ACCESS | FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_NO_OVERLAY,                     0, nullptr}},
     {0xAC, 1, X86InstInfo{"SHRD",    TYPE_INST,     FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_NO_OVERLAY,                                              1, nullptr}},
@@ -257,6 +253,22 @@ void InitializeSecondaryTables() {
 
     // This was originally used by VIA to jump to its alternative instruction set. Used for OP_THUNK
     {0x3F, 1, X86InstInfo{"ALTINST",      TYPE_INST, FLAGS_BLOCK_END | FLAGS_NO_OVERLAY | FLAGS_SETS_RIP,                                                            0, nullptr}},
+  };
+
+  const U8U8InfoStruct TwoByteOpTable_32[] = {
+    {0xA0, 1, X86InstInfo{"PUSH FS", TYPE_INST, GenFlagsSrcSize(SIZE_16BIT) | FLAGS_DEBUG_MEM_ACCESS | FLAGS_NO_OVERLAY,                                                                               0, nullptr}},
+    {0xA1, 1, X86InstInfo{"POP FS",  TYPE_INST, GenFlagsSizes(SIZE_16BIT, SIZE_DEF) | FLAGS_DEBUG_MEM_ACCESS | FLAGS_NO_OVERLAY,                                                                               0, nullptr}},
+
+    {0xA8, 1, X86InstInfo{"PUSH GS", TYPE_INST, GenFlagsSrcSize(SIZE_16BIT) | FLAGS_DEBUG_MEM_ACCESS | FLAGS_NO_OVERLAY,                                                                               0, nullptr}},
+    {0xA9, 1, X86InstInfo{"POP GS",  TYPE_INST, GenFlagsSizes(SIZE_16BIT, SIZE_DEF) | FLAGS_DEBUG_MEM_ACCESS | FLAGS_NO_OVERLAY,                                                                               0, nullptr}},
+  };
+
+  const U8U8InfoStruct TwoByteOpTable_64[] = {
+    {0xA0, 1, X86InstInfo{"PUSH FS", TYPE_INST, GenFlagsSameSize(SIZE_64BIT) | FLAGS_DEBUG_MEM_ACCESS | FLAGS_NO_OVERLAY,                                                0, nullptr}},
+    {0xA1, 1, X86InstInfo{"POP FS",  TYPE_INST, GenFlagsSizes(SIZE_16BIT, SIZE_64BIT) | FLAGS_DEBUG_MEM_ACCESS | FLAGS_NO_OVERLAY,                                                0, nullptr}},
+
+    {0xA8, 1, X86InstInfo{"PUSH GS", TYPE_INST, GenFlagsSameSize(SIZE_64BIT) | FLAGS_DEBUG_MEM_ACCESS | FLAGS_NO_OVERLAY,                                                0, nullptr}},
+    {0xA9, 1, X86InstInfo{"POP GS",  TYPE_INST, GenFlagsSizes(SIZE_16BIT, SIZE_64BIT) | FLAGS_DEBUG_MEM_ACCESS | FLAGS_NO_OVERLAY,                                                0, nullptr}},
   };
 
   const U8U8InfoStruct RepModOpTable[] = {
@@ -560,6 +572,13 @@ void InitializeSecondaryTables() {
   };
 
   GenerateTable(SecondBaseOps, TwoByteOpTable, sizeof(TwoByteOpTable) / sizeof(TwoByteOpTable[0]));
+
+if (Mode == Context::MODE_64BIT) {
+    GenerateTable(SecondBaseOps, TwoByteOpTable_64, sizeof(TwoByteOpTable_64) / sizeof(TwoByteOpTable_64[0]));
+  }
+  else {
+    GenerateTable(SecondBaseOps, TwoByteOpTable_32, sizeof(TwoByteOpTable_32) / sizeof(TwoByteOpTable_32[0]));
+  }
 
   GenerateTableWithCopy(RepModOps, RepModOpTable, sizeof(RepModOpTable) / sizeof(RepModOpTable[0]), SecondBaseOps);
   GenerateTableWithCopy(RepNEModOps, RepNEModOpTable,   sizeof(RepNEModOpTable) / sizeof(RepNEModOpTable[0]), SecondBaseOps);

--- a/unittests/32Bit_ASM/Primary/Pop_Segments.asm
+++ b/unittests/32Bit_ASM/Primary/Pop_Segments.asm
@@ -1,0 +1,45 @@
+
+%ifdef CONFIG
+{
+  "RegData": {
+    "RSP": "0xE000001C"
+  },
+  "Mode": "32BIT"
+}
+%endif
+
+mov esp, 0xe0000040
+mov eax, 0
+
+push eax
+push eax
+push eax
+push eax
+push eax
+push eax
+
+push ax
+push ax
+push ax
+push ax
+push ax
+push ax
+
+; Only pops the segments
+; Doesn't check for a correct segment value
+; Just ensures we are popping the correct amount of data
+pop cs
+pop ss
+pop ds
+pop es
+pop fs
+pop gs
+
+o16 pop cs
+o16 pop ss
+o16 pop ds
+o16 pop es
+o16 pop fs
+o16 pop gs
+
+hlt

--- a/unittests/32Bit_ASM/Primary/Primary_60.asm
+++ b/unittests/32Bit_ASM/Primary/Primary_60.asm
@@ -1,0 +1,44 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x6",
+    "RCX": "0x5",
+    "RDX": "0x4",
+    "RSP": "0xE0000020",
+    "RBX": "0x3",
+    "RBP": "0x2",
+    "RSI": "0x1",
+    "RDI": "0x0"
+  },
+  "Mode": "32BIT"
+}
+%endif
+
+mov esp, 0xe0000020
+
+mov eax, 0
+mov ecx, 1
+mov edx, 2
+mov ebx, 3
+mov ebp, 4
+mov esi, 5
+mov edi, 6
+
+pushad
+
+; Invert the order
+
+mov eax, [esp + 4 * 0]
+mov ecx, [esp + 4 * 1]
+mov edx, [esp + 4 * 2]
+; sp here
+mov ebx, [esp + 4 * 4]
+mov ebp, [esp + 4 * 5]
+mov esi, [esp + 4 * 6]
+mov edi, [esp + 4 * 7]
+
+; Load sp last
+mov esp, [esp + 4 * 3]
+
+
+hlt

--- a/unittests/32Bit_ASM/Primary/Primary_60_2.asm
+++ b/unittests/32Bit_ASM/Primary/Primary_60_2.asm
@@ -1,0 +1,42 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x6",
+    "RCX": "0x5",
+    "RDX": "0x4",
+    "RSP": "0xE0000020",
+    "RBX": "0x3",
+    "RBP": "0x2",
+    "RSI": "0x1",
+    "RDI": "0x0"
+  },
+  "Mode": "32BIT"
+}
+%endif
+
+mov esp, 0xe0000020
+
+mov eax, 0
+mov ecx, 1
+mov edx, 2
+mov ebx, 3
+mov ebp, 4
+mov esi, 5
+mov edi, 6
+
+o16 pusha
+
+; Invert the order
+mov ax, [esp + 2 * 0]
+mov cx, [esp + 2 * 1]
+mov dx, [esp + 2 * 2]
+; sp here
+mov bx, [esp + 2 * 4]
+mov bp, [esp + 2 * 5]
+mov si, [esp + 2 * 6]
+mov di, [esp + 2 * 7]
+
+; Load sp last
+mov sp, [esp + 2 * 3]
+
+hlt

--- a/unittests/32Bit_ASM/Primary/Primary_61.asm
+++ b/unittests/32Bit_ASM/Primary/Primary_61.asm
@@ -1,0 +1,30 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x6",
+    "RCX": "0x5",
+    "RDX": "0x4",
+    "RSP": "0xE0000020",
+    "RBX": "0x3",
+    "RBP": "0x2",
+    "RSI": "0x1",
+    "RDI": "0x0"
+  },
+  "Mode": "32BIT"
+}
+%endif
+
+mov esp, 0xe0000020
+
+push dword 0x6
+push dword 0x5
+push dword 0x4
+push dword 0x3
+push dword 0x41424344 ; Skipped
+push dword 0x2
+push dword 0x1
+push dword 0x0
+
+popad
+
+hlt

--- a/unittests/32Bit_ASM/Primary/Primary_61_2.asm
+++ b/unittests/32Bit_ASM/Primary/Primary_61_2.asm
@@ -1,0 +1,38 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x6",
+    "RCX": "0x5",
+    "RDX": "0x4",
+    "RSP": "0xE0000020",
+    "RBX": "0x3",
+    "RBP": "0x2",
+    "RSI": "0x1",
+    "RDI": "0x0"
+  },
+  "Mode": "32BIT"
+}
+%endif
+
+mov esp, 0xe0000020
+
+mov eax, 0xFF
+mov ecx, 0xFF
+mov edx, 0xFF
+mov ebx, 0xFF
+mov ebp, 0xFF
+mov esi, 0xFF
+mov edi, 0xFF
+
+push word 0x6
+push word 0x5
+push word 0x4
+push word 0x3
+push word 0x4142 ; Skipped
+push word 0x2
+push word 0x1
+push word 0x0
+
+o16 popa
+
+hlt

--- a/unittests/32Bit_ASM/Primary/Push_Segments.asm
+++ b/unittests/32Bit_ASM/Primary/Push_Segments.asm
@@ -1,0 +1,29 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RSP": "0xE000001C"
+  },
+  "Mode": "32BIT"
+}
+%endif
+
+mov esp, 0xe0000040
+
+; Only push the segments
+; Doesn't check for a correct segment value
+; Just ensures we are pushing the correct amount of data
+push cs
+push ss
+push ds
+push es
+push fs
+push gs
+
+o16 push cs
+o16 push ss
+o16 push ds
+o16 push es
+o16 push fs
+o16 push gs
+
+hlt

--- a/unittests/ASM/Primary/Primary_6A_2.asm
+++ b/unittests/ASM/Primary/Primary_6A_2.asm
@@ -1,0 +1,23 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x000000000000FF81",
+    "RSP": "0xE0000018"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rsp, 0xe0000020
+
+push word 0
+push word 0
+push word 0
+push word -127
+
+mov rdx, 0xe0000020
+mov rax, [rdx - 8]
+
+hlt


### PR DESCRIPTION
Thanks to Stefan for finding the missing pusha/popa and push/pop segment register instructions.

From the table changes we still are missing about nine 32bit instructions, which most of them are related to BCD.

This also uncovered a bug in the 8bit push immediate op. We were treating it as always pushing a 64bit sign extended value, instead it pushes a value the size of the operating mode.
Added a new unit test to ensure that.