### PR TITLE
Syscalls/Linux: Refactor guest mman tracking

### DIFF
--- a/Source/Tests/LinuxSyscalls/Syscalls/Memory.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Memory.cpp
@@ -38,9 +38,13 @@ namespace FEX::HLE {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_PASS_FLAGS(madvise, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
+    REGISTER_SYSCALL_IMPL_FLAGS(madvise, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
       [](FEXCore::Core::CpuStateFrame *Frame, void *addr, size_t length, int32_t advice) -> uint64_t {
       uint64_t Result = ::madvise(addr, length, advice);
+
+      if (Result != -1) {
+        FEX::HLE::_SyscallHandler->TrackMadvise((uintptr_t)addr, length, advice);
+      }
       SYSCALL_ERRNO();
     });
 

--- a/Source/Tests/LinuxSyscalls/x32/Memory.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Memory.cpp
@@ -18,12 +18,6 @@ $end_info$
 #include <system_error>
 #include <filesystem>
 
-static std::string get_fdpath(int fd)
-{
-  std::error_code ec;
-  return std::filesystem::canonical(std::filesystem::path("/proc/self/fd") / std::to_string(fd), ec).string();
-}
-
 namespace FEX::HLE::x32 {
   void RegisterMemory() {
     struct old_mmap_struct {
@@ -39,13 +33,7 @@ namespace FEX::HLE::x32 {
         mmap(reinterpret_cast<void*>(arg->addr), arg->len, arg->prot, arg->flags, arg->fd, arg->offset);
 
       if (!FEX::HLE::HasSyscallError(Result)) {
-        auto CTX = Frame->Thread->CTX;
-        if (!(arg->flags & MAP_ANONYMOUS)) {
-          auto filename = get_fdpath(arg->fd);
-
-          FEXCore::Context::AddNamedRegion(CTX, Result, arg->len, arg->offset, filename);
-        }
-        FEXCore::Context::InvalidateGuestCodeRange(CTX, (uintptr_t)Result, arg->len);
+        FEX::HLE::_SyscallHandler->TrackMmap(Result, arg->len, arg->prot, arg->flags, arg->fd, arg->offset);
       }
       return Result;
     });
@@ -55,13 +43,7 @@ namespace FEX::HLE::x32 {
         mmap(reinterpret_cast<void*>(addr), length, prot,flags, fd, (uint64_t)pgoffset * 0x1000);
 
       if (!FEX::HLE::HasSyscallError(Result)) {
-        auto CTX = Frame->Thread->CTX;
-        if (!(flags & MAP_ANONYMOUS)) {
-          auto filename = get_fdpath(fd);
-
-          FEXCore::Context::AddNamedRegion(CTX, Result, length, pgoffset * 0x1000, filename);
-        }
-        FEXCore::Context::InvalidateGuestCodeRange(CTX, (uintptr_t)Result, length);
+        FEX::HLE::_SyscallHandler->TrackMmap(Result, length, prot, flags, fd, pgoffset * 0x1000);
       }
 
       return Result;
@@ -72,9 +54,7 @@ namespace FEX::HLE::x32 {
         munmap(addr, length);
 
       if (Result == 0) {
-        auto CTX = Frame->Thread->CTX;
-        FEXCore::Context::RemoveNamedRegion(CTX, (uintptr_t)addr, length);
-        FEXCore::Context::InvalidateGuestCodeRange(CTX, (uintptr_t)addr, length);
+        FEX::HLE::_SyscallHandler->TrackMunmap((uintptr_t)addr, length);
       }
 
       return Result;
@@ -82,17 +62,22 @@ namespace FEX::HLE::x32 {
 
     REGISTER_SYSCALL_IMPL_X32(mprotect, [](FEXCore::Core::CpuStateFrame *Frame, void *addr, uint32_t len, int prot) -> uint64_t {
       uint64_t Result = ::mprotect(addr, len, prot);
-
-      if (Result != -1 && prot & PROT_EXEC) {
-        auto CTX = Frame->Thread->CTX;
-        FEXCore::Context::InvalidateGuestCodeRange(CTX, (uintptr_t)addr, len);
+      if (Result != -1) {
+        FEX::HLE::_SyscallHandler->TrackMprotect((uintptr_t)addr, len, prot);
       }
+
       SYSCALL_ERRNO();
     });
 
     REGISTER_SYSCALL_IMPL_X32(mremap, [](FEXCore::Core::CpuStateFrame *Frame, void *old_address, size_t old_size, size_t new_size, int flags, void *new_address) -> uint64_t {
-      return reinterpret_cast<uint64_t>(static_cast<FEX::HLE::x32::x32SyscallHandler*>(FEX::HLE::_SyscallHandler)->GetAllocator()->
+      uint64_t Result = reinterpret_cast<uint64_t>(static_cast<FEX::HLE::x32::x32SyscallHandler*>(FEX::HLE::_SyscallHandler)->GetAllocator()->
         mremap(old_address, old_size, new_size, flags, new_address));
+
+      if (!FEX::HLE::HasSyscallError(Result)) {
+        FEX::HLE::_SyscallHandler->TrackMremap((uintptr_t)old_address, old_size, new_size, flags, Result);
+      }
+
+      return Result;
     });
 
     REGISTER_SYSCALL_IMPL_X32(mlockall, [](FEXCore::Core::CpuStateFrame *Frame, int flags) -> uint64_t {
@@ -109,7 +94,9 @@ namespace FEX::HLE::x32 {
       uint32_t ResultAddr{};
       uint64_t Result = static_cast<FEX::HLE::x32::x32SyscallHandler*>(FEX::HLE::_SyscallHandler)->GetAllocator()->
           shmat(shmid, reinterpret_cast<const void*>(shmaddr), shmflg, &ResultAddr);
-      if (Result == 0) {
+
+      if (!FEX::HLE::HasSyscallError(Result)) {
+        FEX::HLE::_SyscallHandler->TrackShmat(shmid, ResultAddr, shmflg);
         return ResultAddr;
       }
       else {
@@ -120,7 +107,12 @@ namespace FEX::HLE::x32 {
     REGISTER_SYSCALL_IMPL_X32(shmdt, [](FEXCore::Core::CpuStateFrame *Frame, const void *shmaddr) -> uint64_t {
       uint64_t Result = static_cast<FEX::HLE::x32::x32SyscallHandler*>(FEX::HLE::_SyscallHandler)->GetAllocator()->
         shmdt(shmaddr);
-      SYSCALL_ERRNO();
+      
+      if (!FEX::HLE::HasSyscallError(Result)) {
+        FEX::HLE::_SyscallHandler->TrackShmdt((uintptr_t)shmaddr);
+      }
+
+      return Result;
     });
   }
 


### PR DESCRIPTION
## Overview
Split off #1558, requires #1670.

Centralises handling of calls to the memory manager.

## Details
### Reworked tracking of memory mappings in `HLE::SyscallsHandler` (Linux syscall abi-neutral base)
- Added `FEX::HLE::SignalHandler::Track[Mmap/Munmap/...]()` (in the base class for both 32/64 handlers)

- Now all memory syscalls, both 32 and 64 bit, call `FEX::HLE::SignalHandler::Track[Mmap/Munmap/...]()` on success of these syscalls. This provides a cleaner and uniform api, and separates syscall implementations from VMA/Flushing logic.
