### PR TITLE
Removes the last usage of 8bit and 16bit multiply

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -1238,12 +1238,6 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
             uint64_t Src2 = *GetSrc<uint64_t*>(SSAData, Op->Header.Args[1]);
 
             switch (OpSize) {
-              case 1:
-                GD = static_cast<int64_t>(static_cast<int8_t>(Src1)) * static_cast<int64_t>(static_cast<int8_t>(Src2));
-                break;
-              case 2:
-                GD = static_cast<int64_t>(static_cast<int16_t>(Src1)) * static_cast<int64_t>(static_cast<int16_t>(Src2));
-                break;
               case 4:
                 GD = static_cast<int64_t>(static_cast<int32_t>(Src1)) * static_cast<int64_t>(static_cast<int32_t>(Src2));
                 break;
@@ -1265,16 +1259,6 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
             uint64_t Src2 = *GetSrc<uint64_t*>(SSAData, Op->Header.Args[1]);
 
             switch (OpSize) {
-              case 1: {
-                int64_t Tmp = static_cast<int64_t>(static_cast<int8_t>(Src1)) * static_cast<int64_t>(static_cast<int8_t>(Src2));
-                GD = Tmp >> 8;
-                break;
-              }
-              case 2: {
-                int64_t Tmp = static_cast<int64_t>(static_cast<int16_t>(Src1)) * static_cast<int64_t>(static_cast<int16_t>(Src2));
-                GD = Tmp >> 16;
-                break;
-              }
               case 4: {
                 int64_t Tmp = static_cast<int64_t>(static_cast<int32_t>(Src1)) * static_cast<int64_t>(static_cast<int32_t>(Src2));
                 GD = Tmp >> 32;
@@ -1295,12 +1279,6 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
             uint64_t Src2 = *GetSrc<uint64_t*>(SSAData, Op->Header.Args[1]);
 
             switch (OpSize) {
-              case 1:
-                GD = static_cast<uint8_t>(Src1) * static_cast<uint8_t>(Src2);
-                break;
-              case 2:
-                GD = static_cast<uint16_t>(Src1) * static_cast<uint16_t>(Src2);
-                break;
               case 4:
                 GD = static_cast<uint32_t>(Src1) * static_cast<uint32_t>(Src2);
                 break;
@@ -1321,14 +1299,6 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
             uint64_t Src1 = *GetSrc<uint64_t*>(SSAData, Op->Header.Args[0]);
             uint64_t Src2 = *GetSrc<uint64_t*>(SSAData, Op->Header.Args[1]);
             switch (OpSize) {
-              case 1:
-                GD = static_cast<uint16_t>(Src1) * static_cast<uint16_t>(Src2);
-                GD >>= 8;
-                break;
-              case 2:
-                GD = static_cast<uint32_t>(Src1) * static_cast<uint32_t>(Src2);
-                GD >>= 16;
-                break;
               case 4:
                 GD = static_cast<uint64_t>(Src1) * static_cast<uint64_t>(Src2);
                 GD >>= 32;

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -140,18 +140,6 @@ DEF_OP(Mul) {
   auto Dst = GetReg<RA_64>(Node);
 
   switch (OpSize) {
-    case 1:
-      sxtb(TMP1, GetReg<RA_64>(Op->Header.Args[0].ID()));
-      sxtb(TMP2, GetReg<RA_64>(Op->Header.Args[1].ID()));
-      mul(Dst, TMP1, TMP2);
-      sxtb(Dst, Dst);
-    break;
-    case 2:
-      sxth(TMP1, GetReg<RA_64>(Op->Header.Args[0].ID()));
-      sxth(TMP2, GetReg<RA_64>(Op->Header.Args[1].ID()));
-      mul(Dst, TMP1, TMP2);
-      sxth(Dst, Dst);
-    break;
     case 4:
       mul(Dst.W(), GetReg<RA_32>(Op->Header.Args[0].ID()), GetReg<RA_32>(Op->Header.Args[1].ID()));
       sxtw(Dst, Dst);
@@ -169,18 +157,6 @@ DEF_OP(UMul) {
   auto Dst = GetReg<RA_64>(Node);
 
   switch (OpSize) {
-    case 1:
-      uxtb(TMP1, GetReg<RA_64>(Op->Header.Args[0].ID()));
-      uxtb(TMP2, GetReg<RA_64>(Op->Header.Args[1].ID()));
-      mul(Dst, TMP1, TMP2);
-      uxtb(Dst, Dst);
-    break;
-    case 2:
-      uxth(TMP1, GetReg<RA_64>(Op->Header.Args[0].ID()));
-      uxth(TMP2, GetReg<RA_64>(Op->Header.Args[1].ID()));
-      mul(Dst, TMP1, TMP2);
-      uxth(Dst, Dst);
-    break;
     case 4:
       mul(Dst.W(), GetReg<RA_32>(Op->Header.Args[0].ID()), GetReg<RA_32>(Op->Header.Args[1].ID()));
     break;
@@ -348,18 +324,6 @@ DEF_OP(MulH) {
   auto Op = IROp->C<IR::IROp_MulH>();
   uint8_t OpSize = IROp->Size;
   switch (OpSize) {
-    case 1:
-      sxtb(TMP1, GetReg<RA_64>(Op->Header.Args[0].ID()));
-      sxtb(TMP2, GetReg<RA_64>(Op->Header.Args[1].ID()));
-      mul(TMP1, TMP1, TMP2);
-      sbfx(GetReg<RA_64>(Node), TMP1, 8, 8);
-    break;
-    case 2:
-      sxth(TMP1, GetReg<RA_64>(Op->Header.Args[0].ID()));
-      sxth(TMP2, GetReg<RA_64>(Op->Header.Args[1].ID()));
-      mul(TMP1, TMP1, TMP2);
-      sbfx(GetReg<RA_64>(Node), TMP1, 16, 16);
-    break;
     case 4:
       sxtw(TMP1, GetReg<RA_64>(Op->Header.Args[0].ID()));
       sxtw(TMP2, GetReg<RA_64>(Op->Header.Args[1].ID()));
@@ -377,18 +341,6 @@ DEF_OP(UMulH) {
   auto Op = IROp->C<IR::IROp_UMulH>();
   uint8_t OpSize = IROp->Size;
   switch (OpSize) {
-    case 1:
-      uxtb(TMP1, GetReg<RA_64>(Op->Header.Args[0].ID()));
-      uxtb(TMP2, GetReg<RA_64>(Op->Header.Args[1].ID()));
-      mul(TMP1, TMP1, TMP2);
-      ubfx(GetReg<RA_64>(Node), TMP1, 8, 8);
-    break;
-    case 2:
-      uxth(TMP1, GetReg<RA_64>(Op->Header.Args[0].ID()));
-      uxth(TMP2, GetReg<RA_64>(Op->Header.Args[1].ID()));
-      mul(TMP1, TMP1, TMP2);
-      ubfx(GetReg<RA_64>(Node), TMP1, 16, 16);
-    break;
     case 4:
       uxtw(TMP1, GetReg<RA_64>(Op->Header.Args[0].ID()));
       uxtw(TMP2, GetReg<RA_64>(Op->Header.Args[1].ID()));

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/ALUOps.cpp
@@ -133,22 +133,10 @@ DEF_OP(Mul) {
   auto Dst = GetDst<RA_64>(Node);
 
   switch (OpSize) {
-  case 1:
-    movsx(rax, GetSrc<RA_8>(Op->Header.Args[0].ID()));
-    movsx(rcx, GetSrc<RA_8>(Op->Header.Args[1].ID()));
-    imul(cl);
-    movsx(Dst, al);
-  break;
-  case 2:
-    movsx(rax, GetSrc<RA_16>(Op->Header.Args[0].ID()));
-    movsx(rcx, GetSrc<RA_16>(Op->Header.Args[1].ID()));
-    imul(cx);
-    movsx(Dst, ax);
-  break;
   case 4:
     movsxd(rax, GetSrc<RA_32>(Op->Header.Args[0].ID()));
     imul(eax, GetSrc<RA_32>(Op->Header.Args[1].ID()));
-    movsxd(Dst.cvt64(), eax);
+    mov(Dst.cvt32(), eax);
   break;
   case 8:
     mov(rax, GetSrc<RA_64>(Op->Header.Args[0].ID()));
@@ -164,20 +152,6 @@ DEF_OP(UMul) {
   uint8_t OpSize = IROp->Size;
 
   switch (OpSize) {
-  case 1:
-    movzx(rax, GetSrc<RA_8>(Op->Header.Args[0].ID()));
-    movzx(rcx, GetSrc<RA_8>(Op->Header.Args[1].ID()));
-    mul(cl);
-    movzx(rax, al);
-    mov(GetDst<RA_64>(Node), rax);
-  break;
-  case 2:
-    movzx(rax, GetSrc<RA_16>(Op->Header.Args[0].ID()));
-    movzx(rcx, GetSrc<RA_16>(Op->Header.Args[1].ID()));
-    mul(cx);
-    movzx(rax, ax);
-    mov(GetDst<RA_64>(Node), rax);
-  break;
   case 4:
     mov(rax, GetSrc<RA_32>(Op->Header.Args[0].ID()));
     mul(GetSrc<RA_32>(Op->Header.Args[1].ID()));
@@ -359,20 +333,6 @@ DEF_OP(MulH) {
   uint8_t OpSize = IROp->Size;
 
   switch (OpSize) {
-  case 1:
-    movsx(rax, GetSrc<RA_8>(Op->Header.Args[0].ID()));
-    movsx(rcx, GetSrc<RA_8>(Op->Header.Args[1].ID()));
-    imul(cl);
-    movsx(rax, ax);
-    mov(GetDst<RA_64>(Node), rax);
-  break;
-  case 2:
-    movsx(rax, GetSrc<RA_16>(Op->Header.Args[0].ID()));
-    movsx(rcx, GetSrc<RA_16>(Op->Header.Args[1].ID()));
-    imul(cx);
-    movsx(rax, dx);
-    mov(GetDst<RA_64>(Node), rax);
-  break;
   case 4:
     movsxd(rax, GetSrc<RA_32>(Op->Header.Args[0].ID()));
     imul(GetSrc<RA_32>(Op->Header.Args[1].ID()));
@@ -392,20 +352,6 @@ DEF_OP(UMulH) {
   uint8_t OpSize = IROp->Size;
 
   switch (OpSize) {
-  case 1:
-    movzx(rax, GetSrc<RA_8>(Op->Header.Args[0].ID()));
-    movzx(rcx, GetSrc<RA_8>(Op->Header.Args[1].ID()));
-    mul(cl);
-    movzx(rax, ax);
-    mov(GetDst<RA_64>(Node), rax);
-  break;
-  case 2:
-    movzx(rax, GetSrc<RA_16>(Op->Header.Args[0].ID()));
-    movzx(rcx, GetSrc<RA_16>(Op->Header.Args[1].ID()));
-    mul(cx);
-    movzx(rax, dx);
-    mov(GetDst<RA_64>(Node), rax);
-  break;
   case 4:
     mov(rax, GetSrc<RA_32>(Op->Header.Args[0].ID()));
     mul(GetSrc<RA_32>(Op->Header.Args[1].ID()));

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -2633,6 +2633,12 @@ void OpDispatchBuilder::IMUL1SrcOp(OpcodeArgs) {
   OrderedNode *Src1 = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
   OrderedNode *Src2 = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
 
+  uint8_t Size = GetSrcSize(Op);
+  if (Size != 8) {
+    Src1 = _Sext(Size * 8, Src1);
+    Src2 = _Sext(Size * 8, Src2);
+  }
+
   auto Dest = _Mul(Src1, Src2);
   StoreResult(GPRClass, Op, Dest, -1);
   GenerateFlags_MUL(Op, Dest, _MulH(Src1, Src2));
@@ -2641,6 +2647,12 @@ void OpDispatchBuilder::IMUL1SrcOp(OpcodeArgs) {
 void OpDispatchBuilder::IMUL2SrcOp(OpcodeArgs) {
   OrderedNode *Src1 = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
   OrderedNode *Src2 = LoadSource(GPRClass, Op, Op->Src[1], Op->Flags, -1);
+
+  uint8_t Size = GetSrcSize(Op);
+  if (Size != 8) {
+    Src1 = _Sext(Size * 8, Src1);
+    Src2 = _Sext(Size * 8, Src2);
+  }
 
   auto Dest = _Mul(Src1, Src2);
   StoreResult(GPRClass, Op, Dest, -1);


### PR DESCRIPTION
This was causing issues in 32bit xeyes.
A couple of the multiply ops were still using 8bit and 16bit multiply
while the other one was already sexting or zexting the source.