### PR TITLE
Fixes FCOMPP, FUCOMPP, and FCOMP

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -6885,7 +6885,7 @@ void OpDispatchBuilder::FNINIT(OpcodeArgs) {
   SetX87Top(_Constant(0));
 }
 
-template<size_t width, bool Integer, OpDispatchBuilder::FCOMIFlags whichflags, bool pop>
+template<size_t width, bool Integer, OpDispatchBuilder::FCOMIFlags whichflags, bool poptwice>
 void OpDispatchBuilder::FCOMI(OpcodeArgs) {
   Current_Header->ShouldInterpret = true;
 
@@ -6938,7 +6938,12 @@ void OpDispatchBuilder::FCOMI(OpcodeArgs) {
     SetRFLAG<FEXCore::X86State::RFLAG_PF_LOC>(HostFlag_Unordered);
   }
 
-  if ((Op->TableInfo->Flags & X86Tables::InstFlags::FLAGS_POP) != 0) {
+
+  if (poptwice) {
+    top = _And(_Add(top, _Constant(2)), mask);
+    SetX87Top(top);
+  }
+  else if ((Op->TableInfo->Flags & X86Tables::InstFlags::FLAGS_POP) != 0) {
     top = _And(_Add(top, _Constant(1)), mask);
     SetX87Top(top);
   }
@@ -8932,7 +8937,7 @@ constexpr uint16_t PF_F2 = 3;
 
     {OPDReg(0xD8, 2) | 0x00, 8, &OpDispatchBuilder::FCOMI<32, false, OpDispatchBuilder::FCOMIFlags::FLAGS_X87, false>},
 
-    {OPDReg(0xD8, 3) | 0x00, 8, &OpDispatchBuilder::FCOMI<32, false, OpDispatchBuilder::FCOMIFlags::FLAGS_X87, true>},
+    {OPDReg(0xD8, 3) | 0x00, 8, &OpDispatchBuilder::FCOMI<32, false, OpDispatchBuilder::FCOMIFlags::FLAGS_X87, false>},
 
     {OPDReg(0xD8, 4) | 0x00, 8, &OpDispatchBuilder::FSUB<32, false, false, OpDispatchBuilder::OpResult::RES_ST0>},
 
@@ -8945,7 +8950,7 @@ constexpr uint16_t PF_F2 = 3;
       {OPD(0xD8, 0xC0), 8, &OpDispatchBuilder::FADD<80, false, OpDispatchBuilder::OpResult::RES_ST0>},
       {OPD(0xD8, 0xC8), 8, &OpDispatchBuilder::FMUL<80, false, OpDispatchBuilder::OpResult::RES_ST0>},
       {OPD(0xD8, 0xD0), 8, &OpDispatchBuilder::FCOMI<80, false, OpDispatchBuilder::FCOMIFlags::FLAGS_X87, false>},
-      {OPD(0xD8, 0xD8), 8, &OpDispatchBuilder::FCOMI<80, false, OpDispatchBuilder::FCOMIFlags::FLAGS_X87, true>},
+      {OPD(0xD8, 0xD8), 8, &OpDispatchBuilder::FCOMI<80, false, OpDispatchBuilder::FCOMIFlags::FLAGS_X87, false>},
       {OPD(0xD8, 0xE0), 8, &OpDispatchBuilder::FSUB<80, false, false, OpDispatchBuilder::OpResult::RES_ST0>},
       {OPD(0xD8, 0xE8), 8, &OpDispatchBuilder::FSUB<80, false, true, OpDispatchBuilder::OpResult::RES_ST0>},
       {OPD(0xD8, 0xF0), 8, &OpDispatchBuilder::FDIV<80, false, false, OpDispatchBuilder::OpResult::RES_ST0>},
@@ -9010,7 +9015,7 @@ constexpr uint16_t PF_F2 = 3;
 
     {OPDReg(0xDA, 2) | 0x00, 8, &OpDispatchBuilder::FCOMI<32, true, OpDispatchBuilder::FCOMIFlags::FLAGS_X87, false>},
 
-    {OPDReg(0xDA, 3) | 0x00, 8, &OpDispatchBuilder::FCOMI<32, true, OpDispatchBuilder::FCOMIFlags::FLAGS_X87, true>},
+    {OPDReg(0xDA, 3) | 0x00, 8, &OpDispatchBuilder::FCOMI<32, true, OpDispatchBuilder::FCOMIFlags::FLAGS_X87, false>},
 
     {OPDReg(0xDA, 4) | 0x00, 8, &OpDispatchBuilder::FSUB<32, true, false, OpDispatchBuilder::OpResult::RES_ST0>},
 
@@ -9067,7 +9072,7 @@ constexpr uint16_t PF_F2 = 3;
 
     {OPDReg(0xDC, 2) | 0x00, 8, &OpDispatchBuilder::FCOMI<64, false, OpDispatchBuilder::FCOMIFlags::FLAGS_X87, false>},
 
-    {OPDReg(0xDC, 3) | 0x00, 8, &OpDispatchBuilder::FCOMI<64, false, OpDispatchBuilder::FCOMIFlags::FLAGS_X87, true>},
+    {OPDReg(0xDC, 3) | 0x00, 8, &OpDispatchBuilder::FCOMI<64, false, OpDispatchBuilder::FCOMIFlags::FLAGS_X87, false>},
 
     {OPDReg(0xDC, 4) | 0x00, 8, &OpDispatchBuilder::FSUB<64, false, false, OpDispatchBuilder::OpResult::RES_ST0>},
 
@@ -9104,7 +9109,7 @@ constexpr uint16_t PF_F2 = 3;
       {OPD(0xDD, 0xD8), 8, &OpDispatchBuilder::FST},
 
       {OPD(0xDD, 0xE0), 8, &OpDispatchBuilder::FCOMI<80, false, OpDispatchBuilder::FCOMIFlags::FLAGS_X87, false>},
-      {OPD(0xDD, 0xE8), 8, &OpDispatchBuilder::FCOMI<80, false, OpDispatchBuilder::FCOMIFlags::FLAGS_X87, true>},
+      {OPD(0xDD, 0xE8), 8, &OpDispatchBuilder::FCOMI<80, false, OpDispatchBuilder::FCOMIFlags::FLAGS_X87, false>},
 
     {OPDReg(0xDE, 0) | 0x00, 8, &OpDispatchBuilder::FADD<16, true, OpDispatchBuilder::OpResult::RES_ST0>},
 
@@ -9112,7 +9117,7 @@ constexpr uint16_t PF_F2 = 3;
 
     {OPDReg(0xDE, 2) | 0x00, 8, &OpDispatchBuilder::FCOMI<16, true, OpDispatchBuilder::FCOMIFlags::FLAGS_X87, false>},
 
-    {OPDReg(0xDE, 3) | 0x00, 8, &OpDispatchBuilder::FCOMI<16, true, OpDispatchBuilder::FCOMIFlags::FLAGS_X87, true>},
+    {OPDReg(0xDE, 3) | 0x00, 8, &OpDispatchBuilder::FCOMI<16, true, OpDispatchBuilder::FCOMIFlags::FLAGS_X87, false>},
 
     {OPDReg(0xDE, 4) | 0x00, 8, &OpDispatchBuilder::FSUB<16, true, false, OpDispatchBuilder::OpResult::RES_ST0>},
 
@@ -9151,8 +9156,8 @@ constexpr uint16_t PF_F2 = 3;
       {OPD(0xDF, 0xC0), 8, &OpDispatchBuilder::X87ModifySTP<true>},
 
       {OPD(0xDF, 0xE0), 8, &OpDispatchBuilder::X87FNSTSW},
-      {OPD(0xDF, 0xE8), 8, &OpDispatchBuilder::FCOMI<80, false, OpDispatchBuilder::FCOMIFlags::FLAGS_RFLAGS, true>},
-      {OPD(0xDF, 0xF0), 8, &OpDispatchBuilder::FCOMI<80, false, OpDispatchBuilder::FCOMIFlags::FLAGS_RFLAGS, true>},
+      {OPD(0xDF, 0xE8), 8, &OpDispatchBuilder::FCOMI<80, false, OpDispatchBuilder::FCOMIFlags::FLAGS_RFLAGS, false>},
+      {OPD(0xDF, 0xF0), 8, &OpDispatchBuilder::FCOMI<80, false, OpDispatchBuilder::FCOMIFlags::FLAGS_RFLAGS, false>},
   };
 #undef OPD
 #undef OPDReg

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -380,7 +380,7 @@ public:
     FLAGS_X87,
     FLAGS_RFLAGS,
   };
