### PR TITLE
Adds a convenience of named thunk configs

### DIFF
--- a/External/FEXCore/Source/Interface/Config/Config.cpp
+++ b/External/FEXCore/Source/Interface/Config/Config.cpp
@@ -324,7 +324,18 @@ namespace FEXCore::Config {
     }
     if (FEXCore::Config::Exists(FEXCore::Config::CONFIG_THUNKCONFIG)) {
       FEX_CONFIG_OPT(PathName, THUNKCONFIG);
-      ExpandPathIfExists(FEXCore::Config::CONFIG_THUNKCONFIG, PathName());
+      auto ExpandedString = ExpandPath(PathName());
+      if (!ExpandedString.empty()) {
+        // Adjust the path if it ended up being relative
+        FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_THUNKCONFIG, ExpandedString);
+      }
+      else if (!PathName().empty()) {
+        // If the filesystem doesn't exist then let's see if it exists in the fex-emu folder
+        std::string NamedConfig = GetDataDirectory() + "ThunkConfigs/" + PathName();
+        if (std::filesystem::exists(NamedConfig)) {
+          FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_THUNKCONFIG, NamedConfig);
+        }
+      }
     }
     if (FEXCore::Config::Exists(FEXCore::Config::CONFIG_OUTPUTLOG)) {
       FEX_CONFIG_OPT(PathName, OUTPUTLOG);

--- a/External/FEXCore/Source/Interface/Config/Config.json
+++ b/External/FEXCore/Source/Interface/Config/Config.json
@@ -77,7 +77,14 @@
         "Default": "",
         "ShortArg": "k",
         "Desc": [
-          "A json file specifying where to overlay the thunks."
+          "A json file specifying where to overlay the thunks.",
+          "This can be a filesystem path",
+          "\teg: ~/MyThunkConfig.json",
+          "Or this can be a named of a Thunk config file",
+          "If the named config file exists in the FEX data folder folder the it will use that one",
+          "\teg: $HOME/.fex-emu/ThunkConfigs/<ThunkConfig name>",
+          "Or if you have XDG_DATA_HOME the config will search in that directory",
+          "\teg: $XDG_DATA_HOME/.fex-emu/ThunkConfigs/<ThunkConfig name>"
         ]
       },
       "Env": {


### PR DESCRIPTION
If the thunk config is not a path then search for the filename in $XDG_DATA_DIR/.fex-emu/ThunkConfigs/
for the file.

Just makes it easier to use rather than having full paths