### PR TITLE
Extends error message about not being able to find guest interpreter

### DIFF
--- a/External/FEXCore/Source/Utils/ELFLoader.cpp
+++ b/External/FEXCore/Source/Utils/ELFLoader.cpp
@@ -67,8 +67,10 @@ bool ELFContainer::IsSupportedELF(std::string const &Filename) {
 }
 
 ELFContainer::ELFContainer(std::string const &Filename, std::string const &RootFS, bool CustomInterpreter) {
+  Loaded = true;
   if (!LoadELF(Filename)) {
     LogMan::Msg::E("Couldn't Load ELF file");
+    Loaded = false;
     return;
   }
 
@@ -87,7 +89,9 @@ ELFContainer::ELFContainer(std::string const &Filename, std::string const &RootF
       // Found the interpreter in the rootfs
     }
     else if (!LoadELF(RawString)) {
-      LogMan::Msg::E("Couldn't load dynamic ELF file's interpreter");
+      LogMan::Msg::E("Failed to find guest ELF's interpter '%s'", RawString);
+      LogMan::Msg::E("Did you forget to set an x86 rootfs? Currently '%s'", RootFS.c_str());
+      Loaded = false;
       return;
     }
   }
@@ -128,8 +132,6 @@ bool ELFContainer::LoadELF(std::string const &Filename) {
 
   if (!ELFFile.is_open())
     return false;
-
-  LogMan::Throw::A(ELFFile.is_open(), "Failed to open file");
 
   ELFFile.seekg(0, ELFFile.end);
   FileSize = ELFFile.tellg();

--- a/External/FEXCore/include/FEXCore/Utils/ELFLoader.h
+++ b/External/FEXCore/include/FEXCore/Utils/ELFLoader.h
@@ -70,6 +70,7 @@ public:
 
   bool WasDynamic() const { return DynamicProgram; }
   bool HasDynamicLinker() const { return !DynamicLinker.empty(); }
+  bool WasLoaded() const { return Loaded; }
   std::string &InterpreterLocation() { return DynamicLinker; }
 
   std::vector<char const*> const *GetNecessaryLibs() const { return &NecessaryLibs; }
@@ -155,6 +156,7 @@ private:
   bool DynamicProgram{false};
   std::string DynamicLinker;
   ProgramHeader TLSHeader{};
+  bool Loaded {false};
 };
 
 } // namespace ELFLoader

--- a/Source/Tests/ELFLoader.cpp
+++ b/Source/Tests/ELFLoader.cpp
@@ -220,10 +220,16 @@ int main(int argc, char **argv, char **const envp) {
     // Early exit if the program passed in doesn't exist
     // Will prevent a crash later
     LogMan::Msg::E("%s: command not found", Program.c_str());
-    return 0;
+    return -ENOEXEC;
   }
 
   FEX::HarnessHelper::ELFCodeLoader Loader{Program, LDPath(), Args, ParsedArgs, envp, &Environment};
+
+  if (!Loader.ELFWasLoaded()) {
+    // Loader couldn't load this program for some reason
+    return -ENOEXEC;
+  }
+
   FEXCore::Config::Set(FEXCore::Config::CONFIG_APP_FILENAME, std::filesystem::canonical(Program));
   FEXCore::Config::Set(FEXCore::Config::CONFIG_IS64BIT_MODE, Loader.Is64BitMode() ? "1" : "0");
 

--- a/Source/Tests/HarnessHelpers.h
+++ b/Source/Tests/HarnessHelpers.h
@@ -747,6 +747,8 @@ public:
     return Info;
   }
 
+  bool ELFWasLoaded() const { return File.WasLoaded(); }
+
 private:
   ::ELFLoader::ELFContainer File;
   ::ELFLoader::ELFSymbolDatabase DB;


### PR DESCRIPTION
Passes the result back up to the frontend as well which allows us to early exit correctly.
Also ensures that we return ENOEXEC on these error cases so if someone is waiting on a return value, they don't just get zero
Fixes #757