### PR TITLE
Segment register index optimization

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -652,6 +652,7 @@ private:
   OrderedNode *Current_HeaderNode{};
 
   OrderedNode *AppendSegmentOffset(OrderedNode *Value, uint32_t Flags, uint32_t DefaultPrefix = 0, bool Override = false);
+  void UpdatePrefixFromSegment(OrderedNode *Segment, uint32_t SegmentReg);
 
   enum class MemoryAccessType {
     // Choose TSO or Non-TSO depending on access type

--- a/External/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
@@ -77,24 +77,6 @@ namespace {
     std::vector<ContextMemberInfo> ClassificationInfo;
   };
 
-  constexpr static std::array<LastAccessType, 15> DefaultAccess = {
-    ACCESS_NONE,
-    ACCESS_NONE,
-    ACCESS_NONE,
-    ACCESS_NONE,
-    ACCESS_NONE,
-    ACCESS_NONE,
-    ACCESS_NONE,
-    ACCESS_NONE,
-    ACCESS_NONE,
-    ACCESS_INVALID, // SSE padding in non-AVX case
-    ACCESS_NONE,
-    ACCESS_NONE,
-    ACCESS_NONE,
-    ACCESS_NONE,
-    ACCESS_NONE,
-  };
-
   static void ClassifyContextStruct(ContextInfo *ContextClassificationInfo, bool SupportsAVX) {
     auto ContextClassification = &ContextClassificationInfo->ClassificationInfo;
 
@@ -103,7 +85,7 @@ namespace {
         offsetof(FEXCore::Core::CPUState, rip),
         sizeof(FEXCore::Core::CPUState::rip),
       },
-      DefaultAccess[0],
+      ACCESS_NONE,
       FEXCore::IR::InvalidClass,
     });
 
@@ -113,62 +95,134 @@ namespace {
           offsetof(FEXCore::Core::CPUState, gregs[0]) + sizeof(FEXCore::Core::CPUState::gregs[0]) * i,
           FEXCore::Core::CPUState::GPR_REG_SIZE,
         },
