### PR TITLE
Revert "Adds resizable frontend decoded buffer"

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Frontend.cpp
+++ b/External/FEXCore/Source/Interface/Core/Frontend.cpp
@@ -983,17 +983,9 @@ bool Decoder::DecodeInstructionsAtEntry(uint8_t const* _InstStream, uint64_t PC)
         break;
       }
 
-      if (DecodedSize >= CTX->Config.MaxInstPerBlock) {
+      if (DecodedSize >= CTX->Config.MaxInstPerBlock ||
+          DecodedSize >= DecodedBuffer.size()) {
         break;
-      }
-
-      if (DecodedSize >= DecodedBuffer.size() &&
-          DecodedBuffer.size() == MaxDecodedBufferSize) {
-        break;
-      }
-      else if (DecodedSize >= DecodedBuffer.size()) {
-        // We can keep going
-        DecodedBuffer.resize(std::min(static_cast<size_t>(DecodedBuffer.size() * 1.5), MaxDecodedBufferSize));
       }
 
       if (TotalInstructions >= CTX->Config.MaxInstPerBlock) {

--- a/External/FEXCore/Source/Interface/Core/Frontend.h
+++ b/External/FEXCore/Source/Interface/Core/Frontend.h
@@ -45,9 +45,7 @@ private:
   bool NormalOp(FEXCore::X86Tables::X86InstInfo const *Info, uint16_t Op);
   bool NormalOpHeader(FEXCore::X86Tables::X86InstInfo const *Info, uint16_t Op);
 
-  static constexpr size_t DefaultDecodedBufferSize = 0x200;
-  static constexpr size_t MaxDecodedBufferSize = 0x10000;
-
+  static constexpr size_t DefaultDecodedBufferSize = 0x10000;
   std::vector<FEXCore::X86Tables::DecodedInst> DecodedBuffer;
   size_t DecodedSize {};
 


### PR DESCRIPTION
This reverts commit c12251607768afa133971f316dcb54b25522e86f.

Broke multiblock. We can come back to this to save some memory.