### PR TITLE
{x32, x64}/Thread: Make use of .data() instead of .at(0)

### DIFF
--- a/Source/Tests/LinuxSyscalls/Syscalls.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls.cpp
@@ -220,10 +220,11 @@ uint64_t ExecveHandler(const char *pathname, char* const* argv, char* const* env
   }
 
   if (Args) {
-    Result = ::syscall(SYS_execveat, Args->dirfd, "/proc/self/exe", const_cast<char *const *>(&ExecveArgs.at(0)), envp, Args->flags);
+    Result = ::syscall(SYS_execveat, Args->dirfd, "/proc/self/exe",
+                       const_cast<char *const *>(ExecveArgs.data()), envp, Args->flags);
   }
   else {
-    Result = execve("/proc/self/exe", const_cast<char *const *>(&ExecveArgs.at(0)), envp);
+    Result = execve("/proc/self/exe", const_cast<char *const *>(ExecveArgs.data()), envp);
   }
 
   SYSCALL_ERRNO();

--- a/Source/Tests/LinuxSyscalls/x32/Thread.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Thread.cpp
@@ -270,7 +270,9 @@ namespace FEX::HLE::x32 {
         Envp.push_back(nullptr);
       }
 
-      return FEX::HLE::ExecveHandler(pathname, argv ? const_cast<char* const*>(&Args.at(0)) : nullptr, envp ? const_cast<char* const*>(&Envp.at(0)) : nullptr, nullptr);
+      auto* const* ArgsPtr = argv ? const_cast<char* const*>(Args.data()) : nullptr;
+      auto* const* EnvpPtr = envp ? const_cast<char* const*>(Envp.data()) : nullptr;
+      return FEX::HLE::ExecveHandler(pathname, ArgsPtr, EnvpPtr, nullptr);
     });
 
     REGISTER_SYSCALL_IMPL_X32(execveat, ([](FEXCore::Core::CpuStateFrame *Frame, int dirfd, const char *pathname, uint32_t *argv, uint32_t *envp, int flags) -> uint64_t {
@@ -297,7 +299,9 @@ namespace FEX::HLE::x32 {
         .flags = flags,
       };
 
-      return FEX::HLE::ExecveHandler(pathname, argv ? const_cast<char* const*>(&Args.at(0)) : nullptr, envp ? const_cast<char * const*>(&Envp.at(0)) : nullptr, &AtArgs);
+      auto* const* ArgsPtr = argv ? const_cast<char* const*>(Args.data()) : nullptr;
+      auto* const* EnvpPtr = envp ? const_cast<char* const*>(Envp.data()) : nullptr;
+      return FEX::HLE::ExecveHandler(pathname, ArgsPtr, EnvpPtr, &AtArgs);
     }));
 
     REGISTER_SYSCALL_IMPL_X32(wait4, [](FEXCore::Core::CpuStateFrame *Frame, pid_t pid, int *wstatus, int options, struct rusage_32 *rusage) -> uint64_t {

--- a/Source/Tests/LinuxSyscalls/x64/Thread.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Thread.cpp
@@ -103,7 +103,9 @@ namespace FEX::HLE::x64 {
         Envp.push_back(nullptr);
       }
 
-      return FEX::HLE::ExecveHandler(pathname, argv ? const_cast<char* const*>(&Args.at(0)) : nullptr, envp ? const_cast<char* const*>(&Envp.at(0)) : nullptr, nullptr);
+      auto* const* ArgsPtr = argv ? const_cast<char* const*>(Args.data()) : nullptr;
+      auto* const* EnvpPtr = envp ? const_cast<char* const*>(Envp.data()) : nullptr;
+      return FEX::HLE::ExecveHandler(pathname, ArgsPtr, EnvpPtr, nullptr);
     });
 
     REGISTER_SYSCALL_IMPL_X64(execveat, ([](FEXCore::Core::CpuStateFrame *Frame, int dirfd, const char *pathname, char *const argv[], char *const envp[], int flags) -> uint64_t {
@@ -131,7 +133,9 @@ namespace FEX::HLE::x64 {
         .flags = flags,
       };
 
-      return FEX::HLE::ExecveHandler(pathname, argv ? const_cast<char* const*>(&Args.at(0)) : nullptr, envp ? const_cast<char * const*>(&Envp.at(0)) : nullptr, &AtArgs);
+      auto* const* ArgsPtr = argv ? const_cast<char* const*>(Args.data()) : nullptr;
+      auto* const* EnvpPtr = envp ? const_cast<char* const*>(Envp.data()) : nullptr;
+      return FEX::HLE::ExecveHandler(pathname, ArgsPtr, EnvpPtr, &AtArgs);
     }));
 
     REGISTER_SYSCALL_IMPL_X64_PASS(wait4, [](FEXCore::Core::CpuStateFrame *Frame, pid_t pid, int *wstatus, int options, struct rusage *rusage) -> uint64_t {


### PR DESCRIPTION
Follows the previous PRs of using .data() instead of .at(0) to retrieve the buffer pointers.