### PR TITLE
General: Remove redundant string constructions in log calls related to IR op name retrieval

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -534,7 +534,7 @@ bool IsConditionTrue(uint8_t Cond, uint64_t Src1, uint64_t Src2) {
     case FEXCore::IR::COND_VS:
     case FEXCore::IR::COND_VC:
     default:
-      LOGMAN_MSG_A("Unsupported compare type");
+      LOGMAN_MSG_A_FMT("Unsupported compare type");
       break;
   }
 
@@ -557,7 +557,7 @@ Res GetSrc(void* SSAData, IR::OrderedNodeWrapper Src) {
 static void StopThread(FEXCore::Core::InternalThreadState *Thread) {
   Thread->CTX->StopThread(Thread);
 
-  LOGMAN_MSG_A("unreachable");
+  LOGMAN_MSG_A_FMT("unreachable");
   FEX_UNREACHABLE;
 }
 
@@ -565,7 +565,7 @@ static void StopThread(FEXCore::Core::InternalThreadState *Thread) {
 static void SignalReturn(FEXCore::Core::InternalThreadState *Thread) {
   Thread->CTX->SignalThread(Thread, FEXCore::Core::SignalEvent::Return);
 
-  LOGMAN_MSG_A("unreachable");
+  LOGMAN_MSG_A_FMT("unreachable");
   FEX_UNREACHABLE;
 }
 
@@ -869,7 +869,7 @@ struct OpHandlers<IR::OP_F80LOADFCW> {
       case 0: extF80_roundingPrecision = 32; break;
       case 2: extF80_roundingPrecision = 64; break;
       case 3: extF80_roundingPrecision = 80; break;
-      case 1: LOGMAN_MSG_A("Invalid x87 precision mode, %d", PC);
+      case 1: LOGMAN_MSG_A_FMT("Invalid x87 precision mode, {}", PC);
     }
 
     auto RC = (NewFCW >> 10) & 3;
@@ -980,7 +980,7 @@ bool InterpreterOps::GetFallbackHandler(IR::IROp_Header *IROp, FallbackInfo *Inf
           *Info = GetFallbackInfo(&OpHandlers<IR::OP_F80CVTTO>::handle8);
           return true;
         }
-      default: LogMan::Msg::D("Unhandled size: %d", OpSize);
+      default: LogMan::Msg::DFmt("Unhandled size: {}", OpSize);
       }
       break;
     }
@@ -994,7 +994,7 @@ bool InterpreterOps::GetFallbackHandler(IR::IROp_Header *IROp, FallbackInfo *Inf
           *Info = GetFallbackInfo(&OpHandlers<IR::OP_F80CVT>::handle8);
           return true;
         }
-        default: LogMan::Msg::D("Unhandled size: %d", OpSize);
+        default: LogMan::Msg::DFmt("Unhandled size: {}", OpSize);
       }
       break;
     }
@@ -1014,7 +1014,7 @@ bool InterpreterOps::GetFallbackHandler(IR::IROp_Header *IROp, FallbackInfo *Inf
           *Info = GetFallbackInfo(Op->Truncate ? &OpHandlers<IR::OP_F80CVTINT>::handle8t : &OpHandlers<IR::OP_F80CVTINT>::handle8);
           return true;
         }
-        default: LogMan::Msg::D("Unhandled size: %d", OpSize);
+        default: LogMan::Msg::DFmt("Unhandled size: {}", OpSize);
       }
       break;
     }
@@ -1039,7 +1039,7 @@ bool InterpreterOps::GetFallbackHandler(IR::IROp_Header *IROp, FallbackInfo *Inf
           *Info = GetFallbackInfo(&OpHandlers<IR::OP_F80CVTTOINT>::handle4);
           return true;
         }
-        default: LogMan::Msg::D("Unhandled size: %d", OpSize);
+        default: LogMan::Msg::DFmt("Unhandled size: {}", OpSize);
       }
       break;
     }
@@ -1117,7 +1117,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
     using namespace FEXCore::IR;
     auto [BlockNode, BlockHeader] = BlockIterator();
     auto BlockIROp = BlockHeader->CW<IROp_CodeBlock>();
-    LOGMAN_THROW_A(BlockIROp->Header.Op == IR::OP_CODEBLOCK, "IR type failed to be a code block");
+    LOGMAN_THROW_A_FMT(BlockIROp->Header.Op == IR::OP_CODEBLOCK, "IR type failed to be a code block");
 
     // We grab these nodes this way so we can iterate easily
     auto CodeBegin = CurrentIR->at(BlockIROp->Begin);
@@ -1167,7 +1167,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               case IR::Fence_Store.Val:
                 std::atomic_thread_fence(std::memory_order_release);
                 break;
-              default: LOGMAN_MSG_A("Unknown Fence: %d", Op->Fence); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Fence: {}", Op->Fence); break;
             }
             break;
           }
@@ -1219,7 +1219,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               case 4: // HLT
                 StopThread(Thread);
               break;
-            default: LOGMAN_MSG_A("Unknown Break Reason: %d", Op->Reason); break;
+            default: LOGMAN_MSG_A_FMT("Unknown Break Reason: {}", Op->Reason); break;
             }
             break;
           }
@@ -1266,17 +1266,17 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
 
             if (OpSize <= 8) {
               uint64_t Src = *GetSrc<uint64_t*>(SSAData, Op->Header.Args[0]);
-              LogMan::Msg::I(">>>> Value in Arg: 0x%lx, %ld", Src, Src);
+              LogMan::Msg::IFmt(">>>> Value in Arg: 0x{:x}, {}", Src, Src);
             }
             else if (OpSize == 16) {
               __uint128_t Src = *GetSrc<__uint128_t*>(SSAData, Op->Header.Args[0]);
               uint64_t Src0 = Src;
               uint64_t Src1 = Src >> 64;
-              LogMan::Msg::I(">>>> Value[0] in Arg: 0x%lx, %ld", Src0, Src0);
-              LogMan::Msg::I("     Value[1] in Arg: 0x%lx, %ld", Src1, Src1);
+              LogMan::Msg::IFmt(">>>> Value[0] in Arg: 0x{:x}, {}", Src0, Src0);
+              LogMan::Msg::IFmt("     Value[1] in Arg: 0x{:x}, {}", Src1, Src1);
             }
             else
-              LOGMAN_MSG_A("Unknown value size: %d", OpSize);
+              LOGMAN_MSG_A_FMT("Unknown value size: {}", OpSize);
             break;
           }
           case IR::OP_CYCLECOUNTER: {
@@ -1308,7 +1308,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             auto Op = IROp->C<IR::IROp_VExtractToGPR>();
             uint32_t SourceSize = GetOpSize(Op->Header.Args[0]);
 
-            LOGMAN_THROW_A(OpSize <= 16, "OpSize is too large for VExtractToGPR: %d", OpSize);
+            LOGMAN_THROW_A_FMT(OpSize <= 16, "OpSize is too large for VExtractToGPR: {}", OpSize);
 
             if (SourceSize == 16) {
               __uint128_t SourceMask = (1ULL << (Op->Header.ElementSize * 8)) - 1;
@@ -1337,7 +1337,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
           case IR::OP_VEXTRACTELEMENT: {
             auto Op = IROp->C<IR::IROp_VExtractElement>();
             uint32_t SourceSize = GetOpSize(Op->Header.Args[0]);
-            LOGMAN_THROW_A(OpSize <= 16, "OpSize is too large for VExtractToGPR: %d", OpSize);
+            LOGMAN_THROW_A_FMT(OpSize <= 16, "OpSize is too large for VExtractElement: {}", OpSize);
             if (SourceSize == 16) {
               __uint128_t SourceMask = (1ULL << (Op->Header.ElementSize * 8)) - 1;
               uint64_t Shift = Op->Header.ElementSize * Op->Index * 8;
@@ -1366,7 +1366,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             auto Op = IROp->C<IR::IROp_VDupElement>();
             uint8_t Elements = OpSize / Op->Header.ElementSize;
 
-            LOGMAN_THROW_A(OpSize <= 16, "OpSize is too large for VDupElement: %d", OpSize);
+            LOGMAN_THROW_A_FMT(OpSize <= 16, "OpSize is too large for VDupElement: {}", OpSize);
             if (OpSize == 16) {
               __uint128_t SourceMask = (1ULL << (Op->Header.ElementSize * 8)) - 1;
               uint64_t Shift = Op->Header.ElementSize * Op->Index * 8;
@@ -1432,7 +1432,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 memcpy(GDP, Data, OpSize);
                 break;
               }
-              default:  LOGMAN_MSG_A("Unhandled LoadContext size: %d", OpSize);
+              default:  LOGMAN_MSG_A_FMT("Unhandled LoadContext size: {}", OpSize);
             }
             #undef LOAD_CTX
             break;
@@ -1462,7 +1462,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 memcpy(GDP, Data, Op->Size);
                 break;
               }
-              default:  LOGMAN_MSG_A("Unhandled LoadContextIndexed size: %d", Op->Size);
+              default:  LOGMAN_MSG_A_FMT("Unhandled LoadContextIndexed size: {}", Op->Size);
             }
             #undef LOAD_CTX
             break;
@@ -1536,7 +1536,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 memcpy(GDP, Result ? &Src1 : &Expected, 16);
                 break;
               }
