### PR TITLE
FCMP: Add frontend bypass, backend float support in OP_CONDJUMP & OP_SELECT

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -353,7 +353,7 @@ InterpreterCore::InterpreterCore(FEXCore::Context::Context *ctx, FEXCore::Core::
   }
 }
 
-template<typename unsigned_type, typename signed_type>
+template<typename unsigned_type, typename signed_type, typename float_type>
 bool IsConditionTrue(uint8_t Cond, uint64_t Src1, uint64_t Src2) {
   bool CompResult = false;
   switch (Cond) {
@@ -386,6 +386,25 @@ bool IsConditionTrue(uint8_t Cond, uint64_t Src1, uint64_t Src2) {
       break;
     case FEXCore::IR::COND_ULE:
       CompResult = static_cast<unsigned_type>(Src1) <= static_cast<unsigned_type>(Src2);
+      break;
+    
+    case FEXCore::IR::COND_FLU:
+      CompResult = reinterpret_cast<float_type&>(Src1) < reinterpret_cast<float_type&>(Src2) || (std::isnan(reinterpret_cast<float_type&>(Src1)) || std::isnan(reinterpret_cast<float_type&>(Src2)));
+      break;
+    case FEXCore::IR::COND_FGE:
+      CompResult = reinterpret_cast<float_type&>(Src1) >= reinterpret_cast<float_type&>(Src2) && !(std::isnan(reinterpret_cast<float_type&>(Src1)) || std::isnan(reinterpret_cast<float_type&>(Src2)));
+      break;
+    case FEXCore::IR::COND_FLEU:
+      CompResult = reinterpret_cast<float_type&>(Src1) <= reinterpret_cast<float_type&>(Src2) || (std::isnan(reinterpret_cast<float_type&>(Src1)) || std::isnan(reinterpret_cast<float_type&>(Src2)));
+      break;
+    case FEXCore::IR::COND_FGT:
+      CompResult = reinterpret_cast<float_type&>(Src1) > reinterpret_cast<float_type&>(Src2) && !(std::isnan(reinterpret_cast<float_type&>(Src1)) || std::isnan(reinterpret_cast<float_type&>(Src2)));
+      break;
+    case FEXCore::IR::COND_FU:
+      CompResult = (std::isnan(reinterpret_cast<float_type&>(Src1)) || std::isnan(reinterpret_cast<float_type&>(Src2)));
+      break;
+    case FEXCore::IR::COND_FNU:
+      CompResult = !(std::isnan(reinterpret_cast<float_type&>(Src1)) || std::isnan(reinterpret_cast<float_type&>(Src2)));
       break;
     case FEXCore::IR::COND_MI:
     case FEXCore::IR::COND_PL:
@@ -519,9 +538,9 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
             uint64_t Src2 = *GetSrc<uint64_t*>(SSAData, Op->Cmp2);
 
             if (Op->CompareSize == 4)
-              CompResult = IsConditionTrue<uint32_t, int32_t>(Op->Cond.Val, Src1, Src2);
+              CompResult = IsConditionTrue<uint32_t, int32_t, float>(Op->Cond.Val, Src1, Src2);
             else
-              CompResult = IsConditionTrue<uint64_t, int64_t>(Op->Cond.Val, Src1, Src2);
+              CompResult = IsConditionTrue<uint64_t, int64_t, double>(Op->Cond.Val, Src1, Src2);
 
             if (CompResult) {
               BlockIterator = NodeIterator(ListBegin, DataBegin, Op->TrueBlock);
@@ -1605,9 +1624,9 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
             bool CompResult;
 
             if (Op->CompareSize == 4)
-              CompResult = IsConditionTrue<uint32_t, int32_t>(Op->Cond.Val, Src1, Src2);
+              CompResult = IsConditionTrue<uint32_t, int32_t, float>(Op->Cond.Val, Src1, Src2);
             else
-              CompResult = IsConditionTrue<uint64_t, int64_t>(Op->Cond.Val, Src1, Src2);
+              CompResult = IsConditionTrue<uint64_t, int64_t, double>(Op->Cond.Val, Src1, Src2);
 
             GD = CompResult ? ArgTrue : ArgFalse;
             break;

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
@@ -124,24 +124,22 @@ DEF_OP(CondJump) {
   uint64_t Const;
   bool isConst = IsInlineConstant(Op->Cmp2, &Const);
 
-  auto RegClass = GetRegClass(Op->Cmp1.ID());
-
   if (isConst && Const == 0 && Op->Cond.Val == FEXCore::IR::COND_EQ) {
-    assert(RegClass == IR::GPRClass || RegClass == IR::GPRFixedClass);
+    LogMan::Throw::A(IsGPR(Op->Cmp1.ID()), "CondJump: Expected GPR");
     cbz(GRCMP(Op->Cmp1.ID()), TrueTargetLabel);
   } else if (isConst && Const == 0 && Op->Cond.Val == FEXCore::IR::COND_NEQ) {
-    assert(RegClass == IR::GPRClass || RegClass == IR::GPRFixedClass);
+    LogMan::Throw::A(IsGPR(Op->Cmp1.ID()), "CondJump: Expected GPR");
     cbnz(GRCMP(Op->Cmp1.ID()), TrueTargetLabel);
   } else {
-    if (RegClass == IR::GPRClass || RegClass == IR::GPRFixedClass) {
+    if (IsGPR(Op->Cmp1.ID())) {
       if (isConst)
         cmp(GRCMP(Op->Cmp1.ID()), Const);
       else
         cmp(GRCMP(Op->Cmp1.ID()), GRCMP(Op->Cmp2.ID()));
-    } else if (RegClass == IR::FPRClass || RegClass == IR::FPRFixedClass) {
+    } else if (IsFPR(Op->Cmp1.ID())) {
       fcmp(GRFCMP(Op->Cmp1.ID()), GRFCMP(Op->Cmp2.ID()));
     } else {
-      assert(false);
+      LogMan::Msg::A("CondJump: Expected GPR or FPR");
     }
 
     b(TrueTargetLabel, MapBranchCC(Op->Cond));

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -681,9 +681,21 @@ bool JITCore::IsInlineConstant(const IR::OrderedNodeWrapper& WNode, uint64_t* Va
 }
 
 FEXCore::IR::RegisterClassType JITCore::GetRegClass(uint32_t Node) {
-  auto Reg = GetPhys(RAPass, Node);
+  auto Class = static_cast<uint32_t>(RAPass->GetNodeRegister(Node) >> 32);
+  return FEXCore::IR::RegisterClassType {Class};
+}
 
-  return FEXCore::IR::RegisterClassType {Reg.Class};
+
+bool JITCore::IsFPR(uint32_t Node) {
+  auto Class = GetRegClass(Node);
+
+  return Class == IR::FPRClass;
+}
+
+bool JITCore::IsGPR(uint32_t Node) {
+  auto Class = GetRegClass(Node);
+
+  return Class == IR::GPRClass;
 }
 
 void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const *IR, [[maybe_unused]] FEXCore::Core::DebugData *DebugData) {

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -680,6 +680,12 @@ bool JITCore::IsInlineConstant(const IR::OrderedNodeWrapper& WNode, uint64_t* Va
   }
 }
 
+FEXCore::IR::RegisterClassType JITCore::GetRegClass(uint32_t Node) {
+  auto Reg = GetPhys(RAPass, Node);
+
+  return FEXCore::IR::RegisterClassType {Reg.Class};
+}
+
 void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const *IR, [[maybe_unused]] FEXCore::Core::DebugData *DebugData) {
   using namespace aarch64;
   JumpTargets.clear();

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -152,6 +152,9 @@ private:
 
   FEXCore::IR::RegisterClassType GetRegClass(uint32_t Node);
 
+  bool IsFPR(uint32_t Node);
+  bool IsGPR(uint32_t Node);
+
   MemOperand GenerateMemOperand(uint8_t AccessSize, aarch64::Register Base, IR::OrderedNodeWrapper Offset, IR::MemOffsetType OffsetType, uint8_t OffsetScale);
 
   bool IsInlineConstant(const IR::OrderedNodeWrapper& Node, uint64_t* Value = nullptr);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -150,6 +150,8 @@ private:
   aarch64::VRegister GetSrc(uint32_t Node);
   aarch64::VRegister GetDst(uint32_t Node);
 
+  FEXCore::IR::RegisterClassType GetRegClass(uint32_t Node);
+
   MemOperand GenerateMemOperand(uint8_t AccessSize, aarch64::Register Base, IR::OrderedNodeWrapper Offset, IR::MemOffsetType OffsetType, uint8_t OffsetScale);
 
   bool IsInlineConstant(const IR::OrderedNodeWrapper& Node, uint64_t* Value = nullptr);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/ALUOps.cpp
@@ -1088,11 +1088,18 @@ DEF_OP(Select) {
   auto Op = IROp->C<IR::IROp_Select>();
   auto Dst = GRD(Node);
 
-  uint64_t Const;
-  if (IsInlineConstant(Op->Cmp2, &Const)) {
-    cmp(GRCMP(Op->Cmp1.ID()), Const);
-  } else {
-    cmp(GRCMP(Op->Cmp1.ID()), GRCMP(Op->Cmp2.ID()));
+  if (IsGPR(Op->Cmp1.ID())) {
+    uint64_t Const;
+    if (IsInlineConstant(Op->Cmp2, &Const)) {
+      cmp(GRCMP(Op->Cmp1.ID()), Const);
+    } else {
+      cmp(GRCMP(Op->Cmp1.ID()), GRCMP(Op->Cmp2.ID()));
+    }
+  } else if (IsFPR(Op->Cmp1.ID())) {
+    if (Op->CompareSize  == 4)
+      ucomiss(GetSrc(Op->Cmp1.ID()), GetSrc(Op->Cmp2.ID()));
+    else
+      ucomisd(GetSrc(Op->Cmp1.ID()), GetSrc(Op->Cmp2.ID()));
   }
 
   uint64_t const_true, const_false;

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
@@ -107,14 +107,19 @@ DEF_OP(CondJump) {
     TrueTargetLabel = &TrueIter->second;
   }
 
-
-  uint64_t Const;
-  bool isConst = IsInlineConstant(Op->Cmp2, &Const);
-
-  if (isConst)
-    cmp(GRCMP(Op->Cmp1.ID()), Const);
-  else
-    cmp(GRCMP(Op->Cmp1.ID()), GRCMP(Op->Cmp2.ID()));
+  if (IsGPR(Op->Cmp1.ID())) {
+    uint64_t Const;
+    if (IsInlineConstant(Op->Cmp2, &Const)) {
+      cmp(GRCMP(Op->Cmp1.ID()), Const);
+    } else {
+      cmp(GRCMP(Op->Cmp1.ID()), GRCMP(Op->Cmp2.ID()));
+    }
+  } else if (IsFPR(Op->Cmp1.ID())) {
+    if (Op->CompareSize  == 4)
+      ucomiss(GetSrc(Op->Cmp1.ID()), GetSrc(Op->Cmp2.ID()));
+    else
+      ucomisd(GetSrc(Op->Cmp1.ID()), GetSrc(Op->Cmp2.ID()));
+  }
 
   auto [_, __, JCC] = GetCC(Op->Cond);
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
@@ -116,26 +116,9 @@ DEF_OP(CondJump) {
   else
     cmp(GRCMP(Op->Cmp1.ID()), GRCMP(Op->Cmp2.ID()));
 
-  switch (Op->Cond.Val) {
-    case FEXCore::IR::COND_EQ:  je(*TrueTargetLabel, T_NEAR); break;
-    case FEXCore::IR::COND_NEQ: jne(*TrueTargetLabel, T_NEAR); break;
-    case FEXCore::IR::COND_SGE: jge(*TrueTargetLabel, T_NEAR); break;
-    case FEXCore::IR::COND_SLT: jl(*TrueTargetLabel, T_NEAR); break;
-    case FEXCore::IR::COND_SGT: jg(*TrueTargetLabel, T_NEAR); break;
-    case FEXCore::IR::COND_SLE: jle(*TrueTargetLabel, T_NEAR); break;
-    case FEXCore::IR::COND_UGE: jae(*TrueTargetLabel, T_NEAR); break;
-    case FEXCore::IR::COND_ULT: jb(*TrueTargetLabel, T_NEAR); break;
-    case FEXCore::IR::COND_UGT: ja(*TrueTargetLabel, T_NEAR); break;
-    case FEXCore::IR::COND_ULE: jna(*TrueTargetLabel, T_NEAR); break;
+  auto [_, __, JCC] = GetCC(Op->Cond);
 
-    case FEXCore::IR::COND_MI:
-    case FEXCore::IR::COND_PL:
-    case FEXCore::IR::COND_VS:
-    case FEXCore::IR::COND_VC:
-    default:
-      LogMan::Msg::A("Unsupported compare type");
-      break;
-  }
+  (this->*JCC)(*TrueTargetLabel, T_NEAR);
 
   if (FalseIter == JumpTargets.end()) {
     FalseTargetLabel = &JumpTargets.try_emplace(Op->FalseBlock.ID()).first->second;

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -473,6 +473,18 @@ uint32_t JITCore::GetPhys(uint32_t Node) {
   return ~0U;
 }
 
+bool JITCore::IsFPR(uint32_t Node) {
+  auto Class =  RAPass->GetNodeRegister(Node) >> 32;
+
+  return Class == IR::FPRClass.Val;
+}
+
+bool JITCore::IsGPR(uint32_t Node) {
+  auto Class =  RAPass->GetNodeRegister(Node) >> 32;
+
+  return Class == IR::GPRClass.Val;
+}
+
 template<uint8_t RAType>
 Xbyak::Reg JITCore::GetSrc(uint32_t Node) {
   // rax, rcx, rdx, rsi, r8, r9,

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -570,6 +570,36 @@ bool JITCore::IsInlineConstant(const IR::OrderedNodeWrapper& WNode, uint64_t* Va
   }
 }
 
+std::tuple<JITCore::SetCC, JITCore::CMovCC, JITCore::JCC> JITCore::GetCC(IR::CondClassType cond) {
+    switch (cond.Val) {
+    case FEXCore::IR::COND_EQ:  return { &CodeGenerator::sete , &CodeGenerator::cmove , &CodeGenerator::je  };
+    case FEXCore::IR::COND_NEQ: return { &CodeGenerator::setne, &CodeGenerator::cmovne, &CodeGenerator::jne };
+    case FEXCore::IR::COND_SGE: return { &CodeGenerator::setge, &CodeGenerator::cmovge, &CodeGenerator::jge };
+    case FEXCore::IR::COND_SLT: return { &CodeGenerator::setl , &CodeGenerator::cmovl , &CodeGenerator::jl  };
+    case FEXCore::IR::COND_SGT: return { &CodeGenerator::setg , &CodeGenerator::cmovg , &CodeGenerator::jg  };
+    case FEXCore::IR::COND_SLE: return { &CodeGenerator::setle, &CodeGenerator::cmovle, &CodeGenerator::jle }; 
+    case FEXCore::IR::COND_UGE: return { &CodeGenerator::setae, &CodeGenerator::cmovae, &CodeGenerator::jae };
+    case FEXCore::IR::COND_ULT: return { &CodeGenerator::setb , &CodeGenerator::cmovb , &CodeGenerator::jb  };
+    case FEXCore::IR::COND_UGT: return { &CodeGenerator::seta , &CodeGenerator::cmova , &CodeGenerator::ja  };
+    case FEXCore::IR::COND_ULE: return { &CodeGenerator::setna, &CodeGenerator::cmovna, &CodeGenerator::jna };
+
+	  case FEXCore::IR::COND_FLU:  return { &CodeGenerator::setb , &CodeGenerator::cmovb , &CodeGenerator::jb  };
+	  case FEXCore::IR::COND_FGE:  return { &CodeGenerator::setae, &CodeGenerator::cmovae, &CodeGenerator::jae };
+	  case FEXCore::IR::COND_FLEU: return { &CodeGenerator::setna, &CodeGenerator::cmovna, &CodeGenerator::jna };
+	  case FEXCore::IR::COND_FGT:  return { &CodeGenerator::seta , &CodeGenerator::cmova , &CodeGenerator::ja  };
+	  case FEXCore::IR::COND_FU:   return { &CodeGenerator::setp , &CodeGenerator::cmovp , &CodeGenerator::jp  };
+	  case FEXCore::IR::COND_FNU:  return { &CodeGenerator::setnp, &CodeGenerator::cmovnp, &CodeGenerator::jnp };
+
+    case FEXCore::IR::COND_MI:
+    case FEXCore::IR::COND_PL:
+    case FEXCore::IR::COND_VS:
+    case FEXCore::IR::COND_VC:
+    default:
+      LogMan::Msg::A("Unsupported compare type");
+      break;
+  }
+}
+
 void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const *IR, [[maybe_unused]] FEXCore::Core::DebugData *DebugData) {
   JumpTargets.clear();
   uint32_t SSACount = IR->GetSSACount();

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -108,6 +108,9 @@ private:
 
   uint32_t GetPhys(uint32_t Node);
 
+  bool IsFPR(uint32_t Node);
+  bool IsGPR(uint32_t Node);
+
   template<uint8_t RAType>
   Xbyak::Reg GetSrc(uint32_t Node);
   template<uint8_t RAType>

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -15,6 +15,8 @@ using namespace Xbyak;
 #include <FEXCore/IR/IR.h>
 #include <FEXCore/IR/IntrusiveIRList.h>
 
+#include <tuple>
+
 namespace FEXCore::CPU {
 struct CodeBuffer {
   uint8_t *Ptr;
@@ -170,6 +172,11 @@ private:
   void RestoreThreadState(void *ucontext);
   std::stack<uint64_t> SignalFrames;
   uint32_t SpillSlots{};
+  using SetCC = void (JITCore::*)(const Operand& op);
+  using CMovCC = void (JITCore::*)(const Reg& reg, const Operand& op);
+  using JCC = void (JITCore::*)(const Label& label, LabelType type);
+
+  std::tuple<SetCC, CMovCC, JCC> GetCC(IR::CondClassType cond);
 
   using OpHandler = void (JITCore::*)(FEXCore::IR::IROp_Header *IROp, uint32_t Node);
   std::array<OpHandler, FEXCore::IR::IROps::OP_LAST + 1> OpHandlers {};

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -850,6 +850,58 @@ OrderedNode *OpDispatchBuilder::SelectCC(uint8_t OP, OrderedNode *TrueValue, Ord
       case 0x5: SrcCond = _Select(FEXCore::IR::COND_NEQ, flagsOpDest, ZeroConst, TrueValue, FalseValue, flagsOpSize); break;
       //default: printf("Missed Condition %04X OP_AND\n", OP); break;
     }
+  } else if (flagsOp == FLAGS_OP_FCMP) {
+    /*
+      x86:ZCP
+        unordered { 11 1 }
+        greater   { 00 0 }
+        less      { 01 0 }
+        equal     { 10 0 }
+      aarch64: NZCV
+        unordered { 0 01 1 }
+        greater   { 0 01 0 }
+        less      { 1 00 0 }
+        equal     { 0 11 0 }
+    */
+
+   /*
+      eq = 0,   // Z set            Equal.
+      ne = 1,   // Z clear          Not equal.
+      cs = 2,   // C set            Carry set.
+      cc = 3,   // C clear          Carry clear.
+      mi = 4,   // N set            Negative.
+      pl = 5,   // N clear          Positive or zero.
+      vs = 6,   // V set            Overflow.
+      vc = 7,   // V clear          No overflow.
+      hi = 8,   // C set, Z clear   Unsigned higher.
+      ls = 9,   // C clear or Z set Unsigned lower or same.
+      ge = 10,  // N == V           Greater or equal.
+      lt = 11,  // N != V           Less than.
+      gt = 12,  // Z clear, N == V  Greater than.
+      le = 13,  // Z set or N != V  Less then or equal
+   */
+    switch(OP) {
+      case 0x2: // CF == 1 // less or unordered                      // N==1 OR V==1        // lt
+        SrcCond = _Select(FEXCore::IR::COND_FLU, flagsOpDest, flagsOpSrc, TrueValue, FalseValue, flagsOpSize);
+        break;
+      case 0x3: // CF == 0 // greater or equal (and not unordered)   // N==V                // ge
+        SrcCond = _Select(FEXCore::IR::COND_FGE, flagsOpDest, flagsOpSrc, TrueValue, FalseValue, flagsOpSize);
+        break;
+      case 0x6: // CF == 1 || ZF == 1 // less or equal or unordered  // Z==1 OR N!=V        // le
+        SrcCond = _Select(FEXCore::IR::COND_FLEU, flagsOpDest, flagsOpSrc, TrueValue, FalseValue, flagsOpSize);
+        break;
+      case 0x7: // CF == 0 && ZF == 0 // greater (and not unordered) // C==1 AND V=0        // hi
+        SrcCond = _Select(FEXCore::IR::COND_FGT, flagsOpDest, flagsOpSrc, TrueValue, FalseValue, flagsOpSize);
+        break;
+      case 0xA: // PF = 1 // unordered                               // V==1                // vs
+        SrcCond = _Select(FEXCore::IR::COND_FU, flagsOpDest, flagsOpSrc, TrueValue, FalseValue, flagsOpSize);
+        break;
+      case 0xB: // PF = 0 // not unordered                           // V==0                // vc
+        SrcCond = _Select(FEXCore::IR::COND_FNU, flagsOpDest, flagsOpSrc, TrueValue, FalseValue, flagsOpSize);
+        break;
+      default:
+        printf("Missed Condition %04X FLAGS_OP_FCMP\n", OP); break;
+    }
   }
 
   return SrcCond;
@@ -7538,6 +7590,11 @@ void OpDispatchBuilder::UCOMISxOp(OpcodeArgs) {
   SetRFLAG<FEXCore::X86State::RFLAG_AF_LOC>(ZeroConst);
   SetRFLAG<FEXCore::X86State::RFLAG_SF_LOC>(ZeroConst);
   SetRFLAG<FEXCore::X86State::RFLAG_OF_LOC>(ZeroConst);
+
+  flagsOp = FLAGS_OP_FCMP;
+  flagsOpDest = Src1;
+  flagsOpSrc = Src2;
+  flagsOpSize = GetSrcSize(Op);
 }
 
 void OpDispatchBuilder::LDMXCSR(OpcodeArgs) {

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -28,6 +28,7 @@ enum {
   FLAGS_OP_NONE,  // must rely on x86 flags
   FLAGS_OP_CMP,   // flags were set by a CMP between flagsOpDest/flagsOpDestSigned and flagsOpSrc/flagsOpSrcSigned with flagsOpSize size
   FLAGS_OP_AND,   // flags were set by an AND/TEST, flagsOpDest contains the resulting value of flagsOpSize size
+  FLAGS_OP_FCMP,  // flags were set by a ucomis* / comis*
 };
 
 public:

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -14,6 +14,14 @@
     "constexpr static uint8_t COND_SLT  = 11",
     "constexpr static uint8_t COND_SGT  = 12",
     "constexpr static uint8_t COND_SLE  = 13",
+
+    "constexpr static uint8_t COND_FLU  = 16 /* float less or unordred */",
+    "constexpr static uint8_t COND_FGE  = 17 /* float greater or equal */",
+    "constexpr static uint8_t COND_FLEU = 18 /* float less or equal or unordred */",
+    "constexpr static uint8_t COND_FGT  = 19 /* float greater */",
+    "constexpr static uint8_t COND_FU   = 20 /* float unordred */",
+    "constexpr static uint8_t COND_FNU  = 21 /* float not unordred */",
+
     "static constexpr FEXCore::IR::RegisterClassType GPRClass {0}",
     "static constexpr FEXCore::IR::RegisterClassType FPRClass {1}",
     "static constexpr FEXCore::IR::RegisterClassType GPRPairClass {2}",


### PR DESCRIPTION
## Overview
- Adds float compare operations as COND_F*
- Extends CondJump and Select to support both integer and float compare params
- Adds a frontend calculation bypass similar to cmp/test

## Todo
- [x] Add `COND_F*` to x86 backend
- [x] Move type checks to function, make it not depend to SRA in arm64 backend
- [x] Rebase