### PR TITLE
IR: Fixes memory ops having a duplicate size field

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/AtomicOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/AtomicOps.cpp
@@ -380,7 +380,7 @@ DEF_OP(CAS) {
 
 DEF_OP(AtomicAdd) {
   auto Op = IROp->C<IR::IROp_AtomicAdd>();
-  switch (Op->Size) {
+  switch (IROp->Size) {
     case 1: {
       std::atomic<uint8_t> *MemData = *GetSrc<std::atomic<uint8_t> **>(Data->SSAData, Op->Header.Args[0]);
       uint8_t Src = *GetSrc<uint8_t*>(Data->SSAData, Op->Header.Args[1]);
@@ -405,13 +405,13 @@ DEF_OP(AtomicAdd) {
       *MemData += Src;
       break;
     }
-    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", IROp->Size);
   }
 }
 
 DEF_OP(AtomicSub) {
   auto Op = IROp->C<IR::IROp_AtomicSub>();
-  switch (Op->Size) {
+  switch (IROp->Size) {
     case 1: {
       std::atomic<uint8_t> *MemData = *GetSrc<std::atomic<uint8_t> **>(Data->SSAData, Op->Header.Args[0]);
       uint8_t Src = *GetSrc<uint8_t*>(Data->SSAData, Op->Header.Args[1]);
@@ -436,13 +436,13 @@ DEF_OP(AtomicSub) {
       *MemData -= Src;
       break;
     }
-    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", IROp->Size);
   }
 }
 
 DEF_OP(AtomicAnd) {
   auto Op = IROp->C<IR::IROp_AtomicAnd>();
-  switch (Op->Size) {
+  switch (IROp->Size) {
     case 1: {
       std::atomic<uint8_t> *MemData = *GetSrc<std::atomic<uint8_t> **>(Data->SSAData, Op->Header.Args[0]);
       uint8_t Src = *GetSrc<uint8_t*>(Data->SSAData, Op->Header.Args[1]);
@@ -467,13 +467,13 @@ DEF_OP(AtomicAnd) {
       *MemData &= Src;
       break;
     }
-    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", IROp->Size);
   }
 }
 
 DEF_OP(AtomicOr) {
   auto Op = IROp->C<IR::IROp_AtomicOr>();
-  switch (Op->Size) {
+  switch (IROp->Size) {
     case 1: {
       std::atomic<uint8_t> *MemData = *GetSrc<std::atomic<uint8_t> **>(Data->SSAData, Op->Header.Args[0]);
       uint8_t Src = *GetSrc<uint8_t*>(Data->SSAData, Op->Header.Args[1]);
@@ -498,13 +498,13 @@ DEF_OP(AtomicOr) {
       *MemData |= Src;
       break;
     }
-    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", IROp->Size);
   }
 }
 
 DEF_OP(AtomicXor) {
   auto Op = IROp->C<IR::IROp_AtomicXor>();
-  switch (Op->Size) {
+  switch (IROp->Size) {
     case 1: {
       std::atomic<uint8_t> *MemData = *GetSrc<std::atomic<uint8_t> **>(Data->SSAData, Op->Header.Args[0]);
       uint8_t Src = *GetSrc<uint8_t*>(Data->SSAData, Op->Header.Args[1]);
@@ -529,13 +529,13 @@ DEF_OP(AtomicXor) {
       *MemData ^= Src;
       break;
     }
-    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", IROp->Size);
   }
 }
 
 DEF_OP(AtomicSwap) {
   auto Op = IROp->C<IR::IROp_AtomicSwap>();
-  switch (Op->Size) {
+  switch (IROp->Size) {
     case 1: {
       std::atomic<uint8_t> *MemData = *GetSrc<std::atomic<uint8_t> **>(Data->SSAData, Op->Header.Args[0]);
       uint8_t Src = *GetSrc<uint8_t*>(Data->SSAData, Op->Header.Args[1]);
@@ -564,13 +564,13 @@ DEF_OP(AtomicSwap) {
       GD = Previous;
       break;
     }
-    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", IROp->Size);
   }
 }
 
 DEF_OP(AtomicFetchAdd) {
   auto Op = IROp->C<IR::IROp_AtomicFetchAdd>();
-  switch (Op->Size) {
+  switch (IROp->Size) {
     case 1: {
       std::atomic<uint8_t> *MemData = *GetSrc<std::atomic<uint8_t> **>(Data->SSAData, Op->Header.Args[0]);
       uint8_t Src = *GetSrc<uint8_t*>(Data->SSAData, Op->Header.Args[1]);
@@ -599,13 +599,13 @@ DEF_OP(AtomicFetchAdd) {
       GD = Previous;
       break;
     }
-    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", IROp->Size);
   }
 }
 
 DEF_OP(AtomicFetchSub) {
   auto Op = IROp->C<IR::IROp_AtomicFetchSub>();
-  switch (Op->Size) {
+  switch (IROp->Size) {
     case 1: {
       std::atomic<uint8_t> *MemData = *GetSrc<std::atomic<uint8_t> **>(Data->SSAData, Op->Header.Args[0]);
       uint8_t Src = *GetSrc<uint8_t*>(Data->SSAData, Op->Header.Args[1]);
@@ -634,13 +634,13 @@ DEF_OP(AtomicFetchSub) {
       GD = Previous;
       break;
     }
-    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", IROp->Size);
   }
 }
 
 DEF_OP(AtomicFetchAnd) {
   auto Op = IROp->C<IR::IROp_AtomicFetchAnd>();
-  switch (Op->Size) {
+  switch (IROp->Size) {
     case 1: {
       std::atomic<uint8_t> *MemData = *GetSrc<std::atomic<uint8_t> **>(Data->SSAData, Op->Header.Args[0]);
       uint8_t Src = *GetSrc<uint8_t*>(Data->SSAData, Op->Header.Args[1]);
@@ -669,13 +669,13 @@ DEF_OP(AtomicFetchAnd) {
       GD = Previous;
       break;
     }
-    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", IROp->Size);
   }
 }
 
 DEF_OP(AtomicFetchOr) {
   auto Op = IROp->C<IR::IROp_AtomicFetchOr>();
-  switch (Op->Size) {
+  switch (IROp->Size) {
     case 1: {
       std::atomic<uint8_t> *MemData = *GetSrc<std::atomic<uint8_t> **>(Data->SSAData, Op->Header.Args[0]);
       uint8_t Src = *GetSrc<uint8_t*>(Data->SSAData, Op->Header.Args[1]);
@@ -704,13 +704,13 @@ DEF_OP(AtomicFetchOr) {
       GD = Previous;
       break;
     }
-    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", IROp->Size);
   }
 }
 
 DEF_OP(AtomicFetchXor) {
   auto Op = IROp->C<IR::IROp_AtomicFetchXor>();
-  switch (Op->Size) {
+  switch (IROp->Size) {
     case 1: {
       std::atomic<uint8_t> *MemData = *GetSrc<std::atomic<uint8_t> **>(Data->SSAData, Op->Header.Args[0]);
       uint8_t Src = *GetSrc<uint8_t*>(Data->SSAData, Op->Header.Args[1]);
@@ -739,13 +739,13 @@ DEF_OP(AtomicFetchXor) {
       GD = Previous;
       break;
     }
-    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", IROp->Size);
   }
 }
 
 DEF_OP(AtomicFetchNeg) {
   auto Op = IROp->C<IR::IROp_AtomicFetchNeg>();
-  switch (Op->Size) {
+  switch (IROp->Size) {
     case 1: {
       using Type = uint8_t;
       GD = AtomicFetchNeg(*GetSrc<Type**>(Data->SSAData, Op->Header.Args[0]));
@@ -766,7 +766,7 @@ DEF_OP(AtomicFetchNeg) {
       GD = AtomicFetchNeg(*GetSrc<Type**>(Data->SSAData, Op->Header.Args[0]));
       break;
     }
-    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", IROp->Size);
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/Interpreter/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/MemoryOps.cpp
@@ -85,17 +85,17 @@ DEF_OP(LoadContextIndexed) {
       GD = *MemData; \
       break; \
     }
-  switch (Op->Size) {
+  switch (IROp->Size) {
     LOAD_CTX(1, uint8_t)
     LOAD_CTX(2, uint16_t)
     LOAD_CTX(4, uint32_t)
     LOAD_CTX(8, uint64_t)
     case 16: {
       void const *MemData = reinterpret_cast<void const*>(ContextPtr);
-      memcpy(GDP, MemData, Op->Size);
+      memcpy(GDP, MemData, IROp->Size);
       break;
     }
-    default:  LOGMAN_MSG_A_FMT("Unhandled LoadContextIndexed size: {}", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled LoadContextIndexed size: {}", IROp->Size);
   }
   #undef LOAD_CTX
 }
@@ -110,7 +110,7 @@ DEF_OP(StoreContextIndexed) {
 
   void *MemData = reinterpret_cast<void*>(ContextPtr);
   void *Src = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  memcpy(MemData, Src, Op->Size);
+  memcpy(MemData, Src, IROp->Size);
 }
 
 DEF_OP(SpillRegister) {
@@ -181,7 +181,7 @@ DEF_OP(LoadMem) {
     }
 
     default:
-      memcpy(GDP, MemData, Op->Size);
+      memcpy(GDP, MemData, IROp->Size);
       break;
   }
 }
@@ -220,7 +220,7 @@ DEF_OP(StoreMem) {
     }
 
     default:
-      memcpy(MemData, GetSrc<void*>(Data->SSAData, Op->Value), Op->Size);
+      memcpy(MemData, GetSrc<void*>(Data->SSAData, Op->Value), IROp->Size);
       break;
   }
 }

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/AtomicOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/AtomicOps.cpp
@@ -219,17 +219,17 @@ DEF_OP(AtomicAdd) {
   auto MemSrc = GetReg<RA_64>(Op->Header.Args[0].ID());
 
   if (SupportsAtomics) {
-    switch (Op->Size) {
+    switch (IROp->Size) {
     case 1: staddlb(GetReg<RA_32>(Op->Header.Args[1].ID()), MemOperand(MemSrc)); break;
     case 2: staddlh(GetReg<RA_32>(Op->Header.Args[1].ID()), MemOperand(MemSrc)); break;
     case 4: staddl(GetReg<RA_32>(Op->Header.Args[1].ID()), MemOperand(MemSrc)); break;
     case 8: staddl(GetReg<RA_64>(Op->Header.Args[1].ID()), MemOperand(MemSrc)); break;
-    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", IROp->Size);
     }
   }
   else {
     // TMP2-TMP3
-    switch (Op->Size) {
+    switch (IROp->Size) {
       case 1: {
         aarch64::Label LoopTop;
         bind(&LoopTop);
@@ -266,7 +266,7 @@ DEF_OP(AtomicAdd) {
         cbnz(TMP2, &LoopTop);
         break;
       }
-      default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
+      default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", IROp->Size);
     }
   }
 }
@@ -278,17 +278,17 @@ DEF_OP(AtomicSub) {
 
   if (SupportsAtomics) {
     neg(TMP2, GetReg<RA_64>(Op->Header.Args[1].ID()));
-    switch (Op->Size) {
+    switch (IROp->Size) {
     case 1: staddlb(TMP2.W(), MemOperand(MemSrc)); break;
     case 2: staddlh(TMP2.W(), MemOperand(MemSrc)); break;
     case 4: staddl(TMP2.W(), MemOperand(MemSrc)); break;
     case 8: staddl(TMP2.X(), MemOperand(MemSrc)); break;
-    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", IROp->Size);
     }
   }
   else {
     // TMP2-TMP3
-    switch (Op->Size) {
+    switch (IROp->Size) {
       case 1: {
         aarch64::Label LoopTop;
         bind(&LoopTop);
@@ -325,7 +325,7 @@ DEF_OP(AtomicSub) {
         cbnz(TMP2, &LoopTop);
         break;
       }
-      default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
+      default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", IROp->Size);
     }
   }
 }
@@ -337,17 +337,17 @@ DEF_OP(AtomicAnd) {
 
   if (SupportsAtomics) {
     mvn(TMP2, GetReg<RA_64>(Op->Header.Args[1].ID()));
-    switch (Op->Size) {
+    switch (IROp->Size) {
     case 1: stclrlb(TMP2.W(), MemOperand(MemSrc)); break;
     case 2: stclrlh(TMP2.W(), MemOperand(MemSrc)); break;
     case 4: stclrl(TMP2.W(), MemOperand(MemSrc)); break;
     case 8: stclrl(TMP2.X(), MemOperand(MemSrc)); break;
-    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", IROp->Size);
     }
   }
   else {
     // TMP2-TMP3
-    switch (Op->Size) {
+    switch (IROp->Size) {
       case 1: {
         aarch64::Label LoopTop;
         bind(&LoopTop);
@@ -384,7 +384,7 @@ DEF_OP(AtomicAnd) {
         cbnz(TMP2, &LoopTop);
         break;
       }
-      default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
+      default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", IROp->Size);
     }
   }
 }
@@ -395,17 +395,17 @@ DEF_OP(AtomicOr) {
   auto MemSrc = GetReg<RA_64>(Op->Header.Args[0].ID());
 
   if (SupportsAtomics) {
-    switch (Op->Size) {
+    switch (IROp->Size) {
     case 1: stsetlb(GetReg<RA_32>(Op->Header.Args[1].ID()), MemOperand(MemSrc)); break;
     case 2: stsetlh(GetReg<RA_32>(Op->Header.Args[1].ID()), MemOperand(MemSrc)); break;
     case 4: stsetl(GetReg<RA_32>(Op->Header.Args[1].ID()), MemOperand(MemSrc)); break;
     case 8: stsetl(GetReg<RA_64>(Op->Header.Args[1].ID()), MemOperand(MemSrc)); break;
-    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", IROp->Size);
     }
   }
   else {
     // TMP2-TMP3
-    switch (Op->Size) {
+    switch (IROp->Size) {
       case 1: {
         aarch64::Label LoopTop;
         bind(&LoopTop);
@@ -442,7 +442,7 @@ DEF_OP(AtomicOr) {
         cbnz(TMP2, &LoopTop);
         break;
       }
-      default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
+      default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", IROp->Size);
     }
   }
 }
@@ -453,17 +453,17 @@ DEF_OP(AtomicXor) {
   auto MemSrc = GetReg<RA_64>(Op->Header.Args[0].ID());
 
   if (SupportsAtomics) {
-    switch (Op->Size) {
+    switch (IROp->Size) {
     case 1: steorlb(GetReg<RA_32>(Op->Header.Args[1].ID()), MemOperand(MemSrc)); break;
     case 2: steorlh(GetReg<RA_32>(Op->Header.Args[1].ID()), MemOperand(MemSrc)); break;
     case 4: steorl(GetReg<RA_32>(Op->Header.Args[1].ID()), MemOperand(MemSrc)); break;
     case 8: steorl(GetReg<RA_64>(Op->Header.Args[1].ID()), MemOperand(MemSrc)); break;
-    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", IROp->Size);
     }
   }
   else {
     // TMP2-TMP3
-    switch (Op->Size) {
+    switch (IROp->Size) {
       case 1: {
         aarch64::Label LoopTop;
         bind(&LoopTop);
@@ -500,7 +500,7 @@ DEF_OP(AtomicXor) {
         cbnz(TMP2, &LoopTop);
         break;
       }
-      default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
+      default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", IROp->Size);
     }
   }
 }
@@ -512,17 +512,17 @@ DEF_OP(AtomicSwap) {
 
   if (SupportsAtomics) {
     mov(TMP2, GetReg<RA_64>(Op->Header.Args[1].ID()));
-    switch (Op->Size) {
+    switch (IROp->Size) {
     case 1: swplb(TMP2.W(), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
     case 2: swplh(TMP2.W(), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
     case 4: swpl(TMP2.W(), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
     case 8: swpl(TMP2.X(), GetReg<RA_64>(Node), MemOperand(MemSrc)); break;
-    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", IROp->Size);
     }
   }
   else {
     // TMP2-TMP3
-    switch (Op->Size) {
+    switch (IROp->Size) {
       case 1: {
         aarch64::Label LoopTop;
         bind(&LoopTop);
@@ -559,7 +559,7 @@ DEF_OP(AtomicSwap) {
         mov(GetReg<RA_64>(Node), TMP2.X());
         break;
       }
-      default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
+      default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", IROp->Size);
     }
   }
 }
@@ -569,17 +569,17 @@ DEF_OP(AtomicFetchAdd) {
   auto MemSrc = GetReg<RA_64>(Op->Header.Args[0].ID());
 
   if (SupportsAtomics) {
-    switch (Op->Size) {
+    switch (IROp->Size) {
     case 1: ldaddalb(GetReg<RA_32>(Op->Header.Args[1].ID()), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
     case 2: ldaddalh(GetReg<RA_32>(Op->Header.Args[1].ID()), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
     case 4: ldaddal(GetReg<RA_32>(Op->Header.Args[1].ID()), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
     case 8: ldaddal(GetReg<RA_64>(Op->Header.Args[1].ID()), GetReg<RA_64>(Node), MemOperand(MemSrc)); break;
-    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", IROp->Size);
     }
   }
   else {
     // TMP2-TMP3
-    switch (Op->Size) {
+    switch (IROp->Size) {
       case 1: {
         aarch64::Label LoopTop;
         bind(&LoopTop);
@@ -620,7 +620,7 @@ DEF_OP(AtomicFetchAdd) {
         mov(GetReg<RA_64>(Node), TMP2);
         break;
       }
-      default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
+      default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", IROp->Size);
     }
   }
 }
@@ -631,17 +631,17 @@ DEF_OP(AtomicFetchSub) {
 
   if (SupportsAtomics) {
     neg(TMP2, GetReg<RA_64>(Op->Header.Args[1].ID()));
-    switch (Op->Size) {
+    switch (IROp->Size) {
     case 1: ldaddalb(TMP2.W(), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
     case 2: ldaddalh(TMP2.W(), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
     case 4: ldaddal(TMP2.W(), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
     case 8: ldaddal(TMP2.X(), GetReg<RA_64>(Node), MemOperand(MemSrc)); break;
-    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", IROp->Size);
     }
   }
   else {
     // TMP2-TMP3
-    switch (Op->Size) {
+    switch (IROp->Size) {
       case 1: {
         aarch64::Label LoopTop;
         bind(&LoopTop);
@@ -682,7 +682,7 @@ DEF_OP(AtomicFetchSub) {
         mov(GetReg<RA_64>(Node), TMP2);
         break;
       }
-      default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
+      default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", IROp->Size);
     }
   }
 }
@@ -693,17 +693,17 @@ DEF_OP(AtomicFetchAnd) {
 
   if (SupportsAtomics) {
     mvn(TMP2, GetReg<RA_64>(Op->Header.Args[1].ID()));
-    switch (Op->Size) {
+    switch (IROp->Size) {
     case 1: ldclralb(TMP2.W(), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
     case 2: ldclralh(TMP2.W(), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
     case 4: ldclral(TMP2.W(), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
     case 8: ldclral(TMP2.X(), GetReg<RA_64>(Node), MemOperand(MemSrc)); break;
-    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", IROp->Size);
     }
   }
   else {
     // TMP2-TMP3
-    switch (Op->Size) {
+    switch (IROp->Size) {
       case 1: {
         aarch64::Label LoopTop;
         bind(&LoopTop);
@@ -744,7 +744,7 @@ DEF_OP(AtomicFetchAnd) {
         mov(GetReg<RA_64>(Node), TMP2);
         break;
       }
-      default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
+      default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", IROp->Size);
     }
   }
 }
@@ -754,17 +754,17 @@ DEF_OP(AtomicFetchOr) {
   auto MemSrc = GetReg<RA_64>(Op->Header.Args[0].ID());
 
   if (SupportsAtomics) {
-    switch (Op->Size) {
+    switch (IROp->Size) {
     case 1: ldsetalb(GetReg<RA_32>(Op->Header.Args[1].ID()), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
     case 2: ldsetalh(GetReg<RA_32>(Op->Header.Args[1].ID()), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
     case 4: ldsetal(GetReg<RA_32>(Op->Header.Args[1].ID()), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
     case 8: ldsetal(GetReg<RA_64>(Op->Header.Args[1].ID()), GetReg<RA_64>(Node), MemOperand(MemSrc)); break;
-    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", IROp->Size);
     }
   }
   else {
     // TMP2-TMP3
-    switch (Op->Size) {
+    switch (IROp->Size) {
       case 1: {
         aarch64::Label LoopTop;
         bind(&LoopTop);
@@ -805,7 +805,7 @@ DEF_OP(AtomicFetchOr) {
         mov(GetReg<RA_64>(Node), TMP2);
         break;
       }
-      default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
+      default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", IROp->Size);
     }
   }
 }
@@ -815,17 +815,17 @@ DEF_OP(AtomicFetchXor) {
   auto MemSrc = GetReg<RA_64>(Op->Header.Args[0].ID());
 
   if (SupportsAtomics) {
-    switch (Op->Size) {
+    switch (IROp->Size) {
     case 1: ldeoralb(GetReg<RA_32>(Op->Header.Args[1].ID()), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
     case 2: ldeoralh(GetReg<RA_32>(Op->Header.Args[1].ID()), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
     case 4: ldeoral(GetReg<RA_32>(Op->Header.Args[1].ID()), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
     case 8: ldeoral(GetReg<RA_64>(Op->Header.Args[1].ID()), GetReg<RA_64>(Node), MemOperand(MemSrc)); break;
-    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", IROp->Size);
     }
   }
   else {
     // TMP2-TMP3
-    switch (Op->Size) {
+    switch (IROp->Size) {
       case 1: {
         aarch64::Label LoopTop;
         bind(&LoopTop);
@@ -866,7 +866,7 @@ DEF_OP(AtomicFetchXor) {
         mov(GetReg<RA_64>(Node), TMP2);
         break;
       }
-      default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
+      default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", IROp->Size);
     }
   }
 }
@@ -876,7 +876,7 @@ DEF_OP(AtomicFetchNeg) {
   auto MemSrc = GetReg<RA_64>(Op->Header.Args[0].ID());
 
   // TMP2-TMP3
-  switch (Op->Size) {
+  switch (IROp->Size) {
     case 1: {
       aarch64::Label LoopTop;
       bind(&LoopTop);
@@ -917,7 +917,7 @@ DEF_OP(AtomicFetchNeg) {
       mov(GetReg<RA_64>(Node), TMP2);
       break;
     }
-    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", IROp->Size);
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -261,7 +261,7 @@ DEF_OP(StoreRegister) {
 
 DEF_OP(LoadContextIndexed) {
   auto Op = IROp->C<IR::IROp_LoadContextIndexed>();
-  size_t size = Op->Size;
+  size_t size = IROp->Size;
   auto index = GetReg<RA_64>(Op->Header.Args[0].ID());
 
   if (Op->Class == FEXCore::IR::GPRClass) {
@@ -288,7 +288,7 @@ DEF_OP(LoadContextIndexed) {
         ldr(GetReg<RA_64>(Node), MemOperand(TMP1, Op->BaseOffset));
         break;
       default:
-        LOGMAN_MSG_A_FMT("Unhandled LoadContextIndexed size: {}", Op->Size);
+        LOGMAN_MSG_A_FMT("Unhandled LoadContextIndexed size: {}", IROp->Size);
         break;
       }
       break;
@@ -335,7 +335,7 @@ DEF_OP(LoadContextIndexed) {
         }
         break;
       default:
-        LOGMAN_MSG_A_FMT("Unhandled LoadContextIndexed size: {}", Op->Size);
+        LOGMAN_MSG_A_FMT("Unhandled LoadContextIndexed size: {}", IROp->Size);
         break;
       }
       break;
@@ -349,7 +349,7 @@ DEF_OP(LoadContextIndexed) {
 
 DEF_OP(StoreContextIndexed) {
   auto Op = IROp->C<IR::IROp_StoreContextIndexed>();
-  size_t size = Op->Size;
+  size_t size = IROp->Size;
   auto index = GetReg<RA_64>(Op->Header.Args[1].ID());
 
   if (Op->Class == FEXCore::IR::GPRClass) {
@@ -378,7 +378,7 @@ DEF_OP(StoreContextIndexed) {
         str(value, MemOperand(TMP1, Op->BaseOffset));
         break;
       default:
-        LOGMAN_MSG_A_FMT("Unhandled StoreContextIndexed size: {}", Op->Size);
+        LOGMAN_MSG_A_FMT("Unhandled StoreContextIndexed size: {}", IROp->Size);
         break;
       }
       break;
@@ -427,7 +427,7 @@ DEF_OP(StoreContextIndexed) {
         }
         break;
       default:
-        LOGMAN_MSG_A_FMT("Unhandled StoreContextIndexed size: {}", Op->Size);
+        LOGMAN_MSG_A_FMT("Unhandled StoreContextIndexed size: {}", IROp->Size);
         break;
       }
       break;
@@ -571,11 +571,11 @@ DEF_OP(LoadMem) {
   auto Op = IROp->C<IR::IROp_LoadMem>();
 
   auto MemReg = GetReg<RA_64>(Op->Header.Args[0].ID());
-  auto MemSrc = GenerateMemOperand(Op->Size, MemReg, Op->Offset, Op->OffsetType, Op->OffsetScale);
+  auto MemSrc = GenerateMemOperand(IROp->Size, MemReg, Op->Offset, Op->OffsetType, Op->OffsetScale);
 
   if (Op->Class == FEXCore::IR::GPRClass) {
     auto Dst = GetReg<RA_64>(Node);
-    switch (Op->Size) {
+    switch (IROp->Size) {
       case 1:
         ldrb(Dst, MemSrc);
         break;
@@ -588,12 +588,12 @@ DEF_OP(LoadMem) {
       case 8:
         ldr(Dst, MemSrc);
         break;
-      default:  LOGMAN_MSG_A_FMT("Unhandled LoadMem size: {}", Op->Size);
+      default:  LOGMAN_MSG_A_FMT("Unhandled LoadMem size: {}", IROp->Size);
     }
   }
   else {
     auto Dst = GetDst(Node);
-    switch (Op->Size) {
+    switch (IROp->Size) {
       case 1:
         ldr(Dst.B(), MemSrc);
         break;
@@ -609,7 +609,7 @@ DEF_OP(LoadMem) {
       case 16:
         ldr(Dst, MemSrc);
         break;
-      default:  LOGMAN_MSG_A_FMT("Unhandled LoadMem size: {}", Op->Size);
+      default:  LOGMAN_MSG_A_FMT("Unhandled LoadMem size: {}", IROp->Size);
     }
   }
 }
@@ -624,7 +624,7 @@ DEF_OP(LoadMemTSO) {
   }
 
   if (SupportsRCPC && Op->Class == FEXCore::IR::GPRClass) {
-    if (Op->Size == 1) {
+    if (IROp->Size == 1) {
       // 8bit load is always aligned to natural alignment
       auto Dst = GetReg<RA_64>(Node);
       ldaprb(Dst, MemSrc);
@@ -633,7 +633,7 @@ DEF_OP(LoadMemTSO) {
       // Aligned
       auto Dst = GetReg<RA_64>(Node);
       nop();
-      switch (Op->Size) {
+      switch (IROp->Size) {
         case 2:
           ldaprh(Dst, MemSrc);
           break;
@@ -643,13 +643,13 @@ DEF_OP(LoadMemTSO) {
         case 8:
           ldapr(Dst, MemSrc);
           break;
-        default:  LOGMAN_MSG_A_FMT("Unhandled LoadMemTSO size: {}", Op->Size);
+        default:  LOGMAN_MSG_A_FMT("Unhandled LoadMemTSO size: {}", IROp->Size);
       }
       nop();
     }
   }
   else if (Op->Class == FEXCore::IR::GPRClass) {
-    if (Op->Size == 1) {
+    if (IROp->Size == 1) {
       // 8bit load is always aligned to natural alignment
       auto Dst = GetReg<RA_64>(Node);
       ldarb(Dst, MemSrc);
@@ -658,7 +658,7 @@ DEF_OP(LoadMemTSO) {
       // Aligned
       auto Dst = GetReg<RA_64>(Node);
       nop();
-      switch (Op->Size) {
+      switch (IROp->Size) {
         case 2:
           ldarh(Dst, MemSrc);
           break;
@@ -668,7 +668,7 @@ DEF_OP(LoadMemTSO) {
         case 8:
           ldar(Dst, MemSrc);
           break;
-        default:  LOGMAN_MSG_A_FMT("Unhandled LoadMemTSO size: {}", Op->Size);
+        default:  LOGMAN_MSG_A_FMT("Unhandled LoadMemTSO size: {}", IROp->Size);
       }
       nop();
     }
@@ -676,7 +676,7 @@ DEF_OP(LoadMemTSO) {
   else {
     dmb(InnerShareable, BarrierAll);
     auto Dst = GetDst(Node);
-    switch (Op->Size) {
+    switch (IROp->Size) {
       case 2:
         ldr(Dst.H(), MemSrc);
         break;
@@ -689,7 +689,7 @@ DEF_OP(LoadMemTSO) {
       case 16:
         ldr(Dst, MemSrc);
         break;
-      default:  LOGMAN_MSG_A_FMT("Unhandled LoadMemTSO size: {}", Op->Size);
+      default:  LOGMAN_MSG_A_FMT("Unhandled LoadMemTSO size: {}", IROp->Size);
     }
     dmb(InnerShareable, BarrierAll);
   }
@@ -700,10 +700,10 @@ DEF_OP(StoreMem) {
 
   auto MemReg = GetReg<RA_64>(Op->Header.Args[0].ID());
 
-  auto MemSrc = GenerateMemOperand(Op->Size, MemReg, Op->Offset, Op->OffsetType, Op->OffsetScale);
+  auto MemSrc = GenerateMemOperand(IROp->Size, MemReg, Op->Offset, Op->OffsetType, Op->OffsetScale);
 
   if (Op->Class == FEXCore::IR::GPRClass) {
-    switch (Op->Size) {
+    switch (IROp->Size) {
       case 1:
         strb(GetReg<RA_64>(Op->Header.Args[1].ID()), MemSrc);
         break;
@@ -716,12 +716,12 @@ DEF_OP(StoreMem) {
       case 8:
         str(GetReg<RA_64>(Op->Header.Args[1].ID()), MemSrc);
         break;
-      default:  LOGMAN_MSG_A_FMT("Unhandled StoreMem size: {}", Op->Size);
+      default:  LOGMAN_MSG_A_FMT("Unhandled StoreMem size: {}", IROp->Size);
     }
   }
   else {
     auto Src = GetSrc(Op->Header.Args[1].ID());
-    switch (Op->Size) {
+    switch (IROp->Size) {
       case 1:
         str(Src.B(), MemSrc);
         break;
@@ -737,7 +737,7 @@ DEF_OP(StoreMem) {
       case 16:
         str(Src, MemSrc);
         break;
-      default:  LOGMAN_MSG_A_FMT("Unhandled StoreMem size: {}", Op->Size);
+      default:  LOGMAN_MSG_A_FMT("Unhandled StoreMem size: {}", IROp->Size);
     }
   }
 }
@@ -751,13 +751,13 @@ DEF_OP(StoreMemTSO) {
   }
 
   if (Op->Class == FEXCore::IR::GPRClass) {
-    if (Op->Size == 1) {
+    if (IROp->Size == 1) {
       // 8bit load is always aligned to natural alignment
       stlrb(GetReg<RA_64>(Op->Header.Args[1].ID()), MemSrc);
     }
     else {
       nop();
-      switch (Op->Size) {
+      switch (IROp->Size) {
         case 2:
           stlrh(GetReg<RA_64>(Op->Header.Args[1].ID()), MemSrc);
           break;
@@ -767,7 +767,7 @@ DEF_OP(StoreMemTSO) {
         case 8:
           stlr(GetReg<RA_64>(Op->Header.Args[1].ID()), MemSrc);
           break;
-        default:  LOGMAN_MSG_A_FMT("Unhandled StoreMemTSO size: {}", Op->Size);
+        default:  LOGMAN_MSG_A_FMT("Unhandled StoreMemTSO size: {}", IROp->Size);
       }
       nop();
     }
@@ -775,7 +775,7 @@ DEF_OP(StoreMemTSO) {
   else {
     dmb(InnerShareable, BarrierAll);
     auto Src = GetSrc(Op->Header.Args[1].ID());
-    switch (Op->Size) {
+    switch (IROp->Size) {
       case 1:
         str(Src.B(), MemSrc);
         break;
@@ -791,7 +791,7 @@ DEF_OP(StoreMemTSO) {
       case 16:
         str(Src, MemSrc);
         break;
-      default:  LOGMAN_MSG_A_FMT("Unhandled StoreMemTSO size: {}", Op->Size);
+      default:  LOGMAN_MSG_A_FMT("Unhandled StoreMemTSO size: {}", IROp->Size);
     }
     dmb(InnerShareable, BarrierAll);
   }
@@ -807,14 +807,14 @@ DEF_OP(ParanoidLoadMemTSO) {
   }
 
   if (Op->Class == FEXCore::IR::GPRClass) {
-    if (Op->Size == 1) {
+    if (IROp->Size == 1) {
       // 8bit load is always aligned to natural alignment
       auto Dst = GetReg<RA_64>(Node);
       ldarb(Dst, MemSrc);
     }
     else {
       auto Dst = GetReg<RA_64>(Node);
-      switch (Op->Size) {
+      switch (IROp->Size) {
         case 2:
           ldarh(Dst, MemSrc);
           break;
@@ -824,13 +824,13 @@ DEF_OP(ParanoidLoadMemTSO) {
         case 8:
           ldar(Dst, MemSrc);
           break;
-        default:  LOGMAN_MSG_A_FMT("Unhandled ParanoidLoadMemTSO size: {}", Op->Size);
+        default:  LOGMAN_MSG_A_FMT("Unhandled ParanoidLoadMemTSO size: {}", IROp->Size);
       }
     }
   }
   else {
     auto Dst = GetDst(Node);
-    switch (Op->Size) {
+    switch (IROp->Size) {
       case 2:
         ldarh(TMP1.W(), MemSrc);
         fmov(Dst.H(), TMP1.W());
@@ -850,7 +850,7 @@ DEF_OP(ParanoidLoadMemTSO) {
         mov(Dst.V2D(), 0, TMP1);
         mov(Dst.V2D(), 1, TMP2);
         break;
-      default:  LOGMAN_MSG_A_FMT("Unhandled ParanoidLoadMemTSO size: {}", Op->Size);
+      default:  LOGMAN_MSG_A_FMT("Unhandled ParanoidLoadMemTSO size: {}", IROp->Size);
     }
   }
 }
@@ -864,12 +864,12 @@ DEF_OP(ParanoidStoreMemTSO) {
   }
 
   if (Op->Class == FEXCore::IR::GPRClass) {
-    if (Op->Size == 1) {
+    if (IROp->Size == 1) {
       // 8bit load is always aligned to natural alignment
       stlrb(GetReg<RA_64>(Op->Header.Args[1].ID()), MemSrc);
     }
     else {
-      switch (Op->Size) {
+      switch (IROp->Size) {
         case 2:
           stlrh(GetReg<RA_64>(Op->Header.Args[1].ID()), MemSrc);
           break;
@@ -879,19 +879,19 @@ DEF_OP(ParanoidStoreMemTSO) {
         case 8:
           stlr(GetReg<RA_64>(Op->Header.Args[1].ID()), MemSrc);
           break;
-        default:  LOGMAN_MSG_A_FMT("Unhandled ParanoidStoreMemTSO size: {}", Op->Size);
+        default:  LOGMAN_MSG_A_FMT("Unhandled ParanoidStoreMemTSO size: {}", IROp->Size);
       }
     }
   }
   else {
     auto Src = GetSrc(Op->Header.Args[1].ID());
-    if (Op->Size == 1) {
+    if (IROp->Size == 1) {
       // 8bit load is always aligned to natural alignment
       mov(TMP1.W(), Src.V16B(), 0);
       stlrb(TMP1, MemSrc);
     }
     else {
-      switch (Op->Size) {
+      switch (IROp->Size) {
         case 2:
           mov(TMP1.W(), Src.V8H(), 0);
           stlrh(TMP1, MemSrc);
@@ -919,7 +919,7 @@ DEF_OP(ParanoidStoreMemTSO) {
           cbnz(TMP3, &B); // < Overwritten with DMB
           break;
         }
-        default:  LOGMAN_MSG_A_FMT("Unhandled ParanoidStoreMemTSO size: {}", Op->Size);
+        default:  LOGMAN_MSG_A_FMT("Unhandled ParanoidStoreMemTSO size: {}", IROp->Size);
       }
     }
   }

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/AtomicOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/AtomicOps.cpp
@@ -121,7 +121,7 @@ DEF_OP(AtomicAdd) {
   Xbyak::Reg MemReg = GetSrc<RA_64>(Op->Header.Args[0].ID());
 
   lock();
-  switch (Op->Size) {
+  switch (IROp->Size) {
     case 1:
       add(byte [MemReg], GetSrc<RA_8>(Op->Header.Args[1].ID()));
       break;
@@ -134,7 +134,7 @@ DEF_OP(AtomicAdd) {
     case 8:
       add(qword [MemReg], GetSrc<RA_64>(Op->Header.Args[1].ID()));
       break;
-    default:  LOGMAN_MSG_A_FMT("Unhandled AtomicAdd size: {}", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled AtomicAdd size: {}", IROp->Size);
   }
 }
 
@@ -143,7 +143,7 @@ DEF_OP(AtomicSub) {
 
   Xbyak::Reg MemReg = GetSrc<RA_64>(Op->Header.Args[0].ID());
   lock();
-  switch (Op->Size) {
+  switch (IROp->Size) {
     case 1:
       sub(byte [MemReg], GetSrc<RA_8>(Op->Header.Args[1].ID()));
       break;
@@ -156,7 +156,7 @@ DEF_OP(AtomicSub) {
     case 8:
       sub(qword [MemReg], GetSrc<RA_64>(Op->Header.Args[1].ID()));
       break;
-    default:  LOGMAN_MSG_A_FMT("Unhandled AtomicAdd size: {}", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled AtomicAdd size: {}", IROp->Size);
   }
 }
 
@@ -165,7 +165,7 @@ DEF_OP(AtomicAnd) {
 
   Xbyak::Reg MemReg = GetSrc<RA_64>(Op->Header.Args[0].ID());
   lock();
-  switch (Op->Size) {
+  switch (IROp->Size) {
     case 1:
       and_(byte [MemReg], GetSrc<RA_8>(Op->Header.Args[1].ID()));
       break;
@@ -178,7 +178,7 @@ DEF_OP(AtomicAnd) {
     case 8:
       and_(qword [MemReg], GetSrc<RA_64>(Op->Header.Args[1].ID()));
       break;
-    default:  LOGMAN_MSG_A_FMT("Unhandled AtomicAdd size: {}", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled AtomicAdd size: {}", IROp->Size);
   }
 }
 
@@ -187,7 +187,7 @@ DEF_OP(AtomicOr) {
 
   Xbyak::Reg MemReg = GetSrc<RA_64>(Op->Header.Args[0].ID());
   lock();
-  switch (Op->Size) {
+  switch (IROp->Size) {
     case 1:
       or_(byte [MemReg], GetSrc<RA_8>(Op->Header.Args[1].ID()));
       break;
@@ -200,7 +200,7 @@ DEF_OP(AtomicOr) {
     case 8:
       or_(qword [MemReg], GetSrc<RA_64>(Op->Header.Args[1].ID()));
       break;
-    default:  LOGMAN_MSG_A_FMT("Unhandled AtomicAdd size: {}", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled AtomicAdd size: {}", IROp->Size);
   }
 }
 
@@ -209,7 +209,7 @@ DEF_OP(AtomicXor) {
 
   Xbyak::Reg MemReg = GetSrc<RA_64>(Op->Header.Args[0].ID());
   lock();
-  switch (Op->Size) {
+  switch (IROp->Size) {
     case 1:
       xor_(byte [MemReg], GetSrc<RA_8>(Op->Header.Args[1].ID()));
       break;
@@ -222,7 +222,7 @@ DEF_OP(AtomicXor) {
     case 8:
       xor_(qword [MemReg], GetSrc<RA_64>(Op->Header.Args[1].ID()));
       break;
-    default:  LOGMAN_MSG_A_FMT("Unhandled AtomicAdd size: {}", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled AtomicAdd size: {}", IROp->Size);
   }
 }
 
@@ -232,7 +232,7 @@ DEF_OP(AtomicSwap) {
   Xbyak::Reg MemReg = rax;
   mov(MemReg, GetSrc<RA_64>(Op->Header.Args[0].ID()));
 
-  switch (Op->Size) {
+  switch (IROp->Size) {
     case 1:
       movzx(GetDst<RA_64>(Node), GetSrc<RA_8>(Op->Header.Args[1].ID()));
       lock();
@@ -253,7 +253,7 @@ DEF_OP(AtomicSwap) {
       lock();
       xchg(qword [MemReg], GetDst<RA_64>(Node));
       break;
-    default:  LOGMAN_MSG_A_FMT("Unhandled AtomicSwap size: {}", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled AtomicSwap size: {}", IROp->Size);
   }
 }
 
@@ -261,7 +261,7 @@ DEF_OP(AtomicFetchAdd) {
   auto Op = IROp->C<IR::IROp_AtomicFetchAdd>();
 
   Xbyak::Reg MemReg = GetSrc<RA_64>(Op->Header.Args[0].ID());
-  switch (Op->Size) {
+  switch (IROp->Size) {
     case 1:
       movzx(rcx, GetSrc<RA_8>(Op->Header.Args[1].ID()));
       lock();
@@ -286,7 +286,7 @@ DEF_OP(AtomicFetchAdd) {
       xadd(qword [MemReg], rcx);
       mov(GetDst<RA_64>(Node), rcx);
       break;
-    default:  LOGMAN_MSG_A_FMT("Unhandled AtomicFetchAdd size: {}", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled AtomicFetchAdd size: {}", IROp->Size);
   }
 }
 
@@ -294,7 +294,7 @@ DEF_OP(AtomicFetchSub) {
   auto Op = IROp->C<IR::IROp_AtomicFetchSub>();
 
   Xbyak::Reg MemReg = GetSrc<RA_64>(Op->Header.Args[0].ID());
-  switch (Op->Size) {
+  switch (IROp->Size) {
     case 1:
       mov(cl, GetSrc<RA_8>(Op->Header.Args[1].ID()));
       neg(cl);
@@ -323,7 +323,7 @@ DEF_OP(AtomicFetchSub) {
       xadd(qword [MemReg], rcx);
       mov(GetDst<RA_64>(Node), rcx);
       break;
-    default:  LOGMAN_MSG_A_FMT("Unhandled AtomicFetchSub size: {}", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled AtomicFetchSub size: {}", IROp->Size);
   }
 }
 
@@ -333,7 +333,7 @@ DEF_OP(AtomicFetchAnd) {
   // TMP1 = rax
   Xbyak::Reg MemReg = GetSrc<RA_64>(Op->Header.Args[0].ID());
 
-  switch (Op->Size) {
+  switch (IROp->Size) {
     case 1: {
       mov(TMP1.cvt8(), byte [MemReg]);
 
@@ -401,7 +401,7 @@ DEF_OP(AtomicFetchAnd) {
       mov(GetDst<RA_64>(Node), TMP3.cvt64());
       break;
     }
-    default:  LOGMAN_MSG_A_FMT("Unhandled AtomicFetchAnd size: {}", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled AtomicFetchAnd size: {}", IROp->Size);
   }
 }
 
@@ -410,7 +410,7 @@ DEF_OP(AtomicFetchOr) {
 
   // TMP1 = rax
   Xbyak::Reg MemReg = GetSrc<RA_64>(Op->Header.Args[0].ID());
-  switch (Op->Size) {
+  switch (IROp->Size) {
     case 1: {
       mov(TMP1.cvt8(), byte [MemReg]);
 
@@ -478,7 +478,7 @@ DEF_OP(AtomicFetchOr) {
       mov(GetDst<RA_64>(Node), TMP3.cvt64());
       break;
     }
-    default:  LOGMAN_MSG_A_FMT("Unhandled AtomicFetchOr size: {}", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled AtomicFetchOr size: {}", IROp->Size);
   }
 }
 
@@ -487,7 +487,7 @@ DEF_OP(AtomicFetchXor) {
 
   // TMP1 = rax
   Xbyak::Reg MemReg = GetSrc<RA_64>(Op->Header.Args[0].ID());
-  switch (Op->Size) {
+  switch (IROp->Size) {
     case 1: {
       mov(TMP1.cvt8(), byte [MemReg]);
 
@@ -555,7 +555,7 @@ DEF_OP(AtomicFetchXor) {
       mov(GetDst<RA_64>(Node), TMP3.cvt64());
       break;
     }
-    default:  LOGMAN_MSG_A_FMT("Unhandled AtomicFetchXor size: {}", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled AtomicFetchXor size: {}", IROp->Size);
   }
 }
 
@@ -563,7 +563,7 @@ DEF_OP(AtomicFetchNeg) {
   auto Op = IROp->C<IR::IROp_AtomicFetchNeg>();
 
   Xbyak::Reg MemReg = GetSrc<RA_64>(Op->Header.Args[0].ID());
-  switch (Op->Size) {
+  switch (IROp->Size) {
     case 1: {
       mov(TMP1.cvt8(), byte [MemReg]);
 
@@ -631,7 +631,7 @@ DEF_OP(AtomicFetchNeg) {
       mov(GetDst<RA_64>(Node), TMP3.cvt64());
       break;
     }
-    default:  LOGMAN_MSG_A_FMT("Unhandled AtomicFetchNeg size: {}", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled AtomicFetchNeg size: {}", IROp->Size);
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/MemoryOps.cpp
@@ -142,7 +142,7 @@ DEF_OP(StoreContext) {
 
 DEF_OP(LoadContextIndexed) {
   auto Op = IROp->C<IR::IROp_LoadContextIndexed>();
-  size_t size = Op->Size;
+  size_t size = IROp->Size;
   Reg index = GetSrc<RA_64>(Op->Header.Args[0].ID());
 
   if (Op->Class.Val == 0) {
@@ -166,7 +166,7 @@ DEF_OP(LoadContextIndexed) {
         mov(GetDst<RA_64>(Node),  qword [rax + index * Op->Stride]);
         break;
       default:
-        LOGMAN_MSG_A_FMT("Unhandled LoadContextIndexed size: {}", Op->Size);
+        LOGMAN_MSG_A_FMT("Unhandled LoadContextIndexed size: {}", IROp->Size);
         break;
       }
       break;
@@ -202,7 +202,7 @@ DEF_OP(LoadContextIndexed) {
         vmovq(GetDst(Node),  qword [rax + index * Op->Stride]);
         break;
       default:
-        LOGMAN_MSG_A_FMT("Unhandled LoadContextIndexed size: {}", Op->Size);
+        LOGMAN_MSG_A_FMT("Unhandled LoadContextIndexed size: {}", IROp->Size);
         break;
       }
       break;
@@ -231,7 +231,7 @@ DEF_OP(LoadContextIndexed) {
           movups(GetDst(Node), xword [STATE + rax]);
         break;
       default:
-        LOGMAN_MSG_A_FMT("Unhandled LoadContextIndexed size: {}", Op->Size);
+        LOGMAN_MSG_A_FMT("Unhandled LoadContextIndexed size: {}", IROp->Size);
         break;
       }
       break;
@@ -246,7 +246,7 @@ DEF_OP(LoadContextIndexed) {
 DEF_OP(StoreContextIndexed) {
   auto Op = IROp->C<IR::IROp_StoreContextIndexed>();
   Reg index = GetSrc<RA_64>(Op->Header.Args[1].ID());
-  size_t size = Op->Size;
+  size_t size = IROp->Size;
 
   if (Op->Class.Val == 0) {
     auto value = GetSrc<RA_64>(Op->Header.Args[0].ID());
@@ -258,9 +258,9 @@ DEF_OP(StoreContextIndexed) {
     case 4:
     case 8: {
       if (!(size == 1 || size == 2 || size == 4 || size == 8)) {
-        LOGMAN_MSG_A_FMT("Unhandled StoreContextIndexed size: {}", Op->Size);
+        LOGMAN_MSG_A_FMT("Unhandled StoreContextIndexed size: {}", IROp->Size);
       }
-      mov(AddressFrame(Op->Size * 8) [rax + index * Op->Stride], value);
+      mov(AddressFrame(IROp->Size * 8) [rax + index * Op->Stride], value);
       break;
     }
     default:
@@ -278,16 +278,16 @@ DEF_OP(StoreContextIndexed) {
       lea(rax, dword [STATE + Op->BaseOffset]);
       switch (size) {
       case 1:
-        pextrb(AddressFrame(Op->Size * 8) [rax + index * Op->Stride], value, 0);
+        pextrb(AddressFrame(IROp->Size * 8) [rax + index * Op->Stride], value, 0);
         break;
       case 2:
-        pextrw(AddressFrame(Op->Size * 8) [rax + index * Op->Stride], value, 0);
+        pextrw(AddressFrame(IROp->Size * 8) [rax + index * Op->Stride], value, 0);
         break;
       case 4:
-        vmovd(AddressFrame(Op->Size * 8) [rax + index * Op->Stride], value);
+        vmovd(AddressFrame(IROp->Size * 8) [rax + index * Op->Stride], value);
         break;
       case 8:
-        vmovq(AddressFrame(Op->Size * 8) [rax + index * Op->Stride], value);
+        vmovq(AddressFrame(IROp->Size * 8) [rax + index * Op->Stride], value);
         break;
       default:
         LOGMAN_MSG_A_FMT("Unhandled StoreContextIndexed size: {}", size);
@@ -301,16 +301,16 @@ DEF_OP(StoreContextIndexed) {
       lea(rax, dword [rax + Op->BaseOffset]);
       switch (size) {
       case 1:
-        pextrb(AddressFrame(Op->Size * 8) [STATE + rax], value, 0);
+        pextrb(AddressFrame(IROp->Size * 8) [STATE + rax], value, 0);
         break;
       case 2:
-        pextrw(AddressFrame(Op->Size * 8) [STATE + rax], value, 0);
+        pextrw(AddressFrame(IROp->Size * 8) [STATE + rax], value, 0);
         break;
       case 4:
-        vmovd(AddressFrame(Op->Size * 8) [STATE + rax], value);
+        vmovd(AddressFrame(IROp->Size * 8) [STATE + rax], value);
         break;
       case 8:
-        vmovq(AddressFrame(Op->Size * 8) [STATE + rax], value);
+        vmovq(AddressFrame(IROp->Size * 8) [STATE + rax], value);
         break;
       case 16:
         if (Op->BaseOffset % 16 == 0)
@@ -472,7 +472,7 @@ DEF_OP(LoadMem) {
   if (Op->Class.Val == 0) {
     auto Dst = GetDst<RA_64>(Node);
 
-    switch (Op->Size) {
+    switch (IROp->Size) {
       case 1: {
         movzx (Dst, byte [MemPtr]);
       }
@@ -489,14 +489,14 @@ DEF_OP(LoadMem) {
         mov(Dst, qword [MemPtr]);
       }
       break;
-      default:  LOGMAN_MSG_A_FMT("Unhandled LoadMem size: {}", Op->Size);
+      default:  LOGMAN_MSG_A_FMT("Unhandled LoadMem size: {}", IROp->Size);
     }
   }
   else
   {
     auto Dst = GetDst(Node);
 
-    switch (Op->Size) {
+    switch (IROp->Size) {
       case 1: {
         movzx(eax, byte [MemPtr]);
         vmovd(Dst, eax);
@@ -516,7 +516,7 @@ DEF_OP(LoadMem) {
       }
       break;
       case 16: {
-         if (Op->Size == Op->Align)
+         if (IROp->Size == Op->Align)
            movups(GetDst(Node), xword [MemPtr]);
          else
            movups(GetDst(Node), xword [MemPtr]);
@@ -525,7 +525,7 @@ DEF_OP(LoadMem) {
          }
        }
        break;
-      default:  LOGMAN_MSG_A_FMT("Unhandled LoadMem size: {}", Op->Size);
+      default:  LOGMAN_MSG_A_FMT("Unhandled LoadMem size: {}", IROp->Size);
     }
   }
 }
@@ -538,7 +538,7 @@ DEF_OP(StoreMem) {
   auto MemPtr = GenerateModRM(MemReg, Op->Offset, Op->OffsetType, Op->OffsetScale);
 
   if (Op->Class.Val == 0) {
-    switch (Op->Size) {
+    switch (IROp->Size) {
     case 1:
       mov(byte [MemPtr], GetSrc<RA_8>(Op->Header.Args[1].ID()));
     break;
@@ -551,11 +551,11 @@ DEF_OP(StoreMem) {
     case 8:
       mov(qword [MemPtr], GetSrc<RA_64>(Op->Header.Args[1].ID()));
     break;
-    default:  LOGMAN_MSG_A_FMT("Unhandled StoreMem size: {}", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled StoreMem size: {}", IROp->Size);
     }
   }
   else {
-    switch (Op->Size) {
+    switch (IROp->Size) {
     case 1:
       pextrb(byte [MemPtr], GetSrc(Op->Header.Args[1].ID()), 0);
     break;
@@ -569,12 +569,12 @@ DEF_OP(StoreMem) {
       vmovq(qword [MemPtr], GetSrc(Op->Header.Args[1].ID()));
     break;
     case 16:
-      if (Op->Size == Op->Align)
+      if (IROp->Size == Op->Align)
         movups(xword [MemPtr], GetSrc(Op->Header.Args[1].ID()));
       else
         movups(xword [MemPtr], GetSrc(Op->Header.Args[1].ID()));
     break;
-    default:  LOGMAN_MSG_A_FMT("Unhandled StoreMem size: {}", Op->Size);
+    default:  LOGMAN_MSG_A_FMT("Unhandled StoreMem size: {}", IROp->Size);
     }
   }
 }

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -570,16 +570,16 @@ private:
 
   OrderedNode* _StoreMemAutoTSO(FEXCore::IR::RegisterClassType Class, uint8_t Size, OrderedNode *ssa0, OrderedNode *ssa1, uint8_t Align = 1) {
     if (CTX->Config.TSOEnabled)
-    	return _StoreMemTSO(ssa0, ssa1, Invalid(), Size, Align, Class, MEM_OFFSET_SXTX, 1);
+    	return _StoreMemTSO(ssa0, ssa1, Invalid(), Align, Class, MEM_OFFSET_SXTX, 1, Size);
     else
-      return _StoreMem(ssa0, ssa1, Invalid(), Size, Align, Class, MEM_OFFSET_SXTX, 1);
+      return _StoreMem(ssa0, ssa1, Invalid(), Align, Class, MEM_OFFSET_SXTX, 1, Size);
   }
 
   OrderedNode* _LoadMemAutoTSO(FEXCore::IR::RegisterClassType Class, uint8_t Size, OrderedNode *ssa0, uint8_t Align = 1) {
     if (CTX->Config.TSOEnabled)
-      return _LoadMemTSO(ssa0, Invalid(), Size, Align, Class, MEM_OFFSET_SXTX, 1);
+      return _LoadMemTSO(ssa0, Invalid(), Align, Class, MEM_OFFSET_SXTX, 1, Size);
     else
-      return _LoadMem(ssa0, Invalid(), Size, Align, Class, MEM_OFFSET_SXTX, 1);
+      return _LoadMem(ssa0, Invalid(), Align, Class, MEM_OFFSET_SXTX, 1, Size);
   }
 
 

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -558,8 +558,10 @@
       "HasDest": true,
       "DestClass": "Complex",
       "DestSize": "Size",
+      "HelperArgs": [
+        "uint8_t", "Size"
+      ],
       "Args": [
-        "uint8_t", "Size",
         "uint32_t", "BaseOffset",
         "uint32_t", "Stride",
         "RegisterClassType", "Class"
@@ -573,12 +575,15 @@
               ],
       "OpClass": "Memory",
       "SSAArgs": "2",
+      "DestSize": "Size",
       "SSANames": [
         "Value",
         "Index"
       ],
+      "HelperArgs": [
+        "uint8_t", "Size"
+      ],
       "Args": [
-        "uint8_t", "Size",
         "uint32_t", "BaseOffset",
         "uint32_t", "Stride",
         "RegisterClassType", "Class"
@@ -644,6 +649,7 @@
               ],
       "OpClass": "Memory",
       "SSAArgs": "1",
+      "DestSize": "1",
       "SSANames": [
         "Value"
       ],
@@ -692,8 +698,10 @@
         "Addr",
         "Offset"
       ],
+      "HelperArgs": [
+        "uint8_t", "Size"
+      ],
       "Args": [
-        "uint8_t", "Size",
         "uint8_t", "Align",
         "RegisterClassType", "Class",
         "MemOffsetType", "OffsetType",
@@ -709,13 +717,16 @@
       "HasSideEffects": true,
       "OpClass": "Memory",
       "SSAArgs": "3",
+      "DestSize": "Size",
       "SSANames": [
         "Addr",
         "Value",
         "Offset"
       ],
+      "HelperArgs": [
+        "uint8_t", "Size"
+      ],
       "Args": [
-        "uint8_t", "Size",
         "uint8_t", "Align",
         "RegisterClassType", "Class",
         "MemOffsetType", "OffsetType",
@@ -735,8 +746,10 @@
         "Addr",
         "Offset"
       ],
+      "HelperArgs": [
+        "uint8_t", "Size"
+      ],
       "Args": [
-        "uint8_t", "Size",
         "uint8_t", "Align",
         "RegisterClassType", "Class",
         "MemOffsetType", "OffsetType",
@@ -750,13 +763,16 @@
       "HasSideEffects": true,
       "OpClass": "Memory",
       "SSAArgs": "3",
+      "DestSize": "Size",
       "SSANames": [
         "Addr",
         "Value",
         "Offset"
       ],
+      "HelperArgs": [
+        "uint8_t", "Size"
+      ],
       "Args": [
-        "uint8_t", "Size",
         "uint8_t", "Align",
         "RegisterClassType", "Class",
         "MemOffsetType", "OffsetType",
@@ -1289,11 +1305,12 @@
               ],
       "OpClass": "Atomic",
       "SSAArgs": "2",
+      "DestSize": "Size",
       "SSANames": [
         "Addr",
         "Value"
       ],
-      "Args": [
+      "HelperArgs": [
         "uint8_t", "Size"
       ]
     },
@@ -1304,11 +1321,12 @@
               ],
       "OpClass": "Atomic",
       "SSAArgs": "2",
+      "DestSize": "Size",
       "SSANames": [
         "Addr",
         "Value"
       ],
-      "Args": [
+      "HelperArgs": [
         "uint8_t", "Size"
       ]
     },
@@ -1319,11 +1337,12 @@
               ],
       "OpClass": "Atomic",
       "SSAArgs": "2",
+      "DestSize": "Size",
       "SSANames": [
         "Addr",
         "Value"
       ],
-      "Args": [
+      "HelperArgs": [
         "uint8_t", "Size"
       ]
     },
@@ -1334,11 +1353,12 @@
               ],
       "OpClass": "Atomic",
       "SSAArgs": "2",
+      "DestSize": "Size",
       "SSANames": [
         "Addr",
         "Value"
       ],
-      "Args": [
+      "HelperArgs": [
         "uint8_t", "Size"
       ]
     },
@@ -1349,11 +1369,12 @@
               ],
       "OpClass": "Atomic",
       "SSAArgs": "2",
+      "DestSize": "Size",
       "SSANames": [
         "Addr",
         "Value"
       ],
-      "Args": [
+      "HelperArgs": [
         "uint8_t", "Size"
       ]
     },
@@ -1372,7 +1393,7 @@
         "Addr",
         "Value"
       ],
-      "Args": [
+      "HelperArgs": [
         "uint8_t", "Size"
       ]
     },
@@ -1392,7 +1413,7 @@
         "Addr",
         "Value"
       ],
-      "Args": [
+      "HelperArgs": [
         "uint8_t", "Size"
       ]
     },
@@ -1413,7 +1434,7 @@
         "Addr",
         "Value"
       ],
-      "Args": [
+      "HelperArgs": [
         "uint8_t", "Size"
       ]
     },
@@ -1433,7 +1454,7 @@
         "Addr",
         "Value"
       ],
-      "Args": [
+      "HelperArgs": [
         "uint8_t", "Size"
       ]
     },
@@ -1453,7 +1474,7 @@
         "Addr",
         "Value"
       ],
-      "Args": [
+      "HelperArgs": [
         "uint8_t", "Size"
       ]
     },
@@ -1473,7 +1494,7 @@
         "Addr",
         "Value"
       ],
-      "Args": [
+      "HelperArgs": [
         "uint8_t", "Size"
       ]
     },
@@ -1491,7 +1512,7 @@
       "SSANames": [
         "Addr"
       ],
-      "Args": [
+      "HelperArgs": [
         "uint8_t", "Size"
       ]
     },

--- a/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -531,7 +531,7 @@ bool ConstProp::ConstantPropagation(IREmitter *IREmit, const IRListView& Current
       auto AddressHeader = IREmit->GetOpHeader(Op->Header.Args[0]);
 
       if (AddressHeader->Op == OP_ADD && AddressHeader->Size == 8) {
-        auto [OffsetType, OffsetScale, Arg0, Arg1] = MemExtendedAddressing(IREmit, Op->Size, AddressHeader);
+        auto [OffsetType, OffsetScale, Arg0, Arg1] = MemExtendedAddressing(IREmit, IROp->Size, AddressHeader);
 
         Op->OffsetType = OffsetType;
         Op->OffsetScale = OffsetScale;
@@ -548,7 +548,7 @@ bool ConstProp::ConstantPropagation(IREmitter *IREmit, const IRListView& Current
       auto AddressHeader = IREmit->GetOpHeader(Op->Header.Args[0]);
 
       if (AddressHeader->Op == OP_ADD && AddressHeader->Size == 8) {
-        auto [OffsetType, OffsetScale, Arg0, Arg1] = MemExtendedAddressing(IREmit, Op->Size, AddressHeader);
+        auto [OffsetType, OffsetScale, Arg0, Arg1] = MemExtendedAddressing(IREmit, IROp->Size, AddressHeader);
 
         Op->OffsetType = OffsetType;
         Op->OffsetScale = OffsetScale;
@@ -941,7 +941,7 @@ bool ConstProp::ConstantInlining(IREmitter *IREmit, const IRListView& CurrentIR)
 
         uint64_t Constant2{};
         if (Op->OffsetType == MEM_OFFSET_SXTX && IREmit->IsValueConstant(Op->Header.Args[1], &Constant2)) {
-          if (IsImmMemory(Constant2, Op->Size)) {
+          if (IsImmMemory(Constant2, IROp->Size)) {
             IREmit->SetWriteCursor(CurrentIR.GetNode(Op->Header.Args[1]));
 
             IREmit->ReplaceNodeArgument(CodeNode, 1, IREmit->_InlineConstant(Constant2));
@@ -958,7 +958,7 @@ bool ConstProp::ConstantInlining(IREmitter *IREmit, const IRListView& CurrentIR)
 
         uint64_t Constant2{};
         if (Op->OffsetType == MEM_OFFSET_SXTX && IREmit->IsValueConstant(Op->Header.Args[2], &Constant2)) {
-          if (IsImmMemory(Constant2, Op->Size)) {
+          if (IsImmMemory(Constant2, IROp->Size)) {
             IREmit->SetWriteCursor(CurrentIR.GetNode(Op->Header.Args[2]));
 
             IREmit->ReplaceNodeArgument(CodeNode, 2, IREmit->_InlineConstant(Constant2));

--- a/External/FEXCore/include/FEXCore/IR/IREmitter.h
+++ b/External/FEXCore/include/FEXCore/IR/IREmitter.h
@@ -80,22 +80,28 @@ friend class FEXCore::IR::PassManager;
     return _Bfi(ssa0, ssa1, Width, lsb, DestSize);
   }
   IRPair<IROp_StoreMem> _StoreMem(FEXCore::IR::RegisterClassType Class, uint8_t Size, OrderedNode *ssa0, OrderedNode *ssa1, uint8_t Align = 1) {
-    return _StoreMem(ssa0, ssa1, Invalid(), Size, Align, Class, MEM_OFFSET_SXTX, 1);
+    return _StoreMem(ssa0, ssa1, Invalid(), Align, Class, MEM_OFFSET_SXTX, 1, Size);
   }
   IRPair<IROp_StoreMemTSO> _StoreMemTSO(FEXCore::IR::RegisterClassType Class, uint8_t Size, OrderedNode *ssa0, OrderedNode *ssa1, uint8_t Align = 1) {
-    return _StoreMemTSO(ssa0, ssa1, Invalid(), Size, Align, Class, MEM_OFFSET_SXTX, 1);
+    return _StoreMemTSO(ssa0, ssa1, Invalid(), Align, Class, MEM_OFFSET_SXTX, 1, Size);
   }
   IRPair<IROp_VStoreMemElement> _VStoreMemElement(uint8_t RegisterSize, uint8_t ElementSize, OrderedNode *ssa0, OrderedNode *ssa1, uint8_t Index, uint8_t Align = 1) {
     return _VStoreMemElement(ssa0, ssa1, Index, Align, RegisterSize, ElementSize);
   }
   IRPair<IROp_LoadMem> _LoadMem(FEXCore::IR::RegisterClassType Class, uint8_t Size, OrderedNode *ssa0, uint8_t Align = 1) {
-    return _LoadMem(ssa0, Invalid(), Size, Align, Class, MEM_OFFSET_SXTX, 1);
+    return _LoadMem(ssa0, Invalid(), Align, Class, MEM_OFFSET_SXTX, 1, Size);
   }
   IRPair<IROp_LoadMemTSO> _LoadMemTSO(FEXCore::IR::RegisterClassType Class, uint8_t Size, OrderedNode *ssa0, uint8_t Align = 1) {
-    return _LoadMemTSO(ssa0, Invalid(), Size, Align, Class, MEM_OFFSET_SXTX, 1);
+    return _LoadMemTSO(ssa0, Invalid(), Align, Class, MEM_OFFSET_SXTX, 1, Size);
   }
   IRPair<IROp_VLoadMemElement> _VLoadMemElement(uint8_t RegisterSize, uint8_t ElementSize, OrderedNode *ssa0, OrderedNode *ssa1, uint8_t Index, uint8_t Align = 1) {
     return _VLoadMemElement(ssa0, ssa1, Index, Align, RegisterSize, ElementSize);
+  }
+  IRPair<IROp_LoadContextIndexed> _LoadContextIndexed(OrderedNode *ssa0, uint8_t Size, uint32_t BaseOffset, uint32_t Stride, RegisterClassType Class) {
+    return _LoadContextIndexed(ssa0, BaseOffset, Stride, Class, Size);
+  }
+  IRPair<IROp_StoreContextIndexed> _StoreContextIndexed(OrderedNode *ssa0, OrderedNode *ssa1, uint8_t Size, uint32_t BaseOffset, uint32_t Stride, RegisterClassType Class) {
+    return _StoreContextIndexed(ssa0, ssa1, BaseOffset, Stride, Class, Size);
   }
   IRPair<IROp_Select> _Select(uint8_t Cond, OrderedNode *ssa0, OrderedNode *ssa1, OrderedNode *ssa2, OrderedNode *ssa3, uint8_t CompareSize = 0) {
     if (CompareSize == 0)

--- a/unittests/IR/Basic/MemoryData.ir
+++ b/unittests/IR/Basic/MemoryData.ir
@@ -16,7 +16,7 @@
   (%ssa2) CodeBlock %start, %end, %ssa1
     (%start i0) BeginBlock %ssa2
     %Addr i64 = Constant #0x100000
-    %Val i32 = LoadMem %Addr i64, %Invalid, #0x8, #0x8, GPR, SXTX, #0x1
+    %Val i32 = LoadMem %Addr i64, %Invalid, #0x8, GPR, SXTX, #0x1, #0x8
     (%Store i64) StoreContext %Val i64, #0x08, GPR
     (%brk i0) Break #4, #4
     (%end i0) EndBlock %ssa2

--- a/unittests/IR/Basic/Sbfe.ir
+++ b/unittests/IR/Basic/Sbfe.ir
@@ -21,7 +21,7 @@
   (%ssa2) CodeBlock %start, %end, %ssa1
     (%start i0) BeginBlock %ssa2
     %Addr1 i64 = Constant #0x1000000
-    %Val i64 = LoadMem %Addr1 i64, %Invalid, #0x8, #0x8, GPR, SXTX, #0x1
+    %Val i64 = LoadMem %Addr1 i64, %Invalid, #0x8, GPR, SXTX, #0x1, #0x8
 ; Test aligned special cases
     %Res1 i64 = Sbfe %Val, #0x8, #0x0
     (%Store1 i64) StoreContext %Res1 i64, #0x08, GPR
@@ -31,7 +31,7 @@
     (%Store3 i64) StoreContext %Res3 i64, #0x18, GPR
     %Addr2 i64 = Constant #0x1000008
 ; Test non special width
-    %Val2 i64 = LoadMem %Addr2 i64, %Invalid, #0x8, #0x8, GPR, SXTX, #0x1
+    %Val2 i64 = LoadMem %Addr2 i64, %Invalid, #0x8, GPR, SXTX, #0x1, #0x8
     %Res4 i64 = Sbfe %Val2, #0x6, #0x0
     (%Store4 i64) StoreContext %Res4 i64, #0x20, GPR
 ; Test with + shift

--- a/unittests/IR/Correctness/AddTruncate.ir
+++ b/unittests/IR/Correctness/AddTruncate.ir
@@ -20,9 +20,9 @@
   (%ssa2) CodeBlock %ssa6, %ssa12, %ssa1
     (%ssa6 i0) BeginBlock %ssa2
     %AddrA i64 = Constant #0x1000000
-    %MemValueA i64 = LoadMem %AddrA i64, %Invalid, #0x8, #0x8, GPR, SXTX, #0x1
+    %MemValueA i64 = LoadMem %AddrA i64, %Invalid, #0x8, GPR, SXTX, #0x1, #0x8
     %AddrB i64 = Constant #0x1000010
-    %MemValueB i64 = LoadMem %AddrB i64, %Invalid, #0x8, #0x8, GPR, SXTX, #0x1
+    %MemValueB i64 = LoadMem %AddrB i64, %Invalid, #0x8, GPR, SXTX, #0x1, #0x8
     %ResultA i32 = Add %MemValueA, %MemValueB
     %ResultB i64 = Add %MemValueA, %MemValueB
     (%Store i64) StoreContext %ResultA i64, #0x08, GPR

--- a/unittests/IR/Correctness/FPRStoreTruncate.ir
+++ b/unittests/IR/Correctness/FPRStoreTruncate.ir
@@ -23,14 +23,14 @@
     (%begin i0) BeginBlock %ssa2
 ; Clear registers
     %AddrB i64 = Constant #0x1000010
-    %ClearVal i128 = LoadMem %AddrB i64, %Invalid, #0x10, #0x10, FPR, SXTX, #0x1
+    %ClearVal i128 = LoadMem %AddrB i64, %Invalid, #0x10, FPR, SXTX, #0x1, #0x10
     (%Clear1 i128) StoreContext %ClearVal i128, #0x90, FPR
     (%Clear2 i128) StoreContext %ClearVal i128, #0xa0, FPR
     (%Clear3 i128) StoreContext %ClearVal i128, #0xb0, FPR
     (%Clear4 i128) StoreContext %ClearVal i128, #0xc0, FPR
 
     %AddrA i64 = Constant #0x1000000
-    %MemValueA i128 = LoadMem %AddrA i64, %Invalid, #0x10, #0x10, FPR, SXTX, #0x1
+    %MemValueA i128 = LoadMem %AddrA i64, %Invalid, #0x10, FPR, SXTX, #0x1, #0x10
 
     (%Store1 i64) StoreContext %MemValueA i128, #0x90, FPR
     (%Store2 i32) StoreContext %MemValueA i128, #0xa0, FPR

--- a/unittests/IR/Correctness/LeftShiftTruncate.ir
+++ b/unittests/IR/Correctness/LeftShiftTruncate.ir
@@ -20,7 +20,7 @@
   (%ssa2) CodeBlock %ssa6, %ssa12, %ssa1
     (%ssa6 i0) BeginBlock %ssa2
     %AddrA i64 = Constant #0x1000000
-    %MemValueA i32 = LoadMem %AddrA i64, %Invalid, #0x4, #0x4, GPR, SXTX, #0x1
+    %MemValueA i32 = LoadMem %AddrA i64, %Invalid, #0x4, GPR, SXTX, #0x1, #0x4
     %Shift i64 = Constant #0x1
     %ResultA i32 = Lshl %MemValueA, %Shift
     %ResultB i64 = Lshl %MemValueA, %Shift

--- a/unittests/IR/Correctness/SubTruncate.ir
+++ b/unittests/IR/Correctness/SubTruncate.ir
@@ -20,9 +20,9 @@
   (%ssa2) CodeBlock %ssa6, %ssa12, %ssa1
     (%ssaStart i0) BeginBlock %ssa2
     %AddrA i64 = Constant #0x1000000
-    %MemValueA i64 = LoadMem %AddrA i64, %Invalid, #0x8, #0x8, GPR, SXTX, #0x1
+    %MemValueA i64 = LoadMem %AddrA i64, %Invalid, #0x8, GPR, SXTX, #0x1, #0x8
     %AddrB i64 = Constant #0x1000010
-    %MemValueB i64 = LoadMem %AddrB i64, %Invalid, #0x8, #0x8, GPR, SXTX, #0x1
+    %MemValueB i64 = LoadMem %AddrB i64, %Invalid, #0x8, GPR, SXTX, #0x1, #0x8
     %ResultA i32 = Sub %MemValueA, %MemValueB
     %ResultB i64 = Sub %MemValueA, %MemValueB
     (%Store i64) StoreContext %ResultA i64, #0x08, GPR


### PR DESCRIPTION
There's zero need for these to have an independent size field and it was
just confusing.
For stores it was always set to zero and for loads it was just
duplicated.

In addition this allows introspection of the store op without casting
the op, which can be useful in edge cases