### PR TITLE
Minor additions to constant propagation

### DIFF
--- a/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -509,13 +509,13 @@ bool ConstProp::Run(IREmitter *IREmit) {
         IREmit->ReplaceWithConstant(CodeNode, NewConstant);
         Changed = true;
         continue;
-      } else if (Is2CST && (Constant2 & (1ULL << 63))) {
+      } /* else if (Is2CST && (Constant2 & (1ULL << 63))) {
         IREmit->SetWriteCursor(CodeNode);
         auto Sub = IREmit->_Sub(CurrentIR.GetNode(Op->Header.Args[0]), IREmit->_Constant(~Constant2 + 1));
         IREmit->ReplaceAllUsesWith(CodeNode, Sub);
         Changed = true;
         continue;
-      }
+      }*/
 
     break;
     }
@@ -535,13 +535,13 @@ bool ConstProp::Run(IREmitter *IREmit) {
         // SUB with the same value returns zero
         IREmit->ReplaceWithConstant(CodeNode, 0);
         Changed = true;
-      } else if (Is2CST && (Constant2 & (1ULL << 63))) {
+      } /*  else if (Is2CST && (Constant2 & (1ULL << 63))) {
         IREmit->SetWriteCursor(CodeNode);
         auto Add = IREmit->_Add(CurrentIR.GetNode(Op->Header.Args[0]), IREmit->_Constant(~Constant2 + 1));
         IREmit->ReplaceAllUsesWith(CodeNode, Add);
         Changed = true;
         continue;
-      }
+      } */
     break;
     }
     case OP_AND: {

--- a/External/FEXCore/include/FEXCore/IR/IREmitter.h
+++ b/External/FEXCore/include/FEXCore/IR/IREmitter.h
@@ -431,6 +431,10 @@ friend class FEXCore::IR::PassManager;
        auto Op = IROp->C<IR::IROp_Constant>();
        if (Constant) *Constant = Op->Constant;
        return true;
+     } else if (IROp->Op == IR::IROps::OP_INLINECONSTANT) {
+       auto Op = IROp->C<IR::IROp_InlineConstant>();
+       if (Constant) *Constant = Op->Constant;
+       return true;
      }
      return false;
   }


### PR DESCRIPTION
1. Invert add/sub instructions with a negative constant to open up more folds into the operation itself
2. Fold X | ~0ULL -> ~0ULL
3. Fold X | 0ULL -> X
4. Fold X ^ 0ULL -> X 
5. Fold constant select operations