### PR TITLE
FEXServer: Adds -w option for waiting on current FEXServer

### DIFF
--- a/Source/Common/FEXServerClient.h
+++ b/Source/Common/FEXServerClient.h
@@ -11,6 +11,7 @@ namespace FEXServerClient {
     TYPE_KILL,
     TYPE_GET_LOG_FD,
     TYPE_GET_ROOTFS_PATH,
+    TYPE_GET_PID_FD,
 
     // Result only
     TYPE_SUCCESS,
@@ -88,6 +89,16 @@ namespace FEXServerClient {
   int RequestLogFD(int ServerSocket);
 
   std::string RequestRootFSPath(int ServerSocket);
+
+  /**
+   * @brief Request a FEXServer to give us a pidfd of the process
+   *
+   * @param ServerSocket - Socket to the server
+   *
+   * @return FD for pidfd
+   */
+  int RequestPIDFD(int ServerSocket);
+
   /**  @} */
 
   /**

--- a/Source/Tools/FEXServer/ArgumentLoader.cpp
+++ b/Source/Tools/FEXServer/ArgumentLoader.cpp
@@ -31,6 +31,11 @@ namespace FEXServer::Config {
       .metavar("n")
       .help("Make FEXServer persistent. Optional number of seconds");
 
+    Parser.add_option("-w", "--wait")
+      .action("store_true")
+      .set_default(false)
+      .help("Wait for the FEXServer to shutdown");
+
     Parser.add_option("-v")
       .action("version")
       .help("Version string");
@@ -39,6 +44,10 @@ namespace FEXServer::Config {
 
     FEXOptions.Kill = Options.get("kill");
     FEXOptions.Foreground = Options.get("foreground");
+    FEXOptions.Wait = Options.get("wait");
+    if (FEXOptions.Wait) {
+      FEXOptions.Foreground = true;
+    }
     FEXOptions.PersistentTimeout = Options.get("persistent");
 
     return FEXOptions;

--- a/Source/Tools/FEXServer/ArgumentLoader.h
+++ b/Source/Tools/FEXServer/ArgumentLoader.h
@@ -5,6 +5,7 @@ namespace FEXServer::Config {
   struct FEXServerOptions {
     bool Kill;
     bool Foreground;
+    bool Wait;
     uint32_t PersistentTimeout;
   };
 


### PR DESCRIPTION
It can be useful to know in tooling when the current active FEXServer
has exited.

Two things can happen when this command is run.
No FEXServer is active, returns immediately.
A FEXServer is active, we query for a pidfd from the active server, then
we wait until it exits.

Both instances of this is valid to use.