### PR TITLE
OpcodeDispatcher: Fixes ptest flags calculation.

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -2233,8 +2233,14 @@ void OpDispatchBuilder::PTestOp(OpcodeArgs) {
   Test2 = _Select(FEXCore::IR::COND_EQ,
       Test2, ZeroConst, OneConst, ZeroConst);
 
+  // Careful, these flags are different between {V,}PTEST and VTESTP{S,D}
   SetRFLAG<FEXCore::X86State::RFLAG_ZF_LOC>(Test1);
   SetRFLAG<FEXCore::X86State::RFLAG_CF_LOC>(Test2);
+
+  SetRFLAG<FEXCore::X86State::RFLAG_AF_LOC>(ZeroConst);
+  SetRFLAG<FEXCore::X86State::RFLAG_SF_LOC>(ZeroConst);
+  SetRFLAG<FEXCore::X86State::RFLAG_OF_LOC>(ZeroConst);
+  SetRFLAG<FEXCore::X86State::RFLAG_PF_LOC>(ZeroConst);
 }
 
 void OpDispatchBuilder::PHMINPOSUWOp(OpcodeArgs) {

--- a/unittests/ASM/H0F38/66_17_2.asm
+++ b/unittests/ASM/H0F38/66_17_2.asm
@@ -1,0 +1,32 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0xFFFFFFFFFFFF43FF",
+    "RBX": "0"
+  }
+}
+%endif
+
+; Set EFLAGS to known value with sahf
+mov rax, -1
+sahf
+
+movups xmm0, [rel .data]
+; Tests a bug that FEX had where ptest would not set OF, SF, AF, PF to zero
+ptest xmm0, xmm0
+
+; Now load back
+; ZF = 1
+; CF = 1
+; OF, SF, AF, PF should be zero
+lahf
+
+; lahf doesn't get OF, get it with seto
+mov rbx, 0
+seto bl
+
+hlt
+
+.data:
+dq 0
+dq 0


### PR DESCRIPTION
We were missing four flags that require setting zero.