### PR TITLE
Linux: Implements the remaining 32-bit syscalls

### DIFF
--- a/Source/Tests/LinuxSyscalls/CMakeLists.txt
+++ b/Source/Tests/LinuxSyscalls/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(LinuxEmulation STATIC
     x32/FD.cpp
     x32/FS.cpp
     x32/Info.cpp
+    x32/IO.cpp
     x32/Memory.cpp
     x32/Msg.cpp
     x32/NotImplemented.cpp
@@ -18,6 +19,7 @@ add_library(LinuxEmulation STATIC
     x32/Sched.cpp
     x32/Signals.cpp
     x32/Socket.cpp
+    x32/Stubs.cpp
     x32/Thread.cpp
     x32/Time.cpp
     x32/Timer.cpp

--- a/Source/Tests/LinuxSyscalls/Syscalls/Namespace.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Namespace.cpp
@@ -41,6 +41,11 @@ namespace FEX::HLE {
         SYSCALL_ERRNO();
       });
 
+      REGISTER_SYSCALL_IMPL_PASS(fsmount, [](FEXCore::Core::CpuStateFrame *Frame, int fs_fd, uint32_t flags, uint32_t attr_flags) -> uint64_t {
+        uint64_t Result = ::syscall(SYSCALL_DEF(fsmount), fs_fd, flags, attr_flags);
+        SYSCALL_ERRNO();
+      });
+
       REGISTER_SYSCALL_IMPL_PASS(fspick, [](FEXCore::Core::CpuStateFrame *Frame, int dfd, const char *path, unsigned int flags) -> uint64_t {
         uint64_t Result = ::syscall(SYSCALL_DEF(fspick), dfd, path, flags);
         SYSCALL_ERRNO();

--- a/Source/Tests/LinuxSyscalls/x32/IO.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/IO.cpp
@@ -1,0 +1,55 @@
+/*
+$info$
+tags: LinuxSyscalls|syscalls-x86-32
+$end_info$
+*/
+
+#include "Tests/LinuxSyscalls/Syscalls.h"
+#include "Tests/LinuxSyscalls/x64/Syscalls.h"
+#include "Tests/LinuxSyscalls/x32/Syscalls.h"
+#include "Tests/LinuxSyscalls/x32/Types.h"
+
+#include <linux/aio_abi.h>
+#include <stdint.h>
+#include <syscall.h>
+#include <unistd.h>
+
+namespace FEX::HLE::x32 {
+  void RegisterIO() {
+    REGISTER_SYSCALL_IMPL_X32(io_getevents, [](FEXCore::Core::CpuStateFrame *Frame, aio_context_t ctx_id, long min_nr, long nr, struct io_event *events, struct timespec32 *timeout) -> uint64_t {
+      struct timespec* timeout_ptr{};
+      struct timespec tp64{};
+      if (timeout) {
+        tp64 = *timeout;
+        timeout_ptr = &tp64;
+      }
+
+      uint64_t Result = ::syscall(SYSCALL_DEF(io_getevents), ctx_id, min_nr, nr, events, timeout_ptr);
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(io_pgetevents, [](FEXCore::Core::CpuStateFrame *Frame, aio_context_t ctx_id, long min_nr, long nr, struct io_event *events, struct timespec32 *timeout, const struct io_sigset  *usig) -> uint64_t {
+      struct timespec* timeout_ptr{};
+      struct timespec tp64{};
+      if (timeout) {
+        tp64 = *timeout;
+        timeout_ptr = &tp64;
+      }
+
+      uint64_t Result = ::syscall(SYSCALL_DEF(io_pgetevents), ctx_id, min_nr, nr, events, timeout_ptr, usig);
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32_PASS(io_pgetevents_time64,
+      [](FEXCore::Core::CpuStateFrame *Frame,
+        aio_context_t ctx_id,
+        long min_nr,
+        long nr,
+        struct io_event *events,
+        struct timespec *timeout,
+        const struct io_sigset  *usig) -> uint64_t {
+      uint64_t Result = ::syscall(SYSCALL_DEF(io_pgetevents), ctx_id, min_nr, nr, events, timeout, usig);
+      SYSCALL_ERRNO();
+    });
+  }
+}

--- a/Source/Tests/LinuxSyscalls/x32/Sched.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Sched.cpp
@@ -5,6 +5,7 @@ $end_info$
 */
 
 #include "Tests/LinuxSyscalls/Syscalls.h"
+#include "Tests/LinuxSyscalls/x64/Syscalls.h"
 #include "Tests/LinuxSyscalls/x32/Syscalls.h"
 #include "Tests/LinuxSyscalls/x32/Types.h"
 
@@ -25,6 +26,11 @@ namespace FEX::HLE::x32 {
       if (tp) {
         *tp = tp64;
       }
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32_PASS(sched_rr_get_interval_time64, [](FEXCore::Core::CpuStateFrame *Frame, pid_t pid, struct timespec *tp) -> uint64_t {
+      uint64_t Result = ::sched_rr_get_interval(pid, tp);
       SYSCALL_ERRNO();
     });
   }

--- a/Source/Tests/LinuxSyscalls/x32/Stubs.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Stubs.cpp
@@ -1,0 +1,40 @@
+/*
+$info$
+tags: LinuxSyscalls|syscalls-x86-32
+$end_info$
+*/
+
+#include <FEXCore/Utils/LogManager.h>
+
+#include "Tests/LinuxSyscalls/Syscalls.h"
+#include "Tests/LinuxSyscalls/x32/Syscalls.h"
+
+#include <errno.h>
+#include <stdint.h>
+#include <sys/types.h>
+
+#define SYSCALL_STUB(name) do { ERROR_AND_DIE_FMT("Syscall: " #name " stub!"); return -ENOSYS; } while(0)
+
+namespace FEXCore::Core {
+  struct CpuStateFrame;
+}
+
+namespace FEX::HLE::x32 {
+  void RegisterStubs() {
+    REGISTER_SYSCALL_IMPL_X32(sigreturn, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t {
+      SYSCALL_STUB(sigreturn);
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(readdir, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t {
+      SYSCALL_STUB(readdir);
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(vm86old, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t {
+      return -ENOSYS;
+    });
+
+    REGISTER_SYSCALL_IMPL_X32(vm86, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t {
+      return -ENOSYS;
+    });
+  }
+}

--- a/Source/Tests/LinuxSyscalls/x32/Syscalls.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Syscalls.cpp
@@ -33,6 +33,7 @@ namespace FEX::HLE::x32 {
   void RegisterFD();
   void RegisterFS();
   void RegisterInfo();
+  void RegisterIO();
   void RegisterMemory();
   void RegisterMsg();
   void RegisterNotImplemented();
@@ -40,6 +41,7 @@ namespace FEX::HLE::x32 {
   void RegisterSemaphore();
   void RegisterSignals();
   void RegisterSocket();
+  void RegisterStubs();
   void RegisterThread();
   void RegisterTime();
   void RegisterTimer();
@@ -136,6 +138,7 @@ namespace FEX::HLE::x32 {
     FEX::HLE::x32::RegisterFD();
     FEX::HLE::x32::RegisterFS();
     FEX::HLE::x32::RegisterInfo();
+    FEX::HLE::x32::RegisterIO();
     FEX::HLE::x32::RegisterMemory();
     FEX::HLE::x32::RegisterMsg();
     FEX::HLE::x32::RegisterNotImplemented();
@@ -143,6 +146,7 @@ namespace FEX::HLE::x32 {
     FEX::HLE::x32::RegisterSemaphore();
     FEX::HLE::x32::RegisterSignals();
     FEX::HLE::x32::RegisterSocket();
+    FEX::HLE::x32::RegisterStubs();
     FEX::HLE::x32::RegisterThread();
     FEX::HLE::x32::RegisterTime();
     FEX::HLE::x32::RegisterTimer();

--- a/Source/Tests/LinuxSyscalls/x64/IO.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/IO.cpp
@@ -24,7 +24,7 @@ namespace FEX::HLE::x64 {
     });
 
     REGISTER_SYSCALL_IMPL_X64_PASS(io_pgetevents, [](FEXCore::Core::CpuStateFrame *Frame, aio_context_t ctx_id, long min_nr, long nr, struct io_event *events, struct timespec *timeout, const struct io_sigset  *usig) -> uint64_t {
-      uint64_t Result = ::syscall(SYSCALL_DEF(io_pgetevents), ctx_id, min_nr, nr, events, timeout);
+      uint64_t Result = ::syscall(SYSCALL_DEF(io_pgetevents), ctx_id, min_nr, nr, events, timeout, usig);
       SYSCALL_ERRNO();
     });
   }


### PR DESCRIPTION
The main one that we can't implement is readdir. Falls in to the same
problem space as getdents.

With this, we have the full entry tables filled out for both 64-bit and
32-bit. With some holes in the implementation, we have almost all
coverage now.