### PR TITLE
Fixes 64bit ELF loading when LLVM ASAN is used

### DIFF
--- a/External/FEXCore/include/FEXCore/Utils/ELFSymbolDatabase.h
+++ b/External/FEXCore/include/FEXCore/Utils/ELFSymbolDatabase.h
@@ -11,7 +11,7 @@ public:
 
   uint64_t GetElfBase() const;
 
-  void MapMemoryRegions(std::function<void*(uint64_t, uint64_t)> Mapper);
+  void MapMemoryRegions(std::function<void*(uint64_t, uint64_t, bool)> Mapper);
   void WriteLoadableSections(::ELFLoader::ELFContainer::MemoryWriter Writer);
 
   uint64_t DefaultRIP() const;
@@ -37,6 +37,9 @@ private:
   ELFInfo LocalInfo;
   std::vector<ELFInfo*> DynamicELFInfo;
   std::vector<ELFInfo*> InitializationOrder;
+  uint64_t ELFMemorySize{};
+  bool FixedNoReplace {true};
+  void *ELFBase{};
 
   std::unordered_map<std::string, ELFInfo*> NameToELF;
   std::vector<std::string> LibrarySearchPaths;
@@ -53,7 +56,7 @@ private:
 
   bool FindLibraryFile(std::string *Result, const char *Library);
   void FillLibrarySearchPaths();
-  void FillMemoryLayouts();
+  void FillMemoryLayouts(uint64_t DefinedBase);
   void FillInitializationOrder();
   void FillSymbols();
 

--- a/Source/Tests/HarnessHelpers.h
+++ b/Source/Tests/HarnessHelpers.h
@@ -695,8 +695,8 @@ public:
   }
 
   void MapMemoryRegion() override {
-    auto DoMMap = [](uint64_t Address, size_t Size) -> void* {
-      void *Result = mmap(reinterpret_cast<void*>(Address), Size, PROT_READ | PROT_WRITE, MAP_FIXED_NOREPLACE | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    auto DoMMap = [](uint64_t Address, size_t Size, bool FixedNoReplace) -> void* {
+      void *Result = mmap(reinterpret_cast<void*>(Address), Size, PROT_READ | PROT_WRITE, (FixedNoReplace ? MAP_FIXED_NOREPLACE : MAP_FIXED) | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
       LogMan::Throw::A(Result != (void*)~0ULL, "Couldn't mmap");
       return Result;
     };


### PR DESCRIPTION
Instead of hardcoding 64bit dynamic ELF files to 0x1'0000'0000 we
instead calculate the size of the ELF in memory. Then allocate the
ELF base up front.

LLVM ASAN steals a large amount of virtual memory space that intersected
with the original hardcoded range which caused memory allocations to
fail.