### PR TITLE
FileManager: Allow reading real root

### DIFF
--- a/Source/Tests/LinuxSyscalls/FileManagement.cpp
+++ b/Source/Tests/LinuxSyscalls/FileManagement.cpp
@@ -130,9 +130,10 @@ FileManager::~FileManager() {
 
 std::string FileManager::GetEmulatedPath(const char *pathname, bool FollowSymlink) {
   auto RootFSPath = LDPath();
-  if (!pathname ||
-      pathname[0] != '/' ||
-      RootFSPath.empty()) {
+  if (!pathname || // If no pathname
+      pathname[0] != '/' || // If relative
+      RootFSPath.empty() || // If RootFS doesn't exist
+      strcmp(pathname, "/") == 0) { // If we are getting root
     return {};
   }
 

--- a/unittests/gvisor-tests/Disabled_Tests
+++ b/unittests/gvisor-tests/Disabled_Tests
@@ -168,3 +168,9 @@ proc_net_test
 rtsignal_test
 sigstop_test
 stat_test
+
+# These search for folders in /
+# Might need to rbind some folders to make it happy
+# This currently passes on x86-64 hosts
+# This fails on AArch64 because getdents isn't emulated
+getdents_test

--- a/unittests/gvisor-tests/Known_Failures
+++ b/unittests/gvisor-tests/Known_Failures
@@ -131,8 +131,9 @@ connect_external_test
 exceptions_test
 
 # These search for folders in /
-# Sadly it finds the rootfs folders instead of the true rootfs and fails
 # Might need to rbind some folders to make it happy
+# This currently passes on x86-64 hosts
+# This fails on AArch64 because getdents isn't emulated
 getdents_test
 
 # Doesn't even pass on real x86 host


### PR DESCRIPTION
wine walks the file structure to ensure the cwdir is safe for use. It
does this with a combination of `getcwd` and `statx`.

Once it reachs `/` then in rootfs environments it would fail to find
directories we've deleted.
Thus making it impossible to find folders like `/mnt` and `/home`

Should be safe since it just gives the application a larger world view