### PR TITLE
Linux: Fixes MAP_32BIT error case

### DIFF
--- a/Source/Tests/LinuxSyscalls/LinuxAllocator.cpp
+++ b/Source/Tests/LinuxSyscalls/LinuxAllocator.cpp
@@ -387,7 +387,7 @@ void *MemAllocator32Bit::mremap(void *old_address, size_t old_size, size_t new_s
   // First, try and allocate a region the size of the new size
   void *MappedPtr = this->mmap(nullptr, new_size, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
   std::scoped_lock<std::mutex> lk{AllocMutex};
-  if (reinterpret_cast<uintptr_t>(MappedPtr) > -4096) {
+  if (FEX::HLE::HasSyscallError(MappedPtr)) {
     // Couldn't find a region that fit our space
     return MappedPtr;
   }

--- a/Source/Tests/LinuxSyscalls/x32/Memory.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Memory.cpp
@@ -30,7 +30,7 @@ namespace FEX::HLE::x32 {
         mmap(reinterpret_cast<void*>(addr), length, prot,flags, fd, offset);
 
       auto Thread = Frame->Thread;
-      if (Result < -4096) {
+      if (!FEX::HLE::HasSyscallError(Result)) {
         if (!(flags & MAP_ANONYMOUS)) {
           auto filename = get_fdpath(fd);
 
@@ -46,7 +46,7 @@ namespace FEX::HLE::x32 {
         mmap(reinterpret_cast<void*>(addr), length, prot,flags, fd, (uint64_t)pgoffset * 0x1000);
 
       auto Thread = Frame->Thread;
-      if (Result < -4096) {
+      if (!FEX::HLE::HasSyscallError(Result)) {
         if (!(flags & MAP_ANONYMOUS)) {
           auto filename = get_fdpath(fd);
 

--- a/Source/Tests/LinuxSyscalls/x64/Memory.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Memory.cpp
@@ -36,7 +36,7 @@ namespace FEX::HLE::x64 {
           munmap(addr, length);
         return Result;
 
-        if (Result < -4096) {
+        if (FEX::HLE::HasSyscallError(Result)) {
           errno = -Result;
           Result = -1;
         }
@@ -62,7 +62,7 @@ namespace FEX::HLE::x64 {
       if (Map32Bit) {
         Result = (uint64_t)static_cast<FEX::HLE::SyscallHandler*>(FEX::HLE::_SyscallHandler)->Get32BitAllocator()->
           mmap(reinterpret_cast<void*>(addr), length, prot,flags, fd, offset);
-        if (Result < -4096) {
+        if (FEX::HLE::HasSyscallError(Result)) {
           errno = -Result;
           Result = -1;
         }


### PR DESCRIPTION
If MAP_32BIT was failing then we weren't checking error result
correctly.
This was causing us to crash.

Now add a helper function for checking syscall results since it is easy
to mess up.

Replaces the few cases where we were manually checking with the helper.

Fixes a Dota: Underlords crash