### PR TITLE
OpcodeDispatcher: Handle PDEP

### DIFF
--- a/External/FEXCore/Source/Interface/Core/CPUID.cpp
+++ b/External/FEXCore/Source/Interface/Core/CPUID.cpp
@@ -622,7 +622,7 @@ FEXCore::CPUID::FunctionResults CPUIDEmu::Function_07h(uint32_t Leaf) {
       (0 <<  5) | // AVX2 support
       (1 <<  6) | // FPU data pointer updated only on exception
       (1 <<  7) | // SMEP support
-      (0 <<  8) | // BMI2
+      (1 <<  8) | // BMI2
       (0 <<  9) | // Enhanced REP MOVSB/STOSB
       (1 << 10) | // INVPCID for system software control of process-context
       (0 << 11) | // Restricted transactional memory

--- a/External/FEXCore/Source/Interface/Core/Interpreter/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/ALUOps.cpp
@@ -493,6 +493,30 @@ DEF_OP(Extr) {
   }
 }
 
+DEF_OP(PDep) {
+  const auto Op = IROp->C<IR::IROp_PExt>();
+  const auto OpSize = IROp->Size;
+
+  if (OpSize != 4 && OpSize != 8) {
+    LOGMAN_MSG_A_FMT("Unknown PDep Size: {}\n", OpSize);
+    return;
+  }
+
+  const uint64_t Input = OpSize == 4 ? *GetSrc<uint32_t*>(Data->SSAData, Op->Args(0))
+                                     : *GetSrc<uint64_t*>(Data->SSAData, Op->Args(0));
+  uint64_t Mask = OpSize == 4 ? *GetSrc<uint32_t*>(Data->SSAData, Op->Args(1))
+                              : *GetSrc<uint64_t*>(Data->SSAData, Op->Args(1));
+
+  uint64_t Result = 0;
+  for (uint64_t Index = 0; Mask > 0; Index++) {
+    const uint64_t Offset = std::countr_zero(Mask);
+    Mask &= Mask - 1;
+    Result |= ((Input >> Index) & 1) << Offset;
+  }
+
+  GD = Result;
+}
+
 DEF_OP(PExt) {
   const auto Op = IROp->C<IR::IROp_PExt>();
   const auto OpSize = IROp->Size;

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -73,6 +73,7 @@ constexpr OpHandlerArray InterpreterOpHandlers = [] {
   REGISTER_OP(ASHR,                   Ashr);
   REGISTER_OP(ROR,                    Ror);
   REGISTER_OP(EXTR,                   Extr);
+  REGISTER_OP(PDEP,                   PDep);
   REGISTER_OP(PEXT,                   PExt);
   REGISTER_OP(LDIV,                   LDiv);
   REGISTER_OP(LUDIV,                  LUDiv);

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
@@ -96,6 +96,7 @@ namespace FEXCore::CPU {
   DEF_OP(Rol);
   DEF_OP(Ror);
   DEF_OP(Extr);
+  DEF_OP(PDep);
   DEF_OP(PExt);
   DEF_OP(LDiv);
   DEF_OP(LUDiv);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -233,6 +233,7 @@ private:
   DEF_OP(Rol);
   DEF_OP(Ror);
   DEF_OP(Extr);
+  DEF_OP(PDep);
   DEF_OP(PExt);
   DEF_OP(LDiv);
   DEF_OP(LUDiv);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/ALUOps.cpp
@@ -671,6 +671,21 @@ DEF_OP(Extr) {
   }
 }
 
+DEF_OP(PDep) {
+  const auto Op = IROp->C<IR::IROp_PExt>();
+  const auto OpSize = IROp->Size;
+
+  const auto Input = GRS(Op->Args(0).ID());
+  const auto Mask  = GRS(Op->Args(1).ID());
+  const auto Dest  = GRD(Node);
+
+  if (OpSize == 4) {
+    pdep(Dest.cvt32(), Input.cvt32(), Mask.cvt32());
+  } else {
+    pdep(Dest.cvt64(), Input.cvt64(), Mask.cvt64());
+  }
+}
+
 DEF_OP(PExt) {
   const auto Op = IROp->C<IR::IROp_PExt>();
   const auto OpSize = IROp->Size;
@@ -1263,6 +1278,7 @@ void X86JITCore::RegisterALUHandlers() {
   REGISTER_OP(ASHR,              Ashr);
   REGISTER_OP(ROR,               Ror);
   REGISTER_OP(EXTR,              Extr);
+  REGISTER_OP(PDEP,              PDep);
   REGISTER_OP(PEXT,              PExt);
   REGISTER_OP(LDIV,              LDiv);
   REGISTER_OP(LUDIV,             LUDiv);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -233,6 +233,7 @@ private:
   DEF_OP(Rol);
   DEF_OP(Ror);
   DEF_OP(Extr);
+  DEF_OP(PDep);
   DEF_OP(PExt);
   DEF_OP(LDiv);
   DEF_OP(LUDiv);

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -2449,6 +2449,14 @@ void OpDispatchBuilder::MULX(OpcodeArgs) {
   StoreResult(GPRClass, Op, Op->Dest, ResultHi, -1);
 }
 
+void OpDispatchBuilder::PDEP(OpcodeArgs) {
+  auto* Input = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+  auto* Mask = LoadSource(GPRClass, Op, Op->Src[1], Op->Flags, -1);
+  auto Result = _PDep(Input, Mask);
+
+  StoreResult(GPRClass, Op, Op->Dest, Result, -1);
+}
+
 void OpDispatchBuilder::PEXT(OpcodeArgs) {
   auto* Input = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
   auto* Mask = LoadSource(GPRClass, Op, Op->Src[1], Op->Flags, -1);
@@ -6196,6 +6204,7 @@ constexpr uint16_t PF_F2 = 3;
     {OPD(2, 0b00, 0xF2), 1, &OpDispatchBuilder::ANDNBMIOp},
     {OPD(2, 0b00, 0xF5), 1, &OpDispatchBuilder::BZHI},
     {OPD(2, 0b10, 0xF5), 1, &OpDispatchBuilder::PEXT},
+    {OPD(2, 0b11, 0xF5), 1, &OpDispatchBuilder::PDEP},
     {OPD(2, 0b11, 0xF6), 1, &OpDispatchBuilder::MULX},
     {OPD(2, 0b00, 0xF7), 1, &OpDispatchBuilder::BEXTRBMIOp},
     {OPD(2, 0b01, 0xF7), 1, &OpDispatchBuilder::BMI2Shift},

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -338,6 +338,7 @@ public:
   void BMI2Shift(OpcodeArgs);
   void BZHI(OpcodeArgs);
   void MULX(OpcodeArgs);
+  void PDEP(OpcodeArgs);
   void PEXT(OpcodeArgs);
   void RORX(OpcodeArgs);
 

--- a/External/FEXCore/Source/Interface/Core/X86Tables/VEXTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/VEXTables.cpp
@@ -396,7 +396,7 @@ void InitializeVEXTables() {
     {OPD(2, 0b00, 0xF5), 1, X86InstInfo{"BZHI", TYPE_INST, FLAGS_MODRM | FLAGS_VEX_2ND_SRC, 0, nullptr}},
     // AMD reference manual is incorrect. PEXT actually maps to 0b10, not 0b01.
     {OPD(2, 0b10, 0xF5), 1, X86InstInfo{"PEXT", TYPE_INST, FLAGS_MODRM | FLAGS_VEX_1ST_SRC, 0, nullptr}},
-    {OPD(2, 0b11, 0xF5), 1, X86InstInfo{"PDEP", TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
+    {OPD(2, 0b11, 0xF5), 1, X86InstInfo{"PDEP", TYPE_INST, FLAGS_MODRM | FLAGS_VEX_1ST_SRC, 0, nullptr}},
 
     {OPD(2, 0b11, 0xF6), 1, X86InstInfo{"MULX", TYPE_INST, FLAGS_MODRM | FLAGS_VEX_1ST_SRC, 0, nullptr}},
 

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -1089,6 +1089,22 @@
       ]
     },
 
+    "PDep": {
+      "Desc": [
+        "Performs a parallel bit deposit.",
+        "Takes the contiguous low-order bits and deposits them into",
+        "the destination at the locations specified by the Mask."
+      ],
+      "OpClass": "ALU",
+      "HasDest": true,
+      "DestClass": "GPR",
+      "SSAArgs": "2",
+      "SSANames": [
+        "Input",
+        "Mask"
+      ]
+    },
+
     "PExt": {
       "Desc": [
         "Performs a parallel bit extract.",

--- a/unittests/ASM/VEX/pdep.asm
+++ b/unittests/ASM/VEX/pdep.asm
@@ -1,0 +1,24 @@
+%ifdef CONFIG
+{
+  "RegData": {
+      "RAX": "0x00012567",
+      "RBX": "0xFF00FFF0",
+      "RCX": "0x12005670",
+      "RDX": "0x0801256708012567",
+      "RSI": "0xFF00FF00FF00FF00",
+      "RDI": "0x0800010025006700"
+  }
+}
+%endif
+
+; 32-bit
+mov eax, 0x00012567
+mov ebx, 0xFF00FFF0
+pdep ecx, eax, ebx
+
+; 64-bit
+mov rdx, 0x0801256708012567
+mov rsi, 0xFF00FF00FF00FF00
+pdep rdi, rdx, rsi
+
+hlt


### PR DESCRIPTION
Handles the last remaining BMI2 instruction, letting us signal full support for BMI2 within our emulated CPUID