### PR TITLE
Core: Mark relevant Interpreter/JIT functions as [[nodiscard]]

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterClass.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterClass.h
@@ -20,17 +20,24 @@ using DestMapType = std::vector<uint32_t>;
 
 class InterpreterCore final : public CPUBackend {
 public:
-  explicit InterpreterCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread, bool CompileThread);
-  std::string GetName() override { return "Interpreter"; }
-  void *CompileCode(uint64_t Entry, FEXCore::IR::IRListView const *IR, FEXCore::Core::DebugData *DebugData, FEXCore::IR::RegisterAllocationData *RAData) override;
+  explicit InterpreterCore(FEXCore::Context::Context *ctx,
+                           FEXCore::Core::InternalThreadState *Thread,
+                           bool CompileThread);
 
-  void *MapRegion(void* HostPtr, uint64_t, uint64_t) override { return HostPtr; }
+  [[nodiscard]] std::string GetName() override { return "Interpreter"; }
 
-  bool NeedsOpDispatch() override { return true; }
+  [[nodiscard]] void *CompileCode(uint64_t Entry,
+                                  FEXCore::IR::IRListView const *IR,
+                                  FEXCore::Core::DebugData *DebugData,
+                                  FEXCore::IR::RegisterAllocationData *RAData) override;
+
+  [[nodiscard]] void *MapRegion(void* HostPtr, uint64_t, uint64_t) override { return HostPtr; }
+
+  [[nodiscard]] bool NeedsOpDispatch() override { return true; }
 
   void CreateAsmDispatch(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread);
 
-  bool HandleSIGBUS(int Signal, void *info, void *ucontext);
+  [[nodiscard]] bool HandleSIGBUS(int Signal, void *info, void *ucontext);
 
   static void InitializeInterpreterOpHandlers();
 
@@ -38,10 +45,7 @@ private:
   FEXCore::Context::Context *CTX;
   FEXCore::Core::InternalThreadState *State;
 
-  uint32_t AllocateTmpSpace(size_t Size);
-
   std::unique_ptr<Dispatcher> Dispatcher{};
-
 };
 
-}
+} // namespace FEXCore::CPU

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.h
@@ -14,6 +14,9 @@ namespace FEXCore::CPU {
 class CPUBackend;
 
 void InitializeInterpreterOpHandlers();
-std::unique_ptr<CPUBackend> CreateInterpreterCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread, bool CompileThread);
 
