### PR TITLE
FEXLoader: Flush log output

### DIFF
--- a/Source/Tests/FEXLoader.cpp
+++ b/Source/Tests/FEXLoader.cpp
@@ -87,6 +87,7 @@ void MsgHandler(LogMan::DebugLevels Level, char const *Message) {
     std::ostringstream Output;
     Output << "[" << CharLevel << "] " << Message << std::endl;
     write(OutputFD, Output.str().c_str(), Output.str().size());
+    fsync(OutputFD);
   }
 }
 
@@ -95,6 +96,7 @@ void AssertHandler(char const *Message) {
     std::ostringstream Output;
     Output << "[ASSERT] " << Message << std::endl;
     write(OutputFD, Output.str().c_str(), Output.str().size());
+    fsync(OutputFD);
   }
 }
 


### PR DESCRIPTION
This was removed when we switched from FILE to raw fd.
This fixes an annoying issue where we would assert and not get any
output.