### PR TITLE
IR: Add handling for ANDN operations 

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/ALUOps.cpp
@@ -351,6 +351,26 @@ DEF_OP(And) {
   }
 }
 
+DEF_OP(Andn) {
+  auto Op = IROp->C<IR::IROp_Andn>();
+  const uint8_t OpSize = IROp->Size;
+
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  constexpr auto Func = [](auto a, auto b) {
+    using Type = decltype(a);
+    return static_cast<Type>(a & static_cast<Type>(~b));
+  };
+
+  switch (OpSize) {
+    DO_OP(1, uint8_t,  Func)
+    DO_OP(2, uint16_t, Func)
+    DO_OP(4, uint32_t, Func)
+    DO_OP(8, uint64_t, Func)
+    default: LOGMAN_MSG_A_FMT("Unknown size: {}", OpSize); break;
+  }
+}
+
 DEF_OP(Xor) {
   auto Op = IROp->C<IR::IROp_Xor>();
   uint8_t OpSize = IROp->Size;
@@ -975,6 +995,7 @@ void InterpreterOps::RegisterALUHandlers() {
   REGISTER_OP(UMULH,             UMulH);
   REGISTER_OP(OR,                Or);
   REGISTER_OP(AND,               And);
+  REGISTER_OP(ANDN,              Andn);
   REGISTER_OP(XOR,               Xor);
   REGISTER_OP(LSHL,              Lshl);
   REGISTER_OP(LSHR,              Lshr);

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
@@ -103,6 +103,7 @@ namespace FEXCore::CPU {
   DEF_OP(UMulH);
   DEF_OP(Or);
   DEF_OP(And);
+  DEF_OP(Andn);
   DEF_OP(Xor);
   DEF_OP(Lshl);
   DEF_OP(Lshr);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -390,6 +390,19 @@ DEF_OP(And) {
   }
 }
 
+DEF_OP(Andn) {
+  auto Op = IROp->C<IR::IROp_Andn>();
+  const auto& Lhs = Op->Header.Args[0];
+  const auto& Rhs = Op->Header.Args[1];
+  uint64_t Const{};
+
+  if (IsInlineConstant(Rhs, &Const)) {
+    bic(GRS(Node), GRS(Lhs.ID()), Const);
+  } else {
+    bic(GRS(Node), GRS(Lhs.ID()), GRS(Rhs.ID()));
+  }
+}
+
 DEF_OP(Xor) {
   auto Op = IROp->C<IR::IROp_Xor>();
   uint64_t Const;
@@ -1079,6 +1092,7 @@ void Arm64JITCore::RegisterALUHandlers() {
   REGISTER_OP(UMULH,             UMulH);
   REGISTER_OP(OR,                Or);
   REGISTER_OP(AND,               And);
+  REGISTER_OP(ANDN,              Andn);
   REGISTER_OP(XOR,               Xor);
   REGISTER_OP(LSHL,              Lshl);
   REGISTER_OP(LSHR,              Lshr);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -213,6 +213,7 @@ private:
   DEF_OP(UMulH);
   DEF_OP(Or);
   DEF_OP(And);
+  DEF_OP(Andn);
   DEF_OP(Xor);
   DEF_OP(Lshl);
   DEF_OP(Lshr);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -216,6 +216,7 @@ private:
   DEF_OP(UMulH);
   DEF_OP(Or);
   DEF_OP(And);
+  DEF_OP(Andn);
   DEF_OP(Xor);
   DEF_OP(Lshl);
   DEF_OP(Lshr);

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -2134,8 +2134,7 @@ void OpDispatchBuilder::ANDNBMIOp(OpcodeArgs) {
   auto* Src1 = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
   auto* Src2 = LoadSource(GPRClass, Op, Op->Src[1], Op->Flags, -1);
 
-  // TODO: This can be replaced with a BIC IR op once it's implemented.
-  auto Dest = _And(_Not(Src1), Src2);
+  auto Dest = _Andn(Src2, Src1);
 
   StoreResult(GPRClass, Op, Dest, -1);
   GenerateFlags_Logical(Op, Dest, Src1, Src2);
@@ -2569,8 +2568,7 @@ void OpDispatchBuilder::BTROp(OpcodeArgs) {
     Result = _Lshr(Dest, BitSelect);
 
     OrderedNode *BitMask = _Lshl(_Constant(1), BitSelect);
-    BitMask = _Not(BitMask);
-    Dest = _And(Dest, BitMask);
+    Dest = _Andn(Dest, BitMask);
     StoreResult(GPRClass, Op, Dest, -1);
   }
   else {
@@ -2591,10 +2589,10 @@ void OpDispatchBuilder::BTROp(OpcodeArgs) {
     // Now add the addresses together and load the memory
     OrderedNode *MemoryLocation = _Add(Dest, Src);
     OrderedNode *BitMask = _Lshl(_Constant(1), BitSelect);
-    BitMask = _Not(BitMask);
 
     if (DestIsLockedMem(Op)) {
       HandledLock = true;
+      BitMask = _Not(BitMask);
       // XXX: Technically this can optimize to an AArch64 ldclralb
       // We don't current support this IR op though
       Result = _AtomicFetchAnd(MemoryLocation, BitMask, 1);
@@ -2606,7 +2604,7 @@ void OpDispatchBuilder::BTROp(OpcodeArgs) {
 
       // Now shift in to the correct bit location
       Result = _Lshr(Value, BitSelect);
-      Value = _And(Value, BitMask);
+      Value = _Andn(Value, BitMask);
       _StoreMemAutoTSO(GPRClass, 1, MemoryLocation, Value, 1);
     }
   }

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
@@ -33,9 +33,7 @@ void OpDispatchBuilder::SetX87TopTag(OrderedNode *Value, uint32_t Tag) {
   OrderedNode *Mask = _Constant(0b11);
   auto TopOffset = _Lshl(Value, _Constant(1));
   Mask = _Lshl(Mask, TopOffset);
-  // XXX: This Neg can be removed if we support BIC
-  Mask = _Not(Mask);
-  OrderedNode *NewFTW = _And(FTW, Mask);
+  OrderedNode *NewFTW = _Andn(FTW, Mask);
   if (Tag != 0) {
     auto TagVal = _Lshl(_Constant(Tag), TopOffset);
     NewFTW = _Or(NewFTW, TagVal);

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -948,6 +948,15 @@
       "SSAArgs": "2"
     },
 
+    "Andn": {
+      "Desc": ["Integer binary AND NOT. Performs the equivalent of Src1 & ~Src2"],
+      "OpClass": "ALU",
+      "HasDest": true,
+      "DestClass": "GPR",
+      "DestSize": "std::max<uint8_t>(4, GetOpSize(ssa0))",
+      "SSAArgs": "2"
+    },
+
     "Xor": {
       "Desc": ["Integer binary exclusive or"
               ],


### PR DESCRIPTION
In a few parts of the OpcodeDecoder there's comments about making use of BIC. Given that, we can introduce the Andn IR operation that performs the same behavior as it.

I've named it `Andn`, since I feel it's more straightforward to read at a glance, but if it's preferable to name it `Bic`, I'm not opposed to changing it.

First time adding an IR op, so if anything looks wonky, just let me know and I'll fix it.