### PR TITLE
Deduplicates some configuration data

### DIFF
--- a/External/FEXCore/Source/Common/StringConv.h
+++ b/External/FEXCore/Source/Common/StringConv.h
@@ -38,4 +38,11 @@ namespace FEXCore::StrConv {
     *Result = Value;
     return true;
   }
+  template <typename T,
+    typename = std::enable_if<std::is_enum<T>::value, T>>
+  [[maybe_unused]] static bool Conv(std::string_view Value, T *Result) {
+    *Result = static_cast<T>(std::stoull(std::string(Value), nullptr, 0));
+    return true;
+  }
+
 }

--- a/External/FEXCore/Source/Interface/Config/Config.cpp
+++ b/External/FEXCore/Source/Interface/Config/Config.cpp
@@ -8,114 +8,12 @@
 
 namespace FEXCore::Config {
   void SetConfig(FEXCore::Context::Context *CTX, ConfigOption Option, uint64_t Config) {
-    switch (Option) {
-    case FEXCore::Config::CONFIG_MULTIBLOCK:
-      CTX->Config.Multiblock = Config != 0;
-    break;
-    case FEXCore::Config::CONFIG_MAXBLOCKINST:
-      CTX->Config.MaxInstPerBlock = Config;
-    break;
-    case FEXCore::Config::CONFIG_DEFAULTCORE:
-      CTX->Config.Core = static_cast<FEXCore::Config::ConfigCore>(Config);
-    break;
-    case FEXCore::Config::CONFIG_VIRTUALMEMSIZE:
-      CTX->Config.VirtualMemSize = Config;
-    break;
-    case FEXCore::Config::CONFIG_SINGLESTEP:
-      CTX->Config.RunningMode = Config != 0 ? FEXCore::Context::CoreRunningMode::MODE_SINGLESTEP : FEXCore::Context::CoreRunningMode::MODE_RUN;
-    break;
-    case FEXCore::Config::CONFIG_GDBSERVER:
-      Config != 0 ? CTX->StartGdbServer() : CTX->StopGdbServer();
-    break;
-    case FEXCore::Config::CONFIG_IS64BIT_MODE:
-      CTX->Config.Is64BitMode = Config != 0;
-    break;
-    case FEXCore::Config::CONFIG_TSO_ENABLED:
-      CTX->Config.TSOEnabled = Config != 0;
-    break;
-    case FEXCore::Config::CONFIG_SMC_CHECKS:
-      CTX->Config.SMCChecks = static_cast<FEXCore::Config::ConfigSMCChecks>(Config);
-    break;
-    case FEXCore::Config::CONFIG_ABI_LOCAL_FLAGS:
-      CTX->Config.ABILocalFlags = Config != 0;
-    break;
-    case FEXCore::Config::CONFIG_ABI_NO_PF:
-      CTX->Config.ABINoPF = Config != 0;
-    break;
-    case FEXCore::Config::CONFIG_VALIDATE_IR_PARSER:
-      CTX->Config.ValidateIRarser = Config != 0;
-    break;
-    case FEXCore::Config::CONFIG_AOTIR_GENERATE:
-      CTX->Config.AOTIRCapture = Config != 0;
-    break;
-    case FEXCore::Config::CONFIG_AOTIR_LOAD:
-      CTX->Config.AOTIRLoad = Config != 0;
-    break;
-    default: LogMan::Msg::A("Unknown configuration option");
-    }
   }
 
   void SetConfig(FEXCore::Context::Context *CTX, ConfigOption Option, std::string const &Config) {
-    switch (Option) {
-    case CONFIG_ROOTFSPATH:
-      CTX->Config.RootFSPath = Config;
-      break;
-    case CONFIG_THUNKLIBSPATH:
-      CTX->Config.ThunkLibsPath = Config;
-      break;
-    case FEXCore::Config::CONFIG_DUMPIR:
-      CTX->Config.DumpIR = Config;
-      break;
-    default: LogMan::Msg::A("Unknown configuration option");
-    }
   }
 
   uint64_t GetConfig(FEXCore::Context::Context *CTX, ConfigOption Option) {
-    switch (Option) {
-    case FEXCore::Config::CONFIG_MULTIBLOCK:
-      return CTX->Config.Multiblock;
-    break;
-    case FEXCore::Config::CONFIG_MAXBLOCKINST:
-      return CTX->Config.MaxInstPerBlock;
-    break;
-    case FEXCore::Config::CONFIG_DEFAULTCORE:
-      return CTX->Config.Core;
-    break;
-    case FEXCore::Config::CONFIG_VIRTUALMEMSIZE:
-      return CTX->Config.VirtualMemSize;
-    break;
-    case FEXCore::Config::CONFIG_SINGLESTEP:
-      return CTX->Config.RunningMode == FEXCore::Context::CoreRunningMode::MODE_SINGLESTEP ? 1 : 0;
-    case FEXCore::Config::CONFIG_GDBSERVER:
-      return CTX->GetGdbServerStatus();
-    break;
-    case FEXCore::Config::CONFIG_IS64BIT_MODE:
-      return CTX->Config.Is64BitMode;
-    break;
-    case FEXCore::Config::CONFIG_TSO_ENABLED:
-      return CTX->Config.TSOEnabled;
-    break;
-    case FEXCore::Config::CONFIG_SMC_CHECKS:
-      return CTX->Config.SMCChecks;
-    break;
-    case FEXCore::Config::CONFIG_ABI_LOCAL_FLAGS:
-      return CTX->Config.ABILocalFlags;
-    break;
-    case FEXCore::Config::CONFIG_ABI_NO_PF:
-      return CTX->Config.ABINoPF;
-    break;
-    case FEXCore::Config::CONFIG_VALIDATE_IR_PARSER:
-      return CTX->Config.ValidateIRarser;
-    break;
-    case FEXCore::Config::CONFIG_AOTIR_GENERATE:
-      return CTX->Config.AOTIRCapture;
-    break;
-    case FEXCore::Config::CONFIG_AOTIR_LOAD:
-      return CTX->Config.AOTIRLoad;
-    break;
-    default: LogMan::Msg::A("Unknown configuration option");
-    }
-
     return 0;
   }
 
@@ -252,8 +150,14 @@ namespace FEXCore::Config {
     }
   }
 
