### PR TITLE
Externals: Add fmtlib as an external

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -33,3 +33,6 @@
 [submodule "External/jemalloc"]
 	path = External/jemalloc
 	url = https://github.com/FEX-Emu/jemalloc.git
+[submodule "External/fmt"]
+	path = External/fmt
+	url = https://github.com/fmtlib/fmt.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,8 @@ include_directories(External/jemalloc/pregen/include/)
 add_subdirectory(External/cpp-optparse/)
 include_directories(External/cpp-optparse/)
 
+add_subdirectory(External/fmt/)
+
 add_subdirectory(External/imgui/)
 include_directories(External/imgui/)
 

--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -306,7 +306,7 @@ endfunction()
 
 function(AddLibrary Name Type)
   add_library(${Name} ${Type} $<TARGET_OBJECTS:${PROJECT_NAME}_object>)
-  target_link_libraries(${Name} pthread vixl dl xxhash FEX_jemalloc)
+  target_link_libraries(${Name} pthread vixl dl fmt::fmt xxhash FEX_jemalloc)
   set_target_properties(${Name} PROPERTIES OUTPUT_NAME FEXCore)
   set_target_properties(${Name} PROPERTIES C_VISIBILITY_PRESET hidden)
   set_target_properties(${Name} PROPERTIES CXX_VISIBILITY_PRESET hidden)


### PR DESCRIPTION
Begins the process of addressing issue #146.

This is separated off, so that others can make use of fmt immediately for other convenient purposes (general localized non-sucky string formatting), while other things are being reworked.