### PR TITLE
Unsafe opts: --unsafe-local-flags, --unsafe-no-pf, --unsafe-no-tso

### DIFF
--- a/External/FEXCore/Source/Interface/Config/Config.cpp
+++ b/External/FEXCore/Source/Interface/Config/Config.cpp
@@ -42,6 +42,9 @@ namespace FEXCore::Config {
     case FEXCore::Config::CONFIG_ABI_LOCAL_FLAGS:
       CTX->Config.ABILocalFlags = Config != 0;
     break;
+    case FEXCore::Config::CONFIG_ABI_NO_PF:
+      CTX->Config.ABINoPF = Config != 0;
+    break;
     default: LogMan::Msg::A("Unknown configuration option");
     }
   }
@@ -97,6 +100,9 @@ namespace FEXCore::Config {
     break;
     case FEXCore::Config::CONFIG_ABI_LOCAL_FLAGS:
       return CTX->Config.ABILocalFlags;
+    break;
+    case FEXCore::Config::CONFIG_ABI_NO_PF:
+      return CTX->Config.ABINoPF;
     break;
     default: LogMan::Msg::A("Unknown configuration option");
     }

--- a/External/FEXCore/Source/Interface/Config/Config.cpp
+++ b/External/FEXCore/Source/Interface/Config/Config.cpp
@@ -39,6 +39,9 @@ namespace FEXCore::Config {
     case FEXCore::Config::CONFIG_SMC_CHECKS:
       CTX->Config.SMCChecks = Config != 0;
     break;
+    case FEXCore::Config::CONFIG_ABI_LOCAL_FLAGS:
+      CTX->Config.ABILocalFlags = Config != 0;
+    break;
     default: LogMan::Msg::A("Unknown configuration option");
     }
   }
@@ -91,6 +94,9 @@ namespace FEXCore::Config {
     break;
     case FEXCore::Config::CONFIG_SMC_CHECKS:
       return CTX->Config.SMCChecks;
+    break;
+    case FEXCore::Config::CONFIG_ABI_LOCAL_FLAGS:
+      return CTX->Config.ABILocalFlags;
     break;
     default: LogMan::Msg::A("Unknown configuration option");
     }

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -63,7 +63,8 @@ namespace FEXCore::Context {
       bool TSOEnabled {true};
       bool SMCChecks {false};
       bool ABILocalFlags {false};
-      
+      bool ABINoPF {false};
+
       std::string DumpIR;
       
     } Config;

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -62,8 +62,10 @@ namespace FEXCore::Context {
       uint64_t EmulatedCPUCores{1};
       bool TSOEnabled {true};
       bool SMCChecks {false};
-
+      bool ABILocalFlags {false};
+      
       std::string DumpIR;
+      
     } Config;
 
     FEXCore::Memory::MemMapper MemoryMapper;

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -488,6 +488,7 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
           case IR::OP_DUMMY:
           case IR::OP_BEGINBLOCK:
           case IR::OP_ENDBLOCK:
+          case IR::OP_INVALIDATEFLAGS:
             break;
           case IR::OP_FENCE: {
             auto Op = IROp->C<IR::IROp_Fence>();

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
@@ -126,6 +126,7 @@ void JITCore::RegisterMiscHandlers() {
   REGISTER_OP(PRINT,      Unhandled);
   REGISTER_OP(GETROUNDINGMODE, GetRoundingMode);
   REGISTER_OP(SETROUNDINGMODE, SetRoundingMode);
+  REGISTER_OP(INVALIDATEFLAGS,   NoOp);
 #undef REGISTER_OP
 }
 }

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/MiscOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/MiscOps.cpp
@@ -142,6 +142,7 @@ void JITCore::RegisterMiscHandlers() {
   REGISTER_OP(PRINT,      Print);
   REGISTER_OP(GETROUNDINGMODE, GetRoundingMode);
   REGISTER_OP(SETROUNDINGMODE, SetRoundingMode);
+  REGISTER_OP(INVALIDATEFLAGS,   NoOp);
 #undef REGISTER_OP
 }
 }

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -4732,7 +4732,7 @@ void OpDispatchBuilder::GenerateFlags_ADC(FEXCore::X86Tables::DecodedOp Op, Orde
   }
 
   // PF
