### PR TITLE
Android build fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.14)
 project(FEX)
 
 option(BUILD_TESTS "Build unit tests to ensure sanity" TRUE)
+option(BUILD_THUNKS "Build thunks" FALSE)
 option(ENABLE_CLANG_FORMAT "Run clang format over the source" FALSE)
 option(ENABLE_IWYU "Enables include what you use program" FALSE)
 option(ENABLE_LTO "Enable LTO with compilation" TRUE)
@@ -175,21 +176,23 @@ if (BUILD_TESTS)
   add_subdirectory(unittests/)
 endif()
 
-include(ExternalProject)
+if (BUILD_THUNKS)
+  include(ExternalProject)
 
-ExternalProject_Add(host-libs
-	PREFIX host-libs
-	SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ThunkLibs/HostLibs"
-  BINARY_DIR "Host"
-	INSTALL_COMMAND ""
-  BUILD_ALWAYS ON
-)
+  ExternalProject_Add(host-libs
+    PREFIX host-libs
+    SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ThunkLibs/HostLibs"
+    BINARY_DIR "Host"
+    INSTALL_COMMAND ""
+    BUILD_ALWAYS ON
+  )
 
-ExternalProject_Add(guest-libs
-	PREFIX guest-libs
-	SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ThunkLibs/GuestLibs"
-  BINARY_DIR "Guest"
-  CMAKE_ARGS "-DX86_C_COMPILER:STRING=${X86_C_COMPILER}" "-DX86_CXX_COMPILER:STRING=${X86_CXX_COMPILER}"
-	INSTALL_COMMAND ""
-  BUILD_ALWAYS ON
-)
+  ExternalProject_Add(guest-libs
+    PREFIX guest-libs
+    SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ThunkLibs/GuestLibs"
+    BINARY_DIR "Guest"
+    CMAKE_ARGS "-DX86_C_COMPILER:STRING=${X86_C_COMPILER}" "-DX86_CXX_COMPILER:STRING=${X86_CXX_COMPILER}"
+    INSTALL_COMMAND ""
+    BUILD_ALWAYS ON
+  )
+endif()

