### PR TITLE
Frontend: Handle VEX RXB bits

### DIFF
--- a/unittests/ASM/VEX/bextr.asm
+++ b/unittests/ASM/VEX/bextr.asm
@@ -1,18 +1,19 @@
 %ifdef CONFIG
 {
   "RegData": {
-      "RAX": "0x7F",
       "RBX": "0",
       "RDX": "0xFF",
-      "RSI": "0"
+      "RSI": "0",
+      "R14": "0x7F",
+      "R15": "0x838"
   }
 }
 %endif
 
 ; General extraction
-mov rax, 0x7FFFFFFFFFFFFFFF
-mov rbx, 0x838              ; Start at bit 56 and extract 8 bits
-bextr rax, rax, rbx         ; This results in 0x7F being placed into RAX
+mov r14, 0x7FFFFFFFFFFFFFFF
+mov r15, 0x838              ; Start at bit 56 and extract 8 bits
+bextr r14, r14, r15         ; This results in 0x7F being placed into RAX
 
 ; Extraction with 0 bits should clear the destination
 mov rbx, -1


### PR DESCRIPTION
These are equivalent to the REX prefix's RXB bits, except that they're in 1's complement form. These are trivial to handle and fix usages of the upper range of registers for ModRM encoded fields.

To ensure that we have coverage for existing possible usages, I've altered the BEXTR test to make use of R14 and R15.