-  template bool Value<bool>::GetIfExists(FEXCore::Config::ConfigOption Option, bool Default);
-  template uint8_t Value<uint8_t>::GetIfExists(FEXCore::Config::ConfigOption Option, uint8_t Default);
+  template bool     Value<bool>::GetIfExists(FEXCore::Config::ConfigOption Option, bool Default);
+  template int8_t   Value<int8_t>::GetIfExists(FEXCore::Config::ConfigOption Option, int8_t Default);
+  template uint8_t  Value<uint8_t>::GetIfExists(FEXCore::Config::ConfigOption Option, uint8_t Default);
+  template int16_t   Value<int16_t>::GetIfExists(FEXCore::Config::ConfigOption Option, int16_t Default);
+  template uint16_t  Value<uint16_t>::GetIfExists(FEXCore::Config::ConfigOption Option, uint16_t Default);
+  template int32_t  Value<int32_t>::GetIfExists(FEXCore::Config::ConfigOption Option, int32_t Default);
+  template uint32_t Value<uint32_t>::GetIfExists(FEXCore::Config::ConfigOption Option, uint32_t Default);
+  template int64_t  Value<int64_t>::GetIfExists(FEXCore::Config::ConfigOption Option, int64_t Default);
   template uint64_t Value<uint64_t>::GetIfExists(FEXCore::Config::ConfigOption Option, uint64_t Default);
 
   // Constructor

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -63,30 +63,27 @@ namespace FEXCore::Context {
     friend class FEXCore::IR::Validation::IRValidation;
 
     struct {
-      bool Multiblock {false};
-      bool BreakOnFrontendFailure {true};
-      int64_t MaxInstPerBlock {-1LL};
-      uint64_t VirtualMemSize {1ULL << 36};
       CoreRunningMode RunningMode {CoreRunningMode::MODE_RUN};
-      FEXCore::Config::ConfigCore Core {FEXCore::Config::CONFIG_INTERPRETER};
-      bool GdbServer {false};
-      std::string RootFSPath;
-      std::string ThunkLibsPath;
-
-      bool Is64BitMode {true};
-      bool TSOEnabled {true};
-      FEXCore::Config::ConfigSMCChecks SMCChecks {FEXCore::Config::CONFIG_SMC_MMAN};
-      bool ABILocalFlags {false};
-      bool ABINoPF {false};
-
-      bool AOTIRCapture {false};
-      bool AOTIRLoad {false};
-
-      std::string DumpIR;
+      uint64_t VirtualMemSize{1ULL << 36};
 
       // this is for internal use
       bool ValidateIRarser { false };
 
+      FEX_CONFIG_OPT(Multiblock, MULTIBLOCK);
+      FEX_CONFIG_OPT(SingleStepConfig, SINGLESTEP);
+      FEX_CONFIG_OPT(GdbServer, GDBSERVER);
+      FEX_CONFIG_OPT(Is64BitMode, IS64BIT_MODE);
+      FEX_CONFIG_OPT(TSOEnabled, TSO_ENABLED);
+      FEX_CONFIG_OPT(ABILocalFlags, ABI_LOCAL_FLAGS);
+      FEX_CONFIG_OPT(ABINoPF, ABI_NO_PF);
+      FEX_CONFIG_OPT(AOTIRCapture, AOTIR_GENERATE);
+      FEX_CONFIG_OPT(AOTIRLoad, AOTIR_LOAD);
+      FEX_CONFIG_OPT(SMCChecks, SMC_CHECKS);
+      FEX_CONFIG_OPT(Core, DEFAULTCORE);
+      FEX_CONFIG_OPT(MaxInstPerBlock, MAXBLOCKINST);
+      FEX_CONFIG_OPT(RootFSPath, ROOTFSPATH);
+      FEX_CONFIG_OPT(ThunkLibsPath, THUNKLIBSPATH);
+      FEX_CONFIG_OPT(DumpIR, DUMPIR);
     } Config;
 
     using IntCallbackReturn =  __attribute__((naked)) void(*)(FEXCore::Core::InternalThreadState *Thread, volatile void *Host_RSP);
@@ -231,7 +228,7 @@ namespace FEXCore::Context {
     std::unique_ptr<GdbServer> DebugServer;
 
     bool StartPaused = false;
-    FEXCore::Config::Value<std::string> AppFilename{FEXCore::Config::CONFIG_APP_FILENAME, ""};
+    FEX_CONFIG_OPT(AppFilename, APP_FILENAME);
   };
 
   uint64_t HandleSyscall(FEXCore::HLE::SyscallHandler *Handler, FEXCore::Core::InternalThreadState *Thread, FEXCore::HLE::SyscallArguments *Args);

--- a/External/FEXCore/Source/Interface/Core/GdbServer.h
+++ b/External/FEXCore/Source/Interface/Core/GdbServer.h
@@ -57,7 +57,7 @@ private:
     bool NoAckMode{false};
     std::string ThreadString{};
     uint32_t CurrentDebuggingThread{};
-    FEXCore::Config::Value<std::string> Filename{FEXCore::Config::CONFIG_APP_FILENAME, ""};
+    FEX_CONFIG_OPT(Filename, APP_FILENAME);
 };
 
 }

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -475,7 +475,6 @@ public:
   OrderedNode *GetPackedRFLAG(bool Lower8);
 
   void SetMultiblock(bool _Multiblock) { Multiblock = _Multiblock; }
