### PR TITLE
ARMJIT: Switches over to loading pointers from state

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -12,30 +12,6 @@ namespace FEXCore::CPU {
 #define GRD(Node) (IROp->Size <= 4 ? GetDst<RA_32>(Node) : GetDst<RA_64>(Node))
 #define GRS(Node) (IROp->Size <= 4 ? GetReg<RA_32>(Node) : GetReg<RA_64>(Node))
 
-static uint64_t LUDIV(uint64_t SrcHigh, uint64_t SrcLow, uint64_t Divisor) {
-  __uint128_t Source = (static_cast<__uint128_t>(SrcHigh) << 64) | SrcLow;
-  __uint128_t Res = Source / Divisor;
-  return Res;
-}
-
-static int64_t LDIV(int64_t SrcHigh, int64_t SrcLow, int64_t Divisor) {
-  __int128_t Source = (static_cast<__int128_t>(SrcHigh) << 64) | SrcLow;
-  __int128_t Res = Source / Divisor;
-  return Res;
-}
-
-static uint64_t LUREM(uint64_t SrcHigh, uint64_t SrcLow, uint64_t Divisor) {
-  __uint128_t Source = (static_cast<__uint128_t>(SrcHigh) << 64) | SrcLow;
-  __uint128_t Res = Source % Divisor;
-  return Res;
-}
-
-static int64_t LREM(int64_t SrcHigh, int64_t SrcLow, int64_t Divisor) {
-  __int128_t Source = (static_cast<__int128_t>(SrcHigh) << 64) | SrcLow;
-  __int128_t Res = Source % Divisor;
-  return Res;
-}
-
 using namespace vixl;
 using namespace vixl::aarch64;
 #define DEF_OP(x) void Arm64JITCore::Op_##x(IR::IROp_Header *IROp, IR::NodeID Node)
@@ -666,7 +642,8 @@ DEF_OP(LDiv) {
       mov(x1, GetReg<RA_64>(Op->Header.Args[0].ID()));
       mov(x2, GetReg<RA_64>(Op->Header.Args[2].ID()));
 
-      LoadConstant(x3, reinterpret_cast<uint64_t>(LDIV));
+      ldr(x3, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.AArch64.LDIV)));
+
       SpillStaticRegs();
       blr(x3);
       FillStaticRegs();
@@ -709,7 +686,7 @@ DEF_OP(LUDiv) {
       mov(x1, GetReg<RA_64>(Op->Header.Args[0].ID()));
       mov(x2, GetReg<RA_64>(Op->Header.Args[2].ID()));
 
-      LoadConstant(x3, reinterpret_cast<uint64_t>(LUDIV));
+      ldr(x3, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.AArch64.LUDIV)));
       SpillStaticRegs();
       blr(x3);
       FillStaticRegs();
@@ -762,7 +739,7 @@ DEF_OP(LRem) {
       mov(x1, GetReg<RA_64>(Op->Header.Args[0].ID()));
       mov(x2, GetReg<RA_64>(Op->Header.Args[2].ID()));
 
-      LoadConstant(x3, reinterpret_cast<uint64_t>(LREM));
+      ldr(x3, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.AArch64.LREM)));
       SpillStaticRegs();
       blr(x3);
       FillStaticRegs();
@@ -812,7 +789,7 @@ DEF_OP(LURem) {
       mov(x1, GetReg<RA_64>(Op->Header.Args[0].ID()));
       mov(x2, GetReg<RA_64>(Op->Header.Args[2].ID()));
 
-      LoadConstant(x3, reinterpret_cast<uint64_t>(LUREM));
+      ldr(x3, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.AArch64.LUREM)));
       SpillStaticRegs();
       blr(x3);
       FillStaticRegs();

--- a/External/FEXCore/Source/Utils/MemberFunctionToPointer.h
+++ b/External/FEXCore/Source/Utils/MemberFunctionToPointer.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <FEXCore/Utils/LogManager.h>
+
+#include <cstdint>
+
+namespace FEXCore::Utils {
+
+/**
+ * @brief Casts a class's member function pointer to a raw pointer that we can JIT
+ *
+ * Has additional validation to ensure we aren't casting a class member that is invalid
+ */
+template <typename PointerToMemberType>
+class MemberFunctionToPointerCast final {
+  public:
+    MemberFunctionToPointerCast(PointerToMemberType Function) {
+      memcpy(&PMF, &Function, sizeof(PMF));
+
+#ifdef _M_X86_64
+      // Itanium C++ ABI (https://itanium-cxx-abi.github.io/cxx-abi/abi.html#member-function-pointers)
+      // Low bit of ptr specifies if this Member function pointer is virtual or not
+      // Throw an assert if we were trying to cast a virtual member
+      LOGMAN_THROW_A_FMT((PMF.ptr & 1) == 0, "C++ Pointer-To-Member representation didn't have low bit set to 0. Are you trying to cast a virtual member?");
+#elif defined(_M_ARM_64 )
+      // C++ ABI for the Arm 64-bit Architecture (IHI 0059E)
+      // 4.2.1 Representation of pointer to member function
+      // Differs from Itanium specification
+      LOGMAN_THROW_A_FMT(PMF.adj == 0, "C++ Pointer-To-Member representation didn't have adj == 0. Are you trying to cast a virtual member?");
+#else
+#error Don't know how to cast Member to function here. Likely just Itanium
+#endif
+    }
+
+    uintptr_t GetConvertedPointer() const {
+      return PMF.ptr;
+    }
+
+  private:
+    struct PointerToMember {
+      uintptr_t ptr;
+      uintptr_t adj;
+    };
+
+    PointerToMember PMF;
+
+    // Ensure the representation of PointerToMember matches
+    static_assert(sizeof(PMF) == sizeof(PointerToMemberType));
+};
+}


### PR DESCRIPTION
These pointers are process or thread specific depending on which pointer
it is.
All of these pointers end up getting used inside of the JIT blocks
themselves and with code caching would result in a ton of relocations
occuring inside the code.

The pointers used within the dispatcher don't currently matter since I'm
not expecting to cache the dispatcher itself. It's only a page per
thread after all. This does move us significantly closer towards using a
single dispatcher for all threads though.

The performance impact of this change is unlikely to be felt at all,
some locations have less code generation which could improve perf
slightly. Some locations move from a 1-3 cycle constant calculation to a
4 cycle load, hard to be felt since it gets hidden by other
instructions.

x86-64 JIT will be added soon after this