### PR TITLE
StructVerifier: Fix struct match and minor fixes

### DIFF
--- a/Scripts/StructPackVerifier.py
+++ b/Scripts/StructPackVerifier.py
@@ -244,7 +244,7 @@ def HandleVarDeclElements(Arch, VarDecl, Cursor):
                     logging.critical ("Can't handle alias type '{0}'".format(Child.spelling))
                     Arch.Parsed = False
             elif (Child.spelling == "fex-match"):
-                VarDecl.ExpectedFEXMatch = True
+                VarDecl.ExpectFEXMatch = True
             else:
                 # Unknown annotation
                 pass
@@ -317,7 +317,7 @@ def HandleStructElements(Arch, Struct, Cursor):
                     Arch.Parsed = False
 
             elif (Child.spelling == "fex-match"):
-                Struct.ExpectedFEXMatch = True
+                Struct.ExpectFEXMatch = True
             else:
                 # Unknown annotation
                 pass

--- a/Source/Tests/LinuxSyscalls/x32/EPoll.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/EPoll.cpp
@@ -18,7 +18,7 @@ $end_info$
 #include <unistd.h>
 #include <vector>
 
-ARG_TO_STR(FEX::HLE::x32::compat_ptr<FEX::HLE::epoll_event_x86>, "%lx")
+ARG_TO_STR(FEX::HLE::x32::compat_ptr<FEX::HLE::x32::epoll_event32>, "%lx")
 ARG_TO_STR(FEX::HLE::x32::compat_ptr<FEX::HLE::x32::timespec32>, "%lx")
 
 namespace FEXCore::Core {
@@ -27,9 +27,9 @@ namespace FEXCore::Core {
 
 namespace FEX::HLE::x32 {
   void RegisterEpoll(FEX::HLE::SyscallHandler *const Handler) {
-    REGISTER_SYSCALL_IMPL_X32(epoll_wait, [](FEXCore::Core::CpuStateFrame *Frame, int epfd, compat_ptr<FEX::HLE::epoll_event_x86> events, int maxevents, int timeout) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(epoll_wait, [](FEXCore::Core::CpuStateFrame *Frame, int epfd, compat_ptr<FEX::HLE::x32::epoll_event32> events, int maxevents, int timeout) -> uint64_t {
       std::vector<struct epoll_event> Events(std::max(0, maxevents));
-      uint64_t Result = ::syscall(SYS_epoll_pwait, epfd, Events.data(), maxevents, timeout, nullptr);
+      uint64_t Result = ::syscall(SYS_epoll_pwait, epfd, Events.data(), maxevents, timeout, nullptr, 8);
 
       if (Result != -1) {
         for (size_t i = 0; i < Result; ++i) {
@@ -39,16 +39,13 @@ namespace FEX::HLE::x32 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(epoll_ctl, [](FEXCore::Core::CpuStateFrame *Frame, int epfd, int op, int fd, compat_ptr<FEX::HLE::epoll_event_x86> event) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(epoll_ctl, [](FEXCore::Core::CpuStateFrame *Frame, int epfd, int op, int fd, compat_ptr<FEX::HLE::x32::epoll_event32> event) -> uint64_t {
       struct epoll_event Event = *event;
       uint64_t Result = ::syscall(SYS_epoll_ctl, epfd, op, fd, &Event);
-      if (Result != -1) {
-        *event = Event;
-      }
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(epoll_pwait, [](FEXCore::Core::CpuStateFrame *Frame, int epfd, compat_ptr<FEX::HLE::epoll_event_x86> events, int maxevent, int timeout, const uint64_t* sigmask, size_t sigsetsize) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(epoll_pwait, [](FEXCore::Core::CpuStateFrame *Frame, int epfd, compat_ptr<FEX::HLE::x32::epoll_event32> events, int maxevent, int timeout, const uint64_t* sigmask, size_t sigsetsize) -> uint64_t {
       std::vector<struct epoll_event> Events(std::max(0, maxevent));
 
       uint64_t Result = ::syscall(SYS_epoll_pwait,
@@ -72,7 +69,7 @@ namespace FEX::HLE::x32 {
 #ifndef SYS_epoll_pwait2
 #define SYS_epoll_pwait2 354
 #endif
-      REGISTER_SYSCALL_IMPL_X32(epoll_pwait2, [](FEXCore::Core::CpuStateFrame *Frame, int epfd, compat_ptr<FEX::HLE::epoll_event_x86> events, int maxevent, compat_ptr<timespec32> timeout, const uint64_t* sigmask, size_t sigsetsize) -> uint64_t {
+      REGISTER_SYSCALL_IMPL_X32(epoll_pwait2, [](FEXCore::Core::CpuStateFrame *Frame, int epfd, compat_ptr<FEX::HLE::x32::epoll_event32> events, int maxevent, compat_ptr<timespec32> timeout, const uint64_t* sigmask, size_t sigsetsize) -> uint64_t {
         std::vector<struct epoll_event> Events(std::max(0, maxevent));
 
         struct timespec tp64{};

--- a/Source/Tests/LinuxSyscalls/x32/Info.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Info.cpp
@@ -21,6 +21,9 @@ namespace FEXCore::Core {
   struct CpuStateFrame;
 }
 
+ARG_TO_STR(FEX::HLE::x32::compat_ptr<FEX::HLE::x32::rlimit32<true>>, "%lx")
+ARG_TO_STR(FEX::HLE::x32::compat_ptr<FEX::HLE::x32::rlimit32<false>>, "%lx")
+
 namespace FEX::HLE::x32 {
   struct sysinfo32 {
     int32_t uptime;

--- a/Source/Tests/LinuxSyscalls/x32/Msg.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Msg.cpp
@@ -14,6 +14,9 @@ $end_info$
 #include <time.h>
 #include <unistd.h>
 
+ARG_TO_STR(FEX::HLE::x32::compat_ptr<FEX::HLE::x32::mq_attr32>, "%lx")
+ARG_TO_STR(FEX::HLE::x32::compat_ptr<FEX::HLE::x32::sigevent32>, "%lx")
+
 namespace FEX::HLE::x32 {
   void RegisterMsg() {
     REGISTER_SYSCALL_IMPL_X32(mq_timedsend, [](FEXCore::Core::CpuStateFrame *Frame, mqd_t mqdes, const char *msg_ptr, size_t msg_len, unsigned int msg_prio, const struct timespec32 *abs_timeout) -> uint64_t {

--- a/Source/Tests/LinuxSyscalls/x32/Signals.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Signals.cpp
@@ -20,6 +20,8 @@ namespace FEXCore::Core {
   struct CpuStateFrame;
 }
 
+ARG_TO_STR(FEX::HLE::x32::compat_ptr<FEXCore::x86::siginfo_t>, "%lx")
+
 namespace FEX::HLE::x32 {
   void CopySigInfo(FEXCore::x86::siginfo_t *Info, siginfo_t const &Host) {
     // Copy the basic things first

--- a/Source/Tests/LinuxSyscalls/x32/Time.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Time.cpp
@@ -19,6 +19,7 @@ $end_info$
 #include <utime.h>
 
 ARG_TO_STR(FEX::HLE::x32::compat_ptr<FEX::HLE::x32::timespec32>, "%lx")
+ARG_TO_STR(FEX::HLE::x32::compat_ptr<FEX::HLE::x32::timex32>, "%lx")
 
 struct timespec;
 namespace FEXCore::Core {

--- a/Source/Tests/LinuxSyscalls/x32/Timer.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Timer.cpp
@@ -19,6 +19,8 @@ namespace FEXCore::Core {
   struct CpuStateFrame;
 }
 
+ARG_TO_STR(FEX::HLE::x32::compat_ptr<FEX::HLE::x32::sigevent32>, "%lx")
+
 namespace FEX::HLE::x32 {
   void RegisterTimer() {
     REGISTER_SYSCALL_IMPL_X32(timer_settime, [](FEXCore::Core::CpuStateFrame *Frame,

--- a/Source/Tests/LinuxSyscalls/x64/Semaphore.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Semaphore.cpp
@@ -16,6 +16,8 @@ namespace FEXCore::Core {
   struct CpuStateFrame;
 }
 
+ARG_TO_STR(FEX::HLE::x64::semun, "%lx")
+
 namespace FEX::HLE::x64 {
   void RegisterSemaphore() {
    REGISTER_SYSCALL_IMPL_X64(semop, [](FEXCore::Core::CpuStateFrame *Frame, int semid, struct sembuf *sops, size_t nsops) -> uint64_t {


### PR DESCRIPTION
Fixes StructVerifier to correctly compare things annotated with `fex-match`.
Minor changes that came from it, but nothing really broken.