### PR TITLE
Frontend: Make lookup tables static in MapModRMToReg

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Frontend.cpp
+++ b/External/FEXCore/Source/Interface/Core/Frontend.cpp
@@ -21,7 +21,7 @@ namespace FEXCore::Frontend {
 using namespace FEXCore::X86Tables;
 
 static uint32_t MapModRMToReg(uint8_t REX, uint8_t bits, bool HighBits, bool HasREX, bool HasXMM, bool HasMM, uint8_t InvalidOffset = 16) {
-  using GPRArray = std::array<uint64_t, 16>;
+  using GPRArray = std::array<uint32_t, 16>;
 
   static constexpr GPRArray GPRIndexes = {
     // Classical ordering?

--- a/External/FEXCore/Source/Interface/Core/Frontend.cpp
+++ b/External/FEXCore/Source/Interface/Core/Frontend.cpp
@@ -21,7 +21,9 @@ namespace FEXCore::Frontend {
 using namespace FEXCore::X86Tables;
 
 static uint32_t MapModRMToReg(uint8_t REX, uint8_t bits, bool HighBits, bool HasREX, bool HasXMM, bool HasMM, uint8_t InvalidOffset = 16) {
-  constexpr std::array<uint64_t, 16> GPRIndexes = {
+  using GPRArray = std::array<uint64_t, 16>;
+
+  static constexpr GPRArray GPRIndexes = {
     // Classical ordering?
     FEXCore::X86State::REG_RAX,
     FEXCore::X86State::REG_RCX,
@@ -41,7 +43,7 @@ static uint32_t MapModRMToReg(uint8_t REX, uint8_t bits, bool HighBits, bool Has
     FEXCore::X86State::REG_R15,
   };
 
-  constexpr std::array<uint64_t, 16> GPR8BitHighIndexes = {
+  static constexpr GPRArray GPR8BitHighIndexes = {
     // Classical ordering?
     FEXCore::X86State::REG_RAX,
     FEXCore::X86State::REG_RCX,
@@ -61,7 +63,7 @@ static uint32_t MapModRMToReg(uint8_t REX, uint8_t bits, bool HighBits, bool Has
     FEXCore::X86State::REG_R15,
   };
 
-  constexpr std::array<uint64_t, 16> XMMIndexes = {
+  static constexpr GPRArray XMMIndexes = {
     FEXCore::X86State::REG_XMM_0,
     FEXCore::X86State::REG_XMM_1,
     FEXCore::X86State::REG_XMM_2,
@@ -80,7 +82,7 @@ static uint32_t MapModRMToReg(uint8_t REX, uint8_t bits, bool HighBits, bool Has
     FEXCore::X86State::REG_XMM_15,
   };
 
-  constexpr std::array<uint64_t, 16> MMIndexes = {
+  static constexpr GPRArray MMIndexes = {
     FEXCore::X86State::REG_MM_0,
     FEXCore::X86State::REG_MM_1,
     FEXCore::X86State::REG_MM_2,
@@ -99,7 +101,7 @@ static uint32_t MapModRMToReg(uint8_t REX, uint8_t bits, bool HighBits, bool Has
     FEXCore::X86State::REG_INVALID
   };
 
-  const std::array<uint64_t, 16> *GPRs = &GPRIndexes;
+  const GPRArray *GPRs = &GPRIndexes;
   if (HasXMM) {
     GPRs = &XMMIndexes;
   }


### PR DESCRIPTION
Allows clang to emit better code, since it doesn't need to push all the values onto the stack for every invocation.

<details>
  <summary>Previous codegen</summary>

```asm
MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char):               # @MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char)
        sub     rsp, 392
        mov     r10b, byte ptr [rsp + 400]
        movups  xmm0, xmmword ptr [rip + .L__const.MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char).GPRIndexes+112]
        movaps  xmmword ptr [rsp + 368], xmm0
        movups  xmm0, xmmword ptr [rip + .L__const.MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char).GPRIndexes+96]
        movaps  xmmword ptr [rsp + 352], xmm0
        movups  xmm0, xmmword ptr [rip + .L__const.MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char).GPRIndexes+80]
        movaps  xmmword ptr [rsp + 336], xmm0
        movups  xmm0, xmmword ptr [rip + .L__const.MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char).GPRIndexes+64]
        movaps  xmmword ptr [rsp + 320], xmm0
        movups  xmm0, xmmword ptr [rip + .L__const.MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char).GPRIndexes+48]
        movaps  xmmword ptr [rsp + 304], xmm0
        movups  xmm0, xmmword ptr [rip + .L__const.MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char).GPRIndexes+32]
        movaps  xmmword ptr [rsp + 288], xmm0
        movups  xmm0, xmmword ptr [rip + .L__const.MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char).GPRIndexes+16]
        movaps  xmmword ptr [rsp + 272], xmm0
        movups  xmm0, xmmword ptr [rip + .L__const.MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char).GPRIndexes]
        movaps  xmmword ptr [rsp + 256], xmm0
        movups  xmm0, xmmword ptr [rip + .L__const.MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char).GPR8BitHighIndexes+112]
        movaps  xmmword ptr [rsp + 240], xmm0
        movups  xmm0, xmmword ptr [rip + .L__const.MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char).GPR8BitHighIndexes+96]
        movaps  xmmword ptr [rsp + 224], xmm0
        movups  xmm0, xmmword ptr [rip + .L__const.MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char).GPR8BitHighIndexes+80]
        movaps  xmmword ptr [rsp + 208], xmm0
        movups  xmm0, xmmword ptr [rip + .L__const.MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char).GPR8BitHighIndexes+64]
        movaps  xmmword ptr [rsp + 192], xmm0
        movups  xmm0, xmmword ptr [rip + .L__const.MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char).GPR8BitHighIndexes+48]
        movaps  xmmword ptr [rsp + 176], xmm0
        movups  xmm0, xmmword ptr [rip + .L__const.MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char).GPR8BitHighIndexes+32]
        movaps  xmmword ptr [rsp + 160], xmm0
        movups  xmm0, xmmword ptr [rip + .L__const.MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char).GPR8BitHighIndexes+16]
        movaps  xmmword ptr [rsp + 144], xmm0
        movups  xmm0, xmmword ptr [rip + .L__const.MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char).GPR8BitHighIndexes]
        movaps  xmmword ptr [rsp + 128], xmm0
        movups  xmm0, xmmword ptr [rip + .L__const.MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char).XMMIndexes+112]
        movaps  xmmword ptr [rsp + 112], xmm0
        movups  xmm0, xmmword ptr [rip + .L__const.MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char).XMMIndexes+96]
        movaps  xmmword ptr [rsp + 96], xmm0
        movups  xmm0, xmmword ptr [rip + .L__const.MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char).XMMIndexes+80]
        movaps  xmmword ptr [rsp + 80], xmm0
        movups  xmm0, xmmword ptr [rip + .L__const.MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char).XMMIndexes+64]
        movaps  xmmword ptr [rsp + 64], xmm0
        movups  xmm0, xmmword ptr [rip + .L__const.MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char).XMMIndexes+48]
        movaps  xmmword ptr [rsp + 48], xmm0
        movups  xmm0, xmmword ptr [rip + .L__const.MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char).XMMIndexes+32]
        movaps  xmmword ptr [rsp + 32], xmm0
        movups  xmm0, xmmword ptr [rip + .L__const.MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char).XMMIndexes+16]
        movaps  xmmword ptr [rsp + 16], xmm0
        movups  xmm0, xmmword ptr [rip + .L__const.MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char).XMMIndexes]
        movaps  xmmword ptr [rsp], xmm0
        movups  xmm0, xmmword ptr [rip + .L__const.MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char).MMIndexes+112]
        movaps  xmmword ptr [rsp - 16], xmm0
        movups  xmm0, xmmword ptr [rip + .L__const.MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char).MMIndexes+96]
        movaps  xmmword ptr [rsp - 32], xmm0
        movups  xmm0, xmmword ptr [rip + .L__const.MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char).MMIndexes+80]
        movaps  xmmword ptr [rsp - 48], xmm0
        movups  xmm0, xmmword ptr [rip + .L__const.MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char).MMIndexes+64]
        movaps  xmmword ptr [rsp - 64], xmm0
        movups  xmm0, xmmword ptr [rip + .L__const.MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char).MMIndexes+48]
        movaps  xmmword ptr [rsp - 80], xmm0
        movups  xmm0, xmmword ptr [rip + .L__const.MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char).MMIndexes+32]
        movaps  xmmword ptr [rsp - 96], xmm0
        movups  xmm0, xmmword ptr [rip + .L__const.MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char).MMIndexes+16]
        movaps  xmmword ptr [rsp - 112], xmm0
        movups  xmm0, xmmword ptr [rip + .L__const.MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char).MMIndexes]
        movaps  xmmword ptr [rsp - 128], xmm0
        test    r8d, r8d
        je      .LBB0_2
        mov     rcx, rsp
        jmp     .LBB0_3
.LBB0_2:
        test    r9b, r9b
        lea     rax, [rsp - 128]
        lea     r8, [rsp + 256]
        cmove   rax, r8
        test    cl, cl
        lea     rcx, [rsp + 128]
        cmovne  rcx, r8
        test    dl, dl
        cmove   rcx, rax
        test    r9b, r9b
        cmovne  rcx, rax
.LBB0_3:
        movzx   eax, dil
        shl     eax, 3
        movzx   edx, sil
        or      edx, eax
        mov     eax, 255
        cmp     dl, r10b
        je      .LBB0_5
        mov     eax, edx
        mov     eax, dword ptr [rcx + 8*rax]
.LBB0_5:
        add     rsp, 392
        ret
.L__const.MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char).GPRIndexes:
        .quad   0                               # 0x0
        .quad   2                               # 0x2
        .quad   3                               # 0x3
        .quad   1                               # 0x1
        .quad   7                               # 0x7
        .quad   6                               # 0x6
        .quad   4                               # 0x4
        .quad   5                               # 0x5
        .quad   8                               # 0x8
        .quad   9                               # 0x9
        .quad   10                              # 0xa
        .quad   11                              # 0xb
        .quad   12                              # 0xc
        .quad   13                              # 0xd
        .quad   14                              # 0xe
        .quad   15                              # 0xf

.L__const.MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char).GPR8BitHighIndexes:
        .quad   0                               # 0x0
        .quad   2                               # 0x2
        .quad   3                               # 0x3
        .quad   1                               # 0x1
        .quad   0                               # 0x0
        .quad   2                               # 0x2
        .quad   3                               # 0x3
        .quad   1                               # 0x1
        .quad   8                               # 0x8
        .quad   9                               # 0x9
        .quad   10                              # 0xa
        .quad   11                              # 0xb
        .quad   12                              # 0xc
        .quad   13                              # 0xd
        .quad   14                              # 0xe
        .quad   15                              # 0xf

.L__const.MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char).XMMIndexes:
        .quad   16                              # 0x10
        .quad   17                              # 0x11
        .quad   18                              # 0x12
        .quad   19                              # 0x13
        .quad   20                              # 0x14
        .quad   21                              # 0x15
        .quad   22                              # 0x16
        .quad   23                              # 0x17
        .quad   24                              # 0x18
        .quad   25                              # 0x19
        .quad   26                              # 0x1a
        .quad   27                              # 0x1b
        .quad   28                              # 0x1c
        .quad   29                              # 0x1d
        .quad   30                              # 0x1e
        .quad   31                              # 0x1f

.L__const.MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char).MMIndexes:
        .quad   32                              # 0x20
        .quad   33                              # 0x21
        .quad   34                              # 0x22
        .quad   35                              # 0x23
        .quad   36                              # 0x24
        .quad   37                              # 0x25
        .quad   38                              # 0x26
        .quad   39                              # 0x27
        .quad   255                             # 0xff
        .quad   255                             # 0xff
        .quad   255                             # 0xff
        .quad   255                             # 0xff
        .quad   255                             # 0xff
        .quad   255                             # 0xff
        .quad   255                             # 0xff
        .quad   255                             # 0xff
```
</details>

<details>
  <summary>After codegen</summary>

```asm
MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char):               # @MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char)
        mov     r11d, offset MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char)::XMMIndexes
        mov     r10b, byte ptr [rsp + 8]
        test    r8d, r8d
        jne     .LBB0_2
        mov     eax, offset MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char)::MMIndexes
        mov     r8d, offset MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char)::GPRIndexes
        test    r9b, r9b
        cmove   rax, r8
        mov     r11d, offset MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char)::GPR8BitHighIndexes
        test    cl, cl
        cmovne  r11, r8
        test    dl, dl
        cmove   r11, rax
        test    r9b, r9b
        cmovne  r11, rax
.LBB0_2:
        movzx   eax, dil
        shl     eax, 3
        movzx   ecx, sil
        or      ecx, eax
        mov     eax, 255
        cmp     cl, r10b
        je      .LBB0_4
        mov     eax, ecx
        mov     eax, dword ptr [r11 + 8*rax]
.LBB0_4:
        ret
MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char)::GPRIndexes:
        .quad   0                               # 0x0
        .quad   2                               # 0x2
        .quad   3                               # 0x3
        .quad   1                               # 0x1
        .quad   7                               # 0x7
        .quad   6                               # 0x6
        .quad   4                               # 0x4
        .quad   5                               # 0x5
        .quad   8                               # 0x8
        .quad   9                               # 0x9
        .quad   10                              # 0xa
        .quad   11                              # 0xb
        .quad   12                              # 0xc
        .quad   13                              # 0xd
        .quad   14                              # 0xe
        .quad   15                              # 0xf

MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char)::GPR8BitHighIndexes:
        .quad   0                               # 0x0
        .quad   2                               # 0x2
        .quad   3                               # 0x3
        .quad   1                               # 0x1
        .quad   0                               # 0x0
        .quad   2                               # 0x2
        .quad   3                               # 0x3
        .quad   1                               # 0x1
        .quad   8                               # 0x8
        .quad   9                               # 0x9
        .quad   10                              # 0xa
        .quad   11                              # 0xb
        .quad   12                              # 0xc
        .quad   13                              # 0xd
        .quad   14                              # 0xe
        .quad   15                              # 0xf

MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char)::XMMIndexes:
        .quad   16                              # 0x10
        .quad   17                              # 0x11
        .quad   18                              # 0x12
        .quad   19                              # 0x13
        .quad   20                              # 0x14
        .quad   21                              # 0x15
        .quad   22                              # 0x16
        .quad   23                              # 0x17
        .quad   24                              # 0x18
        .quad   25                              # 0x19
        .quad   26                              # 0x1a
        .quad   27                              # 0x1b
        .quad   28                              # 0x1c
        .quad   29                              # 0x1d
        .quad   30                              # 0x1e
        .quad   31                              # 0x1f

MapModRMToReg(unsigned char, unsigned char, bool, bool, bool, bool, unsigned char)::MMIndexes:
        .quad   32                              # 0x20
        .quad   33                              # 0x21
        .quad   34                              # 0x22
        .quad   35                              # 0x23
        .quad   36                              # 0x24
        .quad   37                              # 0x25
        .quad   38                              # 0x26
        .quad   39                              # 0x27
        .quad   255                             # 0xff
        .quad   255                             # 0xff
        .quad   255                             # 0xff
        .quad   255                             # 0xff
        .quad   255                             # 0xff
        .quad   255                             # 0xff
        .quad   255                             # 0xff
        .quad   255                             # 0xff
```
</details>