### PR TITLE
BlockCache: Add a cache for faster lookups

### DIFF
--- a/External/FEXCore/Source/Interface/Core/BlockCache.h
+++ b/External/FEXCore/Source/Interface/Core/BlockCache.h
@@ -23,7 +23,7 @@ public:
 
   void Erase(uint64_t Address) {
     // Do L1
-    auto &L1Entry = reinterpret_cast<BlockCacheEntry*>(L1Pointer)[Address & (L1_ENTRIES -1)];
+    auto &L1Entry = reinterpret_cast<BlockCacheEntry*>(L1Pointer)[Address & L1_ENTRIES_MASK];
     if (L1Entry.GuestCode == Address) {
       L1Entry.GuestCode = L1Entry.HostCode = 0;
     }
@@ -48,7 +48,7 @@ public:
 
   uintptr_t AddBlockMapping(uint64_t Address, void *Ptr) { 
     // Do L1
-    auto &L1Entry = reinterpret_cast<BlockCacheEntry*>(L1Pointer)[Address & (L1_ENTRIES -1)];
+    auto &L1Entry = reinterpret_cast<BlockCacheEntry*>(L1Pointer)[Address & L1_ENTRIES_MASK];
     if (L1Entry.GuestCode == Address) {
       L1Entry.GuestCode = L1Entry.HostCode = 0;
     }
@@ -92,6 +92,9 @@ public:
   uintptr_t GetPagePointer() { return PagePointer; }
   uintptr_t GetVirtualMemorySize() const { return VirtualMemSize; }
 
+  constexpr static size_t L1_ENTRIES = 1 * 1024 * 1024; // Must be a power of 2
+  constexpr static size_t L1_ENTRIES_MASK = L1_ENTRIES - 1;
+
 private:
   uintptr_t AllocateBackingForPage() {
     uintptr_t NewBase = AllocateOffset;
@@ -110,7 +113,7 @@ private:
   uintptr_t FindCodePointerForAddress(uint64_t Address) {
     
     // Do L1
-    auto &L1Entry = reinterpret_cast<BlockCacheEntry*>(L1Pointer)[Address & (L1_ENTRIES -1)];
+    auto &L1Entry = reinterpret_cast<BlockCacheEntry*>(L1Pointer)[Address & L1_ENTRIES_MASK];
     if (L1Entry.GuestCode == Address) {
       return L1Entry.HostCode;
     }
@@ -145,7 +148,6 @@ private:
 
   constexpr static size_t CODE_SIZE = 128 * 1024 * 1024;
   constexpr static size_t SIZE_PER_PAGE = 4096 * sizeof(BlockCacheEntry);
-  constexpr static size_t L1_ENTRIES = 1 * 1024 * 1024;
   constexpr static size_t L1_SIZE = L1_ENTRIES * sizeof(BlockCacheEntry);
 
   size_t AllocateOffset {};

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -997,7 +997,7 @@ void JITCore::CreateCustomDispatch(FEXCore::Core::InternalThreadState *Thread) {
   // L1 Cache
   LoadConstant(x0, Thread->BlockCache->GetL1Pointer());
 
-  and_(x3, RipReg, 1 * 1024 * 1024 - 1);
+  and_(x3, RipReg, BlockCache::L1_ENTRIES_MASK);
   add(x0, x0, Operand(x3, Shift::LSL, 4));
   ldp(x1, x0, MemOperand(x0));
   cmp(x0, RipReg);
@@ -1053,7 +1053,7 @@ void JITCore::CreateCustomDispatch(FEXCore::Core::InternalThreadState *Thread) {
       // update L1 cache
       LoadConstant(x0, Thread->BlockCache->GetL1Pointer());
 
-      and_(x1, RipReg, 1 * 1024 * 1024 - 1);
+      and_(x1, RipReg, BlockCache::L1_ENTRIES_MASK);
       add(x0, x0, Operand(x1, Shift::LSL, 4));
       stp(x3, x2, MemOperand(x0));
       blr(x3);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -850,7 +850,7 @@ void JITCore::CreateCustomDispatch(FEXCore::Core::InternalThreadState *Thread) {
     mov(r13, Thread->BlockCache->GetL1Pointer());
     mov(rax, rdx);
 
-    and_(rax, 1 * 1024 * 1024 - 1);
+    and_(rax, BlockCache::L1_ENTRIES_MASK);
     shl(rax, 4);
     cmp(qword[r13 + rax + 8], rdx);
     jne(FullLookup);
@@ -891,7 +891,7 @@ void JITCore::CreateCustomDispatch(FEXCore::Core::InternalThreadState *Thread) {
     // Update L1
     mov(r13, Thread->BlockCache->GetL1Pointer());
     mov(rcx, rdx);
-    and_(rcx, 1 * 1024 * 1024 - 1);
+    and_(rcx, BlockCache::L1_ENTRIES_MASK);
     shl(rcx, 1);
     mov(qword[r13 + rcx*8 + 8], rdx);
     mov(qword[r13 + rcx*8 + 0], rax);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -836,18 +836,31 @@ void JITCore::CreateCustomDispatch(FEXCore::Core::InternalThreadState *Thread) {
   mov(qword [STATE + offsetof(FEXCore::Core::ThreadState, ReturningStackLocation)], rsp);
 
   Label LoopTop;
+  Label FullLookup;
   Label NoBlock;
   Label ThreadPauseHandler{};
 
   L(LoopTop);
   AbsoluteLoopTopAddress = getCurr<uint64_t>();
-
   {
-    mov(r13, Thread->BlockCache->GetPagePointer());
-
     // Load our RIP
     mov(rdx, qword [STATE + offsetof(FEXCore::Core::CPUState, rip)]);
 
+    // L1 Cache
+    mov(r13, Thread->BlockCache->GetL1Pointer());
+    mov(rax, rdx);
+
+    and_(rax, 1 * 1024 * 1024 - 1);
+    shl(rax, 4);
+    cmp(qword[r13 + rax + 8], rdx);
+    jne(FullLookup);
+    call(qword[r13 + rax + 0]);
+    jmp(LoopTop);
+    
+    L(FullLookup);   
+    mov(r13, Thread->BlockCache->GetPagePointer());
+
+    // Full lookup
     mov(rax, rdx);
     mov(rbx, Thread->BlockCache->GetVirtualMemorySize() - 1);
     and_(rax, rbx);
@@ -875,6 +888,14 @@ void JITCore::CreateCustomDispatch(FEXCore::Core::InternalThreadState *Thread) {
     cmp(rax, 0);
     je(NoBlock);
 
+    // Update L1
+    mov(r13, Thread->BlockCache->GetL1Pointer());
+    mov(rcx, rdx);
+    and_(rcx, 1 * 1024 * 1024 - 1);
+    shl(rcx, 1);
+    mov(qword[r13 + rcx*8 + 8], rdx);
+    mov(qword[r13 + rcx*8 + 0], rax);
+    
     // Real block if we made it here
     call(rax);
 

--- a/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -289,7 +289,7 @@ bool ConstProp::Run(IREmitter *IREmit) {
       case OP_ROR: {
         for (int i = 0; i < IROp->NumArgs; i++) {
           auto newArg = RemoveUselessMasking(IREmit, IROp->Args[i], getMask(IROp));
-          if (newArg != IROp->Args[i]) {
+          if (newArg.ID() != IROp->Args[i].ID()) {
             IREmit->ReplaceNodeArgument(CodeNode, i, IREmit->UnwrapNode(newArg));
             Changed = true;
           }
@@ -307,7 +307,7 @@ bool ConstProp::Run(IREmitter *IREmit) {
 
           auto newArg = RemoveUselessMasking(IREmit, IROp->Args[i], imm);
 
-          if (newArg != IROp->Args[i]) {
+          if (newArg.ID() != IROp->Args[i].ID()) {
             IREmit->ReplaceNodeArgument(CodeNode, i, IREmit->UnwrapNode(newArg));
             Changed = true;
           }
@@ -348,7 +348,7 @@ bool ConstProp::Run(IREmitter *IREmit) {
 
         auto newArg = RemoveUselessMasking(IREmit, IROp->Args[0], imm);
 
-        if (newArg != IROp->Args[0]) {
+        if (newArg.ID() != IROp->Args[0].ID()) {
           IREmit->ReplaceNodeArgument(CodeNode, 0, IREmit->UnwrapNode(newArg));
           Changed = true;
         }
@@ -365,7 +365,7 @@ bool ConstProp::Run(IREmitter *IREmit) {
 
         auto newArg = RemoveUselessMasking(IREmit, IROp->Args[0], imm);
 
-        if (newArg != IROp->Args[0]) {
+        if (newArg.ID() != IROp->Args[0].ID()) {
           IREmit->ReplaceNodeArgument(CodeNode, 0, IREmit->UnwrapNode(newArg));
           Changed = true;
         }
@@ -608,7 +608,7 @@ bool ConstProp::Run(IREmitter *IREmit) {
         Changed = true;
       } else {
         auto newArg = RemoveUselessMasking(IREmit, Op->Header.Args[1], IROp->Size * 8 - 1);
-        if (newArg != Op->Header.Args[1]) {
+        if (newArg.ID() != Op->Header.Args[1].ID()) {
           IREmit->ReplaceNodeArgument(CodeNode, 1, IREmit->UnwrapNode(newArg));
           Changed = true;
         }
@@ -634,7 +634,7 @@ bool ConstProp::Run(IREmitter *IREmit) {
         Changed = true;
       } else {
         auto newArg = RemoveUselessMasking(IREmit, Op->Header.Args[1], IROp->Size * 8 - 1);
-        if (newArg != Op->Header.Args[1]) {
+        if (newArg.ID() != Op->Header.Args[1].ID()) {
           IREmit->ReplaceNodeArgument(CodeNode, 1, IREmit->UnwrapNode(newArg));
           Changed = true;
         }


### PR DESCRIPTION
## Overview
This adds an direct cache (1M entries) for the block lookups. Lookups in the Cache are /much/ faster than full lookups, leading to overall speedup. The cache structure is also friendly to atomic modifications.

The cache hit rate is > 98% based on my testing, though it depends on the complexity of the guest app.

This also switches to dispatching via jmp instead of call/ret, and does inline dispatch at the end of each block.

## Generic Block Lookup
```
auto& Entry = Cache[Addr & MASK];
if (Entry.Guest == Addr) {
  return Entry.Host;
} else {
  HostAddr = FullLookup();
  Entry.Guest = Addr;
  Entry.Host = HostAddr;
  return HostAddr;
}
```

## X86 Lookup
```
  mov(r13, ThreadState->BlockCache->GetL1Pointer());
  mov(rax, rdx);

  and_(rax, 1 * 1024 * 1024 - 1);
  shl(rax, 1);
  cmp(qword[r13 + rax*8 + 0], rdx);
  jne(FullLookup);
  call(qword[r13 + rax*8 + 8]);
```

## ARM64 Lookup
```
  and_(x3, RipReg, 1 * 1024 * 1024 - 1);
  add(x0, x0, Operand(x3, Shift::LSL, 4));
  ldp(x0, x1, MemOperand(x0));
  cmp(x0, RipReg);
  b(&FullLookup, Condition::ne);
  blr(x1)
```

## Follow ups
- [ ] Embed the pointers to some context param
- [ ] Simplify dispatcher (Compile and such is shouldn't be in assembly)
- [ ] Do distributed dispatching
- [ ] Do block linking