### PR TITLE
InterpreterCore/Dispatcher: Resolve unused variable warnings

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
@@ -92,8 +92,8 @@ void Dispatcher::RestoreThreadState(void *ucontext) {
     }
 
     if (!(Context->Flags & ArchHelpers::Context::ContextFlags::CONTEXT_FLAG_32BIT)) {
-      FEXCore::x86_64::ucontext_t *guest_uctx = reinterpret_cast<FEXCore::x86_64::ucontext_t*>(Context->UContextLocation);
-      siginfo_t *guest_siginfo = reinterpret_cast<siginfo_t*>(Context->SigInfoLocation);
+      auto *guest_uctx = reinterpret_cast<FEXCore::x86_64::ucontext_t*>(Context->UContextLocation);
+      [[maybe_unused]] auto *guest_siginfo = reinterpret_cast<siginfo_t*>(Context->SigInfoLocation);
 
       // If the guest modified the RIP then we need to take special precautions here
       if (Context->OriginalRIP != guest_uctx->uc_mcontext.gregs[FEXCore::x86_64::FEX_REG_RIP]) {
@@ -127,8 +127,8 @@ void Dispatcher::RestoreThreadState(void *ucontext) {
       }
     }
     else {
-      FEXCore::x86::ucontext_t *guest_uctx = reinterpret_cast<FEXCore::x86::ucontext_t*>(Context->UContextLocation);
-      FEXCore::x86::siginfo_t *guest_siginfo = reinterpret_cast<FEXCore::x86::siginfo_t*>(Context->SigInfoLocation);
+      auto *guest_uctx = reinterpret_cast<FEXCore::x86::ucontext_t*>(Context->UContextLocation);
+      [[maybe_unused]] auto *guest_siginfo = reinterpret_cast<FEXCore::x86::siginfo_t*>(Context->SigInfoLocation);
       // If the guest modified the RIP then we need to take special precautions here
       if (Context->OriginalRIP != guest_uctx->uc_mcontext.gregs[FEXCore::x86::FEX_REG_EIP]) {
         // Hack! Go back to the top of the dispatcher top

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -67,7 +67,6 @@ InterpreterCore::InterpreterCore(FEXCore::Context::Context *ctx, FEXCore::Core::
 
 #ifdef _M_ARM_64
     CTX->SignalDelegation->RegisterHostSignalHandler(SIGBUS, [](FEXCore::Core::InternalThreadState *Thread, int Signal, void *info, void *ucontext) -> bool {
-      InterpreterCore *Core = reinterpret_cast<InterpreterCore*>(Thread->CPUBackend.get());
       return FEXCore::ArchHelpers::Arm64::HandleSIGBUS(true, Signal, info, ucontext);
     }, true);
 #endif


### PR DESCRIPTION
Just resolves three unused variable warnings that cropped up over time

I've marked the guest_siginfo instances in the dispatcher as `[[maybe_unused]]`, since I wasn't sure if they were going to be used in the future. I can remove them entirely if they don't have any future use.