### PR TITLE
Context: Make use of std::optional with GetFilenameHash() 

### DIFF
--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -12,14 +12,15 @@
 #include <FEXCore/Utils/Event.h>
 #include <stdint.h>
 
-#include <memory>
-#include <map>
-#include <unordered_map>
-#include <set>
-#include <mutex>
-#include <istream>
-#include <ostream>
 #include <functional>
+#include <istream>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <ostream>
+#include <set>
+#include <unordered_map>
 
 namespace FEXCore {
 class ThunkHandler;
@@ -223,7 +224,7 @@ namespace FEXCore::Context {
     FEXCore::CodeLoader *LocalLoader{};
 
     // Entry Cache
-    bool GetFilenameHash(std::string const &Filename, std::string &Hash);
+    std::optional<std::string> GetFilenameHash(std::string const &Filename) const;
     void AddThreadRIPsToEntryList(FEXCore::Core::InternalThreadState *Thread);
     void SaveEntryList();
     std::set<uint64_t> EntryList;

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -249,10 +249,11 @@ namespace FEXCore::Context {
       Input.close();
 
       size_t const EntryCount = Size / sizeof(uint64_t);
-      uint64_t *Entries = reinterpret_cast<uint64_t*>(&Data.at(0));
 
       for (size_t i = 0; i < EntryCount; ++i) {
-        EntryList.insert(Entries[i]);
+        uint64_t Entry = 0;
+        std::memcpy(&Entry, &Data[i * sizeof(Entry)], sizeof(Entry));
+        EntryList.insert(Entry);
       }
     }
   }


### PR DESCRIPTION
Removes the need for an out-variable.

While we're in the same area, some minor other tidying up can be done.

Made just to get my feet wet with contributing :)