### PR TITLE
FEXLoader: Print memory map when 32-bit intersect happens

### DIFF
--- a/Source/Tests/FEXLoader.cpp
+++ b/Source/Tests/FEXLoader.cpp
@@ -124,6 +124,28 @@ bool CheckMemMapping() {
 
   return true;
 }
+
+void PrintIntersectingMapping() {
+  std::fstream fs("/proc/self/maps", std::fstream::in | std::fstream::binary);
+  std::string Line;
+  while (std::getline(fs, Line)) {
+    if (fs.eof()) {
+      break;
+    }
+    uint64_t Begin{};
+    uint64_t End{};
+    if (sscanf(Line.c_str(), "%lx-%lx", &Begin, &End) == 2) {
+      // If a memory range is living inside the 32bit memory space then we have a problem
+      if (Begin < 0x1'0000'0000) {
+        LogMan::Msg::EFmt("*** {}", Line);
+      }
+      else {
+        LogMan::Msg::EFmt("    {}", Line);
+      }
+    }
+  }
+}
+
 } // Anonymous namespace
 
 void InterpreterHandler(std::string *Filename, std::string const &RootFS, std::vector<std::string> *args) {
@@ -353,6 +375,7 @@ int main(int argc, char **argv, char **const envp) {
   // Valgrind also places us in the lower 32-bits
   if (!getenv("VALGRIND_LAUNCHER") &&
       !CheckMemMapping()) {
+    PrintIntersectingMapping();
     LogMan::Msg::EFmt("[Unsupported] FEX mapped to lower 32bits! Exiting!");
     return -1;
   }


### PR DESCRIPTION
To get more information as to what intersected