### PR TITLE
Jits: Migrate logs over to fmt where applicable

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -46,7 +46,7 @@ DEF_OP(TruncElementPair) {
       mov(Dst.second, Src.second);
       break;
     }
-    default: LOGMAN_MSG_A("Unhandled Truncation size: %d", Op->Size); break;
+    default: LOGMAN_MSG_A_FMT("Unhandled Truncation size: {}", Op->Size); break;
   }
 }
 
@@ -95,7 +95,7 @@ DEF_OP(Add) {
       case 8:
         add(GetReg<RA_64>(Node), GetReg<RA_64>(Op->Header.Args[0].ID()), Const);
         break;
-      default: LOGMAN_MSG_A("Unsupported Add size: %d", OpSize);
+      default: LOGMAN_MSG_A_FMT("Unsupported Add size: {}", OpSize);
     }
   } else {
     switch (OpSize) {
@@ -105,7 +105,7 @@ DEF_OP(Add) {
       case 8:
         add(GetReg<RA_64>(Node), GetReg<RA_64>(Op->Header.Args[0].ID()), GetReg<RA_64>(Op->Header.Args[1].ID()));
         break;
-      default: LOGMAN_MSG_A("Unsupported Add size: %d", OpSize);
+      default: LOGMAN_MSG_A_FMT("Unsupported Add size: {}", OpSize);
     }
   }
 }
@@ -121,7 +121,7 @@ DEF_OP(Sub) {
       case 8:
         sub(GRS(Node), GRS(Op->Header.Args[0].ID()), Const);
         break;
-      default: LOGMAN_MSG_A("Unsupported Sub size: %d", OpSize);
+      default: LOGMAN_MSG_A_FMT("Unsupported Sub size: {}", OpSize);
     }
   } else {
     switch (OpSize) {
@@ -131,7 +131,7 @@ DEF_OP(Sub) {
       case 8:
         sub(GetReg<RA_64>(Node), GetReg<RA_64>(Op->Header.Args[0].ID()), GetReg<RA_64>(Op->Header.Args[1].ID()));
         break;
-      default: LOGMAN_MSG_A("Unsupported Sub size: %d", OpSize);
+      default: LOGMAN_MSG_A_FMT("Unsupported Sub size: {}", OpSize);
     }
   }
 
@@ -147,7 +147,7 @@ DEF_OP(Neg) {
     case 8:
       neg(GetReg<RA_64>(Node), GetReg<RA_64>(Op->Header.Args[0].ID()));
       break;
-    default: LOGMAN_MSG_A("Unsupported Not size: %d", OpSize);
+    default: LOGMAN_MSG_A_FMT("Unsupported Neg size: {}", OpSize);
   }
 }
 
@@ -163,7 +163,7 @@ DEF_OP(Mul) {
     case 8:
       mul(Dst, GetReg<RA_64>(Op->Header.Args[0].ID()), GetReg<RA_64>(Op->Header.Args[1].ID()));
     break;
-    default: LOGMAN_MSG_A("Unknown Sext size: %d", OpSize);
+    default: LOGMAN_MSG_A_FMT("Unknown Mul size: %d", OpSize);
   }
 }
 
@@ -179,7 +179,7 @@ DEF_OP(UMul) {
     case 8:
       mul(Dst, GetReg<RA_64>(Op->Header.Args[0].ID()), GetReg<RA_64>(Op->Header.Args[1].ID()));
     break;
-    default: LOGMAN_MSG_A("Unknown Sext size: %d", OpSize);
+    default: LOGMAN_MSG_A_FMT("Unknown UMul size: {}", OpSize);
   }
 }
 
@@ -216,7 +216,7 @@ DEF_OP(Div) {
       sdiv(GetReg<RA_64>(Node), GetReg<RA_64>(Op->Header.Args[0].ID()), GetReg<RA_64>(Op->Header.Args[1].ID()));
     break;
     }
-    default: LOGMAN_MSG_A("Unknown DIV Size: %d", Size); break;
+    default: LOGMAN_MSG_A_FMT("Unknown DIV Size: {}", Size); break;
   }
 }
 
@@ -243,7 +243,7 @@ DEF_OP(UDiv) {
       udiv(GetReg<RA_64>(Node), GetReg<RA_64>(Op->Header.Args[0].ID()), GetReg<RA_64>(Op->Header.Args[1].ID()));
       break;
     }
-    default: LOGMAN_MSG_A("Unknown UDIV Size: %d", Size); break;
+    default: LOGMAN_MSG_A_FMT("Unknown UDIV Size: {}", Size); break;
   }
 }
 
@@ -290,7 +290,7 @@ DEF_OP(Rem) {
       msub(GetReg<RA_64>(Node), TMP1, Divisor, Dividend);
     break;
     }
-    default: LOGMAN_MSG_A("Unknown REM Size: %d", OpSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown REM Size: {}", OpSize); break;
   }
 }
 
@@ -332,7 +332,7 @@ DEF_OP(URem) {
       msub(GetReg<RA_64>(Node), TMP1, Divisor, Dividend);
     break;
     }
-    default: LOGMAN_MSG_A("Unknown UREM Size: %d", OpSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown UREM Size: {}", OpSize); break;
   }
 }
 
@@ -349,7 +349,7 @@ DEF_OP(MulH) {
     case 8:
       smulh(GetReg<RA_64>(Node), GetReg<RA_64>(Op->Header.Args[0].ID()), GetReg<RA_64>(Op->Header.Args[1].ID()));
     break;
-    default: LOGMAN_MSG_A("Unknown Sext size: %d", OpSize);
+    default: LOGMAN_MSG_A_FMT("Unknown Sext size: {}", OpSize);
   }
 }
 
@@ -366,7 +366,7 @@ DEF_OP(UMulH) {
     case 8:
       umulh(GetReg<RA_64>(Node), GetReg<RA_64>(Op->Header.Args[0].ID()), GetReg<RA_64>(Op->Header.Args[1].ID()));
     break;
-    default: LOGMAN_MSG_A("Unknown Sext size: %d", OpSize);
+    default: LOGMAN_MSG_A_FMT("Unknown Sext size: {}", OpSize);
   }
 }
 
@@ -462,7 +462,7 @@ DEF_OP(Ror) {
       break;
       }
 
-      default: LOGMAN_MSG_A("Unhandled ROR size: %d", OpSize);
+      default: LOGMAN_MSG_A_FMT("Unhandled ROR size: {}", OpSize);
     }
   } else {
     switch (OpSize) {
@@ -475,7 +475,7 @@ DEF_OP(Ror) {
       break;
       }
 
-      default: LOGMAN_MSG_A("Unhandled ROR size: %d", OpSize);
+      default: LOGMAN_MSG_A_FMT("Unhandled ROR size: {}", OpSize);
     }
   }
 }
@@ -494,7 +494,7 @@ DEF_OP(Extr) {
     break;
     }
 
-    default: LOGMAN_MSG_A("Unhandled EXTR size: %d", OpSize);
+    default: LOGMAN_MSG_A_FMT("Unhandled EXTR size: {}", OpSize);
   }
 }
 
@@ -539,7 +539,7 @@ DEF_OP(LDiv) {
       mov(GetReg<RA_64>(Node), x0);
     break;
     }
-    default: LOGMAN_MSG_A("Unknown LDIV Size: %d", Size); break;
+    default: LOGMAN_MSG_A_FMT("Unknown LDIV Size: {}", Size); break;
   }
 }
 
@@ -582,7 +582,7 @@ DEF_OP(LUDiv) {
       mov(GetReg<RA_64>(Node), x0);
     break;
     }
-    default: LOGMAN_MSG_A("Unknown LUDIV Size: %d", Size); break;
+    default: LOGMAN_MSG_A_FMT("Unknown LUDIV Size: {}", Size); break;
   }
 }
 
@@ -635,7 +635,7 @@ DEF_OP(LRem) {
       mov(GetReg<RA_64>(Node), x0);
     break;
     }
-    default: LOGMAN_MSG_A("Unknown LREM Size: %d", Size); break;
+    default: LOGMAN_MSG_A_FMT("Unknown LREM Size: {}", Size); break;
   }
 }
 
@@ -685,7 +685,7 @@ DEF_OP(LURem) {
       mov(GetReg<RA_64>(Node), x0);
     break;
     }
-    default: LOGMAN_MSG_A("Unknown LUREM Size: %d", OpSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown LUREM Size: {}", OpSize); break;
   }
 }
 
@@ -699,7 +699,7 @@ DEF_OP(Not) {
     case 8:
       mvn(GetReg<RA_64>(Node), GetReg<RA_64>(Op->Header.Args[0].ID()));
       break;
-    default: LOGMAN_MSG_A("Unsupported Not size: %d", OpSize);
+    default: LOGMAN_MSG_A_FMT("Unsupported Not size: {}", OpSize);
   }
 }
 
@@ -730,7 +730,7 @@ DEF_OP(Popcount) {
       // fmov has zero extended, unused bytes are zero
       addv(VTMP1.B(), VTMP1.V8B());
       break;
-    default: LOGMAN_MSG_A("Unsupported Popcount size: %d", OpSize);
+    default: LOGMAN_MSG_A_FMT("Unsupported Popcount size: {}", OpSize);
   }
 
   auto Dst = GetReg<RA_32>(Node);
@@ -779,7 +779,7 @@ DEF_OP(FindMSB) {
       clz(Dst, GetReg<RA_64>(Op->Header.Args[0].ID()));
       sub(Dst, TMP1, Dst);
       break;
-    default: LOGMAN_MSG_A("Unknown REV size: %d", OpSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown FindMSB size: {}", OpSize); break;
   }
 }
 
@@ -800,7 +800,7 @@ DEF_OP(FindTrailingZeros) {
       rbit(GetReg<RA_64>(Node), GetReg<RA_64>(Op->Header.Args[0].ID()));
       clz(GetReg<RA_64>(Node), GetReg<RA_64>(Node));
       break;
-    default: LOGMAN_MSG_A("Unknown size: %d", OpSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown FindTrailingZeros size: {}", OpSize); break;
   }
 }
 
@@ -819,7 +819,7 @@ DEF_OP(CountLeadingZeroes) {
     case 8:
       clz(GetReg<RA_64>(Node), GetReg<RA_64>(Op->Header.Args[0].ID()));
       break;
-    default: LOGMAN_MSG_A("Unknown size: %d", OpSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown CountLeadingZeroes size: {}", OpSize); break;
   }
 }
 
@@ -837,7 +837,7 @@ DEF_OP(Rev) {
     case 8:
       rev(GetReg<RA_64>(Node), GetReg<RA_64>(Op->Header.Args[0].ID()));
       break;
-    default: LOGMAN_MSG_A("Unknown REV size: %d", OpSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown REV size: {}", OpSize); break;
   }
 }
 
@@ -859,14 +859,14 @@ DEF_OP(Bfi) {
       bfi(TMP1, GetReg<RA_64>(Op->Header.Args[1].ID()), Op->lsb, Op->Width);
       mov(GetReg<RA_64>(Node), TMP1);
       break;
-    default: LOGMAN_MSG_A("Unknown BFI size: %d", OpSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown BFI size: {}", OpSize); break;
   }
 }
 
 DEF_OP(Bfe) {
   auto Op = IROp->C<IR::IROp_Bfe>();
-  LOGMAN_THROW_A(IROp->Size <= 8, "OpSize is too large for BFE: %d", IROp->Size);
-  LOGMAN_THROW_A(Op->Width != 0, "Invalid BFE width of 0");
+  LOGMAN_THROW_A_FMT(IROp->Size <= 8, "OpSize is too large for BFE: {}", IROp->Size);
+  LOGMAN_THROW_A_FMT(Op->Width != 0, "Invalid BFE width of 0");
 
   auto Dst = GetReg<RA_64>(Node);
   ubfx(Dst, GetReg<RA_64>(Op->Header.Args[0].ID()), Op->lsb, Op->Width);
@@ -880,7 +880,7 @@ DEF_OP(Sbfe) {
   if (OpSize == 8) {
     sbfx(Dst, GetReg<RA_64>(Op->Header.Args[0].ID()), Op->lsb, Op->Width);
   } else {
-    LogMan::Msg::D("Unimplemented Sbfe size");
+    LogMan::Msg::DFmt("Unimplemented Sbfe size");
   }
 }
 
@@ -911,7 +911,7 @@ Condition MapSelectCC(IR::CondClassType Cond) {
   case FEXCore::IR::COND_MI:
   case FEXCore::IR::COND_PL:
   default:
-  LOGMAN_MSG_A("Unsupported compare type");
+  LOGMAN_MSG_A_FMT("Unsupported compare type");
   return Condition::nv;
   }
 }
@@ -929,7 +929,7 @@ DEF_OP(Select) {
   } else if (IsFPR(Op->Cmp1.ID())) {
     fcmp(GRFCMP(Op->Cmp1.ID()), GRFCMP(Op->Cmp2.ID()));
   } else {
-    LOGMAN_MSG_A("Select: Expected GPR or FPR");
+    LOGMAN_MSG_A_FMT("Select: Expected GPR or FPR");
   }
 
   auto cc = MapSelectCC(Op->Cond);
@@ -940,7 +940,7 @@ DEF_OP(Select) {
 
   if (is_const_true || is_const_false) {
     if (is_const_false != true || is_const_true != true || const_true != 1 || const_false != 0) {
-      LOGMAN_MSG_A("Select: Unsupported compare inline parameters");
+      LOGMAN_MSG_A_FMT("Select: Unsupported compare inline parameters");
     }
     cset(GRS(Node), cc);
   } else {
@@ -964,7 +964,7 @@ DEF_OP(VExtractToGPR) {
     case 8:
       umov(GetReg<RA_64>(Node), GetSrc(Op->Header.Args[0].ID()).V2D(), Op->Idx);
     break;
-    default:  LOGMAN_MSG_A("Unhandled ExtractElementSize: %d", OpSize);
+    default:  LOGMAN_MSG_A_FMT("Unhandled ExtractElementSize: {}", OpSize);
   }
 }
 
@@ -1027,7 +1027,7 @@ DEF_OP(FCmp) {
   bool set = false;
 
   if (Op->Flags & (1 << IR::FCMP_FLAG_EQ)) {
-    LOGMAN_THROW_A(IR::FCMP_FLAG_EQ == 0, "IR::FCMP_FLAG_EQ must equal 0");
+    LOGMAN_THROW_A_FMT(IR::FCMP_FLAG_EQ == 0, "IR::FCMP_FLAG_EQ must equal 0");
     // EQ or unordered
     cset(Dst, Condition::eq); // Z = 1
     csinc(Dst, Dst, xzr, Condition::vc); // IF !V ? Z : 1

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/AtomicOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/AtomicOps.cpp
@@ -34,7 +34,7 @@ DEF_OP(CASPair) {
       mov(Dst.first, TMP3);
       mov(Dst.second, TMP4);
       break;
-    default: LOGMAN_MSG_A("Unsupported: %d", OpSize);
+    default: LOGMAN_MSG_A_FMT("Unsupported: {}", OpSize);
     }
   }
   else {
@@ -97,7 +97,7 @@ DEF_OP(CASPair) {
         bind(&LoopExpected);
         break;
       }
-      default: LOGMAN_MSG_A("Unsupported: %d", OpSize);
+      default: LOGMAN_MSG_A_FMT("Unsupported: {}", OpSize);
     }
   }
 }
@@ -123,7 +123,7 @@ DEF_OP(CAS) {
     case 2: casalh(TMP2.W(), Desired.W(), MemOperand(MemSrc)); break;
     case 4: casal(TMP2.W(), Desired.W(), MemOperand(MemSrc)); break;
     case 8: casal(TMP2.X(), Desired.X(), MemOperand(MemSrc)); break;
-    default: LOGMAN_MSG_A("Unsupported: %d", OpSize);
+    default: LOGMAN_MSG_A_FMT("Unsupported: {}", OpSize);
     }
     mov(GetReg<RA_64>(Node), TMP2);
   }
@@ -214,7 +214,7 @@ DEF_OP(CAS) {
 
         break;
       }
-      default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", OpSize);
+      default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", OpSize);
     }
   }
 }
