### PR TITLE
Pop_Segments: pop cs is not a valid opcode

### DIFF
--- a/unittests/32Bit_ASM/Primary/Pop_Segments.asm
+++ b/unittests/32Bit_ASM/Primary/Pop_Segments.asm
@@ -2,7 +2,7 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "RSP": "0xE000001C"
+    "RSP": "0xE0000040"
   },
   "Mode": "32BIT"
 }
@@ -16,9 +16,7 @@ push eax
 push eax
 push eax
 push eax
-push eax
 
-push ax
 push ax
 push ax
 push ax
@@ -28,14 +26,12 @@ push ax
 ; Only pops the segments
 ; Doesn't check for a correct segment value
 ; Just ensures we are popping the correct amount of data
-pop cs
 pop ss
 pop ds
 pop es
 pop fs
 pop gs
 
-o16 pop cs
 o16 pop ss
 o16 pop ds
 o16 pop es


### PR DESCRIPTION
I have no idea why nasm assembles it, however pop cs shouldn't exist. The test currently crashes with a sigsegv, and for some reason ctest thinks it passed.

`pop cs` decodes to `movhps` and `o16 pop cs` to `pcmpgtd` both in objdump and FEX.

$ objdump -b binary -m i386 -D unittests/32Bit_ASM/Primary/Pop_Segments.asm.bin
```
   0:	bc 40 00 00 e0       	mov    $0xe0000040,%esp
   5:	b8 00 00 00 00       	mov    $0x0,%eax
   a:	50                   	push   %eax
   b:	50                   	push   %eax
   c:	50                   	push   %eax
   d:	50                   	push   %eax
   e:	50                   	push   %eax
   f:	50                   	push   %eax
  10:	66 50                	push   %ax
  12:	66 50                	push   %ax
  14:	66 50                	push   %ax
  16:	66 50                	push   %ax
  18:	66 50                	push   %ax
  1a:	66 50                	push   %ax
  1c:	0f 17 1f             	movhps %xmm3,(%edi)
  1f:	07                   	pop    %es
  20:	0f a1                	pop    %fs
  22:	0f a9                	pop    %gs
  24:	66 0f 66 17          	pcmpgtd (%edi),%xmm2
  28:	66 1f                	popw   %ds
  2a:	66 07                	popw   %es
  2c:	66 0f a1             	popw   %fs
  2f:	66 0f a9             	popw   %gs
  32:	f4                   	hlt    
  33:	c3                   	ret  
```