### PR TITLE
JIT: Implements x87 fallback helpers as lookups in to state 

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterFallbacks.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterFallbacks.cpp
@@ -1,3 +1,4 @@
+#include "FEXCore/Core/CoreState.h"
 #include "Interface/Core/Interpreter/InterpreterOps.h"
 #include "Interface/Core/Interpreter/F80Ops.h"
 
@@ -7,80 +8,127 @@
 namespace FEXCore::CPU {
 
 template<typename R, typename... Args>
-static FallbackInfo GetFallbackInfo(R(*fn)(Args...)) {
-  return {FABI_UNKNOWN, (void*)fn};
+static FallbackInfo GetFallbackInfo(R(*fn)(Args...), FEXCore::Core::FallbackHandlerIndex HandlerIndex) {
+  return {FABI_UNKNOWN, (void*)fn, HandlerIndex};
 }
 
 template<>
-FallbackInfo GetFallbackInfo(X80SoftFloat(*fn)(float)) {
-  return {FABI_F80_F32, (void*)fn};
+FallbackInfo GetFallbackInfo(X80SoftFloat(*fn)(float), FEXCore::Core::FallbackHandlerIndex HandlerIndex) {
+  return {FABI_F80_F32, (void*)fn, HandlerIndex};
 }
 
 template<>
-FallbackInfo GetFallbackInfo(X80SoftFloat(*fn)(double)) {
-  return {FABI_F80_F64, (void*)fn};
+FallbackInfo GetFallbackInfo(X80SoftFloat(*fn)(double), FEXCore::Core::FallbackHandlerIndex HandlerIndex) {
+  return {FABI_F80_F64, (void*)fn, HandlerIndex};
 }
 
 template<>
-FallbackInfo GetFallbackInfo(X80SoftFloat(*fn)(int16_t)) {
-  return {FABI_F80_I16, (void*)fn};
+FallbackInfo GetFallbackInfo(X80SoftFloat(*fn)(int16_t), FEXCore::Core::FallbackHandlerIndex HandlerIndex) {
+  return {FABI_F80_I16, (void*)fn, HandlerIndex};
 }
 
 template<>
-FallbackInfo GetFallbackInfo(void(*fn)(uint16_t)) {
-  return {FABI_VOID_U16, (void*)fn};
+FallbackInfo GetFallbackInfo(void(*fn)(uint16_t), FEXCore::Core::FallbackHandlerIndex HandlerIndex) {
+  return {FABI_VOID_U16, (void*)fn, HandlerIndex};
 }
 
 template<>
-FallbackInfo GetFallbackInfo(X80SoftFloat(*fn)(int32_t)) {
-  return {FABI_F80_I32, (void*)fn};
+FallbackInfo GetFallbackInfo(X80SoftFloat(*fn)(int32_t), FEXCore::Core::FallbackHandlerIndex HandlerIndex) {
+  return {FABI_F80_I32, (void*)fn, HandlerIndex};
 }
 
 template<>
-FallbackInfo GetFallbackInfo(float(*fn)(X80SoftFloat)) {
-  return {FABI_F32_F80, (void*)fn};
+FallbackInfo GetFallbackInfo(float(*fn)(X80SoftFloat), FEXCore::Core::FallbackHandlerIndex HandlerIndex) {
+  return {FABI_F32_F80, (void*)fn, HandlerIndex};
 }
 
 template<>
-FallbackInfo GetFallbackInfo(double(*fn)(X80SoftFloat)) {
-  return {FABI_F64_F80, (void*)fn};
+FallbackInfo GetFallbackInfo(double(*fn)(X80SoftFloat), FEXCore::Core::FallbackHandlerIndex HandlerIndex) {
+  return {FABI_F64_F80, (void*)fn, HandlerIndex};
 }
 
 template<>
-FallbackInfo GetFallbackInfo(int16_t(*fn)(X80SoftFloat)) {
-  return {FABI_I16_F80, (void*)fn};
+FallbackInfo GetFallbackInfo(int16_t(*fn)(X80SoftFloat), FEXCore::Core::FallbackHandlerIndex HandlerIndex) {
+  return {FABI_I16_F80, (void*)fn, HandlerIndex};
 }
 
 template<>
-FallbackInfo GetFallbackInfo(int32_t(*fn)(X80SoftFloat)) {
-  return {FABI_I32_F80, (void*)fn};
+FallbackInfo GetFallbackInfo(int32_t(*fn)(X80SoftFloat), FEXCore::Core::FallbackHandlerIndex HandlerIndex) {
+  return {FABI_I32_F80, (void*)fn, HandlerIndex};
 }
 
 template<>
-FallbackInfo GetFallbackInfo(int64_t(*fn)(X80SoftFloat)) {
-  return {FABI_I64_F80, (void*)fn};
+FallbackInfo GetFallbackInfo(int64_t(*fn)(X80SoftFloat), FEXCore::Core::FallbackHandlerIndex HandlerIndex) {
+  return {FABI_I64_F80, (void*)fn, HandlerIndex};
 }
 
 template<>
-FallbackInfo GetFallbackInfo(uint64_t(*fn)(X80SoftFloat, X80SoftFloat)) {
-  return {FABI_I64_F80_F80, (void*)fn};
+FallbackInfo GetFallbackInfo(uint64_t(*fn)(X80SoftFloat, X80SoftFloat), FEXCore::Core::FallbackHandlerIndex HandlerIndex) {
+  return {FABI_I64_F80_F80, (void*)fn, HandlerIndex};
 }
 
 template<>
-FallbackInfo GetFallbackInfo(X80SoftFloat(*fn)(X80SoftFloat)) {
-  return {FABI_F80_F80, (void*)fn};
+FallbackInfo GetFallbackInfo(X80SoftFloat(*fn)(X80SoftFloat), FEXCore::Core::FallbackHandlerIndex HandlerIndex) {
+  return {FABI_F80_F80, (void*)fn, HandlerIndex};
 }
 
 template<>
-FallbackInfo GetFallbackInfo(X80SoftFloat(*fn)(X80SoftFloat, X80SoftFloat)) {
-  return {FABI_F80_F80_F80, (void*)fn};
+FallbackInfo GetFallbackInfo(X80SoftFloat(*fn)(X80SoftFloat, X80SoftFloat), FEXCore::Core::FallbackHandlerIndex HandlerIndex) {
+  return {FABI_F80_F80_F80, (void*)fn, HandlerIndex};
+}
+
+void InterpreterOps::FillFallbackIndexPointers(uint64_t *Info) {
+  Info[Core::OPINDEX_F80LOADFCW] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80LOADFCW>::handle, Core::OPINDEX_F80LOADFCW).fn);
+  Info[Core::OPINDEX_F80CVTTO_4] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80CVTTO>::handle4, Core::OPINDEX_F80CVTTO_4).fn);
+  Info[Core::OPINDEX_F80CVTTO_8] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80CVTTO>::handle8, Core::OPINDEX_F80CVTTO_8).fn);
+  Info[Core::OPINDEX_F80CVT_4] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80CVT>::handle4, Core::OPINDEX_F80CVT_4).fn);
+  Info[Core::OPINDEX_F80CVT_8] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80CVT>::handle8, Core::OPINDEX_F80CVT_8).fn);
+  Info[Core::OPINDEX_F80CVTINT_2] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80CVTINT>::handle2, Core::OPINDEX_F80CVTINT_2).fn);
+  Info[Core::OPINDEX_F80CVTINT_4] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80CVTINT>::handle4, Core::OPINDEX_F80CVTINT_4).fn);
+  Info[Core::OPINDEX_F80CVTINT_8] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80CVTINT>::handle8, Core::OPINDEX_F80CVTINT_8).fn);
+  Info[Core::OPINDEX_F80CVTINT_TRUNC2] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80CVTINT>::handle2t, Core::OPINDEX_F80CVTINT_TRUNC2).fn);
+  Info[Core::OPINDEX_F80CVTINT_TRUNC4] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80CVTINT>::handle4t, Core::OPINDEX_F80CVTINT_TRUNC4).fn);
+  Info[Core::OPINDEX_F80CVTINT_TRUNC8] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80CVTINT>::handle8t, Core::OPINDEX_F80CVTINT_TRUNC8).fn);
+  Info[Core::OPINDEX_F80CMP_0] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80CMP>::handle<0>, Core::OPINDEX_F80CMP_0).fn);
+  Info[Core::OPINDEX_F80CMP_1] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80CMP>::handle<1>, Core::OPINDEX_F80CMP_1).fn);
+  Info[Core::OPINDEX_F80CMP_2] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80CMP>::handle<2>, Core::OPINDEX_F80CMP_2).fn);
+  Info[Core::OPINDEX_F80CMP_3] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80CMP>::handle<3>, Core::OPINDEX_F80CMP_3).fn);
+  Info[Core::OPINDEX_F80CMP_4] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80CMP>::handle<4>, Core::OPINDEX_F80CMP_4).fn);
+  Info[Core::OPINDEX_F80CMP_5] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80CMP>::handle<5>, Core::OPINDEX_F80CMP_5).fn);
+  Info[Core::OPINDEX_F80CMP_6] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80CMP>::handle<6>, Core::OPINDEX_F80CMP_6).fn);
+  Info[Core::OPINDEX_F80CMP_7] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80CMP>::handle<7>, Core::OPINDEX_F80CMP_7).fn);
+  Info[Core::OPINDEX_F80CVTTOINT_2] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80CVTTOINT>::handle2, Core::OPINDEX_F80CVTTOINT_2).fn);
+  Info[Core::OPINDEX_F80CVTTOINT_4] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80CVTTOINT>::handle4, Core::OPINDEX_F80CVTTOINT_4).fn);
+
+  // Unary
+  Info[Core::OPINDEX_F80ROUND] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80ROUND>::handle, Core::OPINDEX_F80ROUND).fn);
+  Info[Core::OPINDEX_F80F2XM1] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80F2XM1>::handle, Core::OPINDEX_F80F2XM1).fn);
+  Info[Core::OPINDEX_F80TAN] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80TAN>::handle, Core::OPINDEX_F80TAN).fn);
+  Info[Core::OPINDEX_F80SQRT] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80SQRT>::handle, Core::OPINDEX_F80SQRT).fn);
+  Info[Core::OPINDEX_F80SIN] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80SIN>::handle, Core::OPINDEX_F80SIN).fn);
+  Info[Core::OPINDEX_F80COS] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80COS>::handle, Core::OPINDEX_F80COS).fn);
+  Info[Core::OPINDEX_F80XTRACT_EXP] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80XTRACT_EXP>::handle, Core::OPINDEX_F80XTRACT_EXP).fn);
+  Info[Core::OPINDEX_F80XTRACT_SIG] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80XTRACT_SIG>::handle, Core::OPINDEX_F80XTRACT_SIG).fn);
+  Info[Core::OPINDEX_F80BCDSTORE] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80BCDSTORE>::handle, Core::OPINDEX_F80BCDSTORE).fn);
+  Info[Core::OPINDEX_F80BCDLOAD] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80BCDLOAD>::handle, Core::OPINDEX_F80BCDLOAD).fn);
+
+  // Binary
+  Info[Core::OPINDEX_F80ADD] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80ADD>::handle, Core::OPINDEX_F80ADD).fn);
+  Info[Core::OPINDEX_F80SUB] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80SUB>::handle, Core::OPINDEX_F80SUB).fn);
+  Info[Core::OPINDEX_F80MUL] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80MUL>::handle, Core::OPINDEX_F80MUL).fn);
+  Info[Core::OPINDEX_F80DIV] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80DIV>::handle, Core::OPINDEX_F80DIV).fn);
+  Info[Core::OPINDEX_F80FYL2X] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80FYL2X>::handle, Core::OPINDEX_F80FYL2X).fn);
+  Info[Core::OPINDEX_F80ATAN] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80ATAN>::handle, Core::OPINDEX_F80ATAN).fn);
+  Info[Core::OPINDEX_F80FPREM1] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80FPREM1>::handle, Core::OPINDEX_F80FPREM1).fn);
+  Info[Core::OPINDEX_F80FPREM] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80FPREM>::handle, Core::OPINDEX_F80FPREM).fn);
+  Info[Core::OPINDEX_F80SCALE] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80SCALE>::handle, Core::OPINDEX_F80SCALE).fn);
 }
 
 bool InterpreterOps::GetFallbackHandler(IR::IROp_Header *IROp, FallbackInfo *Info) {
   uint8_t OpSize = IROp->Size;
   switch(IROp->Op) {
     case IR::OP_F80LOADFCW: {
-      *Info = GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80LOADFCW>::handle);
+      *Info = GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80LOADFCW>::handle, Core::OPINDEX_F80LOADFCW);
       return true;
     }
 
