### PR TITLE
Fixes Callback interface to take a thread argument

### DIFF
--- a/External/FEXCore/Source/Interface/Context/Context.cpp
+++ b/External/FEXCore/Source/Interface/Context/Context.cpp
@@ -101,8 +101,8 @@ namespace FEXCore::Context {
   void RegisterExternalSyscallVisitor(FEXCore::Context::Context *CTX, [[maybe_unused]] uint64_t Syscall, [[maybe_unused]] FEXCore::HLE::SyscallVisitor *Visitor) {
   }
 
-  void HandleCallback(FEXCore::Context::Context *CTX, uint64_t RIP) {
-    CTX->HandleCallback(RIP);
+  void HandleCallback(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread, uint64_t RIP) {
+    CTX->HandleCallback(Thread, RIP);
   }
 
   void RegisterHostSignalHandler(FEXCore::Context::Context *CTX, int Signal, HostSignalDelegatorFunction Func, bool Required) {

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -200,7 +200,7 @@ namespace FEXCore::Context {
     bool GetGdbServerStatus() const { return DebugServer != nullptr; }
     void StartGdbServer();
     void StopGdbServer();
-    void HandleCallback(uint64_t RIP);
+    void HandleCallback(FEXCore::Core::InternalThreadState *Thread, uint64_t RIP);
     void RegisterHostSignalHandler(int Signal, HostSignalDelegatorFunction Func, bool Required);
     void RegisterFrontendHostSignalHandler(int Signal, HostSignalDelegatorFunction Func, bool Required);
 

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -242,8 +242,7 @@ namespace FEXCore::Context {
     DebugServer.reset();
   }
 
-  void Context::HandleCallback(uint64_t RIP) {
-    auto Thread = Core::ThreadData.Thread;
+  void Context::HandleCallback(FEXCore::Core::InternalThreadState *Thread, uint64_t RIP) {
     Thread->CPUBackend->CallbackPtr(Thread->CurrentFrame, RIP);
   }
 

--- a/External/FEXCore/Source/Interface/HLE/Thunks/Thunks.cpp
+++ b/External/FEXCore/Source/Interface/HLE/Thunks/Thunks.cpp
@@ -51,7 +51,7 @@ namespace FEXCore {
             Thread->CurrentFrame->State.gregs[FEXCore::X86State::REG_RDI] = (uintptr_t)arg0;
             Thread->CurrentFrame->State.gregs[FEXCore::X86State::REG_RSI] = (uintptr_t)arg1;
 
-            Thread->CTX->HandleCallback((uintptr_t)callback);
+            Thread->CTX->HandleCallback(Thread, (uintptr_t)callback);
         }
 
         static void LoadLib(void *ArgsV) {

--- a/External/FEXCore/include/FEXCore/Core/Context.h
+++ b/External/FEXCore/include/FEXCore/Core/Context.h
@@ -217,7 +217,7 @@ namespace FEXCore::Context {
    */
   FEX_DEFAULT_VISIBILITY void RegisterExternalSyscallVisitor(FEXCore::Context::Context *CTX, uint64_t Syscall, FEXCore::HLE::SyscallVisitor *Visitor);
 
-  FEX_DEFAULT_VISIBILITY void HandleCallback(FEXCore::Context::Context *CTX, uint64_t RIP);
+  FEX_DEFAULT_VISIBILITY void HandleCallback(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread, uint64_t RIP);
 
   FEX_DEFAULT_VISIBILITY void RegisterHostSignalHandler(FEXCore::Context::Context *CTX, int Signal, HostSignalDelegatorFunction Func, bool Required);
   FEX_DEFAULT_VISIBILITY void RegisterFrontendHostSignalHandler(FEXCore::Context::Context *CTX, int Signal, HostSignalDelegatorFunction Func, bool Required);


### PR DESCRIPTION
This was using the implicit thread TLS object. All users of this
have access to the thread object directly.

Use that instead. Fixes a subtle bug were the frontend could be trying
to do a callback and TLS sections weren't correctly set.