### PR TITLE
FEXCore: Removes unused debug data

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -897,10 +897,6 @@ namespace FEXCore::Context {
       StartAddr = _StartAddr;
       Length = _Length;
 
-      // Initialize metadata
-      DebugData->GuestCodeSize = TotalInstructionsLength;
-      DebugData->GuestInstructionCount = TotalInstructions;
-
       // Increment stats
       Thread->Stats.BlocksCompiled.fetch_add(1);
 

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -324,12 +324,6 @@ void InterpreterOps::Op_NoOp(FEXCore::IR::IROp_Header *IROp, IROpData *Data, IR:
 void InterpreterOps::InterpretIR(FEXCore::Core::InternalThreadState *Thread, uint64_t Entry, FEXCore::IR::IRListView *CurrentIR, FEXCore::Core::DebugData *DebugData) {
   volatile void *StackEntry = alloca(0);
 
-  // Debug data is only passed in debug builds
-  #ifndef NDEBUG
-  // TODO: should be moved to an IR Op
-  Thread->Stats.InstructionsExecuted.fetch_add(DebugData->GuestInstructionCount);
-  #endif
-
   uintptr_t ListSize = CurrentIR->GetSSACount();
 
   static_assert(sizeof(FEXCore::IR::IROp_Header) == 4);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -765,6 +765,7 @@ void *Arm64JITCore::CompileCode(uint64_t Entry, [[maybe_unused]] FEXCore::IR::IR
     LOGMAN_THROW_A_FMT(BlockIROp->Header.Op == IR::OP_CODEBLOCK, "IR type failed to be a code block");
 #endif
 
+    uintptr_t BlockStartHostCode = GetCursorAddress<uintptr_t>();
     {
       const auto Node = IR->GetID(BlockNode);
       const auto IsTarget = JumpTargets.try_emplace(Node).first;
@@ -779,10 +780,6 @@ void *Arm64JITCore::CompileCode(uint64_t Entry, [[maybe_unused]] FEXCore::IR::IR
       bind(&IsTarget->second);
     }
 
-    if (DebugData) {
-      DebugData->Subblocks.push_back({GetCursorAddress<uintptr_t>(), 0, IR->GetID(BlockNode)});
-    }
-
     for (auto [CodeNode, IROp] : IR->GetCode(BlockNode)) {
       const auto ID = IR->GetID(CodeNode);
 
@@ -792,7 +789,7 @@ void *Arm64JITCore::CompileCode(uint64_t Entry, [[maybe_unused]] FEXCore::IR::IR
     }
 
     if (DebugData) {
-      DebugData->Subblocks.back().HostCodeSize = GetCursorAddress<uintptr_t>() - DebugData->Subblocks.back().HostCodeStart;
+      DebugData->Subblocks.push_back({BlockStartHostCode, static_cast<uint32_t>(GetCursorAddress<uintptr_t>() - BlockStartHostCode)});
     }
   }
 

--- a/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
+++ b/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
@@ -38,7 +38,6 @@ namespace FEXCore::Core {
   struct DebugDataSubblock {
     uintptr_t HostCodeStart;
     uint32_t HostCodeSize;
-    IR::NodeID SSAId;
   };
 
   /**
@@ -48,10 +47,6 @@ namespace FEXCore::Core {
    */
   struct DebugData {
     uint64_t HostCodeSize; ///< The size of the code generated in the host JIT
-    uint64_t GuestCodeSize; ///< The size of the guest side code
-    uint64_t GuestInstructionCount; ///< Number of guest instructions
-    uint64_t TimeSpentInCode; ///< How long this code has spent time running
-    uint64_t RunCount; ///< Number of times this block of code has been run
     std::vector<DebugDataSubblock> Subblocks;
   };
 


### PR DESCRIPTION
This isn't used anywhere. Just remove these.
If we get the imgui debugger running again then we can add even more
stats to sort block costs by.