### PR TITLE
Linux: Make `get_fdpath` more optimal

### DIFF
--- a/Source/Common/FDUtils.h
+++ b/Source/Common/FDUtils.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <FEXCore/Utils/LogManager.h>
+
+#include <fcntl.h>
+#include <filesystem>
+#include <linux/limits.h>
+#include <unistd.h>
+
+namespace FEX {
+[[maybe_unused]]
+static
+std::string get_fdpath(int fd) {
+  char SymlinkPath[PATH_MAX];
+  std::filesystem::path Path = std::filesystem::path("/proc/self/fd") / std::to_string(fd);
+  int Result = readlinkat(AT_FDCWD, Path.c_str(), SymlinkPath, sizeof(SymlinkPath));
+  if (Result != -1) {
+    return SymlinkPath;
+  }
+
+  LOGMAN_MSG_A_FMT("Couldn't get symlink from /proc/self/fd/{}", fd);
+  return {};
+}
+
+}

--- a/Source/Tests/ELFCodeLoader2.h
+++ b/Source/Tests/ELFCodeLoader2.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "Common/Config.h"
+#include "Common/FDUtils.h"
 #include "Tests/LinuxSyscalls/Syscalls.h"
 #include "Linux/Utils/ELFParser.h"
 #include "Linux/Utils/ELFSymbolDatabase.h"
