### PR TITLE
Arm64: Use regular function pointers with CAS handling functions

### DIFF
--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64.cpp
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64.cpp
@@ -221,13 +221,18 @@ bool HandleCASPAL(void *_ucontext, void *_info, uint32_t Instr) {
   return false;
 }
 
+template <typename T>
+using CASExpectedFn = T (*)(T Src, T Expected);
+template <typename T>
+using CASDesiredFn = T (*)(T Src, T Desired);
+
 static
 std::tuple<uint16_t, bool> DoCAS16(
   uint16_t DesiredSrc,
   uint16_t ExpectedSrc,
   uint64_t Addr,
-  std::function<uint16_t(uint16_t SrcVal, uint16_t Expected)> ExpectedFunction,
-  std::function<uint16_t(uint16_t SrcVal, uint16_t Desired)> DesiredFunction) {
+  CASExpectedFn<uint16_t> ExpectedFunction,
+  CASDesiredFn<uint16_t> DesiredFunction) {
   // 16 bit
   uint64_t AlignmentMask = 0b1111;
   if ((Addr & AlignmentMask) == 15) {
@@ -476,8 +481,8 @@ std::tuple<uint32_t, bool> DoCAS32(
   uint32_t DesiredSrc,
   uint32_t ExpectedSrc,
   uint64_t Addr,
-  std::function<uint32_t(uint32_t SrcVal, uint32_t Expected)> ExpectedFunction,
-  std::function<uint32_t(uint32_t SrcVal, uint32_t Desired)> DesiredFunction) {
+  CASExpectedFn<uint32_t> ExpectedFunction,
+  CASDesiredFn<uint32_t> DesiredFunction) {
   // 32 bit
   uint64_t AlignmentMask = 0b1111;
   if ((Addr & AlignmentMask) > 12) {
@@ -683,8 +688,8 @@ std::tuple<uint64_t, bool> DoCAS64(
   uint64_t DesiredSrc,
   uint64_t ExpectedSrc,
   uint64_t Addr,
-  std::function<uint64_t(uint64_t SrcVal, uint64_t Expected)> ExpectedFunction,
-  std::function<uint64_t(uint64_t SrcVal, uint64_t Desired)> DesiredFunction) {
+  CASExpectedFn<uint64_t> ExpectedFunction,
+  CASDesiredFn<uint64_t> DesiredFunction) {
   // 64bit
   uint64_t AlignmentMask = 0b1111;
   if ((Addr & AlignmentMask) > 8) {
@@ -964,7 +969,7 @@ bool HandleAtomicMemOp(void *_ucontext, void *_info, uint32_t Instr) {
       return Desired;
     };
 
-    std::function<uint16_t(uint16_t SrcVal, uint16_t Desired)> DesiredFunction;
+    CASDesiredFn<uint16_t> DesiredFunction{};
 
     switch (Op) {
       case ATOMIC_ADD_OP:
@@ -1031,7 +1036,7 @@ bool HandleAtomicMemOp(void *_ucontext, void *_info, uint32_t Instr) {
       return Desired;
     };
 
-    std::function<uint32_t(uint32_t SrcVal, uint32_t Desired)> DesiredFunction;
+    CASDesiredFn<uint32_t> DesiredFunction{};
 
     switch (Op) {
       case ATOMIC_ADD_OP:
@@ -1098,7 +1103,7 @@ bool HandleAtomicMemOp(void *_ucontext, void *_info, uint32_t Instr) {
       return Desired;
     };
 
-    std::function<uint64_t(uint64_t SrcVal, uint64_t Desired)> DesiredFunction;
+    CASDesiredFn<uint64_t> DesiredFunction{};
 
     switch (Op) {
       case ATOMIC_ADD_OP:


### PR DESCRIPTION
Given these are called in a loop repeatedly, where we know we'll always have a set function to call, std::function adds a little bit of
overhead.

e.g. for the uint32_t case:

<details>
<summary>Previous</summary>

```asm
        sub     sp, sp, #32
        stp     x29, x30, [sp, #16]
        add     x29, sp, #16
        ldr     x8, [x0, #16]
        stur    w1, [x29, #-4]
        str     w2, [sp, #8]
        cbz     x8, .LBB2_2
        ldr     x8, [x0, #24]
        sub     x1, x29, #4
        add     x2, sp, #8
        blr     x8
        ldp     x29, x30, [sp, #16]
        add     sp, sp, #32
        ret
.LBB2_2:
        bl      std::__throw_bad_function_call()
```
</details>

<details>
<summary>After</summary>

```asm
        mov     x3, x0
        mov     w0, w1
        mov     w1, w2
        br      x3
```
</details>