### PR TITLE
Uninstalls both the signal delegator and logmanager handlers on shutdown

### DIFF
--- a/External/FEXCore/Source/Utils/LogManager.cpp
+++ b/External/FEXCore/Source/Utils/LogManager.cpp
@@ -7,6 +7,7 @@ namespace LogMan {
 namespace Throw {
 std::vector<ThrowHandler> Handlers;
 void InstallHandler(ThrowHandler Handler) { Handlers.emplace_back(Handler); }
+void UnInstallHandlers() { Handlers.clear(); }
 
 [[noreturn]] void M(const char *fmt, va_list args) {
   size_t MsgSize = 1024;
@@ -30,6 +31,7 @@ void InstallHandler(ThrowHandler Handler) { Handlers.emplace_back(Handler); }
 namespace Msg {
 std::vector<MsgHandler> Handlers;
 void InstallHandler(MsgHandler Handler) { Handlers.emplace_back(Handler); }
+void UnInstallHandlers() { Handlers.clear(); }
 
 void M(DebugLevels Level, const char *fmt, va_list args) {
   size_t MsgSize = 1024;

--- a/External/FEXCore/include/FEXCore/Utils/LogManager.h
+++ b/External/FEXCore/include/FEXCore/Utils/LogManager.h
@@ -19,6 +19,7 @@ constexpr DebugLevels MSG_LEVEL = INFO;
 namespace Throw {
 using ThrowHandler = void(*)(char const *Message);
 void InstallHandler(ThrowHandler Handler);
+void UnInstallHandlers();
 
 [[noreturn]] void M(const char *fmt, va_list args);
 
@@ -40,6 +41,7 @@ static inline void A(bool, const char*, ...) {}
 namespace Msg {
 using MsgHandler = void(*)(DebugLevels Level, char const *Message);
 void InstallHandler(MsgHandler Handler);
+void UnInstallHandlers();
 
 void M(DebugLevels Level, const char *fmt, va_list args);
 

--- a/Source/Tests/ELFLoader.cpp
+++ b/Source/Tests/ELFLoader.cpp
@@ -283,6 +283,9 @@ int main(int argc, char **argv, char **const envp) {
 
   FEXCore::Config::Shutdown();
 
+  LogMan::Throw::UnInstallHandlers();
+  LogMan::Msg::UnInstallHandlers();
+
   if (OutputFD != stderr &&
       OutputFD != stdout &&
       OutputFD != nullptr) {

--- a/Source/Tests/ELFLoader.cpp
+++ b/Source/Tests/ELFLoader.cpp
@@ -277,6 +277,8 @@ int main(int argc, char **argv, char **const envp) {
 
   auto ProgramStatus = FEXCore::Context::GetProgramStatus(CTX);
 
+  SyscallHandler.reset();
+  SignalDelegation.reset();
   FEXCore::Context::DestroyContext(CTX);
 
   FEXCore::Config::Shutdown();

--- a/Source/Tests/LinuxSyscalls/SignalDelegator.cpp
+++ b/Source/Tests/LinuxSyscalls/SignalDelegator.cpp
@@ -317,6 +317,21 @@ namespace FEX::HLE {
     }
   }
 
+  SignalDelegator::~SignalDelegator() {
+    for (int i = 0; i < MAX_SIGNALS; ++i) {
+      if (i == 0 ||
+          i == SIGKILL ||
+          i == SIGSTOP ||
+          !HostHandlers[i].Installed
+          ) {
+        continue;
+      }
+      sigaction(i, &HostHandlers[i].OldAction, nullptr);
+      HostHandlers[i].Installed = false;
+    }
+    GlobalDelegator = nullptr;
+  }
+
   void SignalDelegator::RegisterTLSState(FEXCore::Core::InternalThreadState *Thread) {
     ThreadData.Thread = Thread;
 

--- a/Source/Tests/LinuxSyscalls/SignalDelegator.h
+++ b/Source/Tests/LinuxSyscalls/SignalDelegator.h
@@ -22,6 +22,7 @@ namespace FEX::HLE {
     // Returns true if the host handled the signal
     // Arguments are the same as sigaction handler
     SignalDelegator();
+    virtual ~SignalDelegator();
 
     /**
      * @brief Registers an emulated thread's object to a TLS object


### PR DESCRIPTION
Can prevent some crashing.