### PR TITLE
Remove 8/16bit ROR and all ROL IR ops as arm doesn't support them

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -1170,12 +1170,6 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
             };
 
             switch (OpSize) {
-              case 1:
-                GD = Ror(static_cast<uint8_t>(Src1), static_cast<uint8_t>(Src2));
-                break;
-              case 2:
-                GD = Ror(static_cast<uint16_t>(Src1), static_cast<uint16_t>(Src2));
-                break;
               case 4:
                 GD = Ror(static_cast<uint32_t>(Src1), static_cast<uint32_t>(Src2));
                 break;
@@ -1642,7 +1636,7 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
           }
           case IR::OP_SELECT: {
             auto Op = IROp->C<IR::IROp_Select>();
-            
+
             uint64_t Src1 = *GetSrc<uint64_t*>(SSAData, Op->Header.Args[0]);
             uint64_t Src2 = *GetSrc<uint64_t*>(SSAData, Op->Header.Args[1]);
 
@@ -1656,7 +1650,7 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
               ArgTrue = *GetSrc<uint64_t*>(SSAData, Op->Header.Args[2]);
               ArgFalse = *GetSrc<uint64_t*>(SSAData, Op->Header.Args[3]);
             }
-            
+
             bool CompResult;
 
             if (Op->CompareSize == 4)

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -1181,34 +1181,6 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
             }
             break;
           }
