### PR TITLE
OpcodeDispatcher: Handle PEXT

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/ALUOps.cpp
@@ -493,6 +493,30 @@ DEF_OP(Extr) {
   }
 }
 
+DEF_OP(PExt) {
+  const auto Op = IROp->C<IR::IROp_PExt>();
+  const auto OpSize = IROp->Size;
+
+  if (OpSize != 4 && OpSize != 8) {
+    LOGMAN_MSG_A_FMT("Unknown PExt Size: {}\n", OpSize);
+    return;
+  }
+
+  const uint64_t Input = OpSize == 4 ? *GetSrc<uint32_t*>(Data->SSAData, Op->Args(0))
+                                     : *GetSrc<uint64_t*>(Data->SSAData, Op->Args(0));
+  uint64_t Mask = OpSize == 4 ? *GetSrc<uint32_t*>(Data->SSAData, Op->Args(1))
+                              : *GetSrc<uint64_t*>(Data->SSAData, Op->Args(1));
+
+  uint64_t Result = 0;
+  for (uint64_t Offset = 0; Mask > 0; Offset++) {
+    const uint64_t Index = std::countr_zero(Mask);
+    Mask &= Mask - 1;
+    Result |= ((Input >> Index) & 1) << Offset;
+  }
+
+  GD = Result;
+}
+
 DEF_OP(LDiv) {
   auto Op = IROp->C<IR::IROp_LDiv>();
   uint8_t OpSize = IROp->Size;

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -73,6 +73,7 @@ constexpr OpHandlerArray InterpreterOpHandlers = [] {
   REGISTER_OP(ASHR,                   Ashr);
   REGISTER_OP(ROR,                    Ror);
   REGISTER_OP(EXTR,                   Extr);
+  REGISTER_OP(PEXT,                   PExt);
   REGISTER_OP(LDIV,                   LDiv);
   REGISTER_OP(LUDIV,                  LUDiv);
   REGISTER_OP(LREM,                   LRem);

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
@@ -96,6 +96,7 @@ namespace FEXCore::CPU {
   DEF_OP(Rol);
   DEF_OP(Ror);
   DEF_OP(Extr);
+  DEF_OP(PExt);
   DEF_OP(LDiv);
   DEF_OP(LUDiv);
   DEF_OP(LRem);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -233,6 +233,7 @@ private:
   DEF_OP(Rol);
   DEF_OP(Ror);
   DEF_OP(Extr);
+  DEF_OP(PExt);
   DEF_OP(LDiv);
   DEF_OP(LUDiv);
   DEF_OP(LRem);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/ALUOps.cpp
@@ -671,6 +671,21 @@ DEF_OP(Extr) {
   }
 }
 
+DEF_OP(PExt) {
+  const auto Op = IROp->C<IR::IROp_PExt>();
+  const auto OpSize = IROp->Size;
+
+  const auto Input = GRS(Op->Args(0).ID());
+  const auto Mask  = GRS(Op->Args(1).ID());
+  const auto Dest  = GRD(Node);
+
+  if (OpSize == 4) {
+    pext(Dest.cvt32(), Input.cvt32(), Mask.cvt32());
+  } else {
+    pext(Dest.cvt64(), Input.cvt64(), Mask.cvt64());
+  }
+}
+
 DEF_OP(LDiv) {
   auto Op = IROp->C<IR::IROp_LDiv>();
   uint8_t OpSize = IROp->Size;
@@ -1248,6 +1263,7 @@ void X86JITCore::RegisterALUHandlers() {
   REGISTER_OP(ASHR,              Ashr);
   REGISTER_OP(ROR,               Ror);
   REGISTER_OP(EXTR,              Extr);
+  REGISTER_OP(PEXT,              PExt);
   REGISTER_OP(LDIV,              LDiv);
   REGISTER_OP(LUDIV,             LUDiv);
   REGISTER_OP(LREM,              LRem);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -233,6 +233,7 @@ private:
   DEF_OP(Rol);
   DEF_OP(Ror);
   DEF_OP(Extr);
+  DEF_OP(PExt);
   DEF_OP(LDiv);
   DEF_OP(LUDiv);
   DEF_OP(LRem);

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -2449,6 +2449,14 @@ void OpDispatchBuilder::MULX(OpcodeArgs) {
   StoreResult(GPRClass, Op, Op->Dest, ResultHi, -1);
 }
 
+void OpDispatchBuilder::PEXT(OpcodeArgs) {
+  auto* Input = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+  auto* Mask = LoadSource(GPRClass, Op, Op->Src[1], Op->Flags, -1);
+  auto Result = _PExt(Input, Mask);
+
+  StoreResult(GPRClass, Op, Op->Dest, Result, -1);
+}
+
 void OpDispatchBuilder::ADXOp(OpcodeArgs) {
   // Handles ADCX and ADOX
 
@@ -6178,6 +6186,7 @@ constexpr uint16_t PF_F2 = 3;
 
     {OPD(2, 0b00, 0xF2), 1, &OpDispatchBuilder::ANDNBMIOp},
     {OPD(2, 0b00, 0xF5), 1, &OpDispatchBuilder::BZHI},
+    {OPD(2, 0b10, 0xF5), 1, &OpDispatchBuilder::PEXT},
     {OPD(2, 0b11, 0xF6), 1, &OpDispatchBuilder::MULX},
     {OPD(2, 0b00, 0xF7), 1, &OpDispatchBuilder::BEXTRBMIOp},
     {OPD(2, 0b01, 0xF7), 1, &OpDispatchBuilder::BMI2Shift},

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -338,6 +338,7 @@ public:
   void BMI2Shift(OpcodeArgs);
   void BZHI(OpcodeArgs);
   void MULX(OpcodeArgs);
+  void PEXT(OpcodeArgs);
   void RORX(OpcodeArgs);
 
   // ADX Ops

--- a/External/FEXCore/Source/Interface/Core/X86Tables/VEXTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/VEXTables.cpp
@@ -394,7 +394,8 @@ void InitializeVEXTables() {
     {OPD(2, 0b11, 0xF3), 1, X86InstInfo{"", TYPE_VEX_GROUP_17, FLAGS_NONE, 0, nullptr}}, // VEX Group 17
 
     {OPD(2, 0b00, 0xF5), 1, X86InstInfo{"BZHI", TYPE_INST, FLAGS_MODRM | FLAGS_VEX_2ND_SRC, 0, nullptr}},
-    {OPD(2, 0b01, 0xF5), 1, X86InstInfo{"PEXT", TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
+    // AMD reference manual is incorrect. PEXT actually maps to 0b10, not 0b01.
+    {OPD(2, 0b10, 0xF5), 1, X86InstInfo{"PEXT", TYPE_INST, FLAGS_MODRM | FLAGS_VEX_1ST_SRC, 0, nullptr}},
     {OPD(2, 0b11, 0xF5), 1, X86InstInfo{"PDEP", TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
 
     {OPD(2, 0b11, 0xF6), 1, X86InstInfo{"MULX", TYPE_INST, FLAGS_MODRM | FLAGS_VEX_1ST_SRC, 0, nullptr}},

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -1074,6 +1074,22 @@
       ]
     },
 
+    "PExt": {
+      "Desc": [
+        "Performs a parallel bit extract.",
+        "Each bit set in the mask will select the corresponding bit in the Input",
+        "and transfers them to the lower contiguous bits in the destination."
+      ],
+      "OpClass": "ALU",
+      "HasDest": true,
+      "DestClass": "GPR",
+      "SSAArgs": "2",
+      "SSANames": [
+        "Input",
+        "Mask"
+      ]
+    },
+
     "LDiv": {
       "Desc": ["Integer long signed division returning lower bits",
                "The Lower and Upper registers will be concated together to generate a dividend twice the size",

--- a/unittests/ASM/VEX/pext.asm
+++ b/unittests/ASM/VEX/pext.asm
@@ -1,0 +1,24 @@
+%ifdef CONFIG
+{
+  "RegData": {
+      "RAX": "0x12345678",
+      "RBX": "0xFF00FFF0",
+      "RCX": "0x00012567",
+      "RDX": "0x1234567812345678",
+      "RSI": "0xFF00FF00FF00FF00",
+      "RDI": "0x12561256"
+  }
+}
+%endif
+
+; 32-bit
+mov eax, 0x12345678
+mov ebx, 0xFF00FFF0
+pext ecx, eax, ebx
+
+; 64-bit
+mov rdx, 0x1234567812345678
+mov rsi, 0xFF00FF00FF00FF00
+pext rdi, rdx, rsi
+
+hlt


### PR DESCRIPTION
Handles one of the two remaining BMI2 opcodes. PDEP will follow after