### PR TITLE
CompileService: Store WorkItem instances as unique_ptr

### DIFF
--- a/External/FEXCore/Source/Interface/Core/CompileService.h
+++ b/External/FEXCore/Source/Interface/Core/CompileService.h
@@ -60,8 +60,8 @@ class CompileService final {
 
     std::mutex QueueMutex{};
     std::mutex CompileMutex{};
-    std::queue<WorkItem*> WorkQueue{};
-    std::vector<WorkItem*> GCArray{};
+    std::queue<std::unique_ptr<WorkItem>> WorkQueue{};
+    std::vector<std::unique_ptr<WorkItem>> GCArray{};
     Event StartWork{};
     std::atomic_bool ShuttingDown{false};
 };

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -1174,7 +1174,7 @@ namespace FEXCore::Context {
         Thread->CompileService->Initialize();
       }
 
-      auto WorkItem = Thread->CompileService->CompileCode(GuestRIP);
+      auto* WorkItem = Thread->CompileService->CompileCode(GuestRIP);
       WorkItem->ServiceWorkDone.Wait();
       // Return here with the data in place
       CodePtr = WorkItem->CodePtr;


### PR DESCRIPTION
Lets us simplify our GC management a little bit and also makes it so we won't potentially leak memory if an exception occurs anywhere.