### PR TITLE
Fixes cache clear bug on x86_64

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -350,11 +350,12 @@ void JITCore::ClearCache() {
       reset();
     }
     else {
+      FreeCodeBuffer(InitialCodeBuffer);
+
       // Resize the code buffer and reallocate our code size
       CurrentCodeBuffer->Size *= 1.5;
       CurrentCodeBuffer->Size = std::min(CurrentCodeBuffer->Size, MAX_CODE_SIZE);
 
-      FreeCodeBuffer(InitialCodeBuffer);
       InitialCodeBuffer = AllocateNewCodeBuffer(CurrentCodeBuffer->Size);
       setNewBuffer(InitialCodeBuffer.Ptr, InitialCodeBuffer.Size);
     }


### PR DESCRIPTION
On cache clear this would munmap pages 1.5x past the code cache.
This most certainly leads to spurious bugs