### PR TITLE
Adds a new ReentrantMutex to use for FEXCore

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -140,6 +140,17 @@ jobs:
       working-directory: ${{runner.workspace}}/build
       run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_StructVerifier.log || true
 
+    - name: APITest tests
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      run: cmake --build . --config $BUILD_TYPE --target api_tests
+
+    - name: APITest Test Results move
+      if: ${{ always() }}
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_APITests.log || true
+
     - name: Truncate test results
       if: ${{ always() }}
       shell: bash

--- a/.gitmodules
+++ b/.gitmodules
@@ -46,3 +46,6 @@
   shallow = true
 	path = External/Vulkan-Docs
 	url = https://github.com/KhronosGroup/Vulkan-Docs.git
+[submodule "External/Catch2"]
+	path = External/Catch2
+	url = https://github.com/catchorg/Catch2.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,6 +268,16 @@ endif()
 add_definitions(-Wno-trigraphs)
 add_definitions(-DGLOBAL_DATA_DIRECTORY="${DATA_DIRECTORY}/")
 
+if (BUILD_TESTS)
+  option(CATCH_BUILD_STATIC_LIBRARY "" ON)
+  set(CATCH_BUILD_STATIC_LIBRARY ON)
+  add_subdirectory(External/Catch2/)
+
+  # Pull in catch_discover_tests definition
+  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/External/Catch2/contrib/")
+  include(Catch)
+endif()
+
 add_subdirectory(External/cpp-optparse/)
 include_directories(External/cpp-optparse/)
 

--- a/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
+++ b/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
@@ -5,6 +5,7 @@
 #include <FEXCore/IR/IntrusiveIRList.h>
 #include <FEXCore/IR/RegisterAllocationData.h>
 #include <FEXCore/Utils/Event.h>
+#include <FEXCore/Utils/InterruptableConditionVariable.h>
 #include <FEXCore/Utils/Threads.h>
 
 #include <unordered_map>
@@ -83,7 +84,7 @@ namespace FEXCore::Core {
     std::atomic<SignalEvent> SignalReason{SignalEvent::Nothing};
 
     std::unique_ptr<FEXCore::Threads::Thread> ExecutionThread;
-    Event StartRunning;
+    InterruptableConditionVariable StartRunning;
     Event ThreadWaiting;
 
     std::unique_ptr<FEXCore::IR::OpDispatchBuilder> OpDispatcher;

--- a/External/FEXCore/include/FEXCore/Utils/InterruptableConditionVariable.h
+++ b/External/FEXCore/include/FEXCore/Utils/InterruptableConditionVariable.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <climits>
+#include <cstdint>
+#include <linux/futex.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+namespace FEXCore {
+  /**
+   * @brief A condition variable that is robust against use of longjmp in signal handlers.
+   *
+   * This is opposed to common `std::condition_variable` implementations:
+   * Longjmp'ing in a signal handler while interrupting a pending `wait_for()`
+   * call can leave the condition variable in an invalid state that breaks later
+   * uses of that object and may cause hangs as a consequence.
+   */
+  class InterruptableConditionVariable final {
+    public:
+      bool Wait(struct timespec *Timeout = nullptr) {
+        while (true) {
+          uint32_t Expected = SIGNALED;
+          uint32_t Desired = UNSIGNALED;
+
+          // If the mutex was already signaled then we can early exit
+          if (Mutex.compare_exchange_strong(Expected, Desired)) {
+            return true;
+          }
+
+          constexpr int Op = FUTEX_WAIT | FUTEX_PRIVATE_FLAG;
+          // WAIT will keep sleeping on the futex word while it is `val`
+          int Result = ::syscall(SYS_futex,
+            &Mutex,
+            Op,
+            Desired, // val
+            Timeout, // Timeout/val2
+            nullptr, // Addr2
+            0); // val3
+
+          if (Timeout && Result == -1 && errno == ETIMEDOUT) {
+            return false;
+          }
+        }
+      }
+
+      template<class Rep, class Period>
+      bool WaitFor(std::chrono::duration<Rep, Period> const& time) {
+        struct timespec Timeout{};
+        auto SecondsDuration = std::chrono::duration_cast<std::chrono::seconds>(time);
+        Timeout.tv_sec = SecondsDuration.count();
+        Timeout.tv_nsec = std::chrono::duration_cast<std::chrono::nanoseconds>(time - SecondsDuration).count();
+        return Wait(&Timeout);
+      }
+
+      void NotifyOne() {
+        DoNotify(1);
+      }
+
+      void NotifyAll() {
+        // Maximum number of waiters
+        DoNotify(INT_MAX);
+      }
+
+    private:
+      std::atomic<uint32_t> Mutex{};
+      constexpr static uint32_t SIGNALED = 1;
+      constexpr static uint32_t UNSIGNALED = 0;
+
+      void DoNotify(int Waiters) {
+        uint32_t Expected = UNSIGNALED;
+        uint32_t Desired = SIGNALED;
+
+        // If the mutex was in an unsignaled state then signal
+        if (Mutex.compare_exchange_strong(Expected, Desired)) {
+          constexpr int Op = FUTEX_WAKE | FUTEX_PRIVATE_FLAG;
+
+          ::syscall(SYS_futex,
+            &Mutex,
+            Op,
+            Waiters, // val - Number of waiters to wake
+            0,       // val2
+            &Mutex,  // Addr2 - Mutex to do the operation on
+            0);    // val3
+        }
+      }
+  };
+}

