### PR TITLE
Ensures pass validation goes through LogManager

### DIFF
--- a/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
@@ -260,7 +260,7 @@ bool IRValidation::Run(IREmitter *IREmit) {
       Out << "Warnings:" << std::endl << Warnings.str() << std::endl;
     }
 
-    std::cerr << Out.str() << std::endl;
+    LogMan::Msg::E("%s", Out.str().c_str());
   }
 
   return false;

--- a/External/FEXCore/Source/Interface/IR/Passes/PhiValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/PhiValidation.cpp
@@ -52,7 +52,7 @@ bool PhiValidation::Run(IREmitter *IREmit) {
 
     Out << "Errors:" << std::endl << Errors.str() << std::endl;
 
-    std::cerr << Out.str() << std::endl;
+    LogMan::Msg::E(Out.str().c_str());
   }
 
 

--- a/External/FEXCore/Source/Interface/IR/Passes/ValueDominanceValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ValueDominanceValidation.cpp
@@ -197,7 +197,7 @@ bool ValueDominanceValidation::Run(IREmitter *IREmit) {
       Out << "Warnings:" << std::endl << Warnings.str() << std::endl;
     }
 
-    std::cerr << Out.str() << std::endl;
+    LogMan::Msg::E(Out.str().c_str());
   }
 
   return false;


### PR DESCRIPTION
Now that it supports large strings we can push these through here.
We really need to avoid touching stdout/stderr as an interpreter