### PR TITLE
Tests/IRLoader: Silence missing override warning

### DIFF
--- a/Source/Tests/IRLoader.cpp
+++ b/Source/Tests/IRLoader.cpp
@@ -140,7 +140,7 @@ class DummySyscallHandler: public FEXCore::HLE::SyscallHandler {
   }
 
   std::shared_mutex StubMutex2;
-  std::shared_lock<std::shared_mutex> CompileCodeLock(uint64_t Start) {
+  std::shared_lock<std::shared_mutex> CompileCodeLock(uint64_t Start) override {
     return std::shared_lock(StubMutex2);
   }
 };


### PR DESCRIPTION
Fixes a warning that slipped through