### PR TITLE
Thunks: Support versioned libraries

### DIFF
--- a/ThunkLibs/Generators/libEGL.py
+++ b/ThunkLibs/Generators/libEGL.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 from ThunkHelpers import *
 
-lib("libEGL")
+lib("libEGL", "0")
 
 fn("EGLBoolean eglBindAPI(EGLenum)")
 fn("EGLBoolean eglChooseConfig(EGLDisplay, const EGLint*, void**, EGLint, EGLint*)")

--- a/ThunkLibs/Generators/libGL.py
+++ b/ThunkLibs/Generators/libGL.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 from ThunkHelpers import *
 
-lib("libGL")
+lib("libGL", "1")
 
 # GLX (except glXGetProcAddress that is implemented in cpp)
 fn("const char* glXQueryCurrentRendererStringMESA(int)")

--- a/ThunkLibs/Generators/libSDL2.py
+++ b/ThunkLibs/Generators/libSDL2.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 from ThunkHelpers import *
 
-lib("libSDL2")
+lib("libSDL2", "")
 
 # these need function pointers
 #  fn("int SDL_TLSSet(SDL_TLSID, const void*, void (*)(void*))")

--- a/ThunkLibs/Generators/libX11.py
+++ b/ThunkLibs/Generators/libX11.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 from ThunkHelpers import *
 
-lib("libX11")
+lib("libX11", "1")
 
 # VArgs support needs manual work
 # fn("char* XSetICValues(XIC, ...)") # TODO VARGS

--- a/ThunkLibs/Generators/libXext.py
+++ b/ThunkLibs/Generators/libXext.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 from ThunkHelpers import *
 
-lib("libXext")
+lib("libXext", "6")
 
 # needs function pointer
 # fn("int (* XSetExtensionErrorHandler(XextErrorHandler))(Display*, const char*, const char*)")

--- a/ThunkLibs/Generators/libXfixes.py
+++ b/ThunkLibs/Generators/libXfixes.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 from ThunkHelpers import *
 
-lib("libXfixes")
+lib("libXfixes", "3")
 
 fn("const char* XFixesGetCursorName(Display*, Cursor, Atom*)")
 fn("int XFixesQueryExtension(Display*, int*, int*)")

--- a/ThunkLibs/Generators/libXrender.py
+++ b/ThunkLibs/Generators/libXrender.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 from ThunkHelpers import *
 
-lib("libXrender")
+lib("libXrender", "1")
 
 fn("Cursor XRenderCreateAnimCursor(Display*, int, XAnimCursor*)")
 fn("Cursor XRenderCreateCursor(Display*, Picture, unsigned int, unsigned int)")

--- a/ThunkLibs/Generators/libasound.py
+++ b/ThunkLibs/Generators/libasound.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 from ThunkHelpers import *
 
-lib("libasound")
+lib("libasound", "2")
 
 fn("const char * snd_asoundlib_version()")
 fn("int snd_dlpath(char *, size_t, const char *)")

--- a/ThunkLibs/Generators/libdrm.py
+++ b/ThunkLibs/Generators/libdrm.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 from ThunkHelpers import *
 
-lib("libdrm")
+lib("libdrm", "2")
 
 # FEX
 fn("size_t FEX_usable_size(void*)"); no_unpack()

--- a/ThunkLibs/Generators/libfex_malloc.py
+++ b/ThunkLibs/Generators/libfex_malloc.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 from ThunkHelpers import *
 
-lib("libfex_malloc")
+lib("libfex_malloc", "")
 
 # FEX
 fn("void fex_get_allocation_ptrs(AllocationPtrs *)")

--- a/ThunkLibs/Generators/libvulkan_device.py
+++ b/ThunkLibs/Generators/libvulkan_device.py
@@ -504,7 +504,7 @@ for i in range(0, NumToErase):
 parse_vulkan(VulkanXML, PrintHeader)
 
 if PrintThunks:
-    lib(LibName)
+    lib(LibName, "")
 
     # Functions here
     export_vulkan()

--- a/ThunkLibs/Generators/libxcb.py
+++ b/ThunkLibs/Generators/libxcb.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 from ThunkHelpers import *
 
-lib("libxcb")
+lib("libxcb", "1")
 
 # There is a paradigm inside of XCB of functions that return a pointer, a length, and an end
 # The application is seemingly reading directly from some internal data structures

--- a/ThunkLibs/Generators/libxcb_dri2.py
+++ b/ThunkLibs/Generators/libxcb_dri2.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 from ThunkHelpers import *
 
