### PR TITLE
FEXCore: Fixes FEXCore_Base config dependency

### DIFF
--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -313,6 +313,7 @@ function(AddDefaultOptionsToTarget Name)
   target_include_directories(${Name} PUBLIC "${CMAKE_BINARY_DIR}/include/")
 
   target_compile_definitions(${Name} PRIVATE ${DEFINES})
+  add_dependencies(${Name} CONFIG_INC)
 
   target_compile_options(${Name}
     PRIVATE
@@ -354,7 +355,6 @@ AddDefaultOptionsToTarget(FEXCore_Base)
 function(AddObject Name Type)
   add_library(${Name} ${Type} ${SRCS})
   add_dependencies(${Name} IR_INC)
-  add_dependencies(${Name} CONFIG_INC)
 
   target_link_libraries(${Name} FEXCore_Base ${LIBS})
   AddDefaultOptionsToTarget(${Name})


### PR DESCRIPTION
This depends on Config. Then everything else links to this, pulling in
the dependency.