### PR TITLE
Adds use-after-scope to the ASAN options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,8 +61,8 @@ endif()
 
 if (ENABLE_ASAN)
   add_definitions(-DENABLE_ASAN=1)
-  add_compile_options(-fno-omit-frame-pointer -fsanitize=address)
-  link_libraries(-fno-omit-frame-pointer -fsanitize=address)
+  add_compile_options(-fno-omit-frame-pointer -fsanitize=address -fsanitize-address-use-after-scope)
+  link_libraries(-fno-omit-frame-pointer -fsanitize=address -fsanitize-address-use-after-scope)
 endif()
 
 if (ENABLE_TSAN)


### PR DESCRIPTION
Useful for seeing stack scoping problems that can crop up