@@ -89,11 +137,11 @@ bool InterpreterOps::GetFallbackHandler(IR::IROp_Header *IROp, FallbackInfo *Inf
 
       switch (Op->Size) {
         case 4: {
-          *Info = GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80CVTTO>::handle4);
+          *Info = GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80CVTTO>::handle4, Core::OPINDEX_F80CVTTO_4);
           return true;
         }
         case 8: {
-          *Info = GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80CVTTO>::handle8);
+          *Info = GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80CVTTO>::handle8, Core::OPINDEX_F80CVTTO_8);
           return true;
         }
       default: LogMan::Msg::DFmt("Unhandled size: {}", OpSize);
@@ -103,11 +151,11 @@ bool InterpreterOps::GetFallbackHandler(IR::IROp_Header *IROp, FallbackInfo *Inf
     case IR::OP_F80CVT: {
       switch (OpSize) {
         case 4: {
-          *Info = GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80CVT>::handle4);
+          *Info = GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80CVT>::handle4, Core::OPINDEX_F80CVT_4);
           return true;
         }
         case 8: {
-          *Info = GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80CVT>::handle8);
+          *Info = GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80CVT>::handle8, Core::OPINDEX_F80CVT_8);
           return true;
         }
         default: LogMan::Msg::DFmt("Unhandled size: {}", OpSize);
