### PR TITLE
Linux: Fixes pidfd_send_signal for 32-bit

### DIFF
--- a/Source/Tests/LinuxSyscalls/Syscalls/Signals.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Signals.cpp
@@ -62,15 +62,5 @@ namespace FEX::HLE {
       SYSCALL_ERRNO();
     });
 
-    if (Handler->IsHostKernelVersionAtLeast(5, 1, 0)) {
-      // XXX: siginfo_t definitely isn't correct for 32-bit
-      REGISTER_SYSCALL_IMPL_PASS(pidfd_send_signal, [](FEXCore::Core::CpuStateFrame *Frame, int pidfd, int sig, siginfo_t *info, unsigned int flags) -> uint64_t {
-        uint64_t Result = ::syscall(SYSCALL_DEF(pidfd_send_signal), pidfd, sig, info, flags);
-        SYSCALL_ERRNO();
-      });
-    }
-    else {
-      REGISTER_SYSCALL_IMPL(pidfd_send_signal, UnimplementedSyscallSafe);
-    }
   }
 }

--- a/Source/Tests/LinuxSyscalls/x32/Syscalls.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Syscalls.cpp
@@ -39,7 +39,7 @@ namespace FEX::HLE::x32 {
   void RegisterNotImplemented();
   void RegisterSched();
   void RegisterSemaphore();
-  void RegisterSignals();
+  void RegisterSignals(FEX::HLE::SyscallHandler *const Handler);
   void RegisterSocket();
   void RegisterStubs();
   void RegisterThread();
@@ -144,7 +144,7 @@ namespace FEX::HLE::x32 {
     FEX::HLE::x32::RegisterNotImplemented();
     FEX::HLE::x32::RegisterSched();
     FEX::HLE::x32::RegisterSemaphore();
-    FEX::HLE::x32::RegisterSignals();
+    FEX::HLE::x32::RegisterSignals(this);
     FEX::HLE::x32::RegisterSocket();
     FEX::HLE::x32::RegisterStubs();
     FEX::HLE::x32::RegisterThread();

--- a/Source/Tests/LinuxSyscalls/x64/Syscalls.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Syscalls.cpp
@@ -23,7 +23,7 @@ namespace FEX::HLE::x64 {
   void RegisterSched();
   void RegisterSocket();
   void RegisterSemaphore();
-  void RegisterSignals();
+  void RegisterSignals(FEX::HLE::SyscallHandler *const Handler);
   void RegisterThread();
   void RegisterTime();
   void RegisterNotImplemented();
@@ -135,7 +135,7 @@ namespace FEX::HLE::x64 {
     FEX::HLE::x64::RegisterSched();
     FEX::HLE::x64::RegisterSocket();
     FEX::HLE::x64::RegisterSemaphore();
-    FEX::HLE::x64::RegisterSignals();
+    FEX::HLE::x64::RegisterSignals(this);
     FEX::HLE::x64::RegisterThread();
     FEX::HLE::x64::RegisterTime();
     FEX::HLE::x64::RegisterNotImplemented();


### PR DESCRIPTION
Due to the way this syscall handles siginfo_t, we only need to shift
data through the padding.

This is due to the syscall not allowing you to send siginfo_t with
si_code being positive. Which is what the kernel uses to interpret the
data if it is reinterpreting it.