### PR TITLE
Remove logs that are just noise at this point

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -374,8 +374,6 @@ namespace FEXCore::Context {
         }
         if (Thread->RunningEvents.Running.load()) {
           StopThread(Thread);
-        } else {
-          LogMan::Msg::D("Skipping thread %p: Already stopped", Thread);
         }
       }
     }
@@ -1214,8 +1212,6 @@ namespace FEXCore::Context {
 
     ++IdleWaitRefCount;
 
-    LogMan::Msg::D("[%d] Waiting to run", Thread->ThreadManager.TID.load());
-
     // Now notify the thread that we are initialized
     Thread->ThreadWaiting.NotifyAll();
 
@@ -1223,8 +1219,6 @@ namespace FEXCore::Context {
       // Parent thread doesn't need to wait to run
       Thread->StartRunning.Wait();
     }
-
-    LogMan::Msg::D("[%d] Running", Thread->ThreadManager.TID.load());
 
     Thread->ExitReason = FEXCore::Context::ExitReason::EXIT_NONE;
 

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -9673,20 +9673,17 @@ constexpr uint16_t PF_F2 = 3;
     {0x7F, 1, &OpDispatchBuilder::UnimplementedOp},
   };
 
-  uint64_t NumInsts{};
-  auto InstallToTable = [&NumInsts](auto& FinalTable, auto& LocalTable) {
+  auto InstallToTable = [](auto& FinalTable, auto& LocalTable) {
     for (auto Op : LocalTable) {
       auto OpNum = std::get<0>(Op);
       auto Dispatcher = std::get<2>(Op);
       for (uint8_t i = 0; i < std::get<1>(Op); ++i) {
         LOGMAN_THROW_A(FinalTable[OpNum + i].OpcodeDispatcher == nullptr, "Duplicate Entry");
         FinalTable[OpNum + i].OpcodeDispatcher = Dispatcher;
-        if (Dispatcher)
-          ++NumInsts;
       }
     }
   };
-  auto InstallToX87Table = [&NumInsts](auto& FinalTable, auto& LocalTable) {
+  auto InstallToX87Table = [](auto& FinalTable, auto& LocalTable) {
     for (auto Op : LocalTable) {
       auto OpNum = std::get<0>(Op);
       bool Repeat = (OpNum & 0x8000) != 0;
@@ -9701,8 +9698,6 @@ constexpr uint16_t PF_F2 = 3;
           FinalTable[(OpNum | 0x40) + i].OpcodeDispatcher = Dispatcher;
           FinalTable[(OpNum | 0x80) + i].OpcodeDispatcher = Dispatcher;
         }
-        if (Dispatcher)
-          ++NumInsts;
       }
     }
   };
@@ -9733,8 +9728,6 @@ constexpr uint16_t PF_F2 = 3;
   InstallToTable(FEXCore::X86Tables::H0F3ATableOps, H0F3ATable);
   InstallToTable(FEXCore::X86Tables::VEXTableOps, VEXTable);
   InstallToTable(FEXCore::X86Tables::EVEXTableOps, EVEXTable);
-
-  LogMan::Msg::D("We installed %ld instructions to the tables", NumInsts);
 }
 
 }

--- a/Source/Tests/LinuxSyscalls/SignalDelegator.cpp
+++ b/Source/Tests/LinuxSyscalls/SignalDelegator.cpp
@@ -249,7 +249,9 @@ namespace FEX::HLE {
 
     // We don't care about the previous handler in this case
     int Result = sigaction(Signal, &SignalHandler.HostAction, &SignalHandler.OldAction);
-    if (Result < 0) {
+    if (Result < 0 &&
+        !(Signal == 32 || Signal == 33)) {
+      // Signal 32 and 33 are consumed by glibc. We don't handle this atm
       LogMan::Msg::E("Failed to install host signal thunk for signal %d: %s", Signal, strerror(errno));
       return false;
     }
@@ -297,7 +299,9 @@ namespace FEX::HLE {
 
     // Only update our host signal here
     int Result = sigaction(Signal, &SignalHandler.HostAction, nullptr);
-    if (Result < 0) {
+    if (Result < 0 &&
+        !(Signal == 32 || Signal == 33)) {
+      // Signal 32 and 33 are consumed by glibc. We don't handle this atm
       LogMan::Msg::E("Failed to update host signal thunk for signal %d: %s", Signal, strerror(errno));
     }
   }


### PR DESCRIPTION
Don't print how many instructions are installed in the tables.
  This isn't useful anymore

Not installing signal 32 and 33 are something we don't support right now. Stop complaining in that case.

Stop printing when a thread is starting up and shutting down. If you want to see this then gdb shows it well.

Don't print clone flags unless we are hitting a case where we are printing another log message.