### PR TITLE
SignalDelegator: Minor changes

### DIFF
--- a/External/FEXCore/include/FEXCore/Core/SignalDelegator.h
+++ b/External/FEXCore/include/FEXCore/Core/SignalDelegator.h
@@ -30,6 +30,8 @@ namespace Core {
 
   class SignalDelegator {
   public:
+    virtual ~SignalDelegator() = default;
+
     /**
      * @brief Registers an emulated thread's object to a TLS object
      *

--- a/Source/Tests/LinuxSyscalls/SignalDelegator.cpp
+++ b/Source/Tests/LinuxSyscalls/SignalDelegator.cpp
@@ -420,27 +420,27 @@ namespace FEX::HLE {
   void SignalDelegator::RegisterHostSignalHandler(int Signal, FEXCore::HostSignalDelegatorFunction Func) {
     // Linux signal handlers are per-process rather than per thread
     // Multiple threads could be calling in to this
-    std::lock_guard<std::mutex> lk(HostDelegatorMutex);
-    HostHandlers[Signal].Handler = Func;
+    std::lock_guard lk(HostDelegatorMutex);
+    HostHandlers[Signal].Handler = std::move(Func);
     InstallHostThunk(Signal);
   }
 
   void SignalDelegator::RegisterFrontendHostSignalHandler(int Signal, FEXCore::HostSignalDelegatorFunction Func) {
     // Linux signal handlers are per-process rather than per thread
     // Multiple threads could be calling in to this
-    std::lock_guard<std::mutex> lk(HostDelegatorMutex);
-    HostHandlers[Signal].FrontendHandler = Func;
+    std::lock_guard lk(HostDelegatorMutex);
+    HostHandlers[Signal].FrontendHandler = std::move(Func);
     InstallHostThunk(Signal);
   }
 
   void SignalDelegator::RegisterHostSignalHandlerForGuest(int Signal, FEXCore::HostSignalDelegatorFunctionForGuest Func) {
-    std::lock_guard<std::mutex> lk(HostDelegatorMutex);
-    HostHandlers[Signal].GuestHandler = Func;
+    std::lock_guard lk(HostDelegatorMutex);
+    HostHandlers[Signal].GuestHandler = std::move(Func);
     InstallHostThunk(Signal);
   }
 
   uint64_t SignalDelegator::RegisterGuestSignalHandler(int Signal, const FEXCore::GuestSigAction *Action, FEXCore::GuestSigAction *OldAction) {
-    std::lock_guard<std::mutex> lk(GuestDelegatorMutex);
+    std::lock_guard lk(GuestDelegatorMutex);
 
     // Invalid signal specified
     if (Signal > MAX_SIGNALS) {

--- a/Source/Tests/LinuxSyscalls/SignalDelegator.cpp
+++ b/Source/Tests/LinuxSyscalls/SignalDelegator.cpp
@@ -300,7 +300,7 @@ namespace FEX::HLE {
 
     // Most signals default to termination
     // These ones are slightly different
-    const std::vector<std::pair<int, SignalDelegator::DefaultBehaviour>> SignalDefaultBehaviours = {
+    static constexpr std::array<std::pair<int, SignalDelegator::DefaultBehaviour>, 14> SignalDefaultBehaviours = {{
       {SIGQUIT,   DEFAULT_COREDUMP},
       {SIGILL,    DEFAULT_COREDUMP},
       {SIGTRAP,   DEFAULT_COREDUMP},
@@ -315,10 +315,10 @@ namespace FEX::HLE {
       {SIGXFSZ,   DEFAULT_COREDUMP},
       {SIGSYS,    DEFAULT_COREDUMP},
       {SIGWINCH,  DEFAULT_IGNORE},
-    };
+    }};
 
-    for (auto Behaviour : SignalDefaultBehaviours) {
-      HostHandlers[Behaviour.first].DefaultBehaviour = Behaviour.second;
+    for (const auto [Signal, Behaviour] : SignalDefaultBehaviours) {
+      HostHandlers[Signal].DefaultBehaviour = Behaviour;
     }
   }
 

--- a/Source/Tests/LinuxSyscalls/SignalDelegator.cpp
+++ b/Source/Tests/LinuxSyscalls/SignalDelegator.cpp
@@ -170,7 +170,7 @@ namespace FEX::HLE {
 
           // Doesn't return
           FEXCore::Context::StopThread(Thread->CTX, Thread);
-          std::unexpected();
+          std::terminate();
         }
       }
       else if (Handler.GuestAction.sigaction_handler.handler == SIG_IGN) {

--- a/Source/Tests/LinuxSyscalls/SignalDelegator.h
+++ b/Source/Tests/LinuxSyscalls/SignalDelegator.h
@@ -30,7 +30,7 @@ namespace FEX::HLE {
     // Returns true if the host handled the signal
     // Arguments are the same as sigaction handler
     SignalDelegator();
-    virtual ~SignalDelegator();
+    ~SignalDelegator() override;
 
     /**
      * @brief Registers an emulated thread's object to a TLS object

--- a/Source/Tests/LinuxSyscalls/SignalDelegator.h
+++ b/Source/Tests/LinuxSyscalls/SignalDelegator.h
@@ -7,6 +7,7 @@ $end_info$
 
 #pragma once
 
+#include <array>
 #include <atomic>
 #include <functional>
 #include <mutex>
@@ -108,7 +109,7 @@ namespace FEX::HLE {
       DefaultBehaviour DefaultBehaviour {DEFAULT_TERM};
     };
 
-    SignalHandler HostHandlers[MAX_SIGNALS + 1]{};
+    std::array<SignalHandler, MAX_SIGNALS + 1> HostHandlers{};
     bool InstallHostThunk(int Signal);
     void UpdateHostThunk(int Signal);
 


### PR DESCRIPTION
A few minor changes that didn't deserve their own PRs.

Primarily some cleanup, but does swap out some deprecated library functions with their relevant counterparts.