### PR TITLE
ALUOps: Fix left-over printf specifier in fmt log

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -163,7 +163,7 @@ DEF_OP(Mul) {
     case 8:
       mul(Dst, GetReg<RA_64>(Op->Header.Args[0].ID()), GetReg<RA_64>(Op->Header.Args[1].ID()));
     break;
-    default: LOGMAN_MSG_A_FMT("Unknown Mul size: %d", OpSize);
+    default: LOGMAN_MSG_A_FMT("Unknown Mul size: {}", OpSize);
   }
 }
 


### PR DESCRIPTION
Noticed this while looking at the JIT