### PR TITLE
RA: Split RAData from RAPass, Optimize data packing, Cleanups

### DIFF
--- a/External/FEXCore/Scripts/json_ir_generator.py
+++ b/External/FEXCore/Scripts/json_ir_generator.py
@@ -236,7 +236,7 @@ def print_ir_arg_printer(ops, defines):
                 if (SSAArgs != 0):
                     for i in range(0, SSAArgs):
                         LastArg = (SSAArgs - i - 1) == 0 and not HasArgs
-                        output_file.write("\tPrintArg(out, IR, Op->Header.Args[%d], RAPass);\n" % i)
+                        output_file.write("\tPrintArg(out, IR, Op->Header.Args[%d], RAData);\n" % i)
                         if not (LastArg):
                             output_file.write("\t*out << \", \";\n")
 

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -139,7 +139,9 @@ namespace FEXCore::Context {
     FEXCore::Core::ThreadState *GetThreadState();
     void LoadEntryList();
 
-    std::tuple<void *, FEXCore::Core::DebugData *> CompileCode(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP);
+    std::tuple<FEXCore::IR::IRListView<true> *, FEXCore::IR::RegisterAllocationData *, uint64_t, uint64_t> GenerateIR(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP);
+
+    std::tuple<void *, FEXCore::IR::IRListView<true> *, FEXCore::Core::DebugData *, FEXCore::IR::RegisterAllocationData *, bool> CompileCode(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP);
     uintptr_t CompileBlock(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP);
     uintptr_t CompileFallbackBlock(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP);
 
@@ -158,7 +160,7 @@ namespace FEXCore::Context {
 #endif
 
   protected:
-    void ClearCodeCache(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP);
+    void ClearCodeCache(FEXCore::Core::InternalThreadState *Thread, bool AlsoClearIRCache);
 
   private:
     void WaitForIdleWithTimeout();

--- a/External/FEXCore/Source/Interface/Core/CompileService.h
+++ b/External/FEXCore/Source/Interface/Core/CompileService.h
@@ -16,6 +16,9 @@ namespace Core {
   struct InternalThreadState;
 }
 
+namespace IR {
+  class RegisterAllocationData;
+};
 class CompileService final {
   public:
     CompileService(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread);
@@ -29,6 +32,7 @@ class CompileService final {
       // Outgoing
       void *CodePtr{};
       FEXCore::IR::IRListView<true> *IRList{};
+      FEXCore::IR::RegisterAllocationData *RAData{};
       FEXCore::Core::DebugData *DebugData{};
 
       // Communication
@@ -37,8 +41,7 @@ class CompileService final {
     };
 
     WorkItem *CompileCode(uint64_t RIP);
-    void ClearCache(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP);
-    void RemoveCodeEntry(uint64_t GuestRIP);
+    void ClearCache(FEXCore::Core::InternalThreadState *Thread);
 
   private:
     FEXCore::Context::Context *CTX;

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -765,17 +765,17 @@ namespace FEXCore::Context {
       Thread->PassManager->Run(Thread->OpDispatcher.get());
 
       if (Thread->CTX->Config.DumpIR != "no") {
-        IRDumper(Thread->PassManager->GetRAPass()->GetAllocationData());
+        IRDumper(Thread->PassManager->GetRAPass() ? Thread->PassManager->GetRAPass()->GetAllocationData() : nullptr);
       }
 
       if (Thread->OpDispatcher->ShouldDump) {
         std::stringstream out;
         auto NewIR = Thread->OpDispatcher->ViewIR();
-        FEXCore::IR::Dump(&out, &NewIR, Thread->PassManager->GetRAPass()->GetAllocationData());
+        FEXCore::IR::Dump(&out, &NewIR, Thread->PassManager->GetRAPass() ? Thread->PassManager->GetRAPass()->GetAllocationData() : nullptr);
         printf("IR 0x%lx:\n%s\n@@@@@\n", GuestRIP, out.str().c_str());
       }
 
-      RAData = Thread->PassManager->GetRAPass()->GetAllocationData();
+      RAData = Thread->PassManager->GetRAPass() ? Thread->PassManager->GetRAPass()->GetAllocationData() : nullptr;
 
       // Create a copy of the IR and place it in this thread's IR cache
       auto AddedIR = Thread->IRLists.try_emplace(GuestRIP, Thread->OpDispatcher->CreateIRCopy());

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterClass.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterClass.h
@@ -22,7 +22,7 @@ public:
   explicit InterpreterCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread, bool CompileThread);
   ~InterpreterCore() override;
   std::string GetName() override { return "Interpreter"; }
-  void *CompileCode(FEXCore::IR::IRListView<true> const *IR, FEXCore::Core::DebugData *DebugData) override;
+  void *CompileCode(FEXCore::IR::IRListView<true> const *IR, FEXCore::Core::DebugData *DebugData, FEXCore::IR::RegisterAllocationData *RAData) override;
 
   void *MapRegion(void* HostPtr, uint64_t, uint64_t) override { return HostPtr; }
 

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -4719,10 +4719,12 @@ void InterpreterCore::ExecuteCode(FEXCore::Core::InternalThreadState *Thread) {
     }
   }
 
+  #ifndef NDEBUG
   auto DebugData = Thread->DebugData.find(Thread->State.State.rip);
   if (DebugData != Thread->DebugData.end()) {
-    Thread->Stats.InstructionsExecuted.fetch_add(DebugData->second.GuestInstructionCount);
+    Thread->Stats.InstructionsExecuted.fetch_add(DebugData->second->GuestInstructionCount);
   }
+  #endif
 }
 
 FEXCore::CPU::CPUBackend *CreateInterpreterCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread, bool CompileThread) {

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -476,7 +476,7 @@ Res InterpreterCore::GetSrc(void* SSAData, IR::OrderedNodeWrapper Src) {
   return reinterpret_cast<Res>(DstPtr);
 }
 
-void *InterpreterCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const *IR, [[maybe_unused]] FEXCore::Core::DebugData *DebugData) {
+void *InterpreterCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const *IR, [[maybe_unused]] FEXCore::Core::DebugData *DebugData, FEXCore::IR::RegisterAllocationData *RAData) {
   return reinterpret_cast<void*>(InterpreterExecution);
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -798,7 +798,7 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
   // Fairly excessive buffer range to make sure we don't overflow
   uint32_t BufferRange = SSACount * 16;
   if ((GetCursorOffset() + BufferRange) > CurrentCodeBuffer->Size) {
-    State->CTX->ClearCodeCache(State, HeaderOp->Entry);
+    State->CTX->ClearCodeCache(State, false);
   }
 
   // AAPCS64

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -683,27 +683,21 @@ void JITCore::LoadConstant(vixl::aarch64::Register Reg, uint64_t Constant) {
   }
 }
 
-struct PhysReg { uint32_t Class; uint32_t VId; };
+static IR::PhysicalRegister GetPhys(IR::RegisterAllocationData *RAData, uint32_t Node) {
+  auto PhyReg = RAData->GetNodeRegister(Node);
 
-static PhysReg GetPhys(IR::RegisterAllocationData *RAData, uint32_t Node) {
-  uint64_t Reg = RAData->GetNodeRegister(Node);
-  auto rv = PhysReg {uint32_t(Reg>>32), (uint32_t)Reg};
+  LogMan::Throw::A(!PhyReg.IsInvalid(), "Couldn't Allocate register for node: ssa%d. Class: %d", Node, PhyReg.Class);
 
-  if (rv.VId != ~0U)
-    return rv;
-  else
-    LogMan::Msg::A("Couldn't Allocate register for node: ssa%d. Class: %d", Node, Reg >> 32);
-
-  return PhysReg { ~0U, ~0U};
+  return PhyReg;
 }
 
 template<>
 aarch64::Register JITCore::GetReg<JITCore::RA_32>(uint32_t Node) {
 auto Reg = GetPhys(RAData, Node);
   if (Reg.Class == IR::GPRFixedClass.Val) {
-    return SRA64[Reg.VId].W();
+    return SRA64[Reg.Reg].W();
   } else if (Reg.Class == IR::GPRClass.Val) {
-    return RA64[Reg.VId].W();
+    return RA64[Reg.Reg].W();
   } else {
     LogMan::Throw::A(false, "Unexpected Class: %d", Reg.Class);
   }
@@ -713,9 +707,9 @@ template<>
 aarch64::Register JITCore::GetReg<JITCore::RA_64>(uint32_t Node) {
   auto Reg = GetPhys(RAData, Node);
   if (Reg.Class == IR::GPRFixedClass.Val) {
-    return SRA64[Reg.VId];
+    return SRA64[Reg.Reg];
   } else if (Reg.Class == IR::GPRClass.Val) {
-    return RA64[Reg.VId];
+    return RA64[Reg.Reg];
   } else {
     LogMan::Throw::A(false, "Unexpected Class: %d", Reg.Class);
   }
@@ -723,22 +717,22 @@ aarch64::Register JITCore::GetReg<JITCore::RA_64>(uint32_t Node) {
 
 template<>
 std::pair<aarch64::Register, aarch64::Register> JITCore::GetSrcPair<JITCore::RA_32>(uint32_t Node) {
-  uint32_t Reg = GetPhys(RAData, Node).VId;
+  uint32_t Reg = GetPhys(RAData, Node).Reg;
   return RA32Pair[Reg];
 }
 
 template<>
 std::pair<aarch64::Register, aarch64::Register> JITCore::GetSrcPair<JITCore::RA_64>(uint32_t Node) {
-  uint32_t Reg = GetPhys(RAData, Node).VId;
+  uint32_t Reg = GetPhys(RAData, Node).Reg;
   return RA64Pair[Reg];
 }
 
 aarch64::VRegister JITCore::GetSrc(uint32_t Node) {
   auto Reg = GetPhys(RAData, Node);
   if (Reg.Class == IR::FPRFixedClass.Val) {
-    return SRAFPR[Reg.VId];
+    return SRAFPR[Reg.Reg];
   } else if (Reg.Class == IR::FPRClass.Val) {
-    return RAFPR[Reg.VId];
+    return RAFPR[Reg.Reg];
   } else {
     LogMan::Throw::A(false, "Unexpected Class: %d", Reg.Class);
   }
@@ -747,9 +741,9 @@ aarch64::VRegister JITCore::GetSrc(uint32_t Node) {
 aarch64::VRegister JITCore::GetDst(uint32_t Node) {
   auto Reg = GetPhys(RAData, Node);
   if (Reg.Class == IR::FPRFixedClass.Val) {
-    return SRAFPR[Reg.VId];
+    return SRAFPR[Reg.Reg];
   } else if (Reg.Class == IR::FPRClass.Val) {
-    return RAFPR[Reg.VId];
+    return RAFPR[Reg.Reg];
   } else {
     LogMan::Throw::A(false, "Unexpected Class: %d", Reg.Class);
   }
@@ -770,8 +764,7 @@ bool JITCore::IsInlineConstant(const IR::OrderedNodeWrapper& WNode, uint64_t* Va
 }
 
 FEXCore::IR::RegisterClassType JITCore::GetRegClass(uint32_t Node) {
-  auto Class = static_cast<uint32_t>(RAData->GetNodeRegister(Node) >> 32);
-  return FEXCore::IR::RegisterClassType {Class};
+  return FEXCore::IR::RegisterClassType {GetPhys(RAData, Node).Class};
 }
 
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -78,7 +78,7 @@ public:
 
   ~JITCore() override;
   std::string GetName() override { return "JIT"; }
-  void *CompileCode(FEXCore::IR::IRListView<true> const *IR, FEXCore::Core::DebugData *DebugData) override;
+  void *CompileCode(FEXCore::IR::IRListView<true> const *IR, FEXCore::Core::DebugData *DebugData, FEXCore::IR::RegisterAllocationData *RAData) override;
 
   void *MapRegion(void* HostPtr, uint64_t, uint64_t) override { return HostPtr; }
 
@@ -232,6 +232,7 @@ private:
 
   CompilerSharedData ThreadSharedData;
   IR::RegisterAllocationPass *RAPass;
+  IR::RegisterAllocationData *RAData;
 
   uint32_t SpillSlots{};
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -613,7 +613,7 @@ void *JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const 
   // Fairly excessive buffer range to make sure we don't overflow
   uint32_t BufferRange = SSACount * 16;
   if ((getSize() + BufferRange) > CurrentCodeBuffer->Size) {
-    ThreadState->CTX->ClearCodeCache(ThreadState, HeaderOp->Entry);
+    ThreadState->CTX->ClearCodeCache(ThreadState, false);
   }
 
 	void *Entry = getCurr<void*>();

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -58,7 +58,7 @@ public:
   explicit JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread, CodeBuffer Buffer, bool CompileThread);
   ~JITCore() override;
   std::string GetName() override { return "JIT"; }
-  void *CompileCode(FEXCore::IR::IRListView<true> const *IR, FEXCore::Core::DebugData *DebugData) override;
+  void *CompileCode(FEXCore::IR::IRListView<true> const *IR, FEXCore::Core::DebugData *DebugData, FEXCore::IR::RegisterAllocationData *RAData) override;
 
   void *MapRegion(void* HostPtr, uint64_t, uint64_t) override { return HostPtr; }
 
@@ -128,6 +128,7 @@ private:
 
   void CreateCustomDispatch(FEXCore::Core::InternalThreadState *Thread);
   IR::RegisterAllocationPass *RAPass;
+  FEXCore::IR::RegisterAllocationData *RAData;
 
 #ifdef BLOCKSTATS
   bool GetSamplingData {true};

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -14,6 +14,7 @@ using namespace Xbyak;
 #include <FEXCore/Core/CPUBackend.h>
 #include <FEXCore/IR/IR.h>
 #include <FEXCore/IR/IntrusiveIRList.h>
+#include "Interface/IR/Passes/RegisterAllocationPass.h"
 
 #include <tuple>
 
@@ -106,7 +107,7 @@ private:
   constexpr static uint8_t RA_64 = 3;
   constexpr static uint8_t RA_XMM = 4;
 
-  uint32_t GetPhys(uint32_t Node);
+  IR::PhysicalRegister GetPhys(uint32_t Node);
 
   bool IsFPR(uint32_t Node);
   bool IsGPR(uint32_t Node);

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -30,6 +30,8 @@
     "static constexpr FEXCore::IR::RegisterClassType ComplexClass {5}",
     "static constexpr FEXCore::IR::RegisterClassType InvalidClass {7}",
     "",
+    "static constexpr uint8_t InvalidReg {31}",
+    "",
     "static const FEXCore::IR::TypeDefinition i8    {TypeDefinition::Create(1, 0)}",
     "static const FEXCore::IR::TypeDefinition i16   {TypeDefinition::Create(2, 0)}",
     "static const FEXCore::IR::TypeDefinition i32   {TypeDefinition::Create(4, 0)}",

--- a/External/FEXCore/Source/Interface/IR/IRDumper.cpp
+++ b/External/FEXCore/Source/Interface/IR/IRDumper.cpp
@@ -74,15 +74,15 @@ static void PrintArg(std::stringstream *out, [[maybe_unused]] IRListView<false> 
     *out << "Unknown Registerclass " << Arg;
 }
 
-static void PrintArg(std::stringstream *out, IRListView<false> const* IR, OrderedNodeWrapper Arg, IR::RegisterAllocationPass *RAPass) {
+static void PrintArg(std::stringstream *out, IRListView<false> const* IR, OrderedNodeWrapper Arg, IR::RegisterAllocationData *RAData) {
   auto [CodeNode, IROp] = IR->at(Arg)();
 
   if (Arg.ID() == 0) {
     *out << "%Invalid";
   } else {
     *out << "%ssa" << std::to_string(Arg.ID());
-    if (RAPass) {
-      uint64_t RegClass = RAPass->GetNodeRegister(Arg.ID());
+    if (RAData) {
+      uint64_t RegClass = RAData->GetNodeRegister(Arg.ID());
       FEXCore::IR::RegisterClassType Class {uint32_t(RegClass >> 32)};
       uint32_t Reg = RegClass;
       switch (Class) {
@@ -147,7 +147,7 @@ static void PrintArg(std::stringstream *out, [[maybe_unused]] IRListView<false> 
   }
 }
 
-void Dump(std::stringstream *out, IRListView<false> const* IR, IR::RegisterAllocationPass *RAPass) {
+void Dump(std::stringstream *out, IRListView<false> const* IR, IR::RegisterAllocationData *RAData) {
   auto HeaderOp = IR->GetHeader();
 
   int8_t CurrentIndent = 0;
@@ -204,8 +204,8 @@ void Dump(std::stringstream *out, IRListView<false> const* IR, IR::RegisterAlloc
 
           *out << "%ssa" << std::to_string(ID);
 
-          if (RAPass) {
-            uint64_t RegClass = RAPass->GetNodeRegister(ID);
+          if (RAData) {
+            uint64_t RegClass = RAData->GetNodeRegister(ID);
             FEXCore::IR::RegisterClassType Class {uint32_t(RegClass >> 32)};
             uint32_t Reg = RegClass;
             switch (Class) {
@@ -264,9 +264,9 @@ void Dump(std::stringstream *out, IRListView<false> const* IR, IR::RegisterAlloc
             auto [NodeNode, IROp] = NodeBegin();
             auto PhiOp  = IROp->C<IR::IROp_PhiValue>();
             *out << "[ ";
-            PrintArg(out, IR, PhiOp->Value, RAPass);
+            PrintArg(out, IR, PhiOp->Value, RAData);
             *out << ", ";
-            PrintArg(out, IR, PhiOp->Block, RAPass);
+            PrintArg(out, IR, PhiOp->Block, RAData);
             *out << " ]";
 
             if (PhiOp->Next.ID())

--- a/External/FEXCore/Source/Interface/IR/IRDumper.cpp
+++ b/External/FEXCore/Source/Interface/IR/IRDumper.cpp
@@ -82,10 +82,9 @@ static void PrintArg(std::stringstream *out, IRListView<false> const* IR, Ordere
   } else {
     *out << "%ssa" << std::to_string(Arg.ID());
     if (RAData) {
-      uint64_t RegClass = RAData->GetNodeRegister(Arg.ID());
-      FEXCore::IR::RegisterClassType Class {uint32_t(RegClass >> 32)};
-      uint32_t Reg = RegClass;
-      switch (Class) {
+      auto PhyReg = RAData->GetNodeRegister(Arg.ID());
+      
+      switch (PhyReg.Class) {
         case FEXCore::IR::GPRClass.Val: *out << "(GPR"; break;
         case FEXCore::IR::GPRFixedClass.Val: *out << "(GPRFixed"; break;
         case FEXCore::IR::FPRClass.Val: *out << "(FPR"; break;
@@ -96,8 +95,8 @@ static void PrintArg(std::stringstream *out, IRListView<false> const* IR, Ordere
         default: *out << "(Unknown"; break;
       }
 
-      if (Class != FEXCore::IR::InvalidClass.Val) {
-        *out << std::dec << Reg << ")";
+      if (PhyReg.Class != FEXCore::IR::InvalidClass.Val) {
+        *out << std::dec << (uint32_t)PhyReg.Reg << ")";
       } else {
         *out << ")";
       }
@@ -205,10 +204,8 @@ void Dump(std::stringstream *out, IRListView<false> const* IR, IR::RegisterAlloc
           *out << "%ssa" << std::to_string(ID);
 
           if (RAData) {
-            uint64_t RegClass = RAData->GetNodeRegister(ID);
-            FEXCore::IR::RegisterClassType Class {uint32_t(RegClass >> 32)};
-            uint32_t Reg = RegClass;
-            switch (Class) {
+            auto PhyReg = RAData->GetNodeRegister(ID);
+            switch (PhyReg.Class) {
               case FEXCore::IR::GPRClass.Val: *out << "(GPR"; break;
               case FEXCore::IR::GPRFixedClass.Val: *out << "(GPRFixed"; break;
               case FEXCore::IR::FPRClass.Val: *out << "(FPR"; break;
@@ -218,8 +215,8 @@ void Dump(std::stringstream *out, IRListView<false> const* IR, IR::RegisterAlloc
               case FEXCore::IR::InvalidClass.Val: *out << "(Invalid"; break;
               default: *out << "(Unknown"; break;
             }
-            if (Class != FEXCore::IR::InvalidClass.Val) {
-              *out << std::dec << Reg << ")";
+            if (PhyReg.Class != FEXCore::IR::InvalidClass.Val) {
+              *out << std::dec << (uint32_t)PhyReg.Reg << ")";
             } else {
               *out << ")";
             }

--- a/External/FEXCore/Source/Interface/IR/PassManager.cpp
+++ b/External/FEXCore/Source/Interface/IR/PassManager.cpp
@@ -1,6 +1,6 @@
+#include "Interface/IR/PassManager.h"
 #include "Interface/IR/Passes.h"
 #include "Interface/IR/Passes/RegisterAllocationPass.h"
-#include "Interface/IR/PassManager.h"
 
 #include <FEXCore/Config/Config.h>
 

--- a/External/FEXCore/Source/Interface/IR/Passes.h
+++ b/External/FEXCore/Source/Interface/IR/Passes.h
@@ -3,6 +3,7 @@
 namespace FEXCore::IR {
 class Pass;
 class RegisterAllocationPass;
+class RegisterAllocationData;
 
 FEXCore::IR::Pass* CreateConstProp(bool InlineConstants);
 FEXCore::IR::Pass* CreateContextLoadStoreElimination();

--- a/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
@@ -52,7 +52,7 @@ bool IRValidation::Run(IREmitter *IREmit) {
 
   IR::RegisterAllocationData * RAData{};
   if (Manager->HasRAPass() && !HeaderOp->ShouldInterpret) {
-    RAData = Manager->GetRAPass()->GetAllocationData();
+    RAData = Manager->GetRAPass() ? Manager->GetRAPass()->GetAllocationData() : nullptr;
   }
 
   for (auto [BlockNode, BlockHeader] : CurrentIR.GetBlocks()) {

--- a/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
@@ -83,10 +83,10 @@ bool IRValidation::Run(IREmitter *IREmit) {
 
         if (RAData) {
           // If we have a register allocator then the destination needs to be assigned a register and class
-          uint64_t Reg = RAData->GetNodeRegister(ID);
+          auto PhyReg = RAData->GetNodeRegister(ID);
 
           FEXCore::IR::RegisterClassType ExpectedClass = IR::GetRegClass(IROp->Op);
-          FEXCore::IR::RegisterClassType AssignedClass = FEXCore::IR::RegisterClassType{uint32_t(Reg >> 32)};
+          FEXCore::IR::RegisterClassType AssignedClass = FEXCore::IR::RegisterClassType{PhyReg.Class};
 
           // If no register class was assigned
           if (AssignedClass == IR::InvalidClass) {
@@ -95,7 +95,7 @@ bool IRValidation::Run(IREmitter *IREmit) {
           }
 
           // If no physical register was assigned
-          if ((uint32_t)Reg == ~0U) {
+          if (PhyReg.Reg == IR::InvalidReg) {
             HadError |= true;
             Errors << "%ssa" << ID << ": Had destination but with no register assigned" << std::endl;
           }

--- a/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -381,7 +381,7 @@ namespace FEXCore::IR {
        * Top 32bits is the class, lower 32bits is the register
        */
       RegisterAllocationData* GetAllocationData() override;
-      std::unique_ptr<RegisterAllocationData, RegisterAllocationDataDeleter> &PullAllocationData() override;
+      std::unique_ptr<RegisterAllocationData, RegisterAllocationDataDeleter> PullAllocationData() override;
     private:
       bool OptimizeSRA;
       uint32_t SpillPointId;
@@ -461,8 +461,8 @@ namespace FEXCore::IR {
     return Graph->AllocData.get();
   }
 
-  std::unique_ptr<RegisterAllocationData, RegisterAllocationDataDeleter>& ConstrainedRAPass::PullAllocationData() {
-    return Graph->AllocData;
+  std::unique_ptr<RegisterAllocationData, RegisterAllocationDataDeleter> ConstrainedRAPass::PullAllocationData() {
+    return std::move(Graph->AllocData);
   }
 
   void ConstrainedRAPass::RecursiveLiveRangeExpansion(FEXCore::IR::IRListView<false> *IR, uint32_t Node, uint32_t DefiningBlockID, LiveRange *LiveRange, const std::unordered_set<uint32_t> &Predecessors, std::unordered_set<uint32_t> &VisitedPredecessors) {

--- a/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -193,6 +193,7 @@ namespace {
   };
 
   struct RegisterGraph {
+    FEXCore::IR::RegisterAllocationData RegAllocMap;
     RegisterSet Set;
     std::vector<RegisterNode> Nodes;
     uint32_t NodeCount;
@@ -390,7 +391,7 @@ namespace FEXCore::IR {
        * @brief Returns the register and class encoded together
        * Top 32bits is the class, lower 32bits is the register
        */
-      uint64_t GetNodeRegister(uint32_t Node) override;
+      RegisterAllocationData* GetAllocationData() override;
     private:
       bool OptimizeSRA;
       uint32_t SpillPointId;
@@ -466,8 +467,12 @@ namespace FEXCore::IR {
     VirtualAddRegisterConflict(Graph, ClassConflict, RegConflict, Class, Reg);
   }
 
-  uint64_t ConstrainedRAPass::GetNodeRegister(uint32_t Node) {
-    return Graph->Nodes[Node].Head.RegAndClass;
+  RegisterAllocationData* ConstrainedRAPass::GetAllocationData() {
+    Graph->RegAllocMap.RegAndClass.resize(Graph->Nodes.size());
+    for (size_t i = 0; i < Graph->Nodes.size(); i++) {
+      Graph->RegAllocMap.RegAndClass[i] = Graph->Nodes[i].Head.RegAndClass;
+  }
+    return &Graph->RegAllocMap;
   }
 
   void ConstrainedRAPass::RecursiveLiveRangeExpansion(FEXCore::IR::IRListView<false> *IR, uint32_t Node, uint32_t DefiningBlockID, LiveRange *LiveRange, const std::unordered_set<uint32_t> &Predecessors, std::unordered_set<uint32_t> &VisitedPredecessors) {

--- a/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.h
+++ b/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.h
@@ -6,10 +6,19 @@ namespace FEXCore::IR {
 template<bool>
 class IRListView;
 
+class RegisterAllocationData {
+  public:
+    std::vector<uint64_t> RegAndClass;
+    uint32_t SpillSlotCount {};
+    uint64_t GetNodeRegister(uint32_t Node) {
+      return RegAndClass[Node];
+    }
+    uint32_t SpillSlots() const { return SpillSlotCount; }
+};
+
 class RegisterAllocationPass : public FEXCore::IR::Pass {
   public:
     bool HasFullRA() const { return HadFullRA; }
-    uint32_t SpillSlots() const { return SpillSlotCount; }
 
     virtual void AllocateRegisterSet(uint32_t RegisterCount, uint32_t ClassCount) = 0;
     virtual void AddRegisters(FEXCore::IR::RegisterClassType Class, uint32_t RegisterCount) = 0;
@@ -36,7 +45,7 @@ class RegisterAllocationPass : public FEXCore::IR::Pass {
      * @brief Returns the register and class encoded together
      * Top 32bits is the class, lower 32bits is the register
      */
-    virtual uint64_t GetNodeRegister(uint32_t Node) = 0;
+    virtual RegisterAllocationData* GetAllocationData() = 0;
     /**  @} */
 
   protected:

--- a/External/FEXCore/include/FEXCore/Core/CPUBackend.h
+++ b/External/FEXCore/include/FEXCore/Core/CPUBackend.h
@@ -7,6 +7,7 @@ namespace FEXCore {
 namespace IR {
   template<bool Copy>
   class IRListView;
+  class RegisterAllocationData;
 }
 
 namespace Core {
@@ -44,7 +45,7 @@ class LLVMCore;
      * @return An executable function pointer that is theoretically compiled from this point.
      * Is actually a function pointer of type `void (FEXCore::Core::ThreadState *Thread)
      */
-    virtual void *CompileCode(FEXCore::IR::IRListView<true> const *IR, FEXCore::Core::DebugData *DebugData) = 0;
+    virtual void *CompileCode(FEXCore::IR::IRListView<true> const *IR, FEXCore::Core::DebugData *DebugData, FEXCore::IR::RegisterAllocationData *RAData) = 0;
 
     /**
      * @brief Function for mapping memory in to the CPUBackend's visible space. Allows setting up virtual mappings if required

--- a/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
+++ b/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
@@ -3,7 +3,9 @@
 #include <FEXCore/Core/CoreState.h>
 #include <FEXCore/Core/CPUBackend.h>
 #include <FEXCore/IR/IntrusiveIRList.h>
+#include <FEXCore/IR/RegisterAllocationData.h>
 #include <FEXCore/Utils/Event.h>
+
 #include <map>
 #include <thread>
 
@@ -78,7 +80,8 @@ namespace FEXCore::Core {
     std::unique_ptr<FEXCore::LookupCache> LookupCache;
 
     std::unordered_map<uint64_t, std::unique_ptr<FEXCore::IR::IRListView<true>>> IRLists;
-    std::unordered_map<uint64_t, FEXCore::Core::DebugData> DebugData;
+    std::unordered_map<uint64_t, std::unique_ptr<FEXCore::IR::RegisterAllocationData, FEXCore::IR::RegisterAllocationDataDeleter>> RALists;
+    std::unordered_map<uint64_t, std::unique_ptr<FEXCore::Core::DebugData>> DebugData;
 
     std::unique_ptr<FEXCore::Frontend::Decoder> FrontendDecoder;
     std::unique_ptr<FEXCore::IR::PassManager> PassManager;

--- a/External/FEXCore/include/FEXCore/IR/IR.h
+++ b/External/FEXCore/include/FEXCore/IR/IR.h
@@ -7,6 +7,7 @@
 
 namespace FEXCore::IR {
 class RegisterAllocationPass;
+class RegisterAllocationData;
 
 /**
  * @brief The IROp_Header is an dynamically sized array
@@ -459,7 +460,7 @@ template<bool>
 class IRListView;
 class IREmitter;
 
-void Dump(std::stringstream *out, IRListView<false> const* IR, IR::RegisterAllocationPass *RAPass);
+void Dump(std::stringstream *out, IRListView<false> const* IR, IR::RegisterAllocationData *RAData);
 IREmitter* Parse(std::istream *in);
 
 template<typename Type>

--- a/External/FEXCore/include/FEXCore/IR/RegisterAllocationData.h
+++ b/External/FEXCore/include/FEXCore/IR/RegisterAllocationData.h
@@ -1,0 +1,52 @@
+#pragma once
+#include "IR.h"
+
+namespace FEXCore::IR {
+
+union PhysicalRegister {
+  uint8_t Raw;
+  struct {
+    uint8_t Reg: 5;
+    uint8_t Class: 3;
+  };
+
+  bool operator==(const PhysicalRegister &Other) const {
+    return Raw == Other.Raw;
+  }
+
+  PhysicalRegister(RegisterClassType Class, uint8_t Reg) : Reg(Reg), Class(Class.Val) { }
+
+  static const PhysicalRegister Invalid() {
+    return PhysicalRegister(InvalidClass, InvalidReg);
+  }
+
+  bool IsInvalid() {
+    return *this == Invalid();
+  }
+};
+
+static_assert(sizeof(PhysicalRegister) == 1);
+
+class RegisterAllocationData;
+struct RegisterAllocationDataDeleter {
+  void operator()(RegisterAllocationData* r) {
+    free(r);
+  }
+};
+
+class RegisterAllocationData {
+  public:
+    uint32_t SpillSlotCount {};
+    PhysicalRegister Map[0];
+
+    PhysicalRegister GetNodeRegister(uint32_t Node) const {
+      return Map[Node];
+    }
+    uint32_t SpillSlots() const { return SpillSlotCount; }
+
+    static size_t Size(uint32_t NodeCount) {
+      return sizeof(RegisterAllocationData) + NodeCount * sizeof(Map[0]);
+    }
+};
+
+} 

--- a/Source/CommonCore/HostFactory.cpp
+++ b/Source/CommonCore/HostFactory.cpp
@@ -30,7 +30,7 @@ namespace HostFactory {
     explicit HostCore(FEXCore::Context::Context* CTX, FEXCore::Core::ThreadState *Thread, bool Fallback);
     ~HostCore() override;
     std::string GetName() override { return "Host Core"; }
-    void* CompileCode(FEXCore::IR::IRListView<true> const *IR, FEXCore::Core::DebugData *DebugData) override;
+    void* CompileCode(FEXCore::IR::IRListView<true> const *IR, FEXCore::Core::DebugData *DebugData, FEXCore::IR::RegisterAllocationData *RAData) override;
 
     void *MapRegion(void *HostPtr, uint64_t VirtualGuestPtr, uint64_t Size) override {
       return HostPtr;
@@ -177,7 +177,7 @@ namespace HostFactory {
     ready();
   }
 
-  void* HostCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const *IR, FEXCore::Core::DebugData *DebugData) {
+  void* HostCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView<true> const *IR, FEXCore::Core::DebugData *DebugData, FEXCore::IR::RegisterAllocationData *RAData) {
     return nullptr;
   }
 


### PR DESCRIPTION
## Overview
Sadly the two parts can't be nicely separated because of how the core/context/compile service were interacting.

### Part A
Moves reg alloc mappings to `RegisterAllocationData` (RAData) from `RAPass`. This makes it possible to re-compile from IR w/o running the optimization passes again. Needed to fix some edge cases where we used stale RA data, for IRLists caching to work and for AOT in the future.

### Part B (7db931b)
This majorly refactors how code gets compiled, and cleans up a lot of things in the way. Removes the LookupCache, IRLists, DebugData usage from the Compile Service, simplifies how caches are cleared, stores RAData so that IRLists can be correctly re-compiled and loads of other cleanups.