### PR TITLE
Thunks: Soften error condition to be non-fatal

### DIFF
--- a/External/FEXCore/Source/Interface/HLE/Thunks/Thunks.cpp
+++ b/External/FEXCore/Source/Interface/HLE/Thunks/Thunks.cpp
@@ -113,8 +113,13 @@ namespace FEXCore {
                     }, CTX->ThunkHandler.get(), (void*)args->target_addr);
 
             if (!Result) {
-                if (Result.Creator != CTX->ThunkHandler.get() || Result.Data != (void*)args->target_addr) {
-                    ERROR_AND_DIE_FMT("Input address for LinkAddressToGuestFunction is already linked elsewhere");
+                if (Result.Creator != CTX->ThunkHandler.get()) {
+                    ERROR_AND_DIE_FMT("Input address for LinkAddressToGuestFunction is already linked by another module");
+                }
+                if (Result.Data != (void*)args->target_addr) {
+                    // NOTE: This may happen in Vulkan thunks if the Vulkan driver resolves two different symbols
+                    //       to the same function (e.g. vkGetPhysicalDeviceFeatures2/vkGetPhysicalDeviceFeatures2KHR)
+                    LogMan::Msg::EFmt("Input address for LinkAddressToGuestFunction is already linked elsewhere");
                 }
             }
         }


### PR DESCRIPTION
Dota Underlords hit this when querying Vulkan two different symbols (vkGetPhysicalDeviceFeatures2/vkGetPhysicalDeviceFeatures2KHR) that resolve to the same function. Ignoring the error in that specific case is safe, since the linked guest functions have the same implementation.

Ideally, we'll make the target guest wrappers unique by-signature to avoid this conflict. Then we can treat the error as fatal again.