### PR TITLE
Core: context-wide guest code invalidations

### DIFF
--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -155,11 +155,13 @@ namespace FEXCore::Context {
     void RegisterHostSignalHandler(int Signal, HostSignalDelegatorFunction Func, bool Required);
     void RegisterFrontendHostSignalHandler(int Signal, HostSignalDelegatorFunction Func, bool Required);
 
-    static void RemoveCodeEntry(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP);
+    // Must be called from owning thread
+    static void RemoveThreadCodeEntry(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP);
 
     // Wrapper which takes CpuStateFrame instead of InternalThreadState
-    static void RemoveCodeEntryFromJit(FEXCore::Core::CpuStateFrame *Frame, uint64_t GuestRIP) {
-      RemoveCodeEntry(Frame->Thread, GuestRIP);
+    // Must be called from owning thread
+    static void RemoveThreadCodeEntryFromJit(FEXCore::Core::CpuStateFrame *Frame, uint64_t GuestRIP) {
+      RemoveThreadCodeEntry(Frame->Thread, GuestRIP);
     }
 
     // Debugger interface

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -1037,7 +1037,7 @@ namespace FEXCore::Context {
     }
   }
 
-  static void FlushThreadCodeRange(FEXCore::Core::InternalThreadState *Thread, uint64_t Start, uint64_t Length) {
+  static void InvalidateGuestThreadCodeRange(FEXCore::Core::InternalThreadState *Thread, uint64_t Start, uint64_t Length) {
     std::lock_guard<std::recursive_mutex> lk(Thread->LookupCache->WriteLock);
 
     auto lower = Thread->LookupCache->CodePages.lower_bound(Start >> 12);
@@ -1050,11 +1050,11 @@ namespace FEXCore::Context {
     }
   }
 
-  void FlushCodeRange(FEXCore::Context::Context *CTX, uint64_t Start, uint64_t Length) {
+  void InvalidateGuestCodeRange(FEXCore::Context::Context *CTX, uint64_t Start, uint64_t Length) {
     std::lock_guard<std::mutex> lk(CTX->ThreadCreationMutex);
     for (auto &Thread : CTX->Threads) {
       if (Thread->RunningEvents.Running.load()) {
-        FlushThreadCodeRange(Thread, Start, Length);
+        InvalidateGuestThreadCodeRange(Thread, Start, Length);
       }
     }
   }

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -1041,11 +1041,12 @@ namespace FEXCore::Context {
     std::lock_guard<std::recursive_mutex> lk(Thread->LookupCache->WriteLock);
 
     auto lower = Thread->LookupCache->CodePages.lower_bound(Start >> 12);
-    auto upper = Thread->LookupCache->CodePages.upper_bound((Start + Length) >> 12);
+    auto upper = Thread->LookupCache->CodePages.upper_bound((Start + Length - 1) >> 12);
 
     for (auto it = lower; it != upper; it++) {
-      for (auto Address: it->second)
-      Context::RemoveThreadCodeEntry(Thread, Address);
+      for (auto Address: it->second) {
+        Context::RemoveThreadCodeEntry(Thread, Address);
+      }
       it->second.clear();
     }
   }

--- a/External/FEXCore/Source/Interface/Core/Interpreter/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/BranchOps.cpp
@@ -147,8 +147,8 @@ DEF_OP(ValidateCode) {
   }
 }
 
-DEF_OP(RemoveCodeEntry) {
-  Data->State->CTX->RemoveCodeEntry(Data->State, Data->CurrentEntry);
+DEF_OP(RemoveThreadCodeEntry) {
+  Data->State->CTX->RemoveThreadCodeEntry(Data->State, Data->CurrentEntry);
 }
 
 DEF_OP(CPUID) {

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -123,7 +123,7 @@ constexpr OpHandlerArray InterpreterOpHandlers = [] {
   REGISTER_OP(INLINESYSCALL,          InlineSyscall);
   REGISTER_OP(THUNK,                  Thunk);
   REGISTER_OP(VALIDATECODE,           ValidateCode);
-  REGISTER_OP(REMOVECODEENTRY,        RemoveCodeEntry);
+  REGISTER_OP(REMOVETHREADCODEENTRY,        RemoveThreadCodeEntry);
   REGISTER_OP(CPUID,                  CPUID);
 
   // Conversion ops

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
@@ -153,7 +153,7 @@ namespace FEXCore::CPU {
   DEF_OP(InlineSyscall);
   DEF_OP(Thunk);
   DEF_OP(ValidateCode);
-  DEF_OP(RemoveCodeEntry);
+  DEF_OP(RemoveThreadCodeEntry);
   DEF_OP(CPUID);
 
   ///< Conversion ops

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
@@ -442,7 +442,7 @@ DEF_OP(ValidateCode) {
   }
 }
 
-DEF_OP(RemoveCodeEntry) {
+DEF_OP(RemoveThreadCodeEntry) {
   // Arguments are passed as follows:
   // X0: Thread
   // X1: RIP
@@ -452,7 +452,7 @@ DEF_OP(RemoveCodeEntry) {
   mov(x0, STATE);
   LoadConstant(x1, Entry);
 
-  ldr(x2, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.AArch64.RemoveCodeEntryFromJIT)));
+  ldr(x2, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.AArch64.RemoveThreadCodeEntryFromJIT)));
   SpillStaticRegs();
   blr(x2);
   FillStaticRegs();
@@ -500,7 +500,7 @@ void Arm64JITCore::RegisterBranchHandlers() {
   REGISTER_OP(INLINESYSCALL,     InlineSyscall);
   REGISTER_OP(THUNK,             Thunk);
   REGISTER_OP(VALIDATECODE,      ValidateCode);
-  REGISTER_OP(REMOVECODEENTRY,   RemoveCodeEntry);
+  REGISTER_OP(REMOVETHREADCODEENTRY,   RemoveThreadCodeEntry);
   REGISTER_OP(CPUID,             CPUID);
 #undef REGISTER_OP
 }

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -453,7 +453,7 @@ Arm64JITCore::Arm64JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::Intern
     Pointers.LREM = reinterpret_cast<uint64_t>(LREM);
     Pointers.PrintValue = reinterpret_cast<uint64_t>(PrintValue);
     Pointers.PrintVectorValue = reinterpret_cast<uint64_t>(PrintVectorValue);
-    Pointers.RemoveCodeEntryFromJIT = reinterpret_cast<uintptr_t>(&Context::Context::RemoveCodeEntryFromJit);
+    Pointers.RemoveThreadCodeEntryFromJIT = reinterpret_cast<uintptr_t>(&Context::Context::RemoveThreadCodeEntryFromJit);
     Pointers.CPUIDObj = reinterpret_cast<uint64_t>(&CTX->CPUID);
 
     {

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -278,7 +278,7 @@ private:
   DEF_OP(InlineSyscall);
   DEF_OP(Thunk);
   DEF_OP(ValidateCode);
-  DEF_OP(RemoveCodeEntry);
+  DEF_OP(RemoveThreadCodeEntry);
   DEF_OP(CPUID);
 
   ///< Conversion ops

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
@@ -259,7 +259,7 @@ DEF_OP(ValidateCode) {
   }
 }
 
-DEF_OP(RemoveCodeEntry) {
+DEF_OP(RemoveThreadCodeEntry) {
   auto NumPush = RA64.size();
 
   for (auto &Reg : RA64)
@@ -272,7 +272,7 @@ DEF_OP(RemoveCodeEntry) {
   mov(rax, Entry); // imm64 move
   mov(rsi, rax);
 
-  call(qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, Pointers.X86.RemoveCodeEntryFromJIT)]);
+  call(qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, Pointers.X86.RemoveThreadCodeEntryFromJIT)]);
 
   if (NumPush & 1)
     add(rsp, 8); // Align
@@ -330,7 +330,7 @@ void X86JITCore::RegisterBranchHandlers() {
   REGISTER_OP(SYSCALL,           Syscall);
   REGISTER_OP(THUNK,             Thunk);
   REGISTER_OP(VALIDATECODE,      ValidateCode);
-  REGISTER_OP(REMOVECODEENTRY,   RemoveCodeEntry);
+  REGISTER_OP(REMOVETHREADCODEENTRY,   RemoveThreadCodeEntry);
   REGISTER_OP(CPUID,             CPUID);
 #undef REGISTER_OP
 }

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -371,7 +371,7 @@ X86JITCore::X86JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalTh
     // Process specific
     Pointers.PrintValue = reinterpret_cast<uint64_t>(PrintValue);
     Pointers.PrintVectorValue = reinterpret_cast<uint64_t>(PrintVectorValue);
-    Pointers.RemoveCodeEntryFromJIT = reinterpret_cast<uintptr_t>(&Context::Context::RemoveCodeEntryFromJit);
+    Pointers.RemoveThreadCodeEntryFromJIT = reinterpret_cast<uintptr_t>(&Context::Context::RemoveThreadCodeEntryFromJit);
     Pointers.CPUIDObj = reinterpret_cast<uint64_t>(&CTX->CPUID);
 
     {

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -276,7 +276,7 @@ private:
   DEF_OP(Syscall);
   DEF_OP(Thunk);
   DEF_OP(ValidateCode);
-  DEF_OP(RemoveCodeEntry);
+  DEF_OP(RemoveThreadCodeEntry);
   DEF_OP(CPUID);
 
   ///< Conversion ops

--- a/External/FEXCore/Source/Interface/Core/LookupCache.cpp
+++ b/External/FEXCore/Source/Interface/Core/LookupCache.cpp
@@ -61,6 +61,7 @@ void LookupCache::HintUsedRange(uint64_t Address, uint64_t Size) {
 }
 
 void LookupCache::ClearL2Cache() {
+  std::lock_guard<std::recursive_mutex> lk(WriteLock);
   // Clear out the page memory
   madvise(reinterpret_cast<void*>(PagePointer), ctx->Config.VirtualMemSize / 4096 * 8, MADV_DONTNEED);
   madvise(reinterpret_cast<void*>(PageMemory), CODE_SIZE, MADV_DONTNEED);
@@ -68,6 +69,8 @@ void LookupCache::ClearL2Cache() {
 }
 
 void LookupCache::ClearCache() {
+  std::lock_guard<std::recursive_mutex> lk(WriteLock);
+
   // Clear L1
   madvise(reinterpret_cast<void*>(L1Pointer), L1_SIZE, MADV_DONTNEED);
   // Clear L2

--- a/External/FEXCore/Source/Interface/IR/AOTIR.cpp
+++ b/External/FEXCore/Source/Interface/IR/AOTIR.cpp
@@ -1,5 +1,6 @@
 #include "Interface/Context/Context.h"
 #include "Interface/IR/AOTIR.h"
+#include "Interface/Core/LookupCache.h"
 
 #include <FEXCore/IR/IntrusiveIRList.h>
 #include <FEXCore/IR/RegisterAllocationData.h>
@@ -349,6 +350,8 @@ namespace FEXCore::IR {
         if (Thread->CPUBackend->NeedsRetainedIRCopy()) {
           // Add to thread local ir cache
           Core::LocalIREntry Entry = {StartAddr, Length, decltype(Entry.IR)(IRList), decltype(Entry.RAData)(RAData), decltype(Entry.DebugData)(DebugData)};
+          
+          std::lock_guard<std::recursive_mutex> lk(Thread->LookupCache->WriteLock);
           Thread->LocalIRCache.insert({GuestRIP, std::move(Entry)});
         }
         else {

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -187,7 +187,7 @@
         "DestSize": "8"
       },
 
-      "RemoveCodeEntry": {
+      "RemoveThreadCodeEntry": {
         "HasSideEffects": true
       },
 

--- a/External/FEXCore/include/FEXCore/Core/Context.h
+++ b/External/FEXCore/include/FEXCore/Core/Context.h
@@ -244,7 +244,7 @@ namespace FEXCore::Context {
 
   FEX_DEFAULT_VISIBILITY void FinalizeAOTIRCache(FEXCore::Context::Context *CTX);
   FEX_DEFAULT_VISIBILITY void WriteFilesWithCode(FEXCore::Context::Context *CTX, std::function<void(const std::string& fileid, const std::string& filename)> Writer);
-  FEX_DEFAULT_VISIBILITY void FlushCodeRange(FEXCore::Context::Context *CTX, uint64_t Start, uint64_t Length);
+  FEX_DEFAULT_VISIBILITY void InvalidateGuestCodeRange(FEXCore::Context::Context *CTX, uint64_t Start, uint64_t Length);
 
   FEX_DEFAULT_VISIBILITY void ConfigureAOTGen(FEXCore::Core::InternalThreadState *Thread, std::set<uint64_t> *ExternalBranches, uint64_t SectionMaxAddress);
 }

--- a/External/FEXCore/include/FEXCore/Core/Context.h
+++ b/External/FEXCore/include/FEXCore/Core/Context.h
@@ -244,7 +244,7 @@ namespace FEXCore::Context {
 
   FEX_DEFAULT_VISIBILITY void FinalizeAOTIRCache(FEXCore::Context::Context *CTX);
   FEX_DEFAULT_VISIBILITY void WriteFilesWithCode(FEXCore::Context::Context *CTX, std::function<void(const std::string& fileid, const std::string& filename)> Writer);
-  FEX_DEFAULT_VISIBILITY void FlushCodeRange(FEXCore::Core::InternalThreadState *Thread, uint64_t Start, uint64_t Length);
+  FEX_DEFAULT_VISIBILITY void FlushCodeRange(FEXCore::Context::Context *CTX, uint64_t Start, uint64_t Length);
 
   FEX_DEFAULT_VISIBILITY void ConfigureAOTGen(FEXCore::Core::InternalThreadState *Thread, std::set<uint64_t> *ExternalBranches, uint64_t SectionMaxAddress);
 }

--- a/External/FEXCore/include/FEXCore/Core/CoreState.h
+++ b/External/FEXCore/include/FEXCore/Core/CoreState.h
@@ -101,7 +101,7 @@ namespace FEXCore::Core {
       uint64_t LREM{};
       uint64_t PrintValue{};
       uint64_t PrintVectorValue{};
-      uint64_t RemoveCodeEntryFromJIT{};
+      uint64_t RemoveThreadCodeEntryFromJIT{};
       uint64_t CPUIDObj{};
       uint64_t CPUIDFunction{};
       uint64_t SyscallHandlerObj{};
@@ -134,7 +134,7 @@ namespace FEXCore::Core {
       // Process specific
       uint64_t PrintValue{};
       uint64_t PrintVectorValue{};
-      uint64_t RemoveCodeEntryFromJIT{};
+      uint64_t RemoveThreadCodeEntryFromJIT{};
       uint64_t CPUIDObj{};
       uint64_t CPUIDFunction{};
       uint64_t SyscallHandlerObj{};

--- a/Source/Tests/LinuxSyscalls/x32/Memory.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Memory.cpp
@@ -45,7 +45,7 @@ namespace FEX::HLE::x32 {
 
           FEXCore::Context::AddNamedRegion(CTX, Result, arg->len, arg->offset, filename);
         }
-        FEXCore::Context::FlushCodeRange(CTX, (uintptr_t)Result, arg->len);
+        FEXCore::Context::InvalidateGuestCodeRange(CTX, (uintptr_t)Result, arg->len);
       }
       return Result;
     });
@@ -61,7 +61,7 @@ namespace FEX::HLE::x32 {
 
           FEXCore::Context::AddNamedRegion(CTX, Result, length, pgoffset * 0x1000, filename);
         }
-        FEXCore::Context::FlushCodeRange(CTX, (uintptr_t)Result, length);
+        FEXCore::Context::InvalidateGuestCodeRange(CTX, (uintptr_t)Result, length);
       }
 
       return Result;
@@ -74,7 +74,7 @@ namespace FEX::HLE::x32 {
       if (Result == 0) {
         auto CTX = Frame->Thread->CTX;
         FEXCore::Context::RemoveNamedRegion(CTX, (uintptr_t)addr, length);
-        FEXCore::Context::FlushCodeRange(CTX, (uintptr_t)addr, length);
+        FEXCore::Context::InvalidateGuestCodeRange(CTX, (uintptr_t)addr, length);
       }
 
       return Result;
@@ -85,7 +85,7 @@ namespace FEX::HLE::x32 {
 
       if (Result != -1 && prot & PROT_EXEC) {
         auto CTX = Frame->Thread->CTX;
-        FEXCore::Context::FlushCodeRange(CTX, (uintptr_t)addr, len);
+        FEXCore::Context::InvalidateGuestCodeRange(CTX, (uintptr_t)addr, len);
       }
       SYSCALL_ERRNO();
     });

--- a/Source/Tests/LinuxSyscalls/x64/Memory.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Memory.cpp
@@ -50,10 +50,10 @@ namespace FEX::HLE::x64 {
         Result = FEXCore::Allocator::munmap(addr, length);
       }
 
-      auto Thread = Frame->Thread;
       if (Result != -1) {
-        FEXCore::Context::RemoveNamedRegion(Thread->CTX, (uintptr_t)addr, length);
-        FEXCore::Context::FlushCodeRange(Thread, (uintptr_t)addr, length);
+        auto CTX = Frame->Thread->CTX;
+        FEXCore::Context::RemoveNamedRegion(CTX, (uintptr_t)addr, length);
+        FEXCore::Context::FlushCodeRange(CTX, (uintptr_t)addr, length);
       }
       SYSCALL_ERRNO();
     });
@@ -78,14 +78,14 @@ namespace FEX::HLE::x64 {
         Result = reinterpret_cast<uint64_t>(FEXCore::Allocator::mmap(addr, length, prot, flags, fd, offset));
       }
 
-      auto Thread = Frame->Thread;
       if (Result != -1) {
+        auto CTX = Frame->Thread->CTX;
         if (!(flags & MAP_ANONYMOUS)) {
           auto filename = get_fdpath(fd);
 
-          FEXCore::Context::AddNamedRegion(Thread->CTX, Result, length, offset, filename);
+          FEXCore::Context::AddNamedRegion(CTX, Result, length, offset, filename);
         }
-        FEXCore::Context::FlushCodeRange(Thread, (uintptr_t)Result, length);
+        FEXCore::Context::FlushCodeRange(CTX, (uintptr_t)Result, length);
       }
       SYSCALL_ERRNO();
     });
@@ -100,9 +100,9 @@ namespace FEX::HLE::x64 {
       [](FEXCore::Core::CpuStateFrame *Frame, void *addr, size_t len, int prot) -> uint64_t {
       uint64_t Result = ::mprotect(addr, len, prot);
 
-      auto Thread = Frame->Thread;
       if (Result != -1 && prot & PROT_EXEC) {
-        FEXCore::Context::FlushCodeRange(Thread, (uintptr_t)addr, len);
+        auto CTX = Frame->Thread->CTX;
+        FEXCore::Context::FlushCodeRange(CTX, (uintptr_t)addr, len);
       }
       SYSCALL_ERRNO();
     });

--- a/Source/Tests/LinuxSyscalls/x64/Memory.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Memory.cpp
@@ -53,7 +53,7 @@ namespace FEX::HLE::x64 {
       if (Result != -1) {
         auto CTX = Frame->Thread->CTX;
         FEXCore::Context::RemoveNamedRegion(CTX, (uintptr_t)addr, length);
-        FEXCore::Context::FlushCodeRange(CTX, (uintptr_t)addr, length);
+        FEXCore::Context::InvalidateGuestCodeRange(CTX, (uintptr_t)addr, length);
       }
       SYSCALL_ERRNO();
     });
@@ -85,7 +85,7 @@ namespace FEX::HLE::x64 {
 
           FEXCore::Context::AddNamedRegion(CTX, Result, length, offset, filename);
         }
-        FEXCore::Context::FlushCodeRange(CTX, (uintptr_t)Result, length);
+        FEXCore::Context::InvalidateGuestCodeRange(CTX, (uintptr_t)Result, length);
       }
       SYSCALL_ERRNO();
     });
