### PR TITLE
x87: Call C++ handlers instead of forcing interpreter

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -461,6 +461,88 @@ struct OpHandlers<IR::OP_F80CVT> {
 };
 
 template<>
+struct OpHandlers<IR::OP_F80CVTINT> {
+  static  int16_t handle2(X80SoftFloat src) {
+    return src;
+  }
+
+  static int32_t handle4(X80SoftFloat src) {
+    return src;
+  }
+
+  static int64_t handle8(X80SoftFloat src) {
+    return src;
+  }
+};
+
+template<>
+struct OpHandlers<IR::OP_F80CVTTOINT> {
+  static X80SoftFloat handle2(int16_t src) {
+    return src;
+  }
+
+  static X80SoftFloat handle4(int32_t src) {
+    return src;
+  }
+};
+
+template<>
+struct OpHandlers<IR::OP_F80ROUND> {
+  static X80SoftFloat handle(X80SoftFloat Src1) {
+    return X80SoftFloat::FRNDINT(Src1);
+  }
+};
+
+template<>
+struct OpHandlers<IR::OP_F80F2XM1> {
+  static X80SoftFloat handle(X80SoftFloat Src1) {
+    return X80SoftFloat::F2XM1(Src1);
+  }
+};
+
+template<>
+struct OpHandlers<IR::OP_F80TAN> {
+  static X80SoftFloat handle(X80SoftFloat Src1) {
+    return X80SoftFloat::FTAN(Src1);
+  }
+};
+
+template<>
+struct OpHandlers<IR::OP_F80SQRT> {
+  static X80SoftFloat handle(X80SoftFloat Src1) {
+    return X80SoftFloat::FSQRT(Src1);
+  }
+};
+
+template<>
+struct OpHandlers<IR::OP_F80SIN> {
+  static X80SoftFloat handle(X80SoftFloat Src1) {
+    return X80SoftFloat::FSIN(Src1);
+  }
+};
+
+template<>
+struct OpHandlers<IR::OP_F80COS> {
+  static X80SoftFloat handle(X80SoftFloat Src1) {
+    return X80SoftFloat::FCOS(Src1);
+  }
+};
+
+template<>
+struct OpHandlers<IR::OP_F80XTRACT_EXP> {
+  static X80SoftFloat handle(X80SoftFloat Src1) {
+    return X80SoftFloat::FXTRACT_EXP(Src1);
+  }
+};
+
+template<>
+struct OpHandlers<IR::OP_F80XTRACT_SIG> {
+  static X80SoftFloat handle(X80SoftFloat Src1) {
+    return X80SoftFloat::FXTRACT_SIG(Src1);
+  }
+};
+
+template<>
 struct OpHandlers<IR::OP_F80ADD> {
   static X80SoftFloat handle(X80SoftFloat Src1, X80SoftFloat Src2) {
     return X80SoftFloat::FADD(Src1, Src2);
@@ -489,6 +571,42 @@ struct OpHandlers<IR::OP_F80DIV> {
 };
 
 
+template<>
+struct OpHandlers<IR::OP_F80FYL2X> {
+  static X80SoftFloat handle(X80SoftFloat Src1, X80SoftFloat Src2) {
+    return X80SoftFloat::FYL2X(Src1, Src2);
+  }
+};
+
+template<>
+struct OpHandlers<IR::OP_F80ATAN> {
+  static X80SoftFloat handle(X80SoftFloat Src1, X80SoftFloat Src2) {
+    return X80SoftFloat::FATAN(Src1, Src2);
+  }
+};
+
+template<>
+struct OpHandlers<IR::OP_F80FPREM1> {
+  static X80SoftFloat handle(X80SoftFloat Src1, X80SoftFloat Src2) {
+    return X80SoftFloat::FREM1(Src1, Src2);
+  }
+};
+
+template<>
+struct OpHandlers<IR::OP_F80FPREM> {
+  static X80SoftFloat handle(X80SoftFloat Src1, X80SoftFloat Src2) {
+    return X80SoftFloat::FREM(Src1, Src2);
+  }
+};
+
+template<>
+struct OpHandlers<IR::OP_F80SCALE> {
+  static X80SoftFloat handle(X80SoftFloat Src1, X80SoftFloat Src2) {
+    return X80SoftFloat::FSCALE(Src1, Src2);
+  }
+};
+
+
 template<typename R, typename... Args>
 FallbackInfo GetFallbackInfo(R(*fn)(Args...)) {
   return {FABI_UNKNOWN, (void*)fn};
@@ -505,6 +623,16 @@ FallbackInfo GetFallbackInfo(X80SoftFloat(*fn)(double)) {
 }
 
 template<>
+FallbackInfo GetFallbackInfo(X80SoftFloat(*fn)(int16_t)) {
+  return {FABI_F80_I16, (void*)fn};
+}
+
+template<>
+FallbackInfo GetFallbackInfo(X80SoftFloat(*fn)(int32_t)) {
+  return {FABI_F80_I32, (void*)fn};
+}
+
+template<>
 FallbackInfo GetFallbackInfo(float(*fn)(X80SoftFloat)) {
   return {FABI_F32_F80, (void*)fn};
 }
@@ -515,8 +643,28 @@ FallbackInfo GetFallbackInfo(double(*fn)(X80SoftFloat)) {
 }
 
 template<>
+FallbackInfo GetFallbackInfo(int16_t(*fn)(X80SoftFloat)) {
+  return {FABI_I16_F80, (void*)fn};
+}
+
+template<>
+FallbackInfo GetFallbackInfo(int32_t(*fn)(X80SoftFloat)) {
+  return {FABI_I32_F80, (void*)fn};
+}
+
+template<>
+FallbackInfo GetFallbackInfo(int64_t(*fn)(X80SoftFloat)) {
+  return {FABI_I64_F80, (void*)fn};
+}
+
+template<>
 FallbackInfo GetFallbackInfo(uint64_t(*fn)(X80SoftFloat, X80SoftFloat)) {
   return {FABI_I64_F80_F80, (void*)fn};
+}
+
+template<>
+FallbackInfo GetFallbackInfo(X80SoftFloat(*fn)(X80SoftFloat)) {
+  return {FABI_F80_F80, (void*)fn};
 }
 
 template<>
@@ -559,6 +707,26 @@ bool InterpreterOps::GetFallbackHandler(IR::IROp_Header *IROp, FallbackInfo *Inf
       }
       break;
     }
+    case IR::OP_F80CVTINT: {
+      auto Op = IROp->C<IR::IROp_F80CVTInt>();
+
+      switch (OpSize) {
+        case 2: {
+          *Info = GetFallbackInfo(&OpHandlers<IR::OP_F80CVTINT>::handle2);
+          return true;
+        }
+        case 4: {
+          *Info = GetFallbackInfo(&OpHandlers<IR::OP_F80CVTINT>::handle4);
+          return true;
+        }
+        case 8: {
+          *Info = GetFallbackInfo(&OpHandlers<IR::OP_F80CVTINT>::handle8);
+          return true;
+        }
+        default: LogMan::Msg::D("Unhandled size: %d", OpSize);
+      }
+      break;
+    }
     case IR::OP_F80CMP: {
       auto Op = IROp->C<IR::IROp_F80Cmp>();
       
@@ -568,16 +736,50 @@ bool InterpreterOps::GetFallbackHandler(IR::IROp_Header *IROp, FallbackInfo *Inf
       return true;
     }
 
-#define COMMON_BIN_OP(OP) \
+    case IR::OP_F80CVTTOINT: {
+      auto Op = IROp->C<IR::IROp_F80CVTToInt>();
+
+      switch (Op->Size) {
+        case 2: {
+          *Info = GetFallbackInfo(&OpHandlers<IR::OP_F80CVTTOINT>::handle2);
+          return true;
+        }
+        case 4: {
+          *Info = GetFallbackInfo(&OpHandlers<IR::OP_F80CVTTOINT>::handle4);
+          return true;
+        }
+        default: LogMan::Msg::D("Unhandled size: %d", OpSize);
+      }
+      break;
+    }
+
+#define COMMON_X87_OP(OP) \
     case IR::OP_F80##OP: { \
       *Info = GetFallbackInfo(&OpHandlers<IR::OP_F80##OP>::handle); \
       return true; \
     }
 
-    COMMON_BIN_OP(ADD)
-    COMMON_BIN_OP(SUB)
-    COMMON_BIN_OP(MUL)
-    COMMON_BIN_OP(DIV)
+    // Unary
+    COMMON_X87_OP(ROUND)
+    COMMON_X87_OP(F2XM1)
+    COMMON_X87_OP(TAN)
+    COMMON_X87_OP(SQRT)
+    COMMON_X87_OP(SIN)
+    COMMON_X87_OP(COS)
+    COMMON_X87_OP(XTRACT_EXP)
+    COMMON_X87_OP(XTRACT_SIG)
+
+    // Binary
+    COMMON_X87_OP(ADD)
+    COMMON_X87_OP(SUB)
+    COMMON_X87_OP(MUL)
+    COMMON_X87_OP(DIV)
+    COMMON_X87_OP(FYL2X)
+    COMMON_X87_OP(ATAN)
+    COMMON_X87_OP(FPREM1)
+    COMMON_X87_OP(FPREM)
+    COMMON_X87_OP(SCALE)
+
     default:
       break;
   }

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
@@ -16,9 +16,15 @@ namespace FEXCore::CPU {
     FABI_UNKNOWN,
     FABI_F80_F32,
     FABI_F80_F64,
+    FABI_F80_I16,
+    FABI_F80_I32,
     FABI_F32_F80,
     FABI_F64_F80,
+    FABI_I16_F80,
+    FABI_I32_F80,
+    FABI_I64_F80,
     FABI_I64_F80_F80,
+    FABI_F80_F80,
     FABI_F80_F80_F80,
   };
 

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
@@ -1,19 +1,36 @@
 namespace FEXCore::Core {
-    struct InternalThreadState;
+  struct InternalThreadState;
 }
 
 namespace FEXCore::IR {
-    template<bool copy>
-    class IRListView;
+  template<bool copy>
+  class IRListView;
 }
 
 namespace FEXCore::Core{
-    struct DebugData;
+  struct DebugData;
 }
 
 namespace FEXCore::CPU {
-    class InterpreterOps {
-        public:
-        static void InterpretIR(FEXCore::Core::InternalThreadState *Thread, FEXCore::IR::IRListView<true> *CurrentIR, FEXCore::Core::DebugData *DebugData);
-    };
+  enum FallbackABI {
+    FABI_UNKNOWN,
+    FABI_F80_F32,
+    FABI_F80_F64,
+    FABI_F32_F80,
+    FABI_F64_F80,
+    FABI_I64_F80_F80,
+    FABI_F80_F80_F80,
+  };
+
+  struct FallbackInfo {
+    FallbackABI ABI;
+    void *fn;
+  };
+  
+  class InterpreterOps {
+
+    public:
+      static void InterpretIR(FEXCore::Core::InternalThreadState *Thread, FEXCore::IR::IRListView<true> *CurrentIR, FEXCore::Core::DebugData *DebugData);
+      static bool GetFallbackHandler(IR::IROp_Header *IROp, FallbackInfo *Info);
+  };
 };

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -1043,10 +1043,6 @@ DEF_OP(FCmp) {
   }
 }
 
-DEF_OP(F80Cmp) {
-  LogMan::Msg::D("Unimplemented");
-}
-
 #undef DEF_OP
 
 void JITCore::RegisterALUHandlers() {
@@ -1095,7 +1091,6 @@ void JITCore::RegisterALUHandlers() {
   REGISTER_OP(FLOAT_TOGPR_U,     Float_ToGPR_U);
   REGISTER_OP(FLOAT_TOGPR_S,     Float_ToGPR_S);
   REGISTER_OP(FCMP,              FCmp);
-  REGISTER_OP(F80CMP,            F80Cmp);
 
 #undef REGISTER_OP
 }

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -223,8 +223,6 @@ private:
   /**  @} */
 
   struct CompilerSharedData {
-    uint64_t InterpreterFallbackHelperAddress{};
-
     uint64_t SignalReturnInstruction{};
 
     uint32_t *SignalHandlerRefCounterPtr{};

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -311,7 +311,6 @@ private:
   DEF_OP(Float_ToGPR_U);
   DEF_OP(Float_ToGPR_S);
   DEF_OP(FCmp);
-  DEF_OP(F80Cmp);
 
   ///< Atomic ops
   DEF_OP(CASPair);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -51,8 +51,8 @@ namespace FEXCore::CPU {
 using namespace Xbyak::util;
 const std::array<Xbyak::Reg, 9> RA64 = { rsi, r8, r9, r10, r11, rbp, r12, r13, r15 };
 const std::array<std::pair<Xbyak::Reg, Xbyak::Reg>, 4> RA64Pair = {{ {rsi, r8}, {r9, r10}, {r11, rbp}, {r12, r13} }};
-const std::array<Xbyak::Reg, 11> RAXMM = { xmm0, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm9, xmm10 };
-const std::array<Xbyak::Xmm, 11> RAXMM_x = { xmm0, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm9, xmm10 };
+const std::array<Xbyak::Reg, 10> RAXMM = { xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm9, xmm10 };
+const std::array<Xbyak::Xmm, 10> RAXMM_x = {  xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm9, xmm10 };
 
 class JITCore final : public CPUBackend, public Xbyak::CodeGenerator {
 public:

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -167,8 +167,6 @@ private:
   uint32_t SignalHandlerRefCounter{};
 
   struct CompilerSharedData {
-    void *InterpreterFallbackHelperAddress;
-
     uint64_t SignalHandlerReturnAddress{};
 
     uint32_t *SignalHandlerRefCounterPtr{};

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -51,8 +51,8 @@ namespace FEXCore::CPU {
 using namespace Xbyak::util;
 const std::array<Xbyak::Reg, 9> RA64 = { rsi, r8, r9, r10, r11, rbp, r12, r13, r15 };
 const std::array<std::pair<Xbyak::Reg, Xbyak::Reg>, 4> RA64Pair = {{ {rsi, r8}, {r9, r10}, {r11, rbp}, {r12, r13} }};
-const std::array<Xbyak::Reg, 10> RAXMM = { xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm9, xmm10 };
-const std::array<Xbyak::Xmm, 10> RAXMM_x = {  xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm9, xmm10 };
+const std::array<Xbyak::Reg, 11> RAXMM = { xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm9, xmm10, xmm11};
+const std::array<Xbyak::Xmm, 11> RAXMM_x = {  xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm9, xmm10, xmm11};
 
 class JITCore final : public CPUBackend, public Xbyak::CodeGenerator {
 public:

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -198,6 +198,9 @@ private:
   void RegisterMoveHandlers();
   void RegisterVectorHandlers();
   void RegisterEncryptionHandlers();
+
+  void PushRegs();
+  void PopRegs();
 #define DEF_OP(x) void Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
 
   ///< Unhandled handler

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
@@ -912,7 +912,10 @@ DEF_OP(VZip2) {
 }
 
 DEF_OP(VBSL) {
-  LogMan::Msg::A("Unimplemented");
+  auto Op = IROp->C<IR::IROp_VBSL>();
+  vpand(xmm11, GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+  vpandn(xmm12, GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[2].ID()));
+  vpor(GetDst(Node), xmm11, xmm12);
 }
 
 DEF_OP(VCMPEQ) {

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
@@ -262,17 +262,17 @@ DEF_OP(VAddP) {
     vpaddw(GetDst(Node), xmm15, xmm14);
     switch (Op->Header.ElementSize) {
       case 1:
-        vpunpcklbw(xmm11, xmm15, xmm14);
+        vpunpcklbw(xmm0, xmm15, xmm14);
         vpunpckhbw(xmm12, xmm15, xmm14);
 
-        vpunpcklbw(xmm15, xmm11, xmm12);
-        vpunpckhbw(xmm14, xmm11, xmm12);
+        vpunpcklbw(xmm15, xmm0, xmm12);
+        vpunpckhbw(xmm14, xmm0, xmm12);
 
-        vpunpcklbw(xmm11, xmm15, xmm14);
+        vpunpcklbw(xmm0, xmm15, xmm14);
         vpunpckhbw(xmm12, xmm15, xmm14);
 
-        vpunpcklbw(xmm15, xmm11, xmm12);
-        vpunpckhbw(xmm14, xmm11, xmm12);
+        vpunpcklbw(xmm15, xmm0, xmm12);
+        vpunpckhbw(xmm14, xmm0, xmm12);
 
         vpaddb(GetDst(Node), xmm15, xmm14);
         break;
@@ -291,17 +291,17 @@ DEF_OP(VAddP) {
         movdqu(xmm15, GetSrc(Op->Header.Args[0].ID()));
         movdqu(xmm14, GetSrc(Op->Header.Args[1].ID()));
 
-        vpunpcklbw(xmm11, xmm15, xmm14);
+        vpunpcklbw(xmm0, xmm15, xmm14);
         vpunpckhbw(xmm12, xmm15, xmm14);
 
-        vpunpcklbw(xmm15, xmm11, xmm12);
-        vpunpckhbw(xmm14, xmm11, xmm12);
+        vpunpcklbw(xmm15, xmm0, xmm12);
+        vpunpckhbw(xmm14, xmm0, xmm12);
 
-        vpunpcklbw(xmm11, xmm15, xmm14);
+        vpunpcklbw(xmm0, xmm15, xmm14);
         vpunpckhbw(xmm12, xmm15, xmm14);
 
-        vpunpcklbw(xmm15, xmm11, xmm12);
-        vpunpckhbw(xmm14, xmm11, xmm12);
+        vpunpcklbw(xmm15, xmm0, xmm12);
+        vpunpckhbw(xmm14, xmm0, xmm12);
 
         vpaddb(GetDst(Node), xmm15, xmm14);
         break;
@@ -913,9 +913,9 @@ DEF_OP(VZip2) {
 
 DEF_OP(VBSL) {
   auto Op = IROp->C<IR::IROp_VBSL>();
-  vpand(xmm11, GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+  vpand(xmm0, GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
   vpandn(xmm12, GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[2].ID()));
-  vpor(GetDst(Node), xmm11, xmm12);
+  vpor(GetDst(Node), xmm0, xmm12);
 }
 
 DEF_OP(VCMPEQ) {

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -6298,7 +6298,7 @@ void OpDispatchBuilder::SetX87Top(OrderedNode *Value) {
 
 template<size_t width>
 void OpDispatchBuilder::FLD(OpcodeArgs) {
-  Current_Header->ShouldInterpret = true;
+  //Current_Header->ShouldInterpret = true;
 
   // Update TOP
   auto orig_top = GetX87Top();
@@ -6333,7 +6333,7 @@ void OpDispatchBuilder::FLD(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::FBLD(OpcodeArgs) {
-  Current_Header->ShouldInterpret = true;
+  //Current_Header->ShouldInterpret = true;
 
   // Update TOP
   auto orig_top = GetX87Top();
@@ -6348,7 +6348,7 @@ void OpDispatchBuilder::FBLD(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::FBSTP(OpcodeArgs) {
-  Current_Header->ShouldInterpret = true;
+  //Current_Header->ShouldInterpret = true;
 
   auto orig_top = GetX87Top();
   auto data = _LoadContextIndexed(orig_top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
@@ -6363,7 +6363,7 @@ void OpDispatchBuilder::FBSTP(OpcodeArgs) {
 
 template<uint64_t Lower, uint32_t Upper>
 void OpDispatchBuilder::FLD_Const(OpcodeArgs) {
-  Current_Header->ShouldInterpret = true;
+  //Current_Header->ShouldInterpret = true;
   // Update TOP
   auto orig_top = GetX87Top();
   auto top = _And(_Sub(orig_top, _Constant(1)), _Constant(7));
@@ -6378,7 +6378,7 @@ void OpDispatchBuilder::FLD_Const(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::FILD(OpcodeArgs) {
-  Current_Header->ShouldInterpret = true;
+  //Current_Header->ShouldInterpret = true;
 
   // Update TOP
   auto orig_top = GetX87Top();
@@ -6418,7 +6418,7 @@ void OpDispatchBuilder::FILD(OpcodeArgs) {
 
 template<size_t width>
 void OpDispatchBuilder::FST(OpcodeArgs) {
-  Current_Header->ShouldInterpret = true;
+  //Current_Header->ShouldInterpret = true;
 
   auto orig_top = GetX87Top();
   auto data = _LoadContextIndexed(orig_top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
@@ -6437,7 +6437,7 @@ void OpDispatchBuilder::FST(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::FIST(OpcodeArgs) {
-  Current_Header->ShouldInterpret = true;
+  //Current_Header->ShouldInterpret = true;
 
   auto Size = GetSrcSize(Op);
 
@@ -6455,7 +6455,7 @@ void OpDispatchBuilder::FIST(OpcodeArgs) {
 
 template <size_t width, bool Integer, OpDispatchBuilder::OpResult ResInST0>
 void OpDispatchBuilder::FADD(OpcodeArgs) {
-  Current_Header->ShouldInterpret = true;
+  //Current_Header->ShouldInterpret = true;
 
   auto top = GetX87Top();
   OrderedNode *StackLocation = top;
@@ -6467,12 +6467,13 @@ void OpDispatchBuilder::FADD(OpcodeArgs) {
 
   if (Op->Src[0].TypeNone.Type != 0) {
     // Memory arg
-    arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
     if (width == 16 || width == 32 || width == 64) {
       if (Integer) {
+        arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
         b = _F80CVTToInt(arg, width / 8);
       }
       else {
+        arg = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
         b = _F80CVTTo(arg, width / 8);
       }
     }
@@ -6500,7 +6501,7 @@ void OpDispatchBuilder::FADD(OpcodeArgs) {
 
 template<size_t width, bool Integer, OpDispatchBuilder::OpResult ResInST0>
 void OpDispatchBuilder::FMUL(OpcodeArgs) {
-  Current_Header->ShouldInterpret = true;
+  //Current_Header->ShouldInterpret = true;
 
   auto top = GetX87Top();
   OrderedNode *StackLocation = top;
@@ -6511,13 +6512,14 @@ void OpDispatchBuilder::FMUL(OpcodeArgs) {
 
   if (Op->Src[0].TypeNone.Type != 0) {
     // Memory arg
-    arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
 
     if (width == 16 || width == 32 || width == 64) {
       if (Integer) {
+        arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
         b = _F80CVTToInt(arg, width / 8);
       }
       else {
+        arg = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
         b = _F80CVTTo(arg, width / 8);
       }
     }
@@ -6547,7 +6549,7 @@ void OpDispatchBuilder::FMUL(OpcodeArgs) {
 
 template<size_t width, bool Integer, bool reverse, OpDispatchBuilder::OpResult ResInST0>
 void OpDispatchBuilder::FDIV(OpcodeArgs) {
-  Current_Header->ShouldInterpret = true;
+  //Current_Header->ShouldInterpret = true;
 
   auto top = GetX87Top();
   OrderedNode *StackLocation = top;
@@ -6558,13 +6560,14 @@ void OpDispatchBuilder::FDIV(OpcodeArgs) {
 
   if (Op->Src[0].TypeNone.Type != 0) {
     // Memory arg
-    arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
 
     if (width == 16 || width == 32 || width == 64) {
       if (Integer) {
+        arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
         b = _F80CVTToInt(arg, width / 8);
       }
       else {
+        arg = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
         b = _F80CVTTo(arg, width / 8);
       }
     }
@@ -6600,7 +6603,7 @@ void OpDispatchBuilder::FDIV(OpcodeArgs) {
 
 template<size_t width, bool Integer, bool reverse, OpDispatchBuilder::OpResult ResInST0>
 void OpDispatchBuilder::FSUB(OpcodeArgs) {
-  Current_Header->ShouldInterpret = true;
+  //Current_Header->ShouldInterpret = true;
 
   auto top = GetX87Top();
   OrderedNode *StackLocation = top;
@@ -6611,13 +6614,14 @@ void OpDispatchBuilder::FSUB(OpcodeArgs) {
 
   if (Op->Src[0].TypeNone.Type != 0) {
     // Memory arg
-    arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
 
     if (width == 16 || width == 32 || width == 64) {
       if (Integer) {
+        arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
         b = _F80CVTToInt(arg, width / 8);
       }
       else {
+        arg = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
         b = _F80CVTTo(arg, width / 8);
       }
     }
@@ -6651,7 +6655,7 @@ void OpDispatchBuilder::FSUB(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::FCHS(OpcodeArgs) {
-  Current_Header->ShouldInterpret = true;
+  //Current_Header->ShouldInterpret = true;
 
   auto top = GetX87Top();
   auto a = _LoadContextIndexed(top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
@@ -6668,7 +6672,7 @@ void OpDispatchBuilder::FCHS(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::FABS(OpcodeArgs) {
-  Current_Header->ShouldInterpret = true;
+  //Current_Header->ShouldInterpret = true;
 
   auto top = GetX87Top();
   auto a = _LoadContextIndexed(top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
@@ -6685,7 +6689,7 @@ void OpDispatchBuilder::FABS(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::FTST(OpcodeArgs) {
-  Current_Header->ShouldInterpret = true;
+  //Current_Header->ShouldInterpret = true;
 
   auto top = GetX87Top();
   auto a = _LoadContextIndexed(top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
@@ -6711,7 +6715,7 @@ void OpDispatchBuilder::FTST(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::FRNDINT(OpcodeArgs) {
-  Current_Header->ShouldInterpret = true;
+  //Current_Header->ShouldInterpret = true;
 
   auto top = GetX87Top();
   auto a = _LoadContextIndexed(top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
@@ -6723,7 +6727,7 @@ void OpDispatchBuilder::FRNDINT(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::FXTRACT(OpcodeArgs) {
-  Current_Header->ShouldInterpret = true;
+  //Current_Header->ShouldInterpret = true;
 
   auto orig_top = GetX87Top();
   auto top = _And(_Sub(orig_top, _Constant(1)), _Constant(7));
@@ -6740,14 +6744,14 @@ void OpDispatchBuilder::FXTRACT(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::FNINIT(OpcodeArgs) {
-  Current_Header->ShouldInterpret = true;
+  //Current_Header->ShouldInterpret = true;
 
   SetX87Top(_Constant(0));
 }
 
 template<size_t width, bool Integer, OpDispatchBuilder::FCOMIFlags whichflags, bool poptwice>
 void OpDispatchBuilder::FCOMI(OpcodeArgs) {
-  Current_Header->ShouldInterpret = true;
+  //Current_Header->ShouldInterpret = true;
 
   auto top = GetX87Top();
   auto mask = _Constant(7);
@@ -6757,12 +6761,13 @@ void OpDispatchBuilder::FCOMI(OpcodeArgs) {
 
   if (Op->Src[0].TypeNone.Type != 0) {
     // Memory arg
-    arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
     if (width == 16 || width == 32 || width == 64) {
       if (Integer) {
+        arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
         b = _F80CVTToInt(arg, width / 8);
       }
       else {
+        arg = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
         b = _F80CVTTo(arg, width / 8);
       }
     }
@@ -6810,7 +6815,7 @@ void OpDispatchBuilder::FCOMI(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::FXCH(OpcodeArgs) {
-  Current_Header->ShouldInterpret = true;
+  //Current_Header->ShouldInterpret = true;
 
   auto top = GetX87Top();
   OrderedNode* arg;
@@ -6830,7 +6835,7 @@ void OpDispatchBuilder::FXCH(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::FST(OpcodeArgs) {
-  Current_Header->ShouldInterpret = true;
+  //Current_Header->ShouldInterpret = true;
 
   auto top = GetX87Top();
   OrderedNode* arg;
@@ -6854,7 +6859,7 @@ void OpDispatchBuilder::FST(OpcodeArgs) {
 
 template<FEXCore::IR::IROps IROp>
 void OpDispatchBuilder::X87UnaryOp(OpcodeArgs) {
-  Current_Header->ShouldInterpret = true;
+  //Current_Header->ShouldInterpret = true;
 
   auto top = GetX87Top();
   auto a = _LoadContextIndexed(top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
@@ -6869,7 +6874,7 @@ void OpDispatchBuilder::X87UnaryOp(OpcodeArgs) {
 
 template<FEXCore::IR::IROps IROp>
 void OpDispatchBuilder::X87BinaryOp(OpcodeArgs) {
-  Current_Header->ShouldInterpret = true;
+  //Current_Header->ShouldInterpret = true;
   auto top = GetX87Top();
 
   auto mask = _Constant(7);
@@ -6900,7 +6905,7 @@ void OpDispatchBuilder::X87ModifySTP(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::X87SinCos(OpcodeArgs) {
-  Current_Header->ShouldInterpret = true;
+  //Current_Header->ShouldInterpret = true;
 
   auto orig_top = GetX87Top();
   auto top = _And(_Sub(orig_top, _Constant(1)), _Constant(7));
@@ -6918,7 +6923,7 @@ void OpDispatchBuilder::X87SinCos(OpcodeArgs) {
 
 void OpDispatchBuilder::X87FYL2X(OpcodeArgs) {
   bool Plus1 = Op->OP == 0x01F9; // FYL2XP
-  Current_Header->ShouldInterpret = true;
+  //Current_Header->ShouldInterpret = true;
 
   auto orig_top = GetX87Top();
   auto top = _And(_Add(orig_top, _Constant(1)), _Constant(7));
@@ -6942,7 +6947,7 @@ void OpDispatchBuilder::X87FYL2X(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::X87TAN(OpcodeArgs) {
-  Current_Header->ShouldInterpret = true;
+  //Current_Header->ShouldInterpret = true;
 
   auto orig_top = GetX87Top();
   auto top = _And(_Sub(orig_top, _Constant(1)), _Constant(7));
@@ -6963,7 +6968,7 @@ void OpDispatchBuilder::X87TAN(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::X87ATAN(OpcodeArgs) {
-  Current_Header->ShouldInterpret = true;
+  //Current_Header->ShouldInterpret = true;
 
   auto orig_top = GetX87Top();
   auto top = _And(_Add(orig_top, _Constant(1)), _Constant(7));
@@ -6979,7 +6984,7 @@ void OpDispatchBuilder::X87ATAN(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::X87LDENV(OpcodeArgs) {
-  Current_Header->ShouldInterpret = true;
+  //Current_Header->ShouldInterpret = true;
   auto Size = GetSrcSize(Op);
   OrderedNode *Mem = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1, false);
 
@@ -7002,7 +7007,7 @@ void OpDispatchBuilder::X87LDENV(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::X87FNSTENV(OpcodeArgs) {
-  Current_Header->ShouldInterpret = true;
+  //Current_Header->ShouldInterpret = true;
 	// 14 bytes for 16bit
 	// 2 Bytes : FCW
 	// 2 Bytes : FSW
@@ -7087,7 +7092,7 @@ void OpDispatchBuilder::X87FSTCW(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::X87LDSW(OpcodeArgs) {
-  Current_Header->ShouldInterpret = true;
+  //Current_Header->ShouldInterpret = true;
   OrderedNode *NewFSW = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
   // Strip out the FSW information
   auto Top = _Bfe(3, 11, NewFSW);
@@ -7105,7 +7110,7 @@ void OpDispatchBuilder::X87LDSW(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::X87FNSTSW(OpcodeArgs) {
-  Current_Header->ShouldInterpret = true;
+  //Current_Header->ShouldInterpret = true;
   // We must construct the FSW from our various bits
   OrderedNode *FSW = _Constant(0);
   auto Top = GetX87Top();
@@ -7125,7 +7130,7 @@ void OpDispatchBuilder::X87FNSTSW(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::X87FNSAVE(OpcodeArgs) {
-  Current_Header->ShouldInterpret = true;
+  //Current_Header->ShouldInterpret = true;
 	// 14 bytes for 16bit
 	// 2 Bytes : FCW
 	// 2 Bytes : FSW
@@ -7223,11 +7228,12 @@ void OpDispatchBuilder::X87FNSAVE(OpcodeArgs) {
   // upper 16 bits [79:64]
   _StoreMem(FPRClass, 8, ST0Location, data, 1);
   ST0Location = _Add(ST0Location, _Constant(8));
-  _VStoreMemElement(16, 2, ST0Location, data, 4, 1);
+  auto topBytes = _VExtractElement(16, 2, data, 4);
+  _StoreMem(FPRClass, 2, ST0Location, topBytes, 1);
 }
 
 void OpDispatchBuilder::X87FRSTOR(OpcodeArgs) {
-  Current_Header->ShouldInterpret = true;
+  //Current_Header->ShouldInterpret = true;
   auto Size = GetSrcSize(Op);
   OrderedNode *Mem = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1, false);
 
@@ -7277,7 +7283,8 @@ void OpDispatchBuilder::X87FRSTOR(OpcodeArgs) {
 
   OrderedNode *Reg = _LoadMem(FPRClass, 8, ST0Location, 1);
   ST0Location = _Add(ST0Location, _Constant(8));
-  Reg = _VLoadMemElement(16, 2, ST0Location, Reg, 4, 1);
+  OrderedNode *RegHigh = _LoadMem(FPRClass, 2, ST0Location, 1);
+  Reg = _VInsElement(16, 2, 4, 0, Reg, RegHigh);
   _StoreContextIndexed(Reg, Top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
 }
 
@@ -7300,7 +7307,7 @@ void OpDispatchBuilder::X87FXAM(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::X87FCMOV(OpcodeArgs) {
-  Current_Header->ShouldInterpret = true;
+  //Current_Header->ShouldInterpret = true;
   enum CompareType {
     COMPARE_ZERO,
     COMPARE_NOTZERO,

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -4404,7 +4404,7 @@ void OpDispatchBuilder::CreateJumpBlocks(std::vector<FEXCore::Frontend::Decoder:
 
 void OpDispatchBuilder::BeginFunction(uint64_t RIP, std::vector<FEXCore::Frontend::Decoder::DecodedBlocks> const *Blocks) {
   Entry = RIP;
-  auto IRHeader = _IRHeader(InvalidNode, RIP, 0, false);
+  auto IRHeader = _IRHeader(InvalidNode, RIP, 0);
   Current_Header = IRHeader.first;
   CreateJumpBlocks(Blocks);
 
@@ -6298,7 +6298,6 @@ void OpDispatchBuilder::SetX87Top(OrderedNode *Value) {
 
 template<size_t width>
 void OpDispatchBuilder::FLD(OpcodeArgs) {
-  //Current_Header->ShouldInterpret = true;
 
   // Update TOP
   auto orig_top = GetX87Top();
@@ -6333,7 +6332,6 @@ void OpDispatchBuilder::FLD(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::FBLD(OpcodeArgs) {
-  //Current_Header->ShouldInterpret = true;
 
   // Update TOP
   auto orig_top = GetX87Top();
@@ -6348,7 +6346,6 @@ void OpDispatchBuilder::FBLD(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::FBSTP(OpcodeArgs) {
-  //Current_Header->ShouldInterpret = true;
 
   auto orig_top = GetX87Top();
   auto data = _LoadContextIndexed(orig_top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
@@ -6363,7 +6360,6 @@ void OpDispatchBuilder::FBSTP(OpcodeArgs) {
 
 template<uint64_t Lower, uint32_t Upper>
 void OpDispatchBuilder::FLD_Const(OpcodeArgs) {
-  //Current_Header->ShouldInterpret = true;
   // Update TOP
   auto orig_top = GetX87Top();
   auto top = _And(_Sub(orig_top, _Constant(1)), _Constant(7));
@@ -6378,7 +6374,6 @@ void OpDispatchBuilder::FLD_Const(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::FILD(OpcodeArgs) {
-  //Current_Header->ShouldInterpret = true;
 
   // Update TOP
   auto orig_top = GetX87Top();
@@ -6418,7 +6413,6 @@ void OpDispatchBuilder::FILD(OpcodeArgs) {
 
 template<size_t width>
 void OpDispatchBuilder::FST(OpcodeArgs) {
-  //Current_Header->ShouldInterpret = true;
 
   auto orig_top = GetX87Top();
   auto data = _LoadContextIndexed(orig_top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
@@ -6437,7 +6431,6 @@ void OpDispatchBuilder::FST(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::FIST(OpcodeArgs) {
-  //Current_Header->ShouldInterpret = true;
 
   auto Size = GetSrcSize(Op);
 
@@ -6455,7 +6448,6 @@ void OpDispatchBuilder::FIST(OpcodeArgs) {
 
 template <size_t width, bool Integer, OpDispatchBuilder::OpResult ResInST0>
 void OpDispatchBuilder::FADD(OpcodeArgs) {
-  //Current_Header->ShouldInterpret = true;
 
   auto top = GetX87Top();
   OrderedNode *StackLocation = top;
@@ -6501,7 +6493,6 @@ void OpDispatchBuilder::FADD(OpcodeArgs) {
 
 template<size_t width, bool Integer, OpDispatchBuilder::OpResult ResInST0>
 void OpDispatchBuilder::FMUL(OpcodeArgs) {
-  //Current_Header->ShouldInterpret = true;
 
   auto top = GetX87Top();
   OrderedNode *StackLocation = top;
@@ -6549,7 +6540,6 @@ void OpDispatchBuilder::FMUL(OpcodeArgs) {
 
 template<size_t width, bool Integer, bool reverse, OpDispatchBuilder::OpResult ResInST0>
 void OpDispatchBuilder::FDIV(OpcodeArgs) {
-  //Current_Header->ShouldInterpret = true;
 
   auto top = GetX87Top();
   OrderedNode *StackLocation = top;
@@ -6603,7 +6593,6 @@ void OpDispatchBuilder::FDIV(OpcodeArgs) {
 
 template<size_t width, bool Integer, bool reverse, OpDispatchBuilder::OpResult ResInST0>
 void OpDispatchBuilder::FSUB(OpcodeArgs) {
-  //Current_Header->ShouldInterpret = true;
 
   auto top = GetX87Top();
   OrderedNode *StackLocation = top;
@@ -6655,7 +6644,6 @@ void OpDispatchBuilder::FSUB(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::FCHS(OpcodeArgs) {
-  //Current_Header->ShouldInterpret = true;
 
   auto top = GetX87Top();
   auto a = _LoadContextIndexed(top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
@@ -6672,7 +6660,6 @@ void OpDispatchBuilder::FCHS(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::FABS(OpcodeArgs) {
-  //Current_Header->ShouldInterpret = true;
 
   auto top = GetX87Top();
   auto a = _LoadContextIndexed(top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
@@ -6689,7 +6676,6 @@ void OpDispatchBuilder::FABS(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::FTST(OpcodeArgs) {
-  //Current_Header->ShouldInterpret = true;
 
   auto top = GetX87Top();
   auto a = _LoadContextIndexed(top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
@@ -6715,7 +6701,6 @@ void OpDispatchBuilder::FTST(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::FRNDINT(OpcodeArgs) {
-  //Current_Header->ShouldInterpret = true;
 
   auto top = GetX87Top();
   auto a = _LoadContextIndexed(top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
@@ -6727,7 +6712,6 @@ void OpDispatchBuilder::FRNDINT(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::FXTRACT(OpcodeArgs) {
-  //Current_Header->ShouldInterpret = true;
 
   auto orig_top = GetX87Top();
   auto top = _And(_Sub(orig_top, _Constant(1)), _Constant(7));
@@ -6744,14 +6728,12 @@ void OpDispatchBuilder::FXTRACT(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::FNINIT(OpcodeArgs) {
-  //Current_Header->ShouldInterpret = true;
 
   SetX87Top(_Constant(0));
 }
 
 template<size_t width, bool Integer, OpDispatchBuilder::FCOMIFlags whichflags, bool poptwice>
 void OpDispatchBuilder::FCOMI(OpcodeArgs) {
-  //Current_Header->ShouldInterpret = true;
 
   auto top = GetX87Top();
   auto mask = _Constant(7);
@@ -6815,7 +6797,6 @@ void OpDispatchBuilder::FCOMI(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::FXCH(OpcodeArgs) {
-  //Current_Header->ShouldInterpret = true;
 
   auto top = GetX87Top();
   OrderedNode* arg;
@@ -6835,7 +6816,6 @@ void OpDispatchBuilder::FXCH(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::FST(OpcodeArgs) {
-  //Current_Header->ShouldInterpret = true;
 
   auto top = GetX87Top();
   OrderedNode* arg;
@@ -6859,7 +6839,6 @@ void OpDispatchBuilder::FST(OpcodeArgs) {
 
 template<FEXCore::IR::IROps IROp>
 void OpDispatchBuilder::X87UnaryOp(OpcodeArgs) {
-  //Current_Header->ShouldInterpret = true;
 
   auto top = GetX87Top();
   auto a = _LoadContextIndexed(top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
@@ -6874,7 +6853,6 @@ void OpDispatchBuilder::X87UnaryOp(OpcodeArgs) {
 
 template<FEXCore::IR::IROps IROp>
 void OpDispatchBuilder::X87BinaryOp(OpcodeArgs) {
-  //Current_Header->ShouldInterpret = true;
   auto top = GetX87Top();
 
   auto mask = _Constant(7);
@@ -6905,7 +6883,6 @@ void OpDispatchBuilder::X87ModifySTP(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::X87SinCos(OpcodeArgs) {
-  //Current_Header->ShouldInterpret = true;
 
   auto orig_top = GetX87Top();
   auto top = _And(_Sub(orig_top, _Constant(1)), _Constant(7));
@@ -6923,7 +6900,6 @@ void OpDispatchBuilder::X87SinCos(OpcodeArgs) {
 
 void OpDispatchBuilder::X87FYL2X(OpcodeArgs) {
   bool Plus1 = Op->OP == 0x01F9; // FYL2XP
-  //Current_Header->ShouldInterpret = true;
 
   auto orig_top = GetX87Top();
   auto top = _And(_Add(orig_top, _Constant(1)), _Constant(7));
@@ -6947,7 +6923,6 @@ void OpDispatchBuilder::X87FYL2X(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::X87TAN(OpcodeArgs) {
-  //Current_Header->ShouldInterpret = true;
 
   auto orig_top = GetX87Top();
   auto top = _And(_Sub(orig_top, _Constant(1)), _Constant(7));
@@ -6968,7 +6943,6 @@ void OpDispatchBuilder::X87TAN(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::X87ATAN(OpcodeArgs) {
-  //Current_Header->ShouldInterpret = true;
 
   auto orig_top = GetX87Top();
   auto top = _And(_Add(orig_top, _Constant(1)), _Constant(7));
@@ -6984,7 +6958,6 @@ void OpDispatchBuilder::X87ATAN(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::X87LDENV(OpcodeArgs) {
-  //Current_Header->ShouldInterpret = true;
   auto Size = GetSrcSize(Op);
   OrderedNode *Mem = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1, false);
 
@@ -7007,7 +6980,6 @@ void OpDispatchBuilder::X87LDENV(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::X87FNSTENV(OpcodeArgs) {
-  //Current_Header->ShouldInterpret = true;
 	// 14 bytes for 16bit
 	// 2 Bytes : FCW
 	// 2 Bytes : FSW
@@ -7092,7 +7064,6 @@ void OpDispatchBuilder::X87FSTCW(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::X87LDSW(OpcodeArgs) {
-  //Current_Header->ShouldInterpret = true;
   OrderedNode *NewFSW = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
   // Strip out the FSW information
   auto Top = _Bfe(3, 11, NewFSW);
@@ -7110,7 +7081,6 @@ void OpDispatchBuilder::X87LDSW(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::X87FNSTSW(OpcodeArgs) {
-  //Current_Header->ShouldInterpret = true;
   // We must construct the FSW from our various bits
   OrderedNode *FSW = _Constant(0);
   auto Top = GetX87Top();
@@ -7130,7 +7100,6 @@ void OpDispatchBuilder::X87FNSTSW(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::X87FNSAVE(OpcodeArgs) {
-  //Current_Header->ShouldInterpret = true;
 	// 14 bytes for 16bit
 	// 2 Bytes : FCW
 	// 2 Bytes : FSW
@@ -7233,7 +7202,6 @@ void OpDispatchBuilder::X87FNSAVE(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::X87FRSTOR(OpcodeArgs) {
-  //Current_Header->ShouldInterpret = true;
   auto Size = GetSrcSize(Op);
   OrderedNode *Mem = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1, false);
 
@@ -7307,7 +7275,6 @@ void OpDispatchBuilder::X87FXAM(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::X87FCMOV(OpcodeArgs) {
-  //Current_Header->ShouldInterpret = true;
   enum CompareType {
     COMPARE_ZERO,
     COMPARE_NOTZERO,

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -6333,7 +6333,7 @@ void OpDispatchBuilder::FLD(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::FBLD(OpcodeArgs) {
-  //Current_Header->ShouldInterpret = true;
+  Current_Header->ShouldInterpret = true;
 
   // Update TOP
   auto orig_top = GetX87Top();
@@ -6348,7 +6348,7 @@ void OpDispatchBuilder::FBLD(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::FBSTP(OpcodeArgs) {
-  //Current_Header->ShouldInterpret = true;
+  Current_Header->ShouldInterpret = true;
 
   auto orig_top = GetX87Top();
   auto data = _LoadContextIndexed(orig_top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -6333,7 +6333,7 @@ void OpDispatchBuilder::FLD(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::FBLD(OpcodeArgs) {
-  Current_Header->ShouldInterpret = true;
+  //Current_Header->ShouldInterpret = true;
 
   // Update TOP
   auto orig_top = GetX87Top();
@@ -6348,7 +6348,7 @@ void OpDispatchBuilder::FBLD(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::FBSTP(OpcodeArgs) {
-  Current_Header->ShouldInterpret = true;
+  //Current_Header->ShouldInterpret = true;
 
   auto orig_top = GetX87Top();
   auto data = _LoadContextIndexed(orig_top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -80,8 +80,7 @@
       ],
       "Args": [
         "uint64_t", "Entry",
-        "uint32_t", "BlockCount",
-        "bool", "ShouldInterpret"
+        "uint32_t", "BlockCount"
       ]
     },
     "CodeBlock": {

--- a/External/FEXCore/Source/Interface/IR/IRParser.cpp
+++ b/External/FEXCore/Source/Interface/IR/IRParser.cpp
@@ -447,7 +447,7 @@ class IRParser: public FEXCore::IR::IREmitter {
       if (!CheckPrintError(Def, Entry.first)) return false;
       if (!CheckPrintError(Def, CodeBlockCount.first)) return false;
 
-      IRHeader = _IRHeader(InvalidNode, Entry.second, CodeBlockCount.second, false);
+      IRHeader = _IRHeader(InvalidNode, Entry.second, CodeBlockCount.second);
     }
 
     SetWriteCursor(nullptr); // isolate the header from everything following

--- a/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -485,7 +485,7 @@ bool ConstProp::Run(IREmitter *IREmit) {
       auto Op = IROp->CW<IR::IROp_LoadMem>();
       auto AddressHeader = IREmit->GetOpHeader(Op->Header.Args[0]);
 
-      if (AddressHeader->Op == OP_ADD && AddressHeader->Size == 8 && !Header->ShouldInterpret) {
+      if (AddressHeader->Op == OP_ADD && AddressHeader->Size == 8) {
 
         auto [OffsetType, OffsetScale, Arg0, Arg1] = MemExtendedAddressing(IREmit, Op->Size, AddressHeader);
 
@@ -503,7 +503,7 @@ bool ConstProp::Run(IREmitter *IREmit) {
       auto Op = IROp->CW<IR::IROp_StoreMem>();
       auto AddressHeader = IREmit->GetOpHeader(Op->Header.Args[0]);
 
-      if (AddressHeader->Op == OP_ADD && AddressHeader->Size == 8 && !Header->ShouldInterpret) {
+      if (AddressHeader->Op == OP_ADD && AddressHeader->Size == 8) {
         auto [OffsetType, OffsetScale, Arg0, Arg1] = MemExtendedAddressing(IREmit, Op->Size, AddressHeader);
 
         Op->OffsetType = OffsetType;
@@ -749,7 +749,7 @@ bool ConstProp::Run(IREmitter *IREmit) {
   }
 
   // constant inlining
-  if (!HeaderOp->ShouldInterpret && InlineConstants) {
+  if (InlineConstants) {
     for (auto [CodeNode, IROp] : CurrentIR.GetAllCode()) {
       switch(IROp->Op) {
         case OP_LSHR:

--- a/External/FEXCore/Source/Interface/IR/Passes/IRCompaction.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/IRCompaction.cpp
@@ -77,7 +77,7 @@ bool IRCompaction::Run(IREmitter *IREmit) {
 
   // Zero is always zero(invalid)
   OldToNewRemap[0].NodeID = 0;
-  auto LocalHeaderOp = LocalBuilder._IRHeader(OrderedNodeWrapper::WrapOffset(0).GetNode(ListBegin), HeaderOp->Entry, HeaderOp->BlockCount, HeaderOp->ShouldInterpret);
+  auto LocalHeaderOp = LocalBuilder._IRHeader(OrderedNodeWrapper::WrapOffset(0).GetNode(ListBegin), HeaderOp->Entry, HeaderOp->BlockCount);
   OldToNewRemap[CurrentIR.GetID(HeaderNode)].NodeID = LocalIR.GetID(LocalHeaderOp.Node);
 
   {

--- a/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
@@ -51,7 +51,7 @@ bool IRValidation::Run(IREmitter *IREmit) {
   LogMan::Throw::A(HeaderOp->Header.Op == OP_IRHEADER, "First op wasn't IRHeader");
 
   IR::RegisterAllocationData * RAData{};
-  if (Manager->HasRAPass() && !HeaderOp->ShouldInterpret) {
+  if (Manager->HasRAPass()) {
     RAData = Manager->GetRAPass() ? Manager->GetRAPass()->GetAllocationData() : nullptr;
   }
 

--- a/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -1502,9 +1502,6 @@ namespace FEXCore::IR {
     auto IR = IREmit->ViewIR();
 
     auto HeaderOp = IR.GetHeader();
-    if (HeaderOp->ShouldInterpret) {
-      return false;
-    }
 
     SpillSlotCount = 0;
     Graph->SpillStack.clear();

--- a/External/FEXCore/Source/Interface/IR/Passes/StaticRegisterAllocationPass.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/StaticRegisterAllocationPass.cpp
@@ -44,9 +44,6 @@ bool IsStaticAllocFpr(uint32_t Offset, RegisterClassType Class, bool AllowGpr) {
 bool StaticRegisterAllocationPass::Run(IREmitter *IREmit) {
   auto CurrentIR = IREmit->ViewIR();
 
-  if (CurrentIR.GetHeader()->ShouldInterpret)
-    return false;
-
   for (auto [BlockNode, BlockIROp] : CurrentIR.GetBlocks()) {
       for (auto [CodeNode, IROp] : CurrentIR.GetCode(BlockNode)) {
         IREmit->SetWriteCursor(CodeNode);


### PR DESCRIPTION
## Overview

This adds a "fallback" path for unimplemented opcodes in the JITs, and adds an interface to query the interpreter for opcode "fallbacks". The interface is semi-generic so it can be used to fallback any opcode, however only the x87 opcodes have been implemented. `ShouldInterpret` & All related logic has been removed.

This passes all tests now

## Details
### x86-64 jit
- Add `JIT::PushRegs` && `JIT::PopRegs`
- Remove xmm0 from allocated regs as it is the return value
- Add xmm11 as an allocated reg, and use xmm0 as scratch reg in its place
- Add fallbacks for the abis used by x87 handlers
- Implement VBSL
- Remove `ShouldInterpret` logic
### arm64 jit
- Add fallback logic
- Remove empty F80Cmp handler
- Remove `ShouldInterpret` logic
### OpDisp
- Make sure that F80CVTTo ops use FPR/GPR arguments as they should
- Replace VSTOREMEMELEMENT with VEXTRACT
- Mark only BCD opcodes as fallbacks
- Remove `ShouldInterpret` logic
### InterpreterOps
- Add API to query handler / abi info
- Implement handlers (copy paste from interpreter execution for now)