### PR TITLE
Linux: Handles the remaining 32-bit siginfo_t usage 

### DIFF
--- a/External/FEXCore/include/FEXCore/Core/UContext.h
+++ b/External/FEXCore/include/FEXCore/Core/UContext.h
@@ -172,6 +172,16 @@ namespace FEXCore {
 
         return val;
       }
+
+      siginfo_t(::siginfo_t val) {
+        si_signo = val.si_signo;
+        si_errno = val.si_errno;
+        si_code = val.si_code;
+
+        // Copy over the union
+        // The union is different sizes on 64-bit versus 32-bit
+        memcpy(val._sifields._pad, _sifields.pad, std::min(sizeof(val._sifields._pad), sizeof(_sifields.pad)));
+      }
     };
     static_assert(sizeof(FEXCore::x86::siginfo_t) == 128, "This needs to be the right size");
 

--- a/Source/Tests/LinuxSyscalls/Syscalls/Signals.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Signals.cpp
@@ -50,17 +50,5 @@ namespace FEX::HLE {
     REGISTER_SYSCALL_IMPL(signalfd4, [](FEXCore::Core::CpuStateFrame *Frame, int fd, const uint64_t *mask, size_t sigsetsize, int flags) -> uint64_t {
       return FEX::HLE::_SyscallHandler->GetSignalDelegator()->GuestSignalFD(fd, mask, sigsetsize, flags);
     });
-
-    REGISTER_SYSCALL_IMPL_PASS(rt_sigqueueinfo, [](FEXCore::Core::CpuStateFrame *Frame, pid_t pid, int sig, siginfo_t *info) -> uint64_t {
-      uint64_t Result = ::syscall(SYSCALL_DEF(rt_sigqueueinfo), pid, sig, info);
-      SYSCALL_ERRNO();
-    });
-
-    // XXX: siginfo_t definitely isn't correct for 32-bit
-    REGISTER_SYSCALL_IMPL_PASS(rt_tgsigqueueinfo, [](FEXCore::Core::CpuStateFrame *Frame, pid_t tgid, pid_t tid, int sig, siginfo_t *info) -> uint64_t {
-      uint64_t Result = ::syscall(SYSCALL_DEF(rt_tgsigqueueinfo), tgid, tid, sig, info);
-      SYSCALL_ERRNO();
-    });
-
   }
 }

--- a/Source/Tests/LinuxSyscalls/x32/Signals.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Signals.cpp
@@ -212,5 +212,29 @@ namespace FEX::HLE::x32 {
     else {
       REGISTER_SYSCALL_IMPL_X32(pidfd_send_signal, UnimplementedSyscallSafe);
     }
+
+    REGISTER_SYSCALL_IMPL_X32_PASS(rt_sigqueueinfo, [](FEXCore::Core::CpuStateFrame *Frame, pid_t pid, int sig, compat_ptr<FEXCore::x86::siginfo_t> info) -> uint64_t {
+      siginfo_t info64{};
+      siginfo_t *info64_p{};
+
+      if (info) {
+        info64_p = &info64;
+      }
+
+      uint64_t Result = ::syscall(SYSCALL_DEF(rt_sigqueueinfo), pid, sig, info64_p);
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X32_PASS(rt_tgsigqueueinfo, [](FEXCore::Core::CpuStateFrame *Frame, pid_t tgid, pid_t tid, int sig, compat_ptr<FEXCore::x86::siginfo_t> info) -> uint64_t {
+      siginfo_t info64{};
+      siginfo_t *info64_p{};
+
+      if (info) {
+        info64_p = &info64;
+      }
+
+      uint64_t Result = ::syscall(SYSCALL_DEF(rt_tgsigqueueinfo), tgid, tid, sig, info64_p);
+      SYSCALL_ERRNO();
+    });
   }
 }

--- a/Source/Tests/LinuxSyscalls/x64/Signals.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Signals.cpp
@@ -40,6 +40,16 @@ namespace FEX::HLE::x64 {
     else {
       REGISTER_SYSCALL_IMPL_X64(pidfd_send_signal, UnimplementedSyscallSafe);
     }
+
+    REGISTER_SYSCALL_IMPL_X64_PASS(rt_sigqueueinfo, [](FEXCore::Core::CpuStateFrame *Frame, pid_t pid, int sig, siginfo_t *info) -> uint64_t {
+      uint64_t Result = ::syscall(SYSCALL_DEF(rt_sigqueueinfo), pid, sig, info);
+      SYSCALL_ERRNO();
+    });
+
+    REGISTER_SYSCALL_IMPL_X64_PASS(rt_tgsigqueueinfo, [](FEXCore::Core::CpuStateFrame *Frame, pid_t tgid, pid_t tid, int sig, siginfo_t *info) -> uint64_t {
+      uint64_t Result = ::syscall(SYSCALL_DEF(rt_tgsigqueueinfo), tgid, tid, sig, info);
+      SYSCALL_ERRNO();
+    });
   }
 }
 


### PR DESCRIPTION
Just need to translate them between 32-bit and 64-bit versions.

Fixes #1254