### PR TITLE
Adds support for named rootfs configurations

### DIFF
--- a/External/FEXCore/Source/Interface/Config/Config.cpp
+++ b/External/FEXCore/Source/Interface/Config/Config.cpp
@@ -82,6 +82,16 @@ namespace FEXCore::Config {
     return ConfigFile;
   }
 
+  std::string GetDataDirectory() {
+    std::string DataDir{};
+
+    char const *HomeDir = GetHomeDirectory();
+    char const *DataXDG = getenv("XDG_DATA_HOME");
+    DataDir = DataXDG ?: HomeDir;
+    DataDir += "/.fex-emu/";
+    return DataDir;
+  }
+
   void SetConfig(FEXCore::Context::Context *CTX, ConfigOption Option, uint64_t Config) {
   }
 

--- a/External/FEXCore/Source/Interface/Config/Config.json
+++ b/External/FEXCore/Source/Interface/Config/Config.json
@@ -46,7 +46,14 @@
         "Default": "",
         "ShortArg": "R",
         "Desc": [
-          "Which Root filesystem prefix to use"
+          "Which Root filesystem prefix to use",
+          "This can be a filesystem path",
+          "\teg: ~/RootFS/Debian_x86_64",
+          "Or this can be a name of a rootfs",
+          "If the named rootfs exists in the FEX data folder then it will use that one",
+          "\teg: $HOME/.fex-emu/RootFS/<RootFS name>/",
+          "Or if you have XDG_DATA_HOME the config will search in that directory",
+          "\teg: $XDG_DATA_HOME/.fex-emu/RootFS/<RootFS name>/"
         ]
       },
       "ThunkHostLibs": {

--- a/External/FEXCore/include/FEXCore/Config/Config.h
+++ b/External/FEXCore/include/FEXCore/Config/Config.h
@@ -54,6 +54,7 @@ namespace Type {
 #undef P
 }
 
+  std::string GetDataDirectory();
   std::string GetConfigDirectory(bool Global);
   std::string GetConfigFileLocation();
   std::string GetApplicationConfig(std::string &Filename, bool Global);

--- a/External/FEXCore/include/FEXCore/Config/Config.h
+++ b/External/FEXCore/include/FEXCore/Config/Config.h
@@ -54,6 +54,10 @@ namespace Type {
 #undef P
 }
 
+  std::string GetConfigDirectory(bool Global);
+  std::string GetConfigFileLocation();
+  std::string GetApplicationConfig(std::string &Filename, bool Global);
+
   using LayerValue = std::list<std::string>;
   using LayerOptions = std::unordered_map<ConfigOption, LayerValue>;
 

--- a/Source/Common/Config.h
+++ b/Source/Common/Config.h
@@ -56,9 +56,5 @@ namespace FEX::Config {
     char *const *envp;
   };
 
-  std::string GetConfigFolder(bool Global);
-  std::string GetConfigFileLocation();
-  std::string GetApplicationConfig(std::string &Filename, bool Global);
-
   void SaveLayerToJSON(std::string Filename, FEXCore::Config::Layer *const Layer);
 }

--- a/Source/Tools/FEXConfig/Main.cpp
+++ b/Source/Tools/FEXConfig/Main.cpp
@@ -449,7 +449,7 @@ namespace {
       if (ImGui::BeginPopupModal(SavedPopupAppName)) {
         if (ImGui::InputText("App name", AppName, 256, ImGuiInputTextFlags_EnterReturnsTrue)) {
           std::string AppNameString = AppName;
-          std::string Filename = FEX::Config::GetApplicationConfig(AppNameString, false);
+          std::string Filename = FEXCore::Config::GetApplicationConfig(AppNameString, false);
           SaveFile(Filename);
           ImGui::CloseCurrentPopup();
         }
@@ -486,7 +486,7 @@ namespace {
     }
     if (Selected.OpenDefault ||
         (ImGui::IsKeyPressed(SDL_SCANCODE_O) && io.KeyCtrl && io.KeyShift)) {
-      OpenFile(FEX::Config::GetConfigFileLocation());
+      OpenFile(FEXCore::Config::GetConfigFileLocation());
     }
     if (Selected.LoadDefault ||
         (ImGui::IsKeyPressed(SDL_SCANCODE_D) && io.KeyCtrl && io.KeyShift)) {
@@ -504,7 +504,7 @@ namespace {
 
     if (Selected.SaveDefault ||
         (ImGui::IsKeyPressed(SDL_SCANCODE_P) && io.KeyCtrl && io.KeyShift)) {
-      SaveFile(FEX::Config::GetConfigFileLocation());
+      SaveFile(FEXCore::Config::GetConfigFileLocation());
     }
     if (Selected.Close ||
         (ImGui::IsKeyPressed(SDL_SCANCODE_W) && io.KeyCtrl && !io.KeyShift)) {
@@ -536,7 +536,7 @@ namespace {
 }
 
 int main() {
-  std::string ImGUIConfig = FEX::Config::GetConfigFolder(false) + "FEXConfig_imgui.ini";
+  std::string ImGUIConfig = FEXCore::Config::GetConfigDirectory(false) + "FEXConfig_imgui.ini";
 
   // Setup SDL
   if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_TIMER | SDL_INIT_GAMECONTROLLER) != 0)


### PR DESCRIPTION
If the relative or absolute folder doesn't exist then FEX will search in the data folder for a rootFS named the same thing
If the path exists then it is used.

For example if my data folder contains `$HOME/.fex-emu/RootFS/Ubuntu_main/` and I set the RootFS option to `Ubuntu_main`
Then this rootfs will be used. Allows you to easily select a rootfs in that folder without having the full file path.

Relies on #916 being merged first
Fixes #684