### PR TITLE
FEXCore: Defer a significant number of ALU flag calculation

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Frontend.h
+++ b/External/FEXCore/Source/Interface/Core/Frontend.h
@@ -35,7 +35,7 @@ public:
 
   uint64_t DecodedMinAddress {};
   uint64_t DecodedMaxAddress {~0ULL};
-  
+
   void SetSectionMaxAddress(uint64_t v) { SectionMaxAddress = v; }
   void SetExternalBranches(std::set<uint64_t> *v) { ExternalBranches = v; }
 private:

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -1425,18 +1425,7 @@ void OpDispatchBuilder::UCOMISxOp(OpcodeArgs) {
     (1 << FCMP_FLAG_LT) |
     (1 << FCMP_FLAG_UNORDERED));
 
-  OrderedNode *HostFlag_CF = _GetHostFlag(Res, FCMP_FLAG_LT);
-  OrderedNode *HostFlag_ZF = _GetHostFlag(Res, FCMP_FLAG_EQ);
-  OrderedNode *HostFlag_Unordered  = _GetHostFlag(Res, FCMP_FLAG_UNORDERED);
-
-  SetRFLAG<FEXCore::X86State::RFLAG_CF_LOC>(HostFlag_CF);
-  SetRFLAG<FEXCore::X86State::RFLAG_ZF_LOC>(HostFlag_ZF);
-  SetRFLAG<FEXCore::X86State::RFLAG_PF_LOC>(HostFlag_Unordered);
-
-  auto ZeroConst = _Constant(0);
-  SetRFLAG<FEXCore::X86State::RFLAG_AF_LOC>(ZeroConst);
-  SetRFLAG<FEXCore::X86State::RFLAG_SF_LOC>(ZeroConst);
-  SetRFLAG<FEXCore::X86State::RFLAG_OF_LOC>(ZeroConst);
+  GenerateFlags_FCMP(Op, Res, Src1, Src2);
 
   flagsOp = SelectionFlag::FCMP;
   flagsOpDest = Src1;
@@ -2198,6 +2187,9 @@ template
 void OpDispatchBuilder::VectorVariableBlend<8>(OpcodeArgs);
 
 void OpDispatchBuilder::PTestOp(OpcodeArgs) {
+  // Invalidate deferred flags early
+  InvalidateDeferredFlags();
+
   auto Size = GetSrcSize(Op);
 
   OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
@@ -685,11 +685,14 @@ void OpDispatchBuilder::FCOMI(OpcodeArgs) {
     SetRFLAG<FEXCore::X86State::X87FLAG_C3_LOC>(HostFlag_ZF);
   }
   else {
+    // Invalidate deferred flags early
+    // OF, SF, AF, PF all undefined
+    InvalidateDeferredFlags();
+
     SetRFLAG<FEXCore::X86State::RFLAG_CF_LOC>(HostFlag_CF);
     SetRFLAG<FEXCore::X86State::RFLAG_ZF_LOC>(HostFlag_ZF);
     SetRFLAG<FEXCore::X86State::RFLAG_PF_LOC>(HostFlag_Unordered);
   }
-
 
   if constexpr (poptwice) {
     // if we are popping then we must first mark this location as empty


### PR DESCRIPTION
This was mainly an optimization around memory usage. ALU ops tend to
bloat the IR quite heavily, but I also noticed a 2-4% uplift in
performance of some applications. So a nice side effect.

Should let us more aggressively target reducing our IR intrusive
allocator size since this is quite reduced.

In a pedantic heavy ALU op code block this reduces the number of IR ops
from 14,756 IR ops to 2,016 prior to optimization.
After optimization both had reduced down to 50 IR ops, proving the
output IR was the same.