### PR TITLE
Fixes crash in 32-bit pselect6 and pselect6_time64

### DIFF
--- a/Source/Tests/LinuxSyscalls/x32/FD.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/FD.cpp
@@ -622,7 +622,7 @@ namespace FEX::HLE::x32 {
         }
       }
 
-      if (sigmaskpack) {
+      if (sigmaskpack && sigmaskpack->sigset) {
         uint64_t *sigmask = sigmaskpack->sigset;
         size_t sigsetsize = sigmaskpack->size;
         for (int32_t i = 0; i < (sigsetsize * 8); ++i) {
@@ -746,7 +746,7 @@ namespace FEX::HLE::x32 {
         }
       }
 
-      if (sigmaskpack) {
+      if (sigmaskpack && sigmaskpack->sigset) {
         uint64_t *sigmask = sigmaskpack->sigset;
         size_t sigsetsize = sigmaskpack->size;
         for (int32_t i = 0; i < (sigsetsize * 8); ++i) {


### PR DESCRIPTION
The kernel can be provided a sigmaskpack pointer without a sigset inside of it.

This was causing a crash in some random applications