### PR TITLE
x32/Socket: Resolve sign comparison mismatch cases

### DIFF
--- a/Source/Tests/LinuxSyscalls/x32/Socket.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Socket.cpp
@@ -52,7 +52,7 @@ namespace FEX::HLE::x32 {
   static uint64_t SendMsg(int sockfd, const struct msghdr32 *msg, int flags) {
     struct msghdr HostHeader{};
     std::vector<iovec> Host_iovec(msg->msg_iovlen);
-    for (int i = 0; i < msg->msg_iovlen; ++i) {
+    for (size_t i = 0; i < msg->msg_iovlen; ++i) {
       Host_iovec[i] = msg->msg_iov[i];
     }
 
@@ -108,7 +108,7 @@ namespace FEX::HLE::x32 {
   static uint64_t RecvMsg(int sockfd, struct msghdr32 *msg, int flags) {
     struct msghdr HostHeader{};
     std::vector<iovec> Host_iovec(msg->msg_iovlen);
-    for (int i = 0; i < msg->msg_iovlen; ++i) {
+    for (size_t i = 0; i < msg->msg_iovlen; ++i) {
       Host_iovec[i] = msg->msg_iov[i];
     }
 
@@ -125,7 +125,7 @@ namespace FEX::HLE::x32 {
 
     uint64_t Result = ::recvmsg(sockfd, &HostHeader, flags);
     if (Result != -1) {
-      for (int i = 0; i < msg->msg_iovlen; ++i) {
+      for (size_t i = 0; i < msg->msg_iovlen; ++i) {
         msg->msg_iov[i] = Host_iovec[i];
       }
 

--- a/Source/Tests/LinuxSyscalls/x32/Socket.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Socket.cpp
@@ -59,7 +59,7 @@ namespace FEX::HLE::x32 {
     HostHeader.msg_name = msg->msg_name;
     HostHeader.msg_namelen = msg->msg_namelen;
 
-    HostHeader.msg_iov = &Host_iovec.at(0);
+    HostHeader.msg_iov = Host_iovec.data();
     HostHeader.msg_iovlen = msg->msg_iovlen;
 
     HostHeader.msg_control = alloca(msg->msg_controllen * 2);
@@ -115,7 +115,7 @@ namespace FEX::HLE::x32 {
     HostHeader.msg_name = msg->msg_name;
     HostHeader.msg_namelen = msg->msg_namelen;
 
-    HostHeader.msg_iov = &Host_iovec.at(0);
+    HostHeader.msg_iov = Host_iovec.data();
     HostHeader.msg_iovlen = msg->msg_iovlen;
 
     HostHeader.msg_control = alloca(msg->msg_controllen*2);


### PR DESCRIPTION
Resolves some trivial sign-comparison warnings for `SendMsg` and `RecvMsg`.

This also fixes a potential case where a crash can occur due to the user sending through a message with a size of zero