### PR TITLE
Allocator fixes

### DIFF
--- a/External/FEXCore/Source/Interface/Core/CPUID.h
+++ b/External/FEXCore/Source/Interface/Core/CPUID.h
@@ -28,9 +28,6 @@ public:
     auto Handler = FunctionHandlers.find(Function);
 
     if (Handler == FunctionHandlers.end()) {
-      #ifndef NDEBUG
-        LogMan::Msg::E("Unhandled CPU ID function, 0x%x-0x%x", Function, Leaf);
-      #endif
       return Function_Reserved(Leaf);
     }
 

--- a/External/FEXCore/Source/Interface/Core/Frontend.cpp
+++ b/External/FEXCore/Source/Interface/Core/Frontend.cpp
@@ -127,12 +127,12 @@ Decoder::Decoder(FEXCore::Context::Context *ctx)
   // Take advantage of page faulting to reduce startup time for minimal runtime cost
   DecodedBuffer =
     reinterpret_cast<FEXCore::X86Tables::DecodedInst *>(
-      ::mmap(0, sizeof(FEXCore::X86Tables::DecodedInst) * DefaultDecodedBufferSize,
+      FEXCore::Allocator::mmap(0, sizeof(FEXCore::X86Tables::DecodedInst) * DefaultDecodedBufferSize,
       PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
 }
 
 Decoder::~Decoder() {
-  ::munmap(DecodedBuffer, sizeof(FEXCore::X86Tables::DecodedInst) * DefaultDecodedBufferSize);
+  FEXCore::Allocator::munmap(DecodedBuffer, sizeof(FEXCore::X86Tables::DecodedInst) * DefaultDecodedBufferSize);
 }
 
 uint8_t Decoder::ReadByte() {

--- a/External/FEXCore/Source/Interface/Core/X86DebugInfo.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86DebugInfo.cpp
@@ -114,8 +114,6 @@ void InstallDebugInfo() {
   GenerateDebugTable(PrimaryInstGroupOps, PrimaryGroupOpTable);
 
   GenerateDebugTable(SecondInstGroupOps, SecondaryExtensionOpTable);
-
-  LogMan::Msg::D("Installing debug info");
 }
 }
 #endif

--- a/External/FEXCore/Source/Interface/Core/X86HelperGen.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86HelperGen.cpp
@@ -50,14 +50,14 @@ void* X86GeneratedCode::AllocateGuestCodeSpace(size_t Size) {
   // We need to have the sigret handler in the lower 32bits of memory space
   // Scan top down and try to allocate a location
   for (size_t Location = 0xFFFF'E000; Location != 0x0; Location -= 0x1000) {
-    void *Ptr = FEXCore::Allocator::mmap(reinterpret_cast<void*>(Location), Size, PROT_READ | PROT_WRITE, MAP_FIXED_NOREPLACE | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    void *Ptr = ::mmap(reinterpret_cast<void*>(Location), Size, PROT_READ | PROT_WRITE, MAP_FIXED_NOREPLACE | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
 
     if (Ptr != MAP_FAILED &&
         reinterpret_cast<uintptr_t>(Ptr) >= LOCATION_MAX) {
       // Failed to map in the lower 32bits
       // Try again
       // Can happen in the case that host kernel ignores MAP_FIXED_NOREPLACE
-      FEXCore::Allocator::munmap(Ptr, Size);
+      ::munmap(Ptr, Size);
       continue;
     }
 

--- a/External/FEXCore/Source/Interface/Core/X86Tables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables.cpp
@@ -108,7 +108,6 @@ void InitializeInfoTables(Context::OperatingMode Mode) {
 
 #ifndef NDEBUG
   X86InstDebugInfo::InstallDebugInfo();
-  LogMan::Msg::D("X86Tables had %ld total insts, and %ld labeled as understood", Total, NumInsts);
 #endif
 }
 


### PR DESCRIPTION
Main thing here is the partial revert of the register allocator code.
This was causing Steam to in to the VMA region count cap of 65k.

Some other minor changes:
1) Frontend no longer accidentally allocates in 32-bit space
2) 64BitAllocator adds a backwards scan to fill VMA holes, reducing the number of holes we have
3) BRKHandler/x86HelperGen Doesn't rely on the 64bit allocator hack to allow through fixed 32-bit offsets to system mmap
4) Removes some logs that were just being annoying and don't really provide us information that matters anymore.