### PR TITLE
FEXConfig: Fixes timeout in select causing 100% CPU load

### DIFF
--- a/Source/Tools/FEXConfig/Main.cpp
+++ b/Source/Tools/FEXConfig/Main.cpp
@@ -129,15 +129,14 @@ namespace {
     while (!INotifyShutdown) {
       constexpr size_t DATA_SIZE = (16 * (sizeof(struct inotify_event) + NAME_MAX + 1));
       char buf[DATA_SIZE];
-      struct timeval tv{};
-      // 50 ms
-      tv.tv_usec = 50000;
-
       int Ret{};
       do {
         fd_set Set{};
         FD_ZERO(&Set);
         FD_SET(INotifyFD, &Set);
+        struct timeval tv{};
+        // 50 ms
+        tv.tv_usec = 50000;
         Ret = select(INotifyFD + 1, &Set, nullptr, nullptr, &tv);
       } while (Ret == 0 && INotifyFD != -1);
 


### PR DESCRIPTION
glibc 2.34 changed the select interface to update the timeout on return
to more closely match the kernel interface.
glibc 2.33 always made a copy instead of updating.
Make sure to set the timeout on each iteration of select otherwise we
will end up having a timeout of zero. Thus burning a CPU core.