### PR TITLE
RFC: ThunkLibs: Callback binding support using copyable functions

### DIFF
--- a/ThunkLibs/include/common/CopyableFunctions.h
+++ b/ThunkLibs/include/common/CopyableFunctions.h
@@ -1,0 +1,121 @@
+
+#include <cstdint>
+#include <cstring>
+#include <cstdio>
+#include <cstdlib>
+#include <cassert>
+#include <tuple>
+
+#include <sys/mman.h>
+
+#define copyable_logf(...)
+
+class binder {
+    using offsets_t = int;
+    
+    struct alignas(16) instance_info_t {
+        void *target;
+        void *marshaler;
+    };
+
+    template<typename R, typename... Args>
+    struct inner;
+
+    template<typename R, typename... Args>
+    struct inner<R(Args...)> {
+        using target_t = R(Args...);
+        using marshaler_t = R(Args..., target_t *target);
+        
+        static const offsets_t offsets;
+
+        static R canonical(Args... args) {
+            instance_info_t *instance_info;
+            #if defined(_M_X86_64)
+                asm("lea 1f(%%rip), %0" :"=r"(instance_info));
+            #elif defined(_M_ARM_64)
+                asm("adr %0, 1f" : "=r"(instance_info));
+            #else
+            #error unsupported arch
+            #endif
+            
+            // force the label to exist
+            asm goto (""::::data);
+
+            return reinterpret_cast<marshaler_t *>(instance_info->marshaler)(args..., reinterpret_cast<target_t *>(instance_info->target));
+            data:
+                asm(".align 16\n 1: .quad 0xdeadbeefdeadbeef");            
+                __builtin_unreachable();
+        }
+    };
+
+    static int find_pattern(uint8_t *canonical_fn_ptr, uint64_t pattern, size_t size) {
+        constexpr auto max_fn_size = 1024;
+        
+        for (int offset = 0; offset < max_fn_size; offset++ ) {
+            if (memcmp(canonical_fn_ptr + offset, &pattern, size) == 0) {
+                return offset;
+            }
+        }
+
+        assert("Failed to find pattern in canonical function" && 0);
+        return -1;
+    }
+    
+    static offsets_t init_offsets(uint8_t *canonical_ptr) {
+        auto end_offset = find_pattern(canonical_ptr, 0xDEADBEEFDEADBEEF, 8);
+
+        return end_offset;
+    }
+
+    static void *make_instance(void *canonical, void *target, void *marshaler, offsets_t offsets) {
+        auto canonical_fn_ptr = (uint8_t*)canonical;
+
+        auto found_end_offset = offsets;
+
+        assert("Failed to find end in canonical function" && found_end_offset != -1);
+
+        [[maybe_unused]] auto align_minus_one = alignof(instance_info_t) - 1;
+
+        assert("Canonical misalignment" && (((uintptr_t)canonical) & align_minus_one));
+
+        auto function_size = found_end_offset;
+
+        assert("function_size misalignment" && (function_size & align_minus_one));
+
+        auto alloc_size = function_size + sizeof(instance_info_t);
+
+        copyable_logf("function len: %d, alloc len: %d\n", (int)function_size, (int)alloc_size);
+
+        // alloc
+        auto instance = (uint8_t*)mmap(0, alloc_size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        
+        // copy
+        memcpy(instance, canonical_fn_ptr, function_size);
+
+        // bind
+        auto code_offset = 0;
+        auto info_offset = alloc_size - sizeof(instance_info_t);
+
+        copyable_logf("code_offset offset: %d\n", (int)code_offset);
+        copyable_logf("info_offset offset: %d\n", (int)info_offset);
+
+        auto info = (instance_info_t*)(instance + info_offset);
+
+        info->target = target;
+        info->marshaler = marshaler;
+
+        return (instance + code_offset);
+    }
+
+public:
+    template<typename T> 
+    static T *make_instance(T *target, typename inner<T>::marshaler_t *marshaler);
+};
+
+
+#define DECL_COPYABLE_TRAMPLOLINE(fn_type) \
+template<> const binder::offsets_t binder::inner<fn_type>::offsets = init_offsets(reinterpret_cast<uint8_t*>(&canonical)); \
+template<> \
+fn_type *binder::make_instance<fn_type>(fn_type *target, binder::inner<fn_type>::marshaler_t *marshaler) { \
+    return reinterpret_cast<fn_type *>(binder::make_instance(reinterpret_cast<void*>(&binder::inner<fn_type>::canonical), reinterpret_cast<void*>(target), reinterpret_cast<void*>(marshaler), binder::inner<fn_type>::offsets)); \
+}

--- a/ThunkLibs/include/common/CopyableFunctions.h
+++ b/ThunkLibs/include/common/CopyableFunctions.h
@@ -10,6 +10,24 @@
 
 #include <sys/mman.h>
 
+// Copyable functions
+
+// Public API
+//
+// assuming typedef void some_fn_type(int, int);
+// DECL_COPYABLE_TRAMPLOLINE(some_fn_type) will generate the trampolines, static structures, canonical fn, etc
+// then
+// some_fn_type *binder::make_instance(some_fn_type *target, marshaler *marshaler) can be used to make a new bound function
+// some_fn_type *binder::get_target(some_fn_type *bound_fn) can be used to lookup the target function of a bound function
+
+
+// Internals
+//
+// binder::inner<type>::canonical has a special end-of-function marker using asm goto to resurrect dead code
+// binder::inner<type>::guest_to_host and binder::inner<type>::host_to_guest hold mappings. These are per type
+//  as functions might be called with different parameters
+// binder::inner<type>::mutex protects guest_to_host, host_to_guest
+
 #define copyable_logf(...)
 
 class binder {

--- a/ThunkLibs/include/common/CopyableFunctions.h
+++ b/ThunkLibs/include/common/CopyableFunctions.h
@@ -1,4 +1,6 @@
 
+#pragma once
+
 #include <cstdint>
 #include <cstring>
 #include <cstdio>

--- a/ThunkLibs/include/common/Guest.h
+++ b/ThunkLibs/include/common/Guest.h
@@ -2,6 +2,8 @@
 #include <stdint.h>
 #include <type_traits>
 
+#include "PackedArguments.h"
+
 #ifndef _M_ARM_64
 #define MAKE_THUNK(lib, name, hash) \
   extern "C" int fexthunks_##lib##_##name(void *args); \
@@ -55,87 +57,6 @@ inline void LinkAddressToFunction(uintptr_t addr, uintptr_t target) {
     args_t args = { addr, target };
     fexthunks_fex_link_address_to_function(&args);
 }
-
-template<typename Result, typename... Args>
-struct PackedArguments;
-
-template<typename R, typename A0>
-struct PackedArguments<R, A0> { A0 a0; R rv; };
-template<typename R, typename A0, typename A1>
-struct PackedArguments<R, A0, A1> { A0 a0; A1 a1; R rv; };
-template<typename R, typename A0, typename A1, typename A2>
-struct PackedArguments<R, A0, A1, A2> { A0 a0; A1 a1; A2 a2; R rv; };
-template<typename R, typename A0, typename A1, typename A2, typename A3>
-struct PackedArguments<R, A0, A1, A2, A3> { A0 a0; A1 a1; A2 a2; A3 a3; R rv; };
-template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-struct PackedArguments<R, A0, A1, A2, A3, A4> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; R rv; };
-template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5>
-struct PackedArguments<R, A0, A1, A2, A3, A4, A5> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; R rv; };
-template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6>
-struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; R rv; };
-template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7>
-struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; R rv; };
-template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8>
-struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; R rv; };
-template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9>
-struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; R rv; };
-template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10>
-struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; R rv; };
-template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11>
-struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; R rv; };
-template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12>
-struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; R rv; };
-
-template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12, typename A13>
-struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; A13 a13; R rv; };
-
-template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9,
-         typename A10, typename A11, typename A12, typename A13, typename A14, typename A15, typename A16, typename A17, typename A18, typename A19,
-         typename A20, typename A21, typename A22, typename A23>
-struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9,
-                       A10, A11, A12, A13, A14, A15, A16, A17, A18, A19,
-                       A20, A21, A22, A23> {
-    A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9;
-    A10 a10; A11 a11; A12 a12; A13 a13; A14 a14; A15 a15; A16 a16; A17 a17; A18 a18; A19 a19;
-    A20 a20; A21 a21; A22 a22; A23 a23; R rv;
-};
-
-template<typename A0>
-struct PackedArguments<void, A0> { A0 a0; };
-template<typename A0, typename A1>
-struct PackedArguments<void, A0, A1> { A0 a0; A1 a1; };
-template<typename A0, typename A1, typename A2>
-struct PackedArguments<void, A0, A1, A2> { A0 a0; A1 a1; A2 a2; };
-template<typename A0, typename A1, typename A2, typename A3>
-struct PackedArguments<void, A0, A1, A2, A3> { A0 a0; A1 a1; A2 a2; A3 a3; };
-template<typename A0, typename A1, typename A2, typename A3, typename A4>
-struct PackedArguments<void, A0, A1, A2, A3, A4> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; };
-template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5>
-struct PackedArguments<void, A0, A1, A2, A3, A4, A5> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; };
-template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6>
-struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; };
-template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7>
-struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; };
-template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8>
-struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; };
-template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9>
-struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; };
-template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10>
-struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; };
-template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11>
-struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; };
-template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12>
-struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; };
-template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12, typename A13>
-struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; A13 a13; };
-template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12, typename A13, typename A14>
-struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; A13 a13; A14 a14; };
-template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12, typename A13, typename A14, typename A15>
-struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; A13 a13; A14 a14; A15 a15; };
-template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12, typename A13, typename A14, typename A15, typename A16>
-struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; A13 a13; A14 a14; A15 a15; A16 a16; };
-template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12, typename A13, typename A14, typename A15, typename A16, typename A17>
-struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; A13 a13; A14 a14; A15 a15; A16 a16; A17 a17; };
 
 // Helper template that packs the given arguments and invokes a thunk at the
 // address stored in the `r11` guest register. The signature of the thunk must

