### PR TITLE
TestHarnessRunner: Convert LOGMAN_THROW_A into error log and exit

### DIFF
--- a/Source/Tests/TestHarnessRunner.cpp
+++ b/Source/Tests/TestHarnessRunner.cpp
@@ -56,11 +56,11 @@ void MsgHandler(LogMan::DebugLevels Level, char const *Message) {
     CharLevel = "???";
     break;
   }
-  printf("[%s] %s\n", CharLevel, Message);
+  fmt::print("[{}] {}\n", CharLevel, Message);
 }
 
 void AssertHandler(char const *Message) {
-  printf("[ASSERT] %s\n", Message);
+  fmt::print("[ASSERT] {}\n", Message);
 }
 
 int main(int argc, char **argv, char **const envp) {
@@ -114,7 +114,7 @@ int main(int argc, char **argv, char **const envp) {
       return Allocator->munmap(addr, length);
     })) {
       // failed to map
-      LogMan::Msg::E("Failed to map 32-bit elf file.");
+      LogMan::Msg::EFmt("Failed to map 32-bit elf file.");
       return -ENOEXEC;
     }
   }
@@ -143,8 +143,8 @@ int main(int argc, char **argv, char **const envp) {
   FEXCore::Context::GetCPUState(CTX, &State);
   bool Passed = !DidFault && Loader.CompareStates(&State, nullptr);
 
-  LogMan::Msg::I("Faulted? %s", DidFault ? "Yes" : "No");
-  LogMan::Msg::I("Passed? %s", Passed ? "Yes" : "No");
+  LogMan::Msg::IFmt("Faulted? {}", DidFault ? "Yes" : "No");
+  LogMan::Msg::IFmt("Passed? {}", Passed ? "Yes" : "No");
 
   SyscallHandler.reset();
   SignalDelegation.reset();


### PR DESCRIPTION
In release builds LOGMAN_THROW_A doesn't do anything, so running the program without arguments would lead to a segfault.

While we're at it, we can convert the logging over to fmt