### PR TITLE
Removes remaining warnings from AArch64 JIT.

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -398,7 +398,6 @@ DEF_OP(Xor) {
 
 DEF_OP(Lshl) {
   auto Op = IROp->C<IR::IROp_Lshl>();
-  uint8_t OpSize = IROp->Size;
   uint64_t Const;
   if (IsInlineConstant(Op->Header.Args[1], &Const)) {
     lsl(GRS(Node), GRS(Op->Header.Args[0].ID()), (unsigned int)Const);
@@ -409,7 +408,6 @@ DEF_OP(Lshl) {
 
 DEF_OP(Lshr) {
   auto Op = IROp->C<IR::IROp_Lshr>();
-  uint8_t OpSize = IROp->Size;
   uint64_t Const;
   if (IsInlineConstant(Op->Header.Args[1], &Const)) {
     lsr(GRS(Node), GRS(Op->Header.Args[0].ID()), (unsigned int)Const);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
@@ -298,7 +298,6 @@ DEF_OP(ValidateCode) {
 }
 
 DEF_OP(RemoveCodeEntry) {
-  auto Op = IROp->C<IR::IROp_RemoveCodeEntry>();
   // Arguments are passed as follows:
   // X0: Thread
   // X1: RIP

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -391,10 +391,9 @@ bool Arm64JITCore::HandleSIGBUS(int Signal, void *info, void *ucontext) {
 }
 
 Arm64JITCore::Arm64JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread, bool CompileThread)
-  : CTX {ctx}
-  , ThreadState {Thread}
-  , Arm64Emitter(0) {
-
+  : Arm64Emitter(0)
+  , CTX {ctx}
+  , ThreadState {Thread} {
   {
     DispatcherConfig config;
     config.ExitFunctionLink = reinterpret_cast<uintptr_t>(&ExitFunctionLink);
@@ -552,6 +551,7 @@ auto Reg = GetPhys(RAData, Node);
   } else {
     LogMan::Throw::A(false, "Unexpected Class: %d", Reg.Class);
   }
+  __builtin_unreachable();
 }
 
 template<>
@@ -564,6 +564,7 @@ aarch64::Register Arm64JITCore::GetReg<Arm64JITCore::RA_64>(uint32_t Node) {
   } else {
     LogMan::Throw::A(false, "Unexpected Class: %d", Reg.Class);
   }
+  __builtin_unreachable();
 }
 
 template<>
@@ -587,6 +588,7 @@ aarch64::VRegister Arm64JITCore::GetSrc(uint32_t Node) {
   } else {
     LogMan::Throw::A(false, "Unexpected Class: %d", Reg.Class);
   }
+  __builtin_unreachable();
 }
 
 aarch64::VRegister Arm64JITCore::GetDst(uint32_t Node) {
@@ -598,6 +600,7 @@ aarch64::VRegister Arm64JITCore::GetDst(uint32_t Node) {
   } else {
     LogMan::Throw::A(false, "Unexpected Class: %d", Reg.Class);
   }
+  __builtin_unreachable();
 }
 
 bool Arm64JITCore::IsInlineConstant(const IR::OrderedNodeWrapper& WNode, uint64_t* Value) {

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -95,7 +95,6 @@ DEF_OP(StoreContext) {
 
 DEF_OP(LoadRegister) {
   auto Op = IROp->C<IR::IROp_LoadRegister>();
-  uint8_t OpSize = IROp->Size;
 
   if (Op->Class == IR::GPRClass) {
     auto regId = (Op->Offset - offsetof(FEXCore::Core::CpuStateFrame, State.gregs[0])) / 8;
@@ -181,8 +180,6 @@ DEF_OP(LoadRegister) {
 
 DEF_OP(StoreRegister) {
   auto Op = IROp->C<IR::IROp_StoreRegister>();
-  uint8_t OpSize = IROp->Size;
-
 
   if (Op->Class == IR::GPRClass) {
     auto regId = Op->Offset / 8 - 1;
@@ -551,6 +548,7 @@ MemOperand Arm64JITCore::GenerateMemOperand(uint8_t AccessSize, aarch64::Registe
       }
     }
   }
+  __builtin_unreachable();
 }
 
 DEF_OP(LoadMem) {

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
@@ -52,7 +52,6 @@ DEF_OP(Break) {
 }
 
 DEF_OP(GetRoundingMode) {
-  auto Op = IROp->C<IR::IROp_GetRoundingMode>();
   auto Dst = GetReg<RA_64>(Node);
   mrs(Dst, FPCR);
   lsr(Dst, Dst,  22);


### PR DESCRIPTION
There are a couple of warnings remaining but need restructuring to solve.
I believe @phire is going to fix the one warning about a virtual destructor in a upcoming PR.
Fixes #679