### PR TITLE
Add TSX names to decode tables so we know what they are

### DIFF
--- a/External/FEXCore/Source/Interface/Core/X86Tables/PrimaryGroupTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/PrimaryGroupTables.cpp
@@ -125,9 +125,12 @@ void InitializePrimaryGroupTables(Context::OperatingMode Mode) {
 
     // GROUP 11
     {OPD(TYPE_GROUP_11, OpToIndex(0xC6), 0), 1, X86InstInfo{"MOV",  TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_MODRM | FLAGS_SF_MOD_DST  | FLAGS_SRC_SEXT,                   1, nullptr}},
-    {OPD(TYPE_GROUP_11, OpToIndex(0xC6), 1), 6, X86InstInfo{"",     TYPE_INVALID, FLAGS_NONE,                                                       0, nullptr}},
+    {OPD(TYPE_GROUP_11, OpToIndex(0xC6), 1), 5, X86InstInfo{"",     TYPE_INVALID, FLAGS_NONE,                                                       0, nullptr}},
+    {OPD(TYPE_GROUP_11, OpToIndex(0xC6), 7), 1, X86InstInfo{"XABORT", TYPE_INST, FLAGS_MODRM,                                                       1, nullptr}},
     {OPD(TYPE_GROUP_11, OpToIndex(0xC7), 0), 1, X86InstInfo{"MOV",  TYPE_INST, FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_SRC_SEXT | FLAGS_DISPLACE_SIZE_DIV_2,                                   4, nullptr}},
-    {OPD(TYPE_GROUP_11, OpToIndex(0xC7), 1), 6, X86InstInfo{"",     TYPE_INVALID, FLAGS_NONE,                                                       0, nullptr}},
+    {OPD(TYPE_GROUP_11, OpToIndex(0xC7), 1), 5, X86InstInfo{"",     TYPE_INVALID, FLAGS_NONE,                                                       0, nullptr}},
+    {OPD(TYPE_GROUP_11, OpToIndex(0xC7), 7), 1, X86InstInfo{"XBEGIN", TYPE_INST, FLAGS_MODRM | FLAGS_SRC_SEXT | FLAGS_SETS_RIP | FLAGS_DISPLACE_SIZE_DIV_2,                                                       4, nullptr}},
+
   };
 
   const U16U8InfoStruct PrimaryGroupOpTable_64[] = {

--- a/External/FEXCore/Source/Interface/Core/X86Tables/SecondaryModRMTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/SecondaryModRMTables.cpp
@@ -21,8 +21,8 @@ void InitializeSecondaryModRMTables() {
     {((1 << 3) | 2), 1, X86InstInfo{"",         TYPE_INVALID, FLAGS_NONE, 0, nullptr}},
     {((1 << 3) | 3), 1, X86InstInfo{"",         TYPE_INVALID, FLAGS_NONE, 0, nullptr}},
     {((1 << 3) | 4), 1, X86InstInfo{"",         TYPE_INVALID, FLAGS_NONE, 0, nullptr}},
-    {((1 << 3) | 5), 1, X86InstInfo{"",         TYPE_INVALID, FLAGS_NONE, 0, nullptr}},
-    {((1 << 3) | 6), 1, X86InstInfo{"",         TYPE_INVALID, FLAGS_NONE, 0, nullptr}},
+    {((1 << 3) | 5), 1, X86InstInfo{"XEND",     TYPE_INST, FLAGS_NONE, 0, nullptr}},
+    {((1 << 3) | 6), 1, X86InstInfo{"XTEST",    TYPE_INST, FLAGS_NONE, 0, nullptr}},
     {((1 << 3) | 7), 1, X86InstInfo{"",         TYPE_INVALID, FLAGS_NONE, 0, nullptr}},
 
     // REG /3


### PR DESCRIPTION
Rather than just stating UND

We can't support this until we have an ARM CPU that supports TME and
more robust multiblock.