### PR TITLE
OpcodeDispatcher: Add missing break for UD2 in INTOp()

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -5916,6 +5916,7 @@ void OpDispatchBuilder::INTOp(OpcodeArgs) {
   }
   case 0x0B:
     Reason = 5;
+  break;
   case 0xCC:
     Reason = 6;
     setRIP = true;


### PR DESCRIPTION
Fixes a case where the reason gets overwritten.