### PR TITLE
unittests: Reenable atomic tests on ARMv8.0

### DIFF
--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64.h
@@ -31,13 +31,19 @@ namespace FEXCore::ArchHelpers::Arm64 {
   constexpr uint32_t CBNZ_MASK = 0x7F'00'00'00;
   constexpr uint32_t CBNZ_INST = 0x35'00'00'00;
 
-  constexpr uint32_t ALU_OP_MASK = 0x7F'00'00'00;
-  constexpr uint32_t ADD_INST    = 0x0B'00'00'00;
-  constexpr uint32_t SUB_INST    = 0x4B'00'00'00;
-  constexpr uint32_t CMP_INST    = 0x6B'00'00'00;
-  constexpr uint32_t AND_INST    = 0x0A'00'00'00;
-  constexpr uint32_t OR_INST     = 0x2A'00'00'00;
-  constexpr uint32_t EOR_INST    = 0x4A'00'00'00;
+  constexpr uint32_t ALU_OP_MASK    = 0x7F'20'00'00;
+  constexpr uint32_t ADD_INST       = 0x0B'00'00'00;
+  constexpr uint32_t SUB_INST       = 0x4B'00'00'00;
+  constexpr uint32_t ADD_SHIFT_INST = 0x0B'20'00'00;
+  constexpr uint32_t SUB_SHIFT_INST = 0x4B'20'00'00;
+  constexpr uint32_t CMP_INST       = 0x6B'00'00'00;
+  constexpr uint32_t CMP_SHIFT_INST = 0x6B'20'00'00;
+  constexpr uint32_t AND_INST       = 0x0A'00'00'00;
+  constexpr uint32_t BIC_INST       = 0x0A'20'00'00;
+  constexpr uint32_t OR_INST        = 0x2A'00'00'00;
+  constexpr uint32_t ORN_INST       = 0x2A'20'00'00;
+  constexpr uint32_t EOR_INST       = 0x4A'00'00'00;
+  constexpr uint32_t EON_INST       = 0x4A'20'00'00;
 
   constexpr uint32_t CCMP_MASK   = 0x7F'E0'0C'10;
   constexpr uint32_t CCMP_INST   = 0x7A'40'00'00;
@@ -50,8 +56,11 @@ namespace FEXCore::ArchHelpers::Arm64 {
     TYPE_ADD,
     TYPE_SUB,
     TYPE_AND,
+    TYPE_BIC,
     TYPE_OR,
+    TYPE_ORN,
     TYPE_EOR,
+    TYPE_EON,
     TYPE_NEG, // This is just a sub with zero. Need to know the differences
   };
 

--- a/unittests/ASM/Disabled_Tests_ARMv8.0
+++ b/unittests/ASM/Disabled_Tests_ARMv8.0
@@ -1,9 +1,3 @@
 # RNG tests unsupported on this runner
 Test_Secondary/09_XX_06.asm
 Test_Secondary/09_XX_07.asm
-
-# Interpreter tests for some atomics are broken on this runner
-# Probably due to clang version changing codegen
-Test_Primary/Primary_23_Atomic16.asm
-Test_Primary/Primary_23_Atomic32.asm
-Test_Primary/Primary_23_Atomic64.asm


### PR DESCRIPTION
The latest ARMv8.0 toolchain is implementing fetch_add with a bic rather
than an and. Not sure why they started doing this but support the
remaining logical operations in our unaligned atomics handler.

Fixes the Interpreter ARMv8.0 atomic ops.

Fixes https://github.com/FEX-Emu/FEX/issues/1742