### PR TITLE
Syscalls: Define MREMAP_DONTUNMAP if missing

### DIFF
--- a/Source/Tests/LinuxSyscalls/x32/Syscalls.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Syscalls.cpp
@@ -11,6 +11,10 @@
 #include <sys/shm.h>
 #include <sys/stat.h>
 
+#ifndef MREMAP_DONTUNMAP
+#define MREMAP_DONTUNMAP 4
+#endif
+
 namespace FEX::HLE::x32 {
 uint64_t MemAllocator::FindPageRange(uint64_t Start, size_t Pages) {
   // Linear range scan


### PR DESCRIPTION
It's not defined on Ubuntu 20.04