### PR TITLE
Config: Avoid a few minor string copies where trivially possible

### DIFF
--- a/External/FEXCore/Source/Interface/Config/Config.cpp
+++ b/External/FEXCore/Source/Interface/Config/Config.cpp
@@ -83,7 +83,7 @@ namespace FEXCore::Config {
     return ConfigFile;
   }
 
-  std::string GetApplicationConfig(std::string &Filename, bool Global) {
+  std::string GetApplicationConfig(const std::string &Filename, bool Global) {
     std::string ConfigFile = GetConfigDirectory(Global);
     if (!Global &&
         !std::filesystem::exists(ConfigFile) &&

--- a/External/FEXCore/include/FEXCore/Config/Config.h
+++ b/External/FEXCore/include/FEXCore/Config/Config.h
@@ -57,7 +57,7 @@ namespace Type {
   __attribute__((visibility("default"))) std::string GetDataDirectory();
   __attribute__((visibility("default"))) std::string GetConfigDirectory(bool Global);
   __attribute__((visibility("default"))) std::string GetConfigFileLocation();
-  __attribute__((visibility("default"))) std::string GetApplicationConfig(std::string &Filename, bool Global);
+  __attribute__((visibility("default"))) std::string GetApplicationConfig(const std::string &Filename, bool Global);
 
   using LayerValue = std::list<std::string>;
   using LayerOptions = std::unordered_map<ConfigOption, LayerValue>;

--- a/Source/Common/Config.cpp
+++ b/Source/Common/Config.cpp
@@ -17,7 +17,7 @@
 #include <json-maker.h>
 
 namespace FEX::Config {
-  bool LoadConfigFile(std::vector<char> &Data, std::string Config) {
+  static bool LoadConfigFile(std::vector<char> &Data, const std::string &Config) {
     std::fstream ConfigFile;
     ConfigFile.open(Config, std::ios::in);
 
@@ -72,7 +72,7 @@ namespace FEX::Config {
     return &*alloc->json_objects->emplace(alloc->json_objects->end());
   }
 
-  void LoadJSonConfig(std::string &Config, std::function<void(const char *Name, const char *ConfigSring)> Func) {
+  static void LoadJSonConfig(const std::string &Config, std::function<void(const char *Name, const char *ConfigSring)> Func) {
     std::vector<char> Data;
     if (!LoadConfigFile(Data, Config)) {
       return;
@@ -132,7 +132,7 @@ namespace FEX::Config {
 #include <FEXCore/Config/ConfigValues.inl>
   }};
 
-  void SaveLayerToJSON(std::string Filename, FEXCore::Config::Layer *const Layer) {
+  void SaveLayerToJSON(const std::string& Filename, FEXCore::Config::Layer *const Layer) {
     char Buffer[4096];
     char *Dest{};
     Dest = json_objOpen(Buffer, nullptr);
@@ -181,7 +181,7 @@ namespace FEX::Config {
     });
   }
 
-  AppLoader::AppLoader(std::string Filename, bool Global)
+  AppLoader::AppLoader(const std::string& Filename, bool Global)
     : FEX::Config::OptionMapper(Global ? FEXCore::Config::LayerType::LAYER_GLOBAL_APP : FEXCore::Config::LayerType::LAYER_LOCAL_APP) {
     Config = FEXCore::Config::GetApplicationConfig(Filename, Global);
 

--- a/Source/Common/Config.cpp
+++ b/Source/Common/Config.cpp
@@ -166,13 +166,13 @@ namespace FEX::Config {
   }
 
   MainLoader::MainLoader()
-    : FEX::Config::OptionMapper(FEXCore::Config::LayerType::LAYER_MAIN) {
-    Config = FEXCore::Config::GetConfigFileLocation();
+    : FEX::Config::OptionMapper(FEXCore::Config::LayerType::LAYER_MAIN)
+    , Config{FEXCore::Config::GetConfigFileLocation()} {
   }
 
   MainLoader::MainLoader(std::string ConfigFile)
-    : FEX::Config::OptionMapper(FEXCore::Config::LayerType::LAYER_MAIN) {
-    Config = ConfigFile;
+    : FEX::Config::OptionMapper(FEXCore::Config::LayerType::LAYER_MAIN)
+    , Config{std::move(ConfigFile)} {
   }
 
   void MainLoader::Load() {

--- a/Source/Common/Config.cpp
+++ b/Source/Common/Config.cpp
@@ -123,7 +123,7 @@ namespace FEX::Config {
 #include <FEXCore/Config/ConfigValues.inl>
   }};
 
-  static const std::map<std::string, FEXCore::Config::ConfigOption> ConfigLookup = {{
+  static const std::map<std::string, FEXCore::Config::ConfigOption, std::less<>> ConfigLookup = {{
 #define OPT_BASE(type, group, enum, json, default) {#json, FEXCore::Config::ConfigOption::CONFIG_##enum},
 #include <FEXCore/Config/ConfigValues.inl>
   }};

--- a/Source/Common/Config.h
+++ b/Source/Common/Config.h
@@ -40,7 +40,7 @@ namespace FEX::Config {
 
   class AppLoader final : public FEX::Config::OptionMapper {
   public:
-    explicit AppLoader(std::string Filename, bool Global);
+    explicit AppLoader(const std::string& Filename, bool Global);
     void Load();
 
   private:
@@ -56,5 +56,5 @@ namespace FEX::Config {
     char *const *envp;
   };
 
-  void SaveLayerToJSON(std::string Filename, FEXCore::Config::Layer *const Layer);
+  void SaveLayerToJSON(const std::string& Filename, FEXCore::Config::Layer *const Layer);
 }


### PR DESCRIPTION
We can make use of heterogenous lookup to avoid constructing std::string instances on lookups.

While we're in the area, we can tidy up some of the interface functions, to pass by reference where applicable.