### PR TITLE
OpcodeDecoder: Convert enums into enum classes where applicable

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -1415,47 +1415,47 @@ void OpDispatchBuilder::LAHFOp(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::FLAGControlOp(OpcodeArgs) {
-  enum OpType {
-    OP_CLEAR,
-    OP_SET,
-    OP_COMPLEMENT,
+  enum class OpType {
+    Clear,
+    Set,
+    Complement,
   };
   OpType Type;
   uint64_t Flag;
   switch (Op->OP) {
   case 0xF5: // CMC
     Flag= FEXCore::X86State::RFLAG_CF_LOC;
-    Type = OP_COMPLEMENT;
+    Type = OpType::Complement;
   break;
   case 0xF8: // CLC
     Flag= FEXCore::X86State::RFLAG_CF_LOC;
-    Type = OP_CLEAR;
+    Type = OpType::Clear;
   break;
   case 0xF9: // STC
     Flag= FEXCore::X86State::RFLAG_CF_LOC;
-    Type = OP_SET;
+    Type = OpType::Set;
   break;
   case 0xFC: // CLD
     Flag= FEXCore::X86State::RFLAG_DF_LOC;
-    Type = OP_CLEAR;
+    Type = OpType::Clear;
   break;
   case 0xFD: // STD
     Flag= FEXCore::X86State::RFLAG_DF_LOC;
-    Type = OP_SET;
+    Type = OpType::Set;
   break;
   }
 
   OrderedNode *Result{};
   switch (Type) {
-  case OP_CLEAR: {
+  case OpType::Clear: {
     Result = _Constant(0);
   break;
   }
-  case OP_SET: {
+  case OpType::Set: {
     Result = _Constant(1);
   break;
   }
-  case OP_COMPLEMENT: {
+  case OpType::Complement: {
     auto RFLAG = GetRFLAG(Flag);
     Result = _Xor(RFLAG, _Constant(1));
   break;

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -3262,7 +3262,7 @@ template<OpDispatchBuilder::Segment Seg>
 void OpDispatchBuilder::ReadSegmentReg(OpcodeArgs) {
   auto Size = GetSrcSize(Op);
   OrderedNode *Src{};
-  if constexpr (Seg == Segment_FS) {
+  if constexpr (Seg == Segment::FS) {
     Src = _LoadContext(Size, offsetof(FEXCore::Core::CPUState, fs), GPRClass);
   }
   else {
@@ -3276,7 +3276,7 @@ template<OpDispatchBuilder::Segment Seg>
 void OpDispatchBuilder::WriteSegmentReg(OpcodeArgs) {
   auto Size = GetSrcSize(Op);
   OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
-  if constexpr (Seg == Segment_FS) {
+  if constexpr (Seg == Segment::FS) {
     _StoreContext(GPRClass, Size, offsetof(FEXCore::Core::CPUState, fs), Src);
   }
   else {
@@ -5665,10 +5665,10 @@ constexpr uint16_t PF_F2 = 3;
     {OPD(FEXCore::X86Tables::TYPE_GROUP_15, PF_NONE, 6), 1, &OpDispatchBuilder::FenceOp<FEXCore::IR::Fence_LoadStore.Val>}, //MFENCE
     {OPD(FEXCore::X86Tables::TYPE_GROUP_15, PF_NONE, 7), 1, &OpDispatchBuilder::StoreFenceOrCLFlush},     //SFENCE
 
-    {OPD(FEXCore::X86Tables::TYPE_GROUP_15, PF_F3, 0), 1, &OpDispatchBuilder::ReadSegmentReg<OpDispatchBuilder::Segment_FS>},
-    {OPD(FEXCore::X86Tables::TYPE_GROUP_15, PF_F3, 1), 1, &OpDispatchBuilder::ReadSegmentReg<OpDispatchBuilder::Segment_GS>},
-    {OPD(FEXCore::X86Tables::TYPE_GROUP_15, PF_F3, 2), 1, &OpDispatchBuilder::WriteSegmentReg<OpDispatchBuilder::Segment_FS>},
-    {OPD(FEXCore::X86Tables::TYPE_GROUP_15, PF_F3, 3), 1, &OpDispatchBuilder::WriteSegmentReg<OpDispatchBuilder::Segment_GS>},
+    {OPD(FEXCore::X86Tables::TYPE_GROUP_15, PF_F3, 0), 1, &OpDispatchBuilder::ReadSegmentReg<OpDispatchBuilder::Segment::FS>},
+    {OPD(FEXCore::X86Tables::TYPE_GROUP_15, PF_F3, 1), 1, &OpDispatchBuilder::ReadSegmentReg<OpDispatchBuilder::Segment::GS>},
+    {OPD(FEXCore::X86Tables::TYPE_GROUP_15, PF_F3, 2), 1, &OpDispatchBuilder::WriteSegmentReg<OpDispatchBuilder::Segment::FS>},
+    {OPD(FEXCore::X86Tables::TYPE_GROUP_15, PF_F3, 3), 1, &OpDispatchBuilder::WriteSegmentReg<OpDispatchBuilder::Segment::GS>},
     {OPD(FEXCore::X86Tables::TYPE_GROUP_15, PF_F3, 5), 1, &OpDispatchBuilder::UnimplementedOp},
     {OPD(FEXCore::X86Tables::TYPE_GROUP_15, PF_F3, 6), 1, &OpDispatchBuilder::UnimplementedOp},
 

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -26,18 +26,20 @@ class OpDispatchBuilder final : public IREmitter {
 friend class FEXCore::IR::Pass;
 friend class FEXCore::IR::PassManager;
 
-enum {
-  FLAGS_OP_NONE,  // must rely on x86 flags
-  FLAGS_OP_CMP,   // flags were set by a CMP between flagsOpDest/flagsOpDestSigned and flagsOpSrc/flagsOpSrcSigned with flagsOpSize size
-  FLAGS_OP_AND,   // flags were set by an AND/TEST, flagsOpDest contains the resulting value of flagsOpSize size
-  FLAGS_OP_FCMP,  // flags were set by a ucomis* / comis*
+enum class SelectionFlag {
+  Nothing,  // must rely on x86 flags
+  CMP,      // flags were set by a CMP between flagsOpDest/flagsOpDestSigned and flagsOpSrc/flagsOpSrcSigned with flagsOpSize size
+  AND,      // flags were set by an AND/TEST, flagsOpDest contains the resulting value of flagsOpSize size
+  FCMP,     // flags were set by a ucomis* / comis*
 };
 
 public:
-  int flagsOp;
-  uint8_t flagsOpSize;
-  OrderedNode* flagsOpDest, *flagsOpSrc;
-  OrderedNode* flagsOpDestSigned, *flagsOpSrcSigned;
+  SelectionFlag flagsOp{};
+  uint8_t flagsOpSize{};
+  OrderedNode* flagsOpDest{};
+  OrderedNode* flagsOpSrc{};
+  OrderedNode* flagsOpDestSigned{};
+  OrderedNode* flagsOpSrcSigned{};
 
   FEXCore::Context::Context *CTX{};
   bool ShouldDump {false};
@@ -69,7 +71,7 @@ public:
   }
 
   void StartNewBlock() {
-    flagsOp = FLAGS_OP_NONE;
+    flagsOp = SelectionFlag::Nothing;
   }
 
   bool FinishOp(uint64_t NextRIP, bool LastOp) {
@@ -519,12 +521,12 @@ private:
 
   template<unsigned BitOffset>
   void SetRFLAG(OrderedNode *Value) {
-    flagsOp = FLAGS_OP_NONE;
+    flagsOp = SelectionFlag::Nothing;
     _StoreFlag(_Bfe(1, 0, Value), BitOffset);
   }
 
   void SetRFLAG(OrderedNode *Value, unsigned BitOffset) {
-    flagsOp = FLAGS_OP_NONE;
+    flagsOp = SelectionFlag::Nothing;
     _StoreFlag(_Bfe(1, 0, Value), BitOffset);
   }
 

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -553,13 +553,13 @@ private:
   void GenerateFlags_RotateLeftImmediate(FEXCore::X86Tables::DecodedOp Op, OrderedNode *Res, OrderedNode *Src1, uint64_t Shift);
 
   OrderedNode * GetX87Top();
-  enum X87Tag {
-    TAG_VALID   = 0b00,
-    TAG_ZERO    = 0b01,
-    TAG_SPECIAL = 0b10,
-    TAG_EMPTY   = 0b11
+  enum class X87Tag {
+    Valid   = 0b00,
+    Zero    = 0b01,
+    Special = 0b10,
+    Empty   = 0b11
   };
-  void SetX87TopTag(OrderedNode *Value, uint32_t Tag);
+  void SetX87TopTag(OrderedNode *Value, X87Tag Tag);
   OrderedNode *GetX87FTW(OrderedNode *Value);
   void SetX87Top(OrderedNode *Value);
 

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -231,9 +231,9 @@ public:
   void PopcountOp(OpcodeArgs);
   void XLATOp(OpcodeArgs);
 
-  enum Segment {
-    Segment_FS,
-    Segment_GS,
+  enum class Segment {
+    FS,
+    GS,
   };
   template<Segment Seg>
   void ReadSegmentReg(OpcodeArgs);

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -1443,7 +1443,7 @@ void OpDispatchBuilder::UCOMISxOp(OpcodeArgs) {
   SetRFLAG<FEXCore::X86State::RFLAG_SF_LOC>(ZeroConst);
   SetRFLAG<FEXCore::X86State::RFLAG_OF_LOC>(ZeroConst);
 
-  flagsOp = FLAGS_OP_FCMP;
+  flagsOp = SelectionFlag::FCMP;
   flagsOpDest = Src1;
   flagsOpSrc = Src2;
   flagsOpSize = GetSrcSize(Op);

--- a/External/FEXCore/include/FEXCore/Utils/EnumUtils.h
+++ b/External/FEXCore/include/FEXCore/Utils/EnumUtils.h
@@ -1,0 +1,72 @@
+#pragma once
+
+// Header for various utilities related to operating with enums
+
+#include <type_traits>
+
+namespace FEXCore {
+
+// Macro that defines all of the built in operators for conveniently using
+// enum classes as flag types without needing to define all of the basic
+// boilerplate.
+#define FEX_DECLARE_ENUM_FLAG_OPERATORS(type)                                                      \
+    [[nodiscard]] constexpr type operator|(type a, type b) noexcept {                              \
+        using T = std::underlying_type_t<type>;                                                    \
+        return static_cast<type>(static_cast<T>(a) | static_cast<T>(b));                           \
+    }                                                                                              \
+    [[nodiscard]] constexpr type operator&(type a, type b) noexcept {                              \
+        using T = std::underlying_type_t<type>;                                                    \
+        return static_cast<type>(static_cast<T>(a) & static_cast<T>(b));                           \
+    }                                                                                              \
+    [[nodiscard]] constexpr type operator^(type a, type b) noexcept {                              \
+        using T = std::underlying_type_t<type>;                                                    \
+        return static_cast<type>(static_cast<T>(a) ^ static_cast<T>(b));                           \
+    }                                                                                              \
+    [[nodiscard]] constexpr type operator<<(type a, type b) noexcept {                             \
+        using T = std::underlying_type_t<type>;                                                    \
+        return static_cast<type>(static_cast<T>(a) << static_cast<T>(b));                          \
+    }                                                                                              \
+    [[nodiscard]] constexpr type operator>>(type a, type b) noexcept {                             \
+        using T = std::underlying_type_t<type>;                                                    \
+        return static_cast<type>(static_cast<T>(a) >> static_cast<T>(b));                          \
+    }                                                                                              \
+    constexpr type& operator|=(type& a, type b) noexcept {                                         \
+        a = a | b;                                                                                 \
+        return a;                                                                                  \
+    }                                                                                              \
+    constexpr type& operator&=(type& a, type b) noexcept {                                         \
+        a = a & b;                                                                                 \
+        return a;                                                                                  \
+    }                                                                                              \
+    constexpr type& operator^=(type& a, type b) noexcept {                                         \
+        a = a ^ b;                                                                                 \
+        return a;                                                                                  \
+    }                                                                                              \
+    constexpr type& operator<<=(type& a, type b) noexcept {                                        \
+        a = a << b;                                                                                \
+        return a;                                                                                  \
+    }                                                                                              \
+    constexpr type& operator>>=(type& a, type b) noexcept {                                        \
+        a = a >> b;                                                                                \
+        return a;                                                                                  \
+    }                                                                                              \
+    [[nodiscard]] constexpr type operator~(type key) noexcept {                                    \
+        using T = std::underlying_type_t<type>;                                                    \
+        return static_cast<type>(~static_cast<T>(key));                                            \
+    }                                                                                              \
+    [[nodiscard]] constexpr bool True(type key) noexcept {                                         \
+        using T = std::underlying_type_t<type>;                                                    \
+        return static_cast<T>(key) != 0;                                                           \
+    }                                                                                              \
+    [[nodiscard]] constexpr bool False(type key) noexcept {                                        \
+        using T = std::underlying_type_t<type>;                                                    \
+        return static_cast<T>(key) == 0;                                                           \
+    }
+
+// Equivalent to C++23's std::to_underlying.
+template <typename Enum>
+[[nodiscard]] constexpr std::underlying_type_t<Enum> ToUnderlying(Enum e) noexcept {
+  return static_cast<std::underlying_type_t<Enum>>(e);
+}
+
+} // namespace FEXCore


### PR DESCRIPTION
Makes them strongly typed so that invalid values can't implicitly be assigned to relevant variables

While we're at it, this adds helper utilities that make working with enum classes a little more convenient for avoiding boilerplate in regards to enum classes that can be used as flags. Now the relevant operations don't need to be defined long-form for every individual enum class.