### PR TITLE
AVX initial groundwork

### DIFF
--- a/External/FEXCore/Source/Interface/Config/Config.json.in
+++ b/External/FEXCore/Source/Interface/Config/Config.json.in
@@ -49,6 +49,13 @@
           "Cache JIT object code to drive.",
           "Allows JIT code to be shared between applications"
         ]
+      },
+      "EnableAVX": {
+        "Type": "bool",
+        "Default": "true",
+        "Desc": [
+          "Determines whether or not we use the expanded register file for AVX or not"
+        ]
       }
     },
     "Emulation": {

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -114,6 +114,7 @@ namespace FEXCore::Context {
       FEX_CONFIG_OPT(CacheObjectCodeCompilation, CACHEOBJECTCODECOMPILATION);
       FEX_CONFIG_OPT(x87ReducedPrecision, X87REDUCEDPRECISION);
       FEX_CONFIG_OPT(x86dec_SynchronizeRIPOnAllBlocks, X86DEC_SYNCHRONIZERIPONALLBLOCKS);
+      FEX_CONFIG_OPT(EnableAVX, ENABLEAVX);
     } Config;
 
     FEXCore::HostFeatures HostFeatures;

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
@@ -209,19 +209,11 @@ void Arm64Emitter::SpillStaticRegs(bool FPRs, uint32_t GPRSpillMask, uint32_t FP
     }
 
     if (FPRs) {
-      for (size_t i = 0; i < SRAFPR.size(); i+=2) {
-        auto Reg1 = SRAFPR[i];
-        auto Reg2 = SRAFPR[i+1];
+      for (size_t i = 0; i < SRAFPR.size(); i++) {
+        const auto Reg = SRAFPR[i];
 
-        if (((1U << Reg1.GetCode()) & FPRSpillMask) &&
-            ((1U << Reg2.GetCode()) & FPRSpillMask)) {
-          stp(Reg1.Q(), Reg2.Q(), MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, State.xmm[i][0])));
-        }
-        else if (((1U << Reg1.GetCode()) & FPRSpillMask)) {
-          str(Reg1.Q(), MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, State.xmm[i][0])));
-        }
-        else if (((1U << Reg2.GetCode()) & FPRSpillMask)) {
-          str(Reg2.Q(), MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, State.xmm[i+1][0])));
+        if (((1U << Reg.GetCode()) & FPRSpillMask) != 0) {
+          str(Reg.Q(), MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, State.xmm[i][0])));
         }
       }
     }
@@ -246,19 +238,11 @@ void Arm64Emitter::FillStaticRegs(bool FPRs, uint32_t GPRFillMask, uint32_t FPRF
     }
 
     if (FPRs) {
-      for (size_t i = 0; i < SRAFPR.size(); i+=2) {
-        auto Reg1 = SRAFPR[i];
-        auto Reg2 = SRAFPR[i+1];
+      for (size_t i = 0; i < SRAFPR.size(); i++) {
+        const auto Reg = SRAFPR[i];
 
-        if (((1U << Reg1.GetCode()) & FPRFillMask) &&
-            ((1U << Reg2.GetCode()) & FPRFillMask)) {
-          ldp(Reg1.Q(), Reg2.Q(), MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, State.xmm[i][0])));
-        }
-        else if (((1U << Reg1.GetCode()) & FPRFillMask)) {
-          ldr(Reg1.Q(), MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, State.xmm[i][0])));
-        }
-        else if (((1U << Reg2.GetCode()) & FPRFillMask)) {
-          ldr(Reg2.Q(), MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, State.xmm[i+1][0])));
+        if (((1U << Reg.GetCode()) & FPRFillMask) != 0) {
+          ldr(Reg.Q(), MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, State.xmm[i][0])));
         }
       }
     }

--- a/External/FEXCore/Source/Interface/Core/CPUID.cpp
+++ b/External/FEXCore/Source/Interface/Core/CPUID.cpp
@@ -83,7 +83,10 @@ static uint32_t CalculateNumberOfCPUs() {
   return CPUs;
 }
 
