### PR TITLE
Disables seccomp

### DIFF
--- a/Source/Tests/LinuxSyscalls/Syscalls/Info.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Info.cpp
@@ -105,8 +105,8 @@ namespace FEX::HLE {
     });
 
     REGISTER_SYSCALL_IMPL(seccomp, [](FEXCore::Core::CpuStateFrame *Frame, unsigned int operation, unsigned int flags, void *args) -> uint64_t {
-      uint64_t Result = ::syscall(SYS_seccomp, operation, flags, args);
-      SYSCALL_ERRNO();
+      // FEX doesn't support seccomp
+      return -EINVAL;
     });
   }
 }

--- a/Source/Tests/LinuxSyscalls/Syscalls/Thread.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Thread.cpp
@@ -288,7 +288,17 @@ namespace FEX::HLE {
     });
 
     REGISTER_SYSCALL_IMPL(prctl, [](FEXCore::Core::CpuStateFrame *Frame, int option, unsigned long arg2, unsigned long arg3, unsigned long arg4, unsigned long arg5) -> uint64_t {
-      uint64_t Result = ::prctl(option, arg2, arg3, arg4, arg5);
+      uint64_t Result{};
+      switch (option) {
+      case PR_SET_SECCOMP:
+      case PR_GET_SECCOMP:
+        // FEX doesn't support seccomp
+        return -EINVAL;
+        break;
+      default:
+        Result = ::prctl(option, arg2, arg3, arg4, arg5);
+      break;
+      }
       SYSCALL_ERRNO();
     });
 


### PR DESCRIPTION
FEX doesn't support seccomp in userspace and allowing these through causes chromium secure sandbox to break.
Disabling these with EINVAL allows FEX to behave as if seccomp isn't enabled in the kernel config

Necessary to get the Civ6 launcher further