### PR TITLE
Have EmulatedFiles support osrelease file

### DIFF
--- a/Source/Tests/LinuxSyscalls/EmulatedFiles/EmulatedFiles.h
+++ b/Source/Tests/LinuxSyscalls/EmulatedFiles/EmulatedFiles.h
@@ -26,7 +26,6 @@ namespace FEX::EmulatedFile {
       std::string cpus_online{};
       std::string cpu_info{};
       using FDReadStringFunc = std::function<int32_t(FEXCore::Context::Context *ctx, int32_t fd, const char *pathname, int32_t flags, mode_t mode)>;
-      std::unordered_set<std::string> EmulatedMap;
       std::unordered_map<std::string, FDReadStringFunc> FDReadCreators;
 
       static int32_t ProcAuxv(FEXCore::Context::Context* ctx, int32_t fd, const char* pathname, int32_t flags, mode_t mode);


### PR DESCRIPTION
This was being checked by an application for kernel version. Which was
seeing too new of a kernel and using things that were unsupported.

Also removes the EmulatedMap which is an unnecessary lookup.