@@ -230,7 +230,7 @@ DEF_OP(AtomicAdd) {
     case 2: staddlh(GetReg<RA_32>(Op->Header.Args[1].ID()), MemOperand(MemSrc)); break;
     case 4: staddl(GetReg<RA_32>(Op->Header.Args[1].ID()), MemOperand(MemSrc)); break;
     case 8: staddl(GetReg<RA_64>(Op->Header.Args[1].ID()), MemOperand(MemSrc)); break;
-    default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
     }
   }
   else {
@@ -272,7 +272,7 @@ DEF_OP(AtomicAdd) {
         cbnz(TMP2, &LoopTop);
         break;
       }
-      default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
+      default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
     }
   }
 }
@@ -289,7 +289,7 @@ DEF_OP(AtomicSub) {
     case 2: staddlh(TMP2.W(), MemOperand(MemSrc)); break;
     case 4: staddl(TMP2.W(), MemOperand(MemSrc)); break;
     case 8: staddl(TMP2.X(), MemOperand(MemSrc)); break;
-    default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
     }
   }
   else {
@@ -331,7 +331,7 @@ DEF_OP(AtomicSub) {
         cbnz(TMP2, &LoopTop);
         break;
       }
-      default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
+      default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
     }
   }
 }
@@ -348,7 +348,7 @@ DEF_OP(AtomicAnd) {
     case 2: stclrlh(TMP2.W(), MemOperand(MemSrc)); break;
     case 4: stclrl(TMP2.W(), MemOperand(MemSrc)); break;
     case 8: stclrl(TMP2.X(), MemOperand(MemSrc)); break;
-    default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
     }
   }
   else {
@@ -390,7 +390,7 @@ DEF_OP(AtomicAnd) {
         cbnz(TMP2, &LoopTop);
         break;
       }
-      default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
+      default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
     }
   }
 }
@@ -406,7 +406,7 @@ DEF_OP(AtomicOr) {
     case 2: stsetlh(GetReg<RA_32>(Op->Header.Args[1].ID()), MemOperand(MemSrc)); break;
     case 4: stsetl(GetReg<RA_32>(Op->Header.Args[1].ID()), MemOperand(MemSrc)); break;
     case 8: stsetl(GetReg<RA_64>(Op->Header.Args[1].ID()), MemOperand(MemSrc)); break;
-    default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
     }
   }
   else {
@@ -448,7 +448,7 @@ DEF_OP(AtomicOr) {
         cbnz(TMP2, &LoopTop);
         break;
       }
-      default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
+      default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
     }
   }
 }
@@ -464,7 +464,7 @@ DEF_OP(AtomicXor) {
     case 2: steorlh(GetReg<RA_32>(Op->Header.Args[1].ID()), MemOperand(MemSrc)); break;
     case 4: steorl(GetReg<RA_32>(Op->Header.Args[1].ID()), MemOperand(MemSrc)); break;
     case 8: steorl(GetReg<RA_64>(Op->Header.Args[1].ID()), MemOperand(MemSrc)); break;
-    default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
     }
   }
   else {
@@ -506,7 +506,7 @@ DEF_OP(AtomicXor) {
         cbnz(TMP2, &LoopTop);
         break;
       }
-      default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
+      default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
     }
   }
 }
@@ -523,7 +523,7 @@ DEF_OP(AtomicSwap) {
     case 2: swplh(TMP2.W(), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
     case 4: swpl(TMP2.W(), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
     case 8: swpl(TMP2.X(), GetReg<RA_64>(Node), MemOperand(MemSrc)); break;
-    default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
     }
   }
   else {
@@ -565,7 +565,7 @@ DEF_OP(AtomicSwap) {
         mov(GetReg<RA_64>(Node), TMP2.X());
         break;
       }
-      default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
+      default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
     }
   }
 }
@@ -580,7 +580,7 @@ DEF_OP(AtomicFetchAdd) {
     case 2: ldaddalh(GetReg<RA_32>(Op->Header.Args[1].ID()), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
     case 4: ldaddal(GetReg<RA_32>(Op->Header.Args[1].ID()), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
     case 8: ldaddal(GetReg<RA_64>(Op->Header.Args[1].ID()), GetReg<RA_64>(Node), MemOperand(MemSrc)); break;
-    default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
     }
   }
   else {
@@ -626,7 +626,7 @@ DEF_OP(AtomicFetchAdd) {
         mov(GetReg<RA_64>(Node), TMP2);
         break;
       }
-      default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
+      default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
     }
   }
 }
@@ -642,7 +642,7 @@ DEF_OP(AtomicFetchSub) {
     case 2: ldaddalh(TMP2.W(), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
     case 4: ldaddal(TMP2.W(), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
     case 8: ldaddal(TMP2.X(), GetReg<RA_64>(Node), MemOperand(MemSrc)); break;
-    default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
     }
   }
   else {
@@ -688,7 +688,7 @@ DEF_OP(AtomicFetchSub) {
         mov(GetReg<RA_64>(Node), TMP2);
         break;
       }
-      default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
+      default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
     }
   }
 }
@@ -704,7 +704,7 @@ DEF_OP(AtomicFetchAnd) {
     case 2: ldclralh(TMP2.W(), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
     case 4: ldclral(TMP2.W(), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
     case 8: ldclral(TMP2.X(), GetReg<RA_64>(Node), MemOperand(MemSrc)); break;
-    default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
     }
   }
   else {
@@ -750,7 +750,7 @@ DEF_OP(AtomicFetchAnd) {
         mov(GetReg<RA_64>(Node), TMP2);
         break;
       }
-      default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
+      default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
     }
   }
 }
@@ -765,7 +765,7 @@ DEF_OP(AtomicFetchOr) {
     case 2: ldsetalh(GetReg<RA_32>(Op->Header.Args[1].ID()), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
     case 4: ldsetal(GetReg<RA_32>(Op->Header.Args[1].ID()), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
     case 8: ldsetal(GetReg<RA_64>(Op->Header.Args[1].ID()), GetReg<RA_64>(Node), MemOperand(MemSrc)); break;
-    default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
     }
   }
   else {
@@ -811,7 +811,7 @@ DEF_OP(AtomicFetchOr) {
         mov(GetReg<RA_64>(Node), TMP2);
         break;
       }
-      default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
+      default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
     }
   }
 }
@@ -826,7 +826,7 @@ DEF_OP(AtomicFetchXor) {
     case 2: ldeoralh(GetReg<RA_32>(Op->Header.Args[1].ID()), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
     case 4: ldeoral(GetReg<RA_32>(Op->Header.Args[1].ID()), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
     case 8: ldeoral(GetReg<RA_64>(Op->Header.Args[1].ID()), GetReg<RA_64>(Node), MemOperand(MemSrc)); break;
-    default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
     }
   }
   else {
@@ -872,7 +872,7 @@ DEF_OP(AtomicFetchXor) {
         mov(GetReg<RA_64>(Node), TMP2);
         break;
       }
-      default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
+      default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
     }
   }
 }
@@ -923,7 +923,7 @@ DEF_OP(AtomicFetchNeg) {
       mov(GetReg<RA_64>(Node), TMP2);
       break;
     }
-    default:  LOGMAN_MSG_A("Unhandled Atomic size: %d", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
@@ -16,15 +16,15 @@ using namespace vixl;
 using namespace vixl::aarch64;
 #define DEF_OP(x) void Arm64JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
 DEF_OP(GuestCallDirect) {
-  LogMan::Msg::D("Unimplemented");
+  LogMan::Msg::DFmt("Unimplemented");
 }
 
 DEF_OP(GuestCallIndirect) {
-  LogMan::Msg::D("Unimplemented");
+  LogMan::Msg::DFmt("Unimplemented");
 }
 
 DEF_OP(GuestReturn) {
-  LogMan::Msg::D("Unimplemented");
+  LogMan::Msg::DFmt("Unimplemented");
 }
 
 DEF_OP(SignalReturn) {
@@ -142,7 +142,7 @@ Condition MapBranchCC(IR::CondClassType Cond) {
   case FEXCore::IR::COND_MI:
   case FEXCore::IR::COND_PL:
   default:
-  LOGMAN_MSG_A("Unsupported compare type");
+  LOGMAN_MSG_A_FMT("Unsupported compare type");
   return Condition::nv;
   }
 }
@@ -169,10 +169,10 @@ DEF_OP(CondJump) {
   bool isConst = IsInlineConstant(Op->Cmp2, &Const);
 
   if (isConst && Const == 0 && Op->Cond.Val == FEXCore::IR::COND_EQ) {
-    LOGMAN_THROW_A(IsGPR(Op->Cmp1.ID()), "CondJump: Expected GPR");
+    LOGMAN_THROW_A_FMT(IsGPR(Op->Cmp1.ID()), "CondJump: Expected GPR");
     cbz(GRCMP(Op->Cmp1.ID()), TrueTargetLabel);
   } else if (isConst && Const == 0 && Op->Cond.Val == FEXCore::IR::COND_NEQ) {
-    LOGMAN_THROW_A(IsGPR(Op->Cmp1.ID()), "CondJump: Expected GPR");
+    LOGMAN_THROW_A_FMT(IsGPR(Op->Cmp1.ID()), "CondJump: Expected GPR");
     cbnz(GRCMP(Op->Cmp1.ID()), TrueTargetLabel);
   } else {
     if (IsGPR(Op->Cmp1.ID())) {
@@ -183,7 +183,7 @@ DEF_OP(CondJump) {
     } else if (IsFPR(Op->Cmp1.ID())) {
       fcmp(GRFCMP(Op->Cmp1.ID()), GRFCMP(Op->Cmp2.ID()));
     } else {
-      LOGMAN_MSG_A("CondJump: Expected GPR or FPR");
+      LOGMAN_MSG_A_FMT("CondJump: Expected GPR or FPR");
     }
 
     b(TrueTargetLabel, MapBranchCC(Op->Cond));

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ConversionOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ConversionOps.cpp
@@ -31,7 +31,7 @@ DEF_OP(VInsGPR) {
       ins(GetDst(Node).V2D(), Op->Index, GetReg<RA_64>(Op->Header.Args[1].ID()));
     break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -52,7 +52,7 @@ DEF_OP(VCastFromGPR) {
     case 8:
       fmov(GetDst(Node).D(), GetReg<RA_64>(Op->Header.Args[0].ID()).X());
       break;
-    default: LOGMAN_MSG_A("Unknown castGPR element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A_FMT("Unknown castGPR element size: {}", Op->Header.ElementSize);
   }
 }
 
@@ -91,7 +91,7 @@ DEF_OP(Float_FToF) {
       fcvt(GetDst(Node).S(), GetSrc(Op->Header.Args[0].ID()).D());
       break;
     }
-    default: LOGMAN_MSG_A("Unknown FCVT sizes: 0x%x", Conv);
+    default: LOGMAN_MSG_A_FMT("Unknown FCVT sizes: 0x{:x}", Conv);
   }
 }
 
@@ -104,7 +104,7 @@ DEF_OP(Vector_SToF) {
     case 8:
       scvtf(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D());
     break;
-    default: LOGMAN_MSG_A("Unknown castGPR element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A_FMT("Unknown Vector_SToF element size: {}", Op->Header.ElementSize);
   }
 }
 
@@ -117,7 +117,7 @@ DEF_OP(Vector_FToZS) {
     case 8:
       fcvtzs(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D());
     break;
-    default: LOGMAN_MSG_A("Unknown castGPR element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A_FMT("Unknown Vector_FToZS element size: {}", Op->Header.ElementSize);
   }
 }
 
@@ -132,7 +132,7 @@ DEF_OP(Vector_FToS) {
       frinti(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D());
       fcvtzs(GetDst(Node).V2D(), GetDst(Node).V2D());
     break;
-    default: LOGMAN_MSG_A("Unknown castGPR element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A_FMT("Unknown Vector_FToS element size: {}", Op->Header.ElementSize);
   }
 }
 
@@ -149,7 +149,7 @@ DEF_OP(Vector_FToF) {
       fcvtn(GetDst(Node).V2S(), GetSrc(Op->Header.Args[0].ID()).V2D());
       break;
     }
-    default: LOGMAN_MSG_A("Unknown Conversion Type : 0%04x", Conv); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Vector_FToF Type : 0x{:04x}", Conv); break;
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -30,7 +30,7 @@ DEF_OP(LoadContext) {
     case 8:
       ldr(GetReg<RA_64>(Node), MemOperand(STATE, Op->Offset));
     break;
-    default:  LOGMAN_MSG_A("Unhandled LoadContext size: %d", OpSize);
+    default:  LOGMAN_MSG_A_FMT("Unhandled LoadContext size: {}", OpSize);
     }
   }
   else {
@@ -51,7 +51,7 @@ DEF_OP(LoadContext) {
     case 16:
       ldr(Dst, MemOperand(STATE, Op->Offset));
     break;
-    default:  LOGMAN_MSG_A("Unhandled LoadContext size: %d", OpSize);
+    default:  LOGMAN_MSG_A_FMT("Unhandled LoadContext size: {}", OpSize);
     }
   }
 }
@@ -73,7 +73,7 @@ DEF_OP(StoreContext) {
     case 8:
       str(GetReg<RA_64>(Op->Header.Args[0].ID()), MemOperand(STATE, Op->Offset));
     break;
-    default:  LOGMAN_MSG_A("Unhandled StoreContext size: %d", OpSize);
+    default:  LOGMAN_MSG_A_FMT("Unhandled StoreContext size: {}", OpSize);
     }
   }
   else {
@@ -94,7 +94,7 @@ DEF_OP(StoreContext) {
     case 16:
       str(Src, MemOperand(STATE, Op->Offset));
     break;
-    default:  LOGMAN_MSG_A("Unhandled LoadContext size: %d", OpSize);
+    default:  LOGMAN_MSG_A_FMT("Unhandled StoreContext size: {}", OpSize);
     }
   }
 }
