### PR TITLE
JITSYMS: Per-block symbol information

### DIFF
--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -139,7 +139,7 @@ namespace FEXCore::Context {
     FEXCore::Core::ThreadState *GetThreadState();
     void LoadEntryList();
 
-    void *CompileCode(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP);
+    std::tuple<void *, FEXCore::Core::DebugData *> CompileCode(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP);
     uintptr_t CompileBlock(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP);
     uintptr_t CompileFallbackBlock(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP);
 

--- a/External/FEXCore/Source/Interface/Core/CompileService.cpp
+++ b/External/FEXCore/Source/Interface/Core/CompileService.cpp
@@ -135,11 +135,15 @@ namespace FEXCore {
         if (Item) {
           // Does the block cache already contain this RIP?
           void *CompiledCode = reinterpret_cast<void*>(CompileThreadData->BlockCache->FindBlock(Item->RIP));
+          FEXCore::Core::DebugData *DebugData = nullptr;
+
           if (!CompiledCode) {
             // Code isn't in cache, compile now
             // Set our thread state's RIP
             CompileThreadData->State.State.rip = Item->RIP;
-            CompiledCode = CTX->CompileCode(CompileThreadData.get(), Item->RIP);
+            auto [Code, Data] = CTX->CompileCode(CompileThreadData.get(), Item->RIP);
+            CompiledCode = Code;
+            DebugData = Data;
           }
 
           if (!CompiledCode) {
@@ -155,6 +159,7 @@ namespace FEXCore {
 
           Item->CodePtr = CompiledCode;
           Item->IRList = CompileThreadData->IRLists.find(Item->RIP)->second.get();
+          Item->DebugData = DebugData;
 
           GCArray.emplace_back(Item);
           Item->ServiceWorkDone.NotifyAll();

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -835,7 +835,13 @@ namespace FEXCore::Context {
     if (CodePtr != nullptr) {
       // The core managed to compile the code.
 #if ENABLE_JITSYMBOLS
+    if (DebugData->Subblocks.size()) {
+      for (auto& Subblock: DebugData->Subblocks) {
+        Symbols.Register((void*)Subblock.HostCodeStart, GuestRIP, Subblock.HostCodeSize);
+      }
+    } else {
       Symbols.Register(CodePtr, GuestRIP, DebugData->HostCodeSize);
+    }
 #endif
 
       --Thread->CompileBlockReentrantRefCount;

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -759,12 +759,20 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
       bind(&IsTarget->second);
     }
 
+    if (DebugData) {
+      DebugData->Subblocks.push_back({Buffer->GetOffsetAddress<uintptr_t>(GetCursorOffset()), 0, IR->GetID(BlockNode)});
+    }
+
     for (auto [CodeNode, IROp] : IR->GetCode(BlockNode)) {
       uint32_t ID = IR->GetID(CodeNode);
 
       // Execute handler
       OpHandler Handler = OpHandlers[IROp->Op];
       (this->*Handler)(IROp, ID);
+    }
+
+    if (DebugData) {
+      DebugData->Subblocks.back().HostCodeSize = Buffer->GetOffsetAddress<uintptr_t>(GetCursorOffset()) - DebugData->Subblocks.back().HostCodeStart;
     }
   }
 

--- a/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
+++ b/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
@@ -32,6 +32,12 @@ namespace FEXCore::Core {
     std::atomic_uint64_t BlocksCompiled;
   };
 
+  struct DebugDataSubblock {
+    uintptr_t HostCodeStart;
+    uint32_t HostCodeSize;
+    uint32_t SSAId;
+  };
+
   /**
    * @brief Contains debug data for a block of code for later debugger analysis
    *
@@ -43,6 +49,7 @@ namespace FEXCore::Core {
     uint64_t GuestInstructionCount; ///< Number of guest instructions
     uint64_t TimeSpentInCode; ///< How long this code has spent time running
     uint64_t RunCount; ///< Number of times this block of code has been run
+    std::vector<DebugDataSubblock> Subblocks;
   };
 
   enum SignalEvent {


### PR DESCRIPTION
This makes `perf top` and such much more useful in multiblock
- Adds an array in DebugData to return information per ssa block
- Registers in the form of `JIT_<guest block head>_<host block-specific-entry>`
- Had to fix some plumbing for debug data