### PR TITLE
Forces SIGRET handler to the lower 32bits VA on 32bit processes

### DIFF
--- a/External/FEXCore/Source/Interface/Core/X86HelperGen.h
+++ b/External/FEXCore/Source/Interface/Core/X86HelperGen.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <FEXCore/Config/Config.h>
+
 #include <stdint.h>
 
 namespace FEXCore {
@@ -12,5 +14,6 @@ public:
 
 private:
   void *CodePtr{};
+  void* AllocateGuestCodeSpace(size_t Size);
 };
 }


### PR DESCRIPTION
This is visible to the guest process so for 32bit it needs to be in the
lower 32bits.