### PR TITLE
ConstProp: Do inline constants in a separate loop

### DIFF
--- a/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -239,8 +239,10 @@ bool ConstProp::Run(IREmitter *IREmit) {
     }
     default: break;
     }
+  }
 
-    if (!HeaderOp->ShouldInterpret && InlineConstants) {
+  if (!HeaderOp->ShouldInterpret && InlineConstants) {
+    for (auto [CodeNode, IROp] : CurrentIR.GetAllCode()) {
       switch(IROp->Op) {
         case OP_LSHR:
         case OP_ASHR:


### PR DESCRIPTION
This is required for the rest of PRs. I'll split into a separate pass after we merge all the changes.