@@ -107,29 +107,29 @@ DEF_OP(LoadRegister) {
     auto regId = (Op->Offset - offsetof(FEXCore::Core::CpuStateFrame, State.gregs[0])) / 8;
     auto regOffs = Op->Offset & 7;
 
-    LOGMAN_THROW_A(regId < SRA64.size(), "out of range regId");
+    LOGMAN_THROW_A_FMT(regId < SRA64.size(), "out of range regId");
 
     auto reg = SRA64[regId];
 
     switch(Op->Header.Size) {
       case 1:
-        LOGMAN_THROW_A(regOffs == 0 || regOffs == 1, "unexpected regOffs");
+        LOGMAN_THROW_A_FMT(regOffs == 0 || regOffs == 1, "unexpected regOffs");
         ubfx(GetReg<RA_64>(Node), reg, regOffs * 8, 8);
         break;
 
       case 2:
-        LOGMAN_THROW_A(regOffs == 0, "unexpected regOffs");
+        LOGMAN_THROW_A_FMT(regOffs == 0, "unexpected regOffs");
         ubfx(GetReg<RA_64>(Node), reg, 0, 16);
         break;
 
       case 4:
-        LOGMAN_THROW_A(regOffs == 0, "unexpected regOffs");
+        LOGMAN_THROW_A_FMT(regOffs == 0, "unexpected regOffs");
         if (GetReg<RA_64>(Node).GetCode() != reg.GetCode())
           mov(GetReg<RA_32>(Node), reg.W());
         break;
 
       case 8:
-        LOGMAN_THROW_A(regOffs == 0, "unexpected regOffs");
+        LOGMAN_THROW_A_FMT(regOffs == 0, "unexpected regOffs");
         if (GetReg<RA_64>(Node).GetCode() != reg.GetCode())
           mov(GetReg<RA_64>(Node), reg);
         break;
@@ -138,24 +138,24 @@ DEF_OP(LoadRegister) {
     auto regId = (Op->Offset - offsetof(FEXCore::Core::CpuStateFrame, State.xmm[0][0])) / 16;
     auto regOffs = Op->Offset & 15;
 
-    LOGMAN_THROW_A(regId < SRAFPR.size(), "out of range regId");
+    LOGMAN_THROW_A_FMT(regId < SRAFPR.size(), "out of range regId");
 
     auto guest = SRAFPR[regId];
     auto host = GetSrc(Node);
 
     switch(Op->Header.Size) {
       case 1:
-        LOGMAN_THROW_A(regOffs == 0, "unexpected regOffs");
+        LOGMAN_THROW_A_FMT(regOffs == 0, "unexpected regOffs");
         mov(host.B(), guest.B());
         break;
 
       case 2:
-        LOGMAN_THROW_A(regOffs == 0, "unexpected regOffs");
+        LOGMAN_THROW_A_FMT(regOffs == 0, "unexpected regOffs");
         fmov(host.H(), guest.H());
         break;
 
       case 4:
-        LOGMAN_THROW_A((regOffs & 3) == 0, "unexpected regOffs");
+        LOGMAN_THROW_A_FMT((regOffs & 3) == 0, "unexpected regOffs");
         if (regOffs == 0) {
           if (host.GetCode() != guest.GetCode())
             fmov(host.S(), guest.S());
@@ -165,7 +165,7 @@ DEF_OP(LoadRegister) {
         break;
 
       case 8:
-        LOGMAN_THROW_A((regOffs & 7) == 0, "unexpected regOffs");
+        LOGMAN_THROW_A_FMT((regOffs & 7) == 0, "unexpected regOffs");
         if (regOffs == 0) {
           if (host.GetCode() != guest.GetCode())
             mov(host.D(), guest.D());
@@ -175,13 +175,13 @@ DEF_OP(LoadRegister) {
         break;
 
       case 16:
-        LOGMAN_THROW_A(regOffs == 0, "unexpected regOffs");
+        LOGMAN_THROW_A_FMT(regOffs == 0, "unexpected regOffs");
         if (host.GetCode() != guest.GetCode())
           mov(host.Q(), guest.Q());
         break;
     }
   } else {
-    LOGMAN_THROW_A(false, "Unhandled Op->Class %d", Op->Class);
+    LOGMAN_THROW_A_FMT(false, "Unhandled Op->Class {}", Op->Class);
   }
 }
 
@@ -192,28 +192,28 @@ DEF_OP(StoreRegister) {
     auto regId = Op->Offset / 8 - 1;
     auto regOffs = Op->Offset & 7;
 
-    LOGMAN_THROW_A(regId < SRA64.size(), "out of range regId");
+    LOGMAN_THROW_A_FMT(regId < SRA64.size(), "out of range regId");
 
     auto reg = SRA64[regId];
 
     switch(Op->Header.Size) {
       case 1:
-        LOGMAN_THROW_A(regOffs == 0 || regOffs == 1, "unexpected regOffs");
+        LOGMAN_THROW_A_FMT(regOffs == 0 || regOffs == 1, "unexpected regOffs");
         bfi(reg, GetReg<RA_64>(Op->Value.ID()), regOffs * 8, 8);
         break;
 
       case 2:
-        LOGMAN_THROW_A(regOffs == 0, "unexpected regOffs");
+        LOGMAN_THROW_A_FMT(regOffs == 0, "unexpected regOffs");
         bfi(reg, GetReg<RA_64>(Op->Value.ID()), 0, 16);
         break;
 
       case 4:
-        LOGMAN_THROW_A(regOffs == 0, "unexpected regOffs");
+        LOGMAN_THROW_A_FMT(regOffs == 0, "unexpected regOffs");
         bfi(reg, GetReg<RA_64>(Op->Value.ID()), 0, 32);
         break;
 
       case 8:
-        LOGMAN_THROW_A(regOffs == 0, "unexpected regOffs");
+        LOGMAN_THROW_A_FMT(regOffs == 0, "unexpected regOffs");
         if (GetReg<RA_64>(Op->Value.ID()).GetCode() != reg.GetCode())
           mov(reg, GetReg<RA_64>(Op->Value.ID()));
         break;
@@ -222,7 +222,7 @@ DEF_OP(StoreRegister) {
     auto regId = (Op->Offset - offsetof(FEXCore::Core::CpuStateFrame, State.xmm[0][0])) / 16;
     auto regOffs = Op->Offset & 15;
 
-    LOGMAN_THROW_A(regId < SRAFPR.size(), "regId out of range");
+    LOGMAN_THROW_A_FMT(regId < SRAFPR.size(), "regId out of range");
 
     auto guest = SRAFPR[regId];
     auto host = GetSrc(Op->Value.ID());
@@ -233,28 +233,28 @@ DEF_OP(StoreRegister) {
         break;
 
       case 2:
-        LOGMAN_THROW_A((regOffs & 1) == 0, "unexpected regOffs");
+        LOGMAN_THROW_A_FMT((regOffs & 1) == 0, "unexpected regOffs");
         ins(guest.V8H(), regOffs/2, host.V8H(), 0);
         break;
 
       case 4:
-        LOGMAN_THROW_A((regOffs & 3) == 0, "unexpected regOffs");
+        LOGMAN_THROW_A_FMT((regOffs & 3) == 0, "unexpected regOffs");
         ins(guest.V4S(), regOffs/4, host.V4S(), 0);
         break;
 
       case 8:
-        LOGMAN_THROW_A((regOffs & 7) == 0, "unexpected regOffs");
+        LOGMAN_THROW_A_FMT((regOffs & 7) == 0, "unexpected regOffs");
         ins(guest.V2D(), regOffs / 8, host.V2D(), 0);
         break;
 
       case 16:
-        LOGMAN_THROW_A(regOffs == 0, "unexpected regOffs");
+        LOGMAN_THROW_A_FMT(regOffs == 0, "unexpected regOffs");
         if (guest.GetCode() != host.GetCode())
           mov(guest.Q(), host.Q());
         break;
     }
   } else {
-    LOGMAN_THROW_A(false, "Unhandled Op->Class %d", Op->Class);
+    LOGMAN_THROW_A_FMT(false, "Unhandled Op->Class {}", Op->Class);
   }
 }
 
@@ -288,15 +288,17 @@ DEF_OP(LoadContextIndexed) {
         ldr(GetReg<RA_64>(Node), MemOperand(TMP1, Op->BaseOffset));
         break;
       default:
-        LOGMAN_MSG_A("Unhandled LoadContextIndexed size: %d", Op->Size);
+        LOGMAN_MSG_A_FMT("Unhandled LoadContextIndexed size: {}", Op->Size);
+        break;
       }
       break;
     }
     case 16:
-      LOGMAN_MSG_A("Invalid Class load of size 16");
+      LOGMAN_MSG_A_FMT("Invalid Class load of size 16");
       break;
     default:
-      LOGMAN_MSG_A("Unhandled LoadContextIndexed stride: %d", Op->Stride);
+      LOGMAN_MSG_A_FMT("Unhandled LoadContextIndexed stride: {}", Op->Stride);
+      break;
     }
   }
   else {
@@ -333,12 +335,14 @@ DEF_OP(LoadContextIndexed) {
         }
         break;
       default:
-        LOGMAN_MSG_A("Unhandled LoadContextIndexed size: %d", Op->Size);
+        LOGMAN_MSG_A_FMT("Unhandled LoadContextIndexed size: {}", Op->Size);
+        break;
       }
       break;
     }
     default:
-      LOGMAN_MSG_A("Unhandled LoadContextIndexed stride: %d", Op->Stride);
+      LOGMAN_MSG_A_FMT("Unhandled LoadContextIndexed stride: {}", Op->Stride);
+      break;
     }
   }
 }
@@ -374,15 +378,17 @@ DEF_OP(StoreContextIndexed) {
         str(value, MemOperand(TMP1, Op->BaseOffset));
         break;
       default:
-        LOGMAN_MSG_A("Unhandled LoadContextIndexed size: %d", Op->Size);
+        LOGMAN_MSG_A_FMT("Unhandled StoreContextIndexed size: {}", Op->Size);
+        break;
       }
       break;
     }
     case 16:
-      LOGMAN_MSG_A("Invalid Class load of size 16");
+      LOGMAN_MSG_A_FMT("Invalid Class store of size 16");
       break;
     default:
-      LOGMAN_MSG_A("Unhandled LoadContextIndexed stride: %d", Op->Stride);
+      LOGMAN_MSG_A_FMT("Unhandled StoreContextIndexed stride: {}", Op->Stride);
+      break;
     }
   }
   else {
@@ -421,12 +427,14 @@ DEF_OP(StoreContextIndexed) {
         }
         break;
       default:
-        LOGMAN_MSG_A("Unhandled LoadContextIndexed size: %d", Op->Size);
+        LOGMAN_MSG_A_FMT("Unhandled StoreContextIndexed size: {}", Op->Size);
+        break;
       }
       break;
     }
     default:
-      LOGMAN_MSG_A("Unhandled LoadContextIndexed stride: %d", Op->Stride);
+      LOGMAN_MSG_A_FMT("Unhandled StoreContextIndexed stride: {}", Op->Stride);
+      break;
     }
   }
 }
@@ -454,7 +462,7 @@ DEF_OP(SpillRegister) {
       str(GetReg<RA_64>(Op->Header.Args[0].ID()), MemOperand(sp, SlotOffset));
       break;
     }
-    default:  LOGMAN_MSG_A("Unhandled SpillRegister size: %d", OpSize);
+    default:  LOGMAN_MSG_A_FMT("Unhandled SpillRegister size: {}", OpSize);
     }
   } else if (Op->Class == FEXCore::IR::FPRClass) {
     switch (OpSize) {
@@ -470,10 +478,10 @@ DEF_OP(SpillRegister) {
       str(GetSrc(Op->Header.Args[0].ID()), MemOperand(sp, SlotOffset));
       break;
     }
-    default:  LOGMAN_MSG_A("Unhandled SpillRegister size: %d", OpSize);
+    default:  LOGMAN_MSG_A_FMT("Unhandled SpillRegister size: {}", OpSize);
     }
   } else {
-    LOGMAN_MSG_A("Unhandled SpillRegister class: %d", Op->Class.Val);
+    LOGMAN_MSG_A_FMT("Unhandled SpillRegister class: {}", Op->Class.Val);
   }
 }
 
@@ -500,7 +508,7 @@ DEF_OP(FillRegister) {
       ldr(GetReg<RA_64>(Node), MemOperand(sp, SlotOffset));
       break;
     }
-    default:  LOGMAN_MSG_A("Unhandled SpillRegister size: %d", OpSize);
+    default:  LOGMAN_MSG_A_FMT("Unhandled FillRegister size: {}", OpSize);
     }
   } else if (Op->Class == FEXCore::IR::FPRClass) {
     switch (OpSize) {
@@ -516,10 +524,10 @@ DEF_OP(FillRegister) {
       ldr(GetDst(Node), MemOperand(sp, SlotOffset));
       break;
     }
-    default:  LOGMAN_MSG_A("Unhandled SpillRegister size: %d", OpSize);
+    default:  LOGMAN_MSG_A_FMT("Unhandled FillRegister size: {}", OpSize);
     }
   } else {
-    LOGMAN_MSG_A("Unhandled FillRegister class: %d", Op->Class.Val);
+    LOGMAN_MSG_A_FMT("Unhandled FillRegister class: {}", Op->Class.Val);
   }
 }
 
@@ -539,7 +547,7 @@ MemOperand Arm64JITCore::GenerateMemOperand(uint8_t AccessSize, aarch64::Registe
     return MemOperand(Base);
   } else {
     if (OffsetScale != 1 && OffsetScale != AccessSize) {
-        LOGMAN_MSG_A("Unhandled GenerateMemOperand OffsetScale: %d", OffsetScale);
+        LOGMAN_MSG_A_FMT("Unhandled GenerateMemOperand OffsetScale: {}", OffsetScale);
     }
     uint64_t Const;
     if (IsInlineConstant(Offset, &Const)) {
@@ -551,7 +559,7 @@ MemOperand Arm64JITCore::GenerateMemOperand(uint8_t AccessSize, aarch64::Registe
         case IR::MEM_OFFSET_UXTW.Val: return MemOperand(Base, RegOffset.W(), Extend::UXTW, (int)std::log2(OffsetScale) );
         case IR::MEM_OFFSET_SXTW.Val: return MemOperand(Base, RegOffset.W(), Extend::SXTW, (int)std::log2(OffsetScale) );
 
-        default: LOGMAN_MSG_A("Unhandled GenerateMemOperand OffsetType: %d", OffsetType.Val); break;
+        default: LOGMAN_MSG_A_FMT("Unhandled GenerateMemOperand OffsetType: {}", OffsetType.Val); break;
       }
     }
   }
@@ -580,7 +588,7 @@ DEF_OP(LoadMem) {
       case 8:
         ldr(Dst, MemSrc);
         break;
-      default:  LOGMAN_MSG_A("Unhandled LoadMem size: %d", Op->Size);
+      default:  LOGMAN_MSG_A_FMT("Unhandled LoadMem size: {}", Op->Size);
     }
   }
   else {
@@ -601,7 +609,7 @@ DEF_OP(LoadMem) {
       case 16:
         ldr(Dst, MemSrc);
         break;
-      default:  LOGMAN_MSG_A("Unhandled LoadMem size: %d", Op->Size);
+      default:  LOGMAN_MSG_A_FMT("Unhandled LoadMem size: {}", Op->Size);
     }
   }
 }
@@ -612,7 +620,7 @@ DEF_OP(LoadMemTSO) {
   auto MemSrc = MemOperand(GetReg<RA_64>(Op->Header.Args[0].ID()));
 
   if (!Op->Offset.IsInvalid()) {
-    LOGMAN_MSG_A("LoadMemTSO: No offset allowed");
+    LOGMAN_MSG_A_FMT("LoadMemTSO: No offset allowed");
   }
 
   if (SupportsRCPC && Op->Class == FEXCore::IR::GPRClass) {
@@ -635,7 +643,7 @@ DEF_OP(LoadMemTSO) {
         case 8:
           ldapr(Dst, MemSrc);
           break;
-        default:  LOGMAN_MSG_A("Unhandled LoadMem size: %d", Op->Size);
+        default:  LOGMAN_MSG_A_FMT("Unhandled LoadMemTSO size: {}", Op->Size);
       }
       nop();
     }
@@ -660,7 +668,7 @@ DEF_OP(LoadMemTSO) {
         case 8:
           ldar(Dst, MemSrc);
           break;
-        default:  LOGMAN_MSG_A("Unhandled LoadMem size: %d", Op->Size);
+        default:  LOGMAN_MSG_A_FMT("Unhandled LoadMemTSO size: {}", Op->Size);
       }
       nop();
     }
@@ -681,7 +689,7 @@ DEF_OP(LoadMemTSO) {
       case 16:
         ldr(Dst, MemSrc);
         break;
-      default:  LOGMAN_MSG_A("Unhandled LoadMem size: %d", Op->Size);
+      default:  LOGMAN_MSG_A_FMT("Unhandled LoadMemTSO size: {}", Op->Size);
     }
     dmb(InnerShareable, BarrierAll);
   }
@@ -708,7 +716,7 @@ DEF_OP(StoreMem) {
       case 8:
         str(GetReg<RA_64>(Op->Header.Args[1].ID()), MemSrc);
         break;
-      default:  LOGMAN_MSG_A("Unhandled StoreMem size: %d", Op->Size);
+      default:  LOGMAN_MSG_A_FMT("Unhandled StoreMem size: {}", Op->Size);
     }
   }
   else {
@@ -729,7 +737,7 @@ DEF_OP(StoreMem) {
       case 16:
         str(Src, MemSrc);
         break;
-      default:  LOGMAN_MSG_A("Unhandled StoreMem size: %d", Op->Size);
+      default:  LOGMAN_MSG_A_FMT("Unhandled StoreMem size: {}", Op->Size);
     }
   }
 }
@@ -739,7 +747,7 @@ DEF_OP(StoreMemTSO) {
   auto MemSrc = MemOperand(GetReg<RA_64>(Op->Header.Args[0].ID()));
 
   if (!Op->Offset.IsInvalid()) {
-    LOGMAN_MSG_A("StoreMemTSO: No offset allowed");
+    LOGMAN_MSG_A_FMT("StoreMemTSO: No offset allowed");
   }
 
   if (Op->Class == FEXCore::IR::GPRClass) {
@@ -759,7 +767,7 @@ DEF_OP(StoreMemTSO) {
         case 8:
           stlr(GetReg<RA_64>(Op->Header.Args[1].ID()), MemSrc);
           break;
-        default:  LOGMAN_MSG_A("Unhandled StoreMem size: %d", Op->Size);
+        default:  LOGMAN_MSG_A_FMT("Unhandled StoreMemTSO size: {}", Op->Size);
       }
       nop();
     }
@@ -783,7 +791,7 @@ DEF_OP(StoreMemTSO) {
       case 16:
         str(Src, MemSrc);
         break;
-      default:  LOGMAN_MSG_A("Unhandled StoreMem size: %d", Op->Size);
+      default:  LOGMAN_MSG_A_FMT("Unhandled StoreMemTSO size: {}", Op->Size);
     }
     dmb(InnerShareable, BarrierAll);
   }
