### PR TITLE
InternalThreadState: Make SignalEvent an enum class

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -328,7 +328,7 @@ namespace FEXCore::Context {
     // Tell all the threads that they should pause
     std::lock_guard<std::mutex> lk(ThreadCreationMutex);
     for (auto &Thread : Threads) {
-      Thread->SignalReason.store(FEXCore::Core::SignalEvent::SIGNALEVENT_PAUSE);
+      Thread->SignalReason.store(FEXCore::Core::SignalEvent::Pause);
       if (Thread->RunningEvents.Running.load()) {
         // Only attempt to stop this thread if it is running
         tgkill(Thread->ThreadManager.PID, Thread->ThreadManager.TID, SignalDelegator::SIGNAL_FOR_PAUSE);
@@ -349,7 +349,7 @@ namespace FEXCore::Context {
     // Spin up all the threads
     std::lock_guard<std::mutex> lk(ThreadCreationMutex);
     for (auto &Thread : Threads) {
-      Thread->SignalReason.store(FEXCore::Core::SignalEvent::SIGNALEVENT_RETURN);
+      Thread->SignalReason.store(FEXCore::Core::SignalEvent::Return);
       Thread->RunningEvents.WaitingToStart.store(true);
     }
 
@@ -429,7 +429,7 @@ namespace FEXCore::Context {
 
   void Context::StopThread(FEXCore::Core::InternalThreadState *Thread) {
     if (Thread->RunningEvents.Running.exchange(false)) {
-      Thread->SignalReason.store(FEXCore::Core::SignalEvent::SIGNALEVENT_STOP);
+      Thread->SignalReason.store(FEXCore::Core::SignalEvent::Stop);
       tgkill(Thread->ThreadManager.PID, Thread->ThreadManager.TID, SignalDelegator::SIGNAL_FOR_PAUSE);
     }
   }

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
@@ -261,7 +261,7 @@ bool Dispatcher::HandleSignalPause(int Signal, void *info, void *ucontext) {
   FEXCore::Core::SignalEvent SignalReason = ThreadState->SignalReason.load();
   auto Frame = ThreadState->CurrentFrame;
 
-  if (SignalReason == FEXCore::Core::SignalEvent::SIGNALEVENT_PAUSE) {
+  if (SignalReason == FEXCore::Core::SignalEvent::Pause) {
     // Store our thread state so we can come back to this
     StoreThreadState(Signal, ucontext);
 
@@ -286,11 +286,11 @@ bool Dispatcher::HandleSignalPause(int Signal, void *info, void *ucontext) {
     // We use this to track if it is safe to clear cache
     ++SignalHandlerRefCounter;
 
-    ThreadState->SignalReason.store(FEXCore::Core::SIGNALEVENT_NONE);
+    ThreadState->SignalReason.store(FEXCore::Core::SignalEvent::Nothing);
     return true;
   }
 
-  if (SignalReason == FEXCore::Core::SignalEvent::SIGNALEVENT_STOP) {
+  if (SignalReason == FEXCore::Core::SignalEvent::Stop) {
     // Our thread is stopping
     // We don't care about anything at this point
     // Set the stack to our starting location when we entered the core and get out safely
@@ -311,18 +311,18 @@ bool Dispatcher::HandleSignalPause(int Signal, void *info, void *ucontext) {
       ArchHelpers::Context::SetPc(ucontext, ThreadStopHandlerAddress);
     }
 
-    ThreadState->SignalReason.store(FEXCore::Core::SIGNALEVENT_NONE);
+    ThreadState->SignalReason.store(FEXCore::Core::SignalEvent::Nothing);
     return true;
   }
 
-  if (SignalReason == FEXCore::Core::SignalEvent::SIGNALEVENT_RETURN) {
+  if (SignalReason == FEXCore::Core::SignalEvent::Return) {
     RestoreThreadState(ucontext);
 
     // Ref count our faults
     // We use this to track if it is safe to clear cache
     --SignalHandlerRefCounter;
 
-    ThreadState->SignalReason.store(FEXCore::Core::SIGNALEVENT_NONE);
+    ThreadState->SignalReason.store(FEXCore::Core::SignalEvent::Nothing);
     return true;
   }
 

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -416,7 +416,7 @@ static void StopThread(FEXCore::Core::InternalThreadState *Thread) {
 
 [[noreturn]]
 static void SignalReturn(FEXCore::Core::InternalThreadState *Thread) {
-  Thread->CTX->SignalThread(Thread, FEXCore::Core::SIGNALEVENT_RETURN);
+  Thread->CTX->SignalThread(Thread, FEXCore::Core::SignalEvent::Return);
 
   LOGMAN_MSG_A("unreachable");
   __builtin_unreachable();

--- a/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
+++ b/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
@@ -54,11 +54,11 @@ namespace FEXCore::Core {
     std::vector<DebugDataSubblock> Subblocks;
   };
 
-  enum SignalEvent {
-    SIGNALEVENT_NONE, // If the guest uses our signal we need to know it was errant on our end
-    SIGNALEVENT_PAUSE,
-    SIGNALEVENT_STOP,
-    SIGNALEVENT_RETURN,
+  enum class SignalEvent {
+    Nothing, // If the guest uses our signal we need to know it was errant on our end
+    Pause,
+    Stop,
+    Return,
   };
 
   struct LocalIREntry {
@@ -78,7 +78,7 @@ namespace FEXCore::Core {
     } RunningEvents;
 
     FEXCore::Context::Context *CTX;
-    std::atomic<SignalEvent> SignalReason {SignalEvent::SIGNALEVENT_NONE};
+    std::atomic<SignalEvent> SignalReason{SignalEvent::Nothing};
 
     std::unique_ptr<FEXCore::Threads::Thread> ExecutionThread;
     Event StartRunning;


### PR DESCRIPTION
Makes the enumeration strongly typed, preventing implicit conversions, minimizing the potential chances of an invalid value being used by accident.

Also has the benefit of allowing the enum to be forward declared, if ever necessary.