### PR TITLE
Interpreter: Move argument names over to IR names

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/ALUOps.cpp
@@ -20,7 +20,7 @@ DEF_OP(TruncElementPair) {
 
   switch (IROp->Size) {
     case 4: {
-      uint64_t *Src = GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[0]);
+      uint64_t *Src = GetSrc<uint64_t*>(Data->SSAData, Op->Pair);
       uint64_t Result{};
       Result = Src[0] & ~0U;
       Result |= Src[1] << 32;
@@ -69,11 +69,11 @@ DEF_OP(CycleCounter) {
 
 DEF_OP(Add) {
   auto Op = IROp->C<IR::IROp_Add>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
-  auto Func = [](auto a, auto b) { return a + b; };
+  auto *Src1 = GetSrc<void*>(Data->SSAData, Op->Src1);
+  auto *Src2 = GetSrc<void*>(Data->SSAData, Op->Src2);
+  const auto Func = [](auto a, auto b) { return a + b; };
 
   switch (OpSize) {
     DO_OP(4, uint32_t, Func)
@@ -84,11 +84,11 @@ DEF_OP(Add) {
 
 DEF_OP(Sub) {
   auto Op = IROp->C<IR::IROp_Sub>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
-  auto Func = [](auto a, auto b) { return a - b; };
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Src1);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Src2);
+  const auto Func = [](auto a, auto b) { return a - b; };
 
   switch (OpSize) {
     DO_OP(4, uint32_t, Func)
@@ -99,9 +99,9 @@ DEF_OP(Sub) {
 
 DEF_OP(Neg) {
   auto Op = IROp->C<IR::IROp_Neg>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  uint64_t Src = *GetSrc<int64_t*>(Data->SSAData, Op->Header.Args[0]);
+  const uint64_t Src = *GetSrc<int64_t*>(Data->SSAData, Op->Src);
   switch (OpSize) {
     case 4:
       GD = -static_cast<int32_t>(Src);
@@ -115,10 +115,10 @@ DEF_OP(Neg) {
 
 DEF_OP(Mul) {
   auto Op = IROp->C<IR::IROp_Mul>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  uint64_t Src1 = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[0]);
-  uint64_t Src2 = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[1]);
+  const uint64_t Src1 = *GetSrc<uint64_t*>(Data->SSAData, Op->Src1);
+  const uint64_t Src2 = *GetSrc<uint64_t*>(Data->SSAData, Op->Src2);
 
   switch (OpSize) {
     case 4:
@@ -138,10 +138,10 @@ DEF_OP(Mul) {
 
 DEF_OP(UMul) {
   auto Op = IROp->C<IR::IROp_UMul>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  uint64_t Src1 = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[0]);
-  uint64_t Src2 = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[1]);
+  const uint64_t Src1 = *GetSrc<uint64_t*>(Data->SSAData, Op->Src1);
+  const uint64_t Src2 = *GetSrc<uint64_t*>(Data->SSAData, Op->Src2);
 
   switch (OpSize) {
     case 4:
@@ -161,9 +161,9 @@ DEF_OP(UMul) {
 
 DEF_OP(Div) {
   auto Op = IROp->C<IR::IROp_Div>();
-  uint8_t OpSize = IROp->Size;
-  uint64_t Src1 = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[0]);
-  uint64_t Src2 = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[1]);
+  const uint8_t OpSize = IROp->Size;
+  const uint64_t Src1 = *GetSrc<uint64_t*>(Data->SSAData, Op->Src1);
+  const uint64_t Src2 = *GetSrc<uint64_t*>(Data->SSAData, Op->Src2);
 
   switch (OpSize) {
     case 1:
@@ -179,7 +179,7 @@ DEF_OP(Div) {
       GD = static_cast<int64_t>(Src1) / static_cast<int64_t>(Src2);
       break;
     case 16: {
-      __int128_t Tmp = *GetSrc<__int128_t*>(Data->SSAData, Op->Header.Args[0]) / *GetSrc<__int128_t*>(Data->SSAData, Op->Header.Args[1]);
+      __int128_t Tmp = *GetSrc<__int128_t*>(Data->SSAData, Op->Src1) / *GetSrc<__int128_t*>(Data->SSAData, Op->Src2);
       memcpy(GDP, &Tmp, 16);
       break;
     }
@@ -189,10 +189,10 @@ DEF_OP(Div) {
 
 DEF_OP(UDiv) {
   auto Op = IROp->C<IR::IROp_UDiv>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  uint64_t Src1 = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[0]);
-  uint64_t Src2 = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[1]);
+  const uint64_t Src1 = *GetSrc<uint64_t*>(Data->SSAData, Op->Src1);
+  const uint64_t Src2 = *GetSrc<uint64_t*>(Data->SSAData, Op->Src2);
 
   switch (OpSize) {
     case 1:
@@ -208,7 +208,7 @@ DEF_OP(UDiv) {
       GD = static_cast<uint64_t>(Src1) / static_cast<uint64_t>(Src2);
       break;
     case 16: {
-      __uint128_t Tmp = *GetSrc<__uint128_t*>(Data->SSAData, Op->Header.Args[0]) / *GetSrc<__uint128_t*>(Data->SSAData, Op->Header.Args[1]);
+      __uint128_t Tmp = *GetSrc<__uint128_t*>(Data->SSAData, Op->Src1) / *GetSrc<__uint128_t*>(Data->SSAData, Op->Src2);
       memcpy(GDP, &Tmp, 16);
       break;
     }
@@ -218,10 +218,10 @@ DEF_OP(UDiv) {
 
 DEF_OP(Rem) {
   auto Op = IROp->C<IR::IROp_Rem>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  uint64_t Src1 = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[0]);
-  uint64_t Src2 = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[1]);
+  const uint64_t Src1 = *GetSrc<uint64_t*>(Data->SSAData, Op->Src1);
+  const uint64_t Src2 = *GetSrc<uint64_t*>(Data->SSAData, Op->Src2);
 
   switch (OpSize) {
     case 1:
@@ -237,7 +237,7 @@ DEF_OP(Rem) {
       GD = static_cast<int64_t>(Src1) % static_cast<int64_t>(Src2);
       break;
     case 16: {
-      __int128_t Tmp = *GetSrc<__int128_t*>(Data->SSAData, Op->Header.Args[0]) % *GetSrc<__int128_t*>(Data->SSAData, Op->Header.Args[1]);
+      __int128_t Tmp = *GetSrc<__int128_t*>(Data->SSAData, Op->Src1) % *GetSrc<__int128_t*>(Data->SSAData, Op->Src2);
       memcpy(GDP, &Tmp, 16);
       break;
     }
@@ -247,10 +247,10 @@ DEF_OP(Rem) {
 
 DEF_OP(URem) {
   auto Op = IROp->C<IR::IROp_URem>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  uint64_t Src1 = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[0]);
-  uint64_t Src2 = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[1]);
+  const uint64_t Src1 = *GetSrc<uint64_t*>(Data->SSAData, Op->Src1);
+  const uint64_t Src2 = *GetSrc<uint64_t*>(Data->SSAData, Op->Src2);
 
   switch (OpSize) {
     case 1:
@@ -266,7 +266,7 @@ DEF_OP(URem) {
       GD = static_cast<uint64_t>(Src1) % static_cast<uint64_t>(Src2);
       break;
     case 16: {
-      __uint128_t Tmp = *GetSrc<__uint128_t*>(Data->SSAData, Op->Header.Args[0]) % *GetSrc<__uint128_t*>(Data->SSAData, Op->Header.Args[1]);
+      __uint128_t Tmp = *GetSrc<__uint128_t*>(Data->SSAData, Op->Src1) % *GetSrc<__uint128_t*>(Data->SSAData, Op->Src2);
       memcpy(GDP, &Tmp, 16);
       break;
     }
@@ -276,10 +276,10 @@ DEF_OP(URem) {
 
 DEF_OP(MulH) {
   auto Op = IROp->C<IR::IROp_MulH>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  uint64_t Src1 = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[0]);
-  uint64_t Src2 = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[1]);
+  const uint64_t Src1 = *GetSrc<uint64_t*>(Data->SSAData, Op->Src1);
+  const uint64_t Src2 = *GetSrc<uint64_t*>(Data->SSAData, Op->Src2);
 
   switch (OpSize) {
     case 4: {
@@ -298,10 +298,10 @@ DEF_OP(MulH) {
 
 DEF_OP(UMulH) {
   auto Op = IROp->C<IR::IROp_UMulH>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  uint64_t Src1 = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[0]);
-  uint64_t Src2 = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[1]);
+  const uint64_t Src1 = *GetSrc<uint64_t*>(Data->SSAData, Op->Src1);
+  const uint64_t Src2 = *GetSrc<uint64_t*>(Data->SSAData, Op->Src2);
   switch (OpSize) {
     case 4:
       GD = static_cast<uint64_t>(Src1) * static_cast<uint64_t>(Src2);
@@ -324,11 +324,11 @@ DEF_OP(UMulH) {
 
 DEF_OP(Or) {
   auto Op = IROp->C<IR::IROp_Or>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
-  auto Func = [](auto a, auto b) { return a | b; };
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Src1);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Src2);
+  const auto Func = [](auto a, auto b) { return a | b; };
 
   switch (OpSize) {
     DO_OP(1, uint8_t,  Func)
@@ -342,11 +342,11 @@ DEF_OP(Or) {
 
 DEF_OP(And) {
   auto Op = IROp->C<IR::IROp_And>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
-  auto Func = [](auto a, auto b) { return a & b; };
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Src1);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Src2);
+  const auto Func = [](auto a, auto b) { return a & b; };
 
   switch (OpSize) {
     DO_OP(1, uint8_t,  Func)
@@ -361,8 +361,8 @@ DEF_OP(Andn) {
   auto Op = IROp->C<IR::IROp_Andn>();
   const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Src1);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Src2);
   constexpr auto Func = [](auto a, auto b) {
     using Type = decltype(a);
     return static_cast<Type>(a & static_cast<Type>(~b));
@@ -379,11 +379,11 @@ DEF_OP(Andn) {
 
 DEF_OP(Xor) {
   auto Op = IROp->C<IR::IROp_Xor>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
-  auto Func = [](auto a, auto b) { return a ^ b; };
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Src1);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Src2);
+  const auto Func = [](auto a, auto b) { return a ^ b; };
 
   switch (OpSize) {
     DO_OP(1, uint8_t,  Func)
@@ -396,11 +396,11 @@ DEF_OP(Xor) {
 
 DEF_OP(Lshl) {
   auto Op = IROp->C<IR::IROp_Lshl>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  uint64_t Src1 = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[0]);
-  uint64_t Src2 = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[1]);
-  uint8_t Mask = OpSize * 8 - 1;
+  const uint64_t Src1 = *GetSrc<uint64_t*>(Data->SSAData, Op->Src1);
+  const uint64_t Src2 = *GetSrc<uint64_t*>(Data->SSAData, Op->Src2);
+  const uint8_t Mask = OpSize * 8 - 1;
   switch (OpSize) {
     case 4:
       GD = static_cast<uint32_t>(Src1) << (Src2 & Mask);
@@ -414,11 +414,11 @@ DEF_OP(Lshl) {
 
 DEF_OP(Lshr) {
   auto Op = IROp->C<IR::IROp_Lshr>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  uint64_t Src1 = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[0]);
-  uint64_t Src2 = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[1]);
-  uint8_t Mask = OpSize * 8 - 1;
+  const uint64_t Src1 = *GetSrc<uint64_t*>(Data->SSAData, Op->Src1);
+  const uint64_t Src2 = *GetSrc<uint64_t*>(Data->SSAData, Op->Src2);
+  const uint8_t Mask = OpSize * 8 - 1;
   switch (OpSize) {
     case 4:
       GD = static_cast<uint32_t>(Src1) >> (Src2 & Mask);
@@ -432,11 +432,11 @@ DEF_OP(Lshr) {
 
 DEF_OP(Ashr) {
   auto Op = IROp->C<IR::IROp_Ashr>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  uint64_t Src1 = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[0]);
-  uint64_t Src2 = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[1]);
-  uint8_t Mask = OpSize * 8 - 1;
+  const uint64_t Src1 = *GetSrc<uint64_t*>(Data->SSAData, Op->Src1);
+  const uint64_t Src2 = *GetSrc<uint64_t*>(Data->SSAData, Op->Src2);
+  const uint8_t Mask = OpSize * 8 - 1;
   switch (OpSize) {
     case 4:
       GD = (uint32_t)(static_cast<int32_t>(Src1) >> (Src2 & Mask));
@@ -450,12 +450,12 @@ DEF_OP(Ashr) {
 
 DEF_OP(Ror) {
   auto Op = IROp->C<IR::IROp_Ror>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  uint64_t Src1 = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[0]);
-  uint64_t Src2 = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[1]);
-  auto Ror = [] (auto In, auto R) {
-    auto RotateMask = sizeof(In) * 8 - 1;
+  const uint64_t Src1 = *GetSrc<uint64_t*>(Data->SSAData, Op->Src1);
+  const uint64_t Src2 = *GetSrc<uint64_t*>(Data->SSAData, Op->Src2);
+  const auto Ror = [] (auto In, auto R) {
+    const auto RotateMask = sizeof(In) * 8 - 1;
     R &= RotateMask;
     return (In >> R) | (In << (sizeof(In) * 8 - R));
   };
@@ -474,11 +474,11 @@ DEF_OP(Ror) {
 
 DEF_OP(Extr) {
   auto Op = IROp->C<IR::IROp_Extr>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  uint64_t Src1 = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[0]);
-  uint64_t Src2 = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[1]);
-  auto Extr = [] (auto Src1, auto Src2, uint8_t lsb) -> decltype(Src1) {
+  const uint64_t Src1 = *GetSrc<uint64_t*>(Data->SSAData, Op->Upper);
+  const uint64_t Src2 = *GetSrc<uint64_t*>(Data->SSAData, Op->Lower);
+  const auto Extr = [] (auto Src1, auto Src2, uint8_t lsb) -> decltype(Src1) {
     __uint128_t Result{};
     Result = Src1;
     Result <<= sizeof(Src1) * 8;
@@ -500,7 +500,7 @@ DEF_OP(Extr) {
 }
 
 DEF_OP(PDep) {
-  const auto Op = IROp->C<IR::IROp_PExt>();
+  const auto Op = IROp->C<IR::IROp_PDep>();
   const auto OpSize = IROp->Size;
 
   if (OpSize != 4 && OpSize != 8) {
@@ -508,10 +508,10 @@ DEF_OP(PDep) {
     return;
   }
 
-  const uint64_t Input = OpSize == 4 ? *GetSrc<uint32_t*>(Data->SSAData, Op->Args(0))
-                                     : *GetSrc<uint64_t*>(Data->SSAData, Op->Args(0));
-  uint64_t Mask = OpSize == 4 ? *GetSrc<uint32_t*>(Data->SSAData, Op->Args(1))
-                              : *GetSrc<uint64_t*>(Data->SSAData, Op->Args(1));
+  const uint64_t Input = OpSize == 4 ? *GetSrc<uint32_t*>(Data->SSAData, Op->Input)
+                                     : *GetSrc<uint64_t*>(Data->SSAData, Op->Input);
+  uint64_t Mask = OpSize == 4 ? *GetSrc<uint32_t*>(Data->SSAData, Op->Mask)
+                              : *GetSrc<uint64_t*>(Data->SSAData, Op->Mask);
 
   uint64_t Result = 0;
   for (uint64_t Index = 0; Mask > 0; Index++) {
@@ -532,10 +532,10 @@ DEF_OP(PExt) {
     return;
   }
 
-  const uint64_t Input = OpSize == 4 ? *GetSrc<uint32_t*>(Data->SSAData, Op->Args(0))
-                                     : *GetSrc<uint64_t*>(Data->SSAData, Op->Args(0));
-  uint64_t Mask = OpSize == 4 ? *GetSrc<uint32_t*>(Data->SSAData, Op->Args(1))
-                              : *GetSrc<uint64_t*>(Data->SSAData, Op->Args(1));
+  const uint64_t Input = OpSize == 4 ? *GetSrc<uint32_t*>(Data->SSAData, Op->Input)
+                                     : *GetSrc<uint64_t*>(Data->SSAData, Op->Input);
+  uint64_t Mask = OpSize == 4 ? *GetSrc<uint32_t*>(Data->SSAData, Op->Mask)
+                              : *GetSrc<uint64_t*>(Data->SSAData, Op->Mask);
 
   uint64_t Result = 0;
   for (uint64_t Offset = 0; Mask > 0; Offset++) {
@@ -549,39 +549,39 @@ DEF_OP(PExt) {
 
 DEF_OP(LDiv) {
   auto Op = IROp->C<IR::IROp_LDiv>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   // Each source is OpSize in size
   // So you can have up to a 128bit divide from x86-64
   switch (OpSize) {
     case 2: {
-      uint16_t SrcLow = *GetSrc<uint16_t*>(Data->SSAData, Op->Header.Args[0]);
-      uint16_t SrcHigh = *GetSrc<uint16_t*>(Data->SSAData, Op->Header.Args[1]);
-      int16_t Divisor = *GetSrc<uint16_t*>(Data->SSAData, Op->Header.Args[2]);
-      int32_t Source = (static_cast<uint32_t>(SrcHigh) << 16) | SrcLow;
-      int32_t Res = Source / Divisor;
+      const uint16_t SrcLow = *GetSrc<uint16_t*>(Data->SSAData, Op->Lower);
+      const uint16_t SrcHigh = *GetSrc<uint16_t*>(Data->SSAData, Op->Upper);
+      const int16_t Divisor = *GetSrc<uint16_t*>(Data->SSAData, Op->Divisor);
+      const int32_t Source = (static_cast<uint32_t>(SrcHigh) << 16) | SrcLow;
+      const int32_t Res = Source / Divisor;
 
       // We only store the lower bits of the result
       GD = static_cast<int16_t>(Res);
       break;
     }
     case 4: {
-      uint32_t SrcLow = *GetSrc<uint32_t*>(Data->SSAData, Op->Header.Args[0]);
-      uint32_t SrcHigh = *GetSrc<uint32_t*>(Data->SSAData, Op->Header.Args[1]);
-      int32_t Divisor = *GetSrc<uint32_t*>(Data->SSAData, Op->Header.Args[2]);
-      int64_t Source = (static_cast<uint64_t>(SrcHigh) << 32) | SrcLow;
-      int64_t Res = Source / Divisor;
+      const uint32_t SrcLow = *GetSrc<uint32_t*>(Data->SSAData, Op->Lower);
+      const uint32_t SrcHigh = *GetSrc<uint32_t*>(Data->SSAData, Op->Upper);
+      const int32_t Divisor = *GetSrc<uint32_t*>(Data->SSAData, Op->Divisor);
+      const int64_t Source = (static_cast<uint64_t>(SrcHigh) << 32) | SrcLow;
+      const int64_t Res = Source / Divisor;
 
       // We only store the lower bits of the result
       GD = static_cast<int32_t>(Res);
       break;
     }
     case 8: {
-      uint64_t SrcLow = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[0]);
-      uint64_t SrcHigh = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[1]);
-      int64_t Divisor = *GetSrc<int64_t*>(Data->SSAData, Op->Header.Args[2]);
-      __int128_t Source = (static_cast<__int128_t>(SrcHigh) << 64) | SrcLow;
-      __int128_t Res = Source / Divisor;
+      const uint64_t SrcLow = *GetSrc<uint64_t*>(Data->SSAData, Op->Lower);
+      const uint64_t SrcHigh = *GetSrc<uint64_t*>(Data->SSAData, Op->Upper);
+      const int64_t Divisor = *GetSrc<int64_t*>(Data->SSAData, Op->Divisor);
+      const __int128_t Source = (static_cast<__int128_t>(SrcHigh) << 64) | SrcLow;
+      const __int128_t Res = Source / Divisor;
 
       // We only store the lower bits of the result
       memcpy(GDP, &Res, OpSize);
@@ -593,39 +593,39 @@ DEF_OP(LDiv) {
 
 DEF_OP(LUDiv) {
   auto Op = IROp->C<IR::IROp_LUDiv>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   // Each source is OpSize in size
   // So you can have up to a 128bit divide from x86-64
   switch (OpSize) {
     case 2: {
-      uint16_t SrcLow = *GetSrc<uint16_t*>(Data->SSAData, Op->Header.Args[0]);
-      uint16_t SrcHigh = *GetSrc<uint16_t*>(Data->SSAData, Op->Header.Args[1]);
-      uint16_t Divisor = *GetSrc<uint16_t*>(Data->SSAData, Op->Header.Args[2]);
-      uint32_t Source = (static_cast<uint32_t>(SrcHigh) << 16) | SrcLow;
-      uint32_t Res = Source / Divisor;
+      const uint16_t SrcLow = *GetSrc<uint16_t*>(Data->SSAData, Op->Lower);
+      const uint16_t SrcHigh = *GetSrc<uint16_t*>(Data->SSAData, Op->Upper);
+      const uint16_t Divisor = *GetSrc<uint16_t*>(Data->SSAData, Op->Divisor);
+      const uint32_t Source = (static_cast<uint32_t>(SrcHigh) << 16) | SrcLow;
+      const uint32_t Res = Source / Divisor;
 
       // We only store the lower bits of the result
       GD = static_cast<uint16_t>(Res);
       break;
     }
     case 4: {
-      uint32_t SrcLow = *GetSrc<uint32_t*>(Data->SSAData, Op->Header.Args[0]);
-      uint32_t SrcHigh = *GetSrc<uint32_t*>(Data->SSAData, Op->Header.Args[1]);
-      uint32_t Divisor = *GetSrc<uint32_t*>(Data->SSAData, Op->Header.Args[2]);
-      uint64_t Source = (static_cast<uint64_t>(SrcHigh) << 32) | SrcLow;
-      uint64_t Res = Source / Divisor;
+      const uint32_t SrcLow = *GetSrc<uint32_t*>(Data->SSAData, Op->Lower);
+      const uint32_t SrcHigh = *GetSrc<uint32_t*>(Data->SSAData, Op->Upper);
+      const uint32_t Divisor = *GetSrc<uint32_t*>(Data->SSAData, Op->Divisor);
+      const uint64_t Source = (static_cast<uint64_t>(SrcHigh) << 32) | SrcLow;
+      const uint64_t Res = Source / Divisor;
 
       // We only store the lower bits of the result
       GD = static_cast<uint32_t>(Res);
       break;
     }
     case 8: {
-      uint64_t SrcLow = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[0]);
-      uint64_t SrcHigh = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[1]);
-      uint64_t Divisor = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[2]);
-      __uint128_t Source = (static_cast<__uint128_t>(SrcHigh) << 64) | SrcLow;
-      __uint128_t Res = Source / Divisor;
+      const uint64_t SrcLow = *GetSrc<uint64_t*>(Data->SSAData, Op->Lower);
+      const uint64_t SrcHigh = *GetSrc<uint64_t*>(Data->SSAData, Op->Upper);
+      const uint64_t Divisor = *GetSrc<uint64_t*>(Data->SSAData, Op->Divisor);
+      const __uint128_t Source = (static_cast<__uint128_t>(SrcHigh) << 64) | SrcLow;
+      const __uint128_t Res = Source / Divisor;
 
       // We only store the lower bits of the result
       memcpy(GDP, &Res, OpSize);
@@ -637,39 +637,39 @@ DEF_OP(LUDiv) {
 
 DEF_OP(LRem) {
   auto Op = IROp->C<IR::IROp_LRem>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   // Each source is OpSize in size
   // So you can have up to a 128bit Remainder from x86-64
   switch (OpSize) {
     case 2: {
-      uint16_t SrcLow = *GetSrc<uint16_t*>(Data->SSAData, Op->Header.Args[0]);
-      uint16_t SrcHigh = *GetSrc<uint16_t*>(Data->SSAData, Op->Header.Args[1]);
-      int16_t Divisor = *GetSrc<uint16_t*>(Data->SSAData, Op->Header.Args[2]);
-      int32_t Source = (static_cast<uint32_t>(SrcHigh) << 16) | SrcLow;
-      int32_t Res = Source % Divisor;
+      const uint16_t SrcLow = *GetSrc<uint16_t*>(Data->SSAData, Op->Lower);
+      const uint16_t SrcHigh = *GetSrc<uint16_t*>(Data->SSAData, Op->Upper);
+      const int16_t Divisor = *GetSrc<uint16_t*>(Data->SSAData, Op->Divisor);
+      const int32_t Source = (static_cast<uint32_t>(SrcHigh) << 16) | SrcLow;
+      const int32_t Res = Source % Divisor;
 
       // We only store the lower bits of the result
       GD = static_cast<int16_t>(Res);
       break;
     }
     case 4: {
-      uint32_t SrcLow = *GetSrc<uint32_t*>(Data->SSAData, Op->Header.Args[0]);
-      uint32_t SrcHigh = *GetSrc<uint32_t*>(Data->SSAData, Op->Header.Args[1]);
-      int32_t Divisor = *GetSrc<uint32_t*>(Data->SSAData, Op->Header.Args[2]);
-      int64_t Source = (static_cast<uint64_t>(SrcHigh) << 32) | SrcLow;
-      int64_t Res = Source % Divisor;
+      const uint32_t SrcLow = *GetSrc<uint32_t*>(Data->SSAData, Op->Lower);
+      const uint32_t SrcHigh = *GetSrc<uint32_t*>(Data->SSAData, Op->Upper);
+      const int32_t Divisor = *GetSrc<uint32_t*>(Data->SSAData, Op->Divisor);
+      const int64_t Source = (static_cast<uint64_t>(SrcHigh) << 32) | SrcLow;
+      const int64_t Res = Source % Divisor;
 
       // We only store the lower bits of the result
       GD = static_cast<int32_t>(Res);
       break;
     }
     case 8: {
-      uint64_t SrcLow = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[0]);
-      uint64_t SrcHigh = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[1]);
-      int64_t Divisor = *GetSrc<int64_t*>(Data->SSAData, Op->Header.Args[2]);
-      __int128_t Source = (static_cast<__int128_t>(SrcHigh) << 64) | SrcLow;
-      __int128_t Res = Source % Divisor;
+      const uint64_t SrcLow = *GetSrc<uint64_t*>(Data->SSAData, Op->Lower);
+      const uint64_t SrcHigh = *GetSrc<uint64_t*>(Data->SSAData, Op->Upper);
+      const int64_t Divisor = *GetSrc<int64_t*>(Data->SSAData, Op->Divisor);
+      const __int128_t Source = (static_cast<__int128_t>(SrcHigh) << 64) | SrcLow;
+      const __int128_t Res = Source % Divisor;
       // We only store the lower bits of the result
       memcpy(GDP, &Res, OpSize);
       break;
@@ -680,39 +680,39 @@ DEF_OP(LRem) {
 
 DEF_OP(LURem) {
   auto Op = IROp->C<IR::IROp_LURem>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   // Each source is OpSize in size
   // So you can have up to a 128bit Remainder from x86-64
   switch (OpSize) {
     case 2: {
-      uint16_t SrcLow = *GetSrc<uint16_t*>(Data->SSAData, Op->Header.Args[0]);
-      uint16_t SrcHigh = *GetSrc<uint16_t*>(Data->SSAData, Op->Header.Args[1]);
-      uint16_t Divisor = *GetSrc<uint16_t*>(Data->SSAData, Op->Header.Args[2]);
-      uint32_t Source = (static_cast<uint32_t>(SrcHigh) << 16) | SrcLow;
-      uint32_t Res = Source % Divisor;
+      const uint16_t SrcLow = *GetSrc<uint16_t*>(Data->SSAData, Op->Lower);
+      const uint16_t SrcHigh = *GetSrc<uint16_t*>(Data->SSAData, Op->Upper);
+      const uint16_t Divisor = *GetSrc<uint16_t*>(Data->SSAData, Op->Divisor);
+      const uint32_t Source = (static_cast<uint32_t>(SrcHigh) << 16) | SrcLow;
+      const uint32_t Res = Source % Divisor;
 
       // We only store the lower bits of the result
       GD = static_cast<uint16_t>(Res);
       break;
     }
     case 4: {
-      uint32_t SrcLow = *GetSrc<uint32_t*>(Data->SSAData, Op->Header.Args[0]);
-      uint32_t SrcHigh = *GetSrc<uint32_t*>(Data->SSAData, Op->Header.Args[1]);
-      uint32_t Divisor = *GetSrc<uint32_t*>(Data->SSAData, Op->Header.Args[2]);
-      uint64_t Source = (static_cast<uint64_t>(SrcHigh) << 32) | SrcLow;
-      uint64_t Res = Source % Divisor;
+      const uint32_t SrcLow = *GetSrc<uint32_t*>(Data->SSAData, Op->Lower);
+      const uint32_t SrcHigh = *GetSrc<uint32_t*>(Data->SSAData, Op->Upper);
+      const uint32_t Divisor = *GetSrc<uint32_t*>(Data->SSAData, Op->Divisor);
+      const uint64_t Source = (static_cast<uint64_t>(SrcHigh) << 32) | SrcLow;
+      const uint64_t Res = Source % Divisor;
 
       // We only store the lower bits of the result
       GD = static_cast<uint32_t>(Res);
       break;
     }
     case 8: {
-      uint64_t SrcLow = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[0]);
-      uint64_t SrcHigh = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[1]);
-      uint64_t Divisor = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[2]);
-      __uint128_t Source = (static_cast<__uint128_t>(SrcHigh) << 64) | SrcLow;
-      __uint128_t Res = Source % Divisor;
+      const uint64_t SrcLow = *GetSrc<uint64_t*>(Data->SSAData, Op->Lower);
+      const uint64_t SrcHigh = *GetSrc<uint64_t*>(Data->SSAData, Op->Upper);
+      const uint64_t Divisor = *GetSrc<uint64_t*>(Data->SSAData, Op->Divisor);
+      const __uint128_t Source = (static_cast<__uint128_t>(SrcHigh) << 64) | SrcLow;
+      const __uint128_t Res = Source % Divisor;
       // We only store the lower bits of the result
       memcpy(GDP, &Res, OpSize);
       break;
@@ -723,62 +723,62 @@ DEF_OP(LURem) {
 
 DEF_OP(Not) {
   auto Op = IROp->C<IR::IROp_Not>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  uint64_t Src = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[0]);
+  const uint64_t Src = *GetSrc<uint64_t*>(Data->SSAData, Op->Src);
   const uint64_t mask[9]= { 0, 0xFF, 0xFFFF, 0, 0xFFFFFFFF, 0, 0, 0, 0xFFFFFFFFFFFFFFFFULL };
-  uint64_t Mask = mask[OpSize];
+  const uint64_t Mask = mask[OpSize];
   GD = (~Src) & Mask;
 }
 
 DEF_OP(Popcount) {
   auto Op = IROp->C<IR::IROp_Popcount>();
-  uint64_t Src = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[0]);
+  const uint64_t Src = *GetSrc<uint64_t*>(Data->SSAData, Op->Src);
   GD = std::popcount(Src);
 }
 
 DEF_OP(FindLSB) {
   auto Op = IROp->C<IR::IROp_FindLSB>();
-  uint64_t Src = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[0]);
-  uint64_t Result = FindFirstSetBit(Src);
+  const uint64_t Src = *GetSrc<uint64_t*>(Data->SSAData, Op->Src);
+  const uint64_t Result = FindFirstSetBit(Src);
   GD = Result - 1;
 }
 
 DEF_OP(FindMSB) {
   auto Op = IROp->C<IR::IROp_FindMSB>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   switch (OpSize) {
-    case 1: GD = (OpSize * 8 - std::countl_zero(*GetSrc<uint8_t*>(Data->SSAData, Op->Header.Args[0]))) - 1; break;
-    case 2: GD = (OpSize * 8 - std::countl_zero(*GetSrc<uint16_t*>(Data->SSAData, Op->Header.Args[0]))) - 1; break;
-    case 4: GD = (OpSize * 8 - std::countl_zero(*GetSrc<uint32_t*>(Data->SSAData, Op->Header.Args[0]))) - 1; break;
-    case 8: GD = (OpSize * 8 - std::countl_zero(*GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[0]))) - 1; break;
+    case 1: GD = (OpSize * 8 - std::countl_zero(*GetSrc<uint8_t*>(Data->SSAData, Op->Src))) - 1; break;
+    case 2: GD = (OpSize * 8 - std::countl_zero(*GetSrc<uint16_t*>(Data->SSAData, Op->Src))) - 1; break;
+    case 4: GD = (OpSize * 8 - std::countl_zero(*GetSrc<uint32_t*>(Data->SSAData, Op->Src))) - 1; break;
+    case 8: GD = (OpSize * 8 - std::countl_zero(*GetSrc<uint64_t*>(Data->SSAData, Op->Src))) - 1; break;
     default: LOGMAN_MSG_A_FMT("Unknown FindMSB size: {}", OpSize); break;
   }
 }
 
 DEF_OP(FindTrailingZeros) {
   auto Op = IROp->C<IR::IROp_FindTrailingZeros>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   switch (OpSize) {
     case 1: {
-      auto Src = *GetSrc<uint8_t*>(Data->SSAData, Op->Header.Args[0]);
+      const auto Src = *GetSrc<uint8_t*>(Data->SSAData, Op->Src);
       GD = std::countr_zero(Src);
       break;
     }
     case 2: {
-      auto Src = *GetSrc<uint16_t*>(Data->SSAData, Op->Header.Args[0]);
+      const auto Src = *GetSrc<uint16_t*>(Data->SSAData, Op->Src);
       GD = std::countr_zero(Src);
       break;
     }
     case 4: {
-      auto Src = *GetSrc<uint32_t*>(Data->SSAData, Op->Header.Args[0]);
+      const auto Src = *GetSrc<uint32_t*>(Data->SSAData, Op->Src);
       GD = std::countr_zero(Src);
       break;
     }
     case 8: {
-      auto Src = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[0]);
+      const auto Src = *GetSrc<uint64_t*>(Data->SSAData, Op->Src);
       GD = std::countr_zero(Src);
       break;
     }
@@ -788,26 +788,26 @@ DEF_OP(FindTrailingZeros) {
 
 DEF_OP(CountLeadingZeroes) {
   auto Op = IROp->C<IR::IROp_CountLeadingZeroes>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   switch (OpSize) {
     case 1: {
-      auto Src = *GetSrc<uint8_t*>(Data->SSAData, Op->Header.Args[0]);
+      const auto Src = *GetSrc<uint8_t*>(Data->SSAData, Op->Src);
       GD = std::countl_zero(Src);
       break;
     }
     case 2: {
-      auto Src = *GetSrc<uint16_t*>(Data->SSAData, Op->Header.Args[0]);
+      const auto Src = *GetSrc<uint16_t*>(Data->SSAData, Op->Src);
       GD = std::countl_zero(Src);
       break;
     }
     case 4: {
-      auto Src = *GetSrc<uint32_t*>(Data->SSAData, Op->Header.Args[0]);
+      const auto Src = *GetSrc<uint32_t*>(Data->SSAData, Op->Src);
       GD = std::countl_zero(Src);
       break;
     }
     case 8: {
-      auto Src = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[0]);
+      const auto Src = *GetSrc<uint64_t*>(Data->SSAData, Op->Src);
       GD = std::countl_zero(Src);
       break;
     }
@@ -817,12 +817,12 @@ DEF_OP(CountLeadingZeroes) {
 
 DEF_OP(Rev) {
   auto Op = IROp->C<IR::IROp_Rev>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   switch (OpSize) {
-    case 2: GD = BSwap16(*GetSrc<uint16_t*>(Data->SSAData, Op->Header.Args[0])); break;
-    case 4: GD = BSwap32(*GetSrc<uint32_t*>(Data->SSAData, Op->Header.Args[0])); break;
-    case 8: GD = BSwap64(*GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[0])); break;
+    case 2: GD = BSwap16(*GetSrc<uint16_t*>(Data->SSAData, Op->Src)); break;
+    case 4: GD = BSwap32(*GetSrc<uint32_t*>(Data->SSAData, Op->Src)); break;
+    case 8: GD = BSwap64(*GetSrc<uint64_t*>(Data->SSAData, Op->Src)); break;
     default: LOGMAN_MSG_A_FMT("Unknown REV size: {}", OpSize); break;
   }
 }
@@ -830,12 +830,13 @@ DEF_OP(Rev) {
 DEF_OP(Bfi) {
   auto Op = IROp->C<IR::IROp_Bfi>();
   uint64_t SourceMask = (1ULL << Op->Width) - 1;
-  if (Op->Width == 64)
+  if (Op->Width == 64) {
     SourceMask = ~0ULL;
-  uint64_t DestMask = ~(SourceMask << Op->lsb);
-  uint64_t Src1 = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[0]);
-  uint64_t Src2 = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[1]);
-  uint64_t Res = (Src1 & DestMask) | ((Src2 & SourceMask) << Op->lsb);
+  }
+  const uint64_t DestMask = ~(SourceMask << Op->lsb);
+  const uint64_t Src1 = *GetSrc<uint64_t*>(Data->SSAData, Op->Dest);
+  const uint64_t Src2 = *GetSrc<uint64_t*>(Data->SSAData, Op->Src);
+  const uint64_t Res = (Src1 & DestMask) | ((Src2 & SourceMask) << Op->lsb);
   GD = Res;
 }
 
@@ -844,10 +845,11 @@ DEF_OP(Bfe) {
 
   LOGMAN_THROW_A_FMT(IROp->Size <= 8, "OpSize is too large for BFE: {}", IROp->Size);
   uint64_t SourceMask = (1ULL << Op->Width) - 1;
-  if (Op->Width == 64)
+  if (Op->Width == 64) {
     SourceMask = ~0ULL;
+  }
   SourceMask <<= Op->lsb;
-  uint64_t Src = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[0]);
+  const uint64_t Src = *GetSrc<uint64_t*>(Data->SSAData, Op->Src);
   GD = (Src & SourceMask) >> Op->lsb;
 }
 
@@ -855,9 +857,9 @@ DEF_OP(Sbfe) {
   auto Op = IROp->C<IR::IROp_Sbfe>();
 
   LOGMAN_THROW_A_FMT(IROp->Size <= 8, "OpSize is too large for SBFE: {}", IROp->Size);
-  int64_t Src = *GetSrc<int64_t*>(Data->SSAData, Op->Header.Args[0]);
-  uint64_t ShiftLeftAmount = (64 - (Op->Width + Op->lsb));
-  uint64_t ShiftRightAmount = ShiftLeftAmount + Op->lsb;
+  int64_t Src = *GetSrc<int64_t*>(Data->SSAData, Op->Src);
+  const uint64_t ShiftLeftAmount = (64 - (Op->Width + Op->lsb));
+  const uint64_t ShiftRightAmount = ShiftLeftAmount + Op->lsb;
   Src <<= ShiftLeftAmount;
   Src >>= ShiftRightAmount;
   GD = Src;
@@ -865,20 +867,20 @@ DEF_OP(Sbfe) {
 
 DEF_OP(Select) {
   auto Op = IROp->C<IR::IROp_Select>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  uint64_t Src1 = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[0]);
-  uint64_t Src2 = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[1]);
+  const uint64_t Src1 = *GetSrc<uint64_t*>(Data->SSAData, Op->Cmp1);
+  const uint64_t Src2 = *GetSrc<uint64_t*>(Data->SSAData, Op->Cmp2);
 
   uint64_t ArgTrue;
   uint64_t ArgFalse;
 
   if (OpSize == 4) {
-    ArgTrue = *GetSrc<uint32_t*>(Data->SSAData, Op->Header.Args[2]);
-    ArgFalse = *GetSrc<uint32_t*>(Data->SSAData, Op->Header.Args[3]);
+    ArgTrue = *GetSrc<uint32_t*>(Data->SSAData, Op->TrueVal);
+    ArgFalse = *GetSrc<uint32_t*>(Data->SSAData, Op->FalseVal);
   } else {
-    ArgTrue = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[2]);
-    ArgFalse = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[3]);
+    ArgTrue = *GetSrc<uint64_t*>(Data->SSAData, Op->TrueVal);
+    ArgFalse = *GetSrc<uint64_t*>(Data->SSAData, Op->FalseVal);
   }
 
   bool CompResult;
@@ -894,7 +896,7 @@ DEF_OP(Select) {
 DEF_OP(VExtractToGPR) {
   auto Op = IROp->C<IR::IROp_VExtractToGPR>();
 
-  uint32_t SourceSize = GetOpSize(Data->CurrentIR, Op->Header.Args[0]);
+  const uint32_t SourceSize = GetOpSize(Data->CurrentIR, Op->Vector);
 
   LOGMAN_THROW_A_FMT(IROp->Size <= 16, "OpSize is too large for VExtractToGPR: {}", IROp->Size);
 
@@ -904,7 +906,7 @@ DEF_OP(VExtractToGPR) {
     if (Op->Header.ElementSize == 8)
       SourceMask = ~0ULL;
 
-    __uint128_t Src = *GetSrc<__uint128_t*>(Data->SSAData, Op->Header.Args[0]);
+    __uint128_t Src = *GetSrc<__uint128_t*>(Data->SSAData, Op->Vector);
     Src >>= Shift;
     Src &= SourceMask;
     memcpy(GDP, &Src, Op->Header.ElementSize);
@@ -915,7 +917,7 @@ DEF_OP(VExtractToGPR) {
     if (Op->Header.ElementSize == 8)
       SourceMask = ~0ULL;
 
-    uint64_t Src = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[0]);
+    uint64_t Src = *GetSrc<uint64_t*>(Data->SSAData, Op->Vector);
     Src >>= Shift;
     Src &= SourceMask;
     GD = Src;
@@ -924,25 +926,25 @@ DEF_OP(VExtractToGPR) {
 
 DEF_OP(Float_ToGPR_ZS) {
   auto Op = IROp->C<IR::IROp_Float_ToGPR_ZS>();
-  uint16_t Conv = (IROp->Size << 8) | Op->SrcElementSize;
+  const uint16_t Conv = (IROp->Size << 8) | Op->SrcElementSize;
   switch (Conv) {
     case 0x0804: { // int64_t <- float
-      int64_t Dst = (int64_t)std::trunc(*GetSrc<float*>(Data->SSAData, Op->Header.Args[0]));
+      const int64_t Dst = (int64_t)std::trunc(*GetSrc<float*>(Data->SSAData, Op->Scalar));
       memcpy(GDP, &Dst, IROp->Size);
       break;
     }
     case 0x0808: { // int64_t <- double
-      int64_t Dst = (int64_t)std::trunc(*GetSrc<double*>(Data->SSAData, Op->Header.Args[0]));
+      const int64_t Dst = (int64_t)std::trunc(*GetSrc<double*>(Data->SSAData, Op->Scalar));
       memcpy(GDP, &Dst, IROp->Size);
       break;
     }
     case 0x0404: { // int32_t <- float
-      int32_t Dst = (int32_t)std::trunc(*GetSrc<float*>(Data->SSAData, Op->Header.Args[0]));
+      const int32_t Dst = (int32_t)std::trunc(*GetSrc<float*>(Data->SSAData, Op->Scalar));
       memcpy(GDP, &Dst, IROp->Size);
       break;
     }
     case 0x0408: { // int32_t <- double
-      int32_t Dst = (int32_t)std::trunc(*GetSrc<double*>(Data->SSAData, Op->Header.Args[0]));
+      const int32_t Dst = (int32_t)std::trunc(*GetSrc<double*>(Data->SSAData, Op->Scalar));
       memcpy(GDP, &Dst, IROp->Size);
       break;
     }
@@ -951,25 +953,25 @@ DEF_OP(Float_ToGPR_ZS) {
 
 DEF_OP(Float_ToGPR_S) {
   auto Op = IROp->C<IR::IROp_Float_ToGPR_S>();
-  uint16_t Conv = (IROp->Size << 8) | Op->SrcElementSize;
+  const uint16_t Conv = (IROp->Size << 8) | Op->SrcElementSize;
   switch (Conv) {
     case 0x0804: { // int64_t <- float
-      int64_t Dst = (int64_t)std::nearbyint(*GetSrc<float*>(Data->SSAData, Op->Header.Args[0]));
+      const int64_t Dst = (int64_t)std::nearbyint(*GetSrc<float*>(Data->SSAData, Op->Scalar));
       memcpy(GDP, &Dst, IROp->Size);
       break;
     }
     case 0x0808: { // int64_t <- double
-      int64_t Dst = (int64_t)std::nearbyint(*GetSrc<double*>(Data->SSAData, Op->Header.Args[0]));
+      const int64_t Dst = (int64_t)std::nearbyint(*GetSrc<double*>(Data->SSAData, Op->Scalar));
       memcpy(GDP, &Dst, IROp->Size);
       break;
     }
     case 0x0404: { // int32_t <- float
-      int32_t Dst = (int32_t)std::nearbyint(*GetSrc<float*>(Data->SSAData, Op->Header.Args[0]));
+      const int32_t Dst = (int32_t)std::nearbyint(*GetSrc<float*>(Data->SSAData, Op->Scalar));
       memcpy(GDP, &Dst, IROp->Size);
       break;
     }
     case 0x0408: { // int32_t <- double
-      int32_t Dst = (int32_t)std::nearbyint(*GetSrc<double*>(Data->SSAData, Op->Header.Args[0]));
+      const int32_t Dst = (int32_t)std::nearbyint(*GetSrc<double*>(Data->SSAData, Op->Scalar));
       memcpy(GDP, &Dst, IROp->Size);
       break;
     }
@@ -980,9 +982,9 @@ DEF_OP(FCmp) {
   auto Op = IROp->C<IR::IROp_FCmp>();
   uint32_t ResultFlags{};
   if (Op->ElementSize == 4) {
-    float Src1 = *GetSrc<float*>(Data->SSAData, Op->Header.Args[0]);
-    float Src2 = *GetSrc<float*>(Data->SSAData, Op->Header.Args[1]);
-    bool Unordered = std::isnan(Src1) || std::isnan(Src2);
+    const float Src1 = *GetSrc<float*>(Data->SSAData, Op->Scalar1);
+    const float Src2 = *GetSrc<float*>(Data->SSAData, Op->Scalar2);
+    const bool Unordered = std::isnan(Src1) || std::isnan(Src2);
     if (Op->Flags & (1 << IR::FCMP_FLAG_LT)) {
       if (Unordered || (Src1 < Src2)) {
         ResultFlags |= (1 << IR::FCMP_FLAG_LT);
@@ -1000,9 +1002,9 @@ DEF_OP(FCmp) {
     }
   }
   else {
-    double Src1 = *GetSrc<double*>(Data->SSAData, Op->Header.Args[0]);
-    double Src2 = *GetSrc<double*>(Data->SSAData, Op->Header.Args[1]);
-    bool Unordered = std::isnan(Src1) || std::isnan(Src2);
+    const double Src1 = *GetSrc<double*>(Data->SSAData, Op->Scalar1);
+    const double Src2 = *GetSrc<double*>(Data->SSAData, Op->Scalar2);
+    const bool Unordered = std::isnan(Src1) || std::isnan(Src2);
     if (Op->Flags & (1 << IR::FCMP_FLAG_LT)) {
       if (Unordered || (Src1 < Src2)) {
         ResultFlags |= (1 << IR::FCMP_FLAG_LT);

--- a/External/FEXCore/Source/Interface/Core/Interpreter/ConversionOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/ConversionOps.cpp
@@ -14,10 +14,10 @@ namespace FEXCore::CPU {
 #define DEF_OP(x) void InterpreterOps::Op_##x(IR::IROp_Header *IROp, IROpData *Data, IR::NodeID Node)
 DEF_OP(VInsGPR) {
   auto Op = IROp->C<IR::IROp_VInsGPR>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  __uint128_t Src1 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Header.Args[0]);
-  __uint128_t Src2 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Header.Args[1]);
+  auto Src1 = *GetSrc<__uint128_t*>(Data->SSAData, Op->DestVector);
+  auto Src2 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Src);
 
   uint64_t Offset = Op->DestIdx * Op->Header.ElementSize * 8;
   __uint128_t Mask = (1ULL << (Op->Header.ElementSize * 8)) - 1;
@@ -35,31 +35,31 @@ DEF_OP(VInsGPR) {
 
 DEF_OP(VCastFromGPR) {
   auto Op = IROp->C<IR::IROp_VCastFromGPR>();
-  memcpy(GDP, GetSrc<void*>(Data->SSAData, Op->Header.Args[0]), Op->Header.ElementSize);
+  memcpy(GDP, GetSrc<void*>(Data->SSAData, Op->Src), Op->Header.ElementSize);
 }
 
 DEF_OP(Float_FromGPR_S) {
   auto Op = IROp->C<IR::IROp_Float_FromGPR_S>();
 
-  uint16_t Conv = (Op->Header.ElementSize << 8) | Op->SrcElementSize;
+  const uint16_t Conv = (Op->Header.ElementSize << 8) | Op->SrcElementSize;
   switch (Conv) {
     case 0x0404: { // Float <- int32_t
-      float Dst = (float)*GetSrc<int32_t*>(Data->SSAData, Op->Header.Args[0]);
+      const float Dst = (float)*GetSrc<int32_t*>(Data->SSAData, Op->Src);
       memcpy(GDP, &Dst, Op->Header.ElementSize);
       break;
     }
     case 0x0408: { // Float <- int64_t
-      float Dst = (float)*GetSrc<int64_t*>(Data->SSAData, Op->Header.Args[0]);
+      const float Dst = (float)*GetSrc<int64_t*>(Data->SSAData, Op->Src);
       memcpy(GDP, &Dst, Op->Header.ElementSize);
       break;
     }
     case 0x0804: { // Double <- int32_t
-      double Dst = (double)*GetSrc<int32_t*>(Data->SSAData, Op->Header.Args[0]);
+      const double Dst = (double)*GetSrc<int32_t*>(Data->SSAData, Op->Src);
       memcpy(GDP, &Dst, Op->Header.ElementSize);
       break;
     }
     case 0x0808: { // Double <- int64_t
-      double Dst = (double)*GetSrc<int64_t*>(Data->SSAData, Op->Header.Args[0]);
+      const double Dst = (double)*GetSrc<int64_t*>(Data->SSAData, Op->Src);
       memcpy(GDP, &Dst, Op->Header.ElementSize);
       break;
     }
@@ -68,15 +68,15 @@ DEF_OP(Float_FromGPR_S) {
 
 DEF_OP(Float_FToF) {
   auto Op = IROp->C<IR::IROp_Float_FToF>();
-  uint16_t Conv = (Op->Header.ElementSize << 8) | Op->SrcElementSize;
+  const uint16_t Conv = (Op->Header.ElementSize << 8) | Op->SrcElementSize;
   switch (Conv) {
     case 0x0804: { // Double <- Float
-      double Dst = (double)*GetSrc<float*>(Data->SSAData, Op->Header.Args[0]);
+      const double Dst = (double)*GetSrc<float*>(Data->SSAData, Op->Scalar);
       memcpy(GDP, &Dst, 8);
       break;
     }
     case 0x0408: { // Float <- Double
-      float Dst = (float)*GetSrc<double*>(Data->SSAData, Op->Header.Args[0]);
+      const float Dst = (float)*GetSrc<double*>(Data->SSAData, Op->Scalar);
       memcpy(GDP, &Dst, 4);
       break;
     }
@@ -86,14 +86,14 @@ DEF_OP(Float_FToF) {
 
 DEF_OP(Vector_SToF) {
   auto Op = IROp->C<IR::IROp_Vector_SToF>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
+  void *Src = GetSrc<void*>(Data->SSAData, Op->Vector);
   uint8_t Tmp[16]{};
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
 
-  auto Func = [](auto a, auto min, auto max) { return a; };
+  const auto Func = [](auto a, auto min, auto max) { return a; };
   switch (Op->Header.ElementSize) {
     DO_VECTOR_1SRC_2TYPE_OP(4, float, int32_t, Func, 0, 0)
     DO_VECTOR_1SRC_2TYPE_OP(8, double, int64_t, Func, 0, 0)
@@ -104,14 +104,14 @@ DEF_OP(Vector_SToF) {
 
 DEF_OP(Vector_FToZS) {
   auto Op = IROp->C<IR::IROp_Vector_FToZS>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
+  void *Src = GetSrc<void*>(Data->SSAData, Op->Vector);
   uint8_t Tmp[16]{};
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
 
-  auto Func = [](auto a, auto min, auto max) { return std::trunc(a); };
+  const auto Func = [](auto a, auto min, auto max) { return std::trunc(a); };
   switch (Op->Header.ElementSize) {
     DO_VECTOR_1SRC_2TYPE_OP(4, int32_t, float, Func, 0, 0)
     DO_VECTOR_1SRC_2TYPE_OP(8, int64_t, double, Func, 0, 0)
@@ -122,14 +122,14 @@ DEF_OP(Vector_FToZS) {
 
 DEF_OP(Vector_FToS) {
   auto Op = IROp->C<IR::IROp_Vector_FToS>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
+  void *Src = GetSrc<void*>(Data->SSAData, Op->Vector);
   uint8_t Tmp[16]{};
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
 
-  auto Func = [](auto a, auto min, auto max) { return std::nearbyint(a); };
+  const auto Func = [](auto a, auto min, auto max) { return std::nearbyint(a); };
   switch (Op->Header.ElementSize) {
     DO_VECTOR_1SRC_2TYPE_OP(4, int32_t, float, Func, 0, 0)
     DO_VECTOR_1SRC_2TYPE_OP(8, int64_t, double, Func, 0, 0)
@@ -140,14 +140,14 @@ DEF_OP(Vector_FToS) {
 
 DEF_OP(Vector_FToF) {
   auto Op = IROp->C<IR::IROp_Vector_FToF>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
+  void *Src = GetSrc<void*>(Data->SSAData, Op->Vector);
   uint8_t Tmp[16]{};
 
-  uint16_t Conv = (Op->Header.ElementSize << 8) | Op->SrcElementSize;
+  const uint16_t Conv = (Op->Header.ElementSize << 8) | Op->SrcElementSize;
 
-  auto Func = [](auto a, auto min, auto max) { return a; };
+  const auto Func = [](auto a, auto min, auto max) { return a; };
   switch (Conv) {
     case 0x0804: { // Double <- float
       // Only the lower elements from the source
@@ -172,17 +172,17 @@ DEF_OP(Vector_FToF) {
 
 DEF_OP(Vector_FToI) {
   auto Op = IROp->C<IR::IROp_Vector_FToI>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
+  void *Src = GetSrc<void*>(Data->SSAData, Op->Vector);
   uint8_t Tmp[16]{};
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
-  auto Func_Nearest = [](auto a) { return std::rint(a); };
-  auto Func_Neg = [](auto a) { return std::floor(a); };
-  auto Func_Pos = [](auto a) { return std::ceil(a); };
-  auto Func_Trunc = [](auto a) { return std::trunc(a); };
-  auto Func_Host = [](auto a) { return std::rint(a); };
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const auto Func_Nearest = [](auto a) { return std::rint(a); };
+  const auto Func_Neg = [](auto a) { return std::floor(a); };
+  const auto Func_Pos = [](auto a) { return std::ceil(a); };
+  const auto Func_Trunc = [](auto a) { return std::trunc(a); };
+  const auto Func_Host = [](auto a) { return std::rint(a); };
 
   switch (Op->Round) {
     case FEXCore::IR::Round_Nearest.Val:

--- a/External/FEXCore/Source/Interface/Core/Interpreter/EncryptionOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/EncryptionOps.cpp
@@ -360,7 +360,7 @@ namespace FEXCore::CPU {
 
 DEF_OP(AESImc) {
   auto Op = IROp->C<IR::IROp_VAESImc>();
-  __uint128_t Src1 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Header.Args[0]);
+  auto Src1 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Vector);
 
   // Pseudo-code
   // Dst = InvMixColumns(STATE)
@@ -371,8 +371,8 @@ DEF_OP(AESImc) {
 
 DEF_OP(AESEnc) {
   auto Op = IROp->C<IR::IROp_VAESEnc>();
-  __uint128_t Src1 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Header.Args[0]);
-  __uint128_t Src2 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Header.Args[1]);
+  auto Src1 = *GetSrc<__uint128_t*>(Data->SSAData, Op->State);
+  auto Src2 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Key);
 
   // Pseudo-code
   // STATE = Src1
@@ -391,8 +391,8 @@ DEF_OP(AESEnc) {
 
 DEF_OP(AESEncLast) {
   auto Op = IROp->C<IR::IROp_VAESEncLast>();
-  __uint128_t Src1 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Header.Args[0]);
-  __uint128_t Src2 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Header.Args[1]);
+  auto Src1 = *GetSrc<__uint128_t*>(Data->SSAData, Op->State);
+  auto Src2 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Key);
 
   // Pseudo-code
   // STATE = Src1
@@ -409,8 +409,8 @@ DEF_OP(AESEncLast) {
 
 DEF_OP(AESDec) {
   auto Op = IROp->C<IR::IROp_VAESDec>();
-  __uint128_t Src1 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Header.Args[0]);
-  __uint128_t Src2 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Header.Args[1]);
+  auto Src1 = *GetSrc<__uint128_t*>(Data->SSAData, Op->State);
+  auto Src2 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Key);
 
   // Pseudo-code
   // STATE = Src1
@@ -429,8 +429,8 @@ DEF_OP(AESDec) {
 
 DEF_OP(AESDecLast) {
   auto Op = IROp->C<IR::IROp_VAESDecLast>();
-  __uint128_t Src1 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Header.Args[0]);
-  __uint128_t Src2 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Header.Args[1]);
+  auto Src1 = *GetSrc<__uint128_t*>(Data->SSAData, Op->State);
+  auto Src2 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Key);
 
   // Pseudo-code
   // STATE = Src1
@@ -447,7 +447,7 @@ DEF_OP(AESDecLast) {
 
 DEF_OP(AESKeyGenAssist) {
   auto Op = IROp->C<IR::IROp_VAESKeyGenAssist>();
-  uint8_t *Src1 = GetSrc<uint8_t*>(Data->SSAData, Op->Header.Args[0]);
+  const uint8_t *Src1 = GetSrc<uint8_t*>(Data->SSAData, Op->Src);
 
   // Pseudo-code
   // X3 = Src1[127:96]

--- a/External/FEXCore/Source/Interface/Core/Interpreter/F80Ops.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/F80Ops.cpp
@@ -20,99 +20,90 @@ DEF_OP(F80LOADFCW) {
 
 DEF_OP(F80ADD) {
   auto Op = IROp->C<IR::IROp_F80Add>();
-  X80SoftFloat Src1 = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->Header.Args[0]);
-  X80SoftFloat Src2 = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->Header.Args[1]);
-  X80SoftFloat Tmp;
-  Tmp = X80SoftFloat::FADD(Src1, Src2);
+  const auto Src1 = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->X80Src1);
+  const auto Src2 = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->X80Src2);
+  const auto Tmp = X80SoftFloat::FADD(Src1, Src2);
 
   memcpy(GDP, &Tmp, sizeof(X80SoftFloat));
 }
 
 DEF_OP(F80SUB) {
   auto Op = IROp->C<IR::IROp_F80Sub>();
-  X80SoftFloat Src1 = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->Header.Args[0]);
-  X80SoftFloat Src2 = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->Header.Args[1]);
-  X80SoftFloat Tmp;
-  Tmp = X80SoftFloat::FSUB(Src1, Src2);
+  const auto Src1 = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->X80Src1);
+  const auto Src2 = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->X80Src2);
+  const auto Tmp = X80SoftFloat::FSUB(Src1, Src2);
 
   memcpy(GDP, &Tmp, sizeof(X80SoftFloat));
 }
 
 DEF_OP(F80MUL) {
   auto Op = IROp->C<IR::IROp_F80Mul>();
-  X80SoftFloat Src1 = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->Header.Args[0]);
-  X80SoftFloat Src2 = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->Header.Args[1]);
-  X80SoftFloat Tmp;
-  Tmp = X80SoftFloat::FMUL(Src1, Src2);
+  const auto Src1 = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->X80Src1);
+  const auto Src2 = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->X80Src2);
+  const auto Tmp = X80SoftFloat::FMUL(Src1, Src2);
 
   memcpy(GDP, &Tmp, sizeof(X80SoftFloat));
 }
 
 DEF_OP(F80DIV) {
   auto Op = IROp->C<IR::IROp_F80Div>();
-  X80SoftFloat Src1 = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->Header.Args[0]);
-  X80SoftFloat Src2 = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->Header.Args[1]);
-  X80SoftFloat Tmp;
-  Tmp = X80SoftFloat::FDIV(Src1, Src2);
+  const auto Src1 = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->X80Src1);
+  const auto Src2 = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->X80Src2);
+  const auto Tmp = X80SoftFloat::FDIV(Src1, Src2);
 
   memcpy(GDP, &Tmp, sizeof(X80SoftFloat));
 }
 
 DEF_OP(F80FYL2X) {
   auto Op = IROp->C<IR::IROp_F80FYL2X>();
-  X80SoftFloat Src1 = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->Header.Args[0]);
-  X80SoftFloat Src2 = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->Header.Args[1]);
-  X80SoftFloat Tmp;
-  Tmp = X80SoftFloat::FYL2X(Src1, Src2);
+  const auto Src1 = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->X80Src1);
+  const auto Src2 = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->X80Src2);
+  const auto Tmp = X80SoftFloat::FYL2X(Src1, Src2);
 
   memcpy(GDP, &Tmp, sizeof(X80SoftFloat));
 }
 
 DEF_OP(F80ATAN) {
   auto Op = IROp->C<IR::IROp_F80ATAN>();
-  X80SoftFloat Src1 = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->Header.Args[0]);
-  X80SoftFloat Src2 = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->Header.Args[1]);
-  X80SoftFloat Tmp;
-  Tmp = X80SoftFloat::FATAN(Src1, Src2);
+  const auto Src1 = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->X80Src1);
+  const auto Src2 = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->X80Src2);
+  const auto Tmp = X80SoftFloat::FATAN(Src1, Src2);
 
   memcpy(GDP, &Tmp, sizeof(X80SoftFloat));
 }
 
 DEF_OP(F80FPREM1) {
   auto Op = IROp->C<IR::IROp_F80FPREM1>();
-  X80SoftFloat Src1 = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->Header.Args[0]);
-  X80SoftFloat Src2 = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->Header.Args[1]);
-  X80SoftFloat Tmp;
-  Tmp = X80SoftFloat::FREM1(Src1, Src2);
+  const auto Src1 = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->X80Src1);
+  const auto Src2 = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->X80Src2);
+  const auto Tmp = X80SoftFloat::FREM1(Src1, Src2);
 
   memcpy(GDP, &Tmp, sizeof(X80SoftFloat));
 }
 
 DEF_OP(F80FPREM) {
   auto Op = IROp->C<IR::IROp_F80FPREM>();
-  X80SoftFloat Src1 = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->Header.Args[0]);
-  X80SoftFloat Src2 = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->Header.Args[1]);
-  X80SoftFloat Tmp;
-  Tmp = X80SoftFloat::FREM(Src1, Src2);
+  const auto Src1 = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->X80Src1);
+  const auto Src2 = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->X80Src2);
+  const auto Tmp = X80SoftFloat::FREM(Src1, Src2);
 
   memcpy(GDP, &Tmp, sizeof(X80SoftFloat));
 }
 
 DEF_OP(F80SCALE) {
   auto Op = IROp->C<IR::IROp_F80SCALE>();
-  X80SoftFloat Src1 = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->Header.Args[0]);
-  X80SoftFloat Src2 = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->Header.Args[1]);
-  X80SoftFloat Tmp;
-  Tmp = X80SoftFloat::FSCALE(Src1, Src2);
+  const auto Src1 = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->X80Src1);
+  const auto Src2 = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->X80Src2);
+  const auto Tmp = X80SoftFloat::FSCALE(Src1, Src2);
 
   memcpy(GDP, &Tmp, sizeof(X80SoftFloat));
 }
 
 DEF_OP(F80CVT) {
   auto Op = IROp->C<IR::IROp_F80CVT>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  X80SoftFloat Src = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->Header.Args[0]);
+  const auto Src = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->X80Src);
 
   switch (OpSize) {
     case 4: {
@@ -131,9 +122,9 @@ DEF_OP(F80CVT) {
 
 DEF_OP(F80CVTINT) {
   auto Op = IROp->C<IR::IROp_F80CVTInt>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  X80SoftFloat Src = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->Header.Args[0]);
+  const auto Src = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->X80Src);
 
   switch (OpSize) {
     case 2: {
@@ -160,13 +151,13 @@ DEF_OP(F80CVTTO) {
 
   switch (Op->SrcSize) {
     case 4: {
-      float Src = *GetSrc<float *>(Data->SSAData, Op->Header.Args[0]);
+      float Src = *GetSrc<float *>(Data->SSAData, Op->X80Src);
       X80SoftFloat Tmp = Src;
       memcpy(GDP, &Tmp, sizeof(X80SoftFloat));
       break;
     }
     case 8: {
-      double Src = *GetSrc<double *>(Data->SSAData, Op->Header.Args[0]);
+      double Src = *GetSrc<double *>(Data->SSAData, Op->X80Src);
       X80SoftFloat Tmp = Src;
       memcpy(GDP, &Tmp, sizeof(X80SoftFloat));
       break;
@@ -180,13 +171,13 @@ DEF_OP(F80CVTTOINT) {
 
   switch (Op->SrcSize) {
     case 2: {
-      int16_t Src = *GetSrc<int16_t*>(Data->SSAData, Op->Header.Args[0]);
+      int16_t Src = *GetSrc<int16_t*>(Data->SSAData, Op->Src);
       X80SoftFloat Tmp = Src;
       memcpy(GDP, &Tmp, sizeof(X80SoftFloat));
       break;
     }
     case 4: {
-      int32_t Src = *GetSrc<int32_t*>(Data->SSAData, Op->Header.Args[0]);
+      int32_t Src = *GetSrc<int32_t*>(Data->SSAData, Op->Src);
       X80SoftFloat Tmp = Src;
       memcpy(GDP, &Tmp, sizeof(X80SoftFloat));
       break;
@@ -197,77 +188,73 @@ DEF_OP(F80CVTTOINT) {
 
 DEF_OP(F80ROUND) {
   auto Op = IROp->C<IR::IROp_F80Round>();
-  X80SoftFloat Src = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->Header.Args[0]);
-  X80SoftFloat Tmp;
-  Tmp = X80SoftFloat::FRNDINT(Src);
+  const auto Src = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->X80Src);
+  const auto Tmp = X80SoftFloat::FRNDINT(Src);
 
   memcpy(GDP, &Tmp, sizeof(X80SoftFloat));
 }
 
 DEF_OP(F80F2XM1) {
   auto Op = IROp->C<IR::IROp_F80F2XM1>();
-  X80SoftFloat Src = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->Header.Args[0]);
-  X80SoftFloat Tmp;
-  Tmp = X80SoftFloat::F2XM1(Src);
+  const auto Src = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->X80Src);
+  const auto Tmp = X80SoftFloat::F2XM1(Src);
 
   memcpy(GDP, &Tmp, sizeof(X80SoftFloat));
 }
 
 DEF_OP(F80TAN) {
   auto Op = IROp->C<IR::IROp_F80TAN>();
-  X80SoftFloat Src = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->Header.Args[0]);
-  X80SoftFloat Tmp;
-  Tmp = X80SoftFloat::FTAN(Src);
+  const auto Src = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->X80Src);
+  const auto Tmp = X80SoftFloat::FTAN(Src);
 
   memcpy(GDP, &Tmp, sizeof(X80SoftFloat));
 }
 
 DEF_OP(F80SQRT) {
   auto Op = IROp->C<IR::IROp_F80SQRT>();
-  X80SoftFloat Src = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->Header.Args[0]);
-  X80SoftFloat Tmp;
-  Tmp = X80SoftFloat::FSQRT(Src);
+  const auto Src = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->X80Src);
+  const auto Tmp = X80SoftFloat::FSQRT(Src);
 
   memcpy(GDP, &Tmp, sizeof(X80SoftFloat));
 }
 
 DEF_OP(F80SIN) {
   auto Op = IROp->C<IR::IROp_F80SIN>();
-  X80SoftFloat Src = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->Header.Args[0]);
-  X80SoftFloat Tmp;
-  Tmp = X80SoftFloat::FSIN(Src);
+  const auto Src = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->X80Src);
+  const auto Tmp = X80SoftFloat::FSIN(Src);
+
   memcpy(GDP, &Tmp, sizeof(X80SoftFloat));
 }
 
 DEF_OP(F80COS) {
   auto Op = IROp->C<IR::IROp_F80COS>();
-  X80SoftFloat Src = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->Header.Args[0]);
-  X80SoftFloat Tmp;
-  Tmp = X80SoftFloat::FCOS(Src);
+  const auto Src = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->X80Src);
+  const auto Tmp = X80SoftFloat::FCOS(Src);
+
   memcpy(GDP, &Tmp, sizeof(X80SoftFloat));
 }
 
 DEF_OP(F80XTRACT_EXP) {
   auto Op = IROp->C<IR::IROp_F80XTRACT_EXP>();
-  X80SoftFloat Src = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->Header.Args[0]);
-  X80SoftFloat Tmp;
-  Tmp = X80SoftFloat::FXTRACT_EXP(Src);
+  const auto Src = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->X80Src);
+  const auto Tmp = X80SoftFloat::FXTRACT_EXP(Src);
+
   memcpy(GDP, &Tmp, sizeof(X80SoftFloat));
 }
 
 DEF_OP(F80XTRACT_SIG) {
   auto Op = IROp->C<IR::IROp_F80XTRACT_SIG>();
-  X80SoftFloat Src = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->Header.Args[0]);
-  X80SoftFloat Tmp;
-  Tmp = X80SoftFloat::FXTRACT_SIG(Src);
+  const auto Src = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->X80Src);
+  const auto Tmp = X80SoftFloat::FXTRACT_SIG(Src);
+
   memcpy(GDP, &Tmp, sizeof(X80SoftFloat));
 }
 
 DEF_OP(F80CMP) {
   auto Op = IROp->C<IR::IROp_F80Cmp>();
   uint32_t ResultFlags{};
-  X80SoftFloat Src1 = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->Header.Args[0]);
-  X80SoftFloat Src2 = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->Header.Args[1]);
+  const auto Src1 = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->X80Src1);
+  const auto Src2 = *GetSrc<X80SoftFloat*>(Data->SSAData, Op->X80Src2);
   bool eq, lt, nan;
   X80SoftFloat::FCMP(Src1, Src2, &eq, &lt, &nan);
   if (Op->Flags & (1 << IR::FCMP_FLAG_LT) &&
@@ -288,7 +275,7 @@ DEF_OP(F80CMP) {
 
 DEF_OP(F80BCDLOAD) {
   auto Op = IROp->C<IR::IROp_F80BCDLoad>();
-  uint8_t *Src1 = GetSrc<uint8_t*>(Data->SSAData, Op->Header.Args[0]);
+  const uint8_t *Src1 = GetSrc<uint8_t*>(Data->SSAData, Op->X80Src);
   uint64_t BCD{};
   // We walk through each uint8_t and pull out the BCD encoding
   // Each 4bit split is a digit
@@ -323,7 +310,7 @@ DEF_OP(F80BCDLOAD) {
 
 DEF_OP(F80BCDSTORE) {
   auto Op = IROp->C<IR::IROp_F80BCDStore>();
-  X80SoftFloat Src1 = X80SoftFloat::FRNDINT(*GetSrc<X80SoftFloat*>(Data->SSAData, Op->Header.Args[0]));
+  X80SoftFloat Src1 = X80SoftFloat::FRNDINT(*GetSrc<X80SoftFloat*>(Data->SSAData, Op->X80Src));
   bool Negative = Src1.Sign;
 
   // Clear the Sign bit
@@ -358,74 +345,74 @@ DEF_OP(F80BCDSTORE) {
 
 DEF_OP(F64SIN) {
   auto Op = IROp->C<IR::IROp_F64SIN>();
-  double Src = *GetSrc<double*>(Data->SSAData, Op->Header.Args[0]);
-  double Tmp = sin(Src);
+  const double Src = *GetSrc<double*>(Data->SSAData, Op->Src);
+  const double Tmp = sin(Src);
   memcpy(GDP, &Tmp, sizeof(double));
 }
 
 DEF_OP(F64COS) {
   auto Op = IROp->C<IR::IROp_F64COS>();
-  double Src = *GetSrc<double*>(Data->SSAData, Op->Header.Args[0]);
-  double Tmp = cos(Src);
+  const double Src = *GetSrc<double*>(Data->SSAData, Op->Src);
+  const double Tmp = cos(Src);
   memcpy(GDP, &Tmp, sizeof(double));
 }
 
 DEF_OP(F64TAN) {
   auto Op = IROp->C<IR::IROp_F64TAN>();
-  double Src = *GetSrc<double*>(Data->SSAData, Op->Header.Args[0]);
-  double Tmp = tan(Src);
+  const double Src = *GetSrc<double*>(Data->SSAData, Op->Src);
+  const double Tmp = tan(Src);
   memcpy(GDP, &Tmp, sizeof(double));
 }
 
 DEF_OP(F64F2XM1) {
   auto Op = IROp->C<IR::IROp_F64F2XM1>();
-  double Src = *GetSrc<double*>(Data->SSAData, Op->Header.Args[0]);
-  double Tmp = exp2(Src) - 1.0;
+  const double Src = *GetSrc<double*>(Data->SSAData, Op->Src);
+  const double Tmp = exp2(Src) - 1.0;
   memcpy(GDP, &Tmp, sizeof(double));
 }
 
 DEF_OP(F64ATAN) {
   auto Op = IROp->C<IR::IROp_F64ATAN>();
-  double Src1 = *GetSrc<double*>(Data->SSAData, Op->Header.Args[0]);
-  double Src2 = *GetSrc<double*>(Data->SSAData, Op->Header.Args[1]);
-  double Tmp = atan2(Src1, Src2);
+  const double Src1 = *GetSrc<double*>(Data->SSAData, Op->Src1);
+  const double Src2 = *GetSrc<double*>(Data->SSAData, Op->Src2);
+  const double Tmp = atan2(Src1, Src2);
 
   memcpy(GDP, &Tmp, sizeof(double));
 }
 
 DEF_OP(F64FPREM) {
   auto Op = IROp->C<IR::IROp_F64FPREM>();
-  double Src1 = *GetSrc<double*>(Data->SSAData, Op->Header.Args[0]);
-  double Src2 = *GetSrc<double*>(Data->SSAData, Op->Header.Args[1]);
-  double Tmp = fmod(Src1, Src2);
+  const double Src1 = *GetSrc<double*>(Data->SSAData, Op->Src1);
+  const double Src2 = *GetSrc<double*>(Data->SSAData, Op->Src2);
+  const double Tmp = fmod(Src1, Src2);
 
   memcpy(GDP, &Tmp, sizeof(double));
 }
 
 DEF_OP(F64FPREM1) {
   auto Op = IROp->C<IR::IROp_F64FPREM1>();
-  double Src1 = *GetSrc<double*>(Data->SSAData, Op->Header.Args[0]);
-  double Src2 = *GetSrc<double*>(Data->SSAData, Op->Header.Args[1]);
-  double Tmp = remainder(Src1, Src2);
+  const double Src1 = *GetSrc<double*>(Data->SSAData, Op->Src1);
+  const double Src2 = *GetSrc<double*>(Data->SSAData, Op->Src2);
+  const double Tmp = remainder(Src1, Src2);
 
   memcpy(GDP, &Tmp, sizeof(double));
 }
 
 DEF_OP(F64FYL2X) {
   auto Op = IROp->C<IR::IROp_F64FYL2X>();
-  double Src1 = *GetSrc<double*>(Data->SSAData, Op->Header.Args[0]);
-  double Src2 = *GetSrc<double*>(Data->SSAData, Op->Header.Args[1]);
-  double Tmp = Src2 * log2(Src1);
+  const double Src1 = *GetSrc<double*>(Data->SSAData, Op->Src);
+  const double Src2 = *GetSrc<double*>(Data->SSAData, Op->Src2);
+  const double Tmp = Src2 * log2(Src1);
 
   memcpy(GDP, &Tmp, sizeof(double));
 }
 
 DEF_OP(F64SCALE) {
   auto Op = IROp->C<IR::IROp_F64SCALE>();
-  double Src1 = *GetSrc<double*>(Data->SSAData, Op->Header.Args[0]);
-  double Src2 = *GetSrc<double*>(Data->SSAData, Op->Header.Args[1]);
-  double trunc = (double)(int64_t)(Src2); //truncate
-  double Tmp = Src1 * exp2(trunc);
+  const double Src1 = *GetSrc<double*>(Data->SSAData, Op->Src1);
+  const double Src2 = *GetSrc<double*>(Data->SSAData, Op->Src2);
+  const double trunc = (double)(int64_t)(Src2); //truncate
+  const double Tmp = Src1 * exp2(trunc);
 
   memcpy(GDP, &Tmp, sizeof(double));
 }

--- a/External/FEXCore/Source/Interface/Core/Interpreter/FlagOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/FlagOps.cpp
@@ -14,7 +14,7 @@ namespace FEXCore::CPU {
 #define DEF_OP(x) void InterpreterOps::Op_##x(IR::IROp_Header *IROp, IROpData *Data, IR::NodeID Node)
 DEF_OP(GetHostFlag) {
   auto Op = IROp->C<IR::IROp_GetHostFlag>();
-  GD = (*GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[0]) >> Op->Flag) & 1;
+  GD = (*GetSrc<uint64_t*>(Data->SSAData, Op->Value) >> Op->Flag) & 1;
 }
 #undef DEF_OP
 

--- a/External/FEXCore/Source/Interface/Core/Interpreter/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/MemoryOps.cpp
@@ -58,7 +58,7 @@ DEF_OP(StoreContext) {
   ContextPtr += Op->Offset;
 
   void *MemData = reinterpret_cast<void*>(ContextPtr);
-  void *Src = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
+  void *Src = GetSrc<void*>(Data->SSAData, Op->Value);
   memcpy(MemData, Src, OpSize);
 }
 
@@ -72,7 +72,7 @@ DEF_OP(StoreRegister) {
 
 DEF_OP(LoadContextIndexed) {
   auto Op = IROp->C<IR::IROp_LoadContextIndexed>();
-  uint64_t Index = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[0]);
+  uint64_t Index = *GetSrc<uint64_t*>(Data->SSAData, Op->Index);
 
   uintptr_t ContextPtr = reinterpret_cast<uintptr_t>(Data->State->CurrentFrame);
 
@@ -102,14 +102,14 @@ DEF_OP(LoadContextIndexed) {
 
 DEF_OP(StoreContextIndexed) {
   auto Op = IROp->C<IR::IROp_StoreContextIndexed>();
-  uint64_t Index = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[1]);
+  uint64_t Index = *GetSrc<uint64_t*>(Data->SSAData, Op->Index);
 
   uintptr_t ContextPtr = reinterpret_cast<uintptr_t>(Data->State->CurrentFrame);
   ContextPtr += Op->BaseOffset;
   ContextPtr += Index * Op->Stride;
 
   void *MemData = reinterpret_cast<void*>(ContextPtr);
-  void *Src = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
+  void *Src = GetSrc<void*>(Data->SSAData, Op->Value);
   memcpy(MemData, Src, IROp->Size);
 }
 
@@ -133,7 +133,7 @@ DEF_OP(LoadFlag) {
 
 DEF_OP(StoreFlag) {
   auto Op = IROp->C<IR::IROp_StoreFlag>();
-  uint8_t Arg = *GetSrc<uint8_t*>(Data->SSAData, Op->Header.Args[0]);
+  uint8_t Arg = *GetSrc<uint8_t*>(Data->SSAData, Op->Value);
 
   uintptr_t ContextPtr = reinterpret_cast<uintptr_t>(Data->State->CurrentFrame);
   ContextPtr += offsetof(FEXCore::Core::CPUState, flags[0]);
@@ -227,9 +227,9 @@ DEF_OP(StoreMem) {
 
 DEF_OP(VLoadMemElement) {
   auto Op = IROp->C<IR::IROp_VLoadMemElement>();
-  void const *MemData = *GetSrc<void const**>(Data->SSAData, Op->Header.Args[0]);
+  void const *MemData = *GetSrc<void const**>(Data->SSAData, Op->Value);
 
-  memcpy(GDP, GetSrc<void*>(Data->SSAData, Op->Header.Args[1]), 16);
+  memcpy(GDP, GetSrc<void*>(Data->SSAData, Op->Addr), 16);
   memcpy(reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(GDP) + (Op->Header.ElementSize * Op->Index)),
     MemData, Op->Header.ElementSize);
 }
@@ -237,8 +237,8 @@ DEF_OP(VLoadMemElement) {
 DEF_OP(VStoreMemElement) {
   #define STORE_DATA(x, y) \
     case x: { \
-      y *MemData = *GetSrc<y**>(Data->SSAData, Op->Header.Args[0]); \
-      memcpy(MemData, &GetSrc<y*>(Data->SSAData, Op->Header.Args[1])[Op->Index], sizeof(y)); \
+      y *MemData = *GetSrc<y**>(Data->SSAData, Op->Value); \
+      memcpy(MemData, &GetSrc<y*>(Data->SSAData, Op->Addr)[Op->Index], sizeof(y)); \
       break; \
     }
 

--- a/External/FEXCore/Source/Interface/Core/Interpreter/MiscOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/MiscOps.cpp
@@ -86,7 +86,7 @@ DEF_OP(GetRoundingMode) {
 
 DEF_OP(SetRoundingMode) {
   auto Op = IROp->C<IR::IROp_SetRoundingMode>();
-  uint8_t GuestRounding = *GetSrc<uint8_t*>(Data->SSAData, Op->Header.Args[0]);
+  const auto GuestRounding = *GetSrc<uint8_t*>(Data->SSAData, Op->RoundMode);
 #ifdef _M_ARM_64
   uint64_t HostRounding{};
   __asm volatile(R"(
@@ -126,16 +126,16 @@ DEF_OP(SetRoundingMode) {
 
 DEF_OP(Print) {
   auto Op = IROp->C<IR::IROp_Print>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   if (OpSize <= 8) {
-    uint64_t Src = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[0]);
+    const auto Src = *GetSrc<uint64_t*>(Data->SSAData, Op->Value);
     LogMan::Msg::IFmt(">>>> Value in Arg: 0x{:x}, {}", Src, Src);
   }
   else if (OpSize == 16) {
-    __uint128_t Src = *GetSrc<__uint128_t*>(Data->SSAData, Op->Header.Args[0]);
-    uint64_t Src0 = Src;
-    uint64_t Src1 = Src >> 64;
+    const auto Src = *GetSrc<__uint128_t*>(Data->SSAData, Op->Value);
+    const uint64_t Src0 = Src;
+    const uint64_t Src1 = Src >> 64;
     LogMan::Msg::IFmt(">>>> Value[0] in Arg: 0x{:x}, {}", Src0, Src0);
     LogMan::Msg::IFmt("     Value[1] in Arg: 0x{:x}, {}", Src1, Src1);
   }

--- a/External/FEXCore/Source/Interface/Core/Interpreter/MoveOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/MoveOps.cpp
@@ -14,15 +14,15 @@ namespace FEXCore::CPU {
 #define DEF_OP(x) void InterpreterOps::Op_##x(IR::IROp_Header *IROp, IROpData *Data, IR::NodeID Node)
 DEF_OP(ExtractElementPair) {
   auto Op = IROp->C<IR::IROp_ExtractElementPair>();
-  uintptr_t Src = GetSrc<uintptr_t>(Data->SSAData, Op->Header.Args[0]);
+  const auto Src = GetSrc<uintptr_t>(Data->SSAData, Op->Pair);
   memcpy(GDP,
     reinterpret_cast<void*>(Src + Op->Header.Size * Op->Element), Op->Header.Size);
 }
 
 DEF_OP(CreateElementPair) {
   auto Op = IROp->C<IR::IROp_CreateElementPair>();
-  void *Src_Lower = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src_Upper = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  const void *Src_Lower = GetSrc<void*>(Data->SSAData, Op->Lower);
+  const void *Src_Upper = GetSrc<void*>(Data->SSAData, Op->Upper);
 
   uint8_t *Dst = GetDest<uint8_t*>(Data->SSAData, Node);
 
@@ -32,9 +32,9 @@ DEF_OP(CreateElementPair) {
 
 DEF_OP(Mov) {
   auto Op = IROp->C<IR::IROp_Mov>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  memcpy(GDP, GetSrc<void*>(Data->SSAData, Op->Header.Args[0]), OpSize);
+  memcpy(GDP, GetSrc<void*>(Data->SSAData, Op->Value), OpSize);
 }
 
 #undef DEF_OP

--- a/External/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
@@ -44,7 +44,7 @@ DEF_OP(SplatVector) {
   uint8_t OpSize = IROp->Size;
 
   LOGMAN_THROW_A_FMT(OpSize <= 16, "Can't handle a vector of size: {}", OpSize);
-  void *Src = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
+  void *Src = GetSrc<void*>(Data->SSAData, Op->Scalar);
   uint8_t Tmp[16];
   uint8_t Elements = 0;
 
@@ -76,60 +76,60 @@ DEF_OP(SplatVector) {
 
 DEF_OP(VMov) {
   auto Op = IROp->C<IR::IROp_VMov>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  __uint128_t Src = *GetSrc<__uint128_t*>(Data->SSAData, Op->Header.Args[0]);
+  const auto Src = *GetSrc<__uint128_t*>(Data->SSAData, Op->Source);
 
   memcpy(GDP, &Src, OpSize);
 }
 
 DEF_OP(VAnd) {
   auto Op = IROp->C<IR::IROp_VAnd>();
-  __uint128_t Src1 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Header.Args[0]);
-  __uint128_t Src2 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Header.Args[1]);
+  const auto Src1 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Vector1);
+  const auto Src2 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Vector2);
 
-  __uint128_t Dst = Src1 & Src2;
+  const auto Dst = Src1 & Src2;
   memcpy(GDP, &Dst, 16);
 }
 
 DEF_OP(VBic) {
   auto Op = IROp->C<IR::IROp_VBic>();
-  __uint128_t Src1 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Header.Args[0]);
-  __uint128_t Src2 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Header.Args[1]);
+  const auto Src1 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Vector1);
+  const auto Src2 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Vector2);
 
-  __uint128_t Dst = Src1 & ~Src2;
+  const auto Dst = Src1 & ~Src2;
   memcpy(GDP, &Dst, 16);
 }
 
 DEF_OP(VOr) {
   auto Op = IROp->C<IR::IROp_VOr>();
-  __uint128_t Src1 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Header.Args[0]);
-  __uint128_t Src2 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Header.Args[1]);
+  const auto Src1 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Vector1);
+  const auto Src2 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Vector2);
 
-  __uint128_t Dst = Src1 | Src2;
+  const auto Dst = Src1 | Src2;
   memcpy(GDP, &Dst, 16);
 }
 
 DEF_OP(VXor) {
   auto Op = IROp->C<IR::IROp_VXor>();
-  __uint128_t Src1 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Header.Args[0]);
-  __uint128_t Src2 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Header.Args[1]);
+  const auto Src1 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Vector1);
+  const auto Src2 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Vector2);
 
-  __uint128_t Dst = Src1 ^ Src2;
+  const auto Dst = Src1 ^ Src2;
   memcpy(GDP, &Dst, 16);
 }
 
 DEF_OP(VAdd) {
   auto Op = IROp->C<IR::IROp_VAdd>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector1);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Vector2);
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
 
-  auto Func = [](auto a, auto b) { return a + b; };
+  const auto Func = [](auto a, auto b) { return a + b; };
   switch (Op->Header.ElementSize) {
     DO_VECTOR_OP(1, uint8_t,  Func)
     DO_VECTOR_OP(2, uint16_t, Func)
@@ -142,15 +142,15 @@ DEF_OP(VAdd) {
 
 DEF_OP(VSub) {
   auto Op = IROp->C<IR::IROp_VSub>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector1);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Vector2);
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
 
-  auto Func = [](auto a, auto b) { return a - b; };
+  const auto Func = [](auto a, auto b) { return a - b; };
   switch (Op->Header.ElementSize) {
     DO_VECTOR_OP(1, uint8_t,  Func)
     DO_VECTOR_OP(2, uint16_t, Func)
@@ -163,15 +163,15 @@ DEF_OP(VSub) {
 
 DEF_OP(VUQAdd) {
   auto Op = IROp->C<IR::IROp_VUQAdd>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector1);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Vector2);
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
 
-  auto Func = [](auto a, auto b) {
+  const auto Func = [](auto a, auto b) {
     decltype(a) res = a + b;
     return res < a ? ~0U : res;
   };
@@ -187,15 +187,15 @@ DEF_OP(VUQAdd) {
 
 DEF_OP(VUQSub) {
   auto Op = IROp->C<IR::IROp_VUQSub>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector1);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Vector2);
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
 
-  auto Func = [](auto a, auto b) {
+  const auto Func = [](auto a, auto b) {
     decltype(a) res = a - b;
     return res > a ? 0U : res;
   };
@@ -211,15 +211,15 @@ DEF_OP(VUQSub) {
 
 DEF_OP(VSQAdd) {
   auto Op = IROp->C<IR::IROp_VSQAdd>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector1);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Vector2);
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
 
-  auto Func = [](auto a, auto b) {
+  const auto Func = [](auto a, auto b) {
     decltype(a) res = a + b;
 
     if (a > 0) {
@@ -245,15 +245,15 @@ DEF_OP(VSQAdd) {
 
 DEF_OP(VSQSub) {
   auto Op = IROp->C<IR::IROp_VSQSub>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector1);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Vector2);
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
 
-  auto Func = [](auto a, auto b) {
+  const auto Func = [](auto a, auto b) {
     __int128_t res = a - b;
     if (res < std::numeric_limits<decltype(a)>::min())
       return std::numeric_limits<decltype(a)>::min();
@@ -275,15 +275,15 @@ DEF_OP(VSQSub) {
 
 DEF_OP(VAddP) {
   auto Op = IROp->C<IR::IROp_VAddP>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->VectorLower);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->VectorUpper);
   uint8_t Tmp[16];
 
-  uint8_t Elements = (OpSize / Op->Header.ElementSize) / 2;
+  const uint8_t Elements = (OpSize / Op->Header.ElementSize) / 2;
 
-  auto Func = [](auto a, auto b) { return a + b; };
+  const auto Func = [](auto a, auto b) { return a + b; };
   switch (Op->Header.ElementSize) {
     DO_VECTOR_PAIR_OP(1, uint8_t,  Func)
     DO_VECTOR_PAIR_OP(2, uint16_t, Func)
@@ -296,14 +296,14 @@ DEF_OP(VAddP) {
 
 DEF_OP(VAddV) {
   auto Op = IROp->C<IR::IROp_VAddV>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
+  void *Src = GetSrc<void*>(Data->SSAData, Op->Vector);
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
 
-  auto Func = [](auto current, auto a) { return current + a; };
+  const auto Func = [](auto current, auto a) { return current + a; };
   switch (Op->Header.ElementSize) {
     DO_VECTOR_REDUCE_1SRC_OP(1, int8_t, Func, 0)
     DO_VECTOR_REDUCE_1SRC_OP(2, int16_t, Func, 0)
@@ -316,14 +316,14 @@ DEF_OP(VAddV) {
 
 DEF_OP(VUMinV) {
   auto Op = IROp->C<IR::IROp_VUMinV>();
-  uint8_t OpSize = IROp->Size;
+  const int8_t OpSize = IROp->Size;
 
-  void *Src = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
+  void *Src = GetSrc<void*>(Data->SSAData, Op->Vector);
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
 
-  auto Func = [](auto current, auto a) { return std::min(current, a); };
+  const auto Func = [](auto current, auto a) { return std::min(current, a); };
   switch (Op->Header.ElementSize) {
     DO_VECTOR_REDUCE_1SRC_OP(1, uint8_t, Func, ~0)
     DO_VECTOR_REDUCE_1SRC_OP(2, uint16_t, Func, ~0)
@@ -336,15 +336,15 @@ DEF_OP(VUMinV) {
 
 DEF_OP(VURAvg) {
   auto Op = IROp->C<IR::IROp_VURAvg>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector1);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Vector2);
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
 
-  auto Func = [](auto a, auto b) { return (a + b + 1) >> 1; };
+  const auto Func = [](auto a, auto b) { return (a + b + 1) >> 1; };
   switch (Op->Header.ElementSize) {
     DO_VECTOR_OP(1, uint8_t,  Func)
     DO_VECTOR_OP(2, uint16_t, Func)
@@ -355,14 +355,14 @@ DEF_OP(VURAvg) {
 
 DEF_OP(VAbs) {
   auto Op = IROp->C<IR::IROp_VAbs>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
+  void *Src = GetSrc<void*>(Data->SSAData, Op->Vector);
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
 
-  auto Func = [](auto a) { return std::abs(a); };
+  const auto Func = [](auto a) { return std::abs(a); };
   switch (Op->Header.ElementSize) {
     DO_VECTOR_1SRC_OP(1, int8_t, Func)
     DO_VECTOR_1SRC_OP(2, int16_t, Func)
@@ -375,14 +375,14 @@ DEF_OP(VAbs) {
 
 DEF_OP(VPopcount) {
   auto Op = IROp->C<IR::IROp_VPopcount>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
+  void *Src = GetSrc<void*>(Data->SSAData, Op->Vector);
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
 
-  auto Func = [](auto a) { return std::popcount(a); };
+  const auto Func = [](auto a) { return std::popcount(a); };
   switch (Op->Header.ElementSize) {
     DO_VECTOR_1SRC_OP(1, uint8_t, Func)
     DO_VECTOR_1SRC_OP(2, uint16_t, Func)
@@ -395,15 +395,15 @@ DEF_OP(VPopcount) {
 
 DEF_OP(VFAdd) {
   auto Op = IROp->C<IR::IROp_VFAdd>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector1);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Vector2);
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
 
-  auto Func = [](auto a, auto b) { return a + b; };
+  const auto Func = [](auto a, auto b) { return a + b; };
   switch (Op->Header.ElementSize) {
     DO_VECTOR_OP(4, float, Func)
     DO_VECTOR_OP(8, double, Func)
@@ -414,15 +414,15 @@ DEF_OP(VFAdd) {
 
 DEF_OP(VFAddP) {
   auto Op = IROp->C<IR::IROp_VFAddP>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->VectorLower);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->VectorUpper);
   uint8_t Tmp[16];
 
-  uint8_t Elements = (OpSize / Op->Header.ElementSize) / 2;
+  const uint8_t Elements = (OpSize / Op->Header.ElementSize) / 2;
 
-  auto Func = [](auto a, auto b) { return a + b; };
+  const auto Func = [](auto a, auto b) { return a + b; };
   switch (Op->Header.ElementSize) {
     DO_VECTOR_PAIR_OP(4, float, Func)
     DO_VECTOR_PAIR_OP(8, double, Func)
@@ -433,15 +433,15 @@ DEF_OP(VFAddP) {
 
 DEF_OP(VFSub) {
   auto Op = IROp->C<IR::IROp_VFSub>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector1);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Vector2);
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
 
-  auto Func = [](auto a, auto b) { return a - b; };
+  const auto Func = [](auto a, auto b) { return a - b; };
   switch (Op->Header.ElementSize) {
     DO_VECTOR_OP(4, float, Func)
     DO_VECTOR_OP(8, double, Func)
@@ -452,15 +452,15 @@ DEF_OP(VFSub) {
 
 DEF_OP(VFMul) {
   auto Op = IROp->C<IR::IROp_VFMul>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector1);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Vector2);
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
 
-  auto Func = [](auto a, auto b) { return a * b; };
+  const auto Func = [](auto a, auto b) { return a * b; };
   switch (Op->Header.ElementSize) {
     DO_VECTOR_OP(4, float, Func)
     DO_VECTOR_OP(8, double, Func)
@@ -471,15 +471,15 @@ DEF_OP(VFMul) {
 
 DEF_OP(VFDiv) {
   auto Op = IROp->C<IR::IROp_VFDiv>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector1);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Vector2);
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
 
-  auto Func = [](auto a, auto b) { return a / b; };
+  const auto Func = [](auto a, auto b) { return a / b; };
   switch (Op->Header.ElementSize) {
     DO_VECTOR_OP(4, float, Func)
     DO_VECTOR_OP(8, double, Func)
@@ -490,15 +490,15 @@ DEF_OP(VFDiv) {
 
 DEF_OP(VFMin) {
   auto Op = IROp->C<IR::IROp_VFMin>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector1);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Vector2);
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
 
-  auto Func = [](auto a, auto b) { return std::min(a, b); };
+  const auto Func = [](auto a, auto b) { return std::min(a, b); };
   switch (Op->Header.ElementSize) {
     DO_VECTOR_OP(4, float, Func)
     DO_VECTOR_OP(8, double, Func)
@@ -509,15 +509,15 @@ DEF_OP(VFMin) {
 
 DEF_OP(VFMax) {
   auto Op = IROp->C<IR::IROp_VFMax>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector1);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Vector2);
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
 
-  auto Func = [](auto a, auto b) { return std::max(a, b); };
+  const auto Func = [](auto a, auto b) { return std::max(a, b); };
   switch (Op->Header.ElementSize) {
     DO_VECTOR_OP(4, float, Func)
     DO_VECTOR_OP(8, double, Func)
@@ -528,14 +528,14 @@ DEF_OP(VFMax) {
 
 DEF_OP(VFRecp) {
   auto Op = IROp->C<IR::IROp_VFRecp>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
+  void *Src = GetSrc<void*>(Data->SSAData, Op->Vector);
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
 
-  auto Func = [](auto a) { return 1.0 / a; };
+  const auto Func = [](auto a) { return 1.0 / a; };
   switch (Op->Header.ElementSize) {
     DO_VECTOR_1SRC_OP(4, float, Func)
     DO_VECTOR_1SRC_OP(8, double, Func)
@@ -546,14 +546,14 @@ DEF_OP(VFRecp) {
 
 DEF_OP(VFSqrt) {
   auto Op = IROp->C<IR::IROp_VFSqrt>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
+  void *Src = GetSrc<void*>(Data->SSAData, Op->Vector);
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
 
-  auto Func = [](auto a) { return std::sqrt(a); };
+  const auto Func = [](auto a) { return std::sqrt(a); };
   switch (Op->Header.ElementSize) {
     DO_VECTOR_1SRC_OP(4, float, Func)
     DO_VECTOR_1SRC_OP(8, double, Func)
@@ -564,14 +564,14 @@ DEF_OP(VFSqrt) {
 
 DEF_OP(VFRSqrt) {
   auto Op = IROp->C<IR::IROp_VFRSqrt>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
+  void *Src = GetSrc<void*>(Data->SSAData, Op->Vector);
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
 
-  auto Func = [](auto a) { return 1.0 / std::sqrt(a); };
+  const auto Func = [](auto a) { return 1.0 / std::sqrt(a); };
   switch (Op->Header.ElementSize) {
     DO_VECTOR_1SRC_OP(4, float, Func)
     DO_VECTOR_1SRC_OP(8, double, Func)
@@ -582,14 +582,14 @@ DEF_OP(VFRSqrt) {
 
 DEF_OP(VNeg) {
   auto Op = IROp->C<IR::IROp_VNeg>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
+  void *Src = GetSrc<void*>(Data->SSAData, Op->Vector);
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
 
-  auto Func = [](auto a) { return -a; };
+  const auto Func = [](auto a) { return -a; };
   switch (Op->Header.ElementSize) {
     DO_VECTOR_1SRC_OP(1, int8_t, Func)
     DO_VECTOR_1SRC_OP(2, int16_t, Func)
@@ -602,14 +602,14 @@ DEF_OP(VNeg) {
 
 DEF_OP(VFNeg) {
   auto Op = IROp->C<IR::IROp_VFNeg>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
+  void *Src = GetSrc<void*>(Data->SSAData, Op->Vector);
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
 
-  auto Func = [](auto a) { return -a; };
+  const auto Func = [](auto a) { return -a; };
   switch (Op->Header.ElementSize) {
     DO_VECTOR_1SRC_OP(4, float, Func)
     DO_VECTOR_1SRC_OP(8, double, Func)
@@ -620,22 +620,22 @@ DEF_OP(VFNeg) {
 
 DEF_OP(VNot) {
   auto Op = IROp->C<IR::IROp_VNot>();
-  __uint128_t Src1 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Header.Args[0]);
+  const auto Src1 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Vector);
 
-  __uint128_t Dst = ~Src1;
+  const auto Dst = ~Src1;
   memcpy(GDP, &Dst, 16);
 }
 
 DEF_OP(VUMin) {
   auto Op = IROp->C<IR::IROp_VUMin>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector1);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Vector2);
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
-  auto Func = [](auto a, auto b) { return std::min(a, b); };
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const auto Func = [](auto a, auto b) { return std::min(a, b); };
 
   switch (Op->Header.ElementSize) {
     DO_VECTOR_OP(1, uint8_t,  Func)
@@ -649,14 +649,14 @@ DEF_OP(VUMin) {
 
 DEF_OP(VSMin) {
   auto Op = IROp->C<IR::IROp_VSMin>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector1);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Vector2);
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
-  auto Func = [](auto a, auto b) { return std::min(a, b); };
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const auto Func = [](auto a, auto b) { return std::min(a, b); };
 
   switch (Op->Header.ElementSize) {
     DO_VECTOR_OP(1, int8_t,  Func)
@@ -670,14 +670,14 @@ DEF_OP(VSMin) {
 
 DEF_OP(VUMax) {
   auto Op = IROp->C<IR::IROp_VUMax>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector1);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Vector2);
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
-  auto Func = [](auto a, auto b) { return std::max(a, b); };
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const auto Func = [](auto a, auto b) { return std::max(a, b); };
 
   switch (Op->Header.ElementSize) {
     DO_VECTOR_OP(1, uint8_t,  Func)
@@ -691,14 +691,14 @@ DEF_OP(VUMax) {
 
 DEF_OP(VSMax) {
   auto Op = IROp->C<IR::IROp_VSMax>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector1);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Vector2);
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
-  auto Func = [](auto a, auto b) { return std::max(a, b); };
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const auto Func = [](auto a, auto b) { return std::max(a, b); };
 
   switch (Op->Header.ElementSize) {
     DO_VECTOR_OP(1, int8_t,  Func)
@@ -712,10 +712,10 @@ DEF_OP(VSMax) {
 
 DEF_OP(VZip) {
   auto Op = IROp->C<IR::IROp_VZip>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->VectorLower);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->VectorUpper);
   uint8_t Tmp[16];
   uint8_t Elements = OpSize / Op->Header.ElementSize;
   uint8_t BaseOffset = IROp->Op == IR::OP_VZIP2 ? (Elements / 2) : 0;
@@ -770,10 +770,10 @@ DEF_OP(VZip) {
 
 DEF_OP(VUnZip) {
   auto Op = IROp->C<IR::IROp_VUnZip>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->VectorLower);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->VectorUpper);
   uint8_t Tmp[16];
   uint8_t Elements = OpSize / Op->Header.ElementSize;
   unsigned Start = IROp->Op == IR::OP_VUNZIP ? 0 : 1;
@@ -828,9 +828,9 @@ DEF_OP(VUnZip) {
 
 DEF_OP(VBSL) {
   auto Op = IROp->C<IR::IROp_VBSL>();
-  __uint128_t Src1 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Header.Args[0]);
-  __uint128_t Src2 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Header.Args[1]);
-  __uint128_t Src3 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Header.Args[2]);
+  const auto Src1 = *GetSrc<__uint128_t*>(Data->SSAData, Op->VectorMask);
+  const auto Src2 = *GetSrc<__uint128_t*>(Data->SSAData, Op->VectorTrue);
+  const auto Src3 = *GetSrc<__uint128_t*>(Data->SSAData, Op->VectorFalse);
 
   __uint128_t Tmp{};
   Tmp = Src2 & Src1;
@@ -841,14 +841,14 @@ DEF_OP(VBSL) {
 
 DEF_OP(VCMPEQ) {
   auto Op = IROp->C<IR::IROp_VCMPEQ>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector1);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Vector2);
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
-  auto Func = [](auto a, auto b) { return a == b ? ~0ULL : 0; };
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const auto Func = [](auto a, auto b) { return a == b ? ~0ULL : 0; };
 
   switch (Op->Header.ElementSize) {
     DO_VECTOR_OP(1, uint8_t,   Func)
@@ -863,14 +863,14 @@ DEF_OP(VCMPEQ) {
 
 DEF_OP(VCMPEQZ) {
   auto Op = IROp->C<IR::IROp_VCMPEQZ>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector);
   uint8_t Src2[16]{};
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
-  auto Func = [](auto a, auto b) { return a == b ? ~0ULL : 0; };
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const auto Func = [](auto a, auto b) { return a == b ? ~0ULL : 0; };
 
   switch (Op->Header.ElementSize) {
     DO_VECTOR_OP(1, uint8_t,   Func)
@@ -885,14 +885,14 @@ DEF_OP(VCMPEQZ) {
 
 DEF_OP(VCMPGT) {
   auto Op = IROp->C<IR::IROp_VCMPGT>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector1);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Vector2);
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
-  auto Func = [](auto a, auto b) { return a > b ? ~0ULL : 0; };
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const auto Func = [](auto a, auto b) { return a > b ? ~0ULL : 0; };
 
   switch (Op->Header.ElementSize) {
     DO_VECTOR_OP(1, int8_t,   Func)
@@ -907,14 +907,14 @@ DEF_OP(VCMPGT) {
 
 DEF_OP(VCMPGTZ) {
   auto Op = IROp->C<IR::IROp_VCMPGTZ>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector);
   uint8_t Src2[16]{};
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
-  auto Func = [](auto a, auto b) { return a > b ? ~0ULL : 0; };
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const auto Func = [](auto a, auto b) { return a > b ? ~0ULL : 0; };
 
   switch (Op->Header.ElementSize) {
     DO_VECTOR_OP(1, int8_t,   Func)
@@ -929,14 +929,14 @@ DEF_OP(VCMPGTZ) {
 
 DEF_OP(VCMPLTZ) {
   auto Op = IROp->C<IR::IROp_VCMPLTZ>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector);
   uint8_t Src2[16]{};
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
-  auto Func = [](auto a, auto b) { return a < b ? ~0ULL : 0; };
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const auto Func = [](auto a, auto b) { return a < b ? ~0ULL : 0; };
 
   switch (Op->Header.ElementSize) {
     DO_VECTOR_OP(1, int8_t,   Func)
@@ -951,15 +951,15 @@ DEF_OP(VCMPLTZ) {
 
 DEF_OP(VFCMPEQ) {
   auto Op = IROp->C<IR::IROp_VFCMPEQ>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector1);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Vector2);
 
-  auto Func = [](auto a, auto b) { return a == b ? ~0ULL : 0; };
+  const auto Func = [](auto a, auto b) { return a == b ? ~0ULL : 0; };
 
   uint8_t Tmp[16];
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
 
   if (Op->Header.ElementSize == OpSize) {
     switch (Op->Header.ElementSize) {
@@ -981,15 +981,15 @@ DEF_OP(VFCMPEQ) {
 
 DEF_OP(VFCMPNEQ) {
   auto Op = IROp->C<IR::IROp_VFCMPNEQ>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector1);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Vector2);
 
-  auto Func = [](auto a, auto b) { return a != b ? ~0ULL : 0; };
+  const auto Func = [](auto a, auto b) { return a != b ? ~0ULL : 0; };
 
   uint8_t Tmp[16];
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
 
   if (Op->Header.ElementSize == OpSize) {
     switch (Op->Header.ElementSize) {
@@ -1011,15 +1011,15 @@ DEF_OP(VFCMPNEQ) {
 
 DEF_OP(VFCMPLT) {
   auto Op = IROp->C<IR::IROp_VFCMPLT>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector1);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Vector2);
 
-  auto Func = [](auto a, auto b) { return a < b ? ~0ULL : 0; };
+  const auto Func = [](auto a, auto b) { return a < b ? ~0ULL : 0; };
 
   uint8_t Tmp[16];
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
 
   if (Op->Header.ElementSize == OpSize) {
     switch (Op->Header.ElementSize) {
@@ -1041,15 +1041,15 @@ DEF_OP(VFCMPLT) {
 
 DEF_OP(VFCMPGT) {
   auto Op = IROp->C<IR::IROp_VFCMPLT>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector1);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Vector2);
 
-  auto Func = [](auto a, auto b) { return a > b ? ~0ULL : 0; };
+  const auto Func = [](auto a, auto b) { return a > b ? ~0ULL : 0; };
 
   uint8_t Tmp[16];
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
 
   if (Op->Header.ElementSize == OpSize) {
     switch (Op->Header.ElementSize) {
@@ -1071,15 +1071,15 @@ DEF_OP(VFCMPGT) {
 
 DEF_OP(VFCMPLE) {
   auto Op = IROp->C<IR::IROp_VFCMPLE>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector1);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Vector2);
 
-  auto Func = [](auto a, auto b) { return a <= b ? ~0ULL : 0; };
+  const auto Func = [](auto a, auto b) { return a <= b ? ~0ULL : 0; };
 
   uint8_t Tmp[16];
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
 
   if (Op->Header.ElementSize == OpSize) {
     switch (Op->Header.ElementSize) {
@@ -1101,15 +1101,15 @@ DEF_OP(VFCMPLE) {
 
 DEF_OP(VFCMPORD) {
   auto Op = IROp->C<IR::IROp_VFCMPORD>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector1);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Vector2);
 
-  auto Func = [](auto a, auto b) { return (!std::isnan(a) && !std::isnan(b)) ? ~0ULL : 0; };
+  const auto Func = [](auto a, auto b) { return (!std::isnan(a) && !std::isnan(b)) ? ~0ULL : 0; };
 
   uint8_t Tmp[16];
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
 
   if (Op->Header.ElementSize == OpSize) {
     switch (Op->Header.ElementSize) {
@@ -1131,15 +1131,15 @@ DEF_OP(VFCMPORD) {
 
 DEF_OP(VFCMPUNO) {
   auto Op = IROp->C<IR::IROp_VFCMPUNO>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector1);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Vector2);
 
-  auto Func = [](auto a, auto b) { return (std::isnan(a) || std::isnan(b)) ? ~0ULL : 0; };
+  const auto Func = [](auto a, auto b) { return (std::isnan(a) || std::isnan(b)) ? ~0ULL : 0; };
 
   uint8_t Tmp[16];
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
 
   if (Op->Header.ElementSize == OpSize) {
     switch (Op->Header.ElementSize) {
@@ -1161,14 +1161,14 @@ DEF_OP(VFCMPUNO) {
 
 DEF_OP(VUShl) {
   auto Op = IROp->C<IR::IROp_VUShl>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->ShiftVector);
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
-  auto Func = [](auto a, auto b) { return b >= (sizeof(a) * 8) ? 0 : a << b; };
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const auto Func = [](auto a, auto b) { return b >= (sizeof(a) * 8) ? 0 : a << b; };
 
   switch (Op->Header.ElementSize) {
     DO_VECTOR_OP(1, uint8_t,  Func)
@@ -1182,14 +1182,14 @@ DEF_OP(VUShl) {
 
 DEF_OP(VUShr) {
   auto Op = IROp->C<IR::IROp_VUShr>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->ShiftVector);
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
-  auto Func = [](auto a, auto b) { return b >= (sizeof(a) * 8) ? 0 : a >> b; };
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const auto Func = [](auto a, auto b) { return b >= (sizeof(a) * 8) ? 0 : a >> b; };
 
   switch (Op->Header.ElementSize) {
     DO_VECTOR_OP(1, uint8_t,  Func)
@@ -1203,14 +1203,16 @@ DEF_OP(VUShr) {
 
 DEF_OP(VSShr) {
   auto Op = IROp->C<IR::IROp_VSShr>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->ShiftVector);
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
-  auto Func = [](auto a, auto b) { return b >= (sizeof(a) * 8) ? (a >> (sizeof(a) * 8 - 1)) : a >> b; };
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const auto Func = [](auto a, auto b) {
+    return b >= (sizeof(a) * 8) ? (a >> (sizeof(a) * 8 - 1)) : a >> b;
+  };
 
   switch (Op->Header.ElementSize) {
     DO_VECTOR_OP(1, int8_t,  Func)
@@ -1224,14 +1226,14 @@ DEF_OP(VSShr) {
 
 DEF_OP(VUShlS) {
   auto Op = IROp->C<IR::IROp_VUShlS>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->ShiftScalar);
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
-  auto Func = [](auto a, auto b) { return b >= (sizeof(a) * 8) ? 0 : a << b; };
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const auto Func = [](auto a, auto b) { return b >= (sizeof(a) * 8) ? 0 : a << b; };
 
   switch (Op->Header.ElementSize) {
     DO_VECTOR_SCALAR_OP(1, uint8_t, Func)
@@ -1246,14 +1248,14 @@ DEF_OP(VUShlS) {
 
 DEF_OP(VUShrS) {
   auto Op = IROp->C<IR::IROp_VUShrS>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->ShiftScalar);
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
-  auto Func = [](auto a, auto b) { return b >= (sizeof(a) * 8) ? 0 : a >> b; };
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const auto Func = [](auto a, auto b) { return b >= (sizeof(a) * 8) ? 0 : a >> b; };
 
   switch (Op->Header.ElementSize) {
     DO_VECTOR_SCALAR_OP(1, uint8_t, Func)
@@ -1268,14 +1270,16 @@ DEF_OP(VUShrS) {
 
 DEF_OP(VSShrS) {
   auto Op = IROp->C<IR::IROp_VSShrS>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->ShiftScalar);
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
-  auto Func = [](auto a, auto b) { return b >= (sizeof(a) * 8) ? (a >> (sizeof(a) * 8 - 1)) : a >> b; };
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const auto Func = [](auto a, auto b) {
+    return b >= (sizeof(a) * 8) ? (a >> (sizeof(a) * 8 - 1)) : a >> b;
+  };
 
   switch (Op->Header.ElementSize) {
     DO_VECTOR_SCALAR_OP(1, int8_t, Func)
@@ -1290,10 +1294,10 @@ DEF_OP(VSShrS) {
 
 DEF_OP(VInsElement) {
   auto Op = IROp->C<IR::IROp_VInsElement>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->DestVector);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->SrcVector);
   uint8_t Tmp[16];
 
   // Copy src1 in to dest
@@ -1330,10 +1334,10 @@ DEF_OP(VInsElement) {
 
 DEF_OP(VInsScalarElement) {
   auto Op = IROp->C<IR::IROp_VInsScalarElement>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->DestVector);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->SrcScalar);
   uint8_t Tmp[16];
 
   // Copy src1 in to dest
@@ -1371,7 +1375,7 @@ DEF_OP(VInsScalarElement) {
 DEF_OP(VExtractElement) {
   auto Op = IROp->C<IR::IROp_VExtractElement>();
 
-  uint32_t SourceSize = GetOpSize(Data->CurrentIR, Op->Header.Args[0]);
+  const uint32_t SourceSize = GetOpSize(Data->CurrentIR, Op->Vector);
   LOGMAN_THROW_A_FMT(IROp->Size <= 16, "OpSize is too large for VExtractElement: {}", IROp->Size);
   if (SourceSize == 16) {
     __uint128_t SourceMask = (1ULL << (Op->Header.ElementSize * 8)) - 1;
@@ -1379,7 +1383,7 @@ DEF_OP(VExtractElement) {
     if (Op->Header.ElementSize == 8)
       SourceMask = ~0ULL;
 
-    __uint128_t Src = *GetSrc<__uint128_t*>(Data->SSAData, Op->Header.Args[0]);
+    __uint128_t Src = *GetSrc<__uint128_t*>(Data->SSAData, Op->Vector);
     Src >>= Shift;
     Src &= SourceMask;
     memcpy(GDP, &Src, Op->Header.ElementSize);
@@ -1390,7 +1394,7 @@ DEF_OP(VExtractElement) {
     if (Op->Header.ElementSize == 8)
       SourceMask = ~0ULL;
 
-    uint64_t Src = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[0]);
+    uint64_t Src = *GetSrc<uint64_t*>(Data->SSAData, Op->Vector);
     Src >>= Shift;
     Src &= SourceMask;
     GD = Src;
@@ -1399,9 +1403,8 @@ DEF_OP(VExtractElement) {
 
 DEF_OP(VDupElement) {
   auto Op = IROp->C<IR::IROp_VDupElement>();
-  uint8_t OpSize = IROp->Size;
-
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t OpSize = IROp->Size;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
 
   LOGMAN_THROW_A_FMT(OpSize <= 16, "OpSize is too large for VDupElement: {}", OpSize);
   if (OpSize == 16) {
@@ -1410,7 +1413,7 @@ DEF_OP(VDupElement) {
     if (Op->Header.ElementSize == 8)
       SourceMask = ~0ULL;
 
-    __uint128_t Src = *GetSrc<__uint128_t*>(Data->SSAData, Op->Header.Args[0]);
+    __uint128_t Src = *GetSrc<__uint128_t*>(Data->SSAData, Op->Vector);
     Src >>= Shift;
     Src &= SourceMask;
     for (size_t i = 0; i < Elements; ++i) {
@@ -1424,7 +1427,7 @@ DEF_OP(VDupElement) {
     if (Op->Header.ElementSize == 8)
       SourceMask = ~0ULL;
 
-    uint64_t Src = *GetSrc<uint64_t*>(Data->SSAData, Op->Header.Args[0]);
+    uint64_t Src = *GetSrc<uint64_t*>(Data->SSAData, Op->Vector);
     Src >>= Shift;
     Src &= SourceMask;
     for (size_t i = 0; i < Elements; ++i) {
@@ -1436,10 +1439,10 @@ DEF_OP(VDupElement) {
 
 DEF_OP(VExtr) {
   auto Op = IROp->C<IR::IROp_VExtr>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  __uint128_t Src1 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Header.Args[0]);
-  __uint128_t Src2 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Header.Args[1]);
+  const auto Src1 = *GetSrc<__uint128_t*>(Data->SSAData, Op->VectorLower);
+  const auto Src2 = *GetSrc<__uint128_t*>(Data->SSAData, Op->VectorUpper);
 
   uint64_t Offset = Op->Index * Op->Header.ElementSize * 8;
   __uint128_t Dst{};
@@ -1456,33 +1459,35 @@ DEF_OP(VExtr) {
 
 DEF_OP(VSLI) {
   auto Op = IROp->C<IR::IROp_VSLI>();
-  __uint128_t Src1 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Header.Args[0]);
-  __uint128_t Src2 = Op->ByteShift * 8;
+  const __uint128_t Src1 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Vector);
+  const __uint128_t Src2 = Op->ByteShift * 8;
 
-  __uint128_t Dst = Op->ByteShift >= sizeof(__uint128_t) ? 0 : Src1 << Src2;
+  const __uint128_t Dst = Op->ByteShift >= sizeof(__uint128_t) ? 0 : Src1 << Src2;
   memcpy(GDP, &Dst, 16);
 }
 
 DEF_OP(VSRI) {
   auto Op = IROp->C<IR::IROp_VSRI>();
-  __uint128_t Src1 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Header.Args[0]);
-  __uint128_t Src2 = Op->ByteShift * 8;
+  const __uint128_t Src1 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Vector);
+  const __uint128_t Src2 = Op->ByteShift * 8;
 
-  __uint128_t Dst = Op->ByteShift >= sizeof(__uint128_t) ? 0 : Src1 >> Src2;
+  const __uint128_t Dst = Op->ByteShift >= sizeof(__uint128_t) ? 0 : Src1 >> Src2;
   memcpy(GDP, &Dst, 16);
 }
 
 DEF_OP(VUShrI) {
   auto Op = IROp->C<IR::IROp_VUShrI>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  uint8_t BitShift = Op->BitShift;
+  void *Src = GetSrc<void*>(Data->SSAData, Op->Vector);
+  const uint8_t BitShift = Op->BitShift;
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const auto Func = [BitShift](auto a) {
+    return BitShift >= (sizeof(a) * 8) ? 0 : a >> BitShift;
+  };
 
-  auto Func = [BitShift](auto a) { return BitShift >= (sizeof(a) * 8) ? 0 : a >> BitShift; };
   switch (Op->Header.ElementSize) {
     DO_VECTOR_1SRC_OP(1, uint8_t, Func)
     DO_VECTOR_1SRC_OP(2, uint16_t, Func)
@@ -1495,15 +1500,17 @@ DEF_OP(VUShrI) {
 
 DEF_OP(VSShrI) {
   auto Op = IROp->C<IR::IROp_VSShrI>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
+  void *Src = GetSrc<void*>(Data->SSAData, Op->Vector);
   uint8_t BitShift = Op->BitShift;
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const auto Func = [BitShift](auto a) {
+    return BitShift >= (sizeof(a) * 8) ? (a >> (sizeof(a) * 8 - 1)) : a >> BitShift;
+  };
 
-  auto Func = [BitShift](auto a) { return BitShift >= (sizeof(a) * 8) ? (a >> (sizeof(a) * 8 - 1)) : a >> BitShift; };
   switch (Op->Header.ElementSize) {
     DO_VECTOR_1SRC_OP(1, int8_t, Func)
     DO_VECTOR_1SRC_OP(2, int16_t, Func)
@@ -1516,15 +1523,17 @@ DEF_OP(VSShrI) {
 
 DEF_OP(VShlI) {
   auto Op = IROp->C<IR::IROp_VShlI>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
+  void *Src = GetSrc<void*>(Data->SSAData, Op->Vector);
   uint8_t BitShift = Op->BitShift;
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const auto Func = [BitShift](auto a) {
+    return BitShift >= (sizeof(a) * 8) ? 0 : (a << BitShift);
+  };
 
-  auto Func = [BitShift](auto a) { return BitShift >= (sizeof(a) * 8) ? 0 : (a << BitShift); };
   switch (Op->Header.ElementSize) {
     DO_VECTOR_1SRC_OP(1, uint8_t, Func)
     DO_VECTOR_1SRC_OP(2, uint16_t, Func)
@@ -1537,15 +1546,17 @@ DEF_OP(VShlI) {
 
 DEF_OP(VUShrNI) {
   auto Op = IROp->C<IR::IROp_VUShrNI>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
+  void *Src = GetSrc<void*>(Data->SSAData, Op->Vector);
   uint8_t BitShift = Op->BitShift;
   uint8_t Tmp[16]{};
 
-  uint8_t Elements = OpSize / (Op->Header.ElementSize << 1);
+  const uint8_t Elements = OpSize / (Op->Header.ElementSize << 1);
+  const auto Func = [BitShift](auto a, auto min, auto max) {
+    return BitShift >= (sizeof(a) * 8) ? 0 : a >> BitShift;
+  };
 
-  auto Func = [BitShift](auto a, auto min, auto max) { return BitShift >= (sizeof(a) * 8) ? 0 : a >> BitShift; };
   switch (Op->Header.ElementSize) {
     DO_VECTOR_1SRC_2TYPE_OP(1, uint8_t, uint16_t, Func, 0, 0)
     DO_VECTOR_1SRC_2TYPE_OP(2, uint16_t, uint32_t, Func, 0, 0)
@@ -1557,16 +1568,18 @@ DEF_OP(VUShrNI) {
 
 DEF_OP(VUShrNI2) {
   auto Op = IROp->C<IR::IROp_VUShrNI2>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->VectorLower);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->VectorUpper);
   uint8_t BitShift = Op->BitShift;
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / (Op->Header.ElementSize << 1);
+  const uint8_t Elements = OpSize / (Op->Header.ElementSize << 1);
+  const auto Func = [BitShift](auto a, auto min, auto max) {
+    return BitShift >= (sizeof(a) * 8) ? 0 : a >> BitShift;
+  };
 
-  auto Func = [BitShift](auto a, auto min, auto max) { return BitShift >= (sizeof(a) * 8) ? 0 : a >> BitShift; };
   switch (Op->Header.ElementSize) {
     DO_VECTOR_1SRC_2TYPE_OP_TOP(1, uint8_t, uint16_t, Func, 0, 0)
     DO_VECTOR_1SRC_2TYPE_OP_TOP(2, uint16_t, uint32_t, Func, 0, 0)
@@ -1578,19 +1591,19 @@ DEF_OP(VUShrNI2) {
 
 DEF_OP(VBitcast) {
   auto Op = IROp->C<IR::IROp_VBitcast>();
-  memcpy(GDP, GetSrc<void*>(Data->SSAData, Op->Header.Args[0]), 16);
+  memcpy(GDP, GetSrc<void*>(Data->SSAData, Op->Source), 16);
 }
 
 DEF_OP(VSXTL) {
   auto Op = IROp->C<IR::IROp_VSXTL>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
+  void *Src = GetSrc<void*>(Data->SSAData, Op->Vector);
   uint8_t Tmp[16]{};
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const auto Func = [](auto a, auto min, auto max) { return a; };
 
-  auto Func = [](auto a, auto min, auto max) { return a; };
   switch (Op->Header.ElementSize) {
     DO_VECTOR_1SRC_2TYPE_OP(2, int16_t, int8_t, Func,  0, 0)
     DO_VECTOR_1SRC_2TYPE_OP(4, int32_t, int16_t, Func, 0, 0)
@@ -1602,14 +1615,14 @@ DEF_OP(VSXTL) {
 
 DEF_OP(VSXTL2) {
   auto Op = IROp->C<IR::IROp_VSXTL2>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
+  void *Src = GetSrc<void*>(Data->SSAData, Op->Vector);
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const auto Func = [](auto a, auto min, auto max) { return a; };
 
-  auto Func = [](auto a, auto min, auto max) { return a; };
   switch (Op->Header.ElementSize) {
     DO_VECTOR_1SRC_2TYPE_OP_TOP_SRC(2, int16_t, int8_t, Func,  0, 0)
     DO_VECTOR_1SRC_2TYPE_OP_TOP_SRC(4, int32_t, int16_t, Func, 0, 0)
@@ -1621,14 +1634,14 @@ DEF_OP(VSXTL2) {
 
 DEF_OP(VUXTL) {
   auto Op = IROp->C<IR::IROp_VUXTL>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
+  void *Src = GetSrc<void*>(Data->SSAData, Op->Vector);
   uint8_t Tmp[16]{};
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const auto Func = [](auto a, auto min, auto max) { return a; };
 
-  auto Func = [](auto a, auto min, auto max) { return a; };
   switch (Op->Header.ElementSize) {
     DO_VECTOR_1SRC_2TYPE_OP(2, uint16_t, uint8_t, Func,  0, 0)
     DO_VECTOR_1SRC_2TYPE_OP(4, uint32_t, uint16_t, Func, 0, 0)
@@ -1640,15 +1653,15 @@ DEF_OP(VUXTL) {
 
 DEF_OP(VUXTL2) {
   auto Op = IROp->C<IR::IROp_VUXTL2>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
+  void *Src = GetSrc<void*>(Data->SSAData, Op->Vector);
 
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const auto Func = [](auto a, auto min, auto max) { return a; };
 
-  auto Func = [](auto a, auto min, auto max) { return a; };
   switch (Op->Header.ElementSize) {
     DO_VECTOR_1SRC_2TYPE_OP_TOP_SRC(2, uint16_t, uint8_t, Func,  0, 0)
     DO_VECTOR_1SRC_2TYPE_OP_TOP_SRC(4, uint32_t, uint16_t, Func, 0, 0)
@@ -1660,14 +1673,16 @@ DEF_OP(VUXTL2) {
 
 DEF_OP(VSQXTN) {
   auto Op = IROp->C<IR::IROp_VSQXTN>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
+  void *Src = GetSrc<void*>(Data->SSAData, Op->Vector);
   uint8_t Tmp[16]{};
 
-  uint8_t Elements = OpSize / (Op->Header.ElementSize << 1);
+  const uint8_t Elements = OpSize / (Op->Header.ElementSize << 1);
+  const auto Func = [](auto a, auto min, auto max) {
+    return std::max(std::min(a, (decltype(a))max), (decltype(a))min);
+  };
 
-  auto Func = [](auto a, auto min, auto max) { return std::max(std::min(a, (decltype(a))max), (decltype(a))min); };
   switch (Op->Header.ElementSize) {
     DO_VECTOR_1SRC_2TYPE_OP(1, int8_t, int16_t, Func, std::numeric_limits<int8_t>::min(), std::numeric_limits<int8_t>::max())
     DO_VECTOR_1SRC_2TYPE_OP(2, int16_t, int32_t, Func, std::numeric_limits<int16_t>::min(), std::numeric_limits<int16_t>::max())
@@ -1678,15 +1693,17 @@ DEF_OP(VSQXTN) {
 
 DEF_OP(VSQXTN2) {
   auto Op = IROp->C<IR::IROp_VSQXTN2>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->VectorLower);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->VectorUpper);
   uint8_t Tmp[16]{};
 
-  uint8_t Elements = OpSize / (Op->Header.ElementSize << 1);
+  const uint8_t Elements = OpSize / (Op->Header.ElementSize << 1);
+  const auto Func = [](auto a, auto min, auto max) {
+    return std::max(std::min(a, (decltype(a))max), (decltype(a))min);
+  };
 
-  auto Func = [](auto a, auto min, auto max) { return std::max(std::min(a, (decltype(a))max), (decltype(a))min); };
   switch (Op->Header.ElementSize) {
     DO_VECTOR_1SRC_2TYPE_OP_TOP(1, int8_t, int16_t, Func, std::numeric_limits<int8_t>::min(), std::numeric_limits<int8_t>::max())
     DO_VECTOR_1SRC_2TYPE_OP_TOP(2, int16_t, int32_t, Func, std::numeric_limits<int16_t>::min(), std::numeric_limits<int16_t>::max())
@@ -1697,14 +1714,16 @@ DEF_OP(VSQXTN2) {
 
 DEF_OP(VSQXTUN) {
   auto Op = IROp->C<IR::IROp_VSQXTUN>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
+  void *Src = GetSrc<void*>(Data->SSAData, Op->Vector);
   uint8_t Tmp[16]{};
 
-  uint8_t Elements = OpSize / (Op->Header.ElementSize << 1);
+  const uint8_t Elements = OpSize / (Op->Header.ElementSize << 1);
+  const auto Func = [](auto a, auto min, auto max) {
+    return std::max(std::min(a, (decltype(a))max), (decltype(a))min);
+  };
 
-  auto Func = [](auto a, auto min, auto max) { return std::max(std::min(a, (decltype(a))max), (decltype(a))min); };
   switch (Op->Header.ElementSize) {
     DO_VECTOR_1SRC_2TYPE_OP(1, uint8_t, int16_t, Func, 0, (1 << 8) - 1)
     DO_VECTOR_1SRC_2TYPE_OP(2, uint16_t, int32_t, Func, 0, (1 << 16) - 1)
@@ -1715,15 +1734,17 @@ DEF_OP(VSQXTUN) {
 
 DEF_OP(VSQXTUN2) {
   auto Op = IROp->C<IR::IROp_VSQXTUN2>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->VectorLower);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->VectorUpper);
   uint8_t Tmp[16]{};
 
-  uint8_t Elements = OpSize / (Op->Header.ElementSize << 1);
+  const uint8_t Elements = OpSize / (Op->Header.ElementSize << 1);
+  const auto Func = [](auto a, auto min, auto max) {
+    return std::max(std::min(a, (decltype(a))max), (decltype(a))min);
+  };
 
-  auto Func = [](auto a, auto min, auto max) { return std::max(std::min(a, (decltype(a))max), (decltype(a))min); };
   switch (Op->Header.ElementSize) {
     DO_VECTOR_1SRC_2TYPE_OP_TOP(1, uint8_t, int16_t, Func, 0, (1 << 8) - 1)
     DO_VECTOR_1SRC_2TYPE_OP_TOP(2, uint16_t, int32_t, Func, 0, (1 << 16) - 1)
@@ -1734,15 +1755,15 @@ DEF_OP(VSQXTUN2) {
 
 DEF_OP(VUMul) {
   auto Op = IROp->C<IR::IROp_VUMul>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector1);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Vector2);
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const auto Func = [](auto a, auto b) { return a * b; };
 
-  auto Func = [](auto a, auto b) { return a * b; };
   switch (Op->Header.ElementSize) {
     DO_VECTOR_OP(1, uint8_t,  Func)
     DO_VECTOR_OP(2, uint16_t, Func)
@@ -1755,16 +1776,16 @@ DEF_OP(VUMul) {
 
 DEF_OP(VUMull) {
   auto Op = IROp->C<IR::IROp_VUMull>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector1);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Vector2);
 
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const auto Func = [](auto a, auto b) { return a * b; };
 
-  auto Func = [](auto a, auto b) { return a * b; };
   switch (Op->Header.ElementSize) {
     DO_VECTOR_2SRC_2TYPE_OP(2, uint16_t, uint8_t, Func)
     DO_VECTOR_2SRC_2TYPE_OP(4, uint32_t, uint16_t, Func)
@@ -1776,15 +1797,15 @@ DEF_OP(VUMull) {
 
 DEF_OP(VSMul) {
   auto Op = IROp->C<IR::IROp_VSMul>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector1);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Vector2);
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const auto Func = [](auto a, auto b) { return a * b; };
 
-  auto Func = [](auto a, auto b) { return a * b; };
   switch (Op->Header.ElementSize) {
     DO_VECTOR_OP(1, int8_t,  Func)
     DO_VECTOR_OP(2, int16_t, Func)
@@ -1797,16 +1818,16 @@ DEF_OP(VSMul) {
 
 DEF_OP(VSMull) {
   auto Op = IROp->C<IR::IROp_VSMull>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector1);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Vector2);
 
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const auto Func = [](auto a, auto b) { return a * b; };
 
-  auto Func = [](auto a, auto b) { return a * b; };
   switch (Op->Header.ElementSize) {
     DO_VECTOR_2SRC_2TYPE_OP(2, int16_t, int8_t, Func)
     DO_VECTOR_2SRC_2TYPE_OP(4, int32_t, int16_t, Func)
@@ -1818,16 +1839,16 @@ DEF_OP(VSMull) {
 
 DEF_OP(VUMull2) {
   auto Op = IROp->C<IR::IROp_VUMull2>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector1);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Vector2);
 
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const auto Func = [](auto a, auto b) { return a * b; };
 
-  auto Func = [](auto a, auto b) { return a * b; };
   switch (Op->Header.ElementSize) {
     DO_VECTOR_2SRC_2TYPE_OP_TOP_SRC(2, uint16_t, uint8_t, Func)
     DO_VECTOR_2SRC_2TYPE_OP_TOP_SRC(4, uint32_t, uint16_t, Func)
@@ -1839,16 +1860,16 @@ DEF_OP(VUMull2) {
 
 DEF_OP(VSMull2) {
   auto Op = IROp->C<IR::IROp_VSMull2>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector1);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Vector2);
 
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const auto Func = [](auto a, auto b) { return a * b; };
 
-  auto Func = [](auto a, auto b) { return a * b; };
   switch (Op->Header.ElementSize) {
     DO_VECTOR_2SRC_2TYPE_OP_TOP_SRC(2, int16_t, int8_t, Func)
     DO_VECTOR_2SRC_2TYPE_OP_TOP_SRC(4, int32_t, int16_t, Func)
@@ -1860,18 +1881,18 @@ DEF_OP(VSMull2) {
 
 DEF_OP(VUABDL) {
   auto Op = IROp->C<IR::IROp_VUABDL>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
-  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Header.Args[1]);
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector1);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Vector2);
 
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
 
-  auto Func8 = [](auto a, auto b) { return std::abs((int16_t)a - (int16_t)b); };
-  auto Func16 = [](auto a, auto b) { return std::abs((int32_t)a - (int32_t)b); };
-  auto Func32 = [](auto a, auto b) { return std::abs((int64_t)a - (int64_t)b); };
+  const auto Func8 = [](auto a, auto b) { return std::abs((int16_t)a - (int16_t)b); };
+  const auto Func16 = [](auto a, auto b) { return std::abs((int32_t)a - (int32_t)b); };
+  const auto Func32 = [](auto a, auto b) { return std::abs((int64_t)a - (int64_t)b); };
 
   switch (Op->Header.ElementSize) {
     DO_VECTOR_2SRC_2TYPE_OP(2, uint16_t, uint8_t, Func8)
@@ -1884,15 +1905,15 @@ DEF_OP(VUABDL) {
 
 DEF_OP(VTBL1) {
   auto Op = IROp->C<IR::IROp_VTBL1>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  uint8_t *Src1 = GetSrc<uint8_t*>(Data->SSAData, Op->Header.Args[0]);
-  uint8_t *Src2 = GetSrc<uint8_t*>(Data->SSAData, Op->Header.Args[1]);
+  const auto *Src1 = GetSrc<uint8_t*>(Data->SSAData, Op->VectorTable);
+  const auto *Src2 = GetSrc<uint8_t*>(Data->SSAData, Op->VectorIndices);
 
   uint8_t Tmp[16];
 
   for (size_t i = 0; i < OpSize; ++i) {
-    uint8_t Index = Src2[i];
+    const uint8_t Index = Src2[i];
     Tmp[i] = Index >= OpSize ? 0 : Src1[Index];
   }
   memcpy(GDP, Tmp, OpSize);
@@ -1900,24 +1921,24 @@ DEF_OP(VTBL1) {
 
 DEF_OP(VRev64) {
   auto Op = IROp->C<IR::IROp_VRev64>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  void *Src = GetSrc<void*>(Data->SSAData, Op->Header.Args[0]);
+  void *Src = GetSrc<void*>(Data->SSAData, Op->Vector);
 
   uint8_t Tmp[16];
 
-  uint8_t Elements = OpSize / 8;
+  const uint8_t Elements = OpSize / 8;
 
   // The element working size is always 64-bit
   // The defined element size in the op is the operating size of the element swapping
-  auto Func8 = [](auto a) { return BSwap64(a); };
-  auto Func16 = [](auto a) {
+  const auto Func8 = [](auto a) { return BSwap64(a); };
+  const auto Func16 = [](auto a) {
     return (a >> 48) |                    // Element[3] -> Element[0]
       ((a >> 16) & 0xFFFF'0000U) |        // Element[2] -> Element[1]
       ((a << 16) & 0xFFFF'0000'0000ULL) | // Element[1] -> Element[2]
       (a << 48);                          // Element[0] -> Element[3]
   };
-  auto Func32 = [](auto a) {
+  const auto Func32 = [](auto a) {
     return (a >> 32) | (a << 32);
   };
 


### PR DESCRIPTION
Converts the opaque args array usage over to the given IR argument names where applicable. Brings the interpreter in sync with the ARM JIT

I made these changes a while ago and I guess I forgot to actually make a PR for them (whoops!)