--- a/ThunkLibs/include/common/PackedArguments.h
+++ b/ThunkLibs/include/common/PackedArguments.h
@@ -1,0 +1,82 @@
+#pragma once
+
+template<typename Result, typename... Args>
+struct PackedArguments;
+
+template<typename R, typename A0>
+struct PackedArguments<R, A0> { A0 a0; R rv; };
+template<typename R, typename A0, typename A1>
+struct PackedArguments<R, A0, A1> { A0 a0; A1 a1; R rv; };
+template<typename R, typename A0, typename A1, typename A2>
+struct PackedArguments<R, A0, A1, A2> { A0 a0; A1 a1; A2 a2; R rv; };
+template<typename R, typename A0, typename A1, typename A2, typename A3>
+struct PackedArguments<R, A0, A1, A2, A3> { A0 a0; A1 a1; A2 a2; A3 a3; R rv; };
+template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
+struct PackedArguments<R, A0, A1, A2, A3, A4> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; R rv; };
+template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5>
+struct PackedArguments<R, A0, A1, A2, A3, A4, A5> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; R rv; };
+template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6>
+struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; R rv; };
+template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7>
+struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; R rv; };
+template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8>
+struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; R rv; };
+template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9>
+struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; R rv; };
+template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10>
+struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; R rv; };
+template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11>
+struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; R rv; };
+template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12>
+struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; R rv; };
+
+template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12, typename A13>
+struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; A13 a13; R rv; };
+
+template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9,
+         typename A10, typename A11, typename A12, typename A13, typename A14, typename A15, typename A16, typename A17, typename A18, typename A19,
+         typename A20, typename A21, typename A22, typename A23>
+struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9,
+                       A10, A11, A12, A13, A14, A15, A16, A17, A18, A19,
+                       A20, A21, A22, A23> {
+    A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9;
+    A10 a10; A11 a11; A12 a12; A13 a13; A14 a14; A15 a15; A16 a16; A17 a17; A18 a18; A19 a19;
+    A20 a20; A21 a21; A22 a22; A23 a23; R rv;
+};
+
+template<typename A0>
+struct PackedArguments<void, A0> { A0 a0; };
+template<typename A0, typename A1>
+struct PackedArguments<void, A0, A1> { A0 a0; A1 a1; };
+template<typename A0, typename A1, typename A2>
+struct PackedArguments<void, A0, A1, A2> { A0 a0; A1 a1; A2 a2; };
+template<typename A0, typename A1, typename A2, typename A3>
+struct PackedArguments<void, A0, A1, A2, A3> { A0 a0; A1 a1; A2 a2; A3 a3; };
+template<typename A0, typename A1, typename A2, typename A3, typename A4>
+struct PackedArguments<void, A0, A1, A2, A3, A4> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; };
+template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5>
+struct PackedArguments<void, A0, A1, A2, A3, A4, A5> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; };
+template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6>
+struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; };
+template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7>
+struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; };
+template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8>
+struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; };
+template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9>
+struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; };
+template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10>
+struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; };
+template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11>
+struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; };
+template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12>
+struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; };
+template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12, typename A13>
+struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; A13 a13; };
+template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12, typename A13, typename A14>
+struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; A13 a13; A14 a14; };
+template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12, typename A13, typename A14, typename A15>
+struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; A13 a13; A14 a14; A15 a15; };
+template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12, typename A13, typename A14, typename A15, typename A16>
+struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; A13 a13; A14 a14; A15 a15; A16 a16; };
+template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12, typename A13, typename A14, typename A15, typename A16, typename A17>
+struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; A13 a13; A14 a14; A15 a15; A16 a16; A17 a17; };

