### PR TITLE
IR: Add type alias for Node IDs 

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/ALUOps.cpp
@@ -13,7 +13,7 @@ $end_info$
 #include <cstdint>
 
 namespace FEXCore::CPU {
-#define DEF_OP(x) void InterpreterOps::Op_##x(FEXCore::IR::IROp_Header *IROp, IROpData *Data, uint32_t Node)
+#define DEF_OP(x) void InterpreterOps::Op_##x(IR::IROp_Header *IROp, IROpData *Data, IR::NodeID Node)
 
 DEF_OP(TruncElementPair) {
   auto Op = IROp->C<IR::IROp_TruncElementPair>();

--- a/External/FEXCore/Source/Interface/Core/Interpreter/AtomicOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/AtomicOps.cpp
@@ -310,7 +310,7 @@ uint64_t AtomicCompareAndSwap(uint64_t expected, uint64_t desired, uint64_t *add
 
 #endif
 
-#define DEF_OP(x) void InterpreterOps::Op_##x(FEXCore::IR::IROp_Header *IROp, IROpData *Data, uint32_t Node)
+#define DEF_OP(x) void InterpreterOps::Op_##x(IR::IROp_Header *IROp, IROpData *Data, IR::NodeID Node)
 DEF_OP(CASPair) {
   auto Op = IROp->C<IR::IROp_CASPair>();
   uint8_t OpSize = IROp->Size;

--- a/External/FEXCore/Source/Interface/Core/Interpreter/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/BranchOps.cpp
@@ -24,7 +24,7 @@ static void SignalReturn(FEXCore::Core::InternalThreadState *Thread) {
   FEX_UNREACHABLE;
 }
 
-#define DEF_OP(x) void InterpreterOps::Op_##x(FEXCore::IR::IROp_Header *IROp, IROpData *Data, uint32_t Node)
+#define DEF_OP(x) void InterpreterOps::Op_##x(IR::IROp_Header *IROp, IROpData *Data, IR::NodeID Node)
 DEF_OP(GuestCallDirect) {
   LogMan::Msg::DFmt("Unimplemented");
 }

--- a/External/FEXCore/Source/Interface/Core/Interpreter/ConversionOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/ConversionOps.cpp
@@ -11,7 +11,7 @@ $end_info$
 #include <cstdint>
 
 namespace FEXCore::CPU {
-#define DEF_OP(x) void InterpreterOps::Op_##x(FEXCore::IR::IROp_Header *IROp, IROpData *Data, uint32_t Node)
+#define DEF_OP(x) void InterpreterOps::Op_##x(IR::IROp_Header *IROp, IROpData *Data, IR::NodeID Node)
 DEF_OP(VInsGPR) {
   auto Op = IROp->C<IR::IROp_VInsGPR>();
   uint8_t OpSize = IROp->Size;

--- a/External/FEXCore/Source/Interface/Core/Interpreter/EncryptionOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/EncryptionOps.cpp
@@ -299,7 +299,7 @@ namespace AES {
 }
 
 namespace FEXCore::CPU {
-#define DEF_OP(x) void InterpreterOps::Op_##x(FEXCore::IR::IROp_Header *IROp, IROpData *Data, uint32_t Node)
+#define DEF_OP(x) void InterpreterOps::Op_##x(IR::IROp_Header *IROp, IROpData *Data, IR::NodeID Node)
 
 DEF_OP(AESImc) {
   auto Op = IROp->C<IR::IROp_VAESImc>();

--- a/External/FEXCore/Source/Interface/Core/Interpreter/F80Ops.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/F80Ops.cpp
@@ -13,7 +13,7 @@ $end_info$
 #include <cstdint>
 
 namespace FEXCore::CPU {
-#define DEF_OP(x) void InterpreterOps::Op_##x(FEXCore::IR::IROp_Header *IROp, IROpData *Data, uint32_t Node)
+#define DEF_OP(x) void InterpreterOps::Op_##x(IR::IROp_Header *IROp, IROpData *Data, IR::NodeID Node)
 DEF_OP(F80LOADFCW) {
   FEXCore::CPU::OpHandlers<IR::OP_F80LOADFCW>::handle(*GetSrc<uint16_t*>(Data->SSAData, IROp->Args[0]));
 }

--- a/External/FEXCore/Source/Interface/Core/Interpreter/FlagOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/FlagOps.cpp
@@ -11,7 +11,7 @@ $end_info$
 #include <cstdint>
 
 namespace FEXCore::CPU {
-#define DEF_OP(x) void InterpreterOps::Op_##x(FEXCore::IR::IROp_Header *IROp, IROpData *Data, uint32_t Node)
+#define DEF_OP(x) void InterpreterOps::Op_##x(IR::IROp_Header *IROp, IROpData *Data, IR::NodeID Node)
 DEF_OP(GetHostFlag) {
   auto Op = IROp->C<IR::IROp_GetHostFlag>();
   GD = (*GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[0]) >> Op->Flag) & 1;

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterDefines.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterDefines.h
@@ -166,7 +166,7 @@ Res GetDest(void* SSAData, FEXCore::IR::OrderedNodeWrapper Op) {
 }
 
 template<typename Res>
-Res GetDest(void* SSAData, uint32_t Op) {
+Res GetDest(void* SSAData, FEXCore::IR::NodeID Op) {
   auto DstPtr = &reinterpret_cast<__uint128_t*>(SSAData)[Op];
   return reinterpret_cast<Res>(DstPtr);
 }

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -35,11 +35,11 @@
 namespace FEXCore::CPU {
 std::array<InterpreterOps::OpHandler, FEXCore::IR::IROps::OP_LAST + 1> InterpreterOps::OpHandlers;
 
-void InterpreterOps::Op_Unhandled(FEXCore::IR::IROp_Header *IROp, IROpData *Data, uint32_t Node) {
+void InterpreterOps::Op_Unhandled(FEXCore::IR::IROp_Header *IROp, IROpData *Data, IR::NodeID Node) {
   LOGMAN_MSG_A_FMT("Unhandled IR Op: {}", FEXCore::IR::GetName(IROp->Op));
 }
 
-void InterpreterOps::Op_NoOp(FEXCore::IR::IROp_Header *IROp, IROpData *Data, uint32_t Node) {
+void InterpreterOps::Op_NoOp(FEXCore::IR::IROp_Header *IROp, IROpData *Data, IR::NodeID Node) {
 }
 
 template<typename R, typename... Args>
@@ -280,8 +280,8 @@ void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uin
     auto CodeLast = CurrentIR->at(BlockIROp->Last);
 
     for (auto [CodeNode, IROp] : CurrentIR->GetCode(BlockNode)) {
-      uint32_t ID = CurrentIR->GetID(CodeNode);
-      uint32_t Op = IROp->Op;
+      const auto ID = CurrentIR->GetID(CodeNode);
+      const uint32_t Op = IROp->Op;
 
       // Execute handler
       OpHandler Handler = InterpreterOps::OpHandlers[Op];

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
@@ -72,10 +72,10 @@ namespace FEXCore::CPU {
         IR::NodeIterator BlockIterator{0, 0};
       };
 
-      using OpHandler = std::function<void(FEXCore::IR::IROp_Header *IROp, IROpData *Data, uint32_t Node)>;
-      static std::array<OpHandler, FEXCore::IR::IROps::OP_LAST + 1> OpHandlers;
+      using OpHandler = std::function<void(IR::IROp_Header *IROp, IROpData *Data, IR::NodeID Node)>;
+      static std::array<OpHandler, IR::IROps::OP_LAST + 1> OpHandlers;
 
-#define DEF_OP(x) static void Op_##x(FEXCore::IR::IROp_Header *IROp, IROpData *Data, uint32_t Node)
+#define DEF_OP(x) static void Op_##x(IR::IROp_Header *IROp, IROpData *Data, IR::NodeID Node)
 
   ///< Unhandled handler
   DEF_OP(Unhandled);

--- a/External/FEXCore/Source/Interface/Core/Interpreter/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/MemoryOps.cpp
@@ -22,7 +22,7 @@ static inline void CacheLineFlush(char *Addr) {
 #endif
 }
 
-#define DEF_OP(x) void InterpreterOps::Op_##x(FEXCore::IR::IROp_Header *IROp, IROpData *Data, uint32_t Node)
+#define DEF_OP(x) void InterpreterOps::Op_##x(IR::IROp_Header *IROp, IROpData *Data, IR::NodeID Node)
 DEF_OP(LoadContext) {
   auto Op = IROp->C<IR::IROp_LoadContext>();
   uint8_t OpSize = IROp->Size;

--- a/External/FEXCore/Source/Interface/Core/Interpreter/MiscOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/MiscOps.cpp
@@ -22,7 +22,7 @@ static void StopThread(FEXCore::Core::InternalThreadState *Thread) {
   FEX_UNREACHABLE;
 }
 
-#define DEF_OP(x) void InterpreterOps::Op_##x(FEXCore::IR::IROp_Header *IROp, IROpData *Data, uint32_t Node)
+#define DEF_OP(x) void InterpreterOps::Op_##x(IR::IROp_Header *IROp, IROpData *Data, IR::NodeID Node)
 DEF_OP(Fence) {
   auto Op = IROp->C<IR::IROp_Fence>();
   switch (Op->Fence) {

--- a/External/FEXCore/Source/Interface/Core/Interpreter/MoveOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/MoveOps.cpp
@@ -11,7 +11,7 @@ $end_info$
 #include <cstdint>
 
 namespace FEXCore::CPU {
-#define DEF_OP(x) void InterpreterOps::Op_##x(FEXCore::IR::IROp_Header *IROp, IROpData *Data, uint32_t Node)
+#define DEF_OP(x) void InterpreterOps::Op_##x(IR::IROp_Header *IROp, IROpData *Data, IR::NodeID Node)
 DEF_OP(ExtractElementPair) {
   auto Op = IROp->C<IR::IROp_ExtractElementPair>();
   uintptr_t Src = GetSrc<uintptr_t>(Data->SSAData, Op->Header.Args[0]);

--- a/External/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
@@ -11,7 +11,7 @@ $end_info$
 #include <cstdint>
 
 namespace FEXCore::CPU {
-#define DEF_OP(x) void InterpreterOps::Op_##x(FEXCore::IR::IROp_Header *IROp, IROpData *Data, uint32_t Node)
+#define DEF_OP(x) void InterpreterOps::Op_##x(IR::IROp_Header *IROp, IROpData *Data, IR::NodeID Node)
 DEF_OP(VectorZero) {
   uint8_t OpSize = IROp->Size;
   memset(GDP, 0, OpSize);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -34,7 +34,7 @@ static int64_t LREM(int64_t SrcHigh, int64_t SrcLow, int64_t Divisor) {
 
 using namespace vixl;
 using namespace vixl::aarch64;
-#define DEF_OP(x) void Arm64JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
+#define DEF_OP(x) void Arm64JITCore::Op_##x(IR::IROp_Header *IROp, IR::NodeID Node)
 DEF_OP(TruncElementPair) {
   auto Op = IROp->C<IR::IROp_TruncElementPair>();
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/AtomicOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/AtomicOps.cpp
@@ -9,7 +9,7 @@ $end_info$
 namespace FEXCore::CPU {
 using namespace vixl;
 using namespace vixl::aarch64;
-#define DEF_OP(x) void Arm64JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
+#define DEF_OP(x) void Arm64JITCore::Op_##x(IR::IROp_Header *IROp, IR::NodeID Node)
 DEF_OP(CASPair) {
   auto Op = IROp->C<IR::IROp_CASPair>();
   uint8_t OpSize = IROp->Size;

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
@@ -17,7 +17,7 @@ $end_info$
 namespace FEXCore::CPU {
 using namespace vixl;
 using namespace vixl::aarch64;
-#define DEF_OP(x) void Arm64JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
+#define DEF_OP(x) void Arm64JITCore::Op_##x(IR::IROp_Header *IROp, IR::NodeID Node)
 DEF_OP(GuestCallDirect) {
   LogMan::Msg::DFmt("Unimplemented");
 }

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ConversionOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ConversionOps.cpp
@@ -10,7 +10,7 @@ namespace FEXCore::CPU {
 
 using namespace vixl;
 using namespace vixl::aarch64;
-#define DEF_OP(x) void Arm64JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
+#define DEF_OP(x) void Arm64JITCore::Op_##x(IR::IROp_Header *IROp, IR::NodeID Node)
 DEF_OP(VInsGPR) {
   auto Op = IROp->C<IR::IROp_VInsGPR>();
   mov(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/EncryptionOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/EncryptionOps.cpp
@@ -10,7 +10,7 @@ $end_info$
 namespace FEXCore::CPU {
 using namespace vixl;
 using namespace vixl::aarch64;
-#define DEF_OP(x) void Arm64JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
+#define DEF_OP(x) void Arm64JITCore::Op_##x(IR::IROp_Header *IROp, IR::NodeID Node)
 
 DEF_OP(AESImc) {
   auto Op = IROp->C<IR::IROp_VAESImc>();

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/FlagOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/FlagOps.cpp
@@ -10,7 +10,7 @@ namespace FEXCore::CPU {
 
 using namespace vixl;
 using namespace vixl::aarch64;
-#define DEF_OP(x) void Arm64JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
+#define DEF_OP(x) void Arm64JITCore::Op_##x(IR::IROp_Header *IROp, IR::NodeID Node)
 DEF_OP(GetHostFlag) {
   auto Op = IROp->C<IR::IROp_GetHostFlag>();
   ubfx(GetReg<RA_64>(Node), GetReg<RA_64>(Op->Header.Args[0].ID()), Op->Flag, 1);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -102,30 +102,30 @@ private:
   constexpr static uint8_t RA_FPR = 2;
 
   template<uint8_t RAType>
-  [[nodiscard]] aarch64::Register GetReg(uint32_t Node) const;
+  [[nodiscard]] aarch64::Register GetReg(IR::NodeID Node) const;
 
   template<>
-  [[nodiscard]] aarch64::Register GetReg<RA_32>(uint32_t Node) const;
+  [[nodiscard]] aarch64::Register GetReg<RA_32>(IR::NodeID Node) const;
   template<>
-  [[nodiscard]] aarch64::Register GetReg<RA_64>(uint32_t Node) const;
+  [[nodiscard]] aarch64::Register GetReg<RA_64>(IR::NodeID Node) const;
 
   template<uint8_t RAType>
-  [[nodiscard]] std::pair<aarch64::Register, aarch64::Register> GetSrcPair(uint32_t Node) const;
+  [[nodiscard]] std::pair<aarch64::Register, aarch64::Register> GetSrcPair(IR::NodeID Node) const;
 
   template<>
-  [[nodiscard]] std::pair<aarch64::Register, aarch64::Register> GetSrcPair<RA_32>(uint32_t Node) const;
+  [[nodiscard]] std::pair<aarch64::Register, aarch64::Register> GetSrcPair<RA_32>(IR::NodeID Node) const;
   template<>
-  [[nodiscard]] std::pair<aarch64::Register, aarch64::Register> GetSrcPair<RA_64>(uint32_t Node) const;
+  [[nodiscard]] std::pair<aarch64::Register, aarch64::Register> GetSrcPair<RA_64>(IR::NodeID Node) const;
 
-  [[nodiscard]] aarch64::VRegister GetSrc(uint32_t Node) const;
-  [[nodiscard]] aarch64::VRegister GetDst(uint32_t Node) const;
+  [[nodiscard]] aarch64::VRegister GetSrc(IR::NodeID Node) const;
+  [[nodiscard]] aarch64::VRegister GetDst(IR::NodeID Node) const;
 
-  [[nodiscard]] FEXCore::IR::RegisterClassType GetRegClass(uint32_t Node) const;
+  [[nodiscard]] FEXCore::IR::RegisterClassType GetRegClass(IR::NodeID Node) const;
 
-  [[nodiscard]] IR::PhysicalRegister GetPhys(uint32_t Node) const;
+  [[nodiscard]] IR::PhysicalRegister GetPhys(IR::NodeID Node) const;
 
-  [[nodiscard]] bool IsFPR(uint32_t Node) const;
-  [[nodiscard]] bool IsGPR(uint32_t Node) const;
+  [[nodiscard]] bool IsFPR(IR::NodeID Node) const;
+  [[nodiscard]] bool IsGPR(IR::NodeID Node) const;
 
   [[nodiscard]] MemOperand GenerateMemOperand(uint8_t AccessSize,
                                               aarch64::Register Base,
@@ -185,8 +185,8 @@ private:
   IR::RegisterAllocationPass *RAPass;
   IR::RegisterAllocationData *RAData;
 
-  using OpHandler = void (Arm64JITCore::*)(FEXCore::IR::IROp_Header *IROp, uint32_t Node);
-  std::array<OpHandler, FEXCore::IR::IROps::OP_LAST + 1> OpHandlers {};
+  using OpHandler = void (Arm64JITCore::*)(IR::IROp_Header *IROp, IR::NodeID Node);
+  std::array<OpHandler, IR::IROps::OP_LAST + 1> OpHandlers {};
   void RegisterALUHandlers();
   void RegisterAtomicHandlers();
   void RegisterBranchHandlers();
@@ -197,7 +197,7 @@ private:
   void RegisterMoveHandlers();
   void RegisterVectorHandlers();
   void RegisterEncryptionHandlers();
-#define DEF_OP(x) void Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
+#define DEF_OP(x) void Op_##x(IR::IROp_Header *IROp, IR::NodeID Node)
 
   ///< Unhandled handler
   DEF_OP(Unhandled);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -11,7 +11,7 @@ namespace FEXCore::CPU {
 
 using namespace vixl;
 using namespace vixl::aarch64;
-#define DEF_OP(x) void Arm64JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
+#define DEF_OP(x) void Arm64JITCore::Op_##x(IR::IROp_Header *IROp, IR::NodeID Node)
 
 DEF_OP(LoadContext) {
   auto Op = IROp->C<IR::IROp_LoadContext>();

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
@@ -17,7 +17,7 @@ static void PrintVectorValue(uint64_t Value, uint64_t ValueUpper) {
 
 using namespace vixl;
 using namespace vixl::aarch64;
-#define DEF_OP(x) void Arm64JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
+#define DEF_OP(x) void Arm64JITCore::Op_##x(IR::IROp_Header *IROp, IR::NodeID Node)
 
 DEF_OP(Fence) {
   auto Op = IROp->C<IR::IROp_Fence>();

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MoveOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MoveOps.cpp
@@ -10,7 +10,7 @@ namespace FEXCore::CPU {
 
 using namespace vixl;
 using namespace vixl::aarch64;
-#define DEF_OP(x) void Arm64JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
+#define DEF_OP(x) void Arm64JITCore::Op_##x(IR::IROp_Header *IROp, IR::NodeID Node)
 DEF_OP(ExtractElementPair) {
   auto Op = IROp->C<IR::IROp_ExtractElementPair>();
   switch (Op->Header.Size) {

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -10,7 +10,7 @@ namespace FEXCore::CPU {
 
 using namespace vixl;
 using namespace vixl::aarch64;
-#define DEF_OP(x) void Arm64JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
+#define DEF_OP(x) void Arm64JITCore::Op_##x(IR::IROp_Header *IROp, IR::NodeID Node)
 DEF_OP(VectorZero) {
   uint8_t OpSize = IROp->Size;
   switch (OpSize) {

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/ALUOps.cpp
@@ -20,7 +20,7 @@ namespace FEXCore::CPU {
 #define GRD(Node) (IROp->Size <= 4 ? GetDst<RA_32>(Node) : GetDst<RA_64>(Node))
 #define GRCMP(Node) (Op->CompareSize == 4 ? GetSrc<RA_32>(Node) : GetSrc<RA_64>(Node))
 
-#define DEF_OP(x) void X86JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
+#define DEF_OP(x) void X86JITCore::Op_##x(IR::IROp_Header *IROp, IR::NodeID Node)
 DEF_OP(TruncElementPair) {
   auto Op = IROp->C<IR::IROp_TruncElementPair>();
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/AtomicOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/AtomicOps.cpp
@@ -15,7 +15,7 @@ $end_info$
 #include <xbyak/xbyak.h>
 
 namespace FEXCore::CPU {
-#define DEF_OP(x) void X86JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
+#define DEF_OP(x) void X86JITCore::Op_##x(IR::IROp_Header *IROp, IR::NodeID Node)
 DEF_OP(CASPair) {
   auto Op = IROp->C<IR::IROp_CAS>();
   uint8_t OpSize = IROp->Size;

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
@@ -28,7 +28,7 @@ $end_info$
 #include <xbyak/xbyak.h>
 
 namespace FEXCore::CPU {
-#define DEF_OP(x) void X86JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
+#define DEF_OP(x) void X86JITCore::Op_##x(IR::IROp_Header *IROp, IR::NodeID Node)
 DEF_OP(GuestCallDirect) {
   LogMan::Msg::DFmt("Unimplemented");
 }

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/ConversionOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/ConversionOps.cpp
@@ -15,7 +15,7 @@ $end_info$
 
 namespace FEXCore::CPU {
 
-#define DEF_OP(x) void X86JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
+#define DEF_OP(x) void X86JITCore::Op_##x(IR::IROp_Header *IROp, IR::NodeID Node)
 DEF_OP(VInsGPR) {
   auto Op = IROp->C<IR::IROp_VInsGPR>();
   movapd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/EncryptionOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/EncryptionOps.cpp
@@ -13,7 +13,7 @@ $end_info$
 #include <xbyak/xbyak.h>
 
 namespace FEXCore::CPU {
-#define DEF_OP(x) void X86JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
+#define DEF_OP(x) void X86JITCore::Op_##x(IR::IROp_Header *IROp, IR::NodeID Node)
 
 DEF_OP(AESImc) {
   auto Op = IROp->C<IR::IROp_VAESImc>();

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/FlagOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/FlagOps.cpp
@@ -14,7 +14,7 @@ $end_info$
 
 namespace FEXCore::CPU {
 
-#define DEF_OP(x) void X86JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
+#define DEF_OP(x) void X86JITCore::Op_##x(IR::IROp_Header *IROp, IR::NodeID Node)
 DEF_OP(GetHostFlag) {
   auto Op = IROp->C<IR::IROp_GetHostFlag>();
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -117,21 +117,21 @@ private:
   constexpr static uint8_t RA_64 = 3;
   constexpr static uint8_t RA_XMM = 4;
 
-  [[nodiscard]] IR::PhysicalRegister GetPhys(uint32_t Node) const;
+  [[nodiscard]] IR::PhysicalRegister GetPhys(IR::NodeID Node) const;
 
-  [[nodiscard]] bool IsFPR(uint32_t Node) const;
-  [[nodiscard]] bool IsGPR(uint32_t Node) const;
-
-  template<uint8_t RAType>
-  [[nodiscard]] Xbyak::Reg GetSrc(uint32_t Node) const;
-  template<uint8_t RAType>
-  [[nodiscard]] std::pair<Xbyak::Reg, Xbyak::Reg> GetSrcPair(uint32_t Node) const;
+  [[nodiscard]] bool IsFPR(IR::NodeID Node) const;
+  [[nodiscard]] bool IsGPR(IR::NodeID Node) const;
 
   template<uint8_t RAType>
-  [[nodiscard]] Xbyak::Reg GetDst(uint32_t Node) const;
+  [[nodiscard]] Xbyak::Reg GetSrc(IR::NodeID Node) const;
+  template<uint8_t RAType>
+  [[nodiscard]] std::pair<Xbyak::Reg, Xbyak::Reg> GetSrcPair(IR::NodeID Node) const;
 
-  [[nodiscard]] Xbyak::Xmm GetSrc(uint32_t Node) const;
-  [[nodiscard]] Xbyak::Xmm GetDst(uint32_t Node) const;
+  template<uint8_t RAType>
+  [[nodiscard]] Xbyak::Reg GetDst(IR::NodeID Node) const;
+
+  [[nodiscard]] Xbyak::Xmm GetSrc(IR::NodeID Node) const;
+  [[nodiscard]] Xbyak::Xmm GetDst(IR::NodeID Node) const;
 
   [[nodiscard]] Xbyak::RegExp GenerateModRM(Xbyak::Reg Base, IR::OrderedNodeWrapper Offset,
                                             IR::MemOffsetType OffsetType, uint8_t OffsetScale) const;
@@ -182,8 +182,8 @@ private:
 
   std::tuple<SetCC, CMovCC, JCC> GetCC(IR::CondClassType cond);
 
-  using OpHandler = void (X86JITCore::*)(FEXCore::IR::IROp_Header *IROp, uint32_t Node);
-  std::array<OpHandler, FEXCore::IR::IROps::OP_LAST + 1> OpHandlers {};
+  using OpHandler = void (X86JITCore::*)(IR::IROp_Header *IROp, IR::NodeID Node);
+  std::array<OpHandler, IR::IROps::OP_LAST + 1> OpHandlers {};
   void RegisterALUHandlers();
   void RegisterAtomicHandlers();
   void RegisterBranchHandlers();
@@ -197,7 +197,7 @@ private:
 
   void PushRegs();
   void PopRegs();
-#define DEF_OP(x) void Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
+#define DEF_OP(x) void Op_##x(IR::IROp_Header *IROp, IR::NodeID Node)
 
   ///< Unhandled handler
   DEF_OP(Unhandled);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/MemoryOps.cpp
@@ -17,7 +17,7 @@ $end_info$
 
 namespace FEXCore::CPU {
 
-#define DEF_OP(x) void X86JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
+#define DEF_OP(x) void X86JITCore::Op_##x(IR::IROp_Header *IROp, IR::NodeID Node)
 
 DEF_OP(LoadContext) {
   auto Op = IROp->C<IR::IROp_LoadContext>();

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/MiscOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/MiscOps.cpp
@@ -26,7 +26,7 @@ static void PrintVectorValue(uint64_t Value, uint64_t ValueUpper) {
   LogMan::Msg::DFmt("Value: 0x{:016x}'{:016x}", ValueUpper, Value);
 }
 
-#define DEF_OP(x) void X86JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
+#define DEF_OP(x) void X86JITCore::Op_##x(IR::IROp_Header *IROp, IR::NodeID Node)
 
 DEF_OP(Fence) {
   auto Op = IROp->C<IR::IROp_Fence>();

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/MoveOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/MoveOps.cpp
@@ -15,7 +15,7 @@ $end_info$
 
 namespace FEXCore::CPU {
 
-#define DEF_OP(x) void X86JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
+#define DEF_OP(x) void X86JITCore::Op_##x(IR::IROp_Header *IROp, IR::NodeID Node)
 DEF_OP(ExtractElementPair) {
   auto Op = IROp->C<IR::IROp_ExtractElementPair>();
   switch (Op->Header.Size) {

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
@@ -16,7 +16,7 @@ $end_info$
 
 namespace FEXCore::CPU {
 
-#define DEF_OP(x) void X86JITCore::Op_##x(FEXCore::IR::IROp_Header *IROp, uint32_t Node)
+#define DEF_OP(x) void X86JITCore::Op_##x(IR::IROp_Header *IROp, IR::NodeID Node)
 DEF_OP(VectorZero) {
   auto Dst = GetDst(Node);
   vpxor(Dst, Dst, Dst);

--- a/External/FEXCore/Source/Interface/IR/IRDumper.cpp
+++ b/External/FEXCore/Source/Interface/IR/IRDumper.cpp
@@ -199,9 +199,9 @@ void Dump(std::stringstream *out, IRListView const* IR, IR::RegisterAllocationDa
 
     ++CurrentIndent;
     for (auto [CodeNode, IROp] : IR->GetCode(BlockNode)) {
-      uint32_t ID = IR->GetID(CodeNode);
+      const auto ID = IR->GetID(CodeNode);
+      const auto Name = FEXCore::IR::GetName(IROp->Op);
 
-      auto Name = FEXCore::IR::GetName(IROp->Op);
       bool Skip{};
       switch (IROp->Op) {
         case IR::OP_PHIVALUE:

--- a/External/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
@@ -337,7 +337,7 @@ private:
   std::unique_ptr<FEXCore::IR::Pass> DCE;
 
   ContextInfo ClassifiedStruct;
-  std::unordered_map<FEXCore::IR::OrderedNodeWrapper::NodeOffsetType, BlockInfo> OffsetToBlockMap;
+  std::unordered_map<FEXCore::IR::NodeID, BlockInfo> OffsetToBlockMap;
 
   ContextMemberInfo *FindMemberInfo(ContextInfo *ClassifiedInfo, uint32_t Offset, uint8_t Size);
   ContextMemberInfo *RecordAccess(ContextMemberInfo *Info, FEXCore::IR::RegisterClassType RegClass, uint32_t Offset, uint8_t Size, LastAccessType AccessType, FEXCore::IR::OrderedNode *Node, FEXCore::IR::OrderedNode *StoreNode = nullptr);

--- a/External/FEXCore/Source/Interface/IR/Passes/IRCompaction.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/IRCompaction.cpp
@@ -24,7 +24,7 @@ namespace FEXCore::IR {
 
 // struct to avoid zero-initialization
 struct RemapNode {
-  IR::OrderedNodeWrapper::NodeOffsetType NodeID;
+  IR::NodeID NodeID;
 };
 
 static_assert(sizeof(RemapNode) == 4);
@@ -172,9 +172,9 @@ bool IRCompaction::Run(IREmitter *IREmit) {
         // Now that we have the op copied over, we need to modify SSA values to point to the new correct locations
         // This doesn't use IR::GetArgs(Op) because we need to remap all SSA nodes
         // Including ones that we don't RA
-        uint8_t NumArgs = LocalIROp->NumArgs;
+        const uint8_t NumArgs = LocalIROp->NumArgs;
         for (uint8_t i = 0; i < NumArgs; ++i) {
-          uint32_t OldArg = LocalIROp->Args[i].ID();
+          const auto OldArg = LocalIROp->Args[i].ID();
           #ifndef NDEBUG
             LOGMAN_THROW_A_FMT(OldToNewRemap[OldArg].NodeID != ~0U, "Tried remapping unfound node %ssa{}", OldArg);
           #endif

--- a/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
@@ -69,15 +69,12 @@ bool IRValidation::Run(IREmitter *IREmit) {
       EntryBlock = BlockNode;
     }
 
-    uint32_t BlockID = CurrentIR.GetID(BlockNode);
-
+    const auto BlockID = CurrentIR.GetID(BlockNode);
     BlockInfo *CurrentBlock = &OffsetToBlockMap.try_emplace(BlockID).first->second;
 
-
     for (auto [CodeNode, IROp] : CurrentIR.GetCode(BlockNode)) {
-      uint32_t ID = CurrentIR.GetID(CodeNode);
-
-      uint8_t OpSize = IROp->Size;
+      const auto ID = CurrentIR.GetID(CodeNode);
+      const uint8_t OpSize = IROp->Size;
 
       if (IROp->HasDest) {
         HadError |= OpSize == 0;

--- a/External/FEXCore/Source/Interface/IR/Passes/IRValidation.h
+++ b/External/FEXCore/Source/Interface/IR/Passes/IRValidation.h
@@ -24,7 +24,7 @@ private:
 
   BitSet<uint64_t> NodeIsLive;
   OrderedNode *EntryBlock;
-  std::unordered_map<IR::OrderedNodeWrapper::NodeOffsetType, BlockInfo> OffsetToBlockMap;
+  std::unordered_map<IR::NodeID, BlockInfo> OffsetToBlockMap;
   size_t MaxNodes{};
 
   friend class RAValidation;

--- a/External/FEXCore/Source/Interface/IR/Passes/ValueDominanceValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ValueDominanceValidation.cpp
@@ -40,7 +40,7 @@ bool ValueDominanceValidation::Run(IREmitter *IREmit) {
   auto CurrentIR = IREmit->ViewIR();
 
   std::ostringstream Errors;
-  std::unordered_map<IR::OrderedNodeWrapper::NodeOffsetType, BlockInfo> OffsetToBlockMap;
+  std::unordered_map<IR::NodeID, BlockInfo> OffsetToBlockMap;
 
   for (auto [BlockNode, BlockHeader] : CurrentIR.GetBlocks()) {
 
@@ -89,9 +89,9 @@ bool ValueDominanceValidation::Run(IREmitter *IREmit) {
     auto BlockIROp = BlockHeader->CW<FEXCore::IR::IROp_CodeBlock>();
 
     for (auto [CodeNode, IROp] : CurrentIR.GetCode(BlockNode)) {
-      uint32_t CodeID = CurrentIR.GetID(CodeNode);
+      const auto CodeID = CurrentIR.GetID(CodeNode);
 
-      uint8_t NumArgs = IR::GetArgs(IROp->Op);
+      const uint8_t NumArgs = IR::GetArgs(IROp->Op);
       for (uint32_t i = 0; i < NumArgs; ++i) {
         if (IROp->Args[i].IsInvalid()) continue;
         if (CurrentIR.GetOp<IROp_Header>(IROp->Args[i])->Op == OP_IRHEADER) continue;

--- a/External/FEXCore/include/FEXCore/IR/IR.h
+++ b/External/FEXCore/include/FEXCore/IR/IR.h
@@ -11,6 +11,7 @@
 #include <tuple>
 
 namespace FEXCore::IR {
+class OrderedNode;
 class RegisterAllocationPass;
 class RegisterAllocationData;
 
@@ -22,7 +23,11 @@ class RegisterAllocationData;
  */
 struct IROp_Header;
 
-class OrderedNode;
+/**
+ * @brief Represents the ID of a given IR node.
+ */
+using NodeID = uint32_t;
+
 /**
  * @brief This is a very simple wrapper for our node pointers
  * You probably don't want to use this directly
@@ -64,7 +69,7 @@ struct NodeWrapperBase final {
     return Node.GetNode(Base);
   }
 
-  uint32_t ID() const;
+  NodeID ID() const;
 
   bool IsInvalid() const { return NodeOffset == 0; }
 
@@ -399,7 +404,7 @@ public:
 		return { RealNode, RealNode->Op(IRList) };
 	}
 
-  uint32_t ID() const {
+  NodeID ID() const {
     return Node.ID();
   }
 
@@ -483,6 +488,6 @@ FEX_DEFAULT_VISIBILITY void Dump(std::stringstream *out, IRListView const* IR, I
 FEX_DEFAULT_VISIBILITY std::unique_ptr<IREmitter> Parse(std::istream *in);
 
 template<typename Type>
-inline uint32_t NodeWrapperBase<Type>::ID() const { return NodeOffset / sizeof(IR::OrderedNode); }
+inline NodeID NodeWrapperBase<Type>::ID() const { return NodeOffset / sizeof(IR::OrderedNode); }
 
 };

--- a/External/FEXCore/include/FEXCore/IR/IntrusiveIRList.h
+++ b/External/FEXCore/include/FEXCore/IR/IntrusiveIRList.h
@@ -176,7 +176,7 @@ public:
   bool IsShared() const { return Flags & FLAG_Shared; }
   void SetShared(bool Set) { if (Set) Flags |= FLAG_Shared; else Flags &= ~FLAG_Shared; }
 
-  uint32_t GetID(OrderedNode *Node) const {
+  NodeID GetID(OrderedNode *Node) const {
     return Node->Wrapped(GetListData()).ID();
   }
 

--- a/External/FEXCore/include/FEXCore/IR/RegisterAllocationData.h
+++ b/External/FEXCore/include/FEXCore/IR/RegisterAllocationData.h
@@ -35,7 +35,7 @@ class RegisterAllocationData {
     bool IsShared {false};
     PhysicalRegister Map[0];
 
-    PhysicalRegister GetNodeRegister(uint32_t Node) const {
+    PhysicalRegister GetNodeRegister(NodeID Node) const {
       return Map[Node];
     }
     uint32_t SpillSlots() const { return SpillSlotCount; }


### PR DESCRIPTION
In quite a few places we have a raw primitive to represent an IR node's ID. This can make reading some bits of the API (or the passes) a little confusing to take in, since there's no meaningful type name for some data structure members, so sometimes scrolling to a particular usage is necessary to see what they represent

We can provide an alias that communicates this directly to the reader at the point of declaration.

This also has the nice benefit of providing a single point of definition for the type of node IDs which can allow for easier changes in the future (e.g. making Node IDs strongly-typed, etc, among other things).