-        DefaultAccess[1],
+        ACCESS_NONE,
         FEXCore::IR::InvalidClass,
       });
     }
 
     ContextClassification->emplace_back(ContextMemberInfo{
       ContextMemberClassification {
-        offsetof(FEXCore::Core::CPUState, es),
-        sizeof(FEXCore::Core::CPUState::es),
+        offsetof(FEXCore::Core::CPUState, es_idx),
+        sizeof(FEXCore::Core::CPUState::es_idx),
       },
-      DefaultAccess[2],
+      ACCESS_NONE,
       FEXCore::IR::InvalidClass,
     });
 
     ContextClassification->emplace_back(ContextMemberInfo{
       ContextMemberClassification {
-        offsetof(FEXCore::Core::CPUState, cs),
-        sizeof(FEXCore::Core::CPUState::cs),
+        offsetof(FEXCore::Core::CPUState, cs_idx),
+        sizeof(FEXCore::Core::CPUState::cs_idx),
       },
-      DefaultAccess[3],
+      ACCESS_NONE,
       FEXCore::IR::InvalidClass,
     });
 
     ContextClassification->emplace_back(ContextMemberInfo{
       ContextMemberClassification {
-        offsetof(FEXCore::Core::CPUState, ss),
-        sizeof(FEXCore::Core::CPUState::ss),
+        offsetof(FEXCore::Core::CPUState, ss_idx),
+        sizeof(FEXCore::Core::CPUState::ss_idx),
       },
-      DefaultAccess[4],
+      ACCESS_NONE,
       FEXCore::IR::InvalidClass,
     });
 
     ContextClassification->emplace_back(ContextMemberInfo{
       ContextMemberClassification {
-        offsetof(FEXCore::Core::CPUState, ds),
-        sizeof(FEXCore::Core::CPUState::ds),
+        offsetof(FEXCore::Core::CPUState, ds_idx),
+        sizeof(FEXCore::Core::CPUState::ds_idx),
       },
-      DefaultAccess[5],
+      ACCESS_NONE,
       FEXCore::IR::InvalidClass,
     });
 
     ContextClassification->emplace_back(ContextMemberInfo{
       ContextMemberClassification {
-        offsetof(FEXCore::Core::CPUState, gs),
-        sizeof(FEXCore::Core::CPUState::gs),
+        offsetof(FEXCore::Core::CPUState, gs_idx),
+        sizeof(FEXCore::Core::CPUState::gs_idx),
       },
-      DefaultAccess[6],
+      ACCESS_NONE,
       FEXCore::IR::InvalidClass,
     });
 
     ContextClassification->emplace_back(ContextMemberInfo{
       ContextMemberClassification {
-        offsetof(FEXCore::Core::CPUState, fs),
-        sizeof(FEXCore::Core::CPUState::fs),
+        offsetof(FEXCore::Core::CPUState, fs_idx),
+        sizeof(FEXCore::Core::CPUState::fs_idx),
       },
-      DefaultAccess[7],
+      ACCESS_NONE,
+      FEXCore::IR::InvalidClass,
+    });
+
+    ContextClassification->emplace_back(ContextMemberInfo{
+      ContextMemberClassification {
+        offsetof(FEXCore::Core::CPUState, _pad),
+        sizeof(FEXCore::Core::CPUState::_pad),
+      },
+      ACCESS_INVALID,
+      FEXCore::IR::InvalidClass,
+    });
+
+    ContextClassification->emplace_back(ContextMemberInfo{
+      ContextMemberClassification {
+        offsetof(FEXCore::Core::CPUState, es_cached),
+        sizeof(FEXCore::Core::CPUState::es_cached),
+      },
+      ACCESS_NONE,
+      FEXCore::IR::InvalidClass,
+    });
+
+    ContextClassification->emplace_back(ContextMemberInfo{
+      ContextMemberClassification {
+        offsetof(FEXCore::Core::CPUState, cs_cached),
+        sizeof(FEXCore::Core::CPUState::cs_cached),
+      },
+      ACCESS_NONE,
+      FEXCore::IR::InvalidClass,
+    });
+
+    ContextClassification->emplace_back(ContextMemberInfo{
+      ContextMemberClassification {
+        offsetof(FEXCore::Core::CPUState, ss_cached),
+        sizeof(FEXCore::Core::CPUState::ss_cached),
+      },
+      ACCESS_NONE,
+      FEXCore::IR::InvalidClass,
+    });
+
+    ContextClassification->emplace_back(ContextMemberInfo{
+      ContextMemberClassification {
+        offsetof(FEXCore::Core::CPUState, ds_cached),
+        sizeof(FEXCore::Core::CPUState::ds_cached),
+      },
+      ACCESS_NONE,
+      FEXCore::IR::InvalidClass,
+    });
+
+    ContextClassification->emplace_back(ContextMemberInfo{
+      ContextMemberClassification {
+        offsetof(FEXCore::Core::CPUState, gs_cached),
+        sizeof(FEXCore::Core::CPUState::gs_cached),
+      },
+      ACCESS_NONE,
+      FEXCore::IR::InvalidClass,
+    });
+
+    ContextClassification->emplace_back(ContextMemberInfo{
+      ContextMemberClassification {
+        offsetof(FEXCore::Core::CPUState, fs_cached),
+        sizeof(FEXCore::Core::CPUState::fs_cached),
+      },
+      ACCESS_NONE,
+      FEXCore::IR::InvalidClass,
+    });
+
+    ContextClassification->emplace_back(ContextMemberInfo{
+      ContextMemberClassification {
+        offsetof(FEXCore::Core::CPUState, _pad2),
+        sizeof(FEXCore::Core::CPUState::_pad2),
+      },
+      ACCESS_INVALID,
       FEXCore::IR::InvalidClass,
     });
 
@@ -179,7 +233,7 @@ namespace {
             offsetof(FEXCore::Core::CPUState, xmm.avx.data[0][0]) + FEXCore::Core::CPUState::XMM_AVX_REG_SIZE * i,
             FEXCore::Core::CPUState::XMM_AVX_REG_SIZE,
           },
-          DefaultAccess[8],
+          ACCESS_NONE,
           FEXCore::IR::InvalidClass,
         });
       }
