### PR TITLE
Naked mman usage removal

### DIFF
--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -121,6 +121,7 @@ set (SRCS
   Interface/IR/Passes/StaticRegisterAllocationPass.cpp
   Interface/IR/Passes/RegisterAllocationPass.cpp
   Interface/IR/Passes/SyscallOptimization.cpp
+  Utils/Allocator.cpp
   Utils/ELFContainer.cpp
   Utils/ELFSymbolDatabase.cpp
   Utils/LogManager.cpp

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/X86Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/X86Dispatcher.cpp
@@ -12,7 +12,7 @@ static constexpr size_t MAX_DISPATCHER_CODE_SIZE = 4096;
 
 X86Dispatcher::X86Dispatcher(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread, DispatcherConfig &config)
   : Dispatcher(ctx, Thread)
-  , Xbyak::CodeGenerator(MAX_DISPATCHER_CODE_SIZE) {
+  , Xbyak::CodeGenerator(MAX_DISPATCHER_CODE_SIZE, nullptr, this) {
 
   using namespace Xbyak;
   using namespace Xbyak::util;

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/X86Dispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/X86Dispatcher.h
@@ -2,16 +2,26 @@
 
 #include "Interface/Core/Dispatcher/Dispatcher.h"
 
+#include <FEXCore/Utils/Allocator.h>
+
 #define XBYAK64
 #include <xbyak/xbyak.h>
 
 namespace FEXCore::CPU {
 
-class X86Dispatcher final : public Dispatcher, public Xbyak::CodeGenerator {
+class X86Dispatcher final : public Dispatcher, public Xbyak::CodeGenerator, public Xbyak::Allocator {
   public:
     X86Dispatcher(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread, DispatcherConfig &config);
 
     virtual ~X86Dispatcher() override;
+
+    // Xbyak::Allocator
+    Xbyak::uint8 *alloc(size_t size) override { Size = size; return reinterpret_cast<uint8_t*>(FEXCore::Allocator::mmap(nullptr, size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0)); }
+    void free(Xbyak::uint8 *p) override { FEXCore::Allocator::munmap(p, Size); }
+    bool useProtect() const override { return false; }
+
+  private:
+    size_t Size{};
 };
 
 }

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -22,6 +22,7 @@ $end_info$
 
 #include <FEXCore/Core/X86Enums.h>
 #include <FEXCore/Core/UContext.h>
+#include <FEXCore/Utils/Allocator.h>
 #include "Interface/Core/Interpreter/InterpreterOps.h"
 
 #include <sys/mman.h>
@@ -303,7 +304,7 @@ Arm64JITCore::CodeBuffer Arm64JITCore::AllocateNewCodeBuffer(size_t Size) {
   CodeBuffer Buffer;
   Buffer.Size = Size;
   Buffer.Ptr = static_cast<uint8_t*>(
-               mmap(nullptr,
+               FEXCore::Allocator::mmap(nullptr,
                     Buffer.Size,
                     PROT_READ | PROT_WRITE | PROT_EXEC,
                     MAP_PRIVATE | MAP_ANONYMOUS,
@@ -314,7 +315,7 @@ Arm64JITCore::CodeBuffer Arm64JITCore::AllocateNewCodeBuffer(size_t Size) {
 }
 
 void Arm64JITCore::FreeCodeBuffer(CodeBuffer Buffer) {
-  munmap(Buffer.Ptr, Buffer.Size);
+  FEXCore::Allocator::munmap(Buffer.Ptr, Buffer.Size);
   Dispatcher->RemoveCodeBuffer(Buffer.Ptr);
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -15,6 +15,7 @@ $end_info$
 
 #include <FEXCore/Core/X86Enums.h>
 #include <FEXCore/Core/UContext.h>
+#include <FEXCore/Utils/Allocator.h>
 
 #include <cmath>
 #include <signal.h>
@@ -30,7 +31,7 @@ CodeBuffer AllocateNewCodeBuffer(size_t Size) {
   CodeBuffer Buffer;
   Buffer.Size = Size;
   Buffer.Ptr = static_cast<uint8_t*>(
-               mmap(nullptr,
+               FEXCore::Allocator::mmap(nullptr,
                     Buffer.Size,
                     PROT_READ | PROT_WRITE | PROT_EXEC,
                     MAP_PRIVATE | MAP_ANONYMOUS,
@@ -40,7 +41,7 @@ CodeBuffer AllocateNewCodeBuffer(size_t Size) {
 }
 
 void FreeCodeBuffer(CodeBuffer Buffer) {
-  munmap(Buffer.Ptr, Buffer.Size);
+  FEXCore::Allocator::munmap(Buffer.Ptr, Buffer.Size);
 }
 
 }

--- a/External/FEXCore/Source/Interface/Core/LookupCache.cpp
+++ b/External/FEXCore/Source/Interface/Core/LookupCache.cpp
@@ -8,6 +8,8 @@ $end_info$
 #include "Interface/Context/Context.h"
 #include "Interface/Core/Core.h"
 #include "Interface/Core/LookupCache.h"
+#include <FEXCore/Utils/Allocator.h>
+
 #include <sys/mman.h>
 
 namespace FEXCore {
@@ -26,27 +28,27 @@ LookupCache::LookupCache(FEXCore::Context::Context *CTX)
   // Allocate a region of memory that we can use to back our block pointers
   // We need one pointer per page of virtual memory
   // At 64GB of virtual memory this will allocate 128MB of virtual memory space
-  PagePointer = reinterpret_cast<uintptr_t>(mmap(nullptr, ctx->Config.VirtualMemSize / 4096 * 8, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+  PagePointer = reinterpret_cast<uintptr_t>(FEXCore::Allocator::mmap(nullptr, ctx->Config.VirtualMemSize / 4096 * 8, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
 
   // Allocate our memory backing our pages
   // We need 32KB per guest page (One pointer per byte)
   // XXX: We can drop down to 16KB if we store 4byte offsets from the code base
   // We currently limit to 128MB of real memory for caching for the total cache size.
   // Can end up being inefficient if we compile a small number of blocks per page
-  PageMemory = reinterpret_cast<uintptr_t>(mmap(nullptr, CODE_SIZE, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+  PageMemory = reinterpret_cast<uintptr_t>(FEXCore::Allocator::mmap(nullptr, CODE_SIZE, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
   LogMan::Throw::A(PageMemory != -1ULL, "Failed to allocate page memory");
 
   // L1 Cache
-  L1Pointer = reinterpret_cast<uintptr_t>(mmap(nullptr, L1_SIZE, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+  L1Pointer = reinterpret_cast<uintptr_t>(FEXCore::Allocator::mmap(nullptr, L1_SIZE, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
   LogMan::Throw::A(L1Pointer != -1ULL, "Failed to allocate L1Pointer");
 
   VirtualMemSize = ctx->Config.VirtualMemSize;
 }
 
 LookupCache::~LookupCache() {
-  munmap(reinterpret_cast<void*>(PagePointer), ctx->Config.VirtualMemSize / 4096 * 8);
-  munmap(reinterpret_cast<void*>(PageMemory), CODE_SIZE);
-  munmap(reinterpret_cast<void*>(L1Pointer), L1_SIZE);
+  FEXCore::Allocator::munmap(reinterpret_cast<void*>(PagePointer), ctx->Config.VirtualMemSize / 4096 * 8);
+  FEXCore::Allocator::munmap(reinterpret_cast<void*>(PageMemory), CODE_SIZE);
+  FEXCore::Allocator::munmap(reinterpret_cast<void*>(L1Pointer), L1_SIZE);
 }
 
 void LookupCache::HintUsedRange(uint64_t Address, uint64_t Size) {

--- a/External/FEXCore/Source/Utils/Allocator.cpp
+++ b/External/FEXCore/Source/Utils/Allocator.cpp
@@ -1,0 +1,7 @@
+#include <FEXCore/Utils/Allocator.h>
+#include <sys/mman.h>
+
+namespace FEXCore::Allocator {
+  MMAP_Hook mmap {::mmap};
+  MUNMAP_Hook munmap {::munmap};
+}

--- a/External/FEXCore/Source/Utils/ELFSymbolDatabase.cpp
+++ b/External/FEXCore/Source/Utils/ELFSymbolDatabase.cpp
@@ -6,6 +6,7 @@ $end_info$
 */
 
 #include <FEXCore/Utils/ELFSymbolDatabase.h>
+#include <FEXCore/Utils/Allocator.h>
 #include <FEXCore/Utils/LogManager.h>
 #include <FEXCore/Utils/Common/MathUtils.h>
 
@@ -110,7 +111,7 @@ ELFSymbolDatabase::ELFSymbolDatabase(::ELFLoader::ELFContainer *file)
   FillSymbols();
 
   if (LocalInfo.Container->WasDynamic() && File->GetMode() == ELFContainer::MODE_64BIT) {
-    ELFBase = mmap(nullptr, ELFMemorySize, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    ELFBase = FEXCore::Allocator::mmap(nullptr, ELFMemorySize, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
     FillMemoryLayouts(reinterpret_cast<uintptr_t>(ELFBase));
     FillInitializationOrder();
     FillSymbols();
@@ -121,7 +122,7 @@ ELFSymbolDatabase::ELFSymbolDatabase(::ELFLoader::ELFContainer *file)
 
 ELFSymbolDatabase::~ELFSymbolDatabase() {
   if (ELFBase) {
-    munmap(ELFBase, ELFMemorySize);
+    FEXCore::Allocator::munmap(ELFBase, ELFMemorySize);
     ELFBase = nullptr;
   }
 }

--- a/External/FEXCore/include/FEXCore/Utils/Allocator.h
+++ b/External/FEXCore/include/FEXCore/Utils/Allocator.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+
+namespace FEXCore::Allocator {
+  using MMAP_Hook = std::function<void*(void*, size_t, int, int, int, off_t)>;
+  using MUNMAP_Hook = std::function<int(void*, size_t)>;
+
+  __attribute__((visibility("default"))) extern MMAP_Hook mmap;
+  __attribute__((visibility("default"))) extern MUNMAP_Hook munmap;
+}

--- a/Source/Tests/ELFCodeLoader.h
+++ b/Source/Tests/ELFCodeLoader.h
@@ -13,6 +13,7 @@
 #include <FEXCore/Core/CodeLoader.h>
 #include <FEXCore/Core/CoreState.h>
 #include <FEXCore/Core/X86Enums.h>
+#include <FEXCore/Utils/Allocator.h>
 #include <FEXCore/Utils/LogManager.h>
 #include <FEXCore/Utils/ELFContainer.h>
 #include <FEXCore/Utils/ELFSymbolDatabase.h>
@@ -194,10 +195,10 @@ public:
   uint64_t GetStackPointer() override {
     uintptr_t StackPointer{};
     if (File.GetMode() == ::ELFLoader::ELFContainer::MODE_64BIT) {
-      StackPointer = reinterpret_cast<uintptr_t>(mmap(nullptr, StackSize(), PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+      StackPointer = reinterpret_cast<uintptr_t>(FEXCore::Allocator::mmap(nullptr, StackSize(), PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
     }
     else {
-      StackPointer = reinterpret_cast<uintptr_t>(mmap(reinterpret_cast<void*>(STACK_OFFSET), StackSize(), PROT_READ | PROT_WRITE, MAP_FIXED_NOREPLACE | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+      StackPointer = reinterpret_cast<uintptr_t>(FEXCore::Allocator::mmap(reinterpret_cast<void*>(STACK_OFFSET), StackSize(), PROT_READ | PROT_WRITE, MAP_FIXED_NOREPLACE | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
       LogMan::Throw::A(StackPointer != ~0ULL, "mmap failed");
     }
 

--- a/Source/Tests/HarnessHelpers.h
+++ b/Source/Tests/HarnessHelpers.h
@@ -13,6 +13,7 @@
 #include <FEXCore/Core/CodeLoader.h>
 #include <FEXCore/Core/CoreState.h>
 #include <FEXCore/Core/X86Enums.h>
+#include <FEXCore/Utils/Allocator.h>
 #include <FEXCore/Utils/LogManager.h>
 #include <FEXCore/Utils/ELFContainer.h>
 #include <FEXCore/Utils/ELFSymbolDatabase.h>
@@ -351,10 +352,10 @@ namespace FEX::HarnessHelper {
 
     uint64_t GetStackPointer() override {
       if (Config.Is64BitMode()) {
-        return reinterpret_cast<uint64_t>(mmap(nullptr, STACK_SIZE, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0)) + STACK_SIZE;
+        return reinterpret_cast<uint64_t>(FEXCore::Allocator::mmap(nullptr, STACK_SIZE, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0)) + STACK_SIZE;
       }
       else {
-        uint64_t Result = reinterpret_cast<uint64_t>(mmap(reinterpret_cast<void*>(STACK_OFFSET), STACK_SIZE, PROT_READ | PROT_WRITE, MAP_FIXED_NOREPLACE | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+        uint64_t Result = reinterpret_cast<uint64_t>(FEXCore::Allocator::mmap(reinterpret_cast<void*>(STACK_OFFSET), STACK_SIZE, PROT_READ | PROT_WRITE, MAP_FIXED_NOREPLACE | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
         LogMan::Throw::A(Result != ~0ULL, "mmap failed");
         return Result + STACK_SIZE;
       }
@@ -367,7 +368,7 @@ namespace FEX::HarnessHelper {
     bool MapMemory(std::function<void *(void *addr, size_t length, int prot, int flags, int fd, off_t offset)> Mapper, std::function<int(void *addr, size_t length)> Unmapper) override {
       bool LimitedSize = true;
       auto DoMMap = [](uint64_t Address, size_t Size) -> void* {
-        void *Result = mmap(reinterpret_cast<void*>(Address), Size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        void *Result = FEXCore::Allocator::mmap(reinterpret_cast<void*>(Address), Size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
         LogMan::Throw::A(Result == reinterpret_cast<void*>(Address), "mmap failed");
         return Result;
       };

--- a/Source/Tests/IRLoader.cpp
+++ b/Source/Tests/IRLoader.cpp
@@ -16,6 +16,7 @@ $end_info$
 #include <FEXCore/Config/Config.h>
 #include <FEXCore/Core/CodeLoader.h>
 #include <FEXCore/Core/Context.h>
+#include <FEXCore/Utils/Allocator.h>
 #include <FEXCore/Utils/LogManager.h>
 
 void MsgHandler(LogMan::DebugLevels Level, char const *Message)
@@ -75,7 +76,7 @@ public:
 
   uint64_t GetStackPointer() override
   {
-    return reinterpret_cast<uint64_t>(mmap(nullptr, STACK_SIZE, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+    return reinterpret_cast<uint64_t>(FEXCore::Allocator::mmap(nullptr, STACK_SIZE, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
   }
 
   uint64_t DefaultRIP() const override

--- a/Source/Tests/IRLoader/Loader.h
+++ b/Source/Tests/IRLoader/Loader.h
@@ -5,6 +5,7 @@
 
 #include "HarnessHelpers.h"
 
+#include <FEXCore/Utils/Allocator.h>
 #include <FEXCore/Utils/LogManager.h>
 
 #include <string>
@@ -31,7 +32,7 @@ namespace FEX::IRLoader {
 
       void MapRegions() {
         for (auto& [region, size] : Config.GetMemoryRegions()) {
-          mmap(reinterpret_cast<void*>(region), size, PROT_READ | PROT_WRITE, MAP_FIXED | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+          FEXCore::Allocator::mmap(reinterpret_cast<void*>(region), size, PROT_READ | PROT_WRITE, MAP_FIXED | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
         }
       }
 

--- a/Source/Tests/LinuxSyscalls/x64/Memory.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Memory.cpp
@@ -16,6 +16,7 @@ $end_info$
 
 #include <FEXCore/Core/Context.h>
 #include <FEXCore/Config/Config.h>
+#include <FEXCore/Utils/Allocator.h>
 #include <fstream>
 #include <filesystem>
 
@@ -28,7 +29,7 @@ static std::string get_fdpath(int fd)
 namespace FEX::HLE::x64 {
   void RegisterMemory() {
     REGISTER_SYSCALL_IMPL_X64(munmap, [](FEXCore::Core::CpuStateFrame *Frame, void *addr, size_t length) -> uint64_t {
-      uint64_t Result = ::munmap(addr, length);
+      uint64_t Result = FEXCore::Allocator::munmap(addr, length);
 
       auto Thread = Frame->Thread;
       if (Result != -1) {
@@ -40,7 +41,7 @@ namespace FEX::HLE::x64 {
 
     REGISTER_SYSCALL_IMPL_X64(mmap, [](FEXCore::Core::CpuStateFrame *Frame, void *addr, size_t length, int prot, int flags, int fd, off_t offset) -> uint64_t {
       static FEX_CONFIG_OPT(AOTIRLoad, AOTIRLOAD);
-      uint64_t Result = reinterpret_cast<uint64_t>(::mmap(addr, length, prot, flags, fd, offset));
+      uint64_t Result = reinterpret_cast<uint64_t>(FEXCore::Allocator::mmap(addr, length, prot, flags, fd, offset));
 
       auto Thread = Frame->Thread;
       if (Result != -1) {

--- a/Source/Tests/TestHarnessRunner.cpp
+++ b/Source/Tests/TestHarnessRunner.cpp
@@ -21,6 +21,7 @@ $end_info$
 #include <FEXCore/Core/X86Enums.h>
 #include <FEXCore/HLE/SyscallHandler.h>
 #include <FEXCore/Debug/InternalThreadState.h>
+#include <FEXCore/Utils/Allocator.h>
 #include <FEXCore/Utils/LogManager.h>
 
 #include <cassert>
@@ -85,12 +86,12 @@ int main(int argc, char **argv, char **const envp) {
 
   if (Loader.Is64BitMode()) {
     if (!Loader.MapMemory([](void *addr, size_t length, int prot, int flags, int fd, off_t offset) {
-      return mmap(addr, length, prot, flags, fd, offset);
+      return FEXCore::Allocator::mmap(addr, length, prot, flags, fd, offset);
     }, [](void *addr, size_t length) {
-      return munmap(addr, length);
+      return FEXCore::Allocator::munmap(addr, length);
     })) {
       // failed to map
-      return -ENOEXEC; 
+      return -ENOEXEC;
     }
   } else {
     Allocator = new FEX::HLE::x32::MemAllocator();
@@ -100,7 +101,7 @@ int main(int argc, char **argv, char **const envp) {
       return Allocator->munmap(addr, length);
     })) {
       // failed to map
-      return -ENOEXEC; 
+      return -ENOEXEC;
     }
   }
 


### PR DESCRIPTION
This removes all usage of naked mman usage for mmap and munmap.

The only behaviour change is that the X86Dispatcher now uses its own allocator rather than allowing xbyak to allocate its own memory regions.

This is a precursor change required before we can implement our own global memory allocator.