### PR TITLE
Utils: Add CompilerDefs.h for compiler-specifics

### DIFF
--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -1,4 +1,5 @@
 #pragma once
+
 #include "Common/JitSymbols.h"
 #include "Interface/Core/CPUID.h"
 #include "Interface/Core/Frontend.h"
@@ -9,6 +10,7 @@
 #include "Interface/IR/Passes/RegisterAllocationPass.h"
 #include <FEXCore/Config/Config.h>
 #include <FEXCore/Core/CPUBackend.h>
+#include <FEXCore/Utils/CompilerDefs.h>
 #include <FEXCore/Utils/Event.h>
 #include <stdint.h>
 
@@ -120,7 +122,7 @@ namespace FEXCore::Context {
       FEX_CONFIG_OPT(DumpIR, DUMPIR);
     } Config;
 
-    using IntCallbackReturn =  __attribute__((naked)) void(*)(FEXCore::Core::InternalThreadState *Thread, volatile void *Host_RSP);
+    using IntCallbackReturn =  FEX_NAKED void(*)(FEXCore::Core::InternalThreadState *Thread, volatile void *Host_RSP);
     IntCallbackReturn InterpreterCallbackReturn;
 
     FEXCore::HostFeatures HostFeatures;

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/X86Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/X86Dispatcher.cpp
@@ -266,7 +266,7 @@ X86Dispatcher::X86Dispatcher(FEXCore::Context::Context *ctx, FEXCore::Core::Inte
 
   {
     ReturnPtr = getCurr<FEXCore::Context::Context::IntCallbackReturn>();
-//  using CallbackReturn =  __attribute__((naked)) void(*)(FEXCore::Core::InternalThreadState *Thread, volatile void *Host_RSP);
+//  using CallbackReturn =  FEX_NAKED void(*)(FEXCore::Core::InternalThreadState *Thread, volatile void *Host_RSP);
 
     // rdi = thread
     // rsi = rsp

--- a/External/FEXCore/Source/Interface/Core/GdbServer.cpp
+++ b/External/FEXCore/Source/Interface/Core/GdbServer.cpp
@@ -15,6 +15,8 @@ $end_info$
 #include <optional>
 #include "Common/NetStream.h"
 #include "Common/SoftFloat.h"
+
+#include <FEXCore/Utils/CompilerDefs.h>
 #include <FEXCore/Utils/LogManager.h>
 
 #include <sys/types.h>
@@ -218,7 +220,7 @@ void GdbServer::SendACK(std::ostream &stream, bool NACK) {
   }
 }
 
-struct __attribute__((packed)) GDBContextDefinition {
+struct FEX_PACKED GDBContextDefinition {
   uint64_t gregs[16];
   uint64_t rip;
   uint32_t eflags;

--- a/External/FEXCore/include/FEXCore/Config/Config.h
+++ b/External/FEXCore/include/FEXCore/Config/Config.h
@@ -1,5 +1,7 @@
 #pragma once
+
 #include <FEXCore/Core/Context.h>
+#include <FEXCore/Utils/CompilerDefs.h>
 #include <FEXCore/Utils/LogManager.h>
 
 #include <list>
@@ -54,15 +56,15 @@ namespace Type {
 #undef P
 }
 
-  __attribute__((visibility("default"))) std::string GetDataDirectory();
-  __attribute__((visibility("default"))) std::string GetConfigDirectory(bool Global);
-  __attribute__((visibility("default"))) std::string GetConfigFileLocation();
-  __attribute__((visibility("default"))) std::string GetApplicationConfig(const std::string &Filename, bool Global);
+  FEX_DEFAULT_VISIBILITY std::string GetDataDirectory();
+  FEX_DEFAULT_VISIBILITY std::string GetConfigDirectory(bool Global);
+  FEX_DEFAULT_VISIBILITY std::string GetConfigFileLocation();
+  FEX_DEFAULT_VISIBILITY std::string GetApplicationConfig(const std::string &Filename, bool Global);
 
   using LayerValue = std::list<std::string>;
   using LayerOptions = std::unordered_map<ConfigOption, LayerValue>;
 
-  class __attribute__((visibility("default"))) Layer {
+  class FEX_DEFAULT_VISIBILITY Layer {
   public:
     explicit Layer(const LayerType _Type);
     virtual ~Layer();
@@ -114,24 +116,24 @@ namespace Type {
     LayerOptions OptionMap;
   };
 
-  __attribute__((visibility("default"))) void Initialize();
-  __attribute__((visibility("default"))) void Shutdown();
+  FEX_DEFAULT_VISIBILITY void Initialize();
+  FEX_DEFAULT_VISIBILITY void Shutdown();
 
-  __attribute__((visibility("default"))) void Load();
-  __attribute__((visibility("default"))) void ReloadMetaLayer();
+  FEX_DEFAULT_VISIBILITY void Load();
+  FEX_DEFAULT_VISIBILITY void ReloadMetaLayer();
 
-  __attribute__((visibility("default"))) void AddLayer(std::unique_ptr<FEXCore::Config::Layer> _Layer);
+  FEX_DEFAULT_VISIBILITY void AddLayer(std::unique_ptr<FEXCore::Config::Layer> _Layer);
 
-  __attribute__((visibility("default"))) bool Exists(ConfigOption Option);
-  __attribute__((visibility("default"))) std::optional<LayerValue*> All(ConfigOption Option);
-  __attribute__((visibility("default"))) std::optional<std::string*> Get(ConfigOption Option);
+  FEX_DEFAULT_VISIBILITY bool Exists(ConfigOption Option);
+  FEX_DEFAULT_VISIBILITY std::optional<LayerValue*> All(ConfigOption Option);
+  FEX_DEFAULT_VISIBILITY std::optional<std::string*> Get(ConfigOption Option);
 
-  __attribute__((visibility("default"))) void Set(ConfigOption Option, std::string Data);
-  __attribute__((visibility("default"))) void Erase(ConfigOption Option);
-  __attribute__((visibility("default"))) void EraseSet(ConfigOption Option, std::string Data);
+  FEX_DEFAULT_VISIBILITY void Set(ConfigOption Option, std::string Data);
+  FEX_DEFAULT_VISIBILITY void Erase(ConfigOption Option);
+  FEX_DEFAULT_VISIBILITY void EraseSet(ConfigOption Option, std::string Data);
 
   template<typename T>
-  class __attribute__((visibility("default"))) Value {
+  class FEX_DEFAULT_VISIBILITY Value {
   public:
     template <typename TT = T,
       typename std::enable_if<!std::is_same<TT, std::string>::value, int>::type = 0>

--- a/External/FEXCore/include/FEXCore/Core/CPUBackend.h
+++ b/External/FEXCore/include/FEXCore/Core/CPUBackend.h
@@ -6,7 +6,10 @@ $end_info$
 */
 
 #pragma once
-#include <stdint.h>
+
+#include <FEXCore/Utils/CompilerDefs.h>
+
+#include <cstdint>
 #include <string>
 
 namespace FEXCore {
@@ -85,8 +88,8 @@ class LLVMCore;
     virtual void ClearCache() {}
     virtual void CopyNecessaryDataForCompileThread(CPUBackend *Original) {}
 
-    using AsmDispatch = __attribute__((naked)) void(*)(FEXCore::Core::CpuStateFrame *Frame);
-    using JITCallback = __attribute__((naked)) void(*)(FEXCore::Core::CpuStateFrame *Frame, uint64_t RIP);
+    using AsmDispatch = FEX_NAKED void(*)(FEXCore::Core::CpuStateFrame *Frame);
+    using JITCallback = FEX_NAKED void(*)(FEXCore::Core::CpuStateFrame *Frame, uint64_t RIP);
 
     JITCallback CallbackPtr{};
   protected:

--- a/External/FEXCore/include/FEXCore/Core/Context.h
+++ b/External/FEXCore/include/FEXCore/Core/Context.h
@@ -5,6 +5,7 @@
 
 #include <FEXCore/Core/SignalDelegator.h>
 #include <FEXCore/Core/CPUID.h>
+#include <FEXCore/Utils/CompilerDefs.h>
 
 #include <istream>
 #include <ostream>
@@ -50,7 +51,7 @@ namespace FEXCore::Context {
   /**
    * @brief This initializes internal FEXCore state that is shared between contexts and requires overhead to setup
    */
-  __attribute__((visibility("default"))) void InitializeStaticTables(OperatingMode Mode = MODE_64BIT);
+  FEX_DEFAULT_VISIBILITY void InitializeStaticTables(OperatingMode Mode = MODE_64BIT);
 
   /**
    * @brief [[threadsafe]] Create a new FEXCore context object
@@ -59,7 +60,7 @@ namespace FEXCore::Context {
    *
    * @return a new context object
    */
-  __attribute__((visibility("default"))) FEXCore::Context::Context *CreateNewContext();
+  FEX_DEFAULT_VISIBILITY FEXCore::Context::Context *CreateNewContext();
 
   /**
    * @brief Post creation context initialization
@@ -69,14 +70,14 @@ namespace FEXCore::Context {
    *
    * @return true if we managed to initialize correctly
    */
-  __attribute__((visibility("default"))) bool InitializeContext(FEXCore::Context::Context *CTX);
+  FEX_DEFAULT_VISIBILITY bool InitializeContext(FEXCore::Context::Context *CTX);
 
   /**
    * @brief Destroy the context object
    *
    * @param CTX
    */
-  __attribute__((visibility("default"))) void DestroyContext(FEXCore::Context::Context *CTX);
+  FEX_DEFAULT_VISIBILITY void DestroyContext(FEXCore::Context::Context *CTX);
 
   /**
    * @brief Allows setting up in memory code and other things prior to launchign code execution
@@ -86,17 +87,17 @@ namespace FEXCore::Context {
    *
    * @return true if we loaded code
    */
-  __attribute__((visibility("default"))) bool InitCore(FEXCore::Context::Context *CTX, FEXCore::CodeLoader *Loader);
+  FEX_DEFAULT_VISIBILITY bool InitCore(FEXCore::Context::Context *CTX, FEXCore::CodeLoader *Loader);
 
-  __attribute__((visibility("default"))) void SetExitHandler(FEXCore::Context::Context *CTX, std::function<void(uint64_t ThreadId, FEXCore::Context::ExitReason)> handler);
-  __attribute__((visibility("default"))) std::function<void(uint64_t ThreadId, FEXCore::Context::ExitReason)> GetExitHandler(FEXCore::Context::Context *CTX);
+  FEX_DEFAULT_VISIBILITY void SetExitHandler(FEXCore::Context::Context *CTX, std::function<void(uint64_t ThreadId, FEXCore::Context::ExitReason)> handler);
+  FEX_DEFAULT_VISIBILITY std::function<void(uint64_t ThreadId, FEXCore::Context::ExitReason)> GetExitHandler(FEXCore::Context::Context *CTX);
 
   /**
    * @brief Pauses execution on the CPU core
    *
    * Blocks until all threads have paused.
    */
-  __attribute__((visibility("default"))) void Pause(FEXCore::Context::Context *CTX);
+  FEX_DEFAULT_VISIBILITY void Pause(FEXCore::Context::Context *CTX);
 
   /**
    * @brief Starts (or continues) the CPU core
@@ -105,7 +106,7 @@ namespace FEXCore::Context {
    * Use RunUntilExit() for synchonous executions
    *
    */
-  __attribute__((visibility("default"))) void Run(FEXCore::Context::Context *CTX);
+  FEX_DEFAULT_VISIBILITY void Run(FEXCore::Context::Context *CTX);
 
   /**
    * @brief Runs the CPU core until it exits
@@ -117,9 +118,9 @@ namespace FEXCore::Context {
    *
    * @return The ExitReason for the parentthread.
    */
-  __attribute__((visibility("default"))) ExitReason RunUntilExit(FEXCore::Context::Context *CTX);
+  FEX_DEFAULT_VISIBILITY ExitReason RunUntilExit(FEXCore::Context::Context *CTX);
 
-  __attribute__((visibility("default"))) void CompileRIP(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP);
+  FEX_DEFAULT_VISIBILITY void CompileRIP(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP);
 
   /**
    * @brief Gets the program exit status
@@ -129,21 +130,21 @@ namespace FEXCore::Context {
    *
    * @return The program exit status
    */
-  __attribute__((visibility("default"))) int GetProgramStatus(FEXCore::Context::Context *CTX);
+  FEX_DEFAULT_VISIBILITY int GetProgramStatus(FEXCore::Context::Context *CTX);
 
   /**
    * @brief Tells the core to shutdown
    *
    * Blocks until shutdown
    */
-  __attribute__((visibility("default"))) void Stop(FEXCore::Context::Context *CTX);
+  FEX_DEFAULT_VISIBILITY void Stop(FEXCore::Context::Context *CTX);
 
   /**
    * @brief Executes one instruction
    *
    * Returns once execution is complete.
    */
-  __attribute__((visibility("default"))) void Step(FEXCore::Context::Context *CTX);
+  FEX_DEFAULT_VISIBILITY void Step(FEXCore::Context::Context *CTX);
 
   /**
    * @brief [[threadsafe]] Returns the ExitReason of the parent thread. Typically used for async result status
@@ -152,7 +153,7 @@ namespace FEXCore::Context {
    *
    * @return The ExitReason for the parentthread
    */
-  __attribute__((visibility("default"))) ExitReason GetExitReason(FEXCore::Context::Context *CTX);
+  FEX_DEFAULT_VISIBILITY ExitReason GetExitReason(FEXCore::Context::Context *CTX);
 
   /**
    * @brief [[theadsafe]] Checks if the Context is either done working or paused(in the case of single stepping)
@@ -163,7 +164,7 @@ namespace FEXCore::Context {
    *
    * @return true if the core is done or paused
    */
-  __attribute__((visibility("default"))) bool IsDone(FEXCore::Context::Context *CTX);
+  FEX_DEFAULT_VISIBILITY bool IsDone(FEXCore::Context::Context *CTX);
 
   /**
    * @brief Gets a copy the CPUState of the parent thread
@@ -171,7 +172,7 @@ namespace FEXCore::Context {
    * @param CTX The context that we created
    * @param State The state object to populate
    */
-  __attribute__((visibility("default"))) void GetCPUState(FEXCore::Context::Context *CTX, FEXCore::Core::CPUState *State);
+  FEX_DEFAULT_VISIBILITY void GetCPUState(FEXCore::Context::Context *CTX, FEXCore::Core::CPUState *State);
 
   /**
    * @brief Copies the CPUState provided to the parent thread
@@ -179,7 +180,7 @@ namespace FEXCore::Context {
    * @param CTX The context that we created
    * @param State The satate object to copy from
    */
-  __attribute__((visibility("default"))) void SetCPUState(FEXCore::Context::Context *CTX, FEXCore::Core::CPUState *State);
+  FEX_DEFAULT_VISIBILITY void SetCPUState(FEXCore::Context::Context *CTX, FEXCore::Core::CPUState *State);
 
   /**
    * @brief Allows the frontend to pass in a custom CPUBackend creation factory
@@ -189,7 +190,7 @@ namespace FEXCore::Context {
    * @param CTX The context that we created
    * @param Factory The factory that the context will call if the DefaultCore config ise set to CUSTOM
    */
-  __attribute__((visibility("default"))) void SetCustomCPUBackendFactory(FEXCore::Context::Context *CTX, CustomCPUFactoryType Factory);
+  FEX_DEFAULT_VISIBILITY void SetCustomCPUBackendFactory(FEXCore::Context::Context *CTX, CustomCPUFactoryType Factory);
 
   /**
    * @brief Sets up memory regions on the guest for mirroring within the guest's VM space
@@ -200,7 +201,7 @@ namespace FEXCore::Context {
    *
    * @return true when successfully mapped. false if there was an error adding
    */
-  __attribute__((visibility("default"))) bool AddVirtualMemoryMapping(FEXCore::Context::Context *CTX, uint64_t VirtualAddress, uint64_t PhysicalAddress, uint64_t Size);
+  FEX_DEFAULT_VISIBILITY bool AddVirtualMemoryMapping(FEXCore::Context::Context *CTX, uint64_t VirtualAddress, uint64_t PhysicalAddress, uint64_t Size);
 
   /**
    * @brief Allows the frontend to set a custom syscall handler
@@ -210,30 +211,30 @@ namespace FEXCore::Context {
    * @param Syscall Which syscall ID to install a visitor to
    * @param Visitor The Visitor to install
    */
-  __attribute__((visibility("default"))) void RegisterExternalSyscallVisitor(FEXCore::Context::Context *CTX, uint64_t Syscall, FEXCore::HLE::SyscallVisitor *Visitor);
+  FEX_DEFAULT_VISIBILITY void RegisterExternalSyscallVisitor(FEXCore::Context::Context *CTX, uint64_t Syscall, FEXCore::HLE::SyscallVisitor *Visitor);
 
-  __attribute__((visibility("default"))) void HandleCallback(FEXCore::Context::Context *CTX, uint64_t RIP);
+  FEX_DEFAULT_VISIBILITY void HandleCallback(FEXCore::Context::Context *CTX, uint64_t RIP);
 
-  __attribute__((visibility("default"))) void RegisterHostSignalHandler(FEXCore::Context::Context *CTX, int Signal, HostSignalDelegatorFunction Func);
-  __attribute__((visibility("default"))) void RegisterFrontendHostSignalHandler(FEXCore::Context::Context *CTX, int Signal, HostSignalDelegatorFunction Func);
+  FEX_DEFAULT_VISIBILITY void RegisterHostSignalHandler(FEXCore::Context::Context *CTX, int Signal, HostSignalDelegatorFunction Func);
+  FEX_DEFAULT_VISIBILITY void RegisterFrontendHostSignalHandler(FEXCore::Context::Context *CTX, int Signal, HostSignalDelegatorFunction Func);
 
-  __attribute__((visibility("default"))) FEXCore::Core::InternalThreadState* CreateThread(FEXCore::Context::Context *CTX, FEXCore::Core::CPUState *NewThreadState, uint64_t ParentTID);
-  __attribute__((visibility("default"))) void InitializeThread(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread);
-  __attribute__((visibility("default"))) void RunThread(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread);
-  __attribute__((visibility("default"))) void StopThread(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread);
-  __attribute__((visibility("default"))) void DestroyThread(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread);
-  __attribute__((visibility("default"))) void CleanupAfterFork(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread);
-  __attribute__((visibility("default"))) void SetSignalDelegator(FEXCore::Context::Context *CTX, FEXCore::SignalDelegator *SignalDelegation);
-  __attribute__((visibility("default"))) void SetSyscallHandler(FEXCore::Context::Context *CTX, FEXCore::HLE::SyscallHandler *Handler);
-  __attribute__((visibility("default"))) FEXCore::CPUID::FunctionResults RunCPUIDFunction(FEXCore::Context::Context *CTX, uint32_t Function, uint32_t Leaf);
+  FEX_DEFAULT_VISIBILITY FEXCore::Core::InternalThreadState* CreateThread(FEXCore::Context::Context *CTX, FEXCore::Core::CPUState *NewThreadState, uint64_t ParentTID);
+  FEX_DEFAULT_VISIBILITY void InitializeThread(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread);
+  FEX_DEFAULT_VISIBILITY void RunThread(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread);
+  FEX_DEFAULT_VISIBILITY void StopThread(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread);
+  FEX_DEFAULT_VISIBILITY void DestroyThread(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread);
+  FEX_DEFAULT_VISIBILITY void CleanupAfterFork(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread);
+  FEX_DEFAULT_VISIBILITY void SetSignalDelegator(FEXCore::Context::Context *CTX, FEXCore::SignalDelegator *SignalDelegation);
+  FEX_DEFAULT_VISIBILITY void SetSyscallHandler(FEXCore::Context::Context *CTX, FEXCore::HLE::SyscallHandler *Handler);
+  FEX_DEFAULT_VISIBILITY FEXCore::CPUID::FunctionResults RunCPUIDFunction(FEXCore::Context::Context *CTX, uint32_t Function, uint32_t Leaf);
 
-  __attribute__((visibility("default"))) void AddNamedRegion(FEXCore::Context::Context *CTX, uintptr_t Base, uintptr_t Length, uintptr_t Offset, const std::string& Name);
-  __attribute__((visibility("default"))) void RemoveNamedRegion(FEXCore::Context::Context *CTX, uintptr_t Base, uintptr_t Length);
-  __attribute__((visibility("default"))) void SetAOTIRLoader(FEXCore::Context::Context *CTX, std::function<int(const std::string&)> CacheReader);
-  __attribute__((visibility("default"))) void SetAOTIRWriter(FEXCore::Context::Context *CTX, std::function<std::unique_ptr<std::ostream>(const std::string&)> CacheWriter);
-  __attribute__((visibility("default"))) void FinalizeAOTIRCache(FEXCore::Context::Context *CTX);
-  __attribute__((visibility("default"))) void WriteFilesWithCode(FEXCore::Context::Context *CTX, std::function<void(const std::string& fileid, const std::string& filename)> Writer);
-  __attribute__((visibility("default"))) void FlushCodeRange(FEXCore::Core::InternalThreadState *Thread, uint64_t Start, uint64_t Length);
+  FEX_DEFAULT_VISIBILITY void AddNamedRegion(FEXCore::Context::Context *CTX, uintptr_t Base, uintptr_t Length, uintptr_t Offset, const std::string& Name);
+  FEX_DEFAULT_VISIBILITY void RemoveNamedRegion(FEXCore::Context::Context *CTX, uintptr_t Base, uintptr_t Length);
+  FEX_DEFAULT_VISIBILITY void SetAOTIRLoader(FEXCore::Context::Context *CTX, std::function<int(const std::string&)> CacheReader);
+  FEX_DEFAULT_VISIBILITY void SetAOTIRWriter(FEXCore::Context::Context *CTX, std::function<std::unique_ptr<std::ostream>(const std::string&)> CacheWriter);
+  FEX_DEFAULT_VISIBILITY void FinalizeAOTIRCache(FEXCore::Context::Context *CTX);
+  FEX_DEFAULT_VISIBILITY void WriteFilesWithCode(FEXCore::Context::Context *CTX, std::function<void(const std::string& fileid, const std::string& filename)> Writer);
+  FEX_DEFAULT_VISIBILITY void FlushCodeRange(FEXCore::Core::InternalThreadState *Thread, uint64_t Start, uint64_t Length);
 
-  __attribute__((visibility("default"))) void ConfigureAOTGen(FEXCore::Core::InternalThreadState *Thread, std::set<uint64_t> *ExternalBranches, uint64_t SectionMaxAddress);
+  FEX_DEFAULT_VISIBILITY void ConfigureAOTGen(FEXCore::Core::InternalThreadState *Thread, std::set<uint64_t> *ExternalBranches, uint64_t SectionMaxAddress);
 }

--- a/External/FEXCore/include/FEXCore/Core/CoreState.h
+++ b/External/FEXCore/include/FEXCore/Core/CoreState.h
@@ -1,12 +1,15 @@
 #pragma once
+
 #include <FEXCore/HLE/Linux/ThreadManagement.h>
+#include <FEXCore/Utils/CompilerDefs.h>
+
 #include <atomic>
 #include <cstddef>
 #include <stdint.h>
 #include <string_view>
 
 namespace FEXCore::Core {
-  struct __attribute__((packed)) CPUState {
+  struct FEX_PACKED CPUState {
     uint64_t rip; ///< Current core's RIP. May not be entirely accurate while JIT is active
     uint64_t gregs[16];
     uint64_t : 64;
@@ -51,6 +54,6 @@ namespace FEXCore::Core {
 
   constexpr uint64_t PAGE_SIZE = 4096;
 
-  __attribute__((visibility("default"))) std::string_view const& GetFlagName(unsigned Flag);
-  __attribute__((visibility("default"))) std::string_view const& GetGRegName(unsigned Reg);
+  FEX_DEFAULT_VISIBILITY std::string_view const& GetFlagName(unsigned Flag);
+  FEX_DEFAULT_VISIBILITY std::string_view const& GetGRegName(unsigned Reg);
 }

--- a/External/FEXCore/include/FEXCore/Core/SignalDelegator.h
+++ b/External/FEXCore/include/FEXCore/Core/SignalDelegator.h
@@ -1,4 +1,7 @@
 #pragma once
+
+#include <FEXCore/Utils/CompilerDefs.h>
+
 #include <cstdint>
 #include <functional>
 #include <signal.h>
@@ -7,11 +10,11 @@ namespace FEXCore {
 namespace Core {
   struct InternalThreadState;
 }
-  struct __attribute__((packed)) GuestSAMask {
+  struct FEX_PACKED GuestSAMask {
     uint64_t Val;
   };
 
-  struct __attribute__((packed)) GuestSigAction {
+  struct FEX_PACKED GuestSigAction {
     union {
       void (*handler)(int);
       void (*sigaction)(int, siginfo_t *, void*);

--- a/External/FEXCore/include/FEXCore/Core/UContext.h
+++ b/External/FEXCore/include/FEXCore/Core/UContext.h
@@ -1,4 +1,7 @@
 #pragma once
+
+#include <FEXCore/Utils/CompilerDefs.h>
+
 #include <cstddef>
 #include <cstdint>
 
@@ -13,7 +16,7 @@ namespace FEXCore {
     constexpr uint64_t UC_STRICT_RESTORE_SS = (1ULL << 2);
 
     ///< Describes the signal stack
-    struct __attribute__((packed)) stack_t {
+    struct FEX_PACKED stack_t {
       void *ss_sp;
       int32_t ss_flags;
       uint32_t : 32;
@@ -21,7 +24,7 @@ namespace FEXCore {
     };
     static_assert(sizeof(FEXCore::x86_64::stack_t) == 24, "This needs to be the right size");
 
-    struct __attribute__((packed)) _libc_fpstate {
+    struct FEX_PACKED _libc_fpstate {
       // This is in FXSAVE format
       uint16_t fcw;
       uint16_t fsw;
@@ -65,19 +68,19 @@ namespace FEXCore {
     };
     static_assert(FEX_REG_CR2 == 22, "Oops");
 
-    struct __attribute__((packed)) mcontext_t {
+    struct FEX_PACKED mcontext_t {
       uint64_t gregs[23];
       FEXCore::x86_64::_libc_fpstate *fpregs;
       uint64_t __reserved[8];
     };
     static_assert(sizeof(FEXCore::x86_64::mcontext_t) == 256, "This needs to be the right size");
 
-    struct __attribute__((packed)) sigset_t {
+    struct FEX_PACKED sigset_t {
       uint64_t val[16];
     };
     static_assert(sizeof(FEXCore::x86_64::sigset_t) == 128, "This needs to be the right size");
 
-    struct __attribute__((packed)) ucontext_t {
+    struct FEX_PACKED ucontext_t {
       uint64_t uc_flags;
       FEXCore::x86_64::ucontext_t *uc_link;
       FEXCore::x86_64::stack_t uc_stack;
@@ -92,12 +95,12 @@ namespace FEXCore {
   }
 
   namespace x86 {
-    struct __attribute__((packed)) siginfo_t {
+    struct FEX_PACKED siginfo_t {
       uint32_t pad[32];
     };
     static_assert(sizeof(FEXCore::x86::siginfo_t) == 128, "This needs to be the right size");
 
-    struct __attribute__((packed)) ucontext_t {
+    struct FEX_PACKED ucontext_t {
       uint32_t pad[91];
     };
     static_assert(sizeof(FEXCore::x86::ucontext_t) == 364, "This needs to be the right size");

--- a/External/FEXCore/include/FEXCore/Debug/X86Tables.h
+++ b/External/FEXCore/include/FEXCore/Debug/X86Tables.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <FEXCore/Core/Context.h>
+#include <FEXCore/Utils/CompilerDefs.h>
 
 #include <cstdint>
 #include <cstring>
@@ -476,29 +477,29 @@ constexpr size_t MAX_XOP_GROUP_TABLE_SIZE = (1 << 6);
 
 constexpr size_t MAX_EVEX_TABLE_SIZE = 256;
 
-extern __attribute__((visibility("default"))) X86InstInfo BaseOps[MAX_PRIMARY_TABLE_SIZE];
-extern __attribute__((visibility("default"))) X86InstInfo SecondBaseOps[MAX_SECOND_TABLE_SIZE];
-extern __attribute__((visibility("default"))) X86InstInfo RepModOps[MAX_REP_MOD_TABLE_SIZE];
-extern __attribute__((visibility("default"))) X86InstInfo RepNEModOps[MAX_REPNE_MOD_TABLE_SIZE];
-extern __attribute__((visibility("default"))) X86InstInfo OpSizeModOps[MAX_OPSIZE_MOD_TABLE_SIZE];
-extern __attribute__((visibility("default"))) X86InstInfo PrimaryInstGroupOps[MAX_INST_GROUP_TABLE_SIZE];
-extern __attribute__((visibility("default"))) X86InstInfo SecondInstGroupOps[MAX_INST_SECOND_GROUP_TABLE_SIZE];
-extern __attribute__((visibility("default"))) X86InstInfo SecondModRMTableOps[MAX_SECOND_MODRM_TABLE_SIZE];
-extern __attribute__((visibility("default"))) X86InstInfo X87Ops[MAX_X87_TABLE_SIZE];
-extern __attribute__((visibility("default"))) X86InstInfo DDDNowOps[MAX_3DNOW_TABLE_SIZE];
-extern __attribute__((visibility("default"))) X86InstInfo H0F38TableOps[MAX_0F_38_TABLE_SIZE];
-extern __attribute__((visibility("default"))) X86InstInfo H0F3ATableOps[MAX_0F_3A_TABLE_SIZE];
+extern FEX_DEFAULT_VISIBILITY X86InstInfo BaseOps[MAX_PRIMARY_TABLE_SIZE];
+extern FEX_DEFAULT_VISIBILITY X86InstInfo SecondBaseOps[MAX_SECOND_TABLE_SIZE];
+extern FEX_DEFAULT_VISIBILITY X86InstInfo RepModOps[MAX_REP_MOD_TABLE_SIZE];
+extern FEX_DEFAULT_VISIBILITY X86InstInfo RepNEModOps[MAX_REPNE_MOD_TABLE_SIZE];
+extern FEX_DEFAULT_VISIBILITY X86InstInfo OpSizeModOps[MAX_OPSIZE_MOD_TABLE_SIZE];
+extern FEX_DEFAULT_VISIBILITY X86InstInfo PrimaryInstGroupOps[MAX_INST_GROUP_TABLE_SIZE];
+extern FEX_DEFAULT_VISIBILITY X86InstInfo SecondInstGroupOps[MAX_INST_SECOND_GROUP_TABLE_SIZE];
+extern FEX_DEFAULT_VISIBILITY X86InstInfo SecondModRMTableOps[MAX_SECOND_MODRM_TABLE_SIZE];
+extern FEX_DEFAULT_VISIBILITY X86InstInfo X87Ops[MAX_X87_TABLE_SIZE];
+extern FEX_DEFAULT_VISIBILITY X86InstInfo DDDNowOps[MAX_3DNOW_TABLE_SIZE];
+extern FEX_DEFAULT_VISIBILITY X86InstInfo H0F38TableOps[MAX_0F_38_TABLE_SIZE];
+extern FEX_DEFAULT_VISIBILITY X86InstInfo H0F3ATableOps[MAX_0F_3A_TABLE_SIZE];
 
 // VEX
-extern __attribute__((visibility("default"))) X86InstInfo VEXTableOps[MAX_VEX_TABLE_SIZE];
-extern __attribute__((visibility("default"))) X86InstInfo VEXTableGroupOps[MAX_VEX_GROUP_TABLE_SIZE];
+extern FEX_DEFAULT_VISIBILITY X86InstInfo VEXTableOps[MAX_VEX_TABLE_SIZE];
+extern FEX_DEFAULT_VISIBILITY X86InstInfo VEXTableGroupOps[MAX_VEX_GROUP_TABLE_SIZE];
 
 // XOP
-extern __attribute__((visibility("default"))) X86InstInfo XOPTableOps[MAX_XOP_TABLE_SIZE];
-extern __attribute__((visibility("default"))) X86InstInfo XOPTableGroupOps[MAX_XOP_GROUP_TABLE_SIZE];
+extern FEX_DEFAULT_VISIBILITY X86InstInfo XOPTableOps[MAX_XOP_TABLE_SIZE];
+extern FEX_DEFAULT_VISIBILITY X86InstInfo XOPTableGroupOps[MAX_XOP_GROUP_TABLE_SIZE];
 
 // EVEX
-extern __attribute__((visibility("default"))) X86InstInfo EVEXTableOps[MAX_EVEX_TABLE_SIZE];
+extern FEX_DEFAULT_VISIBILITY X86InstInfo EVEXTableOps[MAX_EVEX_TABLE_SIZE];
 
-__attribute__((visibility("default"))) void InitializeInfoTables(Context::OperatingMode Mode);
+FEX_DEFAULT_VISIBILITY void InitializeInfoTables(Context::OperatingMode Mode);
 }

--- a/External/FEXCore/include/FEXCore/IR/IR.h
+++ b/External/FEXCore/include/FEXCore/IR/IR.h
@@ -1,8 +1,11 @@
 #pragma once
+
+#include <FEXCore/Utils/CompilerDefs.h>
+
 #include <array>
 #include <cassert>
 #include <cstdint>
-#include <string.h>
+#include <cstring>
 #include <sstream>
 #include <tuple>
 
@@ -459,8 +462,8 @@ public:
 class IRListView;
 class IREmitter;
 
-__attribute__((visibility("default"))) void Dump(std::stringstream *out, IRListView const* IR, IR::RegisterAllocationData *RAData);
-__attribute__((visibility("default"))) IREmitter* Parse(std::istream *in);
+FEX_DEFAULT_VISIBILITY void Dump(std::stringstream *out, IRListView const* IR, IR::RegisterAllocationData *RAData);
+FEX_DEFAULT_VISIBILITY IREmitter* Parse(std::istream *in);
 
 template<typename Type>
 inline uint32_t NodeWrapperBase<Type>::ID() const { return NodeOffset / sizeof(IR::OrderedNode); }

--- a/External/FEXCore/include/FEXCore/Utils/Allocator.h
+++ b/External/FEXCore/include/FEXCore/Utils/Allocator.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <FEXCore/Utils/CompilerDefs.h>
+
 #include <cstdint>
 #include <functional>
 
@@ -11,11 +13,11 @@ namespace FEXCore::Allocator {
   using REALLOC_Hook = void*(*)(void*, size_t);
   using FREE_Hook = void(*)(void*);
 
-  __attribute__((visibility("default"))) extern MMAP_Hook mmap;
-  __attribute__((visibility("default"))) extern MUNMAP_Hook munmap;
-  __attribute__((visibility("default"))) extern MALLOC_Hook malloc;
-  __attribute__((visibility("default"))) extern REALLOC_Hook realloc;
-  __attribute__((visibility("default"))) extern FREE_Hook free;
+  FEX_DEFAULT_VISIBILITY extern MMAP_Hook mmap;
+  FEX_DEFAULT_VISIBILITY extern MUNMAP_Hook munmap;
+  FEX_DEFAULT_VISIBILITY extern MALLOC_Hook malloc;
+  FEX_DEFAULT_VISIBILITY extern REALLOC_Hook realloc;
+  FEX_DEFAULT_VISIBILITY extern FREE_Hook free;
 
   void SetupHooks();
 }

--- a/External/FEXCore/include/FEXCore/Utils/CompilerDefs.h
+++ b/External/FEXCore/include/FEXCore/Utils/CompilerDefs.h
@@ -1,0 +1,21 @@
+#pragma once
+
+// Contains general abstractions related to compilers used to build FEX.
+
+// Specifies the minimum alignment for a variable or structure field, measured in bytes.
+#define FEX_ALIGNED(alignment) __attribute__((aligned(alignment)))
+
+// Allows annotating declarations with extra information.
+#define FEX_ANNOTATE(annotation_str) __attribute__((annotate(annotation_str)))
+
+// Makes the attributed entity have the default DSO visibility level.
+// Compiler options can affect the visibility of symbols. This attribute
+// overrides said changes. This gives entities external linkage.
+#define FEX_DEFAULT_VISIBILITY __attribute__((visibility("default")))
+
+// Indicates that the specified function doesn't need a function prologue/epilogue.
+// emitted for it by the compiler.
+#define FEX_NAKED __attribute__((naked))
+
+// Specifies that a structure member or structure itself should have the smallest possible alignment.
+#define FEX_PACKED __attribute__((packed))

--- a/External/FEXCore/include/FEXCore/Utils/ELFSymbolDatabase.h
+++ b/External/FEXCore/include/FEXCore/Utils/ELFSymbolDatabase.h
@@ -1,10 +1,13 @@
 #pragma once
-#include "ELFContainer.h"
-#include <vector>
+
+#include <FEXCore/Utils/CompilerDefs.h>
+#include <FEXCore/Utils/ELFContainer.h>
+
 #include <unordered_map>
+#include <vector>
 
 namespace ELFLoader {
-class __attribute__((visibility("default"))) ELFSymbolDatabase final {
+class FEX_DEFAULT_VISIBILITY ELFSymbolDatabase final {
 public:
   ELFSymbolDatabase(::ELFLoader::ELFContainer *file);
   ~ELFSymbolDatabase();

--- a/External/FEXCore/include/FEXCore/Utils/LogManager.h
+++ b/External/FEXCore/include/FEXCore/Utils/LogManager.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <FEXCore/Utils/CompilerDefs.h>
+
 #include <functional>
 #include <cstdarg>
 #include <sstream>
@@ -21,8 +23,8 @@ constexpr DebugLevels MSG_LEVEL = INFO;
 
 namespace Throw {
 using ThrowHandler = void(*)(char const *Message);
-__attribute__((visibility("default"))) void InstallHandler(ThrowHandler Handler);
-__attribute__((visibility("default"))) void UnInstallHandlers();
+FEX_DEFAULT_VISIBILITY void InstallHandler(ThrowHandler Handler);
+FEX_DEFAULT_VISIBILITY void UnInstallHandlers();
 
 [[noreturn]] void M(const char *fmt, va_list args);
 
@@ -63,10 +65,10 @@ static inline void AFmt(bool, const char*, ...) {}
 
 namespace Msg {
 using MsgHandler = void(*)(DebugLevels Level, char const *Message);
-__attribute__((visibility("default"))) void InstallHandler(MsgHandler Handler);
-__attribute__((visibility("default"))) void UnInstallHandlers();
+FEX_DEFAULT_VISIBILITY void InstallHandler(MsgHandler Handler);
+FEX_DEFAULT_VISIBILITY void UnInstallHandlers();
 
-__attribute__((visibility("default"))) void M(DebugLevels Level, const char *fmt, va_list args);
+FEX_DEFAULT_VISIBILITY void M(DebugLevels Level, const char *fmt, va_list args);
 
 #if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
 static inline void A(const char *fmt, ...) {
@@ -140,7 +142,7 @@ static inline void ERR(const char *fmt, ...) {
 
 // Fmt-capable interface.
 
-__attribute__((visibility("default"))) void MFmtImpl(DebugLevels level, const char* fmt, const fmt::format_args& args);
+FEX_DEFAULT_VISIBILITY void MFmtImpl(DebugLevels level, const char* fmt, const fmt::format_args& args);
 
 template <typename... Args>
 static inline void MFmt(DebugLevels level, const char* fmt, const Args&... args) {

--- a/Source/Tests/HarnessHelpers.h
+++ b/Source/Tests/HarnessHelpers.h
@@ -1,8 +1,8 @@
 #pragma once
+
 #include "Common/Config.h"
 #include "Common/MathUtils.h"
 
-#include <FEXCore/Core/CodeLoader.h>
 #include <array>
 #include <bitset>
 #include <cassert>
@@ -10,13 +10,15 @@
 #include <fstream>
 #include <sys/mman.h>
 #include <vector>
+
 #include <FEXCore/Core/CodeLoader.h>
 #include <FEXCore/Core/CoreState.h>
 #include <FEXCore/Core/X86Enums.h>
 #include <FEXCore/Utils/Allocator.h>
-#include <FEXCore/Utils/LogManager.h>
+#include <FEXCore/Utils/CompilerDefs.h>
 #include <FEXCore/Utils/ELFContainer.h>
 #include <FEXCore/Utils/ELFSymbolDatabase.h>
+#include <FEXCore/Utils/LogManager.h>
 
 namespace FEX::HarnessHelper {
   inline bool CompareStates(FEXCore::Core::CPUState const& State1,
@@ -306,24 +308,24 @@ namespace FEX::HarnessHelper {
       uint32_t OptionMemDataOffset;
       uint32_t OptionMemDataCount;
       uint8_t  AdditionalData[];
-    }__attribute__((packed));
+    } FEX_PACKED;
 
     struct MemoryRegionBase {
       uint64_t Region;
       uint64_t Size;
-    } __attribute__((packed));
+    } FEX_PACKED;
 
     struct RegDataStructBase {
       uint32_t RegDataCount;
       uint64_t RegKey;
       uint64_t RegValues[];
-    } __attribute__((packed));
+    } FEX_PACKED;
 
     struct MemDataStructBase {
       uint64_t address;
       uint32_t length;
       uint8_t data[];
-    } __attribute__((packed));
+    } FEX_PACKED;
 
     std::vector<char> RawConfigFile;
     ConfigStructBase BaseConfig;

--- a/Source/Tests/LinuxSyscalls/Syscalls.h
+++ b/Source/Tests/LinuxSyscalls/Syscalls.h
@@ -13,6 +13,7 @@ $end_info$
 
 #include <FEXCore/Config/Config.h>
 #include <FEXCore/HLE/SyscallHandler.h>
+#include <FEXCore/Utils/CompilerDefs.h>
 
 #include <atomic>
 #include <condition_variable>
@@ -240,7 +241,7 @@ struct FunctionToLambda<R(*)(Args...) noexcept> {
 	}
 };
 
-struct __attribute__((packed)) epoll_event_x86 {
+struct FEX_PACKED epoll_event_x86 {
   uint32_t events;
   epoll_data_t data;
 

--- a/Source/Tests/LinuxSyscalls/x32/Ioctl/drm.h
+++ b/Source/Tests/LinuxSyscalls/x32/Ioctl/drm.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <FEXCore/Utils/CompilerDefs.h>
+
 #include "Tests/LinuxSyscalls/x32/Types.h"
 #include "Tests/LinuxSyscalls/x32/Ioctl/HelperDefines.h"
 
@@ -20,8 +22,8 @@ namespace FEX::HLE::x32 {
 
 namespace DRM {
 struct
-__attribute__((annotate("alias-x86_32-drm_version")))
-__attribute__((annotate("fex-match")))
+FEX_ANNOTATE("alias-x86_32-drm_version")
+FEX_ANNOTATE("fex-match")
 fex_drm_version {
 	int version_major;	  /**< Major version */
 	int version_minor;	  /**< Minor version */
@@ -66,8 +68,8 @@ fex_drm_version {
 };
 
 struct
-__attribute__((annotate("alias-x86_32-drm_unique")))
-__attribute__((annotate("fex-match")))
+FEX_ANNOTATE("alias-x86_32-drm_unique")
+FEX_ANNOTATE("fex-match")
 fex_drm_unique {
 	compat_size_t unique_len;
 	compat_ptr<char> unique;
@@ -88,8 +90,8 @@ fex_drm_unique {
 };
 
 struct
-__attribute__((annotate("alias-x86_32-drm_map")))
-__attribute__((annotate("fex-match")))
+FEX_ANNOTATE("alias-x86_32-drm_map")
+FEX_ANNOTATE("fex-match")
 fex_drm_map {
 	uint32_t offset;
 	uint32_t size;
@@ -122,8 +124,8 @@ fex_drm_map {
 };
 
 struct
-__attribute__((annotate("alias-x86_32-drm_client")))
-__attribute__((annotate("fex-match")))
+FEX_ANNOTATE("alias-x86_32-drm_client")
+FEX_ANNOTATE("fex-match")
 fex_drm_client {
 	int32_t idx;
 	int32_t auth;
@@ -156,8 +158,8 @@ fex_drm_client {
 };
 
 struct
-__attribute__((annotate("alias-x86_32-drm_stats")))
-__attribute__((annotate("fex-match")))
+FEX_ANNOTATE("alias-x86_32-drm_stats")
+FEX_ANNOTATE("fex-match")
 fex_drm_stats {
 	uint32_t count;
 	struct {
@@ -187,8 +189,8 @@ fex_drm_stats {
 };
 
 struct
-__attribute__((annotate("alias-x86_32-drm_buf_desc")))
-__attribute__((annotate("fex-match")))
+FEX_ANNOTATE("alias-x86_32-drm_buf_desc")
+FEX_ANNOTATE("fex-match")
 fex_drm_buf_desc {
 	int32_t count;
   int32_t size;
@@ -225,8 +227,8 @@ fex_drm_buf_desc {
 };
 
 struct
-__attribute__((annotate("alias-x86_32-drm_buf_info")))
-__attribute__((annotate("fex-match")))
+FEX_ANNOTATE("alias-x86_32-drm_buf_info")
+FEX_ANNOTATE("fex-match")
 fex_drm_buf_info {
 	int32_t count;
 	compat_ptr<struct drm_buf_desc> list;
@@ -247,8 +249,8 @@ fex_drm_buf_info {
 };
 
 struct
-__attribute__((annotate("alias-x86_32-drm_buf_pub")))
-__attribute__((annotate("fex-match")))
+FEX_ANNOTATE("alias-x86_32-drm_buf_pub")
+FEX_ANNOTATE("fex-match")
 fex_drm_buf_pub {
 	int32_t idx;
 	int32_t total;
@@ -275,8 +277,8 @@ fex_drm_buf_pub {
 };
 
 struct
-__attribute__((annotate("alias-x86_32-drm_buf_map")))
-__attribute__((annotate("fex-match")))
+FEX_ANNOTATE("alias-x86_32-drm_buf_map")
+FEX_ANNOTATE("fex-match")
 fex_drm_buf_map {
 	int32_t count;
 #ifdef __cplusplus
@@ -313,8 +315,8 @@ fex_drm_buf_map {
 };
 
 struct
-__attribute__((annotate("alias-x86_32-drm_buf_free")))
-__attribute__((annotate("fex-match")))
+FEX_ANNOTATE("alias-x86_32-drm_buf_free")
+FEX_ANNOTATE("fex-match")
 fex_drm_buf_free {
 	int32_t count;
 	compat_ptr<int> list;
@@ -335,8 +337,8 @@ fex_drm_buf_free {
 };
 
 struct
-__attribute__((annotate("alias-x86_32-drm_ctx_priv_map")))
-__attribute__((annotate("fex-match")))
+FEX_ANNOTATE("alias-x86_32-drm_ctx_priv_map")
+FEX_ANNOTATE("fex-match")
 fex_drm_ctx_priv_map {
 	uint32_t ctx_id;
 	compat_ptr<void> handle;
@@ -357,8 +359,8 @@ fex_drm_ctx_priv_map {
 };
 
 struct
-__attribute__((annotate("alias-x86_32-drm_ctx_res")))
-__attribute__((annotate("fex-match")))
+FEX_ANNOTATE("alias-x86_32-drm_ctx_res")
+FEX_ANNOTATE("fex-match")
 fex_drm_ctx_res {
 	int32_t count;
 	compat_ptr<struct drm_ctx> contexts;
@@ -378,8 +380,8 @@ fex_drm_ctx_res {
 };
 
 struct
-__attribute__((annotate("alias-x86_32-drm_dma")))
-__attribute__((annotate("fex-match")))
+FEX_ANNOTATE("alias-x86_32-drm_dma")
+FEX_ANNOTATE("fex-match")
 fex_drm_dma {
 	int32_t context;
 	int32_t send_count;
@@ -424,8 +426,8 @@ fex_drm_dma {
 };
 
 struct
-__attribute__((annotate("alias-x86_32-drm_scatter_gather")))
-__attribute__((annotate("fex-match")))
+FEX_ANNOTATE("alias-x86_32-drm_scatter_gather")
+FEX_ANNOTATE("fex-match")
 fex_drm_scatter_gather {
 	uint32_t size;
 	uint32_t handle;
@@ -446,8 +448,8 @@ fex_drm_scatter_gather {
 };
 
 struct
-__attribute__((annotate("alias-x86_32-drm_wait_vblank_request")))
-__attribute__((annotate("fex-match")))
+FEX_ANNOTATE("alias-x86_32-drm_wait_vblank_request")
+FEX_ANNOTATE("fex-match")
 fex_drm_wait_vblank_request {
 	enum drm_vblank_seq_type type;
 	uint32_t sequence;
@@ -471,8 +473,8 @@ fex_drm_wait_vblank_request {
 };
 
 struct
-__attribute__((annotate("alias-x86_32-drm_wait_vblank_reply")))
-__attribute__((annotate("fex-match")))
+FEX_ANNOTATE("alias-x86_32-drm_wait_vblank_reply")
+FEX_ANNOTATE("fex-match")
 fex_drm_wait_vblank_reply {
 	enum drm_vblank_seq_type type;
 	uint32_t sequence;
@@ -499,8 +501,8 @@ fex_drm_wait_vblank_reply {
 };
 
 union
-__attribute__((annotate("alias-x86_32-drm_wait_vblank")))
-__attribute__((annotate("fex-match")))
+FEX_ANNOTATE("alias-x86_32-drm_wait_vblank")
+FEX_ANNOTATE("fex-match")
 fex_drm_wait_vblank {
 	fex_drm_wait_vblank_request request;
 	fex_drm_wait_vblank_reply reply;
@@ -509,9 +511,9 @@ fex_drm_wait_vblank {
 };
 
 struct
-__attribute__((annotate("alias-x86_32-drm_update_draw")))
-__attribute__((annotate("fex-match")))
-__attribute__((packed))
+FEX_ANNOTATE("alias-x86_32-drm_update_draw")
+FEX_ANNOTATE("fex-match")
+FEX_PACKED
 fex_drm_update_draw {
 	drm_drawable_t handle;
 	uint32_t type;
@@ -538,9 +540,9 @@ fex_drm_update_draw {
 };
 
 struct
-__attribute__((annotate("alias-x86_32-drm_mode_get_plane_res")))
-__attribute__((annotate("fex-match")))
-__attribute__((packed))
+FEX_ANNOTATE("alias-x86_32-drm_mode_get_plane_res")
+FEX_ANNOTATE("fex-match")
+FEX_PACKED
 fex_drm_mode_get_plane_res {
 	compat_uint64_t plane_id_ptr;
 	uint32_t count_planes;
@@ -560,9 +562,9 @@ fex_drm_mode_get_plane_res {
 };
 
 struct
-__attribute__((annotate("alias-x86_32-drm_mode_fb_cmd2")))
-__attribute__((annotate("fex-match")))
-__attribute__((packed))
+FEX_ANNOTATE("alias-x86_32-drm_mode_fb_cmd2")
+FEX_ANNOTATE("fex-match")
+FEX_PACKED
 fex_drm_mode_fb_cmd2 {
 	uint32_t fb_id;
 	uint32_t width;
@@ -608,9 +610,9 @@ fex_drm_mode_fb_cmd2 {
 };
 
 struct
-__attribute__((annotate("alias-x86_32-drm_mode_obj_get_properties")))
-__attribute__((annotate("fex-match")))
-__attribute__((packed))
+FEX_ANNOTATE("alias-x86_32-drm_mode_obj_get_properties")
+FEX_ANNOTATE("fex-match")
+FEX_PACKED
 fex_drm_mode_obj_get_properties {
 	compat_uint64_t props_ptr;
 	compat_uint64_t prop_values_ptr;
@@ -639,9 +641,9 @@ fex_drm_mode_obj_get_properties {
 };
 
 struct
-__attribute__((annotate("alias-x86_32-drm_mode_obj_set_property")))
-__attribute__((annotate("fex-match")))
-__attribute__((packed))
+FEX_ANNOTATE("alias-x86_32-drm_mode_obj_set_property")
+FEX_ANNOTATE("fex-match")
+FEX_PACKED
 fex_drm_mode_obj_set_property {
 	compat_uint64_t value;
 	uint32_t prop_id;
@@ -671,8 +673,8 @@ fex_drm_mode_obj_set_property {
 
 namespace AMDGPU {
 struct
-__attribute__((annotate("alias-x86_32-drm_amdgpu_gem_metadata")))
-__attribute__((annotate("fex-match")))
+FEX_ANNOTATE("alias-x86_32-drm_amdgpu_gem_metadata")
+FEX_ANNOTATE("fex-match")
 fex_drm_amdgpu_gem_metadata {
 	__u32	handle;
 	__u32	op;
@@ -708,8 +710,8 @@ fex_drm_amdgpu_gem_metadata {
 
 namespace MSM {
 struct
-__attribute__((annotate("alias-x86_32-drm_msm_timespec")))
-__attribute__((annotate("fex-match")))
+FEX_ANNOTATE("alias-x86_32-drm_msm_timespec")
+FEX_ANNOTATE("fex-match")
 fex_drm_msm_timespec {
 	compat_int64_t tv_sec;
 	compat_int64_t tv_nsec;
@@ -729,9 +731,9 @@ fex_drm_msm_timespec {
 };
 
 struct
-__attribute__((annotate("alias-x86_32-drm_msm_wait_fence")))
-__attribute__((annotate("fex-match")))
-__attribute__((packed))
+FEX_ANNOTATE("alias-x86_32-drm_msm_wait_fence")
+FEX_ANNOTATE("fex-match")
+FEX_PACKED
 fex_drm_msm_wait_fence {
 	uint32_t fence;
 	uint32_t pad;
@@ -762,8 +764,8 @@ fex_drm_msm_wait_fence {
 namespace I915 {
 
 struct
-__attribute__((annotate("alias-x86_32-drm_i915_batchbuffer")))
-__attribute__((annotate("fex-match")))
+FEX_ANNOTATE("alias-x86_32-drm_i915_batchbuffer")
+FEX_ANNOTATE("fex-match")
 fex_drm_i915_batchbuffer_t {
 	int32_t start;
 	int32_t used;
@@ -796,8 +798,8 @@ fex_drm_i915_batchbuffer_t {
 };
 
 struct
-__attribute__((annotate("alias-x86_32-drm_i915_irq_emit")))
-__attribute__((annotate("fex-match")))
+FEX_ANNOTATE("alias-x86_32-drm_i915_irq_emit")
+FEX_ANNOTATE("fex-match")
 fex_drm_i915_irq_emit_t {
 	compat_ptr<int> irq_seq;
 
@@ -815,8 +817,8 @@ fex_drm_i915_irq_emit_t {
 };
 
 struct
-__attribute__((annotate("alias-x86_32-drm_i915_getparam")))
-__attribute__((annotate("fex-match")))
+FEX_ANNOTATE("alias-x86_32-drm_i915_getparam")
+FEX_ANNOTATE("fex-match")
 fex_drm_i915_getparam_t
 {
 	int32_t param;
@@ -837,8 +839,8 @@ fex_drm_i915_getparam_t
 };
 
 struct
-__attribute__((annotate("alias-x86_32-drm_i915_mem_alloc")))
-__attribute__((annotate("fex-match")))
+FEX_ANNOTATE("alias-x86_32-drm_i915_mem_alloc")
+FEX_ANNOTATE("fex-match")
 fex_drm_i915_mem_alloc_t
 {
 	int32_t region;
@@ -865,8 +867,8 @@ fex_drm_i915_mem_alloc_t
 };
 
 struct
-__attribute__((annotate("alias-x86_32-_drm_i915_cmdbuffer")))
-__attribute__((annotate("fex-match")))
+FEX_ANNOTATE("alias-x86_32-_drm_i915_cmdbuffer")
+FEX_ANNOTATE("fex-match")
 fex_drm_i915_cmdbuffer_t
 {
 	compat_ptr<char> buf;

--- a/Source/Tests/LinuxSyscalls/x32/Types.h
+++ b/Source/Tests/LinuxSyscalls/x32/Types.h
@@ -7,6 +7,7 @@ $end_info$
 #pragma once
 
 #include <FEXCore/Core/SignalDelegator.h>
+#include <FEXCore/Utils/CompilerDefs.h>
 
 #include <bits/types/stack_t.h>
 #include <cstdint>
@@ -38,8 +39,8 @@ using compat_uid_t = uint16_t;
 using compat_gid_t = uint16_t;
 
 // Can't use using with aligned attributes, clang doesn't honour it
-typedef __attribute__((aligned(4))) uint64_t compat_uint64_t;
-typedef __attribute__((aligned(4))) int64_t compat_int64_t;
+typedef FEX_ALIGNED(4) uint64_t compat_uint64_t;
+typedef FEX_ALIGNED(4) int64_t compat_int64_t;
 
 template<typename T>
 class compat_ptr {
@@ -102,8 +103,8 @@ static_assert(sizeof(compat_ptr<void>) == 4, "Incorrect size");
  * @{ */
 
 struct
-__attribute__((annotate("alias-x86_32-timespec")))
-__attribute__((annotate("fex-match")))
+FEX_ANNOTATE("alias-x86_32-timespec")
+FEX_ANNOTATE("fex-match")
 timespec32 {
   int32_t tv_sec;
   int32_t tv_nsec;
@@ -135,8 +136,8 @@ static_assert(sizeof(timespec32) == 8, "Incorrect size");
  * @{ */
 
 struct
-__attribute__((annotate("alias-x86_32-timeval")))
-__attribute__((annotate("fex-match")))
+FEX_ANNOTATE("alias-x86_32-timeval")
+FEX_ANNOTATE("fex-match")
 timeval32 {
   int32_t tv_sec;
   int32_t tv_usec;
@@ -168,8 +169,8 @@ static_assert(sizeof(timeval32) == 8, "Incorrect size");
  * @{ */
 
 struct
-__attribute__((annotate("alias-x86_32-iovec")))
-__attribute__((annotate("fex-match")))
+FEX_ANNOTATE("alias-x86_32-iovec")
+FEX_ANNOTATE("fex-match")
 iovec32 {
   uint32_t iov_base;
   uint32_t iov_len;
@@ -194,8 +195,8 @@ static_assert(sizeof(iovec32) == 8, "Incorrect size");
 /**  @} */
 
 struct
-__attribute__((annotate("alias-x86_32-cmsghdr")))
-__attribute__((annotate("fex-match")))
+FEX_ANNOTATE("alias-x86_32-cmsghdr")
+FEX_ANNOTATE("fex-match")
 cmsghdr32 {
   uint32_t cmsg_len;
   int32_t cmsg_level;
@@ -207,8 +208,8 @@ static_assert(std::is_trivial<cmsghdr32>::value, "Needs to be trivial");
 static_assert(sizeof(cmsghdr32) == 12, "Incorrect size");
 
 struct
-__attribute__((annotate("alias-x86_32-msghdr")))
-__attribute__((annotate("fex-match")))
+FEX_ANNOTATE("alias-x86_32-msghdr")
+FEX_ANNOTATE("fex-match")
 msghdr32 {
   compat_ptr<void> msg_name;
   socklen_t msg_namelen;
@@ -225,8 +226,8 @@ static_assert(std::is_trivial<msghdr32>::value, "Needs to be trivial");
 static_assert(sizeof(msghdr32) == 28, "Incorrect size");
 
 struct
-__attribute__((annotate("alias-x86_32-mmsghdr")))
-__attribute__((annotate("fex-match")))
+FEX_ANNOTATE("alias-x86_32-mmsghdr")
+FEX_ANNOTATE("fex-match")
 mmsghdr_32 {
   msghdr32 msg_hdr;
   uint32_t msg_len;
@@ -236,8 +237,8 @@ static_assert(std::is_trivial<mmsghdr_32>::value, "Needs to be trivial");
 static_assert(sizeof(mmsghdr_32) == 32, "Incorrect size");
 
 struct
-__attribute__((annotate("alias-x86_32-stack_t")))
-__attribute__((annotate("fex-match")))
+FEX_ANNOTATE("alias-x86_32-stack_t")
+FEX_ANNOTATE("fex-match")
 stack_t32 {
   compat_ptr<void> ss_sp;
   compat_size_t ss_size;
@@ -266,7 +267,7 @@ static_assert(sizeof(stack_t32) == 12, "Incorrect size");
 struct
 // This does not match the glibc implementation of stat
 // Matches the definition of `struct compat_stat` in `arch/x86/include/asm/compat.h`
-__attribute__((annotate("fex-match")))
+FEX_ANNOTATE("fex-match")
 stat32 {
   compat_dev_t st_dev;
   uint16_t __pad1;
@@ -325,8 +326,8 @@ static_assert(sizeof(stat32) == 64, "Incorrect size");
 struct
 // This does not match the glibc implementation of stat
 // Matches the definition of `struct stat64` in `x86_64-linux-gnu/asm/stat.h`
-__attribute__((annotate("fex-match")))
-__attribute__((packed))
+FEX_ANNOTATE("fex-match")
+FEX_PACKED
 stat64_32 {
   compat_uint64_t st_dev;
   uint8_t  __pad0[4];
@@ -413,9 +414,10 @@ static_assert(std::is_trivial<stat64_32>::value, "Needs to be trivial");
 static_assert(sizeof(stat64_32) == 96, "Incorrect size");
 
 struct
-__attribute__((packed,aligned(4)))
-__attribute__((annotate("alias-x86_32-statfs64")))
-__attribute__((annotate("fex-match")))
+FEX_PACKED
+FEX_ALIGNED(4)
+FEX_ANNOTATE("alias-x86_32-statfs64")
+FEX_ANNOTATE("fex-match")
 statfs64_32 {
   uint32_t f_type;
   uint32_t f_bsize;
@@ -470,8 +472,8 @@ static_assert(std::is_trivial<statfs64_32>::value, "Needs to be trivial");
 static_assert(sizeof(statfs64_32) == 84, "Incorrect size");
 
 struct
-__attribute__((annotate("alias-x86_32-flock")))
-__attribute__((annotate("fex-match")))
+FEX_ANNOTATE("alias-x86_32-flock")
+FEX_ANNOTATE("fex-match")
 flock_32 {
   int16_t l_type;
   int16_t l_whence;
@@ -507,8 +509,8 @@ static_assert(sizeof(flock_32) == 16, "Incorrect size");
 // This does not match glibc flock64 definition
 // Matches the definition of `struct compat_flock64` in `arch/x86/include/asm/compat.h`
 struct
-__attribute__((annotate("fex-match")))
-__attribute__((packed))
+FEX_ANNOTATE("fex-match")
+FEX_PACKED
 flock64_32 {
   int16_t l_type;
   int16_t l_whence;
@@ -542,7 +544,7 @@ static_assert(sizeof(flock64_32) == 24, "Incorrect size");
 // There is no public definition of this struct
 // Matches the definition of `struct linux_dirent` in fs/readdir.c
 struct
-__attribute__((annotate("fex-match")))
+FEX_ANNOTATE("fex-match")
 linux_dirent {
   uint64_t d_ino;
   int64_t  d_off;
@@ -556,7 +558,7 @@ static_assert(sizeof(linux_dirent) == 24, "Incorrect size");
 // There is no public definition of this struct
 // Matches the definition of `struct compat_linux_dirent` in fs/readdir.c
 struct
-__attribute__((annotate("fex-match")))
+FEX_ANNOTATE("fex-match")
 linux_dirent_32 {
   compat_ulong_t d_ino;
   compat_ulong_t d_off;
@@ -570,7 +572,7 @@ static_assert(sizeof(linux_dirent_32) == 12, "Incorrect size");
 // There is no public definition of this struct
 // Matches the definition of `struct linux_dirent64` in include/linux/dirent.h
 struct
-__attribute__((annotate("fex-match")))
+FEX_ANNOTATE("fex-match")
 linux_dirent_64 {
   uint64_t d_ino;
   uint64_t d_off;
@@ -585,7 +587,7 @@ static_assert(sizeof(linux_dirent_64) == 24, "Incorrect size");
 // There is no public definition of this struct
 // Matches `struct compat_sigset_argpack`
 struct
-__attribute__((annotate("fex-match")))
+FEX_ANNOTATE("fex-match")
 sigset_argpack32 {
   compat_ptr<uint64_t> sigset;
   compat_size_t size;
@@ -595,8 +597,8 @@ static_assert(std::is_trivial<sigset_argpack32>::value, "Needs to be trivial");
 static_assert(sizeof(sigset_argpack32) == 8, "Incorrect size");
 
 struct
-__attribute__((annotate("alias-x86_32-rusage")))
-__attribute__((annotate("fex-match")))
+FEX_ANNOTATE("alias-x86_32-rusage")
+FEX_ANNOTATE("fex-match")
 rusage_32 {
   timeval32 ru_utime;
   timeval32 ru_stime;
@@ -707,8 +709,8 @@ static_assert(sizeof(rusage_32) == 72, "Incorrect size");
 // This is for rt_sigaction
 // Matches the definition for `struct compat_sigaction` in `include/linux/compat.h`
 struct
-__attribute__((packed))
-__attribute__((annotate("fex-match")))
+FEX_PACKED
+FEX_ANNOTATE("fex-match")
 GuestSigAction_32 {
   FEX::HLE::x32::compat_ptr<void> handler_32;
 

--- a/Source/Tests/LinuxSyscalls/x64/FD.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/FD.cpp
@@ -6,7 +6,9 @@ $end_info$
 
 #include "Tests/LinuxSyscalls/Syscalls.h"
 #include "Tests/LinuxSyscalls/x64/Syscalls.h"
+
 #include <FEXCore/Core/Context.h>
+#include <FEXCore/Utils/CompilerDefs.h>
 
 #include <fcntl.h>
 #include <sys/time.h>
@@ -16,7 +18,7 @@ $end_info$
 #include <unistd.h>
 
 namespace FEX::HLE::x64 {
-  struct __attribute__((packed)) guest_stat {
+  struct FEX_PACKED guest_stat {
     __kernel_ulong_t  st_dev;
     __kernel_ulong_t  st_ino;
     __kernel_ulong_t  st_nlink;


### PR DESCRIPTION
Puts a layer of separation around compiler specifics (and also makes them nicer to write).