### PR TITLE
FEXCore: Implements recoverable INTO instruction

### DIFF
--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/MContext.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/MContext.h
@@ -24,6 +24,7 @@ struct X86ContextBackup {
   uint64_t GPRs[23];
   FEXCore::x86_64::_libc_fpstate FPRState;
   uint64_t sa_mask;
+  bool FaultToTopAndGeneratedException;
 
   // Guest state
   int Signal;
@@ -46,6 +47,7 @@ struct ArmContextBackup {
   uint32_t FPCR;
   __uint128_t FPRs[32];
   uint64_t sa_mask;
+  bool FaultToTopAndGeneratedException;
 
   // Guest state
   int Signal;

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
@@ -49,12 +49,19 @@ public:
   uint64_t ExitFunctionLinkerAddress{};
   uint64_t SignalHandlerReturnAddress{};
   uint64_t UnimplementedInstructionAddress{};
+  uint64_t OverflowExceptionInstructionAddress{};
 
   uint64_t PauseReturnInstruction{};
 
   /**  @} */
 
   uint32_t SignalHandlerRefCounter{};
+  struct SynchronousFaultDataStruct {
+    bool FaultToTopAndGeneratedException{};
+    uint32_t TrapNo;
+    uint32_t err_code;
+    uint32_t si_code;
+  } SynchronousFaultData;
 
   uint64_t Start{};
   uint64_t End{};

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -176,6 +176,7 @@ private:
   struct CompilerSharedData {
     uint64_t SignalReturnInstruction{};
     uint64_t UnimplementedInstructionAddress{};
+    uint64_t OverflowExceptionInstructionAddress{};
 
     uint32_t *SignalHandlerRefCounterPtr{};
     FEXCore::CPU::Dispatcher *Dispatcher{};

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
@@ -40,8 +40,12 @@ DEF_OP(Break) {
   switch (Op->Reason) {
     case FEXCore::IR::Break_Unimplemented: // Hard fault
     case FEXCore::IR::Break_Interrupt: // Guest ud2
-    case FEXCore::IR::Break_Overflow: // overflow
       hlt(4);
+      break;
+    case FEXCore::IR::Break_Overflow: // overflow
+      ResetStack();
+      LoadConstant(TMP1, ThreadSharedData.Dispatcher->OverflowExceptionInstructionAddress);
+      br(TMP1);
       break;
     case FEXCore::IR::Break_Halt: { // HLT
       // Time to quit

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -358,6 +358,7 @@ X86JITCore::X86JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalTh
     ThreadSharedData.SignalHandlerRefCounterPtr = &Dispatcher->SignalHandlerRefCounter;
     ThreadSharedData.SignalHandlerReturnAddress = Dispatcher->SignalHandlerReturnAddress;
     ThreadSharedData.UnimplementedInstructionAddress = Dispatcher->UnimplementedInstructionAddress;
+    ThreadSharedData.OverflowExceptionInstructionAddress = Dispatcher->OverflowExceptionInstructionAddress;
 
     ThreadSharedData.Dispatcher = Dispatcher.get();
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -167,7 +167,7 @@ private:
   struct CompilerSharedData {
     uint64_t SignalHandlerReturnAddress{};
     uint64_t UnimplementedInstructionAddress{};
-
+    uint64_t OverflowExceptionInstructionAddress{};
 
     uint32_t *SignalHandlerRefCounterPtr{};
     FEXCore::CPU::Dispatcher *Dispatcher{};

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/MiscOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/MiscOps.cpp
@@ -49,8 +49,12 @@ DEF_OP(Break) {
   switch (Op->Reason) {
     case FEXCore::IR::Break_Unimplemented: // Hard fault
     case FEXCore::IR::Break_Interrupt: // Guest ud2
-    case FEXCore::IR::Break_Overflow: // overflow
       ud2();
+      break;
+    case FEXCore::IR::Break_Overflow: // overflow
+      // Need to be outside of JIT cache space to ensure cache clearing correctness
+      mov(TMP1, ThreadSharedData.Dispatcher->OverflowExceptionInstructionAddress);
+      jmp(TMP1);
       break;
     case FEXCore::IR::Break_Halt: { // HLT
       // Time to quit

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -5074,8 +5074,9 @@ void OpDispatchBuilder::INTOp(OpcodeArgs) {
   break;
   }
 
+  const uint8_t GPRSize = CTX->GetGPRSize();
+
   if (setRIP) {
-    const uint8_t GPRSize = CTX->GetGPRSize();
 
     BlockSetRIP = setRIP;
 
@@ -5093,6 +5094,8 @@ void OpDispatchBuilder::INTOp(OpcodeArgs) {
     SetFalseJumpTarget(CondJump, FalseBlock);
     SetCurrentCodeBlock(FalseBlock);
 
+    auto NewRIP = GetDynamicPC(Op);
+    _StoreContext(GPRClass, GPRSize, offsetof(FEXCore::Core::CPUState, rip), NewRIP);
     _Break(Reason, Literal);
 
     // Make sure to start a new block after ending this one
@@ -5296,6 +5299,7 @@ void InstallOpcodeHandlers(Context::OperatingMode Mode) {
 
     {0x60, 1, &OpDispatchBuilder::PUSHAOp},
     {0x61, 1, &OpDispatchBuilder::POPAOp},
+    {0xCE, 1, &OpDispatchBuilder::INTOp},
   };
 
   constexpr std::tuple<uint8_t, uint8_t, X86Tables::OpDispatchPtr> BaseOpTable_64[] = {

--- a/unittests/32Bit_ASM/Primary/Primary_CE.asm
+++ b/unittests/32Bit_ASM/Primary/Primary_CE.asm
@@ -1,0 +1,15 @@
+%ifdef CONFIG
+{
+  "RegData": {
+  },
+  "Mode": "32BIT"
+}
+%endif
+
+; Clear OF just incase
+test eax, eax
+
+; Just ensure it executes safely
+into
+
+hlt


### PR DESCRIPTION
This instruction is only available on 32-bit x86. On overflow flag set,
this instruction will raise a SIGSEGV with overflow exception set in
siginfo_t's si_code.

This implements the everything required to raise the signal and modify
our signal results that we are giving to the guest.

This is effectively the first step in generating signal frames with
custom data in it but only enough for INTO today.

This is enough for our unit tests doing non-faulting, and also a handwritten C test that recovers from the signal.
Fixes #929 