-lib_with_filename("libxcb_dri2", "libxcb-dri2")
+lib_with_filename("libxcb_dri2", "0", "libxcb-dri2")
 
 # FEX
 fn("void FEX_xcb_dri2_init_extension(xcb_connection_t *, xcb_extension_t *)"); no_unpack()

--- a/ThunkLibs/Generators/libxcb_dri3.py
+++ b/ThunkLibs/Generators/libxcb_dri3.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 from ThunkHelpers import *
 
-lib_with_filename("libxcb_dri3", "libxcb-dri3")
+lib_with_filename("libxcb_dri3", "0", "libxcb-dri3")
 
 # FEX
 fn("void FEX_xcb_dri3_init_extension(xcb_connection_t *, xcb_extension_t *)"); no_unpack()

--- a/ThunkLibs/Generators/libxcb_glx.py
+++ b/ThunkLibs/Generators/libxcb_glx.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 from ThunkHelpers import *
 
-lib_with_filename("libxcb_glx", "libxcb-glx")
+lib_with_filename("libxcb_glx", "0", "libxcb-glx")
 # FEX
 fn("void FEX_xcb_glx_init_extension(xcb_connection_t *, xcb_extension_t *)"); no_unpack()
 fn("size_t FEX_usable_size(void*)"); no_unpack()

--- a/ThunkLibs/Generators/libxcb_present.py
+++ b/ThunkLibs/Generators/libxcb_present.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 from ThunkHelpers import *
 
-lib_with_filename("libxcb_present", "libxcb-present")
+lib_with_filename("libxcb_present", "0", "libxcb-present")
 # FEX
 fn("void FEX_xcb_present_init_extension(xcb_connection_t *, xcb_extension_t *)"); no_unpack()
 fn("size_t FEX_usable_size(void*)"); no_unpack()

--- a/ThunkLibs/Generators/libxcb_randr.py
+++ b/ThunkLibs/Generators/libxcb_randr.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 from ThunkHelpers import *
 
-lib_with_filename("libxcb_randr", "libxcb-randr")
+lib_with_filename("libxcb_randr", "0", "libxcb-randr")
 
 # FEX
 fn("void FEX_xcb_randr_init_extension(xcb_connection_t *, xcb_extension_t *)"); no_unpack()

--- a/ThunkLibs/Generators/libxcb_shm.py
+++ b/ThunkLibs/Generators/libxcb_shm.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 from ThunkHelpers import *
 
-lib_with_filename("libxcb_shm", "libxcb-shm")
+lib_with_filename("libxcb_shm", "0", "libxcb-shm")
 
 # FEX
 fn("void FEX_xcb_shm_init_extension(xcb_connection_t *, xcb_extension_t *)"); no_unpack()

--- a/ThunkLibs/Generators/libxcb_sync.py
+++ b/ThunkLibs/Generators/libxcb_sync.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 from ThunkHelpers import *
 
-lib_with_filename("libxcb_sync", "libxcb-sync")
+lib_with_filename("libxcb_sync", "1", "libxcb-sync")
 
 # FEX
 fn("void FEX_xcb_sync_init_extension(xcb_connection_t *, xcb_extension_t *)"); no_unpack()

--- a/ThunkLibs/Generators/libxcb_xfixes.py
+++ b/ThunkLibs/Generators/libxcb_xfixes.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 from ThunkHelpers import *
 
-lib_with_filename("libxcb_xfixes", "libxcb-xfixes")
+lib_with_filename("libxcb_xfixes", "0", "libxcb-xfixes")
 
 # FEX
 fn("void FEX_xcb_xfixes_init_extension(xcb_connection_t *, xcb_extension_t *)"); no_unpack()

--- a/ThunkLibs/Generators/libxshmfence.py
+++ b/ThunkLibs/Generators/libxshmfence.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 from ThunkHelpers import *
 
-lib("libxshmfence")
+lib("libxshmfence", "1")
 fn("int xshmfence_trigger(struct xshmfence *)")
 fn("int xshmfence_await(struct xshmfence *)")
 fn("int xshmfence_query(struct xshmfence *)")


### PR DESCRIPTION
We can't expect users to have development libraries installed.
Load the versioned libraries if they exist instead

Also load them in global namespace, which is required for getting
symbols.

Behaviour on x86-64 host seems sporatic here, not sure if unintended
feature.
Doesn't quite behave the same on AArch64 host