### PR TITLE
Invalidations: Move invalidation locks to Context

### DIFF
--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -126,6 +126,8 @@ namespace FEXCore::Context {
     Event PauseWait;
     bool Running{};
 
+    std::shared_mutex CodeInvalidationMutex; 
+    
     FEXCore::CPUIDEmu CPUID;
     FEXCore::HLE::SyscallHandler *SyscallHandler{};
     std::unique_ptr<FEXCore::ThunkHandler> ThunkHandler;

--- a/External/FEXCore/include/FEXCore/Core/Context.h
+++ b/External/FEXCore/include/FEXCore/Core/Context.h
@@ -250,6 +250,7 @@ namespace FEXCore::Context {
   FEX_DEFAULT_VISIBILITY void FinalizeAOTIRCache(FEXCore::Context::Context *CTX);
   FEX_DEFAULT_VISIBILITY void WriteFilesWithCode(FEXCore::Context::Context *CTX, std::function<void(const std::string& fileid, const std::string& filename)> Writer);
   FEX_DEFAULT_VISIBILITY void InvalidateGuestCodeRange(FEXCore::Context::Context *CTX, uint64_t Start, uint64_t Length);
+  FEX_DEFAULT_VISIBILITY void InvalidateGuestCodeRange(FEXCore::Context::Context *CTX, uint64_t Start, uint64_t Length, std::function<void(uint64_t start, uint64_t Length)> callback);
   FEX_DEFAULT_VISIBILITY void MarkMemoryShared(FEXCore::Context::Context *CTX);
 
   FEX_DEFAULT_VISIBILITY void ConfigureAOTGen(FEXCore::Core::InternalThreadState *Thread, std::set<uint64_t> *ExternalBranches, uint64_t SectionMaxAddress);

--- a/External/FEXCore/include/FEXCore/HLE/SyscallHandler.h
+++ b/External/FEXCore/include/FEXCore/HLE/SyscallHandler.h
@@ -79,7 +79,6 @@ namespace FEXCore::HLE {
     virtual FEXCore::CodeLoader *GetCodeLoader() const { return nullptr; }
     virtual void MarkGuestExecutableRange(uint64_t Start, uint64_t Length) { }
     virtual AOTIRCacheEntryLookupResult LookupAOTIRCacheEntry(uint64_t GuestAddr) = 0;
-    virtual std::shared_lock<std::shared_mutex> CompileCodeLock(uint64_t Start) = 0;
 
   protected:
     SyscallOSABI OSABI;

--- a/Source/Tests/IRLoader.cpp
+++ b/Source/Tests/IRLoader.cpp
@@ -138,11 +138,6 @@ class DummySyscallHandler: public FEXCore::HLE::SyscallHandler {
   FEXCore::HLE::AOTIRCacheEntryLookupResult LookupAOTIRCacheEntry(uint64_t GuestAddr) override {
     return {0, 0, FHU::ScopedSignalMaskWithSharedLock {StubMutex}};
   }
-
-  std::shared_mutex StubMutex2;
-  std::shared_lock<std::shared_mutex> CompileCodeLock(uint64_t Start) override {
-    return std::shared_lock(StubMutex2);
-  }
 };
 
 int main(int argc, char **argv, char **const envp)

--- a/Source/Tests/LinuxSyscalls/Syscalls.h
+++ b/Source/Tests/LinuxSyscalls/Syscalls.h
@@ -187,7 +187,6 @@ public:
   void MarkGuestExecutableRange(uint64_t Start, uint64_t Length) override;
   // AOTIRCacheEntryLookupResult also includes a shared lock guard, so the pointed AOTIRCacheEntry return can be safely used
   FEXCore::HLE::AOTIRCacheEntryLookupResult LookupAOTIRCacheEntry(uint64_t GuestAddr) final override;
-  std::shared_lock<std::shared_mutex> CompileCodeLock(uint64_t Start) override;
 
   ///// FORK tracking /////
   void LockBeforeFork();
@@ -295,9 +294,6 @@ private:
     using VMAEntry = SyscallHandler::VMAEntry;
     // Held while reading/writing this struct
     std::shared_mutex Mutex;
-
-    // Held unique {invalidate, mprotect change} to guarantee mt invalidation correctness
-    std::shared_mutex InvalidationMutex;
     
     // Memory ranges indexed by page aligned starting address
     std::map<uint64_t, VMAEntry> VMAs;


### PR DESCRIPTION
#### Overview

Adds an overload of `InvalidateGuestCodeRange` with `std::function<void(uint64_t start, uint64_t Length)> CallAfter` that guarantees no code is compiled between invalidation in and callback invocation. 

As shared code invalidation only needs to be interlocked around each mirror invalidation, and not around the entire invalidation, this is enough for `SyscallHandler::HandleSegfault` to work.

This is also needed for invalidations in #1760, that is where it was inspired from :)