### PR TITLE
JITArm64: Get long divide out of the hot path

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
@@ -436,6 +436,88 @@ Arm64Dispatcher::Arm64Dispatcher(FEXCore::Context::Context *ctx, FEXCore::Core::
     b(&LoopTop);
   }
 
+  // Long division helpers
+  uint64_t LUDIVHandler{};
+  uint64_t LDIVHandler{};
+  uint64_t LUREMHandler{};
+  uint64_t LREMHandler{};
+
+  {
+    LUDIVHandler = GetCursorAddress<uint64_t>();
+
+    PushDynamicRegsAndLR();
+
+    ldr(x3, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.AArch64.LUDIV)));
+
+    SpillStaticRegs();
+    blr(x3);
+    FillStaticRegs();
+
+    // Result is now in x0
+    // Fix the stack and any values that were stepped on
+    PopDynamicRegsAndLR();
+
+    // Go back to our code block
+    ret();
+  }
+
+  {
+    LDIVHandler = GetCursorAddress<uint64_t>();
+
+    PushDynamicRegsAndLR();
+
+    ldr(x3, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.AArch64.LDIV)));
+
+    SpillStaticRegs();
+    blr(x3);
+    FillStaticRegs();
+
+    // Result is now in x0
+    // Fix the stack and any values that were stepped on
+    PopDynamicRegsAndLR();
+
+    // Go back to our code block
+    ret();
+  }
+
+  {
+    LUREMHandler = GetCursorAddress<uint64_t>();
+
+    PushDynamicRegsAndLR();
+
+    ldr(x3, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.AArch64.LUREM)));
+
+    SpillStaticRegs();
+    blr(x3);
+    FillStaticRegs();
+
+    // Result is now in x0
+    // Fix the stack and any values that were stepped on
+    PopDynamicRegsAndLR();
+
+    // Go back to our code block
+    ret();
+  }
+
+  {
+    LREMHandler = GetCursorAddress<uint64_t>();
+
+    PushDynamicRegsAndLR();
+
+    ldr(x3, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.AArch64.LREM)));
+
+    SpillStaticRegs();
+    blr(x3);
+    FillStaticRegs();
+
+    // Result is now in x0
+    // Fix the stack and any values that were stepped on
+    PopDynamicRegsAndLR();
+
+    // Go back to our code block
+    ret();
+  }
+
   place(&l_PagePtr);
   place(&l_CTX);
   place(&l_Sleep);
@@ -470,6 +552,10 @@ Arm64Dispatcher::Arm64Dispatcher(FEXCore::Context::Context *ctx, FEXCore::Core::
     Pointers.OverflowExceptionHandler = OverflowExceptionInstructionAddress;
     Pointers.SignalReturnHandler = SignalHandlerReturnAddress;
     Pointers.L1Pointer = Thread->LookupCache->GetL1Pointer();
+    Pointers.LUDIVHandler = LUDIVHandler;
+    Pointers.LDIVHandler = LDIVHandler;
+    Pointers.LUREMHandler = LUREMHandler;
+    Pointers.LREMHandler = LREMHandler;
   }
 }
 

--- a/External/FEXCore/include/FEXCore/Core/CoreState.h
+++ b/External/FEXCore/include/FEXCore/Core/CoreState.h
@@ -113,6 +113,10 @@ namespace FEXCore::Core {
       uint64_t OverflowExceptionHandler{};
       uint64_t SignalReturnHandler{};
       uint64_t L1Pointer{};
+      uint64_t LUDIVHandler{};
+      uint64_t LDIVHandler{};
+      uint64_t LUREMHandler{};
+      uint64_t LREMHandler{};
       /**  @} */
     } AArch64;
 


### PR DESCRIPTION
For 128-bit divides, we can very quickly check at runtime if we can
avoid the long divide and just do a 64-bit divide.

For unsigned just check if the top bits are all zero.
For signed just check if the top bits match bit 63 of the lower bits.

Additionally, keep the long divide handlers inside of the dispatcher.
This keeps the majority of the code bloat out of the code block itself,
significantly reducing block size for something doing these divides.
Also a fairly large icache improvement from this.

Hard performance number improvements here are hard to get since it
heavily depends on the application, also only occurs on x86-64.

Seems to have helped FTL and Dead Cells performance quite a bit though.