### PR TITLE
OpcodeDispatcher: Handle CLMUL opcode extension

### DIFF
--- a/External/FEXCore/Source/Interface/Core/CPUID.cpp
+++ b/External/FEXCore/Source/Interface/Core/CPUID.cpp
@@ -416,7 +416,7 @@ FEXCore::CPUID::FunctionResults CPUIDEmu::Function_01h(uint32_t Leaf) {
 
   Res.ecx =
     (1 <<  0) | // SSE3
-    (0 <<  1) | // PCLMULQDQ
+    (1 <<  1) | // PCLMULQDQ
     (1 <<  2) | // DS area supports 64bit layout
     (1 <<  3) | // MWait
     (0 <<  4) | // DS-CPL

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -284,6 +284,7 @@ constexpr OpHandlerArray InterpreterOpHandlers = [] {
   REGISTER_OP(VAESDECLAST,            AESDecLast);
   REGISTER_OP(VAESKEYGENASSIST,       AESKeyGenAssist);
   REGISTER_OP(CRC32,                  CRC32);
+  REGISTER_OP(PCLMUL,                 PCLMUL);
 
   // F80 ops
   REGISTER_OP(F80LOADFCW,             F80LOADFCW);

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
@@ -304,6 +304,7 @@ namespace FEXCore::CPU {
   DEF_OP(AESDecLast);
   DEF_OP(AESKeyGenAssist);
   DEF_OP(CRC32);
+  DEF_OP(PCLMUL);
 
   ///< F80 ops
   DEF_OP(F80LOADFCW);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/EncryptionOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/EncryptionOps.cpp
@@ -102,16 +102,45 @@ DEF_OP(CRC32) {
   }
 }
 
+DEF_OP(PCLMUL) {
+  auto Op = IROp->C<IR::IROp_PCLMUL>();
+
+  auto Dst  = GetDst(Node).Q();
+  auto Src1 = GetSrc(Op->Src1.ID()).V2D();
+  auto Src2 = GetSrc(Op->Src2.ID()).V2D();
+
+  switch (Op->Selector) {
+  case 0b00000000:
+    pmull(Dst, Src1, Src2);
+    break;
+  case 0b00000001:
+    mov(VTMP1.V2D(), Src1, 1);
+    pmull(Dst, VTMP1.V2D(), Src2);
+    break;
+  case 0b00010000:
+    mov(VTMP1.V2D(), Src2, 1);
+    pmull(Dst, VTMP1.V2D(), Src1);
+    break;
+  case 0b00010001:
+    pmull2(Dst, Src1, Src2);
+    break;
+  default:
+    LOGMAN_MSG_A_FMT("Unknown PCLMUL selector: {}", Op->Selector);
+    break;
+  }
+}
+
 #undef DEF_OP
 void Arm64JITCore::RegisterEncryptionHandlers() {
 #define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &Arm64JITCore::Op_##x
-  REGISTER_OP(VAESIMC,     AESImc);
-  REGISTER_OP(VAESENC,     AESEnc);
-  REGISTER_OP(VAESENCLAST, AESEncLast);
-  REGISTER_OP(VAESDEC,     AESDec);
-  REGISTER_OP(VAESDECLAST, AESDecLast);
-  REGISTER_OP(VAESKEYGENASSIST, AESKeyGenAssist);
+  REGISTER_OP(VAESIMC,           AESImc);
+  REGISTER_OP(VAESENC,           AESEnc);
+  REGISTER_OP(VAESENCLAST,       AESEncLast);
+  REGISTER_OP(VAESDEC,           AESDec);
+  REGISTER_OP(VAESDECLAST,       AESDecLast);
+  REGISTER_OP(VAESKEYGENASSIST,  AESKeyGenAssist);
   REGISTER_OP(CRC32,             CRC32);
+  REGISTER_OP(PCLMUL,            PCLMUL);
 #undef REGISTER_OP
 }
 }

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -437,6 +437,7 @@ private:
   DEF_OP(AESDecLast);
   DEF_OP(AESKeyGenAssist);
   DEF_OP(CRC32);
+  DEF_OP(PCLMUL);
 #undef DEF_OP
 };
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/EncryptionOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/EncryptionOps.cpp
@@ -75,16 +75,37 @@ DEF_OP(CRC32) {
   }
 }
 