@@ -119,15 +167,30 @@ bool InterpreterOps::GetFallbackHandler(IR::IROp_Header *IROp, FallbackInfo *Inf
 
       switch (OpSize) {
         case 2: {
-          *Info = GetFallbackInfo(Op->Truncate ? &FEXCore::CPU::OpHandlers<IR::OP_F80CVTINT>::handle2t : &FEXCore::CPU::OpHandlers<IR::OP_F80CVTINT>::handle2);
+          if (Op->Truncate) {
+            *Info = GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80CVTINT>::handle2t, Core::OPINDEX_F80CVTINT_TRUNC2);
+          }
+          else {
+            *Info = GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80CVTINT>::handle2, Core::OPINDEX_F80CVTINT_2);
+          }
           return true;
         }
         case 4: {
-          *Info = GetFallbackInfo(Op->Truncate ? &FEXCore::CPU::OpHandlers<IR::OP_F80CVTINT>::handle4t : &FEXCore::CPU::OpHandlers<IR::OP_F80CVTINT>::handle4);
+          if (Op->Truncate) {
+            *Info = GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80CVTINT>::handle4t, Core::OPINDEX_F80CVTINT_TRUNC4);
+          }
+          else {
+            *Info = GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80CVTINT>::handle4, Core::OPINDEX_F80CVTINT_4);
+          }
           return true;
         }
         case 8: {
-          *Info = GetFallbackInfo(Op->Truncate ? &FEXCore::CPU::OpHandlers<IR::OP_F80CVTINT>::handle8t : &FEXCore::CPU::OpHandlers<IR::OP_F80CVTINT>::handle8);
+          if (Op->Truncate) {
+            *Info = GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80CVTINT>::handle8t, Core::OPINDEX_F80CVTINT_TRUNC8);
+          }
+          else {
+            *Info = GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80CVTINT>::handle8, Core::OPINDEX_F80CVTINT_8);
+          }
           return true;
         }
         default: LogMan::Msg::DFmt("Unhandled size: {}", OpSize);
