### PR TITLE
Removes syscall forward errno preprocessor implementation

### DIFF
--- a/Source/Tests/LinuxSyscalls/Syscalls.h
+++ b/Source/Tests/LinuxSyscalls/Syscalls.h
@@ -202,12 +202,6 @@ std::string CollectArgsFmtString() {
 #define ARG_TO_STR(tpy, str)
 #endif
 
-/////
-// REGISTER_SYSCALL_FORWARD_ERRNO implementation
-// Given a syscall wrapper, it generate a syscall implementation using the wrapper's signature, forward the arguments
-// and register to syscalls via RegisterSyscall
-/////
-
 // Helper that allows us to create a variadic template lambda from a given signature
 // by creating a function that expects a fuction pointer with the given signature as a parameter
 template <typename T>
@@ -306,21 +300,6 @@ static_assert(sizeof(epoll_event_x86) == 12, "Incorrect size");
   }
 
 }
-
-// Creates a variadic template lambda from a global function (via FunctionToLambda), then forwards the arguments to the specified function
-// also handles errno
-#define SYSCALL_FORWARD_ERRNO(function) \
-  FEX::HLE::FunctionToLambda<decltype(&::function)>::ReturnFunctionPointer([](FEXCore::Core::CpuStateFrame *Frame, auto... Args) { \
-    FEX::HLE::FunctionToLambda<decltype(&::function)>::RType Result = ::function(Args...); \
-    do { if (Result == -1) return (FEX::HLE::FunctionToLambda<decltype(&::function)>::RType)-errno; return Result; } while(0); \
-  })
-
-// Helpers to register a syscall implementation
-// Creates a syscall forward from a glibc wrapper, and registers it
-#define REGISTER_SYSCALL_FORWARD_ERRNO(function) do { \
-  FEX::HLE::x64::RegisterSyscall(FEX::HLE::x64::SYSCALL_x64_##function, #function, SYSCALL_FORWARD_ERRNO(function)); \
-  FEX::HLE::x32::RegisterSyscall(FEX::HLE::x32::SYSCALL_x86_##function, #function, SYSCALL_FORWARD_ERRNO(function)); \
-  } while(0)
 
 // Registers syscall for both 32bit and 64bit
 #define REGISTER_SYSCALL_IMPL(name, lambda) \

--- a/Source/Tests/LinuxSyscalls/Syscalls/FD.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/FD.cpp
@@ -46,23 +46,20 @@ namespace FEX::HLE {
       SYSCALL_ERRNO();
     });
 
-    /*
     REGISTER_SYSCALL_IMPL(chown, [](FEXCore::Core::CpuStateFrame *Frame, const char *pathname, uid_t owner, gid_t group) -> uint64_t {
-      SYSCALL_STUB(chown);
-    });*/
-    REGISTER_SYSCALL_FORWARD_ERRNO(chown);
+      uint64_t Result = ::chown(pathname, owner, group);
+      SYSCALL_ERRNO();
+    });
 
-    /*
     REGISTER_SYSCALL_IMPL(fchown, [](FEXCore::Core::CpuStateFrame *Frame, int fd, uid_t owner, gid_t group) -> uint64_t {
-      SYSCALL_STUB(fchown);
-    });*/
-    REGISTER_SYSCALL_FORWARD_ERRNO(fchown);
+      uint64_t Result = ::fchown(fd, owner, group);
+      SYSCALL_ERRNO();
+    });
 
