### PR TITLE
IRParser: Convert array of std::string over to array of std::string_view 

### DIFF
--- a/External/FEXCore/Source/Interface/IR/IRParser.cpp
+++ b/External/FEXCore/Source/Interface/IR/IRParser.cpp
@@ -455,12 +455,10 @@ class IRParser: public FEXCore::IR::IREmitter {
         }
         else {
           while (!RemainingLine.empty()) {
-            size_t ArgEnd = std::string::npos;
-            ArgEnd = RemainingLine.find_first_of(",");
+            const size_t ArgEnd = RemainingLine.find(',');
+            std::string Arg = trim(RemainingLine.substr(0, ArgEnd));
 
-            std::string Arg = RemainingLine.substr(0, ArgEnd);
-            Arg = trim(Arg);
-            Def.Args.emplace_back(Arg);
+            Def.Args.emplace_back(std::move(Arg));
 
             RemainingLine.erase(0, ArgEnd+1); // +1 to ensure we go past the ','
             if (ArgEnd == std::string::npos)
@@ -469,8 +467,8 @@ class IRParser: public FEXCore::IR::IREmitter {
         }
       }
 
-      Defs.emplace_back(Def);
-		}
+      CurrentDef = &Defs.emplace_back(std::move(Def));
+    }
 
     // Ensure all of the ops are real ops
     for(size_t i = 0; i < Defs.size(); ++i) {

--- a/External/FEXCore/Source/Interface/IR/IRParser.cpp
+++ b/External/FEXCore/Source/Interface/IR/IRParser.cpp
@@ -505,14 +505,14 @@ class IRParser: public FEXCore::IR::IREmitter {
     SetWriteCursor(nullptr); // isolate the header from everything following
 
     // Initialize SSANameMapper with Invalid value
-    SSANameMapper["%Invalid"] = Invalid();
+    SSANameMapper.insert_or_assign("%Invalid", Invalid());
 
     // Spin through the blocks and generate basic block ops
     for(size_t i = 0; i < Defs.size(); ++i) {
       auto &Def = Defs[i];
       if (Def.OpEnum == FEXCore::IR::IROps::OP_CODEBLOCK) {
         auto CodeBlock = _CodeBlock(InvalidNode, InvalidNode);
-        SSANameMapper[Def.Definition] = CodeBlock.Node;
+        SSANameMapper.insert_or_assign(Def.Definition, CodeBlock.Node);
         Def.Node = CodeBlock.Node;
 
         if (i == 1) {
@@ -622,7 +622,7 @@ class IRParser: public FEXCore::IR::IREmitter {
           IROp->Size = Def.Size.Bytes();
           IROp->ElementSize = 0;
         }
-        SSANameMapper[Def.Definition] = Def.Node;
+        SSANameMapper.insert_or_assign(Def.Definition, Def.Node);
       }
     }
 
@@ -630,11 +630,11 @@ class IRParser: public FEXCore::IR::IREmitter {
 	}
 
   void InitializeStaticTables() {
-    if (NameToOpMap.size() == 0) {
+    if (NameToOpMap.empty()) {
       for (FEXCore::IR::IROps Op = FEXCore::IR::IROps::OP_DUMMY;
          Op <= FEXCore::IR::IROps::OP_LAST;
          Op = static_cast<FEXCore::IR::IROps>(static_cast<uint32_t>(Op) + 1)) {
-        NameToOpMap[FEXCore::IR::GetName(Op)] = Op;
+        NameToOpMap.insert_or_assign(FEXCore::IR::GetName(Op), Op);
       }
     }
   }

--- a/External/FEXCore/Source/Interface/IR/IRParser.cpp
+++ b/External/FEXCore/Source/Interface/IR/IRParser.cpp
@@ -327,7 +327,7 @@ class IRParser: public FEXCore::IR::IREmitter {
 
 
   bool Parse() {
-    auto CheckPrintError = [&](LineDefinition &Def, DecodeFailure Failure) -> bool {
+    const auto CheckPrintError = [&](const LineDefinition &Def, DecodeFailure Failure) -> bool {
       if (Failure != DecodeFailure::DECODE_OKAY) {
         LogMan::Msg::E("Error on Line: %d", Def.LineNumber);
         LogMan::Msg::E("%s", Lines[Def.LineNumber].c_str());

--- a/External/FEXCore/Source/Interface/IR/IRParser.cpp
+++ b/External/FEXCore/Source/Interface/IR/IRParser.cpp
@@ -196,7 +196,7 @@ class IRParser: public FEXCore::IR::IREmitter {
 
   template<>
   std::pair<DecodeFailure, FEXCore::IR::CondClassType> DecodeValue(std::string &Arg) {
-    std::array<std::string, 22> CondNames = {
+    static constexpr std::array<std::string_view, 22> CondNames = {
       "EQ",
       "NEQ",
       "UGE",
@@ -231,7 +231,7 @@ class IRParser: public FEXCore::IR::IREmitter {
 
   template<>
   std::pair<DecodeFailure, FEXCore::IR::MemOffsetType> DecodeValue(std::string &Arg) {
-    std::array<std::string, 3> Names = {
+    static constexpr std::array<std::string_view, 3> Names = {
       "SXTX",
       "UXTW",
       "SXTW",
@@ -247,7 +247,7 @@ class IRParser: public FEXCore::IR::IREmitter {
 
   template<>
   std::pair<DecodeFailure, FEXCore::IR::FenceType> DecodeValue(std::string &Arg) {
-    std::array<std::string, 3> Names = {
+    static constexpr std::array<std::string_view, 3> Names = {
       "Loads",
       "Stores",
       "LoadStores",


### PR DESCRIPTION
Same behavior, but allows the arrays to be constexpr (and use a little bit less space; 16 bytes vs 32 bytes per element*).

\* on clang, GCC, and MSVC (MSVC isn't supported, but included for completeness sake)

While in the area, I noticed some minor other locations that could have some cleanup/improvements (which I've separated into their own commits). 