### PR TITLE
AppConfig: Inject --no-sandbox in to steamwebhelper

### DIFF
--- a/Data/AppConfig/steamwebhelper.json
+++ b/Data/AppConfig/steamwebhelper.json
@@ -1,0 +1,5 @@
+{
+  "Config": {
+    "AdditionalArguments": "--no-sandbox"
+  }
+}

--- a/External/FEXCore/Source/Interface/Config/Config.json.in
+++ b/External/FEXCore/Source/Interface/Config/Config.json.in
@@ -115,6 +115,13 @@
           "This can be useful for setting environment variables that thunks can pick up.",
           "Typically isn't necessary since the guest libc isn't thunked. But is possible."
         ]
+      },
+      "AdditionalArguments": {
+        "Type": "strarray",
+        "Default": "",
+        "Desc": [
+          "Allows the user to pass additional arguments to the application"
+        ]
       }
     },
     "Debug": {

--- a/Source/Tests/ELFCodeLoader2.h
+++ b/Source/Tests/ELFCodeLoader2.h
@@ -255,6 +255,11 @@ class ELFCodeLoader2 final : public FEXCore::CodeLoader {
       Args.erase(Args.begin());
     }
 
+    // Append any additional arguments from config
+    for (auto &Arg : AdditionalArguments.All()) {
+      Args.emplace_back(Arg);
+    }
+
     if (!MainElf.InterpreterElf.empty()) {
       if (!InterpElf.ReadElf(ResolveRootfsFile(MainElf.InterpreterElf, RootFS)) && !InterpElf.ReadElf(MainElf.InterpreterElf))
         return;
@@ -651,5 +656,6 @@ class ELFCodeLoader2 final : public FEXCore::CodeLoader {
   uint64_t ArgumentBackingSize{};
   uint64_t EnvironmentBackingSize{};
   uint64_t BaseOffset{};
+  FEX_CONFIG_OPT(AdditionalArguments, ADDITIONALARGUMENTS);
 
 };


### PR DESCRIPTION
Steam's webhelper has started enabling its sandbox which completely
breaks under FEX since we don't support seccomp.

Curiously the Chromium code is actually supposed to support a fallback
namespace only mode, which is used in glibc 2.34 environments.

The startup script for this will try to use this namespace only mode,
but Chromium developers never tested this in an environment that doesn't
support seccomp.

Due to an early check in their sandbox code, it checks for bpf support
before checking for which sandbox mode it is entering. This returns
early with a false statement which brings the entire browser instance
down with an assert.

Inject the --no-sandbox argument so we get around this and the sandbox
is disabled.