### PR TITLE
Sigaction fixes

### DIFF
--- a/Source/Tests/LinuxSyscalls/x64/Signals.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Signals.cpp
@@ -17,7 +17,11 @@ $end_info$
 
 namespace FEX::HLE::x64 {
   void RegisterSignals() {
-    REGISTER_SYSCALL_IMPL_X64(rt_sigaction, [](FEXCore::Core::CpuStateFrame *Frame, int signum, const FEXCore::GuestSigAction *act, FEXCore::GuestSigAction *oldact) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X64(rt_sigaction, [](FEXCore::Core::CpuStateFrame *Frame, int signum, const FEXCore::GuestSigAction *act, FEXCore::GuestSigAction *oldact, size_t sigsetsize) -> uint64_t {
+      if (sigsetsize != 8) {
+        return -EINVAL;
+      }
+
       return FEX::HLE::_SyscallHandler->GetSignalDelegator()->RegisterGuestSignalHandler(signum, act, oldact);
     });
 

--- a/unittests/gvisor-tests/Known_Failures
+++ b/unittests/gvisor-tests/Known_Failures
@@ -109,7 +109,6 @@ select_test
 semaphore_test
 sendfile_test
 shm_test
-sigaction_test
 sigaltstack_test
 sigiret_test
 signalfd_test


### PR DESCRIPTION
Check for invalid sigsetsize

Since we are using SignalDelegator we don't use errno, so just return Result and check for Result == 0