### PR TITLE
IR: Move BFEs to SetFlag, remove from OP_STOREFLAG

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -889,7 +889,7 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
           }
           case IR::OP_STOREFLAG: {
             auto Op = IROp->C<IR::IROp_StoreFlag>();
-            uint8_t Arg = *GetSrc<uint8_t*>(SSAData, Op->Header.Args[0]) & 1;
+            uint8_t Arg = *GetSrc<uint8_t*>(SSAData, Op->Header.Args[0]);
 
             uintptr_t ContextPtr = reinterpret_cast<uintptr_t>(&Thread->State.State);
             ContextPtr += offsetof(FEXCore::Core::CPUState, flags[0]);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -392,13 +392,11 @@ DEF_OP(LoadFlag) {
   auto Op = IROp->C<IR::IROp_LoadFlag>();
   auto Dst = GetReg<RA_64>(Node);
   ldrb(Dst, MemOperand(STATE, offsetof(FEXCore::Core::CPUState, flags[0]) + Op->Flag));
-  and_(Dst, Dst, 1);
 }
 
 DEF_OP(StoreFlag) {
   auto Op = IROp->C<IR::IROp_StoreFlag>();
-  and_(TMP1, GetReg<RA_64>(Op->Header.Args[0].ID()), 1);
-  strb(TMP1, MemOperand(STATE, offsetof(FEXCore::Core::CPUState, flags[0]) + Op->Flag));
+  strb(GetReg<RA_64>(Op->Header.Args[0].ID()), MemOperand(STATE, offsetof(FEXCore::Core::CPUState, flags[0]) + Op->Flag));
 }
 
 MemOperand JITCore::GenerateMemOperand(uint8_t AccessSize, aarch64::Register Base, IR::OrderedNodeWrapper Offset, IR::MemOffsetType OffsetType, uint8_t OffsetScale) {

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/MemoryOps.cpp
@@ -446,14 +446,12 @@ DEF_OP(LoadFlag) {
 
   auto Dst = GetDst<RA_64>(Node);
   movzx(Dst, byte [STATE + (offsetof(FEXCore::Core::CPUState, flags[0]) + Op->Flag)]);
-  and(Dst, 1);
 }
 
 DEF_OP(StoreFlag) {
   auto Op = IROp->C<IR::IROp_StoreFlag>();
 
   mov (rax, GetSrc<RA_64>(Op->Header.Args[0].ID()));
-  and(rax, 1);
   mov(byte [STATE + (offsetof(FEXCore::Core::CPUState, flags[0]) + Op->Flag)], al);
 }
 

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -4771,16 +4771,17 @@ void OpDispatchBuilder::ResetWorkingList() {
 template<unsigned BitOffset>
 void OpDispatchBuilder::SetRFLAG(OrderedNode *Value) {
   flagsOp = FLAGS_OP_NONE;
-  _StoreFlag(Value, BitOffset);
+  _StoreFlag(_Bfe(1, 0, Value), BitOffset);
 }
 void OpDispatchBuilder::SetRFLAG(OrderedNode *Value, unsigned BitOffset) {
   flagsOp = FLAGS_OP_NONE;
-  _StoreFlag(Value, BitOffset);
+  _StoreFlag(_Bfe(1, 0, Value), BitOffset);
 }
 
 OrderedNode *OpDispatchBuilder::GetRFLAG(unsigned BitOffset) {
   return _LoadFlag(BitOffset);
 }
+
 constexpr std::array<uint32_t, 17> FlagOffsets = {
   FEXCore::X86State::RFLAG_CF_LOC,
   FEXCore::X86State::RFLAG_PF_LOC,

--- a/External/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
@@ -547,8 +547,7 @@ bool RCLSE::RedundantStoreLoadElimination(FEXCore::IR::IREmitter *IREmit) {
         if (LastAccess == ACCESS_WRITE) { // 1 byte so always a full write
           // If the last store matches this load value then we can replace the loaded value with the previous valid one
           IREmit->SetWriteCursor(CodeNode);
-          auto Res = IREmit->_Bfe(1, 0, LastNode);
-          IREmit->ReplaceAllUsesWith(CodeNode, Res);
+          IREmit->ReplaceAllUsesWith(CodeNode, LastNode);
           RecordAccess(Info, FEXCore::IR::GPRClass, offsetof(FEXCore::Core::CPUState, flags[0]) + Op->Flag, 1, ACCESS_READ, LastNode);
           Changed = true;
         }


### PR DESCRIPTION
- Removes masking from reads, as writes always mask. Interpreter already worked like this.
- Moves masking to IR ops

Follow up:
- Optimize frontend codegen to not need as much masking (Use BFEs instead of shifts)