### PR TITLE
FEXCore: Return the ParentThread with InitCore

### DIFF
--- a/External/FEXCore/Source/Interface/Context/Context.cpp
+++ b/External/FEXCore/Source/Interface/Context/Context.cpp
@@ -34,7 +34,7 @@ namespace FEXCore::Context {
     delete CTX;
   }
 
-  bool InitCore(FEXCore::Context::Context *CTX, FEXCore::CodeLoader *Loader) {
+  FEXCore::Core::InternalThreadState* InitCore(FEXCore::Context::Context *CTX, FEXCore::CodeLoader *Loader) {
     return CTX->InitCore(Loader);
   }
 

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -184,7 +184,7 @@ namespace FEXCore::Context {
     Context();
     ~Context();
 
-    bool InitCore(FEXCore::CodeLoader *Loader);
+    FEXCore::Core::InternalThreadState* InitCore(FEXCore::CodeLoader *Loader);
     FEXCore::Context::ExitReason RunUntilExit();
     int GetProgramStatus() const;
     bool IsPaused() const { return !Running; }

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -195,7 +195,7 @@ namespace FEXCore::Context {
     }
   }
 
-  bool Context::InitCore(FEXCore::CodeLoader *Loader) {
+  FEXCore::Core::InternalThreadState* Context::InitCore(FEXCore::CodeLoader *Loader) {
     ThunkHandler.reset(FEXCore::ThunkHandler::Create());
 
     LocalLoader = Loader;
@@ -228,8 +228,7 @@ namespace FEXCore::Context {
     Thread->CurrentFrame->State.rip = StartingRIP = Loader->DefaultRIP();
 
     InitializeThreadData(Thread);
-
-    return true;
+    return Thread;
   }
 
   void Context::StartGdbServer() {

--- a/External/FEXCore/include/FEXCore/Core/Context.h
+++ b/External/FEXCore/include/FEXCore/Core/Context.h
@@ -91,7 +91,7 @@ namespace FEXCore::Context {
    *
    * @return true if we loaded code
    */
-  FEX_DEFAULT_VISIBILITY bool InitCore(FEXCore::Context::Context *CTX, FEXCore::CodeLoader *Loader);
+  FEX_DEFAULT_VISIBILITY FEXCore::Core::InternalThreadState* InitCore(FEXCore::Context::Context *CTX, FEXCore::CodeLoader *Loader);
 
   FEX_DEFAULT_VISIBILITY void SetExitHandler(FEXCore::Context::Context *CTX, ExitHandler handler);
   FEX_DEFAULT_VISIBILITY ExitHandler GetExitHandler(FEXCore::Context::Context *CTX);


### PR DESCRIPTION
This always returns success and for easier state management, just return
our parent thread.

Frontend needs full visibility of this state anyway for thread
management.