### PR TITLE
Syscalls/Thread: Replace std::unexpected with std::terminate

### DIFF
--- a/Source/Tests/LinuxSyscalls/Syscalls/Thread.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Thread.cpp
@@ -376,7 +376,7 @@ namespace FEX::HLE {
       Thread->StatusCode = status;
       FEXCore::Context::Stop(Thread->CTX);
       // This will never be reached
-      std::unexpected();
+      std::terminate();
     });
 
     REGISTER_SYSCALL_IMPL(prlimit64, [](FEXCore::Core::CpuStateFrame *Frame, pid_t pid, int resource, const struct rlimit *new_limit, struct rlimit *old_limit) -> uint64_t {


### PR DESCRIPTION
`std::unexpected` was deprecated in C++11 and removed from the standard in C++17. The default unexpected_handler calls `std::terminate`, so this is identical behavior.