### PR TITLE
Frontend, OpDisp: Don't assert on invalid instructions

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -637,6 +637,13 @@ namespace FEXCore::Context {
         Thread->OpDispatcher->StartNewBlock();
 
         uint64_t InstsInBlock = Block.NumInstructions;
+
+        if (Block.HasInvalidInstruction) {
+          uint8_t GPRSize = Config.Is64BitMode ? 8 : 4;
+          Thread->OpDispatcher->_ExitFunction(Thread->OpDispatcher->_Constant(GPRSize * 8, Block.Entry));
+          break;
+        }
+
         for (size_t i = 0; i < InstsInBlock; ++i) {
           FEXCore::X86Tables::X86InstInfo const* TableInfo {nullptr};
           FEXCore::X86Tables::DecodedInst const* DecodedInfo {nullptr};

--- a/External/FEXCore/Source/Interface/Core/Frontend.h
+++ b/External/FEXCore/Source/Interface/Core/Frontend.h
@@ -20,6 +20,7 @@ public:
     uint64_t Entry{};
     uint64_t NumInstructions{};
     FEXCore::X86Tables::DecodedInst *DecodedInstructions;
+    bool HasInvalidInstruction{};
   };
 
   Decoder(FEXCore::Context::Context *ctx);

--- a/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
@@ -269,7 +269,7 @@ bool IRValidation::Run(IREmitter *IREmit) {
     if (HadWarning) {
       Out << "Warnings:" << std::endl << Warnings.str() << std::endl;
     }
-
+   
     LogMan::Msg::E("%s", Out.str().c_str());
   }
 

--- a/unittests/ASM/Multiblock/ReachableInvalidCode.asm
+++ b/unittests/ASM/Multiblock/ReachableInvalidCode.asm
@@ -1,0 +1,21 @@
+%ifdef CONFIG
+{
+  "Match": "All",
+  "RegData": {
+    "RAX": "0x20"
+  }
+}
+%endif
+
+mov rax, 0
+cmp rax, 0
+
+jz finish
+
+; multiblock should gracefully handle these invalid ops
+db 0xf, 0x3B ; invalid opcode here
+
+finish:
+mov rax, 32
+
+hlt


### PR DESCRIPTION
## Overview
Allows multiblock to compile blocks where some paths lead to invalid / unsupported instructions.

## Details
- Moves REX handling to `Decoder::DecodeInstruction` from `HandleOpHeader`
- Makes `HandleOpHeader` and `HandleOp` return false for unhandled cases instead of asserting
- Adds `HasInvalidInstruction` to `DecodedBlocks`
- Updates `DecodeInstructionsAtEntry` to set `HasInvalidInstruction` to true for blocks with invalid instructions, or assert if the entry block as an invalid insn.
- Updates `Context::CompileCode` to not compile blocks with invalid instructions