### PR TITLE
Changes LogMan assert to defines

### DIFF
--- a/External/FEXCore/Scripts/json_ir_generator.py
+++ b/External/FEXCore/Scripts/json_ir_generator.py
@@ -308,7 +308,7 @@ def print_ir_allocator_helpers(ops, defines):
 
     output_file.write("\tuint8_t GetOpElements(OrderedNode *Op) const {\n")
     output_file.write("\t\tauto HeaderOp = Op->Header.Value.GetNode(Data.Begin());\n")
-    output_file.write("\t\tLogMan::Throw::A(HeaderOp->HasDest, \"Op %s has no dest\\n\", GetName(HeaderOp->Op));\n")
+    output_file.write("\t\tLOGMAN_THROW_A(HeaderOp->HasDest, \"Op %s has no dest\\n\", GetName(HeaderOp->Op));\n")
     output_file.write("\t\treturn HeaderOp->Size / HeaderOp->ElementSize;\n")
     output_file.write("\t}\n\n")
 

--- a/External/FEXCore/Scripts/json_ir_generator.py
+++ b/External/FEXCore/Scripts/json_ir_generator.py
@@ -108,10 +108,10 @@ def print_ir_sizes(ops, defines):
 
     output_file.write("[[maybe_unused]] static size_t GetSize(IROps Op) { return IRSizes[Op]; }\n\n")
 
-    output_file.write("__attribute__((visibility(\"default\"))) std::string_view const& GetName(IROps Op);\n")
-    output_file.write("__attribute__((visibility(\"default\"))) uint8_t GetArgs(IROps Op);\n")
-    output_file.write("__attribute__((visibility(\"default\"))) FEXCore::IR::RegisterClassType GetRegClass(IROps Op);\n\n")
-    output_file.write("__attribute__((visibility(\"default\"))) bool HasSideEffects(IROps Op);\n")
+    output_file.write("__attribute__((const)) __attribute__((visibility(\"default\"))) std::string_view const& GetName(IROps Op);\n")
+    output_file.write("__attribute__((const)) __attribute__((visibility(\"default\"))) uint8_t GetArgs(IROps Op);\n")
+    output_file.write("__attribute__((const)) __attribute__((visibility(\"default\"))) FEXCore::IR::RegisterClassType GetRegClass(IROps Op);\n\n")
+    output_file.write("__attribute__((const)) __attribute__((visibility(\"default\"))) bool HasSideEffects(IROps Op);\n")
 
     output_file.write("#undef IROP_SIZES\n")
     output_file.write("#endif\n\n")

--- a/External/FEXCore/Source/Common/BitSet.h
+++ b/External/FEXCore/Source/Common/BitSet.h
@@ -16,12 +16,12 @@ struct BitSet final {
   ElementType *Memory;
   void Allocate(size_t Elements) {
     size_t AllocateSize = AlignUp(Elements, MinimumSizeBits) / MinimumSize;
-    LogMan::Throw::A((AllocateSize * MinimumSize) >= Elements, "Fail");
+    LOGMAN_THROW_A((AllocateSize * MinimumSize) >= Elements, "Fail");
     Memory = static_cast<ElementType*>(malloc(AllocateSize));
   }
   void Realloc(size_t Elements) {
     size_t AllocateSize = AlignUp(Elements, MinimumSizeBits) / MinimumSize;
-    LogMan::Throw::A((AllocateSize * MinimumSize) >= Elements, "Fail");
+    LOGMAN_THROW_A((AllocateSize * MinimumSize) >= Elements, "Fail");
     Memory = static_cast<ElementType*>(realloc(Memory, AllocateSize));
   }
   void Free() {
@@ -60,7 +60,7 @@ struct BitSetView final {
   ElementType *Memory;
 
   void GetView(BitSet<T> &Set, uint64_t ElementOffset) {
-    LogMan::Throw::A((ElementOffset % MinimumSize) == 0,
+    LOGMAN_THROW_A((ElementOffset % MinimumSize) == 0,
         "Bitset view offset needs to be aligned to size of backing element");
     Memory = &Set.Memory[ElementOffset / MinimumSizeBits];
   }

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/MContext.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/MContext.h
@@ -111,7 +111,7 @@ static inline void BackupContext(void* ucontext, T *Backup) {
 
     // Host FPR state starts at _mcontext->reserved[0];
     HostFPRState *HostState = reinterpret_cast<HostFPRState*>(&_mcontext->__reserved[0]);
-    LogMan::Throw::A(HostState->Head.Magic == FPR_MAGIC, "Wrong FPR Magic: 0x%08x", HostState->Head.Magic);
+    LOGMAN_THROW_A(HostState->Head.Magic == FPR_MAGIC, "Wrong FPR Magic: 0x%08x", HostState->Head.Magic);
     Backup->FPSR = HostState->FPSR;
     Backup->FPCR = HostState->FPCR;
     memcpy(&Backup->FPRs[0], &HostState->FPRs[0], 32 * sizeof(__uint128_t));
@@ -126,7 +126,7 @@ static inline void RestoreContext(void* ucontext, T *Backup) {
    auto _mcontext = GetMContext(ucontext);
 
     HostFPRState *HostState = reinterpret_cast<HostFPRState*>(&_mcontext->__reserved[0]);
-    LogMan::Throw::A(HostState->Head.Magic == FPR_MAGIC, "Wrong FPR Magic: 0x%08x", HostState->Head.Magic);
+    LOGMAN_THROW_A(HostState->Head.Magic == FPR_MAGIC, "Wrong FPR Magic: 0x%08x", HostState->Head.Magic);
     memcpy(&HostState->FPRs[0], &Backup->FPRs[0], 32 * sizeof(__uint128_t));
     HostState->FPCR = Backup->FPCR;
     HostState->FPSR = Backup->FPSR;

--- a/External/FEXCore/Source/Interface/Core/CompileService.cpp
+++ b/External/FEXCore/Source/Interface/Core/CompileService.cpp
@@ -61,7 +61,7 @@ namespace FEXCore {
         }
       }
 
-      LogMan::Throw::A(CompileThreadData->LocalIRCache.size() == 0, "Compile service must never have LocalIRCache");
+      LOGMAN_THROW_A(CompileThreadData->LocalIRCache.size() == 0, "Compile service must never have LocalIRCache");
 
       CompileMutex.unlock();
     }
@@ -124,7 +124,7 @@ namespace FEXCore {
         // If we had a work item then work on it
         if (Item) {
           // Make sure it's not in lookup cache by accident
-          LogMan::Throw::A(CompileThreadData->LookupCache->FindBlock(Item->RIP) == 0, "Compile Service must never have entries in the LookupCache");
+          LOGMAN_THROW_A(CompileThreadData->LookupCache->FindBlock(Item->RIP) == 0, "Compile Service must never have entries in the LookupCache");
 
           // Code isn't in cache, compile now
           // Set our thread state's RIP
@@ -132,7 +132,7 @@ namespace FEXCore {
 
           auto [CodePtr, IRList, DebugData, RAData, Generated, StartAddr, Length] = CTX->CompileCode(CompileThreadData.get(), Item->RIP);
 
-          LogMan::Throw::A(Generated == true, "Compile Service doesn't have IR Cache");
+          LOGMAN_THROW_A(Generated == true, "Compile Service doesn't have IR Cache");
 
           if (!CodePtr) {
             // XXX: We currently have the expectation that compile service code will be significantly smaller than regular thread's code

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -523,7 +523,7 @@ namespace FEXCore::Context {
       std::lock_guard<std::mutex> lk(ThreadCreationMutex);
 
       auto It = std::find(Threads.begin(), Threads.end(), Thread);
-      LogMan::Throw::A(It != Threads.end(), "Thread wasn't in Threads");
+      LOGMAN_THROW_A(It != Threads.end(), "Thread wasn't in Threads");
 
       Threads.erase(It);
     }
@@ -662,7 +662,7 @@ namespace FEXCore::Context {
             HadDispatchError = true;
           }
           else {
-            LogMan::Throw::A(Thread->OpDispatcher->HandledLock == IsLocked, "Missing LOCK HANDLER at 0x%lx{'%s'}\n", Block.Entry + BlockInstructionsLength, TableInfo->Name);
+            LOGMAN_THROW_A(Thread->OpDispatcher->HandledLock == IsLocked, "Missing LOCK HANDLER at 0x%lx{'%s'}\n", Block.Entry + BlockInstructionsLength, TableInfo->Name);
             BlockInstructionsLength += DecodedInfo->InstSize;
             TotalInstructionsLength += DecodedInfo->InstSize;
             ++TotalInstructions;
@@ -741,7 +741,7 @@ namespace FEXCore::Context {
       out.seekg(0);
       auto reparsed = IR::Parse(&out);
       if (reparsed == nullptr) {
-        LogMan::Msg::A("Failed to parse ir\n");
+        LOGMAN_MSG_A("Failed to parse ir\n");
       } else {
         std::stringstream out2;
         auto NewIR2 = reparsed->ViewIR();
@@ -749,7 +749,7 @@ namespace FEXCore::Context {
         if (out.str() != out2.str()) {
           LogMan::Msg::I("one:\n %s", out.str().c_str());
           LogMan::Msg::I("two:\n %s", out2.str().c_str());
-          LogMan::Msg::A("Parsed ir doesn't match\n");
+          LOGMAN_MSG_A("Parsed ir doesn't match\n");
         }
         delete reparsed;
       }
@@ -1035,7 +1035,7 @@ namespace FEXCore::Context {
       Length = _Length;
     }
 
-    LogMan::Throw::A(CodePtr != nullptr, "Failed to compile code %lX", GuestRIP);
+    LOGMAN_THROW_A(CodePtr != nullptr, "Failed to compile code %lX", GuestRIP);
 
     // The core managed to compile the code.
 #if ENABLE_JITSYMBOLS

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
@@ -108,7 +108,7 @@ bool Dispatcher::HandleGuestSignal(int Signal, void *info, void *ucontext, Guest
   if (GuestAction->sa_flags & SA_SIGINFO) {
     if (SRAEnabled) {
       if (!IsAddressInJITCode(ArchHelpers::Context::GetPc(ucontext), false)) {
-        LogMan::Throw::A(!IsAddressInJITCode(ArchHelpers::Context::GetPc(ucontext), true), "Signals in dispatcher have unsynchronized context");
+        LOGMAN_THROW_A(!IsAddressInJITCode(ArchHelpers::Context::GetPc(ucontext), true), "Signals in dispatcher have unsynchronized context");
       } else {
         // We are in jit, SRA must be spilled
         SpillSRA(ucontext);
@@ -220,7 +220,7 @@ bool Dispatcher::HandleGuestSignal(int Signal, void *info, void *ucontext, Guest
   else {
     NewGuestSP -= 4;
     *(uint32_t*)NewGuestSP = CTX->X86CodeGen.SignalReturn;
-    LogMan::Throw::A(CTX->X86CodeGen.SignalReturn < 0x1'0000'0000ULL, "This needs to be below 4GB");
+    LOGMAN_THROW_A(CTX->X86CodeGen.SignalReturn < 0x1'0000'0000ULL, "This needs to be below 4GB");
     Frame->State.gregs[X86State::REG_RSP] = NewGuestSP;
   }
 
@@ -264,7 +264,7 @@ bool Dispatcher::HandleSignalPause(int Signal, void *info, void *ucontext) {
     } else {
       if (SRAEnabled) {
         // We are in non-jit, SRA is already spilled
-        LogMan::Throw::A(!IsAddressInJITCode(ArchHelpers::Context::GetPc(ucontext), true), "Signals in dispatcher have unsynchronized context");
+        LOGMAN_THROW_A(!IsAddressInJITCode(ArchHelpers::Context::GetPc(ucontext), true), "Signals in dispatcher have unsynchronized context");
       }
       ArchHelpers::Context::SetPc(ucontext, ThreadPauseHandlerAddress);
     }
@@ -299,7 +299,7 @@ bool Dispatcher::HandleSignalPause(int Signal, void *info, void *ucontext) {
     } else {
       if (SRAEnabled) {
         // We are in non-jit, SRA is already spilled
-        LogMan::Throw::A(!IsAddressInJITCode(ArchHelpers::Context::GetPc(ucontext), true), "Signals in dispatcher have unsynchronized context");
+        LOGMAN_THROW_A(!IsAddressInJITCode(ArchHelpers::Context::GetPc(ucontext), true), "Signals in dispatcher have unsynchronized context");
       }
       ArchHelpers::Context::SetPc(ucontext, ThreadStopHandlerAddress);
     }

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -376,7 +376,7 @@ bool IsConditionTrue(uint8_t Cond, uint64_t Src1, uint64_t Src2) {
     case FEXCore::IR::COND_VS:
     case FEXCore::IR::COND_VC:
     default:
-      LogMan::Msg::A("Unsupported compare type");
+      LOGMAN_MSG_A("Unsupported compare type");
       break;
   }
 
@@ -399,7 +399,7 @@ Res GetSrc(void* SSAData, IR::OrderedNodeWrapper Src) {
 static void StopThread(FEXCore::Core::InternalThreadState *Thread) {
   Thread->CTX->StopThread(Thread);
 
-  LogMan::Msg::A("unreachable");
+  LOGMAN_MSG_A("unreachable");
   __builtin_unreachable();
 }
 
@@ -407,7 +407,7 @@ static void StopThread(FEXCore::Core::InternalThreadState *Thread) {
 static void SignalReturn(FEXCore::Core::InternalThreadState *Thread) {
   Thread->CTX->SignalThread(Thread, FEXCore::Core::SIGNALEVENT_RETURN);
 
-  LogMan::Msg::A("unreachable");
+  LOGMAN_MSG_A("unreachable");
   __builtin_unreachable();
 }
 
@@ -711,7 +711,7 @@ struct OpHandlers<IR::OP_F80LOADFCW> {
       case 0: extF80_roundingPrecision = 32; break;
       case 2: extF80_roundingPrecision = 64; break;
       case 3: extF80_roundingPrecision = 80; break;
-      case 1: LogMan::Msg::A("Invalid x87 precision mode, %d", PC);
+      case 1: LOGMAN_MSG_A("Invalid x87 precision mode, %d", PC);
     }
 
     auto RC = (NewFCW >> 10) & 3;
@@ -959,7 +959,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
     using namespace FEXCore::IR;
     auto [BlockNode, BlockHeader] = BlockIterator();
     auto BlockIROp = BlockHeader->CW<IROp_CodeBlock>();
-    LogMan::Throw::A(BlockIROp->Header.Op == IR::OP_CODEBLOCK, "IR type failed to be a code block");
+    LOGMAN_THROW_A(BlockIROp->Header.Op == IR::OP_CODEBLOCK, "IR type failed to be a code block");
 
     // We grab these nodes this way so we can iterate easily
     auto CodeBegin = CurrentIR->at(BlockIROp->Begin);
@@ -1009,7 +1009,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               case IR::Fence_Store.Val:
                 std::atomic_thread_fence(std::memory_order_release);
                 break;
-              default: LogMan::Msg::A("Unknown Fence: %d", Op->Fence); break;
+              default: LOGMAN_MSG_A("Unknown Fence: %d", Op->Fence); break;
             }
             break;
           }
@@ -1061,7 +1061,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               case 4: // HLT
                 StopThread(Thread);
               break;
-            default: LogMan::Msg::A("Unknown Break Reason: %d", Op->Reason); break;
+            default: LOGMAN_MSG_A("Unknown Break Reason: %d", Op->Reason); break;
             }
             break;
           }
@@ -1118,7 +1118,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               LogMan::Msg::I("     Value[1] in Arg: 0x%lx, %ld", Src1, Src1);
             }
             else
-              LogMan::Msg::A("Unknown value size: %d", OpSize);
+              LOGMAN_MSG_A("Unknown value size: %d", OpSize);
             break;
           }
           case IR::OP_CYCLECOUNTER: {
@@ -1150,7 +1150,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             auto Op = IROp->C<IR::IROp_VExtractToGPR>();
             uint32_t SourceSize = GetOpSize(Op->Header.Args[0]);
 
-            LogMan::Throw::A(OpSize <= 16, "OpSize is too large for VExtractToGPR: %d", OpSize);
+            LOGMAN_THROW_A(OpSize <= 16, "OpSize is too large for VExtractToGPR: %d", OpSize);
 
             if (SourceSize == 16) {
               __uint128_t SourceMask = (1ULL << (Op->Header.ElementSize * 8)) - 1;
@@ -1179,7 +1179,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
           case IR::OP_VEXTRACTELEMENT: {
             auto Op = IROp->C<IR::IROp_VExtractElement>();
             uint32_t SourceSize = GetOpSize(Op->Header.Args[0]);
-            LogMan::Throw::A(OpSize <= 16, "OpSize is too large for VExtractToGPR: %d", OpSize);
+            LOGMAN_THROW_A(OpSize <= 16, "OpSize is too large for VExtractToGPR: %d", OpSize);
             if (SourceSize == 16) {
               __uint128_t SourceMask = (1ULL << (Op->Header.ElementSize * 8)) - 1;
               uint64_t Shift = Op->Header.ElementSize * Op->Index * 8;
@@ -1240,7 +1240,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 memcpy(GDP, Data, OpSize);
                 break;
               }
-              default:  LogMan::Msg::A("Unhandled LoadContext size: %d", OpSize);
+              default:  LOGMAN_MSG_A("Unhandled LoadContext size: %d", OpSize);
             }
             #undef LOAD_CTX
             break;
@@ -1270,7 +1270,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 memcpy(GDP, Data, Op->Size);
                 break;
               }
-              default:  LogMan::Msg::A("Unhandled LoadContextIndexed size: %d", Op->Size);
+              default:  LOGMAN_MSG_A("Unhandled LoadContextIndexed size: %d", Op->Size);
             }
             #undef LOAD_CTX
             break;
@@ -1344,7 +1344,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 memcpy(GDP, Result ? &Src1 : &Expected, 16);
                 break;
               }
-              default: LogMan::Msg::A("Unknown CAS size: %d", Size); break;
+              default: LOGMAN_MSG_A("Unknown CAS size: %d", Size); break;
             }
             break;
           }
@@ -1360,7 +1360,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 GD = Result;
                 break;
               }
-              default: LogMan::Msg::A("Unhandled Truncation size: %d", Op->Size); break;
+              default: LOGMAN_MSG_A("Unhandled Truncation size: %d", Op->Size); break;
             }
             break;
           }
@@ -1445,7 +1445,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               STORE_DATA(2, uint16_t)
               STORE_DATA(4, uint32_t)
               STORE_DATA(8, uint64_t)
-              default: LogMan::Msg::A("Unhandled StoreMem size"); break;
+              default: LOGMAN_MSG_A("Unhandled StoreMem size"); break;
             }
             #undef STORE_DATA
             break;
@@ -1468,7 +1468,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (OpSize) {
               DO_OP(4, uint32_t, Func)
               DO_OP(8, uint64_t, Func)
-              default: LogMan::Msg::A("Unknown Size: %d", OpSize); break;
+              default: LOGMAN_MSG_A("Unknown Size: %d", OpSize); break;
             }
             break;
           }
@@ -1481,7 +1481,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (OpSize) {
               DO_OP(4, uint32_t, Func)
               DO_OP(8, uint64_t, Func)
-              default: LogMan::Msg::A("Unknown Size: %d", OpSize); break;
+              default: LOGMAN_MSG_A("Unknown Size: %d", OpSize); break;
             }
             break;
           }
@@ -1495,7 +1495,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               case 8:
                 GD = -static_cast<int64_t>(Src);
                 break;
-              default: LogMan::Msg::A("Unknown NEG Size: %d\n", OpSize); break;
+              default: LOGMAN_MSG_A("Unknown NEG Size: %d\n", OpSize); break;
             };
             break;
           }
@@ -1511,7 +1511,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_OP(4, uint32_t, Func)
               DO_OP(8, uint64_t, Func)
               DO_OP(16, __uint128_t, Func)
-              default: LogMan::Msg::A("Unknown Size: %d", OpSize); break;
+              default: LOGMAN_MSG_A("Unknown Size: %d", OpSize); break;
             }
             break;
           }
@@ -1526,7 +1526,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_OP(2, uint16_t, Func)
               DO_OP(4, uint32_t, Func)
               DO_OP(8, uint64_t, Func)
-              default: LogMan::Msg::A("Unknown Size: %d", OpSize); break;
+              default: LOGMAN_MSG_A("Unknown Size: %d", OpSize); break;
             }
             break;
           }
@@ -1541,7 +1541,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_OP(2, uint16_t, Func)
               DO_OP(4, uint32_t, Func)
               DO_OP(8, uint64_t, Func)
-              default: LogMan::Msg::A("Unknown Size: %d", OpSize); break;
+              default: LOGMAN_MSG_A("Unknown Size: %d", OpSize); break;
             }
             break;
           }
@@ -1557,7 +1557,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               case 8:
                 GD = static_cast<int64_t>(Src1) << (Src2 & Mask);
                 break;
-              default: LogMan::Msg::A("Unknown LSHL Size: %d\n", OpSize); break;
+              default: LOGMAN_MSG_A("Unknown LSHL Size: %d\n", OpSize); break;
             };
             break;
           }
@@ -1573,7 +1573,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               case 8:
                 GD = static_cast<uint64_t>(Src1) >> (Src2 & Mask);
                 break;
-              default: LogMan::Msg::A("Unknown LSHR Size: %d\n", OpSize); break;
+              default: LOGMAN_MSG_A("Unknown LSHR Size: %d\n", OpSize); break;
             };
             break;
           }
@@ -1589,7 +1589,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               case 8:
                 GD = (uint64_t)(static_cast<int64_t>(Src1) >> (Src2 & Mask));
                 break;
-              default: LogMan::Msg::A("Unknown ASHR Size: %d\n", OpSize); break;
+              default: LOGMAN_MSG_A("Unknown ASHR Size: %d\n", OpSize); break;
             };
             break;
           }
@@ -1611,7 +1611,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 GD = Ror(static_cast<uint64_t>(Src1), static_cast<uint64_t>(Src2));
                 break;
               }
-              default: LogMan::Msg::A("Unknown ROR Size: %d\n", OpSize); break;
+              default: LOGMAN_MSG_A("Unknown ROR Size: %d\n", OpSize); break;
             }
             break;
           }
@@ -1636,7 +1636,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 GD = Extr(static_cast<uint64_t>(Src1), static_cast<uint64_t>(Src2), Op->LSB);
                 break;
               }
-              default: LogMan::Msg::A("Unknown EXTR Size: %d\n", OpSize); break;
+              default: LOGMAN_MSG_A("Unknown EXTR Size: %d\n", OpSize); break;
             }
             break;
           }
@@ -1665,7 +1665,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 memcpy(GDP, &Tmp, 16);
                 break;
               }
-              default: LogMan::Msg::A("Unknown Mul Size: %d\n", OpSize); break;
+              default: LOGMAN_MSG_A("Unknown Mul Size: %d\n", OpSize); break;
             }
             break;
           }
@@ -1685,7 +1685,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 GD = Tmp >> 64;
               }
               break;
-              default: LogMan::Msg::A("Unknown MulH Size: %d\n", OpSize); break;
+              default: LOGMAN_MSG_A("Unknown MulH Size: %d\n", OpSize); break;
             }
             break;
           }
@@ -1706,7 +1706,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 memcpy(GDP, &Tmp, 16);
                 break;
               }
-              default: LogMan::Msg::A("Unknown UMul Size: %d\n", OpSize); break;
+              default: LOGMAN_MSG_A("Unknown UMul Size: %d\n", OpSize); break;
             }
             break;
           }
@@ -1730,7 +1730,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 GD = Tmp >> 64;
                 break;
               }
-              default: LogMan::Msg::A("Unknown UMulH Size: %d\n", OpSize); break;
+              default: LOGMAN_MSG_A("Unknown UMulH Size: %d\n", OpSize); break;
             }
             break;
           }
@@ -1757,7 +1757,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 memcpy(GDP, &Tmp, 16);
                 break;
               }
-              default: LogMan::Msg::A("Unknown Mul Size: %d\n", OpSize); break;
+              default: LOGMAN_MSG_A("Unknown Mul Size: %d\n", OpSize); break;
             }
             break;
           }
@@ -1784,7 +1784,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 memcpy(GDP, &Tmp, 16);
                 break;
               }
-              default: LogMan::Msg::A("Unknown Mul Size: %d\n", OpSize); break;
+              default: LOGMAN_MSG_A("Unknown Mul Size: %d\n", OpSize); break;
             }
             break;
           }
@@ -1811,7 +1811,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 memcpy(GDP, &Tmp, 16);
                 break;
               }
-              default: LogMan::Msg::A("Unknown Mul Size: %d\n", OpSize); break;
+              default: LOGMAN_MSG_A("Unknown Mul Size: %d\n", OpSize); break;
             }
             break;
           }
@@ -1838,7 +1838,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 memcpy(GDP, &Tmp, 16);
                 break;
               }
-              default: LogMan::Msg::A("Unknown Mul Size: %d\n", OpSize); break;
+              default: LOGMAN_MSG_A("Unknown Mul Size: %d\n", OpSize); break;
             }
             break;
           }
@@ -1862,7 +1862,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               case 2: GD = ((16 + OpSize * 8) - __builtin_clz(*GetSrc<uint16_t*>(SSAData, Op->Header.Args[0]))) - 1; break;
               case 4: GD = (OpSize * 8 - __builtin_clz(*GetSrc<uint32_t*>(SSAData, Op->Header.Args[0]))) - 1; break;
               case 8: GD = (OpSize * 8 - __builtin_clzll(*GetSrc<uint64_t*>(SSAData, Op->Header.Args[0]))) - 1; break;
-              default: LogMan::Msg::A("Unknown REV size: %d", OpSize); break;
+              default: LOGMAN_MSG_A("Unknown REV size: %d", OpSize); break;
             }
             break;
           }
@@ -1872,7 +1872,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               case 2: GD = __builtin_bswap16(*GetSrc<uint16_t*>(SSAData, Op->Header.Args[0])); break;
               case 4: GD = __builtin_bswap32(*GetSrc<uint32_t*>(SSAData, Op->Header.Args[0])); break;
               case 8: GD = __builtin_bswap64(*GetSrc<uint64_t*>(SSAData, Op->Header.Args[0])); break;
-              default: LogMan::Msg::A("Unknown REV size: %d", OpSize); break;
+              default: LOGMAN_MSG_A("Unknown REV size: %d", OpSize); break;
             }
             break;
           }
@@ -1911,7 +1911,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                   GD = sizeof(Src) * 8;
                 break;
               }
-              default: LogMan::Msg::A("Unknown size: %d", OpSize); break;
+              default: LOGMAN_MSG_A("Unknown size: %d", OpSize); break;
             }
             break;
           }
@@ -1952,7 +1952,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                   GD = sizeof(Src) * 8;
                 break;
               }
-              default: LogMan::Msg::A("Unknown size: %d", OpSize); break;
+              default: LOGMAN_MSG_A("Unknown size: %d", OpSize); break;
             }
             break;
           }
@@ -1970,7 +1970,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
           }
           case IR::OP_SBFE: {
             auto Op = IROp->C<IR::IROp_Sbfe>();
-            LogMan::Throw::A(OpSize < 16, "OpSize is too large for BFE: %d", OpSize);
+            LOGMAN_THROW_A(OpSize < 16, "OpSize is too large for BFE: %d", OpSize);
             int64_t Src = *GetSrc<int64_t*>(SSAData, Op->Header.Args[0]);
             uint64_t ShiftLeftAmount = (64 - (Op->Width + Op->lsb));
             uint64_t ShiftRightAmount = ShiftLeftAmount + Op->lsb;
@@ -1981,7 +1981,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
           }
           case IR::OP_BFE: {
             auto Op = IROp->C<IR::IROp_Bfe>();
-            LogMan::Throw::A(OpSize <= 8, "OpSize is too large for BFE: %d", OpSize);
+            LOGMAN_THROW_A(OpSize <= 8, "OpSize is too large for BFE: %d", OpSize);
             uint64_t SourceMask = (1ULL << Op->Width) - 1;
             if (Op->Width == 64)
               SourceMask = ~0ULL;
@@ -2064,7 +2064,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 GD = Result ? Src1 : Expected;
                 break;
               }
-              default: LogMan::Msg::A("Unknown CAS size: %d", Size); break;
+              default: LOGMAN_MSG_A("Unknown CAS size: %d", Size); break;
             }
             break;
           }
@@ -2095,7 +2095,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 *Data += Src;
                 break;
               }
-              default:  LogMan::Msg::A("Unhandled Atomic size: %d", Op->Size);
+              default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
             }
             break;
           }
@@ -2126,7 +2126,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 *Data -= Src;
                 break;
               }
-              default:  LogMan::Msg::A("Unhandled Atomic size: %d", Op->Size);
+              default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
             }
             break;
           }
@@ -2157,7 +2157,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 *Data &= Src;
                 break;
               }
-              default:  LogMan::Msg::A("Unhandled Atomic size: %d", Op->Size);
+              default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
             }
             break;
           }
@@ -2188,7 +2188,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 *Data |= Src;
                 break;
               }
-              default:  LogMan::Msg::A("Unhandled Atomic size: %d", Op->Size);
+              default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
             }
             break;
           }
@@ -2219,7 +2219,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 *Data ^= Src;
                 break;
               }
-              default:  LogMan::Msg::A("Unhandled Atomic size: %d", Op->Size);
+              default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
             }
             break;
           }
@@ -2254,7 +2254,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 GD = Previous;
                 break;
               }
-              default:  LogMan::Msg::A("Unhandled Atomic size: %d", Op->Size);
+              default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
             }
             break;
           }
@@ -2289,7 +2289,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 GD = Previous;
                 break;
               }
-              default:  LogMan::Msg::A("Unhandled Atomic size: %d", Op->Size);
+              default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
             }
             break;
           }
@@ -2324,7 +2324,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 GD = Previous;
                 break;
               }
-              default:  LogMan::Msg::A("Unhandled Atomic size: %d", Op->Size);
+              default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
             }
             break;
           }
@@ -2359,7 +2359,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 GD = Previous;
                 break;
               }
-              default:  LogMan::Msg::A("Unhandled Atomic size: %d", Op->Size);
+              default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
             }
             break;
           }
@@ -2394,7 +2394,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 GD = Previous;
                 break;
               }
-              default:  LogMan::Msg::A("Unhandled Atomic size: %d", Op->Size);
+              default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
             }
             break;
           }
@@ -2429,14 +2429,14 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 GD = Previous;
                 break;
               }
-              default:  LogMan::Msg::A("Unhandled Atomic size: %d", Op->Size);
+              default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
             }
             break;
           }
           // Vector ops
           case IR::OP_CREATEVECTOR2: {
             auto Op = IROp->C<IR::IROp_CreateVector2>();
-            LogMan::Throw::A(OpSize <= 16, "Can't handle a vector of size: %d", OpSize);
+            LOGMAN_THROW_A(OpSize <= 16, "Can't handle a vector of size: %d", OpSize);
             void *Src1 = GetSrc<void*>(SSAData, Op->Header.Args[0]);
             void *Src2 = GetSrc<void*>(SSAData, Op->Header.Args[1]);
             uint8_t Tmp[16];
@@ -2455,7 +2455,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               CREATE_VECTOR(2, uint16_t)
               CREATE_VECTOR(4, uint32_t)
               CREATE_VECTOR(8, uint64_t)
-              default: LogMan::Msg::A("Unknown Element Size: %d", ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", ElementSize); break;
             }
             #undef CREATE_VECTOR
             memcpy(GDP, Tmp, OpSize);
@@ -2465,7 +2465,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
           case IR::OP_SPLATVECTOR4:
           case IR::OP_SPLATVECTOR2: {
             auto Op = IROp->C<IR::IROp_SplatVector2>();
-            LogMan::Throw::A(OpSize <= 16, "Can't handle a vector of size: %d", OpSize);
+            LOGMAN_THROW_A(OpSize <= 16, "Can't handle a vector of size: %d", OpSize);
             void *Src = GetSrc<void*>(SSAData, Op->Header.Args[0]);
             uint8_t Tmp[16];
             uint8_t Elements = 0;
@@ -2473,7 +2473,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (Op->Header.Op) {
               case IR::OP_SPLATVECTOR4: Elements = 4; break;
               case IR::OP_SPLATVECTOR2: Elements = 2; break;
-              default: LogMan::Msg::A("Uknown Splat size"); break;
+              default: LOGMAN_MSG_A("Uknown Splat size"); break;
             }
 
             #define CREATE_VECTOR(elementsize, type) \
@@ -2490,7 +2490,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               CREATE_VECTOR(2, uint16_t)
               CREATE_VECTOR(4, uint32_t)
               CREATE_VECTOR(8, uint64_t)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.Size); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.Size); break;
             }
             #undef CREATE_VECTOR
             memcpy(GDP, Tmp, OpSize);
