### PR TITLE
Config: Make lookup map assignment match behavior of comment

### DIFF
--- a/External/FEXCore/Source/Interface/Config/Config.cpp
+++ b/External/FEXCore/Source/Interface/Config/Config.cpp
@@ -89,7 +89,7 @@ namespace FEXCore::Config {
         auto Value = std::string(EnvVar.begin() + ItEq + 1, EnvVar.end());
 
         // Add the key to the map, overwriting whatever previous value was there
-        LookupMap.emplace(Key, Value);
+        LookupMap.emplace(std::move(Key), std::move(Value));
       }
     };
 

--- a/External/FEXCore/Source/Interface/Config/Config.cpp
+++ b/External/FEXCore/Source/Interface/Config/Config.cpp
@@ -77,9 +77,9 @@ namespace FEXCore::Config {
 
     // If an environment variable exists in both current meta and in the incoming layer then the meta layer value is overwritten
     std::unordered_map<std::string, std::string> LookupMap;
-    auto AddToMap = [&LookupMap](FEXCore::Config::LayerValue const &Value) {
-      for (auto &EnvVar : Value) {
-        auto ItEq = EnvVar.find_first_of("=");
+    const auto AddToMap = [&LookupMap](FEXCore::Config::LayerValue const &Value) {
+      for (const auto &EnvVar : Value) {
+        const auto ItEq = EnvVar.find_first_of('=');
         if (ItEq == std::string::npos) {
           // Broken environment variable
           // Skip

--- a/External/FEXCore/Source/Interface/Config/Config.cpp
+++ b/External/FEXCore/Source/Interface/Config/Config.cpp
@@ -89,7 +89,7 @@ namespace FEXCore::Config {
         auto Value = std::string(EnvVar.begin() + ItEq + 1, EnvVar.end());
 
         // Add the key to the map, overwriting whatever previous value was there
-        LookupMap.emplace(std::move(Key), std::move(Value));
+        LookupMap.insert_or_assign(std::move(Key), std::move(Value));
       }
     };
 


### PR DESCRIPTION
`emplace()` only performs an insertion or assignment if the key doesn't already exist within the map, which is at odds with what the comment above the line indicates should happen.

We can use `insert_or_assign()` to make the behavior work like how the comment indicates it should.

If the existing behavior is more desirable, I can just amend the comment and drop the functional changes.