### PR TITLE
FEXGetConfig: Fix --current-rootfs option

### DIFF
--- a/Source/Common/RootFSSetup.cpp
+++ b/Source/Common/RootFSSetup.cpp
@@ -213,6 +213,23 @@ std::string GetRootFSLockFile() {
   return LockPath;
 }
 
+std::string GetRootFSPathIfExists() {
+  FEX_CONFIG_OPT(LDPath, ROOTFS);
+  if (FEX::FormatCheck::IsSquashFS(LDPath())) {
+    auto LockFile = FEX::RootFS::GetRootFSLockFile();
+    std::string MountPath;
+    if (FEX::RootFS::CheckLockExists(LockFile, &MountPath)) {
+      return MountPath;
+    }
+
+    // Wasn't mounted, don't return squashfs name
+    return {};
+  }
+
+  // Wasn't squashfs, return regular ROOTFS config
+  return LDPath();
+}
+
 enum class ErrorResult {
   ERROR_SUCCESS,
   ERROR_FAIL,

--- a/Source/Common/RootFSSetup.h
+++ b/Source/Common/RootFSSetup.h
@@ -10,6 +10,13 @@ namespace FEX::RootFS {
   std::string GetRootFSLockFile();
   // Returns the socket file for a mount path
   std::string GetRootFSSocketFile(std::string const &MountPath);
+
+  // Returns the string to the rootfs path if it exists
+  // If unconfigured: Return empty string
+  // If regular directory: Return directory
+  // If squashfs: Only returns tmpfs directory if mounted, otherwise empty string
+  std::string GetRootFSPathIfExists();
+
   // Checks if the rootfs lock exists
   bool CheckLockExists(std::string const &LockPath, std::string *MountPath = nullptr);
   bool Setup(char **const envp, uint32_t TryCount = 0);

--- a/Source/Tools/FEXGetConfig/Main.cpp
+++ b/Source/Tools/FEXGetConfig/Main.cpp
@@ -79,9 +79,8 @@ int main(int argc, char **argv, char **envp) {
   }
 
   if (Options.is_set_by_user("current_rootfs")) {
-    auto LockFile = FEX::RootFS::GetRootFSLockFile();
-    std::string MountPath;
-    if (FEX::RootFS::CheckLockExists(LockFile, &MountPath)) {
+    auto MountPath = FEX::RootFS::GetRootFSPathIfExists();
+    if (!MountPath.empty()) {
       fprintf(stdout, "%s\n", MountPath.c_str());
     }
   }


### PR DESCRIPTION
If the configured rootfs wasn't a squashfs then it was failing to return
the directory.

Now it works for both squashfs and directory rootfs again.