@@ -795,7 +803,7 @@ DEF_OP(ParanoidLoadMemTSO) {
   auto MemSrc = MemOperand(GetReg<RA_64>(Op->Header.Args[0].ID()));
 
   if (!Op->Offset.IsInvalid()) {
-    LOGMAN_MSG_A("LoadMemTSO: No offset allowed");
+    LOGMAN_MSG_A_FMT("ParanoidLoadMemTSO: No offset allowed");
   }
 
   if (Op->Class == FEXCore::IR::GPRClass) {
@@ -816,7 +824,7 @@ DEF_OP(ParanoidLoadMemTSO) {
         case 8:
           ldar(Dst, MemSrc);
           break;
-        default:  LOGMAN_MSG_A("Unhandled LoadMem size: %d", Op->Size);
+        default:  LOGMAN_MSG_A_FMT("Unhandled ParanoidLoadMemTSO size: {}", Op->Size);
       }
     }
   }
@@ -842,7 +850,7 @@ DEF_OP(ParanoidLoadMemTSO) {
         mov(Dst.V2D(), 0, TMP1);
         mov(Dst.V2D(), 1, TMP2);
         break;
-      default:  LOGMAN_MSG_A("Unhandled LoadMem size: %d", Op->Size);
+      default:  LOGMAN_MSG_A_FMT("Unhandled ParanoidLoadMemTSO size: {}", Op->Size);
     }
   }
 }
@@ -852,7 +860,7 @@ DEF_OP(ParanoidStoreMemTSO) {
   auto MemSrc = MemOperand(GetReg<RA_64>(Op->Header.Args[0].ID()));
 
   if (!Op->Offset.IsInvalid()) {
-    LOGMAN_MSG_A("StoreMemTSO: No offset allowed");
+    LOGMAN_MSG_A_FMT("ParanoidStoreMemTSO: No offset allowed");
   }
 
   if (Op->Class == FEXCore::IR::GPRClass) {
@@ -871,7 +879,7 @@ DEF_OP(ParanoidStoreMemTSO) {
         case 8:
           stlr(GetReg<RA_64>(Op->Header.Args[1].ID()), MemSrc);
           break;
-        default:  LOGMAN_MSG_A("Unhandled StoreMem size: %d", Op->Size);
+        default:  LOGMAN_MSG_A_FMT("Unhandled ParanoidStoreMemTSO size: {}", Op->Size);
       }
     }
   }
@@ -911,18 +919,18 @@ DEF_OP(ParanoidStoreMemTSO) {
           cbnz(TMP3, &B); // < Overwritten with DMB
           break;
         }
-        default:  LOGMAN_MSG_A("Unhandled StoreMem size: %d", Op->Size);
+        default:  LOGMAN_MSG_A_FMT("Unhandled ParanoidStoreMemTSO size: {}", Op->Size);
       }
     }
   }
 }
 
 DEF_OP(VLoadMemElement) {
-  LOGMAN_MSG_A("Unimplemented");
+  LOGMAN_MSG_A_FMT("Unimplemented");
 }
 
 DEF_OP(VStoreMemElement) {
-  LOGMAN_MSG_A("Unimplemented");
+  LOGMAN_MSG_A_FMT("Unimplemented");
 }
 
 DEF_OP(CacheLineClear) {

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
@@ -8,11 +8,11 @@ $end_info$
 
 namespace FEXCore::CPU {
 static void PrintValue(uint64_t Value) {
-  LogMan::Msg::D("Value: 0x%lx", Value);
+  LogMan::Msg::DFmt("Value: 0x{:x}", Value);
 }
 
 static void PrintVectorValue(uint64_t Value, uint64_t ValueUpper) {
-  LogMan::Msg::D("Value: 0x%016lx'%016lx", ValueUpper, Value);
+  LogMan::Msg::DFmt("Value: 0x{:016x}'{:016x}", ValueUpper, Value);
 }
 
 using namespace vixl;
@@ -31,7 +31,7 @@ DEF_OP(Fence) {
     case IR::Fence_Store.Val:
       dmb(FullSystem, BarrierWrites);
       break;
-    default: LOGMAN_MSG_A("Unknown Fence: %d", Op->Fence); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Fence: {}", Op->Fence); break;
   }
 }
 
@@ -69,7 +69,7 @@ DEF_OP(Break) {
       br(TMP1);
       break;
     }
-    default: LOGMAN_MSG_A("Unknown Break reason: %d", Op->Reason);
+    default: LOGMAN_MSG_A_FMT("Unknown Break reason: {}", Op->Reason);
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MoveOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MoveOps.cpp
@@ -26,7 +26,7 @@ DEF_OP(ExtractElementPair) {
       mov (GetReg<RA_64>(Node), Regs[Op->Element]);
       break;
     }
-    default: LOGMAN_MSG_A("Unknown Size"); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Size"); break;
   }
 }
 
@@ -52,7 +52,7 @@ DEF_OP(CreateElementPair) {
       RegTmp = x0;
       break;
     }
-    default: LOGMAN_MSG_A("Unknown Size"); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Size"); break;
   }
 
   if (Dst.first.GetCode() != RegSecond.GetCode()) {

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -22,7 +22,7 @@ DEF_OP(VectorZero) {
        eor(GetDst(Node).V16B(), GetDst(Node).V16B(), GetDst(Node).V16B());
        break;
      }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", OpSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", OpSize); break;
   }
 }
 
@@ -43,47 +43,47 @@ DEF_OP(VectorImm) {
 }
 
 DEF_OP(CreateVector2) {
-  LOGMAN_MSG_A("Unimplemented");
+  LOGMAN_MSG_A_FMT("Unimplemented");
 }
 
 DEF_OP(CreateVector4) {
-  LOGMAN_MSG_A("Unimplemented");
+  LOGMAN_MSG_A_FMT("Unimplemented");
 }
 
 DEF_OP(SplatVector2) {
-	auto Op = IROp->C<IR::IROp_SplatVector2>();
+  auto Op = IROp->C<IR::IROp_SplatVector2>();
   uint8_t OpSize = IROp->Size;
-	LOGMAN_THROW_A(OpSize <= 16, "Can't handle a vector of size: %d", OpSize);
+  LOGMAN_THROW_A_FMT(OpSize <= 16, "Can't handle a vector of size: {}", OpSize);
 
-	uint8_t ElementSize = OpSize / 2;
+  uint8_t ElementSize = OpSize / 2;
 
-	switch (ElementSize) {
-		case 4:
-			dup(GetDst(Node).V4S(), GetSrc(Op->Header.Args[0].ID()).V4S(), 0);
-		break;
-		case 8:
-			dup(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), 0);
-		break;
-		default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.Size); break;
-	}
+  switch (ElementSize) {
+    case 4:
+      dup(GetDst(Node).V4S(), GetSrc(Op->Header.Args[0].ID()).V4S(), 0);
+    break;
+    case 8:
+      dup(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), 0);
+    break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.Size); break;
+  }
 }
 
 DEF_OP(SplatVector4) {
-	auto Op = IROp->C<IR::IROp_SplatVector4>();
+  auto Op = IROp->C<IR::IROp_SplatVector4>();
   uint8_t OpSize = IROp->Size;
-	LOGMAN_THROW_A(OpSize <= 16, "Can't handle a vector of size: %d", OpSize);
+  LOGMAN_THROW_A_FMT(OpSize <= 16, "Can't handle a vector of size: {}", OpSize);
 
-	uint8_t ElementSize = OpSize / 4;
+  uint8_t ElementSize = OpSize / 4;
 
-	switch (ElementSize) {
-		case 4:
-			dup(GetDst(Node).V4S(), GetSrc(Op->Header.Args[0].ID()).V4S(), 0);
-		break;
-		case 8:
-			dup(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), 0);
-		break;
-		default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.Size); break;
-	}
+  switch (ElementSize) {
+    case 4:
+      dup(GetDst(Node).V4S(), GetSrc(Op->Header.Args[0].ID()).V4S(), 0);
+    break;
+    case 8:
+      dup(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), 0);
+    break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.Size); break;
+  }
 }
 
 DEF_OP(VMov) {
@@ -118,7 +118,7 @@ DEF_OP(VMov) {
 			  mov(GetDst(Node).V16B(), GetSrc(Op->Header.Args[0].ID()).V16B());
 			break;
 		}
-		default: LOGMAN_MSG_A("Unknown Element Size: %d", OpSize); break;
+		default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", OpSize); break;
 	}
 }
 
