### PR TITLE
Support Squashfs based rootfs files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,7 +252,7 @@ add_compile_options(-Wall)
 
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/include/Config.h.in
-  ${CMAKE_BINARY_DIR}/generated/Config.h)
+  ${CMAKE_BINARY_DIR}/generated/ConfigDefines.h)
 
 if (BUILD_TESTS)
   include(CTest)

--- a/Source/Common/CMakeLists.txt
+++ b/Source/Common/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SRCS
   Config.cpp
   EnvironmentLoader.cpp
   FileFormatCheck.cpp
+  RootFSSetup.cpp
   StringUtil.cpp)
 
 add_library(${NAME} STATIC ${SRCS})

--- a/Source/Common/CMakeLists.txt
+++ b/Source/Common/CMakeLists.txt
@@ -1,8 +1,9 @@
 set(NAME Common)
 set(SRCS
   ArgumentLoader.cpp
-  EnvironmentLoader.cpp
   Config.cpp
+  EnvironmentLoader.cpp
+  FileFormatCheck.cpp
   StringUtil.cpp)
 
 add_library(${NAME} STATIC ${SRCS})

--- a/Source/Common/FileFormatCheck.cpp
+++ b/Source/Common/FileFormatCheck.cpp
@@ -1,0 +1,65 @@
+#include <fstream>
+#include <string>
+
+namespace FEX::FormatCheck {
+  bool IsSquashFS(std::string const &Filename) {
+    // If it is a regular file then we need to check if it is a valid archive
+    struct SquashFSHeader {
+      uint32_t magic;
+      uint32_t inode_count;
+      uint32_t mtime;
+      uint32_t block_size;
+      uint32_t fragment_entry_count;
+      uint16_t compression_id;
+      uint16_t block_log;
+      uint16_t flags;
+      uint16_t id_count;
+      uint16_t version_major;
+      uint16_t version_minor;
+      uint64_t More[8]; // More things that don't matter to us
+    };
+
+    SquashFSHeader Header{};
+    std::fstream File(Filename, std::ios::in);
+
+    if (!File.is_open()) {
+      return false;
+    }
+
+    if (!File.seekg(0, std::fstream::end)) {
+      return false;
+    }
+
+    auto FileSize = File.tellg();
+    if (File.fail()) {
+      return false;
+    }
+
+    if (FileSize <= 0) {
+      return false;
+    }
+
+    if (!File.seekg(0, std::fstream::beg)) {
+      return false;
+    }
+
+    if (FileSize < sizeof(SquashFSHeader)) {
+      return false;
+    }
+
+    if (!File.read(reinterpret_cast<char*>(&Header), sizeof(SquashFSHeader))) {
+      return false;
+    }
+
+    // Make sure the cookie matches
+    if (Header.magic == 0x73717368) {
+      // Sanity check the version
+      uint32_t version = (uint32_t)Header.version_major << 16 | Header.version_minor;
+      if (version >= 0x00040000) {
+        // Everything is sane, we can add it
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/Source/Common/FileFormatCheck.h
+++ b/Source/Common/FileFormatCheck.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <string>
+
+namespace FEX::FormatCheck {
+  bool IsSquashFS(std::string const &Filename);
+}

--- a/Source/Common/RootFSSetup.cpp
+++ b/Source/Common/RootFSSetup.cpp
@@ -1,0 +1,124 @@
+#include "ConfigDefines.h"
+#include "Common/Config.h"
+#include "Common/FileFormatCheck.h"
+
+#include <FEXCore/Config/Config.h>
+
+#include <filesystem>
+
+#include <poll.h>
+#include <unistd.h>
+#include <sys/eventfd.h>
+#include <sys/prctl.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+
+namespace FEX::RootFS {
+bool Setup(char **const envp) {
+  // We need to setup the rootfs here
+  // If the configuration is set to use a folder then there is nothing to do
+  // If it is setup to use a squashfs then we need to do something more complex
+
+  FEX_CONFIG_OPT(LDPath, ROOTFS);
+  if (FEX::FormatCheck::IsSquashFS(LDPath())) {
+    pid_t ParentTID = ::getpid();
+    std::string ParentTIDString = std::to_string(ParentTID);
+    std::string Tmp = "/tmp/.FEXMount" + ParentTIDString + "-XXXXXX";
+    char *TempFolder = Tmp.data();
+
+    // Make the temporary mount folder
+    if (mkdtemp(TempFolder) == nullptr) {
+      LogMan::Msg::E("Couldn't create temporary mount name: %s", TempFolder);
+      return false;
+    }
+
+    // Change the permissions
+    if (chmod(TempFolder, 0777) != 0) {
+      LogMan::Msg::E("Couldn't change permissions on temporary mount: %s", TempFolder);
+      rmdir(TempFolder);
+      return false;
+    }
+
+    // Open some pipes for communicating with the new processes
+    int fds[2]{};
+    if (pipe2(fds, 0) != 0) {
+      LogMan::Msg::E("Couldn't open pipe");
+      return false;
+    }
+
+    // Convert the write pipe to a string to pass to the child process
+    std::string PipeString;
+    PipeString = std::to_string(fds[1]);
+
+    pid_t pid = fork();
+    if (pid == 0) {
+      // Child
+      close(fds[0]); // Close read end of pipe
+      const char *argv[6];
+      argv[0] = FEX_INSTALL_PREFIX "/bin/FEXMountDaemon";
+      argv[1] = LDPath().c_str();
+      argv[2] = TempFolder;
+      argv[3] = ParentTIDString.c_str();
+      argv[4] = PipeString.c_str();
+      argv[5] = nullptr;
+
+      if (execve(argv[0], (char * const*)argv, envp) == -1) {
+        // Let the parent know that we couldn't execute for some reason
+        uint64_t error{1};
+        write(fds[1], &error, sizeof(error));
+
+        // Give a hopefully helpful error message for users
+        LogMan::Msg::E("Couldn't execute: %s", argv[0]);
+        LogMan::Msg::E("This means the squashFS rootfs won't be mounted.");
+        LogMan::Msg::E("Expect errors!");
+        // Destroy this fork
+        exit(1);
+      }
+    }
+    else {
+      // Parent
+      // Wait for the child to exit so we can check if it is mounted or not
+      close(fds[1]); // Close write end of the pipe
+
+      // Wait for a message from FEXMountDaemon
+      pollfd PollFD;
+      PollFD.fd = fds[0];
+      PollFD.events = POLLIN;
+
+      poll(&PollFD, 1, -1);
+
+      // Read a value from the pipe to get an expected result
+      // This will come from FEXMountDaemon or our local fork depending on results
+      uint64_t ChildResult{};
+      int Result = read(fds[0], &ChildResult, sizeof(ChildResult));
+
+      if (Result != sizeof(ChildResult)) {
+        LogMan::Msg::D("Spurious read error");
+        return false;
+      }
+
+      if (ChildResult == 1) {
+        // Error
+        LogMan::Msg::D("FEXMountDaemon couldn't mount child for some reason");
+        return false;
+      }
+
+      // Check if we have an directory inside our temp folder
+      std::string Path = TempFolder;
+      std::string PathUser = Path + "/usr";
+      if (!std::filesystem::exists(PathUser)) {
+        LogMan::Msg::D("Child couldn't mount rootfs, /usr doesn't exist");
+        rmdir(TempFolder);
+        return false;
+      }
+
+      // If everything has passed then we can now update the rootfs path
+      FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_ROOTFS, Path);
+      return true;
+    }
+  }
+
+  // Nothing to do
+  return true;
+}
+}

--- a/Source/Common/RootFSSetup.h
+++ b/Source/Common/RootFSSetup.h
@@ -1,0 +1,5 @@
+#pragma once
+
+namespace FEX::RootFS {
+  bool Setup(char **const envp);
+}

--- a/Source/Tests/FEXBash.cpp
+++ b/Source/Tests/FEXBash.cpp
@@ -5,7 +5,7 @@ desc: Launches bash under FEX and passes arguments via -c to it
 $end_info$
 */
 
-#include "Config.h"
+#include "ConfigDefines.h"
 #include "Common/ArgumentLoader.h"
 #include "Common/EnvironmentLoader.h"
 #include "Common/Config.h"

--- a/Source/Tests/FEXLoader.cpp
+++ b/Source/Tests/FEXLoader.cpp
@@ -6,8 +6,9 @@ $end_info$
 */
 
 #include "Common/ArgumentLoader.h"
-#include "Common/EnvironmentLoader.h"
 #include "Common/Config.h"
+#include "Common/EnvironmentLoader.h"
+#include "Common/RootFSSetup.h"
 #include "ELFCodeLoader.h"
 #include "ELFCodeLoader2.h"
 #include "Tests/LinuxSyscalls/x32/Syscalls.h"
@@ -356,6 +357,12 @@ int main(int argc, char **argv, char **const envp) {
   FEXCore::Config::ReloadMetaLayer();
   FEXCore::Config::Set(FEXCore::Config::CONFIG_IS_INTERPRETER, IsInterpreter ? "1" : "0");
   FEXCore::Config::Set(FEXCore::Config::CONFIG_INTERPRETER_INSTALLED, IsInterpreterInstalled() ? "1" : "0");
+
+  // Ensure RootFS is setup before config options try to pull CONFIG_ROOTFS
+  if (!FEX::RootFS::Setup(envp)) {
+    LogMan::Msg::E("RootFS failure");
+    return -1;
+  }
 
   FEX_CONFIG_OPT(SilentLog, SILENTLOG);
   FEX_CONFIG_OPT(AOTIRCapture, AOTIRCAPTURE);

--- a/Source/Tools/CMakeLists.txt
+++ b/Source/Tools/CMakeLists.txt
@@ -3,6 +3,7 @@ if (ENABLE_VISUAL_DEBUGGER)
 endif()
 
 add_subdirectory(FEXConfig/)
+add_subdirectory(FEXMountDaemon/)
 
 set(NAME Opt)
 set(SRCS Opt.cpp)

--- a/Source/Tools/FEXConfig/Main.cpp
+++ b/Source/Tools/FEXConfig/Main.cpp
@@ -1,4 +1,5 @@
 #include "Common/Config.h"
+#include "Common/FileFormatCheck.h"
 
 #include <FEXCore/Utils/Event.h>
 
@@ -11,6 +12,7 @@
 #include <memory>
 #include <mutex>
 #include <filesystem>
+#include <fstream>
 #include <sys/inotify.h>
 #include <thread>
 #include <unistd.h>
@@ -106,6 +108,13 @@ namespace {
     for (auto &it : std::filesystem::directory_iterator(RootFS)) {
       if (it.is_directory()) {
         NamedRootFS.emplace_back(it.path().filename());
+      }
+      else if (it.is_regular_file()) {
+        // If it is a regular file then we need to check if it is a valid archive
+        if (it.path().extension() == "sqsh" &&
+            FEX::FormatCheck::IsSquashFS(it.path().string())) {
+          NamedRootFS.emplace_back(it.path().filename());
+        }
       }
     }
   }

--- a/Source/Tools/FEXMountDaemon/CMakeLists.txt
+++ b/Source/Tools/FEXMountDaemon/CMakeLists.txt
@@ -1,0 +1,9 @@
+set(NAME FEXMountDaemon)
+set(SRCS Main.cpp)
+
+add_executable(${NAME} ${SRCS})
+
+install(TARGETS ${NAME}
+  RUNTIME
+  DESTINATION bin
+  COMPONENT runtime)

--- a/Source/Tools/FEXMountDaemon/Main.cpp
+++ b/Source/Tools/FEXMountDaemon/Main.cpp
@@ -142,16 +142,20 @@ int main(int argc, char **argv, char **envp) {
 
     if (pid == 0) {
       const char *argv[5];
-      argv[0] = "/usr/bin/fusermount";
+      argv[0] = "/bin/fusermount";
       argv[1] = "-u";
       argv[2] = "-q";
       argv[3] = MountPath;
       argv[4] = nullptr;
 
       if (execve(argv[0], (char * const*)argv, envp) == -1) {
-        fprintf(stderr, "fusermount failed to execute. You may have an mount living at '%s' to clean up now\n", SquashFSPath);
-        fprintf(stderr, "Try `%s %s %s %s`\n", argv[0], argv[1], argv[2], argv[3]);
-        exit(1);
+        // Try another location
+        argv[0] = "/usr/bin/fusermount";
+        if (execve(argv[0], (char * const*)argv, envp) == -1) {
+          fprintf(stderr, "fusermount failed to execute. You may have an mount living at '%s' to clean up now\n", SquashFSPath);
+          fprintf(stderr, "Try `%s %s %s %s`\n", argv[0], argv[1], argv[2], argv[3]);
+          exit(1);
+        }
       }
     }
     else {

--- a/Source/Tools/FEXMountDaemon/Main.cpp
+++ b/Source/Tools/FEXMountDaemon/Main.cpp
@@ -1,0 +1,167 @@
+#include <atomic>
+#include <cstdlib>
+#include <cstdint>
+#include <errno.h>
+#include <poll.h>
+#include <stdio.h>
+#include <string.h>
+#include <string>
+#include <unistd.h>
+#include <signal.h>
+#include <linux/limits.h>
+#include <sys/prctl.h>
+#include <sys/wait.h>
+#include <sys/inotify.h>
+
+namespace {
+static std::atomic<bool> ShuttingDown{};
+static int ParentPIDProcess{};
+
+void ActionHandler(int sig, siginfo_t *info, void *context) {
+  if (sig == SIGUSR1 &&
+      info->si_pid == ParentPIDProcess) {
+    // Begin shutdown sequence
+    ShuttingDown = true;
+  }
+  else if (sig == SIGCHLD) {
+    if (!ShuttingDown.load()) {
+      // If our child process shutdown while our parent is still running
+      // Then the parent loses its rootfs and problems occur
+      fprintf(stderr, "FEXMountDaemon child process from squashfuse has closed\n");
+      fprintf(stderr, "Expect errors!\n");
+      ShuttingDown = true;
+    }
+  }
+  else {
+    // Signal sent directly to process
+    // Ignore it
+  }
+}
+}
+
+int main(int argc, char **argv, char **envp) {
+  if (argc < 5) {
+    fprintf(stderr, "usage: %s <SquashFS> <MountPoint> <Parent PID> <pipe wr>\n", argv[0]);
+    return -1;
+  }
+
+  const char *SquashFSPath = argv[1];
+  const char *MountPath = argv[2];
+  ParentPIDProcess = std::atoi(argv[3]);
+  int pipe_wr = std::atoi(argv[4]);
+
+  // Switch this process over to a new session id
+  // Probably not required but allows this to become the process group leader of its session
+  ::setsid();
+
+  // Create local FDs so our internal forks can communicate
+  int localfds[2];
+  pipe2(localfds, 0);
+
+  ::prctl(PR_SET_PDEATHSIG, SIGUSR1);
+  ::prctl(PR_SET_CHILD_SUBREAPER, 1);
+
+  pid_t pid = fork();
+  if (pid == 0) {
+    // Child
+    close(localfds[0]); // Close read side
+    const char *argv[4];
+    argv[0] = "/usr/bin/squashfuse";
+    argv[1] = SquashFSPath;
+    argv[2] = MountPath;
+    argv[3] = nullptr;
+
+    // Try and execute squashfuse to mount our rootfs
+    if (execve(argv[0], (char * const*)argv, envp) == -1) {
+      // Let the parent know that we couldn't execute for some reason
+      uint64_t error{1};
+      write(localfds[1], &error, sizeof(error));
+
+      // Give a hopefully helpful error message for users
+      fprintf(stderr, "'%s' Couldn't execute for some reason: %d %s\n", argv[0], errno, strerror(errno));
+      fprintf(stderr, "To mount squashfs rootfs files you need squashfuse installed\n");
+      fprintf(stderr, "Check your FUSE setup.\n");
+
+      // End the child
+      exit(1);
+    }
+  }
+  else {
+    // Parent
+
+    close(localfds[1]); // Close the write side
+    // Wait for the child to exit
+    // This will happen with execve of squashmount or exit on failure
+    waitpid(pid, nullptr, 0);
+
+    // Setup our signal handlers now so we can capture some events
+    struct sigaction act{};
+    act.sa_sigaction = ActionHandler;
+    act.sa_flags = SA_SIGINFO;
+
+    // SIGUSR1 when FEX exits
+    sigaction(SIGUSR1, &act, nullptr);
+    // SIGCHLD if squashfuse exits early
+    sigaction(SIGCHLD, &act, nullptr);
+    // SIGTERM if something is trying to terminate us
+    sigaction(SIGTERM, &act, nullptr);
+
+    // Check the child pipe for messages
+    pollfd PollFD;
+    PollFD.fd = localfds[0];
+    PollFD.events = POLLIN;
+
+    int Result = poll(&PollFD, 1, 0);
+
+    if (Result == 1 && PollFD.revents & POLLIN) {
+      // Child couldn't execve for whatever reason
+      // Remove the mount path and leave Just in case it was created
+      rmdir(MountPath);
+
+      // Tell FEX that we encountered an issue
+      uint64_t c = 1;
+      write(pipe_wr, &c, sizeof(c));
+      return 1;
+    }
+
+    // Close the pipe now
+    close(localfds[0]);
+
+    // Tell FEX that it can continue booting
+    uint64_t c = 0;
+    write(pipe_wr, &c, sizeof(c));
+
+    // Sleep until we receive a shutdown signal
+    // Needs to loop in case of EINTR
+    while (!ShuttingDown.load()) {
+      select(0, nullptr, nullptr, nullptr, nullptr);
+    }
+
+    // fusermount for unmounting the mountpoint, then the squashfuse will exit automatically
+    pid = fork();
+
+    if (pid == 0) {
+      const char *argv[5];
+      argv[0] = "/usr/bin/fusermount";
+      argv[1] = "-u";
+      argv[2] = "-q";
+      argv[3] = MountPath;
+      argv[4] = nullptr;
+
+      if (execve(argv[0], (char * const*)argv, envp) == -1) {
+        fprintf(stderr, "fusermount failed to execute. You may have an mount living at '%s' to clean up now\n", SquashFSPath);
+        fprintf(stderr, "Try `%s %s %s %s`\n", argv[0], argv[1], argv[2], argv[3]);
+        exit(1);
+      }
+    }
+    else {
+      // Wait for fusermount to leave
+      waitpid(pid, nullptr, 0);
+
+      // Remove the mount path and leave
+      rmdir(MountPath);
+    }
+  }
+
+  return 0;
+}


### PR DESCRIPTION
This adds support to FEXLoader and FEXConfig to automatically mount and manage squashfs rootfs files.

Startup time is impacted around 200-400ms per execve. Which isn't a terrible tradeoff from needing a loose filesystem sitting on the drive.

Additional stats
A loose rootfs consumes 616MB
The loose rootfs getting compressed to tar.gz is 329MB
The loose rootfs getting compressed to a squashfs with zstd is 299MB