### PR TITLE
IR: Convert NodeID into a strong type

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterDefines.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterDefines.h
@@ -161,19 +161,19 @@
 
 template<typename Res>
 Res GetDest(void* SSAData, FEXCore::IR::OrderedNodeWrapper Op) {
-  auto DstPtr = &reinterpret_cast<__uint128_t*>(SSAData)[Op.ID()];
+  auto DstPtr = &reinterpret_cast<__uint128_t*>(SSAData)[Op.ID().Value];
   return reinterpret_cast<Res>(DstPtr);
 }
 
 template<typename Res>
 Res GetDest(void* SSAData, FEXCore::IR::NodeID Op) {
-  auto DstPtr = &reinterpret_cast<__uint128_t*>(SSAData)[Op];
+  auto DstPtr = &reinterpret_cast<__uint128_t*>(SSAData)[Op.Value];
   return reinterpret_cast<Res>(DstPtr);
 }
 
 
 template<typename Res>
 Res GetSrc(void* SSAData, FEXCore::IR::OrderedNodeWrapper Src) {
-  auto DstPtr = &reinterpret_cast<__uint128_t*>(SSAData)[Src.ID()];
+  auto DstPtr = &reinterpret_cast<__uint128_t*>(SSAData)[Src.ID().Value];
   return reinterpret_cast<Res>(DstPtr);
 }

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -78,7 +78,7 @@ private:
   FEXCore::IR::IRListView const *IR;
   uint64_t Entry;
 
-  std::map<IR::OrderedNodeWrapper::NodeOffsetType, aarch64::Label> JumpTargets;
+  std::map<IR::NodeID, aarch64::Label> JumpTargets;
 
   /**
    * @name Register Allocation

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -91,7 +91,7 @@ private:
   std::unique_ptr<FEXCore::CPU::Dispatcher> Dispatcher;
   uint64_t Entry;
 
-  std::unordered_map<IR::OrderedNodeWrapper::NodeOffsetType, Label> JumpTargets;
+  std::unordered_map<IR::NodeID, Label> JumpTargets;
   Xbyak::util::Cpu Features{};
 
   bool MemoryDebug = false;

--- a/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
+++ b/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
@@ -37,7 +37,7 @@ namespace FEXCore::Core {
   struct DebugDataSubblock {
     uintptr_t HostCodeStart;
     uint32_t HostCodeSize;
-    uint32_t SSAId;
+    IR::NodeID SSAId;
   };
 
   /**

--- a/External/FEXCore/include/FEXCore/IR/IREmitter.h
+++ b/External/FEXCore/include/FEXCore/IR/IREmitter.h
@@ -398,7 +398,7 @@ friend class FEXCore::IR::PassManager;
     Phi->Header.Size = ValueIROp->Size;
     Phi->Header.ElementSize = ValueIROp->ElementSize;
 
-    if (!Phi->PhiBegin.ID()) {
+    if (Phi->PhiBegin.ID().IsInvalid()) {
       Phi->PhiBegin = Phi->PhiEnd = Value->Wrapped(DualListData.ListBegin());
       return;
     }

--- a/External/FEXCore/include/FEXCore/IR/IntrusiveIRList.h
+++ b/External/FEXCore/include/FEXCore/IR/IntrusiveIRList.h
@@ -306,9 +306,9 @@ public:
     return iterator(reinterpret_cast<uintptr_t>(GetListData()), reinterpret_cast<uintptr_t>(GetData()), Wrapped);
   }
 
-  iterator at(uint32_t ID) const noexcept {
+  iterator at(NodeID ID) const noexcept {
     OrderedNodeWrapper Wrapped;
-    Wrapped.NodeOffset = ID * sizeof(OrderedNode);
+    Wrapped.NodeOffset = ID.Value * sizeof(OrderedNode);
     return iterator(reinterpret_cast<uintptr_t>(GetListData()), reinterpret_cast<uintptr_t>(GetData()), Wrapped);
   }
 

--- a/External/FEXCore/include/FEXCore/IR/RegisterAllocationData.h
+++ b/External/FEXCore/include/FEXCore/IR/RegisterAllocationData.h
@@ -36,7 +36,7 @@ class RegisterAllocationData {
     PhysicalRegister Map[0];
 
     PhysicalRegister GetNodeRegister(NodeID Node) const {
-      return Map[Node];
+      return Map[Node.Value];
     }
     uint32_t SpillSlots() const { return SpillSlotCount; }
 

--- a/External/FEXCore/include/FEXCore/Utils/BucketList.h
+++ b/External/FEXCore/include/FEXCore/Utils/BucketList.h
@@ -17,7 +17,7 @@ namespace FEXCore {
     static constexpr size_t Size = _Size;
 
     T Items[Size];
-    std::unique_ptr<BucketList<Size>> Next;
+    std::unique_ptr<BucketList<Size, T>> Next;
 
     void Clear() {
       Items[0] = T{};

--- a/External/FEXCore/include/FEXCore/Utils/BucketList.h
+++ b/External/FEXCore/include/FEXCore/Utils/BucketList.h
@@ -22,8 +22,9 @@ namespace FEXCore {
     void Clear() {
       Items[0] = T{};
       #ifndef NDEBUG
-      for (size_t i = 1; i < Size; i++)
-        Items[i] = 0xDEADBEEF;
+      for (size_t i = 1; i < Size; i++) {
+        Items[i] = T{0xDEADBEEF};
+      }
       #endif
       Next.reset();
     }


### PR DESCRIPTION
Converts the NodeID alias into a strongly-typed structure, which will allow catching attempts to pass NodeIDs into incorrect APIs at compile-time, which is a little bit better than passing around unlabeled primitive types that silently convert to one another.