### PR TITLE
Remove most warnings from FEX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ option(ENABLE_ASAN "Enables Clang ASAN" FALSE)
 option(ENABLE_TSAN "Enables Clang TSAN" FALSE)
 option(ENABLE_ASSERTIONS "Enables assertions in build" FALSE)
 option(ENABLE_VISUAL_DEBUGGER "Enables the visual debugger for compiling" FALSE)
+option(ENABLE_STRICT_WERROR "Enables stricter -Werror for CI" FALSE)
+option(ENABLE_WERROR "Enables -Werror" FALSE)
 
 set (X86_C_COMPILER "x86_64-linux-gnu-gcc" CACHE STRING "c compiler for compiling x86 guest libs")
 set (X86_CXX_COMPILER "x86_64-linux-gnu-g++" CACHE STRING "c++ compiler for compiling x86 guest libs")
@@ -145,6 +147,14 @@ endif()
 check_cxx_compiler_flag("-march=native" COMPILER_SUPPORTS_MARCH_NATIVE)
 if(COMPILER_SUPPORTS_MARCH_NATIVE)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
+endif()
+
+if(ENABLE_WERROR OR ENABLE_STRICT_WERROR)
+  add_compile_options(-Werror)
+  if (NOT ENABLE_STRICT_WERROR)
+    # Disable some Werror that can add frustration when developing
+    add_compile_options(-Wno-error=unused-variable)
+  endif()
 endif()
 
 if(_M_ARM_64)

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -400,6 +400,7 @@ static void StopThread(FEXCore::Core::InternalThreadState *Thread) {
   Thread->CTX->StopThread(Thread);
 
   LogMan::Msg::A("unreachable");
+  __builtin_unreachable();
 }
 
 [[noreturn]]
@@ -407,6 +408,7 @@ static void SignalReturn(FEXCore::Core::InternalThreadState *Thread) {
   Thread->CTX->SignalThread(Thread, FEXCore::Core::SIGNALEVENT_RETURN);
 
   LogMan::Msg::A("unreachable");
+  __builtin_unreachable();
 }
 
 template<IR::IROps Op>