@@ -161,7 +161,7 @@ DEF_OP(VAdd) {
       add(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
     break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -184,7 +184,7 @@ DEF_OP(VSub) {
       sub(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
     break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -207,7 +207,7 @@ DEF_OP(VUQAdd) {
       uqadd(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
     break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -230,7 +230,7 @@ DEF_OP(VUQSub) {
       uqsub(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
     break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -253,7 +253,7 @@ DEF_OP(VSQAdd) {
       sqadd(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
     break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -276,7 +276,7 @@ DEF_OP(VSQSub) {
       sqsub(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
     break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -298,7 +298,7 @@ DEF_OP(VAddP) {
         addp(GetDst(Node).V2S(), GetSrc(Op->Header.Args[0].ID()).V2S(), GetSrc(Op->Header.Args[1].ID()).V2S());
         break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -319,7 +319,7 @@ DEF_OP(VAddP) {
         addp(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
         break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
 }
@@ -338,7 +338,7 @@ DEF_OP(VAddV) {
     case 8:
       addp(GetDst(Node).VCast(OpSize * 8, 1), GetSrc(Op->Header.Args[0].ID()).VCast(OpSize * 8, Elements));
       break;
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -353,7 +353,7 @@ DEF_OP(VUMinV) {
     case 4:
       uminv(GetDst(Node).VCast(Op->Header.ElementSize * 8, 1), GetSrc(Op->Header.Args[0].ID()).VCast(OpSize * 8, Elements));
       break;
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -368,7 +368,7 @@ DEF_OP(VURAvg) {
       urhadd(GetDst(Node).V8H(), GetSrc(Op->Header.Args[0].ID()).V8H(), GetSrc(Op->Header.Args[1].ID()).V8H());
     break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -383,7 +383,7 @@ DEF_OP(VAbs) {
         abs(GetDst(Node).D(), GetSrc(Op->Header.Args[0].ID()).D());
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -395,7 +395,7 @@ DEF_OP(VAbs) {
       case 8:
         abs(GetDst(Node).VCast(OpSize * 8, Elements), GetSrc(Op->Header.Args[0].ID()).VCast(OpSize * 8, Elements));
         break;
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
 }
@@ -410,7 +410,7 @@ DEF_OP(VPopcount) {
         cnt(GetDst(Node).V8B(), GetSrc(Op->Header.Args[0].ID()).V8B());
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -419,7 +419,7 @@ DEF_OP(VPopcount) {
       case 1:
         cnt(GetDst(Node).V16B(), GetSrc(Op->Header.Args[0].ID()).V16B());
         break;
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
 }
@@ -438,7 +438,7 @@ DEF_OP(VFAdd) {
         fadd(GetDst(Node).D(), GetSrc(Op->Header.Args[0].ID()).D(), GetSrc(Op->Header.Args[1].ID()).D());
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -452,7 +452,7 @@ DEF_OP(VFAdd) {
         fadd(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
 }
@@ -468,7 +468,7 @@ DEF_OP(VFAddP) {
       faddp(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
     break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -486,7 +486,7 @@ DEF_OP(VFSub) {
         fsub(GetDst(Node).D(), GetSrc(Op->Header.Args[0].ID()).D(), GetSrc(Op->Header.Args[1].ID()).D());
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -500,7 +500,7 @@ DEF_OP(VFSub) {
         fsub(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
 }
@@ -519,7 +519,7 @@ DEF_OP(VFMul) {
         fmul(GetDst(Node).D(), GetSrc(Op->Header.Args[0].ID()).D(), GetSrc(Op->Header.Args[1].ID()).D());
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -533,7 +533,7 @@ DEF_OP(VFMul) {
         fmul(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
 }
@@ -552,7 +552,7 @@ DEF_OP(VFDiv) {
         fdiv(GetDst(Node).D(), GetSrc(Op->Header.Args[0].ID()).D(), GetSrc(Op->Header.Args[1].ID()).D());
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -566,7 +566,7 @@ DEF_OP(VFDiv) {
         fdiv(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
 }
@@ -587,7 +587,7 @@ DEF_OP(VFMin) {
         fcsel(GetDst(Node).D(), GetSrc(Op->Header.Args[0].ID()).D(), GetSrc(Op->Header.Args[1].ID()).D(), Condition::mi);
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -607,7 +607,7 @@ DEF_OP(VFMin) {
         mov(GetDst(Node).V2D(), VTMP2.V2D());
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
 }
@@ -628,7 +628,7 @@ DEF_OP(VFMax) {
         fcsel(GetDst(Node).D(), GetSrc(Op->Header.Args[1].ID()).D(), GetSrc(Op->Header.Args[0].ID()).D(), Condition::mi);
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -648,7 +648,7 @@ DEF_OP(VFMax) {
         mov(GetDst(Node).V2D(), VTMP2.V2D());
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
 }
@@ -669,7 +669,7 @@ DEF_OP(VFRecp) {
         fdiv(GetDst(Node).D(), VTMP1.D(), GetSrc(Op->Header.Args[0].ID()).D());
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -685,7 +685,7 @@ DEF_OP(VFRecp) {
         fdiv(GetDst(Node).V2D(), VTMP1.V2D(), GetSrc(Op->Header.Args[0].ID()).V2D());
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
 }
@@ -704,7 +704,7 @@ DEF_OP(VFSqrt) {
         fsqrt(GetDst(Node).D(), GetSrc(Op->Header.Args[0].ID()).D());
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -718,7 +718,7 @@ DEF_OP(VFSqrt) {
         fsqrt(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D());
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
 }
@@ -741,7 +741,7 @@ DEF_OP(VFRSqrt) {
         fdiv(GetDst(Node).D(), VTMP1.D(), VTMP2.D());
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -759,7 +759,7 @@ DEF_OP(VFRSqrt) {
         fdiv(GetDst(Node).V2D(), VTMP1.V2D(), VTMP2.V2D());
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
 }
@@ -779,7 +779,7 @@ DEF_OP(VNeg) {
   case 8:
     neg(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D());
     break;
-  default: LOGMAN_MSG_A("Unsupported Not size: %d", IROp->Size);
+  default: LOGMAN_MSG_A_FMT("Unsupported VNeg size: {}", IROp->Size);
   }
 }
 
@@ -792,7 +792,7 @@ DEF_OP(VFNeg) {
   case 8:
     fneg(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D());
     break;
-  default: LOGMAN_MSG_A("Unsupported Not size: %d", IROp->Size);
+  default: LOGMAN_MSG_A_FMT("Unsupported VFNeg size: {}", IROp->Size);
   }
 }
 
@@ -823,7 +823,7 @@ DEF_OP(VUMin) {
       mov(GetDst(Node).V2D(), VTMP2.V2D());
     break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -849,7 +849,7 @@ DEF_OP(VSMin) {
       mov(GetDst(Node).V2D(), VTMP2.V2D());
     break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -875,7 +875,7 @@ DEF_OP(VUMax) {
       mov(GetDst(Node).V2D(), VTMP2.V2D());
     break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -901,7 +901,7 @@ DEF_OP(VSMax) {
       mov(GetDst(Node).V2D(), VTMP2.V2D());
     break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -922,7 +922,7 @@ DEF_OP(VZip) {
         zip1(GetDst(Node).V2S(), GetSrc(Op->Header.Args[0].ID()).V2S(), GetSrc(Op->Header.Args[1].ID()).V2S());
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -943,7 +943,7 @@ DEF_OP(VZip) {
         zip1(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
 }
@@ -965,7 +965,7 @@ DEF_OP(VZip2) {
       zip2(GetDst(Node).V2S(), GetSrc(Op->Header.Args[0].ID()).V2S(), GetSrc(Op->Header.Args[1].ID()).V2S());
     break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -986,7 +986,7 @@ DEF_OP(VZip2) {
       zip2(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
     break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
 }
@@ -1008,7 +1008,7 @@ DEF_OP(VUnZip) {
         uzp1(GetDst(Node).V2S(), GetSrc(Op->Header.Args[0].ID()).V2S(), GetSrc(Op->Header.Args[1].ID()).V2S());
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -1029,7 +1029,7 @@ DEF_OP(VUnZip) {
         uzp1(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
 }
@@ -1051,7 +1051,7 @@ DEF_OP(VUnZip2) {
       uzp2(GetDst(Node).V2S(), GetSrc(Op->Header.Args[0].ID()).V2S(), GetSrc(Op->Header.Args[1].ID()).V2S());
     break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -1072,7 +1072,7 @@ DEF_OP(VUnZip2) {
       uzp2(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
     break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
 }
@@ -1105,7 +1105,7 @@ DEF_OP(VCMPEQ) {
         cmeq(GetDst(Node).D(), GetSrc(Op->Header.Args[0].ID()).D(), GetSrc(Op->Header.Args[1].ID()).D());
       break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -1127,7 +1127,7 @@ DEF_OP(VCMPEQ) {
         cmeq(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
       break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
 }
@@ -1146,7 +1146,7 @@ DEF_OP(VCMPEQZ) {
         cmeq(GetDst(Node).D(), GetSrc(Op->Header.Args[0].ID()).D(), 0);
       break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -1168,7 +1168,7 @@ DEF_OP(VCMPEQZ) {
         cmeq(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), 0);
       break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
 }
@@ -1187,7 +1187,7 @@ DEF_OP(VCMPGT) {
         cmgt(GetDst(Node).D(), GetSrc(Op->Header.Args[0].ID()).D(), GetSrc(Op->Header.Args[1].ID()).D());
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -1209,7 +1209,7 @@ DEF_OP(VCMPGT) {
         cmgt(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
 }
@@ -1228,7 +1228,7 @@ DEF_OP(VCMPGTZ) {
         cmgt(GetDst(Node).D(), GetSrc(Op->Header.Args[0].ID()).D(), 0);
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -1250,7 +1250,7 @@ DEF_OP(VCMPGTZ) {
         cmgt(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), 0);
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
 }
@@ -1269,7 +1269,7 @@ DEF_OP(VCMPLTZ) {
         cmlt(GetDst(Node).D(), GetSrc(Op->Header.Args[0].ID()).D(), 0);
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -1291,7 +1291,7 @@ DEF_OP(VCMPLTZ) {
         cmlt(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), 0);
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
 }
@@ -1310,7 +1310,7 @@ DEF_OP(VFCMPEQ) {
         fcmeq(GetDst(Node).D(), GetSrc(Op->Header.Args[0].ID()).D(), GetSrc(Op->Header.Args[1].ID()).D());
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -1328,7 +1328,7 @@ DEF_OP(VFCMPEQ) {
         fcmeq(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
 }
@@ -1347,7 +1347,7 @@ DEF_OP(VFCMPNEQ) {
         fcmeq(GetDst(Node).D(), GetSrc(Op->Header.Args[0].ID()).D(), GetSrc(Op->Header.Args[1].ID()).D());
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
     mvn(GetDst(Node).V8B(), GetDst(Node).V8B());
   }
@@ -1366,7 +1366,7 @@ DEF_OP(VFCMPNEQ) {
         fcmeq(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
     mvn(GetDst(Node).V16B(), GetDst(Node).V16B());
   }
@@ -1386,7 +1386,7 @@ DEF_OP(VFCMPLT) {
         fcmgt(GetDst(Node).D(), GetSrc(Op->Header.Args[1].ID()).D(), GetSrc(Op->Header.Args[0].ID()).D());
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -1404,7 +1404,7 @@ DEF_OP(VFCMPLT) {
         fcmgt(GetDst(Node).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D());
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
 }
@@ -1423,7 +1423,7 @@ DEF_OP(VFCMPGT) {
         fcmgt(GetDst(Node).D(), GetSrc(Op->Header.Args[0].ID()).D(), GetSrc(Op->Header.Args[1].ID()).D());
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -1441,7 +1441,7 @@ DEF_OP(VFCMPGT) {
         fcmgt(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
 }
@@ -1460,7 +1460,7 @@ DEF_OP(VFCMPLE) {
         fcmge(GetDst(Node).D(), GetSrc(Op->Header.Args[1].ID()).D(), GetSrc(Op->Header.Args[0].ID()).D());
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -1478,7 +1478,7 @@ DEF_OP(VFCMPLE) {
         fcmge(GetDst(Node).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D());
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
 }
@@ -1501,7 +1501,7 @@ DEF_OP(VFCMPORD) {
         orr(GetDst(Node).V8B(), VTMP1.V8B(), VTMP2.V8B());
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -1525,7 +1525,7 @@ DEF_OP(VFCMPORD) {
         orr(GetDst(Node).V16B(), VTMP1.V16B(), VTMP2.V16B());
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
 }
@@ -1550,7 +1550,7 @@ DEF_OP(VFCMPUNO) {
         mvn(GetDst(Node).V8B(), GetDst(Node).V8B());
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -1577,21 +1577,21 @@ DEF_OP(VFCMPUNO) {
         mvn(GetDst(Node).V16B(), GetDst(Node).V16B());
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
 }
 
 DEF_OP(VUShl) {
-  LOGMAN_MSG_A("Unimplemented");
+  LOGMAN_MSG_A_FMT("Unimplemented");
 }
 
 DEF_OP(VUShr) {
-  LOGMAN_MSG_A("Unimplemented");
+  LOGMAN_MSG_A_FMT("Unimplemented");
 }
 
 DEF_OP(VSShr) {
-  LOGMAN_MSG_A("Unimplemented");
+  LOGMAN_MSG_A_FMT("Unimplemented");
 }
 
 DEF_OP(VUShlS) {
@@ -1618,7 +1618,7 @@ DEF_OP(VUShlS) {
       ushl(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), VTMP1.V2D());
     break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -1650,7 +1650,7 @@ DEF_OP(VUShrS) {
       ushl(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), VTMP1.V2D());
     break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -1682,7 +1682,7 @@ DEF_OP(VSShrS) {
       sshl(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), VTMP1.V2D());
     break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -1713,7 +1713,7 @@ DEF_OP(VInsElement) {
       mov(reg.V2D(), Op->DestIdx, GetSrc(Op->Header.Args[1].ID()).V2D(), Op->SrcIdx);
     break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 
   if (GetDst(Node).GetCode() != reg.GetCode()) {
@@ -1748,7 +1748,7 @@ DEF_OP(VInsScalarElement) {
       mov(reg.V2D(), Op->DestIdx, GetSrc(Op->Header.Args[1].ID()).V2D(), 0);
     break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 
   if (GetDst(Node).GetCode() != reg.GetCode()) {
@@ -1772,7 +1772,7 @@ DEF_OP(VExtractElement) {
     case 8:
       mov(GetDst(Node).D(), GetSrc(Op->Header.Args[0].ID()).V2D(), Op->Index);
     break;
-    default:  LOGMAN_MSG_A("Unhandled ExtractElementSize: %d", OpSize);
+    default:  LOGMAN_MSG_A_FMT("Unhandled VExtractElement element size: {}", OpSize);
   }
 }
 
@@ -1791,7 +1791,7 @@ DEF_OP(VDupElement) {
     case 8:
       dup(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), Op->Index);
     break;
-    default:  LOGMAN_MSG_A("Unhandled DupElementSize: %d", Op->Header.ElementSize);
+    default:  LOGMAN_MSG_A_FMT("Unhandled VDupElement element size: {}", Op->Header.ElementSize);
   }
 }
 
@@ -1906,7 +1906,7 @@ DEF_OP(VUShrI) {
         ushr(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), Op->BitShift);
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
 }
@@ -1931,7 +1931,7 @@ DEF_OP(VSShrI) {
       sshr(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), std::min((uint8_t)(Op->Header.ElementSize * 8 - 1), Op->BitShift));
     break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -1959,7 +1959,7 @@ DEF_OP(VShlI) {
         shl(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), Op->BitShift);
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
 }
@@ -1980,7 +1980,7 @@ DEF_OP(VUShrNI) {
       shrn(GetDst(Node).V2S(), GetSrc(Op->Header.Args[0].ID()).V2D(), Op->BitShift);
     break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -2000,7 +2000,7 @@ DEF_OP(VUShrNI2) {
       shrn2(VTMP1.V4S(), GetSrc(Op->Header.Args[1].ID()).V2D(), Op->BitShift);
     break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 
   mov(GetDst(Node), VTMP1);
@@ -2023,7 +2023,7 @@ DEF_OP(VSXTL) {
     case 8:
       sxtl(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2S());
     break;
-    default: LOGMAN_MSG_A("Unknown element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize);
   }
 }
 
@@ -2039,7 +2039,7 @@ DEF_OP(VSXTL2) {
     case 8:
       sxtl2(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V4S());
     break;
-    default: LOGMAN_MSG_A("Unknown element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize);
   }
 }
 
@@ -2055,7 +2055,7 @@ DEF_OP(VUXTL) {
     case 8:
       uxtl(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2S());
     break;
-    default: LOGMAN_MSG_A("Unknown element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize);
   }
 }
 
@@ -2071,7 +2071,7 @@ DEF_OP(VUXTL2) {
     case 8:
       uxtl2(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V4S());
     break;
-    default: LOGMAN_MSG_A("Unknown element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize);
   }
 }
 
@@ -2087,7 +2087,7 @@ DEF_OP(VSQXTN) {
     case 4:
       sqxtn(GetDst(Node).V2S(), GetSrc(Op->Header.Args[0].ID()).V2D());
     break;
-    default: LOGMAN_MSG_A("Unknown element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize);
   }
 }
 
@@ -2109,7 +2109,7 @@ DEF_OP(VSQXTN2) {
         sqxtn(VTMP2.V2S(), GetSrc(Op->Header.Args[1].ID()).V2D());
         ins(VTMP1.V4S(), 1, VTMP2.V4S(), 0);
       break;
-      default: LOGMAN_MSG_A("Unknown element size: %d", Op->Header.ElementSize);
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize);
     }
   }
   else {
@@ -2123,7 +2123,7 @@ DEF_OP(VSQXTN2) {
       case 4:
         sqxtn2(VTMP1.V4S(), GetSrc(Op->Header.Args[1].ID()).V2D());
       break;
-      default: LOGMAN_MSG_A("Unknown element size: %d", Op->Header.ElementSize);
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize);
     }
   }
   mov(GetDst(Node), VTMP1);
@@ -2141,7 +2141,7 @@ DEF_OP(VSQXTUN) {
     case 4:
       sqxtun(GetDst(Node).V2S(), GetSrc(Op->Header.Args[0].ID()).V2D());
     break;
-    default: LOGMAN_MSG_A("Unknown element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize);
   }
 }
 
@@ -2163,7 +2163,7 @@ DEF_OP(VSQXTUN2) {
         sqxtun(VTMP2.V2S(), GetSrc(Op->Header.Args[1].ID()).V2D());
         ins(VTMP1.V4S(), 1, VTMP2.V4S(), 0);
       break;
-      default: LOGMAN_MSG_A("Unknown element size: %d", Op->Header.ElementSize);
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize);
     }
   }
   else {
@@ -2177,7 +2177,7 @@ DEF_OP(VSQXTUN2) {
       case 4:
         sqxtun2(VTMP1.V4S(), GetSrc(Op->Header.Args[1].ID()).V2D());
       break;
-      default: LOGMAN_MSG_A("Unknown element size: %d", Op->Header.ElementSize);
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize);
     }
   }
   mov(GetDst(Node), VTMP1);
@@ -2202,7 +2202,7 @@ DEF_OP(VMul) {
       mul(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2D(), GetSrc(Op->Header.Args[1].ID()).V2D());
     break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -2221,7 +2221,7 @@ DEF_OP(VUMull) {
       umull(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2S(), GetSrc(Op->Header.Args[1].ID()).V2S());
     break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize >> 1); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize >> 1); break;
   }
 }
 
@@ -2240,7 +2240,7 @@ DEF_OP(VSMull) {
       smull(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2S(), GetSrc(Op->Header.Args[1].ID()).V2S());
     break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize >> 1); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize >> 1); break;
   }
 }
 
@@ -2259,7 +2259,7 @@ DEF_OP(VUMull2) {
       umull2(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V4S(), GetSrc(Op->Header.Args[1].ID()).V4S());
     break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize >> 1); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize >> 1); break;
   }
 }
 
@@ -2278,7 +2278,7 @@ DEF_OP(VSMull2) {
       smull2(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V4S(), GetSrc(Op->Header.Args[1].ID()).V4S());
     break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize >> 1); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize >> 1); break;
   }
 }
 
@@ -2297,7 +2297,7 @@ DEF_OP(VUABDL) {
       uabdl(GetDst(Node).V2D(), GetSrc(Op->Header.Args[0].ID()).V2S(), GetSrc(Op->Header.Args[1].ID()).V2S());
     break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize >> 1); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize >> 1); break;
   }
 }
 
@@ -2314,7 +2314,7 @@ DEF_OP(VTBL1) {
       tbl(GetDst(Node).V16B(), GetSrc(Op->Header.Args[0].ID()).V16B(), GetSrc(Op->Header.Args[1].ID()).V16B());
     break;
     }
-    default: LOGMAN_MSG_A("Unknown OpSize: %d", OpSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown OpSize: {}", OpSize); break;
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/ALUOps.cpp
@@ -20,7 +20,7 @@ DEF_OP(TruncElementPair) {
       mov(Dst.second, Src.second);
       break;
     }
-    default: LOGMAN_MSG_A("Unhandled Truncation size: %d", Op->Size); break;
+    default: LOGMAN_MSG_A_FMT("Unhandled Truncation size: {}", Op->Size); break;
   }
 }
 
@@ -70,7 +70,7 @@ DEF_OP(Add) {
     case 8:
       add(rax, Const);
       break;
-    default:  LOGMAN_MSG_A("Unhandled Add size: %d", OpSize);
+    default:  LOGMAN_MSG_A_FMT("Unhandled Add size: {}", OpSize);
       break;
     }
   } else {
@@ -81,7 +81,7 @@ DEF_OP(Add) {
     case 8:
       add(rax, GetSrc<RA_64>(Op->Header.Args[1].ID()));
       break;
-    default:  LOGMAN_MSG_A("Unhandled Add size: %d", OpSize);
+    default:  LOGMAN_MSG_A_FMT("Unhandled Add size: {}", OpSize);
       break;
     }
   }
@@ -103,7 +103,7 @@ DEF_OP(Sub) {
     case 8:
       sub(rax, Const);
       break;
-    default:  LOGMAN_MSG_A("Unhandled Sub size: %d", OpSize);
+    default:  LOGMAN_MSG_A_FMT("Unhandled Sub size: {}", OpSize);
       break;
     }
   } else {
@@ -114,7 +114,7 @@ DEF_OP(Sub) {
     case 8:
       sub(rax, GetSrc<RA_64>(Op->Header.Args[1].ID()));
       break;
-    default:  LOGMAN_MSG_A("Unhandled Sub size: %d", OpSize);
+    default:  LOGMAN_MSG_A_FMT("Unhandled Sub size: {}", OpSize);
       break;
     }
   }
@@ -136,7 +136,7 @@ DEF_OP(Neg) {
     Src = GetSrc<RA_64>(Op->Header.Args[0].ID());
     Dst = GetDst<RA_64>(Node);
     break;
-  default:  LOGMAN_MSG_A("Unhandled Neg size: %d", OpSize);
+  default:  LOGMAN_MSG_A_FMT("Unhandled Neg size: {}", OpSize);
     break;
   }
   mov(Dst, Src);
@@ -160,7 +160,7 @@ DEF_OP(Mul) {
     imul(rax, GetSrc<RA_64>(Op->Header.Args[1].ID()));
     mov(Dst, rax);
   break;
-  default: LOGMAN_MSG_A("Unknown Sext size: %d", OpSize);
+  default: LOGMAN_MSG_A_FMT("Unknown Mul size: {}", OpSize);
   }
 }
 
@@ -179,7 +179,7 @@ DEF_OP(UMul) {
     mul(GetSrc<RA_64>(Op->Header.Args[1].ID()));
     mov(GetDst<RA_64>(Node), rax);
   break;
-  default: LOGMAN_MSG_A("Unknown Sext size: %d", OpSize);
+  default: LOGMAN_MSG_A_FMT("Unknown UMul size: {}", OpSize);
   }
 }
 
@@ -218,7 +218,7 @@ DEF_OP(Div) {
     mov(GetDst<RA_64>(Node), rax);
   break;
   }
-  default: LOGMAN_MSG_A("Unknown UDIV Size: %d", Size); break;
+  default: LOGMAN_MSG_A_FMT("Unknown DIV Size: {}", Size); break;
   }
 }
 
@@ -261,7 +261,7 @@ DEF_OP(UDiv) {
     mov(GetDst<RA_64>(Node), rax);
   break;
   }
-  default: LOGMAN_MSG_A("Unknown UDIV OpSize: %d", OpSize); break;
+  default: LOGMAN_MSG_A_FMT("Unknown UDIV OpSize: {}", OpSize); break;
   }
 }
 
@@ -298,7 +298,7 @@ DEF_OP(Rem) {
     mov(GetDst<RA_64>(Node), rdx);
   break;
   }
-  default: LOGMAN_MSG_A("Unknown UDIV Size: %d", OpSize); break;
+  default: LOGMAN_MSG_A_FMT("Unknown Rem Size: {}", OpSize); break;
   }
 }
 
@@ -341,7 +341,7 @@ DEF_OP(URem) {
     mov(GetDst<RA_64>(Node), rdx);
   break;
   }
-  default: LOGMAN_MSG_A("Unknown UDIV OpSize: %d", OpSize); break;
+  default: LOGMAN_MSG_A_FMT("Unknown URem OpSize: {}", OpSize); break;
   }
 }
 
@@ -360,7 +360,7 @@ DEF_OP(MulH) {
     imul(GetSrc<RA_64>(Op->Header.Args[1].ID()));
     mov(GetDst<RA_64>(Node), rdx);
   break;
-  default: LOGMAN_MSG_A("Unknown Sext size: %d", OpSize);
+  default: LOGMAN_MSG_A_FMT("Unknown MulH size: {}", OpSize);
   }
 }
 
@@ -379,7 +379,7 @@ DEF_OP(UMulH) {
     mul(GetSrc<RA_64>(Op->Header.Args[1].ID()));
     mov(GetDst<RA_64>(Node), rdx);
   break;
-  default: LOGMAN_MSG_A("Unknown Sext size: %d", OpSize);
+  default: LOGMAN_MSG_A_FMT("Unknown UMulH size: {}", OpSize);
   }
 }
 
@@ -441,7 +441,7 @@ DEF_OP(Lshl) {
         mov(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()));
         shl(GetDst<RA_64>(Node), Const);
         break;
-      default: LOGMAN_MSG_A("Unknown LSHL Size: %d\n", OpSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown LSHL Size: {}\n", OpSize); break;
     };
   } else {
     mov(rcx, GetSrc<RA_64>(Op->Header.Args[1].ID()));
@@ -456,7 +456,7 @@ DEF_OP(Lshl) {
         mov(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()));
         shl(GetDst<RA_64>(Node), cl);
         break;
-      default: LOGMAN_MSG_A("Unknown LSHL Size: %d\n", OpSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown LSHL Size: {}\n", OpSize); break;
     };
   }
 }
@@ -488,7 +488,7 @@ DEF_OP(Lshr) {
         mov(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()));
         shr(GetDst<RA_64>(Node), Const);
         break;
-      default: LOGMAN_MSG_A("Unknown Size: %d\n", OpSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Size: {}\n", OpSize); break;
     };
 
   } else {
@@ -512,7 +512,7 @@ DEF_OP(Lshr) {
         mov(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()));
         shr(GetDst<RA_64>(Node), cl);
         break;
-      default: LOGMAN_MSG_A("Unknown Size: %d\n", OpSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Size: {}\n", OpSize); break;
     };
   }
 }
@@ -546,7 +546,7 @@ DEF_OP(Ashr) {
       mov(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()));
       sar(GetDst<RA_64>(Node), Const);
     break;
-    default: LOGMAN_MSG_A("Unknown ASHR Size: %d\n", OpSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown ASHR Size: {}\n", OpSize); break;
     };
 
   } else {
@@ -571,7 +571,7 @@ DEF_OP(Ashr) {
       mov(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()));
       sar(GetDst<RA_64>(Node), cl);
     break;
-    default: LOGMAN_MSG_A("Unknown ASHR Size: %d\n", OpSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown ASHR Size: {}\n", OpSize); break;
     };
   }
 }
@@ -596,7 +596,7 @@ DEF_OP(Ror) {
         ror(rax, Const);
       break;
       }
-      default: LOGMAN_MSG_A("Unknown ROR Size: %d\n", OpSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown ROR Size: {}\n", OpSize); break;
     }
   } else {
     mov (rcx, GetSrc<RA_64>(Op->Header.Args[1].ID()));
@@ -612,7 +612,7 @@ DEF_OP(Ror) {
         ror(rax, cl);
       break;
       }
-      default: LOGMAN_MSG_A("Unknown ROR Size: %d\n", OpSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown ROR Size: {}\n", OpSize); break;
     }
   }
   mov(GetDst<RA_64>(Node), rax);
@@ -668,7 +668,7 @@ DEF_OP(LDiv) {
       mov(GetDst<RA_64>(Node), rax);
       break;
     }
-    default: LOGMAN_MSG_A("Unknown LDIV OpSize: %d", OpSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown LDIV OpSize: {}", OpSize); break;
   }
 }
 
@@ -700,7 +700,7 @@ DEF_OP(LUDiv) {
       mov(GetDst<RA_64>(Node), rax);
       break;
     }
-    default: LOGMAN_MSG_A("Unknown LUDIV OpSize: %d", OpSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown LUDIV OpSize: {}", OpSize); break;
   }
 }
 
@@ -732,7 +732,7 @@ DEF_OP(LRem) {
       mov(GetDst<RA_64>(Node), rdx);
       break;
     }
-    default: LOGMAN_MSG_A("Unknown LREM OpSize: %d", OpSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown LREM OpSize: {}", OpSize); break;
   }
 }
 
@@ -764,7 +764,7 @@ DEF_OP(LURem) {
       mov(GetDst<RA_64>(Node), rdx);
       break;
     }
-    default: LOGMAN_MSG_A("Unknown LUDIV OpSize: %d", OpSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown LUREM OpSize: {}", OpSize); break;
   }
 }
 
@@ -829,7 +829,7 @@ DEF_OP(FindMSB) {
     case 8:
       bsr(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()));
       break;
-    default: LOGMAN_MSG_A("Unknown OpSize: %d", OpSize);
+    default: LOGMAN_MSG_A_FMT("Unknown FindMSB OpSize: {}", OpSize);
   }
 }
 
@@ -853,7 +853,7 @@ DEF_OP(FindTrailingZeros) {
       mov(rax, 0x40);
       cmovz(GetDst<RA_64>(Node), rax);
       break;
-    default: LOGMAN_MSG_A("Unknown size: %d", OpSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown FindTrailingZeros size: {}", OpSize); break;
   }
 }
 
@@ -876,7 +876,7 @@ DEF_OP(CountLeadingZeroes) {
         lzcnt(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()));
         break;
       }
-      default: LOGMAN_MSG_A("Unknown size: %d", OpSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown CountLeadingZeros size: {}", OpSize); break;
     }
   }
   else {
@@ -915,7 +915,7 @@ DEF_OP(CountLeadingZeroes) {
         mov(GetDst<RA_64>(Node), rax);
         break;
       }
-      default: LOGMAN_MSG_A("Unknown size: %d", OpSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown CountLeadingZeros size: {}", OpSize); break;
     }
   }
 }
@@ -937,7 +937,7 @@ DEF_OP(Rev) {
       mov (GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()));
       bswap(GetDst<RA_64>(Node).cvt64());
       break;
-    default: LOGMAN_MSG_A("Unknown REV size: %d", OpSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown REV size: {}", OpSize); break;
   }
 }
 
@@ -970,7 +970,7 @@ DEF_OP(Bfi) {
 
 DEF_OP(Bfe) {
   auto Op = IROp->C<IR::IROp_Bfe>();
-  LOGMAN_THROW_A(IROp->Size <= 8, "OpSize is too large for BFE: %d", IROp->Size);
+  LOGMAN_THROW_A_FMT(IROp->Size <= 8, "OpSize is too large for BFE: {}", IROp->Size);
 
   auto Dst = GetDst<RA_64>(Node);
 
@@ -1071,7 +1071,7 @@ DEF_OP(Select) {
 
   if (is_const_true || is_const_false) {
     if (is_const_false != true || is_const_true != true || const_true != 1 || const_false != 0) {
-      LOGMAN_MSG_A("Select: Unsupported compare inline parameters");
+      LOGMAN_MSG_A_FMT("Select: Unsupported compare inline parameters");
     }
     (this->*SetCC)(al);
     movzx(Dst, al);
@@ -1102,7 +1102,7 @@ DEF_OP(VExtractToGPR) {
       pextrq(GetDst<RA_64>(Node), GetSrc(Op->Header.Args[0].ID()), Op->Idx);
     break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/AtomicOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/AtomicOps.cpp
@@ -55,7 +55,7 @@ DEF_OP(CASPair) {
       mov(Dst.second, rdx);
     break;
     }
-    default: LOGMAN_MSG_A("Unsupported: %d", OpSize);
+    default: LOGMAN_MSG_A_FMT("Unsupported: {}", OpSize);
   }
 }
 
@@ -104,7 +104,7 @@ DEF_OP(CAS) {
     mov (GetDst<RA_64>(Node), rax);
   break;
   }
-  default: LOGMAN_MSG_A("Unsupported: %d", OpSize);
+  default: LOGMAN_MSG_A_FMT("Unsupported: {}", OpSize);
   }
 }
 
@@ -127,7 +127,7 @@ DEF_OP(AtomicAdd) {
     case 8:
       add(qword [MemReg], GetSrc<RA_64>(Op->Header.Args[1].ID()));
       break;
-    default:  LOGMAN_MSG_A("Unhandled AtomicAdd size: %d", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled AtomicAdd size: {}", Op->Size);
   }
 }
 
@@ -149,7 +149,7 @@ DEF_OP(AtomicSub) {
     case 8:
       sub(qword [MemReg], GetSrc<RA_64>(Op->Header.Args[1].ID()));
       break;
-    default:  LOGMAN_MSG_A("Unhandled AtomicAdd size: %d", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled AtomicAdd size: {}", Op->Size);
   }
 }
 
@@ -171,7 +171,7 @@ DEF_OP(AtomicAnd) {
     case 8:
       and_(qword [MemReg], GetSrc<RA_64>(Op->Header.Args[1].ID()));
       break;
-    default:  LOGMAN_MSG_A("Unhandled AtomicAdd size: %d", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled AtomicAdd size: {}", Op->Size);
   }
 }
 
@@ -193,7 +193,7 @@ DEF_OP(AtomicOr) {
     case 8:
       or_(qword [MemReg], GetSrc<RA_64>(Op->Header.Args[1].ID()));
       break;
-    default:  LOGMAN_MSG_A("Unhandled AtomicAdd size: %d", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled AtomicAdd size: {}", Op->Size);
   }
 }
 
@@ -215,7 +215,7 @@ DEF_OP(AtomicXor) {
     case 8:
       xor_(qword [MemReg], GetSrc<RA_64>(Op->Header.Args[1].ID()));
       break;
-    default:  LOGMAN_MSG_A("Unhandled AtomicAdd size: %d", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled AtomicAdd size: {}", Op->Size);
   }
 }
 
@@ -246,7 +246,7 @@ DEF_OP(AtomicSwap) {
       lock();
       xchg(qword [MemReg], GetDst<RA_64>(Node));
       break;
-    default:  LOGMAN_MSG_A("Unhandled AtomicAdd size: %d", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled AtomicSwap size: {}", Op->Size);
   }
 }
 
@@ -279,7 +279,7 @@ DEF_OP(AtomicFetchAdd) {
       xadd(qword [MemReg], rcx);
       mov(GetDst<RA_64>(Node), rcx);
       break;
-    default:  LOGMAN_MSG_A("Unhandled AtomicFetchAdd size: %d", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled AtomicFetchAdd size: {}", Op->Size);
   }
 }
 
@@ -316,7 +316,7 @@ DEF_OP(AtomicFetchSub) {
       xadd(qword [MemReg], rcx);
       mov(GetDst<RA_64>(Node), rcx);
       break;
-    default:  LOGMAN_MSG_A("Unhandled AtomicFetchAdd size: %d", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled AtomicFetchSub size: {}", Op->Size);
   }
 }
 
@@ -394,7 +394,7 @@ DEF_OP(AtomicFetchAnd) {
       mov(GetDst<RA_64>(Node), TMP3.cvt64());
       break;
     }
-    default:  LOGMAN_MSG_A("Unhandled AtomicFetchAdd size: %d", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled AtomicFetchAnd size: {}", Op->Size);
   }
 }
 
@@ -471,7 +471,7 @@ DEF_OP(AtomicFetchOr) {
       mov(GetDst<RA_64>(Node), TMP3.cvt64());
       break;
     }
-    default:  LOGMAN_MSG_A("Unhandled AtomicFetchAdd size: %d", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled AtomicFetchOr size: {}", Op->Size);
   }
 }
 
@@ -548,7 +548,7 @@ DEF_OP(AtomicFetchXor) {
       mov(GetDst<RA_64>(Node), TMP3.cvt64());
       break;
     }
-    default:  LOGMAN_MSG_A("Unhandled AtomicFetchAdd size: %d", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled AtomicFetchXor size: {}", Op->Size);
   }
 }
 
@@ -624,7 +624,7 @@ DEF_OP(AtomicFetchNeg) {
       mov(GetDst<RA_64>(Node), TMP3.cvt64());
       break;
     }
-    default:  LOGMAN_MSG_A("Unhandled AtomicFetchAdd size: %d", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled AtomicFetchNeg size: {}", Op->Size);
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
@@ -14,15 +14,15 @@ $end_info$
 namespace FEXCore::CPU {
 #define DEF_OP(x) void X86JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
 DEF_OP(GuestCallDirect) {
-  LogMan::Msg::D("Unimplemented");
+  LogMan::Msg::DFmt("Unimplemented");
 }
 
 DEF_OP(GuestCallIndirect) {
-  LogMan::Msg::D("Unimplemented");
+  LogMan::Msg::DFmt("Unimplemented");
 }
 
 DEF_OP(GuestReturn) {
-  LogMan::Msg::D("Unimplemented");
+  LogMan::Msg::DFmt("Unimplemented");
 }
 
 DEF_OP(SignalReturn) {

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/ConversionOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/ConversionOps.cpp
@@ -31,7 +31,7 @@ DEF_OP(VInsGPR) {
       pinsrq(GetDst(Node), GetSrc<RA_64>(Op->Header.Args[1].ID()), Op->Index);
       break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -52,7 +52,7 @@ DEF_OP(VCastFromGPR) {
     case 8:
       vmovq(GetDst(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()).cvt64());
       break;
-    default: LOGMAN_MSG_A("Unknown castGPR element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A_FMT("Unknown VCastFromGPR element size: {}", Op->Header.ElementSize);
   }
 }
 
@@ -91,7 +91,7 @@ DEF_OP(Float_FToF) {
       cvtsd2ss(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
       break;
     }
-    default: LOGMAN_MSG_A("Unknown FCVT sizes: 0x%x", Conv);
+    default: LOGMAN_MSG_A_FMT("Unknown Float_FToF sizes: 0x{:x}", Conv);
   }
 }
 
@@ -113,7 +113,7 @@ DEF_OP(Vector_SToF) {
       cvtsi2sd(xmm15, rax);
       movlhps(GetDst(Node), xmm15);
     break;
-    default: LOGMAN_MSG_A("Unknown castGPR element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A_FMT("Unknown Vector_SToF element size: {}", Op->Header.ElementSize);
   }
 }
 
@@ -126,7 +126,7 @@ DEF_OP(Vector_FToZS) {
     case 8:
       cvttpd2dq(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
     break;
-    default: LOGMAN_MSG_A("Unknown castGPR element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A_FMT("Unknown Vector_FToZS element size: {}", Op->Header.ElementSize);
   }
 }
 
@@ -139,7 +139,7 @@ DEF_OP(Vector_FToS) {
     case 8:
       cvtpd2dq(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
     break;
-    default: LOGMAN_MSG_A("Unknown castGPR element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A_FMT("Unknown Vector_FToS element size: {}", Op->Header.ElementSize);
   }
 }
 
@@ -156,7 +156,7 @@ DEF_OP(Vector_FToF) {
       cvtpd2ps(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
       break;
     }
-    default: LOGMAN_MSG_A("Unknown Conversion Type : 0%04x", Conv); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Vector_FToF conversion type : 0x{:04x}", Conv); break;
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/MemoryOps.cpp
@@ -36,10 +36,10 @@ DEF_OP(LoadContext) {
     }
     break;
     case 16: {
-      LOGMAN_MSG_A("Invalid GPR load of size 16");
+      LOGMAN_MSG_A_FMT("Invalid GPR load of size 16");
     }
     break;
-    default:  LOGMAN_MSG_A("Unhandled LoadContext size: %d", OpSize);
+    default:  LOGMAN_MSG_A_FMT("Unhandled LoadContext size: {}", OpSize);
     }
   }
   else {
@@ -69,7 +69,7 @@ DEF_OP(LoadContext) {
         movups(GetDst(Node), xword [STATE + Op->Offset]);
     }
     break;
-    default:  LOGMAN_MSG_A("Unhandled LoadContext size: %d", OpSize);
+    default:  LOGMAN_MSG_A_FMT("Unhandled LoadContext size: {}", OpSize);
     }
   }
 }
@@ -98,9 +98,9 @@ DEF_OP(StoreContext) {
     }
     break;
     case 16:
-      LogMan::Msg::D("Invalid store size of 16");
+      LogMan::Msg::DFmt("Invalid store size of 16");
     break;
-    default:  LOGMAN_MSG_A("Unhandled StoreContext size: %d", OpSize);
+    default:  LOGMAN_MSG_A_FMT("Unhandled StoreContext size: {}", OpSize);
     }
   }
   else {
@@ -129,7 +129,7 @@ DEF_OP(StoreContext) {
         movups(xword [STATE + Op->Offset], GetSrc(Op->Header.Args[0].ID()));
     }
     break;
-    default:  LOGMAN_MSG_A("Unhandled StoreContext size: %d", OpSize);
+    default:  LOGMAN_MSG_A_FMT("Unhandled StoreContext size: {}", OpSize);
     }
   }
 }
@@ -160,17 +160,18 @@ DEF_OP(LoadContextIndexed) {
         mov(GetDst<RA_64>(Node),  qword [rax + index * Op->Stride]);
         break;
       default:
-        LOGMAN_MSG_A("Unhandled LoadContextIndexed size: %d", Op->Size);
+        LOGMAN_MSG_A_FMT("Unhandled LoadContextIndexed size: {}", Op->Size);
+        break;
       }
       break;
     }
     case 16:
-      LOGMAN_MSG_A("Invalid Class load of size 16");
+      LOGMAN_MSG_A_FMT("Invalid Class load of size 16");
       break;
     default:
-      LOGMAN_MSG_A("Unhandled LoadContextIndexed stride: %d", Op->Stride);
+      LOGMAN_MSG_A_FMT("Unhandled LoadContextIndexed stride: {}", Op->Stride);
+      break;
     }
-
   }
   else {
     switch (Op->Stride) {
@@ -195,7 +196,8 @@ DEF_OP(LoadContextIndexed) {
         vmovq(GetDst(Node),  qword [rax + index * Op->Stride]);
         break;
       default:
-        LOGMAN_MSG_A("Unhandled LoadContextIndexed size: %d", Op->Size);
+        LOGMAN_MSG_A_FMT("Unhandled LoadContextIndexed size: {}", Op->Size);
+        break;
       }
       break;
     }
@@ -223,12 +225,14 @@ DEF_OP(LoadContextIndexed) {
           movups(GetDst(Node), xword [STATE + rax]);
         break;
       default:
-        LOGMAN_MSG_A("Unhandled LoadContextIndexed size: %d", Op->Size);
+        LOGMAN_MSG_A_FMT("Unhandled LoadContextIndexed size: {}", Op->Size);
+        break;
       }
       break;
     }
     default:
