### PR TITLE
unittests: Fixes ROOTFS needing to be defined prior to cmake

### DIFF
--- a/Scripts/guest_test_runner.py
+++ b/Scripts/guest_test_runner.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+import os
 import sys
 import subprocess
 
@@ -13,6 +14,7 @@ known_failures_file = sys.argv[1]
 expected_output_file = sys.argv[2]
 disabled_tests_file = sys.argv[3]
 test_name = sys.argv[4]
+fexecutable = sys.argv[5]
 
 known_failures = { }
 expected_output = { }
@@ -42,9 +44,16 @@ with open(disabled_tests_file) as dtf:
 # run with timeout to avoid locking up
 RunnerArgs = []
 
+RunnerArgs.append(fexecutable)
+
+ROOTFS_ENV = os.getenv("ROOTFS")
+if ROOTFS_ENV != None:
+    RunnerArgs.append("-R")
+    RunnerArgs.append(ROOTFS_ENV)
+
 # Add the rest of the arguments
-for i in range(len(sys.argv) - 5):
-    RunnerArgs.append(sys.argv[5 + i])
+for i in range(len(sys.argv) - 6):
+    RunnerArgs.append(sys.argv[6 + i])
 
 #print(RunnerArgs)
 

--- a/unittests/POSIX/CMakeLists.txt
+++ b/unittests/POSIX/CMakeLists.txt
@@ -16,7 +16,7 @@ foreach(POSIX_TEST ${POSIX_TESTS})
     "${CMAKE_SOURCE_DIR}/unittests/POSIX/Disabled_Tests"
     "${TEST_NAME}"
     "${CMAKE_BINARY_DIR}/Bin/FEXLoader"
-    "--no-silent" "-c" "irint" "-n" "500" "-R" $ENV{ROOTFS} "--"
+    "--no-silent" "-c" "irint" "-n" "500" "--"
     "${POSIX_TEST}")
 
   add_test(NAME "${TEST_NAME}.jit.posix"
@@ -26,7 +26,7 @@ foreach(POSIX_TEST ${POSIX_TESTS})
     "${CMAKE_SOURCE_DIR}/unittests/POSIX/Disabled_Tests"
     "${TEST_NAME}"
     "${CMAKE_BINARY_DIR}/Bin/FEXLoader"
-    "--no-silent" "-c" "irjit" "-n" "500" "-R" $ENV{ROOTFS} "--"
+    "--no-silent" "-c" "irjit" "-n" "500" "--"
     "${POSIX_TEST}")
 
 endforeach()

--- a/unittests/gcc-target-tests-32/CMakeLists.txt
+++ b/unittests/gcc-target-tests-32/CMakeLists.txt
@@ -18,7 +18,7 @@ foreach(TEST ${TESTS})
     "${CMAKE_SOURCE_DIR}/unittests/gcc-target-tests-32/Disabled_Tests"
     "${TEST_NAME}"
     "${CMAKE_BINARY_DIR}/Bin/FEXLoader"
-    "--no-silent" "-c" "irjit" "-n" "500" "-R" $ENV{ROOTFS} "--"
+    "--no-silent" "-c" "irjit" "-n" "500" "--"
     "${TEST}")
 
 endforeach()

--- a/unittests/gcc-target-tests-64/CMakeLists.txt
+++ b/unittests/gcc-target-tests-64/CMakeLists.txt
@@ -18,7 +18,7 @@ foreach(TEST ${TESTS})
     "${CMAKE_SOURCE_DIR}/unittests/gcc-target-tests-64/Disabled_Tests"
     "${TEST_NAME}"
     "${CMAKE_BINARY_DIR}/Bin/FEXLoader"
-    "--no-silent" "-c" "irjit" "-n" "500" "-R" $ENV{ROOTFS} "--"
+    "--no-silent" "-c" "irjit" "-n" "500" "--"
     "${TEST}")
 
 endforeach()

--- a/unittests/gvisor-tests/CMakeLists.txt
+++ b/unittests/gvisor-tests/CMakeLists.txt
@@ -18,7 +18,7 @@ foreach(TEST ${TESTS})
     "${CMAKE_SOURCE_DIR}/unittests/gvisor-tests/Disabled_Tests"
     "${TEST_NAME}"
     "${CMAKE_BINARY_DIR}/Bin/FEXLoader"
-    "--no-silent" "-c" "irjit" "-n" "500" "-R" $ENV{ROOTFS} "--"
+    "--no-silent" "-c" "irjit" "-n" "500" "--"
     "${TEST}")
 
 endforeach()


### PR DESCRIPTION
cmake will bake in the environment variable in to the build scripts.
Instead have the guest_test_runner fetch it at runtime.

This means if you forget to set ROOTFS prior to running cmake, you can
now set it afterwards and rerun with just ctest instead of a cmake
dance.

Fixes #315