### PR TITLE
CPUID: Implements leaf 4000_0000

### DIFF
--- a/External/FEXCore/Source/Interface/Core/CPUID.h
+++ b/External/FEXCore/Source/Interface/Core/CPUID.h
@@ -79,6 +79,7 @@ private:
   FEXCore::CPUID::FunctionResults Function_0Dh(uint32_t Leaf);
   FEXCore::CPUID::FunctionResults Function_15h(uint32_t Leaf);
   FEXCore::CPUID::FunctionResults Function_1Ah(uint32_t Leaf);
+  FEXCore::CPUID::FunctionResults Function_4000_0000h(uint32_t Leaf);
   FEXCore::CPUID::FunctionResults Function_8000_0000h(uint32_t Leaf);
   FEXCore::CPUID::FunctionResults Function_8000_0001h(uint32_t Leaf);
   FEXCore::CPUID::FunctionResults Function_8000_0002h(uint32_t Leaf);


### PR DESCRIPTION
This region is reserved for hypervisor uses. Let's follow other examples
and return a hypervisor vendor id signature as another way for software
to find if it is running under FEX-Emu.