### PR TITLE
CoreState: Add register size constants

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -178,15 +178,15 @@ namespace FEXCore::Context {
 
     // Initialize default CPU state
     NewThreadState.rip = ~0ULL;
-    for (int i = 0; i < 16; ++i) {
-      NewThreadState.gregs[i] = 0;
+    for (auto& greg : NewThreadState.gregs) {
+      greg = 0;
     }
 
-    for (int i = 0; i < 16; ++i) {
-      NewThreadState.xmm[i][0] = 0xDEADBEEFULL;
-      NewThreadState.xmm[i][1] = 0xBAD0DAD1ULL;
+    for (auto& xmm : NewThreadState.xmm) {
+      xmm[0] = 0xDEADBEEFULL;
+      xmm[1] = 0xBAD0DAD1ULL;
     }
-    memset(NewThreadState.flags, 0, 32);
+    memset(NewThreadState.flags, 0, Core::CPUState::NUM_EFLAG_BITS);
     NewThreadState.flags[1] = 1;
     NewThreadState.flags[9] = 1;
     NewThreadState.FCW = 0x37F;

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
@@ -133,7 +133,7 @@ void Dispatcher::RestoreThreadState(FEXCore::Core::InternalThreadState *Thread, 
         Frame->State.rip = guest_uctx->uc_mcontext.gregs[FEXCore::x86_64::FEX_REG_RIP];
         // XXX: Full context setting
         uint32_t eflags = guest_uctx->uc_mcontext.gregs[FEXCore::x86_64::FEX_REG_EFL];
-        for (size_t i = 0; i < 32; ++i) {
+        for (size_t i = 0; i < Core::CPUState::NUM_EFLAG_BITS; ++i) {
           Frame->State.flags[i] = (eflags & (1U << i)) ? 1 : 0;
         }
 
@@ -191,7 +191,7 @@ void Dispatcher::RestoreThreadState(FEXCore::Core::InternalThreadState *Thread, 
         // XXX: Full context setting
         // First 32-bytes of flags is EFLAGS broken out
         uint32_t eflags = guest_uctx->uc_mcontext.gregs[FEXCore::x86::FEX_REG_EFL];
-        for (size_t i = 0; i < 32; ++i) {
+        for (size_t i = 0; i < Core::CPUState::NUM_EFLAG_BITS; ++i) {
           Frame->State.flags[i] = (eflags & (1U << i)) ? 1 : 0;
         }
 
@@ -219,7 +219,7 @@ void Dispatcher::RestoreThreadState(FEXCore::Core::InternalThreadState *Thread, 
         FEXCore::x86::_libc_fpstate *fpstate = reinterpret_cast<FEXCore::x86::_libc_fpstate*>(guest_uctx->uc_mcontext.fpregs);
 
         // Copy float registers
-        for (size_t i = 0; i < 8; ++i) {
+        for (size_t i = 0; i < Core::CPUState::NUM_MMS; ++i) {
           // 32-bit st register size is only 10 bytes. Not padded to 16byte like x86-64
           memcpy(&Frame->State.mm[i], &fpstate->_st[i], 10);
         }
@@ -529,7 +529,7 @@ bool Dispatcher::HandleGuestSignal(FEXCore::Core::InternalThreadState *Thread, i
 #undef COPY_REG
 
       // Copy float registers
-      for (size_t i = 0; i < 8; ++i) {
+      for (size_t i = 0; i < Core::CPUState::NUM_MMS; ++i) {
         // 32-bit st register size is only 10 bytes. Not padded to 16byte like x86-64
         memcpy(&fpstate->_st[i], &Frame->State.mm[i], 10);
       }

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -106,7 +106,7 @@ DEF_OP(LoadRegister) {
   auto Op = IROp->C<IR::IROp_LoadRegister>();
 
   if (Op->Class == IR::GPRClass) {
-    auto regId = (Op->Offset - offsetof(FEXCore::Core::CpuStateFrame, State.gregs[0])) / 8;
+    auto regId = (Op->Offset - offsetof(Core::CpuStateFrame, State.gregs[0])) / Core::CPUState::GPR_REG_SIZE;
     auto regOffs = Op->Offset & 7;
 
     LOGMAN_THROW_A_FMT(regId < SRA64.size(), "out of range regId");
@@ -137,7 +137,7 @@ DEF_OP(LoadRegister) {
         break;
     }
   } else if (Op->Class == IR::FPRClass) {
-    auto regId = (Op->Offset - offsetof(FEXCore::Core::CpuStateFrame, State.xmm[0][0])) / 16;
+    auto regId = (Op->Offset - offsetof(Core::CpuStateFrame, State.xmm[0][0])) / Core::CPUState::XMM_REG_SIZE;
     auto regOffs = Op->Offset & 15;
 
     LOGMAN_THROW_A_FMT(regId < SRAFPR.size(), "out of range regId");
@@ -191,7 +191,7 @@ DEF_OP(StoreRegister) {
   auto Op = IROp->C<IR::IROp_StoreRegister>();
 
   if (Op->Class == IR::GPRClass) {
-    auto regId = Op->Offset / 8 - 1;
+    auto regId = (Op->Offset / Core::CPUState::GPR_REG_SIZE) - 1;
     auto regOffs = Op->Offset & 7;
 
     LOGMAN_THROW_A_FMT(regId < SRA64.size(), "out of range regId");
@@ -221,7 +221,7 @@ DEF_OP(StoreRegister) {
         break;
     }
   } else if (Op->Class == IR::FPRClass) {
-    auto regId = (Op->Offset - offsetof(FEXCore::Core::CpuStateFrame, State.xmm[0][0])) / 16;
+    auto regId = (Op->Offset - offsetof(Core::CpuStateFrame, State.xmm[0][0])) / Core::CPUState::XMM_REG_SIZE;
     auto regOffs = Op->Offset & 15;
 
     LOGMAN_THROW_A_FMT(regId < SRAFPR.size(), "regId out of range");

--- a/External/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
@@ -107,11 +107,11 @@ namespace {
       FEXCore::IR::InvalidClass,
     });
 
-    for (size_t i = 0; i < 16; ++i) {
+    for (size_t i = 0; i < FEXCore::Core::CPUState::NUM_GPRS; ++i) {
       ContextClassification->emplace_back(ContextMemberInfo{
         ContextMemberClassification {
           offsetof(FEXCore::Core::CPUState, gregs[0]) + sizeof(FEXCore::Core::CPUState::gregs[0]) * i,
-          sizeof(FEXCore::Core::CPUState::gregs[0]),
+          FEXCore::Core::CPUState::GPR_REG_SIZE,
         },
         DefaultAccess[1],
         FEXCore::IR::InvalidClass,
@@ -127,11 +127,11 @@ namespace {
       FEXCore::IR::InvalidClass,
     });
 
-    for (size_t i = 0; i < 16; ++i) {
+    for (size_t i = 0; i < FEXCore::Core::CPUState::NUM_XMMS; ++i) {
       ContextClassification->emplace_back(ContextMemberInfo{
         ContextMemberClassification {
           offsetof(FEXCore::Core::CPUState, xmm[0][0]) + sizeof(FEXCore::Core::CPUState::xmm[0]) * i,
-          sizeof(FEXCore::Core::CPUState::xmm[0]),
+          FEXCore::Core::CPUState::XMM_REG_SIZE,
         },
         DefaultAccess[3],
         FEXCore::IR::InvalidClass,
@@ -192,11 +192,11 @@ namespace {
       FEXCore::IR::InvalidClass,
     });
 
-    for (size_t i = 0; i < (sizeof(FEXCore::Core::CPUState::flags) / sizeof(FEXCore::Core::CPUState::flags[0])); ++i) {
+    for (size_t i = 0; i < FEXCore::Core::CPUState::NUM_FLAGS; ++i) {
       ContextClassification->emplace_back(ContextMemberInfo{
         ContextMemberClassification {
           offsetof(FEXCore::Core::CPUState, flags[0]) + sizeof(FEXCore::Core::CPUState::flags[0]) * i,
-          sizeof(FEXCore::Core::CPUState::flags[0]),
+          FEXCore::Core::CPUState::FLAG_SIZE,
         },
         DefaultAccess[10],
         FEXCore::IR::InvalidClass,
@@ -212,11 +212,11 @@ namespace {
       FEXCore::IR::InvalidClass,
     });
 
-    for (size_t i = 0; i < 8; ++i) {
+    for (size_t i = 0; i < FEXCore::Core::CPUState::NUM_MMS; ++i) {
       ContextClassification->emplace_back(ContextMemberInfo{
         ContextMemberClassification {
           offsetof(FEXCore::Core::CPUState, mm[0][0]) + sizeof(FEXCore::Core::CPUState::mm[0]) * i,
-          sizeof(FEXCore::Core::CPUState::mm[0]),
+          FEXCore::Core::CPUState::MM_REG_SIZE
         },
         DefaultAccess[12],
         FEXCore::IR::InvalidClass,
@@ -224,7 +224,7 @@ namespace {
     }
 
     // GDTs
-    for (size_t i = 0; i < 32; ++i) {
+    for (size_t i = 0; i < FEXCore::Core::CPUState::NUM_GDTS; ++i) {
       ContextClassification->emplace_back(ContextMemberInfo{
         ContextMemberClassification {
           offsetof(FEXCore::Core::CPUState, gdt[0]) + sizeof(FEXCore::Core::CPUState::gdt[0]) * i,
@@ -286,12 +286,12 @@ namespace {
     };
     size_t Offset = 0;
     SetAccess(Offset++, DefaultAccess[0]);
-    for (size_t i = 0; i < 16; ++i) {
+    for (size_t i = 0; i < FEXCore::Core::CPUState::NUM_GPRS; ++i) {
       SetAccess(Offset++, DefaultAccess[1]);
     }
     SetAccess(Offset++, DefaultAccess[2]);
 
-    for (size_t i = 0; i < 16; ++i) {
+    for (size_t i = 0; i < FEXCore::Core::CPUState::NUM_XMMS; ++i) {
       SetAccess(Offset++, DefaultAccess[3]);
     }
 
@@ -303,17 +303,17 @@ namespace {
     SetAccess(Offset++, DefaultAccess[9]);
 
 
-    for (size_t i = 0; i < (sizeof(FEXCore::Core::CPUState::flags) / sizeof(FEXCore::Core::CPUState::flags[0])); ++i) {
+    for (size_t i = 0; i < FEXCore::Core::CPUState::NUM_FLAGS; ++i) {
       SetAccess(Offset++, DefaultAccess[10]);
     }
 
     SetAccess(Offset++, DefaultAccess[11]);
 
-    for (size_t i = 0; i < 8; ++i) {
+    for (size_t i = 0; i < FEXCore::Core::CPUState::NUM_MMS; ++i) {
       SetAccess(Offset++, DefaultAccess[12]);
     }
 
-    for (size_t i = 0; i < 32; ++i) {
+    for (size_t i = 0; i < FEXCore::Core::CPUState::NUM_GDTS; ++i) {
       SetAccess(Offset++, DefaultAccess[13]);
     }
 
@@ -623,7 +623,7 @@ bool RCLSE::RedundantStoreLoadElimination(FEXCore::IR::IREmitter *IREmit) {
         auto Op = IROp->CW<IR::IROp_InvalidateFlags>();
 
         // Loop through non-reserved flag stores and eliminate unused ones.
-        for (unsigned F = 0; F < 32; F++) {
+        for (size_t F = 0; F < Core::CPUState::NUM_EFLAG_BITS; F++) {
           if (!(Op->Flags & (1ULL << F))) {
             continue;
           }

--- a/External/FEXCore/Source/Interface/IR/Passes/DeadStoreElimination.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/DeadStoreElimination.cpp
@@ -101,9 +101,9 @@ uint64_t FPRBit(uint32_t Offset, uint32_t Size) {
     return 0;
   }
 
-  auto begin = offsetof(FEXCore::Core::CpuStateFrame, State.xmm[0][0]);
+  auto begin = offsetof(Core::CpuStateFrame, State.xmm[0][0]);
 
-  auto regn = (Offset - begin)/16;
+  auto regn = (Offset - begin) / Core::CPUState::XMM_REG_SIZE;
   auto bitn = regn * 3;
 
   if (!IsTrackedWriteFPR(Offset, Size))

--- a/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -560,9 +560,11 @@ namespace {
     // Is an OP_LOADREGISTER eligible to read directly from the SRA reg?
     auto IsAliasable = [](uint8_t Size, RegisterClassType StaticClass, uint32_t Offset) {
       if (StaticClass == GPRFixedClass) {
-        return (Size == 8 /*|| Size == 4*/) && ((Offset & 7) == 0); // We need more meta info to support not-size-of-reg
+        // We need more meta info to support not-size-of-reg
+        return (Size == 8 /*|| Size == 4*/) && ((Offset & 7) == 0);
       } else if (StaticClass == FPRFixedClass) {
-        return (Size == 16 /*|| Size == 8 || Size == 4*/) && ((Offset & 15) == 0); // We need more meta info to support not-size-of-reg
+        // We need more meta info to support not-size-of-reg
+        return (Size == 16 /*|| Size == 8 || Size == 4*/) && ((Offset & 15) == 0);
       } else {
         LOGMAN_THROW_A_FMT(false, "Unexpected static class {}", StaticClass);
       }
@@ -578,10 +580,10 @@ namespace {
         auto endFpr = offsetof(FEXCore::Core::CpuStateFrame, State.xmm[16][0]);
 
         if (Offset >= beginGpr && Offset < endGpr) {
-          auto reg = (Offset - beginGpr) / 8;
+          auto reg = (Offset - beginGpr) / Core::CPUState::GPR_REG_SIZE;
           return PhysicalRegister(GPRFixedClass, reg);
         } else if (Offset >= beginFpr && Offset < endFpr) {
-          auto reg = (Offset - beginFpr) / 16;
+          auto reg = (Offset - beginFpr) / Core::CPUState::XMM_REG_SIZE;
           return PhysicalRegister(FPRFixedClass, reg);
         } else {
           LOGMAN_THROW_A_FMT(false, "Unexpected Offset {}", Offset);
@@ -602,10 +604,10 @@ namespace {
         auto endFpr = offsetof(FEXCore::Core::CpuStateFrame, State.xmm[16][0]);
 
         if (Offset >= beginGpr && Offset < endGpr) {
-          auto reg = (Offset - beginGpr) / 8;
+          auto reg = (Offset - beginGpr) / Core::CPUState::GPR_REG_SIZE;
           return &StaticMaps[reg];
         } else if (Offset >= beginFpr && Offset < endFpr) {
-          auto reg = (Offset - beginFpr) / 16;
+          auto reg = (Offset - beginFpr) / Core::CPUState::XMM_REG_SIZE;
           return &StaticMaps[GprSize + reg];
         } else {
           LOGMAN_THROW_A_FMT(false, "Unexpected offset {}", Offset);

--- a/External/FEXCore/Source/Interface/IR/Passes/StaticRegisterAllocationPass.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/StaticRegisterAllocationPass.cpp
@@ -24,15 +24,15 @@ public:
 };
 
 bool IsStaticAllocGpr(uint32_t Offset, RegisterClassType Class) {
-  const auto begin = offsetof(FEXCore::Core::CPUState, gregs[0]);
-  const auto end = offsetof(FEXCore::Core::CPUState, gregs[16]);
+  const auto begin = offsetof(Core::CPUState, gregs[0]);
+  const auto end = offsetof(Core::CPUState, gregs[16]);
 
   if (Offset >= begin && Offset < end) {
-    const auto reg = (Offset - begin) / 8;
+    const auto reg = (Offset - begin) / Core::CPUState::GPR_REG_SIZE;
     LOGMAN_THROW_A_FMT(Class == IR::GPRClass, "unexpected Class {}", Class);
 
     // 0..15 -> 16 in total
-    return reg < 16;
+    return reg < Core::CPUState::NUM_GPRS;
   }
 
   return false;
@@ -43,11 +43,11 @@ bool IsStaticAllocFpr(uint32_t Offset, RegisterClassType Class, bool AllowGpr) {
   const auto end = offsetof(FEXCore::Core::CPUState, xmm[16][0]);
 
   if (Offset >= begin && Offset < end) {
-    const auto reg = (Offset - begin) / 16;
+    const auto reg = (Offset - begin) / Core::CPUState::XMM_REG_SIZE;
     LOGMAN_THROW_A_FMT(Class == IR::FPRClass || (AllowGpr && Class == IR::GPRClass), "unexpected Class {}, AllowGpr {}", Class, AllowGpr);
 
     // 0..15 -> 16 in total
-    return reg < 16;
+    return reg < Core::CPUState::NUM_XMMS;
   }
 
   return false;

--- a/External/FEXCore/include/FEXCore/Core/CoreState.h
+++ b/External/FEXCore/include/FEXCore/Core/CoreState.h
@@ -28,6 +28,20 @@ namespace FEXCore::Core {
     } gdt[32];
     uint16_t FCW;
     uint16_t FTW;
+
+    static constexpr size_t FLAG_SIZE = sizeof(flags[0]);
+    static constexpr size_t GDT_SIZE = sizeof(gdt[0]);
+    static constexpr size_t GPR_REG_SIZE = sizeof(gregs[0]);
+    static constexpr size_t XMM_REG_SIZE = sizeof(xmm[0]);
+    static constexpr size_t MM_REG_SIZE = sizeof(mm[0]);
+
+    // Only the first 32 bits are defined.
+    static constexpr size_t NUM_EFLAG_BITS = 32;
+    static constexpr size_t NUM_FLAGS = sizeof(flags) / FLAG_SIZE;
+    static constexpr size_t NUM_GDTS = sizeof(gdt) / GDT_SIZE;
+    static constexpr size_t NUM_GPRS = sizeof(gregs) / GPR_REG_SIZE;
+    static constexpr size_t NUM_XMMS = sizeof(xmm) / XMM_REG_SIZE;
+    static constexpr size_t NUM_MMS = sizeof(mm) / MM_REG_SIZE;
   };
   static_assert(offsetof(CPUState, xmm) % 16 == 0, "xmm needs to be 128bit aligned!");
 

--- a/Source/Tests/HarnessHelpers.h
+++ b/Source/Tests/HarnessHelpers.h
@@ -101,14 +101,14 @@ namespace FEX::HarnessHelper {
     MatchMask >>= 1;
 
     // GPRS
-    for (unsigned i = 0; i < 16; ++i, MatchMask >>= 1) {
+    for (unsigned i = 0; i < FEXCore::Core::CPUState::NUM_GPRS; ++i, MatchMask >>= 1) {
       if (MatchMask & 1) {
         CheckGPRs("GPR" + std::to_string(i), State1.gregs[i], State2.gregs[i]);
       }
     }
 
     // XMM
-    for (unsigned i = 0; i < 16; ++i, MatchMask >>= 1) {
+    for (unsigned i = 0; i < FEXCore::Core::CPUState::NUM_XMMS; ++i, MatchMask >>= 1) {
       if (MatchMask & 1) {
         CheckGPRs("XMM0_" + std::to_string(i), State1.xmm[i][0], State2.xmm[i][0]);
         CheckGPRs("XMM1_" + std::to_string(i), State1.xmm[i][1], State2.xmm[i][1]);

--- a/Source/Tests/TestHarnessRunner/HostRunner.cpp
+++ b/Source/Tests/TestHarnessRunner/HostRunner.cpp
@@ -149,13 +149,13 @@ public:
     OutState->gregs[FEXCore::X86State::REG_R15] = _mcontext->gregs[REG_R15];
     OutState->rip = _mcontext->gregs[REG_RIP];
 
-    for (size_t i = 0; i < 16; ++i) {
+    for (size_t i = 0; i < FEXCore::Core::CPUState::NUM_XMMS; ++i) {
       memcpy(&OutState->xmm[i], &_mcontext->fpregs->_xmm[i], sizeof(_mcontext->fpregs->_xmm[0]));
     }
 
     uint16_t CurrentOffset = (_mcontext->fpregs->swd >> 11) & 7;
 
-    for (size_t i = 0; i < 8; ++i) {
+    for (size_t i = 0; i < FEXCore::Core::CPUState::NUM_MMS; ++i) {
       memcpy(&OutState->mm[(i + CurrentOffset) % 8], &_mcontext->fpregs->_st[i], sizeof(_mcontext->fpregs->_st[0]));
     }
 

--- a/Source/Tools/Debugger/IMGui_I.cpp
+++ b/Source/Tools/Debugger/IMGui_I.cpp
@@ -103,14 +103,14 @@ namespace CPUState {
           "R15",
         };
 
-        for (unsigned i = 0; i < 16; ++i) {
+        for (unsigned i = 0; i < FEXCore::Core::CPUState::NUM_GPRS; ++i) {
           DiffCol(gregs[i]);
           ImGui::Text("%s: 0x%016lx", GPRNames[i], State.gregs[i]);
           DiffPop(gregs[i]);
         }
       }
       if (ImGui::CollapsingHeader("XMMs")) {
-        for (unsigned i = 0; i < 16; ++i) {
+        for (unsigned i = 0; i < FEXCore::Core::CPUState::NUM_XMMS; ++i) {
           DiffCol(xmm[i][0]);
           ImGui::Text("%2d: 0x%016lx - 0x%016lx", i, State.xmm[i][0], State.xmm[i][1]);
           DiffPop(xmm[i][0]);


### PR DESCRIPTION
Gets rid of some magic numbers and reduces the number of things that need to manually change (e.g. when supporting AVX and needing to increase the xmm size).