### PR TITLE
Ensure idle wait ref counter is 1 on fork

### DIFF
--- a/External/FEXCore/Source/Interface/Context/Context.cpp
+++ b/External/FEXCore/Source/Interface/Context/Context.cpp
@@ -134,6 +134,9 @@ namespace FEXCore::Context {
       // Setting running to false ensures that when they are shutdown we won't send signals to kill them
       DeadThread->State.RunningEvents.Running = false;
     }
+
+    // We now only have one thread
+    CTX->IdleWaitRefCount = 1;
   }
 
   void SetSignalDelegator(FEXCore::Context::Context *CTX, FEXCore::SignalDelegator *SignalDelegation) {


### PR DESCRIPTION
Once we fork, we no longer have any threads to track in the process.
Ensures we don't spin forever on forked process