### PR TITLE
Scripts: Updates AArch64 fit for Clang 14

### DIFF
--- a/Scripts/aarch64_fit_native.py
+++ b/Scripts/aarch64_fit_native.py
@@ -18,11 +18,11 @@ BigCoreIDs = {
         tuple([0x41, 0xd44]): "cortex-x1",
         tuple([0x41, 0xd47]):
             [ ["cortex-a78", "0.0"],
-              ["cortex-a710", "999.0"], # Doesn't exist in clang as of version 13
+              ["cortex-a710", "14.0"],
             ],
         tuple([0x41, 0xd48]):
             [ ["cortex-x1", "0.0"],
-              ["cortex-x2", "999.0"], # Doesn't exist in clang as of version 13
+              ["cortex-x2", "14.0"],
             ],
         tuple([0x41, 0xd0c]): "neoverse-n1",
         tuple([0x41, 0xd49]): "neoverse-n2",
@@ -46,7 +46,7 @@ LittleCoreIDs = {
         tuple([0x41, 0xd05]): "cortex-a55",
         tuple([0x41, 0xd46]):
             [ ["cortex-a55", "0.0"],
-              ["cortex-a510", "999.0"], # Doesn't exist in clang as of version 13
+              ["cortex-a510", "14.0"],
             ],
 
         # Qualcomm


### PR DESCRIPTION
Clang now supports these latest ARMv9 CPUs