### PR TITLE
Arm64: Fixes vixl assertions around ubfm usage

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
@@ -318,7 +318,7 @@ DEF_OP(InlineSyscall) {
           ldr(RegArgs[i].W(), MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, State.gregs[X86State::REG_RBX])));
         }
         else {
-          uxtw(RegArgs[i], Reg);
+          uxtw(RegArgs[i].W(), Reg);
         }
       }
     }
@@ -331,7 +331,7 @@ DEF_OP(InlineSyscall) {
         mov(RegArgs[i], GetReg<RA_64>(Op->Header.Args[i].ID()));
       }
       else {
-        uxtw(RegArgs[i], GetReg<RA_32>(Op->Header.Args[i].ID()));
+        uxtw(RegArgs[i], GetReg<RA_64>(Op->Header.Args[i].ID()));
       }
     }
   }
@@ -354,7 +354,7 @@ DEF_OP(InlineSyscall) {
     mov(GetReg<RA_64>(Node), x0);
   }
   else {
-    uxtw(GetReg<RA_64>(Node), w0);
+    uxtw(GetReg<RA_64>(Node), x0);
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ConversionOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ConversionOps.cpp
@@ -39,11 +39,11 @@ DEF_OP(VCastFromGPR) {
   auto Op = IROp->C<IR::IROp_VCastFromGPR>();
   switch (Op->Header.ElementSize) {
     case 1:
-      uxtb(TMP1.W(), GetReg<RA_32>(Op->Header.Args[0].ID()).W());
+      uxtb(TMP1.W(), GetReg<RA_32>(Op->Header.Args[0].ID()));
       fmov(GetDst(Node).S(), TMP1.W());
       break;
     case 2:
-      uxth(TMP1.W(), GetReg<RA_32>(Op->Header.Args[0].ID()).W());
+      uxth(TMP1.W(), GetReg<RA_32>(Op->Header.Args[0].ID()));
       fmov(GetDst(Node).S(), TMP1.W());
       break;
     case 4:

--- a/unittests/32Bit_ASM/FEX_bugs/InlineSyscall.asm
+++ b/unittests/32Bit_ASM/FEX_bugs/InlineSyscall.asm
@@ -1,0 +1,17 @@
+%ifdef CONFIG
+{
+  "RegData": {
+  },
+  "Mode": "32BIT"
+}
+%endif
+
+; FEX 32-bit inline syscalls hit an assert in uxtw
+; Just use an inline syscall and throw it zero data to catch the assert
+mov eax, 355 ; getrandom, is an inline syscall
+mov ebx, 0
+mov ecx, 0
+mov edx, 0
+int 0x80
+
+hlt


### PR DESCRIPTION
vixl has an assert check to ensure the register sizes are the same for
ubfm.

32-bit Inline syscalls hit this for both arguments and return value.
VCastFromGPR would have hit this but there aren't any x86 instructions
that move 8-bit and 16-bit values in to a vector register.