### PR TITLE
Default hidden visibility and strip symbols

### DIFF
--- a/External/FEXCore/Scripts/json_ir_generator.py
+++ b/External/FEXCore/Scripts/json_ir_generator.py
@@ -108,10 +108,10 @@ def print_ir_sizes(ops, defines):
 
     output_file.write("[[maybe_unused]] static size_t GetSize(IROps Op) { return IRSizes[Op]; }\n\n")
 
-    output_file.write("std::string_view const& GetName(IROps Op);\n")
-    output_file.write("uint8_t GetArgs(IROps Op);\n")
-    output_file.write("FEXCore::IR::RegisterClassType GetRegClass(IROps Op);\n\n")
-    output_file.write("bool HasSideEffects(IROps Op);\n")
+    output_file.write("__attribute__((visibility(\"default\"))) std::string_view const& GetName(IROps Op);\n")
+    output_file.write("__attribute__((visibility(\"default\"))) uint8_t GetArgs(IROps Op);\n")
+    output_file.write("__attribute__((visibility(\"default\"))) FEXCore::IR::RegisterClassType GetRegClass(IROps Op);\n\n")
+    output_file.write("__attribute__((visibility(\"default\"))) bool HasSideEffects(IROps Op);\n")
 
     output_file.write("#undef IROP_SIZES\n")
     output_file.write("#endif\n\n")

--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -286,6 +286,7 @@ function(AddObject Name Type)
     -Werror=implicit-fallthrough
 
     -Wno-trigraphs
+    -ffunction-sections
   )
 
   if (GCC_COLOR)
@@ -311,6 +312,15 @@ function(AddLibrary Name Type)
   target_include_directories(${Name} PUBLIC "${CMAKE_CURRENT_BINARY_DIR}")
   target_include_directories(${Name} PUBLIC "${PROJECT_SOURCE_DIR}/include/")
   target_include_directories(${Name} PUBLIC "${CMAKE_BINARY_DIR}/include/")
+
+  if (CMAKE_BUILD_TYPE MATCHES "RELEASE")
+    target_link_options(${Name}
+      PRIVATE
+      "LINKER:--gc-sections"
+      "LINKER:--strip-all"
+      "LINKER:--as-needed"
+    )
+  endif()
 endfunction()
 
 AddObject(${PROJECT_NAME}_object OBJECT)

--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -266,6 +266,9 @@ function(AddObject Name Type)
 
   target_link_libraries(${Name} pthread rt vixl ${LINUX_LIBS} dl)
   set_target_properties(${Name} PROPERTIES OUTPUT_NAME FEXCore)
+  set_target_properties(${Name} PROPERTIES C_VISIBILITY_PRESET hidden)
+  set_target_properties(${Name} PROPERTIES CXX_VISIBILITY_PRESET hidden)
+  set_target_properties(${Name} PROPERTIES VISIBILITY_INLINES_HIDDEN TRUE)
 
   target_include_directories(${Name} PUBLIC "${CMAKE_CURRENT_BINARY_DIR}")
 
@@ -301,6 +304,9 @@ function(AddLibrary Name Type)
   add_library(${Name} ${Type} $<TARGET_OBJECTS:${PROJECT_NAME}_object>)
   target_link_libraries(${Name} pthread rt vixl ${LINUX_LIBS} dl)
   set_target_properties(${Name} PROPERTIES OUTPUT_NAME FEXCore)
+  set_target_properties(${Name} PROPERTIES C_VISIBILITY_PRESET hidden)
+  set_target_properties(${Name} PROPERTIES CXX_VISIBILITY_PRESET hidden)
+  set_target_properties(${Name} PROPERTIES VISIBILITY_INLINES_HIDDEN TRUE)
 
   target_include_directories(${Name} PUBLIC "${CMAKE_CURRENT_BINARY_DIR}")
   target_include_directories(${Name} PUBLIC "${PROJECT_SOURCE_DIR}/include/")

--- a/External/FEXCore/include/FEXCore/Config/Config.h
+++ b/External/FEXCore/include/FEXCore/Config/Config.h
@@ -54,15 +54,15 @@ namespace Type {
 #undef P
 }
 
