### PR TITLE
jit/arm64: COND_FGT should map to gt, not hi, as it is not FGTU

### DIFF
--- a/Data/AppConfig/steamwebhelper.json
+++ b/Data/AppConfig/steamwebhelper.json
@@ -1,5 +1,0 @@
-{
-  "Config": {
-    "StallProcess": "1"
-  }
-}

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
@@ -137,7 +137,7 @@ Condition MapBranchCC(IR::CondClassType Cond) {
   case FEXCore::IR::COND_FLU: return Condition::lt;
   case FEXCore::IR::COND_FGE: return Condition::ge;
   case FEXCore::IR::COND_FLEU:return Condition::le;
-  case FEXCore::IR::COND_FGT: return Condition::hi;
+  case FEXCore::IR::COND_FGT: return Condition::gt;
   case FEXCore::IR::COND_FU:  return Condition::vs;
   case FEXCore::IR::COND_FNU: return Condition::vc;
   case FEXCore::IR::COND_VS:


### PR DESCRIPTION
Fixes #1127

Finally.

I ended up taking the extremely long road on bisecting this, as I didn't validate that fcmp-eflag-bypass wasn't a culprit leading to me doing a full on bisection of steam, then proceeded to make a race condition bug in the bisection code, then went down the path of chasing that race in the guest code.

But, it's fixed. FIXED :D

Upside: We have amazing new tooling for bisections.

Will follow up with tooling PR