### PR TITLE
Object cache named region no-op implementation

### DIFF
--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -86,6 +86,7 @@ set (SRCS
   Interface/Core/GdbServer.cpp
   Interface/Core/HostFeatures.cpp
   Interface/Core/ObjectCache/JobHandling.cpp
+  Interface/Core/ObjectCache/NamedRegionObjectHandler.cpp
   Interface/Core/ObjectCache/ObjectCacheService.cpp
   Interface/Core/OpcodeDispatcher/Crypto.cpp
   Interface/Core/OpcodeDispatcher/Flags.cpp

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -104,6 +104,7 @@ namespace FEXCore::Context {
       FEX_CONFIG_OPT(BlockJITNaming, BLOCKJITNAMING);
       FEX_CONFIG_OPT(ParanoidTSO, PARANOIDTSO);
       FEX_CONFIG_OPT(CacheObjectCodeCompilation, CACHEOBJECTCODECOMPILATION);
+      FEX_CONFIG_OPT(x87ReducedPrecision, X87REDUCEDPRECISION);
     } Config;
 
     using IntCallbackReturn =  FEX_NAKED void(*)(FEXCore::Core::InternalThreadState *Thread, volatile void *Host_RSP);

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -1180,12 +1180,20 @@ namespace FEXCore::Context {
     if (DebugServer) {
       DebugServer->AlertLibrariesChanged();
     }
+
+    if (CodeObjectCacheService) {
+      CodeObjectCacheService->AsyncAddNamedRegionJob(Base, Size, Offset, filename);
+    }
   }
 
   void Context::RemoveNamedRegion(uintptr_t Base, uintptr_t Size) {
     IRCaptureCache.RemoveNamedRegion(Base, Size);
     if (DebugServer) {
       DebugServer->AlertLibrariesChanged();
+    }
+
+    if (CodeObjectCacheService) {
+      CodeObjectCacheService->AsyncRemoveNamedRegionJob(Base, Size);
     }
   }
 

--- a/External/FEXCore/Source/Interface/Core/ObjectCache/CodeObjectSerializationConfig.h
+++ b/External/FEXCore/Source/Interface/Core/ObjectCache/CodeObjectSerializationConfig.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <cstdint>
+
+namespace FEXCore::CodeSerialize {
+  // If any of the config options mismatch on load then the cache won't be used
+  // Any of these will result in codegen changes
+  struct CodeObjectSerializationConfig {
+		// Cookie in the header of the file, isn't part of the config hash
+    uint64_t Cookie{};
+
+    // Instructions per block configuration
+    int32_t MaxInstPerBlock{};
+
+    // Follows CPUID 4000_0001_EAX[3:0]
+    unsigned Arch : 4;
+
+    // Multiblock enabled
+    bool MultiBlock : 1;
+
+    // TSO enabled
+    bool TSOEnabled : 1;
+
+    // ABI local flag unsafe optimization
+    bool ABILocalFlags : 1;
+
+    // ABI no PF unsafe optimization
+    bool ABINoPF : 1;
+
+    // Static register allocation enabled
+    bool SRA : 1;
+
+    // Paranoid TSO mode enabled
+    bool ParanoidTSO : 1;
+
+    // Guest code execution mode (We don't support live mode switch)
+    bool Is64BitMode : 1;
+
+    // SMC checks style
+    unsigned SMCChecks : 2;
+
+    // x87 reduced precision
+    bool x87ReducedPrecision : 1;
+
+    // Padding to remove uninitialized data warning from asan
+    // Shows remaining amount of bits available for config
+    unsigned _Pad : 18;
+
+    bool operator==(CodeObjectSerializationConfig const &other) const {
+      return Cookie == other.Cookie &&
+        MaxInstPerBlock == other.MaxInstPerBlock &&
+        Arch == other.Arch &&
+        MultiBlock == other.MultiBlock &&
+        TSOEnabled == other.TSOEnabled &&
+        ABILocalFlags == other.ABILocalFlags &&
+        ABINoPF == other.ABINoPF &&
+        SRA == other.SRA &&
+        ParanoidTSO == other.ParanoidTSO &&
+        Is64BitMode == other.Is64BitMode &&
+        SMCChecks == other.SMCChecks &&
+        x87ReducedPrecision == other.x87ReducedPrecision;
+    }
+    static uint64_t GetHash(CodeObjectSerializationConfig const &other) {
+      // For < 64-bits of data just pack directly
+      // Skip the cookie
+      uint64_t Hash{};
+      Hash <<= 32; Hash |= other.MaxInstPerBlock;
+      Hash <<= 1;  Hash |= other.Arch;
+      Hash <<= 1;  Hash |= other.MultiBlock;
+      Hash <<= 1;  Hash |= other.TSOEnabled;
+      Hash <<= 1;  Hash |= other.ABILocalFlags;
+      Hash <<= 1;  Hash |= other.ABINoPF;
+      Hash <<= 1;  Hash |= other.SRA;
+      Hash <<= 1;  Hash |= other.ParanoidTSO;
+      Hash <<= 1;  Hash |= other.Is64BitMode;
+      Hash <<= 2;  Hash |= other.SMCChecks;
+      Hash <<= 1;  Hash |= other.x87ReducedPrecision;
+      return Hash;
+    }
+  };
+
+	static_assert(sizeof(CodeObjectSerializationConfig) == 16, "Size changed");
+  static_assert((sizeof(CodeObjectSerializationConfig) - sizeof(uint64_t)) == 8, "Config size exceeded 64its. Need to change how the hash is generated!");
+}

--- a/External/FEXCore/Source/Interface/Core/ObjectCache/JobHandling.cpp
+++ b/External/FEXCore/Source/Interface/Core/ObjectCache/JobHandling.cpp
@@ -13,11 +13,112 @@
 
 namespace FEXCore::CodeSerialize {
   void AsyncJobHandler::AsyncAddNamedRegionJob(uintptr_t Base, uintptr_t Size, uintptr_t Offset, const std::string &filename) {
-    // XXX: Actually add the add named region job
+    // This function adds a named region *JOB* to our named region handler
+    // This needs to be as fast as possible to keep out of the way of the JIT
+
+    auto BaseFilename = std::filesystem::path(filename).filename().string();
+
+    if (!BaseFilename.empty()) {
+      // Create a new entry that once set up will be put in to our section object map
+      auto Entry = std::make_unique<CodeRegionEntry>(
+        Base,
+        Size,
+        Offset,
+        filename,
+        NamedRegionHandler->DefaultCodeHeader(Base, Offset)
+      );
+
+      // Lock the job ref counter so we can block anything attempting to use the entry before it is loaded
+      Entry->NamedJobRefCountMutex.lock();
+
+      CodeRegionMapType::iterator EntryIterator;
+      {
+        std::unique_lock lk {CodeObjectCacheService->GetEntryMapMutex()};
+
+        auto &EntryMap = CodeObjectCacheService->GetEntryMap();
+
+        auto it = EntryMap.emplace(Base, std::move(Entry));
+        if (!it.second) {
+          // This happens when an application overwrites a previous region without unmapping what was there
+
+          // Lock this entry's Named job reference counter.
+          // Once this passes then we know that this section has been loaded.
+          it.first->second->NamedJobRefCountMutex.lock();
+
+          // Finalize anything the region needs to do first.
+          CodeObjectCacheService->DoCodeRegionClosure(it.first->second->Base, it.first->second.get());
+
+          // munmap the file that was mapped
+          FEXCore::Allocator::munmap(it.first->second->CodeData, it.first->second->FileSize);
+
+          // Remove this entry from the unrelocated map as well
+          {
+            std::unique_lock lk2 {CodeObjectCacheService->GetUnrelocatedEntryMapMutex()};
+            CodeObjectCacheService->GetUnrelocatedEntryMap().erase(it.first->second->EntryHeader.OriginalBase);
+          }
+
+          // Now overwrite the entry in the map
+          it = EntryMap.insert_or_assign(Base, std::move(Entry));
+          EntryIterator = it.first;
+        }
+        else {
+          // No overwrite, just insert
+          EntryIterator = it.first;
+        }
+      }
+
+      // Now that this entry has been added to the map, we can insert a load job using the entry iterator.
+      // This allows us to quickly unblock the JIT thread when it is loading multiple regions and have the async thread
+      // do the loading for us.
+      //
+      // Create the async work queue job now so it can load
+      NamedRegionHandler->AsyncAddNamedRegionWorkItem(BaseFilename, filename, true, EntryIterator);
+
+      // Tell the async thread that it has work to do
+      CodeObjectCacheService->NotifyWork();
+    }
   }
 
   void AsyncJobHandler::AsyncRemoveNamedRegionJob(uintptr_t Base, uintptr_t Size) {
-    // XXX: Actually add the remove named region job
+    // Removing a named region through the job system
+    // We need to find the entry that we are deleting first
+    std::unique_ptr<CodeRegionEntry> EntryPointer;
+    {
+      std::unique_lock lk {CodeObjectCacheService->GetEntryMapMutex()};
+
+      auto &EntryMap = CodeObjectCacheService->GetEntryMap();
+      auto it = EntryMap.find(Base);
+      if (it != EntryMap.end()) {
+        // Lock the job ref counter since we are erasing it
+        // Once this passes it will have been loaded
+        it->second->NamedJobRefCountMutex.lock();
+
+        // Take the pointer from the map
+        EntryPointer = std::move(it->second);
+
+        // We can now unmap the file data
+        FEXCore::Allocator::munmap(EntryPointer->CodeData, EntryPointer->FileSize);
+
+        // Remove this from the entry map
+        EntryMap.erase(it);
+
+        // Remove this entry from the unrelocated map as well
+        {
+          std::unique_lock lk2 {CodeObjectCacheService->GetUnrelocatedEntryMapMutex()};
+          CodeObjectCacheService->GetUnrelocatedEntryMap().erase(EntryPointer->EntryHeader.OriginalBase);
+        }
+      }
+      else {
+        // Tried to remove something that wasn't in our code object tracking
+        return;
+      }
+
+      // Create the async work queue job now so it can finalize what it needs to do
+      NamedRegionHandler->AsyncRemoveNamedRegionWorkItem(Base, Size, std::move(EntryPointer));
+
+      // Tell the async thread that it has work to do
+      CodeObjectCacheService->NotifyWork();
+    }
   }
 
   void AsyncJobHandler::AsyncAddSerializationJob(std::unique_ptr<SerializationJobData> Data) {

--- a/External/FEXCore/Source/Interface/Core/ObjectCache/NamedRegionObjectHandler.cpp
+++ b/External/FEXCore/Source/Interface/Core/ObjectCache/NamedRegionObjectHandler.cpp
@@ -1,0 +1,71 @@
+#include "Interface/Context/Context.h"
+#include "Interface/Core/ObjectCache/ObjectCacheService.h"
+
+#include <FEXCore/Config/Config.h>
+
+namespace FEXCore::CodeSerialize {
+  NamedRegionObjectHandler::NamedRegionObjectHandler(FEXCore::Context::Context *ctx) {
+    DefaultSerializationConfig.Cookie = CODE_COOKIE;
+
+    // Initialize the Arch from CPUID
+    uint32_t Arch = ctx->CPUID.RunFunction(0x4000'0001, 0).eax & 0xF;
+    DefaultSerializationConfig.Arch = Arch;
+
+    DefaultSerializationConfig.MaxInstPerBlock = ctx->Config.MaxInstPerBlock;
+    DefaultSerializationConfig.MultiBlock = ctx->Config.Multiblock;
+    DefaultSerializationConfig.TSOEnabled = ctx->Config.TSOEnabled;
+    DefaultSerializationConfig.ABILocalFlags = ctx->Config.ABILocalFlags;
+    DefaultSerializationConfig.ABINoPF = ctx->Config.ABINoPF;
+    DefaultSerializationConfig.SRA = ctx->Config.StaticRegisterAllocation;
+    DefaultSerializationConfig.ParanoidTSO = ctx->Config.ParanoidTSO;
+    DefaultSerializationConfig.Is64BitMode = ctx->Config.Is64BitMode;
+    DefaultSerializationConfig.SMCChecks = ctx->Config.SMCChecks;
+    DefaultSerializationConfig.x87ReducedPrecision = ctx->Config.x87ReducedPrecision;
+  }
+
+  void NamedRegionObjectHandler::AddNamedRegionObject(CodeRegionMapType::iterator Entry, const std::string &base_filename, const std::string &filename, bool Executable) {
+    // XXX: Add named region objects
+
+    // XXX: Until entry loading is complete just claim it is loaded
+    Entry->second->NamedJobRefCountMutex.unlock();
+  }
+
+  void NamedRegionObjectHandler::RemoveNamedRegionObject(uintptr_t Base, uintptr_t Size, std::unique_ptr<CodeRegionEntry> Entry) {
+    // XXX: Remove named region objects
+
+    // XXX: Until entry loading is complete just claim it is loaded
+    Entry->NamedJobRefCountMutex.unlock();
+  }
+
+  void NamedRegionObjectHandler::HandleNamedRegionObjectJobs() {
+    // Walk through all of our jobs sequentially until the work queue is empty
+    while (NamedWorkQueueJobs.load()) {
+      std::unique_ptr<AsyncJobHandler::NamedRegionWorkItem> WorkItem;
+
+      {
+        // Lock the work queue mutex for a short moment and grab an item from the list
+        std::unique_lock lk {NamedWorkQueueMutex};
+        size_t WorkItems = WorkQueue.size();
+        if (WorkItems != 0) {
+          WorkItem = std::move(WorkQueue.front());
+          WorkQueue.pop();
+        }
+
+        // Atomically update the number of jobs
+        --NamedWorkQueueJobs;
+      }
+
+      if (WorkItem) {
+        if (WorkItem->GetType() == AsyncJobHandler::NamedRegionJobType::JOB_ADD_NAMED_REGION) {
+          auto WorkAdd = static_cast<AsyncJobHandler::WorkItemAddNamedRegion *>(WorkItem.get());
+          AddNamedRegionObject(WorkAdd->Entry, WorkAdd->BaseFilename, WorkAdd->Filename, WorkAdd->Executable);
+        }
+
+        if (WorkItem->GetType() == AsyncJobHandler::NamedRegionJobType::JOB_REMOVE_NAMED_REGION) {
+          auto WorkRemove = static_cast<AsyncJobHandler::WorkItemRemoveNamedRegion *>(WorkItem.get());
+          RemoveNamedRegionObject(WorkRemove->Base, WorkRemove->Size, std::move(WorkRemove->Entry));
+        }
+      }
+    }
+  }
+}

--- a/External/FEXCore/Source/Interface/Core/ObjectCache/ObjectCacheService.cpp
+++ b/External/FEXCore/Source/Interface/Core/ObjectCache/ObjectCacheService.cpp
@@ -14,7 +14,9 @@ namespace {
 
 namespace FEXCore::CodeSerialize {
   CodeObjectSerializeService::CodeObjectSerializeService(FEXCore::Context::Context *ctx)
-    : CTX {ctx} {
+    : CTX {ctx}
+    , AsyncHandler { &NamedRegionHandler , this }
+    , NamedRegionHandler { ctx } {
     Initialize();
   }
 
@@ -65,7 +67,8 @@ namespace FEXCore::CodeSerialize {
       // Wait for work
       WorkAvailable.Wait();
 
-      // XXX: Handle named region async jobs first. Highest priority
+      // Handle named region async jobs first. Highest priority
+      NamedRegionHandler.HandleNamedRegionObjectJobs();
 
       // XXX: Handle code serialization jobs second.
     }


### PR DESCRIPTION
Requires #1690 to be merged first.

The first 11 commits are from that PR, only the final two are new.

This sets up the named region async job interface in a no-op fashion.
The async interface itself is exercised while the async thread that is supposed to do loading and storing of these objects is a minimum no-op implementation.

Next PR will be for having the async thread actually loading and storing these object files.