### PR TITLE
CMAKE: Create directories during configuration, fixes endless generation of unittests

### DIFF
--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -227,13 +227,11 @@ set(OUTPUT_IR_FOLDER "${CMAKE_BINARY_DIR}/include/FEXCore/IR")
 set(OUTPUT_NAME "${OUTPUT_IR_FOLDER}/IRDefines.inc")
 set(INPUT_NAME "${CMAKE_CURRENT_SOURCE_DIR}/Interface/IR/IR.json")
 
-add_custom_target(CREATE_IR_FOLDER ALL
-  COMMAND ${CMAKE_COMMAND} -E make_directory "${OUTPUT_IR_FOLDER}")
+file(MAKE_DIRECTORY "${OUTPUT_IR_FOLDER}")
 
 add_custom_command(
   OUTPUT "${OUTPUT_NAME}"
   DEPENDS "${INPUT_NAME}"
-  DEPENDS CREATE_IR_FOLDER
   DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/../Scripts/json_ir_generator.py"
   COMMAND "python3" "${CMAKE_CURRENT_SOURCE_DIR}/../Scripts/json_ir_generator.py" "${INPUT_NAME}" "${OUTPUT_NAME}"
   )
@@ -247,7 +245,6 @@ set(OUTPUT_IR_DOC "${CMAKE_BINARY_DIR}/IR.md")
 add_custom_command(
   OUTPUT "${OUTPUT_IR_DOC}"
   DEPENDS "${INPUT_NAME}"
-  DEPENDS CREATE_IR_FOLDER
   DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/../Scripts/json_ir_doc_generator.py"
   COMMAND "python3" "${CMAKE_CURRENT_SOURCE_DIR}/../Scripts/json_ir_doc_generator.py" "${INPUT_NAME}" "${OUTPUT_IR_DOC}"
   )
@@ -268,15 +265,13 @@ set(INPUT_CONFIG_NAME "${CMAKE_BINARY_DIR}/generated/Config/Config.json")
 set(OUTPUT_MAN_NAME "${CMAKE_BINARY_DIR}/generated/FEX.1")
 set(OUTPUT_MAN_NAME_COMPRESS "${CMAKE_BINARY_DIR}/generated/FEX.1.gz")
 
