### PR TITLE
Disables killpg tests and reenables a few tests

### DIFF
--- a/unittests/POSIX/Disabled_Tests
+++ b/unittests/POSIX/Disabled_Tests
@@ -542,9 +542,6 @@ conformance-interfaces-raise-10000-1.test
 conformance-interfaces-raise-2-1.test
 
 # Signals change this behaviour
-conformance-interfaces-nanosleep-3-2.test
-conformance-behavior-WIFEXITED-1-3.test
-conformance-interfaces-clock_nanosleep-1-5.test
 conformance-interfaces-sigpending-1-1.test
 conformance-interfaces-sigpending-2-1.test
 
@@ -552,8 +549,6 @@ conformance-interfaces-sigpending-2-1.test
 conformance-interfaces-mmap-11-2.test
 conformance-interfaces-munmap-1-1.test
 conformance-interfaces-munmap-1-2.test
-
-conformance-interfaces-killpg-1-2.test # uses rt_sigsuspend
 conformance-interfaces-kill-1-2.test # uses rt_sigtimedwait
 
 # Unstable tests
@@ -569,5 +564,20 @@ conformance-interfaces-mlockall-8-1.test
 
 # Race happy
 conformance-interfaces-nanosleep-1-3.test
+conformance-interfaces-nanosleep-2-1.test
+conformance-interfaces-clock_nanosleep-1-1.test
 conformance-interfaces-clock_nanosleep-1-3.test
 conformance-interfaces-clock_nanosleep-2-2.test
+conformance-interfaces-mmap-13-1.test
+conformance-interfaces-clock_getres-3-1.test
+
+# Sending signals to the process group causes every test to become flakey
+# Need to run these single threaded or change the program group prior to launch
+# !!! DO NOT REENABLE THESE UNTIL WE HAVE THIS IN PLACE IN CI !!!
+conformance-interfaces-killpg-1-1.test
+conformance-interfaces-killpg-1-2.test
+conformance-interfaces-killpg-2-1.test
+conformance-interfaces-killpg-4-1.test
+conformance-interfaces-killpg-5-1.test
+conformance-interfaces-killpg-6-1.test
+conformance-interfaces-killpg-8-1.test

--- a/unittests/POSIX/Known_Failures
+++ b/unittests/POSIX/Known_Failures
@@ -608,6 +608,21 @@ conformance-interfaces-clock_nanosleep-1-3.test
 conformance-interfaces-clock_nanosleep-2-2.test
 
 # these are inconsistent or fail on CI
-nanosleep-2-1.test
 conformance-interfaces-clock_nanosleep-2-1.test
 conformance-interfaces-difftime-1-1.test
+conformance-interfaces-nanosleep-2-1.test
+conformance-interfaces-mmap-13-1.test
+conformance-interfaces-clock_getres-3-1.test
+conformance-interfaces-clock_nanosleep-1-1.test
+conformance-interfaces-clock_nanosleep-1-1.test
+
+# Sending signals to the process group causes every test to become flakey
+# Need to run these single threaded or change the program group prior to launch
+# !!! DO NOT REENABLE THESE UNTIL WE HAVE THIS IN PLACE IN CI !!!
+conformance-interfaces-killpg-1-1.test
+conformance-interfaces-killpg-1-2.test
+conformance-interfaces-killpg-2-1.test
+conformance-interfaces-killpg-4-1.test
+conformance-interfaces-killpg-5-1.test
+conformance-interfaces-killpg-6-1.test
+conformance-interfaces-killpg-8-1.test


### PR DESCRIPTION
killpg has been causing us testing problems for a while now.
As we were running more tests it was becoming more likely to hit a test
doing killpg in the background.

All of the tests run under the same process group so it is a significant
race condition to have these running.
Until we improve CI to somehow work around how killpg works, we just
need to have these disabled.