### PR TITLE
CodeLoader: Add type aliases for mapper and unmapper functions

### DIFF
--- a/External/FEXCore/include/FEXCore/Core/CodeLoader.h
+++ b/External/FEXCore/include/FEXCore/Core/CodeLoader.h
@@ -19,6 +19,8 @@ public:
   using MapperFn = std::function<void *(void *addr, size_t length, int prot, int flags, int fd, off_t offset)>;
   using UnmapperFn = std::function<int(void *addr, size_t length)>;
 
+  virtual ~CodeLoader() = default;
+
   /**
    * @brief CPU Core uses this to choose what the stack size should be for this code
    */

--- a/External/FEXCore/include/FEXCore/Core/CodeLoader.h
+++ b/External/FEXCore/include/FEXCore/Core/CodeLoader.h
@@ -16,6 +16,8 @@ class IREmitter;
 */
 class CodeLoader {
 public:
+  using MapperFn = std::function<void *(void *addr, size_t length, int prot, int flags, int fd, off_t offset)>;
+  using UnmapperFn = std::function<int(void *addr, size_t length)>;
 
   /**
    * @brief CPU Core uses this to choose what the stack size should be for this code
@@ -35,7 +37,7 @@ public:
   /**
    * @brief Maps and copies the executable, also sets up stack
    */
-  virtual bool MapMemory(std::function<void *(void *addr, size_t length, int prot, int flags, int fd, off_t offset)> Mapper, std::function<int(void *addr, size_t length)> Unmapper) { return false; }
+  virtual bool MapMemory(const MapperFn& Mapper, const UnmapperFn& Unmapper) { return false; }
 
   virtual std::vector<std::string> const *GetApplicationArguments() { return nullptr; }
   virtual void GetExecveArguments(std::vector<char const*> *Args) {}

--- a/Source/Tests/ELFCodeLoader.h
+++ b/Source/Tests/ELFCodeLoader.h
@@ -285,7 +285,7 @@ public:
     return DB.DefaultRIP();
   }
 
-  bool MapMemory(std::function<void *(void *addr, size_t length, int prot, int flags, int fd, off_t offset)> Mapper, std::function<int(void *addr, size_t length)> Unmapper) override {
+  bool MapMemory(const MapperFn& Mapper, const UnmapperFn& Unmapper) override {
     auto DoMMap = [Mapper](uint64_t Address, size_t Size, bool FixedNoReplace) -> void* {
       void *Result = Mapper(reinterpret_cast<void*>(Address), Size, PROT_READ | PROT_WRITE, (FixedNoReplace ? MAP_FIXED_NOREPLACE : MAP_FIXED) | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
       LOGMAN_THROW_A(Result != (void*)~0ULL, "Couldn't mmap");

--- a/Source/Tests/ELFCodeLoader2.h
+++ b/Source/Tests/ELFCodeLoader2.h
@@ -268,8 +268,7 @@ class ELFCodeLoader2 final : public FEXCore::CodeLoader {
     uint64_t val;
   };
 
-  virtual bool MapMemory(std::function<void *(void *addr, size_t length, int prot, int flags, int fd, off_t offset)> Mapper, std::function<int(void *addr, size_t length)> Unmapper) override {
-
+  bool MapMemory(const MapperFn& Mapper, const UnmapperFn& Unmapper) override {
     for (auto Header: MainElf.phdrs) {
       if (Header.p_type == PT_GNU_STACK) {
         if (Header.p_flags & PF_X)

--- a/Source/Tests/HarnessHelpers.h
+++ b/Source/Tests/HarnessHelpers.h
@@ -365,7 +365,7 @@ namespace FEX::HarnessHelper {
       return RIP;
     }
 
-    bool MapMemory(std::function<void *(void *addr, size_t length, int prot, int flags, int fd, off_t offset)> Mapper, std::function<int(void *addr, size_t length)> Unmapper) override {
+    bool MapMemory(const MapperFn& Mapper, const UnmapperFn& Unmapper) override {
       bool LimitedSize = true;
       auto DoMMap = [](uint64_t Address, size_t Size) -> void* {
         void *Result = FEXCore::Allocator::mmap(reinterpret_cast<void*>(Address), Size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);

--- a/Source/Tests/IRLoader.cpp
+++ b/Source/Tests/IRLoader.cpp
@@ -84,7 +84,7 @@ public:
     return IR->GetEntryRIP();
   }
 
-  bool MapMemory(std::function<void *(void *addr, size_t length, int prot, int flags, int fd, off_t offset)> Mapper, std::function<int(void *addr, size_t length)> Unmapper) override
+  bool MapMemory(const MapperFn& Mapper, const UnmapperFn& Unmapper) override
   {
     // Map the memory regions the test file asks for
     IR->MapRegions();


### PR DESCRIPTION
Adds two aliases to turn the signatures of MapMemory from long bois to short bois.

While we're at it, we can also give CodeLoader a virtual destructor to ensure destruction behavior is always consistent, no matter the scenario they're used in.