### PR TITLE
Linux: Implements support for timer_create

### DIFF
--- a/Source/Tests/LinuxSyscalls/SignalDelegator.cpp
+++ b/Source/Tests/LinuxSyscalls/SignalDelegator.cpp
@@ -572,16 +572,7 @@ namespace FEX::HLE {
       return -EINVAL;
     }
 
-    sigset_t HostSet{};
-    sigemptyset(&HostSet);
-
-    for (int32_t i = 0; i < MAX_SIGNALS; ++i) {
-      if (*set & (1ULL << i)) {
-        sigaddset(&HostSet, i + 1);
-      }
-    }
-
-    uint64_t Result = sigtimedwait(&HostSet, info, timeout);
+    uint64_t Result = ::syscall(SYS_rt_sigtimedwait, set, info, timeout);
 
     return Result == -1 ? -errno : Result;
   }

--- a/Source/Tests/LinuxSyscalls/Syscalls/Timer.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Timer.cpp
@@ -25,11 +25,6 @@ namespace FEX::HLE {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL(timer_create, [](FEXCore::Core::CpuStateFrame *Frame, clockid_t clockid, struct sigevent *sevp, kernel_timer_t *timerid) -> uint64_t {
-      uint64_t Result = ::syscall(SYS_timer_create, clockid, sevp, timerid);
-      SYSCALL_ERRNO();
-    });
-
     REGISTER_SYSCALL_IMPL(timer_getoverrun, [](FEXCore::Core::CpuStateFrame *Frame, kernel_timer_t timerid) -> uint64_t {
       uint64_t Result = ::syscall(SYS_timer_getoverrun, timerid);
       SYSCALL_ERRNO();

--- a/Source/Tests/LinuxSyscalls/x32/Timer.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Timer.cpp
@@ -96,5 +96,11 @@ namespace FEX::HLE::x32 {
       }
       SYSCALL_ERRNO();
     });
+
+    REGISTER_SYSCALL_IMPL_X32(timer_create, [](FEXCore::Core::CpuStateFrame *Frame, clockid_t clockid, compat_ptr<FEX::HLE::x32::sigevent32> sevp, kernel_timer_t *timerid) -> uint64_t {
+      sigevent Host = *sevp;
+      uint64_t Result = ::syscall(SYS_timer_create, clockid, &Host, timerid);
+      SYSCALL_ERRNO();
+    });
   }
 }

--- a/Source/Tests/LinuxSyscalls/x64/Time.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Time.cpp
@@ -94,6 +94,7 @@ namespace FEX::HLE::x64 {
       uint64_t Result = ::syscall(SYS_timer_gettime, timerid, curr_value);
       SYSCALL_ERRNO();
     });
+
     REGISTER_SYSCALL_IMPL_X64(adjtimex, [](FEXCore::Core::CpuStateFrame *Frame, struct timex *buf) -> uint64_t {
       uint64_t Result = ::adjtimex(buf);
       SYSCALL_ERRNO();
@@ -101,6 +102,11 @@ namespace FEX::HLE::x64 {
 
     REGISTER_SYSCALL_IMPL_X64(clock_adjtime, [](FEXCore::Core::CpuStateFrame *Frame, clockid_t clk_id, struct timex *buf) -> uint64_t {
       uint64_t Result = ::clock_adjtime(clk_id, buf);
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X64(timer_create, [](FEXCore::Core::CpuStateFrame *Frame, clockid_t clockid, struct sigevent *sevp, kernel_timer_t *timerid) -> uint64_t {
+      uint64_t Result = ::syscall(SYS_timer_create, clockid, sevp, timerid);
       SYSCALL_ERRNO();
     });
   }


### PR DESCRIPTION
Needed to fix rt_sigtimedwait to use the raw syscall.
Needed to have sigtimedwait and sigtimedwait_time64 parse siginfo_t
correctly.
glibc uses this to ensure it is sending the correct signal across from
their helper thread.

Needed to correctly parse sigval and sigevent for 32-bit.

Passes my unit test for timer_create