### PR TITLE
Config: Check for container-manager and redirect

### DIFF
--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -190,6 +190,11 @@ if (ENABLE_JEMALLOC)
   list (APPEND LIBS FEX_jemalloc)
 endif()
 
+# Generate config
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/Interface/Config/Config.json.in
+  ${CMAKE_BINARY_DIR}/generated/Config/Config.json)
+
 # Generate IR include file
 set(OUTPUT_IR_FOLDER "${CMAKE_BINARY_DIR}/include/FEXCore/IR")
 set(OUTPUT_NAME "${OUTPUT_IR_FOLDER}/IRDefines.inc")
@@ -232,7 +237,7 @@ add_custom_target(IR_INC
 set(OUTPUT_CONFIG_FOLDER "${CMAKE_BINARY_DIR}/include/FEXCore/Config")
 set(OUTPUT_CONFIG_NAME "${OUTPUT_CONFIG_FOLDER}/ConfigValues.inl")
 set(OUTPUT_CONFIG_OPTION_NAME "${OUTPUT_CONFIG_FOLDER}/ConfigOptions.inl")
-set(INPUT_CONFIG_NAME "${CMAKE_CURRENT_SOURCE_DIR}/Interface/Config/Config.json")
+set(INPUT_CONFIG_NAME "${CMAKE_BINARY_DIR}/generated/Config/Config.json")
 set(OUTPUT_MAN_NAME "${CMAKE_BINARY_DIR}/generated/FEX.1")
 
 add_custom_target(CREATE_CONFIG_FOLDER ALL

--- a/External/FEXCore/Source/Interface/Config/Config.json.in
+++ b/External/FEXCore/Source/Interface/Config/Config.json.in
@@ -58,7 +58,7 @@
       },
       "ThunkHostLibs": {
         "Type": "str",
-        "Default": "",
+        "Default": "@CMAKE_INSTALL_PREFIX@/lib/fex-emu/HostThunks/",
         "ShortArg": "t",
         "Desc": [
           "Folder to find the host-side thunking libraries."
@@ -66,7 +66,7 @@
       },
       "ThunkGuestLibs": {
         "Type": "str",
-        "Default": "",
+        "Default": "@CMAKE_INSTALL_PREFIX@/share/fex-emu/GuestThunks/",
         "ShortArg": "j",
         "Desc": [
           "Folder to find the guest-side thunking libraries."

--- a/External/FEXCore/include/FEXCore/Config/Config.h
+++ b/External/FEXCore/include/FEXCore/Config/Config.h
@@ -121,6 +121,7 @@ namespace Type {
 
   FEX_DEFAULT_VISIBILITY void Load();
   FEX_DEFAULT_VISIBILITY void ReloadMetaLayer();
+  FEX_DEFAULT_VISIBILITY std::string FindContainerPrefix();
 
   FEX_DEFAULT_VISIBILITY void AddLayer(std::unique_ptr<FEXCore::Config::Layer> _Layer);
 

--- a/Source/Common/RootFSSetup.cpp
+++ b/Source/Common/RootFSSetup.cpp
@@ -221,6 +221,14 @@ bool Setup(char **const envp) {
   // If it is setup to use a squashfs then we need to do something more complex
 
   FEX_CONFIG_OPT(LDPath, ROOTFS);
+  auto ContainerPrefix = FEXCore::Config::FindContainerPrefix();
+  if (!ContainerPrefix.empty()) {
+    // If we are inside of a rootfs/container then drop the rootfs path
+    // Root is already our rootfs
+    FEXCore::Config::Erase(FEXCore::Config::CONFIG_ROOTFS);
+    return true;
+  }
+
   if (FEX::FormatCheck::IsSquashFS(LDPath())) {
     // Check if the rootfs is already mounted
     // We can do this by checking the lock file if it exists

--- a/Source/Tests/FEXBash.cpp
+++ b/Source/Tests/FEXBash.cpp
@@ -47,7 +47,7 @@ int main(int argc, char **argv, char **const envp) {
   // Check if a local FEXInterpreter to FEXBash exists
   // If it does then it takes priority over the installed one
   if (!std::filesystem::exists(FEXInterpreterPath)) {
-    FEXInterpreterPath = FEXINTERPRETER_PATH;
+    FEXInterpreterPath = FEXCore::Config::FindContainerPrefix() + FEXINTERPRETER_PATH;
   }
   const char *FEXArgs[] = {
     FEXInterpreterPath.c_str(),


### PR DESCRIPTION
In the case of running inside of a container then we need to redirect
where we look for configuration.
Currently we only care about pressure vessel so we just redirect some
options to check inside of `/run/host/`

This will resolve an issue where installed thunks wouldn't be found.

Fixes #1265