### PR TITLE
Block linking

### DIFF
--- a/External/FEXCore/Source/Interface/Core/BlockCache.cpp
+++ b/External/FEXCore/Source/Interface/Core/BlockCache.cpp
@@ -56,6 +56,8 @@ void BlockCache::ClearCache() {
   madvise(reinterpret_cast<void*>(PageMemory), CODE_SIZE, MADV_DONTNEED);
   madvise(reinterpret_cast<void*>(L1Pointer), L1_SIZE, MADV_DONTNEED);
   AllocateOffset = 0;
+  // All code is gone, remove links
+  BlockLinks.clear();
 }
 
 }

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -201,12 +201,15 @@ private:
   void PushCalleeSavedRegisters();
   void PopCalleeSavedRegisters();
 
+  static uint64_t ExitFunctionLink(JITCore *core, FEXCore::Core::InternalThreadState *Thread, uint64_t *record);
+
   /**
    * @name Dispatch Helper functions
    * @{ */
   uint64_t AbsoluteLoopTopAddressFillSRA{};
   uint64_t AbsoluteLoopTopAddress{};
   uint64_t ThreadPauseHandlerAddressSpillSRA{};
+  uint64_t ExitFunctionLinkerAddress{};
   uint64_t ThreadPauseHandlerAddress{};
 
   uint64_t ThreadStopHandlerAddressSpillSRA{};

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -801,6 +801,20 @@ static void SleepThread(FEXCore::Context::Context *ctx, FEXCore::Core::InternalT
   ctx->IdleWaitCV.notify_all();
 }
 
+uint64_t JITCore::ExitFunctionLink(JITCore *core, FEXCore::Core::InternalThreadState *Thread, uint64_t *record) {
+  auto GuestRip = record[1];
+
+  auto HostCode = Thread->BlockCache->FindBlock(GuestRip);
+
+  if (!HostCode) {
+    Thread->State.State.rip = GuestRip;
+    return core->AbsoluteLoopTopAddress;
+  }
+
+  record[0] = HostCode;
+  return HostCode;
+}
+
 void JITCore::CreateCustomDispatch(FEXCore::Core::InternalThreadState *Thread) {
   DispatcherCodeBuffer = AllocateNewCodeBuffer(MAX_DISPATCHER_CODE_SIZE);
   setNewBuffer(DispatcherCodeBuffer.Ptr, DispatcherCodeBuffer.Size);
@@ -931,6 +945,18 @@ void JITCore::CreateCustomDispatch(FEXCore::Core::InternalThreadState *Thread) {
     ret();
   }
 
+  {
+    ExitFunctionLinkerAddress = getCurr<uint64_t>();
+    // {rdi, rsi, rdx}
+    mov(rdi, (uintptr_t)this);
+    mov(rsi, STATE);
+    mov(rdx, rax); // rax is set at the block end
+
+    mov(rax, (uintptr_t)&ExitFunctionLink);
+    call(rax);
+    jmp(rax);
+  }
+  
   Label FallbackCore;
   // Block creation
   {

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -811,6 +811,12 @@ uint64_t JITCore::ExitFunctionLink(JITCore *core, FEXCore::Core::InternalThreadS
     return core->AbsoluteLoopTopAddress;
   }
 
+  auto LinkerAddress = core->ExitFunctionLinkerAddress;
+  Thread->BlockCache->AddBlockLink(GuestRip, (uintptr_t)record, [record, LinkerAddress]{
+    // undo the link
+    record[0] = LinkerAddress;
+  });
+
   record[0] = HostCode;
   return HostCode;
 }

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -139,6 +139,8 @@ private:
     CurrentCodeBuffer = &CodeBuffers.emplace_back(Buffer);
   }
 
+  static uint64_t ExitFunctionLink(JITCore* code, FEXCore::Core::InternalThreadState *Thread, uint64_t *record);
+
   // This is the initial code buffer that we will fall back to
   // In a program without signals and code clearing, we will typically
   // only have this code buffer
@@ -154,6 +156,7 @@ private:
   CodeBuffer *CurrentCodeBuffer{};
 
   uint64_t AbsoluteLoopTopAddress{};
+  uint64_t ExitFunctionLinkerAddress{};
   uint64_t ThreadStopHandlerAddress{};
   uint64_t ThreadPauseHandlerAddress{};
 

--- a/unittests/ASM/SelfModifyingCode/Delinking.asm
+++ b/unittests/ASM/SelfModifyingCode/Delinking.asm
@@ -1,0 +1,44 @@
+%ifdef CONFIG
+{
+  "Match": "All",
+  "RegData": {
+    "RAX": "0x20"
+  }
+}
+%endif
+
+mov rcx, 2
+mov rbx, 1
+jmp main
+
+patched_op:
+db 0x48, 0xc7, 0xc0, 0xff, 0xff, 0xff, 0xff
+dec rcx
+jmp main
+
+main:
+
+; warm up the cache
+cmp rcx, 0
+jg patched_op
+
+; should the text exit?
+cmp rbx, 0
+je end
+
+; patch mov rax, -1 to nops
+mov byte [rel patched_op + 0], 0x90
+mov byte [rel patched_op + 1], 0x90
+mov byte [rel patched_op + 2], 0x90
+mov byte [rel patched_op + 3], 0x90
+mov byte [rel patched_op + 4], 0x90
+mov byte [rel patched_op + 5], 0x90
+mov byte [rel patched_op + 6], 0x90
+
+mov rax, 32
+mov rcx, 2
+mov rbx, 0
+jmp main
+
+end:
+hlt


### PR DESCRIPTION
## Overview

Rebased on top of #637 this changes `OP_EXITFUNCTION` to link when arguments are `InlineConstants`


## Linking details
Linking consists of a few different parts.

`JITCore::ExitFunctionLink` takes care of looking up the guest rip from the link record, update it to link to the expected block or backpatch the code for a direct link, and return the next executed pointer. If it fails to find the block, it returns `AbsoluteLoopTopAddress`. It also adds de-linking entries to the Block Cache.

`JITCore::ExitFunctionLinker` (asm-dispatcher) is the default entrypoint that is called when an ExitFunction is not yet linked to a specific block. It recovers the record from the return address (`lr` or from `rax`), calls `JITCore::ExitFunctionLink` and jumps to the returned value.

`BlockCache::AddBlockLink` Is added, that adds a callback to call when a block is removed. `BlockCache::Erase` and `BlockCache::Clear` have been updated to call the callbacks and delete the links as needed.