### PR TITLE
Implements 32-bit sigpending

### DIFF
--- a/Source/Tests/LinuxSyscalls/x32/Signals.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Signals.cpp
@@ -21,6 +21,16 @@ namespace SignalDelegator {
 
 namespace FEX::HLE::x32 {
   void RegisterSignals() {
+    REGISTER_SYSCALL_IMPL_X32(sigpending, [](FEXCore::Core::CpuStateFrame *Frame, compat_old_sigset_t *set) -> uint64_t {
+      uint64_t HostSet{};
+      uint64_t Result = FEX::HLE::_SyscallHandler->GetSignalDelegator()->GuestSigPending(&HostSet, 8);
+      if (Result == 0) {
+        // This old interface only returns the lower signals
+        *set = HostSet & ~0U;
+      }
+      return Result;
+    });
+
     REGISTER_SYSCALL_IMPL_X32(signal, [](FEXCore::Core::CpuStateFrame *Frame, int signum, uint32_t handler) -> uint64_t {
       FEXCore::GuestSigAction newact{};
       FEXCore::GuestSigAction oldact{};

--- a/Source/Tests/LinuxSyscalls/x32/Types.h
+++ b/Source/Tests/LinuxSyscalls/x32/Types.h
@@ -37,6 +37,7 @@ using compat_mode_t = uint16_t;
 using compat_nlink_t = uint16_t;
 using compat_uid_t = uint16_t;
 using compat_gid_t = uint16_t;
+using compat_old_sigset_t = uint32_t;
 
 // Can't use using with aligned attributes, clang doesn't honour it
 typedef FEX_ALIGNED(4) uint64_t compat_uint64_t;


### PR DESCRIPTION
This is a early version of the syscall that only returns the lower 32 signals.
Easy enough to support