### PR TITLE
OpcodeDecoder: Shorten up GPR and MM base offset retrieval

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -5,6 +5,7 @@
 
 #include <FEXCore/Config/Config.h>
 #include <FEXCore/Core/Context.h>
+#include <FEXCore/Core/X86Enums.h>
 #include <FEXCore/Debug/X86Tables.h>
 #include <FEXCore/IR/IntrusiveIRList.h>
 #include <FEXCore/IR/IR.h>
@@ -516,6 +517,11 @@ private:
   void StoreResult_WithOpSize(FEXCore::IR::RegisterClassType Class, FEXCore::X86Tables::DecodedOp Op, FEXCore::X86Tables::DecodedOperand const& Operand, OrderedNode *const Src, uint8_t OpSize, int8_t Align);
   void StoreResult(FEXCore::IR::RegisterClassType Class, FEXCore::X86Tables::DecodedOp Op, FEXCore::X86Tables::DecodedOperand const& Operand, OrderedNode *const Src, int8_t Align);
   void StoreResult(FEXCore::IR::RegisterClassType Class, FEXCore::X86Tables::DecodedOp Op, OrderedNode *const Src, int8_t Align);
+
+  [[nodiscard]] static uint32_t GPROffset(X86State::X86Reg reg) {
+    LOGMAN_THROW_A_FMT(reg <= X86State::X86Reg::REG_R15, "Invalid reg used");
+    return static_cast<uint8_t>(offsetof(Core::CPUState, gregs[static_cast<size_t>(reg)]));
+  }
 
   uint8_t GetDstSize(X86Tables::DecodedOp Op) const;
   uint8_t GetSrcSize(X86Tables::DecodedOp Op) const;

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -523,6 +523,10 @@ private:
     return static_cast<uint8_t>(offsetof(Core::CPUState, gregs[static_cast<size_t>(reg)]));
   }
 