--- a/ThunkLibs/libX11/libX11_Host.cpp
+++ b/ThunkLibs/libX11/libX11_Host.cpp
@@ -12,12 +12,13 @@ $end_info$
 #include <X11/Xutil.h>
 #include <X11/Xresource.h>
 #include "common/Host.h"
+#include "common/CopyableFunctions.h"
 #include <dlfcn.h>
 
 #include "callback_structs.inl"
 #include "callback_typedefs.inl"
 
-struct {
+struct CallbackUnpacks {
     #include "callback_unpacks_header.inl"
 } *callback_unpacks;
 
@@ -57,26 +58,111 @@ char* fexfn_impl_libX11_XGetICValues_internal(XIC a_0, size_t count, unsigned lo
     }
 }
 
-struct XIfEventCB_args {
-    XIfEventCBFN *fn;
-    XPointer arg;
+DECL_COPYABLE_TRAMPLOLINE(XIfEventCBFN)
+
+
+template<typename Result, typename... Args>
+struct PackedArguments;
+
+template<typename R, typename A0>
+struct PackedArguments<R, A0> { A0 a0; R rv; };
+template<typename R, typename A0, typename A1>
+struct PackedArguments<R, A0, A1> { A0 a0; A1 a1; R rv; };
+template<typename R, typename A0, typename A1, typename A2>
+struct PackedArguments<R, A0, A1, A2> { A0 a0; A1 a1; A2 a2; R rv; };
+template<typename R, typename A0, typename A1, typename A2, typename A3>
+struct PackedArguments<R, A0, A1, A2, A3> { A0 a0; A1 a1; A2 a2; A3 a3; R rv; };
+template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
+struct PackedArguments<R, A0, A1, A2, A3, A4> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; R rv; };
+template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5>
+struct PackedArguments<R, A0, A1, A2, A3, A4, A5> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; R rv; };
+template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6>
+struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; R rv; };
+template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7>
+struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; R rv; };
+template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8>
+struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; R rv; };
+template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9>
+struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; R rv; };
+template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10>
+struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; R rv; };
+template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11>
+struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; R rv; };
+template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12>
+struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; R rv; };
+
+template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12, typename A13>
+struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; A13 a13; R rv; };
+
+template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9,
+         typename A10, typename A11, typename A12, typename A13, typename A14, typename A15, typename A16, typename A17, typename A18, typename A19,
+         typename A20, typename A21, typename A22, typename A23>
+struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9,
+                       A10, A11, A12, A13, A14, A15, A16, A17, A18, A19,
+                       A20, A21, A22, A23> {
+    A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9;
+    A10 a10; A11 a11; A12 a12; A13 a13; A14 a14; A15 a15; A16 a16; A17 a17; A18 a18; A19 a19;
+    A20 a20; A21 a21; A22 a22; A23 a23; R rv;
 };
 