@@ -2639,7 +2639,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_0SRC_OP(2, int16_t, Func)
               DO_VECTOR_0SRC_OP(4, int32_t, Func)
               DO_VECTOR_0SRC_OP(8, int64_t, Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -2657,7 +2657,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_1SRC_OP(2, int16_t, Func)
               DO_VECTOR_1SRC_OP(4, int32_t, Func)
               DO_VECTOR_1SRC_OP(8, int64_t, Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -2673,7 +2673,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (Op->Header.ElementSize) {
               DO_VECTOR_1SRC_OP(4, float, Func)
               DO_VECTOR_1SRC_OP(8, double, Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -2692,7 +2692,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_1SRC_OP(2, uint16_t, Func)
               DO_VECTOR_1SRC_OP(4, uint32_t, Func)
               DO_VECTOR_1SRC_OP(8, uint64_t, Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -2711,7 +2711,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_1SRC_OP(2, int16_t, Func)
               DO_VECTOR_1SRC_OP(4, int32_t, Func)
               DO_VECTOR_1SRC_OP(8, int64_t, Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -2730,7 +2730,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_1SRC_OP(2, uint16_t, Func)
               DO_VECTOR_1SRC_OP(4, uint32_t, Func)
               DO_VECTOR_1SRC_OP(8, uint64_t, Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -2750,7 +2750,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_OP(2, uint16_t, Func)
               DO_VECTOR_OP(4, uint32_t, Func)
               DO_VECTOR_OP(8, uint64_t, Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -2769,7 +2769,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_OP(2, uint16_t, Func)
               DO_VECTOR_OP(4, uint32_t, Func)
               DO_VECTOR_OP(8, uint64_t, Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -2791,7 +2791,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_OP(2, uint16_t, Func)
               DO_VECTOR_OP(4, uint32_t, Func)
               DO_VECTOR_OP(8, uint64_t, Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -2813,7 +2813,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_OP(2, uint16_t, Func)
               DO_VECTOR_OP(4, uint32_t, Func)
               DO_VECTOR_OP(8, uint64_t, Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -2845,7 +2845,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_OP(2, int16_t, Func)
               DO_VECTOR_OP(4, int32_t, Func)
               DO_VECTOR_OP(8, int64_t, Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -2873,7 +2873,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_OP(2, int16_t, Func)
               DO_VECTOR_OP(4, int32_t, Func)
               DO_VECTOR_OP(8, int64_t, Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -2891,7 +2891,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (Op->Header.ElementSize) {
               DO_VECTOR_OP(4, float, Func)
               DO_VECTOR_OP(8, double, Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -2908,7 +2908,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (Op->Header.ElementSize) {
               DO_VECTOR_PAIR_OP(4, float, Func)
               DO_VECTOR_PAIR_OP(8, double, Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -2925,7 +2925,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (Op->Header.ElementSize) {
               DO_VECTOR_OP(4, float, Func)
               DO_VECTOR_OP(8, double, Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -2944,7 +2944,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_PAIR_OP(2, uint16_t, Func)
               DO_VECTOR_PAIR_OP(4, uint32_t, Func)
               DO_VECTOR_PAIR_OP(8, uint64_t, Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -2962,7 +2962,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_REDUCE_1SRC_OP(2, int16_t, Func, 0)
               DO_VECTOR_REDUCE_1SRC_OP(4, int32_t, Func, 0)
               DO_VECTOR_REDUCE_1SRC_OP(8, int64_t, Func, 0)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, Op->Header.ElementSize);
             break;
@@ -2979,7 +2979,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (Op->Header.ElementSize) {
               DO_VECTOR_OP(1, uint8_t,  Func)
               DO_VECTOR_OP(2, uint16_t, Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -2997,7 +2997,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_1SRC_OP(2, int16_t, Func)
               DO_VECTOR_1SRC_OP(4, int32_t, Func)
               DO_VECTOR_1SRC_OP(8, int64_t, Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3014,7 +3014,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (Op->Header.ElementSize) {
               DO_VECTOR_OP(4, float, Func)
               DO_VECTOR_OP(8, double, Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3031,7 +3031,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (Op->Header.ElementSize) {
               DO_VECTOR_OP(4, float, Func)
               DO_VECTOR_OP(8, double, Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3048,7 +3048,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (Op->Header.ElementSize) {
               DO_VECTOR_OP(4, float, Func)
               DO_VECTOR_OP(8, double, Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3065,7 +3065,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (Op->Header.ElementSize) {
               DO_VECTOR_OP(4, float, Func)
               DO_VECTOR_OP(8, double, Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3081,7 +3081,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (Op->Header.ElementSize) {
               DO_VECTOR_1SRC_OP(4, float, Func)
               DO_VECTOR_1SRC_OP(8, double, Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3097,7 +3097,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (Op->Header.ElementSize) {
               DO_VECTOR_1SRC_OP(4, float, Func)
               DO_VECTOR_1SRC_OP(8, double, Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3113,7 +3113,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (Op->Header.ElementSize) {
               DO_VECTOR_1SRC_OP(4, float, Func)
               DO_VECTOR_1SRC_OP(8, double, Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3181,7 +3181,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_1SRC_2TYPE_OP(1, uint8_t, uint16_t, Func, 0, 0)
               DO_VECTOR_1SRC_2TYPE_OP(2, uint16_t, uint32_t, Func, 0, 0)
               DO_VECTOR_1SRC_2TYPE_OP(4, uint32_t, uint64_t, Func, 0, 0)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3200,7 +3200,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_1SRC_2TYPE_OP_TOP(1, uint8_t, uint16_t, Func, 0, 0)
               DO_VECTOR_1SRC_2TYPE_OP_TOP(2, uint16_t, uint32_t, Func, 0, 0)
               DO_VECTOR_1SRC_2TYPE_OP_TOP(4, uint32_t, uint64_t, Func, 0, 0)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3216,7 +3216,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (Op->Header.ElementSize) {
               DO_VECTOR_1SRC_2TYPE_OP(1, int8_t, int16_t, Func, std::numeric_limits<int8_t>::min(), std::numeric_limits<int8_t>::max())
               DO_VECTOR_1SRC_2TYPE_OP(2, int16_t, int32_t, Func, std::numeric_limits<int16_t>::min(), std::numeric_limits<int16_t>::max())
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3233,7 +3233,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (Op->Header.ElementSize) {
               DO_VECTOR_1SRC_2TYPE_OP_TOP(1, int8_t, int16_t, Func, std::numeric_limits<int8_t>::min(), std::numeric_limits<int8_t>::max())
               DO_VECTOR_1SRC_2TYPE_OP_TOP(2, int16_t, int32_t, Func, std::numeric_limits<int16_t>::min(), std::numeric_limits<int16_t>::max())
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3249,7 +3249,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (Op->Header.ElementSize) {
               DO_VECTOR_1SRC_2TYPE_OP(1, uint8_t, int16_t, Func, 0, (1 << 8) - 1)
               DO_VECTOR_1SRC_2TYPE_OP(2, uint16_t, int32_t, Func, 0, (1 << 16) - 1)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3266,7 +3266,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (Op->Header.ElementSize) {
               DO_VECTOR_1SRC_2TYPE_OP_TOP(1, uint8_t, int16_t, Func, 0, (1 << 8) - 1)
               DO_VECTOR_1SRC_2TYPE_OP_TOP(2, uint16_t, int32_t, Func, 0, (1 << 16) - 1)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3282,7 +3282,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (Op->Header.ElementSize) {
               DO_VECTOR_1SRC_2TYPE_OP(4, float, uint32_t, Func, 0, 0)
               DO_VECTOR_1SRC_2TYPE_OP(8, double, uint64_t, Func, 0, 0)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3298,7 +3298,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (Op->Header.ElementSize) {
               DO_VECTOR_1SRC_2TYPE_OP(4, float, int32_t, Func, 0, 0)
               DO_VECTOR_1SRC_2TYPE_OP(8, double, int64_t, Func, 0, 0)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3314,7 +3314,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (Op->Header.ElementSize) {
               DO_VECTOR_1SRC_2TYPE_OP(4, uint32_t, float, Func, 0, 0)
               DO_VECTOR_1SRC_2TYPE_OP(8, uint64_t, double, Func, 0, 0)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3330,7 +3330,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (Op->Header.ElementSize) {
               DO_VECTOR_1SRC_2TYPE_OP(4, int32_t, float, Func, 0, 0)
               DO_VECTOR_1SRC_2TYPE_OP(8, int64_t, double, Func, 0, 0)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3346,7 +3346,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (Op->Header.ElementSize) {
               DO_VECTOR_1SRC_2TYPE_OP(4, uint32_t, float, Func, 0, 0)
               DO_VECTOR_1SRC_2TYPE_OP(8, uint64_t, double, Func, 0, 0)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3362,7 +3362,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (Op->Header.ElementSize) {
               DO_VECTOR_1SRC_2TYPE_OP(4, int32_t, float, Func, 0, 0)
               DO_VECTOR_1SRC_2TYPE_OP(8, int64_t, double, Func, 0, 0)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3381,7 +3381,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_OP(2, uint16_t, Func)
               DO_VECTOR_OP(4, uint32_t, Func)
               DO_VECTOR_OP(8, uint64_t, Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3400,7 +3400,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_OP(2, int16_t, Func)
               DO_VECTOR_OP(4, int32_t, Func)
               DO_VECTOR_OP(8, int64_t, Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3419,7 +3419,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_2SRC_2TYPE_OP(2, uint16_t, uint8_t, Func)
               DO_VECTOR_2SRC_2TYPE_OP(4, uint32_t, uint16_t, Func)
               DO_VECTOR_2SRC_2TYPE_OP(8, uint64_t, uint32_t, Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3438,7 +3438,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_2SRC_2TYPE_OP(2, int16_t, int8_t, Func)
               DO_VECTOR_2SRC_2TYPE_OP(4, int32_t, int16_t, Func)
               DO_VECTOR_2SRC_2TYPE_OP(8, int64_t, int32_t, Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3457,7 +3457,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_2SRC_2TYPE_OP_TOP_SRC(2, uint16_t, uint8_t, Func)
               DO_VECTOR_2SRC_2TYPE_OP_TOP_SRC(4, uint32_t, uint16_t, Func)
               DO_VECTOR_2SRC_2TYPE_OP_TOP_SRC(8, uint64_t, uint32_t, Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3476,7 +3476,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_2SRC_2TYPE_OP_TOP_SRC(2, int16_t, int8_t, Func)
               DO_VECTOR_2SRC_2TYPE_OP_TOP_SRC(4, int32_t, int16_t, Func)
               DO_VECTOR_2SRC_2TYPE_OP_TOP_SRC(8, int64_t, int32_t, Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, Op->Header.Size);
             break;
@@ -3493,7 +3493,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_1SRC_2TYPE_OP(2, int16_t, int8_t, Func,  0, 0)
               DO_VECTOR_1SRC_2TYPE_OP(4, int32_t, int16_t, Func, 0, 0)
               DO_VECTOR_1SRC_2TYPE_OP(8, int64_t, int32_t, Func, 0, 0)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3510,7 +3510,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_1SRC_2TYPE_OP_TOP_SRC(2, int16_t, int8_t, Func,  0, 0)
               DO_VECTOR_1SRC_2TYPE_OP_TOP_SRC(4, int32_t, int16_t, Func, 0, 0)
               DO_VECTOR_1SRC_2TYPE_OP_TOP_SRC(8, int64_t, int32_t, Func, 0, 0)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3527,7 +3527,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_1SRC_2TYPE_OP(2, uint16_t, uint8_t, Func,  0, 0)
               DO_VECTOR_1SRC_2TYPE_OP(4, uint32_t, uint16_t, Func, 0, 0)
               DO_VECTOR_1SRC_2TYPE_OP(8, uint64_t, uint32_t, Func, 0, 0)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3545,7 +3545,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_1SRC_2TYPE_OP_TOP_SRC(2, uint16_t, uint8_t, Func,  0, 0)
               DO_VECTOR_1SRC_2TYPE_OP_TOP_SRC(4, uint32_t, uint16_t, Func, 0, 0)
               DO_VECTOR_1SRC_2TYPE_OP_TOP_SRC(8, uint64_t, uint32_t, Func, 0, 0)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3564,7 +3564,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_OP(2, uint16_t, Func)
               DO_VECTOR_OP(4, uint32_t, Func)
               DO_VECTOR_OP(8, uint64_t, Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3583,7 +3583,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_OP(2, int16_t, Func)
               DO_VECTOR_OP(4, int32_t, Func)
               DO_VECTOR_OP(8, int64_t, Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3602,7 +3602,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_OP(2, uint16_t, Func)
               DO_VECTOR_OP(4, uint32_t, Func)
               DO_VECTOR_OP(8, uint64_t, Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3621,7 +3621,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_OP(2, int16_t, Func)
               DO_VECTOR_OP(4, int32_t, Func)
               DO_VECTOR_OP(8, int64_t, Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3640,7 +3640,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_OP(2, uint16_t, Func)
               DO_VECTOR_OP(4, uint32_t, Func)
               DO_VECTOR_OP(8, uint64_t, Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3659,7 +3659,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_OP(2, int16_t, Func)
               DO_VECTOR_OP(4, int32_t, Func)
               DO_VECTOR_OP(8, int64_t, Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3680,7 +3680,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_SCALAR_OP(4, uint32_t, Func)
               DO_VECTOR_SCALAR_OP(8, uint64_t, Func)
               DO_VECTOR_SCALAR_OP(16, __uint128_t, Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3700,7 +3700,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_SCALAR_OP(4, uint32_t, Func)
               DO_VECTOR_SCALAR_OP(8, uint64_t, Func)
               DO_VECTOR_SCALAR_OP(16, __uint128_t, Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3720,7 +3720,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_SCALAR_OP(4, int32_t, Func)
               DO_VECTOR_SCALAR_OP(8, int64_t, Func)
               DO_VECTOR_SCALAR_OP(16, __int128_t, Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3739,7 +3739,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_OP(2, uint16_t, Func)
               DO_VECTOR_OP(4, uint32_t, Func)
               DO_VECTOR_OP(8, uint64_t, Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3795,7 +3795,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 }
                 break;
               }
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
 
             memcpy(GDP, Tmp, OpSize);
@@ -3834,7 +3834,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 Dst_d[Op->DestIdx] = Src2_d[Op->SrcIdx];
                 break;
               }
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             };
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3872,7 +3872,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 Dst_d[Op->DestIdx] = Src2_d;
                 break;
               }
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             };
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3905,7 +3905,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_OP(2, uint16_t,  Func)
               DO_VECTOR_OP(4, uint32_t,  Func)
               DO_VECTOR_OP(8, uint64_t,  Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
 
             memcpy(GDP, Tmp, OpSize);
@@ -3925,7 +3925,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_OP(2, uint16_t,  Func)
               DO_VECTOR_OP(4, uint32_t,  Func)
               DO_VECTOR_OP(8, uint64_t,  Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
 
             memcpy(GDP, Tmp, OpSize);
@@ -3945,7 +3945,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_OP(2, int16_t,  Func)
               DO_VECTOR_OP(4, int32_t,  Func)
               DO_VECTOR_OP(8, int64_t,  Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
 
             memcpy(GDP, Tmp, OpSize);
@@ -3965,7 +3965,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_OP(2, int16_t,  Func)
               DO_VECTOR_OP(4, int32_t,  Func)
               DO_VECTOR_OP(8, int64_t,  Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
 
             memcpy(GDP, Tmp, OpSize);
@@ -3985,7 +3985,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_OP(2, int16_t,  Func)
               DO_VECTOR_OP(4, int32_t,  Func)
               DO_VECTOR_OP(8, int64_t,  Func)
-              default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
             }
 
             memcpy(GDP, Tmp, OpSize);
@@ -4029,7 +4029,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 memcpy(GDP, &Res, OpSize);
                 break;
               }
-              default: LogMan::Msg::A("Unknown LUDIV Size: %d", OpSize); break;
+              default: LOGMAN_MSG_A("Unknown LUDIV Size: %d", OpSize); break;
             }
             break;
           }
@@ -4071,7 +4071,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 memcpy(GDP, &Res, OpSize);
                 break;
               }
-              default: LogMan::Msg::A("Unknown LDIV Size: %d", OpSize); break;
+              default: LOGMAN_MSG_A("Unknown LDIV Size: %d", OpSize); break;
             }
             break;
           }
@@ -4113,7 +4113,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 memcpy(GDP, &Res, OpSize);
                 break;
               }
-              default: LogMan::Msg::A("Unknown LUREM Size: %d", OpSize); break;
+              default: LOGMAN_MSG_A("Unknown LUREM Size: %d", OpSize); break;
             }
             break;
           }
@@ -4154,7 +4154,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 memcpy(GDP, &Res, OpSize);
                 break;
               }
-              default: LogMan::Msg::A("Unknown LREM Size: %d", OpSize); break;
+              default: LOGMAN_MSG_A("Unknown LREM Size: %d", OpSize); break;
             }
             break;
           }
@@ -4308,7 +4308,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 memcpy(GDP, &Dst, 4);
                 break;
               }
-              default: LogMan::Msg::A("Unknown FCVT sizes: 0x%x", Conv);
+              default: LOGMAN_MSG_A("Unknown FCVT sizes: 0x%x", Conv);
             }
             break;
           }
@@ -4337,7 +4337,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
 
                 break;
               }
-              default: LogMan::Msg::A("Unknown Conversion Type : 0%04x", Conv); break;
+              default: LOGMAN_MSG_A("Unknown Conversion Type : 0%04x", Conv); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -4443,14 +4443,14 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               switch (Op->Header.ElementSize) {
               DO_SCALAR_COMPARE_OP(4, float, uint32_t, Func);
               DO_SCALAR_COMPARE_OP(8, double, uint64_t, Func);
-              default: LogMan::Msg::A("Unsupported elementSize: %d", Op->Header.ElementSize);
+              default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
               }
             }
             else {
               switch (Op->Header.ElementSize) {
               DO_VECTOR_COMPARE_OP(4, float, uint32_t, Func);
               DO_VECTOR_COMPARE_OP(8, double, uint64_t, Func);
-              default: LogMan::Msg::A("Unsupported elementSize: %d", Op->Header.ElementSize);
+              default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
               }
             }
 
@@ -4471,14 +4471,14 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               switch (Op->Header.ElementSize) {
               DO_SCALAR_COMPARE_OP(4, float, uint32_t, Func);
               DO_SCALAR_COMPARE_OP(8, double, uint64_t, Func);
-              default: LogMan::Msg::A("Unsupported elementSize: %d", Op->Header.ElementSize);
+              default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
               }
             }
             else {
               switch (Op->Header.ElementSize) {
               DO_VECTOR_COMPARE_OP(4, float, uint32_t, Func);
               DO_VECTOR_COMPARE_OP(8, double, uint64_t, Func);
-              default: LogMan::Msg::A("Unsupported elementSize: %d", Op->Header.ElementSize);
+              default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
               }
             }
 
@@ -4499,14 +4499,14 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               switch (Op->Header.ElementSize) {
               DO_SCALAR_COMPARE_OP(4, float, uint32_t, Func);
               DO_SCALAR_COMPARE_OP(8, double, uint64_t, Func);
-              default: LogMan::Msg::A("Unsupported elementSize: %d", Op->Header.ElementSize);
+              default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
               }
             }
             else {
               switch (Op->Header.ElementSize) {
               DO_VECTOR_COMPARE_OP(4, float, uint32_t, Func);
               DO_VECTOR_COMPARE_OP(8, double, uint64_t, Func);
-              default: LogMan::Msg::A("Unsupported elementSize: %d", Op->Header.ElementSize);
+              default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
               }
             }
 
@@ -4527,14 +4527,14 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               switch (Op->Header.ElementSize) {
               DO_SCALAR_COMPARE_OP(4, float, uint32_t, Func);
               DO_SCALAR_COMPARE_OP(8, double, uint64_t, Func);
-              default: LogMan::Msg::A("Unsupported elementSize: %d", Op->Header.ElementSize);
+              default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
               }
             }
             else {
               switch (Op->Header.ElementSize) {
               DO_VECTOR_COMPARE_OP(4, float, uint32_t, Func);
               DO_VECTOR_COMPARE_OP(8, double, uint64_t, Func);
-              default: LogMan::Msg::A("Unsupported elementSize: %d", Op->Header.ElementSize);
+              default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
               }
             }
 
@@ -4555,14 +4555,14 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               switch (Op->Header.ElementSize) {
               DO_SCALAR_COMPARE_OP(4, float, uint32_t, Func);
               DO_SCALAR_COMPARE_OP(8, double, uint64_t, Func);
-              default: LogMan::Msg::A("Unsupported elementSize: %d", Op->Header.ElementSize);
+              default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
               }
             }
             else {
               switch (Op->Header.ElementSize) {
               DO_VECTOR_COMPARE_OP(4, float, uint32_t, Func);
               DO_VECTOR_COMPARE_OP(8, double, uint64_t, Func);
-              default: LogMan::Msg::A("Unsupported elementSize: %d", Op->Header.ElementSize);
+              default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
               }
             }
 
@@ -4583,14 +4583,14 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               switch (Op->Header.ElementSize) {
               DO_SCALAR_COMPARE_OP(4, float, uint32_t, Func);
               DO_SCALAR_COMPARE_OP(8, double, uint64_t, Func);
-              default: LogMan::Msg::A("Unsupported elementSize: %d", Op->Header.ElementSize);
+              default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
               }
             }
             else {
               switch (Op->Header.ElementSize) {
               DO_VECTOR_COMPARE_OP(4, float, uint32_t, Func);
               DO_VECTOR_COMPARE_OP(8, double, uint64_t, Func);
-              default: LogMan::Msg::A("Unsupported elementSize: %d", Op->Header.ElementSize);
+              default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
               }
             }
 
@@ -5134,7 +5134,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             break;
           }
           default:
-            LogMan::Msg::A("Unknown IR Op: %d(%s)", IROp->Op, FEXCore::IR::GetName(IROp->Op).data());
+            LOGMAN_MSG_A("Unknown IR Op: %d(%s)", IROp->Op, FEXCore::IR::GetName(IROp->Op).data());
             break;
         }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -46,7 +46,7 @@ DEF_OP(TruncElementPair) {
       mov(Dst.second, Src.second);
       break;
     }
-    default: LogMan::Msg::A("Unhandled Truncation size: %d", Op->Size); break;
+    default: LOGMAN_MSG_A("Unhandled Truncation size: %d", Op->Size); break;
   }
 }
 
@@ -95,7 +95,7 @@ DEF_OP(Add) {
       case 8:
         add(GetReg<RA_64>(Node), GetReg<RA_64>(Op->Header.Args[0].ID()), Const);
         break;
-      default: LogMan::Msg::A("Unsupported Add size: %d", OpSize);
+      default: LOGMAN_MSG_A("Unsupported Add size: %d", OpSize);
     }
   } else {
     switch (OpSize) {
@@ -105,7 +105,7 @@ DEF_OP(Add) {
       case 8:
         add(GetReg<RA_64>(Node), GetReg<RA_64>(Op->Header.Args[0].ID()), GetReg<RA_64>(Op->Header.Args[1].ID()));
         break;
-      default: LogMan::Msg::A("Unsupported Add size: %d", OpSize);
+      default: LOGMAN_MSG_A("Unsupported Add size: %d", OpSize);
     }
   }
 }
@@ -121,7 +121,7 @@ DEF_OP(Sub) {
       case 8:
         sub(GRS(Node), GRS(Op->Header.Args[0].ID()), Const);
         break;
-      default: LogMan::Msg::A("Unsupported Sub size: %d", OpSize);
+      default: LOGMAN_MSG_A("Unsupported Sub size: %d", OpSize);
     }
   } else {
     switch (OpSize) {
@@ -131,7 +131,7 @@ DEF_OP(Sub) {
       case 8:
         sub(GetReg<RA_64>(Node), GetReg<RA_64>(Op->Header.Args[0].ID()), GetReg<RA_64>(Op->Header.Args[1].ID()));
         break;
-      default: LogMan::Msg::A("Unsupported Sub size: %d", OpSize);
+      default: LOGMAN_MSG_A("Unsupported Sub size: %d", OpSize);
     }
   }
 
@@ -147,7 +147,7 @@ DEF_OP(Neg) {
     case 8:
       neg(GetReg<RA_64>(Node), GetReg<RA_64>(Op->Header.Args[0].ID()));
       break;
-    default: LogMan::Msg::A("Unsupported Not size: %d", OpSize);
+    default: LOGMAN_MSG_A("Unsupported Not size: %d", OpSize);
   }
 }
 
@@ -164,7 +164,7 @@ DEF_OP(Mul) {
     case 8:
       mul(Dst, GetReg<RA_64>(Op->Header.Args[0].ID()), GetReg<RA_64>(Op->Header.Args[1].ID()));
     break;
-    default: LogMan::Msg::A("Unknown Sext size: %d", OpSize);
+    default: LOGMAN_MSG_A("Unknown Sext size: %d", OpSize);
   }
 }
 
@@ -180,7 +180,7 @@ DEF_OP(UMul) {
     case 8:
       mul(Dst, GetReg<RA_64>(Op->Header.Args[0].ID()), GetReg<RA_64>(Op->Header.Args[1].ID()));
     break;
-    default: LogMan::Msg::A("Unknown Sext size: %d", OpSize);
+    default: LOGMAN_MSG_A("Unknown Sext size: %d", OpSize);
   }
 }
 
@@ -217,7 +217,7 @@ DEF_OP(Div) {
       sdiv(GetReg<RA_64>(Node), GetReg<RA_64>(Op->Header.Args[0].ID()), GetReg<RA_64>(Op->Header.Args[1].ID()));
     break;
     }
-    default: LogMan::Msg::A("Unknown DIV Size: %d", Size); break;
+    default: LOGMAN_MSG_A("Unknown DIV Size: %d", Size); break;
   }
 }
 
@@ -244,7 +244,7 @@ DEF_OP(UDiv) {
       udiv(GetReg<RA_64>(Node), GetReg<RA_64>(Op->Header.Args[0].ID()), GetReg<RA_64>(Op->Header.Args[1].ID()));
       break;
     }
-    default: LogMan::Msg::A("Unknown UDIV Size: %d", Size); break;
+    default: LOGMAN_MSG_A("Unknown UDIV Size: %d", Size); break;
   }
 }
 
@@ -291,7 +291,7 @@ DEF_OP(Rem) {
       msub(GetReg<RA_64>(Node), TMP1, Divisor, Dividend);
     break;
     }
-    default: LogMan::Msg::A("Unknown REM Size: %d", OpSize); break;
+    default: LOGMAN_MSG_A("Unknown REM Size: %d", OpSize); break;
   }
 }
 
@@ -333,7 +333,7 @@ DEF_OP(URem) {
       msub(GetReg<RA_64>(Node), TMP1, Divisor, Dividend);
     break;
     }
-    default: LogMan::Msg::A("Unknown UREM Size: %d", OpSize); break;
+    default: LOGMAN_MSG_A("Unknown UREM Size: %d", OpSize); break;
   }
 }
 
@@ -350,7 +350,7 @@ DEF_OP(MulH) {
     case 8:
       smulh(GetReg<RA_64>(Node), GetReg<RA_64>(Op->Header.Args[0].ID()), GetReg<RA_64>(Op->Header.Args[1].ID()));
     break;
-    default: LogMan::Msg::A("Unknown Sext size: %d", OpSize);
+    default: LOGMAN_MSG_A("Unknown Sext size: %d", OpSize);
   }
 }
 
@@ -367,7 +367,7 @@ DEF_OP(UMulH) {
     case 8:
       umulh(GetReg<RA_64>(Node), GetReg<RA_64>(Op->Header.Args[0].ID()), GetReg<RA_64>(Op->Header.Args[1].ID()));
     break;
-    default: LogMan::Msg::A("Unknown Sext size: %d", OpSize);
+    default: LOGMAN_MSG_A("Unknown Sext size: %d", OpSize);
   }
 }
 
@@ -463,7 +463,7 @@ DEF_OP(Ror) {
       break;
       }
 
-      default: LogMan::Msg::A("Unhandled ROR size: %d", OpSize);
+      default: LOGMAN_MSG_A("Unhandled ROR size: %d", OpSize);
     }
   } else {
     switch (OpSize) {
@@ -476,7 +476,7 @@ DEF_OP(Ror) {
       break;
       }
 
-      default: LogMan::Msg::A("Unhandled ROR size: %d", OpSize);
+      default: LOGMAN_MSG_A("Unhandled ROR size: %d", OpSize);
     }
   }
 }
@@ -495,7 +495,7 @@ DEF_OP(Extr) {
     break;
     }
 
-    default: LogMan::Msg::A("Unhandled EXTR size: %d", OpSize);
+    default: LOGMAN_MSG_A("Unhandled EXTR size: %d", OpSize);
   }
 }
 
@@ -540,7 +540,7 @@ DEF_OP(LDiv) {
       mov(GetReg<RA_64>(Node), x0);
     break;
     }
-    default: LogMan::Msg::A("Unknown LDIV Size: %d", Size); break;
+    default: LOGMAN_MSG_A("Unknown LDIV Size: %d", Size); break;
   }
 }
 
@@ -583,7 +583,7 @@ DEF_OP(LUDiv) {
       mov(GetReg<RA_64>(Node), x0);
     break;
     }
-    default: LogMan::Msg::A("Unknown LUDIV Size: %d", Size); break;
+    default: LOGMAN_MSG_A("Unknown LUDIV Size: %d", Size); break;
   }
 }
 
@@ -636,7 +636,7 @@ DEF_OP(LRem) {
       mov(GetReg<RA_64>(Node), x0);
     break;
     }
-    default: LogMan::Msg::A("Unknown LREM Size: %d", Size); break;
+    default: LOGMAN_MSG_A("Unknown LREM Size: %d", Size); break;
   }
 }
 
@@ -686,7 +686,7 @@ DEF_OP(LURem) {
       mov(GetReg<RA_64>(Node), x0);
     break;
     }
-    default: LogMan::Msg::A("Unknown LUREM Size: %d", OpSize); break;
+    default: LOGMAN_MSG_A("Unknown LUREM Size: %d", OpSize); break;
   }
 }
 
@@ -700,7 +700,7 @@ DEF_OP(Not) {
     case 8:
       mvn(GetReg<RA_64>(Node), GetReg<RA_64>(Op->Header.Args[0].ID()));
       break;
-    default: LogMan::Msg::A("Unsupported Not size: %d", OpSize);
+    default: LOGMAN_MSG_A("Unsupported Not size: %d", OpSize);
   }
 }
 
@@ -731,7 +731,7 @@ DEF_OP(Popcount) {
       // fmov has zero extended, unused bytes are zero
       addv(VTMP1.B(), VTMP1.V8B());
       break;
-    default: LogMan::Msg::A("Unsupported Popcount size: %d", OpSize);
+    default: LOGMAN_MSG_A("Unsupported Popcount size: %d", OpSize);
   }
 
   auto Dst = GetReg<RA_32>(Node);
@@ -780,7 +780,7 @@ DEF_OP(FindMSB) {
       clz(Dst, GetReg<RA_64>(Op->Header.Args[0].ID()));
       sub(Dst, TMP1, Dst);
       break;
-    default: LogMan::Msg::A("Unknown REV size: %d", OpSize); break;
+    default: LOGMAN_MSG_A("Unknown REV size: %d", OpSize); break;
   }
 }
 
@@ -801,7 +801,7 @@ DEF_OP(FindTrailingZeros) {
       rbit(GetReg<RA_64>(Node), GetReg<RA_64>(Op->Header.Args[0].ID()));
       clz(GetReg<RA_64>(Node), GetReg<RA_64>(Node));
       break;
-    default: LogMan::Msg::A("Unknown size: %d", OpSize); break;
+    default: LOGMAN_MSG_A("Unknown size: %d", OpSize); break;
   }
 }
 
@@ -820,7 +820,7 @@ DEF_OP(CountLeadingZeroes) {
     case 8:
       clz(GetReg<RA_64>(Node), GetReg<RA_64>(Op->Header.Args[0].ID()));
       break;
-    default: LogMan::Msg::A("Unknown size: %d", OpSize); break;
+    default: LOGMAN_MSG_A("Unknown size: %d", OpSize); break;
   }
 }
 
@@ -838,7 +838,7 @@ DEF_OP(Rev) {
     case 8:
       rev(GetReg<RA_64>(Node), GetReg<RA_64>(Op->Header.Args[0].ID()));
       break;
-    default: LogMan::Msg::A("Unknown REV size: %d", OpSize); break;
+    default: LOGMAN_MSG_A("Unknown REV size: %d", OpSize); break;
   }
 }
 
@@ -860,15 +860,15 @@ DEF_OP(Bfi) {
       bfi(TMP1, GetReg<RA_64>(Op->Header.Args[1].ID()), Op->lsb, Op->Width);
       mov(GetReg<RA_64>(Node), TMP1);
       break;
-    default: LogMan::Msg::A("Unknown BFI size: %d", OpSize); break;
+    default: LOGMAN_MSG_A("Unknown BFI size: %d", OpSize); break;
   }
 }
 
 DEF_OP(Bfe) {
   auto Op = IROp->C<IR::IROp_Bfe>();
   uint8_t OpSize = IROp->Size;
-  LogMan::Throw::A(OpSize <= 8, "OpSize is too large for BFE: %d", OpSize);
-  LogMan::Throw::A(Op->Width != 0, "Invalid BFE width of 0");
+  LOGMAN_THROW_A(OpSize <= 8, "OpSize is too large for BFE: %d", OpSize);
+  LOGMAN_THROW_A(Op->Width != 0, "Invalid BFE width of 0");
 
   auto Dst = GetReg<RA_64>(Node);
   ubfx(Dst, GetReg<RA_64>(Op->Header.Args[0].ID()), Op->lsb, Op->Width);
@@ -913,7 +913,7 @@ Condition MapSelectCC(IR::CondClassType Cond) {
   case FEXCore::IR::COND_MI:
   case FEXCore::IR::COND_PL:
   default:
-  LogMan::Msg::A("Unsupported compare type");
+  LOGMAN_MSG_A("Unsupported compare type");
   return Condition::nv;
   }
 }
@@ -931,7 +931,7 @@ DEF_OP(Select) {
   } else if (IsFPR(Op->Cmp1.ID())) {
     fcmp(GRFCMP(Op->Cmp1.ID()), GRFCMP(Op->Cmp2.ID()));
   } else {
-    LogMan::Msg::A("Select: Expected GPR or FPR");
+    LOGMAN_MSG_A("Select: Expected GPR or FPR");
   }
 
   auto cc = MapSelectCC(Op->Cond);
@@ -942,7 +942,7 @@ DEF_OP(Select) {
 
   if (is_const_true || is_const_false) {
     if (is_const_false != true || is_const_true != true || const_true != 1 || const_false != 0) {
-      LogMan::Msg::A("Select: Unsupported compare inline parameters");
+      LOGMAN_MSG_A("Select: Unsupported compare inline parameters");
     }
     cset(GRS(Node), cc);
   } else {
@@ -966,7 +966,7 @@ DEF_OP(VExtractToGPR) {
     case 8:
       umov(GetReg<RA_64>(Node), GetSrc(Op->Header.Args[0].ID()).V2D(), Op->Idx);
     break;
-    default:  LogMan::Msg::A("Unhandled ExtractElementSize: %d", OpSize);
+    default:  LOGMAN_MSG_A("Unhandled ExtractElementSize: %d", OpSize);
   }
 }
 
@@ -1014,7 +1014,7 @@ DEF_OP(FCmp) {
   bool set = false;
 
   if (Op->Flags & (1 << IR::FCMP_FLAG_EQ)) {
-    LogMan::Throw::A(IR::FCMP_FLAG_EQ == 0, "IR::FCMP_FLAG_EQ must equal 0");
+    LOGMAN_THROW_A(IR::FCMP_FLAG_EQ == 0, "IR::FCMP_FLAG_EQ must equal 0");
     // EQ or unordered
     cset(Dst, Condition::eq); // Z = 1
     csinc(Dst, Dst, xzr, Condition::vc); // IF !V ? Z : 1

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/AtomicOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/AtomicOps.cpp
@@ -34,7 +34,7 @@ DEF_OP(CASPair) {
       mov(Dst.first, TMP3);
       mov(Dst.second, TMP4);
       break;
-    default: LogMan::Msg::A("Unsupported: %d", OpSize);
+    default: LOGMAN_MSG_A("Unsupported: %d", OpSize);
     }
   }
   else {
@@ -89,7 +89,7 @@ DEF_OP(CASPair) {
         bind(&LoopExpected);
         break;
       }
-      default: LogMan::Msg::A("Unsupported: %d", OpSize);
+      default: LOGMAN_MSG_A("Unsupported: %d", OpSize);
     }
   }
 }
@@ -115,7 +115,7 @@ DEF_OP(CAS) {
     case 2: casalh(TMP2.W(), Desired.W(), MemOperand(MemSrc)); break;
     case 4: casal(TMP2.W(), Desired.W(), MemOperand(MemSrc)); break;
     case 8: casal(TMP2.X(), Desired.X(), MemOperand(MemSrc)); break;
-    default: LogMan::Msg::A("Unsupported: %d", OpSize);
+    default: LOGMAN_MSG_A("Unsupported: %d", OpSize);
     }
     mov(GetReg<RA_64>(Node), TMP2);
   }
@@ -206,7 +206,7 @@ DEF_OP(CAS) {
 
         break;
       }
-      default:  LogMan::Msg::A("Unhandled Atomic size: %d", OpSize);
+      default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", OpSize);
     }
   }
 }
@@ -222,7 +222,7 @@ DEF_OP(AtomicAdd) {
     case 2: staddlh(GetReg<RA_32>(Op->Header.Args[1].ID()), MemOperand(MemSrc)); break;
     case 4: staddl(GetReg<RA_32>(Op->Header.Args[1].ID()), MemOperand(MemSrc)); break;
     case 8: staddl(GetReg<RA_64>(Op->Header.Args[1].ID()), MemOperand(MemSrc)); break;
-    default:  LogMan::Msg::A("Unhandled Atomic size: %d", Op->Size);
+    default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
     }
   }
   else {
@@ -264,7 +264,7 @@ DEF_OP(AtomicAdd) {
         cbnz(TMP2, &LoopTop);
         break;
       }
-      default:  LogMan::Msg::A("Unhandled Atomic size: %d", Op->Size);
+      default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
     }
   }
 }
@@ -281,7 +281,7 @@ DEF_OP(AtomicSub) {
     case 2: staddlh(TMP2.W(), MemOperand(MemSrc)); break;
     case 4: staddl(TMP2.W(), MemOperand(MemSrc)); break;
     case 8: staddl(TMP2.X(), MemOperand(MemSrc)); break;
-    default:  LogMan::Msg::A("Unhandled Atomic size: %d", Op->Size);
+    default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
     }
   }
   else {
@@ -323,7 +323,7 @@ DEF_OP(AtomicSub) {
         cbnz(TMP2, &LoopTop);
         break;
       }
-      default:  LogMan::Msg::A("Unhandled Atomic size: %d", Op->Size);
+      default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
     }
   }
 }
@@ -340,7 +340,7 @@ DEF_OP(AtomicAnd) {
     case 2: stclrlh(TMP2.W(), MemOperand(MemSrc)); break;
     case 4: stclrl(TMP2.W(), MemOperand(MemSrc)); break;
     case 8: stclrl(TMP2.X(), MemOperand(MemSrc)); break;
-    default:  LogMan::Msg::A("Unhandled Atomic size: %d", Op->Size);
+    default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
     }
   }
   else {
@@ -382,7 +382,7 @@ DEF_OP(AtomicAnd) {
         cbnz(TMP2, &LoopTop);
         break;
       }
-      default:  LogMan::Msg::A("Unhandled Atomic size: %d", Op->Size);
+      default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
     }
   }
 }
@@ -398,7 +398,7 @@ DEF_OP(AtomicOr) {
     case 2: stsetlh(GetReg<RA_32>(Op->Header.Args[1].ID()), MemOperand(MemSrc)); break;
     case 4: stsetl(GetReg<RA_32>(Op->Header.Args[1].ID()), MemOperand(MemSrc)); break;
     case 8: stsetl(GetReg<RA_64>(Op->Header.Args[1].ID()), MemOperand(MemSrc)); break;
-    default:  LogMan::Msg::A("Unhandled Atomic size: %d", Op->Size);
+    default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
     }
   }
   else {
@@ -440,7 +440,7 @@ DEF_OP(AtomicOr) {
         cbnz(TMP2, &LoopTop);
         break;
       }
-      default:  LogMan::Msg::A("Unhandled Atomic size: %d", Op->Size);
+      default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
     }
   }
 }
