### PR TITLE
Dispatcher: Use std::vector as the underlying container for std::stack

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
@@ -80,7 +80,7 @@ protected:
 
   ArchHelpers::Context::ContextBackup* StoreThreadState(int Signal, void *ucontext);
   void RestoreThreadState(void *ucontext);
-  std::stack<uint64_t> SignalFrames;
+  std::stack<uint64_t, std::vector<uint64_t>> SignalFrames;
 
   bool SRAEnabled = false;
   virtual void SpillSRA(void *ucontext, uint32_t IgnoreMask) {}


### PR DESCRIPTION
C++, the language of the wrong defaults 🎉

This probably doesn't have significant impact, but it's an easy trap to avoid.