### PR TITLE
OpcodeDispatcher: Fixes CMPXCHG8B/16B with 66h/72h/73h prefix

### DIFF
--- a/External/FEXCore/Scripts/json_ir_generator.py
+++ b/External/FEXCore/Scripts/json_ir_generator.py
@@ -550,6 +550,11 @@ def print_ir_allocator_helpers():
     output_file.write("\t\treturn HeaderOp->Size;\n")
     output_file.write("\t}\n\n")
 
+    output_file.write("\tuint8_t GetOpElementSize(const OrderedNode *Op) const {\n")
+    output_file.write("\t\tauto HeaderOp = Op->Header.Value.GetNode(DualListData.DataBegin());\n")
+    output_file.write("\t\treturn HeaderOp->ElementSize;\n")
+    output_file.write("\t}\n\n")
+
     output_file.write("\tuint8_t GetOpElements(const OrderedNode *Op) const {\n")
     output_file.write("\t\tauto HeaderOp = Op->Header.Value.GetNode(DualListData.DataBegin());\n")
     output_file.write("\t\tLOGMAN_THROW_A_FMT(HeaderOp->HasDest, \"Op {} has no dest\\n\", GetName(HeaderOp->Op));\n")

--- a/External/FEXCore/Source/Interface/Core/Interpreter/AtomicOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/AtomicOps.cpp
@@ -313,10 +313,9 @@ uint64_t AtomicCompareAndSwap(uint64_t expected, uint64_t desired, uint64_t *add
 #define DEF_OP(x) void InterpreterOps::Op_##x(IR::IROp_Header *IROp, IROpData *Data, IR::NodeID Node)
 DEF_OP(CASPair) {
   auto Op = IROp->C<IR::IROp_CASPair>();
-  uint8_t OpSize = IROp->Size;
 
   // Size is the size of each pair element
-  switch (OpSize) {
+  switch (IROp->ElementSize) {
     case 4: {
       GD = AtomicCompareAndSwap(
         *GetSrc<uint64_t*>(Data->SSAData, Op->Expected),
@@ -336,7 +335,7 @@ DEF_OP(CASPair) {
       memcpy(GDP, Result ? &Src1 : &Expected, 16);
       break;
     }
-    default: LOGMAN_MSG_A_FMT("Unknown CAS size: {}", OpSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown CAS size: {}", IROp->ElementSize); break;
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/Interpreter/MoveOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/MoveOps.cpp
@@ -26,8 +26,8 @@ DEF_OP(CreateElementPair) {
 
   uint8_t *Dst = GetDest<uint8_t*>(Data->SSAData, Node);
 
-  memcpy(Dst, Src_Lower, Op->Header.Size);
-  memcpy(Dst + Op->Header.Size, Src_Upper, Op->Header.Size);
+  memcpy(Dst, Src_Lower, IROp->ElementSize);
+  memcpy(Dst + IROp->ElementSize, Src_Upper, IROp->ElementSize);
 }
 
 DEF_OP(Mov) {

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/AtomicOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/AtomicOps.cpp
@@ -12,7 +12,6 @@ using namespace vixl::aarch64;
 #define DEF_OP(x) void Arm64JITCore::Op_##x(IR::IROp_Header *IROp, IR::NodeID Node)
 DEF_OP(CASPair) {
   auto Op = IROp->C<IR::IROp_CASPair>();
-  uint8_t OpSize = IROp->Size;
   // Size is the size of each pair element
   auto Dst = GetSrcPair<RA_64>(Node);
   auto Expected = GetSrcPair<RA_64>(Op->Expected.ID());
@@ -23,7 +22,7 @@ DEF_OP(CASPair) {
     mov(TMP3, Expected.first);
     mov(TMP4, Expected.second);
 
-    switch (OpSize) {
+    switch (IROp->ElementSize) {
     case 4:
       caspal(TMP3.W(), TMP4.W(), Desired.first.W(), Desired.second.W(), MemOperand(MemSrc));
       mov(Dst.first.W(), TMP3.W());
@@ -34,11 +33,11 @@ DEF_OP(CASPair) {
       mov(Dst.first, TMP3);
       mov(Dst.second, TMP4);
       break;
-    default: LOGMAN_MSG_A_FMT("Unsupported: {}", OpSize);
+    default: LOGMAN_MSG_A_FMT("Unsupported: {}", IROp->ElementSize);
     }
   }
   else {
-    switch (OpSize) {
+    switch (IROp->ElementSize) {
       case 4: {
         aarch64::Label LoopTop;
         aarch64::Label LoopNotExpected;
@@ -91,7 +90,7 @@ DEF_OP(CASPair) {
         bind(&LoopExpected);
         break;
       }
-      default: LOGMAN_MSG_A_FMT("Unsupported: {}", OpSize);
+      default: LOGMAN_MSG_A_FMT("Unsupported: {}", IROp->ElementSize);
     }
   }
 }

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MoveOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MoveOps.cpp
@@ -37,7 +37,7 @@ DEF_OP(CreateElementPair) {
   aarch64::Register RegSecond;
   aarch64::Register RegTmp;
 
-  switch (Op->Header.Size) {
+  switch (IROp->ElementSize) {
     case 4: {
       Dst = GetSrcPair<RA_32>(Node);
       RegFirst = GetReg<RA_32>(Op->Header.Args[0].ID());

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/AtomicOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/AtomicOps.cpp
@@ -18,7 +18,6 @@ namespace FEXCore::CPU {
 #define DEF_OP(x) void X86JITCore::Op_##x(IR::IROp_Header *IROp, IR::NodeID Node)
 DEF_OP(CASPair) {
   auto Op = IROp->C<IR::IROp_CAS>();
-  uint8_t OpSize = IROp->Size;
 
   // DataSrc = *Src1
   // if (DataSrc == Src3) { *Src1 == Src2; } Src2 = DataSrc
@@ -44,7 +43,7 @@ DEF_OP(CASPair) {
 
   lock();
 
-  switch (OpSize) {
+  switch (IROp->ElementSize) {
     case 4: {
       cmpxchg8b(dword [MemReg]);
       // EDX:EAX now contains the result
@@ -59,7 +58,7 @@ DEF_OP(CASPair) {
       mov(Dst.second, rdx);
     break;
     }
-    default: LOGMAN_MSG_A_FMT("Unsupported: {}", OpSize);
+    default: LOGMAN_MSG_A_FMT("Unsupported: {}", IROp->ElementSize);
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/MoveOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/MoveOps.cpp
@@ -42,7 +42,7 @@ DEF_OP(CreateElementPair) {
   Xbyak::Reg RegSecond;
   Xbyak::Reg RegTmp;
 
-  switch (Op->Header.Size) {
+  switch (IROp->ElementSize) {
     case 4: {
       Dst = GetSrcPair<RA_32>(Node);
       RegFirst = GetSrc<RA_32>(Op->Header.Args[0].ID());

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -4395,8 +4395,8 @@ void OpDispatchBuilder::CMPXCHGPairOp(OpcodeArgs) {
   const uint8_t GPRSize = CTX->GetGPRSize();
   // REX.W used to determine if it is 16byte or 8byte
   // Unlike CMPXCHG, the destination can only be a memory location
+  uint8_t Size = Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_REX_WIDENING ? 8 : 4;
 
-  const auto Size = GetSrcSize(Op);
   HandledLock = (Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_LOCK) != 0;
   // If this is a memory location then we want the pointer to it
   OrderedNode *Src1 = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1, false);
@@ -5797,8 +5797,13 @@ constexpr uint16_t PF_F2 = 3;
     {OPD(FEXCore::X86Tables::TYPE_GROUP_9, PF_NONE, 6), 1, &OpDispatchBuilder::RDRANDOp<false>},
     {OPD(FEXCore::X86Tables::TYPE_GROUP_9, PF_NONE, 7), 1, &OpDispatchBuilder::RDRANDOp<true>},
 
+    {OPD(FEXCore::X86Tables::TYPE_GROUP_9, PF_F3, 1), 1, &OpDispatchBuilder::CMPXCHGPairOp},
+
+    {OPD(FEXCore::X86Tables::TYPE_GROUP_9, PF_66, 1), 1, &OpDispatchBuilder::CMPXCHGPairOp},
     {OPD(FEXCore::X86Tables::TYPE_GROUP_9, PF_66, 6), 1, &OpDispatchBuilder::RDRANDOp<false>},
     {OPD(FEXCore::X86Tables::TYPE_GROUP_9, PF_66, 7), 1, &OpDispatchBuilder::RDRANDOp<true>},
+
+    {OPD(FEXCore::X86Tables::TYPE_GROUP_9, PF_F2, 1), 1, &OpDispatchBuilder::CMPXCHGPairOp},
 
     // GROUP 12
     {OPD(FEXCore::X86Tables::TYPE_GROUP_12, PF_NONE, 2), 1, &OpDispatchBuilder::PSRLI<2>},

--- a/External/FEXCore/Source/Interface/Core/X86Tables/SecondaryGroupTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/SecondaryGroupTables.cpp
@@ -148,7 +148,7 @@ void InitializeSecondaryGroupTables() {
     // CMPXCHG8B/16B works with all prefixes
     // Tooling fails to decode CMPXCHG with prefix
     {OPD(TYPE_GROUP_9, PF_NONE, 0), 1, X86InstInfo{"",           TYPE_INVALID, FLAGS_NONE,   0, nullptr}},
-    {OPD(TYPE_GROUP_9, PF_NONE, 1), 1, X86InstInfo{"CMPXCHG8B",  TYPE_INST, FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_SF_MOD_MEM_ONLY, 0, nullptr}},
+    {OPD(TYPE_GROUP_9, PF_NONE, 1), 1, X86InstInfo{"CMPXCHG8B/16B", TYPE_INST, FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_SF_MOD_MEM_ONLY, 0, nullptr}},
     {OPD(TYPE_GROUP_9, PF_NONE, 2), 1, X86InstInfo{"",           TYPE_INVALID, FLAGS_NONE,   0, nullptr}},
     {OPD(TYPE_GROUP_9, PF_NONE, 3), 1, X86InstInfo{"",           TYPE_INVALID, FLAGS_NONE,   0, nullptr}},
     {OPD(TYPE_GROUP_9, PF_NONE, 4), 1, X86InstInfo{"",           TYPE_INVALID, FLAGS_NONE,   0, nullptr}},
@@ -157,7 +157,7 @@ void InitializeSecondaryGroupTables() {
     {OPD(TYPE_GROUP_9, PF_NONE, 7), 1, X86InstInfo{"RDSEED",     TYPE_INST, FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_SF_MOD_REG_ONLY, 0, nullptr}},
 
     {OPD(TYPE_GROUP_9, PF_F3, 0), 1, X86InstInfo{"",           TYPE_INVALID, FLAGS_NONE,     0, nullptr}},
-    {OPD(TYPE_GROUP_9, PF_F3, 1), 1, X86InstInfo{"",           TYPE_INVALID, FLAGS_NONE,     0, nullptr}},
+    {OPD(TYPE_GROUP_9, PF_F3, 1), 1, X86InstInfo{"CMPXCHG8B/16B", TYPE_INST, FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_SF_MOD_MEM_ONLY, 0, nullptr}},
     {OPD(TYPE_GROUP_9, PF_F3, 2), 1, X86InstInfo{"",           TYPE_INVALID, FLAGS_NONE,     0, nullptr}},
     {OPD(TYPE_GROUP_9, PF_F3, 3), 1, X86InstInfo{"",           TYPE_INVALID, FLAGS_NONE,     0, nullptr}},
     {OPD(TYPE_GROUP_9, PF_F3, 4), 1, X86InstInfo{"",           TYPE_INVALID, FLAGS_NONE,     0, nullptr}},
@@ -166,7 +166,7 @@ void InitializeSecondaryGroupTables() {
     {OPD(TYPE_GROUP_9, PF_F3, 7), 1, X86InstInfo{"RDPID",      TYPE_INVALID, FLAGS_NONE,     0, nullptr}},
 
     {OPD(TYPE_GROUP_9, PF_66, 0), 1, X86InstInfo{"",           TYPE_INVALID, FLAGS_NONE,     0, nullptr}},
-    {OPD(TYPE_GROUP_9, PF_66, 1), 1, X86InstInfo{"CMPXCHG16B", TYPE_INST, FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_SF_MOD_MEM_ONLY, 0, nullptr}},
+    {OPD(TYPE_GROUP_9, PF_66, 1), 1, X86InstInfo{"CMPXCHG8B/16B", TYPE_INST, FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_SF_MOD_MEM_ONLY, 0, nullptr}},
     {OPD(TYPE_GROUP_9, PF_66, 2), 1, X86InstInfo{"",           TYPE_INVALID, FLAGS_NONE,     0, nullptr}},
     {OPD(TYPE_GROUP_9, PF_66, 3), 1, X86InstInfo{"",           TYPE_INVALID, FLAGS_NONE,     0, nullptr}},
     {OPD(TYPE_GROUP_9, PF_66, 4), 1, X86InstInfo{"",           TYPE_INVALID, FLAGS_NONE,     0, nullptr}},
@@ -175,7 +175,7 @@ void InitializeSecondaryGroupTables() {
     {OPD(TYPE_GROUP_9, PF_66, 7), 1, X86InstInfo{"RDSEED",     TYPE_INST, FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_SF_MOD_REG_ONLY, 0, nullptr}},
 
     {OPD(TYPE_GROUP_9, PF_F2, 0), 1, X86InstInfo{"",           TYPE_INVALID, FLAGS_NONE,     0, nullptr}},
-    {OPD(TYPE_GROUP_9, PF_F2, 1), 1, X86InstInfo{"",           TYPE_INVALID, FLAGS_NONE,     0, nullptr}},
+    {OPD(TYPE_GROUP_9, PF_F2, 1), 1, X86InstInfo{"CMPXCHG8B/16B", TYPE_INST, FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_SF_MOD_MEM_ONLY, 0, nullptr}},
     {OPD(TYPE_GROUP_9, PF_F2, 2), 1, X86InstInfo{"",           TYPE_INVALID, FLAGS_NONE,     0, nullptr}},
     {OPD(TYPE_GROUP_9, PF_F2, 3), 1, X86InstInfo{"",           TYPE_INVALID, FLAGS_NONE,     0, nullptr}},
     {OPD(TYPE_GROUP_9, PF_F2, 4), 1, X86InstInfo{"",           TYPE_INVALID, FLAGS_NONE,     0, nullptr}},

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -229,7 +229,7 @@
                  "The second GPR pair element is a bool if the number is valid",
                  "RNG hardware is allowed to fail early and return. Software must always check this"
                 ],
-        "DestSize": "8",
+        "DestSize": "16",
         "NumElements": "2"
       }
     },
@@ -287,7 +287,7 @@
         "Desc": ["Calls in to the CPUID handler function to return emulated CPUID",
                  "Returns a 128bit GPR pair that fits emulated EAX, EBX, EDX, ECX respectively"
                 ],
-        "DestSize": "8",
+        "DestSize": "16",
         "NumElements": "2"
       },
       "GuestCallDirect u64:$RIP, u64:$NextRIP": {
@@ -304,7 +304,7 @@
 
       "GPR = ExtractElementPair GPRPair:$Pair, u8:$Element": {
         "Desc": ["Extracts a register for the register pair"],
-        "DestSize": "GetOpSize(_Pair)"
+        "DestSize": "GetOpSize(_Pair) >> 1"
       },
 
       "GPRPair = CreateElementPair GPR:$Lower, GPR:$Upper": {
@@ -312,7 +312,7 @@
                  "ssa0 is the lower incoming register",
                  "ssa1 is the upper incoming register"
                 ],
-        "DestSize": "GetOpSize(_Lower)",
+        "DestSize": "GetOpSize(_Lower) * 2",
         "NumElements": "2"
       },
       "SSA = Phi SSA:$PhiBegin, SSA:$PhiEnd, RegisterClass:$Class": {
@@ -535,7 +535,11 @@
                 ],
         "HasDest": true,
         "DestSize": "GetOpSize(_Expected)",
-        "NumElements": "2"
+        "NumElements": "2",
+        "EmitValidation": [
+          "(GetOpElementSize(_Expected) == 4 && GetOpSize(_Expected) == 8) || GetOpElementSize(_Expected) == 8",
+          "(GetOpElementSize(_Expected) == 8 && GetOpSize(_Expected) == 16) || GetOpElementSize(_Expected) == 4"
+        ]
       },
       "GPR = AtomicAdd u8:#Size, GPR:$Value, GPR:$Addr": {
         "HasSideEffects": true,
@@ -655,7 +659,7 @@
 
       "GPRPair = TruncElementPair GPRPair:$Pair, u8:#ByteSize": {
         "Desc": "Truncates each element of a pair to the destination size",
-        "DestSize": "ByteSize",
+        "DestSize": "ByteSize * 2",
         "NumElements": "2"
       },
       "GPR = CycleCounter": {

--- a/unittests/ASM/Secondary/09_XX_01_14.asm
+++ b/unittests/ASM/Secondary/09_XX_01_14.asm
@@ -1,0 +1,47 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x4142434445464748",
+    "RDX": "0x5152535455565758",
+    "RBX": "0x6162636465666768",
+    "R15": "0x7172737475767778",
+    "R12": "0x4142434445464748",
+    "R13": "0x5152535455565758",
+    "R14": "0x0"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rcx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rcx + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [rcx + 8 * 1], rax
+
+mov r14, 0
+; Expected
+mov rax, 0x41424344FFFFFFFF
+mov rdx, 0x5152535455565758
+
+; Desired
+mov rbx, 0x6162636465666768
+mov r15, 0x7172737475767778
+
+; Prefix 66h, ensures it still operates at 16b
+db 0x66
+cmpxchg16b [rcx]
+
+; Set r14 to 1 if if the memory location was expected
+setz r14b
+
+; rdx and rax will now contain the memory's data
+
+; Check memory location to ensure it contains what we want
+mov r12, [rcx + 8 * 0]
+mov r13, [rcx + 8 * 1]
+
+hlt

--- a/unittests/ASM/Secondary/09_XX_01_15.asm
+++ b/unittests/ASM/Secondary/09_XX_01_15.asm
@@ -1,0 +1,41 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x4141414180000000",
+    "RDX": "0x41414141FFFFFFFF",
+    "RBX": "0xFFFFFFFF41424344",
+    "RCX": "0xFFFFFFFF51525354",
+    "R13": "0x5152535441424344",
+    "R14": "0x1"
+  }
+}
+%endif
+
+; Spans 64byte boundary and unaligned
+mov r15, 0xe000003F
+
+mov rax, 0xFFFFFFFF80000000
+mov [r15 + 8 * 0], rax
+
+mov r14, 0
+; Expected
+mov rax, 0x4141414180000000
+mov rdx, 0x41414141FFFFFFFF
+
+; Desired
+mov rbx, 0xFFFFFFFF41424344
+mov rcx, 0xFFFFFFFF51525354
+
+; Prefix 66h, ensures it still operates at 8b
+db 0x66
+cmpxchg8b [r15]
+
+; Set r14 to 1 if if the memory location was expected
+setz r14b
+
+; Memory will now be set to the register data
+; EDX:EAX will be the original data
+
+; Check memory location to ensure it contains what we want
+mov r13, [r15 + 8 * 0]
+hlt

--- a/unittests/ASM/Secondary/09_XX_01_16.asm
+++ b/unittests/ASM/Secondary/09_XX_01_16.asm
@@ -1,0 +1,47 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x4142434445464748",
+    "RDX": "0x5152535455565758",
+    "RBX": "0x6162636465666768",
+    "R15": "0x7172737475767778",
+    "R12": "0x4142434445464748",
+    "R13": "0x5152535455565758",
+    "R14": "0x0"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rcx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rcx + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [rcx + 8 * 1], rax
+
+mov r14, 0
+; Expected
+mov rax, 0x41424344FFFFFFFF
+mov rdx, 0x5152535455565758
+
+; Desired
+mov rbx, 0x6162636465666768
+mov r15, 0x7172737475767778
+
+; Prefix F2h, ensures it still operates at 16b
+db 0xF2
+cmpxchg16b [rcx]
+
+; Set r14 to 1 if if the memory location was expected
+setz r14b
+
+; rdx and rax will now contain the memory's data
+
+; Check memory location to ensure it contains what we want
+mov r12, [rcx + 8 * 0]
+mov r13, [rcx + 8 * 1]
+
+hlt

--- a/unittests/ASM/Secondary/09_XX_01_17.asm
+++ b/unittests/ASM/Secondary/09_XX_01_17.asm
@@ -1,0 +1,47 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x4142434445464748",
+    "RDX": "0x5152535455565758",
+    "RBX": "0x6162636465666768",
+    "R15": "0x7172737475767778",
+    "R12": "0x4142434445464748",
+    "R13": "0x5152535455565758",
+    "R14": "0x0"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rcx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rcx + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [rcx + 8 * 1], rax
+
+mov r14, 0
+; Expected
+mov rax, 0x41424344FFFFFFFF
+mov rdx, 0x5152535455565758
+
+; Desired
+mov rbx, 0x6162636465666768
+mov r15, 0x7172737475767778
+
+; Prefix F3h, ensures it still operates at 16b
+db 0xF3
+cmpxchg16b [rcx]
+
+; Set r14 to 1 if if the memory location was expected
+setz r14b
+
+; rdx and rax will now contain the memory's data
+
+; Check memory location to ensure it contains what we want
+mov r12, [rcx + 8 * 0]
+mov r13, [rcx + 8 * 1]
+
+hlt

--- a/unittests/ASM/Secondary/09_XX_01_18.asm
+++ b/unittests/ASM/Secondary/09_XX_01_18.asm
@@ -1,0 +1,41 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x4141414180000000",
+    "RDX": "0x41414141FFFFFFFF",
+    "RBX": "0xFFFFFFFF41424344",
+    "RCX": "0xFFFFFFFF51525354",
+    "R13": "0x5152535441424344",
+    "R14": "0x1"
+  }
+}
+%endif
+
+; Spans 64byte boundary and unaligned
+mov r15, 0xe000003F
+
+mov rax, 0xFFFFFFFF80000000
+mov [r15 + 8 * 0], rax
+
+mov r14, 0
+; Expected
+mov rax, 0x4141414180000000
+mov rdx, 0x41414141FFFFFFFF
+
+; Desired
+mov rbx, 0xFFFFFFFF41424344
+mov rcx, 0xFFFFFFFF51525354
+
+; Prefix F2h, ensures it still operates at 8b
+db 0xF2
+cmpxchg8b [r15]
+
+; Set r14 to 1 if if the memory location was expected
+setz r14b
+
+; Memory will now be set to the register data
+; EDX:EAX will be the original data
+
+; Check memory location to ensure it contains what we want
+mov r13, [r15 + 8 * 0]
+hlt

--- a/unittests/ASM/Secondary/09_XX_01_19.asm
+++ b/unittests/ASM/Secondary/09_XX_01_19.asm
@@ -1,0 +1,41 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x4141414180000000",
+    "RDX": "0x41414141FFFFFFFF",
+    "RBX": "0xFFFFFFFF41424344",
+    "RCX": "0xFFFFFFFF51525354",
+    "R13": "0x5152535441424344",
+    "R14": "0x1"
+  }
+}
+%endif
+
+; Spans 64byte boundary and unaligned
+mov r15, 0xe000003F
+
+mov rax, 0xFFFFFFFF80000000
+mov [r15 + 8 * 0], rax
+
+mov r14, 0
+; Expected
+mov rax, 0x4141414180000000
+mov rdx, 0x41414141FFFFFFFF
+
+; Desired
+mov rbx, 0xFFFFFFFF41424344
+mov rcx, 0xFFFFFFFF51525354
+
+; Prefix F3h, ensures it still operates at 8b
+db 0xF3
+cmpxchg8b [r15]
+
+; Set r14 to 1 if if the memory location was expected
+setz r14b
+
+; Memory will now be set to the register data
+; EDX:EAX will be the original data
+
+; Check memory location to ensure it contains what we want
+mov r13, [r15 + 8 * 0]
+hlt


### PR DESCRIPTION
The documentation is incorrect about this instruction. It claims that
you use 66h prefix to choose between operating at 8B or 16B.
This is incorrect, real hardware only responds to REX.W for choosing the
operating size. These other prefixes are ignored but is still accepted as
an instruction decoding.

This is based on #1603, only the final four commits are necessary here.