@@ -456,7 +456,7 @@ DEF_OP(AtomicXor) {
     case 2: steorlh(GetReg<RA_32>(Op->Header.Args[1].ID()), MemOperand(MemSrc)); break;
     case 4: steorl(GetReg<RA_32>(Op->Header.Args[1].ID()), MemOperand(MemSrc)); break;
     case 8: steorl(GetReg<RA_64>(Op->Header.Args[1].ID()), MemOperand(MemSrc)); break;
-    default:  LogMan::Msg::A("Unhandled Atomic size: %d", Op->Size);
+    default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
     }
   }
   else {
@@ -498,7 +498,7 @@ DEF_OP(AtomicXor) {
         cbnz(TMP2, &LoopTop);
         break;
       }
-      default:  LogMan::Msg::A("Unhandled Atomic size: %d", Op->Size);
+      default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
     }
   }
 }
@@ -515,7 +515,7 @@ DEF_OP(AtomicSwap) {
     case 2: swplh(TMP2.W(), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
     case 4: swpl(TMP2.W(), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
     case 8: swpl(TMP2.X(), GetReg<RA_64>(Node), MemOperand(MemSrc)); break;
-    default:  LogMan::Msg::A("Unhandled Atomic size: %d", Op->Size);
+    default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
     }
   }
   else {
@@ -558,7 +558,7 @@ DEF_OP(AtomicSwap) {
         mov(GetReg<RA_64>(Node), TMP2.X());
         break;
       }
-      default:  LogMan::Msg::A("Unhandled Atomic size: %d", Op->Size);
+      default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
     }
   }
 }
@@ -573,7 +573,7 @@ DEF_OP(AtomicFetchAdd) {
     case 2: ldaddalh(GetReg<RA_32>(Op->Header.Args[1].ID()), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
     case 4: ldaddal(GetReg<RA_32>(Op->Header.Args[1].ID()), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
     case 8: ldaddal(GetReg<RA_64>(Op->Header.Args[1].ID()), GetReg<RA_64>(Node), MemOperand(MemSrc)); break;
-    default:  LogMan::Msg::A("Unhandled Atomic size: %d", Op->Size);
+    default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
     }
   }
   else {
@@ -619,7 +619,7 @@ DEF_OP(AtomicFetchAdd) {
         mov(GetReg<RA_64>(Node), TMP2);
         break;
       }
-      default:  LogMan::Msg::A("Unhandled Atomic size: %d", Op->Size);
+      default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
     }
   }
 }
@@ -635,7 +635,7 @@ DEF_OP(AtomicFetchSub) {
     case 2: ldaddalh(TMP2.W(), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
     case 4: ldaddal(TMP2.W(), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
     case 8: ldaddal(TMP2.X(), GetReg<RA_64>(Node), MemOperand(MemSrc)); break;
-    default:  LogMan::Msg::A("Unhandled Atomic size: %d", Op->Size);
+    default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
     }
   }
   else {
@@ -681,7 +681,7 @@ DEF_OP(AtomicFetchSub) {
         mov(GetReg<RA_64>(Node), TMP2);
         break;
       }
-      default:  LogMan::Msg::A("Unhandled Atomic size: %d", Op->Size);
+      default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
     }
   }
 }
@@ -697,7 +697,7 @@ DEF_OP(AtomicFetchAnd) {
     case 2: ldclralh(TMP2.W(), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
     case 4: ldclral(TMP2.W(), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
     case 8: ldclral(TMP2.X(), GetReg<RA_64>(Node), MemOperand(MemSrc)); break;
-    default:  LogMan::Msg::A("Unhandled Atomic size: %d", Op->Size);
+    default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
     }
   }
   else {
@@ -743,7 +743,7 @@ DEF_OP(AtomicFetchAnd) {
         mov(GetReg<RA_64>(Node), TMP2);
         break;
       }
-      default:  LogMan::Msg::A("Unhandled Atomic size: %d", Op->Size);
+      default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
     }
   }
 }
@@ -758,7 +758,7 @@ DEF_OP(AtomicFetchOr) {
     case 2: ldsetalh(GetReg<RA_32>(Op->Header.Args[1].ID()), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
     case 4: ldsetal(GetReg<RA_32>(Op->Header.Args[1].ID()), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
     case 8: ldsetal(GetReg<RA_64>(Op->Header.Args[1].ID()), GetReg<RA_64>(Node), MemOperand(MemSrc)); break;
-    default:  LogMan::Msg::A("Unhandled Atomic size: %d", Op->Size);
+    default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
     }
   }
   else {
@@ -804,7 +804,7 @@ DEF_OP(AtomicFetchOr) {
         mov(GetReg<RA_64>(Node), TMP2);
         break;
       }
-      default:  LogMan::Msg::A("Unhandled Atomic size: %d", Op->Size);
+      default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
     }
   }
 }
@@ -819,7 +819,7 @@ DEF_OP(AtomicFetchXor) {
     case 2: ldeoralh(GetReg<RA_32>(Op->Header.Args[1].ID()), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
     case 4: ldeoral(GetReg<RA_32>(Op->Header.Args[1].ID()), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
     case 8: ldeoral(GetReg<RA_64>(Op->Header.Args[1].ID()), GetReg<RA_64>(Node), MemOperand(MemSrc)); break;
-    default:  LogMan::Msg::A("Unhandled Atomic size: %d", Op->Size);
+    default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
     }
   }
   else {
@@ -865,7 +865,7 @@ DEF_OP(AtomicFetchXor) {
         mov(GetReg<RA_64>(Node), TMP2);
         break;
       }
-      default:  LogMan::Msg::A("Unhandled Atomic size: %d", Op->Size);
+      default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
     }
   }
 }

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
@@ -142,7 +142,7 @@ Condition MapBranchCC(IR::CondClassType Cond) {
   case FEXCore::IR::COND_MI:
   case FEXCore::IR::COND_PL:
   default:
-  LogMan::Msg::A("Unsupported compare type");
+  LOGMAN_MSG_A("Unsupported compare type");
   return Condition::nv;
   }
 }
@@ -169,10 +169,10 @@ DEF_OP(CondJump) {
   bool isConst = IsInlineConstant(Op->Cmp2, &Const);
 
   if (isConst && Const == 0 && Op->Cond.Val == FEXCore::IR::COND_EQ) {
-    LogMan::Throw::A(IsGPR(Op->Cmp1.ID()), "CondJump: Expected GPR");
+    LOGMAN_THROW_A(IsGPR(Op->Cmp1.ID()), "CondJump: Expected GPR");
     cbz(GRCMP(Op->Cmp1.ID()), TrueTargetLabel);
   } else if (isConst && Const == 0 && Op->Cond.Val == FEXCore::IR::COND_NEQ) {
-    LogMan::Throw::A(IsGPR(Op->Cmp1.ID()), "CondJump: Expected GPR");
+    LOGMAN_THROW_A(IsGPR(Op->Cmp1.ID()), "CondJump: Expected GPR");
     cbnz(GRCMP(Op->Cmp1.ID()), TrueTargetLabel);
   } else {
     if (IsGPR(Op->Cmp1.ID())) {
@@ -183,7 +183,7 @@ DEF_OP(CondJump) {
     } else if (IsFPR(Op->Cmp1.ID())) {
       fcmp(GRFCMP(Op->Cmp1.ID()), GRFCMP(Op->Cmp2.ID()));
     } else {
-      LogMan::Msg::A("CondJump: Expected GPR or FPR");
+      LOGMAN_MSG_A("CondJump: Expected GPR or FPR");
     }
 
     b(TrueTargetLabel, MapBranchCC(Op->Cond));

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ConversionOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ConversionOps.cpp
@@ -31,7 +31,7 @@ DEF_OP(VInsGPR) {
       ins(GetDst(Node).V2D(), Op->Index, GetReg<RA_64>(Op->Header.Args[1].ID()));
     break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -52,12 +52,12 @@ DEF_OP(VCastFromGPR) {
     case 8:
       fmov(GetDst(Node).D(), GetReg<RA_64>(Op->Header.Args[0].ID()).X());
       break;
-    default: LogMan::Msg::A("Unknown castGPR element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A("Unknown castGPR element size: %d", Op->Header.ElementSize);
   }
 }
 
 DEF_OP(Float_FromGPR_U) {
-  LogMan::Msg::A("Unimplemented");
+  LOGMAN_MSG_A("Unimplemented");
 }
 
 DEF_OP(Float_FromGPR_S) {
@@ -95,7 +95,7 @@ DEF_OP(Float_FToF) {
       fcvt(GetDst(Node).S(), GetSrc(Op->Header.Args[0].ID()).D());
       break;
     }
-    default: LogMan::Msg::A("Unknown FCVT sizes: 0x%x", Conv);
+    default: LOGMAN_MSG_A("Unknown FCVT sizes: 0x%x", Conv);
   }
 }
 
@@ -108,7 +108,7 @@ DEF_OP(Vector_UToF) {
     case 8:
       ucvtf(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D());
     break;
-    default: LogMan::Msg::A("Unknown castGPR element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A("Unknown castGPR element size: %d", Op->Header.ElementSize);
   }
 }
 
@@ -121,7 +121,7 @@ DEF_OP(Vector_SToF) {
     case 8:
       scvtf(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D());
     break;
-    default: LogMan::Msg::A("Unknown castGPR element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A("Unknown castGPR element size: %d", Op->Header.ElementSize);
   }
 }
 
@@ -134,7 +134,7 @@ DEF_OP(Vector_FToZU) {
     case 8:
       fcvtzu(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D());
     break;
-    default: LogMan::Msg::A("Unknown castGPR element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A("Unknown castGPR element size: %d", Op->Header.ElementSize);
   }
 }
 
@@ -147,7 +147,7 @@ DEF_OP(Vector_FToZS) {
     case 8:
       fcvtzs(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D());
     break;
-    default: LogMan::Msg::A("Unknown castGPR element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A("Unknown castGPR element size: %d", Op->Header.ElementSize);
   }
 }
 
@@ -162,7 +162,7 @@ DEF_OP(Vector_FToU) {
       frinti(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D());
       fcvtzu(GetDst(Node).V2D(), GetDst(Node).V2D());
     break;
-    default: LogMan::Msg::A("Unknown castGPR element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A("Unknown castGPR element size: %d", Op->Header.ElementSize);
   }
 }
 
@@ -177,7 +177,7 @@ DEF_OP(Vector_FToS) {
       frinti(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D());
       fcvtzs(GetDst(Node).V2D(), GetDst(Node).V2D());
     break;
-    default: LogMan::Msg::A("Unknown castGPR element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A("Unknown castGPR element size: %d", Op->Header.ElementSize);
   }
 }
 
@@ -194,7 +194,7 @@ DEF_OP(Vector_FToF) {
       fcvtn(GetDst(Node).V2S(), GetSrc(Op->Header.Args[0].ID()).V2D());
       break;
     }
-    default: LogMan::Msg::A("Unknown Conversion Type : 0%04x", Conv); break;
+    default: LOGMAN_MSG_A("Unknown Conversion Type : 0%04x", Conv); break;
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -44,7 +44,7 @@ void Arm64JITCore::Op_Unhandled(FEXCore::IR::IROp_Header *IROp, uint32_t Node) {
   FallbackInfo Info;
   if (!InterpreterOps::GetFallbackHandler(IROp, &Info)) {
     auto Name = FEXCore::IR::GetName(IROp->Op);
-    LogMan::Msg::A("Unhandled IR Op: %s", std::string(Name).c_str());
+    LOGMAN_MSG_A("Unhandled IR Op: %s", std::string(Name).c_str());
   } else {
     switch(Info.ABI) {
       case FABI_VOID_U16:{
@@ -292,7 +292,7 @@ void Arm64JITCore::Op_Unhandled(FEXCore::IR::IROp_Header *IROp, uint32_t Node) {
       case FABI_UNKNOWN:
       default:
       auto Name = FEXCore::IR::GetName(IROp->Op);
-        LogMan::Msg::A("Unhandled IR Fallback abi: %s %d", std::string(Name).c_str(), Info.ABI);
+        LOGMAN_MSG_A("Unhandled IR Fallback abi: %s %d", std::string(Name).c_str(), Info.ABI);
     }
   }
 }
@@ -309,7 +309,7 @@ Arm64JITCore::CodeBuffer Arm64JITCore::AllocateNewCodeBuffer(size_t Size) {
                     PROT_READ | PROT_WRITE | PROT_EXEC,
                     MAP_PRIVATE | MAP_ANONYMOUS,
                     -1, 0));
-  LogMan::Throw::A(!!Buffer.Ptr, "Couldn't allocate code buffer");
+  LOGMAN_THROW_A(!!Buffer.Ptr, "Couldn't allocate code buffer");
   Dispatcher->RegisterCodeBuffer(Buffer.Ptr, Buffer.Size);
   return Buffer;
 }
@@ -578,7 +578,7 @@ Arm64JITCore::~Arm64JITCore() {
 IR::PhysicalRegister Arm64JITCore::GetPhys(uint32_t Node) {
   auto PhyReg = RAData->GetNodeRegister(Node);
 
-  LogMan::Throw::A(!PhyReg.IsInvalid(), "Couldn't Allocate register for node: ssa%d. Class: %d", Node, PhyReg.Class);
+  LOGMAN_THROW_A(!PhyReg.IsInvalid(), "Couldn't Allocate register for node: ssa%d. Class: %d", Node, PhyReg.Class);
 
   return PhyReg;
 }
@@ -592,7 +592,7 @@ aarch64::Register Arm64JITCore::GetReg<Arm64JITCore::RA_32>(uint32_t Node) {
   } else if (Reg.Class == IR::GPRClass.Val) {
     return RA64[Reg.Reg].W();
   } else {
-    LogMan::Throw::A(false, "Unexpected Class: %d", Reg.Class);
+    LOGMAN_THROW_A(false, "Unexpected Class: %d", Reg.Class);
   }
   __builtin_unreachable();
 }
@@ -606,7 +606,7 @@ aarch64::Register Arm64JITCore::GetReg<Arm64JITCore::RA_64>(uint32_t Node) {
   } else if (Reg.Class == IR::GPRClass.Val) {
     return RA64[Reg.Reg];
   } else {
-    LogMan::Throw::A(false, "Unexpected Class: %d", Reg.Class);
+    LOGMAN_THROW_A(false, "Unexpected Class: %d", Reg.Class);
   }
   __builtin_unreachable();
 }
@@ -631,7 +631,7 @@ aarch64::VRegister Arm64JITCore::GetSrc(uint32_t Node) {
   } else if (Reg.Class == IR::FPRClass.Val) {
     return RAFPR[Reg.Reg];
   } else {
-    LogMan::Throw::A(false, "Unexpected Class: %d", Reg.Class);
+    LOGMAN_THROW_A(false, "Unexpected Class: %d", Reg.Class);
   }
   __builtin_unreachable();
 }
@@ -644,7 +644,7 @@ aarch64::VRegister Arm64JITCore::GetDst(uint32_t Node) {
   } else if (Reg.Class == IR::FPRClass.Val) {
     return RAFPR[Reg.Reg];
   } else {
-    LogMan::Throw::A(false, "Unexpected Class: %d", Reg.Class);
+    LOGMAN_THROW_A(false, "Unexpected Class: %d", Reg.Class);
   }
   __builtin_unreachable();
 }
@@ -764,7 +764,7 @@ void *Arm64JITCore::CompileCode(uint64_t Entry, [[maybe_unused]] FEXCore::IR::IR
     bind(&RunBlock);
   }
 
-  //LogMan::Throw::A(RAData->HasFullRA(), "Arm64 JIT only works with RA");
+  //LOGMAN_THROW_A(RAData->HasFullRA(), "Arm64 JIT only works with RA");
 
   SpillSlots = RAData->SpillSlots();
 
@@ -782,7 +782,7 @@ void *Arm64JITCore::CompileCode(uint64_t Entry, [[maybe_unused]] FEXCore::IR::IR
   for (auto [BlockNode, BlockHeader] : IR->GetBlocks()) {
     using namespace FEXCore::IR;
     auto BlockIROp = BlockHeader->CW<FEXCore::IR::IROp_CodeBlock>();
-    LogMan::Throw::A(BlockIROp->Header.Op == IR::OP_CODEBLOCK, "IR type failed to be a code block");
+    LOGMAN_THROW_A(BlockIROp->Header.Op == IR::OP_CODEBLOCK, "IR type failed to be a code block");
 
     {
       uint32_t Node = IR->GetID(BlockNode);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -29,7 +29,7 @@ DEF_OP(LoadContext) {
     case 8:
       ldr(GetReg<RA_64>(Node), MemOperand(STATE, Op->Offset));
     break;
-    default:  LogMan::Msg::A("Unhandled LoadContext size: %d", OpSize);
+    default:  LOGMAN_MSG_A("Unhandled LoadContext size: %d", OpSize);
     }
   }
   else {
@@ -50,7 +50,7 @@ DEF_OP(LoadContext) {
     case 16:
       ldr(Dst, MemOperand(STATE, Op->Offset));
     break;
-    default:  LogMan::Msg::A("Unhandled LoadContext size: %d", OpSize);
+    default:  LOGMAN_MSG_A("Unhandled LoadContext size: %d", OpSize);
     }
   }
 }
@@ -72,7 +72,7 @@ DEF_OP(StoreContext) {
     case 8:
       str(GetReg<RA_64>(Op->Header.Args[0].ID()), MemOperand(STATE, Op->Offset));
     break;
-    default:  LogMan::Msg::A("Unhandled StoreContext size: %d", OpSize);
+    default:  LOGMAN_MSG_A("Unhandled StoreContext size: %d", OpSize);
     }
   }
   else {
@@ -93,7 +93,7 @@ DEF_OP(StoreContext) {
     case 16:
       str(Src, MemOperand(STATE, Op->Offset));
     break;
-    default:  LogMan::Msg::A("Unhandled LoadContext size: %d", OpSize);
+    default:  LOGMAN_MSG_A("Unhandled LoadContext size: %d", OpSize);
     }
   }
 }
@@ -106,29 +106,29 @@ DEF_OP(LoadRegister) {
     auto regId = (Op->Offset - offsetof(FEXCore::Core::CpuStateFrame, State.gregs[0])) / 8;
     auto regOffs = Op->Offset & 7;
 
-    LogMan::Throw::A(regId < SRA64.size(), "out of range regId");
+    LOGMAN_THROW_A(regId < SRA64.size(), "out of range regId");
 
     auto reg = SRA64[regId];
 
     switch(Op->Header.Size) {
       case 1:
-        LogMan::Throw::A(regOffs == 0 || regOffs == 1, "unexpected regOffs");
+        LOGMAN_THROW_A(regOffs == 0 || regOffs == 1, "unexpected regOffs");
         ubfx(GetReg<RA_64>(Node), reg, regOffs * 8, 8);
         break;
 
       case 2:
-        LogMan::Throw::A(regOffs == 0, "unexpected regOffs");
+        LOGMAN_THROW_A(regOffs == 0, "unexpected regOffs");
         ubfx(GetReg<RA_64>(Node), reg, 0, 16);
         break;
 
       case 4:
-        LogMan::Throw::A(regOffs == 0, "unexpected regOffs");
+        LOGMAN_THROW_A(regOffs == 0, "unexpected regOffs");
         if (GetReg<RA_64>(Node).GetCode() != reg.GetCode())
           mov(GetReg<RA_32>(Node), reg.W());
         break;
 
       case 8:
-        LogMan::Throw::A(regOffs == 0, "unexpected regOffs");
+        LOGMAN_THROW_A(regOffs == 0, "unexpected regOffs");
         if (GetReg<RA_64>(Node).GetCode() != reg.GetCode())
           mov(GetReg<RA_64>(Node), reg);
         break;
@@ -137,24 +137,24 @@ DEF_OP(LoadRegister) {
     auto regId = (Op->Offset - offsetof(FEXCore::Core::CpuStateFrame, State.xmm[0][0])) / 16;
     auto regOffs = Op->Offset & 15;
 
-    LogMan::Throw::A(regId < SRAFPR.size(), "out of range regId");
+    LOGMAN_THROW_A(regId < SRAFPR.size(), "out of range regId");
 
     auto guest = SRAFPR[regId];
     auto host = GetSrc(Node);
 
     switch(Op->Header.Size) {
       case 1:
-        LogMan::Throw::A(regOffs == 0, "unexpected regOffs");
+        LOGMAN_THROW_A(regOffs == 0, "unexpected regOffs");
         mov(host.B(), guest.B());
         break;
 
       case 2:
-        LogMan::Throw::A(regOffs == 0, "unexpected regOffs");
+        LOGMAN_THROW_A(regOffs == 0, "unexpected regOffs");
         fmov(host.H(), guest.H());
         break;
 
       case 4:
-        LogMan::Throw::A((regOffs & 3) == 0, "unexpected regOffs");
+        LOGMAN_THROW_A((regOffs & 3) == 0, "unexpected regOffs");
         if (regOffs == 0) {
           if (host.GetCode() != guest.GetCode())
             fmov(host.S(), guest.S());
@@ -164,7 +164,7 @@ DEF_OP(LoadRegister) {
         break;
 
       case 8:
-        LogMan::Throw::A((regOffs & 7) == 0, "unexpected regOffs");
+        LOGMAN_THROW_A((regOffs & 7) == 0, "unexpected regOffs");
         if (regOffs == 0) {
           if (host.GetCode() != guest.GetCode())
             mov(host.D(), guest.D());
@@ -174,13 +174,13 @@ DEF_OP(LoadRegister) {
         break;
 
       case 16:
-        LogMan::Throw::A(regOffs == 0, "unexpected regOffs");
+        LOGMAN_THROW_A(regOffs == 0, "unexpected regOffs");
         if (host.GetCode() != guest.GetCode())
           mov(host.Q(), guest.Q());
         break;
     }
   } else {
-    LogMan::Throw::A(false, "Unhandled Op->Class %d", Op->Class);
+    LOGMAN_THROW_A(false, "Unhandled Op->Class %d", Op->Class);
   }
 }
 
@@ -191,28 +191,28 @@ DEF_OP(StoreRegister) {
     auto regId = Op->Offset / 8 - 1;
     auto regOffs = Op->Offset & 7;
 
-    LogMan::Throw::A(regId < SRA64.size(), "out of range regId");
+    LOGMAN_THROW_A(regId < SRA64.size(), "out of range regId");
 
     auto reg = SRA64[regId];
 
     switch(Op->Header.Size) {
       case 1:
-        LogMan::Throw::A(regOffs == 0 || regOffs == 1, "unexpected regOffs");
+        LOGMAN_THROW_A(regOffs == 0 || regOffs == 1, "unexpected regOffs");
         bfi(reg, GetReg<RA_64>(Op->Value.ID()), regOffs * 8, 8);
         break;
 
       case 2:
-        LogMan::Throw::A(regOffs == 0, "unexpected regOffs");
+        LOGMAN_THROW_A(regOffs == 0, "unexpected regOffs");
         bfi(reg, GetReg<RA_64>(Op->Value.ID()), 0, 16);
         break;
 
       case 4:
-        LogMan::Throw::A(regOffs == 0, "unexpected regOffs");
+        LOGMAN_THROW_A(regOffs == 0, "unexpected regOffs");
         bfi(reg, GetReg<RA_64>(Op->Value.ID()), 0, 32);
         break;
 
       case 8:
-        LogMan::Throw::A(regOffs == 0, "unexpected regOffs");
+        LOGMAN_THROW_A(regOffs == 0, "unexpected regOffs");
         if (GetReg<RA_64>(Op->Value.ID()).GetCode() != reg.GetCode())
           mov(reg, GetReg<RA_64>(Op->Value.ID()));
         break;
@@ -221,7 +221,7 @@ DEF_OP(StoreRegister) {
     auto regId = (Op->Offset - offsetof(FEXCore::Core::CpuStateFrame, State.xmm[0][0])) / 16;
     auto regOffs = Op->Offset & 15;
 
-    LogMan::Throw::A(regId < SRAFPR.size(), "regId out of range");
+    LOGMAN_THROW_A(regId < SRAFPR.size(), "regId out of range");
 
     auto guest = SRAFPR[regId];
     auto host = GetSrc(Op->Value.ID());
@@ -232,28 +232,28 @@ DEF_OP(StoreRegister) {
         break;
 
       case 2:
-        LogMan::Throw::A((regOffs & 1) == 0, "unexpected regOffs");
+        LOGMAN_THROW_A((regOffs & 1) == 0, "unexpected regOffs");
         ins(guest.V8H(), regOffs/2, host.V8H(), 0);
         break;
 
       case 4:
-        LogMan::Throw::A((regOffs & 3) == 0, "unexpected regOffs");
+        LOGMAN_THROW_A((regOffs & 3) == 0, "unexpected regOffs");
         ins(guest.V4S(), regOffs/4, host.V4S(), 0);
         break;
 
       case 8:
-        LogMan::Throw::A((regOffs & 7) == 0, "unexpected regOffs");
+        LOGMAN_THROW_A((regOffs & 7) == 0, "unexpected regOffs");
         ins(guest.V2D(), regOffs / 8, host.V2D(), 0);
         break;
 
       case 16:
-        LogMan::Throw::A(regOffs == 0, "unexpected regOffs");
+        LOGMAN_THROW_A(regOffs == 0, "unexpected regOffs");
         if (guest.GetCode() != host.GetCode())
           mov(guest.Q(), host.Q());
         break;
     }
   } else {
-    LogMan::Throw::A(false, "Unhandled Op->Class %d", Op->Class);
+    LOGMAN_THROW_A(false, "Unhandled Op->Class %d", Op->Class);
   }
 }
 
@@ -287,15 +287,15 @@ DEF_OP(LoadContextIndexed) {
         ldr(GetReg<RA_64>(Node), MemOperand(TMP1, Op->BaseOffset));
         break;
       default:
-        LogMan::Msg::A("Unhandled LoadContextIndexed size: %d", Op->Size);
+        LOGMAN_MSG_A("Unhandled LoadContextIndexed size: %d", Op->Size);
       }
       break;
     }
     case 16:
-      LogMan::Msg::A("Invalid Class load of size 16");
+      LOGMAN_MSG_A("Invalid Class load of size 16");
       break;
     default:
-      LogMan::Msg::A("Unhandled LoadContextIndexed stride: %d", Op->Stride);
+      LOGMAN_MSG_A("Unhandled LoadContextIndexed stride: %d", Op->Stride);
     }
   }
   else {
@@ -332,12 +332,12 @@ DEF_OP(LoadContextIndexed) {
         }
         break;
       default:
-        LogMan::Msg::A("Unhandled LoadContextIndexed size: %d", Op->Size);
+        LOGMAN_MSG_A("Unhandled LoadContextIndexed size: %d", Op->Size);
       }
       break;
     }
     default:
-      LogMan::Msg::A("Unhandled LoadContextIndexed stride: %d", Op->Stride);
+      LOGMAN_MSG_A("Unhandled LoadContextIndexed stride: %d", Op->Stride);
     }
   }
 }
@@ -373,15 +373,15 @@ DEF_OP(StoreContextIndexed) {
         str(value, MemOperand(TMP1, Op->BaseOffset));
         break;
       default:
-        LogMan::Msg::A("Unhandled LoadContextIndexed size: %d", Op->Size);
+        LOGMAN_MSG_A("Unhandled LoadContextIndexed size: %d", Op->Size);
       }
       break;
     }
     case 16:
-      LogMan::Msg::A("Invalid Class load of size 16");
+      LOGMAN_MSG_A("Invalid Class load of size 16");
       break;
     default:
-      LogMan::Msg::A("Unhandled LoadContextIndexed stride: %d", Op->Stride);
+      LOGMAN_MSG_A("Unhandled LoadContextIndexed stride: %d", Op->Stride);
     }
   }
   else {
@@ -420,12 +420,12 @@ DEF_OP(StoreContextIndexed) {
         }
         break;
       default:
-        LogMan::Msg::A("Unhandled LoadContextIndexed size: %d", Op->Size);
+        LOGMAN_MSG_A("Unhandled LoadContextIndexed size: %d", Op->Size);
       }
       break;
     }
     default:
-      LogMan::Msg::A("Unhandled LoadContextIndexed stride: %d", Op->Stride);
+      LOGMAN_MSG_A("Unhandled LoadContextIndexed stride: %d", Op->Stride);
     }
   }
 }
@@ -453,7 +453,7 @@ DEF_OP(SpillRegister) {
       str(GetReg<RA_64>(Op->Header.Args[0].ID()), MemOperand(sp, SlotOffset));
       break;
     }
-    default:  LogMan::Msg::A("Unhandled SpillRegister size: %d", OpSize);
+    default:  LOGMAN_MSG_A("Unhandled SpillRegister size: %d", OpSize);
     }
   } else if (Op->Class == FEXCore::IR::FPRClass) {
     switch (OpSize) {
@@ -469,10 +469,10 @@ DEF_OP(SpillRegister) {
       str(GetSrc(Op->Header.Args[0].ID()), MemOperand(sp, SlotOffset));
       break;
     }
-    default:  LogMan::Msg::A("Unhandled SpillRegister size: %d", OpSize);
+    default:  LOGMAN_MSG_A("Unhandled SpillRegister size: %d", OpSize);
     }
   } else {
-    LogMan::Msg::A("Unhandled SpillRegister class: %d", Op->Class.Val);
+    LOGMAN_MSG_A("Unhandled SpillRegister class: %d", Op->Class.Val);
   }
 }
 
@@ -499,7 +499,7 @@ DEF_OP(FillRegister) {
       ldr(GetReg<RA_64>(Node), MemOperand(sp, SlotOffset));
       break;
     }
-    default:  LogMan::Msg::A("Unhandled SpillRegister size: %d", OpSize);
+    default:  LOGMAN_MSG_A("Unhandled SpillRegister size: %d", OpSize);
     }
   } else if (Op->Class == FEXCore::IR::FPRClass) {
     switch (OpSize) {
@@ -515,10 +515,10 @@ DEF_OP(FillRegister) {
       ldr(GetDst(Node), MemOperand(sp, SlotOffset));
       break;
     }
-    default:  LogMan::Msg::A("Unhandled SpillRegister size: %d", OpSize);
+    default:  LOGMAN_MSG_A("Unhandled SpillRegister size: %d", OpSize);
     }
   } else {
-    LogMan::Msg::A("Unhandled FillRegister class: %d", Op->Class.Val);
+    LOGMAN_MSG_A("Unhandled FillRegister class: %d", Op->Class.Val);
   }
 }
 
@@ -538,7 +538,7 @@ MemOperand Arm64JITCore::GenerateMemOperand(uint8_t AccessSize, aarch64::Registe
     return MemOperand(Base);
   } else {
     if (OffsetScale != 1 && OffsetScale != AccessSize) {
-        LogMan::Msg::A("Unhandled GenerateMemOperand OffsetScale: %d", OffsetScale);
+        LOGMAN_MSG_A("Unhandled GenerateMemOperand OffsetScale: %d", OffsetScale);
     }
     uint64_t Const;
     if (IsInlineConstant(Offset, &Const)) {
@@ -550,7 +550,7 @@ MemOperand Arm64JITCore::GenerateMemOperand(uint8_t AccessSize, aarch64::Registe
         case IR::MEM_OFFSET_UXTW.Val: return MemOperand(Base, RegOffset.W(), Extend::UXTW, (int)std::log2(OffsetScale) );
         case IR::MEM_OFFSET_SXTW.Val: return MemOperand(Base, RegOffset.W(), Extend::SXTW, (int)std::log2(OffsetScale) );
 
-        default: LogMan::Msg::A("Unhandled GenerateMemOperand OffsetType: %d", OffsetType.Val); break;
+        default: LOGMAN_MSG_A("Unhandled GenerateMemOperand OffsetType: %d", OffsetType.Val); break;
       }
     }
   }
@@ -578,7 +578,7 @@ DEF_OP(LoadMem) {
       case 8:
         ldr(Dst, MemSrc);
         break;
-      default:  LogMan::Msg::A("Unhandled LoadMem size: %d", Op->Size);
+      default:  LOGMAN_MSG_A("Unhandled LoadMem size: %d", Op->Size);
     }
   }
   else {
@@ -599,7 +599,7 @@ DEF_OP(LoadMem) {
       case 16:
         ldr(Dst, MemSrc);
         break;
-      default:  LogMan::Msg::A("Unhandled LoadMem size: %d", Op->Size);
+      default:  LOGMAN_MSG_A("Unhandled LoadMem size: %d", Op->Size);
     }
   }
 }
@@ -610,7 +610,7 @@ DEF_OP(LoadMemTSO) {
   auto MemSrc = MemOperand(GetReg<RA_64>(Op->Header.Args[0].ID()));
 
   if (!Op->Offset.IsInvalid()) {
-    LogMan::Msg::A("LoadMemTSO: No offset allowed");
+    LOGMAN_MSG_A("LoadMemTSO: No offset allowed");
   }
 
   if (SupportsRCPC && Op->Class == FEXCore::IR::GPRClass) {
@@ -633,7 +633,7 @@ DEF_OP(LoadMemTSO) {
         case 8:
           ldapr(Dst, MemSrc);
           break;
-        default:  LogMan::Msg::A("Unhandled LoadMem size: %d", Op->Size);
+        default:  LOGMAN_MSG_A("Unhandled LoadMem size: %d", Op->Size);
       }
       nop();
     }
@@ -658,7 +658,7 @@ DEF_OP(LoadMemTSO) {
         case 8:
           ldar(Dst, MemSrc);
           break;
-        default:  LogMan::Msg::A("Unhandled LoadMem size: %d", Op->Size);
+        default:  LOGMAN_MSG_A("Unhandled LoadMem size: %d", Op->Size);
       }
       nop();
     }
@@ -679,7 +679,7 @@ DEF_OP(LoadMemTSO) {
       case 16:
         ldr(Dst, MemSrc);
         break;
-      default:  LogMan::Msg::A("Unhandled LoadMem size: %d", Op->Size);
+      default:  LOGMAN_MSG_A("Unhandled LoadMem size: %d", Op->Size);
     }
     dmb(InnerShareable, BarrierAll);
   }
@@ -706,7 +706,7 @@ DEF_OP(StoreMem) {
       case 8:
         str(GetReg<RA_64>(Op->Header.Args[1].ID()), MemSrc);
         break;
-      default:  LogMan::Msg::A("Unhandled StoreMem size: %d", Op->Size);
+      default:  LOGMAN_MSG_A("Unhandled StoreMem size: %d", Op->Size);
     }
   }
   else {
@@ -727,7 +727,7 @@ DEF_OP(StoreMem) {
       case 16:
         str(Src, MemSrc);
         break;
-      default:  LogMan::Msg::A("Unhandled StoreMem size: %d", Op->Size);
+      default:  LOGMAN_MSG_A("Unhandled StoreMem size: %d", Op->Size);
     }
   }
 }
@@ -737,7 +737,7 @@ DEF_OP(StoreMemTSO) {
   auto MemSrc = MemOperand(GetReg<RA_64>(Op->Header.Args[0].ID()));
 
   if (!Op->Offset.IsInvalid()) {
-    LogMan::Msg::A("StoreMemTSO: No offset allowed");
+    LOGMAN_MSG_A("StoreMemTSO: No offset allowed");
   }
 
   if (Op->Class == FEXCore::IR::GPRClass) {
@@ -757,7 +757,7 @@ DEF_OP(StoreMemTSO) {
         case 8:
           stlr(GetReg<RA_64>(Op->Header.Args[1].ID()), MemSrc);
           break;
-        default:  LogMan::Msg::A("Unhandled StoreMem size: %d", Op->Size);
+        default:  LOGMAN_MSG_A("Unhandled StoreMem size: %d", Op->Size);
       }
       nop();
     }
@@ -781,7 +781,7 @@ DEF_OP(StoreMemTSO) {
       case 16:
         str(Src, MemSrc);
         break;
-      default:  LogMan::Msg::A("Unhandled StoreMem size: %d", Op->Size);
+      default:  LOGMAN_MSG_A("Unhandled StoreMem size: %d", Op->Size);
     }
     dmb(InnerShareable, BarrierAll);
   }
