### PR TITLE
FEXCore: Adds assume optimizing LogManager function 

### DIFF
--- a/External/FEXCore/Source/Common/BitSet.h
+++ b/External/FEXCore/Source/Common/BitSet.h
@@ -20,12 +20,12 @@ struct BitSet final {
   ElementType *Memory;
   void Allocate(size_t Elements) {
     size_t AllocateSize = AlignUp(Elements, MinimumSizeBits) / MinimumSize;
-    LOGMAN_THROW_A_FMT((AllocateSize * MinimumSize) >= Elements, "Fail");
+    LOGMAN_THROW_AA_FMT((AllocateSize * MinimumSize) >= Elements, "Fail");
     Memory = static_cast<ElementType*>(FEXCore::Allocator::malloc(AllocateSize));
   }
   void Realloc(size_t Elements) {
     size_t AllocateSize = AlignUp(Elements, MinimumSizeBits) / MinimumSize;
-    LOGMAN_THROW_A_FMT((AllocateSize * MinimumSize) >= Elements, "Fail");
+    LOGMAN_THROW_AA_FMT((AllocateSize * MinimumSize) >= Elements, "Fail");
     Memory = static_cast<ElementType*>(FEXCore::Allocator::realloc(Memory, AllocateSize));
   }
   void Free() {
@@ -64,7 +64,7 @@ struct BitSetView final {
   ElementType *Memory;
 
   void GetView(BitSet<T> &Set, uint64_t ElementOffset) {
-    LOGMAN_THROW_A_FMT((ElementOffset % MinimumSize) == 0,
+    LOGMAN_THROW_AA_FMT((ElementOffset % MinimumSize) == 0,
                        "Bitset view offset needs to be aligned to size of backing element");
     Memory = &Set.Memory[ElementOffset / MinimumSizeBits];
   }

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/MContext.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/MContext.h
@@ -124,7 +124,7 @@ static inline void SetArmReg(void* ucontext, uint32_t id, uint64_t val) {
 static inline __uint128_t GetArmFPR(void* ucontext, uint32_t id) {
   auto MContext = GetMContext(ucontext);
   HostFPRState *HostState = reinterpret_cast<HostFPRState*>(&MContext->__reserved[0]);
-  LOGMAN_THROW_A_FMT(HostState->Head.Magic == FPR_MAGIC, "Wrong FPR Magic: 0x{:08x}", HostState->Head.Magic);
+  LOGMAN_THROW_AA_FMT(HostState->Head.Magic == FPR_MAGIC, "Wrong FPR Magic: 0x{:08x}", HostState->Head.Magic);
 
   return HostState->FPRs[id];
 }
@@ -143,7 +143,7 @@ static inline void BackupContext(void* ucontext, T *Backup) {
 
     // Host FPR state starts at _mcontext->reserved[0];
     HostFPRState *HostState = reinterpret_cast<HostFPRState*>(&_mcontext->__reserved[0]);
-    LOGMAN_THROW_A_FMT(HostState->Head.Magic == FPR_MAGIC, "Wrong FPR Magic: 0x{:08x}", HostState->Head.Magic);
+    LOGMAN_THROW_AA_FMT(HostState->Head.Magic == FPR_MAGIC, "Wrong FPR Magic: 0x{:08x}", HostState->Head.Magic);
     Backup->FPSR = HostState->FPSR;
     Backup->FPCR = HostState->FPCR;
     memcpy(&Backup->FPRs[0], &HostState->FPRs[0], 32 * sizeof(__uint128_t));
@@ -163,7 +163,7 @@ static inline void RestoreContext(void* ucontext, T *Backup) {
    auto _mcontext = GetMContext(ucontext);
 
     HostFPRState *HostState = reinterpret_cast<HostFPRState*>(&_mcontext->__reserved[0]);
-    LOGMAN_THROW_A_FMT(HostState->Head.Magic == FPR_MAGIC, "Wrong FPR Magic: 0x{:08x}", HostState->Head.Magic);
+    LOGMAN_THROW_AA_FMT(HostState->Head.Magic == FPR_MAGIC, "Wrong FPR Magic: 0x{:08x}", HostState->Head.Magic);
     memcpy(&HostState->FPRs[0], &Backup->FPRs[0], 32 * sizeof(__uint128_t));
     HostState->FPCR = Backup->FPCR;
     HostState->FPSR = Backup->FPSR;

--- a/External/FEXCore/Source/Interface/Core/CPUBackend.cpp
+++ b/External/FEXCore/Source/Interface/Core/CPUBackend.cpp
@@ -58,8 +58,8 @@ auto CPUBackend::AllocateNewCodeBuffer(size_t Size) -> CodeBuffer {
   Buffer.Size = Size;
   Buffer.Ptr = static_cast<uint8_t *>(
       FEXCore::Allocator::mmap(nullptr, Buffer.Size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
-  LOGMAN_THROW_A_FMT(!!Buffer.Ptr, "Couldn't allocate code buffer");
-  
+  LOGMAN_THROW_AA_FMT(!!Buffer.Ptr, "Couldn't allocate code buffer");
+
   if (ThreadState->CTX->Config.GlobalJITNaming()) {
     ThreadState->CTX->Symbols.RegisterJITSpace(Buffer.Ptr, Buffer.Size);
   }

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
@@ -542,7 +542,7 @@ size_t Arm64Dispatcher::GenerateGDBPauseCheck(uint8_t *CodeBuffer, uint64_t Gues
 }
 
 size_t Arm64Dispatcher::GenerateInterpreterTrampoline(uint8_t *CodeBuffer) {
-  LOGMAN_THROW_A_FMT(!config.StaticRegisterAllocation, "GenerateInterpreterTrampoline dispatcher does not support SRA");
+  LOGMAN_THROW_AA_FMT(!config.StaticRegisterAllocation, "GenerateInterpreterTrampoline dispatcher does not support SRA");
   
   *emit.GetBuffer() = vixl::CodeBuffer(CodeBuffer, MaxInterpreterTrampolineSize);
 

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
@@ -692,7 +692,7 @@ bool Dispatcher::HandleGuestSignal(FEXCore::Core::InternalThreadState *Thread, i
   else {
     NewGuestSP -= 4;
     *(uint32_t*)NewGuestSP = SignalReturn;
-    LOGMAN_THROW_A_FMT(SignalReturn < 0x1'0000'0000ULL, "This needs to be below 4GB");
+    LOGMAN_THROW_AA_FMT(SignalReturn < 0x1'0000'0000ULL, "This needs to be below 4GB");
     Frame->State.gregs[FEXCore::X86State::REG_RSP] = NewGuestSP;
   }
 

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/X86Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/X86Dispatcher.cpp
@@ -33,7 +33,7 @@ X86Dispatcher::X86Dispatcher(FEXCore::Context::Context *ctx, const DispatcherCon
       FEXCore::Allocator::mmap(nullptr, MAX_DISPATCHER_CODE_SIZE, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0),
       nullptr) {
 
-  LOGMAN_THROW_A_FMT(!config.StaticRegisterAllocation, "X86 dispatcher does not support SRA");
+  LOGMAN_THROW_AA_FMT(!config.StaticRegisterAllocation, "X86 dispatcher does not support SRA");
 
   using namespace Xbyak;
   using namespace Xbyak::util;

--- a/External/FEXCore/Source/Interface/Core/Interpreter/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/ALUOps.cpp
@@ -843,7 +843,7 @@ DEF_OP(Bfi) {
 DEF_OP(Bfe) {
   auto Op = IROp->C<IR::IROp_Bfe>();
 
-  LOGMAN_THROW_A_FMT(IROp->Size <= 8, "OpSize is too large for BFE: {}", IROp->Size);
+  LOGMAN_THROW_AA_FMT(IROp->Size <= 8, "OpSize is too large for BFE: {}", IROp->Size);
   uint64_t SourceMask = (1ULL << Op->Width) - 1;
   if (Op->Width == 64) {
     SourceMask = ~0ULL;
@@ -856,7 +856,7 @@ DEF_OP(Bfe) {
 DEF_OP(Sbfe) {
   auto Op = IROp->C<IR::IROp_Sbfe>();
 
-  LOGMAN_THROW_A_FMT(IROp->Size <= 8, "OpSize is too large for SBFE: {}", IROp->Size);
+  LOGMAN_THROW_AA_FMT(IROp->Size <= 8, "OpSize is too large for SBFE: {}", IROp->Size);
   int64_t Src = *GetSrc<int64_t*>(Data->SSAData, Op->Src);
   const uint64_t ShiftLeftAmount = (64 - (Op->Width + Op->lsb));
   const uint64_t ShiftRightAmount = ShiftLeftAmount + Op->lsb;
@@ -898,7 +898,7 @@ DEF_OP(VExtractToGPR) {
 
   const uint32_t SourceSize = GetOpSize(Data->CurrentIR, Op->Vector);
 
-  LOGMAN_THROW_A_FMT(IROp->Size <= 16, "OpSize is too large for VExtractToGPR: {}", IROp->Size);
+  LOGMAN_THROW_AA_FMT(IROp->Size <= 16, "OpSize is too large for VExtractToGPR: {}", IROp->Size);
 
   if (SourceSize == 16) {
     __uint128_t SourceMask = (1ULL << (Op->Header.ElementSize * 8)) - 1;

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -358,7 +358,7 @@ void InterpreterOps::InterpretIR(FEXCore::Core::CpuStateFrame *Frame, FEXCore::I
     using namespace FEXCore::IR;
     auto [BlockNode, BlockHeader] = OpData.BlockIterator();
     auto BlockIROp = BlockHeader->CW<IROp_CodeBlock>();
-    LOGMAN_THROW_A_FMT(BlockIROp->Header.Op == IR::OP_CODEBLOCK, "IR type failed to be a code block");
+    LOGMAN_THROW_AA_FMT(BlockIROp->Header.Op == IR::OP_CODEBLOCK, "IR type failed to be a code block");
 
     // Reset the block results per block
     memset(&OpData.BlockResults, 0, sizeof(OpData.BlockResults));

--- a/External/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
@@ -43,7 +43,7 @@ DEF_OP(SplatVector) {
   auto Op = IROp->C<IR::IROp_SplatVector2>();
   uint8_t OpSize = IROp->Size;
 
-  LOGMAN_THROW_A_FMT(OpSize <= 16, "Can't handle a vector of size: {}", OpSize);
+  LOGMAN_THROW_AA_FMT(OpSize <= 16, "Can't handle a vector of size: {}", OpSize);
   void *Src = GetSrc<void*>(Data->SSAData, Op->Scalar);
   uint8_t Tmp[16];
   uint8_t Elements = 0;
@@ -1376,7 +1376,7 @@ DEF_OP(VExtractElement) {
   auto Op = IROp->C<IR::IROp_VExtractElement>();
 
   const uint32_t SourceSize = GetOpSize(Data->CurrentIR, Op->Vector);
-  LOGMAN_THROW_A_FMT(IROp->Size <= 16, "OpSize is too large for VExtractElement: {}", IROp->Size);
+  LOGMAN_THROW_AA_FMT(IROp->Size <= 16, "OpSize is too large for VExtractElement: {}", IROp->Size);
   if (SourceSize == 16) {
     __uint128_t SourceMask = (1ULL << (Op->Header.ElementSize * 8)) - 1;
     uint64_t Shift = Op->Header.ElementSize * Op->Index * 8;
@@ -1406,7 +1406,7 @@ DEF_OP(VDupElement) {
   const uint8_t OpSize = IROp->Size;
   const uint8_t Elements = OpSize / Op->Header.ElementSize;
 
-  LOGMAN_THROW_A_FMT(OpSize <= 16, "OpSize is too large for VDupElement: {}", OpSize);
+  LOGMAN_THROW_AA_FMT(OpSize <= 16, "OpSize is too large for VDupElement: {}", OpSize);
   if (OpSize == 16) {
     __uint128_t SourceMask = (1ULL << (Op->Header.ElementSize * 8)) - 1;
     uint64_t Shift = Op->Header.ElementSize * Op->Index * 8;

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -1084,8 +1084,8 @@ DEF_OP(Bfi) {
 
 DEF_OP(Bfe) {
   auto Op = IROp->C<IR::IROp_Bfe>();
-  LOGMAN_THROW_A_FMT(IROp->Size <= 8, "OpSize is too large for BFE: {}", IROp->Size);
-  LOGMAN_THROW_A_FMT(Op->Width != 0, "Invalid BFE width of 0");
+  LOGMAN_THROW_AA_FMT(IROp->Size <= 8, "OpSize is too large for BFE: {}", IROp->Size);
+  LOGMAN_THROW_AA_FMT(Op->Width != 0, "Invalid BFE width of 0");
 
   auto Dst = GetReg<RA_64>(Node);
   ubfx(Dst, GetReg<RA_64>(Op->Src.ID()), Op->lsb, Op->Width);
@@ -1249,7 +1249,7 @@ DEF_OP(FCmp) {
   bool set = false;
 
   if (Op->Flags & (1 << IR::FCMP_FLAG_EQ)) {
-    LOGMAN_THROW_A_FMT(IR::FCMP_FLAG_EQ == 0, "IR::FCMP_FLAG_EQ must equal 0");
+    LOGMAN_THROW_AA_FMT(IR::FCMP_FLAG_EQ == 0, "IR::FCMP_FLAG_EQ must equal 0");
     // EQ or unordered
     cset(Dst, Condition::eq); // Z = 1
     csinc(Dst, Dst, xzr, Condition::vc); // IF !V ? Z : 1

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/Arm64Relocations.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/Arm64Relocations.cpp
@@ -81,7 +81,7 @@ bool Arm64JITCore::ApplyRelocations(uint64_t GuestEntry, uint64_t CodeEntry, uin
   size_t DataIndex{};
   for (size_t j = 0; j < NumRelocations; ++j) {
     const FEXCore::CPU::Relocation *Reloc = reinterpret_cast<const FEXCore::CPU::Relocation *>(&EntryRelocations[DataIndex]);
-    LOGMAN_THROW_A_FMT((DataIndex % alignof(Relocation)) == 0, "Alignment of relocation wasn't adhered to");
+    LOGMAN_THROW_AA_FMT((DataIndex % alignof(Relocation)) == 0, "Alignment of relocation wasn't adhered to");
 
     switch (Reloc->Header.Type) {
       case FEXCore::CPU::RelocationTypes::RELOC_NAMED_SYMBOL_LITERAL: {

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -549,12 +549,12 @@ template<>
 aarch64::Register Arm64JITCore::GetReg<Arm64JITCore::RA_32>(IR::NodeID Node) const {
   auto Reg = GetPhys(Node);
 
+  LOGMAN_THROW_AA_FMT(Reg.Class == IR::GPRFixedClass.Val || Reg.Class == IR::GPRClass.Val, "Unexpected Class: {}", Reg.Class);
+
   if (Reg.Class == IR::GPRFixedClass.Val) {
     return SRA64[Reg.Reg].W();
   } else if (Reg.Class == IR::GPRClass.Val) {
     return RA64[Reg.Reg].W();
-  } else {
-    LOGMAN_THROW_A_FMT(false, "Unexpected Class: {}", Reg.Class);
   }
 
   FEX_UNREACHABLE;
@@ -564,12 +564,12 @@ template<>
 aarch64::Register Arm64JITCore::GetReg<Arm64JITCore::RA_64>(IR::NodeID Node) const {
   auto Reg = GetPhys(Node);
 
+  LOGMAN_THROW_AA_FMT(Reg.Class == IR::GPRFixedClass.Val || Reg.Class == IR::GPRClass.Val, "Unexpected Class: {}", Reg.Class);
+
   if (Reg.Class == IR::GPRFixedClass.Val) {
     return SRA64[Reg.Reg];
   } else if (Reg.Class == IR::GPRClass.Val) {
     return RA64[Reg.Reg];
-  } else {
-    LOGMAN_THROW_A_FMT(false, "Unexpected Class: {}", Reg.Class);
   }
 
   FEX_UNREACHABLE;
@@ -590,12 +590,12 @@ std::pair<aarch64::Register, aarch64::Register> Arm64JITCore::GetSrcPair<Arm64JI
 aarch64::VRegister Arm64JITCore::GetSrc(IR::NodeID Node) const {
   auto Reg = GetPhys(Node);
 
+  LOGMAN_THROW_AA_FMT(Reg.Class == IR::FPRFixedClass.Val || Reg.Class == IR::FPRClass.Val, "Unexpected Class: {}", Reg.Class);
+
   if (Reg.Class == IR::FPRFixedClass.Val) {
     return SRAFPR[Reg.Reg];
   } else if (Reg.Class == IR::FPRClass.Val) {
     return RAFPR[Reg.Reg];
-  } else {
-    LOGMAN_THROW_A_FMT(false, "Unexpected Class: {}", Reg.Class);
   }
 
   FEX_UNREACHABLE;
@@ -604,12 +604,12 @@ aarch64::VRegister Arm64JITCore::GetSrc(IR::NodeID Node) const {
 aarch64::VRegister Arm64JITCore::GetDst(IR::NodeID Node) const {
   auto Reg = GetPhys(Node);
 
+  LOGMAN_THROW_AA_FMT(Reg.Class == IR::FPRFixedClass.Val || Reg.Class == IR::FPRClass.Val, "Unexpected Class: {}", Reg.Class);
+
   if (Reg.Class == IR::FPRFixedClass.Val) {
     return SRAFPR[Reg.Reg];
   } else if (Reg.Class == IR::FPRClass.Val) {
     return RAFPR[Reg.Reg];
-  } else {
-    LOGMAN_THROW_A_FMT(false, "Unexpected Class: {}", Reg.Class);
   }
 
   FEX_UNREACHABLE;
@@ -732,7 +732,7 @@ void *Arm64JITCore::CompileCode(uint64_t Entry, [[maybe_unused]] FEXCore::IR::IR
     using namespace FEXCore::IR;
 #if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
     auto BlockIROp = BlockHeader->CW<FEXCore::IR::IROp_CodeBlock>();
-    LOGMAN_THROW_A_FMT(BlockIROp->Header.Op == IR::OP_CODEBLOCK, "IR type failed to be a code block");
+    LOGMAN_THROW_AA_FMT(BlockIROp->Header.Op == IR::OP_CODEBLOCK, "IR type failed to be a code block");
 #endif
 
     auto BlockStartHostCode = GetCursorAddress<uint8_t *>();

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -115,23 +115,23 @@ DEF_OP(LoadRegister) {
 
     switch(Op->Header.Size) {
       case 1:
-        LOGMAN_THROW_A_FMT(regOffs == 0 || regOffs == 1, "unexpected regOffs");
+        LOGMAN_THROW_AA_FMT(regOffs == 0 || regOffs == 1, "unexpected regOffs");
         ubfx(GetReg<RA_64>(Node), reg, regOffs * 8, 8);
         break;
 
       case 2:
-        LOGMAN_THROW_A_FMT(regOffs == 0, "unexpected regOffs");
+        LOGMAN_THROW_AA_FMT(regOffs == 0, "unexpected regOffs");
         ubfx(GetReg<RA_64>(Node), reg, 0, 16);
         break;
 
       case 4:
-        LOGMAN_THROW_A_FMT(regOffs == 0, "unexpected regOffs");
+        LOGMAN_THROW_AA_FMT(regOffs == 0, "unexpected regOffs");
         if (GetReg<RA_64>(Node).GetCode() != reg.GetCode())
           mov(GetReg<RA_32>(Node), reg.W());
         break;
 
       case 8:
-        LOGMAN_THROW_A_FMT(regOffs == 0, "unexpected regOffs");
+        LOGMAN_THROW_AA_FMT(regOffs == 0, "unexpected regOffs");
         if (GetReg<RA_64>(Node).GetCode() != reg.GetCode())
           mov(GetReg<RA_64>(Node), reg);
         break;
@@ -147,17 +147,17 @@ DEF_OP(LoadRegister) {
 
     switch(Op->Header.Size) {
       case 1:
-        LOGMAN_THROW_A_FMT(regOffs == 0, "unexpected regOffs");
+        LOGMAN_THROW_AA_FMT(regOffs == 0, "unexpected regOffs");
         mov(host.B(), guest.B());
         break;
 
       case 2:
-        LOGMAN_THROW_A_FMT(regOffs == 0, "unexpected regOffs");
+        LOGMAN_THROW_AA_FMT(regOffs == 0, "unexpected regOffs");
         fmov(host.H(), guest.H());
         break;
 
       case 4:
-        LOGMAN_THROW_A_FMT((regOffs & 3) == 0, "unexpected regOffs");
+        LOGMAN_THROW_AA_FMT((regOffs & 3) == 0, "unexpected regOffs");
         if (regOffs == 0) {
           if (host.GetCode() != guest.GetCode())
             fmov(host.S(), guest.S());
@@ -167,7 +167,7 @@ DEF_OP(LoadRegister) {
         break;
 
       case 8:
-        LOGMAN_THROW_A_FMT((regOffs & 7) == 0, "unexpected regOffs");
+        LOGMAN_THROW_AA_FMT((regOffs & 7) == 0, "unexpected regOffs");
         if (regOffs == 0) {
           if (host.GetCode() != guest.GetCode())
             mov(host.D(), guest.D());
@@ -177,13 +177,13 @@ DEF_OP(LoadRegister) {
         break;
 
       case 16:
-        LOGMAN_THROW_A_FMT(regOffs == 0, "unexpected regOffs");
+        LOGMAN_THROW_AA_FMT(regOffs == 0, "unexpected regOffs");
         if (host.GetCode() != guest.GetCode())
           mov(host.Q(), guest.Q());
         break;
     }
   } else {
-    LOGMAN_THROW_A_FMT(false, "Unhandled Op->Class {}", Op->Class);
+    LOGMAN_THROW_AA_FMT(false, "Unhandled Op->Class {}", Op->Class);
   }
 }
 
@@ -200,22 +200,22 @@ DEF_OP(StoreRegister) {
 
     switch(Op->Header.Size) {
       case 1:
-        LOGMAN_THROW_A_FMT(regOffs == 0 || regOffs == 1, "unexpected regOffs");
+        LOGMAN_THROW_AA_FMT(regOffs == 0 || regOffs == 1, "unexpected regOffs");
         bfi(reg, GetReg<RA_64>(Op->Value.ID()), regOffs * 8, 8);
         break;
 
       case 2:
-        LOGMAN_THROW_A_FMT(regOffs == 0, "unexpected regOffs");
+        LOGMAN_THROW_AA_FMT(regOffs == 0, "unexpected regOffs");
         bfi(reg, GetReg<RA_64>(Op->Value.ID()), 0, 16);
         break;
 
       case 4:
-        LOGMAN_THROW_A_FMT(regOffs == 0, "unexpected regOffs");
+        LOGMAN_THROW_AA_FMT(regOffs == 0, "unexpected regOffs");
         bfi(reg, GetReg<RA_64>(Op->Value.ID()), 0, 32);
         break;
 
       case 8:
-        LOGMAN_THROW_A_FMT(regOffs == 0, "unexpected regOffs");
+        LOGMAN_THROW_AA_FMT(regOffs == 0, "unexpected regOffs");
         if (GetReg<RA_64>(Op->Value.ID()).GetCode() != reg.GetCode())
           mov(reg, GetReg<RA_64>(Op->Value.ID()));
         break;
@@ -235,28 +235,28 @@ DEF_OP(StoreRegister) {
         break;
 
       case 2:
-        LOGMAN_THROW_A_FMT((regOffs & 1) == 0, "unexpected regOffs");
+        LOGMAN_THROW_AA_FMT((regOffs & 1) == 0, "unexpected regOffs");
         ins(guest.V8H(), regOffs/2, host.V8H(), 0);
         break;
 
       case 4:
-        LOGMAN_THROW_A_FMT((regOffs & 3) == 0, "unexpected regOffs");
+        LOGMAN_THROW_AA_FMT((regOffs & 3) == 0, "unexpected regOffs");
         ins(guest.V4S(), regOffs/4, host.V4S(), 0);
         break;
 
       case 8:
-        LOGMAN_THROW_A_FMT((regOffs & 7) == 0, "unexpected regOffs");
+        LOGMAN_THROW_AA_FMT((regOffs & 7) == 0, "unexpected regOffs");
         ins(guest.V2D(), regOffs / 8, host.V2D(), 0);
         break;
 
       case 16:
-        LOGMAN_THROW_A_FMT(regOffs == 0, "unexpected regOffs");
+        LOGMAN_THROW_AA_FMT(regOffs == 0, "unexpected regOffs");
         if (guest.GetCode() != host.GetCode())
           mov(guest.Q(), host.Q());
         break;
     }
   } else {
-    LOGMAN_THROW_A_FMT(false, "Unhandled Op->Class {}", Op->Class);
+    LOGMAN_THROW_AA_FMT(false, "Unhandled Op->Class {}", Op->Class);
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -45,7 +45,7 @@ DEF_OP(VectorImm) {
 DEF_OP(SplatVector2) {
   auto Op = IROp->C<IR::IROp_SplatVector2>();
   const uint8_t OpSize = IROp->Size;
-  LOGMAN_THROW_A_FMT(OpSize <= 16, "Can't handle a vector of size: {}", OpSize);
+  LOGMAN_THROW_AA_FMT(OpSize <= 16, "Can't handle a vector of size: {}", OpSize);
 
   const uint8_t ElementSize = OpSize / 2;
 
@@ -63,7 +63,7 @@ DEF_OP(SplatVector2) {
 DEF_OP(SplatVector4) {
   auto Op = IROp->C<IR::IROp_SplatVector4>();
   const uint8_t OpSize = IROp->Size;
-  LOGMAN_THROW_A_FMT(OpSize <= 16, "Can't handle a vector of size: {}", OpSize);
+  LOGMAN_THROW_AA_FMT(OpSize <= 16, "Can't handle a vector of size: {}", OpSize);
 
   const uint8_t ElementSize = OpSize / 4;
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/ALUOps.cpp
@@ -1034,7 +1034,7 @@ DEF_OP(Bfi) {
 
 DEF_OP(Bfe) {
   auto Op = IROp->C<IR::IROp_Bfe>();
-  LOGMAN_THROW_A_FMT(IROp->Size <= 8, "OpSize is too large for BFE: {}", IROp->Size);
+  LOGMAN_THROW_AA_FMT(IROp->Size <= 8, "OpSize is too large for BFE: {}", IROp->Size);
 
   auto Dst = GetDst<RA_64>(Node);
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -407,7 +407,7 @@ void X86JITCore::ClearCache() {
 IR::PhysicalRegister X86JITCore::GetPhys(IR::NodeID Node) const {
   auto PhyReg = RAData->GetNodeRegister(Node);
 
-  LOGMAN_THROW_A_FMT(PhyReg.Raw != 255, "Couldn't Allocate register for node: ssa{}. Class: {}", Node, PhyReg.Class);
+  LOGMAN_THROW_AA_FMT(PhyReg.Raw != 255, "Couldn't Allocate register for node: ssa{}. Class: {}", Node, PhyReg.Class);
 
   return PhyReg;
 }
@@ -592,7 +592,7 @@ void *X86JITCore::CompileCode(uint64_t Entry, [[maybe_unused]] FEXCore::IR::IRLi
     setSize(getSize() + GDBSize);
   }
 
-  LOGMAN_THROW_A_FMT(RAData != nullptr, "Needs RA");
+  LOGMAN_THROW_AA_FMT(RAData != nullptr, "Needs RA");
 
   SpillSlots = RAData->SpillSlots();
 
@@ -649,7 +649,7 @@ void *X86JITCore::CompileCode(uint64_t Entry, [[maybe_unused]] FEXCore::IR::IRLi
     using namespace FEXCore::IR;
 #if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
     auto BlockIROp = BlockHeader->CW<IROp_CodeBlock>();
-    LOGMAN_THROW_A_FMT(BlockIROp->Header.Op == IR::OP_CODEBLOCK, "IR type failed to be a code block");
+    LOGMAN_THROW_AA_FMT(BlockIROp->Header.Op == IR::OP_CODEBLOCK, "IR type failed to be a code block");
 #endif
 
     auto BlockStartHostCode = getCurr<uint8_t *>();

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
@@ -71,7 +71,7 @@ DEF_OP(SplatVector) {
   auto Op = IROp->C<IR::IROp_SplatVector2>();
   const uint8_t OpSize = IROp->Size;
 
-  LOGMAN_THROW_A_FMT(OpSize <= 16, "Can't handle a vector of size: {}", OpSize);
+  LOGMAN_THROW_AA_FMT(OpSize <= 16, "Can't handle a vector of size: {}", OpSize);
   uint8_t Elements = 0;
 
   switch (Op->Header.Op) {

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/x64Relocations.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/x64Relocations.cpp
@@ -91,7 +91,7 @@ bool X86JITCore::ApplyRelocations(uint64_t GuestEntry, uint64_t CodeEntry, uint6
   size_t DataIndex{};
   for (size_t j = 0; j < NumRelocations; ++j) {
     const FEXCore::CPU::Relocation *Reloc = reinterpret_cast<const FEXCore::CPU::Relocation *>(&EntryRelocations[DataIndex]);
-    LOGMAN_THROW_A_FMT((DataIndex % alignof(Relocation)) == 0, "Alignment of relocation wasn't adhered to");
+    LOGMAN_THROW_AA_FMT((DataIndex % alignof(Relocation)) == 0, "Alignment of relocation wasn't adhered to");
 
     switch (Reloc->Header.Type) {
       case FEXCore::CPU::RelocationTypes::RELOC_NAMED_SYMBOL_LITERAL: {

--- a/External/FEXCore/Source/Interface/Core/LookupCache.cpp
+++ b/External/FEXCore/Source/Interface/Core/LookupCache.cpp
@@ -37,11 +37,11 @@ LookupCache::LookupCache(FEXCore::Context::Context *CTX)
   // We currently limit to 128MB of real memory for caching for the total cache size.
   // Can end up being inefficient if we compile a small number of blocks per page
   PageMemory = reinterpret_cast<uintptr_t>(FEXCore::Allocator::mmap(nullptr, CODE_SIZE, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
-  LOGMAN_THROW_A_FMT(PageMemory != -1ULL, "Failed to allocate page memory");
+  LOGMAN_THROW_AA_FMT(PageMemory != -1ULL, "Failed to allocate page memory");
 
   // L1 Cache
   L1Pointer = reinterpret_cast<uintptr_t>(FEXCore::Allocator::mmap(nullptr, L1_SIZE, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
-  LOGMAN_THROW_A_FMT(L1Pointer != -1ULL, "Failed to allocate L1Pointer");
+  LOGMAN_THROW_AA_FMT(L1Pointer != -1ULL, "Failed to allocate L1Pointer");
 
   VirtualMemSize = ctx->Config.VirtualMemSize;
 }

--- a/External/FEXCore/Source/Interface/Core/LookupCache.h
+++ b/External/FEXCore/Source/Interface/Core/LookupCache.h
@@ -90,7 +90,7 @@ public:
     std::lock_guard<std::recursive_mutex> lk(WriteLock);
     
     [[maybe_unused]] auto Inserted = BlockList.emplace(Address, (uintptr_t)HostCode).second;
-    LOGMAN_THROW_A_FMT(Inserted, "Duplicate block mapping added");
+    LOGMAN_THROW_AA_FMT(Inserted, "Duplicate block mapping added");
 
     // There is no need to update L1 or L2, they will get updated on first lookup
     // However, adding to L1 here increases performance

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -4503,7 +4503,7 @@ void OpDispatchBuilder::Finalize() {
 
   [[maybe_unused]] const FEXCore::IR::IROp_Header *IROp =
   RealNode->Op(DualListData.DataBegin());
-  LOGMAN_THROW_A_FMT(IROp->Op == OP_IRHEADER, "First op in function must be our header");
+  LOGMAN_THROW_AA_FMT(IROp->Op == OP_IRHEADER, "First op in function must be our header");
 
   // Let's walk the jump blocks and see if we have handled every block target
   for (auto &Handler : JumpTargets) {
@@ -4529,7 +4529,7 @@ uint8_t OpDispatchBuilder::GetDstSize(X86Tables::DecodedOp Op) const {
 
   const uint32_t DstSizeFlag = X86Tables::DecodeFlags::GetSizeDstFlags(Op->Flags);
   const uint8_t Size = Sizes[DstSizeFlag];
-  LOGMAN_THROW_A_FMT(Size != 0, "Invalid destination size for op");
+  LOGMAN_THROW_AA_FMT(Size != 0, "Invalid destination size for op");
   return Size;
 }
 
@@ -4547,7 +4547,7 @@ uint8_t OpDispatchBuilder::GetSrcSize(X86Tables::DecodedOp Op) const {
 
   const uint32_t SrcSizeFlag = X86Tables::DecodeFlags::GetSizeSrcFlags(Op->Flags);
   const uint8_t Size = Sizes[SrcSizeFlag];
-  LOGMAN_THROW_A_FMT(Size != 0, "Invalid destination size for op");
+  LOGMAN_THROW_AA_FMT(Size != 0, "Invalid destination size for op");
   return Size;
 }
 
@@ -4791,11 +4791,11 @@ void OpDispatchBuilder::StoreResult_WithOpSize(FEXCore::IR::RegisterClassType Cl
         // For all other sizes, the upper bits are guaranteed to already be zero
          OrderedNode *Value = GetOpSize(Src) == 8 ? _Bfe(4, 32, 0, Src) : Src;
 
-        LOGMAN_THROW_A_FMT(!Operand.Data.GPR.HighBits, "Can't handle 32bit store to high 8bit register");
+        LOGMAN_THROW_AA_FMT(!Operand.Data.GPR.HighBits, "Can't handle 32bit store to high 8bit register");
         _StoreContext(GPRSize, Class, Value, offsetof(FEXCore::Core::CPUState, gregs[gpr]));
       }
       else {
-        LOGMAN_THROW_A_FMT(!(GPRSize == 4 && OpSize > 4), "Oops had a {} GPR load", OpSize);
+        LOGMAN_THROW_AA_FMT(!(GPRSize == 4 && OpSize > 4), "Oops had a {} GPR load", OpSize);
         _StoreContext(std::min(GPRSize, OpSize), Class, Src, offsetof(FEXCore::Core::CPUState, gregs[gpr]) + (Operand.Data.GPR.HighBits ? 1 : 0));
       }
     }

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -665,7 +665,7 @@ private:
   void StoreResult(FEXCore::IR::RegisterClassType Class, FEXCore::X86Tables::DecodedOp Op, OrderedNode *const Src, int8_t Align, MemoryAccessType AccessType = MemoryAccessType::ACCESS_DEFAULT);
 
   [[nodiscard]] static uint32_t GPROffset(X86State::X86Reg reg) {
-    LOGMAN_THROW_A_FMT(reg <= X86State::X86Reg::REG_R15, "Invalid reg used");
+    LOGMAN_THROW_AA_FMT(reg <= X86State::X86Reg::REG_R15, "Invalid reg used");
     return static_cast<uint32_t>(offsetof(Core::CPUState, gregs[static_cast<size_t>(reg)]));
   }
 

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -562,7 +562,7 @@ void OpDispatchBuilder::PSHUFBOp(OpcodeArgs) {
 
 template<size_t ElementSize, bool HalfSize, bool Low>
 void OpDispatchBuilder::PSHUFDOp(OpcodeArgs) {
-  LOGMAN_THROW_A_FMT(ElementSize != 0, "What. No element size?");
+  LOGMAN_THROW_AA_FMT(ElementSize != 0, "What. No element size?");
   const auto Size = GetSrcSize(Op);
   OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
   uint8_t Shuffle = Op->Src[1].Data.Literal.Value;
@@ -599,7 +599,7 @@ void OpDispatchBuilder::PSHUFDOp<4, false, true>(OpcodeArgs);
 
 template<size_t ElementSize>
 void OpDispatchBuilder::SHUFOp(OpcodeArgs) {
-  LOGMAN_THROW_A_FMT(ElementSize != 0, "What. No element size?");
+  LOGMAN_THROW_AA_FMT(ElementSize != 0, "What. No element size?");
   const auto Size = GetSrcSize(Op);
   OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
   OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);

--- a/External/FEXCore/Source/Interface/Core/X86Tables/X86Tables.h
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/X86Tables.h
@@ -33,7 +33,7 @@ static inline void GenerateTable(X86InstInfo *FinalTable, X86TablesInfoStruct<Op
     auto OpNum = Op.first;
     X86InstInfo const &Info = Op.Info;
     for (uint32_t i = 0; i < Op.second; ++i) {
-      LOGMAN_THROW_A_FMT(FinalTable[OpNum + i].Type == TYPE_UNKNOWN, "Duplicate Entry {}->{}", FinalTable[OpNum + i].Name, Info.Name);
+      LOGMAN_THROW_AA_FMT(FinalTable[OpNum + i].Type == TYPE_UNKNOWN, "Duplicate Entry {}->{}", FinalTable[OpNum + i].Name, Info.Name);
       FinalTable[OpNum + i] = Info;
 #ifndef NDEBUG
       ++Total;
@@ -51,7 +51,7 @@ static inline void GenerateTableWithCopy(X86InstInfo *FinalTable, X86TablesInfoS
     auto OpNum = Op.first;
     X86InstInfo const &Info = Op.Info;
     for (uint32_t i = 0; i < Op.second; ++i) {
-      LOGMAN_THROW_A_FMT(FinalTable[OpNum + i].Type == TYPE_UNKNOWN, "Duplicate Entry {}->{}", FinalTable[OpNum + i].Name, Info.Name);
+      LOGMAN_THROW_AA_FMT(FinalTable[OpNum + i].Type == TYPE_UNKNOWN, "Duplicate Entry {}->{}", FinalTable[OpNum + i].Name, Info.Name);
       if (Info.Type == TYPE_COPY_OTHER) {
         FinalTable[OpNum + i] = OtherLocal[OpNum + i];
       }
@@ -74,7 +74,7 @@ static inline void GenerateX87Table(X86InstInfo *FinalTable, X86TablesInfoStruct
     auto OpNum = Op.first;
     X86InstInfo const &Info = Op.Info;
     for (uint32_t i = 0; i < Op.second; ++i) {
-      LOGMAN_THROW_A_FMT(FinalTable[OpNum + i].Type == TYPE_UNKNOWN, "Duplicate Entry {}->{}", FinalTable[OpNum + i].Name, Info.Name);
+      LOGMAN_THROW_AA_FMT(FinalTable[OpNum + i].Type == TYPE_UNKNOWN, "Duplicate Entry {}->{}", FinalTable[OpNum + i].Name, Info.Name);
       if ((OpNum & 0b11'000'000) == 0b11'000'000) {
         // If the mod field is 0b11 then it is a regular op
         FinalTable[OpNum + i] = Info;
@@ -82,7 +82,7 @@ static inline void GenerateX87Table(X86InstInfo *FinalTable, X86TablesInfoStruct
       else {
         // If the mod field is !0b11 then this instruction is duplicated through the whole mod [0b00, 0b10] range
         // and the modrm.rm space because that is used part of the instruction encoding
-        LOGMAN_THROW_A_FMT((OpNum & 0b11'000'000) == 0, "Only support mod field of zero in this path");
+        LOGMAN_THROW_AA_FMT((OpNum & 0b11'000'000) == 0, "Only support mod field of zero in this path");
         for (uint16_t mod = 0b00'000'000; mod < 0b11'000'000; mod += 0b01'000'000) {
           for (uint16_t rm = 0b000; rm < 0b1'000; ++rm) {
             FinalTable[(OpNum | mod | rm) + i] = Info;

--- a/External/FEXCore/Source/Interface/HLE/Thunks/Thunks.cpp
+++ b/External/FEXCore/Source/Interface/HLE/Thunks/Thunks.cpp
@@ -157,11 +157,11 @@ namespace FEXCore {
             auto args = reinterpret_cast<args_t*>(argsv);
             auto CTX = Thread->CTX;
 
-            LOGMAN_THROW_A_FMT(args->original_callee, "Tried to link null pointer address to guest function");
-            LOGMAN_THROW_A_FMT(args->target_addr, "Tried to link address to null pointer guest function");
+            LOGMAN_THROW_AA_FMT(args->original_callee, "Tried to link null pointer address to guest function");
+            LOGMAN_THROW_AA_FMT(args->target_addr, "Tried to link address to null pointer guest function");
             if (!CTX->Config.Is64BitMode) {
-                LOGMAN_THROW_A_FMT((args->original_callee >> 32) == 0, "Tried to link 64-bit address in 32-bit mode");
-                LOGMAN_THROW_A_FMT((args->target_addr >> 32) == 0, "Tried to link 64-bit address in 32-bit mode");
+                LOGMAN_THROW_AA_FMT((args->original_callee >> 32) == 0, "Tried to link 64-bit address in 32-bit mode");
+                LOGMAN_THROW_AA_FMT((args->target_addr >> 32) == 0, "Tried to link 64-bit address in 32-bit mode");
             }
 
             LogMan::Msg::DFmt("Thunks: Adding guest trampoline from address {:#x} to guest function {:#x}",
@@ -217,7 +217,7 @@ namespace FEXCore {
               uintptr_t rv; // Pointer to host trampoline + TrampolineInstanceInfo
           } *args = reinterpret_cast<ArgsRV_t*>(ArgsRV);
 
-          LOGMAN_THROW_A_FMT(args->GuestTarget, "Tried to create host-trampoline to null pointer guest function");
+          LOGMAN_THROW_AA_FMT(args->GuestTarget, "Tried to create host-trampoline to null pointer guest function");
 
           const auto CTX = Thread->CTX;
           const auto ThunkHandler = reinterpret_cast<ThunkHandler_impl *>(CTX->ThunkHandler.get());
@@ -266,7 +266,7 @@ namespace FEXCore {
                 PROT_READ | PROT_WRITE | PROT_EXEC,
                 MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
 
-            LOGMAN_THROW_A_FMT(ThunkHandler->HostTrampolineInstanceDataPtr != MAP_FAILED, "Failed to mmap HostTrampolineInstanceDataPtr");
+            LOGMAN_THROW_AA_FMT(ThunkHandler->HostTrampolineInstanceDataPtr != MAP_FAILED, "Failed to mmap HostTrampolineInstanceDataPtr");
           }
 
           const TrampolineInstanceInfo NewTrampolineInfo {

--- a/External/FEXCore/Source/Interface/IR/AOTIR.cpp
+++ b/External/FEXCore/Source/Interface/IR/AOTIR.cpp
@@ -127,7 +127,7 @@ namespace FEXCore::IR {
 
     auto Array = (AOTIRInlineIndex *)((char*)FilePtr + IndexOffset);
 
-    LOGMAN_THROW_A_FMT(Entry->Array == nullptr && Entry->FilePtr == nullptr, "Entry must not be initialized here");
+    LOGMAN_THROW_AA_FMT(Entry->Array == nullptr && Entry->FilePtr == nullptr, "Entry must not be initialized here");
     Entry->Array = Array;
     Entry->FilePtr = FilePtr;
     Entry->Size = Size;
@@ -387,7 +387,7 @@ namespace FEXCore::IR {
       auto Inserted = AOTIRCache.insert({fileid, AOTIRCacheEntry { .FileId = fileid, .Filename = filename }});
       auto Entry = &(Inserted.first->second);
 
-      LOGMAN_THROW_A_FMT(Entry->Array == nullptr, "Duplicate LoadAOTIRCacheEntry");
+      LOGMAN_THROW_AA_FMT(Entry->Array == nullptr, "Duplicate LoadAOTIRCacheEntry");
 
       if (CTX->Config.AOTIRLoad && AOTIRLoader) {
         auto streamfd = AOTIRLoader(fileid);
@@ -403,7 +403,7 @@ namespace FEXCore::IR {
   }
 
   void AOTIRCaptureCache::UnloadAOTIRCacheEntry(AOTIRCacheEntry *Entry) {
-    LOGMAN_THROW_A_FMT(Entry != nullptr, "Removing not existing entry");
+    LOGMAN_THROW_AA_FMT(Entry != nullptr, "Removing not existing entry");
 
     if (Entry->Array) {
       FEXCore::Allocator::munmap(Entry->FilePtr, Entry->Size);

--- a/External/FEXCore/Source/Interface/IR/IREmitter.cpp
+++ b/External/FEXCore/Source/Interface/IR/IREmitter.cpp
@@ -167,7 +167,7 @@ IREmitter::IRPair<IROp_CodeBlock> IREmitter::CreateNewCodeBlockAfter(OrderedNode
   if (insertAfter) {
     LinkCodeBlocks(insertAfter, CodeNode);
   } else {
-    LOGMAN_THROW_A_FMT(CurrentCodeBlock != nullptr, "CurrentCodeBlock must not be null here");
+    LOGMAN_THROW_AA_FMT(CurrentCodeBlock != nullptr, "CurrentCodeBlock must not be null here");
 
     // Find last block
     auto LastBlock = CurrentCodeBlock;

--- a/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -299,7 +299,7 @@ void ConstProp::FCMPOptimization(IREmitter *IREmit, const IRListView& CurrentIR)
       auto ghf = IROp->CW<IR::IROp_GetHostFlag>();
 
       auto fcmp = IREmit->GetOpHeader(ghf->Value)->CW<IR::IROp_FCmp>();
-      LOGMAN_THROW_A_FMT(fcmp->Header.Op == OP_FCMP || fcmp->Header.Op == OP_F80CMP, "Unexpected OP_GETHOSTFLAG source");
+      LOGMAN_THROW_AA_FMT(fcmp->Header.Op == OP_FCMP || fcmp->Header.Op == OP_F80CMP, "Unexpected OP_GETHOSTFLAG source");
       if(fcmp->Header.Op == OP_FCMP) {
         fcmp->Flags |= 1 << ghf->Flag;
       }

--- a/External/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
@@ -246,7 +246,7 @@ namespace {
       ClassifiedStructSize += it.Class.Size;
     }
 
-    LOGMAN_THROW_A_FMT(ClassifiedStructSize == sizeof(FEXCore::Core::CPUState),
+    LOGMAN_THROW_AA_FMT(ClassifiedStructSize == sizeof(FEXCore::Core::CPUState),
       "Classified CPUStruct size doesn't match real CPUState struct size! {} (classified) != {} (real)",
       ClassifiedStructSize, sizeof(FEXCore::Core::CPUState));
 
@@ -331,8 +331,8 @@ ContextMemberInfo *RCLSE::FindMemberInfo(ContextInfo *ContextClassificationInfo,
 }
 
 ContextMemberInfo *RCLSE::RecordAccess(ContextMemberInfo *Info, FEXCore::IR::RegisterClassType RegClass, uint32_t Offset, uint8_t Size, LastAccessType AccessType, FEXCore::IR::OrderedNode *Node, FEXCore::IR::OrderedNode *StoreNode) {
-  LOGMAN_THROW_A_FMT((Offset + Size) <= (Info->Class.Offset + Info->Class.Size), "Access to context item went over member size");
-  LOGMAN_THROW_A_FMT(Info->Accessed != ACCESS_INVALID, "Tried to access invalid member");
+  LOGMAN_THROW_AA_FMT((Offset + Size) <= (Info->Class.Offset + Info->Class.Size), "Access to context item went over member size");
+  LOGMAN_THROW_AA_FMT(Info->Accessed != ACCESS_INVALID, "Tried to access invalid member");
 
   // If we aren't fully overwriting the member then it is a partial write that we need to track
   if (Size < Info->Class.Size) {

--- a/External/FEXCore/Source/Interface/IR/Passes/IRCompaction.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/IRCompaction.cpp
@@ -77,7 +77,7 @@ bool IRCompaction::Run(IREmitter *IREmit) {
 
   auto HeaderNode = CurrentIR.GetHeaderNode();
   auto HeaderOp = CurrentIR.GetHeader();
-  LOGMAN_THROW_A_FMT(HeaderOp->Header.Op == OP_IRHEADER, "First op wasn't IRHeader");
+  LOGMAN_THROW_AA_FMT(HeaderOp->Header.Op == OP_IRHEADER, "First op wasn't IRHeader");
 
   // This compaction pass is something that we need to ensure correct ordering and distances between IROps
   // Later on we assume that an IROp's SSA value live range is its Node locations
@@ -101,7 +101,7 @@ bool IRCompaction::Run(IREmitter *IREmit) {
   {
     // Generate our codeblocks and link them together
     for (auto [BlockNode, BlockHeader] : CurrentIR.GetBlocks()) {
-      LOGMAN_THROW_A_FMT(BlockHeader->Op == OP_CODEBLOCK, "IR type failed to be a code block");
+      LOGMAN_THROW_AA_FMT(BlockHeader->Op == OP_CODEBLOCK, "IR type failed to be a code block");
 
       auto LocalBlockIRNode = LocalBuilder._CodeBlock(LocalHeaderOp, LocalHeaderOp); // Use LocalHeaderOp as a dummy arg for now
       OldToNewRemap[CurrentIR.GetID(BlockNode).Value].NodeID = LocalIR.GetID(LocalBlockIRNode.Node);
@@ -165,7 +165,7 @@ bool IRCompaction::Run(IREmitter *IREmit) {
     for (auto &Block : GeneratedCodeBlocks) {
 #if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
       auto BlockIROp = LocalIR.GetOp<FEXCore::IR::IROp_CodeBlock>(Block.NewNode);
-      LOGMAN_THROW_A_FMT(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
+      LOGMAN_THROW_AA_FMT(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
 #endif
 
       for (auto [LocalNode, LocalIROp] : LocalIR.GetCode(Block.NewNode)) {

--- a/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
@@ -63,7 +63,7 @@ bool IRValidation::Run(IREmitter *IREmit) {
 
   for (auto [BlockNode, BlockHeader] : CurrentIR.GetBlocks()) {
     auto BlockIROp = BlockHeader->CW<FEXCore::IR::IROp_CodeBlock>();
-    LOGMAN_THROW_A_FMT(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
+    LOGMAN_THROW_AA_FMT(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
 
     if (!EntryBlock) {
       EntryBlock = BlockNode;

--- a/External/FEXCore/Source/Interface/IR/Passes/RAValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/RAValidation.cpp
@@ -197,11 +197,11 @@ bool RAValidation::Run(IREmitter *IREmit) {
 
   // Get the control flow graph from the validation pass
   auto ValidationPass = Manager->GetPass<IRValidation>("IRValidation");
-  LOGMAN_THROW_A_FMT(ValidationPass != nullptr, "Couldn't find IRValidation pass");
+  LOGMAN_THROW_AA_FMT(ValidationPass != nullptr, "Couldn't find IRValidation pass");
 
   auto& OffsetToBlockMap = ValidationPass->OffsetToBlockMap;
 
-  LOGMAN_THROW_A_FMT(ValidationPass->EntryBlock != nullptr, "No entry point");
+  LOGMAN_THROW_AA_FMT(ValidationPass->EntryBlock != nullptr, "No entry point");
   BlocksToVisit.push_front(ValidationPass->EntryBlock); // Currently only a single entry point
 
   bool HadError = false;

--- a/External/FEXCore/Source/Interface/IR/Passes/StaticRegisterAllocationPass.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/StaticRegisterAllocationPass.cpp
@@ -29,7 +29,7 @@ bool IsStaticAllocGpr(uint32_t Offset, RegisterClassType Class) {
 
   if (Offset >= begin && Offset < end) {
     const auto reg = (Offset - begin) / Core::CPUState::GPR_REG_SIZE;
-    LOGMAN_THROW_A_FMT(Class == IR::GPRClass, "unexpected Class {}", Class);
+    LOGMAN_THROW_AA_FMT(Class.Val == IR::GPRClass.Val, "unexpected Class {}", Class);
 
     // 0..15 -> 16 in total
     return reg < Core::CPUState::NUM_GPRS;
@@ -44,7 +44,7 @@ bool IsStaticAllocFpr(uint32_t Offset, RegisterClassType Class, bool AllowGpr) {
 
   if (Offset >= begin && Offset < end) {
     const auto reg = (Offset - begin) / Core::CPUState::XMM_REG_SIZE;
-    LOGMAN_THROW_A_FMT(Class == IR::FPRClass || (AllowGpr && Class == IR::GPRClass), "unexpected Class {}, AllowGpr {}", Class, AllowGpr);
+    LOGMAN_THROW_AA_FMT(Class.Val == IR::FPRClass.Val || (AllowGpr && Class.Val == IR::GPRClass.Val), "unexpected Class {}, AllowGpr {}", Class, AllowGpr);
 
     // 0..15 -> 16 in total
     return reg < Core::CPUState::NUM_XMMS;

--- a/External/FEXCore/Source/Utils/Allocator/64BitAllocator.cpp
+++ b/External/FEXCore/Source/Utils/Allocator/64BitAllocator.cpp
@@ -125,7 +125,7 @@ namespace Alloc::OSAllocator {
 
         [[maybe_unused]] auto Res = mprotect(reinterpret_cast<void*>(ReservedRegion->Base), SizePlusManagedData, PROT_READ | PROT_WRITE);
 
-        LOGMAN_THROW_A_FMT(Res == 0, "Couldn't mprotect region: {} '{}' Likely occurs when running out of memory or Maximum VMAs", errno, strerror(errno));
+        LOGMAN_THROW_AA_FMT(Res == 0, "Couldn't mprotect region: {} '{}' Likely occurs when running out of memory or Maximum VMAs", errno, strerror(errno));
 
         LiveVMARegion *LiveRange = new (reinterpret_cast<void*>(ReservedRegion->Base)) LiveVMARegion();
 

--- a/External/FEXCore/Source/Utils/MemberFunctionToPointer.h
+++ b/External/FEXCore/Source/Utils/MemberFunctionToPointer.h
@@ -21,12 +21,12 @@ class MemberFunctionToPointerCast final {
       // Itanium C++ ABI (https://itanium-cxx-abi.github.io/cxx-abi/abi.html#member-function-pointers)
       // Low bit of ptr specifies if this Member function pointer is virtual or not
       // Throw an assert if we were trying to cast a virtual member
-      LOGMAN_THROW_A_FMT((PMF.ptr & 1) == 0, "C++ Pointer-To-Member representation didn't have low bit set to 0. Are you trying to cast a virtual member?");
+      LOGMAN_THROW_AA_FMT((PMF.ptr & 1) == 0, "C++ Pointer-To-Member representation didn't have low bit set to 0. Are you trying to cast a virtual member?");
 #elif defined(_M_ARM_64 )
       // C++ ABI for the Arm 64-bit Architecture (IHI 0059E)
       // 4.2.1 Representation of pointer to member function
       // Differs from Itanium specification
-      LOGMAN_THROW_A_FMT(PMF.adj == 0, "C++ Pointer-To-Member representation didn't have adj == 0. Are you trying to cast a virtual member?");
+      LOGMAN_THROW_AA_FMT(PMF.adj == 0, "C++ Pointer-To-Member representation didn't have adj == 0. Are you trying to cast a virtual member?");
 #else
 #error Don't know how to cast Member to function here. Likely just Itanium
 #endif

--- a/External/FEXCore/include/FEXCore/IR/IREmitter.h
+++ b/External/FEXCore/include/FEXCore/IR/IREmitter.h
@@ -225,7 +225,7 @@ friend class FEXCore::IR::PassManager;
 
     ReplaceAllUsesWithRange(Node, NewNode, Start, AllNodesIterator(DualListData.ListBegin(), DualListData.DataBegin()));
 
-    LOGMAN_THROW_A_FMT(Node->NumUses == 0, "Node still used");
+    LOGMAN_THROW_AA_FMT(Node->NumUses == 0, "Node still used");
 
     auto IROp = Node->Op(DualListData.DataBegin())->CW<FEXCore::IR::IROp_Header>();
     // We can not remove the op if there are side-effects

--- a/External/FEXCore/include/FEXCore/Utils/BucketList.h
+++ b/External/FEXCore/include/FEXCore/Utils/BucketList.h
@@ -21,7 +21,7 @@ namespace FEXCore {
 
     void Clear() {
       Items[0] = T{};
-      #ifndef NDEBUG
+      #if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
       for (size_t i = 1; i < Size; i++) {
         Items[i] = T{0xDEADBEEF};
       }

--- a/External/FEXCore/include/FEXCore/Utils/LogManager.h
+++ b/External/FEXCore/include/FEXCore/Utils/LogManager.h
@@ -29,6 +29,9 @@ FEX_DEFAULT_VISIBILITY void UnInstallHandlers();
 
 [[noreturn]] void MFmt(const char *fmt, const fmt::format_args& args);
 
+// AA_FMT and AAFmt are assume versions of {AA_FMT, AFmt} which will assert in debug builds if the assumption is incorrect.
+// In a release build these use __builtin_assume so compilers can optimize around the case that these cases always hold true.
+// The assume version should be preferred unless what is being checked has side effects.
 #if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
 template <typename... Args>
 static inline void AFmt(bool Value, const char *fmt, const Args&... args) {
@@ -37,10 +40,21 @@ static inline void AFmt(bool Value, const char *fmt, const Args&... args) {
   }
   MFmt(fmt, fmt::make_format_args(args...));
 }
+template <typename... Args>
+static inline void AAFmt(bool Value, const char *fmt, const Args&... args) {
+  if (MSG_LEVEL < ASSERT || Value) {
+    return;
+  }
+  MFmt(fmt, fmt::make_format_args(args...));
+}
+
 #define LOGMAN_THROW_A_FMT(pred, ...) do { LogMan::Throw::AFmt(pred, __VA_ARGS__); } while (0)
+#define LOGMAN_THROW_AA_FMT(pred, ...) do { LogMan::Throw::AFmt(pred, __VA_ARGS__); } while (0)
 #else
 static inline void AFmt(bool, const char*, ...) {}
 #define LOGMAN_THROW_A_FMT(pred, ...) do {} while (0)
+static inline void AAFmt(bool pred, const char*, ...) { __builtin_assume(pred); }
+#define LOGMAN_THROW_AA_FMT(pred, ...) do { __builtin_assume(pred); } while (0)
 #endif
 
 } // namespace Throw

--- a/Source/Linux/Utils/ELFContainer.cpp
+++ b/Source/Linux/Utils/ELFContainer.cpp
@@ -133,7 +133,7 @@ ELFContainer::ELFContainer(std::string const &Filename, std::string const &RootF
   //PrintInitArray();
   //PrintDynamicTable();
 
-  //LOGMAN_THROW_A_FMT(InterpreterHeader == nullptr, "Can only handle static programs");
+  //LOGMAN_THROW_AA_FMT(InterpreterHeader == nullptr, "Can only handle static programs");
 }
 
 ELFContainer::~ELFContainer() {
@@ -191,8 +191,8 @@ bool ELFContainer::LoadELF_32() {
 
   memcpy(&Header, reinterpret_cast<Elf32_Ehdr *>(&RawFile.at(0)),
          sizeof(Elf32_Ehdr));
-  LOGMAN_THROW_A_FMT(Header._32.e_phentsize == sizeof(Elf32_Phdr), "PH Entry size wasn't correct size");
-  LOGMAN_THROW_A_FMT(Header._32.e_shentsize == sizeof(Elf32_Shdr), "PH Entry size wasn't correct size");
+  LOGMAN_THROW_AA_FMT(Header._32.e_phentsize == sizeof(Elf32_Phdr), "PH Entry size wasn't correct size");
+  LOGMAN_THROW_AA_FMT(Header._32.e_shentsize == sizeof(Elf32_Shdr), "PH Entry size wasn't correct size");
 
   if (Header._32.e_machine != EM_386) {
     LogMan::Msg::DFmt("32bit ELF wasn't x86 based");
@@ -232,8 +232,8 @@ bool ELFContainer::LoadELF_64() {
 
   memcpy(&Header, reinterpret_cast<Elf64_Ehdr *>(&RawFile.at(0)),
          sizeof(Elf64_Ehdr));
-  LOGMAN_THROW_A_FMT(Header._64.e_phentsize == 56, "PH Entry size wasn't 56");
-  LOGMAN_THROW_A_FMT(Header._64.e_shentsize == 64, "PH Entry size wasn't 64");
+  LOGMAN_THROW_AA_FMT(Header._64.e_phentsize == 56, "PH Entry size wasn't 56");
+  LOGMAN_THROW_AA_FMT(Header._64.e_shentsize == 64, "PH Entry size wasn't 64");
 
   if (Header._64.e_machine != EM_X86_64) {
     LogMan::Msg::DFmt("64bit ELF wasn't x86-64 based");
@@ -405,7 +405,7 @@ void ELFContainer::CalculateSymbols() {
     if (SymTabHeader) {
       LOGMAN_THROW_A_FMT(SymTabHeader->sh_link < SectionHeaders.size(),
                          "Symbol table string table section is wrong");
-      LOGMAN_THROW_A_FMT(SymTabHeader->sh_entsize == sizeof(Elf32_Sym),
+      LOGMAN_THROW_AA_FMT(SymTabHeader->sh_entsize == sizeof(Elf32_Sym),
                          "Entry size doesn't match symbol entry");
 
       StringTableHeader = SectionHeaders.at(SymTabHeader->sh_link)._32;
@@ -416,7 +416,7 @@ void ELFContainer::CalculateSymbols() {
     if (DynSymTabHeader) {
       LOGMAN_THROW_A_FMT(DynSymTabHeader->sh_link < SectionHeaders.size(),
                          "Symbol table string table section is wrong");
-      LOGMAN_THROW_A_FMT(DynSymTabHeader->sh_entsize == sizeof(Elf32_Sym),
+      LOGMAN_THROW_AA_FMT(DynSymTabHeader->sh_entsize == sizeof(Elf32_Sym),
                          "Entry size doesn't match symbol entry");
 
       DynStringTableHeader = SectionHeaders.at(DynSymTabHeader->sh_link)._32;
@@ -538,7 +538,7 @@ void ELFContainer::CalculateSymbols() {
     if (SymTabHeader) {
       LOGMAN_THROW_A_FMT(SymTabHeader->sh_link < SectionHeaders.size(),
                          "Symbol table string table section is wrong");
-      LOGMAN_THROW_A_FMT(SymTabHeader->sh_entsize == sizeof(Elf64_Sym),
+      LOGMAN_THROW_AA_FMT(SymTabHeader->sh_entsize == sizeof(Elf64_Sym),
                          "Entry size doesn't match symbol entry");
 
       StringTableHeader = SectionHeaders.at(SymTabHeader->sh_link)._64;
@@ -549,7 +549,7 @@ void ELFContainer::CalculateSymbols() {
     if (DynSymTabHeader) {
       LOGMAN_THROW_A_FMT(DynSymTabHeader->sh_link < SectionHeaders.size(),
                          "Symbol table string table section is wrong");
-      LOGMAN_THROW_A_FMT(DynSymTabHeader->sh_entsize == sizeof(Elf64_Sym),
+      LOGMAN_THROW_AA_FMT(DynSymTabHeader->sh_entsize == sizeof(Elf64_Sym),
                          "Entry size doesn't match symbol entry");
 
       DynStringTableHeader = SectionHeaders.at(DynSymTabHeader->sh_link)._64;
@@ -819,7 +819,7 @@ void ELFContainer::PrintSymbolTable() const {
 
     LOGMAN_THROW_A_FMT(SymTabHeader->sh_link < SectionHeaders.size(),
                        "Symbol table string table section is wrong");
-    LOGMAN_THROW_A_FMT(SymTabHeader->sh_entsize == sizeof(Elf32_Sym),
+    LOGMAN_THROW_AA_FMT(SymTabHeader->sh_entsize == sizeof(Elf32_Sym),
                        "Entry size doesn't match symbol entry");
 
     StringTableHeader = SectionHeaders.at(SymTabHeader->sh_link)._32;
@@ -854,7 +854,7 @@ void ELFContainer::PrintSymbolTable() const {
 
     LOGMAN_THROW_A_FMT(SymTabHeader->sh_link < SectionHeaders.size(),
                        "Symbol table string table section is wrong");
-    LOGMAN_THROW_A_FMT(SymTabHeader->sh_entsize == sizeof(Elf64_Sym),
+    LOGMAN_THROW_AA_FMT(SymTabHeader->sh_entsize == sizeof(Elf64_Sym),
                        "Entry size doesn't match symbol entry");
 
     StringTableHeader = SectionHeaders.at(SymTabHeader->sh_link)._64;
@@ -917,7 +917,7 @@ void ELFContainer::PrintRelocationTable() const {
           LogMan::Msg::DFmt("\toffset: 0x{:x}", Entry->r_offset);
           LogMan::Msg::DFmt("\tSym:    0x{:x}", Sym);
           if (DynSymHeader && Sym != 0) {
-            LOGMAN_THROW_A_FMT(DynSymHeader->sh_entsize == sizeof(Elf64_Sym), "Oops, entry size doesn't match");
+            LOGMAN_THROW_AA_FMT(DynSymHeader->sh_entsize == sizeof(Elf64_Sym), "Oops, entry size doesn't match");
 
             const uint64_t offset = DynSymHeader->sh_offset + Sym * DynSymHeader->sh_entsize;
             const auto *Symbol = reinterpret_cast<const Elf64_Sym *>(&RawFile.at(offset));
@@ -999,7 +999,7 @@ void ELFContainer::FixupRelocations(void *ELFBase, uint64_t GuestELFBase, Symbol
           const Elf64_Sym *EntrySymbol{nullptr};
           const char *EntrySymbolName{nullptr};
           if (DynSymHeader && Sym != 0) {
-            LOGMAN_THROW_A_FMT(DynSymHeader->sh_entsize == sizeof(Elf64_Sym), "Oops, entry size doesn't match");
+            LOGMAN_THROW_AA_FMT(DynSymHeader->sh_entsize == sizeof(Elf64_Sym), "Oops, entry size doesn't match");
 
             const uint64_t offset = DynSymHeader->sh_offset + Sym * DynSymHeader->sh_entsize;
             EntrySymbol = reinterpret_cast<const Elf64_Sym *>(&RawFile.at(offset));

--- a/Source/Tests/ELFCodeLoader.h
+++ b/Source/Tests/ELFCodeLoader.h
@@ -282,7 +282,7 @@ public:
   bool MapMemory(const MapperFn& Mapper, const UnmapperFn& Unmapper) override {
     auto DoMMap = [&Mapper](uint64_t Address, size_t Size, bool FixedNoReplace) -> void* {
       void *Result = Mapper(reinterpret_cast<void*>(Address), Size, PROT_READ | PROT_WRITE, (FixedNoReplace ? MAP_FIXED_NOREPLACE : MAP_FIXED) | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-      LOGMAN_THROW_A_FMT(Result != (void*)~0ULL, "Couldn't mmap");
+      LOGMAN_THROW_AA_FMT(Result != (void*)~0ULL, "Couldn't mmap");
       return Result;
     };
 

--- a/Source/Tests/HarnessHelpers.h
+++ b/Source/Tests/HarnessHelpers.h
@@ -383,7 +383,7 @@ namespace FEX::HarnessHelper {
       }
       else {
         uint64_t Result = reinterpret_cast<uint64_t>(FEXCore::Allocator::mmap(reinterpret_cast<void*>(STACK_OFFSET), STACK_SIZE, PROT_READ | PROT_WRITE, MAP_FIXED_NOREPLACE | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
-        LOGMAN_THROW_A_FMT(Result != ~0ULL, "Stack Pointer mmap failed");
+        LOGMAN_THROW_AA_FMT(Result != ~0ULL, "Stack Pointer mmap failed");
         return Result + STACK_SIZE;
       }
     }
@@ -396,7 +396,7 @@ namespace FEX::HarnessHelper {
       bool LimitedSize = true;
       auto DoMMap = [&Mapper](uint64_t Address, size_t Size) -> void* {
         void *Result = Mapper(reinterpret_cast<void*>(Address), Size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_FIXED | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-        LOGMAN_THROW_A_FMT(Result == reinterpret_cast<void*>(Address), "Map Memory mmap failed");
+        LOGMAN_THROW_AA_FMT(Result == reinterpret_cast<void*>(Address), "Map Memory mmap failed");
         return Result;
       };
 

--- a/Source/Tests/LinuxSyscalls/SignalDelegator.cpp
+++ b/Source/Tests/LinuxSyscalls/SignalDelegator.cpp
@@ -253,7 +253,7 @@ namespace FEX::HLE {
 
   SignalDelegator::SignalDelegator() {
     // Register this delegate
-    LOGMAN_THROW_A_FMT(!GlobalDelegator, "Can't register global delegator multiple times!");
+    LOGMAN_THROW_AA_FMT(!GlobalDelegator, "Can't register global delegator multiple times!");
     GlobalDelegator = this;
     // Signal zero isn't real
     HostHandlers[0].Installed = true;
@@ -309,7 +309,7 @@ namespace FEX::HLE {
     altstack.ss_sp = ThreadData.AltStackPtr;
     altstack.ss_size = SIGSTKSZ * 16;
     altstack.ss_flags = 0;
-    LOGMAN_THROW_A_FMT(!!altstack.ss_sp, "Couldn't allocate stack pointer");
+    LOGMAN_THROW_AA_FMT(!!altstack.ss_sp, "Couldn't allocate stack pointer");
 
     // Register the alt stack
     const int Result = sigaltstack(&altstack, nullptr);

--- a/Source/Tests/LinuxSyscalls/SyscallsSMCTracking.cpp
+++ b/Source/Tests/LinuxSyscalls/SyscallsSMCTracking.cpp
@@ -71,7 +71,7 @@ bool SyscallHandler::HandleSegfault(FEXCore::Core::InternalThreadState *Thread, 
       auto Offset = FaultBase - Entry->first + Entry->second.Offset;
 
       auto VMA = Entry->second.Resource->FirstVMA;
-      LOGMAN_THROW_A_FMT(VMA, "VMA tracking error");
+      LOGMAN_THROW_AA_FMT(VMA, "VMA tracking error");
 
       // Flush all mirrors, remap the page writable as needed
       do {
@@ -81,7 +81,7 @@ bool SyscallHandler::HandleSegfault(FEXCore::Core::InternalThreadState *Thread, 
           if (VMA->Prot.Writable) {
             FEXCore::Context::InvalidateGuestCodeRange(CTX, FaultBaseMirrored, FHU::FEX_PAGE_SIZE, [](uintptr_t Start, uintptr_t Length) {
               auto rv = mprotect((void *)Start, Length, PROT_READ | PROT_WRITE);
-              LogMan::Throw::AFmt(rv == 0, "mprotect({}, {}) failed", Start, Length);
+              LogMan::Throw::AAFmt(rv == 0, "mprotect({}, {}) failed", Start, Length);
             });
           } else {
             FEXCore::Context::InvalidateGuestCodeRange(CTX, FaultBaseMirrored, FHU::FEX_PAGE_SIZE);
@@ -91,7 +91,7 @@ bool SyscallHandler::HandleSegfault(FEXCore::Core::InternalThreadState *Thread, 
     } else {
       FEXCore::Context::InvalidateGuestCodeRange(CTX, FaultBase, FHU::FEX_PAGE_SIZE, [](uintptr_t Start, uintptr_t Length) {
         auto rv = mprotect((void *)Start, Length, PROT_READ | PROT_WRITE);
-        LogMan::Throw::AFmt(rv == 0, "mprotect({}, {}) failed", Start, Length);
+        LogMan::Throw::AAFmt(rv == 0, "mprotect({}, {}) failed", Start, Length);
       });
     }
 
@@ -134,7 +134,7 @@ void SyscallHandler::MarkGuestExecutableRange(uint64_t Start, uint64_t Length) {
           const auto OffsetTop = OffsetBase + ProtectSize;
 
           auto VMA = Mapping->second.Resource->FirstVMA;
-          LOGMAN_THROW_A_FMT(VMA, "VMA tracking error");
+          LOGMAN_THROW_AA_FMT(VMA, "VMA tracking error");
 
           do {
             auto VMAOffsetBase = VMA->Offset;
@@ -147,14 +147,14 @@ void SyscallHandler::MarkGuestExecutableRange(uint64_t Start, uint64_t Length) {
               const auto MirroredSize = std::min(OffsetTop, VMAOffsetTop) - MirroredBase;
 
               auto rv = mprotect((void *)(MirroredBase - VMAOffsetBase + VMABase), MirroredSize, PROT_READ);
-              LogMan::Throw::AFmt(rv == 0, "mprotect({}, {}) failed", MirroredBase, MirroredSize);
+              LogMan::Throw::AAFmt(rv == 0, "mprotect({}, {}) failed", MirroredBase, MirroredSize);
             }
           } while ((VMA = VMA->ResourceNextVMA));
 
         } else if (Mapping->second.Prot.Writable) {
           int rv = mprotect((void *)ProtectBase, ProtectSize, PROT_READ);
 
-          LogMan::Throw::AFmt(rv == 0, "mprotect({}, {}) failed", ProtectBase, ProtectSize);
+          LogMan::Throw::AAFmt(rv == 0, "mprotect({}, {}) failed", ProtectBase, ProtectSize);
         }
       }
     }
@@ -213,7 +213,7 @@ void SyscallHandler::TrackMmap(uintptr_t Base, uintptr_t Size, int Prot, int Fla
       MRID mrid{SpecialDev::Anon, AnonSharedId++};
 
       auto [Iter, Inserted] = VMATracking.MappedResources.emplace(mrid, MappedResource{nullptr, nullptr, 0});
-      LOGMAN_THROW_A_FMT(Inserted == true, "VMA tracking error");
+      LOGMAN_THROW_AA_FMT(Inserted == true, "VMA tracking error");
       Resource = &Iter->second;
       Resource->Iterator = Iter;
     } else {
@@ -276,8 +276,8 @@ void SyscallHandler::TrackMremap(uintptr_t OldAddress, size_t OldSize, size_t Ne
     if (OldSize == 0) {
       // Mirror existing mapping
       // must be a shared mapping
-      LOGMAN_THROW_A_FMT(OldResource != nullptr, "VMA Tracking error");
-      LOGMAN_THROW_A_FMT(OldFlags.Shared, "VMA Tracking error");
+      LOGMAN_THROW_AA_FMT(OldResource != nullptr, "VMA Tracking error");
+      LOGMAN_THROW_AA_FMT(OldFlags.Shared, "VMA Tracking error");
       VMATracking.SetUnsafe(CTX, OldResource, NewAddress, OldOffset, NewSize, OldFlags, OldProt);
     } else {
 
@@ -315,7 +315,7 @@ void SyscallHandler::TrackShmat(int shmid, uintptr_t Base, int shmflg) {
   shmid_ds stat;
 
   auto res = shmctl(shmid, IPC_STAT, &stat);
-  LOGMAN_THROW_A_FMT(res != -1, "shmctl IPC_STAT failed");
+  LOGMAN_THROW_AA_FMT(res != -1, "shmctl IPC_STAT failed");
 
   uint64_t Length = stat.shm_segsz;
 

--- a/Source/Tests/LinuxSyscalls/x32/FD.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/FD.cpp
@@ -451,7 +451,7 @@ namespace FEX::HLE::x32 {
     });
 
     REGISTER_SYSCALL_IMPL_X32(fstatfs64, [](FEXCore::Core::CpuStateFrame *Frame, int fd, size_t sz, struct statfs64_32 *buf) -> uint64_t {
-      LOGMAN_THROW_A_FMT(sz == sizeof(struct statfs64_32), "This needs to match");
+      LOGMAN_THROW_AA_FMT(sz == sizeof(struct statfs64_32), "This needs to match");
 
       struct statfs64 host_stat;
       uint64_t Result = ::fstatfs64(fd, &host_stat);
@@ -462,7 +462,7 @@ namespace FEX::HLE::x32 {
     });
 
     REGISTER_SYSCALL_IMPL_X32(statfs64, [](FEXCore::Core::CpuStateFrame *Frame, const char *path, size_t sz, struct statfs64_32 *buf) -> uint64_t {
-      LOGMAN_THROW_A_FMT(sz == sizeof(struct statfs64_32), "This needs to match");
+      LOGMAN_THROW_AA_FMT(sz == sizeof(struct statfs64_32), "This needs to match");
 
       struct statfs host_stat;
       uint64_t Result = FEX::HLE::_SyscallHandler->FM.Statfs(path, &host_stat);

--- a/Source/Tests/LinuxSyscalls/x32/Memory.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Memory.cpp
@@ -21,11 +21,11 @@ $end_info$
 namespace FEX::HLE::x32 {
 
   void *x32SyscallHandler::GuestMmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset) {
-    LOGMAN_THROW_A_FMT((length >> 32) == 0, "values must fit to 32 bits");
+    LOGMAN_THROW_AA_FMT((length >> 32) == 0, "values must fit to 32 bits");
 
     auto Result = (uint64_t)GetAllocator()->mmap((void*)addr, length, prot, flags, fd, offset);
 
-    LOGMAN_THROW_A_FMT((Result >> 32) == 0|| (Result >> 32) == 0xFFFFFFFF, "values must fit to 32 bits");
+    LOGMAN_THROW_AA_FMT((Result >> 32) == 0|| (Result >> 32) == 0xFFFFFFFF, "values must fit to 32 bits");
 
     if (!FEX::HLE::HasSyscallError(Result)) {
       FEX::HLE::_SyscallHandler->TrackMmap(Result, length, prot, flags, fd, offset);
@@ -37,8 +37,8 @@ namespace FEX::HLE::x32 {
   }
 
   int x32SyscallHandler::GuestMunmap(void *addr, uint64_t length) {
-    LOGMAN_THROW_A_FMT((uintptr_t(addr) >> 32) == 0, "values must fit to 32 bits");
-    LOGMAN_THROW_A_FMT((length >> 32) == 0, "values must fit to 32 bits");
+    LOGMAN_THROW_AA_FMT((uintptr_t(addr) >> 32) == 0, "values must fit to 32 bits");
+    LOGMAN_THROW_AA_FMT((length >> 32) == 0, "values must fit to 32 bits");
 
     auto Result = GetAllocator()->munmap(addr, length);
 


### PR DESCRIPTION
This comes in the form of a new define and a new function.

Assuming assert doesn't quite cover 100% of our asserting logging use
cases so we need to break this out.
If the compiler can't see through side effects at compile time for the
predicate then it'll throw a warning.

This gives us a nice behaviour. In the case that asserts are enabled, we
fall down the assert checking path. So if an assert fails to predicate
we will do an assert log like normal.
The change comes when we build release without asserts, we use the
`__builtin_assume` definition to allow the compiler to optimize around
assumptions. Since these aren't runtime asserts in release build, this
gives us some small optimizations in various locations.

Clang will very specifically do additional optimizations when you
provide it `__builtin_assume` directives that can really be worth it.

I thought of adding this as a freestanding FEXHeaderUtil function, but everywhere we would be using it would also want logging. So it doesn't make sense to duplicate functionality for assert+assume and some redundancy.