### PR TITLE
More 16bit addressing mode fixes

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Frontend.h
+++ b/External/FEXCore/Source/Interface/Core/Frontend.h
@@ -36,8 +36,6 @@ private:
 
   void BranchTargetInMultiblockRange();
 
-  void DecodeModRM(uint8_t *Displacement, FEXCore::X86Tables::ModRMDecoded ModRM);
-  bool DecodeSIB(uint8_t *Displacement, FEXCore::X86Tables::ModRMDecoded ModRM);
   uint8_t ReadByte();
   uint8_t PeekByte(uint8_t Offset);
   uint64_t ReadData(uint8_t Size);
@@ -69,9 +67,9 @@ private:
   std::set<uint64_t> HasBlocks;
 
   // ModRM rm decoding
-  using DecodeModRMPtr = size_t (FEXCore::Frontend::Decoder::*)(X86Tables::DecodedOperand *Operand, X86Tables::ModRMDecoded ModRM, uint8_t Displacement);
-  size_t DecodeModRM_16(X86Tables::DecodedOperand *Operand, X86Tables::ModRMDecoded ModRM, uint8_t Displacement);
-  size_t DecodeModRM_64(X86Tables::DecodedOperand *Operand, X86Tables::ModRMDecoded ModRM, uint8_t Displacement);
+  using DecodeModRMPtr = void (FEXCore::Frontend::Decoder::*)(X86Tables::DecodedOperand *Operand, X86Tables::ModRMDecoded ModRM);
+  void DecodeModRM_16(X86Tables::DecodedOperand *Operand, X86Tables::ModRMDecoded ModRM);
+  void DecodeModRM_64(X86Tables::DecodedOperand *Operand, X86Tables::ModRMDecoded ModRM);
 
   const std::array<DecodeModRMPtr, 2> DecodeModRMs_Disp {
     &FEXCore::Frontend::Decoder::DecodeModRM_64,

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -4663,6 +4663,12 @@ OrderedNode *OpDispatchBuilder::LoadSource_WithOpSize(FEXCore::IR::RegisterClass
       }
     }
 
