### PR TITLE
 OpcodeDispatcher: Implements undocumented repne on string ops

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -3117,11 +3117,6 @@ void OpDispatchBuilder::DECOp(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::STOSOp(OpcodeArgs) {
-  if (Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_REPNE_PREFIX) {
-    LogMan::Msg::E("Invalid REPNE on STOS");
-    DecodeFailure = true;
-    return;
-  }
   if (Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_ADDRESS_SIZE) {
     LogMan::Msg::E("Can't handle adddress size");
     DecodeFailure = true;
@@ -3130,7 +3125,7 @@ void OpDispatchBuilder::STOSOp(OpcodeArgs) {
 
   const auto GPRSize = CTX->GetGPRSize();
   const auto Size = GetSrcSize(Op);
-  const bool Repeat = (Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_REP_PREFIX) != 0;
+  const bool Repeat = (Op->Flags & (FEXCore::X86Tables::DecodeFlags::FLAG_REP_PREFIX | FEXCore::X86Tables::DecodeFlags::FLAG_REPNE_PREFIX)) != 0;
 
   if (!Repeat) {
     OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
@@ -3225,11 +3220,6 @@ void OpDispatchBuilder::STOSOp(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::MOVSOp(OpcodeArgs) {
-  if (Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_REPNE_PREFIX) {
-    LogMan::Msg::E("Invalid REPNE on MOVS");
-    DecodeFailure = true;
-    return;
-  }
   if (Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_ADDRESS_SIZE) {
     LogMan::Msg::E("Can't handle adddress size");
     DecodeFailure = true;
@@ -3246,7 +3236,7 @@ void OpDispatchBuilder::MOVSOp(OpcodeArgs) {
   auto DF = GetRFLAG(FEXCore::X86State::RFLAG_DF_LOC);
   auto PtrDir = _Select(FEXCore::IR::COND_EQ, DF,  _Constant(0), SizeConst, NegSizeConst);
 
-  if (Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_REP_PREFIX) {
+  if (Op->Flags & (FEXCore::X86Tables::DecodeFlags::FLAG_REP_PREFIX | FEXCore::X86Tables::DecodeFlags::FLAG_REPNE_PREFIX)) {
     // Create all our blocks
     auto LoopHead = CreateNewCodeBlockAfter(GetCurrentBlock());
     auto LoopTail = CreateNewCodeBlockAfter(LoopHead);
@@ -3441,11 +3431,6 @@ void OpDispatchBuilder::CMPSOp(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::LODSOp(OpcodeArgs) {
-  if (Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_REPNE_PREFIX) {
-    LogMan::Msg::E("Invalid REPNE on LODS");
-    DecodeFailure = true;
-    return;
-  }
   if (Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_ADDRESS_SIZE) {
     LogMan::Msg::E("Can't handle adddress size");
     DecodeFailure = true;
@@ -3454,7 +3439,7 @@ void OpDispatchBuilder::LODSOp(OpcodeArgs) {
 
   const auto GPRSize = CTX->GetGPRSize();
   const auto Size = GetSrcSize(Op);
-  const bool Repeat = (Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_REP_PREFIX) != 0;
+  const bool Repeat = (Op->Flags & (FEXCore::X86Tables::DecodeFlags::FLAG_REP_PREFIX | FEXCore::X86Tables::DecodeFlags::FLAG_REPNE_PREFIX)) != 0;
 
   if (!Repeat) {
     OrderedNode *Dest_RSI = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RSI]), GPRClass);

--- a/unittests/ASM/Primary/Primary_A4_REPNE.asm
+++ b/unittests/ASM/Primary/Primary_A4_REPNE.asm
@@ -1,0 +1,34 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x4142434445464748",
+    "RDX": "0x0",
+    "RDI": "0xE0000018",
+    "RSI": "0xE0000008"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rdx + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [rdx + 8 * 1], rax
+mov rax, 0x0
+mov [rdx + 8 * 2], rax
+mov [rdx + 8 * 3], rax
+
+lea rdi, [rdx + 8 * 2]
+lea rsi, [rdx + 8 * 0]
+
+cld
+mov rcx, 8
+repne movsb ; rdi <- rsi
+
+mov rax, [rdx + 8 * 2]
+mov rdx, [rdx + 8 * 3]
+hlt

--- a/unittests/ASM/Primary/Primary_A4_REPNE_Down.asm
+++ b/unittests/ASM/Primary/Primary_A4_REPNE_Down.asm
@@ -1,0 +1,34 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x4142434445464748",
+    "RDX": "0x0",
+    "RDI": "0xE000000F",
+    "RSI": "0xDFFFFFFF"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rdx + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [rdx + 8 * 1], rax
+mov rax, 0x0
+mov [rdx + 8 * 2], rax
+mov [rdx + 8 * 3], rax
+
+lea rdi, [rdx + 8 * 2 + 7]
+lea rsi, [rdx + 8 * 0 + 7]
+
+std
+mov rcx, 8
+repne movsb ; rdi <- rsi
+
+mov rax, [rdx + 8 * 2]
+mov rdx, [rdx + 8 * 3]
+hlt

--- a/unittests/ASM/Primary/Primary_A4_REPNE_many.asm
+++ b/unittests/ASM/Primary/Primary_A4_REPNE_many.asm
@@ -1,0 +1,139 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x4142434445464748",
+    "RDX": "0x0",
+    "RDI": "0xE0000018",
+    "RSI": "0xE0000008"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rdx + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [rdx + 8 * 1], rax
+mov rax, 0x0
+mov [rdx + 8 * 2], rax
+mov [rdx + 8 * 3], rax
+
+lea rdi, [rdx + 8 * 2]
+lea rsi, [rdx + 8 * 0]
+
+cld
+mov rcx, 8
+repne movsb ; rdi <- rsi
+
+lea rdi, [rdx + 8 * 2]
+lea rsi, [rdx + 8 * 0]
+
+cld
+mov rcx, 8
+repne movsb ; rdi <- rsi
+
+lea rdi, [rdx + 8 * 2]
+lea rsi, [rdx + 8 * 0]
+
+cld
+mov rcx, 8
+repne movsb ; rdi <- rsi
+
+lea rdi, [rdx + 8 * 2]
+lea rsi, [rdx + 8 * 0]
+
+cld
+mov rcx, 8
+repne movsb ; rdi <- rsi
+
+lea rdi, [rdx + 8 * 2]
+lea rsi, [rdx + 8 * 0]
+
+cld
+mov rcx, 8
+repne movsb ; rdi <- rsi
+
+lea rdi, [rdx + 8 * 2]
+lea rsi, [rdx + 8 * 0]
+
+cld
+mov rcx, 8
+repne movsb ; rdi <- rsi
+
+lea rdi, [rdx + 8 * 2]
+lea rsi, [rdx + 8 * 0]
+
+cld
+mov rcx, 8
+repne movsb ; rdi <- rsi
+
+lea rdi, [rdx + 8 * 2]
+lea rsi, [rdx + 8 * 0]
+
+cld
+mov rcx, 8
+repne movsb ; rdi <- rsi
+
+lea rdi, [rdx + 8 * 2]
+lea rsi, [rdx + 8 * 0]
+
+cld
+mov rcx, 8
+repne movsb ; rdi <- rsi
+
+lea rdi, [rdx + 8 * 2]
+lea rsi, [rdx + 8 * 0]
+
+cld
+mov rcx, 8
+repne movsb ; rdi <- rsi
+
+lea rdi, [rdx + 8 * 2]
+lea rsi, [rdx + 8 * 0]
+
+cld
+mov rcx, 8
+repne movsb ; rdi <- rsi
+
+lea rdi, [rdx + 8 * 2]
+lea rsi, [rdx + 8 * 0]
+
+cld
+mov rcx, 8
+repne movsb ; rdi <- rsi
+
+lea rdi, [rdx + 8 * 2]
+lea rsi, [rdx + 8 * 0]
+
+cld
+mov rcx, 8
+repne movsb ; rdi <- rsi
+
+lea rdi, [rdx + 8 * 2]
+lea rsi, [rdx + 8 * 0]
+
+cld
+mov rcx, 8
+repne movsb ; rdi <- rsi
+
+lea rdi, [rdx + 8 * 2]
+lea rsi, [rdx + 8 * 0]
+
+cld
+mov rcx, 8
+repne movsb ; rdi <- rsi
+
+lea rdi, [rdx + 8 * 2]
+lea rsi, [rdx + 8 * 0]
+
+cld
+mov rcx, 8
+repne movsb ; rdi <- rsi
+
+mov rax, [rdx + 8 * 2]
+mov rdx, [rdx + 8 * 3]
+hlt

--- a/unittests/ASM/Primary/Primary_A5_REPNE.asm
+++ b/unittests/ASM/Primary/Primary_A5_REPNE.asm
@@ -1,0 +1,34 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x4142434445464748",
+    "RDX": "0x0",
+    "RDI": "0xE0000018",
+    "RSI": "0xE0000008"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rdx + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [rdx + 8 * 1], rax
+mov rax, 0x0
+mov [rdx + 8 * 2], rax
+mov [rdx + 8 * 3], rax
+
+lea rdi, [rdx + 8 * 2]
+lea rsi, [rdx + 8 * 0]
+
+cld
+mov rcx, 4
+repne movsw ; rdi <- rsi
+
+mov rax, [rdx + 8 * 2]
+mov rdx, [rdx + 8 * 3]
+hlt

--- a/unittests/ASM/Primary/Primary_A5_REPNE_Down.asm
+++ b/unittests/ASM/Primary/Primary_A5_REPNE_Down.asm
@@ -1,0 +1,34 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x4142434445464748",
+    "RDX": "0x0",
+    "RDI": "0xE000000E",
+    "RSI": "0xDFFFFFFE"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rdx + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [rdx + 8 * 1], rax
+mov rax, 0x0
+mov [rdx + 8 * 2], rax
+mov [rdx + 8 * 3], rax
+
+lea rdi, [rdx + 8 * 2 + 6]
+lea rsi, [rdx + 8 * 0 + 6]
+
+std
+mov rcx, 4
+repne movsw ; rdi <- rsi
+
+mov rax, [rdx + 8 * 2]
+mov rdx, [rdx + 8 * 3]
+hlt

--- a/unittests/ASM/Primary/Primary_A5_dword_REPNE.asm
+++ b/unittests/ASM/Primary/Primary_A5_dword_REPNE.asm
@@ -1,0 +1,34 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x4142434445464748",
+    "RDX": "0x0",
+    "RDI": "0xE0000018",
+    "RSI": "0xE0000008"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rdx + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [rdx + 8 * 1], rax
+mov rax, 0x0
+mov [rdx + 8 * 2], rax
+mov [rdx + 8 * 3], rax
+
+lea rdi, [rdx + 8 * 2]
+lea rsi, [rdx + 8 * 0]
+
+cld
+mov rcx, 2
+repne movsd ; rdi <- rsi
+
+mov rax, [rdx + 8 * 2]
+mov rdx, [rdx + 8 * 3]
+hlt

--- a/unittests/ASM/Primary/Primary_A5_dword_REPNE_Down.asm
+++ b/unittests/ASM/Primary/Primary_A5_dword_REPNE_Down.asm
@@ -1,0 +1,34 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x4142434445464748",
+    "RDX": "0x0",
+    "RDI": "0xE000000C",
+    "RSI": "0xDFFFFFFC"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rdx + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [rdx + 8 * 1], rax
+mov rax, 0x0
+mov [rdx + 8 * 2], rax
+mov [rdx + 8 * 3], rax
+
+lea rdi, [rdx + 8 * 2 + 4]
+lea rsi, [rdx + 8 * 0 + 4]
+
+std
+mov rcx, 2
+repne movsd ; rdi <- rsi
+
+mov rax, [rdx + 8 * 2]
+mov rdx, [rdx + 8 * 3]
+hlt

--- a/unittests/ASM/Primary/Primary_A5_qword_REPNE.asm
+++ b/unittests/ASM/Primary/Primary_A5_qword_REPNE.asm
@@ -1,0 +1,37 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x4142434445464748",
+    "RBX": "0x5152535455565758",
+    "RCX": "0x0",
+    "RDI": "0xE0000020",
+    "RSI": "0xE0000010"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rdx + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [rdx + 8 * 1], rax
+mov rax, 0x0
+mov [rdx + 8 * 2], rax
+mov [rdx + 8 * 3], rax
+mov [rdx + 8 * 4], rax
+
+lea rdi, [rdx + 8 * 2]
+lea rsi, [rdx + 8 * 0]
+
+cld
+mov rcx, 2
+repne movsq ; rdi <- rsi
+
+mov rax, [rdx + 8 * 2]
+mov rbx, [rdx + 8 * 3]
+mov rcx, [rdx + 8 * 4]
+hlt

--- a/unittests/ASM/Primary/Primary_A5_qword_REPNE_Down.asm
+++ b/unittests/ASM/Primary/Primary_A5_qword_REPNE_Down.asm
@@ -1,0 +1,37 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x4142434445464748",
+    "RBX": "0x5152535455565758",
+    "RCX": "0x0",
+    "RDI": "0xE0000008",
+    "RSI": "0xDFFFFFF8"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rdx + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [rdx + 8 * 1], rax
+mov rax, 0x0
+mov [rdx + 8 * 2], rax
+mov [rdx + 8 * 3], rax
+mov [rdx + 8 * 4], rax
+
+lea rdi, [rdx + 8 * 3]
+lea rsi, [rdx + 8 * 1]
+
+std
+mov rcx, 2
+repne movsq ; rdi <- rsi
+
+mov rax, [rdx + 8 * 2]
+mov rbx, [rdx + 8 * 3]
+mov rcx, [rdx + 8 * 4]
+hlt

--- a/unittests/ASM/Primary/Primary_A6_REPNE_Equal.asm
+++ b/unittests/ASM/Primary/Primary_A6_REPNE_Equal.asm
@@ -1,0 +1,51 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x4600",
+    "RCX": "0x0",
+    "RDX": "0x1",
+    "RDI": "0xE000000A",
+    "RSI": "0xE000001A"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+%macro copy 3
+  ; Dest, Src, Size
+  mov rdi, %1
+  mov rsi, %2
+  mov rcx, %3
+
+  cld
+  repne movsb
+%endmacro
+
+mov rdx, 0xe0000000
+
+lea r15, [rdx + 8 * 0]
+lea r14, [rel .StringOne]
+copy r15, r14, 11
+
+lea r15, [rdx + 8 * 2]
+lea r14, [rel .StringTwo]
+copy r15, r14, 11
+
+lea rdi, [rdx + 8 * 0]
+lea rsi, [rdx + 8 * 2]
+
+cld
+mov rcx, 10 ; Lower String length
+repe cmpsb ; rdi cmp rsi
+mov rax, 0
+lahf
+
+mov rdx, 0
+sete dl
+
+hlt
+
+.StringOne: db "TestString\0"
+.StringTwo: db "TestString\0"

--- a/unittests/ASM/Primary/Primary_AA_REPNE.asm
+++ b/unittests/ASM/Primary/Primary_AA_REPNE.asm
@@ -1,0 +1,33 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0xF2F2F2F2F2F2F2F2",
+    "RDX": "0x0",
+    "RDI": "0xE0000018"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rdx + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [rdx + 8 * 1], rax
+mov rax, 0x0
+mov [rdx + 8 * 2], rax
+mov [rdx + 8 * 3], rax
+
+lea rdi, [rdx + 8 * 2]
+
+cld
+mov rcx, 8
+mov rax, 0xF2
+repne stosb ; rdi <- rsi
+
+mov rax, [rdx + 8 * 2]
+mov rdx, [rdx + 8 * 3]
+hlt

--- a/unittests/ASM/Primary/Primary_AA_REPNE_down.asm
+++ b/unittests/ASM/Primary/Primary_AA_REPNE_down.asm
@@ -1,0 +1,33 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0xF2F2F2F2F2F2F2F2",
+    "RDX": "0x0",
+    "RDI": "0xE000000F"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rdx + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [rdx + 8 * 1], rax
+mov rax, 0x0
+mov [rdx + 8 * 2], rax
+mov [rdx + 8 * 3], rax
+
+lea rdi, [rdx + 8 * 2 + 7]
+
+std
+mov rcx, 8
+mov rax, 0xF2
+repne stosb ; rdi <- rsi
+
+mov rax, [rdx + 8 * 2]
+mov rdx, [rdx + 8 * 3]
+hlt

--- a/unittests/ASM/Primary/Primary_AB_dword_REPNE.asm
+++ b/unittests/ASM/Primary/Primary_AB_dword_REPNE.asm
@@ -1,0 +1,33 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0xF1F2F3F4F1F2F3F4",
+    "RDX": "0x0",
+    "RDI": "0xE0000018"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rdx + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [rdx + 8 * 1], rax
+mov rax, 0x0
+mov [rdx + 8 * 2], rax
+mov [rdx + 8 * 3], rax
+
+lea rdi, [rdx + 8 * 2]
+
+cld
+mov rax, 0xF1F2F3F4
+mov rcx, 2
+repne stosd ; rdi <- eax
+
+mov rax, [rdx + 8 * 2]
+mov rdx, [rdx + 8 * 3]
+hlt

--- a/unittests/ASM/Primary/Primary_AB_dword_REPNE_down.asm
+++ b/unittests/ASM/Primary/Primary_AB_dword_REPNE_down.asm
@@ -1,0 +1,33 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0xF1F2F3F4F1F2F3F4",
+    "RDX": "0x0",
+    "RDI": "0xE000000C"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rdx + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [rdx + 8 * 1], rax
+mov rax, 0x0
+mov [rdx + 8 * 2], rax
+mov [rdx + 8 * 3], rax
+
+lea rdi, [rdx + 8 * 2 + 4]
+
+std
+mov rax, 0xF1F2F3F4
+mov rcx, 2
+repne stosd ; rdi <- eax
+
+mov rax, [rdx + 8 * 2]
+mov rdx, [rdx + 8 * 3]
+hlt

--- a/unittests/ASM/Primary/Primary_AB_qword_REPNE.asm
+++ b/unittests/ASM/Primary/Primary_AB_qword_REPNE.asm
@@ -1,0 +1,36 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0xF1F2F3F4F5F6F7F8",
+    "RDX": "0xF1F2F3F4F5F6F7F8",
+    "RSI": "0x0",
+    "RDI": "0xE0000020"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rdx + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [rdx + 8 * 1], rax
+mov rax, 0x0
+mov [rdx + 8 * 2], rax
+mov [rdx + 8 * 3], rax
+mov [rdx + 8 * 4], rax
+
+lea rdi, [rdx + 8 * 2]
+
+cld
+mov rax, 0xF1F2F3F4F5F6F7F8
+mov rcx, 2
+repne stosq ; rdi <- rax
+
+mov rax, [rdx + 8 * 2]
+mov rsi, [rdx + 8 * 4]
+mov rdx, [rdx + 8 * 3]
+hlt

--- a/unittests/ASM/Primary/Primary_AB_qword_REPNE_down.asm
+++ b/unittests/ASM/Primary/Primary_AB_qword_REPNE_down.asm
@@ -1,0 +1,36 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0xF1F2F3F4F5F6F7F8",
+    "RDX": "0xF1F2F3F4F5F6F7F8",
+    "RSI": "0x0",
+    "RDI": "0xE0000008"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rdx + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [rdx + 8 * 1], rax
+mov rax, 0x0
+mov [rdx + 8 * 2], rax
+mov [rdx + 8 * 3], rax
+mov [rdx + 8 * 4], rax
+
+lea rdi, [rdx + 8 * 3]
+
+std
+mov rax, 0xF1F2F3F4F5F6F7F8
+mov rcx, 2
+repne stosq ; rdi <- rax
+
+mov rax, [rdx + 8 * 2]
+mov rsi, [rdx + 8 * 4]
+mov rdx, [rdx + 8 * 3]
+hlt

--- a/unittests/ASM/Primary/Primary_AB_word_REPNE.asm
+++ b/unittests/ASM/Primary/Primary_AB_word_REPNE.asm
@@ -1,0 +1,33 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0xF1F2F1F2F1F2F1F2",
+    "RDX": "0x0",
+    "RDI": "0xE0000018"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rdx + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [rdx + 8 * 1], rax
+mov rax, 0x0
+mov [rdx + 8 * 2], rax
+mov [rdx + 8 * 3], rax
+
+lea rdi, [rdx + 8 * 2]
+
+cld
+mov rcx, 0x4
+mov rax, 0xF1F2
+repne stosw ; rdi <- ax
+
+mov rax, [rdx + 8 * 2]
+mov rdx, [rdx + 8 * 3]
+hlt

--- a/unittests/ASM/Primary/Primary_AB_word_REPNE_down.asm
+++ b/unittests/ASM/Primary/Primary_AB_word_REPNE_down.asm
@@ -1,0 +1,33 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0xF1F2F1F2F1F2F1F2",
+    "RDX": "0x0",
+    "RDI": "0xE000000E"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rdx + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [rdx + 8 * 1], rax
+mov rax, 0x0
+mov [rdx + 8 * 2], rax
+mov [rdx + 8 * 3], rax
+
+lea rdi, [rdx + 8 * 2 + 6]
+
+std
+mov rcx, 0x4
+mov rax, 0xF1F2
+repne stosw ; rdi <- ax
+
+mov rax, [rdx + 8 * 2]
+mov rdx, [rdx + 8 * 3]
+hlt

--- a/unittests/ASM/Primary/Primary_AC_REPNE.asm
+++ b/unittests/ASM/Primary/Primary_AC_REPNE.asm
@@ -1,0 +1,30 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x41",
+    "RSI": "0xE0000008"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rdx + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [rdx + 8 * 1], rax
+mov rax, 0x0
+mov [rdx + 8 * 2], rax
+mov [rdx + 8 * 3], rax
+
+lea rsi, [rdx + 8 * 0]
+
+cld
+mov rax, 0xFF
+mov rcx, 8
+repne lodsb
+
+hlt

--- a/unittests/ASM/Primary/Primary_AC_REPNE_down.asm
+++ b/unittests/ASM/Primary/Primary_AC_REPNE_down.asm
@@ -1,0 +1,30 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x57",
+    "RSI": "0xE0000008"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rdx + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [rdx + 8 * 1], rax
+mov rax, 0x0
+mov [rdx + 8 * 2], rax
+mov [rdx + 8 * 3], rax
+
+lea rsi, [rdx + 8 * 2]
+
+std
+mov rax, 0xFF
+mov rcx, 8
+repne lodsb
+
+hlt

--- a/unittests/ASM/Primary/Primary_AD_REPNE_dword.asm
+++ b/unittests/ASM/Primary/Primary_AD_REPNE_dword.asm
@@ -1,0 +1,33 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x71727374",
+    "RSI": "0xE0000020"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rdx + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [rdx + 8 * 1], rax
+mov rax, 0x6162636465666768
+mov [rdx + 8 * 2], rax
+mov rax, 0x7172737475767778
+mov [rdx + 8 * 3], rax
+mov rax, 0x0
+mov [rdx + 8 * 4], rax
+
+lea rsi, [rdx + 8 * 0]
+
+cld
+mov rax, 0xFF
+mov rcx, 8
+repne lodsd
+
+hlt

--- a/unittests/ASM/Primary/Primary_AD_REPNE_dword_down.asm
+++ b/unittests/ASM/Primary/Primary_AD_REPNE_dword_down.asm
@@ -1,0 +1,33 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x41424344",
+    "RSI": "0xE0000000"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rdx + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [rdx + 8 * 1], rax
+mov rax, 0x6162636465666768
+mov [rdx + 8 * 2], rax
+mov rax, 0x7172737475767778
+mov [rdx + 8 * 3], rax
+mov rax, 0x0
+mov [rdx + 8 * 4], rax
+
+lea rsi, [rdx + 8 * 4]
+
+std
+mov rax, 0xFF
+mov rcx, 8
+repne lodsd
+
+hlt

--- a/unittests/ASM/Primary/Primary_AD_REPNE_qword.asm
+++ b/unittests/ASM/Primary/Primary_AD_REPNE_qword.asm
@@ -1,0 +1,41 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0xB1B2B3B4B5B6B7B8",
+    "RSI": "0xE0000040"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rdx + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [rdx + 8 * 1], rax
+mov rax, 0x6162636465666768
+mov [rdx + 8 * 2], rax
+mov rax, 0x7172737475767778
+mov [rdx + 8 * 3], rax
+mov rax, 0x8182838485868788
+mov [rdx + 8 * 4], rax
+mov rax, 0x9192939495969798
+mov [rdx + 8 * 5], rax
+mov rax, 0xA1A2A3A4A5A6A7A8
+mov [rdx + 8 * 6], rax
+mov rax, 0xB1B2B3B4B5B6B7B8
+mov [rdx + 8 * 7], rax
+mov rax, 0x0
+mov [rdx + 8 * 8], rax
+
+lea rsi, [rdx + 8 * 0]
+
+cld
+mov rax, 0xFF
+mov rcx, 8
+repne lodsq
+
+hlt

--- a/unittests/ASM/Primary/Primary_AD_REPNE_qword_down.asm
+++ b/unittests/ASM/Primary/Primary_AD_REPNE_qword_down.asm
@@ -1,0 +1,41 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x5152535455565758",
+    "RSI": "0xE0000000"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rdx + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [rdx + 8 * 1], rax
+mov rax, 0x6162636465666768
+mov [rdx + 8 * 2], rax
+mov rax, 0x7172737475767778
+mov [rdx + 8 * 3], rax
+mov rax, 0x8182838485868788
+mov [rdx + 8 * 4], rax
+mov rax, 0x9192939495969798
+mov [rdx + 8 * 5], rax
+mov rax, 0xA1A2A3A4A5A6A7A8
+mov [rdx + 8 * 6], rax
+mov rax, 0xB1B2B3B4B5B6B7B8
+mov [rdx + 8 * 7], rax
+mov rax, 0x0
+mov [rdx + 8 * 8], rax
+
+lea rsi, [rdx + 8 * 8]
+
+std
+mov rax, 0xFF
+mov rcx, 8
+repne lodsq
+
+hlt

--- a/unittests/ASM/Primary/Primary_AD_REPNE_word.asm
+++ b/unittests/ASM/Primary/Primary_AD_REPNE_word.asm
@@ -1,0 +1,30 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x5152",
+    "RSI": "0xE0000010"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rdx + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [rdx + 8 * 1], rax
+mov rax, 0x0
+mov [rdx + 8 * 2], rax
+mov [rdx + 8 * 3], rax
+
+lea rsi, [rdx + 8 * 0]
+
+cld
+mov rax, 0xFF
+mov rcx, 8
+repne lodsw
+
+hlt

--- a/unittests/ASM/Primary/Primary_AD_REPNE_word_down.asm
+++ b/unittests/ASM/Primary/Primary_AD_REPNE_word_down.asm
@@ -1,0 +1,30 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x4546",
+    "RSI": "0xE0000000"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rdx + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [rdx + 8 * 1], rax
+mov rax, 0x0
+mov [rdx + 8 * 2], rax
+mov [rdx + 8 * 3], rax
+
+lea rsi, [rdx + 8 * 2]
+
+std
+mov rax, 0xFF
+mov rcx, 8
+repne lodsw
+
+hlt

--- a/unittests/ASM/STOSQ2_REPNE.asm
+++ b/unittests/ASM/STOSQ2_REPNE.asm
@@ -1,0 +1,32 @@
+%ifdef CONFIG
+{
+  "Match": "All",
+  "RegData": {
+    "RAX": "0xDEADBEEFBAD0DAD1"
+  },
+
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+; Starting address to store to
+mov rdi, 0xe8000000
+; Store value
+mov rax, 0xDEADBEEFBAD0DAD1
+mov [rdi], rax
+
+; Set counter to zero
+mov ecx, 0
+; Set store value to zero
+mov rax, 0
+
+repne STOSQ
+
+; Reload what we just stored
+; Ensure that STOSQ didn't write
+mov rdi, 0xe8000000
+mov rax, [rdi]
+
+hlt

--- a/unittests/ASM/STOSQ_REPNE.asm
+++ b/unittests/ASM/STOSQ_REPNE.asm
@@ -1,0 +1,55 @@
+%ifdef CONFIG
+{
+  "Match": "All",
+  "RegData": {
+    "RAX": "0",
+    "RCX": "0",
+    "RDI": "0xE8000100"
+  },
+
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+; Starting address to store to
+mov rdi, 0xe8000000
+
+; How many elements we want to store
+; Additional just in case STOS continues past for some reason
+mov rcx, 0x100
+
+; Data we want to store
+mov rax, 0xDEADBEEFBAD0DAD1
+
+; Direction to increment (Increment when cleared)
+cld
+
+; First fill the area with garbage without using STOS
+mov rdx, 0
+loop_header:
+  mov [rdi + rdx * 8], rax
+  add rdx, 1
+  cmp rdx, rcx
+  jne loop_header
+
+; Now use STOS to fill the data with zero
+
+mov rax, 0x0
+mov rcx, 0x20
+repne stosq
+
+; Now read the data back and ensure it is zero
+
+mov r14, 0xe8000000
+mov r13, 0x20
+mov r12, 0
+mov r11, 0
+loop_header2:
+  add r11, [r14 + r12 * 8]
+  add r12, 1
+  cmp r12, r13
+  jne loop_header2
+
+hlt

--- a/unittests/ASM/STOS_REPNE.asm
+++ b/unittests/ASM/STOS_REPNE.asm
@@ -1,0 +1,61 @@
+%ifdef CONFIG
+{
+  "Match": "All",
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+; Data we want to store
+mov rax, 0xDEADBEEFBAD0DAD1
+
+; Starting address to store to
+mov rdi, 0xe8000000
+
+; How many elements we want to store
+mov rcx, 0x0
+
+; Direction to increment (Increment when cleared)
+cld
+
+; Store bytes
+repne stosw
+
+mov r11, 0
+mov r10, 0xe8000000
+
+movzx r12, word [r10 + 0]
+add r11, r12
+movzx r12, word [r10 + 1]
+add r11, r12
+movzx r12, word [r10 + 2]
+add r11, r12
+movzx r12, word [r10 + 3]
+add r11, r12
+movzx r12, word [r10 + 4]
+add r11, r12
+movzx r12, word [r10 + 5]
+add r11, r12
+movzx r12, word [r10 + 6]
+add r11, r12
+movzx r12, word [r10 + 7]
+add r11, r12
+movzx r12, word [r10 + 8]
+add r11, r12
+movzx r12, word [r10 + 9]
+add r11, r12
+movzx r12, word [r10 + 10]
+add r11, r12
+movzx r12, word [r10 + 11]
+add r11, r12
+movzx r12, word [r10 + 12]
+add r11, r12
+movzx r12, word [r10 + 13]
+add r11, r12
+movzx r12, word [r10 + 14]
+add r11, r12
+movzx r12, word [r10 + 15]
+add r11, r12
+
+hlt


### PR DESCRIPTION
MOVS, LODS, and STOS ops are only documented to support the REP prefix.
These instructions actually repeat correctly with the REPNE prefix as
well.
Behaviour is the same.

Fixes POD Gold