### PR TITLE
Arm64: Fixes MapSelectCC FGT flag

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -916,7 +916,7 @@ Condition MapSelectCC(IR::CondClassType Cond) {
   case FEXCore::IR::COND_FLU: return Condition::lt;
   case FEXCore::IR::COND_FGE: return Condition::ge;
   case FEXCore::IR::COND_FLEU:return Condition::le;
-  case FEXCore::IR::COND_FGT: return Condition::hi;
+  case FEXCore::IR::COND_FGT: return Condition::gt;
   case FEXCore::IR::COND_FU:  return Condition::vs;
   case FEXCore::IR::COND_FNU: return Condition::vc;
   case FEXCore::IR::COND_VS:

--- a/unittests/ASM/FEX_bugs/Test_CmpSelect_Merge.asm
+++ b/unittests/ASM/FEX_bugs/Test_CmpSelect_Merge.asm
@@ -1,0 +1,140 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x0000000aaaaafaaa"
+  }
+}
+%endif
+
+%macro intcompare 3
+  ; instruction, value1, value2
+  mov rcx, %2
+  mov rdx, %3
+  cmp rcx, rdx
+  %1 bl
+  shl rax, 1
+  or rax, rbx
+%endmacro
+
+; This test specifically tests the Select and compare merging that occurs in OpcodeDispatcher
+; The easiest way to test this is to do the comparison op and then SETcc with the flags that we want to ensure is working
+
+; RAX will be our result
+mov rax, 0
+; RBX will be our temp for setcc
+mov rbx, 0
+
+; Test integer ops
+; RCX and RDX for comparison values
+mov rcx, 0
+mov rdx, 0
+
+; Test EQ - true
+intcompare sete, 0, 0
+
+; Test EQ - false
+intcompare sete, 0, 1
+
+; Test NEQ - true
+intcompare setne, 0, 1
+
+; Test NEQ - false
+intcompare setne, 0, 0
+
+; Test SGE - true
+intcompare setge, 0, 0
+
+; Test SGE - false
+intcompare setge, 0, 1
+
+; Test SGE with sign difference - true
+intcompare setge, 1, -1
+
+; Test SGE with sign difference - false
+intcompare setge, -1, 1
+
+; Test SLT - true
+intcompare setl, 0, 1
+
+; Test SLT - false
+intcompare setl, 0, 0
+
+; Test SLT with sign difference - true
+intcompare setl, -1, 1
+
+; Test SLT with sign difference - false
+intcompare setl, 1, -1
+
+; Test SGT - true
+intcompare setg, 1, 0
+
+; Test SGT - false
+intcompare setg, 0, 0
+
+; Test SGT with sign difference - true
+intcompare setg, 1, -1
+
+; Test SGT with sign difference - false
+intcompare setg, -1, 1
+
+; Test SLE - true
+intcompare setle, 0, 0
+
+; Test SLE - false
+intcompare setle, 1, 0
+
+; Test SLE with sign difference - true
+intcompare setle, -1, 1
+
+; Test SLE with sign difference - false
+intcompare setle, 1, -1
+
+; Test UGE - true
+intcompare setae, 0, 0
+
+; Test UGE - false
+intcompare setae, 1, 0
+
+; Test UGE with *sign* difference - true
+intcompare setae, -1, 1
+
+; Test UGE with *sign* difference - false
+intcompare setb, 1, -1
+
+; Test ULT - true
+intcompare setb, 0, 1
+
+; Test ULT - false
+intcompare setb, 1, 0
+
+; Test ULT with *sign* difference - true
+intcompare setb, 1, -1
+
+; Test ULT with *sign* difference - false
+intcompare setb, -1, 1
+
+; Test UGT - true
+intcompare seta, 1, 0
+
+; Test UGT - false
+intcompare seta, 0, 1
+
+; Test UGT with *sign* difference - true
+intcompare seta, -1, 1
+
+; Test UGT with *sign* difference - false
+intcompare seta, 1, -1
+
+; Test ULE - true
+intcompare setbe, 0, 0
+
+; Test ULE - false
+intcompare setbe, 1, 0
+
+; Test ULE with *sign* difference - true
+intcompare setbe, 1, -1
+
+; Test ULE with *sign* difference - false
+intcompare setbe, -1, 1
+
+hlt

