### PR TITLE
Removes MAP_GROWSDOWN usage

### DIFF
--- a/External/FEXCore/Source/Utils/Threads.cpp
+++ b/External/FEXCore/Source/Utils/Threads.cpp
@@ -31,7 +31,7 @@ namespace FEXCore::Threads {
     std::lock_guard lk{DeadStackPoolMutex};
     if (DeadStackPool.size() == 0) {
       // Nothing in the pool, just allocate
-      return FEXCore::Allocator::mmap(nullptr, Size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_GROWSDOWN, -1, 0);
+      return FEXCore::Allocator::mmap(nullptr, Size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
     }
 
     // Keep the first item in the stack pool

--- a/Source/Tests/ELFCodeLoader2.h
+++ b/Source/Tests/ELFCodeLoader2.h
@@ -341,7 +341,7 @@ class ELFCodeLoader2 final : public FEXCore::CodeLoader {
 
     // map stack here, so that nothing gets mapped there
     // This works with both 64-bit and 32-bit. The mapper will only give us a function in the correct region
-    StackPointer = reinterpret_cast<uintptr_t>(Mapper(nullptr, StackSize(), PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_STACK | MAP_GROWSDOWN, -1, 0));
+    StackPointer = reinterpret_cast<uintptr_t>(Mapper(nullptr, StackSize(), PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_STACK, -1, 0));
 
     if (StackPointer == ~0ULL) {
       LogMan::Msg::EFmt("Allocating stack failed");


### PR DESCRIPTION
This is just a memory leak waiting to happen.
Only the primary thread in an application really should have this set
since the kernel cleans it up.

We only ever allocate the primary thread of the guest application then
every host thread's stack on top of that. It's up to the guest when it
is cloning to set up new stack pointers, we don't manage that.

We are already allocating the first thread's size at the soft stack
limit with RLIMIT_STACK anyway.

Fixes #1556