### PR TITLE
Fix Star Wars Knights of the Old Republic 2

### DIFF
--- a/Source/Tests/LinuxSyscalls/Syscalls/FS.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/FS.cpp
@@ -15,7 +15,6 @@ $end_info$
 #include <sys/swap.h>
 #include <sys/syscall.h>
 #include <sys/types.h>
-#include <sys/vfs.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/xattr.h>
@@ -108,16 +107,6 @@ namespace FEX::HLE {
 #else
       return -ENOSYS;
 #endif
-    });
-
-    REGISTER_SYSCALL_IMPL(statfs, [](FEXCore::Core::CpuStateFrame *Frame, const char *path, struct statfs *buf) -> uint64_t {
-      uint64_t Result = FEX::HLE::_SyscallHandler->FM.Statfs(path, buf);
-      SYSCALL_ERRNO();
-    });
-
-    REGISTER_SYSCALL_IMPL(fstatfs, [](FEXCore::Core::CpuStateFrame *Frame, int fd, struct statfs *buf) -> uint64_t {
-      uint64_t Result = ::fstatfs(fd, buf);
-      SYSCALL_ERRNO();
     });
 
     REGISTER_SYSCALL_IMPL(truncate, [](FEXCore::Core::CpuStateFrame *Frame, const char *path, off_t length) -> uint64_t {

--- a/Source/Tests/LinuxSyscalls/x32/FD.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/FD.cpp
@@ -174,6 +174,24 @@ namespace FEX::HLE::x32 {
       SYSCALL_ERRNO();
     });
 
+    REGISTER_SYSCALL_IMPL_X32(statfs, [](FEXCore::Core::CpuStateFrame *Frame, const char *path, statfs32_32 *buf) -> uint64_t {
+      struct statfs host_stat;
+      uint64_t Result = FEX::HLE::_SyscallHandler->FM.Statfs(path, &host_stat);
+      if (Result != -1) {
+        *buf = host_stat;
+      }
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(fstatfs, [](FEXCore::Core::CpuStateFrame *Frame, int fd, statfs32_32 *buf) -> uint64_t {
+      struct statfs host_stat;
+      uint64_t Result = ::fstatfs(fd, &host_stat);
+      if (Result != -1) {
+        *buf = host_stat;
+      }
+      SYSCALL_ERRNO();
+    });
+
     REGISTER_SYSCALL_IMPL_X32(fstatfs64, [](FEXCore::Core::CpuStateFrame *Frame, int fd, size_t sz, struct statfs64_32 *buf) -> uint64_t {
       LOGMAN_THROW_A(sz == sizeof(struct statfs64_32), "This needs to match");
 

--- a/Source/Tests/LinuxSyscalls/x32/Types.h
+++ b/Source/Tests/LinuxSyscalls/x32/Types.h
@@ -472,6 +472,62 @@ static_assert(std::is_trivial<statfs64_32>::value, "Needs to be trivial");
 static_assert(sizeof(statfs64_32) == 84, "Incorrect size");
 
 struct
+FEX_ANNOTATE("alias-x86_32-statfs")
+FEX_ANNOTATE("fex-match")
+statfs32_32 {
+  int32_t f_type;
+  int32_t f_bsize;
+  int32_t f_blocks;
+  int32_t f_bfree;
+  int32_t f_bavail;
+  int32_t f_files;
+  int32_t f_ffree;
+  __kernel_fsid_t f_fsid;
+  int32_t f_namelen;
+  int32_t f_frsize;
+  int32_t f_flags;
+  int32_t pad[4];
+
+  statfs32_32() = delete;
+
+  statfs32_32(struct statfs host) {
+    #define COPY(x) x = host.x
+    COPY(f_type);
+    COPY(f_bsize);
+    COPY(f_blocks);
+    COPY(f_bfree);
+    COPY(f_bavail);
+    COPY(f_files);
+    COPY(f_ffree);
+    COPY(f_namelen);
+    COPY(f_frsize);
+    COPY(f_flags);
+
+    memcpy(&f_fsid, &host.f_fsid, sizeof(f_fsid));
+    #undef COPY
+  }
+
+  statfs32_32(struct statfs64 host) {
+    #define COPY(x) x = host.x
+    COPY(f_type);
+    COPY(f_bsize);
+    COPY(f_blocks);
+    COPY(f_bfree);
+    COPY(f_bavail);
+    COPY(f_files);
+    COPY(f_ffree);
+    COPY(f_namelen);
+    COPY(f_frsize);
+    COPY(f_flags);
+
+    memcpy(&f_fsid, &host.f_fsid, sizeof(f_fsid));
+    #undef COPY
+  }
+};
+static_assert(std::is_trivial<statfs32_32>::value, "Needs to be trivial");
+static_assert(sizeof(statfs32_32) == 64, "Incorrect size");
+
+struct
 FEX_ANNOTATE("alias-x86_32-flock")
 FEX_ANNOTATE("fex-match")
 flock_32 {

--- a/Source/Tests/LinuxSyscalls/x64/FD.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/FD.cpp
@@ -15,6 +15,7 @@ $end_info$
 #include <sys/uio.h>
 #include <sys/sendfile.h>
 #include <sys/syscall.h>
+#include <sys/vfs.h>
 #include <unistd.h>
 
 namespace FEX::HLE::x64 {
@@ -232,6 +233,16 @@ namespace FEX::HLE::x64 {
 
     REGISTER_SYSCALL_IMPL_X64(dup2, [](FEXCore::Core::CpuStateFrame *Frame, int oldfd, int newfd) -> uint64_t {
       uint64_t Result = ::dup2(oldfd, newfd);
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X64(statfs, [](FEXCore::Core::CpuStateFrame *Frame, const char *path, struct statfs *buf) -> uint64_t {
+      uint64_t Result = FEX::HLE::_SyscallHandler->FM.Statfs(path, buf);
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X64(fstatfs, [](FEXCore::Core::CpuStateFrame *Frame, int fd, struct statfs *buf) -> uint64_t {
+      uint64_t Result = ::fstatfs(fd, buf);
       SYSCALL_ERRNO();
     });
   }


### PR DESCRIPTION
This game had some unexpected crashes.
It uses the same engine as Neverwinter nights, so we should have been able to run it.

This older version of the engine managed to uncover a couple of bugs for us.
This fixes the game so it gets ingame now. There is some audio corruption periodically still, probably vector instruction related.
Fixes #894