### PR TITLE
FEXLoader: Make use of unique_ptr for syscall handlers

### DIFF
--- a/Source/Tests/LinuxSyscalls/x32/Syscalls.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Syscalls.cpp
@@ -641,9 +641,8 @@ public:
       });
   }
 
-  x32SyscallHandler::x32SyscallHandler(FEXCore::Context::Context *ctx, FEX::HLE::SignalDelegator *_SignalDelegation, MemAllocator *Allocator)
-    : SyscallHandler {ctx, _SignalDelegation} {
-    AllocHandler.reset(Allocator);
+  x32SyscallHandler::x32SyscallHandler(FEXCore::Context::Context *ctx, FEX::HLE::SignalDelegator *_SignalDelegation, std::unique_ptr<MemAllocator> Allocator)
+    : SyscallHandler{ctx, _SignalDelegation}, AllocHandler{std::move(Allocator)} {
     OSABI = FEXCore::HLE::SyscallOSABI::OS_LINUX32;
     RegisterSyscallHandlers();
   }
@@ -727,17 +726,17 @@ public:
 #endif
   }
 
-  FEX::HLE::x32::MemAllocator *CreateAllocator(bool Use32BitAllocator) {
+  std::unique_ptr<FEX::HLE::x32::MemAllocator> CreateAllocator(bool Use32BitAllocator) {
     if (Use32BitAllocator) {
-      return new MemAllocator32Bit();
+      return std::make_unique<MemAllocator32Bit>();
     }
     else {
-      return new MemAllocatorPassThrough();
+      return std::make_unique<MemAllocatorPassThrough>();
     }
   }
 
-  FEX::HLE::SyscallHandler *CreateHandler(FEXCore::Context::Context *ctx, FEX::HLE::SignalDelegator *_SignalDelegation, MemAllocator *Allocator) {
-    return new x32SyscallHandler(ctx, _SignalDelegation, Allocator);
+  std::unique_ptr<FEX::HLE::SyscallHandler> CreateHandler(FEXCore::Context::Context *ctx, FEX::HLE::SignalDelegator *_SignalDelegation, std::unique_ptr<MemAllocator> Allocator) {
+    return std::make_unique<x32SyscallHandler>(ctx, _SignalDelegation, std::move(Allocator));
   }
 
 }

--- a/Source/Tests/LinuxSyscalls/x32/Syscalls.h
+++ b/Source/Tests/LinuxSyscalls/x32/Syscalls.h
@@ -15,6 +15,7 @@ $end_info$
 #include <bitset>
 #include <condition_variable>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <unordered_map>
 
@@ -41,7 +42,7 @@ public:
 
 class x32SyscallHandler final : public FEX::HLE::SyscallHandler {
 public:
-  x32SyscallHandler(FEXCore::Context::Context *ctx, FEX::HLE::SignalDelegator *_SignalDelegation, MemAllocator *Allocator);
+  x32SyscallHandler(FEXCore::Context::Context *ctx, FEX::HLE::SignalDelegator *_SignalDelegation, std::unique_ptr<MemAllocator> Allocator);
 
   FEX::HLE::x32::MemAllocator *GetAllocator() { return AllocHandler.get(); }
 
@@ -50,8 +51,11 @@ private:
   std::unique_ptr<MemAllocator> AllocHandler{};
 };
 
-FEX::HLE::x32::MemAllocator *CreateAllocator(bool Use32BitAllocator);
-FEX::HLE::SyscallHandler *CreateHandler(FEXCore::Context::Context *ctx, FEX::HLE::SignalDelegator *_SignalDelegation, MemAllocator *Allocator);
+std::unique_ptr<FEX::HLE::x32::MemAllocator> CreateAllocator(bool Use32BitAllocator);
+std::unique_ptr<FEX::HLE::SyscallHandler> CreateHandler(FEXCore::Context::Context *ctx,
+                                                        FEX::HLE::SignalDelegator *_SignalDelegation,
+                                                        std::unique_ptr<MemAllocator> Allocator);
+
 void RegisterSyscallInternal(int SyscallNumber,
 #ifdef DEBUG_STRACE
   const std::string& TraceFormatString,

--- a/Source/Tests/LinuxSyscalls/x64/Syscalls.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Syscalls.cpp
@@ -158,7 +158,7 @@ namespace FEX::HLE::x64 {
 #endif
   }
 
-  FEX::HLE::SyscallHandler *CreateHandler(FEXCore::Context::Context *ctx, FEX::HLE::SignalDelegator *_SignalDelegation) {
-    return new x64SyscallHandler(ctx, _SignalDelegation);
+  std::unique_ptr<FEX::HLE::SyscallHandler> CreateHandler(FEXCore::Context::Context *ctx, FEX::HLE::SignalDelegator *_SignalDelegation) {
+    return std::make_unique<x64SyscallHandler>(ctx, _SignalDelegation);
   }
 }

--- a/Source/Tests/LinuxSyscalls/x64/Syscalls.h
+++ b/Source/Tests/LinuxSyscalls/x64/Syscalls.h
@@ -11,6 +11,7 @@ $end_info$
 
 #include <atomic>
 #include <condition_variable>
+#include <memory>
 #include <mutex>
 #include <unordered_map>
 
@@ -26,7 +27,8 @@ struct InternalThreadState;
 namespace FEX::HLE::x64 {
 #include "SyscallsEnum.h"
 
-FEX::HLE::SyscallHandler *CreateHandler(FEXCore::Context::Context *ctx, FEX::HLE::SignalDelegator *_SignalDelegation);
+std::unique_ptr<FEX::HLE::SyscallHandler> CreateHandler(FEXCore::Context::Context *ctx, FEX::HLE::SignalDelegator *_SignalDelegation);
+
 void RegisterSyscallInternal(int SyscallNumber,
 #ifdef DEBUG_STRACE
   const std::string& TraceFormatString,


### PR DESCRIPTION
Makes the ownership requirements explicit in the interface.

Also makes it harder to unintentionally/accidentally leak memory.