### PR TITLE
Replaces FEX's usage of classic C array element count with std::size

### DIFF
--- a/External/FEXCore/Source/Interface/Core/X86Tables/BaseTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/BaseTables.cpp
@@ -279,13 +279,13 @@ void InitializeBaseTables(Context::OperatingMode Mode) {
     {0xEA, 1, X86InstInfo{"JMPF",   TYPE_INST, FLAGS_NONE,                                                        0, nullptr}},
   };
 
-  GenerateTable(BaseOps, BaseOpTable, sizeof(BaseOpTable) / sizeof(BaseOpTable[0]));
+  GenerateTable(BaseOps, BaseOpTable, std::size(BaseOpTable));
 
   if (Mode == Context::MODE_64BIT) {
-    GenerateTable(BaseOps, BaseOpTable_64, sizeof(BaseOpTable_64) / sizeof(BaseOpTable_64[0]));
+    GenerateTable(BaseOps, BaseOpTable_64, std::size(BaseOpTable_64));
   }
   else {
-    GenerateTable(BaseOps, BaseOpTable_32, sizeof(BaseOpTable_32) / sizeof(BaseOpTable_32[0]));
+    GenerateTable(BaseOps, BaseOpTable_32, std::size(BaseOpTable_32));
   }
 }
 }

--- a/External/FEXCore/Source/Interface/Core/X86Tables/DDDTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/DDDTables.cpp
@@ -38,6 +38,6 @@ void InitializeDDDTables() {
     {0xB7, 1, X86InstInfo{"PMULHRW",  TYPE_3DNOW_INST, FLAGS_MODRM, 0, nullptr}},
   };
 
-  GenerateTable(DDDNowOps, DDDNowOpTable, sizeof(DDDNowOpTable) / sizeof(DDDNowOpTable[0]));
+  GenerateTable(DDDNowOps, DDDNowOpTable, std::size(DDDNowOpTable));
 }
 }

--- a/External/FEXCore/Source/Interface/Core/X86Tables/EVEXTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/EVEXTables.cpp
@@ -20,6 +20,6 @@ void InitializeEVEXTables() {
     {0xE7, 1, X86InstInfo{"VMOVNTDQ",        TYPE_INST, FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_XMM_FLAGS, 0, nullptr}},
   };
 
-  GenerateTable(EVEXTableOps, EVEXTable, sizeof(EVEXTable) / sizeof(EVEXTable[0]));
+  GenerateTable(EVEXTableOps, EVEXTable, std::size(EVEXTable));
 }
 }

--- a/External/FEXCore/Source/Interface/Core/X86Tables/H0F38Tables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/H0F38Tables.cpp
@@ -92,6 +92,6 @@ void InitializeH0F38Tables() {
   };
 #undef OPD
 
-  GenerateTable(H0F38TableOps, H0F38Table, sizeof(H0F38Table) / sizeof(H0F38Table[0]));
+  GenerateTable(H0F38TableOps, H0F38Table, std::size(H0F38Table));
 }
 }

--- a/External/FEXCore/Source/Interface/Core/X86Tables/H0F3ATables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/H0F3ATables.cpp
@@ -48,10 +48,10 @@ void InitializeH0F3ATables(Context::OperatingMode Mode) {
 
 #undef OPD
 
-  GenerateTable(H0F3ATableOps, H0F3ATable, sizeof(H0F3ATable) / sizeof(H0F3ATable[0]));
+  GenerateTable(H0F3ATableOps, H0F3ATable, std::size(H0F3ATable));
 
   if (Mode == Context::MODE_64BIT) {
-    GenerateTable(H0F3ATableOps, H0F3ATable_64, sizeof(H0F3ATable_64) / sizeof(H0F3ATable_64[0]));
+    GenerateTable(H0F3ATableOps, H0F3ATable_64, std::size(H0F3ATable_64));
   }
 }
 }

