### PR TITLE
Syscalls/Linux: Add guest[Mmap/Munmap]

### DIFF
--- a/Source/Tests/ELFCodeLoader.h
+++ b/Source/Tests/ELFCodeLoader.h
@@ -280,7 +280,7 @@ public:
   }
 
   bool MapMemory(const MapperFn& Mapper, const UnmapperFn& Unmapper) override {
-    auto DoMMap = [Mapper](uint64_t Address, size_t Size, bool FixedNoReplace) -> void* {
+    auto DoMMap = [&Mapper](uint64_t Address, size_t Size, bool FixedNoReplace) -> void* {
       void *Result = Mapper(reinterpret_cast<void*>(Address), Size, PROT_READ | PROT_WRITE, (FixedNoReplace ? MAP_FIXED_NOREPLACE : MAP_FIXED) | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
       LOGMAN_THROW_A_FMT(Result != (void*)~0ULL, "Couldn't mmap");
       return Result;

--- a/Source/Tests/FEXLoader.cpp
+++ b/Source/Tests/FEXLoader.cpp
@@ -377,8 +377,8 @@ int main(int argc, char **argv, char **const envp) {
   auto SyscallHandler = Loader.Is64BitMode() ? FEX::HLE::x64::CreateHandler(CTX, SignalDelegation.get())
                                              : FEX::HLE::x32::CreateHandler(CTX, SignalDelegation.get(), std::move(Allocator));
 
-  auto Mapper = [&SyscallHandler](auto && ...args){ return SyscallHandler->GuestMmap(args...); };
-  auto Unmapper = [&SyscallHandler](auto && ...args){ return SyscallHandler->GuestMunmap(args...); };
+  auto Mapper = std::bind_front(&FEX::HLE::SyscallHandler::GuestMmap, SyscallHandler.get());
+  auto Unmapper = std::bind_front(&FEX::HLE::SyscallHandler::GuestMunmap, SyscallHandler.get());
 
   if (!Loader.MapMemory(Mapper, Unmapper)) {
     // failed to map

--- a/Source/Tests/HarnessHelpers.h
+++ b/Source/Tests/HarnessHelpers.h
@@ -390,8 +390,8 @@ namespace FEX::HarnessHelper {
 
     bool MapMemory(const MapperFn& Mapper, const UnmapperFn& Unmapper) override {
       bool LimitedSize = true;
-      auto DoMMap = [](uint64_t Address, size_t Size) -> void* {
-        void *Result = FEXCore::Allocator::mmap(reinterpret_cast<void*>(Address), Size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+      auto DoMMap = [&Mapper](uint64_t Address, size_t Size) -> void* {
+        void *Result = Mapper(reinterpret_cast<void*>(Address), Size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
         LOGMAN_THROW_A_FMT(Result == reinterpret_cast<void*>(Address), "Map Memory mmap failed");
         return Result;
       };

--- a/Source/Tests/HarnessHelpers.h
+++ b/Source/Tests/HarnessHelpers.h
@@ -391,7 +391,7 @@ namespace FEX::HarnessHelper {
     bool MapMemory(const MapperFn& Mapper, const UnmapperFn& Unmapper) override {
       bool LimitedSize = true;
       auto DoMMap = [&Mapper](uint64_t Address, size_t Size) -> void* {
-        void *Result = Mapper(reinterpret_cast<void*>(Address), Size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        void *Result = Mapper(reinterpret_cast<void*>(Address), Size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_FIXED | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
         LOGMAN_THROW_A_FMT(Result == reinterpret_cast<void*>(Address), "Map Memory mmap failed");
         return Result;
       };

--- a/Source/Tests/LinuxSyscalls/Syscalls.h
+++ b/Source/Tests/LinuxSyscalls/Syscalls.h
@@ -164,6 +164,12 @@ public:
 
   FEX::HLE::MemAllocator *Get32BitAllocator() { return Alloc32Handler.get(); }
 
+  // does a mmap as if done via a guest syscall
+  virtual void *GuestMmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset) = 0;
+
+  // does a guest munmap as if done via a guest syscall
+  virtual int GuestMunmap(void *addr, uint64_t length) = 0;
+
   void TrackMmap(uintptr_t Base, uintptr_t Size, int Prot, int Flags, int fd, off_t Offset);
   void TrackMunmap(uintptr_t Base, uintptr_t Size);
   void TrackMprotect(uintptr_t Base, uintptr_t Size, int Prot);

--- a/Source/Tests/LinuxSyscalls/x32/Syscalls.h
+++ b/Source/Tests/LinuxSyscalls/x32/Syscalls.h
@@ -34,6 +34,8 @@ public:
   x32SyscallHandler(FEXCore::Context::Context *ctx, FEX::HLE::SignalDelegator *_SignalDelegation, std::unique_ptr<MemAllocator> Allocator);
 
   FEX::HLE::MemAllocator *GetAllocator() { return AllocHandler.get(); }
+  void *GuestMmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset) override;
+  int GuestMunmap(void *addr, uint64_t length) override;
 
 private:
   void RegisterSyscallHandlers();

--- a/Source/Tests/LinuxSyscalls/x64/Syscalls.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Syscalls.cpp
@@ -74,13 +74,6 @@ namespace FEX::HLE::x64 {
       });
   }
 
-  class x64SyscallHandler final : public FEX::HLE::SyscallHandler {
-  public:
-    x64SyscallHandler(FEXCore::Context::Context *ctx, FEX::HLE::SignalDelegator *_SignalDelegation);
-
-  private:
-    void RegisterSyscallHandlers();
-  };
 
   x64SyscallHandler::x64SyscallHandler(FEXCore::Context::Context *ctx, FEX::HLE::SignalDelegator *_SignalDelegation)
     : SyscallHandler {ctx, _SignalDelegation} {

--- a/Source/Tests/LinuxSyscalls/x64/Syscalls.h
+++ b/Source/Tests/LinuxSyscalls/x64/Syscalls.h
@@ -28,6 +28,17 @@ struct InternalThreadState;
 namespace FEX::HLE::x64 {
 #include "SyscallsEnum.h"
 
+class x64SyscallHandler final : public FEX::HLE::SyscallHandler {
+  public:
+    x64SyscallHandler(FEXCore::Context::Context *ctx, FEX::HLE::SignalDelegator *_SignalDelegation);
+    
+    void *GuestMmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset) override;
+    int GuestMunmap(void *addr, uint64_t length) override;
+
+  private:
+    void RegisterSyscallHandlers();
+};
+
 std::unique_ptr<FEX::HLE::SyscallHandler> CreateHandler(FEXCore::Context::Context *ctx, FEX::HLE::SignalDelegator *_SignalDelegation);
 
 void RegisterSyscallInternal(int SyscallNumber,

--- a/Source/Tests/TestHarnessRunner.cpp
+++ b/Source/Tests/TestHarnessRunner.cpp
@@ -165,8 +165,8 @@ int main(int argc, char **argv, char **const envp) {
   auto SyscallHandler = Loader.Is64BitMode() ? FEX::HLE::x64::CreateHandler(CTX, SignalDelegation.get())
                                              : FEX::HLE::x32::CreateHandler(CTX, SignalDelegation.get(), std::move(Allocator));
 
-  auto Mapper = [&SyscallHandler](auto && ...args){ return SyscallHandler->GuestMmap(args...); };
-  auto Unmapper = [&SyscallHandler](auto && ...args){ return SyscallHandler->GuestMunmap(args...); };
+  auto Mapper = std::bind_front(&FEX::HLE::SyscallHandler::GuestMmap, SyscallHandler.get());
+  auto Unmapper = std::bind_front(&FEX::HLE::SyscallHandler::GuestMunmap, SyscallHandler.get());
 
   if (!Loader.MapMemory(Mapper, Unmapper)) {
     // failed to map


### PR DESCRIPTION
## Overview

Split from #1558, depends on #1671.

Introduces `FEXCore::HLE::SyscallHandler::GuestMmap` and `FEXCore::HLE::SyscallHandler::GuestMunmap` that do a guest-side mmap and munmap, as if it was done by the guest. Updated the rest of the code to use them.

Closes #1637.

## Details
- Added abstract api to `FEXCore::HLE::SyscallHandler`
- Implemented in `x64SyscallHandler` && `x32SyscallHandler`, in the corresponding Memory.cpp files.
- Modified `mmap`, and `munmap` syscall handlers to use the new handlers
- Modified `HandleBRK` to use the new handlers
- Modified the code loaders to use the new handlers