### PR TITLE
 Linux: Implements support for signals 32 and 33 

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
@@ -281,9 +281,8 @@ bool Dispatcher::HandleGuestSignal(int Signal, void *info, void *ucontext, Guest
           guest_siginfo->_sifields._sigchld.stime = HostSigInfo->si_stime;
           break;
       default:
-        LogMan::Msg::D("Unhandled siginfo_t signal: %d", Signal);
         // Hope for the best, most things just copy over
-        memcpy(guest_siginfo, info, sizeof(siginfo_t));
+        memcpy(&guest_siginfo->_sifields, &HostSigInfo->_sifields, sizeof(siginfo_t));
         break;
       }
 

--- a/Source/Tests/LinuxSyscalls/SignalDelegator.h
+++ b/Source/Tests/LinuxSyscalls/SignalDelegator.h
@@ -99,11 +99,25 @@ namespace FEX::HLE {
       DEFAULT_IGNORE,
     };
 
+    struct kernel_sigaction {
+      union {
+        void (*handler)(int);
+        void (*sigaction)(int, siginfo_t*, void*);
+      };
+
+      uint64_t sa_flags;
+
+#ifdef _M_X86_64
+      void (*restorer)();
+#endif
+      uint64_t sa_mask;
+    };
+
     struct SignalHandler {
       std::atomic<bool> Installed{};
       std::atomic<bool> Required{};
-      struct sigaction HostAction{};
-      struct sigaction OldAction{};
+      kernel_sigaction HostAction{};
+      kernel_sigaction OldAction{};
       FEXCore::HostSignalDelegatorFunction Handler{};
       FEXCore::HostSignalDelegatorFunction FrontendHandler{};
       FEXCore::HostSignalDelegatorFunctionForGuest GuestHandler{};
@@ -113,7 +127,7 @@ namespace FEX::HLE {
 
     std::array<SignalHandler, MAX_SIGNALS + 1> HostHandlers{};
     bool InstallHostThunk(int Signal);
-    void UpdateHostThunk(int Signal);
+    bool UpdateHostThunk(int Signal);
 
     std::mutex HostDelegatorMutex;
     std::mutex GuestDelegatorMutex;

--- a/Source/Tests/LinuxSyscalls/Syscalls/Thread.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Thread.cpp
@@ -225,12 +225,12 @@ namespace FEX::HLE {
     });
 
     REGISTER_SYSCALL_IMPL(setuid, [](FEXCore::Core::CpuStateFrame *Frame, uid_t uid) -> uint64_t {
-      uint64_t Result = ::setuid(uid);
+      uint64_t Result = ::syscall(SYS_setuid, uid);
       SYSCALL_ERRNO();
     });
 
     REGISTER_SYSCALL_IMPL(setgid, [](FEXCore::Core::CpuStateFrame *Frame, gid_t gid) -> uint64_t {
-      uint64_t Result = ::setgid(gid);
+      uint64_t Result = ::syscall(SYS_setgid, gid);
       SYSCALL_ERRNO();
     });
 
@@ -260,12 +260,12 @@ namespace FEX::HLE {
     });
 
     REGISTER_SYSCALL_IMPL(setreuid, [](FEXCore::Core::CpuStateFrame *Frame, uid_t ruid, uid_t euid) -> uint64_t {
-      uint64_t Result = ::setreuid(ruid, euid);
+      uint64_t Result = ::syscall(SYS_setreuid, ruid, euid);
       SYSCALL_ERRNO();
     });
 
     REGISTER_SYSCALL_IMPL(setregid, [](FEXCore::Core::CpuStateFrame *Frame, gid_t rgid, gid_t egid) -> uint64_t {
-      uint64_t Result = ::setregid(rgid, egid);
+      uint64_t Result = ::syscall(SYS_setregid, rgid, egid);
       SYSCALL_ERRNO();
     });
 
@@ -275,12 +275,12 @@ namespace FEX::HLE {
     });
 
     REGISTER_SYSCALL_IMPL(setgroups, [](FEXCore::Core::CpuStateFrame *Frame, size_t size, const gid_t *list) -> uint64_t {
-      uint64_t Result = ::setgroups(size, list);
+      uint64_t Result = ::syscall(SYS_setgroups, size, list);
       SYSCALL_ERRNO();
     });
 
     REGISTER_SYSCALL_IMPL(setresuid, [](FEXCore::Core::CpuStateFrame *Frame, uid_t ruid, uid_t euid, uid_t suid) -> uint64_t {
-      uint64_t Result = ::setresuid(ruid, euid, suid);
+      uint64_t Result = ::syscall(SYS_setresuid, ruid, euid, suid);
       SYSCALL_ERRNO();
     });
 
@@ -290,7 +290,7 @@ namespace FEX::HLE {
     });
 
     REGISTER_SYSCALL_IMPL(setresgid, [](FEXCore::Core::CpuStateFrame *Frame, gid_t rgid, gid_t egid, gid_t sgid) -> uint64_t {
-      uint64_t Result = ::setresgid(rgid, egid, sgid);
+      uint64_t Result = ::syscall(SYS_setresgid, rgid, egid, sgid);
       SYSCALL_ERRNO();
     });
 


### PR DESCRIPTION
When a guest tries to use the setxid syscalls, the guest glibc has
a mechanism in place to ensure that the process wide setxid is handled.
The mechanism is fairly complex but it uses signal 33 and sends the signal to all
active threads to ensure every thread sets the correct state here.

We need to intercept this and pass the context information correctly to the guest instead.
Otherwise FEX just crashes when the glibc HOST handler tries handling the guest applications signal.

Fixes the game SOMA https://store.steampowered.com/app/282140/SOMA/
Weirdly this game uses some Autodesk SDK `FBX SDK 2012` which part of its thread initialization code tries to do a `setuid(0)`