### PR TITLE
unittests: Disable known flake in posix tests

### DIFF
--- a/unittests/POSIX/Disabled_Tests
+++ b/unittests/POSIX/Disabled_Tests
@@ -375,3 +375,6 @@ conformance-interfaces-sigaction-25-23.test
 conformance-interfaces-sigaction-25-24.test
 conformance-interfaces-sigaction-25-25.test
 conformance-interfaces-sigaction-25-26.test
+
+# This test is flakey on the interpreter
+conformance-behavior-WIFEXITED-1-3.test

--- a/unittests/POSIX/Known_Failures
+++ b/unittests/POSIX/Known_Failures
@@ -387,3 +387,6 @@ conformance-interfaces-sigaction-25-23.test
 conformance-interfaces-sigaction-25-24.test
 conformance-interfaces-sigaction-25-25.test
 conformance-interfaces-sigaction-25-26.test
+
+# This test is flakey on the interpreter
+conformance-behavior-WIFEXITED-1-3.test


### PR DESCRIPTION
Interpreter is flakey here, likely due to some race, but is periodically
fails and makes CI red.