### PR TITLE
Dispatcher: Fix SRA enabled check in signal delegator handlers

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
@@ -42,8 +42,7 @@ static constexpr size_t MAX_DISPATCHER_CODE_SIZE = 4096;
 #define STATE x28
 
 Arm64Dispatcher::Arm64Dispatcher(FEXCore::Context::Context *ctx, const DispatcherConfig &config)
-  : FEXCore::CPU::Dispatcher(ctx), Arm64Emitter(ctx, MAX_DISPATCHER_CODE_SIZE)
-  , config(config) {
+  : FEXCore::CPU::Dispatcher(ctx, config), Arm64Emitter(ctx, MAX_DISPATCHER_CODE_SIZE) {
   SetAllowAssembler(true);
 
   DispatchPtr = GetCursorAddress<AsmDispatch>();

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.h
@@ -29,7 +29,6 @@ class Arm64Dispatcher final : public Dispatcher, public Arm64Emitter {
     uint64_t LDIVHandlerAddress{};
     uint64_t LUREMHandlerAddress{};
     uint64_t LREMHandlerAddress{};
-    DispatcherConfig config;
 };
 
 }

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
@@ -299,7 +299,7 @@ bool Dispatcher::HandleGuestSignal(FEXCore::Core::InternalThreadState *Thread, i
   // Spill the SRA regardless of signal handler type
   // We are going to be returning to the top of the dispatcher which will fill again
   // Otherwise we might load garbage
-  if (SRAEnabled) {
+  if (config.StaticRegisterAllocation) {
     if (Thread->CPUBackend->IsAddressInCodeBuffer(OldPC)) {
       uint32_t IgnoreMask{};
 #ifdef _M_ARM_64
@@ -665,11 +665,11 @@ bool Dispatcher::HandleSignalPause(FEXCore::Core::InternalThreadState *Thread, i
     // Store our thread state so we can come back to this
     StoreThreadState(Thread, Signal, ucontext);
 
-    if (SRAEnabled && Thread->CPUBackend->IsAddressInCodeBuffer(ArchHelpers::Context::GetPc(ucontext))) {
+    if (config.StaticRegisterAllocation && Thread->CPUBackend->IsAddressInCodeBuffer(ArchHelpers::Context::GetPc(ucontext))) {
       // We are in jit, SRA must be spilled
       ArchHelpers::Context::SetPc(ucontext, ThreadPauseHandlerAddressSpillSRA);
     } else {
-      if (SRAEnabled) {
+      if (config.StaticRegisterAllocation) {
         // We are in non-jit, SRA is already spilled
         LOGMAN_THROW_A_FMT(!IsAddressInDispatcher(ArchHelpers::Context::GetPc(ucontext)),
                            "Signals in dispatcher have unsynchronized context");
@@ -698,11 +698,11 @@ bool Dispatcher::HandleSignalPause(FEXCore::Core::InternalThreadState *Thread, i
     Thread->CurrentFrame->SignalHandlerRefCounter = 0;
 
     // Set the new PC
-    if (SRAEnabled && Thread->CPUBackend->IsAddressInCodeBuffer(ArchHelpers::Context::GetPc(ucontext))) {
+    if (config.StaticRegisterAllocation && Thread->CPUBackend->IsAddressInCodeBuffer(ArchHelpers::Context::GetPc(ucontext))) {
       // We are in jit, SRA must be spilled
       ArchHelpers::Context::SetPc(ucontext, ThreadStopHandlerAddressSpillSRA);
     } else {
-      if (SRAEnabled) {
+      if (config.StaticRegisterAllocation) {
         // We are in non-jit, SRA is already spilled
         LOGMAN_THROW_A_FMT(!IsAddressInDispatcher(ArchHelpers::Context::GetPc(ucontext)),
                            "Signals in dispatcher have unsynchronized context");

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
@@ -84,18 +84,19 @@ public:
   }
 
 protected:
-  Dispatcher(FEXCore::Context::Context *ctx)
+  Dispatcher(FEXCore::Context::Context *ctx, const DispatcherConfig &Config)
     : CTX {ctx}
+    , config {Config}
     {}
 
   ArchHelpers::Context::ContextBackup* StoreThreadState(FEXCore::Core::InternalThreadState *Thread, int Signal, void *ucontext);
   void RestoreThreadState(FEXCore::Core::InternalThreadState *Thread, void *ucontext);
   std::stack<uint64_t, std::vector<uint64_t>> SignalFrames;
 
-  bool SRAEnabled = false;
   virtual void SpillSRA(FEXCore::Core::InternalThreadState *Thread, void *ucontext, uint32_t IgnoreMask) {}
 
   FEXCore::Context::Context *CTX;
+  DispatcherConfig config;
 
   static void SleepThread(FEXCore::Context::Context *ctx, FEXCore::Core::CpuStateFrame *Frame);
 

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/X86Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/X86Dispatcher.cpp
@@ -28,7 +28,7 @@ static constexpr size_t MAX_DISPATCHER_CODE_SIZE = 4096;
 #define STATE r14
 
 X86Dispatcher::X86Dispatcher(FEXCore::Context::Context *ctx, const DispatcherConfig &config)
-  : Dispatcher(ctx)
+  : Dispatcher(ctx, config)
   , Xbyak::CodeGenerator(MAX_DISPATCHER_CODE_SIZE,
       FEXCore::Allocator::mmap(nullptr, MAX_DISPATCHER_CODE_SIZE, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0),
       nullptr) {


### PR DESCRIPTION
When some SRA code was being shuffled around, this config variable was
never being set. This caused the guest signal handlers to never expect
SRA to be enabled.

Moves the Dispatcher config object to the actual dispatcher rather than
having it in the arch specific dispatcher class. Then have the signal
delegator check the config directly instead of having this secondary
config value.

Fixes vc_redist_x64 and vc_redist_x86. Probably also fixes a bunch of
other random Proton/Wine things that rely on signal long jump.