### PR TITLE
unittests: Disables Interpreter tests when its disabled

### DIFF
--- a/unittests/32Bit_ASM/CMakeLists.txt
+++ b/unittests/32Bit_ASM/CMakeLists.txt
@@ -48,9 +48,6 @@ foreach(ASM_SRC ${ASM_SOURCES})
 
   # Format is "<Test Arguments>" "<Test Name>"
   set(TEST_ARGS
-    "--no-silent -g -c irint -n 1   --no-multiblock"    "int_1"     "int"
-    "--no-silent -g -c irint -n 500 --no-multiblock"    "int_500"   "int"
-    "--no-silent -g -c irint -n 500 --multiblock"       "int_500_m" "int"
     "--no-silent -g -c irjit -n 1   --no-multiblock"    "jit_1"     "jit"
     "--no-silent -g -c irjit -n 500 --no-multiblock"    "jit_500"   "jit"
     "--no-silent -g -c irjit -n 500 --multiblock"       "jit_500_m" "jit"
@@ -60,6 +57,14 @@ foreach(ASM_SRC ${ASM_SOURCES})
     list(APPEND TEST_ARGS
       "--no-silent -g -c host"       "host"      "host"
       )
+  endif()
+
+  if (ENABLE_INTERPRETER)
+    list(APPEND TEST_ARGS
+      "--no-silent -g -c irint -n 1   --no-multiblock"    "int_1"     "int"
+      "--no-silent -g -c irint -n 500 --no-multiblock"    "int_500"   "int"
+      "--no-silent -g -c irint -n 500 --multiblock"       "int_500_m" "int"
+    )
   endif()
 
   set (RUNNER_DISABLED "${CMAKE_SOURCE_DIR}/unittests/ASM/Disabled_Tests")

--- a/unittests/ASM/CMakeLists.txt
+++ b/unittests/ASM/CMakeLists.txt
@@ -48,9 +48,6 @@ foreach(ASM_SRC ${ASM_SOURCES})
 
   # Format is "<Test Arguments>" "<Test Name>" "<Test Type>"
   set(TEST_ARGS
-    "--no-silent -g -c irint -n 1   --no-multiblock"   "int_1"     "int"
-    "--no-silent -g -c irint -n 500 --no-multiblock"   "int_500"   "int"
-    "--no-silent -g -c irint -n 500 --multiblock"      "int_500_m" "int"
     "--no-silent -g -c irjit -n 1   --no-multiblock"   "jit_1"     "jit"
     "--no-silent -g -c irjit -n 500 --no-multiblock"   "jit_500"   "jit"
     "--no-silent -g -c irjit -n 500 --multiblock"      "jit_500_m" "jit"
@@ -59,6 +56,14 @@ foreach(ASM_SRC ${ASM_SOURCES})
     list(APPEND TEST_ARGS
       "--no-silent -g -c host"       "host"      "host"
       )
+  endif()
+
+  if (ENABLE_INTERPRETER)
+    list(APPEND TEST_ARGS
+      "--no-silent -g -c irint -n 1   --no-multiblock"   "int_1"     "int"
+      "--no-silent -g -c irint -n 500 --no-multiblock"   "int_500"   "int"
+      "--no-silent -g -c irint -n 500 --multiblock"      "int_500_m" "int"
+    )
   endif()
 
   set (RUNNER_DISABLED "${CMAKE_SOURCE_DIR}/unittests/ASM/Disabled_Tests")

--- a/unittests/IR/CMakeLists.txt
+++ b/unittests/IR/CMakeLists.txt
@@ -22,9 +22,14 @@ foreach(IR_SRC ${IR_SOURCES})
 
   # Since we pass in raw IR, we don't need to worry about various IR gen options
   set(TEST_ARGS
-    "--no-silent -c irint -n 500" "ir_int" "int"
     "--no-silent -c irjit -n 500" "ir_jit" "jit"
     )
+
+  if (ENABLE_INTERPRETER)
+    list(APPEND TEST_ARGS
+      "--no-silent -c irint -n 500" "ir_int" "int"
+    )
+  endif()
 
   set (RUNNER_DISABLED "${CMAKE_SOURCE_DIR}/unittests/ASM/Disabled_Tests")
   if (DEFINED ENV{runner_label})

--- a/unittests/POSIX/CMakeLists.txt
+++ b/unittests/POSIX/CMakeLists.txt
@@ -9,15 +9,17 @@ foreach(POSIX_TEST ${POSIX_TESTS})
   list(GET TEST_NAME_LIST 1 TEST_NAME)
   string(REPLACE "/" "-" TEST_NAME ${TEST_NAME})
 
-  add_test(NAME "${TEST_NAME}.int.posix"
-    COMMAND "python3" "${CMAKE_SOURCE_DIR}/Scripts/guest_test_runner.py"
-    "${CMAKE_SOURCE_DIR}/unittests/POSIX/Known_Failures"
-    "${CMAKE_SOURCE_DIR}/unittests/POSIX/Expected_Output"
-    "${CMAKE_SOURCE_DIR}/unittests/POSIX/Disabled_Tests"
-    "${TEST_NAME}"
-    "${CMAKE_BINARY_DIR}/Bin/FEXLoader"
-    "--no-silent" "-c" "irint" "-n" "500" "--"
-    "${POSIX_TEST}")
+  if (ENABLE_INTERPRETER)
+    add_test(NAME "${TEST_NAME}.int.posix"
+      COMMAND "python3" "${CMAKE_SOURCE_DIR}/Scripts/guest_test_runner.py"
+      "${CMAKE_SOURCE_DIR}/unittests/POSIX/Known_Failures"
+      "${CMAKE_SOURCE_DIR}/unittests/POSIX/Expected_Output"
+      "${CMAKE_SOURCE_DIR}/unittests/POSIX/Disabled_Tests"
+      "${TEST_NAME}"
+      "${CMAKE_BINARY_DIR}/Bin/FEXLoader"
+      "--no-silent" "-c" "irint" "-n" "500" "--"
+      "${POSIX_TEST}")
+  endif()
 
   add_test(NAME "${TEST_NAME}.jit.posix"
     COMMAND "python3" "${CMAKE_SOURCE_DIR}/Scripts/guest_test_runner.py"


### PR DESCRIPTION
Would result in failures if you weren't expecting it.