-  template<size_t width, bool Integer, FCOMIFlags whichflags, bool pop>
+  template<size_t width, bool Integer, FCOMIFlags whichflags, bool poptwice>
   void FCOMI(OpcodeArgs);
 
   void FXSaveOp(OpcodeArgs);

--- a/External/FEXCore/Source/Interface/Core/X86Tables/X87Tables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/X87Tables.cpp
@@ -23,7 +23,7 @@ void InitializeX87Tables() {
       //  / 2
       {OPD(0xD8, 0xD0), 8, X86InstInfo{"FCOM", TYPE_X87, FLAGS_NONE, 0, nullptr}},
       //  / 3
-      {OPD(0xD8, 0xD8), 8, X86InstInfo{"FCOMP", TYPE_X87, FLAGS_NONE, 0, nullptr}},
+      {OPD(0xD8, 0xD8), 8, X86InstInfo{"FCOMP", TYPE_X87, FLAGS_POP, 0, nullptr}},
       //  / 4
       {OPD(0xD8, 0xE0), 8, X86InstInfo{"FSUB", TYPE_X87, FLAGS_NONE, 0, nullptr}},
       //  / 5
@@ -234,7 +234,7 @@ void InitializeX87Tables() {
       //  At some point the Nvidia OpenGL binary driver uses this instruction.
       //  GCC may also end up emitting this instruction in some rare edge case!
       //  Almost all x86 CPUs implement this, and it is expected to be around
-      {OPD(0xDF, 0xC0), 8, X86InstInfo{"FFREEP",  TYPE_X87, FLAGS_NONE, 0, nullptr}},
+      {OPD(0xDF, 0xC0), 8, X86InstInfo{"FFREEP",  TYPE_X87, FLAGS_POP, 0, nullptr}},
       //  / 1
       {OPD(0xDF, 0xC8), 8, X86InstInfo{"",        TYPE_INVALID, FLAGS_NONE, 0, nullptr}},
       //  / 2

--- a/unittests/ASM/X87/D8_D9.asm
+++ b/unittests/ASM/X87/D8_D9.asm
@@ -1,0 +1,16 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM6":  ["0x8000000000000000", "0x3FFF"],
+    "MM7":  ["0x8000000000000000", "0x3FFF"]
+  }
+}
+%endif
+
+; Only tests pop behaviour
+fld1
+fldz
+fcomp
+fld1
+
+hlt

