### PR TITLE
JITSymbols: Change over to runtime enablement of symbols

### DIFF
--- a/External/FEXCore/CMakeLists.txt
+++ b/External/FEXCore/CMakeLists.txt
@@ -16,7 +16,6 @@ endif()
 set(ENABLE_JIT_X86_64 ${_M_X86_64} CACHE BOOL "Enable the x86_64 JIT")
 set(ENABLE_JIT_ARM64 ${_M_ARM_64} CACHE BOOL "Enable the ARM64 JIT")
 option(ENABLE_CLANG_FORMAT "Run clang format over the source" FALSE)
-option(ENABLE_JITSYMBOLS "Enable visibility of JITSymbols in profiling tools" FALSE)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 cmake_policy(SET CMP0083 NEW) # Follow new PIE policy

--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -182,10 +182,6 @@ if (ENABLE_JIT_ARM64)
     Interface/Core/JIT/Arm64/VectorOps.cpp)
 endif()
 
-if (ENABLE_JITSYMBOLS)
-  list(APPEND DEFINES -DENABLE_JITSYMBOLS=1)
-endif()
-
 set (LIBS vixl dl fmt::fmt xxhash tiny-json)
 if (ENABLE_JEMALLOC)
   list (APPEND LIBS FEX_jemalloc)

--- a/External/FEXCore/Source/Common/JitSymbols.cpp
+++ b/External/FEXCore/Source/Common/JitSymbols.cpp
@@ -41,5 +41,16 @@ namespace FEXCore {
     String << std::hex << HostAddr << " " << CodeSize << " " << Name << "_" << HostAddr << std::endl;
     fwrite(String.str().c_str(), 1, String.str().size(), fp);
   }
+
+  void JITSymbols::RegisterJITSpace(void *HostAddr, uint32_t CodeSize) {
+    if (!fp) return;
+
+    // Linux perf format is very straightforward
+    // `<HostPtr> <Size> <Name>\n`
+    std::stringstream String;
+    String << std::hex << HostAddr << " " << CodeSize << " FEXJIT" << std::endl;
+    fwrite(String.str().c_str(), 1, String.str().size(), fp);
+  }
+
 }
 

--- a/External/FEXCore/Source/Common/JitSymbols.h
+++ b/External/FEXCore/Source/Common/JitSymbols.h
@@ -10,6 +10,7 @@ public:
   ~JITSymbols();
   void Register(void *HostAddr, uint64_t GuestAddr, uint32_t CodeSize);
   void Register(void *HostAddr, uint32_t CodeSize, std::string const &Name);
+  void RegisterJITSpace(void *HostAddr, uint32_t CodeSize);
 
 private:
   FILE* fp{};

--- a/External/FEXCore/Source/Interface/Config/Config.json.in
+++ b/External/FEXCore/Source/Interface/Config/Config.json.in
@@ -163,8 +163,25 @@
           "Potentially useful for debugging memory problems",
           "32-bit allocator is always used if your host kernel is older than 4.17"
         ]
+      },
+      "GlobalJITNaming": {
+        "Type": "bool",
+        "Default": "false",
+        "Desc": [
+          "Uses JITSymbols to name all JIT state as one symbol",
+          "Useful for querying how much time is spent inside of the JIT",
+          "Profiling tools will show JIT time as FEXJIT"
+        ]
+      },
+      "BlockJITNaming": {
+        "Type": "bool",
+        "Default": "false",
+        "Desc": [
+          "Uses JITSymbols to name JIT symbols",
+          "Useful for determining hot blocks of code",
+          "Has some file writing overhead per JIT block"
+        ]
       }
