### PR TITLE
Improve compatibility with older uapi kernel headers

### DIFF
--- a/FEXHeaderUtils/FEXHeaderUtils/Syscalls.h
+++ b/FEXHeaderUtils/FEXHeaderUtils/Syscalls.h
@@ -28,6 +28,10 @@ namespace FHU::Syscalls {
 #define CLONE_PIDFD 0x00001000
 #endif
 
+#ifndef SYS_statx
+#define SYS_statx 291
+#endif
+
 inline int32_t getcpu(uint32_t *cpu, uint32_t *node) {
   // Third argument is unused
 #if defined(HAS_SYSCALL_GETCPU) && HAS_SYSCALL_GETCPU

--- a/FEXHeaderUtils/FEXHeaderUtils/Syscalls.h
+++ b/FEXHeaderUtils/FEXHeaderUtils/Syscalls.h
@@ -28,8 +28,14 @@ namespace FHU::Syscalls {
 #define CLONE_PIDFD 0x00001000
 #endif
 
+#if defined(__aarch64__) || defined(_M_ARM64)
 #ifndef SYS_statx
 #define SYS_statx 291
+#endif
+#elif defined(__x86_64__) || defined(_M_X64)
+#ifndef SYS_statx
+#define SYS_statx 332
+#endif
 #endif
 
 inline int32_t getcpu(uint32_t *cpu, uint32_t *node) {

--- a/Source/Tests/LinuxSyscalls/x32/Ioctl/asound.h
+++ b/Source/Tests/LinuxSyscalls/x32/Ioctl/asound.h
@@ -12,6 +12,10 @@ namespace asound {
 #define SNDRV_TIMER_IOCTL_TREAD_OLD	_IOW('T', 0x02, int)
 #endif
 
+#ifndef SNDRV_PCM_IOCTL_USER_PVERSION
+#define SNDRV_PCM_IOCTL_USER_PVERSION   _IOW('A', 0x04, int)
+#endif
+
 #ifndef SNDRV_TIMER_IOCTL_TREAD64
 #define SNDRV_TIMER_IOCTL_TREAD64	_IOW('T', 0xa4, int)
 #endif

--- a/Source/Tests/LinuxSyscalls/x32/Ioctl/sockios.h
+++ b/Source/Tests/LinuxSyscalls/x32/Ioctl/sockios.h
@@ -7,6 +7,9 @@
 
 namespace FEX::HLE::x32 {
 namespace sockios {
+#ifndef SIOCGSKNS
+#define SIOCGSKNS	0x894C
+#endif
 #include "Tests/LinuxSyscalls/x32/Ioctl/sockios.inl"
 }
 }

--- a/Source/Tests/LinuxSyscalls/x32/Ioctl/streams.h
+++ b/Source/Tests/LinuxSyscalls/x32/Ioctl/streams.h
@@ -6,6 +6,9 @@
 
 namespace FEX::HLE::x32 {
 namespace streams {
+#ifndef TIOCGPTPEER
+#define TIOCGPTPEER     _IO('T', 0x41)
+#endif
 #include "Tests/LinuxSyscalls/x32/Ioctl/streams.inl"
 }
 

--- a/Source/Tests/LinuxSyscalls/x32/Ioctl/usbdev.h
+++ b/Source/Tests/LinuxSyscalls/x32/Ioctl/usbdev.h
@@ -7,6 +7,9 @@
 
 namespace FEX::HLE::x32 {
 namespace usbdev {
+#ifndef USBDEVFS_GET_SPEED
+#define USBDEVFS_GET_SPEED         _IO('U', 31)
+#endif
 #ifndef USBDEVFS_CONNINFO_EX
 #define USBDEVFS_CONNINFO_EX(len)  _IOC(_IOC_READ, 'U', 32, len)
 #endif

--- a/Source/Tests/LinuxSyscalls/x32/Socket.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Socket.cpp
@@ -46,6 +46,18 @@ namespace FEX::HLE::x32 {
 #ifndef SO_TIMESTAMPING_OLD
 #define SO_TIMESTAMPING_OLD 37
 #endif
+#ifndef SO_MEMINFO
+#define SO_MEMINFO 55
+#endif
+#ifndef SO_INCOMING_NAPI_ID
+#define SO_INCOMING_NAPI_ID 56
+#endif
+#ifndef SO_PEERGROUPS
+#define SO_PEERGROUPS 59
+#endif
+#ifndef SO_ZEROCOPY
+#define SO_ZEROCOPY 60
+#endif
 #ifndef SO_TXTIME
 #define SO_TXTIME 61
 #endif


### PR DESCRIPTION
Following up the work previously done in 2079f6b3c7be81fd10546ecd978d41a8d7d6f685.
Adding more defines for older Linux uapi headers missing some defines.

Compiles properly now against l4t linux v4.9.140.