@@ -793,7 +793,7 @@ DEF_OP(ParanoidLoadMemTSO) {
   auto MemSrc = MemOperand(GetReg<RA_64>(Op->Header.Args[0].ID()));
 
   if (!Op->Offset.IsInvalid()) {
-    LogMan::Msg::A("LoadMemTSO: No offset allowed");
+    LOGMAN_MSG_A("LoadMemTSO: No offset allowed");
   }
 
   if (Op->Class == FEXCore::IR::GPRClass) {
@@ -815,7 +815,7 @@ DEF_OP(ParanoidLoadMemTSO) {
         case 8:
           ldar(Dst, MemSrc);
           break;
-        default:  LogMan::Msg::A("Unhandled LoadMem size: %d", Op->Size);
+        default:  LOGMAN_MSG_A("Unhandled LoadMem size: %d", Op->Size);
       }
       nop();
     }
@@ -848,7 +848,7 @@ DEF_OP(ParanoidLoadMemTSO) {
         mov(Dst.V2D(), 0, TMP1);
         mov(Dst.V2D(), 1, TMP2);
         break;
-      default:  LogMan::Msg::A("Unhandled LoadMem size: %d", Op->Size);
+      default:  LOGMAN_MSG_A("Unhandled LoadMem size: %d", Op->Size);
     }
   }
 }
@@ -858,7 +858,7 @@ DEF_OP(ParanoidStoreMemTSO) {
   auto MemSrc = MemOperand(GetReg<RA_64>(Op->Header.Args[0].ID()));
 
   if (!Op->Offset.IsInvalid()) {
-    LogMan::Msg::A("StoreMemTSO: No offset allowed");
+    LOGMAN_MSG_A("StoreMemTSO: No offset allowed");
   }
 
   if (Op->Class == FEXCore::IR::GPRClass) {
@@ -878,7 +878,7 @@ DEF_OP(ParanoidStoreMemTSO) {
         case 8:
           stlr(GetReg<RA_64>(Op->Header.Args[1].ID()), MemSrc);
           break;
-        default:  LogMan::Msg::A("Unhandled StoreMem size: %d", Op->Size);
+        default:  LOGMAN_MSG_A("Unhandled StoreMem size: %d", Op->Size);
       }
       nop();
     }
@@ -925,18 +925,18 @@ DEF_OP(ParanoidStoreMemTSO) {
           cbnz(TMP3, &B); // < Overwritten with DMB
           break;
         }
-        default:  LogMan::Msg::A("Unhandled StoreMem size: %d", Op->Size);
+        default:  LOGMAN_MSG_A("Unhandled StoreMem size: %d", Op->Size);
       }
     }
   }
 }
 
 DEF_OP(VLoadMemElement) {
-  LogMan::Msg::A("Unimplemented");
+  LOGMAN_MSG_A("Unimplemented");
 }
 
 DEF_OP(VStoreMemElement) {
-  LogMan::Msg::A("Unimplemented");
+  LOGMAN_MSG_A("Unimplemented");
 }
 
 #undef DEF_OP

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
@@ -31,7 +31,7 @@ DEF_OP(Fence) {
     case IR::Fence_Store.Val:
       dmb(FullSystem, BarrierWrites);
       break;
-    default: LogMan::Msg::A("Unknown Fence: %d", Op->Fence); break;
+    default: LOGMAN_MSG_A("Unknown Fence: %d", Op->Fence); break;
   }
 }
 
@@ -60,7 +60,7 @@ DEF_OP(Break) {
       br(TMP1);
       break;
     }
-    default: LogMan::Msg::A("Unknown Break reason: %d", Op->Reason);
+    default: LOGMAN_MSG_A("Unknown Break reason: %d", Op->Reason);
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MoveOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MoveOps.cpp
@@ -26,7 +26,7 @@ DEF_OP(ExtractElementPair) {
       mov (GetReg<RA_64>(Node), Regs[Op->Element]);
       break;
     }
-    default: LogMan::Msg::A("Unknown Size"); break;
+    default: LOGMAN_MSG_A("Unknown Size"); break;
   }
 }
 
@@ -52,7 +52,7 @@ DEF_OP(CreateElementPair) {
       RegTmp = x0;
       break;
     }
-    default: LogMan::Msg::A("Unknown Size"); break;
+    default: LOGMAN_MSG_A("Unknown Size"); break;
   }
 
   if (Dst.first.GetCode() != RegSecond.GetCode()) {

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -22,7 +22,7 @@ DEF_OP(VectorZero) {
        eor(GetDst(Node).V16B(), GetDst(Node).V16B(), GetDst(Node).V16B());
        break;
      }
-    default: LogMan::Msg::A("Unknown Element Size: %d", OpSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", OpSize); break;
   }
 }
 
@@ -43,17 +43,17 @@ DEF_OP(VectorImm) {
 }
 
 DEF_OP(CreateVector2) {
-  LogMan::Msg::A("Unimplemented");
+  LOGMAN_MSG_A("Unimplemented");
 }
 
 DEF_OP(CreateVector4) {
-  LogMan::Msg::A("Unimplemented");
+  LOGMAN_MSG_A("Unimplemented");
 }
 
 DEF_OP(SplatVector2) {
 	auto Op = IROp->C<IR::IROp_SplatVector2>();
   uint8_t OpSize = IROp->Size;
-	LogMan::Throw::A(OpSize <= 16, "Can't handle a vector of size: %d", OpSize);
+	LOGMAN_THROW_A(OpSize <= 16, "Can't handle a vector of size: %d", OpSize);
 
 	uint8_t ElementSize = OpSize / 2;
 
@@ -64,14 +64,14 @@ DEF_OP(SplatVector2) {
 		case 8:
 			dup(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), 0);
 		break;
-		default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.Size); break;
+		default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.Size); break;
 	}
 }
 
 DEF_OP(SplatVector4) {
 	auto Op = IROp->C<IR::IROp_SplatVector4>();
   uint8_t OpSize = IROp->Size;
-	LogMan::Throw::A(OpSize <= 16, "Can't handle a vector of size: %d", OpSize);
+	LOGMAN_THROW_A(OpSize <= 16, "Can't handle a vector of size: %d", OpSize);
 
 	uint8_t ElementSize = OpSize / 4;
 
@@ -82,7 +82,7 @@ DEF_OP(SplatVector4) {
 		case 8:
 			dup(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), 0);
 		break;
-		default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.Size); break;
+		default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.Size); break;
 	}
 }
 
@@ -118,7 +118,7 @@ DEF_OP(VMov) {
 			  mov(GetDst(Node).V16B(), GetSrc(Op->Header.Args[0].ID()).V16B());
 			break;
 		}
-		default: LogMan::Msg::A("Unknown Element Size: %d", OpSize); break;
+		default: LOGMAN_MSG_A("Unknown Element Size: %d", OpSize); break;
 	}
 }
 
@@ -156,7 +156,7 @@ DEF_OP(VAdd) {
       add(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
     break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -179,7 +179,7 @@ DEF_OP(VSub) {
       sub(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
     break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -202,7 +202,7 @@ DEF_OP(VUQAdd) {
       uqadd(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
     break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -225,7 +225,7 @@ DEF_OP(VUQSub) {
       uqsub(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
     break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -248,7 +248,7 @@ DEF_OP(VSQAdd) {
       sqadd(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
     break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -271,7 +271,7 @@ DEF_OP(VSQSub) {
       sqsub(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
     break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -293,7 +293,7 @@ DEF_OP(VAddP) {
         addp(GetDst(Node).V2S(), GetSrc(Op->Header.Args[0].ID()).V2S(), GetSrc(Op->Header.Args[1].ID()).V2S());
         break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -314,7 +314,7 @@ DEF_OP(VAddP) {
         addp(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
         break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
 }
@@ -333,7 +333,7 @@ DEF_OP(VAddV) {
     case 8:
       addp(GetDst(Node).VCast(OpSize * 8, 1), GetSrc(Op->Header.Args[0].ID()).VCast(OpSize * 8, Elements));
       break;
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -348,7 +348,7 @@ DEF_OP(VURAvg) {
       urhadd(GetDst(Node).V8H(), GetSrc(Op->Header.Args[0].ID()).V8H(), GetSrc(Op->Header.Args[1].ID()).V8H());
     break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -363,7 +363,7 @@ DEF_OP(VAbs) {
         abs(GetDst(Node).D(), GetSrc(Op->Header.Args[0].ID()).D());
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -375,7 +375,7 @@ DEF_OP(VAbs) {
       case 8:
         abs(GetDst(Node).VCast(OpSize * 8, Elements), GetSrc(Op->Header.Args[0].ID()).VCast(OpSize * 8, Elements));
         break;
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
 }
@@ -394,7 +394,7 @@ DEF_OP(VFAdd) {
         fadd(GetDst(Node).D(), GetSrc(Op->Header.Args[0].ID()).D(), GetSrc(Op->Header.Args[1].ID()).D());
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -408,7 +408,7 @@ DEF_OP(VFAdd) {
         fadd(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
 }
@@ -424,7 +424,7 @@ DEF_OP(VFAddP) {
       faddp(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
     break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -442,7 +442,7 @@ DEF_OP(VFSub) {
         fsub(GetDst(Node).D(), GetSrc(Op->Header.Args[0].ID()).D(), GetSrc(Op->Header.Args[1].ID()).D());
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -456,7 +456,7 @@ DEF_OP(VFSub) {
         fsub(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
 }
@@ -475,7 +475,7 @@ DEF_OP(VFMul) {
         fmul(GetDst(Node).D(), GetSrc(Op->Header.Args[0].ID()).D(), GetSrc(Op->Header.Args[1].ID()).D());
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -489,7 +489,7 @@ DEF_OP(VFMul) {
         fmul(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
 }
@@ -508,7 +508,7 @@ DEF_OP(VFDiv) {
         fdiv(GetDst(Node).D(), GetSrc(Op->Header.Args[0].ID()).D(), GetSrc(Op->Header.Args[1].ID()).D());
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -522,7 +522,7 @@ DEF_OP(VFDiv) {
         fdiv(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
 }
@@ -543,7 +543,7 @@ DEF_OP(VFMin) {
         fcsel(GetDst(Node).D(), GetSrc(Op->Header.Args[0].ID()).D(), GetSrc(Op->Header.Args[1].ID()).D(), Condition::mi);
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -563,7 +563,7 @@ DEF_OP(VFMin) {
         mov(GetDst(Node).V2D(), VTMP2.V2D());
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
 }
@@ -584,7 +584,7 @@ DEF_OP(VFMax) {
         fcsel(GetDst(Node).D(), GetSrc(Op->Header.Args[1].ID()).D(), GetSrc(Op->Header.Args[0].ID()).D(), Condition::mi);
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -604,7 +604,7 @@ DEF_OP(VFMax) {
         mov(GetDst(Node).V2D(), VTMP2.V2D());
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
 }
@@ -625,7 +625,7 @@ DEF_OP(VFRecp) {
         fdiv(GetDst(Node).D(), VTMP1.D(), GetSrc(Op->Header.Args[0].ID()).D());
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -641,7 +641,7 @@ DEF_OP(VFRecp) {
         fdiv(GetDst(Node).V2D(), VTMP1.V2D(), GetSrc(Op->Header.Args[0].ID()).V2D());
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
 }
@@ -660,7 +660,7 @@ DEF_OP(VFSqrt) {
         fsqrt(GetDst(Node).D(), GetSrc(Op->Header.Args[0].ID()).D());
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -674,7 +674,7 @@ DEF_OP(VFSqrt) {
         fsqrt(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D());
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
 }
@@ -697,7 +697,7 @@ DEF_OP(VFRSqrt) {
         fdiv(GetDst(Node).D(), VTMP1.D(), VTMP2.D());
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -715,7 +715,7 @@ DEF_OP(VFRSqrt) {
         fdiv(GetDst(Node).V2D(), VTMP1.V2D(), VTMP2.V2D());
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
 }
@@ -736,7 +736,7 @@ DEF_OP(VNeg) {
   case 8:
     neg(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D());
     break;
-  default: LogMan::Msg::A("Unsupported Not size: %d", OpSize);
+  default: LOGMAN_MSG_A("Unsupported Not size: %d", OpSize);
   }
 }
 
@@ -750,7 +750,7 @@ DEF_OP(VFNeg) {
   case 8:
     fneg(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D());
     break;
-  default: LogMan::Msg::A("Unsupported Not size: %d", OpSize);
+  default: LOGMAN_MSG_A("Unsupported Not size: %d", OpSize);
   }
 }
 
@@ -781,7 +781,7 @@ DEF_OP(VUMin) {
       mov(GetDst(Node).V2D(), VTMP2.V2D());
     break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -807,7 +807,7 @@ DEF_OP(VSMin) {
       mov(GetDst(Node).V2D(), VTMP2.V2D());
     break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -833,7 +833,7 @@ DEF_OP(VUMax) {
       mov(GetDst(Node).V2D(), VTMP2.V2D());
     break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -859,7 +859,7 @@ DEF_OP(VSMax) {
       mov(GetDst(Node).V2D(), VTMP2.V2D());
     break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -880,7 +880,7 @@ DEF_OP(VZip) {
         zip1(GetDst(Node).V2S(), GetSrc(Op->Header.Args[0].ID()).V2S(), GetSrc(Op->Header.Args[1].ID()).V2S());
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -901,7 +901,7 @@ DEF_OP(VZip) {
         zip1(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
 }
@@ -923,7 +923,7 @@ DEF_OP(VZip2) {
       zip2(GetDst(Node).V2S(), GetSrc(Op->Header.Args[0].ID()).V2S(), GetSrc(Op->Header.Args[1].ID()).V2S());
     break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -944,7 +944,7 @@ DEF_OP(VZip2) {
       zip2(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
     break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
 }
@@ -977,7 +977,7 @@ DEF_OP(VCMPEQ) {
         cmeq(GetDst(Node).D(), GetSrc(Op->Header.Args[0].ID()).D(), GetSrc(Op->Header.Args[1].ID()).D());
       break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -999,7 +999,7 @@ DEF_OP(VCMPEQ) {
         cmeq(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
       break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
 }
@@ -1018,7 +1018,7 @@ DEF_OP(VCMPEQZ) {
         cmeq(GetDst(Node).D(), GetSrc(Op->Header.Args[0].ID()).D(), 0);
       break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -1040,7 +1040,7 @@ DEF_OP(VCMPEQZ) {
         cmeq(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), 0);
       break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
 }
@@ -1059,7 +1059,7 @@ DEF_OP(VCMPGT) {
         cmgt(GetDst(Node).D(), GetSrc(Op->Header.Args[0].ID()).D(), GetSrc(Op->Header.Args[1].ID()).D());
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -1081,7 +1081,7 @@ DEF_OP(VCMPGT) {
         cmgt(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
 }
@@ -1100,7 +1100,7 @@ DEF_OP(VCMPGTZ) {
         cmgt(GetDst(Node).D(), GetSrc(Op->Header.Args[0].ID()).D(), 0);
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -1122,7 +1122,7 @@ DEF_OP(VCMPGTZ) {
         cmgt(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), 0);
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
 }
@@ -1141,7 +1141,7 @@ DEF_OP(VCMPLTZ) {
         cmlt(GetDst(Node).D(), GetSrc(Op->Header.Args[0].ID()).D(), 0);
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -1163,7 +1163,7 @@ DEF_OP(VCMPLTZ) {
         cmlt(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), 0);
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
 }
@@ -1182,7 +1182,7 @@ DEF_OP(VFCMPEQ) {
         fcmeq(GetDst(Node).D(), GetSrc(Op->Header.Args[0].ID()).D(), GetSrc(Op->Header.Args[1].ID()).D());
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -1200,7 +1200,7 @@ DEF_OP(VFCMPEQ) {
         fcmeq(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
 }
@@ -1219,7 +1219,7 @@ DEF_OP(VFCMPNEQ) {
         fcmeq(GetDst(Node).D(), GetSrc(Op->Header.Args[0].ID()).D(), GetSrc(Op->Header.Args[1].ID()).D());
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
     mvn(GetDst(Node).V8B(), GetDst(Node).V8B());
   }
@@ -1238,7 +1238,7 @@ DEF_OP(VFCMPNEQ) {
         fcmeq(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
     mvn(GetDst(Node).V16B(), GetDst(Node).V16B());
   }
@@ -1258,7 +1258,7 @@ DEF_OP(VFCMPLT) {
         fcmgt(GetDst(Node).D(), GetSrc(Op->Header.Args[1].ID()).D(), GetSrc(Op->Header.Args[0].ID()).D());
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -1276,7 +1276,7 @@ DEF_OP(VFCMPLT) {
         fcmgt(GetDst(Node).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D());
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
 }
@@ -1295,7 +1295,7 @@ DEF_OP(VFCMPGT) {
         fcmgt(GetDst(Node).D(), GetSrc(Op->Header.Args[0].ID()).D(), GetSrc(Op->Header.Args[1].ID()).D());
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -1313,7 +1313,7 @@ DEF_OP(VFCMPGT) {
         fcmgt(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
 }
@@ -1332,7 +1332,7 @@ DEF_OP(VFCMPLE) {
         fcmge(GetDst(Node).D(), GetSrc(Op->Header.Args[1].ID()).D(), GetSrc(Op->Header.Args[0].ID()).D());
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -1350,7 +1350,7 @@ DEF_OP(VFCMPLE) {
         fcmge(GetDst(Node).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D());
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
 }
@@ -1373,7 +1373,7 @@ DEF_OP(VFCMPORD) {
         orr(GetDst(Node).V8B(), VTMP1.V8B(), VTMP2.V8B());
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -1397,7 +1397,7 @@ DEF_OP(VFCMPORD) {
         orr(GetDst(Node).V16B(), VTMP1.V16B(), VTMP2.V16B());
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
 }
@@ -1422,7 +1422,7 @@ DEF_OP(VFCMPUNO) {
         mvn(GetDst(Node).V8B(), GetDst(Node).V8B());
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -1449,21 +1449,21 @@ DEF_OP(VFCMPUNO) {
         mvn(GetDst(Node).V16B(), GetDst(Node).V16B());
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
 }
 
 DEF_OP(VUShl) {
-  LogMan::Msg::A("Unimplemented");
+  LOGMAN_MSG_A("Unimplemented");
 }
 
 DEF_OP(VUShr) {
-  LogMan::Msg::A("Unimplemented");
+  LOGMAN_MSG_A("Unimplemented");
 }
 
 DEF_OP(VSShr) {
-  LogMan::Msg::A("Unimplemented");
+  LOGMAN_MSG_A("Unimplemented");
 }
 
 DEF_OP(VUShlS) {
@@ -1490,7 +1490,7 @@ DEF_OP(VUShlS) {
       ushl(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), VTMP1.V2D());
     break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -1522,7 +1522,7 @@ DEF_OP(VUShrS) {
       ushl(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), VTMP1.V2D());
     break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -1554,7 +1554,7 @@ DEF_OP(VSShrS) {
       sshl(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), VTMP1.V2D());
     break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -1585,7 +1585,7 @@ DEF_OP(VInsElement) {
       mov(reg.V2D(), Op->DestIdx, GetSrc(Op->Header.Args[1].ID()).V2D(), Op->SrcIdx);
     break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 
   if (GetDst(Node).GetCode() != reg.GetCode()) {
@@ -1620,7 +1620,7 @@ DEF_OP(VInsScalarElement) {
       mov(reg.V2D(), Op->DestIdx, GetSrc(Op->Header.Args[1].ID()).V2D(), 0);
     break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 
   if (GetDst(Node).GetCode() != reg.GetCode()) {
@@ -1644,7 +1644,7 @@ DEF_OP(VExtractElement) {
     case 8:
       mov(GetDst(Node).D(), GetSrc(Op->Header.Args[0].ID()).V2D(), Op->Index);
     break;
-    default:  LogMan::Msg::A("Unhandled ExtractElementSize: %d", OpSize);
+    default:  LOGMAN_MSG_A("Unhandled ExtractElementSize: %d", OpSize);
   }
 }
 
@@ -1759,7 +1759,7 @@ DEF_OP(VUShrI) {
         ushr(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), Op->BitShift);
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
 }
@@ -1784,7 +1784,7 @@ DEF_OP(VSShrI) {
       sshr(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), std::min((uint8_t)(Op->Header.ElementSize * 8 - 1), Op->BitShift));
     break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -1812,7 +1812,7 @@ DEF_OP(VShlI) {
         shl(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), Op->BitShift);
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
 }
@@ -1833,7 +1833,7 @@ DEF_OP(VUShrNI) {
       shrn(GetDst(Node).V2S(), GetSrc(Op->Header.Args[0].ID()).V2D(), Op->BitShift);
     break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -1853,7 +1853,7 @@ DEF_OP(VUShrNI2) {
       shrn2(VTMP1.V4S(), GetSrc(Op->Header.Args[1].ID()).V2D(), Op->BitShift);
     break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 
   mov(GetDst(Node), VTMP1);
@@ -1876,7 +1876,7 @@ DEF_OP(VSXTL) {
     case 8:
       sxtl(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2S());
     break;
-    default: LogMan::Msg::A("Unknown element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A("Unknown element size: %d", Op->Header.ElementSize);
   }
 }
 
@@ -1892,7 +1892,7 @@ DEF_OP(VSXTL2) {
     case 8:
       sxtl2(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V4S());
     break;
-    default: LogMan::Msg::A("Unknown element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A("Unknown element size: %d", Op->Header.ElementSize);
   }
 }
 
@@ -1908,7 +1908,7 @@ DEF_OP(VUXTL) {
     case 8:
       uxtl(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2S());
     break;
-    default: LogMan::Msg::A("Unknown element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A("Unknown element size: %d", Op->Header.ElementSize);
   }
 }
 
@@ -1924,7 +1924,7 @@ DEF_OP(VUXTL2) {
     case 8:
       uxtl2(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V4S());
     break;
-    default: LogMan::Msg::A("Unknown element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A("Unknown element size: %d", Op->Header.ElementSize);
   }
 }
 
@@ -1940,7 +1940,7 @@ DEF_OP(VSQXTN) {
     case 4:
       sqxtn(GetDst(Node).V2S(), GetSrc(Op->Header.Args[0].ID()).V2D());
     break;
-    default: LogMan::Msg::A("Unknown element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A("Unknown element size: %d", Op->Header.ElementSize);
   }
 }
 
@@ -1962,7 +1962,7 @@ DEF_OP(VSQXTN2) {
         sqxtn(VTMP2.V2S(), GetSrc(Op->Header.Args[1].ID()).V2D());
         ins(VTMP1.V4S(), 1, VTMP2.V4S(), 0);
       break;
-      default: LogMan::Msg::A("Unknown element size: %d", Op->Header.ElementSize);
+      default: LOGMAN_MSG_A("Unknown element size: %d", Op->Header.ElementSize);
     }
   }
   else {
@@ -1976,7 +1976,7 @@ DEF_OP(VSQXTN2) {
       case 4:
         sqxtn2(VTMP1.V4S(), GetSrc(Op->Header.Args[1].ID()).V2D());
       break;
-      default: LogMan::Msg::A("Unknown element size: %d", Op->Header.ElementSize);
+      default: LOGMAN_MSG_A("Unknown element size: %d", Op->Header.ElementSize);
     }
   }
   mov(GetDst(Node), VTMP1);
@@ -1994,7 +1994,7 @@ DEF_OP(VSQXTUN) {
     case 4:
       sqxtun(GetDst(Node).V2S(), GetSrc(Op->Header.Args[0].ID()).V2D());
     break;
-    default: LogMan::Msg::A("Unknown element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A("Unknown element size: %d", Op->Header.ElementSize);
   }
 }
 
@@ -2016,7 +2016,7 @@ DEF_OP(VSQXTUN2) {
         sqxtun(VTMP2.V2S(), GetSrc(Op->Header.Args[1].ID()).V2D());
         ins(VTMP1.V4S(), 1, VTMP2.V4S(), 0);
       break;
-      default: LogMan::Msg::A("Unknown element size: %d", Op->Header.ElementSize);
+      default: LOGMAN_MSG_A("Unknown element size: %d", Op->Header.ElementSize);
     }
   }
   else {
@@ -2030,7 +2030,7 @@ DEF_OP(VSQXTUN2) {
       case 4:
         sqxtun2(VTMP1.V4S(), GetSrc(Op->Header.Args[1].ID()).V2D());
       break;
-      default: LogMan::Msg::A("Unknown element size: %d", Op->Header.ElementSize);
+      default: LOGMAN_MSG_A("Unknown element size: %d", Op->Header.ElementSize);
     }
   }
   mov(GetDst(Node), VTMP1);
@@ -2055,7 +2055,7 @@ DEF_OP(VMul) {
       mul(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
     break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -2074,7 +2074,7 @@ DEF_OP(VUMull) {
       umull(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2S(), GetSrc(Op->Header.Args[1].ID()).V2S());
     break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize >> 1); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize >> 1); break;
   }
 }
 
@@ -2093,7 +2093,7 @@ DEF_OP(VSMull) {
       smull(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2S(), GetSrc(Op->Header.Args[1].ID()).V2S());
     break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize >> 1); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize >> 1); break;
   }
 }
 
@@ -2112,7 +2112,7 @@ DEF_OP(VUMull2) {
       umull2(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V4S(), GetSrc(Op->Header.Args[1].ID()).V4S());
     break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize >> 1); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize >> 1); break;
   }
 }
 
@@ -2131,7 +2131,7 @@ DEF_OP(VSMull2) {
       smull2(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V4S(), GetSrc(Op->Header.Args[1].ID()).V4S());
     break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize >> 1); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize >> 1); break;
   }
 }
 
@@ -2148,7 +2148,7 @@ DEF_OP(VTBL1) {
       tbl(GetDst(Node).V16B(), GetSrc(Op->Header.Args[0].ID()).V16B(), GetSrc(Op->Header.Args[1].ID()).V16B());
     break;
     }
-    default: LogMan::Msg::A("Unknown OpSize: %d", OpSize); break;
+    default: LOGMAN_MSG_A("Unknown OpSize: %d", OpSize); break;
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/ALUOps.cpp
@@ -20,7 +20,7 @@ DEF_OP(TruncElementPair) {
       mov(Dst.second, Src.second);
       break;
     }
-    default: LogMan::Msg::A("Unhandled Truncation size: %d", Op->Size); break;
+    default: LOGMAN_MSG_A("Unhandled Truncation size: %d", Op->Size); break;
   }
 }
 
@@ -70,7 +70,7 @@ DEF_OP(Add) {
     case 8:
       add(rax, Const);
       break;
-    default:  LogMan::Msg::A("Unhandled Add size: %d", OpSize);
+    default:  LOGMAN_MSG_A("Unhandled Add size: %d", OpSize);
       break;
     }
   } else {
@@ -81,7 +81,7 @@ DEF_OP(Add) {
     case 8:
       add(rax, GetSrc<RA_64>(Op->Header.Args[1].ID()));
       break;
-    default:  LogMan::Msg::A("Unhandled Add size: %d", OpSize);
+    default:  LOGMAN_MSG_A("Unhandled Add size: %d", OpSize);
       break;
     }
   }
@@ -103,7 +103,7 @@ DEF_OP(Sub) {
     case 8:
       sub(rax, Const);
       break;
-    default:  LogMan::Msg::A("Unhandled Sub size: %d", OpSize);
+    default:  LOGMAN_MSG_A("Unhandled Sub size: %d", OpSize);
       break;
     }
   } else {
@@ -114,7 +114,7 @@ DEF_OP(Sub) {
     case 8:
       sub(rax, GetSrc<RA_64>(Op->Header.Args[1].ID()));
       break;
-    default:  LogMan::Msg::A("Unhandled Sub size: %d", OpSize);
+    default:  LOGMAN_MSG_A("Unhandled Sub size: %d", OpSize);
       break;
     }
   }
@@ -136,7 +136,7 @@ DEF_OP(Neg) {
     Src = GetSrc<RA_64>(Op->Header.Args[0].ID());
     Dst = GetDst<RA_64>(Node);
     break;
-  default:  LogMan::Msg::A("Unhandled Neg size: %d", OpSize);
+  default:  LOGMAN_MSG_A("Unhandled Neg size: %d", OpSize);
     break;
   }
   mov(Dst, Src);
@@ -160,7 +160,7 @@ DEF_OP(Mul) {
     imul(rax, GetSrc<RA_64>(Op->Header.Args[1].ID()));
     mov(Dst, rax);
   break;
-  default: LogMan::Msg::A("Unknown Sext size: %d", OpSize);
+  default: LOGMAN_MSG_A("Unknown Sext size: %d", OpSize);
   }
 }
 
@@ -179,7 +179,7 @@ DEF_OP(UMul) {
     mul(GetSrc<RA_64>(Op->Header.Args[1].ID()));
     mov(GetDst<RA_64>(Node), rax);
   break;
-  default: LogMan::Msg::A("Unknown Sext size: %d", OpSize);
+  default: LOGMAN_MSG_A("Unknown Sext size: %d", OpSize);
   }
 }
 
@@ -218,7 +218,7 @@ DEF_OP(Div) {
     mov(GetDst<RA_64>(Node), rax);
   break;
   }
-  default: LogMan::Msg::A("Unknown UDIV Size: %d", Size); break;
+  default: LOGMAN_MSG_A("Unknown UDIV Size: %d", Size); break;
   }
 }
 
@@ -261,7 +261,7 @@ DEF_OP(UDiv) {
     mov(GetDst<RA_64>(Node), rax);
   break;
   }
-  default: LogMan::Msg::A("Unknown UDIV OpSize: %d", OpSize); break;
+  default: LOGMAN_MSG_A("Unknown UDIV OpSize: %d", OpSize); break;
   }
 }
 
@@ -298,7 +298,7 @@ DEF_OP(Rem) {
     mov(GetDst<RA_64>(Node), rdx);
   break;
   }
-  default: LogMan::Msg::A("Unknown UDIV Size: %d", OpSize); break;
+  default: LOGMAN_MSG_A("Unknown UDIV Size: %d", OpSize); break;
   }
 }
 
@@ -341,7 +341,7 @@ DEF_OP(URem) {
     mov(GetDst<RA_64>(Node), rdx);
   break;
   }
-  default: LogMan::Msg::A("Unknown UDIV OpSize: %d", OpSize); break;
+  default: LOGMAN_MSG_A("Unknown UDIV OpSize: %d", OpSize); break;
   }
 }
 
@@ -360,7 +360,7 @@ DEF_OP(MulH) {
     imul(GetSrc<RA_64>(Op->Header.Args[1].ID()));
     mov(GetDst<RA_64>(Node), rdx);
   break;
-  default: LogMan::Msg::A("Unknown Sext size: %d", OpSize);
+  default: LOGMAN_MSG_A("Unknown Sext size: %d", OpSize);
   }
 }
 
@@ -379,7 +379,7 @@ DEF_OP(UMulH) {
     mul(GetSrc<RA_64>(Op->Header.Args[1].ID()));
     mov(GetDst<RA_64>(Node), rdx);
   break;
-  default: LogMan::Msg::A("Unknown Sext size: %d", OpSize);
+  default: LOGMAN_MSG_A("Unknown Sext size: %d", OpSize);
   }
 }
 
@@ -441,7 +441,7 @@ DEF_OP(Lshl) {
         mov(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()));
         shl(GetDst<RA_64>(Node), Const);
         break;
-      default: LogMan::Msg::A("Unknown LSHL Size: %d\n", OpSize); break;
+      default: LOGMAN_MSG_A("Unknown LSHL Size: %d\n", OpSize); break;
     };
   } else {
     mov(rcx, GetSrc<RA_64>(Op->Header.Args[1].ID()));
@@ -456,7 +456,7 @@ DEF_OP(Lshl) {
         mov(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()));
         shl(GetDst<RA_64>(Node), cl);
         break;
-      default: LogMan::Msg::A("Unknown LSHL Size: %d\n", OpSize); break;
+      default: LOGMAN_MSG_A("Unknown LSHL Size: %d\n", OpSize); break;
     };
   }
 }
@@ -488,7 +488,7 @@ DEF_OP(Lshr) {
         mov(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()));
         shr(GetDst<RA_64>(Node), Const);
         break;
-      default: LogMan::Msg::A("Unknown Size: %d\n", OpSize); break;
+      default: LOGMAN_MSG_A("Unknown Size: %d\n", OpSize); break;
     };
 
   } else {
@@ -512,7 +512,7 @@ DEF_OP(Lshr) {
         mov(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()));
         shr(GetDst<RA_64>(Node), cl);
         break;
-      default: LogMan::Msg::A("Unknown Size: %d\n", OpSize); break;
+      default: LOGMAN_MSG_A("Unknown Size: %d\n", OpSize); break;
     };
   }
 }
@@ -546,7 +546,7 @@ DEF_OP(Ashr) {
       mov(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()));
       sar(GetDst<RA_64>(Node), Const);
     break;
-    default: LogMan::Msg::A("Unknown ASHR Size: %d\n", OpSize); break;
+    default: LOGMAN_MSG_A("Unknown ASHR Size: %d\n", OpSize); break;
     };
 
   } else {
@@ -571,7 +571,7 @@ DEF_OP(Ashr) {
       mov(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()));
       sar(GetDst<RA_64>(Node), cl);
     break;
-    default: LogMan::Msg::A("Unknown ASHR Size: %d\n", OpSize); break;
+    default: LOGMAN_MSG_A("Unknown ASHR Size: %d\n", OpSize); break;
     };
   }
 }
@@ -596,7 +596,7 @@ DEF_OP(Ror) {
         ror(rax, Const);
       break;
       }
-      default: LogMan::Msg::A("Unknown ROR Size: %d\n", OpSize); break;
+      default: LOGMAN_MSG_A("Unknown ROR Size: %d\n", OpSize); break;
     }
   } else {
     mov (rcx, GetSrc<RA_64>(Op->Header.Args[1].ID()));
@@ -612,7 +612,7 @@ DEF_OP(Ror) {
         ror(rax, cl);
       break;
       }
-      default: LogMan::Msg::A("Unknown ROR Size: %d\n", OpSize); break;
+      default: LOGMAN_MSG_A("Unknown ROR Size: %d\n", OpSize); break;
     }
   }
   mov(GetDst<RA_64>(Node), rax);
@@ -668,7 +668,7 @@ DEF_OP(LDiv) {
       mov(GetDst<RA_64>(Node), rax);
       break;
     }
-    default: LogMan::Msg::A("Unknown LDIV OpSize: %d", OpSize); break;
+    default: LOGMAN_MSG_A("Unknown LDIV OpSize: %d", OpSize); break;
   }
 }
 
@@ -700,7 +700,7 @@ DEF_OP(LUDiv) {
       mov(GetDst<RA_64>(Node), rax);
       break;
     }
-    default: LogMan::Msg::A("Unknown LUDIV OpSize: %d", OpSize); break;
+    default: LOGMAN_MSG_A("Unknown LUDIV OpSize: %d", OpSize); break;
   }
 }
 
@@ -732,7 +732,7 @@ DEF_OP(LRem) {
       mov(GetDst<RA_64>(Node), rdx);
       break;
     }
-    default: LogMan::Msg::A("Unknown LREM OpSize: %d", OpSize); break;
+    default: LOGMAN_MSG_A("Unknown LREM OpSize: %d", OpSize); break;
   }
 }
 
@@ -764,7 +764,7 @@ DEF_OP(LURem) {
       mov(GetDst<RA_64>(Node), rdx);
       break;
     }
-    default: LogMan::Msg::A("Unknown LUDIV OpSize: %d", OpSize); break;
+    default: LOGMAN_MSG_A("Unknown LUDIV OpSize: %d", OpSize); break;
   }
 }
 
@@ -829,7 +829,7 @@ DEF_OP(FindMSB) {
     case 8:
       bsr(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()));
       break;
-    default: LogMan::Msg::A("Unknown OpSize: %d", OpSize);
+    default: LOGMAN_MSG_A("Unknown OpSize: %d", OpSize);
   }
 }
 
@@ -853,7 +853,7 @@ DEF_OP(FindTrailingZeros) {
       mov(rax, 0x40);
       cmovz(GetDst<RA_64>(Node), rax);
       break;
-    default: LogMan::Msg::A("Unknown size: %d", OpSize); break;
+    default: LOGMAN_MSG_A("Unknown size: %d", OpSize); break;
   }
 }
 
@@ -876,7 +876,7 @@ DEF_OP(CountLeadingZeroes) {
         lzcnt(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()));
         break;
       }
-      default: LogMan::Msg::A("Unknown size: %d", OpSize); break;
+      default: LOGMAN_MSG_A("Unknown size: %d", OpSize); break;
     }
   }
   else {
@@ -915,7 +915,7 @@ DEF_OP(CountLeadingZeroes) {
         mov(GetDst<RA_64>(Node), rax);
         break;
       }
-      default: LogMan::Msg::A("Unknown size: %d", OpSize); break;
+      default: LOGMAN_MSG_A("Unknown size: %d", OpSize); break;
     }
   }
 }
@@ -937,7 +937,7 @@ DEF_OP(Rev) {
       mov (GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()));
       bswap(GetDst<RA_64>(Node).cvt64());
       break;
-    default: LogMan::Msg::A("Unknown REV size: %d", OpSize); break;
+    default: LOGMAN_MSG_A("Unknown REV size: %d", OpSize); break;
   }
 }
 
