### PR TITLE
binfmt_misc interpreter and execve improvements

### DIFF
--- a/External/FEXCore/Source/Interface/HLE/Syscalls.h
+++ b/External/FEXCore/Source/Interface/HLE/Syscalls.h
@@ -2,6 +2,7 @@
 
 #include "Interface/HLE/FileManagement.h"
 
+#include <FEXCore/Config/Config.h>
 #include <FEXCore/Core/Context.h>
 #include <FEXCore/HLE/SyscallHandler.h>
 
@@ -66,6 +67,8 @@ public:
 #ifdef DEBUG_STRACE
   virtual void Strace(FEXCore::HLE::SyscallArguments *Args, uint64_t Ret) = 0;
 #endif
+
+  FEXCore::Config::Value<bool> IsInterpreter{FEXCore::Config::CONFIG_IS_INTERPRETER, 0};
 
 protected:
   std::vector<SyscallFunctionDefinition> Definitions;

--- a/External/FEXCore/include/FEXCore/Config/Config.h
+++ b/External/FEXCore/include/FEXCore/Config/Config.h
@@ -28,6 +28,7 @@ namespace FEXCore::Config {
     CONFIG_OUTPUTLOG,
     CONFIG_BREAK_ON_FRONTEND,
     CONFIG_DUMP_GPRS,
+    CONFIG_IS_INTERPRETER,
   };
 
   enum ConfigCore {

--- a/External/FEXCore/include/FEXCore/Utils/ELFLoader.h
+++ b/External/FEXCore/include/FEXCore/Utils/ELFLoader.h
@@ -76,6 +76,8 @@ public:
   ELFMode GetMode() const { return Mode; }
   size_t GetProgramHeaderCount() const { return ProgramHeaders.size(); }
 
+  static bool IsSupportedELF(std::string const &Filename);
+
 private:
   bool LoadELF(std::string const &Filename);
   bool LoadELF_32();

--- a/Source/Common/ArgumentLoader.cpp
+++ b/Source/Common/ArgumentLoader.cpp
@@ -281,6 +281,14 @@ namespace FEX::ArgLoader {
     ProgramArguments = Parser.parsed_args();
   }
 
+  void LoadWithoutArguments(int _argc, char **_argv) {
+    optparse::OptionParser Parser{};
+    optparse::Values Options = Parser.parse_args(_argc, _argv);
+
+    RemainingArgs = Parser.args();
+    ProgramArguments = Parser.parsed_args();
+  }
+
   std::vector<std::string> Get() {
     return RemainingArgs;
   }

--- a/Source/Common/ArgumentLoader.h
+++ b/Source/Common/ArgumentLoader.h
@@ -20,6 +20,7 @@ namespace FEX::ArgLoader {
     char **argv;
   };
 
+  void LoadWithoutArguments(int _argc, char **_argv);
   std::vector<std::string> Get();
   std::vector<std::string> GetParsedArgs();
 

--- a/Source/Tests/CMakeLists.txt
+++ b/Source/Tests/CMakeLists.txt
@@ -28,7 +28,22 @@ if (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
     WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/bin/
     )
   ")
-  add_custom_target(binfmt_misc
+
+  add_custom_target(binfmt_misc_32
+    COMMAND ${CMAKE_COMMAND} -E
+    echo "Attempting to remove FEX-x86 misc prior to install. Ignore permission denied"
+    COMMAND ${CMAKE_COMMAND} -E
+    echo -1 > /proc/sys/fs/binfmt_misc/FEX-x86 || (exit 0)
+    COMMAND ${CMAKE_COMMAND} -E
+    echo "Attempting to install FEX-x86 misc now."
+    COMMAND ${CMAKE_COMMAND} -E
+      echo
+      ':FEX-x86:M:0:\\x7fELF\\x01\\x01\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x02\\x00\\x03\\x00:\\xff\\xff\\xff\\xff\\xff\\xfe\\xfe\\x00\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xfe\\xff\\xff\\xff:${CMAKE_INSTALL_PREFIX}/bin/${FEX_INTERP}:CF' > /proc/sys/fs/binfmt_misc/register
+    COMMAND ${CMAKE_COMMAND} -E
+    echo "binfmt_misc FEX-x86 installed"
+  )
+
+  add_custom_target(binfmt_misc_64
     COMMAND ${CMAKE_COMMAND} -E
     echo "Attempting to remove FEX-x86_64 misc prior to install. Ignore permission denied"
     COMMAND ${CMAKE_COMMAND} -E
@@ -39,8 +54,13 @@ if (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
       echo
       ':FEX-x86_64:M:0:\\x7fELF\\x02\\x01\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x02\\x00\\x3e\\x00:\\xff\\xff\\xff\\xff\\xff\\xfe\\xfe\\x00\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xfe\\xff\\xff\\xff:${CMAKE_INSTALL_PREFIX}/bin/${FEX_INTERP}:CF' > /proc/sys/fs/binfmt_misc/register
     COMMAND ${CMAKE_COMMAND} -E
-    echo "binfmt_misc FEX installed"
-      )
+    echo "binfmt_misc FEX-x86_64 installed"
+  )
+  add_custom_target(binfmt_misc
+    DEPENDS binfmt_misc_32
+    DEPENDS binfmt_misc_64
+  )
+
 endif()
 
 set(NAME TestHarness)

--- a/Source/Tests/CMakeLists.txt
+++ b/Source/Tests/CMakeLists.txt
@@ -22,6 +22,12 @@ install(TARGETS ${NAME}
     COMPONENT runtime)
 
 if (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+  set(FEX_INTERP FEXInterpreter)
+  install(CODE "
+    EXECUTE_PROCESS(COMMAND ln -sf ${NAME} ${FEX_INTERP}
+    WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/bin/
+    )
+  ")
   add_custom_target(binfmt_misc
     COMMAND ${CMAKE_COMMAND} -E
     echo "Attempting to remove FEX-x86_64 misc prior to install. Ignore permission denied"
@@ -31,7 +37,7 @@ if (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
     echo "Attempting to install FEX-x86_64 misc now."
     COMMAND ${CMAKE_COMMAND} -E
       echo
-      ':FEX-x86_64:M:0:\\x7fELF\\x02\\x01\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x02\\x00\\x3e\\x00:\\xff\\xff\\xff\\xff\\xff\\xfe\\xfe\\x00\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xfe\\xff\\xff\\xff:${CMAKE_INSTALL_PREFIX}/bin/${NAME}:CF' > /proc/sys/fs/binfmt_misc/register
+      ':FEX-x86_64:M:0:\\x7fELF\\x02\\x01\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x02\\x00\\x3e\\x00:\\xff\\xff\\xff\\xff\\xff\\xfe\\xfe\\x00\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xfe\\xff\\xff\\xff:${CMAKE_INSTALL_PREFIX}/bin/${FEX_INTERP}:CF' > /proc/sys/fs/binfmt_misc/register
     COMMAND ${CMAKE_COMMAND} -E
     echo "binfmt_misc FEX installed"
       )


### PR DESCRIPTION
Fixes a bunch of gnarly bugs that crop up due to trying to pass arguments to execve targets.

Adds a symlink FEXInterpreter target that doesn't consume any arguments itself. Necessary since applications could pass arguments that break initialization. We can't safely determine if we are the current executing interpreter otherwise.
Make the assumption that if an application executed through the interpreter will safely call back in to FEXInterpreter once execve is hit.

execve syscall checks if we are executing as an interpreter or not then execute the target application directly, letting the kernel handle the interpreter redirection. This allows us to correctly retain the target application's capabilities.
check out `man capabilities` for all the random features we are forced to inherit from handling this.

Adds x86 binfmt_misc support

Relies on #568