-}
+[[nodiscard]] std::unique_ptr<CPUBackend> CreateInterpreterCore(FEXCore::Context::Context *ctx,
+                                                                FEXCore::Core::InternalThreadState *Thread,
+                                                                bool CompileThread);
+
+} // namespace FEXCore::CPU

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
@@ -336,7 +336,7 @@ namespace FEXCore::CPU {
   DEF_OP(F80BCDSTORE);
 #undef DEF_OP
   template<typename unsigned_type, typename signed_type, typename float_type>
-  static bool IsConditionTrue(uint8_t Cond, uint64_t Src1, uint64_t Src2) {
+  [[nodiscard]] static bool IsConditionTrue(uint8_t Cond, uint64_t Src1, uint64_t Src2) {
     bool CompResult = false;
     switch (Cond) {
       case FEXCore::IR::COND_EQ:

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -42,22 +42,28 @@ public:
     size_t Size;
   };
 
-  explicit Arm64JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread, bool CompileThread);
-
+  explicit Arm64JITCore(FEXCore::Context::Context *ctx,
+                        FEXCore::Core::InternalThreadState *Thread,
+                        bool CompileThread);
   ~Arm64JITCore() override;
-  std::string GetName() override { return "JIT"; }
-  void *CompileCode(uint64_t Entry, FEXCore::IR::IRListView const *IR, FEXCore::Core::DebugData *DebugData, FEXCore::IR::RegisterAllocationData *RAData) override;
 
-  void *MapRegion(void* HostPtr, uint64_t, uint64_t) override { return HostPtr; }
+  [[nodiscard]] std::string GetName() override { return "JIT"; }
 
-  bool NeedsOpDispatch() override { return true; }
+  [[nodiscard]] void *CompileCode(uint64_t Entry,
+                                  FEXCore::IR::IRListView const *IR,
+                                  FEXCore::Core::DebugData *DebugData,
+                                  FEXCore::IR::RegisterAllocationData *RAData) override;
+
+  [[nodiscard]] void *MapRegion(void* HostPtr, uint64_t, uint64_t) override { return HostPtr; }
+
+  [[nodiscard]] bool NeedsOpDispatch() override { return true; }
 
   void ClearCache() override;
 
-  bool HandleSIGBUS(int Signal, void *info, void *ucontext);
+  [[nodiscard]] bool HandleSIGBUS(int Signal, void *info, void *ucontext);
 
   static constexpr size_t INITIAL_CODE_SIZE = 1024 * 1024 * 16;
-  CodeBuffer AllocateNewCodeBuffer(size_t Size);
+  [[nodiscard]] CodeBuffer AllocateNewCodeBuffer(size_t Size);
 
   void CopyNecessaryDataForCompileThread(CPUBackend *Original) override;
 
@@ -95,35 +101,39 @@ private:
   constexpr static uint8_t RA_FPR = 2;
 
   template<uint8_t RAType>
-  aarch64::Register GetReg(uint32_t Node) const;
+  [[nodiscard]] aarch64::Register GetReg(uint32_t Node) const;
 
   template<>
-  aarch64::Register GetReg<RA_32>(uint32_t Node) const;
+  [[nodiscard]] aarch64::Register GetReg<RA_32>(uint32_t Node) const;
   template<>
-  aarch64::Register GetReg<RA_64>(uint32_t Node) const;
+  [[nodiscard]] aarch64::Register GetReg<RA_64>(uint32_t Node) const;
 
   template<uint8_t RAType>
-  std::pair<aarch64::Register, aarch64::Register> GetSrcPair(uint32_t Node) const;
+  [[nodiscard]] std::pair<aarch64::Register, aarch64::Register> GetSrcPair(uint32_t Node) const;
 
   template<>
-  std::pair<aarch64::Register, aarch64::Register> GetSrcPair<RA_32>(uint32_t Node) const;
+  [[nodiscard]] std::pair<aarch64::Register, aarch64::Register> GetSrcPair<RA_32>(uint32_t Node) const;
   template<>
-  std::pair<aarch64::Register, aarch64::Register> GetSrcPair<RA_64>(uint32_t Node) const;
+  [[nodiscard]] std::pair<aarch64::Register, aarch64::Register> GetSrcPair<RA_64>(uint32_t Node) const;
 
-  aarch64::VRegister GetSrc(uint32_t Node) const;
-  aarch64::VRegister GetDst(uint32_t Node) const;
+  [[nodiscard]] aarch64::VRegister GetSrc(uint32_t Node) const;
+  [[nodiscard]] aarch64::VRegister GetDst(uint32_t Node) const;
 
-  FEXCore::IR::RegisterClassType GetRegClass(uint32_t Node) const;
+  [[nodiscard]] FEXCore::IR::RegisterClassType GetRegClass(uint32_t Node) const;
 
-  IR::PhysicalRegister GetPhys(uint32_t Node) const;
+  [[nodiscard]] IR::PhysicalRegister GetPhys(uint32_t Node) const;
 
-  bool IsFPR(uint32_t Node) const;
-  bool IsGPR(uint32_t Node) const;
+  [[nodiscard]] bool IsFPR(uint32_t Node) const;
+  [[nodiscard]] bool IsGPR(uint32_t Node) const;
 
-  MemOperand GenerateMemOperand(uint8_t AccessSize, aarch64::Register Base, IR::OrderedNodeWrapper Offset, IR::MemOffsetType OffsetType, uint8_t OffsetScale);
+  [[nodiscard]] MemOperand GenerateMemOperand(uint8_t AccessSize,
+                                              aarch64::Register Base,
+                                              IR::OrderedNodeWrapper Offset,
+                                              IR::MemOffsetType OffsetType,
+                                              uint8_t OffsetScale);
 
-  bool IsInlineConstant(const IR::OrderedNodeWrapper& Node, uint64_t* Value = nullptr) const;
-  bool IsInlineEntrypointOffset(const IR::OrderedNodeWrapper& WNode, uint64_t* Value) const;
+  [[nodiscard]] bool IsInlineConstant(const IR::OrderedNodeWrapper& Node, uint64_t* Value = nullptr) const;
+  [[nodiscard]] bool IsInlineEntrypointOffset(const IR::OrderedNodeWrapper& WNode, uint64_t* Value) const;
 
   struct LiveRange {
     uint32_t Begin;

--- a/External/FEXCore/Source/Interface/Core/JIT/JITCore.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/JITCore.h
@@ -13,6 +13,11 @@ struct InternalThreadState;
 namespace FEXCore::CPU {
 class CPUBackend;
 
-std::unique_ptr<CPUBackend> CreateX86JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread, bool CompileThread);
-std::unique_ptr<CPUBackend> CreateArm64JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread, bool CompileThread);
-}
+[[nodiscard]] std::unique_ptr<CPUBackend> CreateX86JITCore(FEXCore::Context::Context *ctx,
+                                                           FEXCore::Core::InternalThreadState *Thread,
+                                                           bool CompileThread);
+
+[[nodiscard]] std::unique_ptr<CPUBackend> CreateArm64JITCore(FEXCore::Context::Context *ctx,
+                                                             FEXCore::Core::InternalThreadState *Thread,
+                                                             bool CompileThread);
+} // namespace FEXCore::CPU

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -64,10 +64,6 @@ void FreeCodeBuffer(CodeBuffer Buffer) {
   FEXCore::Allocator::munmap(Buffer.Ptr, Buffer.Size);
 }
 
