### PR TITLE
FEXRootFSFetcher: Update and fix xxhash file hashing

### DIFF
--- a/Scripts/InstallFEX.py
+++ b/Scripts/InstallFEX.py
@@ -306,12 +306,12 @@ def GetRootFSPath():
     return _RootFSPath
 
 def CheckRootFSInstallStatus():
-    # Matches what is available on https://rootfs.fex-emu.org/file/fex-rootfs/RootFS_links.txt
+    # Matches what is available on https://rootfs.fex-emu.org/file/fex-rootfs/RootFS_links_XXH3.txt
     UbuntuVersionToRootFS = {
         "20.04": "Ubuntu_21_04.sqsh",
         "21.04": "Ubuntu_21_04.sqsh",
         "21.10": "Ubuntu_21_10.sqsh",
-        "22.04": "Ubuntu_21_10.sqsh",
+        "22.04": "Ubuntu_22_04.sqsh",
     }
 
     return os.path.exists(GetRootFSPath() + UbuntuVersionToRootFS[GetDistro()[1]])

--- a/Source/Tools/FEXRootFSFetcher/Main.cpp
+++ b/Source/Tools/FEXRootFSFetcher/Main.cpp
@@ -346,7 +346,7 @@ namespace WebFileFetcher {
     std::string Hash;
   };
 
-  const static std::string DownloadURL = "https://rootfs.fex-emu.org/file/fex-rootfs/RootFS_links.txt";
+  const static std::string DownloadURL = "https://rootfs.fex-emu.org/file/fex-rootfs/RootFS_links_XXH3.txt";
 
   std::string DownloadToString(const std::string &URL) {
     std::string BigArgs =

--- a/docs/ReleaseProcess.md
+++ b/docs/ReleaseProcess.md
@@ -80,7 +80,7 @@ Follow the steps in: https://github.com/FEX-Emu/FEX-ppa/blob/main/README_ppa.md
 * Follow the Build_Data file's information for how to generate an image using `build_image.py`
   * This gives a squashfs image for the rootfs
 * Use FEXRootFSFetcher <image.sqsh> to generate the xxhash for the image
-* Update `https://rootfs.fex-emu.org/file/fex-rootfs/RootFS_links.txt` with the new rootfs image and hash
+* Update `https://rootfs.fex-emu.org/file/fex-rootfs/RootFS_links_XXH3.txt` with the new rootfs image and hash
   * This currently lives in a private FEX-Emu backblaze bucket with cloudflare servicing it.
   * Never publically give the direct backblaze link to the file. Will cause BW costs to skyrocket
   * Always pass through cloudflare
@@ -88,9 +88,9 @@ Follow the steps in: https://github.com/FEX-Emu/FEX-ppa/blob/main/README_ppa.md
 * Upload new image to Backblaze using the b2 upload tool
   * b2 upload-file <bucketname> <image.sqsh> <Image folder name>/<image.sqsh>
 
-* Upload the new RootFS_links.txt
+* Upload the new RootFS_links_XXH3.txt
   * Lives in the root of the bucket
-  * b2 upload-file <bucketname> RootFS_links.txt RootFS_links.txt
+  * b2 upload-file <bucketname> RootFS_links_XXH3.txt RootFS_links_XXH3.txt
 
 * Once uploaded it should propagate immediately
 * Might be worth thinking about the coherency problem of updating the hash versus image independently if overwriting an image


### PR DESCRIPTION
The final tail of the file reading was incorrect, so our hashing was
"correct" but it was using stale data from the previous block size read.

Noticed this while wiring up the CI rootfs fetching since the hashing is
a lot simpler there.

Now instead of reading a tail, just attempt to read the full block size
and use the resulting data size instead. Confirmed it matches expected
results now.

In the process we are going to need to update hyperlinks and hashes
anyway, change the hash to XXH3 so it is faster to run.