### PR TITLE
OpDisp: flags bypass

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -645,7 +645,11 @@ namespace FEXCore::Context {
         // Set the block entry point
         Thread->OpDispatcher->SetNewBlockIfChanged(Block.Entry);
 
+
         uint64_t BlockInstructionsLength {};
+
+        // Reset any block-specific state
+        Thread->OpDispatcher->StartNewBlock();
 
         uint64_t InstsInBlock = Block.NumInstructions;
         for (size_t i = 0; i < InstsInBlock; ++i) {

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -800,6 +800,47 @@ OrderedNode *OpDispatchBuilder::SelectCC(uint8_t OP, OrderedNode *TrueValue, Ord
     default: LogMan::Msg::A("Unknown CC Op: 0x%x\n", OP); return nullptr;
   }
 
+  // Try folding the flags generation in the select op
+  if (flagsOp == FLAGS_OP_CMP) {
+    switch(OP) {
+      // SGT
+      case 0xF: SrcCond = _Select(FEXCore::IR::COND_SGT, flagsOpDestSigned, flagsOpSrcSigned, TrueValue, FalseValue, flagsOpSize); break;
+      // SLE
+      case 0xE: SrcCond = _Select(FEXCore::IR::COND_SLE, flagsOpDestSigned, flagsOpSrcSigned, TrueValue, FalseValue, flagsOpSize); break;
+      // SGE
+      case 0xD: SrcCond = _Select(FEXCore::IR::COND_SGE, flagsOpDestSigned, flagsOpSrcSigned, TrueValue, FalseValue, flagsOpSize); break;
+      // SL
+      case 0xC: SrcCond = _Select(FEXCore::IR::COND_SLT, flagsOpDestSigned, flagsOpSrcSigned, TrueValue, FalseValue, flagsOpSize); break;
+      
+      // not sign
+      //case 0x99: SrcCond = _Select(FEXCore::IR::COND_, flagsOpDestSigned, flagsOpSrcSigned, TrueValue, FalseValue, flagsOpSize); break;
+      // sign
+      //case 0x98: SrcCond = _Select(FEXCore::IR::COND_, flagsOpDestSigned, flagsOpSrcSigned, TrueValue, FalseValue, flagsOpSize); break;
+      
+      // UABove
+      case 0x7: SrcCond = _Select(FEXCore::IR::COND_UGT, flagsOpDest, flagsOpSrc, TrueValue, FalseValue, flagsOpSize); break;
+      // UBE
+      case 0x6: SrcCond = _Select(FEXCore::IR::COND_ULE, flagsOpDest, flagsOpSrc, TrueValue, FalseValue, flagsOpSize); break;
+      // NE
+      case 0x5: SrcCond = _Select(FEXCore::IR::COND_NEQ, flagsOpDest, flagsOpSrc, TrueValue, FalseValue, flagsOpSize); break;
+      // EQ/Zero
+      case 0x4: SrcCond = _Select(FEXCore::IR::COND_EQ, flagsOpDest, flagsOpSrc, TrueValue, FalseValue, flagsOpSize); break;
+      // UAE
+      case 0x3: SrcCond = _Select(FEXCore::IR::COND_UGE, flagsOpDest, flagsOpSrc, TrueValue, FalseValue, flagsOpSize); break;
+      // UBelow
+      case 0x2: SrcCond = _Select(FEXCore::IR::COND_ULT, flagsOpDest, flagsOpSrc, TrueValue, FalseValue, flagsOpSize); break;
+
+      //default: printf("Missed Condition %04X OP_CMP\n", OP); break;
+    }
+  }
+  else if (flagsOp == FLAGS_OP_AND) {
+    switch(OP) {
+      case 0x4: SrcCond = _Select(FEXCore::IR::COND_EQ, flagsOpDest, ZeroConst, TrueValue, FalseValue, flagsOpSize); break;
+      case 0x5: SrcCond = _Select(FEXCore::IR::COND_NEQ, flagsOpDest, ZeroConst, TrueValue, FalseValue, flagsOpSize); break;
+      //default: printf("Missed Condition %04X OP_AND\n", OP); break;
+    }
+  }
+
   return SrcCond;
 }
 
@@ -1087,6 +1128,18 @@ void OpDispatchBuilder::TESTOp(OpcodeArgs) {
 
   auto ALUOp = _And(Dest, Src);
   GenerateFlags_Logical(Op, ALUOp, Dest, Src);
+  
+  auto Size = GetDstSize(Op);
+  
+  if (Size >=4) {
+    flagsOp = FLAGS_OP_AND;
+    flagsOpDest = ALUOp;
+    flagsOpSize = Size;
+  } else {
+    flagsOp = FLAGS_OP_AND;
+    flagsOpDest = ALUOp;
+    flagsOpSize = 4;  // assuming ZEXT semantics here
+  }
 }
 
 void OpDispatchBuilder::MOVSXDOp(OpcodeArgs) {
@@ -1149,6 +1202,18 @@ void OpDispatchBuilder::CMPOp(OpcodeArgs) {
   }
 
   GenerateFlags_SUB(Op, Result, Dest, Src);
+
+  if (Size >= 4) {
+    flagsOpSize = Size;
+    flagsOp = FLAGS_OP_CMP;
+    flagsOpDestSigned = flagsOpDest = Dest;
+    flagsOpSrcSigned = flagsOpSrc = Src;
+  } else {
+    flagsOpSize = 4;
+    flagsOp = FLAGS_OP_CMP;
+    flagsOpDestSigned = _Sext(Size * 8, flagsOpDest = Dest);
+    flagsOpSrcSigned = _Sext(Size * 8, flagsOpSrc = Src);
+  }
 }
 
 void OpDispatchBuilder::CQOOp(OpcodeArgs) {
@@ -4646,9 +4711,11 @@ void OpDispatchBuilder::ResetWorkingList() {
 
 template<unsigned BitOffset>
 void OpDispatchBuilder::SetRFLAG(OrderedNode *Value) {
+  flagsOp = FLAGS_OP_NONE;
   _StoreFlag(Value, BitOffset);
 }
 void OpDispatchBuilder::SetRFLAG(OrderedNode *Value, unsigned BitOffset) {
+  flagsOp = FLAGS_OP_NONE;
   _StoreFlag(Value, BitOffset);
 }
 

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -23,7 +23,19 @@ class PassManager;
 class OpDispatchBuilder final : public IREmitter {
 friend class FEXCore::IR::Pass;
 friend class FEXCore::IR::PassManager;
+
+enum {
+  FLAGS_OP_NONE,  // must rely on x86 flags
+  FLAGS_OP_CMP,   // flags were set by a CMP between flagsOpDest/flagsOpDestSigned and flagsOpSrc/flagsOpSrcSigned with flagsOpSize size
+  FLAGS_OP_AND,   // flags were set by an AND/TEST, flagsOpDest contains the resulting value of flagsOpSize size
+};
+
 public:
+  int flagsOp;
+  uint8_t flagsOpSize;
+  OrderedNode* flagsOpDest, *flagsOpSrc;
+  OrderedNode* flagsOpDestSigned, *flagsOpSrcSigned;
+
   FEXCore::Context::Context *CTX{};
   bool ShouldDump {false};
 
@@ -51,6 +63,10 @@ public:
     // We have hit a RIP that is a jump target
     // Thus we need to end up in a new block
     SetCurrentCodeBlock(it->second.BlockEntry);
+  }
+
+  void StartNewBlock() {
+    flagsOp = FLAGS_OP_NONE;
   }
 
   bool FinishOp(uint64_t NextRIP, bool LastOp) {


### PR DESCRIPTION
This

- Adds special cases for when the flags are a result of a cmp or a test

depends on #488, #491, #499 