### PR TITLE
x32: Fixes fcntl OP_GETLK64_32

### DIFF
--- a/Source/Tests/LinuxSyscalls/x32/FD.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/FD.cpp
@@ -240,8 +240,9 @@ namespace FEX::HLE::x32 {
 
       void *lock_arg = (void*)arg;
       struct flock tmp{};
+      int old_cmd = cmd;
 
-      switch (cmd) {
+      switch (old_cmd) {
         case OP_GETLK64_32: {
           cmd = F_GETLK;
           lock_arg = (void*)&tmp;
@@ -292,7 +293,7 @@ namespace FEX::HLE::x32 {
       uint64_t Result = ::fcntl(fd, cmd, lock_arg);
 
       if (Result != -1) {
-        switch (cmd) {
+        switch (old_cmd) {
           case OP_GETLK64_32: {
             *reinterpret_cast<flock64_32*>(arg) = tmp;
             break;


### PR DESCRIPTION
This was overwriting the cmd argument and then being checked in the switch statement
after the call.
Since it was overwritten, it wasn't falling down the correct path, returning a flock_32 instead of a flock64_32