@@ -148,7 +211,7 @@ bool InterpreterOps::GetFallbackHandler(IR::IROp_Header *IROp, FallbackInfo *Inf
         &FEXCore::CPU::OpHandlers<IR::OP_F80CMP>::handle<7>,
       };
 
-      *Info = GetFallbackInfo(handlers[Op->Flags]);
+      *Info = GetFallbackInfo(handlers[Op->Flags], (Core::FallbackHandlerIndex)(Core::OPINDEX_F80CMP_0 + Op->Flags));
       return true;
     }
 
@@ -157,11 +220,11 @@ bool InterpreterOps::GetFallbackHandler(IR::IROp_Header *IROp, FallbackInfo *Inf
 
       switch (Op->Size) {
         case 2: {
-          *Info = GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80CVTTOINT>::handle2);
+          *Info = GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80CVTTOINT>::handle2, Core::OPINDEX_F80CVTTOINT_2);
           return true;
         }
         case 4: {
-          *Info = GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80CVTTOINT>::handle4);
+          *Info = GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80CVTTOINT>::handle4, Core::OPINDEX_F80CVTTOINT_4);
           return true;
         }
         default: LogMan::Msg::DFmt("Unhandled size: {}", OpSize);
@@ -171,7 +234,7 @@ bool InterpreterOps::GetFallbackHandler(IR::IROp_Header *IROp, FallbackInfo *Inf
 
 #define COMMON_X87_OP(OP) \
     case IR::OP_F80##OP: { \
-      *Info = GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80##OP>::handle); \
+      *Info = GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80##OP>::handle, Core::OPINDEX_F80##OP); \
       return true; \
     }
 

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <stdint.h>
 
