### PR TITLE
HostFeatures: Consolidates HostFeatures flags

### DIFF
--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
@@ -58,12 +58,9 @@ const std::array<aarch64::VRegister, 12> RAFPR = {
 // be used by both Arm64 JIT and ARM64 Dispatcher
 class Arm64Emitter : public vixl::aarch64::Assembler {
 protected:
-  Arm64Emitter(size_t size);
+  Arm64Emitter(FEXCore::Context::Context *ctx, size_t size);
 
   vixl::aarch64::CPU CPU;
-  bool SupportsAtomics{};
-  bool SupportsRCPC{};
-
   void LoadConstant(vixl::aarch64::Register Reg, uint64_t Constant);
   void SpillStaticRegs(bool FPRs = true, uint32_t SpillMask = ~0U);
   void FillStaticRegs(bool FPRs = true, uint32_t FillMask = ~0U);
@@ -78,9 +75,6 @@ protected:
   void Align16B();
 
   uint32_t SpillSlots{};
-
-  uint32_t DCacheLineSize{};
-  uint32_t ICacheLineSize{};
 
   FEX_CONFIG_OPT(StaticRegisterAllocation, SRA);
 };

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
@@ -37,7 +37,7 @@ static constexpr size_t MAX_DISPATCHER_CODE_SIZE = 4096;
 #define STATE x28
 
 Arm64Dispatcher::Arm64Dispatcher(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread, DispatcherConfig &config)
-  : Dispatcher(ctx, Thread), Arm64Emitter(MAX_DISPATCHER_CODE_SIZE) {
+  : Dispatcher(ctx, Thread), Arm64Emitter(ctx, MAX_DISPATCHER_CODE_SIZE) {
   SRAEnabled = config.StaticRegisterAssignment;
   SetAllowAssembler(true);
 

--- a/External/FEXCore/Source/Interface/Core/HostFeatures.h
+++ b/External/FEXCore/Source/Interface/Core/HostFeatures.h
@@ -1,10 +1,22 @@
 #pragma once
+#include <cstdint>
 
 namespace FEXCore {
 class HostFeatures final {
   public:
     HostFeatures();
+
+    /**
+     * @brief Backend features that change how codegen is generated from IR
+     *
+     * Specifically things that affect the IR->Codegen process
+     * Not the x86->IR process
+     */
+    uint32_t DCacheLineSize{};
+    uint32_t ICacheLineSize{};
     bool SupportsAES{};
     bool SupportsCLZERO{};
+    bool SupportsAtomics{};
+    bool SupportsRCPC{};
 };
 }

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/AtomicOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/AtomicOps.cpp
@@ -19,7 +19,7 @@ DEF_OP(CASPair) {
   auto Desired = GetSrcPair<RA_64>(Op->Header.Args[1].ID());
   auto MemSrc = GetReg<RA_64>(Op->Header.Args[2].ID());
 
-  if (SupportsAtomics) {
+  if (CTX->HostFeatures.SupportsAtomics) {
     mov(TMP3, Expected.first);
     mov(TMP4, Expected.second);
 
@@ -110,7 +110,7 @@ DEF_OP(CAS) {
   auto Desired = GetReg<RA_64>(Op->Header.Args[1].ID());
   auto MemSrc = GetReg<RA_64>(Op->Header.Args[2].ID());
 
-  if (SupportsAtomics) {
+  if (CTX->HostFeatures.SupportsAtomics) {
     mov(TMP2, Expected);
     switch (OpSize) {
     case 1: casalb(TMP2.W(), Desired.W(), MemOperand(MemSrc)); break;
@@ -218,7 +218,7 @@ DEF_OP(AtomicAdd) {
 
   auto MemSrc = GetReg<RA_64>(Op->Header.Args[0].ID());
 
-  if (SupportsAtomics) {
+  if (CTX->HostFeatures.SupportsAtomics) {
     switch (IROp->Size) {
     case 1: staddlb(GetReg<RA_32>(Op->Header.Args[1].ID()), MemOperand(MemSrc)); break;
     case 2: staddlh(GetReg<RA_32>(Op->Header.Args[1].ID()), MemOperand(MemSrc)); break;
@@ -276,7 +276,7 @@ DEF_OP(AtomicSub) {
 
   auto MemSrc = GetReg<RA_64>(Op->Header.Args[0].ID());
 
-  if (SupportsAtomics) {
+  if (CTX->HostFeatures.SupportsAtomics) {
     neg(TMP2, GetReg<RA_64>(Op->Header.Args[1].ID()));
     switch (IROp->Size) {
     case 1: staddlb(TMP2.W(), MemOperand(MemSrc)); break;
@@ -335,7 +335,7 @@ DEF_OP(AtomicAnd) {
 
   auto MemSrc = GetReg<RA_64>(Op->Header.Args[0].ID());
 
-  if (SupportsAtomics) {
+  if (CTX->HostFeatures.SupportsAtomics) {
     mvn(TMP2, GetReg<RA_64>(Op->Header.Args[1].ID()));
     switch (IROp->Size) {
     case 1: stclrlb(TMP2.W(), MemOperand(MemSrc)); break;
@@ -394,7 +394,7 @@ DEF_OP(AtomicOr) {
 
   auto MemSrc = GetReg<RA_64>(Op->Header.Args[0].ID());
 
-  if (SupportsAtomics) {
+  if (CTX->HostFeatures.SupportsAtomics) {
     switch (IROp->Size) {
     case 1: stsetlb(GetReg<RA_32>(Op->Header.Args[1].ID()), MemOperand(MemSrc)); break;
     case 2: stsetlh(GetReg<RA_32>(Op->Header.Args[1].ID()), MemOperand(MemSrc)); break;
@@ -452,7 +452,7 @@ DEF_OP(AtomicXor) {
 
   auto MemSrc = GetReg<RA_64>(Op->Header.Args[0].ID());
 
-  if (SupportsAtomics) {
+  if (CTX->HostFeatures.SupportsAtomics) {
     switch (IROp->Size) {
     case 1: steorlb(GetReg<RA_32>(Op->Header.Args[1].ID()), MemOperand(MemSrc)); break;
     case 2: steorlh(GetReg<RA_32>(Op->Header.Args[1].ID()), MemOperand(MemSrc)); break;
@@ -510,7 +510,7 @@ DEF_OP(AtomicSwap) {
 
   auto MemSrc = GetReg<RA_64>(Op->Header.Args[0].ID());
 
-  if (SupportsAtomics) {
+  if (CTX->HostFeatures.SupportsAtomics) {
     mov(TMP2, GetReg<RA_64>(Op->Header.Args[1].ID()));
     switch (IROp->Size) {
     case 1: swplb(TMP2.W(), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
@@ -568,7 +568,7 @@ DEF_OP(AtomicFetchAdd) {
   auto Op = IROp->C<IR::IROp_AtomicFetchAdd>();
   auto MemSrc = GetReg<RA_64>(Op->Header.Args[0].ID());
 
-  if (SupportsAtomics) {
+  if (CTX->HostFeatures.SupportsAtomics) {
     switch (IROp->Size) {
     case 1: ldaddalb(GetReg<RA_32>(Op->Header.Args[1].ID()), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
     case 2: ldaddalh(GetReg<RA_32>(Op->Header.Args[1].ID()), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
@@ -629,7 +629,7 @@ DEF_OP(AtomicFetchSub) {
   auto Op = IROp->C<IR::IROp_AtomicFetchSub>();
   auto MemSrc = GetReg<RA_64>(Op->Header.Args[0].ID());
 
-  if (SupportsAtomics) {
+  if (CTX->HostFeatures.SupportsAtomics) {
     neg(TMP2, GetReg<RA_64>(Op->Header.Args[1].ID()));
     switch (IROp->Size) {
     case 1: ldaddalb(TMP2.W(), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
@@ -691,7 +691,7 @@ DEF_OP(AtomicFetchAnd) {
   auto Op = IROp->C<IR::IROp_AtomicFetchAnd>();
   auto MemSrc = GetReg<RA_64>(Op->Header.Args[0].ID());
 
-  if (SupportsAtomics) {
+  if (CTX->HostFeatures.SupportsAtomics) {
     mvn(TMP2, GetReg<RA_64>(Op->Header.Args[1].ID()));
     switch (IROp->Size) {
     case 1: ldclralb(TMP2.W(), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
@@ -753,7 +753,7 @@ DEF_OP(AtomicFetchOr) {
   auto Op = IROp->C<IR::IROp_AtomicFetchOr>();
   auto MemSrc = GetReg<RA_64>(Op->Header.Args[0].ID());
 
-  if (SupportsAtomics) {
+  if (CTX->HostFeatures.SupportsAtomics) {
     switch (IROp->Size) {
     case 1: ldsetalb(GetReg<RA_32>(Op->Header.Args[1].ID()), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
     case 2: ldsetalh(GetReg<RA_32>(Op->Header.Args[1].ID()), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
@@ -814,7 +814,7 @@ DEF_OP(AtomicFetchXor) {
   auto Op = IROp->C<IR::IROp_AtomicFetchXor>();
   auto MemSrc = GetReg<RA_64>(Op->Header.Args[0].ID());
 
-  if (SupportsAtomics) {
+  if (CTX->HostFeatures.SupportsAtomics) {
     switch (IROp->Size) {
     case 1: ldeoralb(GetReg<RA_32>(Op->Header.Args[1].ID()), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;
     case 2: ldeoralh(GetReg<RA_32>(Op->Header.Args[1].ID()), GetReg<RA_32>(Node), MemOperand(MemSrc)); break;

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -333,7 +333,7 @@ void Arm64JITCore::FreeCodeBuffer(CodeBuffer Buffer) {
 }
 
 Arm64JITCore::Arm64JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread, bool CompileThread)
-  : Arm64Emitter(0)
+  : Arm64Emitter(ctx, 0)
   , CTX {ctx}
   , ThreadState {Thread} {
   {

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -623,7 +623,7 @@ DEF_OP(LoadMemTSO) {
     LOGMAN_MSG_A_FMT("LoadMemTSO: No offset allowed");
   }
 
-  if (SupportsRCPC && Op->Class == FEXCore::IR::GPRClass) {
+  if (CTX->HostFeatures.SupportsRCPC && Op->Class == FEXCore::IR::GPRClass) {
     if (IROp->Size == 1) {
       // 8bit load is always aligned to natural alignment
       auto Dst = GetReg<RA_64>(Node);
@@ -939,9 +939,9 @@ DEF_OP(CacheLineClear) {
   // Clear dcache only
   // icache doesn't matter here since the guest application shouldn't be calling clflush on JIT code.
   mov(TMP1, MemReg);
-  for (size_t i = 0; i < std::max(1U, DCacheLineSize / 64U); ++i) {
+  for (size_t i = 0; i < std::max(1U, CTX->HostFeatures.DCacheLineSize / 64U); ++i) {
     dc(DataCacheOp::CVAU, TMP1);
-    add(TMP1, TMP1, DCacheLineSize);
+    add(TMP1, TMP1, CTX->HostFeatures.DCacheLineSize);
   }
   dsb(InnerShareable, BarrierAll);
 }


### PR DESCRIPTION
Some of these were in the Emitter class and some were in the
HostFeatures.

Merge these together since in the future I'm going to be using all of
this data as a key for our AOT code cache.