### PR TITLE
Thunks: Makes file searches a bit easier

### DIFF
--- a/ThunkLibs/GuestLibs/CMakeLists.txt
+++ b/ThunkLibs/GuestLibs/CMakeLists.txt
@@ -37,7 +37,17 @@ endfunction()
 add_custom_target(ThunkGuestsInstall)
 
 function(add_guest_lib NAME)
-  add_library(${NAME}-guest SHARED ../lib${NAME}/lib${NAME}_Guest.cpp ${GEN_lib${NAME}})
+  set (SOURCE_FILE ../lib${NAME}/lib${NAME}_Guest.cpp)
+  get_filename_component(SOURCE_FILE_ABS "${SOURCE_FILE}" ABSOLUTE)
+  if (NOT EXISTS "${SOURCE_FILE_ABS}")
+    set (SOURCE_FILE ../lib${NAME}/Guest.cpp)
+    get_filename_component(SOURCE_FILE_ABS "${SOURCE_FILE}" ABSOLUTE)
+    if (NOT EXISTS "${SOURCE_FILE_ABS}")
+      message (FATAL_ERROR "Thunk source file for Guest lib ${NAME} doesn't exist!")
+    endif()
+  endif()
+
+  add_library(${NAME}-guest SHARED ${SOURCE_FILE} ${GEN_lib${NAME}})
   target_include_directories(${NAME}-guest PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/gen/lib${NAME}" "${CMAKE_CURRENT_SOURCE_DIR}/../include")
 
   add_custom_target(${NAME}-guest-install

--- a/ThunkLibs/HostLibs/CMakeLists.txt
+++ b/ThunkLibs/HostLibs/CMakeLists.txt
@@ -29,8 +29,19 @@ endfunction()
 
 add_custom_target(ThunkHostsInstall)
 function(add_host_lib NAME)
-  add_library(${NAME}-host SHARED ../lib${NAME}/lib${NAME}_Host.cpp ${GEN_lib${NAME}})
+  set (SOURCE_FILE ../lib${NAME}/lib${NAME}_Host.cpp)
+    get_filename_component(SOURCE_FILE_ABS "${SOURCE_FILE}" ABSOLUTE)
+  if (NOT EXISTS "${SOURCE_FILE_ABS}")
+    set (SOURCE_FILE ../lib${NAME}/Host.cpp)
+    get_filename_component(SOURCE_FILE_ABS "${SOURCE_FILE}" ABSOLUTE)
+    if (NOT EXISTS "${SOURCE_FILE_ABS}")
+      message (FATAL_ERROR "Thunk source file for Host lib ${NAME} doesn't exist!")
+    endif()
+  endif()
+
+  add_library(${NAME}-host SHARED ${SOURCE_FILE} ${GEN_lib${NAME}})
   target_include_directories(${NAME}-host PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/gen/lib${NAME}" "${CMAKE_CURRENT_SOURCE_DIR}/../include")
+  target_link_libraries(${NAME}-host PRIVATE dl)
 
   add_custom_target(${NAME}-host-install
     COMMAND ${CMAKE_COMMAND} -E make_directory ${DATA_DIRECTORY}/HostThunks/


### PR DESCRIPTION
Instead of searching inside the thunk folder for Guest and Host files
with a library name attached to it, also search for ones That are just
named `Host.cpp` and `Guest.cpp`.

Makes quickly pounding out a bunch of thunks significantly less tedious.