### PR TITLE
Change page define usages over to self-defined

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,58 +115,6 @@ if (NOT ENABLE_OFFLINE_TELEMETRY)
   add_definitions(-DFEX_DISABLE_TELEMETRY=1)
 endif()
 
-# Check if the build target page size is 4096
-include(CheckCSourceRuns)
-
-check_c_source_runs(
-  "#include <unistd.h>
-  int main(int argc, char* argv[])
-  {
-    return getpagesize() == 4096 ? 0 : 1;
-  }"
-  PAGEFILE_RESULT
-  )
-
-if (NOT ${PAGEFILE_RESULT})
-  message(FATAL_ERROR "Host PAGE_SIZE is not 4096. Can't build on this target")
-endif()
-
-include(CheckCXXSourceCompiles)
-check_cxx_source_compiles(
-"#include <sys/user.h>
- int main() {
-  return PAGE_SIZE;
- }
- "
- HAS_PAGESIZE)
-
-check_cxx_source_compiles(
-"#include <sys/user.h>
- int main() {
-  return PAGE_SHIFT;
- }
- "
- HAS_PAGESHIFT)
-
-check_cxx_source_compiles(
-"#include <sys/user.h>
- int main() {
-  return PAGE_MASK;
- }
- "
- HAS_PAGEMASK)
-
-if (NOT HAS_PAGESIZE)
-  add_definitions(-DPAGE_SIZE=4096)
-endif()
-
-if (NOT HAS_PAGESHIFT)
-  add_definitions(-DPAGE_SHIFT=12)
-endif()
-if (NOT HAS_PAGEMASK)
-  add_definitions("-DPAGE_MASK=(~(PAGE_SIZE-1))")
-endif()
-
 if(DEFINED ENV{TERMUX_VERSION})
   add_definitions(-DTERMUX_BUILD=1)
   set(TERMUX_BUILD 1)

--- a/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -15,6 +15,7 @@ $end_info$
 #include <FEXCore/Utils/BucketList.h>
 #include <FEXCore/Utils/LogManager.h>
 #include <FEXCore/Utils/MathUtils.h>
+#include <FEXHeaderUtils/TypeDefines.h>
 
 #include <algorithm>
 #include <cstddef>
@@ -62,7 +63,7 @@ namespace {
   };
 
   static_assert(sizeof(RegisterNode) == 128 * 4);
