### PR TITLE
unittests: Adds 32-bit into test 

### DIFF
--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -10,7 +10,6 @@ if (BUILD_THUNKS)
   add_subdirectory(ThunkLibs)
 endif()
 
-
 if (BUILD_FEX_LINUX_TESTS)
   add_subdirectory(FEXLinuxTests/)
 endif()

--- a/unittests/FEXLinuxTests/CMakeLists.txt
+++ b/unittests/FEXLinuxTests/CMakeLists.txt
@@ -4,73 +4,89 @@ ExternalProject_Add(FEXLinuxTests
   SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/tests"
   BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/FEXLinuxTests"
   CMAKE_ARGS
-    "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
-    "-DCMAKE_TOOLCHAIN_FILE:FILEPATH=${X86_TOOLCHAIN_FILE}"
+  "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
+  "-DCMAKE_TOOLCHAIN_FILE:FILEPATH=${X86_TOOLCHAIN_FILE}"
   INSTALL_COMMAND ""
   BUILD_ALWAYS ON
-)
+  )
+
+ExternalProject_Add(FEXLinuxTests_32
+  PREFIX FEXLinuxTests_32
+  SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/tests-32"
+  BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/FEXLinuxTests_32"
+  CMAKE_ARGS
+  "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
+  "-DCMAKE_TOOLCHAIN_FILE:FILEPATH=${X86_TOOLCHAIN_FILE}"
+  INSTALL_COMMAND ""
+  BUILD_ALWAYS ON
+  )
 
 # this kind of sucks, but reglob
 file(GLOB_RECURSE TESTS CONFIGURE_DEPENDS tests/*.cpp)
-foreach(TEST ${TESTS})
-  
-  get_filename_component(TEST_NAME ${TEST} NAME_WLE)
+file(GLOB_RECURSE TESTS_32 CONFIGURE_DEPENDS tests-32/*.cpp)
 
-  file(READ ${TEST} TEST_CODE)
-  
-  # Used to insert a configuration dependency to the test file
-  CONFIGURE_FILE(${TEST} ${CMAKE_BINARY_DIR}/junk.file)
+function(AddTests Tests BinDirectory BitnessList)
+  foreach(TEST ${Tests})
+    get_filename_component(TEST_NAME ${TEST} NAME_WLE)
 
-  set(ARGS_REGEX "auto args = \"([^\"]+)\";")
-  string(REGEX MATCH ${ARGS_REGEX} TEST_ARGS ${TEST_CODE})
-  # if cannot handle multiline variables, so we have to match the line first
-  if(${TEST_ARGS} MATCHES ${ARGS_REGEX})
-    string(REGEX REPLACE " |," ";" ARGS "${CMAKE_MATCH_1}")
-    set(VARIATIONS "")
-    foreach(ARG ${ARGS})
-      list(APPEND VARIATIONS "${TEST_NAME}-${ARG}:${ARG}")
-    endforeach()
-  else()
-    set(VARIATIONS "${TEST_NAME}:")
-  endif()
-  
-  set(ALL_BITNESS 32 64)
-  foreach(VARIATION ${VARIATIONS})
-    foreach(BITNESS ${ALL_BITNESS})
-      string(REGEX REPLACE ":" ";" VARIATION "${VARIATION}")
-      list(GET VARIATION 0 VARIATION_NAME)
-      list(GET VARIATION 1 VARIATION_ARG)
-      set(BIN_PATH "${CMAKE_CURRENT_BINARY_DIR}/FEXLinuxTests/${TEST_NAME}.${BITNESS}")
-      
-      set(TEST_CASE "${VARIATION_NAME}.${BITNESS}")
-      
-      # Add jit test case
-      add_test(NAME "${TEST_CASE}.jit.flt"
-        COMMAND "python3" "${CMAKE_SOURCE_DIR}/Scripts/guest_test_runner.py"
-        "${CMAKE_CURRENT_SOURCE_DIR}/Known_Failures"
-        "${CMAKE_CURRENT_SOURCE_DIR}/Expected_Output"
-        "${CMAKE_CURRENT_SOURCE_DIR}/Disabled_Tests"
-        "${TEST_CASE}"
-        "guest"
-        "$<TARGET_FILE:FEXLoader>"
-        "--no-silent" "-c" "irjit" "-n" "500" "--"
-        "${BIN_PATH}"
-        "${VARIATION_ARG}")
-      if (_M_X86_64)
-        # Add host test case
-        add_test(NAME "${TEST_CASE}.host.flt"
+    file(READ ${TEST} TEST_CODE)
+
+    # Used to insert a configuration dependency to the test file
+    CONFIGURE_FILE(${TEST} ${CMAKE_BINARY_DIR}/junk.file)
+
+    set(ARGS_REGEX "auto args = \"([^\"]+)\";")
+    string(REGEX MATCH ${ARGS_REGEX} TEST_ARGS ${TEST_CODE})
+    # if cannot handle multiline variables, so we have to match the line first
+    if(${TEST_ARGS} MATCHES ${ARGS_REGEX})
+      string(REGEX REPLACE " |," ";" ARGS "${CMAKE_MATCH_1}")
+      set(VARIATIONS "")
+      foreach(ARG ${ARGS})
+        list(APPEND VARIATIONS "${TEST_NAME}-${ARG}:${ARG}")
+      endforeach()
+    else()
+      set(VARIATIONS "${TEST_NAME}:")
+    endif()
+
+    foreach(VARIATION ${VARIATIONS})
+      foreach(BITNESS ${BitnessList})
+        string(REGEX REPLACE ":" ";" VARIATION "${VARIATION}")
+        list(GET VARIATION 0 VARIATION_NAME)
+        list(GET VARIATION 1 VARIATION_ARG)
+        set(BIN_PATH "${CMAKE_CURRENT_BINARY_DIR}/${BinDirectory}/${TEST_NAME}.${BITNESS}")
+
+        set(TEST_CASE "${VARIATION_NAME}.${BITNESS}")
+
+        # Add jit test case
+        add_test(NAME "${TEST_CASE}.jit.flt"
           COMMAND "python3" "${CMAKE_SOURCE_DIR}/Scripts/guest_test_runner.py"
-          "${CMAKE_CURRENT_SOURCE_DIR}/Known_Failures_Host"
+          "${CMAKE_CURRENT_SOURCE_DIR}/Known_Failures"
           "${CMAKE_CURRENT_SOURCE_DIR}/Expected_Output"
-          "${CMAKE_CURRENT_SOURCE_DIR}/Disabled_Tests_Host"
+          "${CMAKE_CURRENT_SOURCE_DIR}/Disabled_Tests"
           "${TEST_CASE}"
-          "host"
+          "guest"
+          "$<TARGET_FILE:FEXLoader>"
+          "--no-silent" "-c" "irjit" "-n" "500" "--"
           "${BIN_PATH}"
           "${VARIATION_ARG}")
-      endif()
+        if (_M_X86_64)
+          # Add host test case
+          add_test(NAME "${TEST_CASE}.host.flt"
+            COMMAND "python3" "${CMAKE_SOURCE_DIR}/Scripts/guest_test_runner.py"
+            "${CMAKE_CURRENT_SOURCE_DIR}/Known_Failures_Host"
+            "${CMAKE_CURRENT_SOURCE_DIR}/Expected_Output"
+            "${CMAKE_CURRENT_SOURCE_DIR}/Disabled_Tests_Host"
+            "${TEST_CASE}"
+            "host"
+            "${BIN_PATH}"
+            "${VARIATION_ARG}")
+        endif()
+      endforeach()
     endforeach()
   endforeach()
-endforeach()
+endfunction()
+
+AddTests("${TESTS}" "FEXLinuxTests" "32;64")
+AddTests("${TESTS_32}" "FEXLinuxTests_32"  "32")
 
 execute_process(COMMAND "nproc" OUTPUT_VARIABLE CORES)
 string(STRIP ${CORES} CORES)
@@ -82,7 +98,7 @@ add_custom_target(
   USES_TERMINAL
   COMMAND "ctest" "--timeout" "30" "-j${CORES}" "-R" "\.*\.jit\.flt$$" "--output-on-failure"
   DEPENDS FEXLinuxTests FEXLoader
-)
+  )
 
 # Only host
 add_custom_target(
@@ -91,7 +107,7 @@ add_custom_target(
   USES_TERMINAL
   COMMAND "ctest" "--timeout" "30" "-j${CORES}" "-R" "\.*\.host\.flt$$" "--output-on-failure"
   DEPENDS FEXLinuxTests
-)
+  )
 
 # Both host and emulated
 add_custom_target(
@@ -100,4 +116,4 @@ add_custom_target(
   USES_TERMINAL
   COMMAND "ctest" "--timeout" "30" "-j${CORES}" "-R" "\.*\.flt$$" "--output-on-failure"
   DEPENDS FEXLinuxTests FEXLoader
-)
+  )

--- a/unittests/FEXLinuxTests/tests-32/CMakeLists.txt
+++ b/unittests/FEXLinuxTests/tests-32/CMakeLists.txt
@@ -1,0 +1,56 @@
+cmake_minimum_required(VERSION 3.14)
+project(FEXLinuxTests_32)
+
+set(CMAKE_CXX_STANDARD 17)
+
+unset (CMAKE_C_FLAGS)
+unset (CMAKE_CXX_FLAGS)
+
+set(GENERATE_GUEST_INSTALL_TARGETS TRUE)
+
+file(GLOB_RECURSE TESTS CONFIGURE_DEPENDS *.cpp)
+
+foreach(TEST ${TESTS})
+  get_filename_component(TEST_NAME ${TEST} NAME_WLE)
+
+  # Used to insert a configuration dependency to the test file
+  CONFIGURE_FILE(${TEST} ${CMAKE_BINARY_DIR}/junk.file)
+
+  file(READ ${TEST} TEST_CODE)
+  set(FLAGS_REGEX "//[ ]*append cxxflags: ([^\n]+)")
+
+  string(REGEX MATCH ${FLAGS_REGEX} APPEND_CXX_FLAGS ${TEST_CODE})
+  # if cannot handle multiline variables, so we have to match the line first
+  if(${APPEND_CXX_FLAGS} MATCHES ${FLAGS_REGEX})
+    set(APPEND_CXX_FLAGS "${CMAKE_MATCH_1}")
+  else()
+    set(APPEND_CXX_FLAGS "")
+  endif()
+
+  set(FLAGS_REGEX "//[ ]*append ldflags: ([^\n]+)")
+
+  string(REGEX MATCH ${FLAGS_REGEX} APPEND_LD_FLAGS ${TEST_CODE})
+  # if cannot handle multiline variables, so we have to match the line first
+  if(${APPEND_LD_FLAGS} MATCHES ${FLAGS_REGEX})
+    set(APPEND_LD_FLAGS "${CMAKE_MATCH_1}" )
+  else()
+    set(APPEND_LD_FLAGS "")
+  endif()
+
+  set(FLAGS_REGEX "//[ ]*libs: ([^\n]+)")
+
+  string(REGEX MATCH ${FLAGS_REGEX} LIBS ${TEST_CODE})
+  # if cannot handle multiline variables, so we have to match the line first
+  if(${LIBS} MATCHES ${FLAGS_REGEX})
+    set(LIBS "${CMAKE_MATCH_1}" )
+    string(REGEX REPLACE " |," ";" LIBS "${LIBS}")
+  else()
+    set(LIBS "")
+  endif()
+
+  set(BIN_NAME_32 "${TEST_NAME}.32")
+
+  add_executable(${BIN_NAME_32} ${TEST})
+  set_target_properties(${BIN_NAME_32} PROPERTIES COMPILE_FLAGS "${APPEND_CXX_FLAGS} -m32 -g -O2 " LINK_FLAGS "${APPEND_LD_FLAGS} -m32")
+  target_link_libraries(${BIN_NAME_32} ${LIBS})
+endforeach()

--- a/unittests/FEXLinuxTests/tests-32/signal/into.cpp
+++ b/unittests/FEXLinuxTests/tests-32/signal/into.cpp
@@ -1,0 +1,36 @@
+#include <atomic>
+#include <signal.h>
+
+std::atomic<bool> CorrectFaultData{false};
+static void handler(int signal, siginfo_t *siginfo, void* context) {
+  ucontext_t *_context = (ucontext_t*)context;
+
+  if (signal != SIGSEGV) {
+    return;
+  }
+
+  if (siginfo->si_addr != nullptr) {
+    return;
+  }
+
+  if (_context->uc_mcontext.gregs[REG_TRAPNO] != 4) {
+    return;
+  }
+
+  CorrectFaultData = true;
+}
+
+int main() {
+  struct sigaction act{};
+  act.sa_sigaction = handler;
+  act.sa_flags = SA_SIGINFO;
+  sigaction(SIGSEGV, &act, nullptr);
+
+  __asm volatile(R"(
+  mov $0x7f, %%eax;
+  incb %%al;
+  into;
+  )" ::: "eax");
+
+  return CorrectFaultData ? 0 : 1;
+}


### PR DESCRIPTION
This is a very basic test to check for overflow exception.
`into` instruction only exists on 32-bit, so it needs to not be built as
a 64-bit executable.

Fixes #1808