+    if (AddrSize < GPRSize) {
+      // If AddrSize == 16 then we need to clear the upper bits
+      // GPRSize will be 32 in this case
+      Src = _Bfe(AddrSize, AddrSize * 8, 0, Src);
+    }
+
     LoadableType = true;
   }
   else {
@@ -4790,6 +4796,12 @@ void OpDispatchBuilder::StoreResult_WithOpSize(FEXCore::IR::RegisterClassType Cl
       else {
         MemStoreDst = _Constant(GPRSize * 8, 0);
       }
+    }
+
+    if (AddrSize < GPRSize) {
+      // If AddrSize == 16 then we need to clear the upper bits
+      // GPRSize will be 32 in this case
+      MemStoreDst = _Bfe(AddrSize, AddrSize * 8, 0, MemStoreDst);
     }
 
     MemStore = true;

--- a/External/FEXCore/Source/Interface/Core/X86Tables/BaseTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/BaseTables.cpp
@@ -198,28 +198,28 @@ void InitializeBaseTables(Context::OperatingMode Mode) {
     {0x0F, 1, X86InstInfo{"",   TYPE_SECONDARY_TABLE_PREFIX, FLAGS_NONE,  0, nullptr}},
 
     // x87 table
-    {0xD8, 8, X86InstInfo{"",   TYPE_X87_TABLE_PREFIX, FLAGS_NONE,        0, nullptr}},
+    {0xD8, 8, X86InstInfo{"",   TYPE_X87_TABLE_PREFIX, FLAGS_MODRM,        0, nullptr}},
 
     // ModRM table
     // MoreBytes field repurposed for valid bits mask
-    {0x80, 1, X86InstInfo{"",   TYPE_GROUP_1, FLAGS_NONE, 0, nullptr}},
-    {0x81, 1, X86InstInfo{"",   TYPE_GROUP_1, FLAGS_NONE, 1, nullptr}},
-    {0x82, 1, X86InstInfo{"",   TYPE_GROUP_1, FLAGS_NONE, 2, nullptr}},
-    {0x83, 1, X86InstInfo{"",   TYPE_GROUP_1, FLAGS_NONE, 3, nullptr}},
-    {0xC0, 1, X86InstInfo{"",   TYPE_GROUP_2, FLAGS_NONE, 0, nullptr}},
-    {0xC1, 1, X86InstInfo{"",   TYPE_GROUP_2, FLAGS_NONE, 1, nullptr}},
-    {0xD0, 1, X86InstInfo{"",   TYPE_GROUP_2, FLAGS_NONE, 2, nullptr}},
-    {0xD1, 1, X86InstInfo{"",   TYPE_GROUP_2, FLAGS_NONE, 3, nullptr}},
-    {0xD2, 1, X86InstInfo{"",   TYPE_GROUP_2, FLAGS_NONE, 4, nullptr}},
-    {0xD3, 1, X86InstInfo{"",   TYPE_GROUP_2, FLAGS_NONE, 5, nullptr}},
-    {0xF6, 1, X86InstInfo{"",   TYPE_GROUP_3, FLAGS_NONE, 0, nullptr}},
-    {0xF7, 1, X86InstInfo{"",   TYPE_GROUP_3, FLAGS_NONE, 1, nullptr}},
-    {0xFE, 1, X86InstInfo{"",   TYPE_GROUP_4, FLAGS_NONE, 0, nullptr}},
-    {0xFF, 1, X86InstInfo{"",   TYPE_GROUP_5, FLAGS_NONE, 0, nullptr}},
+    {0x80, 1, X86InstInfo{"",   TYPE_GROUP_1, FLAGS_MODRM, 0, nullptr}},
+    {0x81, 1, X86InstInfo{"",   TYPE_GROUP_1, FLAGS_MODRM, 1, nullptr}},
+    {0x82, 1, X86InstInfo{"",   TYPE_GROUP_1, FLAGS_MODRM, 2, nullptr}},
+    {0x83, 1, X86InstInfo{"",   TYPE_GROUP_1, FLAGS_MODRM, 3, nullptr}},
+    {0xC0, 1, X86InstInfo{"",   TYPE_GROUP_2, FLAGS_MODRM, 0, nullptr}},
+    {0xC1, 1, X86InstInfo{"",   TYPE_GROUP_2, FLAGS_MODRM, 1, nullptr}},
+    {0xD0, 1, X86InstInfo{"",   TYPE_GROUP_2, FLAGS_MODRM, 2, nullptr}},
+    {0xD1, 1, X86InstInfo{"",   TYPE_GROUP_2, FLAGS_MODRM, 3, nullptr}},
+    {0xD2, 1, X86InstInfo{"",   TYPE_GROUP_2, FLAGS_MODRM, 4, nullptr}},
+    {0xD3, 1, X86InstInfo{"",   TYPE_GROUP_2, FLAGS_MODRM, 5, nullptr}},
+    {0xF6, 1, X86InstInfo{"",   TYPE_GROUP_3, FLAGS_MODRM, 0, nullptr}},
+    {0xF7, 1, X86InstInfo{"",   TYPE_GROUP_3, FLAGS_MODRM, 1, nullptr}},
+    {0xFE, 1, X86InstInfo{"",   TYPE_GROUP_4, FLAGS_MODRM, 0, nullptr}},
+    {0xFF, 1, X86InstInfo{"",   TYPE_GROUP_5, FLAGS_MODRM, 0, nullptr}},
 
     // Group 11
-    {0xC6, 1, X86InstInfo{"",   TYPE_GROUP_11, FLAGS_NONE, 0, nullptr}},
-    {0xC7, 1, X86InstInfo{"",   TYPE_GROUP_11, FLAGS_NONE, 1, nullptr}},
+    {0xC6, 1, X86InstInfo{"",   TYPE_GROUP_11, FLAGS_MODRM, 0, nullptr}},
+    {0xC7, 1, X86InstInfo{"",   TYPE_GROUP_11, FLAGS_MODRM, 1, nullptr}},
 
     // VEX table
     {0xC4, 2, X86InstInfo{"",   TYPE_VEX_TABLE_PREFIX, FLAGS_NONE, 0, nullptr}},

--- a/External/FEXCore/Source/Interface/Core/X86Tables/DDDTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/DDDTables.cpp
@@ -5,37 +5,37 @@ using namespace InstFlags;
 
 void InitializeDDDTables() {
   const U8U8InfoStruct DDDNowOpTable[] = {
-    {0x0C, 1, X86InstInfo{"PI2FW",    TYPE_3DNOW_INST, FLAGS_NONE, 0, nullptr}},
-    {0x0D, 1, X86InstInfo{"PI2FD",    TYPE_3DNOW_INST, FLAGS_NONE, 0, nullptr}},
-    {0x1C, 1, X86InstInfo{"PF2IW",    TYPE_3DNOW_INST, FLAGS_NONE, 0, nullptr}},
-    {0x1D, 1, X86InstInfo{"PF2ID",    TYPE_3DNOW_INST, FLAGS_NONE, 0, nullptr}},
+    {0x0C, 1, X86InstInfo{"PI2FW",    TYPE_3DNOW_INST, FLAGS_MODRM, 0, nullptr}},
+    {0x0D, 1, X86InstInfo{"PI2FD",    TYPE_3DNOW_INST, FLAGS_MODRM, 0, nullptr}},
+    {0x1C, 1, X86InstInfo{"PF2IW",    TYPE_3DNOW_INST, FLAGS_MODRM, 0, nullptr}},
+    {0x1D, 1, X86InstInfo{"PF2ID",    TYPE_3DNOW_INST, FLAGS_MODRM, 0, nullptr}},
 
-    {0x8A, 1, X86InstInfo{"PFNACC",   TYPE_3DNOW_INST, FLAGS_NONE, 0, nullptr}},
-    {0x8E, 1, X86InstInfo{"PFPNACC",  TYPE_3DNOW_INST, FLAGS_NONE, 0, nullptr}},
+    {0x8A, 1, X86InstInfo{"PFNACC",   TYPE_3DNOW_INST, FLAGS_MODRM, 0, nullptr}},
+    {0x8E, 1, X86InstInfo{"PFPNACC",  TYPE_3DNOW_INST, FLAGS_MODRM, 0, nullptr}},
 
-    {0x9A, 1, X86InstInfo{"PFSUB",    TYPE_3DNOW_INST, FLAGS_NONE, 0, nullptr}},
-    {0x9E, 1, X86InstInfo{"PFADD",    TYPE_3DNOW_INST, FLAGS_NONE, 0, nullptr}},
+    {0x9A, 1, X86InstInfo{"PFSUB",    TYPE_3DNOW_INST, FLAGS_MODRM, 0, nullptr}},
+    {0x9E, 1, X86InstInfo{"PFADD",    TYPE_3DNOW_INST, FLAGS_MODRM, 0, nullptr}},
 
-    {0xAA, 1, X86InstInfo{"PFSUBR",   TYPE_3DNOW_INST, FLAGS_NONE, 0, nullptr}},
-    {0xAE, 1, X86InstInfo{"PFACC",    TYPE_3DNOW_INST, FLAGS_NONE, 0, nullptr}},
+    {0xAA, 1, X86InstInfo{"PFSUBR",   TYPE_3DNOW_INST, FLAGS_MODRM, 0, nullptr}},
+    {0xAE, 1, X86InstInfo{"PFACC",    TYPE_3DNOW_INST, FLAGS_MODRM, 0, nullptr}},
 
-    {0xBB, 1, X86InstInfo{"PSWAPD",   TYPE_3DNOW_INST, FLAGS_NONE, 0, nullptr}},
-    {0xBF, 1, X86InstInfo{"PAVGUSB",  TYPE_3DNOW_INST, FLAGS_NONE, 0, nullptr}},
+    {0xBB, 1, X86InstInfo{"PSWAPD",   TYPE_3DNOW_INST, FLAGS_MODRM, 0, nullptr}},
+    {0xBF, 1, X86InstInfo{"PAVGUSB",  TYPE_3DNOW_INST, FLAGS_MODRM, 0, nullptr}},
 
-    {0x90, 1, X86InstInfo{"PFCMPGE",  TYPE_3DNOW_INST, FLAGS_NONE, 0, nullptr}},
-    {0x94, 1, X86InstInfo{"PFMIN",    TYPE_3DNOW_INST, FLAGS_NONE, 0, nullptr}},
-    {0x96, 1, X86InstInfo{"PFRCP",    TYPE_3DNOW_INST, FLAGS_NONE, 0, nullptr}},
-    {0x97, 1, X86InstInfo{"PFRSQRT",  TYPE_3DNOW_INST, FLAGS_NONE, 0, nullptr}},
+    {0x90, 1, X86InstInfo{"PFCMPGE",  TYPE_3DNOW_INST, FLAGS_MODRM, 0, nullptr}},
+    {0x94, 1, X86InstInfo{"PFMIN",    TYPE_3DNOW_INST, FLAGS_MODRM, 0, nullptr}},
+    {0x96, 1, X86InstInfo{"PFRCP",    TYPE_3DNOW_INST, FLAGS_MODRM, 0, nullptr}},
+    {0x97, 1, X86InstInfo{"PFRSQRT",  TYPE_3DNOW_INST, FLAGS_MODRM, 0, nullptr}},
 
-    {0xA0, 1, X86InstInfo{"PFCMPGT",  TYPE_3DNOW_INST, FLAGS_NONE, 0, nullptr}},
-    {0xA4, 1, X86InstInfo{"PFMAX",    TYPE_3DNOW_INST, FLAGS_NONE, 0, nullptr}},
-    {0xA6, 1, X86InstInfo{"PFRCPIT1", TYPE_3DNOW_INST, FLAGS_NONE, 0, nullptr}},
-    {0xA7, 1, X86InstInfo{"PFRSQIT1", TYPE_3DNOW_INST, FLAGS_NONE, 0, nullptr}},
+    {0xA0, 1, X86InstInfo{"PFCMPGT",  TYPE_3DNOW_INST, FLAGS_MODRM, 0, nullptr}},
+    {0xA4, 1, X86InstInfo{"PFMAX",    TYPE_3DNOW_INST, FLAGS_MODRM, 0, nullptr}},
+    {0xA6, 1, X86InstInfo{"PFRCPIT1", TYPE_3DNOW_INST, FLAGS_MODRM, 0, nullptr}},
+    {0xA7, 1, X86InstInfo{"PFRSQIT1", TYPE_3DNOW_INST, FLAGS_MODRM, 0, nullptr}},
 
-    {0xB0, 1, X86InstInfo{"PFCMPEQ",  TYPE_3DNOW_INST, FLAGS_NONE, 0, nullptr}},
-    {0xB4, 1, X86InstInfo{"PFMUL",    TYPE_3DNOW_INST, FLAGS_NONE, 0, nullptr}},
-    {0xB6, 1, X86InstInfo{"PFRCPIT2", TYPE_3DNOW_INST, FLAGS_NONE, 0, nullptr}},
-    {0xB7, 1, X86InstInfo{"PMULHRW",  TYPE_3DNOW_INST, FLAGS_NONE, 0, nullptr}},
+    {0xB0, 1, X86InstInfo{"PFCMPEQ",  TYPE_3DNOW_INST, FLAGS_MODRM, 0, nullptr}},
+    {0xB4, 1, X86InstInfo{"PFMUL",    TYPE_3DNOW_INST, FLAGS_MODRM, 0, nullptr}},
+    {0xB6, 1, X86InstInfo{"PFRCPIT2", TYPE_3DNOW_INST, FLAGS_MODRM, 0, nullptr}},
+    {0xB7, 1, X86InstInfo{"PMULHRW",  TYPE_3DNOW_INST, FLAGS_MODRM, 0, nullptr}},
   };
 
   GenerateTable(DDDNowOps, DDDNowOpTable, sizeof(DDDNowOpTable) / sizeof(DDDNowOpTable[0]));

--- a/External/FEXCore/Source/Interface/Core/X86Tables/SecondaryTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/SecondaryTables.cpp
@@ -6,7 +6,7 @@ using namespace InstFlags;
 void InitializeSecondaryTables(Context::OperatingMode Mode) {
   const U8U8InfoStruct TwoByteOpTable[] = {
     // Instructions
-    {0x00, 1, X86InstInfo{"",           TYPE_GROUP_6, FLAGS_NO_OVERLAY,                                                                                 0, nullptr}},
+    {0x00, 1, X86InstInfo{"",           TYPE_GROUP_6, FLAGS_MODRM | FLAGS_NO_OVERLAY,                                                                                 0, nullptr}},
     {0x01, 1, X86InstInfo{"",           TYPE_GROUP_7, FLAGS_NO_OVERLAY,                                                                                 0, nullptr}},
     // These two load segment register data
     {0x02, 1, X86InstInfo{"LAR",        TYPE_UNDEC, FLAGS_NO_OVERLAY,                                                                                   0, nullptr}},
@@ -20,7 +20,7 @@ void InitializeSecondaryTables(Context::OperatingMode Mode) {
     {0x0A, 1, X86InstInfo{"",           TYPE_INVALID, FLAGS_NO_OVERLAY,                                                                                 0, nullptr}},
     {0x0B, 1, X86InstInfo{"UD2",        TYPE_INST, FLAGS_DEBUG | FLAGS_BLOCK_END | FLAGS_NO_OVERLAY,                                                    0, nullptr}},
     {0x0C, 1, X86InstInfo{"",           TYPE_INVALID, FLAGS_NO_OVERLAY,                                                                                 0, nullptr}},
-    {0x0D, 1, X86InstInfo{"",           TYPE_GROUP_P, FLAGS_NO_OVERLAY,                                                                                 0, nullptr}},
+    {0x0D, 1, X86InstInfo{"",           TYPE_GROUP_P, FLAGS_MODRM | FLAGS_NO_OVERLAY,                                                                                 0, nullptr}},
     {0x0E, 1, X86InstInfo{"FEMMS",      TYPE_INST, FLAGS_BLOCK_END | FLAGS_NO_OVERLAY,                                                            0, nullptr}},
     {0x0F, 1, X86InstInfo{"",           TYPE_3DNOW_TABLE, FLAGS_NO_OVERLAY,                                                                             0, nullptr}},
 

--- a/External/FEXCore/Source/Interface/Core/X86Tables/VEXTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/VEXTables.cpp
@@ -478,25 +478,25 @@ void InitializeVEXTables() {
 
 #define OPD(group, pp, opcode) (((group - TYPE_VEX_GROUP_12) << 4) | (pp << 3) | (opcode))
   const U8U8InfoStruct VEXGroupTable[] = {
-    {OPD(TYPE_VEX_GROUP_12, 1, 0b010), 1, X86InstInfo{"VPSRLW",   TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
-    {OPD(TYPE_VEX_GROUP_12, 1, 0b100), 1, X86InstInfo{"VPSRAW",   TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
-    {OPD(TYPE_VEX_GROUP_12, 1, 0b110), 1, X86InstInfo{"VPSLLW",   TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
+    {OPD(TYPE_VEX_GROUP_12, 1, 0b010), 1, X86InstInfo{"VPSRLW",   TYPE_UNDEC, FLAGS_MODRM, 0, nullptr}},
+    {OPD(TYPE_VEX_GROUP_12, 1, 0b100), 1, X86InstInfo{"VPSRAW",   TYPE_UNDEC, FLAGS_MODRM, 0, nullptr}},
+    {OPD(TYPE_VEX_GROUP_12, 1, 0b110), 1, X86InstInfo{"VPSLLW",   TYPE_UNDEC, FLAGS_MODRM, 0, nullptr}},
 
-    {OPD(TYPE_VEX_GROUP_13, 1, 0b010), 1, X86InstInfo{"VPSRLD",   TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
-    {OPD(TYPE_VEX_GROUP_13, 1, 0b100), 1, X86InstInfo{"VPSRAD",   TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
-    {OPD(TYPE_VEX_GROUP_13, 1, 0b110), 1, X86InstInfo{"VPSLLD",   TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
+    {OPD(TYPE_VEX_GROUP_13, 1, 0b010), 1, X86InstInfo{"VPSRLD",   TYPE_UNDEC, FLAGS_MODRM, 0, nullptr}},
+    {OPD(TYPE_VEX_GROUP_13, 1, 0b100), 1, X86InstInfo{"VPSRAD",   TYPE_UNDEC, FLAGS_MODRM, 0, nullptr}},
+    {OPD(TYPE_VEX_GROUP_13, 1, 0b110), 1, X86InstInfo{"VPSLLD",   TYPE_UNDEC, FLAGS_MODRM, 0, nullptr}},
 
     {OPD(TYPE_VEX_GROUP_14, 1, 0b010), 1, X86InstInfo{"VPSRLQ",   TYPE_INST, FLAGS_MODRM | FLAGS_XMM_FLAGS, 1, nullptr}},
     {OPD(TYPE_VEX_GROUP_14, 1, 0b011), 1, X86InstInfo{"VPSRLDQ",  TYPE_INST, FLAGS_MODRM | FLAGS_XMM_FLAGS, 1, nullptr}},
     {OPD(TYPE_VEX_GROUP_14, 1, 0b110), 1, X86InstInfo{"VPSLLQ",   TYPE_INST, FLAGS_MODRM | FLAGS_XMM_FLAGS, 1, nullptr}},
     {OPD(TYPE_VEX_GROUP_14, 1, 0b111), 1, X86InstInfo{"VPSLLDQ",  TYPE_INST, FLAGS_MODRM | FLAGS_XMM_FLAGS, 1, nullptr}},
 
-    {OPD(TYPE_VEX_GROUP_15, 1, 0b010), 1, X86InstInfo{"VLDMXCSR", TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
-    {OPD(TYPE_VEX_GROUP_15, 1, 0b011), 1, X86InstInfo{"VSTMXCSR", TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
+    {OPD(TYPE_VEX_GROUP_15, 1, 0b010), 1, X86InstInfo{"VLDMXCSR", TYPE_UNDEC, FLAGS_MODRM, 0, nullptr}},
+    {OPD(TYPE_VEX_GROUP_15, 1, 0b011), 1, X86InstInfo{"VSTMXCSR", TYPE_UNDEC, FLAGS_MODRM, 0, nullptr}},
 
-    {OPD(TYPE_VEX_GROUP_17, 0, 0b001), 1, X86InstInfo{"BLSR",     TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
-    {OPD(TYPE_VEX_GROUP_17, 0, 0b010), 1, X86InstInfo{"BLSMSK",   TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
-    {OPD(TYPE_VEX_GROUP_17, 0, 0b011), 1, X86InstInfo{"BLSI",     TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
+    {OPD(TYPE_VEX_GROUP_17, 0, 0b001), 1, X86InstInfo{"BLSR",     TYPE_UNDEC, FLAGS_MODRM, 0, nullptr}},
+    {OPD(TYPE_VEX_GROUP_17, 0, 0b010), 1, X86InstInfo{"BLSMSK",   TYPE_UNDEC, FLAGS_MODRM, 0, nullptr}},
+    {OPD(TYPE_VEX_GROUP_17, 0, 0b011), 1, X86InstInfo{"BLSI",     TYPE_UNDEC, FLAGS_MODRM, 0, nullptr}},
   };
 #undef OPD
 

--- a/External/FEXCore/include/FEXCore/Debug/X86Tables.h
+++ b/External/FEXCore/include/FEXCore/Debug/X86Tables.h
@@ -22,8 +22,8 @@ constexpr uint32_t FLAG_ADDRESS_SIZE  = (1 << 1);
 constexpr uint32_t FLAG_LOCK          = (1 << 2);
 constexpr uint32_t FLAG_LEGACY_PREFIX = (1 << 3);
 constexpr uint32_t FLAG_REX_PREFIX    = (1 << 4);
-constexpr uint32_t FLAG_MODRM_PRESENT = (1 << 5);
-constexpr uint32_t FLAG_SIB_PRESENT   = (1 << 6);
+// Hole where 1 << 5 is
+// Hole where 1 << 6 is
 constexpr uint32_t FLAG_REX_WIDENING  = (1 << 7);
 constexpr uint32_t FLAG_REX_XGPR_B    = (1 << 8);
 constexpr uint32_t FLAG_REX_XGPR_X    = (1 << 9);

--- a/unittests/32Bit_ASM/Primary/Primary_8D.asm
+++ b/unittests/32Bit_ASM/Primary/Primary_8D.asm
@@ -1,0 +1,43 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x4000",
+    "RBX": "0x4000",
+    "RCX": "0x8000",
+    "RDX": "0x9000",
+    "RSI": "0x7FC0",
+    "RSP": "0xFFFF7FC0",
+    "RBP": "0x1"
+  },
+  "Mode": "32BIT"
+}
+%endif
+
+mov eax, 0
+mov ebx, 0
+mov esp, -1
+
+; Specific encoded `lea ax, [0x4000]`
+; Operand size override and address size override
+; Nasm doesn't seem to emit this at all
+db 0x67, 0x66, 0x8d, 0x06, 0x00, 0x40
+
+lea bx, [0xC000]
+lea si, [0x4001]
+
+mov ebp, 0
+; Try to LEA past the 16bits
+lea ebp, [bx + si]
+
+lea bx, [0x4000]
+lea si, [0x4000]
+
+; Address size override and Operand size overrides
+lea cx, [bx + si]
+lea dx, [bx + si + 0x1000]
+lea sp, [bx + si - 64]
+
+; Address size override without operand size override
+lea esi, [bx + si - 64]
+
+hlt


### PR DESCRIPTION
There were some edge cases that weren't quite working in the previous test.
Adds some unit tests to ensure it is working correctly.

One edge case was when 16bit addressing was used with a literal offset in the instruction encoding. The literal would have failed to decode. This was impossible to hit on Linux though.

Another one is when the 16bit address was calculated, it wasn't being properly zext.