### PR TITLE
Cleanup threads when they exit

### DIFF
--- a/External/FEXCore/Source/Interface/Context/Context.cpp
+++ b/External/FEXCore/Source/Interface/Context/Context.cpp
@@ -23,6 +23,9 @@ namespace FEXCore::Context {
   }
 
   void DestroyContext(FEXCore::Context::Context *CTX) {
+    if (CTX->ParentThread) {
+      CTX->DestroyThread(CTX->ParentThread);
+    }
     delete CTX;
   }
 

--- a/External/FEXCore/Source/Interface/Context/Context.cpp
+++ b/External/FEXCore/Source/Interface/Context/Context.cpp
@@ -119,20 +119,12 @@ namespace FEXCore::Context {
     CTX->StopThread(Thread);
   }
 
+  void DestroyThread(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread) {
+    CTX->DestroyThread(Thread);
+  }
+
   void DeleteForkedThreads(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread) {
-    // This function is called after fork
-    // We need to cleanup some of the thread data that is dead
-    for (auto &DeadThread : CTX->Threads) {
-      if (DeadThread == Thread) {
-        continue;
-      }
-
-      // Setting running to false ensures that when they are shutdown we won't send signals to kill them
-      DeadThread->RunningEvents.Running = false;
-    }
-
-    // We now only have one thread
-    CTX->IdleWaitRefCount = 1;
+    CTX->DeleteForkedThreads(Thread);
   }
 
   void SetSignalDelegator(FEXCore::Context::Context *CTX, FEXCore::SignalDelegator *SignalDelegation) {

--- a/External/FEXCore/Source/Interface/Context/Context.cpp
+++ b/External/FEXCore/Source/Interface/Context/Context.cpp
@@ -126,8 +126,8 @@ namespace FEXCore::Context {
     CTX->DestroyThread(Thread);
   }
 
-  void DeleteForkedThreads(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread) {
-    CTX->DeleteForkedThreads(Thread);
+  void CleanupAfterFork(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread) {
+    CTX->CleanupAfterFork(Thread);
   }
 
   void SetSignalDelegator(FEXCore::Context::Context *CTX, FEXCore::SignalDelegator *SignalDelegation) {

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -198,7 +198,7 @@ namespace FEXCore::Context {
     void RunThread(FEXCore::Core::InternalThreadState *Thread);
 
     void DestroyThread(FEXCore::Core::InternalThreadState *Thread);
-    void DeleteForkedThreads(FEXCore::Core::InternalThreadState *ExceptForThread);
+    void CleanupAfterFork(FEXCore::Core::InternalThreadState *ExceptForThread);
 
     std::vector<FEXCore::Core::InternalThreadState*> *const GetThreads() { return &Threads; }
 

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -197,6 +197,9 @@ namespace FEXCore::Context {
     void CopyMemoryMapping(FEXCore::Core::InternalThreadState *ParentThread, FEXCore::Core::InternalThreadState *ChildThread);
     void RunThread(FEXCore::Core::InternalThreadState *Thread);
 
+    void DestroyThread(FEXCore::Core::InternalThreadState *Thread);
+    void DeleteForkedThreads(FEXCore::Core::InternalThreadState *ExceptForThread);
+
     std::vector<FEXCore::Core::InternalThreadState*> *const GetThreads() { return &Threads; }
 
     void AddNamedRegion(uintptr_t Base, uintptr_t Size, uintptr_t Offset, const std::string &filename);

--- a/External/FEXCore/include/FEXCore/Core/Context.h
+++ b/External/FEXCore/include/FEXCore/Core/Context.h
@@ -218,6 +218,7 @@ namespace FEXCore::Context {
   void InitializeThread(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread);
   void RunThread(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread);
   void StopThread(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread);
+  void DestroyThread(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread);
   void DeleteForkedThreads(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread);
   void SetSignalDelegator(FEXCore::Context::Context *CTX, FEXCore::SignalDelegator *SignalDelegation);
   void SetSyscallHandler(FEXCore::Context::Context *CTX, FEXCore::HLE::SyscallHandler *Handler);

--- a/External/FEXCore/include/FEXCore/Core/Context.h
+++ b/External/FEXCore/include/FEXCore/Core/Context.h
@@ -219,7 +219,7 @@ namespace FEXCore::Context {
   void RunThread(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread);
   void StopThread(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread);
   void DestroyThread(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread);
-  void DeleteForkedThreads(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread);
+  void CleanupAfterFork(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread);
   void SetSignalDelegator(FEXCore::Context::Context *CTX, FEXCore::SignalDelegator *SignalDelegation);
   void SetSyscallHandler(FEXCore::Context::Context *CTX, FEXCore::HLE::SyscallHandler *Handler);
   FEXCore::CPUID::FunctionResults RunCPUIDFunction(FEXCore::Context::Context *CTX, uint32_t Function, uint32_t Leaf);

--- a/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
+++ b/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
@@ -102,8 +102,9 @@ namespace FEXCore::Core {
     uint32_t CompileBlockReentrantRefCount{};
     std::shared_ptr<FEXCore::CompileService> CompileService;
     bool IsCompileService{false};
+    bool DestroyedByParent{false};  // Should the parent destroy this thread, or it destory itself
 
-    FEXCore::Core::CpuStateFrame BaseFrameState{};
+    alignas(16) FEXCore::Core::CpuStateFrame BaseFrameState{};
 
   };
   static_assert(std::is_standard_layout<InternalThreadState>::value, "This needs to be standard layout");

--- a/Source/Tests/LinuxSyscalls/Syscalls/Thread.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Thread.cpp
@@ -89,7 +89,7 @@ namespace FEX::HLE {
       Thread->ThreadManager.clear_child_tid = nullptr;
 
       // Clear all the other threads that are being tracked
-      FEXCore::Context::DeleteForkedThreads(Thread->CTX, Frame->Thread);
+      FEXCore::Context::CleanupAfterFork(Thread->CTX, Frame->Thread);
 
       // only a  single thread running so no need to remove anything from the thread array
 

--- a/Source/Tests/LinuxSyscalls/x32/Thread.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Thread.cpp
@@ -111,12 +111,19 @@ namespace FEX::HLE::x32 {
         // Return the new threads TID
         uint64_t Result = NewThread->ThreadManager.GetTID();
 
+        if (flags & CLONE_VFORK) {
+          NewThread->DestroyedByParent = true;
+        }
+
         // Actually start the thread
         FEXCore::Context::RunThread(Thread->CTX, NewThread);
 
         if (flags & CLONE_VFORK) {
           // If VFORK is set then the calling process is suspended until the thread exits with execve or exit
           NewThread->ExecutionThread.join();
+
+          // Normally a thread cleans itself up on exit. But because we need to join, we are now responsible 
+          FEXCore::Context::DestroyThread(Thread->CTX, NewThread);
         }
         SYSCALL_ERRNO();
       }


### PR DESCRIPTION
Massively reduces memory usage for programs that fire up large number of threads that only run for a short amount of time.  
This makes it viable to run 24 threads of geekbench without AOTIR (peeks at about 7gb of memory)

fixes #772 
fixes #760 