### PR TITLE
Fixes CMPXCHG flags being incorrect aside from ZF

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -4342,11 +4342,11 @@ void OpDispatchBuilder::CMPXCHGOp(OpcodeArgs) {
     _StoreContext(GPRClass, Size, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RAX]), CASResult);
 
     auto Size = GetDstSize(Op) * 8;
-    OrderedNode *Result = _Sub(CASResult, Src3);
+    OrderedNode *Result = _Sub(Src3, CASResult);
     if (Size < 32)
       Result = _Bfe(Size, 0, Result);
 
-    GenerateFlags_SUB(Op, Result, CASResult, Src3);
+    GenerateFlags_SUB(Op, Result, Src3, CASResult);
 
     // Set ZF
     SetRFLAG<FEXCore::X86State::RFLAG_ZF_LOC>(ZFResult);

--- a/unittests/ASM/TwoByte/0F_B0_8.asm
+++ b/unittests/ASM/TwoByte/0F_B0_8.asm
@@ -1,0 +1,101 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "R15": "0x4142434445469748",
+    "R14": "0x4142434445464600",
+    "R13": "0x4142434445468748",
+    "R12": "0x4142434445464600",
+    "R11": "0x4142434445468748",
+    "R10": "0x4142434400004600",
+    "R9":  "0x4142434445468748",
+    "R8":  "0x0000000000004600"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+; 8bit
+mov rax, 0x4142434445466148
+mov [rdx + 8 * 0], rax
+
+; Not a match
+mov rax, 0x47
+mov rbx, 0
+cmpxchg byte [rdx + 8 * 0], bl
+mov rax, [rdx + 8 * 0]
+lahf
+mov r15, rax
+
+; Match
+mov rax, 0x48
+mov rbx, 0
+cmpxchg byte [rdx + 8 * 0], bl
+mov rax, [rdx + 8 * 0]
+lahf
+mov r14, rax
+
+; 16bit
+mov rax, 0x4142434445466148
+mov [rdx + 8 * 0], rax
+
+; Not a match
+mov rax, 0x4748
+mov rbx, 0
+cmpxchg word [rdx + 8 * 0], bx
+mov rax, [rdx + 8 * 0]
+lahf
+mov r13, rax
+
+; Match
+mov rax, 0x6148
+mov rbx, 0
+cmpxchg word [rdx + 8 * 0], bx
+mov rax, [rdx + 8 * 0]
+lahf
+mov r12, rax
+
+; 32bit
+mov rax, 0x4142434445466148
+mov [rdx + 8 * 0], rax
+
+; Not a match
+mov rax, 0x45464748
+mov rbx, 0
+cmpxchg dword [rdx + 8 * 0], ebx
+mov rax, [rdx + 8 * 0]
+lahf
+mov r11, rax
+
+; Match
+mov rax, 0x45466148
+mov rbx, 0
+cmpxchg dword [rdx + 8 * 0], ebx
+mov rax, [rdx + 8 * 0]
+lahf
+mov r10, rax
+
+; 64bit
+mov rax, 0x4142434445466148
+mov [rdx + 8 * 0], rax
+
+; Not a match
+mov rax, 0x45464748
+mov rbx, 0
+cmpxchg qword [rdx + 8 * 0], rbx
+mov rax, [rdx + 8 * 0]
+lahf
+mov r9, rax
+
+; Match
+mov rax, 0x4142434445466148
+mov rbx, 0
+cmpxchg qword [rdx + 8 * 0], rbx
+mov rax, [rdx + 8 * 0]
+lahf
+mov r8, rax
+
+hlt


### PR DESCRIPTION
Almost everything only checks ZF but we had the arguments reversed for
the rest of the comparison flag results.