### PR TITLE
Removes libcap-dev dependency

### DIFF
--- a/Source/Tests/LinuxSyscalls/Syscalls/Info.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Info.cpp
@@ -11,7 +11,6 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <syslog.h>
-#include <sys/capability.h>
 #include <sys/random.h>
 #include <sys/resource.h>
 #include <sys/syscall.h>
@@ -20,6 +19,9 @@
 #include <unistd.h>
 
 namespace FEX::HLE {
+  using cap_user_header_t = void*;
+  using cap_user_data_t = void*;
+
   void RegisterInfo() {
     REGISTER_SYSCALL_IMPL(uname, [](FEXCore::Core::CpuStateFrame *Frame, struct utsname *buf) -> uint64_t {
       struct utsname Local{};
@@ -62,12 +64,12 @@ namespace FEX::HLE {
     });
 
     REGISTER_SYSCALL_IMPL(capget, [](FEXCore::Core::CpuStateFrame *Frame, cap_user_header_t hdrp, cap_user_data_t datap) -> uint64_t {
-      uint64_t Result = ::capget(hdrp, datap);
+      uint64_t Result = ::syscall(SYS_capget, hdrp, datap);
       SYSCALL_ERRNO();
     });
 
     REGISTER_SYSCALL_IMPL(capset, [](FEXCore::Core::CpuStateFrame *Frame, cap_user_header_t hdrp, const cap_user_data_t datap) -> uint64_t {
-      uint64_t Result = ::capset(hdrp, datap);
+      uint64_t Result = ::syscall(SYS_capset, hdrp, datap);
       SYSCALL_ERRNO();
     });
 

--- a/Source/Tests/LinuxSyscalls/Syscalls/Stubs.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Stubs.cpp
@@ -12,7 +12,6 @@
 #include <sys/ptrace.h>
 #include <grp.h>
 #include <sys/fsuid.h>
-#include <sys/capability.h>
 #include <utime.h>
 #include <signal.h>
 #include <unistd.h>


### PR DESCRIPTION
We are only using this for syscalls getcap and setcap.
These are only passthrough pointers and don't need to be handled from a library.

Noticed this while writing user documentation