### PR TITLE
FEXCore: Don't use Run() inside RunUntilExit()

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -389,8 +389,13 @@ namespace FEXCore::Context {
   }
 
   FEXCore::Context::ExitReason Context::RunUntilExit() {
-    if(!StartPaused)
-      Run();
+    if(!StartPaused) {
+      // We will only have one thread at this point, but just in case run notify everything
+      std::lock_guard lk(ThreadCreationMutex);
+      for (auto &Thread : Threads) {
+        Thread->StartRunning.NotifyAll();
+      }
+    }
 
     ExecutionThread(ParentThread);
     while(true) {

--- a/Source/Tests/LinuxSyscalls/SignalDelegator.cpp
+++ b/Source/Tests/LinuxSyscalls/SignalDelegator.cpp
@@ -301,10 +301,10 @@ namespace FEX::HLE {
   void SignalDelegator::RegisterFrontendTLSState(FEXCore::Core::InternalThreadState *Thread) {
     // Set up our signal alternative stack
     // This is per thread rather than per signal
-    ThreadData.AltStackPtr = FEXCore::Allocator::mmap(nullptr, SIGSTKSZ, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    ThreadData.AltStackPtr = FEXCore::Allocator::mmap(nullptr, SIGSTKSZ * 16, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
     stack_t altstack{};
     altstack.ss_sp = ThreadData.AltStackPtr;
-    altstack.ss_size = SIGSTKSZ;
+    altstack.ss_size = SIGSTKSZ * 16;
     altstack.ss_flags = 0;
     LOGMAN_THROW_A_FMT(!!altstack.ss_sp, "Couldn't allocate stack pointer");
 
@@ -319,7 +319,7 @@ namespace FEX::HLE {
   }
 
   void SignalDelegator::UninstallFrontendTLSState(FEXCore::Core::InternalThreadState *Thread) {
-    FEXCore::Allocator::munmap(ThreadData.AltStackPtr, SIGSTKSZ);
+    FEXCore::Allocator::munmap(ThreadData.AltStackPtr, SIGSTKSZ * 16);
 
     ThreadData.AltStackPtr = nullptr;
 

--- a/unittests/POSIX/Known_Failures
+++ b/unittests/POSIX/Known_Failures
@@ -4,7 +4,6 @@ conformance-interfaces-clock_getcpuclockid-2-1.testconformance-interfaces-clock-
 conformance-interfaces-munmap-2-1.test
 conformance-interfaces-sigqueue-12-1.test
 conformance-interfaces-sigqueue-3-1.test
-conformance-interfaces-sigqueue-7-1.test
 conformance-interfaces-sigqueue-9-1.test
 conformance-interfaces-sigtimedwait-5-1.test
 conformance-interfaces-sigwait-1-1.test
@@ -12,7 +11,6 @@ conformance-interfaces-sigwait-2-1.test
 conformance-interfaces-sigwait-3-1.test
 conformance-interfaces-sigwait-8-1.test
 conformance-interfaces-sigwaitinfo-1-1.test
-conformance-interfaces-sigwaitinfo-2-1.test
 conformance-interfaces-sigwaitinfo-5-1.test
 conformance-interfaces-sigwaitinfo-6-1.test
 conformance-interfaces-sigwaitinfo-9-1.test


### PR DESCRIPTION
Run() is expected to be used after a pause at this point.
Make RunUntilExit() notify using the StartRunning variable entirely.

This is because if we used Run() then the initial thread hasn't yet set
up its core or signal handlers. So it'll ignore SIG63. Then its reason
for pause is still set to Resume.
Once an application tries sending SIG63, we try restoring the context
from a paused state that does exist and crash