### PR TITLE
Fixes memory leak in CPU backends 

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
@@ -350,7 +350,7 @@ void InterpreterCore::CreateAsmDispatch(FEXCore::Context::Context *ctx, FEXCore:
   DispatcherConfig config;
   config.ExecuteBlocksWithCall = true;
 
-  Dispatcher = new Arm64Dispatcher(ctx, Thread, config);
+  Dispatcher = std::make_unique<Arm64Dispatcher>(ctx, Thread, config);
   DispatchPtr = Dispatcher->DispatchPtr;
   CallbackPtr = Dispatcher->CallbackPtr;
 

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
@@ -18,6 +18,7 @@ struct DispatcherConfig {
 
 class Dispatcher {
 public:
+  virtual ~Dispatcher() = default;
   CPUBackend::AsmDispatch DispatchPtr;
   CPUBackend::JITCallback CallbackPtr;
   FEXCore::Context::Context::IntCallbackReturn ReturnPtr;

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/X86Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/X86Dispatcher.cpp
@@ -312,7 +312,7 @@ void InterpreterCore::CreateAsmDispatch(FEXCore::Context::Context *ctx, FEXCore:
   DispatcherConfig config;
   config.ExecuteBlocksWithCall = true;
 
-  Dispatcher = new X86Dispatcher(ctx, Thread, config);
+  Dispatcher = std::make_unique<X86Dispatcher>(ctx, Thread, config);
   DispatchPtr = Dispatcher->DispatchPtr;
   CallbackPtr = Dispatcher->CallbackPtr;
 

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterClass.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterClass.h
@@ -22,7 +22,6 @@ using DestMapType = std::vector<uint32_t>;
 class InterpreterCore final : public CPUBackend {
 public:
   explicit InterpreterCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread, bool CompileThread);
-  ~InterpreterCore() override;
   std::string GetName() override { return "Interpreter"; }
   void *CompileCode(FEXCore::IR::IRListView const *IR, FEXCore::Core::DebugData *DebugData, FEXCore::IR::RegisterAllocationData *RAData) override;
 
@@ -46,7 +45,7 @@ private:
   template<typename Res>
   Res GetSrc(void* SSAData, IR::OrderedNodeWrapper Src);
 
-  Dispatcher *Dispatcher{};
+  std::unique_ptr<Dispatcher> Dispatcher{};
 };
 
 }

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -111,12 +111,6 @@ InterpreterCore::InterpreterCore(FEXCore::Context::Context *ctx, FEXCore::Core::
   }
 }
 
-
-InterpreterCore::~InterpreterCore() {
-  delete Dispatcher;
-}
-
-
 void *InterpreterCore::CompileCode([[maybe_unused]] FEXCore::IR::IRListView const *IR, [[maybe_unused]] FEXCore::Core::DebugData *DebugData, FEXCore::IR::RegisterAllocationData *RAData) {
   return reinterpret_cast<void*>(InterpreterExecution);
 }

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
@@ -73,7 +73,7 @@ DEF_OP(ExitFunction) {
   uint64_t NewRIP;
 
   if (IsInlineConstant(Op->NewRIP, &NewRIP) || IsInlineEntrypointOffset(Op->NewRIP, &NewRIP)) {
-    Literal l_BranchHost{Dispatcher->ExitFunctionLinkerAddress};
+    Literal l_BranchHost{ThreadSharedData.Dispatcher->ExitFunctionLinkerAddress};
     Literal l_BranchGuest{NewRIP};
 
     ldr(x0, &l_BranchHost);
@@ -96,7 +96,7 @@ DEF_OP(ExitFunction) {
     br(x1);
 
     bind(&FullLookup);
-    LoadConstant(TMP1, Dispatcher->AbsoluteLoopTopAddress);
+    LoadConstant(TMP1, ThreadSharedData.Dispatcher->AbsoluteLoopTopAddress);
     str(RipReg, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, State.rip)));
     br(TMP1);
   }

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -63,7 +63,7 @@ public:
   void CopyNecessaryDataForCompileThread(CPUBackend *Original) override;
 
 private:
-  Dispatcher *Dispatcher;
+  std::unique_ptr<FEXCore::CPU::Dispatcher> Dispatcher;
   Label *PendingTargetLabel;
   FEXCore::Context::Context *CTX;
   FEXCore::Core::InternalThreadState *ThreadState;
@@ -162,6 +162,7 @@ private:
     uint64_t SignalReturnInstruction{};
 
     uint32_t *SignalHandlerRefCounterPtr{};
+    FEXCore::CPU::Dispatcher *Dispatcher{};
   };
 
   CompilerSharedData ThreadSharedData;

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
@@ -42,14 +42,14 @@ DEF_OP(Break) {
       add(sp, TMP1, 0);
 
       // Now we need to jump to the thread stop handler
-      LoadConstant(TMP1, Dispatcher->ThreadStopHandlerAddressSpillSRA);
+      LoadConstant(TMP1, ThreadSharedData.Dispatcher->ThreadStopHandlerAddressSpillSRA);
       br(TMP1);
       break;
     }
     case 6: { // INT3
       ResetStack();
 
-      LoadConstant(TMP1, Dispatcher->ThreadPauseHandlerAddressSpillSRA);
+      LoadConstant(TMP1, ThreadSharedData.Dispatcher->ThreadPauseHandlerAddressSpillSRA);
       br(TMP1);
       break;
     }

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
@@ -81,7 +81,7 @@ DEF_OP(ExitFunction) {
     jmp(qword[rax]);
 
     L(l_BranchHost);
-    dq(Dispatcher->ExitFunctionLinkerAddress);
+    dq(ThreadSharedData.Dispatcher->ExitFunctionLinkerAddress);
     L(l_BranchGuest);
     dq(NewRIP);
   } else {
@@ -101,7 +101,7 @@ DEF_OP(ExitFunction) {
     jmp(qword[LookupBase + 0]);
 
     L(FullLookup);
-    mov(rax, Dispatcher->AbsoluteLoopTopAddress);
+    mov(rax, ThreadSharedData.Dispatcher->AbsoluteLoopTopAddress);
     mov(qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, State.rip)], RipReg);
     jmp(rax);
   }

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -83,7 +83,7 @@ private:
   FEXCore::Context::Context *CTX;
   FEXCore::Core::InternalThreadState *ThreadState;
   FEXCore::IR::IRListView const *IR;
