### PR TITLE
Utils: Add header for bit-related utilities

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -15,6 +15,7 @@
 #include <FEXCore/HLE/SyscallHandler.h>
 #include <FEXCore/IR/IR.h>
 #include <FEXCore/IR/IntrusiveIRList.h>
+#include <FEXCore/Utils/BitUtils.h>
 #include <FEXCore/Utils/CompilerDefs.h>
 #include <FEXCore/Utils/LogManager.h>
 
@@ -1873,7 +1874,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
           case IR::OP_FINDLSB: {
             auto Op = IROp->C<IR::IROp_FindLSB>();
             uint64_t Src = *GetSrc<uint64_t*>(SSAData, Op->Header.Args[0]);
-            uint64_t Result = __builtin_ffsll(Src);
+            uint64_t Result = FindFirstSetBit(Src);
             GD = Result - 1;
             break;
           }
@@ -1891,9 +1892,9 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
           case IR::OP_REV: {
             auto Op = IROp->C<IR::IROp_Rev>();
             switch (OpSize) {
-              case 2: GD = __builtin_bswap16(*GetSrc<uint16_t*>(SSAData, Op->Header.Args[0])); break;
-              case 4: GD = __builtin_bswap32(*GetSrc<uint32_t*>(SSAData, Op->Header.Args[0])); break;
-              case 8: GD = __builtin_bswap64(*GetSrc<uint64_t*>(SSAData, Op->Header.Args[0])); break;
+              case 2: GD = BSwap16(*GetSrc<uint16_t*>(SSAData, Op->Header.Args[0])); break;
+              case 4: GD = BSwap32(*GetSrc<uint32_t*>(SSAData, Op->Header.Args[0])); break;
+              case 8: GD = BSwap64(*GetSrc<uint64_t*>(SSAData, Op->Header.Args[0])); break;
               default: LOGMAN_MSG_A("Unknown REV size: %d", OpSize); break;
             }
             break;

--- a/External/FEXCore/include/FEXCore/Utils/BitUtils.h
+++ b/External/FEXCore/include/FEXCore/Utils/BitUtils.h
@@ -1,0 +1,64 @@
+#pragma once
+
+// Header for various utilities that operate on bits and bytes.
+
+#include <bit>
+#include <climits>
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+namespace FEXCore {
+
+// Determines the number of bits inside of a given type.
+template <typename T>
+[[nodiscard]] constexpr size_t BitSize() noexcept {
+    return sizeof(T) * CHAR_BIT;
+}
+
+// Swaps the bytes of a 16-bit unsigned value.
+[[nodiscard]] inline uint16_t BSwap16(uint16_t value) noexcept {
+#ifdef __GNUC__
+    return __builtin_bswap16(value);
+#else
+    return (value >> 8) | (value << 8);
+#endif
+}
+
+// Swaps the bytes of a 32-bit unsigned value.
+[[nodiscard]] inline uint32_t BSwap32(uint32_t value) noexcept {
+#ifdef __GNUC__
+    return __builtin_bswap32(value);
+#else
+    return ((value & 0xFF000000U) >> 24) | ((value & 0x00FF0000U) >> 8) |
+           ((value & 0x0000FF00U) << 8) | ((value & 0x000000FFU) << 24);
+#endif
+}
+
+// Swaps the bytes of a 64-bit unsigned value.
+[[nodiscard]] inline uint64_t BSwap64(uint64_t value) noexcept {
+#ifdef __GNUC__
+    return __builtin_bswap64(value);
+#else
+    return ((value & 0xFF00000000000000ULL) >> 56) | ((value & 0x00FF000000000000ULL) >> 40) |
+           ((value & 0x0000FF0000000000ULL) >> 24) | ((value & 0x000000FF00000000ULL) >> 8) |
+           ((value & 0x00000000FF000000ULL) << 8) | ((value & 0x0000000000FF0000ULL) << 24) |
+           ((value & 0x000000000000FF00ULL) << 40) | ((value & 0x00000000000000FFULL) << 56);
+#endif
+}
+
+// Finds the first least-significant set bit within a given value.
+// Note that all returned indices are 1-based, not 0-based.
+template <typename T>
+[[nodiscard]] constexpr int FindFirstSetBit(T value) noexcept {
+    static_assert(std::is_unsigned_v<T>, "Type must be unsigned.");
+
+    if (value == 0) {
+        return 0;
+    }
+
+    const int trailing_zeroes = std::countr_zero(value);
+    return trailing_zeroes + 1;
+}
+
+} // namespace FEXCore

--- a/Source/Tests/HarnessHelpers.h
+++ b/Source/Tests/HarnessHelpers.h
@@ -15,6 +15,7 @@
 #include <FEXCore/Core/CoreState.h>
 #include <FEXCore/Core/X86Enums.h>
 #include <FEXCore/Utils/Allocator.h>
+#include <FEXCore/Utils/BitUtils.h>
 #include <FEXCore/Utils/CompilerDefs.h>
 #include <FEXCore/Utils/ELFContainer.h>
 #include <FEXCore/Utils/ELFSymbolDatabase.h>
@@ -216,7 +217,7 @@ namespace FEX::HarnessHelper {
           [[maybe_unused]] std::bitset<64> RegFlags = RegData->RegKey;
           assert(RegFlags.count() == 1  && "Must set reg data explicitly per register");
 
-          size_t NameIndex = __builtin_ffsl(RegData->RegKey)- 1;
+          size_t NameIndex = FEXCore::FindFirstSetBit(RegData->RegKey) - 1;
           auto Offset = OffsetArray[NameIndex];
           uint64_t *State1Data = reinterpret_cast<uint64_t*>(reinterpret_cast<uint64_t>(State1) + Offset);
           uint64_t *State2Data = reinterpret_cast<uint64_t*>(reinterpret_cast<uint64_t>(State2) + Offset);


### PR DESCRIPTION
Places a layer of separation around the remaining compiler builtins.