### PR TITLE
Linux: Implements a base implementation of signalfd{4,}

### DIFF
--- a/Source/Tests/LinuxSyscalls/SignalDelegator.h
+++ b/Source/Tests/LinuxSyscalls/SignalDelegator.h
@@ -83,6 +83,7 @@ namespace FEX::HLE {
     uint64_t GuestSigPending(uint64_t *set, size_t sigsetsize);
     uint64_t GuestSigSuspend(uint64_t *set, size_t sigsetsize);
     uint64_t GuestSigTimedWait(uint64_t *set, siginfo_t *info, const struct timespec *timeout, size_t sigsetsize);
+    uint64_t GuestSignalFD(int fd, const uint64_t *set, size_t sigsetsize , int flags);
 
     // Called from the thunk handler to handle the signal
     void HandleSignal(int Signal, void *Info, void *UContext);

--- a/Source/Tests/LinuxSyscalls/Syscalls/Signals.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Signals.cpp
@@ -42,6 +42,14 @@ namespace FEX::HLE {
       SYSCALL_ERRNO();
     });
 
+    REGISTER_SYSCALL_IMPL(signalfd, [](FEXCore::Core::CpuStateFrame *Frame, int fd, const uint64_t *mask, size_t sigsetsize) -> uint64_t {
+      return FEX::HLE::_SyscallHandler->GetSignalDelegator()->GuestSignalFD(fd, mask, sigsetsize, 0);
+    });
+
+    REGISTER_SYSCALL_IMPL(signalfd4, [](FEXCore::Core::CpuStateFrame *Frame, int fd, const uint64_t *mask, size_t sigsetsize, int flags) -> uint64_t {
+      return FEX::HLE::_SyscallHandler->GetSignalDelegator()->GuestSignalFD(fd, mask, sigsetsize, flags);
+    });
+
     if (Handler->IsHostKernelVersionAtLeast(5, 1, 0)) {
       REGISTER_SYSCALL_IMPL(pidfd_send_signal, [](FEXCore::Core::CpuStateFrame *Frame, int pidfd, int sig, siginfo_t *info, unsigned int flags) -> uint64_t {
         uint64_t Result = ::syscall(SYS_pidfd_send_signal, pidfd, sig, info, flags);

--- a/Source/Tests/LinuxSyscalls/Syscalls/Stubs.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Stubs.cpp
@@ -52,14 +52,6 @@ namespace FEX::HLE {
       SYSCALL_STUB(restart_syscall);
     });
 
-    REGISTER_SYSCALL_IMPL(signalfd, [](FEXCore::Core::CpuStateFrame *Frame, int fd, const sigset_t *mask, size_t sizemask) -> uint64_t {
-      SYSCALL_STUB(signalfd);
-    });
-
-    REGISTER_SYSCALL_IMPL(signalfd4, [](FEXCore::Core::CpuStateFrame *Frame, int fd, const sigset_t *mask, size_t sizemask, int flags) -> uint64_t {
-      SYSCALL_STUB(signalfd4);
-    });
-
     REGISTER_SYSCALL_IMPL(rt_tgsigqueueinfo, [](FEXCore::Core::CpuStateFrame *Frame, pid_t tgid, pid_t tid, int sig, siginfo_t *info) -> uint64_t {
       SYSCALL_STUB(rt_tgsigqueueinfo);
     });

--- a/unittests/gvisor-tests/Known_Failures
+++ b/unittests/gvisor-tests/Known_Failures
@@ -72,7 +72,6 @@ epoll_test
 exceptions_test
 exec_binary_test
 exec_test
-fallocate_test
 fcntl_test
 flock_test
 fork_test


### PR DESCRIPTION
This is a base implementation of signalfd.
Signalfd allows the application to receive siginfo_t information through an FD.
The FD is either provided by the application or created by the kernel depending.
This specifically doesn't pick up *true* synchronous signals. tgkill of the number
should theoretically go through this interface.

This very specifically skips our internal required signals for now.
This means it won't pick up SIGILL, SIGBUS, or SIG63.

This is enough to capture an application that just wants to poll for SIGCHLD.
Anything more complex has the same problems of the guest handling a siginfo_t.