-      LOGMAN_MSG_A("Unhandled LoadContextIndexed stride: %d", Op->Stride);
+      LOGMAN_MSG_A_FMT("Unhandled LoadContextIndexed stride: {}", Op->Stride);
+      break;
     }
   }
 }
@@ -248,13 +252,14 @@ DEF_OP(StoreContextIndexed) {
     case 4:
     case 8: {
       if (!(size == 1 || size == 2 || size == 4 || size == 8)) {
-        LOGMAN_MSG_A("Unhandled StoreContextIndexed size: %d", Op->Size);
+        LOGMAN_MSG_A_FMT("Unhandled StoreContextIndexed size: {}", Op->Size);
       }
       mov(AddressFrame(Op->Size * 8) [rax + index * Op->Stride], value);
       break;
     }
     default:
-      LOGMAN_MSG_A("Unhandled StoreContextIndexed stride: %d", Op->Stride);
+      LOGMAN_MSG_A_FMT("Unhandled StoreContextIndexed stride: {}", Op->Stride);
+      break;
     }
   }
   else {
@@ -279,7 +284,8 @@ DEF_OP(StoreContextIndexed) {
         vmovq(AddressFrame(Op->Size * 8) [rax + index * Op->Stride], value);
         break;
       default:
-        LOGMAN_MSG_A("Unhandled StoreContextIndexed size: %d", size);
+        LOGMAN_MSG_A_FMT("Unhandled StoreContextIndexed size: {}", size);
+        break;
       }
       break;
     }