@@ -972,7 +972,7 @@ DEF_OP(Bfe) {
   auto Op = IROp->C<IR::IROp_Bfe>();
   uint8_t OpSize = IROp->Size;
 
-  LogMan::Throw::A(OpSize <= 8, "OpSize is too large for BFE: %d", OpSize);
+  LOGMAN_THROW_A(OpSize <= 8, "OpSize is too large for BFE: %d", OpSize);
 
   auto Dst = GetDst<RA_64>(Node);
 
@@ -1073,7 +1073,7 @@ DEF_OP(Select) {
 
   if (is_const_true || is_const_false) {
     if (is_const_false != true || is_const_true != true || const_true != 1 || const_false != 0) {
-      LogMan::Msg::A("Select: Unsupported compare inline parameters");
+      LOGMAN_MSG_A("Select: Unsupported compare inline parameters");
     }
     (this->*SetCC)(al);
     movzx(Dst, al);
@@ -1104,7 +1104,7 @@ DEF_OP(VExtractToGPR) {
       pextrq(GetDst<RA_64>(Node), GetSrc(Op->Header.Args[0].ID()), Op->Idx);
     break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/AtomicOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/AtomicOps.cpp
@@ -55,7 +55,7 @@ DEF_OP(CASPair) {
       mov(Dst.second, rdx);
     break;
     }
-    default: LogMan::Msg::A("Unsupported: %d", OpSize);
+    default: LOGMAN_MSG_A("Unsupported: %d", OpSize);
   }
 }
 
@@ -104,7 +104,7 @@ DEF_OP(CAS) {
     mov (GetDst<RA_64>(Node), rax);
   break;
   }
-  default: LogMan::Msg::A("Unsupported: %d", OpSize);
+  default: LOGMAN_MSG_A("Unsupported: %d", OpSize);
   }
 }
 
@@ -127,7 +127,7 @@ DEF_OP(AtomicAdd) {
     case 8:
       add(qword [MemReg], GetSrc<RA_64>(Op->Header.Args[1].ID()));
       break;
-    default:  LogMan::Msg::A("Unhandled AtomicAdd size: %d", Op->Size);
+    default:  LOGMAN_MSG_A("Unhandled AtomicAdd size: %d", Op->Size);
   }
 }
 
@@ -149,7 +149,7 @@ DEF_OP(AtomicSub) {
     case 8:
       sub(qword [MemReg], GetSrc<RA_64>(Op->Header.Args[1].ID()));
       break;
-    default:  LogMan::Msg::A("Unhandled AtomicAdd size: %d", Op->Size);
+    default:  LOGMAN_MSG_A("Unhandled AtomicAdd size: %d", Op->Size);
   }
 }
 
@@ -171,7 +171,7 @@ DEF_OP(AtomicAnd) {
     case 8:
       and_(qword [MemReg], GetSrc<RA_64>(Op->Header.Args[1].ID()));
       break;
-    default:  LogMan::Msg::A("Unhandled AtomicAdd size: %d", Op->Size);
+    default:  LOGMAN_MSG_A("Unhandled AtomicAdd size: %d", Op->Size);
   }
 }
 
@@ -193,7 +193,7 @@ DEF_OP(AtomicOr) {
     case 8:
       or_(qword [MemReg], GetSrc<RA_64>(Op->Header.Args[1].ID()));
       break;
-    default:  LogMan::Msg::A("Unhandled AtomicAdd size: %d", Op->Size);
+    default:  LOGMAN_MSG_A("Unhandled AtomicAdd size: %d", Op->Size);
   }
 }
 
@@ -215,7 +215,7 @@ DEF_OP(AtomicXor) {
     case 8:
       xor_(qword [MemReg], GetSrc<RA_64>(Op->Header.Args[1].ID()));
       break;
-    default:  LogMan::Msg::A("Unhandled AtomicAdd size: %d", Op->Size);
+    default:  LOGMAN_MSG_A("Unhandled AtomicAdd size: %d", Op->Size);
   }
 }
 
@@ -246,7 +246,7 @@ DEF_OP(AtomicSwap) {
       lock();
       xchg(qword [MemReg], GetDst<RA_64>(Node));
       break;
-    default:  LogMan::Msg::A("Unhandled AtomicAdd size: %d", Op->Size);
+    default:  LOGMAN_MSG_A("Unhandled AtomicAdd size: %d", Op->Size);
   }
 }
 
@@ -279,7 +279,7 @@ DEF_OP(AtomicFetchAdd) {
       xadd(qword [MemReg], rcx);
       mov(GetDst<RA_64>(Node), rcx);
       break;
-    default:  LogMan::Msg::A("Unhandled AtomicFetchAdd size: %d", Op->Size);
+    default:  LOGMAN_MSG_A("Unhandled AtomicFetchAdd size: %d", Op->Size);
   }
 }
 
@@ -316,7 +316,7 @@ DEF_OP(AtomicFetchSub) {
       xadd(qword [MemReg], rcx);
       mov(GetDst<RA_64>(Node), rcx);
       break;
-    default:  LogMan::Msg::A("Unhandled AtomicFetchAdd size: %d", Op->Size);
+    default:  LOGMAN_MSG_A("Unhandled AtomicFetchAdd size: %d", Op->Size);
   }
 }
 
@@ -394,7 +394,7 @@ DEF_OP(AtomicFetchAnd) {
       mov(GetDst<RA_64>(Node), TMP3.cvt64());
       break;
     }
-    default:  LogMan::Msg::A("Unhandled AtomicFetchAdd size: %d", Op->Size);
+    default:  LOGMAN_MSG_A("Unhandled AtomicFetchAdd size: %d", Op->Size);
   }
 }
 
@@ -471,7 +471,7 @@ DEF_OP(AtomicFetchOr) {
       mov(GetDst<RA_64>(Node), TMP3.cvt64());
       break;
     }
-    default:  LogMan::Msg::A("Unhandled AtomicFetchAdd size: %d", Op->Size);
+    default:  LOGMAN_MSG_A("Unhandled AtomicFetchAdd size: %d", Op->Size);
   }
 }
 
@@ -548,7 +548,7 @@ DEF_OP(AtomicFetchXor) {
       mov(GetDst<RA_64>(Node), TMP3.cvt64());
       break;
     }
-    default:  LogMan::Msg::A("Unhandled AtomicFetchAdd size: %d", Op->Size);
+    default:  LOGMAN_MSG_A("Unhandled AtomicFetchAdd size: %d", Op->Size);
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/ConversionOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/ConversionOps.cpp
@@ -31,7 +31,7 @@ DEF_OP(VInsGPR) {
       pinsrq(GetDst(Node), GetSrc<RA_64>(Op->Header.Args[1].ID()), Op->Index);
       break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -52,12 +52,12 @@ DEF_OP(VCastFromGPR) {
     case 8:
       vmovq(GetDst(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()).cvt64());
       break;
-    default: LogMan::Msg::A("Unknown castGPR element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A("Unknown castGPR element size: %d", Op->Header.ElementSize);
   }
 }
 
 DEF_OP(Float_FromGPR_U) {
-  LogMan::Msg::A("Unimplemented");
+  LOGMAN_MSG_A("Unimplemented");
 }
 
 DEF_OP(Float_FromGPR_S) {
@@ -95,12 +95,12 @@ DEF_OP(Float_FToF) {
       cvtsd2ss(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
       break;
     }
-    default: LogMan::Msg::A("Unknown FCVT sizes: 0x%x", Conv);
+    default: LOGMAN_MSG_A("Unknown FCVT sizes: 0x%x", Conv);
   }
 }
 
 DEF_OP(Vector_UToF) {
-  LogMan::Msg::A("Unimplemented");
+  LOGMAN_MSG_A("Unimplemented");
 }
 
 DEF_OP(Vector_SToF) {
@@ -121,12 +121,12 @@ DEF_OP(Vector_SToF) {
       cvtsi2sd(xmm15, rax);
       movlhps(GetDst(Node), xmm15);
     break;
-    default: LogMan::Msg::A("Unknown castGPR element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A("Unknown castGPR element size: %d", Op->Header.ElementSize);
   }
 }
 
 DEF_OP(Vector_FToZU) {
-  LogMan::Msg::A("Unimplemented");
+  LOGMAN_MSG_A("Unimplemented");
 }
 
 DEF_OP(Vector_FToZS) {
@@ -138,12 +138,12 @@ DEF_OP(Vector_FToZS) {
     case 8:
       cvttpd2dq(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
     break;
-    default: LogMan::Msg::A("Unknown castGPR element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A("Unknown castGPR element size: %d", Op->Header.ElementSize);
   }
 }
 
 DEF_OP(Vector_FToU) {
-  LogMan::Msg::A("Unimplemented");
+  LOGMAN_MSG_A("Unimplemented");
 }
 
 DEF_OP(Vector_FToS) {
@@ -155,7 +155,7 @@ DEF_OP(Vector_FToS) {
     case 8:
       cvtpd2dq(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
     break;
-    default: LogMan::Msg::A("Unknown castGPR element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A("Unknown castGPR element size: %d", Op->Header.ElementSize);
   }
 }
 
@@ -172,7 +172,7 @@ DEF_OP(Vector_FToF) {
       cvtpd2ps(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
       break;
     }
-    default: LogMan::Msg::A("Unknown Conversion Type : 0%04x", Conv); break;
+    default: LOGMAN_MSG_A("Unknown Conversion Type : 0%04x", Conv); break;
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -36,7 +36,7 @@ CodeBuffer AllocateNewCodeBuffer(size_t Size) {
                     PROT_READ | PROT_WRITE | PROT_EXEC,
                     MAP_PRIVATE | MAP_ANONYMOUS,
                     -1, 0));
-  LogMan::Throw::A(Buffer.Ptr != reinterpret_cast<uint8_t*>(~0ULL), "Couldn't allocate code buffer");
+  LOGMAN_THROW_A(Buffer.Ptr != reinterpret_cast<uint8_t*>(~0ULL), "Couldn't allocate code buffer");
   return Buffer;
 }
 
@@ -85,7 +85,7 @@ void X86JITCore::Op_Unhandled(FEXCore::IR::IROp_Header *IROp, uint32_t Node) {
   FallbackInfo Info;
   if (!InterpreterOps::GetFallbackHandler(IROp, &Info)) {
     auto Name = FEXCore::IR::GetName(IROp->Op);
-    LogMan::Msg::A("Unhandled IR Op: %s", std::string(Name).c_str());
+    LOGMAN_MSG_A("Unhandled IR Op: %s", std::string(Name).c_str());
   } else {
     switch(Info.ABI) {
       case FABI_VOID_U16: {
@@ -283,7 +283,7 @@ void X86JITCore::Op_Unhandled(FEXCore::IR::IROp_Header *IROp, uint32_t Node) {
       case FABI_UNKNOWN:
       default:
       auto Name = FEXCore::IR::GetName(IROp->Op);
-        LogMan::Msg::A("Unhandled IR Fallback abi: %s %d", std::string(Name).c_str(), Info.ABI);
+        LOGMAN_MSG_A("Unhandled IR Fallback abi: %s %d", std::string(Name).c_str(), Info.ABI);
     }
   }
 }
@@ -414,7 +414,7 @@ void X86JITCore::ClearCache() {
 IR::PhysicalRegister X86JITCore::GetPhys(uint32_t Node) {
   auto PhyReg = RAData->GetNodeRegister(Node);
 
-  LogMan::Throw::A(PhyReg.Raw != 255, "Couldn't Allocate register for node: ssa%d. Class: %d", Node, PhyReg.Class);
+  LOGMAN_THROW_A(PhyReg.Raw != 255, "Couldn't Allocate register for node: ssa%d. Class: %d", Node, PhyReg.Class);
 
   return PhyReg;
 }
@@ -563,7 +563,7 @@ std::tuple<X86JITCore::SetCC, X86JITCore::CMovCC, X86JITCore::JCC> X86JITCore::G
     case FEXCore::IR::COND_VS:
     case FEXCore::IR::COND_VC:
     default:
-      LogMan::Msg::A("Unsupported compare type");
+      LOGMAN_MSG_A("Unsupported compare type");
       break;
   }
 
@@ -606,7 +606,7 @@ void *X86JITCore::CompileCode(uint64_t Entry, [[maybe_unused]] FEXCore::IR::IRLi
     L(RunBlock);
   }
 
-  LogMan::Throw::A(RAData != nullptr, "Needs RA");
+  LOGMAN_THROW_A(RAData != nullptr, "Needs RA");
 
   SpillSlots = RAData->SpillSlots();
 
@@ -663,7 +663,7 @@ void *X86JITCore::CompileCode(uint64_t Entry, [[maybe_unused]] FEXCore::IR::IRLi
     using namespace FEXCore::IR;
     {
       auto BlockIROp = BlockHeader->CW<IROp_CodeBlock>();
-      LogMan::Throw::A(BlockIROp->Header.Op == IR::OP_CODEBLOCK, "IR type failed to be a code block");
+      LOGMAN_THROW_A(BlockIROp->Header.Op == IR::OP_CODEBLOCK, "IR type failed to be a code block");
 
       uint32_t Node = IR->GetID(BlockNode);
       auto IsTarget = JumpTargets.find(Node);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/MemoryOps.cpp
@@ -36,10 +36,10 @@ DEF_OP(LoadContext) {
     }
     break;
     case 16: {
-      LogMan::Msg::A("Invalid GPR load of size 16");
+      LOGMAN_MSG_A("Invalid GPR load of size 16");
     }
     break;
-    default:  LogMan::Msg::A("Unhandled LoadContext size: %d", OpSize);
+    default:  LOGMAN_MSG_A("Unhandled LoadContext size: %d", OpSize);
     }
   }
   else {
@@ -69,7 +69,7 @@ DEF_OP(LoadContext) {
         movups(GetDst(Node), xword [STATE + Op->Offset]);
     }
     break;
-    default:  LogMan::Msg::A("Unhandled LoadContext size: %d", OpSize);
+    default:  LOGMAN_MSG_A("Unhandled LoadContext size: %d", OpSize);
     }
   }
 }
@@ -100,7 +100,7 @@ DEF_OP(StoreContext) {
     case 16:
       LogMan::Msg::D("Invalid store size of 16");
     break;
-    default:  LogMan::Msg::A("Unhandled StoreContext size: %d", OpSize);
+    default:  LOGMAN_MSG_A("Unhandled StoreContext size: %d", OpSize);
     }
   }
   else {
@@ -129,7 +129,7 @@ DEF_OP(StoreContext) {
         movups(xword [STATE + Op->Offset], GetSrc(Op->Header.Args[0].ID()));
     }
     break;
-    default:  LogMan::Msg::A("Unhandled StoreContext size: %d", OpSize);
+    default:  LOGMAN_MSG_A("Unhandled StoreContext size: %d", OpSize);
     }
   }
 }
@@ -160,15 +160,15 @@ DEF_OP(LoadContextIndexed) {
         mov(GetDst<RA_64>(Node),  qword [rax + index * Op->Stride]);
         break;
       default:
-        LogMan::Msg::A("Unhandled LoadContextIndexed size: %d", Op->Size);
+        LOGMAN_MSG_A("Unhandled LoadContextIndexed size: %d", Op->Size);
       }
       break;
     }
     case 16:
-      LogMan::Msg::A("Invalid Class load of size 16");
+      LOGMAN_MSG_A("Invalid Class load of size 16");
       break;
     default:
-      LogMan::Msg::A("Unhandled LoadContextIndexed stride: %d", Op->Stride);
+      LOGMAN_MSG_A("Unhandled LoadContextIndexed stride: %d", Op->Stride);
     }
 
   }
@@ -195,7 +195,7 @@ DEF_OP(LoadContextIndexed) {
         vmovq(GetDst(Node),  qword [rax + index * Op->Stride]);
         break;
       default:
-        LogMan::Msg::A("Unhandled LoadContextIndexed size: %d", Op->Size);
+        LOGMAN_MSG_A("Unhandled LoadContextIndexed size: %d", Op->Size);
       }
       break;
     }
@@ -223,12 +223,12 @@ DEF_OP(LoadContextIndexed) {
           movups(GetDst(Node), xword [STATE + rax]);
         break;
       default:
-        LogMan::Msg::A("Unhandled LoadContextIndexed size: %d", Op->Size);
+        LOGMAN_MSG_A("Unhandled LoadContextIndexed size: %d", Op->Size);
       }
       break;
     }
     default:
-      LogMan::Msg::A("Unhandled LoadContextIndexed stride: %d", Op->Stride);
+      LOGMAN_MSG_A("Unhandled LoadContextIndexed stride: %d", Op->Stride);
     }
   }
 }
@@ -248,13 +248,13 @@ DEF_OP(StoreContextIndexed) {
     case 4:
     case 8: {
       if (!(size == 1 || size == 2 || size == 4 || size == 8)) {
-        LogMan::Msg::A("Unhandled StoreContextIndexed size: %d", Op->Size);
+        LOGMAN_MSG_A("Unhandled StoreContextIndexed size: %d", Op->Size);
       }
       mov(AddressFrame(Op->Size * 8) [rax + index * Op->Stride], value);
       break;
     }
     default:
-      LogMan::Msg::A("Unhandled StoreContextIndexed stride: %d", Op->Stride);
+      LOGMAN_MSG_A("Unhandled StoreContextIndexed stride: %d", Op->Stride);
     }
   }
   else {
@@ -279,7 +279,7 @@ DEF_OP(StoreContextIndexed) {
         vmovq(AddressFrame(Op->Size * 8) [rax + index * Op->Stride], value);
         break;
       default:
-        LogMan::Msg::A("Unhandled StoreContextIndexed size: %d", size);
+        LOGMAN_MSG_A("Unhandled StoreContextIndexed size: %d", size);
       }
       break;
     }
@@ -307,12 +307,12 @@ DEF_OP(StoreContextIndexed) {
           movups(xword [STATE + rax], value);
         break;
       default:
-        LogMan::Msg::A("Unhandled StoreContextIndexed size: %d", size);
+        LOGMAN_MSG_A("Unhandled StoreContextIndexed size: %d", size);
       }
       break;
     }
     default:
-      LogMan::Msg::A("Unhandled StoreContextIndexed stride: %d", Op->Stride);
+      LOGMAN_MSG_A("Unhandled StoreContextIndexed stride: %d", Op->Stride);
     }
   }
 }
@@ -340,7 +340,7 @@ DEF_OP(SpillRegister) {
         mov(qword [rsp + SlotOffset], GetSrc<RA_64>(Op->Header.Args[0].ID()));
         break;
       }
-      default:  LogMan::Msg::A("Unhandled SpillRegister size: %d", OpSize);
+      default:  LOGMAN_MSG_A("Unhandled SpillRegister size: %d", OpSize);
     }
   } else if (Op->Class == FEXCore::IR::FPRClass) {
     switch (OpSize) {
@@ -356,10 +356,10 @@ DEF_OP(SpillRegister) {
         movaps(xword [rsp + SlotOffset], GetSrc(Op->Header.Args[0].ID()));
         break;
       }
-      default:  LogMan::Msg::A("Unhandled SpillRegister size: %d", OpSize);
+      default:  LOGMAN_MSG_A("Unhandled SpillRegister size: %d", OpSize);
     }
   } else {
-    LogMan::Msg::A("Unhandled SpillRegister class: %d", Op->Class.Val);
+    LOGMAN_MSG_A("Unhandled SpillRegister class: %d", Op->Class.Val);
   }
 
 
@@ -388,7 +388,7 @@ DEF_OP(FillRegister) {
         mov(GetDst<RA_64>(Node), qword [rsp + SlotOffset]);
         break;
       }
-      default:  LogMan::Msg::A("Unhandled FillRegister size: %d", OpSize);
+      default:  LOGMAN_MSG_A("Unhandled FillRegister size: %d", OpSize);
     }
   } else if (Op->Class == FEXCore::IR::FPRClass) {
     switch (OpSize) {
@@ -404,10 +404,10 @@ DEF_OP(FillRegister) {
         movaps(GetDst(Node), xword [rsp + SlotOffset]);
         break;
       }
-      default:  LogMan::Msg::A("Unhandled FillRegister size: %d", OpSize);
+      default:  LOGMAN_MSG_A("Unhandled FillRegister size: %d", OpSize);
     }
   } else {
-    LogMan::Msg::A("Unhandled FillRegister class: %d", Op->Class.Val);
+    LOGMAN_MSG_A("Unhandled FillRegister class: %d", Op->Class.Val);
   }
 }
 
@@ -430,11 +430,11 @@ Xbyak::RegExp X86JITCore::GenerateModRM(Xbyak::Reg Base, IR::OrderedNodeWrapper 
     return Base;
   } else {
     if (OffsetScale != 1 && OffsetScale != 2 && OffsetScale != 4 && OffsetScale != 8) {
-      LogMan::Msg::A("Unhandled GenerateModRM OffsetScale: %d", OffsetScale);
+      LOGMAN_MSG_A("Unhandled GenerateModRM OffsetScale: %d", OffsetScale);
     }
 
     if (OffsetType != IR::MEM_OFFSET_SXTX) {
-      LogMan::Msg::A("Unhandled GenerateModRM OffsetType: %d", OffsetType.Val);
+      LOGMAN_MSG_A("Unhandled GenerateModRM OffsetType: %d", OffsetType.Val);
     }
 
     uint64_t Const;
@@ -475,7 +475,7 @@ DEF_OP(LoadMem) {
         mov(Dst, qword [MemPtr]);
       }
       break;
-      default:  LogMan::Msg::A("Unhandled LoadMem size: %d", Op->Size);
+      default:  LOGMAN_MSG_A("Unhandled LoadMem size: %d", Op->Size);
     }
   }
   else
@@ -511,7 +511,7 @@ DEF_OP(LoadMem) {
          }
        }
        break;
-      default:  LogMan::Msg::A("Unhandled LoadMem size: %d", Op->Size);
+      default:  LOGMAN_MSG_A("Unhandled LoadMem size: %d", Op->Size);
     }
   }
 }
@@ -537,7 +537,7 @@ DEF_OP(StoreMem) {
     case 8:
       mov(qword [MemPtr], GetSrc<RA_64>(Op->Header.Args[1].ID()));
     break;
-    default:  LogMan::Msg::A("Unhandled StoreMem size: %d", Op->Size);
+    default:  LOGMAN_MSG_A("Unhandled StoreMem size: %d", Op->Size);
     }
   }
   else {
@@ -560,17 +560,17 @@ DEF_OP(StoreMem) {
       else
         movups(xword [MemPtr], GetSrc(Op->Header.Args[1].ID()));
     break;
-    default:  LogMan::Msg::A("Unhandled StoreMem size: %d", Op->Size);
+    default:  LOGMAN_MSG_A("Unhandled StoreMem size: %d", Op->Size);
     }
   }
 }
 
 DEF_OP(VLoadMemElement) {
-  LogMan::Msg::A("Unimplemented");
+  LOGMAN_MSG_A("Unimplemented");
 }
 
 DEF_OP(VStoreMemElement) {
-  LogMan::Msg::A("Unimplemented");
+  LOGMAN_MSG_A("Unimplemented");
 }
 
 #undef DEF_OP

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/MiscOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/MiscOps.cpp
@@ -26,7 +26,7 @@ DEF_OP(Fence) {
     case IR::Fence_Store.Val:
       sfence();
       break;
-    default: LogMan::Msg::A("Unknown Fence: %d", Op->Fence); break;
+    default: LOGMAN_MSG_A("Unknown Fence: %d", Op->Fence); break;
   }
 }
 
@@ -70,7 +70,7 @@ DEF_OP(Break) {
       }
     break;
     }
-    default: LogMan::Msg::A("Unknown Break reason: %d", Op->Reason);
+    default: LOGMAN_MSG_A("Unknown Break reason: %d", Op->Reason);
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/MoveOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/MoveOps.cpp
@@ -25,7 +25,7 @@ DEF_OP(ExtractElementPair) {
       mov (GetDst<RA_64>(Node), Regs[Op->Element]);
       break;
     }
-    default: LogMan::Msg::A("Unknown Size"); break;
+    default: LOGMAN_MSG_A("Unknown Size"); break;
   }
 }
 
@@ -51,7 +51,7 @@ DEF_OP(CreateElementPair) {
       RegTmp = rax;
       break;
     }
-    default: LogMan::Msg::A("Unknown Size"); break;
+    default: LOGMAN_MSG_A("Unknown Size"); break;
   }
 
   if (Dst.first != RegSecond) {

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
@@ -62,24 +62,24 @@ DEF_OP(VectorImm) {
 }
 
 DEF_OP(CreateVector2) {
-  LogMan::Msg::A("Unimplemented");
+  LOGMAN_MSG_A("Unimplemented");
 }
 
 DEF_OP(CreateVector4) {
-  LogMan::Msg::A("Unimplemented");
+  LOGMAN_MSG_A("Unimplemented");
 }
 
 DEF_OP(SplatVector) {
   auto Op = IROp->C<IR::IROp_SplatVector2>();
   uint8_t OpSize = IROp->Size;
 
-  LogMan::Throw::A(OpSize <= 16, "Can't handle a vector of size: %d", OpSize);
+  LOGMAN_THROW_A(OpSize <= 16, "Can't handle a vector of size: %d", OpSize);
   uint8_t Elements = 0;
 
   switch (Op->Header.Op) {
     case IR::OP_SPLATVECTOR4: Elements = 4; break;
     case IR::OP_SPLATVECTOR2: Elements = 2; break;
-    default: LogMan::Msg::A("Uknown Splat size"); break;
+    default: LOGMAN_MSG_A("Uknown Splat size"); break;
   }
 
   uint8_t ElementSize = OpSize / Elements;
@@ -92,7 +92,7 @@ DEF_OP(SplatVector) {
     case 8:
       movddup(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
     break;
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.Size); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.Size); break;
   }
 }
 
@@ -130,7 +130,7 @@ DEF_OP(VMov) {
       movaps(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
       break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", OpSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", OpSize); break;
   }
 }
 
