### PR TITLE
Validation Passes: Remove unused variables

### DIFF
--- a/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
@@ -267,10 +267,9 @@ bool IRValidation::Run(IREmitter *IREmit) {
     }
   }
 
-  std::stringstream Out;
-
   HadWarning = false;
   if (HadError || HadWarning) {
+    std::stringstream Out;
     FEXCore::IR::Dump(&Out, &CurrentIR, RAData);
 
     if (HadError) {

--- a/External/FEXCore/Source/Interface/IR/Passes/PhiValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/PhiValidation.cpp
@@ -52,16 +52,12 @@ bool PhiValidation::Run(IREmitter *IREmit) {
     }
   }
 
-  std::stringstream Out;
-
   if (HadError) {
+    std::stringstream Out;
     FEXCore::IR::Dump(&Out, &CurrentIR, nullptr);
-
     Out << "Errors:" << std::endl << Errors.str() << std::endl;
-
     LogMan::Msg::EFmt("{}", Out.str());
   }
-
 
   return false;
 }

--- a/External/FEXCore/Source/Interface/IR/Passes/ValueDominanceValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ValueDominanceValidation.cpp
@@ -28,12 +28,9 @@ public:
 
 bool ValueDominanceValidation::Run(IREmitter *IREmit) {
   bool HadError = false;
-  bool HadWarning = false;
   auto CurrentIR = IREmit->ViewIR();
 
   std::ostringstream Errors;
-  std::ostringstream Warnings;
-
   std::unordered_map<IR::OrderedNodeWrapper::NodeOffsetType, BlockInfo> OffsetToBlockMap;
 
   for (auto [BlockNode, BlockHeader] : CurrentIR.GetBlocks()) {
@@ -193,19 +190,10 @@ bool ValueDominanceValidation::Run(IREmitter *IREmit) {
     }
   }
 
-  std::stringstream Out;
-
-  if (HadError || HadWarning) {
+  if (HadError) {
+    std::stringstream Out;
     FEXCore::IR::Dump(&Out, &CurrentIR, nullptr);
-
-    if (HadError) {
-      Out << "Errors:" << std::endl << Errors.str() << std::endl;
-    }
-
-    if (HadWarning) {
-      Out << "Warnings:" << std::endl << Warnings.str() << std::endl;
-    }
-
+    Out << "Errors:" << std::endl << Errors.str() << std::endl;
     LogMan::Msg::EFmt("{}", Out.str());
   }
 


### PR DESCRIPTION
Removes some logically dead variables, and narrows the construction scope for the error printing stringstream so that we only construct it when we have errors to indicate