### PR TITLE
Fixes uname version and wraps /proc/version

### DIFF
--- a/Source/Tests/CMakeLists.txt
+++ b/Source/Tests/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBS FEXCore Common CommonCore)
 
 add_executable(FEXLoader ELFLoader.cpp)
 target_include_directories(FEXLoader PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/Source/)
+target_include_directories(FEXLoader PRIVATE ${CMAKE_BINARY_DIR}/generated)
 
 target_link_libraries(FEXLoader ${LIBS} LinuxEmulation)
 
@@ -62,6 +63,7 @@ target_link_libraries(TestHarness ${LIBS})
 
 add_executable(TestHarnessRunner TestHarnessRunner.cpp)
 target_include_directories(TestHarnessRunner PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/Source/)
+target_include_directories(TestHarnessRunner PRIVATE ${CMAKE_BINARY_DIR}/generated)
 
 target_link_libraries(TestHarnessRunner ${LIBS} LinuxEmulation)
 
@@ -75,6 +77,7 @@ add_executable(IRLoader
   IRLoader/Loader.cpp
 )
 target_include_directories(IRLoader PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/Source/)
+target_include_directories(IRLoader PRIVATE ${CMAKE_BINARY_DIR}/generated)
 
 target_link_libraries(IRLoader ${LIBS} LinuxEmulation)
 

--- a/Source/Tests/LinuxSyscalls/CMakeLists.txt
+++ b/Source/Tests/LinuxSyscalls/CMakeLists.txt
@@ -54,3 +54,4 @@ add_library(LinuxEmulation STATIC
 )
 
 target_link_libraries(LinuxEmulation FEXCore pthread numa)
+target_include_directories(LinuxEmulation PRIVATE ${CMAKE_BINARY_DIR}/generated)

--- a/Source/Tests/LinuxSyscalls/EmulatedFiles/EmulatedFiles.cpp
+++ b/Source/Tests/LinuxSyscalls/EmulatedFiles/EmulatedFiles.cpp
@@ -593,6 +593,17 @@ namespace FEX::EmulatedFile {
       return f;
     };
 
+    FDReadCreators["/proc/version"] = [&](FEXCore::Context::Context *ctx, int32_t fd, const char *pathname, int32_t flags, mode_t mode) -> int32_t {
+      FILE *fp = tmpfile();
+      // UTS version NEEDS to be in a format that can pass to `date -d`
+      // Format of this is Linux version <Release> (<Compile By>@<Compile Host>) (<Linux Compiler>) #<version> {SMP, PREEMPT, PREEMPT_RT} <UTS version>\n"
+      const char kernel_version[] = "Linux version 5.0.0 (FEX@FEX) (clang) #" GIT_DESCRIBE_STRING " SMP " __DATE__ " " __TIME__ "\n\0";
+      fwrite(kernel_version, sizeof(uint8_t), strlen(kernel_version) + 1, fp);
+      fseek(fp, 0, SEEK_SET);
+      int32_t f = fileno(fp);
+      return f;
+    };
+
     auto NumCPUCores = [&](FEXCore::Context::Context *ctx, int32_t fd, const char *pathname, int32_t flags, mode_t mode) -> int32_t {
       FILE *fp = tmpfile();
       fwrite((void*)&cpus_online.at(0), sizeof(uint8_t), cpus_online.size(), fp);

--- a/Source/Tests/LinuxSyscalls/Syscalls.h
+++ b/Source/Tests/LinuxSyscalls/Syscalls.h
@@ -2,6 +2,7 @@
 
 #include "Tests/LinuxSyscalls/FileManagement.h"
 #include "Tests/LinuxSyscalls/SignalDelegator.h"
+#include "git_version.h"
 
 #include <FEXCore/Config/Config.h>
 #include <FEXCore/HLE/SyscallHandler.h>
@@ -12,10 +13,6 @@
 #include <unordered_map>
 
 #include <sys/epoll.h>
-
-#ifndef FEXCORE_VERSION
-#define FEXCORE_VERSION "1"
-#endif
 
 // #define DEBUG_STRACE
 

--- a/Source/Tests/LinuxSyscalls/Syscalls/Info.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Info.cpp
@@ -33,8 +33,9 @@ namespace FEX::HLE {
       }
       strcpy(buf->sysname, "Linux");
       strcpy(buf->release, "5.0.0");
-      strcpy(buf->version, "#" FEXCORE_VERSION);
-      static_assert(sizeof("#" FEXCORE_VERSION) <= sizeof(buf->version), "FEXCORE_VERSION define became too large!");
+      const char version[] = "#" GIT_DESCRIBE_STRING " SMP " __DATE__ " " __TIME__;
+      strcpy(buf->version, version);
+      static_assert(sizeof(version) <= sizeof(buf->version), "uname version define became too large!");
       // Tell the guest that we are a 64bit kernel
       strcpy(buf->machine, "x86_64");
       return 0;


### PR DESCRIPTION
While implementing /proc/version I noticed we weren't pushing the FEX version to this correctly.
We hadn't ever defined FEXCORE_VERSION so it was always just a 1.
Now we correctly set the version to our describe version and also wraps /proc/version with the same information.

Fixes #840