+#include <FEXCore/Core/CoreState.h>
 #include <FEXCore/IR/IR.h>
 #include <FEXCore/IR/IntrusiveIRList.h>
 
@@ -38,12 +39,14 @@ namespace FEXCore::CPU {
   struct FallbackInfo {
     FallbackABI ABI;
     void *fn;
+    FEXCore::Core::FallbackHandlerIndex HandlerIndex;
   };
 
   class InterpreterOps {
 
     public:
       static void InterpretIR(FEXCore::Core::InternalThreadState *Thread, uint64_t Entry, FEXCore::IR::IRListView *CurrentIR, FEXCore::Core::DebugData *DebugData);
+      static void FillFallbackIndexPointers(uint64_t *Info);
       static bool GetFallbackHandler(IR::IROp_Header *IROp, FallbackInfo *Info);
 
       struct IROpData {

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -93,8 +93,7 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header *IROp, IR::NodeID Node) {
         PushDynamicRegsAndLR();
 
         uxth(w0, GetReg<RA_32>(IROp->Args[0].ID()));
-        LoadConstant(x1, (uintptr_t)Info.fn);
-
+        ldr(x1, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.AArch64.FallbackHandlerPointers[Info.HandlerIndex])));
         blr(x1);
 
         PopDynamicRegsAndLR();
@@ -109,8 +108,7 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header *IROp, IR::NodeID Node) {
         PushDynamicRegsAndLR();
 
         fmov(v0.S(), GetSrc(IROp->Args[0].ID()).S()) ;
-        LoadConstant(x0, (uintptr_t)Info.fn);
-
+        ldr(x0, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.AArch64.FallbackHandlerPointers[Info.HandlerIndex])));
         blr(x0);
 
         PopDynamicRegsAndLR();
@@ -129,8 +127,7 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header *IROp, IR::NodeID Node) {
         PushDynamicRegsAndLR();
 
         mov(v0.D(), GetSrc(IROp->Args[0].ID()).D());
-        LoadConstant(x0, (uintptr_t)Info.fn);
-
+        ldr(x0, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.AArch64.FallbackHandlerPointers[Info.HandlerIndex])));
         blr(x0);
 
         PopDynamicRegsAndLR();
@@ -155,8 +152,7 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header *IROp, IR::NodeID Node) {
         else {
           mov(w0, GetReg<RA_32>(IROp->Args[0].ID()));
         }
-        LoadConstant(x1, (uintptr_t)Info.fn);
-
+        ldr(x1, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.AArch64.FallbackHandlerPointers[Info.HandlerIndex])));
         blr(x1);
 
         PopDynamicRegsAndLR();
@@ -177,8 +173,7 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header *IROp, IR::NodeID Node) {
         umov(x0, GetSrc(IROp->Args[0].ID()).V2D(), 0);
         umov(w1, GetSrc(IROp->Args[0].ID()).V8H(), 4);
 
-        LoadConstant(x2, (uintptr_t)Info.fn);
-
+        ldr(x2, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.AArch64.FallbackHandlerPointers[Info.HandlerIndex])));
         blr(x2);
 
         PopDynamicRegsAndLR();
@@ -197,8 +192,7 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header *IROp, IR::NodeID Node) {
         umov(x0, GetSrc(IROp->Args[0].ID()).V2D(), 0);
         umov(w1, GetSrc(IROp->Args[0].ID()).V8H(), 4);
 
-        LoadConstant(x2, (uintptr_t)Info.fn);
-
+        ldr(x2, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.AArch64.FallbackHandlerPointers[Info.HandlerIndex])));
         blr(x2);
 
         PopDynamicRegsAndLR();
@@ -217,8 +211,7 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header *IROp, IR::NodeID Node) {
         umov(x0, GetSrc(IROp->Args[0].ID()).V2D(), 0);
         umov(w1, GetSrc(IROp->Args[0].ID()).V8H(), 4);
 
-        LoadConstant(x2, (uintptr_t)Info.fn);
-
+        ldr(x2, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.AArch64.FallbackHandlerPointers[Info.HandlerIndex])));
         blr(x2);
 
         PopDynamicRegsAndLR();