-static int XIfEventCB(Display* a0, XEvent* a1, XPointer a2) {
+template<typename A0>
+struct PackedArguments<void, A0> { A0 a0; };
+template<typename A0, typename A1>
+struct PackedArguments<void, A0, A1> { A0 a0; A1 a1; };
+template<typename A0, typename A1, typename A2>
+struct PackedArguments<void, A0, A1, A2> { A0 a0; A1 a1; A2 a2; };
+template<typename A0, typename A1, typename A2, typename A3>
+struct PackedArguments<void, A0, A1, A2, A3> { A0 a0; A1 a1; A2 a2; A3 a3; };
+template<typename A0, typename A1, typename A2, typename A3, typename A4>
+struct PackedArguments<void, A0, A1, A2, A3, A4> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; };
+template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5>
+struct PackedArguments<void, A0, A1, A2, A3, A4, A5> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; };
+template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6>
+struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; };
+template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7>
+struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; };
+template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8>
+struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; };
+template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9>
+struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; };
+template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10>
+struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; };
+template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11>
+struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; };
+template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12>
+struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; };
+template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12, typename A13>
+struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; A13 a13; };
+template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12, typename A13, typename A14>
+struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; A13 a13; A14 a14; };
+template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12, typename A13, typename A14, typename A15>
+struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; A13 a13; A14 a14; A15 a15; };
+template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12, typename A13, typename A14, typename A15, typename A16>
+struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; A13 a13; A14 a14; A15 a15; A16 a16; };
+template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12, typename A13, typename A14, typename A15, typename A16, typename A17>
+struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; A13 a13; A14 a14; A15 a15; A16 a16; A17 a17; };
 
