### PR TITLE
Dispatch: ExitFunction InlineConstant & unsynchronized rip

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -829,6 +829,10 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
   }
 
   if (HeaderOp->ShouldInterpret) {
+    // Make sure RIP is syncronized to the context
+    LoadConstant(x0, HeaderOp->Entry);
+    str(x0, MemOperand(STATE, offsetof(FEXCore::Core::ThreadState, State.rip)));
+    
     LoadConstant(x0, ThreadSharedData.InterpreterFallbackHelperAddress);
     br(x0);
   } else {

--- a/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -820,6 +820,22 @@ bool ConstProp::Run(IREmitter *IREmit) {
           break;
         }
 
+        case OP_EXITFUNCTION:
+        {
+          auto Op = IROp->C<IR::IROp_ExitFunction>();
+
+          uint64_t Constant{};
+          if (IREmit->IsValueConstant(Op->NewRIP, &Constant)) {
+            
+            IREmit->SetWriteCursor(CurrentIR.GetNode(Op->NewRIP));
+
+            IREmit->ReplaceNodeArgument(CodeNode, 0, IREmit->_InlineConstant(Constant));
+
+            Changed = true;
+          }
+          break;
+        }
+
         case OP_OR:
         case OP_XOR:
         case OP_AND:


### PR DESCRIPTION
- [x] Support InlineConstants for ExitFunction
- [x] Don't save rip to ctx if not needed

Follow ups:
- [x] Store RIP on exits from the JIT abi. Needs a bit of refactoring on how we handle RIP wrt Load/Store Context
- [x] Recover RIP on signals (depends on the previous item)