### PR TITLE
TestHarnessRunner: Make argument check more strict

### DIFF
--- a/Source/Tests/TestHarnessRunner.cpp
+++ b/Source/Tests/TestHarnessRunner.cpp
@@ -73,7 +73,7 @@ int main(int argc, char **argv, char **const envp) {
 
   auto Args = FEX::ArgLoader::Get();
 
-  if (Args.empty()) {
+  if (Args.size() < 2) {
     LogMan::Msg::EFmt("Not enough arguments");
     return -1;
   }


### PR DESCRIPTION
Overlooked that more than one argument was being when replacing the throw macro (whoops!)