### PR TITLE
CPUID: Fixes crash on unknown CPU

### DIFF
--- a/External/FEXCore/Source/Interface/Core/CPUID.cpp
+++ b/External/FEXCore/Source/Interface/Core/CPUID.cpp
@@ -321,7 +321,12 @@ void CPUIDEmu::SetupHostHybridFlag() {
       }
 
       Data.IsBig = FoundBig;
-      Data.ProductName = MIDR->ProductName ?: ProductNames::ARM_UNKNOWN;
+      if (MIDR) {
+        Data.ProductName = MIDR->ProductName ?: ProductNames::ARM_UNKNOWN;
+      }
+      else {
+        Data.ProductName = ProductNames::ARM_UNKNOWN;
+      }
     }
   }
   else {
@@ -331,7 +336,12 @@ void CPUIDEmu::SetupHostHybridFlag() {
       auto MIDROption = FindDefinedMIDR(MIDR);
 
       PerCPUData[i].IsBig = true;
-      PerCPUData[i].ProductName = MIDROption->ProductName;
+      if (MIDROption) {
+        PerCPUData[i].ProductName = MIDROption->ProductName ?: ProductNames::ARM_UNKNOWN;
+      }
+      else {
+        PerCPUData[i].ProductName = ProductNames::ARM_UNKNOWN;
+      }
     }
   }
 }


### PR DESCRIPTION
If the CPU is unknown inside of the ARM CPU detection then the
MIDROption selected could have fallen down a path where it is set to
nullptr.

Resolve this crash by doing a nullptr check.