-    XIfEventCB_args *arg = (XIfEventCB_args*)a2;
 
-    XIfEventCB_Args argsrv { a0, a1, arg->arg};
+template<typename R, typename... Args>
+struct CallbackMarshaler;
 
-    call_guest(callback_unpacks->libX11_XIfEventCB, (void*) arg->fn, &argsrv);
-    
-    return argsrv.rv;
-}
+template<typename R, typename... Args>
+struct CallbackMarshaler<R(Args...)> {
+    template<ptrdiff_t offset>
+    static R marshal(Args... args, R(*guest_fn)(Args...)) {
+        uintptr_t guest_unpack = *(uintptr_t*)((uintptr_t)callback_unpacks + offset);
+        PackedArguments<R, Args...> argsrv { args... };
+        call_guest(guest_unpack, (void*)guest_fn, &argsrv);
+        if constexpr (!std::is_void_v<R>) {
+            return argsrv.rv;
+        }
+    }
+};
 
 int fexfn_impl_libX11_XIfEvent_internal(Display* a0, XEvent* a1, XIfEventCBFN* a2, XPointer a3) {
-    static XIfEventCB_args args = { a2, a3 };
+    auto fn = binder::make_instance<XIfEventCBFN>(a2, &CallbackMarshaler<XIfEventCBFN>::marshal<offsetof(CallbackUnpacks, libX11_XIfEventCB)>);
 
-    return fexldr_ptr_libX11_XIfEvent(a0, a1, &XIfEventCB, (XPointer)&args);
+    return fexldr_ptr_libX11_XIfEvent(a0, a1, fn, a3);
 }
 
 Bool fexfn_impl_libX11_XUnregisterIMInstantiateCallback_internal(

--- a/ThunkLibs/libX11/libX11_Host.cpp
+++ b/ThunkLibs/libX11/libX11_Host.cpp
@@ -5,14 +5,14 @@ desc: Handles callbacks and varargs
 $end_info$
 */
 
+#include "common/Host.h"
+
 #include <cstdlib>
 #include <stdio.h>
 
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 #include <X11/Xresource.h>
-#include "common/Host.h"
-#include "common/CopyableFunctions.h"
 #include <dlfcn.h>
 
 #include "callback_structs.inl"
@@ -63,106 +63,9 @@ DECL_COPYABLE_TRAMPLOLINE(XRemoveConnectionWatchCBFN)
 DECL_COPYABLE_TRAMPLOLINE(XIfEventCBFN)
 DECL_COPYABLE_TRAMPLOLINE(XSetErrorHandlerCBFN)
 
-template<typename Result, typename... Args>
-struct PackedArguments;
-
-template<typename R, typename A0>
-struct PackedArguments<R, A0> { A0 a0; R rv; };
-template<typename R, typename A0, typename A1>
-struct PackedArguments<R, A0, A1> { A0 a0; A1 a1; R rv; };
-template<typename R, typename A0, typename A1, typename A2>
-struct PackedArguments<R, A0, A1, A2> { A0 a0; A1 a1; A2 a2; R rv; };
-template<typename R, typename A0, typename A1, typename A2, typename A3>
-struct PackedArguments<R, A0, A1, A2, A3> { A0 a0; A1 a1; A2 a2; A3 a3; R rv; };
-template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-struct PackedArguments<R, A0, A1, A2, A3, A4> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; R rv; };
-template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5>
-struct PackedArguments<R, A0, A1, A2, A3, A4, A5> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; R rv; };
-template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6>
-struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; R rv; };
-template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7>
-struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; R rv; };
-template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8>
-struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; R rv; };
-template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9>
-struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; R rv; };
-template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10>
-struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; R rv; };
-template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11>
-struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; R rv; };
-template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12>
-struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; R rv; };
-
-template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12, typename A13>
-struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; A13 a13; R rv; };
-
-template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9,
-         typename A10, typename A11, typename A12, typename A13, typename A14, typename A15, typename A16, typename A17, typename A18, typename A19,
-         typename A20, typename A21, typename A22, typename A23>
-struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9,
-                       A10, A11, A12, A13, A14, A15, A16, A17, A18, A19,
-                       A20, A21, A22, A23> {
-    A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9;
-    A10 a10; A11 a11; A12 a12; A13 a13; A14 a14; A15 a15; A16 a16; A17 a17; A18 a18; A19 a19;
-    A20 a20; A21 a21; A22 a22; A23 a23; R rv;
-};
-
-template<typename A0>
-struct PackedArguments<void, A0> { A0 a0; };
-template<typename A0, typename A1>
-struct PackedArguments<void, A0, A1> { A0 a0; A1 a1; };
-template<typename A0, typename A1, typename A2>
-struct PackedArguments<void, A0, A1, A2> { A0 a0; A1 a1; A2 a2; };
-template<typename A0, typename A1, typename A2, typename A3>
-struct PackedArguments<void, A0, A1, A2, A3> { A0 a0; A1 a1; A2 a2; A3 a3; };
-template<typename A0, typename A1, typename A2, typename A3, typename A4>
-struct PackedArguments<void, A0, A1, A2, A3, A4> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; };
-template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5>
-struct PackedArguments<void, A0, A1, A2, A3, A4, A5> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; };
-template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6>
-struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; };
-template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7>
-struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; };
-template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8>
-struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; };
-template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9>
-struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; };
-template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10>
-struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; };
-template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11>
-struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; };
-template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12>
-struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; };
-template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12, typename A13>
-struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; A13 a13; };
-template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12, typename A13, typename A14>
-struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; A13 a13; A14 a14; };
-template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12, typename A13, typename A14, typename A15>
-struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; A13 a13; A14 a14; A15 a15; };
-template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12, typename A13, typename A14, typename A15, typename A16>
-struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; A13 a13; A14 a14; A15 a15; A16 a16; };
-template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12, typename A13, typename A14, typename A15, typename A16, typename A17>
-struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; A13 a13; A14 a14; A15 a15; A16 a16; A17 a17; };
-
-
-template<typename R, typename... Args>
-struct CallbackMarshaler;
-
-template<typename R, typename... Args>
-struct CallbackMarshaler<R(Args...)> {
-    template<ptrdiff_t offset>
-    static R marshal(Args... args, R(*guest_fn)(Args...)) {
-        uintptr_t guest_unpack = *(uintptr_t*)((uintptr_t)callback_unpacks + offset);
-        PackedArguments<R, Args...> argsrv { args... };
-        call_guest(guest_unpack, (void*)guest_fn, &argsrv);
-        if constexpr (!std::is_void_v<R>) {
-            return argsrv.rv;
-        }
-    }
-};
-
 int fexfn_impl_libX11_XIfEvent_internal(Display* a0, XEvent* a1, XIfEventCBFN* a2, XPointer a3) {
-    auto fn = binder::make_instance(a2, &CallbackMarshaler<XIfEventCBFN>::marshal<offsetof(CallbackUnpacks, libX11_XIfEventCB)>);
+
+    auto fn = BIND_CALLBACK(a2, XIfEventCB, libX11);
 
     return fexldr_ptr_libX11_XIfEvent(a0, a1, fn, a3);
 }
