### PR TITLE
Fix power of 2 OP_MUL optimisation (Fixes Geekbench result upload) 

### DIFF
--- a/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -712,7 +712,9 @@ bool ConstProp::Run(IREmitter *IREmit) {
           uint64_t amt = __builtin_ctzl(Constant2);
           IREmit->SetWriteCursor(CodeNode);
           auto shift = IREmit->_Lshl(CurrentIR.GetNode(Op->Header.Args[0]), IREmit->_Constant(amt));
+          shift.first->Header.Size = IROp->Size; // force Lshl to be the same size as the original Mul
           IREmit->ReplaceAllUsesWith(CodeNode, shift);
+          Changed = true;
         }
       }
       break;


### PR DESCRIPTION
The new left-shift that replaced the multiply takes
it's size from arg[0]. If arg[0] was 64bit and the original
OP_MUL was 32bit, then the original code would truncate
upper bits, and the replacement code wouldn't.

This bug broke the SSL cert checking code in geekbench,
causing it to fail to upload results.
Fixes #647