-add_custom_target(CREATE_CONFIG_FOLDER ALL
-  COMMAND ${CMAKE_COMMAND} -E make_directory "${OUTPUT_CONFIG_FOLDER}")
+file(MAKE_DIRECTORY "${OUTPUT_CONFIG_FOLDER}")
 
 add_custom_command(
   OUTPUT "${OUTPUT_CONFIG_NAME}"
   OUTPUT "${OUTPUT_CONFIG_OPTION_NAME}"
   OUTPUT "${OUTPUT_MAN_NAME}"
   DEPENDS "${INPUT_CONFIG_NAME}"
-  DEPENDS CREATE_CONFIG_FOLDER
   DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/../Scripts/config_generator.py"
   COMMAND "python3" "${CMAKE_CURRENT_SOURCE_DIR}/../Scripts/config_generator.py" "${INPUT_CONFIG_NAME}" "${OUTPUT_CONFIG_NAME}" "${OUTPUT_MAN_NAME}"
   "${OUTPUT_CONFIG_OPTION_NAME}"

--- a/ThunkLibs/GuestLibs/CMakeLists.txt
+++ b/ThunkLibs/GuestLibs/CMakeLists.txt
@@ -49,13 +49,11 @@ function(generate NAME)
     set(OUTFOLDER "${CMAKE_CURRENT_BINARY_DIR}/gen/${LIBNAME}")
     set(OUTFILE "${OUTFOLDER}/${WHAT}.inl")
 
-    add_custom_command(OUTPUT ${OUTFOLDER}
-      COMMAND ${CMAKE_COMMAND} -E make_directory "${OUTFOLDER}")
+    file(MAKE_DIRECTORY "${OUTFOLDER}")
 
     add_custom_command(
       OUTPUT "${OUTFILE}"
       DEPENDS "${GENERATOR_EXE}"
-      DEPENDS "${OUTFOLDER}"
       DEPENDS "${SOURCE_FILE}"
       COMMAND "${GENERATOR_EXE}" "${SOURCE_FILE}" "${LIBNAME}" "-${WHAT}" "${OUTFILE}" -- -std=c++17
             # Expand include directories to space-separated list of -isystem parameters

--- a/ThunkLibs/HostLibs/CMakeLists.txt
+++ b/ThunkLibs/HostLibs/CMakeLists.txt
@@ -36,12 +36,10 @@ function(generate NAME)
     set(OUTFOLDER "${CMAKE_CURRENT_BINARY_DIR}/gen/${LIBNAME}")
     set(OUTFILE "${OUTFOLDER}/${WHAT}.inl")
 
-    add_custom_command(OUTPUT ${OUTFOLDER}
-      COMMAND ${CMAKE_COMMAND} -E make_directory "${OUTFOLDER}")
-
+    file(MAKE_DIRECTORY "${OUTFOLDER}")
+    
     add_custom_command(
       OUTPUT "${OUTFILE}"
-      DEPENDS "${OUTFOLDER}"
       DEPENDS "${SOURCE_FILE}"
       DEPENDS thunkgen
       COMMAND thunkgen "${SOURCE_FILE}" "${LIBNAME}" "-${WHAT}" "${OUTFILE}" -- -std=c++17

--- a/unittests/32Bit_ASM/CMakeLists.txt
+++ b/unittests/32Bit_ASM/CMakeLists.txt
@@ -16,15 +16,13 @@ foreach(ASM_SRC ${ASM_SOURCES})
   set(OUTPUT_ASM_FOLDER "${CMAKE_BINARY_DIR}/${ASM_DIR}")
 
   # Generate build directory
-  add_custom_command(OUTPUT ${OUTPUT_ASM_FOLDER}
-    COMMAND ${CMAKE_COMMAND} -E make_directory "${OUTPUT_ASM_FOLDER}")
+  file(MAKE_DIRECTORY "${OUTPUT_ASM_FOLDER}")
 
   # Generate a temporary file
   set(ASM_TMP "${ASM_NAME}_TMP.asm")
   set(TMP_FILE "${OUTPUT_ASM_FOLDER}/${ASM_TMP}")
 
   add_custom_command(OUTPUT ${TMP_FILE}
-    DEPENDS "${OUTPUT_ASM_FOLDER}"
     DEPENDS "${ASM_SRC}"
     COMMAND "cp" ARGS "${ASM_SRC}" "${TMP_FILE}"
     COMMAND "sed" ARGS "-i" "-e" "\'1s;^;BITS 32\\norg 10000h\\nmov eax, 0x17\\nmov ds, ax\\n;\'" "-e" "\'\$\$a\\ret\\n\'" "${TMP_FILE}"
@@ -39,7 +37,6 @@ foreach(ASM_SRC ${ASM_SOURCES})
 
   add_custom_command(OUTPUT ${OUTPUT_CONFIG_NAME}
     DEPENDS "${ASM_SRC}"
-    DEPENDS "${OUTPUT_ASM_FOLDER}"
     DEPENDS "${CMAKE_SOURCE_DIR}/Scripts/json_asm_config_parse.py"
     DEPENDS "${CMAKE_SOURCE_DIR}/Scripts/json_config_parse.py"
     COMMAND "python3" ARGS "${CMAKE_SOURCE_DIR}/Scripts/json_asm_config_parse.py" "${ASM_SRC}" "${OUTPUT_CONFIG_NAME}")

--- a/unittests/ASM/CMakeLists.txt
+++ b/unittests/ASM/CMakeLists.txt
@@ -16,15 +16,13 @@ foreach(ASM_SRC ${ASM_SOURCES})
   set(OUTPUT_ASM_FOLDER "${CMAKE_BINARY_DIR}/${ASM_DIR}")
 
   # Generate build directory
-  add_custom_command(OUTPUT ${OUTPUT_ASM_FOLDER}
-    COMMAND ${CMAKE_COMMAND} -E make_directory "${OUTPUT_ASM_FOLDER}")
+  file(MAKE_DIRECTORY "${OUTPUT_ASM_FOLDER}")
 
   # Generate a temporary file
   set(ASM_TMP "${ASM_NAME}_TMP.asm")
   set(TMP_FILE "${OUTPUT_ASM_FOLDER}/${ASM_TMP}")
 
   add_custom_command(OUTPUT ${TMP_FILE}
-    DEPENDS "${OUTPUT_ASM_FOLDER}"
     DEPENDS "${ASM_SRC}"
     COMMAND "cp" ARGS "${ASM_SRC}" "${TMP_FILE}"
     COMMAND "sed" ARGS "-i" "-e" "\'1s;^;BITS 64\\n;\'" "-e" "\'\$\$a\\ret\\n\'" "${TMP_FILE}"
@@ -39,7 +37,6 @@ foreach(ASM_SRC ${ASM_SOURCES})
 
   add_custom_command(OUTPUT ${OUTPUT_CONFIG_NAME}
     DEPENDS "${ASM_SRC}"
-    DEPENDS "${OUTPUT_ASM_FOLDER}"
     DEPENDS "${CMAKE_SOURCE_DIR}/Scripts/json_asm_config_parse.py"
     DEPENDS "${CMAKE_SOURCE_DIR}/Scripts/json_config_parse.py"
     COMMAND "python3" ARGS "${CMAKE_SOURCE_DIR}/Scripts/json_asm_config_parse.py" "${ASM_SRC}" "${OUTPUT_CONFIG_NAME}")


### PR DESCRIPTION
The endless generation is caused because the directory timestamps are newer than some of the generated files, and the directories are a build time dependency, creating a circular dependency that always forces regeneration.
 
I'm not a cmake expert, so not sure if there are any drawbacks with this solution.