### PR TITLE
Enables Invariant TSC CPUID bit

### DIFF
--- a/External/FEXCore/Source/Interface/Core/CPUID.cpp
+++ b/External/FEXCore/Source/Interface/Core/CPUID.cpp
@@ -448,6 +448,8 @@ FEXCore::CPUID::FunctionResults CPUIDEmu::Function_8000_0006h() {
 FEXCore::CPUID::FunctionResults CPUIDEmu::Function_8000_0007h() {
   FEXCore::CPUID::FunctionResults Res{};
   Res.eax = (1 << 2); // APIC timer not affected by p-state
+  Res.edx =
+    (1 << 8); // Invariant TSC
   return Res;
 }
 


### PR DESCRIPTION
I keep forgetting to enable this bit. Fixes #855