### PR TITLE
OpDisp: Read DF outside REP loops as it won't change

### DIFF
--- a/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -163,6 +163,7 @@ namespace {
         Graph->Nodes[i].Head = DefaultNodeHeader;
       }
     }
+    Graph->VisitedNodePredecessors.clear();
   }
 
   void SetNodeClass(RegisterGraph *Graph, uint32_t Node, FEXCore::IR::RegisterClassType Class) {


### PR DESCRIPTION
This ~ doubles the perf on REP prefixed opcodes

Depends on #558