### PR TITLE
Stop hardcoding /usr/bin paths

### DIFF
--- a/Source/Common/RootFSSetup.cpp
+++ b/Source/Common/RootFSSetup.cpp
@@ -283,13 +283,13 @@ ErrorResult SetupSquashFS(char **const envp) {
       // Child
       close(fds[0]); // Close read end of pipe
       const char *argv[5];
-      argv[0] = FEX_INSTALL_PREFIX "/bin/FEXMountDaemon";
+      argv[0] = "FEXMountDaemon";
       argv[1] = LDPath().c_str();
       argv[2] = TempFolder;
       argv[3] = PipeString.c_str();
       argv[4] = nullptr;
 
-      if (execve(argv[0], (char * const*)argv, envp) == -1) {
+      if (execvpe(argv[0], (char * const*)argv, envp) == -1) {
         // Let the parent know that we couldn't execute for some reason
         uint64_t error{1};
         write(fds[1], &error, sizeof(error));

--- a/Source/Tools/FEXRootFSFetcher/Main.cpp
+++ b/Source/Tools/FEXRootFSFetcher/Main.cpp
@@ -13,7 +13,7 @@ namespace Exec {
   int32_t ExecAndWaitForResponse(const char *path, char* const* args) {
     pid_t pid = fork();
     if (pid == 0) {
-      execv(path, args);
+      execvp(path, args);
       _exit(-1);
     }
     else {
@@ -45,7 +45,7 @@ namespace Exec {
       // We can now close the pipe since the duplications take care of the rest
       close(fd[1]);
 
-      execv(path, args);
+      execvp(path, args);
       _exit(-1);
     }
     else {
@@ -302,7 +302,7 @@ namespace Zenity {
   bool ExecWithQuestion(const std::string &Question) {
     std::string TextArg = "--text=" + Question;
     const char *Args[] = {
-      "/usr/bin/zenity",
+      "zenity",
       "--question",
       TextArg.c_str(),
       nullptr,
@@ -316,7 +316,7 @@ namespace Zenity {
   void ExecWithInfo(const std::string &Text) {
     std::string TextArg = "--text=" + Text;
     const char *Args[] = {
-      "/usr/bin/zenity",
+      "zenity",
       "--info",
       TextArg.c_str(),
       nullptr,
@@ -333,7 +333,7 @@ namespace Zenity {
     std::string TextArg = "--text=" + Text;
 
     std::vector<const char*> ExecveArgs = {
-      "/usr/bin/zenity",
+      "zenity",
       "--list",
       TextArg.c_str(),
       "--hide-header",
@@ -365,7 +365,7 @@ namespace Zenity {
     std::string TextArg = "--text=" + Text;
 
     std::vector<const char*> ExecveArgs = {
-      "/usr/bin/zenity",
+      "zenity",
       "--list",
       TextArg.c_str(),
     };
@@ -738,7 +738,7 @@ namespace UnSquash {
 
     if (Extract) {
       const std::vector<const char*> ExecveArgs = {
-        "/usr/bin/unsquashfs",
+        "unsquashfs",
         "-f",
         "-d",
         TargetFolder.c_str(),


### PR DESCRIPTION
Instead of using execve, use execvpe.
This glibc helper will search PATH or `confstr(_CS_PATH)`

Fixes #1475