### PR TITLE
CondJump: Add support for two operands to match Select

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -511,12 +511,12 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
             break;
           case IR::OP_CONDJUMP: {
             auto Op = IROp->C<IR::IROp_CondJump>();
-            uint64_t Arg = *GetSrc<uint64_t*>(SSAData, Op->Header.Args[0]);
+            uint64_t Arg = *GetSrc<uint64_t*>(SSAData, Op->Cmp1);
             if (!!Arg) {
-              BlockIterator = NodeIterator(ListBegin, DataBegin, Op->Header.Args[1]);
+              BlockIterator = NodeIterator(ListBegin, DataBegin, Op->TrueBlock);
             }
             else  {
-              BlockIterator = NodeIterator(ListBegin, DataBegin, Op->Header.Args[2]);
+              BlockIterator = NodeIterator(ListBegin, DataBegin, Op->FalseBlock);
             }
             BlockResults.Redo = true;
             return;

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -511,8 +511,17 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
             break;
           case IR::OP_CONDJUMP: {
             auto Op = IROp->C<IR::IROp_CondJump>();
-            uint64_t Arg = *GetSrc<uint64_t*>(SSAData, Op->Cmp1);
-            if (!!Arg) {
+            bool CompResult;
+
+            uint64_t Src1 = *GetSrc<uint64_t*>(SSAData, Op->Cmp1);
+            uint64_t Src2 = *GetSrc<uint64_t*>(SSAData, Op->Cmp2);
+
+            if (Op->CompareSize == 4)
+              CompResult = IsConditionTrue<uint32_t, int32_t>(Op->Cond.Val, Src1, Src2);
+            else
+              CompResult = IsConditionTrue<uint64_t, int64_t>(Op->Cond.Val, Src1, Src2);
+
+            if (CompResult) {
               BlockIterator = NodeIterator(ListBegin, DataBegin, Op->TrueBlock);
             }
             else  {

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
@@ -117,9 +117,9 @@ DEF_OP(CondJump) {
   uint64_t Const;
   bool isConst = IsInlineConstant(Op->Cmp2, &Const);
 
-  if (isConst && Const == 0 && Op->Operation.Val == FEXCore::IR::COND_EQ) {
+  if (isConst && Const == 0 && Op->Cond.Val == FEXCore::IR::COND_EQ) {
     cbz(GRCMP(Op->Cmp1.ID()), TrueTargetLabel);
-  } else if (isConst && Const == 0 && Op->Operation.Val == FEXCore::IR::COND_NEQ) {
+  } else if (isConst && Const == 0 && Op->Cond.Val == FEXCore::IR::COND_NEQ) {
     cbnz(GRCMP(Op->Cmp1.ID()), TrueTargetLabel);
   } else {
     if (isConst)
@@ -127,7 +127,7 @@ DEF_OP(CondJump) {
     else
       cmp(GRCMP(Op->Cmp1.ID()), GRCMP(Op->Cmp2.ID()));
 
-    b(TrueTargetLabel, MapBranchCC(Op->Operation));
+    b(TrueTargetLabel, MapBranchCC(Op->Cond));
   }
   
   if (FalseIter == JumpTargets.end()) {

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
@@ -95,25 +95,25 @@ DEF_OP(CondJump) {
   Label *TrueTargetLabel;
   Label *FalseTargetLabel;
 
-  auto TrueIter = JumpTargets.find(Op->Header.Args[1].ID());
-  auto FalseIter = JumpTargets.find(Op->Header.Args[2].ID());
+  auto TrueIter = JumpTargets.find(Op->TrueBlock.ID());
+  auto FalseIter = JumpTargets.find(Op->FalseBlock.ID());
 
   if (TrueIter == JumpTargets.end()) {
-    TrueTargetLabel = &JumpTargets.try_emplace(Op->Header.Args[1].ID()).first->second;
+    TrueTargetLabel = &JumpTargets.try_emplace(Op->TrueBlock.ID()).first->second;
   }
   else {
     TrueTargetLabel = &TrueIter->second;
   }
 
   if (FalseIter == JumpTargets.end()) {
-    FalseTargetLabel = &JumpTargets.try_emplace(Op->Header.Args[2].ID()).first->second;
+    FalseTargetLabel = &JumpTargets.try_emplace(Op->FalseBlock.ID()).first->second;
   }
   else {
     FalseTargetLabel = &FalseIter->second;
   }
 
   // Take branch if (src != 0)
-  cmp(GetSrc<RA_64>(Op->Header.Args[0].ID()), 0);
+  cmp(GetSrc<RA_64>(Op->Cmp1.ID()), 0);
   jne(*TrueTargetLabel, T_NEAR);
 
   PendingTargetLabel = FalseTargetLabel;

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -365,12 +365,17 @@
     "CondJump": {
       "HasSideEffects": true,
       "OpClass": "Branch",
-      "SSAArgs": "3",
-      "RAOverride": "1",
+      "SSAArgs": "4",
+      "RAOverride": "2",
       "SSANames": [
-        "Cond",
+        "Cmp1",
+        "Cmp2",
         "TrueBlock",
         "FalseBlock"
+      ],
+      "Args": [
+        "CondClassType", "Cond",
+        "uint8_t", "CompareSize"
       ]
     },
 

--- a/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -284,8 +284,8 @@ bool ConstProp::Run(IREmitter *IREmit) {
         if (IREmit->IsValueConstant(Select->Args[2], &Constant1) && IREmit->IsValueConstant(Select->Args[3], &Constant2)) {
           if (Constant1 == 1 && Constant2 == 0) {
             auto slc = Select->C<IR::IROp_Select>();
-            IREmit->ReplaceNodeArgument(CodeNode, 0, IREmit->UnwarpNode(Select->Args[0]));
-            IREmit->ReplaceNodeArgument(CodeNode, 1, IREmit->UnwarpNode(Select->Args[1]));
+            IREmit->ReplaceNodeArgument(CodeNode, 0, IREmit->UnwrapNode(Select->Args[0]));
+            IREmit->ReplaceNodeArgument(CodeNode, 1, IREmit->UnwrapNode(Select->Args[1]));
             Op->Cond = slc->Cond;
             Op->CompareSize = slc->CompareSize;
             Changed = true;

--- a/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -268,6 +268,29 @@ bool ConstProp::Run(IREmitter *IREmit) {
       }
       break;
     }
+
+    case OP_CONDJUMP: {
+      auto Op = IROp->CW<IR::IROp_CondJump>();
+
+      auto Select = IREmit->GetOpHeader(Op->Header.Args[0]);
+      if (Select->Op == OP_SELECT) {
+        
+        uint64_t Constant1;
+        uint64_t Constant2;
+
+        if (IREmit->IsValueConstant(Select->Args[2], &Constant1) && IREmit->IsValueConstant(Select->Args[3], &Constant2)) {
+          if (Constant1 == 1 && Constant2 == 0) {
+            auto slc = Select->C<IR::IROp_Select>();
+            IREmit->ReplaceNodeArgument(CodeNode, 0, IREmit->UnwarpNode(Select->Args[0]));
+            IREmit->ReplaceNodeArgument(CodeNode, 1, IREmit->UnwarpNode(Select->Args[1]));
+            Op->Cond = slc->Cond;
+            Op->CompareSize = slc->CompareSize;
+            Changed = true;
+            continue;
+          }
+        }
+      }
+    }
     default: break;
     }
   }
@@ -346,6 +369,23 @@ bool ConstProp::Run(IREmitter *IREmit) {
             IREmit->ReplaceNodeArgument(CodeNode, 3, IREmit->_InlineConstant(Constant3));
           }
 
+          break;
+        }
+
+        case OP_CONDJUMP:
+        {
+          auto Op = IROp->C<IR::IROp_CondJump>();
+
+          uint64_t Constant2;
+          if (IREmit->IsValueConstant(Op->Header.Args[1], &Constant2)) {
+            if (IsImmAddSub(Constant2)) {
+              IREmit->SetWriteCursor(CurrentIR.GetNode(Op->Header.Args[1]));
+
+              IREmit->ReplaceNodeArgument(CodeNode, 1, IREmit->_InlineConstant(Constant2));
+              
+              Changed = true;
+            }
+          }
           break;
         }
 

--- a/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -273,7 +273,10 @@ bool ConstProp::Run(IREmitter *IREmit) {
       auto Op = IROp->CW<IR::IROp_CondJump>();
 
       auto Select = IREmit->GetOpHeader(Op->Header.Args[0]);
-      if (Select->Op == OP_SELECT) {
+      
+      uint64_t Constant;
+      // Fold the select into the CondJump if possible. Could handle more complex cases, too.
+      if (Op->Cond.Val == COND_NEQ && IREmit->IsValueConstant(Op->Cmp2, &Constant) && Constant == 0 &&  Select->Op == OP_SELECT) {
         
         uint64_t Constant1;
         uint64_t Constant2;

--- a/External/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
@@ -324,19 +324,19 @@ void RCLSE::CalculateControlFlowInfo(FEXCore::IR::IREmitter *IREmit) {
         case IR::OP_CONDJUMP: {
           auto Op = IROp->CW<IR::IROp_CondJump>();
 
-          OrderedNode *TrueTargetNode = CurrentIR.GetNode(Op->Header.Args[1]);
-          OrderedNode *FalseTargetNode = CurrentIR.GetNode(Op->Header.Args[2]);
+          OrderedNode *TrueTargetNode = CurrentIR.GetNode(Op->TrueBlock);
+          OrderedNode *FalseTargetNode = CurrentIR.GetNode(Op->FalseBlock);
 
           CurrentBlock->Successors.emplace_back(TrueTargetNode);
           CurrentBlock->Successors.emplace_back(FalseTargetNode);
 
           {
-            auto Block = &OffsetToBlockMap.try_emplace(Op->Header.Args[1].ID()).first->second;
+            auto Block = &OffsetToBlockMap.try_emplace(Op->TrueBlock.ID()).first->second;
             Block->Predecessors.emplace_back(BlockNode);
           }
 
           {
-            auto Block = &OffsetToBlockMap.try_emplace(Op->Header.Args[2].ID()).first->second;
+            auto Block = &OffsetToBlockMap.try_emplace(Op->FalseBlock.ID()).first->second;
             Block->Predecessors.emplace_back(BlockNode);
           }
 

--- a/External/FEXCore/Source/Interface/IR/Passes/DeadFlagStoreElimination.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/DeadFlagStoreElimination.cpp
@@ -72,8 +72,8 @@ bool DeadFlagStoreElimination::Run(IREmitter *IREmit) {
         else if (IROp->Op == OP_CONDJUMP) {
           auto Op = IROp->CW<IR::IROp_CondJump>();
 
-          OrderedNode *TrueTargetNode = CurrentIR.GetNode(Op->Header.Args[1]);
-          OrderedNode *FalseTargetNode = CurrentIR.GetNode(Op->Header.Args[2]);
+          OrderedNode *TrueTargetNode = CurrentIR.GetNode(Op->TrueBlock);
+          OrderedNode *FalseTargetNode = CurrentIR.GetNode(Op->FalseBlock);
 
           // stores to remove are written by the next blocks but not read
           FlagMap[BlockNode].kill = FlagMap[TrueTargetNode].writes & ~(FlagMap[TrueTargetNode].reads);

--- a/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
@@ -144,8 +144,8 @@ bool IRValidation::Run(IREmitter *IREmit) {
         case IR::OP_CONDJUMP: {
           auto Op = IROp->C<IR::IROp_CondJump>();
 
-          OrderedNode *TrueTargetNode = CurrentIR.GetNode(Op->Header.Args[1]);
-          OrderedNode *FalseTargetNode = CurrentIR.GetNode(Op->Header.Args[2]);
+          OrderedNode *TrueTargetNode = CurrentIR.GetNode(Op->TrueBlock);
+          OrderedNode *FalseTargetNode = CurrentIR.GetNode(Op->FalseBlock);
 
           CurrentBlock->Successors.emplace_back(TrueTargetNode);
           CurrentBlock->Successors.emplace_back(FalseTargetNode);
@@ -158,7 +158,7 @@ bool IRValidation::Run(IREmitter *IREmit) {
             Errors << "CondJump %ssa" << ID << ": True Target Jumps to Op that isn't the begining of a block" << std::endl;
           }
           else {
-            auto Block = OffsetToBlockMap.try_emplace(Op->Header.Args[1].ID()).first;
+            auto Block = OffsetToBlockMap.try_emplace(Op->TrueBlock.ID()).first;
             Block->second.Predecessors.emplace_back(BlockNode);
           }
 
@@ -167,7 +167,7 @@ bool IRValidation::Run(IREmitter *IREmit) {
             Errors << "CondJump %ssa" << ID << ": False Target Jumps to Op that isn't the begining of a block" << std::endl;
           }
           else {
-            auto Block = OffsetToBlockMap.try_emplace(Op->Header.Args[2].ID()).first;
+            auto Block = OffsetToBlockMap.try_emplace(Op->FalseBlock.ID()).first;
             Block->second.Predecessors.emplace_back(BlockNode);
           }
 

--- a/External/FEXCore/Source/Interface/IR/Passes/ValueDominanceValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ValueDominanceValidation.cpp
@@ -38,19 +38,19 @@ bool ValueDominanceValidation::Run(IREmitter *IREmit) {
         case IR::OP_CONDJUMP: {
           auto Op = IROp->CW<IR::IROp_CondJump>();
 
-          OrderedNode *TrueTargetNode = CurrentIR.GetNode(Op->Header.Args[1]);
-          OrderedNode *FalseTargetNode = CurrentIR.GetNode(Op->Header.Args[2]);
+          OrderedNode *TrueTargetNode = CurrentIR.GetNode(Op->TrueBlock);
+          OrderedNode *FalseTargetNode = CurrentIR.GetNode(Op->FalseBlock);
 
           CurrentBlock->Successors.emplace_back(TrueTargetNode);
           CurrentBlock->Successors.emplace_back(FalseTargetNode);
 
           {
-            auto Block = &OffsetToBlockMap.try_emplace(Op->Header.Args[1].ID()).first->second;
+            auto Block = &OffsetToBlockMap.try_emplace(Op->TrueBlock.ID()).first->second;
             Block->Predecessors.emplace_back(BlockNode);
           }
 
           {
-            auto Block = &OffsetToBlockMap.try_emplace(Op->Header.Args[2].ID()).first->second;
+            auto Block = &OffsetToBlockMap.try_emplace(Op->FalseBlock.ID()).first->second;
             Block->Predecessors.emplace_back(BlockNode);
           }
 

--- a/External/FEXCore/include/FEXCore/IR/IREmitter.h
+++ b/External/FEXCore/include/FEXCore/IR/IREmitter.h
@@ -443,6 +443,10 @@ friend class FEXCore::IR::PassManager;
     return RealNode->Op(Data.Begin());
   }
 
+  OrderedNode *UnwarpNode(OrderedNodeWrapper ssa) {
+    return ssa.GetNode(ListData.Begin());
+  }
+
   // Overwrite a node with a constant
   // Depending on what node has been overwritten, there might be some unallocated space around the node
   // Because we are overwriting the node, we don't have to worry about update all the arguments which use it

--- a/External/FEXCore/include/FEXCore/IR/IREmitter.h
+++ b/External/FEXCore/include/FEXCore/IR/IREmitter.h
@@ -331,8 +331,13 @@ friend class FEXCore::IR::PassManager;
   IRPair<IROp_Jump> _Jump() {
     return _Jump(InvalidNode);
   }
+
   IRPair<IROp_CondJump> _CondJump(OrderedNode *ssa0) {
-    return _CondJump(ssa0, InvalidNode, InvalidNode);
+    return _CondJump(ssa0, _Constant(0), InvalidNode, InvalidNode, {COND_NEQ}, GetOpSize(ssa0));
+  }
+
+  IRPair<IROp_CondJump> _CondJump(OrderedNode *ssa0, OrderedNode *ssa1, OrderedNode *ssa2) {
+    return _CondJump(ssa0, _Constant(0), ssa1, ssa2, {COND_NEQ}, GetOpSize(ssa0));
   }
 
   IRPair<IROp_Phi> _Phi() {
@@ -377,7 +382,7 @@ friend class FEXCore::IR::PassManager;
         Target->Wrapped(ListData.Begin()).ID(),
         std::string(IR::GetName(Target->Op(Data.Begin())->Op)).c_str());
 
-    Op->Header.Args[1].NodeOffset = Target->Wrapped(ListData.Begin()).NodeOffset;
+    Op->TrueBlock.NodeOffset = Target->Wrapped(ListData.Begin()).NodeOffset;
   }
   void SetFalseJumpTarget(IR::IROp_CondJump *Op, OrderedNode *Target) {
     LogMan::Throw::A(Target->Op(Data.Begin())->Op == OP_CODEBLOCK,
@@ -385,7 +390,7 @@ friend class FEXCore::IR::PassManager;
         Target->Wrapped(ListData.Begin()).ID(),
         std::string(IR::GetName(Target->Op(Data.Begin())->Op)).c_str());
 
-    Op->Header.Args[2].NodeOffset = Target->Wrapped(ListData.Begin()).NodeOffset;
+    Op->FalseBlock.NodeOffset = Target->Wrapped(ListData.Begin()).NodeOffset;
   }
 
   void SetJumpTarget(IRPair<IROp_Jump> Op, OrderedNode *Target) {
@@ -401,14 +406,14 @@ friend class FEXCore::IR::PassManager;
         "Tried setting CondJump target to %%ssa%d %s",
         Target->Wrapped(ListData.Begin()).ID(),
         std::string(IR::GetName(Target->Op(Data.Begin())->Op)).c_str());
-    Op.first->Header.Args[1].NodeOffset = Target->Wrapped(ListData.Begin()).NodeOffset;
+    Op.first->TrueBlock.NodeOffset = Target->Wrapped(ListData.Begin()).NodeOffset;
   }
   void SetFalseJumpTarget(IRPair<IROp_CondJump> Op, OrderedNode *Target) {
     LogMan::Throw::A(Target->Op(Data.Begin())->Op == OP_CODEBLOCK,
         "Tried setting CondJump target to %%ssa%d %s",
         Target->Wrapped(ListData.Begin()).ID(),
         std::string(IR::GetName(Target->Op(Data.Begin())->Op)).c_str());
-    Op.first->Header.Args[2].NodeOffset = Target->Wrapped(ListData.Begin()).NodeOffset;
+    Op.first->FalseBlock.NodeOffset = Target->Wrapped(ListData.Begin()).NodeOffset;
   }
 
   /**  @} */

--- a/External/FEXCore/include/FEXCore/IR/IREmitter.h
+++ b/External/FEXCore/include/FEXCore/IR/IREmitter.h
@@ -443,7 +443,7 @@ friend class FEXCore::IR::PassManager;
     return RealNode->Op(Data.Begin());
   }
 
-  OrderedNode *UnwarpNode(OrderedNodeWrapper ssa) {
+  OrderedNode *UnwrapNode(OrderedNodeWrapper ssa) {
     return ssa.GetNode(ListData.Begin());
   }
 


### PR DESCRIPTION
Depends on #488

- Renames Cond to Cmp1, adds Cmp2, adds Cond as a CC (to match select), backwards compatible emit that does Cmp2 = 0, CC = NEQ
- Adds support to the backends for Cmp1/Cmp2 & Cond, with special cases for == 0, !=0 and Cmp2 being a const
- Optimization to fold Selects to CondJumps whenever possible

*rebased and re-re-re-reviewed*