### PR TITLE
Fixes for Counter Strike Global Offensive

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Frontend.cpp
+++ b/External/FEXCore/Source/Interface/Core/Frontend.cpp
@@ -1015,8 +1015,12 @@ bool Decoder::DecodeInstructionsAtEntry(uint8_t const* _InstStream, uint64_t PC)
 
       if (ErrorDuringDecoding) {
         LogMan::Msg::D("Couldn't Decode something at 0x%lx, Started at 0x%lx", PC + PCOffset, PC);
-        LogMan::Throw::A(EntryPoint != (RIPToDecode + PCOffset), "Trying to execute invalid code");
+        LogMan::Throw::A(Blocks.size() != 1, "Decode Error in entry block");
+
         CurrentBlockDecoding.HasInvalidInstruction = true;
+        if (ErrorDuringDecoding && Blocks.size() != 1) {
+          ErrorDuringDecoding = false;
+        }
         break;
       }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MoveOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MoveOps.cpp
@@ -29,18 +29,21 @@ DEF_OP(CreateElementPair) {
   std::pair<aarch64::Register, aarch64::Register> Dst;
   aarch64::Register RegFirst;
   aarch64::Register RegSecond;
+  aarch64::Register RegTmp;
 
   switch (Op->Header.Size) {
     case 4: {
       Dst = GetSrcPair<RA_32>(Node);
       RegFirst = GetReg<RA_32>(Op->Header.Args[0].ID());
       RegSecond = GetReg<RA_32>(Op->Header.Args[1].ID());
+      RegTmp = w0;
       break;
     }
     case 8: {
       Dst = GetSrcPair<RA_64>(Node);
       RegFirst = GetReg<RA_64>(Op->Header.Args[0].ID());
       RegSecond = GetReg<RA_64>(Op->Header.Args[1].ID());
+      RegTmp = x0;
       break;
     }
     default: LogMan::Msg::A("Unknown Size"); break;
@@ -53,7 +56,9 @@ DEF_OP(CreateElementPair) {
     mov(Dst.second, RegSecond);
     mov(Dst.first, RegFirst);
   } else {
-    LogMan::Msg::A("Unhandled CreateElementPair");
+    mov(RegTmp, RegFirst);
+    mov(Dst.second, RegSecond);
+    mov(Dst.first, RegTmp);
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/MoveOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/MoveOps.cpp
@@ -28,18 +28,21 @@ DEF_OP(CreateElementPair) {
   std::pair<Xbyak::Reg, Xbyak::Reg> Dst;
   Xbyak::Reg RegFirst;
   Xbyak::Reg RegSecond;
+  Xbyak::Reg RegTmp;
 
   switch (Op->Header.Size) {
     case 4: {
       Dst = GetSrcPair<RA_32>(Node);
       RegFirst = GetSrc<RA_32>(Op->Header.Args[0].ID());
       RegSecond = GetSrc<RA_32>(Op->Header.Args[1].ID());
+      RegTmp = eax;
       break;
     }
     case 8: {
       Dst = GetSrcPair<RA_64>(Node);
       RegFirst = GetSrc<RA_64>(Op->Header.Args[0].ID());
       RegSecond = GetSrc<RA_64>(Op->Header.Args[1].ID());
+      RegTmp = rax;
       break;
     }
     default: LogMan::Msg::A("Unknown Size"); break;
@@ -52,7 +55,9 @@ DEF_OP(CreateElementPair) {
     mov(Dst.second, RegSecond);
     mov(Dst.first, RegFirst);
   } else {
-    LogMan::Msg::A("Unhandled CreateElementPair");
+    mov(RegTmp, RegFirst);
+    mov(Dst.second, RegSecond);
+    mov(Dst.first, RegTmp);
   }
 }
 

--- a/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -1392,7 +1392,6 @@ namespace FEXCore::IR {
           //LogMan::Throw::A(InterferenceRegisterNode->Head.RegAndClass.Reg != INVALID_REG, "Interference node never assigned a register?");
           LogMan::Throw::A(InterferenceRegClass != ~0U, "Interference node never assigned a register class?");
           LogMan::Throw::A(InterferenceRegisterNode->Head.PhiPartner == nullptr, "We don't support spilling PHI nodes currently");
-          LogMan::Throw::A(InterferenceRegClass == RegClass, "Class doesn't match");
 
           // This is the op that we need to dump
           auto [InterferenceOrderedNode, InterferenceIROp] = IR.at(InterferenceNode)();

--- a/unittests/gcc-target-tests-32/Known_Failures
+++ b/unittests/gcc-target-tests-32/Known_Failures
@@ -7,3 +7,6 @@ sse2-mmx-psraw.c.gcc-target-test-32
 sse2-mmx-psrawi.c.gcc-target-test-32
 sse2-psraw-1.c.gcc-target-test-32
 sse2-shiftqihi-constant-2.c.gcc-target-test-32
+
+# this uses AVX ops (VMOVAPS)
+pr57275.c.gcc-target-test-32

--- a/unittests/gcc-target-tests-64/Known_Failures
+++ b/unittests/gcc-target-tests-64/Known_Failures
@@ -21,3 +21,6 @@ sse2-mmx-psrlw.c.gcc-target-test-64
 
 # this is flaky on the ARMv8.0 runner
 mcount_pic.c.gcc-target-test-64
+
+# this uses AVX ops (VMOVAPS)
+pr57275.c.gcc-target-test-64


### PR DESCRIPTION
Several small things got broken over the past few months
- Fix Frontend to only return false if it has invalid ops in the first block
- Fix CreateElementPair to handle edge cases
- Remove an erratic assert from RA (spill class doesn't have to match value class when spilling a GPR/GPRPair conflict)