### PR TITLE
Common: Support application profiles for games launched through wine

### DIFF
--- a/Source/Common/Config.cpp
+++ b/Source/Common/Config.cpp
@@ -71,6 +71,24 @@ namespace FEX::Config {
 
       // These layers load on initialization
       auto ProgramName = std::filesystem::path(Program).filename();
+      if (ProgramName == "wine" ||
+          ProgramName == "wine64") {
+
+        // If we are running wine or wine64 then we should check the second argument for the application name instead.
+        // wine will change the active program name with `setprogname` or `prctl(PR_SET_NAME`.
+        // Since FEX needs this data far earlier than libraries we need a different check.
+        if (Args.size() > 1) {
+          ProgramName = std::filesystem::path(Args[1]).filename();
+
+          // If this was path separated with '\' then we need to check that.
+          auto WinSeparator = ProgramName.string().find_last_of('\\');
+          if (WinSeparator != ProgramName.string().npos) {
+            // Used windows separators
+            ProgramName = ProgramName.string().substr(WinSeparator + 1);
+          }
+        }
+      }
+
       FEXCore::Config::AddLayer(FEXCore::Config::CreateAppLayer(ProgramName, true));
       FEXCore::Config::AddLayer(FEXCore::Config::CreateAppLayer(ProgramName, false));
       return Program;


### PR DESCRIPTION
Wine will set the application name later in the boot process but we
can't defer application profile loading that late.

Once an application is loaded with wine or wine64, then check the next
argument for the application name instead.

This will allow us to have wine application application profiles.

eg: FEXInterpreter `which wine` $HOME/.wine/drive_c/GOG\ Games/Oblivion/Oblivion.exe
This will give us the application name of `Oblivion.exe`

Same with: FEXInterpreter `which wine` C:\\GOG\ Games\\Oblivion\\Oblivion.exe