### PR TITLE
Switches FEXCore over to pthreads implementation 

### DIFF
--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -124,6 +124,7 @@ set (SRCS
   Utils/ELFLoader.cpp
   Utils/ELFSymbolDatabase.cpp
   Utils/LogManager.cpp
+  Utils/Threads.cpp
   )
 
 if(_M_ARM_64)

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -210,13 +210,15 @@ namespace FEXCore::Context {
     FEXCore::JITSymbols Symbols;
 #endif
 
+    // Public for threading
+    void ExecutionThread(FEXCore::Core::InternalThreadState *Thread);
+
   protected:
     void ClearCodeCache(FEXCore::Core::InternalThreadState *Thread, bool AlsoClearIRCache);
 
   private:
     void WaitForIdleWithTimeout();
 
-    void ExecutionThread(FEXCore::Core::InternalThreadState *Thread);
     void NotifyPause();
 
     void AddBlockMapping(FEXCore::Core::InternalThreadState *Thread, uint64_t Address, void *Ptr, uint64_t Start, uint64_t Length);

--- a/External/FEXCore/Source/Interface/Core/CompileService.h
+++ b/External/FEXCore/Source/Interface/Core/CompileService.h
@@ -2,6 +2,7 @@
 
 #include <FEXCore/Core/CPUBackend.h>
 #include <FEXCore/Utils/Event.h>
+#include <FEXCore/Utils/Threads.h>
 
 #include <memory>
 #include <thread>
@@ -45,12 +46,14 @@ class CompileService final {
     WorkItem *CompileCode(uint64_t RIP);
     void ClearCache(FEXCore::Core::InternalThreadState *Thread);
 
+    // Public for threading
+    void ExecutionThread();
+
   private:
     FEXCore::Context::Context *CTX;
     FEXCore::Core::InternalThreadState *ParentThread;
 
-    void ExecutionThread();
-    std::thread WorkerThread;
+    std::unique_ptr<FEXCore::Threads::Thread> WorkerThread;
     std::unique_ptr<FEXCore::Core::InternalThreadState> CompileThreadData;
 
     std::mutex QueueMutex{};

--- a/External/FEXCore/Source/Interface/Core/GdbServer.cpp
+++ b/External/FEXCore/Source/Interface/Core/GdbServer.cpp
@@ -959,9 +959,14 @@ void GdbServer::GdbServerLoop() {
     }
   }
 }
