### PR TITLE
mtrack: Fixes 32-bit shmat, shmdt tracking, guaranteed invalidation atomicity

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -966,6 +966,9 @@ namespace FEXCore::Context {
   uintptr_t Context::CompileBlock(FEXCore::Core::CpuStateFrame *Frame, uint64_t GuestRIP) {
     auto Thread = Frame->Thread;
 
+    // Needs to be held for SMC interactions around concurrent compile and invalidation hazards
+    auto InvalidationLk = Thread->CTX->SyscallHandler->CompileCodeLock(GuestRIP);
+
     // Is the code in the cache?
     // The backends only check L1 and L2, not L3
     if (auto HostCode = Thread->LookupCache->FindBlock(GuestRIP)) {

--- a/External/FEXCore/include/FEXCore/HLE/SyscallHandler.h
+++ b/External/FEXCore/include/FEXCore/HLE/SyscallHandler.h
@@ -79,6 +79,7 @@ namespace FEXCore::HLE {
     virtual FEXCore::CodeLoader *GetCodeLoader() const { return nullptr; }
     virtual void MarkGuestExecutableRange(uint64_t Start, uint64_t Length) { }
     virtual AOTIRCacheEntryLookupResult LookupAOTIRCacheEntry(uint64_t GuestAddr) = 0;
+    virtual std::shared_lock<std::shared_mutex> CompileCodeLock(uint64_t Start) = 0;
 
   protected:
     SyscallOSABI OSABI;

--- a/Source/Tests/IRLoader.cpp
+++ b/Source/Tests/IRLoader.cpp
@@ -133,14 +133,15 @@ class DummySyscallHandler: public FEXCore::HLE::SyscallHandler {
     return {0, false, 0 };
   }
 
-  std::shared_mutex Mutex;
+  // These are no-ops implementations of the SyscallHandler API
+  std::shared_mutex StubMutex;
   FEXCore::HLE::AOTIRCacheEntryLookupResult LookupAOTIRCacheEntry(uint64_t GuestAddr) override {
-    return {0, 0, FHU::ScopedSignalMaskWithSharedLock {Mutex}};
+    return {0, 0, FHU::ScopedSignalMaskWithSharedLock {StubMutex}};
   }
 
-  std::shared_mutex Mutex2;
+  std::shared_mutex StubMutex2;
   std::shared_lock<std::shared_mutex> CompileCodeLock(uint64_t Start) {
-    return std::shared_lock(Mutex2);
+    return std::shared_lock(StubMutex2);
   }
 };
 

--- a/Source/Tests/IRLoader.cpp
+++ b/Source/Tests/IRLoader.cpp
@@ -137,6 +137,11 @@ class DummySyscallHandler: public FEXCore::HLE::SyscallHandler {
   FEXCore::HLE::AOTIRCacheEntryLookupResult LookupAOTIRCacheEntry(uint64_t GuestAddr) override {
     return {0, 0, FHU::ScopedSignalMaskWithSharedLock {Mutex}};
   }
+
+  std::shared_mutex Mutex2;
+  std::shared_lock<std::shared_mutex> CompileCodeLock(uint64_t Start) {
+    return std::shared_lock(Mutex2);
+  }
 };
 
 int main(int argc, char **argv, char **const envp)

--- a/Source/Tests/LinuxSyscalls/SyscallsSMCTracking.cpp
+++ b/Source/Tests/LinuxSyscalls/SyscallsSMCTracking.cpp
@@ -63,6 +63,10 @@ bool SyscallHandler::HandleSegfault(FEXCore::Core::InternalThreadState *Thread, 
 
     auto FaultBase = FEXCore::AlignDown(FaultAddress, FHU::FEX_PAGE_SIZE);
 
+    // take lock, no code compilation happens between invalidation and prot change
+    // no need for signal mask, we have an outer one
+    std::unique_lock lk2(VMATracking->InvalidationMutex);
+
     if (Entry->second.Flags.Shared) {
       LOGMAN_THROW_A_FMT(Entry->second.Resource, "VMA tracking error");
 
@@ -75,23 +79,25 @@ bool SyscallHandler::HandleSegfault(FEXCore::Core::InternalThreadState *Thread, 
       do {
         if (VMA->Offset <= Offset && (VMA->Offset + VMA->Length) > Offset) {
           auto FaultBaseMirrored = Offset - VMA->Offset + VMA->Base;
+          FEXCore::Context::InvalidateGuestCodeRange(CTX, FaultBaseMirrored, FHU::FEX_PAGE_SIZE);
           if (VMA->Prot.Writable) {
             auto rv = mprotect((void *)FaultBaseMirrored, FHU::FEX_PAGE_SIZE, PROT_READ | PROT_WRITE);
             LogMan::Throw::AFmt(rv == 0, "mprotect({}, {}) failed", FaultBaseMirrored, FHU::FEX_PAGE_SIZE);
           }
-          FEXCore::Context::InvalidateGuestCodeRange(CTX, FaultBaseMirrored, FHU::FEX_PAGE_SIZE);
         }
       } while ((VMA = VMA->ResourceNextVMA));
     } else {
-      // Mark as read write before flush, so that if code is compiled after the Flush but before returning, the segfault will be
-      // re-raised
+      FEXCore::Context::InvalidateGuestCodeRange(CTX, FaultBase, FHU::FEX_PAGE_SIZE);
       auto rv = mprotect((void *)FaultBase, FHU::FEX_PAGE_SIZE, PROT_READ | PROT_WRITE);
       LogMan::Throw::AFmt(rv == 0, "mprotect({}, {}) failed", FaultBase, FHU::FEX_PAGE_SIZE);
-      FEXCore::Context::InvalidateGuestCodeRange(CTX, FaultBase, FHU::FEX_PAGE_SIZE);
     }
 
     return true;
   }
+}
+
+std::shared_lock<std::shared_mutex> SyscallHandler::CompileCodeLock(uint64_t Start) {
+  return std::shared_lock(VMATracking.InvalidationMutex);
 }
 
 void SyscallHandler::MarkGuestExecutableRange(uint64_t Start, uint64_t Length) {

--- a/Source/Tests/LinuxSyscalls/x32/Memory.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Memory.cpp
@@ -112,6 +112,7 @@ namespace FEX::HLE::x32 {
     });
 
     REGISTER_SYSCALL_IMPL_X32(shmat, [](FEXCore::Core::CpuStateFrame *Frame, int shmid, const void *shmaddr, int shmflg) -> uint64_t {
+      // also implemented in ipc:OP_SHMAT
       uint32_t ResultAddr{};
       uint64_t Result = static_cast<FEX::HLE::x32::x32SyscallHandler*>(FEX::HLE::_SyscallHandler)->GetAllocator()->
           shmat(shmid, reinterpret_cast<const void*>(shmaddr), shmflg, &ResultAddr);
@@ -126,6 +127,7 @@ namespace FEX::HLE::x32 {
     });
 
     REGISTER_SYSCALL_IMPL_X32(shmdt, [](FEXCore::Core::CpuStateFrame *Frame, const void *shmaddr) -> uint64_t {
+      // also implemented in ipc:OP_SHMDT
       uint64_t Result = static_cast<FEX::HLE::x32::x32SyscallHandler*>(FEX::HLE::_SyscallHandler)->GetAllocator()->
         shmdt(shmaddr);
       

--- a/Source/Tests/LinuxSyscalls/x32/Semaphore.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Semaphore.cpp
@@ -279,13 +279,21 @@ namespace FEX::HLE::x32 {
         break;
       }
       case OP_SHMAT: {
+        // also implemented in memory:shmat
         Result = static_cast<FEX::HLE::x32::x32SyscallHandler*>(FEX::HLE::_SyscallHandler)->GetAllocator()->
           shmat(first, reinterpret_cast<const void*>(ptr), second, reinterpret_cast<uint32_t*>(third));
+        if (!FEX::HLE::HasSyscallError(Result)) {
+          FEX::HLE::_SyscallHandler->TrackShmat(first, *reinterpret_cast<uint32_t*>(third), second);
+        }
         break;
       }
       case OP_SHMDT: {
+        // also implemented in memory:shmdt
         Result = static_cast<FEX::HLE::x32::x32SyscallHandler*>(FEX::HLE::_SyscallHandler)->GetAllocator()->
           shmdt(reinterpret_cast<void*>(ptr));
+        if (!FEX::HLE::HasSyscallError(Result)) {
+          FEX::HLE::_SyscallHandler->TrackShmdt(ptr);
+        }
         break;
       }
       case OP_SHMGET: {


### PR DESCRIPTION
#### Overview

- Fixes 32-bit shmat, shmdt tracking when called through ipc syscall, that path missed before.

- Adds an extra lock to guarantee that invalidations happen either before or after a block has been compiled, but never during compilation. It is still possible to compile stale code if the code gets modified while being compiled, as the mprotect locks are only applied after successful compilation.

Both of these corner cases were uncovered by the FLT PR, #1737

#### Details
A shared mutex is used so that there is no contention penalty while there are no invalidations.

Locking pattern
- Around Compilation  -> lock shared
- Around Invalidation -> lock unique