### PR TITLE
Use cmake SDL2 target properties

### DIFF
--- a/Source/Tools/FEXConfig/CMakeLists.txt
+++ b/Source/Tools/FEXConfig/CMakeLists.txt
@@ -11,14 +11,13 @@ add_definitions(-DIMGUI_IMPL_OPENGL_LOADER_CUSTOM=<epoxy/gl.h>)
 add_executable(${NAME} ${SRCS})
 
 target_include_directories(${NAME} PRIVATE ${LLVM_INCLUDE_DIRS})
-target_include_directories(${NAME} PRIVATE ${SDL2_INCLUDE_DIRS})
 
 target_include_directories(${NAME} PRIVATE ${CMAKE_SOURCE_DIR}/Source/)
 target_include_directories(${NAME} PRIVATE ${CMAKE_SOURCE_DIR}/Source/Tools/Debugger/)
 
 target_include_directories(${NAME} PRIVATE ${CMAKE_SOURCE_DIR}/External/imgui/examples/)
 
-target_link_libraries(${NAME} PRIVATE FEXCore Common CommonCore pthread epoxy ${SDL2_LIBRARIES} X11 EGL imgui tiny-json json-maker)
+target_link_libraries(${NAME} PRIVATE FEXCore Common CommonCore pthread epoxy SDL2::SDL2 X11 EGL imgui tiny-json json-maker)
 
 install(TARGETS ${NAME}
   RUNTIME


### PR DESCRIPTION
Some distros include generated cmake files instead of the two cmake files from the source.
Distros that use the generated cmake files only have SDL import properties, so we are required
to use those.