### PR TITLE
FEXMountDaemon: Fixes shutdown race conditions

### DIFF
--- a/Source/Common/RootFSSetup.h
+++ b/Source/Common/RootFSSetup.h
@@ -8,8 +8,10 @@ namespace FEX::RootFS {
   bool UpdateRootFSPath();
   // Returns where the rootfs lock file lives even if the squashfs isn't mounted
   std::string GetRootFSLockFile();
+  // Returns the socket file for a mount path
+  std::string GetRootFSSocketFile(std::string const &MountPath);
   // Checks if the rootfs lock exists
-  bool CheckLockExists(std::string const &LockPath);
+  bool CheckLockExists(std::string const &LockPath, std::string *MountPath = nullptr);
   bool Setup(char **const envp);
   void Shutdown();
 }

--- a/Source/Tools/FEXGetConfig/Main.cpp
+++ b/Source/Tools/FEXGetConfig/Main.cpp
@@ -34,6 +34,10 @@ int main(int argc, char **argv, char **envp) {
     .action("store_true")
     .help("SquashFS lock file if squashfs is mounted");
 
+  Parser.add_option("--current-rootfs-socket")
+    .action("store_true")
+    .help("SquashFS socket file if squashfs is mounted");
+
   Parser.add_option("--version")
     .action("store_true")
     .help("Print the installed FEX-Emu version");
@@ -65,13 +69,20 @@ int main(int argc, char **argv, char **envp) {
     }
   }
 
-  if (Options.is_set_by_user("current_rootfs")) {
-    // Ensure RootFS is setup before config options try to pull CONFIG_ROOTFS
-    auto Status = FEX::RootFS::UpdateRootFSPath();
+  if (Options.is_set_by_user("current_rootfs_socket")) {
+    auto LockFile = FEX::RootFS::GetRootFSLockFile();
+    std::string MountPath;
+    if (FEX::RootFS::CheckLockExists(LockFile, &MountPath)) {
+      std::string SocketPath = FEX::RootFS::GetRootFSSocketFile(MountPath);
+      fprintf(stdout, "%s\n", SocketPath.c_str());
+    }
+  }
 
-    if (Status) {
-      FEX_CONFIG_OPT(LDPath, ROOTFS);
-      fprintf(stdout, "%s\n", LDPath().c_str());
+  if (Options.is_set_by_user("current_rootfs")) {
+    auto LockFile = FEX::RootFS::GetRootFSLockFile();
+    std::string MountPath;
+    if (FEX::RootFS::CheckLockExists(LockFile, &MountPath)) {
+      fprintf(stdout, "%s\n", MountPath.c_str());
     }
   }
 


### PR DESCRIPTION
This solves a problem where sometimes FEX would spin up a new process
while FEXMountDaemon was in the process of shutting down. Breaking
things on both sides.

Now the race conditions are squashed that I could see.