-    /*
     REGISTER_SYSCALL_IMPL(lchown, [](FEXCore::Core::CpuStateFrame *Frame, const char *pathname, uid_t owner, gid_t group) -> uint64_t {
-      SYSCALL_STUB(lchown);
-    });*/
-    REGISTER_SYSCALL_FORWARD_ERRNO(lchown);
+      uint64_t Result = ::lchown(pathname, owner, group);
+      SYSCALL_ERRNO();
+    });
 
     REGISTER_SYSCALL_IMPL(lseek, [](FEXCore::Core::CpuStateFrame *Frame, int fd, uint64_t offset, int whence) -> uint64_t {
       uint64_t Result = ::lseek(fd, offset, whence);

--- a/Source/Tests/LinuxSyscalls/Syscalls/FS.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/FS.cpp
@@ -166,83 +166,70 @@ namespace FEX::HLE {
     });
 
 
-    /*
     REGISTER_SYSCALL_IMPL(syncfs, [](FEXCore::Core::CpuStateFrame *Frame, int fd) -> uint64_t {
-      SYSCALL_STUB(syncfs);
-    });*/
-    REGISTER_SYSCALL_FORWARD_ERRNO(syncfs);
+      uint64_t Result = ::syncfs(fd);
+      SYSCALL_ERRNO();
+    });
 
-    /*
     REGISTER_SYSCALL_IMPL(setxattr, [](FEXCore::Core::CpuStateFrame *Frame, const char *path, const char *name, const void *value, size_t size, int flags) -> uint64_t {
-      SYSCALL_STUB(setxattr);
-    });*/
-    REGISTER_SYSCALL_FORWARD_ERRNO(setxattr);
+      uint64_t Result = ::setxattr(path, name, value, size, flags);
+      SYSCALL_ERRNO();
+    });
 
-    /*
     REGISTER_SYSCALL_IMPL(lsetxattr, [](FEXCore::Core::CpuStateFrame *Frame, const char *path, const char *name, const void *value, size_t size, int flags) -> uint64_t {
-      SYSCALL_STUB(lsetxattr);
-    });*/
-    REGISTER_SYSCALL_FORWARD_ERRNO(lsetxattr);
+      uint64_t Result = ::lsetxattr(path, name, value, size, flags);
+      SYSCALL_ERRNO();
+    });
 
-    /*
     REGISTER_SYSCALL_IMPL(fsetxattr, [](FEXCore::Core::CpuStateFrame *Frame, int fd, const char *name, const void *value, size_t size, int flags) -> uint64_t {
-      SYSCALL_STUB(fsetxattr);
-    });*/
-    REGISTER_SYSCALL_FORWARD_ERRNO(fsetxattr);
+      uint64_t Result = ::fsetxattr(fd, name, value, size, flags);
+      SYSCALL_ERRNO();
+    });
 
-    /*
     REGISTER_SYSCALL_IMPL(getxattr, [](FEXCore::Core::CpuStateFrame *Frame, const char *path, const char *name, void *value, size_t size) -> uint64_t {
-      SYSCALL_STUB(getxattr);
-    });*/
-    REGISTER_SYSCALL_FORWARD_ERRNO(getxattr);
+      uint64_t Result = ::getxattr(path, name, value, size);
+      SYSCALL_ERRNO();
+    });
 
-    /*
     REGISTER_SYSCALL_IMPL(lgetxattr, [](FEXCore::Core::CpuStateFrame *Frame, const char *path, const char *name, void *value, size_t size) -> uint64_t {
-      SYSCALL_STUB(lgetxattr);
-    });*/
-    REGISTER_SYSCALL_FORWARD_ERRNO(lgetxattr);
+      uint64_t Result = ::lgetxattr(path, name, value, size);
+      SYSCALL_ERRNO();
+    });
 
-    /*
     REGISTER_SYSCALL_IMPL(fgetxattr, [](FEXCore::Core::CpuStateFrame *Frame, int fd, const char *name, void *value, size_t size) -> uint64_t {
-      SYSCALL_STUB(fgetxattr);
-    });*/
-    REGISTER_SYSCALL_FORWARD_ERRNO(fgetxattr);
+      uint64_t Result = ::fgetxattr(fd, name, value, size);
+      SYSCALL_ERRNO();
+    });
 
-    /*
     REGISTER_SYSCALL_IMPL(listxattr, [](FEXCore::Core::CpuStateFrame *Frame, const char *path, char *list, size_t size) -> uint64_t {
-      SYSCALL_STUB(listxattr);
-    });*/
-    REGISTER_SYSCALL_FORWARD_ERRNO(listxattr);
+      uint64_t Result = ::listxattr(path, list, size);
+      SYSCALL_ERRNO();
+    });
 
