### PR TITLE
Fix mapping of static elfs.

### DIFF
--- a/External/SonicUtils/include/SonicUtils/ELFSymbolDatabase.h
+++ b/External/SonicUtils/include/SonicUtils/ELFSymbolDatabase.h
@@ -9,7 +9,7 @@ public:
   ELFSymbolDatabase(::ELFLoader::ELFContainer *file);
   ~ELFSymbolDatabase();
 
-  ::ELFLoader::ELFContainer::MemoryLayout GetFileLayout() const;
+  uint64_t GetElfBase() const;
 
   void MapMemoryRegions(std::function<void*(uint64_t, uint64_t, bool, bool)> Mapper);
   void WriteLoadableSections(::ELFLoader::ELFContainer::MemoryWriter Writer);

--- a/Source/Tests/HarnessHelpers.h
+++ b/Source/Tests/HarnessHelpers.h
@@ -515,9 +515,8 @@ public:
       MemoryBase = 0;
     }
     // Set up our aux values here
-    auto FileLayout = DB.GetFileLayout();
-    AuxVariables.emplace_back(auxv_t{3, std::get<0>(FileLayout)}); // Program header
-    AuxVariables.emplace_back(auxv_t{7, std::get<0>(FileLayout)}); // Interpreter address
+    AuxVariables.emplace_back(auxv_t{3, DB.GetElfBase()}); // Program header
+    AuxVariables.emplace_back(auxv_t{7, DB.GetElfBase()}); // Interpreter address
     AuxVariables.emplace_back(auxv_t{9, DB.DefaultRIP()}); // AT_ENTRY
     AuxVariables.emplace_back(auxv_t{0, 0}); // Null ender
   }


### PR DESCRIPTION
Due to a bug dealing with empty program headers used as flags, we were previously relocating static ELFs up 16KB, which can cause them to break.

Fixes #498 