### PR TITLE
Config: Enables all host threads by default

### DIFF
--- a/External/FEXCore/Source/Interface/Config/Config.cpp
+++ b/External/FEXCore/Source/Interface/Config/Config.cpp
@@ -416,7 +416,9 @@ namespace JSON {
     Meta->Load();
 
     // Do configuration option fix ups after everything is reloaded
-    if (FEXCore::Config::Exists(FEXCore::Config::CONFIG_THREADS)) {
+    {
+      // Always fix up the number of threads and create the configuration
+      // Otherwise the application could receive zero as the number of threads
       FEX_CONFIG_OPT(Cores, THREADS);
       if (Cores == 0) {
         // When the number of emulated CPU cores is zero then auto detect

--- a/External/FEXCore/Source/Interface/Config/Config.json.in
+++ b/External/FEXCore/Source/Interface/Config/Config.json.in
@@ -32,7 +32,7 @@
       },
       "Threads": {
         "Type": "uint32",
-        "Default": "1",
+        "Default": "0",
         "ShortArg": "T",
         "Desc": [
           "Number of physical hardware threads to tell the process we have.",


### PR DESCRIPTION
We've solved the few threading problems that we had before. So now allow
FEX to query the host for the number of threads.