### PR TITLE
Explictly as for --no-multiblock in tests

### DIFF
--- a/unittests/32Bit_ASM/CMakeLists.txt
+++ b/unittests/32Bit_ASM/CMakeLists.txt
@@ -47,12 +47,12 @@ foreach(ASM_SRC ${ASM_SOURCES})
 
   # Format is "<Test Arguments>" "<Test Name>"
   set(TEST_ARGS
-    "-c irint -n 1"      "int_1"     "int"
-    "-c irint -n 500"    "int_500"   "int"
-    "-c irint -n 500 -m" "int_500_m" "int"
-    "-c irjit -n 1"      "jit_1"     "jit"
-    "-c irjit -n 500"    "jit_500"   "jit"
-    "-c irjit -n 500 -m" "jit_500_m" "jit"
+    "-c irint -n 1   --no-multiblock"    "int_1"     "int"
+    "-c irint -n 500 --no-multiblock"    "int_500"   "int"
+    "-c irint -n 500 --multiblock"       "int_500_m" "int"
+    "-c irjit -n 1   --no-multiblock"    "jit_1"     "jit"
+    "-c irjit -n 500 --no-multiblock"    "jit_500"   "jit"
+    "-c irjit -n 500 --multiblock"       "jit_500_m" "jit"
     )
 
   list(LENGTH TEST_ARGS ARG_COUNT)

--- a/unittests/ASM/CMakeLists.txt
+++ b/unittests/ASM/CMakeLists.txt
@@ -47,12 +47,12 @@ foreach(ASM_SRC ${ASM_SOURCES})
 
   # Format is "<Test Arguments>" "<Test Name>" "<Test Type>"
   set(TEST_ARGS
-    "-g -c irint -n 1"      "int_1"     "int"
-    "-g -c irint -n 500"    "int_500"   "int"
-    "-g -c irint -n 500 -m" "int_500_m" "int"
-    "-g -c irjit -n 1"      "jit_1"     "jit"
-    "-g -c irjit -n 500"    "jit_500"   "jit"
-    "-g -c irjit -n 500 -m" "jit_500_m" "jit"
+    "-g -c irint -n 1   --no-multiblock"   "int_1"     "int"
+    "-g -c irint -n 500 --no-multiblock"   "int_500"   "int"
+    "-g -c irint -n 500 --multiblock"      "int_500_m" "int"
+    "-g -c irjit -n 1   --no-multiblock"   "jit_1"     "jit"
+    "-g -c irjit -n 500 --no-multiblock"   "jit_500"   "jit"
+    "-g -c irjit -n 500 --multiblock"      "jit_500_m" "jit"
     )
   if (_M_X86_64)
     list(APPEND TEST_ARGS


### PR DESCRIPTION
We switched the default over a while back, so we haven't been getting test coverage with multiblock off