### PR TITLE
Remove duplicated compaction pass

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -533,7 +533,7 @@ namespace FEXCore::Context {
       State->IntBackend = State->CPUBackend;
       break;
     case FEXCore::Config::CONFIG_IRJIT:
-      State->PassManager->InsertRAPass(IR::CreateRegisterAllocationPass());
+      State->PassManager->InsertRegisterAllocationPass();
       // Initialization order matters here, the IR JIT may want to have the interpreter created first to get a pointer to its execution function
       // This is useful for JIT to interpreter fallback support
       State->IntBackend.reset(FEXCore::CPU::CreateInterpreterCore(this, State, CompileThread));

--- a/External/FEXCore/Source/Interface/IR/PassManager.cpp
+++ b/External/FEXCore/Source/Interface/IR/PassManager.cpp
@@ -15,7 +15,8 @@ void PassManager::AddDefaultPasses(bool InlineConstants) {
 
   // If the IR is compacted post-RA then the node indexing gets messed up and the backend isn't able to find the register assigned to a node
   // Compact before IR, don't worry about RA generating spills/fills
-  InsertPass(CreateIRCompaction());
+  CompactionPass = CreateIRCompaction();
+  InsertPass(CompactionPass);
 }
 
 void PassManager::AddDefaultValidationPasses() {
@@ -24,6 +25,11 @@ void PassManager::AddDefaultValidationPasses() {
   InsertValidationPass(Validation::CreateIRValidation());
   InsertValidationPass(Validation::CreateValueDominanceValidation());
 #endif
+}
+
+void PassManager::InsertRegisterAllocationPass() {
+    RAPass = IR::CreateRegisterAllocationPass(CompactionPass);
+    InsertPass(RAPass);
 }
 
 bool PassManager::Run(IREmitter *IREmit) {

--- a/External/FEXCore/Source/Interface/IR/PassManager.h
+++ b/External/FEXCore/Source/Interface/IR/PassManager.h
@@ -39,10 +39,8 @@ public:
     Pass->RegisterPassManager(this);
     Passes.emplace_back(Pass);
   }
-  void InsertRAPass(Pass *Pass) {
-    RAPass = Pass;
-    InsertPass(Pass);
-  }
+
+  void InsertRegisterAllocationPass();
 
   bool Run(IREmitter *IREmit);
 
@@ -68,6 +66,7 @@ protected:
 
 private:
   Pass *RAPass{};
+  FEXCore::IR::Pass *CompactionPass{};
 
   std::vector<std::unique_ptr<Pass>> Passes;
 

--- a/External/FEXCore/Source/Interface/IR/Passes.h
+++ b/External/FEXCore/Source/Interface/IR/Passes.h
@@ -12,7 +12,7 @@ FEXCore::IR::Pass* CreateDeadFlagStoreElimination();
 FEXCore::IR::Pass* CreateDeadGPRStoreElimination();
 FEXCore::IR::Pass* CreatePassDeadCodeElimination();
 FEXCore::IR::Pass* CreateIRCompaction();
-FEXCore::IR::RegisterAllocationPass* CreateRegisterAllocationPass();
+FEXCore::IR::RegisterAllocationPass* CreateRegisterAllocationPass(FEXCore::IR::Pass* CompactionPass);
 
 namespace Validation {
 FEXCore::IR::Pass* CreateIRValidation();

--- a/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -271,7 +271,7 @@ namespace {
 namespace FEXCore::IR {
   class ConstrainedRAPass final : public RegisterAllocationPass {
     public:
-      ConstrainedRAPass();
+      ConstrainedRAPass(FEXCore::IR::Pass* _CompactionPass);
       ~ConstrainedRAPass();
       bool Run(IREmitter *IREmit) override;
 
@@ -291,7 +291,7 @@ namespace FEXCore::IR {
       std::vector<uint32_t> TopRAPressure;
 
       RegisterGraph *Graph;
-      std::unique_ptr<FEXCore::IR::Pass> LocalCompaction;
+      FEXCore::IR::Pass* CompactionPass;
 
       void SpillRegisters(FEXCore::IR::IREmitter *IREmit);
 
@@ -319,8 +319,8 @@ namespace FEXCore::IR {
       bool RunAllocateVirtualRegisters(IREmitter *IREmit);
   };
 
-  ConstrainedRAPass::ConstrainedRAPass() {
-    LocalCompaction.reset(FEXCore::IR::CreateIRCompaction());
+  ConstrainedRAPass::ConstrainedRAPass(FEXCore::IR::Pass* _CompactionPass)
+    : CompactionPass {_CompactionPass} {
   }
 
   ConstrainedRAPass::~ConstrainedRAPass() {
@@ -1042,7 +1042,7 @@ namespace FEXCore::IR {
     TopRAPressure.assign(TopRAPressure.size(), 0);
 
     // We need to rerun compaction every step
-    Changed |= LocalCompaction->Run(IREmit);
+    Changed |= CompactionPass->Run(IREmit);
     auto IR = IREmit->ViewIR();
 
     uint32_t SSACount = IR.GetSSACount();
@@ -1121,7 +1121,7 @@ namespace FEXCore::IR {
     return Changed;
   }
 
-  FEXCore::IR::RegisterAllocationPass* CreateRegisterAllocationPass() {
-    return new ConstrainedRAPass{};
+  FEXCore::IR::RegisterAllocationPass* CreateRegisterAllocationPass(FEXCore::IR::Pass* CompactionPass) {
+    return new ConstrainedRAPass{CompactionPass};
   }
 }


### PR DESCRIPTION
RA Pass and passmanager compaction pass don't need to be independent.
This saves some memory.

In the future we should allow passes to fetch passes by name, that will
be part of the PassManager improvement in the future