### PR TITLE
Linux: sigaltstack ignore SS_ONSTACK

### DIFF
--- a/Source/Tests/LinuxSyscalls/SignalDelegator.cpp
+++ b/Source/Tests/LinuxSyscalls/SignalDelegator.cpp
@@ -405,7 +405,8 @@ namespace FEX::HLE {
 
       // We need to check for invalid flags
       // The only flag that can be passed is SS_AUTODISARM and SS_DISABLE
-      if (ss->ss_flags & ~(SS_AUTODISARM | SS_DISABLE)) {
+      if ((ss->ss_flags & ~SS_ONSTACK) & // SS_ONSTACK is ignored
+          ~(SS_AUTODISARM | SS_DISABLE)) {
         // A flag remained that isn't one of the supported ones?
         return -EINVAL;
       }

--- a/unittests/POSIX/Known_Failures
+++ b/unittests/POSIX/Known_Failures
@@ -621,3 +621,9 @@ conformance-interfaces-killpg-8-1.test
 # It puts the thread to sleep for 1 second and expects to wake up within 10ms of the timer
 # If the kernel is doing other things then this 10ms time is too strict and fails periodically
 conformance-interfaces-sigtimedwait-1-1.test
+
+# This test relies on old Linux behaviour
+# This is setting a "invalid" flag that it expects the kernel to return EINVAL on
+# Sadly since this test is so old it happens to set SS_ONSTACK which is a no-op on
+# newer kernels. So this is expected to fail.
+conformance-interfaces-sigaltstack-11-1.test


### PR DESCRIPTION
This flag is ignored with sigaltstack.
Fixes an early assert in:
- Splice
- No Time to Explain Remastered
- Ittledew
- Hyperdrive Massacre
- English Country Tune