### PR TITLE
Core: return unique_ptr by default for cores

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -520,15 +520,15 @@ namespace FEXCore::Context {
     // Create CPU backend
     switch (Config.Core) {
     case FEXCore::Config::CONFIG_INTERPRETER:
-      State->CPUBackend.reset(FEXCore::CPU::CreateInterpreterCore(this, State, CompileThread));
+      State->CPUBackend = FEXCore::CPU::CreateInterpreterCore(this, State, CompileThread);
       break;
     case FEXCore::Config::CONFIG_IRJIT:
       State->PassManager->InsertRegisterAllocationPass(DoSRA);
 
 #if (_M_X86_64 && JIT_X86_64)
-      State->CPUBackend.reset(FEXCore::CPU::CreateX86JITCore(this, State, CompileThread));
+      State->CPUBackend = FEXCore::CPU::CreateX86JITCore(this, State, CompileThread);
 #elif (_M_ARM_64 && JIT_ARM64)
-      State->CPUBackend.reset(FEXCore::CPU::CreateArm64JITCore(this, State, CompileThread));
+      State->CPUBackend = FEXCore::CPU::CreateArm64JITCore(this, State, CompileThread);
 #else
       ERROR_AND_DIE("FEXCore has been compiled without a viable JIT core");
 #endif

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -534,7 +534,9 @@ namespace FEXCore::Context {
 #endif
 
       break;
-    case FEXCore::Config::CONFIG_CUSTOM:      State->CPUBackend.reset(CustomCPUFactory(this, State)); break;
+    case FEXCore::Config::CONFIG_CUSTOM:
+      State->CPUBackend = CustomCPUFactory(this, State);
+      break;
     default: ERROR_AND_DIE("Unknown core configuration");
     }
   }

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -115,8 +115,8 @@ void *InterpreterCore::CompileCode(uint64_t Entry, [[maybe_unused]] FEXCore::IR:
   return reinterpret_cast<void*>(InterpreterExecution);
 }
 
-FEXCore::CPU::CPUBackend *CreateInterpreterCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread, bool CompileThread) {
-  return new InterpreterCore(ctx, Thread, CompileThread);
+std::unique_ptr<CPUBackend> CreateInterpreterCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread, bool CompileThread) {
+  return std::make_unique<InterpreterCore>(ctx, Thread, CompileThread);
 }
 
 }

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 namespace FEXCore::Context {
 struct Context;
 }
@@ -11,6 +13,6 @@ namespace FEXCore::Core {
 namespace FEXCore::CPU {
 class CPUBackend;
 
-FEXCore::CPU::CPUBackend *CreateInterpreterCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread, bool CompileThread);
+std::unique_ptr<CPUBackend> CreateInterpreterCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread, bool CompileThread);
 
 }

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -893,7 +893,7 @@ uint64_t Arm64JITCore::ExitFunctionLink(Arm64JITCore *core, FEXCore::Core::CpuSt
   return HostCode;
 }
 
-FEXCore::CPU::CPUBackend *CreateArm64JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread, bool CompileThread) {
-  return new Arm64JITCore(ctx, Thread, CompileThread);
+std::unique_ptr<CPUBackend> CreateArm64JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread, bool CompileThread) {
+  return std::make_unique<Arm64JITCore>(ctx, Thread, CompileThread);
 }
 }

--- a/External/FEXCore/Source/Interface/Core/JIT/JITCore.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/JITCore.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 namespace FEXCore::Context {
 struct Context;
 }
@@ -11,6 +13,6 @@ struct InternalThreadState;
 namespace FEXCore::CPU {
 class CPUBackend;
 
-FEXCore::CPU::CPUBackend *CreateX86JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread, bool CompileThread);
-FEXCore::CPU::CPUBackend *CreateArm64JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread, bool CompileThread);
+std::unique_ptr<CPUBackend> CreateX86JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread, bool CompileThread);
+std::unique_ptr<CPUBackend> CreateArm64JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread, bool CompileThread);
 }

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -764,7 +764,7 @@ uint64_t X86JITCore::ExitFunctionLink(X86JITCore *core, FEXCore::Core::CpuStateF
   return HostCode;
 }
 
