### PR TITLE
FEXCore: Fixes ERROR_AND_DIE

### DIFF
--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -142,6 +142,7 @@ set (SRCS
   Utils/Allocator.cpp
   Utils/Allocator/64BitAllocator.cpp
   Utils/FileLoading.cpp
+  Utils/ForcedAssert.cpp
   Utils/LogManager.cpp
   Utils/Telemetry.cpp
   Utils/Threads.cpp

--- a/External/FEXCore/Source/Utils/ForcedAssert.cpp
+++ b/External/FEXCore/Source/Utils/ForcedAssert.cpp
@@ -1,0 +1,14 @@
+namespace FEXCore::Assert {
+  // This function can not be inlined
+  [[noreturn]]
+  __attribute__((noinline, naked))
+  void ForcedAssert() {
+#ifdef _M_X86_64
+    asm volatile("ud2");
+#else
+    asm volatile("hlt #1");
+#endif
+  }
+}
+
+

--- a/External/FEXCore/include/FEXCore/Utils/CompilerDefs.h
+++ b/External/FEXCore/include/FEXCore/Utils/CompilerDefs.h
@@ -1,5 +1,4 @@
 #pragma once
-
 // Contains general abstractions related to compilers used to build FEX.
 
 // Specifies the minimum alignment for a variable or structure field, measured in bytes.
@@ -21,9 +20,15 @@
 #define FEX_PACKED __attribute__((packed))
 
 // Causes execution to exit abnormally.
-#define FEX_TRAP_EXECUTION __builtin_trap()
+#define FEX_TRAP_EXECUTION FEXCore::Assert::ForcedAssert()
 
 // Dictates to the compiler that the path this is on should not be reachable
 // from normal execution control flow. If normal execution does reach this,
 // then program behavior is undefined.
 #define FEX_UNREACHABLE __builtin_unreachable()
+
+namespace FEXCore::Assert {
+  // This function can not be inlined
+  [[noreturn]]
+  FEX_DEFAULT_VISIBILITY void ForcedAssert();
+}

--- a/Source/Tests/LinuxSyscalls/SignalDelegator.cpp
+++ b/Source/Tests/LinuxSyscalls/SignalDelegator.cpp
@@ -241,6 +241,12 @@ namespace FEX::HLE {
     return true;
   }
 
+  void SignalDelegator::UninstallHostHandler(int Signal) {
+    SignalHandler &SignalHandler = HostHandlers[Signal];
+
+    ::syscall(SYS_rt_sigaction, Signal, &SignalHandler.OldAction, nullptr, 8);
+  }
+
   SignalDelegator::SignalDelegator() {
     // Register this delegate
     LOGMAN_THROW_A(!GlobalDelegator, "Can't register global delegator multiple times!");

--- a/Source/Tests/LinuxSyscalls/SignalDelegator.h
+++ b/Source/Tests/LinuxSyscalls/SignalDelegator.h
@@ -55,6 +55,7 @@ namespace FEX::HLE {
       uint64_t GuestSignalFD(int fd, const uint64_t *set, size_t sigsetsize , int flags);
     /**  @} */
 
+      void UninstallHostHandler(int Signal);
   protected:
     // Called from the thunk handler to handle the signal
     void HandleGuestSignal(FEXCore::Core::InternalThreadState *Thread, int Signal, void *Info, void *UContext) override;


### PR DESCRIPTION
ERROR_AND_DIE was using __builtin_trap which would send our application
either a SIGILL or SIGTRAP depending on architecture.
This would then be captured by our faulting system and passed over to
the guest application.

If the guest application happened to have a signal handler installed for
these then it would pick up this fault and potentially continue
unsafely.

Now we can remove this usage of __builtin_trap and switch over to our
own handler.

Our frontend will check to see if the fault came from our handler and
uninstall the host signal handlers in this case. Which is what we want
for "ERROR_AND_DIE"