@@ -168,7 +168,7 @@ DEF_OP(VAdd) {
       vpaddq(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -191,7 +191,7 @@ DEF_OP(VSub) {
       vpsubq(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -206,7 +206,7 @@ DEF_OP(VUQAdd) {
       vpaddusw(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -221,7 +221,7 @@ DEF_OP(VUQSub) {
       vpsubusw(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -236,7 +236,7 @@ DEF_OP(VSQAdd) {
       vpaddsw(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -251,7 +251,7 @@ DEF_OP(VSQSub) {
       vpsubsw(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -288,7 +288,7 @@ DEF_OP(VAddP) {
       case 4:
         vphaddd(GetDst(Node), xmm15, xmm14);
         break;
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -317,7 +317,7 @@ DEF_OP(VAddP) {
       case 4:
         vphaddd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
         break;
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
 }
@@ -349,7 +349,7 @@ DEF_OP(VAddV) {
       pinsrd(xmm15, eax, 0);
     break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 
   movaps(Dest, xmm15);
@@ -366,7 +366,7 @@ DEF_OP(VURAvg) {
       vpavgw(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -389,7 +389,7 @@ DEF_OP(VAbs) {
       vpabsq(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
       break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -408,7 +408,7 @@ DEF_OP(VFAdd) {
         vaddsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -422,7 +422,7 @@ DEF_OP(VFAdd) {
         vaddpd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
 }
@@ -436,7 +436,7 @@ DEF_OP(VFAddP) {
     case 8:
       vhaddpd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -455,7 +455,7 @@ DEF_OP(VFSub) {
         vsubsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -469,7 +469,7 @@ DEF_OP(VFSub) {
         vsubpd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
 }
@@ -489,7 +489,7 @@ DEF_OP(VFMul) {
         vmulsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -503,7 +503,7 @@ DEF_OP(VFMul) {
         vmulpd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
 }
@@ -523,7 +523,7 @@ DEF_OP(VFDiv) {
         vdivsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -537,7 +537,7 @@ DEF_OP(VFDiv) {
         vdivpd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
 }
@@ -557,7 +557,7 @@ DEF_OP(VFMin) {
         vminsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -571,7 +571,7 @@ DEF_OP(VFMin) {
         vminpd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
 }
@@ -591,7 +591,7 @@ DEF_OP(VFMax) {
         vmaxsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -605,7 +605,7 @@ DEF_OP(VFMax) {
         vmaxpd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
 }
@@ -623,7 +623,7 @@ DEF_OP(VFRecp) {
         vdivss(GetDst(Node), xmm15, GetSrc(Op->Header.Args[0].ID()));
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -636,7 +636,7 @@ DEF_OP(VFRecp) {
         vdivps(GetDst(Node), xmm15, GetSrc(Op->Header.Args[0].ID()));
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
 }
@@ -656,7 +656,7 @@ DEF_OP(VFSqrt) {
         vsqrtsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[0].ID()));
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -670,7 +670,7 @@ DEF_OP(VFSqrt) {
         vsqrtpd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
 }
@@ -696,7 +696,7 @@ DEF_OP(VFRSqrt) {
         divsd(GetDst(Node), xmm15);
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -710,7 +710,7 @@ DEF_OP(VFRSqrt) {
         divps(GetDst(Node), xmm15);
       break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
 }
@@ -735,7 +735,7 @@ DEF_OP(VNeg) {
       vpsubq(GetDst(Node), xmm15, GetSrc(Op->Header.Args[0].ID()));
     break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -756,7 +756,7 @@ DEF_OP(VFNeg) {
       vxorpd(GetDst(Node), xmm15, GetSrc(Op->Header.Args[0].ID()));
     break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -779,7 +779,7 @@ DEF_OP(VUMin) {
         pinsrq(GetDst(Node), TMP2, 0);
         break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -796,7 +796,7 @@ DEF_OP(VUMin) {
         vpminud(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
         break;
       }
-      default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
 }
@@ -816,7 +816,7 @@ DEF_OP(VSMin) {
       vpminsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -835,7 +835,7 @@ DEF_OP(VUMax) {
       vpmaxud(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -854,7 +854,7 @@ DEF_OP(VSMax) {
       vpmaxsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -879,7 +879,7 @@ DEF_OP(VZip) {
       punpcklqdq(xmm15, GetSrc(Op->Header.Args[1].ID()));
       break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
   movapd(GetDst(Node), xmm15);
 }
@@ -906,7 +906,7 @@ DEF_OP(VZip2) {
       vpunpckhdq(GetDst(Node), xmm15, xmm14);
     break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -927,7 +927,7 @@ DEF_OP(VZip2) {
       punpckhqdq(xmm15, GetSrc(Op->Header.Args[1].ID()));
     break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
     }
     movapd(GetDst(Node), xmm15);
   }
@@ -956,7 +956,7 @@ DEF_OP(VCMPEQ) {
     case 8:
       vpcmpeqq(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
-    default: LogMan::Msg::A("Unsupported elementSize: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
   }
 }
 
@@ -977,7 +977,7 @@ DEF_OP(VCMPEQZ) {
     case 8:
       vpcmpeqq(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), xmm15);
       break;
-    default: LogMan::Msg::A("Unsupported elementSize: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
   }
 }
 
@@ -997,7 +997,7 @@ DEF_OP(VCMPGT) {
     case 8:
       vpcmpgtq(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
-    default: LogMan::Msg::A("Unsupported elementSize: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
   }
 }
 
@@ -1018,7 +1018,7 @@ DEF_OP(VCMPGTZ) {
     case 8:
       vpcmpgtq(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), xmm15);
       break;
-    default: LogMan::Msg::A("Unsupported elementSize: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
   }
 }
 
@@ -1039,7 +1039,7 @@ DEF_OP(VCMPLTZ) {
     case 8:
       vpcmpgtq(GetDst(Node), xmm15, GetSrc(Op->Header.Args[0].ID()));
       break;
-    default: LogMan::Msg::A("Unsupported elementSize: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
   }
 }
 
@@ -1055,7 +1055,7 @@ DEF_OP(VFCMPEQ) {
     case 8:
       vcmpsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 0);
     break;
-    default: LogMan::Msg::A("Unsupported elementSize: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
     }
   }
   else {
@@ -1066,7 +1066,7 @@ DEF_OP(VFCMPEQ) {
     case 8:
       vcmppd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 0);
     break;
-    default: LogMan::Msg::A("Unsupported elementSize: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
     }
   }
 }
@@ -1083,7 +1083,7 @@ DEF_OP(VFCMPNEQ) {
     case 8:
       vcmpsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 4);
     break;
-    default: LogMan::Msg::A("Unsupported elementSize: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
     }
 
   }
@@ -1095,7 +1095,7 @@ DEF_OP(VFCMPNEQ) {
     case 8:
       vcmppd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 4);
     break;
-    default: LogMan::Msg::A("Unsupported elementSize: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
     }
   }
 }
@@ -1112,7 +1112,7 @@ DEF_OP(VFCMPLT) {
     case 8:
       vcmpsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 1);
     break;
-    default: LogMan::Msg::A("Unsupported elementSize: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
     }
   }
   else {
@@ -1123,7 +1123,7 @@ DEF_OP(VFCMPLT) {
     case 8:
       vcmppd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 1);
     break;
-    default: LogMan::Msg::A("Unsupported elementSize: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
     }
   }
 }
@@ -1140,7 +1140,7 @@ DEF_OP(VFCMPGT) {
     case 8:
       vcmpsd(GetDst(Node), GetSrc(Op->Header.Args[1].ID()), GetSrc(Op->Header.Args[0].ID()), 1);
     break;
-    default: LogMan::Msg::A("Unsupported elementSize: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
     }
   }
   else {
@@ -1151,7 +1151,7 @@ DEF_OP(VFCMPGT) {
     case 8:
       vcmppd(GetDst(Node), GetSrc(Op->Header.Args[1].ID()), GetSrc(Op->Header.Args[0].ID()), 1);
     break;
-    default: LogMan::Msg::A("Unsupported elementSize: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
     }
   }
 }
@@ -1168,7 +1168,7 @@ DEF_OP(VFCMPLE) {
     case 8:
       vcmpsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 2);
     break;
-    default: LogMan::Msg::A("Unsupported elementSize: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
     }
   }
   else {
@@ -1179,7 +1179,7 @@ DEF_OP(VFCMPLE) {
     case 8:
       vcmppd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 2);
     break;
-    default: LogMan::Msg::A("Unsupported elementSize: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
     }
   }
 }
@@ -1196,7 +1196,7 @@ DEF_OP(VFCMPORD) {
     case 8:
       vcmpsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 7);
     break;
-    default: LogMan::Msg::A("Unsupported elementSize: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
     }
   }
   else {
@@ -1207,7 +1207,7 @@ DEF_OP(VFCMPORD) {
     case 8:
       vcmppd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 7);
     break;
-    default: LogMan::Msg::A("Unsupported elementSize: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
     }
   }
 }
@@ -1224,7 +1224,7 @@ DEF_OP(VFCMPUNO) {
     case 8:
       vcmpsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 3);
     break;
-    default: LogMan::Msg::A("Unsupported elementSize: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
     }
   }
   else {
@@ -1235,21 +1235,21 @@ DEF_OP(VFCMPUNO) {
     case 8:
       vcmppd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 3);
     break;
-    default: LogMan::Msg::A("Unsupported elementSize: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
     }
   }
 }
 
 DEF_OP(VUShl) {
-  LogMan::Msg::A("Unimplemented");
+  LOGMAN_MSG_A("Unimplemented");
 }
 
 DEF_OP(VUShr) {
-  LogMan::Msg::A("Unimplemented");
+  LOGMAN_MSG_A("Unimplemented");
 }
 
 DEF_OP(VSShr) {
-  LogMan::Msg::A("Unimplemented");
+  LOGMAN_MSG_A("Unimplemented");
 }
 
 DEF_OP(VUShlS) {
@@ -1268,7 +1268,7 @@ DEF_OP(VUShlS) {
       vpsllq(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -1288,7 +1288,7 @@ DEF_OP(VUShrS) {
       vpsrlq(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -1305,7 +1305,7 @@ DEF_OP(VSShrS) {
       break;
     }
     case 8: // Doesn't exist on x86
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -1338,7 +1338,7 @@ DEF_OP(VInsElement) {
     pinsrq(xmm15, rax, Op->DestIdx);
   break;
   }
-  default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+  default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 
   movapd(GetDst(Node), xmm15);
@@ -1373,7 +1373,7 @@ DEF_OP(VInsScalarElement) {
     pinsrq(xmm15, rax, Op->DestIdx);
   break;
   }
-  default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+  default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 
   movapd(GetDst(Node), xmm15);
@@ -1403,7 +1403,7 @@ DEF_OP(VExtractElement) {
       pinsrq(GetDst(Node), rax, 0);
       break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -1454,7 +1454,7 @@ DEF_OP(VUShrI) {
       psrlq(GetDst(Node), Op->BitShift);
       break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -1470,7 +1470,7 @@ DEF_OP(VSShrI) {
       psrad(GetDst(Node), Op->BitShift);
       break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -1490,7 +1490,7 @@ DEF_OP(VShlI) {
       psllq(GetDst(Node), Op->BitShift);
       break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -1520,7 +1520,7 @@ DEF_OP(VUShrNI) {
       mov(rcx, 0x80'80'80'80'80'80'80'80); // Upper
       break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 
   vmovq(xmm15, rax);
@@ -1556,7 +1556,7 @@ DEF_OP(VUShrNI2) {
       mov(rcx, 0x0B'0A'09'08'03'02'01'00); // Upper
       break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 
   vmovq(xmm15, rax);
@@ -1583,7 +1583,7 @@ DEF_OP(VSXTL) {
     case 8:
       pmovsxdq(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
     break;
-    default: LogMan::Msg::A("Unknown element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A("Unknown element size: %d", Op->Header.ElementSize);
   }
 }
 
@@ -1602,7 +1602,7 @@ DEF_OP(VSXTL2) {
     case 8:
       pmovsxdq(GetDst(Node), GetDst(Node));
     break;
-    default: LogMan::Msg::A("Unknown element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A("Unknown element size: %d", Op->Header.ElementSize);
   }
 }
 
@@ -1618,7 +1618,7 @@ DEF_OP(VUXTL) {
     case 8:
       pmovzxdq(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
     break;
-    default: LogMan::Msg::A("Unknown element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A("Unknown element size: %d", Op->Header.ElementSize);
   }
 }
 
@@ -1637,7 +1637,7 @@ DEF_OP(VUXTL2) {
     case 8:
       pmovzxdq(GetDst(Node), GetDst(Node));
     break;
-    default: LogMan::Msg::A("Unknown element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A("Unknown element size: %d", Op->Header.ElementSize);
   }
 }
 
@@ -1650,7 +1650,7 @@ DEF_OP(VSQXTN) {
     case 2:
       packssdw(xmm15, GetSrc(Op->Header.Args[0].ID()));
     break;
-    default: LogMan::Msg::A("Unknown element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A("Unknown element size: %d", Op->Header.ElementSize);
   }
   psrldq(xmm15, 8);
   movaps(GetDst(Node), xmm15);
@@ -1669,7 +1669,7 @@ DEF_OP(VSQXTN2) {
     case 2:
       packssdw(xmm15, GetSrc(Op->Header.Args[1].ID()));
     break;
-    default: LogMan::Msg::A("Unknown element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A("Unknown element size: %d", Op->Header.ElementSize);
   }
 
   if (OpSize == 8) {
@@ -1687,7 +1687,7 @@ DEF_OP(VSQXTUN) {
     case 2:
       packusdw(xmm15, GetSrc(Op->Header.Args[0].ID()));
     break;
-    default: LogMan::Msg::A("Unknown element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A("Unknown element size: %d", Op->Header.ElementSize);
   }
   psrldq(xmm15, 8);
   movaps(GetDst(Node), xmm15);
@@ -1706,7 +1706,7 @@ DEF_OP(VSQXTUN2) {
     case 2:
       packusdw(xmm15, GetSrc(Op->Header.Args[1].ID()));
     break;
-    default: LogMan::Msg::A("Unknown element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A("Unknown element size: %d", Op->Header.ElementSize);
   }
   if (OpSize == 8) {
     psrldq(xmm15, OpSize / 2);
@@ -1726,7 +1726,7 @@ DEF_OP(VMul) {
       vpmulld(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -1757,7 +1757,7 @@ DEF_OP(VUMull) {
       vpmuludq(GetDst(Node), xmm14, xmm15);
     break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -1792,7 +1792,7 @@ DEF_OP(VSMull) {
       vpmuldq(GetDst(Node), xmm14, xmm15);
     break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -1828,7 +1828,7 @@ DEF_OP(VUMull2) {
       vpmuludq(GetDst(Node), xmm14, xmm15);
     break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -1868,7 +1868,7 @@ DEF_OP(VSMull2) {
       vpmuldq(GetDst(Node), xmm14, xmm15);
     break;
     }
-    default: LogMan::Msg::A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
   }
 }
 
@@ -1886,7 +1886,7 @@ DEF_OP(VTBL1) {
       vpshufb(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
     }
-    default: LogMan::Msg::A("Unknown OpSize: %d", OpSize); break;
+    default: LOGMAN_MSG_A("Unknown OpSize: %d", OpSize); break;
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/LookupCache.cpp
+++ b/External/FEXCore/Source/Interface/Core/LookupCache.cpp
@@ -36,11 +36,11 @@ LookupCache::LookupCache(FEXCore::Context::Context *CTX)
   // We currently limit to 128MB of real memory for caching for the total cache size.
   // Can end up being inefficient if we compile a small number of blocks per page
   PageMemory = reinterpret_cast<uintptr_t>(FEXCore::Allocator::mmap(nullptr, CODE_SIZE, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
-  LogMan::Throw::A(PageMemory != -1ULL, "Failed to allocate page memory");
+  LOGMAN_THROW_A(PageMemory != -1ULL, "Failed to allocate page memory");
 
   // L1 Cache
   L1Pointer = reinterpret_cast<uintptr_t>(FEXCore::Allocator::mmap(nullptr, L1_SIZE, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
-  LogMan::Throw::A(L1Pointer != -1ULL, "Failed to allocate L1Pointer");
+  LOGMAN_THROW_A(L1Pointer != -1ULL, "Failed to allocate L1Pointer");
 
   VirtualMemSize = ctx->Config.VirtualMemSize;
 }

--- a/External/FEXCore/Source/Interface/Core/LookupCache.h
+++ b/External/FEXCore/Source/Interface/Core/LookupCache.h
@@ -39,7 +39,7 @@ public:
 
   void AddBlockMapping(uint64_t Address, void *HostCode, uint64_t Start, uint64_t Length) { 
     auto InsertPoint = BlockList.emplace(Address, (uintptr_t)HostCode);
-    LogMan::Throw::A(InsertPoint.second == true, "Dupplicate block mapping added");
+    LOGMAN_THROW_A(InsertPoint.second == true, "Dupplicate block mapping added");
 
     for (auto CurrentPage = Start >> 12, EndPage = (Start + Length) >> 12; CurrentPage <= EndPage; CurrentPage++) {
       CodePages[CurrentPage].push_back(Address);

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -189,7 +189,7 @@ RSP
 SS
 */
 void OpDispatchBuilder::IRETOp(OpcodeArgs) {
-  LogMan::Throw::A(CTX->Config.Is64BitMode == true, "IRET only implemented for x64");
+  LOGMAN_THROW_A(CTX->Config.Is64BitMode == true, "IRET only implemented for x64");
 
   uint8_t GPRSize = CTX->Config.Is64BitMode ? 8 : 4;
 
@@ -277,7 +277,7 @@ void OpDispatchBuilder::SecondaryALUOp(OpcodeArgs) {
   break;
   default:
     IROp = FEXCore::IR::IROps::OP_LAST;
-    LogMan::Msg::A("Unknown ALU Op: 0x%x", Op->OP);
+    LOGMAN_MSG_A("Unknown ALU Op: 0x%x", Op->OP);
   break;
   };
 #undef OPD
@@ -317,7 +317,7 @@ void OpDispatchBuilder::SecondaryALUOp(OpcodeArgs) {
         Result = _Xor(Dest, Src);
         break;
       }
-      default: LogMan::Msg::A("Unknown Atomic IR Op: %d", IROp); break;
+      default: LOGMAN_MSG_A("Unknown Atomic IR Op: %d", IROp); break;
     }
   }
   else {
@@ -872,7 +872,7 @@ OrderedNode *OpDispatchBuilder::SelectCC(uint8_t OP, OrderedNode *TrueValue, Ord
           Check, OneConst, TrueValue, FalseValue);
       break;
     }
-    default: LogMan::Msg::A("Unknown CC Op: 0x%x\n", OP); return nullptr;
+    default: LOGMAN_MSG_A("Unknown CC Op: 0x%x\n", OP); return nullptr;
   }
 
   // Try folding the flags generation in the select op
@@ -998,7 +998,7 @@ void OpDispatchBuilder::CondJUMPOp(OpcodeArgs) {
 
   auto SrcCond = SelectCC(Op->OP & 0xF, TakeBranch, DoNotTakeBranch);
 
-  LogMan::Throw::A(Op->Src[0].TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL, "Src1 needs to be literal here");
+  LOGMAN_THROW_A(Op->Src[0].TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL, "Src1 needs to be literal here");
 
   uint64_t Target = Op->PC + Op->InstSize + Op->Src[0].TypeLiteral.Literal;
 
@@ -1057,7 +1057,7 @@ void OpDispatchBuilder::CondJUMPRCXOp(OpcodeArgs) {
   TakeBranch = _Constant(1);
   DoNotTakeBranch = _Constant(0);
 
-  LogMan::Throw::A(Op->Src[0].TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL, "Src1 needs to be literal here");
+  LOGMAN_THROW_A(Op->Src[0].TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL, "Src1 needs to be literal here");
 
   uint64_t Target = Op->PC + Op->InstSize + Op->Src[0].TypeLiteral.Literal;
 
@@ -1120,7 +1120,7 @@ void OpDispatchBuilder::LoopOp(OpcodeArgs) {
 
   uint32_t SrcSize = (Op->Flags & X86Tables::DecodeFlags::FLAG_ADDRESS_SIZE) ? 4 : 8;
 
-  LogMan::Throw::A(Op->Src[1].TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL, "Src1 needs to be literal here");
+  LOGMAN_THROW_A(Op->Src[1].TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL, "Src1 needs to be literal here");
 
   uint64_t Target = Op->PC + Op->InstSize + Op->Src[1].TypeLiteral.Literal;
 
@@ -1188,7 +1188,7 @@ void OpDispatchBuilder::JUMPOp(OpcodeArgs) {
 
   // This is just an unconditional relative literal jump
   if (Multiblock) {
-    LogMan::Throw::A(Op->Src[0].TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL, "Src1 needs to be literal here");
+    LOGMAN_THROW_A(Op->Src[0].TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL, "Src1 needs to be literal here");
     uint64_t Target = Op->PC + Op->InstSize + Op->Src[0].TypeLiteral.Literal;
     auto JumpBlock = JumpTargets.find(Target);
     if (JumpBlock != JumpTargets.end()) {
@@ -1493,18 +1493,18 @@ void OpDispatchBuilder::MOVSegOp(OpcodeArgs) {
         _StoreContext(GPRClass, 2, offsetof(FEXCore::Core::CPUState, ss), Src);
         break;
       case 6: // GS
-        LogMan::Throw::A(!CTX->Config.Is64BitMode, "We don't support modifying GS selector in 64bit mode!");
+        LOGMAN_THROW_A(!CTX->Config.Is64BitMode, "We don't support modifying GS selector in 64bit mode!");
         if (!CTX->Config.Is64BitMode) {
           _StoreContext(GPRClass, 2, offsetof(FEXCore::Core::CPUState, gs), Src);
         }
         break;
       case 7: // FS
-        LogMan::Throw::A(!CTX->Config.Is64BitMode, "We don't support modifying FS selector in 64bit mode!");
+        LOGMAN_THROW_A(!CTX->Config.Is64BitMode, "We don't support modifying FS selector in 64bit mode!");
         if (!CTX->Config.Is64BitMode) {
           _StoreContext(GPRClass, 2, offsetof(FEXCore::Core::CPUState, fs), Src);
         }
         break;
-      default: LogMan::Msg::A("Unknown segment register: %d", Op->Dest.TypeGPR.GPR);
+      default: LOGMAN_MSG_A("Unknown segment register: %d", Op->Dest.TypeGPR.GPR);
     }
   }
   else {
@@ -1539,7 +1539,7 @@ void OpDispatchBuilder::MOVSegOp(OpcodeArgs) {
           Segment = _LoadContext(2, offsetof(FEXCore::Core::CPUState, fs), GPRClass);
         }
         break;
-      default: LogMan::Msg::A("Unknown segment register: %d", Op->Src[0].TypeGPR.GPR);
+      default: LOGMAN_MSG_A("Unknown segment register: %d", Op->Src[0].TypeGPR.GPR);
     }
     StoreResult(GPRClass, Op, Segment, -1);
   }
@@ -1622,7 +1622,7 @@ void OpDispatchBuilder::SHLOp(OpcodeArgs) {
 void OpDispatchBuilder::SHLImmediateOp(OpcodeArgs) {
   OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
 
-  LogMan::Throw::A(Op->Src[1].TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL, "Src1 needs to be literal here");
+  LOGMAN_THROW_A(Op->Src[1].TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL, "Src1 needs to be literal here");
 
   uint64_t Shift = Op->Src[1].TypeLiteral.Literal;
   auto Size = GetSrcSize(Op) * 8;
@@ -1680,7 +1680,7 @@ void OpDispatchBuilder::SHROp(OpcodeArgs) {
 void OpDispatchBuilder::SHRImmediateOp(OpcodeArgs) {
   auto Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
 
-  LogMan::Throw::A(Op->Src[1].TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL, "Src1 needs to be literal here");
+  LOGMAN_THROW_A(Op->Src[1].TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL, "Src1 needs to be literal here");
 
   uint64_t Shift = Op->Src[1].TypeLiteral.Literal;
   auto Size = GetSrcSize(Op) * 8;
@@ -1757,7 +1757,7 @@ void OpDispatchBuilder::SHLDImmediateOp(OpcodeArgs) {
   OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
   OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
 
-  LogMan::Throw::A(Op->Src[1].TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL, "Src1 needs to be literal here");
+  LOGMAN_THROW_A(Op->Src[1].TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL, "Src1 needs to be literal here");
 
   uint64_t Shift = Op->Src[1].TypeLiteral.Literal;
   auto Size = GetSrcSize(Op) * 8;
@@ -1846,7 +1846,7 @@ void OpDispatchBuilder::SHRDImmediateOp(OpcodeArgs) {
   OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
   OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
 
-  LogMan::Throw::A(Op->Src[1].TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL, "Src1 needs to be literal here");
+  LOGMAN_THROW_A(Op->Src[1].TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL, "Src1 needs to be literal here");
 
   uint64_t Shift = Op->Src[1].TypeLiteral.Literal;
   auto Size = GetSrcSize(Op) * 8;
@@ -1917,7 +1917,7 @@ void OpDispatchBuilder::ASHROp(OpcodeArgs) {
 void OpDispatchBuilder::ASHRImmediateOp(OpcodeArgs) {
   OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
 
-  LogMan::Throw::A(Op->Src[1].TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL, "Src1 needs to be literal here");
+  LOGMAN_THROW_A(Op->Src[1].TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL, "Src1 needs to be literal here");
 
   uint64_t Shift = Op->Src[1].TypeLiteral.Literal;
   auto Size = GetSrcSize(Op) * 8;
@@ -1985,7 +1985,7 @@ void OpDispatchBuilder::ROROp(OpcodeArgs) {
 void OpDispatchBuilder::RORImmediateOp(OpcodeArgs) {
   OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
 
-  LogMan::Throw::A(Op->Src[1].TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL, "Src1 needs to be literal here");
+  LOGMAN_THROW_A(Op->Src[1].TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL, "Src1 needs to be literal here");
 
   uint64_t Shift = Op->Src[1].TypeLiteral.Literal;
   auto Size = GetSrcSize(Op) * 8;
@@ -2063,7 +2063,7 @@ void OpDispatchBuilder::ROLOp(OpcodeArgs) {
 void OpDispatchBuilder::ROLImmediateOp(OpcodeArgs) {
   OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
 
-  LogMan::Throw::A(Op->Src[1].TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL, "Src1 needs to be literal here");
+  LOGMAN_THROW_A(Op->Src[1].TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL, "Src1 needs to be literal here");
 
   uint64_t Shift = Op->Src[1].TypeLiteral.Literal;
   auto Size = GetSrcSize(Op) * 8;
@@ -2784,7 +2784,7 @@ void OpDispatchBuilder::IMULOp(OpcodeArgs) {
     _StoreContext(GPRClass, 8, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RDX]), LocalResultHigh);
   }
   else if (Size == 8) {
-    LogMan::Throw::A(CTX->Config.Is64BitMode, "Doesn't exist in 32bit mode");
+    LOGMAN_THROW_A(CTX->Config.Is64BitMode, "Doesn't exist in 32bit mode");
     // 64bits stored in RAX
     // 64bits stored in RDX
     ResultHigh = _MulH(Src1, Src2);
@@ -2829,7 +2829,7 @@ void OpDispatchBuilder::MULOp(OpcodeArgs) {
     _StoreContext(GPRClass, GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RDX]), ResultHigh);
   }
   else if (Size == 8) {
-    LogMan::Throw::A(CTX->Config.Is64BitMode, "Doesn't exist in 32bit mode");
+    LOGMAN_THROW_A(CTX->Config.Is64BitMode, "Doesn't exist in 32bit mode");
     // 64bits stored in RAX
     // 64bits stored in RDX
     ResultHigh = _UMulH(Src1, Src2);
@@ -2961,7 +2961,7 @@ void OpDispatchBuilder::WriteSegmentReg(OpcodeArgs) {
 void OpDispatchBuilder::EnterOp(OpcodeArgs) {
   uint8_t GPRSize = CTX->Config.Is64BitMode ? 8 : 4;
 
-  LogMan::Throw::A(Op->Src[0].TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL, "Src1 needs to be literal here");
+  LOGMAN_THROW_A(Op->Src[0].TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL, "Src1 needs to be literal here");
   uint64_t Value = Op->Src[0].TypeLiteral.Literal;
 
   uint16_t AllocSpace = Value & 0xFFFF;
@@ -3008,7 +3008,7 @@ void OpDispatchBuilder::RDTSCOp(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::INCOp(OpcodeArgs) {
-  LogMan::Throw::A(!(Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_REP_PREFIX), "Can't handle REP on this\n");
+  LOGMAN_THROW_A(!(Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_REP_PREFIX), "Can't handle REP on this\n");
 
   OrderedNode *Dest;
   OrderedNode *Result;
@@ -3039,7 +3039,7 @@ void OpDispatchBuilder::INCOp(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::DECOp(OpcodeArgs) {
-  LogMan::Throw::A(!(Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_REP_PREFIX), "Can't handle REP on this\n");
+  LOGMAN_THROW_A(!(Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_REP_PREFIX), "Can't handle REP on this\n");
 
   OrderedNode *Dest;
   OrderedNode *Result;
@@ -3070,8 +3070,8 @@ void OpDispatchBuilder::DECOp(OpcodeArgs) {
 
 void OpDispatchBuilder::STOSOp(OpcodeArgs) {
   uint8_t GPRSize = CTX->Config.Is64BitMode ? 8 : 4;
-  LogMan::Throw::A(!(Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_REPNE_PREFIX), "Invalid REPNE on STOS");
-  LogMan::Throw::A(!(Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_ADDRESS_SIZE), "Can't handle adddress size\n");
+  LOGMAN_THROW_A(!(Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_REPNE_PREFIX), "Invalid REPNE on STOS");
+  LOGMAN_THROW_A(!(Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_ADDRESS_SIZE), "Can't handle adddress size\n");
   auto Size = GetSrcSize(Op);
 
   bool Repeat = Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_REP_PREFIX;
@@ -3170,8 +3170,8 @@ void OpDispatchBuilder::STOSOp(OpcodeArgs) {
 
 void OpDispatchBuilder::MOVSOp(OpcodeArgs) {
   uint8_t GPRSize = CTX->Config.Is64BitMode ? 8 : 4;
-  LogMan::Throw::A(!(Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_REPNE_PREFIX), "Invalid REPNE on MOVS\n");
-  LogMan::Throw::A(!(Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_ADDRESS_SIZE), "Can't handle adddress size\n");
+  LOGMAN_THROW_A(!(Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_REPNE_PREFIX), "Invalid REPNE on MOVS\n");
+  LOGMAN_THROW_A(!(Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_ADDRESS_SIZE), "Can't handle adddress size\n");
 
   // RA now can handle these to be here, to avoud DF accesses
   auto Size = GetSrcSize(Op);
@@ -3260,7 +3260,7 @@ void OpDispatchBuilder::MOVSOp(OpcodeArgs) {
 void OpDispatchBuilder::CMPSOp(OpcodeArgs) {
   uint8_t GPRSize = CTX->Config.Is64BitMode ? 8 : 4;
 
-  LogMan::Throw::A(!(Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_ADDRESS_SIZE), "Can't handle adddress size\n");
+  LOGMAN_THROW_A(!(Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_ADDRESS_SIZE), "Can't handle adddress size\n");
   auto Size = GetSrcSize(Op);
 
   bool Repeat = Op->Flags & (FEXCore::X86Tables::DecodeFlags::FLAG_REPNE_PREFIX | FEXCore::X86Tables::DecodeFlags::FLAG_REP_PREFIX);
@@ -3375,8 +3375,8 @@ void OpDispatchBuilder::CMPSOp(OpcodeArgs) {
 void OpDispatchBuilder::LODSOp(OpcodeArgs) {
   uint8_t GPRSize = CTX->Config.Is64BitMode ? 8 : 4;
 
-  LogMan::Throw::A(!(Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_ADDRESS_SIZE), "Can't handle adddress size\n");
-  LogMan::Throw::A(!(Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_REPNE_PREFIX), "LODS doesn't support REPNE");
+  LOGMAN_THROW_A(!(Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_ADDRESS_SIZE), "Can't handle adddress size\n");
+  LOGMAN_THROW_A(!(Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_REPNE_PREFIX), "LODS doesn't support REPNE");
 
   auto Size = GetSrcSize(Op);
   bool Repeat = Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_REP_PREFIX;
@@ -3468,7 +3468,7 @@ void OpDispatchBuilder::LODSOp(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::SCASOp(OpcodeArgs) {
-  LogMan::Throw::A(!(Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_ADDRESS_SIZE), "Can't handle adddress size\n");
+  LOGMAN_THROW_A(!(Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_ADDRESS_SIZE), "Can't handle adddress size\n");
 
   uint8_t GPRSize = CTX->Config.Is64BitMode ? 8 : 4;
 
@@ -3634,7 +3634,7 @@ void OpDispatchBuilder::POPFOp(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::NEGOp(OpcodeArgs) {
-  LogMan::Throw::A(!DestIsLockedMem(Op), "Can't handle LOCK on NEG\n");
+  LOGMAN_THROW_A(!DestIsLockedMem(Op), "Can't handle LOCK on NEG\n");
   OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
   auto ZeroConst = _Constant(0);
   OrderedNode *Result = _Sub(ZeroConst, Dest);
@@ -3685,7 +3685,7 @@ void OpDispatchBuilder::DIVOp(OpcodeArgs) {
     _StoreContext(GPRClass, GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RDX]), URemOp);
   }
   else if (Size == 8) {
-    LogMan::Throw::A(CTX->Config.Is64BitMode, "Doesn't exist in 32bit mode");
+    LOGMAN_THROW_A(CTX->Config.Is64BitMode, "Doesn't exist in 32bit mode");
     OrderedNode *Src1 = _LoadContext(Size, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RAX]), GPRClass);
     OrderedNode *Src2 = _LoadContext(Size, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RDX]), GPRClass);
 
@@ -3736,7 +3736,7 @@ void OpDispatchBuilder::IDIVOp(OpcodeArgs) {
     _StoreContext(GPRClass, GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RDX]), URemOp);
   }
   else if (Size == 8) {
-    LogMan::Throw::A(CTX->Config.Is64BitMode, "Doesn't exist in 32bit mode");
+    LOGMAN_THROW_A(CTX->Config.Is64BitMode, "Doesn't exist in 32bit mode");
     OrderedNode *Src1 = _LoadContext(Size, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RAX]), GPRClass);
     OrderedNode *Src2 = _LoadContext(Size, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RDX]), GPRClass);
 
@@ -4136,7 +4136,7 @@ void OpDispatchBuilder::PSHUFBOp(OpcodeArgs) {
 
 template<size_t ElementSize, bool HalfSize, bool Low>
 void OpDispatchBuilder::PSHUFDOp(OpcodeArgs) {
-  LogMan::Throw::A(ElementSize != 0, "What. No element size?");
+  LOGMAN_THROW_A(ElementSize != 0, "What. No element size?");
   auto Size = GetSrcSize(Op);
   OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
   uint8_t Shuffle = Op->Src[1].TypeLiteral.Literal;
@@ -4164,7 +4164,7 @@ void OpDispatchBuilder::PSHUFDOp(OpcodeArgs) {
 
 template<size_t ElementSize>
 void OpDispatchBuilder::SHUFOp(OpcodeArgs) {
-  LogMan::Throw::A(ElementSize != 0, "What. No element size?");
+  LOGMAN_THROW_A(ElementSize != 0, "What. No element size?");
   auto Size = GetSrcSize(Op);
   OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
   OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
@@ -4220,7 +4220,7 @@ void OpDispatchBuilder::PINSROp(OpcodeArgs) {
 
   OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
   OrderedNode *Dest = LoadSource_WithOpSize(FPRClass, Op, Op->Dest, GetDstSize(Op), Op->Flags, -1);
-  LogMan::Throw::A(Op->Src[1].TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL, "Src1 needs to be literal here");
+  LOGMAN_THROW_A(Op->Src[1].TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL, "Src1 needs to be literal here");
   uint64_t Index = Op->Src[1].TypeLiteral.Literal;
 
   uint8_t NumElements = Size / ElementSize;
@@ -4236,7 +4236,7 @@ void OpDispatchBuilder::PExtrOp(OpcodeArgs) {
   auto Size = GetSrcSize(Op);
 
   OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-  LogMan::Throw::A(Op->Src[1].TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL, "Src1 needs to be literal here");
+  LOGMAN_THROW_A(Op->Src[1].TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL, "Src1 needs to be literal here");
   uint64_t Index = Op->Src[1].TypeLiteral.Literal;
 
   uint8_t NumElements = Size / ElementSize;
@@ -4553,7 +4553,7 @@ void OpDispatchBuilder::Finalize() {
   // Node 0 is invalid node
   OrderedNode *RealNode = reinterpret_cast<OrderedNode*>(GetNode(1));
   FEXCore::IR::IROp_Header *IROp = RealNode->Op(Data.Begin());
-  LogMan::Throw::A(IROp->Op == OP_IRHEADER, "First op in function must be our header");
+  LOGMAN_THROW_A(IROp->Op == OP_IRHEADER, "First op in function must be our header");
 
   // Let's walk the jump blocks and see if we have handled every block target
   for (auto &Handler : JumpTargets) {
@@ -4579,7 +4579,7 @@ uint8_t OpDispatchBuilder::GetDstSize(FEXCore::X86Tables::DecodedOp Op) {
 
   uint32_t DstSizeFlag = FEXCore::X86Tables::DecodeFlags::GetSizeDstFlags(Op->Flags);
   uint8_t Size = Sizes[DstSizeFlag];
-  LogMan::Throw::A(Size != 0, "Invalid destination size for op");
+  LOGMAN_THROW_A(Size != 0, "Invalid destination size for op");
   return Size;
 }
 
@@ -4597,7 +4597,7 @@ uint8_t OpDispatchBuilder::GetSrcSize(FEXCore::X86Tables::DecodedOp Op) {
 
   uint32_t SrcSizeFlag = FEXCore::X86Tables::DecodeFlags::GetSizeSrcFlags(Op->Flags);
   uint8_t Size = Sizes[SrcSizeFlag];
-  LogMan::Throw::A(Size != 0, "Invalid destination size for op");
+  LOGMAN_THROW_A(Size != 0, "Invalid destination size for op");
   return Size;
 }
 
@@ -4654,7 +4654,7 @@ OrderedNode *OpDispatchBuilder::AppendSegmentOffset(OrderedNode *Value, uint32_t
 }
 
 OrderedNode *OpDispatchBuilder::LoadSource_WithOpSize(FEXCore::IR::RegisterClassType Class, FEXCore::X86Tables::DecodedOp const& Op, FEXCore::X86Tables::DecodedOperand const& Operand, uint8_t OpSize, uint32_t Flags, int8_t Align, bool LoadData, bool ForceLoad) {
-  LogMan::Throw::A(Operand.TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_GPR ||
+  LOGMAN_THROW_A(Operand.TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_GPR ||
           Operand.TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL ||
           Operand.TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_GPR_DIRECT ||
           Operand.TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_GPR_INDIRECT ||
@@ -4764,7 +4764,7 @@ OrderedNode *OpDispatchBuilder::LoadSource_WithOpSize(FEXCore::IR::RegisterClass
     LoadableType = true;
   }
   else {
-    LogMan::Msg::A("Unknown Src Type: %d\n", Operand.TypeNone.Type);
+    LOGMAN_MSG_A("Unknown Src Type: %d\n", Operand.TypeNone.Type);
   }
 
   if ((LoadableType && LoadData) || ForceLoad) {
@@ -4791,7 +4791,7 @@ OrderedNode *OpDispatchBuilder::LoadSource(FEXCore::IR::RegisterClassType Class,
 }
 
 void OpDispatchBuilder::StoreResult_WithOpSize(FEXCore::IR::RegisterClassType Class, FEXCore::X86Tables::DecodedOp Op, FEXCore::X86Tables::DecodedOperand const& Operand, OrderedNode *const Src, uint8_t OpSize, int8_t Align) {
-  LogMan::Throw::A((Operand.TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_GPR ||
+  LOGMAN_THROW_A((Operand.TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_GPR ||
           Operand.TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL ||
           Operand.TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_GPR_DIRECT ||
           Operand.TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_GPR_INDIRECT ||
@@ -4824,11 +4824,11 @@ void OpDispatchBuilder::StoreResult_WithOpSize(FEXCore::IR::RegisterClassType Cl
         // For all other sizes, the upper bits are guaranteed to already be zero
          OrderedNode *Value = GetOpSize(Src) == 8 ? _Bfe(4, 32, 0, Src) : Src;
 
-        LogMan::Throw::A(!Operand.TypeGPR.HighBits, "Can't handle 32bit store to high 8bit register");
+        LOGMAN_THROW_A(!Operand.TypeGPR.HighBits, "Can't handle 32bit store to high 8bit register");
         _StoreContext(Class, GPRSize, offsetof(FEXCore::Core::CPUState, gregs[Operand.TypeGPR.GPR]), Value);
       }
       else {
-        LogMan::Throw::A(!(GPRSize == 4 && OpSize > 4), "Oops had a %d GPR load", OpSize);
+        LOGMAN_THROW_A(!(GPRSize == 4 && OpSize > 4), "Oops had a %d GPR load", OpSize);
         _StoreContext(Class, std::min(GPRSize, OpSize), offsetof(FEXCore::Core::CPUState, gregs[Operand.TypeGPR.GPR]) + (Operand.TypeGPR.HighBits ? 1 : 0), Src);
       }
     }
@@ -5072,7 +5072,7 @@ void OpDispatchBuilder::GenerateFlags_ADC(FEXCore::X86Tables::DecodedOp Op, Orde
     case 64:
       AndOp1 = _Bfe(1, 63, AndOp1);
     break;
-    default: LogMan::Msg::A("Unknown BFESize: %d", Size); break;
+    default: LOGMAN_MSG_A("Unknown BFESize: %d", Size); break;
     }
     SetRFLAG<FEXCore::X86State::RFLAG_OF_LOC>(AndOp1);
   }
@@ -5140,7 +5140,7 @@ void OpDispatchBuilder::GenerateFlags_SBB(FEXCore::X86Tables::DecodedOp Op, Orde
     case 8:
       AndOp1 = _Bfe(1, 63, AndOp1);
     break;
-    default: LogMan::Msg::A("Unknown BFESize: %d", GetSrcSize(Op)); break;
+    default: LOGMAN_MSG_A("Unknown BFESize: %d", GetSrcSize(Op)); break;
     }
     SetRFLAG<FEXCore::X86State::RFLAG_OF_LOC>(AndOp1);
   }
@@ -5263,7 +5263,7 @@ void OpDispatchBuilder::GenerateFlags_ADD(FEXCore::X86Tables::DecodedOp Op, Orde
     case 8:
       AndOp1 = _Bfe(1, 63, AndOp1);
     break;
-    default: LogMan::Msg::A("Unknown BFESize: %d", GetSrcSize(Op)); break;
+    default: LOGMAN_MSG_A("Unknown BFESize: %d", GetSrcSize(Op)); break;
     }
     SetRFLAG<FEXCore::X86State::RFLAG_OF_LOC>(AndOp1);
   }
@@ -5820,7 +5820,7 @@ void OpDispatchBuilder::ALUOp(OpcodeArgs) {
   break;
   default:
     IROp = FEXCore::IR::IROps::OP_LAST;
-    LogMan::Msg::A("Unknown ALU Op: 0x%x", Op->OP);
+    LOGMAN_MSG_A("Unknown ALU Op: 0x%x", Op->OP);
   break;
   }
 
@@ -5862,7 +5862,7 @@ void OpDispatchBuilder::ALUOp(OpcodeArgs) {
         Result = _Xor(Dest, Src);
         break;
       }
-      default: LogMan::Msg::A("Unknown Atomic IR Op: %d", IROp); break;
+      default: LOGMAN_MSG_A("Unknown Atomic IR Op: %d", IROp); break;
     }
   }
   else {
@@ -5992,7 +5992,7 @@ template<size_t ElementSize>
 void OpDispatchBuilder::PSRLI(OpcodeArgs) {
   OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
 
-  LogMan::Throw::A(Op->Src[1].TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL, "Src1 needs to be literal here");
+  LOGMAN_THROW_A(Op->Src[1].TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL, "Src1 needs to be literal here");
   uint64_t ShiftConstant = Op->Src[1].TypeLiteral.Literal;
 
   auto Size = GetSrcSize(Op);
@@ -6005,7 +6005,7 @@ template<size_t ElementSize>
 void OpDispatchBuilder::PSLLI(OpcodeArgs) {
   OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
 
-  LogMan::Throw::A(Op->Src[1].TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL, "Src1 needs to be literal here");
+  LOGMAN_THROW_A(Op->Src[1].TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL, "Src1 needs to be literal here");
   uint64_t ShiftConstant = Op->Src[1].TypeLiteral.Literal;
 
   auto Size = GetSrcSize(Op);
@@ -6059,7 +6059,7 @@ void OpDispatchBuilder::PSRAOp(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::PSRLDQ(OpcodeArgs) {
-  LogMan::Throw::A(Op->Src[1].TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL, "Src1 needs to be literal here");
+  LOGMAN_THROW_A(Op->Src[1].TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL, "Src1 needs to be literal here");
   uint64_t Shift = Op->Src[1].TypeLiteral.Literal;
 
   OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
@@ -6071,7 +6071,7 @@ void OpDispatchBuilder::PSRLDQ(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::PSLLDQ(OpcodeArgs) {
-  LogMan::Throw::A(Op->Src[1].TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL, "Src1 needs to be literal here");
+  LOGMAN_THROW_A(Op->Src[1].TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL, "Src1 needs to be literal here");
   uint64_t Shift = Op->Src[1].TypeLiteral.Literal;
 
   OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
@@ -6084,7 +6084,7 @@ void OpDispatchBuilder::PSLLDQ(OpcodeArgs) {
 
 template<size_t ElementSize>
 void OpDispatchBuilder::PSRAIOp(OpcodeArgs) {
-  LogMan::Throw::A(Op->Src[1].TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL, "Src1 needs to be literal here");
+  LOGMAN_THROW_A(Op->Src[1].TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL, "Src1 needs to be literal here");
   uint64_t Shift = Op->Src[1].TypeLiteral.Literal;
 
   OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
@@ -6426,7 +6426,7 @@ void OpDispatchBuilder::VFCMPOp(OpcodeArgs) {
     case 0x07: case 0x0F: case 0x17: case 0x1F: // Ordered
       Result = _VFCMPORD(Size, ElementSize, Src2, Src);
     break;
-    default: LogMan::Msg::A("Unknown Comparison type: %d", CompType);
+    default: LOGMAN_MSG_A("Unknown Comparison type: %d", CompType);
   }
 
   if (Scalar) {
@@ -7514,7 +7514,7 @@ void OpDispatchBuilder::X87FCMOV(OpcodeArgs) {
     Type = COMPARE_ZERO;
   break;
   default:
-    LogMan::Msg::A("Unhandled FCMOV op: 0x%x", Opcode);
+    LOGMAN_MSG_A("Unhandled FCMOV op: 0x%x", Opcode);
   break;
   }
 
@@ -8325,7 +8325,7 @@ void OpDispatchBuilder::AESDecLastOp(OpcodeArgs) {
 
 void OpDispatchBuilder::AESKeyGenAssist(OpcodeArgs) {
   OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-  LogMan::Throw::A(Op->Src[1].TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL, "Src1 needs to be literal here");
+  LOGMAN_THROW_A(Op->Src[1].TypeNone.Type == FEXCore::X86Tables::DecodedOperand::TYPE_LITERAL, "Src1 needs to be literal here");
   uint64_t RCON = Op->Src[1].TypeLiteral.Literal;
 
   auto Res = _VAESKeyGenAssist(Src, RCON);
@@ -9318,7 +9318,7 @@ constexpr uint16_t PF_F2 = 3;
       auto OpNum = std::get<0>(Op);
       auto Dispatcher = std::get<2>(Op);
       for (uint8_t i = 0; i < std::get<1>(Op); ++i) {
-        LogMan::Throw::A(FinalTable[OpNum + i].OpcodeDispatcher == nullptr, "Duplicate Entry");
+        LOGMAN_THROW_A(FinalTable[OpNum + i].OpcodeDispatcher == nullptr, "Duplicate Entry");
         FinalTable[OpNum + i].OpcodeDispatcher = Dispatcher;
         if (Dispatcher)
           ++NumInsts;
@@ -9332,7 +9332,7 @@ constexpr uint16_t PF_F2 = 3;
       OpNum = OpNum & 0x7FF;
       auto Dispatcher = std::get<2>(Op);
       for (uint8_t i = 0; i < std::get<1>(Op); ++i) {
-        LogMan::Throw::A(FinalTable[OpNum + i].OpcodeDispatcher == nullptr, "Duplicate Entry");
+        LOGMAN_THROW_A(FinalTable[OpNum + i].OpcodeDispatcher == nullptr, "Duplicate Entry");
         FinalTable[OpNum + i].OpcodeDispatcher = Dispatcher;
 
         // Flag to indicate if we need to repeat this op in {0x40, 0x80} ranges

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -49,7 +49,7 @@ public:
 
   OrderedNode* GetNewJumpBlock(uint64_t RIP) {
     auto it = JumpTargets.find(RIP);
-    LogMan::Throw::A(it != JumpTargets.end(), "Couldn't find block generated for 0x%lx", RIP);
+    LOGMAN_THROW_A(it != JumpTargets.end(), "Couldn't find block generated for 0x%lx", RIP);
     return it->second.BlockEntry;
   }
 

--- a/External/FEXCore/Source/Interface/Core/X86Tables/X86Tables.h
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/X86Tables.h
@@ -33,7 +33,7 @@ static inline void GenerateTable(X86InstInfo *FinalTable, U8U8InfoStruct const *
     auto OpNum = Op.first;
     X86InstInfo const &Info = Op.Info;
     for (uint32_t i = 0; i < Op.second; ++i) {
-      LogMan::Throw::A(FinalTable[OpNum + i].Type == TYPE_UNKNOWN, "Duplicate Entry %s->%s", FinalTable[OpNum + i].Name, Info.Name);
+      LOGMAN_THROW_A(FinalTable[OpNum + i].Type == TYPE_UNKNOWN, "Duplicate Entry %s->%s", FinalTable[OpNum + i].Name, Info.Name);
       FinalTable[OpNum + i] = Info;
 #ifndef NDEBUG
       ++Total;
@@ -50,7 +50,7 @@ static inline void GenerateTable(X86InstInfo *FinalTable, U16U8InfoStruct const 
     auto OpNum = Op.first;
     X86InstInfo const &Info = Op.Info;
     for (uint32_t i = 0; i < Op.second; ++i) {
-      LogMan::Throw::A(FinalTable[OpNum + i].Type == TYPE_UNKNOWN, "Duplicate Entry %s->%s", FinalTable[OpNum + i].Name, Info.Name);
+      LOGMAN_THROW_A(FinalTable[OpNum + i].Type == TYPE_UNKNOWN, "Duplicate Entry %s->%s", FinalTable[OpNum + i].Name, Info.Name);
       FinalTable[OpNum + i] = Info;
 #ifndef NDEBUG
       ++Total;
@@ -67,7 +67,7 @@ static inline void GenerateTableWithCopy(X86InstInfo *FinalTable, U8U8InfoStruct
     auto OpNum = Op.first;
     X86InstInfo const &Info = Op.Info;
     for (uint32_t i = 0; i < Op.second; ++i) {
-      LogMan::Throw::A(FinalTable[OpNum + i].Type == TYPE_UNKNOWN, "Duplicate Entry %s->%s", FinalTable[OpNum + i].Name, Info.Name);
+      LOGMAN_THROW_A(FinalTable[OpNum + i].Type == TYPE_UNKNOWN, "Duplicate Entry %s->%s", FinalTable[OpNum + i].Name, Info.Name);
       if (Info.Type == TYPE_COPY_OTHER) {
         FinalTable[OpNum + i] = OtherLocal[OpNum + i];
       }
@@ -89,7 +89,7 @@ static inline void GenerateX87Table(X86InstInfo *FinalTable, U16U8InfoStruct con
     auto OpNum = Op.first;
     X86InstInfo const &Info = Op.Info;
     for (uint32_t i = 0; i < Op.second; ++i) {
-      LogMan::Throw::A(FinalTable[OpNum + i].Type == TYPE_UNKNOWN, "Duplicate Entry %s->%s", FinalTable[OpNum + i].Name, Info.Name);
+      LOGMAN_THROW_A(FinalTable[OpNum + i].Type == TYPE_UNKNOWN, "Duplicate Entry %s->%s", FinalTable[OpNum + i].Name, Info.Name);
       if ((OpNum & 0b11'000'000) == 0b11'000'000) {
         // If the mod field is 0b11 then it is a regular op
         FinalTable[OpNum + i] = Info;
@@ -97,7 +97,7 @@ static inline void GenerateX87Table(X86InstInfo *FinalTable, U16U8InfoStruct con
       else {
         // If the mod field is !0b11 then this instruction is duplicated through the whole mod [0b00, 0b10] range
         // and the modrm.rm space because that is used part of the instruction encoding
-        LogMan::Throw::A((OpNum & 0b11'000'000) == 0, "Only support mod field of zero in this path");
+        LOGMAN_THROW_A((OpNum & 0b11'000'000) == 0, "Only support mod field of zero in this path");
         for (uint16_t mod = 0b00'000'000; mod < 0b11'000'000; mod += 0b01'000'000) {
           for (uint16_t rm = 0b000; rm < 0b1'000; ++rm) {
             FinalTable[(OpNum | mod | rm) + i] = Info;

--- a/External/FEXCore/Source/Interface/IR/IREmitter.cpp
+++ b/External/FEXCore/Source/Interface/IR/IREmitter.cpp
@@ -83,7 +83,7 @@ IREmitter::IRPair<IROp_CodeBlock> IREmitter::CreateNewCodeBlockAfter(OrderedNode
   if (insertAfter) {
     LinkCodeBlocks(insertAfter, CodeNode);
   } else {
-    LogMan::Throw::A(CurrentCodeBlock != nullptr, "CurrentCodeBlock must not be null here");
+    LOGMAN_THROW_A(CurrentCodeBlock != nullptr, "CurrentCodeBlock must not be null here");
     
     // Find last block
     auto LastBlock = CurrentCodeBlock;
@@ -102,7 +102,7 @@ IREmitter::IRPair<IROp_CodeBlock> IREmitter::CreateNewCodeBlockAfter(OrderedNode
 
 void IREmitter::SetCurrentCodeBlock(OrderedNode *Node) {
   CurrentCodeBlock = Node;
-  LogMan::Throw::A(Node->Op(Data.Begin())->Op == OP_CODEBLOCK, "Node wasn't codeblock. It was '%s'", std::string(IR::GetName(Node->Op(Data.Begin())->Op)).c_str());
+  LOGMAN_THROW_A(Node->Op(Data.Begin())->Op == OP_CODEBLOCK, "Node wasn't codeblock. It was '%s'", std::string(IR::GetName(Node->Op(Data.Begin())->Op)).c_str());
   SetWriteCursor(Node->Op(Data.Begin())->CW<IROp_CodeBlock>()->Begin.GetNode(ListData.Begin()));
 }
 

--- a/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -260,7 +260,7 @@ bool ConstProp::Run(IREmitter *IREmit) {
       auto ghf = IROp->CW<IR::IROp_GetHostFlag>();
 
       auto fcmp = IREmit->GetOpHeader(ghf->GPR)->CW<IR::IROp_FCmp>();
-      LogMan::Throw::A(fcmp->Header.Op == OP_FCMP || fcmp->Header.Op == OP_F80CMP, "Unexpected OP_GETHOSTFLAG source");
+      LOGMAN_THROW_A(fcmp->Header.Op == OP_FCMP || fcmp->Header.Op == OP_F80CMP, "Unexpected OP_GETHOSTFLAG source");
       if(fcmp->Header.Op == OP_FCMP) {
         fcmp->Flags |= 1 << ghf->Flag;
       }
@@ -463,7 +463,7 @@ bool ConstProp::Run(IREmitter *IREmit) {
 
       if (IREmit->IsValueConstant(IROp->Args[0], &Constant1) &&
           IREmit->IsValueConstant(IROp->Args[1], &Constant2)) {
-        LogMan::Msg::A("Could const prop op: %s", std::string(IR::GetName(IROp->Op)).c_str());
+        LOGMAN_MSG_A("Could const prop op: %s", std::string(IR::GetName(IROp->Op)).c_str());
       }
     break;
     }
@@ -479,7 +479,7 @@ bool ConstProp::Run(IREmitter *IREmit) {
       uint64_t Constant1;
 
       if (IREmit->IsValueConstant(IROp->Args[0], &Constant1)) {
-        LogMan::Msg::A("Could const prop op: %s", std::string(IR::GetName(IROp->Op)).c_str());
+        LOGMAN_MSG_A("Could const prop op: %s", std::string(IR::GetName(IROp->Op)).c_str());
       }
     break;
     }

--- a/External/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
@@ -211,18 +211,18 @@ namespace {
     size_t ClassifiedStructSize{};
     ContextClassificationInfo->Lookup.reserve(sizeof(FEXCore::Core::CPUState));
     for (auto &it : *ContextClassification) {
-      LogMan::Throw::A(it.Class.Offset == ContextClassificationInfo->Lookup.size(), "Offset missmatch %d %d", it.Class.Offset == ContextClassificationInfo->Lookup.size());
+      LOGMAN_THROW_A(it.Class.Offset == ContextClassificationInfo->Lookup.size(), "Offset missmatch %d %d", it.Class.Offset == ContextClassificationInfo->Lookup.size());
       for (int i = 0; i < it.Class.Size; i++) {
         ContextClassificationInfo->Lookup.push_back(&it);
       }
       ClassifiedStructSize += it.Class.Size;
     }
 
-    LogMan::Throw::A(ClassifiedStructSize == sizeof(FEXCore::Core::CPUState),
+    LOGMAN_THROW_A(ClassifiedStructSize == sizeof(FEXCore::Core::CPUState),
       "Classified CPUStruct size doesn't match real CPUState struct size! %ld != %ld",
       ClassifiedStructSize, sizeof(FEXCore::Core::CPUState));
 
-    LogMan::Throw::A(ContextClassificationInfo->Lookup.size() == sizeof(FEXCore::Core::CPUState),
+    LOGMAN_THROW_A(ContextClassificationInfo->Lookup.size() == sizeof(FEXCore::Core::CPUState),
       "Classified CPUStruct size doesn't match real CPUState struct size! %ld != %ld",
       ContextClassificationInfo->Lookup.size(), sizeof(FEXCore::Core::CPUState));
   }
@@ -306,15 +306,15 @@ ContextMemberInfo *RCLSE::FindMemberInfo(ContextInfo *ContextClassificationInfo,
 }
 
 ContextMemberInfo *RCLSE::RecordAccess(ContextMemberInfo *Info, FEXCore::IR::RegisterClassType RegClass, uint32_t Offset, uint8_t Size, LastAccessType AccessType, FEXCore::IR::OrderedNode *Node, FEXCore::IR::OrderedNode *StoreNode) {
-  LogMan::Throw::A((Offset + Size) <= (Info->Class.Offset + Info->Class.Size), "Access to context item went over member size");
-  LogMan::Throw::A(Info->Accessed != ACCESS_INVALID, "Tried to access invalid member");
+  LOGMAN_THROW_A((Offset + Size) <= (Info->Class.Offset + Info->Class.Size), "Access to context item went over member size");
+  LOGMAN_THROW_A(Info->Accessed != ACCESS_INVALID, "Tried to access invalid member");
 
   // If we aren't fully overwriting the member then it is a partial write that we need to track
   if (Size < Info->Class.Size) {
     AccessType = AccessType == ACCESS_WRITE ? ACCESS_PARTIAL_WRITE : ACCESS_PARTIAL_READ;
   }
   if (Size > Info->Class.Size) {
-    LogMan::Msg::A("Can't handle this");
+    LOGMAN_MSG_A("Can't handle this");
   }
 
   Info->Accessed = AccessType;
@@ -500,7 +500,7 @@ bool RCLSE::RedundantStoreLoadElimination(FEXCore::IR::IREmitter *IREmit) {
               else if (LastClass == GPRClass) {
                 LastNode = IREmit->_Bfe(Info->AccessSize, TruncateSize * 8, 0, LastNode);
               } else {
-                LogMan::Msg::A("Unhandled Register class");
+                LOGMAN_MSG_A("Unhandled Register class");
               }
             }
 

--- a/External/FEXCore/Source/Interface/IR/Passes/DeadStoreElimination.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/DeadStoreElimination.cpp
@@ -106,7 +106,7 @@ uint64_t FPRBit(uint32_t Offset, uint32_t Size) {
   else if (Size == 4)
     return  1UL << (bitn);
   else
-    LogMan::Msg::A("Unexpected FPR size %d", Size);
+    LOGMAN_MSG_A("Unexpected FPR size %d", Size);
 
   return 7UL << (bitn); // Return maximum on failure case
 }

--- a/External/FEXCore/Source/Interface/IR/Passes/IRCompaction.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/IRCompaction.cpp
@@ -66,7 +66,7 @@ bool IRCompaction::Run(IREmitter *IREmit) {
 
   auto HeaderNode = CurrentIR.GetHeaderNode();
   auto HeaderOp = CurrentIR.GetHeader();
-  LogMan::Throw::A(HeaderOp->Header.Op == OP_IRHEADER, "First op wasn't IRHeader");
+  LOGMAN_THROW_A(HeaderOp->Header.Op == OP_IRHEADER, "First op wasn't IRHeader");
 
   // This compaction pass is something that we need to ensure correct ordering and distances between IROps
   // Later on we assume that an IROp's SSA value live range is its Node locations
@@ -90,7 +90,7 @@ bool IRCompaction::Run(IREmitter *IREmit) {
   {
     // Generate our codeblocks and link them together
     for (auto [BlockNode, BlockHeader] : CurrentIR.GetBlocks()) {
-      LogMan::Throw::A(BlockHeader->Op == OP_CODEBLOCK, "IR type failed to be a code block");
+      LOGMAN_THROW_A(BlockHeader->Op == OP_CODEBLOCK, "IR type failed to be a code block");
 
       auto LocalBlockIRNode = LocalBuilder._CodeBlock(LocalHeaderOp, LocalHeaderOp); // Use LocalHeaderOp as a dummy arg for now
       OldToNewRemap[CurrentIR.GetID(BlockNode)].NodeID = LocalIR.GetID(LocalBlockIRNode.Node);
@@ -154,7 +154,7 @@ bool IRCompaction::Run(IREmitter *IREmit) {
     // Fixup the arguments of all the IROps
     for (auto &Block : GeneratedCodeBlocks) {
       auto BlockIROp = LocalIR.GetOp<FEXCore::IR::IROp_CodeBlock>(Block.NewNode);
-      LogMan::Throw::A(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
+      LOGMAN_THROW_A(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
 
       for (auto [LocalNode, LocalIROp] : LocalIR.GetCode(Block.NewNode)) {
 
@@ -165,7 +165,7 @@ bool IRCompaction::Run(IREmitter *IREmit) {
         for (uint8_t i = 0; i < NumArgs; ++i) {
           uint32_t OldArg = LocalIROp->Args[i].ID();
           #ifndef NDEBUG
-            LogMan::Throw::A(OldToNewRemap[OldArg].NodeID != ~0U, "Tried remapping unfound node %%ssa%d", OldArg);
+            LOGMAN_THROW_A(OldToNewRemap[OldArg].NodeID != ~0U, "Tried remapping unfound node %%ssa%d", OldArg);
           #endif
           LocalIROp->Args[i].NodeOffset = OldToNewRemap[OldArg].NodeID * sizeof(OrderedNode);
         }
@@ -191,7 +191,7 @@ bool IRCompaction::Run(IREmitter *IREmit) {
 
   // if (NewListSize > OldListSize ||
   //     NewDataSize > OldDataSize) {
-  //   LogMan::Msg::A("Whoa. Compaction made the IR a different size when it shouldn't have. 0x%lx > 0x%lx or 0x%lx > 0x%lx",NewListSize, OldListSize, NewDataSize, OldDataSize);
+  //   LOGMAN_MSG_A("Whoa. Compaction made the IR a different size when it shouldn't have. 0x%lx > 0x%lx or 0x%lx > 0x%lx",NewListSize, OldListSize, NewDataSize, OldDataSize);
   // }
 
   IREmit->CopyData(LocalBuilder);

--- a/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
@@ -55,7 +55,7 @@ bool IRValidation::Run(IREmitter *IREmit) {
   std::vector<uint32_t> Uses(CurrentIR.GetSSACount(), 0);
 
   auto HeaderOp = CurrentIR.GetHeader();
-  LogMan::Throw::A(HeaderOp->Header.Op == OP_IRHEADER, "First op wasn't IRHeader");
+  LOGMAN_THROW_A(HeaderOp->Header.Op == OP_IRHEADER, "First op wasn't IRHeader");
 
   IR::RegisterAllocationData * RAData{};
   if (Manager->HasRAPass()) {
@@ -66,7 +66,7 @@ bool IRValidation::Run(IREmitter *IREmit) {
 
   for (auto [BlockNode, BlockHeader] : CurrentIR.GetBlocks()) {
     auto BlockIROp = BlockHeader->CW<FEXCore::IR::IROp_CodeBlock>();
-    LogMan::Throw::A(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
+    LOGMAN_THROW_A(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
 
     uint32_t BlockID = CurrentIR.GetID(BlockNode);
 
@@ -209,7 +209,7 @@ bool IRValidation::Run(IREmitter *IREmit) {
           break;
         }
         default:
-          // LogMan::Msg::A("Unknown IR Op: %d(%s)", IROp->Op, FEXCore::IR::GetName(IROp->Op).data());
+          // LOGMAN_MSG_A("Unknown IR Op: %d(%s)", IROp->Op, FEXCore::IR::GetName(IROp->Op).data());
         break;
       }
     }

--- a/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -65,7 +65,7 @@ namespace {
         Enumerator(Item);
 
         if (++i == Bucket->Size) {
-          LogMan::Throw::A(Bucket->Next != nullptr, "Interference bug");
+          LOGMAN_THROW_A(Bucket->Next != nullptr, "Interference bug");
           Bucket = Bucket->Next.get();
           i = 0;
         }
@@ -86,7 +86,7 @@ namespace {
           return true;
 
         if (++i == Bucket->Size) {
-          LogMan::Throw::A(Bucket->Next != nullptr, "Bucket in bad state");
+          LOGMAN_THROW_A(Bucket->Next != nullptr, "Bucket in bad state");
           Bucket = Bucket->Next.get();
           i = 0;
         }
@@ -130,7 +130,7 @@ namespace {
         }
         else if (++i == Size) {
           i = 0;
-          LogMan::Throw::A(that->Next != nullptr, "Bucket::Erase but element not contained");
+          LOGMAN_THROW_A(that->Next != nullptr, "Bucket::Erase but element not contained");
           that = that->Next.get();
         }
       }
@@ -445,8 +445,8 @@ namespace FEXCore::IR {
   }
 
   void ConstrainedRAPass::AllocateRegisterSet(uint32_t RegisterCount, uint32_t ClassCount) {
-    LogMan::Throw::A(RegisterCount <= INVALID_REG, "Up to %d regs supported", INVALID_REG);
-    LogMan::Throw::A(ClassCount <= INVALID_CLASS, "Up to %d classes supported", INVALID_CLASS);
+    LOGMAN_THROW_A(RegisterCount <= INVALID_REG, "Up to %d regs supported", INVALID_REG);
+    LOGMAN_THROW_A(ClassCount <= INVALID_CLASS, "Up to %d classes supported", INVALID_CLASS);
 
     Graph = AllocateRegisterGraph(ClassCount);
 
@@ -459,7 +459,7 @@ namespace FEXCore::IR {
   }
 
   void ConstrainedRAPass::AddRegisters(FEXCore::IR::RegisterClassType Class, uint32_t RegisterCount) {
-    LogMan::Throw::A(RegisterCount <= INVALID_REG, "Up to %d regs supported", INVALID_REG);
+    LOGMAN_THROW_A(RegisterCount <= INVALID_REG, "Up to %d regs supported", INVALID_REG);
 
     AllocatePhysicalRegisters(Graph, Class, RegisterCount);
   }
@@ -486,7 +486,7 @@ namespace FEXCore::IR {
 
         auto Op = IROp->C<IROp_CodeBlock>();
 
-        LogMan::Throw::A(Op->Header.Op == OP_CODEBLOCK, "Block not defined by codeblock?");
+        LOGMAN_THROW_A(Op->Header.Op == OP_CODEBLOCK, "Block not defined by codeblock?");
 
         LiveRange->Begin = std::min(LiveRange->Begin, Op->Begin.ID());
         LiveRange->End = std::max(LiveRange->End, Op->Begin.ID());
@@ -514,7 +514,7 @@ namespace FEXCore::IR {
 
         // If the destination hasn't yet been set then set it now
         if (IROp->HasDest) {
-          LogMan::Throw::A(LiveRanges[Node].Begin == ~0U, "Node begin already defined?");
+          LOGMAN_THROW_A(LiveRanges[Node].Begin == ~0U, "Node begin already defined?");
           LiveRanges[Node].Begin = Node;
           // Default to ending right where after it starts
           LiveRanges[Node].End = Node + 1;
@@ -546,7 +546,7 @@ namespace FEXCore::IR {
           if (IR->GetOp<IROp_Header>(IROp->Args[i])->Op == OP_INLINEENTRYPOINTOFFSET) continue;
           if (IR->GetOp<IROp_Header>(IROp->Args[i])->Op == OP_IRHEADER) continue;
           uint32_t ArgNode = IROp->Args[i].ID();
-          LogMan::Throw::A(LiveRanges[ArgNode].Begin != ~0U, "%%ssa%d used by %%ssa%d before defined?", ArgNode, Node);
+          LOGMAN_THROW_A(LiveRanges[ArgNode].Begin != ~0U, "%%ssa%d used by %%ssa%d before defined?", ArgNode, Node);
 
           auto ArgNodeBlockID = Graph->Nodes[ArgNode].Head.BlockID;
           if (ArgNodeBlockID == BlockNodeID) {
@@ -600,7 +600,7 @@ namespace FEXCore::IR {
       } else if (StaticClass == FPRFixedClass) {
         return Size == 16;
       } else {
-        LogMan::Throw::A(false, "Unexpected static class %d", StaticClass);
+        LOGMAN_THROW_A(false, "Unexpected static class %d", StaticClass);
       }
       return false; // Unknown
     };
@@ -612,7 +612,7 @@ namespace FEXCore::IR {
       } else if (StaticClass == FPRFixedClass) {
         return (Size == 16 /*|| Size == 8 || Size == 4*/) && ((Offset & 15) == 0); // We need more meta info to support not-size-of-reg
       } else {
-        LogMan::Throw::A(false, "Unexpected static class %d", StaticClass);
+        LOGMAN_THROW_A(false, "Unexpected static class %d", StaticClass);
       }
       return false; // Unknown
     };
@@ -632,7 +632,7 @@ namespace FEXCore::IR {
           auto reg = (Offset - beginFpr) / 16;
           return PhysicalRegister(FPRFixedClass, reg);
         } else {
-          LogMan::Throw::A(false, "Unexpected Offset %d", Offset);
+          LOGMAN_THROW_A(false, "Unexpected Offset %d", Offset);
           return INVALID_REGCLASS;
         }
     };
@@ -656,7 +656,7 @@ namespace FEXCore::IR {
           auto reg = (Offset - beginFpr) / 16;
           return &StaticMaps[GprSize + reg];
         } else {
-          LogMan::Throw::A(false, "Unexpected offset %d", Offset);
+          LOGMAN_THROW_A(false, "Unexpected offset %d", Offset);
           return (LiveRange**)nullptr;
         }
     };
@@ -668,7 +668,7 @@ namespace FEXCore::IR {
       } else if (PhyReg.Class == FPRFixedClass.Val) {
         return &StaticMaps[GprSize + PhyReg.Reg];
       } else {
-        LogMan::Throw::A(false, "Unexpected Class %d", PhyReg.Class);
+        LOGMAN_THROW_A(false, "Unexpected Class %d", PhyReg.Class);
         return (LiveRange**)nullptr;
       }
     };
@@ -807,7 +807,7 @@ namespace FEXCore::IR {
 
     for (auto [BlockNode, BlockHeader] : IR->GetBlocks()) {
       auto BlockIROp = BlockHeader->CW<FEXCore::IR::IROp_CodeBlock>();
-      LogMan::Throw::A(BlockIROp->Header.Op == IR::OP_CODEBLOCK, "IR type failed to be a code block");
+      LOGMAN_THROW_A(BlockIROp->Header.Op == IR::OP_CODEBLOCK, "IR type failed to be a code block");
 
       BlockInterferences *BlockInterferenceVector = &LocalBlockInterferences.try_emplace(IR->GetID(BlockNode)).first->second;
       BlockInterferenceVector->reserve(BlockIROp->Last.ID() - BlockIROp->Begin.ID());
@@ -910,7 +910,7 @@ namespace FEXCore::IR {
     SpanEnd.resize(NodeCount);
     for (uint32_t i = 0; i < NodeCount; ++i) {
       if (LiveRanges[i].Begin != ~0U) {
-        LogMan::Throw::A(LiveRanges[i].Begin < LiveRanges[i].End , "Span must Begin before Ending");
+        LOGMAN_THROW_A(LiveRanges[i].Begin < LiveRanges[i].End , "Span must Begin before Ending");
 
         auto Class = GetClass(Graph->AllocData->Map[i]);
         SpanStart[LiveRanges[i].Begin].Append(INFO_MAKE(i, Class));
@@ -938,7 +938,7 @@ namespace FEXCore::IR {
       });
     }
 
-    LogMan::Throw::A(Active.Items[0] == 0, "Interference bug");
+    LOGMAN_THROW_A(Active.Items[0] == 0, "Interference bug");
     SpanStart.clear();
     SpanEnd.clear();
   }
@@ -957,7 +957,7 @@ namespace FEXCore::IR {
       RegisterClass *RAClass = &Graph->Set.Classes[RegClass];
 
       if (CurrentNode->Head.PhiPartner) {
-        LogMan::Msg::A("Phi nodes not supported");
+        LOGMAN_MSG_A("Phi nodes not supported");
         #if 0
         // In the case that we have a list of nodes that need the same register allocated we need to do something special
         // We need to gather the data from the forward linked list and make sure they all match the virtual register
@@ -1156,7 +1156,7 @@ namespace FEXCore::IR {
             // This would ensure something will spill earlier if its previous use and next use are farther away
             auto InterferenceNodeNextUse = FindFirstUse(IREmit, InterferenceOrderedNode, NodeOpBeginIter, InterferenceNodeOpEndIter);
             auto InterferenceNodePrevUse = FindLastUseBefore(IREmit, InterferenceOrderedNode, InterferenceNodeOpBeginIter, NodeOpBeginIter);
-            LogMan::Throw::A(InterferenceNodeNextUse != IR::NodeIterator::Invalid(), "Couldn't find next usage of op");
+            LOGMAN_THROW_A(InterferenceNodeNextUse != IR::NodeIterator::Invalid(), "Couldn't find next usage of op");
             // If there is no use of the interference op prior to our op then it only has initial definition
             if (InterferenceNodePrevUse == IR::NodeIterator::Invalid()) InterferenceNodePrevUse = InterferenceNodeOpBeginIter;
 
@@ -1322,7 +1322,7 @@ namespace FEXCore::IR {
         LogMan::Msg::D("\tInt%d: %%ssa%d Remat: %d [%d, %d)", j++, InterferenceNode, InterferenceLiveRange->RematCost, InterferenceLiveRange->Begin, InterferenceLiveRange->End);
       });
     }
-    LogMan::Throw::A(InterferenceIdToSpill != 0, "Couldn't find Node to spill");
+    LOGMAN_THROW_A(InterferenceIdToSpill != 0, "Couldn't find Node to spill");
 
     return InterferenceIdToSpill;
   }
@@ -1357,7 +1357,7 @@ namespace FEXCore::IR {
     auto LastCursor = IREmit->GetWriteCursor();
     auto [CodeNode, IROp] = IR.at(SpillPointId)();
 
-    LogMan::Throw::A(IROp->HasDest, "Can't spill with no dest");
+    LOGMAN_THROW_A(IROp->HasDest, "Can't spill with no dest");
 
     uint32_t Node = IR.GetID(CodeNode);
     RegisterNode *CurrentNode = &Graph->Nodes[Node];
@@ -1381,7 +1381,7 @@ namespace FEXCore::IR {
         // First op post Spill
         auto NextIter = IR.at(CodeNode);
         auto FirstUseLocation = FindFirstUse(IREmit, ConstantNode, NextIter, NodeIterator::Invalid());
-        LogMan::Throw::A(FirstUseLocation != IR::NodeIterator::Invalid(), "At %%ssa%d Spilling Op %%ssa%d but Failure to find op use", Node, InterferenceNode);
+        LOGMAN_THROW_A(FirstUseLocation != IR::NodeIterator::Invalid(), "At %%ssa%d Spilling Op %%ssa%d but Failure to find op use", Node, InterferenceNode);
         if (FirstUseLocation != IR::NodeIterator::Invalid()) {
           --FirstUseLocation;
           auto [FirstUseOrderedNode, _] = FirstUseLocation();
@@ -1399,10 +1399,10 @@ namespace FEXCore::IR {
           FEXCore::IR::RegisterClassType InterferenceRegClass = FEXCore::IR::RegisterClassType{Graph->AllocData->Map[InterferenceNode].Class};
           uint32_t SpillSlot = FindSpillSlot(InterferenceNode, InterferenceRegClass);
           RegisterNode *InterferenceRegisterNode = &Graph->Nodes[InterferenceNode];
-          LogMan::Throw::A(SpillSlot != ~0U, "Interference Node doesn't have a spill slot!");
-          //LogMan::Throw::A(InterferenceRegisterNode->Head.RegAndClass.Reg != INVALID_REG, "Interference node never assigned a register?");
-          LogMan::Throw::A(InterferenceRegClass != ~0U, "Interference node never assigned a register class?");
-          LogMan::Throw::A(InterferenceRegisterNode->Head.PhiPartner == nullptr, "We don't support spilling PHI nodes currently");
+          LOGMAN_THROW_A(SpillSlot != ~0U, "Interference Node doesn't have a spill slot!");
+          //LOGMAN_THROW_A(InterferenceRegisterNode->Head.RegAndClass.Reg != INVALID_REG, "Interference node never assigned a register?");
+          LOGMAN_THROW_A(InterferenceRegClass != ~0U, "Interference node never assigned a register class?");
+          LOGMAN_THROW_A(InterferenceRegisterNode->Head.PhiPartner == nullptr, "We don't support spilling PHI nodes currently");
 
           // This is the op that we need to dump
           auto [InterferenceOrderedNode, InterferenceIROp] = IR.at(InterferenceNode)();
@@ -1435,7 +1435,7 @@ namespace FEXCore::IR {
             ++FirstIter;
             auto FirstUseLocation = FindFirstUse(IREmit, InterferenceOrderedNode, FirstIter, NodeIterator::Invalid());
 
-            LogMan::Throw::A(FirstUseLocation != NodeIterator::Invalid(), "At %%ssa%d Spilling Op %%ssa%d but Failure to find op use", Node, InterferenceNode);
+            LOGMAN_THROW_A(FirstUseLocation != NodeIterator::Invalid(), "At %%ssa%d Spilling Op %%ssa%d but Failure to find op use", Node, InterferenceNode);
             if (FirstUseLocation != IR::NodeIterator::Invalid()) {
               // We want to fill just before the first use
               --FirstUseLocation;

--- a/External/FEXCore/Source/Interface/IR/Passes/StaticRegisterAllocationPass.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/StaticRegisterAllocationPass.cpp
@@ -22,7 +22,7 @@ bool IsStaticAllocGpr(uint32_t Offset, RegisterClassType Class) {
 
   if (Offset >= begin && Offset < end) {
     auto reg = (Offset - begin) / 8;
-    LogMan::Throw::A(Class == IR::GPRClass, "unexpected Class %d", Class);
+    LOGMAN_THROW_A(Class == IR::GPRClass, "unexpected Class %d", Class);
 
     rv = reg < 16; // 0..15 -> 16 in total
   }
@@ -37,7 +37,7 @@ bool IsStaticAllocFpr(uint32_t Offset, RegisterClassType Class, bool AllowGpr) {
 
   if (Offset >= begin && Offset < end) {
     auto reg = (Offset - begin)/16;
-    LogMan::Throw::A(Class == IR::FPRClass || (AllowGpr && Class == IR::GPRClass), "unexpected Class %d, AllowGpr %d", Class, AllowGpr);
+    LOGMAN_THROW_A(Class == IR::FPRClass || (AllowGpr && Class == IR::GPRClass), "unexpected Class %d, AllowGpr %d", Class, AllowGpr);
 
     rv = reg < 16; // 0..15 -> 16 in total
   }

--- a/External/FEXCore/Source/Utils/ELFContainer.cpp
+++ b/External/FEXCore/Source/Utils/ELFContainer.cpp
@@ -134,7 +134,7 @@ ELFContainer::ELFContainer(std::string const &Filename, std::string const &RootF
   //PrintInitArray();
   //PrintDynamicTable();
 
-  //LogMan::Throw::A(InterpreterHeader == nullptr, "Can only handle static programs");
+  //LOGMAN_THROW_A(InterpreterHeader == nullptr, "Can only handle static programs");
 }
 
 ELFContainer::~ELFContainer() {
@@ -196,8 +196,8 @@ bool ELFContainer::LoadELF_32() {
 
   memcpy(&Header, reinterpret_cast<Elf32_Ehdr *>(&RawFile.at(0)),
          sizeof(Elf32_Ehdr));
-  LogMan::Throw::A(Header._32.e_phentsize == sizeof(Elf32_Phdr), "PH Entry size wasn't correct size");
-  LogMan::Throw::A(Header._32.e_shentsize == sizeof(Elf32_Shdr), "PH Entry size wasn't correct size");
+  LOGMAN_THROW_A(Header._32.e_phentsize == sizeof(Elf32_Phdr), "PH Entry size wasn't correct size");
+  LOGMAN_THROW_A(Header._32.e_shentsize == sizeof(Elf32_Shdr), "PH Entry size wasn't correct size");
 
   if (Header._32.e_machine != EM_386) {
     LogMan::Msg::D("32bit ELF wasn't x86 based");
@@ -237,8 +237,8 @@ bool ELFContainer::LoadELF_64() {
 
   memcpy(&Header, reinterpret_cast<Elf64_Ehdr *>(&RawFile.at(0)),
          sizeof(Elf64_Ehdr));
-  LogMan::Throw::A(Header._64.e_phentsize == 56, "PH Entry size wasn't 56");
-  LogMan::Throw::A(Header._64.e_shentsize == 64, "PH Entry size wasn't 64");
+  LOGMAN_THROW_A(Header._64.e_phentsize == 56, "PH Entry size wasn't 56");
+  LOGMAN_THROW_A(Header._64.e_shentsize == 64, "PH Entry size wasn't 64");
 
   if (Header._64.e_machine != EM_X86_64) {
     LogMan::Msg::D("64bit ELF wasn't x86-64 based");
@@ -408,9 +408,9 @@ void ELFContainer::CalculateSymbols() {
     uint64_t NumSymTabSymbols = 0;
     uint64_t NumDynSymSymbols = 0;
     if (SymTabHeader) {
-      LogMan::Throw::A(SymTabHeader->sh_link < SectionHeaders.size(),
+      LOGMAN_THROW_A(SymTabHeader->sh_link < SectionHeaders.size(),
                        "Symbol table string table section is wrong");
-      LogMan::Throw::A(SymTabHeader->sh_entsize == sizeof(Elf32_Sym),
+      LOGMAN_THROW_A(SymTabHeader->sh_entsize == sizeof(Elf32_Sym),
                        "Entry size doesn't match symbol entry");
 
       StringTableHeader = SectionHeaders.at(SymTabHeader->sh_link)._32;
@@ -419,9 +419,9 @@ void ELFContainer::CalculateSymbols() {
     }
 
     if (DynSymTabHeader) {
-      LogMan::Throw::A(DynSymTabHeader->sh_link < SectionHeaders.size(),
+      LOGMAN_THROW_A(DynSymTabHeader->sh_link < SectionHeaders.size(),
                        "Symbol table string table section is wrong");
-      LogMan::Throw::A(DynSymTabHeader->sh_entsize == sizeof(Elf32_Sym),
+      LOGMAN_THROW_A(DynSymTabHeader->sh_entsize == sizeof(Elf32_Sym),
                        "Entry size doesn't match symbol entry");
 
       DynStringTableHeader = SectionHeaders.at(DynSymTabHeader->sh_link)._32;
@@ -511,9 +511,9 @@ void ELFContainer::CalculateSymbols() {
     uint64_t NumSymTabSymbols = 0;
     uint64_t NumDynSymSymbols = 0;
     if (SymTabHeader) {
-      LogMan::Throw::A(SymTabHeader->sh_link < SectionHeaders.size(),
+      LOGMAN_THROW_A(SymTabHeader->sh_link < SectionHeaders.size(),
                        "Symbol table string table section is wrong");
-      LogMan::Throw::A(SymTabHeader->sh_entsize == sizeof(Elf64_Sym),
+      LOGMAN_THROW_A(SymTabHeader->sh_entsize == sizeof(Elf64_Sym),
                        "Entry size doesn't match symbol entry");
 
       StringTableHeader = SectionHeaders.at(SymTabHeader->sh_link)._64;
@@ -522,9 +522,9 @@ void ELFContainer::CalculateSymbols() {
     }
 
     if (DynSymTabHeader) {
-      LogMan::Throw::A(DynSymTabHeader->sh_link < SectionHeaders.size(),
+      LOGMAN_THROW_A(DynSymTabHeader->sh_link < SectionHeaders.size(),
                        "Symbol table string table section is wrong");
-      LogMan::Throw::A(DynSymTabHeader->sh_entsize == sizeof(Elf64_Sym),
+      LOGMAN_THROW_A(DynSymTabHeader->sh_entsize == sizeof(Elf64_Sym),
                        "Entry size doesn't match symbol entry");
 
       DynStringTableHeader = SectionHeaders.at(DynSymTabHeader->sh_link)._64;
@@ -665,7 +665,7 @@ void ELFContainer::PrintHeader() const {
 
 void ELFContainer::PrintSectionHeaders() const {
   if (Mode == MODE_32BIT) {
-    LogMan::Throw::A(Header._32.e_shstrndx < SectionHeaders.size(),
+    LOGMAN_THROW_A(Header._32.e_shstrndx < SectionHeaders.size(),
                      "String index section is wrong index!");
     Elf32_Shdr const *StrHeader = SectionHeaders.at(Header._32.e_shstrndx)._32;
     char const *SHStrings = &RawFile.at(StrHeader->sh_offset);
@@ -685,7 +685,7 @@ void ELFContainer::PrintSectionHeaders() const {
     }
   }
   else {
-    LogMan::Throw::A(Header._64.e_shstrndx < SectionHeaders.size(),
+    LOGMAN_THROW_A(Header._64.e_shstrndx < SectionHeaders.size(),
                      "String index section is wrong index!");
     Elf64_Shdr const *StrHeader = SectionHeaders.at(Header._64.e_shstrndx)._64;
     char const *SHStrings = &RawFile.at(StrHeader->sh_offset);
@@ -708,7 +708,7 @@ void ELFContainer::PrintSectionHeaders() const {
 
 void ELFContainer::PrintProgramHeaders() const {
   if (Mode == MODE_32BIT) {
-    LogMan::Throw::A(Header._32.e_shstrndx < SectionHeaders.size(),
+    LOGMAN_THROW_A(Header._32.e_shstrndx < SectionHeaders.size(),
                      "String index section is wrong index!");
     for (uint32_t i = 0; i < ProgramHeaders.size(); ++i) {
       Elf32_Phdr const *hdr = ProgramHeaders.at(i)._32;
@@ -723,7 +723,7 @@ void ELFContainer::PrintProgramHeaders() const {
     }
   }
   else {
-    LogMan::Throw::A(Header._64.e_shstrndx < SectionHeaders.size(),
+    LOGMAN_THROW_A(Header._64.e_shstrndx < SectionHeaders.size(),
                      "String index section is wrong index!");
     for (uint32_t i = 0; i < ProgramHeaders.size(); ++i) {
       Elf64_Phdr const *hdr = ProgramHeaders.at(i)._64;
@@ -757,9 +757,9 @@ void ELFContainer::PrintSymbolTable() const {
       return;
     }
 
-    LogMan::Throw::A(SymTabHeader->sh_link < SectionHeaders.size(),
+    LOGMAN_THROW_A(SymTabHeader->sh_link < SectionHeaders.size(),
                      "Symbol table string table section is wrong");
-    LogMan::Throw::A(SymTabHeader->sh_entsize == sizeof(Elf32_Sym),
+    LOGMAN_THROW_A(SymTabHeader->sh_entsize == sizeof(Elf32_Sym),
                      "Entry size doesn't match symbol entry");
 
     StringTableHeader = SectionHeaders.at(SymTabHeader->sh_link)._32;
@@ -795,9 +795,9 @@ void ELFContainer::PrintSymbolTable() const {
       return;
     }
 
-    LogMan::Throw::A(SymTabHeader->sh_link < SectionHeaders.size(),
+    LOGMAN_THROW_A(SymTabHeader->sh_link < SectionHeaders.size(),
                      "Symbol table string table section is wrong");
-    LogMan::Throw::A(SymTabHeader->sh_entsize == sizeof(Elf64_Sym),
+    LOGMAN_THROW_A(SymTabHeader->sh_entsize == sizeof(Elf64_Sym),
                      "Entry size doesn't match symbol entry");
 
     StringTableHeader = SectionHeaders.at(SymTabHeader->sh_link)._64;
@@ -842,12 +842,12 @@ void ELFContainer::PrintRelocationTable() const {
         LogMan::Msg::D("Relocation Section: '%s'", &SHStrings[RelaHeader->sh_name]);
 
         if (RelaHeader->sh_info != 0) {
-          LogMan::Throw::A(RelaHeader->sh_info < SectionHeaders.size(), "Rela header pointers to invalid GOT header");
+          LOGMAN_THROW_A(RelaHeader->sh_info < SectionHeaders.size(), "Rela header pointers to invalid GOT header");
           GOTHeader = SectionHeaders.at(RelaHeader->sh_info)._64;
         }
 
         if (RelaHeader->sh_link != 0) {
-          LogMan::Throw::A(RelaHeader->sh_link < SectionHeaders.size(), "Rela header pointers to invalid dyndym header");
+          LOGMAN_THROW_A(RelaHeader->sh_link < SectionHeaders.size(), "Rela header pointers to invalid dyndym header");
           DynSymHeader = SectionHeaders.at(RelaHeader->sh_link)._64;
 
           StringTableHeader = SectionHeaders.at(DynSymHeader->sh_link)._64;
@@ -865,7 +865,7 @@ void ELFContainer::PrintRelocationTable() const {
           LogMan::Msg::D("\toffset: 0x%lx", Entry->r_offset);
           LogMan::Msg::D("\tSym:    0x%lx", Sym);
           if (DynSymHeader && Sym != 0) {
-            LogMan::Throw::A(DynSymHeader->sh_entsize == sizeof(Elf64_Sym), "Oops, entry size doesn't match");
+            LOGMAN_THROW_A(DynSymHeader->sh_entsize == sizeof(Elf64_Sym), "Oops, entry size doesn't match");
 
             uint64_t offset = DynSymHeader->sh_offset + Sym * DynSymHeader->sh_entsize;
             Elf64_Sym const *Symbol =
@@ -928,12 +928,12 @@ void ELFContainer::FixupRelocations(void *ELFBase, uint64_t GuestELFBase, Symbol
         RelaHeader = hdr;
 
         if (RelaHeader->sh_info != 0) {
-          LogMan::Throw::A(RelaHeader->sh_info < SectionHeaders.size(), "Rela header pointers to invalid GOT header");
+          LOGMAN_THROW_A(RelaHeader->sh_info < SectionHeaders.size(), "Rela header pointers to invalid GOT header");
           GOTHeader = SectionHeaders.at(RelaHeader->sh_info)._64;
         }
 
         if (RelaHeader->sh_link != 0) {
-          LogMan::Throw::A(RelaHeader->sh_link < SectionHeaders.size(), "Rela header pointers to invalid dyndym header");
+          LOGMAN_THROW_A(RelaHeader->sh_link < SectionHeaders.size(), "Rela header pointers to invalid dyndym header");
           DynSymHeader = SectionHeaders.at(RelaHeader->sh_link)._64;
 
           StringTableHeader = SectionHeaders.at(DynSymHeader->sh_link)._64;
@@ -950,7 +950,7 @@ void ELFContainer::FixupRelocations(void *ELFBase, uint64_t GuestELFBase, Symbol
           Elf64_Sym const *EntrySymbol {nullptr};
           char const *EntrySymbolName {nullptr};
           if (DynSymHeader && Sym != 0) {
-            LogMan::Throw::A(DynSymHeader->sh_entsize == sizeof(Elf64_Sym), "Oops, entry size doesn't match");
+            LOGMAN_THROW_A(DynSymHeader->sh_entsize == sizeof(Elf64_Sym), "Oops, entry size doesn't match");
 
             uint64_t offset = DynSymHeader->sh_offset + Sym * DynSymHeader->sh_entsize;
             EntrySymbol =

--- a/External/FEXCore/Source/Utils/ELFSymbolDatabase.cpp
+++ b/External/FEXCore/Source/Utils/ELFSymbolDatabase.cpp
@@ -83,7 +83,7 @@ ELFSymbolDatabase::ELFSymbolDatabase(::ELFLoader::ELFContainer *file)
       if (NameToELF.find(Lib) == NameToELF.end()) {
         std::string LibraryPath;
         bool Found = FindLibraryFile(&LibraryPath, Lib.c_str());
-        LogMan::Throw::A(Found, "Couldn't find library '%s'", Lib.c_str());
+        LOGMAN_THROW_A(Found, "Couldn't find library '%s'", Lib.c_str());
         auto Info = DynamicELFInfo.emplace_back(new ELFInfo{});
         Info->Name = Lib;
         Info->Container = new ::ELFLoader::ELFContainer(LibraryPath, {}, true);
@@ -165,7 +165,7 @@ void ELFSymbolDatabase::FillMemoryLayouts(uint64_t DefinedBase) {
     uint64_t CurrentELFAlignedSize = AlignUp(std::get<2>(LocalInfo.CustomLayout), 4096);
     if (CurrentELFBase < 0x10000) {
       // We can't allocate memory in the first 16KB,  Hopefully no elfs require this.
-      LogMan::Msg::A("Elf requires memory mapped in the first 16kb");
+      LOGMAN_MSG_A("Elf requires memory mapped in the first 16kb");
     }
 
     std::get<2>(LocalInfo.CustomLayout) = CurrentELFAlignedSize;

--- a/External/FEXCore/include/FEXCore/HLE/SyscallVisitor.h
+++ b/External/FEXCore/include/FEXCore/HLE/SyscallVisitor.h
@@ -3,7 +3,7 @@
 #include <stdint.h>
 
 namespace FEXCore::HLE {
-#define INVALID_OP { LogMan::Msg::A("Tried to syscall with unknown number of registers");  return 0; }
+#define INVALID_OP { LOGMAN_MSG_A("Tried to syscall with unknown number of registers");  return 0; }
   class SyscallVisitor {
   public:
     SyscallVisitor(uint32_t Mask) : SyscallVisitor(Mask, false) {}

--- a/External/FEXCore/include/FEXCore/IR/IREmitter.h
+++ b/External/FEXCore/include/FEXCore/IR/IREmitter.h
@@ -378,7 +378,7 @@ friend class FEXCore::IR::PassManager;
   }
 
   void SetJumpTarget(IR::IROp_Jump *Op, OrderedNode *Target) {
-    LogMan::Throw::A(Target->Op(Data.Begin())->Op == OP_CODEBLOCK,
+    LOGMAN_THROW_A(Target->Op(Data.Begin())->Op == OP_CODEBLOCK,
         "Tried setting Jump target to %%ssa%d %s",
         Target->Wrapped(ListData.Begin()).ID(),
         std::string(IR::GetName(Target->Op(Data.Begin())->Op)).c_str());
@@ -386,7 +386,7 @@ friend class FEXCore::IR::PassManager;
     Op->Header.Args[0].NodeOffset = Target->Wrapped(ListData.Begin()).NodeOffset;
   }
   void SetTrueJumpTarget(IR::IROp_CondJump *Op, OrderedNode *Target) {
-    LogMan::Throw::A(Target->Op(Data.Begin())->Op == OP_CODEBLOCK,
+    LOGMAN_THROW_A(Target->Op(Data.Begin())->Op == OP_CODEBLOCK,
         "Tried setting CondJump target to %%ssa%d %s",
         Target->Wrapped(ListData.Begin()).ID(),
         std::string(IR::GetName(Target->Op(Data.Begin())->Op)).c_str());
@@ -394,7 +394,7 @@ friend class FEXCore::IR::PassManager;
     Op->TrueBlock.NodeOffset = Target->Wrapped(ListData.Begin()).NodeOffset;
   }
   void SetFalseJumpTarget(IR::IROp_CondJump *Op, OrderedNode *Target) {
-    LogMan::Throw::A(Target->Op(Data.Begin())->Op == OP_CODEBLOCK,
+    LOGMAN_THROW_A(Target->Op(Data.Begin())->Op == OP_CODEBLOCK,
         "Tried setting CondJump target to %%ssa%d %s",
         Target->Wrapped(ListData.Begin()).ID(),
         std::string(IR::GetName(Target->Op(Data.Begin())->Op)).c_str());
@@ -403,7 +403,7 @@ friend class FEXCore::IR::PassManager;
   }
 
   void SetJumpTarget(IRPair<IROp_Jump> Op, OrderedNode *Target) {
-    LogMan::Throw::A(Target->Op(Data.Begin())->Op == OP_CODEBLOCK,
+    LOGMAN_THROW_A(Target->Op(Data.Begin())->Op == OP_CODEBLOCK,
         "Tried setting Jump target to %%ssa%d %s",
         Target->Wrapped(ListData.Begin()).ID(),
         std::string(IR::GetName(Target->Op(Data.Begin())->Op)).c_str());
@@ -411,14 +411,14 @@ friend class FEXCore::IR::PassManager;
     Op.first->Header.Args[0].NodeOffset = Target->Wrapped(ListData.Begin()).NodeOffset;
   }
   void SetTrueJumpTarget(IRPair<IROp_CondJump> Op, OrderedNode *Target) {
-    LogMan::Throw::A(Target->Op(Data.Begin())->Op == OP_CODEBLOCK,
+    LOGMAN_THROW_A(Target->Op(Data.Begin())->Op == OP_CODEBLOCK,
         "Tried setting CondJump target to %%ssa%d %s",
         Target->Wrapped(ListData.Begin()).ID(),
         std::string(IR::GetName(Target->Op(Data.Begin())->Op)).c_str());
     Op.first->TrueBlock.NodeOffset = Target->Wrapped(ListData.Begin()).NodeOffset;
   }
   void SetFalseJumpTarget(IRPair<IROp_CondJump> Op, OrderedNode *Target) {
-    LogMan::Throw::A(Target->Op(Data.Begin())->Op == OP_CODEBLOCK,
+    LOGMAN_THROW_A(Target->Op(Data.Begin())->Op == OP_CODEBLOCK,
         "Tried setting CondJump target to %%ssa%d %s",
         Target->Wrapped(ListData.Begin()).ID(),
         std::string(IR::GetName(Target->Op(Data.Begin())->Op)).c_str());
@@ -487,7 +487,7 @@ friend class FEXCore::IR::PassManager;
 
     ReplaceUsesWithAfter(Node, NewNode, Start);
 
-    LogMan::Throw::A(Node->NumUses == 0, "Node still used");
+    LOGMAN_THROW_A(Node->NumUses == 0, "Node still used");
 
     // Since we have deleted ALL uses, we can safely delete the node.
     Remove(Node);
@@ -501,8 +501,8 @@ friend class FEXCore::IR::PassManager;
   OrderedNode *GetPackedRFLAG(bool Lower8);
 
   void CopyData(IREmitter const &rhs) {
-    LogMan::Throw::A(rhs.Data.BackingSize() <= Data.BackingSize(), "Trying to take ownership of data that is too large");
-    LogMan::Throw::A(rhs.ListData.BackingSize() <= ListData.BackingSize(), "Trying to take ownership of data that is too large");
+    LOGMAN_THROW_A(rhs.Data.BackingSize() <= Data.BackingSize(), "Trying to take ownership of data that is too large");
+    LOGMAN_THROW_A(rhs.ListData.BackingSize() <= ListData.BackingSize(), "Trying to take ownership of data that is too large");
     Data.CopyData(rhs.Data);
     ListData.CopyData(rhs.ListData);
     InvalidNode = rhs.InvalidNode->Wrapped(rhs.ListData.Begin()).GetNode(ListData.Begin());
@@ -565,7 +565,7 @@ friend class FEXCore::IR::PassManager;
   /**  @} */
   void LinkCodeBlocks(OrderedNode *CodeNode, OrderedNode *Next) {
     FEXCore::IR::IROp_CodeBlock *CurrentIROp = CodeNode->Op(Data.Begin())->CW<FEXCore::IR::IROp_CodeBlock>();
-    LogMan::Throw::A(CurrentIROp->Header.Op == IROps::OP_CODEBLOCK, "Invalid");
+    LOGMAN_THROW_A(CurrentIROp->Header.Op == IROps::OP_CODEBLOCK, "Invalid");
 
     CodeNode->append(ListData.Begin(), Next);
   }

--- a/External/FEXCore/include/FEXCore/IR/IntrusiveIRList.h
+++ b/External/FEXCore/include/FEXCore/IR/IntrusiveIRList.h
@@ -156,7 +156,7 @@ public:
 
     // If we are casting to something narrower than just the header, check the opcode.
     if constexpr (!std::is_same<T, IROp_Header>::value) {
-      LogMan::Throw::A(Op->OPCODE == Op->Header.Op, "Expected Node to be '%s'. Found '%s' instead", GetName(Op->OPCODE), GetName(Op->Header.Op));
+      LOGMAN_THROW_A(Op->OPCODE == Op->Header.Op, "Expected Node to be '%s'. Found '%s' instead", GetName(Op->OPCODE), GetName(Op->Header.Op));
     }
 
     return Op;

--- a/External/FEXCore/include/FEXCore/Utils/LogManager.h
+++ b/External/FEXCore/include/FEXCore/Utils/LogManager.h
@@ -32,8 +32,10 @@ static inline void A(bool Value, const char *fmt, ...) {
     va_end(args);
   }
 }
+#define LOGMAN_THROW_A(pred, ...) do { LogMan::Throw::A(pred, __VA_ARGS__); } while (0)
 #else
 static inline void A(bool, const char*, ...) {}
+#define LOGMAN_THROW_A(pred, ...) do {} while (0)
 #endif
 
 } // namespace Throw
@@ -55,8 +57,10 @@ static inline void A(const char *fmt, ...) {
   }
   __builtin_trap();
 }
+#define LOGMAN_MSG_A(...) do { LogMan::Msg::A(__VA_ARGS__); } while (0)
 #else
 static inline void A(const char*, ...) {}
+#define LOGMAN_MSG_A(...) do {} while(0)
 #endif
 
 static inline void E(const char *fmt, ...) {

--- a/Source/CommonCore/HostFactory.cpp
+++ b/Source/CommonCore/HostFactory.cpp
@@ -179,7 +179,7 @@ namespace HostFactory {
   }
 #else
   FEXCore::CPU::CPUBackend *CPUCreationFactory(FEXCore::Context::Context* CTX, FEXCore::Core::InternalThreadState *Thread) {
-    LogMan::Msg::A("HostCPU factory doesn't exist for this host");
+    LOGMAN_MSG_A("HostCPU factory doesn't exist for this host");
     return nullptr;
   }
 #endif

--- a/Source/Tests/ELFCodeLoader.h
+++ b/Source/Tests/ELFCodeLoader.h
@@ -199,7 +199,7 @@ public:
     }
     else {
       StackPointer = reinterpret_cast<uintptr_t>(FEXCore::Allocator::mmap(reinterpret_cast<void*>(STACK_OFFSET), StackSize(), PROT_READ | PROT_WRITE, MAP_FIXED_NOREPLACE | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
-      LogMan::Throw::A(StackPointer != ~0ULL, "mmap failed");
+      LOGMAN_THROW_A(StackPointer != ~0ULL, "mmap failed");
     }
 
     StackPointer += StackSize();
@@ -288,7 +288,7 @@ public:
   bool MapMemory(std::function<void *(void *addr, size_t length, int prot, int flags, int fd, off_t offset)> Mapper, std::function<int(void *addr, size_t length)> Unmapper) override {
     auto DoMMap = [Mapper](uint64_t Address, size_t Size, bool FixedNoReplace) -> void* {
       void *Result = Mapper(reinterpret_cast<void*>(Address), Size, PROT_READ | PROT_WRITE, (FixedNoReplace ? MAP_FIXED_NOREPLACE : MAP_FIXED) | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-      LogMan::Throw::A(Result != (void*)~0ULL, "Couldn't mmap");
+      LOGMAN_THROW_A(Result != (void*)~0ULL, "Couldn't mmap");
       return Result;
     };
 

--- a/Source/Tests/HarnessHelpers.h
+++ b/Source/Tests/HarnessHelpers.h
@@ -132,7 +132,7 @@ namespace FEX::HarnessHelper {
   inline void ReadFile(std::string const &Filename, std::vector<char> *Data) {
     std::fstream TestFile;
     TestFile.open(Filename, std::fstream::in | std::fstream::binary);
-    LogMan::Throw::A(TestFile.is_open(), "Failed to open file");
+    LOGMAN_THROW_A(TestFile.is_open(), "Failed to open file");
 
     TestFile.seekg(0, std::fstream::end);
     size_t FileSize = TestFile.tellg();
@@ -356,7 +356,7 @@ namespace FEX::HarnessHelper {
       }
       else {
         uint64_t Result = reinterpret_cast<uint64_t>(FEXCore::Allocator::mmap(reinterpret_cast<void*>(STACK_OFFSET), STACK_SIZE, PROT_READ | PROT_WRITE, MAP_FIXED_NOREPLACE | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
-        LogMan::Throw::A(Result != ~0ULL, "mmap failed");
+        LOGMAN_THROW_A(Result != ~0ULL, "mmap failed");
         return Result + STACK_SIZE;
       }
     }
@@ -369,7 +369,7 @@ namespace FEX::HarnessHelper {
       bool LimitedSize = true;
       auto DoMMap = [](uint64_t Address, size_t Size) -> void* {
         void *Result = FEXCore::Allocator::mmap(reinterpret_cast<void*>(Address), Size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-        LogMan::Throw::A(Result == reinterpret_cast<void*>(Address), "mmap failed");
+        LOGMAN_THROW_A(Result == reinterpret_cast<void*>(Address), "mmap failed");
         return Result;
       };
 

--- a/Source/Tests/IRLoader.cpp
+++ b/Source/Tests/IRLoader.cpp
@@ -122,7 +122,7 @@ int main(int argc, char **argv, char **const envp)
   auto Args = FEX::ArgLoader::Get();
   auto ParsedArgs = FEX::ArgLoader::GetParsedArgs();
 
-  LogMan::Throw::A(Args.size() > 1, "Not enough arguments");
+  LOGMAN_THROW_A(Args.size() > 1, "Not enough arguments");
 
   FEXCore::Context::InitializeStaticTables();
   auto CTX = FEXCore::Context::CreateNewContext();

--- a/Source/Tests/LinuxSyscalls/SignalDelegator.cpp
+++ b/Source/Tests/LinuxSyscalls/SignalDelegator.cpp
@@ -281,7 +281,7 @@ namespace FEX::HLE {
 
   SignalDelegator::SignalDelegator() {
     // Register this delegate
-    LogMan::Throw::A(!GlobalDelegator, "Can't register global delegator multiple times!");
+    LOGMAN_THROW_A(!GlobalDelegator, "Can't register global delegator multiple times!");
     GlobalDelegator = this;
     // Signal zero isn't real
     HostHandlers[0].Installed = true;
@@ -346,7 +346,7 @@ namespace FEX::HLE {
     altstack.ss_sp = ThreadData.AltStackPtr;
     altstack.ss_size = SIGSTKSZ;
     altstack.ss_flags = 0;
-    LogMan::Throw::A(!!altstack.ss_sp, "Couldn't allocate stack pointer");
+    LOGMAN_THROW_A(!!altstack.ss_sp, "Couldn't allocate stack pointer");
 
     // Register the alt stack
     int Result = sigaltstack(&altstack, nullptr);

--- a/Source/Tests/LinuxSyscalls/Syscalls.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls.cpp
@@ -280,7 +280,7 @@ uint64_t SyscallHandler::HandleSyscall(FEXCore::Core::CpuStateFrame *Frame, FEXC
   // for missing syscalls
   case 255: return std::invoke(Def.Ptr1, Frame, Args->Argument[0]);
   default:
-    LogMan::Msg::A("Unhandled syscall: %d", Args->Argument[0]);
+    LOGMAN_MSG_A("Unhandled syscall: %d", Args->Argument[0]);
     return -1;
   break;
   }

--- a/Source/Tests/LinuxSyscalls/x32/FD.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/FD.cpp
@@ -203,7 +203,7 @@ namespace FEX::HLE::x32 {
     });
 
     REGISTER_SYSCALL_IMPL_X32(fstatfs64, [](FEXCore::Core::CpuStateFrame *Frame, int fd, size_t sz, struct statfs64_32 *buf) -> uint64_t {
-      LogMan::Throw::A(sz == sizeof(struct statfs64_32), "This needs to match");
+      LOGMAN_THROW_A(sz == sizeof(struct statfs64_32), "This needs to match");
 
       struct statfs64 host_stat;
       uint64_t Result = ::fstatfs64(fd, &host_stat);
@@ -214,7 +214,7 @@ namespace FEX::HLE::x32 {
     });
 
     REGISTER_SYSCALL_IMPL_X32(statfs64, [](FEXCore::Core::CpuStateFrame *Frame, const char *path, size_t sz, struct statfs64_32 *buf) -> uint64_t {
-      LogMan::Throw::A(sz == sizeof(struct statfs64_32), "This needs to match");
+      LOGMAN_THROW_A(sz == sizeof(struct statfs64_32), "This needs to match");
 
       struct statfs host_stat;
       uint64_t Result = FEX::HLE::_SyscallHandler->FM.Statfs(path, &host_stat);
@@ -279,7 +279,7 @@ namespace FEX::HLE::x32 {
         case F_SETFL:
           break;
 
-        default: LogMan::Msg::A("Unhandled fcntl64: 0x%x", cmd); break;
+        default: LOGMAN_MSG_A("Unhandled fcntl64: 0x%x", cmd); break;
       }
 
       uint64_t Result = ::fcntl(fd, cmd, lock_arg);

--- a/Source/Tests/LinuxSyscalls/x32/Semaphore.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Semaphore.cpp
@@ -545,7 +545,7 @@ namespace FEX::HLE::x32 {
         int32_t cmd = third & 0xFF;
         compat_ptr<semun_32> semun(ptr);
         bool IPC64 = third & 0x100;
-#define UNHANDLED(x) case x: LogMan::Msg::A("Unhandled semctl cmd: " #x); break
+#define UNHANDLED(x) case x: LOGMAN_MSG_A("Unhandled semctl cmd: " #x); break
         switch (cmd) {
           case IPC_SET: {
             struct semid_ds buf{};
@@ -608,7 +608,7 @@ namespace FEX::HLE::x32 {
           case GETVAL:
             Result = ::semctl(semid, semnum, cmd);
             break;
-          default: LogMan::Msg::A("Unhandled semctl cmd: %d", cmd); return -EINVAL; break;
+          default: LOGMAN_MSG_A("Unhandled semctl cmd: %d", cmd); return -EINVAL; break;
         }
 #undef UNHANDLED
         break;
@@ -658,7 +658,7 @@ namespace FEX::HLE::x32 {
         int32_t cmd = third & 0xFF;
         msgun_32 *msgun = reinterpret_cast<msgun_32*>(ptr);
         bool IPC64 = third & 0x100;
-#define UNHANDLED(x) case x: LogMan::Msg::A("Unhandled msgctl cmd: " #x); break
+#define UNHANDLED(x) case x: LOGMAN_MSG_A("Unhandled msgctl cmd: " #x); break
         switch (cmd) {
           UNHANDLED(IPC_SET);
           case MSG_STAT:
@@ -688,7 +688,7 @@ namespace FEX::HLE::x32 {
           case IPC_RMID:
             Result = ::msgctl(msqid, cmd, nullptr);
             break;
-          default: LogMan::Msg::A("Unhandled msgctl cmd: %d", cmd); return -EINVAL; break;
+          default: LOGMAN_MSG_A("Unhandled msgctl cmd: %d", cmd); return -EINVAL; break;
         }
 #undef UNHANDLED
         break;
@@ -785,7 +785,7 @@ namespace FEX::HLE::x32 {
             Result = ::shmctl(shmid, cmd, nullptr);
             break;
 
-          default: LogMan::Msg::A("Unhandled shmctl cmd: %d", cmd); return -EINVAL; break;
+          default: LOGMAN_MSG_A("Unhandled shmctl cmd: %d", cmd); return -EINVAL; break;
         }
         break;
       }

--- a/Source/Tests/LinuxSyscalls/x32/Socket.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Socket.cpp
@@ -246,7 +246,7 @@ namespace FEX::HLE::x32 {
           break;
         }
         default:
-          LogMan::Msg::A("Unsupported socketcall op: %d", call);
+          LOGMAN_MSG_A("Unsupported socketcall op: %d", call);
           break;
       }
       SYSCALL_ERRNO();

--- a/Source/Tests/LinuxSyscalls/x32/Syscalls.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Syscalls.cpp
@@ -358,7 +358,7 @@ uint64_t MemAllocator::shmat(int shmid, const void* shmaddr, int shmflg, uint32_
       uint32_t SmallRet = Result >> 32;
       if (!(SmallRet == 0 ||
             SmallRet == ~0U)) {
-        LogMan::Msg::A("Syscall returning something with data in the upper 32bits! BUG!");
+        LOGMAN_MSG_A("Syscall returning something with data in the upper 32bits! BUG!");
         return -ENOMEM;
       }
 
@@ -590,7 +590,7 @@ uint64_t MemAllocator::shmdt(const void* shmaddr) {
       auto SyscallNumber = Syscall.SyscallNumber;
       auto Name = GetSyscallName(SyscallNumber);
       auto &Def = Definitions.at(SyscallNumber);
-      LogMan::Throw::A(Def.Ptr == cvt(&UnimplementedSyscall), "Oops overwriting sysall problem, %d, %s", SyscallNumber, Name);
+      LOGMAN_THROW_A(Def.Ptr == cvt(&UnimplementedSyscall), "Oops overwriting sysall problem, %d, %s", SyscallNumber, Name);
       Def.Ptr = Syscall.SyscallHandler;
       Def.NumArgs = Syscall.ArgumentCount;
 #ifdef DEBUG_STRACE

--- a/Source/Tests/LinuxSyscalls/x32/Thread.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Thread.cpp
@@ -27,7 +27,7 @@ namespace FEX::HLE::x32 {
 
     static bool Initialized = false;
     if (Initialized == true && u_info->entry_number == -1) {
-      LogMan::Msg::A("Trying to load a new GDT");
+      LOGMAN_MSG_A("Trying to load a new GDT");
     }
     if (u_info->entry_number == -1) {
       u_info->entry_number = 12; // Sure?

--- a/Source/Tests/LinuxSyscalls/x64/Syscalls.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Syscalls.cpp
@@ -138,7 +138,7 @@ namespace FEX::HLE::x64 {
       auto SyscallNumber = Syscall.SyscallNumber;
       auto Name = GetSyscallName(SyscallNumber);
       auto &Def = Definitions.at(SyscallNumber);
-      LogMan::Throw::A(Def.Ptr == cvt(&UnimplementedSyscall), "Oops overwriting sysall problem, %d, %s", SyscallNumber, Name);
+      LOGMAN_THROW_A(Def.Ptr == cvt(&UnimplementedSyscall), "Oops overwriting sysall problem, %d, %s", SyscallNumber, Name);
       Def.Ptr = Syscall.SyscallHandler;
       Def.NumArgs = Syscall.ArgumentCount;
 #ifdef DEBUG_STRACE

--- a/Source/Tests/TestHarnessRunner.cpp
+++ b/Source/Tests/TestHarnessRunner.cpp
@@ -69,7 +69,7 @@ int main(int argc, char **argv, char **const envp) {
 
   auto Args = FEX::ArgLoader::Get();
 
-  LogMan::Throw::A(Args.size() > 1, "Not enough arguments");
+  LOGMAN_THROW_A(Args.size() > 1, "Not enough arguments");
 
   FEX::HarnessHelper::HarnessCodeLoader Loader{Args[0], Args[1].c_str()};
   FEXCore::Config::Set(FEXCore::Config::CONFIG_IS64BIT_MODE, Loader.Is64BitMode() ? "1" : "0");

--- a/Source/Tests/UnitTestGenerator.cpp
+++ b/Source/Tests/UnitTestGenerator.cpp
@@ -2405,7 +2405,7 @@ int main(int argc, char **argv, char **const envp) {
 
   auto Args = FEX::ArgLoader::Get();
 
-  LogMan::Throw::A(!Args.empty(), "Not enough arguments");
+  LOGMAN_THROW_A(!Args.empty(), "Not enough arguments");
 
   FEXCore::X86Tables::InitializeInfoTables(FEXCore::Context::MODE_64BIT);
 

--- a/Source/Tools/Debugger/IMGui_I.cpp
+++ b/Source/Tools/Debugger/IMGui_I.cpp
@@ -625,7 +625,7 @@ namespace IR {
       //   Header.IRSize = ir->GetOffset();
       //   std::fstream IRFile;
       //   IRFile.open(File, std::fstream::out | std::fstream::binary);
-      //   LogMan::Throw::A(IRFile.is_open(), "Failed to open file");
+      //   LOGMAN_THROW_A(IRFile.is_open(), "Failed to open file");
 
       //   IRFile.write(reinterpret_cast<char*>(&Header), sizeof(Header));
       //   IRFile.write(ir->GetOpAs<char>(0), Header.IRSize);
@@ -638,7 +638,7 @@ namespace IR {
     IRFileHeader Header;
     std::fstream IRFile;
     IRFile.open(Filename, std::fstream::in | std::fstream::binary);
-    LogMan::Throw::A(IRFile.is_open(), "Failed to open file");
+    LOGMAN_THROW_A(IRFile.is_open(), "Failed to open file");
 
     IRFile.read(reinterpret_cast<char*>(&Header), sizeof(Header));
 
@@ -705,7 +705,7 @@ namespace History {
 
     std::fstream HistoryFile;
     HistoryFile.open("History.json", std::fstream::out);
-    LogMan::Throw::A(HistoryFile.is_open(), "Failed to open file");
+    LOGMAN_THROW_A(HistoryFile.is_open(), "Failed to open file");
 
     HistoryFile.write(Buffer, strlen(Buffer));
     HistoryFile.close();

--- a/Source/Tools/Debugger/Main.cpp
+++ b/Source/Tools/Debugger/Main.cpp
@@ -61,7 +61,7 @@ void CreateCoreCallback(char const *Filename, bool ELF) {
     Result = FEXCore::Context::InitCore(CTX, &Loader);
   }
 
-  LogMan::Throw::A(Result, "Couldn't initialize CTX");
+  LOGMAN_THROW_A(Result, "Couldn't initialize CTX");
 
   FEX::DebuggerState::SetContext(CTX);
   FEX::DebuggerState::SetHasNewState();


### PR DESCRIPTION
C++ no-op functions can't optimize out the predicate arguments in all cases.
This was causing a problem where zero cost assertions weren't actually zero cost.

The only way to resolve this is to actually use macros sadly enough.

This will give a fairly hefty performance uplift with anything operating on IR.