### PR TITLE
FEXRootFSFetcher: Fixes some edge case behaviours 

### DIFF
--- a/Source/Tools/FEXRootFSFetcher/Main.cpp
+++ b/Source/Tools/FEXRootFSFetcher/Main.cpp
@@ -27,21 +27,31 @@ namespace Exec {
     return -1;
   }
 
-  int32_t ExecAndWaitForResponseRedirect(const char *path, char* const* args, int stdoutRedirect = STDOUT_FILENO, int stderrRedirect = STDERR_FILENO) {
+  int32_t ExecAndWaitForResponseRedirect(const char *path, char* const* args, int stdoutRedirect = -2, int stderrRedirect = -2) {
     pid_t pid = fork();
     if (pid == 0) {
       if (stdoutRedirect == -1) {
         close(STDOUT_FILENO);
       }
-      else if (stdoutRedirect != STDOUT_FILENO) {
-        close(STDOUT_FILENO);
+      else if (stdoutRedirect == -2) {
+        // Do nothing
+      }
+      else {
+        if (stdoutRedirect != STDOUT_FILENO) {
+          close(STDOUT_FILENO);
+        }
         dup2(stdoutRedirect, STDOUT_FILENO);
       }
       if (stderrRedirect == -1) {
         close(STDERR_FILENO);
       }
-      else if (stderrRedirect != STDOUT_FILENO) {
-        close(STDERR_FILENO);
+      else if (stderrRedirect == -2) {
+        // Do nothing
+      }
+      else {
+        if (stderrRedirect != STDOUT_FILENO) {
+          close(STDERR_FILENO);
+        }
         dup2(stderrRedirect, STDERR_FILENO);
       }
       execvp(path, args);


### PR DESCRIPTION
Makes curl do its continue feature to give the users the best chance of
downloading a rootfs. We don't need to restart the full file transfer on
failure. Helps people with slower connections.

On failure to download, asks the user if they want to retry the download
rather than just exiting with a weird error about hash failure.

Once the image is downloaded, now changes options depending on if
squashfuse or unsquashfs works.

Prevents the user from selecting a bad option and getting unexpected
behaviour. Ideally we would do a squashfs mount test as well for
platforms that don't have working FUSE, like termux. This is harder to
get right and its for an unsupported platform, so I'm not going to
invest more time with it.

Fixes #1525
Fixes #1526
Fixes #1527