### PR TITLE
Remove dependency on signals for clean exits

### DIFF
--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -45,6 +45,8 @@ if (ENABLE_CLANG_FORMAT)
   set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY_EXE} "${CLANG_TIDY_FLAGS}")
 endif()
 
+enable_language(ASM)
+
 set (SRCS
   Common/Paths.cpp
   Common/JitSymbols.cpp
@@ -168,7 +170,10 @@ set (SRCS
   )
 
 if (_M_X86_64)
-  list(APPEND SRCS Interface/Core/Interpreter/x86_64Dispatcher.cpp)
+  list(APPEND SRCS
+    Interface/Core/Interpreter/x86_64Dispatcher.cpp
+    Interface/Core/Interpreter/X86_64Dispatcher.S
+  )
 endif()
 if(_M_ARM_64)
   list(APPEND SRCS

--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -130,6 +130,7 @@ set (SRCS
   Interface/Core/X86Tables.cpp
   Interface/Core/X86DebugInfo.cpp
   Interface/Core/X86HelperGen.cpp
+  Interface/Core/Unwinding.cpp
   Interface/Core/Interpreter/InterpreterCore.cpp
   Interface/Core/Interpreter/InterpreterOps.cpp
   Interface/Core/X86Tables/BaseTables.cpp

--- a/External/FEXCore/Source/Interface/Context/Context.cpp
+++ b/External/FEXCore/Source/Interface/Context/Context.cpp
@@ -189,4 +189,6 @@ namespace Debug {
   }
 }
 
+NullSignalDelegator Context::DefaultSignalDelegator{};
+
 }

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -100,7 +100,10 @@ namespace FEXCore::Context {
     std::unique_ptr<FEXCore::BlockSamplingData> BlockData;
 #endif
 
-    SignalDelegator *SignalDelegation{};
+    static NullSignalDelegator DefaultSignalDelegator;
+
+    // We have a default signal delegator which does nothing
+    SignalDelegator *SignalDelegation = &DefaultSignalDelegator;
     X86GeneratedCode X86CodeGen;
 
     Context();

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -116,6 +116,10 @@ namespace DefaultFallbackCore {
       return nullptr;
     }
 
+    bool IsAddressInJITCode(uint64_t Address, bool IncludeDispatcher) override {
+      return false;
+    }
+
   private:
     FEXCore::Core::InternalThreadState *ThreadState;
   };

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -424,7 +424,15 @@ namespace FEXCore::Context {
   void Context::StopThread(FEXCore::Core::InternalThreadState *Thread) {
     if (Thread->State.RunningEvents.Running.load()) {
       Thread->SignalReason.store(FEXCore::Core::SignalEvent::SIGNALEVENT_STOP);
-      tgkill(Thread->State.ThreadManager.PID, Thread->State.ThreadManager.TID, SignalDelegator::SIGNAL_FOR_PAUSE);
+
+      if (Core::ThreadData.Thread == Thread) {
+        // If a thread is trying to stop itself, we can just jump straight to the the dispatcher
+        (*Thread->LongJumpExit)(Thread);
+      }
+      else {
+        // Otherwise, send a signal
+        tgkill(Thread->State.ThreadManager.PID, Thread->State.ThreadManager.TID, SignalDelegator::SIGNAL_FOR_PAUSE);
+      }
     }
   }
 

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -9,6 +9,7 @@
 #include "Interface/Core/DebugData.h"
 #include "Interface/Core/OpcodeDispatcher.h"
 #include "Interface/Core/Interpreter/InterpreterCore.h"
+#include "Interface/Core/Unwinding.h"
 #include "Interface/Core/JIT/JITCore.h"
 #include "Interface/IR/Passes/RegisterAllocationPass.h"
 #include "Interface/IR/Passes.h"
@@ -430,8 +431,10 @@ namespace FEXCore::Context {
       Thread->SignalReason.store(FEXCore::Core::SignalEvent::SIGNALEVENT_STOP);
 
       if (Core::ThreadData.Thread == Thread) {
-        // If a thread is trying to stop itself, we can just jump straight to the the dispatcher
-        (*Thread->LongJumpExit)(Thread);
+        // If a thread is trying to stop itself, we can clean up and jump straight to the the dispatcher
+        CancelToDispatcher(Thread);
+
+        // Does not return
       }
       else {
         // Otherwise, send a signal

--- a/External/FEXCore/Source/Interface/Core/Interpreter/Arm64Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/Arm64Dispatcher.cpp
@@ -574,4 +574,14 @@ void InterpreterCore::DeleteAsmDispatch() {
   delete Generator;
 }
 
+bool InterpreterCore::IsAddressInJITCode(uint64_t Address, bool IncludeDispatcher) {
+  if (!IncludeDispatcher)
+    return false;
+
+  uint64_t Start = Generator->GetBuffer()->GetStartAddress<uint64_t>();
+  uint64_t End = Generator->GetBuffer()->GetEndAddress<uint64_t>();
+
+  return Address >= Start && Address < End;
+}
+
 }

--- a/External/FEXCore/Source/Interface/Core/Interpreter/Dispatcher_asm.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/Dispatcher_asm.h
@@ -1,0 +1,5 @@
+
+extern "C" {
+ __attribute__((naked)) void DispatcherExit();
+
+}

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterClass.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterClass.h
@@ -33,6 +33,8 @@ public:
 
   bool HandleSIGBUS(int Signal, void *info, void *ucontext);
 
+  bool IsAddressInJITCode(uint64_t Address, bool IncludeDispatcher = true) override;
+
 private:
   FEXCore::Context::Context *CTX;
   FEXCore::Core::InternalThreadState *State;

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -397,9 +397,7 @@ Res GetSrc(void* SSAData, IR::OrderedNodeWrapper Src) {
 
 [[noreturn]]
 static void StopThread(FEXCore::Core::InternalThreadState *Thread) {
-  Thread->CTX->StopThread(Thread);
-
-  LogMan::Msg::A("unreachable");
+  (*Thread->LongJumpExit)(Thread);
 }
 
 [[noreturn]]

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -397,7 +397,9 @@ Res GetSrc(void* SSAData, IR::OrderedNodeWrapper Src) {
 
 [[noreturn]]
 static void StopThread(FEXCore::Core::InternalThreadState *Thread) {
-  (*Thread->LongJumpExit)(Thread);
+  Thread->CTX->StopThread(Thread);
+
+  LogMan::Msg::A("unreachable");
 }
 
 [[noreturn]]

--- a/External/FEXCore/Source/Interface/Core/Interpreter/X86_64Dispatcher.S
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/X86_64Dispatcher.S
@@ -1,0 +1,36 @@
+
+.intel_syntax noprefix
+
+.text
+.globl DispatcherExit
+
+DispatcherExit:
+
+.cfi_startproc simple
+.cfi_def_cfa rsp, 8*8
+
+.cfi_offset r15, 0x30
+.cfi_offset r14, 0x28
+.cfi_offset r13, 0x20
+.cfi_offset r12, 0x18
+.cfi_offset rbp, 0x10
+.cfi_offset rbx, 0x08
+.cfi_offset rip, 0x00
+
+    add rsp, 8
+.cfi_adjust_cfa_offset -8
+    pop r15
+.cfi_adjust_cfa_offset -8
+    pop r14
+.cfi_adjust_cfa_offset -8
+    pop r13
+.cfi_adjust_cfa_offset -8
+    pop r12
+.cfi_adjust_cfa_offset -8
+    pop rbp
+.cfi_adjust_cfa_offset -8
+    pop rbx
+.cfi_adjust_cfa_offset -8
+
+    ret
+.cfi_endproc

--- a/External/FEXCore/Source/Interface/Core/Interpreter/x86_64Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/x86_64Dispatcher.cpp
@@ -482,4 +482,13 @@ void InterpreterCore::DeleteAsmDispatch() {
   delete Generator;
 }
 
+bool InterpreterCore::IsAddressInJITCode(uint64_t Address, bool IncludeDispatcher) {
+  if (!IncludeDispatcher)
+    return false;
+
+  size_t Start = reinterpret_cast<size_t>(Generator->getCode());
+  size_t End = Start + Generator->getSize();
+
+  return Address >= Start && Address < End;
+}
 }

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -212,8 +212,9 @@ private:
   uint64_t ExitFunctionLinkerAddress{};
   uint64_t ThreadPauseHandlerAddress{};
 
-  uint64_t ThreadStopHandlerAddressSpillSRA{};
-  uint64_t ThreadStopHandlerAddress{};
+  uint64_t ThreadStopPivotAddress{};
+  uint64_t ThreadStopSpillAddress{};
+  uint64_t ThreadStopNoSpillAddress{};
   uint64_t PauseReturnInstruction{};
 
   uint32_t SignalHandlerRefCounter{};

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -189,7 +189,7 @@ private:
   static constexpr size_t MAX_CODE_SIZE = 1024 * 1024 * 128;
   static constexpr size_t MAX_DISPATCHER_CODE_SIZE = 4096 * 2;
 
-  bool IsAddressInJITCode(uint64_t Address, bool IncludeDispatcher = true);
+  bool IsAddressInJITCode(uint64_t Address, bool IncludeDispatcher = true) override;
 
 #if DEBUG
   vixl::aarch64::Disassembler Disasm;

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
@@ -36,7 +36,7 @@ DEF_OP(Break) {
       add(sp, TMP1, 0);
 
       // Now we need to jump to the thread stop handler
-      LoadConstant(TMP1, ThreadStopHandlerAddressSpillSRA);
+      LoadConstant(TMP1, ThreadStopSpillAddress);
       br(TMP1);
       break;
     }

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -159,6 +159,7 @@ private:
 
   uint64_t AbsoluteLoopTopAddress{};
   uint64_t ExitFunctionLinkerAddress{};
+  uint64_t ThreadStopHandlerPivotStackAddress{};
   uint64_t ThreadStopHandlerAddress{};
   uint64_t ThreadPauseHandlerAddress{};
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -75,6 +75,8 @@ public:
   bool HandleGuestSignal(int Signal, void *info, void *ucontext, GuestSigAction *GuestAction, stack_t *GuestStack);
   void CopyNecessaryDataForCompileThread(CPUBackend *Original) override;
 
+  bool IsAddressInJITCode(uint64_t Address, bool IncludeDispatcher = true) override;
+
 private:
   Label* PendingTargetLabel{};
   FEXCore::Context::Context *CTX;

--- a/External/FEXCore/Source/Interface/Core/Unwinding.cpp
+++ b/External/FEXCore/Source/Interface/Core/Unwinding.cpp
@@ -1,0 +1,46 @@
+#include <unwind.h> // FIXME grab from somewhere else
+
+#include "Interface/Core/Unwinding.h"
+#include <FEXCore/Utils/LogManager.h>
+
+// This is semi-generic to platforms that implement SysV ABIs with the Unwind Library interface
+// see https://www.uclibc.org/docs/psABI-x86_64 page 85
+//
+// If you are porting to another platform, you will need to rewrite this
+
+_Unwind_Reason_Code StopFn(int version, _Unwind_Action actions, _Unwind_Exception_Class exceptionClass,
+ _Unwind_Exception *exceptionObject, struct _Unwind_Context *context, void *arg) {
+     // This function is called by the unwinder at each stackframe.
+
+    auto Thread = reinterpret_cast<FEXCore::Core::InternalThreadState*>(arg);
+    auto ip = _Unwind_GetIP(context);
+
+    // We check if the current stackframe belongs to either the dispatcher or jit code
+    if (Thread->CPUBackend->IsAddressInJITCode(ip, true)) {
+         // We have now unwound to the correct stack frame
+
+         _Unwind_DeleteException(exceptionObject); // Cleanup
+
+        // Longjump to dispatcher's exit
+        (*Thread->LongJumpExit)(Thread);
+        // Does not return
+     }
+
+    // Otherwise, continue unwinding
+     return _URC_NO_REASON;
+}
+
+void CleanupFn(_Unwind_Reason_Code,  _Unwind_Exception *exception) {
+    delete exception;
+}
+
+void CancelToDispatcher(FEXCore::Core::InternalThreadState *CurrentThread) {
+
+    // We can't allocate this on the stack, because we are about to unwind the stack
+    _Unwind_Exception *e = new _Unwind_Exception {'FEXs', CleanupFn, 0, 0};
+
+    // Ask the ABI to forceably unwind the stack, calling our StopFn at each step
+    _Unwind_ForcedUnwind(e, StopFn, CurrentThread);
+
+    for (;;); // unreachable
+}

--- a/External/FEXCore/Source/Interface/Core/Unwinding.h
+++ b/External/FEXCore/Source/Interface/Core/Unwinding.h
@@ -1,0 +1,12 @@
+#include "Interface/Core/InternalThreadState.h"
+
+/**
+   * @brief Cancel current execution and exit via dispatcher
+   *
+   * @param CurrentThread Must be the thread state of this thread.
+   *
+   * Never returns.
+   * All stack frames are cleaned up and execution is transferred
+   * directly to the dispatcher, which then exits.
+   */
+[[noreturn]] void CancelToDispatcher(FEXCore::Core::InternalThreadState *CurrentThread);

--- a/External/FEXCore/include/FEXCore/Core/CPUBackend.h
+++ b/External/FEXCore/include/FEXCore/Core/CPUBackend.h
@@ -72,6 +72,8 @@ class LLVMCore;
      */
     virtual bool NeedsOpDispatch() = 0;
 
+    virtual bool IsAddressInJITCode(uint64_t Address, bool IncludeDispatcher = true) = 0;
+
     void ExecuteDispatch(FEXCore::Core::InternalThreadState *Thread) {
       DispatchPtr(Thread);
     }

--- a/External/FEXCore/include/FEXCore/Core/SignalDelegator.h
+++ b/External/FEXCore/include/FEXCore/Core/SignalDelegator.h
@@ -65,4 +65,21 @@ namespace Core {
     // 64 is used internally by Valgrind
     constexpr static size_t SIGNAL_FOR_PAUSE {63};
   };
+
+  /**
+   * @brief A dummy implementation of SignalDelegator that doesn't handle any signals
+   */
+  class NullSignalDelegator : public SignalDelegator {
+  public:
+    virtual void RegisterTLSState(FEXCore::Core::InternalThreadState *Thread) override {}
+    virtual void UninstallTLSState(FEXCore::Core::InternalThreadState *Thread) override {}
+
+    virtual void MaskThreadSignals() override {}
+
+    virtual void SetCurrentSignal(uint32_t Signal) override {}
+    virtual void RegisterHostSignalHandler(int Signal, HostSignalDelegatorFunction Func) override {}
+    virtual void RegisterFrontendHostSignalHandler(int Signal, HostSignalDelegatorFunction Func) override {}
+    virtual void RegisterHostSignalHandlerForGuest(int Signal, HostSignalDelegatorFunctionForGuest Func) override {}
+
+  };
 }

--- a/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
+++ b/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
@@ -71,6 +71,8 @@ namespace FEXCore::Core {
     Event StartRunning;
     Event ThreadWaiting;
 
+    std::unique_ptr<std::function<void(FEXCore::Core::InternalThreadState *)>> LongJumpExit;
+
     std::unique_ptr<FEXCore::IR::OpDispatchBuilder> OpDispatcher;
 
     std::unique_ptr<FEXCore::CPU::CPUBackend> CPUBackend;

--- a/Source/CommonCore/HostFactory.cpp
+++ b/Source/CommonCore/HostFactory.cpp
@@ -41,6 +41,10 @@ namespace HostFactory {
 
     bool HandleSIGSEGV(FEXCore::Core::InternalThreadState *Thread, int Signal, void *info, void *ucontext);
 
+    bool IsAddressInJITCode(uint64_t Address, bool IncludeDispatcher) override {
+      return false;
+    }
+
   private:
     uint64_t ReturningStackLocation;
     uint64_t ThreadStopHandlerAddress;

--- a/Source/Tests/CMakeLists.txt
+++ b/Source/Tests/CMakeLists.txt
@@ -76,5 +76,5 @@ add_executable(IRLoader
 )
 target_include_directories(IRLoader PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/Source/)
 
-target_link_libraries(IRLoader ${LIBS} LinuxEmulation)
+target_link_libraries(IRLoader ${LIBS})
 

--- a/Source/Tests/IRLoader.cpp
+++ b/Source/Tests/IRLoader.cpp
@@ -3,8 +3,6 @@
 #include "Common/Config.h"
 #include "HarnessHelpers.h"
 #include "IRLoader/Loader.h"
-#include "Tests/LinuxSyscalls/Syscalls.h"
-#include "Tests/LinuxSyscalls/SignalDelegator.h"
 
 #include <FEXCore/Config/Config.h>
 #include <FEXCore/Core/CodeLoader.h>
@@ -120,9 +118,7 @@ int main(int argc, char **argv, char **const envp) {
   FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_MAXBLOCKINST, BlockSizeConfig());
   FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_GDBSERVER, GdbServerConfig());
   FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_ROOTFSPATH, LDPath());
-  std::unique_ptr<FEX::HLE::SignalDelegator> SignalDelegation = std::make_unique<FEX::HLE::SignalDelegator>();
 
-  FEXCore::Context::SetSignalDelegator(CTX, SignalDelegation.get());
 
 	FEX::IRLoader::Loader Loader(Args[0], Args[1]);
 


### PR DESCRIPTION
Allows consumers of the FEXCore API to run and exit cleanly without having to implement linux signal handling.

As an example, I've removed the linux emulation dependency on IRLoader tests.

### TODO: 

 * [x] ARM jit implementation. 