### PR TITLE
Softfloat: Fixes FSCALE

### DIFF
--- a/External/FEXCore/Source/Common/SoftFloat.h
+++ b/External/FEXCore/Source/Common/SoftFloat.h
@@ -188,6 +188,10 @@ struct X80SoftFloat {
     return extF80_roundToInt(lhs, softfloat_roundingMode, false);
   }
 
+  static X80SoftFloat FRNDINT(X80SoftFloat const &lhs, uint_fast8_t RoundMode) {
+    return extF80_roundToInt(lhs, RoundMode, false);
+  }
+
   static X80SoftFloat FXTRACT_SIG(X80SoftFloat const &lhs) {
 #if defined(DEBUG_X86_FLOAT)
     BIGFLOAT Result;
@@ -257,7 +261,7 @@ struct X80SoftFloat {
 
     return Result;
 #else
-    X80SoftFloat Int = FRNDINT(rhs);
+    X80SoftFloat Int = FRNDINT(rhs, softfloat_round_minMag);
     BIGFLOAT Src2_d = Int;
     Src2_d = exp2l(Src2_d);
     X80SoftFloat Src2_X80 = Src2_d;

--- a/unittests/32Bit_ASM/Disabled_Tests
+++ b/unittests/32Bit_ASM/Disabled_Tests
@@ -1,6 +1,3 @@
-# Needs Precision checking
-Test_32Bit_X87/D9_FD.asm
-
 # Relies on undefined behaviour
 Test_32Bit_X87/D9_F9.asm
 

--- a/unittests/ASM/Disabled_Tests
+++ b/unittests/ASM/Disabled_Tests
@@ -3,7 +3,6 @@ Test_REP/F3_52.asm
 Test_REP/F3_53.asm
 Test_TwoByte/0F_52.asm
 Test_TwoByte/0F_53.asm
-Test_X87/D9_FD.asm
 
 # Not supported in userspace in all cases
 Test_Secondary/15_F3_00.asm

--- a/unittests/ASM/X87/D9_FD_2.asm
+++ b/unittests/ASM/X87/D9_FD_2.asm
@@ -1,0 +1,30 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM6":  ["0x8000000000000000", "0x3FFF"],
+    "MM7":  ["0xD000000000000000", "0xC001"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+lea rdx, [rel data2]
+fld tword [rdx + 8 * 0]
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+fscale
+
+hlt
+
+align 8
+data:
+  dt 64.0
+  dq 0
+
+data2:
+  dt -6.5
+  dq 0


### PR DESCRIPTION
I misread the implementation details of this instruction when
implementing.

The pseudocode says `ST(0) = ST(0) ∗ 2^rndint(ST(1))` so I understood
the instruction to use the current rounding mode of the host to extract
the integer portion of `ST(1)`.

The actual implementation is in the details of the statement `the
integer portion of the floating- point value in ST(1).`

This behaves like round towards zero/truncate, additional hardware
testing and documentation reading confirms this.