### PR TITLE
Use externals xxhash if not found installed

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -39,3 +39,6 @@
 [submodule "External/drm-headers"]
 	path = External/drm-headers
 	url = https://github.com/FEX-Emu/drm-headers.git
+[submodule "External/xxhash"]
+	path = External/xxhash
+	url = https://github.com/FEX-Emu/xxHash.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,13 @@ endif()
 
 find_package(PkgConfig REQUIRED)
 find_package(Python 3.0 REQUIRED COMPONENTS Interpreter)
-pkg_check_modules(XXHASH libxxhash REQUIRED)
+pkg_check_modules(XXHASH libxxhash>=0.8.0 QUIET)
+
+if (NOT XXHASH_FOUND)
+  message(STATUS "xxHash not found. Using Externals")
+  add_subdirectory(External/xxhash/)
+  include_directories(External/xxhash/)
+endif()
 
 add_definitions(-Wno-trigraphs)
 add_definitions(-DGLOBAL_DATA_DIRECTORY="${DATA_DIRECTORY}/")

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -33,7 +33,7 @@ $end_info$
 #include "Interface/HLE/Thunks/Thunks.h"
 #include "FEXCore/Utils/Allocator.h"
 
-#include <xxh3.h>
+#include <xxhash.h>
 #include <fstream>
 #include <unistd.h>
 #include <filesystem>


### PR DESCRIPTION
Also in the case that you don't have v0.8.0 minimum installed

Doesn't quite fix #1148 but this is necessary in some configurations.