### PR TITLE
Handle unaligned cmpxchg and cmpxchg8b on ARMv8.1+

### DIFF
--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -170,7 +170,9 @@ if (_M_X86_64)
   list(APPEND SRCS Interface/Core/Interpreter/x86_64Dispatcher.cpp)
 endif()
 if(_M_ARM_64)
-  list(APPEND SRCS Interface/Core/Interpreter/Arm64Dispatcher.cpp)
+  list(APPEND SRCS
+    Interface/Core/ArchHelpers/Arm64.cpp
+    Interface/Core/Interpreter/Arm64Dispatcher.cpp)
 endif()
 
 set (JIT_LIBS )

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64.cpp
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64.cpp
@@ -1,0 +1,841 @@
+#include <FEXCore/Utils/LogManager.h>
+
+#include <atomic>
+#include <stdint.h>
+
+#include <signal.h>
+
+namespace FEXCore::ArchHelpers::Arm64 {
+static uint64_t LoadAcquire64(uint64_t Addr) {
+  std::atomic<uint64_t> *Atom = reinterpret_cast<std::atomic<uint64_t>*>(Addr);
+  return Atom->load(std::memory_order_acquire);
+}
+
+static bool StoreCAS64(uint64_t &Expected, uint64_t Val, uint64_t Addr) {
+  std::atomic<uint64_t> *Atom = reinterpret_cast<std::atomic<uint64_t>*>(Addr);
+  return Atom->compare_exchange_strong(Expected, Val);
+}
+
+static uint32_t LoadAcquire32(uint64_t Addr) {
+  std::atomic<uint32_t> *Atom = reinterpret_cast<std::atomic<uint32_t>*>(Addr);
+  return Atom->load(std::memory_order_acquire);
+}
+
+static bool StoreCAS32(uint32_t &Expected, uint32_t Val, uint64_t Addr) {
+  std::atomic<uint32_t> *Atom = reinterpret_cast<std::atomic<uint32_t>*>(Addr);
+  return Atom->compare_exchange_strong(Expected, Val);
+}
+
+static uint8_t LoadAcquire8(uint64_t Addr) {
+  std::atomic<uint8_t> *Atom = reinterpret_cast<std::atomic<uint8_t>*>(Addr);
+  return Atom->load(std::memory_order_acquire);
+}
+
+static bool StoreCAS8(uint8_t &Expected, uint8_t Val, uint64_t Addr) {
+  std::atomic<uint8_t> *Atom = reinterpret_cast<std::atomic<uint8_t>*>(Addr);
+  return Atom->compare_exchange_strong(Expected, Val);
+}
+
+bool HandleCASPAL(void *_mcontext, void *_info, uint32_t Instr) {
+  mcontext_t* mcontext = reinterpret_cast<mcontext_t*>(_mcontext);
+  siginfo_t* info = reinterpret_cast<siginfo_t*>(_info);
+
+  if (info->si_code != BUS_ADRALN) {
+    // This only handles alignment problems
+    return false;
+  }
+
+  uint32_t Size = (Instr >> 30) & 1;
+
+  uint32_t DesiredReg1 = Instr & 0b11111;
+  uint32_t DesiredReg2 = DesiredReg1 + 1;
+  uint32_t ExpectedReg1 = (Instr >> 16) & 0b11111;
+  uint32_t ExpectedReg2 = ExpectedReg1 + 1;
+  uint32_t AddressReg = (Instr >> 5) & 0b11111;
+
+  if (Size == 0) {
+    // 32bit
+    uint64_t Addr = mcontext->regs[AddressReg];
+
+    uint32_t DesiredLower = mcontext->regs[DesiredReg1];
+    uint32_t DesiredUpper = mcontext->regs[DesiredReg2];
+
+    uint32_t ExpectedLower = mcontext->regs[ExpectedReg1];
+    uint32_t ExpectedUpper = mcontext->regs[ExpectedReg2];
+
+    // Cross-cacheline CAS doesn't work on ARM
+    // It isn't even guaranteed to work on x86
+    // Intel will do a "split lock" which locks the full bus
+    // AMD will tear instead
+    // Both cross-cacheline and cross 16byte both need dual CAS loops that can tear
+    // ARMv8.4 LSE2 solves all atomic issues except cross-cacheline
+
+    uint64_t AlignmentMask = 0b1111;
+    if ((Addr & AlignmentMask) > 8) {
+      uint64_t Alignment = Addr & 0b111;
+      Addr &= ~0b111ULL;
+      uint64_t AddrUpper = Addr + 8;
+
+      // Crosses a 16byte boundary
+      // Need to do 256bit atomic, but since that doesn't exist we need to do a dual CAS loop
+      __uint128_t Mask = ~0ULL;
+      Mask <<= Alignment * 8;
+      __uint128_t NegMask = ~Mask;
+      __uint128_t TmpExpected{};
+      __uint128_t TmpDesired{};
+
+      __uint128_t Desired = DesiredUpper;
+      Desired <<= 32;
+      Desired |= DesiredLower;
+      Desired <<= Alignment * 8;
+
+      __uint128_t Expected = ExpectedUpper;
+      Expected <<= 32;
+      Expected |= ExpectedLower;
+      Expected <<= Alignment * 8;
+
+      while (1) {
+        __uint128_t LoadOrderUpper = LoadAcquire64(AddrUpper);
+        LoadOrderUpper <<= 64;
+        __uint128_t TmpActual = LoadOrderUpper | LoadAcquire64(Addr);
+
+        // Set up expected
+        TmpExpected = TmpActual;
+        TmpExpected &= NegMask;
+        TmpExpected |= Expected;
+
+        // Set up desired
+        TmpDesired = TmpExpected;
+        TmpDesired &= NegMask;
+        TmpDesired |= Desired;
+
+        uint64_t TmpExpectedLower = TmpExpected;
+        uint64_t TmpExpectedUpper = TmpExpected >> 64;
+
+        uint64_t TmpDesiredLower = TmpDesired;
+        uint64_t TmpDesiredUpper = TmpDesired >> 64;
+
+        if (TmpExpected == TmpActual) {
+          if (StoreCAS64(TmpExpectedUpper, TmpDesiredUpper, AddrUpper)) {
+            if (StoreCAS64(TmpExpectedLower, TmpDesiredLower, Addr)) {
+              // Stored successfully
+              return true;
+            }
+            else {
+              // CAS managed to tear, we can't really solve this
+              // Continue down the path to let the guest know values weren't expected
+            }
+          }
+
+          TmpExpected = TmpExpectedUpper;
+          TmpExpected <<= 64;
+          TmpExpected |= TmpExpectedLower;
+        }
+        else {
+          // Mismatch up front
+          TmpExpected = TmpActual;
+        }
+
+        // Not successful
+        // Now we need to check the results to see if we need to try again
+        __uint128_t FailedResultOurBits = TmpExpected & Mask;
+        __uint128_t FailedResultNotOurBits = TmpExpected & NegMask;
+
+        __uint128_t FailedDesiredOurBits = TmpDesired & Mask;
+        __uint128_t FailedDesiredNotOurBits = TmpDesired & NegMask;
+        if ((FailedResultNotOurBits ^ FailedDesiredNotOurBits) != 0) {
+          // If the bits changed that weren't part of our regular CAS then we need to try again
+          continue;
+        }
+        if ((FailedResultOurBits ^ FailedDesiredOurBits) != 0) {
+          // If the bits changed that we were wanting to change then we have failed and can return
+          // We need to extract the bits and return them in EXPECTED
+          uint64_t FailedResult = FailedResultOurBits >> (Alignment * 8);
+          mcontext->regs[ExpectedReg1] = FailedResult & ~0U;
+          mcontext->regs[ExpectedReg2] = FailedResult >> 32;
+          return true;
+        }
+      }
+    }
+    else {
+      // Fits within a 16byte region
+      uint64_t Alignment = Addr & 0b1111;
+      Addr &= ~0b1111ULL;
+      std::atomic<__uint128_t> *Atomic128 = reinterpret_cast<std::atomic<__uint128_t>*>(Addr);
+
+      __uint128_t Mask = ~0ULL;
+      Mask <<= Alignment * 8;
+      __uint128_t NegMask = ~Mask;
+      __uint128_t TmpExpected{};
+      __uint128_t TmpDesired{};
+
+      __uint128_t Desired = (uint64_t)DesiredUpper << 32 | DesiredLower;
+      Desired <<= Alignment * 8;
+
+      __uint128_t Expected = (uint64_t)ExpectedUpper << 32 | ExpectedLower;
+      Expected <<= Alignment * 8;
+
+      while (1) {
+        TmpExpected = Atomic128->load();
+
+        // Set up expected
+        TmpExpected &= NegMask;
+        TmpExpected |= Expected;
+
+        // Set up desired
+        TmpDesired = TmpExpected;
+        TmpDesired &= NegMask;
+        TmpDesired |= Desired;
+
+        bool CASResult = Atomic128->compare_exchange_strong(TmpExpected, TmpDesired);
+        if (CASResult) {
+          // Successful, so we are done
+          return true;
+        }
+        else {
+          // Not successful
+          // Now we need to check the results to see if we need to try again
+          __uint128_t FailedResultOurBits = TmpExpected & Mask;
+          __uint128_t FailedResultNotOurBits = TmpExpected & NegMask;
+
+          __uint128_t FailedDesiredOurBits = TmpDesired & Mask;
+          __uint128_t FailedDesiredNotOurBits = TmpDesired & NegMask;
+          if ((FailedResultNotOurBits ^ FailedDesiredNotOurBits) != 0) {
+            // If the bits changed that weren't part of our regular CAS then we need to try again
+            continue;
+          }
+          if ((FailedResultOurBits ^ FailedDesiredOurBits) != 0) {
+            // If the bits changed that we were wanting to change then we have failed and can return
+            // We need to extract the bits and return them in EXPECTED
+            uint64_t FailedResult = FailedResultOurBits >> (Alignment * 8);
+            mcontext->regs[ExpectedReg1] = FailedResult & ~0U;
+            mcontext->regs[ExpectedReg2] = FailedResult >> 32;
+            return true;
+          }
+        }
+      }
+    }
+  }
+  return false;
+}
+
+bool HandleCASAL(void *_mcontext, void *_info, uint32_t Instr) {
+  mcontext_t* mcontext = reinterpret_cast<mcontext_t*>(_mcontext);
+  siginfo_t* info = reinterpret_cast<siginfo_t*>(_info);
+
+  if (info->si_code != BUS_ADRALN) {
+    // This only handles alignment problems
+    return false;
+  }
+
+  uint32_t Size = 1 << (Instr >> 30);
+
+  uint32_t DesiredReg = Instr & 0b11111;
+  uint32_t ExpectedReg = (Instr >> 16) & 0b11111;
+  uint32_t AddressReg = (Instr >> 5) & 0b11111;
+
+  uint64_t Addr = mcontext->regs[AddressReg];
+
+  // Cross-cacheline CAS doesn't work on ARM
+  // It isn't even guaranteed to work on x86
+  // Intel will do a "split lock" which locks the full bus
+  // AMD will tear instead
+  // Both cross-cacheline and cross 16byte both need dual CAS loops that can tear
+  // ARMv8.4 LSE2 solves all atomic issues except cross-cacheline
+
+  // 8bit can't be unaligned
+  // Only need to handle 16, 32, 64
+  if (Size == 2) {
+    // 16 bit
+    uint64_t AlignmentMask = 0b1111;
+    if ((Addr & AlignmentMask) == 15) {
+      // Address crosses over 16byte or 64byte threshold
+      // Need a dual 8bit CAS loop
+      uint64_t AddrUpper = Addr + 1;
+
+      uint16_t Desired = mcontext->regs[DesiredReg];
+      uint16_t Expected = mcontext->regs[ExpectedReg];
+
+      uint8_t DesiredLower = Desired;
+      uint8_t DesiredUpper = Desired >> 8;
+
+      uint8_t ExpectedLower = Expected;
+      uint8_t ExpectedUpper = Expected >> 8;
+
+      uint8_t ActualUpper{};
+      uint8_t ActualLower{};
+      // Careful ordering here
+      ActualUpper = LoadAcquire8(AddrUpper);
+      ActualLower = LoadAcquire8(Addr);
+      if (ActualUpper == ExpectedUpper &&
+          ActualLower == ExpectedLower) {
+        if (StoreCAS8(ExpectedUpper, DesiredUpper, AddrUpper)) {
+          if (StoreCAS8(ExpectedLower, DesiredLower, Addr)) {
+            // Stored successfully
+            return true;
+          }
+          else {
+            // CAS managed to tear, we can't really solve this
+            // Continue down the path to let the guest know values weren't expected
+          }
+        }
+
+        ActualLower = ExpectedLower;
+        ActualUpper = ExpectedUpper;
+      }
+
+      // If the bits changed that we were wanting to change then we have failed and can return
+      // We need to extract the bits and return them in EXPECTED
+      uint16_t FailedResult = ActualUpper;
+      FailedResult <<= 8;
+      FailedResult |= ActualLower;
+      mcontext->regs[ExpectedReg] = FailedResult;
+      return true;
+    }
+    else {
+      AlignmentMask = 0b111;
+      if ((Addr & AlignmentMask) == 7) {
+        // Crosses 8byte boundary
+        // Needs 128bit CAS
+        // Fits within a 16byte region
+        uint64_t Alignment = Addr & 0b1111;
+        Addr &= ~0b1111ULL;
+        std::atomic<__uint128_t> *Atomic128 = reinterpret_cast<std::atomic<__uint128_t>*>(Addr);
+
+        __uint128_t Mask = ~0U;
+        Mask <<= Alignment * 8;
+        __uint128_t NegMask = ~Mask;
+        __uint128_t TmpExpected{};
+        __uint128_t TmpDesired{};
+
+        __uint128_t Desired = mcontext->regs[DesiredReg] & 0xFFFF;
+        Desired <<= Alignment * 8;
+
+        __uint128_t Expected = mcontext->regs[ExpectedReg] & 0xFFFF;
+        Expected <<= Alignment * 8;
+
+        while (1) {
+          TmpExpected = Atomic128->load();
+
+          // Set up expected
+          TmpExpected &= NegMask;
+          TmpExpected |= Expected;
+
+          // Set up desired
+          TmpDesired = TmpExpected;
+          TmpDesired &= NegMask;
+          TmpDesired |= Desired;
+
+          bool CASResult = Atomic128->compare_exchange_strong(TmpExpected, TmpDesired);
+          if (CASResult) {
+            // Successful, so we are done
+            return true;
+          }
+          else {
+            // Not successful
+            // Now we need to check the results to see if we need to try again
+            __uint128_t FailedResultOurBits = TmpExpected & Mask;
+            __uint128_t FailedResultNotOurBits = TmpExpected & NegMask;
+
+            __uint128_t FailedDesiredOurBits = TmpDesired & Mask;
+            __uint128_t FailedDesiredNotOurBits = TmpDesired & NegMask;
+            if ((FailedResultNotOurBits ^ FailedDesiredNotOurBits) != 0) {
+              // If the bits changed that weren't part of our regular CAS then we need to try again
+              continue;
+            }
+            if ((FailedResultOurBits ^ FailedDesiredOurBits) != 0) {
+              // If the bits changed that we were wanting to change then we have failed and can return
+              // We need to extract the bits and return them in EXPECTED
+              uint32_t FailedResult = FailedResultOurBits >> (Alignment * 8);
+              mcontext->regs[ExpectedReg] = FailedResult;
+              return true;
+            }
+          }
+        }
+      }
+      else {
+        AlignmentMask = 0b11;
+        if ((Addr & AlignmentMask) == 3) {
+          // Crosses 4byte boundary
+          // Needs 64bit CAS
+          uint64_t Alignment = Addr & AlignmentMask;
+          Addr &= ~AlignmentMask;
+
+          uint64_t Mask = 0xFFFF;
+          Mask <<= Alignment * 8;
+
+          uint64_t NegMask = ~Mask;
+
+          uint64_t TmpExpected{};
+          uint64_t TmpDesired{};
+
+          uint64_t Desired = mcontext->regs[DesiredReg] & 0xFFFF;
+          Desired <<= Alignment * 8;
+
+          uint64_t Expected = mcontext->regs[ExpectedReg] & 0xFFFF;
+          Expected <<= Alignment * 8;
+
+          std::atomic<uint64_t> *Atomic = reinterpret_cast<std::atomic<uint64_t>*>(Addr);
+          while (1) {
+            TmpExpected = Atomic->load();
+
+            // Set up expected
+            TmpExpected &= NegMask;
+            TmpExpected |= Expected;
+
+            // Set up desired
+            TmpDesired = TmpExpected;
+            TmpDesired &= NegMask;
+            TmpDesired |= Desired;
+
+            bool CASResult = Atomic->compare_exchange_strong(TmpExpected, TmpDesired);
+            if (CASResult) {
+              // Successful, so we are done
+              return true;
+            }
+            else {
+              // Not successful
+              // Now we need to check the results to see if we can try again
+              uint64_t FailedResultOurBits = TmpExpected & Mask;
+              uint64_t FailedResultNotOurBits = TmpExpected & NegMask;
+
+              uint64_t FailedDesiredOurBits = TmpDesired & Mask;
+              uint64_t FailedDesiredNotOurBits = TmpDesired & NegMask;
+
+              if ((FailedResultNotOurBits ^ FailedDesiredNotOurBits) != 0) {
+                // If the bits changed that weren't part of our regular CAS then we need to try again
+                continue;
+              }
+              if ((FailedResultOurBits ^ FailedDesiredOurBits) != 0) {
+                // If the bits changed that we were wanting to change then we have failed and can return
+                // We need to extract the bits and return them in EXPECTED
+                uint16_t FailedResult = FailedResultOurBits >> (Alignment * 8);
+                mcontext->regs[ExpectedReg] = FailedResult;
+                return true;
+              }
+            }
+          }
+        }
+        else {
+          // Fits within 4byte boundary
+          // Only needs 32bit CAS
+          // Only alignment offset will be 1 here
+          uint64_t Alignment = Addr & AlignmentMask;
+          Addr &= ~AlignmentMask;
+
+          uint32_t Mask = 0xFFFF;
+          Mask <<= Alignment * 8;
+
+          uint32_t NegMask = ~Mask;
+
+          uint32_t TmpExpected{};
+          uint32_t TmpDesired{};
+
+          uint32_t Desired = mcontext->regs[DesiredReg] & 0xFFFF;
+          Desired <<= Alignment * 8;
+
+          uint32_t Expected = mcontext->regs[ExpectedReg] & 0xFFFF;
+          Expected <<= Alignment * 8;
+
+          std::atomic<uint32_t> *Atomic = reinterpret_cast<std::atomic<uint32_t>*>(Addr);
+          while (1) {
+            TmpExpected = Atomic->load();
+
+            // Set up expected
+            TmpExpected &= NegMask;
+            TmpExpected |= Expected;
+
+            // Set up desired
+            TmpDesired = TmpExpected;
+            TmpDesired &= NegMask;
+            TmpDesired |= Desired;
+
+            bool CASResult = Atomic->compare_exchange_strong(TmpExpected, TmpDesired);
+            if (CASResult) {
+              // Successful, so we are done
+              return true;
+            }
+            else {
+              // Not successful
+              // Now we need to check the results to see if we can try again
+              uint32_t FailedResultOurBits = TmpExpected & Mask;
+              uint32_t FailedResultNotOurBits = TmpExpected & NegMask;
+
+              uint32_t FailedDesiredOurBits = TmpDesired & Mask;
+              uint32_t FailedDesiredNotOurBits = TmpDesired & NegMask;
+
+              if ((FailedResultNotOurBits ^ FailedDesiredNotOurBits) != 0) {
+                // If the bits changed that weren't part of our regular CAS then we need to try again
+                continue;
+              }
+              if ((FailedResultOurBits ^ FailedDesiredOurBits) != 0) {
+                // If the bits changed that we were wanting to change then we have failed and can return
+                // We need to extract the bits and return them in EXPECTED
+                uint16_t FailedResult = FailedResultOurBits >> (Alignment * 8);
+                mcontext->regs[ExpectedReg] = FailedResult;
+                return true;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  else if (Size == 4) {
+    // 32bit
+    uint64_t AlignmentMask = 0b1111;
+    if ((Addr & AlignmentMask) > 12) {
+      // Address crosses over 16byte threshold
+      // Needs dual 4 byte CAS loop
+      uint64_t Alignment = Addr & 0b11;
+      Addr &= ~0b11;
+
+      uint64_t AddrUpper = Addr + 4;
+
+      uint64_t Desired = mcontext->regs[DesiredReg] & ~0U;
+      uint64_t Expected = mcontext->regs[ExpectedReg] & ~0U;
+
+      Desired <<= Alignment * 8;
+      Expected <<= Alignment * 8;
+
+      uint64_t Mask = ~0U;
+      Mask <<= Alignment * 8;
+      uint64_t NegMask = ~Mask;
+
+      // Careful ordering here
+      while (1) {
+        uint64_t LoadOrderUpper = LoadAcquire32(AddrUpper);
+        LoadOrderUpper <<= 32;
+        uint64_t TmpActual = LoadOrderUpper | LoadAcquire32(Addr);
+
+        uint64_t TmpExpected = TmpActual;
+        TmpExpected &= NegMask;
+        TmpExpected |= Expected;
+
+        uint64_t TmpDesired = TmpExpected;
+        TmpDesired &= NegMask;
+        TmpDesired |= Desired;
+
+        if (TmpExpected == TmpActual) {
+          uint32_t TmpExpectedLower = TmpExpected;
+          uint32_t TmpExpectedUpper = TmpExpected >> 32;
+
+          uint32_t TmpDesiredLower = TmpDesired;
+          uint32_t TmpDesiredUpper = TmpDesired >> 32;
+
+          if (StoreCAS32(TmpExpectedUpper, TmpDesiredUpper, AddrUpper)) {
+            if (StoreCAS32(TmpExpectedLower, TmpDesiredLower, Addr)) {
+              // Stored successfully
+              return true;
+            }
+            else {
+              // CAS managed to tear, we can't really solve this
+              // Continue down the path to let the guest know values weren't expected
+            }
+          }
+
+          TmpExpected = TmpExpectedUpper;
+          TmpExpected <<= 32;
+          TmpExpected |= TmpExpectedLower;
+        }
+        else {
+          // Mismatch up front
+          TmpExpected = TmpActual;
+        }
+
+        // Not successful
+        // Now we need to check the results to see if we need to try again
+        uint64_t FailedResultOurBits = TmpExpected & Mask;
+        uint64_t FailedResultNotOurBits = TmpExpected & NegMask;
+
+        uint64_t FailedDesiredOurBits = TmpDesired & Mask;
+        uint64_t FailedDesiredNotOurBits = TmpDesired & NegMask;
+        if ((FailedResultNotOurBits ^ FailedDesiredNotOurBits) != 0) {
+          // If the bits changed that weren't part of our regular CAS then we need to try again
+          continue;
+        }
+        if ((FailedResultOurBits ^ FailedDesiredOurBits) != 0) {
+          // If the bits changed that we were wanting to change then we have failed and can return
+          // We need to extract the bits and return them in EXPECTED
+          uint32_t FailedResult = FailedResultOurBits >> (Alignment * 8);
+          mcontext->regs[ExpectedReg] = FailedResult;
+          return true;
+        }
+      }
+    }
+    else {
+      AlignmentMask = 0b111;
+      if ((Addr & AlignmentMask) >= 5) {
+        // Crosses 8byte boundary
+        // Needs 128bit CAS
+        // Fits within a 16byte region
+        uint64_t Alignment = Addr & 0b1111;
+        Addr &= ~0b1111ULL;
+        std::atomic<__uint128_t> *Atomic128 = reinterpret_cast<std::atomic<__uint128_t>*>(Addr);
+
+        __uint128_t Mask = ~0U;
+        Mask <<= Alignment * 8;
+        __uint128_t NegMask = ~Mask;
+        __uint128_t TmpExpected{};
+        __uint128_t TmpDesired{};
+
+        __uint128_t Desired = mcontext->regs[DesiredReg] & ~0U;
+        Desired <<= Alignment * 8;
+
+        __uint128_t Expected = mcontext->regs[ExpectedReg] & ~0U;
+        Expected <<= Alignment * 8;
+
+        while (1) {
+          TmpExpected = Atomic128->load();
+
+          // Set up expected
+          TmpExpected &= NegMask;
+          TmpExpected |= Expected;
+
+          // Set up desired
+          TmpDesired = TmpExpected;
+          TmpDesired &= NegMask;
+          TmpDesired |= Desired;
+
+          bool CASResult = Atomic128->compare_exchange_strong(TmpExpected, TmpDesired);
+          if (CASResult) {
+            // Successful, so we are done
+            return true;
+          }
+          else {
+            // Not successful
+            // Now we need to check the results to see if we need to try again
+            __uint128_t FailedResultOurBits = TmpExpected & Mask;
+            __uint128_t FailedResultNotOurBits = TmpExpected & NegMask;
+
+            __uint128_t FailedDesiredOurBits = TmpDesired & Mask;
+            __uint128_t FailedDesiredNotOurBits = TmpDesired & NegMask;
+            if ((FailedResultNotOurBits ^ FailedDesiredNotOurBits) != 0) {
+              // If the bits changed that weren't part of our regular CAS then we need to try again
+              continue;
+            }
+            if ((FailedResultOurBits ^ FailedDesiredOurBits) != 0) {
+              // If the bits changed that we were wanting to change then we have failed and can return
+              // We need to extract the bits and return them in EXPECTED
+              uint32_t FailedResult = FailedResultOurBits >> (Alignment * 8);
+              mcontext->regs[ExpectedReg] = FailedResult;
+              return true;
+            }
+          }
+        }
+      }
+      else {
+        // Fits within 8byte boundary
+        // Only needs 64bit CAS
+        // Alignments can be [1,5)
+        uint64_t Alignment = Addr & AlignmentMask;
+        Addr &= ~AlignmentMask;
+
+        uint64_t Mask = ~0U;
+        Mask <<= Alignment * 8;
+
+        uint64_t NegMask = ~Mask;
+
+        uint64_t TmpExpected{};
+        uint64_t TmpDesired{};
+
+        uint64_t Desired = mcontext->regs[DesiredReg] & ~0U;
+        Desired <<= Alignment * 8;
+
+        uint64_t Expected = mcontext->regs[ExpectedReg] & ~0U;
+        Expected <<= Alignment * 8;
+
+        std::atomic<uint64_t> *Atomic = reinterpret_cast<std::atomic<uint64_t>*>(Addr);
+        while (1) {
+          TmpExpected = Atomic->load();
+
+          // Set up expected
+          TmpExpected &= NegMask;
+          TmpExpected |= Expected;
+
+          // Set up desired
+          TmpDesired = TmpExpected;
+          TmpDesired &= NegMask;
+          TmpDesired |= Desired;
+
+          bool CASResult = Atomic->compare_exchange_strong(TmpExpected, TmpDesired);
+          if (CASResult) {
+            // Successful, so we are done
+            return true;
+          }
+          else {
+            // Not successful
+            // Now we need to check the results to see if we can try again
+            uint64_t FailedResultOurBits = TmpExpected & Mask;
+            uint64_t FailedResultNotOurBits = TmpExpected & NegMask;
+
+            uint64_t FailedDesiredOurBits = TmpDesired & Mask;
+            uint64_t FailedDesiredNotOurBits = TmpDesired & NegMask;
+
+            if ((FailedResultNotOurBits ^ FailedDesiredNotOurBits) != 0) {
+              // If the bits changed that weren't part of our regular CAS then we need to try again
+              continue;
+            }
+            if ((FailedResultOurBits ^ FailedDesiredOurBits) != 0) {
+              // If the bits changed that we were wanting to change then we have failed and can return
+              // We need to extract the bits and return them in EXPECTED
+              uint32_t FailedResult = FailedResultOurBits >> (Alignment * 8);
+              mcontext->regs[ExpectedReg] = FailedResult;
+              return true;
+            }
+          }
+        }
+      }
+    }
+  }
+  else if (Size == 8) {
+    // 64bit
+    uint64_t AlignmentMask = 0b1111;
+    if ((Addr & AlignmentMask) > 8) {
+      uint64_t Alignment = Addr & 0b111;
+      Addr &= ~0b111ULL;
+      uint64_t AddrUpper = Addr + 8;
+
+      // Crosses a 16byte boundary
+      // Need to do 256bit atomic, but since that doesn't exist we need to do a dual CAS loop
+      __uint128_t Mask = ~0ULL;
+      Mask <<= Alignment * 8;
+      __uint128_t NegMask = ~Mask;
+      __uint128_t TmpExpected{};
+      __uint128_t TmpDesired{};
+
+      __uint128_t Desired = mcontext->regs[DesiredReg];
+      Desired <<= Alignment * 8;
+
+      __uint128_t Expected = mcontext->regs[ExpectedReg];
+      Expected <<= Alignment * 8;
+
+      while (1) {
+        __uint128_t LoadOrderUpper = LoadAcquire64(AddrUpper);
+        LoadOrderUpper <<= 64;
+        __uint128_t TmpActual = LoadOrderUpper | LoadAcquire64(Addr);
+
+        // Set up expected
+        TmpExpected = TmpActual;
+        TmpExpected &= NegMask;
+        TmpExpected |= Expected;
+
+        // Set up desired
+        TmpDesired = TmpExpected;
+        TmpDesired &= NegMask;
+        TmpDesired |= Desired;
+
+        uint64_t TmpExpectedLower = TmpExpected;
+        uint64_t TmpExpectedUpper = TmpExpected >> 64;
+
+        uint64_t TmpDesiredLower = TmpDesired;
+        uint64_t TmpDesiredUpper = TmpDesired >> 64;
+
+        if (TmpExpected == TmpActual) {
+          if (StoreCAS64(TmpExpectedUpper, TmpDesiredUpper, AddrUpper)) {
+            if (StoreCAS64(TmpExpectedLower, TmpDesiredLower, Addr)) {
+              // Stored successfully
+              return true;
+            }
+            else {
+              // CAS managed to tear, we can't really solve this
+              // Continue down the path to let the guest know values weren't expected
+            }
+          }
+
+          TmpExpected = TmpExpectedUpper;
+          TmpExpected <<= 64;
+          TmpExpected |= TmpExpectedLower;
+        }
+        else {
+          // Mismatch up front
+          TmpExpected = TmpActual;
+        }
+
+        // Not successful
+        // Now we need to check the results to see if we need to try again
+        __uint128_t FailedResultOurBits = TmpExpected & Mask;
+        __uint128_t FailedResultNotOurBits = TmpExpected & NegMask;
+
+        __uint128_t FailedDesiredOurBits = TmpDesired & Mask;
+        __uint128_t FailedDesiredNotOurBits = TmpDesired & NegMask;
+        if ((FailedResultNotOurBits ^ FailedDesiredNotOurBits) != 0) {
+          // If the bits changed that weren't part of our regular CAS then we need to try again
+          continue;
+        }
+        if ((FailedResultOurBits ^ FailedDesiredOurBits) != 0) {
+          // If the bits changed that we were wanting to change then we have failed and can return
+          // We need to extract the bits and return them in EXPECTED
+          uint64_t FailedResult = FailedResultOurBits >> (Alignment * 8);
+          mcontext->regs[ExpectedReg] = FailedResult;
+          return true;
+        }
+      }
+    }
+    else {
+      // Fits within a 16byte region
+      uint64_t Alignment = Addr & AlignmentMask;
+      Addr &= ~AlignmentMask;
+      std::atomic<__uint128_t> *Atomic128 = reinterpret_cast<std::atomic<__uint128_t>*>(Addr);
+
+      __uint128_t Mask = ~0ULL;
+      Mask <<= Alignment * 8;
+      __uint128_t NegMask = ~Mask;
+      __uint128_t TmpExpected{};
+      __uint128_t TmpDesired{};
+
+      __uint128_t Desired = mcontext->regs[DesiredReg];
+      Desired <<= Alignment * 8;
+
+      __uint128_t Expected = mcontext->regs[ExpectedReg];
+      Expected <<= Alignment * 8;
+
+      while (1) {
+        TmpExpected = Atomic128->load();
+
+        // Set up expected
+        TmpExpected &= NegMask;
+        TmpExpected |= Expected;
+
+        // Set up desired
+        TmpDesired = TmpExpected;
+        TmpDesired &= NegMask;
+        TmpDesired |= Desired;
+
+        bool CASResult = Atomic128->compare_exchange_strong(TmpExpected, TmpDesired);
+        if (CASResult) {
+          // Successful, so we are done
+          return true;
+        }
+        else {
+          // Not successful
+          // Now we need to check the results to see if we need to try again
+          __uint128_t FailedResultOurBits = TmpExpected & Mask;
+          __uint128_t FailedResultNotOurBits = TmpExpected & NegMask;
+
+          __uint128_t FailedDesiredOurBits = TmpDesired & Mask;
+          __uint128_t FailedDesiredNotOurBits = TmpDesired & NegMask;
+          if ((FailedResultNotOurBits ^ FailedDesiredNotOurBits) != 0) {
+            // If the bits changed that weren't part of our regular CAS then we need to try again
+            continue;
+          }
+          if ((FailedResultOurBits ^ FailedDesiredOurBits) != 0) {
+            // If the bits changed that we were wanting to change then we have failed and can return
+            // We need to extract the bits and return them in EXPECTED
+            uint64_t FailedResult = FailedResultOurBits >> (Alignment * 8);
+            mcontext->regs[ExpectedReg] = FailedResult;
+            return true;
+          }
+
+          // If we got here, that means the CAS failed
+          // NotOurBits didn't change and bits we cared about didn't change
+          ERROR_AND_DIE("Impossible");
+        }
+      }
+    }
+  }
+
+  return false;
+}
+
+}

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <stdint.h>
+
+namespace FEXCore::ArchHelpers::Arm64 {
+  constexpr uint32_t CASPAL_MASK = 0xBF'E0'FC'00;
+  constexpr uint32_t CASPAL_INST = 0x08'60'FC'00;
+
+  constexpr uint32_t CASAL_MASK = 0x3F'E0'FC'00;
+  constexpr uint32_t CASAL_INST = 0x08'E0'FC'00;
+
+  bool HandleCASPAL(void *_mcontext, void *_info, uint32_t Instr);
+  bool HandleCASAL(void *_mcontext, void *_info, uint32_t Instr);
+}

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterClass.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterClass.h
@@ -36,6 +36,8 @@ public:
   using CallbackReturn =  __attribute__((naked)) void(*)(FEXCore::Core::InternalThreadState *Thread, volatile void *Host_RSP);
   CallbackReturn ReturnPtr;
 
+  bool HandleSIGBUS(int Signal, void *info, void *ucontext);
+
 private:
   FEXCore::Context::Context *CTX;
   FEXCore::Core::InternalThreadState *State;

--- a/unittests/ASM/Disabled_Tests
+++ b/unittests/ASM/Disabled_Tests
@@ -23,3 +23,14 @@ Test_Primary/Primary_E9.asm
 Test_X87/D9_F9.asm
 
 Test_X87/D9_F2.asm
+
+# Doesn't support unaligned on armv8.0
+Test_TwoByte/0F_B0_2.asm
+Test_TwoByte/0F_B0_3.asm
+Test_TwoByte/0F_B0_4.asm
+Test_TwoByte/0F_B0_5.asm
+Test_TwoByte/0F_B0_6.asm
+Test_TwoByte/0F_B0_7.asm
+Test_Secondary/09_XX_01_7.asm
+Test_Secondary/09_XX_01_8.asm
+Test_Secondary/09_XX_01_9.asm

--- a/unittests/ASM/Secondary/09_XX_01_7.asm
+++ b/unittests/ASM/Secondary/09_XX_01_7.asm
@@ -1,0 +1,39 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x4141414180000000",
+    "RDX": "0x41414141FFFFFFFF",
+    "RBX": "0xFFFFFFFF41424344",
+    "RCX": "0xFFFFFFFF51525354",
+    "R13": "0x5152535441424344",
+    "R14": "0x1"
+  }
+}
+%endif
+
+; Within 16 byte region but unaligned
+mov r15, 0xe0000007
+
+mov rax, 0xFFFFFFFF80000000
+mov [r15 + 8 * 0], rax
+
+mov r14, 0
+; Expected
+mov rax, 0x4141414180000000
+mov rdx, 0x41414141FFFFFFFF
+
+; Desired
+mov rbx, 0xFFFFFFFF41424344
+mov rcx, 0xFFFFFFFF51525354
+
+cmpxchg8b [r15]
+
+; Set r14 to 1 if if the memory location was expected
+setz r14b
+
+; Memory will now be set to the register data
+; EDX:EAX will be the original data
+
+; Check memory location to ensure it contains what we want
+mov r13, [r15 + 8 * 0]
+hlt

--- a/unittests/ASM/Secondary/09_XX_01_8.asm
+++ b/unittests/ASM/Secondary/09_XX_01_8.asm
@@ -1,0 +1,39 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x4141414180000000",
+    "RDX": "0x41414141FFFFFFFF",
+    "RBX": "0xFFFFFFFF41424344",
+    "RCX": "0xFFFFFFFF51525354",
+    "R13": "0x5152535441424344",
+    "R14": "0x1"
+  }
+}
+%endif
+
+; Spans 16byte boundary and unaligned
+mov r15, 0xe0000009
+
+mov rax, 0xFFFFFFFF80000000
+mov [r15 + 8 * 0], rax
+
+mov r14, 0
+; Expected
+mov rax, 0x4141414180000000
+mov rdx, 0x41414141FFFFFFFF
+
+; Desired
+mov rbx, 0xFFFFFFFF41424344
+mov rcx, 0xFFFFFFFF51525354
+
+cmpxchg8b [r15]
+
+; Set r14 to 1 if if the memory location was expected
+setz r14b
+
+; Memory will now be set to the register data
+; EDX:EAX will be the original data
+
+; Check memory location to ensure it contains what we want
+mov r13, [r15 + 8 * 0]
+hlt

--- a/unittests/ASM/Secondary/09_XX_01_9.asm
+++ b/unittests/ASM/Secondary/09_XX_01_9.asm
@@ -1,0 +1,39 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x4141414180000000",
+    "RDX": "0x41414141FFFFFFFF",
+    "RBX": "0xFFFFFFFF41424344",
+    "RCX": "0xFFFFFFFF51525354",
+    "R13": "0x5152535441424344",
+    "R14": "0x1"
+  }
+}
+%endif
+
+; Spans 64byte boundary and unaligned
+mov r15, 0xe000003F
+
+mov rax, 0xFFFFFFFF80000000
+mov [r15 + 8 * 0], rax
+
+mov r14, 0
+; Expected
+mov rax, 0x4141414180000000
+mov rdx, 0x41414141FFFFFFFF
+
+; Desired
+mov rbx, 0xFFFFFFFF41424344
+mov rcx, 0xFFFFFFFF51525354
+
+cmpxchg8b [r15]
+
+; Set r14 to 1 if if the memory location was expected
+setz r14b
+
+; Memory will now be set to the register data
+; EDX:EAX will be the original data
+
+; Check memory location to ensure it contains what we want
+mov r13, [r15 + 8 * 0]
+hlt

--- a/unittests/ASM/TwoByte/0F_B0_3.asm
+++ b/unittests/ASM/TwoByte/0F_B0_3.asm
@@ -1,0 +1,98 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x414243444546FF48",
+    "RBX": "0x51525354FFFF5758",
+    "RCX": "0xFFFFFFFF65666768",
+    "RDX": "0xFFFFFFFFFFFFFFFF",
+    "RBP": "0x4748",
+    "RSI": "0x55565758",
+    "RDI": "0x6162636465666768",
+    "RSP": "0x7172737475767778",
+    "R8": "0x7172737475767778"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+; Offset everything by 1 byte
+; Everything stays within 16byte boundary but unaligned
+mov r10, 0xe0000001
+
+mov rax, 0x4142434445464748
+mov [r10 + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [r10 + 8 * 1], rax
+mov rax, 0x6162636465666768
+mov [r10 + 8 * 2], rax
+mov rax, 0x7172737475767778
+mov [r10 + 8 * 3], rax
+
+mov rax, 0
+mov [r10 + 8 * 4], rax
+mov [r10 + 8 * 5], rax
+mov [r10 + 8 * 6], rax
+mov [r10 + 8 * 7], rax
+mov [r10 + 8 * 8], rax
+
+; False
+mov rax, 0
+mov rcx, 0xFF
+cmpxchg [r10 + 8 * 0 + 0], cl
+mov [r10 + 8 * 4 + 0], al
+
+; True
+mov rax, 0x47
+mov rcx, 0xFF
+cmpxchg [r10 + 8 * 0 + 1], cl
+mov [r10 + 8 * 4 + 1], al
+
+; False
+mov rax, 0
+mov rcx, 0xFFFF
+cmpxchg [r10 + 8 * 1 + 0], cx
+mov [r10 + 8 * 5 + 0], ax
+
+; True
+mov rax, 0x5556
+mov rcx, 0xFFFF
+cmpxchg [r10 + 8 * 1 + 2], cx
+mov [r10 + 8 * 5 + 2], ax
+
+; False
+mov rax, 0
+mov rcx, 0xFFFFFFFF
+cmpxchg [r10 + 8 * 2 + 0], ecx
+mov [r10 + 8 * 6 + 0], eax
+
+; True
+mov rax, 0x61626364
+mov rcx, 0xFFFFFFFF
+cmpxchg [r10 + 8 * 2 + 4], ecx ; Wrong
+mov [r10 + 8 * 6 + 4], eax
+
+; False
+mov rax, 0
+mov rcx, 0xFFFFFFFFFFFFFFFF
+cmpxchg [r10 + 8 * 3 + 0], rcx
+mov [r10 + 8 * 7 + 0], rax
+
+; True
+mov rax, 0x7172737475767778
+mov rcx, 0xFFFFFFFFFFFFFFFF
+cmpxchg [r10 + 8 * 3 + 0], rcx
+mov [r10 + 8 * 8], rax
+
+mov rax, [r10 + 8 * 0]
+mov rbx, [r10 + 8 * 1]
+mov rcx, [r10 + 8 * 2]
+mov rdx, [r10 + 8 * 3]
+mov rbp, [r10 + 8 * 4]
+mov rsi, [r10 + 8 * 5]
+mov rdi, [r10 + 8 * 6]
+mov rsp, [r10 + 8 * 7]
+mov r8, [r10 + 8 * 8]
+
+hlt

--- a/unittests/ASM/TwoByte/0F_B0_4.asm
+++ b/unittests/ASM/TwoByte/0F_B0_4.asm
@@ -1,0 +1,100 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x414243444546FF48",
+    "RBX": "0x51525354FFFF5758",
+    "RCX": "0xFFFFFFFF65666768",
+    "RDX": "0xFFFFFFFFFFFFFFFF",
+    "RBP": "0x4748",
+    "RSI": "0x55565758",
+    "RDI": "0x6162636465666768",
+    "RSP": "0x7172737475767778",
+    "R8": "0x7172737475767778"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+; Offset everything by 15 bytes
+mov r10, 0xe000000f
+
+mov rax, 0x4142434445464748
+mov [r10 + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [r10 + 8 * 1], rax
+mov rax, 0x6162636465666768
+mov [r10 + 8 * 2], rax
+mov rax, 0x7172737475767778
+mov [r10 + 8 * 3], rax
+
+mov rax, 0
+mov [r10 + 8 * 4], rax
+mov [r10 + 8 * 5], rax
+mov [r10 + 8 * 6], rax
+mov [r10 + 8 * 7], rax
+mov [r10 + 8 * 8], rax
+
+; False
+mov rax, 0
+mov rcx, 0xFF
+cmpxchg [r10 + 8 * 0 + 0], cl
+mov [r10 + 8 * 4 + 0], al
+
+; True
+mov rax, 0x47
+mov rcx, 0xFF
+cmpxchg [r10 + 8 * 0 + 1], cl
+mov [r10 + 8 * 4 + 1], al
+
+; False
+mov rax, 0
+mov rcx, 0xFFFF
+cmpxchg [r10 + 8 * 1 + 0], cx
+mov [r10 + 8 * 5 + 0], ax
+
+; True
+mov rax, 0x5556
+mov rcx, 0xFFFF
+cmpxchg [r10 + 8 * 1 + 2], cx
+mov [r10 + 8 * 5 + 2], ax
+
+; False
+mov rax, 0
+mov rcx, 0xFFFFFFFF
+cmpxchg [r10 + 8 * 2 + 0], ecx
+mov [r10 + 8 * 6 + 0], eax
+
+; True
+mov rax, 0x61626364
+mov rcx, 0xFFFFFFFF
+cmpxchg [r10 + 8 * 2 + 4], ecx
+mov [r10 + 8 * 6 + 4], eax
+
+; False
+mov rax, 0
+mov rcx, 0xFFFFFFFFFFFFFFFF
+cmpxchg [r10 + 8 * 3 + 0], rcx
+mov [r10 + 8 * 7 + 0], rax
+
+; True
+mov rax, 0x7172737475767778
+mov rcx, 0xFFFFFFFFFFFFFFFF
+cmpxchg [r10 + 8 * 3 + 0], rcx
+mov [r10 + 8 * 8], rax
+
+mov rax, [r10 + 8 * 0]
+mov rbx, [r10 + 8 * 1]
+mov rcx, [r10 + 8 * 2]
+mov rdx, [r10 + 8 * 3]
+mov rbp, [r10 + 8 * 4]
+
+mov rsi, [r10 + 8 * 5]
+mov rdi, [r10 + 8 * 6]
+
+mov rsp, [r10 + 8 * 7]
+mov r8, [r10 + 8 * 8]
+
+hlt
+

--- a/unittests/ASM/TwoByte/0F_B0_5.asm
+++ b/unittests/ASM/TwoByte/0F_B0_5.asm
@@ -1,0 +1,144 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x4142434445464748",
+    "RBX": "0x5152535455FFFF58",
+    "RCX": "0x616263FFFF666768",
+    "RDX": "0xFF72737475767778",
+    "RBP": "0x81828384858687FF",
+    "RSI": "0xB1B2B3B4B5B6B7B8",
+    "RDI": "0xC1C2C3C4C5C6C7C8",
+    "RSP": "0xFF42434445464748",
+    "R8":  "0x51525354555657FF",
+    "R9":  "0x6465646556574647",
+    "R11": "0x0000000000005841",
+    "R12": "0xC8B1A89188718871"
+  }
+}
+%endif
+
+mov r10, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [r10 + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [r10 + 8 * 1], rax
+mov rax, 0x6162636465666768
+mov [r10 + 8 * 2], rax
+mov rax, 0x7172737475767778
+mov [r10 + 8 * 3], rax
+mov rax, 0x8182838485868788
+mov [r10 + 8 * 4], rax
+mov rax, 0x9192939495969798
+mov [r10 + 8 * 5], rax
+mov rax, 0xA1A2A3A4A5A6A7A8
+mov [r10 + 8 * 6], rax
+mov rax, 0xB1B2B3B4B5B6B7B8
+mov [r10 + 8 * 7], rax
+mov rax, 0xC1C2C3C4C5C6C7C8
+mov [r10 + 8 * 8], rax
+
+mov rax, 0
+mov [r10 + 8 * 9], rax
+mov [r10 + 8 * 10], rax
+mov [r10 + 8 * 11], rax
+mov [r10 + 8 * 12], rax
+mov [r10 + 8 * 13], rax
+
+mov rax, 0x4142434445464748
+mov [r10 + 8 * 15], rax
+mov rax, 0x5152535455565758
+mov [r10 + 8 * 16], rax
+
+; 16bit unaligned edges test
+; Offsets   | Test                                |
+; =============================================================
+; 1         | Misaligned inside 32bit region      | 32bit CAS
+; 3         | Misaligned through to 64bit region  | 64bit CAS
+; 7         | Misaligned through to 128bit region | 128bit CAS
+; 15        | Misaligned through to 256bit region | Dual 8bit/64bit CAS *CAN TEAR*
+; 63        | Misaligned across 64byte cachelines | Dual 8bit/64bit CAS *CAN TEAR*
+
+; Offset 1
+; False
+mov rax, 0
+mov rcx, 0xFFFF
+cmpxchg [r10 + 8 * 0 + 1], cx
+mov [r10 + 8 * 9 + 0], ax
+
+; True
+mov rax, 0x5657
+mov rcx, 0xFFFF
+cmpxchg [r10 + 8 * 1 + 1], cx
+mov [r10 + 8 * 9 + 2], ax
+
+; Offset 3
+; False
+mov rax, 0
+mov rcx, 0xFFFF
+cmpxchg [r10 + 8 * 2 + 3], cx
+mov [r10 + 8 * 9 + 4], ax
+
+; True
+mov rax, 0x6465
+mov rcx, 0xFFFF
+cmpxchg [r10 + 8 * 2 + 3], cx
+mov [r10 + 8 * 9 + 6], ax
+
+; Offset 7
+; False
+mov rax, 0
+mov rcx, 0xFFFF
+cmpxchg [r10 + 8 * 3 + 7], cx
+mov [r10 + 8 * 10 + 0], ax
+
+; True
+mov rax, 0x8871
+mov rcx, 0xFFFF
+cmpxchg [r10 + 8 * 3 + 7], cx
+mov [r10 + 8 * 10 + 2], ax
+
+; Offset 15
+; False
+mov rax, 0
+mov rcx, 0xFFFF
+cmpxchg [r10 + 8 * 4 + 15], cx
+mov [r10 + 8 * 10 + 4], ax
+
+; True
+mov rax, 0x8871
+mov rcx, 0xFFFF
+cmpxchg [r10 + 8 * 4 + 15], cx
+mov [r10 + 8 * 10 + 6], ax
+
+; Offset 63
+; False
+mov rax, 0
+mov rcx, 0xFFFF
+cmpxchg [r10 + 8 * 7 + 7], cx
+mov [r10 + 8 * 10 + 6], ax
+
+; True
+mov rax, 0x5841
+mov rcx, 0xFFFF
+cmpxchg [r10 + 8 * 15 + 7], cx
+mov [r10 + 8 * 11 + 0], ax
+
+mov rax, [r10 + 8 * 0]
+mov rbx, [r10 + 8 * 1]
+mov rcx, [r10 + 8 * 2]
+mov rdx, [r10 + 8 * 3]
+mov rbp, [r10 + 8 * 4]
+
+mov rsi, [r10 + 8 * 7]
+mov rdi, [r10 + 8 * 8]
+
+mov rsp, [r10 + 8 * 15]
+mov r8, [r10 + 8 * 16]
+
+mov r9, [r10 + 8 * 9]
+mov r12, [r10 + 8 * 10]
+mov r11, [r10 + 8 * 11]
+
+hlt
+

--- a/unittests/ASM/TwoByte/0F_B0_6.asm
+++ b/unittests/ASM/TwoByte/0F_B0_6.asm
@@ -1,0 +1,127 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x414243ffffffff48",
+    "RBX": "0x5152535455565758",
+    "RCX": "0xffffff6465666768",
+    "RDX": "0x71727374757677ff",
+    "RBP": "0xffffff8485868788",
+    "RSI": "0xffffffb4b5b6b7b8",
+    "RDI": "0xc1c2c3c4c5c6c7ff",
+    "RSP": "0x4445464744454647",
+    "R8":  "0x7861626378616263",
+    "R9":  "0x9881828398818283",
+    "R10": "0xc8b1b2b3c8b1b2b3"
+  }
+}
+%endif
+
+mov r10, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [r10 + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [r10 + 8 * 1], rax
+mov rax, 0x6162636465666768
+mov [r10 + 8 * 2], rax
+mov rax, 0x7172737475767778
+mov [r10 + 8 * 3], rax
+mov rax, 0x8182838485868788
+mov [r10 + 8 * 4], rax
+mov rax, 0x9192939495969798
+mov [r10 + 8 * 5], rax
+mov rax, 0xA1A2A3A4A5A6A7A8
+mov [r10 + 8 * 6], rax
+mov rax, 0xB1B2B3B4B5B6B7B8
+mov [r10 + 8 * 7], rax
+mov rax, 0xC1C2C3C4C5C6C7C8
+mov [r10 + 8 * 8], rax
+
+mov rax, 0
+mov [r10 + 8 * 9], rax
+mov [r10 + 8 * 10], rax
+mov [r10 + 8 * 11], rax
+mov [r10 + 8 * 12], rax
+mov [r10 + 8 * 13], rax
+
+mov rax, 0x4142434445464748
+mov [r10 + 8 * 15], rax
+mov rax, 0x5152535455565758
+mov [r10 + 8 * 16], rax
+
+; 32bit unaligned edges test
+; Offsets       | Test                                |
+; =============================================================
+; 1,2,3         | Misaligned through to 64bit region  | 64bit CAS
+; 5,6,7,9,10,11 | Misaligned through to 128bit region | 128bit CAS
+; 13,14,15      | Misaligned through to 256bit region | Dual 32bit/64bit CAS *CAN TEAR*
+; 61,62,63      | Misaligned across 64byte cachelines | Dual 32bit/64bit CAS *CAN TEAR*
+
+; Offset 1
+; False
+mov rax, 0
+mov rcx, 0xFFFFFFFF
+cmpxchg [r10 + 8 * 0 + 1], ecx
+mov [r10 + 8 * 9 + 0], eax
+
+; True
+mov rax, 0x44454647
+mov rcx, 0xFFFFFFFF
+cmpxchg [r10 + 8 * 0 + 1], ecx
+mov [r10 + 8 * 9 + 4], eax
+
+; Offset 5
+; False
+mov rax, 0
+mov rcx, 0xFFFFFFFF
+cmpxchg [r10 + 8 * 2 + 5], ecx
+mov [r10 + 8 * 10 + 0], eax
+
+; True
+mov rax, 0x78616263
+mov rcx, 0xFFFFFFFF
+cmpxchg [r10 + 8 * 2 + 5], ecx
+mov [r10 + 8 * 10 + 4], eax
+
+; Offset 13
+; False
+mov rax, 0
+mov rcx, 0xFFFFFFFF
+cmpxchg [r10 + 8 * 4 + 5], ecx
+mov [r10 + 8 * 11 + 0], eax
+
+; True
+mov rax, 0x98818283
+mov rcx, 0xFFFFFFFF
+cmpxchg [r10 + 8 * 4 + 5], ecx
+mov [r10 + 8 * 11 + 4], eax
+
+; Offset 61
+; False
+mov rax, 0
+mov rcx, 0xFFFFFFFF
+cmpxchg [r10 + 8 * 7 + 5], ecx
+mov [r10 + 8 * 12 + 0], eax
+
+; Wrong
+; True
+mov rax, 0xC8B1B2B3
+mov rcx, 0xFFFFFFFF
+cmpxchg [r10 + 8 * 7 + 5], ecx
+mov [r10 + 8 * 12 + 4], eax
+
+mov rax, [r10 + 8 * 0]
+mov rbx, [r10 + 8 * 1]
+mov rcx, [r10 + 8 * 2]
+mov rdx, [r10 + 8 * 3]
+mov rbp, [r10 + 8 * 4]
+mov rsi, [r10 + 8 * 7]
+mov rdi, [r10 + 8 * 8]
+mov rsp, [r10 + 8 * 9]
+
+mov r8, [r10 + 8 * 10]
+mov r9, [r10 + 8 * 11]
+mov r10, [r10 + 8 * 12]
+
+hlt
+

--- a/unittests/ASM/TwoByte/0F_B0_7.asm
+++ b/unittests/ASM/TwoByte/0F_B0_7.asm
@@ -1,0 +1,105 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0xffffffffffffff48",
+    "RBX": "0xffffffffffffffff",
+    "RCX": "0x61626364656667ff",
+    "RDI": "0xffffffffffffffb8",
+    "RSP": "0xc1c2c3c4c5c6c7ff",
+    "R8":  "0x6851525354555657",
+    "R9":  "0xc8b1b2b3b4b5b6b7",
+    "R10": "0xc8b1b2b3b4b5b6b7"
+  }
+}
+%endif
+
+mov r10, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [r10 + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [r10 + 8 * 1], rax
+mov rax, 0x6162636465666768
+mov [r10 + 8 * 2], rax
+mov rax, 0x7172737475767778
+mov [r10 + 8 * 3], rax
+mov rax, 0x8182838485868788
+mov [r10 + 8 * 4], rax
+mov rax, 0x9192939495969798
+mov [r10 + 8 * 5], rax
+mov rax, 0xA1A2A3A4A5A6A7A8
+mov [r10 + 8 * 6], rax
+mov rax, 0xB1B2B3B4B5B6B7B8
+mov [r10 + 8 * 7], rax
+mov rax, 0xC1C2C3C4C5C6C7C8
+mov [r10 + 8 * 8], rax
+
+mov rax, 0
+mov [r10 + 8 * 9], rax
+mov [r10 + 8 * 10], rax
+mov [r10 + 8 * 11], rax
+mov [r10 + 8 * 12], rax
+mov [r10 + 8 * 13], rax
+
+mov rax, 0x4142434445464748
+mov [r10 + 8 * 15], rax
+mov rax, 0x5152535455565758
+mov [r10 + 8 * 16], rax
+
+; 64bit unaligned edges test
+; Offsets       | Test                                |
+; =============================================================
+; [1,7]           | Misaligned through to 128bit region | 128bit CAS
+; [9,15], [57,63] | Misaligned through to 256bit region | Dual 64bit CAS
+
+; Offset 1
+; False
+mov rax, 0
+mov rcx, 0xFFFFFFFFFFFFFFFF
+cmpxchg [r10 + 8 * 0 + 1], rcx
+mov [r10 + 8 * 9 + 0], rax
+
+; True
+mov rax, 0x5841424344454647
+mov rcx, 0xFFFFFFFFFFFFFFFF
+cmpxchg [r10 + 8 * 0 + 1], rcx
+mov [r10 + 8 * 10], rax
+
+; Offset 9
+; False
+mov rax, 0
+mov rcx, 0xFFFFFFFFFFFFFFFF
+cmpxchg [r10 + 8 * 1 + 1], rcx
+mov [r10 + 8 * 9 + 0], rax
+
+; True
+mov rax, 0x6851525354555657
+mov rcx, 0xFFFFFFFFFFFFFFFF
+cmpxchg [r10 + 8 * 1 + 1], rcx
+mov [r10 + 8 * 10], rax
+
+; Offset 57
+; False
+mov rax, 0
+mov rcx, 0xFFFFFFFFFFFFFFFF
+cmpxchg [r10 + 8 * 7 + 1], rcx
+mov [r10 + 8 * 11 + 0], rax
+
+; True
+mov rax, 0xC8B1B2B3B4B5B6B7
+mov rcx, 0xFFFFFFFFFFFFFFFF
+cmpxchg [r10 + 8 * 7 + 1], rcx
+mov [r10 + 8 * 12], rax
+
+mov rax, [r10 + 8 * 0]
+mov rbx, [r10 + 8 * 1]
+mov rcx, [r10 + 8 * 2]
+mov rdi, [r10 + 8 * 7]
+mov rsp, [r10 + 8 * 8]
+
+mov r8, [r10 + 8 * 10]
+mov r9, [r10 + 8 * 11]
+mov r10, [r10 + 8 * 12]
+
+hlt
+

--- a/unittests/gvisor-tests/Disabled_Tests
+++ b/unittests/gvisor-tests/Disabled_Tests
@@ -53,3 +53,8 @@ socket_inet_loopback_nogotsan_test
 socket_ip_udp_loopback_test
 socket_ipv4_udp_unbound_loopback_nogotsan_test
 socket_ipv6_udp_unbound_external_networking_test
+
+# These used to crash and fail its test, now hang
+mmap_test
+mremap_test
+semaphore_test

--- a/unittests/gvisor-tests/Known_Failures
+++ b/unittests/gvisor-tests/Known_Failures
@@ -206,3 +206,8 @@ concurrency_test
 socket_stress_test
 sigaltstack_test
 fcntl_test
+
+# These used to crash and fail its test, now hang
+mmap_test
+mremap_test
+semaphore_test


### PR DESCRIPTION
Adds a wackload of unit tests to handle all the prickly edges that unaligned atomics can hit here.
Currently disabled because they don't pass on ARMv8.0 which uses loadstore exclusive pairs which is harder to ensure is correct.
For any cmpxchg or cmpxchg8b instruction that is unaligned we will convert it in to a larger aligned CAS operation.
In the case that the operation crosses a 16byte or 64byte cacheline boundary, it will be split in to two CAS ops that can tear.
For the 16byte variant, this is fixed with ARMv8.4 LSE2. It can't be fixed any other way.
For the 64byte variant it matches AMD behaviour, not Intel behaviour.
Might be worth routing this to telemetry data in the future to know when we need to force threads in to single threaded behaviour.