-              default: LOGMAN_MSG_A("Unknown CAS size: %d", Size); break;
+              default: LOGMAN_MSG_A_FMT("Unknown CAS size: {}", Size); break;
             }
             break;
           }
@@ -1552,7 +1552,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 GD = Result;
                 break;
               }
-              default: LOGMAN_MSG_A("Unhandled Truncation size: %d", Op->Size); break;
+              default: LOGMAN_MSG_A_FMT("Unhandled Truncation size: {}", Op->Size); break;
             }
             break;
           }
@@ -1637,7 +1637,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               STORE_DATA(2, uint16_t)
               STORE_DATA(4, uint32_t)
               STORE_DATA(8, uint64_t)
-              default: LOGMAN_MSG_A("Unhandled StoreMem size"); break;
+              default: LOGMAN_MSG_A_FMT("Unhandled StoreMem size"); break;
             }
             #undef STORE_DATA
             break;
@@ -1670,7 +1670,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (OpSize) {
               DO_OP(4, uint32_t, Func)
               DO_OP(8, uint64_t, Func)
-              default: LOGMAN_MSG_A("Unknown Size: %d", OpSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown size: {}", OpSize); break;
             }
             break;
           }
@@ -1683,7 +1683,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (OpSize) {
               DO_OP(4, uint32_t, Func)
               DO_OP(8, uint64_t, Func)
-              default: LOGMAN_MSG_A("Unknown Size: %d", OpSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown size: {}", OpSize); break;
             }
             break;
           }
@@ -1697,7 +1697,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               case 8:
                 GD = -static_cast<int64_t>(Src);
                 break;
-              default: LOGMAN_MSG_A("Unknown NEG Size: %d\n", OpSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown NEG Size: {}\n", OpSize); break;
             };
             break;
           }
@@ -1713,7 +1713,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_OP(4, uint32_t, Func)
               DO_OP(8, uint64_t, Func)
               DO_OP(16, __uint128_t, Func)
-              default: LOGMAN_MSG_A("Unknown Size: %d", OpSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown size: {}", OpSize); break;
             }
             break;
           }
@@ -1728,7 +1728,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_OP(2, uint16_t, Func)
               DO_OP(4, uint32_t, Func)
               DO_OP(8, uint64_t, Func)
-              default: LOGMAN_MSG_A("Unknown Size: %d", OpSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown size: {}", OpSize); break;
             }
             break;
           }
@@ -1743,7 +1743,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_OP(2, uint16_t, Func)
               DO_OP(4, uint32_t, Func)
               DO_OP(8, uint64_t, Func)
-              default: LOGMAN_MSG_A("Unknown Size: %d", OpSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown size: {}", OpSize); break;
             }
             break;
           }
@@ -1759,7 +1759,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               case 8:
                 GD = static_cast<uint64_t>(Src1) << (Src2 & Mask);
                 break;
-              default: LOGMAN_MSG_A("Unknown LSHL Size: %d\n", OpSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown LSHL Size: {}\n", OpSize); break;
             };
             break;
           }
@@ -1775,7 +1775,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               case 8:
                 GD = static_cast<uint64_t>(Src1) >> (Src2 & Mask);
                 break;
-              default: LOGMAN_MSG_A("Unknown LSHR Size: %d\n", OpSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown LSHR Size: {}\n", OpSize); break;
             };
             break;
           }
@@ -1791,7 +1791,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               case 8:
                 GD = (uint64_t)(static_cast<int64_t>(Src1) >> (Src2 & Mask));
                 break;
-              default: LOGMAN_MSG_A("Unknown ASHR Size: %d\n", OpSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown ASHR Size: {}\n", OpSize); break;
             };
             break;
           }
@@ -1813,7 +1813,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 GD = Ror(static_cast<uint64_t>(Src1), static_cast<uint64_t>(Src2));
                 break;
               }
-              default: LOGMAN_MSG_A("Unknown ROR Size: %d\n", OpSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown ROR Size: {}\n", OpSize); break;
             }
             break;
           }
@@ -1838,7 +1838,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 GD = Extr(static_cast<uint64_t>(Src1), static_cast<uint64_t>(Src2), Op->LSB);
                 break;
               }
-              default: LOGMAN_MSG_A("Unknown EXTR Size: %d\n", OpSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown EXTR Size: {}\n", OpSize); break;
             }
             break;
           }
@@ -1867,7 +1867,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 memcpy(GDP, &Tmp, 16);
                 break;
               }
-              default: LOGMAN_MSG_A("Unknown Mul Size: %d\n", OpSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Mul Size: {}\n", OpSize); break;
             }
             break;
           }
@@ -1887,7 +1887,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 GD = Tmp >> 64;
               }
               break;
-              default: LOGMAN_MSG_A("Unknown MulH Size: %d\n", OpSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown MulH Size: {}\n", OpSize); break;
             }
             break;
           }
@@ -1908,7 +1908,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 memcpy(GDP, &Tmp, 16);
                 break;
               }
-              default: LOGMAN_MSG_A("Unknown UMul Size: %d\n", OpSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown UMul Size: {}\n", OpSize); break;
             }
             break;
           }
@@ -1932,7 +1932,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 GD = Tmp >> 64;
                 break;
               }
-              default: LOGMAN_MSG_A("Unknown UMulH Size: %d\n", OpSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown UMulH Size: {}\n", OpSize); break;
             }
             break;
           }
@@ -1959,7 +1959,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 memcpy(GDP, &Tmp, 16);
                 break;
               }
-              default: LOGMAN_MSG_A("Unknown Mul Size: %d\n", OpSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Mul Size: {}\n", OpSize); break;
             }
             break;
           }
@@ -1986,7 +1986,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 memcpy(GDP, &Tmp, 16);
                 break;
               }
-              default: LOGMAN_MSG_A("Unknown Mul Size: %d\n", OpSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Mul Size: {}\n", OpSize); break;
             }
             break;
           }
@@ -2013,7 +2013,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 memcpy(GDP, &Tmp, 16);
                 break;
               }
-              default: LOGMAN_MSG_A("Unknown Mul Size: %d\n", OpSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Mul Size: {}\n", OpSize); break;
             }
             break;
           }
@@ -2040,7 +2040,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 memcpy(GDP, &Tmp, 16);
                 break;
               }
-              default: LOGMAN_MSG_A("Unknown Mul Size: %d\n", OpSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Mul Size: {}\n", OpSize); break;
             }
             break;
           }
@@ -2064,7 +2064,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               case 2: GD = (OpSize * 8 - std::countl_zero(*GetSrc<uint16_t*>(SSAData, Op->Header.Args[0]))) - 1; break;
               case 4: GD = (OpSize * 8 - std::countl_zero(*GetSrc<uint32_t*>(SSAData, Op->Header.Args[0]))) - 1; break;
               case 8: GD = (OpSize * 8 - std::countl_zero(*GetSrc<uint64_t*>(SSAData, Op->Header.Args[0]))) - 1; break;
