### PR TITLE
Syscalls: Fixes clone3 stack pointer

### DIFF
--- a/Source/Tests/LinuxSyscalls/Syscalls.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls.cpp
@@ -310,6 +310,7 @@ static void PrintFlags(uint64_t Flags){
   FLAGPRINT(CLONE_NEWPID,         0x20000000);
   FLAGPRINT(CLONE_NEWNET,         0x40000000);
   FLAGPRINT(CLONE_IO,             0x80000000);
+  FLAGPRINT(CLONE_PIDFD,          0x00001000);
 #undef FLAGPRINT
 };
 
@@ -479,7 +480,7 @@ uint64_t CloneHandler(FEXCore::Core::CpuStateFrame *Frame, FEX::HLE::clone3_args
       reinterpret_cast<pid_t*>(args->args.child_tid),
       reinterpret_cast<void*>(args->args.tls));
   } else {
-    auto NewThread = FEX::HLE::CreateNewThread(Thread->CTX, Frame, &args->args);
+    auto NewThread = FEX::HLE::CreateNewThread(Thread->CTX, Frame, args);
 
     // Return the new threads TID
     uint64_t Result = NewThread->ThreadManager.GetTID();

--- a/Source/Tests/LinuxSyscalls/Syscalls/Thread.h
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Thread.h
@@ -14,7 +14,7 @@ struct CPUState;
 }
 
 namespace FEX::HLE {
-  FEXCore::Core::InternalThreadState *CreateNewThread(FEXCore::Context::Context *CTX, FEXCore::Core::CpuStateFrame *Frame, FEX::HLE::kernel_clone3_args *args);
+  FEXCore::Core::InternalThreadState *CreateNewThread(FEXCore::Context::Context *CTX, FEXCore::Core::CpuStateFrame *Frame, FEX::HLE::clone3_args *args);
   uint64_t HandleNewClone(FEXCore::Core::InternalThreadState *Thread, FEXCore::Context::Context *CTX, FEXCore::Core::CpuStateFrame *Frame, FEX::HLE::kernel_clone3_args *GuestArgs);
   uint64_t ForkGuest(FEXCore::Core::InternalThreadState *Thread, FEXCore::Core::CpuStateFrame *Frame, uint32_t flags, void *stack, pid_t *parent_tid, pid_t *child_tid, void *tls);
 }


### PR DESCRIPTION
clone2 stack pointer passed in points to the highest address for the
stack.

clone3 switches this around and gives us a base pointer and a size.

glibc started using clone3 for its thread cloning which finally caught
this bug. Necessary to run any application under the Ubuntu 22.04 rootfs
since that uses a new enough glibc to encounter this.