### PR TITLE
Dispatcher: Partial support for RIP adjust in signal handler

### DIFF
--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/MContext.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/MContext.h
@@ -13,6 +13,11 @@
 
 namespace FEXCore::ArchHelpers::Context {
 
+enum ContextFlags : uint32_t {
+  CONTEXT_FLAG_INJIT = (1U << 0),
+  CONTEXT_FLAG_32BIT = (1U << 1),
+};
+
 struct X86ContextBackup {
   // Host State
   // RIP and RSP is stored in GPRs here
@@ -22,8 +27,12 @@ struct X86ContextBackup {
 
   // Guest state
   int Signal;
+  uint32_t Flags;
+  uint64_t OriginalRIP;
+  uint64_t FPStateLocation;
+  uint64_t UContextLocation;
+  uint64_t SigInfoLocation;
   FEXCore::Core::CPUState GuestState;
-
   static constexpr int RedZoneSize = 128;
 };
 
@@ -40,6 +49,11 @@ struct ArmContextBackup {
 
   // Guest state
   int Signal;
+  uint32_t Flags;
+  uint64_t OriginalRIP;
+  uint64_t FPStateLocation;
+  uint64_t UContextLocation;
+  uint64_t SigInfoLocation;
   FEXCore::Core::CPUState GuestState;
 
   // Arm64 doesn't have a red zone

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
@@ -3,6 +3,7 @@
 #include <FEXCore/Core/CPUBackend.h>
 
 #include "Interface/Context/Context.h"
+#include "Interface/Core/ArchHelpers/MContext.h"
 
 #include <bits/types/stack_t.h>
 #include <cstdint>
@@ -77,7 +78,7 @@ protected:
     : CTX {ctx}
     , ThreadState {Thread} {}
 
-  void StoreThreadState(int Signal, void *ucontext);
+  ArchHelpers::Context::ContextBackup* StoreThreadState(int Signal, void *ucontext);
   void RestoreThreadState(void *ucontext);
   std::stack<uint64_t> SignalFrames;
 


### PR DESCRIPTION
When the context structure is adjusted in the signal handler then this
updates the state of the CPU on sigreturn.

We check to see if the RIP was adjusted and in this case we will update
the JIT in a potentially unsafe fashion.
This works well enough with signal handlers that effectively just long
jump and not much else.

Fixes wine initial prefix setup where rundl32 expects to do a try-catch
fault capture but infinite loops without this.