### PR TITLE
Softfloat: Stop doing special handling for FREM

### DIFF
--- a/External/FEXCore/Source/Common/SoftFloat.h
+++ b/External/FEXCore/Source/Common/SoftFloat.h
@@ -57,22 +57,107 @@ struct X80SoftFloat {
 
   // Ops
   static X80SoftFloat FADD(X80SoftFloat const &lhs, X80SoftFloat const &rhs) {
+#ifdef DEBUG_X86_FLOAT
+    BIGFLOAT Result;
+    asm (R"(
+    fninit;
+    fldt %[rhs]; # st1
+    fldt %[lhs]; # st0
+    faddp;
+    fstpt %[result];
+    )"
+    : [result] "=m" (Result)
+    : [lhs] "m" (lhs)
+    , [rhs] "m" (rhs)
+    : "st", "st(1)");
+
+    return Result;
+#else
     return extF80_add(lhs, rhs);
+#endif
   }
 
   static X80SoftFloat FSUB(X80SoftFloat const &lhs, X80SoftFloat const &rhs) {
+#ifdef DEBUG_X86_FLOAT
+    BIGFLOAT Result;
+    asm (R"(
+    fninit;
+    fldt %[rhs]; # st1
+    fldt %[lhs]; # st0
+    fsubp;
+    fstpt %[result];
+    )"
+    : [result] "=m" (Result)
+    : [lhs] "m" (lhs)
+    , [rhs] "m" (rhs)
+    : "st", "st(1)");
+
+    return Result;
+#else
     return extF80_sub(lhs, rhs);
+#endif
   }
 
   static X80SoftFloat FMUL(X80SoftFloat const &lhs, X80SoftFloat const &rhs) {
+#ifdef DEBUG_X86_FLOAT
+    BIGFLOAT Result;
+    asm (R"(
+    fninit;
+    fldt %[rhs]; # st1
+    fldt %[lhs]; # st0
+    fmulp;
+    fstpt %[result];
+    )"
+    : [result] "=m" (Result)
+    : [lhs] "m" (lhs)
+    , [rhs] "m" (rhs)
+    : "st", "st(1)");
+
+    return Result;
+#else
     return extF80_mul(lhs, rhs);
+#endif
   }
 
   static X80SoftFloat FDIV(X80SoftFloat const &lhs, X80SoftFloat const &rhs) {
+#ifdef DEBUG_X86_FLOAT
+    BIGFLOAT Result;
+    asm (R"(
+    fninit;
+    fldt %[rhs]; # st1
+    fldt %[lhs]; # st0
+    fdivp;
+    fstpt %[result];
+    )"
+    : [result] "=m" (Result)
+    : [lhs] "m" (lhs)
+    , [rhs] "m" (rhs)
+    : "st", "st(1)");
+
+    return Result;
+#else
     return extF80_div(lhs, rhs);
+#endif
   }
 
   static X80SoftFloat FREM(X80SoftFloat const &lhs, X80SoftFloat const &rhs) {
+#if defined(DEBUG_X86_FLOAT)
+    BIGFLOAT Result;
+    asm (R"(
+    fninit;
+    fldt %[rhs]; # st1
+    fldt %[lhs]; # st0
+    fprem;
+    fstpt %[result];
+    ffreep %%st(0);
+    )"
+    : [result] "=m" (Result)
+    : [lhs] "m" (lhs)
+    , [rhs] "m" (rhs)
+    : "st", "st(1)");
+
+    return Result;
+#else
     X80SoftFloat Rem = extF80_rem(lhs, rhs);
     if (SignBit(Rem)) {
       Rem = extF80_add(Rem, rhs);
@@ -82,10 +167,29 @@ struct X80SoftFloat {
     }
 
     return Rem;
+#endif
   }
 
   static X80SoftFloat FREM1(X80SoftFloat const &lhs, X80SoftFloat const &rhs) {
+#if defined(DEBUG_X86_FLOAT)
+    BIGFLOAT Result;
+    asm (R"(
+    fninit;
+    fldt %[rhs]; # st1
+    fldt %[lhs]; # st0
+    fprem1;
+    fstpt %[result];
+    ffreep %%st(0);
+    )"
+    : [result] "=m" (Result)
+    : [lhs] "m" (lhs)
+    , [rhs] "m" (rhs)
+    : "st", "st(1)");
+
+    return Result;
+#else
     return extF80_rem(lhs, rhs);
