### PR TITLE
Fixes clock_nanosleep

### DIFF
--- a/Source/Tests/LinuxSyscalls/x64/Time.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Time.cpp
@@ -10,6 +10,7 @@ $end_info$
 #include <stddef.h>
 #include <stdint.h>
 #include <time.h>
+#include <sys/syscall.h>
 #include <sys/time.h>
 #include <sys/times.h>
 #include <sys/timex.h>
@@ -39,7 +40,7 @@ namespace FEX::HLE::x64 {
     });
 
     REGISTER_SYSCALL_IMPL_X64(clock_nanosleep, [](FEXCore::Core::CpuStateFrame *Frame, clockid_t clockid, int flags, const struct timespec *request, struct timespec *remain) -> uint64_t {
-      uint64_t Result = ::clock_nanosleep(clockid, flags, request, remain);
+      uint64_t Result = ::syscall(SYS_clock_nanosleep, clockid, flags, request, remain);
       SYSCALL_ERRNO();
     });
 

--- a/unittests/POSIX/Known_Failures
+++ b/unittests/POSIX/Known_Failures
@@ -1,12 +1,7 @@
 # these fail
 conformance-interfaces-clock-1-1.test
 conformance-interfaces-clock_getcpuclockid-2-1.testconformance-interfaces-clock-1-1.test
-conformance-interfaces-clock_nanosleep-11-1.test
-conformance-interfaces-clock_nanosleep-13-1.test
 conformance-interfaces-munmap-2-1.test
-conformance-interfaces-nanosleep-10000-1.test
-conformance-interfaces-nanosleep-5-1.test
-conformance-interfaces-nanosleep-6-1.test
 conformance-interfaces-sigqueue-10-1.test
 conformance-interfaces-sigqueue-11-1.test
 conformance-interfaces-sigqueue-12-1.test

--- a/unittests/gvisor-tests/Known_Failures
+++ b/unittests/gvisor-tests/Known_Failures
@@ -69,7 +69,6 @@ alarm_test
 arch_prctl_test
 bad_test
 chown_test
-clock_nanosleep_test
 concurrency_test
 connect_external_test
 creat_test


### PR DESCRIPTION
glibc version behaves slightly differently than kernel