### PR TITLE
Adds a FEXBash helper program

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,6 +234,10 @@ endif()
 
 add_compile_options(-Wall)
 
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/Config.h.in
+  ${CMAKE_BINARY_DIR}/generated/Config.h)
+
 if (BUILD_TESTS)
   include(CTest)
   enable_testing()

--- a/Source/Tests/CMakeLists.txt
+++ b/Source/Tests/CMakeLists.txt
@@ -62,6 +62,17 @@ if (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
 
 endif()
 
+add_executable(FEXBash FEXBash.cpp)
+target_include_directories(FEXBash PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/Source/)
+target_include_directories(FEXBash PRIVATE ${CMAKE_BINARY_DIR}/generated)
+
+target_link_libraries(FEXBash ${LIBS} LinuxEmulation)
+
+install(TARGETS FEXBash
+  RUNTIME
+    DESTINATION bin
+    COMPONENT runtime)
+
 add_executable(TestHarnessRunner TestHarnessRunner.cpp)
 target_include_directories(TestHarnessRunner PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/Source/)
 target_include_directories(TestHarnessRunner PRIVATE ${CMAKE_BINARY_DIR}/generated)

--- a/Source/Tests/CMakeLists.txt
+++ b/Source/Tests/CMakeLists.txt
@@ -14,11 +14,15 @@ install(TARGETS FEXLoader
     DESTINATION bin
     COMPONENT runtime)
 
-set(FEX_INTERP FEXInterpreter)
+add_custom_target(FEXInterpreter ALL
+  COMMAND "ln" "-f" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/FEXLoader" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/FEXInterpreter"
+  DEPENDS FEXLoader
+)
+
 install(
   CODE "MESSAGE(\"-- Installing: ${CMAKE_INSTALL_PREFIX}/bin/FEXInterpreter\")"
   CODE "
-  EXECUTE_PROCESS(COMMAND ln -f FEXLoader ${FEX_INTERP}
+  EXECUTE_PROCESS(COMMAND ln -f FEXLoader FEXInterpreter
   WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/bin/
   )"
 )
@@ -33,7 +37,7 @@ if (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
     echo "Attempting to install FEX-x86 misc now."
     COMMAND ${CMAKE_COMMAND} -E
       echo
-      ':FEX-x86:M:0:\\x7fELF\\x01\\x01\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x02\\x00\\x03\\x00:\\xff\\xff\\xff\\xff\\xff\\xfe\\xfe\\x00\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xfe\\xff\\xff\\xff:${CMAKE_INSTALL_PREFIX}/bin/${FEX_INTERP}:CF' > /proc/sys/fs/binfmt_misc/register
+      ':FEX-x86:M:0:\\x7fELF\\x01\\x01\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x02\\x00\\x03\\x00:\\xff\\xff\\xff\\xff\\xff\\xfe\\xfe\\x00\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xfe\\xff\\xff\\xff:${CMAKE_INSTALL_PREFIX}/bin/FEXInterpreter:CF' > /proc/sys/fs/binfmt_misc/register
     COMMAND ${CMAKE_COMMAND} -E
     echo "binfmt_misc FEX-x86 installed"
   )
@@ -47,7 +51,7 @@ if (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
     echo "Attempting to install FEX-x86_64 misc now."
     COMMAND ${CMAKE_COMMAND} -E
       echo
-      ':FEX-x86_64:M:0:\\x7fELF\\x02\\x01\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x02\\x00\\x3e\\x00:\\xff\\xff\\xff\\xff\\xff\\xfe\\xfe\\x00\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xfe\\xff\\xff\\xff:${CMAKE_INSTALL_PREFIX}/bin/${FEX_INTERP}:CF' > /proc/sys/fs/binfmt_misc/register
+      ':FEX-x86_64:M:0:\\x7fELF\\x02\\x01\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x02\\x00\\x3e\\x00:\\xff\\xff\\xff\\xff\\xff\\xfe\\xfe\\x00\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xfe\\xff\\xff\\xff:${CMAKE_INSTALL_PREFIX}/bin/FEXInterpreter:CF' > /proc/sys/fs/binfmt_misc/register
     COMMAND ${CMAKE_COMMAND} -E
     echo "binfmt_misc FEX-x86_64 installed"
   )

--- a/Source/Tests/FEXBash.cpp
+++ b/Source/Tests/FEXBash.cpp
@@ -1,0 +1,58 @@
+#include "Config.h"
+#include "Common/ArgumentLoader.h"
+#include "Common/EnvironmentLoader.h"
+#include "Common/Config.h"
+
+#include <FEXCore/Config/Config.h>
+#include <filesystem>
+#include <string>
+#include <unistd.h>
+
+int main(int argc, char **argv, char **const envp) {
+  FEXCore::Config::Initialize();
+  FEXCore::Config::AddLayer(std::make_unique<FEX::Config::MainLoader>());
+  FEX::ArgLoader::LoadWithoutArguments(argc, argv);
+  FEXCore::Config::AddLayer(std::make_unique<FEX::Config::EnvLoader>(envp));
+  FEXCore::Config::Load();
+
+  // Reload the meta layer
+  FEXCore::Config::ReloadMetaLayer();
+
+  auto Args = FEX::ArgLoader::Get();
+
+  if (Args.empty()) {
+    // Early exit if we weren't passed an argument
+    return 0;
+  }
+
+  FEX_CONFIG_OPT(RootFSPath, ROOTFSPATH);
+  std::vector<const char*> Argv;
+  std::string BinShPath = RootFSPath() + "/bin/sh";
+  std::string FEXInterpreterPath = std::filesystem::path(argv[0]).parent_path().string() + "FEXInterpreter";
+  // Check if a local FEXInterpreter to FEXBash exists
+  // If it does then it takes priority over the installed one
+  if (!std::filesystem::exists(FEXInterpreterPath)) {
+    FEXInterpreterPath = FEXINTERPRETER_PATH;
+  }
+  const char *FEXArgs[] = {
+    FEXInterpreterPath.c_str(),
+    BinShPath.c_str(),
+    "-c",
+  };
+  constexpr size_t FEXArgsCount = sizeof(FEXArgs) / sizeof(FEXArgs[0]);
+
+  Argv.resize(Args.size() + FEXArgsCount + 1);
+
+  // Pass in the FEXInterpreter arguments
+  for (size_t i = 0; i < FEXArgsCount; ++i) {
+    Argv[i] = FEXArgs[i];
+  }
+
+  // Bring in passed in arguments
+  for (size_t i = 0; i < Args.size(); ++i) {
+    Argv[i + FEXArgsCount] = Args[i].c_str();
+  }
+  Argv[Argv.size() - 1] = nullptr;
+
+  return execve(Argv[0], const_cast<char *const*>(&Argv.at(0)), envp);
+}

--- a/include/Config.h.in
+++ b/include/Config.h.in
@@ -1,0 +1,4 @@
+#pragma once
+
+#define FEX_INSTALL_PREFIX "@CMAKE_INSTALL_PREFIX@"
+#define FEXINTERPRETER_PATH FEX_INSTALL_PREFIX "/bin/FEXInterpreter"


### PR DESCRIPTION
This is a helper program to execute a bash command through FEX.
Works around an edge case of
eg:
FEXInterpreter /bin/sh -c "echo A"
versus
FEXBash "echo A"
Argument expansion ends up being a pain point
This isn't currently used but will be very shortly