### PR TITLE
FEXCore: Supports guest SIGILL 

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
@@ -251,6 +251,17 @@ Arm64Dispatcher::Arm64Dispatcher(FEXCore::Context::Context *ctx, FEXCore::Core::
   }
 
   {
+    // Guest SIGILL handler
+    // Needs to be distinct from the SignalHandlerReturnAddress
+    UnimplementedInstructionAddress = GetCursorAddress<uint64_t>();
+
+    if (SRAEnabled)
+      SpillStaticRegs();
+
+    hlt(0);
+  }
+
+  {
     ThreadPauseHandlerAddressSpillSRA = GetCursorAddress<uint64_t>();
     if (SRAEnabled)
       SpillStaticRegs();

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
@@ -48,6 +48,8 @@ public:
   uint64_t ThreadPauseHandlerAddressSpillSRA{};
   uint64_t ExitFunctionLinkerAddress{};
   uint64_t SignalHandlerReturnAddress{};
+  uint64_t UnimplementedInstructionAddress{};
+
   uint64_t PauseReturnInstruction{};
 
   /**  @} */

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/X86Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/X86Dispatcher.cpp
@@ -141,7 +141,7 @@ X86Dispatcher::X86Dispatcher(FEXCore::Context::Context *ctx, FEXCore::Core::Inte
     je(NoBlock);
 
     // Update L1
-    
+
     mov(r13, Thread->LookupCache->GetL1Pointer());
     mov(rcx, rdx);
     and_(rcx, LookupCache::L1_ENTRIES_MASK);
@@ -274,10 +274,15 @@ X86Dispatcher::X86Dispatcher(FEXCore::Context::Context *ctx, FEXCore::Core::Inte
   {
     // Signal return handler
     SignalHandlerReturnAddress = getCurr<uint64_t>();
-
     ud2();
   }
 
+  {
+    // Guest SIGILL handler
+    // Needs to be distinct from the SignalHandlerReturnAddress
+    UnimplementedInstructionAddress = getCurr<uint64_t>();
+    ud2();
+  }
 
   {
     ReturnPtr = getCurr<FEXCore::Context::Context::IntCallbackReturn>();

--- a/External/FEXCore/Source/Interface/Core/Frontend.h
+++ b/External/FEXCore/Source/Interface/Core/Frontend.h
@@ -27,7 +27,7 @@ public:
 
   Decoder(FEXCore::Context::Context *ctx);
   ~Decoder();
-  bool DecodeInstructionsAtEntry(uint8_t const* InstStream, uint64_t PC);
+  void DecodeInstructionsAtEntry(uint8_t const* InstStream, uint64_t PC);
 
   std::vector<DecodedBlocks> const *GetDecodedBlocks() const {
     return &Blocks;

--- a/External/FEXCore/Source/Interface/Core/Interpreter/MiscOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/MiscOps.cpp
@@ -42,8 +42,11 @@ DEF_OP(Fence) {
 DEF_OP(Break) {
   auto Op = IROp->C<IR::IROp_Break>();
   switch (Op->Reason) {
-    case 4: // HLT
+    case FEXCore::IR::Break_Halt: // HLT
       StopThread(Data->State);
+    break;
+    case FEXCore::IR::Break_InvalidInstruction:
+      tgkill(Data->State->ThreadManager.PID, Data->State->ThreadManager.TID, SIGILL);
     break;
   default: LOGMAN_MSG_A_FMT("Unknown Break Reason: {}", Op->Reason); break;
   }

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -396,6 +396,8 @@ Arm64JITCore::Arm64JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::Intern
   if (!CompileThread) {
     ThreadSharedData.SignalHandlerRefCounterPtr = &Dispatcher->SignalHandlerRefCounter;
     ThreadSharedData.SignalReturnInstruction = Dispatcher->SignalHandlerReturnAddress;
+    ThreadSharedData.UnimplementedInstructionAddress = Dispatcher->UnimplementedInstructionAddress;
+
     ThreadSharedData.Dispatcher = Dispatcher.get();
 
     // This will register the host signal handler per thread, which is fine

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -172,6 +172,7 @@ private:
 
   struct CompilerSharedData {
     uint64_t SignalReturnInstruction{};
+    uint64_t UnimplementedInstructionAddress{};
 
     uint32_t *SignalHandlerRefCounterPtr{};
     FEXCore::CPU::Dispatcher *Dispatcher{};

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -357,6 +357,8 @@ X86JITCore::X86JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalTh
 
     ThreadSharedData.SignalHandlerRefCounterPtr = &Dispatcher->SignalHandlerRefCounter;
     ThreadSharedData.SignalHandlerReturnAddress = Dispatcher->SignalHandlerReturnAddress;
+    ThreadSharedData.UnimplementedInstructionAddress = Dispatcher->UnimplementedInstructionAddress;
+
     ThreadSharedData.Dispatcher = Dispatcher.get();
 
     // This will register the host signal handler per thread, which is fine

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -163,6 +163,8 @@ private:
 
   struct CompilerSharedData {
     uint64_t SignalHandlerReturnAddress{};
+    uint64_t UnimplementedInstructionAddress{};
+
 
     uint32_t *SignalHandlerRefCounterPtr{};
     FEXCore::CPU::Dispatcher *Dispatcher{};

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -498,6 +498,8 @@ public:
 
   void UnimplementedOp(OpcodeArgs);
 
+  void InvalidOp(OpcodeArgs);
+
 #undef OpcodeArgs
 
   void SetPackedRFLAG(bool Lower8, OrderedNode *Src);

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -68,7 +68,14 @@
 
     "constexpr static FEXCore::IR::MemOffsetType MEM_OFFSET_SXTX {0};",
     "constexpr static FEXCore::IR::MemOffsetType MEM_OFFSET_UXTW {1};",
-    "constexpr static FEXCore::IR::MemOffsetType MEM_OFFSET_SXTW {2};"
+    "constexpr static FEXCore::IR::MemOffsetType MEM_OFFSET_SXTW {2};",
+
+    "static constexpr FEXCore::IR::BreakReason Break_Unimplemented      {0}",
+    "static constexpr FEXCore::IR::BreakReason Break_Interrupt          {1}",
+    "static constexpr FEXCore::IR::BreakReason Break_Interrupt3         {2}",
+    "static constexpr FEXCore::IR::BreakReason Break_Halt               {3}",
+    "static constexpr FEXCore::IR::BreakReason Break_Overflow           {4}",
+    "static constexpr FEXCore::IR::BreakReason Break_InvalidInstruction {5}"
   ],
 
   "Ops": {
@@ -364,7 +371,7 @@
       "HasSideEffects": true,
       "OpClass": "Misc",
       "Args": [
-        "uint8_t", "Reason",
+        "FEXCore::IR::BreakReason", "Reason",
         "uint8_t", "Literal"
       ]
     },

--- a/External/FEXCore/Source/Interface/IR/IRParser.cpp
+++ b/External/FEXCore/Source/Interface/IR/IRParser.cpp
@@ -38,6 +38,8 @@ enum class DecodeFailure {
   DECODE_INVALID_CONDFLAG,
   DECODE_INVALID_MEMOFFSETTYPE,
   DECODE_INVALID_FENCETYPE,
+  DECODE_INVALID_BREAKTYPE,
+
 };
 
 std::string ltrim(std::string String) {
@@ -74,6 +76,7 @@ std::string DecodeErrorToString(DecodeFailure Failure) {
     case DecodeFailure::DECODE_INVALID_CONDFLAG: return "Invalid Conditional name";
     case DecodeFailure::DECODE_INVALID_MEMOFFSETTYPE: return "Invalid Memory Offset Type";
     case DecodeFailure::DECODE_INVALID_FENCETYPE: return "Invalid Fence Type";
+    case DecodeFailure::DECODE_INVALID_BREAKTYPE: return "Invalid Break Reason Type";
   }
   return "Unknown Error";
 }
@@ -266,6 +269,25 @@ class IRParser: public FEXCore::IR::IREmitter {
       }
     }
     return {DecodeFailure::DECODE_INVALID_FENCETYPE, {}};
+  }
+
+  template<>
+  std::pair<DecodeFailure, FEXCore::IR::BreakReason> DecodeValue(const std::string &Arg) {
+    static constexpr std::array<std::string_view, 6> Names = {
+      "Unimplemented",
+      "Interrupt",
+      "Interrupt3",
+      "Halt",
+      "Overfloat",
+      "InvalidInstruction",
+    };
+
+    for (size_t i = 0; i < Names.size(); ++i) {
+      if (Names[i] == Arg) {
+        return {DecodeFailure::DECODE_OKAY, BreakReason{static_cast<uint8_t>(i)}};
+      }
+    }
+    return {DecodeFailure::DECODE_INVALID_BREAKTYPE, {}};
   }
 
   template<>

--- a/External/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
@@ -662,7 +662,8 @@ bool RCLSE::RedundantStoreLoadElimination(FEXCore::IR::IREmitter *IREmit) {
       else if (IROp->Op == OP_STORECONTEXTINDEXED ||
                IROp->Op == OP_LOADCONTEXTINDEXED ||
                IROp->Op == OP_SYSCALL ||
-               IROp->Op == OP_INLINESYSCALL) {
+               IROp->Op == OP_INLINESYSCALL ||
+               IROp->Op == OP_BREAK) {
         // We can't track through these
         ResetClassificationAccesses(&LocalInfo);
       }

--- a/External/FEXCore/include/FEXCore/IR/IR.h
+++ b/External/FEXCore/include/FEXCore/IR/IR.h
@@ -332,6 +332,14 @@ struct RoundType final {
   friend constexpr bool operator==(const RoundType&, const RoundType&) = default;
 };
 
+struct BreakReason final {
+  uint8_t Val;
+  constexpr operator uint8_t() const {
+    return Val;
+  }
+  friend constexpr bool operator==(const BreakReason&, const BreakReason&) = default;
+};
+
 struct SHA256Sum final {
   uint8_t data[32];
   bool operator<(SHA256Sum const &rhs) const { return memcmp(data, rhs.data, sizeof(data)) < 0; }

--- a/unittests/IR/Basic/MemoryData.ir
+++ b/unittests/IR/Basic/MemoryData.ir
@@ -18,6 +18,6 @@
     %Addr i64 = Constant #0x100000
     %Val i32 = LoadMem %Addr i64, %Invalid, #0x8, GPR, SXTX, #0x1, #0x8
     (%Store i64) StoreContext %Val i64, #0x08, GPR
-    (%brk i0) Break #4, #4
+    (%brk i0) Break Halt, #4
     (%end i0) EndBlock %ssa2
 

--- a/unittests/IR/Basic/Sbfe.ir
+++ b/unittests/IR/Basic/Sbfe.ir
@@ -37,5 +37,5 @@
 ; Test with + shift
     %Res5 i64 = Sbfe %Val2, #0x4, #0x2
     (%Store5 i64) StoreContext %Res5 i64, #0x28, GPR
-    (%brk i0) Break #4, #4
+    (%brk i0) Break Halt, #4
     (%end i0) EndBlock %ssa2

--- a/unittests/IR/Basic/SetGPR.ir
+++ b/unittests/IR/Basic/SetGPR.ir
@@ -11,5 +11,5 @@
     (%ssa6 i0) BeginBlock %ssa2
     %Value i64 = Constant #0x4142434445464748
     (%Store i64) StoreContext %Value i64, #0x8, GPR
-    (%ssa7 i0) Break #4, #4
+    (%ssa7 i0) Break Halt, #4
     (%ssa8 i0) EndBlock %ssa2

--- a/unittests/IR/Correctness/AddTruncate.ir
+++ b/unittests/IR/Correctness/AddTruncate.ir
@@ -34,5 +34,5 @@
     %ResultD i64 = Add %ValueC, %ValueD
     (%Store i64) StoreContext %ResultC i64, #0x18, GPR
     (%Store i64) StoreContext %ResultD i64, #0x20, GPR
-    (%ssa7 i0) Break #4, #4
+    (%ssa7 i0) Break Halt, #4
     (%ssa12 i0) EndBlock %ssa2

--- a/unittests/IR/Correctness/FPRStoreTruncate.ir
+++ b/unittests/IR/Correctness/FPRStoreTruncate.ir
@@ -45,5 +45,5 @@
     (%Store7 i128) StoreContext %Truncated16 i128, #0xf0, FPR
     (%Store8 i128)  StoreContext %Truncated8 i128, #0x100, FPR
     (%Store9 i128)  StoreContext %MemValueA i128, #0x110, FPR
-    (%ssa7 i0) Break #4, #4
+    (%ssa7 i0) Break Halt, #4
     (%end i0) EndBlock %ssa2

--- a/unittests/IR/Correctness/LeftShiftTruncate.ir
+++ b/unittests/IR/Correctness/LeftShiftTruncate.ir
@@ -32,5 +32,5 @@
     %ResultD i64 = Lshl %ValueB, %Shift
     (%Store i64) StoreContext %ResultC i64, #0x18, GPR
     (%Store i64) StoreContext %ResultD i64, #0x20, GPR
-    (%ssa7 i0) Break #4, #4
+    (%ssa7 i0) Break Halt, #4
     (%ssa12 i0) EndBlock %ssa2

--- a/unittests/IR/Correctness/SubTruncate.ir
+++ b/unittests/IR/Correctness/SubTruncate.ir
@@ -34,5 +34,5 @@
     %ResultD i64 = Sub %ValueC, %ValueD
     (%Store i64) StoreContext %ResultC i64, #0x18, GPR
     (%Store i64) StoreContext %ResultD i64, #0x20, GPR
-    (%ssa7 i0) Break #4, #4
+    (%ssa7 i0) Break Halt, #4
     (%ssa12 i0) EndBlock %ssa2


### PR DESCRIPTION
Fixes #1217

Instead of throwing an error and closing down FEX. Instead pass the
SIGILL to the guest application.

On unhandled instruction implementation the instruction, we instead emit
a _Break IR op at that location.

A _Break IR op will ensure the context state is synchronized at the
point of of the fault and has fairly low overhead. We branch to the
dispatcher which does the SRA spilling.

Tested this with an application that attempts an AVX512 instruction,
catches the fault, and continues onward.
With #1383 in place, we also won't pass spurious ERROR_AND_DIE to the guest anymore.