--- a/External/FEXCore/Source/Interface/Core/X86Tables/PrimaryGroupTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/PrimaryGroupTables.cpp
@@ -152,12 +152,12 @@ void InitializePrimaryGroupTables(Context::OperatingMode Mode) {
 
 #undef OPD
 
-  GenerateTable(PrimaryInstGroupOps, PrimaryGroupOpTable, sizeof(PrimaryGroupOpTable) / sizeof(PrimaryGroupOpTable[0]));
+  GenerateTable(PrimaryInstGroupOps, PrimaryGroupOpTable, std::size(PrimaryGroupOpTable));
   if (Mode == Context::MODE_64BIT) {
-    GenerateTable(PrimaryInstGroupOps, PrimaryGroupOpTable_64, sizeof(PrimaryGroupOpTable_64) / sizeof(PrimaryGroupOpTable_64[0]));
+    GenerateTable(PrimaryInstGroupOps, PrimaryGroupOpTable_64, std::size(PrimaryGroupOpTable_64));
   }
   else {
-    GenerateTable(PrimaryInstGroupOps, PrimaryGroupOpTable_32, sizeof(PrimaryGroupOpTable_32) / sizeof(PrimaryGroupOpTable_32[0]));
+    GenerateTable(PrimaryInstGroupOps, PrimaryGroupOpTable_32, std::size(PrimaryGroupOpTable_32));
   }
 
 }

--- a/External/FEXCore/Source/Interface/Core/X86Tables/SecondaryGroupTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/SecondaryGroupTables.cpp
@@ -477,7 +477,7 @@ void InitializeSecondaryGroupTables() {
   };
 #undef OPD
 
-  GenerateTable(SecondInstGroupOps, SecondaryExtensionOpTable, sizeof(SecondaryExtensionOpTable) / sizeof(SecondaryExtensionOpTable[0]));
+  GenerateTable(SecondInstGroupOps, SecondaryExtensionOpTable, std::size(SecondaryExtensionOpTable));
 }
 
 }

--- a/External/FEXCore/Source/Interface/Core/X86Tables/SecondaryModRMTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/SecondaryModRMTables.cpp
@@ -46,6 +46,6 @@ void InitializeSecondaryModRMTables() {
     {((3 << 3) | 7), 1, X86InstInfo{"",         TYPE_INVALID, FLAGS_NONE, 0, nullptr}},
   };
 
-  GenerateTable(SecondModRMTableOps, SecondaryModRMExtensionOpTable, sizeof(SecondaryModRMExtensionOpTable) / sizeof(SecondaryModRMExtensionOpTable[0]));
+  GenerateTable(SecondModRMTableOps, SecondaryModRMExtensionOpTable, std::size(SecondaryModRMExtensionOpTable));
 }
 }

--- a/External/FEXCore/Source/Interface/Core/X86Tables/SecondaryTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/SecondaryTables.cpp
@@ -571,18 +571,18 @@ void InitializeSecondaryTables(Context::OperatingMode Mode) {
     {0xFF, 1, X86InstInfo{"",           TYPE_COPY_OTHER, FLAGS_NONE,                                                            0, nullptr}},
   };
 
-  GenerateTable(SecondBaseOps, TwoByteOpTable, sizeof(TwoByteOpTable) / sizeof(TwoByteOpTable[0]));
+  GenerateTable(SecondBaseOps, TwoByteOpTable, std::size(TwoByteOpTable));
 
 if (Mode == Context::MODE_64BIT) {
-    GenerateTable(SecondBaseOps, TwoByteOpTable_64, sizeof(TwoByteOpTable_64) / sizeof(TwoByteOpTable_64[0]));
+    GenerateTable(SecondBaseOps, TwoByteOpTable_64, std::size(TwoByteOpTable_64));
   }
   else {
-    GenerateTable(SecondBaseOps, TwoByteOpTable_32, sizeof(TwoByteOpTable_32) / sizeof(TwoByteOpTable_32[0]));
+    GenerateTable(SecondBaseOps, TwoByteOpTable_32, std::size(TwoByteOpTable_32));
   }
 
