### PR TITLE
Linux: Only install syscall handlers for the arch we launched with

### DIFF
--- a/Source/Tests/LinuxSyscalls/Syscalls.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls.cpp
@@ -58,6 +58,16 @@ namespace FEX::HLE {
 class SignalDelegator;
 SyscallHandler *_SyscallHandler{};
 
+void RegisterSyscallInternalNop(int SyscallNumber,
+  int32_t HostSyscallNumber,
+  FEXCore::IR::SyscallFlags Flags,
+#ifdef DEBUG_STRACE
+  const std::string& TraceFormatString,
+#endif
+  void* SyscallHandler, int ArgumentCount) {
+  // Do nothing
+}
+
 static bool IsSupportedByInterpreter(std::string const &Filename) {
   // If it is a supported ELF then we can
   if (ELFLoader::ELFContainer::IsSupportedELF(Filename.c_str())) {

--- a/Source/Tests/LinuxSyscalls/Syscalls.h
+++ b/Source/Tests/LinuxSyscalls/Syscalls.h
@@ -84,6 +84,24 @@ struct ExecveAtArgs {
 
 uint64_t ExecveHandler(const char *pathname, char* const* argv, char* const* envp, ExecveAtArgs *Args);
 
+using RegisterSyscallInternalType =
+void (*)(int SyscallNumber,
+  int32_t HostSyscallNumber,
+  FEXCore::IR::SyscallFlags Flags,
+#ifdef DEBUG_STRACE
+  const std::string& TraceFormatString,
+#endif
+  void* SyscallHandler, int ArgumentCount);
+
+
+void RegisterSyscallInternalNop(int SyscallNumber,
+  int32_t HostSyscallNumber,
+  FEXCore::IR::SyscallFlags Flags,
+#ifdef DEBUG_STRACE
+  const std::string& TraceFormatString,
+#endif
+  void* SyscallHandler, int ArgumentCount);
+
 class SyscallHandler : public FEXCore::HLE::SyscallHandler, FEXCore::HLE::SourcecodeResolver {
 public:
   virtual ~SyscallHandler();

--- a/Source/Tests/LinuxSyscalls/x32/Syscalls.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Syscalls.cpp
@@ -28,6 +28,8 @@ namespace FEXCore::Context {
 }
 
 namespace FEX::HLE::x32 {
+  RegisterSyscallInternalType SyscallRegisterHandler = FEX::HLE::RegisterSyscallInternalNop;
+
   void RegisterEpoll(FEX::HLE::SyscallHandler *const Handler);
   void RegisterFD();
   void RegisterFS();
@@ -94,6 +96,7 @@ namespace FEX::HLE::x32 {
   x32SyscallHandler::x32SyscallHandler(FEXCore::Context::Context *ctx, FEX::HLE::SignalDelegator *_SignalDelegation, std::unique_ptr<MemAllocator> Allocator)
     : SyscallHandler{ctx, _SignalDelegation}, AllocHandler{std::move(Allocator)} {
     OSABI = FEXCore::HLE::SyscallOSABI::OS_LINUX32;
+    FEX::HLE::x32::SyscallRegisterHandler = FEX::HLE::x32::RegisterSyscallInternal;
     RegisterSyscallHandlers();
   }
 
@@ -171,6 +174,9 @@ namespace FEX::HLE::x32 {
       Def.StraceFmt = Syscall.TraceFormatString;
 #endif
     }
+
+    // Clear the registration vector
+    syscalls_x32 = {};
 
 #if PRINT_MISSING_SYSCALLS
     for (auto &Syscall: SyscallNames) {

--- a/Source/Tests/LinuxSyscalls/x32/Syscalls.h
+++ b/Source/Tests/LinuxSyscalls/x32/Syscalls.h
@@ -46,6 +46,7 @@ std::unique_ptr<FEX::HLE::SyscallHandler> CreateHandler(FEXCore::Context::Contex
                                                         FEX::HLE::SignalDelegator *_SignalDelegation,
                                                         std::unique_ptr<MemAllocator> Allocator);
 
+extern RegisterSyscallInternalType SyscallRegisterHandler;
 void RegisterSyscallInternal(int SyscallNumber,
   int32_t HostSyscallNumber,
   FEXCore::IR::SyscallFlags Flags,
@@ -68,7 +69,7 @@ void RegisterSyscall(int SyscallNumber, int32_t HostSyscallNumber, FEXCore::IR::
 #ifdef DEBUG_STRACE
   auto TraceFormatString = std::string(Name) + "(" + CollectArgsFmtString<Args...>() + ") = %ld";
 #endif
-  FEX::HLE::x32::RegisterSyscallInternal(SyscallNumber,
+  FEX::HLE::x32::SyscallRegisterHandler(SyscallNumber,
     HostSyscallNumber,
     Flags,
 #ifdef DEBUG_STRACE

--- a/Source/Tests/LinuxSyscalls/x64/Syscalls.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Syscalls.cpp
@@ -13,6 +13,8 @@ $end_info$
 #include <map>
 
 namespace FEX::HLE::x64 {
+  RegisterSyscallInternalType SyscallRegisterHandler = FEX::HLE::RegisterSyscallInternalNop;
+
   void RegisterEpoll(FEX::HLE::SyscallHandler *const Handler);
   void RegisterFD();
   void RegisterInfo();
@@ -78,6 +80,7 @@ namespace FEX::HLE::x64 {
   x64SyscallHandler::x64SyscallHandler(FEXCore::Context::Context *ctx, FEX::HLE::SignalDelegator *_SignalDelegation)
     : SyscallHandler {ctx, _SignalDelegation} {
     OSABI = FEXCore::HLE::SyscallOSABI::OS_LINUX64;
+    FEX::HLE::x64::SyscallRegisterHandler = FEX::HLE::x64::RegisterSyscallInternal;
 
     RegisterSyscallHandlers();
   }
@@ -152,6 +155,9 @@ namespace FEX::HLE::x64 {
       Def.StraceFmt = Syscall.TraceFormatString;
 #endif
     }
+
+    // Clear the registration vector
+    syscalls_x64 = {};
 
     // x86-64 has a gap of syscalls in the range of [335, 424) where there aren't any
     // These are defined that these must return -ENOSYS

--- a/Source/Tests/LinuxSyscalls/x64/Syscalls.h
+++ b/Source/Tests/LinuxSyscalls/x64/Syscalls.h
@@ -7,6 +7,8 @@ $end_info$
 #pragma once
 
 #include "Tests/LinuxSyscalls/FileManagement.h"
+#include "Tests/LinuxSyscalls/Syscalls.h"
+
 #include <FEXCore/HLE/SyscallHandler.h>
 #include <FEXCore/IR/IR.h>
 
@@ -31,7 +33,7 @@ namespace FEX::HLE::x64 {
 class x64SyscallHandler final : public FEX::HLE::SyscallHandler {
   public:
     x64SyscallHandler(FEXCore::Context::Context *ctx, FEX::HLE::SignalDelegator *_SignalDelegation);
-    
+
     void *GuestMmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset) override;
     int GuestMunmap(void *addr, uint64_t length) override;
 
@@ -41,6 +43,7 @@ class x64SyscallHandler final : public FEX::HLE::SyscallHandler {
 
 std::unique_ptr<FEX::HLE::SyscallHandler> CreateHandler(FEXCore::Context::Context *ctx, FEX::HLE::SignalDelegator *_SignalDelegation);
 
+extern RegisterSyscallInternalType SyscallRegisterHandler;
 void RegisterSyscallInternal(int SyscallNumber,
   int32_t HostSyscallNumber,
   FEXCore::IR::SyscallFlags Flags,
@@ -63,7 +66,7 @@ void RegisterSyscall(int SyscallNumber, int32_t HostSyscallNumber, FEXCore::IR::
 #ifdef DEBUG_STRACE
   auto TraceFormatString = std::string(Name) + "(" + CollectArgsFmtString<Args...>() + ") = %ld";
 #endif
-  FEX::HLE::x64::RegisterSyscallInternal(SyscallNumber,
+  FEX::HLE::x64::SyscallRegisterHandler(SyscallNumber,
     HostSyscallNumber,
     Flags,
 #ifdef DEBUG_STRACE


### PR DESCRIPTION
We were registering syscall handlers to the temporary working vectors for
both x86 and x86_64 regardless of which bitness we launched with.

We then only installed the syscall handlers depending on bitness.
This was burning a decent amount of time and some memory on
initialization. Instead just don't register syscall handlers on the
other bitness.

Also stop wasting memory, clear the syscall registration vector after
we've registered everything.

Saves about 28KB of memory per process.