### PR TITLE
Fixes environment variable configuration from multiple layers

### DIFF
--- a/External/FEXCore/include/FEXCore/Config/Config.h
+++ b/External/FEXCore/include/FEXCore/Config/Config.h
@@ -103,6 +103,10 @@ namespace Type {
   protected:
     const LayerType Type;
     LayerOptions OptionMap;
+
+    void Erase(ConfigOption Option) {
+      OptionMap.erase(Option);
+    }
   };
 
   void Initialize();


### PR DESCRIPTION
This was a missing feature that I had skipped previously.
Before this commit, each layer would overwrite all previous environment variables if they had anything defined.

After this commit, the layers will now merge in priority order.
Meaning if a higher priority layer has the same environment variable defined, it will overwrite that specific variable
Ending up with a superset of all the layer's environment variables now.