### PR TITLE
More 32bit syscall fixes

### DIFF
--- a/External/FEXCore/Source/Interface/HLE/x32/FD.cpp
+++ b/External/FEXCore/Source/Interface/HLE/x32/FD.cpp
@@ -169,7 +169,9 @@ namespace FEXCore::HLE::x32 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(fstatfs64, [](FEXCore::Core::InternalThreadState *Thread, int fd, struct statfs64_32 *buf) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(fstatfs64, [](FEXCore::Core::InternalThreadState *Thread, int fd, size_t sz, struct statfs64_32 *buf) -> uint64_t {
+      LogMan::Throw::A(sz == sizeof(struct statfs64_32), "This needs to match");
+
       struct statfs64 host_stat;
       uint64_t Result = ::fstatfs64(fd, &host_stat);
       if (Result != -1) {
@@ -178,7 +180,9 @@ namespace FEXCore::HLE::x32 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(statfs64, [](FEXCore::Core::InternalThreadState *Thread, const char *path, struct statfs64_32 *buf) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(statfs64, [](FEXCore::Core::InternalThreadState *Thread, const char *path, size_t sz, struct statfs64_32 *buf) -> uint64_t {
+      LogMan::Throw::A(sz == sizeof(struct statfs64_32), "This needs to match");
+
       struct statfs host_stat;
       uint64_t Result = Thread->CTX->SyscallHandler->FM.Statfs(path, &host_stat);
       if (Result != -1) {

--- a/External/FEXCore/Source/Interface/HLE/x32/Thread.cpp
+++ b/External/FEXCore/Source/Interface/HLE/x32/Thread.cpp
@@ -239,14 +239,22 @@ namespace FEXCore::HLE::x32 {
     });
 
     REGISTER_SYSCALL_IMPL_X32(sigaltstack, [](FEXCore::Core::InternalThreadState *Thread, const compat_ptr<stack_t32> ss, compat_ptr<stack_t32> old_ss) -> uint64_t {
-      stack_t ss64 = *ss;
+      stack_t ss64{};
       stack_t old64{};
+
+      stack_t *ss64_ptr{};
       stack_t *old64_ptr{};
+
+      if (ss64_ptr) {
+        ss64 = *ss;
+        ss64_ptr = &ss64;
+      }
+
       if (old_ss) {
         old64 = *old_ss;
         old64_ptr = &old64;
       }
-      uint64_t Result = Thread->CTX->SignalDelegation.RegisterGuestSigAltStack(&ss64, old64_ptr);
+      uint64_t Result = Thread->CTX->SignalDelegation.RegisterGuestSigAltStack(ss64_ptr, old64_ptr);
 
       if (Result == 0 && old_ss) {
         *old_ss = old64;

--- a/External/FEXCore/Source/Interface/HLE/x32/Time.cpp
+++ b/External/FEXCore/Source/Interface/HLE/x32/Time.cpp
@@ -31,36 +31,52 @@ namespace FEXCore::HLE::x32 {
     REGISTER_SYSCALL_IMPL_X32(nanosleep, [](FEXCore::Core::InternalThreadState *Thread, const timespec32 *req, timespec32 *rem) -> uint64_t {
       struct timespec req64{};
       struct timespec rem64{};
+
+      struct timespec *rem64_ptr{};
       req64 = *req;
-      rem64 = *rem;
+      if (rem) {
+        rem64 = *rem;
+        rem64_ptr = &rem64;
+      }
       uint64_t Result = ::nanosleep(&req64, &rem64);
-      *rem = rem64;
+      if (rem) {
+        *rem = rem64;
+      }
       SYSCALL_ERRNO();
     });
 
     REGISTER_SYSCALL_IMPL_X32(clock_gettime, [](FEXCore::Core::InternalThreadState *Thread, clockid_t clk_id, timespec32 *tp) -> uint64_t {
       struct timespec tp64{};
-      tp64 = *tp;
       uint64_t Result = ::clock_gettime(clk_id, &tp64);
-      *tp = tp64;
+      if (tp) {
+        *tp = tp64;
+      }
       SYSCALL_ERRNO();
     });
 
     REGISTER_SYSCALL_IMPL_X32(clock_getres, [](FEXCore::Core::InternalThreadState *Thread, clockid_t clk_id, timespec32 *tp) -> uint64_t {
       struct timespec tp64{};
-      tp64 = *tp;
       uint64_t Result = ::clock_getres(clk_id, &tp64);
-      *tp = tp64;
+      if (tp) {
+        *tp = tp64;
+      }
       SYSCALL_ERRNO();
     });
 
     REGISTER_SYSCALL_IMPL_X32(clock_nanosleep, [](FEXCore::Core::InternalThreadState *Thread, clockid_t clockid, int flags, const timespec32 *request, timespec32 *remain) -> uint64_t {
       struct timespec req64{};
       struct timespec rem64{};
+      struct timespec *rem64_ptr{};
+
       req64 = *request;
-      rem64 = *remain;
-      uint64_t Result = ::clock_nanosleep(clockid, flags, &req64, &rem64);
-      *remain = rem64;
+      if (remain) {
+        rem64 = *remain;
+        rem64_ptr = &rem64;
+      }
+      uint64_t Result = ::clock_nanosleep(clockid, flags, &req64, rem64_ptr);
+      if (remain) {
+        *remain = rem64;
+      }
       SYSCALL_ERRNO();
     });
 

--- a/External/FEXCore/Source/Interface/HLE/x32/Types.h
+++ b/External/FEXCore/Source/Interface/HLE/x32/Types.h
@@ -149,20 +149,21 @@ struct cmsghdr32 {
   uint32_t cmsg_len;
   int32_t cmsg_level;
   int32_t cmsg_type;
+  char    cmsg_data[0];
 };
 
 static_assert(std::is_trivial<cmsghdr32>::value, "Needs to be trivial");
 static_assert(sizeof(cmsghdr32) == 12, "Incorrect size");
 
 struct msghdr32 {
-  uint32_t msg_name_ptr;
+  compat_ptr<void> msg_name;
   socklen_t msg_namelen;
 
   compat_ptr<iovec32> msg_iov;
-  uint32_t msg_iovlen;
+  compat_size_t msg_iovlen;
 
-  uint32_t msg_control;
-  uint32_t msg_controllen;
+  compat_ptr<void> msg_control;
+  compat_size_t msg_controllen;
   int32_t msg_flags;
 };
 


### PR DESCRIPTION
fstatfs64 and statfs64 was wrong, the syscall doesn't quite match the
glibc definition

Fixes recvmsg. Specifically the aux data was failing, thus SCM_RIGHTS
wasn't getting passed correctly.

Fixes a couple of time syscalls where their arguments are optional.