@@ -236,8 +229,7 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header *IROp, IR::NodeID Node) {
         umov(x0, GetSrc(IROp->Args[0].ID()).V2D(), 0);
         umov(w1, GetSrc(IROp->Args[0].ID()).V8H(), 4);
 
-        LoadConstant(x2, (uintptr_t)Info.fn);
-
+        ldr(x2, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.AArch64.FallbackHandlerPointers[Info.HandlerIndex])));
         blr(x2);
 
         PopDynamicRegsAndLR();
@@ -255,8 +247,7 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header *IROp, IR::NodeID Node) {
         umov(x0, GetSrc(IROp->Args[0].ID()).V2D(), 0);
         umov(w1, GetSrc(IROp->Args[0].ID()).V8H(), 4);
 
-        LoadConstant(x2, (uintptr_t)Info.fn);
-
+        ldr(x2, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.AArch64.FallbackHandlerPointers[Info.HandlerIndex])));
         blr(x2);
 
         PopDynamicRegsAndLR();
@@ -277,8 +268,7 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header *IROp, IR::NodeID Node) {
         umov(x2, GetSrc(IROp->Args[1].ID()).V2D(), 0);
         umov(w3, GetSrc(IROp->Args[1].ID()).V8H(), 4);
 
-        LoadConstant(x4, (uintptr_t)Info.fn);
-
+        ldr(x4, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.AArch64.FallbackHandlerPointers[Info.HandlerIndex])));
         blr(x4);
 
         PopDynamicRegsAndLR();
@@ -296,8 +286,7 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header *IROp, IR::NodeID Node) {
         umov(x0, GetSrc(IROp->Args[0].ID()).V2D(), 0);
         umov(w1, GetSrc(IROp->Args[0].ID()).V8H(), 4);
 
-        LoadConstant(x2, (uintptr_t)Info.fn);
-
+        ldr(x2, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.AArch64.FallbackHandlerPointers[Info.HandlerIndex])));
         blr(x2);
 
         PopDynamicRegsAndLR();
@@ -320,8 +309,7 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header *IROp, IR::NodeID Node) {
         umov(x2, GetSrc(IROp->Args[1].ID()).V2D(), 0);
         umov(w3, GetSrc(IROp->Args[1].ID()).V8H(), 4);
 
-        LoadConstant(x4, (uintptr_t)Info.fn);
-
+        ldr(x4, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.AArch64.FallbackHandlerPointers[Info.HandlerIndex])));
         blr(x4);
 
         PopDynamicRegsAndLR();
@@ -394,6 +382,9 @@ Arm64JITCore::Arm64JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::Intern
 
     Pointers.SyscallHandlerObj = reinterpret_cast<uint64_t>(CTX->SyscallHandler);
     Pointers.SyscallHandlerFunc = reinterpret_cast<uint64_t>(FEXCore::Context::HandleSyscall);
+
+    // Fill in the fallback handlers
+    InterpreterOps::FillFallbackIndexPointers(Pointers.FallbackHandlerPointers);
 
     // Thread Specific
     Pointers.SignalHandlerRefCountPointer = reinterpret_cast<uint64_t>(&Dispatcher->SignalHandlerRefCounter);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -120,9 +120,7 @@ void X86JITCore::Op_Unhandled(IR::IROp_Header *IROp, IR::NodeID Node) {
       case FABI_VOID_U16: {
         PushRegs();
         mov(edi, GetSrc<RA_32>(IROp->Args[0].ID()));
-        mov(rax, (uintptr_t)Info.fn);
-
-        call(rax);
+        call(qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, Pointers.X86.FallbackHandlerPointers[Info.HandlerIndex])]);
 
         PopRegs();
         break;
@@ -131,9 +129,7 @@ void X86JITCore::Op_Unhandled(IR::IROp_Header *IROp, IR::NodeID Node) {
         PushRegs();
 
         movss(xmm0, GetSrc(IROp->Args[0].ID()));
-        mov(rax, (uintptr_t)Info.fn);
-
-        call(rax);
+        call(qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, Pointers.X86.FallbackHandlerPointers[Info.HandlerIndex])]);
 
         PopRegs();
 
@@ -147,9 +143,7 @@ void X86JITCore::Op_Unhandled(IR::IROp_Header *IROp, IR::NodeID Node) {
         PushRegs();
 
         movsd(xmm0, GetSrc(IROp->Args[0].ID()));
-        mov(rax, (uintptr_t)Info.fn);
-
-        call(rax);
+        call(qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, Pointers.X86.FallbackHandlerPointers[Info.HandlerIndex])]);
 
         PopRegs();
 
