### PR TITLE
General: Resolve -Wignored-qualifiers warnings

### DIFF
--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -286,6 +286,7 @@ function(AddObject Name Type)
   target_compile_options(${Name}
     PRIVATE
     -Wall
+    -Werror=ignored-qualifiers
     -Werror=implicit-fallthrough
 
     -Wno-trigraphs

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -240,7 +240,7 @@ namespace FEXCore::Context {
     void DestroyThread(FEXCore::Core::InternalThreadState *Thread);
     void CleanupAfterFork(FEXCore::Core::InternalThreadState *ExceptForThread);
 
-    std::vector<FEXCore::Core::InternalThreadState*> *const GetThreads() { return &Threads; }
+    std::vector<FEXCore::Core::InternalThreadState*>* GetThreads() { return &Threads; }
 
     uint8_t GetGPRSize() const { return Config.Is64BitMode ? 8 : 4; }
 

--- a/External/FEXCore/include/FEXCore/IR/IntrusiveIRList.h
+++ b/External/FEXCore/include/FEXCore/IR/IntrusiveIRList.h
@@ -69,8 +69,8 @@ class DualIntrusiveAllocator final {
     size_t ListSize() const { return ListCurrentOffset; }
     size_t ListBackingSize() const { return MemorySize; }
 
-    uintptr_t const DataBegin() const { return Data; }
-    uintptr_t const ListBegin() const { return List; }
+    uintptr_t DataBegin() const { return Data; }
+    uintptr_t ListBegin() const { return List; }
 
     void Reset() { DataCurrentOffset = 0; ListCurrentOffset = 0; }
 
@@ -159,7 +159,7 @@ public:
     stream.write((char*)GetListData(), ListSize);
   }
 
-  size_t GetInlineSize() {
+  size_t GetInlineSize() const {
     static_assert(sizeof(*this) == 40);
     return sizeof(*this) + DataSize + ListSize;
   }
@@ -317,11 +317,11 @@ public:
     return iterator(reinterpret_cast<uintptr_t>(GetListData()), reinterpret_cast<uintptr_t>(GetData()), Wrapped);
   }
 
-  uintptr_t const GetData() const {
+  uintptr_t GetData() const {
     return reinterpret_cast<uintptr_t>(IRDataInternal ? IRDataInternal : InlineData);
   }
 
-  uintptr_t const GetListData() const {
+  uintptr_t GetListData() const {
     return reinterpret_cast<uintptr_t>(ListDataInternal ? ListDataInternal : &InlineData[DataSize]);
   }
 


### PR DESCRIPTION
Removes qualifiers that don't do anything to interfaces

Top-level const on functions that return by value can inhibit move semantics (thankfully we didn't have this occur anywhere that would have mattered).