### PR TITLE
Linux: Fixes rlimit syscalls for 32-bit

### DIFF
--- a/Source/Tests/LinuxSyscalls/Syscalls/Info.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Info.cpp
@@ -58,16 +58,6 @@ namespace FEX::HLE {
       return 0;
     });
 
-    REGISTER_SYSCALL_IMPL(getrlimit, [](FEXCore::Core::CpuStateFrame *Frame, int resource, struct rlimit *rlim) -> uint64_t {
-      uint64_t Result = ::getrlimit(resource, rlim);
-      SYSCALL_ERRNO();
-    });
-
-    REGISTER_SYSCALL_IMPL(setrlimit, [](FEXCore::Core::CpuStateFrame *Frame, int resource, const struct rlimit *rlim) -> uint64_t {
-      uint64_t Result = ::setrlimit(resource, rlim);
-      SYSCALL_ERRNO();
-    });
-
     REGISTER_SYSCALL_IMPL(syslog, [](FEXCore::Core::CpuStateFrame *Frame, int type, char *bufp, int len) -> uint64_t {
       uint64_t Result = ::klogctl(type, bufp, len);
       SYSCALL_ERRNO();

--- a/Source/Tests/LinuxSyscalls/x32/Info.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Info.cpp
@@ -22,11 +22,6 @@ namespace FEXCore::Core {
 }
 
 namespace FEX::HLE::x32 {
-  struct rlimit32 {
-    uint32_t rlim_cur;
-    uint32_t rlim_max;
-  };
-
   struct sysinfo32 {
     int32_t uptime;
     uint32_t loads[3];
@@ -46,11 +41,24 @@ namespace FEX::HLE::x32 {
   static_assert(sizeof(sysinfo32) == 64, "Needs to be 64bytes");
 
   void RegisterInfo() {
-    REGISTER_SYSCALL_IMPL_X32(ugetrlimit, [](FEXCore::Core::CpuStateFrame *Frame, int resource, rlimit32 *rlim) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(getrlimit, [](FEXCore::Core::CpuStateFrame *Frame, int resource, compat_ptr<FEX::HLE::x32::rlimit32<true>> rlim) -> uint64_t {
       struct rlimit rlim64{};
       uint64_t Result = ::getrlimit(resource, &rlim64);
-      rlim->rlim_cur = rlim64.rlim_cur;
-      rlim->rlim_max = rlim64.rlim_max;
+      *rlim = rlim64;
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(ugetrlimit, [](FEXCore::Core::CpuStateFrame *Frame, int resource, compat_ptr<FEX::HLE::x32::rlimit32<false>> rlim) -> uint64_t {
+      struct rlimit rlim64{};
+      uint64_t Result = ::getrlimit(resource, &rlim64);
+      *rlim = rlim64;
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(setrlimit, [](FEXCore::Core::CpuStateFrame *Frame, int resource, const compat_ptr<FEX::HLE::x32::rlimit32<false>> rlim) -> uint64_t {
+      struct rlimit rlim64{};
+      rlim64 = *rlim;
+      uint64_t Result = ::setrlimit(resource, &rlim64);
       SYSCALL_ERRNO();
     });
 

--- a/Source/Tests/LinuxSyscalls/x32/Types.h
+++ b/Source/Tests/LinuxSyscalls/x32/Types.h
@@ -915,4 +915,51 @@ old_itimerspec32 {
 static_assert(std::is_trivial<old_itimerspec32>::value, "Needs to be trivial");
 static_assert(sizeof(old_itimerspec32) == 16, "Incorrect size");
 
+template<bool Signed>
+struct
+FEX_ANNOTATE("alias-x86_32-rlimit")
+FEX_ANNOTATE("fex-match")
+rlimit32 {
+  uint32_t rlim_cur;
+  uint32_t rlim_max;
+  rlimit32() = delete;
+
+  operator rlimit() const {
+    static_assert(Signed == false, "Signed variant doesn't exist");
+    rlimit val{};
+
+    val.rlim_cur = rlim_cur;
+    val.rlim_max = rlim_max;
+
+    if (val.rlim_cur == ~0U) {
+      val.rlim_cur = ~0ULL;
+    }
+    if (val.rlim_max == ~0U) {
+      val.rlim_max = ~0ULL;
+    }
+
+    return val;
+  }
+
+  rlimit32(struct rlimit val) {
+    constexpr uint32_t Limit = Signed ? 0x7FFF'FFFF : 0xFFFF'FFFF;
+    if (val.rlim_cur > Limit) {
+      rlim_cur = Limit;
+    }
+    else {
+      rlim_cur = val.rlim_cur;
+    }
+
+    if (val.rlim_max > Limit) {
+      rlim_max = Limit;
+    }
+    else {
+      rlim_max = val.rlim_max;
+    }
+  }
+};
+
+static_assert(std::is_trivial<rlimit32<true>>::value, "Needs to be trivial");
+static_assert(sizeof(rlimit32<true>) == 8, "Incorrect size");
+
 }

--- a/Source/Tests/LinuxSyscalls/x64/Info.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Info.cpp
@@ -24,5 +24,15 @@ namespace FEX::HLE::x64 {
       uint64_t Result = ::getrusage(who, usage);
       SYSCALL_ERRNO();
     });
+
+    REGISTER_SYSCALL_IMPL_X64(getrlimit, [](FEXCore::Core::CpuStateFrame *Frame, int resource, struct rlimit *rlim) -> uint64_t {
+      uint64_t Result = ::getrlimit(resource, rlim);
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X64(setrlimit, [](FEXCore::Core::CpuStateFrame *Frame, int resource, const struct rlimit *rlim) -> uint64_t {
+      uint64_t Result = ::setrlimit(resource, rlim);
+      SYSCALL_ERRNO();
+    });
   }
 }


### PR DESCRIPTION
32-bit versions of these syscalls saturate on the upper limit.
Depending on which syscall it'll saturate signed or unsigned.

With set if the 32-bit value is UINT32_MAX then it'll saturate to the
maximum 64-bit value