### PR TITLE
Disable flaky posix test

### DIFF
--- a/unittests/POSIX/Disabled_Tests
+++ b/unittests/POSIX/Disabled_Tests
@@ -596,3 +596,8 @@ conformance-interfaces-killpg-4-1.test
 conformance-interfaces-killpg-5-1.test
 conformance-interfaces-killpg-6-1.test
 conformance-interfaces-killpg-8-1.test
+
+# This test is flaky
+# It puts the thread to sleep for 1 second and expects to wake up within 10ms of the timer
+# If the kernel is doing other things then this 10ms time is too strict and fails periodically
+conformance-interfaces-sigtimedwait-1-1.test

--- a/unittests/POSIX/Known_Failures
+++ b/unittests/POSIX/Known_Failures
@@ -624,3 +624,8 @@ conformance-interfaces-killpg-4-1.test
 conformance-interfaces-killpg-5-1.test
 conformance-interfaces-killpg-6-1.test
 conformance-interfaces-killpg-8-1.test
+
+# This test is flaky
+# It puts the thread to sleep for 1 second and expects to wake up within 10ms of the timer
+# If the kernel is doing other things then this 10ms time is too strict and fails periodically
+conformance-interfaces-sigtimedwait-1-1.test


### PR DESCRIPTION
Test sleeps for 1 second and expects to come back within 10ms of the time.
When the CPU is doing other things then it can end up missing that timeframe. Thus flake.

Just disable it