### PR TITLE
AOTIR: Switch over to mmap-based loading

### DIFF
--- a/External/FEXCore/Source/Interface/Context/Context.cpp
+++ b/External/FEXCore/Source/Interface/Context/Context.cpp
@@ -142,7 +142,7 @@ namespace FEXCore::Context {
     return CTX->CPUID.RunFunction(Function, Leaf);
   }
 
-  void SetAOTIRLoader(FEXCore::Context::Context *CTX, std::function<std::unique_ptr<std::istream>(const std::string&)> CacheReader) {
+  void SetAOTIRLoader(FEXCore::Context::Context *CTX, std::function<int(const std::string&)> CacheReader) {
     CTX->AOTIRLoader = CacheReader;
   }
 

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -30,6 +30,7 @@ $end_info$
 #include <FEXCore/HLE/SyscallHandler.h>
 
 #include "Interface/HLE/Thunks/Thunks.h"
+#include "FEXCore/Utils/Allocator.h"
 
 #include <xxh3.h>
 #include <fstream>
@@ -184,7 +185,7 @@ namespace FEXCore::Context {
     }
 
     for (auto &Mod: AOTIRCache) {
-      munmap(Mod.second.mapping, Mod.second.size);
+      FEXCore::Allocator::munmap(Mod.second.mapping, Mod.second.size);
     }
   }
 
@@ -937,7 +938,7 @@ namespace FEXCore::Context {
       return false;
     size_t Size = (fileinfo.st_size + 4095) & ~4095;
 
-    void *FilePtr = mmap(nullptr, Size, PROT_READ | PROT_WRITE, MAP_PRIVATE, streamfd, 0);
+    void *FilePtr = FEXCore::Allocator::mmap(nullptr, Size, PROT_READ, MAP_SHARED, streamfd, 0);
 
     if (FilePtr == MAP_FAILED)
       return false;

--- a/External/FEXCore/include/FEXCore/Core/Context.h
+++ b/External/FEXCore/include/FEXCore/Core/Context.h
@@ -226,7 +226,7 @@ namespace FEXCore::Context {
 
   __attribute__((visibility("default"))) void AddNamedRegion(FEXCore::Context::Context *CTX, uintptr_t Base, uintptr_t Length, uintptr_t Offset, const std::string& Name);
   __attribute__((visibility("default"))) void RemoveNamedRegion(FEXCore::Context::Context *CTX, uintptr_t Base, uintptr_t Length);
-  __attribute__((visibility("default"))) void SetAOTIRLoader(FEXCore::Context::Context *CTX, std::function<std::unique_ptr<std::istream>(const std::string&)> CacheReader);
+  __attribute__((visibility("default"))) void SetAOTIRLoader(FEXCore::Context::Context *CTX, std::function<int(const std::string&)> CacheReader);
   __attribute__((visibility("default"))) bool WriteAOTIR(FEXCore::Context::Context *CTX, std::function<std::unique_ptr<std::ostream>(const std::string&)> CacheWriter);
   __attribute__((visibility("default"))) void FlushCodeRange(FEXCore::Core::InternalThreadState *Thread, uint64_t Start, uint64_t Length);
 }

--- a/Source/Tests/FEXLoader.cpp
+++ b/Source/Tests/FEXLoader.cpp
@@ -320,10 +320,10 @@ int main(int argc, char **argv, char **const envp) {
     LogMan::Msg::I("Warning: AOTIR is experimental, and might lead to crashes. Capture doesn't work with programs that fork.");
   }
 
-  FEXCore::Context::SetAOTIRLoader(CTX, [](const std::string &fileid) -> std::unique_ptr<std::istream> {
+  FEXCore::Context::SetAOTIRLoader(CTX, [](const std::string &fileid) -> int {
     auto filepath = std::filesystem::path(FEXCore::Config::GetDataDirectory()) / "aotir" / fileid;
 
-    return std::make_unique<std::ifstream>(filepath, std::ios::in | std::ios::binary);
+    return open(filepath.c_str(), O_RDONLY);
   });
 
   for(auto handler: Loader.AOTMappers) {


### PR DESCRIPTION
## Overview

This updates the file format and the in memory structures so we can mmap the IRData and RAData from the file, instead of having to read it. This also introduces a sorted array for binary searching the file, which can also be mmap'd.

This makes it possible to load AOTIR files very quickly, and in fairly constant time. It effectivelly can pull a few fragments from a huge (6GB+ tested) aotir file without taking 2 seconds to load.

