### PR TITLE
Declare missing template specialization for GetListIfExists

### DIFF
--- a/External/FEXCore/Source/Interface/Config/Config.cpp
+++ b/External/FEXCore/Source/Interface/Config/Config.cpp
@@ -415,5 +415,6 @@ namespace FEXCore::Config {
       *List = **Value;
     }
   }
+  template void Value<std::string>::GetListIfExists(FEXCore::Config::ConfigOption Option, std::list<std::string> *List);
 }
 


### PR DESCRIPTION
Clang 12 picks up that this was missing