### PR TITLE
OpDispatcher: Fixes imul flags calculations

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -2751,8 +2751,15 @@ void OpDispatchBuilder::IMUL1SrcOp(OpcodeArgs) {
   }
 
   auto Dest = _Mul(Src1, Src2);
+  OrderedNode *ResultHigh{};
+  if (Size < 8) {
+    ResultHigh = _Sbfe(Size * 8, Size * 8, Dest);
+  }
+  else {
+    ResultHigh = _MulH(Src1, Src2);
+  }
   StoreResult(GPRClass, Op, Dest, -1);
-  GenerateFlags_MUL(Op, Dest, _MulH(Src1, Src2));
+  GenerateFlags_MUL(Op, Dest, ResultHigh);
 }
 
 void OpDispatchBuilder::IMUL2SrcOp(OpcodeArgs) {
@@ -2766,8 +2773,16 @@ void OpDispatchBuilder::IMUL2SrcOp(OpcodeArgs) {
   }
 
   auto Dest = _Mul(Src1, Src2);
+  OrderedNode *ResultHigh{};
+  if (Size < 8) {
+    ResultHigh = _Sbfe(Size * 8, Size * 8, Dest);
+  }
+  else {
+    ResultHigh = _MulH(Src1, Src2);
+  }
+
   StoreResult(GPRClass, Op, Dest, -1);
-  GenerateFlags_MUL(Op, Dest, _MulH(Src1, Src2));
+  GenerateFlags_MUL(Op, Dest, ResultHigh);
 }
 
 void OpDispatchBuilder::IMULOp(OpcodeArgs) {
@@ -2800,8 +2815,8 @@ void OpDispatchBuilder::IMULOp(OpcodeArgs) {
     // Make sure they get Zext correctly
     auto LocalResult = _Bfe(32, 0, Result);
     auto LocalResultHigh = _Bfe(32, 32, Result);
-    Result = _Sbfe(32, 0, Result);
     ResultHigh = _Sbfe(32, 32, Result);
+    Result = _Sbfe(32, 0, Result);
     _StoreContext(GPRClass, 8, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RAX]), LocalResult);
     _StoreContext(GPRClass, 8, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RDX]), LocalResultHigh);
   }

--- a/unittests/32Bit_ASM/PrimaryGroup/3_F6_05.asm
+++ b/unittests/32Bit_ASM/PrimaryGroup/3_F6_05.asm
@@ -1,0 +1,70 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RDI": "0x00000000000003fc"
+  },
+  "Mode": "32BIT"
+}
+%endif
+
+%macro ofcfmerge 0
+  ; Get CF
+  setc al
+  ; Get OF
+  seto bl
+  and eax, 1
+  and ebx, 1
+
+  ; Merge in to results
+  shl edi, 1
+  or edi, eax
+
+  ; Merge in to results
+  shl edi, 1
+  or edi, ebx
+%endmacro
+
+mov edi, 0
+
+; Max Negative
+mov al, 0x80
+mov bl, 0x80
+
+imul bl
+
+ofcfmerge
+
+; Max Positive
+mov al, 0x79
+mov bl, 0x79
+
+imul bl
+
+ofcfmerge
+
+; Max Positive and Max Negative
+mov al, 0x79
+mov bl, 0x80
+
+imul bl
+
+ofcfmerge
+
+; Max Positive and Max Negative
+mov al, 0x80
+mov bl, 0x79
+
+imul bl
+
+ofcfmerge
+
+; No Overflow
+
+mov al, 0x1
+mov bl, 0x1
+
+imul bl
+
+ofcfmerge
+
+hlt

--- a/unittests/ASM/PrimaryGroup/3_F6_05_2.asm
+++ b/unittests/ASM/PrimaryGroup/3_F6_05_2.asm
@@ -1,0 +1,69 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RDI": "0x00000000000003fc"
+  }
+}
+%endif
+
+%macro ofcfmerge 0
+  ; Get CF
+  setc al
+  ; Get OF
+  seto bl
+  and eax, 1
+  and ebx, 1
+
+  ; Merge in to results
+  shl edi, 1
+  or edi, eax
+
+  ; Merge in to results
+  shl edi, 1
+  or edi, ebx
+%endmacro
+
+mov edi, 0
+
+; Max Negative
+mov al, 0x80
+mov bl, 0x80
+
+imul bl
+
+ofcfmerge
+
+; Max Positive
+mov al, 0x7F
+mov bl, 0x7F
+
+imul bl
+
+ofcfmerge
+
+; Max Positive and Max Negative
+mov al, 0x7F
+mov bl, 0x80
+
+imul bl
+
+ofcfmerge
+
+; Max Positive and Max Negative
+mov al, 0x80
+mov bl, 0x7F
+
+imul bl
+
+ofcfmerge
+
+; No Overflow
+
+mov al, 0x1
+mov bl, 0x1
+
+imul bl
+
+ofcfmerge
+
+hlt

