### PR TITLE
CMake: C/C++ flags for defined singed overflow warping

### DIFF
--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -329,6 +329,7 @@ function(AddDefaultOptionsToTarget Name)
 
     -Wno-trigraphs
     -ffunction-sections
+    -fwrapv
   )
 
   if (GCC_COLOR)

--- a/Source/Tests/LinuxSyscalls/CMakeLists.txt
+++ b/Source/Tests/LinuxSyscalls/CMakeLists.txt
@@ -69,6 +69,7 @@ PRIVATE
   -Werror=implicit-fallthrough
 
   -Wno-trigraphs
+  -fwrapv
 )
 
 target_include_directories(LinuxEmulation

--- a/ThunkLibs/GuestLibs/CMakeLists.txt
+++ b/ThunkLibs/GuestLibs/CMakeLists.txt
@@ -89,6 +89,8 @@ function(add_guest_lib_with_name NAME LIBNAME)
 
   ## Tell GCC to not complain about ignored attributes
   target_compile_options(${LIBNAME}-guest PRIVATE -Wno-attributes)
+  ## Make signed overflow well defined 2's complement overflow
+  target_compile_options(${LIBNAME}-guest PRIVATE -fwrapv)
   target_compile_options(${LIBNAME}-guest PRIVATE -DLIB_NAME=${LIBNAME} -DLIBLIB_NAME=lib${LIBNAME})
 
   if (GENERATE_GUEST_INSTALL_TARGETS)

--- a/ThunkLibs/HostLibs/CMakeLists.txt
+++ b/ThunkLibs/HostLibs/CMakeLists.txt
@@ -71,6 +71,8 @@ function(add_host_lib_with_name NAME LIBNAME)
   target_include_directories(${LIBNAME}-host PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/gen/lib${LIBNAME}")
   target_link_libraries(${LIBNAME}-host PRIVATE dl)
   target_link_libraries(${LIBNAME}-host PRIVATE lib${LIBNAME}-deps)
+  ## Make signed overflow well defined 2's complement overflow
+  target_compile_options(${LIBNAME}-host PRIVATE -fwrapv)
   target_compile_options(${LIBNAME}-host PRIVATE -DLIB_NAME=${LIBNAME} -DLIBLIB_NAME=lib${LIBNAME})
 
   # generated files forward-declare functions that need to be implemented manually, so pass --no-undefined to make sure errors are detected at compile-time rather than runtime


### PR DESCRIPTION
Not an expert on our build system, but I think I caught all cases we want this to be on for.

- FEXCore
- LinuxSyscalls
- Guest thunks
- Host thunks

Closes #1692.