### PR TITLE
Thunks/vulkan: Suppress compiler warnings about unknown attributes

### DIFF
--- a/ThunkLibs/Generators/libvulkan_device.py
+++ b/ThunkLibs/Generators/libvulkan_device.py
@@ -333,6 +333,8 @@ def print_types():
     print_remaining_base_types()
 
     # Structs third
+    print("#pragma GCC diagnostic push")
+    print("#pragma GCC diagnostic ignored \"-Wattributes\"") # Suppress error spam about GCC not recognizing fex-match annotations
     for i in range(0, 2):
         for StructName, Struct in StructDefs.items():
             # First walk the struct members and ensure any dependency is already emitted
@@ -342,6 +344,7 @@ def print_types():
 
             # Now print this struct
             print_struct(Struct.Name)
+    print("#pragma GCC diagnostic pop")
 
 # Walks the commands element in the XML and pulls out all functions
 # This will be used to generate the thunks that we need to hit


### PR DESCRIPTION
Previously, compiling vulkan libs would generate almost 4000 of these warnings:
```
gen/libvulkan_panfrost/Header.inl:2903: warning: ‘annotate’ attribute directive ignored [-Wattributes]
gen/libvulkan_panfrost/Header.inl:2903:47: warning: ‘annotate’ attribute directive ignored [-Wattributes]
 2903 | struct __attribute__((annotate("fex-match"))) VkDescriptorPoolCreateInfo {
      |                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~
```