-
     },
     "Logging": {
       "SilentLog": {

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Common/JitSymbols.h"
 #include "Interface/Core/CPUID.h"
 #include "Interface/Core/HostFeatures.h"
 #include "Interface/Core/X86HelperGen.h"
@@ -12,9 +13,6 @@
 #include <FEXCore/Utils/Event.h>
 #include <stdint.h>
 
-#ifdef ENABLE_JITSYMBOLS
-#include <Common/JITSymbols.h>
-#endif
 
 #include <atomic>
 #include <condition_variable>
@@ -127,6 +125,8 @@ namespace FEXCore::Context {
       FEX_CONFIG_OPT(ThunkConfigFile, THUNKCONFIG);
       FEX_CONFIG_OPT(DumpIR, DUMPIR);
       FEX_CONFIG_OPT(StaticRegisterAllocation, SRA);
+      FEX_CONFIG_OPT(GlobalJITNaming, GLOBALJITNAMING);
+      FEX_CONFIG_OPT(BlockJITNaming, BLOCKJITNAMING);
     } Config;
 
     using IntCallbackReturn =  FEX_NAKED void(*)(FEXCore::Core::InternalThreadState *Thread, volatile void *Host_RSP);
@@ -328,9 +328,7 @@ namespace FEXCore::Context {
     void AddNamedRegion(uintptr_t Base, uintptr_t Size, uintptr_t Offset, const std::string &filename);
     void RemoveNamedRegion(uintptr_t Base, uintptr_t Size);
 
-#if ENABLE_JITSYMBOLS
     FEXCore::JITSymbols Symbols;
-#endif
 
     // Public for threading
     void ExecutionThread(FEXCore::Core::InternalThreadState *Thread);

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -1200,17 +1200,17 @@ namespace FEXCore::Context {
     }
 
     // The core managed to compile the code.
-#if ENABLE_JITSYMBOLS
-    if (DebugData) {
-      if (DebugData->Subblocks.size()) {
-        for (auto& Subblock: DebugData->Subblocks) {
-          Symbols.Register((void*)Subblock.HostCodeStart, GuestRIP, Subblock.HostCodeSize);
+    if (Config.BlockJITNaming()) {
+      if (DebugData) {
+        if (DebugData->Subblocks.size()) {
+          for (auto& Subblock: DebugData->Subblocks) {
+            Symbols.Register((void*)Subblock.HostCodeStart, GuestRIP, Subblock.HostCodeSize);
+          }
+        } else {
+          Symbols.Register(CodePtr, GuestRIP, DebugData->HostCodeSize);
         }
-      } else {
-        Symbols.Register(CodePtr, GuestRIP, DebugData->HostCodeSize);
       }
     }
-#endif
 
     // Insert to caches if we generated IR
     if (GeneratedIR) {

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/X86Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/X86Dispatcher.cpp
@@ -306,10 +306,13 @@ X86Dispatcher::X86Dispatcher(FEXCore::Context::Context *ctx, FEXCore::Core::Inte
   Start = reinterpret_cast<uint64_t>(getCode());
   End = Start + getSize();
 
-  #if ENABLE_JITSYMBOLS
+  if (CTX->Config.BlockJITNaming()) {
     std::string Name = "Dispatch_" + std::to_string(::gettid());
     CTX->Symbols.Register(reinterpret_cast<void*>(Start), End-Start, Name);
-  #endif
+  }
+  if (CTX->Config.GlobalJITNaming()) {
+    CTX->Symbols.RegisterJITSpace(reinterpret_cast<void*>(Start), End-Start);
+  }
 }
 
 X86Dispatcher::~X86Dispatcher() {

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -321,6 +321,9 @@ Arm64JITCore::CodeBuffer Arm64JITCore::AllocateNewCodeBuffer(size_t Size) {
                     -1, 0));
   LOGMAN_THROW_A_FMT(!!Buffer.Ptr, "Couldn't allocate code buffer");
   Dispatcher->RegisterCodeBuffer(Buffer.Ptr, Buffer.Size);
+  if (CTX->Config.GlobalJITNaming()) {
+    CTX->Symbols.RegisterJITSpace(Buffer.Ptr, Buffer.Size);
+  }
   return Buffer;
 }
 


### PR DESCRIPTION
Adds a new option for just describing all JIT state as a single symbol.
Useful for simple profiling of total time spent in the JIT