### PR TITLE
Enable proper IDE integration of thunk libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -480,30 +480,14 @@ endif()
 if (BUILD_THUNKS)
   add_subdirectory(ThunkLibs/Generator)
 
+  # Thunk targets for both host libraries and IDE integration
+  add_subdirectory(ThunkLibs/HostLibs)
+
+  # Thunk targets for IDE integration of guest code, only
+  add_subdirectory(ThunkLibs/GuestLibs)
+
+  # Thunk targets for guest libraries
   include(ExternalProject)
-
-  ExternalProject_Add(host-libs
-    PREFIX host-libs
-    SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ThunkLibs/HostLibs"
-    BINARY_DIR "Host"
-    CMAKE_ARGS
-      "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
-      "-DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}"
-      "-DGENERATOR_EXE=$<TARGET_FILE:thunkgen>"
-    INSTALL_COMMAND ""
-    BUILD_ALWAYS ON
-    DEPENDS thunkgen
-  )
-
-  install(
-    CODE "MESSAGE(\"-- Installing: host-libs\")"
-    CODE "
-    EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} --build . --target ThunkHostsInstall
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/Host
-    )"
-    DEPENDS host-libs
-  )
-
   ExternalProject_Add(guest-libs
     PREFIX guest-libs
     SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ThunkLibs/GuestLibs"

--- a/ThunkLibs/Generator/gen.cpp
+++ b/ThunkLibs/Generator/gen.cpp
@@ -521,7 +521,7 @@ void FrontendAction::EndSourceFileAction() {
         for (auto& data : thunks) {
             const auto& function_name = data.function_name;
             bool is_void = data.return_type->isVoidType();
-            file << "static auto fexfn_pack_" << function_name << "(";
+            file << "FEX_PACKFN_LINKAGE auto fexfn_pack_" << function_name << "(";
             for (std::size_t idx = 0; idx < data.param_types.size(); ++idx) {
                 auto& type = data.param_types[idx];
                 file << (idx == 0 ? "" : ", ") << format_decl(type, "a_" + std::to_string(idx));

--- a/ThunkLibs/GuestLibs/CMakeLists.txt
+++ b/ThunkLibs/GuestLibs/CMakeLists.txt
@@ -1,21 +1,31 @@
 cmake_minimum_required(VERSION 3.14)
 project(guest-thunks)
 
-set(CMAKE_CXX_STANDARD 17)
+if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+  # We've been included using ExternalProject_add, so set up the actual thunk libraries to be cross-compiled
+  set(CMAKE_CXX_STANDARD 17)
 
-# These get passed in from the main cmake project
-set (X86_C_COMPILER "x86_64-linux-gnu-gcc" CACHE STRING "c compiler for compiling x86 guest libs")
-set (X86_CXX_COMPILER "x86_64-linux-gnu-g++" CACHE STRING "c++ compiler for compiling x86 guest libs")
-set (DATA_DIRECTORY "${CMAKE_INSTALL_PREFIX}/share/fex-emu" CACHE PATH "global data directory")
+  # These get passed in from the main cmake project
+  set (X86_C_COMPILER "x86_64-linux-gnu-gcc" CACHE STRING "c compiler for compiling x86 guest libs")
+  set (X86_CXX_COMPILER "x86_64-linux-gnu-g++" CACHE STRING "c++ compiler for compiling x86 guest libs")
+  set (DATA_DIRECTORY "${CMAKE_INSTALL_PREFIX}/share/fex-emu" CACHE PATH "global data directory")
 
-set(CMAKE_C_COMPILER "${X86_C_COMPILER}")
-set(CMAKE_CXX_COMPILER "${X86_CXX_COMPILER}")
+  set(CMAKE_C_COMPILER "${X86_C_COMPILER}")
+  set(CMAKE_CXX_COMPILER "${X86_CXX_COMPILER}")
+
+  set(TARGET_TYPE SHARED)
+  set(GENERATE_GUEST_INSTALL_TARGETS TRUE)
+else()
+  # We've been included using add_subdirectory, so set up targets for IDE integration using the host toolchain
+  set(GENERATOR_EXE thunkgen)
+  set(TARGET_TYPE OBJECT)
+  set(GENERATE_GUEST_INSTALL_TARGETS FALSE)
+endif()
 
 # Syntax: generate(libxyz [LIBNAME libxyz-custom] libxyz-interface.cpp generator-targets...)
-# This defines two targets and a custom command:
+# This defines a target and a custom command:
 # - custom command: Main build step that runs the thunk generator on the given interface definition
-# - libxyz-interface: Target for IDE integration (making sure libxyz-interface.cpp shows up as a source file in the project tree)
-# - libxyz-deps: Interface target to read include directories from which are passed to libclang when parsing the interface definition
+# - libxyz-guest-deps: Interface target to read include directories from which are passed to libclang when parsing the interface definition
 function(generate NAME)
   cmake_parse_arguments(PARSE_ARGV 1 ARGS "" "LIBNAME" "")
   set(ARGN ${ARGS_UNPARSED_ARGUMENTS})
@@ -28,15 +38,11 @@ function(generate NAME)
   endif()
 
   # Interface target for the user to add include directories
-  add_library(${LIBNAME}-deps INTERFACE)
-  target_include_directories(${LIBNAME}-deps INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/../include")
+  add_library(${LIBNAME}-guest-deps INTERFACE)
+  target_include_directories(${LIBNAME}-guest-deps INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/../include")
   # Shorthand for the include directories added after calling this function.
   # This is not evaluated directly, hence directories added after return are still picked up
-  set(prop "$<TARGET_PROPERTY:${LIBNAME}-deps,INTERFACE_INCLUDE_DIRECTORIES>")
-
-  # Target for IDE integration
-  add_library(${LIBNAME}-interface EXCLUDE_FROM_ALL ${SOURCE_FILE})
-  target_link_libraries(${LIBNAME}-interface PRIVATE ${LIBNAME}-deps)
+  set(prop "$<TARGET_PROPERTY:${LIBNAME}-guest-deps,INTERFACE_INCLUDE_DIRECTORIES>")
 
   # Run thunk generator for each of the given output files
   foreach(WHAT IN LISTS ARGN)
@@ -76,19 +82,21 @@ function(add_guest_lib_with_name NAME LIBNAME)
     endif()
   endif()
 
-  add_library(${LIBNAME}-guest SHARED ${SOURCE_FILE} ${GEN_lib${LIBNAME}})
+  add_library(${LIBNAME}-guest ${TARGET_TYPE} ${SOURCE_FILE} ${GEN_lib${LIBNAME}})
   target_include_directories(${LIBNAME}-guest PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/gen/lib${LIBNAME}")
   target_compile_definitions(${LIBNAME}-guest PRIVATE GUEST_THUNK_LIBRARY)
-  target_link_libraries(${LIBNAME}-guest PRIVATE lib${LIBNAME}-deps)
+  target_link_libraries(${LIBNAME}-guest PRIVATE lib${LIBNAME}-guest-deps)
 
   ## Tell GCC to not complain about ignored attributes
   target_compile_options(${LIBNAME}-guest PRIVATE -Wno-attributes)
   target_compile_options(${LIBNAME}-guest PRIVATE -DLIB_NAME=${LIBNAME} -DLIBLIB_NAME=lib${LIBNAME})
 
-  add_custom_target(${LIBNAME}-guest-install
-    COMMAND ${CMAKE_COMMAND} -E make_directory $ENV{DESTDIR}/${DATA_DIRECTORY}/GuestThunks/
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_BINARY_DIR}/lib${LIBNAME}-guest.so $ENV{DESTDIR}/${DATA_DIRECTORY}/GuestThunks/)
-  add_dependencies(ThunkGuestsInstall ${LIBNAME}-guest-install)
+  if (GENERATE_GUEST_INSTALL_TARGETS)
+    add_custom_target(${LIBNAME}-guest-install
+      COMMAND ${CMAKE_COMMAND} -E make_directory $ENV{DESTDIR}/${DATA_DIRECTORY}/GuestThunks/
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_BINARY_DIR}/lib${LIBNAME}-guest.so $ENV{DESTDIR}/${DATA_DIRECTORY}/GuestThunks/)
+    add_dependencies(ThunkGuestsInstall ${LIBNAME}-guest-install)
+  endif()
 endfunction()
 
 function(add_guest_lib NAME)
@@ -175,6 +183,6 @@ generate(libxshmfence ${CMAKE_CURRENT_SOURCE_DIR}/../libxshmfence/libxshmfence_i
 add_guest_lib(xshmfence)
 
 generate(libdrm ${CMAKE_CURRENT_SOURCE_DIR}/../libdrm/libdrm_interface.cpp thunks function_packs function_packs_public)
-target_include_directories(libdrm-deps INTERFACE /usr/include/drm/)
-target_include_directories(libdrm-deps INTERFACE /usr/include/libdrm/)
+target_include_directories(libdrm-guest-deps INTERFACE /usr/include/drm/)
+target_include_directories(libdrm-guest-deps INTERFACE /usr/include/libdrm/)
 add_guest_lib(drm)

--- a/ThunkLibs/HostLibs/CMakeLists.txt
+++ b/ThunkLibs/HostLibs/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.14)
 project(host-thunks)
 
 set(CMAKE_CXX_STANDARD 17)
-set (DATA_DIRECTORY "${CMAKE_INSTALL_PREFIX}/lib/fex-emu" CACHE PATH "global data directory")
+set (HOSTLIBS_DATA_DIRECTORY "${CMAKE_INSTALL_PREFIX}/lib/fex-emu" CACHE PATH "global data directory")
 
 # Syntax: generate(libxyz [LIBNAME libxyz-custom] libxyz-interface.cpp generator-targets...)
 # This defines two targets and a custom command:
@@ -41,10 +41,10 @@ function(generate NAME)
 
     add_custom_command(
       OUTPUT "${OUTFILE}"
-      DEPENDS "${GENERATOR_EXE}"
       DEPENDS "${OUTFOLDER}"
       DEPENDS "${SOURCE_FILE}"
-      COMMAND "${GENERATOR_EXE}" "${SOURCE_FILE}" "${LIBNAME}" "-${WHAT}" "${OUTFILE}" -- -std=c++17
+      DEPENDS thunkgen
+      COMMAND thunkgen "${SOURCE_FILE}" "${LIBNAME}" "-${WHAT}" "${OUTFILE}" -- -std=c++17
             # Expand include directories to space-separated list of -isystem parameters
            "$<$<BOOL:${prop}>:;-isystem$<JOIN:${prop},;-isystem>>"
       VERBATIM
@@ -74,15 +74,10 @@ function(add_host_lib_with_name NAME LIBNAME)
   target_compile_options(${LIBNAME}-host PRIVATE -DLIB_NAME=${LIBNAME} -DLIBLIB_NAME=lib${LIBNAME})
 
   # generated files forward-declare functions that need to be implemented manually, so pass --no-undefined to make sure errors are detected at compile-time rather than runtime
-  target_link_options(${LIBNAME}-host PRIVATE "-Wl,--no-undefined")
+  target_link_options(${LIBNAME}-host PRIVATE "LINKER:--no-undefined")
 
-  add_custom_target(${LIBNAME}-host-install
-    COMMAND ${CMAKE_COMMAND} -E make_directory $ENV{DESTDIR}/${DATA_DIRECTORY}/HostThunks/
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_BINARY_DIR}/lib${LIBNAME}-host.so $ENV{DESTDIR}/${DATA_DIRECTORY}/HostThunks/)
-  add_dependencies(ThunkHostsInstall ${LIBNAME}-host-install)
+  install(TARGETS ${LIBNAME}-host DESTINATION $ENV{DESTDIR}/${HOSTLIBS_DATA_DIRECTORY}/HostThunks/)
 endfunction()
-
-add_custom_target(ThunkHostsInstall)
 
 function(add_host_lib NAME)
   add_host_lib_with_name(${NAME} ${NAME} ${ARGV})

--- a/ThunkLibs/include/common/Guest.h
+++ b/ThunkLibs/include/common/Guest.h
@@ -1,7 +1,20 @@
 #pragma once
 #include <stdint.h>
 
-#define MAKE_THUNK(lib, name, hash) extern "C" { int fexthunks_##lib##_##name(void *args); } asm("fexthunks_" #lib "_" #name ":\n.byte 0xF, 0x3F\n.byte " hash );
+#ifndef _M_ARM_64
+#define MAKE_THUNK(lib, name, hash) \
+  extern "C" int fexthunks_##lib##_##name(void *args); \
+  asm("fexthunks_" #lib "_" #name ":\n.byte 0xF, 0x3F\n.byte " hash );
+#else
+// We're compiling for IDE integration, so provide a dummy-implementation that just calls an undefined function.
+// The name of that function serves as an error message if this library somehow gets loaded at runtime.
+extern "C" void BROKEN_INSTALL___TRIED_LOADING_AARCH64_BUILD_OF_GUEST_THUNK();
+#define MAKE_THUNK(lib, name, hash) \
+  extern "C" int fexthunks_##lib##_##name(void *args) { \
+    BROKEN_INSTALL___TRIED_LOADING_AARCH64_BUILD_OF_GUEST_THUNK(); \
+    return 0; \
+  }
+#endif
 
 // Generated fexfn_pack_ symbols should be hidden by default, but clang does
 // not support aliasing to static functions. Make them regular non-static

--- a/ThunkLibs/include/common/Guest.h
+++ b/ThunkLibs/include/common/Guest.h
@@ -3,6 +3,15 @@
 
 #define MAKE_THUNK(lib, name, hash) extern "C" { int fexthunks_##lib##_##name(void *args); } asm("fexthunks_" #lib "_" #name ":\n.byte 0xF, 0x3F\n.byte " hash );
 
+// Generated fexfn_pack_ symbols should be hidden by default, but clang does
+// not support aliasing to static functions. Make them regular non-static
+// functions on that compiler instead, hence.
+#if defined(__clang__)
+#define FEX_PACKFN_LINKAGE
+#else
+#define FEX_PACKFN_LINKAGE static
+#endif
+
 struct LoadlibArgs {
     const char *Name;
     uintptr_t CallbackThunks;


### PR DESCRIPTION
Previously, IDE engines couldn't parse the Host.cpp/Guest.cpp files of thunk libraries easily. This PR changes host libs to be built as part of the main project to enable parsing the former, and it adds a dummy copy of the guest libs project to enable parsing Guest.cpp.
