### PR TITLE
Fixes #1615

### DIFF
--- a/External/FEXCore/Source/Interface/Core/GdbServer.cpp
+++ b/External/FEXCore/Source/Interface/Core/GdbServer.cpp
@@ -80,9 +80,9 @@ GdbServer::GdbServer(FEXCore::Context::Context *ctx) : CTX(ctx) {
 
   // This is a total hack as there is currently no way to resume once hitting a segfault
   // But it's semi-useful for debugging.
-  for (uint32_t Signal = 0; Signal <= SignalDelegator::MAX_SIGNALS; ++Signal) {
+  for (uint32_t Signal = 0; Signal < SignalDelegator::MAX_SIGNALS; ++Signal) {
     ctx->SignalDelegation->RegisterHostSignalHandler(Signal, [this] (FEXCore::Core::InternalThreadState *Thread, int Signal, void *info, void *ucontext) {
-      if (PassSignals[Signal]) {
+      if (PassSignals[Signal - 1]) {
         // Pass signal to the guest
         return false;
       }
@@ -937,7 +937,7 @@ GdbServer::HandledPacketType GdbServer::handleQuery(const std::string &packet) {
     for (std::string tmp; std::getline(ss, tmp, ';'); ) {
       uint32_t Signal = std::stoi(tmp, nullptr, 16);
       if (Signal < SignalDelegator::MAX_SIGNALS) {
-        PassSignals[Signal] = true;
+        PassSignals[Signal - 1] = true;
       }
     }
 

--- a/External/FEXCore/Source/Interface/Core/GdbServer.h
+++ b/External/FEXCore/Source/Interface/Core/GdbServer.h
@@ -89,7 +89,7 @@ private:
     std::string LibraryMapString{};
 
     // Used to keep track of which signals to pass to the guest
-    std::array<bool, SignalDelegator::MAX_SIGNALS + 1> PassSignals{};
+    std::array<bool, SignalDelegator::MAX_SIGNALS> PassSignals{};
     uint32_t CurrentDebuggingThread{};
     int ListenSocket{};
     FEX_CONFIG_OPT(Filename, APP_FILENAME);

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -61,8 +61,8 @@ void InterpreterCore::InitializeSignalHandlers(FEXCore::Context::Context *CTX) {
     return Core->Dispatcher->HandleGuestSignal(Signal, info, ucontext, GuestAction, GuestStack);
   };
 
-  for (uint32_t Signal = 0; Signal <= SignalDelegator::MAX_SIGNALS; ++Signal) {
-    CTX->SignalDelegation->RegisterHostSignalHandlerForGuest(Signal, GuestSignalHandler);
+  for (uint32_t Signal = 0; Signal < SignalDelegator::MAX_SIGNALS; ++Signal) {
+    CTX->SignalDelegation->RegisterHostSignalHandlerForGuest(Signal + 1, GuestSignalHandler);
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -484,8 +484,8 @@ void Arm64JITCore::InitializeSignalHandlers(FEXCore::Context::Context *CTX) {
     return Core->Dispatcher->HandleGuestSignal(Signal, info, ucontext, GuestAction, GuestStack);
   };
 
-  for (uint32_t Signal = 0; Signal <= SignalDelegator::MAX_SIGNALS; ++Signal) {
-    CTX->SignalDelegation->RegisterHostSignalHandlerForGuest(Signal, GuestSignalHandler);
+  for (uint32_t Signal = 0; Signal < SignalDelegator::MAX_SIGNALS; ++Signal) {
+    CTX->SignalDelegation->RegisterHostSignalHandlerForGuest(Signal + 1, GuestSignalHandler);
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -393,8 +393,8 @@ void X86JITCore::InitializeSignalHandlers(FEXCore::Context::Context *CTX) {
     return Core->Dispatcher->HandleGuestSignal(Signal, info, ucontext, GuestAction, GuestStack);
   };
 
-  for (uint32_t Signal = 0; Signal <= SignalDelegator::MAX_SIGNALS; ++Signal) {
-    CTX->SignalDelegation->RegisterHostSignalHandlerForGuest(Signal, GuestSignalHandler);
+  for (uint32_t Signal = 0; Signal < SignalDelegator::MAX_SIGNALS; ++Signal) {
+    CTX->SignalDelegation->RegisterHostSignalHandlerForGuest(Signal + 1, GuestSignalHandler);
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/SignalDelegator.cpp
+++ b/External/FEXCore/Source/Interface/Core/SignalDelegator.cpp
@@ -89,7 +89,7 @@ namespace FEXCore {
   void SignalDelegator::HandleSignal(int Signal, void *Info, void *UContext) {
     // Let the host take first stab at handling the signal
     auto Thread = GetTLSThread();
-    HostSignalHandler &Handler = HostHandlers[Signal];
+    HostSignalHandler &Handler = HostHandlers[Signal - 1];
 
     if (!Thread) {
       LogMan::Msg::EFmt("[{}] Thread has received a signal and hasn't registered itself with the delegate! Programming error!", FHU::Syscalls::gettid());

--- a/External/FEXCore/include/FEXCore/Core/SignalDelegator.h
+++ b/External/FEXCore/include/FEXCore/Core/SignalDelegator.h
@@ -99,14 +99,14 @@ namespace Core {
       std::vector<FEXCore::HostSignalDelegatorFunction> Handlers{};
       FEXCore::HostSignalDelegatorFunction FrontendHandler{};
     };
-    std::array<HostSignalHandler, MAX_SIGNALS + 1> HostHandlers{};
+    std::array<HostSignalHandler, MAX_SIGNALS> HostHandlers{};
 
   protected:
     void SetHostSignalHandler(int Signal, HostSignalDelegatorFunction Func, bool Required) {
-      HostHandlers[Signal].Handlers.push_back(std::move(Func));
+      HostHandlers[Signal - 1].Handlers.push_back(std::move(Func));
     }
     void SetFrontendHostSignalHandler(int Signal, HostSignalDelegatorFunction Func, bool Required) {
-      HostHandlers[Signal].FrontendHandler = std::move(Func);
+      HostHandlers[Signal - 1].FrontendHandler = std::move(Func);
     }
   };
 }

--- a/Source/Tests/LinuxSyscalls/SignalDelegator.h
+++ b/Source/Tests/LinuxSyscalls/SignalDelegator.h
@@ -103,7 +103,7 @@ namespace FEX::HLE {
       DefaultBehaviour DefaultBehaviour {DEFAULT_TERM};
     };
 
-    std::array<SignalHandler, MAX_SIGNALS + 1> HostHandlers{};
+    std::array<SignalHandler, MAX_SIGNALS> HostHandlers{};
     bool InstallHostThunk(int Signal);
     bool UpdateHostThunk(int Signal);
 


### PR DESCRIPTION
No longer special casing signal slot 0 and instead offset everything by
1.

Signals are in the range of [1,64] inclusive and we were special casing
zero and defining an extra slot everywhere.
Now we just offset the slot lookup, which makes it more similar to the
uint64_t signal mask.