### PR TITLE
CPUID: Add cache information, function 0x2

### DIFF
--- a/External/FEXCore/Source/Interface/Core/CPUID.cpp
+++ b/External/FEXCore/Source/Interface/Core/CPUID.cpp
@@ -109,6 +109,31 @@ FEXCore::CPUID::FunctionResults CPUIDEmu::Function_01h() {
   return Res;
 }
 
+// 2: Cache and TLB information
+FEXCore::CPUID::FunctionResults CPUIDEmu::Function_02h() {
+  FEXCore::CPUID::FunctionResults Res{};
+
+  // returns default values from i7 model 1Ah
+  Res.eax = 0x1 | // Number of iterations needed for all descriptors
+    (0x5A << 8) |
+    (0x03 << 16) |
+    (0x55 << 24);
+
+  Res.ebx = 0xE4 |
+    (0xB2 << 8)  |
+    (0xF0 << 16) |
+    (0 << 24);
+
+  Res.ecx = 0; // null descriptors
+
+  Res.edx = 0x2C |
+    (0x21 << 8)  |
+    (0xCA << 16) |
+    (0x09 << 24);
+
+  return Res;
+}
+
 FEXCore::CPUID::FunctionResults CPUIDEmu::Function_06h() {
   FEXCore::CPUID::FunctionResults Res{};
   Res.eax = (1 << 2); // Always running APIC
@@ -366,7 +391,7 @@ void CPUIDEmu::Init(FEXCore::Context::Context *ctx) {
   CTX = ctx;
   RegisterFunction(0, std::bind(&CPUIDEmu::Function_0h, this));
   RegisterFunction(1, std::bind(&CPUIDEmu::Function_01h, this));
-  // 2: Cache and TLB information
+  RegisterFunction(2, std::bind(&CPUIDEmu::Function_02h, this));
   // 3: Serial Number(previously), now reserved
   // 4: Deterministic cache parameters for each level
   // 5: Monitor/mwait

--- a/External/FEXCore/Source/Interface/Core/CPUID.h
+++ b/External/FEXCore/Source/Interface/Core/CPUID.h
@@ -3,6 +3,7 @@
 #include <unordered_map>
 
 #include <FEXCore/Core/CPUID.h>
+#include <FEXCore/Utils/LogManager.h>
 
 namespace FEXCore {
 namespace Context {
@@ -25,8 +26,12 @@ public:
   FEXCore::CPUID::FunctionResults RunFunction(uint32_t Function) {
     auto Handler = FunctionHandlers.find(Function);
 
-    if (Handler == FunctionHandlers.end())
+    if (Handler == FunctionHandlers.end()) {
+      #ifndef NDEBUG
+        LogMan::Msg::E("Unhandled CPU ID function, 0x%x", Function);
+      #endif
       return Function_Reserved();
+    }
 
     return Handler->second();
   }
@@ -43,6 +48,7 @@ private:
   // Functions
   FEXCore::CPUID::FunctionResults Function_0h();
   FEXCore::CPUID::FunctionResults Function_01h();
+  FEXCore::CPUID::FunctionResults Function_02h();
   FEXCore::CPUID::FunctionResults Function_06h();
   FEXCore::CPUID::FunctionResults Function_07h();
   FEXCore::CPUID::FunctionResults Function_8000_0000h();


### PR DESCRIPTION
glibc has a bug in the cache size lookup logic and mistakenly calculates the cache size as 0 if no information is given.

memcpy has a further bug that it assumes that the size of cache is > 144 bytes, leading to out of bound memcpys.

This adds a basic cpuid 0x2 function, and also adds a log for unhandled cpuid bits in debug bulds.

Fixes glibc2.33 that uses ssse3 memcpy that has the bug.