### PR TITLE
More improvements to BRK handling

### DIFF
--- a/External/FEXCore/Source/Utils/ELFLoader.cpp
+++ b/External/FEXCore/Source/Utils/ELFLoader.cpp
@@ -1,3 +1,4 @@
+#include <FEXCore/Utils/Common/MathUtils.h>
 #include <FEXCore/Utils/ELFLoader.h>
 #include <FEXCore/Utils/LogManager.h>
 #include <cstring>
@@ -201,6 +202,9 @@ bool ELFContainer::LoadELF_32() {
 
   DynamicProgram = Header._32.e_type != ET_EXEC;
 
+  // Default BRK size
+  BRKSize = 4096;
+
   return true;
 }
 
@@ -238,6 +242,9 @@ bool ELFContainer::LoadELF_64() {
   }
 
   DynamicProgram = Header._64.e_type != ET_EXEC;
+
+  // Default BRK size
+  BRKSize = 0x1000'0000;
 
   return true;
 }
@@ -329,6 +336,11 @@ void ELFContainer::CalculateMemoryLayouts() {
       }
     }
   }
+
+  // Calculate BRK
+  MaxPhysAddr = AlignUp(MaxPhysAddr, 4096);
+  BRKBase = MaxPhysAddr;
+  MaxPhysAddr += BRKSize;
 
   PhysMemSize = MaxPhysAddr - MinPhysAddr;
 

--- a/External/FEXCore/include/FEXCore/Utils/ELFLoader.h
+++ b/External/FEXCore/include/FEXCore/Utils/ELFLoader.h
@@ -40,6 +40,15 @@ public:
                            PhysicalMemorySize);
   }
 
+  struct BRKInfo {
+    uint64_t Base;
+    uint64_t Size;
+  };
+
+  BRKInfo GetBRKInfo() const {
+    return {BRKBase, BRKSize};
+  }
+
   // Data, Physical, Size
   using MemoryWriter = std::function<void(void *, uint64_t, uint64_t)>;
   void WriteLoadableSections(MemoryWriter Writer, uint64_t Offset = 0);
@@ -67,6 +76,14 @@ public:
   void GetInitLocations(uint64_t GuestELFBase, std::vector<uint64_t> *Locations);
 
   bool HasTLS() const { return TLSHeader._64 != nullptr; }
