### PR TITLE
Thunks: Adds a new Thunks database config file

### DIFF
--- a/Source/Tests/LinuxSyscalls/FileManagement.h
+++ b/Source/Tests/LinuxSyscalls/FileManagement.h
@@ -17,6 +17,7 @@ $end_info$
 #include <sys/stat.h>
 
 #include <unordered_map>
+#include <unordered_set>
 
 #include "Tests/LinuxSyscalls/EmulatedFiles/EmulatedFiles.h"
 
@@ -76,5 +77,14 @@ private:
   FEX_CONFIG_OPT(ThunkGuestLibs, THUNKGUESTLIBS);
   FEX_CONFIG_OPT(ThunkConfig, THUNKCONFIG);
   uint32_t CurrentPID{};
+
+  void LoadThunkDatabase(bool Global);
+  struct ThunkDBObject {
+    std::string LibraryName;
+    std::unordered_set<std::string> Depends;
+    std::vector<std::string> Overlays;
+    bool Enabled{};
+  };
+  std::unordered_map<std::string, ThunkDBObject> ThunkDB{};
 };
 }


### PR DESCRIPTION
This adds a new `ThunksDB.json` file to the config folder.
This file lets users describe thunks in a meaningful way without
duplicating it amongst multiple configuration files.

eg:
```
{
  "DB": {
    "GL": {
      "Library" : "libGL-guest.so",
      "Depends": [
        "X11"
      ],
      "Overlay": [
        "/usr/lib/x86_64-linux-gnu/libGL.so",
        "/usr/lib/x86_64-linux-gnu/libGL.so.1",
        "/usr/lib/x86_64-linux-gnu/libGL.so.1.2.0",
        "/usr/lib/x86_64-linux-gnu/libGL.so.1.7.0",
        "/lib/x86_64-linux-gnu/libGL.so",
        "/lib/x86_64-linux-gnu/libGL.so.1",
        "/lib/x86_64-linux-gnu/libGL.so.1.2.0",
        "/lib/x86_64-linux-gnu/libGL.so.1.7.0"
      ]
    },
    "X11": {
      "Library": "libX11-guest.so",
      "Overlay": [
        "/usr/lib/x86_64-linux-gnu/libX11.so.6",
        "/lib/x86_64-linux-gnu/libX11.so.6"
      ]
    }
  }
}
```

This file lets the user describe the library with an nicer name, in this instance
`GL` instead of `libGL-guest.so`.
It also tracks depedencies, like how GL currently has a hard dependency on X11.
This allows the loader to automatically enable the dependencies if described.
The `Overlays` array is like the regular Thunks config file but now in this DB file.

With the DB file now describing the libraries, this allows us to then stick a lighter
description inside of the Thunk Config file.

```
{
 "ThunksDB": {
   "GL": 1
 }
}
```

With this example Thunk config file (Which can be configured per application), There is
a new property of name `ThunksDB`.
All this takes is key:value pairs which describe the user friendly library name and an Integer
to state if the thunk should be enabled or not.
This allows very quick toggling of thunks directly inside of the configuration files rather than
breaking the configuration to disable it.