### PR TITLE
Implements support for offline *only* telemetry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ option(ENABLE_STRICT_WERROR "Enables stricter -Werror for CI" FALSE)
 option(ENABLE_WERROR "Enables -Werror" FALSE)
 option(ENABLE_STATIC_PIE "Enables static-pie build" FALSE)
 option(ENABLE_JEMALLOC "Enables jemalloc allocator" TRUE)
+option(ENABLE_OFFLINE_TELEMETRY "Enables FEX offline telemetry" TRUE)
 
 set (X86_C_COMPILER "x86_64-linux-gnu-gcc" CACHE STRING "c compiler for compiling x86 guest libs")
 set (X86_CXX_COMPILER "x86_64-linux-gnu-g++" CACHE STRING "c++ compiler for compiling x86 guest libs")
@@ -80,6 +81,11 @@ set (PTHREAD_LIB pthread)
 if (ENABLE_LLD)
   set (LD_OVERRIDE "-fuse-ld=lld")
   link_libraries(${LD_OVERRIDE})
+endif()
+
+if (NOT ENABLE_OFFLINE_TELEMETRY)
+  # Disable FEX offline telemetry entirely if asked
+  add_definitions(-DFEX_DISABLE_TELEMETRY=1)
 endif()
 
 if (ENABLE_STATIC_PIE)

--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -129,6 +129,7 @@ set (SRCS
   Utils/Allocator.cpp
   Utils/Allocator/64BitAllocator.cpp
   Utils/LogManager.cpp
+  Utils/Telemetry.cpp
   Utils/Threads.cpp
   )
 

--- a/External/FEXCore/Source/Common/Paths.cpp
+++ b/External/FEXCore/Source/Common/Paths.cpp
@@ -3,11 +3,42 @@
 
 #include <cstdlib>
 #include <filesystem>
+#include <pwd.h>
 #include <sys/stat.h>
