### PR TITLE
Disable xbyak size check

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -579,7 +579,7 @@ void *X86JITCore::CompileCode(uint64_t Entry, [[maybe_unused]] FEXCore::IR::IRLi
   this->RAData = RAData;
 
   // Fairly excessive buffer range to make sure we don't overflow
-  uint32_t BufferRange = SSACount * 16;
+  uint32_t BufferRange = SSACount * 64;
   if ((getSize() + BufferRange) > CurrentCodeBuffer->Size) {
     ThreadState->CTX->ClearCodeCache(ThreadState, false);
   }


### PR DESCRIPTION
On x86 this can end up being a significant amount of CPU time.