+  [[nodiscard]] static uint32_t MMBaseOffset() {
+    return static_cast<uint32_t>(offsetof(Core::CPUState, mm[0][0]));
+  }
+
   uint8_t GetDstSize(X86Tables::DecodedOp Op) const;
   uint8_t GetSrcSize(X86Tables::DecodedOp Op) const;
   uint8_t GetDstBitSize(X86Tables::DecodedOp Op) const;

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -1133,7 +1133,7 @@ void OpDispatchBuilder::MASKMOVOp(OpcodeArgs) {
   OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
   OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
 
-  OrderedNode *MemDest = _LoadContext(GPRSize, offsetof(FEXCore::Core::CPUState, gregs[FEXCore::X86State::REG_RDI]), GPRClass);
+  OrderedNode *MemDest = _LoadContext(GPRSize, GPROffset(X86State::REG_RDI), GPRClass);
 
   const size_t NumElements = Size / 64;
   for (size_t Element = 0; Element < NumElements; ++Element) {

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
@@ -73,7 +73,7 @@ void OpDispatchBuilder::FLD(OpcodeArgs) {
     // Implicit arg
     auto offset = _Constant(Op->OP & 7);
     data = _And(_Add(orig_top, offset), mask);
-    data = _LoadContextIndexed(data, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+    data = _LoadContextIndexed(data, 16, MMBaseOffset(), 16, FPRClass);
   }
   OrderedNode *converted = data;
 
@@ -86,7 +86,7 @@ void OpDispatchBuilder::FLD(OpcodeArgs) {
   SetX87TopTag(top, X87Tag::Valid);
   SetX87Top(top);
   // Write to ST[TOP]
-  _StoreContextIndexed(converted, top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  _StoreContextIndexed(converted, top, 16, MMBaseOffset(), 16, FPRClass);
   //_StoreContext(converted, 16, offsetof(FEXCore::Core::CPUState, mm[7][0]));
 }
 
@@ -108,12 +108,12 @@ void OpDispatchBuilder::FBLD(OpcodeArgs) {
   // Read from memory
   OrderedNode *data = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], 16, Op->Flags, -1);
   OrderedNode *converted = _F80BCDLoad(data);
-  _StoreContextIndexed(converted, top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  _StoreContextIndexed(converted, top, 16, MMBaseOffset(), 16, FPRClass);
 }
 
 void OpDispatchBuilder::FBSTP(OpcodeArgs) {
   auto orig_top = GetX87Top();
-  auto data = _LoadContextIndexed(orig_top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  auto data = _LoadContextIndexed(orig_top, 16, MMBaseOffset(), 16, FPRClass);
 
   OrderedNode *converted = _F80BCDStore(data);
 
@@ -138,7 +138,7 @@ void OpDispatchBuilder::FLD_Const(OpcodeArgs) {
   OrderedNode *data = _VCastFromGPR(16, 8, low);
   data = _VInsGPR(16, 8, data, high, 1);
   // Write to ST[TOP]
-  _StoreContextIndexed(data, top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  _StoreContextIndexed(data, top, 16, MMBaseOffset(), 16, FPRClass);
 }
 
 template
@@ -191,13 +191,13 @@ void OpDispatchBuilder::FILD(OpcodeArgs) {
   converted = _VInsElement(16, 8, 1, 0, converted, _VCastFromGPR(16, 8, upper));
 
   // Write to ST[TOP]
-  _StoreContextIndexed(converted, top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  _StoreContextIndexed(converted, top, 16, MMBaseOffset(), 16, FPRClass);
 }
 
 template<size_t width>
 void OpDispatchBuilder::FST(OpcodeArgs) {
   auto orig_top = GetX87Top();
-  auto data = _LoadContextIndexed(orig_top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  auto data = _LoadContextIndexed(orig_top, 16, MMBaseOffset(), 16, FPRClass);
   if constexpr (width == 80) {
     StoreResult_WithOpSize(FPRClass, Op, Op->Dest, data, 10, 1);
   }
@@ -227,7 +227,7 @@ void OpDispatchBuilder::FIST(OpcodeArgs) {
   auto Size = GetSrcSize(Op);
 
   auto orig_top = GetX87Top();
-  OrderedNode *data = _LoadContextIndexed(orig_top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  OrderedNode *data = _LoadContextIndexed(orig_top, 16, MMBaseOffset(), 16, FPRClass);
   data = _F80CVTInt(data, Truncate, Size);
 
   StoreResult_WithOpSize(GPRClass, Op, Op->Dest, data, Size, 1);
@@ -275,10 +275,10 @@ void OpDispatchBuilder::FADD(OpcodeArgs) {
     if constexpr (ResInST0 == OpResult::RES_STI) {
       StackLocation = arg;
     }
-    b = _LoadContextIndexed(arg, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+    b = _LoadContextIndexed(arg, 16, MMBaseOffset(), 16, FPRClass);
   }
 
-  auto a = _LoadContextIndexed(top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  auto a = _LoadContextIndexed(top, 16, MMBaseOffset(), 16, FPRClass);
   auto result = _F80Add(a, b);
 
   if ((Op->TableInfo->Flags & X86Tables::InstFlags::FLAGS_POP) != 0) {
@@ -290,7 +290,7 @@ void OpDispatchBuilder::FADD(OpcodeArgs) {
   }
 
   // Write to ST[TOP]
-  _StoreContextIndexed(result, StackLocation, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  _StoreContextIndexed(result, StackLocation, 16, MMBaseOffset(), 16, FPRClass);
 }
 
 template
@@ -337,10 +337,10 @@ void OpDispatchBuilder::FMUL(OpcodeArgs) {
       StackLocation = arg;
     }
 
-    b = _LoadContextIndexed(arg, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+    b = _LoadContextIndexed(arg, 16, MMBaseOffset(), 16, FPRClass);
   }
 
-  auto a = _LoadContextIndexed(top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  auto a = _LoadContextIndexed(top, 16, MMBaseOffset(), 16, FPRClass);
 
   auto result = _F80Mul(a, b);
 
@@ -353,7 +353,7 @@ void OpDispatchBuilder::FMUL(OpcodeArgs) {
   }
 
   // Write to ST[TOP]
-  _StoreContextIndexed(result, StackLocation, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  _StoreContextIndexed(result, StackLocation, 16, MMBaseOffset(), 16, FPRClass);
 }
 
 template
@@ -400,10 +400,10 @@ void OpDispatchBuilder::FDIV(OpcodeArgs) {
       StackLocation = arg;
     }
 
-    b = _LoadContextIndexed(arg, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+    b = _LoadContextIndexed(arg, 16, MMBaseOffset(), 16, FPRClass);
   }
 
-  auto a = _LoadContextIndexed(top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  auto a = _LoadContextIndexed(top, 16, MMBaseOffset(), 16, FPRClass);
 
   OrderedNode *result{};
   if constexpr (reverse) {
@@ -422,7 +422,7 @@ void OpDispatchBuilder::FDIV(OpcodeArgs) {
   }
 
   // Write to ST[TOP]
-  _StoreContextIndexed(result, StackLocation, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  _StoreContextIndexed(result, StackLocation, 16, MMBaseOffset(), 16, FPRClass);
 }
 
 template
@@ -484,10 +484,10 @@ void OpDispatchBuilder::FSUB(OpcodeArgs) {
     if constexpr (ResInST0 == OpResult::RES_STI) {
       StackLocation = arg;
     }
-    b = _LoadContextIndexed(arg, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+    b = _LoadContextIndexed(arg, 16, MMBaseOffset(), 16, FPRClass);
   }
 
-  auto a = _LoadContextIndexed(top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  auto a = _LoadContextIndexed(top, 16, MMBaseOffset(), 16, FPRClass);
 
   OrderedNode *result{};
   if constexpr (reverse) {
@@ -507,7 +507,7 @@ void OpDispatchBuilder::FSUB(OpcodeArgs) {
   }
 
   // Write to ST[TOP]
-  _StoreContextIndexed(result, StackLocation, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  _StoreContextIndexed(result, StackLocation, 16, MMBaseOffset(), 16, FPRClass);
 }
 
 template
@@ -542,7 +542,7 @@ void OpDispatchBuilder::FSUB<32, true, true, OpDispatchBuilder::OpResult::RES_ST
 
 void OpDispatchBuilder::FCHS(OpcodeArgs) {
   auto top = GetX87Top();
-  auto a = _LoadContextIndexed(top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  auto a = _LoadContextIndexed(top, 16, MMBaseOffset(), 16, FPRClass);
 
   auto low = _Constant(0);
   auto high = _Constant(0b1'000'0000'0000'0000ULL);
@@ -552,12 +552,12 @@ void OpDispatchBuilder::FCHS(OpcodeArgs) {
   auto result = _VXor(a, data, 16, 1);
 
   // Write to ST[TOP]
-  _StoreContextIndexed(result, top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  _StoreContextIndexed(result, top, 16, MMBaseOffset(), 16, FPRClass);
 }
 
 void OpDispatchBuilder::FABS(OpcodeArgs) {
   auto top = GetX87Top();
-  auto a = _LoadContextIndexed(top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  auto a = _LoadContextIndexed(top, 16, MMBaseOffset(), 16, FPRClass);
 
   auto low = _Constant(~0ULL);
   auto high = _Constant(0b0'111'1111'1111'1111ULL);
@@ -567,12 +567,12 @@ void OpDispatchBuilder::FABS(OpcodeArgs) {
   auto result = _VAnd(a, data, 16, 1);
 
   // Write to ST[TOP]
-  _StoreContextIndexed(result, top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  _StoreContextIndexed(result, top, 16, MMBaseOffset(), 16, FPRClass);
 }
 
 void OpDispatchBuilder::FTST(OpcodeArgs) {
   auto top = GetX87Top();
-  auto a = _LoadContextIndexed(top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  auto a = _LoadContextIndexed(top, 16, MMBaseOffset(), 16, FPRClass);
 
   auto low = _Constant(0);
   OrderedNode *data = _VCastFromGPR(16, 8, low);
@@ -596,12 +596,12 @@ void OpDispatchBuilder::FTST(OpcodeArgs) {
 
 void OpDispatchBuilder::FRNDINT(OpcodeArgs) {
   auto top = GetX87Top();
-  auto a = _LoadContextIndexed(top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  auto a = _LoadContextIndexed(top, 16, MMBaseOffset(), 16, FPRClass);
 
   auto result = _F80Round(a);
 
   // Write to ST[TOP]
-  _StoreContextIndexed(result, top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  _StoreContextIndexed(result, top, 16, MMBaseOffset(), 16, FPRClass);
 }
 
 void OpDispatchBuilder::FXTRACT(OpcodeArgs) {
@@ -610,14 +610,14 @@ void OpDispatchBuilder::FXTRACT(OpcodeArgs) {
   SetX87TopTag(top, X87Tag::Valid);
   SetX87Top(top);
 
-  auto a = _LoadContextIndexed(orig_top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  auto a = _LoadContextIndexed(orig_top, 16, MMBaseOffset(), 16, FPRClass);
 
   auto exp = _F80XTRACT_EXP(a);
   auto sig = _F80XTRACT_SIG(a);
 
   // Write to ST[TOP]
-  _StoreContextIndexed(exp, orig_top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
-  _StoreContextIndexed(sig, top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  _StoreContextIndexed(exp, orig_top, 16, MMBaseOffset(), 16, FPRClass);
+  _StoreContextIndexed(sig, top, 16, MMBaseOffset(), 16, FPRClass);
 }
 
 void OpDispatchBuilder::FNINIT(OpcodeArgs) {
@@ -662,10 +662,10 @@ void OpDispatchBuilder::FCOMI(OpcodeArgs) {
     // Implicit arg
     auto offset = _Constant(Op->OP & 7);
     arg = _And(_Add(top, offset), mask);
-    b = _LoadContextIndexed(arg, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+    b = _LoadContextIndexed(arg, 16, MMBaseOffset(), 16, FPRClass);
   }
 
-  auto a = _LoadContextIndexed(top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  auto a = _LoadContextIndexed(top, 16, MMBaseOffset(), 16, FPRClass);
 
   OrderedNode *Res = _F80Cmp(a, b,
     (1 << FCMP_FLAG_EQ) |
@@ -739,12 +739,12 @@ void OpDispatchBuilder::FXCH(OpcodeArgs) {
   auto offset = _Constant(Op->OP & 7);
   arg = _And(_Add(top, offset), mask);
 
-  auto a = _LoadContextIndexed(top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
-  auto b = _LoadContextIndexed(arg, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  auto a = _LoadContextIndexed(top, 16, MMBaseOffset(), 16, FPRClass);
+  auto b = _LoadContextIndexed(arg, 16, MMBaseOffset(), 16, FPRClass);
 
   // Write to ST[TOP]
-  _StoreContextIndexed(b, top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
-  _StoreContextIndexed(a, arg, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  _StoreContextIndexed(b, top, 16, MMBaseOffset(), 16, FPRClass);
+  _StoreContextIndexed(a, arg, 16, MMBaseOffset(), 16, FPRClass);
 }
 
 void OpDispatchBuilder::FST(OpcodeArgs) {
@@ -757,10 +757,10 @@ void OpDispatchBuilder::FST(OpcodeArgs) {
   auto offset = _Constant(Op->OP & 7);
   arg = _And(_Add(top, offset), mask);
 
-  auto a = _LoadContextIndexed(top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  auto a = _LoadContextIndexed(top, 16, MMBaseOffset(), 16, FPRClass);
 
   // Write to ST[TOP]
-  _StoreContextIndexed(a, arg, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  _StoreContextIndexed(a, arg, 16, MMBaseOffset(), 16, FPRClass);
 
   if ((Op->TableInfo->Flags & X86Tables::InstFlags::FLAGS_POP) != 0) {
     // if we are popping then we must first mark this location as empty
@@ -773,14 +773,14 @@ void OpDispatchBuilder::FST(OpcodeArgs) {
 template<FEXCore::IR::IROps IROp>
 void OpDispatchBuilder::X87UnaryOp(OpcodeArgs) {
   auto top = GetX87Top();
-  auto a = _LoadContextIndexed(top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  auto a = _LoadContextIndexed(top, 16, MMBaseOffset(), 16, FPRClass);
 
   auto result = _F80Round(a);
   // Overwrite the op
   result.first->Header.Op = IROp;
 
   // Write to ST[TOP]
-  _StoreContextIndexed(result, top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  _StoreContextIndexed(result, top, 16, MMBaseOffset(), 16, FPRClass);
 }
 
 template
@@ -799,8 +799,8 @@ void OpDispatchBuilder::X87BinaryOp(OpcodeArgs) {
   auto mask = _Constant(7);
   OrderedNode *st1 = _And(_Add(top, _Constant(1)), mask);
 
-  auto a = _LoadContextIndexed(top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
-  st1 = _LoadContextIndexed(st1, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  auto a = _LoadContextIndexed(top, 16, MMBaseOffset(), 16, FPRClass);
+  st1 = _LoadContextIndexed(st1, 16, MMBaseOffset(), 16, FPRClass);
 
   auto result = _F80Add(a, st1);
   // Overwrite the op
@@ -812,7 +812,7 @@ void OpDispatchBuilder::X87BinaryOp(OpcodeArgs) {
   }
 
   // Write to ST[TOP]
-  _StoreContextIndexed(result, top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  _StoreContextIndexed(result, top, 16, MMBaseOffset(), 16, FPRClass);
 }
 
 template
@@ -846,14 +846,14 @@ void OpDispatchBuilder::X87SinCos(OpcodeArgs) {
   SetX87TopTag(top, X87Tag::Valid);
   SetX87Top(top);
 
-  auto a = _LoadContextIndexed(orig_top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  auto a = _LoadContextIndexed(orig_top, 16, MMBaseOffset(), 16, FPRClass);
 
   auto sin = _F80SIN(a);
   auto cos = _F80COS(a);
 
   // Write to ST[TOP]
-  _StoreContextIndexed(sin, orig_top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
-  _StoreContextIndexed(cos, top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  _StoreContextIndexed(sin, orig_top, 16, MMBaseOffset(), 16, FPRClass);
+  _StoreContextIndexed(cos, top, 16, MMBaseOffset(), 16, FPRClass);
 }
 
 void OpDispatchBuilder::X87FYL2X(OpcodeArgs) {
@@ -865,8 +865,8 @@ void OpDispatchBuilder::X87FYL2X(OpcodeArgs) {
   auto top = _And(_Add(orig_top, _Constant(1)), _Constant(7));
   SetX87Top(top);
 
-  OrderedNode *st0 = _LoadContextIndexed(orig_top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
-  OrderedNode *st1 = _LoadContextIndexed(top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  OrderedNode *st0 = _LoadContextIndexed(orig_top, 16, MMBaseOffset(), 16, FPRClass);
+  OrderedNode *st1 = _LoadContextIndexed(top, 16, MMBaseOffset(), 16, FPRClass);
 
   if (Plus1) {
     auto low = _Constant(0x8000'0000'0000'0000ULL);
@@ -879,7 +879,7 @@ void OpDispatchBuilder::X87FYL2X(OpcodeArgs) {
   auto result = _F80FYL2X(st0, st1);
 
   // Write to ST[TOP]
-  _StoreContextIndexed(result, top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  _StoreContextIndexed(result, top, 16, MMBaseOffset(), 16, FPRClass);
 }
 
 void OpDispatchBuilder::X87TAN(OpcodeArgs) {
@@ -888,7 +888,7 @@ void OpDispatchBuilder::X87TAN(OpcodeArgs) {
   SetX87TopTag(top, X87Tag::Valid);
   SetX87Top(top);
 
-  auto a = _LoadContextIndexed(orig_top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  auto a = _LoadContextIndexed(orig_top, 16, MMBaseOffset(), 16, FPRClass);
 
   auto result = _F80TAN(a);
 
@@ -898,8 +898,8 @@ void OpDispatchBuilder::X87TAN(OpcodeArgs) {
   data = _VInsGPR(16, 8, data, high, 1);
 
   // Write to ST[TOP]
-  _StoreContextIndexed(result, orig_top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
-  _StoreContextIndexed(data, top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  _StoreContextIndexed(result, orig_top, 16, MMBaseOffset(), 16, FPRClass);
+  _StoreContextIndexed(data, top, 16, MMBaseOffset(), 16, FPRClass);
 }
 
 void OpDispatchBuilder::X87ATAN(OpcodeArgs) {
@@ -909,13 +909,13 @@ void OpDispatchBuilder::X87ATAN(OpcodeArgs) {
   auto top = _And(_Add(orig_top, _Constant(1)), _Constant(7));
   SetX87Top(top);
 
-  auto a = _LoadContextIndexed(orig_top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
-  OrderedNode *st1 = _LoadContextIndexed(top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  auto a = _LoadContextIndexed(orig_top, 16, MMBaseOffset(), 16, FPRClass);
+  OrderedNode *st1 = _LoadContextIndexed(top, 16, MMBaseOffset(), 16, FPRClass);
 
   auto result = _F80ATAN(st1, a);
 
   // Write to ST[TOP]
-  _StoreContextIndexed(result, top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  _StoreContextIndexed(result, top, 16, MMBaseOffset(), 16, FPRClass);
 }
 
 void OpDispatchBuilder::X87LDENV(OpcodeArgs) {
@@ -1169,14 +1169,14 @@ void OpDispatchBuilder::X87FNSAVE(OpcodeArgs) {
   auto SevenConst = _Constant(7);
   auto TenConst = _Constant(10);
   for (int i = 0; i < 7; ++i) {
-    auto data = _LoadContextIndexed(Top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+    auto data = _LoadContextIndexed(Top, 16, MMBaseOffset(), 16, FPRClass);
     _StoreMem(FPRClass, 16, ST0Location, data, 1);
     ST0Location = _Add(ST0Location, TenConst);
     Top = _And(_Add(Top, OneConst), SevenConst);
   }
 
   // The final st(7) needs a bit of special handling here
-  auto data = _LoadContextIndexed(Top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  auto data = _LoadContextIndexed(Top, 16, MMBaseOffset(), 16, FPRClass);
   // ST7 broken in to two parts
   // Lower 64bits [63:0]
   // upper 16 bits [79:64]
@@ -1238,7 +1238,7 @@ void OpDispatchBuilder::X87FRSTOR(OpcodeArgs) {
     // Mask off the top bits
     Reg = _VAnd(16, 16, Reg, Mask);
 
-    _StoreContextIndexed(Reg, Top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+    _StoreContextIndexed(Reg, Top, 16, MMBaseOffset(), 16, FPRClass);
 
     ST0Location = _Add(ST0Location, TenConst);
     Top = _And(_Add(Top, OneConst), SevenConst);
@@ -1253,12 +1253,12 @@ void OpDispatchBuilder::X87FRSTOR(OpcodeArgs) {
   ST0Location = _Add(ST0Location, _Constant(8));
   OrderedNode *RegHigh = _LoadMem(FPRClass, 2, ST0Location, 1);
   Reg = _VInsElement(16, 2, 4, 0, Reg, RegHigh);
-  _StoreContextIndexed(Reg, Top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  _StoreContextIndexed(Reg, Top, 16, MMBaseOffset(), 16, FPRClass);
 }
 
 void OpDispatchBuilder::X87FXAM(OpcodeArgs) {
   auto top = GetX87Top();
-  auto a = _LoadContextIndexed(top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  auto a = _LoadContextIndexed(top, 16, MMBaseOffset(), 16, FPRClass);
   OrderedNode *Result = _VExtractToGPR(16, 8, a, 1);
 
   // Extract the sign bit
@@ -1370,12 +1370,12 @@ void OpDispatchBuilder::X87FCMOV(OpcodeArgs) {
   auto offset = _Constant(Op->OP & 7);
   arg = _And(_Add(top, offset), mask);
 
-  auto a = _LoadContextIndexed(top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
-  auto b = _LoadContextIndexed(arg, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  auto a = _LoadContextIndexed(top, 16, MMBaseOffset(), 16, FPRClass);
+  auto b = _LoadContextIndexed(arg, 16, MMBaseOffset(), 16, FPRClass);
   auto Result = _VBSL(VecCond, b, a);
 
   // Write to ST[TOP]
-  _StoreContextIndexed(Result, top, 16, offsetof(FEXCore::Core::CPUState, mm[0][0]), 16, FPRClass);
+  _StoreContextIndexed(Result, top, 16, MMBaseOffset(), 16, FPRClass);
 }
 
 void OpDispatchBuilder::X87EMMS(OpcodeArgs) {

--- a/External/FEXCore/include/FEXCore/Core/X86Enums.h
+++ b/External/FEXCore/include/FEXCore/Core/X86Enums.h
@@ -1,125 +1,134 @@
 #pragma once
 
+#include <cstdint>
+
 namespace FEXCore::X86State {
 /**
  * @name The ordered of the GPRs from name to index
  * @{ */
-constexpr unsigned REG_RAX = 0;
-constexpr unsigned REG_RBX = 1;
-constexpr unsigned REG_RCX = 2;
-constexpr unsigned REG_RDX = 3;
-constexpr unsigned REG_RSI = 4;
-constexpr unsigned REG_RDI = 5;
-constexpr unsigned REG_RBP = 6;
-constexpr unsigned REG_RSP = 7;
-constexpr unsigned REG_R8  = 8;
-constexpr unsigned REG_R9  = 9;
-constexpr unsigned REG_R10 = 10;
-constexpr unsigned REG_R11 = 11;
-constexpr unsigned REG_R12 = 12;
-constexpr unsigned REG_R13 = 13;
-constexpr unsigned REG_R14 = 14;
-constexpr unsigned REG_R15 = 15;
-constexpr unsigned REG_XMM_0  = 16;
-constexpr unsigned REG_XMM_1  = 17;
-constexpr unsigned REG_XMM_2  = 18;
-constexpr unsigned REG_XMM_3  = 19;
-constexpr unsigned REG_XMM_4  = 20;
-constexpr unsigned REG_XMM_5  = 21;
-constexpr unsigned REG_XMM_6  = 22;
-constexpr unsigned REG_XMM_7  = 23;
-constexpr unsigned REG_XMM_8  = 24;
-constexpr unsigned REG_XMM_9  = 25;
-constexpr unsigned REG_XMM_10 = 26;
-constexpr unsigned REG_XMM_11 = 27;
-constexpr unsigned REG_XMM_12 = 28;
-constexpr unsigned REG_XMM_13 = 29;
-constexpr unsigned REG_XMM_14 = 30;
-constexpr unsigned REG_XMM_15 = 31;
-constexpr unsigned REG_MM_0   = 32;
-constexpr unsigned REG_MM_1   = 33;
-constexpr unsigned REG_MM_2   = 34;
-constexpr unsigned REG_MM_3   = 35;
-constexpr unsigned REG_MM_4   = 36;
-constexpr unsigned REG_MM_5   = 37;
-constexpr unsigned REG_MM_6   = 38;
-constexpr unsigned REG_MM_7   = 39;
-constexpr unsigned REG_INVALID = 255;
+enum X86Reg : uint32_t {
+  REG_RAX     = 0,
+  REG_RBX     = 1,
+  REG_RCX     = 2,
+  REG_RDX     = 3,
+  REG_RSI     = 4,
+  REG_RDI     = 5,
+  REG_RBP     = 6,
+  REG_RSP     = 7,
+  REG_R8      = 8,
+  REG_R9      = 9,
+  REG_R10     = 10,
+  REG_R11     = 11,
+  REG_R12     = 12,
+  REG_R13     = 13,
+  REG_R14     = 14,
+  REG_R15     = 15,
+  REG_XMM_0   = 16,
+  REG_XMM_1   = 17,
+  REG_XMM_2   = 18,
+  REG_XMM_3   = 19,
+  REG_XMM_4   = 20,
+  REG_XMM_5   = 21,
+  REG_XMM_6   = 22,
+  REG_XMM_7   = 23,
+  REG_XMM_8   = 24,
+  REG_XMM_9   = 25,
+  REG_XMM_10  = 26,
+  REG_XMM_11  = 27,
+  REG_XMM_12  = 28,
+  REG_XMM_13  = 29,
+  REG_XMM_14  = 30,
+  REG_XMM_15  = 31,
+  REG_MM_0    = 32,
+  REG_MM_1    = 33,
+  REG_MM_2    = 34,
+  REG_MM_3    = 35,
+  REG_MM_4    = 36,
+  REG_MM_5    = 37,
+  REG_MM_6    = 38,
+  REG_MM_7    = 39,
+  REG_INVALID = 255,
+};
 /**  @} */
 
 /**
  * @name RFLAG register bit locations
  * @{ */
-constexpr unsigned RFLAG_CF_LOC   = 0;
-constexpr unsigned RFLAG_PF_LOC   = 2;
-constexpr unsigned RFLAG_AF_LOC   = 4;
-constexpr unsigned RFLAG_ZF_LOC   = 6;
-constexpr unsigned RFLAG_SF_LOC   = 7;
-constexpr unsigned RFLAG_TF_LOC   = 8;
-constexpr unsigned RFLAG_IF_LOC   = 9;
-constexpr unsigned RFLAG_DF_LOC   = 10;
-constexpr unsigned RFLAG_OF_LOC   = 11;
-constexpr unsigned RFLAG_IOPL_LOC = 12;
-constexpr unsigned RFLAG_NT_LOC   = 14;
-constexpr unsigned RFLAG_RF_LOC   = 16;
-constexpr unsigned RFLAG_VM_LOC   = 17;
-constexpr unsigned RFLAG_AC_LOC   = 18;
-constexpr unsigned RFLAG_VIF_LOC  = 19;
-constexpr unsigned RFLAG_VIP_LOC  = 20;
-constexpr unsigned RFLAG_ID_LOC   = 21;
-
+enum X86RegLocation : uint32_t {
+  RFLAG_CF_LOC    = 0,
+  RFLAG_PF_LOC    = 2,
+  RFLAG_AF_LOC    = 4,
+  RFLAG_ZF_LOC    = 6,
+  RFLAG_SF_LOC    = 7,
+  RFLAG_TF_LOC    = 8,
+  RFLAG_IF_LOC    = 9,
+  RFLAG_DF_LOC    = 10,
+  RFLAG_OF_LOC    = 11,
+  RFLAG_IOPL_LOC  = 12,
+  RFLAG_NT_LOC    = 14,
+  RFLAG_RF_LOC    = 16,
+  RFLAG_VM_LOC    = 17,
+  RFLAG_AC_LOC    = 18,
+  RFLAG_VIF_LOC   = 19,
+  RFLAG_VIP_LOC   = 20,
+  RFLAG_ID_LOC    = 21,
 
 // So we can share flag handling logic, we put x87 flags after RFLAGS
-constexpr unsigned X87FLAG_BASE   = 32;
-constexpr unsigned X87FLAG_IE_LOC = 32;
-constexpr unsigned X87FLAG_DE_LOC = 33;
-constexpr unsigned X87FLAG_ZE_LOC = 34;
-constexpr unsigned X87FLAG_OE_LOC = 35;
-constexpr unsigned X87FLAG_UE_LOC = 36;
-constexpr unsigned X87FLAG_PE_LOC = 37;
-constexpr unsigned X87FLAG_SF_LOC = 38;
-constexpr unsigned X87FLAG_ES_LOC = 39;
-constexpr unsigned X87FLAG_C0_LOC = 40;
-constexpr unsigned X87FLAG_C1_LOC = 41;
-constexpr unsigned X87FLAG_C2_LOC = 42;
-constexpr unsigned X87FLAG_TOP_LOC = 43; // 3 Bits wide
-constexpr unsigned X87FLAG_C3_LOC = 46;
-constexpr unsigned X87FLAG_B_LOC = 47;
+  X87FLAG_BASE    = 32,
+  X87FLAG_IE_LOC  = 32,
+  X87FLAG_DE_LOC  = 33,
+  X87FLAG_ZE_LOC  = 34,
+  X87FLAG_OE_LOC  = 35,
+  X87FLAG_UE_LOC  = 36,
+  X87FLAG_PE_LOC  = 37,
+  X87FLAG_SF_LOC  = 38,
+  X87FLAG_ES_LOC  = 39,
+  X87FLAG_C0_LOC  = 40,
+  X87FLAG_C1_LOC  = 41,
+  X87FLAG_C2_LOC  = 42,
+  X87FLAG_TOP_LOC = 43, // 3 Bits wide
+  X87FLAG_C3_LOC  = 46,
+  X87FLAG_B_LOC   = 47,
+};
 
 // X86 trap number definitions
-constexpr unsigned X86_TRAPNO_DE      = 0; // Divide-by-zero
-constexpr unsigned X86_TRAPNO_DB      = 1; // Debug
-constexpr unsigned X86_TRAPNO_NMI     = 2; // Non-maskable interrupt
-constexpr unsigned X86_TRAPNO_BP      = 3; // Breakpoint
-constexpr unsigned X86_TRAPNO_OF      = 4; // Overflow
-constexpr unsigned X86_TRAPNO_BR      = 5; // Bound range exceeded
-constexpr unsigned X86_TRAPNO_UD      = 6; // Invalid opcode
-constexpr unsigned X86_TRAPNO_NM      = 7; // Device not available
-constexpr unsigned X86_TRAPNO_DF      = 8; // Double fault
-constexpr unsigned X86_TRAPNO_OLD_MF  = 9; // Coprocessor segment overrun
-constexpr unsigned X86_TRAPNO_TS      = 10; // Invalid TSS
-constexpr unsigned X86_TRAPNO_NP      = 11; // Segment not present
-constexpr unsigned X86_TRAPNO_SS      = 12; // Stack segmentation fault
-constexpr unsigned X86_TRAPNO_GP      = 13; // General Protection fault
-constexpr unsigned X86_TRAPNO_PF      = 14; // Page fault
-constexpr unsigned X86_TRAPNO_SPURIOUS = 15; // Spurious interrupt
-constexpr unsigned X86_TRAPNO_MF       = 16; // X87 float exception
-constexpr unsigned X86_TRAPNO_AC       = 17; // Alignment check
-constexpr unsigned X86_TRAPNO_MC       = 18; // Machine check
-constexpr unsigned X86_TRAPNO_XF       = 19; // SIMD floating point exception
-constexpr unsigned X86_TRAPNO_VE       = 20; // Virtualization exception
-constexpr unsigned X86_TRAPNO_CP       = 21; // Control protection exception
-constexpr unsigned X86_TRAPNO_VC       = 29; // VMM communication exception
-constexpr unsigned X86_TRAPNO_IRET     = 32; // IRET exception
+enum X86TrapNo : uint32_t {
+  X86_TRAPNO_DE       = 0,  // Divide-by-zero
+  X86_TRAPNO_DB       = 1,  // Debug
+  X86_TRAPNO_NMI      = 2,  // Non-maskable interrupt
+  X86_TRAPNO_BP       = 3,  // Breakpoint
+  X86_TRAPNO_OF       = 4,  // Overflow
+  X86_TRAPNO_BR       = 5,  // Bound range exceeded
+  X86_TRAPNO_UD       = 6,  // Invalid opcode
+  X86_TRAPNO_NM       = 7,  // Device not available
+  X86_TRAPNO_DF       = 8,  // Double fault
+  X86_TRAPNO_OLD_MF   = 9,  // Coprocessor segment overrun
+  X86_TRAPNO_TS       = 10, // Invalid TSS
+  X86_TRAPNO_NP       = 11, // Segment not present
+  X86_TRAPNO_SS       = 12, // Stack segmentation fault
+  X86_TRAPNO_GP       = 13, // General Protection fault
+  X86_TRAPNO_PF       = 14, // Page fault
+  X86_TRAPNO_SPURIOUS = 15, // Spurious interrupt
+  X86_TRAPNO_MF       = 16, // X87 float exception
+  X86_TRAPNO_AC       = 17, // Alignment check
+  X86_TRAPNO_MC       = 18, // Machine check
+  X86_TRAPNO_XF       = 19, // SIMD floating point exception
+  X86_TRAPNO_VE       = 20, // Virtualization exception
+  X86_TRAPNO_CP       = 21, // Control protection exception
+  X86_TRAPNO_VC       = 29, // VMM communication exception
+  X86_TRAPNO_IRET     = 32, // IRET exception
+};
 
 // X86 page fault error code bits
 // Populates siginfo gregs[REG_ERR]
-constexpr unsigned X86_PF_PROT  = (1 << 0); // 0: No page found 1: protection fault
-constexpr unsigned X86_PF_WRITE = (1 << 1); // 0: Access was read 1: Access was write
-constexpr unsigned X86_PF_USER  = (1 << 2); // 0: Kernel mode access 1: user-mode access
-constexpr unsigned X86_PF_RSV   = (1 << 3); // 1: Reserved bit?
-constexpr unsigned X86_PF_INSTR = (1 << 4); // 1: Fault from instruction fetch
-constexpr unsigned X86_PF_PK    = (1 << 5); // 1: Protection keys block access
-constexpr unsigned X86_PF_SGX   = (1 << 6); // 1: SGX MMU fault
+enum X86PageFaultBit : uint32_t {
+  X86_PF_PROT  = (1 << 0), // 0: No page found 1: protection fault
+  X86_PF_WRITE = (1 << 1), // 0: Access was read 1: Access was write
+  X86_PF_USER  = (1 << 2), // 0: Kernel mode access 1: user-mode access
+  X86_PF_RSV   = (1 << 3), // 1: Reserved bit?
+  X86_PF_INSTR = (1 << 4), // 1: Fault from instruction fetch
+  X86_PF_PK    = (1 << 5), // 1: Protection keys block access
+  X86_PF_SGX   = (1 << 6), // 1: SGX MMU fault
+};
 
-}
+} // namespace FEXCore::X86State


### PR DESCRIPTION
Previously, getting the offset of a register involved a long string of code via offsetof to get. We can wrap these behind two helper functions to make writing code that requires offsets a little more convenient