-  GenerateTableWithCopy(RepModOps, RepModOpTable, sizeof(RepModOpTable) / sizeof(RepModOpTable[0]), SecondBaseOps);
-  GenerateTableWithCopy(RepNEModOps, RepNEModOpTable,   sizeof(RepNEModOpTable) / sizeof(RepNEModOpTable[0]), SecondBaseOps);
-  GenerateTableWithCopy(OpSizeModOps, OpSizeModOpTable, sizeof(OpSizeModOpTable) / sizeof(OpSizeModOpTable[0]), SecondBaseOps);
+  GenerateTableWithCopy(RepModOps, RepModOpTable, std::size(RepModOpTable), SecondBaseOps);
+  GenerateTableWithCopy(RepNEModOps, RepNEModOpTable,   std::size(RepNEModOpTable), SecondBaseOps);
+  GenerateTableWithCopy(OpSizeModOps, OpSizeModOpTable, std::size(OpSizeModOpTable), SecondBaseOps);
 
 }
 

--- a/External/FEXCore/Source/Interface/Core/X86Tables/VEXTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/VEXTables.cpp
@@ -500,7 +500,7 @@ void InitializeVEXTables() {
   };
 #undef OPD
 
-  GenerateTable(VEXTableOps, VEXTable, sizeof(VEXTable) / sizeof(VEXTable[0]));
-  GenerateTable(VEXTableGroupOps, VEXGroupTable, sizeof(VEXGroupTable) / sizeof(VEXGroupTable[0]));
+  GenerateTable(VEXTableOps, VEXTable, std::size(VEXTable));
+  GenerateTable(VEXTableGroupOps, VEXGroupTable, std::size(VEXGroupTable));
 }
 }

--- a/External/FEXCore/Source/Interface/Core/X86Tables/X87Tables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/X87Tables.cpp
@@ -254,6 +254,6 @@ void InitializeX87Tables() {
 #undef OPD
 #undef OPDReg
 
-  GenerateX87Table(X87Ops, X87OpTable, sizeof(X87OpTable) / sizeof(X87OpTable[0]));
+  GenerateX87Table(X87Ops, X87OpTable, std::size(X87OpTable));
 }
 }

--- a/External/FEXCore/Source/Interface/Core/X86Tables/XOPTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/XOPTables.cpp
@@ -119,7 +119,7 @@ void InitializeXOPTables() {
   };
 #undef OPD
 
-  GenerateTable(XOPTableOps, XOPTable, sizeof(XOPTable) / sizeof(XOPTable[0]));
-  GenerateTable(XOPTableGroupOps, XOPGroupTable, sizeof(XOPGroupTable) / sizeof(XOPGroupTable[0]));
+  GenerateTable(XOPTableOps, XOPTable, std::size(XOPTable));
+  GenerateTable(XOPTableGroupOps, XOPGroupTable, std::size(XOPGroupTable));
 }
 }

--- a/Source/Tests/FEXBash.cpp
+++ b/Source/Tests/FEXBash.cpp
@@ -39,7 +39,7 @@ int main(int argc, char **argv, char **const envp) {
     BinShPath.c_str(),
     "-c",
   };
-  constexpr size_t FEXArgsCount = sizeof(FEXArgs) / sizeof(FEXArgs[0]);
+  constexpr size_t FEXArgsCount = std::size(FEXArgs);
 
   Argv.resize(Args.size() + FEXArgsCount + 1);
 

