### PR TITLE
Fix jemalloc malloc replace

### DIFF
--- a/Source/Tests/CMakeLists.txt
+++ b/Source/Tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_subdirectory(LinuxSyscalls)
 
-set(LIBS FEXCore Common CommonCore FEX_jemalloc)
+set(LIBS FEX_jemalloc FEXCore Common CommonCore)
 
 add_executable(FEXLoader FEXLoader.cpp)
 target_include_directories(FEXLoader PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/Source/)


### PR DESCRIPTION
Currently FEX is replacing glibc symbols at runtime depending on if we captured a 32-bit application or not.
This has us in a weird world where some of our allocations go through jemalloc, some go through glibc.
Instead fix FEX_jemalloc so it correctly replaces glibc symbols and do away with the FEXCore/FEX replacements.

This allows us to have glibc's allocator get replaced and solely work through FEX_jemalloc.
Then when a 32-bit application is running we only replace the VMA allocator for FEX_jemalloc.
This greatly simplifies how the allocator works.

Additionally this is the first step towards supporting static-pie with fex.
We can't yet enable it because we hit bugs inside of glibc with relocations. Some documentation is at #1114 