-  std::string GetDataDirectory();
-  std::string GetConfigDirectory(bool Global);
-  std::string GetConfigFileLocation();
-  std::string GetApplicationConfig(std::string &Filename, bool Global);
+  __attribute__((visibility("default"))) std::string GetDataDirectory();
+  __attribute__((visibility("default"))) std::string GetConfigDirectory(bool Global);
+  __attribute__((visibility("default"))) std::string GetConfigFileLocation();
+  __attribute__((visibility("default"))) std::string GetApplicationConfig(std::string &Filename, bool Global);
 
   using LayerValue = std::list<std::string>;
   using LayerOptions = std::unordered_map<ConfigOption, LayerValue>;
 
-  class Layer {
+  class __attribute__((visibility("default"))) Layer {
   public:
     explicit Layer(const LayerType _Type);
     virtual ~Layer();
@@ -114,24 +114,24 @@ namespace Type {
     LayerOptions OptionMap;
   };
 
-  void Initialize();
-  void Shutdown();
+  __attribute__((visibility("default"))) void Initialize();
+  __attribute__((visibility("default"))) void Shutdown();
 
-  void Load();
-  void ReloadMetaLayer();
+  __attribute__((visibility("default"))) void Load();
+  __attribute__((visibility("default"))) void ReloadMetaLayer();
 
-  void AddLayer(std::unique_ptr<FEXCore::Config::Layer> _Layer);
+  __attribute__((visibility("default"))) void AddLayer(std::unique_ptr<FEXCore::Config::Layer> _Layer);
 
-  bool Exists(ConfigOption Option);
-  std::optional<LayerValue*> All(ConfigOption Option);
-  std::optional<std::string*> Get(ConfigOption Option);
+  __attribute__((visibility("default"))) bool Exists(ConfigOption Option);
+  __attribute__((visibility("default"))) std::optional<LayerValue*> All(ConfigOption Option);
+  __attribute__((visibility("default"))) std::optional<std::string*> Get(ConfigOption Option);
 
-  void Set(ConfigOption Option, std::string Data);
-  void Erase(ConfigOption Option);
-  void EraseSet(ConfigOption Option, std::string Data);
+  __attribute__((visibility("default"))) void Set(ConfigOption Option, std::string Data);
+  __attribute__((visibility("default"))) void Erase(ConfigOption Option);
+  __attribute__((visibility("default"))) void EraseSet(ConfigOption Option, std::string Data);
 
   template<typename T>
-  class Value {
+  class __attribute__((visibility("default"))) Value {
   public:
     template <typename TT = T,
       typename std::enable_if<!std::is_same<TT, std::string>::value, int>::type = 0>

--- a/External/FEXCore/include/FEXCore/Core/Context.h
+++ b/External/FEXCore/include/FEXCore/Core/Context.h
@@ -49,7 +49,7 @@ namespace FEXCore::Context {
   /**
    * @brief This initializes internal FEXCore state that is shared between contexts and requires overhead to setup
    */
-  void InitializeStaticTables(OperatingMode Mode = MODE_64BIT);
+  __attribute__((visibility("default"))) void InitializeStaticTables(OperatingMode Mode = MODE_64BIT);
 
   /**
    * @brief [[threadsafe]] Create a new FEXCore context object
@@ -58,7 +58,7 @@ namespace FEXCore::Context {
    *
    * @return a new context object
    */
-  FEXCore::Context::Context *CreateNewContext();
+  __attribute__((visibility("default"))) FEXCore::Context::Context *CreateNewContext();
 
   /**
    * @brief Post creation context initialization
@@ -68,14 +68,14 @@ namespace FEXCore::Context {
    *
    * @return true if we managed to initialize correctly
    */
-  bool InitializeContext(FEXCore::Context::Context *CTX);
+  __attribute__((visibility("default"))) bool InitializeContext(FEXCore::Context::Context *CTX);
 
   /**
    * @brief Destroy the context object
    *
    * @param CTX
    */
-  void DestroyContext(FEXCore::Context::Context *CTX);
+  __attribute__((visibility("default"))) void DestroyContext(FEXCore::Context::Context *CTX);
 
   /**
    * @brief Allows setting up in memory code and other things prior to launchign code execution
@@ -85,17 +85,17 @@ namespace FEXCore::Context {
    *
    * @return true if we loaded code
    */
-  bool InitCore(FEXCore::Context::Context *CTX, FEXCore::CodeLoader *Loader);
+  __attribute__((visibility("default"))) bool InitCore(FEXCore::Context::Context *CTX, FEXCore::CodeLoader *Loader);
 
-  void SetExitHandler(FEXCore::Context::Context *CTX, std::function<void(uint64_t ThreadId, FEXCore::Context::ExitReason)> handler);
-  std::function<void(uint64_t ThreadId, FEXCore::Context::ExitReason)> GetExitHandler(FEXCore::Context::Context *CTX);
+  __attribute__((visibility("default"))) void SetExitHandler(FEXCore::Context::Context *CTX, std::function<void(uint64_t ThreadId, FEXCore::Context::ExitReason)> handler);
+  __attribute__((visibility("default"))) std::function<void(uint64_t ThreadId, FEXCore::Context::ExitReason)> GetExitHandler(FEXCore::Context::Context *CTX);
 
   /**
    * @brief Pauses execution on the CPU core
    *
    * Blocks until all threads have paused.
    */
-  void Pause(FEXCore::Context::Context *CTX);
+  __attribute__((visibility("default"))) void Pause(FEXCore::Context::Context *CTX);
 
   /**
    * @brief Starts (or continues) the CPU core
@@ -104,7 +104,7 @@ namespace FEXCore::Context {
    * Use RunUntilExit() for synchonous executions
    *
    */
-  void Run(FEXCore::Context::Context *CTX);
+  __attribute__((visibility("default"))) void Run(FEXCore::Context::Context *CTX);
 
   /**
    * @brief Runs the CPU core until it exits
@@ -116,7 +116,7 @@ namespace FEXCore::Context {
    *
    * @return The ExitReason for the parentthread.
    */
-  ExitReason RunUntilExit(FEXCore::Context::Context *CTX);
+  __attribute__((visibility("default"))) ExitReason RunUntilExit(FEXCore::Context::Context *CTX);
 
   /**
    * @brief Gets the program exit status
@@ -126,21 +126,21 @@ namespace FEXCore::Context {
    *
    * @return The program exit status
    */
-  int GetProgramStatus(FEXCore::Context::Context *CTX);
+  __attribute__((visibility("default"))) int GetProgramStatus(FEXCore::Context::Context *CTX);
 
   /**
    * @brief Tells the core to shutdown
    *
    * Blocks until shutdown
    */
-  void Stop(FEXCore::Context::Context *CTX);
+  __attribute__((visibility("default"))) void Stop(FEXCore::Context::Context *CTX);
 
   /**
    * @brief Executes one instruction
    *
    * Returns once execution is complete.
    */
-  void Step(FEXCore::Context::Context *CTX);
+  __attribute__((visibility("default"))) void Step(FEXCore::Context::Context *CTX);
 
   /**
    * @brief [[threadsafe]] Returns the ExitReason of the parent thread. Typically used for async result status
@@ -149,7 +149,7 @@ namespace FEXCore::Context {
    *
    * @return The ExitReason for the parentthread
    */
-  ExitReason GetExitReason(FEXCore::Context::Context *CTX);
+  __attribute__((visibility("default"))) ExitReason GetExitReason(FEXCore::Context::Context *CTX);
 
   /**
    * @brief [[theadsafe]] Checks if the Context is either done working or paused(in the case of single stepping)
@@ -160,7 +160,7 @@ namespace FEXCore::Context {
    *
    * @return true if the core is done or paused
    */
-  bool IsDone(FEXCore::Context::Context *CTX);
+  __attribute__((visibility("default"))) bool IsDone(FEXCore::Context::Context *CTX);
 
   /**
    * @brief Gets a copy the CPUState of the parent thread
@@ -168,7 +168,7 @@ namespace FEXCore::Context {
    * @param CTX The context that we created
    * @param State The state object to populate
    */
-  void GetCPUState(FEXCore::Context::Context *CTX, FEXCore::Core::CPUState *State);
+  __attribute__((visibility("default"))) void GetCPUState(FEXCore::Context::Context *CTX, FEXCore::Core::CPUState *State);
 
   /**
    * @brief Copies the CPUState provided to the parent thread
@@ -176,7 +176,7 @@ namespace FEXCore::Context {
    * @param CTX The context that we created
    * @param State The satate object to copy from
    */
-  void SetCPUState(FEXCore::Context::Context *CTX, FEXCore::Core::CPUState *State);
+  __attribute__((visibility("default"))) void SetCPUState(FEXCore::Context::Context *CTX, FEXCore::Core::CPUState *State);
 
   /**
    * @brief Allows the frontend to pass in a custom CPUBackend creation factory
@@ -186,7 +186,7 @@ namespace FEXCore::Context {
    * @param CTX The context that we created
    * @param Factory The factory that the context will call if the DefaultCore config ise set to CUSTOM
    */
-  void SetCustomCPUBackendFactory(FEXCore::Context::Context *CTX, CustomCPUFactoryType Factory);
+  __attribute__((visibility("default"))) void SetCustomCPUBackendFactory(FEXCore::Context::Context *CTX, CustomCPUFactoryType Factory);
 
   /**
    * @brief Sets up memory regions on the guest for mirroring within the guest's VM space
@@ -197,7 +197,7 @@ namespace FEXCore::Context {
    *
    * @return true when successfully mapped. false if there was an error adding
    */
-  bool AddVirtualMemoryMapping(FEXCore::Context::Context *CTX, uint64_t VirtualAddress, uint64_t PhysicalAddress, uint64_t Size);
+  __attribute__((visibility("default"))) bool AddVirtualMemoryMapping(FEXCore::Context::Context *CTX, uint64_t VirtualAddress, uint64_t PhysicalAddress, uint64_t Size);
 
   /**
    * @brief Allows the frontend to set a custom syscall handler
@@ -207,26 +207,26 @@ namespace FEXCore::Context {
    * @param Syscall Which syscall ID to install a visitor to
    * @param Visitor The Visitor to install
    */
-  void RegisterExternalSyscallVisitor(FEXCore::Context::Context *CTX, uint64_t Syscall, FEXCore::HLE::SyscallVisitor *Visitor);
+  __attribute__((visibility("default"))) void RegisterExternalSyscallVisitor(FEXCore::Context::Context *CTX, uint64_t Syscall, FEXCore::HLE::SyscallVisitor *Visitor);
 
-  void HandleCallback(FEXCore::Context::Context *CTX, uint64_t RIP);
+  __attribute__((visibility("default"))) void HandleCallback(FEXCore::Context::Context *CTX, uint64_t RIP);
 
-  void RegisterHostSignalHandler(FEXCore::Context::Context *CTX, int Signal, HostSignalDelegatorFunction Func);
-  void RegisterFrontendHostSignalHandler(FEXCore::Context::Context *CTX, int Signal, HostSignalDelegatorFunction Func);
+  __attribute__((visibility("default"))) void RegisterHostSignalHandler(FEXCore::Context::Context *CTX, int Signal, HostSignalDelegatorFunction Func);
+  __attribute__((visibility("default"))) void RegisterFrontendHostSignalHandler(FEXCore::Context::Context *CTX, int Signal, HostSignalDelegatorFunction Func);
 
-  FEXCore::Core::InternalThreadState* CreateThread(FEXCore::Context::Context *CTX, FEXCore::Core::CPUState *NewThreadState, uint64_t ParentTID);
-  void InitializeThread(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread);
-  void RunThread(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread);
-  void StopThread(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread);
-  void DestroyThread(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread);
-  void CleanupAfterFork(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread);
-  void SetSignalDelegator(FEXCore::Context::Context *CTX, FEXCore::SignalDelegator *SignalDelegation);
-  void SetSyscallHandler(FEXCore::Context::Context *CTX, FEXCore::HLE::SyscallHandler *Handler);
-  FEXCore::CPUID::FunctionResults RunCPUIDFunction(FEXCore::Context::Context *CTX, uint32_t Function, uint32_t Leaf);
+  __attribute__((visibility("default"))) FEXCore::Core::InternalThreadState* CreateThread(FEXCore::Context::Context *CTX, FEXCore::Core::CPUState *NewThreadState, uint64_t ParentTID);
+  __attribute__((visibility("default"))) void InitializeThread(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread);
+  __attribute__((visibility("default"))) void RunThread(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread);
+  __attribute__((visibility("default"))) void StopThread(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread);
+  __attribute__((visibility("default"))) void DestroyThread(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread);
+  __attribute__((visibility("default"))) void CleanupAfterFork(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread);
+  __attribute__((visibility("default"))) void SetSignalDelegator(FEXCore::Context::Context *CTX, FEXCore::SignalDelegator *SignalDelegation);
+  __attribute__((visibility("default"))) void SetSyscallHandler(FEXCore::Context::Context *CTX, FEXCore::HLE::SyscallHandler *Handler);
+  __attribute__((visibility("default"))) FEXCore::CPUID::FunctionResults RunCPUIDFunction(FEXCore::Context::Context *CTX, uint32_t Function, uint32_t Leaf);
 
-  void AddNamedRegion(FEXCore::Context::Context *CTX, uintptr_t Base, uintptr_t Length, uintptr_t Offset, const std::string& Name);
-  void RemoveNamedRegion(FEXCore::Context::Context *CTX, uintptr_t Base, uintptr_t Length);
-  void SetAOTIRLoader(FEXCore::Context::Context *CTX, std::function<std::unique_ptr<std::istream>(const std::string&)> CacheReader);
-  bool WriteAOTIR(FEXCore::Context::Context *CTX, std::function<std::unique_ptr<std::ostream>(const std::string&)> CacheWriter);
-  void FlushCodeRange(FEXCore::Core::InternalThreadState *Thread, uint64_t Start, uint64_t Length);
+  __attribute__((visibility("default"))) void AddNamedRegion(FEXCore::Context::Context *CTX, uintptr_t Base, uintptr_t Length, uintptr_t Offset, const std::string& Name);
+  __attribute__((visibility("default"))) void RemoveNamedRegion(FEXCore::Context::Context *CTX, uintptr_t Base, uintptr_t Length);
+  __attribute__((visibility("default"))) void SetAOTIRLoader(FEXCore::Context::Context *CTX, std::function<std::unique_ptr<std::istream>(const std::string&)> CacheReader);
+  __attribute__((visibility("default"))) bool WriteAOTIR(FEXCore::Context::Context *CTX, std::function<std::unique_ptr<std::ostream>(const std::string&)> CacheWriter);
+  __attribute__((visibility("default"))) void FlushCodeRange(FEXCore::Core::InternalThreadState *Thread, uint64_t Start, uint64_t Length);
 }

--- a/External/FEXCore/include/FEXCore/Core/CoreState.h
+++ b/External/FEXCore/include/FEXCore/Core/CoreState.h
@@ -51,6 +51,6 @@ namespace FEXCore::Core {
 
   constexpr uint64_t PAGE_SIZE = 4096;
 
-  std::string_view const& GetFlagName(unsigned Flag);
-  std::string_view const& GetGRegName(unsigned Reg);
+  __attribute__((visibility("default"))) std::string_view const& GetFlagName(unsigned Flag);
+  __attribute__((visibility("default"))) std::string_view const& GetGRegName(unsigned Reg);
 }

--- a/External/FEXCore/include/FEXCore/Debug/X86Tables.h
+++ b/External/FEXCore/include/FEXCore/Debug/X86Tables.h
@@ -455,29 +455,29 @@ constexpr size_t MAX_XOP_GROUP_TABLE_SIZE = (1 << 6);
 
 constexpr size_t MAX_EVEX_TABLE_SIZE = 256;
 
-extern X86InstInfo BaseOps[MAX_PRIMARY_TABLE_SIZE];
-extern X86InstInfo SecondBaseOps[MAX_SECOND_TABLE_SIZE];
-extern X86InstInfo RepModOps[MAX_REP_MOD_TABLE_SIZE];
-extern X86InstInfo RepNEModOps[MAX_REPNE_MOD_TABLE_SIZE];
-extern X86InstInfo OpSizeModOps[MAX_OPSIZE_MOD_TABLE_SIZE];
-extern X86InstInfo PrimaryInstGroupOps[MAX_INST_GROUP_TABLE_SIZE];
-extern X86InstInfo SecondInstGroupOps[MAX_INST_SECOND_GROUP_TABLE_SIZE];
-extern X86InstInfo SecondModRMTableOps[MAX_SECOND_MODRM_TABLE_SIZE];
-extern X86InstInfo X87Ops[MAX_X87_TABLE_SIZE];
-extern X86InstInfo DDDNowOps[MAX_3DNOW_TABLE_SIZE];
-extern X86InstInfo H0F38TableOps[MAX_0F_38_TABLE_SIZE];
-extern X86InstInfo H0F3ATableOps[MAX_0F_3A_TABLE_SIZE];
+extern __attribute__((visibility("default"))) X86InstInfo BaseOps[MAX_PRIMARY_TABLE_SIZE];
+extern __attribute__((visibility("default"))) X86InstInfo SecondBaseOps[MAX_SECOND_TABLE_SIZE];
+extern __attribute__((visibility("default"))) X86InstInfo RepModOps[MAX_REP_MOD_TABLE_SIZE];
+extern __attribute__((visibility("default"))) X86InstInfo RepNEModOps[MAX_REPNE_MOD_TABLE_SIZE];
+extern __attribute__((visibility("default"))) X86InstInfo OpSizeModOps[MAX_OPSIZE_MOD_TABLE_SIZE];
+extern __attribute__((visibility("default"))) X86InstInfo PrimaryInstGroupOps[MAX_INST_GROUP_TABLE_SIZE];
+extern __attribute__((visibility("default"))) X86InstInfo SecondInstGroupOps[MAX_INST_SECOND_GROUP_TABLE_SIZE];
+extern __attribute__((visibility("default"))) X86InstInfo SecondModRMTableOps[MAX_SECOND_MODRM_TABLE_SIZE];
+extern __attribute__((visibility("default"))) X86InstInfo X87Ops[MAX_X87_TABLE_SIZE];
+extern __attribute__((visibility("default"))) X86InstInfo DDDNowOps[MAX_3DNOW_TABLE_SIZE];
+extern __attribute__((visibility("default"))) X86InstInfo H0F38TableOps[MAX_0F_38_TABLE_SIZE];
+extern __attribute__((visibility("default"))) X86InstInfo H0F3ATableOps[MAX_0F_3A_TABLE_SIZE];
 
 // VEX
-extern X86InstInfo VEXTableOps[MAX_VEX_TABLE_SIZE];
-extern X86InstInfo VEXTableGroupOps[MAX_VEX_GROUP_TABLE_SIZE];
+extern __attribute__((visibility("default"))) X86InstInfo VEXTableOps[MAX_VEX_TABLE_SIZE];
+extern __attribute__((visibility("default"))) X86InstInfo VEXTableGroupOps[MAX_VEX_GROUP_TABLE_SIZE];
 
 // XOP
-extern X86InstInfo XOPTableOps[MAX_XOP_TABLE_SIZE];
-extern X86InstInfo XOPTableGroupOps[MAX_XOP_GROUP_TABLE_SIZE];
+extern __attribute__((visibility("default"))) X86InstInfo XOPTableOps[MAX_XOP_TABLE_SIZE];
+extern __attribute__((visibility("default"))) X86InstInfo XOPTableGroupOps[MAX_XOP_GROUP_TABLE_SIZE];
 
 // EVEX
-extern X86InstInfo EVEXTableOps[MAX_EVEX_TABLE_SIZE];
+extern __attribute__((visibility("default"))) X86InstInfo EVEXTableOps[MAX_EVEX_TABLE_SIZE];
 
-void InitializeInfoTables(Context::OperatingMode Mode);
+__attribute__((visibility("default"))) void InitializeInfoTables(Context::OperatingMode Mode);
 }

--- a/External/FEXCore/include/FEXCore/IR/IR.h
+++ b/External/FEXCore/include/FEXCore/IR/IR.h
@@ -465,8 +465,8 @@ public:
 class IRListView;
 class IREmitter;
 
-void Dump(std::stringstream *out, IRListView const* IR, IR::RegisterAllocationData *RAData);
-IREmitter* Parse(std::istream *in);
+__attribute__((visibility("default"))) void Dump(std::stringstream *out, IRListView const* IR, IR::RegisterAllocationData *RAData);
+__attribute__((visibility("default"))) IREmitter* Parse(std::istream *in);
 
 template<typename Type>
 inline uint32_t NodeWrapperBase<Type>::ID() const { return NodeOffset / sizeof(IR::OrderedNode); }

--- a/External/FEXCore/include/FEXCore/Utils/ELFLoader.h
+++ b/External/FEXCore/include/FEXCore/Utils/ELFLoader.h
@@ -28,7 +28,7 @@ struct ELFSymbol {
   char const *Name;
 };
 
-class ELFContainer {
+class __attribute__((visibility("default"))) ELFContainer {
 public:
   ELFContainer(std::string const &Filename, std::string const &RootFS, bool CustomInterpreter);
   ~ELFContainer();

--- a/External/FEXCore/include/FEXCore/Utils/ELFSymbolDatabase.h
+++ b/External/FEXCore/include/FEXCore/Utils/ELFSymbolDatabase.h
@@ -4,7 +4,7 @@
 #include <unordered_map>
 
 namespace ELFLoader {
-class ELFSymbolDatabase final {
+class __attribute__((visibility("default"))) ELFSymbolDatabase final {
 public:
   ELFSymbolDatabase(::ELFLoader::ELFContainer *file);
   ~ELFSymbolDatabase();

--- a/External/FEXCore/include/FEXCore/Utils/LogManager.h
+++ b/External/FEXCore/include/FEXCore/Utils/LogManager.h
@@ -18,8 +18,8 @@ constexpr DebugLevels MSG_LEVEL = INFO;
 
 namespace Throw {
 using ThrowHandler = void(*)(char const *Message);
-void InstallHandler(ThrowHandler Handler);
-void UnInstallHandlers();
+__attribute__((visibility("default"))) void InstallHandler(ThrowHandler Handler);
+__attribute__((visibility("default"))) void UnInstallHandlers();
 
 [[noreturn]] void M(const char *fmt, va_list args);
 
@@ -40,10 +40,10 @@ static inline void A(bool, const char*, ...) {}
 
 namespace Msg {
 using MsgHandler = void(*)(DebugLevels Level, char const *Message);
-void InstallHandler(MsgHandler Handler);
-void UnInstallHandlers();
+__attribute__((visibility("default"))) void InstallHandler(MsgHandler Handler);
+__attribute__((visibility("default"))) void UnInstallHandlers();
 
-void M(DebugLevels Level, const char *fmt, va_list args);
+__attribute__((visibility("default"))) void M(DebugLevels Level, const char *fmt, va_list args);
 
 #if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
 static inline void A(const char *fmt, ...) {

--- a/Source/Tests/CMakeLists.txt
+++ b/Source/Tests/CMakeLists.txt
@@ -9,6 +9,15 @@ target_include_directories(FEXLoader PRIVATE ${CMAKE_BINARY_DIR}/generated)
 
 target_link_libraries(FEXLoader ${LIBS} LinuxEmulation)
 
+if (CMAKE_BUILD_TYPE MATCHES "RELEASE")
+  target_link_options(FEXLoader
+    PRIVATE
+    "LINKER:--gc-sections"
+    "LINKER:--strip-all"
+    "LINKER:--as-needed"
+  )
+endif()
+
 install(TARGETS FEXLoader
   RUNTIME
     DESTINATION bin
@@ -67,6 +76,15 @@ target_include_directories(FEXBash PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/Source/)
 target_include_directories(FEXBash PRIVATE ${CMAKE_BINARY_DIR}/generated)
 
 target_link_libraries(FEXBash ${LIBS} LinuxEmulation)
+
+if (CMAKE_BUILD_TYPE MATCHES "RELEASE")
+  target_link_options(FEXBash
+    PRIVATE
+    "LINKER:--gc-sections"
+    "LINKER:--strip-all"
+    "LINKER:--as-needed"
+  )
+endif()
 
 install(TARGETS FEXBash
   RUNTIME


### PR DESCRIPTION
Set our default visibility to hidden. There is no need to have anything default visibility.

Additionally on release builds strip unused sections and symbols.

This shaves the binary down to 2MB on x86-64 host
1.9MB on an ARMv8.2 host

Fixes #934