### PR TITLE
EmulatedFiles: Lock around FDToNameMap accesses

### DIFF
--- a/Source/Tests/LinuxSyscalls/FileManagement.h
+++ b/Source/Tests/LinuxSyscalls/FileManagement.h
@@ -7,6 +7,7 @@
 #include <sys/socket.h>
 #include <poll.h>
 #include <map>
+#include <mutex>
 
 #include "Tests/LinuxSyscalls/EmulatedFiles/EmulatedFiles.h"
 
@@ -47,6 +48,7 @@ public:
 private:
   FEX::EmulatedFile::EmulatedFDManager EmuFD;
 
+  std::mutex FDLock;
   std::unordered_map<int32_t, std::string> FDToNameMap;
   std::string PidSelfPath;
   std::string GetEmulatedPath(const char *pathname);


### PR DESCRIPTION
This seems to cause the geekbench 4.4.4 crashes, still not 100% sure. It's a bug nonetheless.

Likely fixes #847 and #846