### PR TITLE
Implements a couple quality of life configuration option handling

### DIFF
--- a/External/FEXCore/Source/Interface/Config/Config.cpp
+++ b/External/FEXCore/Source/Interface/Config/Config.cpp
@@ -95,9 +95,10 @@ namespace FEXCore::Config {
     // Expand home if it exists
     if (Path.is_relative()) {
       std::string Home = getenv("HOME") ?: "";
-      auto it = PathName.find("~");
-      if (it != std::string::npos) {
-        PathName.replace(it, 1, Home);
+      // Home expansion only works if it is the first character
+      // This matches bash behaviour
+      if (PathName.at(0) == '~') {
+        PathName.replace(0, 1, Home);
         return PathName;
       }
 
@@ -144,7 +145,9 @@ namespace FEXCore::Config {
     }
     if (FEXCore::Config::Exists(FEXCore::Config::CONFIG_OUTPUTLOG)) {
       FEX_CONFIG_OPT(PathName, OUTPUTLOG);
-      ExpandPathIfExists(FEXCore::Config::CONFIG_OUTPUTLOG, PathName());
+      if (PathName() != "stdout" && PathName() != "stderr") {
+        ExpandPathIfExists(FEXCore::Config::CONFIG_OUTPUTLOG, PathName());
+      }
     }
   }
 

--- a/Source/Common/ArgumentLoader.cpp
+++ b/Source/Common/ArgumentLoader.cpp
@@ -66,7 +66,7 @@ namespace FEX::ArgLoader {
 
       CPUGroup.add_option("-T", "--Threads")
           .dest("Threads")
-          .help("Number of physical hardware threads to tell the process we have")
+          .help("Number of physical hardware threads to tell the process we have. 0 will auto detect.")
           .set_default(1);
 
       CPUGroup.add_option("--smc-checks")


### PR DESCRIPTION
This takes the changes from #829 and moves it to the correct location to be picked up from any loader.
This also fixes #873.
Expands the config paths. Anything that has ~ or is relative will be converted to an absolute path.