### PR TITLE
Fixes crash with large strings through LogManager

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -792,8 +792,8 @@ namespace FEXCore::Context {
         auto NewIR2 = reparsed->ViewIR();
         Dump(&out2, &NewIR2, nullptr);
         if (out.str() != out2.str()) {
-          printf("one:\n %s\n", out.str().c_str());
-          printf("two:\n %s\n", out2.str().c_str());
+          LogMan::Msg::I("one:\n %s", out.str().c_str());
+          LogMan::Msg::I("two:\n %s", out2.str().c_str());
           LogMan::Msg::A("Parsed ir doesn't match\n");
         }
         delete reparsed;
@@ -810,7 +810,7 @@ namespace FEXCore::Context {
       std::stringstream out;
       auto NewIR = Thread->OpDispatcher->ViewIR();
       FEXCore::IR::Dump(&out, &NewIR, Thread->PassManager->GetRAPass() ? Thread->PassManager->GetRAPass()->GetAllocationData() : nullptr);
-      printf("IR 0x%lx:\n%s\n@@@@@\n", GuestRIP, out.str().c_str());
+      LogMan::Msg::I("IR 0x%lx:\n%s\n@@@@@\n", GuestRIP, out.str().c_str());
     }
 
     auto RAData = Thread->PassManager->GetRAPass() ? Thread->PassManager->GetRAPass()->PullAllocationData() : nullptr;

--- a/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
@@ -56,7 +56,7 @@ bool IRValidation::Run(IREmitter *IREmit) {
   }
 
   NodeIsLive.Set(1); // IRHEADER
-  
+
   for (auto [BlockNode, BlockHeader] : CurrentIR.GetBlocks()) {
     auto BlockIROp = BlockHeader->CW<FEXCore::IR::IROp_CodeBlock>();
     LogMan::Throw::A(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
@@ -271,8 +271,8 @@ bool IRValidation::Run(IREmitter *IREmit) {
     if (HadWarning) {
       Out << "Warnings:" << std::endl << Warnings.str() << std::endl;
     }
-   
-    fprintf(stderr, "%s", Out.str().c_str());
+
+    LogMan::Msg::E("%s", Out.str().c_str());
   }
 
   return false;

--- a/External/FEXCore/Source/Utils/LogManager.cpp
+++ b/External/FEXCore/Source/Utils/LogManager.cpp
@@ -12,12 +12,18 @@ void UnInstallHandlers() { Handlers.clear(); }
 [[noreturn]] void M(const char *fmt, va_list args) {
   size_t MsgSize = 1024;
   char *Buffer = reinterpret_cast<char*>(alloca(MsgSize));
-  size_t Return = vsnprintf(Buffer, MsgSize, fmt, args);
+  va_list argsCopy;
+  va_copy(argsCopy, args);
+  size_t Return = vsnprintf(Buffer, MsgSize, fmt, argsCopy);
+  va_end(argsCopy);
   if (Return >= MsgSize) {
     // Allocate a bigger size on failure
     MsgSize = Return;
     Buffer = reinterpret_cast<char*>(alloca(MsgSize));
-    vsnprintf(Buffer, MsgSize, fmt, args);
+    va_end(argsCopy);
+    va_copy(argsCopy, args);
+    vsnprintf(Buffer, MsgSize, fmt, argsCopy);
+    va_end(argsCopy);
   }
 
   for (auto &Handler : Handlers) {
@@ -36,12 +42,18 @@ void UnInstallHandlers() { Handlers.clear(); }
 void M(DebugLevels Level, const char *fmt, va_list args) {
   size_t MsgSize = 1024;
   char *Buffer = reinterpret_cast<char*>(alloca(MsgSize));
-  size_t Return = vsnprintf(Buffer, MsgSize, fmt, args);
+  va_list argsCopy;
+  va_copy(argsCopy, args);
+  size_t Return = vsnprintf(Buffer, MsgSize, fmt, argsCopy);
+  va_end(argsCopy);
   if (Return >= MsgSize) {
     // Allocate a bigger size on failure
     MsgSize = Return;
     Buffer = reinterpret_cast<char*>(alloca(MsgSize));
-    vsnprintf(Buffer, MsgSize, fmt, args);
+    va_end(argsCopy);
+    va_copy(argsCopy, args);
+    vsnprintf(Buffer, MsgSize, fmt, argsCopy);
+    va_end(argsCopy);
   }
   for (auto &Handler : Handlers) {
     Handler(Level, Buffer);


### PR DESCRIPTION
va_list types have an edge where after operating on it, then it is undefined behaviour to do anything other than va_end on the object.
So in order to call vsnprintf on it multiple times we must create copies with va_copy.
Easy enough to work around by doing a few more copies of the va_list