### PR TITLE
Allow both ARM64 and X86_64 jits to be compiled at the same time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,12 +91,10 @@ endif()
 if (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
   set(_M_ARM_64 1)
   add_definitions(-D_M_ARM_64=1)
-  add_subdirectory(External/vixl/)
-  include_directories(External/vixl/src/)
-  if(CMAKE_BUILD_TYPE MATCHES DEBUG)
-    add_definitions(-DVIXL_DEBUG=1)
-  endif()
 endif()
+
+add_subdirectory(External/vixl/)
+include_directories(External/vixl/src/)
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   # This means we were attempted to get compiled with GCC

--- a/External/FEXCore/CMakeLists.txt
+++ b/External/FEXCore/CMakeLists.txt
@@ -4,6 +4,17 @@ project(${PROJECT_NAME}
   VERSION 0.01
   LANGUAGES CXX)
 
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
+  set(_M_X86_64 1)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcx16")
+endif()
+
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+  set(_M_ARM_64 1)
+endif()
+
+set(ENABLE_JIT_X86_64 ${_M_X86_64} CACHE BOOL "Enable the x86_64 JIT")
+set(ENABLE_JIT_ARM64 ${_M_ARM_64} CACHE BOOL "Enable the ARM64 JIT")
 option(ENABLE_CLANG_FORMAT "Run clang format over the source" FALSE)
 option(ENABLE_JITSYMBOLS "Enable visibility of JITSymbols in profiling tools" FALSE)
 
@@ -17,22 +28,11 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 include(CheckCXXCompilerFlag)
 include(CheckIncludeFileCXX)
 
-if (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
-  set(_M_X86_64 1)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcx16")
-  message(STATUS "Enabling x86-64 JIT")
-  set(ENABLE_JIT 1)
-endif()
 
-if (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
-  message(STATUS "Enabling AArch64 JIT")
-  set(_M_ARM_64 1)
-  set(ENABLE_JIT 1)
-  if (EXISTS ${CMAKE_CURRENT_DIR}/External/vixl/)
+if (EXISTS ${CMAKE_CURRENT_DIR}/External/vixl/)
     # Useful to have for freestanding libFEXCore
     add_subdirectory(External/vixl/)
     include_directories(External/vixl/src/)
-  endif()
 endif()
 
 set(CMAKE_CXX_STANDARD 20)

--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -130,6 +130,7 @@ set (SRCS
   Interface/Core/X86Tables.cpp
   Interface/Core/X86DebugInfo.cpp
   Interface/Core/X86HelperGen.cpp
+  Interface/Core/ArchHelpers/Arm64_stubs.cpp
   Interface/Core/Interpreter/InterpreterCore.cpp
   Interface/Core/Interpreter/InterpreterOps.cpp
   Interface/Core/X86Tables/BaseTables.cpp

--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -175,47 +175,54 @@ if(_M_ARM_64)
     Interface/Core/Interpreter/Arm64Dispatcher.cpp)
 endif()
 
+set(DEFINES )
 set (JIT_LIBS )
-if (ENABLE_JIT)
-  if (_M_X86_64)
-    add_definitions(-D_M_X86_64=1)
-    if (NOT FORCE_AARCH64)
-      list(APPEND SRCS
-        Interface/Core/JIT/x86_64/JIT.cpp
-        Interface/Core/JIT/x86_64/ALUOps.cpp
-        Interface/Core/JIT/x86_64/AtomicOps.cpp
-        Interface/Core/JIT/x86_64/BranchOps.cpp
-        Interface/Core/JIT/x86_64/ConversionOps.cpp
-        Interface/Core/JIT/x86_64/EncryptionOps.cpp
-        Interface/Core/JIT/x86_64/FlagOps.cpp
-        Interface/Core/JIT/x86_64/MemoryOps.cpp
-        Interface/Core/JIT/x86_64/MiscOps.cpp
-        Interface/Core/JIT/x86_64/MoveOps.cpp
-        Interface/Core/JIT/x86_64/VectorOps.cpp)
-    endif()
-  endif()
-  if(_M_ARM_64)
-    add_definitions(-D_M_ARM_64=1)
-    add_definitions(-DVIXL_INCLUDE_TARGET_AARCH64=1)
-    add_definitions(-DVIXL_CODE_BUFFER_MMAP=1)
-    list(APPEND SRCS
-      Interface/Core/JIT/Arm64/JIT.cpp
-      Interface/Core/JIT/Arm64/ALUOps.cpp
-      Interface/Core/JIT/Arm64/AtomicOps.cpp
-      Interface/Core/JIT/Arm64/BranchOps.cpp
-      Interface/Core/JIT/Arm64/ConversionOps.cpp
-      Interface/Core/JIT/Arm64/EncryptionOps.cpp
-      Interface/Core/JIT/Arm64/FlagOps.cpp
-      Interface/Core/JIT/Arm64/MemoryOps.cpp
-      Interface/Core/JIT/Arm64/MiscOps.cpp
-      Interface/Core/JIT/Arm64/MoveOps.cpp
-      Interface/Core/JIT/Arm64/VectorOps.cpp)
-    list(APPEND JIT_LIBS vixl)
-  endif()
+
+if (_M_X86_64)
+  list(APPEND DEFINES -D_M_X86_64=1)
+endif()
+
+if (_M_ARM_64)
+  list(APPEND DEFINES -D_M_ARM_64=1)
+endif()
+
+if (ENABLE_JIT_X86_64)
+  list(APPEND SRCS
+    Interface/Core/JIT/x86_64/JIT.cpp
+    Interface/Core/JIT/x86_64/ALUOps.cpp
+    Interface/Core/JIT/x86_64/AtomicOps.cpp
+    Interface/Core/JIT/x86_64/BranchOps.cpp
+    Interface/Core/JIT/x86_64/ConversionOps.cpp
+    Interface/Core/JIT/x86_64/EncryptionOps.cpp
+    Interface/Core/JIT/x86_64/FlagOps.cpp
+    Interface/Core/JIT/x86_64/MemoryOps.cpp
+    Interface/Core/JIT/x86_64/MiscOps.cpp
+    Interface/Core/JIT/x86_64/MoveOps.cpp
+    Interface/Core/JIT/x86_64/VectorOps.cpp)
+  list(APPEND DEFINES -DJIT_X86_64)
+endif()
+
+if (ENABLE_JIT_ARM64)
+  list(APPEND DEFINES
+    -DVIXL_INCLUDE_TARGET_AARCH64=1
+    -DJIT_ARM64)
+  list(APPEND SRCS
+    Interface/Core/JIT/Arm64/JIT.cpp
+    Interface/Core/JIT/Arm64/ALUOps.cpp
+    Interface/Core/JIT/Arm64/AtomicOps.cpp
+    Interface/Core/JIT/Arm64/BranchOps.cpp
+    Interface/Core/JIT/Arm64/ConversionOps.cpp
+    Interface/Core/JIT/Arm64/EncryptionOps.cpp
+    Interface/Core/JIT/Arm64/FlagOps.cpp
+    Interface/Core/JIT/Arm64/MemoryOps.cpp
+    Interface/Core/JIT/Arm64/MiscOps.cpp
+    Interface/Core/JIT/Arm64/MoveOps.cpp
+    Interface/Core/JIT/Arm64/VectorOps.cpp)
+  list(APPEND JIT_LIBS vixl)
 endif()
 
 if (ENABLE_JITSYMBOLS)
-  add_definitions(-DENABLE_JITSYMBOLS=1)
+  list(APPEND DEFINES -DENABLE_JITSYMBOLS=1)
 endif()
 
 # Generate IR include file
@@ -251,7 +258,7 @@ add_custom_command(
 set_source_files_properties(${OUTPUT_IR_NAME} PROPERTIES
   GENERATED TRUE)
 
-# Create teh target
+# Create the target
 add_custom_target(IR_INC
   DEPENDS "${OUTPUT_NAME}"
   DEPENDS "${OUTPUT_IR_DOC}")
@@ -274,6 +281,8 @@ function(AddLibrary Name Type)
 
   target_include_directories(${Name} PUBLIC "${PROJECT_SOURCE_DIR}/include/")
   target_include_directories(${Name} PUBLIC "${CMAKE_BINARY_DIR}/include/")
+
+  target_compile_definitions(${Name} PRIVATE ${DEFINES})
 
   target_compile_options(${Name}
     PRIVATE

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -28,7 +28,8 @@ class GdbServer;
 class SiganlDelegator;
 
 namespace CPU {
-  class JITCore;
+  class Arm64JITCore;
+  class X86JITCore;
 }
 namespace HLE {
 class SyscallHandler;
@@ -52,7 +53,13 @@ namespace FEXCore::Context {
 
   struct Context {
     friend class FEXCore::HLE::SyscallHandler;
-    friend class FEXCore::CPU::JITCore;
+  #ifdef JIT_ARM64
+    friend class FEXCore::CPU::Arm64JITCore;
+  #endif
+  #ifdef JIT_X86_64
+    friend class FEXCore::CPU::X86JITCore;
+  #endif
+
     friend class FEXCore::IR::Validation::IRValidation;
 
     struct {

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64.cpp
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64.cpp
@@ -38,8 +38,8 @@ static bool StoreCAS8(uint8_t &Expected, uint8_t Val, uint64_t Addr) {
   return Atom->compare_exchange_strong(Expected, Val);
 }
 
-bool HandleCASPAL(void *_mcontext, void *_info, uint32_t Instr) {
-  mcontext_t* mcontext = reinterpret_cast<mcontext_t*>(_mcontext);
+bool HandleCASPAL(void *_ucontext, void *_info, uint32_t Instr) {
+  mcontext_t* mcontext = &reinterpret_cast<ucontext_t*>(_ucontext)->uc_mcontext;
   siginfo_t* info = reinterpret_cast<siginfo_t*>(_info);
 
   if (info->si_code != BUS_ADRALN) {
@@ -827,8 +827,8 @@ std::tuple<uint64_t, bool> DoCAS64(
 
 }
 
-bool HandleCASAL(void *_mcontext, void *_info, uint32_t Instr) {
-  mcontext_t* mcontext = reinterpret_cast<mcontext_t*>(_mcontext);
+bool HandleCASAL(void *_ucontext, void *_info, uint32_t Instr) {
+  mcontext_t* mcontext = &reinterpret_cast<ucontext_t*>(_ucontext)->uc_mcontext;
   siginfo_t* info = reinterpret_cast<siginfo_t*>(_info);
 
   if (info->si_code != BUS_ADRALN) {
@@ -921,8 +921,8 @@ bool HandleCASAL(void *_mcontext, void *_info, uint32_t Instr) {
   return false;
 }
 
-bool HandleAtomicMemOp(void *_mcontext, void *_info, uint32_t Instr) {
-  mcontext_t* mcontext = reinterpret_cast<mcontext_t*>(_mcontext);
+bool HandleAtomicMemOp(void *_ucontext, void *_info, uint32_t Instr) {
+  mcontext_t* mcontext = &reinterpret_cast<ucontext_t*>(_ucontext)->uc_mcontext;
   siginfo_t* info = reinterpret_cast<siginfo_t*>(_info);
 
   if (info->si_code != BUS_ADRALN) {

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64.h
@@ -24,7 +24,7 @@ namespace FEXCore::ArchHelpers::Arm64 {
   constexpr uint32_t ATOMIC_UMIN_OP = 0b0111;
   constexpr uint32_t ATOMIC_SWAP_OP = 0b1000;
 
-  bool HandleCASPAL(void *_mcontext, void *_info, uint32_t Instr);
-  bool HandleCASAL(void *_mcontext, void *_info, uint32_t Instr);
-  bool HandleAtomicMemOp(void *_mcontext, void *_info, uint32_t Instr);
+  bool HandleCASPAL(void *_ucontext, void *_info, uint32_t Instr);
+  bool HandleCASAL(void *_ucontext, void *_info, uint32_t Instr);
+  bool HandleAtomicMemOp(void *_ucontext, void *_info, uint32_t Instr);
 }

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64_stubs.cpp
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64_stubs.cpp
@@ -1,0 +1,26 @@
+#include "Interface/Core/ArchHelpers/Arm64.h"
+
+#include <FEXCore/Utils/LogManager.h>
+
+namespace FEXCore::ArchHelpers::Arm64 {
+
+#ifndef _M_ARM_64
+// These are stub implementations that exist only to allow instantiating the arm64 jit
+// on non arm platforms.
+
+// Obvously such a configuration can't do the actual arm64-specific stuff
+
+bool HandleCASPAL(void *_ucontext, void *_info, uint32_t Instr) {
+    ERROR_AND_DIE("HandleCASPAL Not Implemented");
+}
+
+bool HandleCASAL(void *_ucontext, void *_info, uint32_t Instr) {
+    ERROR_AND_DIE("HandleCASAL Not Implemented");
+}
+
+bool HandleAtomicMemOp(void *_ucontext, void *_info, uint32_t Instr) {
+    ERROR_AND_DIE("HandleAtomicMemOp Not Implemented");
+}
+#endif
+
+}

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/MContext.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/MContext.h
@@ -1,0 +1,210 @@
+#pragma once
+
+#include <FEXCore/Utils/LogManager.h>
+#include <FEXCore/Core/CoreState.h>
+#include <FEXCore/Core/UContext.h>
+
+#include <signal.h>
+#include <string.h>
+#include <ucontext.h>
+#include <stdint.h>
+#include <type_traits>
+
+
+namespace FEXCore::CPU {
+
+
+struct X86ContextBackup {
+  // Host State
+  // RIP and RSP is stored in GPRs here
+  uint64_t GPRs[23];
+  FEXCore::x86_64::_libc_fpstate FPRState;
+
+  // Guest state
+  int Signal;
+  FEXCore::Core::CPUState GuestState;
+};
+
+struct ArmContextBackup {
+  // Host State
+  uint64_t GPRs[31];
+  uint64_t PrevSP;
+  uint64_t PrevPC;
+  uint64_t PState;
+  uint32_t FPSR;
+  uint32_t FPCR;
+  __uint128_t FPRs[32];
+
+  // Guest state
+  int Signal;
+  FEXCore::Core::CPUState GuestState;
+};
+
+}
+
+namespace FEXCore::ArchHelpers::Context {
+
+static inline mcontext_t* GetMContext(void* ucontext) {
+  ucontext_t* _context = (ucontext_t*)ucontext;
+  return &_context->uc_mcontext;
+}
+
+
+#ifdef _M_ARM_64
+
+static inline uint64_t GetSp(void* ucontext) {
+  return GetMContext(ucontext)->sp;
+}
+
+static inline uint64_t GetPc(void* ucontext) {
+  return GetMContext(ucontext)->pc;
+}
+
+static inline void SetSp(void* ucontext, uint64_t val) {
+  GetMContext(ucontext)->sp = val;
+}
+
+static inline void SetPc(void* ucontext, uint64_t val) {
+  GetMContext(ucontext)->pc = val;
+}
+
+static inline uint64_t GetState(void* ucontext) {
+  return GetMContext(ucontext)->regs[28];
+}
+
+static inline void SetState(void* ucontext, uint64_t val) {
+  GetMContext(ucontext)->regs[28] = val;
+}
+
+static inline uint64_t GetArmReg(void* ucontext, uint32_t id) {
+  return GetMContext(ucontext)->regs[id];
+}
+
+static inline void SetArmReg(void* ucontext, uint32_t id, uint64_t val) {
+  GetMContext(ucontext)->regs[id] = val;
+}
+
+constexpr uint32_t FPR_MAGIC = 0x46508001U;
+
+struct HostCTXHeader {
+  uint32_t Magic;
+  uint32_t Size;
+};
+
+struct HostFPRState {
+  HostCTXHeader Head;
+  uint32_t FPSR;
+  uint32_t FPCR;
+  __uint128_t FPRs[32];
+};
+
+template <typename T>
+static inline void BackupContext(void* ucontext, T *Backup) {
+  if constexpr (std::is_same<T, FEXCore::CPU::ArmContextBackup>::value) {
+    auto _mcontext = GetMContext(ucontext);
+
+    memcpy(&Backup->GPRs[0], &_mcontext->regs[0], 31 * sizeof(uint64_t));
+    Backup->PrevSP = ArchHelpers::Context::GetSp(ucontext);
+    Backup->PrevPC = ArchHelpers::Context::GetPc(ucontext);
+    Backup->PState = _mcontext->pstate;
+
+    // Host FPR state starts at _mcontext->reserved[0];
+    HostFPRState *HostState = reinterpret_cast<HostFPRState*>(&_mcontext->__reserved[0]);
+    LogMan::Throw::A(HostState->Head.Magic == FPR_MAGIC, "Wrong FPR Magic: 0x%08x", HostState->Head.Magic);
+    Backup->FPSR = HostState->FPSR;
+    Backup->FPCR = HostState->FPCR;
+    memcpy(&Backup->FPRs[0], &HostState->FPRs[0], 32 * sizeof(__uint128_t));
+  } else {
+      ERROR_AND_DIE("Wrong context type"); // This must be a runtime error
+  }
+}
+
+template <typename T>
+static inline void RestoreContext(void* ucontext, T *Backup) {
+  if constexpr (std::is_same<T, FEXCore::CPU::ArmContextBackup>::value) {
+   auto _mcontext = GetMContext(ucontext);
+
+    HostFPRState *HostState = reinterpret_cast<HostFPRState*>(&_mcontext->__reserved[0]);
+    LogMan::Throw::A(HostState->Head.Magic == FPR_MAGIC, "Wrong FPR Magic: 0x%08x", HostState->Head.Magic);
+    memcpy(&HostState->FPRs[0], &Backup->FPRs[0], 32 * sizeof(__uint128_t));
+    HostState->FPCR = Backup->FPCR;
+    HostState->FPSR = Backup->FPSR;
+
+    // Restore GPRs and other state
+    _mcontext->pstate = Backup->PState;
+    ArchHelpers::Context::SetPc(ucontext, Backup->PrevPC);
+    ArchHelpers::Context::SetSp(ucontext, Backup->PrevSP);
+    memcpy(&_mcontext->regs[0], &Backup->GPRs[0], 31 * sizeof(uint64_t));
+  } else {
+      ERROR_AND_DIE("Wrong context type"); // This must be a runtime error
+  }
+}
+
+#endif
+
+#ifdef _M_X86_64
+
+static inline uint64_t GetSp(void* ucontext) {
+  return GetMContext(ucontext)->gregs[REG_RSP];
+}
+
+static inline uint64_t GetPc(void* ucontext) {
+  return GetMContext(ucontext)->gregs[REG_RIP];
+  }
+
+static inline void SetSp(void* ucontext, uint64_t val) {
+  GetMContext(ucontext)->gregs[REG_RSP] = val;
+}
+
+static inline void SetPc(void* ucontext, uint64_t val) {
+  GetMContext(ucontext)->gregs[REG_RIP] = val;
+}
+
+static inline uint64_t GetState(void* ucontext) {
+  return GetMContext(ucontext)->gregs[REG_R14];
+}
+
+static inline void SetState(void* ucontext, uint64_t val) {
+  GetMContext(ucontext)->gregs[REG_R14] = val;
+}
+
+static inline uint64_t GetArmReg(void* ucontext, uint32_t id) {
+  ERROR_AND_DIE("Not impelented for x86 host");
+}
+
+static inline void SetArmReg(void* ucontext, uint32_t id, uint64_t val) {
+  ERROR_AND_DIE("Not impelented for x86 host");
+}
+
+template <typename T>
+static inline void BackupContext(void* ucontext, T *Backup) {
+  if constexpr (std::is_same<T, FEXCore::CPU::X86ContextBackup>::value) {
+    auto _mcontext = GetMContext(ucontext);
+
+    // Copy the GPRs
+    memcpy(&Backup->GPRs[0], &_mcontext->gregs[0], sizeof(FEXCore::CPU::X86ContextBackup::GPRs));
+    // Copy the FPRState
+    memcpy(&Backup->FPRState, _mcontext->fpregs, sizeof(FEXCore::CPU::X86ContextBackup::FPRState));
+    // XXX: Save 256bit and 512bit AVX register state
+  } else {
+    ERROR_AND_DIE("Wrong context type"); // This must be a runtime error
+  }
+}
+
+template <typename T>
+static inline void RestoreContext(void* ucontext, T *Backup) {
+  if constexpr (std::is_same<T, FEXCore::CPU::X86ContextBackup>::value) {
+    auto _mcontext = GetMContext(ucontext);
+
+    // Copy the GPRs
+    memcpy(&_mcontext->gregs[0], &Backup->GPRs[0], sizeof(FEXCore::CPU::X86ContextBackup::GPRs));
+    // Copy the FPRState
+    memcpy(_mcontext->fpregs, &Backup->FPRState, sizeof(FEXCore::CPU::X86ContextBackup::FPRState));
+  } else {
+    ERROR_AND_DIE("Wrong context type"); // This must be a runtime error
+  }
+}
+
+#endif
+
+} // namespace FEXCore::ArchHelpers::Context

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -29,7 +29,7 @@ static int64_t LREM(int64_t SrcHigh, int64_t SrcLow, int64_t Divisor) {
 
 using namespace vixl;
 using namespace vixl::aarch64;
-#define DEF_OP(x) void JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
+#define DEF_OP(x) void Arm64JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
 DEF_OP(TruncElementPair) {
   auto Op = IROp->C<IR::IROp_TruncElementPair>();
 
@@ -524,7 +524,7 @@ DEF_OP(LDiv) {
       mov(x1, GetReg<RA_64>(Op->Header.Args[0].ID()));
       mov(x2, GetReg<RA_64>(Op->Header.Args[2].ID()));
 
-#if _M_X86_64
+#if VIXL_SIMULATOR
       CallRuntime(LDIV);
 #else
       LoadConstant(x3, reinterpret_cast<uint64_t>(LDIV));
@@ -571,7 +571,7 @@ DEF_OP(LUDiv) {
       mov(x1, GetReg<RA_64>(Op->Header.Args[0].ID()));
       mov(x2, GetReg<RA_64>(Op->Header.Args[2].ID()));
 
-#if _M_X86_64
+#if VIXL_SIMULATOR
       CallRuntime(LUDIV);
 #else
       LoadConstant(x3, reinterpret_cast<uint64_t>(LUDIV));
@@ -628,7 +628,7 @@ DEF_OP(LRem) {
       mov(x1, GetReg<RA_64>(Op->Header.Args[0].ID()));
       mov(x2, GetReg<RA_64>(Op->Header.Args[2].ID()));
 
-#if _M_X86_64
+#if VIXL_SIMULATOR
       CallRuntime(LREM);
 #else
       LoadConstant(x3, reinterpret_cast<uint64_t>(LREM));
@@ -682,7 +682,7 @@ DEF_OP(LURem) {
       mov(x1, GetReg<RA_64>(Op->Header.Args[0].ID()));
       mov(x2, GetReg<RA_64>(Op->Header.Args[2].ID()));
 
-#if _M_X86_64
+#if VIXL_SIMULATOR
       CallRuntime(LUREM);
 #else
       LoadConstant(x3, reinterpret_cast<uint64_t>(LUREM));
@@ -945,7 +945,7 @@ DEF_OP(Select) {
   } else {
     LogMan::Msg::A("Select: Expected GPR or FPR");
   }
-  
+
   auto cc = MapSelectCC(Op->Cond);
 
   uint64_t const_true, const_false;
@@ -1022,7 +1022,7 @@ DEF_OP(FCmp) {
     fcmp(GetSrc(Op->Header.Args[0].ID()).D(), GetSrc(Op->Header.Args[1].ID()).D());
   }
   auto Dst = GetReg<RA_64>(Node);
-  
+
   bool set = false;
 
   if (Op->Flags & (1 << IR::FCMP_FLAG_EQ)) {
@@ -1057,8 +1057,8 @@ DEF_OP(FCmp) {
 
 #undef DEF_OP
 
-void JITCore::RegisterALUHandlers() {
-#define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &JITCore::Op_##x
+void Arm64JITCore::RegisterALUHandlers() {
+#define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &Arm64JITCore::Op_##x
   REGISTER_OP(TRUNCELEMENTPAIR,  TruncElementPair);
   REGISTER_OP(CONSTANT,          Constant);
   REGISTER_OP(ENTRYPOINTOFFSET,  EntrypointOffset);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -524,14 +524,10 @@ DEF_OP(LDiv) {
       mov(x1, GetReg<RA_64>(Op->Header.Args[0].ID()));
       mov(x2, GetReg<RA_64>(Op->Header.Args[2].ID()));
 
-#if VIXL_SIMULATOR
-      CallRuntime(LDIV);
-#else
       LoadConstant(x3, reinterpret_cast<uint64_t>(LDIV));
       SpillStaticRegs();
       blr(x3);
       FillStaticRegs();
-#endif
 
       // Result is now in x0
       // Fix the stack and any values that were stepped on
@@ -571,14 +567,10 @@ DEF_OP(LUDiv) {
       mov(x1, GetReg<RA_64>(Op->Header.Args[0].ID()));
       mov(x2, GetReg<RA_64>(Op->Header.Args[2].ID()));
 
-#if VIXL_SIMULATOR
-      CallRuntime(LUDIV);
-#else
       LoadConstant(x3, reinterpret_cast<uint64_t>(LUDIV));
       SpillStaticRegs();
       blr(x3);
       FillStaticRegs();
-#endif
 
       // Result is now in x0
       // Fix the stack and any values that were stepped on
@@ -628,14 +620,10 @@ DEF_OP(LRem) {
       mov(x1, GetReg<RA_64>(Op->Header.Args[0].ID()));
       mov(x2, GetReg<RA_64>(Op->Header.Args[2].ID()));
 
-#if VIXL_SIMULATOR
-      CallRuntime(LREM);
-#else
       LoadConstant(x3, reinterpret_cast<uint64_t>(LREM));
       SpillStaticRegs();
       blr(x3);
       FillStaticRegs();
-#endif
 
       // Result is now in x0
       // Fix the stack and any values that were stepped on
@@ -682,14 +670,11 @@ DEF_OP(LURem) {
       mov(x1, GetReg<RA_64>(Op->Header.Args[0].ID()));
       mov(x2, GetReg<RA_64>(Op->Header.Args[2].ID()));
 
-#if VIXL_SIMULATOR
-      CallRuntime(LUREM);
-#else
       LoadConstant(x3, reinterpret_cast<uint64_t>(LUREM));
       SpillStaticRegs();
       blr(x3);
       FillStaticRegs();
-#endif
+
       // Fix the stack and any values that were stepped on
       PopDynamicRegsAndLR();
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/AtomicOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/AtomicOps.cpp
@@ -3,7 +3,7 @@
 namespace FEXCore::CPU {
 using namespace vixl;
 using namespace vixl::aarch64;
-#define DEF_OP(x) void JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
+#define DEF_OP(x) void Arm64JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
 DEF_OP(CASPair) {
   auto Op = IROp->C<IR::IROp_CASPair>();
   uint8_t OpSize = IROp->Size;
@@ -865,8 +865,8 @@ DEF_OP(AtomicFetchXor) {
 }
 
 #undef DEF_OP
-void JITCore::RegisterAtomicHandlers() {
-#define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &JITCore::Op_##x
+void Arm64JITCore::RegisterAtomicHandlers() {
+#define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &Arm64JITCore::Op_##x
   REGISTER_OP(CASPAIR,        CASPair);
   REGISTER_OP(CAS,            CAS);
   REGISTER_OP(ATOMICADD,      AtomicAdd);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
@@ -239,13 +239,9 @@ DEF_OP(Thunk) {
 
   mov(x0, GetReg<RA_64>(Op->Header.Args[0].ID()));
 
-#if VIXL_SIMULATOR
-  ERROR_AND_DIE("JIT: OP_THUNK not supported with arm simulator");
-#else
   auto thunkFn = State->CTX->ThunkHandler->LookupThunk(Op->ThunkNameHash);
   LoadConstant(x2, (uintptr_t)thunkFn);
   blr(x2);
-#endif
 
   PopDynamicRegsAndLR();
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ConversionOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ConversionOps.cpp
@@ -4,7 +4,7 @@ namespace FEXCore::CPU {
 
 using namespace vixl;
 using namespace vixl::aarch64;
-#define DEF_OP(x) void JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
+#define DEF_OP(x) void Arm64JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
 DEF_OP(VInsGPR) {
   auto Op = IROp->C<IR::IROp_VInsGPR>();
   mov(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
@@ -193,8 +193,8 @@ DEF_OP(Vector_FToF) {
 }
 
 #undef DEF_OP
-void JITCore::RegisterConversionHandlers() {
-#define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &JITCore::Op_##x
+void Arm64JITCore::RegisterConversionHandlers() {
+#define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &Arm64JITCore::Op_##x
   REGISTER_OP(VINSGPR,         VInsGPR);
   REGISTER_OP(VCASTFROMGPR,    VCastFromGPR);
   REGISTER_OP(FLOAT_FROMGPR_U, Float_FromGPR_U);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/EncryptionOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/EncryptionOps.cpp
@@ -4,7 +4,7 @@
 namespace FEXCore::CPU {
 using namespace vixl;
 using namespace vixl::aarch64;
-#define DEF_OP(x) void JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
+#define DEF_OP(x) void Arm64JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
 
 DEF_OP(AESImc) {
   auto Op = IROp->C<IR::IROp_VAESImc>();
@@ -83,8 +83,8 @@ DEF_OP(AESKeyGenAssist) {
 }
 
 #undef DEF_OP
-void JITCore::RegisterEncryptionHandlers() {
-#define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &JITCore::Op_##x
+void Arm64JITCore::RegisterEncryptionHandlers() {
+#define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &Arm64JITCore::Op_##x
   REGISTER_OP(VAESIMC,     AESImc);
   REGISTER_OP(VAESENC,     AESEnc);
   REGISTER_OP(VAESENCLAST, AESEncLast);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/FlagOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/FlagOps.cpp
@@ -4,15 +4,15 @@ namespace FEXCore::CPU {
 
 using namespace vixl;
 using namespace vixl::aarch64;
-#define DEF_OP(x) void JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
+#define DEF_OP(x) void Arm64JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
 DEF_OP(GetHostFlag) {
   auto Op = IROp->C<IR::IROp_GetHostFlag>();
   ubfx(GetReg<RA_64>(Node), GetReg<RA_64>(Op->Header.Args[0].ID()), Op->Flag, 1);
 }
 
 #undef DEF_OP
-void JITCore::RegisterFlagHandlers() {
-#define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &JITCore::Op_##x
+void Arm64JITCore::RegisterFlagHandlers() {
+#define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &Arm64JITCore::Op_##x
   REGISTER_OP(GETHOSTFLAG, GetHostFlag);
 #undef REGISTER_OP
 }

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -67,16 +67,16 @@ const std::array<aarch64::VRegister, 12> RAFPR = {
   v8,  v9,  v10, v11, v12, v13, v14, v15
 };
 
-class JITCore final : public CPUBackend, public vixl::aarch64::Assembler  {
+class Arm64JITCore final : public CPUBackend, public vixl::aarch64::Assembler  {
 public:
   struct CodeBuffer {
     uint8_t *Ptr;
     size_t Size;
   };
 
-  explicit JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread, CodeBuffer Buffer, bool CompileThread);
+  explicit Arm64JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread, CodeBuffer Buffer, bool CompileThread);
 
-  ~JITCore() override;
+  ~Arm64JITCore() override;
   std::string GetName() override { return "JIT"; }
   void *CompileCode(FEXCore::IR::IRListView const *IR, FEXCore::Core::DebugData *DebugData, FEXCore::IR::RegisterAllocationData *RAData) override;
 
@@ -202,7 +202,7 @@ private:
   void PushCalleeSavedRegisters();
   void PopCalleeSavedRegisters();
 
-  static uint64_t ExitFunctionLink(JITCore *core, FEXCore::Core::InternalThreadState *Thread, uint64_t *record);
+  static uint64_t ExitFunctionLink(Arm64JITCore *core, FEXCore::Core::InternalThreadState *Thread, uint64_t *record);
 
   /**
    * @name Dispatch Helper functions
@@ -243,7 +243,7 @@ private:
 
   void ResetStack();
 
-  using OpHandler = void (JITCore::*)(FEXCore::IR::IROp_Header *IROp, uint32_t Node);
+  using OpHandler = void (Arm64JITCore::*)(FEXCore::IR::IROp_Header *IROp, uint32_t Node);
   std::array<OpHandler, FEXCore::IR::IROps::OP_LAST + 1> OpHandlers {};
   void RegisterALUHandlers();
   void RegisterAtomicHandlers();

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -4,7 +4,7 @@ namespace FEXCore::CPU {
 
 using namespace vixl;
 using namespace vixl::aarch64;
-#define DEF_OP(x) void JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
+#define DEF_OP(x) void Arm64JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
 
 DEF_OP(LoadContext) {
   auto Op = IROp->C<IR::IROp_LoadContext>();
@@ -104,7 +104,7 @@ DEF_OP(LoadRegister) {
     LogMan::Throw::A(regId < SRA64.size(), "out of range regId");
 
     auto reg = SRA64[regId];
-    
+
     switch(Op->Header.Size) {
       case 1:
         LogMan::Throw::A(regOffs == 0 || regOffs == 1, "unexpected regOffs");
@@ -191,7 +191,7 @@ DEF_OP(StoreRegister) {
     LogMan::Throw::A(regId < SRA64.size(), "out of range regId");
 
     auto reg = SRA64[regId];
-    
+
     switch(Op->Header.Size) {
       case 1:
         LogMan::Throw::A(regOffs == 0 || regOffs == 1, "unexpected regOffs");
@@ -202,7 +202,7 @@ DEF_OP(StoreRegister) {
         LogMan::Throw::A(regOffs == 0, "unexpected regOffs");
         bfi(reg, GetReg<RA_64>(Op->Value.ID()), 0, 16);
         break;
-        
+
       case 4:
         LogMan::Throw::A(regOffs == 0, "unexpected regOffs");
         bfi(reg, GetReg<RA_64>(Op->Value.ID()), 0, 32);
@@ -530,7 +530,7 @@ DEF_OP(StoreFlag) {
   strb(GetReg<RA_64>(Op->Header.Args[0].ID()), MemOperand(STATE, offsetof(FEXCore::Core::CPUState, flags[0]) + Op->Flag));
 }
 
-MemOperand JITCore::GenerateMemOperand(uint8_t AccessSize, aarch64::Register Base, IR::OrderedNodeWrapper Offset, IR::MemOffsetType OffsetType, uint8_t OffsetScale) {
+MemOperand Arm64JITCore::GenerateMemOperand(uint8_t AccessSize, aarch64::Register Base, IR::OrderedNodeWrapper Offset, IR::MemOffsetType OffsetType, uint8_t OffsetScale) {
   if (Offset.IsInvalid()) {
     return MemOperand(Base);
   } else {
@@ -792,8 +792,8 @@ DEF_OP(VStoreMemElement) {
 }
 
 #undef DEF_OP
-void JITCore::RegisterMemoryHandlers() {
-#define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &JITCore::Op_##x
+void Arm64JITCore::RegisterMemoryHandlers() {
+#define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &Arm64JITCore::Op_##x
   REGISTER_OP(LOADCONTEXT,         LoadContext);
   REGISTER_OP(STORECONTEXT,        StoreContext);
   REGISTER_OP(LOADREGISTER,        LoadRegister);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
@@ -4,7 +4,7 @@ namespace FEXCore::CPU {
 
 using namespace vixl;
 using namespace vixl::aarch64;
-#define DEF_OP(x) void JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
+#define DEF_OP(x) void Arm64JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
 
 DEF_OP(Fence) {
   auto Op = IROp->C<IR::IROp_Fence>();
@@ -111,8 +111,8 @@ DEF_OP(SetRoundingMode) {
 }
 
 #undef DEF_OP
-void JITCore::RegisterMiscHandlers() {
-#define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &JITCore::Op_##x
+void Arm64JITCore::RegisterMiscHandlers() {
+#define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &Arm64JITCore::Op_##x
   REGISTER_OP(DUMMY,      NoOp);
   REGISTER_OP(IRHEADER,   NoOp);
   REGISTER_OP(CODEBLOCK,  NoOp);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MoveOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MoveOps.cpp
@@ -4,7 +4,7 @@ namespace FEXCore::CPU {
 
 using namespace vixl;
 using namespace vixl::aarch64;
-#define DEF_OP(x) void JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
+#define DEF_OP(x) void Arm64JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
 DEF_OP(ExtractElementPair) {
   auto Op = IROp->C<IR::IROp_ExtractElementPair>();
   switch (Op->Header.Size) {
@@ -68,8 +68,8 @@ DEF_OP(Mov) {
 }
 
 #undef DEF_OP
-void JITCore::RegisterMoveHandlers() {
-#define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &JITCore::Op_##x
+void Arm64JITCore::RegisterMoveHandlers() {
+#define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &Arm64JITCore::Op_##x
   REGISTER_OP(EXTRACTELEMENTPAIR, ExtractElementPair);
   REGISTER_OP(CREATEELEMENTPAIR,  CreateElementPair);
   REGISTER_OP(MOV,                Mov);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -4,7 +4,7 @@ namespace FEXCore::CPU {
 
 using namespace vixl;
 using namespace vixl::aarch64;
-#define DEF_OP(x) void JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
+#define DEF_OP(x) void Arm64JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
 DEF_OP(VectorZero) {
   uint8_t OpSize = IROp->Size;
   switch (OpSize) {
@@ -1519,7 +1519,7 @@ DEF_OP(VSShrS) {
 
 DEF_OP(VInsElement) {
   auto Op = IROp->C<IR::IROp_VInsElement>();
-  
+
   auto reg = GetSrc(Op->Header.Args[0].ID());
 
   if (GetDst(Node).GetCode() != reg.GetCode()) {
@@ -1554,7 +1554,7 @@ DEF_OP(VInsElement) {
 
 DEF_OP(VInsScalarElement) {
   auto Op = IROp->C<IR::IROp_VInsScalarElement>();
-  
+
   auto reg = GetSrc(Op->Header.Args[0].ID());
 
   if (GetDst(Node).GetCode() != reg.GetCode()) {
@@ -2112,8 +2112,8 @@ DEF_OP(VTBL1) {
 }
 
 #undef DEF_OP
-void JITCore::RegisterVectorHandlers() {
-#define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &JITCore::Op_##x
+void Arm64JITCore::RegisterVectorHandlers() {
+#define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &Arm64JITCore::Op_##x
   REGISTER_OP(VECTORZERO,        VectorZero);
   REGISTER_OP(VECTORIMM,         VectorImm);
   REGISTER_OP(CREATEVECTOR2,     CreateVector2);

--- a/External/FEXCore/Source/Interface/Core/JIT/JITCore.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/JITCore.h
@@ -11,5 +11,6 @@ struct InternalThreadState;
 namespace FEXCore::CPU {
 class CPUBackend;
 
-FEXCore::CPU::CPUBackend *CreateJITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread, bool CompileThread);
+FEXCore::CPU::CPUBackend *CreateX86JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread, bool CompileThread);
+FEXCore::CPU::CPUBackend *CreateArm64JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread, bool CompileThread);
 }

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/ALUOps.cpp
@@ -2,7 +2,7 @@
 #include "Interface/IR/Passes/RegisterAllocationPass.h"
 
 namespace FEXCore::CPU {
-#define DEF_OP(x) void JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
+#define DEF_OP(x) void X86JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
 DEF_OP(TruncElementPair) {
   auto Op = IROp->C<IR::IROp_TruncElementPair>();
 
@@ -1168,8 +1168,8 @@ DEF_OP(FCmp) {
 
 #undef DEF_OP
 
-void JITCore::RegisterALUHandlers() {
-#define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &JITCore::Op_##x
+void X86JITCore::RegisterALUHandlers() {
+#define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &X86JITCore::Op_##x
   REGISTER_OP(TRUNCELEMENTPAIR,  TruncElementPair);
   REGISTER_OP(CONSTANT,          Constant);
   REGISTER_OP(ENTRYPOINTOFFSET,  EntrypointOffset);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/AtomicOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/AtomicOps.cpp
@@ -2,7 +2,7 @@
 #include "Interface/IR/Passes/RegisterAllocationPass.h"
 
 namespace FEXCore::CPU {
-#define DEF_OP(x) void JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
+#define DEF_OP(x) void X86JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
 DEF_OP(CASPair) {
   auto Op = IROp->C<IR::IROp_CAS>();
   uint8_t OpSize = IROp->Size;
@@ -548,8 +548,8 @@ DEF_OP(AtomicFetchXor) {
 }
 
 #undef DEF_OP
-void JITCore::RegisterAtomicHandlers() {
-#define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &JITCore::Op_##x
+void X86JITCore::RegisterAtomicHandlers() {
+#define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &X86JITCore::Op_##x
   REGISTER_OP(CASPAIR,        CASPair);
   REGISTER_OP(CAS,            CAS);
   REGISTER_OP(ATOMICADD,      AtomicAdd);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
@@ -6,7 +6,7 @@
 #include <Interface/HLE/Thunks/Thunks.h>
 
 namespace FEXCore::CPU {
-#define DEF_OP(x) void JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
+#define DEF_OP(x) void X86JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
 DEF_OP(GuestCallDirect) {
   LogMan::Msg::D("Unimplemented");
 }
@@ -80,7 +80,7 @@ DEF_OP(ExitFunction) {
     dq(NewRIP);
   } else {
     Xbyak::Reg RipReg = GetSrc<RA_64>(Op->NewRIP.ID());
-    
+
     // L1 Cache
     mov(rcx, ThreadState->LookupCache->GetL1Pointer());
     mov(rax, RipReg);
@@ -89,7 +89,7 @@ DEF_OP(ExitFunction) {
     shl(rax, 4);
 
     Xbyak::RegExp LookupBase = rcx + rax;
-  
+
     cmp(qword[LookupBase + 8], RipReg);
     jne(FullLookup);
     jmp(qword[LookupBase + 0]);
@@ -227,7 +227,7 @@ DEF_OP(Thunk) {
     sub(rsp, 8); // Align
 
   mov(rdi, GetSrc<RA_64>(Op->Header.Args[0].ID()));
-  
+
   auto thunkFn = ThreadState->CTX->ThunkHandler->LookupThunk(Op->ThunkNameHash);
 
   mov(rax, reinterpret_cast<uintptr_t>(thunkFn));
@@ -341,8 +341,8 @@ DEF_OP(CPUID) {
 }
 
 #undef DEF_OP
-void JITCore::RegisterBranchHandlers() {
-#define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &JITCore::Op_##x
+void X86JITCore::RegisterBranchHandlers() {
+#define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &X86JITCore::Op_##x
   REGISTER_OP(GUESTCALLDIRECT,   GuestCallDirect);
   REGISTER_OP(GUESTCALLINDIRECT, GuestCallIndirect);
   REGISTER_OP(GUESTRETURN,       GuestReturn);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/ConversionOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/ConversionOps.cpp
@@ -3,7 +3,7 @@
 
 namespace FEXCore::CPU {
 
-#define DEF_OP(x) void JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
+#define DEF_OP(x) void X86JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
 DEF_OP(VInsGPR) {
   auto Op = IROp->C<IR::IROp_VInsGPR>();
   movapd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
@@ -171,8 +171,8 @@ DEF_OP(Vector_FToF) {
 }
 
 #undef DEF_OP
-void JITCore::RegisterConversionHandlers() {
-#define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &JITCore::Op_##x
+void X86JITCore::RegisterConversionHandlers() {
+#define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &X86JITCore::Op_##x
   REGISTER_OP(VINSGPR,         VInsGPR);
   REGISTER_OP(VCASTFROMGPR,    VCastFromGPR);
   REGISTER_OP(FLOAT_FROMGPR_U, Float_FromGPR_U);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/EncryptionOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/EncryptionOps.cpp
@@ -2,7 +2,7 @@
 #include "Interface/IR/Passes/RegisterAllocationPass.h"
 
 namespace FEXCore::CPU {
-#define DEF_OP(x) void JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
+#define DEF_OP(x) void X86JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
 
 DEF_OP(AESImc) {
   auto Op = IROp->C<IR::IROp_VAESImc>();
@@ -35,8 +35,8 @@ DEF_OP(AESKeyGenAssist) {
 }
 
 #undef DEF_OP
-void JITCore::RegisterEncryptionHandlers() {
-#define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &JITCore::Op_##x
+void X86JITCore::RegisterEncryptionHandlers() {
+#define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &X86JITCore::Op_##x
   REGISTER_OP(VAESIMC,     AESImc);
   REGISTER_OP(VAESENC,     AESEnc);
   REGISTER_OP(VAESENCLAST, AESEncLast);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/FlagOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/FlagOps.cpp
@@ -3,7 +3,7 @@
 
 namespace FEXCore::CPU {
 
-#define DEF_OP(x) void JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
+#define DEF_OP(x) void X86JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
 DEF_OP(GetHostFlag) {
   auto Op = IROp->C<IR::IROp_GetHostFlag>();
 
@@ -14,8 +14,8 @@ DEF_OP(GetHostFlag) {
 }
 
 #undef DEF_OP
-void JITCore::RegisterFlagHandlers() {
-#define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &JITCore::Op_##x
+void X86JITCore::RegisterFlagHandlers() {
+#define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &X86JITCore::Op_##x
   REGISTER_OP(GETHOSTFLAG, GetHostFlag);
 #undef REGISTER_OP
 }

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -54,10 +54,10 @@ const std::array<std::pair<Xbyak::Reg, Xbyak::Reg>, 4> RA64Pair = {{ {rsi, r8}, 
 const std::array<Xbyak::Reg, 11> RAXMM = { xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm9, xmm10, xmm11};
 const std::array<Xbyak::Xmm, 11> RAXMM_x = {  xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm9, xmm10, xmm11};
 
-class JITCore final : public CPUBackend, public Xbyak::CodeGenerator {
+class X86JITCore final : public CPUBackend, public Xbyak::CodeGenerator {
 public:
-  explicit JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread, CodeBuffer Buffer, bool CompileThread);
-  ~JITCore() override;
+  explicit X86JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread, CodeBuffer Buffer, bool CompileThread);
+  ~X86JITCore() override;
   std::string GetName() override { return "JIT"; }
   void *CompileCode(FEXCore::IR::IRListView const *IR, FEXCore::Core::DebugData *DebugData, FEXCore::IR::RegisterAllocationData *RAData) override;
 
@@ -142,7 +142,7 @@ private:
     CurrentCodeBuffer = &CodeBuffers.emplace_back(Buffer);
   }
 
-  static uint64_t ExitFunctionLink(JITCore* code, FEXCore::Core::InternalThreadState *Thread, uint64_t *record);
+  static uint64_t ExitFunctionLink(X86JITCore* code, FEXCore::Core::InternalThreadState *Thread, uint64_t *record);
 
   // This is the initial code buffer that we will fall back to
   // In a program without signals and code clearing, we will typically
@@ -179,13 +179,13 @@ private:
   void RestoreThreadState(void *ucontext);
   std::stack<uint64_t> SignalFrames;
   uint32_t SpillSlots{};
-  using SetCC = void (JITCore::*)(const Operand& op);
-  using CMovCC = void (JITCore::*)(const Reg& reg, const Operand& op);
-  using JCC = void (JITCore::*)(const Label& label, LabelType type);
+  using SetCC = void (X86JITCore::*)(const Operand& op);
+  using CMovCC = void (X86JITCore::*)(const Reg& reg, const Operand& op);
+  using JCC = void (X86JITCore::*)(const Label& label, LabelType type);
 
   std::tuple<SetCC, CMovCC, JCC> GetCC(IR::CondClassType cond);
 
-  using OpHandler = void (JITCore::*)(FEXCore::IR::IROp_Header *IROp, uint32_t Node);
+  using OpHandler = void (X86JITCore::*)(FEXCore::IR::IROp_Header *IROp, uint32_t Node);
   std::array<OpHandler, FEXCore::IR::IROps::OP_LAST + 1> OpHandlers {};
   void RegisterALUHandlers();
   void RegisterAtomicHandlers();
@@ -210,7 +210,7 @@ private:
 
   ///< ALU Ops
   DEF_OP(TruncElementPair);
-  DEF_OP(Constant); 
+  DEF_OP(Constant);
   DEF_OP(EntrypointOffset);
   DEF_OP(InlineConstant);
   DEF_OP(InlineEntrypointOffset);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/MemoryOps.cpp
@@ -5,7 +5,7 @@
 
 namespace FEXCore::CPU {
 
-#define DEF_OP(x) void JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
+#define DEF_OP(x) void X86JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
 
 DEF_OP(LoadContext) {
   auto Op = IROp->C<IR::IROp_LoadContext>();
@@ -419,7 +419,7 @@ DEF_OP(StoreFlag) {
   mov(byte [STATE + (offsetof(FEXCore::Core::CPUState, flags[0]) + Op->Flag)], al);
 }
 
-Xbyak::RegExp JITCore::GenerateModRM(Xbyak::Reg Base, IR::OrderedNodeWrapper Offset, IR::MemOffsetType OffsetType, uint8_t OffsetScale) {
+Xbyak::RegExp X86JITCore::GenerateModRM(Xbyak::Reg Base, IR::OrderedNodeWrapper Offset, IR::MemOffsetType OffsetType, uint8_t OffsetScale) {
   if (Offset.IsInvalid()) {
     return Base;
   } else {
@@ -568,8 +568,8 @@ DEF_OP(VStoreMemElement) {
 }
 
 #undef DEF_OP
-void JITCore::RegisterMemoryHandlers() {
-#define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &JITCore::Op_##x
+void X86JITCore::RegisterMemoryHandlers() {
+#define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &X86JITCore::Op_##x
   REGISTER_OP(LOADCONTEXT,         LoadContext);
   REGISTER_OP(STORECONTEXT,        StoreContext);
   REGISTER_OP(LOADREGISTER,        Unhandled); // SRA specific, not supported on this backend

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/MiscOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/MiscOps.cpp
@@ -6,7 +6,7 @@ static void PrintValue(uint64_t Value) {
   LogMan::Msg::D("Value: 0x%lx", Value);
 }
 
-#define DEF_OP(x) void JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
+#define DEF_OP(x) void X86JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
 
 DEF_OP(Fence) {
   auto Op = IROp->C<IR::IROp_Fence>();
@@ -125,8 +125,8 @@ DEF_OP(Print) {
 }
 
 #undef DEF_OP
-void JITCore::RegisterMiscHandlers() {
-#define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &JITCore::Op_##x
+void X86JITCore::RegisterMiscHandlers() {
+#define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &X86JITCore::Op_##x
   REGISTER_OP(DUMMY,      NoOp);
   REGISTER_OP(IRHEADER,   NoOp);
   REGISTER_OP(CODEBLOCK,  NoOp);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/MoveOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/MoveOps.cpp
@@ -3,7 +3,7 @@
 
 namespace FEXCore::CPU {
 
-#define DEF_OP(x) void JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
+#define DEF_OP(x) void X86JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
 DEF_OP(ExtractElementPair) {
   auto Op = IROp->C<IR::IROp_ExtractElementPair>();
   switch (Op->Header.Size) {
@@ -67,8 +67,8 @@ DEF_OP(Mov) {
 }
 
 #undef DEF_OP
-void JITCore::RegisterMoveHandlers() {
-#define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &JITCore::Op_##x
+void X86JITCore::RegisterMoveHandlers() {
+#define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &X86JITCore::Op_##x
   REGISTER_OP(EXTRACTELEMENTPAIR, ExtractElementPair);
   REGISTER_OP(CREATEELEMENTPAIR,  CreateElementPair);
   REGISTER_OP(MOV,                Mov);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
@@ -4,7 +4,7 @@
 
 namespace FEXCore::CPU {
 
-#define DEF_OP(x) void JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
+#define DEF_OP(x) void X86JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
 DEF_OP(VectorZero) {
   auto Dst = GetDst(Node);
   vpxor(Dst, Dst, Dst);
@@ -1869,8 +1869,8 @@ DEF_OP(VTBL1) {
 }
 
 #undef DEF_OP
-void JITCore::RegisterVectorHandlers() {
-#define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &JITCore::Op_##x
+void X86JITCore::RegisterVectorHandlers() {
+#define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &X86JITCore::Op_##x
   REGISTER_OP(VECTORZERO,        VectorZero);
   REGISTER_OP(VECTORIMM,         VectorImm);
   REGISTER_OP(CREATEVECTOR2,     CreateVector2);


### PR DESCRIPTION
The main goal of this PR is to minimise the amount of code which is only compiled on one platform. This should allow for easier refactoring of code in both jits.

This is not the old Vixel simulator. A secondary goal is that one FEXCore binary for one platform will be able to emit both x86_64 and Arm64 assembly. This might be useful in the future for a debug interface which shows both x86_on_x86 and arm64 code for comparison, or maybe static profiling tools that show differences in instruction counts between various backends. 

### How to use

 * By default, cmake will select the correct JIT for the host architecture. 
 * Setting -DENABLE_JIT_ARM64=on/off will override this decision. 
 * FexCore will always initialise the correct JIT. 
 * If the correct JIT isn't enabled in, FEXCore die at runtime with `"FEXCore has been compiled without a viable JIT core"` when trying to initialise a jit backend. 