### PR TITLE
JIT: Eliminate redundant jump target map lookups

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
@@ -115,7 +115,7 @@ DEF_OP(Jump) {
 #define GRCMP(Node) (Op->CompareSize == 4 ? GetReg<RA_32>(Node) : GetReg<RA_64>(Node))
 #define GRFCMP(Node) (Op->CompareSize == 4 ? GetDst(Node).S() : GetDst(Node).D())
 
-Condition MapBranchCC(IR::CondClassType Cond) {
+static Condition MapBranchCC(IR::CondClassType Cond) {
   switch (Cond.Val) {
   case FEXCore::IR::COND_EQ: return Condition::eq;
   case FEXCore::IR::COND_NEQ: return Condition::ne;

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -698,10 +698,7 @@ void *Arm64JITCore::CompileCode(uint64_t Entry, [[maybe_unused]] FEXCore::IR::IR
 
     {
       const auto Node = IR->GetID(BlockNode);
-      auto IsTarget = JumpTargets.find(Node);
-      if (IsTarget == JumpTargets.end()) {
-        IsTarget = JumpTargets.try_emplace(Node).first;
-      }
+      const auto IsTarget = JumpTargets.try_emplace(Node).first;
 
       // if there's a pending branch, and it is not fall-through
       if (PendingTargetLabel && PendingTargetLabel != &IsTarget->second)

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -690,14 +690,10 @@ void *X86JITCore::CompileCode(uint64_t Entry, [[maybe_unused]] FEXCore::IR::IRLi
 #endif
 
       const auto Node = IR->GetID(BlockNode);
-      auto IsTarget = JumpTargets.find(Node);
-      if (IsTarget == JumpTargets.end()) {
-        IsTarget = JumpTargets.try_emplace(Node).first;
-      }
+      const auto IsTarget = JumpTargets.try_emplace(Node).first;
 
       // if there is a pending branch, and it is not fall-through
-      if (PendingTargetLabel && PendingTargetLabel != &IsTarget->second)
-      {
+      if (PendingTargetLabel && PendingTargetLabel != &IsTarget->second) {
         jmp(*PendingTargetLabel, T_NEAR);
       }
       PendingTargetLabel = nullptr;


### PR DESCRIPTION
`try_emplace()` will return the existing entry in the map if it exists already, so we don't need to perform a `find()` and then `try_emplace()`. We can just use `try_emplace()` by itself and use the resulting inserted value (or existing one).