### PR TITLE
Adds drm headers to an external repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -36,3 +36,6 @@
 [submodule "External/fmt"]
 	path = External/fmt
 	url = https://github.com/fmtlib/fmt.git
+[submodule "External/drm-headers"]
+	path = External/drm-headers
+	url = https://github.com/FEX-Emu/drm-headers.git

--- a/Source/Tests/LinuxSyscalls/CMakeLists.txt
+++ b/Source/Tests/LinuxSyscalls/CMakeLists.txt
@@ -59,6 +59,7 @@ add_library(LinuxEmulation STATIC
 
 target_link_libraries(LinuxEmulation FEXCore pthread numa)
 target_include_directories(LinuxEmulation PRIVATE ${CMAKE_BINARY_DIR}/generated)
+target_include_directories(LinuxEmulation PRIVATE ${PROJECT_SOURCE_DIR}/External/drm-headers/include/)
 
 set(HEADERS_TO_VERIFY
   x32/Types.h x86_32 # This needs to match structs to 32bit structs


### PR DESCRIPTION
It's highly likely that the host system won't have these headers installed.
Carry them in an external repository to ensure they are available.

Fixes #1047