### PR TITLE
JIT: Fixes signed displacement wraparound on 32-bit 

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/ALUOps.cpp
@@ -38,7 +38,13 @@ DEF_OP(Constant) {
 
 DEF_OP(EntrypointOffset) {
   auto Op = IROp->C<IR::IROp_EntrypointOffset>();
-  GD = Data->CurrentEntry + Op->Offset;
+  uint64_t Mask = ~0ULL;
+  uint8_t OpSize = IROp->Size;
+  if (OpSize == 4) {
+    Mask = 0xFFFF'FFFFULL;
+  }
+
+  GD = (Data->CurrentEntry + Op->Offset) & Mask;
 }
 
 DEF_OP(InlineConstant) {

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -65,7 +65,13 @@ DEF_OP(EntrypointOffset) {
 
   auto Constant = Entry + Op->Offset;
   auto Dst = GetReg<RA_64>(Node);
-  LoadConstant(Dst, Constant);
+  uint64_t Mask = ~0ULL;
+  uint8_t OpSize = IROp->Size;
+  if (OpSize == 4) {
+    Mask = 0xFFFF'FFFFULL;
+  }
+
+  LoadConstant(Dst, Constant & Mask);
 }
 
 DEF_OP(InlineConstant) {

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -582,7 +582,12 @@ bool Arm64JITCore::IsInlineEntrypointOffset(const IR::OrderedNodeWrapper& WNode,
   if (OpHeader->Op == IR::IROps::OP_INLINEENTRYPOINTOFFSET) {
     auto Op = OpHeader->C<IR::IROp_InlineEntrypointOffset>();
     if (Value) {
-      *Value = Entry + Op->Offset;
+      uint64_t Mask = ~0ULL;
+      uint8_t OpSize = OpHeader->Size;
+      if (OpSize == 4) {
+        Mask = 0xFFFF'FFFFULL;
+      }
+      *Value = (Entry + Op->Offset) & Mask;
     }
     return true;
   } else {

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/ALUOps.cpp
@@ -45,7 +45,13 @@ DEF_OP(EntrypointOffset) {
   auto Op = IROp->C<IR::IROp_EntrypointOffset>();
 
   auto Constant = Entry + Op->Offset;
-  mov(GetDst<RA_64>(Node), Constant);
+  uint64_t Mask = ~0ULL;
+  uint8_t OpSize = IROp->Size;
+  if (OpSize == 4) {
+    Mask = 0xFFFF'FFFFULL;
+  }
+
+  mov(GetDst<RA_64>(Node), Constant & Mask);
 }
 
 DEF_OP(InlineConstant) {

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -553,7 +553,12 @@ bool X86JITCore::IsInlineEntrypointOffset(const IR::OrderedNodeWrapper& WNode, u
   if (OpHeader->Op == IR::IROps::OP_INLINEENTRYPOINTOFFSET) {
     auto Op = OpHeader->C<IR::IROp_InlineEntrypointOffset>();
     if (Value) {
-      *Value = Entry + Op->Offset;
+      uint64_t Mask = ~0ULL;
+      uint8_t OpSize = OpHeader->Size;
+      if (OpSize == 4) {
+        Mask = 0xFFFF'FFFFULL;
+      }
+      *Value = (Entry + Op->Offset) & Mask;
     }
     return true;
   } else {

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -1011,9 +1011,24 @@ void OpDispatchBuilder::CondJUMPOp(OpcodeArgs) {
 
   auto SrcCond = SelectCC(Op->OP & 0xF, TakeBranch, DoNotTakeBranch);
 
+  // Jump instruction only uses up to 32-bit signed displacement
   LOGMAN_THROW_A_FMT(Op->Src[0].IsLiteral(), "Src1 needs to be literal here");
+  int64_t TargetOffset = Op->Src[0].Data.Literal.Value;
+  uint64_t InstRIP = Op->PC + Op->InstSize;
+  uint64_t Target = InstRIP + TargetOffset;
 
-  uint64_t Target = Op->PC + Op->InstSize + Op->Src[0].Data.Literal.Value;
+  if (CTX->GetGPRSize() == 4) {
+    // If the GPRSize is 4 then we need to be careful about PC wrapping
+    if (TargetOffset < 0 && -TargetOffset > InstRIP) {
+      // Invert the signed value if we are underflowing
+      TargetOffset = 0x1'0000'0000ULL + TargetOffset;
+    }
+    else if (TargetOffset >= 0 && Target >= 0x1'0000'0000ULL) {
+      // We are overflowing, wrap around
+      TargetOffset = TargetOffset - 0x1'0000'0000ULL;
+    }
+    Target &= 0xFFFFFFFFU;
+  }
 
   auto TrueBlock = JumpTargets.find(Target);
   auto FalseBlock = JumpTargets.find(Op->PC + Op->InstSize);
@@ -1034,7 +1049,7 @@ void OpDispatchBuilder::CondJUMPOp(OpcodeArgs) {
       SetTrueJumpTarget(CondJump, JumpTarget);
       SetCurrentCodeBlock(JumpTarget);
 
-      auto NewRIP = GetDynamicPC(Op, Op->Src[0].Data.Literal.Value);
+      auto NewRIP = GetDynamicPC(Op, TargetOffset);
 
       // Store the new RIP
       _ExitFunction(NewRIP);
@@ -1199,13 +1214,31 @@ void OpDispatchBuilder::LoopOp(OpcodeArgs) {
 void OpDispatchBuilder::JUMPOp(OpcodeArgs) {
   BlockSetRIP = true;
 
+  // Jump instruction only uses up to 32-bit signed displacement
+  LOGMAN_THROW_A_FMT(Op->Src[0].IsLiteral(), "Src1 needs to be literal here");
+  int64_t TargetOffset = Op->Src[0].Data.Literal.Value;
+  uint64_t InstRIP = Op->PC + Op->InstSize;
+  uint64_t TargetRIP = InstRIP + TargetOffset;
+
+  if (CTX->GetGPRSize() == 4) {
+    // If the GPRSize is 4 then we need to be careful about PC wrapping
+    if (TargetOffset < 0 && -TargetOffset > InstRIP) {
+      // Invert the signed value if we are underflowing
+      TargetOffset = 0x1'0000'0000ULL + TargetOffset;
+    }
+    else if (TargetOffset >= 0 && TargetRIP >= 0x1'0000'0000ULL) {
+      // We are overflowing, wrap around
+      TargetOffset = TargetOffset - 0x1'0000'0000ULL;
+    }
+
+    TargetRIP &= 0xFFFFFFFFU;
+  }
+
   // This is just an unconditional relative literal jump
   if (Multiblock) {
-    LOGMAN_THROW_A_FMT(Op->Src[0].IsLiteral(), "Src1 needs to be literal here");
-    uint64_t Target = Op->PC + Op->InstSize + Op->Src[0].Data.Literal.Value;
-    auto JumpBlock = JumpTargets.find(Target);
+    auto JumpBlock = JumpTargets.find(TargetRIP);
     if (JumpBlock != JumpTargets.end()) {
-      _Jump(GetNewJumpBlock(Target));
+      _Jump(GetNewJumpBlock(TargetRIP));
     }
     else {
       // If the block isn't a jump target then we need to create an exit block
@@ -1215,18 +1248,15 @@ void OpDispatchBuilder::JUMPOp(OpcodeArgs) {
       auto JumpTarget = CreateNewCodeBlockAfter(GetCurrentBlock());
       SetJumpTarget(Jump, JumpTarget);
       SetCurrentCodeBlock(JumpTarget);
-      _ExitFunction(GetDynamicPC(Op, Op->Src[0].Data.Literal.Value));
+      _ExitFunction(GetDynamicPC(Op, TargetOffset));
     }
     return;
   }
 
   // Fallback
   {
-    // This source is a literal
-    auto RIPOffset = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
-
     auto RIPTargetConst = GetDynamicPC(Op);
-    auto NewRIP = _Add(RIPOffset, RIPTargetConst);
+    auto NewRIP = _Add(_Constant(TargetOffset), RIPTargetConst);
 
     // Store the new RIP
     _ExitFunction(NewRIP);

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -79,7 +79,7 @@ void OpDispatchBuilder::SyscallOp(OpcodeArgs) {
   }
 
   const uint8_t GPRSize = CTX->GetGPRSize();
-  auto NewRIP = GetDynamicPC(Op, -Op->InstSize);
+  auto NewRIP = GetRelocatedPC(Op, -Op->InstSize);
   _StoreContext(GPRClass, GPRSize, offsetof(FEXCore::Core::CPUState, rip), NewRIP);
 
   const auto& GPRIndicesRef = *GPRIndexes;
@@ -708,12 +708,12 @@ void OpDispatchBuilder::CALLOp(OpcodeArgs) {
     _InvalidateFlags(~0UL); // all flags
   }
 
-  auto ConstantPC = GetDynamicPC(Op);
+  auto ConstantPC = GetRelocatedPC(Op);
 
   OrderedNode *JMPPCOffset = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
 
   OrderedNode *NewRIP = _Add(ConstantPC, JMPPCOffset);
-  auto ConstantPCReturn = GetDynamicPC(Op);
+  auto ConstantPCReturn = GetRelocatedPC(Op);
 
   auto ConstantSize = _Constant(GPRSize);
   auto OldSP = _LoadContext(GPRSize, RSPOffset, GPRClass);
@@ -738,7 +738,7 @@ void OpDispatchBuilder::CALLAbsoluteOp(OpcodeArgs) {
   const uint8_t Size = GetSrcSize(Op);
   OrderedNode *JMPPCOffset = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
 
-  auto ConstantPCReturn = GetDynamicPC(Op);
+  auto ConstantPCReturn = GetRelocatedPC(Op);
 
   auto ConstantSize = _Constant(Size);
   auto OldSP = _LoadContext(GPRSize, RSPOffset, GPRClass);
@@ -1049,7 +1049,7 @@ void OpDispatchBuilder::CondJUMPOp(OpcodeArgs) {
       SetTrueJumpTarget(CondJump, JumpTarget);
       SetCurrentCodeBlock(JumpTarget);
 
-      auto NewRIP = GetDynamicPC(Op, TargetOffset);
+      auto NewRIP = GetRelocatedPC(Op, TargetOffset);
 
       // Store the new RIP
       _ExitFunction(NewRIP);
@@ -1067,7 +1067,7 @@ void OpDispatchBuilder::CondJUMPOp(OpcodeArgs) {
       SetCurrentCodeBlock(JumpTarget);
 
       // Leave block
-      auto RIPTargetConst = GetDynamicPC(Op);
+      auto RIPTargetConst = GetRelocatedPC(Op);
 
       // Store the new RIP
       _ExitFunction(RIPTargetConst);
@@ -1109,7 +1109,7 @@ void OpDispatchBuilder::CondJUMPRCXOp(OpcodeArgs) {
       SetTrueJumpTarget(CondJump, JumpTarget);
       SetCurrentCodeBlock(JumpTarget);
 
-      auto NewRIP = GetDynamicPC(Op, Op->Src[0].Data.Literal.Value);
+      auto NewRIP = GetRelocatedPC(Op, Op->Src[0].Data.Literal.Value);
 
       // Store the new RIP
       _ExitFunction(NewRIP);
@@ -1127,7 +1127,7 @@ void OpDispatchBuilder::CondJUMPRCXOp(OpcodeArgs) {
       SetCurrentCodeBlock(JumpTarget);
 
       // Leave block
-      auto RIPTargetConst = GetDynamicPC(Op);
+      auto RIPTargetConst = GetRelocatedPC(Op);
 
       // Store the new RIP
       _ExitFunction(RIPTargetConst);
@@ -1185,7 +1185,7 @@ void OpDispatchBuilder::LoopOp(OpcodeArgs) {
       SetTrueJumpTarget(CondJump, JumpTarget);
       SetCurrentCodeBlock(JumpTarget);
 
-      auto NewRIP = GetDynamicPC(Op, Op->Src[1].Data.Literal.Value);
+      auto NewRIP = GetRelocatedPC(Op, Op->Src[1].Data.Literal.Value);
 
       // Store the new RIP
       _ExitFunction(NewRIP);
@@ -1203,7 +1203,7 @@ void OpDispatchBuilder::LoopOp(OpcodeArgs) {
       SetCurrentCodeBlock(JumpTarget);
 
       // Leave block
-      auto RIPTargetConst = GetDynamicPC(Op);
+      auto RIPTargetConst = GetRelocatedPC(Op);
 
       // Store the new RIP
       _ExitFunction(RIPTargetConst);
@@ -1248,14 +1248,14 @@ void OpDispatchBuilder::JUMPOp(OpcodeArgs) {
       auto JumpTarget = CreateNewCodeBlockAfter(GetCurrentBlock());
       SetJumpTarget(Jump, JumpTarget);
       SetCurrentCodeBlock(JumpTarget);
-      _ExitFunction(GetDynamicPC(Op, TargetOffset));
+      _ExitFunction(GetRelocatedPC(Op, TargetOffset));
     }
     return;
   }
 
   // Fallback
   {
-    auto RIPTargetConst = GetDynamicPC(Op);
+    auto RIPTargetConst = GetRelocatedPC(Op);
     auto NewRIP = _Add(_Constant(TargetOffset), RIPTargetConst);
 
     // Store the new RIP
@@ -4686,7 +4686,7 @@ OrderedNode *OpDispatchBuilder::LoadSource_WithOpSize(FEXCore::IR::RegisterClass
   }
   else if (Operand.IsRIPRelative()) {
     if (CTX->Config.Is64BitMode) {
-      Src = GetDynamicPC(Op, Operand.Data.RIPLiteral.Value.s);
+      Src = GetRelocatedPC(Op, Operand.Data.RIPLiteral.Value.s);
     }
     else {
       // 32bit this isn't RIP relative but instead absolute
@@ -4761,7 +4761,7 @@ OrderedNode *OpDispatchBuilder::LoadSource_WithOpSize(FEXCore::IR::RegisterClass
   return Src;
 }
 
-OrderedNode *OpDispatchBuilder::GetDynamicPC(FEXCore::X86Tables::DecodedOp const& Op, int64_t Offset) {
+OrderedNode *OpDispatchBuilder::GetRelocatedPC(FEXCore::X86Tables::DecodedOp const& Op, int64_t Offset) {
   const uint8_t GPRSize = CTX->GetGPRSize();
   return _EntrypointOffset(Op->PC + Op->InstSize + Offset - Entry, GPRSize);
 }
@@ -4830,7 +4830,7 @@ void OpDispatchBuilder::StoreResult_WithOpSize(FEXCore::IR::RegisterClassType Cl
   }
   else if (Operand.IsRIPRelative()) {
     if (CTX->Config.Is64BitMode) {
-      MemStoreDst = GetDynamicPC(Op, Operand.Data.RIPLiteral.Value.s);
+      MemStoreDst = GetRelocatedPC(Op, Operand.Data.RIPLiteral.Value.s);
     }
     else {
       // 32bit this isn't RIP relative but instead absolute
@@ -5110,7 +5110,7 @@ void OpDispatchBuilder::INTOp(OpcodeArgs) {
     BlockSetRIP = setRIP;
 
     // We want to set RIP to the next instruction after HLT/INT3
-    auto NewRIP = GetDynamicPC(Op);
+    auto NewRIP = GetRelocatedPC(Op);
     _StoreContext(GPRClass, GPRSize, offsetof(FEXCore::Core::CPUState, rip), NewRIP);
   }
 
@@ -5123,7 +5123,7 @@ void OpDispatchBuilder::INTOp(OpcodeArgs) {
     SetFalseJumpTarget(CondJump, FalseBlock);
     SetCurrentCodeBlock(FalseBlock);
 
-    auto NewRIP = GetDynamicPC(Op);
+    auto NewRIP = GetRelocatedPC(Op);
     _StoreContext(GPRClass, GPRSize, offsetof(FEXCore::Core::CPUState, rip), NewRIP);
     _Break(Reason, Literal);
 
@@ -5224,7 +5224,7 @@ void OpDispatchBuilder::UnimplementedOp(OpcodeArgs) {
 
   // We don't actually support this instruction
   // Multiblock may hit it though
-  _StoreContext(GPRClass, GPRSize, offsetof(FEXCore::Core::CPUState, rip), GetDynamicPC(Op, -Op->InstSize));
+  _StoreContext(GPRClass, GPRSize, offsetof(FEXCore::Core::CPUState, rip), GetRelocatedPC(Op, -Op->InstSize));
   _Break(FEXCore::IR::Break_Unimplemented, 0);
   BlockSetRIP = true;
 
@@ -5237,7 +5237,7 @@ void OpDispatchBuilder::InvalidOp(OpcodeArgs) {
 
   // We don't actually support this instruction
   // Multiblock may hit it though
-  _StoreContext(GPRClass, GPRSize, offsetof(FEXCore::Core::CPUState, rip), GetDynamicPC(Op, -Op->InstSize));
+  _StoreContext(GPRClass, GPRSize, offsetof(FEXCore::Core::CPUState, rip), GetRelocatedPC(Op, -Op->InstSize));
   _Break(FEXCore::IR::Break_InvalidInstruction, 0);
   BlockSetRIP = true;
 }

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -519,7 +519,7 @@ private:
 
   OrderedNode *AppendSegmentOffset(OrderedNode *Value, uint32_t Flags, uint32_t DefaultPrefix = 0, bool Override = false);
 
-  OrderedNode *GetDynamicPC(FEXCore::X86Tables::DecodedOp const& Op, int64_t Offset = 0);
+  OrderedNode *GetRelocatedPC(FEXCore::X86Tables::DecodedOp const& Op, int64_t Offset = 0);
   OrderedNode *LoadSource(FEXCore::IR::RegisterClassType Class, FEXCore::X86Tables::DecodedOp const& Op, FEXCore::X86Tables::DecodedOperand const& Operand, uint32_t Flags, int8_t Align, bool LoadData = true, bool ForceLoad = false);
   OrderedNode *LoadSource_WithOpSize(FEXCore::IR::RegisterClassType Class, FEXCore::X86Tables::DecodedOp const& Op, FEXCore::X86Tables::DecodedOperand const& Operand, uint8_t OpSize, uint32_t Flags, int8_t Align, bool LoadData = true, bool ForceLoad = false);
   void StoreResult_WithOpSize(FEXCore::IR::RegisterClassType Class, FEXCore::X86Tables::DecodedOp Op, FEXCore::X86Tables::DecodedOperand const& Operand, OrderedNode *const Src, uint8_t OpSize, int8_t Align);

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -306,7 +306,9 @@
     },
 
     "EntrypointOffset": {
-      "Desc": ["Returns the <entrypoint> + Offset address"],
+      "Desc": ["Returns the <entrypoint> + Offset address",
+               "When the size is 4 bytes then 32-bit overflow and underflow needs to work"
+              ],
       "OpClass": "ALU",
       "HasDest": true,
       "DestClass": "GPR",
@@ -320,7 +322,9 @@
     },
 
     "InlineEntrypointOffset": {
-      "Desc": ["Returns the <entrypoint> + Offset address"],
+      "Desc": ["Returns the <entrypoint> + Offset address",
+               "When the size is 4 bytes then 32-bit overflow and underflow needs to work"
+              ],
       "OpClass": "ALU",
       "DestSize": "RegisterSize",
       "Args": [

--- a/unittests/32Bit_ASM/Primary/Primary_E8.asm
+++ b/unittests/32Bit_ASM/Primary/Primary_E8.asm
@@ -1,0 +1,44 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x41424344"
+  },
+  "Mode": "32BIT"
+}
+%endif
+
+; Tests for 32-bit signed displacement wrapping
+; Testing for underflow specifically
+; Will crash or hit the code we emit to memory
+
+; We map ten pages to 0xe000'0000
+; Generate a mov eax + hlt over there first
+; 0xb8'44'43'42'41: mov eax, 0x41424344
+; 0xf4: hlt
+
+mov ebx, 0xe0000000
+mov al, 0xb8
+mov byte [ebx], al
+mov eax, 0x41424344
+mov dword [ebx + 1], eax
+mov al, 0xf4
+mov byte [ebx + 5], al
+
+; Do a jump dance to stop multiblock from trying to optimize
+; Otherwise it will JIT code from 0xe000'0000 before written
+lea ebx, [rel next]
+jmp ebx
+next:
+
+; Move temp to eax to overwrite
+mov eax, 0
+
+; Setup esp
+mov esp, 0xe0001000
+
+; This is dependent on where it is in the code!
+call -0x20000000
+
+; Definitely wrong if we hit here
+mov eax, -1
+hlt

--- a/unittests/32Bit_ASM/Primary/Primary_E8_2.asm
+++ b/unittests/32Bit_ASM/Primary/Primary_E8_2.asm
@@ -1,0 +1,50 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x41424344"
+  },
+  "Mode": "32BIT"
+}
+%endif
+
+; Tests for 32-bit signed displacement wrapping
+; Testing for overflow specifically
+; Will crash or hit the code we emit to memory
+
+; We map ten pages to 0xe000'0000
+; Generate a call 0x11000 over there
+; 0xe8'fb'0f'01'20 : call 0x11000
+; 0xf4: hlt - Just in case
+
+mov ebx, 0xe0000000
+mov al, 0xe8
+mov byte [ebx], al
+mov eax, 0x20010ffb
+mov dword [ebx + 1], eax
+mov al, 0xf4
+mov byte [ebx + 5], al
+
+; Do a jump dance to stop multiblock from trying to optimize
+; Otherwise it will JIT code from 0xe000'0000 before written
+lea ebx, [rel next]
+jmp ebx
+next:
+
+; Move temp to eax to overwrite
+mov eax, 0
+
+; Setup esp
+mov esp, 0xe0001000
+
+; This is dependent on where it is in the code!
+call -0x20000000
+
+; Definitely wrong if we hit here
+mov eax, -1
+hlt
+
+; This is where the JIT code will land
+align 0x1000
+
+mov eax, 0x41424344
+hlt

--- a/unittests/32Bit_ASM/Primary/Primary_E9.asm
+++ b/unittests/32Bit_ASM/Primary/Primary_E9.asm
@@ -1,0 +1,41 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x41424344"
+  },
+  "Mode": "32BIT"
+}
+%endif
+
+; Tests for 32-bit signed displacement wrapping
+; Testing for underflow specifically
+; Will crash or hit the code we emit to memory
+
+; We map ten pages to 0xe000'0000
+; Generate a mov eax + hlt over there first
+; 0xb8'44'43'42'41: mov eax, 0x41424344
+; 0xf4: hlt
+
+mov ebx, 0xe0000000
+mov al, 0xb8
+mov byte [ebx], al
+mov eax, 0x41424344
+mov dword [ebx + 1], eax
+mov al, 0xf4
+mov byte [ebx + 5], al
+
+; Do a jump dance to stop multiblock from trying to optimize
+; Otherwise it will JIT code from 0xe000'0000 before written
+lea ebx, [rel next]
+jmp ebx
+next:
+
+; Move temp to eax to overwrite
+mov eax, 0
+
+; This is dependent on where it is in the code!
+jmp -0x20000000
+
+; Definitely wrong if we hit here
+mov eax, -1
+hlt

--- a/unittests/32Bit_ASM/Primary/Primary_E9_2.asm
+++ b/unittests/32Bit_ASM/Primary/Primary_E9_2.asm
@@ -1,0 +1,48 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x41424344"
+  },
+  "Mode": "32BIT"
+}
+%endif
+
+; Tests for 32-bit signed displacement wrapping
+; Testing for overflow specifically
+; Will crash or hit the code we emit to memory
+
+; We map ten pages to 0xe000'0000
+; Generate a jmp 0x11000 over there
+; 0xe9'fb'0f'01'20 : jmp 0x11000
+; 0xf4: hlt - Just in case
+
+mov ebx, 0xe0000000
+mov al, 0xe9
+mov byte [ebx], al
+mov eax, 0x20010ffb
+mov dword [ebx + 1], eax
+mov al, 0xf4
+mov byte [ebx + 5], al
+
+; Do a jump dance to stop multiblock from trying to optimize
+; Otherwise it will JIT code from 0xe000'0000 before written
+lea ebx, [rel next]
+jmp ebx
+next:
+
+; Move temp to eax to overwrite
+mov eax, 0
+
+; This is dependent on where it is in the code!
+jmp -0x20000000
+
+; Definitely wrong if we hit here
+mov eax, -1
+hlt
+
+
+; This is where the JIT code will land
+align 0x1000
+
+mov eax, 0x41424344
+hlt

--- a/unittests/32Bit_ASM/TwoByte/0F_82.asm
+++ b/unittests/32Bit_ASM/TwoByte/0F_82.asm
@@ -1,0 +1,44 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x41424344"
+  },
+  "Mode": "32BIT"
+}
+%endif
+
+; Tests for 32-bit signed displacement wrapping
+; Testing for underflow specifically
+; Will crash or hit the code we emit to memory
+
+; We map ten pages to 0xe000'0000
+; Generate a mov eax + hlt over there first
+; 0xb8'44'43'42'41: mov eax, 0x41424344
+; 0xf4: hlt
+
+mov ebx, 0xe0000000
+mov al, 0xb8
+mov byte [ebx], al
+mov eax, 0x41424344
+mov dword [ebx + 1], eax
+mov al, 0xf4
+mov byte [ebx + 5], al
+
+; Do a jump dance to stop multiblock from trying to optimize
+; Otherwise it will JIT code from 0xe000'0000 before written
+lea ebx, [rel next]
+jmp ebx
+next:
+
+; Move temp to eax to overwrite
+mov eax, 0
+
+; Clear the lower flags so the branch gets taken
+sahf
+
+; This is dependent on where it is in the code!
+jnb -0x20000000
+
+; Definitely wrong if we hit here
+mov eax, -1
+hlt

--- a/unittests/32Bit_ASM/TwoByte/0F_82_2.asm
+++ b/unittests/32Bit_ASM/TwoByte/0F_82_2.asm
@@ -1,0 +1,50 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x41424344"
+  },
+  "Mode": "32BIT"
+}
+%endif
+
+; Tests for 32-bit signed displacement wrapping
+; Testing for overflow specifically
+; Will crash or hit the code we emit to memory
+
+; We map ten pages to 0xe000'0000
+; Generate a call 0x11000 over there
+; 0x0f'83'fa'0f'01'20 : jnb 0x11000
+; 0xf4: hlt - Just in case
+
+mov ebx, 0xe0000000
+mov ax, 0x830f
+mov word [ebx], ax
+mov eax, 0x20010ffa
+mov dword [ebx + 2], eax
+mov al, 0xf4
+mov byte [ebx + 6], al
+
+; Do a jump dance to stop multiblock from trying to optimize
+; Otherwise it will JIT code from 0xe000'0000 before written
+lea ebx, [rel next]
+jmp ebx
+next:
+
+; Move temp to eax to overwrite
+mov eax, 0
+
+; Clear the lower flags so the branch gets taken
+sahf
+
+; This is dependent on where it is in the code!
+jnb -0x20000000
+
+; Definitely wrong if we hit here
+mov eax, -1
+hlt
+
+; This is where the JIT code will land
+align 0x1000
+
+mov eax, 0x41424344
+hlt


### PR DESCRIPTION
This cropped up mostly with multiblock and `jmp <signed displacement>`
This also happened with non multiblock `jcc <signed displacement>`

Due to how IR relocations occur, this needs to happen fairly late but
isn't a big deal.

Fixes #1517