### PR TITLE
General: Place more compiler specifics into CompilerDefs.h

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
@@ -5,6 +5,7 @@
 #include "Interface/Context/Context.h"
 
 #include <FEXCore/Core/X86Enums.h>
+#include <bit>
 #include <cmath>
 
 #include "aarch64/assembler-aarch64.h"
@@ -103,7 +104,7 @@ Arm64Dispatcher::Arm64Dispatcher(FEXCore::Context::Context *ctx, FEXCore::Core::
   ldr(x0, &l_PagePtr);
 
   // Mask the address by the virtual address size so we can check for aliases
-  if (__builtin_popcountl(VirtualMemorySize) == 1) {
+  if (std::popcount(VirtualMemorySize) == 1) {
     and_(x3, RipReg, Thread->LookupCache->GetVirtualMemorySize() - 1);
   }
   else {

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -1867,7 +1867,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
           case IR::OP_POPCOUNT: {
             auto Op = IROp->C<IR::IROp_Popcount>();
             uint64_t Src = *GetSrc<uint64_t*>(SSAData, Op->Header.Args[0]);
-            GD = __builtin_popcountl(Src);
+            GD = std::popcount(Src);
             break;
           }
           case IR::OP_FINDLSB: {
@@ -1880,10 +1880,10 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
           case IR::OP_FINDMSB: {
             auto Op = IROp->C<IR::IROp_FindMSB>();
             switch (OpSize) {
-              case 1: GD = ((24 + OpSize * 8) - __builtin_clz(*GetSrc<uint8_t*>(SSAData, Op->Header.Args[0]))) - 1; break;
-              case 2: GD = ((16 + OpSize * 8) - __builtin_clz(*GetSrc<uint16_t*>(SSAData, Op->Header.Args[0]))) - 1; break;
-              case 4: GD = (OpSize * 8 - __builtin_clz(*GetSrc<uint32_t*>(SSAData, Op->Header.Args[0]))) - 1; break;
-              case 8: GD = (OpSize * 8 - __builtin_clzll(*GetSrc<uint64_t*>(SSAData, Op->Header.Args[0]))) - 1; break;
+              case 1: GD = (OpSize * 8 - std::countl_zero(*GetSrc<uint8_t*>(SSAData, Op->Header.Args[0]))) - 1; break;
+              case 2: GD = (OpSize * 8 - std::countl_zero(*GetSrc<uint16_t*>(SSAData, Op->Header.Args[0]))) - 1; break;
+              case 4: GD = (OpSize * 8 - std::countl_zero(*GetSrc<uint32_t*>(SSAData, Op->Header.Args[0]))) - 1; break;
+              case 8: GD = (OpSize * 8 - std::countl_zero(*GetSrc<uint64_t*>(SSAData, Op->Header.Args[0]))) - 1; break;
               default: LOGMAN_MSG_A("Unknown REV size: %d", OpSize); break;
             }
             break;
@@ -1903,34 +1903,22 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (OpSize) {
               case 1: {
                 auto Src = *GetSrc<uint8_t*>(SSAData, Op->Header.Args[0]);
-                if (Src)
-                  GD = __builtin_ctz(Src);
-                else
-                  GD = sizeof(Src) * 8;
+                GD = std::countr_zero(Src);
                 break;
               }
               case 2: {
                 auto Src = *GetSrc<uint16_t*>(SSAData, Op->Header.Args[0]);
-                if (Src)
-                  GD = __builtin_ctz(Src);
-                else
-                  GD = sizeof(Src) * 8;
+                GD = std::countr_zero(Src);
                 break;
               }
               case 4: {
                 auto Src = *GetSrc<uint32_t*>(SSAData, Op->Header.Args[0]);
-                if (Src)
-                  GD = __builtin_ctz(Src);
-                else
-                  GD = sizeof(Src) * 8;
+                GD = std::countr_zero(Src);
                 break;
               }
               case 8: {
                 auto Src = *GetSrc<uint64_t*>(SSAData, Op->Header.Args[0]);
-                if (Src)
-                  GD = __builtin_ctzll(Src);
-                else
-                  GD = sizeof(Src) * 8;
+                GD = std::countr_zero(Src);
                 break;
               }
               default: LOGMAN_MSG_A("Unknown size: %d", OpSize); break;
@@ -1941,37 +1929,23 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             auto Op = IROp->C<IR::IROp_CountLeadingZeroes>();
             switch (OpSize) {
               case 1: {
-                uint32_t Src = *GetSrc<uint8_t*>(SSAData, Op->Header.Args[0]);
-                Src <<= 24;
-                if (Src)
-                  GD = __builtin_clz(Src);
-                else
-                  GD = 8;
+                auto Src = *GetSrc<uint8_t*>(SSAData, Op->Header.Args[0]);
+                GD = std::countl_zero(Src);
                 break;
               }
               case 2: {
-                uint32_t Src = *GetSrc<uint16_t*>(SSAData, Op->Header.Args[0]);
-                Src <<= 16;
-                if (Src)
-                  GD = __builtin_clz(Src);
-                else
-                  GD = 16;
+                auto Src = *GetSrc<uint16_t*>(SSAData, Op->Header.Args[0]);
+                GD = std::countl_zero(Src);
                 break;
               }
               case 4: {
                 auto Src = *GetSrc<uint32_t*>(SSAData, Op->Header.Args[0]);
-                if (Src)
-                  GD = __builtin_clz(Src);
-                else
-                  GD = sizeof(Src) * 8;
+                GD = std::countl_zero(Src);
                 break;
               }
               case 8: {
                 auto Src = *GetSrc<uint64_t*>(SSAData, Op->Header.Args[0]);
-                if (Src)
-                  GD = __builtin_clzll(Src);
-                else
-                  GD = sizeof(Src) * 8;
+                GD = std::countl_zero(Src);
                 break;
               }
               default: LOGMAN_MSG_A("Unknown size: %d", OpSize); break;

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -10,12 +10,13 @@
 #include "Interface/Core/DebugData.h"
 #include "Interface/Core/InternalThreadState.h"
 #include "Interface/Core/Interpreter/InterpreterClass.h"
-#include <FEXCore/Utils/LogManager.h>
 
 #include <FEXCore/Core/CPUBackend.h>
 #include <FEXCore/HLE/SyscallHandler.h>
 #include <FEXCore/IR/IR.h>
 #include <FEXCore/IR/IntrusiveIRList.h>
+#include <FEXCore/Utils/CompilerDefs.h>
+#include <FEXCore/Utils/LogManager.h>
 
 #include "Interface/HLE/Thunks/Thunks.h"
 
@@ -411,7 +412,7 @@ static void StopThread(FEXCore::Core::InternalThreadState *Thread) {
   Thread->CTX->StopThread(Thread);
 
   LOGMAN_MSG_A("unreachable");
-  __builtin_unreachable();
+  FEX_UNREACHABLE;
 }
 
 [[noreturn]]
@@ -419,7 +420,7 @@ static void SignalReturn(FEXCore::Core::InternalThreadState *Thread) {
   Thread->CTX->SignalThread(Thread, FEXCore::Core::SignalEvent::Return);
 
   LOGMAN_MSG_A("unreachable");
-  __builtin_unreachable();
+  FEX_UNREACHABLE;
 }
 
 template<IR::IROps Op>

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -23,6 +23,7 @@ $end_info$
 #include <FEXCore/Core/X86Enums.h>
 #include <FEXCore/Core/UContext.h>
 #include <FEXCore/Utils/Allocator.h>
+#include <FEXCore/Utils/CompilerDefs.h>
 #include "Interface/Core/Interpreter/InterpreterOps.h"
 
 #include <sys/mman.h>
@@ -594,7 +595,8 @@ aarch64::Register Arm64JITCore::GetReg<Arm64JITCore::RA_32>(uint32_t Node) const
   } else {
     LOGMAN_THROW_A(false, "Unexpected Class: %d", Reg.Class);
   }
-  __builtin_unreachable();
+
+  FEX_UNREACHABLE;
 }
 
 template<>
@@ -608,7 +610,8 @@ aarch64::Register Arm64JITCore::GetReg<Arm64JITCore::RA_64>(uint32_t Node) const
   } else {
     LOGMAN_THROW_A(false, "Unexpected Class: %d", Reg.Class);
   }
-  __builtin_unreachable();
+
+  FEX_UNREACHABLE;
 }
 
 template<>
@@ -633,7 +636,8 @@ aarch64::VRegister Arm64JITCore::GetSrc(uint32_t Node) const {
   } else {
     LOGMAN_THROW_A(false, "Unexpected Class: %d", Reg.Class);
   }
-  __builtin_unreachable();
+
+  FEX_UNREACHABLE;
 }
 
 aarch64::VRegister Arm64JITCore::GetDst(uint32_t Node) const {
@@ -646,7 +650,8 @@ aarch64::VRegister Arm64JITCore::GetDst(uint32_t Node) const {
   } else {
     LOGMAN_THROW_A(false, "Unexpected Class: %d", Reg.Class);
   }
-  __builtin_unreachable();
+
+  FEX_UNREACHABLE;
 }
 
 bool Arm64JITCore::IsInlineConstant(const IR::OrderedNodeWrapper& WNode, uint64_t* Value) const {

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -5,6 +5,7 @@ $end_info$
 */
 
 #include "Interface/Core/JIT/Arm64/JITClass.h"
+#include <FEXCore/Utils/CompilerDefs.h>
 
 namespace FEXCore::CPU {
 
@@ -554,7 +555,8 @@ MemOperand Arm64JITCore::GenerateMemOperand(uint8_t AccessSize, aarch64::Registe
       }
     }
   }
-  __builtin_unreachable();
+
+  FEX_UNREACHABLE;
 }
 
 DEF_OP(LoadMem) {

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -10,6 +10,7 @@ $end_info$
 #include "Interface/HLE/Thunks/Thunks.h"
 
 #include <FEXCore/Core/CoreState.h>
+#include <bit>
 #include <climits>
 #include <cstddef>
 #include <cstdint>
@@ -4266,7 +4267,7 @@ void OpDispatchBuilder::SHUFOp(OpcodeArgs) {
   // [63:0]   = Src1[Selection]
   // [127:64] = Src2[Selection]
   uint8_t SelectionMask = NumElements - 1;
-  uint8_t ShiftAmount = __builtin_popcount(SelectionMask);
+  uint8_t ShiftAmount = std::popcount(SelectionMask);
   for (uint8_t Element = 0; Element < NumElements; ++Element) {
     Dest = _VInsElement(Size, ElementSize, Element, Shuffle & SelectionMask, Dest, Srcs[Element]);
     Shuffle >>= ShiftAmount;

--- a/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -735,9 +735,9 @@ bool ConstProp::ConstantPropagation(IREmitter *IREmit, const IRListView& Current
         uint64_t NewConstant = (Constant1 * Constant2) & getMask(Op);
         IREmit->ReplaceWithConstant(CodeNode, NewConstant);
         Changed = true;
-      } else if (IREmit->IsValueConstant(Op->Header.Args[1], &Constant2) && __builtin_popcountl(Constant2) == 1) {
+      } else if (IREmit->IsValueConstant(Op->Header.Args[1], &Constant2) && std::popcount(Constant2) == 1) {
         if (IROp->Size == 4 || IROp->Size == 8) {
-          uint64_t amt = __builtin_ctzl(Constant2);
+          uint64_t amt = std::countr_zero(Constant2);
           IREmit->SetWriteCursor(CodeNode);
           auto shift = IREmit->_Lshl(CurrentIR.GetNode(Op->Header.Args[0]), IREmit->_Constant(amt));
           shift.first->Header.Size = IROp->Size; // force Lshl to be the same size as the original Mul

--- a/External/FEXCore/Source/Utils/LogManager.cpp
+++ b/External/FEXCore/Source/Utils/LogManager.cpp
@@ -37,7 +37,7 @@ void UnInstallHandlers() { Handlers.clear(); }
     Handler(Buffer);
   }
 
-  __builtin_trap();
+  FEX_TRAP_EXECUTION;
 }
 
 void MFmt(const char *fmt, const fmt::format_args& args) {
@@ -47,7 +47,7 @@ void MFmt(const char *fmt, const fmt::format_args& args) {
     Handler(msg.c_str());
   }
 
-  __builtin_trap();
+  FEX_TRAP_EXECUTION;
 }
 } // namespace Throw
 

--- a/External/FEXCore/include/FEXCore/Utils/CompilerDefs.h
+++ b/External/FEXCore/include/FEXCore/Utils/CompilerDefs.h
@@ -19,3 +19,8 @@
 
 // Specifies that a structure member or structure itself should have the smallest possible alignment.
 #define FEX_PACKED __attribute__((packed))
+
+// Dictates to the compiler that the path this is on should not be reachable
+// from normal execution control flow. If normal execution does reach this,
+// then program behavior is undefined.
+#define FEX_UNREACHABLE __builtin_unreachable()

--- a/External/FEXCore/include/FEXCore/Utils/CompilerDefs.h
+++ b/External/FEXCore/include/FEXCore/Utils/CompilerDefs.h
@@ -20,6 +20,9 @@
 // Specifies that a structure member or structure itself should have the smallest possible alignment.
 #define FEX_PACKED __attribute__((packed))
 
+// Causes execution to exit abnormally.
+#define FEX_TRAP_EXECUTION __builtin_trap()
+
 // Dictates to the compiler that the path this is on should not be reachable
 // from normal execution control flow. If normal execution does reach this,
 // then program behavior is undefined.

--- a/External/FEXCore/include/FEXCore/Utils/LogManager.h
+++ b/External/FEXCore/include/FEXCore/Utils/LogManager.h
@@ -78,7 +78,7 @@ static inline void A(const char *fmt, ...) {
     M(ASSERT, fmt, args);
     va_end(args);
   }
-  __builtin_trap();
+  FEX_TRAP_EXECUTION;
 }
 #define LOGMAN_MSG_A(...) do { LogMan::Msg::A(__VA_ARGS__); } while (0)
 #else
@@ -137,7 +137,7 @@ static inline void ERR(const char *fmt, ...) {
 #define ERROR_AND_DIE(...) \
   do { \
     LogMan::Msg::E(__VA_ARGS__); \
-    __builtin_trap(); \
+    FEX_TRAP_EXECUTION; \
   } while(0)
 
 // Fmt-capable interface.
@@ -190,7 +190,7 @@ static inline void AFmt(const char *fmt, const Args&... args) {
     return;
   }
   MFmtImpl(ASSERT, fmt, fmt::make_format_args(args...));
-  __builtin_trap();
+  FEX_TRAP_EXECUTION;
 }
 #define LOGMAN_MSG_A_FMT(...) do { LogMan::Msg::AFmt(__VA_ARGS__); } while (0)
 #else
@@ -211,7 +211,7 @@ static inline void AFmt(const char*, const Args&...) {}
 #define ERROR_AND_DIE_FMT(...) \
   do { \
     LogMan::Msg::EFmt(__VA_ARGS__); \
-    __builtin_trap(); \
+    FEX_TRAP_EXECUTION; \
   } while(0)
 
 } // namespace Msg


### PR DESCRIPTION
We can also make use of the `<bit>` header to remove some compiler builtins, since many of them were standardized.