@@ -307,12 +313,14 @@ DEF_OP(StoreContextIndexed) {
           movups(xword [STATE + rax], value);
         break;
       default:
-        LOGMAN_MSG_A("Unhandled StoreContextIndexed size: %d", size);
+        LOGMAN_MSG_A_FMT("Unhandled StoreContextIndexed size: {}", size);
+        break;
       }
       break;
     }
     default:
-      LOGMAN_MSG_A("Unhandled StoreContextIndexed stride: %d", Op->Stride);
+      LOGMAN_MSG_A_FMT("Unhandled StoreContextIndexed stride: {}", Op->Stride);
+      break;
     }
   }
 }
@@ -340,7 +348,7 @@ DEF_OP(SpillRegister) {
         mov(qword [rsp + SlotOffset], GetSrc<RA_64>(Op->Header.Args[0].ID()));
         break;
       }
-      default:  LOGMAN_MSG_A("Unhandled SpillRegister size: %d", OpSize);
+      default:  LOGMAN_MSG_A_FMT("Unhandled SpillRegister size: {}", OpSize);
     }
   } else if (Op->Class == FEXCore::IR::FPRClass) {
     switch (OpSize) {
@@ -356,10 +364,10 @@ DEF_OP(SpillRegister) {
         movaps(xword [rsp + SlotOffset], GetSrc(Op->Header.Args[0].ID()));
         break;
       }
-      default:  LOGMAN_MSG_A("Unhandled SpillRegister size: %d", OpSize);
+      default:  LOGMAN_MSG_A_FMT("Unhandled SpillRegister size: {}", OpSize);
     }
   } else {
-    LOGMAN_MSG_A("Unhandled SpillRegister class: %d", Op->Class.Val);
+    LOGMAN_MSG_A_FMT("Unhandled SpillRegister class: {}", Op->Class.Val);
   }
 
 
@@ -388,7 +396,7 @@ DEF_OP(FillRegister) {
         mov(GetDst<RA_64>(Node), qword [rsp + SlotOffset]);
         break;
       }
-      default:  LOGMAN_MSG_A("Unhandled FillRegister size: %d", OpSize);
+      default:  LOGMAN_MSG_A_FMT("Unhandled FillRegister size: {}", OpSize);
     }
   } else if (Op->Class == FEXCore::IR::FPRClass) {
     switch (OpSize) {
@@ -404,10 +412,10 @@ DEF_OP(FillRegister) {
         movaps(GetDst(Node), xword [rsp + SlotOffset]);
         break;
       }
-      default:  LOGMAN_MSG_A("Unhandled FillRegister size: %d", OpSize);
+      default:  LOGMAN_MSG_A_FMT("Unhandled FillRegister size: {}", OpSize);
     }
   } else {
-    LOGMAN_MSG_A("Unhandled FillRegister class: %d", Op->Class.Val);
+    LOGMAN_MSG_A_FMT("Unhandled FillRegister class: {}", Op->Class.Val);
   }
 }
 
@@ -430,11 +438,11 @@ Xbyak::RegExp X86JITCore::GenerateModRM(Xbyak::Reg Base, IR::OrderedNodeWrapper 
     return Base;
   } else {
     if (OffsetScale != 1 && OffsetScale != 2 && OffsetScale != 4 && OffsetScale != 8) {
-      LOGMAN_MSG_A("Unhandled GenerateModRM OffsetScale: %d", OffsetScale);
+      LOGMAN_MSG_A_FMT("Unhandled GenerateModRM OffsetScale: {}", OffsetScale);
     }
 
     if (OffsetType != IR::MEM_OFFSET_SXTX) {
-      LOGMAN_MSG_A("Unhandled GenerateModRM OffsetType: %d", OffsetType.Val);
+      LOGMAN_MSG_A_FMT("Unhandled GenerateModRM OffsetType: {}", OffsetType.Val);
     }
 
     uint64_t Const;
@@ -475,7 +483,7 @@ DEF_OP(LoadMem) {
         mov(Dst, qword [MemPtr]);
       }
       break;
-      default:  LOGMAN_MSG_A("Unhandled LoadMem size: %d", Op->Size);
+      default:  LOGMAN_MSG_A_FMT("Unhandled LoadMem size: {}", Op->Size);
     }
   }
   else
@@ -511,7 +519,7 @@ DEF_OP(LoadMem) {
          }
        }
        break;
-      default:  LOGMAN_MSG_A("Unhandled LoadMem size: %d", Op->Size);
+      default:  LOGMAN_MSG_A_FMT("Unhandled LoadMem size: {}", Op->Size);
     }
   }
 }
@@ -537,7 +545,7 @@ DEF_OP(StoreMem) {
     case 8:
       mov(qword [MemPtr], GetSrc<RA_64>(Op->Header.Args[1].ID()));
     break;
-    default:  LOGMAN_MSG_A("Unhandled StoreMem size: %d", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled StoreMem size: {}", Op->Size);
     }
   }
   else {
@@ -560,17 +568,17 @@ DEF_OP(StoreMem) {
       else
         movups(xword [MemPtr], GetSrc(Op->Header.Args[1].ID()));
     break;
-    default:  LOGMAN_MSG_A("Unhandled StoreMem size: %d", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled StoreMem size: {}", Op->Size);
     }
   }
 }
 
 DEF_OP(VLoadMemElement) {
-  LOGMAN_MSG_A("Unimplemented");
+  LOGMAN_MSG_A_FMT("Unimplemented");
 }
 
 DEF_OP(VStoreMemElement) {
-  LOGMAN_MSG_A("Unimplemented");
+  LOGMAN_MSG_A_FMT("Unimplemented");
 }
 
 DEF_OP(CacheLineClear) {

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/MiscOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/MiscOps.cpp
@@ -9,11 +9,11 @@ $end_info$
 
 namespace FEXCore::CPU {
 static void PrintValue(uint64_t Value) {
-  LogMan::Msg::D("Value: 0x%lx", Value);
+  LogMan::Msg::DFmt("Value: 0x{:x}", Value);
 }
 
 static void PrintVectorValue(uint64_t Value, uint64_t ValueUpper) {
-  LogMan::Msg::D("Value: 0x%016lx'%016lx", ValueUpper, Value);
+  LogMan::Msg::DFmt("Value: 0x{:016x}'{:016x}", ValueUpper, Value);
 }
 
 #define DEF_OP(x) void X86JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
@@ -30,7 +30,7 @@ DEF_OP(Fence) {
     case IR::Fence_Store.Val:
       sfence();
       break;
-    default: LOGMAN_MSG_A("Unknown Fence: %d", Op->Fence); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Fence: {}", Op->Fence); break;
   }
 }
 
@@ -83,7 +83,7 @@ DEF_OP(Break) {
       }
     break;
     }
-    default: LOGMAN_MSG_A("Unknown Break reason: %d", Op->Reason);
+    default: LOGMAN_MSG_A_FMT("Unknown Break reason: {}", Op->Reason);
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/MoveOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/MoveOps.cpp
@@ -25,7 +25,7 @@ DEF_OP(ExtractElementPair) {
       mov (GetDst<RA_64>(Node), Regs[Op->Element]);
       break;
     }
-    default: LOGMAN_MSG_A("Unknown Size"); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Size"); break;
   }
 }
 
@@ -51,7 +51,7 @@ DEF_OP(CreateElementPair) {
       RegTmp = rax;
       break;
     }
-    default: LOGMAN_MSG_A("Unknown Size"); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Size"); break;
   }
 
   if (Dst.first != RegSecond) {

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
@@ -62,24 +62,24 @@ DEF_OP(VectorImm) {
 }
 
 DEF_OP(CreateVector2) {
-  LOGMAN_MSG_A("Unimplemented");
+  LOGMAN_MSG_A_FMT("Unimplemented");
 }
 
 DEF_OP(CreateVector4) {
-  LOGMAN_MSG_A("Unimplemented");
+  LOGMAN_MSG_A_FMT("Unimplemented");
 }
 
 DEF_OP(SplatVector) {
   auto Op = IROp->C<IR::IROp_SplatVector2>();
   uint8_t OpSize = IROp->Size;
 
-  LOGMAN_THROW_A(OpSize <= 16, "Can't handle a vector of size: %d", OpSize);
+  LOGMAN_THROW_A_FMT(OpSize <= 16, "Can't handle a vector of size: {}", OpSize);
   uint8_t Elements = 0;
 
   switch (Op->Header.Op) {
     case IR::OP_SPLATVECTOR4: Elements = 4; break;
     case IR::OP_SPLATVECTOR2: Elements = 2; break;
-    default: LOGMAN_MSG_A("Uknown Splat size"); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Splat size"); break;
   }
 
   uint8_t ElementSize = OpSize / Elements;
@@ -92,7 +92,7 @@ DEF_OP(SplatVector) {
     case 8:
       movddup(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
     break;
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.Size); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.Size); break;
   }
 }
 
@@ -130,7 +130,7 @@ DEF_OP(VMov) {
       movaps(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
       break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", OpSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", OpSize); break;
   }
 }
 
