### PR TITLE
Syscalls/Signals: Add missing arguments to pidfd_send_signal syscall

### DIFF
--- a/Source/Tests/LinuxSyscalls/Syscalls/Signals.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Signals.cpp
@@ -44,7 +44,7 @@ namespace FEX::HLE {
 
     if (Handler->GetHostKernelVersion() >= FEX::HLE::SyscallHandler::KernelVersion(5, 1, 0)) {
       REGISTER_SYSCALL_IMPL(pidfd_send_signal, [](FEXCore::Core::CpuStateFrame *Frame, int pidfd, int sig, siginfo_t *info, unsigned int flags) -> uint64_t {
-        uint64_t Result = ::syscall(SYS_pidfd_send_signal);
+        uint64_t Result = ::syscall(SYS_pidfd_send_signal, pidfd, sig, info, flags);
         SYSCALL_ERRNO();
       });
     }


### PR DESCRIPTION
These were accidentally omitted from the call.