### PR TITLE
Implements support for deferred signal handler installation 

### DIFF
--- a/External/FEXCore/Source/Interface/Context/Context.cpp
+++ b/External/FEXCore/Source/Interface/Context/Context.cpp
@@ -105,12 +105,12 @@ namespace FEXCore::Context {
     CTX->HandleCallback(RIP);
   }
 
-  void RegisterHostSignalHandler(FEXCore::Context::Context *CTX, int Signal, HostSignalDelegatorFunction Func) {
-      CTX->RegisterHostSignalHandler(Signal, Func);
+  void RegisterHostSignalHandler(FEXCore::Context::Context *CTX, int Signal, HostSignalDelegatorFunction Func, bool Required) {
+      CTX->RegisterHostSignalHandler(Signal, Func, Required);
   }
 
-  void RegisterFrontendHostSignalHandler(FEXCore::Context::Context *CTX, int Signal, HostSignalDelegatorFunction Func) {
-    CTX->RegisterFrontendHostSignalHandler(Signal, Func);
+  void RegisterFrontendHostSignalHandler(FEXCore::Context::Context *CTX, int Signal, HostSignalDelegatorFunction Func, bool Required) {
+    CTX->RegisterFrontendHostSignalHandler(Signal, Func, Required);
   }
 
   FEXCore::Core::InternalThreadState* CreateThread(FEXCore::Context::Context *CTX, FEXCore::Core::CPUState *NewThreadState, uint64_t ParentTID) {

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -200,8 +200,8 @@ namespace FEXCore::Context {
     void StartGdbServer();
     void StopGdbServer();
     void HandleCallback(uint64_t RIP);
-    void RegisterHostSignalHandler(int Signal, HostSignalDelegatorFunction Func);
-    void RegisterFrontendHostSignalHandler(int Signal, HostSignalDelegatorFunction Func);
+    void RegisterHostSignalHandler(int Signal, HostSignalDelegatorFunction Func, bool Required);
+    void RegisterFrontendHostSignalHandler(int Signal, HostSignalDelegatorFunction Func, bool Required);
 
     static void RemoveCodeEntry(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP);
 

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -247,12 +247,12 @@ namespace FEXCore::Context {
     Thread->CPUBackend->CallbackPtr(Thread->CurrentFrame, RIP);
   }
 
-  void Context::RegisterHostSignalHandler(int Signal, HostSignalDelegatorFunction Func) {
-      SignalDelegation->RegisterHostSignalHandler(Signal, Func);
+  void Context::RegisterHostSignalHandler(int Signal, HostSignalDelegatorFunction Func, bool Required) {
+      SignalDelegation->RegisterHostSignalHandler(Signal, Func, Required);
   }
 
-  void Context::RegisterFrontendHostSignalHandler(int Signal, HostSignalDelegatorFunction Func) {
-    SignalDelegation->RegisterFrontendHostSignalHandler(Signal, Func);
+  void Context::RegisterFrontendHostSignalHandler(int Signal, HostSignalDelegatorFunction Func, bool Required) {
+    SignalDelegation->RegisterFrontendHostSignalHandler(Signal, Func, Required);
   }
 
   void Context::WaitForIdle() {

--- a/External/FEXCore/Source/Interface/Core/GdbServer.cpp
+++ b/External/FEXCore/Source/Interface/Core/GdbServer.cpp
@@ -64,7 +64,7 @@ GdbServer::GdbServer(FEXCore::Context::Context *ctx) : CTX(ctx) {
           usleep(100000);
 
         return true;
-    });
+    }, true);
 
     StartThread();
 }

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -93,12 +93,12 @@ InterpreterCore::InterpreterCore(FEXCore::Context::Context *ctx, FEXCore::Core::
     CTX->SignalDelegation->RegisterHostSignalHandler(SignalDelegator::SIGNAL_FOR_PAUSE, [](FEXCore::Core::InternalThreadState *Thread, int Signal, void *info, void *ucontext) -> bool {
       InterpreterCore *Core = reinterpret_cast<InterpreterCore*>(Thread->CPUBackend.get());
       return Core->Dispatcher->HandleSignalPause(Signal, info, ucontext);
-    });
+    }, true);
 
     CTX->SignalDelegation->RegisterHostSignalHandler(SIGBUS, [](FEXCore::Core::InternalThreadState *Thread, int Signal, void *info, void *ucontext) -> bool {
       InterpreterCore *Core = reinterpret_cast<InterpreterCore*>(Thread->CPUBackend.get());
       return Core->HandleSIGBUS(Signal, info, ucontext);
-    });
+    }, true);
 
     auto GuestSignalHandler = [](FEXCore::Core::InternalThreadState *Thread, int Signal, void *info, void *ucontext, GuestSigAction *GuestAction, stack_t *GuestStack) -> bool {
       InterpreterCore *Core = reinterpret_cast<InterpreterCore*>(Thread->CPUBackend.get());

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -507,17 +507,17 @@ Arm64JITCore::Arm64JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::Intern
     CTX->SignalDelegation->RegisterHostSignalHandler(SIGILL, [](FEXCore::Core::InternalThreadState *Thread, int Signal, void *info, void *ucontext) -> bool {
       Arm64JITCore *Core = reinterpret_cast<Arm64JITCore*>(Thread->CPUBackend.get());
       return Core->Dispatcher->HandleSIGILL(Signal, info, ucontext);
-    });
+    }, true);
 
     CTX->SignalDelegation->RegisterHostSignalHandler(SIGBUS, [](FEXCore::Core::InternalThreadState *Thread, int Signal, void *info, void *ucontext) -> bool {
       Arm64JITCore *Core = reinterpret_cast<Arm64JITCore*>(Thread->CPUBackend.get());
       return Core->HandleSIGBUS(Signal, info, ucontext);
-    });
+    }, true);
 
     CTX->SignalDelegation->RegisterHostSignalHandler(SignalDelegator::SIGNAL_FOR_PAUSE, [](FEXCore::Core::InternalThreadState *Thread, int Signal, void *info, void *ucontext) -> bool {
       Arm64JITCore *Core = reinterpret_cast<Arm64JITCore*>(Thread->CPUBackend.get());
       return Core->Dispatcher->HandleSignalPause(Signal, info, ucontext);
-    });
+    }, true);
 
     auto GuestSignalHandler = [](FEXCore::Core::InternalThreadState *Thread, int Signal, void *info, void *ucontext, GuestSigAction *GuestAction, stack_t *GuestStack) -> bool {
       Arm64JITCore *Core = reinterpret_cast<Arm64JITCore*>(Thread->CPUBackend.get());

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -348,12 +348,12 @@ X86JITCore::X86JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalTh
     CTX->SignalDelegation->RegisterHostSignalHandler(SIGILL, [](FEXCore::Core::InternalThreadState *Thread, int Signal, void *info, void *ucontext) -> bool {
       X86JITCore *Core = reinterpret_cast<X86JITCore*>(Thread->CPUBackend.get());
       return Core->Dispatcher->HandleSIGILL(Signal, info, ucontext);
-    });
+    }, true);
 
     CTX->SignalDelegation->RegisterHostSignalHandler(SignalDelegator::SIGNAL_FOR_PAUSE, [](FEXCore::Core::InternalThreadState *Thread, int Signal, void *info, void *ucontext) -> bool {
       X86JITCore *Core = reinterpret_cast<X86JITCore*>(Thread->CPUBackend.get());
       return Core->Dispatcher->HandleSignalPause(Signal, info, ucontext);
-    });
+    }, true);
 
     auto GuestSignalHandler = [](FEXCore::Core::InternalThreadState *Thread, int Signal, void *info, void *ucontext, GuestSigAction *GuestAction, stack_t *GuestStack) -> bool {
       X86JITCore *Core = reinterpret_cast<X86JITCore*>(Thread->CPUBackend.get());

--- a/External/FEXCore/include/FEXCore/Core/Context.h
+++ b/External/FEXCore/include/FEXCore/Core/Context.h
@@ -216,8 +216,8 @@ namespace FEXCore::Context {
 
   FEX_DEFAULT_VISIBILITY void HandleCallback(FEXCore::Context::Context *CTX, uint64_t RIP);
 
-  FEX_DEFAULT_VISIBILITY void RegisterHostSignalHandler(FEXCore::Context::Context *CTX, int Signal, HostSignalDelegatorFunction Func);
-  FEX_DEFAULT_VISIBILITY void RegisterFrontendHostSignalHandler(FEXCore::Context::Context *CTX, int Signal, HostSignalDelegatorFunction Func);
+  FEX_DEFAULT_VISIBILITY void RegisterHostSignalHandler(FEXCore::Context::Context *CTX, int Signal, HostSignalDelegatorFunction Func, bool Required);
+  FEX_DEFAULT_VISIBILITY void RegisterFrontendHostSignalHandler(FEXCore::Context::Context *CTX, int Signal, HostSignalDelegatorFunction Func, bool Required);
 
   FEX_DEFAULT_VISIBILITY FEXCore::Core::InternalThreadState* CreateThread(FEXCore::Context::Context *CTX, FEXCore::Core::CPUState *NewThreadState, uint64_t ParentTID);
   FEX_DEFAULT_VISIBILITY void InitializeThread(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread);

--- a/External/FEXCore/include/FEXCore/Core/SignalDelegator.h
+++ b/External/FEXCore/include/FEXCore/Core/SignalDelegator.h
@@ -54,8 +54,8 @@ namespace Core {
      *
      * It's a process level signal handler so one must be careful
      */
-    virtual void RegisterHostSignalHandler(int Signal, HostSignalDelegatorFunction Func) = 0;
-    virtual void RegisterFrontendHostSignalHandler(int Signal, HostSignalDelegatorFunction Func) = 0;
+    virtual void RegisterHostSignalHandler(int Signal, HostSignalDelegatorFunction Func, bool Required) = 0;
+    virtual void RegisterFrontendHostSignalHandler(int Signal, HostSignalDelegatorFunction Func, bool Required) = 0;
 
     /**
      * @brief Registers a signal handler for the host to handle a signal specifically for guest handling

--- a/External/FEXCore/include/FEXCore/Core/UContext.h
+++ b/External/FEXCore/include/FEXCore/Core/UContext.h
@@ -96,7 +96,24 @@ namespace FEXCore {
 
   namespace x86 {
     struct FEX_PACKED siginfo_t {
-      uint32_t pad[32];
+      int si_signo;
+      int si_errno;
+      int si_code;
+      union {
+        uint32_t pad[29];
+        /* SIGILL, SIGFPE, SIGSEGV, SIBUS */
+        struct {
+          uint32_t addr;
+        } _sigfault;
+        /* SIGCHLD */
+        struct {
+          int32_t pid;
+          int32_t uid;
+          int32_t status;
+          int32_t utime;
+          int32_t stime;
+        } _sigchld;
+      } _sifields;
     };
     static_assert(sizeof(FEXCore::x86::siginfo_t) == 128, "This needs to be the right size");
 

--- a/Source/CommonCore/HostFactory.cpp
+++ b/Source/CommonCore/HostFactory.cpp
@@ -56,12 +56,13 @@ namespace HostFactory {
         auto InternalThread = Thread;
         HostCore *Core = reinterpret_cast<HostCore*>(InternalThread->CPUBackend.get());
         return Core->HandleSIGSEGV(Thread, Signal, info, ucontext);
-      }
+      },
+      true
     );
 
     FEXCore::Context::RegisterHostSignalHandler(CTX, 63, [](FEXCore::Core::InternalThreadState *Thread, int Signal, void *info, void *ucontext) -> bool {
       return true;
-    });
+    }, true);
   }
 
   bool HostCore::HandleSIGSEGV(FEXCore::Core::InternalThreadState *Thread, int Signal, void *info, void *ucontext) {

--- a/Source/Tests/LinuxSyscalls/SignalDelegator.h
+++ b/Source/Tests/LinuxSyscalls/SignalDelegator.h
@@ -62,8 +62,8 @@ namespace FEX::HLE {
      *
      * It's a process level signal handler so one must be careful
      */
-    void RegisterHostSignalHandler(int Signal, FEXCore::HostSignalDelegatorFunction Func) override;
-    void RegisterFrontendHostSignalHandler(int Signal, FEXCore::HostSignalDelegatorFunction Func) override;
+    void RegisterHostSignalHandler(int Signal, FEXCore::HostSignalDelegatorFunction Func, bool Required) override;
+    void RegisterFrontendHostSignalHandler(int Signal, FEXCore::HostSignalDelegatorFunction Func, bool Required) override;
 
     /**
      * @brief Registers a signal handler for the host to handle a signal specifically for guest handling
@@ -100,6 +100,7 @@ namespace FEX::HLE {
 
     struct SignalHandler {
       std::atomic<bool> Installed{};
+      bool Required{};
       struct sigaction HostAction{};
       struct sigaction OldAction{};
       FEXCore::HostSignalDelegatorFunction Handler{};

--- a/Source/Tests/TestHarnessRunner.cpp
+++ b/Source/Tests/TestHarnessRunner.cpp
@@ -123,7 +123,7 @@ int main(int argc, char **argv, char **const envp) {
   SignalDelegation->RegisterFrontendHostSignalHandler(SIGSEGV, [&DidFault](FEXCore::Core::InternalThreadState *Thread, int Signal, void *info, void *ucontext) {
       DidFault = true;
     return false;
-  });
+  }, true);
 
   FEXCore::Context::SetSignalDelegator(CTX, SignalDelegation.get());
   FEXCore::Context::SetSyscallHandler(CTX, SyscallHandler.get());

--- a/unittests/POSIX/Known_Failures
+++ b/unittests/POSIX/Known_Failures
@@ -14,7 +14,6 @@ conformance-interfaces-sigqueue-6-1.test
 conformance-interfaces-sigqueue-7-1.test
 conformance-interfaces-sigqueue-8-1.test
 conformance-interfaces-sigqueue-9-1.test
-conformance-interfaces-sigtimedwait-4-1.test
 conformance-interfaces-sigtimedwait-5-1.test
 conformance-interfaces-sigwait-1-1.test
 conformance-interfaces-sigwait-2-1.test
@@ -566,9 +565,6 @@ conformance-interfaces-raise-10000-1.test
 conformance-interfaces-raise-2-1.test
 
 # Signals change this behaviour
-conformance-interfaces-nanosleep-3-2.test
-conformance-behavior-WIFEXITED-1-3.test
-conformance-interfaces-clock_nanosleep-1-5.test
 conformance-interfaces-sigpending-1-1.test
 conformance-interfaces-sigpending-2-1.test
 

--- a/unittests/gvisor-tests/Disabled_Tests
+++ b/unittests/gvisor-tests/Disabled_Tests
@@ -76,3 +76,11 @@ ptrace_test
 
 # Spins from sigtimedwait implementation
 sigtimedwait_test
+
+# The behaviour of this is different between x86 and ARM
+# SIGSEGV kills a thread successfully on ARM but not on x86
+time_test
+
+# The behaviour of this changes depending on if you have asserts enabled or not
+# siginfo_t with unsynchronized context
+pause_test

--- a/unittests/gvisor-tests/Known_Failures
+++ b/unittests/gvisor-tests/Known_Failures
@@ -86,7 +86,6 @@ mount_test
 mremap_test
 open_create_test
 open_test
-pause_test
 pipe_test
 ppoll_test
 prctl_setuid_test
@@ -104,7 +103,6 @@ seccomp_test
 select_test
 semaphore_test
 sendfile_test
-shm_test
 sigaltstack_test
 sigiret_test
 signalfd_test
@@ -125,14 +123,15 @@ splice_test
 stat_test
 sysret_test
 tcp_socket_test
-time_test
 timers_test
 tkill_test
-truncate_test
 vfork_test
 wait_test
-write_test
 xatttr_test
+
+# The behaviour of this is different between x86 and ARM
+# SIGSEGV kills a thread successfully on ARM but not on x86
+time_test
 
 # these are disabled
 # never terminates (even though we use timeout)
@@ -168,3 +167,7 @@ semaphore_test
 # these are flaky on x86
 itimer_test
 stat_times_test
+
+# The behaviour of this changes depending on if you have asserts enabled or not
+# siginfo_t with unsynchronized context
+pause_test


### PR DESCRIPTION
I saw a red herring that I thought the high cpu usage in steamwebhelper could come from signal handlers.
This turned out to not be the case, but now I've got this implemented.

Installs the few signal handlers that we need upfront but for everything that isn't a mandatory signal
we instead now wait until the guest also installs that signal handler.
This fixes #1107