### PR TITLE
JIT relocation handling support

### DIFF
--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -184,7 +184,9 @@ if (ENABLE_JIT_X86_64)
     Interface/Core/JIT/x86_64/MemoryOps.cpp
     Interface/Core/JIT/x86_64/MiscOps.cpp
     Interface/Core/JIT/x86_64/MoveOps.cpp
-    Interface/Core/JIT/x86_64/VectorOps.cpp)
+    Interface/Core/JIT/x86_64/VectorOps.cpp
+    Interface/Core/JIT/x86_64/x64Relocations.cpp
+    )
   list(APPEND DEFINES -DJIT_X86_64)
 endif()
 

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -98,6 +98,7 @@ namespace FEXCore::Context {
       FEX_CONFIG_OPT(LibraryJITNaming, LIBRARYJITNAMING);
       FEX_CONFIG_OPT(BlockJITNaming, BLOCKJITNAMING);
       FEX_CONFIG_OPT(ParanoidTSO, PARANOIDTSO);
+      FEX_CONFIG_OPT(CacheObjectCodeCompilation, CACHEOBJECTCODECOMPILATION);
     } Config;
 
     using IntCallbackReturn =  FEX_NAKED void(*)(FEXCore::Core::InternalThreadState *Thread, volatile void *Host_RSP);

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
@@ -1,5 +1,7 @@
 #include "Interface/Core/ArchHelpers/Arm64Emitter.h"
+#include "Interface/Core/Dispatcher/Dispatcher.h"
 #include "Interface/Context/Context.h"
+#include "Interface/HLE/Thunks/Thunks.h"
 
 #include <FEXCore/Core/CoreState.h>
 #include <FEXCore/Utils/LogManager.h>
