### PR TITLE
Switch to using CpuStateFrames 

### DIFF
--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -1,3 +1,5 @@
+enable_language(ASM)
+
 set (SRCS
   Common/Paths.cpp
   Common/JitSymbols.cpp
@@ -124,6 +126,11 @@ set (SRCS
   Utils/LogManager.cpp
   )
 
+if (_M_X86_64)
+  list(APPEND SRCS
+    Interface/Core/Dispatcher/X86_64Dispatcher.S
+  )
+endif()
 if(_M_ARM_64)
   list(APPEND SRCS
     Interface/Core/ArchHelpers/Arm64.cpp)

--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -135,6 +135,7 @@ if (_M_X86_64)
 endif()
 if(_M_ARM_64)
   list(APPEND SRCS
+    Interface/Core/Dispatcher/Arm64Dispatcher.S
     Interface/Core/ArchHelpers/Arm64.cpp)
 endif()
 

--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -75,6 +75,7 @@ set (SRCS
   Interface/Context/Context.cpp
   Interface/Core/LookupCache.cpp
   Interface/Core/BlockSamplingData.cpp
+  Interface/Core/CodeBuffer.cpp
   Interface/Core/CompileService.cpp
   Interface/Core/Core.cpp
   Interface/Core/CPUID.cpp
@@ -87,6 +88,7 @@ set (SRCS
   Interface/Core/X86HelperGen.cpp
   Interface/Core/ArchHelpers/Arm64_stubs.cpp
   Interface/Core/ArchHelpers/Arm64Emitter.cpp
+  Interface/Core/ArchHelpers/Dwarf.cpp
   Interface/Core/Dispatcher/Dispatcher.cpp
   Interface/Core/Dispatcher/X86Dispatcher.cpp
   Interface/Core/Dispatcher/Arm64Dispatcher.cpp

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
@@ -10,7 +10,10 @@ namespace FEXCore::CPU {
 static const vixl::aarch64::XRegister STATE(STATE_arm64);
 
 // We want vixl to not allocate a default buffer. Jit and dispatcher will manually create one.
-Arm64Emitter::Arm64Emitter(size_t size) : vixl::aarch64::Assembler(size, vixl::aarch64::PositionDependentCode) {
+Arm64Emitter::Arm64Emitter(size_t size) : vixl::aarch64::Assembler(vixl::aarch64::PositionDependentCode) {
+  InternalCodeBuffer = CodeBuffer(size);
+  SetCodeBuffer(InternalCodeBuffer);
+
   CPU.SetUp();
 
   auto Features = vixl::CPUFeatures::InferFromOS();

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
@@ -1,4 +1,5 @@
 #include "Interface/Core/ArchHelpers/Arm64Emitter.h"
+#include "Interface/Core/ArchHelpers/StateReg.h"
 
 #include <FEXCore/Utils/LogManager.h>
 #include <FEXCore/Core/CoreState.h>
@@ -6,7 +7,7 @@
 #include "aarch64/cpu-aarch64.h"
 
 namespace FEXCore::CPU {
-#define STATE x28
+static const vixl::aarch64::XRegister STATE(STATE_arm64);
 
 // We want vixl to not allocate a default buffer. Jit and dispatcher will manually create one.
 Arm64Emitter::Arm64Emitter(size_t size) : vixl::aarch64::Assembler(size, vixl::aarch64::PositionDependentCode) {

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
@@ -10,9 +10,11 @@ namespace FEXCore::CPU {
 static const vixl::aarch64::XRegister STATE(STATE_arm64);
 
 // We want vixl to not allocate a default buffer. Jit and dispatcher will manually create one.
-Arm64Emitter::Arm64Emitter(size_t size) : vixl::aarch64::Assembler(vixl::aarch64::PositionDependentCode) {
-  InternalCodeBuffer = CodeBuffer(size);
-  SetCodeBuffer(InternalCodeBuffer);
+Arm64Emitter::Arm64Emitter(size_t size) : vixl::aarch64::Assembler(0, vixl::aarch64::PositionDependentCode) {
+  if (size) {
+    InternalCodeBuffer = std::move(CodeBuffer(size));
+    SetCodeBuffer(InternalCodeBuffer);
+  }
 
   CPU.SetUp();
 

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
@@ -12,7 +12,9 @@ static const vixl::aarch64::XRegister STATE(STATE_arm64);
 // We want vixl to not allocate a default buffer. Jit and dispatcher will manually create one.
 Arm64Emitter::Arm64Emitter(size_t size) : vixl::aarch64::Assembler(0, vixl::aarch64::PositionDependentCode) {
   if (size) {
-    InternalCodeBuffer = std::move(CodeBuffer(size));
+    auto NewCodeBuffer = CodeBuffer(size);
+    std::swap(InternalCodeBuffer, NewCodeBuffer);
+    //InternalCodeBuffer = std::move(CodeBuffer(size));
     SetCodeBuffer(InternalCodeBuffer);
   }
 

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Interface/Core/CodeBuffer.h"
+
 #include "aarch64/assembler-aarch64.h"
 #include "aarch64/cpu-aarch64.h"
 
@@ -51,6 +53,13 @@ class Arm64Emitter : public vixl::aarch64::Assembler {
 protected:
   Arm64Emitter(size_t size);
 
+  CodeBuffer *CurrentCodeBuffer{};
+
+  void SetCodeBuffer(CodeBuffer &Buffer) {
+    *GetBuffer() = vixl::CodeBuffer(Buffer.Ptr, Buffer.Size);
+    CurrentCodeBuffer = &Buffer;
+  }
+
   vixl::aarch64::CPU CPU;
   bool SupportsAtomics{};
   bool SupportsRCPC{};
@@ -69,6 +78,9 @@ protected:
   void Align16B();
 
   uint32_t SpillSlots{};
+
+private:
+  CodeBuffer InternalCodeBuffer;
 };
 
 }

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
@@ -56,7 +56,9 @@ protected:
   CodeBuffer *CurrentCodeBuffer{};
 
   void SetCodeBuffer(CodeBuffer &Buffer) {
-    *GetBuffer() = vixl::CodeBuffer(Buffer.Ptr, Buffer.Size);
+    vixl::CodeBuffer* CurrentVixlBuffer = GetBuffer();
+    vixl::CodeBuffer NewVixelBuffer(Buffer.Ptr, Buffer.Size);
+    *CurrentVixlBuffer = std::move(NewVixelBuffer);
     CurrentCodeBuffer = &Buffer;
   }
 
@@ -80,7 +82,7 @@ protected:
   uint32_t SpillSlots{};
 
 private:
-  CodeBuffer InternalCodeBuffer;
+  CodeBuffer InternalCodeBuffer{};
 };
 
 }

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Dwarf.cpp
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Dwarf.cpp
@@ -1,0 +1,187 @@
+#include "Interface/Core/ArchHelpers/Dwarf.h"
+#include "Interface/Core/ArchHelpers/DwarfOps.h"
+#include "Interface/Core/ArchHelpers/StateReg.h"
+#include "Interface/Core/CodeBuffer.h"
+#include <FEXCore/Core/CoreState.h>
+
+#include <string>
+#include <stdint.h>
+#include <utility>
+#include <string.h>
+
+#include <unwind.h>
+#include <map>
+
+
+extern "C" {
+  // These are somewhat undocumented functions that glibc exposes
+  extern void __register_frame(void* fde);
+  extern void __deregister_frame(void* fde);
+}
+
+namespace FEXCore::CPU {
+
+std::map<uint64_t, std::string> FDE_mapping;
+
+_Unwind_Reason_Code UnwindBacktraceCallback(struct _Unwind_Context* unwind_context, void* state_voidp) {
+    uint64_t ip = _Unwind_GetIP(unwind_context);
+    uint64_t start = _Unwind_GetRegionStart(unwind_context);
+    uint64_t ra = _Unwind_GetGR(unwind_context, 16);
+
+    printf("ip %lx, region %lx, ra %lx\n", ip, start, ra);
+
+    if (FDE_mapping.contains(start)) {
+        uint64_t cfa = _Unwind_GetCFA(unwind_context);
+        uint64_t ra = _Unwind_GetGR(unwind_context, 16);
+        printf("Dynamic FDE %s\ncfa = %lx, ra = %lx\n", FDE_mapping[start].c_str(), cfa, ra);
+    }
+
+    return _URC_NO_REASON;
+}
+
+void Backtrace() {
+    _Unwind_Backtrace(UnwindBacktraceCallback, nullptr);
+}
+
+
+
+DwarfFrame::DwarfFrame(CodeBuffer *Buffer) {
+  EmitDwarfForCodeBuffer(Buffer);
+
+  // Register the FDE with glibc
+  // We pass a pointer directly to the FDE, glibc will look backwards for the CIE
+  __register_frame(DwarfData.data() + FdeOffset);
+}
+
+DwarfFrame::~DwarfFrame() {
+  // Make sure we unregister the same pointer
+  if (!DwarfData.empty())
+    __deregister_frame(DwarfData.data() + FdeOffset);
+}
+
+
+void DwarfFrame::EmitDwarfForCodeBuffer(CodeBuffer *Buffer) {
+  // Various emitters
+  auto emit_byte = [&] (uint8_t b) { DwarfData.push_back(b); };
+  auto emit_short = [&] (uint16_t s) { emit_byte(s & 0xff); emit_byte(s >> 8); };
+  auto emit_word = [&] (uint32_t w) { emit_short(w & 0xffff); emit_short(w >> 16); };
+  auto emit_u64  = [&] (uint64_t l) { emit_word(l & 0xffffffff); emit_word(l >> 32); };
+  auto emit_uLEB128 = [&] (uint64_t num) {
+    bool more = true;
+    while (more) {
+        more = num > 0x7f;
+        emit_byte((num & 0x7f) | (more << 7));
+        num = num >> 7;
+    }
+  };
+  auto emit_sLEB128 = [&] (int64_t num) {
+    bool more = true;
+    while (more) {
+        uint8_t byte = num & 0x7f;
+        bool sign = (byte & 0x40) != 0;
+        num = num >> 7;
+        more = (num != 0 || sign) && (num != -1 || !sign);
+        emit_byte(byte | (more << 7));
+    }
+
+  };
+  auto emit_string = [&] (std::string str) {
+      for (auto &c : str) {
+          emit_byte(c);
+      }
+      emit_byte('\0');
+  };
+
+  auto fixup32 = [&] (size_t offset, uint32_t val) {
+      DwarfData[offset++] = (val >>  0) & 0xFF;
+      DwarfData[offset++] = (val >>  8) & 0xFF;
+      DwarfData[offset++] = (val >> 16) & 0xFF;
+      DwarfData[offset++] = (val >> 24) & 0xFF;
+  };
+
+  // CIE (Common Information Entry)
+  // Holds common information that can be shared by multiple FDEs
+  emit_word(0x10); // length
+  emit_word(0x0); // CIE_ID
+  emit_byte(1); // CIE_VERSION
+  emit_string("zR"); // augmentation tags (see augmentation data below)
+  emit_uLEB128(1); // Code alignment factor
+  emit_sLEB128(-8); // Data alignment factor
+  emit_byte(16); // Return address register
+      // Augmentation data
+      emit_uLEB128(1); // z = length
+      emit_byte(0x04); // R = DW_EH_PE_absptr | DW_EH_PE_udata8; Pointers are 8 byte absolute
+
+  // Initial instructions
+  while (DwarfData.size() & 0x3)  // PADDING
+  {
+      emit_byte(0x00); // DW_CFA_nop
+  }
+
+  FdeOffset = DwarfData.size();
+
+  // FDE (Frame Description Entry (FDE))
+  // In theory this describes one function
+  // But we are going to abuse things and use one to describe the whole jit code buffer
+  emit_word(0); // length (we will backpatch this below)
+  emit_word(DwarfData.size()); // relative offset to CIE (but negated)
+  emit_u64(reinterpret_cast<uint64_t>(Buffer->Ptr)); // pc start
+  emit_u64(Buffer->Size); // pc length
+  emit_uLEB128(0); // No augmentation
+
+  // FDE instructions
+  // This is a bytecode that libunwind (part of libc) will execute to find the state at
+  // any given instruction within the "function"
+  //
+  // Because our jitted code ALWAYS keeps the current state loaded in r14 (x86_64) or r28 (Arm64)
+  // we can treat this kind of like a base pointer
+  // The following bytecode will apply to the whole codebuffer
+  {
+      // Step one, we need to find the CFA (Call Frame)
+      // Which is just the fake call frame we setup when entering the dispatcher
+
+      // CFA = (STATE)->ReturningStackLocation
+      emit_byte(DW_CFA_def_cfa_expression); // We need a full expression to specify this
+          emit_uLEB128(7); // num bytes
+          emit_byte(DW_OP_reg(STATE_host)); // load STATE onto stack
+          emit_byte(DW_OP_const2u); // load the offset to ReturningStackLocation
+          emit_short(offsetof(FEXCore::Core::CpuStateFrame, ReturningStackLocation));
+          emit_byte(DW_OP_plus); // calculate address of ReturningStackLocation
+          emit_byte(DW_OP_deref); // read the value of ReturningStackLocation
+          emit_byte(DW_OP_nop);
+
+      // That's all we really need. Once the unwinder has found the return address
+      // it can continue up the stack and interrogate more call frames
+
+      // Most call frames contain callee saved registers
+      // But our special fake callframe doesn't, they are actually stored one frame higher
+      // So mark them as undefined
+      emit_byte(DW_CFA_undefined); emit_uLEB128(15);
+      emit_byte(DW_CFA_undefined); emit_uLEB128(14);
+      emit_byte(DW_CFA_undefined); emit_uLEB128(13);
+      emit_byte(DW_CFA_undefined); emit_uLEB128(12);
+      emit_byte(DW_CFA_undefined); emit_uLEB128(6);
+      emit_byte(DW_CFA_undefined); emit_uLEB128(3);
+
+
+      // Return address can be found at CFE+0
+      emit_byte(DW_CFA_offset(16)); emit_uLEB128(0);
+
+      // Advance the program counter to the end of the code buffer so everything above
+      // will apply to the whole codebuffer
+      emit_byte(DW_CFA_advance_loc4); emit_word(Buffer->Size);
+
+      while (DwarfData.size() & 0x3) { // PADDING
+          emit_byte(DW_CFA_nop);
+      }
+  }
+
+  // Fixup FDE length
+  fixup32(FdeOffset, DwarfData.size() - (FdeOffset + 4));
+
+  // Next FDE
+  // Specify a length of zero to signal that there are no more FDEs
+  emit_word(0); // length
+}
+
+}

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Dwarf.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Dwarf.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <vector>
+#include <stdint.h>
+
+namespace FEXCore::CPU {
+class CodeBuffer;
+
+// Holds the data for a Dwarf Frame that has been registered with glibc
+// Will automatically unregister when deleted
+class DwarfFrame {
+public:
+  DwarfFrame() {}
+  DwarfFrame(CodeBuffer *Buffer);
+  ~DwarfFrame();
+
+  DwarfFrame(DwarfFrame &&) noexcept = default;
+  DwarfFrame& operator=(DwarfFrame &&) noexcept = default;
+
+
+private:
+  std::vector<uint8_t> DwarfData;
+  int FdeOffset;
+
+  void EmitDwarfForCodeBuffer(CodeBuffer *Buffer);
+};
+static_assert(std::is_nothrow_move_constructible<DwarfFrame>::value, "DwarfFrame should be noexcept MoveConstructible");
+
+
+void Backtrace();
+}

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/DwarfOps.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/DwarfOps.h
@@ -1,0 +1,53 @@
+#pragma once
+
+// All CFA opcodes from DWARF v4 standard
+#define CFI_OP(high, low) ((high << 6) | low)
+#define DW_CFA_nop                CFI_OP(0x0, 0x00)
+#define DW_CFA_set_loc            CFI_OP(0x0, 0x01) // address
+#define DW_CFA_advance_loc1       CFI_OP(0x0, 0x02) // 1-byte delta
+#define DW_CFA_advance_loc2       CFI_OP(0x0, 0x03) // 2-byte delta
+#define DW_CFA_advance_loc4       CFI_OP(0x0, 0x04) // 4-byte delta
+#define DW_CFA_offset_extended    CFI_OP(0x0, 0x05) // ULEB128 register, ULEB128 offset
+#define DW_CFA_restore_extended   CFI_OP(0x0, 0x06) // ULEB128 register
+#define DW_CFA_undefined          CFI_OP(0x0, 0x07) // ULEB128 register
+#define DW_CFA_same_value         CFI_OP(0x0, 0x08) // ULEB128 register
+#define DW_CFA_register           CFI_OP(0x0, 0x09) // ULEB128 register
+#define DW_CFA_remember_state     CFI_OP(0x0, 0x0a)
+#define DW_CFA_restore_state      CFI_OP(0x0, 0x0b)
+#define DW_CFA_def_cfa            CFI_OP(0x0, 0x0c) // ULEB128 register
+#define DW_CFA_def_cfa_register   CFI_OP(0x0, 0x0d) // ULEB128 register
+#define DW_CFA_def_cfa_offset     CFI_OP(0x0, 0x0e) // ULEB128 offset
+#define DW_CFA_def_cfa_expression CFI_OP(0x0, 0x0f) // BLOCK
+#define DW_CFA_expression         CFI_OP(0x0, 0x10) // ULEB128 offset, BLOCK
+#define DW_CFA_offset_extended_sf CFI_OP(0x0, 0x11) // ULEB128 register, SLEB128 offset
+#define DW_CFA_def_cfa_sf         CFI_OP(0x0, 0x12) // ULEB128 register, SLEB128 offset
+#define DW_CFA_def_cfa_offset_sf  CFI_OP(0x0, 0x13) // SLEB128 offset
+#define DW_CFA_val_offset         CFI_OP(0x0, 0x14) // ULEB128, ULEB128
+#define DW_CFA_val_offset_sf      CFI_OP(0x0, 0x15) // ULEB128, SLEB128
+#define DW_CFA_val_expression     CFI_OP(0x0, 0x16) // ULEB128, BLOCK
+
+#define DW_CFA_lo_user            CFI_OP(0x0, 0x1c)
+#define DW_CFA_hi_user            CFI_OP(0x0, 0x3f)
+
+#define DW_CFA_advance_loc(n)     CFI_OP(0x1, n)
+#define DW_CFA_offset(reg)        CFI_OP(0x2, reg)
+#define DW_CFA_restore(reg)       CFI_OP(0x3, reg)
+
+// Some DWARF expression ops from Dwarf v4 standard
+#define DW_OP_deref   0x06
+#define DW_OP_const1u 0x08
+#define DW_OP_const1s 0x09
+#define DW_OP_const2u 0x0a
+#define DW_OP_const2s 0x0b
+#define DW_OP_const4u 0x0c
+#define DW_OP_const4s 0x0d
+#define DW_OP_const8u 0x0e
+#define DW_OP_const8s 0x0d
+#define DW_OP_constu  0x0e // uLEB128
+#define DW_OP_consts  0x0e // sLEB128
+
+#define DW_OP_plus 0x22
+
+#define DW_OP_reg(n)  (0x50 + n)
+
+#define DW_OP_nop 0x96

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/StateReg.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/StateReg.h
@@ -2,7 +2,7 @@
 
 namespace FEXCore::CPU {
 
-static constexpr unsigned STATE_arm64 = 27; // r27
+static constexpr unsigned STATE_arm64 = 28; // r28
 static constexpr unsigned STATE_x86 = 14; // r14
 
 #ifdef _M_ARM_64

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/StateReg.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/StateReg.h
@@ -1,0 +1,15 @@
+#pragma once
+
+namespace FEXCore::CPU {
+
+static constexpr unsigned STATE_arm64 = 27; // r27
+static constexpr unsigned STATE_x86 = 14; // r14
+
+#ifdef _M_ARM_64
+static constexpr unsigned STATE_host = STATE_arm64;
+#endif
+#ifdef _M_X86_64
+static constexpr unsigned STATE_host = STATE_x86;
+#endif
+
+}

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/X86Emitter.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/X86Emitter.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "Interface/Core/CodeBuffer.h"
+
+#define XBYAK64
+#include <xbyak/xbyak.h>
+
+namespace FEXCore::CPU {
+
+// Ok, I admit this is a bit of a hack....
+// But we don't want XByak to allocate a memory buffer, and passing it any pointer will stop that.
+// We will set a memory buffer later
+// Also, XByak already uses fake pointers like XByak::AutoGrow to control it's internal allocator
+#define XByakNoAllocate reinterpret_cast<void*>(~0llu)
+
+class X86Emitter : public Xbyak::CodeGenerator {
+protected:
+  X86Emitter() : CodeGenerator(4096, XByakNoAllocate) {}
+  X86Emitter(size_t Size) : CodeGenerator(4096, XByakNoAllocate), InternalCodeBuffer(Size) {
+    SetCodeBuffer(InternalCodeBuffer);
+  }
+
+  void SetCodeBuffer(CodeBuffer &Buffer) {
+    setNewBuffer(Buffer.Ptr, Buffer.Size);
+    CurrentCodeBuffer = &Buffer;
+  }
+
+  CodeBuffer *CurrentCodeBuffer{};
+
+private:
+  // Internal codebuffer used when X86Emitter is initialized with a size
+  CodeBuffer InternalCodeBuffer{};
+};
+
+
+
+}

--- a/External/FEXCore/Source/Interface/Core/CodeBuffer.cpp
+++ b/External/FEXCore/Source/Interface/Core/CodeBuffer.cpp
@@ -1,0 +1,25 @@
+#include "Interface/Core/CodeBuffer.h"
+#include <FEXCore/Utils/LogManager.h>
+
+#include <sys/mman.h>
+#include <utility>
+
+namespace FEXCore::CPU {
+
+CodeBuffer::CodeBuffer(size_t Size_) : Size(Size_) {
+  Ptr = static_cast<uint8_t*>(
+               mmap(nullptr,
+                    Size,
+                    PROT_READ | PROT_WRITE | PROT_EXEC,
+                    MAP_PRIVATE | MAP_ANONYMOUS,
+                    -1, 0));
+  LogMan::Throw::A(Ptr != reinterpret_cast<uint8_t*>(~0ULL), "Couldn't allocate code buffer");
+
+  Dwarf = DwarfFrame(this);
+}
+
+CodeBuffer::~CodeBuffer() {
+  munmap(Ptr, Size);
+}
+
+}

--- a/External/FEXCore/Source/Interface/Core/CodeBuffer.cpp
+++ b/External/FEXCore/Source/Interface/Core/CodeBuffer.cpp
@@ -19,7 +19,9 @@ CodeBuffer::CodeBuffer(size_t Size_) : Size(Size_) {
 }
 
 CodeBuffer::~CodeBuffer() {
-  munmap(Ptr, Size);
+  if (Ptr) {
+    munmap(Ptr, Size);
+  }
 }
 
 }

--- a/External/FEXCore/Source/Interface/Core/CodeBuffer.h
+++ b/External/FEXCore/Source/Interface/Core/CodeBuffer.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "Interface/Core/ArchHelpers/Dwarf.h"
+
+#include <stdint.h>
+
+
+namespace FEXCore::CPU {
+class CodeBuffer {
+public:
+  CodeBuffer() {}
+  CodeBuffer(size_t Size);
+  ~CodeBuffer();
+  uint8_t *Ptr;
+  size_t Size;
+
+  CodeBuffer(CodeBuffer&& ) noexcept = default;
+  CodeBuffer& operator=(CodeBuffer &&) noexcept = default;
+
+private:
+  DwarfFrame Dwarf;
+};
+
+static_assert(std::is_nothrow_move_constructible<DwarfFrame>::value, "DwarfFrame should be noexcept MoveConstructible");
+
+
+}

--- a/External/FEXCore/Source/Interface/Core/CodeBuffer.h
+++ b/External/FEXCore/Source/Interface/Core/CodeBuffer.h
@@ -11,13 +11,17 @@ public:
   CodeBuffer() {}
   CodeBuffer(size_t Size);
   ~CodeBuffer();
-  uint8_t *Ptr;
-  size_t Size;
+  uint8_t *Ptr{};
+  size_t Size{};
 
   CodeBuffer(CodeBuffer&& ) noexcept = default;
   CodeBuffer& operator=(CodeBuffer &&) noexcept = default;
 
+  CodeBuffer( const FEXCore::CPU::CodeBuffer& ) = delete; // non construction-copyable
+  CodeBuffer& operator=( const FEXCore::CPU::CodeBuffer& ) = delete; // non copyable
+
 private:
+
   DwarfFrame Dwarf;
 };
 

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.S
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.S
@@ -1,0 +1,99 @@
+
+.text
+.globl Dispatcher
+Dispatcher:
+
+// This isn't actually the dispatcher
+// But if we label it as dispatcher, then this stack frame (which
+// we faked in the real dispatcher) will show up named Dispatcher()
+// in the backtrace, which is more or less the truth.
+
+    .cfi_sections .eh_frame, .debug_frame
+    .cfi_startproc
+
+
+    stp x19, x20, [sp, -16]!
+.cfi_adjust_cfa_offset 16
+.cfi_offset x20, -0x08
+.cfi_offset x19, -0x10
+
+    stp x21, x22, [sp, -16]!
+.cfi_adjust_cfa_offset 16
+.cfi_offset x22, -0x18
+.cfi_offset x21, -0x20
+
+    stp x23, x24, [sp, -16]!
+.cfi_adjust_cfa_offset 16
+.cfi_offset x24, -0x28
+.cfi_offset x23, -0x30
+
+    stp x25, x26, [sp, -16]!
+.cfi_adjust_cfa_offset 16
+.cfi_offset x26, -0x38
+.cfi_offset x25, -0x40
+
+    stp x27, x28, [sp, -16]!
+.cfi_adjust_cfa_offset 16
+.cfi_offset x28, -0x48
+.cfi_offset x27, -0x50
+
+    stp x29, x30, [sp, -16]!
+.cfi_adjust_cfa_offset 16
+.cfi_offset x30, -0x58
+.cfi_offset x29, -0x60
+
+    sub sp, sp, 64
+.cfi_adjust_cfa_offset 64
+
+
+// Additionally we need to store the lower 64bits of v8-v15
+// Here's a fun thing, we can use two ST4 instructions to store everything
+// We just need a single sub to sp before that
+
+// SP supporting move
+// We just saved x19 so it is safe
+    add x19, sp, 0
+
+    st4 {v8.D, v9.D, v10.D, v11.D}[0], [x19], #32
+.cfi_offset d11, -0x88
+.cfi_offset d10, -0x90
+.cfi_offset d9,  -0x98
+.cfi_offset d8,  -0xa0
+
+    st4 {v12.d, v13.d, v14.d, v15.d}[0], [x19], #32
+.cfi_offset d15, -0x68
+.cfi_offset d14, -0x70
+.cfi_offset d13, -0x78
+.cfi_offset d12, -0x80
+
+    nop
+
+.globl DispatcherExitReturn
+DispatcherExitReturn:
+
+    ld4  {v8.D,  v9.D, v10.D, v11.D}[0], [sp], #32
+.cfi_adjust_cfa_offset -32
+    ld4 {v12.D, v13.D, v14.D, v15.D}[0], [sp], #32
+.cfi_adjust_cfa_offset -32
+
+
+    ldp x29, x30, [sp], 16
+.cfi_adjust_cfa_offset -16
+
+    ldp x27, x28, [sp], 16
+.cfi_adjust_cfa_offset -16
+
+    ldp x25, x26, [sp], 16
+.cfi_adjust_cfa_offset -16
+
+    ldp x23, x24, [sp], 16
+.cfi_adjust_cfa_offset -16
+
+    ldp x21, x22, [sp], 16
+.cfi_adjust_cfa_offset -16
+
+    ldp x19, x20, [sp], 16
+.cfi_adjust_cfa_offset -16
+
+    br x30
+.cfi_endproc

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
@@ -1,4 +1,5 @@
 #include "Interface/Core/ArchHelpers/MContext.h"
+#include "Interface/Core/ArchHelpers/StateReg.h"
 #include "Interface/Core/Dispatcher/Arm64Dispatcher.h"
 
 #include "Interface/Core/Interpreter/InterpreterClass.h"
@@ -17,7 +18,7 @@ using namespace vixl;
 using namespace vixl::aarch64;
 
 static constexpr size_t MAX_DISPATCHER_CODE_SIZE = 4096;
-#define STATE x28
+#define STATE vixl::aarch64::Register::GetXRegFromCode(STATE_arm64)
 
 Arm64Dispatcher::Arm64Dispatcher(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread, DispatcherConfig &config)
   : Dispatcher(ctx, Thread), Arm64Emitter(MAX_DISPATCHER_CODE_SIZE) {

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
@@ -190,8 +190,6 @@ Arm64Dispatcher::Arm64Dispatcher(FEXCore::Context::Context *ctx, FEXCore::Core::
 
     ThreadStopHandlerAddress = Buffer->GetOffsetAddress<uint64_t>(GetCursorOffset());
 
-    PopCalleeSavedRegisters();
-
     ldp(x29, x30, MemOperand(sp, 16, PostIndex));
 
     // Return from the function

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
@@ -227,14 +227,6 @@ Arm64Dispatcher::Arm64Dispatcher(FEXCore::Context::Context *ctx, FEXCore::Core::
   }
 
   {
-    SignalHandlerReturnAddress = Buffer->GetOffsetAddress<uint64_t>(GetCursorOffset());
-
-    // Now to get back to our old location we need to do a fault dance
-    // We can't use SIGTRAP here since gdb catches it and never gives it to the application!
-    hlt(0);
-  }
-
-  {
     ThreadPauseHandlerAddressSpillSRA = Buffer->GetOffsetAddress<uint64_t>(GetCursorOffset());
     if (SRAEnabled)
       SpillStaticRegs();

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
@@ -17,7 +17,6 @@ namespace FEXCore::CPU {
 using namespace vixl;
 using namespace vixl::aarch64;
 
-static constexpr size_t MAX_DISPATCHER_CODE_SIZE = 4096;
 #define STATE vixl::aarch64::Register::GetXRegFromCode(STATE_arm64)
 
 Arm64Dispatcher::Arm64Dispatcher(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread, DispatcherConfig &config)

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
@@ -317,10 +317,10 @@ uint64_t Dispatcher::GetCompileBlockPtr() {
   return CompileBlockPtr.Data;
 }
 
-void Dispatcher::RemoveCodeBuffer(uint8_t* start_to_remove) {
+void Dispatcher::ForgetCodeBuffer(CodeBuffer& Buffer) {
   for (auto iter = CodeBuffers.begin(); iter != CodeBuffers.end(); ++iter) {
     auto [start, end] = *iter;
-    if (start == reinterpret_cast<uint64_t>(start_to_remove)) {
+    if (start == reinterpret_cast<uint64_t>(Buffer.Ptr)) {
       CodeBuffers.erase(iter);
       return;
     }

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
@@ -274,11 +274,10 @@ bool Dispatcher::HandleSignalPause(int Signal, void *info, void *ucontext) {
   }
 
   if (SignalReason == FEXCore::Core::SignalEvent::SIGNALEVENT_RETURN) {
-    RestoreThreadState(ucontext);
+    // This signal only comes from interpreter
 
-    // Ref count our faults
-    // We use this to track if it is safe to clear cache
-    --SignalHandlerRefCounter;
+    ArchHelpers::Context::SetSp(ucontext, Frame->ReturningStackLocation);
+    ArchHelpers::Context::SetPc(ucontext, ThreadStopHandlerAddress);
 
     ThreadState->SignalReason.store(FEXCore::Core::SIGNALEVENT_NONE);
     return true;

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
@@ -33,7 +33,6 @@ public:
   uint64_t ThreadPauseHandlerAddress{};
   uint64_t ThreadPauseHandlerAddressSpillSRA{};
   uint64_t ExitFunctionLinkerAddress{};
-  uint64_t SignalHandlerReturnAddress{};
   uint64_t PauseReturnInstruction{};
 
   /**  @} */
@@ -58,6 +57,8 @@ public:
   bool IsAddressInDispatcher(uint64_t Address) {
     return Address >= Start && Address < End;
   }
+
+  void ExecuteGuestFrame(FEXCore::Core::CpuStateFrame *Frame);
 
   virtual ~Dispatcher() {};
 

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher_asm.h
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher_asm.h
@@ -1,0 +1,5 @@
+
+extern "C" {
+ __attribute__((naked)) void DispatcherExit();
+
+}

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher_asm.h
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher_asm.h
@@ -1,5 +1,5 @@
+#pragma once
 
 extern "C" {
- __attribute__((naked)) void DispatcherExit();
-
+  extern void* DispatcherExitReturn();
 }

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/X86Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/X86Dispatcher.cpp
@@ -132,7 +132,7 @@ X86Dispatcher::X86Dispatcher(FEXCore::Context::Context *ctx, FEXCore::Core::Inte
     je(NoBlock);
 
     // Update L1
-    if (config.ExecuteBlocksWithCall) {
+    if (!config.ExecuteBlocksWithCall) {
       mov(r13, Thread->LookupCache->GetL1Pointer());
       mov(rcx, rdx);
       and_(rcx, LookupCache::L1_ENTRIES_MASK);
@@ -261,14 +261,6 @@ X86Dispatcher::X86Dispatcher(FEXCore::Context::Context *ctx, FEXCore::Core::Inte
     // Back to the loop top now
     jmp(LoopTop);
   }
-
-  {
-    // Signal return handler
-    SignalHandlerReturnAddress = getCurr<uint64_t>();
-
-    ud2();
-  }
-
 
   {
     ReturnPtr = getCurr<FEXCore::Context::Context::IntCallbackReturn>();

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/X86Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/X86Dispatcher.cpp
@@ -1,3 +1,4 @@
+#include "Interface/Core/ArchHelpers/StateReg.h"
 #include "Interface/Core/Dispatcher/X86Dispatcher.h"
 #include "Interface/Core/Dispatcher/Dispatcher_asm.h"
 
@@ -10,7 +11,7 @@
 
 namespace FEXCore::CPU {
 static constexpr size_t MAX_DISPATCHER_CODE_SIZE = 4096;
-#define STATE r14
+static Xbyak::Reg64 STATE(STATE_x86);
 
 X86Dispatcher::X86Dispatcher(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread, DispatcherConfig &config)
   : Dispatcher(ctx, Thread)

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/X86Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/X86Dispatcher.cpp
@@ -15,7 +15,7 @@ static Xbyak::Reg64 STATE(STATE_x86);
 
 X86Dispatcher::X86Dispatcher(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread, DispatcherConfig &config)
   : Dispatcher(ctx, Thread)
-  , Xbyak::CodeGenerator(MAX_DISPATCHER_CODE_SIZE) {
+  , X86Emitter(MAX_DISPATCHER_CODE_SIZE) {
 
   using namespace Xbyak;
   using namespace Xbyak::util;
@@ -64,7 +64,8 @@ X86Dispatcher::X86Dispatcher(FEXCore::Context::Context *ctx, FEXCore::Core::Inte
   mov(STATE, rdi);
 
   // Create a fake stack frame so we can exit by returning
-  push(reinterpret_cast<uint64_t>(&DispatcherExit));
+  mov(rax, reinterpret_cast<uint64_t>(DispatcherExitReturn));
+  push(rax);
 
   // Save this stack pointer so we can cleanly shutdown the emulation with a long jump
   // regardless of where we were in the stack
@@ -170,7 +171,6 @@ X86Dispatcher::X86Dispatcher(FEXCore::Context::Context *ctx, FEXCore::Core::Inte
     L(ExitBlock);
     ThreadStopHandlerAddress = getCurr<uint64_t>();
 
-    add(rsp, 8);
     ret();
   }
 

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/X86Dispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/X86Dispatcher.h
@@ -1,13 +1,10 @@
 #pragma once
 
+#include "Interface/Core/ArchHelpers/X86Emitter.h"
 #include "Interface/Core/Dispatcher/Dispatcher.h"
 
-#define XBYAK64
-#include <xbyak/xbyak.h>
-
 namespace FEXCore::CPU {
-
-class X86Dispatcher final : public Dispatcher, public Xbyak::CodeGenerator {
+class X86Dispatcher final : public Dispatcher, public X86Emitter {
   public:
     X86Dispatcher(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread, DispatcherConfig &config);
 

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/X86_64Dispatcher.S
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/X86_64Dispatcher.S
@@ -1,0 +1,36 @@
+
+.intel_syntax noprefix
+
+.text
+.globl DispatcherExit
+
+DispatcherExit:
+
+.cfi_startproc simple
+.cfi_def_cfa rsp, 8*8
+
+.cfi_offset r15, 0x30
+.cfi_offset r14, 0x28
+.cfi_offset r13, 0x20
+.cfi_offset r12, 0x18
+.cfi_offset rbp, 0x10
+.cfi_offset rbx, 0x08
+.cfi_offset rip, 0x00
+
+    add rsp, 8
+.cfi_adjust_cfa_offset -8
+    pop r15
+.cfi_adjust_cfa_offset -8
+    pop r14
+.cfi_adjust_cfa_offset -8
+    pop r13
+.cfi_adjust_cfa_offset -8
+    pop r12
+.cfi_adjust_cfa_offset -8
+    pop rbp
+.cfi_adjust_cfa_offset -8
+    pop rbx
+.cfi_adjust_cfa_offset -8
+
+    ret
+.cfi_endproc

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/X86_64Dispatcher.S
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/X86_64Dispatcher.S
@@ -1,21 +1,31 @@
-
 .intel_syntax noprefix
 
 .text
-.globl DispatcherExit
 
-DispatcherExit:
+.globl Dispatcher
+Dispatcher:
+// This isn't actually the dispatcher
+// But if we label it as dispatcher, then this stack frame (which
+// we faked in the real dispatcher) will show up named Dispatcher()
+// in the backtrace, which is more or less the truth.
 
-.cfi_startproc simple
-.cfi_def_cfa rsp, 8*8
+    .cfi_sections .eh_frame, .debug_frame
 
-.cfi_offset r15, 0x30
-.cfi_offset r14, 0x28
-.cfi_offset r13, 0x20
-.cfi_offset r12, 0x18
-.cfi_offset rbp, 0x10
-.cfi_offset rbx, 0x08
-.cfi_offset rip, 0x00
+    .cfi_startproc
+    .cfi_adjust_cfa_offset 56
+    .cfi_offset rbx, -0x10
+    .cfi_offset rbp, -0x18
+    .cfi_offset r12, -0x20
+    .cfi_offset r13, -0x28
+    .cfi_offset r14, -0x30
+    .cfi_offset r15, -0x38
+
+// This nop stands in for what would theoretically be a call instruction
+    nop
+
+// The real dispatcher will set this label as it's return address
+.globl DispatcherExitReturn
+DispatcherExitReturn:
 
     add rsp, 8
 .cfi_adjust_cfa_offset -8

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -10,6 +10,7 @@
 #include "Interface/Core/DebugData.h"
 #include "Interface/Core/InternalThreadState.h"
 #include "Interface/Core/Interpreter/InterpreterClass.h"
+#include "Interface/Core/ArchHelpers/Dwarf.h"
 #include <FEXCore/Utils/LogManager.h>
 
 #include <FEXCore/Core/CPUBackend.h>
@@ -1060,6 +1061,9 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, FEX
             switch (Op->Reason) {
               case 4: // HLT
                 StopThread(Thread);
+              break;
+              case 6: // INT3
+                Backtrace();
               break;
             default: LogMan::Msg::A("Unknown Break Reason: %d", Op->Reason); break;
             }

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
@@ -22,13 +22,13 @@ DEF_OP(GuestReturn) {
 }
 
 DEF_OP(SignalReturn) {
-  // First we must reset the stack
-  ResetStack();
+  // Load saved stack for this call frame
+  ldr(TMP1, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, ReturningStackLocation)));
+  add(sp, TMP1, 0);
 
-  // Now branch to our signal return helper
-  // This can't be a direct branch since the code needs to live at a constant location
-  LoadConstant(x0, ThreadSharedData.SignalReturnInstruction);
-  br(x0);
+  // Jump to cleanup code
+  LoadConstant(TMP1, Dispatcher->ThreadStopHandlerAddressSpillSRA);
+  br(TMP1);
 }
 
 DEF_OP(CallbackReturn) {

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -430,7 +430,6 @@ Arm64JITCore::Arm64JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::Intern
     CallbackPtr = Dispatcher->CallbackPtr;
 
     ThreadSharedData.SignalHandlerRefCounterPtr = &Dispatcher->SignalHandlerRefCounter;
-    ThreadSharedData.SignalReturnInstruction = Dispatcher->SignalHandlerReturnAddress;
 
     Dispatcher->RegisterCodeBuffer(InitialCodeBuffer);
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -2,6 +2,7 @@
 
 #include "Interface/Core/LookupCache.h"
 #include "Interface/Core/ArchHelpers/Arm64Emitter.h"
+#include "Interface/Core/ArchHelpers/StateReg.h"
 #include "Interface/Core/Dispatcher/Dispatcher.h"
 
 #include "aarch64/assembler-aarch64.h"
@@ -12,7 +13,7 @@
 #include <FEXCore/IR/IR.h>
 #include <FEXCore/IR/IntrusiveIRList.h>
 
-#define STATE x28
+#define STATE vixl::aarch64::Register::GetXRegFromCode(STATE_arm64)
 #define TMP1 x0
 #define TMP2 x1
 #define TMP3 x2

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -430,7 +430,7 @@ DEF_OP(StoreContextIndexed) {
 DEF_OP(SpillRegister) {
   auto Op = IROp->C<IR::IROp_SpillRegister>();
   uint8_t OpSize = IROp->Size;
-  uint32_t SlotOffset = Op->Slot * 16 + 16;
+  uint32_t SlotOffset = Op->Slot * 16;
 
   if (Op->Class == FEXCore::IR::GPRClass) {
     switch (OpSize) {
@@ -476,7 +476,7 @@ DEF_OP(SpillRegister) {
 DEF_OP(FillRegister) {
   auto Op = IROp->C<IR::IROp_FillRegister>();
   uint8_t OpSize = IROp->Size;
-  uint32_t SlotOffset = Op->Slot * 16 + 16;
+  uint32_t SlotOffset = Op->Slot * 16;
 
   if (Op->Class == FEXCore::IR::GPRClass) {
     switch (OpSize) {

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
@@ -20,13 +20,8 @@ DEF_OP(GuestReturn) {
 }
 
 DEF_OP(SignalReturn) {
-  // Adjust the stack first for a regular return
-  if (SpillSlots) {
-    add(rsp, SpillSlots * 16); // + 8 to consume return address
-  }
-
-  mov(TMP1, ThreadSharedData.SignalHandlerReturnAddress);
-  jmp(TMP1);
+  mov(rsp, qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, ReturningStackLocation)]);
+  ret();
 }
 
 DEF_OP(CallbackReturn) {

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -304,7 +304,6 @@ X86JITCore::X86JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalTh
     CallbackPtr = Dispatcher->CallbackPtr;
 
     ThreadSharedData.SignalHandlerRefCounterPtr = &Dispatcher->SignalHandlerRefCounter;
-    ThreadSharedData.SignalHandlerReturnAddress = Dispatcher->SignalHandlerReturnAddress;
 
     Dispatcher->RegisterCodeBuffer(InitialCodeBuffer);
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -138,8 +138,6 @@ private:
   std::vector<CodeBuffer> CodeBuffers{};
 
   struct CompilerSharedData {
-    uint64_t SignalHandlerReturnAddress{};
-
     uint32_t *SignalHandlerRefCounterPtr{};
   };
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Interface/Core/ArchHelpers/StateReg.h"
 #include "Interface/Core/LookupCache.h"
 #include "Interface/Core/BlockSamplingData.h"
 #include "Interface/Core/Dispatcher/Dispatcher.h"
@@ -32,7 +33,6 @@ void FreeCodeBuffer(CodeBuffer Buffer);
 
 namespace FEXCore::CPU {
 
-
 // Temp registers
 // rax, rcx, rdx, rsi, r8, r9,
 // r10, r11
@@ -43,7 +43,6 @@ namespace FEXCore::CPU {
 // 1St Argument: rdi <ThreadState>
 // XMM:
 // All temp
-#define STATE r14
 #define TMP1 rax
 #define TMP2 rcx
 #define TMP3 rdx
@@ -71,6 +70,8 @@ public:
   static constexpr size_t INITIAL_CODE_SIZE = 1024 * 1024 * 16;
   static constexpr size_t MAX_CODE_SIZE = 1024 * 1024 * 256;
   void CopyNecessaryDataForCompileThread(CPUBackend *Original) override;
+
+  static constexpr Xbyak::Reg64 STATE = Xbyak::Reg64(STATE_x86);
 
 private:
   Label* PendingTargetLabel{};

--- a/Source/Tests/LinuxSyscalls/SignalDelegator.h
+++ b/Source/Tests/LinuxSyscalls/SignalDelegator.h
@@ -98,11 +98,11 @@ namespace FEX::HLE {
       FEXCore::HostSignalDelegatorFunctionForGuest GuestHandler{};
       FEXCore::GuestSigAction GuestAction{};
       DefaultBehaviour DefaultBehaviour {DEFAULT_TERM};
+      std::atomic<bool> MaskedInHandler{};
     };
 
     SignalHandler HostHandlers[MAX_SIGNALS + 1]{};
-    bool InstallHostThunk(int Signal);
-    void UpdateHostThunk(int Signal);
+    bool InstallOrUpdateHostThunk(int Signal);
 
     std::mutex HostDelegatorMutex;
     std::mutex GuestDelegatorMutex;

--- a/Source/Tests/LinuxSyscalls/SignalDelegator.h
+++ b/Source/Tests/LinuxSyscalls/SignalDelegator.h
@@ -80,7 +80,16 @@ namespace FEX::HLE {
 
     void SetCurrentSignal(uint32_t Signal) override;
 
+    /**
+     * @brief Enable the altstack for signal handling.
+     *
+     * Fex's regular backends shouldn't need it, and gdb backtraces don't like altstacks
+     * But It's useful for the host core, which does special things and doesn't insure a clean stack pointer
+     */
+    void EnableAltStack() { AltStack = true; }
+
   private:
+    bool AltStack{};
     enum DefaultBehaviour {
       DEFAULT_TERM,
       // Core dump based signals are supposed to have a coredump appear

--- a/unittests/gvisor-tests/Known_Failures
+++ b/unittests/gvisor-tests/Known_Failures
@@ -110,7 +110,6 @@ pwritev2_test
 rseq_test
 rtsignal_test
 seccomp_test
-select_test
 semaphore_test
 sendfile_test
 shm_test


### PR DESCRIPTION
This PR Continues the work of #817

Previously we were hiding the fact that our signal handlers were recursive. This change makes it blindingly obvious.
It also makes debugging way easier when combined with #851 

This change also removes most instances of host context modification and fixes a few signal handing bugs.
