### PR TITLE
Moves shmat to 64bit memory specific file

### DIFF
--- a/External/FEXCore/Source/Interface/HLE/Syscalls/SHM.cpp
+++ b/External/FEXCore/Source/Interface/HLE/Syscalls/SHM.cpp
@@ -20,23 +20,6 @@ namespace FEXCore::HLE {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(shmat, [](FEXCore::Core::InternalThreadState *Thread, int shmid, const void *shmaddr, int shmflg) -> uint64_t {
-      const void* HostPointer{};
-      uint64_t BasePointer = Thread->CTX->MemoryMapper.GetPointer<uint64_t>(0);
-      if (shmaddr) {
-        HostPointer = shmaddr;
-      }
-      else {
-        HostPointer = reinterpret_cast<void*>(BasePointer + Thread->CTX->MemoryMapper.GetSHMSize());
-      }
-
-      uint64_t Result = reinterpret_cast<uint64_t>(shmat(shmid, HostPointer, shmflg));
-      if (Result != -1 && !shmaddr) {
-        Result -= BasePointer;
-      }
-      SYSCALL_ERRNO();
-    });
-
     REGISTER_SYSCALL_IMPL(shmctl, [](FEXCore::Core::InternalThreadState *Thread, int shmid, int cmd, struct shmid_ds *buf) -> uint64_t {
       uint64_t Result = ::shmctl(shmid, cmd, buf);
       SYSCALL_ERRNO();

--- a/External/FEXCore/Source/Interface/HLE/x64/Memory.cpp
+++ b/External/FEXCore/Source/Interface/HLE/x64/Memory.cpp
@@ -3,6 +3,7 @@
 #include "Interface/Context/Context.h"
 
 #include <sys/mman.h>
+#include <sys/shm.h>
 
 #define MEM_PASSTHROUGH
 namespace FEXCore::HLE::x64 {
@@ -38,6 +39,11 @@ namespace FEXCore::HLE::x64 {
 
     REGISTER_SYSCALL_IMPL_X64(munlockall, [](FEXCore::Core::InternalThreadState *Thread) -> uint64_t {
       uint64_t Result = ::munlockall();
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X64(shmat, [](FEXCore::Core::InternalThreadState *Thread, int shmid, const void *shmaddr, int shmflg) -> uint64_t {
+      uint64_t Result = reinterpret_cast<uint64_t>(shmat(shmid, shmaddr, shmflg));
       SYSCALL_ERRNO();
     });
   }


### PR DESCRIPTION
This removes the bad attempt to keep shm regions in our 64GB shm region

This will need to be handled specially on the 32bit side through its
memory management once we have that wired up