### PR TITLE
SRA: Static Register Allocation

### DIFF
--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -156,6 +156,7 @@ set (SRCS
   Interface/IR/Passes/PhiValidation.cpp
   Interface/IR/Passes/RedundantFlagCalculationElimination.cpp
   Interface/IR/Passes/DeadFlagStoreElimination.cpp
+  Interface/IR/Passes/StaticRegisterAllocationPass.cpp
   Interface/IR/Passes/DeadGPRStoreElimination.cpp
   Interface/IR/Passes/DeadFPRStoreElimination.cpp
   Interface/IR/Passes/RegisterAllocationPass.cpp

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -796,27 +796,6 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
             memcpy(Data, Src, Op->Size);
             break;
           }
-          case IR::OP_LOADCONTEXTPAIR: {
-            auto Op = IROp->C<IR::IROp_LoadContextPair>();
-
-            uintptr_t ContextPtr = reinterpret_cast<uintptr_t>(&Thread->State.State);
-            ContextPtr += Op->Offset;
-
-            void *Data = reinterpret_cast<void*>(ContextPtr);
-            memcpy(GDP, Data, Op->Size * 2);
-            break;
-          }
-          case IR::OP_STORECONTEXTPAIR: {
-            auto Op = IROp->C<IR::IROp_StoreContextPair>();
-
-            uintptr_t ContextPtr = reinterpret_cast<uintptr_t>(&Thread->State.State);
-            ContextPtr += Op->Offset;
-
-            void *Data = reinterpret_cast<void*>(ContextPtr);
-            void *Src = GetSrc<void*>(SSAData, Op->Header.Args[0]);
-            memcpy(Data, Src, Op->Size * 2);
-            break;
-          }
           case IR::OP_CREATEELEMENTPAIR: {
             auto Op = IROp->C<IR::IROp_CreateElementPair>();
             void *Src_Lower = GetSrc<void*>(SSAData, Op->Header.Args[0]);

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -1081,7 +1081,15 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
             uint64_t Src1 = *GetSrc<uint64_t*>(SSAData, Op->Header.Args[0]);
             uint64_t Src2 = *GetSrc<uint64_t*>(SSAData, Op->Header.Args[1]);
             uint8_t Mask = OpSize * 8 - 1;
-            GD = Src1 >> (Src2 & Mask);
+            switch (OpSize) {
+              case 4:
+                GD = static_cast<uint32_t>(Src1) >> (Src2 & Mask);
+                break;
+              case 8:
+                GD = static_cast<uint64_t>(Src1) >> (Src2 & Mask);
+                break;
+              default: LogMan::Msg::A("Unknown LSHR Size: %d\n", OpSize); break;
+            };
             break;
           }
           case IR::OP_ASHR: {
@@ -1090,12 +1098,6 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
             uint64_t Src2 = *GetSrc<uint64_t*>(SSAData, Op->Header.Args[1]);
             uint8_t Mask = OpSize * 8 - 1;
             switch (OpSize) {
-              case 1:
-                GD = (uint8_t)(static_cast<int8_t>(Src1) >> (Src2 & Mask));
-                break;
-              case 2:
-                GD = (uint16_t)(static_cast<int16_t>(Src1) >> (Src2 & Mask));
-                break;
               case 4:
                 GD = (uint32_t)(static_cast<int32_t>(Src1) >> (Src2 & Mask));
                 break;

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -801,9 +801,10 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
             void *Src_Lower = GetSrc<void*>(SSAData, Op->Header.Args[0]);
             void *Src_Upper = GetSrc<void*>(SSAData, Op->Header.Args[1]);
 
-            memcpy(GDP, Src_Lower, Op->Header.Size);
-            memcpy(reinterpret_cast<void*>(reinterpret_cast<uint64_t>(GDP) + Op->Header.Size),
-              Src_Upper, Op->Header.Size);
+            uint8_t *Dst = GetDest<uint8_t*>(SSAData, WrapperOp);
+  
+            memcpy(Dst, Src_Lower, Op->Header.Size);
+            memcpy(Dst + Op->Header.Size, Src_Upper, Op->Header.Size);
             break;
           }
           case IR::OP_EXTRACTELEMENTPAIR: {

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -773,22 +773,26 @@ DEF_OP(Popcount) {
   uint8_t OpSize = IROp->Size;
   switch (OpSize) {
     case 0x1:
-      fmov(VTMP1.B(), GetReg<RA_32>(Op->Header.Args[0].ID()));
+      fmov(VTMP1.S(), GetReg<RA_32>(Op->Header.Args[0].ID()));
+      // only use lowest byte
       cnt(VTMP1.V8B(), VTMP1.V8B());
       break;
     case 0x2:
-      fmov(VTMP1.H(), GetReg<RA_32>(Op->Header.Args[0].ID()));
+      fmov(VTMP1.S(), GetReg<RA_32>(Op->Header.Args[0].ID()));
       cnt(VTMP1.V8B(), VTMP1.V8B());
-      addv(VTMP1.B(), VTMP1.V8B());
+      // only count two lowest bytes
+      addp(VTMP1.V8B(), VTMP1.V8B(), VTMP1.V8B());
       break;
     case 0x4:
       fmov(VTMP1.S(), GetReg<RA_32>(Op->Header.Args[0].ID()));
       cnt(VTMP1.V8B(), VTMP1.V8B());
+      // fmov has zero extended, unused bytes are zero
       addv(VTMP1.B(), VTMP1.V8B());
       break;
     case 0x8:
       fmov(VTMP1.D(), GetReg<RA_64>(Op->Header.Args[0].ID()));
       cnt(VTMP1.V8B(), VTMP1.V8B());
+      // fmov has zero extended, unused bytes are zero
       addv(VTMP1.B(), VTMP1.V8B());
       break;
     default: LogMan::Msg::A("Unsupported Popcount size: %d", OpSize);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -1014,7 +1014,7 @@ DEF_OP(FCmp) {
   bool set = false;
 
   if (Op->Flags & (1 << IR::FCMP_FLAG_EQ)) {
-    assert(IR::FCMP_FLAG_EQ == 0);
+    LogMan::Throw::A(IR::FCMP_FLAG_EQ == 0, "IR::FCMP_FLAG_EQ must equal 0");
     // EQ or unordered
     cset(Dst, Condition::eq); // Z = 1
     csinc(Dst, Dst, xzr, Condition::vc); // IF !V ? Z : 1

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -506,15 +506,7 @@ DEF_OP(LDiv) {
     break;
     }
     case 8: {
-      uint64_t SPOffset = AlignUp((RA64.size() + 1) * 8, 16);
-
-      sub(sp, sp, SPOffset);
-      int i = 0;
-      for (auto RA : RA64) {
-        str(RA, MemOperand(sp, i * 8));
-        i++;
-      }
-      str(lr,       MemOperand(sp, RA64.size() * 8 + 0 * 8));
+      PushDynamicRegsAndLR();
 
       mov(x0, GetReg<RA_64>(Op->Header.Args[1].ID()));
       mov(x1, GetReg<RA_64>(Op->Header.Args[0].ID()));
@@ -524,25 +516,17 @@ DEF_OP(LDiv) {
       CallRuntime(LDIV);
 #else
       LoadConstant(x3, reinterpret_cast<uint64_t>(LDIV));
-      SpillStaticRegs(true);
+      SpillStaticRegs();
       blr(x3);
-      FillStaticRegs(true);
+      FillStaticRegs();
 #endif
 
       // Result is now in x0
       // Fix the stack and any values that were stepped on
-      i = 0;
-      for (auto RA : RA64) {
-        ldr(RA, MemOperand(sp, i * 8));
-        i++;
-      }
+      PopDynamicRegsAndLR();
 
       // Move result to its destination register
       mov(GetReg<RA_64>(Node), x0);
-
-      ldr(lr,       MemOperand(sp, RA64.size() * 8 + 0 * 8));
-
-      add(sp, sp, SPOffset);
     break;
     }
     default: LogMan::Msg::A("Unknown LDIV Size: %d", Size); break;
@@ -569,15 +553,7 @@ DEF_OP(LUDiv) {
     break;
     }
     case 8: {
-      uint64_t SPOffset = AlignUp((RA64.size() + 1) * 8, 16);
-
-      sub(sp, sp, SPOffset);
-      int i = 0;
-      for (auto RA : RA64) {
-        str(RA, MemOperand(sp, i * 8));
-        i++;
-      }
-      str(lr,       MemOperand(sp, RA64.size() * 8 + 0 * 8));
+      PushDynamicRegsAndLR();
 
       mov(x0, GetReg<RA_64>(Op->Header.Args[1].ID()));
       mov(x1, GetReg<RA_64>(Op->Header.Args[0].ID()));
@@ -587,25 +563,17 @@ DEF_OP(LUDiv) {
       CallRuntime(LUDIV);
 #else
       LoadConstant(x3, reinterpret_cast<uint64_t>(LUDIV));
-      SpillStaticRegs(true);
+      SpillStaticRegs();
       blr(x3);
-      FillStaticRegs(true);
+      FillStaticRegs();
 #endif
 
       // Result is now in x0
       // Fix the stack and any values that were stepped on
-      i = 0;
-      for (auto RA : RA64) {
-        ldr(RA, MemOperand(sp, i * 8));
-        i++;
-      }
+      PopDynamicRegsAndLR();
 
       // Move result to its destination register
       mov(GetReg<RA_64>(Node), x0);
-
-      ldr(lr,       MemOperand(sp, RA64.size() * 8 + 0 * 8));
-
-      add(sp, sp, SPOffset);
     break;
     }
     default: LogMan::Msg::A("Unknown LUDIV Size: %d", Size); break;
@@ -642,15 +610,7 @@ DEF_OP(LRem) {
     break;
     }
     case 8: {
-              uint64_t SPOffset = AlignUp((RA64.size() + 1) * 8, 16);
-
-      sub(sp, sp, SPOffset);
-      int i = 0;
-      for (auto RA : RA64) {
-        str(RA, MemOperand(sp, i * 8));
-        i++;
-      }
-      str(lr,       MemOperand(sp, RA64.size() * 8 + 0 * 8));
+      PushDynamicRegsAndLR();
 
       mov(x0, GetReg<RA_64>(Op->Header.Args[1].ID()));
       mov(x1, GetReg<RA_64>(Op->Header.Args[0].ID()));
@@ -660,25 +620,17 @@ DEF_OP(LRem) {
       CallRuntime(LREM);
 #else
       LoadConstant(x3, reinterpret_cast<uint64_t>(LREM));
-      SpillStaticRegs(true);
+      SpillStaticRegs();
       blr(x3);
-      FillStaticRegs(true);
+      FillStaticRegs();
 #endif
 
       // Result is now in x0
       // Fix the stack and any values that were stepped on
-      i = 0;
-      for (auto RA : RA64) {
-        ldr(RA, MemOperand(sp, i * 8));
-        i++;
-      }
+      PopDynamicRegsAndLR();
 
       // Move result to its destination register
       mov(GetReg<RA_64>(Node), x0);
-
-      ldr(lr,       MemOperand(sp, RA64.size() * 8 + 0 * 8));
-
-      add(sp, sp, SPOffset);
     break;
     }
     default: LogMan::Msg::A("Unknown LREM Size: %d", Size); break;
@@ -711,15 +663,8 @@ DEF_OP(LURem) {
     break;
     }
     case 8: {
-      uint64_t SPOffset = AlignUp((RA64.size() + 1) * 8, 16);
 
-      sub(sp, sp, SPOffset);
-      int i = 0;
-      for (auto RA : RA64) {
-        str(RA, MemOperand(sp, i * 8));
-        i++;
-      }
-      str(lr,       MemOperand(sp, RA64.size() * 8 + 0 * 8));
+      PushDynamicRegsAndLR();
 
       mov(x0, GetReg<RA_64>(Op->Header.Args[1].ID()));
       mov(x1, GetReg<RA_64>(Op->Header.Args[0].ID()));
@@ -729,25 +674,16 @@ DEF_OP(LURem) {
       CallRuntime(LUREM);
 #else
       LoadConstant(x3, reinterpret_cast<uint64_t>(LUREM));
-      SpillStaticRegs(true);
+      SpillStaticRegs();
       blr(x3);
-      FillStaticRegs(true);
+      FillStaticRegs();
 #endif
+      // Fix the stack and any values that were stepped on
+      PopDynamicRegsAndLR();
 
       // Result is now in x0
-      // Fix the stack and any values that were stepped on
-      i = 0;
-      for (auto RA : RA64) {
-        ldr(RA, MemOperand(sp, i * 8));
-        i++;
-      }
-
       // Move result to its destination register
       mov(GetReg<RA_64>(Node), x0);
-
-      ldr(lr,       MemOperand(sp, RA64.size() * 8 + 0 * 8));
-
-      add(sp, sp, SPOffset);
     break;
     }
     default: LogMan::Msg::A("Unknown LUREM Size: %d", OpSize); break;

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -770,10 +770,31 @@ DEF_OP(Not) {
 
 DEF_OP(Popcount) {
   auto Op = IROp->C<IR::IROp_Popcount>();
-  auto Dst = GetReg<RA_64>(Node);
-  fmov(VTMP1.D(), GetReg<RA_64>(Op->Header.Args[0].ID()));
-  cnt(VTMP1.V8B(), VTMP1.V8B());
-  addv(VTMP1.B(), VTMP1.V8B());
+  uint8_t OpSize = IROp->Size;
+  switch (OpSize) {
+    case 0x1:
+      fmov(VTMP1.B(), GetReg<RA_32>(Op->Header.Args[0].ID()));
+      cnt(VTMP1.V8B(), VTMP1.V8B());
+      break;
+    case 0x2:
+      fmov(VTMP1.H(), GetReg<RA_32>(Op->Header.Args[0].ID()));
+      cnt(VTMP1.V8B(), VTMP1.V8B());
+      addv(VTMP1.B(), VTMP1.V8B());
+      break;
+    case 0x4:
+      fmov(VTMP1.S(), GetReg<RA_32>(Op->Header.Args[0].ID()));
+      cnt(VTMP1.V8B(), VTMP1.V8B());
+      addv(VTMP1.B(), VTMP1.V8B());
+      break;
+    case 0x8:
+      fmov(VTMP1.D(), GetReg<RA_64>(Op->Header.Args[0].ID()));
+      cnt(VTMP1.V8B(), VTMP1.V8B());
+      addv(VTMP1.B(), VTMP1.V8B());
+      break;
+    default: LogMan::Msg::A("Unsupported Popcount size: %d", OpSize);
+  }
+
+  auto Dst = GetReg<RA_32>(Node);
   umov(Dst.W(), VTMP1.B(), 0);
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -524,7 +524,9 @@ DEF_OP(LDiv) {
       CallRuntime(LDIV);
 #else
       LoadConstant(x3, reinterpret_cast<uint64_t>(LDIV));
+      SpillStaticRegs(true);
       blr(x3);
+      FillStaticRegs(true);
 #endif
 
       // Result is now in x0
@@ -585,7 +587,9 @@ DEF_OP(LUDiv) {
       CallRuntime(LUDIV);
 #else
       LoadConstant(x3, reinterpret_cast<uint64_t>(LUDIV));
+      SpillStaticRegs(true);
       blr(x3);
+      FillStaticRegs(true);
 #endif
 
       // Result is now in x0
@@ -656,7 +660,9 @@ DEF_OP(LRem) {
       CallRuntime(LREM);
 #else
       LoadConstant(x3, reinterpret_cast<uint64_t>(LREM));
+      SpillStaticRegs(true);
       blr(x3);
+      FillStaticRegs(true);
 #endif
 
       // Result is now in x0
@@ -723,7 +729,9 @@ DEF_OP(LURem) {
       CallRuntime(LUREM);
 #else
       LoadConstant(x3, reinterpret_cast<uint64_t>(LUREM));
+      SpillStaticRegs(true);
       blr(x3);
+      FillStaticRegs(true);
 #endif
 
       // Result is now in x0

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
@@ -167,6 +167,7 @@ DEF_OP(Syscall) {
   // X2: Pointer to SyscallArguments
 
   PushDynamicRegsAndLR();
+  SpillStaticRegs();
 
   LoadConstant(x0, reinterpret_cast<uint64_t>(CTX->SyscallHandler));
   mov(x1, STATE);
@@ -177,6 +178,7 @@ DEF_OP(Syscall) {
 
   // Result is now in x0
   // Fix the stack and any values that were stepped on
+  FillStaticRegs();
   PopDynamicRegsAndLR();
 
   // Move result to its destination register

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
@@ -308,7 +308,9 @@ DEF_OP(RemoveCodeEntry) {
   LoadConstant(x1, Op->RIP);
  
   LoadConstant(x2, reinterpret_cast<uintptr_t>(&Context::Context::RemoveCodeEntry));
+  SpillStaticRegs(true);
   blr(x2);
+  FillStaticRegs(true);
 
   // Fix the stack and any values that were stepped on
   i = 0;
@@ -349,7 +351,9 @@ DEF_OP(CPUID) {
   PtrCast Ptr;
   Ptr.ClassPtr = &FEXCore::CPUIDEmu::RunFunction;
   LoadConstant(x3, Ptr.Data);
+  SpillStaticRegs(true);
   blr(x3);
+  FillStaticRegs(true);
 
   i = 0;
   for (auto RA : RA64) {

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
@@ -32,6 +32,10 @@ DEF_OP(SignalReturn) {
 }
 
 DEF_OP(CallbackReturn) {
+
+  // spill back to CTX
+  SpillStaticRegs();
+  
   // First we must reset the stack
   ldp(TMP1, lr, MemOperand(sp, 16, PostIndex));
   add(sp, TMP1, 0); // Move that supports SP
@@ -208,6 +212,8 @@ DEF_OP(Thunk) {
 
   uint64_t SPOffset = AlignUp((RA64.size() + 1) * 8, 16);
 
+  SpillStaticRegs(); // spill to ctx before ra64 spill
+
   sub(sp, sp, SPOffset);
 
   int i = 0;
@@ -234,6 +240,8 @@ DEF_OP(Thunk) {
   }
 
   ldr(lr, MemOperand(sp, RA64.size() * 8 + 0 * 8));
+
+  FillStaticRegs(); // loat from ctx after ra64 refill
 
   add(sp, sp, SPOffset);
 }

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -758,11 +758,13 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
 
   auto HeaderOp = IR->GetHeader();
 
-  LoadConstant(x0, HeaderOp->Entry);
   
   if (HeaderOp->ShouldInterpret) {
     return reinterpret_cast<void*>(ThreadSharedData.InterpreterFallbackHelperAddress);
   }
+  
+  // Debug Helper
+  //LoadConstant(x0, HeaderOp->Entry);
 
   this->IR = IR;
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -446,6 +446,10 @@ bool JITCore::HandleSignalPause(int Signal, void *info, void *ucontext) {
 
     // Set the new PC
     _mcontext->pc = ThreadStopHandlerAddress;
+
+    // Set x28 (which is our state register) to point to our guest thread data
+    _mcontext->regs[28 /* STATE */] = reinterpret_cast<uint64_t>(State);
+    
     State->SignalReason.store(FEXCore::Core::SIGNALEVENT_NONE);
     return true;
   }

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -411,7 +411,7 @@ bool JITCore::HandleSignalPause(int Signal, void *info, void *ucontext) {
 
     if (!IsAddressInJITCode(_mcontext->pc, false)) {
       // We are in non-jit, SRA is already spilled
-      assert(!IsAddressInJITCode(_mcontext->pc, true));
+      LogMan::Throw::A(!IsAddressInJITCode(_mcontext->pc, true), "Signals in dispatcher have unsynchronized context");
       _mcontext->pc = ThreadPauseHandlerAddress;
     } else {
       // We are in jit, SRA must be spilled
@@ -455,7 +455,7 @@ bool JITCore::HandleSignalPause(int Signal, void *info, void *ucontext) {
     // Set the new PC
     if (!IsAddressInJITCode(_mcontext->pc, false)) {
       // We are in non-jit, SRA is already spilled
-      assert(!IsAddressInJITCode(_mcontext->pc, true));
+      LogMan::Throw::A(!IsAddressInJITCode(_mcontext->pc, true), "Signals in dispatcher have unsynchronized context");
       _mcontext->pc = ThreadStopHandlerAddress;
     } else {
       // We are in jit, SRA must be spilled
@@ -665,8 +665,7 @@ auto Reg = GetPhys(RAPass, Node);
   } else if (Reg.Class == IR::GPRClass.Val) {
     return RA64[Reg.VId].W();
   } else {
-    printf("Unexpected Class: %d\n", Reg.Class);
-    assert(false);
+    LogMan::Throw::A(false, "Unexpected Class: %d", Reg.Class);
   }
 }
 
@@ -678,8 +677,7 @@ aarch64::Register JITCore::GetReg<JITCore::RA_64>(uint32_t Node) {
   } else if (Reg.Class == IR::GPRClass.Val) {
     return RA64[Reg.VId];
   } else {
-    printf("Unexpected Class: %d\n", Reg.Class);
-    assert(false);
+    LogMan::Throw::A(false, "Unexpected Class: %d", Reg.Class);
   }
 }
 
@@ -702,8 +700,7 @@ aarch64::VRegister JITCore::GetSrc(uint32_t Node) {
   } else if (Reg.Class == IR::FPRClass.Val) {
     return RAFPR[Reg.VId];
   } else {
-    printf("Unexpected Class: %d\n", Reg.Class);
-    assert(false);
+    LogMan::Throw::A(false, "Unexpected Class: %d", Reg.Class);
   }
 }
 
@@ -714,8 +711,7 @@ aarch64::VRegister JITCore::GetDst(uint32_t Node) {
   } else if (Reg.Class == IR::FPRClass.Val) {
     return RAFPR[Reg.VId];
   } else {
-    printf("Unexpected Class: %d\n", Reg.Class);
-    assert(false);
+    LogMan::Throw::A(false, "Unexpected Class: %d", Reg.Class);
   }
 }
 
@@ -1321,11 +1317,14 @@ void JITCore::PushDynamicRegsAndLR() {
     i+=2;
   }
 
+#if 0 // All GPRs should be caller saved
   for (auto RA : RA64)
   {
     str(RA, MemOperand(sp, i * 8));
     i++;
   }
+#endif
+
   str(lr, MemOperand(sp, RA64.size() * 8 + 0 * 8));
 }
 
@@ -1339,11 +1338,13 @@ void JITCore::PopDynamicRegsAndLR() {
     i+=2;
   }
 
+#if 0 // All GPRs should be caller saved
   for (auto RA : RA64)
   {
     ldr(RA, MemOperand(sp, i * 8));
     i++;
   }
+#endif
 
   ldr(lr, MemOperand(sp, i * 8 + 0 * 8));
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -742,13 +742,13 @@ FEXCore::IR::RegisterClassType JITCore::GetRegClass(uint32_t Node) {
 bool JITCore::IsFPR(uint32_t Node) {
   auto Class = GetRegClass(Node);
 
-  return Class == IR::FPRClass;
+  return Class == IR::FPRClass || Class == IR::FPRFixedClass;
 }
 
 bool JITCore::IsGPR(uint32_t Node) {
   auto Class = GetRegClass(Node);
 
-  return Class == IR::GPRClass;
+  return Class == IR::GPRClass || Class == IR::GPRFixedClass;
 }
 
 void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const *IR, [[maybe_unused]] FEXCore::Core::DebugData *DebugData) {

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -1287,7 +1287,7 @@ void JITCore::SpillStaticRegs() {
       stp(SRA64[i], SRA64[i+1], MemOperand(STATE, offsetof(FEXCore::Core::ThreadState, State.gregs[i])));
   }
 
-  for (size_t i = 0; i < SRAFPR.size(); i++) {
+  for (size_t i = 0; i < SRAFPR.size(); i+=2) {
     stp(SRAFPR[i].Q(), SRAFPR[i+1].Q(), MemOperand(STATE, offsetof(FEXCore::Core::ThreadState, State.xmm[i][0])));
   }
 }
@@ -1322,7 +1322,7 @@ void JITCore::PushDynamicRegsAndLR() {
   }
 #endif
 
-  str(lr, MemOperand(sp, i * 8 + 0 * 8));
+  str(lr, MemOperand(sp, i * 8));
 }
 
 void JITCore::PopDynamicRegsAndLR() {
@@ -1343,7 +1343,7 @@ void JITCore::PopDynamicRegsAndLR() {
   }
 #endif
 
-  ldr(lr, MemOperand(sp, i * 8 + 0 * 8));
+  ldr(lr, MemOperand(sp, i * 8));
 
   add(sp, sp, SPOffset);
 }

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -1322,7 +1322,7 @@ void JITCore::PushDynamicRegsAndLR() {
   }
 #endif
 
-  str(lr, MemOperand(sp, RA64.size() * 8 + 0 * 8));
+  str(lr, MemOperand(sp, i * 8 + 0 * 8));
 }
 
 void JITCore::PopDynamicRegsAndLR() {

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -759,8 +759,9 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
     return reinterpret_cast<void*>(ThreadSharedData.InterpreterFallbackHelperAddress);
   }
   
-  // Debug Helper
-  //LoadConstant(x0, HeaderOp->Entry);
+  #ifndef NDEBUG
+  LoadConstant(x0, HeaderOp->Entry);
+  #endif
 
   this->IR = IR;
 
@@ -797,7 +798,6 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
   auto Buffer = GetBuffer();
   auto Entry = Buffer->GetOffsetAddress<uint64_t>(GetCursorOffset());
 
-  //brk(0);
 
   if (SpillSlots) {
     add(TMP1, sp, 0); // Move that supports SP
@@ -1291,7 +1291,7 @@ void JITCore::SpillStaticRegs() {
   }
 
   for (size_t i = 0; i < SRAFPR.size(); i++) {
-    stp(SRAFPR[i].Q(), SRAFPR[i].Q(), MemOperand(STATE, offsetof(FEXCore::Core::ThreadState, State.xmm[i][0])));
+    stp(SRAFPR[i].Q(), SRAFPR[i+1].Q(), MemOperand(STATE, offsetof(FEXCore::Core::ThreadState, State.xmm[i][0])));
   }
 }
 
@@ -1301,7 +1301,7 @@ void JITCore::FillStaticRegs() {
   }
 
   for (size_t i = 0; i < SRAFPR.size(); i+=2) {
-    ldp(SRAFPR[i].Q(), SRAFPR[i].Q(), MemOperand(STATE, offsetof(FEXCore::Core::ThreadState, State.xmm[i][0])));
+    ldp(SRAFPR[i].Q(), SRAFPR[i+1].Q(), MemOperand(STATE, offsetof(FEXCore::Core::ThreadState, State.xmm[i][0])));
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -517,9 +517,6 @@ JITCore::JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadSt
   RAPass->AddRegisters(FEXCore::IR::GPRPairClass, NumUsedGPRPairs);
   RAPass->AddRegisters(FEXCore::IR::ComplexClass, 1);
 
-  RAPass->AllocateRegisterConflicts(FEXCore::IR::GPRClass, NumUsedGPRs);
-  RAPass->AllocateRegisterConflicts(FEXCore::IR::GPRPairClass, NumUsedGPRs);
-
   for (uint32_t i = 0; i < NumUsedGPRPairs; ++i) {
     RAPass->AddRegisterConflict(FEXCore::IR::GPRClass, i * 2,     FEXCore::IR::GPRPairClass, i);
     RAPass->AddRegisterConflict(FEXCore::IR::GPRClass, i * 2 + 1, FEXCore::IR::GPRPairClass, i);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -212,7 +212,7 @@ private:
   static constexpr size_t MAX_CODE_SIZE = 1024 * 1024 * 128;
   static constexpr size_t MAX_DISPATCHER_CODE_SIZE = 4096 * 2;
 
-  bool IsAddressInJITCode(uint64_t Address);
+  bool IsAddressInJITCode(uint64_t Address, bool IncludeDispatcher = true);
 
 #if DEBUG
   vixl::aarch64::Disassembler Disasm;
@@ -227,12 +227,11 @@ private:
   /**
    * @name Dispatch Helper functions
    * @{ */
-  aarch64::Label LoopTop{};
-  aarch64::Label Exit{};
   uint64_t AbsoluteLoopTopAddress{};
+  uint64_t ThreadPauseHandlerAddressSpillSRA{};
   uint64_t ThreadPauseHandlerAddress{};
 
-  Label ThreadPauseHandler{};
+  uint64_t ThreadStopHandlerAddressSpillSRA{};
   uint64_t ThreadStopHandlerAddress{};
   uint64_t PauseReturnInstruction{};
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -204,6 +204,7 @@ private:
   /**
    * @name Dispatch Helper functions
    * @{ */
+  uint64_t AbsoluteLoopTopAddressFillSRA{};
   uint64_t AbsoluteLoopTopAddress{};
   uint64_t ThreadPauseHandlerAddressSpillSRA{};
   uint64_t ThreadPauseHandlerAddress{};

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -375,10 +375,7 @@ private:
   DEF_OP(GetHostFlag);
 
   ///< Memory ops
-  DEF_OP(LoadContextPair);
-  DEF_OP(StoreContextPair);
-
-  DEF_OP(LoadContext);
+    DEF_OP(LoadContext);
   DEF_OP(StoreContext);
   DEF_OP(LoadRegister);
   DEF_OP(StoreRegister);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -29,56 +29,33 @@ namespace FEXCore::CPU {
 using namespace vixl;
 using namespace vixl::aarch64;
 
-//
+// All but x29 are caller saved
 const std::array<aarch64::Register, 16> SRA64 = {
-  x19, x20, x21, x22, x23, x24, x25, x26,
-  x27, x29, x18, x17, x16, x15, x14, x13
+  x4, x5, x6, x7, x8, x9, x10, x11,
+  x12, x18, x17, x16, x15, x14, x13, x29
 };
 
-// RA64 array has more entries for spilling
-#define RA64_COUNT 9
-
-const std::array<aarch64::Register, 15> RA64 = {
-  x4, x5, x6, x7, x8, x9, x10, x11,
-  x12,
-  
-  x13, x14, x15, x16, x17, x18,
+// All are callee saved
+const std::array<aarch64::Register, 9> RA64 = {
+  x20, x21, x22, x23, x24, x25, x26, x27,
+  x19
 };
 
 const std::array<std::pair<aarch64::Register, aarch64::Register>, 4>  RA64Pair = {{
-  {x4, x5},
-  {x6, x7},
-  {x8, x9},
-  {x10, x11},
-/*
-  {x12, x13},
-  {x14, x15},
-  {x16, x17},
-  {x18, x19},
   {x20, x21},
   {x22, x23},
   {x24, x25},
   {x26, x27},
-  */
 }};
 
 const std::array<std::pair<aarch64::Register, aarch64::Register>, 4> RA32Pair = {{
-  {w4, w5},
-  {w6, w7},
-  {w8, w9},
-  {w10, w11},
-  /*
-  {w12, w13},
-  {w14, w15},
-  {w16, w17},
-  {w18, w19},
   {w20, w21},
   {w22, w23},
   {w24, w25},
   {w26, w27},
-  */
 }};
 
+// All are caller saved
 const std::array<aarch64::VRegister, 16> SRAFPR = {
   v16, v17, v18, v19, v20, v21, v22, v23,
   v24, v25, v26, v27, v28, v29, v30, v31
@@ -130,7 +107,7 @@ private:
   /**
    * @name Register Allocation
    * @{ */
-  constexpr static uint32_t NumGPRs = RA64_COUNT;//RA64.size();
+  constexpr static uint32_t NumGPRs = RA64.size();
   constexpr static uint32_t NumFPRs = RAFPR.size();
   constexpr static uint32_t NumGPRPairs = RA64Pair.size();
   constexpr static uint32_t NumCalleeGPRs = 10;
@@ -254,8 +231,11 @@ private:
 
   uint32_t SpillSlots{};
 
-  void SpillStaticRegs(bool OnlyCallerSaved = false);
-  void FillStaticRegs(bool OnlyCallerSaved = false);
+  void SpillStaticRegs();
+  void FillStaticRegs();
+
+  void PushDynamicRegsAndLR();
+  void PopDynamicRegsAndLR();
 
   using OpHandler = void (JITCore::*)(FEXCore::IR::IROp_Header *IROp, uint32_t Node);
   std::array<OpHandler, FEXCore::IR::IROps::OP_LAST + 1> OpHandlers {};

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -5,38 +5,6 @@ namespace FEXCore::CPU {
 using namespace vixl;
 using namespace vixl::aarch64;
 #define DEF_OP(x) void JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
-DEF_OP(LoadContextPair) {
-  auto Op = IROp->C<IR::IROp_LoadContextPair>();
-  switch (Op->Size) {
-    case 4: {
-      auto Dst = GetSrcPair<RA_32>(Node);
-      ldp(Dst.first, Dst.second, MemOperand(STATE, Op->Offset));
-      break;
-    }
-    case 8: {
-      auto Dst = GetSrcPair<RA_64>(Node);
-      ldp(Dst.first, Dst.second, MemOperand(STATE, Op->Offset));
-      break;
-    }
-    default: LogMan::Msg::A("Unknown Size"); break;
-  }
-}
-
-DEF_OP(StoreContextPair) {
-  auto Op = IROp->C<IR::IROp_StoreContextPair>();
-  switch (Op->Size) {
-    case 4: {
-      auto Src = GetSrcPair<RA_32>(Op->Header.Args[0].ID());
-      stp(Src.first, Src.second, MemOperand(STATE, Op->Offset));
-      break;
-    }
-    case 8: {
-      auto Src = GetSrcPair<RA_64>(Op->Header.Args[0].ID());
-      stp(Src.first, Src.second, MemOperand(STATE, Op->Offset));
-      break;
-    }
-  }
-}
 
 DEF_OP(LoadContext) {
   auto Op = IROp->C<IR::IROp_LoadContext>();
@@ -828,8 +796,6 @@ DEF_OP(VStoreMemElement) {
 #undef DEF_OP
 void JITCore::RegisterMemoryHandlers() {
 #define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &JITCore::Op_##x
-  REGISTER_OP(LOADCONTEXTPAIR,     LoadContextPair);
-  REGISTER_OP(STORECONTEXTPAIR,    StoreContextPair);
   REGISTER_OP(LOADCONTEXT,         LoadContext);
   REGISTER_OP(STORECONTEXT,        StoreContext);
   REGISTER_OP(LOADREGISTER,        LoadRegister);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -101,29 +101,29 @@ DEF_OP(LoadRegister) {
     auto regId = (Op->Offset - offsetof(FEXCore::Core::ThreadState, State.gregs[0])) / 8;
     auto regOffs = Op->Offset & 7;
 
-    assert(regId < SRA64.size());
+    LogMan::Throw::A(regId < SRA64.size(), "out of range regId");
 
     auto reg = SRA64[regId];
     
     switch(Op->Header.Size) {
       case 1:
-        assert(regOffs == 0 || regOffs == 1);
+        LogMan::Throw::A(regOffs == 0 || regOffs == 1, "unexpected regOffs");
         ubfx(GetReg<RA_64>(Node), reg, regOffs * 8, 8);
         break;
 
       case 2:
-        assert(regOffs == 0);
+        LogMan::Throw::A(regOffs == 0, "unexpected regOffs");
         ubfx(GetReg<RA_64>(Node), reg, 0, 16);
         break;
 
       case 4:
-        assert(regOffs == 0);
+        LogMan::Throw::A(regOffs == 0, "unexpected regOffs");
         if (GetReg<RA_64>(Node).GetCode() != reg.GetCode())
           mov(GetReg<RA_32>(Node), reg.W());
         break;
 
       case 8:
-        assert(regOffs == 0);
+        LogMan::Throw::A(regOffs == 0, "unexpected regOffs");
         if (GetReg<RA_64>(Node).GetCode() != reg.GetCode())
           mov(GetReg<RA_64>(Node), reg);
         break;
@@ -132,25 +132,24 @@ DEF_OP(LoadRegister) {
     auto regId = (Op->Offset - offsetof(FEXCore::Core::ThreadState, State.xmm[0][0])) / 16;
     auto regOffs = Op->Offset & 15;
 
-    assert(regId < SRAFPR.size());
+    LogMan::Throw::A(regId < SRAFPR.size(), "out of range regId");
 
     auto guest = SRAFPR[regId];
     auto host = GetSrc(Node);
 
     switch(Op->Header.Size) {
       case 1:
-        assert(regOffs == 0);
+        LogMan::Throw::A(regOffs == 0, "unexpected regOffs");
         mov(host.B(), guest.B());
         break;
 
       case 2:
-        assert(regOffs == 0);
+        LogMan::Throw::A(regOffs == 0, "unexpected regOffs");
         fmov(host.H(), guest.H());
         break;
 
       case 4:
-        //assert(regOffs == 0);
-        assert((regOffs & 3) == 0);
+        LogMan::Throw::A((regOffs & 3) == 0, "unexpected regOffs");
         if (regOffs == 0) {
           if (host.GetCode() != guest.GetCode())
             fmov(host.S(), guest.S());
@@ -160,8 +159,7 @@ DEF_OP(LoadRegister) {
         break;
 
       case 8:
-        //assert(regOffs == 0);
-        assert((regOffs & 7) == 0);
+        LogMan::Throw::A((regOffs & 7) == 0, "unexpected regOffs");
         if (regOffs == 0) {
           if (host.GetCode() != guest.GetCode())
             mov(host.D(), guest.D());
@@ -171,13 +169,13 @@ DEF_OP(LoadRegister) {
         break;
 
       case 16:
-        assert(regOffs == 0);
+        LogMan::Throw::A(regOffs == 0, "unexpected regOffs");
         if (host.GetCode() != guest.GetCode())
           mov(host.Q(), guest.Q());
         break;
     }
   } else {
-    assert(false);
+    LogMan::Throw::A(false, "Unhandled Op->Class %d", Op->Class);
   }
 }
 
@@ -190,28 +188,28 @@ DEF_OP(StoreRegister) {
     auto regId = Op->Offset / 8 - 1;
     auto regOffs = Op->Offset & 7;
 
-    assert(regId < SRA64.size());
+    LogMan::Throw::A(regId < SRA64.size(), "out of range regId");
 
     auto reg = SRA64[regId];
     
     switch(Op->Header.Size) {
       case 1:
-        assert(regOffs == 0 || regOffs == 1);
+        LogMan::Throw::A(regOffs == 0 || regOffs == 1, "unexpected regOffs");
         bfi(reg, GetReg<RA_64>(Op->Value.ID()), regOffs * 8, 8);
         break;
 
       case 2:
-        assert(regOffs == 0);
+        LogMan::Throw::A(regOffs == 0, "unexpected regOffs");
         bfi(reg, GetReg<RA_64>(Op->Value.ID()), 0, 16);
         break;
         
       case 4:
-        assert(regOffs == 0);
+        LogMan::Throw::A(regOffs == 0, "unexpected regOffs");
         bfi(reg, GetReg<RA_64>(Op->Value.ID()), 0, 32);
         break;
 
       case 8:
-        assert(regOffs == 0);
+        LogMan::Throw::A(regOffs == 0, "unexpected regOffs");
         if (GetReg<RA_64>(Op->Value.ID()).GetCode() != reg.GetCode())
           mov(reg, GetReg<RA_64>(Op->Value.ID()));
         break;
@@ -220,7 +218,7 @@ DEF_OP(StoreRegister) {
     auto regId = (Op->Offset - offsetof(FEXCore::Core::ThreadState, State.xmm[0][0])) / 16;
     auto regOffs = Op->Offset & 15;
 
-    assert(regId < SRAFPR.size());
+    LogMan::Throw::A(regId < SRAFPR.size());
 
     auto guest = SRAFPR[regId];
     auto host = GetSrc(Op->Value.ID());
@@ -231,28 +229,28 @@ DEF_OP(StoreRegister) {
         break;
 
       case 2:
-        assert((regOffs & 1) == 0);
+        LogMan::Throw::A((regOffs & 1) == 0, "unexpected regOffs");
         ins(guest.V8H(), regOffs/2, host.V8H(), 0);
         break;
 
       case 4:
-        assert((regOffs & 3) == 0);
+        LogMan::Throw::A((regOffs & 3) == 0, "unexpected regOffs");
         ins(guest.V4S(), regOffs/4, host.V4S(), 0);
         break;
 
       case 8:
-        assert((regOffs & 7) == 0);
+        LogMan::Throw::A((regOffs & 7) == 0, "unexpected regOffs");
         ins(guest.V2D(), regOffs / 8, host.V2D(), 0);
         break;
 
       case 16:
-        assert(regOffs == 0);
+        LogMan::Throw::A(regOffs == 0);
         if (guest.GetCode() != host.GetCode())
           mov(guest.Q(), host.Q());
         break;
     }
   } else {
-    assert(false);
+    LogMan::Throw::A(false, "Unhandled Op->Class %d", Op->Class);
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -124,6 +124,171 @@ DEF_OP(StoreContext) {
   }
 }
 
+
+DEF_OP(LoadRegister) {
+  auto Op = IROp->C<IR::IROp_LoadRegister>();
+  uint8_t OpSize = IROp->Size;
+
+  if (Op->Class == IR::GPRClass) {
+    auto regId = (Op->Offset - offsetof(FEXCore::Core::ThreadState, State.gregs[0])) / 8;
+    auto regOffs = Op->Offset & 7;
+
+    assert(regId < SRA64.size());
+
+    auto reg = SRA64[regId];
+    
+    switch(Op->Header.Size) {
+      case 1:
+        assert(regOffs == 0 || regOffs == 1);
+        ubfx(GetReg<RA_64>(Node), reg, regOffs * 8, 8);
+        break;
+
+      case 2:
+        assert(regOffs == 0);
+        ubfx(GetReg<RA_64>(Node), reg, 0, 16);
+        break;
+
+      case 4:
+        assert(regOffs == 0);
+        if (GetReg<RA_64>(Node).GetCode() != reg.GetCode())
+          mov(GetReg<RA_32>(Node), reg.W());
+        break;
+
+      case 8:
+        assert(regOffs == 0);
+        if (GetReg<RA_64>(Node).GetCode() != reg.GetCode())
+          mov(GetReg<RA_64>(Node), reg);
+        break;
+    }
+  } else if (Op->Class == IR::FPRClass) {
+    auto regId = (Op->Offset - offsetof(FEXCore::Core::ThreadState, State.xmm[0][0])) / 16;
+    auto regOffs = Op->Offset & 15;
+
+    assert(regId < SRAFPR.size());
+
+    auto guest = SRAFPR[regId];
+    auto host = GetSrc(Node);
+
+    switch(Op->Header.Size) {
+      case 1:
+        assert(regOffs == 0);
+        mov(host.B(), guest.B());
+        break;
+
+      case 2:
+        assert(regOffs == 0);
+        fmov(host.H(), guest.H());
+        break;
+
+      case 4:
+        //assert(regOffs == 0);
+        assert((regOffs & 3) == 0);
+        if (regOffs == 0) {
+          if (host.GetCode() != guest.GetCode())
+            fmov(host.S(), guest.S());
+        } else {
+          ins(host.V4S(), 0, guest.V4S(), regOffs/4);
+        }
+        break;
+
+      case 8:
+        //assert(regOffs == 0);
+        assert((regOffs & 7) == 0);
+        if (regOffs == 0) {
+          if (host.GetCode() != guest.GetCode())
+            mov(host.D(), guest.D());
+        } else {
+          ins(host.V2D(), 0, guest.V2D(), regOffs/8);
+        }
+        break;
+
+      case 16:
+        assert(regOffs == 0);
+        if (host.GetCode() != guest.GetCode())
+          mov(host.Q(), guest.Q());
+        break;
+    }
+  } else {
+    assert(false);
+  }
+}
+
+DEF_OP(StoreRegister) {
+  auto Op = IROp->C<IR::IROp_StoreRegister>();
+  uint8_t OpSize = IROp->Size;
+
+
+  if (Op->Class == IR::GPRClass) {
+    auto regId = Op->Offset / 8 - 1;
+    auto regOffs = Op->Offset & 7;
+
+    assert(regId < SRA64.size());
+
+    auto reg = SRA64[regId];
+    
+    switch(Op->Header.Size) {
+      case 1:
+        assert(regOffs == 0 || regOffs == 1);
+        bfi(reg, GetReg<RA_64>(Op->Value.ID()), regOffs * 8, 8);
+        break;
+
+      case 2:
+        assert(regOffs == 0);
+        bfi(reg, GetReg<RA_64>(Op->Value.ID()), 0, 16);
+        break;
+        
+      case 4:
+        assert(regOffs == 0);
+        bfi(reg, GetReg<RA_64>(Op->Value.ID()), 0, 32);
+        break;
+
+      case 8:
+        assert(regOffs == 0);
+        if (GetReg<RA_64>(Op->Value.ID()).GetCode() != reg.GetCode())
+          mov(reg, GetReg<RA_64>(Op->Value.ID()));
+        break;
+    }
+  } else if (Op->Class == IR::FPRClass) {
+    auto regId = (Op->Offset - offsetof(FEXCore::Core::ThreadState, State.xmm[0][0])) / 16;
+    auto regOffs = Op->Offset & 15;
+
+    assert(regId < SRAFPR.size());
+
+    auto guest = SRAFPR[regId];
+    auto host = GetSrc(Op->Value.ID());
+
+    switch(Op->Header.Size) {
+      case 1:
+        ins(guest.V16B(), regOffs, host.V16B(), 0);
+        break;
+
+      case 2:
+        assert((regOffs & 1) == 0);
+        ins(guest.V8H(), regOffs/2, host.V8H(), 0);
+        break;
+
+      case 4:
+        assert((regOffs & 3) == 0);
+        ins(guest.V4S(), regOffs/4, host.V4S(), 0);
+        break;
+
+      case 8:
+        assert((regOffs & 7) == 0);
+        ins(guest.V2D(), regOffs / 8, host.V2D(), 0);
+        break;
+
+      case 16:
+        assert(regOffs == 0);
+        if (guest.GetCode() != host.GetCode())
+          mov(guest.Q(), host.Q());
+        break;
+    }
+  } else {
+    assert(false);
+  }
+}
+
+
 DEF_OP(LoadContextIndexed) {
   auto Op = IROp->C<IR::IROp_LoadContextIndexed>();
   size_t size = Op->Size;
@@ -667,6 +832,8 @@ void JITCore::RegisterMemoryHandlers() {
   REGISTER_OP(STORECONTEXTPAIR,    StoreContextPair);
   REGISTER_OP(LOADCONTEXT,         LoadContext);
   REGISTER_OP(STORECONTEXT,        StoreContext);
+  REGISTER_OP(LOADREGISTER,        LoadRegister);
+  REGISTER_OP(STOREREGISTER,       StoreRegister);
   REGISTER_OP(LOADCONTEXTINDEXED,  LoadContextIndexed);
   REGISTER_OP(STORECONTEXTINDEXED, StoreContextIndexed);
   REGISTER_OP(SPILLREGISTER,       SpillRegister);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -218,7 +218,7 @@ DEF_OP(StoreRegister) {
     auto regId = (Op->Offset - offsetof(FEXCore::Core::ThreadState, State.xmm[0][0])) / 16;
     auto regOffs = Op->Offset & 15;
 
-    LogMan::Throw::A(regId < SRAFPR.size());
+    LogMan::Throw::A(regId < SRAFPR.size(), "regId out of range");
 
     auto guest = SRAFPR[regId];
     auto host = GetSrc(Op->Value.ID());
@@ -244,7 +244,7 @@ DEF_OP(StoreRegister) {
         break;
 
       case 16:
-        LogMan::Throw::A(regOffs == 0);
+        LogMan::Throw::A(regOffs == 0, "unexpected regOffs");
         if (guest.GetCode() != host.GetCode())
           mov(guest.Q(), host.Q());
         break;

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
@@ -36,7 +36,7 @@ DEF_OP(Break) {
       add(sp, TMP1, 0);
 
       // Now we need to jump to the thread stop handler
-      LoadConstant(TMP1, ThreadStopHandlerAddress);
+      LoadConstant(TMP1, ThreadStopHandlerAddressSpillSRA);
       br(TMP1);
       break;
     }
@@ -44,7 +44,7 @@ DEF_OP(Break) {
       ldp(TMP1, lr, MemOperand(sp, 16, PostIndex));
       add(sp, TMP1, 0); // Move that supports SP
 
-      LoadConstant(TMP1, ThreadPauseHandlerAddress);
+      LoadConstant(TMP1, ThreadPauseHandlerAddressSpillSRA);
       br(TMP1);
       break;
     }

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MoveOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MoveOps.cpp
@@ -26,20 +26,34 @@ DEF_OP(ExtractElementPair) {
 
 DEF_OP(CreateElementPair) {
   auto Op = IROp->C<IR::IROp_CreateElementPair>();
+  std::pair<aarch64::Register, aarch64::Register> Dst;
+  aarch64::Register RegFirst;
+  aarch64::Register RegSecond;
+
   switch (Op->Header.Size) {
     case 4: {
-      auto Dst = GetSrcPair<RA_32>(Node);
-      mov(Dst.first, GetReg<RA_32>(Op->Header.Args[0].ID()));
-      mov(Dst.second, GetReg<RA_32>(Op->Header.Args[1].ID()));
+      Dst = GetSrcPair<RA_32>(Node);
+      RegFirst = GetSrc<RA_32>(Op->Header.Args[0].ID());
+      RegSecond = GetSrc<RA_32>(Op->Header.Args[1].ID());
       break;
     }
     case 8: {
-      auto Dst = GetSrcPair<RA_64>(Node);
-      mov(Dst.first, GetReg<RA_64>(Op->Header.Args[0].ID()));
-      mov(Dst.second, GetReg<RA_64>(Op->Header.Args[1].ID()));
+      Dst = GetSrcPair<RA_64>(Node);
+      RegFirst = GetSrc<RA_64>(Op->Header.Args[0].ID());
+      RegSecond = GetSrc<RA_64>(Op->Header.Args[1].ID());
       break;
     }
     default: LogMan::Msg::A("Unknown Size"); break;
+  }
+
+  if (Dst.first != RegSecond) {
+    mov(Dst.first, RegFirst);
+    mov(Dst.second, RegSecond);
+  } else if (Dst.second != RegFirst) {
+    mov(Dst.second, RegSecond);
+    mov(Dst.first, RegFirst);
+  } else {
+    LogMan::Msg::A("Unhandled CreateElementPair");
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MoveOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MoveOps.cpp
@@ -33,23 +33,23 @@ DEF_OP(CreateElementPair) {
   switch (Op->Header.Size) {
     case 4: {
       Dst = GetSrcPair<RA_32>(Node);
-      RegFirst = GetSrc<RA_32>(Op->Header.Args[0].ID());
-      RegSecond = GetSrc<RA_32>(Op->Header.Args[1].ID());
+      RegFirst = GetReg<RA_32>(Op->Header.Args[0].ID());
+      RegSecond = GetReg<RA_32>(Op->Header.Args[1].ID());
       break;
     }
     case 8: {
       Dst = GetSrcPair<RA_64>(Node);
-      RegFirst = GetSrc<RA_64>(Op->Header.Args[0].ID());
-      RegSecond = GetSrc<RA_64>(Op->Header.Args[1].ID());
+      RegFirst = GetReg<RA_64>(Op->Header.Args[0].ID());
+      RegSecond = GetReg<RA_64>(Op->Header.Args[1].ID());
       break;
     }
     default: LogMan::Msg::A("Unknown Size"); break;
   }
 
-  if (Dst.first != RegSecond) {
+  if (Dst.first.GetCode() != RegSecond.GetCode()) {
     mov(Dst.first, RegFirst);
     mov(Dst.second, RegSecond);
-  } else if (Dst.second != RegFirst) {
+  } else if (Dst.second.GetCode() != RegFirst.GetCode()) {
     mov(Dst.second, RegSecond);
     mov(Dst.first, RegFirst);
   } else {

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -361,7 +361,7 @@ JITCore::JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadSt
   RAPass->AddRegisters(FEXCore::IR::GPRClass, NumGPRs);
   RAPass->AddRegisters(FEXCore::IR::FPRClass, NumXMMs);
   RAPass->AddRegisters(FEXCore::IR::GPRPairClass, NumGPRPairs);
-
+  
   RAPass->AllocateRegisterConflicts(FEXCore::IR::GPRClass, NumGPRs);
   RAPass->AllocateRegisterConflicts(FEXCore::IR::GPRPairClass, NumGPRs);
 
@@ -957,7 +957,6 @@ void JITCore::CreateCustomDispatch(FEXCore::Core::InternalThreadState *Thread) {
     // Adjust the stack to remove the alignment and also the return address
     // We will have been called from the ASM dispatcher, so we know where we came from
     add(rsp, 16);
-
     jmp(LoopTop);
   }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -361,9 +361,6 @@ JITCore::JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadSt
   RAPass->AddRegisters(FEXCore::IR::GPRClass, NumGPRs);
   RAPass->AddRegisters(FEXCore::IR::FPRClass, NumXMMs);
   RAPass->AddRegisters(FEXCore::IR::GPRPairClass, NumGPRPairs);
-  
-  RAPass->AllocateRegisterConflicts(FEXCore::IR::GPRClass, NumGPRs);
-  RAPass->AllocateRegisterConflicts(FEXCore::IR::GPRPairClass, NumGPRs);
 
   for (uint32_t i = 0; i < NumGPRPairs; ++i) {
     RAPass->AddRegisterConflict(FEXCore::IR::GPRClass, i * 2,     FEXCore::IR::GPRPairClass, i);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -48,7 +48,7 @@ namespace FEXCore::CPU {
 #define TMP4 rdi
 #define TMP5 rbx
 using namespace Xbyak::util;
-const std::array<Xbyak::Reg, 9> RA64 = { rsi, r8, r9, r10, r11, rbp, r12, r13, r15 };
+const std::array<Xbyak::Reg, 9> RA64 = { rsi, r8, r9, r10, r11, rbp, r12, r13, r15};
 const std::array<std::pair<Xbyak::Reg, Xbyak::Reg>, 4> RA64Pair = {{ {rsi, r8}, {r9, r10}, {r11, rbp}, {r12, r13} }};
 const std::array<Xbyak::Reg, 11> RAXMM = { xmm0, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm9, xmm10 };
 const std::array<Xbyak::Xmm, 11> RAXMM_x = { xmm0, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm9, xmm10 };
@@ -92,7 +92,7 @@ private:
   constexpr static uint32_t NumXMMs = RAXMM.size();
   constexpr static uint32_t NumGPRPairs = RA64Pair.size();
   constexpr static uint32_t RegisterCount = NumGPRs + NumXMMs + NumGPRPairs;
-  constexpr static uint32_t RegisterClasses = 3;
+  constexpr static uint32_t RegisterClasses = 5;
 
   constexpr static uint64_t GPRBase = (0ULL << 32);
   constexpr static uint64_t XMMBase = (1ULL << 32);
@@ -302,6 +302,8 @@ private:
   DEF_OP(StoreContextPair);
   DEF_OP(LoadContext);
   DEF_OP(StoreContext);
+  DEF_OP(LoadRegister);
+  DEF_OP(StoreRegister);
   DEF_OP(LoadContextIndexed);
   DEF_OP(StoreContextIndexed);
   DEF_OP(SpillRegister);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -298,8 +298,6 @@ private:
   DEF_OP(GetHostFlag);
 
   ///< Memory ops
-  DEF_OP(LoadContextPair);
-  DEF_OP(StoreContextPair);
   DEF_OP(LoadContext);
   DEF_OP(StoreContext);
   DEF_OP(LoadRegister);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -48,7 +48,7 @@ namespace FEXCore::CPU {
 #define TMP4 rdi
 #define TMP5 rbx
 using namespace Xbyak::util;
-const std::array<Xbyak::Reg, 9> RA64 = { rsi, r8, r9, r10, r11, rbp, r12, r13, r15};
+const std::array<Xbyak::Reg, 9> RA64 = { rsi, r8, r9, r10, r11, rbp, r12, r13, r15 };
 const std::array<std::pair<Xbyak::Reg, Xbyak::Reg>, 4> RA64Pair = {{ {rsi, r8}, {r9, r10}, {r11, rbp}, {r12, r13} }};
 const std::array<Xbyak::Reg, 11> RAXMM = { xmm0, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm9, xmm10 };
 const std::array<Xbyak::Xmm, 11> RAXMM_x = { xmm0, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm9, xmm10 };
@@ -300,8 +300,6 @@ private:
   ///< Memory ops
   DEF_OP(LoadContext);
   DEF_OP(StoreContext);
-  DEF_OP(LoadRegister);
-  DEF_OP(StoreRegister);
   DEF_OP(LoadContextIndexed);
   DEF_OP(StoreContextIndexed);
   DEF_OP(SpillRegister);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -92,7 +92,7 @@ private:
   constexpr static uint32_t NumXMMs = RAXMM.size();
   constexpr static uint32_t NumGPRPairs = RA64Pair.size();
   constexpr static uint32_t RegisterCount = NumGPRs + NumXMMs + NumGPRPairs;
-  constexpr static uint32_t RegisterClasses = 5;
+  constexpr static uint32_t RegisterClasses = 6;
 
   constexpr static uint64_t GPRBase = (0ULL << 32);
   constexpr static uint64_t XMMBase = (1ULL << 32);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/MemoryOps.cpp
@@ -610,6 +610,8 @@ void JITCore::RegisterMemoryHandlers() {
   REGISTER_OP(STORECONTEXTPAIR,    StoreContextPair);
   REGISTER_OP(LOADCONTEXT,         LoadContext);
   REGISTER_OP(STORECONTEXT,        StoreContext);
+  REGISTER_OP(LOADREGISTER,        Unhandled); // SRA specific, not supported on this backend
+  REGISTER_OP(STOREREGISTER,       Unhandled);
   REGISTER_OP(LOADCONTEXTINDEXED,  LoadContextIndexed);
   REGISTER_OP(STORECONTEXTINDEXED, StoreContextIndexed);
   REGISTER_OP(SPILLREGISTER,       SpillRegister);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/MemoryOps.cpp
@@ -6,42 +6,6 @@
 namespace FEXCore::CPU {
 
 #define DEF_OP(x) void JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
-DEF_OP(LoadContextPair) {
-  auto Op = IROp->C<IR::IROp_LoadContextPair>();
-  switch (Op->Size) {
-    case 4: {
-      auto Dst = GetSrcPair<RA_32>(Node);
-      mov(Dst.first,  dword [STATE + Op->Offset]);
-      mov(Dst.second, dword [STATE + Op->Offset + Op->Size]);
-      break;
-    }
-    case 8: {
-      auto Dst = GetSrcPair<RA_64>(Node);
-      mov(Dst.first,  qword [STATE + Op->Offset]);
-      mov(Dst.second, qword [STATE + Op->Offset + Op->Size]);
-      break;
-    }
-    default: LogMan::Msg::A("Unknown Size"); break;
-  }
-}
-
-DEF_OP(StoreContextPair) {
-  auto Op = IROp->C<IR::IROp_StoreContextPair>();
-  switch (Op->Size) {
-    case 4: {
-      auto Src = GetSrcPair<RA_32>(Op->Header.Args[0].ID());
-      mov(dword [STATE + Op->Offset], Src.first);
-      mov(dword [STATE + Op->Offset + Op->Size], Src.first);
-      break;
-    }
-    case 8: {
-      auto Src = GetSrcPair<RA_64>(Op->Header.Args[0].ID());
-      mov(qword [STATE + Op->Offset], Src.first);
-      mov(qword [STATE + Op->Offset + Op->Size], Src.first);
-      break;
-    }
-  }
-}
 
 DEF_OP(LoadContext) {
   auto Op = IROp->C<IR::IROp_LoadContext>();
@@ -606,8 +570,6 @@ DEF_OP(VStoreMemElement) {
 #undef DEF_OP
 void JITCore::RegisterMemoryHandlers() {
 #define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &JITCore::Op_##x
-  REGISTER_OP(LOADCONTEXTPAIR,     LoadContextPair);
-  REGISTER_OP(STORECONTEXTPAIR,    StoreContextPair);
   REGISTER_OP(LOADCONTEXT,         LoadContext);
   REGISTER_OP(STORECONTEXT,        StoreContext);
   REGISTER_OP(LOADREGISTER,        Unhandled); // SRA specific, not supported on this backend

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/MoveOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/MoveOps.cpp
@@ -25,20 +25,34 @@ DEF_OP(ExtractElementPair) {
 
 DEF_OP(CreateElementPair) {
   auto Op = IROp->C<IR::IROp_CreateElementPair>();
+  std::pair<Xbyak::Reg, Xbyak::Reg> Dst;
+  Xbyak::Reg RegFirst;
+  Xbyak::Reg RegSecond;
+
   switch (Op->Header.Size) {
     case 4: {
-      auto Dst = GetSrcPair<RA_32>(Node);
-      mov(Dst.first, GetSrc<RA_32>(Op->Header.Args[0].ID()));
-      mov(Dst.second, GetSrc<RA_32>(Op->Header.Args[1].ID()));
+      Dst = GetSrcPair<RA_32>(Node);
+      RegFirst = GetSrc<RA_32>(Op->Header.Args[0].ID());
+      RegSecond = GetSrc<RA_32>(Op->Header.Args[1].ID());
       break;
     }
     case 8: {
-      auto Dst = GetSrcPair<RA_64>(Node);
-      mov(Dst.first, GetSrc<RA_64>(Op->Header.Args[0].ID()));
-      mov(Dst.second, GetSrc<RA_64>(Op->Header.Args[1].ID()));
+      Dst = GetSrcPair<RA_64>(Node);
+      RegFirst = GetSrc<RA_64>(Op->Header.Args[0].ID());
+      RegSecond = GetSrc<RA_64>(Op->Header.Args[1].ID());
       break;
     }
     default: LogMan::Msg::A("Unknown Size"); break;
+  }
+
+  if (Dst.first != RegSecond) {
+    mov(Dst.first, RegFirst);
+    mov(Dst.second, RegSecond);
+  } else if (Dst.second != RegFirst) {
+    mov(Dst.second, RegSecond);
+    mov(Dst.first, RegFirst);
+  } else {
+    LogMan::Msg::A("Unhandled CreateElementPair");
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -4372,10 +4372,17 @@ void OpDispatchBuilder::CMPXCHGPairOp(OpcodeArgs) {
 
   // Always load 128bits from the context
   // Since we want the full RBX and RCX loaded
+ 
+  /*
   OrderedNode *Desired = _LoadContextPair(8, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RBX]), GPRPairClass);
   if (Size == 4) {
     Desired = _TruncElementPair(Desired, 4);
   }
+  */
+
+  OrderedNode *Desired_Lower = _LoadContext(Size, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RBX]), GPRClass);
+  OrderedNode *Desired_Upper = _LoadContext(Size, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RCX]), GPRClass);
+  OrderedNode *Desired = _CreateElementPair(Desired_Lower, Desired_Upper);
 
   // ssa0 = Expected
   // ssa1 = Desired

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -1006,7 +1006,7 @@ void OpDispatchBuilder::CondJUMPRCXOp(OpcodeArgs) {
 
   OrderedNode *CondReg = _LoadContext(Size, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RCX]), GPRClass);
   SrcCond = _Select(FEXCore::IR::COND_EQ,
-          CondReg, ZeroConst, TakeBranch, DoNotTakeBranch);
+          CondReg, ZeroConst, TakeBranch, DoNotTakeBranch, Size);
 
   auto TrueBlock = JumpTargets.find(Target);
   auto FalseBlock = JumpTargets.find(Op->PC + Op->InstSize);

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -4370,16 +4370,6 @@ void OpDispatchBuilder::CMPXCHGPairOp(OpcodeArgs) {
   OrderedNode *Expected_Upper = _LoadContext(Size, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RDX]), GPRClass);
   OrderedNode *Expected = _CreateElementPair(Expected_Lower, Expected_Upper);
 
-  // Always load 128bits from the context
-  // Since we want the full RBX and RCX loaded
- 
-  /*
-  OrderedNode *Desired = _LoadContextPair(8, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RBX]), GPRPairClass);
-  if (Size == 4) {
-    Desired = _TruncElementPair(Desired, 4);
-  }
-  */
-
   OrderedNode *Desired_Lower = _LoadContext(Size, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RBX]), GPRClass);
   OrderedNode *Desired_Upper = _LoadContext(Size, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RCX]), GPRClass);
   OrderedNode *Desired = _CreateElementPair(Desired_Lower, Desired_Upper);

--- a/External/FEXCore/Source/Interface/IR/IR.cpp
+++ b/External/FEXCore/Source/Interface/IR/IR.cpp
@@ -52,11 +52,15 @@ static void PrintArg(std::stringstream *out, [[maybe_unused]] IRListView<false> 
 }
 
 static void PrintArg(std::stringstream *out, [[maybe_unused]] IRListView<false> const* IR, RegisterClassType Arg) {
-  if (Arg == 0)
+  if (Arg == GPRClass.Val)
     *out << "GPR";
-  else if (Arg == 1)
+  else if (Arg == GPRFixedClass.Val)
+    *out << "GPRFixed";
+  else if (Arg == FPRClass.Val)
     *out << "FPR";
-  else if (Arg == 2)
+  else if (Arg == FPRFixedClass.Val)
+    *out << "FPRFixed";
+  else if (Arg == GPRPairClass.Val)
     *out << "GPRPair";
   else
     *out << "Unknown Registerclass " << Arg;
@@ -72,7 +76,9 @@ static void PrintArg(std::stringstream *out, IRListView<false> const* IR, Ordere
     uint32_t Reg = RegClass;
     switch (Class) {
       case FEXCore::IR::GPRClass.Val: *out << "(GPR"; break;
+      case FEXCore::IR::GPRFixedClass.Val: *out << "(GPRFixed"; break;
       case FEXCore::IR::FPRClass.Val: *out << "(FPR"; break;
+      case FEXCore::IR::FPRFixedClass.Val: *out << "(FPRFixed"; break;
       case FEXCore::IR::GPRPairClass.Val: *out << "(GPRPair"; break;
       case FEXCore::IR::ComplexClass.Val: *out << "(Complex"; break;
       case FEXCore::IR::InvalidClass.Val: *out << "(Invalid"; break;
@@ -188,7 +194,9 @@ void Dump(std::stringstream *out, IRListView<false> const* IR, IR::RegisterAlloc
             uint32_t Reg = RegClass;
             switch (Class) {
               case FEXCore::IR::GPRClass.Val: *out << "(GPR"; break;
+              case FEXCore::IR::GPRFixedClass.Val: *out << "(GPRFixed"; break;
               case FEXCore::IR::FPRClass.Val: *out << "(FPR"; break;
+              case FEXCore::IR::FPRFixedClass.Val: *out << "(FPRFixed"; break;
               case FEXCore::IR::GPRPairClass.Val: *out << "(GPRPair"; break;
               case FEXCore::IR::ComplexClass.Val: *out << "(Complex"; break;
               case FEXCore::IR::InvalidClass.Val: *out << "(Invalid"; break;

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -23,9 +23,11 @@
     "constexpr static uint8_t COND_FNU  = 21 /* float not unordred */",
 
     "static constexpr FEXCore::IR::RegisterClassType GPRClass {0}",
-    "static constexpr FEXCore::IR::RegisterClassType FPRClass {1}",
-    "static constexpr FEXCore::IR::RegisterClassType GPRPairClass {2}",
-    "static constexpr FEXCore::IR::RegisterClassType ComplexClass {3}",
+    "static constexpr FEXCore::IR::RegisterClassType GPRFixedClass {1}",
+    "static constexpr FEXCore::IR::RegisterClassType FPRClass {2}",
+    "static constexpr FEXCore::IR::RegisterClassType FPRFixedClass {3}",
+    "static constexpr FEXCore::IR::RegisterClassType GPRPairClass {4}",
+    "static constexpr FEXCore::IR::RegisterClassType ComplexClass {5}",
     "static constexpr FEXCore::IR::RegisterClassType InvalidClass {~0U}",
     "",
     "static const FEXCore::IR::TypeDefinition i8    {TypeDefinition::Create(1, 0)}",
@@ -455,6 +457,49 @@
       "HasDest": true,
       "DestClass": "GPR",
       "FixedDestSize": "8"
+    },
+
+    "LoadRegister": {
+      "Desc": ["Loads a value from the static-ra context with offset",
+               "Dest = Ctx[Offset]"
+              ],
+      "OpClass": "StaticRA",
+      "HasDest": true,
+      "DestClass": "Complex",
+      "DestSize": "Size",
+      "HelperArgs": [
+        "uint8_t", "Size"
+      ],
+      "Args": [
+        "bool", "IsAlias",
+        "uint32_t", "Offset",
+        "RegisterClassType", "Class",
+        "RegisterClassType", "StaticClass"
+      ]
+    },
+
+    "StoreRegister": {
+      "HasSideEffects": true,
+      "Desc": ["Stores a value to the static-ra context with offset",
+               "Ctx[Offset] = Value",
+               "Zero Extends if value's type is too small",
+               "Truncates if value's type is too large"
+              ],
+      "OpClass": "StaticRA",
+      "SSAArgs": "1",
+      "SSANames": [
+        "Value"
+      ],
+      "DestSize": "Size",
+      "HelperArgs": [
+        "uint8_t", "Size"
+      ],
+      "Args": [
+        "bool", "IsPrewrite",
+        "uint32_t", "Offset",
+        "RegisterClassType", "Class",
+        "RegisterClassType", "StaticClass"
+      ]
     },
 
     "LoadContext": {

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -930,6 +930,7 @@
               ],
       "OpClass": "ALU",
       "HasDest": true,
+      "DestSize": "std::max<uint8_t>(4, GetOpSize(ssa0))",
       "DestClass": "GPR",
       "SSAArgs": "2"
     },
@@ -939,6 +940,7 @@
               ],
       "OpClass": "ALU",
       "HasDest": true,
+      "DestSize": "std::max<uint8_t>(4, GetOpSize(ssa0))",
       "DestClass": "GPR",
       "SSAArgs": "2"
     },

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -211,36 +211,6 @@
       ]
     },
 
-    "LoadContextPair": {
-      "OpClass": "Memory",
-      "Desc": ["Loads a pair of values from the context"
-              ],
-      "HasDest": true,
-      "DestClass": "GPRPair",
-      "DestSize": "Size",
-      "NumElements": "2",
-      "Args": [
-        "uint8_t", "Size",
-        "uint32_t", "Offset",
-        "RegisterClassType", "Class"
-      ]
-    },
-
-    "StoreContextPair": {
-      "HasSideEffects": true,
-      "OpClass": "Memory",
-      "Desc": ["Stores a pair of values back in to the context"],
-      "SSAArgs": "1",
-      "SSANames": [
-        "Value"
-      ],
-      "Args": [
-        "uint8_t", "Size",
-        "uint32_t", "Offset",
-        "RegisterClassType", "Class"
-      ]
-    },
-
     "ExtractElementPair": {
       "OpClass": "Moves",
       "Desc": ["Extracts a register for the register pair"],

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -920,6 +920,7 @@
               ],
       "OpClass": "ALU",
       "HasDest": true,
+      "DestSize": "std::max<uint8_t>(4, GetOpSize(ssa0))",
       "DestClass": "GPR",
       "SSAArgs": "2"
     },

--- a/External/FEXCore/Source/Interface/IR/PassManager.cpp
+++ b/External/FEXCore/Source/Interface/IR/PassManager.cpp
@@ -4,7 +4,7 @@
 
 namespace FEXCore::IR {
 
-void PassManager::AddDefaultPasses(bool InlineConstants) {
+void PassManager::AddDefaultPasses(bool InlineConstants, bool StaticRegisterAllocation) {
   InsertPass(CreateContextLoadStoreElimination());
   InsertPass(CreateDeadFlagStoreElimination());
   InsertPass(CreateDeadGPRStoreElimination());
@@ -16,6 +16,10 @@ void PassManager::AddDefaultPasses(bool InlineConstants) {
 
   InsertPass(CreateSyscallOptimization());
   InsertPass(CreatePassDeadCodeElimination());
+
+  // only do SRA if enabled and JIT
+  if (InlineConstants && StaticRegisterAllocation)
+    InsertPass(CreateStaticRegisterAllocationPass());
 
   // If the IR is compacted post-RA then the node indexing gets messed up and the backend isn't able to find the register assigned to a node
   // Compact before IR, don't worry about RA generating spills/fills
@@ -31,8 +35,8 @@ void PassManager::AddDefaultValidationPasses() {
 #endif
 }
 
-void PassManager::InsertRegisterAllocationPass() {
-    RAPass = IR::CreateRegisterAllocationPass(CompactionPass);
+void PassManager::InsertRegisterAllocationPass(bool OptimizeSRA) {
+    RAPass = IR::CreateRegisterAllocationPass(CompactionPass, OptimizeSRA);
     InsertPass(RAPass);
 }
 

--- a/External/FEXCore/Source/Interface/IR/PassManager.h
+++ b/External/FEXCore/Source/Interface/IR/PassManager.h
@@ -33,14 +33,14 @@ protected:
 class PassManager final {
   friend class SyscallOptimization;
 public:
-  void AddDefaultPasses(bool InlineConstants);
+  void AddDefaultPasses(bool InlineConstants, bool StaticRegisterAllocation);
   void AddDefaultValidationPasses();
   void InsertPass(Pass *Pass) {
     Pass->RegisterPassManager(this);
     Passes.emplace_back(Pass);
   }
 
-  void InsertRegisterAllocationPass();
+  void InsertRegisterAllocationPass(bool OptimizeSRA);
 
   bool Run(IREmitter *IREmit);
 

--- a/External/FEXCore/Source/Interface/IR/Passes.h
+++ b/External/FEXCore/Source/Interface/IR/Passes.h
@@ -13,7 +13,8 @@ FEXCore::IR::Pass* CreateDeadGPRStoreElimination();
 FEXCore::IR::Pass* CreateDeadFPRStoreElimination();
 FEXCore::IR::Pass* CreatePassDeadCodeElimination();
 FEXCore::IR::Pass* CreateIRCompaction();
-FEXCore::IR::RegisterAllocationPass* CreateRegisterAllocationPass(FEXCore::IR::Pass* CompactionPass);
+FEXCore::IR::RegisterAllocationPass* CreateRegisterAllocationPass(FEXCore::IR::Pass* CompactionPass, bool OptimizeSRA);
+FEXCore::IR::Pass* CreateStaticRegisterAllocationPass();
 
 namespace Validation {
 FEXCore::IR::Pass* CreateIRValidation();

--- a/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -235,7 +235,7 @@ bool ConstProp::Run(IREmitter *IREmit) {
       auto ghf = IROp->CW<IR::IROp_GetHostFlag>();
 
       auto fcmp = IREmit->GetOpHeader(ghf->GPR)->CW<IR::IROp_FCmp>();
-      assert(fcmp->Header.Op == OP_FCMP || fcmp->Header.Op == OP_F80CMP);
+      LogMan::Throw::A(fcmp->Header.Op == OP_FCMP || fcmp->Header.Op == OP_F80CMP, "Unexpected OP_GETHOSTFLAG source");
       if(fcmp->Header.Op == OP_FCMP) {
         fcmp->Flags |= 1 << ghf->Flag;
       }

--- a/External/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
@@ -558,9 +558,7 @@ bool RCLSE::RedundantStoreLoadElimination(FEXCore::IR::IREmitter *IREmit) {
         }
       }
       else if (IROp->Op == OP_STORECONTEXTINDEXED ||
-               IROp->Op == OP_LOADCONTEXTINDEXED ||
-               IROp->Op == OP_LOADCONTEXTPAIR ||
-               IROp->Op == OP_STORECONTEXTPAIR) {
+               IROp->Op == OP_LOADCONTEXTINDEXED) {
         // We can't track through these
         ResetClassificationAccesses(&LocalInfo);
       }

--- a/External/FEXCore/Source/Interface/IR/Passes/DeadFPRStoreElimination.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/DeadFPRStoreElimination.cpp
@@ -93,9 +93,7 @@ bool DeadFPRStoreElimination::Run(IREmitter *IREmit) {
             FPRMap[BlockNode].reads |= FPRBit(Op->Offset, IROp->Size);
         }
         else if (IROp->Op == OP_STORECONTEXTINDEXED ||
-               IROp->Op == OP_LOADCONTEXTINDEXED ||
-               IROp->Op == OP_LOADCONTEXTPAIR ||
-               IROp->Op == OP_STORECONTEXTPAIR) {
+               IROp->Op == OP_LOADCONTEXTINDEXED) {
           // We can't track through these
           FPRMap[BlockNode].reads = -1;
         }

--- a/External/FEXCore/Source/Interface/IR/Passes/DeadFlagStoreElimination.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/DeadFlagStoreElimination.cpp
@@ -68,9 +68,9 @@ bool DeadFlagStoreElimination::Run(IREmitter *IREmit) {
           OrderedNode *TargetNode = CurrentIR.GetNode(Op->Header.Args[0]);
 
           // stores to remove are written by the next block but not read
-          FlagMap[BlockNode].kill = FlagMap[TargetNode].writes & ~(FlagMap[TargetNode].reads);
+          FlagMap[BlockNode].kill = FlagMap[TargetNode].writes & ~(FlagMap[TargetNode].reads) & ~FlagMap[BlockNode].reads;
 
-          // Flags that are written by the next block can be considered as written by this block, if not read
+          // GPRs that are written by the next block can be considered as written by this block, if not read
           FlagMap[BlockNode].writes |= FlagMap[BlockNode].kill & ~FlagMap[BlockNode].reads;
         }
         else if (IROp->Op == OP_CONDJUMP) {
@@ -80,8 +80,8 @@ bool DeadFlagStoreElimination::Run(IREmitter *IREmit) {
           OrderedNode *FalseTargetNode = CurrentIR.GetNode(Op->FalseBlock);
 
           // stores to remove are written by the next blocks but not read
-          FlagMap[BlockNode].kill = FlagMap[TrueTargetNode].writes & ~(FlagMap[TrueTargetNode].reads);
-          FlagMap[BlockNode].kill &= FlagMap[FalseTargetNode].writes & ~(FlagMap[FalseTargetNode].reads);
+          FlagMap[BlockNode].kill = FlagMap[TrueTargetNode].writes & ~(FlagMap[TrueTargetNode].reads) & ~FlagMap[BlockNode].reads;
+          FlagMap[BlockNode].kill &= FlagMap[FalseTargetNode].writes & ~(FlagMap[FalseTargetNode].reads) & ~FlagMap[BlockNode].reads;
 
           // Flags that are written by the next blocks can be considered as written by this block, if not read
           FlagMap[BlockNode].writes |= FlagMap[BlockNode].kill & ~FlagMap[BlockNode].reads;

--- a/External/FEXCore/Source/Interface/IR/Passes/DeadFlagStoreElimination.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/DeadFlagStoreElimination.cpp
@@ -70,7 +70,7 @@ bool DeadFlagStoreElimination::Run(IREmitter *IREmit) {
           // stores to remove are written by the next block but not read
           FlagMap[BlockNode].kill = FlagMap[TargetNode].writes & ~(FlagMap[TargetNode].reads) & ~FlagMap[BlockNode].reads;
 
-          // GPRs that are written by the next block can be considered as written by this block, if not read
+          // Flags that are written by the next block can be considered as written by this block, if not read
           FlagMap[BlockNode].writes |= FlagMap[BlockNode].kill & ~FlagMap[BlockNode].reads;
         }
         else if (IROp->Op == OP_CONDJUMP) {

--- a/External/FEXCore/Source/Interface/IR/Passes/DeadGPRStoreElimination.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/DeadGPRStoreElimination.cpp
@@ -77,9 +77,7 @@ bool DeadGPRStoreElimination::Run(IREmitter *IREmit) {
             GPRMap[BlockNode].reads |= GPRBit(Op->Offset);
         }
         else if (IROp->Op == OP_STORECONTEXTINDEXED ||
-               IROp->Op == OP_LOADCONTEXTINDEXED ||
-               IROp->Op == OP_LOADCONTEXTPAIR ||
-               IROp->Op == OP_STORECONTEXTPAIR) {
+               IROp->Op == OP_LOADCONTEXTINDEXED) {
           // We can't track through these
           GPRMap[BlockNode].reads = -1;
         }

--- a/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -6,6 +6,8 @@
 #include <iterator>
 #include <unordered_set>
 
+#define SRA_DEBUG(...) // printf(__VA_ARGS__)
+
 namespace {
   constexpr uint32_t INVALID_REG = ~0U;
   constexpr uint64_t INVALID_REGCLASS = ~0ULL;
@@ -56,6 +58,10 @@ namespace {
     uint32_t Begin;
     uint32_t End;
     uint32_t RematCost;
+    int64_t PrefferedRegister;
+    uint32_t PreWritten;
+    bool Written;
+    bool Global;
   };
 
   struct SpillStackUnit {
@@ -175,6 +181,23 @@ namespace {
     Graph->Nodes[Node].Head.PhiPartner = &Graph->Nodes[Partner];
   }
 
+
+  bool DoesNodeConflictWithRegAndClass(RegisterGraph *Graph, RegisterNode const *InterferenceNode, uint64_t RegAndClass) {
+    if (InterferenceNode->Head.RegAndClass == RegAndClass) {
+      return true;
+    }
+
+    FEXCore::IR::RegisterClassType InterferenceClass = FEXCore::IR::RegisterClassType{(uint32_t)(InterferenceNode->Head.RegAndClass >> 32)};
+    uint32_t InterferenceReg = InterferenceNode->Head.RegAndClass;
+    if (InterferenceReg != INVALID_REG &&
+        InterferenceReg < Graph->Set.Classes[InterferenceClass].Conflicts.size() &&
+        Graph->Set.Classes[InterferenceClass].Conflicts[InterferenceReg] == RegAndClass) {
+      return true;
+    }
+
+    return false;
+  }
+
   /**
    * @brief Individual node interference check
    */
@@ -182,15 +205,8 @@ namespace {
     // Walk the node's interference list and see if it interferes with this register
     for (uint32_t i = 0; i < Node->Head.InterferenceCount; ++i) {
       RegisterNode *InterferenceNode = &Graph->Nodes[Node->InterferenceList[i]];
-      if (InterferenceNode->Head.RegAndClass == RegAndClass) {
-        return true;
-      }
-
-      FEXCore::IR::RegisterClassType InterferenceClass = FEXCore::IR::RegisterClassType{(uint32_t)(InterferenceNode->Head.RegAndClass >> 32)};
-      uint32_t InterferenceReg = InterferenceNode->Head.RegAndClass;
-      if (InterferenceReg != INVALID_REG &&
-          InterferenceReg < Graph->Set.Classes[InterferenceClass].Conflicts.size() &&
-          Graph->Set.Classes[InterferenceClass].Conflicts[InterferenceReg] == RegAndClass) {
+      
+      if (DoesNodeConflictWithRegAndClass(Graph, InterferenceNode, RegAndClass)) {
         return true;
       }
     }
@@ -221,6 +237,11 @@ namespace {
     switch (IROp->Op) {
       case IR::OP_LOADCONTEXT: {
         auto Op = IROp->C<IR::IROp_LoadContext>();
+        return Op->Class;
+        break;
+      }
+      case IR::OP_LOADREGISTER: {
+        auto Op = IROp->C<IR::IROp_LoadRegister>();
         return Op->Class;
         break;
       }
@@ -272,12 +293,13 @@ namespace {
 namespace FEXCore::IR {
   class ConstrainedRAPass final : public RegisterAllocationPass {
     public:
-      ConstrainedRAPass(FEXCore::IR::Pass* _CompactionPass);
+      ConstrainedRAPass(FEXCore::IR::Pass* _CompactionPass, bool OptimizeSRA);
       ~ConstrainedRAPass();
       bool Run(IREmitter *IREmit) override;
 
       void AllocateRegisterSet(uint32_t RegisterCount, uint32_t ClassCount) override;
       void AddRegisters(FEXCore::IR::RegisterClassType Class, uint32_t RegisterCount) override;
+      void AddStaticRegisters(FEXCore::IR::RegisterClassType Class, uint32_t RegisterBase, uint32_t RegisterCount) override;
       void AddRegisterConflict(FEXCore::IR::RegisterClassType ClassConflict, uint32_t RegConflict, FEXCore::IR::RegisterClassType Class, uint32_t Reg) override;
       void AllocateRegisterConflicts(FEXCore::IR::RegisterClassType Class, uint32_t NumConflicts) override;
 
@@ -287,6 +309,7 @@ namespace FEXCore::IR {
        */
       uint64_t GetNodeRegister(uint32_t Node) override;
     private:
+    bool OptimizeSRA;
 
       std::vector<uint32_t> PhysicalRegisterCount;
       std::vector<uint32_t> TopRAPressure;
@@ -304,6 +327,7 @@ namespace FEXCore::IR {
       BlockInterferences GlobalBlockInterferences;
 
       void CalculateLiveRange(FEXCore::IR::IRListView<false> *IR);
+      void OptimizeStaticRegisters(FEXCore::IR::IRListView<false> *IR);
       void CalculateBlockInterferences(FEXCore::IR::IRListView<false> *IR);
       void CalculateBlockNodeInterference(FEXCore::IR::IRListView<false> *IR);
       void CalculateNodeInterference(FEXCore::IR::IRListView<false> *IR);
@@ -316,12 +340,13 @@ namespace FEXCore::IR {
 
       uint32_t FindNodeToSpill(IREmitter *IREmit, RegisterNode *RegisterNode, uint32_t CurrentLocation, LiveRange const *OpLiveRange, int32_t RematCost = -1);
       uint32_t FindSpillSlot(uint32_t Node, FEXCore::IR::RegisterClassType RegisterClass);
+      uint32_t StaticRegisterBase;
 
       bool RunAllocateVirtualRegisters(IREmitter *IREmit);
   };
 
-  ConstrainedRAPass::ConstrainedRAPass(FEXCore::IR::Pass* _CompactionPass)
-    : CompactionPass {_CompactionPass} {
+  ConstrainedRAPass::ConstrainedRAPass(FEXCore::IR::Pass* _CompactionPass, bool _OptimizeSRA)
+    : CompactionPass {_CompactionPass}, OptimizeSRA(_OptimizeSRA) {
   }
 
   ConstrainedRAPass::~ConstrainedRAPass() {
@@ -340,6 +365,11 @@ namespace FEXCore::IR {
     AllocateRegisters(Graph, Class, DEFAULT_VIRTUAL_REG_COUNT);
     AllocatePhysicalRegisters(Graph, Class, RegisterCount);
     PhysicalRegisterCount[Class] = RegisterCount;
+  }
+
+
+  void ConstrainedRAPass::AddStaticRegisters(FEXCore::IR::RegisterClassType Class, uint32_t RegisterBase, uint32_t RegisterCount) {
+    StaticRegisterBase = RegisterBase;
   }
 
   void ConstrainedRAPass::AddRegisterConflict(FEXCore::IR::RegisterClassType ClassConflict, uint32_t RegConflict, FEXCore::IR::RegisterClassType Class, uint32_t Reg) {
@@ -383,9 +413,10 @@ namespace FEXCore::IR {
     if (Nodes > LiveRanges.size()) {
       LiveRanges.resize(Nodes);
     }
-    LiveRanges.assign(Nodes * sizeof(LiveRange), {~0U, ~0U});
+    LiveRanges.assign(Nodes * sizeof(LiveRange), {~0U, ~0U, 0, -1, false, 0});
 
     constexpr uint32_t DEFAULT_REMAT_COST = 1000;
+
     for (auto [BlockNode, BlockHeader] : IR->GetBlocks()) {
       uint32_t BlockNodeID = IR->GetID(BlockNode);
       for (auto [CodeNode, IROp] : IR->GetCode(BlockNode)) {
@@ -399,11 +430,13 @@ namespace FEXCore::IR {
           LiveRanges[Node].End = Node;
         }
 
+
         // Calculate remat cost
         switch (IROp->Op) {
           case IR::OP_CONSTANT: LiveRanges[Node].RematCost = 1; break;
           case IR::OP_LOADFLAG:
           case IR::OP_LOADCONTEXT: LiveRanges[Node].RematCost = 10; break;
+          case IR::OP_LOADREGISTER: LiveRanges[Node].RematCost = 10; break;
           case IR::OP_LOADMEM:
           case IR::OP_LOADMEMTSO:
             LiveRanges[Node].RematCost = 100;
@@ -425,10 +458,12 @@ namespace FEXCore::IR {
           LogMan::Throw::A(LiveRanges[ArgNode].Begin != ~0U, "%%ssa%d used by %%ssa%d before defined?", ArgNode, Node);
 
           auto ArgNodeBlockID = Graph->Nodes[ArgNode].Head.BlockID;
-          if ( ArgNodeBlockID== BlockNodeID) {
+          if (ArgNodeBlockID == BlockNodeID) {
             // Set the node end to be at least here
             LiveRanges[ArgNode].End = Node;
           } else {
+            LiveRanges[ArgNode].Global = true;
+
             // Grow the live range to include this use
             LiveRanges[ArgNode].Begin = std::min(LiveRanges[ArgNode].Begin, Node);
             LiveRanges[ArgNode].End = std::max(LiveRanges[ArgNode].End, Node);
@@ -457,6 +492,208 @@ namespace FEXCore::IR {
             SetNodePartner(Graph, CurrentSourcePartner, ValueOp->Value.ID());
             CurrentSourcePartner = ValueOp->Value.ID();
             NodeBegin = IR->at(ValueOp->Next);
+          }
+        }
+      }
+    }
+  }
+
+  void ConstrainedRAPass::OptimizeStaticRegisters(FEXCore::IR::IRListView<false> *IR) {
+
+    auto IsPreWritable = [](uint8_t Size, RegisterClassType StaticClass) {
+      if (StaticClass == GPRFixedClass) {
+        return Size == 8;
+      } else if (StaticClass == FPRFixedClass) {
+        return Size == 16;
+      } else {
+        assert(false);
+      }
+    };
+
+    auto IsAliasable = [](uint8_t Size, RegisterClassType StaticClass) {
+      if (StaticClass == GPRFixedClass) {
+        return Size == 8 || Size == 4; // lower values depend on z-ext semantics
+      } else if (StaticClass == FPRFixedClass) {
+        return Size == 16 || Size == 8 || Size == 4; // maybe 2 and 1 are safe too
+      } else {
+        assert(false);
+      }
+    };
+
+    auto GetRegAndClassFromOffset = [](uint32_t Offset) {
+        auto beginGpr = offsetof(FEXCore::Core::ThreadState, State.gregs[0]);
+        auto endGpr = offsetof(FEXCore::Core::ThreadState, State.gregs[17]);
+
+        auto beginFpr = offsetof(FEXCore::Core::ThreadState, State.xmm[0][0]);
+        auto endFpr = offsetof(FEXCore::Core::ThreadState, State.xmm[17][0]);
+
+        if (Offset >= beginGpr && Offset < endGpr) {
+          //assert(Class == GPRClass);
+          auto reg = (Offset - beginGpr) / 8;
+          return (uint64_t(GPRFixedClass.Val)<<32) | reg;
+        } else if (Offset >= beginFpr && Offset < endFpr) {
+          //assert(Class == FPRClass);
+          auto reg = (Offset - beginFpr) / 16;
+          return (uint64_t(FPRFixedClass.Val)<<32) | reg;
+        } else {
+          assert(false);
+          return ~0UL;
+        }
+    };
+
+    auto GprSize = PhysicalRegisterCount[GPRFixedClass.Val];
+    auto MapsSize = PhysicalRegisterCount[GPRFixedClass.Val] + PhysicalRegisterCount[FPRFixedClass.Val];
+    LiveRange* StaticMaps[MapsSize];
+    
+    auto GetStaticMapFromOffset = [&](uint32_t Offset) {
+        auto beginGpr = offsetof(FEXCore::Core::ThreadState, State.gregs[0]);
+        auto endGpr = offsetof(FEXCore::Core::ThreadState, State.gregs[17]);
+
+        auto beginFpr = offsetof(FEXCore::Core::ThreadState, State.xmm[0][0]);
+        auto endFpr = offsetof(FEXCore::Core::ThreadState, State.xmm[17][0]);
+
+        if (Offset >= beginGpr && Offset < endGpr) {
+          //assert(Class == GPRClass);
+          auto reg = (Offset - beginGpr) / 8;
+          return &StaticMaps[reg];
+        } else if (Offset >= beginFpr && Offset < endFpr) {
+          //assert(Class == FPRClass);
+          auto reg = (Offset - beginFpr) / 16;
+          return &StaticMaps[GprSize + reg];
+        } else {
+          assert(false);
+          return (LiveRange**)nullptr;
+        }
+    };
+
+    auto GetStaticMapFromReg = [&](int64_t RegAndClass) {
+      uint32_t Class = RegAndClass >> 32;
+      uint32_t Reg = RegAndClass;
+
+      if (Class == GPRFixedClass.Val) {
+        return &StaticMaps[Reg];
+      } else if (Class == FPRFixedClass.Val) {
+        return &StaticMaps[GprSize + Reg];
+      } else {
+        printf("Class: %d\n", Class);
+        assert(false);
+        return (LiveRange**)nullptr;
+      }
+    };
+
+    // do a pass to set writen IDs
+    for (auto [BlockNode, BlockHeader] : IR->GetBlocks()) {
+      for (auto [CodeNode, IROp] : IR->GetCode(BlockNode)) {
+        uint32_t Node = IR->GetID(CodeNode);
+        if (IROp->Op == OP_STOREREGISTER) {
+          auto Op = IROp->C<IR::IROp_StoreRegister>();
+          //int -1 /*vreg*/ = (int)(Op->Offset / 8) - 1;
+
+          if (IsPreWritable(IROp->Size, Op->StaticClass) 
+            && LiveRanges[Op->Value.ID()].PrefferedRegister == -1
+            && !LiveRanges[Op->Value.ID()].Global) {
+            
+            //pre-write and sra-allocate in the defining node - this might be undone if a read before the actual store happens
+            SRA_DEBUG("Prewritting ssa%d (Store in ssa%d)\n", Op->Value.ID(), Node);
+            LiveRanges[Op->Value.ID()].PrefferedRegister = GetRegAndClassFromOffset(Op->Offset);
+            LiveRanges[Op->Value.ID()].PreWritten = Node;
+            SetNodeClass(Graph, Op->Value.ID(), Op->StaticClass);
+          }
+        }
+      }
+    }
+
+    ////
+    for (auto [BlockNode, BlockHeader] : IR->GetBlocks()) {
+      memset(StaticMaps, 0, MapsSize * sizeof(LiveRange*));
+      for (auto [CodeNode, IROp] : IR->GetCode(BlockNode)) {
+        uint32_t Node = IR->GetID(CodeNode);
+
+        uint8_t NumArgs = IR::GetArgs(IROp->Op);
+        for (uint8_t i = 0; i < NumArgs; ++i) {
+          if (IROp->Args[i].IsInvalid()) continue;
+          if (IR->GetOp<IROp_Header>(IROp->Args[i])->Op == OP_INLINECONSTANT) continue;
+          uint32_t ArgNode = IROp->Args[i].ID();
+          
+          // ACCESSED after write, let's not SRA this one
+          if (LiveRanges[ArgNode].Written) {
+            SRA_DEBUG("Demoting ssa%d because accessed after write in ssa%d\n", ArgNode, Node);
+            LiveRanges[ArgNode].PrefferedRegister = -1;
+            auto ArgNodeNode = IR->GetNode(IROp->Args[i]);
+            SetNodeClass(Graph, ArgNode, GetRegClassFromNode(IR, ArgNodeNode->Op(IR->GetData())));
+          }
+        }
+
+
+        if (IROp->HasDest) {
+          if (LiveRanges[Node].PrefferedRegister  != -1) {
+            SRA_DEBUG("ssa%d is a pre-write\n", Node);
+            auto StaticMap = GetStaticMapFromReg(LiveRanges[Node].PrefferedRegister);
+            if ((*StaticMap)) {
+              SRA_DEBUG("Markng ssa%ld as written because ssa%d writes to sra%d\n", (*StaticMap) - &LiveRanges[0], Node, -1 /*vreg*/);
+              (*StaticMap)->Written = true;
+            }
+            (*StaticMap) = &LiveRanges[Node];
+          }
+
+          if (IROp->Op == OP_LOADREGISTER) {
+            auto Op = IROp->C<IR::IROp_LoadRegister>();
+
+            auto StaticMap = GetStaticMapFromOffset(Op->Offset);
+
+            // Make sure there wasn't a store pre-written before this read
+            if ((*StaticMap) && (*StaticMap)->PreWritten) {
+              uint32_t ID = (*StaticMap) - &LiveRanges[0];
+
+              SRA_DEBUG("ssa%d cannot be a pre-write because ssa%d reads from sra%d before storereg", ID, Node, -1 /*vreg*/);
+              (*StaticMap)->PrefferedRegister = -1;
+              (*StaticMap)->PreWritten = 0;
+              SetNodeClass(Graph, ID, Op->Class);
+            }
+
+            // if not sra-allocated and full size, sra-allocate
+            if (!LiveRanges[Node].Global && LiveRanges[Node].PrefferedRegister  == -1) {
+              // only full size reads can be aliased
+              if (IsAliasable(IROp->Size, Op->StaticClass)) {
+
+                // We can only track a single active span.
+                // Marking here as written is overly agressive, but 
+                // there might be write(s) later on the instruction stream
+                if ((*StaticMap)) {
+                  SRA_DEBUG("Markng ssa%ld as written because ssa%d re-loads sra%d, and we can't track possible future writes\n", (*StaticMap) - &LiveRanges[0], Node, -1 /*vreg*/);
+                  (*StaticMap)->Written = true; 
+                }
+
+                LiveRanges[Node].PrefferedRegister = GetRegAndClassFromOffset(Op->Offset); //0, 1, and so on
+                (*StaticMap) = &LiveRanges[Node];
+                SetNodeClass(Graph, Node, Op->StaticClass);
+                SRA_DEBUG("Marking ssa%d as allocated to sra%d\n", Node, -1 /*vreg*/);
+              }
+            }
+          }
+        }
+
+        if (IROp->Op == OP_STOREREGISTER) {
+          auto Op = IROp->C<IR::IROp_StoreRegister>();
+
+          //int -1 /*vreg*/ = (int)(Op->Offset / 8) - 1;
+          auto StaticMap = GetStaticMapFromOffset(Op->Offset);
+          // if a read pending, it has been writting
+          if ((*StaticMap)) {
+            // old way of calculating this
+            //uint32_t ID  = (*StaticMap) - &LiveRanges[0];
+            // ID != Op->Value.ID() || IROp->Size != 8
+
+            // writes to self don't invalidate the span
+            if ((*StaticMap)->PreWritten != Node) {
+              SRA_DEBUG("Markng ssa%d as written because ssa%d writes to sra%d with value ssa%d. Write size is %d\n", ID, Node, -1 /*vreg*/, Op->Value.ID(), IROp->Size);
+              (*StaticMap)->Written = true;
+            }
+          }
+          if (LiveRanges[Op->Value.ID()].PreWritten == Node) {
+            // no longer pre-written
+            LiveRanges[Op->Value.ID()].PreWritten = 0;
+            SRA_DEBUG("Markng ssa%d as no longer pre-written as ssa%d is a storereg for sra%d\n", Op->Value.ID(), Node, -1 /*vreg*/);
           }
         }
       }
@@ -566,8 +803,21 @@ namespace FEXCore::IR {
       for (uint32_t j = i + 1; j < NodeCount; ++j) {
         if (!(LiveRanges[i].Begin >= LiveRanges[j].End ||
               LiveRanges[j].Begin >= LiveRanges[i].End)) {
-          AddInterference(i, j);
-          AddInterference(j, i);
+          
+          auto GetClass = [](uint64_t RegAndClass) {
+            uint32_t Class = RegAndClass >> 32;
+
+            if (Class == IR::GPRPairClass.Val)
+              return IR::GPRClass.Val;
+            else
+              return Class;
+          };
+
+          if (GetClass(Graph->Nodes[i].Head.RegAndClass) == GetClass(Graph->Nodes[j].Head.RegAndClass))
+          {
+            AddInterference(i, j);
+            AddInterference(j, i);
+          }
         }
       }
     }
@@ -579,9 +829,12 @@ namespace FEXCore::IR {
       if (CurrentNode->Head.RegAndClass == INVALID_REGCLASS)
         continue;
 
+      auto LiveRange = &LiveRanges[i];
+
       FEXCore::IR::RegisterClassType RegClass = FEXCore::IR::RegisterClassType{uint32_t(CurrentNode->Head.RegAndClass >> 32)};
       uint64_t RegAndClass = ~0ULL;
       RegisterClass *RAClass = &Graph->Set.Classes[RegClass];
+
       if (CurrentNode->Head.PhiPartner) {
         // In the case that we have a list of nodes that need the same register allocated we need to do something special
         // We need to gather the data from the forward linked list and make sure they all match the virtual register
@@ -606,7 +859,7 @@ namespace FEXCore::IR {
           RegAndClass |= AllocateMoreRegisters(Graph, RegClass);
         }
 
-        TopRAPressure[RegClass] = std::max((uint32_t)RegAndClass, TopRAPressure[RegClass]);
+        TopRAPressure[RegClass] = std::max((uint32_t)RegAndClass + 1, TopRAPressure[RegClass]);
 
         // Walk the partners and ensure they are all set to the same register now
         for (auto Partner : Nodes) {
@@ -614,11 +867,16 @@ namespace FEXCore::IR {
         }
       }
       else {
-        for (uint32_t ri = 0; ri < RAClass->Count; ++ri) {
-          uint64_t RegisterToCheck = (static_cast<uint64_t>(RegClass) << 32) + ri;
-          if (!DoesNodeInterfereWithRegister(Graph, CurrentNode, RegisterToCheck)) {
-            RegAndClass = RegisterToCheck;
-            break;
+
+        if (LiveRange->PrefferedRegister != -1) {
+          RegAndClass = LiveRange->PrefferedRegister;
+        } else {
+          for (uint32_t ri = 0; ri < RAClass->Count; ++ri) {
+            uint64_t RegisterToCheck = (static_cast<uint64_t>(RegClass) << 32) + ri;
+            if (!DoesNodeInterfereWithRegister(Graph, CurrentNode, RegisterToCheck)) {
+              RegAndClass = RegisterToCheck;
+              break;
+            }
           }
         }
 
@@ -628,7 +886,7 @@ namespace FEXCore::IR {
           RegAndClass |= AllocateMoreRegisters(Graph, RegClass);
         }
 
-        TopRAPressure[RegClass] = std::max((uint32_t)RegAndClass, TopRAPressure[RegClass]);
+        TopRAPressure[RegClass] = std::max((uint32_t)RegAndClass + 1, TopRAPressure[RegClass]);
         CurrentNode->Head.RegAndClass = RegAndClass;
       }
     }
@@ -713,6 +971,9 @@ namespace FEXCore::IR {
             (RematCost != -1 && InterferenceLiveRange->RematCost != RematCost)) {
           continue;
         }
+
+        //if ((RegisterNode->Head.RegAndClass>>32) != (InterferenceNode->Head.RegAndClass>>32))
+        //  continue;
 
         // If this node's live range fully encompasses the live range of the interference node
         // then spilling that interference node will not lower RA
@@ -941,8 +1202,9 @@ namespace FEXCore::IR {
           // that is cheapest
           FEXCore::IR::RegisterClassType RegClass = FEXCore::IR::RegisterClassType{uint32_t(CurrentNode->Head.RegAndClass >> 32)};
           bool NeedsToSpill = (uint32_t)CurrentNode->Head.RegAndClass >= PhysicalRegisterCount.at(RegClass);
-
+      
           if (NeedsToSpill) {
+            //printf("SPILL Class: %d %lX, %x\n", RegClass, CurrentNode->Head.RegAndClass, PhysicalRegisterCount.at(RegClass));
             bool Spilled = false;
 
             // First let's just check for constants that we can just rematerialize instead of spilling
@@ -977,6 +1239,7 @@ namespace FEXCore::IR {
                 LogMan::Throw::A((InterferenceRegisterNode->Head.RegAndClass & ~0U) != ~0U, "Interference node never assigned a register?");
                 LogMan::Throw::A(InterferenceRegClass != ~0U, "Interference node never assigned a register class?");
                 LogMan::Throw::A(InterferenceRegisterNode->Head.PhiPartner == nullptr, "We don't support spilling PHI nodes currently");
+                LogMan::Throw::A(InterferenceRegClass == RegClass, "Class doesn't match");
 
                 // This is the op that we need to dump
                 auto [InterferenceOrderedNode, InterferenceIROp] = IR.at(InterferenceNode)();
@@ -1051,14 +1314,16 @@ namespace FEXCore::IR {
     ResetRegisterGraph(Graph, SSACount);
     FindNodeClasses(Graph, &IR);
     CalculateLiveRange(&IR);
+    if (OptimizeSRA)
+      OptimizeStaticRegisters(&IR);
 
     // Linear foward scan based interference calculation is faster for smaller blocks
     // Smarter block based interference calculation is faster for larger blocks
-    if (SSACount >= 2048) {
+    /*if (SSACount >= 2048) {
       CalculateBlockInterferences(&IR);
       CalculateBlockNodeInterference(&IR);
     }
-    else {
+    else*/ {
       CalculateNodeInterference(&IR);
     }
     AllocateVirtualRegisters();
@@ -1108,9 +1373,9 @@ namespace FEXCore::IR {
       for (size_t i = 0; i < PhysicalRegisterCount.size(); ++i) {
         // Virtual registers fit completely within physical registers
         // Remap virtual 1:1 to physical
-        HadFullRA &= TopRAPressure[i] < PhysicalRegisterCount[i];
+        HadFullRA &= TopRAPressure[i] <= PhysicalRegisterCount[i];
       }
-
+      
       if (HadFullRA) {
         break;
       }
@@ -1122,7 +1387,7 @@ namespace FEXCore::IR {
     return Changed;
   }
 
-  FEXCore::IR::RegisterAllocationPass* CreateRegisterAllocationPass(FEXCore::IR::Pass* CompactionPass) {
-    return new ConstrainedRAPass{CompactionPass};
+  FEXCore::IR::RegisterAllocationPass* CreateRegisterAllocationPass(FEXCore::IR::Pass* CompactionPass, bool OptimizeSRA) {
+    return new ConstrainedRAPass{CompactionPass, OptimizeSRA};
   }
 }

--- a/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -510,11 +510,11 @@ namespace FEXCore::IR {
       }
     };
 
-    auto IsAliasable = [](uint8_t Size, RegisterClassType StaticClass) {
+    auto IsAliasable = [](uint8_t Size, RegisterClassType StaticClass, uint32_t Offset) {
       if (StaticClass == GPRFixedClass) {
-        return Size == 8 || Size == 4; // lower values depend on z-ext semantics
+        return (Size == 8 || Size == 4) && ((Offset & 7) == 0); // lower values depend on z-ext semantics
       } else if (StaticClass == FPRFixedClass) {
-        return Size == 16 || Size == 8 || Size == 4; // maybe 2 and 1 are safe too
+        return (Size == 16 || Size == 8 || Size == 4) && ((Offset & 15) == 0); // maybe 2 and 1 are safe too
       } else {
         assert(false);
       }
@@ -654,7 +654,7 @@ namespace FEXCore::IR {
             // if not sra-allocated and full size, sra-allocate
             if (!LiveRanges[Node].Global && LiveRanges[Node].PrefferedRegister  == -1) {
               // only full size reads can be aliased
-              if (IsAliasable(IROp->Size, Op->StaticClass)) {
+              if (IsAliasable(IROp->Size, Op->StaticClass, Op->Offset)) {
 
                 // We can only track a single active span.
                 // Marking here as written is overly agressive, but 

--- a/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -509,9 +509,9 @@ namespace FEXCore::IR {
 
     auto IsAliasable = [](uint8_t Size, RegisterClassType StaticClass, uint32_t Offset) {
       if (StaticClass == GPRFixedClass) {
-        return (Size == 8 || Size == 4) && ((Offset & 7) == 0); // lower values depend on z-ext semantics
+        return (Size == 8 /*|| Size == 4*/) && ((Offset & 7) == 0); // We need more meta info to support not-size-of-reg
       } else if (StaticClass == FPRFixedClass) {
-        return (Size == 16 || Size == 8 || Size == 4) && ((Offset & 15) == 0); // maybe 2 and 1 are safe too
+        return (Size == 16 /*|| Size == 8 || Size == 4*/) && ((Offset & 15) == 0); // We need more meta info to support not-size-of-reg
       } else {
         assert(false);
       }

--- a/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -503,7 +503,7 @@ namespace FEXCore::IR {
       } else if (StaticClass == FPRFixedClass) {
         return Size == 16;
       } else {
-        assert(false);
+        LogMan::Throw::A(false, "Unexpected static class %d", StaticClass);
       }
     };
 
@@ -513,7 +513,7 @@ namespace FEXCore::IR {
       } else if (StaticClass == FPRFixedClass) {
         return (Size == 16 /*|| Size == 8 || Size == 4*/) && ((Offset & 15) == 0); // We need more meta info to support not-size-of-reg
       } else {
-        assert(false);
+        LogMan::Throw::A(false, "Unexpected static class %d", StaticClass);
       }
     };
 
@@ -525,15 +525,13 @@ namespace FEXCore::IR {
         auto endFpr = offsetof(FEXCore::Core::ThreadState, State.xmm[17][0]);
 
         if (Offset >= beginGpr && Offset < endGpr) {
-          //assert(Class == GPRClass);
           auto reg = (Offset - beginGpr) / 8;
           return (uint64_t(GPRFixedClass.Val)<<32) | reg;
         } else if (Offset >= beginFpr && Offset < endFpr) {
-          //assert(Class == FPRClass);
           auto reg = (Offset - beginFpr) / 16;
           return (uint64_t(FPRFixedClass.Val)<<32) | reg;
         } else {
-          assert(false);
+          LogMan::Throw::A(false, "Unexpected Offset %d", Offset);
           return ~0UL;
         }
     };
@@ -550,15 +548,13 @@ namespace FEXCore::IR {
         auto endFpr = offsetof(FEXCore::Core::ThreadState, State.xmm[17][0]);
 
         if (Offset >= beginGpr && Offset < endGpr) {
-          //assert(Class == GPRClass);
           auto reg = (Offset - beginGpr) / 8;
           return &StaticMaps[reg];
         } else if (Offset >= beginFpr && Offset < endFpr) {
-          //assert(Class == FPRClass);
           auto reg = (Offset - beginFpr) / 16;
           return &StaticMaps[GprSize + reg];
         } else {
-          assert(false);
+          LogMan::Throw::A(false, "Unexpected offset %d", Offset);
           return (LiveRange**)nullptr;
         }
     };
@@ -572,8 +568,7 @@ namespace FEXCore::IR {
       } else if (Class == FPRFixedClass.Val) {
         return &StaticMaps[GprSize + Reg];
       } else {
-        printf("Class: %d\n", Class);
-        assert(false);
+        LogMan::Throw::A(false, "Unexpected Class %d", Class);
         return (LiveRange**)nullptr;
       }
     };

--- a/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.h
+++ b/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.h
@@ -13,6 +13,7 @@ class RegisterAllocationPass : public FEXCore::IR::Pass {
 
     virtual void AllocateRegisterSet(uint32_t RegisterCount, uint32_t ClassCount) = 0;
     virtual void AddRegisters(FEXCore::IR::RegisterClassType Class, uint32_t RegisterCount) = 0;
+    virtual void AddStaticRegisters(FEXCore::IR::RegisterClassType Class, uint32_t RegisterBase, uint32_t RegisterCount) = 0;
 
     /**
      * @brief Adds a conflict between the two registers (and their respective classes) so if one is allocated then the other can not be allocated in

--- a/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.h
+++ b/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.h
@@ -13,7 +13,6 @@ class RegisterAllocationPass : public FEXCore::IR::Pass {
 
     virtual void AllocateRegisterSet(uint32_t RegisterCount, uint32_t ClassCount) = 0;
     virtual void AddRegisters(FEXCore::IR::RegisterClassType Class, uint32_t RegisterCount) = 0;
-    virtual void AddStaticRegisters(FEXCore::IR::RegisterClassType Class, uint32_t RegisterBase, uint32_t RegisterCount) = 0;
 
     /**
      * @brief Adds a conflict between the two registers (and their respective classes) so if one is allocated then the other can not be allocated in
@@ -28,7 +27,6 @@ class RegisterAllocationPass : public FEXCore::IR::Pass {
      * AddRegisterConflict(GPRClass, 1, PairClass, 1); -> Make sure the pair interferes with x1
      */
     virtual void AddRegisterConflict(FEXCore::IR::RegisterClassType ClassConflict, uint32_t RegConflict, FEXCore::IR::RegisterClassType Class, uint32_t Reg) = 0;
-    virtual void AllocateRegisterConflicts(FEXCore::IR::RegisterClassType Class, uint32_t NumConflicts) = 0;
 
     /**
      * @name Inference graph handling

--- a/External/FEXCore/Source/Interface/IR/Passes/StaticRegisterAllocationPass.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/StaticRegisterAllocationPass.cpp
@@ -1,0 +1,106 @@
+#include "Interface/IR/PassManager.h"
+#include "Interface/Core/OpcodeDispatcher.h"
+
+// Higher values might result in more stores getting eliminated but will make the optimization take more time
+
+namespace FEXCore::IR {
+
+class StaticRegisterAllocationPass final : public FEXCore::IR::Pass {
+public:
+  bool Run(IREmitter *IREmit) override;
+};
+
+bool IsStaticAllocGpr(uint32_t Offset, RegisterClassType Class) {
+  bool rv = false;
+  auto begin = offsetof(FEXCore::Core::ThreadState, State.gregs[0]);
+  auto end = offsetof(FEXCore::Core::ThreadState, State.gregs[17]);
+
+  if (Offset >= begin && Offset < end) {
+    auto reg = (Offset - begin) / 8;
+    assert(Class == IR::GPRClass);
+
+    rv = reg < 16; // 0..15 -> 16 in total
+  }
+
+  return rv;
+}
+
+bool IsStaticAllocFpr(uint32_t Offset, RegisterClassType Class, bool AllowGpr) {
+  bool rv = false;
+  auto begin = offsetof(FEXCore::Core::ThreadState, State.xmm[0][0]);
+  auto end = offsetof(FEXCore::Core::ThreadState, State.xmm[17][0]);
+
+  if (Offset >= begin && Offset < end) {
+    auto reg = (Offset - begin)/16;
+    assert(Class == IR::FPRClass || (AllowGpr && Class == IR::GPRClass));
+
+    rv = reg < 16; // 0..15 -> 16 in total
+  }
+
+  return rv;
+}
+/**
+ * @brief This is a temporary pass to detect simple multiblock dead GPR stores
+ *
+ * First pass computes which GPRs are read and written per block
+ *
+ * Second pass computes which GPRs are stored, but overwritten by the next block(s).
+ * It also propagates this information a few times to catch dead GPRs across multiple blocks.
+ *
+ * Third pass removes the dead stores.
+ *
+ */
+bool StaticRegisterAllocationPass::Run(IREmitter *IREmit) {
+  auto CurrentIR = IREmit->ViewIR();
+
+  if (CurrentIR.GetHeader()->ShouldInterpret)
+    return false;
+
+  for (auto [BlockNode, BlockIROp] : CurrentIR.GetBlocks()) {
+      for (auto [CodeNode, IROp] : CurrentIR.GetCode(BlockNode)) {
+        IREmit->SetWriteCursor(CodeNode);
+        
+        if (IROp->Op == OP_LOADCONTEXT) {
+            auto Op = IROp->CW<IR::IROp_LoadContext>();
+
+            if (IsStaticAllocGpr(Op->Offset, Op->Class) || IsStaticAllocFpr(Op->Offset, Op->Class, true)) {
+              auto GeneralClass = Op->Class;
+              if (IsStaticAllocFpr(Op->Offset, GeneralClass, true) && GeneralClass == GPRClass) {
+                GeneralClass = FPRClass;
+              }
+              auto StaticClass = GeneralClass == GPRClass ? GPRFixedClass : FPRFixedClass;
+              OrderedNode *sraReg = IREmit->_LoadRegister(false, Op->Offset, GeneralClass, StaticClass, Op->Header.Size);
+              if (GeneralClass != Op->Class) {
+                sraReg = IREmit->_VExtractToGPR(Op->Header.Size, Op->Header.Size, sraReg, 0);
+              }
+              IREmit->ReplaceAllUsesWith(CodeNode, sraReg);
+            }
+        } if (IROp->Op == OP_STORECONTEXT) {
+            auto Op = IROp->CW<IR::IROp_StoreContext>();
+
+            if (IsStaticAllocGpr(Op->Offset, Op->Class) || IsStaticAllocFpr(Op->Offset, Op->Class, true)) {
+              auto val = IREmit->UnwrapNode(Op->Value);
+
+              auto GeneralClass = Op->Class;
+              if (IsStaticAllocFpr(Op->Offset, GeneralClass, true) && GeneralClass == GPRClass) {
+                val = IREmit->_VCastFromGPR(Op->Header.Size, Op->Header.Size, val);
+                GeneralClass = FPRClass;
+              }
+
+              auto StaticClass = GeneralClass == GPRClass ? GPRFixedClass : FPRFixedClass;
+              OrderedNode *sraReg = IREmit->_StoreRegister(val, false, Op->Offset, GeneralClass, StaticClass, Op->Header.Size);
+
+              IREmit->Remove(CodeNode);
+            }
+        }
+    }
+  }
+
+  return true;
+}
+
+FEXCore::IR::Pass* CreateStaticRegisterAllocationPass() {
+  return new StaticRegisterAllocationPass{};
+}
+
+}

--- a/External/FEXCore/Source/Interface/IR/Passes/StaticRegisterAllocationPass.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/StaticRegisterAllocationPass.cpp
@@ -1,8 +1,6 @@
 #include "Interface/IR/PassManager.h"
 #include "Interface/Core/OpcodeDispatcher.h"
 
-// Higher values might result in more stores getting eliminated but will make the optimization take more time
-
 namespace FEXCore::IR {
 
 class StaticRegisterAllocationPass final : public FEXCore::IR::Pass {
@@ -40,14 +38,7 @@ bool IsStaticAllocFpr(uint32_t Offset, RegisterClassType Class, bool AllowGpr) {
   return rv;
 }
 /**
- * @brief This is a temporary pass to detect simple multiblock dead GPR stores
- *
- * First pass computes which GPRs are read and written per block
- *
- * Second pass computes which GPRs are stored, but overwritten by the next block(s).
- * It also propagates this information a few times to catch dead GPRs across multiple blocks.
- *
- * Third pass removes the dead stores.
+ * @brief This pass replaces Load/Store Context with Load/Store Register for Statically Mapped registers. It also does some validation.
  *
  */
 bool StaticRegisterAllocationPass::Run(IREmitter *IREmit) {

--- a/External/FEXCore/Source/Interface/IR/Passes/StaticRegisterAllocationPass.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/StaticRegisterAllocationPass.cpp
@@ -17,7 +17,7 @@ bool IsStaticAllocGpr(uint32_t Offset, RegisterClassType Class) {
 
   if (Offset >= begin && Offset < end) {
     auto reg = (Offset - begin) / 8;
-    assert(Class == IR::GPRClass);
+    LogMan::Throw::A(Class == IR::GPRClass, "unexpected Class %d", Class);
 
     rv = reg < 16; // 0..15 -> 16 in total
   }
@@ -32,7 +32,7 @@ bool IsStaticAllocFpr(uint32_t Offset, RegisterClassType Class, bool AllowGpr) {
 
   if (Offset >= begin && Offset < end) {
     auto reg = (Offset - begin)/16;
-    assert(Class == IR::FPRClass || (AllowGpr && Class == IR::GPRClass));
+    LogMan::Throw::A(Class == IR::FPRClass || (AllowGpr && Class == IR::GPRClass), "unexpected Class %d, AllowGpr %d", Class, AllowGpr);
 
     rv = reg < 16; // 0..15 -> 16 in total
   }

--- a/External/FEXCore/include/FEXCore/IR/IR.h
+++ b/External/FEXCore/include/FEXCore/IR/IR.h
@@ -68,7 +68,8 @@ struct NodeWrapperBase final {
   Type const *GetNode(uintptr_t Base) const { return reinterpret_cast<Type*>(Base + NodeOffset); }
 
   void SetOffset(uintptr_t Base, uintptr_t Value) { NodeOffset = Value - Base; }
-  bool operator==(NodeWrapperBase const &rhs) const { return NodeOffset == rhs.NodeOffset; }
+  constexpr bool operator==(NodeWrapperBase<Type> const &rhs) const { return NodeOffset == rhs.NodeOffset; }
+  constexpr bool operator!=(NodeWrapperBase<Type> const &rhs) const { return !operator==(rhs); }
 };
 
 static_assert(std::is_trivial<NodeWrapperBase<OrderedNode>>::value);


### PR DESCRIPTION
## Overview
Static Register Allocation keeps the guest context in fixed host registers in order to reduce load/stores and moves. 

The way this implementation works is: It replaces all eligible Load/Store Contexts to Load/Store Register, It adds an extra pass after the liveness analysis that determines whenever moves to/from the SRA host registers can be eliminated, and it adds context syncing logic. 

SRA is only implemented for the arm64 backend.

This
- Adds `OP_LOADREGISTER` and `OP_STOREREGISTER` to manipulate the statically allocated register context.
- Adds a new pass, StaticRegisterAllocation, than converts Load/Store Context to Load/Store Reg.
- Add two new allocation classes, `GPRFixedClass` and `FPRFixedClass`.
- Extends RegisterAllocation to alias-allocate `LoadRegister` and pre-write `StoreRegister`. The new allocation classes are used internally to represent SRA allocations in a separate dimension from the rest of the allocations.
- Updates the arm64 backend with needed meta-info, adds `SpillStaticRegs` and `FillStaticRegs` and calls them as needed to keep in sync with the in memory context around dispatch/callbacks/syscalls/signals
- Fixes some bugs in the reg allocators around class conflicts, global spans
- Cleanups spilling logic in the arm64 backend, adds FPR spills

## Compile Time Performance
The total extra cost is at O(4*N), and greatly reduces pressure on the register allocation and thus improving compile speeds.

## Runtime Performance
~ + 100% for integer bytemark, + 75% for floating point bytemark (See #477 for exact numbers)

## Correctness
- [x] Bytemark works
- [x] FTL works
- [x] UT2004 + hangover works
- [x] Metro 2033 Redux + hangover works
- [x] Tests pass

## Limitations
- Receiving a STOP or PAUSE signal while in the dispatcher will corrupt the guest register state. There's an assertion for that.
- Spilling overhead will slow down tight loops that do nothing but call out to C/C++ (syscalls, Interp Fallbacks, LDiv, that stuff)
- `Load/StoreContextIndexed` don't work as expected from/to the SRA'd regs
- read-aliasing assumes that opcodes that consume i32 values don't read the top bits. This isn't always true. We need to do use-analysis to prove it.

## Todo
- [x] Initial PoC without aliasing
- [x] `alias-allocation` for `LoadRegister`
- [x] `pre-write` for `StoreRegister`
- [x] Get review feedback
- [x] Add spills/reload on OP_SYSCALL for signal semantics
- [x] Optimize spill/reload code
- [x] Cleanup, document, test

## Follow ups
- [ ] Recover FPRs on exception
- [ ] Configurable SRA regs + disable SRA option
- [ ] Give back top 8 GPRS/FPRs to RA on x86-32
- [ ] Re-enable block live range calculations
- [ ] SRA re-allocation when the regs don't hold context values