### PR TITLE
unittests: Classify CPU based on CPU features

### DIFF
--- a/Scripts/ClassifyCPU.py
+++ b/Scripts/ClassifyCPU.py
@@ -1,0 +1,56 @@
+#!/usr/bin/python3
+import os
+import subprocess
+import sys
+import tempfile
+import platform
+
+def ListContainsRequired(Features, RequiredFeatures):
+    for Req in RequiredFeatures:
+        if not Req in Features:
+            return False
+    return True
+
+def GetCPUFeaturesVersion():
+
+    # Also LOR but kernel doesn't expose this
+    v8_1Mandatory = ["atomics", "asimdrdm", "crc32"]
+    v8_2Mandatory = v8_1Mandatory + ["dcpop"]
+    v8_3Mandatory = v8_2Mandatory + ["fcma", "jscvt", "lrcpc", "paca", "pacg"]
+    v8_4Mandatory = v8_3Mandatory + ["asimddp", "flagm", "ilrcpc", "uscat"]
+
+    #  fphp asimdhp asimddp
+
+    File = open("/proc/cpuinfo", "r")
+    Lines = File.readlines()
+    File.close()
+
+    # Minimum spec is ARMv8.0
+    _ArchVersion = "8.0"
+    for Line in Lines:
+        if "Features" in Line:
+            Features = Line.split(":")[1].strip().split(" ")
+
+            # We don't care beyond 8.4 right now
+            if ListContainsRequired(Features, v8_4Mandatory):
+                _ArchVersion = "8.4"
+            elif ListContainsRequired(Features, v8_3Mandatory):
+                _ArchVersion = "8.3"
+            elif ListContainsRequired(Features, v8_2Mandatory):
+                _ArchVersion = "8.2"
+            elif ListContainsRequired(Features, v8_1Mandatory):
+                _ArchVersion = "8.1"
+            break;
+
+    return _ArchVersion
+
+def main():
+    if (platform.machine() == "aarch64"):
+        print("ARMv{}".format(GetCPUFeaturesVersion()))
+    elif (platform.machine() == "x86_64"):
+        print("x64")
+
+    sys.exit(0)
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/unittests/32Bit_ASM/CMakeLists.txt
+++ b/unittests/32Bit_ASM/CMakeLists.txt
@@ -8,6 +8,11 @@ endif()
 file(GLOB_RECURSE ASM_SOURCES CONFIGURE_DEPENDS *.asm)
 
 set(ASM_DEPENDS "")
+
+execute_process(COMMAND "python3" "${CMAKE_SOURCE_DIR}/Scripts/ClassifyCPU.py"
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  OUTPUT_VARIABLE CPU_CLASS)
+
 foreach(ASM_SRC ${ASM_SOURCES})
   file(RELATIVE_PATH REL_ASM ${CMAKE_SOURCE_DIR} ${ASM_SRC})
   file(RELATIVE_PATH REL_TEST_ASM ${CMAKE_CURRENT_SOURCE_DIR} ${ASM_SRC})
@@ -64,11 +69,6 @@ foreach(ASM_SRC ${ASM_SOURCES})
     )
   endif()
 
-  set (RUNNER_DISABLED "${CMAKE_SOURCE_DIR}/unittests/ASM/Disabled_Tests")
-  if (DEFINED ENV{runner_label})
-    set (RUNNER_DISABLED "${CMAKE_SOURCE_DIR}/unittests/ASM/Disabled_Tests_$ENV{runner_label}")
-  endif()
-
   list(LENGTH TEST_ARGS ARG_COUNT)
   math(EXPR ARG_COUNT "${ARG_COUNT}-1")
   foreach(Index RANGE 0 ${ARG_COUNT} 3)
@@ -86,7 +86,7 @@ foreach(ASM_SRC ${ASM_SOURCES})
       "${CMAKE_SOURCE_DIR}/unittests/32Bit_ASM/Known_Failures"
       "${CMAKE_SOURCE_DIR}/unittests/32Bit_ASM/Disabled_Tests"
       "${CMAKE_SOURCE_DIR}/unittests/32Bit_ASM/Disabled_Tests_${TEST_TYPE}"
-      "${RUNNER_DISABLED}"
+      "${CMAKE_SOURCE_DIR}/unittests/32Bit_ASM/Disabled_Tests_${CPU_CLASS}"
       "Test_32Bit_${REL_TEST_ASM}"
       "${CMAKE_BINARY_DIR}/Bin/TestHarnessRunner"
       ${ARGS_LIST} "${OUTPUT_NAME}" "${OUTPUT_CONFIG_NAME}")

--- a/unittests/ASM/CMakeLists.txt
+++ b/unittests/ASM/CMakeLists.txt
@@ -8,6 +8,11 @@ endif()
 file(GLOB_RECURSE ASM_SOURCES CONFIGURE_DEPENDS *.asm)
 
 set(ASM_DEPENDS "")
+
+execute_process(COMMAND "python3" "${CMAKE_SOURCE_DIR}/Scripts/ClassifyCPU.py"
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  OUTPUT_VARIABLE CPU_CLASS)
+
 foreach(ASM_SRC ${ASM_SOURCES})
   file(RELATIVE_PATH REL_ASM ${CMAKE_SOURCE_DIR} ${ASM_SRC})
   file(RELATIVE_PATH REL_TEST_ASM ${CMAKE_CURRENT_SOURCE_DIR} ${ASM_SRC})
@@ -63,11 +68,6 @@ foreach(ASM_SRC ${ASM_SOURCES})
     )
   endif()
 
-  set (RUNNER_DISABLED "${CMAKE_SOURCE_DIR}/unittests/ASM/Disabled_Tests")
-  if (DEFINED ENV{runner_label})
-    set (RUNNER_DISABLED "${CMAKE_SOURCE_DIR}/unittests/ASM/Disabled_Tests_$ENV{runner_label}")
-  endif()
-
   list(LENGTH TEST_ARGS ARG_COUNT)
   math(EXPR ARG_COUNT "${ARG_COUNT}-1")
   foreach(Index RANGE 0 ${ARG_COUNT} 3)
@@ -90,7 +90,7 @@ foreach(ASM_SRC ${ASM_SOURCES})
       "${CMAKE_SOURCE_DIR}/unittests/ASM/Known_Failures"
       "${CMAKE_SOURCE_DIR}/unittests/ASM/Disabled_Tests"
       "${CMAKE_SOURCE_DIR}/unittests/ASM/Disabled_Tests_${TEST_TYPE}"
-      "${RUNNER_DISABLED}"
+      "${CMAKE_SOURCE_DIR}/unittests/ASM/Disabled_Tests_${CPU_CLASS}"
       "Test_${REL_TEST_ASM}"
       "${CMAKE_BINARY_DIR}/Bin/TestHarnessRunner"
       ${ARGS_LIST} "${OUTPUT_NAME}" "${OUTPUT_CONFIG_NAME}")


### PR DESCRIPTION
Instead of relying on runner features, classify based on CPU features.

This fixes an annoying issue where if running unit tests locally without
it set then you get an unexpected failure.

Fixes #1807