### PR TITLE
Arm64Emitter: Allow non-optimizing LoadConstant

### DIFF
--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
@@ -61,7 +61,7 @@ protected:
   Arm64Emitter(FEXCore::Context::Context *ctx, size_t size);
 
   vixl::aarch64::CPU CPU;
-  void LoadConstant(vixl::aarch64::Register Reg, uint64_t Constant);
+  void LoadConstant(vixl::aarch64::Register Reg, uint64_t Constant, bool NOPPad = false);
   void SpillStaticRegs(bool FPRs = true, uint32_t SpillMask = ~0U);
   void FillStaticRegs(bool FPRs = true, uint32_t FillMask = ~0U);
 


### PR DESCRIPTION
This is pulled from the code cache PR. Will be necessary for supporting
relocations.

Not currently being used but will be once we have code caching in place.