### PR TITLE
Context: Add alias for exit handler

### DIFF
--- a/External/FEXCore/Source/Interface/Context/Context.cpp
+++ b/External/FEXCore/Source/Interface/Context/Context.cpp
@@ -37,12 +37,11 @@ namespace FEXCore::Context {
     return CTX->InitCore(Loader);
   }
 
-  void SetExitHandler(FEXCore::Context::Context *CTX,
-      std::function<void(uint64_t ThreadId, FEXCore::Context::ExitReason)> handler) {
-    CTX->CustomExitHandler = handler;
+  void SetExitHandler(FEXCore::Context::Context *CTX, ExitHandler handler) {
+    CTX->CustomExitHandler = std::move(handler);
   }
 
-  std::function<void(uint64_t ThreadId, FEXCore::Context::ExitReason)> GetExitHandler(FEXCore::Context::Context *CTX) {
+  ExitHandler GetExitHandler(FEXCore::Context::Context *CTX) {
     return CTX->CustomExitHandler;
   }
 

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -147,7 +147,7 @@ namespace FEXCore::Context {
     std::unique_ptr<FEXCore::ThunkHandler> ThunkHandler;
 
     CustomCPUFactoryType CustomCPUFactory;
-    std::function<void(uint64_t ThreadId, FEXCore::Context::ExitReason)> CustomExitHandler;
+    FEXCore::Context::ExitHandler CustomExitHandler;
 
     struct AOTIRCacheEntry {
       AOTIRInlineIndex *Array;

--- a/External/FEXCore/Source/Interface/Core/GdbServer.cpp
+++ b/External/FEXCore/Source/Interface/Core/GdbServer.cpp
@@ -47,11 +47,11 @@ void GdbServer::Break(int signal) {
 }
 
 GdbServer::GdbServer(FEXCore::Context::Context *ctx) : CTX(ctx) {
-    ctx->CustomExitHandler = [this](uint64_t ThreadId, FEXCore::Context::ExitReason ExitReason) {
+    Context::SetExitHandler(ctx, [this](uint64_t ThreadId, FEXCore::Context::ExitReason ExitReason) {
         if (ExitReason == FEXCore::Context::ExitReason::EXIT_DEBUG) {
             this->Break(SIGTRAP);
         }
-    };
+    });
 
     // This is a total hack as there is currently no way to resume once hitting a segfault
     // But it's semi-useful for debugging.

--- a/External/FEXCore/include/FEXCore/Core/Context.h
+++ b/External/FEXCore/include/FEXCore/Core/Context.h
@@ -46,7 +46,10 @@ namespace FEXCore::Context {
     MODE_32BIT,
     MODE_64BIT,
   };
+
   using CustomCPUFactoryType = std::function<std::unique_ptr<FEXCore::CPU::CPUBackend> (FEXCore::Context::Context*, FEXCore::Core::InternalThreadState *Thread)>;
+
+  using ExitHandler = std::function<void(uint64_t ThreadId, FEXCore::Context::ExitReason)>;
 
   /**
    * @brief This initializes internal FEXCore state that is shared between contexts and requires overhead to setup
@@ -90,8 +93,8 @@ namespace FEXCore::Context {
    */
   FEX_DEFAULT_VISIBILITY bool InitCore(FEXCore::Context::Context *CTX, FEXCore::CodeLoader *Loader);
 
-  FEX_DEFAULT_VISIBILITY void SetExitHandler(FEXCore::Context::Context *CTX, std::function<void(uint64_t ThreadId, FEXCore::Context::ExitReason)> handler);
-  FEX_DEFAULT_VISIBILITY std::function<void(uint64_t ThreadId, FEXCore::Context::ExitReason)> GetExitHandler(FEXCore::Context::Context *CTX);
+  FEX_DEFAULT_VISIBILITY void SetExitHandler(FEXCore::Context::Context *CTX, ExitHandler handler);
+  FEX_DEFAULT_VISIBILITY ExitHandler GetExitHandler(FEXCore::Context::Context *CTX);
 
   /**
    * @brief Pauses execution on the CPU core


### PR DESCRIPTION
Places the definition in one place so it doesn't need to be written several times.