### PR TITLE
OpcodeDispatcher: Mark lookup tables as static in Get{Src,Dst}Size

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -4610,7 +4610,7 @@ void OpDispatchBuilder::Finalize() {
 }
 
 uint8_t OpDispatchBuilder::GetDstSize(FEXCore::X86Tables::DecodedOp Op) const {
-  constexpr std::array<uint8_t, 8> Sizes = {
+  static constexpr std::array<uint8_t, 8> Sizes = {
     0, // Invalid DEF
     1,
     2,
@@ -4628,7 +4628,7 @@ uint8_t OpDispatchBuilder::GetDstSize(FEXCore::X86Tables::DecodedOp Op) const {
 }
 
 uint8_t OpDispatchBuilder::GetSrcSize(FEXCore::X86Tables::DecodedOp Op) const {
-  constexpr std::array<uint8_t, 8> Sizes = {
+  static constexpr std::array<uint8_t, 8> Sizes = {
     0, // Invalid DEF
     1,
     2,


### PR DESCRIPTION
Same behavior, but allows clang to elide pushing all of these values on and off the stack, particularly given these are called quite frequently throughout the opcode dispatcher.

A reduced example like so:

<details>
<summary>Code</summary>

```cpp
#include <array>
#include <cstdint>

constexpr uint32_t FLAG_SIZE_DST_OFF = 19;
constexpr uint32_t SIZE_MASK         = 0b111;
inline uint32_t GetSizeDstFlags(uint32_t Flags) { return (Flags >> FLAG_SIZE_DST_OFF) & SIZE_MASK; }

struct DecodedInst {
  uint64_t PC;

  uint16_t OP;
  uint32_t Flags;

  uint8_t ModRM;
  uint8_t SIB;
  uint8_t InstSize;
  uint8_t LastEscapePrefix;
};

uint8_t GetDstSize(DecodedInst* Op) {
  constexpr std::array<uint8_t, 8> Sizes = {
    0, // Invalid DEF
    1,
    2,
    4,
    8,
    16,
    32,
    0, // Invalid DEF
  };

  uint32_t DstSizeFlag = GetSizeDstFlags(Op->Flags);
  uint8_t Size = Sizes[DstSizeFlag];
  return Size;
}
```
</details>

Generates:

<details>
<summary>Aarch64</summary>

```asm
GetDstSize(DecodedInst*):           // @GetDstSize(DecodedInst*)
        sub     sp, sp, #16
        mov     x9, #256
        ldr     w8, [x0, #12]
        movk    x9, #1026, lsl #16
        movk    x9, #4104, lsl #32
        movk    x9, #32, lsl #48
        str     x9, [sp, #8]
        add     x9, sp, #8
        bfxil   x9, x8, #19, #3
        ldrb    w0, [x9]
        add     sp, sp, #16
        ret
```
</details>

<details>
<summary>x86</summary>

```asm
GetDstSize(DecodedInst*):           # @GetDstSize(DecodedInst*)
        movabs  rax, 9024825867763968
        mov     qword ptr [rsp - 8], rax
        mov     eax, dword ptr [rdi + 12]
        shr     eax, 19
        and     eax, 7
        mov     al, byte ptr [rsp + rax - 8]
        ret
```
</details>

With the change, we now get:

<details>
<summary>Aarch64</summary>

```asm
GetDstSize(DecodedInst*):
        ldr     w8, [x0, #12]
        adrp    x9, GetDstSize(DecodedInst*)::Sizes
        add     x9, x9, :lo12:GetDstSize(DecodedInst*)::Sizes
        ubfx    x8, x8, #19, #3
        ldrb    w0, [x9, x8]
        ret
GetDstSize(DecodedInst*)::Sizes:
        .asciz  "\000\001\002\004\b\020 "
```
</details>

<details>
<summary>x86</summary>

```asm
GetDstSize(DecodedInst*):
        mov     eax, dword ptr [rdi + 12]
        shr     eax, 19
        and     eax, 7
        mov     al, byte ptr [rax + GetDstSize(DecodedInst*)::Sizes]
        ret
GetDstSize(DecodedInst*)::Sizes:
        .asciz  "\000\001\002\004\b\020 "
```
</details>