### PR TITLE
Flush IR/Code cache on mmap, mmunmap & mprot

### DIFF
--- a/External/FEXCore/Source/Interface/Config/Config.cpp
+++ b/External/FEXCore/Source/Interface/Config/Config.cpp
@@ -34,7 +34,7 @@ namespace FEXCore::Config {
       CTX->Config.TSOEnabled = Config != 0;
     break;
     case FEXCore::Config::CONFIG_SMC_CHECKS:
-      CTX->Config.SMCChecks = Config != 0;
+      CTX->Config.SMCChecks = static_cast<FEXCore::Config::ConfigSMCChecks>(Config);
     break;
     case FEXCore::Config::CONFIG_ABI_LOCAL_FLAGS:
       CTX->Config.ABILocalFlags = Config != 0;

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -208,7 +208,7 @@ namespace FEXCore::Context {
     void ExecutionThread(FEXCore::Core::InternalThreadState *Thread);
     void NotifyPause();
 
-    void AddBlockMapping(FEXCore::Core::InternalThreadState *Thread, uint64_t Address, void *Ptr);
+    void AddBlockMapping(FEXCore::Core::InternalThreadState *Thread, uint64_t Address, void *Ptr, uint64_t Start, uint64_t Length);
 
     FEXCore::CodeLoader *LocalLoader{};
 

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -67,7 +67,7 @@ namespace FEXCore::Context {
 
       bool Is64BitMode {true};
       bool TSOEnabled {true};
-      bool SMCChecks {false};
+      FEXCore::Config::ConfigSMCChecks SMCChecks {FEXCore::Config::CONFIG_SMC_MMAN};
       bool ABILocalFlags {false};
       bool ABINoPF {false};
 

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -607,8 +607,8 @@ namespace FEXCore::Context {
     return Thread;
   }
 
-  void Context::AddBlockMapping(FEXCore::Core::InternalThreadState *Thread, uint64_t Address, void *Ptr) {
-    Thread->LookupCache->AddBlockMapping(Address, Ptr);
+  void Context::AddBlockMapping(FEXCore::Core::InternalThreadState *Thread, uint64_t Address, void *Ptr, uint64_t Start, uint64_t Length) {
+    Thread->LookupCache->AddBlockMapping(Address, Ptr, Start, Length);
   }
 
   void Context::ClearCodeCache(FEXCore::Core::InternalThreadState *Thread, bool AlsoClearIRCache) {
@@ -853,7 +853,8 @@ namespace FEXCore::Context {
         
         if (AOTEntry != Mod->end()) {
           // verify hash
-          auto hash = fasthash64((void*)(AOTEntry->second.start + file->second.Start  - file->second.Offset), AOTEntry->second.len, 0);
+          auto MappedStart = AOTEntry->second.start + file->second.Start  - file->second.Offset;
+          auto hash = fasthash64((void*)MappedStart, AOTEntry->second.len, 0);
           if (hash == AOTEntry->second.crc) {
             IRList = AOTEntry->second.IR;
             //LogMan::Msg::D("using %s + %lx -> %lx\n", file->second.fileid.c_str(), AOTEntry->first, GuestRIP);
@@ -862,7 +863,7 @@ namespace FEXCore::Context {
 
             RAData = AOTEntry->second.RAData;
             DebugData = new FEXCore::Core::DebugData();
-            StartAddr = AOTEntry->second.start;
+            StartAddr = MappedStart;
             Length = AOTEntry->second.len;
 
             GeneratedIR = true;
@@ -1117,7 +1118,7 @@ namespace FEXCore::Context {
       --Thread->CompileBlockReentrantRefCount;
 
     // Insert to lookup cache
-    AddBlockMapping(Thread, GuestRIP, CodePtr);
+    AddBlockMapping(Thread, GuestRIP, CodePtr, StartAddr, Length);
 
     return (uintptr_t)CodePtr;
 
@@ -1175,6 +1176,18 @@ namespace FEXCore::Context {
     IdleWaitCV.notify_all();
 
     SignalDelegation->UninstallTLSState(Thread);
+  }
+
+  void FlushCodeRange(FEXCore::Core::InternalThreadState *Thread, uint64_t Start, uint64_t Length) {
+
+    auto lower = Thread->LookupCache->CodePages.lower_bound(Start >> 12);
+    auto upper = Thread->LookupCache->CodePages.upper_bound((Start + Length) >> 12);
+    
+    for (auto it = lower; it != upper; it++) {
+      for (auto Address: it->second) 
+        Context::RemoveCodeEntry(Thread, Address);
+      it->second.clear();
+    }
   }
 
   void Context::RemoveCodeEntry(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP) {

--- a/External/FEXCore/Source/Interface/Core/LookupCache.h
+++ b/External/FEXCore/Source/Interface/Core/LookupCache.h
@@ -35,9 +35,15 @@ public:
     }
   }
 
-  void AddBlockMapping(uint64_t Address, void *HostCode) { 
+  std::map<uint64_t, std::vector<uint64_t>> CodePages;
+
+  void AddBlockMapping(uint64_t Address, void *HostCode, uint64_t Start, uint64_t Length) { 
     auto InsertPoint = BlockList.emplace(Address, (uintptr_t)HostCode);
     LogMan::Throw::A(InsertPoint.second == true, "Dupplicate block mapping added");
+
+    for (auto CurrentPage = Start >> 12, EndPage = (Start + Length) >> 12; CurrentPage <= EndPage; CurrentPage++) {
+      CodePages[CurrentPage].push_back(Address);
+    }
 
     // no need to update L1 or L2, they will get updated on first lookup
   }
@@ -196,6 +202,7 @@ private:
         return false;
     }
   };
+
 
   std::map<BlockLinkTag, std::function<void()>> BlockLinks;
   std::map<uint64_t, uint64_t> BlockList;

--- a/External/FEXCore/include/FEXCore/Config/Config.h
+++ b/External/FEXCore/include/FEXCore/Config/Config.h
@@ -44,6 +44,12 @@ namespace FEXCore::Config {
     CONFIG_CUSTOM,
   };
 
+  enum ConfigSMCChecks {
+    CONFIG_SMC_NONE,
+    CONFIG_SMC_MMAN,
+    CONFIG_SMC_FULL,
+  };
+  
   void SetConfig(FEXCore::Context::Context *CTX, ConfigOption Option, uint64_t Config);
   void SetConfig(FEXCore::Context::Context *CTX, ConfigOption Option, std::string const &Config);
   uint64_t GetConfig(FEXCore::Context::Context *CTX, ConfigOption Option);

--- a/External/FEXCore/include/FEXCore/Core/Context.h
+++ b/External/FEXCore/include/FEXCore/Core/Context.h
@@ -238,4 +238,5 @@ namespace FEXCore::Context {
   void RemoveNamedRegion(FEXCore::Context::Context *CTX, uintptr_t Base, uintptr_t Length);
   void SetAOTIRLoader(FEXCore::Context::Context *CTX, std::function<std::unique_ptr<std::istream>(const std::string&)> CacheReader);
   bool WriteAOTIR(FEXCore::Context::Context *CTX, std::function<std::unique_ptr<std::ostream>(const std::string&)> CacheWriter);
+  void FlushCodeRange(FEXCore::Core::InternalThreadState *Thread, uint64_t Start, uint64_t Length);
 }

--- a/Source/Common/ArgumentLoader.cpp
+++ b/Source/Common/ArgumentLoader.cpp
@@ -66,11 +66,11 @@ namespace FEX::ArgLoader {
           .help("Number of physical hardware threads to tell the process we have")
           .set_default(1);
 
-      CPUGroup.add_option("--smc-full-checks")
+      CPUGroup.add_option("--smc-checks")
         .dest("SMCChecks")
-        .action("store_true")
-        .help("Checks code for modification before execution. Slow.")
-        .set_default(false);
+        .choices({"none", "mman", "full"})
+        .help("Checks code for modification before execution.\n\tnone: No checks\n\tmman: Invalidate on mmap, mprotect, munmap\n\tfull: Validate code before every run (slow)")
+        .set_default("mman");
 
       CPUGroup.add_option("--unsafe-no-tso")
         .dest("TSOEnabled")
@@ -229,8 +229,13 @@ namespace FEX::ArgLoader {
       }
 
       if (Options.is_set_by_user("SMCChecks")) {
-        bool SMCChecks = Options.get("SMCChecks");
-        Set(FEXCore::Config::ConfigOption::CONFIG_SMC_CHECKS, std::to_string(SMCChecks));
+        auto SMCChecks = Options["SMCChecks"];
+        if (SMCChecks == "none")
+          Set(FEXCore::Config::ConfigOption::CONFIG_SMC_CHECKS, "0");
+        else if (SMCChecks == "mman")
+          Set(FEXCore::Config::ConfigOption::CONFIG_SMC_CHECKS, "1");
+        else if (SMCChecks == "full")
+          Set(FEXCore::Config::ConfigOption::CONFIG_SMC_CHECKS, "2");
       }
       if (Options.is_set_by_user("AbiLocalFlags")) {
         bool AbiLocalFlags = Options.get("AbiLocalFlags");

--- a/Source/Tests/ELFLoader.cpp
+++ b/Source/Tests/ELFLoader.cpp
@@ -205,7 +205,7 @@ int main(int argc, char **argv, char **const envp) {
   FEXCore::Config::Value<std::string> OutputLog{FEXCore::Config::CONFIG_OUTPUTLOG, "stderr"};
   FEXCore::Config::Value<std::string> DumpIR{FEXCore::Config::CONFIG_DUMPIR, "no"};
   FEXCore::Config::Value<bool> TSOEnabledConfig{FEXCore::Config::CONFIG_TSO_ENABLED, true};
-  FEXCore::Config::Value<bool> SMCChecksConfig{FEXCore::Config::CONFIG_SMC_CHECKS, false};
+  FEXCore::Config::Value<uint8_t> SMCChecksConfig{FEXCore::Config::CONFIG_SMC_CHECKS, FEXCore::Config::CONFIG_SMC_MMAN};
   FEXCore::Config::Value<bool> ABILocalFlags{FEXCore::Config::CONFIG_ABI_LOCAL_FLAGS, false};
   FEXCore::Config::Value<bool> AbiNoPF{FEXCore::Config::CONFIG_ABI_NO_PF, false};
   FEXCore::Config::Value<bool> AOTIRCapture{FEXCore::Config::CONFIG_AOTIR_GENERATE, false};

--- a/Source/Tests/TestHarnessRunner.cpp
+++ b/Source/Tests/TestHarnessRunner.cpp
@@ -71,7 +71,7 @@ int main(int argc, char **argv, char **const envp) {
   FEXCore::Config::Value<std::string> OutputLog{FEXCore::Config::CONFIG_OUTPUTLOG, "stderr"};
   FEXCore::Config::Value<std::string> DumpIR{FEXCore::Config::CONFIG_DUMPIR, "no"};
   FEXCore::Config::Value<bool> TSOEnabledConfig{FEXCore::Config::CONFIG_TSO_ENABLED, true};
-  FEXCore::Config::Value<bool> SMCChecksConfig{FEXCore::Config::CONFIG_SMC_CHECKS, false};
+  FEXCore::Config::Value<uint8_t> SMCChecksConfig{FEXCore::Config::CONFIG_SMC_CHECKS, FEXCore::Config::CONFIG_SMC_MMAN};
   FEXCore::Config::Value<bool> ABILocalFlags{FEXCore::Config::CONFIG_ABI_LOCAL_FLAGS, false};
   FEXCore::Config::Value<bool> AbiNoPF{FEXCore::Config::CONFIG_ABI_NO_PF, false};
 

--- a/Source/Tools/FEXConfig/Main.cpp
+++ b/Source/Tools/FEXConfig/Main.cpp
@@ -301,11 +301,27 @@ namespace {
         ConfigChanged = true;
       }
 
+      ImGui::Text("SMC Checks: ");
+      int SMCChecks = FEXCore::Config::CONFIG_SMC_MMAN;
+      
       Value = LoadedConfig->Get(FEXCore::Config::ConfigOption::CONFIG_SMC_CHECKS);
-      bool SMCChecks = Value.has_value() && **Value == "1";
-      if (ImGui::Checkbox("SMC Checks", &SMCChecks)) {
-        LoadedConfig->EraseSet(FEXCore::Config::ConfigOption::CONFIG_SMC_CHECKS, SMCChecks ? "1" : "0");
-        ConfigChanged = true;
+      if (Value.has_value()) {
+        if (**Value == "0") {
+          SMCChecks = FEXCore::Config::CONFIG_SMC_NONE;
+        } else if (**Value == "1") {
+          SMCChecks = FEXCore::Config::CONFIG_SMC_MMAN;
+        } else if (**Value == "2") {
+          SMCChecks = FEXCore::Config::CONFIG_SMC_FULL;
+        }
+      }
+
+      bool SMCChanged = false;
+      SMCChanged |= ImGui::RadioButton("None", &SMCChecks, FEXCore::Config::CONFIG_SMC_NONE); ImGui::SameLine();
+      SMCChanged |= ImGui::RadioButton("MMan", &SMCChecks, FEXCore::Config::CONFIG_SMC_MMAN); ImGui::SameLine();
+      SMCChanged |= ImGui::RadioButton("Full", &SMCChecks, FEXCore::Config::CONFIG_SMC_FULL);
+
+      if (SMCChanged) {
+        LoadedConfig->EraseSet(FEXCore::Config::ConfigOption::CONFIG_SMC_CHECKS, std::to_string(SMCChecks));
       }
 
       Value = LoadedConfig->Get(FEXCore::Config::ConfigOption::CONFIG_ABI_LOCAL_FLAGS);

--- a/unittests/ASM/CMakeLists.txt
+++ b/unittests/ASM/CMakeLists.txt
@@ -74,7 +74,7 @@ foreach(ASM_SRC ${ASM_SOURCES})
     string(REPLACE " " ";" ARGS_LIST ${ARGS})
 
     if (TEST_NAME MATCHES "SelfModifyingCode")
-      list(APPEND ARGS_LIST "--smc-full-checks")
+      list(APPEND ARGS_LIST "--smc-checks=full")
     endif()
 
     add_test(NAME ${TEST_NAME}


### PR DESCRIPTION
## Motivation
To get gimp working w/o --smc

## Overview
This flushes the cache on `mmap` or `munmap`, and on `mprotect` w/ `PROT_EXEC` set. The idea is to catch .so load and unload, to avoid the actual need for smc tracking for non-jits.

This is a very naive implementation that uses block-lists per-page, and erases the entire page when touched.

With this, GIMP works at interactive speeds.

## Details
- [x] rebase on top of `skmp/ir-cache`
- [x] Keep blocks-in-page lists
- [x] Insert blocks on lists based on their start/length range
- [x] Invalidate on mmap, munmap, mprotect, 64 and 32 bits

## TODO
- [x] Modify `--smc` to have `--smc-chekcs=none`, `--smc-chekcs=mman` and `--smc-chekcs=full`. Make the default value `mman`

## Follow ups
- [x] Find better structures & algos for tracking and intersecting invalidation ranges (#807)
- [x] Make invalidation remove from all threads (#806)
- [x] Self-invalidation issues with interpreter, rare (#808)