### PR TITLE
Adds support for proper sized GPR->FPR sized conversions

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -3726,25 +3726,56 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
           }
           case IR::OP_FLOAT_FROMGPR_S: {
             auto Op = IROp->C<IR::IROp_Float_FromGPR_S>();
-            if (Op->Header.ElementSize == 8) {
-              double Dst = (double)*GetSrc<int64_t*>(SSAData, Op->Header.Args[0]);
-              memcpy(GDP, &Dst, Op->Header.ElementSize);
-            }
-            else {
-              float Dst = (float)*GetSrc<int32_t*>(SSAData, Op->Header.Args[0]);
-              memcpy(GDP, &Dst, Op->Header.ElementSize);
+
+            uint16_t Conv = (Op->Header.ElementSize << 8) | Op->SrcElementSize;
+            switch (Conv) {
+              case 0x0404: { // Float <- int32_t
+                float Dst = (float)*GetSrc<int32_t*>(SSAData, Op->Header.Args[0]);
+                memcpy(GDP, &Dst, Op->Header.ElementSize);
+                break;
+              }
+              case 0x0408: { // Float <- int64_t
+                float Dst = (float)*GetSrc<int64_t*>(SSAData, Op->Header.Args[0]);
+                memcpy(GDP, &Dst, Op->Header.ElementSize);
+                break;
+              }
+              case 0x0804: { // Double <- int32_t
+                double Dst = (double)*GetSrc<int32_t*>(SSAData, Op->Header.Args[0]);
+                memcpy(GDP, &Dst, Op->Header.ElementSize);
+                break;
+              }
+              case 0x0808: { // Double <- int64_t
+                double Dst = (double)*GetSrc<int64_t*>(SSAData, Op->Header.Args[0]);
+                memcpy(GDP, &Dst, Op->Header.ElementSize);
+                break;
+              }
             }
             break;
           }
           case IR::OP_FLOAT_FROMGPR_U: {
             auto Op = IROp->C<IR::IROp_Float_FromGPR_U>();
-            if (Op->Header.ElementSize == 8) {
-              double Dst = (double)*GetSrc<uint64_t*>(SSAData, Op->Header.Args[0]);
-              memcpy(GDP, &Dst, Op->Header.ElementSize);
-            }
-            else {
-              float Dst = (float)*GetSrc<uint32_t*>(SSAData, Op->Header.Args[0]);
-              memcpy(GDP, &Dst, Op->Header.ElementSize);
+            uint16_t Conv = (Op->Header.ElementSize << 8) | Op->SrcElementSize;
+            switch (Conv) {
+              case 0x0404: { // Float <- int32_t
+                float Dst = (float)*GetSrc<uint32_t*>(SSAData, Op->Header.Args[0]);
+                memcpy(GDP, &Dst, Op->Header.ElementSize);
+                break;
+              }
+              case 0x0408: { // Float <- int64_t
+                float Dst = (float)*GetSrc<uint64_t*>(SSAData, Op->Header.Args[0]);
+                memcpy(GDP, &Dst, Op->Header.ElementSize);
+                break;
+              }
+              case 0x0804: { // Double <- int32_t
+                double Dst = (double)*GetSrc<uint32_t*>(SSAData, Op->Header.Args[0]);
+                memcpy(GDP, &Dst, Op->Header.ElementSize);
+                break;
+              }
+              case 0x0808: { // Double <- int64_t
+                double Dst = (double)*GetSrc<uint64_t*>(SSAData, Op->Header.Args[0]);
+                memcpy(GDP, &Dst, Op->Header.ElementSize);
+                break;
+              }
             }
             break;
           }

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ConversionOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ConversionOps.cpp
@@ -56,11 +56,24 @@ DEF_OP(Float_FromGPR_U) {
 
 DEF_OP(Float_FromGPR_S) {
   auto Op = IROp->C<IR::IROp_Float_FromGPR_S>();
-  if (Op->Header.ElementSize == 8) {
-    scvtf(GetDst(Node).D(), GetReg<RA_64>(Op->Header.Args[0].ID()));
-  }
-  else {
-    scvtf(GetDst(Node).S(), GetReg<RA_32>(Op->Header.Args[0].ID()));
+  uint16_t Conv = (Op->Header.ElementSize << 8) | Op->SrcElementSize;
+  switch (Conv) {
+    case 0x0404: { // Float <- int32_t
+      scvtf(GetDst(Node).S(), GetReg<RA_32>(Op->Header.Args[0].ID()));
+      break;
+    }
+    case 0x0408: { // Float <- int64_t
+      scvtf(GetDst(Node).S(), GetReg<RA_64>(Op->Header.Args[0].ID()));
+      break;
+    }
+    case 0x0804: { // Double <- int32_t
+      scvtf(GetDst(Node).D(), GetReg<RA_32>(Op->Header.Args[0].ID()));
+      break;
+    }
+    case 0x0808: { // Double <- int64_t
+      scvtf(GetDst(Node).D(), GetReg<RA_64>(Op->Header.Args[0].ID()));
+      break;
+    }
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/ConversionOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/ConversionOps.cpp
@@ -56,11 +56,24 @@ DEF_OP(Float_FromGPR_U) {
 
 DEF_OP(Float_FromGPR_S) {
   auto Op = IROp->C<IR::IROp_Float_FromGPR_S>();
-  if (Op->Header.ElementSize == 8) {
-    cvtsi2sd(GetDst(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()));
-  }
-  else {
-    cvtsi2ss(GetDst(Node), GetSrc<RA_32>(Op->Header.Args[0].ID()));
+  uint16_t Conv = (Op->Header.ElementSize << 8) | Op->SrcElementSize;
+  switch (Conv) {
+    case 0x0404: { // Float <- int32_t
+      cvtsi2ss(GetDst(Node), GetSrc<RA_32>(Op->Header.Args[0].ID()));
+      break;
+    }
+    case 0x0408: { // Float <- int64_t
+      cvtsi2ss(GetDst(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()));
+      break;
+    }
+    case 0x0804: { // Double <- int32_t
+      cvtsi2sd(GetDst(Node), GetSrc<RA_32>(Op->Header.Args[0].ID()));
+      break;
+    }
+    case 0x0808: { // Double <- int64_t
+      cvtsi2sd(GetDst(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()));
+      break;
+    }
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -5995,23 +5995,10 @@ void OpDispatchBuilder::CVTGPR_To_FPR(OpcodeArgs) {
 
   size_t GPRSize = GetSrcSize(Op);
 
-  if (GPRSize == 8) {
-    // Source is 64bit
-    if (DstElementSize == 4) {
-      Src = _Bfe(32, 0, Src);
-    }
-  }
-  else {
-    // Source is 32bit and Signed
-    if (DstElementSize == 8 && Signed) {
-      Src = _Sext(32, Src);
-    }
-  }
-
   if (Signed)
-    Src = _Float_FromGPR_S(Src, DstElementSize);
+    Src = _Float_FromGPR_S(DstElementSize, GPRSize, Src);
   else
-    Src = _Float_FromGPR_U(Src, DstElementSize);
+    Src = _Float_FromGPR_U(DstElementSize, GPRSize, Src);
 
   OrderedNode *Dest = LoadSource_WithOpSize(FPRClass, Op, Op->Dest, 16, Op->Flags, -1);
 

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -2882,14 +2882,17 @@
               ],
       "HasDest": true,
       "DestClass": "FPR",
-      "DestSize": "16",
-      "NumElements": "16 / ElementSize",
+      "DestSize": "DstElementSize",
+      "NumElements": "1",
       "SSAArgs": "1",
       "SSANames": [
         "GPR"
       ],
       "HelperArgs": [
-        "uint8_t", "ElementSize"
+        "uint8_t", "DstElementSize"
+      ],
+      "Args": [
+        "uint8_t", "SrcElementSize"
       ]
     },
 
@@ -2900,14 +2903,17 @@
               ],
       "HasDest": true,
       "DestClass": "FPR",
-      "DestSize": "16",
-      "NumElements": "16 / ElementSize",
+      "DestSize": "DstElementSize",
+      "NumElements": "1",
       "SSAArgs": "1",
       "SSANames": [
         "GPR"
       ],
       "HelperArgs": [
-        "uint8_t", "ElementSize"
+        "uint8_t", "DstElementSize"
+      ],
+      "Args": [
+        "uint8_t", "SrcElementSize"
       ]
     },
 

--- a/External/FEXCore/include/FEXCore/IR/IREmitter.h
+++ b/External/FEXCore/include/FEXCore/IR/IREmitter.h
@@ -292,6 +292,12 @@ friend class FEXCore::IR::PassManager;
   IRPair<IROp_Vector_FToF> _Vector_FToF(uint8_t RegisterSize, uint8_t DstElementSize, uint8_t SrcElementSize, OrderedNode *ssa0) {
     return _Vector_FToF(ssa0, SrcElementSize, RegisterSize, DstElementSize);
   }
+  IRPair<IROp_Float_FromGPR_U> _Float_FromGPR_U(uint8_t DstElementSize, uint8_t SrcElementSize, OrderedNode *ssa0) {
+    return _Float_FromGPR_U(ssa0, SrcElementSize, DstElementSize);
+  }
+  IRPair<IROp_Float_FromGPR_S> _Float_FromGPR_S(uint8_t DstElementSize, uint8_t SrcElementSize, OrderedNode *ssa0) {
+    return _Float_FromGPR_S(ssa0, SrcElementSize, DstElementSize);
+  }
   IRPair<IROp_Float_FToF> _Float_FToF(uint8_t DstElementSize, uint8_t SrcElementSize, OrderedNode *ssa0) {
     return _Float_FToF(ssa0, SrcElementSize, DstElementSize);
   }

--- a/unittests/ASM/REP/F3_2A_2.asm
+++ b/unittests/ASM/REP/F3_2A_2.asm
@@ -1,0 +1,23 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "XMM0":  ["0x414243444F800000", "0x5152535455565758"]
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rdx + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [rdx + 8 * 1], rax
+
+movapd xmm0, [rdx + 8 * 0]
+
+; Ensures that a large "negative" 32bit value converts correctly in cvtsi2ss when treated as a 64bit value
+; Upper bits being zero
+mov rax, 0xFFFFFFFF
+cvtsi2ss xmm0, rax
+
+hlt


### PR DESCRIPTION
Both x86 and AArch64 support converting from one sized GPR to another
sized FPR. Expose it in our IR op.

Fixes a bug in CVTSI2SS with a 64bit source and it was treating the
input source as a 32bit value.

eg:
0x0000'0000'FFFF'FFFF was treated as converting to -1 float, which was wrong since it is a 64bit value

Major thanks to d-bub on discord for isolating this to such an easy reproduction case!