### PR TITLE
WIP: Guest Signals: Correctly block raised signal, implement SA_NODEFER, sigreturn sa_mask restore

### DIFF
--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/MContext.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/MContext.h
@@ -23,7 +23,7 @@ struct X86ContextBackup {
   // RIP and RSP is stored in GPRs here
   uint64_t GPRs[23];
   FEXCore::x86_64::_libc_fpstate FPRState;
-  uint64_t sa_mask;
+  uint64_t sigmask;
   bool FaultToTopAndGeneratedException;
 
   // Guest state
@@ -46,7 +46,7 @@ struct ArmContextBackup {
   uint32_t FPSR;
   uint32_t FPCR;
   __uint128_t FPRs[32];
-  uint64_t sa_mask;
+  uint64_t sigmask;
   bool FaultToTopAndGeneratedException;
 
   // Guest state
@@ -149,7 +149,7 @@ static inline void BackupContext(void* ucontext, T *Backup) {
     memcpy(&Backup->FPRs[0], &HostState->FPRs[0], 32 * sizeof(__uint128_t));
 
     // Save the signal mask so we can restore it
-    memcpy(&Backup->sa_mask, &_ucontext->uc_sigmask, sizeof(uint64_t));
+    memcpy(&Backup->sigmask, &_ucontext->uc_sigmask, sizeof(uint64_t));
   } else {
     // This must be a runtime error
     ERROR_AND_DIE_FMT("Wrong context type");
@@ -175,7 +175,7 @@ static inline void RestoreContext(void* ucontext, T *Backup) {
     memcpy(&_mcontext->regs[0], &Backup->GPRs[0], 31 * sizeof(uint64_t));
 
     // Restore the signal mask now
-    memcpy(&_ucontext->uc_sigmask, &Backup->sa_mask, sizeof(uint64_t));
+    memcpy(&_ucontext->uc_sigmask, &Backup->sigmask, sizeof(uint64_t));
   } else {
     // This must be a runtime error
     ERROR_AND_DIE_FMT("Wrong context type");
@@ -236,7 +236,7 @@ static inline void BackupContext(void* ucontext, T *Backup) {
     // XXX: Save 256bit and 512bit AVX register state
 
     // Save the signal mask so we can restore it
-    memcpy(&Backup->sa_mask, &_ucontext->uc_sigmask, sizeof(uint64_t));
+    memcpy(&Backup->sigmask, &_ucontext->uc_sigmask, sizeof(uint64_t));
   } else {
     // This must be a runtime error
     ERROR_AND_DIE_FMT("Wrong context type");
@@ -255,7 +255,7 @@ static inline void RestoreContext(void* ucontext, T *Backup) {
     memcpy(_mcontext->fpregs, &Backup->FPRState, sizeof(X86ContextBackup::FPRState));
 
     // Restore the signal mask now
-    memcpy(&_ucontext->uc_sigmask, &Backup->sa_mask, sizeof(uint64_t));
+    memcpy(&_ucontext->uc_sigmask, &Backup->sigmask, sizeof(uint64_t));
   } else {
     // This must be a runtime error
     ERROR_AND_DIE_FMT("Wrong context type");

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
@@ -123,7 +123,6 @@ void Dispatcher::RestoreThreadState(void *ucontext) {
       auto HostUctx = (ucontext_t*)ucontext;
       // guest might have modified uc_sigmask here
       // FEX_TODO_ISSUE(1682, "Handle actual sigmask size in a better way here")
-      CTX->SignalDelegation->NotifyGuestMaskChange((GuestSAMask*)&guest_uctx->uc_sigmask);
       memcpy(&HostUctx->uc_sigmask, &guest_uctx->uc_sigmask, sizeof(uint64_t));
 
       // If the guest modified the RIP then we need to take special precautions here
@@ -188,7 +187,6 @@ void Dispatcher::RestoreThreadState(void *ucontext) {
       auto HostUctx = (ucontext_t*)ucontext;
       // guest might have modified uc_sigmask here
       // FEX_TODO_ISSUE(1682, "Handle actual sigmask size in a better way here")
-      CTX->SignalDelegation->NotifyGuestMaskChange((GuestSAMask*)&guest_uctx->uc_sigmask);
       memcpy(&HostUctx->uc_sigmask, &guest_uctx->uc_sigmask, sizeof(uint64_t));
 
       // If the guest modified the RIP then we need to take special precautions here
@@ -252,6 +250,10 @@ void Dispatcher::RestoreThreadState(void *ucontext) {
       }
     }
   }
+
+  //FEX_TODO("This is a bit of a hack")
+  auto HostUctx = (ucontext_t*)ucontext;
+  CTX->SignalDelegation->NotifyGuestMaskChange((GuestSAMask*)&HostUctx->uc_sigmask);
 }
 
 static uint32_t ConvertSignalToTrapNo(int Signal, siginfo_t *HostSigInfo) {

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
@@ -480,6 +480,11 @@ bool Dispatcher::HandleGuestSignal(int Signal, void *info, void *ucontext, Guest
 
       Frame->State.gregs[X86State::REG_RSI] = SigInfoLocation;
       Frame->State.gregs[X86State::REG_RDX] = UContextLocation;
+
+      //FEX_TODO("nicer size here")
+      memcpy(&guest_uctx->uc_sigmask, &GuestAction->sa_mask, sizeof(uint64_t));
+      //FEX_TODO("nicer types here")
+      CTX->SignalDelegation->NotifyGuestMaskChange((GuestSAMask*)&guest_uctx->uc_sigmask);
     }
     else {
       ContextBackup->Flags |= ArchHelpers::Context::ContextFlags::CONTEXT_FLAG_32BIT;
@@ -609,6 +614,11 @@ bool Dispatcher::HandleGuestSignal(int Signal, void *info, void *ucontext, Guest
       *(uint32_t*)NewGuestSP = SigInfoLocation;
       NewGuestSP -= 4;
       *(uint32_t*)NewGuestSP = Signal;
+
+      //FEX_TODO("nicer size here")
+      memcpy(&guest_uctx->uc_sigmask, &GuestAction->sa_mask, sizeof(uint64_t));
+      //FEX_TODO("nicer types here")
+      CTX->SignalDelegation->NotifyGuestMaskChange((GuestSAMask*)&guest_uctx->uc_sigmask);
     }
 
     Frame->State.rip = reinterpret_cast<uint64_t>(GuestAction->sigaction_handler.sigaction);

--- a/External/FEXCore/include/FEXCore/Core/SignalDelegator.h
+++ b/External/FEXCore/include/FEXCore/Core/SignalDelegator.h
@@ -75,6 +75,8 @@ namespace Core {
     // 64 is used internally by Valgrind
     constexpr static size_t SIGNAL_FOR_PAUSE {63};
 
+    virtual void NotifyGuestMaskChange(GuestSAMask *NewMask) = 0;
+
   protected:
     FEXCore::Core::InternalThreadState *GetTLSThread();
     virtual void HandleGuestSignal(FEXCore::Core::InternalThreadState *Thread, int Signal, void *info, void *ucontext) = 0;

--- a/Source/Tests/LinuxSyscalls/SignalDelegator.h
+++ b/Source/Tests/LinuxSyscalls/SignalDelegator.h
@@ -55,6 +55,9 @@ namespace FEX::HLE {
     /**  @} */
 
       void UninstallHostHandler(int Signal);
+
+      void NotifyGuestMaskChange(FEXCore::GuestSAMask *NewMask);
+
   protected:
     // Called from the thunk handler to handle the signal
     void HandleGuestSignal(FEXCore::Core::InternalThreadState *Thread, int Signal, void *Info, void *UContext) override;


### PR DESCRIPTION
#### Overview

This is the first set of fixes from #1682

- The raised signal in the guest handler would not be blocked. As the host handler does sigreturn, we can't rely on the host handling there.
- Also implemented guest SA_NODEFER there.
- On guest signal return, the guest provided `uc_sigmask` is restored, not the one saved on signal entry, as the guest can modify this.

#### TODO
- [ ] Cleanup the code
- [ ] move more of the signal logic away from the jit dispatcher
- [ ] Make sure we don't set SA_NODEFER for the host signals, as we don't want that there
- [ ] Integrate tests from https://github.com/FEX-Emu/fex-assorted-tests-bins/tree/main/src/tests

#### Test todo
- [ ] Add test for procmask inside signal handler, with and without SA_NODEFER
- [ ] Add test for procmask after signal handler, with and without SA_NODEFER
- [ ] SA_NODEFER tests validating around host signal handling
- [ ] Verify guest_uctx sigmask is set correctly before entry to signal handler