### PR TITLE
FEXServerClient: When running under pressure-vessel don't use FEXServer rootfs

### DIFF
--- a/External/FEXCore/Source/Interface/Config/Config.cpp
+++ b/External/FEXCore/Source/Interface/Config/Config.cpp
@@ -371,6 +371,22 @@ namespace JSON {
     return {};
   }
 
+
+  std::string FindContainer() {
+    // We only support pressure-vessel at the moment
+    const static std::string ContainerManager = "/run/host/container-manager";
+    if (std::filesystem::exists(ContainerManager)) {
+      std::vector<char> Manager{};
+      if (FEXCore::FileLoading::LoadFile(Manager, ContainerManager)) {
+        // Trim the whitespace, may contain a newline
+        std::string ManagerStr = Manager.data();
+        ManagerStr = FEXCore::StringUtils::Trim(ManagerStr);
+        return ManagerStr;
+      }
+    }
+    return {};
+  }
+
   std::string FindContainerPrefix() {
     // We only support pressure-vessel at the moment
     const static std::string ContainerManager = "/run/host/container-manager";

--- a/External/FEXCore/include/FEXCore/Config/Config.h
+++ b/External/FEXCore/include/FEXCore/Config/Config.h
@@ -163,6 +163,7 @@ namespace Type {
 
   FEX_DEFAULT_VISIBILITY void Load();
   FEX_DEFAULT_VISIBILITY void ReloadMetaLayer();
+  FEX_DEFAULT_VISIBILITY std::string FindContainer();
   FEX_DEFAULT_VISIBILITY std::string FindContainerPrefix();
 
   FEX_DEFAULT_VISIBILITY void AddLayer(std::unique_ptr<FEXCore::Config::Layer> _Layer);

--- a/Source/Common/FEXServerClient.cpp
+++ b/Source/Common/FEXServerClient.cpp
@@ -135,10 +135,14 @@ namespace FEXServerClient {
       return false;
     }
 
-    std::string RootFSPath = FEXServerClient::RequestRootFSPath(ServerFD);
+    // If we were started in a container then we want to use the rootfs that they provided.
+    // In the pressure-vessel case this is a combination of our rootfs and the steam soldier runtime.
+    if (FEXCore::Config::FindContainer() != "pressure-vessel") {
+      std::string RootFSPath = FEXServerClient::RequestRootFSPath(ServerFD);
 
-    // If everything has passed then we can now update the rootfs path
-    FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_ROOTFS, RootFSPath);
+      //// If everything has passed then we can now update the rootfs path
+      FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_ROOTFS, RootFSPath);
+    }
 
     return true;
   }


### PR DESCRIPTION
pressure-vessel overrides our rootfs when it does a pivot_root.
Since we are still communicating to the FEXServer we were pulling the
configured rootfs.

Instead check if we are in pressure vessel and avoid doing that.

This fixes FEX running under pressure-vessel.

(There may be some implications to this down the road with code caching
but let's worry about that later)