### PR TITLE
OpcodeDispatcher: Fixes pextrb with high registers

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -755,7 +755,7 @@ void OpDispatchBuilder::PExtrOp(OpcodeArgs) {
   }
   else {
     // If we are storing to memory then we store the size of the element extracted
-    StoreResult(GPRClass, Op, Result, -1);
+    StoreResult_WithOpSize(GPRClass, Op, Op->Dest, Result, ElementSize, -1);
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/X86Tables/H0F3ATables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/H0F3ATables.cpp
@@ -31,7 +31,7 @@ void InitializeH0F3ATables(Context::OperatingMode Mode) {
     {OPD(0, PF_3A_66,   0x0E), 1, X86InstInfo{"PBLENDW",         TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS,           1, nullptr}},
     {OPD(0, PF_3A_66,   0x0F), 1, X86InstInfo{"PALIGNR",         TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS, 1, nullptr}},
 
-    {OPD(0, PF_3A_66,   0x14), 1, X86InstInfo{"PEXTRB",          TYPE_INST, GenFlagsSizes(SIZE_8BIT, SIZE_128BIT) | FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_SF_DST_GPR | FLAGS_XMM_FLAGS, 1, nullptr}},
+    {OPD(0, PF_3A_66,   0x14), 1, X86InstInfo{"PEXTRB",          TYPE_INST, GenFlagsSizes(SIZE_32BIT, SIZE_128BIT) | FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_SF_DST_GPR | FLAGS_XMM_FLAGS, 1, nullptr}},
     {OPD(0, PF_3A_66,   0x15), 1, X86InstInfo{"PEXTRW",          TYPE_INST, GenFlagsSizes(SIZE_16BIT, SIZE_128BIT) | FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_SF_DST_GPR | FLAGS_XMM_FLAGS, 1, nullptr}},
     {OPD(0, PF_3A_66,   0x16), 1, X86InstInfo{"PEXTRD",          TYPE_INST, GenFlagsSizes(SIZE_32BIT, SIZE_128BIT) | FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_SF_DST_GPR | FLAGS_XMM_FLAGS, 1, nullptr}},
     {OPD(0, PF_3A_66,   0x17), 1, X86InstInfo{"EXTRACTPS",       TYPE_INST, GenFlagsSizes(SIZE_32BIT, SIZE_128BIT) | FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_SF_DST_GPR | FLAGS_XMM_FLAGS, 1, nullptr}},

--- a/unittests/ASM/H0F3A/66_14_2.asm
+++ b/unittests/ASM/H0F3A/66_14_2.asm
@@ -1,0 +1,34 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RSP": "0x48",
+    "RBP": "0x47",
+    "RSI": "0x46",
+    "RDI": "0x45"
+  }
+}
+%endif
+
+lea rdx, [rel data]
+
+movaps xmm0, [rel data]
+
+; Special testing for storing in to registers rsp, rbp, rsi, rdi
+; These registers are in the 'high' modrm.reg encoding which can
+; mean ah/ch/dh/bh or rsp/rbp/rsi/rdi depending on instruction
+
+mov rsp, -1
+mov rbp, -1
+mov rsi, -1
+mov rdi, -1
+
+pextrb rsp, xmm0, 0
+pextrb rbp, xmm0, 1
+pextrb rsi, xmm0, 2
+pextrb rdi, xmm0, 3
+
+hlt
+
+align 16
+data:
+dq 0x4142434445464748


### PR DESCRIPTION
Previously if the instruction was encoded to use rsp, rbp, rsi, or rdi
then due to how these were encoded in modrm this would hit the frontend
path for writing to the high 8 bits of a 16bit register.

This is because it's instruction specific if an 8-bit modrm instruction
chooses to use the high 8-bit region or the upper 4 registers.
See the ModRM.reg section of `ModRM.reg and .r/m Field Encodings`
specifically to see what each encoding stands for. Has four different
meanings per encoding depending on instruction.

This instruction doesn't actually write to registers at 8-bit size, it
extracts an element at 8-bit size and then zero extends it to the full
GPR.

When storing to memory it always stores to memory at the size of the
element extracted.

I grepped around the instruction tables to see if there were any other
instances of this mistake. This was the only one.

Fixes https://github.com/FEX-Emu/FEX/issues/1472 and also gets Psychonauts 2 running.