@@ -190,7 +244,7 @@ namespace {
             offsetof(FEXCore::Core::CPUState, xmm.sse.data[0][0]) + FEXCore::Core::CPUState::XMM_SSE_REG_SIZE * i,
             FEXCore::Core::CPUState::XMM_SSE_REG_SIZE,
           },
-          DefaultAccess[8],
+          ACCESS_NONE,
           FEXCore::IR::InvalidClass,
         });
       }
@@ -200,7 +254,7 @@ namespace {
             offsetof(FEXCore::Core::CPUState, xmm.sse.pad[0][0]),
             static_cast<uint16_t>(FEXCore::Core::CPUState::XMM_SSE_REG_SIZE * FEXCore::Core::CPUState::NUM_XMMS),
           },
-          DefaultAccess[9],
+          ACCESS_INVALID,
           FEXCore::IR::InvalidClass,
         });
     }
@@ -211,7 +265,7 @@ namespace {
           offsetof(FEXCore::Core::CPUState, flags[0]) + sizeof(FEXCore::Core::CPUState::flags[0]) * i,
           FEXCore::Core::CPUState::FLAG_SIZE,
         },
-        DefaultAccess[10],
+        ACCESS_NONE,
         FEXCore::IR::InvalidClass,
       });
     }
@@ -222,7 +276,7 @@ namespace {
           offsetof(FEXCore::Core::CPUState, mm[0][0]) + sizeof(FEXCore::Core::CPUState::mm[0]) * i,
           FEXCore::Core::CPUState::MM_REG_SIZE
         },
-        DefaultAccess[11],
+        ACCESS_NONE,
         FEXCore::IR::InvalidClass,
       });
     }
@@ -234,7 +288,7 @@ namespace {
           offsetof(FEXCore::Core::CPUState, gdt[0]) + sizeof(FEXCore::Core::CPUState::gdt[0]) * i,
           sizeof(FEXCore::Core::CPUState::gdt[0]),
         },
-        DefaultAccess[12],
+        ACCESS_NONE,
         FEXCore::IR::InvalidClass,
       });
     }
@@ -245,7 +299,7 @@ namespace {
         offsetof(FEXCore::Core::CPUState, FCW),
         sizeof(FEXCore::Core::CPUState::FCW),
       },
-      DefaultAccess[13],
+      ACCESS_NONE,
       FEXCore::IR::InvalidClass,
     });
 
@@ -255,7 +309,7 @@ namespace {
         offsetof(FEXCore::Core::CPUState, FTW),
         sizeof(FEXCore::Core::CPUState::FTW),
       },
-      DefaultAccess[14],
+      ACCESS_NONE,
       FEXCore::IR::InvalidClass,
     });
 
@@ -289,40 +343,55 @@ namespace {
       ContextClassification->at(Offset).StoreNode = nullptr;
     };
     size_t Offset = 0;
-    SetAccess(Offset++, DefaultAccess[0]);
+    SetAccess(Offset++, ACCESS_NONE);
     for (size_t i = 0; i < FEXCore::Core::CPUState::NUM_GPRS; ++i) {
-      SetAccess(Offset++, DefaultAccess[1]);
+      SetAccess(Offset++, ACCESS_NONE);
     }
 