-FEXCore::CPU::CPUBackend *CreateX86JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread, bool CompileThread) {
-  return new X86JITCore(ctx, Thread, AllocateNewCodeBuffer(CompileThread ? X86JITCore::MAX_CODE_SIZE : X86JITCore::INITIAL_CODE_SIZE), CompileThread);
+std::unique_ptr<CPUBackend> CreateX86JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread, bool CompileThread) {
+  return std::make_unique<X86JITCore>(ctx, Thread, AllocateNewCodeBuffer(CompileThread ? X86JITCore::MAX_CODE_SIZE : X86JITCore::INITIAL_CODE_SIZE), CompileThread);
 }
 }

--- a/External/FEXCore/include/FEXCore/Core/Context.h
+++ b/External/FEXCore/include/FEXCore/Core/Context.h
@@ -46,7 +46,7 @@ namespace FEXCore::Context {
     MODE_32BIT,
     MODE_64BIT,
   };
-  using CustomCPUFactoryType = std::function<FEXCore::CPU::CPUBackend* (FEXCore::Context::Context*, FEXCore::Core::InternalThreadState *Thread)>;
+  using CustomCPUFactoryType = std::function<std::unique_ptr<FEXCore::CPU::CPUBackend> (FEXCore::Context::Context*, FEXCore::Core::InternalThreadState *Thread)>;
 
   /**
    * @brief This initializes internal FEXCore state that is shared between contexts and requires overhead to setup

--- a/Source/CommonCore/HostFactory.cpp
+++ b/Source/CommonCore/HostFactory.cpp
@@ -174,11 +174,11 @@ namespace HostFactory {
     return nullptr;
   }
 
-  FEXCore::CPU::CPUBackend *CPUCreationFactory(FEXCore::Context::Context* CTX, FEXCore::Core::InternalThreadState *Thread) {
-    return new HostCore(CTX, Thread, false);
+  std::unique_ptr<FEXCore::CPU::CPUBackend> CPUCreationFactory(FEXCore::Context::Context* CTX, FEXCore::Core::InternalThreadState *Thread) {
+    return std::make_unique<HostCore>(CTX, Thread, false);
   }
 #else
-  FEXCore::CPU::CPUBackend *CPUCreationFactory(FEXCore::Context::Context* CTX, FEXCore::Core::InternalThreadState *Thread) {
+  std::unique_ptr<FEXCore::CPU::CPUBackend> CPUCreationFactory(FEXCore::Context::Context* CTX, FEXCore::Core::InternalThreadState *Thread) {
     LOGMAN_MSG_A("HostCPU factory doesn't exist for this host");
     return nullptr;
   }

--- a/Source/CommonCore/HostFactory.h
+++ b/Source/CommonCore/HostFactory.h
@@ -1,3 +1,7 @@
+#pragma once
+
+#include <memory>
+
 namespace FEXCore::CPU {
   class CPUBackend;
 }
@@ -9,6 +13,5 @@ namespace FEXCore::Core {
 }
 
 namespace HostFactory {
-  FEXCore::CPU::CPUBackend *CPUCreationFactory(FEXCore::Context::Context* CTX, FEXCore::Core::InternalThreadState *Thread);
-  FEXCore::CPU::CPUBackend *CPUCreationFactoryFallback(FEXCore::Context::Context* CTX, FEXCore::Core::InternalThreadState *Thread);
+  std::unique_ptr<FEXCore::CPU::CPUBackend> CPUCreationFactory(FEXCore::Context::Context* CTX, FEXCore::Core::InternalThreadState *Thread);
 }


### PR DESCRIPTION
Mainly done to communicate the intended ownership responsibilities directly within the interface itself and make it harder to unintentionally leak memory.