### PR TITLE
Hangover: Initial support for the syscall handling.

### DIFF
--- a/External/FEXCore/include/FEXCore/HLE/SyscallHandler.h
+++ b/External/FEXCore/include/FEXCore/HLE/SyscallHandler.h
@@ -32,6 +32,7 @@ namespace FEXCore::HLE {
     OS_LINUX32,
     OS_WIN64,
     OS_WIN32,
+    OS_HANGOVER,
   };
 
   class SyscallHandler {


### PR DESCRIPTION
Hangover currently abuses the syscall op for thunking purposes.
Very likely this will be changed in the future but for now make sure to
support that use case.