### PR TITLE
Syscalls: Add helper for version testing

### DIFF
--- a/Source/Tests/LinuxSyscalls/Syscalls.h
+++ b/Source/Tests/LinuxSyscalls/Syscalls.h
@@ -123,6 +123,10 @@ public:
   uint32_t GetHostKernelVersion() const { return HostKernelVersion; }
   uint32_t GetGuestKernelVersion() const { return GuestKernelVersion; }
 
+  bool IsHostKernelVersionAtLeast(uint32_t Major, uint32_t Minor = 0, uint32_t Patch = 0) const {
+    return GetHostKernelVersion() >= KernelVersion(Major, Minor, Patch);
+  }
+
   static uint32_t CalculateHostKernelVersion();
   uint32_t CalculateGuestKernelVersion();
 

--- a/Source/Tests/LinuxSyscalls/Syscalls/FD.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/FD.cpp
@@ -206,7 +206,7 @@ namespace FEX::HLE {
       SYSCALL_ERRNO();
     });
 
-    if (Handler->GetHostKernelVersion() >= FEX::HLE::SyscallHandler::KernelVersion(5, 8, 0)) {
+    if (Handler->IsHostKernelVersionAtLeast(5, 8, 0)) {
       // Only exists on kernel 5.8+
       REGISTER_SYSCALL_IMPL(faccessat2, [](FEXCore::Core::CpuStateFrame *Frame, int dirfd, const char *pathname, int mode, int flags) -> uint64_t {
         uint64_t Result = FEX::HLE::_SyscallHandler->FM.FAccessat2(dirfd, pathname, mode, flags);
@@ -331,7 +331,7 @@ namespace FEX::HLE {
       SYSCALL_ERRNO();
     });
 
-    if (Handler->GetHostKernelVersion() >= FEX::HLE::SyscallHandler::KernelVersion(5, 3, 0)) {
+    if (Handler->IsHostKernelVersionAtLeast(5, 3, 0)) {
       REGISTER_SYSCALL_IMPL(pidfd_open, [](FEXCore::Core::CpuStateFrame *Frame, pid_t pid, unsigned int flags) -> uint64_t {
         uint64_t Result = ::syscall(SYS_pidfd_open, pid, flags);
         SYSCALL_ERRNO();
@@ -341,7 +341,7 @@ namespace FEX::HLE {
       REGISTER_SYSCALL_IMPL(pidfd_open, UnimplementedSyscallSafe);
     }
 
-    if (Handler->GetHostKernelVersion() >= FEX::HLE::SyscallHandler::KernelVersion(5, 9, 0)) {
+    if (Handler->IsHostKernelVersionAtLeast(5, 9, 0)) {
       REGISTER_SYSCALL_IMPL(close_range, [](FEXCore::Core::CpuStateFrame *Frame, unsigned int first, unsigned int last, unsigned int flags) -> uint64_t {
         uint64_t Result = FEX::HLE::_SyscallHandler->FM.CloseRange(first, last, flags);
         SYSCALL_ERRNO();

--- a/Source/Tests/LinuxSyscalls/Syscalls/IOUring.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/IOUring.cpp
@@ -20,7 +20,7 @@ namespace SignalDelegator {
 
 namespace FEX::HLE {
   void RegisterIOUring(FEX::HLE::SyscallHandler *const Handler) {
-    if (Handler->GetHostKernelVersion() >= FEX::HLE::SyscallHandler::KernelVersion(5, 1, 0)) {
+    if (Handler->IsHostKernelVersionAtLeast(5, 1, 0)) {
       REGISTER_SYSCALL_IMPL(io_uring_setup, [](FEXCore::Core::CpuStateFrame *Frame, uint32_t entries, void* params) -> uint64_t {
         uint64_t Result = ::syscall(SYS_io_uring_setup, entries, params);
         SYSCALL_ERRNO();

--- a/Source/Tests/LinuxSyscalls/Syscalls/Signals.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Signals.cpp
@@ -42,7 +42,7 @@ namespace FEX::HLE {
       SYSCALL_ERRNO();
     });
 
-    if (Handler->GetHostKernelVersion() >= FEX::HLE::SyscallHandler::KernelVersion(5, 1, 0)) {
+    if (Handler->IsHostKernelVersionAtLeast(5, 1, 0)) {
       REGISTER_SYSCALL_IMPL(pidfd_send_signal, [](FEXCore::Core::CpuStateFrame *Frame, int pidfd, int sig, siginfo_t *info, unsigned int flags) -> uint64_t {
         uint64_t Result = ::syscall(SYS_pidfd_send_signal);
         SYSCALL_ERRNO();

--- a/Source/Tests/LinuxSyscalls/x32/EPoll.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/EPoll.cpp
@@ -64,7 +64,7 @@ namespace FEX::HLE::x32 {
       SYSCALL_ERRNO();
     });
 
-    if (Handler->GetHostKernelVersion() >= FEX::HLE::SyscallHandler::KernelVersion(5, 11, 0)) {
+    if (Handler->IsHostKernelVersionAtLeast(5, 11, 0)) {
 #ifndef SYS_epoll_pwait2
 #define SYS_epoll_pwait2 354
 #endif

--- a/Source/Tests/LinuxSyscalls/x64/EPoll.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/EPoll.cpp
@@ -67,7 +67,7 @@ namespace FEX::HLE::x64 {
       SYSCALL_ERRNO();
     });
 
-    if (Handler->GetHostKernelVersion() >= FEX::HLE::SyscallHandler::KernelVersion(5, 11, 0)) {
+    if (Handler->IsHostKernelVersionAtLeast(5, 11, 0)) {
 #ifndef SYS_epoll_pwait2
 #define SYS_epoll_pwait2 354
 #endif

--- a/Source/Tests/LinuxSyscalls/x64/Memory.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Memory.cpp
@@ -110,7 +110,7 @@ namespace FEX::HLE::x64 {
 #ifndef SYS_process_madvise
 #define SYS_process_madvise 440
 #endif
-    if (Handler->GetHostKernelVersion() >= FEX::HLE::SyscallHandler::KernelVersion(5, 10, 0)) {
+    if (Handler->IsHostKernelVersionAtLeast(5, 10, 0)) {
       REGISTER_SYSCALL_IMPL_X64(process_madvise, [](FEXCore::Core::CpuStateFrame *Frame, int pidfd, const struct iovec *iovec, size_t vlen, int advice, unsigned int flags) -> uint64_t {
         uint64_t Result = ::syscall(SYS_process_madvise, pidfd, iovec, vlen, advice, flags);
         SYSCALL_ERRNO();


### PR DESCRIPTION
Shortens up the version testing code in a few places to make for quicker reading.