+DEF_OP(PCLMUL) {
+  auto Op = IROp->C<IR::IROp_PCLMUL>();
+
+  auto Dst = GetDst(Node);
+  auto Src1 = GetSrc(Op->Src1.ID());
+  auto Src2 = GetSrc(Op->Src2.ID());
+
+  switch (Op->Selector) {
+  case 0b00000000:
+  case 0b00000001:
+  case 0b00010000:
+  case 0b00010001:
+    vpclmulqdq(Dst, Src1, Src2, Op->Selector);
+    break;
+  default:
+    LOGMAN_MSG_A_FMT("Unknown PCLMUL selector: {}", Op->Selector);
+    break;
+  }
+}
+
 #undef DEF_OP
 void X86JITCore::RegisterEncryptionHandlers() {
 #define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &X86JITCore::Op_##x
-  REGISTER_OP(VAESIMC,     AESImc);
-  REGISTER_OP(VAESENC,     AESEnc);
-  REGISTER_OP(VAESENCLAST, AESEncLast);
-  REGISTER_OP(VAESDEC,     AESDec);
-  REGISTER_OP(VAESDECLAST, AESDecLast);
-  REGISTER_OP(VAESKEYGENASSIST, AESKeyGenAssist);
+  REGISTER_OP(VAESIMC,           AESImc);
+  REGISTER_OP(VAESENC,           AESEnc);
+  REGISTER_OP(VAESENCLAST,       AESEncLast);
+  REGISTER_OP(VAESDEC,           AESDec);
+  REGISTER_OP(VAESDECLAST,       AESDecLast);
+  REGISTER_OP(VAESKEYGENASSIST,  AESKeyGenAssist);
   REGISTER_OP(CRC32,             CRC32);
+  REGISTER_OP(PCLMUL,            PCLMUL);
 #undef REGISTER_OP
 }
 }

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -491,6 +491,7 @@ private:
   DEF_OP(AESDecLast);
   DEF_OP(AESKeyGenAssist);
   DEF_OP(CRC32);
+  DEF_OP(PCLMUL);
 #undef DEF_OP
 };
 

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -6650,6 +6650,8 @@ constexpr uint16_t PF_F2 = 3;
     {OPD(2, 0b10, 0xF7), 1, &OpDispatchBuilder::BMI2Shift},
     {OPD(2, 0b11, 0xF7), 1, &OpDispatchBuilder::BMI2Shift},
 
+    {OPD(3, 0b01, 0x44), 1, &OpDispatchBuilder::VPCLMULQDQOp},
+
     {OPD(3, 0b11, 0xF0), 1, &OpDispatchBuilder::RORX},
   };
 #undef OPD

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -6566,6 +6566,7 @@ constexpr uint16_t PF_F2 = 3;
     {OPD(0, PF_3A_66,   0x40), 1, &OpDispatchBuilder::DPPOp<4>},
     {OPD(0, PF_3A_66,   0x41), 1, &OpDispatchBuilder::DPPOp<8>},
     {OPD(0, PF_3A_66,   0x42), 1, &OpDispatchBuilder::MPSADBWOp},
+    {OPD(0, PF_3A_66,   0x44), 1, &OpDispatchBuilder::PCLMULQDQOp},
 
     {OPD(0, PF_3A_NONE, 0xCC), 1, &OpDispatchBuilder::SHA1RNDS4Op},
   };

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -622,6 +622,7 @@ public:
 
   void MPSADBWOp(OpcodeArgs);
   void PCLMULQDQOp(OpcodeArgs);
+  void VPCLMULQDQOp(OpcodeArgs);
 
   void CRC32(OpcodeArgs);
 

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -621,6 +621,7 @@ public:
   void DPPOp(OpcodeArgs);
 
   void MPSADBWOp(OpcodeArgs);
+  void PCLMULQDQOp(OpcodeArgs);
 
   void CRC32(OpcodeArgs);
 

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Crypto.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Crypto.cpp
@@ -317,4 +317,15 @@ void OpDispatchBuilder::PCLMULQDQOp(OpcodeArgs) {
   StoreResult(FPRClass, Op, Res, -1);
 }
 