--- a/unittests/ASM/X87/DA_D9.asm
+++ b/unittests/ASM/X87/DA_D9.asm
@@ -1,0 +1,17 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM6":  ["0x8000000000000000", "0x3FFF"],
+    "MM7":  ["0x8000000000000000", "0x3FFF"]
+  }
+}
+%endif
+
+; Only tests pop behaviour
+fld1
+fldz
+fldz
+fcompp
+fld1
+
+hlt

--- a/unittests/ASM/X87/DA_E9.asm
+++ b/unittests/ASM/X87/DA_E9.asm
@@ -1,0 +1,17 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM6":  ["0x8000000000000000", "0x3FFF"],
+    "MM7":  ["0x8000000000000000", "0x3FFF"]
+  }
+}
+%endif
+
+; Only tests pop behaviour
+fld1
+fldz
+fldz
+fucompp
+fld1
+
+hlt

--- a/unittests/ASM/X87/DD_E9.asm
+++ b/unittests/ASM/X87/DD_E9.asm
@@ -1,0 +1,16 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM6":  ["0x8000000000000000", "0x3FFF"],
+    "MM7":  ["0x8000000000000000", "0x3FFF"]
+  }
+}
+%endif
+
+; Only tests pop behaviour
+fld1
+fldz
+fucomp
+fld1
+
+hlt


### PR DESCRIPTION
FCOMP was missing the pop flag in the info table
FCOMPP and FUCOMPP actually pop two values off the stack, which we hadn't supported before.