### PR TITLE
Thunks: Adds libvulkan steam pinned library thunking support

### DIFF
--- a/Data/ThunksDB.json
+++ b/Data/ThunksDB.json
@@ -39,6 +39,7 @@
       "Overlay": [
         "@PREFIX_LIB@/x86_64-linux-gnu/libvulkan.so",
         "@PREFIX_LIB@/x86_64-linux-gnu/libvulkan.so.1",
+        "@HOME@/.local/share/Steam/ubuntu12_32/steam-runtime/pinned_libs_64/libvulkan.so.1"
       ],
       "Comment": [
         "Vulkan library relies on xcb, otherwise it crashes with jemalloc"

--- a/External/FEXCore/include/FEXCore/Common/Paths.h
+++ b/External/FEXCore/include/FEXCore/Common/Paths.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <FEXCore/Utils/CompilerDefs.h>
+
+#include <string>
+
+namespace FEXCore::Paths {
+  FEX_DEFAULT_VISIBILITY const char *GetHomeDirectory();
+
+  FEX_DEFAULT_VISIBILITY std::string GetCachePath();
+
+  FEX_DEFAULT_VISIBILITY std::string GetEntryCachePath();
+}


### PR DESCRIPTION
Since we have switched over to thunking the vulkan loader, behaviour has
changed here and we need to thunk this library.

While a bit unsafe to thunk arbitrary libraries, we know this one is
safe to thunk.

Fixes thunking Vulkan on steam games which have been broken since
switching over to vulkan loader thunking.

In the future this may become unnecessary but it is required for now.