### PR TITLE
LogManager: Add fmt-capable logging functions

### DIFF
--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -267,7 +267,7 @@ function(AddObject Name Type)
   add_dependencies(${Name} IR_INC)
   add_dependencies(${Name} CONFIG_INC)
 
-  target_link_libraries(${Name} pthread vixl dl xxhash FEX_jemalloc)
+  target_link_libraries(${Name} pthread vixl dl fmt::fmt xxhash FEX_jemalloc)
   set_target_properties(${Name} PROPERTIES OUTPUT_NAME FEXCore)
   set_target_properties(${Name} PROPERTIES C_VISIBILITY_PRESET hidden)
   set_target_properties(${Name} PROPERTIES CXX_VISIBILITY_PRESET hidden)

--- a/External/FEXCore/Source/Utils/LogManager.cpp
+++ b/External/FEXCore/Source/Utils/LogManager.cpp
@@ -39,6 +39,16 @@ void UnInstallHandlers() { Handlers.clear(); }
 
   __builtin_trap();
 }
+
+void MFmt(const char *fmt, const fmt::format_args& args) {
+  auto msg = fmt::vformat(fmt, args);
+
+  for (auto& Handler : Handlers) {
+    Handler(msg.c_str());
+  }
+
+  __builtin_trap();
+}
 } // namespace Throw
 
 namespace Msg {
@@ -64,6 +74,14 @@ void M(DebugLevels Level, const char *fmt, va_list args) {
   }
   for (auto &Handler : Handlers) {
     Handler(Level, Buffer);
+  }
+}
+
+void MFmtImpl(DebugLevels level, const char* fmt, const fmt::format_args& args) {
+  const auto msg = fmt::vformat(fmt, args);
+
+  for (auto& Handler : Handlers) {
+    Handler(level, msg.c_str());
   }
 }
 


### PR DESCRIPTION
Addresses #146 a little more by providing an interface to perform fmt-compatible logging, allowing migration over to it to begin.

No more, will people on the project be tormented by classic printf features like:

- Accidentally passing in a non-trivial type
- Goofy looking PRI macros
- Not being able to add support for custom types
- Mixing up signed/unsigned printf formatting specifiers accidentally

fmt-capable versions of the logging functions are named the same as the existing functions, just with a `Fmt` or `_FMT` suffix (depending on whether or not it's a function being used or a macro, respectively).