### PR TITLE
Core: Adds Code Object Cache service 

### DIFF
--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -85,6 +85,8 @@ set (SRCS
   Interface/Core/Frontend.cpp
   Interface/Core/GdbServer.cpp
   Interface/Core/HostFeatures.cpp
+  Interface/Core/ObjectCache/JobHandling.cpp
+  Interface/Core/ObjectCache/ObjectCacheService.cpp
   Interface/Core/OpcodeDispatcher/Crypto.cpp
   Interface/Core/OpcodeDispatcher/Flags.cpp
   Interface/Core/OpcodeDispatcher/Vector.cpp

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -4,6 +4,7 @@
 #include "Interface/Core/CPUID.h"
 #include "Interface/Core/HostFeatures.h"
 #include "Interface/Core/X86HelperGen.h"
+#include "Interface/Core/ObjectCache/ObjectCacheService.h"
 #include "Interface/IR/AOTIR.h"
 #include <FEXCore/Config/Config.h>
 #include <FEXCore/Core/Context.h>
@@ -33,6 +34,10 @@ namespace FEXCore {
 class CodeLoader;
 class ThunkHandler;
 class GdbServer;
+
+namespace CodeSerialize {
+  class CodeObjectSerializeService;
+}
 
 namespace CPU {
   class Arm64JITCore;
@@ -326,6 +331,7 @@ namespace FEXCore::Context {
     std::unique_ptr<GdbServer> DebugServer;
 
     IR::AOTIRCaptureCache IRCaptureCache;
+    std::unique_ptr<FEXCore::CodeSerialize::CodeObjectSerializeService> CodeObjectCacheService;
 
     bool StartPaused = false;
     FEX_CONFIG_OPT(AppFilename, APP_FILENAME);

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -1017,6 +1017,9 @@ namespace FEXCore::Context {
       ));
     }
 
+    // Clear any relocations that might have been generated
+    Thread->CPUBackend->ClearRelocations();
+
     if (IRCaptureCache.PostCompileCode(
         Thread,
         CodePtr,

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -830,6 +830,7 @@ void *Arm64JITCore::CompileCode(uint64_t Entry, [[maybe_unused]] FEXCore::IR::IR
 
   if (DebugData) {
     DebugData->HostCodeSize = reinterpret_cast<uintptr_t>(CodeEnd) - reinterpret_cast<uintptr_t>(GuestEntry);
+    DebugData->Relocations = &Relocations;
   }
   Relocations.clear();
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -832,7 +832,6 @@ void *Arm64JITCore::CompileCode(uint64_t Entry, [[maybe_unused]] FEXCore::IR::IR
     DebugData->HostCodeSize = reinterpret_cast<uintptr_t>(CodeEnd) - reinterpret_cast<uintptr_t>(GuestEntry);
     DebugData->Relocations = &Relocations;
   }
-  Relocations.clear();
 
   this->IR = nullptr;
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -68,6 +68,8 @@ public:
 
   static void InitializeSignalHandlers(FEXCore::Context::Context *CTX);
 
+  void ClearRelocations() override { Relocations.clear(); }
+
 private:
   FEX_CONFIG_OPT(ParanoidTSO, PARANOIDTSO);
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -804,7 +804,6 @@ void *X86JITCore::CompileCode(uint64_t Entry, [[maybe_unused]] FEXCore::IR::IRLi
     DebugData->HostCodeSize = reinterpret_cast<uintptr_t>(GuestExit) - reinterpret_cast<uintptr_t>(GuestEntry);
     DebugData->Relocations = &Relocations;
   }
-  Relocations.clear();
 
   return GuestEntry;
 }

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -802,6 +802,7 @@ void *X86JITCore::CompileCode(uint64_t Entry, [[maybe_unused]] FEXCore::IR::IRLi
 
   if (DebugData) {
     DebugData->HostCodeSize = reinterpret_cast<uintptr_t>(GuestExit) - reinterpret_cast<uintptr_t>(GuestEntry);
+    DebugData->Relocations = &Relocations;
   }
   Relocations.clear();
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -84,6 +84,8 @@ public:
 
   static void InitializeSignalHandlers(FEXCore::Context::Context *CTX);
 
+  void ClearRelocations() override { Relocations.clear(); }
+
 private:
 
   /**

--- a/External/FEXCore/Source/Interface/Core/ObjectCache/JobHandling.cpp
+++ b/External/FEXCore/Source/Interface/Core/ObjectCache/JobHandling.cpp
@@ -1,0 +1,26 @@
+#include "Interface/Context/Context.h"
+#include "Interface/Core/ObjectCache/ObjectCacheService.h"
+
+#include <FEXCore/Config/Config.h>
+
+#include <fcntl.h>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <sys/uio.h>
+#include <sys/mman.h>
+#include <xxhash.h>
+
+namespace FEXCore::CodeSerialize {
+  void AsyncJobHandler::AsyncAddNamedRegionJob(uintptr_t Base, uintptr_t Size, uintptr_t Offset, const std::string &filename) {
+    // XXX: Actually add the add named region job
+  }
+
+  void AsyncJobHandler::AsyncRemoveNamedRegionJob(uintptr_t Base, uintptr_t Size) {
+    // XXX: Actually add the remove named region job
+  }
+
+  void AsyncJobHandler::AsyncAddSerializationJob(std::unique_ptr<SerializationJobData> Data) {
+    // XXX: Actually add serialization job
+  }
+}

--- a/External/FEXCore/Source/Interface/Core/ObjectCache/ObjectCacheService.cpp
+++ b/External/FEXCore/Source/Interface/Core/ObjectCache/ObjectCacheService.cpp
@@ -1,0 +1,82 @@
+#include "Interface/Core/ObjectCache/ObjectCacheService.h"
+
+#include <FEXCore/Config/Config.h>
+
+#include <memory>
+
+namespace {
+  static void* ThreadHandler(void *Arg) {
+    FEXCore::CodeSerialize::CodeObjectSerializeService *This = reinterpret_cast<FEXCore::CodeSerialize::CodeObjectSerializeService*>(Arg);
+    This->ExecutionThread();
+    return nullptr;
+  }
+}
+
+namespace FEXCore::CodeSerialize {
+  CodeObjectSerializeService::CodeObjectSerializeService(FEXCore::Context::Context *ctx)
+    : CTX {ctx} {
+    Initialize();
+  }
+
+  void CodeObjectSerializeService::Shutdown() {
+    if (CTX->Config.CacheObjectCodeCompilation() == FEXCore::Config::ConfigObjectCodeHandler::CONFIG_NONE) {
+      return;
+    }
+
+    WorkerThreadShuttingDown = true;
+
+    // Kick the working thread
+    WorkAvailable.NotifyAll();
+
+    if (WorkerThread->joinable()) {
+      // Wait for worker thread to close down
+      WorkerThread->join(nullptr);
+    }
+  }
+
+  void CodeObjectSerializeService::Initialize() {
+    // Add a canary so we don't crash on empty map iterator handling
+    auto it = AddressToEntryMap.insert_or_assign(~0ULL, std::make_unique<CodeRegionEntry>());
+		UnrelocatedAddressToEntryMap.insert_or_assign(~0ULL, it.first->second.get());
+
+		uint64_t OldMask = FEXCore::Threads::SetSignalMask(~0ULL);
+		WorkerThread = FEXCore::Threads::Thread::Create(ThreadHandler, this);
+    FEXCore::Threads::SetSignalMask(OldMask);
+	}
+
+  void CodeObjectSerializeService::DoCodeRegionClosure(uint64_t Base, CodeRegionEntry *it) {
+    if (Base == ~0ULL) {
+      // Don't do closure on canary
+      return;
+    }
+    // XXX: Do code region closure
+  }
+
+  CodeObjectFileSection const *CodeObjectSerializeService::FetchCodeObjectFromCache(uint64_t GuestRIP) {
+    // XXX: Actually fetch code objects from cache
+    return nullptr;
+  }
+
+  void CodeObjectSerializeService::ExecutionThread() {
+    // Set our thread name so we can see its relation
+    char ThreadName[16] = "ObjectCodeSeri\0";
+    pthread_setname_np(pthread_self(), ThreadName);
+    while (WorkerThreadShuttingDown.load() != true) {
+      // Wait for work
+      WorkAvailable.Wait();
+
+      // XXX: Handle named region async jobs first. Highest priority
+
+      // XXX: Handle code serialization jobs second.
+    }
+
+    // Do final code region closures on thread shutdown
+    for (auto &it : AddressToEntryMap) {
+      DoCodeRegionClosure(it.first, it.second.get());
+    }
+
+    // Safely clear our maps now
+    AddressToEntryMap.clear();
+    UnrelocatedAddressToEntryMap.clear();
+	}
+}

--- a/External/FEXCore/Source/Interface/Core/ObjectCache/ObjectCacheService.h
+++ b/External/FEXCore/Source/Interface/Core/ObjectCache/ObjectCacheService.h
@@ -1,0 +1,250 @@
+#pragma once
+#include "Interface/Context/Context.h"
+#include "Interface/Core/ObjectCache/Relocations.h"
+
+#include <FEXCore/Utils/Event.h>
+#include <FEXCore/Utils/Threads.h>
+
+#include <map>
+#include <memory>
+#include <shared_mutex>
+#include <string>
+#include <vector>
+
+namespace FEXCore::CodeSerialize {
+  struct CodeRegionEntry {
+    // XXX: File out code region entry
+  };
+
+  struct CodeSerializationData {
+  };
+
+  struct CodeObjectFileSection {
+    bool Serialized;
+    bool Invalid;
+    const CodeSerializationData *Data;
+    const char *HostCode;
+    uint64_t NumRelocations;
+    const char *Relocations;
+  };
+
+  // Map type must use an interator that isn't invalidation on erase/insert
+  using CodeRegionMapType = std::map<uint64_t, std::unique_ptr<CodeRegionEntry>>;
+  using CodeRegionPtrMapType = std::map<uint64_t, CodeRegionEntry*>;
+
+  // XXX: Does this need to be signal safe?
+  using CodeSerializationMutex = std::shared_mutex;
+
+  class AsyncJobHandler final {
+    public:
+      /**
+       * @brief Structure containing all the data required to async serialize code objects
+       */
+      struct SerializationJobData {
+        uint64_t GuestRIP;        ///< The RIP for the guest
+        // XXX: Support multiblock
+        uint64_t GuestCodeLength; ///< The Guest's code length
+        uint64_t GuestCodeHash;   ///< Hash of the guest code
+
+        void *HostCodeBegin;      ///< Host JIT code starting memory address
+        size_t HostCodeLength;    ///< Host JIT code length
+        uint64_t HostCodeHash;    ///< Host JIT code hash before any backpatching
+
+        // This is the thread specific ref counter for outstanding jobs.
+        // This shared mutex is incremented when the job is added, then decremented when the job is complete.
+        // If a thread is shutting down or clearing code cache then the thread will pull a unique lock on this mutex.
+        // This way it will wait until the async job handler is complete with it.
+        CodeSerializationMutex *ThreadJobRefCount;
+
+        // These are the reolocations for this serialization job
+        // Relatively small number of entries most of the time
+        std::vector<FEXCore::CPU::Relocation> Relocations;
+
+        /**
+         * @name Objects filled in from the Code Object Serialization service when a job is added
+         * @{ */
+          // This is the code region's ref counter for outstanding jobs.
+          // This shared mutex is incremented when the job is added, then decremented when the job is complete.
+          // If a named region is being removed then a unique lock will be pulled to wait for all jobs to complete and no new jobs to be added.
+          CodeSerializationMutex *ObjectJobRefCountMutexPtr;
+
+          // This is the code region iterator to reduce the number of map lookups
+          // This will remain valid while jobs are outstanding for this region
+          CodeRegionMapType::iterator CodeRegionIterator;
+        /**  @} */
+      };
+
+    protected:
+      friend class CodeObjectSerializeService;
+      /**
+       * @name Async job submission functions
+       * @{ */
+        void AsyncAddNamedRegionJob(uintptr_t Base, uintptr_t Size, uintptr_t Offset, const std::string &filename);
+        void AsyncRemoveNamedRegionJob(uintptr_t Base, uintptr_t Size);
+        void AsyncAddSerializationJob(std::unique_ptr<SerializationJobData> Data);
+      /**  @} */
+
+    private:
+      /**
+       * @name Async named region handling
+       * @{ */
+        /**
+         * @brief The async named region jobs to handle.
+         *
+         * Only two, Code serialization goes in to a different queue.
+         */
+        enum class NamedRegionJobType {
+          JOB_ADD_NAMED_REGION,
+          JOB_REMOVE_NAMED_REGION,
+        };
+
+        class NamedRegionWorkItem {
+          public:
+          NamedRegionJobType GetType() const { return Type; }
+
+          protected:
+            friend class WorkItemAddNamedRegion;
+            NamedRegionWorkItem(NamedRegionJobType type)
+              : Type {type} {}
+
+          private:
+            NamedRegionJobType Type;
+        };
+
+        class WorkItemAddNamedRegion : public NamedRegionWorkItem {
+          public:
+            WorkItemAddNamedRegion(const std::string &base, const std::string &filename, bool executable, CodeRegionMapType::iterator entry)
+              : NamedRegionWorkItem {NamedRegionJobType::JOB_ADD_NAMED_REGION}
+              , BaseFilename {base}
+              , Filename {filename}
+              , Executable {executable}
+              , Entry {entry}
+              {}
+            const std::string BaseFilename;
+            const std::string Filename;
+            bool Executable;
+            CodeRegionMapType::iterator Entry;
+        };
+
+        class WorkItemRemoveNamedRegion : public NamedRegionWorkItem {
+          public:
+            WorkItemRemoveNamedRegion(uint64_t base, uint64_t size, CodeRegionMapType::iterator entry)
+              : NamedRegionWorkItem {NamedRegionJobType::JOB_REMOVE_NAMED_REGION}
+              , Base {base}
+              , Size {size}
+              , Entry {entry} {}
+
+            uint64_t Base;
+            uint64_t Size;
+            CodeRegionMapType::iterator Entry;
+        };
+      /**  @} */
+  };
+
+  /**
+   * @brief Context specific code object serialization class
+   *
+   * Contains everything required for FEXCore to serialize code objects
+   */
+  class CodeObjectSerializeService final {
+    public:
+      CodeObjectSerializeService(FEXCore::Context::Context *ctx);
+
+      /**
+       * @brief Initialize the internal interface
+       *
+       * Is a public interface to allow the service to reinitialize after forking
+       */
+      void Initialize();
+
+      /**
+       * @brief Safely shut down the Code Object serialization service.
+       *
+       * This service needs to be resiliant to application crashes, but shutting down safely is still preferred.
+       */
+      void Shutdown();
+
+      /**
+       * @name Async interface
+       * @{ */
+        /**
+         * @brief Loads a named region in to the code serialization service. As async as possible.
+         *
+         * @param Base - Virtual address that this named region is loaded
+         * @param Size - The size of the region
+         * @param Offset - The offset from the file
+         * @param filename - The filename itself
+         */
+        void AsyncAddNamedRegionJob(uintptr_t Base, uintptr_t Size, uintptr_t Offset, const std::string &filename) {
+          AsyncHandler.AsyncAddNamedRegionJob(Base, Size, Offset, filename);
+        }
+
+        /**
+         * @brief Unloads a named region from the code serialization service. As async as possible.
+         *
+         * @param Base - Virtual address of the named region
+         * @param Size - The size of the region
+         */
+        void AsyncRemoveNamedRegionJob(uintptr_t Base, uintptr_t Size) {
+          AsyncHandler.AsyncRemoveNamedRegionJob(Base, Size);
+        }
+
+        /**
+         * @brief Adds a code object serialization job. As async as possible.
+         * Code hashing happens prior to async job serialization to catch invalidations due to backpatching.
+         *
+         * @param Data - A fully filled out struct containing all the code serialization
+         */
+        void AsyncAddSerializationJob(std::unique_ptr<AsyncJobHandler::SerializationJobData> Data) {
+          AsyncHandler.AsyncAddSerializationJob(std::move(Data));
+        }
+      /**  @} */
+
+      /**
+       * @name Synchronous interface
+       * @{ */
+        /**
+         * @brief Synchronously waits for this thread's job queue to become empty.
+         *
+         * This is necessary for when a thread is shutting down
+         *
+         * @param ThreadJobRefCount - The shared mutex to wait on until to be empty
+         */
+        static void WaitForEmptyJobQueue(CodeSerializationMutex *ThreadJobRefCount) {
+          // Once the shared mutex is empty this unique lock will be gained
+          std::unique_lock lk {*ThreadJobRefCount};
+        }
+
+        /**
+         * @brief Fetches object code from the Code Object Cache for JIT.
+         *
+         * @param GuestRIP - Which GuestRIP to search the cache for
+         *
+         * @return Data required for the JIT to relocate the Object code.
+         */
+        CodeObjectFileSection const *FetchCodeObjectFromCache(uint64_t GuestRIP);
+      /**  @} */
+
+      // Public for threading
+      void ExecutionThread();
+
+    protected:
+      /**
+       * @brief Safely closes out code object regions from the map
+       *
+       * @param it - iterator to do a closure on
+       */
+      void DoCodeRegionClosure(uint64_t Base, CodeRegionEntry *it);
+
+    private:
+      FEXCore::Context::Context *CTX;
+
+      Event WorkAvailable{};
+      std::unique_ptr<FEXCore::Threads::Thread> WorkerThread;
+      std::atomic_bool WorkerThreadShuttingDown {false};
+      AsyncJobHandler AsyncHandler{};
+
+      CodeRegionMapType AddressToEntryMap;
+      CodeRegionPtrMapType UnrelocatedAddressToEntryMap;
+  };
+}

--- a/External/FEXCore/include/FEXCore/Core/CPUBackend.h
+++ b/External/FEXCore/include/FEXCore/Core/CPUBackend.h
@@ -25,6 +25,10 @@ namespace Core {
   struct CpuStateFrame;
 }
 
+namespace CodeSerialize {
+  struct CodeObjectFileSection;
+}
+
 namespace CPU {
 class InterpreterCore;
 class JITCore;
@@ -58,6 +62,16 @@ class LLVMCore;
                                             FEXCore::IR::IRListView const *IR,
                                             FEXCore::Core::DebugData *DebugData,
                                             FEXCore::IR::RegisterAllocationData *RAData) = 0;
+
+    /**
+     * @brief Relocates a block of code from the JIT code object cache
+     *
+     * @param Entry - RIP of the entry
+     * @param SerializationData - Serialization data referring to the object cache for `Entry`
+     *
+     * @return An executable function pointer relocated from the cache object
+     */
+    [[nodiscard]] virtual void *RelocateJITObjectCode(uint64_t Entry, CodeSerialize::CodeObjectFileSection const *SerializationData) { return nullptr; }
 
     /**
      * @brief Function for mapping memory in to the CPUBackend's visible space. Allows setting up virtual mappings if required

--- a/External/FEXCore/include/FEXCore/Core/CPUBackend.h
+++ b/External/FEXCore/include/FEXCore/Core/CPUBackend.h
@@ -112,6 +112,11 @@ class LLVMCore;
      */
     virtual bool NeedsRetainedIRCopy() const { return false; }
 
+    /**
+     * @brief Clear any relocations after JIT compiling
+     */
+    virtual void ClearRelocations() {}
+
     using AsmDispatch = FEX_NAKED void(*)(FEXCore::Core::CpuStateFrame *Frame);
     using JITCallback = FEX_NAKED void(*)(FEXCore::Core::CpuStateFrame *Frame, uint64_t RIP);
 

--- a/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
+++ b/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
@@ -9,6 +9,7 @@
 #include <FEXCore/Utils/Threads.h>
 
 #include <unordered_map>
+#include <shared_mutex>
 
 namespace FEXCore {
   class LookupCache;
@@ -103,7 +104,8 @@ namespace FEXCore::Core {
     int StatusCode{};
     FEXCore::Context::ExitReason ExitReason {FEXCore::Context::ExitReason::EXIT_WAITING};
     std::shared_ptr<FEXCore::CompileService> CompileService;
-    bool IsCompileService{false};
+
+    std::shared_mutex ObjectCacheRefCounter{};
     bool DestroyedByParent{false};  // Should the parent destroy this thread, or it destory itself
 
     alignas(16) FEXCore::Core::CpuStateFrame BaseFrameState{};

--- a/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
+++ b/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
@@ -19,6 +19,10 @@ namespace FEXCore::Context {
   struct Context;
 }
 
+namespace FEXCore::CPU {
+  union Relocation;
+}
+
 namespace FEXCore::Frontend {
   class Decoder;
 }
@@ -48,6 +52,7 @@ namespace FEXCore::Core {
   struct DebugData {
     uint64_t HostCodeSize; ///< The size of the code generated in the host JIT
     std::vector<DebugDataSubblock> Subblocks;
+    std::vector<FEXCore::CPU::Relocation> *Relocations;
   };
 
   enum class SignalEvent {


### PR DESCRIPTION
Requires #1688 to be merged first.
First five commits commits are from that PR.

This hooks up the Code Object Cache service as a no-op implementation.
Exercising most of the external facing API to the class but all of the interfaces not yet doing any work.