### PR TITLE
ARM64: Fixes bugs in unaligned atomic signal handlers

### DIFF
--- a/unittests/ASM/Disabled_Tests_ARMv8.0
+++ b/unittests/ASM/Disabled_Tests_ARMv8.0
@@ -8,6 +8,9 @@ Test_TwoByte/0F_B0_7.asm
 Test_Secondary/09_XX_01_7.asm
 Test_Secondary/09_XX_01_8.asm
 Test_Secondary/09_XX_01_9.asm
+Test_Secondary/09_XX_01_11.asm
+Test_Secondary/09_XX_01_12.asm
+Test_Secondary/09_XX_01_13.asm
 
 # Doesn't support unaligned atomic memory ops on armv8.0
 Test_Primary/Primary_01_Atomic16.asm

--- a/unittests/ASM/Secondary/09_XX_01_10.asm
+++ b/unittests/ASM/Secondary/09_XX_01_10.asm
@@ -1,0 +1,43 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x80000000",
+    "RDX": "0xFFFFFFFF",
+    "RBX": "0x0000000080000000",
+    "RCX": "0x00000000ffffffff",
+    "R13": "0xffffffff80000000",
+    "R14": "0x0"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov r15, 0xe0000000
+
+mov rax, 0xFFFFFFFF80000000
+mov [r15 + 8 * 0], rax
+
+mov r14, 0
+; Expected
+mov eax, 0x41424344
+mov edx, 0x51525354
+
+; Desired
+mov ebx, 0x80000000
+mov ecx, 0xFFFFFFFF
+
+; Memory is already Desired and NOT expected
+; Finds bug in CAS on AArch64
+
+cmpxchg8b [r15]
+
+; Set r14 to 1 if if the memory location was expected
+setz r14b
+
+; edx and eax will now contain the memory's data
+
+; Check memory location to ensure it contains what we want
+mov r13, [r15 + 8 * 0]
+hlt

--- a/unittests/ASM/Secondary/09_XX_01_11.asm
+++ b/unittests/ASM/Secondary/09_XX_01_11.asm
@@ -1,0 +1,42 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x0000000080000000",
+    "RDX": "0x00000000ffffffff",
+    "RBX": "0x4141414180000000",
+    "RCX": "0x41414141ffffffff",
+    "R13": "0xffffffff80000000",
+    "R14": "0x0"
+  }
+}
+%endif
+
+; Within 16 byte region but unaligned
+mov r15, 0xe0000007
+
+mov rax, 0xFFFFFFFF80000000
+mov [r15 + 8 * 0], rax
+
+mov r14, 0
+; Expected
+mov rax, 0xFFFFFFFF41424344
+mov rdx, 0xFFFFFFFF51525354
+
+; Desired
+mov rbx, 0x4141414180000000
+mov rcx, 0x41414141FFFFFFFF
+
+; Memory is already Desired and NOT expected
+; Finds bug in CAS on AArch64
+
+cmpxchg8b [r15]
+
+; Set r14 to 1 if if the memory location was expected
+setz r14b
+
+; Memory will now be set to the register data
+; EDX:EAX will be the original data
+
+; Check memory location to ensure it contains what we want
+mov r13, [r15 + 8 * 0]
+hlt

--- a/unittests/ASM/Secondary/09_XX_01_12.asm
+++ b/unittests/ASM/Secondary/09_XX_01_12.asm
@@ -1,0 +1,42 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x0000000080000000",
+    "RDX": "0x00000000ffffffff",
+    "RBX": "0x4141414180000000",
+    "RCX": "0x41414141ffffffff",
+    "R13": "0xffffffff80000000",
+    "R14": "0x0"
+  }
+}
+%endif
+
+; Spans 16byte boundary and unaligned
+mov r15, 0xe0000009
+
+mov rax, 0xFFFFFFFF80000000
+mov [r15 + 8 * 0], rax
+
+mov r14, 0
+; Expected
+mov rax, 0xFFFFFFFF41424344
+mov rdx, 0xFFFFFFFF51525354
+
+; Desired
+mov rbx, 0x4141414180000000
+mov rcx, 0x41414141FFFFFFFF
+
+; Memory is already Desired and NOT expected
+; Finds bug in CAS on AArch64
+
+cmpxchg8b [r15]
+
+; Set r14 to 1 if if the memory location was expected
+setz r14b
+
+; Memory will now be set to the register data
+; EDX:EAX will be the original data
+
+; Check memory location to ensure it contains what we want
+mov r13, [r15 + 8 * 0]
+hlt

--- a/unittests/ASM/Secondary/09_XX_01_13.asm
+++ b/unittests/ASM/Secondary/09_XX_01_13.asm
@@ -1,0 +1,42 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x0000000080000000",
+    "RDX": "0x00000000ffffffff",
+    "RBX": "0x4141414180000000",
+    "RCX": "0x41414141ffffffff",
+    "R13": "0xffffffff80000000",
+    "R14": "0x0"
+  }
+}
+%endif
+
+; Spans 64byte boundary and unaligned
+mov r15, 0xe000003F
+
+mov rax, 0xFFFFFFFF80000000
+mov [r15 + 8 * 0], rax
+
+mov r14, 0
+; Expected
+mov rax, 0xFFFFFFFF41424344
+mov rdx, 0xFFFFFFFF51525354
+
+; Desired
+mov rbx, 0x4141414180000000
+mov rcx, 0x41414141FFFFFFFF
+
+; Memory is already Desired and NOT expected
+; Finds bug in CAS on AArch64
+
+cmpxchg8b [r15]
+
+; Set r14 to 1 if if the memory location was expected
+setz r14b
+
+; Memory will now be set to the register data
+; EDX:EAX will be the original data
+
+; Check memory location to ensure it contains what we want
+mov r13, [r15 + 8 * 0]
+hlt


### PR DESCRIPTION
There were two bugs in here.

The first bug here is with with the CMPXCHG emulation.
1) If the *Expected* value did *NOT* match what was in memory
2) *AND* The *Desired* value matched the memory value
3) The CAS would incorrectly return success for this CMPXCHG
4) Thus setting ZF incorrectly

The second bug comes from atomic memory operations (Add, CLR, EOR, SET, SWAP).
This operation is a Load + &lt;Op&gt; + CAS
1) If the memory backing between the Load and CAS changes
2) The CAS would then fail
3) On Atomic memory operations this should then retry to ensure it completes successfully
4) We were not retrying on failure in this case
5) Thus something like `LOCK INC` would have never atomically incremented correctly
6) We can't use our ASM unit tests to test this, since it needs thread contention.