### PR TITLE
Implements support for installing global application profiles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,6 +246,7 @@ endif()
 add_subdirectory(External/FEXCore)
 
 add_subdirectory(Source/)
+add_subdirectory(Data/AppConfig/)
 
 if (BUILD_TESTS)
   add_subdirectory(unittests/)

--- a/Data/AppConfig/CMakeLists.txt
+++ b/Data/AppConfig/CMakeLists.txt
@@ -1,0 +1,25 @@
+file(GLOB CONFIG_SOURCES CONFIGURE_DEPENDS *.json)
+file(GLOB GEN_CONFIG_SOURCES CONFIGURE_DEPENDS *.json.in)
+
+# Any application configuration json file gets installed
+foreach(CONFIG_SRC ${CONFIG_SOURCES})
+  install(FILES ${CONFIG_SRC}
+    DESTINATION ${DATA_DIRECTORY}/AppConfig/)
+endforeach()
+
+# Any configuration file json file that needs to be generated
+# First generate then install it
+foreach(GEN_CONFIG_SRC ${GEN_CONFIG_SOURCES})
+  # Get the filename only component
+  get_filename_component(CONFIG_NAME ${GEN_CONFIG_SRC} NAME_WE)
+
+  # Configure it
+  configure_file(
+    ${GEN_CONFIG_SRC}
+    ${CMAKE_BINARY_DIR}/Data/AppConfig/${CONFIG_NAME}.json)
+
+  # Then install the configured json
+  install(
+    FILES ${CMAKE_BINARY_DIR}/Data/AppConfig/${CONFIG_NAME}.json
+    DESTINATION ${DATA_DIRECTORY}/AppConfig/)
+endforeach()

--- a/Data/AppConfig/steam.json.in
+++ b/Data/AppConfig/steam.json.in
@@ -1,0 +1,5 @@
+{
+  "Config": {
+    "Env": "STEAM_GAME_LAUNCH_SHELL=@CMAKE_INSTALL_PREFIX@/bin/FEXBash"
+  }
+}


### PR DESCRIPTION
These need to be used sparingly, we don't want to proactively crush user options.