### PR TITLE
Only use SDL2 import target if it exists

### DIFF
--- a/Source/Tools/FEXConfig/CMakeLists.txt
+++ b/Source/Tools/FEXConfig/CMakeLists.txt
@@ -17,6 +17,12 @@ target_include_directories(${NAME} PRIVATE ${CMAKE_SOURCE_DIR}/Source/Tools/Debu
 
 target_include_directories(${NAME} PRIVATE ${CMAKE_SOURCE_DIR}/External/imgui/examples/)
 
+if (TARGET SDL2)
+  target_link_libraries(${NAME} PRIVATE SDL2::SDL2)
+else()
+  target_include_directories(${NAME} PRIVATE ${SDL2_INCLUDE_DIRS})
+  target_link_libraries(${NAME} PRIVATE ${SDL2_LIBRARIES})
+endif()
 target_link_libraries(${NAME} PRIVATE FEXCore Common CommonCore pthread epoxy SDL2::SDL2 X11 EGL imgui tiny-json json-maker)
 
 install(TARGETS ${NAME}


### PR DESCRIPTION
Should fix Arch and Ubuntu 20.04 together