### PR TITLE
Fix inconsistent allocation schemes used for RegisterAllocationData

### DIFF
--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -189,8 +189,7 @@ namespace FEXCore::Context {
 
     struct GenerateIRResult {
       FEXCore::IR::IRListView* IRList;
-      // User's responsibility to deallocate this.
-      FEXCore::IR::RegisterAllocationData* RAData;
+      FEXCore::IR::RegisterAllocationData::UniquePtr RAData;
       uint64_t TotalInstructions;
       uint64_t TotalInstructionsLength;
       uint64_t StartAddr;
@@ -202,8 +201,7 @@ namespace FEXCore::Context {
       void* CompiledCode;
       FEXCore::IR::IRListView* IRData;
       FEXCore::Core::DebugData* DebugData;
-      // User's responsibility to deallocate this.
-      FEXCore::IR::RegisterAllocationData* RAData;
+      FEXCore::IR::RegisterAllocationData::UniquePtr RAData;
       bool GeneratedIR;
       uint64_t StartAddr;
       uint64_t Length;

--- a/External/FEXCore/Source/Interface/IR/AOTIR.h
+++ b/External/FEXCore/Source/Interface/IR/AOTIR.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "FEXCore/IR/RegisterAllocationData.h"
 #include <FEXCore/Config/Config.h>
 
 #include <atomic>
@@ -93,7 +94,7 @@ namespace FEXCore::IR {
 
       struct PreGenerateIRFetchResult {
         FEXCore::IR::IRListView *IRList {};
-        FEXCore::IR::RegisterAllocationData *RAData {};
+        FEXCore::IR::RegisterAllocationData::UniquePtr RAData {};
         FEXCore::Core::DebugData *DebugData {};
         uint64_t StartAddr {};
         uint64_t Length {};
@@ -106,7 +107,7 @@ namespace FEXCore::IR {
         uint64_t GuestRIP,
         uint64_t StartAddr,
         uint64_t Length,
-        FEXCore::IR::RegisterAllocationData *RAData,
+        FEXCore::IR::RegisterAllocationData::UniquePtr RAData,
         FEXCore::IR::IRListView *IRList,
         FEXCore::Core::DebugData *DebugData,
         bool GeneratedIR);

--- a/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -89,7 +89,7 @@ namespace {
   };
 
   struct RegisterGraph {
-    std::unique_ptr<IR::RegisterAllocationData, IR::RegisterAllocationDataDeleter> AllocData;
+    IR::RegisterAllocationData::UniquePtr AllocData;
     RegisterSet Set;
     std::vector<RegisterNode> Nodes{};
     uint32_t NodeCount{};
@@ -153,10 +153,7 @@ namespace {
     Graph->Nodes.resize(NodeCount);
 
     Graph->VisitedNodePredecessors.clear();
-    Graph->AllocData.reset((FEXCore::IR::RegisterAllocationData*)FEXCore::Allocator::malloc(FEXCore::IR::RegisterAllocationData::Size(NodeCount)));
-    memset(&Graph->AllocData->Map[0], PhysicalRegister::Invalid().Raw, NodeCount);
-    Graph->AllocData->MapCount = NodeCount;
-    Graph->AllocData->IsShared = false; // not shared by default
+    Graph->AllocData = RegisterAllocationData::Create(NodeCount);
     Graph->NodeCount = NodeCount;
   }
 
@@ -283,7 +280,7 @@ namespace {
        * Top 32bits is the class, lower 32bits is the register
        */
       RegisterAllocationData* GetAllocationData() override;
-      std::unique_ptr<RegisterAllocationData, RegisterAllocationDataDeleter> PullAllocationData() override;
+      RegisterAllocationData::UniquePtr PullAllocationData() override;
 
     private:
       using BlockInterferences = std::vector<IR::NodeID>;
@@ -379,7 +376,7 @@ namespace {
     return Graph->AllocData.get();
   }
 
-  std::unique_ptr<RegisterAllocationData, RegisterAllocationDataDeleter> ConstrainedRAPass::PullAllocationData() {
+  RegisterAllocationData::UniquePtr ConstrainedRAPass::PullAllocationData() {
     return std::move(Graph->AllocData);
   }
 

--- a/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
+++ b/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
@@ -68,7 +68,7 @@ namespace FEXCore::Core {
     uint64_t StartAddr;
     uint64_t Length;
     std::unique_ptr<FEXCore::IR::IRListView, FEXCore::IR::IRListViewDeleter> IR;
-    std::unique_ptr<FEXCore::IR::RegisterAllocationData, FEXCore::IR::RegisterAllocationDataDeleter> RAData;
+    FEXCore::IR::RegisterAllocationData::UniquePtr RAData;
     std::unique_ptr<FEXCore::Core::DebugData> DebugData;
   };
 


### PR DESCRIPTION
`RegisterAllocationData` must be allocated using `FEXCore::Allocator::malloc` and deallocated using `FEXCore::Allocator::free`. Address Sanitizer suggested this was not done consistently, and upon closer inspection I found two problematic pieces:
1.  `AOTIRCaptureCache::PreGenerateIRFetch` returned a raw pointer of a `RegisterAllocationData` inlined in `AOTIRInlineEntry::InlineData`
2. `AOTIRCaptureCache::PostCompileCode` used `free` for deallocation (though I'm not sure that's actually different from `FEXCore::Allocator::free` in that context?)

Since manual bookkeeping of the right deallocation function is messy and error-prone, this PR changes *all* interfaces handling `RegisterAllocationData` in an owning fashion to pass around the full `unique_ptr` type instead. A convenience type alias is provided to make this easier. This works well in most cases, with one notable exception in AOTIR: A little dance is required to pass ownership of `RegisterAllocationData` across threads here, since that code does not support moveable-lambdas solely because of using `std::function`.

There is only one minor functional change in this PR: `AOTIRCaptureCache::PreGenerateIRFetch` now creates a copy of the `RegisterAllocationData` from its `InlineData`.
