### PR TITLE
OpcodeDispatcher: Implements support for PAUSE 

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -176,6 +176,7 @@ constexpr OpHandlerArray InterpreterOpHandlers = [] {
   REGISTER_OP(INVALIDATEFLAGS,        NoOp);
   REGISTER_OP(PROCESSORID,            ProcessorID);
   REGISTER_OP(RDRAND,                 RDRAND);
+  REGISTER_OP(YIELD,                  Yield);
 
   // Move ops
   REGISTER_OP(EXTRACTELEMENTPAIR,     ExtractElementPair);

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
@@ -199,6 +199,7 @@ namespace FEXCore::CPU {
   DEF_OP(SetRoundingMode);
   DEF_OP(ProcessorID);
   DEF_OP(RDRAND);
+  DEF_OP(Yield);
 
   ///< Move ops
   DEF_OP(ExtractElementPair);

--- a/External/FEXCore/Source/Interface/Core/Interpreter/MiscOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/MiscOps.cpp
@@ -157,6 +157,11 @@ DEF_OP(RDRAND) {
   // Second result is if we managed to read a valid random number or not
   DstPtr[1] = Result == 8 ? 1 : 0;
 }
+
+DEF_OP(Yield) {
+  // Nop implementation
+}
+
 #undef DEF_OP
 
 } // namespace FEXCore::CPU

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -330,6 +330,7 @@ private:
   DEF_OP(SetRoundingMode);
   DEF_OP(ProcessorID);
   DEF_OP(RDRAND);
+  DEF_OP(Yield);
 
   ///< Move ops
   DEF_OP(ExtractElementPair);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
@@ -219,6 +219,10 @@ DEF_OP(RDRAND) {
   cset(Dst.second, Condition::ne);
 }
 
+DEF_OP(Yield) {
+  hint(SystemHint::YIELD);
+}
+
 #undef DEF_OP
 void Arm64JITCore::RegisterMiscHandlers() {
 #define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &Arm64JITCore::Op_##x
@@ -237,6 +241,7 @@ void Arm64JITCore::RegisterMiscHandlers() {
   REGISTER_OP(INVALIDATEFLAGS,   NoOp);
   REGISTER_OP(PROCESSORID,   ProcessorID);
   REGISTER_OP(RDRAND, RDRAND);
+  REGISTER_OP(YIELD, Yield);
 
 #undef REGISTER_OP
 }

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -385,6 +385,7 @@ private:
   DEF_OP(SetRoundingMode);
   DEF_OP(ProcessorID);
   DEF_OP(RDRAND);
+  DEF_OP(Yield);
 
   ///< Move ops
   DEF_OP(ExtractElementPair);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/MiscOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/MiscOps.cpp
@@ -166,6 +166,10 @@ DEF_OP(RDRAND) {
   setc(Dst.second.cvt8());
 }
 
+DEF_OP(Yield) {
+  pause();
+}
+
 #undef DEF_OP
 void X86JITCore::RegisterMiscHandlers() {
 #define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &X86JITCore::Op_##x
@@ -184,6 +188,7 @@ void X86JITCore::RegisterMiscHandlers() {
   REGISTER_OP(INVALIDATEFLAGS,   NoOp);
   REGISTER_OP(PROCESSORID,   ProcessorID);
   REGISTER_OP(RDRAND, RDRAND);
+  REGISTER_OP(YIELD, Yield);
 #undef REGISTER_OP
 }
 }

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -1443,6 +1443,11 @@ void OpDispatchBuilder::XCHGOp(OpcodeArgs) {
     // But this would result in a zext on 64bit, which would ruin the no-op nature of the instruction
     // So x86-64 spec mandates this special case that even though it is a 32bit instruction and
     // is supposed to zext the result, it is a true no-op
+    if (Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_REP_PREFIX) {
+      // If this instruction has a REP prefix then this is architectually defined to be a `PAUSE` instruction.
+      // On older processors this ends up being a true `REP NOP` which is why they stuck this here.
+      _Yield();
+    }
     return;
   }
 

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -231,6 +231,11 @@
                 ],
         "DestSize": "16",
         "NumElements": "2"
+      },
+      "Yield": {
+        "HasSideEffects": true,
+        "Desc": ["This is a hint instruction that the CPU is likely to do a spin so it might want to pause to help out SMP",
+                 "Can be implemented as a NOP if necessary"]
       }
     },
     "Branch": {

--- a/unittests/ASM/Primary/Pause.asm
+++ b/unittests/ASM/Primary/Pause.asm
@@ -1,0 +1,12 @@
+%ifdef CONFIG
+{
+}
+%endif
+
+; Set rcx to an absurd number just incase something terrible occurs since pause = `rep nop`
+mov rcx, -1
+
+; Just ensure execution.
+pause
+
+hlt


### PR DESCRIPTION
The pause instruction is architecturally defined to be the `REP NOP`
instruction.

This allows people to use this instruction as a backwards compatible
pause without checking for CPUID support. In fact there is no way to
check if the hardware implements this as a `REP NOP` or a `PAUSE`.

If you have new enough hardware then this just ends up being a PAUSE.

Pass this PAUSE over to our host to help out applications that are
writing spin loops with a PAUSE in it, which we were deleting
previously.