### PR TITLE
SMC: Track code pages before frontend decode

### DIFF
--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -328,7 +328,7 @@ namespace FEXCore::Context {
 
     void NotifyPause();
 
-    void AddBlockMapping(FEXCore::Core::InternalThreadState *Thread, uint64_t Address, void *Ptr, uint64_t Start, uint64_t Length);
+    void AddBlockMapping(FEXCore::Core::InternalThreadState *Thread, uint64_t Address, void *Ptr);
     FEXCore::CodeLoader *LocalLoader{};
 
     // Entry Cache

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -1056,7 +1056,7 @@ namespace FEXCore::Context {
     }
 
     // Insert to lookup cache
-    // Block pages containing this blocks are added via AddBlockExecutableRange before each page gets accessed in the frontend
+    // Pages containing this block are added via AddBlockExecutableRange before each page gets accessed in the frontend
     AddBlockMapping(Thread, GuestRIP, CodePtr);
 
     return (uintptr_t)CodePtr;

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -634,11 +634,8 @@ namespace FEXCore::Context {
     FEXCore::Threads::Thread::CleanupAfterFork();
   }
 
-  void Context::AddBlockMapping(FEXCore::Core::InternalThreadState *Thread, uint64_t Address, void *Ptr, uint64_t Start, uint64_t Length) {
-    // Only call MarkGuestExecutableRange if new pages are marked as containing code
-    if (Thread->LookupCache->AddBlockMapping(Address, Ptr, Start, Length)) {
-      Thread->CTX->SyscallHandler->MarkGuestExecutableRange(Start, Length);
-    }
+  void Context::AddBlockMapping(FEXCore::Core::InternalThreadState *Thread, uint64_t Address, void *Ptr) {
+    Thread->LookupCache->AddBlockMapping(Address, Ptr);
   }
 
   void Context::ClearCodeCache(FEXCore::Core::InternalThreadState *Thread, bool AlsoClearIRCache) {
@@ -719,7 +716,11 @@ namespace FEXCore::Context {
     uint64_t TotalInstructions {0};
     uint64_t TotalInstructionsLength {0};
 
-    Thread->FrontendDecoder->DecodeInstructionsAtEntry(GuestCode, GuestRIP);
+    Thread->FrontendDecoder->DecodeInstructionsAtEntry(GuestCode, GuestRIP, [Thread](uint64_t BlockEntry, uint64_t Start, uint64_t Length) {
+      if (Thread->LookupCache->AddBlockExecutableRange(BlockEntry, Start, Length)) {
+        Thread->CTX->SyscallHandler->MarkGuestExecutableRange(Start, Length);
+      }
+    });
 
     auto CodeBlocks = Thread->FrontendDecoder->GetDecodedBlocks();
 
@@ -1055,7 +1056,8 @@ namespace FEXCore::Context {
     }
 
     // Insert to lookup cache
-    AddBlockMapping(Thread, GuestRIP, CodePtr, StartAddr, Length);
+    // Block pages containing this blocks are added via AddBlockExecutableRange before each page gets accessed in the frontend
+    AddBlockMapping(Thread, GuestRIP, CodePtr);
 
     return (uintptr_t)CodePtr;
   }

--- a/External/FEXCore/Source/Interface/Core/Frontend.cpp
+++ b/External/FEXCore/Source/Interface/Core/Frontend.cpp
@@ -1190,22 +1190,24 @@ void Decoder::DecodeInstructionsAtEntry(uint8_t const* _InstStream, uint64_t PC,
 
     while (1) {
 
-      // This is worst case
+      // MAX_INST_SIZE assumes worst case
       auto OpMinAddress = RIPToDecode + PCOffset;
       auto OpMaxAddress = OpMinAddress + MAX_INST_SIZE;
 
-      if ((OpMinAddress & FHU::FEX_PAGE_MASK) != CurrentCodePage) {
-        CurrentCodePage = OpMinAddress & FHU::FEX_PAGE_MASK;
-        if (!CodePages.contains(CurrentCodePage)) {
-          CodePages.insert(CurrentCodePage);
+      auto OpMinPage = OpMinAddress & FHU::FEX_PAGE_MASK;
+      auto OpMaxPage = OpMaxAddress & FHU::FEX_PAGE_MASK;
+
+
+      if (OpMinPage != CurrentCodePage) {
+        CurrentCodePage = OpMinPage;
+        if (CodePages.insert(CurrentCodePage).second) {
           AddContainedCodePage(PC, CurrentCodePage, FHU::FEX_PAGE_SIZE);
         }
       }
 
-      if ((OpMaxAddress & FHU::FEX_PAGE_MASK) != CurrentCodePage) {
-        CurrentCodePage = OpMaxAddress & FHU::FEX_PAGE_MASK;
-        if (!CodePages.contains(CurrentCodePage)) {
-          CodePages.insert(CurrentCodePage);
+      if (OpMaxPage != CurrentCodePage) {
+        CurrentCodePage = OpMaxPage;
+        if (CodePages.insert(CurrentCodePage).second) {
           AddContainedCodePage(PC, CurrentCodePage, FHU::FEX_PAGE_SIZE);
         }
       }

--- a/External/FEXCore/Source/Interface/Core/Frontend.h
+++ b/External/FEXCore/Source/Interface/Core/Frontend.h
@@ -27,7 +27,7 @@ public:
 
   Decoder(FEXCore::Context::Context *ctx);
   ~Decoder();
-  void DecodeInstructionsAtEntry(uint8_t const* InstStream, uint64_t PC);
+  void DecodeInstructionsAtEntry(uint8_t const* InstStream, uint64_t PC, std::function<void(uint64_t BlockEntry, uint64_t Start, uint64_t Length)> AddContainedCodePage);
 
   std::vector<DecodedBlocks> const *GetDecodedBlocks() const {
     return &Blocks;

--- a/External/FEXCore/Source/Interface/Core/LookupCache.cpp
+++ b/External/FEXCore/Source/Interface/Core/LookupCache.cpp
@@ -52,14 +52,6 @@ LookupCache::~LookupCache() {
   FEXCore::Allocator::munmap(reinterpret_cast<void*>(L1Pointer), L1_SIZE);
 }
 
-void LookupCache::HintUsedRange(uint64_t Address, uint64_t Size) {
-  // Tell the kernel we will definitely need [Address, Address+Size) mapped for the page pointer
-  // Page Pointer is allocated per page, so shift by page size
-  Address >>= 12;
-  Size >>= 12;
-  madvise(reinterpret_cast<void*>(PagePointer + Address), Size, MADV_WILLNEED);
-}
-
 void LookupCache::ClearL2Cache() {
   std::lock_guard<std::recursive_mutex> lk(WriteLock);
   // Clear out the page memory

--- a/External/FEXCore/Source/Interface/Core/LookupCache.h
+++ b/External/FEXCore/Source/Interface/Core/LookupCache.h
@@ -25,9 +25,6 @@ public:
   LookupCache(FEXCore::Context::Context *CTX);
   ~LookupCache();
 
-  using LookupCacheIter = uintptr_t;
-  uintptr_t End() { return 0; }
-
   uintptr_t FindBlock(uint64_t Address) {
     // Try L1, no lock needed
     auto &L1Entry = reinterpret_cast<LookupCacheEntry*>(L1Pointer)[Address & L1_ENTRIES_MASK];
@@ -72,16 +69,17 @@ public:
 
   std::map<uint64_t, std::vector<uint64_t>> CodePages;
 
-  // Appends Block {Address} to the blocks contained between [Start, Start + Length)
+  // Appends Block {Address} to CodePages [Start, Start + Length)
   // Returns true if new pages are marked as containing code
   bool AddBlockExecutableRange(uint64_t Address, uint64_t Start, uint64_t Length) {
     std::lock_guard<std::recursive_mutex> lk(WriteLock);
     
     bool rv = false;
 
-    for (auto CurrentPage = Start >> 12, EndPage = (Start + Length) >> 12; CurrentPage <= EndPage; CurrentPage++) {
-      rv |= CodePages[CurrentPage].size() == 0;
-      CodePages[CurrentPage].push_back(Address);
+    for (auto CurrentPage = Start >> 12, EndPage = (Start + Length -1) >> 12; CurrentPage <= EndPage; CurrentPage++) {
+      auto &CodePage = CodePages[CurrentPage];
+      rv |= CodePage.size() == 0;
+      CodePage.push_back(Address);
     }
 
     return rv;
@@ -91,9 +89,8 @@ public:
   void AddBlockMapping(uint64_t Address, void *HostCode) {
     std::lock_guard<std::recursive_mutex> lk(WriteLock);
     
-    [[maybe_unused]] auto InsertPoint = BlockList.emplace(Address, (uintptr_t)HostCode);
-    BlockList.emplace(Address, (uintptr_t)HostCode);
-    LOGMAN_THROW_A_FMT(InsertPoint.second == true, "Dupplicate block mapping added");
+    [[maybe_unused]] auto Inserted = BlockList.emplace(Address, (uintptr_t)HostCode).second;
+    LOGMAN_THROW_A_FMT(Inserted, "Duplicate block mapping added");
 
     // There is no need to update L1 or L2, they will get updated on first lookup
     // However, adding to L1 here increases performance
@@ -152,8 +149,6 @@ public:
 
   void ClearCache();
   void ClearL2Cache();
-
-  void HintUsedRange(uint64_t Address, uint64_t Size);
 
   uintptr_t GetL1Pointer() const { return L1Pointer; }
   uintptr_t GetPagePointer() const { return PagePointer; }

--- a/External/FEXCore/Source/Interface/Core/LookupCache.h
+++ b/External/FEXCore/Source/Interface/Core/LookupCache.h
@@ -91,9 +91,7 @@ public:
   void AddBlockMapping(uint64_t Address, void *HostCode) {
     std::lock_guard<std::recursive_mutex> lk(WriteLock);
     
-#if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
-    auto InsertPoint =
-#endif
+    [[maybe_unused]] auto InsertPoint = BlockList.emplace(Address, (uintptr_t)HostCode);
     BlockList.emplace(Address, (uintptr_t)HostCode);
     LOGMAN_THROW_A_FMT(InsertPoint.second == true, "Dupplicate block mapping added");
 

--- a/unittests/FEXLinuxTests/tests/smc/smc-mt-2.cpp
+++ b/unittests/FEXLinuxTests/tests/smc/smc-mt-2.cpp
@@ -60,8 +60,12 @@ void *thread(void *) {
   return 0;
 }
 
-int main() {
+void RunIteration() {
+  printf("Starting Iteration\n");
   code = (char *)mmap(0, 4096, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANON, 0, 0);
+  ready_for_modification = false;
+  thread_unblocked = false;
+  thread_counter = 0;
 
   pthread_t tid;
   pthread_create(&tid, 0, &thread, 0);
@@ -91,9 +95,17 @@ int main() {
     }
   }
 
-  printf("Should exit now\n");
+  printf("Iteration should finish now\n");
   void *rv;
   pthread_join(tid, &rv);
+  printf("Iteration done\n");
+  munmap(code, 4096);
+}
 
+int main() {
+  
+  for (int i = 0; i < 100; i++) {
+    RunIteration();
+  }
   return 0;
 }


### PR DESCRIPTION
#### Overview
During compilation, another thread might change the code while it is being compiled.

This modifies `frontend` & `compile` to add watches to pages before they are read for code from the frontend.

This guarantees that we never tear during compilation with parts of the block being stale.

`smc-mt-2` is also updated to do 100 iterations, as this is a race test and might pass some times

#### Details
- Add iterations to `smc-mt-2`
- Split code page tracking from `LookupCache::AddBlockMapping` to `LookupCache::AddBlockExecutableRange`
- Remove code page tracking from `Context::AddBlockMapping`
- Add `std::function<void(uint64_t BlockEntry, uint64_t Start, uint64_t Length)> AddContainedCodePage` to `Frontend::DecodeInstructionsAtEntry`, call it once for every page encountered in this block, before any reads are done. Opcodes are assumed to be MAX_SIZE for this.
- Change `Context::GenerateIR`  to call `Frontend::DecodeInstructionsAtEntry` with a callback that does code page tracking

Fixes #1765