### PR TITLE
General: Migrate logging over to fmt where possible 

### DIFF
--- a/External/FEXCore/Scripts/json_ir_generator.py
+++ b/External/FEXCore/Scripts/json_ir_generator.py
@@ -308,7 +308,7 @@ def print_ir_allocator_helpers(ops, defines):
 
     output_file.write("\tuint8_t GetOpElements(OrderedNode *Op) const {\n")
     output_file.write("\t\tauto HeaderOp = Op->Header.Value.GetNode(DualListData.DataBegin());\n")
-    output_file.write("\t\tLOGMAN_THROW_A(HeaderOp->HasDest, \"Op %s has no dest\\n\", GetName(HeaderOp->Op));\n")
+    output_file.write("\t\tLOGMAN_THROW_A_FMT(HeaderOp->HasDest, \"Op {} has no dest\\n\", GetName(HeaderOp->Op));\n")
     output_file.write("\t\treturn HeaderOp->Size / HeaderOp->ElementSize;\n")
     output_file.write("\t}\n\n")
 

--- a/External/FEXCore/Source/Common/BitSet.h
+++ b/External/FEXCore/Source/Common/BitSet.h
@@ -17,12 +17,12 @@ struct BitSet final {
   ElementType *Memory;
   void Allocate(size_t Elements) {
     size_t AllocateSize = AlignUp(Elements, MinimumSizeBits) / MinimumSize;
-    LOGMAN_THROW_A((AllocateSize * MinimumSize) >= Elements, "Fail");
+    LOGMAN_THROW_A_FMT((AllocateSize * MinimumSize) >= Elements, "Fail");
     Memory = static_cast<ElementType*>(FEXCore::Allocator::malloc(AllocateSize));
   }
   void Realloc(size_t Elements) {
     size_t AllocateSize = AlignUp(Elements, MinimumSizeBits) / MinimumSize;
-    LOGMAN_THROW_A((AllocateSize * MinimumSize) >= Elements, "Fail");
+    LOGMAN_THROW_A_FMT((AllocateSize * MinimumSize) >= Elements, "Fail");
     Memory = static_cast<ElementType*>(FEXCore::Allocator::realloc(Memory, AllocateSize));
   }
   void Free() {
@@ -61,8 +61,8 @@ struct BitSetView final {
   ElementType *Memory;
 
   void GetView(BitSet<T> &Set, uint64_t ElementOffset) {
-    LOGMAN_THROW_A((ElementOffset % MinimumSize) == 0,
-        "Bitset view offset needs to be aligned to size of backing element");
+    LOGMAN_THROW_A_FMT((ElementOffset % MinimumSize) == 0,
+                       "Bitset view offset needs to be aligned to size of backing element");
     Memory = &Set.Memory[ElementOffset / MinimumSizeBits];
   }
 

--- a/External/FEXCore/Source/Common/Paths.cpp
+++ b/External/FEXCore/Source/Common/Paths.cpp
@@ -72,7 +72,7 @@ namespace FEXCore::Paths {
     // Ensure the folder structure is created for our Data
     if (!std::filesystem::exists(*EntryCache, ec) &&
         !std::filesystem::create_directories(*EntryCache, ec)) {
-      LogMan::Msg::D("Couldn't create EntryCache directory: '%s'", EntryCache->c_str());
+      LogMan::Msg::DFmt("Couldn't create EntryCache directory: '{}'", *EntryCache);
     }
   }
 

--- a/External/FEXCore/Source/Common/SoftFloat.h
+++ b/External/FEXCore/Source/Common/SoftFloat.h
@@ -111,7 +111,7 @@ struct X80SoftFloat {
   }
 
   static X80SoftFloat FSCALE(X80SoftFloat const &lhs, X80SoftFloat const &rhs) {
-    WARN_ONCE("x87: Application used FSCALE which may have accuracy problems");
+    WARN_ONCE_FMT("x87: Application used FSCALE which may have accuracy problems");
     X80SoftFloat Int = FRNDINT(rhs);
     BIGFLOAT Src2_d = Int;
     Src2_d = exp2l(Src2_d);
@@ -121,7 +121,7 @@ struct X80SoftFloat {
   }
 
   static X80SoftFloat F2XM1(X80SoftFloat const &lhs) {
-    WARN_ONCE("x87: Application used F2XM1 which may have accuracy problems");
+    WARN_ONCE_FMT("x87: Application used F2XM1 which may have accuracy problems");
     BIGFLOAT Src1_d = lhs;
     BIGFLOAT Result = exp2l(Src1_d);
     Result -= 1.0;
@@ -129,7 +129,7 @@ struct X80SoftFloat {
   }
 
   static X80SoftFloat FYL2X(X80SoftFloat const &lhs, X80SoftFloat const &rhs) {
-    WARN_ONCE("x87: Application used FYL2X which may have accuracy problems");
+    WARN_ONCE_FMT("x87: Application used FYL2X which may have accuracy problems");
     BIGFLOAT Src1_d = lhs;
     BIGFLOAT Src2_d = rhs;
     BIGFLOAT Tmp = Src2_d * log2l(Src1_d);
@@ -137,7 +137,7 @@ struct X80SoftFloat {
   }
 
   static X80SoftFloat FATAN(X80SoftFloat const &lhs, X80SoftFloat const &rhs) {
-    WARN_ONCE("x87: Application used FATAN which may have accuracy problems");
+    WARN_ONCE_FMT("x87: Application used FATAN which may have accuracy problems");
     BIGFLOAT Src1_d = lhs;
     BIGFLOAT Src2_d = rhs;
     BIGFLOAT Tmp = atan2l(Src1_d, Src2_d);
@@ -145,21 +145,21 @@ struct X80SoftFloat {
   }
 
   static X80SoftFloat FTAN(X80SoftFloat const &lhs) {
-    WARN_ONCE("x87: Application used FTAN which may have accuracy problems");
+    WARN_ONCE_FMT("x87: Application used FTAN which may have accuracy problems");
     BIGFLOAT Src_d = lhs;
     Src_d = tanl(Src_d);
     return Src_d;
   }
 
   static X80SoftFloat FSIN(X80SoftFloat const &lhs) {
-    WARN_ONCE("x87: Application used FSIN which may have accuracy problems");
+    WARN_ONCE_FMT("x87: Application used FSIN which may have accuracy problems");
     BIGFLOAT Src_d = lhs;
     Src_d = sinl(Src_d);
     return Src_d;
   }
 
   static X80SoftFloat FCOS(X80SoftFloat const &lhs) {
-    WARN_ONCE("x87: Application used FCOS which may have accuracy problems");
+    WARN_ONCE_FMT("x87: Application used FCOS which may have accuracy problems");
     BIGFLOAT Src_d = lhs;
     Src_d = cosl(Src_d);
     return Src_d;

--- a/External/FEXCore/Source/Interface/Config/Config.cpp
+++ b/External/FEXCore/Source/Interface/Config/Config.cpp
@@ -74,14 +74,14 @@ namespace JSON {
 
     json_t const *json = json_createWithPool(&Data.at(0), &Pool.PoolObject);
     if (!json) {
-      LogMan::Msg::E("Couldn't create json");
+      LogMan::Msg::EFmt("Couldn't create json");
       return;
     }
 
     json_t const* ConfigList = json_getProperty(json, "Config");
 
     if (!ConfigList) {
-      LogMan::Msg::E("Couldn't get config list");
+      LogMan::Msg::EFmt("Couldn't get config list");
       return;
     }
 
@@ -92,12 +92,12 @@ namespace JSON {
       const char* ConfigString = json_getValue(ConfigItem);
 
       if (!ConfigName) {
-        LogMan::Msg::E("Couldn't get config name");
+        LogMan::Msg::EFmt("Couldn't get config name");
         return;
       }
 
       if (!ConfigString) {
-        LogMan::Msg::E("Couldn't get ConfigString for '%s'", ConfigName);
+        LogMan::Msg::EFmt("Couldn't get ConfigString for '{}'", ConfigName);
         return;
       }
 
@@ -173,7 +173,7 @@ namespace JSON {
     if (!Global &&
         !std::filesystem::exists(ConfigFile, ec) &&
         !std::filesystem::create_directories(ConfigFile, ec)) {
-      LogMan::Msg::D("Couldn't create config directory: '%s'", ConfigFile.c_str());
+      LogMan::Msg::DFmt("Couldn't create config directory: '{}'", ConfigFile);
       // Let's go local in this case
       return "./" + Filename + ".json";
     }

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64.cpp
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64.cpp
@@ -1437,9 +1437,8 @@ bool HandleAtomicMemOp(void *_ucontext, void *_info, uint32_t Instr) {
         DesiredFunction = SWAPDesired;
         break;
       default:
-        LogMan::Msg::E("Unhandled JIT SIGBUS Atomic mem op 0x%02x", Op);
+        LogMan::Msg::EFmt("Unhandled JIT SIGBUS Atomic mem op 0x{:02x}", Op);
         return false;
-        break;
     }
 
     auto Res = DoCAS16<true>(
@@ -1499,9 +1498,8 @@ bool HandleAtomicMemOp(void *_ucontext, void *_info, uint32_t Instr) {
         DesiredFunction = SWAPDesired;
         break;
       default:
-        LogMan::Msg::E("Unhandled JIT SIGBUS Atomic mem op 0x%02x", Op);
+        LogMan::Msg::EFmt("Unhandled JIT SIGBUS Atomic mem op 0x{:02x}", Op);
         return false;
-        break;
     }
 
     auto Res = DoCAS32<true>(
@@ -1561,9 +1559,8 @@ bool HandleAtomicMemOp(void *_ucontext, void *_info, uint32_t Instr) {
         DesiredFunction = SWAPDesired;
         break;
       default:
-        LogMan::Msg::E("Unhandled JIT SIGBUS Atomic mem op 0x%02x", Op);
+        LogMan::Msg::EFmt("Unhandled JIT SIGBUS Atomic mem op 0x{:02x}", Op);
         return false;
-        break;
     }
 
     auto Res = DoCAS64<true>(
@@ -1744,8 +1741,8 @@ static uint64_t HandleCAS_NoAtomics(void *_ucontext, void *_info)
      if ((NextInstr & FEXCore::ArchHelpers::Arm64::STLXR_MASK) == FEXCore::ArchHelpers::Arm64::STLXR_INST) {
        #if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
        // Just double check that the memory destination matches
-       uint32_t StoreAddressReg = GetRnReg(NextInstr);
-       LOGMAN_THROW_A(StoreAddressReg == AddressReg, "StoreExclusive memory register didn't match the store exclusive register");
+       const uint32_t StoreAddressReg = GetRnReg(NextInstr);
+       LOGMAN_THROW_A_FMT(StoreAddressReg == AddressReg, "StoreExclusive memory register didn't match the store exclusive register");
        #endif
        DesiredReg = GetRdReg(NextInstr);
      }
@@ -1865,8 +1862,8 @@ uint64_t HandleAtomicLoadstoreExclusive(void *_ucontext, void *_info) {
     else if ((NextInstr & FEXCore::ArchHelpers::Arm64::STLXR_MASK) == FEXCore::ArchHelpers::Arm64::STLXR_INST) {
 #if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
       // Just double check that the memory destination matches
-      uint32_t StoreAddressReg = GetRnReg(NextInstr);
-      LOGMAN_THROW_A(StoreAddressReg == AddressReg, "StoreExclusive memory register didn't match the store exclusive register");
+      const uint32_t StoreAddressReg = GetRnReg(NextInstr);
+      LOGMAN_THROW_A_FMT(StoreAddressReg == AddressReg, "StoreExclusive memory register didn't match the store exclusive register");
 #endif
       uint32_t StatusReg = GetRmReg(NextInstr);
       uint32_t StoreResultReg = GetRdReg(NextInstr);
@@ -1885,7 +1882,7 @@ uint64_t HandleAtomicLoadstoreExclusive(void *_ucontext, void *_info) {
       break;
     }
     else {
-      LogMan::Msg::A("Unknown instruction 0x%08x", NextInstr);
+      LogMan::Msg::AFmt("Unknown instruction 0x{:08x}", NextInstr);
     }
   }
 
@@ -1951,9 +1948,8 @@ uint64_t HandleAtomicLoadstoreExclusive(void *_ucontext, void *_info) {
         DesiredFunction = NEGDesired;
         break;
       default:
-        LogMan::Msg::E("Unhandled JIT SIGBUS Atomic mem op 0x%02x", AtomicOp);
+        LogMan::Msg::EFmt("Unhandled JIT SIGBUS Atomic mem op 0x{:02x}", AtomicOp);
         return false;
-        break;
     }
 
     auto Res = DoCAS16<DoRetry>(
@@ -2028,9 +2024,8 @@ uint64_t HandleAtomicLoadstoreExclusive(void *_ucontext, void *_info) {
         DesiredFunction = NEGDesired;
         break;
       default:
-        LogMan::Msg::E("Unhandled JIT SIGBUS Atomic mem op 0x%02x", AtomicOp);
+        LogMan::Msg::EFmt("Unhandled JIT SIGBUS Atomic mem op 0x{:02x}", AtomicOp);
         return false;
-        break;
     }
 
     auto Res = DoCAS32<DoRetry>(
@@ -2105,9 +2100,8 @@ uint64_t HandleAtomicLoadstoreExclusive(void *_ucontext, void *_info) {
         DesiredFunction = NEGDesired;
         break;
       default:
-        LogMan::Msg::E("Unhandled JIT SIGBUS Atomic mem op 0x%02x", AtomicOp);
+        LogMan::Msg::EFmt("Unhandled JIT SIGBUS Atomic mem op 0x{:02x}", AtomicOp);
         return false;
-        break;
     }
 
     auto Res = DoCAS64<DoRetry>(

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
@@ -32,7 +32,7 @@ Arm64Emitter::Arm64Emitter(size_t size) : vixl::aarch64::Assembler(size, vixl::a
   SetCPUFeatures(Features);
 
   if (!SupportsAtomics) {
-    WARN_ONCE("Host CPU doesn't support atomics. Expect bad performance");
+    WARN_ONCE_FMT("Host CPU doesn't support atomics. Expect bad performance");
   }
 
 #ifdef _M_ARM_64

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64_stubs.cpp
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64_stubs.cpp
@@ -12,15 +12,15 @@ namespace FEXCore::ArchHelpers::Arm64 {
 // Obvously such a configuration can't do the actual arm64-specific stuff
 
 bool HandleCASPAL(void *_ucontext, void *_info, uint32_t Instr) {
-    ERROR_AND_DIE("HandleCASPAL Not Implemented");
+    ERROR_AND_DIE_FMT("HandleCASPAL Not Implemented");
 }
 
 bool HandleCASAL(void *_ucontext, void *_info, uint32_t Instr) {
-    ERROR_AND_DIE("HandleCASAL Not Implemented");
+    ERROR_AND_DIE_FMT("HandleCASAL Not Implemented");
 }
 
 bool HandleAtomicMemOp(void *_ucontext, void *_info, uint32_t Instr) {
-    ERROR_AND_DIE("HandleAtomicMemOp Not Implemented");
+    ERROR_AND_DIE_FMT("HandleAtomicMemOp Not Implemented");
 }
 #endif
 

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/MContext.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/MContext.h
@@ -122,7 +122,7 @@ static inline void SetArmReg(void* ucontext, uint32_t id, uint64_t val) {
 static inline __uint128_t GetArmFPR(void* ucontext, uint32_t id) {
   auto MContext = GetMContext(ucontext);
   HostFPRState *HostState = reinterpret_cast<HostFPRState*>(&MContext->__reserved[0]);
-  LOGMAN_THROW_A(HostState->Head.Magic == FPR_MAGIC, "Wrong FPR Magic: 0x%08x", HostState->Head.Magic);
+  LOGMAN_THROW_A_FMT(HostState->Head.Magic == FPR_MAGIC, "Wrong FPR Magic: 0x{:08x}", HostState->Head.Magic);
 
   return HostState->FPRs[id];
 }
@@ -141,7 +141,7 @@ static inline void BackupContext(void* ucontext, T *Backup) {
 
     // Host FPR state starts at _mcontext->reserved[0];
     HostFPRState *HostState = reinterpret_cast<HostFPRState*>(&_mcontext->__reserved[0]);
-    LOGMAN_THROW_A(HostState->Head.Magic == FPR_MAGIC, "Wrong FPR Magic: 0x%08x", HostState->Head.Magic);
+    LOGMAN_THROW_A_FMT(HostState->Head.Magic == FPR_MAGIC, "Wrong FPR Magic: 0x{:08x}", HostState->Head.Magic);
     Backup->FPSR = HostState->FPSR;
     Backup->FPCR = HostState->FPCR;
     memcpy(&Backup->FPRs[0], &HostState->FPRs[0], 32 * sizeof(__uint128_t));
@@ -149,7 +149,8 @@ static inline void BackupContext(void* ucontext, T *Backup) {
     // Save the signal mask so we can restore it
     memcpy(&Backup->sa_mask, &_ucontext->uc_sigmask, sizeof(uint64_t));
   } else {
-      ERROR_AND_DIE("Wrong context type"); // This must be a runtime error
+    // This must be a runtime error
+    ERROR_AND_DIE_FMT("Wrong context type");
   }
 }
 
@@ -160,7 +161,7 @@ static inline void RestoreContext(void* ucontext, T *Backup) {
    auto _mcontext = GetMContext(ucontext);
 
     HostFPRState *HostState = reinterpret_cast<HostFPRState*>(&_mcontext->__reserved[0]);
-    LOGMAN_THROW_A(HostState->Head.Magic == FPR_MAGIC, "Wrong FPR Magic: 0x%08x", HostState->Head.Magic);
+    LOGMAN_THROW_A_FMT(HostState->Head.Magic == FPR_MAGIC, "Wrong FPR Magic: 0x{:08x}", HostState->Head.Magic);
     memcpy(&HostState->FPRs[0], &Backup->FPRs[0], 32 * sizeof(__uint128_t));
     HostState->FPCR = Backup->FPCR;
     HostState->FPSR = Backup->FPSR;
@@ -174,7 +175,8 @@ static inline void RestoreContext(void* ucontext, T *Backup) {
     // Restore the signal mask now
     memcpy(&_ucontext->uc_sigmask, &Backup->sa_mask, sizeof(uint64_t));
   } else {
-      ERROR_AND_DIE("Wrong context type"); // This must be a runtime error
+    // This must be a runtime error
+    ERROR_AND_DIE_FMT("Wrong context type");
   }
 }
 
@@ -207,15 +209,15 @@ static inline void SetState(void* ucontext, uint64_t val) {
 }
 
 static inline uint64_t GetArmReg(void* ucontext, uint32_t id) {
-  ERROR_AND_DIE("Not impelented for x86 host");
+  ERROR_AND_DIE_FMT("Not impelented for x86 host");
 }
 
 static inline void SetArmReg(void* ucontext, uint32_t id, uint64_t val) {
-  ERROR_AND_DIE("Not impelented for x86 host");
+  ERROR_AND_DIE_FMT("Not impelented for x86 host");
 }
 
 static inline __uint128_t GetArmFPR(void* ucontext, uint32_t id) {
-  ERROR_AND_DIE("Not implemented for x86 host");
+  ERROR_AND_DIE_FMT("Not implemented for x86 host");
 }
 
 using ContextBackup = X86ContextBackup;
@@ -234,7 +236,8 @@ static inline void BackupContext(void* ucontext, T *Backup) {
     // Save the signal mask so we can restore it
     memcpy(&Backup->sa_mask, &_ucontext->uc_sigmask, sizeof(uint64_t));
   } else {
-    ERROR_AND_DIE("Wrong context type"); // This must be a runtime error
+    // This must be a runtime error
+    ERROR_AND_DIE_FMT("Wrong context type");
   }
 }
 
@@ -252,7 +255,8 @@ static inline void RestoreContext(void* ucontext, T *Backup) {
     // Restore the signal mask now
     memcpy(&_ucontext->uc_sigmask, &Backup->sa_mask, sizeof(uint64_t));
   } else {
-    ERROR_AND_DIE("Wrong context type"); // This must be a runtime error
+    // This must be a runtime error
+    ERROR_AND_DIE_FMT("Wrong context type");
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/BlockSamplingData.cpp
+++ b/External/FEXCore/Source/Interface/Core/BlockSamplingData.cpp
@@ -27,7 +27,7 @@ namespace FEXCore {
              << std::endl;
     }
     Output.close();
-    LogMan::Msg::D("Dumped %d blocks of sampling data", SamplingMap.size());
+    LogMan::Msg::DFmt("Dumped {} blocks of sampling data", SamplingMap.size());
   }
 
   BlockSamplingData::BlockData *BlockSamplingData::GetBlockData(uint64_t RIP) {

--- a/External/FEXCore/Source/Interface/Core/CompileService.cpp
+++ b/External/FEXCore/Source/Interface/Core/CompileService.cpp
@@ -74,7 +74,7 @@ namespace FEXCore {
         }
       }
 
-      LOGMAN_THROW_A(CompileThreadData->LocalIRCache.size() == 0, "Compile service must never have LocalIRCache");
+      LOGMAN_THROW_A_FMT(CompileThreadData->LocalIRCache.size() == 0, "Compile service must never have LocalIRCache");
 
       CompileMutex.unlock();
     }
@@ -137,7 +137,7 @@ namespace FEXCore {
         // If we had a work item then work on it
         if (Item) {
           // Make sure it's not in lookup cache by accident
-          LOGMAN_THROW_A(CompileThreadData->LookupCache->FindBlock(Item->RIP) == 0, "Compile Service must never have entries in the LookupCache");
+          LOGMAN_THROW_A_FMT(CompileThreadData->LookupCache->FindBlock(Item->RIP) == 0, "Compile Service must never have entries in the LookupCache");
 
           // Code isn't in cache, compile now
           // Set our thread state's RIP
@@ -145,11 +145,11 @@ namespace FEXCore {
 
           auto [CodePtr, IRList, DebugData, RAData, Generated, StartAddr, Length] = CTX->CompileCode(CompileThreadData.get(), Item->RIP);
 
-          LOGMAN_THROW_A(Generated == true, "Compile Service doesn't have IR Cache");
+          LOGMAN_THROW_A_FMT(Generated == true, "Compile Service doesn't have IR Cache");
 
           if (!CodePtr) {
             // XXX: We currently have the expectation that compile service code will be significantly smaller than regular thread's code
-            ERROR_AND_DIE("Couldn't compile code for thread at RIP: 0x%lx", Item->RIP);
+            ERROR_AND_DIE_FMT("Couldn't compile code for thread at RIP: 0x{:x}", Item->RIP);
           }
 
           Item->CodePtr = CodePtr;

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
@@ -79,7 +79,7 @@ void Dispatcher::RestoreThreadState(void *ucontext) {
     OldSP = ArchHelpers::Context::GetSp(ucontext);
   }
   else {
-    LOGMAN_THROW_A(!SignalFrames.empty(), "Trying to restore a signal frame when we don't have any");
+    LOGMAN_THROW_A_FMT(!SignalFrames.empty(), "Trying to restore a signal frame when we don't have any");
     OldSP = SignalFrames.top();
     SignalFrames.pop();
   }
@@ -260,7 +260,7 @@ bool Dispatcher::HandleGuestSignal(int Signal, void *info, void *ucontext, Guest
         // This can also happen if we have put a signal on hold, then we just reenabled the signal
         // So we are in the syscall handler
         // Only throw a log message in this case
-        LogMan::Msg::E("Signals in dispatcher have unsynchronized context");
+        LogMan::Msg::EFmt("Signals in dispatcher have unsynchronized context");
       }
     }
   }
@@ -492,7 +492,7 @@ bool Dispatcher::HandleGuestSignal(int Signal, void *info, void *ucontext, Guest
           guest_siginfo->_sifields._timer.sigval.sival_int = HostSigInfo->si_int;
           break;
         default:
-          LogMan::Msg::E("Unhandled siginfo_t for signal: %d\n", Signal);
+          LogMan::Msg::EFmt("Unhandled siginfo_t for signal: {}\n", Signal);
           break;
       }
 
@@ -526,7 +526,7 @@ bool Dispatcher::HandleGuestSignal(int Signal, void *info, void *ucontext, Guest
   else {
     NewGuestSP -= 4;
     *(uint32_t*)NewGuestSP = SignalReturn;
-    LOGMAN_THROW_A(SignalReturn < 0x1'0000'0000ULL, "This needs to be below 4GB");
+    LOGMAN_THROW_A_FMT(SignalReturn < 0x1'0000'0000ULL, "This needs to be below 4GB");
     Frame->State.gregs[FEXCore::X86State::REG_RSP] = NewGuestSP;
   }
 
@@ -578,7 +578,8 @@ bool Dispatcher::HandleSignalPause(int Signal, void *info, void *ucontext) {
     } else {
       if (SRAEnabled) {
         // We are in non-jit, SRA is already spilled
-        LOGMAN_THROW_A(!IsAddressInJITCode(ArchHelpers::Context::GetPc(ucontext), true), "Signals in dispatcher have unsynchronized context");
+        LOGMAN_THROW_A_FMT(!IsAddressInJITCode(ArchHelpers::Context::GetPc(ucontext), true),
+                           "Signals in dispatcher have unsynchronized context");
       }
       ArchHelpers::Context::SetPc(ucontext, ThreadPauseHandlerAddress);
     }
@@ -610,7 +611,8 @@ bool Dispatcher::HandleSignalPause(int Signal, void *info, void *ucontext) {
     } else {
       if (SRAEnabled) {
         // We are in non-jit, SRA is already spilled
-        LOGMAN_THROW_A(!IsAddressInJITCode(ArchHelpers::Context::GetPc(ucontext), true), "Signals in dispatcher have unsynchronized context");
+        LOGMAN_THROW_A_FMT(!IsAddressInJITCode(ArchHelpers::Context::GetPc(ucontext), true),
+                           "Signals in dispatcher have unsynchronized context");
       }
       ArchHelpers::Context::SetPc(ucontext, ThreadStopHandlerAddress);
     }

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -674,7 +674,7 @@ void *Arm64JITCore::CompileCode(uint64_t Entry, [[maybe_unused]] FEXCore::IR::IR
     bind(&RunBlock);
   }
 
-  //LOGMAN_THROW_A(RAData->HasFullRA(), "Arm64 JIT only works with RA");
+  //LOGMAN_THROW_A_FMT(RAData->HasFullRA(), "Arm64 JIT only works with RA");
 
   SpillSlots = RAData->SpillSlots();
 

--- a/External/FEXCore/Source/Interface/Core/LookupCache.cpp
+++ b/External/FEXCore/Source/Interface/Core/LookupCache.cpp
@@ -37,11 +37,11 @@ LookupCache::LookupCache(FEXCore::Context::Context *CTX)
   // We currently limit to 128MB of real memory for caching for the total cache size.
   // Can end up being inefficient if we compile a small number of blocks per page
   PageMemory = reinterpret_cast<uintptr_t>(FEXCore::Allocator::mmap(nullptr, CODE_SIZE, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
-  LOGMAN_THROW_A(PageMemory != -1ULL, "Failed to allocate page memory");
+  LOGMAN_THROW_A_FMT(PageMemory != -1ULL, "Failed to allocate page memory");
 
   // L1 Cache
   L1Pointer = reinterpret_cast<uintptr_t>(FEXCore::Allocator::mmap(nullptr, L1_SIZE, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
-  LOGMAN_THROW_A(L1Pointer != -1ULL, "Failed to allocate L1Pointer");
+  LOGMAN_THROW_A_FMT(L1Pointer != -1ULL, "Failed to allocate L1Pointer");
 
   VirtualMemSize = ctx->Config.VirtualMemSize;
 }

--- a/External/FEXCore/Source/Interface/Core/LookupCache.h
+++ b/External/FEXCore/Source/Interface/Core/LookupCache.h
@@ -50,7 +50,7 @@ public:
     auto InsertPoint =
 #endif
     BlockList.emplace(Address, (uintptr_t)HostCode);
-    LOGMAN_THROW_A(InsertPoint.second == true, "Dupplicate block mapping added");
+    LOGMAN_THROW_A_FMT(InsertPoint.second == true, "Dupplicate block mapping added");
 
     for (auto CurrentPage = Start >> 12, EndPage = (Start + Length) >> 12; CurrentPage <= EndPage; CurrentPage++) {
       CodePages[CurrentPage].push_back(Address);

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -54,7 +54,7 @@ public:
 
   OrderedNode* GetNewJumpBlock(uint64_t RIP) {
     auto it = JumpTargets.find(RIP);
-    LOGMAN_THROW_A(it != JumpTargets.end(), "Couldn't find block generated for 0x%lx", RIP);
+    LOGMAN_THROW_A_FMT(it != JumpTargets.end(), "Couldn't find block generated for 0x{:x}", RIP);
     return it->second.BlockEntry;
   }
 

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Crypto.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Crypto.cpp
@@ -53,7 +53,7 @@ void OpDispatchBuilder::AESDecLastOp(OpcodeArgs) {
 
 void OpDispatchBuilder::AESKeyGenAssist(OpcodeArgs) {
   OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-  LOGMAN_THROW_A(Op->Src[1].IsLiteral(), "Src1 needs to be literal here");
+  LOGMAN_THROW_A_FMT(Op->Src[1].IsLiteral(), "Src1 needs to be literal here");
   uint64_t RCON = Op->Src[1].Data.Literal.Value;
 
   auto Res = _VAESKeyGenAssist(Src, RCON);

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
@@ -132,13 +132,17 @@ void OpDispatchBuilder::GenerateFlags_ADC(FEXCore::X86Tables::DecodedOp Op, Orde
     case 64:
       AndOp1 = _Bfe(1, 63, AndOp1);
     break;
-    default: LOGMAN_MSG_A("Unknown BFESize: %d", Size); break;
+    default:
+      LOGMAN_MSG_A_FMT("Unknown BFE size: {}", Size);
+    break;
     }
     SetRFLAG<FEXCore::X86State::RFLAG_OF_LOC>(AndOp1);
   }
 }
 
 void OpDispatchBuilder::GenerateFlags_SBB(FEXCore::X86Tables::DecodedOp Op, OrderedNode *Res, OrderedNode *Src1, OrderedNode *Src2, OrderedNode *CF) {
+  const auto SrcSize = GetSrcSize(Op);
+
   // AF
   {
     OrderedNode *AFRes = _Xor(_Xor(Src1, Src2), Res);
@@ -148,7 +152,7 @@ void OpDispatchBuilder::GenerateFlags_SBB(FEXCore::X86Tables::DecodedOp Op, Orde
 
   // SF
   {
-    auto SignBitConst = _Constant(GetSrcSize(Op) * 8 - 1);
+    auto SignBitConst = _Constant(SrcSize * 8 - 1);
 
     auto LshrOp = _Lshr(Res, SignBitConst);
     SetRFLAG<FEXCore::X86State::RFLAG_SF_LOC>(LshrOp);
@@ -187,7 +191,7 @@ void OpDispatchBuilder::GenerateFlags_SBB(FEXCore::X86Tables::DecodedOp Op, Orde
     auto XorOp2 = _Xor(Res, Src1);
     OrderedNode *AndOp1 = _And(XorOp1, XorOp2);
 
-    switch (GetSrcSize(Op)) {
+    switch (SrcSize) {
     case 1:
       AndOp1 = _Bfe(1, 7, AndOp1);
     break;
@@ -200,7 +204,9 @@ void OpDispatchBuilder::GenerateFlags_SBB(FEXCore::X86Tables::DecodedOp Op, Orde
     case 8:
       AndOp1 = _Bfe(1, 63, AndOp1);
     break;
-    default: LOGMAN_MSG_A("Unknown BFESize: %d", GetSrcSize(Op)); break;
+    default:
+      LOGMAN_MSG_A_FMT("Unknown BFE size: {}", SrcSize);
+    break;
     }
     SetRFLAG<FEXCore::X86State::RFLAG_OF_LOC>(AndOp1);
   }
@@ -264,6 +270,8 @@ void OpDispatchBuilder::GenerateFlags_SUB(FEXCore::X86Tables::DecodedOp Op, Orde
 }
 
 void OpDispatchBuilder::GenerateFlags_ADD(FEXCore::X86Tables::DecodedOp Op, OrderedNode *Res, OrderedNode *Src1, OrderedNode *Src2, bool UpdateCF) {
+  const auto SrcSize = GetSrcSize(Op);
+
   // AF
   {
     OrderedNode *AFRes = _Xor(_Xor(Src1, Src2), Res);
@@ -273,7 +281,7 @@ void OpDispatchBuilder::GenerateFlags_ADD(FEXCore::X86Tables::DecodedOp Op, Orde
 
   // SF
   {
-    auto SignBitConst = _Constant(GetSrcSize(Op) * 8 - 1);
+    auto SignBitConst = _Constant(SrcSize * 8 - 1);
 
     auto LshrOp = _Lshr(Res, SignBitConst);
     SetRFLAG<FEXCore::X86State::RFLAG_SF_LOC>(LshrOp);
@@ -310,7 +318,7 @@ void OpDispatchBuilder::GenerateFlags_ADD(FEXCore::X86Tables::DecodedOp Op, Orde
 
     OrderedNode *AndOp1 = _And(XorOp1, XorOp2);
 
-    switch (GetSrcSize(Op)) {
+    switch (SrcSize) {
     case 1:
       AndOp1 = _Bfe(1, 7, AndOp1);
     break;
@@ -323,7 +331,9 @@ void OpDispatchBuilder::GenerateFlags_ADD(FEXCore::X86Tables::DecodedOp Op, Orde
     case 8:
       AndOp1 = _Bfe(1, 63, AndOp1);
     break;
-    default: LOGMAN_MSG_A("Unknown BFESize: %d", GetSrcSize(Op)); break;
+    default:
+      LOGMAN_MSG_A_FMT("Unknown BFE size: {}", SrcSize);
+    break;
     }
     SetRFLAG<FEXCore::X86State::RFLAG_OF_LOC>(AndOp1);
   }

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -515,8 +515,8 @@ void OpDispatchBuilder::PSHUFBOp(OpcodeArgs) {
 
 template<size_t ElementSize, bool HalfSize, bool Low>
 void OpDispatchBuilder::PSHUFDOp(OpcodeArgs) {
-  LOGMAN_THROW_A(ElementSize != 0, "What. No element size?");
-  auto Size = GetSrcSize(Op);
+  LOGMAN_THROW_A_FMT(ElementSize != 0, "What. No element size?");
+  const auto Size = GetSrcSize(Op);
   OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
   uint8_t Shuffle = Op->Src[1].Data.Literal.Value;
 
@@ -552,8 +552,8 @@ void OpDispatchBuilder::PSHUFDOp<4, false, true>(OpcodeArgs);
 
 template<size_t ElementSize>
 void OpDispatchBuilder::SHUFOp(OpcodeArgs) {
-  LOGMAN_THROW_A(ElementSize != 0, "What. No element size?");
-  auto Size = GetSrcSize(Op);
+  LOGMAN_THROW_A_FMT(ElementSize != 0, "What. No element size?");
+  const auto Size = GetSrcSize(Op);
   OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
   OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
   uint8_t Shuffle = Op->Src[1].Data.Literal.Value;
@@ -620,7 +620,7 @@ void OpDispatchBuilder::PINSROp(OpcodeArgs) {
     Src = LoadSource_WithOpSize(GPRClass, Op, Op->Src[0], ElementSize, Op->Flags, -1);
   }
   OrderedNode *Dest = LoadSource_WithOpSize(FPRClass, Op, Op->Dest, GetDstSize(Op), Op->Flags, -1);
-  LOGMAN_THROW_A(Op->Src[1].IsLiteral(), "Src1 needs to be literal here");
+  LOGMAN_THROW_A_FMT(Op->Src[1].IsLiteral(), "Src1 needs to be literal here");
   uint64_t Index = Op->Src[1].Data.Literal.Value;
 
   uint8_t NumElements = Size / ElementSize;
@@ -641,7 +641,7 @@ template
 void OpDispatchBuilder::PINSROp<8>(OpcodeArgs);
 
 void OpDispatchBuilder::InsertPSOp(OpcodeArgs) {
-  LOGMAN_THROW_A(Op->Src[1].IsLiteral(), "Src1 needs to be literal here");
+  LOGMAN_THROW_A_FMT(Op->Src[1].IsLiteral(), "Src1 needs to be literal here");
   uint8_t Imm = Op->Src[1].Data.Literal.Value;
   uint8_t CountS = (Imm >> 6);
   uint8_t CountD = (Imm >> 4) & 0b11;
@@ -689,7 +689,7 @@ void OpDispatchBuilder::PExtrOp(OpcodeArgs) {
   const auto Size = GetSrcSize(Op);
 
   OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-  LOGMAN_THROW_A(Op->Src[1].IsLiteral(), "Src1 needs to be literal here");
+  LOGMAN_THROW_A_FMT(Op->Src[1].IsLiteral(), "Src1 needs to be literal here");
   uint64_t Index = Op->Src[1].Data.Literal.Value;
 
   const uint8_t NumElements = Size / ElementSize;
@@ -784,7 +784,7 @@ template<size_t ElementSize>
 void OpDispatchBuilder::PSRLI(OpcodeArgs) {
   OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
 
-  LOGMAN_THROW_A(Op->Src[1].IsLiteral(), "Src1 needs to be literal here");
+  LOGMAN_THROW_A_FMT(Op->Src[1].IsLiteral(), "Src1 needs to be literal here");
   uint64_t ShiftConstant = Op->Src[1].Data.Literal.Value;
 
   auto Size = GetSrcSize(Op);
@@ -804,7 +804,7 @@ template<size_t ElementSize>
 void OpDispatchBuilder::PSLLI(OpcodeArgs) {
   OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
 
-  LOGMAN_THROW_A(Op->Src[1].IsLiteral(), "Src1 needs to be literal here");
+  LOGMAN_THROW_A_FMT(Op->Src[1].IsLiteral(), "Src1 needs to be literal here");
   uint64_t ShiftConstant = Op->Src[1].Data.Literal.Value;
 
   auto Size = GetSrcSize(Op);
@@ -867,7 +867,7 @@ template
 void OpDispatchBuilder::PSRAOp<4>(OpcodeArgs);
 
 void OpDispatchBuilder::PSRLDQ(OpcodeArgs) {
-  LOGMAN_THROW_A(Op->Src[1].IsLiteral(), "Src1 needs to be literal here");
+  LOGMAN_THROW_A_FMT(Op->Src[1].IsLiteral(), "Src1 needs to be literal here");
   uint64_t Shift = Op->Src[1].Data.Literal.Value;
 
   OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
@@ -879,7 +879,7 @@ void OpDispatchBuilder::PSRLDQ(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::PSLLDQ(OpcodeArgs) {
-  LOGMAN_THROW_A(Op->Src[1].IsLiteral(), "Src1 needs to be literal here");
+  LOGMAN_THROW_A_FMT(Op->Src[1].IsLiteral(), "Src1 needs to be literal here");
   uint64_t Shift = Op->Src[1].Data.Literal.Value;
 
   OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
@@ -892,7 +892,7 @@ void OpDispatchBuilder::PSLLDQ(OpcodeArgs) {
 
 template<size_t ElementSize>
 void OpDispatchBuilder::PSRAIOp(OpcodeArgs) {
-  LOGMAN_THROW_A(Op->Src[1].IsLiteral(), "Src1 needs to be literal here");
+  LOGMAN_THROW_A_FMT(Op->Src[1].IsLiteral(), "Src1 needs to be literal here");
   uint64_t Shift = Op->Src[1].Data.Literal.Value;
 
   OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
@@ -1226,7 +1226,9 @@ void OpDispatchBuilder::VFCMPOp(OpcodeArgs) {
     case 0x07: case 0x0F: case 0x17: case 0x1F: // Ordered
       Result = _VFCMPORD(Size, ElementSize, Src2, Src);
     break;
-    default: LOGMAN_MSG_A("Unknown Comparison type: %d", CompType);
+    default:
+      LOGMAN_MSG_A_FMT("Unknown Comparison type: {}", CompType);
+    break;
   }
 
   if constexpr (Scalar) {
@@ -2110,7 +2112,7 @@ void OpDispatchBuilder::ExtendVectorElements<4, 8, true>(OpcodeArgs);
 
 template<size_t ElementSize, bool Scalar>
 void OpDispatchBuilder::VectorRound(OpcodeArgs) {
-  LOGMAN_THROW_A(Op->Src[1].IsLiteral(), "Src1 needs to be literal here");
+  LOGMAN_THROW_A_FMT(Op->Src[1].IsLiteral(), "Src1 needs to be literal here");
   uint64_t Mode = Op->Src[1].Data.Literal.Value;
   uint64_t RoundControlSource = (Mode >> 2) & 1;
   uint64_t RoundControl = Mode & 0b11;
@@ -2155,7 +2157,7 @@ void OpDispatchBuilder::VectorRound<8, true>(OpcodeArgs);
 
 template<size_t ElementSize>
 void OpDispatchBuilder::VectorBlend(OpcodeArgs) {
-  LOGMAN_THROW_A(Op->Src[1].IsLiteral(), "Src1 needs to be literal here");
+  LOGMAN_THROW_A_FMT(Op->Src[1].IsLiteral(), "Src1 needs to be literal here");
   uint8_t Select = Op->Src[1].Data.Literal.Value;
 
   OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
@@ -2275,7 +2277,7 @@ void OpDispatchBuilder::PHMINPOSUWOp(OpcodeArgs) {
 
 template<size_t ElementSize>
 void OpDispatchBuilder::DPPOp(OpcodeArgs) {
-  LOGMAN_THROW_A(Op->Src[1].IsLiteral(), "Src1 needs to be literal here");
+  LOGMAN_THROW_A_FMT(Op->Src[1].IsLiteral(), "Src1 needs to be literal here");
   uint8_t Mask = Op->Src[1].Data.Literal.Value;
   uint8_t SrcMask = Mask >> 4;
   uint8_t DstMask = Mask & 0xF;
@@ -2323,7 +2325,7 @@ template
 void OpDispatchBuilder::DPPOp<8>(OpcodeArgs);
 
 void OpDispatchBuilder::MPSADBWOp(OpcodeArgs) {
-  LOGMAN_THROW_A(Op->Src[1].IsLiteral(), "Src1 needs to be literal here");
+  LOGMAN_THROW_A_FMT(Op->Src[1].IsLiteral(), "Src1 needs to be literal here");
   uint8_t Select = Op->Src[1].Data.Literal.Value;
 
   // Src1 needs to be in byte offset

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
@@ -1334,7 +1334,7 @@ void OpDispatchBuilder::X87FCMOV(OpcodeArgs) {
     Type = COMPARE_ZERO;
   break;
   default:
-    LOGMAN_MSG_A("Unhandled FCMOV op: 0x%x", Opcode);
+    LOGMAN_MSG_A_FMT("Unhandled FCMOV op: 0x{:x}", Opcode);
   break;
   }
 

--- a/External/FEXCore/Source/Interface/Core/SignalDelegator.cpp
+++ b/External/FEXCore/Source/Interface/Core/SignalDelegator.cpp
@@ -53,7 +53,7 @@ namespace FEXCore {
     // Be warned, a thread will inherit the signal mask if created from this thread
     int Result = pthread_sigmask(how, &SignalSet, nullptr);
     if (Result != 0) {
-      LogMan::Msg::E("Couldn't register thread to mask signals");
+      LogMan::Msg::EFmt("Couldn't register thread to mask signals");
     }
   }
 
@@ -91,7 +91,7 @@ namespace FEXCore {
     HostSignalHandler &Handler = HostHandlers[Signal];
 
     if (!Thread) {
-      LogMan::Msg::E("[%d] Thread has received a signal and hasn't registered itself with the delegate! Programming error!", ::gettid());
+      LogMan::Msg::EFmt("[{}] Thread has received a signal and hasn't registered itself with the delegate! Programming error!", ::gettid());
     }
     else {
       if (Handler.Handler &&

--- a/External/FEXCore/Source/Interface/Core/X86Tables/X86Tables.h
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/X86Tables.h
@@ -34,7 +34,7 @@ static inline void GenerateTable(X86InstInfo *FinalTable, U8U8InfoStruct const *
     auto OpNum = Op.first;
     X86InstInfo const &Info = Op.Info;
     for (uint32_t i = 0; i < Op.second; ++i) {
-      LOGMAN_THROW_A(FinalTable[OpNum + i].Type == TYPE_UNKNOWN, "Duplicate Entry %s->%s", FinalTable[OpNum + i].Name, Info.Name);
+      LOGMAN_THROW_A_FMT(FinalTable[OpNum + i].Type == TYPE_UNKNOWN, "Duplicate Entry {}->{}", FinalTable[OpNum + i].Name, Info.Name);
       FinalTable[OpNum + i] = Info;
 #ifndef NDEBUG
       ++Total;
@@ -51,7 +51,7 @@ static inline void GenerateTable(X86InstInfo *FinalTable, U16U8InfoStruct const 
     auto OpNum = Op.first;
     X86InstInfo const &Info = Op.Info;
     for (uint32_t i = 0; i < Op.second; ++i) {
-      LOGMAN_THROW_A(FinalTable[OpNum + i].Type == TYPE_UNKNOWN, "Duplicate Entry %s->%s", FinalTable[OpNum + i].Name, Info.Name);
+      LOGMAN_THROW_A_FMT(FinalTable[OpNum + i].Type == TYPE_UNKNOWN, "Duplicate Entry {}->{}", FinalTable[OpNum + i].Name, Info.Name);
       FinalTable[OpNum + i] = Info;
 #ifndef NDEBUG
       ++Total;
@@ -68,7 +68,7 @@ static inline void GenerateTableWithCopy(X86InstInfo *FinalTable, U8U8InfoStruct
     auto OpNum = Op.first;
     X86InstInfo const &Info = Op.Info;
     for (uint32_t i = 0; i < Op.second; ++i) {
-      LOGMAN_THROW_A(FinalTable[OpNum + i].Type == TYPE_UNKNOWN, "Duplicate Entry %s->%s", FinalTable[OpNum + i].Name, Info.Name);
+      LOGMAN_THROW_A_FMT(FinalTable[OpNum + i].Type == TYPE_UNKNOWN, "Duplicate Entry {}->{}", FinalTable[OpNum + i].Name, Info.Name);
       if (Info.Type == TYPE_COPY_OTHER) {
         FinalTable[OpNum + i] = OtherLocal[OpNum + i];
       }
@@ -90,7 +90,7 @@ static inline void GenerateX87Table(X86InstInfo *FinalTable, U16U8InfoStruct con
     auto OpNum = Op.first;
     X86InstInfo const &Info = Op.Info;
     for (uint32_t i = 0; i < Op.second; ++i) {
-      LOGMAN_THROW_A(FinalTable[OpNum + i].Type == TYPE_UNKNOWN, "Duplicate Entry %s->%s", FinalTable[OpNum + i].Name, Info.Name);
+      LOGMAN_THROW_A_FMT(FinalTable[OpNum + i].Type == TYPE_UNKNOWN, "Duplicate Entry {}->{}", FinalTable[OpNum + i].Name, Info.Name);
       if ((OpNum & 0b11'000'000) == 0b11'000'000) {
         // If the mod field is 0b11 then it is a regular op
         FinalTable[OpNum + i] = Info;
@@ -98,7 +98,7 @@ static inline void GenerateX87Table(X86InstInfo *FinalTable, U16U8InfoStruct con
       else {
         // If the mod field is !0b11 then this instruction is duplicated through the whole mod [0b00, 0b10] range
         // and the modrm.rm space because that is used part of the instruction encoding
-        LOGMAN_THROW_A((OpNum & 0b11'000'000) == 0, "Only support mod field of zero in this path");
+        LOGMAN_THROW_A_FMT((OpNum & 0b11'000'000) == 0, "Only support mod field of zero in this path");
         for (uint16_t mod = 0b00'000'000; mod < 0b11'000'000; mod += 0b01'000'000) {
           for (uint16_t rm = 0b000; rm < 0b1'000; ++rm) {
             FinalTable[(OpNum | mod | rm) + i] = Info;

--- a/External/FEXCore/Source/Interface/HLE/Thunks/Thunks.cpp
+++ b/External/FEXCore/Source/Interface/HLE/Thunks/Thunks.cpp
@@ -66,12 +66,12 @@ namespace FEXCore {
 
             auto SOName = CTX->Config.ThunkHostLibsPath() + "/" + (const char*)Name + "-host.so";
 
-            LogMan::Msg::D("Load lib: %s -> %s", Name, SOName.c_str());
+            LogMan::Msg::DFmt("Load lib: {} -> {}", Name, SOName);
 
             auto Handle = dlopen(SOName.c_str(), RTLD_LOCAL | RTLD_NOW);
 
             if (!Handle) {
-                LogMan::Msg::E("Load lib: failed to dlopen %s: %s", SOName.c_str(), dlerror());
+                LogMan::Msg::EFmt("Load lib: failed to dlopen {}: {}", SOName, dlerror());
                 return;
             }
 
@@ -82,7 +82,7 @@ namespace FEXCore {
             (void*&)InitFN = dlsym(Handle, InitSym.c_str());
 
             if (!InitFN) {
-                LogMan::Msg::E("Load lib: failed to find export %s", InitSym.c_str());
+                LogMan::Msg::EFmt("Load lib: failed to find export {}", InitSym);
                 return;
             }
 
@@ -98,7 +98,7 @@ namespace FEXCore {
                     That->Thunks[*reinterpret_cast<IR::SHA256Sum*>(Exports[i].sha256)] = Exports[i].Fn;
                 }
 
-                LogMan::Msg::D("Loaded %d syms", i);
+                LogMan::Msg::DFmt("Loaded {} syms", i);
             }
         }
 

--- a/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -287,7 +287,7 @@ void ConstProp::FCMPOptimization(IREmitter *IREmit, const IRListView& CurrentIR)
       auto ghf = IROp->CW<IR::IROp_GetHostFlag>();
 
       auto fcmp = IREmit->GetOpHeader(ghf->GPR)->CW<IR::IROp_FCmp>();
-      LOGMAN_THROW_A(fcmp->Header.Op == OP_FCMP || fcmp->Header.Op == OP_F80CMP, "Unexpected OP_GETHOSTFLAG source");
+      LOGMAN_THROW_A_FMT(fcmp->Header.Op == OP_FCMP || fcmp->Header.Op == OP_F80CMP, "Unexpected OP_GETHOSTFLAG source");
       if(fcmp->Header.Op == OP_FCMP) {
         fcmp->Flags |= 1 << ghf->Flag;
       }

--- a/External/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
@@ -353,15 +353,15 @@ ContextMemberInfo *RCLSE::FindMemberInfo(ContextInfo *ContextClassificationInfo,
 }
 
 ContextMemberInfo *RCLSE::RecordAccess(ContextMemberInfo *Info, FEXCore::IR::RegisterClassType RegClass, uint32_t Offset, uint8_t Size, LastAccessType AccessType, FEXCore::IR::OrderedNode *Node, FEXCore::IR::OrderedNode *StoreNode) {
-  LOGMAN_THROW_A((Offset + Size) <= (Info->Class.Offset + Info->Class.Size), "Access to context item went over member size");
-  LOGMAN_THROW_A(Info->Accessed != ACCESS_INVALID, "Tried to access invalid member");
+  LOGMAN_THROW_A_FMT((Offset + Size) <= (Info->Class.Offset + Info->Class.Size), "Access to context item went over member size");
+  LOGMAN_THROW_A_FMT(Info->Accessed != ACCESS_INVALID, "Tried to access invalid member");
 
   // If we aren't fully overwriting the member then it is a partial write that we need to track
   if (Size < Info->Class.Size) {
     AccessType = AccessType == ACCESS_WRITE ? ACCESS_PARTIAL_WRITE : ACCESS_PARTIAL_READ;
   }
   if (Size > Info->Class.Size) {
-    LOGMAN_MSG_A("Can't handle this");
+    LOGMAN_MSG_A_FMT("Can't handle this");
   }
 
   Info->Accessed = AccessType;
@@ -503,7 +503,7 @@ bool RCLSE::RedundantStoreLoadElimination(FEXCore::IR::IREmitter *IREmit) {
           IREmit->Remove(LastStoreNode);
 
           if (LastSize < IROp->Size) {
-            //printf("RCLSE: Eliminated partial write\n");
+            //fmt::print("RCLSE: Eliminated partial write\n");
           }
           Changed = true;
         }
@@ -589,7 +589,7 @@ bool RCLSE::RedundantStoreLoadElimination(FEXCore::IR::IREmitter *IREmit) {
               RecordAccess(Info, Op->Class, Op->Offset, IROp->Size, ACCESS_READ, LastNode);
               Changed = true;
             } else {
-              //printf("RCLSE: Not GPR class, missed, %d, lastS: %d, S: %d, Node S: %d\n", LastClass, LastSize, IROp->Size, IREmit->GetOpSize(LastNode));
+              //fmt::print("RCLSE: Not GPR class, missed, {}, lastS: {}, S: {}, Node S: {}\n", LastClass, LastSize, IROp->Size, IREmit->GetOpSize(LastNode));
             }
           }
         }

--- a/External/FEXCore/Source/Interface/IR/Passes/DeadStoreElimination.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/DeadStoreElimination.cpp
@@ -116,7 +116,7 @@ uint64_t FPRBit(uint32_t Offset, uint32_t Size) {
   else if (Size == 4)
     return  1UL << (bitn);
   else
-    LOGMAN_MSG_A("Unexpected FPR size %d", Size);
+    LOGMAN_MSG_A_FMT("Unexpected FPR size {}", Size);
 
   return 7UL << (bitn); // Return maximum on failure case
 }

--- a/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
@@ -282,7 +282,7 @@ bool IRValidation::Run(IREmitter *IREmit) {
 
     LogMan::Msg::EFmt("{}", Out.str());
 
-    LOGMAN_MSG_A("Encountered IR validation Error");
+    LOGMAN_MSG_A_FMT("Encountered IR validation Error");
 
     Errors.clear();
     Warnings.clear();

--- a/External/FEXCore/Source/Interface/IR/Passes/RAValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/RAValidation.cpp
@@ -32,7 +32,7 @@ struct RegState {
 
   // Mark a physical register as containing a SSA id
   bool Set(PhysicalRegister Reg, uint32_t ssa) {
-    LOGMAN_THROW_A(ssa != 0, "RegState assumes ssa0 will be the block header and never assigned to a register");
+    LOGMAN_THROW_A_FMT(ssa != 0, "RegState assumes ssa0 will be the block header and never assigned to a register");
 
     // PhyscialRegisters aren't fully mapped until assembly emission
     // We need to apply a generic mapping here to catch any aliasing
@@ -197,11 +197,11 @@ bool RAValidation::Run(IREmitter *IREmit) {
 
   // Get the control flow graph from the validation pass
   auto ValidationPass = Manager->GetPass<IRValidation>("IRValidation");
-  LOGMAN_THROW_A(ValidationPass != nullptr, "Couldn't find IRValidation pass");
+  LOGMAN_THROW_A_FMT(ValidationPass != nullptr, "Couldn't find IRValidation pass");
 
   auto& OffsetToBlockMap = ValidationPass->OffsetToBlockMap;
 
-  LOGMAN_THROW_A(ValidationPass->EntryBlock != nullptr, "No entry point");
+  LOGMAN_THROW_A_FMT(ValidationPass->EntryBlock != nullptr, "No entry point");
   BlocksToVisit.push_front(ValidationPass->EntryBlock); // Currently only a single entry point
 
   bool HadError = false;
@@ -440,8 +440,7 @@ bool RAValidation::Run(IREmitter *IREmit) {
     FEXCore::IR::Dump(&IrDump, &CurrentIR, RAData);
 
     LogMan::Msg::EFmt("RA Validation Error\n{}\nErrors:\n{}\n", IrDump.str(), Errors.str());
-
-    LOGMAN_MSG_A("Encountered RA validation Error");
+    LOGMAN_MSG_A_FMT("Encountered RA validation Error");
 
     Errors.clear();
   }

--- a/External/FEXCore/Source/Interface/IR/Passes/StaticRegisterAllocationPass.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/StaticRegisterAllocationPass.cpp
@@ -24,33 +24,33 @@ public:
 };
 
 bool IsStaticAllocGpr(uint32_t Offset, RegisterClassType Class) {
-  bool rv = false;
-  auto begin = offsetof(FEXCore::Core::CPUState, gregs[0]);
-  auto end = offsetof(FEXCore::Core::CPUState, gregs[17]);
+  const auto begin = offsetof(FEXCore::Core::CPUState, gregs[0]);
+  const auto end = offsetof(FEXCore::Core::CPUState, gregs[17]);
 
   if (Offset >= begin && Offset < end) {
-    auto reg = (Offset - begin) / 8;
-    LOGMAN_THROW_A(Class == IR::GPRClass, "unexpected Class %d", Class);
+    const auto reg = (Offset - begin) / 8;
+    LOGMAN_THROW_A_FMT(Class == IR::GPRClass, "unexpected Class {}", Class);
 
-    rv = reg < 16; // 0..15 -> 16 in total
+    // 0..15 -> 16 in total
+    return reg < 16;
   }
 
-  return rv;
+  return false;
 }
 
 bool IsStaticAllocFpr(uint32_t Offset, RegisterClassType Class, bool AllowGpr) {
-  bool rv = false;
-  auto begin = offsetof(FEXCore::Core::CPUState, xmm[0][0]);
-  auto end = offsetof(FEXCore::Core::CPUState, xmm[17][0]);
+  const auto begin = offsetof(FEXCore::Core::CPUState, xmm[0][0]);
+  const auto end = offsetof(FEXCore::Core::CPUState, xmm[17][0]);
 
   if (Offset >= begin && Offset < end) {
-    auto reg = (Offset - begin)/16;
-    LOGMAN_THROW_A(Class == IR::FPRClass || (AllowGpr && Class == IR::GPRClass), "unexpected Class %d, AllowGpr %d", Class, AllowGpr);
+    const auto reg = (Offset - begin) / 16;
+    LOGMAN_THROW_A_FMT(Class == IR::FPRClass || (AllowGpr && Class == IR::GPRClass), "unexpected Class {}, AllowGpr {}", Class, AllowGpr);
 
-    rv = reg < 16; // 0..15 -> 16 in total
+    // 0..15 -> 16 in total
+    return reg < 16;
   }
 
-  return rv;
+  return false;
 }
 /**
  * @brief This pass replaces Load/Store Context with Load/Store Register for Statically Mapped registers. It also does some validation.

--- a/External/FEXCore/Source/Utils/Allocator/64BitAllocator.cpp
+++ b/External/FEXCore/Source/Utils/Allocator/64BitAllocator.cpp
@@ -124,7 +124,7 @@ namespace Alloc::OSAllocator {
 
         [[maybe_unused]] auto Res = mprotect(reinterpret_cast<void*>(ReservedRegion->Base), SizePlusManagedData, PROT_READ | PROT_WRITE);
 
-        LOGMAN_THROW_A(Res == 0, "Couldn't mprotect region: %d '%s' Likely occurs when running out of memory or Maximum VMAs", errno, strerror(errno));
+        LOGMAN_THROW_A_FMT(Res == 0, "Couldn't mprotect region: {} '{}' Likely occurs when running out of memory or Maximum VMAs", errno, strerror(errno));
 
         LiveVMARegion *LiveRange = new (reinterpret_cast<void*>(ReservedRegion->Base)) LiveVMARegion();
 

--- a/External/FEXCore/Source/Utils/Telemetry.cpp
+++ b/External/FEXCore/Source/Utils/Telemetry.cpp
@@ -27,7 +27,7 @@ namespace FEXCore::Telemetry {
     std::error_code ec{};
     if (!std::filesystem::exists(DataDirectory, ec) &&
         !std::filesystem::create_directories(DataDirectory, ec)) {
-      LogMan::Msg::I("Couldn't create telemetry Folder");
+      LogMan::Msg::IFmt("Couldn't create telemetry Folder");
     }
   }
 

--- a/External/FEXCore/Source/Utils/Threads.cpp
+++ b/External/FEXCore/Source/Utils/Threads.cpp
@@ -188,7 +188,8 @@ namespace FEXCore::Threads {
     ClearStackPool(DeadStackPool);
     ClearStackPool(LiveStackPool);
 
-    LogMan::Throw::A((DeadStackPool.size() + LiveStackPool.size()) <= 1, "After fork we should only have zero or one tracked stacks!");
+    LogMan::Throw::AFmt((DeadStackPool.size() + LiveStackPool.size()) <= 1,
+                        "After fork we should only have zero or one tracked stacks!");
   }
 
   static FEXCore::Threads::Pointers Ptrs = {

--- a/External/FEXCore/include/FEXCore/Config/Config.h
+++ b/External/FEXCore/include/FEXCore/Config/Config.h
@@ -184,7 +184,7 @@ namespace Type {
     Value(FEXCore::Config::ConfigOption _Option)
       : Option {_Option} {
       if (!FEXCore::Config::Exists(Option)) {
-        ERROR_AND_DIE("FEXCore::Config::Value has no value");
+        ERROR_AND_DIE_FMT("FEXCore::Config::Value has no value");
       }
 
       ValueData = Get(Option);
@@ -194,7 +194,7 @@ namespace Type {
     Value(FEXCore::Config::ConfigOption _Option)
       : Option {_Option} {
       if (!FEXCore::Config::Exists(Option)) {
-        ERROR_AND_DIE("FEXCore::Config::Value has no value");
+        ERROR_AND_DIE_FMT("FEXCore::Config::Value has no value");
       }
 
       ValueData = GetIfExists(Option);

--- a/External/FEXCore/include/FEXCore/HLE/SyscallVisitor.h
+++ b/External/FEXCore/include/FEXCore/HLE/SyscallVisitor.h
@@ -3,7 +3,7 @@
 #include <stdint.h>
 
 namespace FEXCore::HLE {
-#define INVALID_OP { LOGMAN_MSG_A("Tried to syscall with unknown number of registers");  return 0; }
+#define INVALID_OP { LOGMAN_MSG_A_FMT("Tried to syscall with unknown number of registers");  return 0; }
   class SyscallVisitor {
   public:
     SyscallVisitor(uint32_t Mask) : SyscallVisitor(Mask, false) {}

--- a/External/FEXCore/include/FEXCore/Utils/BucketList.h
+++ b/External/FEXCore/include/FEXCore/Utils/BucketList.h
@@ -44,7 +44,7 @@ namespace FEXCore {
         Enumerator(Item);
 
         if (++i == Bucket->Size) {
-          LOGMAN_THROW_A(Bucket->Next != nullptr, "Interference bug");
+          LOGMAN_THROW_A_FMT(Bucket->Next != nullptr, "Interference bug");
           Bucket = Bucket->Next.get();
           i = 0;
         }
@@ -65,7 +65,7 @@ namespace FEXCore {
           return true;
 
         if (++i == Bucket->Size) {
-          LOGMAN_THROW_A(Bucket->Next != nullptr, "Bucket in bad state");
+          LOGMAN_THROW_A_FMT(Bucket->Next != nullptr, "Bucket in bad state");
           Bucket = Bucket->Next.get();
           i = 0;
         }
@@ -109,7 +109,7 @@ namespace FEXCore {
         }
         else if (++i == Size) {
           i = 0;
-          LOGMAN_THROW_A(that->Next != nullptr, "Bucket::Erase but element not contained");
+          LOGMAN_THROW_A_FMT(that->Next != nullptr, "Bucket::Erase but element not contained");
           that = that->Next.get();
         }
       }

--- a/External/FEXCore/include/FEXCore/Utils/LogManager.h
+++ b/External/FEXCore/include/FEXCore/Utils/LogManager.h
@@ -19,29 +19,13 @@ enum DebugLevels {
 
 constexpr DebugLevels MSG_LEVEL = INFO;
 
+// Note that all logging functions with the Fmt or _FMT suffix on them expect
+// format strings as used by fmtlib (or C++ std::format).
+
 namespace Throw {
 using ThrowHandler = void(*)(char const *Message);
 FEX_DEFAULT_VISIBILITY void InstallHandler(ThrowHandler Handler);
 FEX_DEFAULT_VISIBILITY void UnInstallHandlers();
-
-[[noreturn]] void M(const char *fmt, va_list args);
-
-#if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
-static inline void A(bool Value, const char *fmt, ...) {
-  if (MSG_LEVEL >= ASSERT && !Value) {
-    va_list args;
-    va_start(args, fmt);
-    M(fmt, args);
-    va_end(args);
-  }
-}
-#define LOGMAN_THROW_A(pred, ...) do { LogMan::Throw::A(pred, __VA_ARGS__); } while (0)
-#else
-static inline void A(bool, const char*, ...) {}
-#define LOGMAN_THROW_A(pred, ...) do {} while (0)
-#endif
-
-// Fmt interface
 
 [[noreturn]] void MFmt(const char *fmt, const fmt::format_args& args);
 
@@ -66,77 +50,7 @@ using MsgHandler = void(*)(DebugLevels Level, char const *Message);
 FEX_DEFAULT_VISIBILITY void InstallHandler(MsgHandler Handler);
 FEX_DEFAULT_VISIBILITY void UnInstallHandlers();
 
-FEX_DEFAULT_VISIBILITY void M(DebugLevels Level, const char *fmt, va_list args);
-
-#if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
-static inline void A(const char *fmt, ...) {
-  if (MSG_LEVEL >= ASSERT) {
-    va_list args;
-    va_start(args, fmt);
-    M(ASSERT, fmt, args);
-    va_end(args);
-  }
-  FEX_TRAP_EXECUTION;
-}
-#define LOGMAN_MSG_A(...) do { LogMan::Msg::A(__VA_ARGS__); } while (0)
-#else
-static inline void A(const char*, ...) {}
-#define LOGMAN_MSG_A(...) do {} while(0)
-#endif
-
-static inline void E(const char *fmt, ...) {
-  if (MSG_LEVEL >= ERROR) {
-    va_list args;
-    va_start(args, fmt);
-    M(ERROR, fmt, args);
-    va_end(args);
-  }
-}
-static inline void D(const char *fmt, ...) {
-  if (MSG_LEVEL >= DEBUG) {
-    va_list args;
-    va_start(args, fmt);
-    M(DEBUG, fmt, args);
-    va_end(args);
-  }
-}
-static inline void I(const char *fmt, ...) {
-  if (MSG_LEVEL >= INFO) {
-    va_list args;
-    va_start(args, fmt);
-    M(INFO, fmt, args);
-    va_end(args);
-  }
-}
-
-static inline void OUT(const char *fmt, ...) {
-  va_list args;
-  va_start(args, fmt);
-  M(STDOUT, fmt, args);
-  va_end(args);
-}
-
-static inline void ERR(const char *fmt, ...) {
-  va_list args;
-  va_start(args, fmt);
-  M(STDERR, fmt, args);
-  va_end(args);
-}
-
-#define WARN_ONCE(...) \
-  do { \
-    static bool Warned{}; \
-    if (!Warned) { \
-      LogMan::Msg::D(__VA_ARGS__); \
-      Warned = true; \
-    } \
-  } while (0);
-
-#define ERROR_AND_DIE(...) \
-  do { \
-    LogMan::Msg::E(__VA_ARGS__); \
-    FEX_TRAP_EXECUTION; \
-  } while(0)
+FEX_DEFAULT_VISIBILITY void D(const char *fmt, ...);
 
 // Fmt-capable interface.
 

--- a/Source/CommonCore/HostFactory.cpp
+++ b/Source/CommonCore/HostFactory.cpp
@@ -167,7 +167,7 @@ namespace HostFactory {
     ldt.lm = 0; // Not-64-bit
     int Res = modify_ldt(0x11, &ldt);
     if (Res == -1) {
-      LogMan::Msg::E("Couldn't load 32-bit LDT");
+      LogMan::Msg::EFmt("Couldn't load 32-bit LDT");
       return;
     }
 
@@ -188,7 +188,7 @@ namespace HostFactory {
     ldt.lm = 0; // Not-64-bit
     Res = modify_ldt(0x11, &ldt);
     if (Res == -1) {
-      LogMan::Msg::E("Couldn't load 32-bit LDT");
+      LogMan::Msg::EFmt("Couldn't load 32-bit LDT");
       return;
     }
 
@@ -206,7 +206,7 @@ namespace HostFactory {
     ldt.lm = 0; // Not-64-bit
     Res = modify_ldt(0x11, &ldt);
     if (Res == -1) {
-      LogMan::Msg::E("Couldn't load 32-bit LDT");
+      LogMan::Msg::EFmt("Couldn't load 32-bit LDT");
       return;
     }
 
@@ -296,7 +296,7 @@ namespace HostFactory {
   }
 #else
   std::unique_ptr<FEXCore::CPU::CPUBackend> CPUCreationFactory(FEXCore::Context::Context* CTX, FEXCore::Core::InternalThreadState *Thread) {
-    LOGMAN_MSG_A("HostCPU factory doesn't exist for this host");
+    LOGMAN_MSG_A_FMT("HostCPU factory doesn't exist for this host");
     return nullptr;
   }
 #endif

--- a/Source/Linux/Utils/ELFParser.h
+++ b/Source/Linux/Utils/ELFParser.h
@@ -47,12 +47,12 @@ struct ELFParser {
 
     uint8_t header[5];
     if (pread(fd, header, sizeof(header), 0) == -1) {
-      LogMan::Msg::E("Failed to read elf header from '%d'", fd);
+      LogMan::Msg::EFmt("Failed to read elf header from '{}'", fd);
       return false;
     }
 
     if (header[0] != ELFMAG0 || header[1] != ELFMAG1 || header[2] != ELFMAG2 || header[3] != ELFMAG3) {
-      LogMan::Msg::E("Elf header from '%d' doesn't match ELF MAGIC", fd);
+      LogMan::Msg::EFmt("Elf header from '{}' doesn't match ELF MAGIC", fd);
       return false;
     }
 
@@ -61,7 +61,7 @@ struct ELFParser {
     if (header[EI_CLASS] == ELFCLASS32) {
       Elf32_Ehdr hdr32;
       if (pread(fd, &hdr32, sizeof(hdr32), 0) == -1) {
-        LogMan::Msg::E("Failed to read Ehdr32 from '%d'", fd);
+        LogMan::Msg::EFmt("Failed to read Ehdr32 from '{}'", fd);
         return false;
       }
 
@@ -69,13 +69,13 @@ struct ELFParser {
 
       // check elf header
       if (hdr32.e_ehsize != sizeof(hdr32)) {
-        LogMan::Msg::E("Invalid e_ehsize32 from '%d'", fd);
+        LogMan::Msg::EFmt("Invalid e_ehsize32 from '{}'", fd);
         return false;
       }
 
       // check program header
       if (hdr32.e_phentsize != sizeof(Elf32_Phdr)) {
-        LogMan::Msg::E("Invalid e_phentsize32 from '%d'", fd);
+        LogMan::Msg::EFmt("Invalid e_phentsize32 from '{}'", fd);
         return false;
       }
 
@@ -100,14 +100,14 @@ struct ELFParser {
       #undef COPY
 
       if (ehdr.e_machine != EM_386) {
-        LogMan::Msg::E("Invalid e_machine from '%d'", fd);
+        LogMan::Msg::EFmt("Invalid e_machine from '{}'", fd);
         return false;
       }
 
       type = ::ELFLoader::ELFContainer::TYPE_X86_32;
     } else if (header[EI_CLASS] == ELFCLASS64) {
       if (pread(fd, &ehdr, sizeof(ehdr), 0) == -1) {
-        LogMan::Msg::E("Failed to read Ehdr64 from '%d'", fd);
+        LogMan::Msg::EFmt("Failed to read Ehdr64 from '{}'", fd);
         return false;
       }
 
@@ -115,31 +115,31 @@ struct ELFParser {
 
       // check elf header
       if (ehdr.e_ehsize != sizeof(ehdr)) {
-        LogMan::Msg::E("Invalid e_ehsize64 from '%d'", fd);
+        LogMan::Msg::EFmt("Invalid e_ehsize64 from '{}'", fd);
         return false;
       }
 
       // check program header
       if (ehdr.e_phentsize != sizeof(Elf64_Phdr)) {
-        LogMan::Msg::E("Invalid e_phentsize64 from '%d'", fd);
+        LogMan::Msg::EFmt("Invalid e_phentsize64 from '{}'", fd);
         return false;
       }
 
       if (ehdr.e_machine != EM_X86_64) {
-        LogMan::Msg::E("Invalid e_machine64 from '%d'", fd);
+        LogMan::Msg::EFmt("Invalid e_machine64 from '{}'", fd);
         return false;
       }
 
       type = ::ELFLoader::ELFContainer::TYPE_X86_64;
     } else {
       // Unexpected elf type
-      LogMan::Msg::E("Unexpected elf type from '%d'", fd);
+      LogMan::Msg::EFmt("Unexpected elf type from '{}'", fd);
       return false;
     }
 
     // sanity check program header count
     if (ehdr.e_phnum < 1 || ehdr.e_phnum > 65536 / ehdr.e_phentsize) {
-      LogMan::Msg::E("Too many program headers '%d'", fd);
+      LogMan::Msg::EFmt("Too many program headers '{}'", fd);
       return false;
     }
 
@@ -147,7 +147,7 @@ struct ELFParser {
       Elf32_Phdr phdrs32[ehdr.e_phnum];
 
       if (pread(fd, phdrs32, sizeof(Elf32_Phdr) * ehdr.e_phnum, ehdr.e_phoff) == -1) {
-        LogMan::Msg::E("Failed to read phdr32 from '%d'", fd);
+        LogMan::Msg::EFmt("Failed to read phdr32 from '{}'", fd);
         return false;
       }
 
@@ -172,7 +172,7 @@ struct ELFParser {
       phdrs.resize(ehdr.e_phnum);
 
       if (pread(fd, &phdrs[0], sizeof(Elf64_Phdr) * ehdr.e_phnum, ehdr.e_phoff) == -1) {
-        LogMan::Msg::E("Failed to read phdr64 from '%d'", fd);
+        LogMan::Msg::EFmt("Failed to read phdr64 from '{}'", fd);
         return false;
       }
     }
@@ -182,7 +182,7 @@ struct ELFParser {
         InterpreterElf.resize(phdr.p_filesz);
 
         if (pread(fd, &InterpreterElf[0], phdr.p_filesz, phdr.p_offset) == -1) {
-          LogMan::Msg::E("Failed to read interpreter from '%d'", fd);
+          LogMan::Msg::EFmt("Failed to read interpreter from '{}'", fd);
           return false;
         }
       }

--- a/Source/Linux/Utils/ELFSymbolDatabase.cpp
+++ b/Source/Linux/Utils/ELFSymbolDatabase.cpp
@@ -89,7 +89,7 @@ ELFSymbolDatabase::ELFSymbolDatabase(::ELFLoader::ELFContainer *file)
         bool Found =
 #endif
         FindLibraryFile(&LibraryPath, Lib.c_str());
-        LOGMAN_THROW_A(Found, "Couldn't find library '%s'", Lib.c_str());
+        LOGMAN_THROW_A_FMT(Found, "Couldn't find library '{}'", Lib);
         auto Info = DynamicELFInfo.emplace_back(new ELFInfo{});
         Info->Name = Lib;
         Info->Container = new ::ELFLoader::ELFContainer(LibraryPath, {}, true);
@@ -171,7 +171,7 @@ void ELFSymbolDatabase::FillMemoryLayouts(uint64_t DefinedBase) {
     uint64_t CurrentELFAlignedSize = AlignUp(std::get<2>(LocalInfo.CustomLayout), 4096);
     if (CurrentELFBase < 0x10000) {
       // We can't allocate memory in the first 16KB,  Hopefully no elfs require this.
-      LOGMAN_MSG_A("Elf requires memory mapped in the first 16kb");
+      LOGMAN_MSG_A_FMT("Elf requires memory mapped in the first 16kb");
     }
 
     std::get<2>(LocalInfo.CustomLayout) = CurrentELFAlignedSize;

--- a/Source/Tests/ELFCodeLoader.h
+++ b/Source/Tests/ELFCodeLoader.h
@@ -282,7 +282,7 @@ public:
   bool MapMemory(const MapperFn& Mapper, const UnmapperFn& Unmapper) override {
     auto DoMMap = [Mapper](uint64_t Address, size_t Size, bool FixedNoReplace) -> void* {
       void *Result = Mapper(reinterpret_cast<void*>(Address), Size, PROT_READ | PROT_WRITE, (FixedNoReplace ? MAP_FIXED_NOREPLACE : MAP_FIXED) | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-      LOGMAN_THROW_A(Result != (void*)~0ULL, "Couldn't mmap");
+      LOGMAN_THROW_A_FMT(Result != (void*)~0ULL, "Couldn't mmap");
       return Result;
     };
 

--- a/Source/Tests/IRLoader/Loader.cpp
+++ b/Source/Tests/IRLoader/Loader.cpp
@@ -13,7 +13,7 @@ namespace FEX::IRLoader {
     std::fstream fp(Filename, std::fstream::binary | std::fstream::in);
 
     if (!fp.is_open()) {
-      LogMan::Msg::E("Couldn't open IR file '%s'", Filename.c_str());
+      LogMan::Msg::EFmt("Couldn't open IR file '{}'", Filename);
       return;
     }
 
@@ -25,7 +25,7 @@ namespace FEX::IRLoader {
       
       std::stringstream out;
       FEXCore::IR::Dump(&out, &NewIR, nullptr);
-      printf("IR:\n%s\n@@@@@\n", out.str().c_str());
+      fmt::print("IR:\n{}\n@@@@@\n", out.str());
     }
   }
 }

--- a/Source/Tests/LinuxSyscalls/EmulatedFiles/EmulatedFiles.cpp
+++ b/Source/Tests/LinuxSyscalls/EmulatedFiles/EmulatedFiles.cpp
@@ -759,7 +759,7 @@ namespace FEX::EmulatedFile {
     uint64_t auxvBase=0, auxvSize=0;
     FEX::HLE::_SyscallHandler->GetCodeLoader()->GetAuxv(auxvBase, auxvSize);
     if (!auxvBase) {
-      LogMan::Msg::D("Failed to get Auxv stack address");
+      LogMan::Msg::DFmt("Failed to get Auxv stack address");
       return -1;
     }
 

--- a/Source/Tests/LinuxSyscalls/FileManagement.cpp
+++ b/Source/Tests/LinuxSyscalls/FileManagement.cpp
@@ -263,9 +263,9 @@ FileManager::FileManager(FEXCore::Context::Context *ctx)
     if (false) {
       // Useful for debugging
       if (ThunkOverlays.size()) {
-        LogMan::Msg::I("Thunk Overlays:");
-        for (auto &Thunk: ThunkOverlays) {
-          LogMan::Msg::I("\t%s -> %s", Thunk.first.c_str(), Thunk.second.c_str());
+        LogMan::Msg::IFmt("Thunk Overlays:");
+        for (const auto& [Overlay, ThunkPath] : ThunkOverlays) {
+          LogMan::Msg::IFmt("\t{} -> {}", Overlay, ThunkPath);
         }
       }
     }

--- a/Source/Tests/LinuxSyscalls/LinuxAllocator.cpp
+++ b/Source/Tests/LinuxSyscalls/LinuxAllocator.cpp
@@ -426,7 +426,7 @@ uint64_t MemAllocator32Bit::shmat(int shmid, const void* shmaddr, int shmflg, ui
       uint32_t SmallRet = Result >> 32;
       if (!(SmallRet == 0 ||
             SmallRet == ~0U)) {
-        LOGMAN_MSG_A("Syscall returning something with data in the upper 32bits! BUG!");
+        LOGMAN_MSG_A_FMT("Syscall returning something with data in the upper 32bits! BUG!");
         return -ENOMEM;
       }
 

--- a/Source/Tests/LinuxSyscalls/SignalDelegator.cpp
+++ b/Source/Tests/LinuxSyscalls/SignalDelegator.cpp
@@ -127,7 +127,7 @@ namespace FEX::HLE {
         // We handled this signal, continue running
         return;
       }
-      ERROR_AND_DIE("Unhandled guest exception");
+      ERROR_AND_DIE_FMT("Unhandled guest exception");
     }
 
     // Unhandled crash
@@ -231,10 +231,10 @@ namespace FEX::HLE {
     }
 
     // Only update the old action if we haven't ever been installed
-    int Result = ::syscall(SYS_rt_sigaction, Signal, &SignalHandler.HostAction, SignalHandler.Installed ? nullptr : &SignalHandler.OldAction, 8);
+    const int Result = ::syscall(SYS_rt_sigaction, Signal, &SignalHandler.HostAction, SignalHandler.Installed ? nullptr : &SignalHandler.OldAction, 8);
     if (Result < 0) {
       // Signal 32 and 33 are consumed by glibc. We don't handle this atm
-      LogMan::Msg::A("Failed to install host signal thunk for signal %d: %s", Signal, strerror(errno));
+      LogMan::Msg::AFmt("Failed to install host signal thunk for signal {}: {}", Signal, strerror(errno));
       return false;
     }
 
@@ -249,7 +249,7 @@ namespace FEX::HLE {
 
   SignalDelegator::SignalDelegator() {
     // Register this delegate
-    LOGMAN_THROW_A(!GlobalDelegator, "Can't register global delegator multiple times!");
+    LOGMAN_THROW_A_FMT(!GlobalDelegator, "Can't register global delegator multiple times!");
     GlobalDelegator = this;
     // Signal zero isn't real
     HostHandlers[0].Installed = true;
@@ -305,12 +305,12 @@ namespace FEX::HLE {
     altstack.ss_sp = ThreadData.AltStackPtr;
     altstack.ss_size = SIGSTKSZ;
     altstack.ss_flags = 0;
-    LOGMAN_THROW_A(!!altstack.ss_sp, "Couldn't allocate stack pointer");
+    LOGMAN_THROW_A_FMT(!!altstack.ss_sp, "Couldn't allocate stack pointer");
 
     // Register the alt stack
-    int Result = sigaltstack(&altstack, nullptr);
+    const int Result = sigaltstack(&altstack, nullptr);
     if (Result == -1) {
-      LogMan::Msg::E("Failed to install alternative signal stack %s", strerror(errno));
+      LogMan::Msg::EFmt("Failed to install alternative signal stack {}", strerror(errno));
     }
 
     // Get the current host signal mask
@@ -326,9 +326,9 @@ namespace FEX::HLE {
     altstack.ss_flags = SS_DISABLE;
 
     // Uninstall the alt stack
-    int Result = sigaltstack(&altstack, nullptr);
+    const int Result = sigaltstack(&altstack, nullptr);
     if (Result == -1) {
-      LogMan::Msg::E("Failed to uninstall alternative signal stack %s", strerror(errno));
+      LogMan::Msg::EFmt("Failed to uninstall alternative signal stack {}", strerror(errno));
     }
   }
 

--- a/Source/Tests/LinuxSyscalls/Syscalls.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls.cpp
@@ -283,7 +283,7 @@ static int Clone2HandlerRet(void *arg) {
 #endif
 
 static void PrintFlags(uint64_t Flags){
-#define FLAGPRINT(x, y) if (Flags & (y)) LogMan::Msg::I("\tFlag: " #x)
+#define FLAGPRINT(x, y) if (Flags & (y)) LogMan::Msg::IFmt("\tFlag: " #x)
   FLAGPRINT(CSIGNAL,              0x000000FF);
   FLAGPRINT(CLONE_VM,             0x00000100);
   FLAGPRINT(CLONE_FS,             0x00000200);
@@ -415,7 +415,7 @@ uint64_t CloneHandler(FEXCore::Core::CpuStateFrame *Frame, FEX::HLE::clone3_args
 
     if (AnyFlagsSet(args->args.flags, CLONE_THREAD)) {
       if (!AllFlagsSet(args->args.flags, CLONE_SYSVSEM | CLONE_FS |  CLONE_FILES | CLONE_SIGHAND)) {
-        LogMan::Msg::I("clone: CLONE_THREAD: Unsuported flags w/ CLONE_THREAD (Shared Resources), %X", args->args.flags);
+        LogMan::Msg::IFmt("clone: CLONE_THREAD: Unsuported flags w/ CLONE_THREAD (Shared Resources), {:X}", args->args.flags);
         return false;
       }
     }
@@ -423,7 +423,7 @@ uint64_t CloneHandler(FEXCore::Core::CpuStateFrame *Frame, FEX::HLE::clone3_args
       if (AnyFlagsSet(args->args.flags, CLONE_SYSVSEM | CLONE_FS | CLONE_FILES | CLONE_SIGHAND | CLONE_VM)) {
         // CLONE_VM is particularly nasty here
         // Memory regions at the point of clone(More similar to a fork) are shared
-        LogMan::Msg::I("clone: Unsuported flags w/o CLONE_THREAD (Shared Resources), %X", args->args.flags);
+        LogMan::Msg::IFmt("clone: Unsuported flags w/o CLONE_THREAD (Shared Resources), {:X}", args->args.flags);
         return false;
       }
     }
@@ -445,7 +445,7 @@ uint64_t CloneHandler(FEXCore::Core::CpuStateFrame *Frame, FEX::HLE::clone3_args
       }
     }
     else {
-      LogMan::Msg::I("Unsupported flag with CLONE_THREAD. This breaks TLS, falling down classic thread path");
+      LogMan::Msg::IFmt("Unsupported flag with CLONE_THREAD. This breaks TLS, falling down classic thread path");
       PrintFlags(flags);
     }
   }
@@ -460,14 +460,14 @@ uint64_t CloneHandler(FEXCore::Core::CpuStateFrame *Frame, FEX::HLE::clone3_args
 
   if (AnyFlagsSet(flags, CLONE_PTRACE)) {
     PrintFlags(flags);
-    LogMan::Msg::D("clone: Ptrace* not supported");
+    LogMan::Msg::DFmt("clone: Ptrace* not supported");
   }
 
   if (!(flags & CLONE_THREAD)) {
     if (flags & CLONE_VFORK) {
       PrintFlags(flags);
       flags &= ~CLONE_VM;
-      LogMan::Msg::D("clone: WARNING: CLONE_VFORK w/o CLONE_THREAD");
+      LogMan::Msg::DFmt("clone: WARNING: CLONE_VFORK w/o CLONE_THREAD");
     }
 
     // CLONE_PARENT is ignored (Implied by CLONE_THREAD)
@@ -639,7 +639,7 @@ uint64_t SyscallHandler::HandleSyscall(FEXCore::Core::CpuStateFrame *Frame, FEXC
   // for missing syscalls
   case 255: return std::invoke(Def.Ptr1, Frame, Args->Argument[0]);
   default:
-    LOGMAN_MSG_A("Unhandled syscall: %d", Args->Argument[0]);
+    LOGMAN_MSG_A_FMT("Unhandled syscall: {}", Args->Argument[0]);
     return -1;
   break;
   }
@@ -666,7 +666,7 @@ void SyscallHandler::Strace(FEXCore::HLE::SyscallArguments *Args, uint64_t Ret) 
 #endif
 
 uint64_t UnimplementedSyscall(FEXCore::Core::CpuStateFrame *Frame, uint64_t SyscallNumber) {
-  ERROR_AND_DIE("Unhandled system call: %d", SyscallNumber);
+  ERROR_AND_DIE_FMT("Unhandled system call: {}", SyscallNumber);
   return -ENOSYS;
 }
 

--- a/Source/Tests/LinuxSyscalls/Syscalls/Info.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Info.cpp
@@ -41,7 +41,7 @@ namespace FEX::HLE {
       }
       else {
         strcpy(buf->nodename, "FEXCore");
-        LogMan::Msg::E("Couldn't determine host nodename. Defaulting to '%s'", buf->nodename);
+        LogMan::Msg::EFmt("Couldn't determine host nodename. Defaulting to '{}'", buf->nodename);
       }
       strcpy(buf->sysname, "Linux");
       uint32_t GuestVersion = FEX::HLE::_SyscallHandler->GetGuestKernelVersion();

--- a/Source/Tests/LinuxSyscalls/Syscalls/NotImplemented.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/NotImplemented.cpp
@@ -13,7 +13,7 @@ $end_info$
 #include <sys/epoll.h>
 
 #define REGISTER_SYSCALL_NOT_IMPL(name) REGISTER_SYSCALL_IMPL(name, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t { \
-  LogMan::Msg::D("Using deprecated/removed syscall: " #name); \
+  LogMan::Msg::DFmt("Using deprecated/removed syscall: " #name); \
   return -ENOSYS; \
 });
 

--- a/Source/Tests/LinuxSyscalls/Syscalls/Stubs.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Stubs.cpp
@@ -14,7 +14,7 @@ $end_info$
 #include <stdint.h>
 #include <sys/types.h>
 
-#define SYSCALL_STUB(name) do { ERROR_AND_DIE("Syscall: " #name " stub!"); return -ENOSYS; } while(0)
+#define SYSCALL_STUB(name) do { ERROR_AND_DIE_FMT("Syscall: " #name " stub!"); return -ENOSYS; } while(0)
 
 namespace FEXCore::Core {
   struct CpuStateFrame;

--- a/Source/Tests/LinuxSyscalls/Syscalls/Thread.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Thread.cpp
@@ -85,9 +85,9 @@ namespace FEX::HLE {
     // clone3 flag
     if (flags & CLONE_PIDFD) {
       // Use pidfd_open to emulate this flag
-      int pidfd = ::syscall(SYSCALL_DEF(pidfd_open), Result, 0);
+      const int pidfd = ::syscall(SYSCALL_DEF(pidfd_open), Result, 0);
       if (Result == ~0ULL) {
-        LogMan::Msg::E("Couldn't get pidfd of TID %d\n", Result);
+        LogMan::Msg::EFmt("Couldn't get pidfd of TID {}\n", Result);
       }
       else {
         *reinterpret_cast<int*>(args->pidfd) = pidfd;
@@ -437,7 +437,7 @@ namespace FEX::HLE {
           return -ENODEV; // Claim we don't support faulting on CPUID
         break;
         default:
-          LogMan::Msg::E("Unknown prctl: 0x%x", code);
+          LogMan::Msg::EFmt("Unknown prctl: 0x{:x}", code);
           Result = -EINVAL;
         break;
       }

--- a/Source/Tests/LinuxSyscalls/x32/FD.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/FD.cpp
@@ -220,7 +220,7 @@ namespace FEX::HLE::x32 {
     });
 
     REGISTER_SYSCALL_IMPL_X32(fstatfs64, [](FEXCore::Core::CpuStateFrame *Frame, int fd, size_t sz, struct statfs64_32 *buf) -> uint64_t {
-      LOGMAN_THROW_A(sz == sizeof(struct statfs64_32), "This needs to match");
+      LOGMAN_THROW_A_FMT(sz == sizeof(struct statfs64_32), "This needs to match");
 
       struct statfs64 host_stat;
       uint64_t Result = ::fstatfs64(fd, &host_stat);
@@ -231,7 +231,7 @@ namespace FEX::HLE::x32 {
     });
 
     REGISTER_SYSCALL_IMPL_X32(statfs64, [](FEXCore::Core::CpuStateFrame *Frame, const char *path, size_t sz, struct statfs64_32 *buf) -> uint64_t {
-      LOGMAN_THROW_A(sz == sizeof(struct statfs64_32), "This needs to match");
+      LOGMAN_THROW_A_FMT(sz == sizeof(struct statfs64_32), "This needs to match");
 
       struct statfs host_stat;
       uint64_t Result = FEX::HLE::_SyscallHandler->FM.Statfs(path, &host_stat);
@@ -299,7 +299,9 @@ namespace FEX::HLE::x32 {
         case F_GETFL:
           break;
 
-        default: LOGMAN_MSG_A("Unhandled fcntl64: 0x%x", cmd); break;
+        default:
+          LOGMAN_MSG_A_FMT("Unhandled fcntl64: 0x{:x}", cmd);
+          break;
       }
 
       uint64_t Result = ::fcntl(fd, cmd, lock_arg);

--- a/Source/Tests/LinuxSyscalls/x32/IoctlEmulation.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/IoctlEmulation.cpp
@@ -28,13 +28,13 @@ extern "C" {
 
 namespace FEX::HLE::x32 {
   static void UnhandledIoctl(const char *Type, int fd, uint32_t cmd, uint32_t args) {
-    LogMan::Msg::E("@@@@@@@@@@@@@@@@@@@@@@@@@");
-    LogMan::Msg::E("Unhandled %s ioctl(%d, 0x%08x, 0x%08x)", Type, fd, cmd, args);
-    LogMan::Msg::E("\tDir  : 0x%x", _IOC_DIR(cmd));
-    LogMan::Msg::E("\tType : 0x%x", _IOC_TYPE(cmd));
-    LogMan::Msg::E("\tNR   : 0x%x", _IOC_NR(cmd));
-    LogMan::Msg::E("\tSIZE : 0x%x", _IOC_SIZE(cmd));
-    LogMan::Msg::A("@@@@@@@@@@@@@@@@@@@@@@@@@");
+    LogMan::Msg::EFmt("@@@@@@@@@@@@@@@@@@@@@@@@@");
+    LogMan::Msg::EFmt("Unhandled {} ioctl({}, 0x{:08x}, 0x{:08x})", Type, fd, cmd, args);
+    LogMan::Msg::EFmt("\tDir  : 0x{:x}", _IOC_DIR(cmd));
+    LogMan::Msg::EFmt("\tType : 0x{:x}", _IOC_TYPE(cmd));
+    LogMan::Msg::EFmt("\tNR   : 0x{:x}", _IOC_NR(cmd));
+    LogMan::Msg::EFmt("\tSIZE : 0x{:x}", _IOC_SIZE(cmd));
+    LogMan::Msg::AFmt("@@@@@@@@@@@@@@@@@@@@@@@@@");
   }
 
   namespace BasicHandler {
@@ -464,7 +464,7 @@ namespace FEX::HLE::x32 {
           FDToHandler.SetFDHandler(fd, Virtio_Handler);
         }
         else {
-          LogMan::Msg::E("Unknown DRM device: '%s'", Version.name);
+          LogMan::Msg::EFmt("Unknown DRM device: '{}'", Version.name);
         }
       }
     }

--- a/Source/Tests/LinuxSyscalls/x32/NotImplemented.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/NotImplemented.cpp
@@ -16,7 +16,7 @@ namespace FEXCore::Core {
 
 namespace FEX::HLE::x32 {
 #define REGISTER_SYSCALL_NOT_IMPL_X32(name) REGISTER_SYSCALL_IMPL_X32(name, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t { \
-  LogMan::Msg::D("Using deprecated/removed syscall: " #name); \
+  LogMan::Msg::DFmt("Using deprecated/removed syscall: " #name); \
   return -ENOSYS; \
 });
 #define REGISTER_SYSCALL_NO_PERM_X32(name) REGISTER_SYSCALL_IMPL_X32(name, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t { \

--- a/Source/Tests/LinuxSyscalls/x32/Semaphore.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Semaphore.cpp
@@ -558,7 +558,7 @@ namespace FEX::HLE::x32 {
         int32_t cmd = third & 0xFF;
         compat_ptr<semun_32> semun(ptr);
         bool IPC64 = third & 0x100;
-#define UNHANDLED(x) case x: LOGMAN_MSG_A("Unhandled semctl cmd: " #x); break
+#define UNHANDLED(x) case x: LOGMAN_MSG_A_FMT("Unhandled semctl cmd: " #x); break
         switch (cmd) {
           case IPC_SET: {
             struct semid_ds buf{};
@@ -621,7 +621,9 @@ namespace FEX::HLE::x32 {
           case GETVAL:
             Result = ::semctl(semid, semnum, cmd);
             break;
-          default: LOGMAN_MSG_A("Unhandled semctl cmd: %d", cmd); return -EINVAL; break;
+          default:
+            LOGMAN_MSG_A_FMT("Unhandled semctl cmd: {}", cmd);
+            return -EINVAL;
         }
 #undef UNHANDLED
         break;
@@ -688,7 +690,7 @@ namespace FEX::HLE::x32 {
         msgun_32 msgun{};
         msgun.val = ptr;
         bool IPC64 = second & 0x100;
-#define UNHANDLED(x) case x: LOGMAN_MSG_A("Unhandled msgctl cmd: " #x); break
+#define UNHANDLED(x) case x: LOGMAN_MSG_A_FMT("Unhandled msgctl cmd: " #x); break
         switch (cmd) {
           UNHANDLED(IPC_SET);
           case MSG_STAT:
@@ -718,7 +720,9 @@ namespace FEX::HLE::x32 {
           case IPC_RMID:
             Result = ::msgctl(msqid, cmd, nullptr);
             break;
-          default: LOGMAN_MSG_A("Unhandled msgctl cmd: %d", cmd); return -EINVAL; break;
+          default:
+            LOGMAN_MSG_A_FMT("Unhandled msgctl cmd: {}", cmd);
+            return -EINVAL;
         }
 #undef UNHANDLED
         break;
@@ -815,7 +819,9 @@ namespace FEX::HLE::x32 {
             Result = ::shmctl(shmid, cmd, nullptr);
             break;
 
-          default: LOGMAN_MSG_A("Unhandled shmctl cmd: %d", cmd); return -EINVAL; break;
+          default:
+            LOGMAN_MSG_A_FMT("Unhandled shmctl cmd: {}", cmd);
+            return -EINVAL;
         }
         break;
       }
@@ -898,8 +904,9 @@ namespace FEX::HLE::x32 {
         case GETVAL:
           Result = ::semctl(semid, semnum, cmd, semun);
           break;
-        default: LOGMAN_MSG_A("Unhandled semctl cmd: %d", cmd); return -EINVAL; break;
-
+        default:
+          LOGMAN_MSG_A_FMT("Unhandled semctl cmd: {}", cmd);
+          return -EINVAL;
       }
       SYSCALL_ERRNO();
     });

--- a/Source/Tests/LinuxSyscalls/x32/Signals.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Signals.cpp
@@ -64,7 +64,7 @@ namespace FEX::HLE::x32 {
           Info->_sifields._timer.sigval.sival_int = Host.si_int;
           break;
         default:
-          LogMan::Msg::E("Unhandled siginfo_t for sigtimedwait: %d", Info->si_signo);
+          LogMan::Msg::EFmt("Unhandled siginfo_t for sigtimedwait: {}", Info->si_signo);
           break;
       }
     }

--- a/Source/Tests/LinuxSyscalls/x32/Socket.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Socket.cpp
@@ -264,7 +264,7 @@ namespace FEX::HLE::x32 {
           break;
         }
         default:
-          LOGMAN_MSG_A("Unsupported socketcall op: %d", call);
+          LOGMAN_MSG_A_FMT("Unsupported socketcall op: {}", call);
           break;
       }
       SYSCALL_ERRNO();

--- a/Source/Tests/LinuxSyscalls/x32/Syscalls.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Syscalls.cpp
@@ -154,7 +154,7 @@ namespace FEX::HLE::x32 {
       auto &Def = Definitions.at(SyscallNumber);
 #if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
       auto Name = GetSyscallName(SyscallNumber);
-      LOGMAN_THROW_A(Def.Ptr == cvt(&UnimplementedSyscall), "Oops overwriting sysall problem, %d, %s", SyscallNumber, Name);
+      LOGMAN_THROW_A_FMT(Def.Ptr == cvt(&UnimplementedSyscall), "Oops overwriting sysall problem, {}, {}", SyscallNumber, Name);
 #endif
       Def.Ptr = Syscall.SyscallHandler;
       Def.NumArgs = Syscall.ArgumentCount;
@@ -167,7 +167,7 @@ namespace FEX::HLE::x32 {
 #if PRINT_MISSING_SYSCALLS
     for (auto &Syscall: SyscallNames) {
       if (Definitions[Syscall.first].Ptr == cvt(&UnimplementedSyscall)) {
-        LogMan::Msg::D("Unimplemented syscall: %d: %s", Syscall.first, Syscall.second);
+        LogMan::Msg::DFmt("Unimplemented syscall: {}: {}", Syscall.first, Syscall.second);
       }
     }
 #endif

--- a/Source/Tests/LinuxSyscalls/x64/NotImplemented.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/NotImplemented.cpp
@@ -17,7 +17,7 @@ namespace FEXCore::Core {
 
 namespace FEX::HLE::x64 {
 #define REGISTER_SYSCALL_NOT_IMPL_X64(name) REGISTER_SYSCALL_IMPL_X64(name, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t { \
-  LogMan::Msg::D("Using deprecated/removed syscall: " #name); \
+  LogMan::Msg::DFmt("Using deprecated/removed syscall: " #name); \
   return -ENOSYS; \
 });
 #define REGISTER_SYSCALL_NO_PERM_X64(name) REGISTER_SYSCALL_IMPL_X64(name, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t { \

--- a/Source/Tests/LinuxSyscalls/x64/Semaphore.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Semaphore.cpp
@@ -79,8 +79,9 @@ namespace FEX::HLE::x64 {
         case GETVAL:
           Result = ::semctl(semid, semnum, cmd, semun);
           break;
-        default: LOGMAN_MSG_A("Unhandled semctl cmd: %d", cmd); return -EINVAL; break;
-
+        default:
+          LOGMAN_MSG_A_FMT("Unhandled semctl cmd: {}", cmd);
+          return -EINVAL;
       }
       SYSCALL_ERRNO();
     });

--- a/Source/Tests/LinuxSyscalls/x64/Syscalls.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Syscalls.cpp
@@ -144,7 +144,7 @@ namespace FEX::HLE::x64 {
       auto &Def = Definitions.at(SyscallNumber);
 #if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
       auto Name = GetSyscallName(SyscallNumber);
-      LOGMAN_THROW_A(Def.Ptr == cvt(&UnimplementedSyscall), "Oops overwriting sysall problem, %d, %s", SyscallNumber, Name);
+      LOGMAN_THROW_A_FMT(Def.Ptr == cvt(&UnimplementedSyscall), "Oops overwriting sysall problem, {}, {}", SyscallNumber, Name);
 #endif
       Def.Ptr = Syscall.SyscallHandler;
       Def.NumArgs = Syscall.ArgumentCount;
@@ -157,7 +157,7 @@ namespace FEX::HLE::x64 {
 #if PRINT_MISSING_SYSCALLS
     for (auto &Syscall: SyscallNames) {
       if (Definitions[Syscall.first].Ptr == cvt(&UnimplementedSyscall)) {
-        LogMan::Msg::D("Unimplemented syscall: %s", Syscall.second);
+        LogMan::Msg::DFmt("Unimplemented syscall: %s", Syscall.second);
       }
     }
 #endif

--- a/Source/Tests/UnitTestGenerator.cpp
+++ b/Source/Tests/UnitTestGenerator.cpp
@@ -2386,7 +2386,7 @@ int main(int argc, char **argv, char **const envp) {
 
   auto Args = FEX::ArgLoader::Get();
 
-  LOGMAN_THROW_A(!Args.empty(), "Not enough arguments");
+  LOGMAN_THROW_A_FMT(!Args.empty(), "Not enough arguments");
 
   FEXCore::Context::InitializeStaticTables(FEXCore::Context::MODE_64BIT);
 

--- a/Source/Tools/Debugger/IMGui_I.cpp
+++ b/Source/Tools/Debugger/IMGui_I.cpp
@@ -611,11 +611,8 @@ namespace IR {
     }
     ImGui::End();
 
-    char const *InitialPath;
-    char const *File;
-
-    InitialPath = Dialog.saveFileDialog(HadSelectedSaveIR, "./");
-    File = Dialog.getChosenPath();
+    const char *InitialPath = Dialog.saveFileDialog(HadSelectedSaveIR, "./");
+    const char *File = Dialog.getChosenPath();
     if (strlen(InitialPath) > 0 && strlen(File) > 0) {
       // FEXCore::IR::IntrusiveIRList *ir;
       // bool HadIR = FEXCore::Context::Debug::FindIRForRIP(FEX::DebuggerState::GetContext(), Disasm::CurrentDisasmRIP, &ir);
@@ -623,22 +620,19 @@ namespace IR {
       //   IRFileHeader Header;
       //   Header.RIP = Disasm::CurrentDisasmRIP;
       //   Header.IRSize = ir->GetOffset();
-      //   std::fstream IRFile;
-      //   IRFile.open(File, std::fstream::out | std::fstream::binary);
-      //   LOGMAN_THROW_A(IRFile.is_open(), "Failed to open file");
-
+      //   std::fstream IRFile(File, std::fstream::out | std::fstream::binary);
+      //   LOGMAN_THROW_A_FMT(IRFile.is_open(), "Failed to open file");
+      //
       //   IRFile.write(reinterpret_cast<char*>(&Header), sizeof(Header));
       //   IRFile.write(ir->GetOpAs<char>(0), Header.IRSize);
-      //   IRFile.close();
       // }
     }
   }
 
   void LoadIR(char const *Filename) {
     IRFileHeader Header;
-    std::fstream IRFile;
-    IRFile.open(Filename, std::fstream::in | std::fstream::binary);
-    LOGMAN_THROW_A(IRFile.is_open(), "Failed to open file");
+    std::fstream IRFile(Filename, std::fstream::in | std::fstream::binary);
+    LOGMAN_THROW_A_FMT(IRFile.is_open(), "Failed to open file");
 
     IRFile.read(reinterpret_cast<char*>(&Header), sizeof(Header));
 
@@ -703,12 +697,10 @@ namespace History {
     Dest = json_objClose(Dest);
     json_end(Dest);
 
-    std::fstream HistoryFile;
-    HistoryFile.open("History.json", std::fstream::out);
-    LOGMAN_THROW_A(HistoryFile.is_open(), "Failed to open file");
+    std::fstream HistoryFile("History.json", std::fstream::out);
+    LOGMAN_THROW_A_FMT(HistoryFile.is_open(), "Failed to open file");
 
     HistoryFile.write(Buffer, strlen(Buffer));
-    HistoryFile.close();
   }
 
   void Add(HistoryType Type, const char *Filename) {
@@ -882,7 +874,7 @@ namespace MemoryViewer {
     //  MappedRegionsMemoryCurrentItem = static_cast<int>(RIP - MappedRegions[MappedRegionsCurrentItem].Offset) / 16;
 
     //  // Now set the Current Address textbox and string to the correct address
-    //  LogMan::Msg::D("RIP is 0x%lx", RIP);
+    //  LogMan::Msg::DFmt("RIP is 0x{:x}", RIP);
     //  CurrentAddress = RIP;
     //  std::ostringstream out{};
     //  out << "0x" << std::hex << CurrentAddress;

--- a/Source/Tools/Debugger/Main.cpp
+++ b/Source/Tools/Debugger/Main.cpp
@@ -55,13 +55,13 @@ void CreateCoreCallback(char const *Filename, bool ELF) {
     std::string ConfigName = Filename;
     ConfigName.erase(ConfigName.end() - 3, ConfigName.end());
     ConfigName += "config.bin";
-    LogMan::Msg::I("Opening '%s'", Filename);
-    LogMan::Msg::I("Opening '%s'", ConfigName.c_str());
+    LogMan::Msg::IFmt("Opening '{}'", Filename);
+    LogMan::Msg::IFmt("Opening '{}'", ConfigName);
     FEX::HarnessHelper::HarnessCodeLoader Loader{Filename, ConfigName.c_str()};
     Result = FEXCore::Context::InitCore(CTX, &Loader);
   }
 
-  LOGMAN_THROW_A(Result, "Couldn't initialize CTX");
+  LOGMAN_THROW_A_FMT(Result, "Couldn't initialize CTX");
 
   FEX::DebuggerState::SetContext(CTX);
   FEX::DebuggerState::SetHasNewState();


### PR DESCRIPTION
Migrates the remaining bits of the codebase over to fmt to make logs nice and uniform. Now we only need to keep around the debug portion of the printf-style logger to handle the strace syscall in LinuxSyscalls/Syscalls.cpp, everything else can be removed

Addresses https://github.com/FEX-Emu/FEX/issues/146 a little further