### PR TITLE
Passes: Return by unique_ptr where applicable

### DIFF
--- a/External/FEXCore/Source/Interface/IR/PassManager.cpp
+++ b/External/FEXCore/Source/Interface/IR/PassManager.cpp
@@ -45,10 +45,9 @@ void PassManager::AddDefaultPasses(bool InlineConstants, bool StaticRegisterAllo
       InsertPass(CreateStaticRegisterAllocationPass());
   }
 
-  CompactionPass = CreateIRCompaction();
   // If the IR is compacted post-RA then the node indexing gets messed up and the backend isn't able to find the register assigned to a node
   // Compact before IR, don't worry about RA generating spills/fills
-  InsertPass(CompactionPass);
+  CompactionPass = InsertPass(CreateIRCompaction());
 }
 
 void PassManager::AddDefaultValidationPasses() {
@@ -60,8 +59,7 @@ void PassManager::AddDefaultValidationPasses() {
 }
 
 void PassManager::InsertRegisterAllocationPass(bool OptimizeSRA) {
-    RAPass = IR::CreateRegisterAllocationPass(CompactionPass, OptimizeSRA);
-    InsertPass(RAPass);
+  RAPass = InsertPass(IR::CreateRegisterAllocationPass(CompactionPass, OptimizeSRA));
 }
 
 bool PassManager::Run(IREmitter *IREmit) {

--- a/External/FEXCore/Source/Interface/IR/PassManager.h
+++ b/External/FEXCore/Source/Interface/IR/PassManager.h
@@ -42,9 +42,9 @@ class PassManager final {
 public:
   void AddDefaultPasses(bool InlineConstants, bool StaticRegisterAllocation);
   void AddDefaultValidationPasses();
-  void InsertPass(Pass *Pass) {
+  Pass* InsertPass(std::unique_ptr<Pass> Pass) {
     Pass->RegisterPassManager(this);
-    Passes.emplace_back(Pass);
+    return Passes.emplace_back(std::move(Pass)).get();
   }
 
   void InsertRegisterAllocationPass(bool OptimizeSRA);
@@ -73,15 +73,15 @@ protected:
 
 private:
   Pass *RAPass{};
-  FEXCore::IR::Pass *CompactionPass{};
+  Pass *CompactionPass{};
 
   std::vector<std::unique_ptr<Pass>> Passes;
 
 #if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
   std::vector<std::unique_ptr<Pass>> ValidationPasses;
-  void InsertValidationPass(Pass *Pass) {
+  void InsertValidationPass(std::unique_ptr<Pass> Pass) {
     Pass->RegisterPassManager(this);
-    ValidationPasses.emplace_back(Pass);
+    ValidationPasses.emplace_back(std::move(Pass));
   }
 #endif
 

--- a/External/FEXCore/Source/Interface/IR/PassManager.h
+++ b/External/FEXCore/Source/Interface/IR/PassManager.h
@@ -52,7 +52,7 @@ public:
   bool Run(IREmitter *IREmit);
 
   void RegisterExitHandler(ShouldExitHandler Handler) {
-    ExitHandler = Handler;
+    ExitHandler = std::move(Handler);
   }
 
   bool HasRAPass() const {

--- a/External/FEXCore/Source/Interface/IR/Passes.h
+++ b/External/FEXCore/Source/Interface/IR/Passes.h
@@ -1,25 +1,27 @@
 #pragma once
 
+#include <memory>
+
 namespace FEXCore::IR {
 class Pass;
 class RegisterAllocationPass;
 class RegisterAllocationData;
 
-FEXCore::IR::Pass* CreateConstProp(bool InlineConstants);
-FEXCore::IR::Pass* CreateContextLoadStoreElimination();
-FEXCore::IR::Pass* CreateSyscallOptimization();
-FEXCore::IR::Pass* CreateDeadFlagCalculationEliminination();
-FEXCore::IR::Pass* CreateDeadStoreElimination();
-FEXCore::IR::Pass* CreatePassDeadCodeElimination();
-FEXCore::IR::Pass* CreateIRCompaction();
-FEXCore::IR::RegisterAllocationPass* CreateRegisterAllocationPass(FEXCore::IR::Pass* CompactionPass, bool OptimizeSRA);
-FEXCore::IR::Pass* CreateStaticRegisterAllocationPass();
-FEXCore::IR::Pass* CreateLongDivideEliminationPass();
+std::unique_ptr<FEXCore::IR::Pass> CreateConstProp(bool InlineConstants);
+std::unique_ptr<FEXCore::IR::Pass> CreateContextLoadStoreElimination();
+std::unique_ptr<FEXCore::IR::Pass> CreateSyscallOptimization();
+std::unique_ptr<FEXCore::IR::Pass> CreateDeadFlagCalculationEliminination();
+std::unique_ptr<FEXCore::IR::Pass> CreateDeadStoreElimination();
+std::unique_ptr<FEXCore::IR::Pass> CreatePassDeadCodeElimination();
+std::unique_ptr<FEXCore::IR::Pass> CreateIRCompaction();
+std::unique_ptr<FEXCore::IR::RegisterAllocationPass> CreateRegisterAllocationPass(FEXCore::IR::Pass* CompactionPass, bool OptimizeSRA);
+std::unique_ptr<FEXCore::IR::Pass> CreateStaticRegisterAllocationPass();
+std::unique_ptr<FEXCore::IR::Pass> CreateLongDivideEliminationPass();
 
 namespace Validation {
-FEXCore::IR::Pass* CreateIRValidation();
-FEXCore::IR::Pass* CreatePhiValidation();
-FEXCore::IR::Pass* CreateValueDominanceValidation();
+std::unique_ptr<FEXCore::IR::Pass> CreateIRValidation();
+std::unique_ptr<FEXCore::IR::Pass> CreatePhiValidation();
+std::unique_ptr<FEXCore::IR::Pass> CreateValueDominanceValidation();
 }
 }
 

--- a/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -992,8 +992,8 @@ bool ConstProp::Run(IREmitter *IREmit) {
   return Changed;
 }
 
-FEXCore::IR::Pass* CreateConstProp(bool InlineConstants) {
-  return new ConstProp(InlineConstants);
+std::unique_ptr<FEXCore::IR::Pass> CreateConstProp(bool InlineConstants) {
+  return std::make_unique<ConstProp>(InlineConstants);
 }
 
 }

--- a/External/FEXCore/Source/Interface/IR/Passes/DeadCodeElimination.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/DeadCodeElimination.cpp
@@ -59,10 +59,8 @@ void DeadCodeElimination::markUsed(OrderedNodeWrapper *CodeOp, IROp_Header *IROp
 
 }
 
-
-FEXCore::IR::Pass* CreatePassDeadCodeElimination() {
-  return new DeadCodeElimination{};
+std::unique_ptr<FEXCore::IR::Pass> CreatePassDeadCodeElimination() {
+  return std::make_unique<DeadCodeElimination>();
 }
-
 
 }

--- a/External/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
@@ -283,7 +283,7 @@ class RCLSE final : public FEXCore::IR::Pass {
 public:
   RCLSE() {
     ClassifyContextStruct(&ClassifiedStruct);
-    DCE.reset(FEXCore::IR::CreatePassDeadCodeElimination());
+    DCE = FEXCore::IR::CreatePassDeadCodeElimination();
   }
   bool Run(FEXCore::IR::IREmitter *IREmit) override;
 private:
@@ -636,8 +636,8 @@ bool RCLSE::Run(FEXCore::IR::IREmitter *IREmit) {
 
 namespace FEXCore::IR {
 
-FEXCore::IR::Pass* CreateContextLoadStoreElimination() {
-  return new RCLSE{};
+std::unique_ptr<FEXCore::IR::Pass> CreateContextLoadStoreElimination() {
+  return std::make_unique<RCLSE>();
 }
 
 }

--- a/External/FEXCore/Source/Interface/IR/Passes/DeadStoreElimination.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/DeadStoreElimination.cpp
@@ -331,8 +331,8 @@ bool DeadStoreElimination::Run(IREmitter *IREmit) {
   return Changed;
 }
 
-FEXCore::IR::Pass* CreateDeadStoreElimination() {
-  return new DeadStoreElimination{};
+std::unique_ptr<FEXCore::IR::Pass> CreateDeadStoreElimination() {
+  return std::make_unique<DeadStoreElimination>();
 }
 
 }

--- a/External/FEXCore/Source/Interface/IR/Passes/IRCompaction.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/IRCompaction.cpp
@@ -199,8 +199,8 @@ bool IRCompaction::Run(IREmitter *IREmit) {
   return true;
 }
 
-FEXCore::IR::Pass* CreateIRCompaction() {
-  return new IRCompaction{};
+std::unique_ptr<FEXCore::IR::Pass> CreateIRCompaction() {
+  return std::make_unique<IRCompaction>();
 }
 
 }

--- a/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
@@ -285,7 +285,7 @@ bool IRValidation::Run(IREmitter *IREmit) {
   return false;
 }
 
-FEXCore::IR::Pass* CreateIRValidation() {
-  return new IRValidation{};
+std::unique_ptr<FEXCore::IR::Pass> CreateIRValidation() {
+  return std::make_unique<IRValidation>();
 }
 }

--- a/External/FEXCore/Source/Interface/IR/Passes/LongDivideRemovalPass.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/LongDivideRemovalPass.cpp
@@ -106,7 +106,7 @@ bool LongDivideEliminationPass::Run(IREmitter *IREmit) {
   return Changed;
 }
 
-FEXCore::IR::Pass* CreateLongDivideEliminationPass() {
-  return new LongDivideEliminationPass{};
+std::unique_ptr<FEXCore::IR::Pass> CreateLongDivideEliminationPass() {
+  return std::make_unique<LongDivideEliminationPass>();
 }
 }

--- a/External/FEXCore/Source/Interface/IR/Passes/PhiValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/PhiValidation.cpp
@@ -66,8 +66,8 @@ bool PhiValidation::Run(IREmitter *IREmit) {
   return false;
 }
 
-FEXCore::IR::Pass* CreatePhiValidation() {
-  return new PhiValidation{};
+std::unique_ptr<FEXCore::IR::Pass> CreatePhiValidation() {
+  return std::make_unique<PhiValidation>();
 }
 
 }

--- a/External/FEXCore/Source/Interface/IR/Passes/RedundantFlagCalculationElimination.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/RedundantFlagCalculationElimination.cpp
@@ -59,8 +59,8 @@ bool DeadFlagCalculationEliminination::Run(IREmitter *IREmit) {
   return Changed;
 }
 
-FEXCore::IR::Pass* CreateDeadFlagCalculationEliminination() {
-  return new DeadFlagCalculationEliminination{};
+std::unique_ptr<FEXCore::IR::Pass> CreateDeadFlagCalculationEliminination() {
+  return std::make_unique<DeadFlagCalculationEliminination>();
 }
 
 }

--- a/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -1538,7 +1538,7 @@ namespace FEXCore::IR {
     return Changed;
   }
 
-  FEXCore::IR::RegisterAllocationPass* CreateRegisterAllocationPass(FEXCore::IR::Pass* CompactionPass, bool OptimizeSRA) {
-    return new ConstrainedRAPass{CompactionPass, OptimizeSRA};
+  std::unique_ptr<FEXCore::IR::RegisterAllocationPass> CreateRegisterAllocationPass(FEXCore::IR::Pass* CompactionPass, bool OptimizeSRA) {
+    return std::make_unique<ConstrainedRAPass>(CompactionPass, OptimizeSRA);
   }
 }

--- a/External/FEXCore/Source/Interface/IR/Passes/StaticRegisterAllocationPass.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/StaticRegisterAllocationPass.cpp
@@ -94,8 +94,8 @@ bool StaticRegisterAllocationPass::Run(IREmitter *IREmit) {
   return true;
 }
 
-FEXCore::IR::Pass* CreateStaticRegisterAllocationPass() {
-  return new StaticRegisterAllocationPass{};
+std::unique_ptr<FEXCore::IR::Pass> CreateStaticRegisterAllocationPass() {
+  return std::make_unique<StaticRegisterAllocationPass>();
 }
 
 }

--- a/External/FEXCore/Source/Interface/IR/Passes/SyscallOptimization.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/SyscallOptimization.cpp
@@ -44,12 +44,11 @@ bool SyscallOptimization::Run(IREmitter *IREmit) {
     }
   }
 
-
   return Changed;
 }
 
-FEXCore::IR::Pass* CreateSyscallOptimization() {
-  return new SyscallOptimization{};
+std::unique_ptr<FEXCore::IR::Pass> CreateSyscallOptimization() {
+  return std::make_unique<SyscallOptimization>();
 }
 
 }

--- a/External/FEXCore/Source/Interface/IR/Passes/ValueDominanceValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ValueDominanceValidation.cpp
@@ -212,8 +212,8 @@ bool ValueDominanceValidation::Run(IREmitter *IREmit) {
   return false;
 }
 
-FEXCore::IR::Pass* CreateValueDominanceValidation() {
-  return new ValueDominanceValidation{};
+std::unique_ptr<FEXCore::IR::Pass> CreateValueDominanceValidation() {
+  return std::make_unique<ValueDominanceValidation>();
 }
 
 }


### PR DESCRIPTION
Same behavior, but makes the ownership intentions explicit in the interface.

