### PR TITLE
Allocator: Reserve upper 128TB of VA on 64-bit process

### DIFF
--- a/External/FEXCore/Source/Utils/Allocator.cpp
+++ b/External/FEXCore/Source/Utils/Allocator.cpp
@@ -1,5 +1,7 @@
 #include "Utils/Allocator/HostAllocator.h"
 #include <FEXCore/Utils/Allocator.h>
+#include <FEXCore/Utils/CompilerDefs.h>
+#include <FEXCore/Utils/LogManager.h>
 #include <sys/mman.h>
 #ifdef ENABLE_JEMALLOC
 #include <jemalloc/jemalloc.h>
@@ -85,4 +87,149 @@ namespace FEXCore::Allocator {
   }
 #pragma GCC diagnostic pop
 
+  FEX_DEFAULT_VISIBILITY size_t DetermineVASize() {
+    static constexpr std::array<uintptr_t, 7> TLBSizes = {
+      57,
+      52,
+      48,
+      47,
+      42,
+      39,
+      36,
+    };
+
+    for (auto Bits : TLBSizes) {
+      uintptr_t Size = 1ULL << Bits;
+      // Just try allocating
+      // We can't actually determine VA size on ARM safely
+      auto Find = [](uintptr_t Size) -> bool {
+        for (int i = 0; i < 64; ++i) {
+          // Try grabbing a some of the top pages of the range
+          // x86 allocates some high pages in the top end
+          void *Ptr = ::mmap(reinterpret_cast<void*>(Size - PAGE_SIZE * i), PAGE_SIZE, PROT_NONE, MAP_FIXED_NOREPLACE | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+          if (Ptr != (void*)~0ULL) {
+            ::munmap(Ptr, PAGE_SIZE);
+            if (Ptr == (void*)(Size - PAGE_SIZE * i)) {
+              return true;
+            }
+          }
+        }
+        return false;
+      };
+
+      if (Find(Size)) {
+        return Bits;
+      }
+    }
+
+    LOGMAN_MSG_A_FMT("Couldn't determine host VA size");
+    FEX_UNREACHABLE;
+  }
+
+  PtrCache* StealMemoryRegion(uintptr_t Begin, uintptr_t End) {
+    PtrCache *Cache{};
+    uint64_t CacheSize{};
+    uint64_t CurrentCacheOffset = 0;
+    constexpr std::array<size_t, 10> ReservedVMARegionSizes = {{
+      // Anything larger than 64GB fails out
+      64ULL * 1024 * 1024 * 1024,   // 64GB
+      32ULL * 1024 * 1024 * 1024,   // 32GB
+      16ULL * 1024 * 1024 * 1024,   // 16GB
+      4ULL * 1024 * 1024 * 1024,    // 4GB
+      1ULL * 1024 * 1024 * 1024, // 1GB
+      512ULL * 1024 * 1024,      // 512MB
+      128ULL * 1024 * 1024,      // 128MB
+      32ULL * 1024 * 1024,       // 32MB
+      1ULL * 1024 * 1024,        // 1MB
+      4096ULL                    // One page
+    }};
+    constexpr size_t AllocationSizeMaxIndex = ReservedVMARegionSizes.size() - 1;
+    uint64_t CurrentSizeIndex = 0;
+
+    int PROT_FLAGS = PROT_READ | PROT_WRITE;
+    for (size_t MemoryOffset = Begin; MemoryOffset < End;) {
+      size_t AllocationSize = ReservedVMARegionSizes[CurrentSizeIndex];
+      size_t MemoryOffsetUpper = MemoryOffset + AllocationSize;
+
+      // If we would go above the upper bound on size then try the next size
+      if (MemoryOffsetUpper > End) {
+        ++CurrentSizeIndex;
+        continue;
+      }
+
+      void *Ptr = ::mmap(reinterpret_cast<void*>(MemoryOffset), AllocationSize, PROT_FLAGS, MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE | MAP_FIXED_NOREPLACE, -1, 0);
+
+      // If we managed to allocate and not get the address we want then unmap it
+      // This happens with kernels older than 4.17
+      if (reinterpret_cast<uintptr_t>(Ptr) + AllocationSize > End) {
+        ::munmap(Ptr, AllocationSize);
+        Ptr = reinterpret_cast<void*>(~0ULL);
+      }
+
+      // If we failed to allocate and we are on the smallest allocation size then just continue onward
+      // This page was unmappable
+      if (reinterpret_cast<uintptr_t>(Ptr) == ~0ULL && CurrentSizeIndex == AllocationSizeMaxIndex) {
+        CurrentSizeIndex = 0;
+        MemoryOffset += AllocationSize;
+        continue;
+      }
+
+      // Congratulations we were able to map this bit
+      // Reset and claim it was available
+      if (reinterpret_cast<uintptr_t>(Ptr) != ~0ULL) {
+        if (!Cache) {
+          Cache = reinterpret_cast<PtrCache *>(Ptr);
+          CacheSize = AllocationSize;
+          PROT_FLAGS = PROT_NONE;
+        }
+        else {
+          Cache[CurrentCacheOffset] = {
+            .Ptr = static_cast<uint64_t>(reinterpret_cast<uint64_t>(Ptr)),
+            .Size = static_cast<uint64_t>(AllocationSize)
+          };
+          ++CurrentCacheOffset;
+        }
+
+        CurrentSizeIndex = 0;
+        MemoryOffset += AllocationSize;
+        continue;
+      }
+
+      // Couldn't allocate at this size
+      // Increase and continue
+      ++CurrentSizeIndex;
+    }
+
+    Cache[CurrentCacheOffset] = {
+      .Ptr = static_cast<uint64_t>(reinterpret_cast<uint64_t>(Cache)),
+      .Size = CacheSize,
+    };
+    return Cache;
+  }
+
+  PtrCache* Steal48BitVA() {
+    size_t Bits = FEXCore::Allocator::DetermineVASize();
+    if (Bits < 48) {
+      return nullptr;
+    }
+
+    uintptr_t Begin48BitVA = 0x0'8000'0000'0000ULL;
+    uintptr_t End48BitVA   = 0x1'0000'0000'0000ULL;
+    return StealMemoryRegion(Begin48BitVA, End48BitVA);
+  }
+
+  void ReclaimMemoryRegion(PtrCache* Regions) {
+    if (Regions == nullptr) {
+      return;
+    }
+
+    for (size_t i = 0;; ++i) {
+      void *Ptr = reinterpret_cast<void*>(Regions[i].Ptr);
+      size_t Size = Regions[i].Size;
+      ::munmap(Ptr, Size);
+      if (Ptr == Regions) {
+        break;
+      }
+    }
+  }
 }