--- a/unittests/ASM/PrimaryGroup/3_F6_05_3.asm
+++ b/unittests/ASM/PrimaryGroup/3_F6_05_3.asm
@@ -1,0 +1,69 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RDI": "0x00000000000003fc"
+  }
+}
+%endif
+
+%macro ofcfmerge 0
+  ; Get CF
+  setc al
+  ; Get OF
+  seto bl
+  and eax, 1
+  and ebx, 1
+
+  ; Merge in to results
+  shl edi, 1
+  or edi, eax
+
+  ; Merge in to results
+  shl edi, 1
+  or edi, ebx
+%endmacro
+
+mov edi, 0
+
+; Max Negative
+mov ax, 0x8000
+mov bx, 0x8000
+
+imul bx
+
+ofcfmerge
+
+; Max Positive
+mov ax, 0x7FFF
+mov bx, 0x7FFF
+
+imul bx
+
+ofcfmerge
+
+; Max Positive and Max Negative
+mov ax, 0x7FFF
+mov bx, 0x8000
+
+imul bx
+
+ofcfmerge
+
+; Max Positive and Max Negative
+mov ax, 0x8000
+mov bx, 0x7FFF
+
+imul bx
+
+ofcfmerge
+
+; No Overflow
+
+mov ax, 0x1
+mov bx, 0x1
+
+imul bx
+
+ofcfmerge
+
+hlt

--- a/unittests/ASM/PrimaryGroup/3_F6_05_4.asm
+++ b/unittests/ASM/PrimaryGroup/3_F6_05_4.asm
@@ -1,0 +1,69 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RDI": "0x00000000000003fc"
+  }
+}
+%endif
+
+%macro ofcfmerge 0
+  ; Get CF
+  setc al
+  ; Get OF
+  seto bl
+  and eax, 1
+  and ebx, 1
+
+  ; Merge in to results
+  shl edi, 1
+  or edi, eax
+
+  ; Merge in to results
+  shl edi, 1
+  or edi, ebx
+%endmacro
+
+mov edi, 0
+
+; Max Negative
+mov eax, 0x80000000
+mov ebx, 0x80000000
+
+imul ebx
+
+ofcfmerge
+
+; Max Positive
+mov eax, 0x7FFFFFFF
+mov ebx, 0x7FFFFFFF
+
+imul ebx
+
+ofcfmerge
+
+; Max Positive and Max Negative
+mov eax, 0x7FFFFFFF
+mov ebx, 0x80000000
+
+imul ebx
+
+ofcfmerge
+
+; Max Positive and Max Negative
+mov eax, 0x80000000
+mov ebx, 0x7FFFFFFF
+
+imul ebx
+
+ofcfmerge
+
+; No Overflow
+
+mov eax, 0x1
+mov ebx, 0x1
+
+imul ebx
+
+ofcfmerge
+
+hlt

--- a/unittests/ASM/PrimaryGroup/3_F6_05_5.asm
+++ b/unittests/ASM/PrimaryGroup/3_F6_05_5.asm
@@ -1,0 +1,69 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RDI": "0x00000000000003fc"
+  }
+}
+%endif
+
+%macro ofcfmerge 0
+  ; Get CF
+  setc al
+  ; Get OF
+  seto bl
+  and eax, 1
+  and ebx, 1
+
+  ; Merge in to results
+  shl edi, 1
+  or edi, eax
+
+  ; Merge in to results
+  shl edi, 1
+  or edi, ebx
+%endmacro
+
+mov edi, 0
+
+; Max Negative
+mov rax, 0x8000000000000000
+mov rbx, 0x8000000000000000
+
+imul rbx
+
+ofcfmerge
+
+; Max Positive
+mov rax, 0x7FFFFFFFFFFFFFFF
+mov rbx, 0x7FFFFFFFFFFFFFFF
+
+imul rbx
+
+ofcfmerge
+
+; Max Positive and Max Negative
+mov rax, 0x7FFFFFFFFFFFFFFF
+mov rbx, 0x8000000000000000
+
+imul rbx
+
+ofcfmerge
+
+; Max Positive and Max Negative
+mov rax, 0x8000000000000000
+mov rbx, 0x7FFFFFFFFFFFFFFF
+
+imul rbx
+
+ofcfmerge
+
+; No Overflow
+
+mov rax, 0x1
+mov rbx, 0x1
+
+imul rbx
+
+ofcfmerge
+
+hlt

--- a/unittests/ASM/TwoByte/0F_AF_2.asm
+++ b/unittests/ASM/TwoByte/0F_AF_2.asm
@@ -1,7 +1,7 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "R15": "0x0000000000c00030"
+    "R15": "0x000f000000c00030"
   }
 }
 %endif
@@ -27,6 +27,17 @@
 
 mov r8, 0xe0000000
 mov r15, 0
+
+; Negative * Negative
+mov eax, 0x00008000
+mov ebx, 0x00008000
+imul ax, bx
+ofcfmerge
+
+mov eax, 0x80000000
+mov ebx, 0x80000000
+imul eax, ebx
+ofcfmerge
 
 ; Positive * Positive
 mov rax, 128


### PR DESCRIPTION
We were calculating the high bits incorrectly in a couple variants