### PR TITLE
OpcodeDispatcher: Amend return types of BitSize helpers

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -4466,11 +4466,11 @@ uint8_t OpDispatchBuilder::GetSrcSize(X86Tables::DecodedOp Op) const {
   return Size;
 }
 
-uint8_t OpDispatchBuilder::GetSrcBitSize(X86Tables::DecodedOp Op) const {
+uint32_t OpDispatchBuilder::GetSrcBitSize(X86Tables::DecodedOp Op) const {
   return GetSrcSize(Op) * 8;
 }
 
-uint8_t OpDispatchBuilder::GetDstBitSize(X86Tables::DecodedOp Op) const {
+uint32_t OpDispatchBuilder::GetDstBitSize(X86Tables::DecodedOp Op) const {
   return GetDstSize(Op) * 8;
 }
 

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -528,10 +528,10 @@ private:
     return static_cast<uint32_t>(offsetof(Core::CPUState, mm[0][0]));
   }
 
-  uint8_t GetDstSize(X86Tables::DecodedOp Op) const;
-  uint8_t GetSrcSize(X86Tables::DecodedOp Op) const;
-  uint32_t GetDstBitSize(X86Tables::DecodedOp Op) const;
-  uint32_t GetSrcBitSize(X86Tables::DecodedOp Op) const;
+  [[nodiscard]] uint8_t GetDstSize(X86Tables::DecodedOp Op) const;
+  [[nodiscard]] uint8_t GetSrcSize(X86Tables::DecodedOp Op) const;
+  [[nodiscard]] uint32_t GetDstBitSize(X86Tables::DecodedOp Op) const;
+  [[nodiscard]] uint32_t GetSrcBitSize(X86Tables::DecodedOp Op) const;
 
   template<unsigned BitOffset>
   void SetRFLAG(OrderedNode *Value) {

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -530,8 +530,8 @@ private:
 
   uint8_t GetDstSize(X86Tables::DecodedOp Op) const;
   uint8_t GetSrcSize(X86Tables::DecodedOp Op) const;
-  uint8_t GetDstBitSize(X86Tables::DecodedOp Op) const;
-  uint8_t GetSrcBitSize(X86Tables::DecodedOp Op) const;
+  uint32_t GetDstBitSize(X86Tables::DecodedOp Op) const;
+  uint32_t GetSrcBitSize(X86Tables::DecodedOp Op) const;
 
   template<unsigned BitOffset>
   void SetRFLAG(OrderedNode *Value) {

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -521,7 +521,7 @@ private:
 
   [[nodiscard]] static uint32_t GPROffset(X86State::X86Reg reg) {
     LOGMAN_THROW_A_FMT(reg <= X86State::X86Reg::REG_R15, "Invalid reg used");
-    return static_cast<uint8_t>(offsetof(Core::CPUState, gregs[static_cast<size_t>(reg)]));
+    return static_cast<uint32_t>(offsetof(Core::CPUState, gregs[static_cast<size_t>(reg)]));
   }
 
   [[nodiscard]] static uint32_t MMBaseOffset() {


### PR DESCRIPTION
Amends the return size to handle a concern brought up by neobrain in #1362 

While we're at it, we can mark these helper functions as `[[nodiscard]]` to catch obvious bugs