-}
-
-namespace FEXCore::CPU {
-
 void X86JITCore::CopyNecessaryDataForCompileThread(CPUBackend *Original) {
   X86JITCore *Core = reinterpret_cast<X86JITCore*>(Original);
   ThreadSharedData = Core->ThreadSharedData;

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -30,13 +30,8 @@ struct CodeBuffer {
   size_t Size;
 };
 
-CodeBuffer AllocateNewCodeBuffer(size_t Size);
+[[nodiscard]] CodeBuffer AllocateNewCodeBuffer(size_t Size);
 void FreeCodeBuffer(CodeBuffer Buffer);
-
-}
-
-namespace FEXCore::CPU {
-
 
 // Temp registers
 // rax, rcx, rdx, rsi, r8, r9,
@@ -62,14 +57,22 @@ const std::array<Xbyak::Xmm, 11> RAXMM_x = {  xmm1, xmm2, xmm3, xmm4, xmm5, xmm6
 
 class X86JITCore final : public CPUBackend, public Xbyak::CodeGenerator {
 public:
-  explicit X86JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread, CodeBuffer Buffer, bool CompileThread);
+  explicit X86JITCore(FEXCore::Context::Context *ctx,
+                      FEXCore::Core::InternalThreadState *Thread,
+                      CodeBuffer Buffer,
+                      bool CompileThread);
   ~X86JITCore() override;
-  std::string GetName() override { return "JIT"; }
-  void *CompileCode(uint64_t Entry, FEXCore::IR::IRListView const *IR, FEXCore::Core::DebugData *DebugData, FEXCore::IR::RegisterAllocationData *RAData) override;
 
-  void *MapRegion(void* HostPtr, uint64_t, uint64_t) override { return HostPtr; }
+  [[nodiscard]] std::string GetName() override { return "JIT"; }
 
-  bool NeedsOpDispatch() override { return true; }
+  [[nodiscard]] void *CompileCode(uint64_t Entry,
+                                  FEXCore::IR::IRListView const *IR,
+                                  FEXCore::Core::DebugData *DebugData,
+                                  FEXCore::IR::RegisterAllocationData *RAData) override;
+
+  [[nodiscard]] void *MapRegion(void* HostPtr, uint64_t, uint64_t) override { return HostPtr; }
+
+  [[nodiscard]] bool NeedsOpDispatch() override { return true; }
 
   void ClearCache() override;
 
@@ -111,26 +114,27 @@ private:
   constexpr static uint8_t RA_64 = 3;
   constexpr static uint8_t RA_XMM = 4;
 
-  IR::PhysicalRegister GetPhys(uint32_t Node) const;
+  [[nodiscard]] IR::PhysicalRegister GetPhys(uint32_t Node) const;
 
-  bool IsFPR(uint32_t Node) const;
-  bool IsGPR(uint32_t Node) const;
-
-  template<uint8_t RAType>
-  Xbyak::Reg GetSrc(uint32_t Node) const;
-  template<uint8_t RAType>
-  std::pair<Xbyak::Reg, Xbyak::Reg> GetSrcPair(uint32_t Node) const;
+  [[nodiscard]] bool IsFPR(uint32_t Node) const;
+  [[nodiscard]] bool IsGPR(uint32_t Node) const;
 
   template<uint8_t RAType>
-  Xbyak::Reg GetDst(uint32_t Node) const;
+  [[nodiscard]] Xbyak::Reg GetSrc(uint32_t Node) const;
+  template<uint8_t RAType>
+  [[nodiscard]] std::pair<Xbyak::Reg, Xbyak::Reg> GetSrcPair(uint32_t Node) const;
 
-  Xbyak::Xmm GetSrc(uint32_t Node) const;
-  Xbyak::Xmm GetDst(uint32_t Node) const;
+  template<uint8_t RAType>
+  [[nodiscard]] Xbyak::Reg GetDst(uint32_t Node) const;
 
-  Xbyak::RegExp GenerateModRM(Xbyak::Reg Base, IR::OrderedNodeWrapper Offset, IR::MemOffsetType OffsetType, uint8_t OffsetScale) const;
+  [[nodiscard]] Xbyak::Xmm GetSrc(uint32_t Node) const;
+  [[nodiscard]] Xbyak::Xmm GetDst(uint32_t Node) const;
 
-  bool IsInlineConstant(const IR::OrderedNodeWrapper& Node, uint64_t* Value = nullptr) const;
-  bool IsInlineEntrypointOffset(const IR::OrderedNodeWrapper& WNode, uint64_t* Value) const;
+  [[nodiscard]] Xbyak::RegExp GenerateModRM(Xbyak::Reg Base, IR::OrderedNodeWrapper Offset,
+                                            IR::MemOffsetType OffsetType, uint8_t OffsetScale) const;
+
+  [[nodiscard]] bool IsInlineConstant(const IR::OrderedNodeWrapper& Node, uint64_t* Value = nullptr) const;
+  [[nodiscard]] bool IsInlineEntrypointOffset(const IR::OrderedNodeWrapper& WNode, uint64_t* Value) const;
 
   IR::RegisterAllocationPass *RAPass;
   FEXCore::IR::RegisterAllocationData *RAData;

--- a/External/FEXCore/include/FEXCore/Core/CPUBackend.h
+++ b/External/FEXCore/include/FEXCore/Core/CPUBackend.h
@@ -36,7 +36,7 @@ class LLVMCore;
     /**
      * @return The name of this backend
      */
-    virtual std::string GetName() = 0;
+    [[nodiscard]] virtual std::string GetName() = 0;
     /**
      * @brief Tells this CPUBackend to compile code for the provided IR and DebugData
      *
@@ -54,14 +54,17 @@ class LLVMCore;
      * @return An executable function pointer that is theoretically compiled from this point.
      * Is actually a function pointer of type `void (FEXCore::Core::ThreadState *Thread)
      */
-    virtual void *CompileCode(uint64_t Entry, FEXCore::IR::IRListView const *IR, FEXCore::Core::DebugData *DebugData, FEXCore::IR::RegisterAllocationData *RAData) = 0;
+    [[nodiscard]] virtual void *CompileCode(uint64_t Entry,
+                                            FEXCore::IR::IRListView const *IR,
+                                            FEXCore::Core::DebugData *DebugData,
+                                            FEXCore::IR::RegisterAllocationData *RAData) = 0;
 
     /**
      * @brief Function for mapping memory in to the CPUBackend's visible space. Allows setting up virtual mappings if required
      *
      * @return Currently unused
      */
-    virtual void *MapRegion(void *HostPtr, uint64_t GuestPtr, uint64_t Size) = 0;
+    [[nodiscard]] virtual void *MapRegion(void *HostPtr, uint64_t GuestPtr, uint64_t Size) = 0;
 
     /**
      * @brief This is post-setup initialization that is called just before code executino
@@ -79,7 +82,7 @@ class LLVMCore;
      *
      * @return true if it needs the IR
      */
-    virtual bool NeedsOpDispatch() = 0;
+    [[nodiscard]] virtual bool NeedsOpDispatch() = 0;
 
     void ExecuteDispatch(FEXCore::Core::CpuStateFrame *Frame) {
       DispatchPtr(Frame);


### PR DESCRIPTION
Lets the compiler warn loudly when the result from any of these functions are left unused (indicating a bug).

This is primarily useful for the GetSrc/GetDst-related functions when making new IR op implementations, but the other cases are relatively useful for catching silent bugs introduced during refactors.