### PR TITLE
gdb: jit integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.14)
 project(FEX)
 
+INCLUDE (CheckIncludeFiles)
+CHECK_INCLUDE_FILES ("gdb/jit-reader.h" HAVE_GDB_JIT_READER_H)
+
 option(BUILD_TESTS "Build unit tests to ensure sanity" TRUE)
 option(BUILD_FEX_LINUX_TESTS "Build FEXLinuxTests, requires g++/g++-multilib or g++-x86-64-linux-gnu/g++-multilib-x86-64-linux-gnu" FALSE)
 option(BUILD_THUNKS "Build thunks" FALSE)
@@ -13,6 +16,7 @@ option(ENABLE_MOLD "Enable linking with mold" FALSE)
 option(ENABLE_ASAN "Enables Clang ASAN" FALSE)
 option(ENABLE_TSAN "Enables Clang TSAN" FALSE)
 option(ENABLE_ASSERTIONS "Enables assertions in build" FALSE)
+option(ENABLE_GDB_SYMBOLS "Enables GDBSymbols integration support" ${HAVE_GDB_JIT_READER_H})
 option(ENABLE_VISUAL_DEBUGGER "Enables the visual debugger for compiling" FALSE)
 option(ENABLE_STRICT_WERROR "Enables stricter -Werror for CI" FALSE)
 option(ENABLE_WERROR "Enables -Werror" FALSE)
@@ -43,6 +47,12 @@ if (ENABLE_ASSERTIONS)
   message(STATUS "Assertions enabled")
   add_definitions(-DASSERTIONS_ENABLED=1)
 endif()
+
+if (ENABLE_GDB_SYMBOLS)
+  message(STATUS "GDBSymbols support enabled")
+  add_definitions(-DGDB_SYMBOLS_ENABLED=1)
+endif()
+
 
 if (ENABLE_INTERPRETER)
   message(STATUS "Interpreter enabled")

--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -118,6 +118,7 @@ set (SRCS
   Interface/Core/X86Tables/X87Tables.cpp
   Interface/Core/X86Tables/XOPTables.cpp
   Interface/HLE/Thunks/Thunks.cpp
+  Interface/GDBJIT/GDBJIT.cpp
   Interface/IR/AOTIR.cpp
   Interface/IR/IRDumper.cpp
   Interface/IR/IRParser.cpp

--- a/External/FEXCore/Source/Interface/Config/Config.json.in
+++ b/External/FEXCore/Source/Interface/Config/Config.json.in
@@ -208,6 +208,16 @@
           "Useful for determining hot blocks of code",
           "Has some file writing overhead per JIT block"
         ]
