### PR TITLE
Handle FD flag remapping correctly

### DIFF
--- a/Source/Tests/LinuxSyscalls/x32/FD.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/FD.cpp
@@ -263,13 +263,15 @@ namespace FEX::HLE::x32 {
           break;
         }
 
+        case F_SETFL:
+          lock_arg = (void*)FEX::HLE::RemapFromX86Flags(arg);
+          break;
         // Maps directly
         case F_DUPFD:
         case F_DUPFD_CLOEXEC:
         case F_GETFD:
         case F_SETFD:
         case F_GETFL:
-        case F_SETFL:
           break;
 
         default: LOGMAN_MSG_A("Unhandled fcntl64: 0x%x", cmd); break;
@@ -294,8 +296,12 @@ namespace FEX::HLE::x32 {
           break;
           case F_DUPFD:
           case F_DUPFD_CLOEXEC:
-          FEX::HLE::x32::CheckAndAddFDDuplication(fd, Result);
-          break;
+            FEX::HLE::x32::CheckAndAddFDDuplication(fd, Result);
+            break;
+          case F_GETFL: {
+            Result = FEX::HLE::RemapToX86Flags(Result);
+            break;
+          }
           default: break;
         }
       }

--- a/Source/Tests/LinuxSyscalls/x64/FD.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/FD.cpp
@@ -77,7 +77,21 @@ namespace FEX::HLE::x64 {
     });
 
     REGISTER_SYSCALL_IMPL_X64(fcntl, [](FEXCore::Core::CpuStateFrame *Frame, int fd, int cmd, uint64_t arg) -> uint64_t {
-      uint64_t Result = ::fcntl(fd, cmd, arg);
+      uint64_t Result{};
+      switch (cmd) {
+      case F_GETFL:
+        Result = ::fcntl(fd, cmd, arg);
+        if (Result != -1) {
+          Result = FEX::HLE::RemapToX86Flags(Result);
+        }
+        break;
+      case F_SETFL:
+        Result = ::fcntl(fd, cmd, FEX::HLE::RemapFromX86Flags(arg));
+        break;
+      default:
+        Result = ::fcntl(fd, cmd, arg);
+        break;
+      }
       SYSCALL_ERRNO();
     });
 


### PR DESCRIPTION
FD flag remapping was broken. It would remap one flag on to another and then the next check would remap it back.

Instead keep a mask of the flags to be remapped then remap them all at the end.
Also goes through the ops and fixes a few cases where it was remapping wrong flags.