### PR TITLE
x87: Round, Truncate & Precision control

### DIFF
--- a/External/FEXCore/Source/Common/SoftFloat.h
+++ b/External/FEXCore/Source/Common/SoftFloat.h
@@ -77,7 +77,7 @@ struct X80SoftFloat {
   }
 
   static X80SoftFloat FRNDINT(X80SoftFloat const &lhs) {
-    return extF80_roundToInt(lhs, softfloat_round_near_even, false);
+    return extF80_roundToInt(lhs, softfloat_roundingMode, false);
   }
 
   static X80SoftFloat FXTRACT_SIG(X80SoftFloat const &lhs) {
@@ -173,19 +173,26 @@ struct X80SoftFloat {
   }
 
   operator int16_t() const {
-    return extF80_to_i32(*this, softfloat_round_near_even, false);
+    auto rv = extF80_to_i32(*this, softfloat_roundingMode, false);
+    if (rv > INT16_MAX) {
+      return INT16_MAX;
+    } else if (rv < INT16_MIN) {
+      return INT16_MIN;
+    } else {
+      return rv;
+    }
   }
 
   operator int32_t() const {
-    return extF80_to_i32(*this, softfloat_round_near_even, false);
+    return extF80_to_i32(*this, softfloat_roundingMode, false);
   }
 
   operator int64_t() const {
-    return extF80_to_i64(*this, softfloat_round_near_even, false);
+    return extF80_to_i64(*this, softfloat_roundingMode, false);
   }
 
   operator uint64_t() const {
-    return extF80_to_ui64(*this, softfloat_round_near_even, false);
+    return extF80_to_ui64(*this, softfloat_roundingMode, false);
   }
 
   void operator=(const float rhs) {

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -250,6 +250,7 @@ namespace FEXCore::Context {
     memset(NewThreadState.flags, 0, 32);
     NewThreadState.flags[1] = 1;
     NewThreadState.flags[9] = 1;
+    NewThreadState.FCW = 0x37F;
 
     FEXCore::Core::InternalThreadState *Thread = CreateThread(&NewThreadState, 0);
 

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
@@ -14,6 +14,7 @@ namespace FEXCore::Core{
 namespace FEXCore::CPU {
   enum FallbackABI {
     FABI_UNKNOWN,
+    FABI_VOID_U16,
     FABI_F80_F32,
     FABI_F80_F64,
     FABI_F80_I16,

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -196,7 +196,7 @@ bool JITCore::HandleGuestSignal(int Signal, void *info, void *ucontext, GuestSig
       memcpy(guest_uctx->__fpregs_mem._xmm, ThreadState->State.State.xmm, sizeof(ThreadState->State.State.xmm));
 
       // FCW store default
-      guest_uctx->__fpregs_mem.fcw = 0x37F;
+      guest_uctx->__fpregs_mem.fcw = ThreadState->State.State.FCW;
 
       // Reconstruct FSW
       guest_uctx->__fpregs_mem.fsw =
@@ -374,6 +374,16 @@ void JITCore::Op_Unhandled(FEXCore::IR::IROp_Header *IROp, uint32_t Node) {
     LogMan::Msg::A("Unhandled IR Op: %s", std::string(Name).c_str());
   } else {
     switch(Info.ABI) {
+      case FABI_VOID_U16: {
+        PushRegs();
+        mov(edi, GetSrc<RA_32>(IROp->Args[0].ID()));
+        mov(rax, (uintptr_t)Info.fn);
+
+        call(rax);
+
+        PopRegs();
+        break;
+      }
       case FABI_F80_F32:{
         PushRegs();
 

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -349,6 +349,8 @@ public:
   void FST(OpcodeArgs);
 
   void FST(OpcodeArgs);
+
+  template<bool Truncate>
   void FIST(OpcodeArgs);
 
   enum class OpResult {
@@ -381,6 +383,7 @@ public:
   void X87TAN(OpcodeArgs);
   void X87ATAN(OpcodeArgs);
   void X87LDENV(OpcodeArgs);
+  void X87FLDCW(OpcodeArgs);
   void X87FNSTENV(OpcodeArgs);
   void X87FSTCW(OpcodeArgs);
   void X87LDSW(OpcodeArgs);

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -3309,6 +3309,15 @@
       ]
     },
 
+    "F80LoadFCW": {
+      "OpClass": "Vector",
+      "HasSideEffects": true,
+      "SSAArgs": "1",
+      "SSANames": [
+        "X80FCW"
+      ]
+    },
+
     "F80Add": {
       "OpClass": "Vector",
       "HasDest": true,
@@ -3437,6 +3446,9 @@
       "SSAArgs": "1",
       "SSANames": [
         "X80Src"
+      ],
+      "Args": [
+        "bool", "Truncate"
       ],
       "HelperArgs": [
         "uint8_t", "Size"

--- a/External/FEXCore/Source/Interface/IR/IRParser.cpp
+++ b/External/FEXCore/Source/Interface/IR/IRParser.cpp
@@ -82,6 +82,15 @@ class IRParser: public FEXCore::IR::IREmitter {
 	}
 
   template<>
+  std::pair<DecodeFailure, bool> DecodeValue(std::string &Arg) {
+    if (Arg.at(0) != '#') return {DecodeFailure::DECODE_INVALIDCHAR, 0};
+
+    uint8_t Result = strtoul(&Arg.at(1), nullptr, 0);
+    if (errno == ERANGE || Result > 1) return {DecodeFailure::DECODE_INVALIDRANGE, 0};
+    return {DecodeFailure::DECODE_OKAY, Result != 0};
+  }
+
+  template<>
   std::pair<DecodeFailure, uint16_t> DecodeValue(std::string &Arg) {
     if (Arg.at(0) != '#') return {DecodeFailure::DECODE_INVALIDCHAR, 0};
 

--- a/External/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
@@ -33,7 +33,7 @@ namespace {
     std::vector<ContextMemberInfo> ClassificationInfo;
   };
 
-  constexpr static std::array<LastAccessType, 14> DefaultAccess = {
+  constexpr static std::array<LastAccessType, 15> DefaultAccess = {
     ACCESS_NONE,
     ACCESS_NONE,
     ACCESS_INVALID, // PAD
@@ -46,6 +46,7 @@ namespace {
     ACCESS_NONE,
     ACCESS_NONE,
     ACCESS_INVALID, // PAD
+    ACCESS_NONE,
     ACCESS_NONE,
     ACCESS_NONE,
   };
@@ -190,6 +191,16 @@ namespace {
       });
     }
 
+    // FCW
+    ContextClassification->emplace_back(ContextMemberInfo {
+      ContextMemberClassification {
+        offsetof(FEXCore::Core::CPUState, FCW),
+        sizeof(FEXCore::Core::CPUState::FCW),
+      },
+      DefaultAccess[14],
+      FEXCore::IR::InvalidClass,
+    });
+
     size_t ClassifiedStructSize{};
     ContextClassificationInfo->Lookup.reserve(sizeof(FEXCore::Core::CPUState));
     for (auto &it : *ContextClassification) {
@@ -250,6 +261,8 @@ namespace {
     for (size_t i = 0; i < 32; ++i) {
       SetAccess(Offset++, DefaultAccess[13]);
     }
+
+    SetAccess(Offset++, DefaultAccess[14]);
   }
 
   struct BlockInfo {

--- a/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
@@ -270,7 +270,7 @@ bool IRValidation::Run(IREmitter *IREmit) {
       Out << "Warnings:" << std::endl << Warnings.str() << std::endl;
     }
    
-    LogMan::Msg::E("%s", Out.str().c_str());
+    fprintf(stderr, "%s", Out.str().c_str());
   }
 
   return false;

--- a/External/FEXCore/include/FEXCore/Core/CoreState.h
+++ b/External/FEXCore/include/FEXCore/Core/CoreState.h
@@ -22,6 +22,7 @@ namespace FEXCore::Core {
     struct {
       uint32_t base;
     } gdt[32];
+    uint16_t FCW;
   };
   static_assert(offsetof(CPUState, xmm) % 16 == 0, "xmm needs to be 128bit aligned!");
 


### PR DESCRIPTION
## Overview
Adds rounding mode, precision control and implements fisttp* as truncating conversions.

Fixes rendering in Counter Strike 1.6, fixes valgrind's `insn_fpu` & `insn_sse3`

## Details
- [x] Add FCW to the context
- [x] Add `OP_F80LOADFCW` that sets the F80 rounding mode, precision
- [x] Update F80 Handlers to use the precision specified instead of hardcoding
- [x] Extend `OP_F80CVTINT` to have a `bool Truncate` to support `FISTTP*`
- [x] Make sure all fpu ops to use FCW instead of constants

## Follow Ups
- #779, #780