### PR TITLE
Cmake: Change static-pie message to indicate compiled without it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,7 +208,7 @@ if (ENABLE_STATIC_PIE)
       message (FATAL_ERROR "Application has __rela_iplt_{start,end} symbols. Which means static-pie can't be enabled")
     endif()
   else()
-    message (FATAL_ERROR "Couldn't compile static-pie test. Static-pie can't be enabled!")
+    message (FATAL_ERROR "Couldn't compile static-pie test. Static-pie can't be enabled! Is your glibc compiled without static-pie?")
   endif()
 endif()
 


### PR DESCRIPTION
If glibc is compiled without static-pie then we can't detect that. We
will just get a compile failure.
Looks like ALARM is compiling glibc without --enable-static-pie for
whatever reason.

Fixes #1326 as much as we can. We need to ask the ALARM maintainers to
change their configuration.