### PR TITLE
AOTIR: fix use after free

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -1218,8 +1218,6 @@ namespace FEXCore::Context {
                 AotFile->Stream->write((char*)&tag, sizeof(tag));
               }
               AotFile->AppendAOTIRCaptureCache(LocalRIP, LocalStartAddr, Length, hash, IRList, RAData);
-              delete IRList;
-              FEXCore::Allocator::free(RAData);
             });
           }
         }


### PR DESCRIPTION
These variables are owned by other parts of the code, and AOTIR should not be freeing/deleting them.