### PR TITLE
OpcodeDispatcher: Removes extraneous extract in VFCMP

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -1187,13 +1187,6 @@ void OpDispatchBuilder::VFCMPOp(OpcodeArgs) {
   auto Size = GetSrcSize(Op);
   OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
   OrderedNode *Dest = LoadSource_WithOpSize(FPRClass, Op, Op->Dest, GetDstSize(Op), Op->Flags, -1);
-  OrderedNode *Src2{};
-  if constexpr (Scalar) {
-    Src2 = _VExtractElement(GetDstSize(Op), Size, Dest, 0);
-  }
-  else {
-    Src2 = Dest;
-  }
   uint8_t CompType = Op->Src[1].Data.Literal.Value;
 
   OrderedNode *Result{};
@@ -1201,30 +1194,30 @@ void OpDispatchBuilder::VFCMPOp(OpcodeArgs) {
   //auto ALUOp = _VCMPGT(Size, ElementSize, Dest, Src);
   switch (CompType) {
     case 0x00: case 0x08: case 0x10: case 0x18: // EQ
-      Result = _VFCMPEQ(Size, ElementSize, Src2, Src);
+      Result = _VFCMPEQ(Size, ElementSize, Dest, Src);
     break;
     case 0x01: case 0x09: case 0x11: case 0x19: // LT, GT(Swapped operand)
-      Result = _VFCMPLT(Size, ElementSize, Src2, Src);
+      Result = _VFCMPLT(Size, ElementSize, Dest, Src);
     break;
     case 0x02: case 0x0A: case 0x12: case 0x1A: // LE, GE(Swapped operand)
-      Result = _VFCMPLE(Size, ElementSize, Src2, Src);
+      Result = _VFCMPLE(Size, ElementSize, Dest, Src);
     break;
     case 0x03: case 0x0B: case 0x13: case 0x1B: // Unordered
-      Result = _VFCMPUNO(Size, ElementSize, Src2, Src);
+      Result = _VFCMPUNO(Size, ElementSize, Dest, Src);
     break;
     case 0x04: case 0x0C: case 0x14: case 0x1C: // NEQ
-      Result = _VFCMPNEQ(Size, ElementSize, Src2, Src);
+      Result = _VFCMPNEQ(Size, ElementSize, Dest, Src);
     break;
     case 0x05: case 0x0D: case 0x15: case 0x1D: // NLT, NGT(Swapped operand)
-      Result = _VFCMPLT(Size, ElementSize, Src2, Src);
+      Result = _VFCMPLT(Size, ElementSize, Dest, Src);
       Result = _VNot(Size, ElementSize, Result);
     break;
     case 0x06: case 0x0E: case 0x16: case 0x1E: // NLE, NGE(Swapped operand)
-      Result = _VFCMPLE(Size, ElementSize, Src2, Src);
+      Result = _VFCMPLE(Size, ElementSize, Dest, Src);
       Result = _VNot(Size, ElementSize, Result);
     break;
     case 0x07: case 0x0F: case 0x17: case 0x1F: // Ordered
-      Result = _VFCMPORD(Size, ElementSize, Src2, Src);
+      Result = _VFCMPORD(Size, ElementSize, Dest, Src);
     break;
     default:
       LOGMAN_MSG_A_FMT("Unknown Comparison type: {}", CompType);


### PR DESCRIPTION
We don't need to extract the element to compare it.