### PR TITLE
Adds support for CPUID leafs

### DIFF
--- a/External/FEXCore/Source/Interface/Context/Context.cpp
+++ b/External/FEXCore/Source/Interface/Context/Context.cpp
@@ -143,8 +143,8 @@ namespace FEXCore::Context {
     CTX->SyscallHandler = Handler;
   }
 
-  FEXCore::CPUID::FunctionResults RunCPUIDFunction(FEXCore::Context::Context *CTX, uint32_t Function, [[maybe_unused]] uint32_t Leaf) {
-    return CTX->CPUID.RunFunction(Function);
+  FEXCore::CPUID::FunctionResults RunCPUIDFunction(FEXCore::Context::Context *CTX, uint32_t Function, uint32_t Leaf) {
+    return CTX->CPUID.RunFunction(Function, Leaf);
   }
 
   void SetAOTIRLoader(FEXCore::Context::Context *CTX, std::function<std::unique_ptr<std::istream>(const std::string&)> CacheReader) {

--- a/External/FEXCore/Source/Interface/Core/CPUID.h
+++ b/External/FEXCore/Source/Interface/Core/CPUID.h
@@ -23,7 +23,7 @@ private:
 public:
   void Init(FEXCore::Context::Context *ctx);
 
-  FEXCore::CPUID::FunctionResults RunFunction(uint32_t Function) {
+  FEXCore::CPUID::FunctionResults RunFunction(uint32_t Function, [[maybe_unused]] uint32_t Leaf) {
     auto Handler = FunctionHandlers.find(Function);
 
     if (Handler == FunctionHandlers.end()) {

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -1097,8 +1097,9 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, FEX
             auto Op = IROp->C<IR::IROp_CPUID>();
             uint64_t *DstPtr = GetDest<uint64_t*>(SSAData, WrapperOp);
             uint64_t Arg = *GetSrc<uint64_t*>(SSAData, Op->Header.Args[0]);
+            uint64_t Leaf = *GetSrc<uint64_t*>(SSAData, Op->Header.Args[1]);
 
-            auto Results = Thread->CTX->CPUID.RunFunction(Arg);
+            auto Results = Thread->CTX->CPUID.RunFunction(Arg, Leaf);
             memcpy(DstPtr, &Results, sizeof(uint32_t) * 4);
             break;
           }

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
@@ -324,10 +324,12 @@ DEF_OP(CPUID) {
 
   // x0 = CPUID Handler
   // x1 = CPUID Function
+  // x2 = CPUID Leaf
   LoadConstant(x0, reinterpret_cast<uint64_t>(&CTX->CPUID));
   mov(x1, GetReg<RA_64>(Op->Header.Args[0].ID()));
+  mov(x2, GetReg<RA_64>(Op->Header.Args[1].ID()));
 
-  using ClassPtrType = FEXCore::CPUID::FunctionResults (FEXCore::CPUIDEmu::*)(uint32_t);
+  using ClassPtrType = FEXCore::CPUID::FunctionResults (FEXCore::CPUIDEmu::*)(uint32_t, uint32_t);
   union PtrCast {
     ClassPtrType ClassPtr;
     uintptr_t Data;

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
@@ -297,7 +297,7 @@ DEF_OP(RemoveCodeEntry) {
 DEF_OP(CPUID) {
   auto Op = IROp->C<IR::IROp_CPUID>();
 
-  using ClassPtrType = FEXCore::CPUID::FunctionResults (FEXCore::CPUIDEmu::*)(uint32_t Function);
+  using ClassPtrType = FEXCore::CPUID::FunctionResults (FEXCore::CPUIDEmu::*)(uint32_t Function, uint32_t Leaf);
   union {
     ClassPtrType ClassPtr;
     uint64_t Raw;
@@ -314,6 +314,7 @@ DEF_OP(CPUID) {
   // Result: RAX, RDX. 4xi32
 
   mov (rsi, GetSrc<RA_64>(Op->Header.Args[0].ID()));
+  mov (rdx, GetSrc<RA_64>(Op->Header.Args[1].ID()));
   mov (rdi, reinterpret_cast<uint64_t>(&CTX->CPUID));
 
   auto NumPush = RA64.size();

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -1563,8 +1563,10 @@ void OpDispatchBuilder::MOVOffsetOp(OpcodeArgs) {
 void OpDispatchBuilder::CPUIDOp(OpcodeArgs) {
   uint8_t GPRSize = CTX->Config.Is64BitMode ? 8 : 4;
 
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-  auto Res = _CPUID(Src);
+  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Leaf = _LoadContext(4, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RCX]), GPRClass);
+
+  auto Res = _CPUID(Src, Leaf);
 
   OrderedNode *Result_Lower = _ExtractElementPair(Res, 0);
   OrderedNode *Result_Upper = _ExtractElementPair(Res, 1);

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -1138,7 +1138,11 @@
       "DestClass": "GPRPair",
       "FixedDestSize": "8",
       "NumElements": "2",
-      "SSAArgs": "1"
+      "SSAArgs": "2",
+      "SSANames": [
+        "Function",
+        "Leaf"
+      ]
     },
 
     "Bfi": {


### PR DESCRIPTION
Leafs come from ECX but only some CPUID functions support this.
This adds the initial infrastructure but doesn't yet add support for the CPUID functions to consume the leaf.