--- a/unittests/APITests/CMakeLists.txt
+++ b/unittests/APITests/CMakeLists.txt
@@ -1,0 +1,25 @@
+set (TESTS
+  InterruptableConditionVariable)
+
+list(APPEND LIBS FEXCore)
+
+foreach(API_TEST ${TESTS})
+  add_executable(${API_TEST} ${API_TEST}.cpp)
+  target_link_libraries(${API_TEST} PRIVATE ${LIBS} Catch2::Catch2WithMain)
+
+  catch_discover_tests(${API_TEST}
+    TEST_SUFFIX ".${API_TEST}.APITest")
+endforeach()
+
+execute_process(COMMAND "nproc" OUTPUT_VARIABLE CORES)
+string(STRIP ${CORES} CORES)
+
+add_custom_target(
+  api_tests
+  WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+  USES_TERMINAL
+  COMMAND "ctest" "--timeout" "302" "-j${CORES}" "-R" "\.*.APITest")
+
+foreach(API_TEST ${TESTS})
+  add_dependencies(api_tests ${API_TEST})
+endforeach()

--- a/unittests/APITests/InterruptableConditionVariable.cpp
+++ b/unittests/APITests/InterruptableConditionVariable.cpp
@@ -1,0 +1,154 @@
+#include <catch2/catch.hpp>
+#include <chrono>
+#include <csetjmp>
+#include <FEXCore/Utils/InterruptableConditionVariable.h>
+#include <thread>
+#include <signal.h>
+
+// Test that ensures the Reentrant mutex will timeout without signaling
+TEST_CASE("SimpleWait") {
+  auto Dur = std::chrono::seconds(1);
+  FEXCore::InterruptableConditionVariable Mutex{};
+
+  auto Now = std::chrono::high_resolution_clock::now();
+  bool Signaled = Mutex.WaitFor(Dur);
+  auto End = std::chrono::high_resolution_clock::now();
+
+  // We weren't signaled
+  REQUIRE(Signaled == false);
+
+  // We waited at least the full duration
+  REQUIRE((End - Now) >= Dur);
+}
+
+void WaitThread(FEXCore::InterruptableConditionVariable *Mutex, bool *Signaled) {
+  auto Dur = std::chrono::seconds(5);
+  *Signaled = Mutex->WaitFor(Dur);
+}
+
+// Test that ensure the Reentrant mutex will signal without timing out
+TEST_CASE("SignaledWait") {
+  bool Signaled{};
+  FEXCore::InterruptableConditionVariable Mutex{};
+
+  std::thread t(WaitThread, &Mutex, &Signaled);
+
+  auto Now = std::chrono::high_resolution_clock::now();
+  Mutex.NotifyAll();
+  auto End = std::chrono::high_resolution_clock::now();
+
+  t.join();
+
+  auto Dur = std::chrono::seconds(5);
+  // Expected to signal
+  REQUIRE(Signaled);
+  // Ensure we didn't timeout
+  REQUIRE((End - Now) < Dur);
+}
+
+static jmp_buf LongJump{};
+static int32_t NumberOfJumps{};
+FEXCore::InterruptableConditionVariable WaitMutex{};
+
+void SignalHandler(int Signal) {
+  ++NumberOfJumps;
+  longjmp(LongJump, 1);
+}
+
+void WaitThreadLongJump(
+  FEXCore::InterruptableConditionVariable *Mutex,
+  FEXCore::InterruptableConditionVariable *ThreadReadyMutex,
+  bool *Signaled,
+  int32_t *TID) {
+
+  // Store the TID
+  *TID = ::gettid();
+
+  // Setup a long jump signal handler
+  struct sigaction sa{};
+  sa.sa_flags = SA_RESTART | SA_NODEFER;
+  sigemptyset(&sa.sa_mask);
+  sa.sa_handler = SignalHandler;
+  sigaction(SIGUSR1, &sa, nullptr);
+
+  // long jump here
+  int Value = setjmp(LongJump);
+
+  if (Value == 0) {
+    // Only notify that we are ready once
+    ThreadReadyMutex->NotifyAll();
+  }
+
+  // Notify the loop that we are ready for signaling again
+  WaitMutex.NotifyAll();
+
+  // Time out after two seconds
+  auto Dur = std::chrono::seconds(2);
+  *Signaled = Mutex->WaitFor(Dur);
+}
+
+// Test that ensures the Reentrant mutex survives over a long jump
+// Without signaling the mutex
+TEST_CASE("SignaledWaitLongJumpNoSignal") {
+  int32_t TID{};
+  bool Signaled{};
+  FEXCore::InterruptableConditionVariable Mutex{};
+  FEXCore::InterruptableConditionVariable ThreadReadyMutex{};
+
+  NumberOfJumps = 0;
+  std::thread t(WaitThreadLongJump, &Mutex, &ThreadReadyMutex, &Signaled, &TID);
+
+  // Wait for our thread to become ready
+  ThreadReadyMutex.Wait();
+
+  int32_t NumberOfJumpsToDo = 5;
+  for (int32_t i = 0; i < NumberOfJumpsToDo; ++i) {
+    // Wait for the thread to signal that it is ready to receive signal
+    WaitMutex.WaitFor(std::chrono::milliseconds(500));
+    // Send the signal to the thread
+    tgkill(::getpid(), TID, SIGUSR1);
+  }
+
+  // Wait for thread join
+  t.join();
+
+  // We never signaled, so we should never receive signal
+  REQUIRE(Signaled == false);
+  // Ensure we long jumped the correct number of times
+  REQUIRE(NumberOfJumps == NumberOfJumpsToDo);
+}
+
+// Test that ensures the Reentrant mutex survives over a long jump
+// With signaling the mutex
+TEST_CASE("SignaledWaitLongJumpSignal") {
+  int32_t TID{};
+  bool Signaled{};
+  FEXCore::InterruptableConditionVariable Mutex{};
+  FEXCore::InterruptableConditionVariable ThreadReadyMutex{};
+
+  NumberOfJumps = 0;
+  std::thread t(WaitThreadLongJump, &Mutex, &ThreadReadyMutex, &Signaled, &TID);
+
+  // Wait for our thread to become ready
+  ThreadReadyMutex.Wait();
+
+  int32_t NumberOfJumpsToDo = 5;
+  for (int32_t i = 0; i < NumberOfJumpsToDo; ++i) {
+    // Wait for the thread to signal that it is ready to receive signal
+    WaitMutex.WaitFor(std::chrono::milliseconds(500));
+
+    // Send the signal to the thread
+    tgkill(::getpid(), TID, SIGUSR1);
+  }
+
+  // Notify the thread's mutex now
+  Mutex.NotifyAll();
+
+  // Wait for thread join
+  t.join();
+
+  // We signaled so we should have received it now
+  REQUIRE(Signaled);
+  // Ensure we long jumped the correct number of times
+  REQUIRE(NumberOfJumps == NumberOfJumpsToDo);
+}

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_subdirectory(APITests/)
 add_subdirectory(ASM/)
 add_subdirectory(32Bit_ASM/)
 add_subdirectory(IR/)


### PR DESCRIPTION
Necessary to workaround a gdbstub hang on shutdown since regular std::mutex and std::condition_variable aren't reentrant safe.