### PR TITLE
Fixes GCC tests

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -32,7 +32,14 @@ DEF_OP(VectorImm) {
   uint8_t OpSize = IROp->Size;
   uint8_t Elements = OpSize / Op->Header.ElementSize;
 
-  movi(GetDst(Node).VCast(OpSize * 8, Elements), Op->Immediate);
+  if (Op->Header.ElementSize == 8) {
+    // movi with 64bit element size doesn't do what we want here
+    LoadConstant(TMP1.X(), Op->Immediate);
+    dup(GetDst(Node).V2D(), TMP1.X());
+  }
+  else {
+    movi(GetDst(Node).VCast(OpSize * 8, Elements), Op->Immediate);
+  }
 }
 
 DEF_OP(CreateVector2) {

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -534,11 +534,13 @@ DEF_OP(VFMin) {
     // Scalar
     switch (Op->Header.ElementSize) {
       case 4: {
-        fmin(GetDst(Node).S(), GetSrc(Op->Header.Args[0].ID()).S(), GetSrc(Op->Header.Args[1].ID()).S());
+        fcmp(GetSrc(Op->Header.Args[0].ID()).S(), GetSrc(Op->Header.Args[1].ID()).S());
+        fcsel(GetDst(Node).S(), GetSrc(Op->Header.Args[0].ID()).S(), GetSrc(Op->Header.Args[1].ID()).S(), Condition::mi);
       break;
       }
       case 8: {
-        fmin(GetDst(Node).D(), GetSrc(Op->Header.Args[0].ID()).D(), GetSrc(Op->Header.Args[1].ID()).D());
+        fcmp(GetSrc(Op->Header.Args[0].ID()).D(), GetSrc(Op->Header.Args[1].ID()).D());
+        fcsel(GetDst(Node).D(), GetSrc(Op->Header.Args[0].ID()).D(), GetSrc(Op->Header.Args[1].ID()).D(), Condition::mi);
       break;
       }
       default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
@@ -548,11 +550,17 @@ DEF_OP(VFMin) {
     // Vector
     switch (Op->Header.ElementSize) {
       case 4: {
-        fmin(GetDst(Node).V4S(), GetSrc(Op->Header.Args[0].ID()).V4S(), GetSrc(Op->Header.Args[1].ID()).V4S());
+        fcmgt(VTMP1.V4S(), GetSrc(Op->Header.Args[1].ID()).V4S(), GetSrc(Op->Header.Args[0].ID()).V4S());
+        mov(VTMP2.V4S(), GetSrc(Op->Header.Args[0].ID()).V4S());
+        bif(VTMP2.V16B(), GetSrc(Op->Header.Args[1].ID()).V16B(), VTMP1.V16B());
+        mov(GetDst(Node).V4S(), VTMP2.V4S());
       break;
       }
       case 8: {
-        fmin(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
+        fcmgt(VTMP1.V2D(), GetSrc(Op->Header.Args[1].ID()).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D());
+        mov(VTMP2.V2D(), GetSrc(Op->Header.Args[0].ID()).V2D());
+        bif(VTMP2.V16B(), GetSrc(Op->Header.Args[1].ID()).V16B(), VTMP1.V16B());
+        mov(GetDst(Node).V2D(), VTMP2.V2D());
       break;
       }
       default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
@@ -567,11 +575,13 @@ DEF_OP(VFMax) {
     // Scalar
     switch (Op->Header.ElementSize) {
       case 4: {
-        fmax(GetDst(Node).S(), GetSrc(Op->Header.Args[0].ID()).S(), GetSrc(Op->Header.Args[1].ID()).S());
+        fcmp(GetSrc(Op->Header.Args[0].ID()).S(), GetSrc(Op->Header.Args[1].ID()).S());
+        fcsel(GetDst(Node).S(), GetSrc(Op->Header.Args[1].ID()).S(), GetSrc(Op->Header.Args[0].ID()).S(), Condition::mi);
       break;
       }
       case 8: {
-        fmax(GetDst(Node).D(), GetSrc(Op->Header.Args[0].ID()).D(), GetSrc(Op->Header.Args[1].ID()).D());
+        fcmp(GetSrc(Op->Header.Args[0].ID()).D(), GetSrc(Op->Header.Args[1].ID()).D());
+        fcsel(GetDst(Node).D(), GetSrc(Op->Header.Args[1].ID()).D(), GetSrc(Op->Header.Args[0].ID()).D(), Condition::mi);
       break;
       }
       default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
@@ -581,11 +591,17 @@ DEF_OP(VFMax) {
     // Vector
     switch (Op->Header.ElementSize) {
       case 4: {
-        fmax(GetDst(Node).V4S(), GetSrc(Op->Header.Args[0].ID()).V4S(), GetSrc(Op->Header.Args[1].ID()).V4S());
+        fcmgt(VTMP1.V4S(), GetSrc(Op->Header.Args[1].ID()).V4S(), GetSrc(Op->Header.Args[0].ID()).V4S());
+        mov(VTMP2.V4S(), GetSrc(Op->Header.Args[0].ID()).V4S());
+        bit(VTMP2.V16B(), GetSrc(Op->Header.Args[1].ID()).V16B(), VTMP1.V16B());
+        mov(GetDst(Node).V4S(), VTMP2.V4S());
       break;
       }
       case 8: {
-        fmax(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
+        fcmgt(VTMP1.V2D(), GetSrc(Op->Header.Args[1].ID()).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D());
+        mov(VTMP2.V2D(), GetSrc(Op->Header.Args[0].ID()).V2D());
+        bit(VTMP2.V16B(), GetSrc(Op->Header.Args[1].ID()).V16B(), VTMP1.V16B());
+        mov(GetDst(Node).V2D(), VTMP2.V2D());
       break;
       }
       default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -775,7 +775,10 @@ DEF_OP(VUMin) {
     break;
     }
     case 8: {
-      umin(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
+      cmhi(VTMP1.V2D(), GetSrc(Op->Header.Args[1].ID()).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D());
+      mov(VTMP2.V2D(), GetSrc(Op->Header.Args[0].ID()).V2D());
+      bif(VTMP2.V16B(), GetSrc(Op->Header.Args[1].ID()).V16B(), VTMP1.V16B());
+      mov(GetDst(Node).V2D(), VTMP2.V2D());
     break;
     }
     default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
@@ -798,7 +801,10 @@ DEF_OP(VSMin) {
     break;
     }
     case 8: {
-      smin(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
+      cmgt(VTMP1.V2D(), GetSrc(Op->Header.Args[1].ID()).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D());
+      mov(VTMP2.V2D(), GetSrc(Op->Header.Args[0].ID()).V2D());
+      bif(VTMP2.V16B(), GetSrc(Op->Header.Args[1].ID()).V16B(), VTMP1.V16B());
+      mov(GetDst(Node).V2D(), VTMP2.V2D());
     break;
     }
     default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
@@ -821,7 +827,10 @@ DEF_OP(VUMax) {
     break;
     }
     case 8: {
-      umax(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
+      cmhi(VTMP1.V2D(), GetSrc(Op->Header.Args[1].ID()).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D());
+      mov(VTMP2.V2D(), GetSrc(Op->Header.Args[0].ID()).V2D());
+      bit(VTMP2.V16B(), GetSrc(Op->Header.Args[1].ID()).V16B(), VTMP1.V16B());
+      mov(GetDst(Node).V2D(), VTMP2.V2D());
     break;
     }
     default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
@@ -844,7 +853,10 @@ DEF_OP(VSMax) {
     break;
     }
     case 8: {
-      smax(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
+      cmgt(VTMP1.V2D(), GetSrc(Op->Header.Args[1].ID()).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D());
+      mov(VTMP2.V2D(), GetSrc(Op->Header.Args[0].ID()).V2D());
+      bit(VTMP2.V16B(), GetSrc(Op->Header.Args[1].ID()).V16B(), VTMP1.V16B());
+      mov(GetDst(Node).V2D(), VTMP2.V2D());
     break;
     }
     default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -4241,7 +4241,11 @@ void OpDispatchBuilder::PExtrOp(OpcodeArgs) {
   uint8_t NumElements = Size / ElementSize;
   Index &= NumElements - 1;
 
-  auto Result = _VExtractToGPR(16, ElementSize, Src, Index);
+  OrderedNode *Result = _VExtractToGPR(16, ElementSize, Src, Index);
+
+  if (ElementSize < 4) {
+    Result = _Bfe(4, ElementSize * 8, 0, Result);
+  }
   StoreResult(GPRClass, Op, Result, -1);
 }
 

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -5975,6 +5975,9 @@ void OpDispatchBuilder::PSRLDOp(OpcodeArgs) {
   OrderedNode *Result{};
 
   if (Scalar) {
+    // Incoming element size for the shift source is always 8
+    auto MaxShift = _VectorImm(ElementSize * 8, 8, 8);
+    Src = _VUMin(8, 8, MaxShift, Src);
     Result = _VUShrS(Size, ElementSize, Dest, Src);
   }
   else {
@@ -6020,6 +6023,9 @@ void OpDispatchBuilder::PSLL(OpcodeArgs) {
   OrderedNode *Result{};
 
   if (Scalar) {
+    // Incoming element size for the shift source is always 8
+    auto MaxShift = _VectorImm(ElementSize * 8, 8, 8);
+    Src = _VUMin(8, 8, MaxShift, Src);
     Result = _VUShlS(Size, ElementSize, Dest, Src);
   }
   else {
@@ -6039,6 +6045,9 @@ void OpDispatchBuilder::PSRAOp(OpcodeArgs) {
   OrderedNode *Result{};
 
   if (Scalar) {
+    // Incoming element size for the shift source is always 8
+    auto MaxShift = _VectorImm(ElementSize * 8, 8, 8);
+    Src = _VUMin(8, 8, MaxShift, Src);
     Result = _VSShrS(Size, ElementSize, Dest, Src);
   }
   else {

--- a/unittests/gcc-target-tests-64/Disabled_Tests
+++ b/unittests/gcc-target-tests-64/Disabled_Tests
@@ -1,16 +1,32 @@
-# these fail on arm
-pr72867.c.gcc-target-test-64
-sse2-mmx-pslld.c.gcc-target-test-64
-sse2-mmx-psllq.c.gcc-target-test-64
-sse2-mmx-psllw.c.gcc-target-test-64
-sse2-mmx-psraw.c.gcc-target-test-64
-sse2-mmx-psrad.c.gcc-target-test-64
-sse2-mmx-psrld.c.gcc-target-test-64
-sse2-mmx-psrlq.c.gcc-target-test-64
-sse2-mmx-psrlw.c.gcc-target-test-64
+# This has invalid asm generated for its test
+# 'foo' gets the argument in edi
+# Passes the argument to bar in eax
+# 'bar' accepts the argument in edi
+# inline asm is incorrect, needs to use =d and d on the value
+asm-5.c.gcc-target-test-64
 
-# this is flaky on the ARMv8.0 runner
-mcount_pic.c.gcc-target-test-64
+# Fails even on host device
+# 'test_pextrw' does a zero extend to the gpr
+# Which means its -3339 value turns in to 0xf2f5
+# While the 'compute_correct_result' value does a sign extension
+# Which turns the value in to 0xfffff2f5
+# This causes its comparison to fail
+sse2-mmx-pextrw.c.gcc-target-test-64
 
 # Uses AVX
+# Test is compiled with -march=native, which means the build machine had avx
+# Needs to be recompiled to care about it
 pr57275.c.gcc-target-test-64
+
+# Fails even on host device
+# Stores a large 64bit value in to a union of double and 'unsigned long long'
+# 'test' loads this value in to a x87 register, then stores that value on to the stack
+# Checks the flag and skips a bunch of x87 logic, and loads that value back from the stack in to rax
+# Value has been munged from the fld + fstp step
+# 0xFFF279535D540FE4 was the original value
+# 0xFFFA79535D540FE4 was the value it turned in to
+pr88240.c.gcc-target-test-64
+
+# This relies on SIGPROF which means we need real signal support to handle this
+# Crashes or hangs depending on which runner is running it
+mcount_pic.c.gcc-target-test-64

--- a/unittests/gcc-target-tests-64/Known_Failures
+++ b/unittests/gcc-target-tests-64/Known_Failures
@@ -1,21 +1,32 @@
-# these fail on x86 and arm
+# This has invalid asm generated for its test
+# 'foo' gets the argument in edi
+# Passes the argument to bar in eax
+# 'bar' accepts the argument in edi
+# inline asm is incorrect, needs to use =d and d on the value
 asm-5.c.gcc-target-test-64
-pr88240.c.gcc-target-test-64
+
+# Fails even on host device
+# 'test_pextrw' does a zero extend to the gpr
+# Which means its -3339 value turns in to 0xf2f5
+# While the 'compute_correct_result' value does a sign extension
+# Which turns the value in to 0xfffff2f5
+# This causes its comparison to fail
 sse2-mmx-pextrw.c.gcc-target-test-64
 
-# these fail on arm
-pr72867.c.gcc-target-test-64
-sse2-mmx-pslld.c.gcc-target-test-64
-sse2-mmx-psllq.c.gcc-target-test-64
-sse2-mmx-psllw.c.gcc-target-test-64
-sse2-mmx-psraw.c.gcc-target-test-64
-sse2-mmx-psrad.c.gcc-target-test-64
-sse2-mmx-psrld.c.gcc-target-test-64
-sse2-mmx-psrlq.c.gcc-target-test-64
-sse2-mmx-psrlw.c.gcc-target-test-64
-
-# this is flaky on the ARMv8.0 runner
-mcount_pic.c.gcc-target-test-64
-
-# this uses AVX ops (VMOVAPS)
+# Uses AVX
+# Test is compiled with -march=native, which means the build machine had avx
+# Needs to be recompiled to care about it
 pr57275.c.gcc-target-test-64
+
+# Fails even on host device
+# Stores a large 64bit value in to a union of double and 'unsigned long long'
+# 'test' loads this value in to a x87 register, then stores that value on to the stack
+# Checks the flag and skips a bunch of x87 logic, and loads that value back from the stack in to rax
+# Value has been munged from the fld + fstp step
+# 0xFFF279535D540FE4 was the original value
+# 0xFFFA79535D540FE4 was the value it turned in to
+pr88240.c.gcc-target-test-64
+
+# This relies on SIGPROF which means we need real signal support to handle this
+# Crashes or hangs depending on which runner is running it
+mcount_pic.c.gcc-target-test-64


### PR DESCRIPTION
This goes through the failing GCC unit tests and fixes them.

The remaining tests are ones that either don't work on host x86 systems already, requires AVX, or relies on SIGPROF.
They are now documented entirely why they fail and the rest are fixed.

Fixes #713