### PR TITLE
Documentation: Adds hypervisor CPUID information

### DIFF
--- a/docs/CPUID.md
+++ b/docs/CPUID.md
@@ -1,0 +1,25 @@
+# FEXCore custom CPUID functions
+
+## 4000_0000h - Hypervisor information function
+* Follows VMWare and Microsoft's hypervisor information proposal
+* https://lwn.net/Articles/301888/
+* https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/tlfs/feature-discovery
+
+* EAX - The maximum input value for the hypervisor CPUID information
+** 4000_0000h - Only first leaf
+* EBX - Hypervisor vendor ID signature
+** 'FEXI' - 4958_4546h
+* ECX - Hypervisor vendor ID signature
+** 'FEXI' - 4958_4546h
+* EDX - Hypervisor vendor ID signature
+** 'EMU\0' - 0055_4d45h
+
+* memcpy ebx:ecx:edx in to a 12 byte string to get 'FEXIFEXIEMU\0' for determining running under FEX
+
+## 4000_0001h - 4000_000Fh
+* **Reserved range**
+* Returns zero until implemented
+
+## 4000_0010h - 4FFF_FFFFh
+* **Undefined**
+* FEX-Emu will return zero until implemented


### PR DESCRIPTION
Currently we only implement function 4000_0000h. This will expand in the
future but this is all we have right now.