### PR TITLE
Context: Take some arguments as pointer-to-const

### DIFF
--- a/External/FEXCore/Source/Interface/Context/Context.cpp
+++ b/External/FEXCore/Source/Interface/Context/Context.cpp
@@ -51,7 +51,7 @@ namespace FEXCore::Context {
     CTX->CustomExitHandler = std::move(handler);
   }
 
-  ExitHandler GetExitHandler(FEXCore::Context::Context *CTX) {
+  ExitHandler GetExitHandler(const FEXCore::Context::Context *CTX) {
     return CTX->CustomExitHandler;
   }
 
@@ -71,23 +71,23 @@ namespace FEXCore::Context {
     return CTX->RunUntilExit();
   }
 
-  int GetProgramStatus(FEXCore::Context::Context *CTX) {
+  int GetProgramStatus(const FEXCore::Context::Context *CTX) {
     return CTX->GetProgramStatus();
   }
 
-  FEXCore::Context::ExitReason GetExitReason(FEXCore::Context::Context *CTX) {
+  FEXCore::Context::ExitReason GetExitReason(const FEXCore::Context::Context *CTX) {
     return CTX->ParentThread->ExitReason;
   }
 
-  bool IsDone(FEXCore::Context::Context *CTX) {
+  bool IsDone(const FEXCore::Context::Context *CTX) {
     return CTX->IsPaused();
   }
 
-  void GetCPUState(FEXCore::Context::Context *CTX, FEXCore::Core::CPUState *State) {
+  void GetCPUState(const FEXCore::Context::Context *CTX, FEXCore::Core::CPUState *State) {
     memcpy(State, CTX->ParentThread->CurrentFrame, sizeof(FEXCore::Core::CPUState));
   }
 
-  void SetCPUState(FEXCore::Context::Context *CTX, FEXCore::Core::CPUState *State) {
+  void SetCPUState(FEXCore::Context::Context *CTX, const FEXCore::Core::CPUState *State) {
     memcpy(CTX->ParentThread->CurrentFrame, State, sizeof(FEXCore::Core::CPUState));
   }
 

--- a/External/FEXCore/Source/Interface/Context/Context.cpp
+++ b/External/FEXCore/Source/Interface/Context/Context.cpp
@@ -115,11 +115,11 @@ namespace FEXCore::Context {
   }
 
   void RegisterHostSignalHandler(FEXCore::Context::Context *CTX, int Signal, HostSignalDelegatorFunction Func, bool Required) {
-      CTX->RegisterHostSignalHandler(Signal, Func, Required);
+      CTX->RegisterHostSignalHandler(Signal, std::move(Func), Required);
   }
 
   void RegisterFrontendHostSignalHandler(FEXCore::Context::Context *CTX, int Signal, HostSignalDelegatorFunction Func, bool Required) {
-    CTX->RegisterFrontendHostSignalHandler(Signal, Func, Required);
+    CTX->RegisterFrontendHostSignalHandler(Signal, std::move(Func), Required);
   }
 
   FEXCore::Core::InternalThreadState* CreateThread(FEXCore::Context::Context *CTX, FEXCore::Core::CPUState *NewThreadState, uint64_t ParentTID) {

--- a/External/FEXCore/include/FEXCore/Core/Context.h
+++ b/External/FEXCore/include/FEXCore/Core/Context.h
@@ -94,7 +94,7 @@ namespace FEXCore::Context {
   FEX_DEFAULT_VISIBILITY FEXCore::Core::InternalThreadState* InitCore(FEXCore::Context::Context *CTX, FEXCore::CodeLoader *Loader);
 
   FEX_DEFAULT_VISIBILITY void SetExitHandler(FEXCore::Context::Context *CTX, ExitHandler handler);
-  FEX_DEFAULT_VISIBILITY ExitHandler GetExitHandler(FEXCore::Context::Context *CTX);
+  FEX_DEFAULT_VISIBILITY ExitHandler GetExitHandler(const FEXCore::Context::Context *CTX);
 
   /**
    * @brief Pauses execution on the CPU core
@@ -134,7 +134,7 @@ namespace FEXCore::Context {
    *
    * @return The program exit status
    */
-  FEX_DEFAULT_VISIBILITY int GetProgramStatus(FEXCore::Context::Context *CTX);
+  FEX_DEFAULT_VISIBILITY int GetProgramStatus(const FEXCore::Context::Context *CTX);
 
   /**
    * @brief Tells the core to shutdown
@@ -157,7 +157,7 @@ namespace FEXCore::Context {
    *
    * @return The ExitReason for the parentthread
    */
-  FEX_DEFAULT_VISIBILITY ExitReason GetExitReason(FEXCore::Context::Context *CTX);
+  FEX_DEFAULT_VISIBILITY ExitReason GetExitReason(const FEXCore::Context::Context *CTX);
 
   /**
    * @brief [[theadsafe]] Checks if the Context is either done working or paused(in the case of single stepping)
@@ -168,7 +168,7 @@ namespace FEXCore::Context {
    *
    * @return true if the core is done or paused
    */
-  FEX_DEFAULT_VISIBILITY bool IsDone(FEXCore::Context::Context *CTX);
+  FEX_DEFAULT_VISIBILITY bool IsDone(const FEXCore::Context::Context *CTX);
 
   /**
    * @brief Gets a copy the CPUState of the parent thread
@@ -176,7 +176,8 @@ namespace FEXCore::Context {
    * @param CTX The context that we created
    * @param State The state object to populate
    */
-  FEX_DEFAULT_VISIBILITY void GetCPUState(FEXCore::Context::Context *CTX, FEXCore::Core::CPUState *State);
+  FEX_DEFAULT_VISIBILITY void GetCPUState(const FEXCore::Context::Context *CTX,
+                                          FEXCore::Core::CPUState *State);
 
   /**
    * @brief Copies the CPUState provided to the parent thread
@@ -184,7 +185,8 @@ namespace FEXCore::Context {
    * @param CTX The context that we created
    * @param State The satate object to copy from
    */
-  FEX_DEFAULT_VISIBILITY void SetCPUState(FEXCore::Context::Context *CTX, FEXCore::Core::CPUState *State);
+  FEX_DEFAULT_VISIBILITY void SetCPUState(FEXCore::Context::Context *CTX,
+                                          const FEXCore::Core::CPUState *State);
 
   /**
    * @brief Allows the frontend to pass in a custom CPUBackend creation factory


### PR DESCRIPTION
Several API functions act as state querying functions. These can take some parameters by const to communicate that we don't intend to modify the respective passed in instance (and also allow the API to be more flexible in how it's used)