### PR TITLE
Fixes PT_LOAD with zero file size

### DIFF
--- a/Source/Tests/ELFCodeLoader2.h
+++ b/Source/Tests/ELFCodeLoader2.h
@@ -68,6 +68,11 @@ class ELFCodeLoader2 final : public FEXCore::CodeLoader {
     auto off = Header.p_offset - PAGE_OFFSET(Header.p_vaddr);
 
     size = PAGE_ALIGN(size);
+    if (size == 0) {
+      // PT_LOAD section without a file size
+      // Will need to have a memory size that is not zero instead
+      return true;
+    }
 
     void *rv;
 


### PR DESCRIPTION
gzip ships a PT_LOAD program section without a file size and only a memory size.
In the case of a zero file size PT_LOAD then return success immediately in this section loader.
This fixes Steam using gzip to package up crash logs