-    SetAccess(Offset++, DefaultAccess[2]);
-    SetAccess(Offset++, DefaultAccess[3]);
-    SetAccess(Offset++, DefaultAccess[4]);
-    SetAccess(Offset++, DefaultAccess[5]);
-    SetAccess(Offset++, DefaultAccess[6]);
-    SetAccess(Offset++, DefaultAccess[7]);
+    // Segment indexes
+    SetAccess(Offset++, ACCESS_NONE);
+    SetAccess(Offset++, ACCESS_NONE);
+    SetAccess(Offset++, ACCESS_NONE);
+    SetAccess(Offset++, ACCESS_NONE);
+    SetAccess(Offset++, ACCESS_NONE);
+    SetAccess(Offset++, ACCESS_NONE);
+
+    // Pad
+    SetAccess(Offset++, ACCESS_INVALID);
+
+    // Segments
+    SetAccess(Offset++, ACCESS_NONE);
+    SetAccess(Offset++, ACCESS_NONE);
+    SetAccess(Offset++, ACCESS_NONE);
+    SetAccess(Offset++, ACCESS_NONE);
+    SetAccess(Offset++, ACCESS_NONE);
+    SetAccess(Offset++, ACCESS_NONE);
+
+    // Pad2
+    SetAccess(Offset++, ACCESS_INVALID);
 
     for (size_t i = 0; i < FEXCore::Core::CPUState::NUM_XMMS; ++i) {
-      SetAccess(Offset++, DefaultAccess[8]);
+      SetAccess(Offset++, ACCESS_NONE);
     }
 
     if (!SupportsAVX) {
-      SetAccess(Offset++, DefaultAccess[9]);
+      SetAccess(Offset++, ACCESS_NONE);
     }
 
     for (size_t i = 0; i < FEXCore::Core::CPUState::NUM_FLAGS; ++i) {
-      SetAccess(Offset++, DefaultAccess[10]);
+      SetAccess(Offset++, ACCESS_NONE);
     }
 
     for (size_t i = 0; i < FEXCore::Core::CPUState::NUM_MMS; ++i) {
-      SetAccess(Offset++, DefaultAccess[11]);
+      SetAccess(Offset++, ACCESS_NONE);
     }
 
     for (size_t i = 0; i < FEXCore::Core::CPUState::NUM_GDTS; ++i) {
-      SetAccess(Offset++, DefaultAccess[12]);
+      SetAccess(Offset++, ACCESS_NONE);
     }
 
