### PR TITLE
IR: add IsFragmentExit, IsBlockExit

### DIFF
--- a/External/FEXCore/Source/Interface/IR/IREmitter.cpp
+++ b/External/FEXCore/Source/Interface/IR/IREmitter.cpp
@@ -16,6 +16,27 @@ $end_info$
 #include <vector>
 
 namespace FEXCore::IR {
+
+bool IsFragmentExit(FEXCore::IR::IROps Op) {
+  switch (Op) {
+    case OP_EXITFUNCTION:
+    case OP_BREAK:
+      return true;
+    default:
+    return false;
+  }
+}
+
+bool IsBlockExit(FEXCore::IR::IROps Op) {
+  switch(Op) {
+    case OP_JUMP:
+    case OP_CONDJUMP:
+      return true;
+    default:
+      return IsFragmentExit(Op);
+  }
+}
+
 FEXCore::IR::RegisterClassType IREmitter::WalkFindRegClass(OrderedNode *Node) {
   auto Class = GetOpRegClass(Node);
   switch (Class) {

--- a/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
@@ -244,16 +244,10 @@ bool IRValidation::Run(IREmitter *IREmit) {
       // Blocks need to have an instruction that leaves the block in some way before the EndBlock instruction
       {
         auto Op = GetOp(CodeCurrent);
-        switch (Op) {
-          case OP_EXITFUNCTION:
-          case OP_JUMP:
-          case OP_CONDJUMP:
-          case OP_BREAK:
-            break;
-          default:
-            HadError |= true;
-            Errors << "%ssa" << BlockID << " Didn't have an exit IR op as its last instruction" << std::endl;
-        };
+        if (!IsBlockExit(Op)) {
+          HadError |= true;
+          Errors << "%ssa" << BlockID << " Didn't have a block exit IR op as its last instruction" << std::endl;
+        }
       }
     }
   }

--- a/External/FEXCore/include/FEXCore/IR/IR.h
+++ b/External/FEXCore/include/FEXCore/IR/IR.h
@@ -16,6 +16,7 @@
 #include <fmt/format.h>
 
 namespace FEXCore::IR {
+
 class OrderedNode;
 class RegisterAllocationPass;
 class RegisterAllocationData;
@@ -567,6 +568,9 @@ template<typename Type>
 inline NodeID NodeWrapperBase<Type>::ID() const {
   return NodeID(NodeOffset / sizeof(IR::OrderedNode));
 }
+
+bool IsFragmentExit(FEXCore::IR::IROps Op);
+bool IsBlockExit(FEXCore::IR::IROps Op);
 
 } // namespace FEXCore::IR
 


### PR DESCRIPTION
#### Overview
This is the start of the plan to move all such helpers to common functions, so that when semantics change we don't have to change all the optimisation passes manually.