### PR TITLE
General: Resolve -Wcast-qual warnings

### DIFF
--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -286,6 +286,7 @@ function(AddObject Name Type)
   target_compile_options(${Name}
     PRIVATE
     -Wall
+    -Werror=cast-qual
     -Werror=ignored-qualifiers
     -Werror=implicit-fallthrough
 

--- a/External/FEXCore/Source/Common/SoftFloat.h
+++ b/External/FEXCore/Source/Common/SoftFloat.h
@@ -158,18 +158,24 @@ struct X80SoftFloat {
   }
 
   operator float() const {
-    float32_t Result = extF80_to_f32(*this);
-    return *(float*)&Result;
+    const float32_t Result = extF80_to_f32(*this);
+    float flt;
+    std::memcpy(&flt, &Result, sizeof(flt));
+    return flt;
   }
 
   operator double() const {
-    float64_t Result = extF80_to_f64(*this);
-    return *(double*)&Result;
+    const float64_t Result = extF80_to_f64(*this);
+    double flt;
+    std::memcpy(&flt, &Result, sizeof(flt));
+    return flt;
   }
 
   operator BIGFLOAT() const {
-    float128_t Result = extF80_to_f128(*this);
-    return *(BIGFLOAT*)&Result;
+    const float128_t Result = extF80_to_f128(*this);
+    BIGFLOAT flt;
+    std::memcpy(&flt, &Result, sizeof(flt));
+    return flt;
   }
 
   operator int16_t() const {
@@ -196,11 +202,15 @@ struct X80SoftFloat {
   }
 
   void operator=(const float rhs) {
-    *this = f32_to_extF80(*(float32_t*)&rhs);
+    float32_t flt;
+    std::memcpy(&flt, &rhs, sizeof(flt));
+    *this = f32_to_extF80(flt);
   }
 
   void operator=(const double rhs) {
-    *this = f64_to_extF80(*(float64_t*)&rhs);
+    float64_t flt;
+    std::memcpy(&flt, &rhs, sizeof(flt));
+    *this = f64_to_extF80(flt);
   }
 
   void operator=(const int16_t rhs) {
@@ -226,15 +236,21 @@ struct X80SoftFloat {
   }
 
   X80SoftFloat(const float rhs) {
-    *this = f32_to_extF80(*(float32_t*)&rhs);
+    float32_t flt;
+    std::memcpy(&flt, &rhs, sizeof(float32_t));
+    *this = f32_to_extF80(flt);
   }
 
   X80SoftFloat(const double rhs) {
-    *this = f64_to_extF80(*(float64_t*)&rhs);
+    float64_t flt;
+    std::memcpy(&flt, &rhs, sizeof(float64_t));
+    *this = f64_to_extF80(flt);
   }
 
   X80SoftFloat(BIGFLOAT rhs) {
-    *this = f128_to_extF80(*(float128_t*)&rhs);
+    float128_t flt;
+    std::memcpy(&flt, &rhs, sizeof(float128_t));
+    *this = f128_to_extF80(flt);
   }
 
   X80SoftFloat(const int16_t rhs) {

--- a/External/FEXCore/Source/Common/SoftFloat.h
+++ b/External/FEXCore/Source/Common/SoftFloat.h
@@ -1,4 +1,6 @@
 #pragma once
+
+#include <FEXCore/Utils/BitUtils.h>
 #include <FEXCore/Utils/LogManager.h>
 
 #include <cmath>
@@ -159,23 +161,17 @@ struct X80SoftFloat {
 
   operator float() const {
     const float32_t Result = extF80_to_f32(*this);
-    float flt;
-    std::memcpy(&flt, &Result, sizeof(flt));
-    return flt;
+    return FEXCore::BitCast<float>(Result);
   }
 
   operator double() const {
     const float64_t Result = extF80_to_f64(*this);
-    double flt;
-    std::memcpy(&flt, &Result, sizeof(flt));
-    return flt;
+    return FEXCore::BitCast<double>(Result);
   }
 
   operator BIGFLOAT() const {
     const float128_t Result = extF80_to_f128(*this);
-    BIGFLOAT flt;
-    std::memcpy(&flt, &Result, sizeof(flt));
-    return flt;
+    return FEXCore::BitCast<BIGFLOAT>(Result);
   }
 
   operator int16_t() const {
@@ -202,15 +198,11 @@ struct X80SoftFloat {
   }
 
   void operator=(const float rhs) {
-    float32_t flt;
-    std::memcpy(&flt, &rhs, sizeof(flt));
-    *this = f32_to_extF80(flt);
+    *this = f32_to_extF80(FEXCore::BitCast<float32_t>(rhs));
   }
 
   void operator=(const double rhs) {
-    float64_t flt;
-    std::memcpy(&flt, &rhs, sizeof(flt));
-    *this = f64_to_extF80(flt);
+    *this = f64_to_extF80(FEXCore::BitCast<float64_t>(rhs));
   }
 
   void operator=(const int16_t rhs) {
@@ -236,21 +228,15 @@ struct X80SoftFloat {
   }
 
   X80SoftFloat(const float rhs) {
-    float32_t flt;
-    std::memcpy(&flt, &rhs, sizeof(float32_t));
-    *this = f32_to_extF80(flt);
+    *this = f32_to_extF80(FEXCore::BitCast<float32_t>(rhs));
   }
 
   X80SoftFloat(const double rhs) {
-    float64_t flt;
-    std::memcpy(&flt, &rhs, sizeof(float64_t));
-    *this = f64_to_extF80(flt);
+    *this = f64_to_extF80(FEXCore::BitCast<float64_t>(rhs));
   }
 
   X80SoftFloat(BIGFLOAT rhs) {
-    float128_t flt;
-    std::memcpy(&flt, &rhs, sizeof(float128_t));
-    *this = f128_to_extF80(flt);
+    *this = f128_to_extF80(FEXCore::BitCast<float128_t>(rhs));
   }
 
   X80SoftFloat(const int16_t rhs) {

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
@@ -257,7 +257,7 @@ DEF_OP(Thunk) {
 
 DEF_OP(ValidateCode) {
   auto Op = IROp->C<IR::IROp_ValidateCode>();
-  uint8_t *OldCode = (uint8_t *)&Op->CodeOriginalLow;
+  const auto *OldCode = (const uint8_t *)&Op->CodeOriginalLow;
   int len = Op->CodeLength;
   int idx = 0;
 
@@ -268,7 +268,7 @@ DEF_OP(ValidateCode) {
   while (len >= 8)
   {
     ldr(x2, MemOperand(x0, idx));
-    LoadConstant(x3, *(uint32_t *)(OldCode + idx));
+    LoadConstant(x3, *(const uint32_t *)(OldCode + idx));
     cmp(x2, x3);
     csel(GetReg<RA_64>(Node), GetReg<RA_64>(Node), x1, Condition::eq);
     len -= 8;
@@ -277,7 +277,7 @@ DEF_OP(ValidateCode) {
   while (len >= 4)
   {
     ldr(w2, MemOperand(x0, idx));
-    LoadConstant(w3, *(uint32_t *)(OldCode + idx));
+    LoadConstant(w3, *(const uint32_t *)(OldCode + idx));
     cmp(w2, w3);
     csel(GetReg<RA_64>(Node), GetReg<RA_64>(Node), x1, Condition::eq);
     len -= 4;
@@ -286,7 +286,7 @@ DEF_OP(ValidateCode) {
   while (len >= 2)
   {
     ldrh(w2, MemOperand(x0, idx));
-    LoadConstant(w3, *(uint16_t *)(OldCode + idx));
+    LoadConstant(w3, *(const uint16_t *)(OldCode + idx));
     cmp(w2, w3);
     csel(GetReg<RA_64>(Node), GetReg<RA_64>(Node), x1, Condition::eq);
     len -= 2;
@@ -295,7 +295,7 @@ DEF_OP(ValidateCode) {
   while (len >= 1)
   {
     ldrb(w2, MemOperand(x0, idx));
-    LoadConstant(w3, *(uint8_t *)(OldCode + idx));
+    LoadConstant(w3, *(const uint8_t *)(OldCode + idx));
     cmp(w2, w3);
     csel(GetReg<RA_64>(Node), GetReg<RA_64>(Node), x1, Condition::eq);
     len -= 1;

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
@@ -248,7 +248,7 @@ DEF_OP(Thunk) {
 
 DEF_OP(ValidateCode) {
   auto Op = IROp->C<IR::IROp_ValidateCode>();
-  uint8_t* OldCode = (uint8_t*)&Op->CodeOriginalLow;
+  const auto* OldCode = (const uint8_t*)&Op->CodeOriginalLow;
   int len = Op->CodeLength;
   int idx = 0;
 
@@ -256,20 +256,20 @@ DEF_OP(ValidateCode) {
   mov(rax, Entry + Op->Offset);
   mov(rbx, 1);
   while (len >= 4) {
-    cmp(dword[rax + idx], *(uint32_t*)(OldCode + idx));
+    cmp(dword[rax + idx], *(const uint32_t*)(OldCode + idx));
     cmovne(GetDst<RA_64>(Node), rbx);
     len-=4;
     idx+=4;
   }
   while (len >= 2) {
-    mov(rcx, *(uint16_t*)(OldCode + idx));
+    mov(rcx, *(const uint16_t*)(OldCode + idx));
     cmp(word[rax + idx], cx);
     cmovne(GetDst<RA_64>(Node), rbx);
     len-=2;
     idx+=2;
   }
   while (len >= 1) {
-    cmp(byte[rax + idx], *(uint8_t*)(OldCode + idx));
+    cmp(byte[rax + idx], *(const uint8_t*)(OldCode + idx));
     cmovne(GetDst<RA_64>(Node), rbx);
     len-=1;
     idx+=1;

--- a/External/FEXCore/include/FEXCore/Utils/BitUtils.h
+++ b/External/FEXCore/include/FEXCore/Utils/BitUtils.h
@@ -6,6 +6,7 @@
 #include <climits>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <type_traits>
 
 namespace FEXCore {
@@ -59,6 +60,22 @@ template <typename T>
 
     const int trailing_zeroes = std::countr_zero(value);
     return trailing_zeroes + 1;
+}
+
+// Stand-in for std::bit_cast until libc++ implements it.
+template <typename To, typename From>
+[[nodiscard]] inline To BitCast(const From& source) noexcept
+{
+  static_assert(sizeof(From) == sizeof(To),
+                "BitCast source and destination types must be equal in size.");
+  static_assert(std::is_trivially_copyable_v<From>,
+                "BitCast source type must be trivially copyable.");
+  static_assert(std::is_trivially_copyable_v<To>,
+                "BitCast destination type must be trivially copyable.");
+
+  std::aligned_storage_t<sizeof(To), alignof(To)> storage;
+  std::memcpy(&storage, &source, sizeof(storage));
+  return reinterpret_cast<To&>(storage);
 }
 
 } // namespace FEXCore


### PR DESCRIPTION
Ensures that qualifiers are preserved on references and pointers to prevent undefined behavior.