### PR TITLE
FlexBitSet: Use non-template type parameter for index parameters

### DIFF
--- a/External/FEXCore/Source/Utils/Allocator/FlexBitSet.h
+++ b/External/FEXCore/Source/Utils/Allocator/FlexBitSet.h
@@ -14,18 +14,18 @@ struct FlexBitSet final {
 
   T Memory[];
 
-  bool Get(T Element) {
+  bool Get(size_t Element) const {
     return (Memory[Element / MinimumSizeBits] & (1ULL << (Element % MinimumSizeBits))) != 0;
   }
-  bool TestAndClear(T Element) {
+  bool TestAndClear(size_t Element) {
     bool Value = Get(Element);
     Memory[Element / MinimumSizeBits] &= ~(1ULL << (Element % MinimumSizeBits));
     return Value;
   }
-  void Set(T Element) {
+  void Set(size_t Element) {
     Memory[Element / MinimumSizeBits] |= (1ULL << (Element % MinimumSizeBits));
   }
-  void Clear(T Element) {
+  void Clear(size_t Element) {
     Memory[Element / MinimumSizeBits] &= ~(1ULL << (Element % MinimumSizeBits));
   }
   void MemClear(size_t Elements) {
@@ -37,14 +37,14 @@ struct FlexBitSet final {
 
   // This very explicitly doesn't let you take an address
   // Is only a getter
-  bool operator[](T Element) {
+  bool operator[](size_t Element) const {
     return Get(Element);
   }
 
-  static size_t Size(T Elements) {
+  static size_t Size(uint64_t Elements) {
     return Alloc::AlignUp(Elements / MinimumSizeBits, MinimumSizeBits);
   }
 };
 
 static_assert(sizeof(FlexBitSet<uint64_t>) == 0, "This needs to be a flex member");
-static_assert(std::is_trivially_copyable<FlexBitSet<uint64_t>>::value, "Needsto be trivially copyable");
+static_assert(std::is_trivially_copyable_v<FlexBitSet<uint64_t>>, "Needs to be trivially copyable");


### PR DESCRIPTION
These parameters are used as indexes into the tracked memory, so sizing the index variable relative to the type being stored is kind of sketchy.

e.g. If the tracked types were uint8_t for example, we'd still want the indexing parameters to be regularly sized so that we aren't implicitly truncating values all the time when passing values to a uint8_t parameter (and while all usages are currently using uint64_t as type T, we may as well address this).

While we're at it, we can make both Get() and operator[] const member functions, since they don't directly modify any underlying data, they only read it.