### PR TITLE
Linux: Fixes for clone3 stack size

### DIFF
--- a/Source/Tests/LinuxSyscalls/Syscalls.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls.cpp
@@ -246,7 +246,7 @@ struct StackFrameData {
   FEXCore::Core::InternalThreadState *Thread{};
   FEXCore::Context::Context *CTX{};
   FEXCore::Core::CpuStateFrame NewFrame{};
-  FEX::HLE::kernel_clone3_args GuestArgs{};
+  FEX::HLE::clone3_args GuestArgs{};
   void *NewStack;
   size_t StackSize;
 };
@@ -321,7 +321,7 @@ static uint64_t Clone2Handler(FEXCore::Core::CpuStateFrame *Frame, FEX::HLE::clo
   StackFrameData *Data = (StackFrameData *)FEXCore::Allocator::malloc(sizeof(StackFrameData));
   Data->Thread = Frame->Thread;
   Data->CTX = Frame->Thread->CTX;
-  Data->GuestArgs = args->args;
+  Data->GuestArgs = *args;
 
   // In the case of thread, we need a new stack
   Data->StackSize = 8 * 1024 * 1024;
@@ -357,7 +357,7 @@ static uint64_t Clone3Handler(FEXCore::Core::CpuStateFrame *Frame, FEX::HLE::clo
   Data->Ret = (uint64_t)Clone3HandlerRet;
   Data->Data.Thread = Frame->Thread;
   Data->Data.CTX = Frame->Thread->CTX;
-  Data->Data.GuestArgs = args->args;
+  Data->Data.GuestArgs = *args;
 
   Data->Data.StackSize = StackSize;
   Data->Data.NewStack = NewStack;
@@ -483,6 +483,7 @@ uint64_t CloneHandler(FEXCore::Core::CpuStateFrame *Frame, FEX::HLE::clone3_args
     // CLONE_PARENT is ignored (Implied by CLONE_THREAD)
     return FEX::HLE::ForkGuest(Thread, Frame, flags,
       reinterpret_cast<void*>(args->args.stack),
+      args->args.stack_size,
       reinterpret_cast<pid_t*>(args->args.parent_tid),
       reinterpret_cast<pid_t*>(args->args.child_tid),
       reinterpret_cast<void*>(args->args.tls));

--- a/Source/Tests/LinuxSyscalls/Syscalls/Thread.h
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Thread.h
@@ -15,6 +15,6 @@ struct CPUState;
 
 namespace FEX::HLE {
   FEXCore::Core::InternalThreadState *CreateNewThread(FEXCore::Context::Context *CTX, FEXCore::Core::CpuStateFrame *Frame, FEX::HLE::clone3_args *args);
-  uint64_t HandleNewClone(FEXCore::Core::InternalThreadState *Thread, FEXCore::Context::Context *CTX, FEXCore::Core::CpuStateFrame *Frame, FEX::HLE::kernel_clone3_args *GuestArgs);
-  uint64_t ForkGuest(FEXCore::Core::InternalThreadState *Thread, FEXCore::Core::CpuStateFrame *Frame, uint32_t flags, void *stack, pid_t *parent_tid, pid_t *child_tid, void *tls);
+  uint64_t HandleNewClone(FEXCore::Core::InternalThreadState *Thread, FEXCore::Context::Context *CTX, FEXCore::Core::CpuStateFrame *Frame, FEX::HLE::clone3_args *GuestArgs);
+  uint64_t ForkGuest(FEXCore::Core::InternalThreadState *Thread, FEXCore::Core::CpuStateFrame *Frame, uint32_t flags, void *stack, size_t StackSize, pid_t *parent_tid, pid_t *child_tid, void *tls);
 }

--- a/Source/Tests/LinuxSyscalls/x32/Thread.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Thread.cpp
@@ -86,7 +86,7 @@ namespace FEX::HLE::x32 {
           .parent_tid = reinterpret_cast<uint64_t>(parent_tid),
           .exit_signal = flags & CSIGNAL,
           .stack = reinterpret_cast<uint64_t>(stack),
-          .stack_size = ~0ULL, // This syscall isn't able to see the stack size
+          .stack_size = 0, // This syscall isn't able to see the stack size
           .tls = reinterpret_cast<uint64_t>(tls),
           .set_tid = 0, // This syscall isn't able to select TIDs
           .set_tid_size = 0,

--- a/Source/Tests/LinuxSyscalls/x64/Thread.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Thread.cpp
@@ -46,7 +46,7 @@ namespace FEX::HLE::x64 {
           .parent_tid = reinterpret_cast<uint64_t>(parent_tid),
           .exit_signal = flags & CSIGNAL,
           .stack = reinterpret_cast<uint64_t>(stack),
-          .stack_size = ~0ULL, // This syscall isn't able to see the stack size
+          .stack_size = 0, // This syscall isn't able to see the stack size
           .tls = reinterpret_cast<uint64_t>(tls),
           .set_tid = 0, // This syscall isn't able to select TIDs
           .set_tid_size = 0,


### PR DESCRIPTION
We weren't adjusting the guest stack size when using clone3.
If the clone comes from CLONE3 then we need to offset the RSP by the
provided stack size.

This also translates to fork/vfork through clone, so make sure to adjust
stack in that case as well.

Fixes Ender Lilies crashing with Ubuntu 22.04 rootfs