-    /*
     REGISTER_SYSCALL_IMPL(llistxattr, [](FEXCore::Core::CpuStateFrame *Frame, const char *path, char *list, size_t size) -> uint64_t {
-      SYSCALL_STUB(llistxattr);
-    });*/
-    REGISTER_SYSCALL_FORWARD_ERRNO(llistxattr);
+      uint64_t Result = ::llistxattr(path, list, size);
+      SYSCALL_ERRNO();
+    });
 
-    /*
     REGISTER_SYSCALL_IMPL(flistxattr, [](FEXCore::Core::CpuStateFrame *Frame, int fd, char *list, size_t size) -> uint64_t {
-      SYSCALL_STUB(flistxattr);
-    });*/
-    REGISTER_SYSCALL_FORWARD_ERRNO(flistxattr);
+      uint64_t Result = ::flistxattr(fd, list, size);
+      SYSCALL_ERRNO();
+    });
 
-    /*
     REGISTER_SYSCALL_IMPL(removexattr, [](FEXCore::Core::CpuStateFrame *Frame, const char *path, const char *name) -> uint64_t {
-      SYSCALL_STUB(removexattr);
-    });*/
-    REGISTER_SYSCALL_FORWARD_ERRNO(removexattr);
+      uint64_t Result = ::removexattr(path, name);
+      SYSCALL_ERRNO();
+    });
 
-    /*
     REGISTER_SYSCALL_IMPL(lremovexattr, [](FEXCore::Core::CpuStateFrame *Frame, const char *path, const char *name) -> uint64_t {
-      SYSCALL_STUB(lremovexattr);
-    });*/
-    REGISTER_SYSCALL_FORWARD_ERRNO(lremovexattr);
+      uint64_t Result = ::lremovexattr(path, name);
+      SYSCALL_ERRNO();
+    });
 
-    /*
     REGISTER_SYSCALL_IMPL(fremovexattr, [](FEXCore::Core::CpuStateFrame *Frame, int fd, const char *name) -> uint64_t {
-      SYSCALL_STUB(fremovexattr);
-    });*/
-    REGISTER_SYSCALL_FORWARD_ERRNO(fremovexattr);
+      uint64_t Result = ::fremovexattr(fd, name);
+      SYSCALL_ERRNO();
+    });
 
     REGISTER_SYSCALL_IMPL(fanotify_init, [](FEXCore::Core::CpuStateFrame *Frame, unsigned int flags, unsigned int event_f_flags) -> uint64_t {
       uint64_t Result = ::fanotify_init(flags, event_f_flags);

--- a/Source/Tests/LinuxSyscalls/Syscalls/Thread.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Thread.cpp
@@ -356,31 +356,30 @@ namespace FEX::HLE {
       SYSCALL_ERRNO();
     });
 
-    /*
     REGISTER_SYSCALL_IMPL(setpgid, [](FEXCore::Core::CpuStateFrame *Frame, pid_t pid, pid_t pgid) -> uint64_t {
-      SYSCALL_STUB(setpgid);
-    });*/
-    REGISTER_SYSCALL_FORWARD_ERRNO(setpgid);
+      uint64_t Result = ::setpgid(pid, pgid);
+      SYSCALL_ERRNO();
+    });
 
-    /*REGISTER_SYSCALL_IMPL(getpgid, [](FEXCore::Core::CpuStateFrame *Frame, pid_t pid) -> uint64_t {
-      SYSCALL_STUB(getpgid);
-    });*/
-    REGISTER_SYSCALL_FORWARD_ERRNO(getpgid);
+    REGISTER_SYSCALL_IMPL(getpgid, [](FEXCore::Core::CpuStateFrame *Frame, pid_t pid) -> uint64_t {
+      uint64_t Result = ::getpgid(pid);
+      SYSCALL_ERRNO();
+    });
 
