### PR TITLE
Arm64: Fixes fill and spill slot offset calculation

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -434,7 +434,7 @@ DEF_OP(StoreContextIndexed) {
 DEF_OP(SpillRegister) {
   auto Op = IROp->C<IR::IROp_SpillRegister>();
   uint8_t OpSize = IROp->Size;
-  uint32_t SlotOffset = Op->Slot * 16 + 16;
+  uint32_t SlotOffset = Op->Slot * 16;
 
   if (Op->Class == FEXCore::IR::GPRClass) {
     switch (OpSize) {
@@ -480,7 +480,7 @@ DEF_OP(SpillRegister) {
 DEF_OP(FillRegister) {
   auto Op = IROp->C<IR::IROp_FillRegister>();
   uint8_t OpSize = IROp->Size;
-  uint32_t SlotOffset = Op->Slot * 16 + 16;
+  uint32_t SlotOffset = Op->Slot * 16;
 
   if (Op->Class == FEXCore::IR::GPRClass) {
     switch (OpSize) {


### PR DESCRIPTION
+16 doesn't matter anymore. This can cause stack corruption