### PR TITLE
Updates release script to match what I want it to be

### DIFF
--- a/Scripts/changelog_generator.py
+++ b/Scripts/changelog_generator.py
@@ -28,7 +28,7 @@ for line in sys.stdin.readlines():
             Meta["_Misc"] = []
         Meta["_Misc"].append(line.strip())
 
-print(sys.argv[1])
+print("FEX Release {0}".format(sys.argv[1]))
 
 Category = ""
 Tag = ""

--- a/Scripts/generate_release.sh
+++ b/Scripts/generate_release.sh
@@ -1,21 +1,29 @@
 #!/bin/env bash
 
-if [ "$#" -ne 2 ];
+PREVIOUS=FEX-$(date --date='-1 month' +%y%m)
+CURRENT=FEX-$(date +%y%m)
+
+if ! git rev-list $PREVIOUS > /dev/null 2>&1 ;
 then
-echo "$0: <NUMERIC-VERSION-PREV> <NUMERIC-VERSION-NEXT>"
-exit -1
+  echo "$PREVIOUS tag doesn't exist"
+  exit
 fi
 
+if git rev-list $CURRENT > /dev/null 2>&1 ;
+then
+  echo "$CURRENT tag already exists!"
+  exit
+fi
 
-echo "Tagging FEX-$2, previous release FEX-$1"
+echo "Tagging $CURRENT, previous release $PREVIOUS"
 echo "Press cltr-c to cancel within 10 seconds"
 sleep 10
 
-git tag FEX-$2 -a -m "temporary"
+git tag $CURRENT -a -m "temporary"
 Scripts/generate_doc_outline.sh > docs/SourceOutline.md
-git commit docs/SourceOutline.md -m "Docs: Update for release FEX-$2"
-git tad -d FEX-$2
-git tag FEX-$2 -a -m "$(Scripts/generate_changelog.sh FEX-$1 FEX-$2)" --edit
+git commit docs/SourceOutline.md -m "Docs: Update for release $CURRENT"
+git tag -d $CURRENT
+git tag $CURRENT -a -m "$(Scripts/generate_changelog.sh $PREVIOUS $CURRENT)" --edit
 
-echo "Inspect if everything went smoothly via 'git log -6 FEX-$2' "
-echo "if all is good, do 'git push FEX-$2:FEX-$2'"
+echo "Inspect if everything went smoothly via 'git log -6 $CURRENT' "
+echo "if all is good, do 'git push upstream $CURRENT'"


### PR DESCRIPTION
Generates the current and previous tag automatically.
Checks to ensure the previous tag exists and that the current tag does not

Lets me run the script and then just check it after the fact.
Will break if we don't have a release for a month, which I'll deal with when it happens