### PR TITLE
Linux: Implements support for POSIX message queues on 32-bit

### DIFF
--- a/Source/Tests/LinuxSyscalls/Syscalls/Msg.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Msg.cpp
@@ -39,23 +39,8 @@ namespace FEX::HLE {
     });
 
     // last two parameters are optional
-    REGISTER_SYSCALL_IMPL(mq_open, [](FEXCore::Core::CpuStateFrame *Frame, const char *name, int oflag, mode_t mode, struct mq_attr *attr) -> uint64_t {
-      uint64_t Result = ::syscall(SYS_mq_open, name, oflag, mode, attr);
-      SYSCALL_ERRNO();
-    });
-
     REGISTER_SYSCALL_IMPL(mq_unlink, [](FEXCore::Core::CpuStateFrame *Frame, const char *name) -> uint64_t {
       uint64_t Result = ::syscall(SYS_mq_unlink, name);
-      SYSCALL_ERRNO();
-    });
-
-    REGISTER_SYSCALL_IMPL(mq_notify, [](FEXCore::Core::CpuStateFrame *Frame, mqd_t mqdes, const struct sigevent *sevp) -> uint64_t {
-      uint64_t Result = ::syscall(SYS_mq_notify, mqdes, sevp);
-      SYSCALL_ERRNO();
-    });
-
-    REGISTER_SYSCALL_IMPL(mq_getsetattr, [](FEXCore::Core::CpuStateFrame *Frame, mqd_t mqdes, struct mq_attr *newattr, struct mq_attr *oldattr) -> uint64_t {
-      uint64_t Result = ::syscall(SYS_mq_getsetattr, mqdes, newattr, oldattr);
       SYSCALL_ERRNO();
     });
   }

--- a/Source/Tests/LinuxSyscalls/x32/Types.h
+++ b/Source/Tests/LinuxSyscalls/x32/Types.h
@@ -13,6 +13,7 @@ $end_info$
 #include <cstdint>
 #include <cstring>
 #include <fcntl.h>
+#include <mqueue.h>
 #include <signal.h>
 #include <sys/resource.h>
 #include <sys/socket.h>
@@ -1124,4 +1125,35 @@ sigevent32 {
 
 static_assert(std::is_trivial<sigval32>::value, "Needs to be trivial");
 static_assert(sizeof(sigval32) == 4, "Incorrect size");
+
+struct
+FEX_ANNOTATE("alias-x86_32-mq_attr")
+FEX_ANNOTATE("fex-match")
+mq_attr32 {
+  compat_long_t mq_flags;
+  compat_long_t mq_maxmsg;
+  compat_long_t mq_msgsize;
+  compat_long_t mq_curmsgs;
+  compat_long_t __pad[4];
+  mq_attr32() = delete;
+
+  operator mq_attr() const {
+    struct mq_attr val{};
+    val.mq_flags   = mq_flags;
+    val.mq_maxmsg  = mq_maxmsg;
+    val.mq_msgsize = mq_msgsize;
+    val.mq_curmsgs = mq_curmsgs;
+    return val;
+  }
+
+  mq_attr32(struct mq_attr val) {
+    mq_flags   = val.mq_flags;
+    mq_maxmsg  = val.mq_maxmsg;
+    mq_msgsize = val.mq_msgsize;
+    mq_curmsgs = val.mq_curmsgs;
+  }
+};
+
+static_assert(std::is_trivial<mq_attr32>::value, "Needs to be trivial");
+static_assert(sizeof(mq_attr32) == 32, "Incorrect size");
 }

--- a/Source/Tests/LinuxSyscalls/x64/Msg.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Msg.cpp
@@ -28,5 +28,20 @@ namespace FEX::HLE::x64 {
       uint64_t Result = ::syscall(SYS_mq_timedreceive, mqdes, msg_ptr, msg_len, msg_prio, abs_timeout);
       SYSCALL_ERRNO();
     });
+
+    REGISTER_SYSCALL_IMPL_X64(mq_open, [](FEXCore::Core::CpuStateFrame *Frame, const char *name, int oflag, mode_t mode, struct mq_attr *attr) -> uint64_t {
+      uint64_t Result = ::syscall(SYS_mq_open, name, oflag, mode, attr);
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X64(mq_notify, [](FEXCore::Core::CpuStateFrame *Frame, mqd_t mqdes, const struct sigevent *sevp) -> uint64_t {
+      uint64_t Result = ::syscall(SYS_mq_notify, mqdes, sevp);
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X64(mq_getsetattr, [](FEXCore::Core::CpuStateFrame *Frame, mqd_t mqdes, struct mq_attr *newattr, struct mq_attr *oldattr) -> uint64_t {
+      uint64_t Result = ::syscall(SYS_mq_getsetattr, mqdes, newattr, oldattr);
+      SYSCALL_ERRNO();
+    });
   }
 }


### PR DESCRIPTION
These would have worked for 64-bit but wasn't working on 32-bit.
This now passes my unit test.

Relies on #1275 to be merged first.
Fixes #1260

Fun fact. strace when running a 32-bit application that executes mq_open, it fails to parse the mq_attr struct. Making seeing the arguments with strace pretty much entirely broken.