@@ -164,9 +158,7 @@ void X86JITCore::Op_Unhandled(IR::IROp_Header *IROp, IR::NodeID Node) {
         PushRegs();
 
         mov(edi, GetSrc<RA_32>(IROp->Args[0].ID()));
-        mov(rax, (uintptr_t)Info.fn);
-
-        call(rax);
+        call(qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, Pointers.X86.FallbackHandlerPointers[Info.HandlerIndex])]);
 
         PopRegs();
 
@@ -182,9 +174,7 @@ void X86JITCore::Op_Unhandled(IR::IROp_Header *IROp, IR::NodeID Node) {
         movq(rdi, GetSrc(IROp->Args[0].ID()));
         pextrq(rsi, GetSrc(IROp->Args[0].ID()), 1);
 
-        mov(rax, (uintptr_t)Info.fn);
-
-        call(rax);
+        call(qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, Pointers.X86.FallbackHandlerPointers[Info.HandlerIndex])]);
 
         PopRegs();
 
@@ -198,9 +188,7 @@ void X86JITCore::Op_Unhandled(IR::IROp_Header *IROp, IR::NodeID Node) {
         movq(rdi, GetSrc(IROp->Args[0].ID()));
         pextrq(rsi, GetSrc(IROp->Args[0].ID()), 1);
 
-        mov(rax, (uintptr_t)Info.fn);
-
-        call(rax);
+        call(qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, Pointers.X86.FallbackHandlerPointers[Info.HandlerIndex])]);
 
         PopRegs();
 
@@ -214,9 +202,7 @@ void X86JITCore::Op_Unhandled(IR::IROp_Header *IROp, IR::NodeID Node) {
         movq(rdi, GetSrc(IROp->Args[0].ID()));
         pextrq(rsi, GetSrc(IROp->Args[0].ID()), 1);
 
-        mov(rax, (uintptr_t)Info.fn);
-
-        call(rax);
+        call(qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, Pointers.X86.FallbackHandlerPointers[Info.HandlerIndex])]);
 
         PopRegs();
 
@@ -229,9 +215,7 @@ void X86JITCore::Op_Unhandled(IR::IROp_Header *IROp, IR::NodeID Node) {
         movq(rdi, GetSrc(IROp->Args[0].ID()));
         pextrq(rsi, GetSrc(IROp->Args[0].ID()), 1);
 
-        mov(rax, (uintptr_t)Info.fn);
-
-        call(rax);
+        call(qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, Pointers.X86.FallbackHandlerPointers[Info.HandlerIndex])]);
 
         PopRegs();
 
@@ -244,9 +228,7 @@ void X86JITCore::Op_Unhandled(IR::IROp_Header *IROp, IR::NodeID Node) {
         movq(rdi, GetSrc(IROp->Args[0].ID()));
         pextrq(rsi, GetSrc(IROp->Args[0].ID()), 1);
 
-        mov(rax, (uintptr_t)Info.fn);
-
-        call(rax);
+        call(qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, Pointers.X86.FallbackHandlerPointers[Info.HandlerIndex])]);
 
         PopRegs();
 
@@ -262,9 +244,7 @@ void X86JITCore::Op_Unhandled(IR::IROp_Header *IROp, IR::NodeID Node) {
         movq(rdx, GetSrc(IROp->Args[1].ID()));
         pextrq(rcx, GetSrc(IROp->Args[1].ID()), 1);
 
-        mov(rax, (uintptr_t)Info.fn);
-
-        call(rax);
+        call(qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, Pointers.X86.FallbackHandlerPointers[Info.HandlerIndex])]);
 
         PopRegs();
 
@@ -277,9 +257,7 @@ void X86JITCore::Op_Unhandled(IR::IROp_Header *IROp, IR::NodeID Node) {
         movq(rdi, GetSrc(IROp->Args[0].ID()));
         pextrq(rsi, GetSrc(IROp->Args[0].ID()), 1);
 
-        mov(rax, (uintptr_t)Info.fn);
-
-        call(rax);
+        call(qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, Pointers.X86.FallbackHandlerPointers[Info.HandlerIndex])]);
 
         PopRegs();
 
@@ -297,9 +275,7 @@ void X86JITCore::Op_Unhandled(IR::IROp_Header *IROp, IR::NodeID Node) {
         movq(rdx, GetSrc(IROp->Args[1].ID()));
         pextrq(rcx, GetSrc(IROp->Args[1].ID()), 1);
 
-        mov(rax, (uintptr_t)Info.fn);
-
-        call(rax);
+        call(qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, Pointers.X86.FallbackHandlerPointers[Info.HandlerIndex])]);
 
         PopRegs();
 