@@ -16,7 +18,9 @@ namespace FEXCore::CPU {
 #define STATE x28
 
 // We want vixl to not allocate a default buffer. Jit and dispatcher will manually create one.
-Arm64Emitter::Arm64Emitter(FEXCore::Context::Context *ctx, size_t size) : vixl::aarch64::Assembler(size, vixl::aarch64::PositionDependentCode) {
+Arm64Emitter::Arm64Emitter(FEXCore::Context::Context *ctx, size_t size)
+  : vixl::aarch64::Assembler(size, vixl::aarch64::PositionDependentCode)
+  , EmitterCTX {ctx} {
   CPU.SetUp();
 
   auto Features = vixl::CPUFeatures::InferFromOS();
@@ -321,8 +325,126 @@ void Arm64Emitter::ResetStack() {
 void Arm64Emitter::Align16B() {
   uint64_t CurrentOffset = GetCursorAddress<uint64_t>();
   for (uint64_t i = (16 - (CurrentOffset & 0xF)); i != 0; i -= 4) {
-      nop();
+    nop();
   }
+}
+
+uint64_t Arm64Emitter::GetNamedSymbolLiteral(FEXCore::CPU::RelocNamedSymbolLiteral::NamedSymbol Op) {
+  switch (Op) {
+    case FEXCore::CPU::RelocNamedSymbolLiteral::NamedSymbol::SYMBOL_LITERAL_EXITFUNCTION_LINKER:
+      return Dispatcher->ExitFunctionLinkerAddress;
+    break;
+    default:
+      ERROR_AND_DIE_FMT("Unknown named symbol literal: {}", static_cast<uint32_t>(Op));
+    break;
+  }
+  return ~0ULL;
+}
+
+void Arm64Emitter::InsertNamedThunkRelocation(vixl::aarch64::Register Reg, const IR::SHA256Sum &Sum) {
+  Relocation MoveABI{};
+  MoveABI.NamedThunkMove.Header.Type = FEXCore::CPU::RelocationTypes::RELOC_NAMED_THUNK_MOVE;
+  // Offset is the offset from the entrypoint of the block
+  auto CurrentCursor = GetCursorAddress<uint64_t>();
+  MoveABI.NamedThunkMove.Offset = CurrentCursor - GuestEntry;
+  MoveABI.NamedThunkMove.Symbol = Sum;
+  MoveABI.NamedThunkMove.RegisterIndex = Reg.GetCode();
+
+  uint64_t Pointer = reinterpret_cast<uint64_t>(EmitterCTX->ThunkHandler->LookupThunk(Sum));
+
+  LoadConstant(Reg, Pointer, EmitterCTX->Config.CacheObjectCodeCompilation());
+  Relocations.emplace_back(MoveABI);
+}
+
+Arm64Emitter::NamedSymbolLiteralPair Arm64Emitter::InsertNamedSymbolLiteral(FEXCore::CPU::RelocNamedSymbolLiteral::NamedSymbol Op) {
+  uint64_t Pointer = GetNamedSymbolLiteral(Op);
+
+  Arm64Emitter::NamedSymbolLiteralPair Lit {
+    .Lit = Literal(Pointer),
+    .MoveABI = {
+      .NamedSymbolLiteral = {
+        .Header = {
+          .Type = FEXCore::CPU::RelocationTypes::RELOC_NAMED_SYMBOL_LITERAL,
+        },
+        .Symbol = Op,
+        .Offset = 0,
+      },
+    },
+  };
+  return Lit;
+}
+
+void Arm64Emitter::PlaceNamedSymbolLiteral(NamedSymbolLiteralPair &Lit) {
+  // Offset is the offset from the entrypoint of the block
+  auto CurrentCursor = GetCursorAddress<uint64_t>();
+  Lit.MoveABI.NamedSymbolLiteral.Offset = CurrentCursor - GuestEntry;
+
+  place(&Lit.Lit);
+  Relocations.emplace_back(Lit.MoveABI);
+}
+
+void Arm64Emitter::InsertGuestRIPMove(vixl::aarch64::Register Reg, uint64_t Constant) {
+  Relocation MoveABI{};
+  MoveABI.GuestRIPMove.Header.Type = FEXCore::CPU::RelocationTypes::RELOC_GUEST_RIP_MOVE;
+  // Offset is the offset from the entrypoint of the block
+  auto CurrentCursor = GetCursorAddress<uint64_t>();
+  MoveABI.GuestRIPMove.Offset = CurrentCursor - GuestEntry;
+  MoveABI.GuestRIPMove.GuestRIP = Constant;
+  MoveABI.GuestRIPMove.RegisterIndex = Reg.GetCode();
+
+  LoadConstant(Reg, Constant, EmitterCTX->Config.CacheObjectCodeCompilation());
+  Relocations.emplace_back(MoveABI);
+}
+
+bool Arm64Emitter::ApplyRelocations(uint64_t GuestEntry, uint64_t CodeEntry, uint64_t CursorEntry, size_t NumRelocations, const char* EntryRelocations) {
+  size_t DataIndex{};
+  for (size_t j = 0; j < NumRelocations; ++j) {
+    const FEXCore::CPU::Relocation *Reloc = reinterpret_cast<const FEXCore::CPU::Relocation *>(&EntryRelocations[DataIndex]);
+    LOGMAN_THROW_A_FMT((DataIndex % alignof(Relocation)) == 0, "Alignment of relocation wasn't adhered to");
+
+    switch (Reloc->Header.Type) {
+      case FEXCore::CPU::RelocationTypes::RELOC_NAMED_SYMBOL_LITERAL: {
+        uint64_t Pointer = GetNamedSymbolLiteral(Reloc->NamedSymbolLiteral.Symbol);
+        // Relocation occurs at the cursorEntry + offset relative to that cursor
+        GetBuffer()->SetCursorOffset(CursorEntry + Reloc->NamedSymbolLiteral.Offset);
+
+        // Generate a literal so we can place it
+        Literal<uint64_t> Lit(Pointer);
+        place(&Lit);
+
+        DataIndex += sizeof(Reloc->NamedSymbolLiteral);
+        break;
+      }
+      case FEXCore::CPU::RelocationTypes::RELOC_NAMED_THUNK_MOVE: {
+        uint64_t Pointer = reinterpret_cast<uint64_t>(EmitterCTX->ThunkHandler->LookupThunk(Reloc->NamedThunkMove.Symbol));
+        if (Pointer == ~0ULL) {
+          return false;
+        }
+
+        // Relocation occurs at the cursorEntry + offset relative to that cursor.
+        GetBuffer()->SetCursorOffset(CursorEntry + Reloc->NamedThunkMove.Offset);
+        LoadConstant(vixl::aarch64::XRegister(Reloc->NamedThunkMove.RegisterIndex), Pointer, true);
+        DataIndex += sizeof(Reloc->NamedThunkMove);
+        break;
+      }
+      case FEXCore::CPU::RelocationTypes::RELOC_GUEST_RIP_MOVE: {
+        // XXX: Reenable once the JIT Object Cache is upstream
+        // XXX: Should spin the relocation list, create a list of guest RIP moves, and ask for them all once, reduces lock contention.
+        uint64_t Pointer = ~0ULL; // EmitterCTX->JITObjectCache->FindRelocatedRIP(Reloc->GuestRIPMove.GuestRIP);
+        if (Pointer == ~0ULL) {
+          return false;
+        }
+
+        // Relocation occurs at the cursorEntry + offset relative to that cursor.
+        GetBuffer()->SetCursorOffset(CursorEntry + Reloc->GuestRIPMove.Offset);
+        LoadConstant(vixl::aarch64::XRegister(Reloc->GuestRIPMove.RegisterIndex), Pointer, true);
+        DataIndex += sizeof(Reloc->GuestRIPMove);
+        break;
+      }
+    }
+  }
+
+  return true;
 }
 
 }

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include "Interface/Core/Dispatcher/Dispatcher.h"
+#include "Interface/Core/ObjectCache/Relocations.h"
+
 #include "aarch64/assembler-aarch64.h"
 #include "aarch64/constants-aarch64.h"
 #include "aarch64/cpu-aarch64.h"
@@ -60,6 +63,9 @@ class Arm64Emitter : public vixl::aarch64::Assembler {
 protected:
   Arm64Emitter(FEXCore::Context::Context *ctx, size_t size);
 
+  std::unique_ptr<FEXCore::CPU::Dispatcher> Dispatcher;
+
+  FEXCore::Context::Context *EmitterCTX;
   vixl::aarch64::CPU CPU;
   void LoadConstant(vixl::aarch64::Register Reg, uint64_t Constant, bool NOPPad = false);
   void SpillStaticRegs(bool FPRs = true, uint32_t GPRSpillMask = ~0U, uint32_t FPRSpillMask = ~0U);
@@ -79,8 +85,66 @@ protected:
 
   void ResetStack();
   void Align16B();
+  /**
+   * @name Relocations
+   * @{ */
+
+    uint64_t GetNamedSymbolLiteral(FEXCore::CPU::RelocNamedSymbolLiteral::NamedSymbol Op);
+
+    /**
+     * @brief A literal pair relocation object for named symbol literals
+     */
+    struct NamedSymbolLiteralPair {
+      Literal<uint64_t> Lit;
+      Relocation MoveABI{};
+    };
+
+    /**
+     * @brief Inserts a thunk relocation
+     *
+     * @param Reg - The GPR to move the thunk handler in to
+     * @param Sum - The hash of the thunk
+     */
+    void InsertNamedThunkRelocation(vixl::aarch64::Register Reg, const IR::SHA256Sum &Sum);
+
+    /**
+     * @brief Inserts a guest GPR move relocation
+     *
+     * @param Reg - The GPR to move the guest RIP in to
+     * @param Constant - The guest RIP that will be relocated
+     */
+    void InsertGuestRIPMove(vixl::aarch64::Register Reg, uint64_t Constant);
+
+    /**
+     * @brief Inserts a named symbol as a literal in memory
+     *
+     * Need to use `PlaceNamedSymbolLiteral` with the return value to place the literal in the desired location
+     *
+     * @param Op The named symbol to place
+     *
+     * @return A temporary `NamedSymbolLiteralPair`
+     */
+    NamedSymbolLiteralPair InsertNamedSymbolLiteral(FEXCore::CPU::RelocNamedSymbolLiteral::NamedSymbol Op);
+
+    /**
+     * @brief Place the named symbol literal relocation in memory
+     *
+     * @param Lit - Which literal to place
+     */
+    void PlaceNamedSymbolLiteral(NamedSymbolLiteralPair &Lit);
+
+    std::vector<FEXCore::CPU::Relocation> Relocations;
+
+    ///< Relocation code loading
+    bool ApplyRelocations(uint64_t GuestEntry, uint64_t CodeEntry, uint64_t CursorEntry, size_t NumRelocations, const char* EntryRelocations);
+
+  /**  @} */
 
   uint32_t SpillSlots{};
+  /**
+  * @brief Current guest RIP entrypoint
+  */
+  uint64_t GuestEntry{};
 
   FEX_CONFIG_OPT(StaticRegisterAllocation, SRA);
 };

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
@@ -39,7 +39,7 @@ static constexpr size_t MAX_DISPATCHER_CODE_SIZE = 4096;
 #define STATE x28
 
 Arm64Dispatcher::Arm64Dispatcher(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread, DispatcherConfig &config)
-  : Dispatcher(ctx, Thread), Arm64Emitter(ctx, MAX_DISPATCHER_CODE_SIZE) {
+  : FEXCore::CPU::Dispatcher(ctx, Thread), Arm64Emitter(ctx, MAX_DISPATCHER_CODE_SIZE) {
   SRAEnabled = config.StaticRegisterAssignment;
   SetAllowAssembler(true);
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -739,9 +739,9 @@ void *Arm64JITCore::CompileCode(uint64_t Entry, [[maybe_unused]] FEXCore::IR::IR
   // X1-X3 = Temp
   // X4-r18 = RA
 
-  auto GuestEntry = GetCursorAddress<uint64_t>();
+  GuestEntry = GetCursorAddress<uint64_t>();
 
- if (CTX->GetGdbServerStatus()) {
+  if (CTX->GetGdbServerStatus()) {
     aarch64::Label RunBlock;
 
     // If we have a gdb server running then run in a less efficient mode that checks if we need to exit
@@ -831,6 +831,7 @@ void *Arm64JITCore::CompileCode(uint64_t Entry, [[maybe_unused]] FEXCore::IR::IR
   if (DebugData) {
     DebugData->HostCodeSize = reinterpret_cast<uintptr_t>(CodeEnd) - reinterpret_cast<uintptr_t>(GuestEntry);
   }
+  Relocations.clear();
 
   this->IR = nullptr;
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -649,6 +649,7 @@ void *X86JITCore::CompileCode(uint64_t Entry, [[maybe_unused]] FEXCore::IR::IRLi
   }
 
 	void *GuestEntry = getCurr<void*>();
+  CursorEntry = getSize();
   this->IR = IR;
 
   if (CTX->GetGdbServerStatus()) {
@@ -802,6 +803,8 @@ void *X86JITCore::CompileCode(uint64_t Entry, [[maybe_unused]] FEXCore::IR::IRLi
   if (DebugData) {
     DebugData->HostCodeSize = reinterpret_cast<uintptr_t>(GuestExit) - reinterpret_cast<uintptr_t>(GuestEntry);
   }
+  Relocations.clear();
+
   return GuestEntry;
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/x64Relocations.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/x64Relocations.cpp
@@ -1,0 +1,138 @@
+/*
+$info$
+tags: backend|x86-64
+desc: relocation logic of the x86-64 splatter backend
+$end_info$
+*/
+#include "Interface/Core/JIT/x86_64/JITClass.h"
+#include "Interface/HLE/Thunks/Thunks.h"
+
+namespace FEXCore::CPU {
+uint64_t X86JITCore::GetNamedSymbolLiteral(FEXCore::CPU::RelocNamedSymbolLiteral::NamedSymbol Op) {
+  switch (Op) {
+    case FEXCore::CPU::RelocNamedSymbolLiteral::NamedSymbol::SYMBOL_LITERAL_EXITFUNCTION_LINKER:
+      return Dispatcher->ExitFunctionLinkerAddress;
+    break;
+    default:
+      ERROR_AND_DIE_FMT("Unknown named symbol literal: {}", static_cast<uint32_t>(Op));
+    break;
+  }
+  return ~0ULL;
+
+}
+
+void X86JITCore::LoadConstantWithPadding(Xbyak::Reg Reg, uint64_t Constant) {
+  // The maximum size a move constant can be in bytes
+  // Need to NOP pad to this size to ensure backpatching is always the same size
+  // Calculated as:
+  // [Rex]
+  // [Mov op]
+  // [8 byte constant]
+  //
+  // All other move types are smaller than this. xbyak will use a NOP slide which is quite quick
+  constexpr static size_t MAX_MOVE_SIZE = 10;
+  auto StartingOffset = getSize();
+  mov(Reg, Constant);
+  auto MoveSize = getSize() - StartingOffset;
+  auto NOPPadSize = MAX_MOVE_SIZE - MoveSize;
+  nop(NOPPadSize);
+}
+
+X86JITCore::NamedSymbolLiteralPair X86JITCore::InsertNamedSymbolLiteral(FEXCore::CPU::RelocNamedSymbolLiteral::NamedSymbol Op) {
+  NamedSymbolLiteralPair Lit {
+    .MoveABI = {
+      .NamedSymbolLiteral = {
+        .Header = {
+          .Type = FEXCore::CPU::RelocationTypes::RELOC_NAMED_SYMBOL_LITERAL,
+        },
+        .Symbol = Op,
+        .Offset = 0,
+      },
+    },
+  };
+  return Lit;
+}
+
+void X86JITCore::PlaceNamedSymbolLiteral(NamedSymbolLiteralPair &Lit) {
+  // Offset is the offset from the entrypoint of the block
+  auto CurrentCursor = getSize();
+  Lit.MoveABI.NamedSymbolLiteral.Offset = CurrentCursor - CursorEntry;
+
+  uint64_t Pointer = GetNamedSymbolLiteral(Lit.MoveABI.NamedSymbolLiteral.Symbol);
+
+  L(Lit.Offset);
+  dq(Pointer);
+  Relocations.emplace_back(Lit.MoveABI);
+}
+
+
+void X86JITCore::InsertGuestRIPMove(Xbyak::Reg Reg, uint64_t Constant) {
+  Relocation MoveABI{};
+  MoveABI.GuestRIPMove.Header.Type = FEXCore::CPU::RelocationTypes::RELOC_GUEST_RIP_MOVE;
+
+  // Offset is the offset from the entrypoint of the block
+  auto CurrentCursor = getSize();
+  MoveABI.GuestRIPMove.Offset = CurrentCursor - CursorEntry;
+  MoveABI.GuestRIPMove.GuestRIP = Constant;
+  MoveABI.GuestRIPMove.RegisterIndex = Reg.getIdx();
+
+  if (CTX->Config.CacheObjectCodeCompilation()) {
+    LoadConstantWithPadding(Reg, Constant);
+  }
+  else {
+    mov(Reg, Constant);
+  }
+
+  Relocations.emplace_back(MoveABI);
+}
+
+bool X86JITCore::ApplyRelocations(uint64_t GuestEntry, uint64_t CodeEntry, uint64_t CursorEntry, size_t NumRelocations, const char* EntryRelocations) {
+  size_t DataIndex{};
+  for (size_t j = 0; j < NumRelocations; ++j) {
+    const FEXCore::CPU::Relocation *Reloc = reinterpret_cast<const FEXCore::CPU::Relocation *>(&EntryRelocations[DataIndex]);
+    LOGMAN_THROW_A_FMT((DataIndex % alignof(Relocation)) == 0, "Alignment of relocation wasn't adhered to");
+
+    switch (Reloc->Header.Type) {
+      case FEXCore::CPU::RelocationTypes::RELOC_NAMED_SYMBOL_LITERAL: {
+        uint64_t Pointer = GetNamedSymbolLiteral(Reloc->NamedSymbolLiteral.Symbol);
+        // Relocation occurs at the cursorEntry + offset relative to that cursor.
+        setSize(CursorEntry + Reloc->NamedSymbolLiteral.Offset);
+
+        // Place the pointer
+        dq(Pointer);
+
+        DataIndex += sizeof(Reloc->NamedSymbolLiteral);
+        break;
+      }
+      case FEXCore::CPU::RelocationTypes::RELOC_NAMED_THUNK_MOVE: {
+        uint64_t Pointer = reinterpret_cast<uint64_t>(CTX->ThunkHandler->LookupThunk(Reloc->NamedThunkMove.Symbol));
+        if (Pointer == ~0ULL) {
+          return false;
+        }
+
+        // Relocation occurs at the cursorEntry + offset relative to that cursor.
+        setSize(CursorEntry + Reloc->NamedThunkMove.Offset);
+        LoadConstantWithPadding(Xbyak::Reg64(Reloc->NamedThunkMove.RegisterIndex), Pointer);
+        DataIndex += sizeof(Reloc->NamedThunkMove);
+        break;
+      }
+      case FEXCore::CPU::RelocationTypes::RELOC_GUEST_RIP_MOVE:
+        // XXX: Reenable once the JIT Object Cache is upstream
+        // XXX: Should spin the relocation list, create a list of guest RIP moves, and ask for them all once, reduces lock contention.
+        uint64_t Pointer = ~0ULL; // EmitterCTX->JITObjectCache->FindRelocatedRIP(Reloc->GuestRIPMove.GuestRIP);
+        if (Pointer == ~0ULL) {
+          return false;
+        }
+
+        // Relocation occurs at the cursorEntry + offset relative to that cursor.
+        setSize(CursorEntry + Reloc->GuestRIPMove.Offset);
+        LoadConstantWithPadding(Xbyak::Reg64(Reloc->GuestRIPMove.RegisterIndex), Pointer);
+        DataIndex += sizeof(Reloc->GuestRIPMove);
+        break;
+    }
+  }
+
+  return true;
+}
+}
+


### PR DESCRIPTION
The JITs currently don't use this. This is just the handling code
itself.

One line disabled in each JIT handling Guest RIP move relocations until the JIT
Object cache is enabled.