### PR TITLE
unittests: Investigate failing CI changes

### DIFF
--- a/unittests/gvisor-tests/Disabled_Tests
+++ b/unittests/gvisor-tests/Disabled_Tests
@@ -178,6 +178,9 @@ getdents_test
 # Flaky
 udp_socket_test
 
-# Needs investigation, breaks on x86 runner
-inotify_test
+# This test checks for the header layout from `/proc/net/udp` which has changed slightly with newer kernels
 proc_net_udp_test
+
+# This test is broken since kernel commit: 36e2c7421f02
+# Upstream gvisor has the offending tests removed
+inotify_test

--- a/unittests/gvisor-tests/Known_Failures
+++ b/unittests/gvisor-tests/Known_Failures
@@ -204,6 +204,9 @@ stat_test
 # Flaky
 udp_socket_test
 
-# Needs investigation, breaks on x86 runner
-inotify_test
+# This test checks for the header layout from `/proc/net/udp` which has changed slightly with newer kernels
 proc_net_udp_test
+
+# This test is broken since kernel commit: 36e2c7421f02
+# Upstream gvisor has the offending tests removed
+inotify_test


### PR DESCRIPTION
One gvisor test didn't expect a file header to change layout.
Another one was testing behaviour that was removed from upstream Linux

Fixes #1741