### PR TITLE
Remove most warnings in FEX again

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -865,8 +865,7 @@ DEF_OP(Bfi) {
 
 DEF_OP(Bfe) {
   auto Op = IROp->C<IR::IROp_Bfe>();
-  uint8_t OpSize = IROp->Size;
-  LOGMAN_THROW_A(OpSize <= 8, "OpSize is too large for BFE: %d", OpSize);
+  LOGMAN_THROW_A(IROp->Size <= 8, "OpSize is too large for BFE: %d", IROp->Size);
   LOGMAN_THROW_A(Op->Width != 0, "Invalid BFE width of 0");
 
   auto Dst = GetReg<RA_64>(Node);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -44,8 +44,10 @@ using namespace vixl::aarch64;
 void Arm64JITCore::Op_Unhandled(FEXCore::IR::IROp_Header *IROp, uint32_t Node) {
   FallbackInfo Info;
   if (!InterpreterOps::GetFallbackHandler(IROp, &Info)) {
+#if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
     auto Name = FEXCore::IR::GetName(IROp->Op);
     LOGMAN_MSG_A("Unhandled IR Op: %s", std::string(Name).c_str());
+#endif
   } else {
     switch(Info.ABI) {
       case FABI_VOID_U16:{
@@ -292,8 +294,11 @@ void Arm64JITCore::Op_Unhandled(FEXCore::IR::IROp_Header *IROp, uint32_t Node) {
 
       case FABI_UNKNOWN:
       default:
-      auto Name = FEXCore::IR::GetName(IROp->Op);
+#if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
+        auto Name = FEXCore::IR::GetName(IROp->Op);
         LOGMAN_MSG_A("Unhandled IR Fallback abi: %s %d", std::string(Name).c_str(), Info.ABI);
+#endif
+      break;
     }
   }
 }
@@ -707,8 +712,6 @@ void *Arm64JITCore::CompileCode(uint64_t Entry, [[maybe_unused]] FEXCore::IR::IR
   this->Entry = Entry;
   this->RAData = RAData;
 
-  auto HeaderOp = IR->GetHeader();
-
   #ifndef NDEBUG
   LoadConstant(x0, Entry);
   #endif
@@ -786,8 +789,10 @@ void *Arm64JITCore::CompileCode(uint64_t Entry, [[maybe_unused]] FEXCore::IR::IR
 
   for (auto [BlockNode, BlockHeader] : IR->GetBlocks()) {
     using namespace FEXCore::IR;
+#if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
     auto BlockIROp = BlockHeader->CW<FEXCore::IR::IROp_CodeBlock>();
     LOGMAN_THROW_A(BlockIROp->Header.Op == IR::OP_CODEBLOCK, "IR type failed to be a code block");
+#endif
 
     {
       uint32_t Node = IR->GetID(BlockNode);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -766,7 +766,6 @@ DEF_OP(VFRSqrt) {
 
 DEF_OP(VNeg) {
   auto Op = IROp->C<IR::IROp_VNeg>();
-  uint8_t OpSize = IROp->Size;
   switch (Op->Header.ElementSize) {
   case 1:
     neg(GetDst(Node).V16B(), GetSrc(Op->Header.Args[0].ID()).V16B());
@@ -780,13 +779,12 @@ DEF_OP(VNeg) {
   case 8:
     neg(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D());
     break;
-  default: LOGMAN_MSG_A("Unsupported Not size: %d", OpSize);
+  default: LOGMAN_MSG_A("Unsupported Not size: %d", IROp->Size);
   }
 }
 
 DEF_OP(VFNeg) {
   auto Op = IROp->C<IR::IROp_VFNeg>();
-  uint8_t OpSize = IROp->Size;
   switch (Op->Header.ElementSize) {
   case 4:
     fneg(GetDst(Node).V4S(), GetSrc(Op->Header.Args[0].ID()).V4S());
@@ -794,7 +792,7 @@ DEF_OP(VFNeg) {
   case 8:
     fneg(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D());
     break;
-  default: LOGMAN_MSG_A("Unsupported Not size: %d", OpSize);
+  default: LOGMAN_MSG_A("Unsupported Not size: %d", IROp->Size);
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/ALUOps.cpp
@@ -970,9 +970,7 @@ DEF_OP(Bfi) {
 
 DEF_OP(Bfe) {
   auto Op = IROp->C<IR::IROp_Bfe>();
-  uint8_t OpSize = IROp->Size;
-
-  LOGMAN_THROW_A(OpSize <= 8, "OpSize is too large for BFE: %d", OpSize);
+  LOGMAN_THROW_A(IROp->Size <= 8, "OpSize is too large for BFE: %d", IROp->Size);
 
   auto Dst = GetDst<RA_64>(Node);
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -84,8 +84,10 @@ void X86JITCore::PopRegs() {
 void X86JITCore::Op_Unhandled(FEXCore::IR::IROp_Header *IROp, uint32_t Node) {
   FallbackInfo Info;
   if (!InterpreterOps::GetFallbackHandler(IROp, &Info)) {
+#if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
     auto Name = FEXCore::IR::GetName(IROp->Op);
     LOGMAN_MSG_A("Unhandled IR Op: %s", std::string(Name).c_str());
+#endif
   } else {
     switch(Info.ABI) {
       case FABI_VOID_U16: {
@@ -282,8 +284,11 @@ void X86JITCore::Op_Unhandled(FEXCore::IR::IROp_Header *IROp, uint32_t Node) {
 
       case FABI_UNKNOWN:
       default:
+#if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
       auto Name = FEXCore::IR::GetName(IROp->Op);
         LOGMAN_MSG_A("Unhandled IR Fallback abi: %s %d", std::string(Name).c_str(), Info.ABI);
+#endif
+        break;
     }
   }
 }
@@ -662,8 +667,10 @@ void *X86JITCore::CompileCode(uint64_t Entry, [[maybe_unused]] FEXCore::IR::IRLi
   for (auto [BlockNode, BlockHeader] : IR->GetBlocks()) {
     using namespace FEXCore::IR;
     {
+#if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
       auto BlockIROp = BlockHeader->CW<IROp_CodeBlock>();
       LOGMAN_THROW_A(BlockIROp->Header.Op == IR::OP_CODEBLOCK, "IR type failed to be a code block");
+#endif
 
       uint32_t Node = IR->GetID(BlockNode);
       auto IsTarget = JumpTargets.find(Node);

--- a/External/FEXCore/Source/Interface/Core/LookupCache.h
+++ b/External/FEXCore/Source/Interface/Core/LookupCache.h
@@ -38,7 +38,10 @@ public:
   std::map<uint64_t, std::vector<uint64_t>> CodePages;
 
   void AddBlockMapping(uint64_t Address, void *HostCode, uint64_t Start, uint64_t Length) { 
-    auto InsertPoint = BlockList.emplace(Address, (uintptr_t)HostCode);
+#if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
+    auto InsertPoint =
+#endif
+    BlockList.emplace(Address, (uintptr_t)HostCode);
     LOGMAN_THROW_A(InsertPoint.second == true, "Dupplicate block mapping added");
 
     for (auto CurrentPage = Start >> 12, EndPage = (Start + Length) >> 12; CurrentPage <= EndPage; CurrentPage++) {

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -4602,7 +4602,10 @@ void OpDispatchBuilder::Finalize() {
 
   // Node 0 is invalid node
   OrderedNode *RealNode = reinterpret_cast<OrderedNode*>(GetNode(1));
-  FEXCore::IR::IROp_Header *IROp = RealNode->Op(DualListData.DataBegin());
+#if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
+  FEXCore::IR::IROp_Header *IROp =
+#endif
+  RealNode->Op(DualListData.DataBegin());
   LOGMAN_THROW_A(IROp->Op == OP_IRHEADER, "First op in function must be our header");
 
   // Let's walk the jump blocks and see if we have handled every block target

--- a/External/FEXCore/Source/Interface/IR/Passes/IRCompaction.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/IRCompaction.cpp
@@ -153,8 +153,10 @@ bool IRCompaction::Run(IREmitter *IREmit) {
   {
     // Fixup the arguments of all the IROps
     for (auto &Block : GeneratedCodeBlocks) {
+#if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
       auto BlockIROp = LocalIR.GetOp<FEXCore::IR::IROp_CodeBlock>(Block.NewNode);
       LOGMAN_THROW_A(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
+#endif
 
       for (auto [LocalNode, LocalIROp] : LocalIR.GetCode(Block.NewNode)) {
 

--- a/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
@@ -54,8 +54,10 @@ bool IRValidation::Run(IREmitter *IREmit) {
 
   std::vector<uint32_t> Uses(CurrentIR.GetSSACount(), 0);
 
+#if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
   auto HeaderOp = CurrentIR.GetHeader();
   LOGMAN_THROW_A(HeaderOp->Header.Op == OP_IRHEADER, "First op wasn't IRHeader");
+#endif
 
   IR::RegisterAllocationData * RAData{};
   if (Manager->HasRAPass()) {

--- a/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -1399,11 +1399,13 @@ namespace FEXCore::IR {
         if (InterferenceNode != ~0U) {
           FEXCore::IR::RegisterClassType InterferenceRegClass = FEXCore::IR::RegisterClassType{Graph->AllocData->Map[InterferenceNode].Class};
           uint32_t SpillSlot = FindSpillSlot(InterferenceNode, InterferenceRegClass);
+#if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
           RegisterNode *InterferenceRegisterNode = &Graph->Nodes[InterferenceNode];
           LOGMAN_THROW_A(SpillSlot != ~0U, "Interference Node doesn't have a spill slot!");
           //LOGMAN_THROW_A(InterferenceRegisterNode->Head.RegAndClass.Reg != INVALID_REG, "Interference node never assigned a register?");
           LOGMAN_THROW_A(InterferenceRegClass != ~0U, "Interference node never assigned a register class?");
           LOGMAN_THROW_A(InterferenceRegisterNode->Head.PhiPartner == nullptr, "We don't support spilling PHI nodes currently");
+#endif
 
           // This is the op that we need to dump
           auto [InterferenceOrderedNode, InterferenceIROp] = IR.at(InterferenceNode)();

--- a/External/FEXCore/Source/Utils/ELFSymbolDatabase.cpp
+++ b/External/FEXCore/Source/Utils/ELFSymbolDatabase.cpp
@@ -82,7 +82,10 @@ ELFSymbolDatabase::ELFSymbolDatabase(::ELFLoader::ELFContainer *file)
     for (auto &Lib : UnfilledDependencies) {
       if (NameToELF.find(Lib) == NameToELF.end()) {
         std::string LibraryPath;
-        bool Found = FindLibraryFile(&LibraryPath, Lib.c_str());
+#if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
+        bool Found =
+#endif
+        FindLibraryFile(&LibraryPath, Lib.c_str());
         LOGMAN_THROW_A(Found, "Couldn't find library '%s'", Lib.c_str());
         auto Info = DynamicELFInfo.emplace_back(new ELFInfo{});
         Info->Name = Lib;

--- a/External/FEXCore/include/FEXCore/IR/IREmitter.h
+++ b/External/FEXCore/include/FEXCore/IR/IREmitter.h
@@ -583,7 +583,11 @@ friend class FEXCore::IR::PassManager;
    * @{ */
   /**  @} */
   void LinkCodeBlocks(OrderedNode *CodeNode, OrderedNode *Next) {
-    FEXCore::IR::IROp_CodeBlock *CurrentIROp = CodeNode->Op(DualListData.DataBegin())->CW<FEXCore::IR::IROp_CodeBlock>();
+#if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
+    FEXCore::IR::IROp_CodeBlock *CurrentIROp =
+#endif
+    CodeNode->Op(DualListData.DataBegin())->CW<FEXCore::IR::IROp_CodeBlock>();
+
     LOGMAN_THROW_A(CurrentIROp->Header.Op == IROps::OP_CODEBLOCK, "Invalid");
 
     CodeNode->append(DualListData.ListBegin(), Next);

--- a/Source/Common/Config.cpp
+++ b/Source/Common/Config.cpp
@@ -60,15 +60,16 @@ namespace FEX::Config {
     jsonPool_t PoolObject;
     std::unique_ptr<std::list<json_t>> json_objects;
   };
+  static_assert(offsetof(JsonAllocator, PoolObject) == 0, "This needs to be at offset zero");
 
   json_t* PoolInit(jsonPool_t* Pool) {
-    JsonAllocator* alloc = json_containerOf(Pool, JsonAllocator, PoolObject);
+    JsonAllocator* alloc = reinterpret_cast<JsonAllocator*>(Pool);
     alloc->json_objects = std::make_unique<std::list<json_t>>();
     return &*alloc->json_objects->emplace(alloc->json_objects->end());
   }
 
   json_t* PoolAlloc(jsonPool_t* Pool) {
-    JsonAllocator* alloc = json_containerOf(Pool, JsonAllocator, PoolObject);
+    JsonAllocator* alloc = reinterpret_cast<JsonAllocator*>(Pool);
     return &*alloc->json_objects->emplace(alloc->json_objects->end());
   }
 

--- a/Source/Tests/LinuxSyscalls/SignalDelegator.cpp
+++ b/Source/Tests/LinuxSyscalls/SignalDelegator.cpp
@@ -318,7 +318,7 @@ namespace FEX::HLE {
       {SIGWINCH,  DEFAULT_IGNORE},
     }};
 
-    for (const auto [Signal, Behaviour] : SignalDefaultBehaviours) {
+    for (const auto &[Signal, Behaviour] : SignalDefaultBehaviours) {
       HostHandlers[Signal].DefaultBehaviour = Behaviour;
     }
   }

--- a/Source/Tests/LinuxSyscalls/x32/FD.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/FD.cpp
@@ -243,7 +243,7 @@ namespace FEX::HLE::x32 {
         }
 
         case F_SETFL:
-          lock_arg = (void*)FEX::HLE::RemapFromX86Flags(arg);
+          lock_arg = reinterpret_cast<void*>(FEX::HLE::RemapFromX86Flags(arg));
           break;
         // Maps directly
         case F_DUPFD:

--- a/Source/Tests/LinuxSyscalls/x32/Syscalls.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Syscalls.cpp
@@ -698,9 +698,11 @@ public:
     // Set all the new definitions
     for (auto &Syscall : syscalls_x32) {
       auto SyscallNumber = Syscall.SyscallNumber;
-      auto Name = GetSyscallName(SyscallNumber);
       auto &Def = Definitions.at(SyscallNumber);
+#if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
+      auto Name = GetSyscallName(SyscallNumber);
       LOGMAN_THROW_A(Def.Ptr == cvt(&UnimplementedSyscall), "Oops overwriting sysall problem, %d, %s", SyscallNumber, Name);
+#endif
       Def.Ptr = Syscall.SyscallHandler;
       Def.NumArgs = Syscall.ArgumentCount;
 #ifdef DEBUG_STRACE

--- a/Source/Tests/LinuxSyscalls/x64/Syscalls.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Syscalls.cpp
@@ -137,9 +137,11 @@ namespace FEX::HLE::x64 {
     // Set all the new definitions
     for (auto &Syscall : syscalls_x64) {
       auto SyscallNumber = Syscall.SyscallNumber;
-      auto Name = GetSyscallName(SyscallNumber);
       auto &Def = Definitions.at(SyscallNumber);
+#if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
+      auto Name = GetSyscallName(SyscallNumber);
       LOGMAN_THROW_A(Def.Ptr == cvt(&UnimplementedSyscall), "Oops overwriting sysall problem, %d, %s", SyscallNumber, Name);
+#endif
       Def.Ptr = Syscall.SyscallHandler;
       Def.NumArgs = Syscall.ArgumentCount;
 #ifdef DEBUG_STRACE


### PR DESCRIPTION
Still have a few of the offsetof on a non standard layout object warning