### PR TITLE
Linux: Implements rt_{tg,}sigqueueinfo

### DIFF
--- a/Source/Tests/LinuxSyscalls/Syscalls/Signals.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Signals.cpp
@@ -50,6 +50,16 @@ namespace FEX::HLE {
       return FEX::HLE::_SyscallHandler->GetSignalDelegator()->GuestSignalFD(fd, mask, sigsetsize, flags);
     });
 
+    REGISTER_SYSCALL_IMPL(rt_sigqueueinfo, [](FEXCore::Core::CpuStateFrame *Frame, pid_t pid, int sig, siginfo_t *info) -> uint64_t {
+      uint64_t Result = ::syscall(SYS_rt_sigqueueinfo, pid, sig, info);
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL(rt_tgsigqueueinfo, [](FEXCore::Core::CpuStateFrame *Frame, pid_t tgid, pid_t tid, int sig, siginfo_t *info) -> uint64_t {
+      uint64_t Result = ::syscall(SYS_rt_tgsigqueueinfo, tgid, tid, sig, info);
+      SYSCALL_ERRNO();
+    });
+
     if (Handler->IsHostKernelVersionAtLeast(5, 1, 0)) {
       REGISTER_SYSCALL_IMPL(pidfd_send_signal, [](FEXCore::Core::CpuStateFrame *Frame, int pidfd, int sig, siginfo_t *info, unsigned int flags) -> uint64_t {
         uint64_t Result = ::syscall(SYS_pidfd_send_signal, pidfd, sig, info, flags);

--- a/Source/Tests/LinuxSyscalls/Syscalls/Stubs.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Stubs.cpp
@@ -40,20 +40,12 @@ namespace FEX::HLE {
       return -EPERM;
     });
 
-    REGISTER_SYSCALL_IMPL(rt_sigqueueinfo, [](FEXCore::Core::CpuStateFrame *Frame, pid_t pid, int sig, siginfo_t *uinfo) -> uint64_t {
-      SYSCALL_STUB(rt_sigqueueinfo);
-    });
-
     REGISTER_SYSCALL_IMPL(modify_ldt, [](FEXCore::Core::CpuStateFrame *Frame, int func, void *ptr, unsigned long bytecount) -> uint64_t {
       SYSCALL_STUB(modify_ldt);
     });
 
     REGISTER_SYSCALL_IMPL(restart_syscall, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t {
       SYSCALL_STUB(restart_syscall);
-    });
-
-    REGISTER_SYSCALL_IMPL(rt_tgsigqueueinfo, [](FEXCore::Core::CpuStateFrame *Frame, pid_t tgid, pid_t tid, int sig, siginfo_t *info) -> uint64_t {
-      SYSCALL_STUB(rt_tgsigqueueinfo);
     });
 
     REGISTER_SYSCALL_IMPL(rseq, [](FEXCore::Core::CpuStateFrame *Frame,  struct rseq  *rseq, uint32_t rseq_len, int flags, uint32_t sig) -> uint64_t {

--- a/unittests/POSIX/Known_Failures
+++ b/unittests/POSIX/Known_Failures
@@ -2,17 +2,9 @@
 conformance-interfaces-clock-1-1.test
 conformance-interfaces-clock_getcpuclockid-2-1.testconformance-interfaces-clock-1-1.test
 conformance-interfaces-munmap-2-1.test
-conformance-interfaces-sigqueue-10-1.test
-conformance-interfaces-sigqueue-11-1.test
 conformance-interfaces-sigqueue-12-1.test
-conformance-interfaces-sigqueue-2-1.test
-conformance-interfaces-sigqueue-2-2.test
 conformance-interfaces-sigqueue-3-1.test
-conformance-interfaces-sigqueue-4-1.test
-conformance-interfaces-sigqueue-5-1.test
-conformance-interfaces-sigqueue-6-1.test
 conformance-interfaces-sigqueue-7-1.test
-conformance-interfaces-sigqueue-8-1.test
 conformance-interfaces-sigqueue-9-1.test
 conformance-interfaces-sigtimedwait-5-1.test
 conformance-interfaces-sigwait-1-1.test
@@ -23,8 +15,6 @@ conformance-interfaces-sigwaitinfo-1-1.test
 conformance-interfaces-sigwaitinfo-2-1.test
 conformance-interfaces-sigwaitinfo-5-1.test
 conformance-interfaces-sigwaitinfo-6-1.test
-conformance-interfaces-sigwaitinfo-7-1.test
-conformance-interfaces-sigwaitinfo-8-1.test
 conformance-interfaces-sigwaitinfo-9-1.test
 
 # these are disabled


### PR DESCRIPTION
We already support receiving user signals in our signal handlers for this.
Just need to push through syscalls.

This fixes Dead Island Definitive Edition so it runs.