### PR TITLE
JITs: Emit identification string in the code buffers

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -405,6 +405,7 @@ Arm64JITCore::Arm64JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::Intern
   InitialCodeBuffer = AllocateNewCodeBuffer(Arm64JITCore::INITIAL_CODE_SIZE);
   *GetBuffer() = vixl::CodeBuffer(InitialCodeBuffer.Ptr, InitialCodeBuffer.Size);
   SetAllowAssembler(true);
+  EmitDetectionString();
 
   CurrentCodeBuffer = &InitialCodeBuffer;
 
@@ -487,6 +488,13 @@ Arm64JITCore::Arm64JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::Intern
   }
 }
 
+void Arm64JITCore::EmitDetectionString() {
+  const char JITString[] = "FEXJIT::Arm64JITCore::";
+  auto Buffer = GetBuffer();
+  Buffer->EmitString(JITString);
+  Buffer->Align();
+}
+
 void Arm64JITCore::ClearCache() {
   // Get the backing code buffer
   auto Buffer = GetBuffer();
@@ -527,6 +535,7 @@ void Arm64JITCore::ClearCache() {
     EmplaceNewCodeBuffer(NewCodeBuffer);
     *Buffer = vixl::CodeBuffer(NewCodeBuffer.Ptr, NewCodeBuffer.Size);
   }
+  EmitDetectionString();
 }
 
 Arm64JITCore::~Arm64JITCore() {

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -183,6 +183,8 @@ private:
   };
 
   CompilerSharedData ThreadSharedData;
+
+  void EmitDetectionString();
   IR::RegisterAllocationPass *RAPass;
   IR::RegisterAllocationData *RAData;
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -330,6 +330,7 @@ X86JITCore::X86JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalTh
   }
 
   CurrentCodeBuffer = &InitialCodeBuffer;
+  EmitDetectionString();
 
   RAPass = Thread->PassManager->GetPass<IR::RegisterAllocationPass>("RA");
 
@@ -406,6 +407,13 @@ X86JITCore::~X86JITCore() {
   FreeCodeBuffer(InitialCodeBuffer);
 }
 
+void X86JITCore::EmitDetectionString() {
+  const char JITString[] = "FEXJIT::X86JITCore::";
+  for (char c : JITString) {
+    db(c);
+  }
+}
+
 void X86JITCore::ClearCache() {
   if (*ThreadSharedData.SignalHandlerRefCounterPtr == 0) {
     if (!CodeBuffers.empty()) {
@@ -444,6 +452,8 @@ void X86JITCore::ClearCache() {
     EmplaceNewCodeBuffer(NewCodeBuffer);
     setNewBuffer(NewCodeBuffer.Ptr, NewCodeBuffer.Size);
   }
+
+  EmitDetectionString();
 }
 
 IR::PhysicalRegister X86JITCore::GetPhys(IR::NodeID Node) const {

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -152,6 +152,8 @@ private:
 
   static uint64_t ExitFunctionLink(X86JITCore* code, FEXCore::Core::CpuStateFrame *Frame, uint64_t *record);
 
+  void EmitDetectionString();
+
   // This is the initial code buffer that we will fall back to
   // In a program without signals and code clearing, we will typically
   // only have this code buffer


### PR DESCRIPTION
At the start of each code buffer, emit a small string for letting memory
inspection know if a code region is for the JITs.