@@ -102,7 +102,7 @@ namespace FEX::HLE::x64 {
 
       if (Result != -1 && prot & PROT_EXEC) {
         auto CTX = Frame->Thread->CTX;
-        FEXCore::Context::FlushCodeRange(CTX, (uintptr_t)addr, len);
+        FEXCore::Context::InvalidateGuestCodeRange(CTX, (uintptr_t)addr, len);
       }
       SYSCALL_ERRNO();
     });


### PR DESCRIPTION
## Overview

Split off #1558, requires #1669.

Makes guest code invalidations context-wide by default, renames API from `Context::FlushCodeRange` to `Context::InvalidateGuestCodeRange`

## Details
### Invalidating jit code can now be done context-wide (affects: `Context`, `LookupCache`, `IR`)
- `LookupCache` has been updated to include a lock that is only ever contested on cross thread invalidations, and protects all writes and most reads from all structures, including `InternalThreadState::LocalIRCache` which is not part of LookupCache)

- Reads from `LookupCache` L1C are not protected by the mutex, and invalidations to L1C are done in a way that will likely tear without side effects. This needs to be validated & tested.

- Only invalidations of `LookupCache` may happen from another thread. All other operations are done from the owning thread.

- `FlushCodeRange()` has been changed to iterate over all threads and invalidate on them all

- Thread invalidation has been moved to `FlushThreadCodeRange()`

- In IR/Backends `OP_RemoveCodeEntry`  has been renamed to `OP_RemoveThreadCodeEntry`, as it is meant to do invalidations only on the current thread.

## Suggested follow ups
- [x] Move `LocalIRCache` to `LookupCache` (#1675)