### PR TITLE
Linux: Fixes build on Ubuntu 20.04 take 2

### DIFF
--- a/Source/Tests/LinuxSyscalls/x32/Types.h
+++ b/Source/Tests/LinuxSyscalls/x32/Types.h
@@ -9,6 +9,7 @@ $end_info$
 #include <FEXCore/Core/SignalDelegator.h>
 #include <FEXCore/Utils/CompilerDefs.h>
 
+#include <linux/types.h>
 #include <asm/ipcbuf.h>
 #include <asm/shmbuf.h>
 #include <bits/types/stack_t.h>
@@ -16,7 +17,6 @@ $end_info$
 #include <cstring>
 #include <fcntl.h>
 #include <limits>
-#include <linux/types.h>
 #include <sys/ipc.h>
 #include <mqueue.h>
 #include <signal.h>


### PR DESCRIPTION
Fixes #1457

Header include order matters here. Rude.