### PR TITLE
Fixes Host and guest thunks install path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -507,7 +507,7 @@ if (BUILD_THUNKS)
   install(
     CODE "MESSAGE(\"-- Installing: guest-libs\")"
     CODE "
-    EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} --build . --target ThunkGuestsInstall
+    EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} --build . --target install
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/Guest
     )"
     DEPENDS guest-libs

--- a/ThunkLibs/GuestLibs/CMakeLists.txt
+++ b/ThunkLibs/GuestLibs/CMakeLists.txt
@@ -92,10 +92,7 @@ function(add_guest_lib_with_name NAME LIBNAME)
   target_compile_options(${LIBNAME}-guest PRIVATE -DLIB_NAME=${LIBNAME} -DLIBLIB_NAME=lib${LIBNAME})
 
   if (GENERATE_GUEST_INSTALL_TARGETS)
-    add_custom_target(${LIBNAME}-guest-install
-      COMMAND ${CMAKE_COMMAND} -E make_directory $ENV{DESTDIR}/${DATA_DIRECTORY}/GuestThunks/
-      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_BINARY_DIR}/lib${LIBNAME}-guest.so $ENV{DESTDIR}/${DATA_DIRECTORY}/GuestThunks/)
-    add_dependencies(ThunkGuestsInstall ${LIBNAME}-guest-install)
+    install(TARGETS ${LIBNAME}-guest DESTINATION ${DATA_DIRECTORY}/GuestThunks/)
   endif()
 endfunction()
 

--- a/ThunkLibs/HostLibs/CMakeLists.txt
+++ b/ThunkLibs/HostLibs/CMakeLists.txt
@@ -76,7 +76,7 @@ function(add_host_lib_with_name NAME LIBNAME)
   # generated files forward-declare functions that need to be implemented manually, so pass --no-undefined to make sure errors are detected at compile-time rather than runtime
   target_link_options(${LIBNAME}-host PRIVATE "LINKER:--no-undefined")
 
-  install(TARGETS ${LIBNAME}-host DESTINATION $ENV{DESTDIR}/${HOSTLIBS_DATA_DIRECTORY}/HostThunks/)
+  install(TARGETS ${LIBNAME}-host DESTINATION ${HOSTLIBS_DATA_DIRECTORY}/HostThunks/)
 endfunction()
 
 function(add_host_lib NAME)


### PR DESCRIPTION
Hosts were using the cmake install path with $DESTDIR which duplicates
paths.

GuestThunks were doing some magic that wasn't actually necessary