### PR TITLE
unittests: Hotfix for older nasm

### DIFF
--- a/unittests/32Bit_ASM/Primary/Primary_CF.asm
+++ b/unittests/32Bit_ASM/Primary/Primary_CF.asm
@@ -10,7 +10,7 @@
 
 mov esp, 0xe0000010
 
-lea ebx, dword [rel .end]
+lea ebx, [rel .end]
 
 mov eax, 0x202
 push eax ; RFLAGS

--- a/unittests/ASM/Primary/Primary_CF.asm
+++ b/unittests/ASM/Primary/Primary_CF.asm
@@ -9,7 +9,7 @@
 
 mov esp, 0xe0000030
 
-lea rbx, qword [rel .end]
+lea rbx, [rel .end]
 mov rcx, 0x33
 mov rdx, rsp
 


### PR DESCRIPTION
Newer nasm takes the size specifier for LEA, older ones do not