### PR TITLE
OpcodeDispatcher: Handle BMI1 BEXTR

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Frontend.cpp
+++ b/External/FEXCore/Source/Interface/Core/Frontend.cpp
@@ -595,7 +595,7 @@ bool Decoder::NormalOp(FEXCore::X86Tables::X86InstInfo const *Info, uint16_t Op,
 
   size_t CurrentSrc = 0;
 
-  if ((Info->Flags & FEXCore::X86Tables::InstFlags::FLAGS_VEX) != 0) {
+  if ((Info->Flags & FEXCore::X86Tables::InstFlags::FLAGS_VEX_1ST_SRC) != 0) {
     DecodeInst->Src[CurrentSrc].Type = DecodedOperand::OpType::GPR;
     DecodeInst->Src[CurrentSrc].Data.GPR.HighBits = false;
     DecodeInst->Src[CurrentSrc].Data.GPR.GPR = MapVEXToReg(Options.vvvv, HasXMMSrc);
@@ -611,6 +611,13 @@ bool Decoder::NormalOp(FEXCore::X86Tables::X86InstInfo const *Info, uint16_t Op,
       if (!ModRMOperand(DecodeInst->Dest, DecodeInst->Src[CurrentSrc], HasXMMDst, HasXMMSrc, HasMMDst, HasMMSrc, Is8BitDest, Is8BitSrc))
         return false;
     }
+    ++CurrentSrc;
+  }
+
+  if ((Info->Flags & FEXCore::X86Tables::InstFlags::FLAGS_VEX_2ND_SRC) != 0) {
+    DecodeInst->Src[CurrentSrc].Type = DecodedOperand::OpType::GPR;
+    DecodeInst->Src[CurrentSrc].Data.GPR.HighBits = false;
+    DecodeInst->Src[CurrentSrc].Data.GPR.GPR = MapVEXToReg(Options.vvvv, HasXMMSrc);
     ++CurrentSrc;
   }
 

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -326,6 +326,7 @@ public:
 
   // BMI Ops
   void ANDNBMIOp(OpcodeArgs);
+  void BEXTRBMIOp(OpcodeArgs);
 
   // X87 Ops
   template<size_t width>

--- a/External/FEXCore/Source/Interface/Core/X86Tables/VEXTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/VEXTables.cpp
@@ -399,7 +399,7 @@ void InitializeVEXTables() {
 
     {OPD(2, 0b11, 0xF6), 1, X86InstInfo{"MULX", TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
 
-    {OPD(2, 0b00, 0xF7), 1, X86InstInfo{"BEXTR", TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
+    {OPD(2, 0b00, 0xF7), 1, X86InstInfo{"BEXTR", TYPE_INST, FLAGS_MODRM | FLAGS_VEX_2ND_SRC, 0, nullptr}},
     {OPD(2, 0b01, 0xF7), 1, X86InstInfo{"SHLX", TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
     {OPD(2, 0b10, 0xF7), 1, X86InstInfo{"SARX", TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
     {OPD(2, 0b11, 0xF7), 1, X86InstInfo{"SHRX", TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},

--- a/External/FEXCore/Source/Interface/Core/X86Tables/VEXTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/VEXTables.cpp
@@ -386,7 +386,7 @@ void InitializeVEXTables() {
     {OPD(2, 0b01, 0xDE), 1, X86InstInfo{"VAESDEC", TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
     {OPD(2, 0b01, 0xDF), 1, X86InstInfo{"VAESDECLAST", TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
 
-    {OPD(2, 0b00, 0xF2), 1, X86InstInfo{"ANDN", TYPE_INST, FLAGS_MODRM | FLAGS_VEX, 0, nullptr}},
+    {OPD(2, 0b00, 0xF2), 1, X86InstInfo{"ANDN", TYPE_INST, FLAGS_MODRM | FLAGS_VEX_1ST_SRC, 0, nullptr}},
 
     {OPD(2, 0b00, 0xF3), 1, X86InstInfo{"", TYPE_VEX_GROUP_17, FLAGS_NONE, 0, nullptr}}, // VEX Group 17
     {OPD(2, 0b01, 0xF3), 1, X86InstInfo{"", TYPE_VEX_GROUP_17, FLAGS_NONE, 0, nullptr}}, // VEX Group 17

--- a/External/FEXCore/include/FEXCore/Debug/X86Tables.h
+++ b/External/FEXCore/include/FEXCore/Debug/X86Tables.h
@@ -338,8 +338,10 @@ constexpr uint32_t FLAGS_POP                  = (1 << 22);
 // Only SEXT if the instruction is operating in 64bit operand size
 constexpr uint32_t FLAGS_SRC_SEXT64BIT        = (1 << 23);
 
-// Whether or not the instruction has a VEX prefix
-constexpr uint32_t FLAGS_VEX                  = (1 << 24);
+// Whether or not the instruction has a VEX prefix for the first source operand
+constexpr uint32_t FLAGS_VEX_1ST_SRC          = (1 << 24);
+// Whether or not the instruction has a VEX prefix for the second source operand
+constexpr uint32_t FLAGS_VEX_2ND_SRC          = (1 << 25);
 
 constexpr uint32_t FLAGS_SIZE_DST_OFF = 26;
 constexpr uint32_t FLAGS_SIZE_SRC_OFF = FLAGS_SIZE_DST_OFF + 3;

--- a/unittests/ASM/VEX/bextr.asm
+++ b/unittests/ASM/VEX/bextr.asm
@@ -1,0 +1,34 @@
+%ifdef CONFIG
+{
+  "RegData": {
+      "RAX": "0x7F",
+      "RBX": "0",
+      "RDX": "0xFF",
+      "RSI": "0"
+  }
+}
+%endif
+
+; General extraction
+mov rax, 0x7FFFFFFFFFFFFFFF
+mov rbx, 0x838              ; Start at bit 56 and extract 8 bits
+bextr rax, rax, rbx         ; This results in 0x7F being placed into RAX
+
+; Extraction with 0 bits should clear the destination
+mov rbx, -1
+mov rcx, 0
+bextr rbx, rbx, rcx
+
+; Same tests as above but with 32-bit registers
+
+; General extraction
+mov rdx, 0x7FFFFFFFFFFFFFFF
+mov rsi, 0x818              ; Start at bit 24 and extract 8 bits
+bextr edx, edx, esi         ; This results in 0xFF being placed into EDX
+
+; Extraction with 0 bits should clear RSI to 0
+mov rsi, -1
+mov rdi, 0
+bextr esi, esi, edi
+
+hlt


### PR DESCRIPTION
Follows up the PR handling BMI1 ANDN (#1325), this adds handling for BMI1's BEXTR instruction

After this, all that remains is to add handling for BLSI/BLSMSK/BLSR. These are similar enough that I will likely include all of them in the following PR after this one.