### PR TITLE
Arm64: Adds support for RCPC2 extension

### DIFF
--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64.h
@@ -12,6 +12,10 @@ namespace FEXCore::ArchHelpers::Arm64 {
   constexpr uint32_t ATOMIC_MEM_MASK = 0x3B200C00;
   constexpr uint32_t ATOMIC_MEM_INST = 0x38200000;
 
+  constexpr uint32_t RCPC2_MASK  = 0x3F'E0'0C'00;
+  constexpr uint32_t LDAPUR_INST = 0x19'40'00'00;
+  constexpr uint32_t STLUR_INST  = 0x19'00'00'00;
+
   constexpr uint32_t LDAXP_MASK = 0xBF'FF'80'00;
   constexpr uint32_t LDAXP_INST = 0x88'7F'80'00;
 
@@ -83,8 +87,8 @@ namespace FEXCore::ArchHelpers::Arm64 {
     return (Instr >> RM_OFFSET) & REGISTER_MASK;
   }
 
-  bool HandleAtomicLoad(void *_ucontext, void *_info, uint32_t Instr);
-  bool HandleAtomicStore(void *_ucontext, void *_info, uint32_t Instr);
+  bool HandleAtomicLoad(void *_ucontext, void *_info, uint32_t Instr, int64_t Offset);
+  bool HandleAtomicStore(void *_ucontext, void *_info, uint32_t Instr, int64_t Offset);
   bool HandleAtomicLoad128(void *_ucontext, void *_info, uint32_t Instr);
   uint64_t HandleAtomicLoadstoreExclusive(void *_ucontext, void *_info);
   bool HandleCASPAL(void *_ucontext, void *_info, uint32_t Instr);

--- a/External/FEXCore/Source/Interface/Core/HostFeatures.cpp
+++ b/External/FEXCore/Source/Interface/Core/HostFeatures.cpp
@@ -60,6 +60,7 @@ HostFeatures::HostFeatures() {
   // Only supported when FEAT_AFP is supported
   SupportsFlushInputsToZero = Features.Has(vixl::CPUFeatures::Feature::kAFP);
   SupportsRCPC = Features.Has(vixl::CPUFeatures::Feature::kRCpc);
+  SupportsTSOImm9 = Features.Has(vixl::CPUFeatures::Feature::kRCpcImm);
 
   // We need to get the CPU's cache line size
   // We expect sane targets that have correct cacheline sizes across clusters
@@ -79,6 +80,8 @@ HostFeatures::HostFeatures() {
   SupportsAES = Features.has(Xbyak::util::Cpu::tAESNI);
   SupportsCRC = Features.has(Xbyak::util::Cpu::tSSE42);
   SupportsRAND = Features.has(Xbyak::util::Cpu::tRDRAND) && Features.has(Xbyak::util::Cpu::tRDSEED);
+  SupportsRCPC = true;
+  SupportsTSOImm9 = true;
 
   // xbyak doesn't know how to check for CLZero
   uint32_t eax, ebx, ecx, edx;

--- a/External/FEXCore/Source/Interface/Core/HostFeatures.h
+++ b/External/FEXCore/Source/Interface/Core/HostFeatures.h
@@ -19,6 +19,7 @@ class HostFeatures final {
     bool SupportsCLZERO{};
     bool SupportsAtomics{};
     bool SupportsRCPC{};
+    bool SupportsTSOImm9{};
     bool SupportsRAND{};
 
     // Float exception behaviour

--- a/External/FEXCore/Source/Interface/IR/PassManager.cpp
+++ b/External/FEXCore/Source/Interface/IR/PassManager.cpp
@@ -30,7 +30,7 @@ void PassManager::AddDefaultPasses(FEXCore::Context::Context *ctx, bool InlineCo
 
     InsertPass(CreateDeadStoreElimination());
     InsertPass(CreatePassDeadCodeElimination());
-    InsertPass(CreateConstProp(InlineConstants));
+    InsertPass(CreateConstProp(InlineConstants, ctx->HostFeatures.SupportsTSOImm9));
 
     ////// InsertPass(CreateDeadFlagCalculationEliminination());
 

--- a/External/FEXCore/Source/Interface/IR/Passes.h
+++ b/External/FEXCore/Source/Interface/IR/Passes.h
@@ -11,7 +11,7 @@ class Pass;
 class RegisterAllocationPass;
 class RegisterAllocationData;
 
-std::unique_ptr<FEXCore::IR::Pass> CreateConstProp(bool InlineConstants);
+std::unique_ptr<FEXCore::IR::Pass> CreateConstProp(bool InlineConstants, bool SupportsTSOImm9);
 std::unique_ptr<FEXCore::IR::Pass> CreateContextLoadStoreElimination();
 std::unique_ptr<FEXCore::IR::Pass> CreateSyscallOptimization();
 std::unique_ptr<FEXCore::IR::Pass> CreateDeadFlagCalculationEliminination();


### PR DESCRIPTION
This allows us to have RCPC loadstore operations with a 9-bit signed
offset.

This gives us a small range of [-256,256) of immediate encoding range on
our TSO loadstore operations.
Updates the inline constant pass in ConstProp to support this range on
TSO IR ops if the host supports RCPC2.

Apple M1 supports this extension, didn't test with Cortex-X2/A710.