### PR TITLE
FDUtils: Fix get_fdpath

### DIFF
--- a/Source/Common/FDUtils.h
+++ b/Source/Common/FDUtils.h
@@ -15,7 +15,7 @@ std::string get_fdpath(int fd) {
   std::filesystem::path Path = std::filesystem::path("/proc/self/fd") / std::to_string(fd);
   int Result = readlinkat(AT_FDCWD, Path.c_str(), SymlinkPath, sizeof(SymlinkPath));
   if (Result != -1) {
-    return SymlinkPath;
+    return std::string(SymlinkPath, Result);
   }
 
   LOGMAN_MSG_A_FMT("Couldn't get symlink from /proc/self/fd/{}", fd);


### PR DESCRIPTION
Our `get_fdpath` was broken and would include junk data after the filename, as `readlinkat` does not null terminate,it returns length instead. 