-    /*REGISTER_SYSCALL_IMPL(setfsuid, [](FEXCore::Core::CpuStateFrame *Frame, uid_t fsuid) -> uint64_t {
-      SYSCALL_STUB(setfsuid);
-    });*/
-    REGISTER_SYSCALL_FORWARD_ERRNO(setfsuid);
+    REGISTER_SYSCALL_IMPL(setfsuid, [](FEXCore::Core::CpuStateFrame *Frame, uid_t fsuid) -> uint64_t {
+      uint64_t Result = ::setfsuid(fsuid);
+      SYSCALL_ERRNO();
+    });
 
-    /*REGISTER_SYSCALL_IMPL(setfsgid, [](FEXCore::Core::CpuStateFrame *Frame, uid_t fsgid) -> uint64_t {
-      SYSCALL_STUB(setfsgid);
-    });*/
-    REGISTER_SYSCALL_FORWARD_ERRNO(setfsgid);
+    REGISTER_SYSCALL_IMPL(setfsgid, [](FEXCore::Core::CpuStateFrame *Frame, uid_t fsgid) -> uint64_t {
+      uint64_t Result = ::setfsgid(fsgid);
+      SYSCALL_ERRNO();
+    });
 
-    /*REGISTER_SYSCALL_IMPL(getsid, [](FEXCore::Core::CpuStateFrame *Frame, pid_t pid) -> uint64_t {
-      SYSCALL_STUB(getsid);
-    });*/
-    REGISTER_SYSCALL_FORWARD_ERRNO(getsid);
+    REGISTER_SYSCALL_IMPL(getsid, [](FEXCore::Core::CpuStateFrame *Frame, pid_t pid) -> uint64_t {
+      uint64_t Result = ::getsid(pid);
+      SYSCALL_ERRNO();
+    });
 
     REGISTER_SYSCALL_IMPL(waitid, [](FEXCore::Core::CpuStateFrame *Frame, idtype_t idtype, id_t id, siginfo_t *infop, int options) -> uint64_t {
       uint64_t Result = ::waitid(idtype, id, infop, options);

--- a/Source/Tests/LinuxSyscalls/x32/Syscalls.h
+++ b/Source/Tests/LinuxSyscalls/x32/Syscalls.h
@@ -101,10 +101,6 @@ bool RegisterSyscall(int num, const char *name, F f){
 
 }
 
-// Helpers to register a syscall implementation
-// Creates a syscall forward from a glibc wrapper, and registers it
-#define REGISTER_SYSCALL_FORWARD_ERRNO_X32(function) do { RegisterSyscall(x32::SYSCALL_x86_##function, #function, SYSCALL_FORWARD_ERRNO(function)); } while(0)
-
 // Registers syscall for 32bit only
 #define REGISTER_SYSCALL_IMPL_X32(name, lambda) \
   struct impl_##name { \

--- a/Source/Tests/LinuxSyscalls/x64/Syscalls.h
+++ b/Source/Tests/LinuxSyscalls/x64/Syscalls.h
@@ -76,10 +76,6 @@ bool RegisterSyscall(int num, const char *name, F f){
 
 }
 
-// Helpers to register a syscall implementation
-// Creates a syscall forward from a glibc wrapper, and registers it
-#define REGISTER_SYSCALL_FORWARD_ERRNO_X64(function) do { RegisterSyscall(x64::SYSCALL_x64_##function, #function, SYSCALL_FORWARD_ERRNO(function)); } while(0)
-
 // Registers syscall for 64bit only
 #define REGISTER_SYSCALL_IMPL_X64(name, lambda) \
   struct impl_##name { \

--- a/unittests/gvisor-tests/Known_Failures
+++ b/unittests/gvisor-tests/Known_Failures
@@ -67,7 +67,6 @@ affinity_test
 aio_test
 alarm_test
 arch_prctl_test
-chown_test
 concurrency_test
 connect_external_test
 epoll_test
@@ -125,7 +124,6 @@ socket_netlink_route_test
 socket_stress_test
 splice_test
 stat_test
-sync_test
 sysret_test
 tcp_socket_test
 time_test


### PR DESCRIPTION
This was causing issues with syscalls returning errors.
Remove it and move on