-    SetAccess(Offset++, DefaultAccess[13]);
-    SetAccess(Offset++, DefaultAccess[14]);
+    SetAccess(Offset++, ACCESS_NONE);
+    SetAccess(Offset++, ACCESS_NONE);
   }
 
   struct BlockInfo {

--- a/External/FEXCore/include/FEXCore/Core/CoreState.h
+++ b/External/FEXCore/include/FEXCore/Core/CoreState.h
@@ -28,9 +28,16 @@ namespace FEXCore::Core {
 
     uint64_t rip; ///< Current core's RIP. May not be entirely accurate while JIT is active
     uint64_t gregs[16];
-    uint16_t es, cs, ss, ds;
-    uint64_t gs;
-    uint64_t fs;
+    // Raw segment register indexes
+    uint16_t es_idx, cs_idx, ss_idx, ds_idx;
+    uint16_t gs_idx, fs_idx;
+    uint16_t _pad[2];
+
+    // Segment registers holding base addresses
+    uint32_t es_cached, cs_cached, ss_cached, ds_cached;
+    uint64_t gs_cached;
+    uint64_t fs_cached;
+    uint64_t _pad2[1];
     XMMRegs xmm;
     uint8_t flags[48];
     uint64_t mm[8][2];

--- a/Source/Tests/HarnessHelpers.h
+++ b/Source/Tests/HarnessHelpers.h
@@ -127,13 +127,13 @@ namespace FEX::HarnessHelper {
 
     // GS
     if (MatchMask & 1) {
-      CheckGPRs("GS", State1.gs, State2.gs);
+      CheckGPRs("GS", State1.gs_cached, State2.gs_cached);
     }
     MatchMask >>= 1;
 
     // FS
     if (MatchMask & 1) {
-      CheckGPRs("FS", State1.fs, State2.fs);
+      CheckGPRs("FS", State1.fs_cached, State2.fs_cached);
     }
     MatchMask >>= 1;
 
@@ -233,8 +233,8 @@ namespace FEX::HarnessHelper {
           offsetof(FEXCore::Core::CPUState, xmm.avx.data[13][0]),
           offsetof(FEXCore::Core::CPUState, xmm.avx.data[14][0]),
           offsetof(FEXCore::Core::CPUState, xmm.avx.data[15][0]),
-          offsetof(FEXCore::Core::CPUState, gs),
-          offsetof(FEXCore::Core::CPUState, fs),
+          offsetof(FEXCore::Core::CPUState, gs_cached),
+          offsetof(FEXCore::Core::CPUState, fs_cached),
           offsetof(FEXCore::Core::CPUState, flags),
           offsetof(FEXCore::Core::CPUState, mm[0][0]),
           offsetof(FEXCore::Core::CPUState, mm[1][0]),
@@ -280,8 +280,8 @@ namespace FEX::HarnessHelper {
           offsetof(FEXCore::Core::CPUState, xmm.sse.data[13][0]),
           offsetof(FEXCore::Core::CPUState, xmm.sse.data[14][0]),
           offsetof(FEXCore::Core::CPUState, xmm.sse.data[15][0]),
-          offsetof(FEXCore::Core::CPUState, gs),
-          offsetof(FEXCore::Core::CPUState, fs),
+          offsetof(FEXCore::Core::CPUState, gs_cached),
+          offsetof(FEXCore::Core::CPUState, fs_cached),
           offsetof(FEXCore::Core::CPUState, flags),
           offsetof(FEXCore::Core::CPUState, mm[0][0]),
           offsetof(FEXCore::Core::CPUState, mm[1][0]),

--- a/Source/Tests/LinuxSyscalls/Syscalls/Thread.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Thread.cpp
@@ -455,7 +455,7 @@ namespace FEX::HLE {
             // Ignore a non-canonical address
             return -EPERM;
           }
-          Frame->State.gs = addr;
+          Frame->State.gs_cached = addr;
           Result = 0;
         break;
         case 0x1002: // ARCH_SET_FS
@@ -463,15 +463,15 @@ namespace FEX::HLE {
             // Ignore a non-canonical address
             return -EPERM;
           }
-          Frame->State.fs = addr;
+          Frame->State.fs_cached = addr;
           Result = 0;
         break;
         case 0x1003: // ARCH_GET_FS
-          *reinterpret_cast<uint64_t*>(addr) = Frame->State.fs;
+          *reinterpret_cast<uint64_t*>(addr) = Frame->State.fs_cached;
           Result = 0;
         break;
         case 0x1004: // ARCH_GET_GS
-          *reinterpret_cast<uint64_t*>(addr) = Frame->State.gs;
+          *reinterpret_cast<uint64_t*>(addr) = Frame->State.gs_cached;
           Result = 0;
         break;
         case 0x3001: // ARCH_CET_STATUS

--- a/Source/Tests/LinuxSyscalls/x32/Thread.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Thread.cpp
@@ -68,6 +68,29 @@ namespace FEX::HLE::x32 {
     // Now we need to update the thread's GDT to handle this change
     auto GDT = &Frame->State.gdt[u_info->entry_number];
     GDT->base = u_info->base_addr;
+
+    // With the segment register optimization we need to check all of the segment registers and update.
+    const auto GetEntry = [](auto value) {
+      return value >> 3;
+    };
+    if (GetEntry(Frame->State.cs_idx) == u_info->entry_number) {
+      Frame->State.cs_cached = GDT->base;
+    }
+    if (GetEntry(Frame->State.ds_idx) == u_info->entry_number) {
+      Frame->State.ds_cached = GDT->base;
+    }
+    if (GetEntry(Frame->State.es_idx) == u_info->entry_number) {
+      Frame->State.es_cached = GDT->base;
+    }
+    if (GetEntry(Frame->State.fs_idx) == u_info->entry_number) {
+      Frame->State.fs_cached = GDT->base;
+    }
+    if (GetEntry(Frame->State.gs_idx) == u_info->entry_number) {
+      Frame->State.gs_cached = GDT->base;
+    }
+    if (GetEntry(Frame->State.ss_idx) == u_info->entry_number) {
+      Frame->State.ss_cached = GDT->base;
+    }
     return 0;
   }
 

--- a/Source/Tests/LinuxSyscalls/x64/Thread.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Thread.cpp
@@ -24,7 +24,7 @@ $end_info$
 
 namespace FEX::HLE::x64 {
   uint64_t SetThreadArea(FEXCore::Core::CpuStateFrame *Frame, void *tls) {
-    Frame->State.fs = reinterpret_cast<uint64_t>(tls);
+    Frame->State.fs_cached = reinterpret_cast<uint64_t>(tls);
     return 0;
   }
 

--- a/unittests/IR/Correctness/FPRStoreTruncate.ir
+++ b/unittests/IR/Correctness/FPRStoreTruncate.ir
@@ -26,28 +26,28 @@
     %AddrB i64 = Constant #0x1000010
 
     %ClearVal i128 = LoadMem FPR, #0x10, %AddrB i64, %Invalid, #0x10, SXTX, #1
-    (%Clear1 i128) StoreContext #0x10, FPR, %ClearVal i128, #0xa0
-    (%Clear2 i128) StoreContext #0x10, FPR, %ClearVal i128, #0xc0
-    (%Clear3 i128) StoreContext #0x10, FPR, %ClearVal i128, #0xe0
-    (%Clear4 i128) StoreContext #0x10, FPR, %ClearVal i128, #0x100
+    (%Clear1 i128) StoreContext #0x10, FPR, %ClearVal i128, #0xc0
+    (%Clear2 i128) StoreContext #0x10, FPR, %ClearVal i128, #0xe0
+    (%Clear3 i128) StoreContext #0x10, FPR, %ClearVal i128, #0x100
+    (%Clear4 i128) StoreContext #0x10, FPR, %ClearVal i128, #0x120
 
     %AddrA i64 = Constant #0x1000000
 
     %MemValueA i128 = LoadMem FPR, #0x10, %AddrA i64, %Invalid, #0x10, SXTX, #1
-    (%Store1 i128) StoreContext #0x10, FPR, %MemValueA i128, #0xa0
-    (%Store2 i128) StoreContext #0x10, FPR, %MemValueA i128, #0xc0
-    (%Store3 i128) StoreContext #0x10, FPR, %MemValueA i128, #0xe0
-    (%Store4 i8)   StoreContext  #0x1, FPR, %MemValueA i128, #0x100
+    (%Store1 i128) StoreContext #0x10, FPR, %MemValueA i128, #0xc0
+    (%Store2 i128) StoreContext #0x10, FPR, %MemValueA i128, #0xe0
+    (%Store3 i128) StoreContext #0x10, FPR, %MemValueA i128, #0x100
+    (%Store4 i8)   StoreContext  #0x1, FPR, %MemValueA i128, #0x120
 
-    %Truncated64 i64 = LoadContext #0x8, FPR, #0xa0
-    %Truncated32 i32 = LoadContext #0x4, FPR, #0xc0
-    %Truncated16 i16 = LoadContext #0x2, FPR, #0xe0
-    %Truncated8  i8  = LoadContext #0x1, FPR, #0x100
+    %Truncated64 i64 = LoadContext #0x8, FPR, #0xc0
+    %Truncated32 i32 = LoadContext #0x4, FPR, #0xe0
+    %Truncated16 i16 = LoadContext #0x2, FPR, #0x100
+    %Truncated8  i8  = LoadContext #0x1, FPR, #0x120
 
-    (%Store5 i128) StoreContext #0x10, FPR, %Truncated64 i128, #0x120
-    (%Store6 i128) StoreContext #0x10, FPR, %Truncated32 i128, #0x140
-    (%Store7 i128) StoreContext #0x10, FPR, %Truncated16 i128, #0x160
-    (%Store8 i128) StoreContext #0x10, FPR, %Truncated8 i128, #0x180
-    (%Store9 i128) StoreContext #0x10, FPR, %MemValueA i128, #0x1A0
+    (%Store5 i128) StoreContext #0x10, FPR, %Truncated64 i128, #0x140
+    (%Store6 i128) StoreContext #0x10, FPR, %Truncated32 i128, #0x160
+    (%Store7 i128) StoreContext #0x10, FPR, %Truncated16 i128, #0x180
+    (%Store8 i128) StoreContext #0x10, FPR, %Truncated8 i128, #0x1A0
+    (%Store9 i128) StoreContext #0x10, FPR, %MemValueA i128, #0x1C0
     (%ssa7 i0) Break {0.11.0.128}
     (%end i0) EndBlock %ssa2


### PR DESCRIPTION
Segment registers are indexed significantly more than they are changed.
Pay the cost of indexing during the set and store rather than the per
register index.

Should be a fairly significant performance improvement for 32-bit
applications. At least on hardware that doesn't have a data dependent
prefetcher.

Breaks Steam atm and isn't clean.