### PR TITLE
RegisterAllocationPass: Reduce usages of NodeIDs where applicable

### DIFF
--- a/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -583,7 +583,7 @@ namespace {
     LiveRange* StaticMaps[MapsSize];
 
     // Get a StaticMap entry from context offset
-    auto GetStaticMapFromOffset = [&](uint32_t Offset) {
+    const auto GetStaticMapFromOffset = [&](uint32_t Offset) -> LiveRange** {
         auto beginGpr = offsetof(FEXCore::Core::CpuStateFrame, State.gregs[0]);
         auto endGpr = offsetof(FEXCore::Core::CpuStateFrame, State.gregs[17]);
 
@@ -598,19 +598,19 @@ namespace {
           return &StaticMaps[GprSize + reg];
         } else {
           LOGMAN_THROW_A_FMT(false, "Unexpected offset {}", Offset);
-          return (LiveRange**)nullptr;
+          return nullptr;
         }
     };
 
     // Get a StaticMap entry from reg and class
-    auto GetStaticMapFromReg = [&](IR::PhysicalRegister PhyReg) {
+    const auto GetStaticMapFromReg = [&](IR::PhysicalRegister PhyReg) -> LiveRange** {
       if (PhyReg.Class == GPRFixedClass.Val) {
         return &StaticMaps[PhyReg.Reg];
       } else if (PhyReg.Class == FPRFixedClass.Val) {
         return &StaticMaps[GprSize + PhyReg.Reg];
       } else {
         LOGMAN_THROW_A_FMT(false, "Unexpected Class {}", PhyReg.Class);
-        return (LiveRange**)nullptr;
+        return nullptr;
       }
     };
 


### PR DESCRIPTION
A basic tidying up of cases where NodeIDs are passed around by repeatedly calling `ID()`. This will make it a little more convenient for turning the NodeID alias into a strong type in a followup, since it minimizes locations that need to be touched (making a review a little nicer).