--- a/unittests/ASM/FEX_bugs/Test_CmpSelect_Merge_Float.asm
+++ b/unittests/ASM/FEX_bugs/Test_CmpSelect_Merge_Float.asm
@@ -1,0 +1,130 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x000000000cbe0708"
+  }
+}
+%endif
+
+%macro floatcompare 3
+  ; instruction, value1, value2
+  movsd xmm0, %2
+  movsd xmm1, %3
+  ucomisd xmm0, xmm1
+
+  %1 bl
+  shl rax, 1
+  or rax, rbx
+%endmacro
+
+; This test specifically tests the Select and compare merging that occurs in OpcodeDispatcher
+; The easiest way to test this is to do the comparison op and then SETcc with the flags that we want to ensure is working
+
+; RAX will be our result
+mov rax, 0
+; RBX will be our temp for setcc
+mov rbx, 0
+
+; Float comparisons
+; xmm0 and xmm1 will be our comparison values
+
+; FLU (CF == 1), SETNE
+; FLEU (CF == 1 || ZF == 1), SETBE
+; FU (PF == 1), SETP
+; FNU (PF == 0), SETNP
+; FGE (CF == 0), SETAE
+; FGT (CF == 0 && ZF == 0), SETA
+
+; Test FLU - true
+floatcompare setne, [rel .float_0], [rel .float_1]
+
+; Test FLU - false
+floatcompare setne, [rel .float_0], [rel .float_1]
+
+; Test FLU (unordered) - true
+floatcompare setne, [rel .float_0], [rel .float_qnan]
+
+; Test FLU (unordered) - true
+floatcompare setne, [rel .float_qnan], [rel .float_1]
+
+; Test FLEU - true
+floatcompare setbe, [rel .float_0], [rel .float_0]
+
+; Test FLEU - false
+floatcompare setbe, [rel .float_1], [rel .float_0]
+
+; Test FLEU (unordered) - true
+floatcompare setbe, [rel .float_0], [rel .float_qnan]
+
+; Test FLEU (unordered) - true
+floatcompare setbe, [rel .float_qnan], [rel .float_1]
+
+; Test FU - true
+floatcompare setp, [rel .float_0], [rel .float_qnan]
+
+; Test FU - true
+floatcompare setp, [rel .float_qnan], [rel .float_0]
+
+; Test FU - true
+floatcompare setp, [rel .float_qnan], [rel .float_qnan]
+
+; Test FU - false
+floatcompare setp, [rel .float_1], [rel .float_0]
+
+; Test FU - false
+floatcompare setp, [rel .float_0], [rel .float_1]
+
+; Test FU - false
+floatcompare setp, [rel .float_0], [rel .float_0]
+
+; Test FNU - false
+floatcompare setnp, [rel .float_0], [rel .float_qnan]
+
+; Test FNU - false
+floatcompare setnp, [rel .float_qnan], [rel .float_0]
+
+; Test FNU - false
+floatcompare setnp, [rel .float_qnan], [rel .float_qnan]
+
+; Test FNU - true
+floatcompare setnp, [rel .float_1], [rel .float_0]
+
+; Test FNU - true
+floatcompare setnp, [rel .float_0], [rel .float_1]
+
+; Test FNU - true
+floatcompare setnp, [rel .float_0], [rel .float_0]
+
+; Test FGE - true
+floatcompare seta, [rel .float_0], [rel .float_0]
+
+; Test FGE - false
+floatcompare seta, [rel .float_0], [rel .float_1]
+
+; Test FGE (unordered) - false
+floatcompare seta, [rel .float_0], [rel .float_qnan]
+
+; Test FGE (unordered) - false
+floatcompare seta, [rel .float_qnan], [rel .float_1]
+
+; Test FGT - true
+floatcompare seta, [rel .float_1], [rel .float_0]
+
+; Test FGT - false
+floatcompare seta, [rel .float_0], [rel .float_1]
+
+; Test FGT (unordered) - false
+floatcompare seta, [rel .float_0], [rel .float_qnan]
+
+; Test FGT (unordered) - false
+floatcompare seta, [rel .float_qnan], [rel .float_1]
+
+hlt
+
+align 8
+.float_1:
+dq 1.0
+.float_0:
+dq 0.0
+.float_qnan:
+dq 0x7ff8000000000000

