### PR TITLE
arm64: Fix blocks with over 256 spill slots.

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
@@ -22,9 +22,7 @@ DEF_OP(GuestReturn) {
 
 DEF_OP(SignalReturn) {
   // First we must reset the stack
-  if (SpillSlots) {
-    add(sp, sp, SpillSlots * 16);
-  }
+  ResetStack();
 
   // Now branch to our signal return helper
   // This can't be a direct branch since the code needs to live at a constant location
@@ -38,9 +36,7 @@ DEF_OP(CallbackReturn) {
   SpillStaticRegs();
   
   // First we must reset the stack
-  if (SpillSlots) {
-    add(sp, sp, SpillSlots * 16);
-  }
+  ResetStack();
 
   // We can now lower the ref counter again
   LoadConstant(x0, reinterpret_cast<uint64_t>(ThreadSharedData.SignalHandlerRefCounterPtr));
@@ -64,9 +60,7 @@ DEF_OP(ExitFunction) {
 
   Label FullLookup;
 
-  if (SpillSlots) {
-    add(sp, sp, SpillSlots * 16);
-  }
+  ResetStack();
 
   aarch64::Register RipReg;
   uint64_t NewRIP;

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -242,6 +242,8 @@ private:
   void PushDynamicRegsAndLR();
   void PopDynamicRegsAndLR();
 
+  void ResetStack();
+
   using OpHandler = void (JITCore::*)(FEXCore::IR::IROp_Header *IROp, uint32_t Node);
   std::array<OpHandler, FEXCore::IR::IROps::OP_LAST + 1> OpHandlers {};
   void RegisterALUHandlers();

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
@@ -41,9 +41,7 @@ DEF_OP(Break) {
       break;
     }
     case 6: { // INT3
-      if (SpillSlots) {
-        add(sp, sp, SpillSlots * 16);
-      }
+      ResetStack();
 
       LoadConstant(TMP1, ThreadPauseHandlerAddressSpillSRA);
       br(TMP1);


### PR DESCRIPTION
With multiblock and -n4000, at least one block in geekbench5's camera
benchmark was spilling 324 values. This meant the required stack
adjustment was 5184 bytes, which is larger than can fit into a 12bit
immediate.

Now, it's probally a bug that our RA is spilling that many values, and
we probally should be packing our spill slots closer together, but we
still shouldn't fail to run in this edge case.

So this commit adds a fallback path which uses a temp register to load
the stack adjustment.