+#endif
   }
 
   static X80SoftFloat FRNDINT(X80SoftFloat const &lhs) {
@@ -93,15 +197,47 @@ struct X80SoftFloat {
   }
 
   static X80SoftFloat FXTRACT_SIG(X80SoftFloat const &lhs) {
+#if defined(DEBUG_X86_FLOAT)
+    BIGFLOAT Result;
+    asm (R"(
+    fninit;
+    fldt %[lhs]; # st0
+    fxtract;
+    fstpt %[result];
+    ffreep %%st(0);
+    )"
+    : [result] "=m" (Result)
+    : [lhs] "m" (lhs)
+    : "st", "st(1)");
+
+    return Result;
+#else
     X80SoftFloat Tmp = lhs;
     Tmp.Exponent = 0x3FFF;
     Tmp.Sign = lhs.Sign;
     return Tmp;
+#endif
   }
 
   static X80SoftFloat FXTRACT_EXP(X80SoftFloat const &lhs) {
+#if defined(DEBUG_X86_FLOAT)
+    BIGFLOAT Result;
+    asm (R"(
+    fninit;
+    fldt %[lhs]; # st0
+    fxtract;
+    ffreep %%st(0);
+    fstpt %[result];
+    )"
+    : [result] "=m" (Result)
+    : [lhs] "m" (lhs)
+    : "st", "st(1)");
+
+    return Result;
+#else
     int32_t TrueExp = lhs.Exponent - ExponentBias;
     return i32_to_extF80(TrueExp);
+#endif
   }
 
   static void FCMP(X80SoftFloat const &lhs, X80SoftFloat const &rhs, bool *eq, bool *lt, bool *nan) {
@@ -112,61 +248,189 @@ struct X80SoftFloat {
 
   static X80SoftFloat FSCALE(X80SoftFloat const &lhs, X80SoftFloat const &rhs) {
     WARN_ONCE_FMT("x87: Application used FSCALE which may have accuracy problems");
+#ifdef DEBUG_X86_FLOAT
+    BIGFLOAT Result;
+    asm (R"(
+    fninit;
+    fldt %[rhs]; # st1
+    fldt %[lhs]; # st0
+    fscale; # st0 = st0 * 2^(rdint(st1))
+    fstpt %[result];
+    ffreep %%st(0);
+    )"
+    : [result] "=m" (Result)
+    : [lhs] "m" (lhs)
+    , [rhs] "m" (rhs)
+    : "st", "st(1)");
+
+    return Result;
+#else
     X80SoftFloat Int = FRNDINT(rhs);
     BIGFLOAT Src2_d = Int;
     Src2_d = exp2l(Src2_d);
     X80SoftFloat Src2_X80 = Src2_d;
     X80SoftFloat Result = extF80_mul(lhs, Src2_X80);
     return Result;
+#endif
   }
 
   static X80SoftFloat F2XM1(X80SoftFloat const &lhs) {
     WARN_ONCE_FMT("x87: Application used F2XM1 which may have accuracy problems");
+#ifdef DEBUG_X86_FLOAT
+    BIGFLOAT Result;
+    asm (R"(
+    fninit;
+    fldt %[lhs]; # st0
+    f2xm1; # st0 = 2^st(0) - 1
+    fstpt %[result];
+    )"
+    : [result] "=m" (Result)
+    : [lhs] "m" (lhs)
+    : "st");
+
+    return Result;
+#else
     BIGFLOAT Src1_d = lhs;
     BIGFLOAT Result = exp2l(Src1_d);
     Result -= 1.0;
     return Result;
+#endif
   }
 
   static X80SoftFloat FYL2X(X80SoftFloat const &lhs, X80SoftFloat const &rhs) {
     WARN_ONCE_FMT("x87: Application used FYL2X which may have accuracy problems");
+#ifdef DEBUG_X86_FLOAT
+    BIGFLOAT Result;
+    asm (R"(
+    fninit;
+    fldt %[rhs]; # st(1)
+    fldt %[lhs]; # st(0)
+    fyl2x; # st(1) * log2l(st(0))
+    fstpt %[result];
+    )"
+    : [result] "=m" (Result)
+    : [lhs] "m" (lhs)
+    , [rhs] "m" (rhs)
+    : "st", "st(1)");
+
+    return Result;
+#else
     BIGFLOAT Src1_d = lhs;
     BIGFLOAT Src2_d = rhs;
     BIGFLOAT Tmp = Src2_d * log2l(Src1_d);
     return Tmp;
+#endif
   }
 
   static X80SoftFloat FATAN(X80SoftFloat const &lhs, X80SoftFloat const &rhs) {
     WARN_ONCE_FMT("x87: Application used FATAN which may have accuracy problems");
+#ifdef DEBUG_X86_FLOAT
+    BIGFLOAT Result;
+    asm (R"(
+    fninit;
+    fldt %[lhs];
+    fldt %[rhs];
+    fpatan;
+    fstpt %[result];
+    )"
+    : [result] "=m" (Result)
+    : [lhs] "m" (lhs)
+    , [rhs] "m" (rhs)
+    : "st", "st(1)");
+
+    return Result;
+#else
     BIGFLOAT Src1_d = lhs;
     BIGFLOAT Src2_d = rhs;
     BIGFLOAT Tmp = atan2l(Src1_d, Src2_d);
     return Tmp;
