### PR TITLE
IR: Change FCMP to return x86-style flags

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -4254,18 +4254,19 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
             if (Op->ElementSize == 4) {
               float Src1 = *GetSrc<float*>(SSAData, Op->Header.Args[0]);
               float Src2 = *GetSrc<float*>(SSAData, Op->Header.Args[1]);
+              bool Unordered = std::isnan(Src1) || std::isnan(Src2);
               if (Op->Flags & (1 << FCMP_FLAG_LT)) {
-                if (Src1 < Src2) {
+                if (Unordered || (Src1 < Src2)) {
                   ResultFlags |= (1 << FCMP_FLAG_LT);
                 }
               }
               if (Op->Flags & (1 << FCMP_FLAG_UNORDERED)) {
-                if (std::isnan(Src1) || std::isnan(Src2)) {
+                if (Unordered) {
                   ResultFlags |= (1 << FCMP_FLAG_UNORDERED);
                 }
               }
               if (Op->Flags & (1 << FCMP_FLAG_EQ)) {
-                if (Src1 == Src2) {
+                if (Unordered || (Src1 == Src2)) {
                   ResultFlags |= (1 << FCMP_FLAG_EQ);
                 }
               }
@@ -4273,18 +4274,19 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
             else {
               double Src1 = *GetSrc<double*>(SSAData, Op->Header.Args[0]);
               double Src2 = *GetSrc<double*>(SSAData, Op->Header.Args[1]);
+              bool Unordered = std::isnan(Src1) || std::isnan(Src2);
               if (Op->Flags & (1 << FCMP_FLAG_LT)) {
-                if (Src1 < Src2) {
+                if (Unordered || (Src1 < Src2)) {
                   ResultFlags |= (1 << FCMP_FLAG_LT);
                 }
               }
               if (Op->Flags & (1 << FCMP_FLAG_UNORDERED)) {
-                if (std::isnan(Src1) || std::isnan(Src2)) {
+                if (Unordered) {
                   ResultFlags |= (1 << FCMP_FLAG_UNORDERED);
                 }
               }
               if (Op->Flags & (1 << FCMP_FLAG_EQ)) {
-                if (Src1 == Src2) {
+                if (Unordered || (Src1 == Src2)) {
                   ResultFlags |= (1 << FCMP_FLAG_EQ);
                 }
               }

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -1074,22 +1074,36 @@ DEF_OP(FCmp) {
     fcmp(GetSrc(Op->Header.Args[0].ID()).D(), GetSrc(Op->Header.Args[1].ID()).D());
   }
   auto Dst = GetReg<RA_64>(Node);
-  eor(Dst, Dst, Dst);
+  
+  bool set = false;
+
+  if (Op->Flags & (1 << IR::FCMP_FLAG_EQ)) {
+    assert(IR::FCMP_FLAG_EQ == 0);
+    // EQ or unordered
+    cset(Dst, Condition::eq); // Z = 1
+    csinc(Dst, Dst, xzr, Condition::vc); // IF !V ? Z : 1
+    set = true;
+  }
 
   if (Op->Flags & (1 << IR::FCMP_FLAG_LT)) {
-    cset(TMP2, Condition::mi);
-    lsl(TMP2, TMP2, IR::FCMP_FLAG_LT);
-    orr(Dst, Dst, TMP2);
+    // LT or unordered
+    cset(TMP2, Condition::lt);
+    if (!set) {
+      lsl(Dst, TMP2, IR::FCMP_FLAG_LT);
+      set = true;
+    } else {
+      bfi(Dst, TMP2, IR::FCMP_FLAG_LT, 1);
+    }
   }
-  if (Op->Flags & (1 << IR::FCMP_FLAG_EQ)) {
-    cset(TMP2, Condition::eq);
-    lsl(TMP2, TMP2, IR::FCMP_FLAG_EQ);
-    orr(Dst, Dst, TMP2);
-  }
+
   if (Op->Flags & (1 << IR::FCMP_FLAG_UNORDERED)) {
     cset(TMP2, Condition::vs);
-    lsl(TMP2, TMP2, IR::FCMP_FLAG_UNORDERED);
-    orr(Dst, Dst, TMP2);
+    if (!set) {
+      lsl(Dst, TMP2, IR::FCMP_FLAG_UNORDERED);
+      set = true;
+    } else {
+      bfi(Dst, TMP2, IR::FCMP_FLAG_UNORDERED, 1);
+    }
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/ALUOps.cpp
@@ -805,6 +805,7 @@ DEF_OP(LURem) {
   }
 }
 
+
 DEF_OP(Not) {
   auto Op = IROp->C<IR::IROp_Not>();
   auto Dst = GetDst<RA_64>(Node);

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -7529,8 +7529,6 @@ void OpDispatchBuilder::UCOMISxOp(OpcodeArgs) {
   OrderedNode *HostFlag_CF = _GetHostFlag(Res, FCMP_FLAG_LT);
   OrderedNode *HostFlag_ZF = _GetHostFlag(Res, FCMP_FLAG_EQ);
   OrderedNode *HostFlag_Unordered  = _GetHostFlag(Res, FCMP_FLAG_UNORDERED);
-  HostFlag_CF = _Or(HostFlag_CF, HostFlag_Unordered);
-  HostFlag_ZF = _Or(HostFlag_ZF, HostFlag_Unordered);
 
   SetRFLAG<FEXCore::X86State::RFLAG_CF_LOC>(HostFlag_CF);
   SetRFLAG<FEXCore::X86State::RFLAG_ZF_LOC>(HostFlag_ZF);


### PR DESCRIPTION
This means that NANs set all flags (like x86 does), instead of setting only the unordered one. Simplifies the rest of the logic.

Also optimized the aarch64 a bit