### PR TITLE
Linux: Implements pivot_root syscall

### DIFF
--- a/Source/Tests/LinuxSyscalls/Syscalls/FS.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/FS.cpp
@@ -229,5 +229,10 @@ namespace FEX::HLE {
       uint64_t Result = ::fanotify_mark(fanotify_fd, flags, mask, dirfd, pathname);
       SYSCALL_ERRNO();
     });
+
+    REGISTER_SYSCALL_IMPL(pivot_root, [](FEXCore::Core::CpuStateFrame *Frame, const char *new_root, const char *put_old) -> uint64_t {
+      uint64_t Result = ::syscall(SYS_pivot_root, new_root, put_old);
+      SYSCALL_ERRNO();
+    });
   }
 }

--- a/Source/Tests/LinuxSyscalls/Syscalls/NotImplemented.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/NotImplemented.cpp
@@ -41,7 +41,6 @@ namespace FEX::HLE {
       REGISTER_SYSCALL_NOT_IMPL(_sysctl); // Was removed in Linux 5.5
 
       REGISTER_SYSCALL_NO_PERM(vhangup);
-      REGISTER_SYSCALL_NO_PERM(pivot_root);
       REGISTER_SYSCALL_NO_PERM(reboot)
       REGISTER_SYSCALL_NO_PERM(sethostname);
       REGISTER_SYSCALL_NO_PERM(setdomainname);


### PR DESCRIPTION
Somehow missed this one. Easy enough and matches between architectures.
Used by bubblewrap