### PR TITLE
GdbStub: Fix memory leak in GdbServerLoop()

### DIFF
--- a/External/FEXCore/Source/Interface/Core/GdbServer.cpp
+++ b/External/FEXCore/Source/Interface/Core/GdbServer.cpp
@@ -939,7 +939,7 @@ void GdbServer::GdbServerLoop() {
 
     {
         std::lock_guard lk(sendMutex);
-        CommsStream.release();
+        CommsStream.reset();
     }
   }
 }


### PR DESCRIPTION
Previously the opened socket stream would be leaked.