### PR TITLE
CMake: Always use local xxhash to statically link

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,13 +275,9 @@ endif()
 
 find_package(PkgConfig REQUIRED)
 find_package(Python 3.0 REQUIRED COMPONENTS Interpreter)
-pkg_check_modules(XXHASH libxxhash>=0.8.0 QUIET)
 
-if (NOT XXHASH_FOUND)
-  message(STATUS "xxHash not found. Using Externals")
-  add_subdirectory(External/xxhash/)
-  include_directories(External/xxhash/)
-endif()
+add_subdirectory(External/xxhash/)
+include_directories(External/xxhash/)
 
 add_definitions(-Wno-trigraphs)
 add_definitions(-DGLOBAL_DATA_DIRECTORY="${DATA_DIRECTORY}/")


### PR DESCRIPTION
Dynamically linking xxhash is causing problems with pressure-vessel.

With this in place we only have the typical C++ dependencies
```
$ ldd ./Bin/FEXLoader
        linux-vdso.so.1 (0x00007fff44d9d000)
        libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f4c4d884000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f4c4d7a0000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f4c4d786000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f4c4d55e000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f4c4e0fa000)
```