### PR TITLE
SocketLogging: Fixes MsgHandler not syncing with Assert level

### DIFF
--- a/Source/Common/SocketLogging.cpp
+++ b/Source/Common/SocketLogging.cpp
@@ -108,7 +108,7 @@ namespace FEX::SocketLogging {
     static std::unique_ptr<ClientConnector> Client{};
 
     void MsgHandler(LogMan::DebugLevels Level, char const *Message) {
-      Client->MsgHandler(Level, false, Message);
+      Client->MsgHandler(Level, Level == LogMan::DebugLevels::ASSERT, Message);
     }
 
     void AssertHandler(char const *Message) {


### PR DESCRIPTION
AssertHandler by default synchronizes but MsgHandler with Assert level
should also synchronize.

Fixes an issue where LogMan::Msg::AFmt wasn't syncing so the
FEXLogServer would never see the messages.