### PR TITLE
Adds an option to disable jemalloc from cmake 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ option(ENABLE_VISUAL_DEBUGGER "Enables the visual debugger for compiling" FALSE)
 option(ENABLE_STRICT_WERROR "Enables stricter -Werror for CI" FALSE)
 option(ENABLE_WERROR "Enables -Werror" FALSE)
 option(ENABLE_STATIC_PIE "Enables static-pie build" FALSE)
+option(ENABLE_JEMALLOC "Enables jemalloc allocator" TRUE)
 
 set (X86_C_COMPILER "x86_64-linux-gnu-gcc" CACHE STRING "c compiler for compiling x86 guest libs")
 set (X86_CXX_COMPILER "x86_64-linux-gnu-g++" CACHE STRING "c++ compiler for compiling x86 guest libs")
@@ -146,6 +147,16 @@ endif()
 if (ENABLE_TSAN)
   add_compile_options(-fno-omit-frame-pointer -fsanitize=thread)
   link_libraries(-fno-omit-frame-pointer -fsanitize=thread)
+endif()
+
+if (ENABLE_JEMALLOC)
+  add_definitions(-DENABLE_JEMALLOC=1)
+else()
+  message (STATUS
+    " jemalloc disabled!\n"
+    " This is not a recommended configuration!\n"
+    " This will very explicitly break 32-bit application execution!\n"
+    " Use at your own risk!")
 endif()
 
 set (CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -fno-omit-frame-pointer")

--- a/Source/Tests/CMakeLists.txt
+++ b/Source/Tests/CMakeLists.txt
@@ -1,6 +1,10 @@
 add_subdirectory(LinuxSyscalls)
 
-set(LIBS FEX_jemalloc FEXCore Common CommonCore)
+if (ENABLE_JEMALLOC)
+  set (LIBS FEX_jemalloc)
+endif()
+
+list(APPEND LIBS FEXCore Common CommonCore)
 
 add_executable(FEXLoader FEXLoader.cpp)
 target_include_directories(FEXLoader PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/Source/)

--- a/Source/Tests/FEXLoader.cpp
+++ b/Source/Tests/FEXLoader.cpp
@@ -322,7 +322,9 @@ int main(int argc, char **argv, char **const envp) {
 
 #if !(defined(ENABLE_ASAN) && ENABLE_ASAN)
   // LLVM ASAN maps things to the lower 32bits
-  if (!CheckMemMapping()) {
+  // Valgrind also places us in the lower 32-bits
+  if (!getenv("VALGRIND_LAUNCHER") &&
+      !CheckMemMapping()) {
     LogMan::Msg::E("[Unsupported] FEX mapped to lower 32bits! Exiting!");
     return -1;
   }


### PR DESCRIPTION
While not recommended. It is necessary to allow disabling jemalloc if you want to run asan or tsan