### PR TITLE
Linux: Fixes 32-bit interval timers

### DIFF
--- a/Source/Tests/LinuxSyscalls/Syscalls/Timer.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Timer.cpp
@@ -48,15 +48,5 @@ namespace FEX::HLE {
       uint64_t Result = ::syscall(SYS_timer_delete, timerid);
       SYSCALL_ERRNO();
     });
-
-    REGISTER_SYSCALL_IMPL(getitimer, [](FEXCore::Core::CpuStateFrame *Frame, int which, struct itimerval *curr_value) -> uint64_t {
-      uint64_t Result = ::getitimer(which, curr_value);
-      SYSCALL_ERRNO();
-    });
-
-    REGISTER_SYSCALL_IMPL(setitimer, [](FEXCore::Core::CpuStateFrame *Frame, int which, const struct itimerval *new_value, struct itimerval *old_value) -> uint64_t {
-      uint64_t Result = ::setitimer(which, new_value, old_value);
-      SYSCALL_ERRNO();
-    });
   }
 }

--- a/Source/Tests/LinuxSyscalls/x32/Timer.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Timer.cpp
@@ -6,10 +6,12 @@ $end_info$
 
 #include "Tests/LinuxSyscalls/Syscalls.h"
 #include "Tests/LinuxSyscalls/x32/Syscalls.h"
+#include "Tests/LinuxSyscalls/x32/Types.h"
 
 #include <bits/types/timer_t.h>
 #include <stdint.h>
 #include <syscall.h>
+#include <sys/time.h>
 #include <unistd.h>
 
 namespace FEXCore::Core {
@@ -25,6 +27,42 @@ namespace FEX::HLE::x32 {
 
     REGISTER_SYSCALL_IMPL_X32(timer_gettime64, [](FEXCore::Core::CpuStateFrame *Frame, timer_t timerid, struct itimerspec *curr_value) -> uint64_t {
       uint64_t Result = ::syscall(SYS_timer_gettime, timerid, curr_value);
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(getitimer, [](FEXCore::Core::CpuStateFrame *Frame, int which, FEX::HLE::x32::itimerval32 *curr_value) -> uint64_t {
+      itimerval val{};
+      itimerval *val_p{};
+      if (curr_value) {
+        val_p = &val;
+      }
+      uint64_t Result = ::getitimer(which, val_p);
+      if (curr_value) {
+        *curr_value = val;
+      }
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(setitimer, [](FEXCore::Core::CpuStateFrame *Frame, int which, const FEX::HLE::x32::itimerval32 *new_value, FEX::HLE::x32::itimerval32 *old_value) -> uint64_t {
+      itimerval val{};
+      itimerval old{};
+      itimerval *val_p{};
+      itimerval *old_p{};
+
+      if (new_value) {
+        val = *new_value;
+        val_p = &val;
+      }
+
+      if (old_value) {
+        old_p = &old;
+      }
+
+      uint64_t Result = ::setitimer(which, val_p, old_p);
+
+      if (old_value) {
+        *old_value = old;
+      }
       SYSCALL_ERRNO();
     });
   }

--- a/Source/Tests/LinuxSyscalls/x32/Types.h
+++ b/Source/Tests/LinuxSyscalls/x32/Types.h
@@ -17,6 +17,7 @@ $end_info$
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/statfs.h>
+#include <sys/time.h>
 #include <sys/uio.h>
 #include <time.h>
 #include <type_traits>
@@ -161,6 +162,39 @@ timeval32 {
 
 static_assert(std::is_trivial<timeval32>::value, "Needs to be trivial");
 static_assert(sizeof(timeval32) == 8, "Incorrect size");
+
+/**
+ * @name itimerval32
+ *
+ * This is a itimerval implementation that matches 32bit linux implementation
+ * Provides conversation operators for the host version
+ * @{ */
+
+struct
+FEX_ANNOTATE("alias-x86_32-itimerval")
+FEX_ANNOTATE("fex-match")
+itimerval32 {
+  FEX::HLE::x32::timeval32 it_interval;
+  FEX::HLE::x32::timeval32 it_value;
+
+  itimerval32() = delete;
+
+  operator itimerval() const {
+    itimerval spec{};
+    spec.it_interval = it_interval;
+    spec.it_value = it_value;
+    return spec;
+  }
+
+  itimerval32(struct itimerval spec)
+    : it_interval { spec.it_interval }
+    , it_value { spec.it_value } {
+  }
+};
+/**  @} */
+
+static_assert(std::is_trivial<itimerval32>::value, "Needs to be trivial");
+static_assert(sizeof(itimerval32) == 16, "Incorrect size");
 
 /**
  * @name iovec32

--- a/Source/Tests/LinuxSyscalls/x64/Time.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Time.cpp
@@ -58,6 +58,16 @@ namespace FEX::HLE::x64 {
       uint64_t Result = ::utimes(filename, times);
       SYSCALL_ERRNO();
     });
+
+    REGISTER_SYSCALL_IMPL_X64(getitimer, [](FEXCore::Core::CpuStateFrame *Frame, int which, struct itimerval *curr_value) -> uint64_t {
+      uint64_t Result = ::getitimer(which, curr_value);
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X64(setitimer, [](FEXCore::Core::CpuStateFrame *Frame, int which, const struct itimerval *new_value, struct itimerval *old_value) -> uint64_t {
+      uint64_t Result = ::setitimer(which, new_value, old_value);
+      SYSCALL_ERRNO();
+    });
   }
 }
 


### PR DESCRIPTION
getitimer and setitimer use an itimerval struct with 32-bit members in
it.

Handles this case and now the timers work