### PR TITLE
Context: Move GPR size retrieval to its own function

### DIFF
--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -242,6 +242,8 @@ namespace FEXCore::Context {
 
     std::vector<FEXCore::Core::InternalThreadState*> *const GetThreads() { return &Threads; }
 
+    uint8_t GetGPRSize() const { return Config.Is64BitMode ? 8 : 4; }
+
     void AddNamedRegion(uintptr_t Base, uintptr_t Size, uintptr_t Offset, const std::string &filename);
     void RemoveNamedRegion(uintptr_t Base, uintptr_t Size);
 

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -655,7 +655,7 @@ namespace FEXCore::Context {
 
     Thread->OpDispatcher->BeginFunction(GuestRIP, CodeBlocks);
 
-    uint8_t GPRSize = Config.Is64BitMode ? 8 : 4;
+    const uint8_t GPRSize = GetGPRSize();
 
     for (size_t j = 0; j < CodeBlocks->size(); ++j) {
       FEXCore::Frontend::Decoder::DecodedBlocks const &Block = CodeBlocks->at(j);
@@ -735,7 +735,7 @@ namespace FEXCore::Context {
             return { nullptr, nullptr, 0, 0, 0, 0 };
           }
           else {
-            uint8_t GPRSize = Config.Is64BitMode ? 8 : 4;
+            const uint8_t GPRSize = GetGPRSize();
 
             // We had some instructions. Early exit
             Thread->OpDispatcher->_ExitFunction(Thread->OpDispatcher->_EntrypointOffset(Block.Entry + BlockInstructionsLength - GuestRIP, GPRSize));

--- a/External/FEXCore/Source/Interface/Core/Frontend.cpp
+++ b/External/FEXCore/Source/Interface/Core/Frontend.cpp
@@ -939,7 +939,7 @@ void Decoder::BranchTargetInMultiblockRange() {
 
   // If the RIP setting is conditional AND within our symbol range then it can be considered for multiblock
   uint64_t TargetRIP = 0;
-  uint8_t GPRSize = CTX->Config.Is64BitMode ? 8 : 4;
+  const uint8_t GPRSize = CTX->GetGPRSize();
   bool Conditional = true;
 
   switch (DecodeInst->OP) {

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -85,7 +85,7 @@ public:
       auto it = JumpTargets.find(NextRIP);
       if (it == JumpTargets.end()) {
 
-        uint8_t GPRSize = CTX->Config.Is64BitMode ? 8 : 4;
+        const uint8_t GPRSize = CTX->GetGPRSize();
         // If we don't have a jump target to a new block then we have to leave
         // Set the RIP to the next instruction and leave
         auto RelocatedNextRIP = _EntrypointOffset(NextRIP - Entry, GPRSize);


### PR DESCRIPTION
This is repeated in quite a few spots throughout the opcode dispatcher, so we can place it in a utility function and use it instead.