### PR TITLE
Standarized TODO markers: FEX_TODO, FEX_TODO_ISSUE

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -41,6 +41,7 @@ $end_info$
 #include <FEXCore/Utils/LogManager.h>
 #include <FEXCore/Utils/Threads.h>
 #include <FEXHeaderUtils/Syscalls.h>
+#include <FEXHeaderUtils/TodoDefines.h>
 
 #include <algorithm>
 #include <array>
@@ -1016,7 +1017,8 @@ namespace FEXCore::Context {
     }
 
     // If it is the parent thread that died then just leave
-    // XXX: This doesn't make sense when the parent thread doesn't outlive its children
+    FEX_TODO("This doesn't make sense when the parent thread doesn't outlive its children");
+
     if (Thread->ThreadManager.parent_tid == 0) {
       CoreShuttingDown.store(true);
       Thread->ExitReason = FEXCore::Context::ExitReason::EXIT_SHUTDOWN;

--- a/FEXHeaderUtils/FEXHeaderUtils/TodoDefines.h
+++ b/FEXHeaderUtils/FEXHeaderUtils/TodoDefines.h
@@ -5,15 +5,17 @@
 #endif
 
 #if FEX_WARN_TODO
-// Use like FEX_TODO_ISSUE(github ticket number, username, comment) or
-// FEX_TODO_ISSUE(github ticket number, comment)
-#define FEX_TODO_ISSUE(number, ...) DO_PRAGMA(GCC warning "TODO: https://github.com/FEX-Emu/FEX/issues/" #number __VA_ARGS__)
-// Use like FEX_TODO(username, comment) or FEX_TODO(comment)
-#define FEX_TODO(...) DO_PRAGMA(GCC warning "TODO: " __VA_ARGS__);
+// FEX_TODO_ISSUE(github ticket number, "comment")
+#define FEX_TODO_ISSUE(github_ticket, comment) DO_PRAGMA(GCC warning "TODO: https://github.com/FEX-Emu/FEX/issues/" #github_ticket comment);
+// FEX_TODO("comment")
+#define FEX_TODO(comment) DO_PRAGMA(GCC warning "TODO: " comment);
 #else
-// Use like FEX_TODO_ISSUE(github ticket number, username, comment) or
-// FEX_TODO_ISSUE(github ticket number, comment)
-#define FEX_TODO_ISSUE(number, ...) do {} while (false)
-// Use like FEX_TODO(username, comment) or FEX_TODO(comment)
-#define FEX_TODO(...) do {} while (false)
+// FEX_TODO_ISSUE(github ticket number, "comment")
+#define FEX_TODO_ISSUE(github_ticket, comment)
+// FEX_TODO("comment")
+#define FEX_TODO(comment)
 #endif
+
+// For linking to tickets, non-todo
+// FEX_TICKET(github ticket number) or FEX_TICKET(github ticket number, "comment")
+#define FEX_TICKET(github_ticket, ...)

--- a/FEXHeaderUtils/FEXHeaderUtils/TodoDefines.h
+++ b/FEXHeaderUtils/FEXHeaderUtils/TodoDefines.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#ifndef DO_PRAGMA
+#define DO_PRAGMA(x) _Pragma (#x)
+#endif
+
+#if FEX_WARN_TODO
+// Use like FEX_TODO_ISSUE(github ticket number, username, comment) or
+// FEX_TODO_ISSUE(github ticket number, comment)
+#define FEX_TODO_ISSUE(number, ...) DO_PRAGMA(GCC warning "TODO: https://github.com/FEX-Emu/FEX/issues/" #number __VA_ARGS__)
+// Use like FEX_TODO(username, comment) or FEX_TODO(comment)
+#define FEX_TODO(...) DO_PRAGMA(GCC warning "TODO: " __VA_ARGS__);
+#else
+// Use like FEX_TODO_ISSUE(github ticket number, username, comment) or
+// FEX_TODO_ISSUE(github ticket number, comment)
+#define FEX_TODO_ISSUE(number, ...) do {} while (false)
+// Use like FEX_TODO(username, comment) or FEX_TODO(comment)
+#define FEX_TODO(...) do {} while (false)
+#endif


### PR DESCRIPTION
Proposal for #1696
clang-tidy already has support for detailed todo comments with the format
```
//TODO(details): comment
```
which seems to be the standardised google way to handle this.

I've defined ours as `FEX_TODO` and `FEX_TODO_ISSUE` for easier grepping.

Use like
#### For TODOs
- FEX_TODO_ISSUE(github ticket number, "comment")
- FEX_TODO("comment");

#### For non-todo linking to tickets
- FEX_TICKET(github ticket number)
- FEX_TICKET(github ticket number, "comment")


`#define FEX_WARN_TODO 1`  will generate warnings. That's arguably not very useful as one can just grep for `FEX_TODO`.

Thoughts?

(Closes #1696)