### PR TITLE
CPUID: Adds support for hybrid flag

### DIFF
--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -141,6 +141,7 @@ set (SRCS
   Interface/IR/Passes/SyscallOptimization.cpp
   Utils/Allocator.cpp
   Utils/Allocator/64BitAllocator.cpp
+  Utils/FileLoading.cpp
   Utils/LogManager.cpp
   Utils/Telemetry.cpp
   Utils/Threads.cpp

--- a/External/FEXCore/Source/Interface/Core/CPUID.h
+++ b/External/FEXCore/Source/Interface/Core/CPUID.h
@@ -37,6 +37,7 @@ public:
   }
 private:
   FEXCore::Context::Context *CTX;
+  bool Hybrid{};
   FEX_CONFIG_OPT(Cores, THREADS);
 
   using FunctionHandler = std::function<FEXCore::CPUID::FunctionResults(uint32_t Leaf)>;

--- a/External/FEXCore/Source/Utils/FileLoading.cpp
+++ b/External/FEXCore/Source/Utils/FileLoading.cpp
@@ -1,0 +1,51 @@
+#include <string>
+#include <vector>
+#include <filesystem>
+#include <fstream>
+
+namespace FEXCore::FileLoading {
+bool LoadFile(std::vector<char> &Data, const std::string &Filepath, size_t FixedSize) {
+  std::fstream ConfigFile;
+  ConfigFile.open(Filepath, std::ios::in);
+
+  if (!ConfigFile.is_open()) {
+    return false;
+  }
+
+  size_t FileSize{};
+
+  if (FixedSize == 0) {
+    if (!ConfigFile.seekg(0, std::fstream::end)) {
+      return false;
+    }
+
+    FileSize = ConfigFile.tellg();
+    if (ConfigFile.fail()) {
+      return false;
+    }
+
+    if (!ConfigFile.seekg(0, std::fstream::beg)) {
+      return false;
+    }
+  }
+  else {
+    FileSize = FixedSize;
+  }
+
+  if (FileSize > 0) {
+    Data.resize(FileSize);
+    if (!ConfigFile.read(&Data.at(0), FileSize)) {
+      // Probably means permissions aren't set. Just early exit
+      return false;
+    }
+    ConfigFile.close();
+  }
+  else {
+    return false;
+  }
+
+  return true;
+}
+
+
+}

--- a/External/FEXCore/Source/Utils/FileLoading.h
+++ b/External/FEXCore/Source/Utils/FileLoading.h
@@ -1,0 +1,18 @@
+#pragma once
+#include <string>
+#include <vector>
+#include <filesystem>
+#include <fstream>
+
+namespace FEXCore::FileLoading {
+  /**
+   * @brief Loads a filepath in to a vector of data
+   *
+   * @param Data The vector to load the file data in to
+   * @param Filepath The filepath to load
+   *
+   * @return true on file loaded, false on failure
+   */
+  bool LoadFile(std::vector<char> &Data, const std::string &Filepath, size_t FixedSize = 0);
+}
+


### PR DESCRIPTION
CPUID lets the application know if it is running on a CPU with hybrid
CPU clusters.
This matches big.little fairly easily. Walk the affinity mask and
check if we are running on a big.little system and report it to the
guest.

For x86-64 host just pass through the flag.