### PR TITLE
FEXLoader: Fix create_directories check for aotir .path file writting

### DIFF
--- a/Source/Tests/FEXLoader.cpp
+++ b/Source/Tests/FEXLoader.cpp
@@ -462,7 +462,8 @@ int main(int argc, char **argv, char **const envp) {
     FEXCore::Context::RunUntilExit(CTX);
   }
 
-  if (std::filesystem::create_directories(std::filesystem::path(FEXCore::Config::GetDataDirectory()) / "aotir", ec)) {
+  std::filesystem::create_directories(std::filesystem::path(FEXCore::Config::GetDataDirectory()) / "aotir", ec);
+  if (!ec) {
     FEXCore::Context::WriteFilesWithCode(CTX, [](const std::string& fileid, const std::string& filename) {
       auto filepath = std::filesystem::path(FEXCore::Config::GetDataDirectory()) / "aotir" / (fileid + ".path");
       int fd = open(filepath.c_str(), O_CREAT | O_EXCL | O_WRONLY, 0644);


### PR DESCRIPTION
Split from #1558.

Looks like this worked only when the directory was created, and not when it already existed.