+// TODO: Replace usages with CTX->HostFeatures.EnableAVX
+//       when AVX implementations are further along.
 constexpr uint32_t SUPPORTS_AVX = 0;
+
 // #define CPUID_AMD
 #ifdef CPUID_AMD
 constexpr uint32_t FAMILY_IDENTIFIER =

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -154,6 +154,9 @@ namespace FEXCore::Context {
     if (Config.CacheObjectCodeCompilation() != FEXCore::Config::ConfigObjectCodeHandler::CONFIG_NONE) {
       CodeObjectCacheService = std::make_unique<FEXCore::CodeSerialize::CodeObjectSerializeService>(this);
     }
+    if (!Config.EnableAVX) {
+      HostFeatures.SupportsAVX = false;
+    }
   }
 
   Context::~Context() {

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -187,6 +187,8 @@ namespace FEXCore::Context {
     for (auto& xmm : NewThreadState.xmm) {
       xmm[0] = 0xDEADBEEFULL;
       xmm[1] = 0xBAD0DAD1ULL;
+      xmm[2] = 0xDEADCAFEULL;
+      xmm[3] = 0xBAD2CAD3ULL;
     }
     memset(NewThreadState.flags, 0, Core::CPUState::NUM_EFLAG_BITS);
     NewThreadState.flags[1] = 1;

--- a/External/FEXCore/Source/Interface/Core/GdbServer.cpp
+++ b/External/FEXCore/Source/Interface/Core/GdbServer.cpp
@@ -259,7 +259,7 @@ struct FEX_PACKED GDBContextDefinition {
   uint32_t fctrl;
   uint32_t fstat;
   uint32_t dummies[6];
-  uint64_t xmm[Core::CPUState::NUM_XMMS][2];
+  uint64_t xmm[Core::CPUState::NUM_XMMS][4];
   uint32_t mxcsr;
 };
 
@@ -490,6 +490,30 @@ std::string buildTargetXML() {
       reg("mxcsr", "int", 32);
 
     xml << "</feature>\n";
+
+    xml << "<feature name='org.gnu.gdb.i386.avx'>";
+    xml <<
+        R"(<vector id="v4f" type="ieee_single" count="4"/>
+        <vector id="v2d" type="ieee_double" count="2"/>
+        <vector id="v16i8" type="int8" count="16"/>
+        <vector id="v8i16" type="int16" count="8"/>
+        <vector id="v4i32" type="int32" count="4"/>
+        <vector id="v2i64" type="int64" count="2"/>
+        <union id="vec128">
+          <field name="v4_float" type="v4f"/>
+          <field name="v2_double" type="v2d"/>
+          <field name="v16_int8" type="v16i8"/>
+          <field name="v8_int16" type="v8i16"/>
+          <field name="v4_int32" type="v4i32"/>
+          <field name="v2_int64" type="v2i64"/>
+          <field name="uint128" type="uint128"/>
+        </union>
+        )";
+    for (size_t i = 0; i < Core::CPUState::NUM_XMMS; i++) {
+        reg(fmt::format("ymm{}h", i), "vec128", 128);
+    }
+    xml << "</feature>\n";
+
   xml << "</target>";
   xml << std::flush;
 

--- a/External/FEXCore/Source/Interface/Core/HostFeatures.cpp
+++ b/External/FEXCore/Source/Interface/Core/HostFeatures.cpp
@@ -62,6 +62,9 @@ HostFeatures::HostFeatures() {
   SupportsRCPC = Features.Has(vixl::CPUFeatures::Feature::kRCpc);
   SupportsTSOImm9 = Features.Has(vixl::CPUFeatures::Feature::kRCpcImm);
 
+  SupportsAVX = Features.Has(vixl::CPUFeatures::Feature::kSVE2) &&
+                vixl::aarch64::CPU::ReadSVEVectorLengthInBits() >= 256;
+
   // We need to get the CPU's cache line size
   // We expect sane targets that have correct cacheline sizes across clusters
   uint64_t CTR;
@@ -82,6 +85,7 @@ HostFeatures::HostFeatures() {
   SupportsRAND = Features.has(Xbyak::util::Cpu::tRDRAND) && Features.has(Xbyak::util::Cpu::tRDSEED);
   SupportsRCPC = true;
   SupportsTSOImm9 = true;
+  SupportsAVX = true;
 
   // xbyak doesn't know how to check for CLZero
   uint32_t eax, ebx, ecx, edx;

--- a/External/FEXCore/Source/Interface/Core/HostFeatures.h
+++ b/External/FEXCore/Source/Interface/Core/HostFeatures.h
@@ -21,6 +21,7 @@ class HostFeatures final {
     bool SupportsRCPC{};
     bool SupportsTSOImm9{};
     bool SupportsRAND{};
+    bool SupportsAVX{};
 
     // Float exception behaviour
     bool SupportsFlushInputsToZero{};

--- a/External/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
@@ -121,7 +121,7 @@ namespace {
     ContextClassification->emplace_back(ContextMemberInfo{
       ContextMemberClassification {
         offsetof(FEXCore::Core::CPUState, gregs[16]),
-        sizeof(uint64_t),
+        sizeof(uint64_t) * 3,
       },
       DefaultAccess[2], ///< NOP padding
       FEXCore::IR::InvalidClass,

--- a/External/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
@@ -76,10 +76,7 @@ namespace {
     std::vector<ContextMemberInfo> ClassificationInfo;
   };
 
-  constexpr static std::array<LastAccessType, 16> DefaultAccess = {
-    ACCESS_NONE,
-    ACCESS_NONE,
-    ACCESS_INVALID, // PAD
+  constexpr static std::array<LastAccessType, 14> DefaultAccess = {
     ACCESS_NONE,
     ACCESS_NONE,
     ACCESS_NONE,
@@ -88,7 +85,8 @@ namespace {
     ACCESS_NONE,
     ACCESS_NONE,
     ACCESS_NONE,
-    ACCESS_INVALID, // PAD
+    ACCESS_NONE,
+    ACCESS_NONE,
     ACCESS_NONE,
     ACCESS_NONE,
     ACCESS_NONE,
@@ -120,10 +118,55 @@ namespace {
 
     ContextClassification->emplace_back(ContextMemberInfo{
       ContextMemberClassification {
-        offsetof(FEXCore::Core::CPUState, gregs[16]),
-        sizeof(uint64_t) * 3,
+        offsetof(FEXCore::Core::CPUState, es),
+        sizeof(FEXCore::Core::CPUState::es),
       },
-      DefaultAccess[2], ///< NOP padding
+      DefaultAccess[2],
+      FEXCore::IR::InvalidClass,
+    });
+
+    ContextClassification->emplace_back(ContextMemberInfo{
+      ContextMemberClassification {
+        offsetof(FEXCore::Core::CPUState, cs),
+        sizeof(FEXCore::Core::CPUState::cs),
+      },
+      DefaultAccess[3],
+      FEXCore::IR::InvalidClass,
+    });
+
+    ContextClassification->emplace_back(ContextMemberInfo{
+      ContextMemberClassification {
+        offsetof(FEXCore::Core::CPUState, ss),
+        sizeof(FEXCore::Core::CPUState::ss),
+      },
+      DefaultAccess[4],
+      FEXCore::IR::InvalidClass,
+    });
+
+    ContextClassification->emplace_back(ContextMemberInfo{
+      ContextMemberClassification {
+        offsetof(FEXCore::Core::CPUState, ds),
+        sizeof(FEXCore::Core::CPUState::ds),
+      },
+      DefaultAccess[5],
+      FEXCore::IR::InvalidClass,
+    });
+
+    ContextClassification->emplace_back(ContextMemberInfo{
+      ContextMemberClassification {
+        offsetof(FEXCore::Core::CPUState, gs),
+        sizeof(FEXCore::Core::CPUState::gs),
+      },
+      DefaultAccess[6],
+      FEXCore::IR::InvalidClass,
+    });
+
+    ContextClassification->emplace_back(ContextMemberInfo{
+      ContextMemberClassification {
+        offsetof(FEXCore::Core::CPUState, fs),
+        sizeof(FEXCore::Core::CPUState::fs),
+      },
+      DefaultAccess[7],
       FEXCore::IR::InvalidClass,
     });
 
@@ -133,64 +176,10 @@ namespace {
           offsetof(FEXCore::Core::CPUState, xmm[0][0]) + sizeof(FEXCore::Core::CPUState::xmm[0]) * i,
           FEXCore::Core::CPUState::XMM_REG_SIZE,
         },
-        DefaultAccess[3],
+        DefaultAccess[8],
         FEXCore::IR::InvalidClass,
       });
     }
-
-    ContextClassification->emplace_back(ContextMemberInfo{
-      ContextMemberClassification {
-        offsetof(FEXCore::Core::CPUState, es),
-        sizeof(FEXCore::Core::CPUState::es),
-      },
-      DefaultAccess[5],
-      FEXCore::IR::InvalidClass,
-    });
-
-    ContextClassification->emplace_back(ContextMemberInfo{
-      ContextMemberClassification {
-        offsetof(FEXCore::Core::CPUState, cs),
-        sizeof(FEXCore::Core::CPUState::cs),
-      },
-      DefaultAccess[6],
-      FEXCore::IR::InvalidClass,
-    });
-
-    ContextClassification->emplace_back(ContextMemberInfo{
-      ContextMemberClassification {
-        offsetof(FEXCore::Core::CPUState, ss),
-        sizeof(FEXCore::Core::CPUState::ss),
-      },
-      DefaultAccess[7],
-      FEXCore::IR::InvalidClass,
-    });
-
-    ContextClassification->emplace_back(ContextMemberInfo{
-      ContextMemberClassification {
-        offsetof(FEXCore::Core::CPUState, ds),
-        sizeof(FEXCore::Core::CPUState::ds),
-      },
-      DefaultAccess[8],
-      FEXCore::IR::InvalidClass,
-    });
-
-    ContextClassification->emplace_back(ContextMemberInfo{
-      ContextMemberClassification {
-        offsetof(FEXCore::Core::CPUState, gs),
-        sizeof(FEXCore::Core::CPUState::gs),
-      },
-      DefaultAccess[4],
-      FEXCore::IR::InvalidClass,
-    });
-
-    ContextClassification->emplace_back(ContextMemberInfo{
-      ContextMemberClassification {
-        offsetof(FEXCore::Core::CPUState, fs),
-        sizeof(FEXCore::Core::CPUState::fs),
-      },
-      DefaultAccess[9],
-      FEXCore::IR::InvalidClass,
-    });
 
     for (size_t i = 0; i < FEXCore::Core::CPUState::NUM_FLAGS; ++i) {
       ContextClassification->emplace_back(ContextMemberInfo{
@@ -198,19 +187,10 @@ namespace {
           offsetof(FEXCore::Core::CPUState, flags[0]) + sizeof(FEXCore::Core::CPUState::flags[0]) * i,
           FEXCore::Core::CPUState::FLAG_SIZE,
         },
-        DefaultAccess[10],
+        DefaultAccess[9],
         FEXCore::IR::InvalidClass,
       });
     }
-
-    ContextClassification->emplace_back(ContextMemberInfo{
-      ContextMemberClassification {
-        offsetof(FEXCore::Core::CPUState, flags[48]),
-        sizeof(uint64_t),
-      },
-      DefaultAccess[11], ///< NOP padding
-      FEXCore::IR::InvalidClass,
-    });
 
     for (size_t i = 0; i < FEXCore::Core::CPUState::NUM_MMS; ++i) {
       ContextClassification->emplace_back(ContextMemberInfo{
@@ -218,7 +198,7 @@ namespace {
           offsetof(FEXCore::Core::CPUState, mm[0][0]) + sizeof(FEXCore::Core::CPUState::mm[0]) * i,
           FEXCore::Core::CPUState::MM_REG_SIZE
         },
-        DefaultAccess[12],
+        DefaultAccess[10],
         FEXCore::IR::InvalidClass,
       });
     }
@@ -230,7 +210,7 @@ namespace {
           offsetof(FEXCore::Core::CPUState, gdt[0]) + sizeof(FEXCore::Core::CPUState::gdt[0]) * i,
           sizeof(FEXCore::Core::CPUState::gdt[0]),
         },
-        DefaultAccess[13],
+        DefaultAccess[11],
         FEXCore::IR::InvalidClass,
       });
     }
@@ -241,7 +221,7 @@ namespace {
         offsetof(FEXCore::Core::CPUState, FCW),
         sizeof(FEXCore::Core::CPUState::FCW),
       },
-      DefaultAccess[14],
+      DefaultAccess[12],
       FEXCore::IR::InvalidClass,
     });
 
@@ -251,7 +231,7 @@ namespace {
         offsetof(FEXCore::Core::CPUState, FTW),
         sizeof(FEXCore::Core::CPUState::FTW),
       },
-      DefaultAccess[15],
+      DefaultAccess[13],
       FEXCore::IR::InvalidClass,
     });
 
@@ -289,36 +269,32 @@ namespace {
     for (size_t i = 0; i < FEXCore::Core::CPUState::NUM_GPRS; ++i) {
       SetAccess(Offset++, DefaultAccess[1]);
     }
+
     SetAccess(Offset++, DefaultAccess[2]);
-
-    for (size_t i = 0; i < FEXCore::Core::CPUState::NUM_XMMS; ++i) {
-      SetAccess(Offset++, DefaultAccess[3]);
-    }
-
+    SetAccess(Offset++, DefaultAccess[3]);
     SetAccess(Offset++, DefaultAccess[4]);
     SetAccess(Offset++, DefaultAccess[5]);
     SetAccess(Offset++, DefaultAccess[6]);
     SetAccess(Offset++, DefaultAccess[7]);
-    SetAccess(Offset++, DefaultAccess[8]);
-    SetAccess(Offset++, DefaultAccess[9]);
 
+    for (size_t i = 0; i < FEXCore::Core::CPUState::NUM_XMMS; ++i) {
+      SetAccess(Offset++, DefaultAccess[8]);
+    }
 
     for (size_t i = 0; i < FEXCore::Core::CPUState::NUM_FLAGS; ++i) {
+      SetAccess(Offset++, DefaultAccess[9]);
+    }
+
+    for (size_t i = 0; i < FEXCore::Core::CPUState::NUM_MMS; ++i) {
       SetAccess(Offset++, DefaultAccess[10]);
     }
 
-    SetAccess(Offset++, DefaultAccess[11]);
-
-    for (size_t i = 0; i < FEXCore::Core::CPUState::NUM_MMS; ++i) {
-      SetAccess(Offset++, DefaultAccess[12]);
-    }
-
     for (size_t i = 0; i < FEXCore::Core::CPUState::NUM_GDTS; ++i) {
-      SetAccess(Offset++, DefaultAccess[13]);
+      SetAccess(Offset++, DefaultAccess[11]);
     }
 
-    SetAccess(Offset++, DefaultAccess[14]);
-    SetAccess(Offset++, DefaultAccess[15]);
+    SetAccess(Offset++, DefaultAccess[12]);
+    SetAccess(Offset++, DefaultAccess[13]);
   }
 
   struct BlockInfo {

--- a/External/FEXCore/include/FEXCore/Core/CoreState.h
+++ b/External/FEXCore/include/FEXCore/Core/CoreState.h
@@ -13,15 +13,11 @@ namespace FEXCore::Core {
   struct FEX_PACKED CPUState {
     uint64_t rip; ///< Current core's RIP. May not be entirely accurate while JIT is active
     uint64_t gregs[16];
-    uint64_t : 64;
-    uint64_t : 64;
-    uint64_t : 64;
-    uint64_t xmm[16][4];
     uint16_t es, cs, ss, ds;
     uint64_t gs;
     uint64_t fs;
+    uint64_t xmm[16][4];
     uint8_t flags[48];
-    uint64_t : 64; // Ensures mm is aligned
     uint64_t mm[8][2];
 
     // 32bit x86 state
@@ -46,6 +42,7 @@ namespace FEXCore::Core {
     static constexpr size_t NUM_MMS = sizeof(mm) / MM_REG_SIZE;
   };
   static_assert(offsetof(CPUState, xmm) % 32 == 0, "xmm needs to be 256-bit aligned!");
+  static_assert(offsetof(CPUState, mm) % 16 == 0, "mm needs to be 128-bit aligned!");
 
   struct InternalThreadState;
 

--- a/External/FEXCore/include/FEXCore/Core/CoreState.h
+++ b/External/FEXCore/include/FEXCore/Core/CoreState.h
@@ -14,7 +14,9 @@ namespace FEXCore::Core {
     uint64_t rip; ///< Current core's RIP. May not be entirely accurate while JIT is active
     uint64_t gregs[16];
     uint64_t : 64;
-    uint64_t xmm[16][2];
+    uint64_t : 64;
+    uint64_t : 64;
+    uint64_t xmm[16][4];
     uint16_t es, cs, ss, ds;
     uint64_t gs;
     uint64_t fs;
@@ -43,7 +45,7 @@ namespace FEXCore::Core {
     static constexpr size_t NUM_XMMS = sizeof(xmm) / XMM_REG_SIZE;
     static constexpr size_t NUM_MMS = sizeof(mm) / MM_REG_SIZE;
   };
-  static_assert(offsetof(CPUState, xmm) % 16 == 0, "xmm needs to be 128bit aligned!");
+  static_assert(offsetof(CPUState, xmm) % 32 == 0, "xmm needs to be 256-bit aligned!");
 
   struct InternalThreadState;
 

--- a/External/FEXCore/include/FEXCore/Core/UContext.h
+++ b/External/FEXCore/include/FEXCore/Core/UContext.h
@@ -27,6 +27,57 @@ namespace FEXCore {
     };
     static_assert(sizeof(FEXCore::x86_64::stack_t) == 24, "This needs to be the right size");
 
+    /**
+     * Describes the software specific bytes added at the end of the
+     * fpstate to identify whether or not an extended context area is
+     * present and what kind of extended features are present in said
+     * context area.
+     */
+    struct FEX_PACKED fpx_sw_bytes {
+      static constexpr uint32_t FP_XSTATE_MAGIC = 0x46505853;
+
+      enum FeatureFlag : uint32_t {
+        FEATURE_FP         = 1U << 0,
+        FEATURE_SSE        = 1U << 1,
+        FEATURE_YMM        = 1U << 2,
+        FEATURE_BNDREGS    = 1U << 3,
+        FEATURE_BNDCSR     = 1U << 4,
+        FEATURE_OPMASK     = 1U << 5,
+        FEATURE_ZMM_Hi256  = 1U << 6,
+        FEATURE_Hi16_ZMM   = 1U << 7,
+        FEATURE_PT_UNIMPL  = 1U << 8,
+        FEATURE_PKRU       = 1U << 9,
+        FEATURE_PASID      = 1U << 10,
+        FEATURE_RESERVED11 = 1U << 11,
+        FEATURE_RESERVED12 = 1U << 12,
+        FEATURE_RESERVED13 = 1U << 13,
+        FEATURE_RESERVED14 = 1U << 14,
+        FEATURE_LBR        = 1U << 15,
+        FEATURE_RESERVED16 = 1U << 16,
+        FEATURE_XTILE_CFG  = 1U << 17,
+        FEATURE_XTILE_DATA = 1U << 18,
+      };
+
+      // If magic1 is set to FP_XSTATE_MAGIC, then the encompassing
+      // frame is an xstate frame. If 0, then it's a legacy frame.
+      uint32_t magic1;
+
+      // Total size of the fpstate area
+      // - magic1 = 0               -> sizeof(fpstate)
+      // - magic1 = FP_XSTATE_MAGIC -> sizeof(xstate) + extensions (if any)
+      uint32_t extended_size;
+
+      // Feature bitmask describing supported features.
+      uint64_t xfeatures;
+
+      // Actual XSAVE state size, based on above xfeatures
+      uint32_t xstate_size;
+
+      // Reserved data
+      uint32_t padding[7];
+    };
+    static_assert(sizeof(fpx_sw_bytes) == 48);
+
     struct FEX_PACKED _libc_fpstate {
       // This is in FXSAVE format
       uint16_t fcw;
@@ -39,9 +90,36 @@ namespace FEXCore {
       uint32_t mxcsr_mask;
       __uint128_t _st[8];
       __uint128_t _xmm[16];
-      uint32_t _res[24];
+      uint32_t _res[12];
+
+      // Linux uses 12 of the bytes relegated for software purposes
+      // to store info describing any existing XSAVE context data.
+      fpx_sw_bytes sw_reserved;
     };
     static_assert(sizeof(FEXCore::x86_64::_libc_fpstate) == 512, "This needs to be the right size");
+
+    struct FEX_PACKED xstate_header {
+      uint64_t xfeatures;
+      uint64_t reserved1[2];
+      uint64_t reserved2[5];
+    };
+    static_assert(sizeof(xstate_header) == 64);
+
+    struct FEX_PACKED ymmh_state {
+      __uint128_t ymmh_space[16];
+    };
+    static_assert(sizeof(ymmh_state) == 256);
+
+    /**
+     * Extended state that includes both the main fpstate
+     * and the extended state.
+     */
+    struct FEX_PACKED xstate {
+      _libc_fpstate fpstate;
+      xstate_header xstate_hdr;
+      ymmh_state ymmh;
+    };
+    static_assert(sizeof(xstate) == 832);
 
     ///< The order of these must match the GNU ordering
     enum ContextRegs {
@@ -233,6 +311,11 @@ namespace FEXCore {
     };
     static_assert(sizeof(FEXCore::x86::_libc_fpreg) == 10, "This needs to be the right size");
 
+    // Same layout on both x86 and x86_64
+    using fpx_sw_bytes = x86_64::fpx_sw_bytes;
+    using xstate_header = x86_64::xstate_header;
+    using ymmh_state = x86_64::ymmh_state;
+
     enum fpstate_magic {
       // Legacy fpstate
       MAGIC_FPU = 0xFFFF'0000,
@@ -257,9 +340,20 @@ namespace FEXCore {
       __uint128_t _st_pad[8]; // Ignored st data
       __uint128_t _xmm[8]; // First 8 XMM registers
       uint32_t pad2[44]; // Second 8 XMM registers plus padding
-      uint32_t pad3[12]; // extended state encoding
+      fpx_sw_bytes sw_reserved; // extended state encoding
     };
     static_assert(sizeof(FEXCore::x86::_libc_fpstate) == 624, "This needs to be the right size");
+
+    /**
+     * Extended state that includes both the main fpstate
+     * and the extended state.
+     */
+    struct FEX_PACKED xstate {
+      _libc_fpstate fpstate;
+      xstate_header xstate_hdr;
+      ymmh_state ymmh;
+    };
+    static_assert(sizeof(xstate) == 944);
 
     struct FEX_PACKED ucontext_t {
       uint32_t uc_flags;

--- a/unittests/IR/Correctness/FPRStoreTruncate.ir
+++ b/unittests/IR/Correctness/FPRStoreTruncate.ir
@@ -25,28 +25,28 @@
     %AddrB i64 = Constant #0x1000010
 
     %ClearVal i128 = LoadMem FPR, #0x10, %AddrB i64, %Invalid, #0x10, SXTX, #1
-    (%Clear1 i128) StoreContext #0x10, FPR, %ClearVal i128, #0x90
-    (%Clear2 i128) StoreContext #0x10, FPR, %ClearVal i128, #0xa0
-    (%Clear3 i128) StoreContext #0x10, FPR, %ClearVal i128, #0xb0
-    (%Clear4 i128) StoreContext #0x10, FPR, %ClearVal i128, #0xc0
+    (%Clear1 i128) StoreContext #0x10, FPR, %ClearVal i128, #0xa0
+    (%Clear2 i128) StoreContext #0x10, FPR, %ClearVal i128, #0xc0
+    (%Clear3 i128) StoreContext #0x10, FPR, %ClearVal i128, #0xe0
+    (%Clear4 i128) StoreContext #0x10, FPR, %ClearVal i128, #0x100
 
     %AddrA i64 = Constant #0x1000000
 
     %MemValueA i128 = LoadMem FPR, #0x10, %AddrA i64, %Invalid, #0x10, SXTX, #1
-    (%Store1 i128) StoreContext #0x10, FPR, %MemValueA i128, #0x90
-    (%Store2 i128) StoreContext #0x10, FPR, %MemValueA i128, #0xa0
-    (%Store3 i128) StoreContext #0x10, FPR, %MemValueA i128, #0xb0
-    (%Store4 i8)   StoreContext  #0x1, FPR, %MemValueA i128, #0xc0
+    (%Store1 i128) StoreContext #0x10, FPR, %MemValueA i128, #0xa0
+    (%Store2 i128) StoreContext #0x10, FPR, %MemValueA i128, #0xc0
+    (%Store3 i128) StoreContext #0x10, FPR, %MemValueA i128, #0xe0
+    (%Store4 i8)   StoreContext  #0x1, FPR, %MemValueA i128, #0x100
 
-    %Truncated64 i64 = LoadContext #0x8, FPR, #0x90
-    %Truncated32 i32 = LoadContext #0x4, FPR, #0xa0
-    %Truncated16 i16 = LoadContext #0x2, FPR, #0xb0
-    %Truncated8  i8  = LoadContext #0x1, FPR, #0xc0
+    %Truncated64 i64 = LoadContext #0x8, FPR, #0xa0
+    %Truncated32 i32 = LoadContext #0x4, FPR, #0xc0
+    %Truncated16 i16 = LoadContext #0x2, FPR, #0xe0
+    %Truncated8  i8  = LoadContext #0x1, FPR, #0x100
 
-    (%Store5 i128) StoreContext #0x10, FPR, %Truncated64 i128, #0xd0
-    (%Store6 i128) StoreContext #0x10, FPR, %Truncated32 i128, #0xe0
-    (%Store7 i128) StoreContext #0x10, FPR, %Truncated16 i128, #0xf0
-    (%Store8 i128) StoreContext #0x10, FPR, %Truncated8 i128, #0x100
-    (%Store9 i128) StoreContext #0x10, FPR, %MemValueA i128, #0x110
+    (%Store5 i128) StoreContext #0x10, FPR, %Truncated64 i128, #0x120
+    (%Store6 i128) StoreContext #0x10, FPR, %Truncated32 i128, #0x140
+    (%Store7 i128) StoreContext #0x10, FPR, %Truncated16 i128, #0x160
+    (%Store8 i128) StoreContext #0x10, FPR, %Truncated8 i128, #0x180
+    (%Store9 i128) StoreContext #0x10, FPR, %MemValueA i128, #0x1A0
     (%ssa7 i0) Break Halt, #4
     (%end i0) EndBlock %ssa2


### PR DESCRIPTION
Provides a minimal as possible set of changes to modify various bits of FEX to make it ready to start the implementation of AVX.

This essentially just expands the core state xmm registers and ensures that nothing breaks due to that.

Subsequent PRs will make use of the extended state/implement IR handling for it