### PR TITLE
 First step in paranoid TSO mode

### DIFF
--- a/External/FEXCore/Source/Interface/Config/Config.json
+++ b/External/FEXCore/Source/Interface/Config/Config.json
@@ -188,6 +188,14 @@
           "Removes the calculation of the parity flag from GPR instructions.",
           "Assuming no uses rely on it"
         ]
+      },
+      "ParanoidTSO": {
+        "Type": "bool",
+        "Default": "false",
+        "Desc": [
+          "Makes TSO operations even more strict.",
+          "Forces vector loadstores to also become atomic."
+        ]
       }
     },
     "Misc": {

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64.h
@@ -12,6 +12,12 @@ namespace FEXCore::ArchHelpers::Arm64 {
   constexpr uint32_t ATOMIC_MEM_MASK = 0x3B200C00;
   constexpr uint32_t ATOMIC_MEM_INST = 0x38200000;
 
+  constexpr uint32_t LDAXP_MASK = 0xBF'FF'80'00;
+  constexpr uint32_t LDAXP_INST = 0x88'7F'80'00;
+
+  constexpr uint32_t STLXP_MASK = 0xBF'E0'80'00;
+  constexpr uint32_t STLXP_INST = 0x88'20'80'00;
+
   // Load ops are 4 bits
   // Acquire and release bits are independent on the instruction
   constexpr uint32_t ATOMIC_ADD_OP  = 0b0000;

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -359,6 +359,34 @@ bool Arm64JITCore::HandleSIGBUS(int Signal, void *info, void *ucontext) {
     // Back up one instruction and have another go
     ArchHelpers::Context::SetPc(ucontext, ArchHelpers::Context::GetPc(ucontext) - 4);
   }
+  else if ((Instr & FEXCore::ArchHelpers::Arm64::LDAXP_MASK) == FEXCore::ArchHelpers::Arm64::LDAXP_INST) { // LDAXP
+    uint32_t DataReg2 = (Instr >> 10) & 0x1F;
+    // Convert to LDP
+    uint32_t LDP = 0b0010'1001'0100'0000'0000'0000'0000'0000;
+    LDP |= Size << 31;
+    LDP |= DataReg2 << 10;
+    LDP |= AddrReg << 5;
+    LDP |= DataReg;
+    PC[-1] = DMB;
+    PC[0] = LDP;
+    PC[1] = DMB;
+    // Back up one instruction and have another go
+    ArchHelpers::Context::SetPc(ucontext, ArchHelpers::Context::GetPc(ucontext) - 4);
+  }
+  else if ((Instr & FEXCore::ArchHelpers::Arm64::STLXP_MASK) == FEXCore::ArchHelpers::Arm64::STLXP_INST) { // STLXP
+    uint32_t DataReg2 = (Instr >> 10) & 0x1F;
+    // Convert to STP
+    uint32_t STP = 0b0010'1001'0000'0000'0000'0000'0000'0000;
+    STP |= Size << 31;
+    STP |= DataReg2 << 10;
+    STP |= AddrReg << 5;
+    STP |= DataReg;
+    PC[-1] = DMB;
+    PC[0] = STP;
+    PC[1] = DMB;
+    // Back up one instruction and have another go
+    ArchHelpers::Context::SetPc(ucontext, ArchHelpers::Context::GetPc(ucontext) - 4);
+  }
   else if ((Instr & FEXCore::ArchHelpers::Arm64::CASPAL_MASK) == FEXCore::ArchHelpers::Arm64::CASPAL_INST) { // CASPAL
     if (FEXCore::ArchHelpers::Arm64::HandleCASPAL(ucontext, info, Instr)) {
       // Skip this instruction now

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -63,6 +63,8 @@ public:
   void CopyNecessaryDataForCompileThread(CPUBackend *Original) override;
 
 private:
+  FEX_CONFIG_OPT(ParanoidTSO, PARANOIDTSO);
+
   std::unique_ptr<FEXCore::CPU::Dispatcher> Dispatcher;
   Label *PendingTargetLabel;
   FEXCore::Context::Context *CTX;
@@ -303,6 +305,8 @@ private:
   DEF_OP(StoreMem);
   DEF_OP(LoadMemTSO);
   DEF_OP(StoreMemTSO);
+  DEF_OP(ParanoidLoadMemTSO);
+  DEF_OP(ParanoidStoreMemTSO);
   DEF_OP(VLoadMemElement);
   DEF_OP(VStoreMemElement);
 

--- a/Source/Tools/FEXConfig/Main.cpp
+++ b/Source/Tools/FEXConfig/Main.cpp
@@ -439,6 +439,13 @@ namespace {
         ConfigChanged = true;
       }
 
+      Value = LoadedConfig->Get(FEXCore::Config::ConfigOption::CONFIG_PARANOIDTSO);
+      bool ParanoidTSOEnabled = Value.has_value() && **Value == "1";
+      if (ImGui::Checkbox("Paranoid TSO Enabled", &ParanoidTSOEnabled)) {
+        LoadedConfig->EraseSet(FEXCore::Config::ConfigOption::CONFIG_PARANOIDTSO, ParanoidTSOEnabled ? "1" : "0");
+        ConfigChanged = true;
+      }
+
       ImGui::Text("SMC Checks: ");
       int SMCChecks = FEXCore::Config::CONFIG_SMC_MMAN;
 


### PR DESCRIPTION
This moves vector ops down the GPR atomic backpatch path.
Next step after this is to add SIGBUS based handlers for these rather than backpatching.
Needs more work to treat aligned versus unaligned vector loadstores differently