### PR TITLE
Returns EPERM on clone with namespace

### DIFF
--- a/Source/Tests/LinuxSyscalls/x32/Thread.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Thread.cpp
@@ -83,7 +83,10 @@ namespace FEX::HLE::x32 {
       }
 
       if (AnyFlagsSet(flags, CLONE_NEWNS | CLONE_NEWCGROUP | CLONE_NEWUTS | CLONE_NEWIPC | CLONE_NEWUSER | CLONE_NEWPID | CLONE_NEWNET)) {
-        ERROR_AND_DIE("clone: Namespaces are not supported");
+        // NEWUSER doesn't need any privileges from 3.8 onward
+        // We just don't support it yet
+        LogMan::Msg::I("Unconditionally returning EPERM on clone namespace");
+        return -EPERM;
       }
 
       if (!(flags & CLONE_THREAD)) {

--- a/Source/Tests/LinuxSyscalls/x64/Thread.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Thread.cpp
@@ -81,7 +81,10 @@ namespace FEX::HLE::x64 {
       }
 
       if (AnyFlagsSet(flags, CLONE_NEWNS | CLONE_NEWCGROUP | CLONE_NEWUTS | CLONE_NEWIPC | CLONE_NEWUSER | CLONE_NEWPID | CLONE_NEWNET)) {
-        ERROR_AND_DIE("clone: Namespaces are not supported");
+        // NEWUSER doesn't need any privileges from 3.8 onward
+        // We just don't support it yet
+        LogMan::Msg::I("Unconditionally returning EPERM on clone namespace");
+        return -EPERM;
       }
 
       if (!(flags & CLONE_THREAD)) {

--- a/unittests/gvisor-tests/Known_Failures
+++ b/unittests/gvisor-tests/Known_Failures
@@ -101,7 +101,6 @@ prctl_setuid_test
 prctl_test
 preadv2_test
 proc_net_test
-proc_pid_uid_gid_map_test
 proc_test
 pselect_test
 ptrace_test


### PR DESCRIPTION
Notably this allows applications to work that don't require the namespace but check up front if they are able to clone with it.
Civ 6's launcher checks this as an example