### PR TITLE
RCLSE: Invalidate around OP_SYSCALLs, Syscalls might read the context

### DIFF
--- a/External/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
@@ -598,7 +598,8 @@ bool RCLSE::RedundantStoreLoadElimination(FEXCore::IR::IREmitter *IREmit) {
         }
       }
       else if (IROp->Op == OP_STORECONTEXTINDEXED ||
-               IROp->Op == OP_LOADCONTEXTINDEXED) {
+               IROp->Op == OP_LOADCONTEXTINDEXED || 
+               IROp->Op == OP_SYSCALL) {
         // We can't track through these
         ResetClassificationAccesses(&LocalInfo);
       }


### PR DESCRIPTION
Fixes steam w/ all optimization passes enabled