### PR TITLE
Linux: Implements support for clone with namespaces 

### DIFF
--- a/External/FEXCore/Source/Interface/Config/Config.cpp
+++ b/External/FEXCore/Source/Interface/Config/Config.cpp
@@ -10,6 +10,14 @@
 #include <sys/sysinfo.h>
 
 namespace FEXCore::Config {
+namespace DefaultValues {
+#define P(x) x
+#define OPT_BASE(type, group, enum, json, default) const P(type) P(enum) = P(default);
+#define OPT_STR(group, enum, json, default) const std::string_view P(enum) = P(default);
+#define OPT_STRARRAY(group, enum, json, default) OPT_STR(group, enum, json, default)
+#include <FEXCore/Config/ConfigValues.inl>
+}
+
   std::string GetDataDirectory() {
     std::string DataDir{};
 
@@ -384,6 +392,17 @@ namespace FEXCore::Config {
     }
     else {
       return Default;
+    }
+  }
+
+  template<>
+  std::string Value<std::string>::GetIfExists(FEXCore::Config::ConfigOption Option, std::string_view Default) {
+    auto Value = FEXCore::Config::Get(Option);
+    if (Value) {
+      return **Value;
+    }
+    else {
+      return std::string(Default);
     }
   }
 

--- a/External/FEXCore/Source/Interface/Context/Context.cpp
+++ b/External/FEXCore/Source/Interface/Context/Context.cpp
@@ -117,6 +117,10 @@ namespace FEXCore::Context {
     return CTX->CreateThread(NewThreadState, ParentTID);
   }
 
+  void ExecutionThread(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread) {
+    return CTX->ExecutionThread(Thread);
+  }
+
   void InitializeThread(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread) {
     return CTX->InitializeThread(Thread);
   }

--- a/External/FEXCore/Source/Interface/IR/IRParser.cpp
+++ b/External/FEXCore/Source/Interface/IR/IRParser.cpp
@@ -70,8 +70,6 @@ std::string DecodeErrorToString(DecodeFailure Failure) {
   return "Unknown Error";
 }
 
-std::unordered_map<std::string_view, FEXCore::IR::IROps> NameToOpMap;
-
 class IRParser: public FEXCore::IR::IREmitter {
   public:
   template<typename Type>
@@ -299,9 +297,10 @@ class IRParser: public FEXCore::IR::IREmitter {
   std::unordered_map<std::string, OrderedNode*> SSANameMapper;
   std::vector<LineDefinition> Defs;
   LineDefinition *CurrentDef{};
+  std::unordered_map<std::string_view, FEXCore::IR::IROps> NameToOpMap;
 
   IRParser(std::istream *text) {
-    InitializeStaticTables();
+    InitializeNameMap();
 
     std::string TmpLine;
     while (!text->eof()) {
@@ -630,7 +629,7 @@ class IRParser: public FEXCore::IR::IREmitter {
 		return true;
 	}
 
-  void InitializeStaticTables() {
+  void InitializeNameMap() {
     if (NameToOpMap.empty()) {
       for (FEXCore::IR::IROps Op = FEXCore::IR::IROps::OP_DUMMY;
          Op <= FEXCore::IR::IROps::OP_LAST;

--- a/External/FEXCore/Source/Utils/Allocator.cpp
+++ b/External/FEXCore/Source/Utils/Allocator.cpp
@@ -75,6 +75,11 @@ namespace FEXCore::Allocator {
 #endif
     FEXCore::Allocator::mmap = ::mmap;
     FEXCore::Allocator::munmap = ::munmap;
+
+    // XXX: This is currently a leak.
+    // We can't work around this yet until static initializers that allocate memory are completely removed from our codebase
+    // Luckily we only remove this on process shutdown, so the kernel will do the cleanup for us
+    Alloc64.release();
   }
 #pragma GCC diagnostic pop
 

--- a/External/FEXCore/Source/Utils/Telemetry.cpp
+++ b/External/FEXCore/Source/Utils/Telemetry.cpp
@@ -12,7 +12,7 @@
 namespace FEXCore::Telemetry {
 #ifndef FEX_DISABLE_TELEMETRY
   static std::array<Value, FEXCore::Telemetry::TelemetryType::TYPE_LAST> TelemetryValues = {{ }};
-  const std::array<std::string, FEXCore::Telemetry::TelemetryType::TYPE_LAST> TelemetryNames {
+  const std::array<std::string_view, FEXCore::Telemetry::TelemetryType::TYPE_LAST> TelemetryNames {
     "64byte Split Locks",
     "16Byte Split atomics",
     "VEX instructions (AVX)",

--- a/External/FEXCore/include/FEXCore/Core/Context.h
+++ b/External/FEXCore/include/FEXCore/Core/Context.h
@@ -223,6 +223,7 @@ namespace FEXCore::Context {
   FEX_DEFAULT_VISIBILITY void RegisterFrontendHostSignalHandler(FEXCore::Context::Context *CTX, int Signal, HostSignalDelegatorFunction Func, bool Required);
 
   FEX_DEFAULT_VISIBILITY FEXCore::Core::InternalThreadState* CreateThread(FEXCore::Context::Context *CTX, FEXCore::Core::CPUState *NewThreadState, uint64_t ParentTID);
+  FEX_DEFAULT_VISIBILITY void ExecutionThread(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread);
   FEX_DEFAULT_VISIBILITY void InitializeThread(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread);
   FEX_DEFAULT_VISIBILITY void RunThread(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread);
   FEX_DEFAULT_VISIBILITY void StopThread(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread);

--- a/External/FEXCore/include/FEXCore/Utils/Threads.h
+++ b/External/FEXCore/include/FEXCore/Utils/Threads.h
@@ -32,9 +32,14 @@ namespace FEXCore::Threads {
       void* Arg);
 
     static void CleanupAfterFork();
+
     /**  @} */
 
     // Set API functions
     static void SetInternalPointers(Pointers const &_Ptrs);
   };
+
+  void *AllocateStackObject(size_t Size);
+  void DeallocateStackObject(void *Ptr, size_t Size);
+  void Shutdown();
 }

--- a/Source/Tests/FEXLoader.cpp
+++ b/Source/Tests/FEXLoader.cpp
@@ -22,6 +22,7 @@ $end_info$
 #include <FEXCore/Utils/Allocator.h>
 #include <FEXCore/Utils/LogManager.h>
 #include <FEXCore/Utils/Telemetry.h>
+#include <FEXCore/Utils/Threads.h>
 
 #include <cstdint>
 #include <filesystem>
@@ -579,6 +580,7 @@ int main(int argc, char **argv, char **const envp) {
   FEXCore::Context::DestroyContext(CTX);
 
   FEXCore::Context::ShutdownStaticTables();
+  FEXCore::Threads::Shutdown();
 
   Loader.FreeSections();
 

--- a/Source/Tests/LinuxSyscalls/Syscalls.h
+++ b/Source/Tests/LinuxSyscalls/Syscalls.h
@@ -272,7 +272,7 @@ struct open_how {
   uint64_t resolve;
 };
 
-struct clone3_args {
+struct kernel_clone3_args {
   uint64_t flags;
   uint64_t pidfd;
   uint64_t child_tid;
@@ -285,6 +285,17 @@ struct clone3_args {
   uint64_t set_tid_size;
   uint64_t cgroup;
 };
+
+enum TypeOfClone {
+  TYPE_CLONE2,
+  TYPE_CLONE3,
+};
+
+struct clone3_args {
+  TypeOfClone Type;
+  kernel_clone3_args args;
+};
+
 uint64_t CloneHandler(FEXCore::Core::CpuStateFrame *Frame, FEX::HLE::clone3_args *args);
 
   inline static int RemapFromX86Flags(int flags) {

--- a/Source/Tests/LinuxSyscalls/Syscalls/Thread.h
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Thread.h
@@ -14,6 +14,7 @@ struct CPUState;
 }
 
 namespace FEX::HLE {
-  FEXCore::Core::InternalThreadState *CreateNewThread(FEXCore::Context::Context *CTX, FEXCore::Core::CpuStateFrame *Frame, FEX::HLE::clone3_args *args);
+  FEXCore::Core::InternalThreadState *CreateNewThread(FEXCore::Context::Context *CTX, FEXCore::Core::CpuStateFrame *Frame, FEX::HLE::kernel_clone3_args *args);
+  uint64_t HandleNewClone(FEXCore::Core::InternalThreadState *Thread, FEXCore::Context::Context *CTX, FEXCore::Core::CpuStateFrame *Frame, FEX::HLE::kernel_clone3_args *GuestArgs);
   uint64_t ForkGuest(FEXCore::Core::InternalThreadState *Thread, FEXCore::Core::CpuStateFrame *Frame, uint32_t flags, void *stack, pid_t *parent_tid, pid_t *child_tid, void *tls);
 }

--- a/Source/Tests/LinuxSyscalls/x32/Thread.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Thread.cpp
@@ -63,17 +63,20 @@ namespace FEX::HLE::x32 {
   void RegisterThread() {
     REGISTER_SYSCALL_IMPL_X32(clone, ([](FEXCore::Core::CpuStateFrame *Frame, uint32_t flags, void *stack, pid_t *parent_tid, void *tls, pid_t *child_tid) -> uint64_t {
       FEX::HLE::clone3_args args {
-        .flags = flags & ~CSIGNAL, // This no longer contains CSIGNAL
-        .pidfd = reinterpret_cast<uint64_t>(parent_tid), // For clone, pidfd is duplicated here
-        .child_tid = reinterpret_cast<uint64_t>(child_tid),
-        .parent_tid = reinterpret_cast<uint64_t>(parent_tid),
-        .exit_signal = flags & CSIGNAL,
-        .stack = reinterpret_cast<uint64_t>(stack),
-        .stack_size = ~0ULL, // This syscall isn't able to see the stack size
-        .tls = reinterpret_cast<uint64_t>(tls),
-        .set_tid = 0, // This syscall isn't able to select TIDs
-        .set_tid_size = 0,
-        .cgroup = 0, // This syscall can't select cgroups
+        .Type = TypeOfClone::TYPE_CLONE2,
+        .args = {
+          .flags = flags & ~CSIGNAL, // This no longer contains CSIGNAL
+          .pidfd = reinterpret_cast<uint64_t>(parent_tid), // For clone, pidfd is duplicated here
+          .child_tid = reinterpret_cast<uint64_t>(child_tid),
+          .parent_tid = reinterpret_cast<uint64_t>(parent_tid),
+          .exit_signal = flags & CSIGNAL,
+          .stack = reinterpret_cast<uint64_t>(stack),
+          .stack_size = ~0ULL, // This syscall isn't able to see the stack size
+          .tls = reinterpret_cast<uint64_t>(tls),
+          .set_tid = 0, // This syscall isn't able to select TIDs
+          .set_tid_size = 0,
+          .cgroup = 0, // This syscall can't select cgroups
+        }
       };
       return CloneHandler(Frame, &args);
     }));

--- a/unittests/gvisor-tests/Disabled_Tests
+++ b/unittests/gvisor-tests/Disabled_Tests
@@ -91,3 +91,7 @@ rtsignal_test
 # This takes advantage of CLONE_VM in a way that breaks FEX's TLS usage
 # Need to workaround this somehow
 aio_test
+
+# The Solidrun CI board isn't running a kernel with namespaces enabled
+# gvisor doesn't error check correctly in this case and returns hard failure instead of correctly exiting
+proc_pid_uid_gid_map_test

--- a/unittests/gvisor-tests/Disabled_Tests
+++ b/unittests/gvisor-tests/Disabled_Tests
@@ -87,3 +87,7 @@ pause_test
 
 # ARMv8.4 periodically flakes on this one
 rtsignal_test
+
+# This takes advantage of CLONE_VM in a way that breaks FEX's TLS usage
+# Need to workaround this somehow
+aio_test

--- a/unittests/gvisor-tests/Known_Failures
+++ b/unittests/gvisor-tests/Known_Failures
@@ -173,3 +173,7 @@ pause_test
 
 # ARMv8.4 periodically flakes on this one
 rtsignal_test
+
+# The Solidrun CI board isn't running a kernel with namespaces enabled
+# gvisor doesn't error check correctly in this case and returns hard failure instead of correctly exiting
+proc_pid_uid_gid_map_test


### PR DESCRIPTION
This is very tricky to handle and it has a bunch of rough edges.
One of the major problems that we can't workaround is that if we receive a
clone flag that pthreads can't support with THREAD, then we are required to fall down
the pthreads code path.
This is because threads going down the clone path will break TLS and we don't have
a way to work around it currently.

So this adds a clone path, a clone3 path, and keeps the legacy path as well.
Which makes this fairly convoluted but it gets pressure-vessel working on x86-64 host.
It's a bit tricky to setup but it does work.

Still some work necessary to get pressure-vessel working on AArch64 host, but I'm working on that.