### PR TITLE
FEXMountDaemon: Make squashfs mounting more robust

### DIFF
--- a/Source/Common/RootFSSetup.cpp
+++ b/Source/Common/RootFSSetup.cpp
@@ -5,6 +5,7 @@
 #include <FEXCore/Config/Config.h>
 
 #include <filesystem>
+#include <fstream>
 
 #include <poll.h>
 #include <unistd.h>
@@ -12,8 +13,59 @@
 #include <sys/prctl.h>
 #include <sys/stat.h>
 #include <sys/wait.h>
+#include <sys/utsname.h>
 
 namespace FEX::RootFS {
+
+static std::fstream SquashFSLock{};
+bool SanityCheckPath(std::string const &LDPath) {
+// Check if we have an directory inside our temp folder
+  std::string PathUser = LDPath + "/usr";
+  if (!std::filesystem::exists(PathUser)) {
+    LogMan::Msg::D("Child couldn't mount rootfs, /usr doesn't exist");
+    rmdir(LDPath.c_str());
+    return false;
+  }
+
+  return true;
+}
+
+bool CheckLockExists(std::string const LockPath) {
+  // If the lock file for a squashfs path exists the we can try
+  // to open it and ref counting will keep it alive
+  if (std::filesystem::exists(LockPath)) {
+    SquashFSLock.open(LockPath, std::ios_base::in | std::ios_base::binary);
+    if (SquashFSLock.is_open()) {
+      // We managed to open the file. Which means the mount application has now refcounted our interaction with it
+      // Extract the data in it to know where it was mounted
+      std::string NewPath;
+      SquashFSLock >> NewPath;
+      if (NewPath.empty()) {
+        // Couldn't open for whatever reason
+        SquashFSLock.close();
+        return false;
+      }
+      if (!SanityCheckPath(NewPath)) {
+        // Mount doesn't exist anymore
+        SquashFSLock.close();
+        // Removing the dangling mount directory
+        rmdir(NewPath.c_str());
+
+        // Remove the dangling lock file
+        unlink(LockPath.c_str());
+        return false;
+      }
+      FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_ROOTFS, NewPath);
+      return true;
+    }
+  }
+  return false;
+}
+
+void OpenLock(std::string const LockPath) {
+  SquashFSLock.open(LockPath, std::ios_base::in | std::ios_base::binary);
+}
+
 bool Setup(char **const envp) {
   // We need to setup the rootfs here
   // If the configuration is set to use a folder then there is nothing to do
@@ -21,6 +73,20 @@ bool Setup(char **const envp) {
 
   FEX_CONFIG_OPT(LDPath, ROOTFS);
   if (FEX::FormatCheck::IsSquashFS(LDPath())) {
+    // Check if the rootfs is already mounted
+    // We can do this by checking the lock file if it exists
+
+    struct utsname uts{};
+    uname (&uts);
+    std::string LockPath = "/tmp/.FEX-";
+    LockPath += std::filesystem::path(LDPath()).filename();
+    LockPath += ".lock.";
+    LockPath += uts.nodename;
+
+    if (CheckLockExists(LockPath)) {
+      // RootFS already exists. Nothing to do
+      return true;
+    }
     pid_t ParentTID = ::getpid();
     std::string ParentTIDString = std::to_string(ParentTID);
     std::string Tmp = "/tmp/.FEXMount" + ParentTIDString + "-XXXXXX";
@@ -103,22 +169,27 @@ bool Setup(char **const envp) {
         return false;
       }
 
+      // Open the lock to let the daemon know that it has an active user
+      OpenLock(LockPath);
+
       // Check if we have an directory inside our temp folder
-      std::string Path = TempFolder;
-      std::string PathUser = Path + "/usr";
-      if (!std::filesystem::exists(PathUser)) {
-        LogMan::Msg::D("Child couldn't mount rootfs, /usr doesn't exist");
-        rmdir(TempFolder);
+      if (!SanityCheckPath(TempFolder)) {
         return false;
       }
 
       // If everything has passed then we can now update the rootfs path
-      FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_ROOTFS, Path);
+      FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_ROOTFS, TempFolder);
       return true;
     }
   }
 
   // Nothing to do
   return true;
+}
+
+void Shutdown() {
+  // Close the FD so our rootfs process can refcount
+  // Even if we crash the rootfs process will see a close event
+  SquashFSLock.close();
 }
 }

--- a/Source/Common/RootFSSetup.h
+++ b/Source/Common/RootFSSetup.h
@@ -2,4 +2,5 @@
 
 namespace FEX::RootFS {
   bool Setup(char **const envp);
+  void Shutdown();
 }

--- a/Source/Tests/FEXLoader.cpp
+++ b/Source/Tests/FEXLoader.cpp
@@ -571,6 +571,8 @@ int main(int argc, char **argv, char **const envp) {
 
   Loader.FreeSections();
 
+  FEX::RootFS::Shutdown();
+
   FEXCore::Config::Shutdown();
 
   LogMan::Throw::UnInstallHandlers();
@@ -578,6 +580,7 @@ int main(int argc, char **argv, char **const envp) {
 
   FEXCore::Allocator::ClearHooks();
   // Allocator is now original system allocator
+
 
   if (ShutdownReason == FEXCore::Context::ExitReason::EXIT_SHUTDOWN) {
     return ProgramStatus;


### PR DESCRIPTION
Instead of watching to ensure our parent process is still alive. Mount the
squashfs once and use a combination of file leases and inotify to
ref count how many processes are using the rootfs.

This makes it so in the common case, the FEXMountDaemon only ever executes once
and runs until all FEX processes stop running.
In the rare edge case there is a race condition where multiple FEXMountDaemon
applications will start, but only one will end up mounting the squashfs.
In this case, one application wins and the one that failed to grab the lease
will wait until the other one completes.

With this change, squashfs should be reasonable to use now.