### PR TITLE
OpDisp: Imm SAR OpSize < 32 needs sign extension

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -1871,6 +1871,10 @@ void OpDispatchBuilder::ASHRImmediateOp(OpcodeArgs) {
   else
     Shift &= 0x1F;
 
+  if (Size < 32) {
+    Dest = _Sbfe(Size, 0, Dest);
+  }
+  
   OrderedNode *Src = _Constant(Size, Shift);
   OrderedNode *Result = _Ashr(Dest, Src);
 

--- a/unittests/gcc-target-tests-32/Disabled_Tests
+++ b/unittests/gcc-target-tests-32/Disabled_Tests
@@ -1,0 +1,2 @@
+# Uses AVX
+pr57275.c.gcc-target-test-64

--- a/unittests/gcc-target-tests-32/Known_Failures
+++ b/unittests/gcc-target-tests-32/Known_Failures
@@ -1,10 +1,6 @@
 pr72867.c.gcc-target-test-32
 pr88240.c.gcc-target-test-32
 sse2-mmx-pextrw.c.gcc-target-test-32
-sse2-mmx-psraw.c.gcc-target-test-32
-sse2-mmx-psrawi.c.gcc-target-test-32
-sse2-psraw-1.c.gcc-target-test-32
-sse2-shiftqihi-constant-2.c.gcc-target-test-32
 
 # this uses AVX ops (VMOVAPS)
 pr57275.c.gcc-target-test-32

--- a/unittests/gcc-target-tests-64/Disabled_Tests
+++ b/unittests/gcc-target-tests-64/Disabled_Tests
@@ -3,6 +3,7 @@ pr72867.c.gcc-target-test-64
 sse2-mmx-pslld.c.gcc-target-test-64
 sse2-mmx-psllq.c.gcc-target-test-64
 sse2-mmx-psllw.c.gcc-target-test-64
+sse2-mmx-psraw.c.gcc-target-test-64
 sse2-mmx-psrad.c.gcc-target-test-64
 sse2-mmx-psrld.c.gcc-target-test-64
 sse2-mmx-psrlq.c.gcc-target-test-64
@@ -10,3 +11,6 @@ sse2-mmx-psrlw.c.gcc-target-test-64
 
 # this is flaky on the ARMv8.0 runner
 mcount_pic.c.gcc-target-test-64
+
+# Uses AVX
+pr57275.c.gcc-target-test-64

--- a/unittests/gcc-target-tests-64/Known_Failures
+++ b/unittests/gcc-target-tests-64/Known_Failures
@@ -2,16 +2,13 @@
 asm-5.c.gcc-target-test-64
 pr88240.c.gcc-target-test-64
 sse2-mmx-pextrw.c.gcc-target-test-64
-sse2-mmx-psraw.c.gcc-target-test-64
-sse2-mmx-psrawi.c.gcc-target-test-64
-sse2-psraw-1.c.gcc-target-test-64
-sse2-shiftqihi-constant-2.c.gcc-target-test-64
 
 # these fail on arm
 pr72867.c.gcc-target-test-64
 sse2-mmx-pslld.c.gcc-target-test-64
 sse2-mmx-psllq.c.gcc-target-test-64
 sse2-mmx-psllw.c.gcc-target-test-64
+sse2-mmx-psraw.c.gcc-target-test-64
 sse2-mmx-psrad.c.gcc-target-test-64
 sse2-mmx-psrld.c.gcc-target-test-64
 sse2-mmx-psrlq.c.gcc-target-test-64


### PR DESCRIPTION
## Overview
Fixes sar8 and sar16 sign extension in OpDisp. Fixes #774

## Follow up
#786