### PR TITLE
Core: After fork make sure to cleanup stacks

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -617,6 +617,9 @@ namespace FEXCore::Context {
 
     // We now only have one thread
     IdleWaitRefCount = 1;
+
+    // Clean up dead stacks
+    FEXCore::Threads::Thread::CleanupAfterFork();
   }
 
   void Context::AddBlockMapping(FEXCore::Core::InternalThreadState *Thread, uint64_t Address, void *Ptr, uint64_t Start, uint64_t Length) {

--- a/External/FEXCore/include/FEXCore/Utils/Threads.h
+++ b/External/FEXCore/include/FEXCore/Utils/Threads.h
@@ -7,8 +7,11 @@ namespace FEXCore::Threads {
 
   class Thread;
   using CreateThreadFunc = std::function<std::unique_ptr<Thread>(ThreadFunc Func, void* Arg)>;
+  using CleanupAfterForkFunc = std::function<void()>;
+
   struct Pointers {
     CreateThreadFunc CreateThread;
+    CleanupAfterForkFunc CleanupAfterFork;
   };
 
   // API
@@ -19,10 +22,19 @@ namespace FEXCore::Threads {
     virtual bool join(void **ret) = 0;
     virtual bool detach() = 0;
     virtual bool IsSelf() = 0;
+
+    /**
+     * @name Calls provided API functions
+     * @{ */
+
     static std::unique_ptr<Thread> Create(
       ThreadFunc Func,
       void* Arg);
 
+    static void CleanupAfterFork();
+    /**  @} */
+
+    // Set API functions
     static void SetInternalPointers(Pointers const &_Ptrs);
   };
 }


### PR DESCRIPTION
After FEX has forked, there aren't any other threads in the process but their stacks remain.
We need to have some book keeping in place to have the stack ranges available to clean up
after fork.

We now keep both live stacks and dead stacks in a dequeue and on fork we will walk both to
clean up all stack objects that aren't our current thread.