### PR TITLE
JitSymbols: Make use of fmt

### DIFF
--- a/External/FEXCore/Source/Common/JitSymbols.cpp
+++ b/External/FEXCore/Source/Common/JitSymbols.cpp
@@ -18,7 +18,7 @@ namespace FEXCore {
 
   JITSymbols::~JITSymbols() = default;
 
-  void JITSymbols::Register(void *HostAddr, uint64_t GuestAddr, uint32_t CodeSize) {
+  void JITSymbols::Register(const void *HostAddr, uint64_t GuestAddr, uint32_t CodeSize) {
     if (!fp) return;
 
     // Linux perf format is very straightforward
@@ -26,7 +26,7 @@ namespace FEXCore {
     fmt::print(fp.get(), "{:x} {:x} JIT_0x{:x}_{:x}\n", HostAddr, CodeSize, GuestAddr, HostAddr);
   }
 
-  void JITSymbols::Register(void *HostAddr, uint32_t CodeSize, std::string const &Name) {
+  void JITSymbols::Register(const void *HostAddr, uint32_t CodeSize, std::string const &Name) {
     if (!fp) return;
 
     // Linux perf format is very straightforward
@@ -34,7 +34,7 @@ namespace FEXCore {
     fmt::print(fp.get(), "{:x} {:x} {}_{:x}\n", HostAddr, CodeSize, Name, HostAddr);
   }
 
-  void JITSymbols::RegisterNamedRegion(void *HostAddr, uint32_t CodeSize, std::string const &Name) {
+  void JITSymbols::RegisterNamedRegion(const void *HostAddr, uint32_t CodeSize, std::string const &Name) {
     if (!fp) return;
 
     // Linux perf format is very straightforward
@@ -42,7 +42,7 @@ namespace FEXCore {
     fmt::print(fp.get(), "{:x} {:x} {}\n", HostAddr, CodeSize, Name);
   }
 
-  void JITSymbols::RegisterJITSpace(void *HostAddr, uint32_t CodeSize) {
+  void JITSymbols::RegisterJITSpace(const void *HostAddr, uint32_t CodeSize) {
     if (!fp) return;
 
     // Linux perf format is very straightforward

--- a/External/FEXCore/Source/Common/JitSymbols.cpp
+++ b/External/FEXCore/Source/Common/JitSymbols.cpp
@@ -26,7 +26,7 @@ namespace FEXCore {
     fmt::print(fp.get(), "{:x} {:x} JIT_0x{:x}_{:x}\n", HostAddr, CodeSize, GuestAddr, HostAddr);
   }
 
-  void JITSymbols::Register(const void *HostAddr, uint32_t CodeSize, std::string const &Name) {
+  void JITSymbols::Register(const void *HostAddr, uint32_t CodeSize, std::string_view Name) {
     if (!fp) return;
 
     // Linux perf format is very straightforward
@@ -34,7 +34,7 @@ namespace FEXCore {
     fmt::print(fp.get(), "{:x} {:x} {}_{:x}\n", HostAddr, CodeSize, Name, HostAddr);
   }
 
-  void JITSymbols::RegisterNamedRegion(const void *HostAddr, uint32_t CodeSize, std::string const &Name) {
+  void JITSymbols::RegisterNamedRegion(const void *HostAddr, uint32_t CodeSize, std::string_view Name) {
     if (!fp) return;
 
     // Linux perf format is very straightforward

--- a/External/FEXCore/Source/Common/JitSymbols.h
+++ b/External/FEXCore/Source/Common/JitSymbols.h
@@ -11,10 +11,10 @@ public:
   JITSymbols();
   ~JITSymbols();
 
-  void Register(void *HostAddr, uint64_t GuestAddr, uint32_t CodeSize);
-  void Register(void *HostAddr, uint32_t CodeSize, std::string const &Name);
-  void RegisterNamedRegion(void *HostAddr, uint32_t CodeSize, std::string const &Name);
-  void RegisterJITSpace(void *HostAddr, uint32_t CodeSize);
+  void Register(const void *HostAddr, uint64_t GuestAddr, uint32_t CodeSize);
+  void Register(const void *HostAddr, uint32_t CodeSize, std::string const &Name);
+  void RegisterNamedRegion(const void *HostAddr, uint32_t CodeSize, std::string const &Name);
+  void RegisterJITSpace(const void *HostAddr, uint32_t CodeSize);
 
 private:
   using FILEPtr = std::unique_ptr<FILE, decltype(&std::fclose)>;

--- a/External/FEXCore/Source/Common/JitSymbols.h
+++ b/External/FEXCore/Source/Common/JitSymbols.h
@@ -1,6 +1,8 @@
 #pragma once
+
 #include <cstdint>
 #include <cstdio>
+#include <memory>
 #include <string>
 
 namespace FEXCore {
@@ -8,12 +10,15 @@ class JITSymbols final {
 public:
   JITSymbols();
   ~JITSymbols();
+
   void Register(void *HostAddr, uint64_t GuestAddr, uint32_t CodeSize);
   void Register(void *HostAddr, uint32_t CodeSize, std::string const &Name);
   void RegisterNamedRegion(void *HostAddr, uint32_t CodeSize, std::string const &Name);
   void RegisterJITSpace(void *HostAddr, uint32_t CodeSize);
 
 private:
-  FILE* fp{};
+  using FILEPtr = std::unique_ptr<FILE, decltype(&std::fclose)>;
+
+  FILEPtr fp;
 };
 }

--- a/External/FEXCore/Source/Common/JitSymbols.h
+++ b/External/FEXCore/Source/Common/JitSymbols.h
@@ -3,7 +3,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <memory>
-#include <string>
+#include <string_view>
 
 namespace FEXCore {
 class JITSymbols final {
@@ -12,8 +12,8 @@ public:
   ~JITSymbols();
 
   void Register(const void *HostAddr, uint64_t GuestAddr, uint32_t CodeSize);
-  void Register(const void *HostAddr, uint32_t CodeSize, std::string const &Name);
-  void RegisterNamedRegion(const void *HostAddr, uint32_t CodeSize, std::string const &Name);
+  void Register(const void *HostAddr, uint32_t CodeSize, std::string_view Name);
+  void RegisterNamedRegion(const void *HostAddr, uint32_t CodeSize, std::string_view Name);
   void RegisterJITSpace(const void *HostAddr, uint32_t CodeSize);
 
 private:


### PR DESCRIPTION
Simplifies the format strings that get written out, making them a little nicer to visually parse