### PR TITLE
RCLSE: Fixes an assumption in RCLSE 

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -55,9 +55,9 @@ void X86JITCore::CopyNecessaryDataForCompileThread(CPUBackend *Original) {
 }
 
 void X86JITCore::PushRegs() {
-  for (auto &Xmm : RAXMM_x) {
-    sub(rsp, 16);
-    movaps(ptr[rsp], Xmm);
+  sub(rsp, 16 * RAXMM_x.size());
+  for (size_t i = 0; i < RAXMM_x.size(); ++i) {
+    movaps(ptr[rsp + i * 16], RAXMM_x[i]);
   }
 
   for (auto &Reg : RA64)
@@ -76,10 +76,11 @@ void X86JITCore::PopRegs() {
   for (uint32_t i = RA64.size(); i > 0; --i)
     pop(RA64[i - 1]);
 
-  for (uint32_t i = RAXMM_x.size(); i > 0; --i) {
-    movaps(RAXMM_x[i - 1], ptr[rsp]);
-    add(rsp, 16);
+  for (size_t i = 0; i < RAXMM_x.size(); ++i) {
+    movaps(RAXMM_x[i], ptr[rsp + i * 16]);
   }
+
+  add(rsp, 16 * RAXMM_x.size());
 }
 
 void X86JITCore::Op_Unhandled(FEXCore::IR::IROp_Header *IROp, uint32_t Node) {

--- a/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -448,8 +448,10 @@ bool ConstProp::ZextAndMaskingElimination(IREmitter *IREmit, const IRListView& C
         IREmit->ReplaceAllUsesWith(CodeNode, CurrentIR.GetNode(source));
       } else if (IROp->Size == sourceHeader->Size) {
         // VMOV of same size
+        // XXX: This is unsafe of an optimization since in some cases we can't see through garbage data in the upper bits of a vector
+        // RCLSE generates VMOV instructions which are being used as a zero extension
         //printf("printf vmov of same size?!\n");
-        IREmit->ReplaceAllUsesWith(CodeNode, CurrentIR.GetNode(source));
+        //IREmit->ReplaceAllUsesWith(CodeNode, CurrentIR.GetNode(source));
       }
       break;
     }


### PR DESCRIPTION
There is an assumption in the RCLSE pass that if a StoreContext + LoadContext pair of the same size
with a vector register that it is safe to remove the LoadContext.
This isn't quite safe since it can't entirely see through the IR to determine if the store op
had already zext the upper bits of the register.

This was causing 8byte loadcontext operations to "load" with garbage data in the upper
bits when it was expecting a zext.

Which granted it is likely a bug that not all vector ops zero their upper bits but that's a battle for a different day.

Additionally:
- Removes a couple dead optimizations in the GPR path that was never hit.
- Cleans up how access types are checked
- Uses ReplaceAllUsesWithRange to reinforce that this is purely a per block optimization still

Fixes #881 and also VC1 video decoding in mpv.