--- a/unittests/ASM/FEX_bugs/Test_CmpSelect_Merge_Float_branch.asm
+++ b/unittests/ASM/FEX_bugs/Test_CmpSelect_Merge_Float_branch.asm
@@ -1,0 +1,144 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x000000000cbe0708"
+  }
+}
+%endif
+
+%macro floatcompare 3
+  ; instruction, value1, value2
+  movsd xmm0, %2
+  movsd xmm1, %3
+
+  shl rax, 1
+  ucomisd xmm0, xmm1
+
+  ; Conditional branch
+  %1 %%true
+
+  %%fallthrough:
+    ; False fallthrough path
+    mov rbx, 0
+    jmp %%combine
+
+  %%true:
+    ; True path
+    mov rbx, 1
+
+  %%combine:
+    ; Combine
+    or rax, rbx
+%endmacro
+
+; This test specifically tests the Select and compare merging that occurs in OpcodeDispatcher
+; The easiest way to test this is to do the comparison op and then SETcc with the flags that we want to ensure is working
+
+; RAX will be our result
+mov rax, 0
+; RBX will be our temp for setcc
+mov rbx, 0
+
+; Float comparisons
+; xmm0 and xmm1 will be our comparison values
+
+; FLU (CF == 1), SETNE
+; FLEU (CF == 1 || ZF == 1), SETBE
+; FU (PF == 1), SETP
+; FNU (PF == 0), SETNP
+; FGE (CF == 0), SETAE
+; FGT (CF == 0 && ZF == 0), SETA
+
+; Test FLU - true
+floatcompare jne, [rel .float_0], [rel .float_1]
+
+; Test FLU - false
+floatcompare jne, [rel .float_0], [rel .float_1]
+
+; Test FLU (unordered) - true
+floatcompare jne, [rel .float_0], [rel .float_qnan]
+
+; Test FLU (unordered) - true
+floatcompare jne, [rel .float_qnan], [rel .float_1]
+
+; Test FLEU - true
+floatcompare jbe, [rel .float_0], [rel .float_0]
+
+; Test FLEU - false
+floatcompare jbe, [rel .float_1], [rel .float_0]
+
+; Test FLEU (unordered) - true
+floatcompare jbe, [rel .float_0], [rel .float_qnan]
+
+; Test FLEU (unordered) - true
+floatcompare jbe, [rel .float_qnan], [rel .float_1]
+
+; Test FU - true
+floatcompare jp, [rel .float_0], [rel .float_qnan]
+
+; Test FU - true
+floatcompare jp, [rel .float_qnan], [rel .float_0]
+
+; Test FU - true
+floatcompare jp, [rel .float_qnan], [rel .float_qnan]
+
+; Test FU - false
+floatcompare jp, [rel .float_1], [rel .float_0]
+
+; Test FU - false
+floatcompare jp, [rel .float_0], [rel .float_1]
+
+; Test FU - false
+floatcompare jp, [rel .float_0], [rel .float_0]
+
+; Test FNU - false
+floatcompare jnp, [rel .float_0], [rel .float_qnan]
+
+; Test FNU - false
+floatcompare jnp, [rel .float_qnan], [rel .float_0]
+
+; Test FNU - false
+floatcompare jnp, [rel .float_qnan], [rel .float_qnan]
+
+; Test FNU - true
+floatcompare jnp, [rel .float_1], [rel .float_0]
+
+; Test FNU - true
+floatcompare jnp, [rel .float_0], [rel .float_1]
+
+; Test FNU - true
+floatcompare jnp, [rel .float_0], [rel .float_0]
+
+; Test FGE - true
+floatcompare ja, [rel .float_0], [rel .float_0]
+
+; Test FGE - false
+floatcompare ja, [rel .float_0], [rel .float_1]
+
+; Test FGE (unordered) - false
+floatcompare ja, [rel .float_0], [rel .float_qnan]
+
+; Test FGE (unordered) - false
+floatcompare ja, [rel .float_qnan], [rel .float_1]
+
+; Test FGT - true
+floatcompare ja, [rel .float_1], [rel .float_0]
+
+; Test FGT - false
+floatcompare ja, [rel .float_0], [rel .float_1]
+
+; Test FGT (unordered) - false
+floatcompare ja, [rel .float_0], [rel .float_qnan]
+
+; Test FGT (unordered) - false
+floatcompare ja, [rel .float_qnan], [rel .float_1]
+
+hlt
+
+align 8
+.float_1:
+dq 1.0
+.float_0:
+dq 0.0
+.float_qnan:
+dq 0x7ff8000000000000

