### PR TITLE
OpcodeDispatcher: Fixes SIGILL on unsupported host instructions

### DIFF
--- a/External/FEXCore/Source/Interface/Core/HostFeatures.cpp
+++ b/External/FEXCore/Source/Interface/Core/HostFeatures.cpp
@@ -84,6 +84,16 @@ HostFeatures::HostFeatures() {
   SupportsCRC = Features.has(Xbyak::util::Cpu::tSSE42);
   SupportsRAND = Features.has(Xbyak::util::Cpu::tRDRAND) && Features.has(Xbyak::util::Cpu::tRDSEED);
 
+  // xbyak doesn't know how to check for CLZero
+  uint32_t eax, ebx, ecx, edx;
+  // First ensure we support a new enough extended CPUID function range
+  __cpuid(0x8000'0000, eax, ebx, ecx, edx);
+  if (eax >= 0x8000'0008U) {
+    // CLZero defined in 8000_00008_EBX[bit 0]
+    __cpuid(0x8000'0008, eax, ebx, ecx, edx);
+    SupportsCLZERO = ebx & 1;
+  }
+
   SupportsFlushInputsToZero = true;
   SupportsFloatExceptions = true;
 #else

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -1175,6 +1175,8 @@ private:
     else
       return _LoadMem(Class, Size, ssa0, Invalid(), Align, MEM_OFFSET_SXTX, 1);
   }
+
+  void InstallHostSpecificOpcodeHandlers();
 };
 
 void InstallOpcodeHandlers(Context::OperatingMode Mode);

--- a/unittests/ASM/Disabled_Tests_x64
+++ b/unittests/ASM/Disabled_Tests_x64
@@ -1,0 +1,3 @@
+# Intel doesn't support CLZero, which the CI uses
+Test_SecondaryModRM/Reg_7_4.asm
+Test_SecondaryModRM/Reg_7_4_2.asm


### PR DESCRIPTION
If the host doesn't support the instructions required for implementing
an instruction then don't even add them to the opcodedispatcher.

This means that we will never try emitting instructions that the host
doesn't support (For these instructions anyway) and successfully passes
the guest SIGILL for these particular instructions.

Fixes #1631