### PR TITLE
FEXLoader: Resolve the absolute path to rootfs if possible

### DIFF
--- a/Source/Tests/ELFCodeLoader2.h
+++ b/Source/Tests/ELFCodeLoader2.h
@@ -177,7 +177,9 @@ class ELFCodeLoader2 final : public FEXCore::CodeLoader {
     return LoadBase;
   }
 
-  std::string ResolveRootfsFile(std::string File, std::string RootFS) {
+  public:
+
+  static std::string ResolveRootfsFile(std::string const &File, std::string RootFS) {
     // If the path is relative then just run that
     if (std::filesystem::path(File).is_relative()) {
       return File;
@@ -201,7 +203,6 @@ class ELFCodeLoader2 final : public FEXCore::CodeLoader {
     return RootFSLink;
   }
 
-  public:
   struct LoadedSection {
     uintptr_t ElfBase;
     uintptr_t Base;


### PR DESCRIPTION
If the user passes in an absolute path then check to see if it exists in
the rootfs before executing.

Useful for launching applications directly out of the rootfs with
FEXInterpreter.

In the case that the absolute path doesn't exist in the rootfs then
fallback to the host system as usual