### PR TITLE
CPUID: Improvements to have a more sane configuration 

### DIFF
--- a/External/FEXCore/Source/Interface/Core/CPUID.h
+++ b/External/FEXCore/Source/Interface/Core/CPUID.h
@@ -24,23 +24,23 @@ private:
 public:
   void Init(FEXCore::Context::Context *ctx);
 
-  FEXCore::CPUID::FunctionResults RunFunction(uint32_t Function, [[maybe_unused]] uint32_t Leaf) {
+  FEXCore::CPUID::FunctionResults RunFunction(uint32_t Function, uint32_t Leaf) {
     auto Handler = FunctionHandlers.find(Function);
 
     if (Handler == FunctionHandlers.end()) {
       #ifndef NDEBUG
-        LogMan::Msg::E("Unhandled CPU ID function, 0x%x", Function);
+        LogMan::Msg::E("Unhandled CPU ID function, 0x%x-0x%x", Function, Leaf);
       #endif
-      return Function_Reserved();
+      return Function_Reserved(Leaf);
     }
 
-    return Handler->second();
+    return Handler->second(Leaf);
   }
 private:
   FEXCore::Context::Context *CTX;
   FEX_CONFIG_OPT(Cores, THREADS);
 
-  using FunctionHandler = std::function<FEXCore::CPUID::FunctionResults()>;
+  using FunctionHandler = std::function<FEXCore::CPUID::FunctionResults(uint32_t Leaf)>;
   void RegisterFunction(uint32_t Function, FunctionHandler Handler) {
     FunctionHandlers[Function] = Handler;
   }
@@ -48,23 +48,26 @@ private:
   std::unordered_map<uint32_t, FunctionHandler> FunctionHandlers;
 
   // Functions
-  FEXCore::CPUID::FunctionResults Function_0h();
-  FEXCore::CPUID::FunctionResults Function_01h();
-  FEXCore::CPUID::FunctionResults Function_02h();
-  FEXCore::CPUID::FunctionResults Function_06h();
-  FEXCore::CPUID::FunctionResults Function_07h();
-  FEXCore::CPUID::FunctionResults Function_15h();
-  FEXCore::CPUID::FunctionResults Function_8000_0000h();
-  FEXCore::CPUID::FunctionResults Function_8000_0001h();
-  FEXCore::CPUID::FunctionResults Function_8000_0002h();
-  FEXCore::CPUID::FunctionResults Function_8000_0003h();
-  FEXCore::CPUID::FunctionResults Function_8000_0004h();
-  FEXCore::CPUID::FunctionResults Function_8000_0005h();
-  FEXCore::CPUID::FunctionResults Function_8000_0006h();
-  FEXCore::CPUID::FunctionResults Function_8000_0007h();
-  FEXCore::CPUID::FunctionResults Function_8000_0008h();
-  FEXCore::CPUID::FunctionResults Function_8000_0009h();
-  FEXCore::CPUID::FunctionResults Function_8000_0019h();
-  FEXCore::CPUID::FunctionResults Function_Reserved();
+  FEXCore::CPUID::FunctionResults Function_0h(uint32_t Leaf);
+  FEXCore::CPUID::FunctionResults Function_01h(uint32_t Leaf);
+  FEXCore::CPUID::FunctionResults Function_02h(uint32_t Leaf);
+  FEXCore::CPUID::FunctionResults Function_04h(uint32_t Leaf);
+  FEXCore::CPUID::FunctionResults Function_06h(uint32_t Leaf);
+  FEXCore::CPUID::FunctionResults Function_07h(uint32_t Leaf);
+  FEXCore::CPUID::FunctionResults Function_0Dh(uint32_t Leaf);
+  FEXCore::CPUID::FunctionResults Function_15h(uint32_t Leaf);
+  FEXCore::CPUID::FunctionResults Function_8000_0000h(uint32_t Leaf);
+  FEXCore::CPUID::FunctionResults Function_8000_0001h(uint32_t Leaf);
+  FEXCore::CPUID::FunctionResults Function_8000_0002h(uint32_t Leaf);
+  FEXCore::CPUID::FunctionResults Function_8000_0003h(uint32_t Leaf);
+  FEXCore::CPUID::FunctionResults Function_8000_0004h(uint32_t Leaf);
+  FEXCore::CPUID::FunctionResults Function_8000_0005h(uint32_t Leaf);
+  FEXCore::CPUID::FunctionResults Function_8000_0006h(uint32_t Leaf);
+  FEXCore::CPUID::FunctionResults Function_8000_0007h(uint32_t Leaf);
+  FEXCore::CPUID::FunctionResults Function_8000_0008h(uint32_t Leaf);
+  FEXCore::CPUID::FunctionResults Function_8000_0009h(uint32_t Leaf);
+  FEXCore::CPUID::FunctionResults Function_8000_0019h(uint32_t Leaf);
+  FEXCore::CPUID::FunctionResults Function_8000_001Dh(uint32_t Leaf);
+  FEXCore::CPUID::FunctionResults Function_Reserved(uint32_t Leaf);
 };
 }

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
@@ -319,8 +319,9 @@ DEF_OP(CPUID) {
   //
   // Result: RAX, RDX. 4xi32
 
-  mov (rsi, GetSrc<RA_64>(Op->Header.Args[0].ID()));
-  mov (rdx, GetSrc<RA_64>(Op->Header.Args[1].ID()));
+  // rsi can be in the source registers, so copy argument to edx first
+  mov (edx, GetSrc<RA_32>(Op->Header.Args[1].ID()));
+  mov (esi, GetSrc<RA_32>(Op->Header.Args[0].ID()));
   mov (rdi, reinterpret_cast<uint64_t>(&CTX->CPUID));
 
   auto NumPush = RA64.size();


### PR DESCRIPTION
When running the cpuid application (http://www.etallen.com/cpuid.html) I noticed
that we were returning some garbage data here.

After initially implementing support for leaf functions, it still didn't resolve the issue.
So I had to fix those in the x86-64 JIT.

I then went through and solved more issues with the function results.

- We now return a more sane CPU family that is near the feature set we support
- APICID now understands how to fill out the data correctly depending on emulated core counts
- Disabled some CPU features that we don't actually support
- Found two more cache functions that we weren't populating
  - Filled with generic data cache size data
  - Only thing that matters is that we ensure that cacheline size is reported as 64bytes
  - L1D: 32KB, L1I: 32KB, L2: 512KB, L3: 8MB claimed for caches
- Implemented Leafs for functions
  - 7h - Only has leaf 0
  - Dh - Extended CPU features support
    - Another register that lets you claim support for x87, SSE, and AVX
    - Leaf 1 & 2 has some additional data
  - 4h & 8000'0001Dh - Extended cache properties
    - Almost the same as each other. One reports slightly less data though