### PR TITLE
NetStream: Move NetBuf definition into cpp file 

### DIFF
--- a/External/FEXCore/include/FEXCore/Utils/NetStream.h
+++ b/External/FEXCore/include/FEXCore/Utils/NetStream.h
@@ -10,15 +10,14 @@
 namespace FEXCore::Utils {
 class FEX_DEFAULT_VISIBILITY NetStream : public std::iostream {
 public:
-    NetStream(int socketfd) : std::iostream(new NetBuf(socketfd)) {}
+    explicit NetStream(int socketfd) : std::iostream(new NetBuf(socketfd)) {}
     virtual ~NetStream();
 
 private:
     class NetBuf : public std::streambuf {
 
     public:
-        NetBuf(int socketfd) {
-            socket = socketfd;
+        explicit NetBuf(int socketfd) : socket{socketfd} {
             reset_output_buffer();
         }
         virtual ~NetBuf();

--- a/External/FEXCore/include/FEXCore/Utils/NetStream.h
+++ b/External/FEXCore/include/FEXCore/Utils/NetStream.h
@@ -2,43 +2,12 @@
 
 #include <FEXCore/Utils/CompilerDefs.h>
 
-#include <array>
 #include <iostream>
-#include <iterator>
-#include <string.h>
 
 namespace FEXCore::Utils {
 class FEX_DEFAULT_VISIBILITY NetStream : public std::iostream {
 public:
-    explicit NetStream(int socketfd) : std::iostream(new NetBuf(socketfd)) {}
+    explicit NetStream(int socketfd);
     ~NetStream() override;
-
-private:
-    class NetBuf : public std::streambuf {
-    public:
-        explicit NetBuf(int socketfd) : socket{socketfd} {
-            reset_output_buffer();
-        }
-        ~NetBuf() override;
-
-    protected:
-        std::streamsize xsputn(const char* buffer, std::streamsize size) override;
-
-        std::streambuf::int_type underflow() override;
-        std::streambuf::int_type overflow(std::streambuf::int_type ch) override;
-        int sync() override;
-
-    private:
-        void reset_output_buffer() {
-            // we always leave room for one extra char
-            setp(std::begin(output_buffer), std::end(output_buffer) -1);
-        }
-
-        int flushBuffer(const char *buffer, size_t size);
-
-        int socket;
-        std::array<char, 1400> output_buffer;
-        std::array<char, 1500> input_buffer; // enough for a typical packet
-    };
 };
-}
+} // namespace FEXCore::Utils

--- a/External/FEXCore/include/FEXCore/Utils/NetStream.h
+++ b/External/FEXCore/include/FEXCore/Utils/NetStream.h
@@ -11,23 +11,22 @@ namespace FEXCore::Utils {
 class FEX_DEFAULT_VISIBILITY NetStream : public std::iostream {
 public:
     explicit NetStream(int socketfd) : std::iostream(new NetBuf(socketfd)) {}
-    virtual ~NetStream();
+    ~NetStream() override;
 
 private:
     class NetBuf : public std::streambuf {
-
     public:
         explicit NetBuf(int socketfd) : socket{socketfd} {
             reset_output_buffer();
         }
-        virtual ~NetBuf();
+        ~NetBuf() override;
 
     protected:
-        virtual std::streamsize xsputn(const char* buffer, std::streamsize size);
+        std::streamsize xsputn(const char* buffer, std::streamsize size) override;
 
-        virtual std::streambuf::int_type underflow();
-        virtual std::streambuf::int_type overflow(std::streambuf::int_type ch);
-        virtual int sync();
+        std::streambuf::int_type underflow() override;
+        std::streambuf::int_type overflow(std::streambuf::int_type ch) override;
+        int sync() override;
 
     private:
         void reset_output_buffer() {


### PR DESCRIPTION
Given this is a private class, we can make it fully internal to reduce header dependencies on it in including code and also minimize files that need to be rebuilt if NetBuf changes.