### PR TITLE
externals: Update fmt to 8.1.1

### DIFF
--- a/External/FEXCore/Source/Common/JitSymbols.cpp
+++ b/External/FEXCore/Source/Common/JitSymbols.cpp
@@ -23,7 +23,7 @@ namespace FEXCore {
 
     // Linux perf format is very straightforward
     // `<HostPtr> <Size> <Name>\n`
-    fmt::print(fp.get(), "{:x} {:x} JIT_0x{:x}_{:x}\n", HostAddr, CodeSize, GuestAddr, HostAddr);
+    fmt::print(fp.get(), "{} {:x} JIT_0x{:x}_{}\n", HostAddr, CodeSize, GuestAddr, HostAddr);
   }
 
   void JITSymbols::Register(const void *HostAddr, uint32_t CodeSize, std::string_view Name) {
@@ -31,7 +31,7 @@ namespace FEXCore {
 
     // Linux perf format is very straightforward
     // `<HostPtr> <Size> <Name>\n`
-    fmt::print(fp.get(), "{:x} {:x} {}_{:x}\n", HostAddr, CodeSize, Name, HostAddr);
+    fmt::print(fp.get(), "{} {:x} {}_{}\n", HostAddr, CodeSize, Name, HostAddr);
   }
 
   void JITSymbols::RegisterNamedRegion(const void *HostAddr, uint32_t CodeSize, std::string_view Name) {
@@ -39,7 +39,7 @@ namespace FEXCore {
 
     // Linux perf format is very straightforward
     // `<HostPtr> <Size> <Name>\n`
-    fmt::print(fp.get(), "{:x} {:x} {}\n", HostAddr, CodeSize, Name);
+    fmt::print(fp.get(), "{} {:x} {}\n", HostAddr, CodeSize, Name);
   }
 
   void JITSymbols::RegisterJITSpace(const void *HostAddr, uint32_t CodeSize) {
@@ -47,7 +47,7 @@ namespace FEXCore {
 
     // Linux perf format is very straightforward
     // `<HostPtr> <Size> <Name>\n`
-    fmt::print(fp.get(), "{:x} {:x} FEXJIT\n", HostAddr, CodeSize);
+    fmt::print(fp.get(), "{} {:x} FEXJIT\n", HostAddr, CodeSize);
   }
 
 } // namespace FEXCore

--- a/External/FEXCore/include/FEXCore/Debug/X86Tables.h
+++ b/External/FEXCore/include/FEXCore/Debug/X86Tables.h
@@ -7,6 +7,8 @@
 #include <cstring>
 #include <type_traits>
 
+#include <fmt/format.h>
+
 namespace FEXCore::IR {
 ///< Forward declaration of OpDispatchBuilder
 class OpDispatchBuilder;
@@ -513,3 +515,11 @@ extern FEX_DEFAULT_VISIBILITY std::array<X86InstInfo, MAX_XOP_GROUP_TABLE_SIZE> 
 // EVEX
 extern FEX_DEFAULT_VISIBILITY std::array<X86InstInfo, MAX_EVEX_TABLE_SIZE> EVEXTableOps;
 }
+
+template <>
+struct fmt::formatter<FEXCore::X86Tables::DecodedOperand::OpType> : formatter<uint32_t> {
+  template <typename FormatContext>
+  auto format(FEXCore::X86Tables::DecodedOperand::OpType type, FormatContext& ctx) const {
+    return fmt::formatter<uint32_t>::format(static_cast<uint32_t>(type), ctx);
+  }
+};

--- a/Source/Common/SocketLogging.h
+++ b/Source/Common/SocketLogging.h
@@ -1,6 +1,11 @@
 #pragma once
+
 #include <FEXCore/Utils/Event.h>
 #include <FEXCore/Utils/LogManager.h>
+
+#include <functional>
+#include <memory>
+#include <string>
 
 namespace FEX::SocketLogging {
   // Client side

--- a/Source/Tests/IRLoader.cpp
+++ b/Source/Tests/IRLoader.cpp
@@ -61,13 +61,13 @@ void MsgHandler(LogMan::DebugLevels Level, char const *Message)
     break;
   }
 
-  fmt::format("[{}] {}\n", CharLevel, Message);
+  fmt::print("[{}] {}\n", CharLevel, Message);
   fflush(stdout);
 }
 
 void AssertHandler(char const *Message)
 {
-  fmt::format("[ASSERT] {}\n", Message);
+  fmt::print("[ASSERT] {}\n", Message);
   fflush(stdout);
 }
 


### PR DESCRIPTION
Brings along a bunch of enhancements and ensures we always build against the latest version ([Changelog here](https://github.com/fmtlib/fmt/releases))

Also fixes up a few issues that arose due to changes in fmt to keep FEX forwards-compatible with it