### PR TITLE
unittests: Fixes a missing dependency on ASM tests

### DIFF
--- a/unittests/32Bit_ASM/CMakeLists.txt
+++ b/unittests/32Bit_ASM/CMakeLists.txt
@@ -39,6 +39,7 @@ foreach(ASM_SRC ${ASM_SOURCES})
 
   add_custom_command(OUTPUT ${OUTPUT_CONFIG_NAME}
     DEPENDS "${ASM_SRC}"
+    DEPENDS "${OUTPUT_ASM_FOLDER}"
     DEPENDS "${CMAKE_SOURCE_DIR}/Scripts/json_asm_config_parse.py"
     DEPENDS "${CMAKE_SOURCE_DIR}/Scripts/json_config_parse.py"
     COMMAND "python3" ARGS "${CMAKE_SOURCE_DIR}/Scripts/json_asm_config_parse.py" "${ASM_SRC}" "${OUTPUT_CONFIG_NAME}")

--- a/unittests/ASM/CMakeLists.txt
+++ b/unittests/ASM/CMakeLists.txt
@@ -39,6 +39,7 @@ foreach(ASM_SRC ${ASM_SOURCES})
 
   add_custom_command(OUTPUT ${OUTPUT_CONFIG_NAME}
     DEPENDS "${ASM_SRC}"
+    DEPENDS "${OUTPUT_ASM_FOLDER}"
     DEPENDS "${CMAKE_SOURCE_DIR}/Scripts/json_asm_config_parse.py"
     DEPENDS "${CMAKE_SOURCE_DIR}/Scripts/json_config_parse.py"
     COMMAND "python3" ARGS "${CMAKE_SOURCE_DIR}/Scripts/json_asm_config_parse.py" "${ASM_SRC}" "${OUTPUT_CONFIG_NAME}")


### PR DESCRIPTION
The output asm folder needs to be created before the config file can be
generated. Otherwise the python script will fail.