### PR TITLE
JIT: Ensures signals in compileservice JIT space is handled

### DIFF
--- a/External/FEXCore/Source/Interface/Core/CompileService.cpp
+++ b/External/FEXCore/Source/Interface/Core/CompileService.cpp
@@ -85,7 +85,6 @@ namespace FEXCore {
     SelectedThread->CPUBackend->ClearCache();
   }
 
-
   CompileService::WorkItem *CompileService::CompileCode(uint64_t RIP) {
     // Tell the worker thread to compile code for us
     WorkItem *Item = new WorkItem{};

--- a/External/FEXCore/Source/Interface/Core/CompileService.h
+++ b/External/FEXCore/Source/Interface/Core/CompileService.h
@@ -48,6 +48,9 @@ class CompileService final {
     // Public for threading
     void ExecutionThread();
 
+    bool IsAddressInJITCode(uint64_t Address) const {
+      return CompileThreadData->CPUBackend->IsAddressInJITCode(Address, false, false);
+    }
   private:
     FEXCore::Context::Context *CTX;
     FEXCore::Core::InternalThreadState *ParentThread;

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
@@ -3,6 +3,7 @@
 #include "Interface/Core/ArchHelpers/MContext.h"
 #include "Interface/Core/Dispatcher/Dispatcher.h"
 #include "Interface/Core/X86HelperGen.h"
+#include "Interface/Core/CompileService.h"
 
 #include <FEXCore/Config/Config.h>
 #include <FEXCore/Core/CoreState.h>
@@ -655,15 +656,19 @@ void Dispatcher::RemoveCodeBuffer(uint8_t* start_to_remove) {
   }
 }
 
-bool Dispatcher::IsAddressInJITCode(uint64_t Address, bool IncludeDispatcher) const {
+bool Dispatcher::IsAddressInJITCode(uint64_t Address, bool IncludeDispatcher, bool IncludeCompileService) const {
   for (auto [start, end] : CodeBuffers) {
     if (Address >= start && Address < end) {
       return true;
     }
   }
 
-  if (IncludeDispatcher) {
-    return IsAddressInDispatcher(Address);
+  if (IncludeDispatcher && IsAddressInDispatcher(Address)) {
+    return true;
+  }
+
+  if (IncludeCompileService &&  ThreadState->CompileService && ThreadState->CompileService->IsAddressInJITCode(Address)) {
+    return true;
   }
   return false;
 }

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
@@ -70,7 +70,7 @@ public:
 
   void RemoveCodeBuffer(uint8_t* start);
 
-  bool IsAddressInJITCode(uint64_t Address, bool IncludeDispatcher = true) const;
+  bool IsAddressInJITCode(uint64_t Address, bool IncludeDispatcher = true, bool IncludeCompileService = true) const;
   bool IsAddressInDispatcher(uint64_t Address) const {
     return Address >= Start && Address < End;
   }

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -64,6 +64,9 @@ public:
   [[nodiscard]] CodeBuffer AllocateNewCodeBuffer(size_t Size);
 
   void CopyNecessaryDataForCompileThread(CPUBackend *Original) override;
+  bool IsAddressInJITCode(uint64_t Address, bool IncludeDispatcher = true, bool IncludeCompileService = true) const override {
+    return Dispatcher->IsAddressInJITCode(Address, IncludeDispatcher, IncludeCompileService);
+  }
 
 private:
   FEX_CONFIG_OPT(ParanoidTSO, PARANOIDTSO);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -80,6 +80,10 @@ public:
   static constexpr size_t MAX_CODE_SIZE = 1024 * 1024 * 256;
   void CopyNecessaryDataForCompileThread(CPUBackend *Original) override;
 
+  bool IsAddressInJITCode(uint64_t Address, bool IncludeDispatcher = true, bool IncludeCompileService = true) const override {
+    return Dispatcher->IsAddressInJITCode(Address, IncludeDispatcher, IncludeCompileService);
+  }
+
 private:
   Label* PendingTargetLabel{};
   FEXCore::Context::Context *CTX;

--- a/External/FEXCore/include/FEXCore/Core/CPUBackend.h
+++ b/External/FEXCore/include/FEXCore/Core/CPUBackend.h
@@ -90,6 +90,7 @@ class LLVMCore;
 
     virtual void ClearCache() {}
     virtual void CopyNecessaryDataForCompileThread(CPUBackend *Original) {}
+    virtual bool IsAddressInJITCode(uint64_t Address, bool IncludeDispatcher = true, bool IncludeCompileService = true) const { return false; }
 
     using AsmDispatch = FEX_NAKED void(*)(FEXCore::Core::CpuStateFrame *Frame);
     using JITCallback = FEX_NAKED void(*)(FEXCore::Core::CpuStateFrame *Frame, uint64_t RIP);


### PR DESCRIPTION
If a SIGBUS is received in compile service code then we weren't handling
it correctly. Instead we would fail the JIT space check and hand it off
to the guest.