### PR TITLE
JITSymbols: Allow grouping JIT symbols by guest named regions

### DIFF
--- a/External/FEXCore/Source/Common/JitSymbols.cpp
+++ b/External/FEXCore/Source/Common/JitSymbols.cpp
@@ -42,6 +42,16 @@ namespace FEXCore {
     fwrite(String.str().c_str(), 1, String.str().size(), fp);
   }
 
+  void JITSymbols::RegisterNamedRegion(void *HostAddr, uint32_t CodeSize, std::string const &Name) {
+    if (!fp) return;
+
+    // Linux perf format is very straightforward
+    // `<HostPtr> <Size> <Name>\n`
+    std::stringstream String;
+    String << std::hex << HostAddr << " " << CodeSize << " " << Name << std::endl;
+    fwrite(String.str().c_str(), 1, String.str().size(), fp);
+  }
+
   void JITSymbols::RegisterJITSpace(void *HostAddr, uint32_t CodeSize) {
     if (!fp) return;
 

--- a/External/FEXCore/Source/Common/JitSymbols.h
+++ b/External/FEXCore/Source/Common/JitSymbols.h
@@ -10,6 +10,7 @@ public:
   ~JITSymbols();
   void Register(void *HostAddr, uint64_t GuestAddr, uint32_t CodeSize);
   void Register(void *HostAddr, uint32_t CodeSize, std::string const &Name);
+  void RegisterNamedRegion(void *HostAddr, uint32_t CodeSize, std::string const &Name);
   void RegisterJITSpace(void *HostAddr, uint32_t CodeSize);
 
 private:

--- a/External/FEXCore/Source/Interface/Config/Config.json.in
+++ b/External/FEXCore/Source/Interface/Config/Config.json.in
@@ -173,6 +173,15 @@
           "Profiling tools will show JIT time as FEXJIT"
         ]
       },
+      "LibraryJITNaming": {
+        "Type": "bool",
+        "Default": "false",
+        "Desc": [
+          "Uses JITSymbols to name JIT symbols grouped by library",
+          "Useful for querying how much time is spent in each guest library",
+          "Can be used to help guide thunk generation"
+        ]
+      },
       "BlockJITNaming": {
         "Type": "bool",
         "Default": "false",

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -126,6 +126,7 @@ namespace FEXCore::Context {
       FEX_CONFIG_OPT(DumpIR, DUMPIR);
       FEX_CONFIG_OPT(StaticRegisterAllocation, SRA);
       FEX_CONFIG_OPT(GlobalJITNaming, GLOBALJITNAMING);
+      FEX_CONFIG_OPT(LibraryJITNaming, LIBRARYJITNAMING);
       FEX_CONFIG_OPT(BlockJITNaming, BLOCKJITNAMING);
     } Config;
 
@@ -175,9 +176,11 @@ namespace FEXCore::Context {
       bool ContainsCode;
     };
 
-    std::map<uint64_t, AddrToFileEntry> AddrToFile;
+    using AddrToFileMapType = std::map<uint64_t, AddrToFileEntry>;
+    AddrToFileMapType AddrToFile;
     std::map<std::string, std::string> FilesWithCode;
 
+    AddrToFileMapType::iterator FindAddrForFile(uint64_t Entry, uint64_t Length);
 #ifdef BLOCKSTATS
     std::unique_ptr<FEXCore::BlockSamplingData> BlockData;
 #endif


### PR DESCRIPTION
This lets us have JITsymbols grouped by library.
Useful for determining where to thunk.

Sadly perf doesn't have an option to deduplicate regions by name, so
some external tooling is necessary to make it look nice.