### PR TITLE
Allows overriding FEX folder locations with environment variables

### DIFF
--- a/External/FEXCore/Scripts/config_generator.py
+++ b/External/FEXCore/Scripts/config_generator.py
@@ -159,7 +159,42 @@ def print_man_environment(options):
                 default
             )
 
+    print_man_environment_tail()
     output_man.write(".El\n")
+
+def print_man_environment_tail():
+
+    # Additional environment variables that live outside of the normal loop
+    print_man_env_option(
+    "FEX_APP_CONFIG_LOCATION",
+    [
+    "Allows the user to override where FEX looks for configuration files",
+    "By default FEX will look in {$HOME, $XDG_CONFIG_HOME}/.fex-emu/",
+    "This will override the full path",
+    ],
+    "''")
+
+    print_man_env_option(
+    "FEX_APP_CONFIG",
+    [
+    "Allows the user to override where FEX looks for only the application config file",
+    "By default FEX will look in {$HOME, $XDG_CONFIG_HOME}/.fex-emu/Config.json",
+    "This will override this file location",
+    "One must be careful with this option as it will override any applications that load with execve as well"
+    "If you need to support applications that execve then use FEX_APP_CONFIG_LOCATION instead"
+    ],
+    "''")
+
+    print_man_env_option(
+    "FEX_APP_DATA_LOCATION",
+    [
+    "Allows the user to override where FEX looks for data files",
+    "By default FEX will look in {$HOME, $XDG_DATA_HOME}/.fex-emu/",
+    "This will override the full path",
+    "This is the folder where FEX stores generated files like IR cache"
+    ],
+    "''")
+
 def print_man_header():
     header ='''.Dd {0}
 .Dt FEX

--- a/External/FEXCore/Source/Interface/Config/Config.cpp
+++ b/External/FEXCore/Source/Interface/Config/Config.cpp
@@ -48,8 +48,15 @@ namespace FEXCore::Config {
     else {
       char const *HomeDir = GetHomeDirectory();
       char const *ConfigXDG = getenv("XDG_CONFIG_HOME");
-      ConfigDir = ConfigXDG ? ConfigXDG : HomeDir;
-      ConfigDir += "/.fex-emu/";
+      char const *ConfigOverride = getenv("FEX_APP_CONFIG_LOCATION");
+      if (ConfigOverride) {
+        // Config override completely overrides the config directory
+        ConfigDir = ConfigOverride;
+      }
+      else {
+        ConfigDir = ConfigXDG ? ConfigXDG : HomeDir;
+        ConfigDir += "/.fex-emu/";
+      }
 
       // Ensure the folder structure is created for our configuration
       if (!std::filesystem::exists(ConfigDir) &&
@@ -64,7 +71,15 @@ namespace FEXCore::Config {
   }
 
   std::string GetConfigFileLocation() {
-    std::string ConfigFile = GetConfigDirectory(false) + "Config.json";
+    std::string ConfigFile{};
+    const char *AppConfig = getenv("FEX_APP_CONFIG");
+    if (AppConfig) {
+      // App config environment variable overwrites only the config file
+      ConfigFile = AppConfig;
+    }
+    else {
+      ConfigFile = GetConfigDirectory(false) + "Config.json";
+    }
     return ConfigFile;
   }
 
@@ -87,8 +102,15 @@ namespace FEXCore::Config {
 
     char const *HomeDir = GetHomeDirectory();
     char const *DataXDG = getenv("XDG_DATA_HOME");
-    DataDir = DataXDG ?: HomeDir;
-    DataDir += "/.fex-emu/";
+    char const *DataOverride = getenv("FEX_APP_DATA_LOCATION");
+    if (DataOverride) {
+      // Data override will override the complete directory
+      DataDir = DataOverride;
+    }
+    else {
+      DataDir = DataXDG ?: HomeDir;
+      DataDir += "/.fex-emu/";
+    }
     return DataDir;
   }
 


### PR DESCRIPTION
Introduces three new environment variables that need to live outside of the scope
of the regular argument loader path.
This will allow external applications to adjust FEX parameters in interesting ways.

FEX_APP_CONFIG: Allows you to override where Config.json lives
FEX_APP_CONFIG_LOCATION: Allows you to provide an entire folder of app profiles
FEX_APP_DATA_LOCATION: Allows you to override where the data gets stored and loaded from

Fixes #572