@@ -170,18 +73,22 @@ int fexfn_impl_libX11_XIfEvent_internal(Display* a0, XEvent* a1, XIfEventCBFN* a
 Bool fexfn_impl_libX11_XUnregisterIMInstantiateCallback_internal(
     Display* a0, struct _XrmHashBucketRec* a1,
     char* a2, char* a3, XUnregisterIMInstantiateCallbackCBFN* a4, XPointer a5) {
-    auto fn = binder::make_instance(a4, &CallbackMarshaler<XUnregisterIMInstantiateCallbackCBFN>::marshal<offsetof(CallbackUnpacks, libX11_XUnregisterIMInstantiateCallbackCB)>);
+
+    auto fn = BIND_CALLBACK(a4, XUnregisterIMInstantiateCallbackCB, libX11);
+
     return fexldr_ptr_libX11_XUnregisterIMInstantiateCallback(a0, a1, a2, a3, fn, a5);
 }
 
 void fexfn_impl_libX11_XRemoveConnectionWatch_internal(Display* a0, XRemoveConnectionWatchCBFN* a1, XPointer a2) {
-    auto fn = binder::make_instance(a1, &CallbackMarshaler<XRemoveConnectionWatchCBFN>::marshal<offsetof(CallbackUnpacks, libX11_XRemoveConnectionWatchCB)>);
+
+    auto fn = BIND_CALLBACK(a1, XRemoveConnectionWatchCB, libX11);
 
     return fexldr_ptr_libX11_XRemoveConnectionWatch(a0, fn, a2);
 }
 
 XSetErrorHandlerCBFN* fexfn_impl_libX11_XSetErrorHandler_internal(XSetErrorHandlerCBFN a_0) {
-    auto fn = binder::make_instance(a_0, &CallbackMarshaler<XSetErrorHandlerCBFN>::marshal<offsetof(CallbackUnpacks, libX11_XSetErrorHandlerCB)>);
+    
+    auto fn = BIND_CALLBACK(a_0, XSetErrorHandlerCB, libX11);
 
     XSetErrorHandlerCBFN* old = fexldr_ptr_libX11_XSetErrorHandler(fn);
 

--- a/ThunkLibs/libX11/libX11_Host.cpp
+++ b/ThunkLibs/libX11/libX11_Host.cpp
@@ -180,18 +180,15 @@ void fexfn_impl_libX11_XRemoveConnectionWatch_internal(Display* a0, XRemoveConne
     return fexldr_ptr_libX11_XRemoveConnectionWatch(a0, fn, a2);
 }
 
-static XErrorHandler guest_handler;
-
 XSetErrorHandlerCBFN* fexfn_impl_libX11_XSetErrorHandler_internal(XSetErrorHandlerCBFN a_0) {
     auto fn = binder::make_instance(a_0, &CallbackMarshaler<XSetErrorHandlerCBFN>::marshal<offsetof(CallbackUnpacks, libX11_XSetErrorHandlerCB)>);
 
-    auto old = guest_handler;
-    guest_handler = a_0;
+    XSetErrorHandlerCBFN* old = fexldr_ptr_libX11_XSetErrorHandler(fn);
 
-    // FEX_TODO(Get return value from bound fn)
-    fexldr_ptr_libX11_XSetErrorHandler(fn);
+    auto guest = binder::get_target(old);
+    assert(guest != 0 || old == 0);
 
-    return old;
+    return guest;
 }
 
 #include "function_unpacks.inl"

--- a/ThunkLibs/libX11/libX11_Host.cpp
+++ b/ThunkLibs/libX11/libX11_Host.cpp
@@ -58,8 +58,10 @@ char* fexfn_impl_libX11_XGetICValues_internal(XIC a_0, size_t count, unsigned lo
     }
 }
 
+DECL_COPYABLE_TRAMPLOLINE(XUnregisterIMInstantiateCallbackCBFN)
+DECL_COPYABLE_TRAMPLOLINE(XRemoveConnectionWatchCBFN)
 DECL_COPYABLE_TRAMPLOLINE(XIfEventCBFN)
-
+DECL_COPYABLE_TRAMPLOLINE(XSetErrorHandlerCBFN)
 
 template<typename Result, typename... Args>
 struct PackedArguments;
@@ -160,37 +162,35 @@ struct CallbackMarshaler<R(Args...)> {
 };
 
 int fexfn_impl_libX11_XIfEvent_internal(Display* a0, XEvent* a1, XIfEventCBFN* a2, XPointer a3) {
-    auto fn = binder::make_instance<XIfEventCBFN>(a2, &CallbackMarshaler<XIfEventCBFN>::marshal<offsetof(CallbackUnpacks, libX11_XIfEventCB)>);
+    auto fn = binder::make_instance(a2, &CallbackMarshaler<XIfEventCBFN>::marshal<offsetof(CallbackUnpacks, libX11_XIfEventCB)>);
 
     return fexldr_ptr_libX11_XIfEvent(a0, a1, fn, a3);
 }
 
 Bool fexfn_impl_libX11_XUnregisterIMInstantiateCallback_internal(
-    Display*, struct _XrmHashBucketRec*,
-    char*, char*, XUnregisterIMInstantiateCallbackCBFN*, XPointer) {
-    fprintf(stderr, "XUnregisterIMInstantiateCallback: Stubbed");
-    return true;
+    Display* a0, struct _XrmHashBucketRec* a1,
+    char* a2, char* a3, XUnregisterIMInstantiateCallbackCBFN* a4, XPointer a5) {
+    auto fn = binder::make_instance(a4, &CallbackMarshaler<XUnregisterIMInstantiateCallbackCBFN>::marshal<offsetof(CallbackUnpacks, libX11_XUnregisterIMInstantiateCallbackCB)>);
+    return fexldr_ptr_libX11_XUnregisterIMInstantiateCallback(a0, a1, a2, a3, fn, a5);
 }
 
-void fexfn_impl_libX11_XRemoveConnectionWatch_internal(Display*, XRemoveConnectionWatchCBFN*, XPointer) {
-    fprintf(stderr, "XRemoveConnectionWatch: Stubbed");
+void fexfn_impl_libX11_XRemoveConnectionWatch_internal(Display* a0, XRemoveConnectionWatchCBFN* a1, XPointer a2) {
+    auto fn = binder::make_instance(a1, &CallbackMarshaler<XRemoveConnectionWatchCBFN>::marshal<offsetof(CallbackUnpacks, libX11_XRemoveConnectionWatchCB)>);
+
+    return fexldr_ptr_libX11_XRemoveConnectionWatch(a0, fn, a2);
 }
 
-XErrorHandler guest_handler;
+static XErrorHandler guest_handler;
 
-int XSetErrorHandlerCB(Display* a_0, XErrorEvent* a_1) {
-    static XSetErrorHandlerCB_Args argsrv { a_0, a_1};
-    
-    call_guest(callback_unpacks->libX11_XSetErrorHandlerCB, (void*) guest_handler, &argsrv);
-    
-    return argsrv.rv;
-}
+XSetErrorHandlerCBFN* fexfn_impl_libX11_XSetErrorHandler_internal(XSetErrorHandlerCBFN a_0) {
+    auto fn = binder::make_instance(a_0, &CallbackMarshaler<XSetErrorHandlerCBFN>::marshal<offsetof(CallbackUnpacks, libX11_XSetErrorHandlerCB)>);
 
-XSetErrorHandlerCBFN* fexfn_impl_libX11_XSetErrorHandler_internal(XErrorHandler a_0) {
     auto old = guest_handler;
     guest_handler = a_0;
 
-    fexldr_ptr_libX11_XSetErrorHandler(&XSetErrorHandlerCB);
+    // FEX_TODO(Get return value from bound fn)
+    fexldr_ptr_libX11_XSetErrorHandler(fn);
+
     return old;
 }
 

--- a/ThunkLibs/libXext/libXext_Host.cpp
+++ b/ThunkLibs/libXext/libXext_Host.cpp
@@ -4,6 +4,8 @@ tags: thunklibs|X11
 $end_info$
 */
 
+#include "common/Host.h"
+
 #include <stdio.h>
 
 #include <X11/Xlib.h>
@@ -38,7 +40,6 @@ extern "C" {
 #include <X11/extensions/syncproto.h>
 //#include <X11/extensions/XTest.h>
 
-#include "common/Host.h"
 #include <dlfcn.h>
 
 #include "ldr_ptrs.inl"


### PR DESCRIPTION
#### Overview
The code is a bit ugly, but it works.

Copyable functions are standard functions sprinkled with some inline assembly so we can determine their size and to bake a literal pool inside them. As they are copied around, they also cannot refer to any globals as there is no relocation performed on copy. Compiler options must guarantee that no stack check guards, etc are done as well.

Callbacks need copyable functions, or something similar, so we can bind a distinct guest callback to a distinct host callback without a data argument.

As a proof of concept, libX11 callbacks are implemented here.

#### Details
- mt-safe guest -> host and host -> guest lookup tables are kept
- function storage space is allocated using mmap in 16kb chunks
- function storage space is /leaked/. We could free on lib unload.

#### Alternative implementations
Another approach to this could be to use the `r11` trick as used in GCH, and make the copyable function naked + inline asm. This would guarantee no relocations are performed, and would not repack the arguments needlessly, at the expense of depending that the compiler doesn't trample over `r11` for x86-64 and the corresponding arm64 reg we choose.

Thoughts?