--- a/unittests/ASM/FEX_bugs/Test_CmpSelect_Merge_branch.asm
+++ b/unittests/ASM/FEX_bugs/Test_CmpSelect_Merge_branch.asm
@@ -1,0 +1,154 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x0000000aaaaafaaa"
+  }
+}
+%endif
+
+%macro intcompare 3
+  ; instruction, value1, value2
+  mov rcx, %2
+  mov rdx, %3
+  shl rax, 1
+  cmp rcx, rdx
+
+  ; Conditional branch
+  %1 %%true
+
+  %%fallthrough:
+    ; False fallthrough path
+    mov rbx, 0
+    jmp %%combine
+
+  %%true:
+    ; True path
+    mov rbx, 1
+
+  %%combine:
+    ; Combine
+    or rax, rbx
+%endmacro
+
+; This test specifically tests the Select and compare merging that occurs in OpcodeDispatcher
+; The easiest way to test this is to do the comparison op and then SETcc with the flags that we want to ensure is working
+
+; RAX will be our result
+mov rax, 0
+; RBX will be our temp for setcc
+mov rbx, 0
+
+; Test integer ops
+; RCX and RDX for comparison values
+mov rcx, 0
+mov rdx, 0
+
+; Test EQ - true
+intcompare je, 0, 0
+
+; Test EQ - false
+intcompare je, 0, 1
+
+; Test NEQ - true
+intcompare jne, 0, 1
+
+; Test NEQ - false
+intcompare jne, 0, 0
+
+; Test SGE - true
+intcompare jge, 0, 0
+
+; Test SGE - false
+intcompare jge, 0, 1
+
+; Test SGE with sign difference - true
+intcompare jge, 1, -1
+
+; Test SGE with sign difference - false
+intcompare jge, -1, 1
+
+; Test SLT - true
+intcompare jl, 0, 1
+
+; Test SLT - false
+intcompare jl, 0, 0
+
+; Test SLT with sign difference - true
+intcompare jl, -1, 1
+
+; Test SLT with sign difference - false
+intcompare jl, 1, -1
+
+; Test SGT - true
+intcompare jg, 1, 0
+
+; Test SGT - false
+intcompare jg, 0, 0
+
+; Test SGT with sign difference - true
+intcompare jg, 1, -1
+
+; Test SGT with sign difference - false
+intcompare jg, -1, 1
+
+; Test SLE - true
+intcompare jle, 0, 0
+
+; Test SLE - false
+intcompare jle, 1, 0
+
+; Test SLE with sign difference - true
+intcompare jle, -1, 1
+
+; Test SLE with sign difference - false
+intcompare jle, 1, -1
+
+; Test UGE - true
+intcompare jae, 0, 0
+
+; Test UGE - false
+intcompare jae, 1, 0
+
+; Test UGE with *sign* difference - true
+intcompare jae, -1, 1
+
+; Test UGE with *sign* difference - false
+intcompare jb, 1, -1
+
+; Test ULT - true
+intcompare jb, 0, 1
+
+; Test ULT - false
+intcompare jb, 1, 0
+
+; Test ULT with *sign* difference - true
+intcompare jb, 1, -1
+
+; Test ULT with *sign* difference - false
+intcompare jb, -1, 1
+
+; Test UGT - true
+intcompare ja, 1, 0
+
+; Test UGT - false
+intcompare ja, 0, 1
+
+; Test UGT with *sign* difference - true
+intcompare ja, -1, 1
+
+; Test UGT with *sign* difference - false
+intcompare ja, 1, -1
+
+; Test ULE - true
+intcompare jbe, 0, 0
+
+; Test ULE - false
+intcompare jbe, 1, 0
+
+; Test ULE with *sign* difference - true
+intcompare jbe, 1, -1
+
+; Test ULE with *sign* difference - false
+intcompare jbe, -1, 1
+
+hlt


### PR DESCRIPTION
As a continuation to #1404, this was mapped to the incorrect Arm64 flags

Also adds the unit tests that were missing from #1404