### PR TITLE
unittests: Workaround runner issues

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -131,16 +131,16 @@ jobs:
       working-directory: ${{runner.workspace}}/build
       run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_GCC32.log || true
 
-    - name: Struct verifier tests
-      working-directory: ${{runner.workspace}}/build
-      shell: bash
-      run: cmake --build . --config $BUILD_TYPE --target struct_verifier
+      #- name: Struct verifier tests
+      #  working-directory: ${{runner.workspace}}/build
+      #  shell: bash
+      #  run: cmake --build . --config $BUILD_TYPE --target struct_verifier
 
-    - name: Struct verifier Test Results move
-      if: ${{ always() }}
-      shell: bash
-      working-directory: ${{runner.workspace}}/build
-      run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_StructVerifier.log || true
+      #- name: Struct verifier Test Results move
+      #  if: ${{ always() }}
+      #  shell: bash
+      #  working-directory: ${{runner.workspace}}/build
+      #  run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_StructVerifier.log || true
 
     - name: APITest tests
       working-directory: ${{runner.workspace}}/build

--- a/Source/Tests/LinuxSyscalls/CMakeLists.txt
+++ b/Source/Tests/LinuxSyscalls/CMakeLists.txt
@@ -89,7 +89,8 @@ PRIVATE
 set(HEADERS_TO_VERIFY
   x32/Types.h          x86_32 # This needs to match structs to 32bit structs
   x32/Ioctl/asound.h   x86_32 # This needs to match structs to 32bit structs
-  x32/Ioctl/drm.h      x86_32 # This needs to match structs to 32bit structs
+  # DRM disabled for now while investigation occurs
+  # x32/Ioctl/drm.h      x86_32 # This needs to match structs to 32bit structs
   x32/Ioctl/streams.h  x86_32 # This needs to match structs to 32bit structs
   x32/Ioctl/usbdev.h   x86_32 # This needs to match structs to 32bit structs
   x32/Ioctl/input.h    x86_32 # This needs to match structs to 32bit structs
@@ -104,7 +105,8 @@ math(EXPR ARG_COUNT "${ARG_COUNT}-1")
 set (ARGS
   "-x" "c++"
   "-std=c++20"
-  "-fno-operator-names")
+  "-fno-operator-names"
+  "-I${PROJECT_SOURCE_DIR}/External/drm-headers/include/")
 # Global include directories
 get_directory_property (INC_DIRS INCLUDE_DIRECTORIES)
 list(TRANSFORM INC_DIRS PREPEND "-I")

--- a/unittests/ASM/Disabled_Tests_ARMv8.0
+++ b/unittests/ASM/Disabled_Tests_ARMv8.0
@@ -1,3 +1,9 @@
 # RNG tests unsupported on this runner
 Test_Secondary/09_XX_06.asm
 Test_Secondary/09_XX_07.asm
+
+# Interpreter tests for some atomics are broken on this runner
+# Probably due to clang version changing codegen
+Test_Primary/Primary_23_Atomic16.asm
+Test_Primary/Primary_23_Atomic32.asm
+Test_Primary/Primary_23_Atomic64.asm

--- a/unittests/gvisor-tests/Disabled_Tests
+++ b/unittests/gvisor-tests/Disabled_Tests
@@ -177,3 +177,7 @@ getdents_test
 
 # Flaky
 udp_socket_test
+
+# Needs investigation, breaks on x86 runner
+inotify_test
+proc_net_udp_test

--- a/unittests/gvisor-tests/Known_Failures
+++ b/unittests/gvisor-tests/Known_Failures
@@ -203,3 +203,7 @@ stat_test
 
 # Flaky
 udp_socket_test
+
+# Needs investigation, breaks on x86 runner
+inotify_test
+proc_net_udp_test


### PR DESCRIPTION
Runners have been updated which have caused unit tests to start failing in new interesting ways.
Work around these, will create issues to do a followup on the failures.