### PR TITLE
Properly implement single CAS on ARMv8.0

### DIFF
--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64.h
@@ -30,6 +30,7 @@ namespace FEXCore::ArchHelpers::Arm64 {
   constexpr uint32_t ALU_OP_MASK = 0x7F'00'00'00;
   constexpr uint32_t ADD_INST    = 0x0B'00'00'00;
   constexpr uint32_t SUB_INST    = 0x4B'00'00'00;
+  constexpr uint32_t CMP_INST    = 0x6B'00'00'00;
   constexpr uint32_t AND_INST    = 0x0A'00'00'00;
   constexpr uint32_t OR_INST     = 0x2A'00'00'00;
   constexpr uint32_t EOR_INST    = 0x4A'00'00'00;

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -98,7 +98,7 @@ static uint64_t AtomicFetchNeg(uint64_t *Addr) {
 static uint8_t AtomicCompareAndSwap8(uint8_t expected, uint8_t desired, uint8_t *addr)
 {
   using Type = uint8_t;
-  std::atomic<Type> *Data = reinterpret_cast<std::atomic<Type>*>(Addr);
+  std::atomic<Type> *Data = reinterpret_cast<std::atomic<Type>*>(addr);
 
   Type Src1 = expected;
   Type Src2 = desired;
@@ -112,7 +112,7 @@ static uint8_t AtomicCompareAndSwap8(uint8_t expected, uint8_t desired, uint8_t 
 static uint16_t AtomicCompareAndSwap16(uint16_t expected, uint16_t desired, uint16_t *addr)
 {
   using Type = uint16_t;
-  std::atomic<Type> *Data = reinterpret_cast<std::atomic<Type>*>(Addr);
+  std::atomic<Type> *Data = reinterpret_cast<std::atomic<Type>*>(addr);
 
   Type Src1 = expected;
   Type Src2 = desired;
@@ -126,7 +126,7 @@ static uint16_t AtomicCompareAndSwap16(uint16_t expected, uint16_t desired, uint
 static uint32_t AtomicCompareAndSwap32(uint32_t expected, uint32_t desired, uint32_t *addr)
 {
   using Type = uint32_t;
-  std::atomic<Type> *Data = reinterpret_cast<std::atomic<Type>*>(Addr);
+  std::atomic<Type> *Data = reinterpret_cast<std::atomic<Type>*>(addr);
 
   Type Src1 = expected;
   Type Src2 = desired;
@@ -140,7 +140,7 @@ static uint32_t AtomicCompareAndSwap32(uint32_t expected, uint32_t desired, uint
 static uint64_t AtomicCompareAndSwap64(uint64_t expected, uint64_t desired, uint64_t *addr)
 {
   using Type = uint64_t;
-  std::atomic<Type> *Data = reinterpret_cast<std::atomic<Type>*>(Addr);
+  std::atomic<Type> *Data = reinterpret_cast<std::atomic<Type>*>(addr);
 
   Type Src1 = expected;
   Type Src2 = desired;

--- a/unittests/ASM/Disabled_Tests_ARMv8.0
+++ b/unittests/ASM/Disabled_Tests_ARMv8.0
@@ -1,10 +1,4 @@
 # Doesn't support unaligned on armv8.0
-Test_TwoByte/0F_B0_2.asm
-Test_TwoByte/0F_B0_3.asm
-Test_TwoByte/0F_B0_4.asm
-Test_TwoByte/0F_B0_5.asm
-Test_TwoByte/0F_B0_6.asm
-Test_TwoByte/0F_B0_7.asm
 Test_Secondary/09_XX_01_7.asm
 Test_Secondary/09_XX_01_8.asm
 Test_Secondary/09_XX_01_9.asm


### PR DESCRIPTION
This implements unaligned CAS through the SIGBUS handler for ARMv8.0. It also rewrites the `OP_CAS` in the Interpreter to generate the pattern that can be detected by SIGBUS.

Fixes 0F_B0* tests for ARMv8.0.

