### PR TITLE
Container escape information

### DIFF
--- a/Source/Tests/LinuxSyscalls/EmulatedFiles/EmulatedFiles.cpp
+++ b/Source/Tests/LinuxSyscalls/EmulatedFiles/EmulatedFiles.cpp
@@ -684,6 +684,23 @@ namespace FEX::EmulatedFile {
 
     FDReadCreators["/fex/arch"] = HostArchitecture;
 
+    auto RootFSPath = [&](FEXCore::Context::Context *ctx, int32_t fd, const char *pathname, int32_t flags, mode_t mode) -> int32_t {
+      int FD = GenTmpFD();
+      auto RootFSPath = LDPath();
+      if (!RootFSPath.empty()) {
+        write(FD, RootFSPath.data(), RootFSPath.size());
+      }
+
+      // Null terminate
+      char Null = '\0';
+      write(FD, &Null, sizeof(Null));
+
+      lseek(FD, 0, SEEK_SET);
+      return FD;
+    };
+
+    FDReadCreators["/fex/rootfs_path"] = RootFSPath;
+
     string procAuxv = string("/proc/") + std::to_string(getpid()) + string("/auxv");
 
     FDReadCreators[procAuxv] = &EmulatedFDManager::ProcAuxv;

--- a/Source/Tests/LinuxSyscalls/EmulatedFiles/EmulatedFiles.cpp
+++ b/Source/Tests/LinuxSyscalls/EmulatedFiles/EmulatedFiles.cpp
@@ -668,6 +668,22 @@ namespace FEX::EmulatedFile {
     FDReadCreators["/sys/devices/system/cpu/online"] = NumCPUCores;
     FDReadCreators["/sys/devices/system/cpu/present"] = NumCPUCores;
 
+    auto HostArchitecture = [&](FEXCore::Context::Context *ctx, int32_t fd, const char *pathname, int32_t flags, mode_t mode) -> int32_t {
+      int FD = GenTmpFD();
+#ifdef _M_ARM_64
+      const char Arch[] = "arm64\0";
+#elif defined(_M_X86_64)
+      const char Arch[] = "x86_64\0";
+#else
+      const char Arch[] = "unknown\0";
+#endif
+      write(FD, Arch, sizeof(Arch));
+      lseek(FD, 0, SEEK_SET);
+      return FD;
+    };
+
+    FDReadCreators["/fex/arch"] = HostArchitecture;
+
     string procAuxv = string("/proc/") + std::to_string(getpid()) + string("/auxv");
 
     FDReadCreators[procAuxv] = &EmulatedFDManager::ProcAuxv;

--- a/Source/Tests/LinuxSyscalls/EmulatedFiles/EmulatedFiles.h
+++ b/Source/Tests/LinuxSyscalls/EmulatedFiles/EmulatedFiles.h
@@ -33,5 +33,6 @@ namespace FEX::EmulatedFile {
 
       static int32_t ProcAuxv(FEXCore::Context::Context* ctx, int32_t fd, const char* pathname, int32_t flags, mode_t mode);
       FEX_CONFIG_OPT(ThreadsConfig, THREADS);
+      FEX_CONFIG_OPT(LDPath, ROOTFS);
   };
 }

--- a/Source/Tests/LinuxSyscalls/FileManagement.cpp
+++ b/Source/Tests/LinuxSyscalls/FileManagement.cpp
@@ -291,8 +291,28 @@ std::string FileManager::GetEmulatedPath(const char *pathname, bool FollowSymlin
     return thunkOverlay->second;
   }
 
+  if (strstr(pathname, "/fex/host") == pathname) {
+    // Redirect `/fex/host`
+    const char *NewLocation = &pathname[strlen("/fex/host")];
+    if (NewLocation[0] == '\0') {
+      return "/";
+    }
+
+    return NewLocation;
+  }
+
   if (RootFSPath.empty()) { // If RootFS doesn't exist
     return {};
+  }
+
+  if (strstr(pathname, "/fex/rootfs") == pathname) {
+    // Redirect `/fex/rootfs`
+    const char *NewLocation = &pathname[strlen("/fex/rootfs")];
+    if (NewLocation[0] == '\0') {
+      return RootFSPath;
+    }
+
+    return RootFSPath + NewLocation;
   }
 
   std::string Path = RootFSPath + pathname;


### PR DESCRIPTION
Adds some information that container software can use to escape the sandbox.
To be used by containers that know what they are doing with Multiarch + FEX-Emu.