### PR TITLE
A wackload of new 32bit syscall support

### DIFF
--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -154,7 +154,10 @@ set (SRCS
   Interface/HLE/x32/Memory.cpp
   Interface/HLE/x32/NotImplemented.cpp
   Interface/HLE/x32/Semaphore.cpp
+  Interface/HLE/x32/Sched.cpp
+  Interface/HLE/x32/Socket.cpp
   Interface/HLE/x32/Thread.cpp
+  Interface/HLE/x32/Time.cpp
   Interface/HLE/x64/FD.cpp
   Interface/HLE/x64/IO.cpp
   Interface/HLE/x64/Ioctl.cpp

--- a/External/FEXCore/Source/Interface/HLE/x32/FD.cpp
+++ b/External/FEXCore/Source/Interface/HLE/x32/FD.cpp
@@ -1,285 +1,524 @@
+#include "Common/MathUtils.h"
+
 #include "Interface/HLE/Syscalls.h"
 #include "Interface/HLE/x32/Syscalls.h"
 #include "Interface/Context/Context.h"
 
+#include <dirent.h>
 #include <fcntl.h>
 #include <stdint.h>
 #include <sys/file.h>
 #include <sys/eventfd.h>
 #include <sys/inotify.h>
 #include <sys/mman.h>
+#include <sys/statfs.h>
 #include <sys/syscall.h>
 #include <sys/timerfd.h>
 #include <sys/uio.h>
-
-namespace FEXCore::Core {
-struct InternalThreadState;
-}
+#include <sys/vfs.h>
+#include <unistd.h>
 
 namespace FEXCore::HLE::x32 {
-  struct iovec_32 {
-    uint32_t iov_base;
-    uint32_t iov_len;
-  };
-
-  struct __attribute__((packed)) guest_stat32 {
-    uint32_t st_dev;
-    uint32_t st_ino;
-    uint32_t st_nlink;
-
-    uint16_t st_mode;
-    uint16_t st_uid;
-    uint16_t st_gid;
-    uint16_t __pad0;
-
-    uint32_t st_rdev;
-    uint32_t st_size;
-    uint32_t st_blksize;
-    uint32_t st_blocks;  /* Number 512-byte blocks allocated. */
-    uint32_t st_atime_;
-    uint32_t st_atime_nsec;
-    uint32_t st_mtime_;
-    uint32_t st_mtime_nsec;
-    uint32_t st_ctime_;
-    uint32_t st_ctime_nsec;
-    uint32_t __unused[3];
-  };
-
-  struct __attribute__((packed)) guest_stat64_32 {
-    uint64_t st_dev;
-    uint64_t pad0;
-    uint32_t __st_ino;
-
-    uint32_t st_mode;
-    uint32_t st_nlink;
-
-    uint32_t st_uid;
-    uint32_t st_gid;
-
-    uint64_t st_rdev;
-    uint32_t pad3;
-    int64_t st_size;
-    uint32_t st_blksize;
-    uint64_t st_blocks;  /* Number 512-byte blocks allocated. */
-    uint32_t st_atime_;
-    uint32_t st_atime_nsec;
-    uint32_t st_mtime_;
-    uint32_t st_mtime_nsec;
-    uint32_t st_ctime_;
-    uint32_t st_ctime_nsec;
-    uint64_t st_ino;
-  };
-
-  static void CopyStat32(guest_stat32 *guest, struct stat *host) {
-#define COPY(x) guest->x = host->x
-    COPY(st_dev);
-    COPY(st_ino);
-    COPY(st_nlink);
-
-    COPY(st_mode);
-    COPY(st_uid);
-    COPY(st_gid);
-
-    COPY(st_rdev);
-    COPY(st_size);
-    COPY(st_blksize);
-    COPY(st_blocks);
-
-    guest->st_atime_ = host->st_atim.tv_sec;
-    guest->st_atime_nsec = host->st_atim.tv_nsec;
-
-    guest->st_mtime_ = host->st_mtime;
-    guest->st_mtime_nsec = host->st_mtim.tv_nsec;
-
-    guest->st_ctime_ = host->st_ctime;
-    guest->st_ctime_nsec = host->st_ctim.tv_nsec;
-#undef COPY
-  }
-
-  static void CopyStat64_32(guest_stat64_32 *guest, struct stat *host) {
-#define COPY(x) guest->x = host->x
-    COPY(st_dev);
-    COPY(st_ino);
-    COPY(st_nlink);
-
-    COPY(st_mode);
-    COPY(st_uid);
-    COPY(st_gid);
-
-    COPY(st_rdev);
-    COPY(st_size);
-    COPY(st_blksize);
-    COPY(st_blocks);
-
-    guest->__st_ino = host->st_ino;
-
-    guest->st_atime_ = host->st_atim.tv_sec;
-    guest->st_atime_nsec = host->st_atim.tv_nsec;
-
-    guest->st_mtime_ = host->st_mtime;
-    guest->st_mtime_nsec = host->st_mtim.tv_nsec;
-
-    guest->st_ctime_ = host->st_ctime;
-    guest->st_ctime_nsec = host->st_ctim.tv_nsec;
-#undef COPY
-  }
-
+  using fd_set32 = uint32_t;
 
   void RegisterFD() {
-    REGISTER_SYSCALL_IMPL_X32(readv, [](FEXCore::Core::InternalThreadState *Thread, int fd, const struct iovec_32 *iov, int iovcnt) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(poll, [](FEXCore::Core::InternalThreadState *Thread, struct pollfd *fds, nfds_t nfds, int timeout) -> uint64_t {
+      uint64_t Result = ::poll(fds, nfds, timeout);
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(ppoll, [](FEXCore::Core::InternalThreadState *Thread, struct pollfd *fds, nfds_t nfds, timespec32 *timeout_ts, const uint64_t *sigmask, size_t sigsetsize) -> uint64_t {
+      // sigsetsize is unused here since it is currently a constant and not exposed through glibc
+      struct timespec tp64{};
+      struct timespec *timed_ptr{};
+      if (timeout_ts) {
+        tp64 = *timeout_ts;
+        timed_ptr = &tp64;
+      }
+
+      sigset_t HostSet{};
+
+      if (sigmask) {
+        sigemptyset(&HostSet);
+
+        for (int32_t i = 0; i < (sigsetsize * 8); ++i) {
+          if (*sigmask & (1ULL << i)) {
+            sigaddset(&HostSet, i + 1);
+          }
+        }
+      }
+
+      uint64_t Result = ppoll(
+        fds,
+        nfds,
+        timed_ptr,
+        sigmask ? &HostSet : nullptr);
+
+      if (timeout_ts) {
+        *timeout_ts = tp64;
+      }
+
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(ppoll_time64, [](FEXCore::Core::InternalThreadState *Thread, struct pollfd *fds, nfds_t nfds, struct timespec *timeout_ts, const uint64_t *sigmask, size_t sigsetsize) -> uint64_t {
+      // sigsetsize is unused here since it is currently a constant and not exposed through glibc
+      sigset_t HostSet{};
+
+      if (sigmask) {
+        sigemptyset(&HostSet);
+
+        for (int32_t i = 0; i < (sigsetsize * 8); ++i) {
+          if (*sigmask & (1ULL << i)) {
+            sigaddset(&HostSet, i + 1);
+          }
+        }
+      }
+
+      uint64_t Result = ppoll(
+        fds,
+        nfds,
+        timeout_ts,
+        sigmask ? &HostSet : nullptr);
+
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(_llseek, [](FEXCore::Core::InternalThreadState *Thread, uint32_t fd, uint32_t offset_high, uint32_t offset_low, loff_t *result, uint32_t whence) -> uint64_t {
+      uint64_t Offset = offset_high;
+      Offset <<= 32;
+      Offset |= offset_low;
+      uint64_t Result = lseek(fd, Offset, whence);
+      if (Result != -1) {
+        *result = Result;
+      }
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(readv, [](FEXCore::Core::InternalThreadState *Thread, int fd, const struct iovec32 *iov, int iovcnt) -> uint64_t {
       std::vector<iovec> Host_iovec(iovcnt);
       for (int i = 0; i < iovcnt; ++i) {
-        Host_iovec[i].iov_base = reinterpret_cast<void*>(iov[i].iov_base);
-        Host_iovec[i].iov_len = iov[i].iov_len;
+        Host_iovec[i] = iov[i];
       }
 
       uint64_t Result = ::readv(fd, &Host_iovec.at(0), iovcnt);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(writev, [](FEXCore::Core::InternalThreadState *Thread, int fd, const struct iovec_32 *iov, int iovcnt) -> uint32_t {
+    REGISTER_SYSCALL_IMPL_X32(writev, [](FEXCore::Core::InternalThreadState *Thread, int fd, const struct iovec32 *iov, int iovcnt) -> uint64_t {
       std::vector<iovec> Host_iovec(iovcnt);
       for (int i = 0; i < iovcnt; ++i) {
-        Host_iovec[i].iov_base = reinterpret_cast<void*>(iov[i].iov_base);
-        Host_iovec[i].iov_len = iov[i].iov_len;
+        Host_iovec[i] = iov[i];
       }
       uint64_t Result = ::writev(fd, &Host_iovec.at(0), iovcnt);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(stat, [](FEXCore::Core::InternalThreadState *Thread, const char *pathname, guest_stat32 *buf) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(stat, [](FEXCore::Core::InternalThreadState *Thread, const char *pathname, stat32 *buf) -> uint64_t {
       struct stat host_stat;
       uint64_t Result = Thread->CTX->SyscallHandler->FM.Stat(pathname, &host_stat);
       if (Result != -1) {
-        CopyStat32(buf, &host_stat);
+        *buf = host_stat;
       }
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(fstat, [](FEXCore::Core::InternalThreadState *Thread, int fd, guest_stat32 *buf) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(fstat, [](FEXCore::Core::InternalThreadState *Thread, int fd, stat32 *buf) -> uint64_t {
       struct stat host_stat;
       uint64_t Result = ::fstat(fd, &host_stat);
       if (Result != -1) {
-        CopyStat32(buf, &host_stat);
+        *buf = host_stat;
       }
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(lstat, [](FEXCore::Core::InternalThreadState *Thread, const char *path, guest_stat32 *buf) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(lstat, [](FEXCore::Core::InternalThreadState *Thread, const char *path, stat32 *buf) -> uint64_t {
       struct stat host_stat;
       uint64_t Result = Thread->CTX->SyscallHandler->FM.Lstat(path, &host_stat);
       if (Result != -1) {
-        CopyStat32(buf, &host_stat);
+        *buf = host_stat;
       }
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(stat64, [](FEXCore::Core::InternalThreadState *Thread, const char *pathname, guest_stat64_32 *buf) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(stat64, [](FEXCore::Core::InternalThreadState *Thread, const char *pathname, stat64_32 *buf) -> uint64_t {
       struct stat host_stat;
       uint64_t Result = Thread->CTX->SyscallHandler->FM.Stat(pathname, &host_stat);
       if (Result != -1) {
-        CopyStat64_32(buf, &host_stat);
+        *buf = host_stat;
       }
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(lstat64, [](FEXCore::Core::InternalThreadState *Thread, const char *path, guest_stat64_32 *buf) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(lstat64, [](FEXCore::Core::InternalThreadState *Thread, const char *path, stat64_32 *buf) -> uint64_t {
       struct stat host_stat;
       uint64_t Result = Thread->CTX->SyscallHandler->FM.Lstat(path, &host_stat);
+
       if (Result != -1) {
-        CopyStat64_32(buf, &host_stat);
+        *buf = host_stat;
       }
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(fstat64, [](FEXCore::Core::InternalThreadState *Thread, int fd, guest_stat64_32 *buf) -> uint64_t {
-      struct stat host_stat;
-      uint64_t Result = ::fstat(fd, &host_stat);
+    REGISTER_SYSCALL_IMPL_X32(fstat64, [](FEXCore::Core::InternalThreadState *Thread, int fd, stat64_32 *buf) -> uint64_t {
+      struct stat64 host_stat;
+      uint64_t Result = ::fstat64(fd, &host_stat);
       if (Result != -1) {
-        CopyStat64_32(buf, &host_stat);
+        *buf = host_stat;
       }
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(preadv, [](FEXCore::Core::InternalThreadState *Thread, int fd, const struct iovec_32 *iov, int iovcnt, off_t offset) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(fstatfs64, [](FEXCore::Core::InternalThreadState *Thread, int fd, struct statfs64_32 *buf) -> uint64_t {
+      struct statfs64 host_stat;
+      uint64_t Result = ::fstatfs64(fd, &host_stat);
+      if (Result != -1) {
+        *buf = host_stat;
+      }
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(statfs64, [](FEXCore::Core::InternalThreadState *Thread, const char *path, struct statfs64_32 *buf) -> uint64_t {
+      struct statfs host_stat;
+      uint64_t Result = Thread->CTX->SyscallHandler->FM.Statfs(path, &host_stat);
+      if (Result != -1) {
+        *buf = host_stat;
+      }
+
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(fcntl64, [](FEXCore::Core::InternalThreadState *Thread, int fd, int cmd, uint64_t arg) -> uint64_t {
+      // fcntl64 struct directly matches the 64bit fcntl op
+      // cmd just needs to be fixed up
+      // These are redefined to be their non-64bit tagged value on x86-64
+      constexpr int OP_GETLK64_32 = 12;
+      constexpr int OP_SETLK64_32 = 13;
+      constexpr int OP_SETLKW64_32 = 14;
+
+      void *lock_arg = (void*)arg;
+      struct flock tmp{};
+
+      switch (cmd) {
+        case OP_GETLK64_32: {
+          cmd = F_GETLK;
+          lock_arg = (void*)&tmp;
+          tmp = *reinterpret_cast<flock64_32*>(arg);
+          break;
+        }
+        case OP_SETLK64_32: {
+          cmd = F_SETLK;
+          lock_arg = (void*)&tmp;
+          tmp = *reinterpret_cast<flock64_32*>(arg);
+          break;
+        }
+        case OP_SETLKW64_32: {
+          cmd = F_SETLKW;
+          lock_arg = (void*)&tmp;
+          tmp = *reinterpret_cast<flock64_32*>(arg);
+          break;
+        }
+        case F_OFD_SETLK:
+        case F_OFD_GETLK:
+        case F_OFD_SETLKW: {
+          lock_arg = (void*)&tmp;
+          tmp = *reinterpret_cast<flock64_32*>(arg);
+          break;
+        }
+        case F_GETLK:
+        case F_SETLK:
+        case F_SETLKW: {
+          lock_arg = (void*)&tmp;
+          tmp = *reinterpret_cast<flock_32*>(arg);
+          break;
+        }
+
+        // Maps directly
+        case F_DUPFD:
+        case F_DUPFD_CLOEXEC:
+        case F_GETFD:
+        case F_SETFD:
+        case F_GETFL:
+        case F_SETFL:
+          break;
+
+        default: LogMan::Msg::A("Unhandled fcntl64: 0x%x", cmd); break;
+      }
+
+      uint64_t Result = ::fcntl(fd, cmd, lock_arg);
+
+      if (Result != -1) {
+        switch (cmd) {
+          case OP_GETLK64_32: {
+            *reinterpret_cast<flock64_32*>(arg) = tmp;
+            break;
+          }
+          case F_OFD_GETLK: {
+            *reinterpret_cast<flock64_32*>(arg) = tmp;
+            break;
+          }
+          case F_GETLK: {
+            *reinterpret_cast<flock_32*>(arg) = tmp;
+            break;
+          }
+          break;
+          default: break;
+        }
+      }
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(preadv, [](FEXCore::Core::InternalThreadState *Thread, int fd, const struct iovec32 *iov, int iovcnt, off_t offset) -> uint64_t {
       std::vector<iovec> Host_iovec(iovcnt);
       for (int i = 0; i < iovcnt; ++i) {
-        Host_iovec[i].iov_base = reinterpret_cast<void*>(iov[i].iov_base);
-        Host_iovec[i].iov_len = iov[i].iov_len;
+        Host_iovec[i] = iov[i];
       }
 
       uint64_t Result = ::preadv(fd, &Host_iovec.at(0), iovcnt, offset);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(pwritev, [](FEXCore::Core::InternalThreadState *Thread, int fd, const struct iovec_32 *iov, int iovcnt, off_t offset) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(pwritev, [](FEXCore::Core::InternalThreadState *Thread, int fd, const struct iovec32 *iov, int iovcnt, off_t offset) -> uint64_t {
       std::vector<iovec> Host_iovec(iovcnt);
       for (int i = 0; i < iovcnt; ++i) {
-        Host_iovec[i].iov_base = reinterpret_cast<void*>(iov[i].iov_base);
-        Host_iovec[i].iov_len = iov[i].iov_len;
+        Host_iovec[i] = iov[i];
       }
 
       uint64_t Result = ::pwritev(fd, &Host_iovec.at(0), iovcnt, offset);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(process_vm_readv, [](FEXCore::Core::InternalThreadState *Thread, pid_t pid, const struct iovec_32 *local_iov, unsigned long liovcnt, const struct iovec_32 *remote_iov, unsigned long riovcnt, unsigned long flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(process_vm_readv, [](FEXCore::Core::InternalThreadState *Thread, pid_t pid, const struct iovec32 *local_iov, unsigned long liovcnt, const struct iovec32 *remote_iov, unsigned long riovcnt, unsigned long flags) -> uint64_t {
       std::vector<iovec> Host_local_iovec(liovcnt);
       std::vector<iovec> Host_remote_iovec(riovcnt);
 
       for (int i = 0; i < liovcnt; ++i) {
-        Host_local_iovec[i].iov_base = reinterpret_cast<void*>(local_iov[i].iov_base);
-        Host_local_iovec[i].iov_len = local_iov[i].iov_len;
+        Host_local_iovec[i] = local_iov[i];
       }
 
       for (int i = 0; i < riovcnt; ++i) {
-        Host_remote_iovec[i].iov_base = reinterpret_cast<void*>(remote_iov[i].iov_base);
-        Host_remote_iovec[i].iov_len = remote_iov[i].iov_len;
+        Host_remote_iovec[i] = remote_iov[i];
       }
 
       uint64_t Result = ::process_vm_readv(pid, &Host_local_iovec.at(0), liovcnt, &Host_remote_iovec.at(0), riovcnt, flags);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(process_vm_writev, [](FEXCore::Core::InternalThreadState *Thread, pid_t pid, const struct iovec_32 *local_iov, unsigned long liovcnt, const struct iovec_32 *remote_iov, unsigned long riovcnt, unsigned long flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(process_vm_writev, [](FEXCore::Core::InternalThreadState *Thread, pid_t pid, const struct iovec32 *local_iov, unsigned long liovcnt, const struct iovec32 *remote_iov, unsigned long riovcnt, unsigned long flags) -> uint64_t {
       std::vector<iovec> Host_local_iovec(liovcnt);
       std::vector<iovec> Host_remote_iovec(riovcnt);
 
       for (int i = 0; i < liovcnt; ++i) {
-        Host_local_iovec[i].iov_base = reinterpret_cast<void*>(local_iov[i].iov_base);
-        Host_local_iovec[i].iov_len = local_iov[i].iov_len;
+        Host_local_iovec[i] = local_iov[i];
       }
 
       for (int i = 0; i < riovcnt; ++i) {
-        Host_remote_iovec[i].iov_base = reinterpret_cast<void*>(remote_iov[i].iov_base);
-        Host_remote_iovec[i].iov_len = remote_iov[i].iov_len;
+        Host_remote_iovec[i] = remote_iov[i];
       }
 
       uint64_t Result = ::process_vm_writev(pid, &Host_local_iovec.at(0), liovcnt, &Host_remote_iovec.at(0), riovcnt, flags);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(preadv2, [](FEXCore::Core::InternalThreadState *Thread, int fd, const struct iovec_32 *iov, int iovcnt, off_t offset, int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(preadv2, [](FEXCore::Core::InternalThreadState *Thread, int fd, const struct iovec32 *iov, int iovcnt, off_t offset, int flags) -> uint64_t {
       std::vector<iovec> Host_iovec(iovcnt);
       for (int i = 0; i < iovcnt; ++i) {
-        Host_iovec[i].iov_base = reinterpret_cast<void*>(iov[i].iov_base);
-        Host_iovec[i].iov_len = iov[i].iov_len;
+        Host_iovec[i] = iov[i];
       }
 
       uint64_t Result = ::preadv2(fd, &Host_iovec.at(0), iovcnt, offset, flags);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(pwritev2, [](FEXCore::Core::InternalThreadState *Thread, int fd, const struct iovec_32 *iov, int iovcnt, off_t offset, int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(pwritev2, [](FEXCore::Core::InternalThreadState *Thread, int fd, const struct iovec32 *iov, int iovcnt, off_t offset, int flags) -> uint64_t {
       std::vector<iovec> Host_iovec(iovcnt);
       for (int i = 0; i < iovcnt; ++i) {
-        Host_iovec[i].iov_base = reinterpret_cast<void*>(iov[i].iov_base);
-        Host_iovec[i].iov_len = iov[i].iov_len;
+        Host_iovec[i] = iov[i];
       }
 
       uint64_t Result = ::pwritev2(fd, &Host_iovec.at(0), iovcnt, offset, flags);
       SYSCALL_ERRNO();
     });
 
+    REGISTER_SYSCALL_IMPL_X32(fstatat64, [](FEXCore::Core::InternalThreadState *Thread, int dirfd, const char *pathname, stat64_32 *buf, int flag) -> uint64_t {
+      struct stat64 host_stat;
+      uint64_t Result = ::fstatat64(dirfd, pathname, &host_stat, flag);
+      if (Result != -1) {
+        *buf = host_stat;
+      }
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(ioctl, [](FEXCore::Core::InternalThreadState *Thread, int fd, uint32_t request, uint32_t args) -> uint64_t {
+      uint64_t Result = ::syscall(SYS_ioctl,
+        static_cast<uint64_t>(fd),
+        request,
+        args);
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(getdents, [](FEXCore::Core::InternalThreadState *Thread, int fd, void *dirp, uint32_t count) -> uint64_t {
+#ifdef SYS_getdents
+      std::vector<uint8_t> TmpVector(count);
+      void *TmpPtr = reinterpret_cast<void*>(&TmpVector.at(0));
+
+      // Copy the incoming structures to our temporary array
+      for (uint64_t Offset = 0, TmpOffset = 0;
+          Offset < count;) {
+        linux_dirent_32 *Incoming = (linux_dirent_32*)(reinterpret_cast<uint64_t>(dirp) + Offset);
+        linux_dirent *Tmp = (linux_dirent*)(reinterpret_cast<uint64_t>(TmpPtr) + TmpOffset);
+
+        if (!Incoming->d_reclen ||
+            (Offset + Incoming->d_reclen) > count) {
+          break;
+        }
+
+        size_t NewRecLen = Incoming->d_reclen + (sizeof(linux_dirent) - sizeof(linux_dirent_32));
+        Tmp->d_ino    = Incoming->d_ino;
+        Tmp->d_off    = Incoming->d_off;
+        Tmp->d_reclen = NewRecLen;
+
+        // This actually copies two more bytes than the string of d_name
+        // Copies a null byte for the string
+        // Copies a d_type flag that lives after the name
+        size_t CopySize = std::clamp<uint32_t>(Incoming->d_reclen - offsetof(linux_dirent_32, d_name), 0U, count - Offset);
+        memcpy(Tmp->d_name, Incoming->d_name, CopySize);
+
+        // We take up 8 more bytes of space
+        TmpOffset += NewRecLen;
+        Offset += Incoming->d_reclen;
+      }
+
+      uint64_t Result = syscall(SYS_getdents,
+        static_cast<uint64_t>(fd),
+        TmpPtr,
+        static_cast<uint64_t>(count));
+
+      // Now copy back in to the array we were given
+      if (Result != -1) {
+        uint64_t Offset = 0;
+        // With how the emulation occurs we will always return a smaller buffer than what was given to us
+        for (uint64_t TmpOffset = 0, num = 0; TmpOffset < Result; ++num) {
+          linux_dirent_32 *Outgoing = (linux_dirent_32*)(reinterpret_cast<uint64_t>(dirp) + Offset);
+          linux_dirent *Tmp = (linux_dirent*)(reinterpret_cast<uint64_t>(TmpPtr) + TmpOffset);
+
+          if (!Tmp->d_reclen) {
+            break;
+          }
+
+          size_t NewRecLen = Tmp->d_reclen - (sizeof(std::remove_reference<decltype(*Tmp)>::type) - sizeof(*Outgoing));
+          Outgoing->d_ino = Tmp->d_ino;
+          // If we pass d_off directly then we seem to encounter issues?
+          Outgoing->d_off = num; //Tmp->d_off;
+          size_t OffsetOfName = offsetof(std::remove_reference<decltype(*Tmp)>::type, d_name);
+          Outgoing->d_reclen = NewRecLen;
+
+          // Copies null character and d_type flag as well
+          memcpy(Outgoing->d_name, Tmp->d_name, Tmp->d_reclen - OffsetOfName);
+
+          TmpOffset += Tmp->d_reclen;
+          // Outgoing is 8 bytes smaller
+          Offset += NewRecLen;
+        }
+        Result = Offset;
+      }
+      SYSCALL_ERRNO();
+#else
+      // XXX: Emulate
+      return -ENOSYS;
+#endif
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(getdents64, [](FEXCore::Core::InternalThreadState *Thread, int fd, void *dirp, uint32_t count) -> uint64_t {
+      uint64_t Result = ::syscall(SYS_getdents64,
+        static_cast<uint64_t>(fd),
+        dirp,
+        static_cast<uint64_t>(count));
+      if (Result != -1) {
+        // Walk each offset
+        // if we are passing the full d_off to the 32bit application then it seems to break things?
+        for (size_t i = 0, num = 0; i < Result; ++num) {
+          linux_dirent_64 *Incoming = (linux_dirent_64*)(reinterpret_cast<uint64_t>(dirp) + i);
+          Incoming->d_off = num;
+          i += Incoming->d_reclen;
+        }
+      }
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(_newselect, [](FEXCore::Core::InternalThreadState *Thread, int nfds, fd_set32 *readfds, fd_set32 *writefds, fd_set32 *exceptfds, struct timeval32 *timeout) -> uint64_t {
+      struct timeval tp64{};
+      if (timeout) {
+        tp64 = *timeout;
+      }
+
+      fd_set Host_readfds;
+      fd_set Host_writefds;
+      fd_set Host_exceptfds;
+      FD_ZERO(&Host_readfds);
+      FD_ZERO(&Host_writefds);
+      FD_ZERO(&Host_exceptfds);
+
+      // Round up to the full 32bit word
+      uint32_t NumWords = AlignUp(nfds, 32) / 4;
+
+      if (readfds) {
+        for (int i = 0; i < NumWords; ++i) {
+          uint32_t FD = readfds[i];
+          int32_t Rem = nfds - (i * 32);
+          for (int j = 0; j < 32 && j < Rem; ++j) {
+            if ((FD >> j) & 1) {
+              FD_SET(i * 32 + j, &Host_readfds);
+            }
+          }
+        }
+      }
+
+      if (writefds) {
+        for (int i = 0; i < NumWords; ++i) {
+          uint32_t FD = writefds[i];
+          int32_t Rem = nfds - (i * 32);
+          for (int j = 0; j < 32 && j < Rem; ++j) {
+            if ((FD >> j) & 1) {
+              FD_SET(i * 32 + j, &Host_writefds);
+            }
+          }
+        }
+      }
+
+      if (exceptfds) {
+        for (int i = 0; i < NumWords; ++i) {
+          uint32_t FD = exceptfds[i];
+          int32_t Rem = nfds - (i * 32);
+          for (int j = 0; j < 32 && j < Rem; ++j) {
+            if ((FD >> j) & 1) {
+              FD_SET(i * 32 + j, &Host_exceptfds);
+            }
+          }
+        }
+      }
+
+      uint64_t Result = ::select(nfds,
+        readfds ? &Host_readfds : nullptr,
+        writefds ? &Host_writefds : nullptr,
+        exceptfds ? &Host_exceptfds : nullptr,
+        timeout ? &tp64 : nullptr);
+
+      if (timeout) {
+        *timeout = tp64;
+      }
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(fadvise64_64, [](FEXCore::Core::InternalThreadState *Thread, int32_t fd, uint32_t offset_low, uint32_t offset_high, uint32_t len_low, uint32_t len_high, int advice) -> uint64_t {
+      uint64_t Offset = offset_high;
+      Offset <<= 32;
+      Offset |= offset_low;
+      uint64_t Len = len_high;
+      Len <<= 32;
+      Len |= len_low;
+      uint64_t Result = ::posix_fadvise64(fd, Offset, Len, advice);
+      SYSCALL_ERRNO();
+    });
   }
 }

--- a/External/FEXCore/Source/Interface/HLE/x32/FS.cpp
+++ b/External/FEXCore/Source/Interface/HLE/x32/FS.cpp
@@ -6,12 +6,25 @@
 #include "Interface/HLE/Syscalls.h"
 
 #include <sys/mount.h>
+#include <unistd.h>
 
 namespace FEXCore::HLE::x32 {
   void RegisterFS() {
     REGISTER_SYSCALL_IMPL_X32(umount, [](FEXCore::Core::InternalThreadState *Thread, const char *target) -> uint64_t {
       uint64_t Result = ::umount(target);
       SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(ftruncate64, [](FEXCore::Core::InternalThreadState *Thread, int fd, uint32_t offset_low, uint32_t offset_high) -> uint64_t {
+      uint64_t Offset = offset_high;
+      Offset <<= 32;
+      Offset |= offset_low;
+      uint64_t Result = ::ftruncate(fd, Offset);
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(sigprocmask, [](FEXCore::Core::InternalThreadState *Thread, int how, const uint64_t *set, uint64_t *oldset, size_t sigsetsize) -> uint64_t {
+      return Thread->CTX->SignalDelegation.GuestSigProcMask(how, set, oldset);
     });
   }
 }

--- a/External/FEXCore/Source/Interface/HLE/x32/Memory.cpp
+++ b/External/FEXCore/Source/Interface/HLE/x32/Memory.cpp
@@ -4,65 +4,295 @@
 #include "Interface/Context/Context.h"
 #include "Interface/Core/InternalThreadState.h"
 
+#include "Common/MathUtils.h"
+
+#include <bitset>
 #include <stddef.h>
 #include <stdint.h>
 #include <sys/mman.h>
 
-namespace FEXCore::Core {
-struct InternalThreadState;
-}
-
-#define MEM_PASSTHROUGH
 namespace FEXCore::HLE::x32 {
-    static uint32_t MMap(FEXCore::Core::InternalThreadState *Thread, void *addr, size_t length, int prot, int flags, int fd, off_t offset) {
-#ifdef MEM_PASSTHROUGH
-      if (flags & MAP_FIXED) {
-        uint64_t Result = reinterpret_cast<uint64_t>(::mmap(addr, length, prot, flags, fd, offset));
-        SYSCALL_ERRNO();
-      }
-#ifdef MAP_32BIT
-      else if (addr == nullptr && offset == 0 && fd == -1) {
-        prot &= ~PROT_EXEC;
-        uint64_t Result = reinterpret_cast<uint64_t>(::mmap(addr, length, prot, flags | MAP_32BIT, fd, offset));
-        SYSCALL_ERRNO();
-      }
-#endif
-      else if (!addr) {
-        // Okay, MAP_32BIT doesn't exist here
-        // We need to spin through the lower 32bit and try and find a free address
-        // In the future we should definitely use a bitmap allocator to understand where we can place pages
+class MemAllocator {
+private:
+  static constexpr uint64_t PAGE_SHIFT = 12;
+  static constexpr uint64_t PAGE_SIZE = 1 << PAGE_SHIFT;
+  static constexpr uint64_t PAGE_MASK = (1 << PAGE_SHIFT) - 1;
+  static constexpr uint64_t BASE_KEY = 16;
+  const uint64_t TOP_KEY = 0xFFFF'F000ULL >> PAGE_SHIFT;
 
-        // Skip the first page since we can never allocate that
-        static uint64_t StartingPage = Core::PAGE_SIZE;
-        constexpr uint64_t Max4GB = 0x1'0000'0000;
-        flags |= MAP_FIXED_NOREPLACE;
-        uint64_t Result{};
-        for (; StartingPage < Max4GB; StartingPage += Core::PAGE_SIZE) {
-          Result = reinterpret_cast<uint64_t>(::mmap(reinterpret_cast<void*>(StartingPage), length, prot, flags, fd, offset));
-          if (Result != ~0ULL) {
-            return Result;
-          }
-        }
-        // If we get here then we are out of memory
-        return -ENOMEM;
+public:
+  MemAllocator() {
+    // First 16 pages are taken by the Linux kernel
+    for (size_t i = 0; i < 16; ++i) {
+      MappedPages.set(i);
+    }
+    // Take the top page as well
+    MappedPages.set(TOP_KEY);
+  }
+  void *mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset);
+  int munmap(void *addr, size_t length);
+  void *mremap(void *old_address, size_t old_size, size_t new_size, int flags, void *new_address);
+
+private:
+  // Set that contains 4k mapped pages
+  // This is the full 32bit memory range
+  std::bitset<0x10'0000> MappedPages;
+  uint64_t LastScanLocation = BASE_KEY;
+  std::mutex AllocMutex{};
+  uint64_t FindPageRange(uint64_t Start, size_t Pages);
+  uint64_t FindPageRange_TopDown(uint64_t Start, size_t Pages);
+};
+
+uint64_t MemAllocator::FindPageRange(uint64_t Start, size_t Pages) {
+  // Linear range scan
+  while (Start != TOP_KEY) {
+    bool Free = true;
+    if ((Start + Pages) > TOP_KEY) {
+      return 0;
+    }
+    uint64_t Offset = 0;
+    for (; Offset < Pages; ++Offset) {
+      if (MappedPages.test(Start + Offset)) {
+        Free = false;
+        break;
       }
-      else {
-        return ~1U;
-      }
-#else
-      return Thread->CTX->SyscallHandler->HandleMMAP(Thread, addr, length, prot, flags, fd, offset);
-#endif
     }
 
-  void RegisterMemory() {
-    REGISTER_SYSCALL_IMPL_X32(mmap, MMap);
+    if (Free) {
+      return Start;
+    }
+    Start += Offset + 1;
+  }
 
-    REGISTER_SYSCALL_IMPL_X32(mmap2, [](FEXCore::Core::InternalThreadState *Thread, void *addr, size_t length, int prot, int flags, int fd, off_t pgoffset) -> uint32_t {
-      return MMap(Thread, addr, length, prot, flags, fd, pgoffset * 0x1000);
+  return 0;
+}
+
+uint64_t MemAllocator::FindPageRange_TopDown(uint64_t Start, size_t Pages) {
+  // Linear range scan
+  Start -= Pages;
+  while (Start != BASE_KEY) {
+    bool Free = true;
+    if (Start < BASE_KEY) {
+      return 0;
+    }
+
+    uint64_t Offset = 0;
+    for (; Offset < Pages; ++Offset) {
+      if (MappedPages.test(Start + Offset)) {
+        Free = false;
+        break;
+      }
+    }
+
+    if (Free) {
+      return Start;
+    }
+    Start -= (Pages - Offset) + 1;
+  }
+
+  return 0;
+}
+
+void *MemAllocator::mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset) {
+  std::scoped_lock<std::mutex> lk{AllocMutex};
+  size_t PagesLength = AlignUp(length, PAGE_SIZE) >> PAGE_SHIFT;
+
+  uintptr_t Addr = reinterpret_cast<uintptr_t>(addr);
+  uintptr_t PageAddr = AlignUp(Addr, PAGE_SIZE) >> PAGE_SHIFT;
+
+  uintptr_t PageEnd = PageAddr + PagesLength;
+
+  bool Fixed = ((flags & MAP_FIXED) ||
+      (flags & MAP_FIXED_NOREPLACE));
+
+  // Both Addr and length must be page aligned
+  if (Addr & PAGE_MASK) {
+    return (void*)-EINVAL;
+  }
+
+  // If we do have an fd then offset must be page aligned
+  if (fd != -1 &&
+      offset & PAGE_MASK) {
+    return (void*)-EINVAL;
+  }
+
+  if (Addr + length > std::numeric_limits<uint32_t>::max()) {
+    return (void*)-EOVERFLOW;
+  }
+
+  // Check reserved range
+  if (Fixed && PageAddr < 16) {
+    return (void*)-EINVAL;
+  }
+
+  if (!Fixed) {
+    // If we aren't mapping fixed the ignore the address input
+    Addr = 0;
+    PageAddr = 0;
+    PageEnd = PagesLength;
+  }
+
+  // Find a region that fits our address
+  if (Addr == 0) {
+    bool Wrapped = false;
+    uint64_t BottomPage = LastScanLocation;
+restart:
+    {
+      // Linear range scan
+      uint64_t LowerPage = FindPageRange(BottomPage, PagesLength);
+      if (LowerPage == 0) {
+        // Try again but this time from the start
+        BottomPage = BASE_KEY;
+        LowerPage = FindPageRange(BottomPage, PagesLength);
+      }
+
+      uint64_t UpperPage = LowerPage + PagesLength;
+      if (LowerPage == 0) {
+        return (void*)(uintptr_t)-ENOMEM;
+      }
+      {
+        // Try and map the range
+        void *MappedPtr = ::mmap(
+          reinterpret_cast<void*>(LowerPage<< PAGE_SHIFT),
+          length,
+          prot,
+          flags | MAP_FIXED_NOREPLACE,
+          fd,
+          offset);
+
+        if (MappedPtr == MAP_FAILED) {
+          if (UpperPage == TOP_KEY) {
+            BottomPage = BASE_KEY;
+            Wrapped = true;
+            goto restart;
+          }
+          else if (Wrapped &&
+            LowerPage >= LastScanLocation) {
+            // We linear scanned the entire memory range. Give up
+            return (void*)(uintptr_t)-errno;
+          }
+          else {
+            // Try again
+            BottomPage += PagesLength;
+            goto restart;
+          }
+        }
+        else {
+          LastScanLocation = UpperPage;
+          // Set the range as mapped
+          for (size_t i = 0; i < PagesLength; ++i) {
+            MappedPages.set(LowerPage + i);
+          }
+          return MappedPtr;
+        }
+      }
+    }
+  }
+  else {
+    void *MappedPtr = ::mmap(
+      reinterpret_cast<void*>(PageAddr << PAGE_SHIFT),
+      PagesLength << PAGE_SHIFT,
+      prot,
+      flags,
+      fd,
+      offset);
+
+    if (MappedPtr != MAP_FAILED) {
+      for (size_t i = 0; i < PagesLength; ++i) {
+        MappedPages.set(PageAddr + i);
+      }
+      return MappedPtr;
+    }
+    else {
+      return (void*)(uintptr_t)-errno;
+    }
+  }
+  return 0;
+}
+
+int MemAllocator::munmap(void *addr, size_t length) {
+  std::scoped_lock<std::mutex> lk{AllocMutex};
+  size_t PagesLength = AlignUp(length, PAGE_SIZE) >> PAGE_SHIFT;
+
+  uintptr_t Addr = reinterpret_cast<uintptr_t>(addr);
+  uintptr_t PageAddr = Addr >> PAGE_SHIFT;
+
+  uintptr_t PageEnd = PageAddr + PagesLength;
+
+  // Both Addr and length must be page aligned
+  if (Addr & PAGE_MASK) {
+    return -EINVAL;
+  }
+
+  if (length & PAGE_MASK) {
+    return -EINVAL;
+  }
+
+  if (Addr + length > std::numeric_limits<uint32_t>::max()) {
+    return -EOVERFLOW;
+  }
+
+  // Check reserved range
+  if (PageAddr < 16) {
+    // Return success for these
+    return 0;
+  }
+
+  while (PageAddr != PageEnd) {
+    // Always pass to munmap, it may be something allocated we aren't tracking
+    int Result = ::munmap(reinterpret_cast<void*>(PageAddr << PAGE_SHIFT), PAGE_SIZE);
+    if (Result != 0) {
+      return -errno;
+    }
+
+    if (MappedPages.test(PageAddr)) {
+      MappedPages.reset(PageAddr);
+    }
+
+    ++PageAddr;
+  }
+
+  return 0;
+}
+
+void *MemAllocator::mremap(void *old_address, size_t old_size, size_t new_size, int flags, void *new_address) {
+  std::scoped_lock<std::mutex> lk{AllocMutex};
+  // XXX: Not currently supported
+  return reinterpret_cast<void*>(-ENOMEM);
+}
+
+  static std::unique_ptr<MemAllocator> alloc{};
+  void RegisterMemory() {
+    alloc = std::make_unique<MemAllocator>();
+
+    REGISTER_SYSCALL_IMPL_X32(mmap, [](FEXCore::Core::InternalThreadState *Thread, uint32_t addr, uint32_t length, int prot, int flags, int fd, int32_t offset) -> uint64_t {
+      return (uint64_t)alloc->mmap(reinterpret_cast<void*>(addr), length, prot,flags, fd, offset);
     });
 
-    REGISTER_SYSCALL_IMPL_X32(mprotect, [](FEXCore::Core::InternalThreadState *Thread, void *addr, size_t len, int prot) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(mmap2, [](FEXCore::Core::InternalThreadState *Thread, uint32_t addr, uint32_t length, int prot, int flags, int fd, int32_t pgoffset) -> uint64_t {
+      return (uint64_t)alloc->mmap(reinterpret_cast<void*>(addr), length, prot,flags, fd, pgoffset * 0x1000);
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(munmap, [](FEXCore::Core::InternalThreadState *Thread, void *addr, size_t length) -> uint64_t {
+      return alloc->munmap(addr, length);
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(mprotect, [](FEXCore::Core::InternalThreadState *Thread, void *addr, uint32_t len, int prot) -> uint64_t {
       uint64_t Result = ::mprotect(addr, len, prot);
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(mremap, [](FEXCore::Core::InternalThreadState *Thread, void *old_address, size_t old_size, size_t new_size, int flags, void *new_address) -> uint64_t {
+      return reinterpret_cast<uint64_t>(alloc->mremap(old_address, old_size, new_size, flags, new_address));
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(mlockall, [](FEXCore::Core::InternalThreadState *Thread, int flags) -> uint64_t {
+      uint64_t Result = ::mlock2(reinterpret_cast<void*>(0x1'0000), 0x1'0000'0000ULL - 0x1'0000, flags);
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(munlockall, [](FEXCore::Core::InternalThreadState *Thread) -> uint64_t {
+      uint64_t Result = ::munlock(reinterpret_cast<void*>(0x1'0000), 0x1'0000'0000ULL - 0x1'0000);
       SYSCALL_ERRNO();
     });
   }

--- a/External/FEXCore/Source/Interface/HLE/x32/Sched.cpp
+++ b/External/FEXCore/Source/Interface/HLE/x32/Sched.cpp
@@ -1,0 +1,23 @@
+#include "Interface/Context/Context.h"
+#include "Interface/HLE/Syscalls.h"
+#include "Interface/HLE/x32/Syscalls.h"
+
+#include <stdint.h>
+#include <sched.h>
+#include <sys/time.h>
+#include <sys/resource.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+namespace FEXCore::HLE::x32 {
+  void RegisterSched() {
+    REGISTER_SYSCALL_IMPL_X32(sched_rr_get_interval, [](FEXCore::Core::InternalThreadState *Thread, pid_t pid, struct timespec32 *tp) -> uint64_t {
+      struct timespec tp64{};
+      uint64_t Result = ::sched_rr_get_interval(pid, tp ? &tp64 : nullptr);
+      if (tp) {
+        *tp = tp64;
+      }
+      SYSCALL_ERRNO();
+    });
+  }
+}

--- a/External/FEXCore/Source/Interface/HLE/x32/Semaphore.cpp
+++ b/External/FEXCore/Source/Interface/HLE/x32/Semaphore.cpp
@@ -8,10 +8,6 @@
 #include <sys/shm.h>
 #include <sys/types.h>
 
-namespace FEXCore::Core {
-struct InternalThreadState;
-}
-
 namespace FEXCore::HLE::x32 {
   // Define the IPC ops
   enum IPCOp {
@@ -29,66 +25,779 @@ namespace FEXCore::HLE::x32 {
     OP_SHMCTL     = 24,
   };
 
-  void RegisterSemaphore() {
-    REGISTER_SYSCALL_IMPL_X32(ipc, [](FEXCore::Core::InternalThreadState *Thread, uint32_t call, int32_t first, int32_t second, int32_t third, uint32_t ptr, int32_t fifth) -> uint32_t {
-      uint64_t Result{};
-      switch (static_cast<IPCOp>(call)) {
-        case OP_SEMOP: {
-          Result = ::semop(first, reinterpret_cast<struct sembuf*>(ptr), second);
-          break;
-        }
-        case OP_SEMGET: {
-          Result = ::semget(first, second, third);
-          break;
-        }
-        case OP_SEMCTL: {
-          Result = ::semctl(first, second, third, ptr);
-          break;
-        }
-        case OP_SEMTIMEDOP: {
-          Result = ::semtimedop(first, reinterpret_cast<struct sembuf*>(ptr), second, reinterpret_cast<struct timespec*>(fifth));
-          break;
-        }
-        case OP_MSGSND: {
-          Result = ::msgsnd(first, reinterpret_cast<void*>(ptr), second, third);
-          break;
-        }
-        case OP_MSGRCV: {
-          Result = ::msgrcv(first, reinterpret_cast<void*>(ptr), second, fifth, third);
-          break;
-        }
-        case OP_MSGGET: {
-          Result = ::msgget(first, second);
-          break;
-        }
-        case OP_MSGCTL: {
-          Result = ::msgctl(first, second, reinterpret_cast<struct msqid_ds*>(ptr));
-          break;
-        }
-        case OP_SHMAT: {
-          Result = reinterpret_cast<uint64_t>(::shmat(first, reinterpret_cast<void*>(ptr), second));
-          if (Result != -1) {
-            *reinterpret_cast<uint32_t*>(third) = static_cast<uint32_t>(Result);
-            Result = 0;
+  struct msgbuf_32 {
+    uint32_t mtype;
+    char mtext[1];
+  };
+
+  struct ipc_perm_32 {
+    uint32_t key;
+    uint16_t uid;
+    uint16_t gid;
+    uint16_t cuid;
+    uint16_t cgid;
+    uint16_t mode;
+    uint16_t seq;
+
+    ipc_perm_32() = delete;
+
+    operator struct ipc_perm() const {
+      struct ipc_perm perm;
+      perm.__key = key;
+      perm.uid   = uid;
+      perm.gid   = gid;
+      perm.cuid  = cuid;
+      perm.cgid  = cgid;
+      perm.mode  = mode;
+      perm.__seq = seq;
+      return perm;
+    }
+
+    ipc_perm_32(struct ipc_perm perm) {
+      key  = perm.__key;
+      uid  = perm.uid;
+      gid  = perm.gid;
+      cuid = perm.cuid;
+      cgid = perm.cgid;
+      mode = perm.mode;
+      seq  = perm.__seq;
+    }
+  };
+
+  static_assert(std::is_trivial<ipc_perm_32>::value, "Needs to be trivial");
+  static_assert(sizeof(ipc_perm_32) == 16, "Incorrect size");
+
+  struct ipc_perm_64 {
+    uint32_t key;
+    uint32_t uid;
+    uint32_t gid;
+    uint32_t cuid;
+    uint32_t cgid;
+    uint16_t mode;
+    uint16_t _pad1;
+    uint16_t seq;
+    uint16_t _pad2;
+    compat_ulong_t _pad[2];
+
+    ipc_perm_64() = delete;
+
+    operator struct ipc_perm() const {
+      struct ipc_perm perm;
+      perm.__key = key;
+      perm.uid   = uid;
+      perm.gid   = gid;
+      perm.cuid  = cuid;
+      perm.cgid  = cgid;
+      perm.mode  = mode;
+      perm.__seq = seq;
+      return perm;
+    }
+
+    ipc_perm_64(struct ipc_perm perm) {
+      key  = perm.__key;
+      uid  = perm.uid;
+      gid  = perm.gid;
+      cuid = perm.cuid;
+      cgid = perm.cgid;
+      mode = perm.mode;
+      seq  = perm.__seq;
+    }
+  };
+
+  static_assert(std::is_trivial<ipc_perm_64>::value, "Needs to be trivial");
+  static_assert(sizeof(ipc_perm_64) == 36, "Incorrect size");
+
+  struct shmid_ds_32 {
+    ipc_perm_32 shm_perm;
+    int32_t shm_segsz;
+    int32_t shm_atime;
+    int32_t shm_dtime;
+    int32_t shm_ctime;
+    uint16_t shm_cpid;
+    uint16_t shm_lpid;
+    uint16_t shm_nattch;
+    uint16_t shm_unused;
+    uint32_t shm_unused2;
+    uint32_t shm_unused3;
+
+    shmid_ds_32() = delete;
+
+    operator struct shmid_ds() const {
+      struct shmid_ds buf;
+      buf.shm_perm = shm_perm;
+
+      buf.shm_segsz = shm_segsz;
+      buf.shm_atime = shm_atime;
+      buf.shm_dtime = shm_dtime;
+      buf.shm_ctime = shm_ctime;
+      buf.shm_cpid = shm_cpid;
+      buf.shm_lpid = shm_lpid;
+      buf.shm_nattch = shm_nattch;
+      return buf;
+    }
+
+    shmid_ds_32(struct shmid_ds buf)
+      : shm_perm {buf.shm_perm} {
+      shm_segsz = buf.shm_segsz;
+      shm_atime = buf.shm_atime;
+      shm_dtime = buf.shm_dtime;
+      shm_ctime = buf.shm_ctime;
+      shm_cpid = buf.shm_cpid;
+      shm_lpid = buf.shm_lpid;
+      shm_nattch = buf.shm_nattch;
+    }
+  };
+
+  static_assert(std::is_trivial<shmid_ds_32>::value, "Needs to be trivial");
+  static_assert(sizeof(shmid_ds_32) == 48, "Incorrect size");
+
+  struct shmid_ds_64 {
+    ipc_perm_64 shm_perm;
+    compat_size_t shm_segsz;
+    compat_ulong_t shm_atime;
+    compat_ulong_t shm_atime_high;
+    compat_ulong_t shm_dtime;
+    compat_ulong_t shm_dtime_high;
+    compat_ulong_t shm_ctime;
+    compat_ulong_t shm_ctime_high;
+    int32_t shm_cpid;
+    int32_t shm_lpid;
+    compat_ulong_t shm_nattch;
+    compat_ulong_t shm_unused4;
+    compat_ulong_t shm_unused5;
+
+    shmid_ds_64() = delete;
+
+    operator struct shmid_ds() const {
+      struct shmid_ds buf;
+      buf.shm_perm = shm_perm;
+
+      buf.shm_segsz = shm_segsz;
+      buf.shm_atime = shm_atime_high;
+      buf.shm_atime <<= 32;
+      buf.shm_atime |= shm_atime;
+
+      buf.shm_dtime = shm_dtime_high;
+      buf.shm_dtime <<= 32;
+      buf.shm_dtime |= shm_dtime;
+
+      buf.shm_ctime = shm_ctime_high;
+      buf.shm_ctime <<= 32;
+      buf.shm_ctime |= shm_ctime;
+
+      buf.shm_cpid = shm_cpid;
+      buf.shm_lpid = shm_lpid;
+      buf.shm_nattch = shm_nattch;
+      return buf;
+    }
+
+    shmid_ds_64(struct shmid_ds buf)
+      : shm_perm {buf.shm_perm} {
+      shm_segsz = buf.shm_segsz;
+      shm_atime = buf.shm_atime;
+      shm_atime_high = buf.shm_atime >> 32;
+      shm_dtime = buf.shm_dtime;
+      shm_dtime_high = buf.shm_dtime >> 32;
+      shm_ctime = buf.shm_ctime;
+      shm_ctime_high = buf.shm_ctime >> 32;
+      shm_cpid = buf.shm_cpid;
+      shm_lpid = buf.shm_lpid;
+      shm_nattch = buf.shm_nattch;
+    }
+  };
+
+  static_assert(std::is_trivial<shmid_ds_64>::value, "Needs to be trivial");
+  static_assert(sizeof(shmid_ds_64) == 84, "Incorrect size");
+
+  struct semid_ds_32 {
+    struct ipc_perm_32 sem_perm;
+    int32_t sem_otime;
+    int32_t sem_ctime;
+    uint32_t sem_base;
+    uint32_t sem_pending;
+    uint32_t sem_pending_last;
+    uint32_t undo;
+    uint16_t sem_nsems;
+    uint16_t _pad;
+
+    semid_ds_32() = delete;
+
+    operator struct semid_ds() const {
+      struct semid_ds buf{};
+      buf.sem_perm = sem_perm;
+
+      buf.sem_otime = sem_otime;
+      buf.sem_ctime = sem_ctime;
+      buf.sem_nsems = sem_nsems;
+
+      // sem_base, sem_pending, sem_pending_last, undo doesn't exist in the definition
+      // Kernel doesn't return anything in them
+      return buf;
+    }
+
+    semid_ds_32(struct semid_ds buf)
+      : sem_perm {buf.sem_perm} {
+      sem_otime = buf.sem_otime;
+      sem_ctime = buf.sem_ctime;
+      sem_nsems = buf.sem_nsems;
+    }
+  };
+
+  static_assert(std::is_trivial<semid_ds_32>::value, "Needs to be trivial");
+  static_assert(sizeof(semid_ds_32) == 44, "Incorrect size");
+
+  struct semid_ds_64 {
+    struct ipc_perm_64 sem_perm;
+    uint32_t sem_otime;
+    uint32_t sem_otime_high;
+    uint32_t sem_ctime;
+    uint32_t sem_ctime_high;
+    uint32_t sem_nsems;
+    uint32_t _pad[2];
+
+    semid_ds_64() = delete;
+
+    operator struct semid_ds() const {
+      struct semid_ds buf{};
+      buf.sem_perm = sem_perm;
+
+      buf.sem_otime = sem_otime_high;
+      buf.sem_otime <<= 32;
+      buf.sem_otime |= sem_otime;
+      buf.sem_ctime = sem_ctime_high;
+      buf.sem_ctime <<= 32;
+      buf.sem_ctime |= sem_ctime;
+      buf.sem_nsems = sem_nsems;
+
+      // sem_base, sem_pending, sem_pending_last, undo doesn't exist in the definition
+      // Kernel doesn't return anything in them
+      return buf;
+    }
+
+    semid_ds_64(struct semid_ds buf)
+      : sem_perm {buf.sem_perm} {
+      sem_otime = buf.sem_otime;
+      sem_otime_high = buf.sem_otime >> 32;
+      sem_ctime = buf.sem_ctime;
+      sem_ctime_high = buf.sem_ctime >> 32;
+      sem_nsems = buf.sem_nsems;
+    }
+  };
+
+  static_assert(std::is_trivial<semid_ds_64>::value, "Needs to be trivial");
+  static_assert(sizeof(semid_ds_64) == 64, "Incorrect size");
+
+  struct msqid_ds_32 {
+    struct ipc_perm_32 msg_perm;
+    compat_uptr_t msg_first;
+    compat_uptr_t msg_last;
+    uint32_t msg_stime;
+    uint32_t msg_rtime;
+    uint32_t msg_ctime;
+    uint32_t msg_lcbytes;
+    uint32_t msg_lqbytes;
+    uint16_t msg_cbytes;
+    uint16_t msg_qnum;
+    uint16_t msg_qbytes;
+    uint16_t msg_lspid;
+    uint16_t msg_lrpid;
+
+    msqid_ds_32() = delete;
+    msqid_ds_32(struct msqid_ds buf)
+      : msg_perm {buf.msg_perm} {
+      // msg_first and msg_last are unused and untouched
+      msg_stime = buf.msg_stime;
+      msg_rtime = buf.msg_rtime;
+      msg_ctime = buf.msg_ctime;
+      if (buf.msg_cbytes > std::numeric_limits<uint16_t>::max()) {
+        msg_cbytes = std::numeric_limits<uint16_t>::max();
+      }
+      else {
+        msg_cbytes = buf.msg_cbytes;
+      }
+      msg_lcbytes = buf.msg_cbytes;
+
+      if (buf.msg_qnum > std::numeric_limits<uint16_t>::max()) {
+        msg_qnum = std::numeric_limits<uint16_t>::max();
+      }
+      else {
+        msg_qnum = buf.msg_qnum;
+      }
+
+      if (buf.msg_cbytes > std::numeric_limits<uint16_t>::max()) {
+        msg_cbytes = std::numeric_limits<uint16_t>::max();
+      }
+      else {
+        msg_cbytes = buf.msg_cbytes;
+      }
+      msg_lqbytes = buf.msg_qbytes;
+      msg_lspid = buf.msg_lspid;
+      msg_lrpid = buf.msg_lrpid;
+    }
+  };
+  static_assert(std::is_trivial<msqid_ds_32>::value, "Needs to be trivial");
+  static_assert(sizeof(msqid_ds_32) == 56, "Incorrect size");
+
+  struct msqid_ds_64 {
+    struct ipc_perm_64 msg_perm;
+    uint32_t msg_stime;
+    uint32_t msg_stime_high;
+    uint32_t msg_rtime;
+    uint32_t msg_rtime_high;
+    uint32_t msg_ctime;
+    uint32_t msg_ctime_high;
+    uint32_t msg_cbytes;
+    uint32_t msg_qnum;
+    uint32_t msg_qbytes;
+    uint32_t msg_lspid;
+    uint32_t msg_lrpid;
+    uint32_t _pad[2];
+
+    msqid_ds_64() = delete;
+    msqid_ds_64(struct msqid_ds buf)
+      : msg_perm {buf.msg_perm} {
+      msg_stime = buf.msg_stime;
+      msg_stime_high = buf.msg_stime >> 32;
+      msg_rtime = buf.msg_rtime;
+      msg_rtime_high = buf.msg_rtime >> 32;
+      msg_ctime = buf.msg_ctime;
+      msg_ctime_high = buf.msg_ctime >> 32;
+      msg_cbytes = buf.msg_cbytes;
+      msg_qnum = buf.msg_qnum;
+      msg_qbytes = buf.msg_qbytes;
+      msg_lspid = buf.msg_lspid;
+      msg_lrpid = buf.msg_lrpid;
+    }
+  };
+
+  static_assert(std::is_trivial<msqid_ds_64>::value, "Needs to be trivial");
+  static_assert(sizeof(msqid_ds_64) == 88, "Incorrect size");
+
+  struct shminfo_32 {
+    uint32_t shmmax;
+    uint32_t shmmin;
+    uint32_t shmmni;
+    uint32_t shmseg;
+    uint32_t shmall;
+
+    shminfo_32() = delete;
+
+    operator struct shminfo() const {
+      struct shminfo si;
+      si.shmmax = shmmax;
+      si.shmmin = shmmin;
+      si.shmmni = shmmni;
+      si.shmseg = shmseg;
+      si.shmall = shmall;
+      return si;
+    }
+
+    shminfo_32(struct shminfo si) {
+      shmmax = si.shmmax;
+      shmmin = si.shmmin;
+      shmmni = si.shmmni;
+      shmseg = si.shmseg;
+      shmall = si.shmall;
+    }
+  };
+
+  static_assert(std::is_trivial<shminfo_32>::value, "Needs to be trivial");
+  static_assert(sizeof(shminfo_32) == 20, "Incorrect size");
+
+  struct shminfo_64 {
+    compat_ulong_t shmmax;
+    compat_ulong_t shmmin;
+    compat_ulong_t shmmni;
+    compat_ulong_t shmseg;
+    compat_ulong_t shmall;
+    compat_ulong_t __unused[4];
+
+    shminfo_64() = delete;
+
+    operator struct shminfo() const {
+      struct shminfo si;
+      si.shmmax = shmmax;
+      si.shmmin = shmmin;
+      si.shmmni = shmmni;
+      si.shmseg = shmseg;
+      si.shmall = shmall;
+      return si;
+    }
+
+    shminfo_64(struct shminfo si) {
+      shmmax = si.shmmax;
+      shmmin = si.shmmin;
+      shmmni = si.shmmni;
+      shmseg = si.shmseg;
+      shmall = si.shmall;
+    }
+  };
+
+  static_assert(std::is_trivial<shminfo_64>::value, "Needs to be trivial");
+  static_assert(sizeof(shminfo_64) == 36, "Incorrect size");
+
+  struct shm_info_32 {
+    int used_ids;
+    uint32_t shm_tot;
+    uint32_t shm_rss;
+    uint32_t shm_swp;
+    uint32_t swap_attempts;
+    uint32_t swap_successes;
+
+    shm_info_32() = delete;
+
+    shm_info_32(struct shm_info si) {
+      used_ids = si.used_ids;
+      shm_tot = si.shm_tot;
+      shm_rss = si.shm_rss;
+      shm_swp = si.shm_swp;
+      swap_attempts = si.swap_attempts;
+      swap_successes = si.swap_successes;
+    }
+  };
+
+  static_assert(std::is_trivial<shm_info_32>::value, "Needs to be trivial");
+  static_assert(sizeof(shm_info_32) == 24, "Incorrect size");
+
+  struct shm_info_64 {
+    int used_ids;
+    uint32_t _pad;
+    uint64_t shm_tot;
+    uint64_t shm_rss;
+    uint64_t shm_swp;
+    uint64_t swap_attempts;
+    uint64_t swap_successes;
+
+    shm_info_64() = delete;
+
+    shm_info_64(struct shm_info si) {
+      used_ids = si.used_ids;
+      shm_tot = si.shm_tot;
+      shm_rss = si.shm_rss;
+      shm_swp = si.shm_swp;
+      swap_attempts = si.swap_attempts;
+      swap_successes = si.swap_successes;
+    }
+  };
+
+  static_assert(std::is_trivial<shm_info_64>::value, "Needs to be trivial");
+  static_assert(sizeof(shm_info_64) == 48, "Incorrect size");
+
+  union semun_32 {
+    int32_t val;      // Value for SETVAL
+    compat_ptr<semid_ds_32> buf32; // struct semid_ds* - Buffer ptr for IPC_STAT, IPC_SET
+    compat_ptr<semid_ds_64> buf64; // struct semid_ds* - Buffer ptr for IPC_STAT, IPC_SET
+    uint32_t array;   // uint16_t array for GETALL, SETALL
+    compat_ptr<struct seminfo> __buf;   // struct seminfo * - Buffer for IPC_INFO
+  };
+
+  union msgun_32 {
+    int32_t val;      // Value for SETVAL
+    compat_ptr<msqid_ds_32> buf32; // struct msgid_ds* - Buffer ptr for IPC_STAT, IPC_SET
+    compat_ptr<msqid_ds_64> buf64; // struct msgid_ds* - Buffer ptr for IPC_STAT, IPC_SET
+    uint32_t array;   // uint16_t array for GETALL, SETALL
+    compat_ptr<struct msginfo> __buf;   // struct msginfo * - Buffer for IPC_INFO
+  };
+
+  union shmun_32 {
+    int32_t val;      // Value for SETVAL
+    compat_ptr<shmid_ds_32> buf32; // struct shmid_ds* - Buffer ptr for IPC_STAT, IPC_SET
+    compat_ptr<shmid_ds_64> buf64; // struct shmid_ds* - Buffer ptr for IPC_STAT, IPC_SET
+    uint32_t array;   // uint16_t array for GETALL, SETALL
+    compat_ptr<struct shminfo_32> __buf32;   // struct shminfo * - Buffer for IPC_INFO
+    compat_ptr<struct shminfo_64> __buf64;   // struct shminfo * - Buffer for IPC_INFO
+
+    compat_ptr<struct shm_info_32> __buf_info_32;   // struct shm_info * - Buffer for SHM_INFO
+    compat_ptr<struct shm_info_64> __buf_info_64;   // struct shm_info * - Buffer for SHM_INFO
+  };
+
+  union semun {
+    int val;			/* value for SETVAL */
+    struct semid_ds_32 *buf;	/* buffer for IPC_STAT & IPC_SET */
+    unsigned short *array;	/* array for GETALL & SETALL */
+    struct seminfo *__buf;	/* buffer for IPC_INFO */
+    void *__pad;
+  };
+
+  uint64_t _ipc(FEXCore::Core::InternalThreadState *Thread, uint32_t call, uint32_t first, uint32_t second, uint32_t third, uint32_t ptr, uint32_t fifth) {
+    uint64_t Result{};
+
+    switch (static_cast<IPCOp>(call)) {
+      case OP_SEMOP: {
+        Result = ::semop(first, reinterpret_cast<struct sembuf*>(ptr), second);
+        break;
+      }
+      case OP_SEMGET: {
+        Result = ::semget(first, second, third);
+        break;
+      }
+      case OP_SEMCTL: {
+        uint32_t semid = first;
+        uint32_t semnum = second;
+        // Upper 16bits used for a different flag?
+        int32_t cmd = third & 0xFF;
+        compat_ptr<semun_32> semun(ptr);
+        bool IPC64 = third & 0x100;
+#define UNHANDLED(x) case x: LogMan::Msg::A("Unhandled semctl cmd: " #x); break
+        switch (cmd) {
+          case IPC_SET: {
+            struct semid_ds buf{};
+            if (IPC64) {
+              buf = *semun->buf64;
+            }
+            else {
+              buf = *semun->buf32;
+            }
+            Result = ::semctl(semid, semnum, cmd, &buf);
+            if (Result != -1) {
+              if (IPC64) {
+                *semun->buf64 = buf;
+              }
+              else {
+                *semun->buf32 = buf;
+              }
+            }
+            break;
           }
-          break;
+          case SEM_STAT:
+          case SEM_STAT_ANY:
+          case IPC_STAT: {
+            struct semid_ds buf{};
+            Result = ::semctl(semid, semnum, cmd, &buf);
+            if (Result != -1) {
+              if (IPC64) {
+                *semun->buf64 = buf;
+              }
+              else {
+                *semun->buf32 = buf;
+              }
+            }
+            break;
+          }
+          case SEM_INFO:
+          case IPC_INFO: {
+            struct seminfo si{};
+            Result = ::semctl(semid, semnum, cmd, &si);
+            if (Result != -1) {
+              memcpy(semun->__buf, &si, sizeof(si));
+            }
+            break;
+          }
+          case GETALL:
+          case SETALL: {
+            // ptr is just a int32_t* in this case
+            Result = ::semctl(semid, semnum, cmd, semun->array);
+            break;
+          }
+          case SETVAL: {
+            // ptr is just a int32_t in this case
+            Result = ::semctl(semid, semnum, cmd, semun->val);
+            break;
+          }
+          case IPC_RMID:
+          case GETPID:
+          case GETNCNT:
+          case GETZCNT:
+          case GETVAL:
+            Result = ::semctl(semid, semnum, cmd);
+            break;
+          default: LogMan::Msg::A("Unhandled semctl cmd: %d", cmd); return -EINVAL; break;
         }
-        case OP_SHMDT: {
-          Result = ::shmdt(reinterpret_cast<void*>(ptr));
-          break;
-        }
-        case OP_SHMGET: {
-          Result = ::shmget(first, second, third);
-          break;
-        }
-        case OP_SHMCTL: {
-          Result = ::shmctl(first, second, reinterpret_cast<struct shmid_ds*>(ptr));
-          break;
+#undef UNHANDLED
+        break;
+      }
+      case OP_SEMTIMEDOP: {
+        timespec32 *timeout = reinterpret_cast<timespec32*>(fifth);
+        struct timespec tp64{};
+        struct timespec *timed_ptr{};
+        if (timeout) {
+          tp64 = *timeout;
+          timed_ptr = &tp64;
         }
 
-        default: return -ENOSYS;
+        Result = ::semtimedop(first, reinterpret_cast<struct sembuf*>(ptr), second, timed_ptr);
+        break;
       }
-      SYSCALL_ERRNO();
-    });
+      case OP_MSGSND: {
+        // Requires a temporary buffer
+        std::vector<uint8_t> Tmp(second + sizeof(size_t));
+        struct msgbuf *TmpMsg = reinterpret_cast<struct msgbuf *>(&Tmp.at(0));
+        msgbuf_32 *src = reinterpret_cast<msgbuf_32*>(ptr);
+        TmpMsg->mtype = src->mtype;
+        memcpy(TmpMsg->mtext, src->mtext, second);
+
+        Result = ::msgsnd(first, TmpMsg, second, third);
+        break;
+      }
+      case OP_MSGRCV: {
+        std::vector<uint8_t> Tmp(second + sizeof(size_t));
+        struct msgbuf *TmpMsg = reinterpret_cast<struct msgbuf *>(&Tmp.at(0));
+
+        Result = ::msgrcv(first, TmpMsg, second, *reinterpret_cast<uint32_t*>(fifth), third);
+
+        if (Result != -1) {
+          msgbuf_32 *src = reinterpret_cast<msgbuf_32*>(*reinterpret_cast<uint32_t*>(ptr));
+          src->mtype = TmpMsg->mtype;
+          memcpy(src->mtext, TmpMsg->mtext, Result);
+        }
+        break;
+      }
+      case OP_MSGGET: {
+        Result = ::msgget(first, second);
+        break;
+      }
+      case OP_MSGCTL: {
+        uint32_t msqid = first;
+        int32_t cmd = third & 0xFF;
+        msgun_32 *msgun = reinterpret_cast<msgun_32*>(ptr);
+        bool IPC64 = third & 0x100;
+#define UNHANDLED(x) case x: LogMan::Msg::A("Unhandled msgctl cmd: " #x); break
+        switch (cmd) {
+          UNHANDLED(IPC_SET);
+          case MSG_STAT:
+          case MSG_STAT_ANY:
+          case IPC_STAT: {
+            struct msqid_ds buf{};
+            Result = ::msgctl(msqid, cmd, &buf);
+            if (Result != -1) {
+              if (IPC64) {
+                *msgun->buf64 = buf;
+              }
+              else {
+                *msgun->buf32 = buf;
+              }
+            }
+            break;
+          }
+          case MSG_INFO:
+          case IPC_INFO: {
+            struct msginfo mi{};
+            Result = ::msgctl(msqid, cmd, reinterpret_cast<struct msqid_ds*>(&mi));
+            if (Result != -1) {
+              memcpy(msgun->__buf, &mi, sizeof(mi));
+            }
+            break;
+          }
+          case IPC_RMID:
+            Result = ::msgctl(msqid, cmd, nullptr);
+            break;
+          default: LogMan::Msg::A("Unhandled msgctl cmd: %d", cmd); return -EINVAL; break;
+        }
+#undef UNHANDLED
+        break;
+      }
+      case OP_SHMAT: {
+        Result = reinterpret_cast<uint64_t>(shmat(first, reinterpret_cast<const void*>(ptr), second));
+        if (Result != -1) {
+          uint32_t SmallRet = Result >> 32;
+          if (!(SmallRet == 0 ||
+                SmallRet == ~0U)) {
+            LogMan::Msg::A("Syscall returning something with data in the upper 32bits! BUG!");
+            return -ENOMEM;
+          }
+
+          *reinterpret_cast<uint32_t*>(third) = static_cast<uint32_t>(Result);
+          // Zero return on success
+          Result = 0;
+        }
+        break;
+      }
+      case OP_SHMDT: {
+        Result = ::shmdt(reinterpret_cast<void*>(ptr));
+        break;
+      }
+      case OP_SHMGET: {
+        Result = ::shmget(first, second, third);
+        break;
+      }
+      case OP_SHMCTL: {
+        int32_t shmid = first;
+        int32_t shmcmd = second;
+        int32_t cmd = shmcmd & 0xFF;
+        bool IPC64 = shmcmd & 0x100;
+        shmun_32 *shmun = reinterpret_cast<shmun_32*>(ptr);
+
+        switch (cmd) {
+          case IPC_SET: {
+            struct shmid_ds buf{};
+            if (IPC64) {
+              buf = *shmun->buf64;
+            }
+            else {
+              buf = *shmun->buf32;
+            }
+            Result = ::shmctl(shmid, cmd, &buf);
+            if (Result != -1) {
+              if (IPC64) {
+                *shmun->buf64 = buf;
+              }
+              else {
+                *shmun->buf32 = buf;
+              }
+            }
+            break;
+          }
+          case SHM_STAT:
+          case SHM_STAT_ANY:
+          case IPC_STAT: {
+            struct shmid_ds buf{};
+            Result = ::shmctl(shmid, cmd, &buf);
+            if (Result != -1) {
+              if (IPC64) {
+                buf = *shmun->buf64;
+              }
+              else {
+                buf = *shmun->buf32;
+              }
+            }
+            break;
+          }
+          case IPC_INFO: {
+            struct shminfo si{};
+            Result = ::shmctl(shmid, cmd, reinterpret_cast<struct shmid_ds*>(&si));
+            if (Result != -1) {
+              if (IPC64) {
+                *shmun->__buf64 = si;
+              }
+              else {
+                *shmun->__buf32 = si;
+              }
+            }
+            break;
+          }
+          case SHM_INFO: {
+            struct shm_info si{};
+            Result = ::shmctl(shmid, cmd, reinterpret_cast<struct shmid_ds*>(&si));
+            if (Result != -1) {
+              if (IPC64) {
+                *shmun->__buf_info_64 = si;
+              }
+              else {
+                *shmun->__buf_info_32 = si;
+              }
+            }
+            break;
+          }
+          case SHM_LOCK:
+            Result = ::shmctl(shmid, cmd, nullptr);
+            break;
+          case SHM_UNLOCK:
+            Result = ::shmctl(shmid, cmd, nullptr);
+            break;
+          case IPC_RMID:
+            Result = ::shmctl(shmid, cmd, nullptr);
+            break;
+
+          default: LogMan::Msg::A("Unhandled shmctl cmd: %d", cmd); return -EINVAL; break;
+        }
+        break;
+      }
+
+      default: return -ENOSYS;
+    }
+    SYSCALL_ERRNO();
+  }
+  void RegisterSemaphore() {
+    REGISTER_SYSCALL_IMPL_X32(ipc, _ipc);
   }
 }

--- a/External/FEXCore/Source/Interface/HLE/x32/Socket.cpp
+++ b/External/FEXCore/Source/Interface/HLE/x32/Socket.cpp
@@ -1,0 +1,218 @@
+#include "Interface/HLE/Syscalls.h"
+#include "Interface/HLE/x32/Syscalls.h"
+
+#include "Interface/Context/Context.h"
+#include "Interface/Core/InternalThreadState.h"
+
+#include <FEXCore/Utils/LogManager.h>
+
+#include <cstring>
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/socket.h>
+
+namespace FEXCore::HLE::x32 {
+  enum SockOp {
+    OP_SOCKET = 1,
+    OP_BIND = 2,
+    OP_CONNECT = 3,
+    OP_LISTEN = 4,
+    OP_ACCEPT = 5,
+    OP_GETSOCKNAME = 6,
+    OP_GETPEERNAME = 7,
+    OP_SOCKETPAIR = 8,
+    OP_SEND = 9,
+    OP_RECV = 10,
+    OP_SENDTO = 11,
+    OP_RECVFROM = 12,
+    OP_SHUTDOWN = 13,
+    OP_SETSOCKOPT = 14,
+    OP_GETSOCKOPT = 15,
+    OP_SENDMSG = 16,
+    OP_RECVMSG = 17,
+    OP_ACCEPT4 = 18,
+    OP_RECVMMSG = 19,
+    OP_SENDMMSG = 20,
+  };
+
+  void RegisterSocket() {
+    REGISTER_SYSCALL_IMPL_X32(socketcall, [](FEXCore::Core::InternalThreadState *Thread, uint32_t call, uint32_t *Arguments) -> uint64_t {
+      uint64_t Result{};
+
+      switch (call) {
+        case OP_SOCKET: {
+          Result = ::socket(Arguments[0], Arguments[1], Arguments[2]);
+          break;
+        }
+        case OP_BIND: {
+          Result = ::bind(Arguments[0], reinterpret_cast<const struct sockaddr *>(Arguments[1]), Arguments[2]);
+          break;
+        }
+        case OP_CONNECT: {
+          Result = ::connect(Arguments[0], reinterpret_cast<const struct sockaddr *>(Arguments[1]), Arguments[2]);
+          break;
+        }
+        case OP_LISTEN: {
+          Result = ::listen(Arguments[0], Arguments[1]);
+          break;
+        }
+        case OP_ACCEPT: {
+          Result = ::accept(Arguments[0], reinterpret_cast<struct sockaddr *>(Arguments[1]), reinterpret_cast<socklen_t*>(Arguments[2]));
+          break;
+        }
+        case OP_GETSOCKNAME: {
+          Result = ::getsockname(Arguments[0], reinterpret_cast<struct sockaddr *>(Arguments[1]), reinterpret_cast<socklen_t*>(Arguments[2]));
+          break;
+        }
+        case OP_GETPEERNAME: {
+          Result = ::getpeername(Arguments[0], reinterpret_cast<struct sockaddr *>(Arguments[1]), reinterpret_cast<socklen_t*>(Arguments[2]));
+          break;
+        }
+        case OP_SOCKETPAIR: {
+          Result = ::socketpair(Arguments[0], Arguments[1], Arguments[2], reinterpret_cast<int32_t*>(Arguments[3]));
+          break;
+        }
+        case OP_SEND: {
+          Result = ::send(Arguments[0], reinterpret_cast<const void*>(Arguments[1]), Arguments[2], Arguments[3]);
+          break;
+        }
+        case OP_RECV: {
+          Result = ::recv(Arguments[0], reinterpret_cast<void*>(Arguments[1]), Arguments[2], Arguments[3]);
+          break;
+        }
+        case OP_SENDTO: {
+          Result = ::sendto(
+            Arguments[0],
+            reinterpret_cast<const void*>(Arguments[1]),
+            Arguments[2],
+            Arguments[3],
+            reinterpret_cast<struct sockaddr *>(Arguments[4]), reinterpret_cast<socklen_t>(Arguments[5])
+            );
+          break;
+        }
+        case OP_RECVFROM: {
+          Result = ::recvfrom(
+            Arguments[0],
+            reinterpret_cast<void*>(Arguments[1]),
+            Arguments[2],
+            Arguments[3],
+            reinterpret_cast<struct sockaddr *>(Arguments[4]), reinterpret_cast<socklen_t*>(Arguments[5])
+            );
+          break;
+        }
+        case OP_SHUTDOWN: {
+          Result = ::shutdown(Arguments[0], Arguments[1]);
+          break;
+        }
+        case OP_SETSOCKOPT: {
+          Result = ::setsockopt(
+            Arguments[0],
+            Arguments[1],
+            Arguments[2],
+            reinterpret_cast<const void*>(Arguments[3]),
+            reinterpret_cast<socklen_t>(Arguments[4])
+            );
+          break;
+        }
+        case OP_GETSOCKOPT: {
+          Result = ::getsockopt(
+            Arguments[0],
+            Arguments[1],
+            Arguments[2],
+            reinterpret_cast<void*>(Arguments[3]),
+            reinterpret_cast<socklen_t*>(Arguments[4])
+            );
+          break;
+        }
+        case OP_SENDMSG: {
+          const struct msghdr32 *guest_msg = reinterpret_cast<const struct msghdr32*>(Arguments[1]);
+
+          struct msghdr HostHeader{};
+          std::vector<iovec> Host_iovec(guest_msg->msg_iovlen);
+          for (int i = 0; i < guest_msg->msg_iovlen; ++i) {
+            Host_iovec[i] = guest_msg->msg_iov[i];
+          }
+
+          HostHeader.msg_name = reinterpret_cast<void*>(guest_msg->msg_name_ptr);
+          HostHeader.msg_namelen = guest_msg->msg_namelen;
+
+          HostHeader.msg_iov = &Host_iovec.at(0);
+          HostHeader.msg_iovlen = guest_msg->msg_iovlen;
+
+          HostHeader.msg_control = reinterpret_cast<void*>(guest_msg->msg_control);
+          HostHeader.msg_controllen = guest_msg->msg_controllen;
+
+          HostHeader.msg_flags = guest_msg->msg_flags;
+
+          Result = ::sendmsg(Arguments[0], &HostHeader, Arguments[2]);
+          break;
+        }
+        case OP_RECVMSG: {
+          struct msghdr32 *guest_msg = reinterpret_cast<struct msghdr32*>(Arguments[1]);
+
+          struct msghdr HostHeader{};
+          std::vector<iovec> Host_iovec(guest_msg->msg_iovlen);
+          for (int i = 0; i < guest_msg->msg_iovlen; ++i) {
+            Host_iovec[i] = guest_msg->msg_iov[i];
+          }
+
+          HostHeader.msg_name = reinterpret_cast<void*>(guest_msg->msg_name_ptr);
+          HostHeader.msg_namelen = guest_msg->msg_namelen;
+
+          HostHeader.msg_iov = &Host_iovec.at(0);
+          HostHeader.msg_iovlen = guest_msg->msg_iovlen;
+
+          HostHeader.msg_control = alloca(guest_msg->msg_controllen);
+          HostHeader.msg_controllen = guest_msg->msg_controllen;
+
+          HostHeader.msg_flags = guest_msg->msg_flags;
+
+          Result = ::recvmsg(Arguments[0], &HostHeader, Arguments[2]);
+          if (Result != -1) {
+            for (int i = 0; i < guest_msg->msg_iovlen; ++i) {
+              guest_msg->msg_iov[i] = Host_iovec[i];
+            }
+
+            guest_msg->msg_namelen = HostHeader.msg_namelen;
+
+            guest_msg->msg_controllen = HostHeader.msg_controllen;
+
+            guest_msg->msg_flags = HostHeader.msg_flags;
+            if (HostHeader.msg_controllen) {
+              // Host and guest cmsg data structures aren't compatible.
+              // Copy them over now
+              uint32_t CurrentGuestPtr = guest_msg->msg_control;
+              for (struct cmsghdr *cmsg = CMSG_FIRSTHDR(&HostHeader);
+                  cmsg != nullptr;
+                  cmsg = CMSG_NXTHDR(&HostHeader, cmsg)) {
+                cmsghdr32 *CurrentGuest = reinterpret_cast<cmsghdr32*>(CurrentGuestPtr);
+
+                // Copy over the header first
+                CurrentGuest->cmsg_len = cmsg->cmsg_len;
+                CurrentGuest->cmsg_level = cmsg->cmsg_level;
+                CurrentGuest->cmsg_type = cmsg->cmsg_type;
+
+                CurrentGuestPtr += sizeof(cmsghdr32);
+
+                // Offset the result by the size of the structure change
+                Result -= sizeof(cmsghdr) - sizeof(cmsghdr32);
+
+                // Now copy over the data
+                if (cmsg->cmsg_len) {
+                  uint8_t *GuestData = reinterpret_cast<uint8_t*>(CurrentGuestPtr);
+                  memcpy(GuestData, CMSG_DATA(cmsg), cmsg->cmsg_len);
+                  CurrentGuestPtr += cmsg->cmsg_len;
+                }
+              }
+            }
+          }
+          break;
+        }
+        default:
+          LogMan::Msg::A("Unsupported socketcall op: %d", call);
+          break;
+      }
+      SYSCALL_ERRNO();
+    });
+  }
+}

--- a/External/FEXCore/Source/Interface/HLE/x32/Syscalls.cpp
+++ b/External/FEXCore/Source/Interface/HLE/x32/Syscalls.cpp
@@ -7,6 +7,9 @@
 
 #include <FEXCore/Utils/LogManager.h>
 
+#include <fcntl.h>
+#include <sys/stat.h>
+
 namespace FEXCore::HLE {
   void RegisterEpoll();
   void RegisterFD();
@@ -35,8 +38,11 @@ namespace FEXCore::HLE::x32 {
   void RegisterInfo();
   void RegisterMemory();
   void RegisterNotImplemented();
+  void RegisterSched();
   void RegisterSemaphore();
+  void RegisterSocket();
   void RegisterThread();
+  void RegisterTime();
 
   std::map<int, const char*> SyscallNames = {
     #include "SyscallsNames.inl"
@@ -160,8 +166,11 @@ void x32SyscallHandler::Strace(FEXCore::HLE::SyscallArguments *Args, uint64_t Re
     FEXCore::HLE::x32::RegisterInfo();
     FEXCore::HLE::x32::RegisterMemory();
     FEXCore::HLE::x32::RegisterNotImplemented();
+    FEXCore::HLE::x32::RegisterSched();
     FEXCore::HLE::x32::RegisterSemaphore();
+    FEXCore::HLE::x32::RegisterSocket();
     FEXCore::HLE::x32::RegisterThread();
+    FEXCore::HLE::x32::RegisterTime();
 
     // Set all the new definitions
     for (auto &Syscall : syscalls_x32) {

--- a/External/FEXCore/Source/Interface/HLE/x32/Syscalls.h
+++ b/External/FEXCore/Source/Interface/HLE/x32/Syscalls.h
@@ -2,6 +2,7 @@
 
 #include "Interface/HLE/FileManagement.h"
 #include <FEXCore/HLE/SyscallHandler.h>
+#include "Interface/HLE/x32/Types.h"
 
 #include <atomic>
 #include <condition_variable>

--- a/External/FEXCore/Source/Interface/HLE/x32/Thread.cpp
+++ b/External/FEXCore/Source/Interface/HLE/x32/Thread.cpp
@@ -1,14 +1,21 @@
 #include "Interface/HLE/Syscalls.h"
+#include "Interface/HLE/Syscalls/Thread.h"
 #include "Interface/HLE/x32/Syscalls.h"
 #include "Interface/HLE/x32/Thread.h"
 
 #include "Interface/Context/Context.h"
 #include "Interface/Core/InternalThreadState.h"
-#include "Interface/HLE/Syscalls.h"
+
+#include <FEXCore/Core/CodeLoader.h>
 
 #include <stdint.h>
+#include <linux/futex.h>
+#include <sys/syscall.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#include <filesystem>
+
+ARG_TO_STR(FEXCore::HLE::x32::compat_ptr<FEXCore::HLE::x32::stack_t32>, "%x")
 
 namespace FEXCore::HLE::x32 {
   uint64_t SetThreadArea(FEXCore::Core::InternalThreadState *Thread, void *tls) {
@@ -32,41 +39,255 @@ namespace FEXCore::HLE::x32 {
     Thread->rip += 2;
   }
 
+  static bool AnyFlagsSet(uint64_t Flags, uint64_t Mask) {
+    return (Flags & Mask) != 0;
+  }
+
+  static bool AllFlagsSet(uint64_t Flags, uint64_t Mask) {
+    return (Flags & Mask) == Mask;
+  }
+
   void RegisterThread() {
-    REGISTER_SYSCALL_IMPL_X32(waitpid, [](FEXCore::Core::InternalThreadState *Thread, pid_t pid, int32_t *status, int32_t options) -> uint32_t {
+    REGISTER_SYSCALL_IMPL_X32(clone, [](FEXCore::Core::InternalThreadState *Thread, uint32_t flags, void *stack, pid_t *parent_tid, void *tls, pid_t *child_tid) -> uint64_t {
+    #define FLAGPRINT(x, y) if (flags & (y)) LogMan::Msg::I("\tFlag: " #x)
+      FLAGPRINT(CSIGNAL,              0x000000FF);
+      FLAGPRINT(CLONE_VM,             0x00000100);
+      FLAGPRINT(CLONE_FS,             0x00000200);
+      FLAGPRINT(CLONE_FILES,          0x00000400);
+      FLAGPRINT(CLONE_SIGHAND,        0x00000800);
+      FLAGPRINT(CLONE_PTRACE,         0x00002000);
+      FLAGPRINT(CLONE_VFORK,          0x00004000);
+      FLAGPRINT(CLONE_PARENT,         0x00008000);
+      FLAGPRINT(CLONE_THREAD,         0x00010000);
+      FLAGPRINT(CLONE_NEWNS,          0x00020000);
+      FLAGPRINT(CLONE_SYSVSEM,        0x00040000);
+      FLAGPRINT(CLONE_SETTLS,         0x00080000);
+      FLAGPRINT(CLONE_PARENT_SETTID,  0x00100000);
+      FLAGPRINT(CLONE_CHILD_CLEARTID, 0x00200000);
+      FLAGPRINT(CLONE_DETACHED,       0x00400000);
+      FLAGPRINT(CLONE_UNTRACED,       0x00800000);
+      FLAGPRINT(CLONE_CHILD_SETTID,   0x01000000);
+      FLAGPRINT(CLONE_NEWCGROUP,      0x02000000);
+      FLAGPRINT(CLONE_NEWUTS,         0x04000000);
+      FLAGPRINT(CLONE_NEWIPC,         0x08000000);
+      FLAGPRINT(CLONE_NEWUSER,        0x10000000);
+      FLAGPRINT(CLONE_NEWPID,         0x20000000);
+      FLAGPRINT(CLONE_NEWNET,         0x40000000);
+      FLAGPRINT(CLONE_IO,             0x80000000);
+
+      if (AnyFlagsSet(flags, CLONE_UNTRACED | CLONE_PTRACE)) {
+        LogMan::Msg::D("clone: Ptrace* not supported");
+      }
+
+      if (AnyFlagsSet(flags, CLONE_NEWNS | CLONE_NEWCGROUP | CLONE_NEWUTS | CLONE_NEWIPC | CLONE_NEWUSER | CLONE_NEWPID | CLONE_NEWNET)) {
+        ERROR_AND_DIE("clone: Namespaces are not supported");
+      }
+
+      if (!(flags & CLONE_THREAD)) {
+
+        if (flags & CLONE_VFORK) {
+          flags &= ~CLONE_VFORK;
+          flags &= ~CLONE_VM;
+          LogMan::Msg::D("clone: WARNING: CLONE_VFORK w/o CLONE_THREAD");
+        }
+
+        if (AnyFlagsSet(flags, CLONE_SYSVSEM | CLONE_FS |  CLONE_FILES | CLONE_SIGHAND | CLONE_VM)) {
+          ERROR_AND_DIE("clone: Unsuported flags w/o CLONE_THREAD (Shared Resources), %X", flags);
+        }
+
+        // CLONE_PARENT is ignored (Implied by CLONE_THREAD)
+
+        if (Thread->CTX->GetThreadCount() != 1) {
+          LogMan::Msg::E("clone: Fork only supported on single threaded applications. Allowing");
+        }
+
+        return ForkGuest(Thread, flags, stack, parent_tid, child_tid, tls);
+      } else {
+
+        if (!AllFlagsSet(flags, CLONE_SYSVSEM | CLONE_FS |  CLONE_FILES | CLONE_SIGHAND)) {
+          ERROR_AND_DIE("clone: CLONE_THREAD: Unsuported flags w/ CLONE_THREAD (Shared Resources), %X", flags);
+        }
+
+        auto NewThread = CreateNewThread(Thread, flags, stack, parent_tid, child_tid, tls);
+
+        // Return the new threads TID
+        uint64_t Result = NewThread->State.ThreadManager.GetTID();
+
+        // Actually start the thread
+        Thread->CTX->RunThread(NewThread);
+
+        if (flags & CLONE_VFORK) {
+          // If VFORK is set then the calling process is suspended until the thread exits with execve or exit
+          NewThread->ExecutionThread.join();
+        }
+        SYSCALL_ERRNO();
+      }
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(waitpid, [](FEXCore::Core::InternalThreadState *Thread, pid_t pid, int32_t *status, int32_t options) -> uint64_t {
       uint64_t Result = ::waitpid(pid, status, options);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(nice, [](FEXCore::Core::InternalThreadState *Thread, int inc) -> uint32_t {
+    REGISTER_SYSCALL_IMPL_X32(nice, [](FEXCore::Core::InternalThreadState *Thread, int inc) -> uint64_t {
       uint64_t Result = ::nice(inc);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(set_thread_area, [](FEXCore::Core::InternalThreadState *Thread, struct user_desc *u_info) -> uint32_t {
-      LogMan::Msg::D("Set_thread_area");
-      LogMan::Msg::D("\tentry_number:    %d", u_info->entry_number);
-      LogMan::Msg::D("\tbase_addr:       0x%x", u_info->base_addr);
-      LogMan::Msg::D("\tlimit:           0x%x", u_info->limit);
-      LogMan::Msg::D("\tseg_32bit:       %d", u_info->seg_32bit);
-      LogMan::Msg::D("\tcontents:        %d", u_info->contents);
-      LogMan::Msg::D("\tread_exec_only:  %d", u_info->read_exec_only);
-      LogMan::Msg::D("\tlimit_in_pages:  %d", u_info->limit_in_pages);
-      LogMan::Msg::D("\tseg_not_present: %d", u_info->seg_not_present);
-      LogMan::Msg::D("\tuseable:         %d", u_info->useable);
+    REGISTER_SYSCALL_IMPL_X32(set_thread_area, [](FEXCore::Core::InternalThreadState *Thread, struct user_desc *u_info) -> uint64_t {
+      return SetThreadArea(Thread, u_info);
+    });
 
-      static bool Initialized = false;
-      if (Initialized == true) {
-        LogMan::Msg::A("Trying to load a new GDT");
-      }
-      if (u_info->entry_number == -1) {
-        u_info->entry_number = 12; // Sure?
-        Initialized = true;
-      }
-      // Now we need to update the thread's GDT to handle this change
-      auto GDT = &Thread->State.State.gdt[u_info->entry_number];
-      GDT->base = u_info->base_addr;
+    REGISTER_SYSCALL_IMPL_X32(set_robust_list, [](FEXCore::Core::InternalThreadState *Thread, struct robust_list_head *head, size_t len) -> uint64_t {
+      // Retain the robust list head but don't give it to the kernel
+      // The kernel would break if it tried parsing a 32bit robust list from a 64bit process
+      Thread->State.ThreadManager.robust_list_head = reinterpret_cast<uint64_t>(head);
       return 0;
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(get_robust_list, [](FEXCore::Core::InternalThreadState *Thread, int pid, struct robust_list_head **head, uint32_t *len_ptr) -> uint64_t {
+      // Give the robust list back to the application
+      // Steam specifically checks to make sure the robust list is set
+      *(uint32_t**)head = (uint32_t*)Thread->State.ThreadManager.robust_list_head;
+      *len_ptr = 12;
+      return 0;
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(futex, [](FEXCore::Core::InternalThreadState *Thread, int *uaddr, int futex_op, int val, const timespec32 *timeout, int *uaddr2, uint32_t val3) -> uint64_t {
+      void* timeout_ptr = (void*)timeout;
+      struct timespec tp64{};
+      int cmd = futex_op & FUTEX_CMD_MASK;
+      if (timeout &&
+          (cmd == FUTEX_WAIT ||
+           cmd == FUTEX_LOCK_PI ||
+           cmd == FUTEX_WAIT_BITSET ||
+           cmd == FUTEX_WAIT_REQUEUE_PI)) {
+        // timeout argument is only handled as timespec in these cases
+        // Otherwise just an integer
+        tp64 = *timeout;
+        timeout_ptr = &tp64;
+      }
+
+      uint64_t Result = syscall(SYS_futex,
+        uaddr,
+        futex_op,
+        val,
+        timeout_ptr,
+        uaddr2,
+        val3);
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(getuid32, [](FEXCore::Core::InternalThreadState *Thread) -> uint64_t {
+      uint64_t Result = ::getuid();
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(getgid32, [](FEXCore::Core::InternalThreadState *Thread) -> uint64_t {
+      uint64_t Result = ::getgid();
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(setuid32, [](FEXCore::Core::InternalThreadState *Thread, uid_t uid) -> uint64_t {
+      uint64_t Result = ::setuid(uid);
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(setgid32, [](FEXCore::Core::InternalThreadState *Thread, gid_t gid) -> uint64_t {
+      uint64_t Result = ::setgid(gid);
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(geteuid32, [](FEXCore::Core::InternalThreadState *Thread) -> uint64_t {
+      uint64_t Result = ::geteuid();
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(getegid32, [](FEXCore::Core::InternalThreadState *Thread) -> uint64_t {
+      uint64_t Result = ::getegid();
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(setreuid32, [](FEXCore::Core::InternalThreadState *Thread, uid_t ruid, uid_t euid) -> uint64_t {
+      uint64_t Result = ::setreuid(ruid, euid);
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(setresuid32, [](FEXCore::Core::InternalThreadState *Thread, uid_t ruid, uid_t euid, uid_t suid) -> uint64_t {
+      uint64_t Result = ::setresuid(ruid, euid, suid);
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(getresuid32, [](FEXCore::Core::InternalThreadState *Thread, uid_t *ruid, uid_t *euid, uid_t *suid) -> uint64_t {
+      uint64_t Result = ::getresuid(ruid, euid, suid);
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(setresgid32, [](FEXCore::Core::InternalThreadState *Thread, gid_t rgid, gid_t egid, gid_t sgid) -> uint64_t {
+      uint64_t Result = ::setresgid(rgid, egid, sgid);
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(getresgid32, [](FEXCore::Core::InternalThreadState *Thread, gid_t *rgid, gid_t *egid, gid_t *sgid) -> uint64_t {
+      uint64_t Result = ::getresgid(rgid, egid, sgid);
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(setregid32, [](FEXCore::Core::InternalThreadState *Thread, gid_t rgid, gid_t egid) -> uint64_t {
+      uint64_t Result = ::setregid(rgid, egid);
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(sigaltstack, [](FEXCore::Core::InternalThreadState *Thread, const compat_ptr<stack_t32> ss, compat_ptr<stack_t32> old_ss) -> uint64_t {
+      stack_t ss64 = *ss;
+      stack_t old64{};
+      stack_t *old64_ptr{};
+      if (old_ss) {
+        old64 = *old_ss;
+        old64_ptr = &old64;
+      }
+      uint64_t Result = Thread->CTX->SignalDelegation.RegisterGuestSigAltStack(&ss64, old64_ptr);
+
+      if (Result == 0 && old_ss) {
+        *old_ss = old64;
+      }
+      return Result;
+    });
+
+    // launch a new process under fex
+    // currently does not propagate argv[0] correctly
+    REGISTER_SYSCALL_IMPL_X32(execve, [](FEXCore::Core::InternalThreadState *Thread, const char *pathname, uint32_t *argv, uint32_t *envp) -> uint64_t {
+      std::vector<const char*> Args;
+      std::vector<const char*> Envp;
+
+      std::error_code ec;
+      bool exists = std::filesystem::exists(pathname, ec);
+      if (ec || !exists) {
+        return -ENOENT;
+      }
+
+      Thread->CTX->GetCodeLoader()->GetExecveArguments(&Args);
+
+      Args.push_back("--");
+
+      Args.push_back(pathname);
+
+      for (int i = 0; argv[i]; i++) {
+        if (i == 0)
+          continue;
+
+        Args.push_back(reinterpret_cast<const char*>(static_cast<uintptr_t>(argv[i])));
+      }
+
+      Args.push_back(nullptr);
+
+      for (int i = 0; envp[i]; i++) {
+        Envp.push_back(reinterpret_cast<const char*>(static_cast<uintptr_t>(envp[i])));
+      }
+
+      uint64_t Result = execve("/proc/self/exe", const_cast<char *const *>(&Args[0]), const_cast<char *const *>(&Envp[0]));
+
+      SYSCALL_ERRNO();
     });
   }
 }

--- a/External/FEXCore/Source/Interface/HLE/x32/Time.cpp
+++ b/External/FEXCore/Source/Interface/HLE/x32/Time.cpp
@@ -1,0 +1,94 @@
+#include "Interface/HLE/Syscalls.h"
+#include "Interface/HLE/x64/Syscalls.h"
+#include "Interface/HLE/x32/Syscalls.h"
+
+#include <stddef.h>
+#include <stdint.h>
+#include <time.h>
+#include <sys/time.h>
+#include <sys/times.h>
+#include <sys/timex.h>
+#include <unistd.h>
+#include <utime.h>
+
+namespace FEXCore::HLE::x32 {
+  void RegisterTime() {
+    REGISTER_SYSCALL_IMPL_X32(gettimeofday, [](FEXCore::Core::InternalThreadState *Thread, timeval32 *tv, struct timezone *tz) -> uint64_t {
+      struct timeval tv64{};
+      struct timeval *tv_ptr{};
+      if (tv) {
+        tv_ptr = &tv64;
+      }
+
+      uint64_t Result = ::gettimeofday(tv_ptr, tz);
+
+      if (tv) {
+        *tv = tv64;
+      }
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(nanosleep, [](FEXCore::Core::InternalThreadState *Thread, const timespec32 *req, timespec32 *rem) -> uint64_t {
+      struct timespec req64{};
+      struct timespec rem64{};
+      req64 = *req;
+      rem64 = *rem;
+      uint64_t Result = ::nanosleep(&req64, &rem64);
+      *rem = rem64;
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(clock_gettime, [](FEXCore::Core::InternalThreadState *Thread, clockid_t clk_id, timespec32 *tp) -> uint64_t {
+      struct timespec tp64{};
+      tp64 = *tp;
+      uint64_t Result = ::clock_gettime(clk_id, &tp64);
+      *tp = tp64;
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(clock_getres, [](FEXCore::Core::InternalThreadState *Thread, clockid_t clk_id, timespec32 *tp) -> uint64_t {
+      struct timespec tp64{};
+      tp64 = *tp;
+      uint64_t Result = ::clock_getres(clk_id, &tp64);
+      *tp = tp64;
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(clock_nanosleep, [](FEXCore::Core::InternalThreadState *Thread, clockid_t clockid, int flags, const timespec32 *request, timespec32 *remain) -> uint64_t {
+      struct timespec req64{};
+      struct timespec rem64{};
+      req64 = *request;
+      rem64 = *remain;
+      uint64_t Result = ::clock_nanosleep(clockid, flags, &req64, &rem64);
+      *remain = rem64;
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(clock_settime, [](FEXCore::Core::InternalThreadState *Thread, clockid_t clockid, const timespec32 *tp) -> uint64_t {
+      struct timespec tp64{};
+      tp64 = *tp;
+      uint64_t Result = ::clock_settime(clockid, &tp64);
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(clock_gettime64, [](FEXCore::Core::InternalThreadState *Thread, clockid_t clk_id, timespec *tp) -> uint64_t {
+      uint64_t Result = ::clock_gettime(clk_id, tp);
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(clock_settime64, [](FEXCore::Core::InternalThreadState *Thread, clockid_t clockid, const struct timespec *tp) -> uint64_t {
+      uint64_t Result = ::clock_settime(clockid, tp);
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(clock_getres_time64, [](FEXCore::Core::InternalThreadState *Thread, clockid_t clk_id, timespec *tp) -> uint64_t {
+      uint64_t Result = ::clock_getres(clk_id, tp);
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(clock_nanosleep_time64, [](FEXCore::Core::InternalThreadState *Thread, clockid_t clockid, int flags, const struct timespec *request, struct timespec *remain) -> uint64_t {
+      uint64_t Result = ::clock_nanosleep(clockid, flags, request, remain);
+      SYSCALL_ERRNO();
+    });
+  }
+}

--- a/External/FEXCore/Source/Interface/HLE/x32/Types.h
+++ b/External/FEXCore/Source/Interface/HLE/x32/Types.h
@@ -1,0 +1,482 @@
+#pragma once
+
+#include <bits/types/stack_t.h>
+#include <cstdint>
+#include <cstring>
+#include <fcntl.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/statfs.h>
+#include <sys/uio.h>
+#include <time.h>
+#include <type_traits>
+
+namespace FEXCore::HLE::x32 {
+
+// Basic types to make tracking easier
+using compat_ulong_t = uint32_t;
+using compat_uptr_t = uint32_t;
+using compat_size_t = uint32_t;
+
+template<typename T>
+class compat_ptr {
+public:
+  compat_ptr() = delete;
+  compat_ptr(uint32_t In) : Ptr {In} {}
+  compat_ptr(T *In) : Ptr {static_cast<uint32_t>(reinterpret_cast<uintptr_t>(In))} {}
+
+  T operator*() {
+    return *Interpret();
+  }
+
+  T *operator->() {
+    return Interpret();
+  }
+
+  operator T*() const {
+    return Interpret();
+  }
+
+  explicit operator bool() const noexcept {
+    return !!Ptr;
+  }
+
+  explicit operator uintptr_t() const {
+    return Ptr;
+  }
+
+  uint32_t Ptr;
+private:
+  T* Interpret() const {
+    return reinterpret_cast<T*>(Ptr);
+  }
+};
+
+static_assert(std::is_trivial<compat_ptr<void>>::value, "Needs to be trivial");
+static_assert(sizeof(compat_ptr<void>) == 4, "Incorrect size");
+
+/**
+ * @name timespec32
+ *
+ * This is a timespec implementation that matches 32bit linux implementation
+ * Provides conversation operators for the host version
+ * @{ */
+
+struct timespec32 {
+  int32_t tv_sec;
+  int32_t tv_nsec;
+
+  timespec32() = delete;
+
+  operator timespec() const {
+    timespec spec{};
+    spec.tv_sec = tv_sec;
+    spec.tv_nsec = tv_nsec;
+    return spec;
+  }
+
+  timespec32(struct timespec spec) {
+    tv_sec = spec.tv_sec;
+    tv_nsec = spec.tv_nsec;
+  }
+};
+
+static_assert(std::is_trivial<timespec32>::value, "Needs to be trivial");
+static_assert(sizeof(timespec32) == 8, "Incorrect size");
+/**  @} */
+
+/**
+ * @name timeval32
+ *
+ * This is a timeval implementation that matches 32bit linux implementation
+ * Provides conversation operators for the host version
+ * @{ */
+
+struct timeval32 {
+  int32_t tv_sec;
+  int32_t tv_usec;
+
+  timeval32() = delete;
+
+  operator timeval() const {
+    timeval spec{};
+    spec.tv_sec = tv_sec;
+    spec.tv_usec = tv_usec;
+    return spec;
+  }
+
+  timeval32(struct timeval spec) {
+    tv_sec = spec.tv_sec;
+    tv_usec = spec.tv_usec;
+  }
+};
+/**  @} */
+
+static_assert(std::is_trivial<timeval32>::value, "Needs to be trivial");
+static_assert(sizeof(timeval32) == 8, "Incorrect size");
+
+/**
+ * @name iovec32
+ *
+ * This is a iovec implementation that matches 32bit linux implementation
+ * Provides conversation operators for the host version
+ * @{ */
+
+struct iovec32 {
+  uint32_t iov_base;
+  uint32_t iov_len;
+
+  iovec32() = delete;
+
+  operator iovec() const {
+    iovec vec{};
+    vec.iov_base = reinterpret_cast<void*>(iov_base);
+    vec.iov_len = iov_len;
+    return vec;
+  }
+
+  iovec32(struct iovec vec) {
+    iov_base = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(vec.iov_base));
+    iov_len = vec.iov_len;
+  }
+};
+
+static_assert(std::is_trivial<iovec32>::value, "Needs to be trivial");
+static_assert(sizeof(iovec32) == 8, "Incorrect size");
+/**  @} */
+
+struct cmsghdr32 {
+  uint32_t cmsg_len;
+  int32_t cmsg_level;
+  int32_t cmsg_type;
+};
+
+static_assert(std::is_trivial<cmsghdr32>::value, "Needs to be trivial");
+static_assert(sizeof(cmsghdr32) == 12, "Incorrect size");
+
+struct msghdr32 {
+  uint32_t msg_name_ptr;
+  socklen_t msg_namelen;
+
+  compat_ptr<iovec32> msg_iov;
+  uint32_t msg_iovlen;
+
+  uint32_t msg_control;
+  uint32_t msg_controllen;
+  int32_t msg_flags;
+};
+
+static_assert(std::is_trivial<msghdr32>::value, "Needs to be trivial");
+static_assert(sizeof(msghdr32) == 28, "Incorrect size");
+
+struct stack_t32 {
+  compat_ptr<void> ss_sp;
+  compat_size_t ss_size;
+  int32_t ss_flags;
+
+  stack_t32() = delete;
+
+  operator stack_t() const {
+    stack_t ss{};
+    ss.ss_sp    = ss_sp;
+    ss.ss_size  = ss_size;
+    ss.ss_flags = ss_flags;
+    return ss;
+  }
+
+  stack_t32(stack_t ss)
+    : ss_sp {ss.ss_sp} {
+    ss_size  = ss.ss_size;
+    ss_flags = ss.ss_flags;
+  }
+};
+
+static_assert(std::is_trivial<stack_t32>::value, "Needs to be trivial");
+static_assert(sizeof(stack_t32) == 12, "Incorrect size");
+
+struct stat32 {
+  uint32_t st_dev;
+  uint32_t st_ino;
+  uint32_t st_nlink;
+
+  uint16_t st_mode;
+  uint16_t st_uid;
+  uint16_t st_gid;
+  uint16_t __pad0;
+
+  uint32_t st_rdev;
+  uint32_t st_size;
+  uint32_t st_blksize;
+  uint32_t st_blocks;  /* Number 512-byte blocks allocated. */
+  uint32_t st_atime_;
+  uint32_t st_atime_nsec;
+  uint32_t st_mtime_;
+  uint32_t st_mtime_nsec;
+  uint32_t st_ctime_;
+  uint32_t st_ctime_nsec;
+  uint32_t __unused[3];
+
+  stat32() = delete;
+
+  stat32(struct stat host) {
+    #define COPY(x) x = host.x
+    COPY(st_dev);
+    COPY(st_ino);
+    COPY(st_nlink);
+
+    COPY(st_mode);
+    COPY(st_uid);
+    COPY(st_gid);
+
+    COPY(st_rdev);
+    COPY(st_size);
+    COPY(st_blksize);
+    COPY(st_blocks);
+
+    st_atime_ = host.st_atim.tv_sec;
+    st_atime_nsec = host.st_atim.tv_nsec;
+
+    st_mtime_ = host.st_mtime;
+    st_mtime_nsec = host.st_mtim.tv_nsec;
+
+    st_ctime_ = host.st_ctime;
+    st_ctime_nsec = host.st_ctim.tv_nsec;
+    #undef COPY
+  }
+};
+static_assert(std::is_trivial<stat32>::value, "Needs to be trivial");
+static_assert(sizeof(stat32) == 72, "Incorrect size");
+
+struct __attribute__((packed)) stat64_32 {
+  uint64_t st_dev;
+  uint32_t pad0;
+  uint32_t __st_ino;
+
+  uint32_t st_mode;
+  uint32_t st_nlink;
+
+  uint32_t st_uid;
+  uint32_t st_gid;
+
+  uint64_t st_rdev;
+  uint32_t pad3;
+  int64_t st_size;
+  uint32_t st_blksize;
+  uint64_t st_blocks;  /* Number 512-byte blocks allocated. */
+  uint32_t st_atime_;
+  uint32_t st_atime_nsec;
+  uint32_t st_mtime_;
+  uint32_t st_mtime_nsec;
+  uint32_t st_ctime_;
+  uint32_t st_ctime_nsec;
+  uint64_t st_ino;
+
+  stat64_32() = delete;
+
+  stat64_32(struct stat host) {
+    #define COPY(x) x = host.x
+    COPY(st_dev);
+    COPY(st_ino);
+    COPY(st_nlink);
+
+    COPY(st_mode);
+    COPY(st_uid);
+    COPY(st_gid);
+
+    COPY(st_rdev);
+    COPY(st_size);
+    COPY(st_blksize);
+    COPY(st_blocks);
+
+    __st_ino = host.st_ino;
+
+    st_atime_ = host.st_atim.tv_sec;
+    st_atime_nsec = host.st_atim.tv_nsec;
+
+    st_mtime_ = host.st_mtime;
+    st_mtime_nsec = host.st_mtim.tv_nsec;
+
+    st_ctime_ = host.st_ctime;
+    st_ctime_nsec = host.st_ctim.tv_nsec;
+    #undef COPY
+  }
+
+  stat64_32(struct stat64 host) {
+    #define COPY(x) x = host.x
+    COPY(st_dev);
+    COPY(st_ino);
+    COPY(st_nlink);
+
+    COPY(st_mode);
+    COPY(st_uid);
+    COPY(st_gid);
+
+    COPY(st_rdev);
+    COPY(st_size);
+    COPY(st_blksize);
+    COPY(st_blocks);
+
+    __st_ino = host.st_ino;
+
+    st_atime_ = host.st_atim.tv_sec;
+    st_atime_nsec = host.st_atim.tv_nsec;
+
+    st_mtime_ = host.st_mtime;
+    st_mtime_nsec = host.st_mtim.tv_nsec;
+
+    st_ctime_ = host.st_ctime;
+    st_ctime_nsec = host.st_ctim.tv_nsec;
+    #undef COPY
+  }
+};
+static_assert(std::is_trivial<stat64_32>::value, "Needs to be trivial");
+static_assert(sizeof(stat64_32) == 96, "Incorrect size");
+
+struct __attribute__((packed,aligned(4))) statfs64_32 {
+  uint32_t f_type;
+  uint32_t f_bsize;
+  uint64_t f_blocks;
+  uint64_t f_bfree;
+  uint64_t f_bavail;
+  uint64_t f_files;
+  uint64_t f_ffree;
+  __kernel_fsid_t f_fsid;
+  uint32_t f_namelen;
+  uint32_t f_frsize;
+  uint32_t f_flags;
+  uint32_t pad[4];
+
+  statfs64_32() = delete;
+
+  statfs64_32(struct statfs host) {
+    #define COPY(x) x = host.x
+    COPY(f_type);
+    COPY(f_bsize);
+    COPY(f_blocks);
+    COPY(f_bfree);
+    COPY(f_bavail);
+    COPY(f_files);
+    COPY(f_ffree);
+    COPY(f_namelen);
+    COPY(f_frsize);
+    COPY(f_flags);
+
+    memcpy(&f_fsid, &host.f_fsid, sizeof(f_fsid));
+    #undef COPY
+  }
+
+  statfs64_32(struct statfs64 host) {
+    #define COPY(x) x = host.x
+    COPY(f_type);
+    COPY(f_bsize);
+    COPY(f_blocks);
+    COPY(f_bfree);
+    COPY(f_bavail);
+    COPY(f_files);
+    COPY(f_ffree);
+    COPY(f_namelen);
+    COPY(f_frsize);
+    COPY(f_flags);
+
+    memcpy(&f_fsid, &host.f_fsid, sizeof(f_fsid));
+    #undef COPY
+  }
+};
+static_assert(std::is_trivial<statfs64_32>::value, "Needs to be trivial");
+static_assert(sizeof(statfs64_32) == 84, "Incorrect size");
+
+struct flock_32 {
+  int16_t l_type;
+  int16_t l_whence;
+  int32_t l_start;
+  int32_t l_len;
+  int32_t l_pid;
+
+  flock_32() = delete;
+
+  flock_32(struct flock host) {
+    l_type   = host.l_type;
+    l_whence = host.l_whence;
+    l_start  = host.l_start;
+    l_len    = host.l_len;
+    l_pid    = host.l_pid;
+  }
+
+  operator struct flock() const {
+    struct flock res{};
+    res.l_type   = l_type;
+    res.l_whence = l_whence;
+    res.l_start  = l_start;
+    res.l_len    = l_len;
+    res.l_pid    = l_pid;
+    return res;
+  }
+};
+
+static_assert(std::is_trivial<flock_32>::value, "Needs to be trivial");
+static_assert(sizeof(flock_32) == 16, "Incorrect size");
+
+// glibc doesn't pack flock64 while the kernel does
+struct flock64_32 {
+  int16_t l_type;
+  int16_t l_whence;
+  int32_t l_start;
+  int32_t l_len;
+  int32_t l_pid;
+
+  flock64_32() = delete;
+
+  flock64_32(struct flock host) {
+    l_type   = host.l_type;
+    l_whence = host.l_whence;
+    l_start  = host.l_start;
+    l_len    = host.l_len;
+    l_pid    = host.l_pid;
+  }
+
+  operator struct flock() const {
+    struct flock res{};
+    res.l_type   = l_type;
+    res.l_whence = l_whence;
+    res.l_start  = l_start;
+    res.l_len    = l_len;
+    res.l_pid    = l_pid;
+    return res;
+  }
+};
+static_assert(std::is_trivial<flock64_32>::value, "Needs to be trivial");
+static_assert(sizeof(flock64_32) == 16, "Incorrect size");
+
+struct linux_dirent {
+  uint64_t d_ino;
+  int64_t  d_off;
+  uint16_t d_reclen;
+  uint8_t _pad[6];
+  char d_name[];
+};
+static_assert(std::is_trivial<linux_dirent>::value, "Needs to be trivial");
+static_assert(sizeof(linux_dirent) == 24, "Incorrect size");
+
+struct linux_dirent_32 {
+  uint32_t d_ino;
+  int32_t d_off;
+  uint16_t d_reclen;
+  uint8_t _pad[2];
+  char d_name[];
+  /* Has hidden null character and d_type */
+};
+static_assert(std::is_trivial<linux_dirent_32>::value, "Needs to be trivial");
+static_assert(sizeof(linux_dirent_32) == 12, "Incorrect size");
+
+struct linux_dirent_64 {
+  uint64_t d_ino;
+  uint64_t d_off;
+  uint16_t d_reclen;
+  uint8_t  d_type;
+  uint8_t _pad[5];
+  char d_name[];
+};
+static_assert(std::is_trivial<linux_dirent_64>::value, "Needs to be trivial");
+static_assert(sizeof(linux_dirent_64) == 24, "Incorrect size");
+
+}


### PR DESCRIPTION
This implements a bunch of new 32bit syscalls which almost gets FEX to
be able to run Steam.

The main missing syscalls are mremap, shmat, and ioctl for supporting
Steam execution.