### PR TITLE
Ioctl: Safely access v3d csd ioctl structure

### DIFF
--- a/Source/Tests/LinuxSyscalls/x32/Ioctl/drm.h
+++ b/Source/Tests/LinuxSyscalls/x32/Ioctl/drm.h
@@ -991,7 +991,7 @@ fex_drm_v3d_submit_csd {
   uint32_t pad;
   /**  @} */
 
-  fex_drm_v3d_submit_csd() = delete;
+  fex_drm_v3d_submit_csd() = default;
 
   operator drm_v3d_submit_csd() const {
     drm_v3d_submit_csd val{};
@@ -1007,6 +1007,37 @@ fex_drm_v3d_submit_csd {
     val.pad = pad;
     return val;
   }
+
+  static void SafeConvertToGuest(fex_drm_v3d_submit_csd *Result, drm_v3d_submit_csd Src, size_t IoctlSize) {
+    // We need to be more careful since this API changes over time
+    fex_drm_v3d_submit_csd Tmp = Src;
+    memcpy(Result, &Tmp, IoctlSize);
+  }
+
+  static
+  drm_v3d_submit_csd SafeConvertToHost(fex_drm_v3d_submit_csd *Src, size_t IoctlSize) {
+    // We need to be more careful since this API changes over time
+    drm_v3d_submit_csd Result{};
+
+    // Copy the incoming variable over with memcpy
+    // This way if it is smaller than expected we will zero the remaining struct
+    fex_drm_v3d_submit_csd Tmp{};
+    memcpy(&Tmp, Src, std::min(IoctlSize, sizeof(fex_drm_v3d_submit_csd)));
+
+    memcpy(Result.cfg, Tmp.cfg, sizeof(cfg));
+    memcpy(Result.coef, Tmp.coef, sizeof(coef));
+    Result.bo_handles = Tmp.bo_handles;
+    Result.bo_handle_count = Tmp.bo_handle_count;
+    Result.in_sync = Tmp.in_sync;
+    Result.out_sync = Tmp.out_sync;
+    Result.perfmon_id = Tmp.perfmon_id;
+    Result.extensions = Tmp.extensions;
+    Result.flags = Tmp.flags;
+    Result.pad = Tmp.pad;
+
+    return Result;
+  }
+
   fex_drm_v3d_submit_csd(drm_v3d_submit_csd val) {
     memcpy(cfg, val.cfg, sizeof(cfg));
     memcpy(coef, val.coef, sizeof(coef));

--- a/Source/Tests/LinuxSyscalls/x32/IoctlEmulation.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/IoctlEmulation.cpp
@@ -373,10 +373,10 @@ namespace FEX::HLE::x32 {
       switch (_IOC_NR(cmd)) {
         case _IOC_NR(FEX_DRM_IOCTL_V3D_SUBMIT_CSD): {
           FEX::HLE::x32::V3D::fex_drm_v3d_submit_csd *val = reinterpret_cast<FEX::HLE::x32::V3D::fex_drm_v3d_submit_csd*>(args);
-          drm_v3d_submit_csd Host_val = *val;
+          drm_v3d_submit_csd Host_val = FEX::HLE::x32::V3D::fex_drm_v3d_submit_csd::SafeConvertToHost(val, _IOC_SIZE(cmd));
           uint64_t Result = ::ioctl(fd, DRM_IOCTL_V3D_SUBMIT_CSD, &Host_val);
           if (Result != -1) {
-            *val = Host_val;
+            FEX::HLE::x32::V3D::fex_drm_v3d_submit_csd::SafeConvertToGuest(val, Host_val, _IOC_SIZE(cmd));
           }
           SYSCALL_ERRNO();
           break;


### PR DESCRIPTION
DRM ioctls are taking advantage of the fact that any ioctl structure
that is passed in to the kernel smaller than the expected value will
zero out the remaining members of the structure.

Some more ioctls coming down the pipe will also abuse this, so we might
as well as get started with the v3d ioctl that requires it.

Due to how this works, the kernel knows how big an ioctl structure
should be and if the userspace passes in a smaller struct, it will
memset the remaining size to zero.