### PR TITLE
ThunksDB: Fix String.find error check

### DIFF
--- a/Source/Tests/LinuxSyscalls/FileManagement.cpp
+++ b/Source/Tests/LinuxSyscalls/FileManagement.cpp
@@ -149,7 +149,7 @@ void FileManager::LoadThunkDatabase(bool Global) {
 
             auto ReplacePrefix = [](std::string_view String, const char *Prefix, const char *NewPrefix) -> std::pair<bool, std::string> {
               auto it = String.find(Prefix);
-              if (it != String.size()) {
+              if (it != String.npos) {
                 size_t SizeOfOldPrefix = strlen(Prefix);
                 std::string Replacement {String};
                 Replacement.replace(it, SizeOfOldPrefix, NewPrefix);


### PR DESCRIPTION
#### Overview

`std::string::find` returns `std::string::npos` on fail, not `std::string::size` or `std::string::end`