--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -261,9 +261,6 @@ add_custom_target(IR_INC
 check_cxx_compiler_flag(-fdiagnostics-color=always GCC_COLOR)
 check_cxx_compiler_flag(-fcolor-diagnostics CLANG_COLOR)
 
-set(LINUX_LIBS
-  numa)
-
 function(AddLibrary Name Type)
   add_library(${Name} ${Type} ${SRCS})
   add_dependencies(${Name} IR_INC)

--- a/External/FEXCore/Source/Interface/Config/Config.cpp
+++ b/External/FEXCore/Source/Interface/Config/Config.cpp
@@ -4,6 +4,7 @@
 #include "Interface/Context/Context.h"
 
 #include <FEXCore/Config/Config.h>
+#include <map>
 
 namespace FEXCore::Config {
   void SetConfig(FEXCore::Context::Context *CTX, ConfigOption Option, uint64_t Config) {

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -26,6 +26,7 @@
 #ifdef _M_X86_64
 #include <xmmintrin.h>
 #endif
+#include <unistd.h>
 
 namespace FEXCore::CPU {
 
@@ -397,13 +398,19 @@ Res GetSrc(void* SSAData, IR::OrderedNodeWrapper Src) {
 [[noreturn]]
 static void StopThread(FEXCore::Core::InternalThreadState *Thread) {
   Thread->CTX->StopThread(Thread);
-  std::unexpected();
+
+  // If the StopThread signal is delayed for any reason, spin forever
+  for (;;)
+    sleep(1);
 }
 
 [[noreturn]]
 static void SignalReturn(FEXCore::Core::InternalThreadState *Thread) {
   Thread->CTX->SignalThread(Thread, FEXCore::Core::SIGNALEVENT_RETURN);
-  std::unexpected();
+
+  // If the return signal is delayed for any reason, spin forever
+  for (;;)
+    sleep(1);
 }
 
 void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, FEXCore::IR::IRListView<true> *CurrentIR, FEXCore::Core::DebugData *DebugData) {

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -352,7 +352,7 @@ bool IsConditionTrue(uint8_t Cond, uint64_t Src1, uint64_t Src2) {
     case FEXCore::IR::COND_ULE:
       CompResult = static_cast<unsigned_type>(Src1) <= static_cast<unsigned_type>(Src2);
       break;
-    
+
     case FEXCore::IR::COND_FLU:
       CompResult = reinterpret_cast<float_type&>(Src1) < reinterpret_cast<float_type&>(Src2) || (std::isnan(reinterpret_cast<float_type&>(Src1)) || std::isnan(reinterpret_cast<float_type&>(Src2)));
       break;
@@ -399,18 +399,14 @@ Res GetSrc(void* SSAData, IR::OrderedNodeWrapper Src) {
 static void StopThread(FEXCore::Core::InternalThreadState *Thread) {
   Thread->CTX->StopThread(Thread);
 
-  // If the StopThread signal is delayed for any reason, spin forever
-  for (;;)
-    sleep(1);
+  LogMan::Msg::A("unreachable");
 }
 
 [[noreturn]]
 static void SignalReturn(FEXCore::Core::InternalThreadState *Thread) {
   Thread->CTX->SignalThread(Thread, FEXCore::Core::SIGNALEVENT_RETURN);
 
-  // If the return signal is delayed for any reason, spin forever
-  for (;;)
-    sleep(1);
+  LogMan::Msg::A("unreachable");
 }
 
 void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, FEXCore::IR::IRListView<true> *CurrentIR, FEXCore::Core::DebugData *DebugData) {
@@ -468,7 +464,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, FEX
         switch (IROp->Op) {
           case IR::OP_VALIDATECODE: {
             auto Op = IROp->C<IR::IROp_ValidateCode>();
-            
+
             if (memcmp((void*)Op->CodePtr, &Op->CodeOriginalLow, Op->CodeLength) != 0) {
               GD = 1;
             } else {
@@ -510,7 +506,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, FEX
 
             void *Data = reinterpret_cast<void*>(ContextPtr);
             void *Src = GetSrc<void*>(SSAData, Op->Header.Args[0]);
-            
+
             memcpy(Data, Src, OpSize);
 
             BlockResults.Quit = true;
@@ -790,7 +786,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, FEX
             void *Src_Upper = GetSrc<void*>(SSAData, Op->Header.Args[1]);
 
             uint8_t *Dst = GetDest<uint8_t*>(SSAData, WrapperOp);
-  
+
             memcpy(Dst, Src_Lower, Op->Header.Size);
             memcpy(Dst + Op->Header.Size, Src_Upper, Op->Header.Size);
             break;

--- a/External/FEXCore/Source/Interface/Core/LookupCache.h
+++ b/External/FEXCore/Source/Interface/Core/LookupCache.h
@@ -2,6 +2,8 @@
 #include "Interface/Context/Context.h"
 #include <FEXCore/Utils/LogManager.h>
 
+#include <map>
+
 namespace FEXCore {
 class LookupCache {
 public:

--- a/External/FEXCore/Source/Interface/IR/IRParser.cpp
+++ b/External/FEXCore/Source/Interface/IR/IRParser.cpp
@@ -1,6 +1,7 @@
 #include <string>
 #include <vector>
 #include <istream>
+#include <unordered_map>
 
 #include <FEXCore/IR/IR.h>
 #include <FEXCore/IR/IntrusiveIRList.h>

--- a/External/FEXCore/Source/Utils/ELFLoader.cpp
+++ b/External/FEXCore/Source/Utils/ELFLoader.cpp
@@ -328,8 +328,8 @@ void ELFContainer::CalculateMemoryLayouts() {
       //
       // We need to ignore such empty sections, or we will mistakenly assume the elf starts at zero.
       if (hdr->p_memsz > 0) {
-        MinPhysAddr = std::min(MinPhysAddr, hdr->p_paddr);
-        MaxPhysAddr = std::max(MaxPhysAddr, hdr->p_paddr + hdr->p_memsz);
+        MinPhysAddr = std::min(MinPhysAddr, static_cast<uint64_t>(hdr->p_paddr));
+        MaxPhysAddr = std::max(MaxPhysAddr, static_cast<uint64_t>(hdr->p_paddr + hdr->p_memsz));
       }
       if (hdr->p_type == PT_TLS) {
         TLSHeader._64 = hdr;

--- a/External/FEXCore/include/FEXCore/Config/Config.h
+++ b/External/FEXCore/include/FEXCore/Config/Config.h
@@ -3,7 +3,9 @@
 
 #include <list>
 #include <memory>
+#include <optional>
 #include <stdint.h>
+#include <unordered_map>
 
 namespace FEXCore::Config {
   enum ConfigOption {

--- a/External/FEXCore/include/FEXCore/Core/CoreState.h
+++ b/External/FEXCore/include/FEXCore/Core/CoreState.h
@@ -47,6 +47,11 @@ namespace FEXCore::Core {
 
   static_assert(std::is_standard_layout<ThreadState>::value, "This needs to be standard layout");
 
+#ifdef PAGE_SIZE
+  static_assert(PAGE_SIZE == 4096, "FEX only supports 4k pages");
+#undef PAGE_SIZE
+#endif
+
   constexpr uint64_t PAGE_SIZE = 4096;
 
   std::string_view const& GetFlagName(unsigned Flag);

--- a/External/FEXCore/include/FEXCore/Core/UContext.h
+++ b/External/FEXCore/include/FEXCore/Core/UContext.h
@@ -2,8 +2,6 @@
 #include <cstddef>
 #include <cstdint>
 
-#include <bits/types/sigset_t.h>
-
 namespace FEXCore {
   namespace x86_64 {
     // uc_flags flags
@@ -74,18 +72,22 @@ namespace FEXCore {
     };
     static_assert(sizeof(FEXCore::x86_64::mcontext_t) == 256, "This needs to be the right size");
 
+    struct __attribute__((packed)) sigset_t {
+      uint64_t val[16];
+    };
+    static_assert(sizeof(FEXCore::x86_64::sigset_t) == 128, "This needs to be the right size");
+
     struct __attribute__((packed)) ucontext_t {
       uint64_t uc_flags;
       FEXCore::x86_64::ucontext_t *uc_link;
       FEXCore::x86_64::stack_t uc_stack;
       FEXCore::x86_64::mcontext_t uc_mcontext;
-      sigset_t uc_sigmask;
+      FEXCore::x86_64::sigset_t uc_sigmask;
       FEXCore::x86_64::_libc_fpstate __fpregs_mem;
       uint64_t __ssp[4];
     };
     static_assert(offsetof(FEXCore::x86_64::ucontext_t, uc_mcontext) == 40, "Needs to be correct");
 
-    static_assert(sizeof(sigset_t) == 128, "This needs to be the right size");
     static_assert(sizeof(FEXCore::x86_64::ucontext_t) == 968, "This needs to be the right size");
   }
 

--- a/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
+++ b/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
@@ -6,7 +6,7 @@
 #include <FEXCore/IR/RegisterAllocationData.h>
 #include <FEXCore/Utils/Event.h>
 
-#include <map>
+#include <unordered_map>
 #include <thread>
 
 namespace FEXCore {

--- a/External/FEXCore/include/FEXCore/Utils/ELFLoader.h
+++ b/External/FEXCore/include/FEXCore/Utils/ELFLoader.h
@@ -8,6 +8,15 @@
 #include <unordered_map>
 #include <vector>
 
+// Add macros which are missing in some versions of <elf.h>
+#ifndef ELF32_ST_VISIBILITY
+#define ELF32_ST_VISIBILITY(o) ((o) & 0x3)
+#endif
+
+#ifndef ELF64_ST_VISIBILITY
+#define ELF64_ST_VISIBILITY(o) ((o) & 0x3)
+#endif
+
 namespace ELFLoader {
 struct ELFSymbol {
   uint64_t FileOffset;

--- a/Source/Common/Config.cpp
+++ b/Source/Common/Config.cpp
@@ -2,6 +2,7 @@
 
 #include <FEXCore/Utils/LogManager.h>
 
+#include <array>
 #include <cassert>
 #include <cstring>
 #include <filesystem>

--- a/Source/Tests/CMakeLists.txt
+++ b/Source/Tests/CMakeLists.txt
@@ -1,7 +1,3 @@
-enable_language(ASM_NASM)
-if(NOT CMAKE_ASM_NASM_COMPILER_LOADED)
-  error("Failed to find NASM compatible assembler!")
-endif()
 
 set(SYSCALL_SRCS
   LinuxSyscalls/FileManagement.cpp

--- a/Source/Tests/CMakeLists.txt
+++ b/Source/Tests/CMakeLists.txt
@@ -1,74 +1,21 @@
 
-set(SYSCALL_SRCS
-  LinuxSyscalls/FileManagement.cpp
-  LinuxSyscalls/EmulatedFiles/EmulatedFiles.cpp
-  LinuxSyscalls/SignalDelegator.cpp
-  LinuxSyscalls/Syscalls.cpp
-  LinuxSyscalls/x32/Syscalls.cpp
-  LinuxSyscalls/x32/EPoll.cpp
-  LinuxSyscalls/x32/FD.cpp
-  LinuxSyscalls/x32/FS.cpp
-  LinuxSyscalls/x32/Info.cpp
-  LinuxSyscalls/x32/Memory.cpp
-  LinuxSyscalls/x32/NotImplemented.cpp
-  LinuxSyscalls/x32/Semaphore.cpp
-  LinuxSyscalls/x32/Sched.cpp
-  LinuxSyscalls/x32/Signals.cpp
-  LinuxSyscalls/x32/Socket.cpp
-  LinuxSyscalls/x32/Thread.cpp
-  LinuxSyscalls/x32/Time.cpp
-  LinuxSyscalls/x32/Timer.cpp
-  LinuxSyscalls/x64/EPoll.cpp
-  LinuxSyscalls/x64/FD.cpp
-  LinuxSyscalls/x64/IO.cpp
-  LinuxSyscalls/x64/Ioctl.cpp
-  LinuxSyscalls/x64/Info.cpp
-  LinuxSyscalls/x64/Memory.cpp
-  LinuxSyscalls/x64/Msg.cpp
-  LinuxSyscalls/x64/NotImplemented.cpp
-  LinuxSyscalls/x64/Semaphore.cpp
-  LinuxSyscalls/x64/Sched.cpp
-  LinuxSyscalls/x64/Signals.cpp
-  LinuxSyscalls/x64/Socket.cpp
-  LinuxSyscalls/x64/Thread.cpp
-  LinuxSyscalls/x64/Syscalls.cpp
-  LinuxSyscalls/x64/Time.cpp
-  LinuxSyscalls/Syscalls/EPoll.cpp
-  LinuxSyscalls/Syscalls/FD.cpp
-  LinuxSyscalls/Syscalls/FS.cpp
-  LinuxSyscalls/Syscalls/Info.cpp
-  LinuxSyscalls/Syscalls/IO.cpp
-  LinuxSyscalls/Syscalls/Key.cpp
-  LinuxSyscalls/Syscalls/Memory.cpp
-  LinuxSyscalls/Syscalls/Msg.cpp
-  LinuxSyscalls/Syscalls/Sched.cpp
-  LinuxSyscalls/Syscalls/Semaphore.cpp
-  LinuxSyscalls/Syscalls/SHM.cpp
-  LinuxSyscalls/Syscalls/Signals.cpp
-  LinuxSyscalls/Syscalls/Socket.cpp
-  LinuxSyscalls/Syscalls/Thread.cpp
-  LinuxSyscalls/Syscalls/Time.cpp
-  LinuxSyscalls/Syscalls/Timer.cpp
-  LinuxSyscalls/Syscalls/NotImplemented.cpp
-  LinuxSyscalls/Syscalls/Stubs.cpp
-  )
-set(LIBS FEXCore Common CommonCore pthread)
-set(NAME FEXLoader)
-set(SRCS ELFLoader.cpp ${SYSCALL_SRCS})
+add_subdirectory(LinuxSyscalls)
 
-add_executable(${NAME} ${SRCS})
-target_include_directories(${NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/Source/)
+set(LIBS FEXCore Common CommonCore)
 
-target_link_libraries(${NAME} ${LIBS})
+add_executable(FEXLoader ELFLoader.cpp)
+target_include_directories(FEXLoader PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/Source/)
 
-install(TARGETS ${NAME}
+target_link_libraries(FEXLoader ${LIBS} LinuxEmulation)
+
+install(TARGETS FEXLoader
   RUNTIME
     DESTINATION bin
     COMPONENT runtime)
 
 set(FEX_INTERP FEXInterpreter)
 install(CODE "
-  EXECUTE_PROCESS(COMMAND ln -f ${NAME} ${FEX_INTERP}
+  EXECUTE_PROCESS(COMMAND ln -f FEXLoader ${FEX_INTERP}
   WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/bin/
   )
 ")
@@ -108,39 +55,26 @@ if (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
 
 endif()
 
-set(NAME TestHarness)
-set(SRCS TestHarness.cpp)
+add_executable(TestHarness TestHarness.cpp)
+target_include_directories(TestHarness PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/Source/)
 
-add_executable(${NAME} ${SRCS})
-target_include_directories(${NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/Source/)
+target_link_libraries(TestHarness ${LIBS})
 
-target_link_libraries(${NAME} ${LIBS})
+add_executable(TestHarnessRunner TestHarnessRunner.cpp)
+target_include_directories(TestHarnessRunner PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/Source/)
 
-set(NAME TestHarnessRunner)
-set(SRCS TestHarnessRunner.cpp
-  ${SYSCALL_SRCS})
+target_link_libraries(TestHarnessRunner ${LIBS} LinuxEmulation)
 
-add_executable(${NAME} ${SRCS})
-target_include_directories(${NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/Source/)
+add_executable(UnitTestGenerator UnitTestGenerator.cpp)
+target_include_directories(UnitTestGenerator PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/Source/)
 
-target_link_libraries(${NAME} ${LIBS})
+target_link_libraries(UnitTestGenerator ${LIBS})
 
-set(NAME UnitTestGenerator)
-set(SRCS UnitTestGenerator.cpp)
-
-add_executable(${NAME} ${SRCS})
-target_include_directories(${NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/Source/)
-
-target_link_libraries(${NAME} ${LIBS})
-
-set(NAME IRLoader)
-set(SRCS
+add_executable(IRLoader
   IRLoader.cpp
   IRLoader/Loader.cpp
-  ${SYSCALL_SRCS})
+)
+target_include_directories(IRLoader PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/Source/)
 
-add_executable(${NAME} ${SRCS})
-target_include_directories(${NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/Source/)
-
-target_link_libraries(${NAME} ${LIBS})
+target_link_libraries(IRLoader ${LIBS} LinuxEmulation)
 

--- a/Source/Tests/HarnessHelpers.h
+++ b/Source/Tests/HarnessHelpers.h
@@ -328,6 +328,11 @@ namespace FEX::HarnessHelper {
     ConfigStructBase BaseConfig;
   };
 
+#ifdef PAGE_SIZE
+  static_assert(PAGE_SIZE == 4096, "FEX only supports 4k pages");
+#undef PAGE_SIZE
+#endif
+
   class HarnessCodeLoader final : public FEXCore::CodeLoader {
 
     static constexpr uint32_t PAGE_SIZE = 4096;

--- a/Source/Tests/HarnessHelpers.h
+++ b/Source/Tests/HarnessHelpers.h
@@ -3,6 +3,7 @@
 #include "Common/MathUtils.h"
 
 #include <FEXCore/Core/CodeLoader.h>
+#include <array>
 #include <bitset>
 #include <cassert>
 #include <cstring>

--- a/Source/Tests/LinuxSyscalls/CMakeLists.txt
+++ b/Source/Tests/LinuxSyscalls/CMakeLists.txt
@@ -1,0 +1,56 @@
+
+add_library(LinuxEmulation STATIC
+    FileManagement.cpp
+    EmulatedFiles/EmulatedFiles.cpp
+    SignalDelegator.cpp
+    Syscalls.cpp
+    x32/Syscalls.cpp
+    x32/EPoll.cpp
+    x32/FD.cpp
+    x32/FS.cpp
+    x32/Info.cpp
+    x32/Memory.cpp
+    x32/NotImplemented.cpp
+    x32/Semaphore.cpp
+    x32/Sched.cpp
+    x32/Signals.cpp
+    x32/Socket.cpp
+    x32/Thread.cpp
+    x32/Time.cpp
+    x32/Timer.cpp
+    x64/EPoll.cpp
+    x64/FD.cpp
+    x64/IO.cpp
+    x64/Ioctl.cpp
+    x64/Info.cpp
+    x64/Memory.cpp
+    x64/Msg.cpp
+    x64/NotImplemented.cpp
+    x64/Semaphore.cpp
+    x64/Sched.cpp
+    x64/Signals.cpp
+    x64/Socket.cpp
+    x64/Thread.cpp
+    x64/Syscalls.cpp
+    x64/Time.cpp
+    Syscalls/EPoll.cpp
+    Syscalls/FD.cpp
+    Syscalls/FS.cpp
+    Syscalls/Info.cpp
+    Syscalls/IO.cpp
+    Syscalls/Key.cpp
+    Syscalls/Memory.cpp
+    Syscalls/Msg.cpp
+    Syscalls/Sched.cpp
+    Syscalls/Semaphore.cpp
+    Syscalls/SHM.cpp
+    Syscalls/Signals.cpp
+    Syscalls/Socket.cpp
+    Syscalls/Thread.cpp
+    Syscalls/Time.cpp
+    Syscalls/Timer.cpp
+    Syscalls/NotImplemented.cpp
+    Syscalls/Stubs.cpp
+)
+
+target_link_libraries(LinuxEmulation FEXCore pthread)

--- a/Source/Tests/LinuxSyscalls/CMakeLists.txt
+++ b/Source/Tests/LinuxSyscalls/CMakeLists.txt
@@ -53,4 +53,4 @@ add_library(LinuxEmulation STATIC
     Syscalls/Stubs.cpp
 )
 
-target_link_libraries(LinuxEmulation FEXCore pthread)
+target_link_libraries(LinuxEmulation FEXCore pthread numa)

--- a/unittests/32Bit_ASM/CMakeLists.txt
+++ b/unittests/32Bit_ASM/CMakeLists.txt
@@ -1,3 +1,7 @@
+enable_language(ASM_NASM)
+if(NOT CMAKE_ASM_NASM_COMPILER_LOADED)
+  error("Failed to find NASM compatible assembler!")
+endif()
 
 # Careful. Globbing can't see changes to the contents of files
 # Need to do a fresh clean to see changes

--- a/unittests/ASM/CMakeLists.txt
+++ b/unittests/ASM/CMakeLists.txt
@@ -1,3 +1,7 @@
+enable_language(ASM_NASM)
+if(NOT CMAKE_ASM_NASM_COMPILER_LOADED)
+  error("Failed to find NASM compatible assembler!")
+endif()
 
 # Careful. Globbing can't see changes to the contents of files
 # Need to do a fresh clean to see changes


### PR DESCRIPTION
These are all the changes I needed to make while trying to get FEX built under termux on my android phone.

I've put this porting effort on hold for now, as NDK r21 doesn't implement `std::filesystem` and termux are still working on updating to r22. 

Apart from `std::filesystem` issues, I manged to get FEXCore building. The LinuxEmulation layer is going to need some more work. 

I have another PR coming which allows building and running IRLoader without LinuxEmulation (which it doesn't use). 