--- a/External/FEXCore/Source/Utils/Allocator/64BitAllocator.cpp
+++ b/External/FEXCore/Source/Utils/Allocator/64BitAllocator.cpp
@@ -1,6 +1,7 @@
 #include "Utils/Allocator/FlexBitSet.h"
 #include "Utils/Allocator/HostAllocator.h"
 #include "Utils/Allocator/IntrusiveArenaAllocator.h"
+#include <FEXCore/Utils/Allocator.h>
 #include <FEXCore/Utils/LogManager.h>
 
 #include <algorithm>
@@ -139,49 +140,14 @@ namespace Alloc::OSAllocator {
       }
 
       // 32-bit old kernel workarounds
-      struct PtrCache {
-        uint32_t Ptr;
-        uint32_t Size;
-      };
-      PtrCache *Steal32BitIfOldKernel();
-      void Clear32BitOnOldKernel(PtrCache *Base);
+      FEXCore::Allocator::PtrCache *Steal32BitIfOldKernel();
   };
 
 void OSAllocator_64Bit::DetermineVASize() {
-  static constexpr std::array<uintptr_t, 7> TLBSizes = {
-    1ULL << 57,
-    1ULL << 52,
-    1ULL << 48,
-    1ULL << 47,
-    1ULL << 42,
-    1ULL << 39,
-    1ULL << 36,
-  };
-
-  for (auto Size : TLBSizes) {
-    // Just try allocating
-    // We can't actually determine VA size on ARM safely
-    auto Find = [](uintptr_t Size) -> bool {
-      for (int i = 0; i < 64; ++i) {
-        // Try grabbing a some of the top pages of the range
-        // x86 allocates some high pages in the top end
-        void *Ptr = ::mmap(reinterpret_cast<void*>(Size - PAGE_SIZE * i), PAGE_SIZE, PROT_NONE, MAP_FIXED_NOREPLACE | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-        if (Ptr != (void*)~0ULL) {
-          ::munmap(Ptr, PAGE_SIZE);
-          if (Ptr == (void*)(Size - PAGE_SIZE * i)) {
-            return true;
-          }
-        }
-      }
-      return false;
-    };
-
-    if (Find(Size)) {
-      UPPER_BOUND = Size;
-      UPPER_BOUND_PAGE = UPPER_BOUND / PAGE_SIZE;
-      break;
-    }
-  }
+  size_t Bits = FEXCore::Allocator::DetermineVASize();
+  uintptr_t Size = 1ULL << Bits;
+  UPPER_BOUND = Size;
+  UPPER_BOUND_PAGE = UPPER_BOUND / PAGE_SIZE;
 }
 
 void *OSAllocator_64Bit::Mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset) {
@@ -523,7 +489,7 @@ int OSAllocator_64Bit::Munmap(void *addr, size_t length) {
   return 0;
 }
 
-OSAllocator_64Bit::PtrCache *OSAllocator_64Bit::Steal32BitIfOldKernel() {
+FEXCore::Allocator::PtrCache *OSAllocator_64Bit::Steal32BitIfOldKernel() {
   // First calculate kernel version
   struct utsname buf{};
   if (uname(&buf) == -1) {
@@ -548,95 +514,10 @@ OSAllocator_64Bit::PtrCache *OSAllocator_64Bit::Steal32BitIfOldKernel() {
     return nullptr;
   }
 
-  OSAllocator_64Bit::PtrCache *Cache{};
-  uint32_t CacheSize{};
-  uint32_t CurrentCacheOffset = 0;
-  constexpr std::array<size_t, 6> ReservedVMARegionSizes = {{
-    1ULL * 1024 * 1024 * 1024, // 1GB
-    512ULL * 1024 * 1024,      // 512MB
-    128ULL * 1024 * 1024,      // 128MB
-    32ULL * 1024 * 1024,       // 32MB
-    1ULL * 1024 * 1024,        // 1MB
-    4096ULL                    // One page
-  }};
-  constexpr size_t AllocationSizeMaxIndex = ReservedVMARegionSizes.size() - 1;
-  uint64_t CurrentSizeIndex = 0;
-
   constexpr size_t LOWER_BOUND_32 = 0x1'0000;
   constexpr size_t UPPER_BOUND_32 = LOWER_BOUND;
 
-  for (size_t MemoryOffset = LOWER_BOUND_32; MemoryOffset < UPPER_BOUND_32;) {
-    size_t AllocationSize = ReservedVMARegionSizes[CurrentSizeIndex];
-    size_t MemoryOffsetUpper = MemoryOffset + AllocationSize;
-
-    // If we would go above the upper bound on size then try the next size
-    if (MemoryOffsetUpper > UPPER_BOUND_32) {
-      ++CurrentSizeIndex;
-      continue;
-    }
-
-    void *Ptr = ::mmap(reinterpret_cast<void*>(MemoryOffset), AllocationSize, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE, -1, 0);
-
-    // If we managed to allocate and not get the address we want then unmap it
-    // This happens with kernels older than 4.17
-    if (reinterpret_cast<uintptr_t>(Ptr) + AllocationSize > UPPER_BOUND_32) {
-      ::munmap(Ptr, AllocationSize);
-      Ptr = reinterpret_cast<void*>(~0ULL);
-    }
-
-    // If we failed to allocate and we are on the smallest allocation size then just continue onward
-    // This page was unmappable
-    if (reinterpret_cast<uintptr_t>(Ptr) == ~0ULL && CurrentSizeIndex == AllocationSizeMaxIndex) {
-      CurrentSizeIndex = 0;
-      MemoryOffset += AllocationSize;
-      continue;
-    }
-
-    // Congratulations we were able to map this bit
-    // Reset and claim it was available
-    if (reinterpret_cast<uintptr_t>(Ptr) != ~0ULL) {
-      if (!Cache) {
-        Cache = reinterpret_cast<OSAllocator_64Bit::PtrCache *>(Ptr);
-        CacheSize = AllocationSize;
-      }
-      else {
-        Cache[CurrentCacheOffset] = {
-          .Ptr = static_cast<uint32_t>(reinterpret_cast<uint64_t>(Ptr)),
-          .Size = static_cast<uint32_t>(AllocationSize)
-        };
-        ++CurrentCacheOffset;
-      }
-
-      CurrentSizeIndex = 0;
-      MemoryOffset += AllocationSize;
-      continue;
-    }
-
-    // Couldn't allocate at this size
-    // Increase and continue
-    ++CurrentSizeIndex;
-  }
-
-  Cache[CurrentCacheOffset] = {
-    .Ptr = static_cast<uint32_t>(reinterpret_cast<uint64_t>(Cache)),
-    .Size = CacheSize,
-  };
-  return Cache;
-}
-
-void OSAllocator_64Bit::Clear32BitOnOldKernel(OSAllocator_64Bit::PtrCache *Base) {
-  if (Base == nullptr) {
-    return;
-  }
-
-  for (size_t i = 0;; ++i) {
-    void *Ptr = reinterpret_cast<void*>(Base[i].Ptr);
-    size_t Size = Base[i].Size;
-    ::munmap(Ptr, Size);
-    if (Ptr == Base) {
-      break;
-    }
-  }
+  return FEXCore::Allocator::StealMemoryRegion(LOWER_BOUND_32, UPPER_BOUND_32);
 }
 
 OSAllocator_64Bit::OSAllocator_64Bit() {
@@ -735,7 +616,7 @@ OSAllocator_64Bit::OSAllocator_64Bit() {
     ++CurrentSizeIndex;
   }
 
-  Clear32BitOnOldKernel(ArrayPtr);
+  FEXCore::Allocator::ReclaimMemoryRegion(ArrayPtr);
 }
 
 OSAllocator_64Bit::~OSAllocator_64Bit() {

--- a/External/FEXCore/include/FEXCore/Utils/Allocator.h
+++ b/External/FEXCore/include/FEXCore/Utils/Allocator.h
@@ -21,4 +21,21 @@ namespace FEXCore::Allocator {
 
   FEX_DEFAULT_VISIBILITY void SetupHooks();
   FEX_DEFAULT_VISIBILITY void ClearHooks();
+
+  FEX_DEFAULT_VISIBILITY size_t DetermineVASize();
+  // 48-bit VA handling
+  struct PtrCache {
+    uint64_t Ptr;
+    uint64_t Size;
+  };
+
+  FEX_DEFAULT_VISIBILITY PtrCache* StealMemoryRegion(uintptr_t Begin, uintptr_t End);
+  FEX_DEFAULT_VISIBILITY void ReclaimMemoryRegion(PtrCache* Regions);
+  // When running a 64-bit executable on ARM then userspace guest only gets 47 bits of VA
+  // This is a feature of x86-64 where the kernel gets a full 128TB of VA space
+  // x86-64 canonical addresses with bit 48 set will sign extend the address (Ignoring LA57)
+  // AArch64 canonical addresses are only up to bits 48/52 with the remainder being other things
+  // Use this to reserve the top 128TB of VA so the guest never see it
+  // Returns nullptr on host VA < 48bits
+  FEX_DEFAULT_VISIBILITY PtrCache* Steal48BitVA();
 }

--- a/Source/Tests/FEXLoader.cpp
+++ b/Source/Tests/FEXLoader.cpp
@@ -478,8 +478,11 @@ int main(int argc, char **argv, char **const envp) {
   FEXCore::Config::Set(FEXCore::Config::CONFIG_IS64BIT_MODE, Loader.Is64BitMode() ? "1" : "0");
 
   std::unique_ptr<FEX::HLE::x32::MemAllocator> Allocator;
+  FEXCore::Allocator::PtrCache *Base48Bit{};
 
   if (Loader.Is64BitMode()) {
+    // Destroy the 48th bit if it exists
+    Base48Bit = FEXCore::Allocator::Steal48BitVA();
     if (!Loader.MapMemory([](void *addr, size_t length, int prot, int flags, int fd, off_t offset) {
       return FEXCore::Allocator::mmap(addr, length, prot, flags, fd, offset);
     }, [](void *addr, size_t length) {
@@ -619,6 +622,7 @@ int main(int argc, char **argv, char **const envp) {
   LogMan::Msg::UnInstallHandlers();
 
   FEXCore::Allocator::ClearHooks();
+  FEXCore::Allocator::ReclaimMemoryRegion(Base48Bit);
   // Allocator is now original system allocator
 
   FEXCore::Telemetry::Shutdown(ProgramName);


### PR DESCRIPTION
Only a partial fix for #1330, still needs preemption disabled to work.

On x86-64 hosts the Linux kernel resides in the top bit of VA which
isn't mapped in to userspace.
This means that userspace will never receive pointers living with that
top bit set unless you're running a 57bit VA host.

This results in userspace pointers never needing to do the sign
extending pointer canonicalization. But additionally some applications
actually don't understand the pointer canonicalization.
This results in bugs like: https://github.com/golang/go/issues/49405
Now if you're running on a 57bit VA host, this will end up behaving like
FEX but it seems like no one in golang land has really messed with 57bit
VA yet.

In AArch64, when configured with a 48bit VA, the userspace gets the full
48bit VA space and on EL mode switch has the full address range change
to the kernel's 48bit VA.
This means that we will /very/ likely allocate pointers in the high
48bit space since Linux currently allocates top-down.

So behave more like x86-64, hide the top 128TB of memory space from the
guest before boot.

Testing: Took the M1Max 15ms to 21ms allocate the top 128TB.