### PR TITLE
Fixes truncate and creat

### DIFF
--- a/Source/Tests/LinuxSyscalls/Syscalls/FS.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/FS.cpp
@@ -120,15 +120,15 @@ namespace FEX::HLE {
       SYSCALL_ERRNO();
     });
 
-    /*REGISTER_SYSCALL_IMPL(truncate, [](FEXCore::Core::CpuStateFrame *Frame, const char *path, off_t length) -> uint64_t {
-      SYSCALL_STUB(truncate);
-    });*/
-    REGISTER_SYSCALL_FORWARD_ERRNO(truncate);
+    REGISTER_SYSCALL_IMPL(truncate, [](FEXCore::Core::CpuStateFrame *Frame, const char *path, off_t length) -> uint64_t {
+      uint64_t Result = ::truncate(path, length);
+      SYSCALL_ERRNO();
+    });
 
-    /*REGISTER_SYSCALL_IMPL(creat, [](FEXCore::Core::CpuStateFrame *Frame, const char *pathname, mode_t mode) -> uint64_t {
-      SYSCALL_STUB(creat);
-    });*/
-    REGISTER_SYSCALL_FORWARD_ERRNO(creat);
+    REGISTER_SYSCALL_IMPL(creat, [](FEXCore::Core::CpuStateFrame *Frame, const char *pathname, mode_t mode) -> uint64_t {
+      uint64_t Result = ::creat(pathname, mode);
+      SYSCALL_ERRNO();
+    });
 
     REGISTER_SYSCALL_IMPL(chroot, [](FEXCore::Core::CpuStateFrame *Frame, const char *path) -> uint64_t {
       uint64_t Result = ::chroot(path);

--- a/unittests/gvisor-tests/Known_Failures
+++ b/unittests/gvisor-tests/Known_Failures
@@ -72,7 +72,6 @@ chown_test
 clock_nanosleep_test
 concurrency_test
 connect_external_test
-creat_test
 epoll_test
 exceptions_test
 exec_binary_test
@@ -88,7 +87,6 @@ getrusage_test
 inotify_test
 itimer_test
 memfd_test
-mknod_test
 mmap_test
 mount_test
 mremap_test


### PR DESCRIPTION
These were using the passthrough helper which doesn't was breaking the result value