### PR TITLE
syscalls: Disallow disabling CPUID from arch_prctl

### DIFF
--- a/Source/Tests/LinuxSyscalls/Syscalls/Thread.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Thread.cpp
@@ -352,6 +352,12 @@ namespace FEX::HLE {
         case 0x3001: // ARCH_CET_STATUS
           Result = -EINVAL; // We don't support CET, return EINVAL
         break;
+        case 0x1011: // ARCH_GET_CPUID
+          return 1;
+        break;
+        case 0x1012: // ARCH_SET_CPUID
+          return -ENODEV; // Claim we don't support faulting on CPUID
+        break;
         default:
           LogMan::Msg::E("Unknown prctl: 0x%x", code);
           Result = -EINVAL;


### PR DESCRIPTION
In a newer version of the kernel there was a feature to disallow cpuid.
We can emulate this by saying it is always enabled and disallow the ability to disable it.