+#endif
   }
 
   static X80SoftFloat FTAN(X80SoftFloat const &lhs) {
     WARN_ONCE_FMT("x87: Application used FTAN which may have accuracy problems");
+#ifdef DEBUG_X86_FLOAT
+    BIGFLOAT Result;
+    asm (R"(
+    fninit;
+    fldt %[lhs]; # st0
+    fptan;
+    ffreep %%st(0);
+    fstpt %[result];
+    )"
+    : [result] "=m" (Result)
+    : [lhs] "m" (lhs)
+    : "st");
+
+    return Result;
+#else
     BIGFLOAT Src_d = lhs;
     Src_d = tanl(Src_d);
     return Src_d;
+#endif
   }
 
   static X80SoftFloat FSIN(X80SoftFloat const &lhs) {
     WARN_ONCE_FMT("x87: Application used FSIN which may have accuracy problems");
+#ifdef DEBUG_X86_FLOAT
+    BIGFLOAT Result;
+    asm (R"(
+    fninit;
+    fldt %[lhs]; # st0
+    fsin;
+    fstpt %[result];
+    )"
+    : [result] "=m" (Result)
+    : [lhs] "m" (lhs)
+    : "st");
+
+    return Result;
+#else
     BIGFLOAT Src_d = lhs;
     Src_d = sinl(Src_d);
     return Src_d;
+#endif
   }
 
   static X80SoftFloat FCOS(X80SoftFloat const &lhs) {
     WARN_ONCE_FMT("x87: Application used FCOS which may have accuracy problems");
+#ifdef DEBUG_X86_FLOAT
+    BIGFLOAT Result;
+    asm (R"(
+    fninit;
+    fldt %[lhs]; # st0
+    fcos;
+    fstpt %[result];
+    )"
+    : [result] "=m" (Result)
+    : [lhs] "m" (lhs)
+    : "st");
+
+    return Result;
+#else
     BIGFLOAT Src_d = lhs;
     Src_d = cosl(Src_d);
     return Src_d;
+#endif
   }
 
   static X80SoftFloat FSQRT(X80SoftFloat const &lhs) {
+#ifdef DEBUG_X86_FLOAT
+    BIGFLOAT Result;
+    asm (R"(
+    fninit;
+    fldt %[lhs]; # st0
+    fsqrt;
+    fstpt %[result];
+    )"
+    : [result] "=m" (Result)
+    : [lhs] "m" (lhs)
+    : "st");
+
+    return Result;
+#else
     return extF80_sqrt(lhs);
+#endif
   }
 
   operator float() const {

--- a/External/FEXCore/Source/Common/SoftFloat.h
+++ b/External/FEXCore/Source/Common/SoftFloat.h
@@ -158,15 +158,7 @@ struct X80SoftFloat {
 
     return Result;
 #else
-    X80SoftFloat Rem = extF80_rem(lhs, rhs);
-    if (SignBit(Rem)) {
-      Rem = extF80_add(Rem, rhs);
-    }
-    else {
-      Rem.Sign = SignBit(lhs);
-    }
-
-    return Rem;
+    return extF80_rem(lhs, rhs);
 #endif
   }
 

--- a/unittests/32Bit_ASM/Disabled_Tests
+++ b/unittests/32Bit_ASM/Disabled_Tests
@@ -5,3 +5,6 @@ Test_32Bit_X87/D9_FD.asm
 Test_32Bit_X87/D9_F9.asm
 
 Test_32Bit_X87/D9_F2.asm
+
+# Relies on rounding correctness
+Test_32Bit_X87/D9_F8.asm

--- a/unittests/32Bit_ASM/Known_Failures
+++ b/unittests/32Bit_ASM/Known_Failures
@@ -1,0 +1,1 @@
+Test_32Bit_X87/D9_F8.asm

--- a/unittests/ASM/Disabled_Tests
+++ b/unittests/ASM/Disabled_Tests
@@ -23,3 +23,6 @@ Test_Primary/Primary_E9.asm
 Test_X87/D9_F9.asm
 
 Test_X87/D9_F2.asm
+
+# Relies on rounding correctness
+Test_X87/D9_F8.asm

--- a/unittests/ASM/Known_Failures
+++ b/unittests/ASM/Known_Failures
@@ -1,1 +1,1 @@
-# No known failures
+Test_X87/D9_F8.asm


### PR DESCRIPTION
This isn't correct and breaks games.
This makes the FREM and REM1 implementation the same.
While not 100% correct, it is still better than before.
New issues will be created to handle the differences in the future.

Fixes #1374.
Also fixes most of the HL2 issues, just not the seam issue.