### PR TITLE
Arm64: Reimplements support for binfmt_misc without update-binfmts

### DIFF
--- a/Source/Tests/CMakeLists.txt
+++ b/Source/Tests/CMakeLists.txt
@@ -42,25 +42,56 @@ install(
 install(PROGRAMS "${PROJECT_SOURCE_DIR}/Scripts/FEXUpdateAOTIRCache.sh" DESTINATION bin RENAME FEXUpdateAOTIRCache)
 
 if (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
-  add_custom_target(binfmt_misc_32
-    echo "Attempting to install FEX-x86 misc now."
-    COMMAND "update-binfmts" "--importdir=${CMAKE_INSTALL_PREFIX}/share/binfmts/" "--import" "FEX-x86"
-    COMMAND ${CMAKE_COMMAND} -E
-    echo "binfmt_misc FEX-x86 installed"
-  )
+  find_program(UPDATE_BINFMTS_PROGRAM update-binfmts)
+  if (UPDATE_BINFMTS_PROGRAM)
+    add_custom_target(binfmt_misc_32
+      echo "Attempting to install FEX-x86 misc now."
+      COMMAND "update-binfmts" "--importdir=${CMAKE_INSTALL_PREFIX}/share/binfmts/" "--import" "FEX-x86"
+      COMMAND ${CMAKE_COMMAND} -E
+      echo "binfmt_misc FEX-x86 installed"
+    )
 
-  add_custom_target(binfmt_misc_64
-    COMMAND ${CMAKE_COMMAND} -E
-    echo "Attempting to install FEX-x86_64 misc now."
-    COMMAND "update-binfmts" "--importdir=${CMAKE_INSTALL_PREFIX}/share/binfmts/" "--import" "FEX-x86_64"
-    COMMAND ${CMAKE_COMMAND} -E
-    echo "binfmt_misc FEX-x86_64 installed"
-  )
+    add_custom_target(binfmt_misc_64
+      COMMAND ${CMAKE_COMMAND} -E
+      echo "Attempting to install FEX-x86_64 misc now."
+      COMMAND "update-binfmts" "--importdir=${CMAKE_INSTALL_PREFIX}/share/binfmts/" "--import" "FEX-x86_64"
+      COMMAND ${CMAKE_COMMAND} -E
+      echo "binfmt_misc FEX-x86_64 installed"
+    )
+  else()
+    # In the case of update-binfmts not being available (Arch for example) then we need to install manually
+    add_custom_target(binfmt_misc_32
+      COMMAND ${CMAKE_COMMAND} -E
+        echo "Attempting to remove FEX-x86 misc prior to install. Ignore permission denied"
+      COMMAND ${CMAKE_COMMAND} -E
+        echo -1 > /proc/sys/fs/binfmt_misc/FEX-x86 || (exit 0)
+      COMMAND ${CMAKE_COMMAND} -E
+        echo "Attempting to install FEX-x86 misc now."
+      COMMAND ${CMAKE_COMMAND} -E
+        echo
+        ':FEX-x86:M:0:\\x7fELF\\x01\\x01\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x02\\x00\\x03\\x00:\\xff\\xff\\xff\\xff\\xff\\xfe\\xfe\\x00\\x00\\x00\\x00\\xff\\xff\\xff\\xff\\xff\\xfe\\xff\\xff\\xff:${CMAKE_INSTALL_PREFIX}/bin/FEXInterpreter:POCF' > /proc/sys/fs/binfmt_misc/register
+      COMMAND ${CMAKE_COMMAND} -E
+        echo "binfmt_misc FEX-x86 installed"
+      )
+    add_custom_target(binfmt_misc_64
+      COMMAND ${CMAKE_COMMAND} -E
+        echo "Attempting to remove FEX-x86_64 misc prior to install. Ignore permission denied"
+      COMMAND ${CMAKE_COMMAND} -E
+        echo -1 > /proc/sys/fs/binfmt_misc/FEX-x86_64 || (exit 0)
+      COMMAND ${CMAKE_COMMAND} -E
+        echo "Attempting to install FEX-x86_64 misc now."
+      COMMAND ${CMAKE_COMMAND} -E
+        echo
+        ':FEX-x86_64:M:0:\\x7fELF\\x02\\x01\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x02\\x00\\x3e\\x00:\\xff\\xff\\xff\\xff\\xff\\xfe\\xfe\\x00\\x00\\x00\\x00\\xff\\xff\\xff\\xff\\xff\\xfe\\xff\\xff\\xff:${CMAKE_INSTALL_PREFIX}/bin/FEXInterpreter:POCF' > /proc/sys/fs/binfmt_misc/register
+      COMMAND ${CMAKE_COMMAND} -E
+        echo "binfmt_misc FEX-x86_64 installed"
+      )
+  endif()
+
   add_custom_target(binfmt_misc
     DEPENDS binfmt_misc_32
     DEPENDS binfmt_misc_64
   )
-
 endif()
 
 add_executable(FEXBash FEXBash.cpp)


### PR DESCRIPTION
Arch doesn't have update-binfmts. Fall back to the classic approach
without it.

Fixes #1195