@@ -825,8 +827,6 @@ bool InterpreterOps::GetFallbackHandler(IR::IROp_Header *IROp, FallbackInfo *Inf
       break;
     }
     case IR::OP_F80CVT: {
-      auto Op = IROp->C<IR::IROp_F80CVT>();
-
       switch (OpSize) {
         case 4: {
           *Info = GetFallbackInfo(&OpHandlers<IR::OP_F80CVT>::handle4);
@@ -988,7 +988,6 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, FEX
           }
 
           case IR::OP_REMOVECODEENTRY: {
-            auto Op = IROp->C<IR::IROp_RemoveCodeEntry>();
             Thread->CTX->RemoveCodeEntry(Thread, CurrentIR->GetHeader()->Entry);
             break;
           }

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
@@ -271,8 +271,6 @@ DEF_OP(ValidateCode) {
 }
 
 DEF_OP(RemoveCodeEntry) {
-  auto Op = IROp->C<IR::IROp_RemoveCodeEntry>();
-
   auto NumPush = RA64.size();
 
   for (auto &Reg : RA64)

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -568,7 +568,6 @@ void *X86JITCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView const *IR
   uint32_t SSACount = IR->GetSSACount();
 
   this->RAData = RAData;
-  auto HeaderOp = IR->GetHeader();
 
   // Fairly excessive buffer range to make sure we don't overflow
   uint32_t BufferRange = SSACount * 16;

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -997,8 +997,6 @@ void OpDispatchBuilder::CondJUMPOp(OpcodeArgs) {
 
   // Fallback
   {
-    uint8_t GPRSize = CTX->Config.Is64BitMode ? 8 : 4;
-
     auto CondJump = _CondJump(SrcCond);
 
     // Taking branch block
@@ -1059,7 +1057,6 @@ void OpDispatchBuilder::CondJUMPRCXOp(OpcodeArgs) {
   auto CurrentBlock = GetCurrentBlock();
 
   {
-    uint8_t GPRSize = CTX->Config.Is64BitMode ? 8 : 4;
     auto CondJump = _CondJump(CondReg, {COND_EQ});
 
     // Taking branch block
@@ -1136,7 +1133,6 @@ void OpDispatchBuilder::LoopOp(OpcodeArgs) {
   auto FalseBlock = JumpTargets.find(Op->PC + Op->InstSize);
 
   {
-    uint8_t GPRSize = CTX->Config.Is64BitMode ? 8 : 4;
     auto CondJump = _CondJump(SrcCond);
 
     // Taking branch block
@@ -1176,7 +1172,6 @@ void OpDispatchBuilder::LoopOp(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::JUMPOp(OpcodeArgs) {
-  uint8_t GPRSize = CTX->Config.Is64BitMode ? 8 : 4;
   BlockSetRIP = true;
 
   // This is just an unconditional relative literal jump
@@ -4324,8 +4319,6 @@ void OpDispatchBuilder::CMPXCHGOp(OpcodeArgs) {
   // 0x80064000
   // 0x80064000
 
-  auto ZeroConst = _Constant(0);
-  auto OneConst = _Constant(1);
   if (Op->Dest.TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_GPR) {
     OrderedNode *Src1{};
     OrderedNode *Src1Lower{};

--- a/External/FEXCore/Source/Interface/IR/IRDumper.cpp
+++ b/External/FEXCore/Source/Interface/IR/IRDumper.cpp
@@ -24,6 +24,7 @@ static void PrintArg(std::stringstream *out, [[maybe_unused]] IRListView const* 
   *out << "#0x" << std::hex << Arg;
 }
 
+[[maybe_unused]]
 static void PrintArg(std::stringstream *out, [[maybe_unused]] IRListView const* IR, const char* Arg) {
   *out <<  Arg;
 }
@@ -91,7 +92,7 @@ static void PrintArg(std::stringstream *out, IRListView const* IR, OrderedNodeWr
     *out << "%ssa" << std::to_string(Arg.ID());
     if (RAData) {
       auto PhyReg = RAData->GetNodeRegister(Arg.ID());
-      
+
       switch (PhyReg.Class) {
         case FEXCore::IR::GPRClass.Val: *out << "(GPR"; break;
         case FEXCore::IR::GPRFixedClass.Val: *out << "(GPRFixed"; break;

--- a/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -158,12 +158,7 @@ bool ConstProp::Run(IREmitter *IREmit) {
 
   bool Changed = false;
   auto CurrentIR = IREmit->ViewIR();
-
-  auto Header = CurrentIR.GetHeader();
-
   auto OriginalWriteCursor = IREmit->GetWriteCursor();
-
-  auto HeaderOp = CurrentIR.GetHeader();
 
   {
 

--- a/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -1360,7 +1360,6 @@ namespace FEXCore::IR {
 
     // If this node is allocated above the number of physical registers we have then we need to search the interference list and spill the one
     // that is cheapest
-    FEXCore::IR::RegisterClassType RegClass = FEXCore::IR::RegisterClassType{CurrentRegAndClass.Class};
     bool NeedsToSpill = CurrentRegAndClass.Reg == INVALID_REG;
 
     if (NeedsToSpill) {
@@ -1505,8 +1504,6 @@ namespace FEXCore::IR {
     bool Changed = false;
 
     auto IR = IREmit->ViewIR();
-
-    auto HeaderOp = IR.GetHeader();
 
     SpillSlotCount = 0;
     Graph->SpillStack.clear();


### PR DESCRIPTION
This removes a significant number of warnings from FEX.
Avoids changing code that would conflict with #831 though.

Remaining warnings end up being in externals or the `offsetof(FEXCore::Context::Context, Config.RunningMode)` warning