### PR TITLE
JitSymbols: Print file+offset if possible

### DIFF
--- a/External/FEXCore/Source/Common/JitSymbols.cpp
+++ b/External/FEXCore/Source/Common/JitSymbols.cpp
@@ -34,6 +34,14 @@ namespace FEXCore {
     fmt::print(fp.get(), "{} {:x} {}_{}\n", HostAddr, CodeSize, Name, HostAddr);
   }
 
+  void JITSymbols::Register(const void *HostAddr, uint32_t CodeSize, std::string_view Name, uintptr_t Offset) {
+    if (!fp) return;
+
+    // Linux perf format is very straightforward
+    // `<HostPtr> <Size> <Name>\n`
+    fmt::print(fp.get(), "{} {:x} {}+0x{:x} ({})\n", HostAddr, CodeSize, Name, Offset, HostAddr);
+  }
+
   void JITSymbols::RegisterNamedRegion(const void *HostAddr, uint32_t CodeSize, std::string_view Name) {
     if (!fp) return;
 

--- a/External/FEXCore/Source/Common/JitSymbols.h
+++ b/External/FEXCore/Source/Common/JitSymbols.h
@@ -13,6 +13,7 @@ public:
 
   void Register(const void *HostAddr, uint64_t GuestAddr, uint32_t CodeSize);
   void Register(const void *HostAddr, uint32_t CodeSize, std::string_view Name);
+  void Register(const void *HostAddr, uint32_t CodeSize, std::string_view Name, uintptr_t Offset);
   void RegisterNamedRegion(const void *HostAddr, uint32_t CodeSize, std::string_view Name);
   void RegisterJITSpace(const void *HostAddr, uint32_t CodeSize);
 

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -996,12 +996,22 @@ namespace FEXCore::Context {
     // The core managed to compile the code.
     if (Config.BlockJITNaming()) {
       if (DebugData) {
+        auto GuestRIPLookup = this->SyscallHandler->LookupAOTIRCacheEntry(GuestRIP);
+
         if (DebugData->Subblocks.size()) {
           for (auto& Subblock: DebugData->Subblocks) {
+            if (GuestRIPLookup.Entry) {
+              Symbols.Register(CodePtr, DebugData->HostCodeSize, GuestRIPLookup.Entry->Filename, GuestRIP - GuestRIPLookup.Offset);
+            } else {
             Symbols.Register((void*)Subblock.HostCodeStart, GuestRIP, Subblock.HostCodeSize);
           }
+          }
+        } else {
+          if (GuestRIPLookup.Entry) {
+            Symbols.Register(CodePtr, DebugData->HostCodeSize, GuestRIPLookup.Entry->Filename, GuestRIP - GuestRIPLookup.Offset);
         } else {
           Symbols.Register(CodePtr, GuestRIP, DebugData->HostCodeSize);
+          }
         }
       }
     }


### PR DESCRIPTION
Using the memtrack infrastructure, blocks symbols for perf are named based on `/guest/containing/file.so+offset (0xGuestRip)`.

The offset is from the file start, not from `.text`, so not directly compatible with `addr2line`. Still very helpful when looking at the block in disassembly tools.

![Screenshot from 2022-05-17 15-43-36](https://user-images.githubusercontent.com/393266/168815619-6b1391f6-8821-44ef-8fd6-4e0978d0afa4.png)