-  bool GetMultiblock() { return Multiblock; }
 
 private:
   bool DecodeFailure{false};

--- a/External/FEXCore/Source/Interface/Core/X86HelperGen.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86HelperGen.cpp
@@ -28,7 +28,7 @@ X86GeneratedCode::~X86GeneratedCode() {
 }
 
 void* X86GeneratedCode::AllocateGuestCodeSpace(size_t Size) {
-  FEXCore::Config::Value<bool> Is64BitMode{FEXCore::Config::CONFIG_IS64BIT_MODE, 0};
+  FEX_CONFIG_OPT(Is64BitMode, IS64BIT_MODE);
 
   if (Is64BitMode()) {
     // 64bit mode can have its sigret handler anywhere

--- a/External/FEXCore/Source/Interface/HLE/Thunks/Thunks.cpp
+++ b/External/FEXCore/Source/Interface/HLE/Thunks/Thunks.cpp
@@ -23,7 +23,7 @@ static thread_local FEXCore::Core::InternalThreadState *Thread;
 
 
 namespace FEXCore {
-    
+
     struct ExportEntry { uint8_t *sha256; ThunkedFunction* Fn; };
 
     class ThunkHandler_impl final: public ThunkHandler {
@@ -41,7 +41,7 @@ namespace FEXCore {
             Set arg0/1 to arg regs, use CTX::HandleCallback to handle the callback
         */
         static void CallCallback(void *callback, void *arg0, void* arg1) {
-            
+
             Thread->State.State.gregs[FEXCore::X86State::REG_RDI] = (uintptr_t)arg0;
             Thread->State.State.gregs[FEXCore::X86State::REG_RSI] = (uintptr_t)arg1;
 
@@ -57,10 +57,10 @@ namespace FEXCore {
             auto Name = Args->Name;
             auto CallbackThunks = Args->CallbackThunks;
 
-            auto SOName = CTX->Config.ThunkLibsPath + "/" + (const char*)Name + "-host.so";
+            auto SOName = CTX->Config.ThunkLibsPath() + "/" + (const char*)Name + "-host.so";
 
             LogMan::Msg::D("Load lib: %s -> %s", Name, SOName.c_str());
-            
+
             auto Handle = dlopen(SOName.c_str(), RTLD_LOCAL | RTLD_NOW);
 
             if (!Handle) {
@@ -78,7 +78,7 @@ namespace FEXCore {
                 LogMan::Msg::E("Load lib: failed to find export %s", InitSym.c_str());
                 return;
             }
-            
+
             auto Exports = InitFN((void*)&CallCallback, CallbackThunks);
 
             auto That = reinterpret_cast<ThunkHandler_impl*>(CTX->ThunkHandler.get());

--- a/External/FEXCore/Source/Interface/IR/PassManager.cpp
+++ b/External/FEXCore/Source/Interface/IR/PassManager.cpp
@@ -7,7 +7,7 @@
 namespace FEXCore::IR {
 
 void PassManager::AddDefaultPasses(bool InlineConstants, bool StaticRegisterAllocation) {
-  FEXCore::Config::Value<bool> DisablePasses{FEXCore::Config::CONFIG_DEBUG_DISABLE_OPTIMIZATION_PASSES, false};
+  FEX_CONFIG_OPT(DisablePasses, DEBUG_DISABLE_OPTIMIZATION_PASSES);
 
   if (!DisablePasses()) {
     InsertPass(CreateContextLoadStoreElimination());

--- a/External/FEXCore/include/FEXCore/Config/ConfigValues.inl
+++ b/External/FEXCore/include/FEXCore/Config/ConfigValues.inl
@@ -1,0 +1,72 @@
+#ifndef OPT_BASE
+#define OPT_BASE(type, group, enum, json, env, default)
+#endif
+#ifndef OPT_BOOL
+#define OPT_BOOL(group, enum, json, env, default) OPT_BASE(bool, group, enum, json, env, default)
+#endif
+#ifndef OPT_UINT8
+#define OPT_UINT8(group, enum, json, env, default) OPT_BASE(uint8_t, group, enum, json, env, default)
+#endif
+#ifndef OPT_INT32
+#define OPT_INT32(group, enum, json, env, default) OPT_BASE(int32_t, group, enum, json, env, default)
+#endif
+#ifndef OPT_UINT32
+#define OPT_UINT32(group, enum, json, env, default) OPT_BASE(uint32_t, group, enum, json, env, default)
+#endif
+#ifndef OPT_UINT64
+#define OPT_UINT64(group, enum, json, env, default) OPT_BASE(uint64_t, group, enum, json, env, default)
+#endif
+#ifndef OPT_STR
+#define OPT_STR(group, enum, json, env, default) OPT_BASE(std::string, group, enum, json, env, default)
+#endif
+#ifndef OPT_STRARRAY
+#define OPT_STRARRAY(group, enum, json, env, default) OPT_BASE(std::string, group, enum, json, env, default)
+#endif
+
+// Option definitions
+// Arguments
+// 1) Group
+// 2) Enum name
+// 3) json Option name
+// 4) Environment Option name
+// 5) Default option
+OPT_UINT32(CPU, DEFAULTCORE,      Core,       CORE,       FEXCore::Config::ConfigCore::CONFIG_IRJIT)
+OPT_BOOL  (CPU, MULTIBLOCK,       Multiblock, MULTIBLOCK, true)
+OPT_INT32 (CPU, MAXBLOCKINST,     MaxInst,    MAXINST,    5000)
+OPT_INT32 (CPU, EMULATED_CPU_CORES, Threads,  THREADS,    1)
+
+OPT_STR   (EMULATION, ROOTFSPATH,    RootFS,     ROOTFS,     "")
+OPT_STR   (EMULATION, THUNKLIBSPATH, ThunkLibs,  THUNKLIBS,  "")
+OPT_STR   (EMULATION, THUNKSCONFIGPATH, ThunksConfigPath, THUNKSCONFIGPATH,  "")
+
+OPT_STR   (EMULATION, ENVIRONMENT,   Env,        ENV,        "")
+
+OPT_BOOL  (DEBUG, SINGLESTEP,   SingleStep, SINGLESTEP, false)
+OPT_BOOL  (DEBUG, GDBSERVER,    GdbServer,  GDBSERVER,  false)
+OPT_STR   (DEBUG, DUMPIR,       DumpIR,     DUMPIR,     "no")
+OPT_BOOL  (DEBUG, DUMP_GPRS,    DumpGPRs,   DUMP_GPRS,  false)
+OPT_BOOL  (DEBUG, DEBUG_DISABLE_OPTIMIZATION_PASSES, O0, O0, false)
+
+OPT_BOOL (LOGGING, SILENTLOGS, SilentLog, SILENTLOG, false)
+OPT_STR  (LOGGING, OUTPUTLOG,  OutputLog, OUTPUTLOG, "")
+
+OPT_BOOL  (HACKS, TSO_ENABLED,     TSOEnabled, TSO_ENABLED,      true)
+OPT_UINT8 (HACKS, SMC_CHECKS,      SMCChecks,  SMC_CHECKS,       FEXCore::Config::CONFIG_SMC_MMAN)
+OPT_BOOL  (HACKS, ABI_LOCAL_FLAGS, ABILocalFlags, ABILOCALFLAGS, false)
+OPT_BOOL  (HACKS, ABI_NO_PF,       ABINoPF,       ABINOPF,       false)
+
+OPT_BOOL (MISC, IS_INTERPRETER, INVALID, INVALID, false)
+OPT_BOOL (MISC, INTERPRETER_INSTALLED, INVALID, INVALID, false)
+OPT_STR  (MISC, APP_FILENAME, INVALID, INVALID, "")
+OPT_BOOL (MISC, AOTIR_GENERATE, AOTIRCapture, AOT_GENERATE, false)
+OPT_BOOL (MISC, AOTIR_LOAD, AOTIRLoad, AOT_LOAD, false)
+OPT_BOOL (MISC, IS64BIT_MODE, INVALID, INVALID, false)
+
+#undef OPT_BASE
+#undef OPT_BOOL
+#undef OPT_UINT8
+#undef OPT_INT32
+#undef OPT_UINT32
+#undef OPT_UINT64
+#undef OPT_STR
+#undef OPT_STRARRAY

--- a/Source/Common/ArgumentLoader.cpp
+++ b/Source/Common/ArgumentLoader.cpp
@@ -189,11 +189,6 @@ namespace FEX::ArgLoader {
 #endif
       }
 
-      if (Options.is_set_by_user("Break")) {
-        bool Break = Options.get("Break");
-        Set(FEXCore::Config::ConfigOption::CONFIG_BREAK_ON_FRONTEND, std::to_string(Break));
-      }
-
       if (Options.is_set_by_user("SingleStep")) {
         bool SingleStep = Options.get("SingleStep");
         Set(FEXCore::Config::ConfigOption::CONFIG_SINGLESTEP, std::to_string(SingleStep));

--- a/Source/Common/Config.cpp
+++ b/Source/Common/Config.cpp
@@ -171,27 +171,18 @@ namespace FEX::Config {
   }
 
   static const std::map<FEXCore::Config::ConfigOption, std::string> ConfigToNameLookup = {{
-    {FEXCore::Config::ConfigOption::CONFIG_DEFAULTCORE,        "Core"},
-    {FEXCore::Config::ConfigOption::CONFIG_MAXBLOCKINST,       "MaxInst"},
-    {FEXCore::Config::ConfigOption::CONFIG_SINGLESTEP,         "SingleStep"},
-    {FEXCore::Config::ConfigOption::CONFIG_MULTIBLOCK,         "Multiblock"},
-    {FEXCore::Config::ConfigOption::CONFIG_GDBSERVER,          "GdbServer"},
-    {FEXCore::Config::ConfigOption::CONFIG_EMULATED_CPU_CORES, "Threads"},
-    {FEXCore::Config::ConfigOption::CONFIG_ROOTFSPATH,         "RootFS"},
-    {FEXCore::Config::ConfigOption::CONFIG_THUNKLIBSPATH,      "ThunkLibs"},
-    {FEXCore::Config::ConfigOption::CONFIG_SILENTLOGS,         "SilentLog"},
-    {FEXCore::Config::ConfigOption::CONFIG_ENVIRONMENT,        "Env"},
-    {FEXCore::Config::ConfigOption::CONFIG_OUTPUTLOG,          "OutputLog"},
-    {FEXCore::Config::ConfigOption::CONFIG_DUMPIR,             "DumpIR"},
-    {FEXCore::Config::ConfigOption::CONFIG_TSO_ENABLED,        "TSOEnabled"},
-    {FEXCore::Config::ConfigOption::CONFIG_SMC_CHECKS,         "SMCChecks"},
-    {FEXCore::Config::ConfigOption::CONFIG_ABI_LOCAL_FLAGS,    "ABILocalFlags"},
-    {FEXCore::Config::ConfigOption::CONFIG_ABI_NO_PF,          "ABINoPF"},
-    {FEXCore::Config::ConfigOption::CONFIG_DEBUG_DISABLE_OPTIMIZATION_PASSES, "O0"},
-    {FEXCore::Config::ConfigOption::CONFIG_AOTIR_GENERATE,       "AOTIRCapture"},
-    {FEXCore::Config::ConfigOption::CONFIG_AOTIR_LOAD,           "AOTIRLoad"},
+#define OPT_BASE(type, group, enum, json, env, default) {FEXCore::Config::ConfigOption::CONFIG_##enum, #json},
+#include <FEXCore/Config/ConfigValues.inl>
   }};
 
+  static const std::map<std::string, FEXCore::Config::ConfigOption> ConfigLookup = {{
+#define OPT_BASE(type, group, enum, json, env, default) {#json, FEXCore::Config::ConfigOption::CONFIG_##enum},
+#include <FEXCore/Config/ConfigValues.inl>
+  }};
+  static const std::vector<std::pair<const char*, FEXCore::Config::ConfigOption>> EnvConfigLookup = {{
+#define OPT_BASE(type, group, enum, json, env, default) {"FEX_" #env, FEXCore::Config::ConfigOption::CONFIG_##enum},
+#include <FEXCore/Config/ConfigValues.inl>
+  }};
 
   void SaveLayerToJSON(std::string Filename, FEXCore::Config::Layer *const Layer) {
     char Buffer[4096];
@@ -218,28 +209,6 @@ namespace FEX::Config {
   OptionMapper::OptionMapper(FEXCore::Config::LayerType Layer)
     : FEXCore::Config::Layer(Layer) {
   }
-
-  static const std::map<std::string, FEXCore::Config::ConfigOption> ConfigLookup = {{
-    {"Core",          FEXCore::Config::ConfigOption::CONFIG_DEFAULTCORE},
-    {"MaxInst",       FEXCore::Config::ConfigOption::CONFIG_MAXBLOCKINST},
-    {"SingleStep",    FEXCore::Config::ConfigOption::CONFIG_SINGLESTEP},
-    {"Multiblock",    FEXCore::Config::ConfigOption::CONFIG_MULTIBLOCK},
-    {"GdbServer",     FEXCore::Config::ConfigOption::CONFIG_GDBSERVER},
-    {"Threads",       FEXCore::Config::ConfigOption::CONFIG_EMULATED_CPU_CORES},
-    {"RootFS",        FEXCore::Config::ConfigOption::CONFIG_ROOTFSPATH},
-    {"ThunkLibs",     FEXCore::Config::ConfigOption::CONFIG_THUNKLIBSPATH},
-    {"SilentLog",     FEXCore::Config::ConfigOption::CONFIG_SILENTLOGS},
-    {"Env",           FEXCore::Config::ConfigOption::CONFIG_ENVIRONMENT},
-    {"OutputLog",     FEXCore::Config::ConfigOption::CONFIG_OUTPUTLOG},
-    {"DumpIR",        FEXCore::Config::ConfigOption::CONFIG_DUMPIR},
-    {"TSOEnabled",    FEXCore::Config::ConfigOption::CONFIG_TSO_ENABLED},
-    {"SMCChecks",     FEXCore::Config::ConfigOption::CONFIG_SMC_CHECKS},
-    {"ABILocalFlags", FEXCore::Config::ConfigOption::CONFIG_ABI_LOCAL_FLAGS},
-    {"AbiNoPF",       FEXCore::Config::ConfigOption::CONFIG_ABI_NO_PF},
-    {"O0",            FEXCore::Config::ConfigOption::CONFIG_DEBUG_DISABLE_OPTIMIZATION_PASSES},
-    {"AOTIRCapture",   FEXCore::Config::ConfigOption::CONFIG_AOTIR_GENERATE},
-    {"AOTIRLoad",       FEXCore::Config::ConfigOption::CONFIG_AOTIR_LOAD},
-  }};
 
   void OptionMapper::MapNameToOption(const char *ConfigName, const char *ConfigString) {
     auto it = ConfigLookup.find(ConfigName);
@@ -311,32 +280,9 @@ namespace FEX::Config {
       }
     };
 
-    static const std::array<std::pair<std::string, FEXCore::Config::ConfigOption>, 20> ConfigLookup = {{
-      {"FEX_CORE",          FEXCore::Config::ConfigOption::CONFIG_DEFAULTCORE},
-      {"FEX_MAXINST",       FEXCore::Config::ConfigOption::CONFIG_MAXBLOCKINST},
-      {"FEX_SINGLESTEP",    FEXCore::Config::ConfigOption::CONFIG_SINGLESTEP},
-      {"FEX_MULTIBLOCK",    FEXCore::Config::ConfigOption::CONFIG_MULTIBLOCK},
-      {"FEX_GDBSERVER",     FEXCore::Config::ConfigOption::CONFIG_GDBSERVER},
-      {"FEX_THREADS",       FEXCore::Config::ConfigOption::CONFIG_EMULATED_CPU_CORES},
-      {"FEX_ROOTFS",        FEXCore::Config::ConfigOption::CONFIG_ROOTFSPATH},
-      {"FEX_THUNKLIBS",     FEXCore::Config::ConfigOption::CONFIG_THUNKLIBSPATH},
-      {"FEX_SILENTLOG",     FEXCore::Config::ConfigOption::CONFIG_SILENTLOGS},
-      {"FEX_ENV",           FEXCore::Config::ConfigOption::CONFIG_ENVIRONMENT},
-      {"FEX_OUTPUTLOG",     FEXCore::Config::ConfigOption::CONFIG_OUTPUTLOG},
-      {"FEX_DUMPIR",        FEXCore::Config::ConfigOption::CONFIG_DUMPIR},
-      {"FEX_TSOENABLED",    FEXCore::Config::ConfigOption::CONFIG_TSO_ENABLED},
-      {"FEX_SMCCHECKS",     FEXCore::Config::ConfigOption::CONFIG_SMC_CHECKS},
-      {"FEX_ABILOCALFLAGS", FEXCore::Config::ConfigOption::CONFIG_ABI_LOCAL_FLAGS},
-      {"FEX_ABINOPF",       FEXCore::Config::ConfigOption::CONFIG_ABI_NO_PF},
-      {"FEX_BREAK",         FEXCore::Config::ConfigOption::CONFIG_BREAK_ON_FRONTEND},
-      {"FEX_DUMP_GPRS",     FEXCore::Config::ConfigOption::CONFIG_DUMP_GPRS},
-      {"FEX_AOT_GENERATE",  FEXCore::Config::ConfigOption::CONFIG_AOTIR_GENERATE},
-      {"FEX_AOT_LOAD",      FEXCore::Config::ConfigOption::CONFIG_AOTIR_LOAD},
-    }};
-
     std::optional<std::string_view> Value;
 
-    for (auto &it : ConfigLookup) {
+    for (auto &it : EnvConfigLookup) {
       if ((Value = GetVar(it.first)).has_value()) {
         Set(it.second, std::string(*Value));
       }

--- a/Source/Core/CPU/HostCore/HostCore.cpp
+++ b/Source/Core/CPU/HostCore/HostCore.cpp
@@ -48,7 +48,6 @@ private:
   void InstallSignalHandler();
 
   FEX::ThreadState *ThreadState;
-  FEXCore::Config::Value<bool> ConfigMultiblock{"Multiblock", false};
   std::thread ExecutionThread;
   Memmap LocalMemoryMapper{};
   pid_t ChildPid;

--- a/Source/Tests/HarnessHelpers.h
+++ b/Source/Tests/HarnessHelpers.h
@@ -289,7 +289,7 @@ namespace FEX::HarnessHelper {
     bool Is64BitMode() const { return BaseConfig.OptionMode == 1; }
 
   private:
-    FEXCore::Config::Value<bool> ConfigDumpGPRs{FEXCore::Config::CONFIG_DUMP_GPRS, false};
+    FEX_CONFIG_OPT(ConfigDumpGPRs, DUMP_GPRS);
 
     struct ConfigStructBase {
       uint64_t OptionMatch;

--- a/Source/Tests/IRLoader.cpp
+++ b/Source/Tests/IRLoader.cpp
@@ -98,13 +98,6 @@ int main(int argc, char **argv, char **const envp) {
   FEXCore::Config::AddLayer(std::make_unique<FEX::Config::EnvLoader>(envp));
   FEXCore::Config::Load();
 
-  FEXCore::Config::Value<uint8_t> CoreConfig{FEXCore::Config::CONFIG_DEFAULTCORE, 0};
-  FEXCore::Config::Value<uint64_t> BlockSizeConfig{FEXCore::Config::CONFIG_MAXBLOCKINST, 1};
-  FEXCore::Config::Value<bool> SingleStepConfig{FEXCore::Config::CONFIG_SINGLESTEP, false};
-  FEXCore::Config::Value<bool> MultiblockConfig{FEXCore::Config::CONFIG_MULTIBLOCK, false};
-  FEXCore::Config::Value<bool> GdbServerConfig{FEXCore::Config::CONFIG_GDBSERVER, false};
-  FEXCore::Config::Value<std::string> LDPath{FEXCore::Config::CONFIG_ROOTFSPATH, ""};
-
   auto Args = FEX::ArgLoader::Get();
   auto ParsedArgs = FEX::ArgLoader::GetParsedArgs();
 
@@ -114,12 +107,6 @@ int main(int argc, char **argv, char **const envp) {
   auto CTX = FEXCore::Context::CreateNewContext();
   FEXCore::Context::InitializeContext(CTX);
 
-  FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_DEFAULTCORE, CoreConfig() > 3 ? FEXCore::Config::CONFIG_CUSTOM : CoreConfig());
-  FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_MULTIBLOCK, MultiblockConfig());
-  FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_SINGLESTEP, SingleStepConfig());
-  FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_MAXBLOCKINST, BlockSizeConfig());
-  FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_GDBSERVER, GdbServerConfig());
-  FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_ROOTFSPATH, LDPath());
   std::unique_ptr<FEX::HLE::SignalDelegator> SignalDelegation = std::make_unique<FEX::HLE::SignalDelegator>();
 
   FEXCore::Context::SetSignalDelegator(CTX, SignalDelegation.get());

--- a/Source/Tests/LinuxSyscalls/EmulatedFiles/EmulatedFiles.h
+++ b/Source/Tests/LinuxSyscalls/EmulatedFiles/EmulatedFiles.h
@@ -29,6 +29,6 @@ namespace FEX::EmulatedFile {
       std::unordered_map<std::string, FDReadStringFunc> FDReadCreators;
 
       static int32_t ProcAuxv(FEXCore::Context::Context* ctx, int32_t fd, const char* pathname, int32_t flags, mode_t mode);
-      FEXCore::Config::Value<uint64_t> ThreadsConfig{FEXCore::Config::CONFIG_EMULATED_CPU_CORES, 1};
+      FEX_CONFIG_OPT(ThreadsConfig, EMULATED_CPU_CORES);
   };
 }

--- a/Source/Tests/LinuxSyscalls/FileManagement.h
+++ b/Source/Tests/LinuxSyscalls/FileManagement.h
@@ -50,7 +50,7 @@ private:
   std::string PidSelfPath;
   std::string GetEmulatedPath(const char *pathname);
 
-  FEXCore::Config::Value<std::string> Filename{FEXCore::Config::CONFIG_APP_FILENAME, ""};
-  FEXCore::Config::Value<std::string> LDPath{FEXCore::Config::CONFIG_ROOTFSPATH, ""};
+  FEX_CONFIG_OPT(Filename, APP_FILENAME);
+  FEX_CONFIG_OPT(LDPath, ROOTFSPATH);
 };
 }

--- a/Source/Tests/LinuxSyscalls/Syscalls.h
+++ b/Source/Tests/LinuxSyscalls/Syscalls.h
@@ -99,12 +99,12 @@ public:
   void SetCodeLoader(FEXCore::CodeLoader *Loader) { LocalLoader = Loader; }
   FEX::HLE::SignalDelegator *GetSignalDelegator() { return SignalDelegation; }
 
-  FEXCore::Config::Value<bool> IsInterpreter{FEXCore::Config::CONFIG_IS_INTERPRETER, 0};
-  FEXCore::Config::Value<bool> IsInterpreterInstalled{FEXCore::Config::CONFIG_INTERPRETER_INSTALLED, 0};
-  FEXCore::Config::Value<std::string> Filename{FEXCore::Config::CONFIG_APP_FILENAME, ""};
-  FEXCore::Config::Value<std::string> RootFSPath{FEXCore::Config::CONFIG_ROOTFSPATH, ""};
-  FEXCore::Config::Value<uint64_t> ThreadsConfig{FEXCore::Config::CONFIG_EMULATED_CPU_CORES, 1};
-  FEXCore::Config::Value<bool> Is64BitMode{FEXCore::Config::CONFIG_IS64BIT_MODE, 0};
+  FEX_CONFIG_OPT(IsInterpreter, IS_INTERPRETER);
+  FEX_CONFIG_OPT(IsInterpreterInstalled, INTERPRETER_INSTALLED);
+  FEX_CONFIG_OPT(Filename, APP_FILENAME);
+  FEX_CONFIG_OPT(RootFSPath, ROOTFSPATH);
+  FEX_CONFIG_OPT(ThreadsConfig, EMULATED_CPU_CORES);
+  FEX_CONFIG_OPT(Is64BitMode, IS64BIT_MODE);
 
   uint32_t GetHostKernelVersion() const { return HostKernelVersion; }
 

--- a/Source/Tests/LinuxSyscalls/x64/Memory.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Memory.cpp
@@ -31,7 +31,7 @@ namespace FEX::HLE::x64 {
     });
 
     REGISTER_SYSCALL_IMPL_X64(mmap, [](FEXCore::Core::InternalThreadState *Thread, void *addr, size_t length, int prot, int flags, int fd, off_t offset) -> uint64_t {
-      static FEXCore::Config::Value<bool> AOTIRLoad(FEXCore::Config::CONFIG_AOTIR_LOAD, false);
+      static FEX_CONFIG_OPT(AOTIRLoad, AOTIR_LOAD);
       uint64_t Result = reinterpret_cast<uint64_t>(::mmap(addr, length, prot, flags, fd, offset));
       if (Result != -1) {
         if (!(flags & MAP_ANONYMOUS)) {

--- a/Source/Tests/TestHarness.cpp
+++ b/Source/Tests/TestHarness.cpp
@@ -63,14 +63,6 @@ int main(int argc, char **argv) {
 
   auto CTX2 = FEXCore::Context::CreateNewContext();
 
-  FEXCore::Config::SetConfig(CTX1, FEXCore::Config::CONFIG_DEFAULTCORE, FEXCore::Config::CONFIG_CUSTOM);
-  FEXCore::Config::SetConfig(CTX1, FEXCore::Config::CONFIG_SINGLESTEP, 1);
-  FEXCore::Config::SetConfig(CTX1, FEXCore::Config::CONFIG_MAXBLOCKINST, 1);
-
-  FEXCore::Config::SetConfig(CTX2, FEXCore::Config::CONFIG_DEFAULTCORE, FEXCore::Config::CONFIG_INTERPRETER);
-  FEXCore::Config::SetConfig(CTX2, FEXCore::Config::CONFIG_SINGLESTEP, 1);
-  FEXCore::Config::SetConfig(CTX2, FEXCore::Config::CONFIG_MAXBLOCKINST, 1);
-
   FEXCore::Context::InitializeContext(CTX1);
   FEXCore::Context::InitializeContext(CTX2);
 

--- a/Source/Tests/TestHarnessRunner.cpp
+++ b/Source/Tests/TestHarnessRunner.cpp
@@ -58,47 +58,19 @@ int main(int argc, char **argv, char **const envp) {
   FEXCore::Config::AddLayer(std::make_unique<FEX::Config::EnvLoader>(envp));
   FEXCore::Config::Load();
 
-  FEXCore::Config::Value<uint8_t> CoreConfig{FEXCore::Config::CONFIG_DEFAULTCORE, 0};
-  FEXCore::Config::Value<uint64_t> BlockSizeConfig{FEXCore::Config::CONFIG_MAXBLOCKINST, 1};
-  FEXCore::Config::Value<bool> SingleStepConfig{FEXCore::Config::CONFIG_SINGLESTEP, false};
-  FEXCore::Config::Value<bool> MultiblockConfig{FEXCore::Config::CONFIG_MULTIBLOCK, false};
-  FEXCore::Config::Value<bool> GdbServerConfig{FEXCore::Config::CONFIG_GDBSERVER, false};
-  FEXCore::Config::Value<uint64_t> ThreadsConfig{FEXCore::Config::CONFIG_EMULATED_CPU_CORES, 1};
-  FEXCore::Config::Value<std::string> LDPath{FEXCore::Config::CONFIG_ROOTFSPATH, ""};
-  FEXCore::Config::Value<std::string> ThunkLibsPath{FEXCore::Config::CONFIG_THUNKLIBSPATH, ""};
-  FEXCore::Config::Value<bool> SilentLog{FEXCore::Config::CONFIG_SILENTLOGS, false};
-  FEXCore::Config::Value<std::string> Environment{FEXCore::Config::CONFIG_ENVIRONMENT, ""};
-  FEXCore::Config::Value<std::string> OutputLog{FEXCore::Config::CONFIG_OUTPUTLOG, "stderr"};
-  FEXCore::Config::Value<std::string> DumpIR{FEXCore::Config::CONFIG_DUMPIR, "no"};
-  FEXCore::Config::Value<bool> TSOEnabledConfig{FEXCore::Config::CONFIG_TSO_ENABLED, true};
-  FEXCore::Config::Value<uint8_t> SMCChecksConfig{FEXCore::Config::CONFIG_SMC_CHECKS, FEXCore::Config::CONFIG_SMC_MMAN};
-  FEXCore::Config::Value<bool> ABILocalFlags{FEXCore::Config::CONFIG_ABI_LOCAL_FLAGS, false};
-  FEXCore::Config::Value<bool> AbiNoPF{FEXCore::Config::CONFIG_ABI_NO_PF, false};
-
   auto Args = FEX::ArgLoader::Get();
 
   LogMan::Throw::A(Args.size() > 1, "Not enough arguments");
 
   FEX::HarnessHelper::HarnessCodeLoader Loader{Args[0], Args[1].c_str()};
+  FEXCore::Config::Set(FEXCore::Config::CONFIG_IS64BIT_MODE, Loader.Is64BitMode() ? "1" : "0");
 
   FEXCore::Context::InitializeStaticTables(Loader.Is64BitMode() ? FEXCore::Context::MODE_64BIT : FEXCore::Context::MODE_32BIT);
   auto CTX = FEXCore::Context::CreateNewContext();
 
-  FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_DEFAULTCORE, CoreConfig());
-  FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_MULTIBLOCK, MultiblockConfig());
-  FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_SINGLESTEP, SingleStepConfig());
-  FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_MAXBLOCKINST, BlockSizeConfig());
-  FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_IS64BIT_MODE, Loader.Is64BitMode());
-  FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_TSO_ENABLED, TSOEnabledConfig());
-  FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_SMC_CHECKS, SMCChecksConfig());
-  FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_ABI_LOCAL_FLAGS, ABILocalFlags());
-  FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_ABI_NO_PF, AbiNoPF());
-  FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_DUMPIR, DumpIR());
-  FEXCore::Config::SetConfig(CTX, FEXCore::Config::CONFIG_VALIDATE_IR_PARSER, true);
   FEXCore::Context::SetCustomCPUBackendFactory(CTX, HostFactory::CPUCreationFactory);
 
   FEXCore::Context::InitializeContext(CTX);
-  FEXCore::Config::Set(FEXCore::Config::CONFIG_IS64BIT_MODE, Loader.Is64BitMode() ? "1" : "0");
 
   std::unique_ptr<FEX::HLE::SignalDelegator> SignalDelegation = std::make_unique<FEX::HLE::SignalDelegator>();
   std::unique_ptr<FEXCore::HLE::SyscallHandler> SyscallHandler{

--- a/Source/Tools/Debugger/IMGui_I.cpp
+++ b/Source/Tools/Debugger/IMGui_I.cpp
@@ -788,10 +788,10 @@ namespace History {
 namespace Config {
   bool ShowConfig = true;
   struct Configs {
-    FEXCore::Config::Value<uint64_t> ConfigMaxInst{FEXCore::Config::CONFIG_MAXBLOCKINST, 255};
-    FEXCore::Config::Value<uint8_t> ConfigCore{FEXCore::Config::CONFIG_DEFAULTCORE, 0};
-    FEXCore::Config::Value<uint8_t> ConfigRunningMode{FEXCore::Config::CONFIG_SINGLESTEP, 0};
-    FEXCore::Config::Value<bool> ConfigMultiblock{FEXCore::Config::CONFIG_MULTIBLOCK, false};
+    FEX_CONFIG_OPT(ConfigMaxInst, MAXBLOCKINST);
+    FEX_CONFIG_OPT(ConfigCore, DEFAULTCORE);
+    FEX_CONFIG_OPT(ConfigRunningMode, SINGLESTEP);
+    FEX_CONFIG_OPT(ConfigMultiblock, MULTIBLOCK);
   };
 
   std::unique_ptr<Configs> Config;


### PR DESCRIPTION
Configuration mapping was duplicated between three different tables.
Additionally default configuration values were strewn about. Making it confusing as to what the default value would end up being

Adds a new ConfigValues.inl header that defines a few things right next to each other.
Defines the enum name as usual.
Defines the JSON config option name.
Defines the Environment config option name
Defines the default value that the configuration should be