### PR TITLE
AOTIR: .aotir files are now streamed out

### DIFF
--- a/External/FEXCore/Source/Interface/Context/Context.cpp
+++ b/External/FEXCore/Source/Interface/Context/Context.cpp
@@ -149,8 +149,12 @@ namespace FEXCore::Context {
     CTX->AOTIRLoader = CacheReader;
   }
 
-  bool WriteAOTIR(FEXCore::Context::Context *CTX, std::function<std::unique_ptr<std::ostream>(const std::string&)> CacheWriter) {
-    return CTX->WriteAOTIRCache(CacheWriter);
+  void SetAOTIRWriter(FEXCore::Context::Context *CTX, std::function<std::unique_ptr<std::ostream>(const std::string&)> CacheWriter) {
+    CTX->AOTIRWriter = CacheWriter;
+  }
+
+  void FinalizeAOTIRCache(FEXCore::Context::Context *CTX) {
+    CTX->FinalizeAOTIRCache();
   }
 
   void WriteFilesWithCode(FEXCore::Context::Context *CTX, std::function<void(const std::string& fileid, const std::string& filename)> Writer) {

--- a/External/FEXCore/include/FEXCore/Core/Context.h
+++ b/External/FEXCore/include/FEXCore/Core/Context.h
@@ -230,7 +230,8 @@ namespace FEXCore::Context {
   __attribute__((visibility("default"))) void AddNamedRegion(FEXCore::Context::Context *CTX, uintptr_t Base, uintptr_t Length, uintptr_t Offset, const std::string& Name);
   __attribute__((visibility("default"))) void RemoveNamedRegion(FEXCore::Context::Context *CTX, uintptr_t Base, uintptr_t Length);
   __attribute__((visibility("default"))) void SetAOTIRLoader(FEXCore::Context::Context *CTX, std::function<int(const std::string&)> CacheReader);
-  __attribute__((visibility("default"))) bool WriteAOTIR(FEXCore::Context::Context *CTX, std::function<std::unique_ptr<std::ostream>(const std::string&)> CacheWriter);
+  __attribute__((visibility("default"))) void SetAOTIRWriter(FEXCore::Context::Context *CTX, std::function<std::unique_ptr<std::ostream>(const std::string&)> CacheWriter);
+  __attribute__((visibility("default"))) void FinalizeAOTIRCache(FEXCore::Context::Context *CTX);
   __attribute__((visibility("default"))) void WriteFilesWithCode(FEXCore::Context::Context *CTX, std::function<void(const std::string& fileid, const std::string& filename)> Writer);
   __attribute__((visibility("default"))) void FlushCodeRange(FEXCore::Core::InternalThreadState *Thread, uint64_t Start, uint64_t Length);
 


### PR DESCRIPTION
## Overview
Makes it possible to write out the aotir file format without keeping everything in memory, which makes it possible to use --aotirgenerate on arm devices directly.

## Details
- Modifies aotir file format so that the index comes last in the file
- Writes out each block as it gets generated, not all at the end
- Special cases AOTIRGenerate to not keep IR, RA or CodeData around