### PR TITLE
General: Add missing const specifiers where applicable

### DIFF
--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -181,7 +181,7 @@ namespace FEXCore::Context {
 
     bool InitCore(FEXCore::CodeLoader *Loader);
     FEXCore::Context::ExitReason RunUntilExit();
-    int GetProgramStatus();
+    int GetProgramStatus() const;
     bool IsPaused() const { return !Running; }
     void Pause();
     void Run();
@@ -192,7 +192,7 @@ namespace FEXCore::Context {
     void StopThread(FEXCore::Core::InternalThreadState *Thread);
     void SignalThread(FEXCore::Core::InternalThreadState *Thread, FEXCore::Core::SignalEvent Event);
 
-    bool GetGdbServerStatus() { return (bool)DebugServer; }
+    bool GetGdbServerStatus() const { return DebugServer != nullptr; }
     void StartGdbServer();
     void StopGdbServer();
     void HandleCallback(uint64_t RIP);

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -457,7 +457,7 @@ namespace FEXCore::Context {
     }
   }
 
-  int Context::GetProgramStatus() {
+  int Context::GetProgramStatus() const {
     return ParentThread->StatusCode;
   }
 

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
@@ -351,7 +351,7 @@ void Dispatcher::RemoveCodeBuffer(uint8_t* start_to_remove) {
   }
 }
 
-bool Dispatcher::IsAddressInJITCode(uint64_t Address, bool IncludeDispatcher) {
+bool Dispatcher::IsAddressInJITCode(uint64_t Address, bool IncludeDispatcher) const {
   for (auto [start, end] : CodeBuffers) {
     if (Address >= start && Address < end) {
       return true;

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
@@ -54,8 +54,8 @@ public:
 
   void RemoveCodeBuffer(uint8_t* start);
 
-  bool IsAddressInJITCode(uint64_t Address, bool IncludeDispatcher = true);
-  bool IsAddressInDispatcher(uint64_t Address) {
+  bool IsAddressInJITCode(uint64_t Address, bool IncludeDispatcher = true) const;
+  bool IsAddressInDispatcher(uint64_t Address) const {
     return Address >= Start && Address < End;
   }
 

--- a/External/FEXCore/Source/Interface/Core/Frontend.cpp
+++ b/External/FEXCore/Source/Interface/Core/Frontend.cpp
@@ -131,7 +131,7 @@ uint8_t Decoder::ReadByte() {
   return Byte;
 }
 
-uint8_t Decoder::PeekByte(uint8_t Offset) {
+uint8_t Decoder::PeekByte(uint8_t Offset) const {
   uint8_t Byte = InstStream[InstructionSize + Offset];
   return Byte;
 }

--- a/External/FEXCore/Source/Interface/Core/Frontend.h
+++ b/External/FEXCore/Source/Interface/Core/Frontend.h
@@ -26,7 +26,7 @@ public:
   Decoder(FEXCore::Context::Context *ctx);
   bool DecodeInstructionsAtEntry(uint8_t const* InstStream, uint64_t PC);
 
-  std::vector<DecodedBlocks> const *GetDecodedBlocks() {
+  std::vector<DecodedBlocks> const *GetDecodedBlocks() const {
     return &Blocks;
   }
 
@@ -43,7 +43,7 @@ private:
   void BranchTargetInMultiblockRange();
 
   uint8_t ReadByte();
-  uint8_t PeekByte(uint8_t Offset);
+  uint8_t PeekByte(uint8_t Offset) const;
   uint64_t ReadData(uint8_t Size);
   void SkipBytes(uint8_t Size) { InstructionSize += Size; }
   bool NormalOp(FEXCore::X86Tables::X86InstInfo const *Info, uint16_t Op);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -575,7 +575,7 @@ Arm64JITCore::~Arm64JITCore() {
   FreeCodeBuffer(InitialCodeBuffer);
 }
 
-IR::PhysicalRegister Arm64JITCore::GetPhys(uint32_t Node) {
+IR::PhysicalRegister Arm64JITCore::GetPhys(uint32_t Node) const {
   auto PhyReg = RAData->GetNodeRegister(Node);
 
   LOGMAN_THROW_A(!PhyReg.IsInvalid(), "Couldn't Allocate register for node: ssa%d. Class: %d", Node, PhyReg.Class);
@@ -584,7 +584,7 @@ IR::PhysicalRegister Arm64JITCore::GetPhys(uint32_t Node) {
 }
 
 template<>
-aarch64::Register Arm64JITCore::GetReg<Arm64JITCore::RA_32>(uint32_t Node) {
+aarch64::Register Arm64JITCore::GetReg<Arm64JITCore::RA_32>(uint32_t Node) const {
   auto Reg = GetPhys(Node);
 
   if (Reg.Class == IR::GPRFixedClass.Val) {
@@ -598,7 +598,7 @@ aarch64::Register Arm64JITCore::GetReg<Arm64JITCore::RA_32>(uint32_t Node) {
 }
 
 template<>
-aarch64::Register Arm64JITCore::GetReg<Arm64JITCore::RA_64>(uint32_t Node) {
+aarch64::Register Arm64JITCore::GetReg<Arm64JITCore::RA_64>(uint32_t Node) const {
   auto Reg = GetPhys(Node);
 
   if (Reg.Class == IR::GPRFixedClass.Val) {
@@ -612,18 +612,18 @@ aarch64::Register Arm64JITCore::GetReg<Arm64JITCore::RA_64>(uint32_t Node) {
 }
 
 template<>
-std::pair<aarch64::Register, aarch64::Register> Arm64JITCore::GetSrcPair<Arm64JITCore::RA_32>(uint32_t Node) {
+std::pair<aarch64::Register, aarch64::Register> Arm64JITCore::GetSrcPair<Arm64JITCore::RA_32>(uint32_t Node) const {
   uint32_t Reg = GetPhys(Node).Reg;
   return RA32Pair[Reg];
 }
 
 template<>
-std::pair<aarch64::Register, aarch64::Register> Arm64JITCore::GetSrcPair<Arm64JITCore::RA_64>(uint32_t Node) {
+std::pair<aarch64::Register, aarch64::Register> Arm64JITCore::GetSrcPair<Arm64JITCore::RA_64>(uint32_t Node) const {
   uint32_t Reg = GetPhys(Node).Reg;
   return RA64Pair[Reg];
 }
 
-aarch64::VRegister Arm64JITCore::GetSrc(uint32_t Node) {
+aarch64::VRegister Arm64JITCore::GetSrc(uint32_t Node) const {
   auto Reg = GetPhys(Node);
 
   if (Reg.Class == IR::FPRFixedClass.Val) {
@@ -636,7 +636,7 @@ aarch64::VRegister Arm64JITCore::GetSrc(uint32_t Node) {
   __builtin_unreachable();
 }
 
-aarch64::VRegister Arm64JITCore::GetDst(uint32_t Node) {
+aarch64::VRegister Arm64JITCore::GetDst(uint32_t Node) const {
   auto Reg = GetPhys(Node);
 
   if (Reg.Class == IR::FPRFixedClass.Val) {
@@ -649,7 +649,7 @@ aarch64::VRegister Arm64JITCore::GetDst(uint32_t Node) {
   __builtin_unreachable();
 }
 
-bool Arm64JITCore::IsInlineConstant(const IR::OrderedNodeWrapper& WNode, uint64_t* Value) {
+bool Arm64JITCore::IsInlineConstant(const IR::OrderedNodeWrapper& WNode, uint64_t* Value) const {
   auto OpHeader = IR->GetOp<IR::IROp_Header>(WNode);
 
   if (OpHeader->Op == IR::IROps::OP_INLINECONSTANT) {
@@ -663,7 +663,7 @@ bool Arm64JITCore::IsInlineConstant(const IR::OrderedNodeWrapper& WNode, uint64_
   }
 }
 
-bool Arm64JITCore::IsInlineEntrypointOffset(const IR::OrderedNodeWrapper& WNode, uint64_t* Value) {
+bool Arm64JITCore::IsInlineEntrypointOffset(const IR::OrderedNodeWrapper& WNode, uint64_t* Value) const {
   auto OpHeader = IR->GetOp<IR::IROp_Header>(WNode);
 
   if (OpHeader->Op == IR::IROps::OP_INLINEENTRYPOINTOFFSET) {
@@ -677,18 +677,18 @@ bool Arm64JITCore::IsInlineEntrypointOffset(const IR::OrderedNodeWrapper& WNode,
   }
 }
 
-FEXCore::IR::RegisterClassType Arm64JITCore::GetRegClass(uint32_t Node) {
+FEXCore::IR::RegisterClassType Arm64JITCore::GetRegClass(uint32_t Node) const {
   return FEXCore::IR::RegisterClassType {GetPhys(Node).Class};
 }
 
 
-bool Arm64JITCore::IsFPR(uint32_t Node) {
+bool Arm64JITCore::IsFPR(uint32_t Node) const {
   auto Class = GetRegClass(Node);
 
   return Class == IR::FPRClass || Class == IR::FPRFixedClass;
 }
 
-bool Arm64JITCore::IsGPR(uint32_t Node) {
+bool Arm64JITCore::IsGPR(uint32_t Node) const {
   auto Class = GetRegClass(Node);
 
   return Class == IR::GPRClass || Class == IR::GPRFixedClass;

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -96,35 +96,35 @@ private:
   constexpr static uint8_t RA_FPR = 2;
 
   template<uint8_t RAType>
-  aarch64::Register GetReg(uint32_t Node);
+  aarch64::Register GetReg(uint32_t Node) const;
 
   template<>
-  aarch64::Register GetReg<RA_32>(uint32_t Node);
+  aarch64::Register GetReg<RA_32>(uint32_t Node) const;
   template<>
-  aarch64::Register GetReg<RA_64>(uint32_t Node);
+  aarch64::Register GetReg<RA_64>(uint32_t Node) const;
 
   template<uint8_t RAType>
-  std::pair<aarch64::Register, aarch64::Register> GetSrcPair(uint32_t Node);
+  std::pair<aarch64::Register, aarch64::Register> GetSrcPair(uint32_t Node) const;
 
   template<>
-  std::pair<aarch64::Register, aarch64::Register> GetSrcPair<RA_32>(uint32_t Node);
+  std::pair<aarch64::Register, aarch64::Register> GetSrcPair<RA_32>(uint32_t Node) const;
   template<>
-  std::pair<aarch64::Register, aarch64::Register> GetSrcPair<RA_64>(uint32_t Node);
+  std::pair<aarch64::Register, aarch64::Register> GetSrcPair<RA_64>(uint32_t Node) const;
 
-  aarch64::VRegister GetSrc(uint32_t Node);
-  aarch64::VRegister GetDst(uint32_t Node);
+  aarch64::VRegister GetSrc(uint32_t Node) const;
+  aarch64::VRegister GetDst(uint32_t Node) const;
 
-  FEXCore::IR::RegisterClassType GetRegClass(uint32_t Node);
+  FEXCore::IR::RegisterClassType GetRegClass(uint32_t Node) const;
 
-  IR::PhysicalRegister GetPhys(uint32_t Node);
+  IR::PhysicalRegister GetPhys(uint32_t Node) const;
 
-  bool IsFPR(uint32_t Node);
-  bool IsGPR(uint32_t Node);
+  bool IsFPR(uint32_t Node) const;
+  bool IsGPR(uint32_t Node) const;
 
   MemOperand GenerateMemOperand(uint8_t AccessSize, aarch64::Register Base, IR::OrderedNodeWrapper Offset, IR::MemOffsetType OffsetType, uint8_t OffsetScale);
 
-  bool IsInlineConstant(const IR::OrderedNodeWrapper& Node, uint64_t* Value = nullptr);
-  bool IsInlineEntrypointOffset(const IR::OrderedNodeWrapper& WNode, uint64_t* Value);
+  bool IsInlineConstant(const IR::OrderedNodeWrapper& Node, uint64_t* Value = nullptr) const;
+  bool IsInlineEntrypointOffset(const IR::OrderedNodeWrapper& WNode, uint64_t* Value) const;
 
   struct LiveRange {
     uint32_t Begin;

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -411,7 +411,7 @@ void X86JITCore::ClearCache() {
   }
 }
 
-IR::PhysicalRegister X86JITCore::GetPhys(uint32_t Node) {
+IR::PhysicalRegister X86JITCore::GetPhys(uint32_t Node) const {
   auto PhyReg = RAData->GetNodeRegister(Node);
 
   LOGMAN_THROW_A(PhyReg.Raw != 255, "Couldn't Allocate register for node: ssa%d. Class: %d", Node, PhyReg.Class);
@@ -419,98 +419,98 @@ IR::PhysicalRegister X86JITCore::GetPhys(uint32_t Node) {
   return PhyReg;
 }
 
-bool X86JITCore::IsFPR(uint32_t Node) {
+bool X86JITCore::IsFPR(uint32_t Node) const {
   return RAData->GetNodeRegister(Node).Class == IR::FPRClass.Val;
 }
 
-bool X86JITCore::IsGPR(uint32_t Node) {
+bool X86JITCore::IsGPR(uint32_t Node) const {
   return RAData->GetNodeRegister(Node).Class == IR::GPRClass.Val;
 }
 
 template<uint8_t RAType>
-Xbyak::Reg X86JITCore::GetSrc(uint32_t Node) {
+Xbyak::Reg X86JITCore::GetSrc(uint32_t Node) const {
   // rax, rcx, rdx, rsi, r8, r9,
   // r10
   // Callee Saved
   // rbx, rbp, r12, r13, r14, r15
   auto PhyReg = GetPhys(Node);
-  if (RAType == RA_64)
+  if constexpr (RAType == RA_64)
     return RA64[PhyReg.Reg].cvt64();
-  else if (RAType == RA_XMM)
+  else if constexpr (RAType == RA_XMM)
     return RAXMM[PhyReg.Reg];
-  else if (RAType == RA_32)
+  else if constexpr (RAType == RA_32)
     return RA64[PhyReg.Reg].cvt32();
-  else if (RAType == RA_16)
+  else if constexpr (RAType == RA_16)
     return RA64[PhyReg.Reg].cvt16();
-  else if (RAType == RA_8)
+  else if constexpr (RAType == RA_8)
     return RA64[PhyReg.Reg].cvt8();
 }
 
 template
-Xbyak::Reg X86JITCore::GetSrc<X86JITCore::RA_64>(uint32_t Node);
+Xbyak::Reg X86JITCore::GetSrc<X86JITCore::RA_64>(uint32_t Node) const;
 
 template
-Xbyak::Reg X86JITCore::GetSrc<X86JITCore::RA_32>(uint32_t Node);
+Xbyak::Reg X86JITCore::GetSrc<X86JITCore::RA_32>(uint32_t Node) const;
 
 template
-Xbyak::Reg X86JITCore::GetSrc<X86JITCore::RA_16>(uint32_t Node);
+Xbyak::Reg X86JITCore::GetSrc<X86JITCore::RA_16>(uint32_t Node) const;
 
 template
-Xbyak::Reg X86JITCore::GetSrc<X86JITCore::RA_8>(uint32_t Node);
+Xbyak::Reg X86JITCore::GetSrc<X86JITCore::RA_8>(uint32_t Node) const;
 
-Xbyak::Xmm X86JITCore::GetSrc(uint32_t Node) {
+Xbyak::Xmm X86JITCore::GetSrc(uint32_t Node) const {
   auto PhyReg = GetPhys(Node);
   return RAXMM_x[PhyReg.Reg];
 }
 
 template<uint8_t RAType>
-Xbyak::Reg X86JITCore::GetDst(uint32_t Node) {
+Xbyak::Reg X86JITCore::GetDst(uint32_t Node) const {
   auto PhyReg = GetPhys(Node);
-  if (RAType == RA_64)
+  if constexpr (RAType == RA_64)
     return RA64[PhyReg.Reg].cvt64();
-  else if (RAType == RA_XMM)
+  else if constexpr (RAType == RA_XMM)
     return RAXMM[PhyReg.Reg];
-  else if (RAType == RA_32)
+  else if constexpr (RAType == RA_32)
     return RA64[PhyReg.Reg].cvt32();
-  else if (RAType == RA_16)
+  else if constexpr (RAType == RA_16)
     return RA64[PhyReg.Reg].cvt16();
-  else if (RAType == RA_8)
+  else if constexpr (RAType == RA_8)
     return RA64[PhyReg.Reg].cvt8();
 }
 
 template
-Xbyak::Reg X86JITCore::GetDst<X86JITCore::RA_64>(uint32_t Node);
+Xbyak::Reg X86JITCore::GetDst<X86JITCore::RA_64>(uint32_t Node) const;
 
 template
-Xbyak::Reg X86JITCore::GetDst<X86JITCore::RA_32>(uint32_t Node);
+Xbyak::Reg X86JITCore::GetDst<X86JITCore::RA_32>(uint32_t Node) const;
 
 template
-Xbyak::Reg X86JITCore::GetDst<X86JITCore::RA_16>(uint32_t Node);
+Xbyak::Reg X86JITCore::GetDst<X86JITCore::RA_16>(uint32_t Node) const;
 
 template
-Xbyak::Reg X86JITCore::GetDst<X86JITCore::RA_8>(uint32_t Node);
+Xbyak::Reg X86JITCore::GetDst<X86JITCore::RA_8>(uint32_t Node) const;
 
 template<uint8_t RAType>
-std::pair<Xbyak::Reg, Xbyak::Reg> X86JITCore::GetSrcPair(uint32_t Node) {
+std::pair<Xbyak::Reg, Xbyak::Reg> X86JITCore::GetSrcPair(uint32_t Node) const {
   auto PhyReg = GetPhys(Node);
-  if (RAType == RA_64)
+  if constexpr (RAType == RA_64)
     return RA64Pair[PhyReg.Reg];
-  else if (RAType == RA_32)
+  else if constexpr (RAType == RA_32)
     return {RA64Pair[PhyReg.Reg].first.cvt32(), RA64Pair[PhyReg.Reg].second.cvt32()};
 }
 
 template
-std::pair<Xbyak::Reg, Xbyak::Reg> X86JITCore::GetSrcPair<X86JITCore::RA_64>(uint32_t Node);
+std::pair<Xbyak::Reg, Xbyak::Reg> X86JITCore::GetSrcPair<X86JITCore::RA_64>(uint32_t Node) const;
 
 template
-std::pair<Xbyak::Reg, Xbyak::Reg> X86JITCore::GetSrcPair<X86JITCore::RA_32>(uint32_t Node);
+std::pair<Xbyak::Reg, Xbyak::Reg> X86JITCore::GetSrcPair<X86JITCore::RA_32>(uint32_t Node) const;
 
-Xbyak::Xmm X86JITCore::GetDst(uint32_t Node) {
+Xbyak::Xmm X86JITCore::GetDst(uint32_t Node) const {
   auto PhyReg = GetPhys(Node);
   return RAXMM_x[PhyReg.Reg];
 }
 
-bool X86JITCore::IsInlineConstant(const IR::OrderedNodeWrapper& WNode, uint64_t* Value) {
+bool X86JITCore::IsInlineConstant(const IR::OrderedNodeWrapper& WNode, uint64_t* Value) const {
   auto OpHeader = IR->GetOp<IR::IROp_Header>(WNode);
 
   if (OpHeader->Op == IR::IROps::OP_INLINECONSTANT) {
@@ -524,7 +524,7 @@ bool X86JITCore::IsInlineConstant(const IR::OrderedNodeWrapper& WNode, uint64_t*
   }
 }
 
-bool X86JITCore::IsInlineEntrypointOffset(const IR::OrderedNodeWrapper& WNode, uint64_t* Value) {
+bool X86JITCore::IsInlineEntrypointOffset(const IR::OrderedNodeWrapper& WNode, uint64_t* Value) const {
   auto OpHeader = IR->GetOp<IR::IROp_Header>(WNode);
 
   if (OpHeader->Op == IR::IROps::OP_INLINEENTRYPOINTOFFSET) {

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -112,26 +112,26 @@ private:
   constexpr static uint8_t RA_64 = 3;
   constexpr static uint8_t RA_XMM = 4;
 
-  IR::PhysicalRegister GetPhys(uint32_t Node);
+  IR::PhysicalRegister GetPhys(uint32_t Node) const;
 
-  bool IsFPR(uint32_t Node);
-  bool IsGPR(uint32_t Node);
-
-  template<uint8_t RAType>
-  Xbyak::Reg GetSrc(uint32_t Node);
-  template<uint8_t RAType>
-  std::pair<Xbyak::Reg, Xbyak::Reg> GetSrcPair(uint32_t Node);
+  bool IsFPR(uint32_t Node) const;
+  bool IsGPR(uint32_t Node) const;
 
   template<uint8_t RAType>
-  Xbyak::Reg GetDst(uint32_t Node);
+  Xbyak::Reg GetSrc(uint32_t Node) const;
+  template<uint8_t RAType>
+  std::pair<Xbyak::Reg, Xbyak::Reg> GetSrcPair(uint32_t Node) const;
 
-  Xbyak::Xmm GetSrc(uint32_t Node);
-  Xbyak::Xmm GetDst(uint32_t Node);
+  template<uint8_t RAType>
+  Xbyak::Reg GetDst(uint32_t Node) const;
 
-  Xbyak::RegExp GenerateModRM(Xbyak::Reg Base, IR::OrderedNodeWrapper Offset, IR::MemOffsetType OffsetType, uint8_t OffsetScale);
+  Xbyak::Xmm GetSrc(uint32_t Node) const;
+  Xbyak::Xmm GetDst(uint32_t Node) const;
 
-  bool IsInlineConstant(const IR::OrderedNodeWrapper& Node, uint64_t* Value = nullptr);
-  bool IsInlineEntrypointOffset(const IR::OrderedNodeWrapper& WNode, uint64_t* Value);
+  Xbyak::RegExp GenerateModRM(Xbyak::Reg Base, IR::OrderedNodeWrapper Offset, IR::MemOffsetType OffsetType, uint8_t OffsetScale) const;
+
+  bool IsInlineConstant(const IR::OrderedNodeWrapper& Node, uint64_t* Value = nullptr) const;
+  bool IsInlineEntrypointOffset(const IR::OrderedNodeWrapper& WNode, uint64_t* Value) const;
 
   IR::RegisterAllocationPass *RAPass;
   FEXCore::IR::RegisterAllocationData *RAData;

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/MemoryOps.cpp
@@ -425,7 +425,7 @@ DEF_OP(StoreFlag) {
   mov(byte [STATE + (offsetof(FEXCore::Core::CPUState, flags[0]) + Op->Flag)], al);
 }
 
-Xbyak::RegExp X86JITCore::GenerateModRM(Xbyak::Reg Base, IR::OrderedNodeWrapper Offset, IR::MemOffsetType OffsetType, uint8_t OffsetScale) {
+Xbyak::RegExp X86JITCore::GenerateModRM(Xbyak::Reg Base, IR::OrderedNodeWrapper Offset, IR::MemOffsetType OffsetType, uint8_t OffsetScale) const {
   if (Offset.IsInvalid()) {
     return Base;
   } else {

--- a/External/FEXCore/Source/Interface/Core/LookupCache.h
+++ b/External/FEXCore/Source/Interface/Core/LookupCache.h
@@ -98,8 +98,8 @@ public:
 
   void HintUsedRange(uint64_t Address, uint64_t Size);
 
-  uintptr_t GetL1Pointer() { return L1Pointer; }
-  uintptr_t GetPagePointer() { return PagePointer; }
+  uintptr_t GetL1Pointer() const { return L1Pointer; }
+  uintptr_t GetPagePointer() const { return PagePointer; }
   uintptr_t GetVirtualMemorySize() const { return VirtualMemSize; }
 
   constexpr static size_t L1_ENTRIES = 1 * 1024 * 1024; // Must be a power of 2

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -4682,7 +4682,7 @@ void OpDispatchBuilder::Finalize() {
   }
 }
 
-uint8_t OpDispatchBuilder::GetDstSize(FEXCore::X86Tables::DecodedOp Op) {
+uint8_t OpDispatchBuilder::GetDstSize(FEXCore::X86Tables::DecodedOp Op) const {
   constexpr std::array<uint8_t, 8> Sizes = {
     0, // Invalid DEF
     1,
@@ -4700,7 +4700,7 @@ uint8_t OpDispatchBuilder::GetDstSize(FEXCore::X86Tables::DecodedOp Op) {
   return Size;
 }
 
-uint8_t OpDispatchBuilder::GetSrcSize(FEXCore::X86Tables::DecodedOp Op) {
+uint8_t OpDispatchBuilder::GetSrcSize(FEXCore::X86Tables::DecodedOp Op) const {
   constexpr std::array<uint8_t, 8> Sizes = {
     0, // Invalid DEF
     1,

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -105,7 +105,7 @@ public:
 
   void ResetWorkingList();
   void ResetDecodeFailure() { DecodeFailure = false; }
-  bool HadDecodeFailure() { return DecodeFailure; }
+  bool HadDecodeFailure() const { return DecodeFailure; }
 
   void BeginFunction(uint64_t RIP, std::vector<FEXCore::Frontend::Decoder::DecodedBlocks> const *Blocks);
   void Finalize();
@@ -495,8 +495,8 @@ private:
   void StoreResult(FEXCore::IR::RegisterClassType Class, FEXCore::X86Tables::DecodedOp Op, FEXCore::X86Tables::DecodedOperand const& Operand, OrderedNode *const Src, int8_t Align);
   void StoreResult(FEXCore::IR::RegisterClassType Class, FEXCore::X86Tables::DecodedOp Op, OrderedNode *const Src, int8_t Align);
 
-  uint8_t GetDstSize(FEXCore::X86Tables::DecodedOp Op);
-  uint8_t GetSrcSize(FEXCore::X86Tables::DecodedOp Op);
+  uint8_t GetDstSize(FEXCore::X86Tables::DecodedOp Op) const;
+  uint8_t GetSrcSize(FEXCore::X86Tables::DecodedOp Op) const;
 
   template<unsigned BitOffset>
   void SetRFLAG(OrderedNode *Value);

--- a/External/FEXCore/include/FEXCore/Config/Config.h
+++ b/External/FEXCore/include/FEXCore/Config/Config.h
@@ -106,8 +106,8 @@ namespace Type {
       OptionMap.erase(Option);
     }
 
-    const LayerType GetLayerType() const { return Type; }
-    const LayerOptions &GetOptionMap() { return OptionMap; }
+    LayerType GetLayerType() const { return Type; }
+    const LayerOptions &GetOptionMap() const { return OptionMap; }
 
   protected:
     const LayerType Type;
@@ -171,8 +171,8 @@ namespace Type {
       GetListIfExists(Option, &AppendList);
     }
 
-    operator T() { return ValueData; }
-    T operator()() { return ValueData; }
+    operator T() const { return ValueData; }
+    T operator()() const { return ValueData; }
     Value<T>(T Value) { ValueData = Value; }
     std::list<T> &All() { return AppendList; }
 

--- a/External/FEXCore/include/FEXCore/HLE/Linux/ThreadManagement.h
+++ b/External/FEXCore/include/FEXCore/HLE/Linux/ThreadManagement.h
@@ -7,12 +7,12 @@ namespace FEXCore::HLE {
 // Tracking relationships between thread IDs and such
 class ThreadManagement {
 public:
-  uint64_t GetUID()  { return UID; }
-  uint64_t GetGID()  { return GID; }
-  uint64_t GetEUID() { return EUID; }
-  uint64_t GetEGID() { return EGID; }
-  uint64_t GetTID()  { return TID; }
-  uint64_t GetPID() { return PID; }
+  uint64_t GetUID()  const { return UID; }
+  uint64_t GetGID()  const { return GID; }
+  uint64_t GetEUID() const { return EUID; }
+  uint64_t GetEGID() const { return EGID; }
+  uint64_t GetTID()  const { return TID; }
+  uint64_t GetPID()  const { return PID; }
 
   uint64_t UID{1000};
   uint64_t GID{1000};

--- a/External/FEXCore/include/FEXCore/IR/IR.h
+++ b/External/FEXCore/include/FEXCore/IR/IR.h
@@ -275,13 +275,13 @@ struct CondClassType final {
 
 struct MemOffsetType final {
   uint8_t Val;
-  operator uint8_t() {
+  operator uint8_t() const {
     return Val;
   }
-  int operator ==(const MemOffsetType other) {
+  int operator ==(const MemOffsetType other) const {
     return Val == other.Val;
   }
-  int operator !=(const MemOffsetType other) {
+  int operator !=(const MemOffsetType other) const {
     return Val != other.Val;
   }
 };
@@ -383,7 +383,7 @@ public:
 		return { RealNode, RealNode->Op(IRList) };
 	}
 
-  uint32_t ID() {
+  uint32_t ID() const {
     return Node.ID();
   }
 

--- a/External/FEXCore/include/FEXCore/IR/IntrusiveIRList.h
+++ b/External/FEXCore/include/FEXCore/IR/IntrusiveIRList.h
@@ -35,12 +35,12 @@ class DualIntrusiveAllocator final {
       FEXCore::Allocator::free(reinterpret_cast<void*>(Data));
     }
 
-    bool DataCheckSize(size_t Size) {
+    bool DataCheckSize(size_t Size) const {
       size_t NewOffset = DataCurrentOffset + Size;
       return NewOffset <= MemorySize;
     }
 
-    bool ListCheckSize(size_t Size) {
+    bool ListCheckSize(size_t Size) const {
       size_t NewOffset = ListCurrentOffset + Size;
       return NewOffset <= MemorySize;
     }

--- a/External/FEXCore/include/FEXCore/IR/RegisterAllocationData.h
+++ b/External/FEXCore/include/FEXCore/IR/RegisterAllocationData.h
@@ -21,7 +21,7 @@ union PhysicalRegister {
     return PhysicalRegister(InvalidClass, InvalidReg);
   }
 
-  bool IsInvalid() {
+  bool IsInvalid() const {
     return *this == Invalid();
   }
 };


### PR DESCRIPTION
A minor change that adds missing const specifiers to getters that don't modify the internal class state. Makes the API a little more explicit (and in some locations, a little more consistent) about non-modifying operations.