### PR TITLE
JIT: fallthrough branching

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Frontend.cpp
+++ b/External/FEXCore/Source/Interface/Core/Frontend.cpp
@@ -4,6 +4,7 @@
 #include "LogManager.h"
 
 #include <array>
+#include <algorithm>
 #include <cstring>
 #include <FEXCore/Core/X86Enums.h>
 #include <FEXCore/Debug/X86Tables.h>
@@ -1003,6 +1004,11 @@ bool Decoder::DecodeInstructionsAtEntry(uint8_t const* _InstStream, uint64_t PC)
     CurrentBlockDecoding.DecodedInstructions = &DecodedBuffer.at(BlockStartOffset);
   }
 
+
+  // sort for better branching
+  std::sort(Blocks.begin(), Blocks.end(), [](const FEXCore::Frontend::Decoder::DecodedBlocks& a, const FEXCore::Frontend::Decoder::DecodedBlocks& b) {
+    return a.Entry < b.Entry;
+  });
   return !ErrorDuringDecoding;
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
@@ -69,8 +69,7 @@ DEF_OP(Jump) {
   else {
     TargetLabel = &IsTarget->second;
   }
-
-  b(TargetLabel);
+  PendingTargetLabel = TargetLabel;
 }
 
 DEF_OP(CondJump) {
@@ -89,15 +88,14 @@ DEF_OP(CondJump) {
     TrueTargetLabel = &TrueIter->second;
   }
 
+  cbnz(GetReg<RA_64>(Op->Header.Args[0].ID()), TrueTargetLabel);
   if (FalseIter == JumpTargets.end()) {
-    FalseTargetLabel = &JumpTargets.try_emplace(Op->Header.Args[2].ID()).first->second;
+    FalseTargetLabel = &JumpTargets.try_emplace(Op->Header.Args[4].ID()).first->second;
   }
   else {
     FalseTargetLabel = &FalseIter->second;
   }
-
-  cbnz(GetReg<RA_64>(Op->Header.Args[0].ID()), TrueTargetLabel);
-  b(FalseTargetLabel);
+  PendingTargetLabel = FalseTargetLabel;
 }
 
 DEF_OP(Syscall) {

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
@@ -78,19 +78,19 @@ DEF_OP(CondJump) {
   Label *TrueTargetLabel;
   Label *FalseTargetLabel;
 
-  auto TrueIter = JumpTargets.find(Op->Header.Args[1].ID());
-  auto FalseIter = JumpTargets.find(Op->Header.Args[2].ID());
+  auto TrueIter = JumpTargets.find(Op->TrueBlock.ID());
+  auto FalseIter = JumpTargets.find(Op->FalseBlock.ID());
 
   if (TrueIter == JumpTargets.end()) {
-    TrueTargetLabel = &JumpTargets.try_emplace(Op->Header.Args[1].ID()).first->second;
+    TrueTargetLabel = &JumpTargets.try_emplace(Op->TrueBlock.ID()).first->second;
   }
   else {
     TrueTargetLabel = &TrueIter->second;
   }
 
-  cbnz(GetReg<RA_64>(Op->Header.Args[0].ID()), TrueTargetLabel);
+  cbnz(GetReg<RA_64>(Op->Cond.ID()), TrueTargetLabel);
   if (FalseIter == JumpTargets.end()) {
-    FalseTargetLabel = &JumpTargets.try_emplace(Op->Header.Args[4].ID()).first->second;
+    FalseTargetLabel = &JumpTargets.try_emplace(Op->FalseBlock.ID()).first->second;
   }
   else {
     FalseTargetLabel = &FalseIter->second;

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -643,6 +643,7 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
   }
 
   PendingTargetLabel = nullptr;
+
   for (auto [BlockNode, BlockHeader] : IR->GetBlocks()) {
     using namespace FEXCore::IR;
     auto BlockIROp = BlockHeader->CW<FEXCore::IR::IROp_CodeBlock>();
@@ -655,11 +656,13 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
         IsTarget = JumpTargets.try_emplace(Node).first;
       }
 
+      // if there's a pending branch, and it is not fall-through
       if (PendingTargetLabel && PendingTargetLabel != &IsTarget->second)
       {
         b(PendingTargetLabel);
       }
       PendingTargetLabel = nullptr;
+      
       bind(&IsTarget->second);
     }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -642,6 +642,7 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
     stp(TMP1, lr, MemOperand(sp, -16, PreIndex));
   }
 
+  PendingTargetLabel = nullptr;
   for (auto [BlockNode, BlockHeader] : IR->GetBlocks()) {
     using namespace FEXCore::IR;
     auto BlockIROp = BlockHeader->CW<FEXCore::IR::IROp_CodeBlock>();
@@ -654,6 +655,11 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
         IsTarget = JumpTargets.try_emplace(Node).first;
       }
 
+      if (PendingTargetLabel && PendingTargetLabel != &IsTarget->second)
+      {
+        b(PendingTargetLabel);
+      }
+      PendingTargetLabel = nullptr;
       bind(&IsTarget->second);
     }
 
@@ -665,6 +671,13 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
       (this->*Handler)(IROp, ID);
     }
   }
+
+  // Make sure last branch is generated. It certainly can't be eliminated here.
+  if (PendingTargetLabel)
+  {
+    b(PendingTargetLabel);
+  }
+  PendingTargetLabel = nullptr;
 
   FinalizeCode();
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -101,6 +101,7 @@ public:
   static CodeBuffer AllocateNewCodeBuffer(size_t Size);
 
 private:
+  Label *PendingTargetLabel;
   FEXCore::Context::Context *CTX;
   FEXCore::Core::InternalThreadState *State;
   FEXCore::IR::IRListView<true> const *IR;

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
@@ -86,7 +86,7 @@ DEF_OP(Jump) {
     TargetLabel = &IsTarget->second;
   }
 
-  jmp(*TargetLabel, T_NEAR);
+  PendingTargetLabel = TargetLabel;
 }
 
 DEF_OP(CondJump) {
@@ -115,7 +115,8 @@ DEF_OP(CondJump) {
   // Take branch if (src != 0)
   cmp(GetSrc<RA_64>(Op->Header.Args[0].ID()), 0);
   jne(*TrueTargetLabel, T_NEAR);
-  jmp(*FalseTargetLabel, T_NEAR);
+
+  PendingTargetLabel = FalseTargetLabel;
 }
 
 DEF_OP(Syscall) {

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -71,6 +71,7 @@ public:
   bool HandleGuestSignal(int Signal, void *info, void *ucontext, SignalDelegator::GuestSigAction *GuestAction, stack_t *GuestStack);
 
 private:
+  Label* PendingTargetLabel{};
   FEXCore::Context::Context *CTX;
   FEXCore::Core::InternalThreadState *ThreadState;
   FEXCore::IR::IRListView<true> const *IR;


### PR DESCRIPTION
This changes the arm & x86 backends to only generate branches when needed.

It also sorts the blocks on the frontend to make their order optimal for this.

This assumes that if a local branch exists for the current block, OP_JUMP or OP_JUMPCOND is the last opcode of the block.