### PR TITLE
Linux: Fixes execve on softlinks in rootfs

### DIFF
--- a/Source/Tests/LinuxSyscalls/FileManagement.h
+++ b/Source/Tests/LinuxSyscalls/FileManagement.h
@@ -63,12 +63,13 @@ public:
 
   void UpdatePID(uint32_t PID) { CurrentPID = PID; }
 
+  std::string GetEmulatedPath(const char *pathname, bool FollowSymlink = false);
+
 private:
   FEX::EmulatedFile::EmulatedFDManager EmuFD;
 
   std::mutex FDLock;
   std::unordered_map<int32_t, std::string> FDToNameMap;
-  std::string GetEmulatedPath(const char *pathname, bool FollowSymlink = false);
   std::map<std::string, std::string, std::less<>> ThunkOverlays;
 
   FEX_CONFIG_OPT(Filename, APP_FILENAME);

--- a/Source/Tests/LinuxSyscalls/Syscalls.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls.cpp
@@ -116,12 +116,14 @@ uint64_t ExecveHandler(const char *pathname, char* const* argv, char* const* env
 
   std::error_code ec;
   std::string RootFS = FEX::HLE::_SyscallHandler->RootFSPath();
+
   // Check the rootfs if it is available first
   if (pathname[0] == '/') {
-    Filename = RootFS  + pathname;
-
-    bool exists = std::filesystem::exists(Filename, ec);
-    if (ec || !exists) {
+    auto Path = FEX::HLE::_SyscallHandler->FM.GetEmulatedPath(pathname, true);
+    if (!Path.empty() && std::filesystem::exists(Path, ec)) {
+      Filename = Path;
+    }
+    else {
       Filename = pathname;
     }
   }

--- a/Source/Tests/LinuxSyscalls/x64/NotImplemented.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/NotImplemented.cpp
@@ -5,6 +5,7 @@ $end_info$
 */
 
 #include <FEXCore/Utils/LogManager.h>
+#include "Tests/LinuxSyscalls/Syscalls.h"
 #include "Tests/LinuxSyscalls/x64/Syscalls.h"
 
 #include <errno.h>


### PR DESCRIPTION
Ubuntu soft links a bunch of binaries in /usr/bin to softlinks that live
in /etc/alternatives/

When hitting any of these alternative softlinks execve would fail if the
host also didn't have the same softlink paths.

Allows us to correctly follow the symlinks on execve as well which fixes
launching wine directly from the wine symlink.
Alternatively you could have launched /usr/bin/wine-stable directly.

Also fixes FEX strace again.