### PR TITLE
JITx86: Switches over to loading pointers from state

### DIFF
--- a/External/FEXCore/include/FEXCore/Core/CoreState.h
+++ b/External/FEXCore/include/FEXCore/Core/CoreState.h
@@ -64,7 +64,30 @@ namespace FEXCore::Core {
     } AArch64;
 
     struct {
-      // XXX: Not implemented yet
+      // Process specific
+      uint64_t PrintValue{};
+      uint64_t PrintVectorValue{};
+      uint64_t RemoveCodeEntryFromJIT{};
+      uint64_t CPUIDObj{};
+      uint64_t CPUIDFunction{};
+      uint64_t SyscallHandlerObj{};
+      uint64_t SyscallHandlerFunc{};
+
+      // Thread Specific
+      uint64_t SignalHandlerRefCountPointer{};
+
+      /**
+       * @name Dispatcher pointers
+       * @{ */
+      uint64_t DispatcherLoopTop{};
+      uint64_t DispatcherLoopTopFillSRA{};
+      uint64_t ThreadStopHandler{};
+      uint64_t ThreadPauseHandler{};
+      uint64_t UnimplementedInstructionHandler{};
+      uint64_t OverflowExceptionHandler{};
+      uint64_t SignalReturnHandler{};
+      uint64_t L1Pointer{};
+      /**  @} */
     } X86;
   };
 


### PR DESCRIPTION
Just like the previous AArch64 JIT.
These pointers are process or thread specific depending on the pointer
and should be loaded from the State object.

Performance here might slightly increase.

This is required for code cache on x86

Needs https://github.com/FEX-Emu/FEX/pull/1574 merged first.