+#include <unistd.h>
 
 namespace FEXCore::Paths {
   std::unique_ptr<std::string> CachePath;
   std::unique_ptr<std::string> EntryCache;
+
+  char const* FindUserHomeThroughUID() {
+    auto passwd = getpwuid(geteuid());
+    if (passwd) {
+      return passwd->pw_dir;
+    }
+    return nullptr;
+  }
+
+  const char *GetHomeDirectory() {
+    char const *HomeDir = getenv("HOME");
+
+    // Try to get home directory from uid
+    if (!HomeDir) {
+      HomeDir = FindUserHomeThroughUID();
+    }
+
+    // try the PWD
+    if (!HomeDir) {
+      HomeDir = getenv("PWD");
+    }
+
+    // Still doesn't exit? You get local
+    if (!HomeDir) {
+      HomeDir = ".";
+    }
+
+    return HomeDir;
+  }
 
   void InitializePaths() {
     CachePath = std::make_unique<std::string>();

--- a/External/FEXCore/Source/Common/Paths.h
+++ b/External/FEXCore/Source/Common/Paths.h
@@ -4,6 +4,9 @@
 namespace FEXCore::Paths {
   void InitializePaths();
   void ShutdownPaths();
+
+  const char *GetHomeDirectory();
+
   std::string GetCachePath();
   std::string GetEntryCachePath();
 }

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -1091,7 +1091,9 @@ namespace FEXCore::Context {
 
     if (NewBlock == 0) {
       LogMan::Msg::E("CompileBlockJit: Failed to compile code %lX - aborting process", GuestRIP);
-      abort();
+      // Return similar behaviour of SIGILL abort
+      Frame->Thread->StatusCode = 128 + SIGILL;
+      Stop(false /* Ignore current thread */);
     }
   }
 

--- a/External/FEXCore/Source/Interface/Core/Frontend.cpp
+++ b/External/FEXCore/Source/Interface/Core/Frontend.cpp
@@ -15,6 +15,7 @@ $end_info$
 #include <FEXCore/Core/X86Enums.h>
 #include <FEXCore/Debug/X86Tables.h>
 #include <FEXCore/Utils/LogManager.h>
+#include <FEXCore/Utils/Telemetry.h>
 #include <set>
 #include <sys/mman.h>
 
@@ -696,6 +697,7 @@ bool Decoder::NormalOpHeader(FEXCore::X86Tables::X86InstInfo const *Info, uint16
     return NormalOp(&X87Ops[X87Op], X87Op);
   }
   else if (Info->Type == FEXCore::X86Tables::TYPE_VEX_TABLE_PREFIX) {
+    FEXCORE_TELEMETRY_SET(VEXOpTelem, 1);
     uint16_t map_select = 1;
     uint16_t pp = 0;
 
@@ -723,6 +725,7 @@ bool Decoder::NormalOpHeader(FEXCore::X86Tables::X86InstInfo const *Info, uint16
 
     if (LocalInfo->Type >= FEXCore::X86Tables::TYPE_VEX_GROUP_12 &&
         LocalInfo->Type <= FEXCore::X86Tables::TYPE_VEX_GROUP_17) {
+    FEXCORE_TELEMETRY_SET(VEXOpTelem, 1);
     // We have ModRM
     uint8_t ModRMByte = ReadByte();
     DecodeInst->ModRM = ModRMByte;
@@ -740,6 +743,8 @@ bool Decoder::NormalOpHeader(FEXCore::X86Tables::X86InstInfo const *Info, uint16
       return NormalOp(LocalInfo, Op);
   }
   else if (Info->Type == FEXCore::X86Tables::TYPE_GROUP_EVEX) {
+    FEXCORE_TELEMETRY_SET(EVEXOpTelem, 1);
+
     /* uint8_t P1 = */ ReadByte();
     /* uint8_t P2 = */ ReadByte();
     /* uint8_t P3 = */ ReadByte();

--- a/External/FEXCore/Source/Interface/Core/Frontend.h
+++ b/External/FEXCore/Source/Interface/Core/Frontend.h
@@ -2,6 +2,7 @@
 
 #include <FEXCore/Debug/X86Tables.h>
 #include <FEXCore/HLE/SyscallHandler.h>
+#include <FEXCore/Utils/Telemetry.h>
 
 #include <array>
 #include <cstdint>
@@ -89,5 +90,8 @@ private:
   };
 
   const uint8_t *AdjustAddrForSpecialRegion(uint8_t const* _InstStream, uint64_t EntryPoint, uint64_t RIP);
+
+  FEXCORE_TELEMETRY_INIT(VEXOpTelem, TYPE_USES_VEX_OPS);
+  FEXCORE_TELEMETRY_INIT(EVEXOpTelem, TYPE_USES_EVEX_OPS);
 };
 }

--- a/External/FEXCore/Source/Utils/Telemetry.cpp
+++ b/External/FEXCore/Source/Utils/Telemetry.cpp
@@ -1,0 +1,61 @@
+
+#include "Common/Paths.h"
+
+#include <FEXCore/Config/Config.h>
+#include <FEXCore/Utils/LogManager.h>
+#include <FEXCore/Utils/Telemetry.h>
+
+#include <array>
+#include <filesystem>
+#include <fstream>
+
+namespace FEXCore::Telemetry {
+#ifndef FEX_DISABLE_TELEMETRY
+  static std::array<Value, FEXCore::Telemetry::TelemetryType::TYPE_LAST> TelemetryValues = {{ }};
+  const std::array<std::string, FEXCore::Telemetry::TelemetryType::TYPE_LAST> TelemetryNames {
+    "64byte Split Locks",
+    "16Byte Split atomics",
+    "VEX instructions (AVX)",
+    "EVEX instructions (AVX512)",
+  };
+  void Initialize() {
+    auto DataDirectory = Config::GetDataDirectory();
+    DataDirectory += "Telemetry/";
+
+    // Ensure the folder structure is created for our configuration
+    std::error_code ec{};
+    if (!std::filesystem::exists(DataDirectory, ec) &&
+        !std::filesystem::create_directories(DataDirectory, ec)) {
+      LogMan::Msg::I("Couldn't create telemetry Folder");
+    }
+  }
+
+  void Shutdown(std::filesystem::path &ApplicationName) {
+    auto DataDirectory = Config::GetDataDirectory();
+    DataDirectory += "Telemetry/" + ApplicationName.string() + ".telem";
+
+    std::error_code ec{};
+    if (std::filesystem::exists(DataDirectory, ec)) {
+      // If the file exists, retain a single backup
+      auto Backup = DataDirectory + ".1";
+      std::filesystem::copy_file(DataDirectory, Backup, std::filesystem::copy_options::overwrite_existing, ec);
+    }
+
+    std::fstream fs(DataDirectory, std::ios_base::out | std::ios_base::trunc);
+    if (fs.is_open()) {
+      for (size_t i = 0; i < TelemetryType::TYPE_LAST; ++i) {
+        auto &Name = TelemetryNames.at(i);
+        auto &Data = TelemetryValues.at(i);
+        fs << Name << ": " << *Data << std::endl;
+      }
+
+      fs.flush();
+      fs.close();
+    }
+  }
+
+  Value &GetObject(TelemetryType Type) {
+    return TelemetryValues.at(Type);
+  }
+#endif
+}

--- a/External/FEXCore/include/FEXCore/Utils/Telemetry.h
+++ b/External/FEXCore/include/FEXCore/Utils/Telemetry.h
@@ -1,0 +1,67 @@
+#pragma once
+#include <atomic>
+#include <stdint.h>
+#include <type_traits>
+#include <filesystem>
+
+namespace FEXCore::Telemetry {
+#ifndef FEX_DISABLE_TELEMETRY
+  class Value;
+
+  class Value final {
+    public:
+      Value() = default;
+      Value(uint64_t Default) : Data {Default} {}
+
+      uint64_t operator*() const { return Data; }
+      void operator=(uint64_t Value) { Data = Value; }
+      void operator|=(uint64_t Value) { Data |= Value; }
+      void operator++(int) { Data++; }
+
+      std::atomic<uint64_t> *GetAddr() { return &Data; }
+
+    private:
+      std::atomic<uint64_t> Data;
+  };
+
+  enum TelemetryType {
+    TYPE_HAS_SPLIT_LOCKS,
+    TYPE_16BYTE_SPLIT,
+    TYPE_USES_VEX_OPS,
+    TYPE_USES_EVEX_OPS,
+    TYPE_LAST,
+  };
+
+  Value &GetObject(TelemetryType Type);
+
+  void Initialize();
+  void Shutdown(std::filesystem::path &ApplicationName);
+
+// Telemetry object declaration
+// This returns the internal structure to the telemetry data structures
+// One must be careful with placing these in the hot path of code execution
+// It can be fairly costly, especially in the static version where it puts barriers in the code
+#define FEXCORE_TELEMETRY_STATIC_INIT(Name, Type) static FEXCore::Telemetry::Value &Name = FEXCore::Telemetry::GetObject(FEXCore::Telemetry::Type)
+#define FEXCORE_TELEMETRY_INIT(Name, Type) FEXCore::Telemetry::Value &Name = FEXCore::Telemetry::GetObject(FEXCore::Telemetry::Type)
+// Telemetry ALU operations
+// These are typically 3-4 instructions depending on what you're doing
+#define FEXCORE_TELEMETRY_SET(Name, Value) Name = Value
+#define FEXCORE_TELEMETRY_OR(Name, Value) Name |= Value
+#define FEXCORE_TELEMETRY_INC(Name) Name++
+
+// Returns a pointer to std::atomic<uint64_t>. Can be useful if you are attempting to JIT telemetry accesses for debug purposes
+// Not recommended to do telemetry inside JIT code in production code
+#define FEXCORE_TELEMETRY_Addr(Name) Name->GetAddr()
+#else
+  static inline void Initialize() {}
+  static inline void Shutdown(std::filesystem::path &) {}
+
+#define FEXCORE_TELEMETRY_STATIC_INIT(Name, Type)
+#define FEXCORE_TELEMETRY_INIT(Name, Type)
+#define FEXCORE_TELEMETRY(Name, Value) do {} while(0)
+#define FEXCORE_TELEMETRY_SET(Name, Value) do {} while(0)
+#define FEXCORE_TELEMETRY_OR(Name, Value) do {} while(0)
+#define FEXCORE_TELEMETRY_INC(Name) do {} while(0)
+#define FEXCORE_TELEMETRY_Addr(Name) reinterpret_cast<std::atomic<uint64_t>*>(nullptr)
+#endif
+}

--- a/Source/Tests/FEXLoader.cpp
+++ b/Source/Tests/FEXLoader.cpp
@@ -21,6 +21,7 @@ $end_info$
 #include <FEXCore/Core/Context.h>
 #include <FEXCore/Utils/Allocator.h>
 #include <FEXCore/Utils/LogManager.h>
+#include <FEXCore/Utils/Telemetry.h>
 
 #include <cstdint>
 #include <filesystem>
@@ -409,6 +410,7 @@ int main(int argc, char **argv, char **const envp) {
     }
   }
 
+  FEXCore::Telemetry::Initialize();
   InterpreterHandler(&Program, LDPath(), &Args);
 
   std::error_code ec{};
@@ -590,7 +592,7 @@ int main(int argc, char **argv, char **const envp) {
   FEXCore::Allocator::ClearHooks();
   // Allocator is now original system allocator
 
-
+  FEXCore::Telemetry::Shutdown(ProgramName);
   if (ShutdownReason == FEXCore::Context::ExitReason::EXIT_SHUTDOWN) {
     return ProgramStatus;
   }


### PR DESCRIPTION
This information is only ever going to be offline. Will be useful for multiple reasons.

1) Searching for split lock usage in applications, which can be a programming bug.
  a) This isn't visible on AMD systems and on Intel is a fairly new linux feature
2) Having more information about when an application breaks.
3) Useful for some minor profiling for devs looking for statistical data