### PR TITLE
Context: Place return value from GenerateIR into a struct

### DIFF
--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -217,9 +217,28 @@ namespace FEXCore::Context {
     bool GetDebugDataForRIP(uint64_t RIP, FEXCore::Core::DebugData *Data);
     bool FindHostCodeForRIP(uint64_t RIP, uint8_t **Code);
 
-    std::tuple<FEXCore::IR::IRListView *, FEXCore::IR::RegisterAllocationData *, uint64_t, uint64_t, uint64_t, uint64_t> GenerateIR(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP);
+    struct GenerateIRResult {
+      FEXCore::IR::IRListView* IRList;
+      // User's responsibility to deallocate this.
+      FEXCore::IR::RegisterAllocationData* RAData;
+      uint64_t TotalInstructions;
+      uint64_t TotalInstructionsLength;
+      uint64_t StartAddr;
+      uint64_t Length;
+    };
+    [[nodiscard]] GenerateIRResult GenerateIR(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP);
 
-    std::tuple<void *, FEXCore::IR::IRListView *, FEXCore::Core::DebugData *, FEXCore::IR::RegisterAllocationData *, bool, uint64_t, uint64_t> CompileCode(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP);
+    struct CompileCodeResult {
+      void* CompiledCode;
+      FEXCore::IR::IRListView* IRData;
+      FEXCore::Core::DebugData* DebugData;
+      // User's responsibility to deallocate this.
+      FEXCore::IR::RegisterAllocationData* RAData;
+      bool GeneratedIR;
+      uint64_t StartAddr;
+      uint64_t Length;
+    };
+    [[nodiscard]] CompileCodeResult CompileCode(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP);
     uintptr_t CompileBlock(FEXCore::Core::CpuStateFrame *Frame, uint64_t GuestRIP);
     
     // same as CompileBlock, but aborts on failure


### PR DESCRIPTION
This makes it a little more straightforward to see what these return values mean without needing to look at the implementation, since a tuple's declaration is kind of opaque.

These tuples were also getting a little bit large enough to make the signature a little lengthy. Since the types are still aggregates, it's still possible to use structured bindings with them.