### PR TITLE
Makes us handle DFL smarter

### DIFF
--- a/External/FEXCore/Source/Interface/Core/SignalDelegator.cpp
+++ b/External/FEXCore/Source/Interface/Core/SignalDelegator.cpp
@@ -184,10 +184,16 @@ namespace FEXCore {
     if (Handler.OldAction.sa_flags & SA_SIGINFO) {
       Handler.OldAction.sa_sigaction(Signal, static_cast<siginfo_t*>(Info), UContext);
     }
-    else if (Handler.OldAction.sa_handler == SIG_DFL) {
-      signal(Signal, SIG_DFL);
+    else if (Handler.OldAction.sa_handler == SIG_IGN ||
+      (Handler.OldAction.sa_handler == SIG_DFL &&
+       Handler.DefaultBehaviour == DEFAULT_IGNORE)) {
+      // Do nothing
     }
-    else if (Handler.OldAction.sa_handler == SIG_IGN) {
+    else if (Handler.OldAction.sa_handler == SIG_DFL &&
+      (Handler.DefaultBehaviour == DEFAULT_COREDUMP ||
+       Handler.DefaultBehaviour == DEFAULT_TERM)) {
+      // Reassign back to DFL and crash
+      signal(Signal, SIG_DFL);
     }
     else {
       Handler.OldAction.sa_handler(Signal);


### PR DESCRIPTION
For the ones that should be IGNORE we can safely ignore them at that
point.
For the ones that have a default behaviour of crashing, just go ahead
and crash.

This was having the fun problem space that if we received an ignore
event, we would remove the fault handler then if the guest registered a
handler it would have never been called.

SIGWINCH specifically is one that defaults to ignore and we need to care
about. If SIGWICH happened before the guest registered a handler then it
would never receive the signal.

The ones that their default behaviour is faulting are fine to uninstall
and then immediately crash, since it is a real crash at that point.