### PR TITLE
Struct verifier fixes and reenable

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -131,16 +131,16 @@ jobs:
       working-directory: ${{runner.workspace}}/build
       run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_GCC32.log || true
 
-      #- name: Struct verifier tests
-      #  working-directory: ${{runner.workspace}}/build
-      #  shell: bash
-      #  run: cmake --build . --config $BUILD_TYPE --target struct_verifier
+    - name: Struct verifier tests
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      run: cmake --build . --config $BUILD_TYPE --target struct_verifier
 
-      #- name: Struct verifier Test Results move
-      #  if: ${{ always() }}
-      #  shell: bash
-      #  working-directory: ${{runner.workspace}}/build
-      #  run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_StructVerifier.log || true
+    - name: Struct verifier Test Results move
+      if: ${{ always() }}
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_StructVerifier.log || true
 
     - name: APITest tests
       working-directory: ${{runner.workspace}}/build

--- a/Source/Tests/LinuxSyscalls/CMakeLists.txt
+++ b/Source/Tests/LinuxSyscalls/CMakeLists.txt
@@ -89,8 +89,7 @@ PRIVATE
 set(HEADERS_TO_VERIFY
   x32/Types.h          x86_32 # This needs to match structs to 32bit structs
   x32/Ioctl/asound.h   x86_32 # This needs to match structs to 32bit structs
-  # DRM disabled for now while investigation occurs
-  # x32/Ioctl/drm.h      x86_32 # This needs to match structs to 32bit structs
+  x32/Ioctl/drm.h      x86_32 # This needs to match structs to 32bit structs
   x32/Ioctl/streams.h  x86_32 # This needs to match structs to 32bit structs
   x32/Ioctl/usbdev.h   x86_32 # This needs to match structs to 32bit structs
   x32/Ioctl/input.h    x86_32 # This needs to match structs to 32bit structs

--- a/Source/Tests/LinuxSyscalls/x32/IoctlEmulation.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/IoctlEmulation.cpp
@@ -18,10 +18,6 @@
 
 #include <cstdint>
 #include <functional>
-extern "C" {
-#include <drm/drm.h>
-#include <drm/msm_drm.h>
-}
 #include <sys/ioctl.h>
 #include <sys/syscall.h>
 #include <unistd.h>

--- a/Source/Tests/LinuxSyscalls/x64/Ioctl/drm.h
+++ b/Source/Tests/LinuxSyscalls/x64/Ioctl/drm.h
@@ -6,16 +6,19 @@
 #include "Tests/LinuxSyscalls/x64/Ioctl/HelperDefines.h"
 
 #include <cstdint>
-#include <drm/drm.h>
-#include <drm/drm_mode.h>
-#include <drm/i915_drm.h>
-#include <drm/amdgpu_drm.h>
-#include <drm/lima_drm.h>
-#include <drm/panfrost_drm.h>
-#include <drm/msm_drm.h>
-#include <drm/nouveau_drm.h>
-#include <drm/vc4_drm.h>
-#include <drm/v3d_drm.h>
+extern "C" {
+#include "fex-drm/drm.h"
+#include "fex-drm/drm_mode.h"
+#include "fex-drm/i915_drm.h"
+#include "fex-drm/amdgpu_drm.h"
+#include "fex-drm/lima_drm.h"
+#include "fex-drm/panfrost_drm.h"
+#include "fex-drm/msm_drm.h"
+#include "fex-drm/nouveau_drm.h"
+#include "fex-drm/vc4_drm.h"
+#include "fex-drm/v3d_drm.h"
+#include "fex-drm/virtgpu_drm.h"
+}
 #include <sys/ioctl.h>
 
 #define CPYT(x) val.x = x


### PR DESCRIPTION
Multiple problems here.
System drm headers were being used instead of our provided external ones. Not sure when this broke but must have been at least half a year.

Fixed definition of a v3d ioctl, which has its own problems but as far as I currently understand, it's an ABI break.

Fixes #1740 