### PR TITLE
FEXCore: Fixes CompileService race condition on thread creation

### DIFF
--- a/External/FEXCore/Source/Interface/Core/CompileService.cpp
+++ b/External/FEXCore/Source/Interface/Core/CompileService.cpp
@@ -35,7 +35,9 @@ namespace FEXCore {
     CTX->InitializeCompiler(CompileThreadData.get(), true);
     CompileThreadData->CPUBackend->CopyNecessaryDataForCompileThread(ParentThread->CPUBackend.get());
 
+    uint64_t OldMask = FEXCore::Threads::SetSignalMask(~0ULL);
     WorkerThread = FEXCore::Threads::Thread::Create(ThreadHandler, this);
+    FEXCore::Threads::SetSignalMask(OldMask);
   }
 
   void CompileService::Initialize() {
@@ -104,9 +106,6 @@ namespace FEXCore {
   }
 
   void CompileService::ExecutionThread() {
-    // Ignore signals coming from the guest
-    CTX->SignalDelegation->MaskThreadSignals();
-
     // Set our thread name so we can see its relation
     char ThreadName[16]{};
     snprintf(ThreadName, 16, "%ld-CS", ParentThread->ThreadManager.TID.load());

--- a/External/FEXCore/Source/Utils/Threads.cpp
+++ b/External/FEXCore/Source/Utils/Threads.cpp
@@ -10,8 +10,11 @@
 #include <pthread.h>
 #include <stdint.h>
 #include <sys/mman.h>
+#include <sys/signal.h>
+#include <sys/syscall.h>
 #include <bits/mman-map-flags-generic.h>
 #include <deque>
+#include <unistd.h>
 
 namespace FEXCore::Threads {
   // Stack pool handling
@@ -208,5 +211,10 @@ namespace FEXCore::Threads {
 
   void FEXCore::Threads::Thread::SetInternalPointers(Pointers const &_Ptrs) {
     memcpy(&Ptrs, &_Ptrs, sizeof(FEXCore::Threads::Pointers));
+  }
+
+  uint64_t SetSignalMask(uint64_t Mask) {
+    ::syscall(SYS_rt_sigprocmask, SIG_SETMASK, &Mask, &Mask, 8);
+    return Mask;
   }
 }

--- a/External/FEXCore/include/FEXCore/Utils/Threads.h
+++ b/External/FEXCore/include/FEXCore/Utils/Threads.h
@@ -42,4 +42,13 @@ namespace FEXCore::Threads {
   void *AllocateStackObject(size_t Size);
   void DeallocateStackObject(void *Ptr, size_t Size);
   void Shutdown();
+
+  /**
+   * @brief Sets the calling thread's signal mask to the one provided
+   *
+   * @param Mask The new 64-bit signal mask to set
+   *
+   * @return The previous signal mask
+   */
+  uint64_t SetSignalMask(uint64_t Mask);
 }


### PR DESCRIPTION
The CompileService was spinning up with the incoming thread mask and
then setting the mask once running.

Instead set the mask, which the thread inherits, then set it back once
it is created.