-  FEXCore::CPU::Dispatcher *Dispatcher;
+  std::unique_ptr<FEXCore::CPU::Dispatcher> Dispatcher;
 
   std::unordered_map<IR::OrderedNodeWrapper::NodeOffsetType, Label> JumpTargets;
   Xbyak::util::Cpu Features{};
@@ -161,6 +161,7 @@ private:
     uint64_t SignalHandlerReturnAddress{};
 
     uint32_t *SignalHandlerRefCounterPtr{};
+    FEXCore::CPU::Dispatcher *Dispatcher{};
   };
 
   CompilerSharedData ThreadSharedData;

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/MiscOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/MiscOps.cpp
@@ -43,7 +43,7 @@ DEF_OP(Break) {
       mov(rsp, qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, ReturningStackLocation)]);
 
       // Now we need to jump to the thread stop handler
-      mov(TMP1, Dispatcher->ThreadStopHandlerAddress);
+      mov(TMP1, ThreadSharedData.Dispatcher->ThreadStopHandlerAddress);
       jmp(TMP1);
       break;
     }
@@ -56,7 +56,7 @@ DEF_OP(Break) {
         }
 
         // This jump target needs to be a constant offset here
-        mov(TMP1, Dispatcher->ThreadPauseHandlerAddress);
+        mov(TMP1, ThreadSharedData.Dispatcher->ThreadPauseHandlerAddress);
         jmp(TMP1);
       }
       else {
@@ -65,7 +65,7 @@ DEF_OP(Break) {
         mov(rsp, qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, ReturningStackLocation)]);
 
         // Now we need to jump to the thread stop handler
-        mov(TMP1, Dispatcher->ThreadStopHandlerAddress);
+        mov(TMP1, ThreadSharedData.Dispatcher->ThreadStopHandlerAddress);
         jmp(TMP1);
       }
     break;


### PR DESCRIPTION
Dispatcher wasn't ever getting cleaned up.
Also ensures sharing it with the CompileService otherwise it crashes on use.