### PR TITLE
FEXBash: Set PS1 to make it more obvious when running under FEX

### DIFF
--- a/Source/Tests/FEXBash.cpp
+++ b/Source/Tests/FEXBash.cpp
@@ -59,7 +59,7 @@ int main(int argc, char **argv, char **const envp) {
   // Lets us start an emulated bash instance
   const size_t FEXArgsCount = std::size(FEXArgs) - (Args.empty() ? 1 : 0);
 
-  Argv.resize(Args.size() + FEXArgsCount + 1);
+  Argv.resize(Args.size() + FEXArgsCount);
 
   // Pass in the FEXInterpreter arguments
   for (size_t i = 0; i < FEXArgsCount; ++i) {
@@ -70,7 +70,39 @@ int main(int argc, char **argv, char **const envp) {
   for (size_t i = 0; i < Args.size(); ++i) {
     Argv[i + FEXArgsCount] = Args[i].c_str();
   }
-  Argv[Argv.size() - 1] = nullptr;
 
-  return execve(Argv[0], const_cast<char *const*>(&Argv.at(0)), envp);
+  // Set --norc when no arguments are passed so PS1 doesn't get overwritten
+  const char* NoRC = "--norc";
+  if (Args.empty()) {
+    Argv.emplace_back(NoRC);
+  }
+
+  Argv.emplace_back(nullptr);
+
+  // Prepend `FEXBash>` to PS1 to be less confusing about running under emulation
+  // In most cases PS1 isn't an environment variable, but instead a shell variable
+  // But in case the user has set the PS1 environment variable then still prepend
+  //
+  // To get the shell variables as an environment variable then you can do `PS1=$PS1 FEXBash`
+  std::vector<const char *> Envp{};
+  char *PS1Env{};
+  for (unsigned i = 0;; ++i) {
+    if (envp[i] == nullptr)
+      break;
+    if (strstr(envp[i], "PS1=") == envp[i]) {
+      PS1Env = envp[i];
+    }
+    else {
+	Envp.emplace_back(envp[i]);
+    }
+  }
+
+  std::string PS1 = "PS1=FEXBash> ";
+  if (PS1Env) {
+    PS1 += &PS1Env[strlen("PS1=")];
+  }
+  Envp.emplace_back(PS1.c_str());
+  Envp.emplace_back(nullptr);
+
+  return execve(Argv[0], const_cast<char *const*>(&Argv.at(0)), const_cast<char *const*>(&Envp[0]));
 }


### PR DESCRIPTION
This requires us to pass in --no-rc to bash since otherwise PS1 gets
overwritten by shell variables and nothing happens.

Which this is fine for the common use case of just wanting to run a
basic bash script under emulation.