### PR TITLE
Linux: Fixes 32-bit allocator range scanning

### DIFF
--- a/Source/Tests/LinuxSyscalls/LinuxAllocator.cpp
+++ b/Source/Tests/LinuxSyscalls/LinuxAllocator.cpp
@@ -209,7 +209,8 @@ restart:
                  MappedPtr >= reinterpret_cast<void*>(TOP_KEY << FHU::FEX_PAGE_SHIFT)) {
           // Handles the case where MAP_FIXED_NOREPLACE failed with MAP_FAILED
           // or if the host system's kernel isn't new enough then it returns the wrong pointer
-          if (MappedPtr >= reinterpret_cast<void*>(TOP_KEY << FHU::FEX_PAGE_SHIFT)) {
+          if (MappedPtr != MAP_FAILED &&
+              MappedPtr >= reinterpret_cast<void*>(TOP_KEY << FHU::FEX_PAGE_SHIFT)) {
             // Make sure to munmap this so we don't leak memory
             ::munmap(MappedPtr, length);
           }
@@ -227,10 +228,10 @@ restart:
           else {
             // Try again
             if (SearchDown) {
-              BottomPage -= PagesLength;
+              --BottomPage;
             }
             else {
-              BottomPage += PagesLength;
+              ++BottomPage;
             }
             goto restart;
           }


### PR DESCRIPTION
32-bit allocations were scanning for available pages by shifting by the
length of allocation. This is incorrect since large allocations would
then only scan through the region in very large chunks. Especially if
MAP_32BIT was present. Instead scan by page size to ensure better fit.

This fixes X-Plane 11.

Also ensure we don't try to munmap a range unless the result is
MAP_FAILED, noticed we were trying to munmap ~0ULL