### PR TITLE
AOTIR: Fix RAData free

### DIFF
--- a/External/FEXCore/Source/Interface/IR/AOTIR.cpp
+++ b/External/FEXCore/Source/Interface/IR/AOTIR.cpp
@@ -349,7 +349,7 @@ namespace FEXCore::IR {
         else {
           // If the IR doesn't need to be retained then we can just delete it now
           delete DebugData;
-          delete RAData;
+          free(RAData);
           delete IRList;
         }
       }


### PR DESCRIPTION
This thing is allocated with malloc so it needs to be free'd with free.
This was poisoning asan runs.