+  uint64_t GetTLSBase() const {
+    if (GetMode() == ELFMode::MODE_64BIT) {
+      return TLSHeader._64->p_vaddr;
+    }
+    else {
+      return TLSHeader._32->p_vaddr;
+    }
+  }
 
   enum ELFMode {
     MODE_32BIT,
@@ -122,6 +139,9 @@ private:
   uint64_t MinPhysicalMemoryLocation{0};
   uint64_t MaxPhysicalMemoryLocation{0};
   uint64_t PhysicalMemorySize{0};
+
+  uint64_t BRKBase{};
+  uint64_t BRKSize{};
   ProgramHeader InterpreterHeader{};
   bool DynamicProgram{false};
   std::string DynamicLinker;

--- a/Source/Tests/ELFLoader.cpp
+++ b/Source/Tests/ELFLoader.cpp
@@ -207,7 +207,6 @@ int main(int argc, char **argv, char **const envp) {
   FEXCore::Config::Value<bool> ABILocalFlags{FEXCore::Config::CONFIG_ABI_LOCAL_FLAGS, false};
   FEXCore::Config::Value<bool> AbiNoPF{FEXCore::Config::CONFIG_ABI_NO_PF, false};
 
-
   ::SilentLog = SilentLog();
 
   if (!::SilentLog) {
@@ -269,6 +268,8 @@ int main(int argc, char **argv, char **const envp) {
       CTX,
       SignalDelegation.get(),
       &Loader)};
+  auto BRKInfo = Loader.GetBRKInfo();
+  SyscallHandler->DefaultProgramBreak(BRKInfo.Base, BRKInfo.Size);
 
   FEXCore::Context::SetSignalDelegator(CTX, SignalDelegation.get());
   FEXCore::Context::SetSyscallHandler(CTX, SyscallHandler.get());

--- a/Source/Tests/HarnessHelpers.h
+++ b/Source/Tests/HarnessHelpers.h
@@ -495,13 +495,13 @@ public:
       //AuxVariables.emplace_back(auxv_t{24, ~0ULL}); // AT_PLATFORM
       // On x86 only allows userspace to check for monitor and fs/gs base writing in CPL3
       //AuxVariables.emplace_back(auxv_t{26, 0}); // AT_HWCAP2
-      AuxVariables.emplace_back(auxv_t{32, 0ULL}); // sysinfo (vDSO)
-      AuxVariables.emplace_back(auxv_t{33, 0ULL}); // sysinfo (vDSO)
+      AuxVariables.emplace_back(auxv_t{32, 0}); // AT_SYSINFO - Entry point to syscall
+      AuxVariables.emplace_back(auxv_t{33, 0}); // AT_SYSINFO_EHDR - Address of the start of VDSO
     }
     else {
       AuxVariables.emplace_back(auxv_t{4, 0x20}); // AT_PHENT
-      AuxVariables.emplace_back(auxv_t{32, 0ULL}); // sysinfo (vDSO)
-      AuxVariables.emplace_back(auxv_t{33, 0ULL}); // sysinfo (vDSO)
+      AuxVariables.emplace_back(auxv_t{32, 0}); // AT_SYSINFO - Entry point to syscall
+      AuxVariables.emplace_back(auxv_t{33, 0}); // AT_SYSINFO_EHDR - Address of the start of VDSO
     }
 
     AuxVariables.emplace_back(auxv_t{3, DB.GetElfBase()}); // Program header
@@ -733,9 +733,16 @@ public:
 
   bool Is64BitMode() const { return File.GetMode() == ::ELFLoader::ELFContainer::MODE_64BIT; }
 
+  ::ELFLoader::ELFContainer::BRKInfo GetBRKInfo() const {
+    auto Info = File.GetBRKInfo();
+    Info.Base += DB.GetElfBase();
+    return Info;
+  }
+
 private:
   ::ELFLoader::ELFContainer File;
   ::ELFLoader::ELFSymbolDatabase DB;
+
   std::vector<std::string> Args;
   std::vector<std::string> EnvironmentVariables;
   std::vector<char const*> LoaderArgs;

--- a/Source/Tests/LinuxSyscalls/Syscalls.h
+++ b/Source/Tests/LinuxSyscalls/Syscalls.h
@@ -47,12 +47,12 @@ namespace FEX::HLE {
 class SyscallHandler : public FEXCore::HLE::SyscallHandler {
 public:
   SyscallHandler(FEXCore::Context::Context *ctx, FEX::HLE::SignalDelegator *_SignalDelegation);
-  virtual ~SyscallHandler() = default;
+  virtual ~SyscallHandler();
 
   // In the case that the syscall doesn't hit the optimized path then we still need to go here
   uint64_t HandleSyscall(FEXCore::Core::InternalThreadState *Thread, FEXCore::HLE::SyscallArguments *Args) final override;
 
-  void DefaultProgramBreak(FEXCore::Core::InternalThreadState *Thread);
+  void DefaultProgramBreak(uint64_t Base, uint64_t Size);
 
   using SyscallPtrArg0 = uint64_t(*)(FEXCore::Core::InternalThreadState *Thread);
   using SyscallPtrArg1 = uint64_t(*)(FEXCore::Core::InternalThreadState *Thread, uint64_t);
@@ -116,6 +116,8 @@ protected:
   // BRK management
   uint64_t DataSpace {};
   uint64_t DataSpaceSize {};
+  uint64_t DataSpaceMaxSize {};
+  uint64_t DataSpaceStartingSize{};
 
   // (Major << 24) | (Minor << 16) | Patch
   uint32_t HostKernelVersion{};

--- a/unittests/gvisor-tests/Known_Failures
+++ b/unittests/gvisor-tests/Known_Failures
@@ -68,7 +68,6 @@ aio_test
 alarm_test
 arch_prctl_test
 bad_test
-brk_test
 chmod_test
 chown_test
 clock_nanosleep_test


### PR DESCRIPTION
Base size is now only one page in size. We will then increment that BRK
size by 8MB alignments. 256MB for 32bit applications was causing some
applications on the edge to run out of virtual memory
I was hitting some 32bit applications that were being fairly mean with
BRK. They were allocating all of BRK space then running out of virtual
memory space with its mmap handler fallback after freeing BRK space.

This means we now munmap BRK pages on release for the guest, similar to
behaviour that Linux does.

Additionally I had an application that was getting very upset that BRK
wasn't actually at the end of program space. So allocate at the end of
program space like expected.