### PR TITLE
Allows installing of FEXThunks in our data directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,16 +259,35 @@ if (BUILD_THUNKS)
     PREFIX host-libs
     SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ThunkLibs/HostLibs"
     BINARY_DIR "Host"
+    CMAKE_ARGS "-DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}"
     INSTALL_COMMAND ""
     BUILD_ALWAYS ON
+  )
+
+  install(
+    CODE "MESSAGE(\"-- Installing: host-libs\")"
+    CODE "
+    EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} --build . --target ThunkHostsInstall
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/Host
+    )"
+    DEPENDS host-libs
   )
 
   ExternalProject_Add(guest-libs
     PREFIX guest-libs
     SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ThunkLibs/GuestLibs"
     BINARY_DIR "Guest"
-    CMAKE_ARGS "-DX86_C_COMPILER:STRING=${X86_C_COMPILER}" "-DX86_CXX_COMPILER:STRING=${X86_CXX_COMPILER}"
+    CMAKE_ARGS "-DX86_C_COMPILER:STRING=${X86_C_COMPILER}" "-DX86_CXX_COMPILER:STRING=${X86_CXX_COMPILER}" "-DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}"
     INSTALL_COMMAND ""
     BUILD_ALWAYS ON
+  )
+
+  install(
+    CODE "MESSAGE(\"-- Installing: guest-libs\")"
+    CODE "
+    EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} --build . --target ThunkGuestsInstall
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/Guest
+    )"
+    DEPENDS guest-libs
   )
 endif()

--- a/ThunkLibs/GuestLibs/CMakeLists.txt
+++ b/ThunkLibs/GuestLibs/CMakeLists.txt
@@ -6,6 +6,7 @@ set(CMAKE_CXX_STANDARD 17)
 # These get passed in from the main cmake project
 set (X86_C_COMPILER "x86_64-linux-gnu-gcc" CACHE STRING "c compiler for compiling x86 guest libs")
 set (X86_CXX_COMPILER "x86_64-linux-gnu-g++" CACHE STRING "c++ compiler for compiling x86 guest libs")
+set (DATA_DIRECTORY "${CMAKE_INSTALL_PREFIX}/share/fex-emu" CACHE PATH "global data directory")
 
 set(CMAKE_C_COMPILER "${X86_C_COMPILER}")
 set(CMAKE_CXX_COMPILER "${X86_CXX_COMPILER}")
@@ -33,9 +34,16 @@ function(generate NAME)
   set(GEN_${NAME} ${OUTPUTS} PARENT_SCOPE)
 endfunction()
 
+add_custom_target(ThunkGuestsInstall)
+
 function(add_guest_lib NAME)
-    add_library(${NAME}-guest SHARED ../lib${NAME}/lib${NAME}_Guest.cpp ${GEN_lib${NAME}})
-    target_include_directories(${NAME}-guest PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/gen/lib${NAME}" "${CMAKE_CURRENT_SOURCE_DIR}/../include")
+  add_library(${NAME}-guest SHARED ../lib${NAME}/lib${NAME}_Guest.cpp ${GEN_lib${NAME}})
+  target_include_directories(${NAME}-guest PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/gen/lib${NAME}" "${CMAKE_CURRENT_SOURCE_DIR}/../include")
+
+  add_custom_target(${NAME}-guest-install
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${DATA_DIRECTORY}/GuestThunks/
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_BINARY_DIR}/lib${NAME}-guest.so ${DATA_DIRECTORY}/GuestThunks/)
+  add_dependencies(ThunkGuestsInstall ${NAME}-guest-install)
 endfunction()
 
 generate(libasound thunks function_packs function_packs_public)

--- a/ThunkLibs/HostLibs/CMakeLists.txt
+++ b/ThunkLibs/HostLibs/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.14)
 project(host-thunks)
 
 set(CMAKE_CXX_STANDARD 17)
+set (DATA_DIRECTORY "${CMAKE_INSTALL_PREFIX}/lib/fex-emu" CACHE PATH "global data directory")
 
 function(generate NAME)
   foreach(WHAT IN LISTS ARGN)
@@ -26,9 +27,15 @@ function(generate NAME)
   set(GEN_${NAME} ${OUTPUTS} PARENT_SCOPE)
 endfunction()
 
+add_custom_target(ThunkHostsInstall)
 function(add_host_lib NAME)
-    add_library(${NAME}-host SHARED ../lib${NAME}/lib${NAME}_Host.cpp ${GEN_lib${NAME}})
-    target_include_directories(${NAME}-host PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/gen/lib${NAME}" "${CMAKE_CURRENT_SOURCE_DIR}/../include")
+  add_library(${NAME}-host SHARED ../lib${NAME}/lib${NAME}_Host.cpp ${GEN_lib${NAME}})
+  target_include_directories(${NAME}-host PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/gen/lib${NAME}" "${CMAKE_CURRENT_SOURCE_DIR}/../include")
+
+  add_custom_target(${NAME}-host-install
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${DATA_DIRECTORY}/HostThunks/
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_BINARY_DIR}/lib${NAME}-host.so ${DATA_DIRECTORY}/HostThunks/)
+  add_dependencies(ThunkHostsInstall ${NAME}-host-install)
 endfunction()
 
 generate(libasound function_unpacks tab_function_unpacks ldr ldr_ptrs)


### PR DESCRIPTION
This is necessary for building FEX packages that contain some initial thunk libs.
Gives an initial foothold for a default location for the host and guest thunk folders