### PR TITLE
FEXCore: Support synchronizing RIP on block entry through config

### DIFF
--- a/Data/AppConfig/VC_redist.x64.exe.json
+++ b/Data/AppConfig/VC_redist.x64.exe.json
@@ -1,0 +1,5 @@
+{
+  "Config": {
+    "x86dec_SynchronizeRIPOnAllBlocks": "1"
+  }
+}

--- a/Data/AppConfig/VC_redist.x86.exe.json
+++ b/Data/AppConfig/VC_redist.x86.exe.json
@@ -1,0 +1,5 @@
+{
+  "Config": {
+    "x86dec_SynchronizeRIPOnAllBlocks": "1"
+  }
+}

--- a/Data/AppConfig/vcredist_x64.exe.json
+++ b/Data/AppConfig/vcredist_x64.exe.json
@@ -1,0 +1,5 @@
+{
+  "Config": {
+    "x86dec_SynchronizeRIPOnAllBlocks": "1"
+  }
+}

--- a/Data/AppConfig/vcredist_x86.exe.json
+++ b/Data/AppConfig/vcredist_x86.exe.json
@@ -1,0 +1,5 @@
+{
+  "Config": {
+    "x86dec_SynchronizeRIPOnAllBlocks": "1"
+  }
+}

--- a/External/FEXCore/Source/Interface/Config/Config.json.in
+++ b/External/FEXCore/Source/Interface/Config/Config.json.in
@@ -309,6 +309,16 @@
           "Forces a process to stall out on initialization",
           "Useful for a process that keeps restarting and doesn't work"
         ]
+      },
+      "x86dec_SynchronizeRIPOnAllBlocks": {
+        "Type": "bool",
+        "Default": "false",
+        "Desc": [
+          "An application that uses try-catch or longjump extensively needs the ability to do context aware state flushing",
+          "In the case of FEX's block-linking, it won't always ensure that RIP is synchronized.",
+          "If an exception occurs and RIP isn't synchronized, then FEX's exception stack restore may not long jump as expected",
+          "Can be useful for Wine applications that rely on stack unwinding"
+        ]
       }
     },
     "Misc": {

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -113,6 +113,7 @@ namespace FEXCore::Context {
       FEX_CONFIG_OPT(ParanoidTSO, PARANOIDTSO);
       FEX_CONFIG_OPT(CacheObjectCodeCompilation, CACHEOBJECTCODECOMPILATION);
       FEX_CONFIG_OPT(x87ReducedPrecision, X87REDUCEDPRECISION);
+      FEX_CONFIG_OPT(x86dec_SynchronizeRIPOnAllBlocks, X86DEC_SYNCHRONIZERIPONALLBLOCKS);
     } Config;
 
     FEXCore::HostFeatures HostFeatures;


### PR DESCRIPTION
If an application is doing long jumps on exceptions then we need to
ensure that RIP is synchronized at least to block entry for some amount
of safety.

Due to our block linking which doesn't ensure that RIP is synchronized
on block entry, our exception handling wouldn't see a RIP change, thus
not going down the path that we jump to Dispatcher loop top on RIP
change.

Burn a couple of instructions on block entry to ensure that RIP
synchronized but only on config.

**Fixes Proton Experimental hangs when it is installing the VC runtimes.**