### PR TITLE
TSO: Add auto migration optimisation for applications that don't need TSO

### DIFF
--- a/External/FEXCore/Source/Interface/Config/Config.json.in
+++ b/External/FEXCore/Source/Interface/Config/Config.json.in
@@ -260,6 +260,14 @@
           "Highly likely to break any multithreaded application if disabled."
         ]
       },
+      "TSOAutoMigration": {
+        "Type": "bool",
+        "Default": "true",
+        "Desc": [
+          "Automatically enables TSO when shared memory is used.",
+          "Should work without issues in most cases."
+        ]
+      },
       "X87ReducedPrecision": {
         "Type": "bool",
         "Default": "false",

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -86,6 +86,7 @@ namespace FEXCore::Context {
       FEX_CONFIG_OPT(GdbServer, GDBSERVER);
       FEX_CONFIG_OPT(Is64BitMode, IS64BIT_MODE);
       FEX_CONFIG_OPT(TSOEnabled, TSOENABLED);
+      FEX_CONFIG_OPT(TSOAutoMigration, TSOAUTOMIGRATION);
       FEX_CONFIG_OPT(ABILocalFlags, ABILOCALFLAGS);
       FEX_CONFIG_OPT(ABINoPF, ABINOPF);
       FEX_CONFIG_OPT(AOTIRCapture, AOTIRCAPTURE);
@@ -297,6 +298,10 @@ namespace FEXCore::Context {
     FEXCore::Utils::PooledAllocatorMMap OpDispatcherAllocator;
     FEXCore::Utils::PooledAllocatorMMap FrontendAllocator;
 
+    void MarkMemoryShared();
+
+    bool IsTSOEnabled() { return (IsMemoryShared || !Config.TSOAutoMigration) && Config.TSOEnabled; }
+
   protected:
     void ClearCodeCache(FEXCore::Core::InternalThreadState *Thread, bool AlsoClearIRCache);
 
@@ -335,6 +340,7 @@ namespace FEXCore::Context {
     std::unique_ptr<FEXCore::CodeSerialize::CodeObjectSerializeService> CodeObjectCacheService;
 
     bool StartPaused = false;
+    bool IsMemoryShared = false;
     FEX_CONFIG_OPT(AppFilename, APP_FILENAME);
   };
 

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -1236,14 +1236,14 @@ private:
   uint64_t Entry;
 
   OrderedNode* _StoreMemAutoTSO(FEXCore::IR::RegisterClassType Class, uint8_t Size, OrderedNode *Addr, OrderedNode *Value, uint8_t Align = 1) {
-    if (CTX->Config.TSOEnabled)
+    if (CTX->IsTSOEnabled())
       return _StoreMemTSO(Class, Size, Value, Addr, Invalid(), Align, MEM_OFFSET_SXTX, 1);
     else
       return _StoreMem(Class, Size, Value, Addr, Invalid(), Align, MEM_OFFSET_SXTX, 1);
   }
 
   OrderedNode* _LoadMemAutoTSO(FEXCore::IR::RegisterClassType Class, uint8_t Size, OrderedNode *ssa0, uint8_t Align = 1) {
-    if (CTX->Config.TSOEnabled)
+    if (CTX->IsTSOEnabled())
       return _LoadMemTSO(Class, Size, ssa0, Invalid(), Align, MEM_OFFSET_SXTX, 1);
     else
       return _LoadMem(Class, Size, ssa0, Invalid(), Align, MEM_OFFSET_SXTX, 1);

--- a/External/FEXCore/include/FEXCore/Core/Context.h
+++ b/External/FEXCore/include/FEXCore/Core/Context.h
@@ -250,6 +250,7 @@ namespace FEXCore::Context {
   FEX_DEFAULT_VISIBILITY void FinalizeAOTIRCache(FEXCore::Context::Context *CTX);
   FEX_DEFAULT_VISIBILITY void WriteFilesWithCode(FEXCore::Context::Context *CTX, std::function<void(const std::string& fileid, const std::string& filename)> Writer);
   FEX_DEFAULT_VISIBILITY void InvalidateGuestCodeRange(FEXCore::Context::Context *CTX, uint64_t Start, uint64_t Length);
+  FEX_DEFAULT_VISIBILITY void MarkMemoryShared(FEXCore::Context::Context *CTX);
 
   FEX_DEFAULT_VISIBILITY void ConfigureAOTGen(FEXCore::Core::InternalThreadState *Thread, std::set<uint64_t> *ExternalBranches, uint64_t SectionMaxAddress);
 }

--- a/Source/Tests/LinuxSyscalls/Syscalls.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls.cpp
@@ -438,6 +438,10 @@ uint64_t CloneHandler(FEXCore::Core::CpuStateFrame *Frame, FEX::HLE::clone3_args
     return false;
   };
 
+  if (flags & CLONE_VM) {
+    MarkMemoryShared(Frame->Thread->CTX);
+  }
+
   // If there are flags that can't be handled regularly then we need to hand off to the true clone handler
   if (HasUnhandledFlags(args)) {
     if (!AnyFlagsSet(flags, CLONE_THREAD)) {

--- a/Source/Tests/LinuxSyscalls/SyscallsSMCTracking.cpp
+++ b/Source/Tests/LinuxSyscalls/SyscallsSMCTracking.cpp
@@ -189,6 +189,10 @@ static std::string get_fdpath(int fd) {
 void SyscallHandler::TrackMmap(uintptr_t Base, uintptr_t Size, int Prot, int Flags, int fd, off_t Offset) {
 	Size = FEXCore::AlignUp(Size, FHU::FEX_PAGE_SIZE);
 
+  if (Flags & MAP_SHARED) {
+    MarkMemoryShared(CTX);
+  }
+
   {
     FHU::ScopedSignalMaskWithUniqueLock lk(_SyscallHandler->VMATracking.Mutex);
 
@@ -311,6 +315,8 @@ void SyscallHandler::TrackMremap(uintptr_t OldAddress, size_t OldSize, size_t Ne
 }
 
 void SyscallHandler::TrackShmat(int shmid, uintptr_t Base, int shmflg) {
+  MarkMemoryShared(CTX);
+
   shmid_ds stat;
 
   auto res = shmctl(shmid, IPC_STAT, &stat);


### PR DESCRIPTION
#### Overview
Single threaded applications that don't use shared memory don't need TSO to be enabled. This is often the case with many command line applications like `bash`, `uname`, most executions of `python/3` and many others.

For those cases, we can generate non-tso code, and switch to tso mode once they might do shared memory operations.

This introduces a new configuration, `TSOAutoMigration`, that controls this optimisation and is by default enabled.

This optimisation was inspired by qemu, that also implements the same optimisation.

#### Details
- Adds `TSOAutoMigration:bool=true` configuration
- Adds `void Context::MarkMemoryShared()` that does the migration and sets the `Context::IsMemoryShared` flag
- Adds `void MarkMemoryShared(FEXCore::Context::Context *CTX)` wrapper
- Adds `bool Context::IsTSOEnabled()` that returns true if TSO ops need to be emitted, taking into account `Context::IsMemoryShared` as well as `Config.TSOAutoMigration` and `Config.TSOEnabled`
- Modifies `OpDispatchBuilder::_StoreMemAutoTSO` and `OpDispatchBuilder::_LoadMemAutoTSO` to use `Context::IsTSOEnabled()`
- Modifies `CloneHandler` to call `MarkMemoryShared` if `CLONE_VM` is set
- Modifies `TrackMmap` to call `MarkMemoryShared` if `MAP_SHARED` is set
- Modifies `TrackShmat` to always call `MarkMemoryShared`

#### Complications
This makes IR and OBJ caching somewhat more involved, as we might have to migrate caching files during execution. This is not handled in this PR, and `TSOAutoMigration` should be turned off for those use cases.


This might also have issues with some corner cases around migrations.

If shared mode is entered while a signal return is pending, the signal return depends on the existing code cache not going away. In order to mitigate this, only the lookup and IR caches are invalidated, but not the code caches. This means non-tso code might run but a short while after signal return, even if shared mode has been entered.

Also, another edge case is when rest of the fragment right after `clone`, `mmap` `ipc` or `shmat` does some memory operation that needs to be TSO. This could be avoided if those were made (optional?) redispatches, at a small performance cost, and might be something we want to do in the future.