### PR TITLE
HostFeatures: Detect if the host CPU suports float exceptions 

### DIFF
--- a/External/FEXCore/Source/Interface/Core/HostFeatures.h
+++ b/External/FEXCore/Source/Interface/Core/HostFeatures.h
@@ -18,5 +18,9 @@ class HostFeatures final {
     bool SupportsCLZERO{};
     bool SupportsAtomics{};
     bool SupportsRCPC{};
+
+    // Float exception behaviour
+    bool SupportsFlushInputsToZero{};
+    bool SupportsFloatExceptions{};
 };
 }


### PR DESCRIPTION
On x86 this is always supported.
On ARM this is only supported if FPCR writes actually enable the things.
Also detects the AFP feature for flushing input denormals to zero.

These are all part of the x86 MXCSR.
No Cortex supports FPCR exceptions, while Apple M1 CPUs support
Exceptions but not the true "AFP" extension
Apple instead supports some additional flags in their
`SYS_APL_AFPCR_EL0` register for enabling this.