### PR TITLE
Arm64: Makes unaligned backpatching be less aggressive with DMB

### DIFF
--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64.h
@@ -72,8 +72,16 @@ namespace FEXCore::ArchHelpers::Arm64 {
   constexpr uint32_t RN_OFFSET = 5;
   constexpr uint32_t RM_OFFSET = 16;
 
-  constexpr uint32_t DMB = 0b1101'0101'0000'0011'0011'0000'1011'1111 |
+  constexpr uint32_t DMB_ALL = 0b1101'0101'0000'0011'0011'0000'1011'1111 |
     0b1011'0000'0000; // Inner shareable all
+
+  constexpr uint32_t DMB_READ = 0b1101'0101'0000'0011'0011'0000'1011'1111 |
+    0b1010'0000'0000; // Inner shareable reads
+
+  constexpr uint32_t DMB_WRITE = 0b1101'0101'0000'0011'0011'0000'1011'1111 |
+    0b1001'0000'0000; // Inner shareable Writes
+
+  constexpr uint32_t NOP = 0b1101'0101'0000'0011'0010'0000'0001'1111;
 
   inline uint32_t GetRdReg(uint32_t Instr) {
     return (Instr >> RD_OFFSET) & REGISTER_MASK;


### PR DESCRIPTION
No need to do a full inner-shareable read/write DMB on both sides of the
instruction.
We only need to do inner-shareable read OR write depending on the type
of loadstore.

Couldn't find a bench where this made a significant difference but
surely there is one somewhere.

First commit is from https://github.com/FEX-Emu/FEX/pull/1702, needs that merged first before this.