+void OpDispatchBuilder::VPCLMULQDQOp(OpcodeArgs) {
+  LOGMAN_THROW_A_FMT(Op->Src[2].IsLiteral(), "Selector needs to be literal here");
+
+  OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags, -1);
+  const auto Selector = static_cast<uint8_t>(Op->Src[2].Data.Literal.Value);
+
+  auto Res = _PCLMUL(Src1, Src2, Selector);
+  StoreResult(FPRClass, Op, Res, -1);
+}
+
 }

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Crypto.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Crypto.cpp
@@ -306,4 +306,15 @@ void OpDispatchBuilder::AESKeyGenAssist(OpcodeArgs) {
   StoreResult(FPRClass, Op, Res, -1);
 }
 
+void OpDispatchBuilder::PCLMULQDQOp(OpcodeArgs) {
+  LOGMAN_THROW_A_FMT(Op->Src[1].IsLiteral(), "Selector needs to be literal here");
+
+  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  const auto Selector = static_cast<uint8_t>(Op->Src[1].Data.Literal.Value);
+
+  auto Res = _PCLMUL(Dest, Src, Selector);
+  StoreResult(FPRClass, Op, Res, -1);
+}
+
 }

--- a/External/FEXCore/Source/Interface/Core/X86Tables/H0F3ATables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/H0F3ATables.cpp
@@ -42,7 +42,7 @@ void InitializeH0F3ATables(Context::OperatingMode Mode) {
     {OPD(0, PF_3A_66,   0x40), 1, X86InstInfo{"DPPS",            TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS, 1, nullptr}},
     {OPD(0, PF_3A_66,   0x41), 1, X86InstInfo{"DPPD",            TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS, 1, nullptr}},
     {OPD(0, PF_3A_66,   0x42), 1, X86InstInfo{"MPSADBW",         TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS, 1, nullptr}},
-    {OPD(0, PF_3A_66,   0x44), 1, X86InstInfo{"PCLMULQDQ",       TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
+    {OPD(0, PF_3A_66,   0x44), 1, X86InstInfo{"PCLMULQDQ",       TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS, 1, nullptr}},
 
     {OPD(0, PF_3A_66,   0x60), 1, X86InstInfo{"PCMPESTRM",       TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
     {OPD(0, PF_3A_66,   0x61), 1, X86InstInfo{"PCMPESTRI",       TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},

--- a/External/FEXCore/Source/Interface/Core/X86Tables/VEXTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/VEXTables.cpp
@@ -441,7 +441,7 @@ void InitializeVEXTables() {
     {OPD(3, 0b01, 0x40), 1, X86InstInfo{"VDPPS", TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
     {OPD(3, 0b01, 0x41), 1, X86InstInfo{"VDPPD", TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
     {OPD(3, 0b01, 0x42), 1, X86InstInfo{"VMPSADBW", TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
-    {OPD(3, 0b01, 0x44), 1, X86InstInfo{"VPCLMULQDQ", TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
+    {OPD(3, 0b01, 0x44), 1, X86InstInfo{"VPCLMULQDQ", TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_VEX_1ST_SRC | FLAGS_XMM_FLAGS, 1, nullptr}},
     {OPD(3, 0b01, 0x46), 1, X86InstInfo{"VPERM2I128", TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
 
     {OPD(3, 0b01, 0x48), 1, X86InstInfo{"VPERMILzz2PS", TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -1481,6 +1481,16 @@
         "Desc": ["CRC32 using polynomial 0x1EDC6F41"
                 ],
         "DestSize": "std::max<uint8_t>(4, GetOpSize(_Src1))"
+      },
+      "FPR = PCLMUL FPR:$Src1, FPR:$Src2, u8:$Selector": {
+        "Desc": [
+          "Performs carryless multiplication of 64-bit elements depending on the selector.",
+          "Selector = 0b00000000: Uses low 64-bit elements from both input vectors",
+          "Selector = 0b00000001: Uses high 64-bit element from Src1 and low 64-bit element from Src2",
+          "Selector = 0b00010000: Uses low 64-bit element from Src1 and high 64-bit element from Src2",
+          "Selector = 0b00010001: Uses high 64-bit elements from both input vectors"
+        ],
+        "DestSize": "16"
       }
     },
     "F64": {

--- a/External/FEXCore/include/FEXCore/Debug/X86Tables.h
+++ b/External/FEXCore/include/FEXCore/Debug/X86Tables.h
@@ -186,7 +186,7 @@ struct DecodedInst {
   bool DecodedSIB;
 
   DecodedOperand Dest;
-  DecodedOperand Src[2];
+  DecodedOperand Src[3];
 
   // Constains the dispatcher handler pointer
   X86InstInfo const* TableInfo;

--- a/unittests/ASM/H0F3A/pclmulqdq.asm
+++ b/unittests/ASM/H0F3A/pclmulqdq.asm
@@ -1,0 +1,37 @@
+%ifdef CONFIG
+{
+  "RegData": {
+      "XMM1": ["0x1E2017C5BEE29400", "0x38358E40CC367C7A"],
+      "XMM2": ["0x6868C3F3AAED56E0", "0xF0FCE9E294E6E6DE"],
+      "XMM3": ["0xE208147952DE57A0", "0x317D360F86C80DC9"],
+      "XMM4": ["0xBBA54C87DA872B40", "0x6495428B7641EBE6"],
+      "XMM5": ["0x170B5A1B5CDD42EA", "0x719F094BB2358CA1"]
+  }
+}
+%endif
+
+lea rdx, [rel .data]
+
+; With imm = 0b00000000
+movaps xmm1, [rdx + 16 * 0]
+movaps xmm2, [rdx + 16 * 1]
+pclmulqdq xmm1, xmm2, 0
+
+; With imm = 0b00000001
+movaps xmm3, [rdx + 16 * 0]
+pclmulqdq xmm3, xmm2, 1
+
+; With imm = 0b00010000
+movaps xmm4, [rdx + 16 * 0]
+pclmulqdq xmm4, xmm2, 16
+
+; With imm = 0b00010001
+movaps xmm5, [rdx + 16 * 0]
+pclmulqdq xmm5, xmm2, 17
+
+hlt
+
+align 16
+.data:
+db 0xe0, 0xfc, 0x2b, 0xa1, 0x06, 0x4f, 0x6c, 0xa7, 0x0f, 0x06, 0x6a, 0x1e, 0x7f, 0x76, 0x80, 0x9b
+db 0xe0, 0x56, 0xed, 0xaa, 0xf3, 0xc3, 0x68, 0x68, 0xde, 0xe6, 0xe6, 0x94, 0xe2, 0xe9, 0xfc, 0xf0

--- a/unittests/ASM/VEX/vpclmulqdq.asm
+++ b/unittests/ASM/VEX/vpclmulqdq.asm
@@ -1,0 +1,37 @@
+%ifdef CONFIG
+{
+  "RegData": {
+      "XMM1": ["0xA76C4F06A12BFCE0", "0x9B80767F1E6A060F"],
+      "XMM2": ["0x6868C3F3AAED56E0", "0xF0FCE9E294E6E6DE"],
+      "XMM3": ["0x1E2017C5BEE29400", "0x38358E40CC367C7A"],
+      "XMM4": ["0xE208147952DE57A0", "0x317D360F86C80DC9"],
+      "XMM5": ["0xBBA54C87DA872B40", "0x6495428B7641EBE6"],
+      "XMM6": ["0x170B5A1B5CDD42EA", "0x719F094BB2358CA1"]
+  }
+}
+%endif
+
+lea rdx, [rel .data]
+
+; Load inputs
+movaps xmm1, [rdx + 16 * 0]
+movaps xmm2, [rdx + 16 * 1]
+
+; With imm = 0b00000000
+vpclmulqdq xmm3, xmm1, xmm2, 0
+
+; With imm = 0b00000001
+vpclmulqdq xmm4, xmm1, xmm2, 1
+
+; With imm = 0b00010000
+vpclmulqdq xmm5, xmm1, xmm2, 16
+
+; With imm = 0b00010001
+vpclmulqdq xmm6, xmm1, xmm2, 17
+
+hlt
+
+align 16
+.data:
+db 0xe0, 0xfc, 0x2b, 0xa1, 0x06, 0x4f, 0x6c, 0xa7, 0x0f, 0x06, 0x6a, 0x1e, 0x7f, 0x76, 0x80, 0x9b
+db 0xe0, 0x56, 0xed, 0xaa, 0xf3, 0xc3, 0x68, 0x68, 0xde, 0xe6, 0xe6, 0x94, 0xe2, 0xe9, 0xfc, 0xf0


### PR DESCRIPTION
Closes #1713 

`PCLMULQDQ` on x86 is very closely matched by one of AArch64's own carryless multiplication instructions (`PMULL`/`PMULL2`), albeit with just a tad less flexibility, but nothing that makes it unworkable.

This allows us to handle the x86 CLMUL instruction extension and enable the corresponding CPUID bit.