### PR TITLE
Adds kernel version check to FEXLoader

### DIFF
--- a/Source/Tests/ELFLoader.cpp
+++ b/Source/Tests/ELFLoader.cpp
@@ -234,6 +234,14 @@ int main(int argc, char **argv, char **const envp) {
 
   FEX::HarnessHelper::ELFCodeLoader Loader{Program, LDPath(), Args, ParsedArgs, envp, &Environment};
 
+  uint32_t KernelVersion = FEX::HLE::SyscallHandler::CalculateHostKernelVersion();
+  if (KernelVersion < FEX::HLE::SyscallHandler::KernelVersion(4, 17) &&
+      !Loader.Is64BitMode()) {
+    // We require 4.17 minimum for MAP_FIXED_NOREPLACE on 32bit ELFs
+    LogMan::Msg::E("FEXLoader requires kernel 4.17 minimum");
+    return -1;
+  }
+
   FEXCore::Context::InitializeStaticTables(Loader.Is64BitMode() ? FEXCore::Context::MODE_64BIT : FEXCore::Context::MODE_32BIT);
   auto CTX = FEXCore::Context::CreateNewContext();
   FEXCore::Context::InitializeContext(CTX);

--- a/Source/Tests/HarnessHelpers.h
+++ b/Source/Tests/HarnessHelpers.h
@@ -361,8 +361,8 @@ namespace FEX::HarnessHelper {
     void MapMemoryRegion() override {
       bool LimitedSize = true;
       auto DoMMap = [](uint64_t Address, size_t Size) -> void* {
-        void *Result = mmap(reinterpret_cast<void*>(Address), Size, PROT_READ | PROT_WRITE, MAP_FIXED_NOREPLACE | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-        LogMan::Throw::A(Result != (void*)~0ULL, "mmap failed");
+        void *Result = mmap(reinterpret_cast<void*>(Address), Size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        LogMan::Throw::A(Result == reinterpret_cast<void*>(Address), "mmap failed");
         return Result;
       };
 

--- a/Source/Tests/LinuxSyscalls/Syscalls.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls.cpp
@@ -67,6 +67,26 @@ SyscallHandler::SyscallHandler(FEXCore::Context::Context *ctx, FEX::HLE::SignalD
   : FM {ctx}
   , SignalDelegation {_SignalDelegation} {
   FEX::HLE::_SyscallHandler = this;
+  HostKernelVersion = CalculateHostKernelVersion();
+}
+
+uint32_t SyscallHandler::CalculateHostKernelVersion() {
+  struct utsname buf{};
+  if (uname(&buf) == -1) {
+    return 0;
+  }
+
+  int32_t Major{};
+  int32_t Minor{};
+  int32_t Patch{};
+  char Tmp{};
+  std::istringstream ss{buf.release};
+  ss >> Major;
+  ss.read(&Tmp, 1);
+  ss >> Minor;
+  ss.read(&Tmp, 1);
+  ss >> Patch;
+  return (Major << 24) | (Minor << 16) | Patch;
 }
 
 uint64_t SyscallHandler::HandleSyscall(FEXCore::Core::InternalThreadState *Thread, FEXCore::HLE::SyscallArguments *Args) {

--- a/Source/Tests/LinuxSyscalls/Syscalls.h
+++ b/Source/Tests/LinuxSyscalls/Syscalls.h
@@ -102,6 +102,13 @@ public:
   FEXCore::Config::Value<uint64_t> ThreadsConfig{FEXCore::Config::CONFIG_EMULATED_CPU_CORES, 1};
   FEXCore::Config::Value<bool> Is64BitMode{FEXCore::Config::CONFIG_IS64BIT_MODE, 0};
 
+  uint32_t GetHostKernelVersion() const { return HostKernelVersion; }
+
+  static uint32_t CalculateHostKernelVersion();
+  static uint32_t KernelVersion(uint32_t Major, uint32_t Minor = 0, uint32_t Patch = 0) {
+    return (Major << 24) | (Minor << 16) | Patch;
+  }
+
 protected:
   std::vector<SyscallFunctionDefinition> Definitions{};
   std::mutex MMapMutex;
@@ -109,6 +116,9 @@ protected:
   // BRK management
   uint64_t DataSpace {};
   uint64_t DataSpaceSize {};
+
+  // (Major << 24) | (Minor << 16) | Patch
+  uint32_t HostKernelVersion{};
 
 private:
 
@@ -121,6 +131,7 @@ private:
   #ifdef DEBUG_STRACE
     void Strace(FEXCore::HLE::SyscallArguments *Args, uint64_t Ret);
   #endif
+
 };
 
 FEX::HLE::SyscallHandler *CreateHandler(FEXCore::Context::OperatingMode Mode,


### PR DESCRIPTION
This will also be used soon to calculate if we can use ioctl32, which syscalls to version against, and our emulated uname version implementation.