### PR TITLE
Fixes FEXConfig trying to update full refresh

### DIFF
--- a/Source/Tools/FEXConfig/Main.cpp
+++ b/Source/Tools/FEXConfig/Main.cpp
@@ -571,7 +571,7 @@ int main() {
   ImGui_ImplOpenGL3_Init(glsl_version);
 
   while (!glfwWindowShouldClose(Window)) {
-    glfwPollEvents();
+    glfwWaitEvents();
 
     // Start the Dear ImGui frame
     ImGui_ImplOpenGL3_NewFrame();


### PR DESCRIPTION
This burns a decent amount of CPU time just idling and we don't have active screen elements to matter here
It's still responsive because it'll update as the window gets any events