### PR TITLE
BlockCache -> LookupCache, L3C

### DIFF
--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -118,7 +118,7 @@ set (SRCS
   Common/SoftFloat-3e/s_f32UIToCommonNaN.c
   Interface/Config/Config.cpp
   Interface/Context/Context.cpp
-  Interface/Core/BlockCache.cpp
+  Interface/Core/LookupCache.cpp
   Interface/Core/BlockSamplingData.cpp
   Interface/Core/CompileService.cpp
   Interface/Core/Core.cpp

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -166,7 +166,7 @@ namespace FEXCore::Context {
     void ExecutionThread(FEXCore::Core::InternalThreadState *Thread);
     void NotifyPause();
 
-    uintptr_t AddBlockMapping(FEXCore::Core::InternalThreadState *Thread, uint64_t Address, void *Ptr);
+    void AddBlockMapping(FEXCore::Core::InternalThreadState *Thread, uint64_t Address, void *Ptr);
 
     FEXCore::CodeLoader *LocalLoader{};
 

--- a/External/FEXCore/Source/Interface/Core/CompileService.cpp
+++ b/External/FEXCore/Source/Interface/Core/CompileService.cpp
@@ -150,11 +150,7 @@ namespace FEXCore {
             ERROR_AND_DIE("Couldn't compile code for thread at RIP: 0x%lx", Item->RIP);
           }
 
-          auto BlockMapPtr = CompileThreadData->LookupCache->AddBlockMapping(Item->RIP, CompiledCode);
-          if (BlockMapPtr == 0) {
-            // XXX: We currently have the expectation that compiler service block cache will be significantly underutilized compared to regular thread
-            ERROR_AND_DIE("Couldn't add code to block cache for thread at RIP: 0x%lx", Item->RIP);
-          }
+          CompileThreadData->LookupCache->AddBlockMapping(Item->RIP, CompiledCode);
 
           Item->CodePtr = CompiledCode;
           Item->IRList = CompileThreadData->IRLists.find(Item->RIP)->second.get();

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -559,24 +559,8 @@ namespace FEXCore::Context {
     return Thread;
   }
 
-  uintptr_t Context::AddBlockMapping(FEXCore::Core::InternalThreadState *Thread, uint64_t Address, void *Ptr) {
-    auto BlockMapPtr = Thread->LookupCache->AddBlockMapping(Address, Ptr);
-    if (BlockMapPtr == 0) {
-      Thread->LookupCache->ClearCache();
-
-      // Pull out the current IR we added and store it back after we cleared the rest of the list
-      // Needed in the case the the block mapping has aliased
-      auto iter = Thread->IRLists.find(Address);
-      if (iter != Thread->IRLists.end()) {
-        auto IR = iter->second.release();
-        Thread->IRLists.clear();
-        Thread->IRLists.try_emplace(Address, IR);
-      }
-      BlockMapPtr = Thread->LookupCache->AddBlockMapping(Address, Ptr);
-      LogMan::Throw::A(BlockMapPtr, "Couldn't add mapping after clearing mapping cache");
-    }
-
-    return BlockMapPtr;
+  void Context::AddBlockMapping(FEXCore::Core::InternalThreadState *Thread, uint64_t Address, void *Ptr) {
+    Thread->LookupCache->AddBlockMapping(Address, Ptr);
   }
 
   void Context::ClearCodeCache(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP) {
@@ -815,6 +799,13 @@ namespace FEXCore::Context {
   }
 
   uintptr_t Context::CompileBlock(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP) {
+    
+    // Is the code in the cache?
+    // The backends only check L1 and L2, not L3
+    if (auto HostCode = Thread->LookupCache->FindBlock(GuestRIP)) {
+      return HostCode;
+    }
+
     void *CodePtr;
     FEXCore::Core::DebugData *DebugData;
     bool DecrementRefCount = false;
@@ -855,7 +846,9 @@ namespace FEXCore::Context {
 
       if (DecrementRefCount)
         --Thread->CompileBlockReentrantRefCount;
-      return AddBlockMapping(Thread, GuestRIP, CodePtr);
+      AddBlockMapping(Thread, GuestRIP, CodePtr);
+
+      return (uintptr_t)CodePtr;
     }
 
     if (DecrementRefCount)
@@ -869,12 +862,8 @@ namespace FEXCore::Context {
     // This will most likely fail since regular code use won't be using a fallback core.
     // It's mainly for testing new instruction encodings
     void *CodePtr = Thread->FallbackBackend->CompileCode(nullptr, nullptr);
-    if (CodePtr) {
-     uintptr_t Ptr = reinterpret_cast<uintptr_t >(AddBlockMapping(Thread, GuestRIP, CodePtr));
-     return Ptr;
-    }
-
-    return 0;
+    AddBlockMapping(Thread, GuestRIP, CodePtr);
+    return (uintptr_t)CodePtr;
   }
 
   void Context::ExecutionThread(FEXCore::Core::InternalThreadState *Thread) {

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterClass.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterClass.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Interface/Core/BlockCache.h"
+#include "Interface/Core/LookupCache.h"
 #include "Interface/Core/InternalThreadState.h"
 
 #include <FEXCore/Core/CPUBackend.h>

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -5,7 +5,7 @@
 #ifdef _M_ARM_64
 #include "Interface/Core/ArchHelpers/Arm64.h"
 #endif
-#include "Interface/Core/BlockCache.h"
+#include "Interface/Core/LookupCache.h"
 #include "Interface/Core/DebugData.h"
 #include "Interface/Core/InternalThreadState.h"
 #include "Interface/Core/Interpreter/InterpreterClass.h"

--- a/External/FEXCore/Source/Interface/Core/Interpreter/x86_64Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/x86_64Dispatcher.cpp
@@ -94,13 +94,13 @@ DispatchGenerator::DispatchGenerator(FEXCore::Context::Context *ctx, FEXCore::Co
   AbsoluteLoopTopAddress = getCurr<uint64_t>();
 
   {
-    mov(r13, Thread->BlockCache->GetPagePointer());
+    mov(r13, Thread->LookupCache->GetPagePointer());
 
     // Load our RIP
     mov(rdx, qword [STATE + offsetof(FEXCore::Core::CPUState, rip)]);
 
     mov(rax, rdx);
-    mov(rbx, Thread->BlockCache->GetVirtualMemorySize() - 1);
+    mov(rbx, Thread->LookupCache->GetVirtualMemorySize() - 1);
     and_(rax, rbx);
     shr(rax, 12);
 
@@ -113,7 +113,7 @@ DispatchGenerator::DispatchGenerator(FEXCore::Context::Context *ctx, FEXCore::Co
     mov (rax, rdx);
     and_(rax, 0x0FFF);
 
-    shl(rax, (int)log2(sizeof(FEXCore::BlockCache::BlockCacheEntry)));
+    shl(rax, (int)log2(sizeof(FEXCore::LookupCache::LookupCacheEntry)));
 
     // check for aliasing
     mov(rcx, qword [rdi + rax + 8]);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
@@ -84,9 +84,9 @@ DEF_OP(ExitFunction) {
     RipReg = GetReg<RA_64>(Op->Header.Args[0].ID());
     
     // L1 Cache
-    LoadConstant(x0, State->BlockCache->GetL1Pointer());
+    LoadConstant(x0, State->LookupCache->GetL1Pointer());
 
-    and_(x3, RipReg, BlockCache::L1_ENTRIES_MASK);
+    and_(x3, RipReg, LookupCache::L1_ENTRIES_MASK);
     add(x0, x0, Operand(x3, Shift::LSL, 4));
 
     ldp(x1, x0, MemOperand(x0));

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Interface/Core/BlockCache.h"
+#include "Interface/Core/LookupCache.h"
 
 #include "aarch64/assembler-aarch64.h"
 #include "aarch64/cpu-aarch64.h"

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
@@ -81,10 +81,10 @@ DEF_OP(ExitFunction) {
     Xbyak::Reg RipReg = GetSrc<RA_64>(Op->NewRIP.ID());
     
     // L1 Cache
-    mov(rcx, ThreadState->BlockCache->GetL1Pointer());
+    mov(rcx, ThreadState->LookupCache->GetL1Pointer());
     mov(rax, RipReg);
 
-    and_(rax, BlockCache::L1_ENTRIES_MASK);
+    and_(rax, LookupCache::L1_ENTRIES_MASK);
     shl(rax, 4);
 
     Xbyak::RegExp LookupBase = rcx + rax;

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Interface/Core/BlockCache.h"
+#include "Interface/Core/LookupCache.h"
 #include "Interface/Core/BlockSamplingData.h"
 
 #include "Interface/Core/JIT/x86_64/JIT.h"

--- a/External/FEXCore/Source/Interface/Core/LookupCache.cpp
+++ b/External/FEXCore/Source/Interface/Core/LookupCache.cpp
@@ -1,10 +1,10 @@
 #include "Interface/Context/Context.h"
 #include "Interface/Core/Core.h"
-#include "Interface/Core/BlockCache.h"
+#include "Interface/Core/LookupCache.h"
 #include <sys/mman.h>
 
 namespace FEXCore {
-BlockCache::BlockCache(FEXCore::Context::Context *CTX)
+LookupCache::LookupCache(FEXCore::Context::Context *CTX)
   : ctx {CTX} {
 
   // Block cache ends up looking like this
@@ -36,13 +36,13 @@ BlockCache::BlockCache(FEXCore::Context::Context *CTX)
   VirtualMemSize = ctx->Config.VirtualMemSize;
 }
 
-BlockCache::~BlockCache() {
+LookupCache::~LookupCache() {
   munmap(reinterpret_cast<void*>(PagePointer), ctx->Config.VirtualMemSize / 4096 * 8);
   munmap(reinterpret_cast<void*>(PageMemory), CODE_SIZE);
   munmap(reinterpret_cast<void*>(L1Pointer), L1_SIZE);
 }
 
-void BlockCache::HintUsedRange(uint64_t Address, uint64_t Size) {
+void LookupCache::HintUsedRange(uint64_t Address, uint64_t Size) {
   // Tell the kernel we will definitely need [Address, Address+Size) mapped for the page pointer
   // Page Pointer is allocated per page, so shift by page size
   Address >>= 12;
@@ -50,7 +50,7 @@ void BlockCache::HintUsedRange(uint64_t Address, uint64_t Size) {
   madvise(reinterpret_cast<void*>(PagePointer + Address), Size, MADV_WILLNEED);
 }
 
-void BlockCache::ClearCache() {
+void LookupCache::ClearCache() {
   // Clear out the page memory
   madvise(reinterpret_cast<void*>(PagePointer), ctx->Config.VirtualMemSize / 4096 * 8, MADV_DONTNEED);
   madvise(reinterpret_cast<void*>(PageMemory), CODE_SIZE, MADV_DONTNEED);

--- a/External/FEXCore/Source/Interface/Core/LookupCache.cpp
+++ b/External/FEXCore/Source/Interface/Core/LookupCache.cpp
@@ -50,14 +50,22 @@ void LookupCache::HintUsedRange(uint64_t Address, uint64_t Size) {
   madvise(reinterpret_cast<void*>(PagePointer + Address), Size, MADV_WILLNEED);
 }
 
-void LookupCache::ClearCache() {
+void LookupCache::ClearL2Cache() {
   // Clear out the page memory
   madvise(reinterpret_cast<void*>(PagePointer), ctx->Config.VirtualMemSize / 4096 * 8, MADV_DONTNEED);
   madvise(reinterpret_cast<void*>(PageMemory), CODE_SIZE, MADV_DONTNEED);
-  madvise(reinterpret_cast<void*>(L1Pointer), L1_SIZE, MADV_DONTNEED);
   AllocateOffset = 0;
+}
+
+void LookupCache::ClearCache() {
+  // Clear L1
+  madvise(reinterpret_cast<void*>(L1Pointer), L1_SIZE, MADV_DONTNEED);
+  // Clear L2
+  ClearL2Cache();
   // All code is gone, remove links
   BlockLinks.clear();
+  // All code is gone, clear the block list
+  BlockList.clear();
 }
 
 }

--- a/External/FEXCore/Source/Interface/Core/LookupCache.h
+++ b/External/FEXCore/Source/Interface/Core/LookupCache.h
@@ -3,18 +3,18 @@
 #include <FEXCore/Utils/LogManager.h>
 
 namespace FEXCore {
-class BlockCache {
+class LookupCache {
 public:
 
-  struct BlockCacheEntry { 
+  struct LookupCacheEntry { 
     uintptr_t HostCode;
     uintptr_t GuestCode;
   };
 
-  BlockCache(FEXCore::Context::Context *CTX);
-  ~BlockCache();
+  LookupCache(FEXCore::Context::Context *CTX);
+  ~LookupCache();
 
-  using BlockCacheIter = uintptr_t;
+  using LookupCacheIter = uintptr_t;
   uintptr_t End() { return 0; }
 
   uintptr_t FindBlock(uint64_t Address) {
@@ -31,7 +31,7 @@ public:
     }
 
     // Do L1
-    auto &L1Entry = reinterpret_cast<BlockCacheEntry*>(L1Pointer)[Address & L1_ENTRIES_MASK];
+    auto &L1Entry = reinterpret_cast<LookupCacheEntry*>(L1Pointer)[Address & L1_ENTRIES_MASK];
     if (L1Entry.GuestCode == Address) {
       L1Entry.GuestCode = L1Entry.HostCode = 0;
     }
@@ -49,14 +49,14 @@ public:
     }
 
     // Page exists, just set the offset to zero
-    auto BlockPointers = reinterpret_cast<BlockCacheEntry*>(LocalPagePointer);
+    auto BlockPointers = reinterpret_cast<LookupCacheEntry*>(LocalPagePointer);
     BlockPointers[PageOffset].GuestCode = 0;
     BlockPointers[PageOffset].HostCode = 0;
   }
 
   uintptr_t AddBlockMapping(uint64_t Address, void *Ptr) { 
     // Do L1
-    auto &L1Entry = reinterpret_cast<BlockCacheEntry*>(L1Pointer)[Address & L1_ENTRIES_MASK];
+    auto &L1Entry = reinterpret_cast<LookupCacheEntry*>(L1Pointer)[Address & L1_ENTRIES_MASK];
     if (L1Entry.GuestCode == Address) {
       L1Entry.GuestCode = L1Entry.HostCode = 0;
     }
@@ -82,7 +82,7 @@ public:
     }
 
     // Add the new pointer to the page block
-    auto BlockPointers = reinterpret_cast<BlockCacheEntry*>(LocalPagePointer);
+    auto BlockPointers = reinterpret_cast<LookupCacheEntry*>(LocalPagePointer);
     uintptr_t CastPtr = reinterpret_cast<uintptr_t>(Ptr);
 
     // This silently replaces existing mappings
@@ -125,7 +125,7 @@ private:
   uintptr_t FindCodePointerForAddress(uint64_t Address) {
     
     // Do L1
-    auto &L1Entry = reinterpret_cast<BlockCacheEntry*>(L1Pointer)[Address & L1_ENTRIES_MASK];
+    auto &L1Entry = reinterpret_cast<LookupCacheEntry*>(L1Pointer)[Address & L1_ENTRIES_MASK];
     if (L1Entry.GuestCode == Address) {
       return L1Entry.HostCode;
     }
@@ -143,7 +143,7 @@ private:
     }
 
     // Find there pointer for the address in the blocks
-    auto BlockPointers = reinterpret_cast<BlockCacheEntry*>(LocalPagePointer);
+    auto BlockPointers = reinterpret_cast<LookupCacheEntry*>(LocalPagePointer);
 
     if (BlockPointers[PageOffset].GuestCode == FullAddress)
     {
@@ -175,8 +175,8 @@ private:
   std::map<BlockLinkTag, std::function<void()>> BlockLinks;
 
   constexpr static size_t CODE_SIZE = 128 * 1024 * 1024;
-  constexpr static size_t SIZE_PER_PAGE = 4096 * sizeof(BlockCacheEntry);
-  constexpr static size_t L1_SIZE = L1_ENTRIES * sizeof(BlockCacheEntry);
+  constexpr static size_t SIZE_PER_PAGE = 4096 * sizeof(LookupCacheEntry);
+  constexpr static size_t L1_SIZE = L1_ENTRIES * sizeof(LookupCacheEntry);
 
   size_t AllocateOffset {};
 

--- a/External/FEXCore/Source/Interface/Core/LookupCache.h
+++ b/External/FEXCore/Source/Interface/Core/LookupCache.h
@@ -18,7 +18,26 @@ public:
   uintptr_t End() { return 0; }
 
   uintptr_t FindBlock(uint64_t Address) {
-    return FindCodePointerForAddress(Address);
+    auto HostCode = FindCodePointerForAddress(Address);
+    if (HostCode) {
+      return HostCode;
+    } else {
+      auto HostCode = BlockList.find(Address);
+
+      if (HostCode != BlockList.end()) {
+        CacheBlockMapping(Address, HostCode->second);
+        return HostCode->second;
+      } else {
+        return 0;
+      }
+    }
+  }
+
+  void AddBlockMapping(uint64_t Address, void *HostCode) { 
+    auto InsertPoint = BlockList.emplace(Address, (uintptr_t)HostCode);
+    LogMan::Throw::A(InsertPoint.second == true, "Dupplicate block mapping added");
+
+    // no need to update L1 or L2, they will get updated on first lookup
   }
 
   void Erase(uint64_t Address) {
@@ -29,6 +48,9 @@ public:
     for (auto it = lower; it != upper; it = BlockLinks.erase(it)) {
       it->second();
     }
+
+    // Remove from BlockList
+    BlockList.erase(Address);
 
     // Do L1
     auto &L1Entry = reinterpret_cast<LookupCacheEntry*>(L1Pointer)[Address & L1_ENTRIES_MASK];
@@ -54,7 +76,25 @@ public:
     BlockPointers[PageOffset].HostCode = 0;
   }
 
-  uintptr_t AddBlockMapping(uint64_t Address, void *Ptr) { 
+
+  void AddBlockLink(uint64_t GuestDestination, uintptr_t HostLink, const std::function<void()> &delinker) {
+    BlockLinks.insert({{GuestDestination, HostLink}, delinker});
+  }
+
+  void ClearCache();
+  void ClearL2Cache();
+
+  void HintUsedRange(uint64_t Address, uint64_t Size);
+
+  uintptr_t GetL1Pointer() { return L1Pointer; }
+  uintptr_t GetPagePointer() { return PagePointer; }
+  uintptr_t GetVirtualMemorySize() const { return VirtualMemSize; }
+
+  constexpr static size_t L1_ENTRIES = 1 * 1024 * 1024; // Must be a power of 2
+  constexpr static size_t L1_ENTRIES_MASK = L1_ENTRIES - 1;
+
+private:
+  void CacheBlockMapping(uint64_t Address, uintptr_t HostCode) { 
     // Do L1
     auto &L1Entry = reinterpret_cast<LookupCacheEntry*>(L1Pointer)[Address & L1_ENTRIES_MASK];
     if (L1Entry.GuestCode == Address) {
@@ -74,8 +114,9 @@ public:
       // Allocate one now if we can
       uintptr_t NewPageBacking = AllocateBackingForPage();
       if (!NewPageBacking) {
-        // Couldn't allocate, return so the frontend can recover from this
-        return 0;
+        // Couldn't allocate, clear L2 and retry
+        ClearL2Cache();
+        CacheBlockMapping(Address, HostCode);
       }
       Pointers[Address] = NewPageBacking;
       LocalPagePointer = NewPageBacking;
@@ -83,31 +124,12 @@ public:
 
     // Add the new pointer to the page block
     auto BlockPointers = reinterpret_cast<LookupCacheEntry*>(LocalPagePointer);
-    uintptr_t CastPtr = reinterpret_cast<uintptr_t>(Ptr);
 
     // This silently replaces existing mappings
     BlockPointers[PageOffset].GuestCode = FullAddress;
-    BlockPointers[PageOffset].HostCode = CastPtr;
-
-    return CastPtr;
+    BlockPointers[PageOffset].HostCode = HostCode;
   }
 
-  void AddBlockLink(uint64_t GuestDestination, uintptr_t HostLink, const std::function<void()> &delinker) {
-    BlockLinks.insert({{GuestDestination, HostLink}, delinker});
-  }
-
-  void ClearCache();
-
-  void HintUsedRange(uint64_t Address, uint64_t Size);
-
-  uintptr_t GetL1Pointer() { return L1Pointer; }
-  uintptr_t GetPagePointer() { return PagePointer; }
-  uintptr_t GetVirtualMemorySize() const { return VirtualMemSize; }
-
-  constexpr static size_t L1_ENTRIES = 1 * 1024 * 1024; // Must be a power of 2
-  constexpr static size_t L1_ENTRIES_MASK = L1_ENTRIES - 1;
-
-private:
   uintptr_t AllocateBackingForPage() {
     uintptr_t NewBase = AllocateOffset;
     uintptr_t NewEnd = AllocateOffset + SIZE_PER_PAGE;
@@ -173,6 +195,7 @@ private:
   };
 
   std::map<BlockLinkTag, std::function<void()>> BlockLinks;
+  std::map<uint64_t, uint64_t> BlockList;
 
   constexpr static size_t CODE_SIZE = 128 * 1024 * 1024;
   constexpr static size_t SIZE_PER_PAGE = 4096 * sizeof(LookupCacheEntry);

--- a/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
+++ b/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
@@ -8,7 +8,7 @@
 #include <thread>
 
 namespace FEXCore {
-  class BlockCache;
+  class LookupCache;
   class CompileService;
 }
 
@@ -75,7 +75,7 @@ namespace FEXCore::Core {
     std::shared_ptr<FEXCore::CPU::CPUBackend> IntBackend;
     std::unique_ptr<FEXCore::CPU::CPUBackend> FallbackBackend;
 
-    std::unique_ptr<FEXCore::BlockCache> BlockCache;
+    std::unique_ptr<FEXCore::LookupCache> LookupCache;
 
     std::unordered_map<uint64_t, std::unique_ptr<FEXCore::IR::IRListView<true>>> IRLists;
     std::unordered_map<uint64_t, FEXCore::Core::DebugData> DebugData;

--- a/Source/Tests/LinuxSyscalls/x32/Syscalls.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Syscalls.cpp
@@ -11,6 +11,10 @@
 #include <sys/shm.h>
 #include <sys/stat.h>
 
+#ifndef MREMAP_DONTUNMAP
+#define MREMAP_DONTUNMAP 4
+#endif
+
 namespace FEX::HLE::x32 {
 uint64_t MemAllocator::FindPageRange(uint64_t Start, size_t Pages) {
   // Linear range scan


### PR DESCRIPTION
## Overview
This renames BlockCache to LookupCache, and adds a 3rd level of lookup so that inserts never fail and that the lookup cache doesn't 'forget blocks'.

If L2 is full, it'll reset and lazy re-build the lookup cache from L3.

## Depends
- #721