### PR TITLE
Have tests that throw a non-HLT SIGSEGV fail

### DIFF
--- a/External/FEXCore/Source/Interface/Context/Context.cpp
+++ b/External/FEXCore/Source/Interface/Context/Context.cpp
@@ -99,6 +99,10 @@ namespace FEXCore::Context {
     CTX->HandleCallback(RIP);
   }
 
+  void RegisterHostSignalHandler(FEXCore::Context::Context *CTX, int Signal, HostSignalDelegatorFunction Func) {
+      CTX->RegisterHostSignalHandler(Signal, Func);
+  }
+
   void RegisterFrontendHostSignalHandler(FEXCore::Context::Context *CTX, int Signal, HostSignalDelegatorFunction Func) {
     CTX->RegisterFrontendHostSignalHandler(Signal, Func);
   }

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -117,6 +117,7 @@ namespace FEXCore::Context {
     void StartGdbServer();
     void StopGdbServer();
     void HandleCallback(uint64_t RIP);
+    void RegisterHostSignalHandler(int Signal, HostSignalDelegatorFunction Func);
     void RegisterFrontendHostSignalHandler(int Signal, HostSignalDelegatorFunction Func);
 
     static void RemoveCodeEntry(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP);

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -286,6 +286,10 @@ namespace FEXCore::Context {
     Thread->CPUBackend->CallbackPtr(Thread, RIP);
   }
 
+  void Context::RegisterHostSignalHandler(int Signal, HostSignalDelegatorFunction Func) {
+      SignalDelegation->RegisterHostSignalHandler(Signal, Func);
+  }
+
   void Context::RegisterFrontendHostSignalHandler(int Signal, HostSignalDelegatorFunction Func) {
     SignalDelegation->RegisterFrontendHostSignalHandler(Signal, Func);
   }

--- a/External/FEXCore/include/FEXCore/Core/Context.h
+++ b/External/FEXCore/include/FEXCore/Core/Context.h
@@ -218,6 +218,7 @@ namespace FEXCore::Context {
 
   void HandleCallback(FEXCore::Context::Context *CTX, uint64_t RIP);
 
+  void RegisterHostSignalHandler(FEXCore::Context::Context *CTX, int Signal, HostSignalDelegatorFunction Func);
   void RegisterFrontendHostSignalHandler(FEXCore::Context::Context *CTX, int Signal, HostSignalDelegatorFunction Func);
 
   FEXCore::Core::InternalThreadState* CreateThread(FEXCore::Context::Context *CTX, FEXCore::Core::CPUState *NewThreadState, uint64_t ParentTID);

--- a/Source/CommonCore/HostFactory.cpp
+++ b/Source/CommonCore/HostFactory.cpp
@@ -58,7 +58,7 @@ namespace HostFactory {
     , CTX {CTX}
     , ThreadState {Thread}
     , IsFallback {Fallback} {
-    FEXCore::Context::RegisterFrontendHostSignalHandler(CTX, SIGSEGV,
+    FEXCore::Context::RegisterHostSignalHandler(CTX, SIGSEGV,
       [](FEXCore::Core::InternalThreadState *Thread, int Signal, void *info, void *ucontext) -> bool {
         auto InternalThread = reinterpret_cast<FEXCore::Core::InternalThreadState*>(Thread);
         HostCore *Core = reinterpret_cast<HostCore*>(InternalThread->CPUBackend.get());
@@ -66,7 +66,7 @@ namespace HostFactory {
       }
     );
 
-    FEXCore::Context::RegisterFrontendHostSignalHandler(CTX, 63, [](FEXCore::Core::InternalThreadState *Thread, int Signal, void *info, void *ucontext) -> bool {
+    FEXCore::Context::RegisterHostSignalHandler(CTX, 63, [](FEXCore::Core::InternalThreadState *Thread, int Signal, void *info, void *ucontext) -> bool {
       return true;
     });
   }

--- a/Source/Tests/TestHarnessRunner.cpp
+++ b/Source/Tests/TestHarnessRunner.cpp
@@ -102,7 +102,7 @@ int main(int argc, char **argv, char **const envp) {
   std::unique_ptr<FEXCore::HLE::SyscallHandler> SyscallHandler{FEX::HLE::CreateHandler(Loader.Is64BitMode() ? FEXCore::Context::OperatingMode::MODE_64BIT : FEXCore::Context::OperatingMode::MODE_32BIT, CTX, SignalDelegation.get())};
 
   bool DidFault = false;
-  SignalDelegation->RegisterFrontendHostSignalHandler(SIGSEGV, [&DidFail](FEXCore::Core::InternalThreadState *Thread, int Signal, void *info, void *ucontext) {
+  SignalDelegation->RegisterFrontendHostSignalHandler(SIGSEGV, [&DidFault](FEXCore::Core::InternalThreadState *Thread, int Signal, void *info, void *ucontext) {
       DidFault = true;
     return false;
   });

--- a/Source/Tests/TestHarnessRunner.cpp
+++ b/Source/Tests/TestHarnessRunner.cpp
@@ -101,9 +101,9 @@ int main(int argc, char **argv, char **const envp) {
   std::unique_ptr<FEX::HLE::SignalDelegator> SignalDelegation = std::make_unique<FEX::HLE::SignalDelegator>();
   std::unique_ptr<FEXCore::HLE::SyscallHandler> SyscallHandler{FEX::HLE::CreateHandler(Loader.Is64BitMode() ? FEXCore::Context::OperatingMode::MODE_64BIT : FEXCore::Context::OperatingMode::MODE_32BIT, CTX, SignalDelegation.get())};
 
-  bool DidFail = false;
+  bool DidFault = false;
   SignalDelegation->RegisterFrontendHostSignalHandler(SIGSEGV, [&DidFail](FEXCore::Core::InternalThreadState *Thread, int Signal, void *info, void *ucontext) {
-    DidFail = true;
+      DidFault = true;
     return false;
   });
 
@@ -119,9 +119,9 @@ int main(int argc, char **argv, char **const envp) {
   // Just re-use compare state. It also checks against the expected values in config.
   FEXCore::Core::CPUState State;
   FEXCore::Context::GetCPUState(CTX, &State);
-  bool Passed = !DidFail && Loader.CompareStates(&State, nullptr);
+  bool Passed = !DidFault && Loader.CompareStates(&State, nullptr);
 
-  LogMan::Msg::I("Faulted? %s", DidFail ? "Yes" : "No");
+  LogMan::Msg::I("Faulted? %s", DidFault ? "Yes" : "No");
   LogMan::Msg::I("Passed? %s", Passed ? "Yes" : "No");
 
   FEXCore::Context::DestroyContext(CTX);

--- a/Source/Tests/TestHarnessRunner.cpp
+++ b/Source/Tests/TestHarnessRunner.cpp
@@ -101,6 +101,12 @@ int main(int argc, char **argv, char **const envp) {
   std::unique_ptr<FEX::HLE::SignalDelegator> SignalDelegation = std::make_unique<FEX::HLE::SignalDelegator>();
   std::unique_ptr<FEXCore::HLE::SyscallHandler> SyscallHandler{FEX::HLE::CreateHandler(Loader.Is64BitMode() ? FEXCore::Context::OperatingMode::MODE_64BIT : FEXCore::Context::OperatingMode::MODE_32BIT, CTX, SignalDelegation.get())};
 
+  bool DidFail = false;
+  SignalDelegation->RegisterFrontendHostSignalHandler(SIGSEGV, [&DidFail](FEXCore::Core::InternalThreadState *Thread, int Signal, void *info, void *ucontext) {
+    DidFail = true;
+    return false;
+  });
+
   FEXCore::Context::SetSignalDelegator(CTX, SignalDelegation.get());
   FEXCore::Context::SetSyscallHandler(CTX, SyscallHandler.get());
   bool Result1 = FEXCore::Context::InitCore(CTX, &Loader);
@@ -113,9 +119,10 @@ int main(int argc, char **argv, char **const envp) {
   // Just re-use compare state. It also checks against the expected values in config.
   FEXCore::Core::CPUState State;
   FEXCore::Context::GetCPUState(CTX, &State);
-  bool Passed = Loader.CompareStates(&State, nullptr);
+  bool Passed = !DidFail && Loader.CompareStates(&State, nullptr);
 
-  LogMan::Msg::I("Passed? %s\n", Passed ? "Yes" : "No");
+  LogMan::Msg::I("Faulted? %s", DidFail ? "Yes" : "No");
+  LogMan::Msg::I("Passed? %s", Passed ? "Yes" : "No");
 
   FEXCore::Context::DestroyContext(CTX);
 


### PR DESCRIPTION
This patch moves HandleSIGSEGV in HostFactory.cpp to a non-frontend host signal handler, then registers its own frontend signal handler to catch unhandled segmentation faults. 

Related issue: #561

Still needs an intentionally failing test to verify, so I'm marking this as a draft for now.