### PR TITLE
Removes Main config loader from test runners

### DIFF
--- a/Source/Tests/IRLoader.cpp
+++ b/Source/Tests/IRLoader.cpp
@@ -98,7 +98,6 @@ int main(int argc, char **argv, char **const envp) {
   LogMan::Msg::InstallHandler(MsgHandler);
 
   FEXCore::Config::Initialize();
-  FEXCore::Config::AddLayer(std::make_unique<FEX::Config::MainLoader>());
   FEXCore::Config::AddLayer(std::make_unique<FEX::ArgLoader::ArgLoader>(argc, argv));
   FEXCore::Config::AddLayer(std::make_unique<FEX::Config::EnvLoader>(envp));
   FEXCore::Config::Load();

--- a/Source/Tests/TestHarness.cpp
+++ b/Source/Tests/TestHarness.cpp
@@ -52,7 +52,6 @@ int main(int argc, char **argv) {
   LogMan::Msg::InstallHandler(MsgHandler);
 
   FEXCore::Config::Initialize();
-  FEXCore::Config::AddLayer(std::make_unique<FEX::Config::MainLoader>());
   FEXCore::Config::AddLayer(std::make_unique<FEX::ArgLoader::ArgLoader>(argc, argv));
   FEXCore::Config::Load();
 

--- a/Source/Tests/TestHarnessRunner.cpp
+++ b/Source/Tests/TestHarnessRunner.cpp
@@ -53,7 +53,6 @@ int main(int argc, char **argv, char **const envp) {
   LogMan::Throw::InstallHandler(AssertHandler);
   LogMan::Msg::InstallHandler(MsgHandler);
   FEXCore::Config::Initialize();
-  FEXCore::Config::AddLayer(std::make_unique<FEX::Config::MainLoader>());
   FEXCore::Config::AddLayer(std::make_unique<FEX::ArgLoader::ArgLoader>(argc, argv));
   FEXCore::Config::AddLayer(std::make_unique<FEX::Config::EnvLoader>(envp));
   FEXCore::Config::Load();


### PR DESCRIPTION
This was accidental and can cause test failures.
Make sure to not load arguments from Main config for these