### PR TITLE
BUGFIX https://github.com/FEX-Emu/FEX/issues/613

### DIFF
--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -102,8 +102,6 @@ set (SRCS
   Interface/Core/ArchHelpers/Arm64_stubs.cpp
   Interface/Core/ArchHelpers/Arm64Emitter.cpp
   Interface/Core/Dispatcher/Dispatcher.cpp
-  Interface/Core/Dispatcher/X86Dispatcher.cpp
-  Interface/Core/Dispatcher/Arm64Dispatcher.cpp
   Interface/Core/Interpreter/InterpreterFallbacks.cpp
   Interface/Core/X86Tables/BaseTables.cpp
   Interface/Core/X86Tables/DDDTables.cpp
@@ -144,6 +142,19 @@ set (SRCS
   Utils/Telemetry.cpp
   Utils/Threads.cpp
   )
+
+if (_M_X86_64)
+  list(APPEND SRCS
+  Interface/Core/Dispatcher/X86Dispatcher.cpp
+  )
+endif()
+
+if (_M_ARM_64)
+  list(APPEND SRCS
+  Interface/Core/Dispatcher/Arm64Dispatcher.cpp
+  )
+endif()
+
 
 if (ENABLE_INTERPRETER)
   list(APPEND SRCS

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.h
@@ -29,6 +29,8 @@ class Arm64Dispatcher final : public Dispatcher, public Arm64Emitter {
     uint64_t LDIVHandlerAddress{};
     uint64_t LUREMHandlerAddress{};
     uint64_t LREMHandlerAddress{};
+    uint64_t StaticRegsSpillerAddress{};
+    uint64_t StaticRegsFillerAddress{};
     DispatcherConfig config;
 };
 

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
@@ -693,6 +693,7 @@ bool Dispatcher::HandleSignalPause(FEXCore::Core::InternalThreadState *Thread, i
     // We don't care about anything at this point
     // Set the stack to our starting location when we entered the core and get out safely
     ArchHelpers::Context::SetSp(ucontext, Frame->ReturningStackLocation);
+    ArchHelpers::Context::SetState(ucontext, reinterpret_cast<uint64_t>(Frame));
 
     // Our ref counting doesn't matter anymore
     Thread->CurrentFrame->SignalHandlerRefCounter = 0;

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
@@ -83,6 +83,8 @@ public:
     CallbackPtr(Frame, RIP);
   }
 
+  static void SleepThread(FEXCore::Context::Context *ctx, FEXCore::Core::CpuStateFrame *Frame);
+
 protected:
   Dispatcher(FEXCore::Context::Context *ctx)
     : CTX {ctx}
@@ -96,8 +98,6 @@ protected:
   virtual void SpillSRA(FEXCore::Core::InternalThreadState *Thread, void *ucontext, uint32_t IgnoreMask) {}
 
   FEXCore::Context::Context *CTX;
-
-  static void SleepThread(FEXCore::Context::Context *ctx, FEXCore::Core::CpuStateFrame *Frame);
 
   static uint64_t GetCompileBlockPtr();
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -369,7 +369,7 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header *IROp, IR::NodeID Node) {
 }
 
 
-static uint64_t Arm64JITCore_ExitFunctionLink(FEXCore::Core::CpuStateFrame *Frame, uint64_t *record) {
+uint64_t Arm64JITCore::ExitFunctionLink(FEXCore::Core::CpuStateFrame *Frame, uint64_t *record) {
   auto Thread = Frame->Thread;
   auto GuestRip = record[1];
 
@@ -483,7 +483,7 @@ Arm64JITCore::Arm64JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::Intern
 
     Common.SyscallHandlerObj = reinterpret_cast<uint64_t>(CTX->SyscallHandler);
     Common.SyscallHandlerFunc = reinterpret_cast<uint64_t>(FEXCore::Context::HandleSyscall);
-    Common.ExitFunctionLink = reinterpret_cast<uintptr_t>(&Arm64JITCore_ExitFunctionLink);
+    Common.ExitFunctionLink = reinterpret_cast<uintptr_t>(&Arm64JITCore::ExitFunctionLink);
 
 
     // Fill in the fallback handlers

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -64,6 +64,8 @@ public:
 
   void ClearRelocations() override { Relocations.clear(); }
 
+  static uint64_t ExitFunctionLink(FEXCore::Core::CpuStateFrame *Frame, uint64_t *record);
+
 private:
   FEX_CONFIG_OPT(ParanoidTSO, PARANOIDTSO);
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
@@ -80,8 +80,8 @@ DEF_OP(ExitFunction) {
     Label l_BranchHost;
     Label l_BranchGuest;
 
-    lea(rax, ptr[rip + l_BranchHost]);
-    jmp(qword[rax]);
+    lea(rsi, ptr[rip + l_BranchHost]);
+    jmp(qword[rsi]);
 
     L(l_BranchHost);
     //FEX_TODO(this is not per thread)

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
@@ -80,7 +80,10 @@ DEF_OP(ExitFunction) {
     Label l_BranchHost;
     Label l_BranchGuest;
 
+    // Store this in second function parameter
+    // register, where ExitFunctionLinker expects it:
     lea(rsi, ptr[rip + l_BranchHost]);
+    
     jmp(qword[rsi]);
 
     L(l_BranchHost);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -300,7 +300,7 @@ void X86JITCore::Op_Unhandled(IR::IROp_Header *IROp, IR::NodeID Node) {
   }
 }
 
-static uint64_t X86JITCore_ExitFunctionLink(FEXCore::Core::CpuStateFrame *Frame, uint64_t *record) {
+uint64_t X86JITCore::ExitFunctionLink(FEXCore::Core::CpuStateFrame *Frame, uint64_t *record) {
   auto Thread = Frame->Thread;
   auto GuestRip = record[1];
 
@@ -371,7 +371,7 @@ X86JITCore::X86JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalTh
 
     Common.SyscallHandlerObj = reinterpret_cast<uint64_t>(CTX->SyscallHandler);
     Common.SyscallHandlerFunc = reinterpret_cast<uint64_t>(FEXCore::Context::HandleSyscall);
-    Common.ExitFunctionLink = reinterpret_cast<uintptr_t>(&X86JITCore_ExitFunctionLink);
+    Common.ExitFunctionLink = reinterpret_cast<uintptr_t>(&X86JITCore::ExitFunctionLink);
 
     // Fill in the fallback handlers
     InterpreterOps::FillFallbackIndexPointers(Common.FallbackHandlerPointers);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -72,6 +72,8 @@ public:
 
   void ClearRelocations() override { Relocations.clear(); }
 
+  static uint64_t ExitFunctionLink(FEXCore::Core::CpuStateFrame *Frame, uint64_t *record);
+
 private:
 
   /**
@@ -194,8 +196,6 @@ private:
 #ifdef BLOCKSTATS
   bool GetSamplingData {true};
 #endif
-
-  static uint64_t ExitFunctionLink(FEXCore::Core::CpuStateFrame *Frame, uint64_t *record);
 
   // This is purely a debugging aid for developers to see if they are in JIT code space when inspecting raw memory
   void EmitDetectionString();

--- a/External/FEXCore/include/FEXCore/Core/CoreState.h
+++ b/External/FEXCore/include/FEXCore/Core/CoreState.h
@@ -4,6 +4,7 @@
 #include <FEXCore/Utils/CompilerDefs.h>
 #include <FEXCore/Core/CPUBackend.h>
 
+#include <setjmp.h>
 #include <atomic>
 #include <cstddef>
 #include <stdint.h>
@@ -205,6 +206,9 @@ namespace FEXCore::Core {
 
     // Pointers that the JIT needs to load to remove relocations
     JITPointers Pointers;
+    
+    jmp_buf   EmuContext;
+    jmp_buf   CallbackContext;
   };
   static_assert(offsetof(CpuStateFrame, State) == 0, "CPUState must be first member in CpuStateFrame");
   static_assert(offsetof(CpuStateFrame, State.rip) == 0, "rip must be zero offset in CpuStateFrame");

--- a/External/FEXCore/include/FEXCore/Core/CoreState.h
+++ b/External/FEXCore/include/FEXCore/Core/CoreState.h
@@ -158,6 +158,8 @@ namespace FEXCore::Core {
         uint64_t LDIVHandler{};
         uint64_t LUREMHandler{};
         uint64_t LREMHandler{};
+        uint64_t StaticRegsSpiller{};
+        uint64_t StaticRegsFiller{};
         /**  @} */
       } AArch64;
 


### PR DESCRIPTION
Convert the dynamically generated dispatcher assembly as much as possible to
regular C++ functions, with some modest glue functions whenever that is not
fully possible.

1) There still is quite a lot of assembly. This is for moving the state pointer to the proper places, and for calling register save/restore sequences  without interference by compiler generated code. Still, this change separates the glue code in assembly from the functional FEX code, now in C++. Likely some of the assembler glue repetition in this change can be reduced somewhat by making use of C++ templates, or otherwise good ol' C macros. Suggestions are welcome on this subject.

2) This change contains copies of register save/restore functions from current register set definitions in Arm64Emitter.h. That is definitely not what it should finally look like. I did not see an easy way to base this assembly on the register set definitions in the arm emitter, so suspect that we should generate them in a build tool. If this pull request seems attractive to the reviewers then we should determine how to implement it. I then would suggest submitting this pull request as is and after that immediately start working on the generator (I hesitate mixing different changes into one larger one). This should not be too hard, just a build tool, but this could be combined with some slight cleanup of the register definition framework in FEX.

3) There is some code that I did not see hit by any of the current tests. Rather than trying to already do their re-implementation in C++ I marked them with an assert. 

4) After this change submits some cleanup of the existing FEX code around it is probably possible

5) Stefanos submitted some dispatcher changes related to the gdb server at the end of last week. I have not looked into this yet, left them as is.

6) SignalSafeCompile was already constant True, and this change ignores config.StaticRegisterAllocation (which until recently was a constant True as well in the Dispatcher code). It seems that StaticRegisterAllocation is the goal; is there any reason for these conditionals?

7) Running ctest on X86 and Arm I noticed that several tests already failed before the changes in this pull request. The current changes failed and passed in the same ways
