### PR TITLE
Adds an option to stall processes on launch

### DIFF
--- a/Data/AppConfig/steamwebhelper.json
+++ b/Data/AppConfig/steamwebhelper.json
@@ -1,0 +1,5 @@
+{
+  "Config": {
+    "StallProcess": "1"
+  }
+}

--- a/External/FEXCore/Source/Interface/Config/Config.json
+++ b/External/FEXCore/Source/Interface/Config/Config.json
@@ -214,6 +214,14 @@
           "Makes TSO operations even more strict.",
           "Forces vector loadstores to also become atomic."
         ]
+      },
+      "StallProcess": {
+        "Type": "bool",
+        "Default": "false",
+        "Desc": [
+          "Forces a process to stall out on initialization",
+          "Useful for a process that keeps restarting and doesn't work"
+        ]
       }
     },
     "Misc": {

--- a/Source/Tests/FEXLoader.cpp
+++ b/Source/Tests/FEXLoader.cpp
@@ -352,13 +352,24 @@ int main(int argc, char **argv, char **const envp) {
   std::string Program = Args[0];
 
   // These layers load on initialization
-  FEXCore::Config::AddLayer(std::make_unique<FEX::Config::AppLoader>(std::filesystem::path(Program).filename(), true));
-  FEXCore::Config::AddLayer(std::make_unique<FEX::Config::AppLoader>(std::filesystem::path(Program).filename(), false));
+  auto ProgramName = std::filesystem::path(Program).filename();
+  FEXCore::Config::AddLayer(std::make_unique<FEX::Config::AppLoader>(ProgramName, true));
+  FEXCore::Config::AddLayer(std::make_unique<FEX::Config::AppLoader>(ProgramName, false));
 
   // Reload the meta layer
   FEXCore::Config::ReloadMetaLayer();
   FEXCore::Config::Set(FEXCore::Config::CONFIG_IS_INTERPRETER, IsInterpreter ? "1" : "0");
   FEXCore::Config::Set(FEXCore::Config::CONFIG_INTERPRETER_INSTALLED, IsInterpreterInstalled() ? "1" : "0");
+
+  // Early check for process stall
+  // Doesn't use CONFIG_ROOTFS and we don't want it to spin up a squashfs instance
+  FEX_CONFIG_OPT(StallProcess, STALLPROCESS);
+  if (StallProcess) {
+    while (1) {
+      // Stall this process out forever
+      select(0, nullptr, nullptr, nullptr, nullptr);
+    }
+  }
 
   // Ensure RootFS is setup before config options try to pull CONFIG_ROOTFS
   if (!FEX::RootFS::Setup(envp)) {


### PR DESCRIPTION
For misbehaving applications before we can fully diagnose, allow
a config that hangs a process on load.