--- a/Source/Tests/UnitTestGenerator.cpp
+++ b/Source/Tests/UnitTestGenerator.cpp
@@ -193,7 +193,7 @@ void GeneratePrimaryTable() {
 
   bool AddressSizePrefix = false;
   auto DoNormalOps = [&](const char *NameSuffix, auto Inserter, std::optional<std::function<void()>> ModRMInserter, uint8_t REX = 0) {
-    for (size_t OpIndex = 0; OpIndex < (sizeof(BaseOps) / sizeof(BaseOps[0])); ++OpIndex) {
+    for (size_t OpIndex = 0; OpIndex < std::size(BaseOps); ++OpIndex) {
       auto &Op = BaseOps[OpIndex];
       if (Op.Type == TYPE_INST) {
         if (Op.Flags & InstFlags::FLAGS_SETS_RIP ||
@@ -764,7 +764,7 @@ void GeneratePrimaryGroupTable() {
   CurrentPrefix = "PrimaryGroup";
 
   auto DoNormalOps = [&](const char *NameSuffix, auto SkipCheck, auto Inserter, auto &Table, std::optional<std::function<void(uint8_t)>> ModRMInserter, uint8_t REX = 0) {
-    for (size_t OpIndex = 0; OpIndex < (sizeof(Table) / sizeof(Table[0])); ++OpIndex) {
+    for (size_t OpIndex = 0; OpIndex < std::size(Table); ++OpIndex) {
       auto &Op = Table[OpIndex];
       if (Op.Type == TYPE_INST) {
         if (Op.Flags & InstFlags::FLAGS_SETS_RIP ||
@@ -1147,7 +1147,7 @@ void GenerateSecondaryTable() {
   CurrentPrefix = "Secondary";
 
   auto DoNormalOps = [&](const char *NameSuffix, auto SkipCheck, auto Inserter, std::optional<std::function<void()>> ModRMInserter, uint8_t REX = 0) {
-    for (size_t OpIndex = 0; OpIndex < (sizeof(SecondBaseOps) / sizeof(SecondBaseOps[0])); ++OpIndex) {
+    for (size_t OpIndex = 0; OpIndex < std::size(SecondBaseOps); ++OpIndex) {
       auto &Op = SecondBaseOps[OpIndex];
       if (Op.Type == TYPE_INST) {
         if (Op.Flags & InstFlags::FLAGS_SETS_RIP ||
@@ -1542,7 +1542,7 @@ void GenerateSecondaryGroupTable() {
   CurrentPrefix = "SecondaryGroup";
 
   auto DoNormalOps = [&](const char *NameSuffix, auto SkipCheck, auto Inserter, std::optional<std::function<void(uint8_t)>> ModRMInserter, uint8_t REX = 0) {
-    for (size_t OpIndex = 0; OpIndex < (sizeof(SecondInstGroupOps) / sizeof(SecondInstGroupOps[0])); ++OpIndex) {
+    for (size_t OpIndex = 0; OpIndex < std::size(SecondInstGroupOps); ++OpIndex) {
       auto &Op = SecondInstGroupOps[OpIndex];
       if (Op.Type == TYPE_INST) {
         if (Op.Flags & InstFlags::FLAGS_SETS_RIP ||
@@ -1937,7 +1937,7 @@ void GenerateSSEInstructions() {
   bool AddressSizePrefix = false;
 
   auto DoNormalOps = [&](const char *NameSuffix, auto SkipCheck, auto Inserter, auto &Table, std::optional<std::function<void()>> ModRMInserter, uint8_t REX = 0) {
-    for (size_t OpIndex = 0; OpIndex < (sizeof(Table) / sizeof(Table[0])); ++OpIndex) {
+    for (size_t OpIndex = 0; OpIndex < std::size(Table); ++OpIndex) {
       auto &Op = Table[OpIndex];
       if (Op.Type == TYPE_INST) {
         if (Op.Flags & InstFlags::FLAGS_SETS_RIP ||
@@ -2419,7 +2419,7 @@ int main(int argc, char **argv, char **const envp) {
       FILE *fp = fopen(Filename.c_str(), "wbe");
 
       fprintf(fp, "HEX, Name, Num Times compiled\n");
-      for (size_t OpIndex = 0; OpIndex < (sizeof(Table) / sizeof(Table[0])); ++OpIndex) {
+      for (size_t OpIndex = 0; OpIndex < std::size(Table); ++OpIndex) {
         auto &Op = Table[OpIndex];
         if (Op.Type == TYPE_INST) {
           fprintf(fp, "0x%zx, %s, %d\n", OpIndex, Op.Name, Op.NumUnitTestsGenerated);

--- a/Source/Tools/Debugger/IMGui_I.cpp
+++ b/Source/Tools/Debugger/IMGui_I.cpp
@@ -770,7 +770,7 @@ namespace History {
       HistoryFile.close();
 
       json_t elem[32];
-      json_t const* json = json_create(&Data.at(0), elem, sizeof(elem) / sizeof(json_t));
+      json_t const* json = json_create(&Data.at(0), elem, std::size(elem));
 
       json_t const* HistoryList = json_getProperty(json, "History");
       for (json_t const* HistoryItem = json_getChild(HistoryList);


### PR DESCRIPTION
Just learned that this is a c++17 feature and it's a nice little
cleanup.

Only one remains in our codebase which can't easily be replaced