### PR TITLE
OpDisp: Validate LOCK handling, add missing segment offsets

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -476,6 +476,7 @@ public:
 
   void SetMultiblock(bool _Multiblock) { Multiblock = _Multiblock; }
 
+  bool HandledLock = false;
 private:
   bool DecodeFailure{false};
   FEXCore::IR::IROp_IRHeader *Current_Header{};


### PR DESCRIPTION
## Overview

This adds a `HandledLock` variable to OpDispatcher, that is used in `Core.cpp` to make sure the lock prefixes have been handled.

It also adds the segment offsets missing from some memory opcodes (often ones with LOCK)

Addresses most of #845 and implements #793 