@@ -45,13 +46,6 @@ class ELFCodeLoader2 final : public FEXCore::CodeLoader {
   uintptr_t BrkStart;
   uintptr_t StackPointer;
 
-
-  static std::string get_fdpath(int fd)
-  {
-    std::error_code ec;
-    return std::filesystem::canonical(std::filesystem::path("/proc/self/fd") / std::to_string(fd), ec).string();
-  }
-
   size_t CalculateTotalElfSize(const std::vector<Elf64_Phdr> &headers)
   {
     auto first = std::find_if(headers.begin(), headers.end(), [](const Elf64_Phdr &Header) { return Header.p_type == PT_LOAD; });
@@ -84,7 +78,7 @@ class ELFCodeLoader2 final : public FEXCore::CodeLoader {
       LogMan::Msg::EFmt("MapFile: Some elf mapping failed, {}, fd: {}\n", errno, file.fd);
       return false;
     } else {
-      auto Filename = get_fdpath(file.fd);
+      auto Filename = FEX::get_fdpath(file.fd);
       Sections.push_back({Base, (uintptr_t)rv, size, (off_t)off, Filename, (prot & PROT_EXEC) != 0});
 
       return true;

--- a/Source/Tests/LinuxSyscalls/EmulatedFiles/EmulatedFiles.cpp
+++ b/Source/Tests/LinuxSyscalls/EmulatedFiles/EmulatedFiles.cpp
@@ -5,6 +5,7 @@ desc: Emulated /proc/cpuinfo, version, osrelease, etc
 $end_info$
 */
 
+#include "Common/FDUtils.h"
 #include "Tests/LinuxSyscalls/Syscalls.h"
 #include "Tests/LinuxSyscalls/EmulatedFiles/EmulatedFiles.h"
 
@@ -711,13 +712,9 @@ namespace FEX::EmulatedFile {
     if (((pathname && pathname[0] != '/') || // If pathname exists then it must not be absolute
         !pathname) &&
         dirfs != AT_FDCWD) {
-      auto get_fdpath = [](int fd) -> std::string {
-        std::error_code ec;
-        return std::filesystem::canonical(std::filesystem::path("/proc/self/fd") / std::to_string(fd), ec).string();
-      };
       // Passed in a dirfd that isn't magic FDCWD
       // We need to get the path from the fd now
-      Path = get_fdpath(dirfs);
+      Path = FEX::get_fdpath(dirfs);
 
       if (pathname) {
         if (!Path.empty()) {

--- a/Source/Tests/LinuxSyscalls/FileManagement.cpp
+++ b/Source/Tests/LinuxSyscalls/FileManagement.cpp
@@ -5,6 +5,8 @@ desc: Rootfs overlay logic
 $end_info$
 */
 
+#include "Common/FDUtils.h"
+
 #include "Tests/LinuxSyscalls/FileManagement.h"
 #include "Tests/LinuxSyscalls/EmulatedFiles/EmulatedFiles.h"
 #include "Tests/LinuxSyscalls/Syscalls.h"
@@ -539,13 +541,9 @@ uint64_t FileManager::Readlinkat(int dirfd, const char *pathname, char *buf, siz
   if (((pathname && pathname[0] != '/') || // If pathname exists then it must not be absolute
         !pathname) &&
         dirfd != AT_FDCWD) {
-    auto get_fdpath = [](int fd) -> std::string {
-      std::error_code ec;
-      return std::filesystem::canonical(std::filesystem::path("/proc/self/fd") / std::to_string(fd), ec).string();
-    };
     // Passed in a dirfd that isn't magic FDCWD
     // We need to get the path from the fd now
-    Path = get_fdpath(dirfd);
+    Path = FEX::get_fdpath(dirfd);
 
     if (pathname) {
       if (!Path.empty()) {

--- a/Source/Tests/LinuxSyscalls/Syscalls.h
+++ b/Source/Tests/LinuxSyscalls/Syscalls.h
@@ -48,6 +48,7 @@ namespace FEXCore {
 }
 
 namespace FEX::HLE {
+
 class SyscallHandler;
 class SignalDelegator;
   void RegisterEpoll();


### PR DESCRIPTION
std::filesystem::canonical is very heavyweight and walks the full path
to ensure that each folder in the path is not a symlink.

eg:
```
readlink("/proc", 0x7ffd5646e210, 1023)                                         = -1 EINVAL (Invalid argument)
readlink("/proc/self", "880556", 1023)                                          = 6
readlink("/proc/880556", 0x7ffd5646e210, 1023)                                  = -1 EINVAL (Invalid argument)
readlink("/proc/880556/fd", 0x7ffd5646e210, 1023)                               = -1 EINVAL (Invalid argument)
readlink("/proc/880556/fd/5", "/home/ryanh/.fex-emu/RootFS/Ubuntu_22_04/usr/lib/x86_64-linux-gnu/ld-linux-x86-6"..., 1023) = 86
readlink("/home", 0x7ffd5646e210, 1023)                                         = -1 EINVAL (Invalid argument)
readlink("/home/ryanh", 0x7ffd5646e210, 1023)                                   = -1 EINVAL (Invalid argument)
readlink("/home/ryanh/.fex-emu", 0x7ffd5646e210, 1023)                          = -1 EINVAL (Invalid argument)
readlink("/home/ryanh/.fex-emu/RootFS", 0x7ffd5646e210, 1023)                   = -1 EINVAL (Invalid argument)
readlink("/home/ryanh/.fex-emu/RootFS/Ubuntu_22_04", 0x7ffd5646e210, 1023)      = -1 EINVAL (Invalid argument)
readlink("/home/ryanh/.fex-emu/RootFS/Ubuntu_22_04/usr", 0x7ffd5646e210, 1023)  = -1 EINVAL (Invalid argument)
readlink("/home/ryanh/.fex-emu/RootFS/Ubuntu_22_04/usr/lib", 0x7ffd5646e210, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/ryanh/.fex-emu/RootFS/Ubuntu_22_04/usr/lib/x86_64-linux-gnu", 0x7ffd5646e210, 1023) = -1 EINVAL (Invalid argument)
readlink("/home/ryanh/.fex-emu/RootFS/Ubuntu_22_04/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2", 0x7ffd5646e210, 1023) = -1 EINVAL (Invalid argument)
```

This is what was occuring for every single mmap that occurs. /really/
adding to the time for the syscall to take.
This also happens on a couple of other syscalls which are using this new
path now.

The primary reason why this works is that we know that every entry in
`/proc/self/fd/` is a symlink. So instead of asking for canonical, we
can just read the symlink and this will redirect us to the canonical
path.
So this previous example goes from 14 syscalls down to 1.

eg:
```
readlinkat(AT_FDCWD, "/proc/self/fd/5", "/home/ryanh/.fex-emu/RootFS/Ubuntu_22_04/usr/lib/x86_64-linux-gnu/ld-linux-x86-6"..., 4096) = 86
```

While this is only a minor improvement in the "typical" operating environment,
this significantly improves performance of FEX under proot or if the
rootfs lives on a network share.