### PR TITLE
Clean up and document ScopedSignalMask

### DIFF
--- a/FEXHeaderUtils/FEXHeaderUtils/ScopedSignalMask.h
+++ b/FEXHeaderUtils/FEXHeaderUtils/ScopedSignalMask.h
@@ -12,7 +12,15 @@
 
 namespace FHU {
   /**
-   * @brief A class that masks signals and locks a mutex until it goes out of scope. It is NOT SAFE to move across threads.
+   * @brief A drop-in replacement for std::lock_guard that masks POSIX signals while the mutex is locked
+   *
+   * Use this class to prevent reentrancy issues of C++ mutexes with certain signal handlers.
+   * Common examples of such issues are:
+   * - C++ mutexes not unlocking due to a signal handler longjmping out of a scope owning the mutex
+   * - The signal handler itself using a mutex that would be re-locked if the handler gets invoked
+   *   again before unlocking
+   *
+   * Ownership of this object may be moved, but it is NOT SAFE to move across threads.
    *
    * Constructor order:
    * 1) Mask signals
@@ -21,8 +29,6 @@ namespace FHU {
    * Destructor Order:
    * 1) Unlock Mutex
    * 2) Unmask signals
-   *
-   * Masking signals around mutex locks is needed for signal-reentrant safety
    */
   template<typename MutexType, void (MutexType::*lock_fn)(), void (MutexType::*unlock_fn)()>
   class ScopedSignalMaskWithMutexBase final {


### PR DESCRIPTION
Having three separate classes that essentially implement the same complex concept is cumbersome: It adds ambiguity to call-sites ("which of these should I use?") and wastes programmer time on looking for differences between the implementations. This isn't helped by us having to maintain the same docstring thrice, which hence hasn't seen as much love as the complexity of the concept deserves.

This change unifies the three separate classes we had before, allowing them to be documented more easily and clearly highlighting the difference of each specialization. For convenience at call-sites, the three names previously used are still available as specializations.