@@ -176,7 +176,7 @@ DEF_OP(VAdd) {
       vpaddq(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -199,7 +199,7 @@ DEF_OP(VSub) {
       vpsubq(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -214,7 +214,7 @@ DEF_OP(VUQAdd) {
       vpaddusw(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -229,7 +229,7 @@ DEF_OP(VUQSub) {
       vpsubusw(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -244,7 +244,7 @@ DEF_OP(VSQAdd) {
       vpaddsw(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -259,7 +259,7 @@ DEF_OP(VSQSub) {
       vpsubsw(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -296,7 +296,7 @@ DEF_OP(VAddP) {
       case 4:
         vphaddd(GetDst(Node), xmm15, xmm14);
         break;
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -325,7 +325,7 @@ DEF_OP(VAddP) {
       case 4:
         vphaddd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
         break;
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
 }
@@ -357,7 +357,7 @@ DEF_OP(VAddV) {
       pinsrd(xmm15, eax, 0);
     break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 
   movaps(Dest, xmm15);
@@ -376,7 +376,7 @@ DEF_OP(VUMinV) {
       pinsrw(Dest, eax, 1);
     break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -391,7 +391,7 @@ DEF_OP(VURAvg) {
       vpavgw(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -414,7 +414,7 @@ DEF_OP(VAbs) {
       vpabsq(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
       break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -438,7 +438,7 @@ DEF_OP(VPopcount) {
       }
       break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 
   movaps(Dest, xmm15);
@@ -459,7 +459,7 @@ DEF_OP(VFAdd) {
         vaddsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -473,7 +473,7 @@ DEF_OP(VFAdd) {
         vaddpd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
 }
@@ -487,7 +487,7 @@ DEF_OP(VFAddP) {
     case 8:
       vhaddpd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -506,7 +506,7 @@ DEF_OP(VFSub) {
         vsubsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -520,7 +520,7 @@ DEF_OP(VFSub) {
         vsubpd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
 }
@@ -540,7 +540,7 @@ DEF_OP(VFMul) {
         vmulsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -554,7 +554,7 @@ DEF_OP(VFMul) {
         vmulpd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
 }
@@ -574,7 +574,7 @@ DEF_OP(VFDiv) {
         vdivsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -588,7 +588,7 @@ DEF_OP(VFDiv) {
         vdivpd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
 }
@@ -608,7 +608,7 @@ DEF_OP(VFMin) {
         vminsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -622,7 +622,7 @@ DEF_OP(VFMin) {
         vminpd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
 }
@@ -642,7 +642,7 @@ DEF_OP(VFMax) {
         vmaxsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -656,7 +656,7 @@ DEF_OP(VFMax) {
         vmaxpd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
 }
@@ -674,7 +674,7 @@ DEF_OP(VFRecp) {
         vdivss(GetDst(Node), xmm15, GetSrc(Op->Header.Args[0].ID()));
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -687,7 +687,7 @@ DEF_OP(VFRecp) {
         vdivps(GetDst(Node), xmm15, GetSrc(Op->Header.Args[0].ID()));
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
 }
@@ -707,7 +707,7 @@ DEF_OP(VFSqrt) {
         vsqrtsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[0].ID()));
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -721,7 +721,7 @@ DEF_OP(VFSqrt) {
         vsqrtpd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
 }
@@ -747,7 +747,7 @@ DEF_OP(VFRSqrt) {
         divsd(GetDst(Node), xmm15);
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -761,7 +761,7 @@ DEF_OP(VFRSqrt) {
         divps(GetDst(Node), xmm15);
       break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
 }
@@ -786,7 +786,7 @@ DEF_OP(VNeg) {
       vpsubq(GetDst(Node), xmm15, GetSrc(Op->Header.Args[0].ID()));
     break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -807,7 +807,7 @@ DEF_OP(VFNeg) {
       vxorpd(GetDst(Node), xmm15, GetSrc(Op->Header.Args[0].ID()));
     break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -830,7 +830,7 @@ DEF_OP(VUMin) {
         pinsrq(GetDst(Node), TMP2, 0);
         break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -847,7 +847,7 @@ DEF_OP(VUMin) {
         vpminud(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
         break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
 }
@@ -867,7 +867,7 @@ DEF_OP(VSMin) {
       vpminsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -886,7 +886,7 @@ DEF_OP(VUMax) {
       vpmaxud(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -905,7 +905,7 @@ DEF_OP(VSMax) {
       vpmaxsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -930,7 +930,7 @@ DEF_OP(VZip) {
       punpcklqdq(xmm15, GetSrc(Op->Header.Args[1].ID()));
       break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
   movapd(GetDst(Node), xmm15);
 }
@@ -957,7 +957,7 @@ DEF_OP(VZip2) {
       vpunpckhdq(GetDst(Node), xmm15, xmm14);
     break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
   else {
@@ -978,7 +978,7 @@ DEF_OP(VZip2) {
       punpckhqdq(xmm15, GetSrc(Op->Header.Args[1].ID()));
     break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
     movapd(GetDst(Node), xmm15);
   }
@@ -989,7 +989,7 @@ DEF_OP(VUnZip) {
   uint8_t OpSize = IROp->Size;
 
   if (OpSize == 8) {
-    LOGMAN_MSG_A("Unsupported registersize on VunZip");
+    LOGMAN_MSG_A_FMT("Unsupported register size on VUnZip");
   }
   else {
     switch (Op->Header.ElementSize) {
@@ -1031,7 +1031,7 @@ DEF_OP(VUnZip) {
           0b0'0);
         break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
 }
@@ -1042,7 +1042,7 @@ DEF_OP(VUnZip2) {
 
 
   if (OpSize == 8) {
-    LOGMAN_MSG_A("Unsupported registersize on VunZip");
+    LOGMAN_MSG_A_FMT("Unsupported register size on VUnZip2");
   }
   else {
     switch (Op->Header.ElementSize) {
@@ -1084,7 +1084,7 @@ DEF_OP(VUnZip2) {
           0b1'1);
         break;
       }
-      default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
   }
 }
@@ -1113,7 +1113,7 @@ DEF_OP(VCMPEQ) {
     case 8:
       vpcmpeqq(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
-    default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A_FMT("Unsupported element size: {}", Op->Header.ElementSize);
   }
 }
 
@@ -1134,7 +1134,7 @@ DEF_OP(VCMPEQZ) {
     case 8:
       vpcmpeqq(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), xmm15);
       break;
-    default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A_FMT("Unsupported element size: {}", Op->Header.ElementSize);
   }
 }
 
@@ -1154,7 +1154,7 @@ DEF_OP(VCMPGT) {
     case 8:
       vpcmpgtq(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
-    default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A_FMT("Unsupported element size: {}", Op->Header.ElementSize);
   }
 }
 
@@ -1175,7 +1175,7 @@ DEF_OP(VCMPGTZ) {
     case 8:
       vpcmpgtq(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), xmm15);
       break;
-    default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A_FMT("Unsupported element size: {}", Op->Header.ElementSize);
   }
 }
 
@@ -1196,7 +1196,7 @@ DEF_OP(VCMPLTZ) {
     case 8:
       vpcmpgtq(GetDst(Node), xmm15, GetSrc(Op->Header.Args[0].ID()));
       break;
-    default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A_FMT("Unsupported element size: {}", Op->Header.ElementSize);
   }
 }
 
@@ -1212,7 +1212,7 @@ DEF_OP(VFCMPEQ) {
     case 8:
       vcmpsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 0);
     break;
-    default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A_FMT("Unsupported element size: {}", Op->Header.ElementSize);
     }
   }
   else {
@@ -1223,7 +1223,7 @@ DEF_OP(VFCMPEQ) {
     case 8:
       vcmppd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 0);
     break;
-    default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A_FMT("Unsupported element size: {}", Op->Header.ElementSize);
     }
   }
 }
@@ -1240,7 +1240,7 @@ DEF_OP(VFCMPNEQ) {
     case 8:
       vcmpsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 4);
     break;
-    default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A_FMT("Unsupported element size: {}", Op->Header.ElementSize);
     }
 
   }
@@ -1252,7 +1252,7 @@ DEF_OP(VFCMPNEQ) {
     case 8:
       vcmppd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 4);
     break;
-    default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A_FMT("Unsupported element size: {}", Op->Header.ElementSize);
     }
   }
 }
@@ -1269,7 +1269,7 @@ DEF_OP(VFCMPLT) {
     case 8:
       vcmpsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 1);
     break;
-    default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A_FMT("Unsupported element size: {}", Op->Header.ElementSize);
     }
   }
   else {
@@ -1280,7 +1280,7 @@ DEF_OP(VFCMPLT) {
     case 8:
       vcmppd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 1);
     break;
-    default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A_FMT("Unsupported element size: {}", Op->Header.ElementSize);
     }
   }
 }
@@ -1297,7 +1297,7 @@ DEF_OP(VFCMPGT) {
     case 8:
       vcmpsd(GetDst(Node), GetSrc(Op->Header.Args[1].ID()), GetSrc(Op->Header.Args[0].ID()), 1);
     break;
-    default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A_FMT("Unsupported element size: {}", Op->Header.ElementSize);
     }
   }
   else {
@@ -1308,7 +1308,7 @@ DEF_OP(VFCMPGT) {
     case 8:
       vcmppd(GetDst(Node), GetSrc(Op->Header.Args[1].ID()), GetSrc(Op->Header.Args[0].ID()), 1);
     break;
-    default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A_FMT("Unsupported element size: {}", Op->Header.ElementSize);
     }
   }
 }
@@ -1325,7 +1325,7 @@ DEF_OP(VFCMPLE) {
     case 8:
       vcmpsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 2);
     break;
-    default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A_FMT("Unsupported element size: {}", Op->Header.ElementSize);
     }
   }
   else {
@@ -1336,7 +1336,7 @@ DEF_OP(VFCMPLE) {
     case 8:
       vcmppd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 2);
     break;
-    default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A_FMT("Unsupported element size: {}", Op->Header.ElementSize);
     }
   }
 }
@@ -1353,7 +1353,7 @@ DEF_OP(VFCMPORD) {
     case 8:
       vcmpsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 7);
     break;
-    default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A_FMT("Unsupported element size: {}", Op->Header.ElementSize);
     }
   }
   else {
@@ -1364,7 +1364,7 @@ DEF_OP(VFCMPORD) {
     case 8:
       vcmppd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 7);
     break;
-    default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A_FMT("Unsupported element size: {}", Op->Header.ElementSize);
     }
   }
 }
@@ -1381,7 +1381,7 @@ DEF_OP(VFCMPUNO) {
     case 8:
       vcmpsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 3);
     break;
-    default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A_FMT("Unsupported element size: {}", Op->Header.ElementSize);
     }
   }
   else {
@@ -1392,21 +1392,21 @@ DEF_OP(VFCMPUNO) {
     case 8:
       vcmppd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 3);
     break;
-    default: LOGMAN_MSG_A("Unsupported elementSize: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A_FMT("Unsupported element size: {}", Op->Header.ElementSize);
     }
   }
 }
 
 DEF_OP(VUShl) {
-  LOGMAN_MSG_A("Unimplemented");
+  LOGMAN_MSG_A_FMT("Unimplemented");
 }
 
 DEF_OP(VUShr) {
-  LOGMAN_MSG_A("Unimplemented");
+  LOGMAN_MSG_A_FMT("Unimplemented");
 }
 
 DEF_OP(VSShr) {
-  LOGMAN_MSG_A("Unimplemented");
+  LOGMAN_MSG_A_FMT("Unimplemented");
 }
 
 DEF_OP(VUShlS) {
@@ -1425,7 +1425,7 @@ DEF_OP(VUShlS) {
       vpsllq(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -1445,7 +1445,7 @@ DEF_OP(VUShrS) {
       vpsrlq(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -1462,7 +1462,7 @@ DEF_OP(VSShrS) {
       break;
     }
     case 8: // Doesn't exist on x86
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -1495,7 +1495,7 @@ DEF_OP(VInsElement) {
     pinsrq(xmm15, rax, Op->DestIdx);
   break;
   }
-  default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+  default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 
   movapd(GetDst(Node), xmm15);
@@ -1530,7 +1530,7 @@ DEF_OP(VInsScalarElement) {
     pinsrq(xmm15, rax, Op->DestIdx);
   break;
   }
-  default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+  default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 
   movapd(GetDst(Node), xmm15);
@@ -1560,7 +1560,7 @@ DEF_OP(VExtractElement) {
       pinsrq(GetDst(Node), rax, 0);
       break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -1613,7 +1613,7 @@ DEF_OP(VDupElement) {
         (Op->Index << 1));
       break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -1666,7 +1666,7 @@ DEF_OP(VUShrI) {
       psrlq(GetDst(Node), Op->BitShift);
       break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -1704,7 +1704,7 @@ DEF_OP(VSShrI) {
       }
       break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -1724,7 +1724,7 @@ DEF_OP(VShlI) {
       psllq(GetDst(Node), Op->BitShift);
       break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -1754,7 +1754,7 @@ DEF_OP(VUShrNI) {
       mov(rcx, 0x80'80'80'80'80'80'80'80); // Upper
       break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 
   vmovq(xmm15, rax);
@@ -1790,7 +1790,7 @@ DEF_OP(VUShrNI2) {
       mov(rcx, 0x0B'0A'09'08'03'02'01'00); // Upper
       break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 
   vmovq(xmm15, rax);
@@ -1817,7 +1817,7 @@ DEF_OP(VSXTL) {
     case 8:
       pmovsxdq(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
     break;
-    default: LOGMAN_MSG_A("Unknown element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize);
   }
 }
 
@@ -1836,7 +1836,7 @@ DEF_OP(VSXTL2) {
     case 8:
       pmovsxdq(GetDst(Node), GetDst(Node));
     break;
-    default: LOGMAN_MSG_A("Unknown element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize);
   }
 }
 
@@ -1852,7 +1852,7 @@ DEF_OP(VUXTL) {
     case 8:
       pmovzxdq(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
     break;
-    default: LOGMAN_MSG_A("Unknown element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize);
   }
 }
 
@@ -1871,7 +1871,7 @@ DEF_OP(VUXTL2) {
     case 8:
       pmovzxdq(GetDst(Node), GetDst(Node));
     break;
-    default: LOGMAN_MSG_A("Unknown element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize);
   }
 }
 
@@ -1884,7 +1884,7 @@ DEF_OP(VSQXTN) {
     case 2:
       packssdw(xmm15, GetSrc(Op->Header.Args[0].ID()));
     break;
-    default: LOGMAN_MSG_A("Unknown element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize);
   }
   psrldq(xmm15, 8);
   movaps(GetDst(Node), xmm15);
@@ -1903,7 +1903,7 @@ DEF_OP(VSQXTN2) {
     case 2:
       packssdw(xmm15, GetSrc(Op->Header.Args[1].ID()));
     break;
-    default: LOGMAN_MSG_A("Unknown element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize);
   }
 
   if (OpSize == 8) {
@@ -1921,7 +1921,7 @@ DEF_OP(VSQXTUN) {
     case 2:
       packusdw(xmm15, GetSrc(Op->Header.Args[0].ID()));
     break;
-    default: LOGMAN_MSG_A("Unknown element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize);
   }
   psrldq(xmm15, 8);
   movaps(GetDst(Node), xmm15);
@@ -1940,7 +1940,7 @@ DEF_OP(VSQXTUN2) {
     case 2:
       packusdw(xmm15, GetSrc(Op->Header.Args[1].ID()));
     break;
-    default: LOGMAN_MSG_A("Unknown element size: %d", Op->Header.ElementSize);
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize);
   }
   if (OpSize == 8) {
     psrldq(xmm15, OpSize / 2);
@@ -1960,7 +1960,7 @@ DEF_OP(VMul) {
       vpmulld(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -1991,7 +1991,7 @@ DEF_OP(VUMull) {
       vpmuludq(GetDst(Node), xmm14, xmm15);
     break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -2026,7 +2026,7 @@ DEF_OP(VSMull) {
       vpmuldq(GetDst(Node), xmm14, xmm15);
     break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -2062,7 +2062,7 @@ DEF_OP(VUMull2) {
       vpmuludq(GetDst(Node), xmm14, xmm15);
     break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -2102,7 +2102,7 @@ DEF_OP(VSMull2) {
       vpmuldq(GetDst(Node), xmm14, xmm15);
     break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -2123,7 +2123,7 @@ DEF_OP(VUABDL) {
       vpabsd(GetDst(Node), GetDst(Node));
       break;
     }
-    default: LOGMAN_MSG_A("Unknown Element Size: %d", Op->Header.ElementSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
 }
 
@@ -2141,7 +2141,7 @@ DEF_OP(VTBL1) {
       vpshufb(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
       break;
     }
-    default: LOGMAN_MSG_A("Unknown OpSize: %d", OpSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown OpSize: {}", OpSize); break;
   }
 }
 


### PR DESCRIPTION
Brings over the rest of the JIT logs for consistency.

This also fixes some incorrect logging string (e.g. where the error string for AtomicSwap, would indicate an invalid size for AtomicAdd, etc) 