### PR TITLE
Fixes fixed stack offset for 32-bit applications

### DIFF
--- a/Source/Tests/ELFCodeLoader.h
+++ b/Source/Tests/ELFCodeLoader.h
@@ -194,13 +194,7 @@ public:
 
   uint64_t GetStackPointer() override {
     uintptr_t StackPointer{};
-    if (File.GetMode() == ::ELFLoader::ELFContainer::MODE_64BIT) {
-      StackPointer = reinterpret_cast<uintptr_t>(FEXCore::Allocator::mmap(nullptr, StackSize(), PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
-    }
-    else {
-      StackPointer = reinterpret_cast<uintptr_t>(FEXCore::Allocator::mmap(reinterpret_cast<void*>(STACK_OFFSET), StackSize(), PROT_READ | PROT_WRITE, MAP_FIXED_NOREPLACE | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
-      LOGMAN_THROW_A(StackPointer != ~0ULL, "Get Stack Pointer mmap failed");
-    }
+    StackPointer = reinterpret_cast<uintptr_t>(FEXCore::Allocator::mmap(nullptr, StackSize(), PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
 
     StackPointer += StackSize();
     // Set up our initial CPU state
@@ -307,13 +301,13 @@ public:
   }
 
   char const *FindSymbolNameInRange(uint64_t Address) {
-    
+
     ELFLoader::ELFSymbol const *Sym;
     Sym = DB.GetSymbolInRange(std::make_pair(Address, 1));
     if (Sym) {
       return Sym->Name;
     }
-    
+
     return nullptr;
   }
 
@@ -356,7 +350,6 @@ private:
   uint64_t EnvironmentBackingSize{};
 
   constexpr static uint64_t STACK_SIZE = 8 * 1024 * 1024;
-  constexpr static uint64_t STACK_OFFSET = 0xc000'0000;
 };
 
 }


### PR DESCRIPTION
Instead of forcing a fixed offset for the stack. Allow it to get placed automatically.
64-bit was already doing this; Now we can also do it in 32-bit.
This is possible because the mapper that is mapping the code will always map in the 32-bit space
for a 32-bit guest.

Fixes #317