-          case IR::OP_ROL: {
-            auto Op = IROp->C<IR::IROp_Rol>();
-            uint64_t Src1 = *GetSrc<uint64_t*>(SSAData, Op->Header.Args[0]);
-            uint64_t Src2 = *GetSrc<uint64_t*>(SSAData, Op->Header.Args[1]);
-            auto Rol = [] (auto In, auto R) {
-            auto RotateMask = sizeof(In) * 8 - 1;
-              R &= RotateMask;
-              return (In << R) | (In >> (sizeof(In) * 8 - R));
-            };
-
-            switch (OpSize) {
-            case 1:
-              GD = Rol(static_cast<uint8_t>(Src1), static_cast<uint8_t>(Src2));
-              break;
-            case 2:
-              GD = Rol(static_cast<uint16_t>(Src1), static_cast<uint16_t>(Src2));
-              break;
-            case 4:
-              GD = Rol(static_cast<uint32_t>(Src1), static_cast<uint32_t>(Src2));
-              break;
-            case 8: {
-              GD = Rol(static_cast<uint64_t>(Src1), static_cast<uint64_t>(Src2));
-              break;
-            }
-            default: LogMan::Msg::A("Unknown ROL Size: %d\n", OpSize); break;
-            }
-            break;
-          }
           case IR::OP_EXTR: {
             auto Op = IROp->C<IR::IROp_Extr>();
             uint64_t Src1 = *GetSrc<uint64_t*>(SSAData, Op->Header.Args[0]);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -561,20 +561,6 @@ DEF_OP(Ror) {
   uint64_t Const;
   if (IsInlineConstant(Op->Header.Args[1], &Const)) {
     switch (OpSize) {
-      case 1: {
-        mov(TMP1.W(), GetReg<RA_32>(Op->Header.Args[0].ID()));
-        bfi(TMP1.W(), GetReg<RA_32>(Op->Header.Args[0].ID()), 8, 8);
-        bfi(TMP1.W(), GetReg<RA_32>(Op->Header.Args[0].ID()), 16, 8);
-        bfi(TMP1.W(), GetReg<RA_32>(Op->Header.Args[0].ID()), 24, 8);
-        ror(GetReg<RA_32>(Node), TMP1.W(), (unsigned int)Const);
-      break;
-      }
-      case 2: {
-        mov(TMP1.W(), GetReg<RA_32>(Op->Header.Args[0].ID()));
-        bfi(TMP1.W(), GetReg<RA_32>(Op->Header.Args[0].ID()), 16, 16);
-        ror(GetReg<RA_32>(Node), TMP1.W(), (unsigned int)Const);
-      break;
-      }
       case 4: {
         ror(GetReg<RA_32>(Node), GetReg<RA_32>(Op->Header.Args[0].ID()), (unsigned int)Const);
       break;
@@ -588,20 +574,6 @@ DEF_OP(Ror) {
     }
   } else {
     switch (OpSize) {
-      case 1: {
-        mov(TMP1.W(), GetReg<RA_32>(Op->Header.Args[0].ID()));
-        bfi(TMP1.W(), GetReg<RA_32>(Op->Header.Args[0].ID()), 8, 8);
-        bfi(TMP1.W(), GetReg<RA_32>(Op->Header.Args[0].ID()), 16, 8);
-        bfi(TMP1.W(), GetReg<RA_32>(Op->Header.Args[0].ID()), 24, 8);
-        rorv(GetReg<RA_32>(Node), TMP1.W(), GetReg<RA_32>(Op->Header.Args[1].ID()));
-      break;
-      }
-      case 2: {
-        mov(TMP1.W(), GetReg<RA_32>(Op->Header.Args[0].ID()));
-        bfi(TMP1.W(), GetReg<RA_32>(Op->Header.Args[0].ID()), 16, 16);
-        rorv(GetReg<RA_32>(Node), TMP1.W(), GetReg<RA_32>(Op->Header.Args[1].ID()));
-      break;
-      }
       case 4: {
         rorv(GetReg<RA_32>(Node), GetReg<RA_32>(Op->Header.Args[0].ID()), GetReg<RA_32>(Op->Header.Args[1].ID()));
       break;
@@ -1127,7 +1099,7 @@ DEF_OP(Select) {
   uint64_t const_true, const_false;
   bool is_const_true = IsInlineConstant(Op->Header.Args[2], &const_true);
   bool is_const_false = IsInlineConstant(Op->Header.Args[3], &const_false);
-  
+
   if (is_const_true || is_const_false) {
     if (is_const_false != true || is_const_true != true || const_true != 1 || const_false != 0) {
       LogMan::Msg::A("Select: Unsupported compare inline parameters");

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -480,80 +480,6 @@ DEF_OP(Ashr) {
   }
 }
 
-DEF_OP(Rol) {
-  auto Op = IROp->C<IR::IROp_Rol>();
-  uint8_t OpSize = IROp->Size;
-
-  uint64_t Const;
-  if (IsInlineConstant(Op->Header.Args[1], &Const)) {
-    switch (OpSize) {
-      case 1: {
-        mov(GetReg<RA_32>(Node), GetReg<RA_32>(Op->Header.Args[0].ID()));
-        bfi(GetReg<RA_32>(Node), GetReg<RA_32>(Node), 8, 8);
-        bfi(GetReg<RA_32>(Node), GetReg<RA_32>(Node), 16, 8);
-        bfi(GetReg<RA_32>(Node), GetReg<RA_32>(Node), 24, 8);
-        ror(GetReg<RA_32>(Node), GetReg<RA_32>(Node), 8 - (unsigned int)Const);
-        and_(GetReg<RA_32>(Node), GetReg<RA_32>(Node), 0xFF);
-        break;
-      }
-      case 2: {
-        mov(GetReg<RA_32>(Node), GetReg<RA_32>(Op->Header.Args[0].ID()));
-        bfi(GetReg<RA_32>(Node), GetReg<RA_32>(Node), 16, 16);
-        ror(GetReg<RA_32>(Node), GetReg<RA_32>(Node), 16 - (unsigned int)Const);
-        and_(GetReg<RA_32>(Node), GetReg<RA_32>(Node), 0xFFFF);
-        break;
-      }
-      case 4: {
-        ror(GetReg<RA_32>(Node), GetReg<RA_32>(Op->Header.Args[0].ID()), 32 - (unsigned int)Const);
-      break;
-      }
-      case 8: {
-        ror(GetReg<RA_64>(Node), GetReg<RA_64>(Op->Header.Args[0].ID()), 64 - (unsigned int)Const);
-      break;
-      }
-      default: LogMan::Msg::A("Unhandled ROL size: %d", OpSize);
-    }
-  } else {
-    switch (OpSize) {
-      case 1: {
-        movz(TMP1, 8);
-        sub(TMP1.W(), TMP1.W(), GetReg<RA_32>(Op->Header.Args[1].ID()));
-
-        mov(GetReg<RA_32>(Node), GetReg<RA_32>(Op->Header.Args[0].ID()));
-        bfi(GetReg<RA_32>(Node), GetReg<RA_32>(Node), 8, 8);
-        bfi(GetReg<RA_32>(Node), GetReg<RA_32>(Node), 16, 8);
-        bfi(GetReg<RA_32>(Node), GetReg<RA_32>(Node), 24, 8);
-        rorv(GetReg<RA_32>(Node), GetReg<RA_32>(Node), TMP1.W());
-        and_(GetReg<RA_32>(Node), GetReg<RA_32>(Node), 0xFF);
-        break;
-      }
-      case 2: {
-        movz(TMP1, 16);
-        sub(TMP1.W(), TMP1.W(), GetReg<RA_32>(Op->Header.Args[1].ID()));
-
-        mov(GetReg<RA_32>(Node), GetReg<RA_32>(Op->Header.Args[0].ID()));
-        bfi(GetReg<RA_32>(Node), GetReg<RA_32>(Node), 16, 16);
-        rorv(GetReg<RA_32>(Node), GetReg<RA_32>(Node), TMP1.W());
-        and_(GetReg<RA_32>(Node), GetReg<RA_32>(Node), 0xFFFF);
-        break;
-      }
-      case 4: {
-        movz(TMP1, 32);
-        sub(TMP1.W(), TMP1.W(), GetReg<RA_32>(Op->Header.Args[1].ID()));
-        rorv(GetReg<RA_32>(Node), GetReg<RA_32>(Op->Header.Args[0].ID()), TMP1.W());
-      break;
-      }
-      case 8: {
-        movz(TMP1, 64);
-        sub(TMP1, TMP1, GetReg<RA_64>(Op->Header.Args[1].ID()));
-        rorv(GetReg<RA_64>(Node), GetReg<RA_64>(Op->Header.Args[0].ID()), TMP1);
-      break;
-      }
-      default: LogMan::Msg::A("Unhandled ROL size: %d", OpSize);
-    }
-  }
-}
-
 DEF_OP(Ror) {
   auto Op = IROp->C<IR::IROp_Ror>();
   uint8_t OpSize = IROp->Size;
@@ -1218,7 +1144,6 @@ void JITCore::RegisterALUHandlers() {
   REGISTER_OP(LSHL,              Lshl);
   REGISTER_OP(LSHR,              Lshr);
   REGISTER_OP(ASHR,              Ashr);
-  REGISTER_OP(ROL,               Rol);
   REGISTER_OP(ROR,               Ror);
   REGISTER_OP(EXTR,              Extr);
   REGISTER_OP(LDIV,              LDiv);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/ALUOps.cpp
@@ -613,66 +613,6 @@ DEF_OP(Ashr) {
   }
 }
 
-DEF_OP(Rol) {
-  auto Op = IROp->C<IR::IROp_Rol>();
-  uint8_t OpSize = IROp->Size;
-
-  uint8_t Mask = OpSize * 8 - 1;
-
-  uint64_t Const;
-  if (IsInlineConstant(Op->Header.Args[1], &Const)) {
-    Const &= Mask;
-    switch (OpSize) {
-      case 1: {
-        movzx(rax, GetSrc<RA_8>(Op->Header.Args[0].ID()));
-        rol(al, Const);
-      break;
-      }
-      case 2: {
-        movzx(rax, GetSrc<RA_16>(Op->Header.Args[0].ID()));
-        rol(ax, Const);
-      break;
-      }
-      case 4: {
-        mov(eax, GetSrc<RA_32>(Op->Header.Args[0].ID()));
-        rol(eax, Const);
-      break;
-      }
-      case 8: {
-        mov(rax, GetSrc<RA_64>(Op->Header.Args[0].ID()));
-        rol(rax, Const);
-      break;
-      }
-    }
-  } else {
-    mov (rcx, GetSrc<RA_64>(Op->Header.Args[1].ID()));
-    and(rcx, Mask);
-    switch (OpSize) {
-      case 1: {
-        movzx(rax, GetSrc<RA_8>(Op->Header.Args[0].ID()));
-        rol(al, cl);
-      break;
-      }
-      case 2: {
-        movzx(rax, GetSrc<RA_16>(Op->Header.Args[0].ID()));
-        rol(ax, cl);
-      break;
-      }
-      case 4: {
-        mov(eax, GetSrc<RA_32>(Op->Header.Args[0].ID()));
-        rol(eax, cl);
-      break;
-      }
-      case 8: {
-        mov(rax, GetSrc<RA_64>(Op->Header.Args[0].ID()));
-        rol(rax, cl);
-      break;
-      }
-    }
-  }
-  mov(GetDst<RA_64>(Node), rax);
-}
-
 DEF_OP(Ror) {
   auto Op = IROp->C<IR::IROp_Ror>();
   uint8_t OpSize = IROp->Size;
@@ -1345,7 +1285,6 @@ void JITCore::RegisterALUHandlers() {
   REGISTER_OP(LSHL,              Lshl);
   REGISTER_OP(LSHR,              Lshr);
   REGISTER_OP(ASHR,              Ashr);
-  REGISTER_OP(ROL,               Rol);
   REGISTER_OP(ROR,               Ror);
   REGISTER_OP(EXTR,              Extr);
   REGISTER_OP(LDIV,              LDiv);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/ALUOps.cpp
@@ -683,16 +683,6 @@ DEF_OP(Ror) {
   if (IsInlineConstant(Op->Header.Args[1], &Const)) {
     Const &= Mask;
     switch (OpSize) {
-      case 1: {
-        movzx(rax, GetSrc<RA_8>(Op->Header.Args[0].ID()));
-        ror(al, Const);
-      break;
-      }
-      case 2: {
-        movzx(rax, GetSrc<RA_16>(Op->Header.Args[0].ID()));
-        ror(ax, Const);
-      break;
-      }
       case 4: {
         mov(eax, GetSrc<RA_32>(Op->Header.Args[0].ID()));
         ror(eax, Const);
@@ -703,21 +693,12 @@ DEF_OP(Ror) {
         ror(rax, Const);
       break;
       }
+      default: LogMan::Msg::A("Unknown ROR Size: %d\n", OpSize); break;
     }
   } else {
     mov (rcx, GetSrc<RA_64>(Op->Header.Args[1].ID()));
     and(rcx, Mask);
     switch (OpSize) {
-      case 1: {
-        movzx(rax, GetSrc<RA_8>(Op->Header.Args[0].ID()));
-        ror(al, cl);
-      break;
-      }
-      case 2: {
-        movzx(rax, GetSrc<RA_16>(Op->Header.Args[0].ID()));
-        ror(ax, cl);
-      break;
-      }
       case 4: {
         mov(eax, GetSrc<RA_32>(Op->Header.Args[0].ID()));
         ror(eax, cl);
@@ -728,6 +709,7 @@ DEF_OP(Ror) {
         ror(rax, cl);
       break;
       }
+      default: LogMan::Msg::A("Unknown ROR Size: %d\n", OpSize); break;
     }
   }
   mov(GetDst<RA_64>(Node), rax);
@@ -1193,11 +1175,11 @@ DEF_OP(Select) {
   } else {
     cmp(GRCMP(Op->Cmp1.ID()), GRCMP(Op->Cmp2.ID()));
   }
-  
+
   uint64_t const_true, const_false;
   bool is_const_true = IsInlineConstant(Op->TrueVal, &const_true);
   bool is_const_false = IsInlineConstant(Op->FalseVal, &const_false);
-  
+
   if (is_const_true || is_const_false) {
     if (is_const_false != true || is_const_true != true || const_true != 1 || const_false != 0) {
       LogMan::Msg::A("Select: Unsupported compare inline parameters");
@@ -1214,7 +1196,7 @@ DEF_OP(Select) {
       case FEXCore::IR::COND_ULT: setb(al); break;
       case FEXCore::IR::COND_UGT: seta(al); break;
       case FEXCore::IR::COND_ULE: setna(al); break;
-      
+
       case FEXCore::IR::COND_MI:
       case FEXCore::IR::COND_PL:
       case FEXCore::IR::COND_VS:
@@ -1237,7 +1219,7 @@ DEF_OP(Select) {
       case FEXCore::IR::COND_ULT: cmovb(rax, GetSrc<RA_64>(Op->TrueVal.ID())); break;
       case FEXCore::IR::COND_UGT: cmova(rax, GetSrc<RA_64>(Op->TrueVal.ID())); break;
       case FEXCore::IR::COND_ULE: cmovna(rax, GetSrc<RA_64>(Op->TrueVal.ID())); break;
-      
+
       case FEXCore::IR::COND_MI:
       case FEXCore::IR::COND_PL:
       case FEXCore::IR::COND_VS:

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -1991,7 +1991,7 @@ void OpDispatchBuilder::RCROp8x1Bit(OpcodeArgs) {
 
   // Rotate and insert CF in the upper bit
   OrderedNode *Res = _Bfe(7, 1, Dest);
-  Res = _Bfi(1, 7, Res, CF);
+  Res = _Bfi(Size/8, 1, 7, Res, CF);
 
   // Our new CF will be bit (Shift - 1) of the source
   auto NewCF = _Bfe(1, Shift - 1, Dest);
@@ -2091,10 +2091,10 @@ void OpDispatchBuilder::RCRSmallerOp(OpcodeArgs) {
   // We need to cover 32bits plus the amount that could rotate in
   for (size_t i = 0; i < (32 + Size + 1); i += (Size + 1)) {
     // Insert incoming value
-    Tmp = _Bfi(Size, i, Tmp, Dest);
+    Tmp = _Bfi(8, Size, i, Tmp, Dest);
 
     // Insert CF
-    Tmp = _Bfi(1, i + Size, Tmp, CF);
+    Tmp = _Bfi(8, 1, i + Size, Tmp, CF);
   }
 
   // Entire bitfield has been setup
@@ -2229,14 +2229,14 @@ void OpDispatchBuilder::RCLSmallerOp(OpcodeArgs) {
 
   for (size_t i = 0; i < (32 + Size + 1); i += (Size + 1)) {
     // Insert incoming value
-    Tmp = _Bfi(Size, 63 - i - Size, Tmp, Dest);
+    Tmp = _Bfi(8, Size, 63 - i - Size, Tmp, Dest);
 
     // Insert CF
-    Tmp = _Bfi(1, 63 - i, Tmp, CF);
+    Tmp = _Bfi(8, 1, 63 - i, Tmp, CF);
   }
 
   // Insert incoming value
-  Tmp = _Bfi(Size, 0, Tmp, Dest);
+  Tmp = _Bfi(8, Size, 0, Tmp, Dest);
 
   // The data is now set up like this
   // [Data][CF]:[Data][CF]:[Data][CF]:[Data][CF]
@@ -7481,7 +7481,7 @@ void OpDispatchBuilder::STMXCSR(OpcodeArgs) {
   // Default MXCSR
   OrderedNode *MXCSR = _Constant(32, 0x1F80);
   OrderedNode *RoundingMode = _GetRoundingMode();
-  MXCSR = _Bfi(3, 13, MXCSR, RoundingMode);
+  MXCSR = _Bfi(4, 3, 13, MXCSR, RoundingMode);
 
   StoreResult(GPRClass, Op, MXCSR, -1);
 }

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -907,16 +907,6 @@
       "SSAArgs": "2"
     },
 
-    "Rol": {
-      "Desc": ["Integer rotate left",
-               "```diff\n- Warning! Not a native op on AArch64. Will negate rotate value and do a ROR\n```"
-              ],
-      "OpClass": "ALU",
-      "HasDest": true,
-      "DestClass": "GPR",
-      "SSAArgs": "2"
-    },
-
     "Ror": {
       "Desc": ["Integer rotate right"
               ],

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -1115,11 +1115,14 @@
       "OpClass": "ALU",
       "HasDest": true,
       "DestClass": "GPR",
-      "DestSize": "GetOpSize(ssa0)",
+      "DestSize": "DestSize",
       "SSAArgs": "2",
       "SSANames": [
         "Dest",
         "Src"
+      ],
+      "HelperArgs": [
+        "uint8_t", "DestSize"
       ],
       "Args": [
         "uint8_t", "Width",

--- a/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -53,7 +53,7 @@ static bool IsImmMemory(uint64_t imm, uint8_t AccessSize) {
 }
 
 std::tuple<MemOffsetType, uint8_t, OrderedNode*, OrderedNode*> MemExtendedAddressing(IREmitter *IREmit, uint8_t AccessSize,  IROp_Header* AddressHeader) {
-  
+
   auto Src0Header = IREmit->GetOpHeader(AddressHeader->Args[0]);
   if (Src0Header->Size == 8) {
     //Try to optimize: Base + MUL(Offset, Scale)
@@ -108,7 +108,7 @@ std::tuple<MemOffsetType, uint8_t, OrderedNode*, OrderedNode*> MemExtendedAddres
 }
 
 bool ConstProp::Run(IREmitter *IREmit) {
-  
+
   bool Changed = false;
   auto CurrentIR = IREmit->ViewIR();
 
@@ -117,7 +117,7 @@ bool ConstProp::Run(IREmitter *IREmit) {
   auto OriginalWriteCursor = IREmit->GetWriteCursor();
 
   auto HeaderOp = CurrentIR.GetHeader();
-  
+
 
   for (auto [CodeNode, IROp] : CurrentIR.GetAllCode()) {
 
@@ -179,7 +179,7 @@ bool ConstProp::Run(IREmitter *IREmit) {
         Op->OffsetScale = OffsetScale;
         IREmit->ReplaceNodeArgument(CodeNode, 0, Arg0);
         IREmit->ReplaceNodeArgument(CodeNode, 1, Arg1);
-        
+
         Changed = true;
       }
       break;
@@ -196,7 +196,7 @@ bool ConstProp::Run(IREmitter *IREmit) {
         Op->OffsetScale = OffsetScale;
         IREmit->ReplaceNodeArgument(CodeNode, 0, Arg0);
         IREmit->ReplaceNodeArgument(CodeNode, 2, Arg1);
-        
+
         Changed = true;
       }
       break;
@@ -246,7 +246,7 @@ bool ConstProp::Run(IREmitter *IREmit) {
         auto val = IREmit->GetOpHeader(Op->Header.Args[0]);
 
         uint64_t Constant3;
-        if (val->Op == OP_SELECT && 
+        if (val->Op == OP_SELECT &&
             IREmit->IsValueConstant(val->Args[2], &Constant2) &&
             IREmit->IsValueConstant(val->Args[3], &Constant3) &&
             Constant2 == 1 &&
@@ -349,7 +349,7 @@ bool ConstProp::Run(IREmitter *IREmit) {
 
         uint64_t Constant2;
         uint64_t Constant3;
-        if (val->Op == OP_SELECT && 
+        if (val->Op == OP_SELECT &&
             IREmit->IsValueConstant(val->Args[2], &Constant2) &&
             IREmit->IsValueConstant(val->Args[3], &Constant3) &&
             Constant2 == 1 &&
@@ -382,11 +382,11 @@ bool ConstProp::Run(IREmitter *IREmit) {
       auto Op = IROp->CW<IR::IROp_CondJump>();
 
       auto Select = IREmit->GetOpHeader(Op->Header.Args[0]);
-      
+
       uint64_t Constant;
       // Fold the select into the CondJump if possible. Could handle more complex cases, too.
       if (Op->Cond.Val == COND_NEQ && IREmit->IsValueConstant(Op->Cmp2, &Constant) && Constant == 0 &&  Select->Op == OP_SELECT) {
-        
+
         uint64_t Constant1;
         uint64_t Constant2;
 
@@ -412,7 +412,6 @@ bool ConstProp::Run(IREmitter *IREmit) {
       switch(IROp->Op) {
         case OP_LSHR:
         case OP_ASHR:
-        case OP_ROL:
         case OP_ROR:
         case OP_LSHL:
         {
@@ -446,7 +445,7 @@ bool ConstProp::Run(IREmitter *IREmit) {
               IREmit->SetWriteCursor(CurrentIR.GetNode(Op->Header.Args[1]));
 
               IREmit->ReplaceNodeArgument(CodeNode, 1, IREmit->_InlineConstant(Constant2));
-              
+
               Changed = true;
             }
           }
@@ -463,7 +462,7 @@ bool ConstProp::Run(IREmitter *IREmit) {
               IREmit->SetWriteCursor(CurrentIR.GetNode(Op->Header.Args[1]));
 
               IREmit->ReplaceNodeArgument(CodeNode, 1, IREmit->_InlineConstant(Constant1));
-              
+
               Changed = true;
             }
           }
@@ -494,7 +493,7 @@ bool ConstProp::Run(IREmitter *IREmit) {
               IREmit->SetWriteCursor(CurrentIR.GetNode(Op->Header.Args[1]));
 
               IREmit->ReplaceNodeArgument(CodeNode, 1, IREmit->_InlineConstant(Constant2));
-              
+
               Changed = true;
             }
           }

--- a/External/FEXCore/include/FEXCore/IR/IREmitter.h
+++ b/External/FEXCore/include/FEXCore/IR/IREmitter.h
@@ -70,8 +70,8 @@ friend class FEXCore::IR::PassManager;
   IRPair<IROp_Sbfe> _Sbfe(uint8_t Width, uint8_t lsb, OrderedNode *ssa0) {
     return _Sbfe(ssa0, Width, lsb);
   }
-  IRPair<IROp_Bfi> _Bfi(uint8_t Width, uint8_t lsb, OrderedNode *ssa0, OrderedNode *ssa1) {
-    return _Bfi(ssa0, ssa1, Width, lsb);
+  IRPair<IROp_Bfi> _Bfi(uint8_t DestSize, uint8_t Width, uint8_t lsb, OrderedNode *ssa0, OrderedNode *ssa1) {
+    return _Bfi(ssa0, ssa1, Width, lsb, DestSize);
   }
   IRPair<IROp_StoreMem> _StoreMem(FEXCore::IR::RegisterClassType Class, uint8_t Size, OrderedNode *ssa0, OrderedNode *ssa1, uint8_t Align = 1) {
     return _StoreMem(ssa0, ssa1, Invalid(), Size, Align, Class, MEM_OFFSET_SXTX, 1);
@@ -94,7 +94,7 @@ friend class FEXCore::IR::PassManager;
   IRPair<IROp_Select> _Select(uint8_t Cond, OrderedNode *ssa0, OrderedNode *ssa1, OrderedNode *ssa2, OrderedNode *ssa3, uint8_t CompareSize = 0) {
     if (CompareSize == 0)
       CompareSize = std::max<uint8_t>(4, std::max<uint8_t>(GetOpSize(ssa0), GetOpSize(ssa1)));
-      
+
     return _Select(ssa0, ssa1, ssa2, ssa3, {Cond}, CompareSize);
   }
   IRPair<IROp_Sext> _Sext(uint8_t SrcSize, OrderedNode *ssa0) {


### PR DESCRIPTION
This eliminates several IR ops that lie about support on the ARM 64 backend and moves the workarounds into Opcode Dispatcher

Alternative to #528