@@ -345,6 +321,9 @@ X86JITCore::X86JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalTh
 
     Pointers.SyscallHandlerObj = reinterpret_cast<uint64_t>(CTX->SyscallHandler);
     Pointers.SyscallHandlerFunc = reinterpret_cast<uint64_t>(FEXCore::Context::HandleSyscall);
+
+    // Fill in the fallback handlers
+    InterpreterOps::FillFallbackIndexPointers(Pointers.FallbackHandlerPointers);
 
     // Thread Specific
     Pointers.SignalHandlerRefCountPointer = reinterpret_cast<uint64_t>(&Dispatcher->SignalHandlerRefCounter);

--- a/External/FEXCore/include/FEXCore/Core/CoreState.h
+++ b/External/FEXCore/include/FEXCore/Core/CoreState.h
@@ -31,6 +31,57 @@ namespace FEXCore::Core {
   static_assert(offsetof(CPUState, xmm) % 16 == 0, "xmm needs to be 128bit aligned!");
 
   struct InternalThreadState;
+
+  enum FallbackHandlerIndex {
+    OPINDEX_F80LOADFCW = 0,
+    OPINDEX_F80CVTTO_4,
+    OPINDEX_F80CVTTO_8,
+    OPINDEX_F80CVT_4,
+    OPINDEX_F80CVT_8,
+    OPINDEX_F80CVTINT_2,
+    OPINDEX_F80CVTINT_4,
+    OPINDEX_F80CVTINT_8,
+    OPINDEX_F80CVTINT_TRUNC2,
+    OPINDEX_F80CVTINT_TRUNC4,
+    OPINDEX_F80CVTINT_TRUNC8,
+    OPINDEX_F80CMP_0,
+    OPINDEX_F80CMP_1,
+    OPINDEX_F80CMP_2,
+    OPINDEX_F80CMP_3,
+    OPINDEX_F80CMP_4,
+    OPINDEX_F80CMP_5,
+    OPINDEX_F80CMP_6,
+    OPINDEX_F80CMP_7,
+    OPINDEX_F80CVTTOINT_2,
+    OPINDEX_F80CVTTOINT_4,
+
+    // Unary
+    OPINDEX_F80ROUND,
+    OPINDEX_F80F2XM1,
+    OPINDEX_F80TAN,
+    OPINDEX_F80SQRT,
+    OPINDEX_F80SIN,
+    OPINDEX_F80COS,
+    OPINDEX_F80XTRACT_EXP,
+    OPINDEX_F80XTRACT_SIG,
+    OPINDEX_F80BCDSTORE,
+    OPINDEX_F80BCDLOAD,
+
+    // Binary
+    OPINDEX_F80ADD,
+    OPINDEX_F80SUB,
+    OPINDEX_F80MUL,
+    OPINDEX_F80DIV,
+    OPINDEX_F80FYL2X,
+    OPINDEX_F80ATAN,
+    OPINDEX_F80FPREM1,
+    OPINDEX_F80FPREM,
+    OPINDEX_F80SCALE,
+
+    // Maximum
+    OPINDEX_MAX,
+  };
+
   union JITPointers {
     struct {
       // Process specific
@@ -45,6 +96,8 @@ namespace FEXCore::Core {
       uint64_t CPUIDFunction{};
       uint64_t SyscallHandlerObj{};
       uint64_t SyscallHandlerFunc{};
+
+      uint64_t FallbackHandlerPointers[FallbackHandlerIndex::OPINDEX_MAX];
 
       // Thread Specific
       uint64_t SignalHandlerRefCountPointer{};
@@ -72,6 +125,8 @@ namespace FEXCore::Core {
       uint64_t CPUIDFunction{};
       uint64_t SyscallHandlerObj{};
       uint64_t SyscallHandlerFunc{};
+
+      uint64_t FallbackHandlerPointers[FallbackHandlerIndex::OPINDEX_MAX];
 
       // Thread Specific
       uint64_t SignalHandlerRefCountPointer{};


### PR DESCRIPTION
This allows x87 fallbacks to be loaded from the upcoming code cache
without relocations.

Only 40 pointers necessary to store and means x87 code won't hit
relocations heavily.

Probably improves performance slightly on the x86 host side but should
be neglible.

Needs #1574 and #1575 merged first.