### PR TITLE
FEXCore: Delete IR after it is used

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterClass.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterClass.h
@@ -39,6 +39,8 @@ public:
 
   static void InitializeSignalHandlers(FEXCore::Context::Context *CTX);
 
+  bool NeedsRetainedIRCopy() const override { return true; }
+
 private:
   FEXCore::Context::Context *CTX;
   FEXCore::Core::InternalThreadState *State;

--- a/External/FEXCore/Source/Interface/IR/AOTIR.cpp
+++ b/External/FEXCore/Source/Interface/IR/AOTIR.cpp
@@ -349,9 +349,17 @@ namespace FEXCore::IR {
 
       // Insert to caches if we generated IR
       if (GeneratedIR) {
-        // Add to thread local ir cache
-        Core::LocalIREntry Entry = {StartAddr, Length, decltype(Entry.IR)(IRList), decltype(Entry.RAData)(RAData), decltype(Entry.DebugData)(DebugData)};
-        Thread->LocalIRCache.insert({GuestRIP, std::move(Entry)});
+        if (Thread->CPUBackend->NeedsRetainedIRCopy()) {
+          // Add to thread local ir cache
+          Core::LocalIREntry Entry = {StartAddr, Length, decltype(Entry.IR)(IRList), decltype(Entry.RAData)(RAData), decltype(Entry.DebugData)(DebugData)};
+          Thread->LocalIRCache.insert({GuestRIP, std::move(Entry)});
+        }
+        else {
+          // If the IR doesn't need to be retained then we can just delete it now
+          delete DebugData;
+          delete RAData;
+          delete IRList;
+        }
       }
     }
 

--- a/External/FEXCore/include/FEXCore/Core/CPUBackend.h
+++ b/External/FEXCore/include/FEXCore/Core/CPUBackend.h
@@ -92,6 +92,13 @@ class LLVMCore;
     virtual void CopyNecessaryDataForCompileThread(CPUBackend *Original) {}
     virtual bool IsAddressInJITCode(uint64_t Address, bool IncludeDispatcher = true, bool IncludeCompileService = true) const { return false; }
 
+    /**
+     * @brief Does this CPUBackend need its IR to stick around for correct emulation
+     *
+     * This should only be used on the interpreter, all other backends can clear their IR
+     */
+    virtual bool NeedsRetainedIRCopy() const { return false; }
+
     using AsmDispatch = FEX_NAKED void(*)(FEXCore::Core::CpuStateFrame *Frame);
     using JITCallback = FEX_NAKED void(*)(FEXCore::Core::CpuStateFrame *Frame, uint64_t RIP);
 


### PR DESCRIPTION
For the JIT cores we don't need to keep IR around, it's only necessary
for the Interpreter. So once the AOT IR service is done dealing with the
IR, check to see if we can delete it.

This causes teeworld's title screen memory usage to go from 730MB to
566MB. 77.5% the memory usage there.

This is effectively an infinite memory leak if the codespace wasn't ever
overwritten or invalidated. So larger memory usage programs would end up
having a larger impact.