-  constexpr size_t REGISTER_NODES_PER_PAGE = PAGE_SIZE / sizeof(RegisterNode);
+  constexpr size_t REGISTER_NODES_PER_PAGE = FHU::FEX_PAGE_SIZE / sizeof(RegisterNode);
 
   struct RegisterSet {
     std::vector<RegisterClass> Classes;

--- a/External/FEXCore/Source/Utils/Allocator.cpp
+++ b/External/FEXCore/Source/Utils/Allocator.cpp
@@ -3,6 +3,7 @@
 #include <FEXCore/Utils/CompilerDefs.h>
 #include <FEXCore/Utils/LogManager.h>
 #include <FEXHeaderUtils/Syscalls.h>
+#include <FEXHeaderUtils/TypeDefines.h>
 
 #include <array>
 #include <sys/mman.h>
@@ -110,10 +111,10 @@ namespace FEXCore::Allocator {
         for (int i = 0; i < 64; ++i) {
           // Try grabbing a some of the top pages of the range
           // x86 allocates some high pages in the top end
-          void *Ptr = ::mmap(reinterpret_cast<void*>(Size - PAGE_SIZE * i), PAGE_SIZE, PROT_NONE, MAP_FIXED_NOREPLACE | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+          void *Ptr = ::mmap(reinterpret_cast<void*>(Size - FHU::FEX_PAGE_SIZE * i), FHU::FEX_PAGE_SIZE, PROT_NONE, MAP_FIXED_NOREPLACE | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
           if (Ptr != (void*)~0ULL) {
-            ::munmap(Ptr, PAGE_SIZE);
-            if (Ptr == (void*)(Size - PAGE_SIZE * i)) {
+            ::munmap(Ptr, FHU::FEX_PAGE_SIZE);
+            if (Ptr == (void*)(Size - FHU::FEX_PAGE_SIZE * i)) {
               return true;
             }
           }

--- a/FEXHeaderUtils/FEXHeaderUtils/TypeDefines.h
+++ b/FEXHeaderUtils/FEXHeaderUtils/TypeDefines.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <cstddef>
+
+namespace FHU {
+  // FEX assumes an operating page size of 4096
+  // To work around build systems that build on a 16k/64k page size, define our page size here
+  // Don't use the system provided PAGE_SIZE define because of this.
+  constexpr size_t FEX_PAGE_SIZE = 4096;
+  constexpr size_t FEX_PAGE_SHIFT = 12;
+  constexpr size_t FEX_PAGE_MASK = ~(FEX_PAGE_SIZE - 1);
+}

--- a/Source/Tests/HarnessHelpers.h
+++ b/Source/Tests/HarnessHelpers.h
@@ -22,6 +22,7 @@
 #include <FEXCore/Utils/LogManager.h>
 #include <FEXCore/Utils/MathUtils.h>
 #include <FEXHeaderUtils/Syscalls.h>
+#include <FEXHeaderUtils/TypeDefines.h>
 
 #include <fmt/format.h>
 
@@ -396,14 +397,14 @@ namespace FEX::HarnessHelper {
       };
 
       if (LimitedSize) {
-        DoMMap(0xe000'0000, PAGE_SIZE * 10);
+        DoMMap(0xe000'0000, FHU::FEX_PAGE_SIZE * 10);
 
         // SIB8
         // We test [-128, -126] (Bottom)
         // We test [-8, 8] (Middle)
         // We test [120, 127] (Top)
         // Can fit in two pages
-        DoMMap(0xe800'0000 - PAGE_SIZE, PAGE_SIZE * 2);
+        DoMMap(0xe800'0000 - FHU::FEX_PAGE_SIZE, FHU::FEX_PAGE_SIZE * 2);
       }
       else {
         // This is scratch memory location and SIB8 location
@@ -413,7 +414,7 @@ namespace FEX::HarnessHelper {
       }
 
       // Map in the memory region for the test file
-      size_t Length = FEXCore::AlignUp(RawFile.size(), PAGE_SIZE);
+      size_t Length = FEXCore::AlignUp(RawFile.size(), FHU::FEX_PAGE_SIZE);
       Code_start_page = reinterpret_cast<uint64_t>(DoMMap(Code_start_page, Length));
       mprotect(reinterpret_cast<void*>(Code_start_page), Length, PROT_READ | PROT_WRITE | PROT_EXEC);
       RIP = Code_start_page;
@@ -446,7 +447,7 @@ namespace FEX::HarnessHelper {
     bool Is64BitMode() const { return Config.Is64BitMode(); }
 
   private:
-    constexpr static uint64_t STACK_SIZE = PAGE_SIZE;
+    constexpr static uint64_t STACK_SIZE = FHU::FEX_PAGE_SIZE;
     constexpr static uint64_t STACK_OFFSET = 0xc000'0000;
     // Zero is special case to know when we are done
     uint64_t Code_start_page = 0x1'0000;

--- a/Source/Tests/LinuxSyscalls/LinuxAllocator.cpp
+++ b/Source/Tests/LinuxSyscalls/LinuxAllocator.cpp
@@ -3,6 +3,7 @@
 
 #include <FEXCore/Utils/MathUtils.h>
 #include <FEXHeaderUtils/Syscalls.h>
+#include <FEXHeaderUtils/TypeDefines.h>
 
 #include <bitset>
 #include <map>
@@ -20,8 +21,8 @@ namespace FEX::HLE {
 class MemAllocator32Bit final : public FEX::HLE::MemAllocator {
 private:
   static constexpr uint64_t BASE_KEY = 16;
-  const uint64_t TOP_KEY = 0xFFFF'F000ULL >> PAGE_SHIFT;
-  const uint64_t TOP_KEY32BIT = 0x1F'F000ULL >> PAGE_SHIFT;
+  const uint64_t TOP_KEY = 0xFFFF'F000ULL >> FHU::FEX_PAGE_SHIFT;
+  const uint64_t TOP_KEY32BIT = 0x1F'F000ULL >> FHU::FEX_PAGE_SHIFT;
 
 public:
   MemAllocator32Bit() {
@@ -132,10 +133,10 @@ uint64_t MemAllocator32Bit::FindPageRange_TopDown(uint64_t Start, size_t Pages) 
 
 void *MemAllocator32Bit::mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset) {
   std::scoped_lock<std::mutex> lk{AllocMutex};
-  size_t PagesLength = FEXCore::AlignUp(length, PAGE_SIZE) >> PAGE_SHIFT;
+  size_t PagesLength = FEXCore::AlignUp(length, FHU::FEX_PAGE_SIZE) >> FHU::FEX_PAGE_SHIFT;
 
   uintptr_t Addr = reinterpret_cast<uintptr_t>(addr);
-  uintptr_t PageAddr = Addr >> PAGE_SHIFT;
+  uintptr_t PageAddr = Addr >> FHU::FEX_PAGE_SHIFT;
 
   // Define MAP_FIXED_NOREPLACE ourselves to ensure we always parse this flag
   constexpr int FEX_MAP_FIXED_NOREPLACE = 0x100000;
@@ -143,13 +144,13 @@ void *MemAllocator32Bit::mmap(void *addr, size_t length, int prot, int flags, in
       (flags & FEX_MAP_FIXED_NOREPLACE));
 
   // Both Addr and length must be page aligned
-  if (Addr & ~PAGE_MASK) {
+  if (Addr & ~FHU::FEX_PAGE_MASK) {
     return reinterpret_cast<void*>(-EINVAL);
   }
 
   // If we do have an fd then offset must be page aligned
   if (fd != -1 &&
-      offset & ~PAGE_MASK) {
+      offset & ~FHU::FEX_PAGE_MASK) {
     return reinterpret_cast<void*>(-EINVAL);
   }
 
@@ -190,7 +191,7 @@ restart:
       {
         // Try and map the range
         void *MappedPtr = ::mmap(
-          reinterpret_cast<void*>(LowerPage<< PAGE_SHIFT),
+          reinterpret_cast<void*>(LowerPage<< FHU::FEX_PAGE_SHIFT),
           length,
           prot,
           flags | FEX_MAP_FIXED_NOREPLACE,
@@ -202,10 +203,10 @@ restart:
           return reinterpret_cast<void*>(-errno);
         }
         else if (MappedPtr == MAP_FAILED ||
-                 MappedPtr >= reinterpret_cast<void*>(TOP_KEY << PAGE_SHIFT)) {
+                 MappedPtr >= reinterpret_cast<void*>(TOP_KEY << FHU::FEX_PAGE_SHIFT)) {
           // Handles the case where MAP_FIXED_NOREPLACE failed with MAP_FAILED
           // or if the host system's kernel isn't new enough then it returns the wrong pointer
-          if (MappedPtr >= reinterpret_cast<void*>(TOP_KEY << PAGE_SHIFT)) {
+          if (MappedPtr >= reinterpret_cast<void*>(TOP_KEY << FHU::FEX_PAGE_SHIFT)) {
             // Make sure to munmap this so we don't leak memory
             ::munmap(MappedPtr, length);
           }
@@ -251,14 +252,14 @@ restart:
   }
   else {
     void *MappedPtr = ::mmap(
-      reinterpret_cast<void*>(PageAddr << PAGE_SHIFT),
-      PagesLength << PAGE_SHIFT,
+      reinterpret_cast<void*>(PageAddr << FHU::FEX_PAGE_SHIFT),
+      PagesLength << FHU::FEX_PAGE_SHIFT,
       prot,
       flags,
       fd,
       offset);
 
-    if (MappedPtr >= reinterpret_cast<void*>(TOP_KEY << PAGE_SHIFT) &&
+    if (MappedPtr >= reinterpret_cast<void*>(TOP_KEY << FHU::FEX_PAGE_SHIFT) &&
         (flags & FEX_MAP_FIXED_NOREPLACE)) {
       // Handles the case where MAP_FIXED_NOREPLACE isn't handled by the host system's
       // kernel and returns the wrong pointer
@@ -279,19 +280,19 @@ restart:
 
 int MemAllocator32Bit::munmap(void *addr, size_t length) {
   std::scoped_lock<std::mutex> lk{AllocMutex};
-  size_t PagesLength = FEXCore::AlignUp(length, PAGE_SIZE) >> PAGE_SHIFT;
+  size_t PagesLength = FEXCore::AlignUp(length, FHU::FEX_PAGE_SIZE) >> FHU::FEX_PAGE_SHIFT;
 
   uintptr_t Addr = reinterpret_cast<uintptr_t>(addr);
-  uintptr_t PageAddr = Addr >> PAGE_SHIFT;
+  uintptr_t PageAddr = Addr >> FHU::FEX_PAGE_SHIFT;
 
   uintptr_t PageEnd = PageAddr + PagesLength;
 
   // Both Addr and length must be page aligned
-  if (Addr & ~PAGE_MASK) {
+  if (Addr & ~FHU::FEX_PAGE_MASK) {
     return -EINVAL;
   }
 
-  if (length & ~PAGE_MASK) {
+  if (length & ~FHU::FEX_PAGE_MASK) {
     return -EINVAL;
   }
 
@@ -307,7 +308,7 @@ int MemAllocator32Bit::munmap(void *addr, size_t length) {
 
   while (PageAddr != PageEnd) {
     // Always pass to munmap, it may be something allocated we aren't tracking
-    int Result = ::munmap(reinterpret_cast<void*>(PageAddr << PAGE_SHIFT), PAGE_SIZE);
+    int Result = ::munmap(reinterpret_cast<void*>(PageAddr << FHU::FEX_PAGE_SHIFT), FHU::FEX_PAGE_SIZE);
     if (Result != 0) {
       return -errno;
     }
@@ -323,8 +324,8 @@ int MemAllocator32Bit::munmap(void *addr, size_t length) {
 }
 
 void *MemAllocator32Bit::mremap(void *old_address, size_t old_size, size_t new_size, int flags, void *new_address) {
-  size_t OldPagesLength = FEXCore::AlignUp(old_size, PAGE_SIZE) >> PAGE_SHIFT;
-  size_t NewPagesLength = FEXCore::AlignUp(new_size, PAGE_SIZE) >> PAGE_SHIFT;
+  size_t OldPagesLength = FEXCore::AlignUp(old_size, FHU::FEX_PAGE_SIZE) >> FHU::FEX_PAGE_SHIFT;
+  size_t NewPagesLength = FEXCore::AlignUp(new_size, FHU::FEX_PAGE_SIZE) >> FHU::FEX_PAGE_SHIFT;
 
   {
     std::scoped_lock<std::mutex> lk{AllocMutex};
@@ -335,12 +336,12 @@ void *MemAllocator32Bit::mremap(void *old_address, size_t old_size, size_t new_s
         if (!(flags & MREMAP_DONTUNMAP)) {
           // Unmap the old location
           uintptr_t OldAddr = reinterpret_cast<uintptr_t>(old_address);
-          SetFreePages(OldAddr >> PAGE_SHIFT, OldPagesLength);
+          SetFreePages(OldAddr >> FHU::FEX_PAGE_SHIFT, OldPagesLength);
         }
 
         // Map the new pages
         uintptr_t NewAddr = reinterpret_cast<uintptr_t>(MappedPtr);
-        SetUsedPages(NewAddr >> PAGE_SHIFT, NewPagesLength);
+        SetUsedPages(NewAddr >> FHU::FEX_PAGE_SHIFT, NewPagesLength);
       }
       else {
         return reinterpret_cast<void*>(-errno);
@@ -348,15 +349,15 @@ void *MemAllocator32Bit::mremap(void *old_address, size_t old_size, size_t new_s
     }
     else {
       uintptr_t OldAddr = reinterpret_cast<uintptr_t>(old_address);
-      uintptr_t OldPageAddr = OldAddr >> PAGE_SHIFT;
+      uintptr_t OldPageAddr = OldAddr >> FHU::FEX_PAGE_SHIFT;
 
       if (NewPagesLength < OldPagesLength) {
         void *MappedPtr = ::mremap(old_address, old_size, new_size, flags & ~MREMAP_MAYMOVE);
 
         if (MappedPtr != MAP_FAILED) {
           // Clear the pages that we just shrunk
-          size_t NewPagesLength = FEXCore::AlignUp(new_size, PAGE_SIZE) >> PAGE_SHIFT;
-          uintptr_t NewPageAddr = reinterpret_cast<uintptr_t>(MappedPtr) >> PAGE_SHIFT;
+          size_t NewPagesLength = FEXCore::AlignUp(new_size, FHU::FEX_PAGE_SIZE) >> FHU::FEX_PAGE_SHIFT;
+          uintptr_t NewPageAddr = reinterpret_cast<uintptr_t>(MappedPtr) >> FHU::FEX_PAGE_SHIFT;
           SetFreePages(NewPageAddr + NewPagesLength, OldPagesLength - NewPagesLength);
           return MappedPtr;
         }
@@ -380,9 +381,9 @@ void *MemAllocator32Bit::mremap(void *old_address, size_t old_size, size_t new_s
 
           if (MappedPtr != MAP_FAILED) {
             // Map the new pages
-            size_t NewPagesLength = FEXCore::AlignUp(new_size, PAGE_SIZE) >> PAGE_SHIFT;
+            size_t NewPagesLength = FEXCore::AlignUp(new_size, FHU::FEX_PAGE_SIZE) >> FHU::FEX_PAGE_SHIFT;
             uintptr_t NewAddr = reinterpret_cast<uintptr_t>(MappedPtr);
-            SetUsedPages(NewAddr >> PAGE_SHIFT, NewPagesLength);
+            SetUsedPages(NewAddr >> FHU::FEX_PAGE_SHIFT, NewPagesLength);
             return MappedPtr;
           }
           else if (!(flags & MREMAP_MAYMOVE)) {
@@ -416,13 +417,13 @@ void *MemAllocator32Bit::mremap(void *old_address, size_t old_size, size_t new_s
       // If we have both MREMAP_DONTUNMAP not set and the new pointer is at a new location
       // Make sure to clear the old mapping
       uintptr_t OldAddr = reinterpret_cast<uintptr_t>(old_address);
-      SetFreePages(OldAddr >> PAGE_SHIFT , OldPagesLength);
+      SetFreePages(OldAddr >> FHU::FEX_PAGE_SHIFT , OldPagesLength);
     }
 
     // Map the new pages
-    size_t NewPagesLength = FEXCore::AlignUp(new_size, PAGE_SIZE) >> PAGE_SHIFT;
+    size_t NewPagesLength = FEXCore::AlignUp(new_size, FHU::FEX_PAGE_SIZE) >> FHU::FEX_PAGE_SHIFT;
     uintptr_t NewAddr = reinterpret_cast<uintptr_t>(MappedPtr);
-    SetUsedPages(NewAddr >> PAGE_SHIFT, NewPagesLength);
+    SetUsedPages(NewAddr >> FHU::FEX_PAGE_SHIFT, NewPagesLength);
     return MappedPtr;
   }
 
@@ -445,7 +446,7 @@ uint64_t MemAllocator32Bit::shmat(int shmid, const void* shmaddr, int shmflg, ui
       }
 
       uintptr_t NewAddr = reinterpret_cast<uintptr_t>(Result);
-      uintptr_t NewPageAddr = NewAddr >> PAGE_SHIFT;
+      uintptr_t NewPageAddr = NewAddr >> FHU::FEX_PAGE_SHIFT;
 
       // Add to the map
       PageToShm[NewPageAddr] = shmid;
@@ -457,7 +458,7 @@ uint64_t MemAllocator32Bit::shmat(int shmid, const void* shmaddr, int shmflg, ui
 
       if (shmctl(shmid, IPC_STAT, &buf) == 0) {
         // Map the new pages
-        size_t NewPagesLength = buf.shm_segsz >> PAGE_SHIFT;
+        size_t NewPagesLength = buf.shm_segsz >> FHU::FEX_PAGE_SHIFT;
         SetUsedPages(NewPageAddr, NewPagesLength);
       }
 
@@ -475,7 +476,7 @@ uint64_t MemAllocator32Bit::shmat(int shmid, const void* shmaddr, int shmflg, ui
     uint64_t PagesLength{};
 
     if (shmctl(shmid, IPC_STAT, &buf) == 0) {
-      PagesLength = FEXCore::AlignUp(buf.shm_segsz, PAGE_SIZE) >> PAGE_SHIFT;
+      PagesLength = FEXCore::AlignUp(buf.shm_segsz, FHU::FEX_PAGE_SIZE) >> FHU::FEX_PAGE_SHIFT;
     }
     else {
       return -EINVAL;
@@ -501,7 +502,7 @@ restart:
         // Try and map the range
         void *MappedPtr = ::shmat(
           shmid,
-          reinterpret_cast<const void*>(LowerPage << PAGE_SHIFT),
+          reinterpret_cast<const void*>(LowerPage << FHU::FEX_PAGE_SHIFT),
           shmflg);
 
         if (MappedPtr == MAP_FAILED) {
@@ -544,7 +545,7 @@ restart:
   }
 }
 uint64_t MemAllocator32Bit::shmdt(const void* shmaddr) {
-  uint32_t AddrPage = reinterpret_cast<uint64_t>(shmaddr) >> PAGE_SHIFT;
+  uint32_t AddrPage = reinterpret_cast<uint64_t>(shmaddr) >> FHU::FEX_PAGE_SHIFT;
   auto it = PageToShm.find(AddrPage);
 
   if (it == PageToShm.end()) {


### PR DESCRIPTION
In the case of an AArch64 builder is using 16kb or 64kb pages like is
common on servers then it would fail to compile, even if the resulting
application would only ever run on 4k page hosts.

Resolve this by removing the build check and hardcoding 4kb pages for
each of our uses. We still require 4kb pages to run, so this mostly just
removes the weirdness where it is 16kb builder + 4k runner. Would have
broken some of our assumptions when running.