### PR TITLE
Implements MOVNTDQA

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -9127,6 +9127,7 @@ constexpr uint16_t PF_F2 = 3;
     {OPD(PF_38_66,   0x1D), 1, &OpDispatchBuilder::PABS<2>},
     {OPD(PF_38_NONE, 0x1E), 1, &OpDispatchBuilder::PABS<4>},
     {OPD(PF_38_66,   0x1E), 1, &OpDispatchBuilder::PABS<4>},
+    {OPD(PF_38_66,   0x2A), 1, &OpDispatchBuilder::MOVAPSOp},
     {OPD(PF_38_66,   0x3B), 1, &OpDispatchBuilder::UnimplementedOp},
 
     {OPD(PF_38_66, 0xDB), 1, &OpDispatchBuilder::AESImcOp},

--- a/External/FEXCore/Source/Interface/Core/X86Tables/H0F38Tables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/H0F38Tables.cpp
@@ -54,7 +54,7 @@ void InitializeH0F38Tables() {
     {OPD(PF_38_66,   0x25), 1, X86InstInfo{"PMOVSXDQ",   TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
     {OPD(PF_38_66,   0x28), 1, X86InstInfo{"PMULDQ",     TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
     {OPD(PF_38_66,   0x29), 1, X86InstInfo{"PCMPEQQ",    TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
-    {OPD(PF_38_66,   0x2A), 1, X86InstInfo{"MOVNTDQA",   TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
+    {OPD(PF_38_66,   0x2A), 1, X86InstInfo{"MOVNTDQA",   TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_SF_MOD_MEM_ONLY | FLAGS_XMM_FLAGS, 0, nullptr}},
     {OPD(PF_38_66,   0x2B), 1, X86InstInfo{"PACKUSDW",   TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
 
     {OPD(PF_38_66,   0x30), 1, X86InstInfo{"PMOVZXBW",   TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},

--- a/unittests/ASM/H0F38/66_2A.asm
+++ b/unittests/ASM/H0F38/66_2A.asm
@@ -1,0 +1,22 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "XMM0": ["0x4142434445464748", "0x5152535455565758"]
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rdx + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [rdx + 8 * 1], rax
+
+mov rax, 0x0
+mov [rdx + 8 * 2], rax
+mov [rdx + 8 * 3], rax
+
+movntdqa xmm0, [rdx + 8 * 0]
+
+hlt


### PR DESCRIPTION
Found this when running Steamlink under FEX on my laptop.
Turns out the Iris video driver now uses this unconditionally in a couple of locations.
Makes sense there since all the Iris targets are expected to support SSE4.1 atm.