### PR TITLE
Fixes crash on empty path config string

### DIFF
--- a/External/FEXCore/Source/Interface/Config/Config.cpp
+++ b/External/FEXCore/Source/Interface/Config/Config.cpp
@@ -90,6 +90,10 @@ namespace FEXCore::Config {
   }
 
   std::string ExpandPath(std::string PathName) {
+    if (PathName.empty()) {
+      return {};
+    }
+
     std::filesystem::path Path{PathName};
 
     // Expand home if it exists


### PR DESCRIPTION
If the config exists as an empty string then this would crash