### PR TITLE
DecodedOperand: Add helper functions for type testing 

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -526,12 +526,12 @@ private:
   OrderedNode * GetX87Top();
   void SetX87Top(OrderedNode *Value);
 
-  bool DestIsLockedMem(FEXCore::X86Tables::DecodedOp Op) {
-    return Op->Dest.TypeNone.Type !=FEXCore::X86Tables::DecodedOperand::TYPE_GPR && (Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_LOCK);
+  bool DestIsLockedMem(FEXCore::X86Tables::DecodedOp Op) const {
+    return DestIsMem(Op) && (Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_LOCK) != 0;
   }
 
-  bool DestIsMem(FEXCore::X86Tables::DecodedOp Op) {
-    return Op->Dest.TypeNone.Type !=FEXCore::X86Tables::DecodedOperand::TYPE_GPR;
+  bool DestIsMem(FEXCore::X86Tables::DecodedOp Op) const {
+    return !Op->Dest.IsGPR();
   }
 
   void CreateJumpBlocks(std::vector<FEXCore::Frontend::Decoder::DecodedBlocks> const *Blocks);

--- a/External/FEXCore/include/FEXCore/Debug/X86Tables.h
+++ b/External/FEXCore/include/FEXCore/Debug/X86Tables.h
@@ -418,6 +418,9 @@ struct X86InstInfo {
     // We don't care if the opcode dispatcher differs
     return true;
   }
+  bool operator!=(const X86InstInfo &b) const {
+    return !operator==(b);
+  }
 };
 
 static_assert(std::is_trivial<X86InstInfo>::value, "X86InstInfo needs to be trivial");


### PR DESCRIPTION
Shortens the length of code necessary for testing the type of a decoded operand.

Also relocates the type field out of all the union types to have it in a central location.