### PR TITLE
FEXGlobalIncludes.h: Automatically included via cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -478,6 +478,7 @@ endif()
 
 add_subdirectory(FEXHeaderUtils/)
 include_directories(FEXHeaderUtils/)
+add_definitions(-include FEXHeaderUtils/FEXGlobalIncludes.h)
 
 add_subdirectory(External/FEXCore)
 

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -42,7 +42,6 @@ $end_info$
 #include <FEXCore/Utils/LogManager.h>
 #include <FEXCore/Utils/Threads.h>
 #include <FEXHeaderUtils/Syscalls.h>
-#include <FEXHeaderUtils/TodoDefines.h>
 
 #include <algorithm>
 #include <array>

--- a/FEXHeaderUtils/FEXHeaderUtils/FEXGlobalIncludes.h
+++ b/FEXHeaderUtils/FEXHeaderUtils/FEXGlobalIncludes.h
@@ -1,0 +1,4 @@
+// This is included via CMake for FEXCore, others
+#pragma once
+
+#include "TodoDefines.h"


### PR DESCRIPTION
#### Overview
Follow up from #1700, introduces `FEXHeaderUtils/FEXGlobalIncludes.h`, modifies CMake scripts to automatically include ot.

`FEXHeaderUtils/FEXGlobalIncludes.h` just includes `TodoDefines.h` for now, and we should be /very/ careful about things we forcefully include