-              default: LOGMAN_MSG_A("Unknown REV size: %d", OpSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown REV size: {}", OpSize); break;
             }
             break;
           }
@@ -2074,7 +2074,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               case 2: GD = BSwap16(*GetSrc<uint16_t*>(SSAData, Op->Header.Args[0])); break;
               case 4: GD = BSwap32(*GetSrc<uint32_t*>(SSAData, Op->Header.Args[0])); break;
               case 8: GD = BSwap64(*GetSrc<uint64_t*>(SSAData, Op->Header.Args[0])); break;
-              default: LOGMAN_MSG_A("Unknown REV size: %d", OpSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown REV size: {}", OpSize); break;
             }
             break;
           }
@@ -2101,7 +2101,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 GD = std::countr_zero(Src);
                 break;
               }
-              default: LOGMAN_MSG_A("Unknown size: %d", OpSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown size: {}", OpSize); break;
             }
             break;
           }
@@ -2128,7 +2128,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 GD = std::countl_zero(Src);
                 break;
               }
-              default: LOGMAN_MSG_A("Unknown size: %d", OpSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown size: {}", OpSize); break;
             }
             break;
           }
@@ -2146,7 +2146,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
           }
           case IR::OP_SBFE: {
             auto Op = IROp->C<IR::IROp_Sbfe>();
-            LOGMAN_THROW_A(OpSize < 16, "OpSize is too large for BFE: %d", OpSize);
+            LOGMAN_THROW_A_FMT(OpSize < 16, "OpSize is too large for SBFE: {}", OpSize);
             int64_t Src = *GetSrc<int64_t*>(SSAData, Op->Header.Args[0]);
             uint64_t ShiftLeftAmount = (64 - (Op->Width + Op->lsb));
             uint64_t ShiftRightAmount = ShiftLeftAmount + Op->lsb;
@@ -2157,7 +2157,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
           }
           case IR::OP_BFE: {
             auto Op = IROp->C<IR::IROp_Bfe>();
-            LOGMAN_THROW_A(OpSize <= 8, "OpSize is too large for BFE: %d", OpSize);
+            LOGMAN_THROW_A_FMT(OpSize <= 8, "OpSize is too large for BFE: {}", OpSize);
             uint64_t SourceMask = (1ULL << Op->Width) - 1;
             if (Op->Width == 64)
               SourceMask = ~0ULL;
@@ -2240,7 +2240,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 GD = Result ? Src1 : Expected;
                 break;
               }
-              default: LOGMAN_MSG_A("Unknown CAS size: %d", Size); break;
+              default: LOGMAN_MSG_A_FMT("Unknown CAS size: {}", Size); break;
             }
             break;
           }
@@ -2271,7 +2271,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 *Data += Src;
                 break;
               }
-              default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
+              default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
             }
             break;
           }
@@ -2302,7 +2302,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 *Data -= Src;
                 break;
               }
-              default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
+              default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
             }
             break;
           }
@@ -2333,7 +2333,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 *Data &= Src;
                 break;
               }
-              default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
+              default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
             }
             break;
           }
@@ -2364,7 +2364,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 *Data |= Src;
                 break;
               }
-              default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
+              default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
             }
             break;
           }
@@ -2395,7 +2395,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 *Data ^= Src;
                 break;
               }
-              default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
+              default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
             }
             break;
           }
@@ -2430,7 +2430,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 GD = Previous;
                 break;
               }
-              default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
+              default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
             }
             break;
           }
@@ -2465,7 +2465,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 GD = Previous;
                 break;
               }
-              default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
+              default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
             }
             break;
           }
@@ -2500,7 +2500,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 GD = Previous;
                 break;
               }
-              default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
+              default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
             }
             break;
           }
@@ -2535,7 +2535,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 GD = Previous;
                 break;
               }
-              default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
+              default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
             }
             break;
           }
@@ -2570,7 +2570,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 GD = Previous;
                 break;
               }
-              default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
+              default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
             }
             break;
           }
@@ -2605,7 +2605,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 GD = Previous;
                 break;
               }
-              default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
+              default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
             }
             break;
           }
@@ -2632,14 +2632,14 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 GD = AtomicFetchNeg(*GetSrc<Type**>(SSAData, Op->Header.Args[0]));
                 break;
               }
-              default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
+              default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
             }
             break;
           }
           // Vector ops
           case IR::OP_CREATEVECTOR2: {
             auto Op = IROp->C<IR::IROp_CreateVector2>();
-            LOGMAN_THROW_A(OpSize <= 16, "Can't handle a vector of size: %d", OpSize);
+            LOGMAN_THROW_A_FMT(OpSize <= 16, "Can't handle a vector of size: {}", OpSize);
             void *Src1 = GetSrc<void*>(SSAData, Op->Header.Args[0]);
             void *Src2 = GetSrc<void*>(SSAData, Op->Header.Args[1]);
             uint8_t Tmp[16];
@@ -2658,7 +2658,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               CREATE_VECTOR(2, uint16_t)
               CREATE_VECTOR(4, uint32_t)
               CREATE_VECTOR(8, uint64_t)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", ElementSize); break;
             }
             #undef CREATE_VECTOR
             memcpy(GDP, Tmp, OpSize);
@@ -2668,7 +2668,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
           case IR::OP_SPLATVECTOR4:
           case IR::OP_SPLATVECTOR2: {
             auto Op = IROp->C<IR::IROp_SplatVector2>();
-            LOGMAN_THROW_A(OpSize <= 16, "Can't handle a vector of size: %d", OpSize);
+            LOGMAN_THROW_A_FMT(OpSize <= 16, "Can't handle a vector of size: {}", OpSize);
             void *Src = GetSrc<void*>(SSAData, Op->Header.Args[0]);
             uint8_t Tmp[16];
             uint8_t Elements = 0;
@@ -2676,7 +2676,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (Op->Header.Op) {
               case IR::OP_SPLATVECTOR4: Elements = 4; break;
               case IR::OP_SPLATVECTOR2: Elements = 2; break;
-              default: LOGMAN_MSG_A("Uknown Splat size"); break;
+              default: LOGMAN_MSG_A_FMT("Uknown Splat size"); break;
             }
 
             #define CREATE_VECTOR(elementsize, type) \
@@ -2693,7 +2693,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               CREATE_VECTOR(2, uint16_t)
               CREATE_VECTOR(4, uint32_t)
               CREATE_VECTOR(8, uint64_t)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.Size); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.Size); break;
             }
             #undef CREATE_VECTOR
             memcpy(GDP, Tmp, OpSize);
