### PR TITLE
Separate thread and state

### DIFF
--- a/External/FEXCore/Source/Interface/Context/Context.cpp
+++ b/External/FEXCore/Source/Interface/Context/Context.cpp
@@ -65,11 +65,11 @@ namespace FEXCore::Context {
   }
 
   void GetCPUState(FEXCore::Context::Context *CTX, FEXCore::Core::CPUState *State) {
-    memcpy(State, &CTX->ParentThread->State.State, sizeof(FEXCore::Core::CPUState));
+    memcpy(State, CTX->ParentThread->CurrentFrame, sizeof(FEXCore::Core::CPUState));
   }
 
   void SetCPUState(FEXCore::Context::Context *CTX, FEXCore::Core::CPUState *State) {
-    memcpy(&CTX->ParentThread->State.State, State, sizeof(FEXCore::Core::CPUState));
+    memcpy(CTX->ParentThread->CurrentFrame, State, sizeof(FEXCore::Core::CPUState));
   }
 
   void Pause(FEXCore::Context::Context *CTX) {
@@ -82,10 +82,6 @@ namespace FEXCore::Context {
 
   void SetCustomCPUBackendFactory(FEXCore::Context::Context *CTX, CustomCPUFactoryType Factory) {
     CTX->CustomCPUFactory = std::move(Factory);
-  }
-
-  void SetFallbackCPUBackendFactory(FEXCore::Context::Context *CTX, CustomCPUFactoryType Factory) {
-    CTX->FallbackCPUFactory = std::move(Factory);
   }
 
   bool AddVirtualMemoryMapping([[maybe_unused]] FEXCore::Context::Context *CTX, [[maybe_unused]] uint64_t VirtualAddress, [[maybe_unused]] uint64_t PhysicalAddress, [[maybe_unused]] uint64_t Size) {
@@ -132,7 +128,7 @@ namespace FEXCore::Context {
       }
 
       // Setting running to false ensures that when they are shutdown we won't send signals to kill them
-      DeadThread->State.RunningEvents.Running = false;
+      DeadThread->RunningEvents.Running = false;
     }
 
     // We now only have one thread
@@ -178,10 +174,6 @@ namespace Debug {
     return CTX->GetRuntimeStatsForThread(Thread);
   }
 
-  FEXCore::Core::CPUState GetCPUState(FEXCore::Context::Context *CTX) {
-    return CTX->GetCPUState();
-  }
-
   bool GetDebugDataForRIP(FEXCore::Context::Context *CTX, uint64_t RIP, FEXCore::Core::DebugData *Data) {
     return CTX->GetDebugDataForRIP(RIP, Data);
   }
@@ -198,10 +190,6 @@ namespace Debug {
   // void SetIRForRIP(FEXCore::Context::Context *CTX, uint64_t RIP, FEXCore::IR::IntrusiveIRList *const ir) {
   //   CTX->SetIRForRIP(RIP, ir);
   // }
-
-  FEXCore::Core::ThreadState *GetThreadState(FEXCore::Context::Context *CTX) {
-    return CTX->GetThreadState();
-  }
 }
 
 }

--- a/External/FEXCore/Source/Interface/Core/CompileService.cpp
+++ b/External/FEXCore/Source/Interface/Core/CompileService.cpp
@@ -92,7 +92,7 @@ namespace FEXCore {
 
     // Set our thread name so we can see its relation
     char ThreadName[16]{};
-    snprintf(ThreadName, 16, "%ld-CS", ParentThread->State.ThreadManager.TID.load());
+    snprintf(ThreadName, 16, "%ld-CS", ParentThread->ThreadManager.TID.load());
     pthread_setname_np(pthread_self(), ThreadName);
 
     while (true) {
@@ -121,10 +121,10 @@ namespace FEXCore {
         if (Item) {
           // Make sure it's not in lookup cache by accident
           LogMan::Throw::A(CompileThreadData->LookupCache->FindBlock(Item->RIP) == 0, "Compile Service must never have entries in the LookupCache");
-          
+
           // Code isn't in cache, compile now
           // Set our thread state's RIP
-          CompileThreadData->State.State.rip = Item->RIP;
+          CompileThreadData->CurrentFrame->State.rip = Item->RIP;
 
           auto [CodePtr, IRList, DebugData, RAData, Generated, StartAddr, Length] = CTX->CompileCode(CompileThreadData.get(), Item->RIP);
 

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -158,7 +158,7 @@ namespace DefaultFallbackCore {
     bool NeedsOpDispatch() override { return false; }
 
     void *CompileCode(FEXCore::IR::IRListView const *IR, FEXCore::Core::DebugData *DebugData, FEXCore::IR::RegisterAllocationData *RAData) override {
-      LogMan::Msg::E("Fell back to default code handler at RIP: 0x%lx", ThreadState->State.State.rip);
+      LogMan::Msg::E("Fell back to default code handler at RIP: 0x%lx", ThreadState->CurrentFrame->State.rip);
       return nullptr;
     }
 
@@ -175,7 +175,6 @@ namespace DefaultFallbackCore {
 
 namespace FEXCore::Context {
   Context::Context() {
-    FallbackCPUFactory = FEXCore::Core::DefaultFallbackCore::CPUCreationFactory;
 #ifdef BLOCKSTATS
     BlockData = std::make_unique<FEXCore::BlockSamplingData>();
 #endif
@@ -319,12 +318,12 @@ namespace FEXCore::Context {
 
     Loader->MapMemoryRegion();
 
-    Thread->State.State.gregs[X86State::REG_RSP] = Loader->SetupStack();
+    Thread->CurrentFrame->State.gregs[X86State::REG_RSP] = Loader->SetupStack();
 
     Loader->LoadMemory();
     Loader->GetInitLocations(&InitLocations);
 
-    Thread->State.State.rip = StartingRIP = Loader->DefaultRIP();
+    Thread->CurrentFrame->State.rip = StartingRIP = Loader->DefaultRIP();
 
     InitializeThreadData(Thread);
 
@@ -344,7 +343,7 @@ namespace FEXCore::Context {
 
   void Context::HandleCallback(uint64_t RIP) {
     auto Thread = Core::ThreadData.Thread;
-    Thread->CPUBackend->CallbackPtr(Thread, RIP);
+    Thread->CPUBackend->CallbackPtr(Thread->CurrentFrame, RIP);
   }
 
   void Context::RegisterHostSignalHandler(int Signal, HostSignalDelegatorFunction Func) {
@@ -388,9 +387,9 @@ namespace FEXCore::Context {
     std::lock_guard<std::mutex> lk(ThreadCreationMutex);
     for (auto &Thread : Threads) {
       Thread->SignalReason.store(FEXCore::Core::SignalEvent::SIGNALEVENT_PAUSE);
-      if (Thread->State.RunningEvents.Running.load()) {
+      if (Thread->RunningEvents.Running.load()) {
         // Only attempt to stop this thread if it is running
-        tgkill(Thread->State.ThreadManager.PID, Thread->State.ThreadManager.TID, SignalDelegator::SIGNAL_FOR_PAUSE);
+        tgkill(Thread->ThreadManager.PID, Thread->ThreadManager.TID, SignalDelegator::SIGNAL_FOR_PAUSE);
       }
     }
   }
@@ -409,7 +408,7 @@ namespace FEXCore::Context {
     std::lock_guard<std::mutex> lk(ThreadCreationMutex);
     for (auto &Thread : Threads) {
       Thread->SignalReason.store(FEXCore::Core::SignalEvent::SIGNALEVENT_RETURN);
-      Thread->State.RunningEvents.WaitingToStart.store(true);
+      Thread->RunningEvents.WaitingToStart.store(true);
     }
 
     for (auto &Thread : Threads) {
@@ -462,17 +461,17 @@ namespace FEXCore::Context {
       std::lock_guard<std::mutex> lk(ThreadCreationMutex);
       for (auto &Thread : Threads) {
         if (IgnoreCurrentThread &&
-            Thread->State.ThreadManager.TID == tid) {
+            Thread->ThreadManager.TID == tid) {
           // If we are callign stop from the current thread then we can ignore sending signals to this thread
           // This means that this thread is already gone
           continue;
         }
-        else if (Thread->State.ThreadManager.TID == tid) {
+        else if (Thread->ThreadManager.TID == tid) {
           // We need to save the current thread for last to ensure all threads receive their stop signals
           CurrentThread = Thread;
           continue;
         }
-        if (Thread->State.RunningEvents.Running.load()) {
+        if (Thread->RunningEvents.Running.load()) {
           StopThread(Thread);
         } else {
           LogMan::Msg::D("Skipping thread %p: Already stopped", Thread);
@@ -487,16 +486,16 @@ namespace FEXCore::Context {
   }
 
   void Context::StopThread(FEXCore::Core::InternalThreadState *Thread) {
-    if (Thread->State.RunningEvents.Running.exchange(false)) {
+    if (Thread->RunningEvents.Running.exchange(false)) {
       Thread->SignalReason.store(FEXCore::Core::SignalEvent::SIGNALEVENT_STOP);
-      tgkill(Thread->State.ThreadManager.PID, Thread->State.ThreadManager.TID, SignalDelegator::SIGNAL_FOR_PAUSE);
+      tgkill(Thread->ThreadManager.PID, Thread->ThreadManager.TID, SignalDelegator::SIGNAL_FOR_PAUSE);
     }
   }
 
   void Context::SignalThread(FEXCore::Core::InternalThreadState *Thread, FEXCore::Core::SignalEvent Event) {
-    if (Thread->State.RunningEvents.Running.load()) {
+    if (Thread->RunningEvents.Running.load()) {
       Thread->SignalReason.store(Event);
-      tgkill(Thread->State.ThreadManager.PID, Thread->State.ThreadManager.TID, SignalDelegator::SIGNAL_FOR_PAUSE);
+      tgkill(Thread->ThreadManager.PID, Thread->ThreadManager.TID, SignalDelegator::SIGNAL_FOR_PAUSE);
     }
   }
 
@@ -595,7 +594,7 @@ namespace FEXCore::Context {
 #endif
 
       break;
-    case FEXCore::Config::CONFIG_CUSTOM:      State->CPUBackend.reset(CustomCPUFactory(this, &State->State)); break;
+    case FEXCore::Config::CONFIG_CUSTOM:      State->CPUBackend.reset(CustomCPUFactory(this, State)); break;
     default: ERROR_AND_DIE("Unknown core configuration");
     }
   }
@@ -607,14 +606,15 @@ namespace FEXCore::Context {
     {
       std::lock_guard<std::mutex> lk(ThreadCreationMutex);
       Thread = Threads.emplace_back(new FEXCore::Core::InternalThreadState{});
-      Thread->State.ThreadManager.TID = ++ThreadID;
+      Thread->ThreadManager.TID = ++ThreadID;
     }
 
     // Copy over the new thread state to the new object
-    memcpy(&Thread->State.State, NewThreadState, sizeof(FEXCore::Core::CPUState));
+    memcpy(Thread->CurrentFrame, NewThreadState, sizeof(FEXCore::Core::CPUState));
+    Thread->CurrentFrame->Thread = Thread;
 
     // Set up the thread manager state
-    Thread->State.ThreadManager.parent_tid = ParentTID;
+    Thread->ThreadManager.parent_tid = ParentTID;
 
     InitializeCompiler(Thread, false);
 
@@ -1030,7 +1030,8 @@ namespace FEXCore::Context {
   }
 
 
-  uintptr_t Context::CompileBlock(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP) {
+  uintptr_t Context::CompileBlock(FEXCore::Core::CpuStateFrame *Frame, uint64_t GuestRIP) {
+    auto Thread = Frame->Thread;
 
     // Is the code in the cache?
     // The backends only check L1 and L2, not L3
@@ -1139,14 +1140,14 @@ namespace FEXCore::Context {
     Thread->ExitReason = FEXCore::Context::ExitReason::EXIT_WAITING;
 
     // Let's do some initial bookkeeping here
-    Thread->State.ThreadManager.TID = ::gettid();
-    Thread->State.ThreadManager.PID = ::getpid();
+    Thread->ThreadManager.TID = ::gettid();
+    Thread->ThreadManager.PID = ::getpid();
     SignalDelegation->RegisterTLSState(Thread);
     ThunkHandler->RegisterTLSState(Thread);
 
     ++IdleWaitRefCount;
 
-    LogMan::Msg::D("[%d] Waiting to run", Thread->State.ThreadManager.TID.load());
+    LogMan::Msg::D("[%d] Waiting to run", Thread->ThreadManager.TID.load());
 
     // Now notify the thread that we are initialized
     Thread->ThreadWaiting.NotifyAll();
@@ -1156,25 +1157,25 @@ namespace FEXCore::Context {
       Thread->StartRunning.Wait();
     }
 
-    LogMan::Msg::D("[%d] Running", Thread->State.ThreadManager.TID.load());
+    LogMan::Msg::D("[%d] Running", Thread->ThreadManager.TID.load());
 
     Thread->ExitReason = FEXCore::Context::ExitReason::EXIT_NONE;
 
-    Thread->State.RunningEvents.Running = true;
+    Thread->RunningEvents.Running = true;
 
-    Thread->CPUBackend->ExecuteDispatch(Thread);
+    Thread->CPUBackend->ExecuteDispatch(Thread->CurrentFrame);
 
-    Thread->State.RunningEvents.WaitingToStart = false;
-    Thread->State.RunningEvents.Running = false;
+    Thread->RunningEvents.WaitingToStart = false;
+    Thread->RunningEvents.Running = false;
 
     // If it is the parent thread that died then just leave
     // XXX: This doesn't make sense when the parent thread doesn't outlive its children
-    if (Thread->State.ThreadManager.parent_tid == 0) {
+    if (Thread->ThreadManager.parent_tid == 0) {
       CoreShuttingDown.store(true);
       Thread->ExitReason = FEXCore::Context::ExitReason::EXIT_SHUTDOWN;
 
       if (CustomExitHandler) {
-        CustomExitHandler(Thread->State.ThreadManager.TID, Thread->ExitReason);
+        CustomExitHandler(Thread->ThreadManager.TID, Thread->ExitReason);
       }
     }
 
@@ -1205,16 +1206,16 @@ namespace FEXCore::Context {
 
   // Debug interface
   void Context::CompileRIP(FEXCore::Core::InternalThreadState *Thread, uint64_t RIP) {
-    uint64_t RIPBackup = Thread->State.State.rip;
-    Thread->State.State.rip = RIP;
+    uint64_t RIPBackup = Thread->CurrentFrame->State.rip;
+    Thread->CurrentFrame->State.rip = RIP;
 
     // Erase the RIP from all the storage backings if it exists
     RemoveCodeEntry(Thread, RIP);
 
     // We don't care if compilation passes or not
-    CompileBlock(Thread, RIP);
+    CompileBlock(Thread->CurrentFrame, RIP);
 
-    Thread->State.State.rip = RIPBackup;
+    Thread->CurrentFrame->State.rip = RIPBackup;
   }
 
   uint64_t Context::GetThreadCount() const {
@@ -1223,10 +1224,6 @@ namespace FEXCore::Context {
 
   FEXCore::Core::RuntimeStats *Context::GetRuntimeStatsForThread(uint64_t Thread) {
     return &Threads[Thread]->Stats;
-  }
-
-  FEXCore::Core::CPUState Context::GetCPUState() {
-    return ParentThread->State.State;
   }
 
   bool Context::GetDebugDataForRIP(uint64_t RIP, FEXCore::Core::DebugData *Data) {
@@ -1249,11 +1246,9 @@ namespace FEXCore::Context {
     return true;
   }
 
-  FEXCore::Core::ThreadState *Context::GetThreadState() {
-    return &ParentThread->State;
-  }
+  uint64_t HandleSyscall(FEXCore::HLE::SyscallHandler *Handler, FEXCore::Core::CpuStateFrame *Frame, FEXCore::HLE::SyscallArguments *Args) {
+    auto Thread = Frame->Thread; // FIXME: Call HandleSyscall directly with frame
 
-  uint64_t HandleSyscall(FEXCore::HLE::SyscallHandler *Handler, FEXCore::Core::InternalThreadState *Thread, FEXCore::HLE::SyscallArguments *Args) {
     uint64_t Result{};
     Result = Handler->HandleSyscall(Thread, Args);
     return Result;

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -1247,10 +1247,8 @@ namespace FEXCore::Context {
   }
 
   uint64_t HandleSyscall(FEXCore::HLE::SyscallHandler *Handler, FEXCore::Core::CpuStateFrame *Frame, FEXCore::HLE::SyscallArguments *Args) {
-    auto Thread = Frame->Thread; // FIXME: Call HandleSyscall directly with frame
-
     uint64_t Result{};
-    Result = Handler->HandleSyscall(Thread, Args);
+    Result = Handler->HandleSyscall(Frame, Args);
     return Result;
   }
 

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterClass.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterClass.h
@@ -8,7 +8,8 @@
 #include <FEXCore/IR/IntrusiveIRList.h>
 
 namespace FEXCore::CPU {
-class DispatchGenerator;
+class X86DispatchGenerator;
+class Arm64DispatchGenerator;
 
 #define DESTMAP_AS_MAP 0
 #if DESTMAP_AS_MAP
@@ -47,7 +48,12 @@ private:
   template<typename Res>
   Res GetSrc(void* SSAData, IR::OrderedNodeWrapper Src);
 
-  DispatchGenerator *Generator{};
+#ifdef _M_X86_64
+  X86DispatchGenerator *Generator{};
+#endif
+#ifdef _M_ARM_64
+  Arm64DispatchGenerator *Generator{};
+#endif
 };
 
 }

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -26,8 +26,10 @@
 
 namespace FEXCore::CPU {
 
-static void InterpreterExecution(FEXCore::Core::InternalThreadState *Thread) {
-  auto LocalEntry = Thread->LocalIRCache.find(Thread->State.State.rip);
+static void InterpreterExecution(FEXCore::Core::CpuStateFrame *Frame) {
+  auto Thread = Frame->Thread;
+
+  auto LocalEntry = Thread->LocalIRCache.find(Thread->CurrentFrame->State.rip);
 
   InterpreterOps::InterpretIR(Thread, LocalEntry->second.IR.get(), LocalEntry->second.DebugData.get());
 }

--- a/External/FEXCore/Source/Interface/Core/Interpreter/x86_64Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/x86_64Dispatcher.cpp
@@ -32,14 +32,16 @@ class X86DispatchGenerator : public Xbyak::CodeGenerator {
     std::stack<uint64_t> SignalFrames;
 };
 
-static void SleepThread(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread) {
+static void SleepThread(FEXCore::Context::Context *ctx, FEXCore::Core::CpuStateFrame *Frame) {
+  auto Thread = Frame->Thread;
+
   --ctx->IdleWaitRefCount;
   ctx->IdleWaitCV.notify_all();
 
   // Go to sleep
   Thread->StartRunning.Wait();
 
-  Thread->State.RunningEvents.Running = true;
+  Thread->RunningEvents.Running = true;
   ++ctx->IdleWaitRefCount;
   ctx->IdleWaitCV.notify_all();
 }
@@ -85,7 +87,7 @@ X86DispatchGenerator::X86DispatchGenerator(FEXCore::Context::Context *ctx, FEXCo
 
   // Save this stack pointer so we can cleanly shutdown the emulation with a long jump
   // regardless of where we were in the stack
-  mov(qword [rdi + offsetof(FEXCore::Core::ThreadState, ReturningStackLocation)], rsp);
+  mov(qword [rdi + offsetof(FEXCore::Core::CpuStateFrame, ReturningStackLocation)], rsp);
 
   Label LoopTop;
   Label NoBlock;
@@ -170,7 +172,7 @@ X86DispatchGenerator::X86DispatchGenerator(FEXCore::Context::Context *ctx, FEXCo
   {
     L(NoBlock);
 
-    using ClassPtrType = uintptr_t (FEXCore::Context::Context::*)(FEXCore::Core::InternalThreadState *, uint64_t);
+    using ClassPtrType = uintptr_t (FEXCore::Context::Context::*)(FEXCore::Core::CpuStateFrame *, uint64_t);
     union PtrCast {
       ClassPtrType ClassPtr;
       uintptr_t Data;
@@ -227,12 +229,12 @@ X86DispatchGenerator::X86DispatchGenerator(FEXCore::Context::Context *ctx, FEXCo
 
     // Store the trampoline to the guest stack
     // Guest stack is now correctly misaligned after a regular call instruction
-    sub(qword [STATE + offsetof(FEXCore::Core::InternalThreadState, State.State.gregs[X86State::REG_RSP])], 16);
-    mov(rbx, qword [STATE + offsetof(FEXCore::Core::InternalThreadState, State.State.gregs[X86State::REG_RSP])]);
+    sub(qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, State.gregs[X86State::REG_RSP])], 16);
+    mov(rbx, qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, State.gregs[X86State::REG_RSP])]);
     mov(qword [rbx], rax);
 
     // Store RIP to the context state
-    mov(qword [STATE + offsetof(FEXCore::Core::InternalThreadState, State.State.rip)], rsi);
+    mov(qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, State.rip)], rsi);
 
     // Back to the loop top now
     jmp(LoopTop);
@@ -287,7 +289,7 @@ void X86DispatchGenerator::StoreThreadState(int Signal, void *ucontext) {
   // Save guest state
   // We can't guarantee if registers are in context or host GPRs
   // So we need to save everything
-  memcpy(&Context->GuestState, &State->State, sizeof(FEXCore::Core::CPUState));
+  memcpy(&Context->GuestState, State->CurrentFrame, sizeof(FEXCore::Core::CPUState));
 
   // Set the new SP
   ArchHelpers::Context::SetSp(ucontext, NewSP);
@@ -302,7 +304,7 @@ void X86DispatchGenerator::RestoreThreadState(void *ucontext) {
   X86ContextBackup *Context = reinterpret_cast<X86ContextBackup*>(NewSP);
 
   // First thing, reset the guest state
-  memcpy(&State->State, &Context->GuestState, sizeof(FEXCore::Core::CPUState));
+  memcpy(State->CurrentFrame, &Context->GuestState, sizeof(FEXCore::Core::CPUState));
 
   // Now restore host state
   ArchHelpers::Context::RestoreContext(ucontext, Context);
@@ -318,10 +320,10 @@ bool X86DispatchGenerator::HandleGuestSignal(int Signal, void *info, void *ucont
   // Set the new PC
   ArchHelpers::Context::SetPc(ucontext, AbsoluteLoopTopAddress);
   // Set our state register to point to our guest thread data
-  ArchHelpers::Context::SetState(ucontext, reinterpret_cast<uint64_t>(State));
+  ArchHelpers::Context::SetState(ucontext, reinterpret_cast<uint64_t>(State->CurrentFrame));
 
 
-  uint64_t OldGuestSP = State->State.State.gregs[X86State::REG_RSP];
+  uint64_t OldGuestSP = State->CurrentFrame->State.gregs[X86State::REG_RSP];
   uint64_t NewGuestSP = OldGuestSP;
 
   if (!(GuestStack->ss_flags & SS_DISABLE)) {
@@ -342,22 +344,22 @@ bool X86DispatchGenerator::HandleGuestSignal(int Signal, void *info, void *ucont
   // Don't need this offset if we aren't going to be putting siginfo in to it
   NewGuestSP -= 128;
 
-  State->State.State.gregs[X86State::REG_RDI] = Signal;
+  State->CurrentFrame->State.gregs[X86State::REG_RDI] = Signal;
 
   if (GuestAction->sa_flags & SA_SIGINFO) {
     // XXX: siginfo_t(RSI), ucontext (RDX)
-    State->State.State.gregs[X86State::REG_RSI] = 0;
-    State->State.State.gregs[X86State::REG_RDX] = 0;
-    State->State.State.rip = reinterpret_cast<uint64_t>(GuestAction->sigaction_handler.sigaction);
+    State->CurrentFrame->State.gregs[X86State::REG_RSI] = 0;
+    State->CurrentFrame->State.gregs[X86State::REG_RDX] = 0;
+    State->CurrentFrame->State.rip = reinterpret_cast<uint64_t>(GuestAction->sigaction_handler.sigaction);
   }
   else {
-    State->State.State.rip = reinterpret_cast<uint64_t>(GuestAction->sigaction_handler.handler);
+    State->CurrentFrame->State.rip = reinterpret_cast<uint64_t>(GuestAction->sigaction_handler.handler);
   }
 
   // Set up the new SP for stack handling
   NewGuestSP -= 8;
   *(uint64_t*)NewGuestSP = CTX->X86CodeGen.SignalReturn;
-  State->State.State.gregs[X86State::REG_RSP] = NewGuestSP;
+  State->CurrentFrame->State.gregs[X86State::REG_RSP] = NewGuestSP;
 
   return true;
 }
@@ -375,7 +377,7 @@ bool X86DispatchGenerator::HandleSignalPause(int Signal, void *info, void *ucont
     ArchHelpers::Context::SetPc(ucontext, ThreadPauseHandlerAddress);
 
     // Set our state register to point to our guest thread data
-    ArchHelpers::Context::SetState(ucontext, reinterpret_cast<uint64_t>(State));
+    ArchHelpers::Context::SetState(ucontext, reinterpret_cast<uint64_t>(State->CurrentFrame));
 
 
     State->SignalReason.store(FEXCore::Core::SIGNALEVENT_NONE);
@@ -386,7 +388,7 @@ bool X86DispatchGenerator::HandleSignalPause(int Signal, void *info, void *ucont
     // Our thread is stopping
     // We don't care about anything at this point
     // Set the stack to our starting location when we entered the core and get out safely
-    ArchHelpers::Context::SetSp(ucontext, State->State.ReturningStackLocation);
+    ArchHelpers::Context::SetSp(ucontext, State->CurrentFrame->ReturningStackLocation);
 
     // Set the new PC
     ArchHelpers::Context::SetPc(ucontext, ThreadStopHandlerAddress);

--- a/External/FEXCore/Source/Interface/Core/Interpreter/x86_64Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/x86_64Dispatcher.cpp
@@ -1,4 +1,5 @@
 #include "Common/MathUtils.h"
+#include "Interface/Core/ArchHelpers/MContext.h"
 #include "Interface/Core/Interpreter/InterpreterClass.h"
 #include "Interface/Context/Context.h"
 #include <FEXCore/Core/X86Enums.h>
@@ -10,9 +11,9 @@ namespace FEXCore::CPU {
 static constexpr size_t MAX_DISPATCHER_CODE_SIZE = 4096;
 #define STATE r14
 
-class DispatchGenerator : public Xbyak::CodeGenerator {
+class X86DispatchGenerator : public Xbyak::CodeGenerator {
   public:
-    DispatchGenerator(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread);
+    X86DispatchGenerator(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread);
     bool HandleGuestSignal(int Signal, void *info, void *ucontext, GuestSigAction *GuestAction, stack_t *GuestStack);
     bool HandleSignalPause(int Signal, void *info, void *ucontext);
 
@@ -43,7 +44,7 @@ static void SleepThread(FEXCore::Context::Context *ctx, FEXCore::Core::InternalT
   ctx->IdleWaitCV.notify_all();
 }
 
-DispatchGenerator::DispatchGenerator(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread)
+X86DispatchGenerator::X86DispatchGenerator(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread)
   : Xbyak::CodeGenerator(MAX_DISPATCHER_CODE_SIZE)
   , CTX {ctx}
   , State {Thread} {
@@ -120,7 +121,7 @@ DispatchGenerator::DispatchGenerator(FEXCore::Context::Context *ctx, FEXCore::Co
     mov(rcx, qword [rdi + rax + 8]);
     cmp(rcx, rdx);
     jne(NoBlock);
-    
+
     // Load the block pointer
     mov(rax, qword [rdi + rax]);
 
@@ -263,28 +264,13 @@ DispatchGenerator::DispatchGenerator(FEXCore::Context::Context *ctx, FEXCore::Co
   ready();
 }
 
-struct ContextBackup {
-  uint64_t StoredCookie;
-  // Host State
-  // RIP and RSP is stored in GPRs here
-  uint64_t GPRs[NGREG];
-  _libc_fpstate FPRState;
-
-  // Guest state
-  int Signal;
-  FEXCore::Core::CPUState GuestState;
-};
-
-void DispatchGenerator::StoreThreadState(int Signal, void *ucontext) {
-  ucontext_t* _context = (ucontext_t*)ucontext;
-  mcontext_t* _mcontext = &_context->uc_mcontext;
-
+void X86DispatchGenerator::StoreThreadState(int Signal, void *ucontext) {
   // We can end up getting a signal at any point in our host state
   // Jump to a handler that saves all state so we can safely return
-  uint64_t OldSP = _mcontext->gregs[REG_RSP];
+  uint64_t OldSP = ArchHelpers::Context::GetSp(ucontext);
   uintptr_t NewSP = OldSP;
 
-  size_t StackOffset = sizeof(ContextBackup);
+  size_t StackOffset = sizeof(X86ContextBackup);
 
   // We need to back up behind the host's red zone
   // We do this on the guest side as well
@@ -292,16 +278,8 @@ void DispatchGenerator::StoreThreadState(int Signal, void *ucontext) {
   NewSP -= StackOffset;
   NewSP = AlignDown(NewSP, 16);
 
-  ContextBackup *Context = reinterpret_cast<ContextBackup*>(NewSP);
-
-  Context->StoredCookie = 0x4142434445464748ULL;
-
-  // Copy the GPRs
-  memcpy(&Context->GPRs[0], &_mcontext->gregs[0], NGREG * sizeof(_mcontext->gregs[0]));
-  // Copy the FPRState
-  memcpy(&Context->FPRState, _mcontext->fpregs, sizeof(_libc_fpstate));
-
-  // XXX: Save 256bit and 512bit AVX register state
+  X86ContextBackup *Context = reinterpret_cast<X86ContextBackup*>(NewSP);
+  ArchHelpers::Context::BackupContext(ucontext, Context);
 
   // Retain the action pointer so we can see it when we return
   Context->Signal = Signal;
@@ -312,50 +290,36 @@ void DispatchGenerator::StoreThreadState(int Signal, void *ucontext) {
   memcpy(&Context->GuestState, &State->State, sizeof(FEXCore::Core::CPUState));
 
   // Set the new SP
-  _mcontext->gregs[REG_RSP] = NewSP;
+  ArchHelpers::Context::SetSp(ucontext, NewSP);
 
   SignalFrames.push(NewSP);
 }
 
-void DispatchGenerator::RestoreThreadState(void *ucontext) {
-  ucontext_t* _context = (ucontext_t*)ucontext;
-  mcontext_t* _mcontext = &_context->uc_mcontext;
-
+void X86DispatchGenerator::RestoreThreadState(void *ucontext) {
   uint64_t OldSP = SignalFrames.top();
   SignalFrames.pop();
   uintptr_t NewSP = OldSP;
-  ContextBackup *Context = reinterpret_cast<ContextBackup*>(NewSP);
-
-  if (Context->StoredCookie != 0x4142434445464748ULL) {
-    LogMan::Msg::D("COOKIE WAS NOT CORRECT!\n");
-    exit(-1);
-  }
+  X86ContextBackup *Context = reinterpret_cast<X86ContextBackup*>(NewSP);
 
   // First thing, reset the guest state
   memcpy(&State->State, &Context->GuestState, sizeof(FEXCore::Core::CPUState));
 
   // Now restore host state
-
-  // Copy the GPRs
-  memcpy(&_mcontext->gregs[0], &Context->GPRs[0], NGREG * sizeof(_mcontext->gregs[0]));
-  // Copy the FPRState
-  memcpy(_mcontext->fpregs, &Context->FPRState, sizeof(_libc_fpstate));
+  ArchHelpers::Context::RestoreContext(ucontext, Context);
 
   // Restore the previous signal state
   // This allows recursive signals to properly handle signal masking as we are walking back up the list of signals
   CTX->SignalDelegation->SetCurrentSignal(Context->Signal);
 }
 
-bool DispatchGenerator::HandleGuestSignal(int Signal, void *info, void *ucontext, GuestSigAction *GuestAction, stack_t *GuestStack) {
-  ucontext_t* _context = (ucontext_t*)ucontext;
-  mcontext_t* _mcontext = &_context->uc_mcontext;
-
+bool X86DispatchGenerator::HandleGuestSignal(int Signal, void *info, void *ucontext, GuestSigAction *GuestAction, stack_t *GuestStack) {
   StoreThreadState(Signal, ucontext);
 
   // Set the new PC
-  _mcontext->gregs[REG_RIP] = AbsoluteLoopTopAddress;
+  ArchHelpers::Context::SetPc(ucontext, AbsoluteLoopTopAddress);
   // Set our state register to point to our guest thread data
-  _mcontext->gregs[REG_R14] = reinterpret_cast<uint64_t>(State);
+  ArchHelpers::Context::SetState(ucontext, reinterpret_cast<uint64_t>(State));
+
 
   uint64_t OldGuestSP = State->State.State.gregs[X86State::REG_RSP];
   uint64_t NewGuestSP = OldGuestSP;
@@ -398,37 +362,34 @@ bool DispatchGenerator::HandleGuestSignal(int Signal, void *info, void *ucontext
   return true;
 }
 
-bool DispatchGenerator::HandleSignalPause(int Signal, void *info, void *ucontext) {
+bool X86DispatchGenerator::HandleSignalPause(int Signal, void *info, void *ucontext) {
   FEXCore::Core::SignalEvent SignalReason = State->SignalReason.load();
 
   if (SignalReason == FEXCore::Core::SignalEvent::SIGNALEVENT_PAUSE) {
-    ucontext_t* _context = (ucontext_t*)ucontext;
-    mcontext_t* _mcontext = &_context->uc_mcontext;
+
 
     // Store our thread state so we can come back to this
     StoreThreadState(Signal, ucontext);
 
     // Set the new PC
-    _mcontext->gregs[REG_RIP] = ThreadPauseHandlerAddress;
+    ArchHelpers::Context::SetPc(ucontext, ThreadPauseHandlerAddress);
 
     // Set our state register to point to our guest thread data
-    _mcontext->gregs[REG_R14] = reinterpret_cast<uint64_t>(State);
+    ArchHelpers::Context::SetState(ucontext, reinterpret_cast<uint64_t>(State));
+
 
     State->SignalReason.store(FEXCore::Core::SIGNALEVENT_NONE);
     return true;
   }
 
   if (SignalReason == FEXCore::Core::SignalEvent::SIGNALEVENT_STOP) {
-    ucontext_t* _context = (ucontext_t*)ucontext;
-    mcontext_t* _mcontext = &_context->uc_mcontext;
-
     // Our thread is stopping
     // We don't care about anything at this point
     // Set the stack to our starting location when we entered the core and get out safely
-    _mcontext->gregs[REG_RSP] = State->State.ReturningStackLocation;
+    ArchHelpers::Context::SetSp(ucontext, State->State.ReturningStackLocation);
 
     // Set the new PC
-    _mcontext->gregs[REG_RIP] = ThreadStopHandlerAddress;
+    ArchHelpers::Context::SetPc(ucontext, ThreadStopHandlerAddress);
 
     State->SignalReason.store(FEXCore::Core::SIGNALEVENT_NONE);
     return true;
@@ -444,8 +405,10 @@ bool DispatchGenerator::HandleSignalPause(int Signal, void *info, void *ucontext
   return false;
 }
 
+#ifdef _M_X86_64
+
 void InterpreterCore::CreateAsmDispatch(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread) {
-  Generator = new DispatchGenerator(ctx, Thread);
+  Generator = new X86DispatchGenerator(ctx, Thread);
   DispatchPtr = Generator->DispatchPtr;
   CallbackPtr = Generator->CallbackPtr;
 
@@ -454,17 +417,19 @@ void InterpreterCore::CreateAsmDispatch(FEXCore::Context::Context *ctx, FEXCore:
 }
 
 bool InterpreterCore::HandleGuestSignal(int Signal, void *info, void *ucontext, GuestSigAction *GuestAction, stack_t *GuestStack) {
-  DispatchGenerator *Gen = Generator;
+  X86DispatchGenerator *Gen = Generator;
   return Gen->HandleGuestSignal(Signal, info, ucontext, GuestAction, GuestStack);
 }
 
 bool InterpreterCore::HandleSignalPause(int Signal, void *info, void *ucontext) {
-  DispatchGenerator *Gen = Generator;
+  X86DispatchGenerator *Gen = Generator;
   return Gen->HandleSignalPause(Signal, info, ucontext);
 }
 
 void InterpreterCore::DeleteAsmDispatch() {
   delete Generator;
 }
+
+#endif
 
 }

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -23,14 +23,16 @@ void Arm64JITCore::CopyNecessaryDataForCompileThread(CPUBackend *Original) {
   ThreadSharedData = Core->ThreadSharedData;
 }
 
-static void SleepThread(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread) {
+static void SleepThread(FEXCore::Context::Context *ctx, FEXCore::Core::CpuStateFrame *Frame) {
+  auto Thread = Frame->Thread;
+
   --ctx->IdleWaitRefCount;
   ctx->IdleWaitCV.notify_all();
 
   // Go to sleep
   Thread->StartRunning.Wait();
 
-  Thread->State.RunningEvents.Running = true;
+  Thread->RunningEvents.Running = true;
   ++ctx->IdleWaitRefCount;
   ctx->IdleWaitCV.notify_all();
 }
@@ -352,7 +354,7 @@ void Arm64JITCore::StoreThreadState(int Signal, void *ucontext) {
   // Save guest state
   // We can't guarantee if registers are in context or host GPRs
   // So we need to save everything
-  memcpy(&Context->GuestState, &State->State, sizeof(FEXCore::Core::CPUState));
+  memcpy(&Context->GuestState, ThreadState->CurrentFrame, sizeof(FEXCore::Core::CPUState));
 
   // Set the new SP
   ArchHelpers::Context::SetSp(ucontext, NewSP);
@@ -364,7 +366,7 @@ void Arm64JITCore::RestoreThreadState(void *ucontext) {
   ArmContextBackup *Context = reinterpret_cast<ArmContextBackup*>(NewSP);
 
   // First thing, reset the guest state
-  memcpy(&State->State, &Context->GuestState, sizeof(FEXCore::Core::CPUState));
+  memcpy(ThreadState->CurrentFrame, &Context->GuestState, sizeof(FEXCore::Core::CPUState));
 
   ArchHelpers::Context::RestoreContext(ucontext, Context);
 
@@ -399,17 +401,19 @@ bool Arm64JITCore::HandleSIGILL(int Signal, void *info, void *ucontext) {
 bool Arm64JITCore::HandleGuestSignal(int Signal, void *info, void *ucontext, GuestSigAction *GuestAction, stack_t *GuestStack) {
   StoreThreadState(Signal, ucontext);
 
+  auto Frame = ThreadState->CurrentFrame;
+
   // Set the new PC
   ArchHelpers::Context::SetPc(ucontext, AbsoluteLoopTopAddressFillSRA);
   // Set x28 (which is our state register) to point to our guest thread data
-  ArchHelpers::Context::SetState(ucontext, reinterpret_cast<uint64_t>(State));
+  ArchHelpers::Context::SetState(ucontext, reinterpret_cast<uint64_t>(Frame));
 
   // Ref count our faults
   // We use this to track if it is safe to clear cache
   ++SignalHandlerRefCounter;
 
-  State->State.State.gregs[X86State::REG_RDI] = Signal;
-  uint64_t OldGuestSP = State->State.State.gregs[X86State::REG_RSP];
+  ThreadState->CurrentFrame->State.gregs[X86State::REG_RDI] = Signal;
+  uint64_t OldGuestSP = ThreadState->CurrentFrame->State.gregs[X86State::REG_RSP];
   uint64_t NewGuestSP = OldGuestSP;
 
   if (!(GuestStack->ss_flags & SS_DISABLE)) {
@@ -437,7 +441,7 @@ bool Arm64JITCore::HandleGuestSignal(int Signal, void *info, void *ucontext, Gue
     } else {
       // We are in jit, SRA must be spilled
       for(int i = 0; i < SRA64.size(); i++) {
-        State->State.State.gregs[i] = ArchHelpers::Context::GetArmReg(ucontext, SRA64[i].GetCode());
+        ThreadState->CurrentFrame->State.gregs[i] = ArchHelpers::Context::GetArmReg(ucontext, SRA64[i].GetCode());
       }
       // TODO: Also recover FPRs, not sure where the neon context is
       // This is usually not needed
@@ -463,7 +467,7 @@ bool Arm64JITCore::HandleGuestSignal(int Signal, void *info, void *ucontext, Gue
       guest_uctx->uc_mcontext.fpregs = &guest_uctx->__fpregs_mem;
 
 #define COPY_REG(x) \
-      guest_uctx->uc_mcontext.gregs[FEXCore::x86_64::FEX_REG_##x] = State->State.State.gregs[X86State::REG_##x];
+      guest_uctx->uc_mcontext.gregs[FEXCore::x86_64::FEX_REG_##x] = Frame->State.gregs[X86State::REG_##x];
       COPY_REG(R8);
       COPY_REG(R9);
       COPY_REG(R10);
@@ -483,19 +487,19 @@ bool Arm64JITCore::HandleGuestSignal(int Signal, void *info, void *ucontext, Gue
 #undef COPY_REG
 
       // Copy float registers
-      memcpy(guest_uctx->__fpregs_mem._st, State->State.State.mm, sizeof(State->State.State.mm));
-      memcpy(guest_uctx->__fpregs_mem._xmm, State->State.State.xmm, sizeof(State->State.State.xmm));
+      memcpy(guest_uctx->__fpregs_mem._st, Frame->State.mm, sizeof(Frame->State.mm));
+      memcpy(guest_uctx->__fpregs_mem._xmm, Frame->State.xmm, sizeof(Frame->State.xmm));
 
       // FCW store default
-      guest_uctx->__fpregs_mem.fcw = State->State.State.FCW;
+      guest_uctx->__fpregs_mem.fcw = Frame->State.FCW;
 
       // Reconstruct FSW
       guest_uctx->__fpregs_mem.fsw =
-        (State->State.State.flags[FEXCore::X86State::X87FLAG_TOP_LOC] << 11) |
-        (State->State.State.flags[FEXCore::X86State::X87FLAG_C0_LOC] << 8) |
-        (State->State.State.flags[FEXCore::X86State::X87FLAG_C1_LOC] << 9) |
-        (State->State.State.flags[FEXCore::X86State::X87FLAG_C2_LOC] << 10) |
-        (State->State.State.flags[FEXCore::X86State::X87FLAG_C3_LOC] << 14);
+        (Frame->State.flags[FEXCore::X86State::X87FLAG_TOP_LOC] << 11) |
+        (Frame->State.flags[FEXCore::X86State::X87FLAG_C0_LOC] << 8) |
+        (Frame->State.flags[FEXCore::X86State::X87FLAG_C1_LOC] << 9) |
+        (Frame->State.flags[FEXCore::X86State::X87FLAG_C2_LOC] << 10) |
+        (Frame->State.flags[FEXCore::X86State::X87FLAG_C3_LOC] << 14);
 
       // Copy over signal stack information
       guest_uctx->uc_stack.ss_flags = GuestStack->ss_flags;
@@ -503,8 +507,8 @@ bool Arm64JITCore::HandleGuestSignal(int Signal, void *info, void *ucontext, Gue
       guest_uctx->uc_stack.ss_size = GuestStack->ss_size;
 
       // XXX: siginfo_t(RSI)
-      State->State.State.gregs[X86State::REG_RSI] = 0x4142434445460000;
-      State->State.State.gregs[X86State::REG_RDX] = UContextLocation;
+      Frame->State.gregs[X86State::REG_RSI] = 0x4142434445460000;
+      Frame->State.gregs[X86State::REG_RDX] = UContextLocation;
     }
     else {
       // XXX: 32bit Support
@@ -519,25 +523,25 @@ bool Arm64JITCore::HandleGuestSignal(int Signal, void *info, void *ucontext, Gue
       *(uint32_t*)NewGuestSP = SigInfoLocation;
     }
 
-    State->State.State.rip = reinterpret_cast<uint64_t>(GuestAction->sigaction_handler.sigaction);
+    Frame->State.rip = reinterpret_cast<uint64_t>(GuestAction->sigaction_handler.sigaction);
   }
   else {
-    State->State.State.rip = reinterpret_cast<uint64_t>(GuestAction->sigaction_handler.handler);
+    Frame->State.rip = reinterpret_cast<uint64_t>(GuestAction->sigaction_handler.handler);
   }
 
   if (CTX->Config.Is64BitMode) {
-    State->State.State.gregs[X86State::REG_RDI] = Signal;
+    Frame->State.gregs[X86State::REG_RDI] = Signal;
 
     // Set up the new SP for stack handling
     NewGuestSP -= 8;
     *(uint64_t*)NewGuestSP = CTX->X86CodeGen.SignalReturn;
-    State->State.State.gregs[X86State::REG_RSP] = NewGuestSP;
+    Frame->State.gregs[X86State::REG_RSP] = NewGuestSP;
   }
   else {
     NewGuestSP -= 4;
     *(uint32_t*)NewGuestSP = CTX->X86CodeGen.SignalReturn;
     LogMan::Throw::A(CTX->X86CodeGen.SignalReturn < 0x1'0000'0000ULL, "This needs to be below 4GB");
-    State->State.State.gregs[X86State::REG_RSP] = NewGuestSP;
+    Frame->State.gregs[X86State::REG_RSP] = NewGuestSP;
   }
 
   return true;
@@ -645,7 +649,8 @@ bool Arm64JITCore::HandleSIGBUS(int Signal, void *info, void *ucontext) {
 }
 
 bool Arm64JITCore::HandleSignalPause(int Signal, void *info, void *ucontext) {
-  FEXCore::Core::SignalEvent SignalReason = State->SignalReason.load();
+  FEXCore::Core::SignalEvent SignalReason = ThreadState->SignalReason.load();
+  auto Frame = ThreadState->CurrentFrame;
 
   if (SignalReason == FEXCore::Core::SignalEvent::SIGNALEVENT_PAUSE) {
     // Store our thread state so we can come back to this
@@ -661,12 +666,12 @@ bool Arm64JITCore::HandleSignalPause(int Signal, void *info, void *ucontext) {
     }
 
     // Set x28 (which is our state register) to point to our guest thread data
-    ArchHelpers::Context::SetState(ucontext, reinterpret_cast<uint64_t>(State));
+    ArchHelpers::Context::SetState(ucontext, reinterpret_cast<uint64_t>(Frame));
     // Ref count our faults
     // We use this to track if it is safe to clear cache
     ++SignalHandlerRefCounter;
 
-    State->SignalReason.store(FEXCore::Core::SIGNALEVENT_NONE);
+    ThreadState->SignalReason.store(FEXCore::Core::SIGNALEVENT_NONE);
     return true;
   }
 
@@ -677,7 +682,7 @@ bool Arm64JITCore::HandleSignalPause(int Signal, void *info, void *ucontext) {
     // We use this to track if it is safe to clear cache
     --SignalHandlerRefCounter;
 
-    State->SignalReason.store(FEXCore::Core::SIGNALEVENT_NONE);
+    ThreadState->SignalReason.store(FEXCore::Core::SIGNALEVENT_NONE);
     return true;
   }
 
@@ -685,7 +690,7 @@ bool Arm64JITCore::HandleSignalPause(int Signal, void *info, void *ucontext) {
     // Our thread is stopping
     // We don't care about anything at this point
     // Set the stack to our starting location when we entered the JIT and get out safely
-    ArchHelpers::Context::SetSp(ucontext, State->State.ReturningStackLocation);
+    ArchHelpers::Context::SetSp(ucontext, Frame->ReturningStackLocation);
 
     // Our ref counting doesn't matter anymore
     SignalHandlerRefCounter = 0;
@@ -701,9 +706,9 @@ bool Arm64JITCore::HandleSignalPause(int Signal, void *info, void *ucontext) {
     }
 
     // Set x28 (which is our state register) to point to our guest thread data
-    ArchHelpers::Context::SetState(ucontext, reinterpret_cast<uint64_t>(State));
+    ArchHelpers::Context::SetState(ucontext, reinterpret_cast<uint64_t>(Frame));
 
-    State->SignalReason.store(FEXCore::Core::SIGNALEVENT_NONE);
+    ThreadState->SignalReason.store(FEXCore::Core::SIGNALEVENT_NONE);
     return true;
   }
 
@@ -713,7 +718,7 @@ bool Arm64JITCore::HandleSignalPause(int Signal, void *info, void *ucontext) {
 Arm64JITCore::Arm64JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread, CodeBuffer Buffer, bool CompileThread)
   : vixl::aarch64::Assembler(Buffer.Ptr, Buffer.Size, vixl::aarch64::PositionDependentCode)
   , CTX {ctx}
-  , State {Thread}
+  , ThreadState {Thread}
   , InitialCodeBuffer {Buffer}
 {
   CurrentCodeBuffer = &InitialCodeBuffer;
@@ -1007,7 +1012,7 @@ void *Arm64JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView const *
   // Fairly excessive buffer range to make sure we don't overflow
   uint32_t BufferRange = SSACount * 16;
   if ((GetCursorOffset() + BufferRange) > CurrentCodeBuffer->Size) {
-    State->CTX->ClearCodeCache(State, false);
+    ThreadState->CTX->ClearCodeCache(ThreadState, false);
   }
 
   // AAPCS64
@@ -1040,7 +1045,8 @@ void *Arm64JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView const *
     // This happens when single stepping
 
     static_assert(sizeof(CTX->Config.RunningMode) == 4, "This is expected to be size of 4");
-    ldr(x0, MemOperand(STATE, offsetof(FEXCore::Core::InternalThreadState, CTX)));
+    ldr(x0, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, Thread))); // Get thread
+    ldr(x0, MemOperand(x0, offsetof(FEXCore::Core::InternalThreadState, CTX))); // Get Context
     ldr(w0, MemOperand(x0, offsetof(FEXCore::Context::Context, Config.RunningMode)));
 
     // If the value == 0 then we don't need to stop
@@ -1048,7 +1054,7 @@ void *Arm64JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView const *
     {
       // Make sure RIP is syncronized to the context
       LoadConstant(x0, HeaderOp->Entry);
-      str(x0, MemOperand(STATE, offsetof(FEXCore::Core::ThreadState, State.rip)));
+      str(x0, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, State.rip)));
 
       // Stop the thread
       LoadConstant(x0, ThreadPauseHandlerAddressSpillSRA);
@@ -1213,14 +1219,15 @@ void Arm64JITCore::PopCalleeSavedRegisters() {
   }
 }
 
-uint64_t Arm64JITCore::ExitFunctionLink(Arm64JITCore *core, FEXCore::Core::InternalThreadState *Thread, uint64_t *record) {
+uint64_t Arm64JITCore::ExitFunctionLink(Arm64JITCore *core, FEXCore::Core::CpuStateFrame *Frame, uint64_t *record) {
+  auto Thread = Frame->Thread;
   auto GuestRip = record[1];
 
   auto HostCode = Thread->LookupCache->FindBlock(GuestRip);
 
   if (!HostCode) {
     //printf("ExitFunctionLink: Aborting, %lX not in cache\n", GuestRip);
-    Thread->State.State.rip = GuestRip;
+    Frame->State.rip = GuestRip;
     return core->AbsoluteLoopTopAddress;
   }
 
@@ -1301,7 +1308,7 @@ void Arm64JITCore::CreateCustomDispatch(FEXCore::Core::InternalThreadState *Thre
 
   uintptr_t CompileBlockPtr{};
   {
-    using ClassPtrType = uintptr_t (FEXCore::Context::Context::*)(FEXCore::Core::InternalThreadState *, uint64_t);
+    using ClassPtrType = uintptr_t (FEXCore::Context::Context::*)(FEXCore::Core::CpuStateFrame *, uint64_t);
     union PtrCast {
       ClassPtrType ClassPtr;
       uintptr_t Data;
@@ -1326,7 +1333,7 @@ void Arm64JITCore::CreateCustomDispatch(FEXCore::Core::InternalThreadState *Thre
   // Save this stack pointer so we can cleanly shutdown the emulation with a long jump
   // regardless of where we were in the stack
   add(x0, sp, 0);
-  str(x0, MemOperand(STATE, offsetof(FEXCore::Core::ThreadState, ReturningStackLocation)));
+  str(x0, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, ReturningStackLocation)));
 
   auto Align16B = [&Buffer, this]() {
     uint64_t CurrentOffset = Buffer->GetOffsetAddress<uint64_t>(GetCursorOffset());
@@ -1351,7 +1358,7 @@ void Arm64JITCore::CreateCustomDispatch(FEXCore::Core::InternalThreadState *Thre
 
   // Load in our RIP
   // Don't modify x2 since it contains our RIP once the block doesn't exist
-  ldr(x2, MemOperand(STATE, offsetof(FEXCore::Core::ThreadState, State.rip)));
+  ldr(x2, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, State.rip)));
   auto RipReg = x2;
 
   // L1 Cache
@@ -1452,13 +1459,13 @@ void Arm64JITCore::CreateCustomDispatch(FEXCore::Core::InternalThreadState *Thre
   {
     bind(&NoBlock);
 
-    ldr(x0, MemOperand(STATE, offsetof(FEXCore::Core::InternalThreadState, CTX)));
+    ldr(x0, &l_CTX);
     mov(x1, STATE);
     ldr(x3, &l_CompileBlock);
 
     // X2 contains our guest RIP
     SpillStaticRegs();
-    blr(x3); // { CTX, ThreadState, RIP}
+    blr(x3); // { CTX, Frame, RIP}
     FillStaticRegs();
 
     // X0 now contains the block pointer
@@ -1530,16 +1537,16 @@ void Arm64JITCore::CreateCustomDispatch(FEXCore::Core::InternalThreadState *Thre
     // Guest will be misaligned because calling a thunk won't correct the guest's stack once we call the callback from the host
     LoadConstant(x0, CTX->X86CodeGen.CallbackReturn);
 
-    ldr(x2, MemOperand(STATE, offsetof(FEXCore::Core::InternalThreadState, State.State.gregs[X86State::REG_RSP])));
+    ldr(x2, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, State.gregs[X86State::REG_RSP])));
     sub(x2, x2, 16);
-    str(x2, MemOperand(STATE, offsetof(FEXCore::Core::InternalThreadState, State.State.gregs[X86State::REG_RSP])));
+    str(x2, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, State.gregs[X86State::REG_RSP])));
 
     // Store the trampoline to the guest stack
     // Guest stack is now correctly misaligned after a regular call instruction
     str(x0, MemOperand(x2));
 
     // Store RIP to the context state
-    str(x1, MemOperand(STATE, offsetof(FEXCore::Core::InternalThreadState, State.State.rip)));
+    str(x1, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, State.rip)));
 
     // load static regs
     FillStaticRegs();
@@ -1569,21 +1576,21 @@ void Arm64JITCore::CreateCustomDispatch(FEXCore::Core::InternalThreadState *Thre
 
 void Arm64JITCore::SpillStaticRegs() {
   for (size_t i = 0; i < SRA64.size(); i+=2) {
-      stp(SRA64[i], SRA64[i+1], MemOperand(STATE, offsetof(FEXCore::Core::ThreadState, State.gregs[i])));
+      stp(SRA64[i], SRA64[i+1], MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, State.gregs[i])));
   }
 
   for (size_t i = 0; i < SRAFPR.size(); i+=2) {
-    stp(SRAFPR[i].Q(), SRAFPR[i+1].Q(), MemOperand(STATE, offsetof(FEXCore::Core::ThreadState, State.xmm[i][0])));
+    stp(SRAFPR[i].Q(), SRAFPR[i+1].Q(), MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, State.xmm[i][0])));
   }
 }
 
 void Arm64JITCore::FillStaticRegs() {
   for (size_t i = 0; i < SRA64.size(); i+=2) {
-    ldp(SRA64[i], SRA64[i+1], MemOperand(STATE, offsetof(FEXCore::Core::ThreadState, State.gregs[i])));
+    ldp(SRA64[i], SRA64[i+1], MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, State.gregs[i])));
   }
 
   for (size_t i = 0; i < SRAFPR.size(); i+=2) {
-    ldp(SRAFPR[i].Q(), SRAFPR[i+1].Q(), MemOperand(STATE, offsetof(FEXCore::Core::ThreadState, State.xmm[i][0])));
+    ldp(SRAFPR[i].Q(), SRAFPR[i+1].Q(), MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, State.xmm[i][0])));
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -99,7 +99,7 @@ public:
 private:
   Label *PendingTargetLabel;
   FEXCore::Context::Context *CTX;
-  FEXCore::Core::InternalThreadState *State;
+  FEXCore::Core::InternalThreadState *ThreadState;
   FEXCore::IR::IRListView const *IR;
 
   std::map<IR::OrderedNodeWrapper::NodeOffsetType, aarch64::Label> JumpTargets;
@@ -202,7 +202,7 @@ private:
   void PushCalleeSavedRegisters();
   void PopCalleeSavedRegisters();
 
-  static uint64_t ExitFunctionLink(Arm64JITCore *core, FEXCore::Core::InternalThreadState *Thread, uint64_t *record);
+  static uint64_t ExitFunctionLink(Arm64JITCore *core, FEXCore::Core::CpuStateFrame *Frame, uint64_t *record);
 
   /**
    * @name Dispatch Helper functions

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -98,7 +98,7 @@ DEF_OP(LoadRegister) {
   uint8_t OpSize = IROp->Size;
 
   if (Op->Class == IR::GPRClass) {
-    auto regId = (Op->Offset - offsetof(FEXCore::Core::ThreadState, State.gregs[0])) / 8;
+    auto regId = (Op->Offset - offsetof(FEXCore::Core::CpuStateFrame, State.gregs[0])) / 8;
     auto regOffs = Op->Offset & 7;
 
     LogMan::Throw::A(regId < SRA64.size(), "out of range regId");
@@ -129,7 +129,7 @@ DEF_OP(LoadRegister) {
         break;
     }
   } else if (Op->Class == IR::FPRClass) {
-    auto regId = (Op->Offset - offsetof(FEXCore::Core::ThreadState, State.xmm[0][0])) / 16;
+    auto regId = (Op->Offset - offsetof(FEXCore::Core::CpuStateFrame, State.xmm[0][0])) / 16;
     auto regOffs = Op->Offset & 15;
 
     LogMan::Throw::A(regId < SRAFPR.size(), "out of range regId");
@@ -215,7 +215,7 @@ DEF_OP(StoreRegister) {
         break;
     }
   } else if (Op->Class == IR::FPRClass) {
-    auto regId = (Op->Offset - offsetof(FEXCore::Core::ThreadState, State.xmm[0][0])) / 16;
+    auto regId = (Op->Offset - offsetof(FEXCore::Core::CpuStateFrame, State.xmm[0][0])) / 16;
     auto regOffs = Op->Offset & 15;
 
     LogMan::Throw::A(regId < SRAFPR.size(), "regId out of range");

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
@@ -32,7 +32,7 @@ DEF_OP(Break) {
     case 4: { // HLT
       // Time to quit
       // Set our stack to the starting stack location
-      ldr(TMP1, MemOperand(STATE, offsetof(FEXCore::Core::ThreadState, ReturningStackLocation)));
+      ldr(TMP1, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, ReturningStackLocation)));
       add(sp, TMP1, 0);
 
       // Now we need to jump to the thread stop handler

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
@@ -40,7 +40,7 @@ DEF_OP(CallbackReturn) {
   sub(dword [rax], 1);
 
   // We need to adjust an additional 8 bytes to get back to the original "misaligned" RSP state
-  add(qword [STATE + offsetof(FEXCore::Core::InternalThreadState, State.State.gregs[X86State::REG_RSP])], 8);
+  add(qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, State.gregs[X86State::REG_RSP])], 8);
 
   // Now jump back to the thunk
   // XXX: XMM?
@@ -96,7 +96,7 @@ DEF_OP(ExitFunction) {
 
     L(FullLookup);
     mov(rax, AbsoluteLoopTopAddress);
-    mov(qword [STATE + offsetof(FEXCore::Core::InternalThreadState, State.State.rip)], RipReg);
+    mov(qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, State.rip)], RipReg);
     jmp(rax);
   }
 
@@ -286,7 +286,7 @@ DEF_OP(RemoveCodeEntry) {
   mov(rsi, rax);
 
 
-  mov(rax, reinterpret_cast<uintptr_t>(&Context::Context::RemoveCodeEntry));
+  mov(rax, reinterpret_cast<uintptr_t>(&Context::Context::RemoveCodeEntryFromJit));
   call(rax);
 
   if (NumPush & 1)

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -63,7 +63,7 @@ void X86JITCore::StoreThreadState(int Signal, void *ucontext) {
   // Save guest state
   // We can't guarantee if registers are in context or host GPRs
   // So we need to save everything
-  memcpy(&Context->GuestState, &ThreadState->State, sizeof(FEXCore::Core::CPUState));
+  memcpy(&Context->GuestState, ThreadState->CurrentFrame, sizeof(FEXCore::Core::CPUState));
 
   // Set the new SP
   ArchHelpers::Context::SetSp(ucontext, NewSP);
@@ -78,7 +78,7 @@ void X86JITCore::RestoreThreadState(void *ucontext) {
   X86ContextBackup *Context = reinterpret_cast<X86ContextBackup*>(NewSP);
 
   // First thing, reset the guest state
-  memcpy(&ThreadState->State, &Context->GuestState, sizeof(FEXCore::Core::CPUState));
+  memcpy(ThreadState->CurrentFrame, &Context->GuestState, sizeof(FEXCore::Core::CPUState));
 
   // Now restore host state
   ArchHelpers::Context::RestoreContext(ucontext, Context);
@@ -90,17 +90,18 @@ void X86JITCore::RestoreThreadState(void *ucontext) {
 
 bool X86JITCore::HandleGuestSignal(int Signal, void *info, void *ucontext, GuestSigAction *GuestAction, stack_t *GuestStack) {
   StoreThreadState(Signal, ucontext);
+  auto Frame = ThreadState->CurrentFrame;
 
   // Set the new PC
   ArchHelpers::Context::SetPc(ucontext, AbsoluteLoopTopAddress);
   // Set our state register to point to our guest thread data
-  ArchHelpers::Context::SetState(ucontext, reinterpret_cast<uint64_t>(ThreadState));
+  ArchHelpers::Context::SetState(ucontext, reinterpret_cast<uint64_t>(Frame));
 
   // Ref count our faults
   // We use this to track if it is safe to clear cache
   ++SignalHandlerRefCounter;
 
-  uint64_t OldGuestSP = ThreadState->State.State.gregs[X86State::REG_RSP];
+  uint64_t OldGuestSP = Frame->State.gregs[X86State::REG_RSP];
   uint64_t NewGuestSP = OldGuestSP;
 
   if (!(GuestStack->ss_flags & SS_DISABLE)) {
@@ -136,7 +137,7 @@ bool X86JITCore::HandleGuestSignal(int Signal, void *info, void *ucontext, Guest
       guest_uctx->uc_mcontext.fpregs = &guest_uctx->__fpregs_mem;
 
 #define COPY_REG(x) \
-      guest_uctx->uc_mcontext.gregs[FEXCore::x86_64::FEX_REG_##x] = ThreadState->State.State.gregs[X86State::REG_##x];
+      guest_uctx->uc_mcontext.gregs[FEXCore::x86_64::FEX_REG_##x] = Frame->State.gregs[X86State::REG_##x];
       COPY_REG(R8);
       COPY_REG(R9);
       COPY_REG(R10);
@@ -156,19 +157,19 @@ bool X86JITCore::HandleGuestSignal(int Signal, void *info, void *ucontext, Guest
 #undef COPY_REG
 
       // Copy float registers
-      memcpy(guest_uctx->__fpregs_mem._st, ThreadState->State.State.mm, sizeof(ThreadState->State.State.mm));
-      memcpy(guest_uctx->__fpregs_mem._xmm, ThreadState->State.State.xmm, sizeof(ThreadState->State.State.xmm));
+      memcpy(guest_uctx->__fpregs_mem._st, Frame->State.mm, sizeof(Frame->State.mm));
+      memcpy(guest_uctx->__fpregs_mem._xmm, Frame->State.xmm, sizeof(Frame->State.xmm));
 
       // FCW store default
-      guest_uctx->__fpregs_mem.fcw = ThreadState->State.State.FCW;
+      guest_uctx->__fpregs_mem.fcw = Frame->State.FCW;
 
       // Reconstruct FSW
       guest_uctx->__fpregs_mem.fsw =
-        (ThreadState->State.State.flags[FEXCore::X86State::X87FLAG_TOP_LOC] << 11) |
-        (ThreadState->State.State.flags[FEXCore::X86State::X87FLAG_C0_LOC] << 8) |
-        (ThreadState->State.State.flags[FEXCore::X86State::X87FLAG_C1_LOC] << 9) |
-        (ThreadState->State.State.flags[FEXCore::X86State::X87FLAG_C2_LOC] << 10) |
-        (ThreadState->State.State.flags[FEXCore::X86State::X87FLAG_C3_LOC] << 14);
+        (Frame->State.flags[FEXCore::X86State::X87FLAG_TOP_LOC] << 11) |
+        (Frame->State.flags[FEXCore::X86State::X87FLAG_C0_LOC] << 8) |
+        (Frame->State.flags[FEXCore::X86State::X87FLAG_C1_LOC] << 9) |
+        (Frame->State.flags[FEXCore::X86State::X87FLAG_C2_LOC] << 10) |
+        (Frame->State.flags[FEXCore::X86State::X87FLAG_C3_LOC] << 14);
 
       // Copy over signal stack information
       guest_uctx->uc_stack.ss_flags = GuestStack->ss_flags;
@@ -176,8 +177,8 @@ bool X86JITCore::HandleGuestSignal(int Signal, void *info, void *ucontext, Guest
       guest_uctx->uc_stack.ss_size = GuestStack->ss_size;
 
       // XXX: siginfo_t(RSI)
-      ThreadState->State.State.gregs[X86State::REG_RSI] = 0x4142434445460000;
-      ThreadState->State.State.gregs[X86State::REG_RDX] = UContextLocation;
+      Frame->State.gregs[X86State::REG_RSI] = 0x4142434445460000;
+      Frame->State.gregs[X86State::REG_RDX] = UContextLocation;
     }
     else {
       // XXX: 32bit Support
@@ -192,25 +193,25 @@ bool X86JITCore::HandleGuestSignal(int Signal, void *info, void *ucontext, Guest
       *(uint32_t*)NewGuestSP = SigInfoLocation;
     }
 
-    ThreadState->State.State.rip = reinterpret_cast<uint64_t>(GuestAction->sigaction_handler.sigaction);
+    Frame->State.rip = reinterpret_cast<uint64_t>(GuestAction->sigaction_handler.sigaction);
   }
   else {
-    ThreadState->State.State.rip = reinterpret_cast<uint64_t>(GuestAction->sigaction_handler.handler);
+    Frame->State.rip = reinterpret_cast<uint64_t>(GuestAction->sigaction_handler.handler);
   }
 
   if (CTX->Config.Is64BitMode) {
-    ThreadState->State.State.gregs[X86State::REG_RDI] = Signal;
+    Frame->State.gregs[X86State::REG_RDI] = Signal;
 
     // Set up the new SP for stack handling
     NewGuestSP -= 8;
     *(uint64_t*)NewGuestSP = CTX->X86CodeGen.SignalReturn;
-    ThreadState->State.State.gregs[X86State::REG_RSP] = NewGuestSP;
+    Frame->State.gregs[X86State::REG_RSP] = NewGuestSP;
   }
   else {
     NewGuestSP -= 4;
     *(uint32_t*)NewGuestSP = CTX->X86CodeGen.SignalReturn;
     LogMan::Throw::A(CTX->X86CodeGen.SignalReturn < 0x1'0000'0000ULL, "This needs to be below 4GB");
-    ThreadState->State.State.gregs[X86State::REG_RSP] = NewGuestSP;
+    Frame->State.gregs[X86State::REG_RSP] = NewGuestSP;
   }
 
   return true;
@@ -246,6 +247,7 @@ bool X86JITCore::HandleSIGILL(int Signal, void *info, void *ucontext) {
 
 bool X86JITCore::HandleSignalPause(int Signal, void *info, void *ucontext) {
   FEXCore::Core::SignalEvent SignalReason = ThreadState->SignalReason.load();
+  auto Frame = ThreadState->CurrentFrame;
 
   if (SignalReason == FEXCore::Core::SignalEvent::SIGNALEVENT_PAUSE) {
 
@@ -256,7 +258,7 @@ bool X86JITCore::HandleSignalPause(int Signal, void *info, void *ucontext) {
     ArchHelpers::Context::SetPc(ucontext, ThreadPauseHandlerAddress);
 
     // Set our state register to point to our guest thread data
-    ArchHelpers::Context::SetState(ucontext, reinterpret_cast<uint64_t>(ThreadState));
+    ArchHelpers::Context::SetState(ucontext, reinterpret_cast<uint64_t>(Frame));
 
     // Ref count our faults
     // We use this to track if it is safe to clear cache
@@ -281,7 +283,7 @@ bool X86JITCore::HandleSignalPause(int Signal, void *info, void *ucontext) {
     // Our thread is stopping
     // We don't care about anything at this point
     // Set the stack to our starting location when we entered the JIT and get out safely
-    ArchHelpers::Context::SetSp(ucontext, ThreadState->State.ReturningStackLocation);
+    ArchHelpers::Context::SetSp(ucontext, ThreadState->CurrentFrame->ReturningStackLocation);
 
     // Our ref counting doesn't matter anymore
     SignalHandlerRefCounter = 0;
@@ -831,7 +833,7 @@ void *X86JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView const *IR
     // If we have a gdb server running then run in a less efficient mode that checks if we need to exit
     // This happens when single stepping
     static_assert(sizeof(CTX->Config.RunningMode) == 4, "This is expected to be size of 4");
-    mov(rax, qword [STATE + (offsetof(FEXCore::Core::InternalThreadState, CTX))]);
+    mov(rax, reinterpret_cast<uint64_t>(CTX));
 
     // If the value == 0 then branch to the top
     cmp(dword [rax + (offsetof(FEXCore::Context::Context, Config.RunningMode))], 0);
@@ -981,25 +983,28 @@ void *X86JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView const *IR
   return Entry;
 }
 
-static void SleepThread(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread) {
+static void SleepThread(FEXCore::Context::Context *ctx, FEXCore::Core::CpuStateFrame *Frame) {
+  auto Thread = Frame->Thread;
+
   --ctx->IdleWaitRefCount;
   ctx->IdleWaitCV.notify_all();
 
   // Go to sleep
   Thread->StartRunning.Wait();
 
-  Thread->State.RunningEvents.Running = true;
+  Thread->RunningEvents.Running = true;
   ++ctx->IdleWaitRefCount;
   ctx->IdleWaitCV.notify_all();
 }
 
-uint64_t X86JITCore::ExitFunctionLink(X86JITCore *core, FEXCore::Core::InternalThreadState *Thread, uint64_t *record) {
+uint64_t X86JITCore::ExitFunctionLink(X86JITCore *core, FEXCore::Core::CpuStateFrame *Frame, uint64_t *record) {
+  auto Thread = Frame->Thread;
   auto GuestRip = record[1];
 
   auto HostCode = Thread->LookupCache->FindBlock(GuestRip);
 
   if (!HostCode) {
-    Thread->State.State.rip = GuestRip;
+    Thread->CurrentFrame->State.rip = GuestRip;
     return core->AbsoluteLoopTopAddress;
   }
 
@@ -1062,7 +1067,7 @@ void X86JITCore::CreateCustomDispatch(FEXCore::Core::InternalThreadState *Thread
 
   // Save this stack pointer so we can cleanly shutdown the emulation with a long jump
   // regardless of where we were in the stack
-  mov(qword [STATE + offsetof(FEXCore::Core::ThreadState, ReturningStackLocation)], rsp);
+  mov(qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, ReturningStackLocation)], rsp);
 
   Label LoopTop;
   Label FullLookup;
@@ -1073,7 +1078,7 @@ void X86JITCore::CreateCustomDispatch(FEXCore::Core::InternalThreadState *Thread
   AbsoluteLoopTopAddress = getCurr<uint64_t>();
   {
     // Load our RIP
-    mov(rdx, qword [STATE + offsetof(FEXCore::Core::CPUState, rip)]);
+    mov(rdx, qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, State.rip)]);
 
     // L1 Cache
     mov(r13, Thread->LookupCache->GetL1Pointer());
@@ -1160,7 +1165,7 @@ void X86JITCore::CreateCustomDispatch(FEXCore::Core::InternalThreadState *Thread
   {
     L(NoBlock);
 
-    using ClassPtrType = uintptr_t (FEXCore::Context::Context::*)(FEXCore::Core::InternalThreadState *, uint64_t);
+    using ClassPtrType = uintptr_t (FEXCore::Context::Context::*)(FEXCore::Core::CpuStateFrame *, uint64_t);
     union PtrCast {
       ClassPtrType ClassPtr;
       uintptr_t Data;
@@ -1235,12 +1240,12 @@ void X86JITCore::CreateCustomDispatch(FEXCore::Core::InternalThreadState *Thread
 
     // Store the trampoline to the guest stack
     // Guest stack is now correctly misaligned after a regular call instruction
-    sub(qword [STATE + offsetof(FEXCore::Core::InternalThreadState, State.State.gregs[X86State::REG_RSP])], 16);
-    mov(rbx, qword [STATE + offsetof(FEXCore::Core::InternalThreadState, State.State.gregs[X86State::REG_RSP])]);
+    sub(qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, State.gregs[X86State::REG_RSP])], 16);
+    mov(rbx, qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, State.gregs[X86State::REG_RSP])]);
     mov(qword [rbx], rax);
 
     // Store RIP to the context state
-    mov(qword [STATE + offsetof(FEXCore::Core::InternalThreadState, State.State.rip)], rsi);
+    mov(qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, State.rip)], rsi);
 
     // Back to the loop top now
     jmp(LoopTop);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -142,7 +142,7 @@ private:
     CurrentCodeBuffer = &CodeBuffers.emplace_back(Buffer);
   }
 
-  static uint64_t ExitFunctionLink(X86JITCore* code, FEXCore::Core::InternalThreadState *Thread, uint64_t *record);
+  static uint64_t ExitFunctionLink(X86JITCore* code, FEXCore::Core::CpuStateFrame *Frame, uint64_t *record);
 
   // This is the initial code buffer that we will fall back to
   // In a program without signals and code clearing, we will typically

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/MiscOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/MiscOps.cpp
@@ -34,7 +34,7 @@ DEF_OP(Break) {
     case 4: { // HLT
       // Time to quit
       // Set our stack to the starting stack location
-      mov(rsp, qword [STATE + offsetof(FEXCore::Core::ThreadState, ReturningStackLocation)]);
+      mov(rsp, qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, ReturningStackLocation)]);
 
       // Now we need to jump to the thread stop handler
       mov(TMP1, ThreadStopHandlerAddress);
@@ -56,7 +56,7 @@ DEF_OP(Break) {
       else {
         // If we don't have a gdb server attached then....crash?
         // Treat this case like HLT
-        mov(rsp, qword [STATE + offsetof(FEXCore::Core::ThreadState, ReturningStackLocation)]);
+        mov(rsp, qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, ReturningStackLocation)]);
 
         // Now we need to jump to the thread stop handler
         mov(TMP1, ThreadStopHandlerAddress);

--- a/External/FEXCore/Source/Interface/HLE/Thunks/Thunks.cpp
+++ b/External/FEXCore/Source/Interface/HLE/Thunks/Thunks.cpp
@@ -41,9 +41,8 @@ namespace FEXCore {
             Set arg0/1 to arg regs, use CTX::HandleCallback to handle the callback
         */
         static void CallCallback(void *callback, void *arg0, void* arg1) {
-
-            Thread->State.State.gregs[FEXCore::X86State::REG_RDI] = (uintptr_t)arg0;
-            Thread->State.State.gregs[FEXCore::X86State::REG_RSI] = (uintptr_t)arg1;
+            Thread->CurrentFrame->State.gregs[FEXCore::X86State::REG_RDI] = (uintptr_t)arg0;
+            Thread->CurrentFrame->State.gregs[FEXCore::X86State::REG_RSI] = (uintptr_t)arg1;
 
             Thread->CTX->HandleCallback((uintptr_t)callback);
         }

--- a/External/FEXCore/Source/Interface/IR/Passes/DeadStoreElimination.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/DeadStoreElimination.cpp
@@ -28,7 +28,7 @@ bool IsFullGPR(uint32_t Offset, uint8_t Size) {
     return false;
   if (Offset & 7)
     return false;
-  
+
   if (Offset < 8 || Offset >= (17 * 8))
     return false;
 
@@ -36,7 +36,7 @@ bool IsFullGPR(uint32_t Offset, uint8_t Size) {
 }
 
 bool IsGPR(uint32_t Offset) {
-  
+
   if (Offset < 8 || Offset >= (17 * 8))
     return false;
 
@@ -48,7 +48,7 @@ uint32_t GPRBit(uint32_t Offset) {
     return 0;
   }
 
-  return  1 << ((Offset - 8)/8); 
+  return  1 << ((Offset - 8)/8);
 }
 
 struct FPRInfo {
@@ -58,9 +58,9 @@ struct FPRInfo {
 };
 
 bool IsFPR(uint32_t Offset) {
-  
-  auto begin = offsetof(FEXCore::Core::ThreadState, State.xmm[0][0]);
-  auto end = offsetof(FEXCore::Core::ThreadState, State.xmm[17][0]);
+
+  auto begin = offsetof(FEXCore::Core::CpuStateFrame, State.xmm[0][0]);
+  auto end = offsetof(FEXCore::Core::CpuStateFrame, State.xmm[17][0]);
 
   if (Offset < begin || Offset >= end)
     return false;
@@ -84,7 +84,7 @@ uint64_t FPRBit(uint32_t Offset, uint32_t Size) {
     return 0;
   }
 
-  auto begin = offsetof(FEXCore::Core::ThreadState, State.xmm[0][0]);
+  auto begin = offsetof(FEXCore::Core::CpuStateFrame, State.xmm[0][0]);
 
   auto regn = (Offset - begin)/16;
   auto bitn = regn * 3;
@@ -138,7 +138,7 @@ bool DeadStoreElimination::Run(IREmitter *IREmit) {
         //// Flags ////
         if (IROp->Op == OP_STOREFLAG) {
           auto Op = IROp->C<IR::IROp_StoreFlag>();
-          
+
           auto& BlockInfo = InfoMap[BlockNode];
 
           BlockInfo.flag.writes |= 1UL << Op->Flag;
@@ -203,7 +203,7 @@ bool DeadStoreElimination::Run(IREmitter *IREmit) {
   {
     for (auto [BlockNode, BlockIROp] : CurrentIR.GetBlocks()) {
       auto CodeBlock = BlockIROp->C<IROp_CodeBlock>();
-      
+
       auto IROp = CurrentIR.GetNode(CurrentIR.GetNode(CodeBlock->Last)->Header.Previous)->Op(CurrentIR.GetData());
 
       if (IROp->Op == OP_JUMP) {
@@ -220,8 +220,8 @@ bool DeadStoreElimination::Run(IREmitter *IREmit) {
 
         // Flags that are written by the next block can be considered as written by this block, if not read
         BlockInfo.flag.writes |= BlockInfo.flag.kill & ~BlockInfo.flag.reads;
-        
-        
+
+
         //// GPRs ////
 
         // stores to remove are written by the next block but not read
@@ -258,7 +258,7 @@ bool DeadStoreElimination::Run(IREmitter *IREmit) {
         // Flags that are written by the next blocks can be considered as written by this block, if not read
         BlockInfo.flag.writes |= BlockInfo.flag.kill & ~BlockInfo.flag.reads;
 
-        
+
         //// GPRs ////
 
         // stores to remove are written by the next blocks but not read
@@ -300,7 +300,7 @@ bool DeadStoreElimination::Run(IREmitter *IREmit) {
           }
         } else if (IROp->Op == OP_STORECONTEXT) {
           auto Op = IROp->C<IR::IROp_StoreContext>();
-          
+
           auto& BlockInfo = InfoMap[BlockNode];
 
           //// GPRs ////

--- a/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -613,11 +613,11 @@ namespace FEXCore::IR {
 
     // Get SRA Reg and Class from a Context offset
     auto GetRegAndClassFromOffset = [](uint32_t Offset) {
-        auto beginGpr = offsetof(FEXCore::Core::ThreadState, State.gregs[0]);
-        auto endGpr = offsetof(FEXCore::Core::ThreadState, State.gregs[17]);
+        auto beginGpr = offsetof(FEXCore::Core::CpuStateFrame, State.gregs[0]);
+        auto endGpr = offsetof(FEXCore::Core::CpuStateFrame, State.gregs[17]);
 
-        auto beginFpr = offsetof(FEXCore::Core::ThreadState, State.xmm[0][0]);
-        auto endFpr = offsetof(FEXCore::Core::ThreadState, State.xmm[17][0]);
+        auto beginFpr = offsetof(FEXCore::Core::CpuStateFrame, State.xmm[0][0]);
+        auto endFpr = offsetof(FEXCore::Core::CpuStateFrame, State.xmm[17][0]);
 
         if (Offset >= beginGpr && Offset < endGpr) {
           auto reg = (Offset - beginGpr) / 8;
@@ -637,11 +637,11 @@ namespace FEXCore::IR {
 
     // Get a StaticMap entry from context offset
     auto GetStaticMapFromOffset = [&](uint32_t Offset) {
-        auto beginGpr = offsetof(FEXCore::Core::ThreadState, State.gregs[0]);
-        auto endGpr = offsetof(FEXCore::Core::ThreadState, State.gregs[17]);
+        auto beginGpr = offsetof(FEXCore::Core::CpuStateFrame, State.gregs[0]);
+        auto endGpr = offsetof(FEXCore::Core::CpuStateFrame, State.gregs[17]);
 
-        auto beginFpr = offsetof(FEXCore::Core::ThreadState, State.xmm[0][0]);
-        auto endFpr = offsetof(FEXCore::Core::ThreadState, State.xmm[17][0]);
+        auto beginFpr = offsetof(FEXCore::Core::CpuStateFrame, State.xmm[0][0]);
+        auto endFpr = offsetof(FEXCore::Core::CpuStateFrame, State.xmm[17][0]);
 
         if (Offset >= beginGpr && Offset < endGpr) {
           auto reg = (Offset - beginGpr) / 8;

--- a/External/FEXCore/Source/Interface/IR/Passes/StaticRegisterAllocationPass.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/StaticRegisterAllocationPass.cpp
@@ -10,8 +10,8 @@ public:
 
 bool IsStaticAllocGpr(uint32_t Offset, RegisterClassType Class) {
   bool rv = false;
-  auto begin = offsetof(FEXCore::Core::ThreadState, State.gregs[0]);
-  auto end = offsetof(FEXCore::Core::ThreadState, State.gregs[17]);
+  auto begin = offsetof(FEXCore::Core::CPUState, gregs[0]);
+  auto end = offsetof(FEXCore::Core::CPUState, gregs[17]);
 
   if (Offset >= begin && Offset < end) {
     auto reg = (Offset - begin) / 8;
@@ -25,8 +25,8 @@ bool IsStaticAllocGpr(uint32_t Offset, RegisterClassType Class) {
 
 bool IsStaticAllocFpr(uint32_t Offset, RegisterClassType Class, bool AllowGpr) {
   bool rv = false;
-  auto begin = offsetof(FEXCore::Core::ThreadState, State.xmm[0][0]);
-  auto end = offsetof(FEXCore::Core::ThreadState, State.xmm[17][0]);
+  auto begin = offsetof(FEXCore::Core::CPUState, xmm[0][0]);
+  auto end = offsetof(FEXCore::Core::CPUState, xmm[17][0]);
 
   if (Offset >= begin && Offset < end) {
     auto reg = (Offset - begin)/16;

--- a/External/FEXCore/include/FEXCore/Core/CPUBackend.h
+++ b/External/FEXCore/include/FEXCore/Core/CPUBackend.h
@@ -71,15 +71,15 @@ class LLVMCore;
      */
     virtual bool NeedsOpDispatch() = 0;
 
-    void ExecuteDispatch(FEXCore::Core::InternalThreadState *Thread) {
-      DispatchPtr(Thread);
+    void ExecuteDispatch(FEXCore::Core::CpuStateFrame *Frame) {
+      DispatchPtr(Frame);
     }
 
     virtual void ClearCache() {}
     virtual void CopyNecessaryDataForCompileThread(CPUBackend *Original) {}
 
-    using AsmDispatch = __attribute__((naked)) void(*)(FEXCore::Core::InternalThreadState *Thread);
-    using JITCallback = __attribute__((naked)) void(*)(FEXCore::Core::InternalThreadState *Thread, uint64_t RIP);
+    using AsmDispatch = __attribute__((naked)) void(*)(FEXCore::Core::CpuStateFrame *Frame);
+    using JITCallback = __attribute__((naked)) void(*)(FEXCore::Core::CpuStateFrame *Frame, uint64_t RIP);
 
     JITCallback CallbackPtr{};
   protected:

--- a/External/FEXCore/include/FEXCore/Core/Context.h
+++ b/External/FEXCore/include/FEXCore/Core/Context.h
@@ -16,7 +16,7 @@ namespace FEXCore {
 
 namespace FEXCore::Core {
   struct CPUState;
-  struct ThreadState;
+  struct InternalThreadState;
 }
 
 namespace FEXCore::CPU {
@@ -44,7 +44,7 @@ namespace FEXCore::Context {
     MODE_32BIT,
     MODE_64BIT,
   };
-  using CustomCPUFactoryType = std::function<FEXCore::CPU::CPUBackend* (FEXCore::Context::Context*, FEXCore::Core::ThreadState *Thread)>;
+  using CustomCPUFactoryType = std::function<FEXCore::CPU::CPUBackend* (FEXCore::Context::Context*, FEXCore::Core::InternalThreadState *Thread)>;
 
   /**
    * @brief This initializes internal FEXCore state that is shared between contexts and requires overhead to setup
@@ -187,17 +187,6 @@ namespace FEXCore::Context {
    * @param Factory The factory that the context will call if the DefaultCore config ise set to CUSTOM
    */
   void SetCustomCPUBackendFactory(FEXCore::Context::Context *CTX, CustomCPUFactoryType Factory);
-
-  /**
-   * @brief Allows a custom CPUBackend creation factory for fallback routines when the main CPUBackend core can't handle an instruction
-   *
-   * This is only useful for debugging new instruction decodings that FEXCore doesn't understand
-   * The CPUBackend that is created from this factory must have its NeedsOpDispatch function to return false
-   *
-   * @param CTX The context that we created
-   * @param Factory The factory that the context will call on core creation
-   */
-  void SetFallbackCPUBackendFactory(FEXCore::Context::Context *CTX, CustomCPUFactoryType Factory);
 
   /**
    * @brief Sets up memory regions on the guest for mirroring within the guest's VM space

--- a/External/FEXCore/include/FEXCore/Core/CoreState.h
+++ b/External/FEXCore/include/FEXCore/Core/CoreState.h
@@ -26,13 +26,11 @@ namespace FEXCore::Core {
   };
   static_assert(offsetof(CPUState, xmm) % 16 == 0, "xmm needs to be 128bit aligned!");
 
-  struct ThreadState {
-    CPUState State{};
+  struct InternalThreadState;
 
-    struct {
-      std::atomic_bool Running {false};
-      std::atomic_bool WaitingToStart {false};
-    } RunningEvents;
+  // Each guest JIT frame has one of these
+  struct CpuStateFrame {
+    CPUState State;
 
     /**
      * @brief Stack location for the CPU backends to return the stack pointer to
@@ -40,13 +38,11 @@ namespace FEXCore::Core {
      * Allows the CPU cores to do a long jump out of their execution and safely shut down
      */
     uint64_t ReturningStackLocation{};
-
-    FEXCore::HLE::ThreadManagement ThreadManager;
+    InternalThreadState* Thread;
   };
-  static_assert(offsetof(ThreadState, State) == 0, "CPUState must be first member in threadstate");
-  static_assert(offsetof(ThreadState, State.rip) == 0, "rip must be zero offset in threadstate");
-
-  static_assert(std::is_standard_layout<ThreadState>::value, "This needs to be standard layout");
+  static_assert(offsetof(CpuStateFrame, State) == 0, "CPUState must be first member in CpuStateFrame");
+  static_assert(offsetof(CpuStateFrame, State.rip) == 0, "rip must be zero offset in CpuStateFrame");
+  static_assert(std::is_standard_layout<CpuStateFrame>::value, "This needs to be standard layout");
 
 #ifdef PAGE_SIZE
   static_assert(PAGE_SIZE == 4096, "FEX only supports 4k pages");

--- a/External/FEXCore/include/FEXCore/Debug/ContextDebug.h
+++ b/External/FEXCore/include/FEXCore/Debug/ContextDebug.h
@@ -18,14 +18,12 @@ namespace Debug {
 
   uint64_t GetThreadCount(FEXCore::Context::Context *CTX);
   FEXCore::Core::RuntimeStats *GetRuntimeStatsForThread(FEXCore::Context::Context *CTX, uint64_t Thread);
-  FEXCore::Core::CPUState GetCPUState(FEXCore::Context::Context *CTX);
 
   bool GetDebugDataForRIP(FEXCore::Context::Context *CTX, uint64_t RIP, FEXCore::Core::DebugData *Data);
   bool FindHostCodeForRIP(FEXCore::Context::Context *CTX, uint64_t RIP, uint8_t **Code);
 	// XXX:
   // bool FindIRForRIP(FEXCore::Context::Context *CTX, uint64_t RIP, FEXCore::IR::IntrusiveIRList **ir);
   // void SetIRForRIP(FEXCore::Context::Context *CTX, uint64_t RIP, FEXCore::IR::IntrusiveIRList *const ir);
-  FEXCore::Core::ThreadState *GetThreadState(FEXCore::Context::Context *CTX);
 }
 }
 

--- a/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
+++ b/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
@@ -70,7 +70,12 @@ namespace FEXCore::Core {
   };
 
   struct InternalThreadState {
-    FEXCore::Core::ThreadState State;
+    FEXCore::Core::CpuStateFrame* CurrentFrame = &BaseFrameState;
+
+    struct {
+      std::atomic_bool Running {false};
+      std::atomic_bool WaitingToStart {false};
+    } RunningEvents;
 
     FEXCore::Context::Context *CTX;
     std::atomic<SignalEvent> SignalReason {SignalEvent::SIGNALEVENT_NONE};
@@ -88,6 +93,7 @@ namespace FEXCore::Core {
 
     std::unique_ptr<FEXCore::Frontend::Decoder> FrontendDecoder;
     std::unique_ptr<FEXCore::IR::PassManager> PassManager;
+    FEXCore::HLE::ThreadManagement ThreadManager;
 
     RuntimeStats Stats{};
 
@@ -96,8 +102,10 @@ namespace FEXCore::Core {
     uint32_t CompileBlockReentrantRefCount{};
     std::shared_ptr<FEXCore::CompileService> CompileService;
     bool IsCompileService{false};
+
+    FEXCore::Core::CpuStateFrame BaseFrameState{};
+
   };
-  static_assert(offsetof(InternalThreadState, State) == 0, "InternalThreadState must have State be the first object");
   static_assert(std::is_standard_layout<InternalThreadState>::value, "This needs to be standard layout");
 }
 

--- a/External/FEXCore/include/FEXCore/HLE/SyscallHandler.h
+++ b/External/FEXCore/include/FEXCore/HLE/SyscallHandler.h
@@ -8,6 +8,7 @@ namespace FEXCore::Context {
 
 namespace FEXCore::Core {
   struct InternalThreadState;
+  struct CpuStateFrame;
 }
 
 namespace FEXCore::HLE {
@@ -36,7 +37,7 @@ namespace FEXCore::HLE {
   public:
     virtual ~SyscallHandler() = default;
 
-    virtual uint64_t HandleSyscall(FEXCore::Core::InternalThreadState *Thread, FEXCore::HLE::SyscallArguments *Args) = 0;
+    virtual uint64_t HandleSyscall(FEXCore::Core::CpuStateFrame *Frame, FEXCore::HLE::SyscallArguments *Args) = 0;
     virtual SyscallABI GetSyscallABI(uint64_t Syscall) = 0;
 
     SyscallOSABI GetOSABI() const { return OSABI; }

--- a/Source/CommonCore/HostFactory.h
+++ b/Source/CommonCore/HostFactory.h
@@ -9,6 +9,6 @@ namespace FEXCore::Core {
 }
 
 namespace HostFactory {
-  FEXCore::CPU::CPUBackend *CPUCreationFactory(FEXCore::Context::Context* CTX, FEXCore::Core::ThreadState *Thread);
-  FEXCore::CPU::CPUBackend *CPUCreationFactoryFallback(FEXCore::Context::Context* CTX, FEXCore::Core::ThreadState *Thread);
+  FEXCore::CPU::CPUBackend *CPUCreationFactory(FEXCore::Context::Context* CTX, FEXCore::Core::InternalThreadState *Thread);
+  FEXCore::CPU::CPUBackend *CPUCreationFactoryFallback(FEXCore::Context::Context* CTX, FEXCore::Core::InternalThreadState *Thread);
 }

--- a/Source/Tests/LinuxSyscalls/SignalDelegator.cpp
+++ b/Source/Tests/LinuxSyscalls/SignalDelegator.cpp
@@ -149,11 +149,11 @@ namespace FEX::HLE {
       // We have an emulation thread pointer, we can now modify its state
       if (Handler.GuestAction.sigaction_handler.handler == SIG_DFL) {
         if (Handler.DefaultBehaviour == DEFAULT_TERM) {
-          if (Thread->State.ThreadManager.clear_child_tid) {
-            std::atomic<uint32_t> *Addr = reinterpret_cast<std::atomic<uint32_t>*>(Thread->State.ThreadManager.clear_child_tid);
+          if (Thread->ThreadManager.clear_child_tid) {
+            std::atomic<uint32_t> *Addr = reinterpret_cast<std::atomic<uint32_t>*>(Thread->ThreadManager.clear_child_tid);
             Addr->store(0);
             syscall(SYS_futex,
-                Thread->State.ThreadManager.clear_child_tid,
+                Thread->ThreadManager.clear_child_tid,
                 FUTEX_WAKE,
                 ~0ULL,
                 0,
@@ -469,7 +469,7 @@ namespace FEX::HLE {
     bool UsingAltStack{};
     uint64_t AltStackBase = reinterpret_cast<uint64_t>(ThreadData.GuestAltStack.ss_sp);
     uint64_t AltStackEnd = AltStackBase + ThreadData.GuestAltStack.ss_size;
-    uint64_t GuestSP = ThreadData.Thread->State.State.gregs[FEXCore::X86State::REG_RSP];
+    uint64_t GuestSP = ThreadData.Thread->CurrentFrame->State.gregs[FEXCore::X86State::REG_RSP];
 
     if (!(ThreadData.GuestAltStack.ss_flags & SS_DISABLE) &&
         GuestSP >= AltStackBase &&
@@ -528,7 +528,7 @@ namespace FEX::HLE {
     if (PendingSignals != 0) {
       for (int i = 0; i < 64; ++i) {
         if (PendingSignals & (1ULL << i)) {
-          tgkill(ThreadData.Thread->State.ThreadManager.PID, ThreadData.Thread->State.ThreadManager.TID, i + 1);
+          tgkill(ThreadData.Thread->ThreadManager.PID, ThreadData.Thread->ThreadManager.TID, i + 1);
           // We might not even return here which is spooky
         }
       }

--- a/Source/Tests/LinuxSyscalls/Syscalls.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls.cpp
@@ -23,7 +23,7 @@
 namespace FEX::HLE {
 SyscallHandler *_SyscallHandler{};
 
-uint64_t SyscallHandler::HandleBRK(FEXCore::Core::InternalThreadState *Thread, void *Addr) {
+uint64_t SyscallHandler::HandleBRK(FEXCore::Core::CpuStateFrame *Frame, void *Addr) {
   std::lock_guard<std::mutex> lk(MMapMutex);
 
   uint64_t Result;
@@ -124,19 +124,19 @@ uint32_t SyscallHandler::CalculateHostKernelVersion() {
   return (Major << 24) | (Minor << 16) | Patch;
 }
 
-uint64_t SyscallHandler::HandleSyscall(FEXCore::Core::InternalThreadState *Thread, FEXCore::HLE::SyscallArguments *Args) {
+uint64_t SyscallHandler::HandleSyscall(FEXCore::Core::CpuStateFrame *Frame, FEXCore::HLE::SyscallArguments *Args) {
   auto &Def = Definitions[Args->Argument[0]];
   uint64_t Result{};
   switch (Def.NumArgs) {
-  case 0: Result = std::invoke(Def.Ptr0, Thread); break;
-  case 1: Result = std::invoke(Def.Ptr1, Thread, Args->Argument[1]); break;
-  case 2: Result = std::invoke(Def.Ptr2, Thread, Args->Argument[1], Args->Argument[2]); break;
-  case 3: Result = std::invoke(Def.Ptr3, Thread, Args->Argument[1], Args->Argument[2], Args->Argument[3]); break;
-  case 4: Result = std::invoke(Def.Ptr4, Thread, Args->Argument[1], Args->Argument[2], Args->Argument[3], Args->Argument[4]); break;
-  case 5: Result = std::invoke(Def.Ptr5, Thread, Args->Argument[1], Args->Argument[2], Args->Argument[3], Args->Argument[4], Args->Argument[5]); break;
-  case 6: Result = std::invoke(Def.Ptr6, Thread, Args->Argument[1], Args->Argument[2], Args->Argument[3], Args->Argument[4], Args->Argument[5], Args->Argument[6]); break;
+  case 0: Result = std::invoke(Def.Ptr0, Frame); break;
+  case 1: Result = std::invoke(Def.Ptr1, Frame, Args->Argument[1]); break;
+  case 2: Result = std::invoke(Def.Ptr2, Frame, Args->Argument[1], Args->Argument[2]); break;
+  case 3: Result = std::invoke(Def.Ptr3, Frame, Args->Argument[1], Args->Argument[2], Args->Argument[3]); break;
+  case 4: Result = std::invoke(Def.Ptr4, Frame, Args->Argument[1], Args->Argument[2], Args->Argument[3], Args->Argument[4]); break;
+  case 5: Result = std::invoke(Def.Ptr5, Frame, Args->Argument[1], Args->Argument[2], Args->Argument[3], Args->Argument[4], Args->Argument[5]); break;
+  case 6: Result = std::invoke(Def.Ptr6, Frame, Args->Argument[1], Args->Argument[2], Args->Argument[3], Args->Argument[4], Args->Argument[5], Args->Argument[6]); break;
   // for missing syscalls
-  case 255: return std::invoke(Def.Ptr1, Thread, Args->Argument[0]);
+  case 255: return std::invoke(Def.Ptr1, Frame, Args->Argument[0]);
   default:
     LogMan::Msg::A("Unhandled syscall: %d", Args->Argument[0]);
     return -1;
@@ -164,12 +164,12 @@ void SyscallHandler::Strace(FEXCore::HLE::SyscallArguments *Args, uint64_t Ret) 
 }
 #endif
 
-uint64_t UnimplementedSyscall(FEXCore::Core::InternalThreadState *Thread, uint64_t SyscallNumber) {
+uint64_t UnimplementedSyscall(FEXCore::Core::CpuStateFrame *Frame, uint64_t SyscallNumber) {
   ERROR_AND_DIE("Unhandled system call: %d", SyscallNumber);
   return -ENOSYS;
 }
 
-uint64_t UnimplementedSyscallSafe(FEXCore::Core::InternalThreadState *Thread, uint64_t SyscallNumber) {
+uint64_t UnimplementedSyscallSafe(FEXCore::Core::CpuStateFrame *Frame, uint64_t SyscallNumber) {
   return -ENOSYS;
 }
 

--- a/Source/Tests/LinuxSyscalls/Syscalls/EPoll.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/EPoll.cpp
@@ -8,12 +8,12 @@
 namespace FEX::HLE {
   void RegisterEpoll() {
 
-    REGISTER_SYSCALL_IMPL(epoll_create, [](FEXCore::Core::InternalThreadState *Thread, int size) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(epoll_create, [](FEXCore::Core::CpuStateFrame *Frame, int size) -> uint64_t {
       uint64_t Result = epoll_create(size);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(epoll_create1, [](FEXCore::Core::InternalThreadState *Thread, int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(epoll_create1, [](FEXCore::Core::CpuStateFrame *Frame, int flags) -> uint64_t {
       uint64_t Result = epoll_create1(flags);
       SYSCALL_ERRNO();
     });

--- a/Source/Tests/LinuxSyscalls/Syscalls/FD.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/FD.cpp
@@ -37,200 +37,200 @@ namespace FEX::HLE {
   }
 
   void RegisterFD(FEX::HLE::SyscallHandler *const Handler) {
-    REGISTER_SYSCALL_IMPL(read, [](FEXCore::Core::InternalThreadState *Thread, int fd, void *buf, size_t count) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(read, [](FEXCore::Core::CpuStateFrame *Frame, int fd, void *buf, size_t count) -> uint64_t {
       uint64_t Result = ::read(fd, buf, count);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(write, [](FEXCore::Core::InternalThreadState *Thread, int fd, void *buf, size_t count) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(write, [](FEXCore::Core::CpuStateFrame *Frame, int fd, void *buf, size_t count) -> uint64_t {
       uint64_t Result = ::write(fd, buf, count);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(open, [](FEXCore::Core::InternalThreadState *Thread, const char *pathname, int flags, uint32_t mode) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(open, [](FEXCore::Core::CpuStateFrame *Frame, const char *pathname, int flags, uint32_t mode) -> uint64_t {
       flags = RemapFlags(flags);
       uint64_t Result = FEX::HLE::_SyscallHandler->FM.Open(pathname, flags, mode);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(close, [](FEXCore::Core::InternalThreadState *Thread, int fd) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(close, [](FEXCore::Core::CpuStateFrame *Frame, int fd) -> uint64_t {
       uint64_t Result = FEX::HLE::_SyscallHandler->FM.Close(fd);
       SYSCALL_ERRNO();
     });
 
     /*
-    REGISTER_SYSCALL_IMPL(chown, [](FEXCore::Core::InternalThreadState *Thread, const char *pathname, uid_t owner, gid_t group) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(chown, [](FEXCore::Core::CpuStateFrame *Frame, const char *pathname, uid_t owner, gid_t group) -> uint64_t {
       SYSCALL_STUB(chown);
     });*/
     REGISTER_SYSCALL_FORWARD_ERRNO(chown);
 
     /*
-    REGISTER_SYSCALL_IMPL(fchown, [](FEXCore::Core::InternalThreadState *Thread, int fd, uid_t owner, gid_t group) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(fchown, [](FEXCore::Core::CpuStateFrame *Frame, int fd, uid_t owner, gid_t group) -> uint64_t {
       SYSCALL_STUB(fchown);
     });*/
     REGISTER_SYSCALL_FORWARD_ERRNO(fchown);
 
     /*
-    REGISTER_SYSCALL_IMPL(lchown, [](FEXCore::Core::InternalThreadState *Thread, const char *pathname, uid_t owner, gid_t group) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(lchown, [](FEXCore::Core::CpuStateFrame *Frame, const char *pathname, uid_t owner, gid_t group) -> uint64_t {
       SYSCALL_STUB(lchown);
     });*/
     REGISTER_SYSCALL_FORWARD_ERRNO(lchown);
 
-    REGISTER_SYSCALL_IMPL(lseek, [](FEXCore::Core::InternalThreadState *Thread, int fd, uint64_t offset, int whence) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(lseek, [](FEXCore::Core::CpuStateFrame *Frame, int fd, uint64_t offset, int whence) -> uint64_t {
       uint64_t Result = ::lseek(fd, offset, whence);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(pread64, [](FEXCore::Core::InternalThreadState *Thread, int fd, void *buf, size_t count, off_t offset) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(pread64, [](FEXCore::Core::CpuStateFrame *Frame, int fd, void *buf, size_t count, off_t offset) -> uint64_t {
       uint64_t Result = ::pread64(fd, buf, count, offset);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(pwrite64, [](FEXCore::Core::InternalThreadState *Thread, int fd, void *buf, size_t count, off_t offset) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(pwrite64, [](FEXCore::Core::CpuStateFrame *Frame, int fd, void *buf, size_t count, off_t offset) -> uint64_t {
       uint64_t Result = ::pwrite64(fd, buf, count, offset);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(access, [](FEXCore::Core::InternalThreadState *Thread, const char *pathname, int mode) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(access, [](FEXCore::Core::CpuStateFrame *Frame, const char *pathname, int mode) -> uint64_t {
       uint64_t Result = FEX::HLE::_SyscallHandler->FM.Access(pathname, mode);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(pipe, [](FEXCore::Core::InternalThreadState *Thread, int pipefd[2]) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(pipe, [](FEXCore::Core::CpuStateFrame *Frame, int pipefd[2]) -> uint64_t {
       uint64_t Result = ::pipe(pipefd);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(dup, [](FEXCore::Core::InternalThreadState *Thread, int oldfd) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(dup, [](FEXCore::Core::CpuStateFrame *Frame, int oldfd) -> uint64_t {
       uint64_t Result = ::dup(oldfd);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(dup2, [](FEXCore::Core::InternalThreadState *Thread, int oldfd, int newfd) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(dup2, [](FEXCore::Core::CpuStateFrame *Frame, int oldfd, int newfd) -> uint64_t {
       uint64_t Result = ::dup2(oldfd, newfd);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(dup3, [](FEXCore::Core::InternalThreadState* Thread, int oldfd, int newfd, int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(dup3, [](FEXCore::Core::CpuStateFrame* Frame, int oldfd, int newfd, int flags) -> uint64_t {
       flags = RemapFlags(flags);
       uint64_t Result = ::dup3(oldfd, newfd, flags);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(flock, [](FEXCore::Core::InternalThreadState *Thread, int fd, int operation) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(flock, [](FEXCore::Core::CpuStateFrame *Frame, int fd, int operation) -> uint64_t {
       uint64_t Result = ::flock(fd, operation);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(fsync, [](FEXCore::Core::InternalThreadState *Thread, int fd) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(fsync, [](FEXCore::Core::CpuStateFrame *Frame, int fd) -> uint64_t {
       uint64_t Result = ::fsync(fd);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(fdatasync, [](FEXCore::Core::InternalThreadState *Thread, int fd) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(fdatasync, [](FEXCore::Core::CpuStateFrame *Frame, int fd) -> uint64_t {
       uint64_t Result = ::fdatasync(fd);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(ftruncate, [](FEXCore::Core::InternalThreadState *Thread, int fd, off_t length) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(ftruncate, [](FEXCore::Core::CpuStateFrame *Frame, int fd, off_t length) -> uint64_t {
       uint64_t Result = ::ftruncate(fd, length);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(fallocate, [](FEXCore::Core::InternalThreadState *Thread, int fd, int mode, off_t offset, off_t len) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(fallocate, [](FEXCore::Core::CpuStateFrame *Frame, int fd, int mode, off_t offset, off_t len) -> uint64_t {
       uint64_t Result = ::fallocate(fd, mode, offset, len);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(fchmod, [](FEXCore::Core::InternalThreadState *Thread, int fd, int mode) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(fchmod, [](FEXCore::Core::CpuStateFrame *Frame, int fd, int mode) -> uint64_t {
       uint64_t Result = ::fchmod(fd, mode);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(readahead, [](FEXCore::Core::InternalThreadState *Thread, int fd, off64_t offset, size_t count) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(readahead, [](FEXCore::Core::CpuStateFrame *Frame, int fd, off64_t offset, size_t count) -> uint64_t {
       uint64_t Result = ::readahead(fd, offset, count);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(fadvise64, [](FEXCore::Core::InternalThreadState *Thread, int fd, off_t offset, off_t len, int advice) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(fadvise64, [](FEXCore::Core::CpuStateFrame *Frame, int fd, off_t offset, off_t len, int advice) -> uint64_t {
       uint64_t Result = ::posix_fadvise64(fd, offset, len, advice);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(inotify_init, [](FEXCore::Core::InternalThreadState *Thread) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(inotify_init, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t {
       uint64_t Result = ::inotify_init();
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(inotify_add_watch, [](FEXCore::Core::InternalThreadState *Thread, int fd, const char *pathname, uint32_t mask) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(inotify_add_watch, [](FEXCore::Core::CpuStateFrame *Frame, int fd, const char *pathname, uint32_t mask) -> uint64_t {
       uint64_t Result = ::inotify_add_watch(fd, pathname, mask);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(inotify_rm_watch, [](FEXCore::Core::InternalThreadState *Thread, int fd, int wd) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(inotify_rm_watch, [](FEXCore::Core::CpuStateFrame *Frame, int fd, int wd) -> uint64_t {
       uint64_t Result = ::inotify_rm_watch(fd, wd);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(openat, [](FEXCore::Core::InternalThreadState *Thread, int dirfs, const char *pathname, int flags, uint32_t mode) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(openat, [](FEXCore::Core::CpuStateFrame *Frame, int dirfs, const char *pathname, int flags, uint32_t mode) -> uint64_t {
       flags = RemapFlags(flags);
       uint64_t Result = FEX::HLE::_SyscallHandler->FM.Openat(dirfs, pathname, flags, mode);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(mkdirat, [](FEXCore::Core::InternalThreadState *Thread, int dirfd, const char *pathname, mode_t mode) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(mkdirat, [](FEXCore::Core::CpuStateFrame *Frame, int dirfd, const char *pathname, mode_t mode) -> uint64_t {
       uint64_t Result = ::mkdirat(dirfd, pathname, mode);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(mknodat, [](FEXCore::Core::InternalThreadState *Thread, int dirfd, const char *pathname, mode_t mode, dev_t dev) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(mknodat, [](FEXCore::Core::CpuStateFrame *Frame, int dirfd, const char *pathname, mode_t mode, dev_t dev) -> uint64_t {
       uint64_t Result = ::mknodat(dirfd, pathname, mode, dev);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(fchownat, [](FEXCore::Core::InternalThreadState *Thread, int dirfd, const char *pathname, uid_t owner, gid_t group, int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(fchownat, [](FEXCore::Core::CpuStateFrame *Frame, int dirfd, const char *pathname, uid_t owner, gid_t group, int flags) -> uint64_t {
       uint64_t Result = ::fchownat(dirfd, pathname, owner, group, flags);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(unlinkat, [](FEXCore::Core::InternalThreadState *Thread, int dirfd, const char *pathname, int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(unlinkat, [](FEXCore::Core::CpuStateFrame *Frame, int dirfd, const char *pathname, int flags) -> uint64_t {
       uint64_t Result = ::unlinkat(dirfd, pathname, flags);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(renameat, [](FEXCore::Core::InternalThreadState *Thread, int olddirfd, const char *oldpath, int newdirfd, const char *newpath) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(renameat, [](FEXCore::Core::CpuStateFrame *Frame, int olddirfd, const char *oldpath, int newdirfd, const char *newpath) -> uint64_t {
       uint64_t Result = ::renameat(olddirfd, oldpath, newdirfd, newpath);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(linkat, [](FEXCore::Core::InternalThreadState *Thread, int olddirfd, const char *oldpath, int newdirfd, const char *newpath, int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(linkat, [](FEXCore::Core::CpuStateFrame *Frame, int olddirfd, const char *oldpath, int newdirfd, const char *newpath, int flags) -> uint64_t {
       uint64_t Result = ::linkat(olddirfd, oldpath, newdirfd, newpath, flags);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(symlinkat, [](FEXCore::Core::InternalThreadState *Thread, const char *target, int newdirfd, const char *linkpath) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(symlinkat, [](FEXCore::Core::CpuStateFrame *Frame, const char *target, int newdirfd, const char *linkpath) -> uint64_t {
       uint64_t Result = ::symlinkat(target, newdirfd, linkpath);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(readlinkat, [](FEXCore::Core::InternalThreadState *Thread, int dirfd, const char *pathname, char *buf, size_t bufsiz) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(readlinkat, [](FEXCore::Core::CpuStateFrame *Frame, int dirfd, const char *pathname, char *buf, size_t bufsiz) -> uint64_t {
       uint64_t Result = FEX::HLE::_SyscallHandler->FM.Readlinkat(dirfd, pathname, buf, bufsiz);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(fchmodat, [](FEXCore::Core::InternalThreadState *Thread, int dirfd, const char *pathname, mode_t mode) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(fchmodat, [](FEXCore::Core::CpuStateFrame *Frame, int dirfd, const char *pathname, mode_t mode) -> uint64_t {
       uint64_t Result = syscall(SYS_fchmodat, dirfd, pathname, mode);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(faccessat, [](FEXCore::Core::InternalThreadState *Thread, int dirfd, const char *pathname, int mode) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(faccessat, [](FEXCore::Core::CpuStateFrame *Frame, int dirfd, const char *pathname, int mode) -> uint64_t {
       uint64_t Result = FEX::HLE::_SyscallHandler->FM.FAccessat(dirfd, pathname, mode);
       SYSCALL_ERRNO();
     });
 
     if (Handler->GetHostKernelVersion() >= FEX::HLE::SyscallHandler::KernelVersion(5, 8, 0)) {
       // Only exists on kernel 5.8+
-      REGISTER_SYSCALL_IMPL(faccessat2, [](FEXCore::Core::InternalThreadState *Thread, int dirfd, const char *pathname, int mode, int flags) -> uint64_t {
+      REGISTER_SYSCALL_IMPL(faccessat2, [](FEXCore::Core::CpuStateFrame *Frame, int dirfd, const char *pathname, int mode, int flags) -> uint64_t {
         uint64_t Result = FEX::HLE::_SyscallHandler->FM.FAccessat2(dirfd, pathname, mode, flags);
         SYSCALL_ERRNO();
       });
@@ -239,86 +239,86 @@ namespace FEX::HLE {
       REGISTER_SYSCALL_IMPL(faccessat2, UnimplementedSyscallSafe);
     }
 
-    REGISTER_SYSCALL_IMPL(splice, [](FEXCore::Core::InternalThreadState *Thread, int fd_in, loff_t *off_in, int fd_out, loff_t *off_out, size_t len, unsigned int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(splice, [](FEXCore::Core::CpuStateFrame *Frame, int fd_in, loff_t *off_in, int fd_out, loff_t *off_out, size_t len, unsigned int flags) -> uint64_t {
       uint64_t Result = ::splice(fd_in, off_in, fd_out, off_out, len, flags);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(tee, [](FEXCore::Core::InternalThreadState *Thread, int fd_in, int fd_out, size_t len, unsigned int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(tee, [](FEXCore::Core::CpuStateFrame *Frame, int fd_in, int fd_out, size_t len, unsigned int flags) -> uint64_t {
       uint64_t Result = ::tee(fd_in, fd_out, len, flags);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(sync_file_range, [](FEXCore::Core::InternalThreadState *Thread, int fd, off64_t offset, off64_t nbytes, unsigned int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(sync_file_range, [](FEXCore::Core::CpuStateFrame *Frame, int fd, off64_t offset, off64_t nbytes, unsigned int flags) -> uint64_t {
       uint64_t Result = ::sync_file_range(fd, offset, nbytes, flags);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(timerfd_create, [](FEXCore::Core::InternalThreadState *Thread, int32_t clockid, int32_t flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(timerfd_create, [](FEXCore::Core::CpuStateFrame *Frame, int32_t clockid, int32_t flags) -> uint64_t {
       uint64_t Result = ::timerfd_create(clockid, flags);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(timerfd_settime, [](FEXCore::Core::InternalThreadState *Thread, int fd, int flags, const struct itimerspec *new_value, struct itimerspec *old_value) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(timerfd_settime, [](FEXCore::Core::CpuStateFrame *Frame, int fd, int flags, const struct itimerspec *new_value, struct itimerspec *old_value) -> uint64_t {
       uint64_t Result = ::timerfd_settime(fd, flags, new_value, old_value);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(timerfd_gettime, [](FEXCore::Core::InternalThreadState *Thread, int fd, struct itimerspec *curr_value) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(timerfd_gettime, [](FEXCore::Core::CpuStateFrame *Frame, int fd, struct itimerspec *curr_value) -> uint64_t {
       uint64_t Result = ::timerfd_gettime(fd, curr_value);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(eventfd, [](FEXCore::Core::InternalThreadState *Thread, uint32_t initval, uint32_t flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(eventfd, [](FEXCore::Core::CpuStateFrame *Frame, uint32_t initval, uint32_t flags) -> uint64_t {
       uint64_t Result = ::eventfd(initval, flags);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(pipe2, [](FEXCore::Core::InternalThreadState *Thread, int pipefd[2], int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(pipe2, [](FEXCore::Core::CpuStateFrame *Frame, int pipefd[2], int flags) -> uint64_t {
       flags = RemapFlags(flags);
       uint64_t Result = ::pipe2(pipefd, flags);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(inotify_init1, [](FEXCore::Core::InternalThreadState *Thread, int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(inotify_init1, [](FEXCore::Core::CpuStateFrame *Frame, int flags) -> uint64_t {
       flags = RemapFlags(flags);
       uint64_t Result = ::inotify_init1(flags);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(renameat2, [](FEXCore::Core::InternalThreadState *Thread, int olddirfd, const char *oldpath, int newdirfd, const char *newpath, unsigned int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(renameat2, [](FEXCore::Core::CpuStateFrame *Frame, int olddirfd, const char *oldpath, int newdirfd, const char *newpath, unsigned int flags) -> uint64_t {
       uint64_t Result = ::renameat2(olddirfd, oldpath, newdirfd, newpath, flags);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(memfd_create, [](FEXCore::Core::InternalThreadState *Thread, const char *name, uint32_t flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(memfd_create, [](FEXCore::Core::CpuStateFrame *Frame, const char *name, uint32_t flags) -> uint64_t {
       uint64_t Result = ::memfd_create(name, flags);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(statx, [](FEXCore::Core::InternalThreadState *Thread, int dirfd, const char *pathname, int flags, uint32_t mask, struct statx *statxbuf) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(statx, [](FEXCore::Core::CpuStateFrame *Frame, int dirfd, const char *pathname, int flags, uint32_t mask, struct statx *statxbuf) -> uint64_t {
       uint64_t Result = FEX::HLE::_SyscallHandler->FM.Statx(dirfd, pathname, flags, mask, statxbuf);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(name_to_handle_at, [](FEXCore::Core::InternalThreadState *Thread, int dirfd, const char *pathname, struct file_handle *handle, int *mount_id, int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(name_to_handle_at, [](FEXCore::Core::CpuStateFrame *Frame, int dirfd, const char *pathname, struct file_handle *handle, int *mount_id, int flags) -> uint64_t {
       flags = RemapFlags(flags);
       uint64_t Result = ::name_to_handle_at(dirfd, pathname, handle, mount_id, flags);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(open_by_handle_at, [](FEXCore::Core::InternalThreadState *Thread, int mount_fd, struct file_handle *handle, int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(open_by_handle_at, [](FEXCore::Core::CpuStateFrame *Frame, int mount_fd, struct file_handle *handle, int flags) -> uint64_t {
       flags = RemapFlags(flags);
       uint64_t Result = ::open_by_handle_at(mount_fd, handle, flags);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(eventfd2, [](FEXCore::Core::InternalThreadState *Thread, unsigned int initval, int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(eventfd2, [](FEXCore::Core::CpuStateFrame *Frame, unsigned int initval, int flags) -> uint64_t {
       uint64_t Result = ::eventfd(initval, flags);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(copy_file_range, [](FEXCore::Core::InternalThreadState *Thread, int fd_in, loff_t *off_in, int fd_out, loff_t *off_out, size_t len, unsigned int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(copy_file_range, [](FEXCore::Core::CpuStateFrame *Frame, int fd_in, loff_t *off_in, int fd_out, loff_t *off_out, size_t len, unsigned int flags) -> uint64_t {
       uint64_t Result = ::copy_file_range(fd_in, off_in, fd_out, off_out, len, flags);
       SYSCALL_ERRNO();
     });

--- a/Source/Tests/LinuxSyscalls/Syscalls/FS.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/FS.cpp
@@ -16,72 +16,72 @@
 
 namespace FEX::HLE {
   void RegisterFS() {
-    REGISTER_SYSCALL_IMPL(getcwd, [](FEXCore::Core::InternalThreadState *Thread, char *buf, size_t size) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(getcwd, [](FEXCore::Core::CpuStateFrame *Frame, char *buf, size_t size) -> uint64_t {
       uint64_t Result = syscall(SYS_getcwd, buf, size);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(chdir, [](FEXCore::Core::InternalThreadState *Thread, const char *path) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(chdir, [](FEXCore::Core::CpuStateFrame *Frame, const char *path) -> uint64_t {
       uint64_t Result = ::chdir(path);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(fchdir, [](FEXCore::Core::InternalThreadState *Thread, int fd) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(fchdir, [](FEXCore::Core::CpuStateFrame *Frame, int fd) -> uint64_t {
       uint64_t Result = ::fchdir(fd);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(rename, [](FEXCore::Core::InternalThreadState *Thread, const char *oldpath, const char *newpath) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(rename, [](FEXCore::Core::CpuStateFrame *Frame, const char *oldpath, const char *newpath) -> uint64_t {
       uint64_t Result = ::rename(oldpath, newpath);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(mkdir, [](FEXCore::Core::InternalThreadState *Thread, const char *pathname, mode_t mode) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(mkdir, [](FEXCore::Core::CpuStateFrame *Frame, const char *pathname, mode_t mode) -> uint64_t {
       uint64_t Result = ::mkdir(pathname, mode);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(rmdir, [](FEXCore::Core::InternalThreadState *Thread, const char *pathname) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(rmdir, [](FEXCore::Core::CpuStateFrame *Frame, const char *pathname) -> uint64_t {
       uint64_t Result = ::rmdir(pathname);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(link, [](FEXCore::Core::InternalThreadState *Thread, const char *oldpath, const char *newpath) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(link, [](FEXCore::Core::CpuStateFrame *Frame, const char *oldpath, const char *newpath) -> uint64_t {
       uint64_t Result = ::link(oldpath, newpath);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(unlink, [](FEXCore::Core::InternalThreadState *Thread, const char *pathname) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(unlink, [](FEXCore::Core::CpuStateFrame *Frame, const char *pathname) -> uint64_t {
       uint64_t Result = ::unlink(pathname);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(symlink, [](FEXCore::Core::InternalThreadState *Thread, const char *target, const char *linkpath) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(symlink, [](FEXCore::Core::CpuStateFrame *Frame, const char *target, const char *linkpath) -> uint64_t {
       uint64_t Result = ::symlink(target, linkpath);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(readlink, [](FEXCore::Core::InternalThreadState *Thread, const char *pathname, char *buf, size_t bufsiz) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(readlink, [](FEXCore::Core::CpuStateFrame *Frame, const char *pathname, char *buf, size_t bufsiz) -> uint64_t {
       uint64_t Result = FEX::HLE::_SyscallHandler->FM.Readlink(pathname, buf, bufsiz);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(chmod, [](FEXCore::Core::InternalThreadState *Thread, const char *pathname, mode_t mode) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(chmod, [](FEXCore::Core::CpuStateFrame *Frame, const char *pathname, mode_t mode) -> uint64_t {
       uint64_t Result = ::chmod(pathname, mode);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(umask, [](FEXCore::Core::InternalThreadState *Thread, mode_t mask) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(umask, [](FEXCore::Core::CpuStateFrame *Frame, mode_t mask) -> uint64_t {
       uint64_t Result = ::umask(mask);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(mknod, [](FEXCore::Core::InternalThreadState *Thread, const char *pathname, mode_t mode, dev_t dev) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(mknod, [](FEXCore::Core::CpuStateFrame *Frame, const char *pathname, mode_t mode, dev_t dev) -> uint64_t {
       uint64_t Result = FEX::HLE::_SyscallHandler->FM.Mknod(pathname, mode, dev);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(ustat, [](FEXCore::Core::InternalThreadState *Thread, dev_t dev, struct ustat *ubuf) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(ustat, [](FEXCore::Core::CpuStateFrame *Frame, dev_t dev, struct ustat *ubuf) -> uint64_t {
       // Since version 2.28 of GLIBC it has stopped providing a wrapper for this syscall
 #ifdef SYS_ustat
       uint64_t Result = syscall(SYS_ustat, dev, ubuf);
@@ -95,7 +95,7 @@ namespace FEX::HLE {
       arg1 is one of: void, unsigned int fs_index, const char *fsname
       arg2 is one of: void, char *buf
     */
-    REGISTER_SYSCALL_IMPL(sysfs, [](FEXCore::Core::InternalThreadState *Thread, int option,  uint64_t arg1,  uint64_t arg2) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(sysfs, [](FEXCore::Core::CpuStateFrame *Frame, int option,  uint64_t arg1,  uint64_t arg2) -> uint64_t {
 #ifdef SYS_sysfs
       uint64_t Result = syscall(SYS_sysfs, option, arg1, arg2);
       SYSCALL_ERRNO();
@@ -104,146 +104,146 @@ namespace FEX::HLE {
 #endif
     });
 
-    REGISTER_SYSCALL_IMPL(statfs, [](FEXCore::Core::InternalThreadState *Thread, const char *path, struct statfs *buf) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(statfs, [](FEXCore::Core::CpuStateFrame *Frame, const char *path, struct statfs *buf) -> uint64_t {
       uint64_t Result = FEX::HLE::_SyscallHandler->FM.Statfs(path, buf);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(fstatfs, [](FEXCore::Core::InternalThreadState *Thread, int fd, struct statfs *buf) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(fstatfs, [](FEXCore::Core::CpuStateFrame *Frame, int fd, struct statfs *buf) -> uint64_t {
       uint64_t Result = ::fstatfs(fd, buf);
       SYSCALL_ERRNO();
     });
 
-    /*REGISTER_SYSCALL_IMPL(truncate, [](FEXCore::Core::InternalThreadState *Thread, const char *path, off_t length) -> uint64_t {
+    /*REGISTER_SYSCALL_IMPL(truncate, [](FEXCore::Core::CpuStateFrame *Frame, const char *path, off_t length) -> uint64_t {
       SYSCALL_STUB(truncate);
     });*/
     REGISTER_SYSCALL_FORWARD_ERRNO(truncate);
 
-    /*REGISTER_SYSCALL_IMPL(creat, [](FEXCore::Core::InternalThreadState *Thread, const char *pathname, mode_t mode) -> uint64_t {
+    /*REGISTER_SYSCALL_IMPL(creat, [](FEXCore::Core::CpuStateFrame *Frame, const char *pathname, mode_t mode) -> uint64_t {
       SYSCALL_STUB(creat);
     });*/
     REGISTER_SYSCALL_FORWARD_ERRNO(creat);
 
-    REGISTER_SYSCALL_IMPL(chroot, [](FEXCore::Core::InternalThreadState *Thread, const char *path) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(chroot, [](FEXCore::Core::CpuStateFrame *Frame, const char *path) -> uint64_t {
       uint64_t Result = ::chroot(path);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(sync, [](FEXCore::Core::InternalThreadState *Thread) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(sync, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t {
       sync();
       return 0; // always successful
     });
 
-    REGISTER_SYSCALL_IMPL(acct, [](FEXCore::Core::InternalThreadState *Thread, const char *filename) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(acct, [](FEXCore::Core::CpuStateFrame *Frame, const char *filename) -> uint64_t {
       uint64_t Result = ::acct(filename);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(mount, [](FEXCore::Core::InternalThreadState *Thread, const char *source, const char *target, const char *filesystemtype, unsigned long mountflags, const void *data) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(mount, [](FEXCore::Core::CpuStateFrame *Frame, const char *source, const char *target, const char *filesystemtype, unsigned long mountflags, const void *data) -> uint64_t {
       uint64_t Result = ::mount(source, target, filesystemtype, mountflags, data);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(umount2, [](FEXCore::Core::InternalThreadState *Thread, const char *target, int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(umount2, [](FEXCore::Core::CpuStateFrame *Frame, const char *target, int flags) -> uint64_t {
       uint64_t Result = ::umount2(target, flags);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(swapon, [](FEXCore::Core::InternalThreadState *Thread, const char *path, int swapflags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(swapon, [](FEXCore::Core::CpuStateFrame *Frame, const char *path, int swapflags) -> uint64_t {
       uint64_t Result = ::swapon(path, swapflags);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(swapoff, [](FEXCore::Core::InternalThreadState *Thread, const char *path) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(swapoff, [](FEXCore::Core::CpuStateFrame *Frame, const char *path) -> uint64_t {
       uint64_t Result = ::swapoff(path);
       SYSCALL_ERRNO();
     });
 
 
     /*
-    REGISTER_SYSCALL_IMPL(syncfs, [](FEXCore::Core::InternalThreadState *Thread, int fd) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(syncfs, [](FEXCore::Core::CpuStateFrame *Frame, int fd) -> uint64_t {
       SYSCALL_STUB(syncfs);
     });*/
     REGISTER_SYSCALL_FORWARD_ERRNO(syncfs);
 
     /*
-    REGISTER_SYSCALL_IMPL(setxattr, [](FEXCore::Core::InternalThreadState *Thread, const char *path, const char *name, const void *value, size_t size, int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(setxattr, [](FEXCore::Core::CpuStateFrame *Frame, const char *path, const char *name, const void *value, size_t size, int flags) -> uint64_t {
       SYSCALL_STUB(setxattr);
     });*/
     REGISTER_SYSCALL_FORWARD_ERRNO(setxattr);
 
     /*
-    REGISTER_SYSCALL_IMPL(lsetxattr, [](FEXCore::Core::InternalThreadState *Thread, const char *path, const char *name, const void *value, size_t size, int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(lsetxattr, [](FEXCore::Core::CpuStateFrame *Frame, const char *path, const char *name, const void *value, size_t size, int flags) -> uint64_t {
       SYSCALL_STUB(lsetxattr);
     });*/
     REGISTER_SYSCALL_FORWARD_ERRNO(lsetxattr);
 
     /*
-    REGISTER_SYSCALL_IMPL(fsetxattr, [](FEXCore::Core::InternalThreadState *Thread, int fd, const char *name, const void *value, size_t size, int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(fsetxattr, [](FEXCore::Core::CpuStateFrame *Frame, int fd, const char *name, const void *value, size_t size, int flags) -> uint64_t {
       SYSCALL_STUB(fsetxattr);
     });*/
     REGISTER_SYSCALL_FORWARD_ERRNO(fsetxattr);
 
     /*
-    REGISTER_SYSCALL_IMPL(getxattr, [](FEXCore::Core::InternalThreadState *Thread, const char *path, const char *name, void *value, size_t size) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(getxattr, [](FEXCore::Core::CpuStateFrame *Frame, const char *path, const char *name, void *value, size_t size) -> uint64_t {
       SYSCALL_STUB(getxattr);
     });*/
     REGISTER_SYSCALL_FORWARD_ERRNO(getxattr);
 
     /*
-    REGISTER_SYSCALL_IMPL(lgetxattr, [](FEXCore::Core::InternalThreadState *Thread, const char *path, const char *name, void *value, size_t size) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(lgetxattr, [](FEXCore::Core::CpuStateFrame *Frame, const char *path, const char *name, void *value, size_t size) -> uint64_t {
       SYSCALL_STUB(lgetxattr);
     });*/
     REGISTER_SYSCALL_FORWARD_ERRNO(lgetxattr);
 
     /*
-    REGISTER_SYSCALL_IMPL(fgetxattr, [](FEXCore::Core::InternalThreadState *Thread, int fd, const char *name, void *value, size_t size) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(fgetxattr, [](FEXCore::Core::CpuStateFrame *Frame, int fd, const char *name, void *value, size_t size) -> uint64_t {
       SYSCALL_STUB(fgetxattr);
     });*/
     REGISTER_SYSCALL_FORWARD_ERRNO(fgetxattr);
 
     /*
-    REGISTER_SYSCALL_IMPL(listxattr, [](FEXCore::Core::InternalThreadState *Thread, const char *path, char *list, size_t size) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(listxattr, [](FEXCore::Core::CpuStateFrame *Frame, const char *path, char *list, size_t size) -> uint64_t {
       SYSCALL_STUB(listxattr);
     });*/
     REGISTER_SYSCALL_FORWARD_ERRNO(listxattr);
 
     /*
-    REGISTER_SYSCALL_IMPL(llistxattr, [](FEXCore::Core::InternalThreadState *Thread, const char *path, char *list, size_t size) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(llistxattr, [](FEXCore::Core::CpuStateFrame *Frame, const char *path, char *list, size_t size) -> uint64_t {
       SYSCALL_STUB(llistxattr);
     });*/
     REGISTER_SYSCALL_FORWARD_ERRNO(llistxattr);
 
     /*
-    REGISTER_SYSCALL_IMPL(flistxattr, [](FEXCore::Core::InternalThreadState *Thread, int fd, char *list, size_t size) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(flistxattr, [](FEXCore::Core::CpuStateFrame *Frame, int fd, char *list, size_t size) -> uint64_t {
       SYSCALL_STUB(flistxattr);
     });*/
     REGISTER_SYSCALL_FORWARD_ERRNO(flistxattr);
 
     /*
-    REGISTER_SYSCALL_IMPL(removexattr, [](FEXCore::Core::InternalThreadState *Thread, const char *path, const char *name) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(removexattr, [](FEXCore::Core::CpuStateFrame *Frame, const char *path, const char *name) -> uint64_t {
       SYSCALL_STUB(removexattr);
     });*/
     REGISTER_SYSCALL_FORWARD_ERRNO(removexattr);
 
     /*
-    REGISTER_SYSCALL_IMPL(lremovexattr, [](FEXCore::Core::InternalThreadState *Thread, const char *path, const char *name) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(lremovexattr, [](FEXCore::Core::CpuStateFrame *Frame, const char *path, const char *name) -> uint64_t {
       SYSCALL_STUB(lremovexattr);
     });*/
     REGISTER_SYSCALL_FORWARD_ERRNO(lremovexattr);
 
     /*
-    REGISTER_SYSCALL_IMPL(fremovexattr, [](FEXCore::Core::InternalThreadState *Thread, int fd, const char *name) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(fremovexattr, [](FEXCore::Core::CpuStateFrame *Frame, int fd, const char *name) -> uint64_t {
       SYSCALL_STUB(fremovexattr);
     });*/
     REGISTER_SYSCALL_FORWARD_ERRNO(fremovexattr);
 
-    REGISTER_SYSCALL_IMPL(fanotify_init, [](FEXCore::Core::InternalThreadState *Thread, unsigned int flags, unsigned int event_f_flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(fanotify_init, [](FEXCore::Core::CpuStateFrame *Frame, unsigned int flags, unsigned int event_f_flags) -> uint64_t {
       uint64_t Result = ::fanotify_init(flags, event_f_flags);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(fanotify_mark, [](FEXCore::Core::InternalThreadState *Thread, int fanotify_fd, unsigned int flags, uint64_t mask, int dirfd, const char *pathname) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(fanotify_mark, [](FEXCore::Core::CpuStateFrame *Frame, int fanotify_fd, unsigned int flags, uint64_t mask, int dirfd, const char *pathname) -> uint64_t {
       uint64_t Result = ::fanotify_mark(fanotify_fd, flags, mask, dirfd, pathname);
       SYSCALL_ERRNO();
     });

--- a/Source/Tests/LinuxSyscalls/Syscalls/IO.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/IO.cpp
@@ -8,42 +8,42 @@
 
 namespace FEX::HLE {
   void RegisterIO() {
-    REGISTER_SYSCALL_IMPL(iopl, [](FEXCore::Core::InternalThreadState *Thread, int level) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(iopl, [](FEXCore::Core::CpuStateFrame *Frame, int level) -> uint64_t {
       // Just claim we don't have permission
       return -EPERM;
     });
 
-    REGISTER_SYSCALL_IMPL(ioperm, [](FEXCore::Core::InternalThreadState *Thread, unsigned long from, unsigned long num, int turn_on) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(ioperm, [](FEXCore::Core::CpuStateFrame *Frame, unsigned long from, unsigned long num, int turn_on) -> uint64_t {
       // ioperm not available on our architecture
       return -EPERM;
     });
 
-    REGISTER_SYSCALL_IMPL(io_setup, [](FEXCore::Core::InternalThreadState *Thread, unsigned nr_events, aio_context_t *ctx_idp) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(io_setup, [](FEXCore::Core::CpuStateFrame *Frame, unsigned nr_events, aio_context_t *ctx_idp) -> uint64_t {
       uint64_t Result = ::syscall(SYS_io_setup, nr_events, ctx_idp);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(io_destroy, [](FEXCore::Core::InternalThreadState *Thread, aio_context_t ctx_id) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(io_destroy, [](FEXCore::Core::CpuStateFrame *Frame, aio_context_t ctx_id) -> uint64_t {
       uint64_t Result = ::syscall(SYS_io_destroy, ctx_id);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(io_submit, [](FEXCore::Core::InternalThreadState *Thread, aio_context_t ctx_id, long nr, struct iocb **iocbpp) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(io_submit, [](FEXCore::Core::CpuStateFrame *Frame, aio_context_t ctx_id, long nr, struct iocb **iocbpp) -> uint64_t {
       uint64_t Result = ::syscall(SYS_io_submit, ctx_id, nr, iocbpp);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(io_cancel, [](FEXCore::Core::InternalThreadState *Thread, aio_context_t ctx_id, struct iocb *iocb, struct io_event *result) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(io_cancel, [](FEXCore::Core::CpuStateFrame *Frame, aio_context_t ctx_id, struct iocb *iocb, struct io_event *result) -> uint64_t {
       uint64_t Result = ::syscall(SYS_io_cancel, ctx_id, iocb, result);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(ioprio_set, [](FEXCore::Core::InternalThreadState *Thread, int which, int who) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(ioprio_set, [](FEXCore::Core::CpuStateFrame *Frame, int which, int who) -> uint64_t {
       uint64_t Result = ::syscall(SYS_ioprio_set, which, who);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(ioprio_get, [](FEXCore::Core::InternalThreadState *Thread, int which, int who, int ioprio) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(ioprio_get, [](FEXCore::Core::CpuStateFrame *Frame, int which, int who, int ioprio) -> uint64_t {
       uint64_t Result = ::syscall(SYS_ioprio_get, which, who, ioprio);
       SYSCALL_ERRNO();
     });

--- a/Source/Tests/LinuxSyscalls/Syscalls/Info.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Info.cpp
@@ -21,7 +21,7 @@
 
 namespace FEX::HLE {
   void RegisterInfo() {
-    REGISTER_SYSCALL_IMPL(uname, [](FEXCore::Core::InternalThreadState *Thread, struct utsname *buf) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(uname, [](FEXCore::Core::CpuStateFrame *Frame, struct utsname *buf) -> uint64_t {
       struct utsname Local{};
       if (::uname(&Local) == 0) {
         memcpy(buf->nodename, Local.nodename, sizeof(Local.nodename));
@@ -40,37 +40,37 @@ namespace FEX::HLE {
       return 0;
     });
 
-    REGISTER_SYSCALL_IMPL(getrlimit, [](FEXCore::Core::InternalThreadState *Thread, int resource, struct rlimit *rlim) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(getrlimit, [](FEXCore::Core::CpuStateFrame *Frame, int resource, struct rlimit *rlim) -> uint64_t {
       uint64_t Result = ::getrlimit(resource, rlim);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(setrlimit, [](FEXCore::Core::InternalThreadState *Thread, int resource, const struct rlimit *rlim) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(setrlimit, [](FEXCore::Core::CpuStateFrame *Frame, int resource, const struct rlimit *rlim) -> uint64_t {
       uint64_t Result = ::setrlimit(resource, rlim);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(syslog, [](FEXCore::Core::InternalThreadState *Thread, int type, char *bufp, int len) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(syslog, [](FEXCore::Core::CpuStateFrame *Frame, int type, char *bufp, int len) -> uint64_t {
       uint64_t Result = ::klogctl(type, bufp, len);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(getrandom, [](FEXCore::Core::InternalThreadState *Thread, void *buf, size_t buflen, unsigned int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(getrandom, [](FEXCore::Core::CpuStateFrame *Frame, void *buf, size_t buflen, unsigned int flags) -> uint64_t {
       uint64_t Result = ::getrandom(buf, buflen, flags);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(capget, [](FEXCore::Core::InternalThreadState *Thread, cap_user_header_t hdrp, cap_user_data_t datap) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(capget, [](FEXCore::Core::CpuStateFrame *Frame, cap_user_header_t hdrp, cap_user_data_t datap) -> uint64_t {
       uint64_t Result = ::capget(hdrp, datap);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(capset, [](FEXCore::Core::InternalThreadState *Thread, cap_user_header_t hdrp, const cap_user_data_t datap) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(capset, [](FEXCore::Core::CpuStateFrame *Frame, cap_user_header_t hdrp, const cap_user_data_t datap) -> uint64_t {
       uint64_t Result = ::capset(hdrp, datap);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(getcpu, [](FEXCore::Core::InternalThreadState *Thread, unsigned *cpu, unsigned *node, struct getcpu_cache *tcache) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(getcpu, [](FEXCore::Core::CpuStateFrame *Frame, unsigned *cpu, unsigned *node, struct getcpu_cache *tcache) -> uint64_t {
       uint32_t LocalCPU{};
       uint32_t LocalNode{};
       // tcache is ignored
@@ -90,12 +90,12 @@ namespace FEX::HLE {
     });
 
     //compare  two  processes  to determine if they share a kernel resource
-    REGISTER_SYSCALL_IMPL(kcmp, [](FEXCore::Core::InternalThreadState *Thread, pid_t pid1, pid_t pid2, int type, unsigned long idx1, unsigned long idx2) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(kcmp, [](FEXCore::Core::CpuStateFrame *Frame, pid_t pid1, pid_t pid2, int type, unsigned long idx1, unsigned long idx2) -> uint64_t {
       uint64_t Result = ::syscall(SYS_kcmp, pid1, pid2, type, idx1, idx2);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(seccomp, [](FEXCore::Core::InternalThreadState *Thread, unsigned int operation, unsigned int flags, void *args) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(seccomp, [](FEXCore::Core::CpuStateFrame *Frame, unsigned int operation, unsigned int flags, void *args) -> uint64_t {
       uint64_t Result = ::syscall(SYS_seccomp, operation, flags, args);
       SYSCALL_ERRNO();
     });

--- a/Source/Tests/LinuxSyscalls/Syscalls/Key.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Key.cpp
@@ -8,34 +8,34 @@
 
 namespace FEX::HLE {
   void RegisterKey() {
-    REGISTER_SYSCALL_IMPL(add_key, [](FEXCore::Core::InternalThreadState *Thread, const char *type, const char *description, const void *payload, size_t plen, int32_t /*key_serial_t*/ keyring) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(add_key, [](FEXCore::Core::CpuStateFrame *Frame, const char *type, const char *description, const void *payload, size_t plen, int32_t /*key_serial_t*/ keyring) -> uint64_t {
       uint64_t Result = syscall(SYS_add_key, type, description, payload, plen, keyring);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(request_key, [](FEXCore::Core::InternalThreadState *Thread, const char *type, const char *description, const char *callout_info, int32_t /*key_serial_t*/ dest_keyring) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(request_key, [](FEXCore::Core::CpuStateFrame *Frame, const char *type, const char *description, const char *callout_info, int32_t /*key_serial_t*/ dest_keyring) -> uint64_t {
       uint64_t Result = syscall(SYS_request_key, type, description, callout_info, dest_keyring);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(keyctl, [](FEXCore::Core::InternalThreadState *Thread, int operation, uint64_t arg2, uint64_t arg3, uint64_t arg4, uint64_t arg5) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(keyctl, [](FEXCore::Core::CpuStateFrame *Frame, int operation, uint64_t arg2, uint64_t arg3, uint64_t arg4, uint64_t arg5) -> uint64_t {
       uint64_t Result = syscall(SYS_keyctl, operation, arg2, arg3, arg4, arg5);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(pkey_mprotect, [](FEXCore::Core::InternalThreadState *Thread, void *addr, size_t len, int prot, int pkey) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(pkey_mprotect, [](FEXCore::Core::CpuStateFrame *Frame, void *addr, size_t len, int prot, int pkey) -> uint64_t {
       // Added in Linux 4.9
       uint64_t Result = ::pkey_mprotect(addr, len, prot, pkey);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(pkey_alloc, [](FEXCore::Core::InternalThreadState *Thread, unsigned int flags, unsigned int access_rights) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(pkey_alloc, [](FEXCore::Core::CpuStateFrame *Frame, unsigned int flags, unsigned int access_rights) -> uint64_t {
       // Added in Linux 4.9
       uint64_t Result = ::pkey_alloc(flags, access_rights);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(pkey_free, [](FEXCore::Core::InternalThreadState *Thread, int pkey) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(pkey_free, [](FEXCore::Core::CpuStateFrame *Frame, int pkey) -> uint64_t {
       // Added in Linux 4.9
       uint64_t Result = ::pkey_free(pkey);
       SYSCALL_ERRNO();

--- a/Source/Tests/LinuxSyscalls/Syscalls/Memory.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Memory.cpp
@@ -11,73 +11,73 @@
 
 namespace FEX::HLE {
   void RegisterMemory() {
-    REGISTER_SYSCALL_IMPL(brk, [](FEXCore::Core::InternalThreadState *Thread, void *addr) -> uint64_t {
-      uint64_t Result = FEX::HLE::_SyscallHandler->HandleBRK(Thread, addr);
+    REGISTER_SYSCALL_IMPL(brk, [](FEXCore::Core::CpuStateFrame *Frame, void *addr) -> uint64_t {
+      uint64_t Result = FEX::HLE::_SyscallHandler->HandleBRK(Frame, addr);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(msync, [](FEXCore::Core::InternalThreadState *Thread, void *addr, size_t length, int32_t flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(msync, [](FEXCore::Core::CpuStateFrame *Frame, void *addr, size_t length, int32_t flags) -> uint64_t {
       uint64_t Result = ::msync(addr, length, flags);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(mincore, [](FEXCore::Core::InternalThreadState *Thread, void *addr, size_t length, uint8_t *vec) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(mincore, [](FEXCore::Core::CpuStateFrame *Frame, void *addr, size_t length, uint8_t *vec) -> uint64_t {
       uint64_t Result = ::mincore(addr, length, vec);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(madvise, [](FEXCore::Core::InternalThreadState *Thread, void *addr, size_t length, int32_t advice) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(madvise, [](FEXCore::Core::CpuStateFrame *Frame, void *addr, size_t length, int32_t advice) -> uint64_t {
       uint64_t Result = ::madvise(addr, length, advice);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(mlock, [](FEXCore::Core::InternalThreadState *Thread, const void *addr, size_t len) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(mlock, [](FEXCore::Core::CpuStateFrame *Frame, const void *addr, size_t len) -> uint64_t {
       uint64_t Result = ::mlock(addr, len);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(munlock, [](FEXCore::Core::InternalThreadState *Thread, const void *addr, size_t len) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(munlock, [](FEXCore::Core::CpuStateFrame *Frame, const void *addr, size_t len) -> uint64_t {
       uint64_t Result = ::munlock(addr, len);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(mlock2, [](FEXCore::Core::InternalThreadState *Thread, const void *addr, size_t len, int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(mlock2, [](FEXCore::Core::CpuStateFrame *Frame, const void *addr, size_t len, int flags) -> uint64_t {
       uint64_t Result = ::mlock2(addr, len, flags);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(remap_file_pages, [](FEXCore::Core::InternalThreadState *Thread, void *addr, size_t size, int prot, size_t pgoff, int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(remap_file_pages, [](FEXCore::Core::CpuStateFrame *Frame, void *addr, size_t size, int prot, size_t pgoff, int flags) -> uint64_t {
       // This syscall is deprecated, not sure when it will end up being removed
       uint64_t Result = ::remap_file_pages(addr, size, prot, pgoff, flags);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(mbind, [](FEXCore::Core::InternalThreadState *Thread, void *addr, unsigned long len, int mode, const unsigned long *nodemask, unsigned long maxnode, unsigned flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(mbind, [](FEXCore::Core::CpuStateFrame *Frame, void *addr, unsigned long len, int mode, const unsigned long *nodemask, unsigned long maxnode, unsigned flags) -> uint64_t {
       uint64_t Result = ::mbind(addr, len, mode, nodemask, maxnode, flags);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(get_mempolicy, [](FEXCore::Core::InternalThreadState *Thread, int *mode, unsigned long *nodemask, unsigned long maxnode, void *addr, unsigned long flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(get_mempolicy, [](FEXCore::Core::CpuStateFrame *Frame, int *mode, unsigned long *nodemask, unsigned long maxnode, void *addr, unsigned long flags) -> uint64_t {
       uint64_t Result = ::get_mempolicy(mode, nodemask, maxnode, addr, flags);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(set_mempolicy, [](FEXCore::Core::InternalThreadState *Thread, int mode, const unsigned long *nodemask, unsigned long maxnode) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(set_mempolicy, [](FEXCore::Core::CpuStateFrame *Frame, int mode, const unsigned long *nodemask, unsigned long maxnode) -> uint64_t {
       uint64_t Result = ::set_mempolicy(mode, nodemask, maxnode);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(migrate_pages, [](FEXCore::Core::InternalThreadState *Thread, int pid, unsigned long maxnode, const unsigned long *old_nodes, const unsigned long *new_nodes) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(migrate_pages, [](FEXCore::Core::CpuStateFrame *Frame, int pid, unsigned long maxnode, const unsigned long *old_nodes, const unsigned long *new_nodes) -> uint64_t {
       uint64_t Result = ::migrate_pages(pid, maxnode, old_nodes, new_nodes);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(move_pages, [](FEXCore::Core::InternalThreadState *Thread, int pid, unsigned long count, void **pages, const int *nodes, int *status, int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(move_pages, [](FEXCore::Core::CpuStateFrame *Frame, int pid, unsigned long count, void **pages, const int *nodes, int *status, int flags) -> uint64_t {
       uint64_t Result = ::move_pages(pid, count, pages, nodes, status, flags);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(membarrier, [](FEXCore::Core::InternalThreadState *Thread, int cmd, int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(membarrier, [](FEXCore::Core::CpuStateFrame *Frame, int cmd, int flags) -> uint64_t {
         uint64_t Result = syscall(SYS_membarrier, cmd, flags);
         SYSCALL_ERRNO();
     });

--- a/Source/Tests/LinuxSyscalls/Syscalls/Msg.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Msg.cpp
@@ -11,43 +11,43 @@
 
 namespace FEX::HLE {
   void RegisterMsg() {
-    REGISTER_SYSCALL_IMPL(msgget, [](FEXCore::Core::InternalThreadState *Thread, key_t key, int msgflg) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(msgget, [](FEXCore::Core::CpuStateFrame *Frame, key_t key, int msgflg) -> uint64_t {
       uint64_t Result = ::msgget(key, msgflg);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(msgsnd, [](FEXCore::Core::InternalThreadState *Thread, int msqid, const void *msgp, size_t msgsz, int msgflg) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(msgsnd, [](FEXCore::Core::CpuStateFrame *Frame, int msqid, const void *msgp, size_t msgsz, int msgflg) -> uint64_t {
       uint64_t Result = ::msgsnd(msqid, msgp, msgsz, msgflg);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(msgrcv, [](FEXCore::Core::InternalThreadState *Thread, int msqid, void *msgp, size_t msgsz, long msgtyp, int msgflg) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(msgrcv, [](FEXCore::Core::CpuStateFrame *Frame, int msqid, void *msgp, size_t msgsz, long msgtyp, int msgflg) -> uint64_t {
       uint64_t Result = ::msgrcv(msqid, msgp, msgsz, msgtyp, msgflg);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(msgctl, [](FEXCore::Core::InternalThreadState *Thread, int msqid, int cmd, struct msqid_ds *buf) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(msgctl, [](FEXCore::Core::CpuStateFrame *Frame, int msqid, int cmd, struct msqid_ds *buf) -> uint64_t {
       uint64_t Result = ::msgctl(msqid, cmd, buf);
       SYSCALL_ERRNO();
     });
 
     // last two parameters are optional
-    REGISTER_SYSCALL_IMPL(mq_open, [](FEXCore::Core::InternalThreadState *Thread, const char *name, int oflag, mode_t mode, struct mq_attr *attr) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(mq_open, [](FEXCore::Core::CpuStateFrame *Frame, const char *name, int oflag, mode_t mode, struct mq_attr *attr) -> uint64_t {
       uint64_t Result = ::mq_open(name, oflag, mode, attr);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(mq_unlink, [](FEXCore::Core::InternalThreadState *Thread, const char *name) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(mq_unlink, [](FEXCore::Core::CpuStateFrame *Frame, const char *name) -> uint64_t {
       uint64_t Result = ::mq_unlink(name);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(mq_notify, [](FEXCore::Core::InternalThreadState *Thread, mqd_t mqdes, const struct sigevent *sevp) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(mq_notify, [](FEXCore::Core::CpuStateFrame *Frame, mqd_t mqdes, const struct sigevent *sevp) -> uint64_t {
       uint64_t Result = ::mq_notify(mqdes, sevp);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(mq_getsetattr, [](FEXCore::Core::InternalThreadState *Thread, mqd_t mqdes, struct mq_attr *newattr, struct mq_attr *oldattr) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(mq_getsetattr, [](FEXCore::Core::CpuStateFrame *Frame, mqd_t mqdes, struct mq_attr *newattr, struct mq_attr *oldattr) -> uint64_t {
       uint64_t Result = ::syscall(SYS_mq_getsetattr, mqdes, newattr, oldattr);
       SYSCALL_ERRNO();
     });

--- a/Source/Tests/LinuxSyscalls/Syscalls/NotImplemented.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/NotImplemented.cpp
@@ -6,16 +6,16 @@
 #include <stdint.h>
 #include <sys/epoll.h>
 
-#define REGISTER_SYSCALL_NOT_IMPL(name) REGISTER_SYSCALL_IMPL(name, [](FEXCore::Core::InternalThreadState *Thread) -> uint64_t { \
+#define REGISTER_SYSCALL_NOT_IMPL(name) REGISTER_SYSCALL_IMPL(name, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t { \
   LogMan::Msg::D("Using deprecated/removed syscall: " #name); \
   return -ENOSYS; \
 });
 
-#define REGISTER_SYSCALL_NO_PERM(name) REGISTER_SYSCALL_IMPL(name, [](FEXCore::Core::InternalThreadState *Thread) -> uint64_t { \
+#define REGISTER_SYSCALL_NO_PERM(name) REGISTER_SYSCALL_IMPL(name, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t { \
   return -EPERM; \
 });
 
-#define REGISTER_SYSCALL_NO_ACCESS(name) REGISTER_SYSCALL_IMPL(name, [](FEXCore::Core::InternalThreadState *Thread) -> uint64_t { \
+#define REGISTER_SYSCALL_NO_ACCESS(name) REGISTER_SYSCALL_IMPL(name, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t { \
   return -EACCES; \
 });
 

--- a/Source/Tests/LinuxSyscalls/Syscalls/SHM.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/SHM.cpp
@@ -8,17 +8,17 @@
 
 namespace FEX::HLE {
   void RegisterSHM() {
-    REGISTER_SYSCALL_IMPL(shmget, [](FEXCore::Core::InternalThreadState *Thread, key_t key, size_t size, int shmflg) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(shmget, [](FEXCore::Core::CpuStateFrame *Frame, key_t key, size_t size, int shmflg) -> uint64_t {
       uint64_t Result = shmget(key, size, shmflg);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(shmctl, [](FEXCore::Core::InternalThreadState *Thread, int shmid, int cmd, struct shmid_ds *buf) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(shmctl, [](FEXCore::Core::CpuStateFrame *Frame, int shmid, int cmd, struct shmid_ds *buf) -> uint64_t {
       uint64_t Result = ::shmctl(shmid, cmd, buf);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(shmdt, [](FEXCore::Core::InternalThreadState *Thread, const void *shmaddr) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(shmdt, [](FEXCore::Core::CpuStateFrame *Frame, const void *shmaddr) -> uint64_t {
       uint64_t Result = ::shmdt(shmaddr);
       SYSCALL_ERRNO();
     });

--- a/Source/Tests/LinuxSyscalls/Syscalls/Sched.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Sched.cpp
@@ -12,56 +12,56 @@
 namespace FEX::HLE {
   void RegisterSched() {
 
-    REGISTER_SYSCALL_IMPL(sched_yield, [](FEXCore::Core::InternalThreadState *Thread) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(sched_yield, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t {
       uint64_t Result = ::sched_yield();
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(getpriority, [](FEXCore::Core::InternalThreadState *Thread, int which, int who) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(getpriority, [](FEXCore::Core::CpuStateFrame *Frame, int which, int who) -> uint64_t {
       uint64_t Result = ::syscall(SYS_getpriority, which, who);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(setpriority, [](FEXCore::Core::InternalThreadState *Thread, int which, int who, int prio) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(setpriority, [](FEXCore::Core::CpuStateFrame *Frame, int which, int who, int prio) -> uint64_t {
       uint64_t Result = ::setpriority(which, who, prio);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(sched_setparam, [](FEXCore::Core::InternalThreadState *Thread, pid_t pid, const struct sched_param *param) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(sched_setparam, [](FEXCore::Core::CpuStateFrame *Frame, pid_t pid, const struct sched_param *param) -> uint64_t {
       uint64_t Result = ::sched_setparam(pid, param);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(sched_getparam, [](FEXCore::Core::InternalThreadState *Thread, pid_t pid, struct sched_param *param) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(sched_getparam, [](FEXCore::Core::CpuStateFrame *Frame, pid_t pid, struct sched_param *param) -> uint64_t {
       uint64_t Result = ::sched_getparam(pid, param);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(sched_setscheduler, [](FEXCore::Core::InternalThreadState *Thread, pid_t pid, int policy, const struct sched_param *param) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(sched_setscheduler, [](FEXCore::Core::CpuStateFrame *Frame, pid_t pid, int policy, const struct sched_param *param) -> uint64_t {
       uint64_t Result = ::sched_setscheduler(pid, policy, param);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(sched_getscheduler, [](FEXCore::Core::InternalThreadState *Thread, pid_t pid) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(sched_getscheduler, [](FEXCore::Core::CpuStateFrame *Frame, pid_t pid) -> uint64_t {
       uint64_t Result = ::sched_getscheduler(pid);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(sched_get_priority_max, [](FEXCore::Core::InternalThreadState *Thread, int policy) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(sched_get_priority_max, [](FEXCore::Core::CpuStateFrame *Frame, int policy) -> uint64_t {
       uint64_t Result = ::sched_get_priority_max(policy);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(sched_get_priority_min, [](FEXCore::Core::InternalThreadState *Thread, int policy) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(sched_get_priority_min, [](FEXCore::Core::CpuStateFrame *Frame, int policy) -> uint64_t {
       uint64_t Result = ::sched_get_priority_min(policy);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(sched_setaffinity, [](FEXCore::Core::InternalThreadState *Thread, pid_t pid, size_t cpusetsize, const unsigned long *mask) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(sched_setaffinity, [](FEXCore::Core::CpuStateFrame *Frame, pid_t pid, size_t cpusetsize, const unsigned long *mask) -> uint64_t {
       return 0;
     });
 
-    REGISTER_SYSCALL_IMPL(sched_getaffinity, [](FEXCore::Core::InternalThreadState *Thread, pid_t pid, size_t cpusetsize, unsigned char *mask) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(sched_getaffinity, [](FEXCore::Core::CpuStateFrame *Frame, pid_t pid, size_t cpusetsize, unsigned char *mask) -> uint64_t {
       uint64_t Cores = FEX::HLE::_SyscallHandler->ThreadsConfig();
       uint64_t Bytes = ((Cores+7) / 8);
       // If we don't have at least one byte in the resulting structure
@@ -80,12 +80,12 @@ namespace FEX::HLE {
       return Bytes;
     });
 
-    REGISTER_SYSCALL_IMPL(sched_setattr, [](FEXCore::Core::InternalThreadState *Thread, pid_t pid, struct sched_attr *attr, unsigned int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(sched_setattr, [](FEXCore::Core::CpuStateFrame *Frame, pid_t pid, struct sched_attr *attr, unsigned int flags) -> uint64_t {
       uint64_t Result = ::syscall(SYS_sched_setattr, pid, attr, flags);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(sched_getattr, [](FEXCore::Core::InternalThreadState *Thread, pid_t pid, struct sched_attr *attr, unsigned int size, unsigned int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(sched_getattr, [](FEXCore::Core::CpuStateFrame *Frame, pid_t pid, struct sched_attr *attr, unsigned int size, unsigned int flags) -> uint64_t {
       uint64_t Result = ::syscall(SYS_sched_getattr, pid, attr, size, flags);
       SYSCALL_ERRNO();
     });

--- a/Source/Tests/LinuxSyscalls/Syscalls/Semaphore.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Semaphore.cpp
@@ -8,12 +8,12 @@
 
 namespace FEX::HLE {
   void RegisterSemaphore() {
-    REGISTER_SYSCALL_IMPL(semget, [](FEXCore::Core::InternalThreadState *Thread, key_t key, int nsems, int semflg) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(semget, [](FEXCore::Core::CpuStateFrame *Frame, key_t key, int nsems, int semflg) -> uint64_t {
       uint64_t Result = ::semget(key, nsems, semflg);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(semctl, [](FEXCore::Core::InternalThreadState *Thread, int semid, int semnum, int cmd, void* semun) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(semctl, [](FEXCore::Core::CpuStateFrame *Frame, int semid, int semnum, int cmd, void* semun) -> uint64_t {
       uint64_t Result = ::semctl(semid, semnum, cmd, semun);
       SYSCALL_ERRNO();
     });

--- a/Source/Tests/LinuxSyscalls/Syscalls/Signals.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Signals.cpp
@@ -16,19 +16,19 @@ namespace SignalDelegator {
 
 namespace FEX::HLE {
   void RegisterSignals() {
-    REGISTER_SYSCALL_IMPL(rt_sigprocmask, [](FEXCore::Core::InternalThreadState *Thread, int how, const uint64_t *set, uint64_t *oldset) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(rt_sigprocmask, [](FEXCore::Core::CpuStateFrame *Frame, int how, const uint64_t *set, uint64_t *oldset) -> uint64_t {
       return FEX::HLE::_SyscallHandler->GetSignalDelegator()->GuestSigProcMask(how, set, oldset);
     });
 
-    REGISTER_SYSCALL_IMPL(rt_sigpending, [](FEXCore::Core::InternalThreadState *Thread, uint64_t *set, size_t sigsetsize) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(rt_sigpending, [](FEXCore::Core::CpuStateFrame *Frame, uint64_t *set, size_t sigsetsize) -> uint64_t {
       return FEX::HLE::_SyscallHandler->GetSignalDelegator()->GuestSigPending(set, sigsetsize);
     });
 
-    REGISTER_SYSCALL_IMPL(rt_sigsuspend, [](FEXCore::Core::InternalThreadState *Thread, uint64_t *unewset, size_t sigsetsize) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(rt_sigsuspend, [](FEXCore::Core::CpuStateFrame *Frame, uint64_t *unewset, size_t sigsetsize) -> uint64_t {
       return FEX::HLE::_SyscallHandler->GetSignalDelegator()->GuestSigSuspend(unewset, sigsetsize);
     });
 
-    REGISTER_SYSCALL_IMPL(userfaultfd, [](FEXCore::Core::InternalThreadState *Thread, int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(userfaultfd, [](FEXCore::Core::CpuStateFrame *Frame, int flags) -> uint64_t {
       uint64_t Result = ::syscall(SYS_userfaultfd, flags);
       SYSCALL_ERRNO();
     });

--- a/Source/Tests/LinuxSyscalls/Syscalls/Socket.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Socket.cpp
@@ -9,77 +9,77 @@
 namespace FEX::HLE {
   void RegisterSocket() {
 
-    REGISTER_SYSCALL_IMPL(socket, [](FEXCore::Core::InternalThreadState *Thread, int domain, int type, int protocol) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(socket, [](FEXCore::Core::CpuStateFrame *Frame, int domain, int type, int protocol) -> uint64_t {
       uint64_t Result = ::socket(domain, type, protocol);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(connect, [](FEXCore::Core::InternalThreadState *Thread, int sockfd, const struct sockaddr *addr, socklen_t addrlen) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(connect, [](FEXCore::Core::CpuStateFrame *Frame, int sockfd, const struct sockaddr *addr, socklen_t addrlen) -> uint64_t {
       uint64_t Result = ::connect(sockfd, addr, addrlen);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(accept4, [](FEXCore::Core::InternalThreadState *Thread, int sockfd, struct sockaddr *addr, socklen_t *addrlen, int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(accept4, [](FEXCore::Core::CpuStateFrame *Frame, int sockfd, struct sockaddr *addr, socklen_t *addrlen, int flags) -> uint64_t {
       uint64_t Result = ::accept4(sockfd, addr, addrlen, flags);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(sendto, [](FEXCore::Core::InternalThreadState *Thread, int sockfd, const void *buf, size_t len, int flags, const struct sockaddr *dest_addr, socklen_t addrlen) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(sendto, [](FEXCore::Core::CpuStateFrame *Frame, int sockfd, const void *buf, size_t len, int flags, const struct sockaddr *dest_addr, socklen_t addrlen) -> uint64_t {
       uint64_t Result = ::sendto(sockfd, buf, len, flags, dest_addr, addrlen);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(recvfrom, [](FEXCore::Core::InternalThreadState *Thread, int sockfd, void *buf, size_t len, int flags, struct sockaddr *src_addr, socklen_t *addrlen) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(recvfrom, [](FEXCore::Core::CpuStateFrame *Frame, int sockfd, void *buf, size_t len, int flags, struct sockaddr *src_addr, socklen_t *addrlen) -> uint64_t {
       uint64_t Result = ::recvfrom(sockfd, buf, len, flags, src_addr, addrlen);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(sendmsg, [](FEXCore::Core::InternalThreadState *Thread, int sockfd, const struct msghdr *msg, int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(sendmsg, [](FEXCore::Core::CpuStateFrame *Frame, int sockfd, const struct msghdr *msg, int flags) -> uint64_t {
       uint64_t Result = ::sendmsg(sockfd, msg, flags);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(recvmsg, [](FEXCore::Core::InternalThreadState *Thread, int sockfd, struct msghdr *msg, int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(recvmsg, [](FEXCore::Core::CpuStateFrame *Frame, int sockfd, struct msghdr *msg, int flags) -> uint64_t {
       uint64_t Result = ::recvmsg(sockfd, msg, flags);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(shutdown, [](FEXCore::Core::InternalThreadState *Thread, int sockfd, int how) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(shutdown, [](FEXCore::Core::CpuStateFrame *Frame, int sockfd, int how) -> uint64_t {
       uint64_t Result = ::shutdown(sockfd, how);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(bind, [](FEXCore::Core::InternalThreadState *Thread, int sockfd, const struct sockaddr *addr, socklen_t addrlen) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(bind, [](FEXCore::Core::CpuStateFrame *Frame, int sockfd, const struct sockaddr *addr, socklen_t addrlen) -> uint64_t {
       uint64_t Result = ::bind(sockfd, addr, addrlen);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(listen, [](FEXCore::Core::InternalThreadState *Thread, int sockfd, int backlog) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(listen, [](FEXCore::Core::CpuStateFrame *Frame, int sockfd, int backlog) -> uint64_t {
       uint64_t Result = ::listen(sockfd, backlog);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(getsockname, [](FEXCore::Core::InternalThreadState *Thread, int sockfd, struct sockaddr *addr, socklen_t *addrlen) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(getsockname, [](FEXCore::Core::CpuStateFrame *Frame, int sockfd, struct sockaddr *addr, socklen_t *addrlen) -> uint64_t {
       uint64_t Result = ::getsockname(sockfd, addr, addrlen);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(getpeername, [](FEXCore::Core::InternalThreadState *Thread, int sockfd, struct sockaddr *addr, socklen_t *addrlen) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(getpeername, [](FEXCore::Core::CpuStateFrame *Frame, int sockfd, struct sockaddr *addr, socklen_t *addrlen) -> uint64_t {
       uint64_t Result = ::getpeername(sockfd, addr, addrlen);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(socketpair, [](FEXCore::Core::InternalThreadState *Thread, int domain, int type, int protocol, int sv[2]) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(socketpair, [](FEXCore::Core::CpuStateFrame *Frame, int domain, int type, int protocol, int sv[2]) -> uint64_t {
       uint64_t Result = ::socketpair(domain, type, protocol, sv);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(setsockopt, [](FEXCore::Core::InternalThreadState *Thread, int sockfd, int level, int optname, const void *optval, socklen_t optlen) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(setsockopt, [](FEXCore::Core::CpuStateFrame *Frame, int sockfd, int level, int optname, const void *optval, socklen_t optlen) -> uint64_t {
       uint64_t Result = ::setsockopt(sockfd, level, optname, optval, optlen);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(getsockopt, [](FEXCore::Core::InternalThreadState *Thread, int sockfd, int level, int optname, void *optval, socklen_t *optlen) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(getsockopt, [](FEXCore::Core::CpuStateFrame *Frame, int sockfd, int level, int optname, void *optval, socklen_t *optlen) -> uint64_t {
       uint64_t Result = ::getsockopt(sockfd, level, optname, optval, optlen);
       SYSCALL_ERRNO();
     });

--- a/Source/Tests/LinuxSyscalls/Syscalls/Stubs.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Stubs.cpp
@@ -26,48 +26,48 @@
 namespace FEX::HLE {
   void RegisterStubs() {
 
-    REGISTER_SYSCALL_IMPL(rt_sigreturn, [](FEXCore::Core::InternalThreadState *Thread) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(rt_sigreturn, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t {
       SYSCALL_STUB(rt_sigreturn);
     });
 
-    REGISTER_SYSCALL_IMPL(ptrace, [](FEXCore::Core::InternalThreadState *Thread, int /*enum __ptrace_request*/ request, pid_t pid, void *addr, void *data) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(ptrace, [](FEXCore::Core::CpuStateFrame *Frame, int /*enum __ptrace_request*/ request, pid_t pid, void *addr, void *data) -> uint64_t {
       SYSCALL_STUB(ptrace);
     });
 
-    REGISTER_SYSCALL_IMPL(rt_sigtimedwait, [](FEXCore::Core::InternalThreadState *Thread, sigset_t *set, const struct timespec*, size_t sigsetsize) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(rt_sigtimedwait, [](FEXCore::Core::CpuStateFrame *Frame, sigset_t *set, const struct timespec*, size_t sigsetsize) -> uint64_t {
       SYSCALL_STUB(rt_sigtimedwait);
     });
 
-    REGISTER_SYSCALL_IMPL(rt_sigqueueinfo, [](FEXCore::Core::InternalThreadState *Thread, pid_t pid, int sig, siginfo_t *uinfo) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(rt_sigqueueinfo, [](FEXCore::Core::CpuStateFrame *Frame, pid_t pid, int sig, siginfo_t *uinfo) -> uint64_t {
       SYSCALL_STUB(rt_sigqueueinfo);
     });
 
-    REGISTER_SYSCALL_IMPL(modify_ldt, [](FEXCore::Core::InternalThreadState *Thread, int func, void *ptr, unsigned long bytecount) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(modify_ldt, [](FEXCore::Core::CpuStateFrame *Frame, int func, void *ptr, unsigned long bytecount) -> uint64_t {
       SYSCALL_STUB(modify_ldt);
     });
 
-    REGISTER_SYSCALL_IMPL(restart_syscall, [](FEXCore::Core::InternalThreadState *Thread) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(restart_syscall, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t {
       SYSCALL_STUB(restart_syscall);
     });
 
-    REGISTER_SYSCALL_IMPL(signalfd, [](FEXCore::Core::InternalThreadState *Thread, int fd, const sigset_t *mask, size_t sizemask) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(signalfd, [](FEXCore::Core::CpuStateFrame *Frame, int fd, const sigset_t *mask, size_t sizemask) -> uint64_t {
       SYSCALL_STUB(signalfd);
     });
 
-    REGISTER_SYSCALL_IMPL(signalfd4, [](FEXCore::Core::InternalThreadState *Thread, int fd, const sigset_t *mask, size_t sizemask, int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(signalfd4, [](FEXCore::Core::CpuStateFrame *Frame, int fd, const sigset_t *mask, size_t sizemask, int flags) -> uint64_t {
       SYSCALL_STUB(signalfd4);
     });
 
-    REGISTER_SYSCALL_IMPL(rt_tgsigqueueinfo, [](FEXCore::Core::InternalThreadState *Thread, pid_t tgid, pid_t tid, int sig, siginfo_t *info) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(rt_tgsigqueueinfo, [](FEXCore::Core::CpuStateFrame *Frame, pid_t tgid, pid_t tid, int sig, siginfo_t *info) -> uint64_t {
       SYSCALL_STUB(rt_tgsigqueueinfo);
     });
 
     // execute program relative to a directory file descriptor
-    REGISTER_SYSCALL_IMPL(execveat, [](FEXCore::Core::InternalThreadState *Thread, int dirfd, const char *pathname, char *const argv[], char *const envp[], int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(execveat, [](FEXCore::Core::CpuStateFrame *Frame, int dirfd, const char *pathname, char *const argv[], char *const envp[], int flags) -> uint64_t {
       SYSCALL_STUB(execveat);
     });
 
-    REGISTER_SYSCALL_IMPL(rseq, [](FEXCore::Core::InternalThreadState *Thread,  struct rseq  *rseq, uint32_t rseq_len, int flags, uint32_t sig) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(rseq, [](FEXCore::Core::CpuStateFrame *Frame,  struct rseq  *rseq, uint32_t rseq_len, int flags, uint32_t sig) -> uint64_t {
       SYSCALL_STUB(rseq);
     });
   }

--- a/Source/Tests/LinuxSyscalls/Syscalls/Thread.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Thread.cpp
@@ -27,29 +27,29 @@
 ARG_TO_STR(idtype_t, "%u")
 
 namespace FEX::HLE {
-  FEXCore::Core::InternalThreadState *CreateNewThread(FEXCore::Core::InternalThreadState *Thread, uint32_t flags, void *stack, pid_t *parent_tid, pid_t *child_tid, void *tls) {
+  FEXCore::Core::InternalThreadState *CreateNewThread(FEXCore::Context:: Context *CTX, FEXCore::Core::CpuStateFrame *Frame, uint32_t flags, void *stack, pid_t *parent_tid, pid_t *child_tid, void *tls) {
     FEXCore::Core::CPUState NewThreadState{};
     // Clone copies the parent thread's state
-    memcpy(&NewThreadState, Thread->CurrentFrame, sizeof(FEXCore::Core::CPUState));
+    memcpy(&NewThreadState, Frame, sizeof(FEXCore::Core::CPUState));
 
     NewThreadState.gregs[FEXCore::X86State::REG_RAX] = 0;
     NewThreadState.gregs[FEXCore::X86State::REG_RBX] = 0;
     NewThreadState.gregs[FEXCore::X86State::REG_RBP] = 0;
     NewThreadState.gregs[FEXCore::X86State::REG_RSP] = reinterpret_cast<uint64_t>(stack);
 
-    auto NewThread = FEXCore::Context::CreateThread(Thread->CTX, &NewThreadState, reinterpret_cast<uint64_t>(parent_tid));
-    FEXCore::Context::InitializeThread(Thread->CTX, NewThread);
+    auto NewThread = FEXCore::Context::CreateThread(CTX, &NewThreadState, reinterpret_cast<uint64_t>(parent_tid));
+    FEXCore::Context::InitializeThread(CTX, NewThread);
 
     if (FEX::HLE::_SyscallHandler->Is64BitMode()) {
       if (flags & CLONE_SETTLS) {
-        x64::SetThreadArea(NewThread, tls);
+        x64::SetThreadArea(NewThread->CurrentFrame, tls);
       }
       // Set us to start just after the syscall instruction
       x64::AdjustRipForNewThread(NewThread->CurrentFrame);
     }
     else {
       if (flags & CLONE_SETTLS) {
-        x32::SetThreadArea(NewThread, tls);
+        x32::SetThreadArea(NewThread->CurrentFrame, tls);
       }
       x32::AdjustRipForNewThread(NewThread->CurrentFrame);
     }
@@ -78,7 +78,7 @@ namespace FEX::HLE {
     return NewThread;
   }
 
-  uint64_t ForkGuest(FEXCore::Core::InternalThreadState *Thread, uint32_t flags, void *stack, pid_t *parent_tid, pid_t *child_tid, void *tls) {
+  uint64_t ForkGuest(FEXCore::Core::InternalThreadState *Thread, FEXCore::Core::CpuStateFrame *Frame, uint32_t flags, void *stack, pid_t *parent_tid, pid_t *child_tid, void *tls) {
     pid_t Result = fork();
 
     if (Result == 0) {
@@ -89,7 +89,7 @@ namespace FEX::HLE {
       Thread->ThreadManager.clear_child_tid = nullptr;
 
       // Clear all the other threads that are being tracked
-      FEXCore::Context::DeleteForkedThreads(Thread->CTX, Thread);
+      FEXCore::Context::DeleteForkedThreads(Thread->CTX, Frame->Thread);
 
       // only a  single thread running so no need to remove anything from the thread array
 
@@ -97,7 +97,7 @@ namespace FEX::HLE {
       if (stack != nullptr) {
         // use specified stack
         LogMan::Msg::D("@@@@@@@ Fork uses custom stack");
-        Thread->CurrentFrame->State.gregs[FEXCore::X86State::REG_RSP] = reinterpret_cast<uint64_t>(stack);
+        Frame->State.gregs[FEXCore::X86State::REG_RSP] = reinterpret_cast<uint64_t>(stack);
       } else {
         // In the case of fork and nullptr stack then the child uses the same stack space as the parent
         // Same virtual address, different addressspace
@@ -106,13 +106,13 @@ namespace FEX::HLE {
 
       if (FEX::HLE::_SyscallHandler->Is64BitMode()) {
         if (flags & CLONE_SETTLS) {
-          x64::SetThreadArea(Thread, tls);
+          x64::SetThreadArea(Frame, tls);
         }
       }
       else {
         // 32bit TLS doesn't just set the fs register
         if (flags & CLONE_SETTLS) {
-          x32::SetThreadArea(Thread, tls);
+          x32::SetThreadArea(Frame, tls);
         }
       }
 
@@ -143,20 +143,21 @@ namespace FEX::HLE {
   }
 
   void RegisterThread() {
-    REGISTER_SYSCALL_IMPL(getpid, [](FEXCore::Core::InternalThreadState *Thread) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(getpid, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t {
       uint64_t Result = ::getpid();
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(fork, [](FEXCore::Core::InternalThreadState *Thread) -> uint64_t {
-      return ForkGuest(Thread, 0, 0, 0, 0, 0);
+    REGISTER_SYSCALL_IMPL(fork, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t {
+      return ForkGuest(Frame->Thread, Frame, 0, 0, 0, 0, 0);
     });
 
-    REGISTER_SYSCALL_IMPL(vfork, [](FEXCore::Core::InternalThreadState *Thread) -> uint64_t {
-      return ForkGuest(Thread, 0, 0, 0, 0, 0);
+    REGISTER_SYSCALL_IMPL(vfork, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t {
+      return ForkGuest(Frame->Thread, Frame, 0, 0, 0, 0, 0);
     });
 
-    REGISTER_SYSCALL_IMPL(exit, [](FEXCore::Core::InternalThreadState *Thread, int status) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(exit, [](FEXCore::Core::CpuStateFrame *Frame, int status) -> uint64_t {
+      auto Thread = Frame->Thread;
       if (Thread->ThreadManager.clear_child_tid) {
         std::atomic<uint32_t> *Addr = reinterpret_cast<std::atomic<uint32_t>*>(Thread->ThreadManager.clear_child_tid);
         Addr->store(0);
@@ -175,133 +176,133 @@ namespace FEX::HLE {
       return 0;
     });
 
-    REGISTER_SYSCALL_IMPL(kill, [](FEXCore::Core::InternalThreadState *Thread, pid_t pid, int sig) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(kill, [](FEXCore::Core::CpuStateFrame *Frame, pid_t pid, int sig) -> uint64_t {
       uint64_t Result = ::kill(pid, sig);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(tkill, [](FEXCore::Core::InternalThreadState *Thread, int tid, int sig) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(tkill, [](FEXCore::Core::CpuStateFrame *Frame, int tid, int sig) -> uint64_t {
       uint64_t Result = ::tgkill(-1, tid, sig);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(tgkill, [](FEXCore::Core::InternalThreadState *Thread, int tgid, int tid, int sig) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(tgkill, [](FEXCore::Core::CpuStateFrame *Frame, int tgid, int tid, int sig) -> uint64_t {
       uint64_t Result = ::tgkill(tgid, tid, sig);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(getuid, [](FEXCore::Core::InternalThreadState *Thread) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(getuid, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t {
       uint64_t Result = ::getuid();
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(getgid, [](FEXCore::Core::InternalThreadState *Thread) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(getgid, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t {
       uint64_t Result = ::getgid();
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(setuid, [](FEXCore::Core::InternalThreadState *Thread, uid_t uid) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(setuid, [](FEXCore::Core::CpuStateFrame *Frame, uid_t uid) -> uint64_t {
       uint64_t Result = ::setuid(uid);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(setgid, [](FEXCore::Core::InternalThreadState *Thread, gid_t gid) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(setgid, [](FEXCore::Core::CpuStateFrame *Frame, gid_t gid) -> uint64_t {
       uint64_t Result = ::setgid(gid);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(geteuid, [](FEXCore::Core::InternalThreadState *Thread) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(geteuid, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t {
       uint64_t Result = ::geteuid();
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(getegid, [](FEXCore::Core::InternalThreadState *Thread) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(getegid, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t {
       uint64_t Result = ::getegid();
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(getppid, [](FEXCore::Core::InternalThreadState *Thread) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(getppid, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t {
       uint64_t Result = ::getppid();
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(getpgrp, [](FEXCore::Core::InternalThreadState *Thread) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(getpgrp, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t {
       uint64_t Result = ::getpgrp();
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(setsid, [](FEXCore::Core::InternalThreadState *Thread) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(setsid, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t {
       uint64_t Result = ::setsid();
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(setreuid, [](FEXCore::Core::InternalThreadState *Thread, uid_t ruid, uid_t euid) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(setreuid, [](FEXCore::Core::CpuStateFrame *Frame, uid_t ruid, uid_t euid) -> uint64_t {
       uint64_t Result = ::setreuid(ruid, euid);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(setregid, [](FEXCore::Core::InternalThreadState *Thread, gid_t rgid, gid_t egid) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(setregid, [](FEXCore::Core::CpuStateFrame *Frame, gid_t rgid, gid_t egid) -> uint64_t {
       uint64_t Result = ::setregid(rgid, egid);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(getgroups, [](FEXCore::Core::InternalThreadState *Thread, int size, gid_t list[]) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(getgroups, [](FEXCore::Core::CpuStateFrame *Frame, int size, gid_t list[]) -> uint64_t {
       uint64_t Result = ::getgroups(size, list);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(setgroups, [](FEXCore::Core::InternalThreadState *Thread, size_t size, const gid_t *list) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(setgroups, [](FEXCore::Core::CpuStateFrame *Frame, size_t size, const gid_t *list) -> uint64_t {
       uint64_t Result = ::setgroups(size, list);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(setresuid, [](FEXCore::Core::InternalThreadState *Thread, uid_t ruid, uid_t euid, uid_t suid) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(setresuid, [](FEXCore::Core::CpuStateFrame *Frame, uid_t ruid, uid_t euid, uid_t suid) -> uint64_t {
       uint64_t Result = ::setresuid(ruid, euid, suid);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(getresuid, [](FEXCore::Core::InternalThreadState *Thread, uid_t *ruid, uid_t *euid, uid_t *suid) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(getresuid, [](FEXCore::Core::CpuStateFrame *Frame, uid_t *ruid, uid_t *euid, uid_t *suid) -> uint64_t {
       uint64_t Result = ::getresuid(ruid, euid, suid);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(setresgid, [](FEXCore::Core::InternalThreadState *Thread, gid_t rgid, gid_t egid, gid_t sgid) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(setresgid, [](FEXCore::Core::CpuStateFrame *Frame, gid_t rgid, gid_t egid, gid_t sgid) -> uint64_t {
       uint64_t Result = ::setresgid(rgid, egid, sgid);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(getresgid, [](FEXCore::Core::InternalThreadState *Thread, gid_t *rgid, gid_t *egid, gid_t *sgid) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(getresgid, [](FEXCore::Core::CpuStateFrame *Frame, gid_t *rgid, gid_t *egid, gid_t *sgid) -> uint64_t {
       uint64_t Result = ::getresgid(rgid, egid, sgid);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(personality, [](FEXCore::Core::InternalThreadState *Thread, uint64_t persona) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(personality, [](FEXCore::Core::CpuStateFrame *Frame, uint64_t persona) -> uint64_t {
       uint64_t Result = ::personality(persona);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(prctl, [](FEXCore::Core::InternalThreadState *Thread, int option, unsigned long arg2, unsigned long arg3, unsigned long arg4, unsigned long arg5) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(prctl, [](FEXCore::Core::CpuStateFrame *Frame, int option, unsigned long arg2, unsigned long arg3, unsigned long arg4, unsigned long arg5) -> uint64_t {
       uint64_t Result = ::prctl(option, arg2, arg3, arg4, arg5);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(arch_prctl, [](FEXCore::Core::InternalThreadState *Thread, int code, unsigned long addr) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(arch_prctl, [](FEXCore::Core::CpuStateFrame *Frame, int code, unsigned long addr) -> uint64_t {
       uint64_t Result{};
       switch (code) {
         case 0x1001: // ARCH_SET_GS
-          Thread->CurrentFrame->State.gs = addr;
+          Frame->State.gs = addr;
           Result = 0;
         break;
         case 0x1002: // ARCH_SET_FS
-          Thread->CurrentFrame->State.fs = addr;
+          Frame->State.fs = addr;
           Result = 0;
         break;
         case 0x1003: // ARCH_GET_FS
-          *reinterpret_cast<uint64_t*>(addr) = Thread->CurrentFrame->State.fs;
+          *reinterpret_cast<uint64_t*>(addr) = Frame->State.fs;
           Result = 0;
         break;
         case 0x1004: // ARCH_GET_GS
-          *reinterpret_cast<uint64_t*>(addr) = Thread->CurrentFrame->State.gs;
+          *reinterpret_cast<uint64_t*>(addr) = Frame->State.gs;
           Result = 0;
         break;
         case 0x3001: // ARCH_CET_STATUS
@@ -315,65 +316,67 @@ namespace FEX::HLE {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(gettid, [](FEXCore::Core::InternalThreadState *Thread) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(gettid, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t {
       uint64_t Result = ::gettid();
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(set_tid_address, [](FEXCore::Core::InternalThreadState *Thread, int *tidptr) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(set_tid_address, [](FEXCore::Core::CpuStateFrame *Frame, int *tidptr) -> uint64_t {
+      auto Thread = Frame->Thread;
       Thread->ThreadManager.clear_child_tid = tidptr;
       return Thread->ThreadManager.GetTID();
     });
 
-    REGISTER_SYSCALL_IMPL(exit_group, [](FEXCore::Core::InternalThreadState *Thread, int status) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(exit_group, [](FEXCore::Core::CpuStateFrame *Frame, int status) -> uint64_t {
+      auto Thread = Frame->Thread;
       Thread->StatusCode = status;
       FEXCore::Context::Stop(Thread->CTX);
       // This will never be reached
       std::unexpected();
     });
 
-    REGISTER_SYSCALL_IMPL(prlimit64, [](FEXCore::Core::InternalThreadState *Thread, pid_t pid, int resource, const struct rlimit *new_limit, struct rlimit *old_limit) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(prlimit64, [](FEXCore::Core::CpuStateFrame *Frame, pid_t pid, int resource, const struct rlimit *new_limit, struct rlimit *old_limit) -> uint64_t {
       uint64_t Result = ::prlimit(pid, (enum __rlimit_resource)(resource), new_limit, old_limit);
       SYSCALL_ERRNO();
     });
 
     /*
-    REGISTER_SYSCALL_IMPL(setpgid, [](FEXCore::Core::InternalThreadState *Thread, pid_t pid, pid_t pgid) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(setpgid, [](FEXCore::Core::CpuStateFrame *Frame, pid_t pid, pid_t pgid) -> uint64_t {
       SYSCALL_STUB(setpgid);
     });*/
     REGISTER_SYSCALL_FORWARD_ERRNO(setpgid);
 
-    /*REGISTER_SYSCALL_IMPL(getpgid, [](FEXCore::Core::InternalThreadState *Thread, pid_t pid) -> uint64_t {
+    /*REGISTER_SYSCALL_IMPL(getpgid, [](FEXCore::Core::CpuStateFrame *Frame, pid_t pid) -> uint64_t {
       SYSCALL_STUB(getpgid);
     });*/
     REGISTER_SYSCALL_FORWARD_ERRNO(getpgid);
 
-    /*REGISTER_SYSCALL_IMPL(setfsuid, [](FEXCore::Core::InternalThreadState *Thread, uid_t fsuid) -> uint64_t {
+    /*REGISTER_SYSCALL_IMPL(setfsuid, [](FEXCore::Core::CpuStateFrame *Frame, uid_t fsuid) -> uint64_t {
       SYSCALL_STUB(setfsuid);
     });*/
     REGISTER_SYSCALL_FORWARD_ERRNO(setfsuid);
 
-    /*REGISTER_SYSCALL_IMPL(setfsgid, [](FEXCore::Core::InternalThreadState *Thread, uid_t fsgid) -> uint64_t {
+    /*REGISTER_SYSCALL_IMPL(setfsgid, [](FEXCore::Core::CpuStateFrame *Frame, uid_t fsgid) -> uint64_t {
       SYSCALL_STUB(setfsgid);
     });*/
     REGISTER_SYSCALL_FORWARD_ERRNO(setfsgid);
 
-    /*REGISTER_SYSCALL_IMPL(getsid, [](FEXCore::Core::InternalThreadState *Thread, pid_t pid) -> uint64_t {
+    /*REGISTER_SYSCALL_IMPL(getsid, [](FEXCore::Core::CpuStateFrame *Frame, pid_t pid) -> uint64_t {
       SYSCALL_STUB(getsid);
     });*/
     REGISTER_SYSCALL_FORWARD_ERRNO(getsid);
 
-    REGISTER_SYSCALL_IMPL(waitid, [](FEXCore::Core::InternalThreadState *Thread, idtype_t idtype, id_t id, siginfo_t *infop, int options) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(waitid, [](FEXCore::Core::CpuStateFrame *Frame, idtype_t idtype, id_t id, siginfo_t *infop, int options) -> uint64_t {
       uint64_t Result = ::waitid(idtype, id, infop, options);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(unshare, [](FEXCore::Core::InternalThreadState *Thread, int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(unshare, [](FEXCore::Core::CpuStateFrame *Frame, int flags) -> uint64_t {
       uint64_t Result = ::unshare(flags);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(setns, [](FEXCore::Core::InternalThreadState *Thread, int fd, int nstype) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(setns, [](FEXCore::Core::CpuStateFrame *Frame, int fd, int nstype) -> uint64_t {
       uint64_t Result = ::setns(fd, nstype);
       SYSCALL_ERRNO();
     });

--- a/Source/Tests/LinuxSyscalls/Syscalls/Thread.h
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Thread.h
@@ -8,6 +8,6 @@ struct CPUState;
 }
 
 namespace FEX::HLE {
-  FEXCore::Core::InternalThreadState *CreateNewThread(FEXCore::Core::InternalThreadState *Thread, uint32_t flags, void *stack, pid_t *parent_tid, pid_t *child_tid, void *tls);
-  uint64_t ForkGuest(FEXCore::Core::InternalThreadState *Thread, uint32_t flags, void *stack, pid_t *parent_tid, pid_t *child_tid, void *tls);
+  FEXCore::Core::InternalThreadState *CreateNewThread(FEXCore::Context::Context *CTX, FEXCore::Core::CpuStateFrame *Frame, uint32_t flags, void *stack, pid_t *parent_tid, pid_t *child_tid, void *tls);
+  uint64_t ForkGuest(FEXCore::Core::InternalThreadState *Thread, FEXCore::Core::CpuStateFrame *Frame, uint32_t flags, void *stack, pid_t *parent_tid, pid_t *child_tid, void *tls);
 }

--- a/Source/Tests/LinuxSyscalls/Syscalls/Time.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Time.cpp
@@ -13,32 +13,32 @@
 
 namespace FEX::HLE {
   void RegisterTime() {
-    REGISTER_SYSCALL_IMPL(pause, [](FEXCore::Core::InternalThreadState *Thread) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(pause, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t {
       uint64_t Result = ::pause();
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(time, [](FEXCore::Core::InternalThreadState *Thread, time_t *tloc) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(time, [](FEXCore::Core::CpuStateFrame *Frame, time_t *tloc) -> uint64_t {
       uint64_t Result = ::time(tloc);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(times, [](FEXCore::Core::InternalThreadState *Thread, struct tms *buf) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(times, [](FEXCore::Core::CpuStateFrame *Frame, struct tms *buf) -> uint64_t {
       uint64_t Result = ::times(buf);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(utime, [](FEXCore::Core::InternalThreadState *Thread, char* filename, const struct utimbuf* times) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(utime, [](FEXCore::Core::CpuStateFrame *Frame, char* filename, const struct utimbuf* times) -> uint64_t {
       uint64_t Result = ::utime(filename, times);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(adjtimex, [](FEXCore::Core::InternalThreadState *Thread, struct timex *buf) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(adjtimex, [](FEXCore::Core::CpuStateFrame *Frame, struct timex *buf) -> uint64_t {
       uint64_t Result = ::adjtimex(buf);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(clock_adjtime, [](FEXCore::Core::InternalThreadState *Thread, clockid_t clk_id, struct timex *buf) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(clock_adjtime, [](FEXCore::Core::CpuStateFrame *Frame, clockid_t clk_id, struct timex *buf) -> uint64_t {
       uint64_t Result = ::clock_adjtime(clk_id, buf);
       SYSCALL_ERRNO();
     });

--- a/Source/Tests/LinuxSyscalls/Syscalls/Timer.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Timer.cpp
@@ -13,42 +13,42 @@
 namespace FEX::HLE {
   void RegisterTimer() {
 
-    REGISTER_SYSCALL_IMPL(alarm, [](FEXCore::Core::InternalThreadState *Thread, unsigned int seconds) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(alarm, [](FEXCore::Core::CpuStateFrame *Frame, unsigned int seconds) -> uint64_t {
       uint64_t Result = ::alarm(seconds);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(timer_create, [](FEXCore::Core::InternalThreadState *Thread, clockid_t clockid, struct sigevent *sevp, timer_t *timerid) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(timer_create, [](FEXCore::Core::CpuStateFrame *Frame, clockid_t clockid, struct sigevent *sevp, timer_t *timerid) -> uint64_t {
       uint64_t Result = ::syscall(SYS_timer_create, clockid, sevp, timerid);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(timer_settime, [](FEXCore::Core::InternalThreadState *Thread, timer_t timerid, int flags, const struct itimerspec *new_value, struct itimerspec *old_value) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(timer_settime, [](FEXCore::Core::CpuStateFrame *Frame, timer_t timerid, int flags, const struct itimerspec *new_value, struct itimerspec *old_value) -> uint64_t {
       uint64_t Result = ::syscall(SYS_timer_settime, timerid, flags, new_value, old_value);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(timer_gettime, [](FEXCore::Core::InternalThreadState *Thread, timer_t timerid, struct itimerspec *curr_value) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(timer_gettime, [](FEXCore::Core::CpuStateFrame *Frame, timer_t timerid, struct itimerspec *curr_value) -> uint64_t {
       uint64_t Result = ::syscall(SYS_timer_gettime, timerid, curr_value);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(timer_getoverrun, [](FEXCore::Core::InternalThreadState *Thread, timer_t timerid) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(timer_getoverrun, [](FEXCore::Core::CpuStateFrame *Frame, timer_t timerid) -> uint64_t {
       uint64_t Result = ::syscall(SYS_timer_getoverrun, timerid);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(timer_delete, [](FEXCore::Core::InternalThreadState *Thread, timer_t timerid) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(timer_delete, [](FEXCore::Core::CpuStateFrame *Frame, timer_t timerid) -> uint64_t {
       uint64_t Result = ::syscall(SYS_timer_delete, timerid);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(getitimer, [](FEXCore::Core::InternalThreadState *Thread, int which, struct itimerval *curr_value) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(getitimer, [](FEXCore::Core::CpuStateFrame *Frame, int which, struct itimerval *curr_value) -> uint64_t {
       uint64_t Result = ::getitimer(which, curr_value);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(setitimer, [](FEXCore::Core::InternalThreadState *Thread, int which, const struct itimerval *new_value, struct itimerval *old_value) -> uint64_t {
+    REGISTER_SYSCALL_IMPL(setitimer, [](FEXCore::Core::CpuStateFrame *Frame, int which, const struct itimerval *new_value, struct itimerval *old_value) -> uint64_t {
       uint64_t Result = ::setitimer(which, new_value, old_value);
       SYSCALL_ERRNO();
     });

--- a/Source/Tests/LinuxSyscalls/x32/EPoll.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/EPoll.cpp
@@ -13,7 +13,7 @@ ARG_TO_STR(FEX::HLE::x32::compat_ptr<FEX::HLE::epoll_event_x86>, "%lx")
 
 namespace FEX::HLE::x32 {
   void RegisterEpoll() {
-    REGISTER_SYSCALL_IMPL_X32(epoll_wait, [](FEXCore::Core::InternalThreadState *Thread, int epfd, compat_ptr<epoll_event_x86> events, int maxevents, int timeout) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(epoll_wait, [](FEXCore::Core::CpuStateFrame *Frame, int epfd, compat_ptr<epoll_event_x86> events, int maxevents, int timeout) -> uint64_t {
       std::vector<struct epoll_event> Events;
       Events.resize(maxevents);
       uint64_t Result = epoll_wait(epfd, &Events.at(0), maxevents, timeout);
@@ -26,7 +26,7 @@ namespace FEX::HLE::x32 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(epoll_ctl, [](FEXCore::Core::InternalThreadState *Thread, int epfd, int op, int fd, epoll_event_x86 *event) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(epoll_ctl, [](FEXCore::Core::CpuStateFrame *Frame, int epfd, int op, int fd, epoll_event_x86 *event) -> uint64_t {
       struct epoll_event Event = *event;
       uint64_t Result = epoll_ctl(epfd, op, fd, &Event);
       if (Result != -1) {
@@ -35,7 +35,7 @@ namespace FEX::HLE::x32 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(epoll_pwait, [](FEXCore::Core::InternalThreadState *Thread, int epfd, compat_ptr<epoll_event_x86> events, int maxevent, int timeout, const void* sigmask) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(epoll_pwait, [](FEXCore::Core::CpuStateFrame *Frame, int epfd, compat_ptr<epoll_event_x86> events, int maxevent, int timeout, const void* sigmask) -> uint64_t {
       std::vector<struct epoll_event> Events;
       Events.resize(maxevent);
 

--- a/Source/Tests/LinuxSyscalls/x32/FD.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/FD.cpp
@@ -49,12 +49,12 @@ namespace FEX::HLE::x32 {
 #endif
 
   void RegisterFD() {
-    REGISTER_SYSCALL_IMPL_X32(poll, [](FEXCore::Core::InternalThreadState *Thread, struct pollfd *fds, nfds_t nfds, int timeout) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(poll, [](FEXCore::Core::CpuStateFrame *Frame, struct pollfd *fds, nfds_t nfds, int timeout) -> uint64_t {
       uint64_t Result = ::poll(fds, nfds, timeout);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(ppoll, [](FEXCore::Core::InternalThreadState *Thread, struct pollfd *fds, nfds_t nfds, timespec32 *timeout_ts, const uint64_t *sigmask, size_t sigsetsize) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(ppoll, [](FEXCore::Core::CpuStateFrame *Frame, struct pollfd *fds, nfds_t nfds, timespec32 *timeout_ts, const uint64_t *sigmask, size_t sigsetsize) -> uint64_t {
       // sigsetsize is unused here since it is currently a constant and not exposed through glibc
       struct timespec tp64{};
       struct timespec *timed_ptr{};
@@ -88,7 +88,7 @@ namespace FEX::HLE::x32 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(ppoll_time64, [](FEXCore::Core::InternalThreadState *Thread, struct pollfd *fds, nfds_t nfds, struct timespec *timeout_ts, const uint64_t *sigmask, size_t sigsetsize) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(ppoll_time64, [](FEXCore::Core::CpuStateFrame *Frame, struct pollfd *fds, nfds_t nfds, struct timespec *timeout_ts, const uint64_t *sigmask, size_t sigsetsize) -> uint64_t {
       // sigsetsize is unused here since it is currently a constant and not exposed through glibc
       sigset_t HostSet{};
 
@@ -111,7 +111,7 @@ namespace FEX::HLE::x32 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(_llseek, [](FEXCore::Core::InternalThreadState *Thread, uint32_t fd, uint32_t offset_high, uint32_t offset_low, loff_t *result, uint32_t whence) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(_llseek, [](FEXCore::Core::CpuStateFrame *Frame, uint32_t fd, uint32_t offset_high, uint32_t offset_low, loff_t *result, uint32_t whence) -> uint64_t {
       uint64_t Offset = offset_high;
       Offset <<= 32;
       Offset |= offset_low;
@@ -122,7 +122,7 @@ namespace FEX::HLE::x32 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(readv, [](FEXCore::Core::InternalThreadState *Thread, int fd, const struct iovec32 *iov, int iovcnt) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(readv, [](FEXCore::Core::CpuStateFrame *Frame, int fd, const struct iovec32 *iov, int iovcnt) -> uint64_t {
       std::vector<iovec> Host_iovec(iovcnt);
       for (int i = 0; i < iovcnt; ++i) {
         Host_iovec[i] = iov[i];
@@ -132,7 +132,7 @@ namespace FEX::HLE::x32 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(writev, [](FEXCore::Core::InternalThreadState *Thread, int fd, const struct iovec32 *iov, int iovcnt) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(writev, [](FEXCore::Core::CpuStateFrame *Frame, int fd, const struct iovec32 *iov, int iovcnt) -> uint64_t {
       std::vector<iovec> Host_iovec(iovcnt);
       for (int i = 0; i < iovcnt; ++i) {
         Host_iovec[i] = iov[i];
@@ -141,7 +141,7 @@ namespace FEX::HLE::x32 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(stat, [](FEXCore::Core::InternalThreadState *Thread, const char *pathname, stat32 *buf) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(stat, [](FEXCore::Core::CpuStateFrame *Frame, const char *pathname, stat32 *buf) -> uint64_t {
       struct stat host_stat;
       uint64_t Result = FEX::HLE::_SyscallHandler->FM.Stat(pathname, &host_stat);
       if (Result != -1) {
@@ -150,7 +150,7 @@ namespace FEX::HLE::x32 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(fstat, [](FEXCore::Core::InternalThreadState *Thread, int fd, stat32 *buf) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(fstat, [](FEXCore::Core::CpuStateFrame *Frame, int fd, stat32 *buf) -> uint64_t {
       struct stat host_stat;
       uint64_t Result = ::fstat(fd, &host_stat);
       if (Result != -1) {
@@ -159,7 +159,7 @@ namespace FEX::HLE::x32 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(lstat, [](FEXCore::Core::InternalThreadState *Thread, const char *path, stat32 *buf) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(lstat, [](FEXCore::Core::CpuStateFrame *Frame, const char *path, stat32 *buf) -> uint64_t {
       struct stat host_stat;
       uint64_t Result = FEX::HLE::_SyscallHandler->FM.Lstat(path, &host_stat);
       if (Result != -1) {
@@ -168,7 +168,7 @@ namespace FEX::HLE::x32 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(stat64, [](FEXCore::Core::InternalThreadState *Thread, const char *pathname, stat64_32 *buf) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(stat64, [](FEXCore::Core::CpuStateFrame *Frame, const char *pathname, stat64_32 *buf) -> uint64_t {
       struct stat host_stat;
       uint64_t Result = FEX::HLE::_SyscallHandler->FM.Stat(pathname, &host_stat);
       if (Result != -1) {
@@ -177,7 +177,7 @@ namespace FEX::HLE::x32 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(lstat64, [](FEXCore::Core::InternalThreadState *Thread, const char *path, stat64_32 *buf) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(lstat64, [](FEXCore::Core::CpuStateFrame *Frame, const char *path, stat64_32 *buf) -> uint64_t {
       struct stat host_stat;
       uint64_t Result = FEX::HLE::_SyscallHandler->FM.Lstat(path, &host_stat);
 
@@ -187,7 +187,7 @@ namespace FEX::HLE::x32 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(fstat64, [](FEXCore::Core::InternalThreadState *Thread, int fd, stat64_32 *buf) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(fstat64, [](FEXCore::Core::CpuStateFrame *Frame, int fd, stat64_32 *buf) -> uint64_t {
       struct stat64 host_stat;
       uint64_t Result = ::fstat64(fd, &host_stat);
       if (Result != -1) {
@@ -196,7 +196,7 @@ namespace FEX::HLE::x32 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(fstatfs64, [](FEXCore::Core::InternalThreadState *Thread, int fd, size_t sz, struct statfs64_32 *buf) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(fstatfs64, [](FEXCore::Core::CpuStateFrame *Frame, int fd, size_t sz, struct statfs64_32 *buf) -> uint64_t {
       LogMan::Throw::A(sz == sizeof(struct statfs64_32), "This needs to match");
 
       struct statfs64 host_stat;
@@ -207,7 +207,7 @@ namespace FEX::HLE::x32 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(statfs64, [](FEXCore::Core::InternalThreadState *Thread, const char *path, size_t sz, struct statfs64_32 *buf) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(statfs64, [](FEXCore::Core::CpuStateFrame *Frame, const char *path, size_t sz, struct statfs64_32 *buf) -> uint64_t {
       LogMan::Throw::A(sz == sizeof(struct statfs64_32), "This needs to match");
 
       struct statfs host_stat;
@@ -219,7 +219,7 @@ namespace FEX::HLE::x32 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(fcntl64, [](FEXCore::Core::InternalThreadState *Thread, int fd, int cmd, uint64_t arg) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(fcntl64, [](FEXCore::Core::CpuStateFrame *Frame, int fd, int cmd, uint64_t arg) -> uint64_t {
       // fcntl64 struct directly matches the 64bit fcntl op
       // cmd just needs to be fixed up
       // These are redefined to be their non-64bit tagged value on x86-64
@@ -299,7 +299,7 @@ namespace FEX::HLE::x32 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(preadv, [](FEXCore::Core::InternalThreadState *Thread, int fd, const struct iovec32 *iov, int iovcnt, off_t offset) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(preadv, [](FEXCore::Core::CpuStateFrame *Frame, int fd, const struct iovec32 *iov, int iovcnt, off_t offset) -> uint64_t {
       std::vector<iovec> Host_iovec(iovcnt);
       for (int i = 0; i < iovcnt; ++i) {
         Host_iovec[i] = iov[i];
@@ -309,7 +309,7 @@ namespace FEX::HLE::x32 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(pwritev, [](FEXCore::Core::InternalThreadState *Thread, int fd, const struct iovec32 *iov, int iovcnt, off_t offset) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(pwritev, [](FEXCore::Core::CpuStateFrame *Frame, int fd, const struct iovec32 *iov, int iovcnt, off_t offset) -> uint64_t {
       std::vector<iovec> Host_iovec(iovcnt);
       for (int i = 0; i < iovcnt; ++i) {
         Host_iovec[i] = iov[i];
@@ -319,7 +319,7 @@ namespace FEX::HLE::x32 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(process_vm_readv, [](FEXCore::Core::InternalThreadState *Thread, pid_t pid, const struct iovec32 *local_iov, unsigned long liovcnt, const struct iovec32 *remote_iov, unsigned long riovcnt, unsigned long flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(process_vm_readv, [](FEXCore::Core::CpuStateFrame *Frame, pid_t pid, const struct iovec32 *local_iov, unsigned long liovcnt, const struct iovec32 *remote_iov, unsigned long riovcnt, unsigned long flags) -> uint64_t {
       std::vector<iovec> Host_local_iovec(liovcnt);
       std::vector<iovec> Host_remote_iovec(riovcnt);
 
@@ -335,7 +335,7 @@ namespace FEX::HLE::x32 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(process_vm_writev, [](FEXCore::Core::InternalThreadState *Thread, pid_t pid, const struct iovec32 *local_iov, unsigned long liovcnt, const struct iovec32 *remote_iov, unsigned long riovcnt, unsigned long flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(process_vm_writev, [](FEXCore::Core::CpuStateFrame *Frame, pid_t pid, const struct iovec32 *local_iov, unsigned long liovcnt, const struct iovec32 *remote_iov, unsigned long riovcnt, unsigned long flags) -> uint64_t {
       std::vector<iovec> Host_local_iovec(liovcnt);
       std::vector<iovec> Host_remote_iovec(riovcnt);
 
@@ -351,7 +351,7 @@ namespace FEX::HLE::x32 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(preadv2, [](FEXCore::Core::InternalThreadState *Thread, int fd, const struct iovec32 *iov, int iovcnt, off_t offset, int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(preadv2, [](FEXCore::Core::CpuStateFrame *Frame, int fd, const struct iovec32 *iov, int iovcnt, off_t offset, int flags) -> uint64_t {
       std::vector<iovec> Host_iovec(iovcnt);
       for (int i = 0; i < iovcnt; ++i) {
         Host_iovec[i] = iov[i];
@@ -361,7 +361,7 @@ namespace FEX::HLE::x32 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(pwritev2, [](FEXCore::Core::InternalThreadState *Thread, int fd, const struct iovec32 *iov, int iovcnt, off_t offset, int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(pwritev2, [](FEXCore::Core::CpuStateFrame *Frame, int fd, const struct iovec32 *iov, int iovcnt, off_t offset, int flags) -> uint64_t {
       std::vector<iovec> Host_iovec(iovcnt);
       for (int i = 0; i < iovcnt; ++i) {
         Host_iovec[i] = iov[i];
@@ -371,7 +371,7 @@ namespace FEX::HLE::x32 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(fstatat64, [](FEXCore::Core::InternalThreadState *Thread, int dirfd, const char *pathname, stat64_32 *buf, int flag) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(fstatat64, [](FEXCore::Core::CpuStateFrame *Frame, int dirfd, const char *pathname, stat64_32 *buf, int flag) -> uint64_t {
       struct stat64 host_stat;
       uint64_t Result = FEX::HLE::_SyscallHandler->FM.NewFSStatAt64(dirfd, pathname, &host_stat, flag);
       if (Result != -1) {
@@ -380,11 +380,11 @@ namespace FEX::HLE::x32 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(ioctl, [](FEXCore::Core::InternalThreadState *Thread, int fd, uint32_t request, uint32_t args) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(ioctl, [](FEXCore::Core::CpuStateFrame *Frame, int fd, uint32_t request, uint32_t args) -> uint64_t {
       return ioctl32(fd, request, args);
     });
 
-    REGISTER_SYSCALL_IMPL_X32(getdents, [](FEXCore::Core::InternalThreadState *Thread, int fd, void *dirp, uint32_t count) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(getdents, [](FEXCore::Core::CpuStateFrame *Frame, int fd, void *dirp, uint32_t count) -> uint64_t {
 #ifdef SYS_getdents
       std::vector<uint8_t> TmpVector(count);
       void *TmpPtr = reinterpret_cast<void*>(&TmpVector.at(0));
@@ -456,7 +456,7 @@ namespace FEX::HLE::x32 {
 #endif
     });
 
-    REGISTER_SYSCALL_IMPL_X32(getdents64, [](FEXCore::Core::InternalThreadState *Thread, int fd, void *dirp, uint32_t count) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(getdents64, [](FEXCore::Core::CpuStateFrame *Frame, int fd, void *dirp, uint32_t count) -> uint64_t {
       uint64_t Result = ::syscall(SYS_getdents64,
         static_cast<uint64_t>(fd),
         dirp,
@@ -473,7 +473,7 @@ namespace FEX::HLE::x32 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(_newselect, [](FEXCore::Core::InternalThreadState *Thread, int nfds, fd_set32 *readfds, fd_set32 *writefds, fd_set32 *exceptfds, struct timeval32 *timeout) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(_newselect, [](FEXCore::Core::CpuStateFrame *Frame, int nfds, fd_set32 *readfds, fd_set32 *writefds, fd_set32 *exceptfds, struct timeval32 *timeout) -> uint64_t {
       struct timeval tp64{};
       if (timeout) {
         tp64 = *timeout;
@@ -566,7 +566,7 @@ namespace FEX::HLE::x32 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(pselect6, [](FEXCore::Core::InternalThreadState *Thread, int nfds, fd_set32 *readfds, fd_set32 *writefds, fd_set32 *exceptfds, timespec32 *timeout, compat_ptr<sigset_argpack32> sigmaskpack) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(pselect6, [](FEXCore::Core::CpuStateFrame *Frame, int nfds, fd_set32 *readfds, fd_set32 *writefds, fd_set32 *exceptfds, timespec32 *timeout, compat_ptr<sigset_argpack32> sigmaskpack) -> uint64_t {
       struct timespec tp64{};
       if (timeout) {
         tp64 = *timeout;
@@ -674,7 +674,7 @@ namespace FEX::HLE::x32 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(fadvise64_64, [](FEXCore::Core::InternalThreadState *Thread, int32_t fd, uint32_t offset_low, uint32_t offset_high, uint32_t len_low, uint32_t len_high, int advice) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(fadvise64_64, [](FEXCore::Core::CpuStateFrame *Frame, int32_t fd, uint32_t offset_low, uint32_t offset_high, uint32_t len_low, uint32_t len_high, int advice) -> uint64_t {
       uint64_t Offset = offset_high;
       Offset <<= 32;
       Offset |= offset_low;
@@ -685,17 +685,17 @@ namespace FEX::HLE::x32 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(timerfd_settime64, [](FEXCore::Core::InternalThreadState *Thread, int fd, int flags, const struct itimerspec *new_value, struct itimerspec *old_value) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(timerfd_settime64, [](FEXCore::Core::CpuStateFrame *Frame, int fd, int flags, const struct itimerspec *new_value, struct itimerspec *old_value) -> uint64_t {
       uint64_t Result = ::timerfd_settime(fd, flags, new_value, old_value);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(timerfd_gettime64, [](FEXCore::Core::InternalThreadState *Thread, int fd, struct itimerspec *curr_value) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(timerfd_gettime64, [](FEXCore::Core::CpuStateFrame *Frame, int fd, struct itimerspec *curr_value) -> uint64_t {
       uint64_t Result = ::timerfd_gettime(fd, curr_value);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(pselect6_time64, [](FEXCore::Core::InternalThreadState *Thread, int nfds, fd_set32 *readfds, fd_set32 *writefds, fd_set32 *exceptfds, struct timespec *timeout, compat_ptr<sigset_argpack32> sigmaskpack) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(pselect6_time64, [](FEXCore::Core::CpuStateFrame *Frame, int nfds, fd_set32 *readfds, fd_set32 *writefds, fd_set32 *exceptfds, struct timespec *timeout, compat_ptr<sigset_argpack32> sigmaskpack) -> uint64_t {
       fd_set Host_readfds;
       fd_set Host_writefds;
       fd_set Host_exceptfds;
@@ -791,12 +791,12 @@ namespace FEX::HLE::x32 {
           }
         }
       }
-      
+
       SYSCALL_ERRNO();
     });
   }
 
-  REGISTER_SYSCALL_IMPL_X32(sendfile, [](FEXCore::Core::InternalThreadState *Thread, int out_fd, int in_fd, compat_off_t *offset, size_t count) -> uint64_t {
+  REGISTER_SYSCALL_IMPL_X32(sendfile, [](FEXCore::Core::CpuStateFrame *Frame, int out_fd, int in_fd, compat_off_t *offset, size_t count) -> uint64_t {
     off_t Local{};
     off_t *Local_p{};
     if (offset) {
@@ -808,7 +808,7 @@ namespace FEX::HLE::x32 {
   });
 
 
-  REGISTER_SYSCALL_IMPL_X32(sendfile64, [](FEXCore::Core::InternalThreadState *Thread, int out_fd, int in_fd, off_t *offset, compat_size_t count) -> uint64_t {
+  REGISTER_SYSCALL_IMPL_X32(sendfile64, [](FEXCore::Core::CpuStateFrame *Frame, int out_fd, int in_fd, off_t *offset, compat_size_t count) -> uint64_t {
     // Linux definition for this is a bit confusing
     // Defines offset as compat_loff_t* but loads loff_t worth of data
     // count is defined as compat_size_t still

--- a/Source/Tests/LinuxSyscalls/x32/FS.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/FS.cpp
@@ -6,12 +6,12 @@
 
 namespace FEX::HLE::x32 {
   void RegisterFS() {
-    REGISTER_SYSCALL_IMPL_X32(umount, [](FEXCore::Core::InternalThreadState *Thread, const char *target) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(umount, [](FEXCore::Core::CpuStateFrame *Frame, const char *target) -> uint64_t {
       uint64_t Result = ::umount(target);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(ftruncate64, [](FEXCore::Core::InternalThreadState *Thread, int fd, uint32_t offset_low, uint32_t offset_high) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(ftruncate64, [](FEXCore::Core::CpuStateFrame *Frame, int fd, uint32_t offset_low, uint32_t offset_high) -> uint64_t {
       uint64_t Offset = offset_high;
       Offset <<= 32;
       Offset |= offset_low;
@@ -19,7 +19,7 @@ namespace FEX::HLE::x32 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(sigprocmask, [](FEXCore::Core::InternalThreadState *Thread, int how, const uint64_t *set, uint64_t *oldset, size_t sigsetsize) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(sigprocmask, [](FEXCore::Core::CpuStateFrame *Frame, int how, const uint64_t *set, uint64_t *oldset, size_t sigsetsize) -> uint64_t {
       return FEX::HLE::_SyscallHandler->GetSignalDelegator()->GuestSigProcMask(how, set, oldset);
     });
   }

--- a/Source/Tests/LinuxSyscalls/x32/Info.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Info.cpp
@@ -29,7 +29,7 @@ namespace FEX::HLE::x32 {
   static_assert(sizeof(sysinfo32) == 64, "Needs to be 64bytes");
 
   void RegisterInfo() {
-    REGISTER_SYSCALL_IMPL_X32(ugetrlimit, [](FEXCore::Core::InternalThreadState *Thread, int resource, rlimit32 *rlim) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(ugetrlimit, [](FEXCore::Core::CpuStateFrame *Frame, int resource, rlimit32 *rlim) -> uint64_t {
       struct rlimit rlim64{};
       uint64_t Result = ::getrlimit(resource, &rlim64);
       rlim->rlim_cur = rlim64.rlim_cur;
@@ -37,7 +37,7 @@ namespace FEX::HLE::x32 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(sysinfo, [](FEXCore::Core::InternalThreadState *Thread, struct sysinfo32 *info) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(sysinfo, [](FEXCore::Core::CpuStateFrame *Frame, struct sysinfo32 *info) -> uint64_t {
       struct sysinfo Host{};
       uint64_t Result = ::sysinfo(&Host);
       if (Result != -1) {
@@ -58,7 +58,7 @@ namespace FEX::HLE::x32 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(getrusage, [](FEXCore::Core::InternalThreadState *Thread, int who, rusage_32 *usage) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(getrusage, [](FEXCore::Core::CpuStateFrame *Frame, int who, rusage_32 *usage) -> uint64_t {
       struct rusage usage64 = *usage;
       uint64_t Result = ::getrusage(who, &usage64);
       *usage = usage64;

--- a/Source/Tests/LinuxSyscalls/x32/Memory.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Memory.cpp
@@ -20,10 +20,11 @@ static std::string get_fdpath(int fd)
 namespace FEX::HLE::x32 {
 
   void RegisterMemory() {
-    REGISTER_SYSCALL_IMPL_X32(mmap, [](FEXCore::Core::InternalThreadState *Thread, uint32_t addr, uint32_t length, int prot, int flags, int fd, int32_t offset) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(mmap, [](FEXCore::Core::CpuStateFrame *Frame, uint32_t addr, uint32_t length, int prot, int flags, int fd, int32_t offset) -> uint64_t {
       auto Result = (uint64_t)static_cast<FEX::HLE::x32::x32SyscallHandler*>(FEX::HLE::_SyscallHandler)->GetAllocator()->
         mmap(reinterpret_cast<void*>(addr), length, prot,flags, fd, offset);
 
+      auto Thread = Frame->Thread;
       if (Result != -1) {
         if (!(flags & MAP_ANONYMOUS)) {
           auto filename = get_fdpath(fd);
@@ -36,10 +37,11 @@ namespace FEX::HLE::x32 {
       return Result;
     });
 
-    REGISTER_SYSCALL_IMPL_X32(mmap2, [](FEXCore::Core::InternalThreadState *Thread, uint32_t addr, uint32_t length, int prot, int flags, int fd, uint32_t pgoffset) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(mmap2, [](FEXCore::Core::CpuStateFrame *Frame, uint32_t addr, uint32_t length, int prot, int flags, int fd, uint32_t pgoffset) -> uint64_t {
       auto Result = (uint64_t)static_cast<FEX::HLE::x32::x32SyscallHandler*>(FEX::HLE::_SyscallHandler)->GetAllocator()->
         mmap(reinterpret_cast<void*>(addr), length, prot,flags, fd, (uint64_t)pgoffset * 0x1000);
-      
+
+      auto Thread = Frame->Thread;
       if (Result != -1) {
         if (!(flags & MAP_ANONYMOUS)) {
           auto filename = get_fdpath(fd);
@@ -52,35 +54,35 @@ namespace FEX::HLE::x32 {
       return Result;
     });
 
-    REGISTER_SYSCALL_IMPL_X32(munmap, [](FEXCore::Core::InternalThreadState *Thread, void *addr, size_t length) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(munmap, [](FEXCore::Core::CpuStateFrame *Frame, void *addr, size_t length) -> uint64_t {
       auto Result = static_cast<FEX::HLE::x32::x32SyscallHandler*>(FEX::HLE::_SyscallHandler)->GetAllocator()->
         munmap(addr, length);
       if (Result != -1) {
-        FEXCore::Context::RemoveNamedRegion(Thread->CTX, (uintptr_t)addr, length);
-        FEXCore::Context::FlushCodeRange(Thread, (uintptr_t)addr, length);
+        FEXCore::Context::RemoveNamedRegion(Frame->Thread->CTX, (uintptr_t)addr, length);
+        FEXCore::Context::FlushCodeRange(Frame->Thread, (uintptr_t)addr, length);
       }
       return Result;
     });
 
-    REGISTER_SYSCALL_IMPL_X32(mprotect, [](FEXCore::Core::InternalThreadState *Thread, void *addr, uint32_t len, int prot) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(mprotect, [](FEXCore::Core::CpuStateFrame *Frame, void *addr, uint32_t len, int prot) -> uint64_t {
       uint64_t Result = ::mprotect(addr, len, prot);
       if (Result != -1 && prot & PROT_EXEC) {
-        FEXCore::Context::FlushCodeRange(Thread, (uintptr_t)addr, len);
+        FEXCore::Context::FlushCodeRange(Frame->Thread, (uintptr_t)addr, len);
       }
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(mremap, [](FEXCore::Core::InternalThreadState *Thread, void *old_address, size_t old_size, size_t new_size, int flags, void *new_address) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(mremap, [](FEXCore::Core::CpuStateFrame *Frame, void *old_address, size_t old_size, size_t new_size, int flags, void *new_address) -> uint64_t {
       return reinterpret_cast<uint64_t>(static_cast<FEX::HLE::x32::x32SyscallHandler*>(FEX::HLE::_SyscallHandler)->GetAllocator()->
         mremap(old_address, old_size, new_size, flags, new_address));
     });
 
-    REGISTER_SYSCALL_IMPL_X32(mlockall, [](FEXCore::Core::InternalThreadState *Thread, int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(mlockall, [](FEXCore::Core::CpuStateFrame *Frame, int flags) -> uint64_t {
       uint64_t Result = ::mlock2(reinterpret_cast<void*>(0x1'0000), 0x1'0000'0000ULL - 0x1'0000, flags);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(munlockall, [](FEXCore::Core::InternalThreadState *Thread) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(munlockall, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t {
       uint64_t Result = ::munlock(reinterpret_cast<void*>(0x1'0000), 0x1'0000'0000ULL - 0x1'0000);
       SYSCALL_ERRNO();
     });

--- a/Source/Tests/LinuxSyscalls/x32/NotImplemented.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/NotImplemented.cpp
@@ -3,11 +3,11 @@
 #include <FEXCore/Utils/LogManager.h>
 
 namespace FEX::HLE::x32 {
-#define REGISTER_SYSCALL_NOT_IMPL_X32(name) REGISTER_SYSCALL_IMPL_X32(name, [](FEXCore::Core::InternalThreadState *Thread) -> uint64_t { \
+#define REGISTER_SYSCALL_NOT_IMPL_X32(name) REGISTER_SYSCALL_IMPL_X32(name, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t { \
   LogMan::Msg::D("Using deprecated/removed syscall: " #name); \
   return -ENOSYS; \
 });
-#define REGISTER_SYSCALL_NO_PERM_X32(name) REGISTER_SYSCALL_IMPL_X32(name, [](FEXCore::Core::InternalThreadState *Thread) -> uint64_t { \
+#define REGISTER_SYSCALL_NO_PERM_X32(name) REGISTER_SYSCALL_IMPL_X32(name, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t { \
   return -EPERM; \
 });
 

--- a/Source/Tests/LinuxSyscalls/x32/Sched.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Sched.cpp
@@ -10,7 +10,7 @@
 
 namespace FEX::HLE::x32 {
   void RegisterSched() {
-    REGISTER_SYSCALL_IMPL_X32(sched_rr_get_interval, [](FEXCore::Core::InternalThreadState *Thread, pid_t pid, struct timespec32 *tp) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(sched_rr_get_interval, [](FEXCore::Core::CpuStateFrame *Frame, pid_t pid, struct timespec32 *tp) -> uint64_t {
       struct timespec tp64{};
       uint64_t Result = ::sched_rr_get_interval(pid, tp ? &tp64 : nullptr);
       if (tp) {

--- a/Source/Tests/LinuxSyscalls/x32/Semaphore.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Semaphore.cpp
@@ -520,7 +520,7 @@ namespace FEX::HLE::x32 {
     void *__pad;
   };
 
-  uint64_t _ipc(FEXCore::Core::InternalThreadState *Thread, uint32_t call, uint32_t first, uint32_t second, uint32_t third, uint32_t ptr, uint32_t fifth) {
+  uint64_t _ipc(FEXCore::Core::CpuStateFrame *Frame, uint32_t call, uint32_t first, uint32_t second, uint32_t third, uint32_t ptr, uint32_t fifth) {
     uint64_t Result{};
 
     switch (static_cast<IPCOp>(call)) {

--- a/Source/Tests/LinuxSyscalls/x32/Signals.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Signals.cpp
@@ -15,7 +15,7 @@ namespace SignalDelegator {
 
 namespace FEX::HLE::x32 {
   void RegisterSignals() {
-    REGISTER_SYSCALL_IMPL_X32(signal, [](FEXCore::Core::InternalThreadState *Thread, int signum, uint32_t handler) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(signal, [](FEXCore::Core::CpuStateFrame *Frame, int signum, uint32_t handler) -> uint64_t {
       FEXCore::GuestSigAction newact{};
       FEXCore::GuestSigAction oldact{};
       newact.sigaction_handler.handler = reinterpret_cast<decltype(newact.sigaction_handler.handler)>(handler);
@@ -23,7 +23,7 @@ namespace FEX::HLE::x32 {
       return static_cast<uint32_t>(reinterpret_cast<uint64_t>(oldact.sigaction_handler.handler));
     });
 
-    REGISTER_SYSCALL_IMPL_X32(rt_sigaction, [](FEXCore::Core::InternalThreadState *Thread, int signum, const GuestSigAction_32 *act, GuestSigAction_32 *oldact) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(rt_sigaction, [](FEXCore::Core::CpuStateFrame *Frame, int signum, const GuestSigAction_32 *act, GuestSigAction_32 *oldact) -> uint64_t {
       FEXCore::GuestSigAction *act64_p{};
       FEXCore::GuestSigAction *old64_p{};
 

--- a/Source/Tests/LinuxSyscalls/x32/Socket.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Socket.cpp
@@ -35,7 +35,7 @@ namespace FEX::HLE::x32 {
   };
 
   void RegisterSocket() {
-    REGISTER_SYSCALL_IMPL_X32(socketcall, [](FEXCore::Core::InternalThreadState *Thread, uint32_t call, uint32_t *Arguments) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(socketcall, [](FEXCore::Core::CpuStateFrame *Frame, uint32_t call, uint32_t *Arguments) -> uint64_t {
       uint64_t Result{};
 
       switch (call) {
@@ -246,7 +246,7 @@ namespace FEX::HLE::x32 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(sendmmsg, [](FEXCore::Core::InternalThreadState *Thread, int sockfd, compat_ptr<mmsghdr_32> msgvec, uint32_t vlen, int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(sendmmsg, [](FEXCore::Core::CpuStateFrame *Frame, int sockfd, compat_ptr<mmsghdr_32> msgvec, uint32_t vlen, int flags) -> uint64_t {
       std::vector<iovec> Host_iovec;
       std::vector<uint8_t> Controllen;
       std::vector<struct msghdr> Messages{vlen};

--- a/Source/Tests/LinuxSyscalls/x32/Syscalls.h
+++ b/Source/Tests/LinuxSyscalls/x32/Syscalls.h
@@ -117,7 +117,7 @@ void RegisterSyscallInternal(int SyscallNumber,
 // Deduces return, args... from the function passed
 // Does not work with lambas, because they are objects with operator (), not functions
 template<typename R, typename ...Args>
-bool RegisterSyscall(int SyscallNumber, const char *Name, R(*fn)(FEXCore::Core::InternalThreadState *Thread, Args...)) {
+bool RegisterSyscall(int SyscallNumber, const char *Name, R(*fn)(FEXCore::Core::CpuStateFrame *Frame, Args...)) {
 #ifdef DEBUG_STRACE
   auto TraceFormatString = std::string(Name) + "(" + CollectArgsFmtString<Args...>() + ") = %ld";
 #endif

--- a/Source/Tests/LinuxSyscalls/x32/Thread.h
+++ b/Source/Tests/LinuxSyscalls/x32/Thread.h
@@ -3,7 +3,7 @@
 
 namespace FEXCore::Core {
 struct InternalThreadState;
-struct CPUState;
+struct CpuStateFrame;
 }
 
 namespace FEX::HLE::x32 {
@@ -21,5 +21,5 @@ namespace FEX::HLE::x32 {
   };
 
   uint64_t SetThreadArea(FEXCore::Core::InternalThreadState *Thread, void *tls);
-  void AdjustRipForNewThread(FEXCore::Core::CPUState *Thread);
+  void AdjustRipForNewThread(FEXCore::Core::CpuStateFrame *Frame);
 }

--- a/Source/Tests/LinuxSyscalls/x32/Thread.h
+++ b/Source/Tests/LinuxSyscalls/x32/Thread.h
@@ -20,6 +20,6 @@ namespace FEX::HLE::x32 {
     uint32_t useable         : 1;
   };
 
-  uint64_t SetThreadArea(FEXCore::Core::InternalThreadState *Thread, void *tls);
+  uint64_t SetThreadArea(FEXCore::Core::CpuStateFrame *Frame, void *tls);
   void AdjustRipForNewThread(FEXCore::Core::CpuStateFrame *Frame);
 }

--- a/Source/Tests/LinuxSyscalls/x32/Time.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Time.cpp
@@ -15,7 +15,7 @@ ARG_TO_STR(FEX::HLE::x32::compat_ptr<FEX::HLE::x32::timespec32>, "%lx")
 
 namespace FEX::HLE::x32 {
   void RegisterTime() {
-    REGISTER_SYSCALL_IMPL_X32(gettimeofday, [](FEXCore::Core::InternalThreadState *Thread, timeval32 *tv, struct timezone *tz) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(gettimeofday, [](FEXCore::Core::CpuStateFrame *Frame, timeval32 *tv, struct timezone *tz) -> uint64_t {
       struct timeval tv64{};
       struct timeval *tv_ptr{};
       if (tv) {
@@ -30,7 +30,7 @@ namespace FEX::HLE::x32 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(nanosleep, [](FEXCore::Core::InternalThreadState *Thread, const timespec32 *req, timespec32 *rem) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(nanosleep, [](FEXCore::Core::CpuStateFrame *Frame, const timespec32 *req, timespec32 *rem) -> uint64_t {
       struct timespec req64{};
       struct timespec rem64{};
 
@@ -47,7 +47,7 @@ namespace FEX::HLE::x32 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(clock_gettime, [](FEXCore::Core::InternalThreadState *Thread, clockid_t clk_id, timespec32 *tp) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(clock_gettime, [](FEXCore::Core::CpuStateFrame *Frame, clockid_t clk_id, timespec32 *tp) -> uint64_t {
       struct timespec tp64{};
       uint64_t Result = ::clock_gettime(clk_id, &tp64);
       if (tp) {
@@ -56,7 +56,7 @@ namespace FEX::HLE::x32 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(clock_getres, [](FEXCore::Core::InternalThreadState *Thread, clockid_t clk_id, timespec32 *tp) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(clock_getres, [](FEXCore::Core::CpuStateFrame *Frame, clockid_t clk_id, timespec32 *tp) -> uint64_t {
       struct timespec tp64{};
       uint64_t Result = ::clock_getres(clk_id, &tp64);
       if (tp) {
@@ -65,7 +65,7 @@ namespace FEX::HLE::x32 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(clock_nanosleep, [](FEXCore::Core::InternalThreadState *Thread, clockid_t clockid, int flags, const timespec32 *request, timespec32 *remain) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(clock_nanosleep, [](FEXCore::Core::CpuStateFrame *Frame, clockid_t clockid, int flags, const timespec32 *request, timespec32 *remain) -> uint64_t {
       struct timespec req64{};
       struct timespec rem64{};
       struct timespec *rem64_ptr{};
@@ -82,14 +82,14 @@ namespace FEX::HLE::x32 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(clock_settime, [](FEXCore::Core::InternalThreadState *Thread, clockid_t clockid, const timespec32 *tp) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(clock_settime, [](FEXCore::Core::CpuStateFrame *Frame, clockid_t clockid, const timespec32 *tp) -> uint64_t {
       struct timespec tp64{};
       tp64 = *tp;
       uint64_t Result = ::clock_settime(clockid, &tp64);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(utimensat, [](FEXCore::Core::InternalThreadState *Thread, int dirfd, const char *pathname, const compat_ptr<timespec32> times, int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(utimensat, [](FEXCore::Core::CpuStateFrame *Frame, int dirfd, const char *pathname, const compat_ptr<timespec32> times, int flags) -> uint64_t {
       timespec times64[2]{};
       times64[0] = times[0];
       times64[1] = times[1];
@@ -98,32 +98,32 @@ namespace FEX::HLE::x32 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(clock_gettime64, [](FEXCore::Core::InternalThreadState *Thread, clockid_t clk_id, timespec *tp) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(clock_gettime64, [](FEXCore::Core::CpuStateFrame *Frame, clockid_t clk_id, timespec *tp) -> uint64_t {
       uint64_t Result = ::clock_gettime(clk_id, tp);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(clock_adjtime64, [](FEXCore::Core::InternalThreadState *Thread, clockid_t clk_id, struct timex *buf) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(clock_adjtime64, [](FEXCore::Core::CpuStateFrame *Frame, clockid_t clk_id, struct timex *buf) -> uint64_t {
       uint64_t Result = ::clock_adjtime(clk_id, buf);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(clock_settime64, [](FEXCore::Core::InternalThreadState *Thread, clockid_t clockid, const struct timespec *tp) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(clock_settime64, [](FEXCore::Core::CpuStateFrame *Frame, clockid_t clockid, const struct timespec *tp) -> uint64_t {
       uint64_t Result = ::clock_settime(clockid, tp);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(clock_getres_time64, [](FEXCore::Core::InternalThreadState *Thread, clockid_t clk_id, timespec *tp) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(clock_getres_time64, [](FEXCore::Core::CpuStateFrame *Frame, clockid_t clk_id, timespec *tp) -> uint64_t {
       uint64_t Result = ::clock_getres(clk_id, tp);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(clock_nanosleep_time64, [](FEXCore::Core::InternalThreadState *Thread, clockid_t clockid, int flags, const struct timespec *request, struct timespec *remain) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(clock_nanosleep_time64, [](FEXCore::Core::CpuStateFrame *Frame, clockid_t clockid, int flags, const struct timespec *request, struct timespec *remain) -> uint64_t {
       uint64_t Result = ::clock_nanosleep(clockid, flags, request, remain);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(utimensat_time64, [](FEXCore::Core::InternalThreadState *Thread, int dirfd, const char *pathname, const struct timespec times[2], int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(utimensat_time64, [](FEXCore::Core::CpuStateFrame *Frame, int dirfd, const char *pathname, const struct timespec times[2], int flags) -> uint64_t {
       uint64_t Result = ::utimensat(dirfd, pathname, times, flags);
       SYSCALL_ERRNO();
     });

--- a/Source/Tests/LinuxSyscalls/x32/Timer.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Timer.cpp
@@ -12,12 +12,12 @@
 
 namespace FEX::HLE::x32 {
   void RegisterTimer() {
-    REGISTER_SYSCALL_IMPL_X32(timer_settime64, [](FEXCore::Core::InternalThreadState *Thread, timer_t timerid, int flags, const struct itimerspec *new_value, struct itimerspec *old_value) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(timer_settime64, [](FEXCore::Core::CpuStateFrame *Frame, timer_t timerid, int flags, const struct itimerspec *new_value, struct itimerspec *old_value) -> uint64_t {
       uint64_t Result = ::timer_settime(timerid, flags, new_value, old_value);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(timer_gettime64, [](FEXCore::Core::InternalThreadState *Thread, timer_t timerid, struct itimerspec *curr_value) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(timer_gettime64, [](FEXCore::Core::CpuStateFrame *Frame, timer_t timerid, struct itimerspec *curr_value) -> uint64_t {
       uint64_t Result = ::timer_gettime(timerid, curr_value);
       SYSCALL_ERRNO();
     });

--- a/Source/Tests/LinuxSyscalls/x64/EPoll.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/EPoll.cpp
@@ -11,7 +11,7 @@
 
 namespace FEX::HLE::x64 {
   void RegisterEpoll() {
-    REGISTER_SYSCALL_IMPL_X64(epoll_wait, [](FEXCore::Core::InternalThreadState *Thread, int epfd, epoll_event_x86 *events, int maxevents, int timeout) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(epoll_wait, [](FEXCore::Core::CpuStateFrame *Frame, int epfd, epoll_event_x86 *events, int maxevents, int timeout) -> uint64_t {
       std::vector<struct epoll_event> Events;
       Events.resize(maxevents);
       uint64_t Result = epoll_wait(epfd, &Events.at(0), maxevents, timeout);
@@ -24,7 +24,7 @@ namespace FEX::HLE::x64 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(epoll_ctl, [](FEXCore::Core::InternalThreadState *Thread, int epfd, int op, int fd, epoll_event_x86 *event) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(epoll_ctl, [](FEXCore::Core::CpuStateFrame *Frame, int epfd, int op, int fd, epoll_event_x86 *event) -> uint64_t {
       struct epoll_event Event;
       struct epoll_event *EventPtr{};
       if (event) {
@@ -38,7 +38,7 @@ namespace FEX::HLE::x64 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(epoll_pwait, [](FEXCore::Core::InternalThreadState *Thread, int epfd, epoll_event_x86 *events, int maxevent, int timeout, const void* sigmask) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(epoll_pwait, [](FEXCore::Core::CpuStateFrame *Frame, int epfd, epoll_event_x86 *events, int maxevent, int timeout, const void* sigmask) -> uint64_t {
       std::vector<struct epoll_event> Events;
       Events.resize(maxevent);
 

--- a/Source/Tests/LinuxSyscalls/x64/FD.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/FD.cpp
@@ -60,37 +60,37 @@ namespace FEX::HLE::x64 {
   }
 
   void RegisterFD() {
-    REGISTER_SYSCALL_IMPL_X64(poll, [](FEXCore::Core::InternalThreadState *Thread, struct pollfd *fds, nfds_t nfds, int timeout) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(poll, [](FEXCore::Core::CpuStateFrame *Frame, struct pollfd *fds, nfds_t nfds, int timeout) -> uint64_t {
       uint64_t Result = ::poll(fds, nfds, timeout);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(select, [](FEXCore::Core::InternalThreadState *Thread, int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds, struct timeval *timeout) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(select, [](FEXCore::Core::CpuStateFrame *Frame, int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds, struct timeval *timeout) -> uint64_t {
       uint64_t Result = ::select(nfds, readfds, writefds, exceptfds, timeout);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(fcntl, [](FEXCore::Core::InternalThreadState *Thread, int fd, int cmd, uint64_t arg) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(fcntl, [](FEXCore::Core::CpuStateFrame *Frame, int fd, int cmd, uint64_t arg) -> uint64_t {
       uint64_t Result = ::fcntl(fd, cmd, arg);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(futimesat, [](FEXCore::Core::InternalThreadState *Thread, int dirfd, const char *pathname, const struct timeval times[2]) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(futimesat, [](FEXCore::Core::CpuStateFrame *Frame, int dirfd, const char *pathname, const struct timeval times[2]) -> uint64_t {
       uint64_t Result = ::futimesat(dirfd, pathname, times);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(utimensat, [](FEXCore::Core::InternalThreadState *Thread, int dirfd, const char *pathname, const struct timespec times[2], int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(utimensat, [](FEXCore::Core::CpuStateFrame *Frame, int dirfd, const char *pathname, const struct timespec times[2], int flags) -> uint64_t {
       uint64_t Result = ::syscall(SYS_utimensat, dirfd, pathname, times, flags);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(pselect6, [](FEXCore::Core::InternalThreadState *Thread, int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds, const struct timespec *timeout, const sigset_t *sigmask) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(pselect6, [](FEXCore::Core::CpuStateFrame *Frame, int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds, const struct timespec *timeout, const sigset_t *sigmask) -> uint64_t {
       uint64_t Result = pselect(nfds, readfds, writefds, exceptfds, timeout, sigmask);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(stat, [](FEXCore::Core::InternalThreadState *Thread, const char *pathname, guest_stat *buf) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(stat, [](FEXCore::Core::CpuStateFrame *Frame, const char *pathname, guest_stat *buf) -> uint64_t {
       struct stat host_stat;
       uint64_t Result = FEX::HLE::_SyscallHandler->FM.Stat(pathname, &host_stat);
       if (Result != -1) {
@@ -99,7 +99,7 @@ namespace FEX::HLE::x64 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(fstat, [](FEXCore::Core::InternalThreadState *Thread, int fd, guest_stat *buf) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(fstat, [](FEXCore::Core::CpuStateFrame *Frame, int fd, guest_stat *buf) -> uint64_t {
       struct stat host_stat;
       uint64_t Result = ::fstat(fd, &host_stat);
       if (Result != -1) {
@@ -108,7 +108,7 @@ namespace FEX::HLE::x64 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(lstat, [](FEXCore::Core::InternalThreadState *Thread, const char *path, guest_stat *buf) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(lstat, [](FEXCore::Core::CpuStateFrame *Frame, const char *path, guest_stat *buf) -> uint64_t {
       struct stat host_stat;
       uint64_t Result = FEX::HLE::_SyscallHandler->FM.Lstat(path, &host_stat);
       if (Result != -1) {
@@ -117,17 +117,17 @@ namespace FEX::HLE::x64 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(readv, [](FEXCore::Core::InternalThreadState *Thread, int fd, const struct iovec *iov, int iovcnt) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(readv, [](FEXCore::Core::CpuStateFrame *Frame, int fd, const struct iovec *iov, int iovcnt) -> uint64_t {
       uint64_t Result = ::readv(fd, iov, iovcnt);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(writev, [](FEXCore::Core::InternalThreadState *Thread, int fd, const struct iovec *iov, int iovcnt) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(writev, [](FEXCore::Core::CpuStateFrame *Frame, int fd, const struct iovec *iov, int iovcnt) -> uint64_t {
       uint64_t Result = ::writev(fd, iov, iovcnt);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(newfstatat, [](FEXCore::Core::InternalThreadState *Thread, int dirfd, const char *pathname, guest_stat *buf, int flag) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(newfstatat, [](FEXCore::Core::CpuStateFrame *Frame, int dirfd, const char *pathname, guest_stat *buf, int flag) -> uint64_t {
       struct stat host_stat;
       uint64_t Result = FEX::HLE::_SyscallHandler->FM.NewFSStatAt(dirfd, pathname, &host_stat, flag);
       if (Result != -1) {
@@ -136,48 +136,48 @@ namespace FEX::HLE::x64 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(vmsplice, [](FEXCore::Core::InternalThreadState *Thread, int fd, const struct iovec *iov, unsigned long nr_segs, unsigned int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(vmsplice, [](FEXCore::Core::CpuStateFrame *Frame, int fd, const struct iovec *iov, unsigned long nr_segs, unsigned int flags) -> uint64_t {
       uint64_t Result = ::vmsplice(fd, iov, nr_segs, flags);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(preadv, [](FEXCore::Core::InternalThreadState *Thread, int fd, const struct iovec *iov, int iovcnt, off_t offset) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(preadv, [](FEXCore::Core::CpuStateFrame *Frame, int fd, const struct iovec *iov, int iovcnt, off_t offset) -> uint64_t {
       uint64_t Result = ::preadv(fd, iov, iovcnt, offset);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(pwritev, [](FEXCore::Core::InternalThreadState *Thread, int fd, const struct iovec *iov, int iovcnt, off_t offset) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(pwritev, [](FEXCore::Core::CpuStateFrame *Frame, int fd, const struct iovec *iov, int iovcnt, off_t offset) -> uint64_t {
       uint64_t Result = ::pwritev(fd, iov, iovcnt, offset);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(preadv2, [](FEXCore::Core::InternalThreadState *Thread, int fd, const struct iovec *iov, int iovcnt, off_t offset, int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(preadv2, [](FEXCore::Core::CpuStateFrame *Frame, int fd, const struct iovec *iov, int iovcnt, off_t offset, int flags) -> uint64_t {
       uint64_t Result = ::preadv2(fd, iov, iovcnt, offset, flags);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(pwritev2, [](FEXCore::Core::InternalThreadState *Thread, int fd, const struct iovec *iov, int iovcnt, off_t offset, int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(pwritev2, [](FEXCore::Core::CpuStateFrame *Frame, int fd, const struct iovec *iov, int iovcnt, off_t offset, int flags) -> uint64_t {
       uint64_t Result = ::pwritev2(fd, iov, iovcnt, offset, flags);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(process_vm_readv, [](FEXCore::Core::InternalThreadState *Thread, pid_t pid, const struct iovec *local_iov, unsigned long liovcnt, const struct iovec *remote_iov, unsigned long riovcnt, unsigned long flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(process_vm_readv, [](FEXCore::Core::CpuStateFrame *Frame, pid_t pid, const struct iovec *local_iov, unsigned long liovcnt, const struct iovec *remote_iov, unsigned long riovcnt, unsigned long flags) -> uint64_t {
       uint64_t Result = ::process_vm_readv(pid, local_iov, liovcnt, remote_iov, riovcnt, flags);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(process_vm_writev, [](FEXCore::Core::InternalThreadState *Thread, pid_t pid, const struct iovec *local_iov, unsigned long liovcnt, const struct iovec *remote_iov, unsigned long riovcnt, unsigned long flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(process_vm_writev, [](FEXCore::Core::CpuStateFrame *Frame, pid_t pid, const struct iovec *local_iov, unsigned long liovcnt, const struct iovec *remote_iov, unsigned long riovcnt, unsigned long flags) -> uint64_t {
       uint64_t Result = ::process_vm_writev(pid, local_iov, liovcnt, remote_iov, riovcnt, flags);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(ppoll, [](FEXCore::Core::InternalThreadState *Thread, struct pollfd *fds, nfds_t nfds, const struct timespec *timeout_ts, const sigset_t *sigmask, size_t sigsetsize) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(ppoll, [](FEXCore::Core::CpuStateFrame *Frame, struct pollfd *fds, nfds_t nfds, const struct timespec *timeout_ts, const sigset_t *sigmask, size_t sigsetsize) -> uint64_t {
       // sigsetsize is unused here since it is currently a constant and not exposed through glibc
       uint64_t Result = ::ppoll(fds, nfds, timeout_ts, sigmask);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(getdents, [](FEXCore::Core::InternalThreadState *Thread, int fd, void *dirp, uint32_t count) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(getdents, [](FEXCore::Core::CpuStateFrame *Frame, int fd, void *dirp, uint32_t count) -> uint64_t {
   #ifdef SYS_getdents
       uint64_t Result = syscall(SYS_getdents,
         static_cast<uint64_t>(fd),
@@ -190,7 +190,7 @@ namespace FEX::HLE::x64 {
   #endif
     });
 
-    REGISTER_SYSCALL_IMPL_X64(getdents64, [](FEXCore::Core::InternalThreadState *Thread, int fd, void *dirp, uint32_t count) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(getdents64, [](FEXCore::Core::CpuStateFrame *Frame, int fd, void *dirp, uint32_t count) -> uint64_t {
       uint64_t Result = syscall(SYS_getdents64,
         static_cast<uint64_t>(fd),
         reinterpret_cast<uint64_t>(dirp),
@@ -198,7 +198,7 @@ namespace FEX::HLE::x64 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(sendfile, [](FEXCore::Core::InternalThreadState *Thread, int out_fd, int in_fd, off_t *offset, size_t count) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(sendfile, [](FEXCore::Core::CpuStateFrame *Frame, int out_fd, int in_fd, off_t *offset, size_t count) -> uint64_t {
       uint64_t Result = ::sendfile(out_fd, in_fd, offset, count);
       SYSCALL_ERRNO();
     });

--- a/Source/Tests/LinuxSyscalls/x64/IO.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/IO.cpp
@@ -7,12 +7,12 @@
 
 namespace FEX::HLE::x64 {
   void RegisterIO() {
-    REGISTER_SYSCALL_IMPL_X64(io_getevents, [](FEXCore::Core::InternalThreadState *Thread, aio_context_t ctx_id, long min_nr, long nr, struct io_event *events, struct timespec *timeout) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(io_getevents, [](FEXCore::Core::CpuStateFrame *Frame, aio_context_t ctx_id, long min_nr, long nr, struct io_event *events, struct timespec *timeout) -> uint64_t {
       uint64_t Result = ::syscall(SYS_io_getevents, ctx_id, min_nr, nr, events, timeout);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(io_pgetevents, [](FEXCore::Core::InternalThreadState *Thread, aio_context_t ctx_id, long min_nr, long nr, struct io_event *events, struct timespec *timeout, const struct io_sigset  *usig) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(io_pgetevents, [](FEXCore::Core::CpuStateFrame *Frame, aio_context_t ctx_id, long min_nr, long nr, struct io_event *events, struct timespec *timeout, const struct io_sigset  *usig) -> uint64_t {
       uint64_t Result = ::syscall(SYS_io_pgetevents, ctx_id, min_nr, nr, events, timeout);
       SYSCALL_ERRNO();
     });

--- a/Source/Tests/LinuxSyscalls/x64/Info.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Info.cpp
@@ -9,12 +9,12 @@
 
 namespace FEX::HLE::x64 {
   void RegisterInfo() {
-    REGISTER_SYSCALL_IMPL_X64(sysinfo, [](FEXCore::Core::InternalThreadState *Thread, struct sysinfo *info) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(sysinfo, [](FEXCore::Core::CpuStateFrame *Frame, struct sysinfo *info) -> uint64_t {
       uint64_t Result = ::sysinfo(info);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(getrusage, [](FEXCore::Core::InternalThreadState *Thread, int who, struct rusage *usage) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(getrusage, [](FEXCore::Core::CpuStateFrame *Frame, int who, struct rusage *usage) -> uint64_t {
       uint64_t Result = ::getrusage(who, usage);
       SYSCALL_ERRNO();
     });

--- a/Source/Tests/LinuxSyscalls/x64/Ioctl.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Ioctl.cpp
@@ -7,7 +7,7 @@
 
 namespace FEX::HLE::x64 {
   void RegisterIoctl() {
-    REGISTER_SYSCALL_IMPL_X64(ioctl, [](FEXCore::Core::InternalThreadState *Thread, int fd, uint64_t request, void *args) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(ioctl, [](FEXCore::Core::CpuStateFrame *Frame, int fd, uint64_t request, void *args) -> uint64_t {
       uint64_t Result = ::ioctl(fd, request, args);
       SYSCALL_ERRNO();
     });

--- a/Source/Tests/LinuxSyscalls/x64/Memory.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Memory.cpp
@@ -21,8 +21,10 @@ static std::string get_fdpath(int fd)
 
 namespace FEX::HLE::x64 {
   void RegisterMemory() {
-    REGISTER_SYSCALL_IMPL_X64(munmap, [](FEXCore::Core::InternalThreadState *Thread, void *addr, size_t length) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(munmap, [](FEXCore::Core::CpuStateFrame *Frame, void *addr, size_t length) -> uint64_t {
       uint64_t Result = ::munmap(addr, length);
+
+      auto Thread = Frame->Thread;
       if (Result != -1) {
         FEXCore::Context::RemoveNamedRegion(Thread->CTX, (uintptr_t)addr, length);
         FEXCore::Context::FlushCodeRange(Thread, (uintptr_t)addr, length);
@@ -30,9 +32,11 @@ namespace FEX::HLE::x64 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(mmap, [](FEXCore::Core::InternalThreadState *Thread, void *addr, size_t length, int prot, int flags, int fd, off_t offset) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(mmap, [](FEXCore::Core::CpuStateFrame *Frame, void *addr, size_t length, int prot, int flags, int fd, off_t offset) -> uint64_t {
       static FEX_CONFIG_OPT(AOTIRLoad, AOTIR_LOAD);
       uint64_t Result = reinterpret_cast<uint64_t>(::mmap(addr, length, prot, flags, fd, offset));
+
+      auto Thread = Frame->Thread;
       if (Result != -1) {
         if (!(flags & MAP_ANONYMOUS)) {
           auto filename = get_fdpath(fd);
@@ -44,30 +48,32 @@ namespace FEX::HLE::x64 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(mremap, [](FEXCore::Core::InternalThreadState *Thread, void *old_address, size_t old_size, size_t new_size, int flags, void *new_address) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(mremap, [](FEXCore::Core::CpuStateFrame *Frame, void *old_address, size_t old_size, size_t new_size, int flags, void *new_address) -> uint64_t {
       uint64_t Result = reinterpret_cast<uint64_t>(::mremap(old_address, old_size, new_size, flags, new_address));
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(mprotect, [](FEXCore::Core::InternalThreadState *Thread, void *addr, size_t len, int prot) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(mprotect, [](FEXCore::Core::CpuStateFrame *Frame, void *addr, size_t len, int prot) -> uint64_t {
       uint64_t Result = ::mprotect(addr, len, prot);
+
+      auto Thread = Frame->Thread;
       if (Result != -1 && prot & PROT_EXEC) {
         FEXCore::Context::FlushCodeRange(Thread, (uintptr_t)addr, len);
       }
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(mlockall, [](FEXCore::Core::InternalThreadState *Thread, int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(mlockall, [](FEXCore::Core::CpuStateFrame *Frame, int flags) -> uint64_t {
       uint64_t Result = ::mlockall(flags);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(munlockall, [](FEXCore::Core::InternalThreadState *Thread) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(munlockall, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t {
       uint64_t Result = ::munlockall();
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(shmat, [](FEXCore::Core::InternalThreadState *Thread, int shmid, const void *shmaddr, int shmflg) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(shmat, [](FEXCore::Core::CpuStateFrame *Frame, int shmid, const void *shmaddr, int shmflg) -> uint64_t {
       uint64_t Result = reinterpret_cast<uint64_t>(shmat(shmid, shmaddr, shmflg));
       SYSCALL_ERRNO();
     });

--- a/Source/Tests/LinuxSyscalls/x64/Msg.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Msg.cpp
@@ -6,12 +6,12 @@
 
 namespace FEX::HLE::x64 {
   void RegisterMsg() {
-    REGISTER_SYSCALL_IMPL_X64(mq_timedsend, [](FEXCore::Core::InternalThreadState *Thread, mqd_t mqdes, const char *msg_ptr, size_t msg_len, unsigned int msg_prio, const struct timespec *abs_timeout) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(mq_timedsend, [](FEXCore::Core::CpuStateFrame *Frame, mqd_t mqdes, const char *msg_ptr, size_t msg_len, unsigned int msg_prio, const struct timespec *abs_timeout) -> uint64_t {
       uint64_t Result = ::mq_timedsend(mqdes, msg_ptr, msg_len, msg_prio, abs_timeout);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(mq_timedreceive, [](FEXCore::Core::InternalThreadState *Thread, mqd_t mqdes, char *msg_ptr, size_t msg_len, unsigned int *msg_prio, const struct timespec *abs_timeout) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(mq_timedreceive, [](FEXCore::Core::CpuStateFrame *Frame, mqd_t mqdes, char *msg_ptr, size_t msg_len, unsigned int *msg_prio, const struct timespec *abs_timeout) -> uint64_t {
       uint64_t Result = ::mq_timedreceive(mqdes, msg_ptr, msg_len, msg_prio, abs_timeout);
       SYSCALL_ERRNO();
     });

--- a/Source/Tests/LinuxSyscalls/x64/NotImplemented.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/NotImplemented.cpp
@@ -3,11 +3,11 @@
 #include "Tests/LinuxSyscalls/x64/Syscalls.h"
 
 namespace FEX::HLE::x64 {
-#define REGISTER_SYSCALL_NOT_IMPL_X64(name) REGISTER_SYSCALL_IMPL_X64(name, [](FEXCore::Core::InternalThreadState *Thread) -> uint64_t { \
+#define REGISTER_SYSCALL_NOT_IMPL_X64(name) REGISTER_SYSCALL_IMPL_X64(name, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t { \
   LogMan::Msg::D("Using deprecated/removed syscall: " #name); \
   return -ENOSYS; \
 });
-#define REGISTER_SYSCALL_NO_PERM_X64(name) REGISTER_SYSCALL_IMPL_X64(name, [](FEXCore::Core::InternalThreadState *Thread) -> uint64_t { \
+#define REGISTER_SYSCALL_NO_PERM_X64(name) REGISTER_SYSCALL_IMPL_X64(name, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t { \
   return -EPERM; \
 });
 

--- a/Source/Tests/LinuxSyscalls/x64/Sched.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Sched.cpp
@@ -11,7 +11,7 @@
 
 namespace FEX::HLE::x64 {
   void RegisterSched() {
-    REGISTER_SYSCALL_IMPL_X64(sched_rr_get_interval, [](FEXCore::Core::InternalThreadState *Thread, pid_t pid, struct timespec *tp) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(sched_rr_get_interval, [](FEXCore::Core::CpuStateFrame *Frame, pid_t pid, struct timespec *tp) -> uint64_t {
       uint64_t Result = ::sched_rr_get_interval(pid, tp);
       SYSCALL_ERRNO();
     });

--- a/Source/Tests/LinuxSyscalls/x64/Semaphore.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Semaphore.cpp
@@ -6,12 +6,12 @@
 
 namespace FEX::HLE::x64 {
   void RegisterSemaphore() {
-   REGISTER_SYSCALL_IMPL_X64(semop, [](FEXCore::Core::InternalThreadState *Thread, int semid, struct sembuf *sops, size_t nsops) -> uint64_t {
+   REGISTER_SYSCALL_IMPL_X64(semop, [](FEXCore::Core::CpuStateFrame *Frame, int semid, struct sembuf *sops, size_t nsops) -> uint64_t {
       uint64_t Result = ::semop(semid, sops, nsops);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(semtimedop, [](FEXCore::Core::InternalThreadState *Thread, int semid, struct sembuf *sops, size_t nsops, const struct timespec *timeout) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(semtimedop, [](FEXCore::Core::CpuStateFrame *Frame, int semid, struct sembuf *sops, size_t nsops, const struct timespec *timeout) -> uint64_t {
       uint64_t Result = ::semtimedop(semid, sops, nsops, timeout);
       SYSCALL_ERRNO();
     });

--- a/Source/Tests/LinuxSyscalls/x64/Signals.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Signals.cpp
@@ -11,7 +11,7 @@
 
 namespace FEX::HLE::x64 {
   void RegisterSignals() {
-    REGISTER_SYSCALL_IMPL_X64(rt_sigaction, [](FEXCore::Core::InternalThreadState *Thread, int signum, const FEXCore::GuestSigAction *act, FEXCore::GuestSigAction *oldact) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(rt_sigaction, [](FEXCore::Core::CpuStateFrame *Frame, int signum, const FEXCore::GuestSigAction *act, FEXCore::GuestSigAction *oldact) -> uint64_t {
       return FEX::HLE::_SyscallHandler->GetSignalDelegator()->RegisterGuestSignalHandler(signum, act, oldact);
     });
   }

--- a/Source/Tests/LinuxSyscalls/x64/Socket.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Socket.cpp
@@ -4,17 +4,17 @@
 
 namespace FEX::HLE::x64 {
   void RegisterSocket() {
-    REGISTER_SYSCALL_IMPL_X64(accept, [](FEXCore::Core::InternalThreadState *Thread, int sockfd, struct sockaddr *addr, socklen_t *addrlen) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(accept, [](FEXCore::Core::CpuStateFrame *Frame, int sockfd, struct sockaddr *addr, socklen_t *addrlen) -> uint64_t {
       uint64_t Result = ::accept(sockfd, addr, addrlen);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(recvmmsg, [](FEXCore::Core::InternalThreadState *Thread, int sockfd, struct mmsghdr *msgvec, unsigned int vlen, int flags, struct timespec *timeout) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(recvmmsg, [](FEXCore::Core::CpuStateFrame *Frame, int sockfd, struct mmsghdr *msgvec, unsigned int vlen, int flags, struct timespec *timeout) -> uint64_t {
       uint64_t Result = ::recvmmsg(sockfd, msgvec, vlen, flags, timeout);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(sendmmsg, [](FEXCore::Core::InternalThreadState *Thread, int sockfd, struct mmsghdr *msgvec, uint32_t vlen, int flags) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(sendmmsg, [](FEXCore::Core::CpuStateFrame *Frame, int sockfd, struct mmsghdr *msgvec, uint32_t vlen, int flags) -> uint64_t {
       uint64_t Result = ::sendmmsg(sockfd, msgvec, vlen, flags);
       SYSCALL_ERRNO();
     });

--- a/Source/Tests/LinuxSyscalls/x64/Syscalls.h
+++ b/Source/Tests/LinuxSyscalls/x64/Syscalls.h
@@ -37,7 +37,7 @@ void RegisterSyscallInternal(int SyscallNumber,
 // Deduces return, args... from the function passed
 // Does not work with lambas, because they are objects with operator (), not functions
 template<typename R, typename ...Args>
-bool RegisterSyscall(int SyscallNumber, const char *Name, R(*fn)(FEXCore::Core::InternalThreadState *Thread, Args...)) {
+bool RegisterSyscall(int SyscallNumber, const char *Name, R(*fn)(FEXCore::Core::CpuStateFrame *Frame, Args...)) {
 #ifdef DEBUG_STRACE
   auto TraceFormatString = std::string(Name) + "(" + CollectArgsFmtString<Args...>() + ") = %ld";
 #endif

--- a/Source/Tests/LinuxSyscalls/x64/Thread.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Thread.cpp
@@ -18,8 +18,8 @@
 #include <filesystem>
 
 namespace FEX::HLE::x64 {
-  uint64_t SetThreadArea(FEXCore::Core::InternalThreadState *Thread, void *tls) {
-    Thread->CurrentFrame->State.fs = reinterpret_cast<uint64_t>(tls);
+  uint64_t SetThreadArea(FEXCore::Core::CpuStateFrame *Frame, void *tls) {
+    Frame->State.fs = reinterpret_cast<uint64_t>(tls);
     return 0;
   }
 
@@ -36,7 +36,7 @@ namespace FEX::HLE::x64 {
   }
 
   void RegisterThread() {
-    REGISTER_SYSCALL_IMPL_X64(futex, [](FEXCore::Core::InternalThreadState *Thread, int *uaddr, int futex_op, int val, const struct timespec *timeout, int *uaddr2, uint32_t val3) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(futex, [](FEXCore::Core::CpuStateFrame *Frame, int *uaddr, int futex_op, int val, const struct timespec *timeout, int *uaddr2, uint32_t val3) -> uint64_t {
       uint64_t Result = syscall(SYS_futex,
         uaddr,
         futex_op,
@@ -47,7 +47,7 @@ namespace FEX::HLE::x64 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(clone, [](FEXCore::Core::InternalThreadState *Thread, uint32_t flags, void *stack, pid_t *parent_tid, pid_t *child_tid, void *tls) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(clone, [](FEXCore::Core::CpuStateFrame *Frame, uint32_t flags, void *stack, pid_t *parent_tid, pid_t *child_tid, void *tls) -> uint64_t {
     #define FLAGPRINT(x, y) if (flags & (y)) LogMan::Msg::I("\tFlag: " #x)
       FLAGPRINT(CSIGNAL,              0x000000FF);
       FLAGPRINT(CLONE_VM,             0x00000100);
@@ -74,6 +74,8 @@ namespace FEX::HLE::x64 {
       FLAGPRINT(CLONE_NEWNET,         0x40000000);
       FLAGPRINT(CLONE_IO,             0x80000000);
 
+      auto Thread = Frame->Thread;
+
       if (AnyFlagsSet(flags, CLONE_UNTRACED | CLONE_PTRACE)) {
         LogMan::Msg::D("clone: Ptrace* not supported");
       }
@@ -96,14 +98,14 @@ namespace FEX::HLE::x64 {
 
         // CLONE_PARENT is ignored (Implied by CLONE_THREAD)
 
-        return FEX::HLE::ForkGuest(Thread, flags, stack, parent_tid, child_tid, tls);
+        return FEX::HLE::ForkGuest(Thread, Frame, flags, stack, parent_tid, child_tid, tls);
       } else {
 
         if (!AllFlagsSet(flags, CLONE_SYSVSEM | CLONE_FS |  CLONE_FILES | CLONE_SIGHAND)) {
           ERROR_AND_DIE("clone: CLONE_THREAD: Unsuported flags w/ CLONE_THREAD (Shared Resources), %X", flags);
         }
 
-        auto NewThread = FEX::HLE::CreateNewThread(Thread, flags, stack, parent_tid, child_tid, tls);
+        auto NewThread = FEX::HLE::CreateNewThread(Thread->CTX, Frame, flags, stack, parent_tid, child_tid, tls);
 
         // Return the new threads TID
         uint64_t Result = NewThread->ThreadManager.GetTID();
@@ -120,24 +122,25 @@ namespace FEX::HLE::x64 {
       }
     });
 
-    REGISTER_SYSCALL_IMPL_X64(set_robust_list, [](FEXCore::Core::InternalThreadState *Thread, struct robust_list_head *head, size_t len) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(set_robust_list, [](FEXCore::Core::CpuStateFrame *Frame, struct robust_list_head *head, size_t len) -> uint64_t {
+      auto Thread = Frame->Thread;
       Thread->ThreadManager.robust_list_head = reinterpret_cast<uint64_t>(head);
       uint64_t Result = ::syscall(SYS_set_robust_list, head, len);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(get_robust_list, [](FEXCore::Core::InternalThreadState *Thread, int pid, struct robust_list_head **head, size_t *len_ptr) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(get_robust_list, [](FEXCore::Core::CpuStateFrame *Frame, int pid, struct robust_list_head **head, size_t *len_ptr) -> uint64_t {
       uint64_t Result = ::syscall(SYS_get_robust_list, pid, head, len_ptr);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(sigaltstack, [](FEXCore::Core::InternalThreadState *Thread, const stack_t *ss, stack_t *old_ss) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(sigaltstack, [](FEXCore::Core::CpuStateFrame *Frame, const stack_t *ss, stack_t *old_ss) -> uint64_t {
       return FEX::HLE::_SyscallHandler->GetSignalDelegator()->RegisterGuestSigAltStack(ss, old_ss);
     });
 
     // launch a new process under fex
     // currently does not propagate argv[0] correctly
-    REGISTER_SYSCALL_IMPL_X64(execve, [](FEXCore::Core::InternalThreadState *Thread, const char *pathname, char *const argv[], char *const envp[]) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(execve, [](FEXCore::Core::CpuStateFrame *Frame, const char *pathname, char *const argv[], char *const envp[]) -> uint64_t {
       std::vector<const char*> Args;
       std::string Filename{};
 
@@ -191,7 +194,7 @@ namespace FEX::HLE::x64 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(wait4, [](FEXCore::Core::InternalThreadState *Thread, pid_t pid, int *wstatus, int options, struct rusage *rusage) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(wait4, [](FEXCore::Core::CpuStateFrame *Frame, pid_t pid, int *wstatus, int options, struct rusage *rusage) -> uint64_t {
       uint64_t Result = ::wait4(pid, wstatus, options, rusage);
       SYSCALL_ERRNO();
     });

--- a/Source/Tests/LinuxSyscalls/x64/Thread.h
+++ b/Source/Tests/LinuxSyscalls/x64/Thread.h
@@ -3,10 +3,10 @@
 
 namespace FEXCore::Core {
 struct InternalThreadState;
-struct CPUState;
+struct CpuStateFrame;
 }
 
 namespace FEX::HLE::x64 {
   uint64_t SetThreadArea(FEXCore::Core::InternalThreadState *Thread, void *tls);
-  void AdjustRipForNewThread(FEXCore::Core::CPUState *Thread);
+  void AdjustRipForNewThread(FEXCore::Core::CpuStateFrame *Frame);
 }

--- a/Source/Tests/LinuxSyscalls/x64/Thread.h
+++ b/Source/Tests/LinuxSyscalls/x64/Thread.h
@@ -7,6 +7,6 @@ struct CpuStateFrame;
 }
 
 namespace FEX::HLE::x64 {
-  uint64_t SetThreadArea(FEXCore::Core::InternalThreadState *Thread, void *tls);
+  uint64_t SetThreadArea(FEXCore::Core::CpuStateFrame *Frame, void *tls);
   void AdjustRipForNewThread(FEXCore::Core::CpuStateFrame *Frame);
 }

--- a/Source/Tests/LinuxSyscalls/x64/Time.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Time.cpp
@@ -12,42 +12,42 @@
 
 namespace FEX::HLE::x64 {
   void RegisterTime() {
-    REGISTER_SYSCALL_IMPL_X64(gettimeofday, [](FEXCore::Core::InternalThreadState *Thread, struct timeval *tv, struct timezone *tz) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(gettimeofday, [](FEXCore::Core::CpuStateFrame *Frame, struct timeval *tv, struct timezone *tz) -> uint64_t {
       uint64_t Result = ::gettimeofday(tv, tz);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(nanosleep, [](FEXCore::Core::InternalThreadState *Thread, const struct timespec *req, struct timespec *rem) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(nanosleep, [](FEXCore::Core::CpuStateFrame *Frame, const struct timespec *req, struct timespec *rem) -> uint64_t {
       uint64_t Result = ::nanosleep(req, rem);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(clock_gettime, [](FEXCore::Core::InternalThreadState *Thread, clockid_t clk_id, struct timespec *tp) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(clock_gettime, [](FEXCore::Core::CpuStateFrame *Frame, clockid_t clk_id, struct timespec *tp) -> uint64_t {
       uint64_t Result = ::clock_gettime(clk_id, tp);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(clock_getres, [](FEXCore::Core::InternalThreadState *Thread, clockid_t clk_id, struct timespec *tp) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(clock_getres, [](FEXCore::Core::CpuStateFrame *Frame, clockid_t clk_id, struct timespec *tp) -> uint64_t {
       uint64_t Result = ::clock_getres(clk_id, tp);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(clock_nanosleep, [](FEXCore::Core::InternalThreadState *Thread, clockid_t clockid, int flags, const struct timespec *request, struct timespec *remain) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(clock_nanosleep, [](FEXCore::Core::CpuStateFrame *Frame, clockid_t clockid, int flags, const struct timespec *request, struct timespec *remain) -> uint64_t {
       uint64_t Result = ::clock_nanosleep(clockid, flags, request, remain);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(clock_settime, [](FEXCore::Core::InternalThreadState *Thread, clockid_t clockid, const struct timespec *tp) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(clock_settime, [](FEXCore::Core::CpuStateFrame *Frame, clockid_t clockid, const struct timespec *tp) -> uint64_t {
       uint64_t Result = ::clock_settime(clockid, tp);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(settimeofday, [](FEXCore::Core::InternalThreadState *Thread, const struct timeval *tv, const struct timezone *tz) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(settimeofday, [](FEXCore::Core::CpuStateFrame *Frame, const struct timeval *tv, const struct timezone *tz) -> uint64_t {
       uint64_t Result = ::settimeofday(tv, tz);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X64(utimes, [](FEXCore::Core::InternalThreadState *Thread, const char *filename, const struct timeval times[2]) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(utimes, [](FEXCore::Core::CpuStateFrame *Frame, const char *filename, const struct timeval times[2]) -> uint64_t {
       uint64_t Result = ::utimes(filename, times);
       SYSCALL_ERRNO();
     });

--- a/Source/Tools/Debugger/DebuggerState.cpp
+++ b/Source/Tools/Debugger/DebuggerState.cpp
@@ -59,10 +59,11 @@ void SetRunningMode(int RunningMode) {
 }
 
 FEXCore::Core::CPUState GetCPUState() {
-  if (!ActiveCore()) {
-    return FEXCore::Core::CPUState{};
+  auto ret = FEXCore::Core::CPUState{};
+  if (ActiveCore()) {
+    FEXCore::Context::GetCPUState(s_CTX, &ret);
   }
-  return FEXCore::Context::Debug::GetCPUState(s_CTX);
+  return ret;
 }
 
 bool IsCoreRunning() {


### PR DESCRIPTION
This PR extracts the CPU state of the Current Frame out of the Thread state and puts it in a separate object that we can access via indirection.

The State Register now points to the CpuStateFrame. Currently there is only one CpuStateFrame, but this PR prepares the way for future work which creates one CpuStateFrame per signal/callback layer.

#### Downsides
Some operations now require an extra level of indirection to access the ThreadState object. But most of these are outside of the hot loop, and accompanied by a bunch of extra code which make the extra overhead minimal. 

The Interpreter is one place where the extra indirection is in the hot loop. This could theoretically be cleaned up in a future PR if people think this is necessary.

#### Upsides

With Future PRs, this approach allows faster guest signals and faster callbacks. It also allows complete back traces and cleanups on thread exit. 