### PR TITLE
CMakeLists: Flag unannotated implicit fallthrough as an error

### DIFF
--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -278,7 +278,11 @@ function(AddObject Name Type)
 
   target_compile_options(${Name}
     PRIVATE
-    -Wno-trigraphs -Wall)
+    -Wall
+    -Werror=implicit-fallthrough
+
+    -Wno-trigraphs
+  )
 
   if (GCC_COLOR)
     target_compile_options(${Name}

--- a/External/FEXCore/Source/Common/SoftFloat-3e/extF80_roundToInt.c
+++ b/External/FEXCore/Source/Common/SoftFloat-3e/extF80_roundToInt.c
@@ -96,6 +96,7 @@ extFloat80_t
         switch ( roundingMode ) {
          case softfloat_round_near_even:
             if ( !(sigA & UINT64_C( 0x7FFFFFFFFFFFFFFF )) ) break;
+            __attribute__((fallthrough));
          case softfloat_round_near_maxMag:
             if ( exp == 0x3FFE ) goto mag1;
             break;

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -56,12 +56,12 @@ namespace {
     v = 0;
 
     switch (len & 7) {
-    case 7: v ^= (uint64_t)pos2[6] << 48;
-    case 6: v ^= (uint64_t)pos2[5] << 40;
-    case 5: v ^= (uint64_t)pos2[4] << 32;
-    case 4: v ^= (uint64_t)pos2[3] << 24;
-    case 3: v ^= (uint64_t)pos2[2] << 16;
-    case 2: v ^= (uint64_t)pos2[1] << 8;
+    case 7: v ^= (uint64_t)pos2[6] << 48; [[fallthrough]]; 
+    case 6: v ^= (uint64_t)pos2[5] << 40; [[fallthrough]];
+    case 5: v ^= (uint64_t)pos2[4] << 32; [[fallthrough]];
+    case 4: v ^= (uint64_t)pos2[3] << 24; [[fallthrough]];
+    case 3: v ^= (uint64_t)pos2[2] << 16; [[fallthrough]];
+    case 2: v ^= (uint64_t)pos2[1] << 8;  [[fallthrough]];
     case 1: v ^= (uint64_t)pos2[0];
       h ^= mix(v);
       h *= m;

--- a/External/FEXCore/Source/Interface/Core/Frontend.cpp
+++ b/External/FEXCore/Source/Interface/Core/Frontend.cpp
@@ -129,26 +129,17 @@ uint8_t Decoder::PeekByte(uint8_t Offset) {
 }
 
 uint64_t Decoder::ReadData(uint8_t Size) {
-  uint64_t Res{};
-#define READ_DATA(x, y) \
-  case x: { \
-    y const *Data = reinterpret_cast<y const*>(&InstStream[InstructionSize]); \
-    Res = *Data; \
-  } \
-  break
-
-  switch (Size) {
-  case 0: return 0;
-  READ_DATA(1, uint8_t);
-  READ_DATA(2, uint16_t);
-  case 3: memcpy(&Res, &InstStream[InstructionSize], Size);
-  READ_DATA(4, uint32_t);
-  READ_DATA(8, uint64_t);
-  default:
-  LogMan::Msg::A("Unknown data size to read");
-  return 0;
+  if (Size == 0) {
+    return 0;
   }
-#undef READ_DATA
+
+  if (Size > sizeof(uint64_t)) {
+    LogMan::Msg::A("Unknown data size to read");
+    return 0;
+  }
+
+  uint64_t Res = 0;
+  std::memcpy(&Res, &InstStream[InstructionSize], Size);
 
 #ifndef NDEBUG
   for(size_t i = 0; i < Size; ++i) {
@@ -157,6 +148,7 @@ uint64_t Decoder::ReadData(uint8_t Size) {
 #else
   SkipBytes(Size);
 #endif
+
   return Res;
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -903,8 +903,8 @@ Condition MapSelectCC(IR::CondClassType Cond) {
   case FEXCore::IR::COND_FGT: return Condition::hi;
   case FEXCore::IR::COND_FU:  return Condition::vs;
   case FEXCore::IR::COND_FNU: return Condition::vc;
-  case FEXCore::IR::COND_VS:;
-  case FEXCore::IR::COND_VC:;
+  case FEXCore::IR::COND_VS:
+  case FEXCore::IR::COND_VC:
   case FEXCore::IR::COND_MI:
   case FEXCore::IR::COND_PL:
   default:

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
@@ -131,8 +131,8 @@ Condition MapBranchCC(IR::CondClassType Cond) {
   case FEXCore::IR::COND_FGT: return Condition::hi;
   case FEXCore::IR::COND_FU:  return Condition::vs;
   case FEXCore::IR::COND_FNU: return Condition::vc;
-  case FEXCore::IR::COND_VS:;
-  case FEXCore::IR::COND_VC:;
+  case FEXCore::IR::COND_VS:
+  case FEXCore::IR::COND_VC:
   case FEXCore::IR::COND_MI:
   case FEXCore::IR::COND_PL:
   default:

--- a/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -739,8 +739,11 @@ bool ConstProp::Run(IREmitter *IREmit) {
           }
         }
       }
+      break;
     }
-    default: break;
+
+    default:
+      break;
     }
   }
 


### PR DESCRIPTION
Prevents a class of sneaky logic bugs from slipping through into the codebase.

This also resolves a case of such a bug within the Decorder's ReadData() where all 3 byte reads would be performed as if they were a 4 byte read.