+static void* ThreadHandler(void *Arg) {
+  FEXCore::GdbServer *This = reinterpret_cast<FEXCore::GdbServer*>(Arg);
+  This->GdbServerLoop();
+  return nullptr;
+}
 
 void GdbServer::StartThread() {
-    gdbServerThread = std::thread(&GdbServer::GdbServerLoop, this);
+    gdbServerThread = FEXCore::Threads::Thread::Create(ThreadHandler, this);
 }
 
 std::unique_ptr<std::iostream> GdbServer::OpenSocket() {

--- a/External/FEXCore/Source/Interface/Core/GdbServer.h
+++ b/External/FEXCore/Source/Interface/Core/GdbServer.h
@@ -3,13 +3,17 @@ $info$
 tags: glue|gdbserver
 $end_info$
 */
+#pragma once
 
 #include <mutex>
 #include <thread>
 
 #include "Interface/Context/Context.h"
-
 #include "Common/NetStream.h"
+
+#include <FEXCore/Utils/Threads.h>
+
+#include <mutex>
 
 namespace FEXCore {
 
@@ -17,12 +21,14 @@ class GdbServer {
 public:
     GdbServer(FEXCore::Context::Context *ctx);
 
+    // Public for threading
+    void GdbServerLoop();
+
 private:
     void Break(int signal);
 
     std::unique_ptr<std::iostream> OpenSocket();
     void StartThread();
-    void GdbServerLoop();
     std::string ReadPacket(std::iostream &stream);
     void SendPacket(std::ostream &stream, std::string packet);
 
@@ -55,7 +61,7 @@ private:
     HandledPacketType readReg(std::string& packet);
 
     FEXCore::Context::Context *CTX;
-    std::thread gdbServerThread;
+    std::unique_ptr<FEXCore::Threads::Thread> gdbServerThread;
     std::unique_ptr<std::iostream> CommsStream;
     std::mutex sendMutex;
     bool SettingNoAckMode{false};

--- a/External/FEXCore/Source/Utils/Threads.cpp
+++ b/External/FEXCore/Source/Utils/Threads.cpp
@@ -1,0 +1,64 @@
+#include <FEXCore/Utils/Threads.h>
+
+#include <cstring>
+#include <pthread.h>
+
+namespace FEXCore::Threads {
+  class PThread final : public Thread {
+    public:
+    PThread(FEXCore::Threads::ThreadFunc Func, void *Arg) {
+      pthread_attr_t Attr{};
+      pthread_attr_init(&Attr);
+      pthread_create(&Thread, &Attr, Func, Arg);
+    }
+
+    bool joinable() override {
+      pthread_attr_t Attr{};
+      if (pthread_getattr_np(Thread, &Attr) == 0) {
+        int AttachState{};
+        if (pthread_attr_getdetachstate(&Attr, &AttachState) == 0) {
+          if (AttachState == PTHREAD_CREATE_JOINABLE) {
+            return true;
+          }
+        }
+      }
+      return false;
+    }
+
+    bool join(void **ret) override {
+      return pthread_join(Thread, ret) == 0;
+    }
+
+    bool detach() override {
+      return pthread_detach(Thread) == 0;
+    }
+
+    bool IsSelf() override {
+      auto self = pthread_self();
+      return self == Thread;
+    }
+
+    private:
+    pthread_t Thread;
+  };
+
+  std::unique_ptr<FEXCore::Threads::Thread> CreateThread_PThread(
+    ThreadFunc Func,
+    void* Arg) {
+    return std::make_unique<PThread>(Func, Arg);
+  }
+
+  static FEXCore::Threads::Pointers Ptrs = {
+    .CreateThread = CreateThread_PThread,
+  };
+
+  std::unique_ptr<FEXCore::Threads::Thread> FEXCore::Threads::Thread::Create(
+    ThreadFunc Func,
+    void* Arg) {
+    return Ptrs.CreateThread(Func, Arg);
+  }
+
+  void FEXCore::Threads::Thread::SetInternalPointers(Pointers const &_Ptrs) {
+    memcpy(&Ptrs, &_Ptrs, sizeof(FEXCore::Threads::Pointers));
+  }
+}

--- a/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
+++ b/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
@@ -5,9 +5,9 @@
 #include <FEXCore/IR/IntrusiveIRList.h>
 #include <FEXCore/IR/RegisterAllocationData.h>
 #include <FEXCore/Utils/Event.h>
+#include <FEXCore/Utils/Threads.h>
 
 #include <unordered_map>
-#include <thread>
 
 namespace FEXCore {
   class LookupCache;
@@ -80,7 +80,7 @@ namespace FEXCore::Core {
     FEXCore::Context::Context *CTX;
     std::atomic<SignalEvent> SignalReason {SignalEvent::SIGNALEVENT_NONE};
 
-    std::thread ExecutionThread;
+    std::unique_ptr<FEXCore::Threads::Thread> ExecutionThread;
     Event StartRunning;
     Event ThreadWaiting;
 

--- a/External/FEXCore/include/FEXCore/Utils/Threads.h
+++ b/External/FEXCore/include/FEXCore/Utils/Threads.h
@@ -1,0 +1,28 @@
+#pragma once
+#include <functional>
+#include <memory>
+
+namespace FEXCore::Threads {
+  using ThreadFunc = void*(*)(void* user_ptr);
+
+  class Thread;
+  using CreateThreadFunc = std::function<std::unique_ptr<Thread>(ThreadFunc Func, void* Arg)>;
+  struct Pointers {
+    CreateThreadFunc CreateThread;
+  };
+
+  // API
+  class Thread {
+    public:
+    virtual ~Thread() = default;
+    virtual bool joinable() = 0;
+    virtual bool join(void **ret) = 0;
+    virtual bool detach() = 0;
+    virtual bool IsSelf() = 0;
+    static std::unique_ptr<Thread> Create(
+      ThreadFunc Func,
+      void* Arg);
+
+    static void SetInternalPointers(Pointers const &_Ptrs);
+  };
+}

--- a/Source/Tests/LinuxSyscalls/x32/Thread.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Thread.cpp
@@ -128,7 +128,7 @@ namespace FEX::HLE::x32 {
 
         if (flags & CLONE_VFORK) {
           // If VFORK is set then the calling process is suspended until the thread exits with execve or exit
-          NewThread->ExecutionThread.join();
+          NewThread->ExecutionThread->join(nullptr);
 
           // Normally a thread cleans itself up on exit. But because we need to join, we are now responsible 
           FEXCore::Context::DestroyThread(Thread->CTX, NewThread);

--- a/Source/Tests/LinuxSyscalls/x64/Thread.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Thread.cpp
@@ -128,7 +128,7 @@ namespace FEX::HLE::x64 {
 
         if (flags & CLONE_VFORK) {
           // If VFORK is set then the calling process is suspended until the thread exits with execve or exit
-          NewThread->ExecutionThread.join();
+          NewThread->ExecutionThread->join(nullptr);
 
           // Normally a thread cleans itself up on exit. But because we need to join, we are now responsible
           FEXCore::Context::DestroyThread(Thread->CTX, NewThread);


### PR DESCRIPTION
This defaults to a pthread implementation but it can be switched over to a custom thread
handler if the frontend desires.