### PR TITLE
IRParser: Make use of fmt where applicable

### DIFF
--- a/External/FEXCore/Source/Interface/IR/IRDumper.cpp
+++ b/External/FEXCore/Source/Interface/IR/IRDumper.cpp
@@ -37,7 +37,7 @@ static void PrintArg(std::stringstream *out, [[maybe_unused]] IRListView const* 
 }
 
 static void PrintArg(std::stringstream *out, [[maybe_unused]] IRListView const* IR, CondClassType Arg) {
-  std::array<std::string, 22> CondNames = {
+  static constexpr std::array<std::string_view, 22> CondNames = {
     "EQ",
     "NEQ",
     "UGE",
@@ -66,7 +66,7 @@ static void PrintArg(std::stringstream *out, [[maybe_unused]] IRListView const* 
 }
 
 static void PrintArg(std::stringstream *out, [[maybe_unused]] IRListView const* IR, MemOffsetType Arg) {
-  std::array<std::string, 3> Names = {
+  static constexpr std::array<std::string_view, 3> Names = {
     "SXTX",
     "UXTW",
     "SXTW",


### PR DESCRIPTION
While we're in the same area, we can make the dumper lookup tables constexpr.