### PR TITLE
Passes: Replace <iostream> header with narrower equivalents

### DIFF
--- a/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
@@ -11,7 +11,7 @@ $end_info$
 #include "Interface/Core/OpcodeDispatcher.h"
 #include "Common/BitSet.h"
 
-#include <iostream>
+#include <sstream>
 
 namespace {
   struct BlockInfo {

--- a/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
@@ -279,7 +279,7 @@ bool IRValidation::Run(IREmitter *IREmit) {
       Out << "Warnings:" << std::endl << Warnings.str() << std::endl;
     }
 
-    LogMan::Msg::E("%s", Out.str().c_str());
+    LogMan::Msg::EFmt("{}", Out.str());
   }
 
   return false;

--- a/External/FEXCore/Source/Interface/IR/Passes/PhiValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/PhiValidation.cpp
@@ -59,7 +59,7 @@ bool PhiValidation::Run(IREmitter *IREmit) {
 
     Out << "Errors:" << std::endl << Errors.str() << std::endl;
 
-    LogMan::Msg::E(Out.str().c_str());
+    LogMan::Msg::EFmt("{}", Out.str());
   }
 
 

--- a/External/FEXCore/Source/Interface/IR/Passes/PhiValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/PhiValidation.cpp
@@ -8,7 +8,7 @@ $end_info$
 #include "Interface/IR/PassManager.h"
 #include "Interface/Core/OpcodeDispatcher.h"
 
-#include <iostream>
+#include <sstream>
 
 namespace FEXCore::IR::Validation {
 

--- a/External/FEXCore/Source/Interface/IR/Passes/ValueDominanceValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ValueDominanceValidation.cpp
@@ -206,7 +206,7 @@ bool ValueDominanceValidation::Run(IREmitter *IREmit) {
       Out << "Warnings:" << std::endl << Warnings.str() << std::endl;
     }
 
-    LogMan::Msg::E(Out.str().c_str());
+    LogMan::Msg::EFmt("{}", Out.str());
   }
 
   return false;

--- a/External/FEXCore/Source/Interface/IR/Passes/ValueDominanceValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ValueDominanceValidation.cpp
@@ -8,9 +8,9 @@ $end_info$
 #include "Interface/IR/PassManager.h"
 #include "Interface/Core/OpcodeDispatcher.h"
 
-#include <iostream>
 #include <map>
 #include <list>
+#include <sstream>
 #include <unordered_map>
 
 namespace {


### PR DESCRIPTION
`<iostream>` injects a static constructor in translation units that include it, even if its facilities aren't used. We can make use of `<sstream>` to avoid needing to execute those on startup.

While we're in the area, we can pass some logging strings as arguments to a format string instead of directly passing the output as a format string, so that the strings avoid being mangled (especially given we have things like `%ssa` in the strings which can unintentionally be interpreted as a null terminated string specifier).