### PR TITLE
IR: Make some interface functions accept pointers to const 

### DIFF
--- a/External/FEXCore/include/FEXCore/IR/IR.h
+++ b/External/FEXCore/include/FEXCore/IR/IR.h
@@ -287,14 +287,14 @@ class OrderedNode final {
     void AddUse() { ++NumUses; }
     void RemoveUse() { --NumUses; }
 
-    value_type Wrapped(uintptr_t Base) {
+    value_type Wrapped(uintptr_t Base) const {
       value_type Tmp;
       Tmp.SetOffset(Base, reinterpret_cast<uintptr_t>(this));
       return Tmp;
     }
 
   private:
-    value_type WrappedOffset(uint32_t Offset) {
+    value_type WrappedOffset(uint32_t Offset) const {
       value_type Tmp;
       Tmp.NodeOffset = Offset;
       return Tmp;

--- a/External/FEXCore/include/FEXCore/IR/IR.h
+++ b/External/FEXCore/include/FEXCore/IR/IR.h
@@ -106,33 +106,38 @@ struct NodeWrapperBase final {
   using NodeOffsetType = uint32_t;
   NodeOffsetType NodeOffset;
 
-  static NodeWrapperBase WrapOffset(NodeOffsetType Offset) {
+  explicit NodeWrapperBase() = default;
+
+  [[nodiscard]] static NodeWrapperBase WrapOffset(NodeOffsetType Offset) {
     NodeWrapperBase Wrapped;
     Wrapped.NodeOffset = Offset;
     return Wrapped;
   }
 
-  static NodeWrapperBase WrapPtr(uintptr_t Base, uintptr_t Value) {
+  [[nodiscard]] static NodeWrapperBase WrapPtr(uintptr_t Base, uintptr_t Value) {
     NodeWrapperBase Wrapped;
     Wrapped.SetOffset(Base, Value);
     return Wrapped;
   }
 
-  static void *UnwrapNode(uintptr_t Base, NodeWrapperBase Node) {
+  [[nodiscard]] static void *UnwrapNode(uintptr_t Base, NodeWrapperBase Node) {
     return Node.GetNode(Base);
   }
 
-  NodeID ID() const;
+  [[nodiscard]] NodeID ID() const;
 
-  bool IsInvalid() const { return NodeOffset == 0; }
+  [[nodiscard]] bool IsInvalid() const { return NodeOffset == 0; }
 
-  explicit NodeWrapperBase() = default;
-
-  Type *GetNode(uintptr_t Base) { return reinterpret_cast<Type*>(Base + NodeOffset); }
-  const Type *GetNode(uintptr_t Base) const { return reinterpret_cast<const Type*>(Base + NodeOffset); }
+  [[nodiscard]] Type *GetNode(uintptr_t Base) {
+    return reinterpret_cast<Type*>(Base + NodeOffset);
+  }
+  [[nodiscard]] const Type *GetNode(uintptr_t Base) const {
+    return reinterpret_cast<const Type*>(Base + NodeOffset);
+  }
 
   void SetOffset(uintptr_t Base, uintptr_t Value) { NodeOffset = Value - Base; }
-  friend constexpr bool operator==(const NodeWrapperBase<Type>&, const NodeWrapperBase<Type>&) = default;
+
+  [[nodiscard]] friend constexpr bool operator==(const NodeWrapperBase<Type>&, const NodeWrapperBase<Type>&) = default;
 };
 
 static_assert(std::is_trivial_v<NodeWrapperBase<OrderedNode>>);
@@ -259,9 +264,9 @@ class OrderedNode final {
      * Doesn't find the head of the list
      *
      */
-    size_t size(uintptr_t Base) const {
+    [[nodiscard]] size_t size(uintptr_t Base) const {
       size_t Size = 1;
-      // Walk the list forward until we hit a sentinal
+      // Walk the list forward until we hit a sentinel
       value_type Current = Header.Next;
       while (Current.NodeOffset != 0) {
         ++Size;
@@ -279,22 +284,26 @@ class OrderedNode final {
       SetPrevious(Base, Header.Next, Header.Previous);
     }
 
-    IROp_Header const* Op(uintptr_t Base) const { return Header.Value.GetNode(Base); }
-    IROp_Header *Op(uintptr_t Base) { return Header.Value.GetNode(Base); }
+    [[nodiscard]] IROp_Header const* Op(uintptr_t Base) const {
+      return Header.Value.GetNode(Base);
+    }
+    [[nodiscard]] IROp_Header *Op(uintptr_t Base) {
+      return Header.Value.GetNode(Base);
+    }
 
-    uint32_t GetUses() const { return NumUses; }
+    [[nodiscard]] uint32_t GetUses() const { return NumUses; }
 
     void AddUse() { ++NumUses; }
     void RemoveUse() { --NumUses; }
 
-    value_type Wrapped(uintptr_t Base) const {
+    [[nodiscard]] value_type Wrapped(uintptr_t Base) const {
       value_type Tmp;
       Tmp.SetOffset(Base, reinterpret_cast<uintptr_t>(this));
       return Tmp;
     }
 
   private:
-    value_type WrappedOffset(uint32_t Offset) const {
+    [[nodiscard]] value_type WrappedOffset(uint32_t Offset) const {
       value_type Tmp;
       Tmp.NodeOffset = Offset;
       return Tmp;
@@ -320,87 +329,89 @@ static_assert(sizeof(OrderedNode) == (sizeof(OrderedNodeHeader) + sizeof(uint32_
 
 struct RegisterClassType final {
   uint32_t Val;
-  constexpr operator uint32_t() const {
+  [[nodiscard]] constexpr operator uint32_t() const {
     return Val;
   }
-  friend constexpr bool operator==(const RegisterClassType&, const RegisterClassType&) = default;
+  [[nodiscard]] friend constexpr bool operator==(const RegisterClassType&, const RegisterClassType&) = default;
 };
 
 struct CondClassType final {
   uint8_t Val;
-  constexpr operator uint8_t() const {
+  [[nodiscard]] constexpr operator uint8_t() const {
     return Val;
   }
-  friend constexpr bool operator==(const CondClassType&, const CondClassType&) = default;
+  [[nodiscard]] friend constexpr bool operator==(const CondClassType&, const CondClassType&) = default;
 };
 
 struct MemOffsetType final {
   uint8_t Val;
-  constexpr operator uint8_t() const {
+  [[nodiscard]] constexpr operator uint8_t() const {
     return Val;
   }
-  friend constexpr bool operator==(const MemOffsetType&, const MemOffsetType&) = default;
+  [[nodiscard]] friend constexpr bool operator==(const MemOffsetType&, const MemOffsetType&) = default;
 };
 
 struct TypeDefinition final {
   uint16_t Val;
 
-  constexpr operator uint16_t() const {
+  [[nodiscard]] constexpr operator uint16_t() const {
     return Val;
   }
 
-  static constexpr TypeDefinition Create(uint8_t Bytes) {
+  [[nodiscard]] static constexpr TypeDefinition Create(uint8_t Bytes) {
     TypeDefinition Type{};
     Type.Val = Bytes << 8;
     return Type;
   }
 
-  static constexpr TypeDefinition Create(uint8_t Bytes, uint8_t Elements) {
+  [[nodiscard]] static constexpr TypeDefinition Create(uint8_t Bytes, uint8_t Elements) {
     TypeDefinition Type{};
     Type.Val = (Bytes << 8) | (Elements & 255);
     return Type;
   }
 
-  constexpr uint8_t Bytes() const {
+  [[nodiscard]] constexpr uint8_t Bytes() const {
     return Val >> 8;
   }
 
-  constexpr uint8_t Elements() const {
+  [[nodiscard]] constexpr uint8_t Elements() const {
     return Val & 255;
   }
 
-  friend constexpr bool operator==(const TypeDefinition&, const TypeDefinition&) = default;
+  [[nodiscard]] friend constexpr bool operator==(const TypeDefinition&, const TypeDefinition&) = default;
 };
 
 static_assert(std::is_trivial_v<TypeDefinition>);
 
 struct FenceType final {
   uint8_t Val;
-  constexpr operator uint8_t() const {
+  [[nodiscard]] constexpr operator uint8_t() const {
     return Val;
   }
-  friend constexpr bool operator==(const FenceType&, const FenceType&) = default;
+  [[nodiscard]] friend constexpr bool operator==(const FenceType&, const FenceType&) = default;
 };
 
 struct RoundType final {
   uint8_t Val;
-  constexpr operator uint8_t() const {
+  [[nodiscard]] constexpr operator uint8_t() const {
     return Val;
   }
-  friend constexpr bool operator==(const RoundType&, const RoundType&) = default;
+  [[nodiscard]] friend constexpr bool operator==(const RoundType&, const RoundType&) = default;
 };
 
 struct BreakReason final {
   uint8_t Val;
-  constexpr operator uint8_t() const {
+  [[nodiscard]] constexpr operator uint8_t() const {
     return Val;
   }
-  friend constexpr bool operator==(const BreakReason&, const BreakReason&) = default;
+  [[nodiscard]] friend constexpr bool operator==(const BreakReason&, const BreakReason&) = default;
 };
 
 struct SHA256Sum final {
   uint8_t data[32];
-  bool operator<(SHA256Sum const &rhs) const { return memcmp(data, rhs.data, sizeof(data)) < 0; }
+  [[nodiscard]] bool operator<(SHA256Sum const &rhs) const {
+    return memcmp(data, rhs.data, sizeof(data)) < 0;
+  }
 };
 
 class NodeIterator;
@@ -411,32 +422,32 @@ class NodeIterator;
  */
 class NodeIterator {
 public:
-	using value_type              = std::tuple<OrderedNode*, IROp_Header*>;
-	using size_type               = std::size_t;
-	using difference_type         = std::ptrdiff_t;
-	using reference               = value_type&;
-	using const_reference         = const value_type&;
-	using pointer                 = value_type*;
-	using const_pointer           = const value_type*;
-	using iterator                = NodeIterator;
-	using const_iterator          = const NodeIterator;
-	using reverse_iterator        = iterator;
-	using const_reverse_iterator  = const_iterator;
-	using iterator_category       = std::bidirectional_iterator_tag;
+  using value_type              = std::tuple<OrderedNode*, IROp_Header*>;
+  using size_type               = std::size_t;
+  using difference_type         = std::ptrdiff_t;
+  using reference               = value_type&;
+  using const_reference         = const value_type&;
+  using pointer                 = value_type*;
+  using const_pointer           = const value_type*;
+  using iterator                = NodeIterator;
+  using const_iterator          = const NodeIterator;
+  using reverse_iterator        = iterator;
+  using const_reverse_iterator  = const_iterator;
+  using iterator_category       = std::bidirectional_iterator_tag;
 
-	NodeIterator(uintptr_t Base, uintptr_t IRBase) : BaseList {Base}, IRList{ IRBase } {}
-	explicit NodeIterator(uintptr_t Base, uintptr_t IRBase, OrderedNodeWrapper Ptr) : BaseList {Base},  IRList{ IRBase }, Node {Ptr} {}
+  NodeIterator(uintptr_t Base, uintptr_t IRBase) : BaseList {Base}, IRList{ IRBase } {}
+  explicit NodeIterator(uintptr_t Base, uintptr_t IRBase, OrderedNodeWrapper Ptr) : BaseList {Base},  IRList{ IRBase }, Node {Ptr} {}
 
-	bool operator==(const NodeIterator &rhs) const {
-		return Node.NodeOffset == rhs.Node.NodeOffset;
-	}
+  [[nodiscard]] bool operator==(const NodeIterator &rhs) const {
+    return Node.NodeOffset == rhs.Node.NodeOffset;
+  }
 
-	bool operator!=(const NodeIterator &rhs) const {
-		return !operator==(rhs);
-	}
+  [[nodiscard]] bool operator!=(const NodeIterator &rhs) const {
+    return !operator==(rhs);
+  }
 
   NodeIterator operator++() {
-		OrderedNodeHeader *RealNode = reinterpret_cast<OrderedNodeHeader*>(Node.GetNode(BaseList));
+    OrderedNodeHeader *RealNode = reinterpret_cast<OrderedNodeHeader*>(Node.GetNode(BaseList));
     Node = RealNode->Next;
     return *this;
   }
@@ -447,26 +458,26 @@ public:
     return *this;
   }
 
-	value_type operator*() {
-		OrderedNode *RealNode = Node.GetNode(BaseList);
-		return { RealNode, RealNode->Op(IRList) };
-	}
-
-	value_type operator()() {
+  [[nodiscard]] value_type operator*() {
     OrderedNode *RealNode = Node.GetNode(BaseList);
-		return { RealNode, RealNode->Op(IRList) };
-	}
+    return { RealNode, RealNode->Op(IRList) };
+  }
 
-  NodeID ID() const {
+  [[nodiscard]] value_type operator()() {
+    OrderedNode *RealNode = Node.GetNode(BaseList);
+    return { RealNode, RealNode->Op(IRList) };
+  }
+
+  [[nodiscard]] NodeID ID() const {
     return Node.ID();
   }
 
-  static NodeIterator Invalid() {
+  [[nodiscard]] static NodeIterator Invalid() {
     return NodeIterator(0, 0);
   }
 
 protected:
-	uintptr_t BaseList{};
+  uintptr_t BaseList{};
   uintptr_t IRList{};
   OrderedNodeWrapper Node{};
 };
@@ -486,11 +497,11 @@ protected:
 class AllNodesIterator : public NodeIterator {
 public:
   AllNodesIterator(uintptr_t Base, uintptr_t IRBase) : NodeIterator(Base, IRBase) {}
-	explicit AllNodesIterator(uintptr_t Base, uintptr_t IRBase, OrderedNodeWrapper Ptr) : NodeIterator(Base, IRBase, Ptr) {}
+  explicit AllNodesIterator(uintptr_t Base, uintptr_t IRBase, OrderedNodeWrapper Ptr) : NodeIterator(Base, IRBase, Ptr) {}
   AllNodesIterator(NodeIterator other) : NodeIterator(other) {} // Allow NodeIterator to be upgraded
 
   AllNodesIterator operator++() {
-		OrderedNodeHeader *RealNode = reinterpret_cast<OrderedNodeHeader*>(Node.GetNode(BaseList));
+    OrderedNodeHeader *RealNode = reinterpret_cast<OrderedNodeHeader*>(Node.GetNode(BaseList));
     auto IROp = Node.GetNode(BaseList)->Op(IRList);
 
     // If this is the last node of a codeblock, we need to continue to the next block
@@ -507,8 +518,8 @@ public:
       Node = RealNode->Next;
     }
 
-		return *this;
-	}
+    return *this;
+  }
 
   AllNodesIterator operator--() {
     auto IROp = Node.GetNode(BaseList)->Op(IRList);
@@ -529,7 +540,7 @@ public:
     return *this;
   }
 
-  static AllNodesIterator Invalid() {
+  [[nodiscard]] static AllNodesIterator Invalid() {
     return AllNodesIterator(0, 0);
   }
 };

--- a/External/FEXCore/include/FEXCore/IR/IntrusiveIRList.h
+++ b/External/FEXCore/include/FEXCore/IR/IntrusiveIRList.h
@@ -176,7 +176,7 @@ public:
   bool IsShared() const { return Flags & FLAG_Shared; }
   void SetShared(bool Set) { if (Set) Flags |= FLAG_Shared; else Flags &= ~FLAG_Shared; }
 
-  NodeID GetID(OrderedNode *Node) const {
+  NodeID GetID(const OrderedNode *Node) const {
     return Node->Wrapped(GetListData()).ID();
   }
 
@@ -269,7 +269,7 @@ public:
     return BlockRange(this);
   }
 
-  CodeRange GetCode(OrderedNode *block) const {
+  CodeRange GetCode(const OrderedNode *block) const {
     return CodeRange(this, block->Wrapped(GetListData()));
   }
 
@@ -312,7 +312,7 @@ public:
     return iterator(reinterpret_cast<uintptr_t>(GetListData()), reinterpret_cast<uintptr_t>(GetData()), Wrapped);
   }
 
-  iterator at(OrderedNode *Node) const noexcept {
+  iterator at(const OrderedNode *Node) const noexcept {
     auto Wrapped = Node->Wrapped(reinterpret_cast<uintptr_t>(GetListData()));
     return iterator(reinterpret_cast<uintptr_t>(GetListData()), reinterpret_cast<uintptr_t>(GetData()), Wrapped);
   }

--- a/External/FEXCore/include/FEXCore/IR/IntrusiveIRList.h
+++ b/External/FEXCore/include/FEXCore/IR/IntrusiveIRList.h
@@ -283,19 +283,19 @@ public:
   {
     OrderedNodeWrapper Wrapped;
     Wrapped.NodeOffset = sizeof(OrderedNode);
-    return iterator(reinterpret_cast<uintptr_t>(GetListData()), reinterpret_cast<uintptr_t>(GetData()), Wrapped);
+    return iterator(GetListData(), GetData(), Wrapped);
   }
 
   /**
    * @brief This is not an iterator that you can reverse iterator through!
    *
-   * @return Our iterator sentinal to ensure ending correctly
+   * @return Our iterator sentinel to ensure ending correctly
    */
   iterator end() const noexcept
   {
     OrderedNodeWrapper Wrapped;
     Wrapped.NodeOffset = 0;
-    return iterator(reinterpret_cast<uintptr_t>(GetListData()), reinterpret_cast<uintptr_t>(GetData()), Wrapped);
+    return iterator(GetListData(), GetData(), Wrapped);
   }
 
   /**
@@ -303,18 +303,19 @@ public:
    * @return Iterator for this op
    */
   iterator at(OrderedNodeWrapper Wrapped) const noexcept {
-    return iterator(reinterpret_cast<uintptr_t>(GetListData()), reinterpret_cast<uintptr_t>(GetData()), Wrapped);
+    return iterator(GetListData(), GetData(), Wrapped);
   }
 
   iterator at(NodeID ID) const noexcept {
     OrderedNodeWrapper Wrapped;
     Wrapped.NodeOffset = ID.Value * sizeof(OrderedNode);
-    return iterator(reinterpret_cast<uintptr_t>(GetListData()), reinterpret_cast<uintptr_t>(GetData()), Wrapped);
+    return iterator(GetListData(), GetData(), Wrapped);
   }
 
   iterator at(const OrderedNode *Node) const noexcept {
-    auto Wrapped = Node->Wrapped(reinterpret_cast<uintptr_t>(GetListData()));
-    return iterator(reinterpret_cast<uintptr_t>(GetListData()), reinterpret_cast<uintptr_t>(GetData()), Wrapped);
+    const auto ListData = GetListData();
+    auto Wrapped = Node->Wrapped(ListData);
+    return iterator(ListData, GetData(), Wrapped);
   }
 
   uintptr_t GetData() const {


### PR DESCRIPTION
Some interface functions are just querying state, so we can allow them being used with const qualified data.

Also includes some other minor API-related changes