### PR TITLE
Syscalls: Move construction of syscall name map into GetSyscallName()

### DIFF
--- a/Source/Tests/LinuxSyscalls/x32/Syscalls.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Syscalls.cpp
@@ -45,18 +45,20 @@ namespace FEX::HLE::x32 {
   void RegisterTime();
   void RegisterTimer();
 
-  std::map<int, const char*> SyscallNames = {
-    #include "SyscallsNames.inl"
-  };
+#if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
+  [[nodiscard]] static const char* GetSyscallName(int SyscallNumber) {
+    static const std::map<int, const char*> SyscallNames = {
+      #include "SyscallsNames.inl"
+    };
 
-  const char* GetSyscallName(int SyscallNumber) {
-    const char* name = "[unknown syscall]";
+    const auto EntryIter = SyscallNames.find(SyscallNumber);
+    if (EntryIter == SyscallNames.cend()) {
+      return "[unknown syscall]";
+    }
 
-    if (SyscallNames.count(SyscallNumber))
-      name = SyscallNames[SyscallNumber];
-
-    return name;
+    return EntryIter->second;
   }
+#endif
 
   struct InternalSyscallDefinition {
     int SyscallNumber;

--- a/Source/Tests/LinuxSyscalls/x64/Syscalls.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Syscalls.cpp
@@ -28,18 +28,20 @@ namespace FEX::HLE::x64 {
   void RegisterTime();
   void RegisterNotImplemented();
 
-  std::map<int, const char*> SyscallNames = {
-    #include "SyscallsNames.inl"
-  };
+#if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
+  [[nodiscard]] static const char* GetSyscallName(int SyscallNumber) {
+    static const std::map<int, const char*> SyscallNames = {
+      #include "SyscallsNames.inl"
+    };
 
-  const char* GetSyscallName(int SyscallNumber) {
-    const char* name = "[unknown syscall]";
+    const auto EntryIter = SyscallNames.find(SyscallNumber);
+    if (EntryIter == SyscallNames.cend()) {
+      return "[unknown syscall]";
+    }
 
-    if (SyscallNames.count(SyscallNumber))
-      name = SyscallNames[SyscallNumber];
-
-    return name;
+    return EntryIter->second;
   }
+#endif
 
   struct InternalSyscallDefinition {
     int SyscallNumber;


### PR DESCRIPTION
These maps are primarily used for debugging, so we don't need to construct and allocate the data until GetSyscallName() is called.

Eliminates a tiny bit of memory usage and a static constructor for release builds.