-  {
+  if (!CTX->Config.ABINoPF) {
     auto PopCountOp = _Popcount(_And(Res, _Constant(0xFF)));
 
     auto XorOp = _Xor(PopCountOp, _Constant(1));
@@ -4799,7 +4799,7 @@ void OpDispatchBuilder::GenerateFlags_SBB(FEXCore::X86Tables::DecodedOp Op, Orde
   }
 
   // PF
-  {
+  if (!CTX->Config.ABINoPF) {
     auto PopCountOp = _Popcount(_And(Res, _Constant(0xFF)));
 
     auto XorOp = _Xor(PopCountOp, _Constant(1));
@@ -4865,7 +4865,7 @@ void OpDispatchBuilder::GenerateFlags_SUB(FEXCore::X86Tables::DecodedOp Op, Orde
   }
 
   // PF
-  {
+  if (!CTX->Config.ABINoPF) {
     auto EightBitMask = _Constant(0xFF);
     auto PopCountOp = _Popcount(_And(Res, EightBitMask));
     auto XorOp = _Xor(PopCountOp, _Constant(1));
@@ -4920,7 +4920,7 @@ void OpDispatchBuilder::GenerateFlags_ADD(FEXCore::X86Tables::DecodedOp Op, Orde
   }
 
   // PF
-  {
+  if (!CTX->Config.ABINoPF) {
     auto EightBitMask = _Constant(0xFF);
     auto PopCountOp = _Popcount(_And(Res, EightBitMask));
     auto XorOp = _Xor(PopCountOp, _Constant(1));
@@ -5030,7 +5030,7 @@ void OpDispatchBuilder::GenerateFlags_Logical(FEXCore::X86Tables::DecodedOp Op, 
   }
 
   // PF
-  {
+  if (!CTX->Config.ABINoPF) {
     auto EightBitMask = _Constant(0xFF);
     auto PopCountOp = _Popcount(_And(Res, EightBitMask));
     auto XorOp = _Xor(PopCountOp, _Constant(1));
@@ -5067,7 +5067,7 @@ void OpDispatchBuilder::GenerateFlags_ShiftLeft(FEXCore::X86Tables::DecodedOp Op
   }
 
   // PF
-  {
+  if (!CTX->Config.ABINoPF) {
     auto EightBitMask = _Constant(0xFF);
     auto PopCountOp = _Popcount(_And(Res, EightBitMask));
     auto XorOp = _Xor(PopCountOp, _Constant(1));
@@ -5113,7 +5113,7 @@ void OpDispatchBuilder::GenerateFlags_ShiftRight(FEXCore::X86Tables::DecodedOp O
   }
 
   // PF
-  {
+  if (!CTX->Config.ABINoPF) {
     auto EightBitMask = _Constant(0xFF);
     auto PopCountOp = _Popcount(_And(Res, EightBitMask));
     auto XorOp = _Xor(PopCountOp, _Constant(1));
@@ -5159,7 +5159,7 @@ void OpDispatchBuilder::GenerateFlags_SignShiftRight(FEXCore::X86Tables::Decoded
   }
 
   // PF
-  {
+  if (!CTX->Config.ABINoPF) {
     auto EightBitMask = _Constant(0xFF);
     auto PopCountOp = _Popcount(_And(Res, EightBitMask));
     auto XorOp = _Xor(PopCountOp, _Constant(1));
@@ -5205,7 +5205,7 @@ void OpDispatchBuilder::GenerateFlags_ShiftLeftImmediate(FEXCore::X86Tables::Dec
   }
 
   // PF
-  {
+  if (!CTX->Config.ABINoPF) {
     auto EightBitMask = _Constant(0xFF);
     auto PopCountOp = _Popcount(_And(Res, EightBitMask));
     auto XorOp = _Xor(PopCountOp, _Constant(1));
@@ -5252,7 +5252,7 @@ void OpDispatchBuilder::GenerateFlags_SignShiftRightImmediate(FEXCore::X86Tables
   }
 
   // PF
-  {
+  if (!CTX->Config.ABINoPF) {
     auto EightBitMask = _Constant(0xFF);
     auto PopCountOp = _Popcount(_And(Res, EightBitMask));
     auto XorOp = _Xor(PopCountOp, _Constant(1));
@@ -5301,7 +5301,7 @@ void OpDispatchBuilder::GenerateFlags_ShiftRightImmediate(FEXCore::X86Tables::De
   }
 
   // PF
-  {
+  if (!CTX->Config.ABINoPF) {
     auto EightBitMask = _Constant(0xFF);
     auto PopCountOp = _Popcount(_And(Res, EightBitMask));
     auto XorOp = _Xor(PopCountOp, _Constant(1));

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -144,6 +144,11 @@ void OpDispatchBuilder::NOPOp(OpcodeArgs) {
 void OpDispatchBuilder::RETOp(OpcodeArgs) {
   uint8_t GPRSize = CTX->Config.Is64BitMode ? 8 : 4;
 
+  // ABI Optimization: Flags don't survive calls or rets
+  if (CTX->Config.ABILocalFlags) {
+    _InvalidateFlags();
+  }
+  
   auto Constant = _Constant(GPRSize);
 
   auto OldSP = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RSP]), GPRClass);
@@ -622,6 +627,12 @@ void OpDispatchBuilder::CALLOp(OpcodeArgs) {
   uint8_t GPRSize = CTX->Config.Is64BitMode ? 8 : 4;
 
   BlockSetRIP = true;
+
+  // ABI Optimization: Flags don't survive calls or rets
+  if (CTX->Config.ABILocalFlags) {
+    _InvalidateFlags();
+  }
+
   auto ConstantPC = _Constant(Op->PC + Op->InstSize);
 
   OrderedNode *JMPPCOffset = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -89,6 +89,11 @@
       ]
     },
 
+    "InvalidateFlags": {
+      "OpClass": "Misc",
+      "HasSideEffects": true
+    },
+
     "EndBlock": {
       "HasSideEffects": true,
       "OpClass": "Misc",

--- a/External/FEXCore/Source/Interface/IR/Passes/DeadFlagStoreElimination.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/DeadFlagStoreElimination.cpp
@@ -42,6 +42,9 @@ bool DeadFlagStoreElimination::Run(IREmitter *IREmit) {
           auto Op = IROp->CW<IR::IROp_StoreFlag>();
           FlagMap[BlockNode].writes |= 1 << Op->Flag;
         }
+        else if  (IROp->Op == OP_INVALIDATEFLAGS) {
+          FlagMap[BlockNode].writes = -1;
+        }
         else if (IROp->Op == OP_LOADFLAG) {
           auto Op = IROp->CW<IR::IROp_LoadFlag>();
           FlagMap[BlockNode].reads |= 1 << Op->Flag;

--- a/External/FEXCore/include/FEXCore/Config/Config.h
+++ b/External/FEXCore/include/FEXCore/Config/Config.h
@@ -19,6 +19,7 @@ namespace FEXCore::Config {
     CONFIG_TSO_ENABLED,
     CONFIG_SMC_CHECKS,
     CONFIG_ABI_LOCAL_FLAGS,
+    CONFIG_ABI_NO_PF,
     CONFIG_DUMPIR,
   };
 

--- a/External/FEXCore/include/FEXCore/Config/Config.h
+++ b/External/FEXCore/include/FEXCore/Config/Config.h
@@ -18,7 +18,8 @@ namespace FEXCore::Config {
     CONFIG_EMULATED_CPU_CORES,
     CONFIG_TSO_ENABLED,
     CONFIG_SMC_CHECKS,
-    CONFIG_DUMPIR
+    CONFIG_ABI_LOCAL_FLAGS,
+    CONFIG_DUMPIR,
   };
 
   enum ConfigCore {

--- a/Source/Common/ArgumentLoader.cpp
+++ b/Source/Common/ArgumentLoader.cpp
@@ -81,7 +81,13 @@ namespace FEX::ArgLoader {
       CPUGroup.add_option("--unsafe-local-flags")
         .dest("AbiLocalFlags")
         .action("store_true")
-        .help("Assumes flags are not used across calls")
+        .help("Assumes flags are not used across calls. Hand-written asm could violate this assumption")
+        .set_default(false);
+
+      CPUGroup.add_option("--unsafe-no-pf")
+        .dest("AbiNoPF")
+        .action("store_true")
+        .help("Does not calculate the parity flag on integer operations")
         .set_default(false);
 
       Parser.add_option_group(CPUGroup);
@@ -217,6 +223,10 @@ namespace FEX::ArgLoader {
       if (Options.is_set_by_user("AbiLocalFlags")) {
         bool AbiLocalFlags = Options.get("AbiLocalFlags");
         Config::Add("AbiLocalFlags", std::to_string(AbiLocalFlags));
+      }
+      if (Options.is_set_by_user("AbiNoPF")) {
+        bool AbiNoPF = Options.get("AbiNoPF");
+        Config::Add("AbiNoPF", std::to_string(AbiNoPF));
       }
     }
 

--- a/Source/Common/ArgumentLoader.cpp
+++ b/Source/Common/ArgumentLoader.cpp
@@ -48,23 +48,23 @@ namespace FEX::ArgLoader {
         .dest("MaxInst")
         .help("Maximum number of instructions to stick in a block")
         .set_default(~0U);
-     CPUGroup.add_option("-m", "--multiblock")
-        .dest("Multiblock")
-        .action("store_true")
-        .help("Enable Multiblock code compilation");
-     CPUGroup.add_option("--no-multiblock")
-        .dest("Multiblock")
-        .action("store_false")
-        .help("Enable Multiblock code compilation");
-    CPUGroup.add_option("-G", "--gdb")
-        .dest("GdbServer")
-        .action("store_true")
-        .help("Enables the GDB server");
+      CPUGroup.add_option("-m", "--multiblock")
+          .dest("Multiblock")
+          .action("store_true")
+          .help("Enable Multiblock code compilation");
+      CPUGroup.add_option("--no-multiblock")
+          .dest("Multiblock")
+          .action("store_false")
+          .help("Enable Multiblock code compilation");
+      CPUGroup.add_option("-G", "--gdb")
+          .dest("GdbServer")
+          .action("store_true")
+          .help("Enables the GDB server");
 
-    CPUGroup.add_option("-T", "--Threads")
-        .dest("Threads")
-        .help("Number of physical hardware threads to tell the process we have")
-        .set_default(1);
+      CPUGroup.add_option("-T", "--Threads")
+          .dest("Threads")
+          .help("Number of physical hardware threads to tell the process we have")
+          .set_default(1);
 
       CPUGroup.add_option("--disable-tso")
         .dest("TSOEnabled")
@@ -76,6 +76,11 @@ namespace FEX::ArgLoader {
         .dest("SMCChecks")
         .action("store_true")
         .help("Checks code for modification before execution. Slow.")
+        .set_default(false);
+      CPUGroup.add_option("--abi-local-flags")
+        .dest("AbiLocalFlags")
+        .action("store_true")
+        .help("Assume flags are not preserved across calls")
         .set_default(false);
 
       Parser.add_option_group(CPUGroup);
@@ -207,6 +212,10 @@ namespace FEX::ArgLoader {
       if (Options.is_set_by_user("SMCChecks")) {
         bool SMCChecks = Options.get("SMCChecks");
         Config::Add("SMCChecks", std::to_string(SMCChecks));
+      }
+      if (Options.is_set_by_user("AbiLocalFlags")) {
+        bool AbiLocalFlags = Options.get("AbiLocalFlags");
+        Config::Add("AbiLocalFlags", std::to_string(AbiLocalFlags));
       }
     }
 

--- a/Source/Common/ArgumentLoader.cpp
+++ b/Source/Common/ArgumentLoader.cpp
@@ -66,21 +66,22 @@ namespace FEX::ArgLoader {
           .help("Number of physical hardware threads to tell the process we have")
           .set_default(1);
 
-      CPUGroup.add_option("--disable-tso")
-        .dest("TSOEnabled")
-        .action("store_false")
-        .help("Disables TSO IR ops. Highly likely to break any threaded application")
-        .set_default(true);
-
       CPUGroup.add_option("--smc-full-checks")
         .dest("SMCChecks")
         .action("store_true")
         .help("Checks code for modification before execution. Slow.")
         .set_default(false);
-      CPUGroup.add_option("--abi-local-flags")
+
+      CPUGroup.add_option("--unsafe-no-tso")
+        .dest("TSOEnabled")
+        .action("store_false")
+        .help("Disables TSO IR ops. Highly likely to break any threaded application")
+        .set_default(true);
+
+      CPUGroup.add_option("--unsafe-local-flags")
         .dest("AbiLocalFlags")
         .action("store_true")
-        .help("Assume flags are not preserved across calls")
+        .help("Assumes flags are not used across calls")
         .set_default(false);
 
       Parser.add_option_group(CPUGroup);

--- a/Source/Tests/ELFLoader.cpp
+++ b/Source/Tests/ELFLoader.cpp
@@ -112,6 +112,7 @@ int main(int argc, char **argv, char **const envp) {
   FEX::Config::Value<bool> TSOEnabledConfig{"TSOEnabled", true};
   FEX::Config::Value<bool> SMCChecksConfig{"SMCChecks", false};
   FEX::Config::Value<bool> ABILocalFlags{"ABILocalFlags", false};
+  FEX::Config::Value<bool> AbiNoPF{"AbiNoPF", false};
 
   ::SilentLog = SilentLog();
 
@@ -158,6 +159,7 @@ int main(int argc, char **argv, char **const envp) {
   FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_TSO_ENABLED, TSOEnabledConfig());
   FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_SMC_CHECKS, SMCChecksConfig());
   FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_ABI_LOCAL_FLAGS, ABILocalFlags());
+  FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_ABI_NO_PF, AbiNoPF());
   FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_DUMPIR, DumpIR());
   
   FEXCore::Context::SetCustomCPUBackendFactory(CTX, VMFactory::CPUCreationFactory);

--- a/Source/Tests/ELFLoader.cpp
+++ b/Source/Tests/ELFLoader.cpp
@@ -111,6 +111,7 @@ int main(int argc, char **argv, char **const envp) {
   FEX::Config::Value<std::string> DumpIR{"DumpIR", "no"};
   FEX::Config::Value<bool> TSOEnabledConfig{"TSOEnabled", true};
   FEX::Config::Value<bool> SMCChecksConfig{"SMCChecks", false};
+  FEX::Config::Value<bool> ABILocalFlags{"ABILocalFlags", false};
 
   ::SilentLog = SilentLog();
 
@@ -156,6 +157,7 @@ int main(int argc, char **argv, char **const envp) {
   FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_EMULATED_CPU_CORES, ThreadsConfig());
   FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_TSO_ENABLED, TSOEnabledConfig());
   FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_SMC_CHECKS, SMCChecksConfig());
+  FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_ABI_LOCAL_FLAGS, ABILocalFlags());
   FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_DUMPIR, DumpIR());
   
   FEXCore::Context::SetCustomCPUBackendFactory(CTX, VMFactory::CPUCreationFactory);

--- a/Source/Tests/TestHarnessRunner.cpp
+++ b/Source/Tests/TestHarnessRunner.cpp
@@ -63,6 +63,8 @@ int main(int argc, char **argv, char **const envp) {
   FEX::Config::Value<bool> TSOEnabledConfig{"TSOEnabled", true};
   FEX::Config::Value<bool> SMCChecksConfig{"SMCChecks", false};
   FEX::Config::Value<bool> ABILocalFlags{"ABILocalFlags", false};
+  FEX::Config::Value<bool> AbiNoPF{"AbiNoPF", false};
+
   auto Args = FEX::ArgLoader::Get();
 
   LogMan::Throw::A(Args.size() > 1, "Not enough arguments");
@@ -82,6 +84,7 @@ int main(int argc, char **argv, char **const envp) {
   FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_TSO_ENABLED, TSOEnabledConfig());
   FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_SMC_CHECKS, SMCChecksConfig());
   FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_ABI_LOCAL_FLAGS, ABILocalFlags());
+  FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_ABI_NO_PF, AbiNoPF());
   FEXCore::Context::SetCustomCPUBackendFactory(CTX, HostCPUFactory::HostCPUCreationFactory);
 
   FEXCore::Context::AddGuestMemoryRegion(CTX, SHM);

--- a/Source/Tests/TestHarnessRunner.cpp
+++ b/Source/Tests/TestHarnessRunner.cpp
@@ -60,8 +60,9 @@ int main(int argc, char **argv, char **const envp) {
   FEX::Config::Value<uint64_t> BlockSizeConfig{"MaxInst", 1};
   FEX::Config::Value<bool> SingleStepConfig{"SingleStep", false};
   FEX::Config::Value<bool> MultiblockConfig{"Multiblock", false};
+  FEX::Config::Value<bool> TSOEnabledConfig{"TSOEnabled", true};
   FEX::Config::Value<bool> SMCChecksConfig{"SMCChecks", false};
-
+  FEX::Config::Value<bool> ABILocalFlags{"ABILocalFlags", false};
   auto Args = FEX::ArgLoader::Get();
 
   LogMan::Throw::A(Args.size() > 1, "Not enough arguments");
@@ -78,7 +79,9 @@ int main(int argc, char **argv, char **const envp) {
   FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_SINGLESTEP, SingleStepConfig());
   FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_MAXBLOCKINST, BlockSizeConfig());
   FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_IS64BIT_MODE, Loader.Is64BitMode());
+  FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_TSO_ENABLED, TSOEnabledConfig());
   FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_SMC_CHECKS, SMCChecksConfig());
+  FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_ABI_LOCAL_FLAGS, ABILocalFlags());
   FEXCore::Context::SetCustomCPUBackendFactory(CTX, HostCPUFactory::HostCPUCreationFactory);
 
   FEXCore::Context::AddGuestMemoryRegion(CTX, SHM);


### PR DESCRIPTION
- InvalidateFlags pseudo-op is a hint for the Dead Flags Elimination pass that flags are not needed past that point
- Adds a new option, --unsafe-local-flags, that invalidates the flags on CALLs or RETs. This might break code that doesn't follow the ABI rules.
- Adds a new option, --unsafe-no-pf, that doesn't calculate PF for integer operations. This might break code that actually uses PF.
- Renames --disable-tso to --unsafe-no-tso to group the options nicely