### PR TITLE
OpcodeDispatcher: Fixes FNINIT

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
@@ -621,8 +621,8 @@ void OpDispatchBuilder::FXTRACT(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::FNINIT(OpcodeArgs) {
-  // Init FCW to 0x037
-  auto NewFCW = _Constant(16, 0x037);
+  // Init FCW to 0x037F
+  auto NewFCW = _Constant(16, 0x037F);
   _F80LoadFCW(NewFCW);
   _StoreContext(2, GPRClass, NewFCW, offsetof(FEXCore::Core::CPUState, FCW));
 

--- a/unittests/32Bit_ASM/X87/DB_E3.asm
+++ b/unittests/32Bit_ASM/X87/DB_E3.asm
@@ -1,0 +1,18 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x037F"
+  },
+  "Mode": "32BIT"
+}
+%endif
+
+mov eax, 0
+mov esp, 0xe0000008
+fninit
+
+; Ensures that fnstcw after fninit sets the correct value
+fnstcw [esp]
+mov ax, word [esp]
+
+hlt


### PR DESCRIPTION
Was incorrectly setting the FCW to 037h when it was supposed to be
037Fh.

Fixes a bug in a visual novel where its CPUID state wouldn't initialize
if this was set incorrectly.

Thanks to risho on the Discord for pointing out the issue in the game!