+      },
+      "GDBSymbols": {
+        "Type": "bool",
+        "Default": "false",
+        "Desc": [
+          "Integrates with GDB using the JIT interface.",
+          "Needs the fex jit loader in GDB, which can be loaded via `jit-reader-load libFEXGDBReader.so.`",
+          "Also needs x86_64-linux-gnu-objdump in PATH.",
+          "Can be very slow."
+        ]
       }
     },
     "Logging": {

--- a/External/FEXCore/Source/Interface/Context/Context.cpp
+++ b/External/FEXCore/Source/Interface/Context/Context.cpp
@@ -156,6 +156,7 @@ namespace FEXCore::Context {
 
   void SetSyscallHandler(FEXCore::Context::Context *CTX, FEXCore::HLE::SyscallHandler *Handler) {
     CTX->SyscallHandler = Handler;
+    CTX->SourcecodeResolver = Handler->GetSourcecodeResolver();
   }
 
   FEXCore::CPUID::FunctionResults RunCPUIDFunction(FEXCore::Context::Context *CTX, uint32_t Function, uint32_t Leaf) {

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -49,6 +49,8 @@ namespace CPU {
 namespace HLE {
 struct SyscallArguments;
 class SyscallHandler;
+class SourcecodeResolver;
+struct SourcecodeMap;
 }
 }
 
@@ -107,6 +109,7 @@ namespace FEXCore::Context {
       FEX_CONFIG_OPT(GlobalJITNaming, GLOBALJITNAMING);
       FEX_CONFIG_OPT(LibraryJITNaming, LIBRARYJITNAMING);
       FEX_CONFIG_OPT(BlockJITNaming, BLOCKJITNAMING);
+      FEX_CONFIG_OPT(GDBSymbols, GDBSYMBOLS);
       FEX_CONFIG_OPT(ParanoidTSO, PARANOIDTSO);
       FEX_CONFIG_OPT(CacheObjectCodeCompilation, CACHEOBJECTCODECOMPILATION);
       FEX_CONFIG_OPT(x87ReducedPrecision, X87REDUCEDPRECISION);
@@ -130,6 +133,7 @@ namespace FEXCore::Context {
     
     FEXCore::CPUIDEmu CPUID;
     FEXCore::HLE::SyscallHandler *SyscallHandler{};
+    FEXCore::HLE::SourcecodeResolver *SourcecodeResolver{};
     std::unique_ptr<FEXCore::ThunkHandler> ThunkHandler;
     std::unique_ptr<FEXCore::CPU::Dispatcher> Dispatcher;
 

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -199,7 +199,7 @@ namespace FEXCore::Context {
       uint64_t StartAddr;
       uint64_t Length;
     };
-    [[nodiscard]] GenerateIRResult GenerateIR(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP);
+    [[nodiscard]] GenerateIRResult GenerateIR(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP, bool ExtendedDebugInfo);
 
     struct CompileCodeResult {
       void* CompiledCode;

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -717,7 +717,7 @@ namespace FEXCore::Context {
     }
   }
 
-  Context::GenerateIRResult Context::GenerateIR(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP) {    
+  Context::GenerateIRResult Context::GenerateIR(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP, bool ExtendedDebugInfo) {    
     Thread->OpDispatcher->ReownOrClaimBuffer();
     Thread->OpDispatcher->ResetWorkingList();
 
@@ -772,7 +772,9 @@ namespace FEXCore::Context {
           DecodedInfo = &Block.DecodedInstructions[i];
           bool IsLocked = DecodedInfo->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_LOCK;
 
-          Thread->OpDispatcher->_GuestOpcode(Block.Entry + BlockInstructionsLength - GuestRIP);
+          if (ExtendedDebugInfo) {
+            Thread->OpDispatcher->_GuestOpcode(Block.Entry + BlockInstructionsLength - GuestRIP);
+          }
           
           if (Config.SMCChecks == FEXCore::Config::CONFIG_SMC_FULL) {
             auto ExistingCodePtr = reinterpret_cast<uint64_t*>(Block.Entry + BlockInstructionsLength);
@@ -936,7 +938,7 @@ namespace FEXCore::Context {
 
     if (IRList == nullptr) {
       // Generate IR + Meta Info
-      auto [IRCopy, RACopy, TotalInstructions, TotalInstructionsLength, _StartAddr, _Length] = GenerateIR(Thread, GuestRIP);
+      auto [IRCopy, RACopy, TotalInstructions, TotalInstructionsLength, _StartAddr, _Length] = GenerateIR(Thread, GuestRIP, Config.GDBSymbols());
 
       // Setup pointers to internal structures
       IRList = IRCopy;

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -164,6 +164,7 @@ constexpr OpHandlerArray InterpreterOpHandlers = [] {
   REGISTER_OP(CODEBLOCK,              NoOp);
   REGISTER_OP(BEGINBLOCK,             NoOp);
   REGISTER_OP(ENDBLOCK,               NoOp);
+  REGISTER_OP(GUESTOPCODE,            NoOp);
   REGISTER_OP(FENCE,                  Fence);
   REGISTER_OP(BREAK,                  Break);
   REGISTER_OP(PHI,                    NoOp);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -672,6 +672,7 @@ void *Arm64JITCore::CompileCode(uint64_t Entry, [[maybe_unused]] FEXCore::IR::IR
 
   this->Entry = Entry;
   this->RAData = RAData;
+  this->DebugData = DebugData;
 
   #ifndef NDEBUG
   LoadConstant(x0, Entry);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -147,6 +147,7 @@ private:
   void EmitDetectionString();
   IR::RegisterAllocationPass *RAPass;
   IR::RegisterAllocationData *RAData;
+  FEXCore::Core::DebugData *DebugData;
 
   void ResetStack();
   /**
@@ -348,7 +349,7 @@ private:
   DEF_OP(CacheLineZero);
 
   ///< Misc ops
-  DEF_OP(EndBlock);
+  DEF_OP(GuestOpcode);
   DEF_OP(Fence);
   DEF_OP(Break);
   DEF_OP(Phi);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
@@ -6,11 +6,18 @@ $end_info$
 
 #include <syscall.h>
 #include "Interface/Core/JIT/Arm64/JITClass.h"
+#include "FEXCore/Debug/InternalThreadState.h"
 
 namespace FEXCore::CPU {
 using namespace vixl;
 using namespace vixl::aarch64;
 #define DEF_OP(x) void Arm64JITCore::Op_##x(IR::IROp_Header *IROp, IR::NodeID Node)
+
+DEF_OP(GuestOpcode) {
+  auto Op = IROp->C<IR::IROp_GuestOpcode>();
+  // metadata
+  DebugData->GuestOpcodes.push_back({Op->GuestEntryOffset, GetCursorAddress<uint8_t*>() - GuestEntry});
+}
 
 DEF_OP(Fence) {
   auto Op = IROp->C<IR::IROp_Fence>();
@@ -232,6 +239,7 @@ void Arm64JITCore::RegisterMiscHandlers() {
   REGISTER_OP(CODEBLOCK,  NoOp);
   REGISTER_OP(BEGINBLOCK, NoOp);
   REGISTER_OP(ENDBLOCK,   NoOp);
+  REGISTER_OP(GUESTOPCODE, GuestOpcode);
   REGISTER_OP(FENCE,      Fence);
   REGISTER_OP(BREAK,      Break);
   REGISTER_OP(PHI,        NoOp);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -189,6 +189,7 @@ private:
 
   IR::RegisterAllocationPass *RAPass;
   FEXCore::IR::RegisterAllocationData *RAData;
+  FEXCore::Core::DebugData *DebugData;
 
 #ifdef BLOCKSTATS
   bool GetSamplingData {true};
@@ -200,6 +201,11 @@ private:
   void EmitDetectionString();
 
   uint32_t SpillSlots{};
+  /**
+  * @brief Current guest RIP entrypoint
+  */
+  uint8_t *GuestEntry{};
+  
   using SetCC = void (X86JITCore::*)(const Operand& op);
   using CMovCC = void (X86JITCore::*)(const Reg& reg, const Operand& op);
   using JCC = void (X86JITCore::*)(const Label& label, LabelType type);
@@ -341,7 +347,7 @@ private:
   DEF_OP(CacheLineZero);
 
   ///< Misc ops
-  DEF_OP(EndBlock);
+  DEF_OP(GuestOpcode);
   DEF_OP(Fence);
   DEF_OP(Break);
   DEF_OP(Phi);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/MiscOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/MiscOps.cpp
@@ -7,6 +7,7 @@ $end_info$
 #include "Interface/Context/Context.h"
 #include "Interface/Core/Dispatcher/Dispatcher.h"
 #include "Interface/Core/JIT/x86_64/JITClass.h"
+#include "FEXCore/Debug/InternalThreadState.h"
 
 #include <FEXCore/Core/CoreState.h>
 #include <FEXCore/Utils/LogManager.h>
@@ -19,6 +20,12 @@ $end_info$
 
 namespace FEXCore::CPU {
 #define DEF_OP(x) void X86JITCore::Op_##x(IR::IROp_Header *IROp, IR::NodeID Node)
+
+DEF_OP(GuestOpcode) {
+  auto Op = IROp->C<IR::IROp_GuestOpcode>();
+  // metadata
+  DebugData->GuestOpcodes.push_back({Op->GuestEntryOffset, getCurr<uint8_t*>() - GuestEntry});
+}
 
 DEF_OP(Fence) {
   auto Op = IROp->C<IR::IROp_Fence>();
@@ -178,6 +185,7 @@ void X86JITCore::RegisterMiscHandlers() {
   REGISTER_OP(CODEBLOCK,  NoOp);
   REGISTER_OP(BEGINBLOCK, NoOp);
   REGISTER_OP(ENDBLOCK,   NoOp);
+  REGISTER_OP(GUESTOPCODE, GuestOpcode);
   REGISTER_OP(FENCE,      Fence);
   REGISTER_OP(BREAK,      Break);
   REGISTER_OP(PHI,        NoOp);

--- a/External/FEXCore/Source/Interface/GDBJIT/GDBJIT.cpp
+++ b/External/FEXCore/Source/Interface/GDBJIT/GDBJIT.cpp
@@ -1,0 +1,127 @@
+#include "GDBJIT.h"
+
+#include <FEXCore/Debug/InternalThreadState.h>
+#include <FEXCore/HLE/SourcecodeResolver.h>
+#include <FEXCore/Utils/LogManager.h>
+
+#if defined(GDB_SYMBOLS_ENABLED)
+
+#include <FEXCore/Debug/GDBReaderInterface.h>
+
+extern "C" {
+enum jit_actions_t { JIT_NOACTION = 0, JIT_REGISTER_FN, JIT_UNREGISTER_FN };
+
+struct jit_code_entry {
+  jit_code_entry *next_entry;
+  jit_code_entry *prev_entry;
+  const char *symfile_addr;
+  uint64_t symfile_size;
+};
+
+struct jit_descriptor {
+  uint32_t version;
+  /* This type should be jit_actions_t, but we use uint32_t
+     to be explicit about the bitwidth.  */
+  uint32_t action_flag;
+  jit_code_entry *relevant_entry;
+  jit_code_entry *first_entry;
+};
+
+/* Make sure to specify the version statically, because the
+   debugger may check the version before we can set it.  */
+
+constinit jit_descriptor __jit_debug_descriptor = {.version = 1};
+
+/* GDB puts a breakpoint in this function.  */
+void __attribute__((noinline)) __jit_debug_register_code() {
+  asm volatile("" ::"r"(&__jit_debug_descriptor));
+};
+}
+
+namespace FEXCore {
+
+void GDBJITRegister(FEXCore::IR::AOTIRCacheEntry *Entry, uintptr_t VAFileStart,
+                    uint64_t GuestRIP, uintptr_t HostEntry,
+                    FEXCore::Core::DebugData *DebugData) {
+  auto map = Entry->SourcecodeMap.get();
+
+  if (map) {
+    auto FileOffset = GuestRIP - VAFileStart;
+
+    auto Sym = map->FindSymbolMapping(FileOffset);
+
+    std::string SymName = HLE::SourcecodeSymbolMapping::SymName(
+        Sym, Entry->Filename, HostEntry, FileOffset);
+
+    std::vector<gdb_line_mapping> Lines;
+    for (const auto &GuestOpcode : DebugData->GuestOpcodes) {
+      auto Line = map->FindLineMapping(GuestRIP + GuestOpcode.GuestEntryOffset -
+                                       VAFileStart);
+      if (Line) {
+        Lines.push_back(
+            {Line->LineNumber, HostEntry + GuestOpcode.HostEntryOffset});
+      }
+    }
+
+    size_t size = sizeof(info_t) + 1 * sizeof(blocks_t) +
+                  Lines.size() * sizeof(gdb_line_mapping);
+
+    auto mem = (uint8_t *)malloc(size);
+    auto base = mem;
+    info_t *info = (info_t *)mem;
+    mem += sizeof(info_t);
+
+    strncpy(info->filename, map->SourceFile.c_str(), 511);
+
+    info->nblocks = 1;
+
+    auto blocks = (blocks_t *)mem;
+    info->blocks_ofs = mem - base;
+
+    mem += info->nblocks * sizeof(blocks_t);
+
+    for (int i = 0; i < info->nblocks; i++) {
+      strncpy(blocks[i].name, SymName.c_str(), 511);
+      blocks[i].start = HostEntry;
+      blocks[i].end = HostEntry + DebugData->HostCodeSize;
+    }
+
+    info->nlines = Lines.size();
+
+    auto lines = (gdb_line_mapping *)mem;
+    info->lines_ofs = mem - base;
+    mem += info->nlines * sizeof(gdb_line_mapping);
+
+    if (info->nlines) {
+      memcpy(lines, &Lines.at(0), info->nlines * sizeof(gdb_line_mapping));
+    }
+
+    auto entry = new jit_code_entry{0, 0, 0, 0};
+
+    entry->symfile_addr = (const char *)info;
+    entry->symfile_size = size;
+
+    if (__jit_debug_descriptor.first_entry) {
+      __jit_debug_descriptor.relevant_entry->next_entry = entry;
+      entry->prev_entry = __jit_debug_descriptor.relevant_entry;
+    } else {
+      __jit_debug_descriptor.first_entry = entry;
+    }
+
+    __jit_debug_descriptor.relevant_entry = entry;
+    __jit_debug_descriptor.action_flag = JIT_REGISTER_FN;
+    __jit_debug_register_code();
+  }
+}
+} // namespace FEXCore
+#else
+namespace FEXCore {
+void GDBJITRegister([[maybe_unused]] FEXCore::IR::AOTIRCacheEntry *Entry,
+                    [[maybe_unused]] uintptr_t VAFileStart,
+                    [[maybe_unused]] uint64_t GuestRIP,
+                    [[maybe_unused]] uintptr_t HostEntry,
+                    [[maybe_unused]] FEXCore::Core::DebugData *DebugData) {
+  ERROR_AND_DIE_FMT("GDBSymbols support not compiled in");
+}
+} // namespace FEXCore
+#endif

--- a/External/FEXCore/Source/Interface/GDBJIT/GDBJIT.h
+++ b/External/FEXCore/Source/Interface/GDBJIT/GDBJIT.h
@@ -1,0 +1,7 @@
+
+
+#include <Interface/IR/AOTIR.h>
+
+namespace FEXCore {
+    void GDBJITRegister(FEXCore::IR::AOTIRCacheEntry *Entry, uintptr_t VAFileStart, uint64_t GuestRIP, uintptr_t HostEntry, FEXCore::Core::DebugData *DebugData);
+}

--- a/External/FEXCore/Source/Interface/IR/AOTIR.cpp
+++ b/External/FEXCore/Source/Interface/IR/AOTIR.cpp
@@ -418,11 +418,6 @@ namespace FEXCore::IR {
       __jit_debug_descriptor.relevant_entry = entry;
       __jit_debug_descriptor.action_flag = JIT_REGISTER_FN;
       __jit_debug_register_code();
-      // LogMan::Msg::DFmt("Registered {} - blocks {}, lines {}, Code {:x}, Size {}", SymName, info->nblocks, info->nlines,
-      // HostEntry, DebugData->HostCodeSize);
-
-      // DebuggerHandle
-      // register?
     }
   }
   #endif

--- a/External/FEXCore/Source/Interface/IR/AOTIR.cpp
+++ b/External/FEXCore/Source/Interface/IR/AOTIR.cpp
@@ -300,9 +300,9 @@ namespace FEXCore::IR {
 
   AOTIRCaptureCache::PreGenerateIRFetchResult AOTIRCaptureCache::PreGenerateIRFetch(uint64_t GuestRIP, FEXCore::IR::IRListView *IRList) {
     auto AOTIRCacheEntry = CTX->SyscallHandler->LookupAOTIRCacheEntry(GuestRIP);
-    
+
     PreGenerateIRFetchResult Result{};
-    
+
     if (AOTIRCacheEntry.Entry) {
       AOTIRCacheEntry.Entry->ContainsCode = true;
 
@@ -344,24 +344,11 @@ namespace FEXCore::IR {
     auto map = Entry->SourcecodeMap.get();
 
     if (map) {
-      auto FileBegin = GuestRIP - VAFileStart;
+      auto FileOffset = GuestRIP - VAFileStart;
 
-      auto Sym = map->FindSymbolMapping(FileBegin);
+      auto Sym = map->FindSymbolMapping(FileOffset);
 
-      std::string SymName;
-      if (Sym) {
-        auto SymOffset = FileBegin - Sym->FileGuestBegin;
-        if (SymOffset) {
-          SymName = fmt::format("{}: {}+{} @{:x}", std::filesystem::path(Entry->Filename).stem().string(), Sym->Name,
-                                SymOffset, HostEntry);
-        } else {
-          SymName = fmt::format("{}: {} @{:x}", std::filesystem::path(Entry->Filename).stem().string(), Sym->Name,
-                                HostEntry);
-        }
-      } else {
-        SymName = fmt::format("{}: +{} @{:x}", std::filesystem::path(Entry->Filename).stem().string(), FileBegin,
-                              HostEntry);
-      }
+      std::string SymName = HLE::SourcecodeSymbolMapping::SymName(Sym, Entry->Filename, HostEntry, FileOffset);
 
       std::vector<gdb_line_mapping> Lines;
       for (const auto &GuestOpcode : DebugData->GuestOpcodes) {

--- a/External/FEXCore/Source/Interface/IR/AOTIR.cpp
+++ b/External/FEXCore/Source/Interface/IR/AOTIR.cpp
@@ -6,6 +6,7 @@
 #include <FEXCore/Utils/Allocator.h>
 #include <FEXCore/HLE/SyscallHandler.h>
 #include <Interface/Core/LookupCache.h>
+#include <FEXCore/HLE/SourcecodeResolver.h>
 
 #include <cstddef>
 #include <cstdint>
@@ -16,6 +17,63 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <xxhash.h>
+
+
+#if defined(GDB_SYMBOLS_ENABLED)
+
+#include <gdb/jit-reader.h>
+
+struct blocks_t {
+  char name[512];
+  GDB_CORE_ADDR start;
+  GDB_CORE_ADDR end;
+};
+
+struct info_t {
+  char filename[512];
+  long blocks_ofs;
+  long lines_ofs;
+
+  int nblocks;
+  int nlines;
+};
+
+
+extern "C" {
+enum jit_actions_t
+{
+  JIT_NOACTION = 0,
+  JIT_REGISTER_FN,
+  JIT_UNREGISTER_FN
+};
+
+struct jit_code_entry
+{
+  jit_code_entry *next_entry;
+  jit_code_entry *prev_entry;
+  const char *symfile_addr;
+  uint64_t symfile_size;
+};
+
+struct jit_descriptor
+{
+  uint32_t version;
+  /* This type should be jit_actions_t, but we use uint32_t
+     to be explicit about the bitwidth.  */
+  uint32_t action_flag;
+  jit_code_entry *relevant_entry;
+  jit_code_entry *first_entry;
+};
+
+/* Make sure to specify the version statically, because the
+   debugger may check the version before we can set it.  */
+
+constinit jit_descriptor __jit_debug_descriptor = { .version = 1 };
+
+/* GDB puts a breakpoint in this function.  */
+void __attribute__((noinline)) __jit_debug_register_code() { asm volatile (""::"r"(&__jit_debug_descriptor)); };
+}
+#endif
 
 namespace FEXCore::IR {
   AOTIRInlineEntry *AOTIRInlineIndex::GetInlineEntry(uint64_t DataOffset) {
@@ -253,7 +311,7 @@ namespace FEXCore::IR {
 
         if (Mod != nullptr)
         {
-          auto AOTEntry = Mod->Find(GuestRIP - AOTIRCacheEntry.Offset);
+          auto AOTEntry = Mod->Find(GuestRIP - AOTIRCacheEntry.VAFileStart);
 
           if (AOTEntry) {
             // verify hash
@@ -281,6 +339,94 @@ namespace FEXCore::IR {
     return Result;
   }
 
+#if defined(GDB_SYMBOLS_ENABLED)
+  static void GDBJITRegister(AOTIRCacheEntry *Entry, uintptr_t VAFileStart, uint64_t GuestRIP, uintptr_t HostEntry, FEXCore::Core::DebugData *DebugData) {
+    auto map = Entry->SourcecodeMap.get();
+
+    if (map) {
+      auto FileBegin = GuestRIP - VAFileStart;
+
+      auto Sym = map->FindSymbolMapping(FileBegin);
+
+      std::string SymName;
+      if (Sym) {
+        auto SymOffset = FileBegin - Sym->FileGuestBegin;
+        if (SymOffset) {
+          SymName = fmt::format("{}: {}+{} @{:x}", std::filesystem::path(Entry->Filename).stem().string(), Sym->Name,
+                                SymOffset, HostEntry);
+        } else {
+          SymName = fmt::format("{}: {} @{:x}", std::filesystem::path(Entry->Filename).stem().string(), Sym->Name,
+                                HostEntry);
+        }
+      } else {
+        SymName = fmt::format("{}: +{} @{:x}", std::filesystem::path(Entry->Filename).stem().string(), FileBegin,
+                              HostEntry);
+      }
+
+      std::vector<gdb_line_mapping> Lines;
+      for (const auto &GuestOpcode : DebugData->GuestOpcodes) {
+        auto Line = map->FindLineMapping(GuestRIP + GuestOpcode.GuestEntryOffset - VAFileStart);
+        if (Line) {
+          Lines.push_back({Line->LineNumber, HostEntry + GuestOpcode.HostEntryOffset});
+        }
+      }
+
+      size_t size = sizeof(info_t) + 1 * sizeof(blocks_t) + Lines.size() * sizeof(gdb_line_mapping);
+
+      auto mem = (uint8_t *)malloc(size);
+      auto base = mem;
+      info_t *info = (info_t *)mem;
+      mem += sizeof(info_t);
+
+      strncpy(info->filename, map->SourceFile.c_str(), 511);
+
+      info->nblocks = 1;
+
+      auto blocks = (blocks_t *)mem;
+      info->blocks_ofs = mem - base;
+
+      mem += info->nblocks * sizeof(blocks_t);
+
+      for (int i = 0; i < info->nblocks; i++) {
+        strncpy(blocks[i].name, SymName.c_str(), 511);
+        blocks[i].start = HostEntry;
+        blocks[i].end = HostEntry + DebugData->HostCodeSize;
+      }
+
+      info->nlines = Lines.size();
+
+      auto lines = (gdb_line_mapping *)mem;
+      info->lines_ofs = mem - base;
+      mem += info->nlines * sizeof(gdb_line_mapping);
+
+      if (info->nlines) {
+        memcpy(lines, &Lines.at(0), info->nlines * sizeof(gdb_line_mapping));
+      }
+
+      auto entry = new jit_code_entry{0, 0, 0, 0};
+
+      entry->symfile_addr = (const char *)info;
+      entry->symfile_size = size;
+
+      if (__jit_debug_descriptor.first_entry) {
+        __jit_debug_descriptor.relevant_entry->next_entry = entry;
+        entry->prev_entry = __jit_debug_descriptor.relevant_entry;
+      } else {
+        __jit_debug_descriptor.first_entry = entry;
+      }
+
+      __jit_debug_descriptor.relevant_entry = entry;
+      __jit_debug_descriptor.action_flag = JIT_REGISTER_FN;
+      __jit_debug_register_code();
+      // LogMan::Msg::DFmt("Registered {} - blocks {}, lines {}, Code {:x}, Size {}", SymName, info->nblocks, info->nlines,
+      // HostEntry, DebugData->HostCodeSize);
+
+      // DebuggerHandle
+      // register?
+    }
+  }
+  #endif
+
   bool AOTIRCaptureCache::PostCompileCode(
     FEXCore::Core::InternalThreadState *Thread,
     void* CodePtr,
@@ -291,8 +437,9 @@ namespace FEXCore::IR {
     FEXCore::IR::IRListView *IRList,
     FEXCore::Core::DebugData *DebugData,
     bool GeneratedIR) {
+
     // Both generated ir and LibraryJITName need a named region lookup
-    if (GeneratedIR || CTX->Config.LibraryJITNaming()) {
+    if (GeneratedIR || CTX->Config.LibraryJITNaming() || CTX->Config.GDBSymbols()) {
 
       auto AOTIRCacheEntry = CTX->SyscallHandler->LookupAOTIRCacheEntry(GuestRIP);
 
@@ -301,14 +448,22 @@ namespace FEXCore::IR {
           CTX->Symbols.RegisterNamedRegion(CodePtr, DebugData->HostCodeSize, AOTIRCacheEntry.Entry->Filename);
         }
 
+        if (CTX->Config.GDBSymbols()) {
+          #if defined(GDB_SYMBOLS_ENABLED)
+            GDBJITRegister(AOTIRCacheEntry.Entry, AOTIRCacheEntry.VAFileStart, GuestRIP, (uintptr_t)CodePtr, DebugData);
+          #else
+            ERROR_AND_DIE_FMT("GDBSymbols support not compiled in");
+          #endif
+        }
+
         // Add to AOT cache if aot generation is enabled
         if (GeneratedIR && RAData &&
             (CTX->Config.AOTIRCapture() || CTX->Config.AOTIRGenerate())) {
 
           auto hash = XXH3_64bits((void*)StartAddr, Length);
 
-          auto LocalRIP = GuestRIP - AOTIRCacheEntry.Offset;
-          auto LocalStartAddr = StartAddr - AOTIRCacheEntry.Offset;
+          auto LocalRIP = GuestRIP - AOTIRCacheEntry.VAFileStart;
+          auto LocalStartAddr = StartAddr - AOTIRCacheEntry.VAFileStart;
           auto FileId = AOTIRCacheEntry.Entry->FileId;
           // The underlying pointer and the unique_ptr deleter for RAData must
           // be marshalled separately to the lambda below. Otherwise, the
@@ -377,7 +532,7 @@ namespace FEXCore::IR {
 
       std::unique_lock lk(AOTIRCacheLock);
 
-      auto Inserted = AOTIRCache.insert({fileid, AOTIRCacheEntry{0, 0, 0, fileid, filename, false}});
+      auto Inserted = AOTIRCache.insert({fileid, AOTIRCacheEntry { .FileId = fileid, .Filename = filename }});
       auto Entry = &(Inserted.first->second);
 
       LOGMAN_THROW_A_FMT(Entry->Array == nullptr, "Duplicate LoadAOTIRCacheEntry");

--- a/External/FEXCore/Source/Interface/IR/AOTIR.cpp
+++ b/External/FEXCore/Source/Interface/IR/AOTIR.cpp
@@ -6,7 +6,7 @@
 #include <FEXCore/Utils/Allocator.h>
 #include <FEXCore/HLE/SyscallHandler.h>
 #include <Interface/Core/LookupCache.h>
-#include <FEXCore/HLE/SourcecodeResolver.h>
+#include <Interface/GDBJIT/GDBJIT.h>
 
 #include <cstddef>
 #include <cstdint>
@@ -18,62 +18,6 @@
 #include <unistd.h>
 #include <xxhash.h>
 
-
-#if defined(GDB_SYMBOLS_ENABLED)
-
-#include <gdb/jit-reader.h>
-
-struct blocks_t {
-  char name[512];
-  GDB_CORE_ADDR start;
-  GDB_CORE_ADDR end;
-};
-
-struct info_t {
-  char filename[512];
-  long blocks_ofs;
-  long lines_ofs;
-
-  int nblocks;
-  int nlines;
-};
-
-
-extern "C" {
-enum jit_actions_t
-{
-  JIT_NOACTION = 0,
-  JIT_REGISTER_FN,
-  JIT_UNREGISTER_FN
-};
-
-struct jit_code_entry
-{
-  jit_code_entry *next_entry;
-  jit_code_entry *prev_entry;
-  const char *symfile_addr;
-  uint64_t symfile_size;
-};
-
-struct jit_descriptor
-{
-  uint32_t version;
-  /* This type should be jit_actions_t, but we use uint32_t
-     to be explicit about the bitwidth.  */
-  uint32_t action_flag;
-  jit_code_entry *relevant_entry;
-  jit_code_entry *first_entry;
-};
-
-/* Make sure to specify the version statically, because the
-   debugger may check the version before we can set it.  */
-
-constinit jit_descriptor __jit_debug_descriptor = { .version = 1 };
-
-/* GDB puts a breakpoint in this function.  */
-void __attribute__((noinline)) __jit_debug_register_code() { asm volatile (""::"r"(&__jit_debug_descriptor)); };
-}
-#endif
 
 namespace FEXCore::IR {
   AOTIRInlineEntry *AOTIRInlineIndex::GetInlineEntry(uint64_t DataOffset) {
@@ -339,76 +283,6 @@ namespace FEXCore::IR {
     return Result;
   }
 
-#if defined(GDB_SYMBOLS_ENABLED)
-  static void GDBJITRegister(AOTIRCacheEntry *Entry, uintptr_t VAFileStart, uint64_t GuestRIP, uintptr_t HostEntry, FEXCore::Core::DebugData *DebugData) {
-    auto map = Entry->SourcecodeMap.get();
-
-    if (map) {
-      auto FileOffset = GuestRIP - VAFileStart;
-
-      auto Sym = map->FindSymbolMapping(FileOffset);
-
-      std::string SymName = HLE::SourcecodeSymbolMapping::SymName(Sym, Entry->Filename, HostEntry, FileOffset);
-
-      std::vector<gdb_line_mapping> Lines;
-      for (const auto &GuestOpcode : DebugData->GuestOpcodes) {
-        auto Line = map->FindLineMapping(GuestRIP + GuestOpcode.GuestEntryOffset - VAFileStart);
-        if (Line) {
-          Lines.push_back({Line->LineNumber, HostEntry + GuestOpcode.HostEntryOffset});
-        }
-      }
-
-      size_t size = sizeof(info_t) + 1 * sizeof(blocks_t) + Lines.size() * sizeof(gdb_line_mapping);
-
-      auto mem = (uint8_t *)malloc(size);
-      auto base = mem;
-      info_t *info = (info_t *)mem;
-      mem += sizeof(info_t);
-
-      strncpy(info->filename, map->SourceFile.c_str(), 511);
-
-      info->nblocks = 1;
-
-      auto blocks = (blocks_t *)mem;
-      info->blocks_ofs = mem - base;
-
-      mem += info->nblocks * sizeof(blocks_t);
-
-      for (int i = 0; i < info->nblocks; i++) {
-        strncpy(blocks[i].name, SymName.c_str(), 511);
-        blocks[i].start = HostEntry;
-        blocks[i].end = HostEntry + DebugData->HostCodeSize;
-      }
-
-      info->nlines = Lines.size();
-
-      auto lines = (gdb_line_mapping *)mem;
-      info->lines_ofs = mem - base;
-      mem += info->nlines * sizeof(gdb_line_mapping);
-
-      if (info->nlines) {
-        memcpy(lines, &Lines.at(0), info->nlines * sizeof(gdb_line_mapping));
-      }
-
-      auto entry = new jit_code_entry{0, 0, 0, 0};
-
-      entry->symfile_addr = (const char *)info;
-      entry->symfile_size = size;
-
-      if (__jit_debug_descriptor.first_entry) {
-        __jit_debug_descriptor.relevant_entry->next_entry = entry;
-        entry->prev_entry = __jit_debug_descriptor.relevant_entry;
-      } else {
-        __jit_debug_descriptor.first_entry = entry;
-      }
-
-      __jit_debug_descriptor.relevant_entry = entry;
-      __jit_debug_descriptor.action_flag = JIT_REGISTER_FN;
-      __jit_debug_register_code();
-    }
-  }
-  #endif
-
   bool AOTIRCaptureCache::PostCompileCode(
     FEXCore::Core::InternalThreadState *Thread,
     void* CodePtr,
@@ -431,11 +305,7 @@ namespace FEXCore::IR {
         }
 
         if (CTX->Config.GDBSymbols()) {
-          #if defined(GDB_SYMBOLS_ENABLED)
-            GDBJITRegister(AOTIRCacheEntry.Entry, AOTIRCacheEntry.VAFileStart, GuestRIP, (uintptr_t)CodePtr, DebugData);
-          #else
-            ERROR_AND_DIE_FMT("GDBSymbols support not compiled in");
-          #endif
+          GDBJITRegister(AOTIRCacheEntry.Entry, AOTIRCacheEntry.VAFileStart, GuestRIP, (uintptr_t)CodePtr, DebugData);
         }
 
         // Add to AOT cache if aot generation is enabled

--- a/External/FEXCore/Source/Interface/IR/AOTIR.h
+++ b/External/FEXCore/Source/Interface/IR/AOTIR.h
@@ -12,6 +12,7 @@
 #include <unordered_map>
 #include <shared_mutex>
 #include <queue>
+#include <FEXCore/HLE/SourcecodeResolver.h>
 
 namespace FEXCore::Core {
 struct DebugData;
@@ -75,6 +76,7 @@ namespace FEXCore::IR {
     AOTIRInlineIndex *Array;
     void *FilePtr;
     size_t Size;
+    std::unique_ptr<FEXCore::HLE::SourcecodeMap> SourcecodeMap;
     std::string FileId;
     std::string Filename;
     bool ContainsCode;

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -181,6 +181,11 @@
         "RAOverride": "0"
       },
 
+      "GuestOpcode u32:$GuestEntryOffset": {
+        "Desc": ["Marks the beginning of a guest opcode"],
+        "HasSideEffects": true
+      },
+
       "GPR = ValidateCode u64:$CodeOriginalLow, u64:$CodeOriginalhigh, i64:$Offset, u8:$CodeLength": {
         "HasSideEffects": true,
         "HasDest": true,

--- a/External/FEXCore/include/FEXCore/Debug/GDBReaderInterface.h
+++ b/External/FEXCore/include/FEXCore/Debug/GDBReaderInterface.h
@@ -1,0 +1,22 @@
+#include <cstddef>
+#include <cstdint>
+
+#include <gdb/jit-reader.h>
+
+// everything is stored inline as it is marshaled cross process by gdb
+
+struct blocks_t {
+  char name[512];
+  GDB_CORE_ADDR start;
+  GDB_CORE_ADDR end;
+};
+
+struct info_t {
+  char filename[512];
+
+  ptrdiff_t blocks_ofs;
+  ptrdiff_t lines_ofs;
+
+  int nblocks;
+  int nlines;
+};

--- a/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
+++ b/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
@@ -46,6 +46,11 @@ namespace FEXCore::Core {
     uint32_t HostCodeSize;
   };
 
+  struct DebugDataGuestOpcode {
+    uint64_t GuestEntryOffset;
+    ptrdiff_t HostEntryOffset;
+  };
+
   /**
    * @brief Contains debug data for a block of code for later debugger analysis
    *
@@ -54,6 +59,7 @@ namespace FEXCore::Core {
   struct DebugData {
     uint64_t HostCodeSize; ///< The size of the code generated in the host JIT
     std::vector<DebugDataSubblock> Subblocks;
+    std::vector<DebugDataGuestOpcode> GuestOpcodes;
     std::vector<FEXCore::CPU::Relocation> *Relocations;
   };
 

--- a/External/FEXCore/include/FEXCore/HLE/SourcecodeResolver.h
+++ b/External/FEXCore/include/FEXCore/HLE/SourcecodeResolver.h
@@ -1,9 +1,11 @@
 #pragma once
 #include <algorithm>
-#include <optional>
 #include <string>
 #include <vector>
 #include <memory>
+#include <filesystem>
+
+#include <fmt/format.h>
 
 namespace FEXCore::IR {
   struct AOTIRCacheEntry;
@@ -23,6 +25,22 @@ struct SourcecodeSymbolMapping {
   uintptr_t FileGuestEnd;
 
   std::string Name;
+
+  static std::string SymName(const SourcecodeSymbolMapping *Sym, const std::string &GuestFilename, uintptr_t HostEntry, uintptr_t FileBegin) {
+    if (Sym) {
+      auto SymOffset = FileBegin - Sym->FileGuestBegin;
+      if (SymOffset) {
+        return fmt::format("{}: {}+{} @{:x}", std::filesystem::path(GuestFilename).stem().string(), Sym->Name,
+                              SymOffset, HostEntry);
+      } else {
+        return fmt::format("{}: {} @{:x}", std::filesystem::path(GuestFilename).stem().string(), Sym->Name,
+                              HostEntry);
+      }
+    } else {
+      return fmt::format("{}: +{} @{:x}", std::filesystem::path(GuestFilename).stem().string(), FileBegin,
+                            HostEntry);
+    }
+  }
 };
 
 struct SourcecodeMap {

--- a/External/FEXCore/include/FEXCore/HLE/SourcecodeResolver.h
+++ b/External/FEXCore/include/FEXCore/HLE/SourcecodeResolver.h
@@ -1,0 +1,78 @@
+#pragma once
+#include <algorithm>
+#include <optional>
+#include <string>
+#include <vector>
+#include <memory>
+
+namespace FEXCore::IR {
+  struct AOTIRCacheEntry;
+}
+
+namespace FEXCore::HLE {
+
+struct SourcecodeLineMapping {
+  uintptr_t FileGuestBegin;
+  uintptr_t FileGuestEnd;
+  
+  int LineNumber;
+};
+
+struct SourcecodeSymbolMapping {
+  uintptr_t FileGuestBegin;
+  uintptr_t FileGuestEnd;
+
+  std::string Name;
+};
+
+struct SourcecodeMap {
+  std::string SourceFile;
+  std::vector<SourcecodeLineMapping> SortedLineMappings;
+  std::vector<SourcecodeSymbolMapping> SortedSymbolMappings;
+
+  template<typename F>
+  void IterateLineMappings(uintptr_t FileBegin, uintptr_t Size, const F &Callback) const {
+    auto Begin = FileBegin;
+    auto End = FileBegin + Size;
+
+    auto Found = std::lower_bound(SortedLineMappings.cbegin(), SortedLineMappings.cend(), Begin, [](const auto &Range, const auto Position) {
+      return Range.FileGuestEnd <= Position;
+    });
+
+    while (Found != SortedLineMappings.cend()) {
+      if (Found->FileGuestBegin < End && Found->FileGuestEnd > Begin) {
+        Callback(Found);
+      } else {
+        break;
+      }
+      Found++;
+    }
+  }
+
+  const SourcecodeLineMapping *FindLineMapping(uintptr_t FileBegin) const {
+    return Find(FileBegin, SortedLineMappings);
+  }
+
+  const SourcecodeSymbolMapping *FindSymbolMapping(uintptr_t FileBegin) const {
+    return Find(FileBegin, SortedSymbolMappings);
+  }
+private:
+  template<typename VecT>
+  const typename VecT::value_type *Find(uintptr_t FileBegin, const VecT &SortedMappings) const {
+    auto Found = std::lower_bound(SortedMappings.cbegin(), SortedMappings.cend(), FileBegin, [](const auto &Range, const auto Position) {
+      return Range.FileGuestEnd <= Position;
+    });
+
+    if (Found != SortedMappings.end() && Found->FileGuestBegin <= FileBegin && Found->FileGuestEnd > FileBegin) {
+      return &(*Found);
+    } else {
+      return {};
+    }
+  }
+};
+
+class SourcecodeResolver {
+public:
+  virtual std::unique_ptr<SourcecodeMap> GenerateMap(const std::string_view& GuestBinaryFile, const std::string_view& GuestBinaryFileId) = 0;
+};
+}

--- a/External/FEXCore/include/FEXCore/HLE/SyscallHandler.h
+++ b/External/FEXCore/include/FEXCore/HLE/SyscallHandler.h
@@ -50,9 +50,11 @@ namespace FEXCore::HLE {
   };
 
   class SyscallHandler;
+  class SourcecodeResolver;
+
   struct AOTIRCacheEntryLookupResult {
-    AOTIRCacheEntryLookupResult(FEXCore::IR::AOTIRCacheEntry *Entry, uintptr_t Offset, FHU::ScopedSignalMaskWithSharedLock &&lk)
-      : Entry(Entry), Offset(Offset), lk(std::move(lk))
+    AOTIRCacheEntryLookupResult(FEXCore::IR::AOTIRCacheEntry *Entry, uintptr_t VAFileStart, FHU::ScopedSignalMaskWithSharedLock &&lk)
+      : Entry(Entry), VAFileStart(VAFileStart), lk(std::move(lk))
     {
 
     }
@@ -60,7 +62,7 @@ namespace FEXCore::HLE {
     AOTIRCacheEntryLookupResult(AOTIRCacheEntryLookupResult&&) = default;
 
     FEXCore::IR::AOTIRCacheEntry *Entry;
-    uintptr_t Offset;
+    uintptr_t VAFileStart;
 
     friend class SyscallHandler;
     protected:
@@ -80,6 +82,7 @@ namespace FEXCore::HLE {
     virtual void MarkGuestExecutableRange(uint64_t Start, uint64_t Length) { }
     virtual AOTIRCacheEntryLookupResult LookupAOTIRCacheEntry(uint64_t GuestAddr) = 0;
 
+    virtual SourcecodeResolver *GetSourcecodeResolver() { return nullptr; }
   protected:
     SyscallOSABI OSABI;
   };

--- a/Source/Tests/LinuxSyscalls/Syscalls.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls.cpp
@@ -7,6 +7,7 @@ $end_info$
 */
 
 #include "Linux/Utils/ELFContainer.h"
+#include "Linux/Utils/ELFParser.h"
 
 #include "Tests/LinuxSyscalls/LinuxAllocator.h"
 #include "Tests/LinuxSyscalls/Syscalls.h"
@@ -37,6 +38,7 @@ $end_info$
 #include <filesystem>
 #include <fstream>
 #include <memory>
+#include <regex>
 #include <sched.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -698,6 +700,331 @@ void SyscallHandler::UnlockAfterFork() {
   // VMATracking.Mutex.unlock();
   
   FM.GetFDLock()->unlock(); 
+}
+
+static bool isHEX(char c) {
+  return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f');
+}
+
+std::unique_ptr<FEXCore::HLE::SourcecodeMap> SyscallHandler::GenerateMap(const std::string_view& GuestBinaryFile, const std::string_view& GuestBinaryFileId) {
+
+  ELFParser GuestELF;
+
+  if (!GuestELF.ReadElf(std::string(GuestBinaryFile))) {
+    LogMan::Msg::DFmt("GenerateMap: '{}' is not an elf file?", GuestBinaryFile);
+    return {};
+  }
+  
+  struct stat GuestBinaryFileStat;
+
+  if (stat(GuestBinaryFile.data(), &GuestBinaryFileStat)) {
+    LogMan::Msg::DFmt("GenerateMap: failed to stat '{}'", GuestBinaryFile);
+    return {};
+  }
+
+  std::error_code ec;
+  auto FexSrcPath = std::filesystem::path(FEXCore::Config::GetDataDirectory()) / "fexsrc";
+  std::filesystem::create_directories(FexSrcPath, ec);
+
+  if (ec) {
+    LogMan::Msg::DFmt("GenerateMap: failed to create_directories '{}'", FexSrcPath.string());
+    return {};
+  }
+
+  auto GuestSourceFile = (FexSrcPath / GuestBinaryFileId).string() + ".src";
+
+  struct stat GuestSourceFileStat;
+
+  if (stat(GuestSourceFile.data(), &GuestSourceFileStat) != 0 || GuestBinaryFileStat.st_mtime > GuestSourceFileStat.st_mtime) {
+    LogMan::Msg::DFmt("GenerateMap: Generating source for '{}'", GuestBinaryFile);
+    auto command = fmt::format("x86_64-linux-gnu-objdump -SC \'{}\' > '{}'", GuestBinaryFile, GuestSourceFile);  
+    if (system(command.c_str()) != 0) {
+      LogMan::Msg::DFmt("GenerateMap: '{}' failed", command);
+      return {};
+    }
+  }
+
+  auto GuestIndexFile = (FexSrcPath / GuestBinaryFileId).string() + ".idx";
+  struct stat GuestIndexFileStat;
+
+  bool GenerateIndex = stat(GuestIndexFile.data(), &GuestIndexFileStat) != 0 || GuestSourceFileStat.st_mtime > GuestIndexFileStat.st_mtime;
+
+  if (!GenerateIndex) {
+    LogMan::Msg::DFmt("GenerateMap: reading index '{}'", GuestIndexFile);
+    
+    std::ifstream Stream(GuestIndexFile);
+
+    if (!Stream) {
+      LogMan::Msg::DFmt("GenerateMap: failed to open '{}'", GuestIndexFile);
+      goto DoGenerate;
+    }
+
+    //"fexsrcindex0"
+    char filemagic[12];
+    Stream.read(filemagic, sizeof(filemagic));
+    if (memcmp(filemagic, "fexsrcindex0", sizeof(filemagic)) != 0) {
+      LogMan::Msg::DFmt("GenerateMap: '{}' has invalid magic '{}'", GuestIndexFile, filemagic);
+      goto DoGenerate;
+    }
+
+    auto rv = std::make_unique<FEXCore::HLE::SourcecodeMap>();
+
+    {
+      auto len = rv->SourceFile.size();
+      Stream.read((char*)&len, sizeof(len));
+      rv->SourceFile.resize(len);
+      Stream.read(rv->SourceFile.data(), len);
+    }
+
+    {
+      auto len = rv->SortedLineMappings.size();
+      
+      Stream.read((char*)&len, sizeof(len));
+
+      rv->SortedLineMappings.resize(len);
+
+      for (auto &Mapping: rv->SortedLineMappings) {
+        Stream.read((char*)&Mapping.FileGuestBegin, sizeof(Mapping.FileGuestBegin));
+        Stream.read((char*)&Mapping.FileGuestEnd, sizeof(Mapping.FileGuestEnd));
+        Stream.read((char*)&Mapping.LineNumber, sizeof(Mapping.LineNumber));
+      }
+    }
+
+    {
+      auto len = rv->SortedSymbolMappings.size();
+      
+      Stream.read((char*)&len, sizeof(len));
+
+      rv->SortedSymbolMappings.resize(len);
+
+      for (auto &Mapping: rv->SortedSymbolMappings) {
+        Stream.read((char*)&Mapping.FileGuestBegin, sizeof(Mapping.FileGuestBegin));
+        Stream.read((char*)&Mapping.FileGuestEnd, sizeof(Mapping.FileGuestEnd));
+
+        {
+          auto len = Mapping.Name.size();
+          Stream.read((char*)&len, sizeof(len));
+          Mapping.Name.resize(len);
+          Stream.read(Mapping.Name.data(), len);
+        }
+      }
+    }
+
+    LogMan::Msg::DFmt("GenerateMap: Finished reading index", GuestIndexFile);
+    return rv;
+  } else {
+    DoGenerate:
+    LogMan::Msg::DFmt("GenerateMap: Generating index for '{}'", GuestSourceFile);
+    std::ifstream Stream(GuestSourceFile);
+
+    if (!Stream) {
+      LogMan::Msg::DFmt("GenerateMap: failed to open '{}'", GuestSourceFile);
+    }
+
+    std::ofstream IndexStream(GuestIndexFile);
+
+    if (!IndexStream) {
+      LogMan::Msg::DFmt("GenerateMap: failed to open '{}' for writing", GuestIndexFile);
+    }
+
+    IndexStream.write("fexsrcindex0", strlen("fexsrcindex0"));
+
+    std::string Line;
+    int LineNum = 0;
+    auto Syntax = std::regex_constants::ECMAScript | std::regex_constants::optimize;
+
+    //"0000000000057030 <name>"
+    std::regex SymbolDefPattern(R"(^([0-9a-z]{8,16}) (<[^>]+>):$)", Syntax);
+
+    //"    addrhex:\t...."
+    //^ *([0-9a-z]+):\\t
+    std::regex OffsetDefPattern("^ +([0-9a-z]+)", Syntax);
+
+    bool PreviousLineWasEmpty = false;
+
+    uintptr_t LastSymbolOffset{};
+    uintptr_t CurrentSymbolOffset{};
+    std::string LastSymbolName;
+
+    uintptr_t LastOffset{};
+    uintptr_t CurrentOffset{};
+    int LastOffsetLine;
+
+    auto rv = std::make_unique<FEXCore::HLE::SourcecodeMap>();
+
+    rv->SourceFile = GuestSourceFile;
+
+    auto EndSymbol = [&] {
+      if (LastSymbolOffset) {
+        rv->SortedSymbolMappings.push_back({LastSymbolOffset, CurrentSymbolOffset, LastSymbolName});
+
+        // LogMan::Msg::DFmt("Ended Symbol {} - {:x}...{:x}", LastSymbolName, LastSymbolOffset, CurrentSymbolOffset);
+      }
+      LastSymbolOffset = {};
+    };
+
+    auto EndLine = [&] {
+      if (LastOffset) {
+        rv->SortedLineMappings.push_back({LastOffset, CurrentOffset, LastOffsetLine});
+
+        // LogMan::Msg::DFmt("Ended Line {} - {:x}...{:x}", LastOffsetLine, LastOffset, CurrentOffset);
+      }
+      LastOffset = {};
+    };
+
+    while (std::getline(Stream, Line)) {
+      LineNum++;
+
+      auto LineIsEmpty = Line.empty();
+
+      if (LineIsEmpty) {
+        PreviousLineWasEmpty = true;
+      } else {
+
+        // LogMan::Msg::DFmt("Line: '{}'", Line);
+
+        if (isHEX(Line[0])) {
+          std::string addr;
+          int offs = 1;
+          for (; !isspace(Line[offs]) && offs < Line.size(); offs++)
+            ;
+
+          if (offs == Line.size())
+            continue;
+          if (offs != 8 && offs != 16)
+            continue;
+
+          auto VAOffset = std::strtoul(Line.substr(0, offs).c_str(), nullptr, 16);
+
+          auto FileOffset = GuestELF.VAToFile(VAOffset);
+
+          if (FileOffset == 0) {
+            LogMan::Msg::EFmt("File Offset {:x} did not map to file?! {}", VAOffset, Line);
+          }
+
+          CurrentSymbolOffset = FileOffset;
+
+          if (PreviousLineWasEmpty) {
+            EndSymbol();
+          }
+          LastSymbolOffset = CurrentSymbolOffset;
+
+          for (; Line[offs] != '<' && offs < Line.size(); offs++)
+            ;
+
+          if (offs == Line.size())
+            continue;
+
+          offs++;
+
+          LastSymbolName = Line.substr(offs, Line.size() - 2 - offs);
+
+          // LogMan::Msg::DFmt("Symbol {} @ {:x} -> Line {}", LastSymbolName, LastSymbolOffset, LineNum);
+        } else if (isspace(Line[0])) {
+          int offs = 1;
+          for (; isspace(Line[offs]) && offs < Line.size(); offs++)
+            ;
+
+          if (offs == Line.size())
+            continue;
+
+          int start = offs;
+
+          for (; Line[offs] != ':' && offs < Line.size(); offs++)
+            ;
+
+          if (offs == Line.size())
+            continue;
+
+          if (Line[offs + 1] == '\t') {
+            auto VAOffsetStr = Line.substr(start, offs - start);
+            auto VAOffset = std::strtoul(VAOffsetStr.c_str(), nullptr, 16);
+            auto FileOffset = GuestELF.VAToFile(VAOffset);
+            if (FileOffset == 0) {
+              LogMan::Msg::EFmt("File Offset {:x} did not map to file?! {}", VAOffset, Line);
+            } else {
+              if (LastOffset > FileOffset) {
+                LogMan::Msg::EFmt("File Offset {:x} less than previous {:} ?!  {}", FileOffset, LastOffset, Line);
+              }
+              CurrentOffset = FileOffset;
+
+              EndLine();
+
+              LastOffset = CurrentOffset;
+              LastOffsetLine = LineNum;
+            }
+          }
+        }
+#if WHY_REGEX_NO_WORKY_I_WONDER
+        std::cmatch Matches;
+        if (std::regex_match(Line.c_str(), Matches, SymbolDefPattern)) {
+          CurrentSymbolOffset = std::strtoul(Matches[0], nullptr, 16);
+          if (PreviousLineWasEmpty) {
+            EndSymbol();
+          }
+          LastSymbolOffset = CurrentSymbolOffset;
+          LastSymbolName = Matches[1];
+          LogMan::Msg::DFmt("Symbol {} @ {:x} -> Line {}", LastSymbolName, LastSymbolOffset, LineNum);
+        } else if (std::regex_match(Line.c_str(), Matches, OffsetDefPattern)) {
+          LastOffset = std::strtoul(Matches[0].second, nullptr, 16);
+          LogMan::Msg::DFmt("Offset {:x} -> Line {}", LastOffset, LineNum);
+        }
+#endif
+        // something else -- keep going
+      }
+    }
+
+    CurrentOffset = LastOffset + 4;
+    CurrentSymbolOffset = CurrentOffset;
+
+    EndSymbol();
+    EndLine();
+
+    std::sort(rv->SortedLineMappings.begin(), rv->SortedLineMappings.end(),
+              [](const auto &One, const auto &Two) { return One.FileGuestEnd <= Two.FileGuestBegin; });
+
+    std::sort(rv->SortedSymbolMappings.begin(), rv->SortedSymbolMappings.end(),
+              [](const auto &One, const auto &Two) { return One.FileGuestEnd <= Two.FileGuestBegin; });
+
+    {
+      auto len = rv->SourceFile.size();
+      IndexStream.write((const char*)&len, sizeof(len));
+      IndexStream.write(rv->SourceFile.c_str(), len);
+    }
+
+    {
+      auto len = rv->SortedLineMappings.size();
+      
+      IndexStream.write((const char*)&len, sizeof(len));
+
+      for (const auto &Mapping: rv->SortedLineMappings) {
+        IndexStream.write((const char*)&Mapping.FileGuestBegin, sizeof(Mapping.FileGuestBegin));
+        IndexStream.write((const char*)&Mapping.FileGuestEnd, sizeof(Mapping.FileGuestEnd));
+        IndexStream.write((const char*)&Mapping.LineNumber, sizeof(Mapping.LineNumber));
+      }
+    }
+
+    {
+      auto len = rv->SortedSymbolMappings.size();
+      
+      IndexStream.write((char*)&len, sizeof(len));
+
+      for (const auto &Mapping: rv->SortedSymbolMappings) {
+        IndexStream.write((const char*)&Mapping.FileGuestBegin, sizeof(Mapping.FileGuestBegin));
+        IndexStream.write((const char*)&Mapping.FileGuestEnd, sizeof(Mapping.FileGuestEnd));
+
+        {
+          auto len = Mapping.Name.size();
+          IndexStream.write((const char*)&len, sizeof(len));
+          IndexStream.write(Mapping.Name.c_str(), len);
+        }
+      }
+    }
+
+    return rv;
+  }
+
+  
 }
 
 }

--- a/Source/Tests/LinuxSyscalls/Syscalls.h
+++ b/Source/Tests/LinuxSyscalls/Syscalls.h
@@ -12,6 +12,7 @@ $end_info$
 
 #include <FEXCore/Config/Config.h>
 #include <FEXCore/HLE/SyscallHandler.h>
+#include <FEXCore/HLE/SourcecodeResolver.h>
 #include <FEXCore/IR/IR.h>
 #include <FEXCore/Utils/CompilerDefs.h>
 
@@ -83,7 +84,7 @@ struct ExecveAtArgs {
 
 uint64_t ExecveHandler(const char *pathname, char* const* argv, char* const* envp, ExecveAtArgs *Args);
 
-class SyscallHandler : public FEXCore::HLE::SyscallHandler {
+class SyscallHandler : public FEXCore::HLE::SyscallHandler, FEXCore::HLE::SourcecodeResolver {
 public:
   virtual ~SyscallHandler();
 
@@ -192,6 +193,8 @@ public:
   ///// FORK tracking /////
   void LockBeforeFork();
   void UnlockAfterFork();
+
+  SourcecodeResolver *GetSourcecodeResolver() override { return this; }
   
 protected:
   SyscallHandler(FEXCore::Context::Context *_CTX, FEX::HLE::SignalDelegator *_SignalDelegation);
@@ -224,6 +227,8 @@ private:
   #endif
 
   std::unique_ptr<FEX::HLE::MemAllocator> Alloc32Handler{};
+
+  std::unique_ptr<FEXCore::HLE::SourcecodeMap> GenerateMap(const std::string_view& GuestBinaryFile, const std::string_view& GuestBinaryFileId) override;
   
   ///// VMA (Virtual Memory Area) tracking /////
 

--- a/Source/Tests/LinuxSyscalls/SyscallsSMCTracking.cpp
+++ b/Source/Tests/LinuxSyscalls/SyscallsSMCTracking.cpp
@@ -173,7 +173,7 @@ FEXCore::HLE::AOTIRCacheEntryLookupResult SyscallHandler::LookupAOTIRCacheEntry(
 
   if (Entry != _SyscallHandler->VMATracking.VMAs.end()) {
     rv.Entry = Entry->second.Resource ? Entry->second.Resource->AOTIRCacheEntry : nullptr;
-    rv.Offset = Entry->second.Base - Entry->second.Offset;
+    rv.VAFileStart = Entry->second.Base - Entry->second.Offset;
   }
 
   return rv;

--- a/Source/Tools/CMakeLists.txt
+++ b/Source/Tools/CMakeLists.txt
@@ -11,6 +11,9 @@ if (NOT TERMUX_BUILD)
   add_subdirectory(FEXRootFSFetcher/)
 endif()
 
+if (ENABLE_GDB_SYMBOLS)
+  add_subdirectory(FEXGDBReader/)
+endif()
 add_subdirectory(FEXGetConfig/)
 add_subdirectory(FEXServer/)
 

--- a/Source/Tools/FEXGDBReader/CMakeLists.txt
+++ b/Source/Tools/FEXGDBReader/CMakeLists.txt
@@ -1,0 +1,12 @@
+set(NAME FEXGDBReader)
+set(SRCS FEXGDBReader.cpp)
+
+add_library(${NAME} SHARED ${SRCS})
+
+install(TARGETS ${NAME}
+  RUNTIME
+  LIBRARY DESTINATION /usr/lib/gdb
+  COMPONENT LIBRARY)
+
+target_include_directories(${NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/Source/)
+target_include_directories(${NAME} PRIVATE ${CMAKE_BINARY_DIR}/generated)

--- a/Source/Tools/FEXGDBReader/CMakeLists.txt
+++ b/Source/Tools/FEXGDBReader/CMakeLists.txt
@@ -10,3 +10,6 @@ install(TARGETS ${NAME}
 
 target_include_directories(${NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/Source/)
 target_include_directories(${NAME} PRIVATE ${CMAKE_BINARY_DIR}/generated)
+
+# We don't actually link, but this is a nice way to get the include dirs
+target_link_libraries(${NAME} PRIVATE Common)

--- a/Source/Tools/FEXGDBReader/FEXGDBReader.cpp
+++ b/Source/Tools/FEXGDBReader/FEXGDBReader.cpp
@@ -1,0 +1,82 @@
+#include <cstddef>
+#include <cstdio>
+#include <unordered_map>
+#include <mutex>
+#include <string>
+
+#include "gdb/jit-reader.h"
+
+GDB_DECLARE_GPL_COMPATIBLE_READER;
+
+// everything is stored inline as it is marshaled cross process by gdb
+
+struct blocks_t {
+  const char name[512];
+  GDB_CORE_ADDR start;
+  GDB_CORE_ADDR end;
+};
+
+struct info_t {
+  char filename[512];
+  long blocks_ofs;
+  long lines_ofs;
+
+  int nblocks;
+  int nlines;
+};
+
+#define debugf(...)
+
+extern "C" {
+static enum gdb_status read_debug_info(struct gdb_reader_funcs *self, struct gdb_symbol_callbacks *cbs, void *memory, long memory_sz) {
+  
+  info_t *info = (info_t *)memory;
+  blocks_t *blocks = (blocks_t *)(info->blocks_ofs + (long)memory);
+  gdb_line_mapping *lines = (gdb_line_mapping *)(info->lines_ofs + (long)memory);
+  debugf("info: %p\n", info);
+  debugf("info: s %p\n", info->filename);
+  debugf("info: s %s\n", info->filename);
+  debugf("info: l %d\n", info->nlines);
+  debugf("info: b %d\n", info->nblocks);
+
+  struct gdb_object *object = cbs->object_open(cbs);
+  struct gdb_symtab *symtab = cbs->symtab_open(cbs, object, info->filename);
+
+  for (int i = 0; i < info->nblocks; i++) {
+    debugf("info: %d\n", i);
+    debugf("info: %lx\n", blocks[i].start);
+    debugf("info: %lx\n", blocks[i].end);
+    debugf("info: %s\n", blocks[i].name);
+    cbs->block_open(cbs, symtab, NULL, blocks[i].start, blocks[i].end, blocks[i].name);
+  }
+
+  debugf("info: lines %d\n", info->nlines);
+  debugf("info: lines %p\n", lines);
+
+  for (int i = 0; i < info->nlines; i++) {
+    debugf("info: line: %d\n", i);
+    debugf("info: line pc: %lx\n", lines[i].pc);
+    debugf("info: line file: %d\n", lines[i].line);
+  }
+  cbs->line_mapping_add(cbs, symtab, info->nlines, lines);
+
+  // don't close here, symtab and object are cached
+  cbs->symtab_close(cbs, symtab);
+  cbs->object_close(cbs, object);
+  return GDB_SUCCESS;
+}
+
+enum gdb_status unwind_frame(struct gdb_reader_funcs *self, struct gdb_unwind_callbacks *cbs) { return GDB_SUCCESS; }
+
+struct gdb_frame_id get_frame_id(struct gdb_reader_funcs *self, struct gdb_unwind_callbacks *cbs) {
+  struct gdb_frame_id frame = {0x1234000, 0};
+  return frame;
+}
+
+void destroy_reader(struct gdb_reader_funcs *self) {}
+
+extern struct gdb_reader_funcs *gdb_init_reader(void) {
+  static struct gdb_reader_funcs funcs = {GDB_READER_INTERFACE_VERSION, NULL, read_debug_info, unwind_frame, get_frame_id, destroy_reader};
+  return &funcs;
+}
+}

--- a/Source/Tools/FEXGDBReader/FEXGDBReader.cpp
+++ b/Source/Tools/FEXGDBReader/FEXGDBReader.cpp
@@ -4,26 +4,9 @@
 #include <mutex>
 #include <string>
 
-#include "gdb/jit-reader.h"
+#include <FEXCore/Debug/GDBReaderInterface.h>
 
 GDB_DECLARE_GPL_COMPATIBLE_READER;
-
-// everything is stored inline as it is marshaled cross process by gdb
-
-struct blocks_t {
-  const char name[512];
-  GDB_CORE_ADDR start;
-  GDB_CORE_ADDR end;
-};
-
-struct info_t {
-  char filename[512];
-  long blocks_ofs;
-  long lines_ofs;
-
-  int nblocks;
-  int nlines;
-};
 
 #define debugf(...)
 


### PR DESCRIPTION
#### Intro
The question no one asked: If gdb stub is too much in fex, what about fex stub in gdb?

This is a very-quick-hack-and-slash prototype to get some feedback. With a small set of features, gdb could become /much/ more welcoming to us. I'll ponder on what that means and think about talking with upstream.

Even as is, the results are very encouraging. Looks like long-term, we'd have to generate faux elfs or work with upstream for an improved interface.


#### Overview
##### x86-64 host
![Split view debugging x86-64](https://user-images.githubusercontent.com/393266/174461639-98c44e63-a5d3-4c42-ae65-2bede8b88837.png)

##### arm64 host
![Split view debugging arm64](https://user-images.githubusercontent.com/393266/175543519-8d690416-d6fc-45c1-8c16-912df9a60536.png)

Uses the gdb jit interface to register guest asm and guest source. Uses `x86-....-objdump -SC` to generate mixed asm / source 'source' files. Places them in `~/.fex-emu/fexsrc/fileid.fexsrc`.

Can be slow during objdump, parsing or with many symbols.

See https://github.com/FEX-Emu/fex-assorted-tests-bins/tree/main/src/gdb-jit#gdb-jit-interface-test on how to use the GDB side of things.

in gdb,
```
layout split
```

Is pretty. `ni`, `si`, `n`,`s` are your friends.


#### Limitations
- Dispatcher debug info is not registered
- Backtraces are broken. GDB depends on us for them, including for the host.
- Guest registers aren't registered as symbols
- Guest debug symbols aren't registered as symbols either


#### Depends 
- #1799