### PR TITLE
Backends: Unified dispatch, interface rework, cleanups

### DIFF
--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -351,6 +351,7 @@ namespace FEXCore::Context {
     
     std::shared_mutex CustomIRMutex;
     std::unordered_map<uint64_t, std::tuple<std::function<void(uintptr_t Entrypoint, FEXCore::IR::IREmitter *)>, void *, void *>> CustomIRHandlers;
+    FEXCore::CPU::CPUBackendFeatures BackendFeatures;
     FEXCore::CPU::DispatcherConfig DispatcherConfig;
   };
 

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.h
@@ -15,8 +15,10 @@ namespace FEXCore::CPU {
 
 class Arm64Dispatcher final : public Dispatcher, public Arm64Emitter {
   public:
-    Arm64Dispatcher(FEXCore::Context::Context *ctx, DispatcherConfig &config);
+    Arm64Dispatcher(FEXCore::Context::Context *ctx, const DispatcherConfig &config);
     void InitThreadPointers(FEXCore::Core::InternalThreadState *Thread) override;
+    size_t GenerateGDBPauseCheck(uint8_t *CodeBuffer, uint64_t GuestRIP) override;
+    size_t GenerateInterpreterTrampoline(uint8_t *CodeBuffer) override;
 
   protected:
     void SpillSRA(FEXCore::Core::InternalThreadState *Thread, void *ucontext, uint32_t IgnoreMask) override;
@@ -27,6 +29,7 @@ class Arm64Dispatcher final : public Dispatcher, public Arm64Emitter {
     uint64_t LDIVHandlerAddress{};
     uint64_t LUREMHandlerAddress{};
     uint64_t LREMHandlerAddress{};
+    DispatcherConfig config;
 };
 
 }

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
@@ -26,9 +26,7 @@ struct Context;
 namespace FEXCore::CPU {
 
 struct DispatcherConfig {
-  bool InterpreterDispatch = false;
-  uintptr_t ExitFunctionLink = 0;
-  bool SupportsStaticRegisterAllocation = false;
+  bool StaticRegisterAllocation = false;
 };
 
 class Dispatcher {
@@ -67,8 +65,15 @@ public:
 
   virtual void InitThreadPointers(FEXCore::Core::InternalThreadState *Thread) = 0;
 
-  static std::unique_ptr<Dispatcher> CreateX86(FEXCore::Context::Context *CTX, DispatcherConfig &Config);
-  static std::unique_ptr<Dispatcher> CreateArm64(FEXCore::Context::Context *CTX, DispatcherConfig &Config);
+  // These are across all arches for now
+  static constexpr size_t MaxGDBPauseCheckSize = 128;
+  static constexpr size_t MaxInterpreterTrampolineSize = 128;
+
+  virtual size_t GenerateGDBPauseCheck(uint8_t *CodeBuffer, uint64_t GuestRIP) = 0;
+  virtual size_t GenerateInterpreterTrampoline(uint8_t *CodeBuffer) = 0;
+
+  static std::unique_ptr<Dispatcher> CreateX86(FEXCore::Context::Context *CTX, const DispatcherConfig &Config);
+  static std::unique_ptr<Dispatcher> CreateArm64(FEXCore::Context::Context *CTX, const DispatcherConfig &Config);
   
   void ExecuteDispatch(FEXCore::Core::CpuStateFrame *Frame) {
     DispatchPtr(Frame);

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/X86Dispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/X86Dispatcher.h
@@ -17,8 +17,10 @@ namespace FEXCore::CPU {
 
 class X86Dispatcher final : public Dispatcher, public Xbyak::CodeGenerator {
   public:
-    X86Dispatcher(FEXCore::Context::Context *ctx, DispatcherConfig &config);
+    X86Dispatcher(FEXCore::Context::Context *ctx, const DispatcherConfig &config);
     void InitThreadPointers(FEXCore::Core::InternalThreadState *Thread) override;
+    size_t GenerateGDBPauseCheck(uint8_t *CodeBuffer, uint64_t GuestRIP) override;
+    size_t GenerateInterpreterTrampoline(uint8_t *CodeBuffer) override;
 
     virtual ~X86Dispatcher() override;
 };

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterClass.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterClass.h
@@ -8,6 +8,7 @@
 #include <FEXCore/IR/IntrusiveIRList.h>
 
 namespace FEXCore::CPU {
+class Dispatcher;
 class X86DispatchGenerator;
 class Arm64DispatchGenerator;
 
@@ -20,7 +21,7 @@ using DestMapType = std::vector<uint32_t>;
 
 class InterpreterCore final : public CPUBackend {
 public:
-  explicit InterpreterCore(FEXCore::Context::Context *ctx,
+  explicit InterpreterCore(Dispatcher *Dispatch,
                            FEXCore::Core::InternalThreadState *Thread);
 
   [[nodiscard]] std::string GetName() override { return "Interpreter"; }
@@ -28,7 +29,7 @@ public:
   [[nodiscard]] void *CompileCode(uint64_t Entry,
                                   FEXCore::IR::IRListView const *IR,
                                   FEXCore::Core::DebugData *DebugData,
-                                  FEXCore::IR::RegisterAllocationData *RAData) override;
+                                  FEXCore::IR::RegisterAllocationData *RAData, bool GDBEnabled) override;
 
   [[nodiscard]] void *MapRegion(void* HostPtr, uint64_t, uint64_t) override { return HostPtr; }
 
@@ -40,6 +41,7 @@ public:
 
 private:
   size_t BufferUsed;
+  Dispatcher *Dispatch;
 };
 
 template<typename T>

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.h
@@ -17,6 +17,6 @@ struct DispatcherConfig;
 [[nodiscard]] std::unique_ptr<CPUBackend> CreateInterpreterCore(FEXCore::Context::Context *ctx,
                                                                 FEXCore::Core::InternalThreadState *Thread);
 void InitializeInterpreterSignalHandlers(FEXCore::Context::Context *CTX);
-void GetInterpreterDispatcherConfig(DispatcherConfig &config);
+CPUBackendFeatures GetInterpreterBackendFeatures();
 
 } // namespace FEXCore::CPU

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/Arm64Relocations.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/Arm64Relocations.cpp
@@ -26,7 +26,7 @@ void Arm64JITCore::InsertNamedThunkRelocation(vixl::aarch64::Register Reg, const
   Relocation MoveABI{};
   MoveABI.NamedThunkMove.Header.Type = FEXCore::CPU::RelocationTypes::RELOC_NAMED_THUNK_MOVE;
   // Offset is the offset from the entrypoint of the block
-  auto CurrentCursor = GetCursorAddress<uint64_t>();
+  auto CurrentCursor = GetCursorAddress<uint8_t *>();
   MoveABI.NamedThunkMove.Offset = CurrentCursor - GuestEntry;
   MoveABI.NamedThunkMove.Symbol = Sum;
   MoveABI.NamedThunkMove.RegisterIndex = Reg.GetCode();
@@ -57,7 +57,7 @@ Arm64JITCore::NamedSymbolLiteralPair Arm64JITCore::InsertNamedSymbolLiteral(FEXC
 
 void Arm64JITCore::PlaceNamedSymbolLiteral(NamedSymbolLiteralPair &Lit) {
   // Offset is the offset from the entrypoint of the block
-  auto CurrentCursor = GetCursorAddress<uint64_t>();
+  auto CurrentCursor = GetCursorAddress<uint8_t *>();
   Lit.MoveABI.NamedSymbolLiteral.Offset = CurrentCursor - GuestEntry;
 
   place(&Lit.Lit);
@@ -68,7 +68,7 @@ void Arm64JITCore::InsertGuestRIPMove(vixl::aarch64::Register Reg, uint64_t Cons
   Relocation MoveABI{};
   MoveABI.GuestRIPMove.Header.Type = FEXCore::CPU::RelocationTypes::RELOC_GUEST_RIP_MOVE;
   // Offset is the offset from the entrypoint of the block
-  auto CurrentCursor = GetCursorAddress<uint64_t>();
+  auto CurrentCursor = GetCursorAddress<uint8_t *>();
   MoveABI.GuestRIPMove.Offset = CurrentCursor - GuestEntry;
   MoveABI.GuestRIPMove.GuestRIP = Constant;
   MoveABI.GuestRIPMove.RegisterIndex = Reg.GetCode();

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -52,7 +52,7 @@ public:
   [[nodiscard]] void *CompileCode(uint64_t Entry,
                                   FEXCore::IR::IRListView const *IR,
                                   FEXCore::Core::DebugData *DebugData,
-                                  FEXCore::IR::RegisterAllocationData *RAData) override;
+                                  FEXCore::IR::RegisterAllocationData *RAData, bool GDBEnabled) override;
 
   [[nodiscard]] void *MapRegion(void* HostPtr, uint64_t, uint64_t) override { return HostPtr; }
 
@@ -208,7 +208,7 @@ private:
   /**
   * @brief Current guest RIP entrypoint
   */
-  uint64_t GuestEntry{};
+  uint8_t *GuestEntry{};
 
   using OpHandler = void (Arm64JITCore::*)(IR::IROp_Header *IROp, IR::NodeID Node);
   std::array<OpHandler, IR::IROps::OP_LAST + 1> OpHandlers {};

--- a/External/FEXCore/Source/Interface/Core/JIT/JITCore.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/JITCore.h
@@ -16,11 +16,11 @@ class CPUBackend;
 [[nodiscard]] std::unique_ptr<CPUBackend> CreateX86JITCore(FEXCore::Context::Context *ctx,
                                                            FEXCore::Core::InternalThreadState *Thread);
 void InitializeX86JITSignalHandlers(FEXCore::Context::Context *CTX);
-void GetX86JITDispatcherConfig(DispatcherConfig &config);
+CPUBackendFeatures GetX86JITBackendFeatures();
 
 [[nodiscard]] std::unique_ptr<CPUBackend> CreateArm64JITCore(FEXCore::Context::Context *ctx,
                                                              FEXCore::Core::InternalThreadState *Thread);
 void InitializeArm64JITSignalHandlers(FEXCore::Context::Context *CTX);
-void GetArm64JITDispatcherConfig(DispatcherConfig &config);
+CPUBackendFeatures GetArm64JITBackendFeatures();
 
 } // namespace FEXCore::CPU

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -60,7 +60,7 @@ public:
   [[nodiscard]] void *CompileCode(uint64_t Entry,
                                   FEXCore::IR::IRListView const *IR,
                                   FEXCore::Core::DebugData *DebugData,
-                                  FEXCore::IR::RegisterAllocationData *RAData) override;
+                                  FEXCore::IR::RegisterAllocationData *RAData, bool GDBEnabled) override;
 
   [[nodiscard]] void *MapRegion(void* HostPtr, uint64_t, uint64_t) override { return HostPtr; }
 

--- a/External/FEXCore/include/FEXCore/Core/CPUBackend.h
+++ b/External/FEXCore/include/FEXCore/Core/CPUBackend.h
@@ -33,6 +33,10 @@ namespace CodeSerialize {
 }
 
 namespace CPU {
+  struct CPUBackendFeatures {
+    bool SupportsStaticRegisterAllocation = false;
+  };
+  
   class CPUBackend {
   public:
     struct CodeBuffer {
@@ -71,7 +75,7 @@ namespace CPU {
     [[nodiscard]] virtual void *CompileCode(uint64_t Entry,
                                             FEXCore::IR::IRListView const *IR,
                                             FEXCore::Core::DebugData *DebugData,
-                                            FEXCore::IR::RegisterAllocationData *RAData) = 0;
+                                            FEXCore::IR::RegisterAllocationData *RAData, bool GDBEnabled) = 0;
 
     /**
      * @brief Relocates a block of code from the JIT code object cache

--- a/External/FEXCore/include/FEXCore/Core/CoreState.h
+++ b/External/FEXCore/include/FEXCore/Core/CoreState.h
@@ -105,6 +105,7 @@ namespace FEXCore::Core {
       uint64_t CPUIDFunction{};
       uint64_t SyscallHandlerObj{};
       uint64_t SyscallHandlerFunc{};
+      uint64_t ExitFunctionLink{};
 
       uint64_t FallbackHandlerPointers[FallbackHandlerIndex::OPINDEX_MAX];
 

--- a/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
+++ b/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
@@ -42,7 +42,7 @@ namespace FEXCore::Core {
   };
 
   struct DebugDataSubblock {
-    uintptr_t HostCodeStart;
+    uint32_t HostCodeOffset;
     uint32_t HostCodeSize;
   };
 


### PR DESCRIPTION
#### Overview

This makes it the responsibility of the dispatcher to generate GDB checks and interpreter trampolines, unifies the dispatcher between interpreter and jits.

Reworked a lot of minor inconveniences along the way as well as did some small cleanups.

#### Depends
#1783