### PR TITLE
frontend: Improve IR for some *SS/*SD opcodes

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -3882,8 +3882,12 @@ void OpDispatchBuilder::VectorScalarALUOp(OpcodeArgs) {
   // Overwrite our IR's op type
   ALUOp.first->Header.Op = IROp;
 
-  // Insert the lower bits
-  auto Result = _VInsScalarElement(Size, ElementSize, 0, Dest, ALUOp);
+  OrderedNode* Result = ALUOp;
+
+  if (Size != ElementSize) {
+    // Insert the lower bits
+    Result = _VInsScalarElement(Size, ElementSize, 0, Dest, Result);
+  }
 
   StoreResult(FPRClass, Op, Result, -1);
 }

--- a/External/FEXCore/Source/Interface/Core/X86Tables/SecondaryTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/SecondaryTables.cpp
@@ -372,16 +372,16 @@ void InitializeSecondaryTables(Context::OperatingMode Mode) {
     {0x40, 16, X86InstInfo{"",         TYPE_COPY_OTHER, FLAGS_NONE,                                                      0, nullptr}},
 
     {0x50, 1, X86InstInfo{"",          TYPE_INVALID, FLAGS_NONE,                                                         0, nullptr}},
-    {0x51, 1, X86InstInfo{"SQRTSD",    TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS,                    0, nullptr}},
+    {0x51, 1, X86InstInfo{"SQRTSD",    TYPE_INST, GenFlagsSameSize(SIZE_64BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS,                    0, nullptr}},
     {0x52, 6, X86InstInfo{"",          TYPE_INVALID, FLAGS_NONE,                                                         0, nullptr}},
-    {0x58, 1, X86InstInfo{"ADDSD",     TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS,                    0, nullptr}},
-    {0x59, 1, X86InstInfo{"MULSD",     TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS,                    0, nullptr}},
+    {0x58, 1, X86InstInfo{"ADDSD",     TYPE_INST, GenFlagsSameSize(SIZE_64BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS,                    0, nullptr}},
+    {0x59, 1, X86InstInfo{"MULSD",     TYPE_INST, GenFlagsSameSize(SIZE_64BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS,                    0, nullptr}},
     {0x5A, 1, X86InstInfo{"CVTSD2SS",  TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS,                    0, nullptr}},
     {0x5B, 1, X86InstInfo{"",          TYPE_INVALID, FLAGS_NONE,                                                         0, nullptr}},
-    {0x5C, 1, X86InstInfo{"SUBSD",     TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS,                    0, nullptr}},
-    {0x5D, 1, X86InstInfo{"MINSD",     TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS,                    0, nullptr}},
-    {0x5E, 1, X86InstInfo{"DIVSD",     TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS,                    0, nullptr}},
-    {0x5F, 1, X86InstInfo{"MAXSD",     TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS,                    0, nullptr}},
+    {0x5C, 1, X86InstInfo{"SUBSD",     TYPE_INST, GenFlagsSameSize(SIZE_64BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS,                    0, nullptr}},
+    {0x5D, 1, X86InstInfo{"MINSD",     TYPE_INST, GenFlagsSameSize(SIZE_64BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS,                    0, nullptr}},
+    {0x5E, 1, X86InstInfo{"DIVSD",     TYPE_INST, GenFlagsSameSize(SIZE_64BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS,                    0, nullptr}},
+    {0x5F, 1, X86InstInfo{"MAXSD",     TYPE_INST, GenFlagsSameSize(SIZE_64BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS,                    0, nullptr}},
 
     {0x60, 16, X86InstInfo{"",         TYPE_INVALID, FLAGS_NONE,                                                         0, nullptr}},
 


### PR DESCRIPTION
- Removes needless VINSERTs
- Updates x86 tables to use 64 bit width for *SD ops