@@ -2852,7 +2852,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_0SRC_OP(2, int16_t, Func)
               DO_VECTOR_0SRC_OP(4, int32_t, Func)
               DO_VECTOR_0SRC_OP(8, int64_t, Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -2870,7 +2870,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_1SRC_OP(2, int16_t, Func)
               DO_VECTOR_1SRC_OP(4, int32_t, Func)
               DO_VECTOR_1SRC_OP(8, int64_t, Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -2886,7 +2886,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (Op->Header.ElementSize) {
               DO_VECTOR_1SRC_OP(4, float, Func)
               DO_VECTOR_1SRC_OP(8, double, Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -2905,7 +2905,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_1SRC_OP(2, uint16_t, Func)
               DO_VECTOR_1SRC_OP(4, uint32_t, Func)
               DO_VECTOR_1SRC_OP(8, uint64_t, Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -2924,7 +2924,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_1SRC_OP(2, int16_t, Func)
               DO_VECTOR_1SRC_OP(4, int32_t, Func)
               DO_VECTOR_1SRC_OP(8, int64_t, Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -2943,7 +2943,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_1SRC_OP(2, uint16_t, Func)
               DO_VECTOR_1SRC_OP(4, uint32_t, Func)
               DO_VECTOR_1SRC_OP(8, uint64_t, Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -2963,7 +2963,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_OP(2, uint16_t, Func)
               DO_VECTOR_OP(4, uint32_t, Func)
               DO_VECTOR_OP(8, uint64_t, Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -2982,7 +2982,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_OP(2, uint16_t, Func)
               DO_VECTOR_OP(4, uint32_t, Func)
               DO_VECTOR_OP(8, uint64_t, Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3004,7 +3004,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_OP(2, uint16_t, Func)
               DO_VECTOR_OP(4, uint32_t, Func)
               DO_VECTOR_OP(8, uint64_t, Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3026,7 +3026,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_OP(2, uint16_t, Func)
               DO_VECTOR_OP(4, uint32_t, Func)
               DO_VECTOR_OP(8, uint64_t, Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3058,7 +3058,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_OP(2, int16_t, Func)
               DO_VECTOR_OP(4, int32_t, Func)
               DO_VECTOR_OP(8, int64_t, Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3086,7 +3086,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_OP(2, int16_t, Func)
               DO_VECTOR_OP(4, int32_t, Func)
               DO_VECTOR_OP(8, int64_t, Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3104,7 +3104,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (Op->Header.ElementSize) {
               DO_VECTOR_OP(4, float, Func)
               DO_VECTOR_OP(8, double, Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3121,7 +3121,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (Op->Header.ElementSize) {
               DO_VECTOR_PAIR_OP(4, float, Func)
               DO_VECTOR_PAIR_OP(8, double, Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3138,7 +3138,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (Op->Header.ElementSize) {
               DO_VECTOR_OP(4, float, Func)
               DO_VECTOR_OP(8, double, Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3157,7 +3157,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_PAIR_OP(2, uint16_t, Func)
               DO_VECTOR_PAIR_OP(4, uint32_t, Func)
               DO_VECTOR_PAIR_OP(8, uint64_t, Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3175,7 +3175,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_REDUCE_1SRC_OP(2, int16_t, Func, 0)
               DO_VECTOR_REDUCE_1SRC_OP(4, int32_t, Func, 0)
               DO_VECTOR_REDUCE_1SRC_OP(8, int64_t, Func, 0)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, Op->Header.ElementSize);
             break;
@@ -3193,7 +3193,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_REDUCE_1SRC_OP(2, uint16_t, Func, ~0)
               DO_VECTOR_REDUCE_1SRC_OP(4, uint32_t, Func, ~0U)
               DO_VECTOR_REDUCE_1SRC_OP(8, uint64_t, Func, ~0ULL)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, Op->Header.ElementSize);
             break;
@@ -3210,7 +3210,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (Op->Header.ElementSize) {
               DO_VECTOR_OP(1, uint8_t,  Func)
               DO_VECTOR_OP(2, uint16_t, Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3228,7 +3228,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_1SRC_OP(2, int16_t, Func)
               DO_VECTOR_1SRC_OP(4, int32_t, Func)
               DO_VECTOR_1SRC_OP(8, int64_t, Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3246,7 +3246,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_1SRC_OP(2, uint16_t, Func)
               DO_VECTOR_1SRC_OP(4, uint32_t, Func)
               DO_VECTOR_1SRC_OP(8, uint64_t, Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3263,7 +3263,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (Op->Header.ElementSize) {
               DO_VECTOR_OP(4, float, Func)
               DO_VECTOR_OP(8, double, Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3280,7 +3280,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (Op->Header.ElementSize) {
               DO_VECTOR_OP(4, float, Func)
               DO_VECTOR_OP(8, double, Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3297,7 +3297,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (Op->Header.ElementSize) {
               DO_VECTOR_OP(4, float, Func)
               DO_VECTOR_OP(8, double, Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3314,7 +3314,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (Op->Header.ElementSize) {
               DO_VECTOR_OP(4, float, Func)
               DO_VECTOR_OP(8, double, Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3330,7 +3330,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (Op->Header.ElementSize) {
               DO_VECTOR_1SRC_OP(4, float, Func)
               DO_VECTOR_1SRC_OP(8, double, Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3346,7 +3346,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (Op->Header.ElementSize) {
               DO_VECTOR_1SRC_OP(4, float, Func)
               DO_VECTOR_1SRC_OP(8, double, Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3362,7 +3362,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (Op->Header.ElementSize) {
               DO_VECTOR_1SRC_OP(4, float, Func)
               DO_VECTOR_1SRC_OP(8, double, Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3430,7 +3430,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_1SRC_2TYPE_OP(1, uint8_t, uint16_t, Func, 0, 0)
               DO_VECTOR_1SRC_2TYPE_OP(2, uint16_t, uint32_t, Func, 0, 0)
               DO_VECTOR_1SRC_2TYPE_OP(4, uint32_t, uint64_t, Func, 0, 0)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3449,7 +3449,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_1SRC_2TYPE_OP_TOP(1, uint8_t, uint16_t, Func, 0, 0)
               DO_VECTOR_1SRC_2TYPE_OP_TOP(2, uint16_t, uint32_t, Func, 0, 0)
               DO_VECTOR_1SRC_2TYPE_OP_TOP(4, uint32_t, uint64_t, Func, 0, 0)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3465,7 +3465,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (Op->Header.ElementSize) {
               DO_VECTOR_1SRC_2TYPE_OP(1, int8_t, int16_t, Func, std::numeric_limits<int8_t>::min(), std::numeric_limits<int8_t>::max())
               DO_VECTOR_1SRC_2TYPE_OP(2, int16_t, int32_t, Func, std::numeric_limits<int16_t>::min(), std::numeric_limits<int16_t>::max())
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3482,7 +3482,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (Op->Header.ElementSize) {
               DO_VECTOR_1SRC_2TYPE_OP_TOP(1, int8_t, int16_t, Func, std::numeric_limits<int8_t>::min(), std::numeric_limits<int8_t>::max())
               DO_VECTOR_1SRC_2TYPE_OP_TOP(2, int16_t, int32_t, Func, std::numeric_limits<int16_t>::min(), std::numeric_limits<int16_t>::max())
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3498,7 +3498,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (Op->Header.ElementSize) {
               DO_VECTOR_1SRC_2TYPE_OP(1, uint8_t, int16_t, Func, 0, (1 << 8) - 1)
               DO_VECTOR_1SRC_2TYPE_OP(2, uint16_t, int32_t, Func, 0, (1 << 16) - 1)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3515,7 +3515,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (Op->Header.ElementSize) {
               DO_VECTOR_1SRC_2TYPE_OP_TOP(1, uint8_t, int16_t, Func, 0, (1 << 8) - 1)
               DO_VECTOR_1SRC_2TYPE_OP_TOP(2, uint16_t, int32_t, Func, 0, (1 << 16) - 1)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3531,7 +3531,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (Op->Header.ElementSize) {
               DO_VECTOR_1SRC_2TYPE_OP(4, float, int32_t, Func, 0, 0)
               DO_VECTOR_1SRC_2TYPE_OP(8, double, int64_t, Func, 0, 0)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3547,7 +3547,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (Op->Header.ElementSize) {
               DO_VECTOR_1SRC_2TYPE_OP(4, int32_t, float, Func, 0, 0)
               DO_VECTOR_1SRC_2TYPE_OP(8, int64_t, double, Func, 0, 0)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3563,7 +3563,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             switch (Op->Header.ElementSize) {
               DO_VECTOR_1SRC_2TYPE_OP(4, int32_t, float, Func, 0, 0)
               DO_VECTOR_1SRC_2TYPE_OP(8, int64_t, double, Func, 0, 0)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3582,7 +3582,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_OP(2, uint16_t, Func)
               DO_VECTOR_OP(4, uint32_t, Func)
               DO_VECTOR_OP(8, uint64_t, Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3601,7 +3601,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_OP(2, int16_t, Func)
               DO_VECTOR_OP(4, int32_t, Func)
               DO_VECTOR_OP(8, int64_t, Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3620,7 +3620,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_2SRC_2TYPE_OP(2, uint16_t, uint8_t, Func)
               DO_VECTOR_2SRC_2TYPE_OP(4, uint32_t, uint16_t, Func)
               DO_VECTOR_2SRC_2TYPE_OP(8, uint64_t, uint32_t, Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3639,7 +3639,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_2SRC_2TYPE_OP(2, int16_t, int8_t, Func)
               DO_VECTOR_2SRC_2TYPE_OP(4, int32_t, int16_t, Func)
               DO_VECTOR_2SRC_2TYPE_OP(8, int64_t, int32_t, Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3658,7 +3658,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_2SRC_2TYPE_OP_TOP_SRC(2, uint16_t, uint8_t, Func)
               DO_VECTOR_2SRC_2TYPE_OP_TOP_SRC(4, uint32_t, uint16_t, Func)
               DO_VECTOR_2SRC_2TYPE_OP_TOP_SRC(8, uint64_t, uint32_t, Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3677,7 +3677,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_2SRC_2TYPE_OP_TOP_SRC(2, int16_t, int8_t, Func)
               DO_VECTOR_2SRC_2TYPE_OP_TOP_SRC(4, int32_t, int16_t, Func)
               DO_VECTOR_2SRC_2TYPE_OP_TOP_SRC(8, int64_t, int32_t, Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, Op->Header.Size);
             break;
@@ -3699,7 +3699,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_2SRC_2TYPE_OP(2, uint16_t, uint8_t, Func8)
               DO_VECTOR_2SRC_2TYPE_OP(4, uint32_t, uint16_t, Func16)
               DO_VECTOR_2SRC_2TYPE_OP(8, uint64_t, uint32_t, Func32)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3716,7 +3716,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_1SRC_2TYPE_OP(2, int16_t, int8_t, Func,  0, 0)
               DO_VECTOR_1SRC_2TYPE_OP(4, int32_t, int16_t, Func, 0, 0)
               DO_VECTOR_1SRC_2TYPE_OP(8, int64_t, int32_t, Func, 0, 0)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3733,7 +3733,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_1SRC_2TYPE_OP_TOP_SRC(2, int16_t, int8_t, Func,  0, 0)
               DO_VECTOR_1SRC_2TYPE_OP_TOP_SRC(4, int32_t, int16_t, Func, 0, 0)
               DO_VECTOR_1SRC_2TYPE_OP_TOP_SRC(8, int64_t, int32_t, Func, 0, 0)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3750,7 +3750,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_1SRC_2TYPE_OP(2, uint16_t, uint8_t, Func,  0, 0)
               DO_VECTOR_1SRC_2TYPE_OP(4, uint32_t, uint16_t, Func, 0, 0)
               DO_VECTOR_1SRC_2TYPE_OP(8, uint64_t, uint32_t, Func, 0, 0)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3768,7 +3768,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_1SRC_2TYPE_OP_TOP_SRC(2, uint16_t, uint8_t, Func,  0, 0)
               DO_VECTOR_1SRC_2TYPE_OP_TOP_SRC(4, uint32_t, uint16_t, Func, 0, 0)
               DO_VECTOR_1SRC_2TYPE_OP_TOP_SRC(8, uint64_t, uint32_t, Func, 0, 0)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3787,7 +3787,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_OP(2, uint16_t, Func)
               DO_VECTOR_OP(4, uint32_t, Func)
               DO_VECTOR_OP(8, uint64_t, Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3806,7 +3806,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_OP(2, int16_t, Func)
               DO_VECTOR_OP(4, int32_t, Func)
               DO_VECTOR_OP(8, int64_t, Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3825,7 +3825,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_OP(2, uint16_t, Func)
               DO_VECTOR_OP(4, uint32_t, Func)
               DO_VECTOR_OP(8, uint64_t, Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3844,7 +3844,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_OP(2, int16_t, Func)
               DO_VECTOR_OP(4, int32_t, Func)
               DO_VECTOR_OP(8, int64_t, Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3863,7 +3863,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_OP(2, uint16_t, Func)
               DO_VECTOR_OP(4, uint32_t, Func)
               DO_VECTOR_OP(8, uint64_t, Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3882,7 +3882,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_OP(2, int16_t, Func)
               DO_VECTOR_OP(4, int32_t, Func)
               DO_VECTOR_OP(8, int64_t, Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3903,7 +3903,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_SCALAR_OP(4, uint32_t, Func)
               DO_VECTOR_SCALAR_OP(8, uint64_t, Func)
               DO_VECTOR_SCALAR_OP(16, __uint128_t, Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3923,7 +3923,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_SCALAR_OP(4, uint32_t, Func)
               DO_VECTOR_SCALAR_OP(8, uint64_t, Func)
               DO_VECTOR_SCALAR_OP(16, __uint128_t, Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3943,7 +3943,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_SCALAR_OP(4, int32_t, Func)
               DO_VECTOR_SCALAR_OP(8, int64_t, Func)
               DO_VECTOR_SCALAR_OP(16, __int128_t, Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -3962,7 +3962,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_OP(2, uint16_t, Func)
               DO_VECTOR_OP(4, uint32_t, Func)
               DO_VECTOR_OP(8, uint64_t, Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -4018,7 +4018,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 }
                 break;
               }
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
 
             memcpy(GDP, Tmp, OpSize);
@@ -4075,7 +4075,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 }
                 break;
               }
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
 
             memcpy(GDP, Tmp, OpSize);
@@ -4115,7 +4115,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 Dst_d[Op->DestIdx] = Src2_d[Op->SrcIdx];
                 break;
               }
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             };
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -4153,7 +4153,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 Dst_d[Op->DestIdx] = Src2_d;
                 break;
               }
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             };
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -4186,7 +4186,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_OP(2, uint16_t,  Func)
               DO_VECTOR_OP(4, uint32_t,  Func)
               DO_VECTOR_OP(8, uint64_t,  Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
 
             memcpy(GDP, Tmp, OpSize);
@@ -4206,7 +4206,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_OP(2, uint16_t,  Func)
               DO_VECTOR_OP(4, uint32_t,  Func)
               DO_VECTOR_OP(8, uint64_t,  Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
 
             memcpy(GDP, Tmp, OpSize);
@@ -4226,7 +4226,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_OP(2, int16_t,  Func)
               DO_VECTOR_OP(4, int32_t,  Func)
               DO_VECTOR_OP(8, int64_t,  Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
 
             memcpy(GDP, Tmp, OpSize);
@@ -4246,7 +4246,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_OP(2, int16_t,  Func)
               DO_VECTOR_OP(4, int32_t,  Func)
               DO_VECTOR_OP(8, int64_t,  Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
 
             memcpy(GDP, Tmp, OpSize);
@@ -4266,7 +4266,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               DO_VECTOR_OP(2, int16_t,  Func)
               DO_VECTOR_OP(4, int32_t,  Func)
               DO_VECTOR_OP(8, int64_t,  Func)
-              default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
             }
 
             memcpy(GDP, Tmp, OpSize);
@@ -4310,7 +4310,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 memcpy(GDP, &Res, OpSize);
                 break;
               }
-              default: LOGMAN_MSG_A("Unknown LUDIV Size: %d", OpSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown LUDIV Size: {}", OpSize); break;
             }
             break;
           }
@@ -4352,7 +4352,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 memcpy(GDP, &Res, OpSize);
                 break;
               }
-              default: LOGMAN_MSG_A("Unknown LDIV Size: %d", OpSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown LDIV Size: {}", OpSize); break;
             }
             break;
           }
@@ -4394,7 +4394,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 memcpy(GDP, &Res, OpSize);
                 break;
               }
-              default: LOGMAN_MSG_A("Unknown LUREM Size: %d", OpSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown LUREM Size: {}", OpSize); break;
             }
             break;
           }
@@ -4435,7 +4435,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 memcpy(GDP, &Res, OpSize);
                 break;
               }
-              default: LOGMAN_MSG_A("Unknown LREM Size: %d", OpSize); break;
+              default: LOGMAN_MSG_A_FMT("Unknown LREM Size: {}", OpSize); break;
             }
             break;
           }
@@ -4572,7 +4572,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 memcpy(GDP, &Dst, 4);
                 break;
               }
-              default: LOGMAN_MSG_A("Unknown FCVT sizes: 0x%x", Conv);
+              default: LOGMAN_MSG_A_FMT("Unknown FCVT sizes: 0x{:x}", Conv);
             }
             break;
           }
@@ -4601,7 +4601,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
 
                 break;
               }
-              default: LOGMAN_MSG_A("Unknown Conversion Type : 0%04x", Conv); break;
+              default: LOGMAN_MSG_A_FMT("Unknown Conversion Type : 0x{:04x}", Conv); break;
             }
             memcpy(GDP, Tmp, OpSize);
             break;
@@ -4754,14 +4754,14 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               switch (Op->Header.ElementSize) {
               DO_SCALAR_COMPARE_OP(4, float, uint32_t, Func);
               DO_SCALAR_COMPARE_OP(8, double, uint64_t, Func);
-              default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
+              default: LOGMAN_MSG_A_FMT("Unsupported elementSize: {}", Op->Header.ElementSize);
               }
             }
             else {
               switch (Op->Header.ElementSize) {
               DO_VECTOR_COMPARE_OP(4, float, uint32_t, Func);
               DO_VECTOR_COMPARE_OP(8, double, uint64_t, Func);
-              default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
+              default: LOGMAN_MSG_A_FMT("Unsupported elementSize: {}", Op->Header.ElementSize);
               }
             }
 
@@ -4782,14 +4782,14 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               switch (Op->Header.ElementSize) {
               DO_SCALAR_COMPARE_OP(4, float, uint32_t, Func);
               DO_SCALAR_COMPARE_OP(8, double, uint64_t, Func);
-              default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
+              default: LOGMAN_MSG_A_FMT("Unsupported elementSize: {}", Op->Header.ElementSize);
               }
             }
             else {
               switch (Op->Header.ElementSize) {
               DO_VECTOR_COMPARE_OP(4, float, uint32_t, Func);
               DO_VECTOR_COMPARE_OP(8, double, uint64_t, Func);
-              default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
+              default: LOGMAN_MSG_A_FMT("Unsupported elementSize: {}", Op->Header.ElementSize);
               }
             }
 
@@ -4810,14 +4810,14 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               switch (Op->Header.ElementSize) {
               DO_SCALAR_COMPARE_OP(4, float, uint32_t, Func);
               DO_SCALAR_COMPARE_OP(8, double, uint64_t, Func);
-              default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
+              default: LOGMAN_MSG_A_FMT("Unsupported elementSize: {}", Op->Header.ElementSize);
               }
             }
             else {
               switch (Op->Header.ElementSize) {
               DO_VECTOR_COMPARE_OP(4, float, uint32_t, Func);
               DO_VECTOR_COMPARE_OP(8, double, uint64_t, Func);
-              default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
+              default: LOGMAN_MSG_A_FMT("Unsupported elementSize: {}", Op->Header.ElementSize);
               }
             }
 
@@ -4838,14 +4838,14 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               switch (Op->Header.ElementSize) {
               DO_SCALAR_COMPARE_OP(4, float, uint32_t, Func);
               DO_SCALAR_COMPARE_OP(8, double, uint64_t, Func);
-              default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
+              default: LOGMAN_MSG_A_FMT("Unsupported elementSize: {}", Op->Header.ElementSize);
               }
             }
             else {
               switch (Op->Header.ElementSize) {
               DO_VECTOR_COMPARE_OP(4, float, uint32_t, Func);
               DO_VECTOR_COMPARE_OP(8, double, uint64_t, Func);
-              default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
+              default: LOGMAN_MSG_A_FMT("Unsupported elementSize: {}", Op->Header.ElementSize);
               }
             }
 
@@ -4866,14 +4866,14 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               switch (Op->Header.ElementSize) {
               DO_SCALAR_COMPARE_OP(4, float, uint32_t, Func);
               DO_SCALAR_COMPARE_OP(8, double, uint64_t, Func);
-              default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
+              default: LOGMAN_MSG_A_FMT("Unsupported elementSize: {}", Op->Header.ElementSize);
               }
             }
             else {
               switch (Op->Header.ElementSize) {
               DO_VECTOR_COMPARE_OP(4, float, uint32_t, Func);
               DO_VECTOR_COMPARE_OP(8, double, uint64_t, Func);
-              default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
+              default: LOGMAN_MSG_A_FMT("Unsupported elementSize: {}", Op->Header.ElementSize);
               }
             }
 
@@ -4894,14 +4894,14 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
               switch (Op->Header.ElementSize) {
               DO_SCALAR_COMPARE_OP(4, float, uint32_t, Func);
               DO_SCALAR_COMPARE_OP(8, double, uint64_t, Func);
-              default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
+              default: LOGMAN_MSG_A_FMT("Unsupported elementSize: {}", Op->Header.ElementSize);
               }
             }
             else {
               switch (Op->Header.ElementSize) {
               DO_VECTOR_COMPARE_OP(4, float, uint32_t, Func);
               DO_VECTOR_COMPARE_OP(8, double, uint64_t, Func);
-              default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
+              default: LOGMAN_MSG_A_FMT("Unsupported elementSize: {}", Op->Header.ElementSize);
               }
             }
 
@@ -5145,7 +5145,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 memcpy(GDP, &Tmp, OpSize);
                 break;
               }
-            default: LogMan::Msg::D("Unhandled size: %d", OpSize);
+            default: LogMan::Msg::DFmt("Unhandled size: {}", OpSize);
             }
             break;
           }
@@ -5169,7 +5169,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 memcpy(GDP, &Tmp, sizeof(Tmp));
                 break;
               }
-            default: LogMan::Msg::D("Unhandled size: %d", OpSize);
+            default: LogMan::Msg::DFmt("Unhandled size: {}", OpSize);
             }
             break;
           }
@@ -5189,7 +5189,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 memcpy(GDP, &Tmp, sizeof(X80SoftFloat));
                 break;
               }
-            default: LogMan::Msg::D("Unhandled size: %d", OpSize);
+            default: LogMan::Msg::DFmt("Unhandled size: {}", OpSize);
             }
             break;
           }
@@ -5209,7 +5209,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
                 memcpy(GDP, &Tmp, sizeof(X80SoftFloat));
                 break;
               }
-            default: LogMan::Msg::D("Unhandled size: %d", OpSize);
+            default: LogMan::Msg::DFmt("Unhandled size: {}", OpSize);
             }
             break;
           }
@@ -5445,7 +5445,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
             break;
           }
           default:
-            LOGMAN_MSG_A("Unknown IR Op: %d(%s)", IROp->Op, FEXCore::IR::GetName(IROp->Op).data());
+            LOGMAN_MSG_A_FMT("Unknown IR Op: {}({})", IROp->Op, FEXCore::IR::GetName(IROp->Op));
             break;
         }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -36,7 +36,7 @@ CodeBuffer AllocateNewCodeBuffer(size_t Size) {
                     PROT_READ | PROT_WRITE | PROT_EXEC,
                     MAP_PRIVATE | MAP_ANONYMOUS,
                     -1, 0));
-  LOGMAN_THROW_A(Buffer.Ptr != reinterpret_cast<uint8_t*>(~0ULL), "Couldn't allocate code buffer");
+  LOGMAN_THROW_A_FMT(Buffer.Ptr != reinterpret_cast<uint8_t*>(~0ULL), "Couldn't allocate code buffer");
   return Buffer;
 }
 
@@ -85,8 +85,7 @@ void X86JITCore::Op_Unhandled(FEXCore::IR::IROp_Header *IROp, uint32_t Node) {
   FallbackInfo Info;
   if (!InterpreterOps::GetFallbackHandler(IROp, &Info)) {
 #if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
-    auto Name = FEXCore::IR::GetName(IROp->Op);
-    LOGMAN_MSG_A("Unhandled IR Op: %s", std::string(Name).c_str());
+    LOGMAN_MSG_A_FMT("Unhandled IR Op: {}", FEXCore::IR::GetName(IROp->Op));
 #endif
   } else {
     switch(Info.ABI) {
@@ -285,8 +284,7 @@ void X86JITCore::Op_Unhandled(FEXCore::IR::IROp_Header *IROp, uint32_t Node) {
       case FABI_UNKNOWN:
       default:
 #if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
-      auto Name = FEXCore::IR::GetName(IROp->Op);
-        LOGMAN_MSG_A("Unhandled IR Fallback abi: %s %d", std::string(Name).c_str(), Info.ABI);
+        LOGMAN_MSG_A_FMT("Unhandled IR Fallback ABI: {} {}", FEXCore::IR::GetName(IROp->Op), Info.ABI);
 #endif
         break;
     }
@@ -419,7 +417,7 @@ void X86JITCore::ClearCache() {
 IR::PhysicalRegister X86JITCore::GetPhys(uint32_t Node) const {
   auto PhyReg = RAData->GetNodeRegister(Node);
 
-  LOGMAN_THROW_A(PhyReg.Raw != 255, "Couldn't Allocate register for node: ssa%d. Class: %d", Node, PhyReg.Class);
+  LOGMAN_THROW_A_FMT(PhyReg.Raw != 255, "Couldn't Allocate register for node: ssa{}. Class: {}", Node, PhyReg.Class);
 
   return PhyReg;
 }
@@ -568,7 +566,7 @@ std::tuple<X86JITCore::SetCC, X86JITCore::CMovCC, X86JITCore::JCC> X86JITCore::G
     case FEXCore::IR::COND_VS:
     case FEXCore::IR::COND_VC:
     default:
-      LOGMAN_MSG_A("Unsupported compare type");
+      LOGMAN_MSG_A_FMT("Unsupported compare type");
       break;
   }
 
@@ -611,7 +609,7 @@ void *X86JITCore::CompileCode(uint64_t Entry, [[maybe_unused]] FEXCore::IR::IRLi
     L(RunBlock);
   }
 
-  LOGMAN_THROW_A(RAData != nullptr, "Needs RA");
+  LOGMAN_THROW_A_FMT(RAData != nullptr, "Needs RA");
 
   SpillSlots = RAData->SpillSlots();
 
@@ -669,7 +667,7 @@ void *X86JITCore::CompileCode(uint64_t Entry, [[maybe_unused]] FEXCore::IR::IRLi
     {
 #if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
       auto BlockIROp = BlockHeader->CW<IROp_CodeBlock>();
-      LOGMAN_THROW_A(BlockIROp->Header.Op == IR::OP_CODEBLOCK, "IR type failed to be a code block");
+      LOGMAN_THROW_A_FMT(BlockIROp->Header.Op == IR::OP_CODEBLOCK, "IR type failed to be a code block");
 #endif
 
       uint32_t Node = IR->GetID(BlockNode);
@@ -721,7 +719,7 @@ void *X86JITCore::CompileCode(uint64_t Entry, [[maybe_unused]] FEXCore::IR::IRLi
             Inst << "Reg" << GetPhys(ArgNode) << (i + 1 == NumArgs ? "" : ", ");
         }
 
-        LogMan::Msg::D("%s", Inst.str().c_str());
+        LogMan::Msg::DFmt("{}", Inst.str());
       }
       #endif
       uint32_t ID = IR->GetID(CodeNode);

--- a/External/FEXCore/Source/Interface/IR/IREmitter.cpp
+++ b/External/FEXCore/Source/Interface/IR/IREmitter.cpp
@@ -82,7 +82,7 @@ IREmitter::IRPair<IROp_CodeBlock> IREmitter::CreateNewCodeBlockAfter(OrderedNode
   if (insertAfter) {
     LinkCodeBlocks(insertAfter, CodeNode);
   } else {
-    LOGMAN_THROW_A(CurrentCodeBlock != nullptr, "CurrentCodeBlock must not be null here");
+    LOGMAN_THROW_A_FMT(CurrentCodeBlock != nullptr, "CurrentCodeBlock must not be null here");
 
     // Find last block
     auto LastBlock = CurrentCodeBlock;
@@ -101,7 +101,7 @@ IREmitter::IRPair<IROp_CodeBlock> IREmitter::CreateNewCodeBlockAfter(OrderedNode
 
 void IREmitter::SetCurrentCodeBlock(OrderedNode *Node) {
   CurrentCodeBlock = Node;
-  LOGMAN_THROW_A(Node->Op(DualListData.DataBegin())->Op == OP_CODEBLOCK, "Node wasn't codeblock. It was '%s'", std::string(IR::GetName(Node->Op(DualListData.DataBegin())->Op)).c_str());
+  LOGMAN_THROW_A_FMT(Node->Op(DualListData.DataBegin())->Op == OP_CODEBLOCK, "Node wasn't codeblock. It was '{}'", IR::GetName(Node->Op(DualListData.DataBegin())->Op));
   SetWriteCursor(Node->Op(DualListData.DataBegin())->CW<IROp_CodeBlock>()->Begin.GetNode(DualListData.ListBegin()));
 }
 

--- a/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -489,7 +489,7 @@ bool ConstProp::ConstantPropagation(IREmitter *IREmit, const IRListView& Current
 
       if (IREmit->IsValueConstant(IROp->Args[0], &Constant1) &&
           IREmit->IsValueConstant(IROp->Args[1], &Constant2)) {
-        LOGMAN_MSG_A("Could const prop op: %s", std::string(IR::GetName(IROp->Op)).c_str());
+        LOGMAN_MSG_A_FMT("Could const prop op: {}", IR::GetName(IROp->Op));
       }
     break;
     }
@@ -505,7 +505,7 @@ bool ConstProp::ConstantPropagation(IREmitter *IREmit, const IRListView& Current
       uint64_t Constant1;
 
       if (IREmit->IsValueConstant(IROp->Args[0], &Constant1)) {
-        LOGMAN_MSG_A("Could const prop op: %s", std::string(IR::GetName(IROp->Op)).c_str());
+        LOGMAN_MSG_A_FMT("Could const prop op: {}", IR::GetName(IROp->Op));
       }
     break;
     }

--- a/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
@@ -56,7 +56,7 @@ bool IRValidation::Run(IREmitter *IREmit) {
 
 #if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
   auto HeaderOp = CurrentIR.GetHeader();
-  LOGMAN_THROW_A(HeaderOp->Header.Op == OP_IRHEADER, "First op wasn't IRHeader");
+  LOGMAN_THROW_A_FMT(HeaderOp->Header.Op == OP_IRHEADER, "First op wasn't IRHeader");
 #endif
 
   IR::RegisterAllocationData * RAData{};
@@ -68,7 +68,7 @@ bool IRValidation::Run(IREmitter *IREmit) {
 
   for (auto [BlockNode, BlockHeader] : CurrentIR.GetBlocks()) {
     auto BlockIROp = BlockHeader->CW<FEXCore::IR::IROp_CodeBlock>();
-    LOGMAN_THROW_A(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
+    LOGMAN_THROW_A_FMT(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
 
     uint32_t BlockID = CurrentIR.GetID(BlockNode);
 
@@ -211,7 +211,7 @@ bool IRValidation::Run(IREmitter *IREmit) {
           break;
         }
         default:
-          // LOGMAN_MSG_A("Unknown IR Op: %d(%s)", IROp->Op, FEXCore::IR::GetName(IROp->Op).data());
+          // LOGMAN_MSG_A_FMT("Unknown IR Op: {}({})", IROp->Op, FEXCore::IR::GetName(IROp->Op));
         break;
       }
     }

--- a/External/FEXCore/include/FEXCore/IR/IREmitter.h
+++ b/External/FEXCore/include/FEXCore/IR/IREmitter.h
@@ -398,50 +398,50 @@ friend class FEXCore::IR::PassManager;
   }
 
   void SetJumpTarget(IR::IROp_Jump *Op, OrderedNode *Target) {
-    LOGMAN_THROW_A(Target->Op(DualListData.DataBegin())->Op == OP_CODEBLOCK,
-        "Tried setting Jump target to %%ssa%d %s",
+    LOGMAN_THROW_A_FMT(Target->Op(DualListData.DataBegin())->Op == OP_CODEBLOCK,
+        "Tried setting Jump target to %ssa{} {}",
         Target->Wrapped(DualListData.ListBegin()).ID(),
-        std::string(IR::GetName(Target->Op(DualListData.DataBegin())->Op)).c_str());
+        IR::GetName(Target->Op(DualListData.DataBegin())->Op));
 
     Op->Header.Args[0].NodeOffset = Target->Wrapped(DualListData.ListBegin()).NodeOffset;
   }
   void SetTrueJumpTarget(IR::IROp_CondJump *Op, OrderedNode *Target) {
-    LOGMAN_THROW_A(Target->Op(DualListData.DataBegin())->Op == OP_CODEBLOCK,
-        "Tried setting CondJump target to %%ssa%d %s",
+    LOGMAN_THROW_A_FMT(Target->Op(DualListData.DataBegin())->Op == OP_CODEBLOCK,
+        "Tried setting CondJump target to %ssa{} {}",
         Target->Wrapped(DualListData.ListBegin()).ID(),
-        std::string(IR::GetName(Target->Op(DualListData.DataBegin())->Op)).c_str());
+        IR::GetName(Target->Op(DualListData.DataBegin())->Op));
 
     Op->TrueBlock.NodeOffset = Target->Wrapped(DualListData.ListBegin()).NodeOffset;
   }
   void SetFalseJumpTarget(IR::IROp_CondJump *Op, OrderedNode *Target) {
-    LOGMAN_THROW_A(Target->Op(DualListData.DataBegin())->Op == OP_CODEBLOCK,
-        "Tried setting CondJump target to %%ssa%d %s",
+    LOGMAN_THROW_A_FMT(Target->Op(DualListData.DataBegin())->Op == OP_CODEBLOCK,
+        "Tried setting CondJump target to %ssa{} {}",
         Target->Wrapped(DualListData.ListBegin()).ID(),
-        std::string(IR::GetName(Target->Op(DualListData.DataBegin())->Op)).c_str());
+        IR::GetName(Target->Op(DualListData.DataBegin())->Op));
 
     Op->FalseBlock.NodeOffset = Target->Wrapped(DualListData.ListBegin()).NodeOffset;
   }
 
   void SetJumpTarget(IRPair<IROp_Jump> Op, OrderedNode *Target) {
-    LOGMAN_THROW_A(Target->Op(DualListData.DataBegin())->Op == OP_CODEBLOCK,
-        "Tried setting Jump target to %%ssa%d %s",
+    LOGMAN_THROW_A_FMT(Target->Op(DualListData.DataBegin())->Op == OP_CODEBLOCK,
+        "Tried setting Jump target to %ssa{} {}",
         Target->Wrapped(DualListData.ListBegin()).ID(),
-        std::string(IR::GetName(Target->Op(DualListData.DataBegin())->Op)).c_str());
+        IR::GetName(Target->Op(DualListData.DataBegin())->Op));
 
     Op.first->Header.Args[0].NodeOffset = Target->Wrapped(DualListData.ListBegin()).NodeOffset;
   }
   void SetTrueJumpTarget(IRPair<IROp_CondJump> Op, OrderedNode *Target) {
-    LOGMAN_THROW_A(Target->Op(DualListData.DataBegin())->Op == OP_CODEBLOCK,
-        "Tried setting CondJump target to %%ssa%d %s",
+    LOGMAN_THROW_A_FMT(Target->Op(DualListData.DataBegin())->Op == OP_CODEBLOCK,
+        "Tried setting CondJump target to %ssa{} {}",
         Target->Wrapped(DualListData.ListBegin()).ID(),
-        std::string(IR::GetName(Target->Op(DualListData.DataBegin())->Op)).c_str());
+        IR::GetName(Target->Op(DualListData.DataBegin())->Op));
     Op.first->TrueBlock.NodeOffset = Target->Wrapped(DualListData.ListBegin()).NodeOffset;
   }
   void SetFalseJumpTarget(IRPair<IROp_CondJump> Op, OrderedNode *Target) {
-    LOGMAN_THROW_A(Target->Op(DualListData.DataBegin())->Op == OP_CODEBLOCK,
-        "Tried setting CondJump target to %%ssa%d %s",
+    LOGMAN_THROW_A_FMT(Target->Op(DualListData.DataBegin())->Op == OP_CODEBLOCK,
+        "Tried setting CondJump target to %ssa{} {}",
         Target->Wrapped(DualListData.ListBegin()).ID(),
-        std::string(IR::GetName(Target->Op(DualListData.DataBegin())->Op)).c_str());
+        IR::GetName(Target->Op(DualListData.DataBegin())->Op));
     Op.first->FalseBlock.NodeOffset = Target->Wrapped(DualListData.ListBegin()).NodeOffset;
   }
 
@@ -507,7 +507,7 @@ friend class FEXCore::IR::PassManager;
 
     ReplaceUsesWithAfter(Node, NewNode, Start);
 
-    LOGMAN_THROW_A(Node->NumUses == 0, "Node still used");
+    LOGMAN_THROW_A_FMT(Node->NumUses == 0, "Node still used");
 
     // Since we have deleted ALL uses, we can safely delete the node.
     Remove(Node);
@@ -521,8 +521,8 @@ friend class FEXCore::IR::PassManager;
   OrderedNode *GetPackedRFLAG(bool Lower8);
 
   void CopyData(IREmitter const &rhs) {
-    LOGMAN_THROW_A(rhs.DualListData.DataBackingSize() <= DualListData.DataBackingSize(), "Trying to take ownership of data that is too large");
-    LOGMAN_THROW_A(rhs.DualListData.ListBackingSize() <= DualListData.ListBackingSize(), "Trying to take ownership of data that is too large");
+    LOGMAN_THROW_A_FMT(rhs.DualListData.DataBackingSize() <= DualListData.DataBackingSize(), "Trying to take ownership of data that is too large");
+    LOGMAN_THROW_A_FMT(rhs.DualListData.ListBackingSize() <= DualListData.ListBackingSize(), "Trying to take ownership of data that is too large");
     DualListData.CopyData(rhs.DualListData);
     InvalidNode = rhs.InvalidNode->Wrapped(rhs.DualListData.ListBegin()).GetNode(DualListData.ListBegin());
     CurrentWriteCursor = rhs.CurrentWriteCursor;
@@ -588,7 +588,7 @@ friend class FEXCore::IR::PassManager;
 #endif
     CodeNode->Op(DualListData.DataBegin())->CW<FEXCore::IR::IROp_CodeBlock>();
 
-    LOGMAN_THROW_A(CurrentIROp->Header.Op == IROps::OP_CODEBLOCK, "Invalid");
+    LOGMAN_THROW_A_FMT(CurrentIROp->Header.Op == IROps::OP_CODEBLOCK, "Invalid");
 
     CodeNode->append(DualListData.ListBegin(), Next);
   }

--- a/External/FEXCore/include/FEXCore/IR/IntrusiveIRList.h
+++ b/External/FEXCore/include/FEXCore/IR/IntrusiveIRList.h
@@ -197,7 +197,7 @@ public:
 
     // If we are casting to something narrower than just the header, check the opcode.
     if constexpr (!std::is_same<T, IROp_Header>::value) {
-      LOGMAN_THROW_A(Op->OPCODE == Op->Header.Op, "Expected Node to be '%s'. Found '%s' instead", GetName(Op->OPCODE), GetName(Op->Header.Op));
+      LOGMAN_THROW_A_FMT(Op->OPCODE == Op->Header.Op, "Expected Node to be '{}'. Found '{}' instead", GetName(Op->OPCODE), GetName(Op->Header.Op));
     }
 
     return Op;


### PR DESCRIPTION
Prior to the introduction of fmt, there wasn't a nice and easy way to format std::string_view, but now that we have it in place, we can modify relevant log calls to make use of it and get rid of the need to construct a string around the view, tidying up callsites a little.

While we're in the same area, we can make the rest of the modified file use fmt where appropriate.