### PR TITLE
x86_64: Migrate args over to named IR arguments

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/ALUOps.cpp
@@ -27,7 +27,7 @@ DEF_OP(TruncElementPair) {
   switch (IROp->Size) {
     case 4: {
       auto Dst = GetSrcPair<RA_32>(Node);
-      auto Src = GetSrcPair<RA_32>(Op->Header.Args[0].ID());
+      auto Src = GetSrcPair<RA_32>(Op->Pair.ID());
       mov(Dst.first, Src.first);
       mov(Dst.second, Src.second);
       break;
@@ -75,12 +75,12 @@ DEF_OP(CycleCounter) {
 
 DEF_OP(Add) {
   auto Op = IROp->C<IR::IROp_Add>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  mov(rax, GetSrc<RA_64>(Op->Header.Args[0].ID()));
+  mov(rax, GetSrc<RA_64>(Op->Src1.ID()));
 
   uint64_t Const;
-  if (IsInlineConstant(Op->Header.Args[1], &Const)) {
+  if (IsInlineConstant(Op->Src2, &Const)) {
     switch (OpSize) {
     case 4:
       add(eax, Const);
@@ -94,10 +94,10 @@ DEF_OP(Add) {
   } else {
     switch (OpSize) {
     case 4:
-      add(eax, GetSrc<RA_32>(Op->Header.Args[1].ID()));
+      add(eax, GetSrc<RA_32>(Op->Src2.ID()));
       break;
     case 8:
-      add(rax, GetSrc<RA_64>(Op->Header.Args[1].ID()));
+      add(rax, GetSrc<RA_64>(Op->Src2.ID()));
       break;
     default:  LOGMAN_MSG_A_FMT("Unhandled Add size: {}", OpSize);
       break;
@@ -108,12 +108,12 @@ DEF_OP(Add) {
 
 DEF_OP(Sub) {
   auto Op = IROp->C<IR::IROp_Sub>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  mov(rax, GetSrc<RA_64>(Op->Header.Args[0].ID()));
+  mov(rax, GetSrc<RA_64>(Op->Src1.ID()));
 
   uint64_t Const;
-  if (IsInlineConstant(Op->Header.Args[1], &Const)) {
+  if (IsInlineConstant(Op->Src2, &Const)) {
     switch (OpSize) {
     case 4:
       sub(eax, Const);
@@ -127,10 +127,10 @@ DEF_OP(Sub) {
   } else {
     switch (OpSize) {
     case 4:
-      sub(eax, GetSrc<RA_32>(Op->Header.Args[1].ID()));
+      sub(eax, GetSrc<RA_32>(Op->Src2.ID()));
       break;
     case 8:
-      sub(rax, GetSrc<RA_64>(Op->Header.Args[1].ID()));
+      sub(rax, GetSrc<RA_64>(Op->Src2.ID()));
       break;
     default:  LOGMAN_MSG_A_FMT("Unhandled Sub size: {}", OpSize);
       break;
@@ -141,17 +141,17 @@ DEF_OP(Sub) {
 
 DEF_OP(Neg) {
   auto Op = IROp->C<IR::IROp_Neg>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   Xbyak::Reg Src;
   Xbyak::Reg Dst;
   switch (OpSize) {
   case 4:
-    Src = GetSrc<RA_32>(Op->Header.Args[0].ID());
+    Src = GetSrc<RA_32>(Op->Src.ID());
     Dst = GetDst<RA_32>(Node);
     break;
   case 8:
-    Src = GetSrc<RA_64>(Op->Header.Args[0].ID());
+    Src = GetSrc<RA_64>(Op->Src.ID());
     Dst = GetDst<RA_64>(Node);
     break;
   default:  LOGMAN_MSG_A_FMT("Unhandled Neg size: {}", OpSize);
@@ -163,19 +163,19 @@ DEF_OP(Neg) {
 
 DEF_OP(Mul) {
   auto Op = IROp->C<IR::IROp_Mul>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   auto Dst = GetDst<RA_64>(Node);
 
   switch (OpSize) {
   case 4:
-    movsxd(rax, GetSrc<RA_32>(Op->Header.Args[0].ID()));
-    imul(eax, GetSrc<RA_32>(Op->Header.Args[1].ID()));
+    movsxd(rax, GetSrc<RA_32>(Op->Src1.ID()));
+    imul(eax, GetSrc<RA_32>(Op->Src2.ID()));
     mov(Dst.cvt32(), eax);
   break;
   case 8:
-    mov(rax, GetSrc<RA_64>(Op->Header.Args[0].ID()));
-    imul(rax, GetSrc<RA_64>(Op->Header.Args[1].ID()));
+    mov(rax, GetSrc<RA_64>(Op->Src1.ID()));
+    imul(rax, GetSrc<RA_64>(Op->Src2.ID()));
     mov(Dst, rax);
   break;
   default: LOGMAN_MSG_A_FMT("Unknown Mul size: {}", OpSize);
@@ -184,17 +184,17 @@ DEF_OP(Mul) {
 
 DEF_OP(UMul) {
   auto Op = IROp->C<IR::IROp_UMul>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   switch (OpSize) {
   case 4:
-    mov(rax, GetSrc<RA_32>(Op->Header.Args[0].ID()));
-    mul(GetSrc<RA_32>(Op->Header.Args[1].ID()));
+    mov(rax, GetSrc<RA_32>(Op->Src1.ID()));
+    mul(GetSrc<RA_32>(Op->Src2.ID()));
     mov(GetDst<RA_64>(Node), rax);
   break;
   case 8:
-    mov(rax, GetSrc<RA_64>(Op->Header.Args[0].ID()));
-    mul(GetSrc<RA_64>(Op->Header.Args[1].ID()));
+    mov(rax, GetSrc<RA_64>(Op->Src1.ID()));
+    mul(GetSrc<RA_64>(Op->Src2.ID()));
     mov(GetDst<RA_64>(Node), rax);
   break;
   default: LOGMAN_MSG_A_FMT("Unknown UMul size: {}", OpSize);
@@ -203,36 +203,36 @@ DEF_OP(UMul) {
 
 DEF_OP(Div) {
   auto Op = IROp->C<IR::IROp_Div>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   // Each source is OpSize in size
   // So you can have up to a 128bit divide from x86-64
   auto Size = OpSize;
   switch (Size) {
   case 1: {
-    movsx(ax, GetSrc<RA_8>(Op->Header.Args[0].ID()));
-    idiv(GetSrc<RA_8>(Op->Header.Args[1].ID()));
+    movsx(ax, GetSrc<RA_8>(Op->Src1.ID()));
+    idiv(GetSrc<RA_8>(Op->Src2.ID()));
     movsx(GetDst<RA_32>(Node), al);
   break;
   }
   case 2: {
-    mov (ax, GetSrc<RA_16>(Op->Header.Args[0].ID()));
+    mov (ax, GetSrc<RA_16>(Op->Src1.ID()));
     cwd();
-    idiv(GetSrc<RA_16>(Op->Header.Args[1].ID()));
+    idiv(GetSrc<RA_16>(Op->Src2.ID()));
     movsx(GetDst<RA_32>(Node), ax);
   break;
   }
   case 4: {
-    mov (eax, GetSrc<RA_32>(Op->Header.Args[0].ID()));
+    mov (eax, GetSrc<RA_32>(Op->Src1.ID()));
     cdq();
-    idiv(GetSrc<RA_32>(Op->Header.Args[1].ID()));
+    idiv(GetSrc<RA_32>(Op->Src2.ID()));
     movsxd(GetDst<RA_64>(Node).cvt64(), eax);
   break;
   }
   case 8: {
-    mov (rax, GetSrc<RA_64>(Op->Header.Args[0].ID()));
+    mov (rax, GetSrc<RA_64>(Op->Src1.ID()));
     cqo();
-    idiv(GetSrc<RA_64>(Op->Header.Args[1].ID()));
+    idiv(GetSrc<RA_64>(Op->Src2.ID()));
     mov(GetDst<RA_64>(Node), rax);
   break;
   }
@@ -242,39 +242,39 @@ DEF_OP(Div) {
 
 DEF_OP(UDiv) {
   auto Op = IROp->C<IR::IROp_UDiv>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   // Each source is OpSize in size
   // So you can have up to a 128bit divide from x86-64
   switch (OpSize) {
   case 1: {
-    mov (al, GetSrc<RA_8>(Op->Header.Args[0].ID()));
+    mov (al, GetSrc<RA_8>(Op->Src1.ID()));
     mov (edx, 0);
-    mov (cl, GetSrc<RA_8>(Op->Header.Args[1].ID()));
+    mov (cl, GetSrc<RA_8>(Op->Src2.ID()));
     div(cl);
     movzx(GetDst<RA_32>(Node), al);
   break;
   }
   case 2: {
-    mov (ax, GetSrc<RA_16>(Op->Header.Args[0].ID()));
+    mov (ax, GetSrc<RA_16>(Op->Src1.ID()));
     mov (edx, 0);
-    mov (cx, GetSrc<RA_16>(Op->Header.Args[1].ID()));
+    mov (cx, GetSrc<RA_16>(Op->Src2.ID()));
     div(cx);
     movzx(GetDst<RA_32>(Node), ax);
   break;
   }
   case 4: {
-    mov (eax, GetSrc<RA_32>(Op->Header.Args[0].ID()));
+    mov (eax, GetSrc<RA_32>(Op->Src1.ID()));
     mov (edx, 0);
-    mov (ecx, GetSrc<RA_32>(Op->Header.Args[1].ID()));
+    mov (ecx, GetSrc<RA_32>(Op->Src2.ID()));
     div(ecx);
     mov(GetDst<RA_32>(Node), eax);
   break;
   }
   case 8: {
-    mov (rax, GetSrc<RA_64>(Op->Header.Args[0].ID()));
+    mov (rax, GetSrc<RA_64>(Op->Src1.ID()));
     mov (rdx, 0);
-    mov (rcx, GetSrc<RA_64>(Op->Header.Args[1].ID()));
+    mov (rcx, GetSrc<RA_64>(Op->Src2.ID()));
     div(rcx);
     mov(GetDst<RA_64>(Node), rax);
   break;
@@ -285,34 +285,34 @@ DEF_OP(UDiv) {
 
 DEF_OP(Rem) {
   auto Op = IROp->C<IR::IROp_Rem>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   switch (OpSize) {
   case 1: {
-    movsx(ax, GetSrc<RA_8>(Op->Header.Args[0].ID()));
-    idiv(GetSrc<RA_8>(Op->Header.Args[1].ID()));
+    movsx(ax, GetSrc<RA_8>(Op->Src1.ID()));
+    idiv(GetSrc<RA_8>(Op->Src2.ID()));
     mov(al, ah);
     movsx(GetDst<RA_32>(Node), al);
   break;
   }
   case 2: {
-    mov (ax, GetSrc<RA_16>(Op->Header.Args[0].ID()));
+    mov (ax, GetSrc<RA_16>(Op->Src1.ID()));
     cwd();
-    idiv(GetSrc<RA_16>(Op->Header.Args[1].ID()));
+    idiv(GetSrc<RA_16>(Op->Src2.ID()));
     movsx(GetDst<RA_32>(Node), dx);
   break;
   }
   case 4: {
-    mov (eax, GetSrc<RA_32>(Op->Header.Args[0].ID()));
+    mov (eax, GetSrc<RA_32>(Op->Src1.ID()));
     cdq();
-    idiv(GetSrc<RA_32>(Op->Header.Args[1].ID()));
+    idiv(GetSrc<RA_32>(Op->Src2.ID()));
     movsxd(GetDst<RA_64>(Node).cvt64(), edx);
   break;
   }
   case 8: {
-    mov (rax, GetSrc<RA_64>(Op->Header.Args[0].ID()));
+    mov (rax, GetSrc<RA_64>(Op->Src1.ID()));
     cqo();
-    idiv(GetSrc<RA_64>(Op->Header.Args[1].ID()));
+    idiv(GetSrc<RA_64>(Op->Src2.ID()));
     mov(GetDst<RA_64>(Node), rdx);
   break;
   }
@@ -322,39 +322,39 @@ DEF_OP(Rem) {
 
 DEF_OP(URem) {
   auto Op = IROp->C<IR::IROp_URem>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   // Each source is OpSize in size
   // So you can have up to a 128bit divide from x86-64
   switch (OpSize) {
   case 1: {
-    mov (al, GetSrc<RA_8>(Op->Header.Args[0].ID()));
+    mov (al, GetSrc<RA_8>(Op->Src1.ID()));
     mov (edx, 0);
-    mov (cl, GetSrc<RA_8>(Op->Header.Args[1].ID()));
+    mov (cl, GetSrc<RA_8>(Op->Src2.ID()));
     div(cl);
     movzx(GetDst<RA_32>(Node), ah);
   break;
   }
   case 2: {
-    mov (ax, GetSrc<RA_16>(Op->Header.Args[0].ID()));
+    mov (ax, GetSrc<RA_16>(Op->Src1.ID()));
     mov (edx, 0);
-    mov (cx, GetSrc<RA_16>(Op->Header.Args[1].ID()));
+    mov (cx, GetSrc<RA_16>(Op->Src2.ID()));
     div(cx);
     movzx(GetDst<RA_32>(Node), dx);
   break;
   }
   case 4: {
-    mov (eax, GetSrc<RA_32>(Op->Header.Args[0].ID()));
+    mov (eax, GetSrc<RA_32>(Op->Src1.ID()));
     mov (edx, 0);
-    mov (ecx, GetSrc<RA_32>(Op->Header.Args[1].ID()));
+    mov (ecx, GetSrc<RA_32>(Op->Src2.ID()));
     div(ecx);
     mov(GetDst<RA_32>(Node), edx);
   break;
   }
   case 8: {
-    mov (rax, GetSrc<RA_64>(Op->Header.Args[0].ID()));
+    mov (rax, GetSrc<RA_64>(Op->Src1.ID()));
     mov (rdx, 0);
-    mov (rcx, GetSrc<RA_64>(Op->Header.Args[1].ID()));
+    mov (rcx, GetSrc<RA_64>(Op->Src2.ID()));
     div(rcx);
     mov(GetDst<RA_64>(Node), rdx);
   break;
@@ -365,17 +365,17 @@ DEF_OP(URem) {
 
 DEF_OP(MulH) {
   auto Op = IROp->C<IR::IROp_MulH>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   switch (OpSize) {
   case 4:
-    movsxd(rax, GetSrc<RA_32>(Op->Header.Args[0].ID()));
-    imul(GetSrc<RA_32>(Op->Header.Args[1].ID()));
+    movsxd(rax, GetSrc<RA_32>(Op->Src1.ID()));
+    imul(GetSrc<RA_32>(Op->Src2.ID()));
     movsxd(GetDst<RA_64>(Node).cvt64(), edx);
   break;
   case 8:
-    mov(rax, GetSrc<RA_64>(Op->Header.Args[0].ID()));
-    imul(GetSrc<RA_64>(Op->Header.Args[1].ID()));
+    mov(rax, GetSrc<RA_64>(Op->Src1.ID()));
+    imul(GetSrc<RA_64>(Op->Src2.ID()));
     mov(GetDst<RA_64>(Node), rdx);
   break;
   default: LOGMAN_MSG_A_FMT("Unknown MulH size: {}", OpSize);
@@ -384,17 +384,17 @@ DEF_OP(MulH) {
 
 DEF_OP(UMulH) {
   auto Op = IROp->C<IR::IROp_UMulH>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   switch (OpSize) {
   case 4:
-    mov(rax, GetSrc<RA_32>(Op->Header.Args[0].ID()));
-    mul(GetSrc<RA_32>(Op->Header.Args[1].ID()));
+    mov(rax, GetSrc<RA_32>(Op->Src1.ID()));
+    mul(GetSrc<RA_32>(Op->Src2.ID()));
     mov(GetDst<RA_64>(Node), rdx);
   break;
   case 8:
-    mov(rax, GetSrc<RA_64>(Op->Header.Args[0].ID()));
-    mul(GetSrc<RA_64>(Op->Header.Args[1].ID()));
+    mov(rax, GetSrc<RA_64>(Op->Src1.ID()));
+    mul(GetSrc<RA_64>(Op->Src2.ID()));
     mov(GetDst<RA_64>(Node), rdx);
   break;
   default: LOGMAN_MSG_A_FMT("Unknown UMulH size: {}", OpSize);
@@ -404,13 +404,13 @@ DEF_OP(UMulH) {
 DEF_OP(Or) {
   auto Op = IROp->C<IR::IROp_Or>();
   auto Dst = GetDst<RA_64>(Node);
-  mov(rax, GetSrc<RA_64>(Op->Header.Args[0].ID()));
+  mov(rax, GetSrc<RA_64>(Op->Src1.ID()));
 
   uint64_t Const;
-  if (IsInlineConstant(Op->Header.Args[1], &Const)) {
+  if (IsInlineConstant(Op->Src2, &Const)) {
     or_(rax, Const);
   } else {
-    or_(rax, GetSrc<RA_64>(Op->Header.Args[1].ID()));
+    or_(rax, GetSrc<RA_64>(Op->Src2.ID()));
   }
   mov(Dst, rax);
 }
@@ -418,20 +418,20 @@ DEF_OP(Or) {
 DEF_OP(And) {
   auto Op = IROp->C<IR::IROp_And>();
   auto Dst = GetDst<RA_64>(Node);
-  mov(rax, GetSrc<RA_64>(Op->Header.Args[0].ID()));
+  mov(rax, GetSrc<RA_64>(Op->Src1.ID()));
   uint64_t Const;
-  if (IsInlineConstant(Op->Header.Args[1], &Const)) {
+  if (IsInlineConstant(Op->Src2, &Const)) {
     and_(rax, Const);
   } else {
-    and_(rax, GetSrc<RA_64>(Op->Header.Args[1].ID()));
+    and_(rax, GetSrc<RA_64>(Op->Src2.ID()));
   }
   mov(Dst, rax);
 }
 
 DEF_OP(Andn) {
   auto Op = IROp->C<IR::IROp_Andn>();
-  const auto& Lhs = Op->Header.Args[0];
-  const auto& Rhs = Op->Header.Args[1];
+  const auto& Lhs = Op->Src1;
+  const auto& Rhs = Op->Src2;
   auto Dst = GRD(Node);
 
   uint64_t Const{};
@@ -450,47 +450,46 @@ DEF_OP(Andn) {
 DEF_OP(Xor) {
   auto Op = IROp->C<IR::IROp_Xor>();
   auto Dst = GetDst<RA_64>(Node);
-  mov(rax, GetSrc<RA_64>(Op->Header.Args[0].ID()));
+  mov(rax, GetSrc<RA_64>(Op->Src1.ID()));
   uint64_t Const;
-  if (IsInlineConstant(Op->Header.Args[1], &Const)) {
+  if (IsInlineConstant(Op->Src2, &Const)) {
     xor_(rax, Const);
   } else {
-    xor_(rax, GetSrc<RA_64>(Op->Header.Args[1].ID()));
+    xor_(rax, GetSrc<RA_64>(Op->Src2.ID()));
   }
   mov(Dst, rax);
 }
 
 DEF_OP(Lshl) {
   auto Op = IROp->C<IR::IROp_Lshl>();
-  uint8_t OpSize = IROp->Size;
-
-  uint8_t Mask = OpSize * 8 - 1;
+  const uint8_t OpSize = IROp->Size;
+  const uint8_t Mask = OpSize * 8 - 1;
 
   uint64_t Const;
-  if (IsInlineConstant(Op->Header.Args[1], &Const)) {
+  if (IsInlineConstant(Op->Src2, &Const)) {
     Const &= Mask;
     switch (OpSize) {
       case 4:
-        mov(GetDst<RA_32>(Node), GetSrc<RA_32>(Op->Header.Args[0].ID()));
+        mov(GetDst<RA_32>(Node), GetSrc<RA_32>(Op->Src1.ID()));
         shl(GetDst<RA_32>(Node), Const);
         break;
       case 8:
-        mov(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()));
+        mov(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Src1.ID()));
         shl(GetDst<RA_64>(Node), Const);
         break;
       default: LOGMAN_MSG_A_FMT("Unknown LSHL Size: {}\n", OpSize); break;
     };
   } else {
-    mov(rcx, GetSrc<RA_64>(Op->Header.Args[1].ID()));
+    mov(rcx, GetSrc<RA_64>(Op->Src2.ID()));
     and_(rcx, Mask);
 
     switch (OpSize) {
       case 4:
-        mov(GetDst<RA_32>(Node), GetSrc<RA_32>(Op->Header.Args[0].ID()));
+        mov(GetDst<RA_32>(Node), GetSrc<RA_32>(Op->Src1.ID()));
         shl(GetDst<RA_32>(Node), cl);
         break;
       case 8:
-        mov(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()));
+        mov(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Src1.ID()));
         shl(GetDst<RA_64>(Node), cl);
         break;
       default: LOGMAN_MSG_A_FMT("Unknown LSHL Size: {}\n", OpSize); break;
@@ -500,53 +499,52 @@ DEF_OP(Lshl) {
 
 DEF_OP(Lshr) {
   auto Op = IROp->C<IR::IROp_Lshr>();
-  uint8_t OpSize = IROp->Size;
-
-  uint8_t Mask = OpSize * 8 - 1;
+  const uint8_t OpSize = IROp->Size;
+  const uint8_t Mask = OpSize * 8 - 1;
 
   uint64_t Const;
-  if (IsInlineConstant(Op->Header.Args[1], &Const)) {
+  if (IsInlineConstant(Op->Src2, &Const)) {
     Const &= Mask;
 
     switch (OpSize) {
       case 1:
-        movzx(GetDst<RA_32>(Node), GetSrc<RA_8>(Op->Header.Args[0].ID()));
+        movzx(GetDst<RA_32>(Node), GetSrc<RA_8>(Op->Src1.ID()));
         shr(GetDst<RA_32>(Node).cvt8(), Const);
         break;
       case 2:
-        movzx(GetDst<RA_32>(Node), GetSrc<RA_16>(Op->Header.Args[0].ID()));
+        movzx(GetDst<RA_32>(Node), GetSrc<RA_16>(Op->Src1.ID()));
         shr(GetDst<RA_32>(Node).cvt16(), Const);
         break;
       case 4:
-        mov(GetDst<RA_32>(Node), GetSrc<RA_32>(Op->Header.Args[0].ID()));
+        mov(GetDst<RA_32>(Node), GetSrc<RA_32>(Op->Src1.ID()));
         shr(GetDst<RA_32>(Node), Const);
         break;
       case 8:
-        mov(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()));
+        mov(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Src1.ID()));
         shr(GetDst<RA_64>(Node), Const);
         break;
       default: LOGMAN_MSG_A_FMT("Unknown Size: {}\n", OpSize); break;
     };
 
   } else {
-    mov (rcx, GetSrc<RA_64>(Op->Header.Args[1].ID()));
+    mov (rcx, GetSrc<RA_64>(Op->Src2.ID()));
     and_(rcx, Mask);
 
     switch (OpSize) {
       case 1:
-        movzx(GetDst<RA_32>(Node), GetSrc<RA_8>(Op->Header.Args[0].ID()));
+        movzx(GetDst<RA_32>(Node), GetSrc<RA_8>(Op->Src1.ID()));
         shr(GetDst<RA_32>(Node).cvt8(), cl);
         break;
       case 2:
-        movzx(GetDst<RA_32>(Node), GetSrc<RA_16>(Op->Header.Args[0].ID()));
+        movzx(GetDst<RA_32>(Node), GetSrc<RA_16>(Op->Src1.ID()));
         shr(GetDst<RA_32>(Node).cvt16(), cl);
         break;
       case 4:
-        mov(GetDst<RA_32>(Node), GetSrc<RA_32>(Op->Header.Args[0].ID()));
+        mov(GetDst<RA_32>(Node), GetSrc<RA_32>(Op->Src1.ID()));
         shr(GetDst<RA_32>(Node), cl);
         break;
       case 8:
-        mov(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()));
+        mov(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Src1.ID()));
         shr(GetDst<RA_64>(Node), cl);
         break;
       default: LOGMAN_MSG_A_FMT("Unknown Size: {}\n", OpSize); break;
@@ -556,56 +554,55 @@ DEF_OP(Lshr) {
 
 DEF_OP(Ashr) {
   auto Op = IROp->C<IR::IROp_Ashr>();
-  uint8_t OpSize = IROp->Size;
-
-  uint8_t Mask = OpSize * 8 - 1;
+  const uint8_t OpSize = IROp->Size;
+  const uint8_t Mask = OpSize * 8 - 1;
 
   uint64_t Const;
-  if (IsInlineConstant(Op->Header.Args[1], &Const)) {
+  if (IsInlineConstant(Op->Src2, &Const)) {
     Const &= Mask;
 
     switch (OpSize) {
     case 1:
-      movsx(rax, GetSrc<RA_8>(Op->Header.Args[0].ID()));
+      movsx(rax, GetSrc<RA_8>(Op->Src1.ID()));
       sar(al, Const);
       movzx(GetDst<RA_64>(Node), al);
     break;
     case 2:
-      movsx(rax, GetSrc<RA_16>(Op->Header.Args[0].ID()));
+      movsx(rax, GetSrc<RA_16>(Op->Src1.ID()));
       sar(ax, Const);
       movzx(GetDst<RA_64>(Node), ax);
     break;
     case 4:
-      mov(GetDst<RA_32>(Node), GetSrc<RA_32>(Op->Header.Args[0].ID()));
+      mov(GetDst<RA_32>(Node), GetSrc<RA_32>(Op->Src1.ID()));
       sar(GetDst<RA_32>(Node), Const);
     break;
     case 8:
-      mov(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()));
+      mov(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Src1.ID()));
       sar(GetDst<RA_64>(Node), Const);
     break;
     default: LOGMAN_MSG_A_FMT("Unknown ASHR Size: {}\n", OpSize); break;
     };
 
   } else {
-    mov (rcx, GetSrc<RA_64>(Op->Header.Args[1].ID()));
+    mov (rcx, GetSrc<RA_64>(Op->Src2.ID()));
     and_(rcx, Mask);
     switch (OpSize) {
     case 1:
-      movsx(rax, GetSrc<RA_8>(Op->Header.Args[0].ID()));
+      movsx(rax, GetSrc<RA_8>(Op->Src1.ID()));
       sar(al, cl);
       movzx(GetDst<RA_64>(Node), al);
     break;
     case 2:
-      movsx(rax, GetSrc<RA_16>(Op->Header.Args[0].ID()));
+      movsx(rax, GetSrc<RA_16>(Op->Src1.ID()));
       sar(ax, cl);
       movzx(GetDst<RA_64>(Node), ax);
     break;
     case 4:
-      mov(GetDst<RA_32>(Node), GetSrc<RA_32>(Op->Header.Args[0].ID()));
+      mov(GetDst<RA_32>(Node), GetSrc<RA_32>(Op->Src1.ID()));
       sar(GetDst<RA_32>(Node), cl);
     break;
     case 8:
-      mov(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()));
+      mov(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Src1.ID()));
       sar(GetDst<RA_64>(Node), cl);
     break;
     default: LOGMAN_MSG_A_FMT("Unknown ASHR Size: {}\n", OpSize); break;
@@ -615,37 +612,36 @@ DEF_OP(Ashr) {
 
 DEF_OP(Ror) {
   auto Op = IROp->C<IR::IROp_Ror>();
-  uint8_t OpSize = IROp->Size;
-
-  uint8_t Mask = OpSize * 8 - 1;
+  const uint8_t OpSize = IROp->Size;
+  const uint8_t Mask = OpSize * 8 - 1;
 
   uint64_t Const;
-  if (IsInlineConstant(Op->Header.Args[1], &Const)) {
+  if (IsInlineConstant(Op->Src2, &Const)) {
     Const &= Mask;
     switch (OpSize) {
       case 4: {
-        mov(eax, GetSrc<RA_32>(Op->Header.Args[0].ID()));
+        mov(eax, GetSrc<RA_32>(Op->Src1.ID()));
         ror(eax, Const);
       break;
       }
       case 8: {
-        mov(rax, GetSrc<RA_64>(Op->Header.Args[0].ID()));
+        mov(rax, GetSrc<RA_64>(Op->Src1.ID()));
         ror(rax, Const);
       break;
       }
       default: LOGMAN_MSG_A_FMT("Unknown ROR Size: {}\n", OpSize); break;
     }
   } else {
-    mov (rcx, GetSrc<RA_64>(Op->Header.Args[1].ID()));
+    mov (rcx, GetSrc<RA_64>(Op->Src2.ID()));
     and_(rcx, Mask);
     switch (OpSize) {
       case 4: {
-        mov(eax, GetSrc<RA_32>(Op->Header.Args[0].ID()));
+        mov(eax, GetSrc<RA_32>(Op->Src1.ID()));
         ror(eax, cl);
       break;
       }
       case 8: {
-        mov(rax, GetSrc<RA_64>(Op->Header.Args[0].ID()));
+        mov(rax, GetSrc<RA_64>(Op->Src1.ID()));
         ror(rax, cl);
       break;
       }
@@ -657,19 +653,19 @@ DEF_OP(Ror) {
 
 DEF_OP(Extr) {
   auto Op = IROp->C<IR::IROp_Extr>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   switch (OpSize) {
     case 4: {
-      mov(eax, GetSrc<RA_32>(Op->Header.Args[0].ID()));
-      mov(ecx, GetSrc<RA_32>(Op->Header.Args[1].ID()));
+      mov(eax, GetSrc<RA_32>(Op->Upper.ID()));
+      mov(ecx, GetSrc<RA_32>(Op->Lower.ID()));
       shrd(ecx, eax, Op->LSB);
       mov(GetDst<RA_32>(Node), ecx);
       break;
     }
     case 8: {
-      mov(rax, GetSrc<RA_64>(Op->Header.Args[0].ID()));
-      mov(rcx, GetSrc<RA_64>(Op->Header.Args[1].ID()));
+      mov(rax, GetSrc<RA_64>(Op->Upper.ID()));
+      mov(rcx, GetSrc<RA_64>(Op->Lower.ID()));
       shrd(rcx, rax, Op->LSB);
       mov(GetDst<RA_64>(Node), rcx);
       break;
@@ -681,8 +677,8 @@ DEF_OP(PDep) {
   const auto Op = IROp->C<IR::IROp_PExt>();
   const auto OpSize = IROp->Size;
 
-  const auto Input = GRS(Op->Args(0).ID());
-  const auto Mask  = GRS(Op->Args(1).ID());
+  const auto Input = GRS(Op->Input.ID());
+  const auto Mask  = GRS(Op->Mask.ID());
   const auto Dest  = GRD(Node);
 
   if (OpSize == 4) {
@@ -696,8 +692,8 @@ DEF_OP(PExt) {
   const auto Op = IROp->C<IR::IROp_PExt>();
   const auto OpSize = IROp->Size;
 
-  const auto Input = GRS(Op->Args(0).ID());
-  const auto Mask  = GRS(Op->Args(1).ID());
+  const auto Input = GRS(Op->Input.ID());
+  const auto Mask  = GRS(Op->Mask.ID());
   const auto Dest  = GRD(Node);
 
   if (OpSize == 4) {
@@ -709,29 +705,29 @@ DEF_OP(PExt) {
 
 DEF_OP(LDiv) {
   auto Op = IROp->C<IR::IROp_LDiv>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   // Each source is OpSize in size
   // So you can have up to a 128bit divide from x86-64
   switch (OpSize) {
     case 2: {
-      mov(eax, GetSrc<RA_16>(Op->Header.Args[0].ID()));
-      mov(edx, GetSrc<RA_16>(Op->Header.Args[1].ID()));
-      idiv(GetSrc<RA_16>(Op->Header.Args[2].ID()));
+      mov(eax, GetSrc<RA_16>(Op->Lower.ID()));
+      mov(edx, GetSrc<RA_16>(Op->Upper.ID()));
+      idiv(GetSrc<RA_16>(Op->Divisor.ID()));
       movsx(GetDst<RA_64>(Node), ax);
       break;
     }
     case 4: {
-      mov(eax, GetSrc<RA_32>(Op->Header.Args[0].ID()));
-      mov(edx, GetSrc<RA_32>(Op->Header.Args[1].ID()));
-      idiv(GetSrc<RA_32>(Op->Header.Args[2].ID()));
+      mov(eax, GetSrc<RA_32>(Op->Lower.ID()));
+      mov(edx, GetSrc<RA_32>(Op->Upper.ID()));
+      idiv(GetSrc<RA_32>(Op->Divisor.ID()));
       movsxd(GetDst<RA_64>(Node).cvt64(), eax);
       break;
     }
     case 8: {
-      mov(rax, GetSrc<RA_64>(Op->Header.Args[0].ID()));
-      mov(rdx, GetSrc<RA_64>(Op->Header.Args[1].ID()));
-      idiv(GetSrc<RA_64>(Op->Header.Args[2].ID()));
+      mov(rax, GetSrc<RA_64>(Op->Lower.ID()));
+      mov(rdx, GetSrc<RA_64>(Op->Upper.ID()));
+      idiv(GetSrc<RA_64>(Op->Divisor.ID()));
       mov(GetDst<RA_64>(Node), rax);
       break;
     }
@@ -741,29 +737,29 @@ DEF_OP(LDiv) {
 
 DEF_OP(LUDiv) {
   auto Op = IROp->C<IR::IROp_LUDiv>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   // Each source is OpSize in size
   // So you can have up to a 128bit divide from x86-64
   switch (OpSize) {
     case 2: {
-      mov (ax, GetSrc<RA_16>(Op->Header.Args[0].ID()));
-      mov (dx, GetSrc<RA_16>(Op->Header.Args[1].ID()));
-      div(GetSrc<RA_16>(Op->Header.Args[2].ID()));
+      mov (ax, GetSrc<RA_16>(Op->Lower.ID()));
+      mov (dx, GetSrc<RA_16>(Op->Upper.ID()));
+      div(GetSrc<RA_16>(Op->Divisor.ID()));
       movzx(GetDst<RA_32>(Node), ax);
       break;
     }
     case 4: {
-      mov (eax, GetSrc<RA_32>(Op->Header.Args[0].ID()));
-      mov (edx, GetSrc<RA_32>(Op->Header.Args[1].ID()));
-      div(GetSrc<RA_32>(Op->Header.Args[2].ID()));
+      mov (eax, GetSrc<RA_32>(Op->Lower.ID()));
+      mov (edx, GetSrc<RA_32>(Op->Upper.ID()));
+      div(GetSrc<RA_32>(Op->Divisor.ID()));
       mov(GetDst<RA_64>(Node), rax);
       break;
     }
     case 8: {
-      mov (rax, GetSrc<RA_64>(Op->Header.Args[0].ID()));
-      mov (rdx, GetSrc<RA_64>(Op->Header.Args[1].ID()));
-      div(GetSrc<RA_64>(Op->Header.Args[2].ID()));
+      mov (rax, GetSrc<RA_64>(Op->Lower.ID()));
+      mov (rdx, GetSrc<RA_64>(Op->Upper.ID()));
+      div(GetSrc<RA_64>(Op->Divisor.ID()));
       mov(GetDst<RA_64>(Node), rax);
       break;
     }
@@ -773,29 +769,29 @@ DEF_OP(LUDiv) {
 
 DEF_OP(LRem) {
   auto Op = IROp->C<IR::IROp_LRem>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   // Each source is OpSize in size
   // So you can have up to a 128bit divide from x86-64
   switch (OpSize) {
     case 2: {
-      mov(ax, GetSrc<RA_16>(Op->Header.Args[0].ID()));
-      mov(dx, GetSrc<RA_16>(Op->Header.Args[1].ID()));
-      idiv(GetSrc<RA_16>(Op->Header.Args[2].ID()));
+      mov(ax, GetSrc<RA_16>(Op->Lower.ID()));
+      mov(dx, GetSrc<RA_16>(Op->Upper.ID()));
+      idiv(GetSrc<RA_16>(Op->Divisor.ID()));
       movsx(GetDst<RA_64>(Node), dx);
       break;
     }
     case 4: {
-      mov(eax, GetSrc<RA_32>(Op->Header.Args[0].ID()));
-      mov(edx, GetSrc<RA_32>(Op->Header.Args[1].ID()));
-      idiv(GetSrc<RA_32>(Op->Header.Args[2].ID()));
+      mov(eax, GetSrc<RA_32>(Op->Lower.ID()));
+      mov(edx, GetSrc<RA_32>(Op->Upper.ID()));
+      idiv(GetSrc<RA_32>(Op->Divisor.ID()));
       mov(GetDst<RA_64>(Node), rdx);
       break;
     }
     case 8: {
-      mov(rax, GetSrc<RA_64>(Op->Header.Args[0].ID()));
-      mov(rdx, GetSrc<RA_64>(Op->Header.Args[1].ID()));
-      idiv(GetSrc<RA_64>(Op->Header.Args[2].ID()));
+      mov(rax, GetSrc<RA_64>(Op->Lower.ID()));
+      mov(rdx, GetSrc<RA_64>(Op->Upper.ID()));
+      idiv(GetSrc<RA_64>(Op->Divisor.ID()));
       mov(GetDst<RA_64>(Node), rdx);
       break;
     }
@@ -805,29 +801,29 @@ DEF_OP(LRem) {
 
 DEF_OP(LURem) {
   auto Op = IROp->C<IR::IROp_LURem>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   // Each source is OpSize in size
   // So you can have up to a 128bit divide from x86-64
   switch (OpSize) {
     case 2: {
-      mov (ax, GetSrc<RA_16>(Op->Header.Args[0].ID()));
-      mov (dx, GetSrc<RA_16>(Op->Header.Args[1].ID()));
-      div(GetSrc<RA_16>(Op->Header.Args[2].ID()));
+      mov (ax, GetSrc<RA_16>(Op->Lower.ID()));
+      mov (dx, GetSrc<RA_16>(Op->Upper.ID()));
+      div(GetSrc<RA_16>(Op->Divisor.ID()));
       movzx(GetDst<RA_64>(Node), dx);
       break;
     }
     case 4: {
-      mov (eax, GetSrc<RA_32>(Op->Header.Args[0].ID()));
-      mov (edx, GetSrc<RA_32>(Op->Header.Args[1].ID()));
-      div(GetSrc<RA_32>(Op->Header.Args[2].ID()));
+      mov (eax, GetSrc<RA_32>(Op->Lower.ID()));
+      mov (edx, GetSrc<RA_32>(Op->Upper.ID()));
+      div(GetSrc<RA_32>(Op->Divisor.ID()));
       mov(GetDst<RA_64>(Node), rdx);
       break;
     }
     case 8: {
-      mov (rax, GetSrc<RA_64>(Op->Header.Args[0].ID()));
-      mov (rdx, GetSrc<RA_64>(Op->Header.Args[1].ID()));
-      div(GetSrc<RA_64>(Op->Header.Args[2].ID()));
+      mov (rax, GetSrc<RA_64>(Op->Lower.ID()));
+      mov (rdx, GetSrc<RA_64>(Op->Upper.ID()));
+      div(GetSrc<RA_64>(Op->Divisor.ID()));
       mov(GetDst<RA_64>(Node), rdx);
       break;
     }
@@ -839,31 +835,31 @@ DEF_OP(LURem) {
 DEF_OP(Not) {
   auto Op = IROp->C<IR::IROp_Not>();
   auto Dst = GetDst<RA_64>(Node);
-  mov(Dst, GetSrc<RA_64>(Op->Header.Args[0].ID()));
+  mov(Dst, GetSrc<RA_64>(Op->Src.ID()));
   not_(Dst);
 }
 
 DEF_OP(Popcount) {
   auto Op = IROp->C<IR::IROp_Popcount>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   auto Dst64 = GetDst<RA_64>(Node);
 
   switch (OpSize) {
     case 1:
-      movzx(GetDst<RA_32>(Node), GetSrc<RA_8>(Op->Header.Args[0].ID()));
+      movzx(GetDst<RA_32>(Node), GetSrc<RA_8>(Op->Src.ID()));
       popcnt(Dst64, Dst64);
       break;
     case 2: {
-      movzx(GetDst<RA_32>(Node), GetSrc<RA_16>(Op->Header.Args[0].ID()));
+      movzx(GetDst<RA_32>(Node), GetSrc<RA_16>(Op->Src.ID()));
       popcnt(Dst64, Dst64);
       break;
     }
     case 4:
-      popcnt(GetDst<RA_32>(Node), GetSrc<RA_32>(Op->Header.Args[0].ID()));
+      popcnt(GetDst<RA_32>(Node), GetSrc<RA_32>(Op->Src.ID()));
       break;
     case 8:
-      popcnt(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()));
+      popcnt(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Src.ID()));
       break;
   }
 }
@@ -871,11 +867,11 @@ DEF_OP(Popcount) {
 DEF_OP(FindLSB) {
   auto Op = IROp->C<IR::IROp_FindLSB>();
 
-  bsf(rcx, GetSrc<RA_64>(Op->Header.Args[0].ID()));
+  bsf(rcx, GetSrc<RA_64>(Op->Src.ID()));
   mov(rax, 0x40);
   cmovz(rcx, rax);
   xor_(rax, rax);
-  cmp(GetSrc<RA_64>(Op->Header.Args[0].ID()), 1);
+  cmp(GetSrc<RA_64>(Op->Src.ID()), 1);
   sbb(rax, rax);
   or_(rax, rcx);
   mov (GetDst<RA_64>(Node), rax);
@@ -883,18 +879,18 @@ DEF_OP(FindLSB) {
 
 DEF_OP(FindMSB) {
   auto Op = IROp->C<IR::IROp_FindMSB>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   switch (OpSize) {
     case 2:
-      bsr(GetDst<RA_16>(Node), GetSrc<RA_16>(Op->Header.Args[0].ID()));
+      bsr(GetDst<RA_16>(Node), GetSrc<RA_16>(Op->Src.ID()));
       movzx(GetDst<RA_32>(Node), GetDst<RA_16>(Node));
       break;
     case 4:
-      bsr(GetDst<RA_32>(Node), GetSrc<RA_32>(Op->Header.Args[0].ID()));
+      bsr(GetDst<RA_32>(Node), GetSrc<RA_32>(Op->Src.ID()));
       break;
     case 8:
-      bsr(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()));
+      bsr(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Src.ID()));
       break;
     default: LOGMAN_MSG_A_FMT("Unknown FindMSB OpSize: {}", OpSize);
   }
@@ -902,21 +898,21 @@ DEF_OP(FindMSB) {
 
 DEF_OP(FindTrailingZeros) {
   auto Op = IROp->C<IR::IROp_FindTrailingZeros>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   switch (OpSize) {
     case 2:
-      bsf(GetDst<RA_16>(Node), GetSrc<RA_16>(Op->Header.Args[0].ID()));
+      bsf(GetDst<RA_16>(Node), GetSrc<RA_16>(Op->Src.ID()));
       mov(ax, 0x10);
       cmovz(GetDst<RA_16>(Node), ax);
     break;
     case 4:
-      bsf(GetDst<RA_32>(Node), GetSrc<RA_32>(Op->Header.Args[0].ID()));
+      bsf(GetDst<RA_32>(Node), GetSrc<RA_32>(Op->Src.ID()));
       mov(eax, 0x20);
       cmovz(GetDst<RA_32>(Node), eax);
       break;
     case 8:
-      bsf(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()));
+      bsf(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Src.ID()));
       mov(rax, 0x40);
       cmovz(GetDst<RA_64>(Node), rax);
       break;
@@ -926,21 +922,21 @@ DEF_OP(FindTrailingZeros) {
 
 DEF_OP(CountLeadingZeroes) {
   auto Op = IROp->C<IR::IROp_CountLeadingZeroes>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   if (Features.has(Xbyak::util::Cpu::tLZCNT)) {
     switch (OpSize) {
       case 2: {
-        lzcnt(GetDst<RA_16>(Node), GetSrc<RA_16>(Op->Header.Args[0].ID()));
+        lzcnt(GetDst<RA_16>(Node), GetSrc<RA_16>(Op->Src.ID()));
         movzx(GetDst<RA_32>(Node), GetDst<RA_16>(Node));
         break;
       }
       case 4: {
-        lzcnt(GetDst<RA_32>(Node), GetSrc<RA_32>(Op->Header.Args[0].ID()));
+        lzcnt(GetDst<RA_32>(Node), GetSrc<RA_32>(Op->Src.ID()));
         break;
       }
       case 8: {
-        lzcnt(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()));
+        lzcnt(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Src.ID()));
         break;
       }
       default: LOGMAN_MSG_A_FMT("Unknown CountLeadingZeros size: {}", OpSize); break;
@@ -949,11 +945,11 @@ DEF_OP(CountLeadingZeroes) {
   else {
     switch (OpSize) {
       case 2: {
-        test(GetSrc<RA_16>(Op->Header.Args[0].ID()), GetSrc<RA_16>(Op->Header.Args[0].ID()));
+        test(GetSrc<RA_16>(Op->Src.ID()), GetSrc<RA_16>(Op->Src.ID()));
         mov(eax, 0x10);
         Label Skip;
         je(Skip);
-          bsr(ax, GetSrc<RA_16>(Op->Header.Args[0].ID()));
+          bsr(ax, GetSrc<RA_16>(Op->Src.ID()));
           xor_(ax, 0xF);
           movzx(eax, ax);
         L(Skip);
@@ -961,22 +957,22 @@ DEF_OP(CountLeadingZeroes) {
         break;
       }
       case 4: {
-        test(GetSrc<RA_32>(Op->Header.Args[0].ID()), GetSrc<RA_32>(Op->Header.Args[0].ID()));
+        test(GetSrc<RA_32>(Op->Src.ID()), GetSrc<RA_32>(Op->Src.ID()));
         mov(eax, 0x20);
         Label Skip;
         je(Skip);
-          bsr(eax, GetSrc<RA_32>(Op->Header.Args[0].ID()));
+          bsr(eax, GetSrc<RA_32>(Op->Src.ID()));
           xor_(eax, 0x1F);
         L(Skip);
         mov(GetDst<RA_32>(Node), eax);
         break;
       }
       case 8: {
-        test(GetSrc<RA_64>(Op->Header.Args[0].ID()), GetSrc<RA_64>(Op->Header.Args[0].ID()));
+        test(GetSrc<RA_64>(Op->Src.ID()), GetSrc<RA_64>(Op->Src.ID()));
         mov(rax, 0x40);
         Label Skip;
         je(Skip);
-          bsr(rax, GetSrc<RA_64>(Op->Header.Args[0].ID()));
+          bsr(rax, GetSrc<RA_64>(Op->Src.ID()));
           xor_(rax, 0x3F);
         L(Skip);
         mov(GetDst<RA_64>(Node), rax);
@@ -989,19 +985,19 @@ DEF_OP(CountLeadingZeroes) {
 
 DEF_OP(Rev) {
   auto Op = IROp->C<IR::IROp_Rev>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   switch (OpSize) {
     case 2:
-      mov (GetDst<RA_32>(Node), GetSrc<RA_32>(Op->Header.Args[0].ID()));
+      mov (GetDst<RA_32>(Node), GetSrc<RA_32>(Op->Src.ID()));
       rol(GetDst<RA_16>(Node), 8);
     break;
     case 4:
-      mov (GetDst<RA_32>(Node), GetSrc<RA_32>(Op->Header.Args[0].ID()));
+      mov (GetDst<RA_32>(Node), GetSrc<RA_32>(Op->Src.ID()));
       bswap(GetDst<RA_32>(Node).cvt32());
       break;
     case 8:
-      mov (GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()));
+      mov (GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Src.ID()));
       bswap(GetDst<RA_64>(Node).cvt64());
       break;
     default: LOGMAN_MSG_A_FMT("Unknown REV size: {}", OpSize); break;
@@ -1010,17 +1006,18 @@ DEF_OP(Rev) {
 
 DEF_OP(Bfi) {
   auto Op = IROp->C<IR::IROp_Bfi>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   auto Dst = GetDst<RA_64>(Node);
 
   uint64_t SourceMask = (1ULL << Op->Width) - 1;
-  if (Op->Width == 64)
+  if (Op->Width == 64) {
     SourceMask = ~0ULL;
-  uint64_t DestMask = ~(SourceMask << Op->lsb);
+  }
+  const uint64_t DestMask = ~(SourceMask << Op->lsb);
 
-  mov(TMP1, GetSrc<RA_64>(Op->Header.Args[1].ID()));
-  mov(Dst, GetSrc<RA_64>(Op->Header.Args[0].ID()));
+  mov(TMP1, GetSrc<RA_64>(Op->Src.ID()));
+  mov(Dst, GetSrc<RA_64>(Op->Dest.ID()));
 
   mov(TMP2, DestMask);
   and_(Dst, TMP2);
@@ -1045,16 +1042,16 @@ DEF_OP(Bfe) {
   if (Op->lsb == 0) {
     switch (Op->Width / 8) {
     case 1:
-      movzx(Dst, GetSrc<RA_8>(Op->Header.Args[0].ID()));
+      movzx(Dst, GetSrc<RA_8>(Op->Src.ID()));
       return;
     case 2:
-      movzx(Dst, GetSrc<RA_16>(Op->Header.Args[0].ID()));
+      movzx(Dst, GetSrc<RA_16>(Op->Src.ID()));
       return;
     case 4:
-      mov(Dst.cvt32(), GetSrc<RA_32>(Op->Header.Args[0].ID()));
+      mov(Dst.cvt32(), GetSrc<RA_32>(Op->Src.ID()));
       return;
     case 8:
-      mov(Dst, GetSrc<RA_64>(Op->Header.Args[0].ID()));
+      mov(Dst, GetSrc<RA_64>(Op->Src.ID()));
       return;
     default:
       // Need to use slower general case
@@ -1062,7 +1059,7 @@ DEF_OP(Bfe) {
     }
   }
 
-  mov(Dst, GetSrc<RA_64>(Op->Header.Args[0].ID()));
+  mov(Dst, GetSrc<RA_64>(Op->Src.ID()));
 
   if (Op->lsb != 0)
     shr(Dst, Op->lsb);
@@ -1081,16 +1078,16 @@ DEF_OP(Sbfe) {
   if (Op->lsb == 0) {
     switch (Op->Width / 8) {
     case 1:
-      movsx(Dst, GetSrc<RA_8>(Op->Header.Args[0].ID()));
+      movsx(Dst, GetSrc<RA_8>(Op->Src.ID()));
       return;
     case 2:
-      movsx(Dst, GetSrc<RA_16>(Op->Header.Args[0].ID()));
+      movsx(Dst, GetSrc<RA_16>(Op->Src.ID()));
       return;
     case 4:
-      movsxd(Dst.cvt64(), GetSrc<RA_32>(Op->Header.Args[0].ID()));
+      movsxd(Dst.cvt64(), GetSrc<RA_32>(Op->Src.ID()));
       return;
     case 8:
-      mov(Dst, GetSrc<RA_64>(Op->Header.Args[0].ID()));
+      mov(Dst, GetSrc<RA_64>(Op->Src.ID()));
       return;
     default:
       // Need to use slower general case
@@ -1102,7 +1099,7 @@ DEF_OP(Sbfe) {
   {
     uint64_t ShiftLeftAmount = (64 - (Op->Width + Op->lsb));
     uint64_t ShiftRightAmount = ShiftLeftAmount + Op->lsb;
-    mov(Dst, GetSrc<RA_64>(Op->Header.Args[0].ID()));
+    mov(Dst, GetSrc<RA_64>(Op->Src.ID()));
     shl(Dst, ShiftLeftAmount);
     sar(Dst, ShiftRightAmount);
   }
@@ -1150,19 +1147,19 @@ DEF_OP(VExtractToGPR) {
 
   switch (Op->Header.ElementSize) {
     case 1: {
-      pextrb(GetDst<RA_32>(Node), GetSrc(Op->Header.Args[0].ID()), Op->Index);
+      pextrb(GetDst<RA_32>(Node), GetSrc(Op->Vector.ID()), Op->Index);
     break;
     }
     case 2: {
-      pextrw(GetDst<RA_32>(Node), GetSrc(Op->Header.Args[0].ID()), Op->Index);
+      pextrw(GetDst<RA_32>(Node), GetSrc(Op->Vector.ID()), Op->Index);
     break;
     }
     case 4: {
-      pextrd(GetDst<RA_32>(Node), GetSrc(Op->Header.Args[0].ID()), Op->Index);
+      pextrd(GetDst<RA_32>(Node), GetSrc(Op->Vector.ID()), Op->Index);
     break;
     }
     case 8: {
-      pextrq(GetDst<RA_64>(Node), GetSrc(Op->Header.Args[0].ID()), Op->Index);
+      pextrq(GetDst<RA_64>(Node), GetSrc(Op->Vector.ID()), Op->Index);
     break;
     }
     default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
@@ -1171,39 +1168,40 @@ DEF_OP(VExtractToGPR) {
 
 DEF_OP(Float_ToGPR_ZS) {
   auto Op = IROp->C<IR::IROp_Float_ToGPR_ZS>();
+  const uint16_t Conv = (IROp->Size << 8) | Op->SrcElementSize;
 
-  uint16_t Conv = (IROp->Size << 8) | Op->SrcElementSize;
   switch (Conv) {
     case 0x0804: // int64_t <- float
-      cvttss2si(GetDst<RA_64>(Node), GetSrc(Op->Header.Args[0].ID()));
+      cvttss2si(GetDst<RA_64>(Node), GetSrc(Op->Scalar.ID()));
     break;
     case 0x0808: // int64_t <- double
-      cvttsd2si(GetDst<RA_64>(Node), GetSrc(Op->Header.Args[0].ID()));
+      cvttsd2si(GetDst<RA_64>(Node), GetSrc(Op->Scalar.ID()));
     break;
     case 0x0404: // int32_t <- float
-      cvttss2si(GetDst<RA_32>(Node), GetSrc(Op->Header.Args[0].ID()));
+      cvttss2si(GetDst<RA_32>(Node), GetSrc(Op->Scalar.ID()));
     break;
     case 0x0408: // int32_t <- double
-      cvttsd2si(GetDst<RA_32>(Node), GetSrc(Op->Header.Args[0].ID()));
+      cvttsd2si(GetDst<RA_32>(Node), GetSrc(Op->Scalar.ID()));
     break;
   }
 }
 
 DEF_OP(Float_ToGPR_S) {
   auto Op = IROp->C<IR::IROp_Float_ToGPR_S>();
-  uint16_t Conv = (IROp->Size << 8) | Op->SrcElementSize;
+  const uint16_t Conv = (IROp->Size << 8) | Op->SrcElementSize;
+
   switch (Conv) {
     case 0x0804: // int64_t <- float
-      cvtss2si(GetDst<RA_64>(Node), GetSrc(Op->Header.Args[0].ID()));
+      cvtss2si(GetDst<RA_64>(Node), GetSrc(Op->Scalar.ID()));
     break;
     case 0x0808: // int64_t <- double
-      cvtsd2si(GetDst<RA_64>(Node), GetSrc(Op->Header.Args[0].ID()));
+      cvtsd2si(GetDst<RA_64>(Node), GetSrc(Op->Scalar.ID()));
     break;
     case 0x0404: // int32_t <- float
-      cvtss2si(GetDst<RA_32>(Node), GetSrc(Op->Header.Args[0].ID()));
+      cvtss2si(GetDst<RA_32>(Node), GetSrc(Op->Scalar.ID()));
     break;
     case 0x0408: // int32_t <- double
-      cvtsd2si(GetDst<RA_32>(Node), GetSrc(Op->Header.Args[0].ID()));
+      cvtsd2si(GetDst<RA_32>(Node), GetSrc(Op->Scalar.ID()));
     break;
   }
 }
@@ -1213,18 +1211,18 @@ DEF_OP(FCmp) {
 
   if (Op->Flags & (1 << IR::FCMP_FLAG_UNORDERED)) {
     if (Op->ElementSize == 4) {
-      ucomiss(GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      ucomiss(GetSrc(Op->Scalar1.ID()), GetSrc(Op->Scalar2.ID()));
     }
     else {
-      ucomisd(GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      ucomisd(GetSrc(Op->Scalar1.ID()), GetSrc(Op->Scalar2.ID()));
     }
   }
   else {
     if (Op->ElementSize == 4) {
-      comiss(GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      comiss(GetSrc(Op->Scalar1.ID()), GetSrc(Op->Scalar2.ID()));
     }
     else {
-      comisd(GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      comisd(GetSrc(Op->Scalar1.ID()), GetSrc(Op->Scalar2.ID()));
     }
   }
   mov (rdx, 0);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
@@ -209,7 +209,7 @@ DEF_OP(Thunk) {
   if (NumPush & 1)
     sub(rsp, 8); // Align
 
-  mov(rdi, GetSrc<RA_64>(Op->Header.Args[0].ID()));
+  mov(rdi, GetSrc<RA_64>(Op->ArgPtr.ID()));
 
   auto thunkFn = ThreadState->CTX->ThunkHandler->LookupThunk(Op->ThunkNameHash);
 
@@ -288,8 +288,8 @@ DEF_OP(CPUID) {
   // Result: RAX, RDX. 4xi32
 
   // rsi can be in the source registers, so copy argument to edx first
-  mov (edx, GetSrc<RA_32>(Op->Header.Args[1].ID()));
-  mov (esi, GetSrc<RA_32>(Op->Header.Args[0].ID()));
+  mov (edx, GetSrc<RA_32>(Op->Leaf.ID()));
+  mov (esi, GetSrc<RA_32>(Op->Function.ID()));
   mov (rdi, qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.CPUIDObj)]);
 
   auto NumPush = RA64.size();

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/EncryptionOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/EncryptionOps.cpp
@@ -17,44 +17,44 @@ namespace FEXCore::CPU {
 
 DEF_OP(AESImc) {
   auto Op = IROp->C<IR::IROp_VAESImc>();
-  vaesimc(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
+  vaesimc(GetDst(Node), GetSrc(Op->Vector.ID()));
 }
 
 DEF_OP(AESEnc) {
   auto Op = IROp->C<IR::IROp_VAESEnc>();
-  vaesenc(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+  vaesenc(GetDst(Node), GetSrc(Op->State.ID()), GetSrc(Op->Key.ID()));
 }
 
 DEF_OP(AESEncLast) {
   auto Op = IROp->C<IR::IROp_VAESEncLast>();
-  vaesenclast(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+  vaesenclast(GetDst(Node), GetSrc(Op->State.ID()), GetSrc(Op->Key.ID()));
 }
 
 DEF_OP(AESDec) {
   auto Op = IROp->C<IR::IROp_VAESDec>();
-  vaesdec(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+  vaesdec(GetDst(Node), GetSrc(Op->State.ID()), GetSrc(Op->Key.ID()));
 }
 
 DEF_OP(AESDecLast) {
   auto Op = IROp->C<IR::IROp_VAESDecLast>();
-  vaesdeclast(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+  vaesdeclast(GetDst(Node), GetSrc(Op->State.ID()), GetSrc(Op->Key.ID()));
 }
 
 DEF_OP(AESKeyGenAssist) {
   auto Op = IROp->C<IR::IROp_VAESKeyGenAssist>();
-  vaeskeygenassist(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), Op->RCON);
+  vaeskeygenassist(GetDst(Node), GetSrc(Op->Src.ID()), Op->RCON);
 }
 
 DEF_OP(CRC32) {
   auto Op = IROp->C<IR::IROp_CRC32>();
   switch (IROp->Size) {
   case 4:
-    mov(TMP1, GetSrc<RA_32>(Op->Header.Args[1].ID()));
-    mov(GetDst<RA_32>(Node), GetSrc<RA_32>(Op->Header.Args[0].ID()));
+    mov(TMP1, GetSrc<RA_32>(Op->Src2.ID()));
+    mov(GetDst<RA_32>(Node), GetSrc<RA_32>(Op->Src1.ID()));
   break;
   case 8:
-    mov(TMP1, GetSrc<RA_64>(Op->Header.Args[1].ID()));
-    mov(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()));
+    mov(TMP1, GetSrc<RA_64>(Op->Src2.ID()));
+    mov(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Src1.ID()));
   break;
   default: LOGMAN_MSG_A_FMT("Unknown CRC32 size: {}", IROp->Size);
   }

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/FlagOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/FlagOps.cpp
@@ -18,7 +18,7 @@ namespace FEXCore::CPU {
 DEF_OP(GetHostFlag) {
   auto Op = IROp->C<IR::IROp_GetHostFlag>();
 
-  mov(rax, GetSrc<RA_64>(Op->Header.Args[0].ID()));
+  mov(rax, GetSrc<RA_64>(Op->Value.ID()));
   shr(rax, Op->Flag);
   and_(rax, 1);
   mov(GetDst<RA_64>(Node), rax);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/MiscOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/MiscOps.cpp
@@ -110,7 +110,7 @@ DEF_OP(GetRoundingMode) {
 
 DEF_OP(SetRoundingMode) {
   auto Op = IROp->C<IR::IROp_SetRoundingMode>();
-  auto Src = GetSrc<RA_32>(Op->Header.Args[0].ID());
+  auto Src = GetSrc<RA_32>(Op->RoundMode.ID());
 
   // Load old mxcsr
   // Only stores to memory
@@ -135,13 +135,13 @@ DEF_OP(Print) {
   auto Op = IROp->C<IR::IROp_Print>();
 
   PushRegs();
-  if (IsGPR(Op->Header.Args[0].ID())) {
-    mov (rdi, GetSrc<RA_64>(Op->Header.Args[0].ID()));
+  if (IsGPR(Op->Value.ID())) {
+    mov (rdi, GetSrc<RA_64>(Op->Value.ID()));
     call(qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.PrintValue)]);
   }
   else {
-    pextrq(rdi, GetSrc(Op->Header.Args[0].ID()), 0);
-    pextrq(rsi, GetSrc(Op->Header.Args[0].ID()), 1);
+    pextrq(rdi, GetSrc(Op->Value.ID()), 0);
+    pextrq(rsi, GetSrc(Op->Value.ID()), 1);
 
     call(qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.PrintVectorValue)]);
   }

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/MoveOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/MoveOps.cpp
@@ -20,13 +20,13 @@ DEF_OP(ExtractElementPair) {
   auto Op = IROp->C<IR::IROp_ExtractElementPair>();
   switch (Op->Header.Size) {
     case 4: {
-      auto Src = GetSrcPair<RA_32>(Op->Header.Args[0].ID());
+      auto Src = GetSrcPair<RA_32>(Op->Pair.ID());
       std::array<Xbyak::Reg, 2> Regs = {Src.first, Src.second};
       mov (GetDst<RA_32>(Node), Regs[Op->Element]);
       break;
     }
     case 8: {
-      auto Src = GetSrcPair<RA_64>(Op->Header.Args[0].ID());
+      auto Src = GetSrcPair<RA_64>(Op->Pair.ID());
       std::array<Xbyak::Reg, 2> Regs = {Src.first, Src.second};
       mov (GetDst<RA_64>(Node), Regs[Op->Element]);
       break;
@@ -45,15 +45,15 @@ DEF_OP(CreateElementPair) {
   switch (IROp->ElementSize) {
     case 4: {
       Dst = GetSrcPair<RA_32>(Node);
-      RegFirst = GetSrc<RA_32>(Op->Header.Args[0].ID());
-      RegSecond = GetSrc<RA_32>(Op->Header.Args[1].ID());
+      RegFirst = GetSrc<RA_32>(Op->Lower.ID());
+      RegSecond = GetSrc<RA_32>(Op->Upper.ID());
       RegTmp = eax;
       break;
     }
     case 8: {
       Dst = GetSrcPair<RA_64>(Node);
-      RegFirst = GetSrc<RA_64>(Op->Header.Args[0].ID());
-      RegSecond = GetSrc<RA_64>(Op->Header.Args[1].ID());
+      RegFirst = GetSrc<RA_64>(Op->Lower.ID());
+      RegSecond = GetSrc<RA_64>(Op->Upper.ID());
       RegTmp = rax;
       break;
     }
@@ -75,7 +75,7 @@ DEF_OP(CreateElementPair) {
 
 DEF_OP(Mov) {
   auto Op = IROp->C<IR::IROp_Mov>();
-  mov (GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Header.Args[0].ID()));
+  mov (GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Value.ID()));
 }
 
 #undef DEF_OP

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
@@ -2144,7 +2144,7 @@ DEF_OP(VTBL1) {
 }
 
 DEF_OP(VRev64) {
-  auto Op = IROp->C<IR::IROp_VDupElement>();
+  auto Op = IROp->C<IR::IROp_VRev64>();
 
   switch (Op->Header.ElementSize) {
     case 1: {

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
@@ -69,7 +69,7 @@ DEF_OP(VectorImm) {
 
 DEF_OP(SplatVector) {
   auto Op = IROp->C<IR::IROp_SplatVector2>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   LOGMAN_THROW_A_FMT(OpSize <= 16, "Can't handle a vector of size: {}", OpSize);
   uint8_t Elements = 0;
@@ -80,15 +80,15 @@ DEF_OP(SplatVector) {
     default: LOGMAN_MSG_A_FMT("Unknown Splat size"); break;
   }
 
-  uint8_t ElementSize = OpSize / Elements;
+  const uint8_t ElementSize = OpSize / Elements;
 
   switch (ElementSize) {
     case 4:
-      movapd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
+      movapd(GetDst(Node), GetSrc(Op->Scalar.ID()));
       shufps(GetDst(Node), GetDst(Node), 0);
     break;
     case 8:
-      movddup(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
+      movddup(GetDst(Node), GetSrc(Op->Scalar.ID()));
     break;
     default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.Size); break;
   }
@@ -96,36 +96,36 @@ DEF_OP(SplatVector) {
 
 DEF_OP(VMov) {
   auto Op = IROp->C<IR::IROp_VMov>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   switch (OpSize) {
     case 1: {
       vpxor(xmm15, xmm15, xmm15);
-      pextrb(eax, GetSrc(Op->Header.Args[0].ID()), 0);
+      pextrb(eax, GetSrc(Op->Source.ID()), 0);
       pinsrb(xmm15, eax, 0);
       movapd(GetDst(Node), xmm15);
       break;
     }
     case 2: {
       vpxor(xmm15, xmm15, xmm15);
-      pextrw(eax, GetSrc(Op->Header.Args[0].ID()), 0);
+      pextrw(eax, GetSrc(Op->Source.ID()), 0);
       pinsrw(xmm15, eax, 0);
       movapd(GetDst(Node), xmm15);
       break;
     }
     case 4: {
       vpxor(xmm15, xmm15, xmm15);
-      pextrd(eax, GetSrc(Op->Header.Args[0].ID()), 0);
+      pextrd(eax, GetSrc(Op->Source.ID()), 0);
       pinsrd(xmm15, eax, 0);
       movapd(GetDst(Node), xmm15);
       break;
     }
     case 8: {
-      movq(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
+      movq(GetDst(Node), GetSrc(Op->Source.ID()));
       break;
     }
     case 16: {
-      movaps(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
+      movaps(GetDst(Node), GetSrc(Op->Source.ID()));
       break;
     }
     default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", OpSize); break;
@@ -134,44 +134,44 @@ DEF_OP(VMov) {
 
 DEF_OP(VAnd) {
   auto Op = IROp->C<IR::IROp_VAnd>();
-  vpand(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+  vpand(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
 }
 
 DEF_OP(VBic) {
   auto Op = IROp->C<IR::IROp_VBic>();
   // This doesn't map directly to ARM
   vpcmpeqd(xmm15, xmm15, xmm15);
-  vpxor(xmm15, GetSrc(Op->Header.Args[1].ID()), xmm15);
-  vpand(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), xmm15);
+  vpxor(xmm15, GetSrc(Op->Vector2.ID()), xmm15);
+  vpand(GetDst(Node), GetSrc(Op->Vector1.ID()), xmm15);
 }
 
 DEF_OP(VOr) {
   auto Op = IROp->C<IR::IROp_VOr>();
-  vpor(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+  vpor(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
 }
 
 DEF_OP(VXor) {
   auto Op = IROp->C<IR::IROp_VXor>();
-  vpxor(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+  vpxor(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
 }
 
 DEF_OP(VAdd) {
   auto Op = IROp->C<IR::IROp_VAdd>();
   switch (Op->Header.ElementSize) {
     case 1: {
-      vpaddb(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpaddb(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
     }
     case 2: {
-      vpaddw(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpaddw(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
     }
     case 4: {
-      vpaddd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpaddd(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
     }
     case 8: {
-      vpaddq(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpaddq(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
     }
     default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
@@ -182,19 +182,19 @@ DEF_OP(VSub) {
   auto Op = IROp->C<IR::IROp_VSub>();
   switch (Op->Header.ElementSize) {
     case 1: {
-      vpsubb(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpsubb(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
     }
     case 2: {
-      vpsubw(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpsubw(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
     }
     case 4: {
-      vpsubd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpsubd(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
     }
     case 8: {
-      vpsubq(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpsubq(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
     }
     default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
@@ -205,11 +205,11 @@ DEF_OP(VUQAdd) {
   auto Op = IROp->C<IR::IROp_VUQAdd>();
   switch (Op->Header.ElementSize) {
     case 1: {
-      vpaddusb(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpaddusb(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
     }
     case 2: {
-      vpaddusw(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpaddusw(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
     }
     default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
@@ -220,11 +220,11 @@ DEF_OP(VUQSub) {
   auto Op = IROp->C<IR::IROp_VUQSub>();
   switch (Op->Header.ElementSize) {
     case 1: {
-      vpsubusb(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpsubusb(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
     }
     case 2: {
-      vpsubusw(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpsubusw(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
     }
     default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
@@ -235,11 +235,11 @@ DEF_OP(VSQAdd) {
   auto Op = IROp->C<IR::IROp_VSQAdd>();
   switch (Op->Header.ElementSize) {
     case 1: {
-      vpaddsb(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpaddsb(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
     }
     case 2: {
-      vpaddsw(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpaddsw(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
     }
     default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
@@ -250,11 +250,11 @@ DEF_OP(VSQSub) {
   auto Op = IROp->C<IR::IROp_VSQSub>();
   switch (Op->Header.ElementSize) {
     case 1: {
-      vpsubsb(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpsubsb(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
     }
     case 2: {
-      vpsubsw(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpsubsw(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
     }
     default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
@@ -263,14 +263,14 @@ DEF_OP(VSQSub) {
 
 DEF_OP(VAddP) {
   auto Op = IROp->C<IR::IROp_VAddP>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   if (OpSize == 8) {
     // Can't handle this natively without dropping to MMX
     // Emulate
     vpxor(xmm14, xmm14, xmm14);
-    movq(xmm15, GetSrc(Op->Header.Args[0].ID()));
-    vshufpd(xmm15, xmm15, GetSrc(Op->Header.Args[1].ID()), 0b00);
+    movq(xmm15, GetSrc(Op->VectorLower.ID()));
+    vshufpd(xmm15, xmm15, GetSrc(Op->VectorUpper.ID()), 0b00);
     vpaddw(GetDst(Node), xmm15, xmm14);
     switch (Op->Header.ElementSize) {
       case 1:
@@ -300,8 +300,8 @@ DEF_OP(VAddP) {
   else {
     switch (Op->Header.ElementSize) {
       case 1:
-        movdqu(xmm15, GetSrc(Op->Header.Args[0].ID()));
-        movdqu(xmm14, GetSrc(Op->Header.Args[1].ID()));
+        movdqu(xmm15, GetSrc(Op->VectorLower.ID()));
+        movdqu(xmm14, GetSrc(Op->VectorUpper.ID()));
 
         vpunpcklbw(xmm0, xmm15, xmm14);
         vpunpckhbw(xmm12, xmm15, xmm14);
@@ -318,10 +318,10 @@ DEF_OP(VAddP) {
         vpaddb(GetDst(Node), xmm15, xmm14);
         break;
       case 2:
-        vphaddw(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+        vphaddw(GetDst(Node), GetSrc(Op->VectorLower.ID()), GetSrc(Op->VectorUpper.ID()));
         break;
       case 4:
-        vphaddd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+        vphaddd(GetDst(Node), GetSrc(Op->VectorLower.ID()), GetSrc(Op->VectorUpper.ID()));
         break;
       default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
     }
@@ -330,12 +330,13 @@ DEF_OP(VAddP) {
 
 DEF_OP(VAddV) {
   auto Op = IROp->C<IR::IROp_VAddV>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  auto Src = GetSrc(Op->Header.Args[0].ID());
+  auto Src = GetSrc(Op->Vector.ID());
   auto Dest = GetDst(Node);
   vpxor(xmm15, xmm15, xmm15);
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
   switch (Op->Header.ElementSize) {
     case 2: {
       for (int i = Elements; i > 1; i >>= 1) {
@@ -364,7 +365,7 @@ DEF_OP(VAddV) {
 DEF_OP(VUMinV) {
   auto Op = IROp->C<IR::IROp_VUMinV>();
 
-  auto Src = GetSrc(Op->Header.Args[0].ID());
+  auto Src = GetSrc(Op->Vector.ID());
   auto Dest = GetDst(Node);
   switch (Op->Header.ElementSize) {
     case 2: {
@@ -382,11 +383,11 @@ DEF_OP(VURAvg) {
   auto Op = IROp->C<IR::IROp_VURAvg>();
   switch (Op->Header.ElementSize) {
     case 1: {
-      vpavgb(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpavgb(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
     }
     case 2: {
-      vpavgw(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpavgw(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
     }
     default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
@@ -397,19 +398,19 @@ DEF_OP(VAbs) {
   auto Op = IROp->C<IR::IROp_VAbs>();
   switch (Op->Header.ElementSize) {
     case 1: {
-      vpabsb(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
+      vpabsb(GetDst(Node), GetSrc(Op->Vector.ID()));
       break;
     }
     case 2: {
-      vpabsw(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
+      vpabsw(GetDst(Node), GetSrc(Op->Vector.ID()));
       break;
     }
     case 4: {
-      vpabsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
+      vpabsd(GetDst(Node), GetSrc(Op->Vector.ID()));
       break;
     }
     case 8: {
-      vpabsq(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
+      vpabsq(GetDst(Node), GetSrc(Op->Vector.ID()));
       break;
     }
     default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
@@ -418,13 +419,13 @@ DEF_OP(VAbs) {
 
 DEF_OP(VPopcount) {
   auto Op = IROp->C<IR::IROp_VPopcount>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
   // This only supports 8bit popcount on 8byte to 16byte registers
 
-  auto Src = GetSrc(Op->Header.Args[0].ID());
+  auto Src = GetSrc(Op->Vector.ID());
   auto Dest = GetDst(Node);
   vpxor(xmm15, xmm15, xmm15);
-  uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / Op->Header.ElementSize;
 
   // This is disgustingly bad on x86-64 but we only need it for compatibility
   switch (Op->Header.ElementSize) {
@@ -444,17 +445,17 @@ DEF_OP(VPopcount) {
 
 DEF_OP(VFAdd) {
   auto Op = IROp->C<IR::IROp_VFAdd>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   if (Op->Header.ElementSize == OpSize) {
     // Scalar
     switch (Op->Header.ElementSize) {
       case 4: {
-        vaddss(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+        vaddss(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
       }
       case 8: {
-        vaddsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+        vaddsd(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
       }
       default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
@@ -464,11 +465,11 @@ DEF_OP(VFAdd) {
     // Vector
     switch (Op->Header.ElementSize) {
       case 4: {
-        vaddps(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+        vaddps(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
       }
       case 8: {
-        vaddpd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+        vaddpd(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
       }
       default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
@@ -480,10 +481,10 @@ DEF_OP(VFAddP) {
   auto Op = IROp->C<IR::IROp_VFAddP>();
   switch (Op->Header.ElementSize) {
     case 4:
-      vhaddps(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vhaddps(GetDst(Node), GetSrc(Op->VectorLower.ID()), GetSrc(Op->VectorUpper.ID()));
       break;
     case 8:
-      vhaddpd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vhaddpd(GetDst(Node), GetSrc(Op->VectorLower.ID()), GetSrc(Op->VectorUpper.ID()));
       break;
     default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
   }
@@ -491,17 +492,17 @@ DEF_OP(VFAddP) {
 
 DEF_OP(VFSub) {
   auto Op = IROp->C<IR::IROp_VFSub>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   if (Op->Header.ElementSize == OpSize) {
     // Scalar
     switch (Op->Header.ElementSize) {
       case 4: {
-        vsubss(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+        vsubss(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
       }
       case 8: {
-        vsubsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+        vsubsd(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
       }
       default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
@@ -511,11 +512,11 @@ DEF_OP(VFSub) {
     // Vector
     switch (Op->Header.ElementSize) {
       case 4: {
-        vsubps(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+        vsubps(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
       }
       case 8: {
-        vsubpd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+        vsubpd(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
       }
       default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
@@ -525,17 +526,17 @@ DEF_OP(VFSub) {
 
 DEF_OP(VFMul) {
   auto Op = IROp->C<IR::IROp_VFMul>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   if (Op->Header.ElementSize == OpSize) {
     // Scalar
     switch (Op->Header.ElementSize) {
       case 4: {
-        vmulss(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+        vmulss(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
       }
       case 8: {
-        vmulsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+        vmulsd(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
       }
       default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
@@ -545,11 +546,11 @@ DEF_OP(VFMul) {
     // Vector
     switch (Op->Header.ElementSize) {
       case 4: {
-        vmulps(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+        vmulps(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
       }
       case 8: {
-        vmulpd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+        vmulpd(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
       }
       default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
@@ -559,17 +560,17 @@ DEF_OP(VFMul) {
 
 DEF_OP(VFDiv) {
   auto Op = IROp->C<IR::IROp_VFDiv>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   if (Op->Header.ElementSize == OpSize) {
     // Scalar
     switch (Op->Header.ElementSize) {
       case 4: {
-        vdivss(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+        vdivss(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
       }
       case 8: {
-        vdivsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+        vdivsd(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
       }
       default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
@@ -579,11 +580,11 @@ DEF_OP(VFDiv) {
     // Vector
     switch (Op->Header.ElementSize) {
       case 4: {
-        vdivps(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+        vdivps(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
       }
       case 8: {
-        vdivpd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+        vdivpd(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
       }
       default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
@@ -593,17 +594,17 @@ DEF_OP(VFDiv) {
 
 DEF_OP(VFMin) {
   auto Op = IROp->C<IR::IROp_VFMin>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   if (Op->Header.ElementSize == OpSize) {
     // Scalar
     switch (Op->Header.ElementSize) {
       case 4: {
-        vminss(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+        vminss(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
       }
       case 8: {
-        vminsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+        vminsd(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
       }
       default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
@@ -613,11 +614,11 @@ DEF_OP(VFMin) {
     // Vector
     switch (Op->Header.ElementSize) {
       case 4: {
-        vminps(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+        vminps(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
       }
       case 8: {
-        vminpd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+        vminpd(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
       }
       default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
@@ -627,17 +628,17 @@ DEF_OP(VFMin) {
 
 DEF_OP(VFMax) {
   auto Op = IROp->C<IR::IROp_VFMax>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   if (Op->Header.ElementSize == OpSize) {
     // Scalar
     switch (Op->Header.ElementSize) {
       case 4: {
-        vmaxss(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+        vmaxss(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
       }
       case 8: {
-        vmaxsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+        vmaxsd(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
       }
       default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
@@ -647,11 +648,11 @@ DEF_OP(VFMax) {
     // Vector
     switch (Op->Header.ElementSize) {
       case 4: {
-        vmaxps(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+        vmaxps(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
       }
       case 8: {
-        vmaxpd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+        vmaxpd(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
       }
       default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
@@ -661,7 +662,7 @@ DEF_OP(VFMax) {
 
 DEF_OP(VFRecp) {
   auto Op = IROp->C<IR::IROp_VFRecp>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   if (Op->Header.ElementSize == OpSize) {
     // Scalar
@@ -669,7 +670,7 @@ DEF_OP(VFRecp) {
       case 4: {
         mov(eax, 0x3f800000); // 1.0f
         vmovd(xmm15, eax);
-        vdivss(GetDst(Node), xmm15, GetSrc(Op->Header.Args[0].ID()));
+        vdivss(GetDst(Node), xmm15, GetSrc(Op->Vector.ID()));
       break;
       }
       default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
@@ -682,7 +683,7 @@ DEF_OP(VFRecp) {
         mov(eax, 0x3f800000); // 1.0f
         vmovd(xmm15, eax);
         pshufd(xmm15, xmm15, 0);
-        vdivps(GetDst(Node), xmm15, GetSrc(Op->Header.Args[0].ID()));
+        vdivps(GetDst(Node), xmm15, GetSrc(Op->Vector.ID()));
       break;
       }
       default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
@@ -692,17 +693,17 @@ DEF_OP(VFRecp) {
 
 DEF_OP(VFSqrt) {
   auto Op = IROp->C<IR::IROp_VFSqrt>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   if (Op->Header.ElementSize == OpSize) {
     // Scalar
     switch (Op->Header.ElementSize) {
       case 4: {
-        vsqrtss(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[0].ID()));
+        vsqrtss(GetDst(Node), GetSrc(Op->Vector.ID()), GetSrc(Op->Vector.ID()));
       break;
       }
       case 8: {
-        vsqrtsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[0].ID()));
+        vsqrtsd(GetDst(Node), GetSrc(Op->Vector.ID()), GetSrc(Op->Vector.ID()));
       break;
       }
       default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
@@ -712,11 +713,11 @@ DEF_OP(VFSqrt) {
     // Vector
     switch (Op->Header.ElementSize) {
       case 4: {
-        vsqrtps(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
+        vsqrtps(GetDst(Node), GetSrc(Op->Vector.ID()));
       break;
       }
       case 8: {
-        vsqrtpd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
+        vsqrtpd(GetDst(Node), GetSrc(Op->Vector.ID()));
       break;
       }
       default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
@@ -726,21 +727,21 @@ DEF_OP(VFSqrt) {
 
 DEF_OP(VFRSqrt) {
   auto Op = IROp->C<IR::IROp_VFRSqrt>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   if (Op->Header.ElementSize == OpSize) {
     // Scalar
     switch (Op->Header.ElementSize) {
       case 4: {
         mov(eax, 0x3f800000); // 1.0f
-        sqrtss(xmm15, GetSrc(Op->Header.Args[0].ID()));
+        sqrtss(xmm15, GetSrc(Op->Vector.ID()));
         vmovd(GetDst(Node), eax);
         divss(GetDst(Node), xmm15);
       break;
       }
       case 8: {
         mov(eax, 0x3f800000); // 1.0f
-        sqrtsd(xmm15, GetSrc(Op->Header.Args[0].ID()));
+        sqrtsd(xmm15, GetSrc(Op->Vector.ID()));
         vmovd(GetDst(Node), eax);
         divsd(GetDst(Node), xmm15);
       break;
@@ -753,7 +754,7 @@ DEF_OP(VFRSqrt) {
     switch (Op->Header.ElementSize) {
       case 4: {
         mov(rax, 0x3f800000); // 1.0f
-        sqrtps(xmm15, GetSrc(Op->Header.Args[0].ID()));
+        sqrtps(xmm15, GetSrc(Op->Vector.ID()));
         vmovd(GetDst(Node), eax);
         pshufd(GetDst(Node), GetDst(Node), 0);
         divps(GetDst(Node), xmm15);
@@ -769,19 +770,19 @@ DEF_OP(VNeg) {
   vpxor(xmm15, xmm15, xmm15);
   switch (Op->Header.ElementSize) {
     case 1: {
-      vpsubb(GetDst(Node), xmm15, GetSrc(Op->Header.Args[0].ID()));
+      vpsubb(GetDst(Node), xmm15, GetSrc(Op->Vector.ID()));
     break;
     }
     case 2: {
-      vpsubw(GetDst(Node), xmm15, GetSrc(Op->Header.Args[0].ID()));
+      vpsubw(GetDst(Node), xmm15, GetSrc(Op->Vector.ID()));
     break;
     }
     case 4: {
-      vpsubd(GetDst(Node), xmm15, GetSrc(Op->Header.Args[0].ID()));
+      vpsubd(GetDst(Node), xmm15, GetSrc(Op->Vector.ID()));
     break;
     }
     case 8: {
-      vpsubq(GetDst(Node), xmm15, GetSrc(Op->Header.Args[0].ID()));
+      vpsubq(GetDst(Node), xmm15, GetSrc(Op->Vector.ID()));
     break;
     }
     default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
@@ -795,14 +796,14 @@ DEF_OP(VFNeg) {
       mov(rax, 0x80000000);
       vmovd(xmm15, eax);
       pshufd(xmm15, xmm15, 0);
-      vxorps(GetDst(Node), xmm15, GetSrc(Op->Header.Args[0].ID()));
+      vxorps(GetDst(Node), xmm15, GetSrc(Op->Vector.ID()));
     break;
     }
     case 8: {
       mov(rax, 0x8000000000000000ULL);
       vmovq(xmm15, rax);
       pshufd(xmm15, xmm15, 0b01'00'01'00);
-      vxorpd(GetDst(Node), xmm15, GetSrc(Op->Header.Args[0].ID()));
+      vxorpd(GetDst(Node), xmm15, GetSrc(Op->Vector.ID()));
     break;
     }
     default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
@@ -812,7 +813,7 @@ DEF_OP(VFNeg) {
 DEF_OP(VNot) {
   auto Op = IROp->C<IR::IROp_VNot>();
   pcmpeqd(xmm15, xmm15);
-  vpxor(GetDst(Node), xmm15, GetSrc(Op->Header.Args[0].ID()));
+  vpxor(GetDst(Node), xmm15, GetSrc(Op->Vector.ID()));
 }
 
 DEF_OP(VUMin) {
@@ -821,8 +822,8 @@ DEF_OP(VUMin) {
     switch (Op->Header.ElementSize) {
       case 8: {
         // This isn't very nice on x86 until AVX-512
-        pextrq(TMP1, GetSrc(Op->Header.Args[0].ID()), 0);
-        pextrq(TMP2, GetSrc(Op->Header.Args[1].ID()), 0);
+        pextrq(TMP1, GetSrc(Op->Vector1.ID()), 0);
+        pextrq(TMP2, GetSrc(Op->Vector2.ID()), 0);
         cmp(TMP1, TMP2);
         cmovb(TMP2, TMP1);
         pinsrq(GetDst(Node), TMP2, 0);
@@ -834,15 +835,15 @@ DEF_OP(VUMin) {
   else {
     switch (Op->Header.ElementSize) {
       case 1: {
-        vpminub(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+        vpminub(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
         break;
       }
       case 2: {
-        vpminuw(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+        vpminuw(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
         break;
       }
       case 4: {
-        vpminud(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+        vpminud(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
         break;
       }
       default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
@@ -854,15 +855,15 @@ DEF_OP(VSMin) {
   auto Op = IROp->C<IR::IROp_VSMin>();
   switch (Op->Header.ElementSize) {
     case 1: {
-      vpminsb(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpminsb(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
     }
     case 2: {
-      vpminsw(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpminsw(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
     }
     case 4: {
-      vpminsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpminsd(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
     }
     default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
@@ -873,15 +874,15 @@ DEF_OP(VUMax) {
   auto Op = IROp->C<IR::IROp_VUMax>();
   switch (Op->Header.ElementSize) {
     case 1: {
-      vpmaxub(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpmaxub(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
     }
     case 2: {
-      vpmaxuw(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpmaxuw(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
     }
     case 4: {
-      vpmaxud(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpmaxud(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
     }
     default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
@@ -892,15 +893,15 @@ DEF_OP(VSMax) {
   auto Op = IROp->C<IR::IROp_VSMax>();
   switch (Op->Header.ElementSize) {
     case 1: {
-      vpmaxsb(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpmaxsb(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
     }
     case 2: {
-      vpmaxsw(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpmaxsw(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
     }
     case 4: {
-      vpmaxsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpmaxsd(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
     }
     default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
@@ -909,23 +910,23 @@ DEF_OP(VSMax) {
 
 DEF_OP(VZip) {
   auto Op = IROp->C<IR::IROp_VZip>();
-  movapd(xmm15, GetSrc(Op->Header.Args[0].ID()));
+  movapd(xmm15, GetSrc(Op->VectorLower.ID()));
 
   switch (Op->Header.ElementSize) {
     case 1: {
-      punpcklbw(xmm15, GetSrc(Op->Header.Args[1].ID()));
+      punpcklbw(xmm15, GetSrc(Op->VectorUpper.ID()));
       break;
     }
     case 2: {
-      punpcklwd(xmm15, GetSrc(Op->Header.Args[1].ID()));
+      punpcklwd(xmm15, GetSrc(Op->VectorUpper.ID()));
       break;
     }
     case 4: {
-      punpckldq(xmm15, GetSrc(Op->Header.Args[1].ID()));
+      punpckldq(xmm15, GetSrc(Op->VectorUpper.ID()));
       break;
     }
     case 8: {
-      punpcklqdq(xmm15, GetSrc(Op->Header.Args[1].ID()));
+      punpcklqdq(xmm15, GetSrc(Op->VectorUpper.ID()));
       break;
     }
     default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
@@ -935,13 +936,13 @@ DEF_OP(VZip) {
 
 DEF_OP(VZip2) {
   auto Op = IROp->C<IR::IROp_VZip2>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
-  movapd(xmm15, GetSrc(Op->Header.Args[0].ID()));
+  movapd(xmm15, GetSrc(Op->VectorLower.ID()));
 
   if (OpSize == 8) {
-    vpslldq(xmm15, GetSrc(Op->Header.Args[0].ID()), 4);
-    vpslldq(xmm14, GetSrc(Op->Header.Args[1].ID()), 4);
+    vpslldq(xmm15, GetSrc(Op->VectorLower.ID()), 4);
+    vpslldq(xmm14, GetSrc(Op->VectorUpper.ID()), 4);
     switch (Op->Header.ElementSize) {
     case 1: {
       vpunpckhbw(GetDst(Node), xmm15, xmm14);
@@ -961,19 +962,19 @@ DEF_OP(VZip2) {
   else {
     switch (Op->Header.ElementSize) {
     case 1: {
-      punpckhbw(xmm15, GetSrc(Op->Header.Args[1].ID()));
+      punpckhbw(xmm15, GetSrc(Op->VectorUpper.ID()));
     break;
     }
     case 2: {
-      punpckhwd(xmm15, GetSrc(Op->Header.Args[1].ID()));
+      punpckhwd(xmm15, GetSrc(Op->VectorUpper.ID()));
     break;
     }
     case 4: {
-      punpckhdq(xmm15, GetSrc(Op->Header.Args[1].ID()));
+      punpckhdq(xmm15, GetSrc(Op->VectorUpper.ID()));
     break;
     }
     case 8: {
-      punpckhqdq(xmm15, GetSrc(Op->Header.Args[1].ID()));
+      punpckhqdq(xmm15, GetSrc(Op->VectorUpper.ID()));
     break;
     }
     default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
@@ -984,7 +985,7 @@ DEF_OP(VZip2) {
 
 DEF_OP(VUnZip) {
   auto Op = IROp->C<IR::IROp_VUnZip>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   if (OpSize == 8) {
     LOGMAN_MSG_A_FMT("Unsupported register size on VUnZip");
@@ -997,8 +998,8 @@ DEF_OP(VUnZip) {
         mov(rcx, 0x80'80'80'80'80'80'80'80); // Upper
         vmovq(xmm15, rax);
         pinsrq(xmm15, rcx, 1);
-        vpshufb(xmm14, GetSrc(Op->Header.Args[0].ID()), xmm15);
-        vpshufb(xmm13, GetSrc(Op->Header.Args[1].ID()), xmm15);
+        vpshufb(xmm14, GetSrc(Op->VectorLower.ID()), xmm15);
+        vpshufb(xmm13, GetSrc(Op->VectorUpper.ID()), xmm15);
         // movlhps back to combine
         vmovlhps(GetDst(Node), xmm14, xmm13);
         break;
@@ -1009,23 +1010,23 @@ DEF_OP(VUnZip) {
         mov(rcx, 0x80'80'80'80'80'80'80'80); // Upper
         vmovq(xmm15, rax);
         pinsrq(xmm15, rcx, 1);
-        vpshufb(xmm14, GetSrc(Op->Header.Args[0].ID()), xmm15);
-        vpshufb(xmm13, GetSrc(Op->Header.Args[1].ID()), xmm15);
+        vpshufb(xmm14, GetSrc(Op->VectorLower.ID()), xmm15);
+        vpshufb(xmm13, GetSrc(Op->VectorUpper.ID()), xmm15);
         // movlhps back to combine
         vmovlhps(GetDst(Node), xmm14, xmm13);
         break;
       }
       case 4: {
         vshufps(GetDst(Node),
-          GetSrc(Op->Header.Args[0].ID()),
-          GetSrc(Op->Header.Args[1].ID()),
+          GetSrc(Op->VectorLower.ID()),
+          GetSrc(Op->VectorUpper.ID()),
           0b10'00'10'00);
         break;
       }
       case 8: {
         vshufpd(GetDst(Node),
-          GetSrc(Op->Header.Args[0].ID()),
-          GetSrc(Op->Header.Args[1].ID()),
+          GetSrc(Op->VectorLower.ID()),
+          GetSrc(Op->VectorUpper.ID()),
           0b0'0);
         break;
       }
@@ -1036,8 +1037,7 @@ DEF_OP(VUnZip) {
 
 DEF_OP(VUnZip2) {
   auto Op = IROp->C<IR::IROp_VUnZip2>();
-  uint8_t OpSize = IROp->Size;
-
+  const uint8_t OpSize = IROp->Size;
 
   if (OpSize == 8) {
     LOGMAN_MSG_A_FMT("Unsupported register size on VUnZip2");
@@ -1050,8 +1050,8 @@ DEF_OP(VUnZip2) {
         mov(rcx, 0x80'80'80'80'80'80'80'80); // Upper
         vmovq(xmm15, rax);
         pinsrq(xmm15, rcx, 1);
-        vpshufb(xmm14, GetSrc(Op->Header.Args[0].ID()), xmm15);
-        vpshufb(xmm13, GetSrc(Op->Header.Args[1].ID()), xmm15);
+        vpshufb(xmm14, GetSrc(Op->VectorLower.ID()), xmm15);
+        vpshufb(xmm13, GetSrc(Op->VectorUpper.ID()), xmm15);
         // movlhps back to combine
         vmovlhps(GetDst(Node), xmm14, xmm13);
         break;
@@ -1062,23 +1062,23 @@ DEF_OP(VUnZip2) {
         mov(rcx, 0x80'80'80'80'80'80'80'80); // Upper
         vmovq(xmm15, rax);
         pinsrq(xmm15, rcx, 1);
-        vpshufb(xmm14, GetSrc(Op->Header.Args[0].ID()), xmm15);
-        vpshufb(xmm13, GetSrc(Op->Header.Args[1].ID()), xmm15);
+        vpshufb(xmm14, GetSrc(Op->VectorLower.ID()), xmm15);
+        vpshufb(xmm13, GetSrc(Op->VectorUpper.ID()), xmm15);
         // movlhps back to combine
         vmovlhps(GetDst(Node), xmm14, xmm13);
         break;
       }
       case 4: {
         vshufps(GetDst(Node),
-          GetSrc(Op->Header.Args[0].ID()),
-          GetSrc(Op->Header.Args[1].ID()),
+          GetSrc(Op->VectorLower.ID()),
+          GetSrc(Op->VectorUpper.ID()),
           0b11'01'11'01);
         break;
       }
       case 8: {
         vshufpd(GetDst(Node),
-          GetSrc(Op->Header.Args[0].ID()),
-          GetSrc(Op->Header.Args[1].ID()),
+          GetSrc(Op->VectorLower.ID()),
+          GetSrc(Op->VectorUpper.ID()),
           0b1'1);
         break;
       }
@@ -1090,8 +1090,8 @@ DEF_OP(VUnZip2) {
 
 DEF_OP(VBSL) {
   auto Op = IROp->C<IR::IROp_VBSL>();
-  vpand(xmm0, GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
-  vpandn(xmm12, GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[2].ID()));
+  vpand(xmm0, GetSrc(Op->VectorMask.ID()), GetSrc(Op->VectorTrue.ID()));
+  vpandn(xmm12, GetSrc(Op->VectorMask.ID()), GetSrc(Op->VectorFalse.ID()));
   vpor(GetDst(Node), xmm0, xmm12);
 }
 
@@ -1100,16 +1100,16 @@ DEF_OP(VCMPEQ) {
 
   switch (Op->Header.ElementSize) {
     case 1:
-      vpcmpeqb(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpcmpeqb(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
     case 2:
-      vpcmpeqw(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpcmpeqw(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
     case 4:
-      vpcmpeqd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpcmpeqd(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
     case 8:
-      vpcmpeqq(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpcmpeqq(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
     default: LOGMAN_MSG_A_FMT("Unsupported element size: {}", Op->Header.ElementSize);
   }
@@ -1121,16 +1121,16 @@ DEF_OP(VCMPEQZ) {
 
   switch (Op->Header.ElementSize) {
     case 1:
-      vpcmpeqb(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), xmm15);
+      vpcmpeqb(GetDst(Node), GetSrc(Op->Vector.ID()), xmm15);
       break;
     case 2:
-      vpcmpeqw(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), xmm15);
+      vpcmpeqw(GetDst(Node), GetSrc(Op->Vector.ID()), xmm15);
       break;
     case 4:
-      vpcmpeqd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), xmm15);
+      vpcmpeqd(GetDst(Node), GetSrc(Op->Vector.ID()), xmm15);
       break;
     case 8:
-      vpcmpeqq(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), xmm15);
+      vpcmpeqq(GetDst(Node), GetSrc(Op->Vector.ID()), xmm15);
       break;
     default: LOGMAN_MSG_A_FMT("Unsupported element size: {}", Op->Header.ElementSize);
   }
@@ -1141,16 +1141,16 @@ DEF_OP(VCMPGT) {
 
   switch (Op->Header.ElementSize) {
     case 1:
-      vpcmpgtb(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpcmpgtb(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
     case 2:
-      vpcmpgtw(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpcmpgtw(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
     case 4:
-      vpcmpgtd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpcmpgtd(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
     case 8:
-      vpcmpgtq(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpcmpgtq(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
     default: LOGMAN_MSG_A_FMT("Unsupported element size: {}", Op->Header.ElementSize);
   }
@@ -1162,16 +1162,16 @@ DEF_OP(VCMPGTZ) {
 
   switch (Op->Header.ElementSize) {
     case 1:
-      vpcmpgtb(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), xmm15);
+      vpcmpgtb(GetDst(Node), GetSrc(Op->Vector.ID()), xmm15);
       break;
     case 2:
-      vpcmpgtw(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), xmm15);
+      vpcmpgtw(GetDst(Node), GetSrc(Op->Vector.ID()), xmm15);
       break;
     case 4:
-      vpcmpgtd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), xmm15);
+      vpcmpgtd(GetDst(Node), GetSrc(Op->Vector.ID()), xmm15);
       break;
     case 8:
-      vpcmpgtq(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), xmm15);
+      vpcmpgtq(GetDst(Node), GetSrc(Op->Vector.ID()), xmm15);
       break;
     default: LOGMAN_MSG_A_FMT("Unsupported element size: {}", Op->Header.ElementSize);
   }
@@ -1183,16 +1183,16 @@ DEF_OP(VCMPLTZ) {
 
   switch (Op->Header.ElementSize) {
     case 1:
-      vpcmpgtb(GetDst(Node), xmm15, GetSrc(Op->Header.Args[0].ID()));
+      vpcmpgtb(GetDst(Node), xmm15, GetSrc(Op->Vector.ID()));
       break;
     case 2:
-      vpcmpgtw(GetDst(Node), xmm15, GetSrc(Op->Header.Args[0].ID()));
+      vpcmpgtw(GetDst(Node), xmm15, GetSrc(Op->Vector.ID()));
       break;
     case 4:
-      vpcmpgtd(GetDst(Node), xmm15, GetSrc(Op->Header.Args[0].ID()));
+      vpcmpgtd(GetDst(Node), xmm15, GetSrc(Op->Vector.ID()));
       break;
     case 8:
-      vpcmpgtq(GetDst(Node), xmm15, GetSrc(Op->Header.Args[0].ID()));
+      vpcmpgtq(GetDst(Node), xmm15, GetSrc(Op->Vector.ID()));
       break;
     default: LOGMAN_MSG_A_FMT("Unsupported element size: {}", Op->Header.ElementSize);
   }
@@ -1200,15 +1200,15 @@ DEF_OP(VCMPLTZ) {
 
 DEF_OP(VFCMPEQ) {
   auto Op = IROp->C<IR::IROp_VFCMPEQ>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   if (Op->Header.ElementSize == OpSize) {
     switch (Op->Header.ElementSize) {
     case 4:
-      vcmpss(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 0);
+      vcmpss(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()), 0);
     break;
     case 8:
-      vcmpsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 0);
+      vcmpsd(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()), 0);
     break;
     default: LOGMAN_MSG_A_FMT("Unsupported element size: {}", Op->Header.ElementSize);
     }
@@ -1216,10 +1216,10 @@ DEF_OP(VFCMPEQ) {
   else {
     switch (Op->Header.ElementSize) {
     case 4:
-      vcmpps(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 0);
+      vcmpps(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()), 0);
     break;
     case 8:
-      vcmppd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 0);
+      vcmppd(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()), 0);
     break;
     default: LOGMAN_MSG_A_FMT("Unsupported element size: {}", Op->Header.ElementSize);
     }
@@ -1228,15 +1228,15 @@ DEF_OP(VFCMPEQ) {
 
 DEF_OP(VFCMPNEQ) {
   auto Op = IROp->C<IR::IROp_VFCMPNEQ>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   if (Op->Header.ElementSize == OpSize) {
     switch (Op->Header.ElementSize) {
     case 4:
-      vcmpss(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 4);
+      vcmpss(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()), 4);
     break;
     case 8:
-      vcmpsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 4);
+      vcmpsd(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()), 4);
     break;
     default: LOGMAN_MSG_A_FMT("Unsupported element size: {}", Op->Header.ElementSize);
     }
@@ -1245,10 +1245,10 @@ DEF_OP(VFCMPNEQ) {
   else {
     switch (Op->Header.ElementSize) {
     case 4:
-      vcmpps(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 4);
+      vcmpps(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()), 4);
     break;
     case 8:
-      vcmppd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 4);
+      vcmppd(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()), 4);
     break;
     default: LOGMAN_MSG_A_FMT("Unsupported element size: {}", Op->Header.ElementSize);
     }
@@ -1257,15 +1257,15 @@ DEF_OP(VFCMPNEQ) {
 
 DEF_OP(VFCMPLT) {
   auto Op = IROp->C<IR::IROp_VFCMPLT>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   if (Op->Header.ElementSize == OpSize) {
     switch (Op->Header.ElementSize) {
     case 4:
-      vcmpss(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 1);
+      vcmpss(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()), 1);
     break;
     case 8:
-      vcmpsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 1);
+      vcmpsd(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()), 1);
     break;
     default: LOGMAN_MSG_A_FMT("Unsupported element size: {}", Op->Header.ElementSize);
     }
@@ -1273,10 +1273,10 @@ DEF_OP(VFCMPLT) {
   else {
     switch (Op->Header.ElementSize) {
     case 4:
-      vcmpps(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 1);
+      vcmpps(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()), 1);
     break;
     case 8:
-      vcmppd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 1);
+      vcmppd(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()), 1);
     break;
     default: LOGMAN_MSG_A_FMT("Unsupported element size: {}", Op->Header.ElementSize);
     }
@@ -1285,15 +1285,15 @@ DEF_OP(VFCMPLT) {
 
 DEF_OP(VFCMPGT) {
   auto Op = IROp->C<IR::IROp_VFCMPGT>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   if (Op->Header.ElementSize == OpSize) {
     switch (Op->Header.ElementSize) {
     case 4:
-      vcmpss(GetDst(Node), GetSrc(Op->Header.Args[1].ID()), GetSrc(Op->Header.Args[0].ID()), 1);
+      vcmpss(GetDst(Node), GetSrc(Op->Vector2.ID()), GetSrc(Op->Vector1.ID()), 1);
     break;
     case 8:
-      vcmpsd(GetDst(Node), GetSrc(Op->Header.Args[1].ID()), GetSrc(Op->Header.Args[0].ID()), 1);
+      vcmpsd(GetDst(Node), GetSrc(Op->Vector2.ID()), GetSrc(Op->Vector1.ID()), 1);
     break;
     default: LOGMAN_MSG_A_FMT("Unsupported element size: {}", Op->Header.ElementSize);
     }
@@ -1301,10 +1301,10 @@ DEF_OP(VFCMPGT) {
   else {
     switch (Op->Header.ElementSize) {
     case 4:
-      vcmpps(GetDst(Node), GetSrc(Op->Header.Args[1].ID()), GetSrc(Op->Header.Args[0].ID()), 1);
+      vcmpps(GetDst(Node), GetSrc(Op->Vector2.ID()), GetSrc(Op->Vector1.ID()), 1);
     break;
     case 8:
-      vcmppd(GetDst(Node), GetSrc(Op->Header.Args[1].ID()), GetSrc(Op->Header.Args[0].ID()), 1);
+      vcmppd(GetDst(Node), GetSrc(Op->Vector2.ID()), GetSrc(Op->Vector1.ID()), 1);
     break;
     default: LOGMAN_MSG_A_FMT("Unsupported element size: {}", Op->Header.ElementSize);
     }
@@ -1313,15 +1313,15 @@ DEF_OP(VFCMPGT) {
 
 DEF_OP(VFCMPLE) {
   auto Op = IROp->C<IR::IROp_VFCMPLE>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   if (Op->Header.ElementSize == OpSize) {
     switch (Op->Header.ElementSize) {
     case 4:
-      vcmpss(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 2);
+      vcmpss(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()), 2);
     break;
     case 8:
-      vcmpsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 2);
+      vcmpsd(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()), 2);
     break;
     default: LOGMAN_MSG_A_FMT("Unsupported element size: {}", Op->Header.ElementSize);
     }
@@ -1329,10 +1329,10 @@ DEF_OP(VFCMPLE) {
   else {
     switch (Op->Header.ElementSize) {
     case 4:
-      vcmpps(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 2);
+      vcmpps(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()), 2);
     break;
     case 8:
-      vcmppd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 2);
+      vcmppd(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()), 2);
     break;
     default: LOGMAN_MSG_A_FMT("Unsupported element size: {}", Op->Header.ElementSize);
     }
@@ -1341,15 +1341,15 @@ DEF_OP(VFCMPLE) {
 
 DEF_OP(VFCMPORD) {
   auto Op = IROp->C<IR::IROp_VFCMPORD>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   if (Op->Header.ElementSize == OpSize) {
     switch (Op->Header.ElementSize) {
     case 4:
-      vcmpss(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 7);
+      vcmpss(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()), 7);
     break;
     case 8:
-      vcmpsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 7);
+      vcmpsd(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()), 7);
     break;
     default: LOGMAN_MSG_A_FMT("Unsupported element size: {}", Op->Header.ElementSize);
     }
@@ -1357,10 +1357,10 @@ DEF_OP(VFCMPORD) {
   else {
     switch (Op->Header.ElementSize) {
     case 4:
-      vcmpps(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 7);
+      vcmpps(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()), 7);
     break;
     case 8:
-      vcmppd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 7);
+      vcmppd(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()), 7);
     break;
     default: LOGMAN_MSG_A_FMT("Unsupported element size: {}", Op->Header.ElementSize);
     }
@@ -1369,15 +1369,15 @@ DEF_OP(VFCMPORD) {
 
 DEF_OP(VFCMPUNO) {
   auto Op = IROp->C<IR::IROp_VFCMPUNO>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   if (Op->Header.ElementSize == OpSize) {
     switch (Op->Header.ElementSize) {
     case 4:
-      vcmpss(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 3);
+      vcmpss(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()), 3);
     break;
     case 8:
-      vcmpsd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 3);
+      vcmpsd(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()), 3);
     break;
     default: LOGMAN_MSG_A_FMT("Unsupported element size: {}", Op->Header.ElementSize);
     }
@@ -1385,10 +1385,10 @@ DEF_OP(VFCMPUNO) {
   else {
     switch (Op->Header.ElementSize) {
     case 4:
-      vcmpps(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 3);
+      vcmpps(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()), 3);
     break;
     case 8:
-      vcmppd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), 3);
+      vcmppd(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()), 3);
     break;
     default: LOGMAN_MSG_A_FMT("Unsupported element size: {}", Op->Header.ElementSize);
     }
@@ -1412,15 +1412,15 @@ DEF_OP(VUShlS) {
 
   switch (Op->Header.ElementSize) {
     case 2: {
-      vpsllw(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpsllw(GetDst(Node), GetSrc(Op->Vector.ID()), GetSrc(Op->ShiftScalar.ID()));
       break;
     }
     case 4: {
-      vpslld(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpslld(GetDst(Node), GetSrc(Op->Vector.ID()), GetSrc(Op->ShiftScalar.ID()));
       break;
     }
     case 8: {
-      vpsllq(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpsllq(GetDst(Node), GetSrc(Op->Vector.ID()), GetSrc(Op->ShiftScalar.ID()));
       break;
     }
     default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
@@ -1432,15 +1432,15 @@ DEF_OP(VUShrS) {
 
   switch (Op->Header.ElementSize) {
     case 2: {
-      vpsrlw(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpsrlw(GetDst(Node), GetSrc(Op->Vector.ID()), GetSrc(Op->ShiftScalar.ID()));
       break;
     }
     case 4: {
-      vpsrld(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpsrld(GetDst(Node), GetSrc(Op->Vector.ID()), GetSrc(Op->ShiftScalar.ID()));
       break;
     }
     case 8: {
-      vpsrlq(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpsrlq(GetDst(Node), GetSrc(Op->Vector.ID()), GetSrc(Op->ShiftScalar.ID()));
       break;
     }
     default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
@@ -1452,11 +1452,11 @@ DEF_OP(VSShrS) {
 
   switch (Op->Header.ElementSize) {
     case 2: {
-      vpsraw(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpsraw(GetDst(Node), GetSrc(Op->Vector.ID()), GetSrc(Op->ShiftScalar.ID()));
       break;
     }
     case 4: {
-      vpsrad(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpsrad(GetDst(Node), GetSrc(Op->Vector.ID()), GetSrc(Op->ShiftScalar.ID()));
       break;
     }
     case 8: // Doesn't exist on x86
@@ -1466,7 +1466,7 @@ DEF_OP(VSShrS) {
 
 DEF_OP(VInsElement) {
   auto Op = IROp->C<IR::IROp_VInsElement>();
-  movapd(xmm15, GetSrc(Op->Header.Args[0].ID()));
+  movapd(xmm15, GetSrc(Op->DestVector.ID()));
 
   // Dst_d[Op->DestIdx] = Src2_d[Op->SrcIdx];
 
@@ -1474,22 +1474,22 @@ DEF_OP(VInsElement) {
   // pinsrq xmm, reg64/mem64, imm8
   switch (Op->Header.ElementSize) {
   case 1: {
-    pextrb(eax, GetSrc(Op->Header.Args[1].ID()), Op->SrcIdx);
+    pextrb(eax, GetSrc(Op->SrcVector.ID()), Op->SrcIdx);
     pinsrb(xmm15, eax, Op->DestIdx);
   break;
   }
   case 2: {
-    pextrw(eax, GetSrc(Op->Header.Args[1].ID()), Op->SrcIdx);
+    pextrw(eax, GetSrc(Op->SrcVector.ID()), Op->SrcIdx);
     pinsrw(xmm15, eax, Op->DestIdx);
   break;
   }
   case 4: {
-    pextrd(eax, GetSrc(Op->Header.Args[1].ID()), Op->SrcIdx);
+    pextrd(eax, GetSrc(Op->SrcVector.ID()), Op->SrcIdx);
     pinsrd(xmm15, eax, Op->DestIdx);
   break;
   }
   case 8: {
-    pextrq(rax, GetSrc(Op->Header.Args[1].ID()), Op->SrcIdx);
+    pextrq(rax, GetSrc(Op->SrcVector.ID()), Op->SrcIdx);
     pinsrq(xmm15, rax, Op->DestIdx);
   break;
   }
@@ -1501,7 +1501,7 @@ DEF_OP(VInsElement) {
 
 DEF_OP(VInsScalarElement) {
   auto Op = IROp->C<IR::IROp_VInsScalarElement>();
-  movapd(xmm15, GetSrc(Op->Header.Args[0].ID()));
+  movapd(xmm15, GetSrc(Op->DestVector.ID()));
 
   // Dst_d[Op->DestIdx] = Src2_d[Op->SrcIdx];
 
@@ -1509,22 +1509,22 @@ DEF_OP(VInsScalarElement) {
   // pinsrq xmm, reg64/mem64, imm8
   switch (Op->Header.ElementSize) {
   case 1: {
-    pextrb(eax, GetSrc(Op->Header.Args[1].ID()), 0);
+    pextrb(eax, GetSrc(Op->SrcScalar.ID()), 0);
     pinsrb(xmm15, eax, Op->DestIdx);
   break;
   }
   case 2: {
-    pextrw(eax, GetSrc(Op->Header.Args[1].ID()), 0);
+    pextrw(eax, GetSrc(Op->SrcScalar.ID()), 0);
     pinsrw(xmm15, eax, Op->DestIdx);
   break;
   }
   case 4: {
-    pextrd(eax, GetSrc(Op->Header.Args[1].ID()), 0);
+    pextrd(eax, GetSrc(Op->SrcScalar.ID()), 0);
     pinsrd(xmm15, eax, Op->DestIdx);
   break;
   }
   case 8: {
-    pextrq(rax, GetSrc(Op->Header.Args[1].ID()), 0);
+    pextrq(rax, GetSrc(Op->SrcScalar.ID()), 0);
     pinsrq(xmm15, rax, Op->DestIdx);
   break;
   }
@@ -1539,22 +1539,22 @@ DEF_OP(VExtractElement) {
 
   switch (Op->Header.Size) {
     case 1: {
-      pextrb(eax, GetSrc(Op->Header.Args[0].ID()), Op->Index);
+      pextrb(eax, GetSrc(Op->Vector.ID()), Op->Index);
       pinsrb(GetDst(Node), eax, 0);
       break;
     }
     case 2: {
-      pextrw(eax, GetSrc(Op->Header.Args[0].ID()), Op->Index);
+      pextrw(eax, GetSrc(Op->Vector.ID()), Op->Index);
       pinsrw(GetDst(Node), eax, 0);
       break;
     }
     case 4: {
-      pextrd(eax, GetSrc(Op->Header.Args[0].ID()), Op->Index);
+      pextrd(eax, GetSrc(Op->Vector.ID()), Op->Index);
       pinsrd(GetDst(Node), eax, 0);
       break;
     }
     case 8: {
-      pextrq(rax, GetSrc(Op->Header.Args[0].ID()), Op->Index);
+      pextrq(rax, GetSrc(Op->Vector.ID()), Op->Index);
       pinsrq(GetDst(Node), rax, 0);
       break;
     }
@@ -1568,35 +1568,35 @@ DEF_OP(VDupElement) {
   switch (Op->Header.ElementSize) {
     case 1: {
       // First extract the index
-      pextrb(eax, GetSrc(Op->Header.Args[0].ID()), Op->Index);
+      pextrb(eax, GetSrc(Op->Vector.ID()), Op->Index);
       // Insert it in to the first element of the destination
       pinsrb(GetDst(Node), eax, 0);
       pinsrb(GetDst(Node), eax, 1);
       // Shuffle low elements
-      vpshuflw(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), 0);
+      vpshuflw(GetDst(Node), GetSrc(Op->Vector.ID()), 0);
       // Insert element in to the first upper 64bit element
       pinsrb(GetDst(Node), eax, 8);
       pinsrb(GetDst(Node), eax, 9);
       // Shuffle high elements
-      vpshufhw(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), 0);
+      vpshufhw(GetDst(Node), GetSrc(Op->Vector.ID()), 0);
       break;
     }
     case 2: {
       // First extract the index
-      pextrw(eax, GetSrc(Op->Header.Args[0].ID()), Op->Index);
+      pextrw(eax, GetSrc(Op->Vector.ID()), Op->Index);
       // Insert it in to the first element of the destination
       pinsrw(GetDst(Node), eax, 0);
       // Shuffle low elements
-      vpshuflw(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), 0);
+      vpshuflw(GetDst(Node), GetSrc(Op->Vector.ID()), 0);
       // Insert element in to the first upper 64bit element
       pinsrw(GetDst(Node), eax, 4);
       // Shuffle high elements
-      vpshufhw(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), 0);
+      vpshufhw(GetDst(Node), GetSrc(Op->Vector.ID()), 0);
       break;
     }
     case 4: {
       vpshufd(GetDst(Node),
-        GetSrc(Op->Header.Args[0].ID()),
+        GetSrc(Op->Vector.ID()),
         (Op->Index << 0) |
         (Op->Index << 2) |
         (Op->Index << 4) |
@@ -1605,8 +1605,8 @@ DEF_OP(VDupElement) {
     }
     case 8: {
       vshufpd(GetDst(Node),
-        GetSrc(Op->Header.Args[0].ID()),
-        GetSrc(Op->Header.Args[0].ID()),
+        GetSrc(Op->Vector.ID()),
+        GetSrc(Op->Vector.ID()),
         (Op->Index << 0) |
         (Op->Index << 1));
       break;
@@ -1619,38 +1619,38 @@ DEF_OP(VDupElement) {
 
 DEF_OP(VExtr) {
   auto Op = IROp->C<IR::IROp_VExtr>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   if (OpSize == 8) {
     // No way to do this with 64bit source without dropping to MMX
     // So emulate it
     vpxor(xmm14, xmm14, xmm14);
-    movq(xmm15, GetSrc(Op->Header.Args[1].ID()));
-    vshufpd(xmm15, xmm15, GetSrc(Op->Header.Args[0].ID()), 0b00);
+    movq(xmm15, GetSrc(Op->VectorUpper.ID()));
+    vshufpd(xmm15, xmm15, GetSrc(Op->VectorLower.ID()), 0b00);
     vpalignr(GetDst(Node), xmm14, xmm15, Op->Index);
   }
   else {
-    vpalignr(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()), Op->Index);
+    vpalignr(GetDst(Node), GetSrc(Op->VectorLower.ID()), GetSrc(Op->VectorUpper.ID()), Op->Index);
   }
 }
 
 DEF_OP(VSLI) {
   auto Op = IROp->C<IR::IROp_VSLI>();
-  movapd(xmm15, GetSrc(Op->Header.Args[0].ID()));
+  movapd(xmm15, GetSrc(Op->Vector.ID()));
   pslldq(xmm15, Op->ByteShift);
   movapd(GetDst(Node), xmm15);
 }
 
 DEF_OP(VSRI) {
   auto Op = IROp->C<IR::IROp_VSRI>();
-  movapd(xmm15, GetSrc(Op->Header.Args[0].ID()));
+  movapd(xmm15, GetSrc(Op->Vector.ID()));
   psrldq(xmm15, Op->ByteShift);
   movapd(GetDst(Node), xmm15);
 }
 
 DEF_OP(VUShrI) {
   auto Op = IROp->C<IR::IROp_VUShrI>();
-  movapd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
+  movapd(GetDst(Node), GetSrc(Op->Vector.ID()));
   switch (Op->Header.ElementSize) {
     case 2: {
       psrlw(GetDst(Node), Op->BitShift);
@@ -1671,12 +1671,12 @@ DEF_OP(VUShrI) {
 DEF_OP(VSShrI) {
   auto Op = IROp->C<IR::IROp_VSShrI>();
   auto Dest = GetDst(Node);
-  movapd(Dest, GetSrc(Op->Header.Args[0].ID()));
+  movapd(Dest, GetSrc(Op->Vector.ID()));
   switch (Op->Header.ElementSize) {
     case 1: {
       // This isn't a native instruction on x86
-      uint8_t OpSize = IROp->Size;
-      uint8_t Elements = OpSize / Op->Header.ElementSize;
+      const uint8_t OpSize = IROp->Size;
+      const uint8_t Elements = OpSize / Op->Header.ElementSize;
       for (int i = 0; i < Elements; ++i) {
         pextrb(eax, Dest, i);
         movsx(eax, al);
@@ -1708,7 +1708,7 @@ DEF_OP(VSShrI) {
 
 DEF_OP(VShlI) {
   auto Op = IROp->C<IR::IROp_VShlI>();
-  movapd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
+  movapd(GetDst(Node), GetSrc(Op->Vector.ID()));
   switch (Op->Header.ElementSize) {
     case 2: {
       psllw(GetDst(Node), Op->BitShift);
@@ -1728,7 +1728,7 @@ DEF_OP(VShlI) {
 
 DEF_OP(VUShrNI) {
   auto Op = IROp->C<IR::IROp_VUShrNI>();
-  movapd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
+  movapd(GetDst(Node), GetSrc(Op->Vector.ID()));
   vpxor(xmm15, xmm15, xmm15);
   switch (Op->Header.ElementSize) {
     case 1: {
@@ -1765,7 +1765,7 @@ DEF_OP(VUShrNI2) {
   // Src1 = Lower results
   // Src2 = Upper Results
   auto Op = IROp->C<IR::IROp_VUShrNI2>();
-  movapd(xmm13, GetSrc(Op->Header.Args[1].ID()));
+  movapd(xmm13, GetSrc(Op->VectorUpper.ID()));
   switch (Op->Header.ElementSize) {
     case 1: {
       psrlw(xmm13, Op->BitShift);
@@ -1795,25 +1795,25 @@ DEF_OP(VUShrNI2) {
   vmovq(xmm14, rcx);
   punpcklqdq(xmm15, xmm14);
   vpshufb(xmm14, xmm13, xmm15);
-  vpor(GetDst(Node), xmm14, GetSrc(Op->Header.Args[0].ID()));
+  vpor(GetDst(Node), xmm14, GetSrc(Op->VectorLower.ID()));
 }
 
 DEF_OP(VBitcast) {
   auto Op = IROp->C<IR::IROp_VBitcast>();
-  movaps(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
+  movaps(GetDst(Node), GetSrc(Op->Source.ID()));
 }
 
 DEF_OP(VSXTL) {
   auto Op = IROp->C<IR::IROp_VSXTL>();
   switch (Op->Header.ElementSize) {
     case 2:
-      pmovsxbw(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
+      pmovsxbw(GetDst(Node), GetSrc(Op->Vector.ID()));
     break;
     case 4:
-      pmovsxwd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
+      pmovsxwd(GetDst(Node), GetSrc(Op->Vector.ID()));
     break;
     case 8:
-      pmovsxdq(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
+      pmovsxdq(GetDst(Node), GetSrc(Op->Vector.ID()));
     break;
     default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize);
   }
@@ -1823,7 +1823,7 @@ DEF_OP(VSXTL2) {
   auto Op = IROp->C<IR::IROp_VSXTL2>();
   uint8_t OpSize = IROp->Size;
 
-  vpsrldq(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), OpSize / 2);
+  vpsrldq(GetDst(Node), GetSrc(Op->Vector.ID()), OpSize / 2);
   switch (Op->Header.ElementSize) {
     case 2:
       pmovsxbw(GetDst(Node), GetDst(Node));
@@ -1842,13 +1842,13 @@ DEF_OP(VUXTL) {
   auto Op = IROp->C<IR::IROp_VUXTL>();
   switch (Op->Header.ElementSize) {
     case 2:
-      pmovzxbw(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
+      pmovzxbw(GetDst(Node), GetSrc(Op->Vector.ID()));
     break;
     case 4:
-      pmovzxwd(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
+      pmovzxwd(GetDst(Node), GetSrc(Op->Vector.ID()));
     break;
     case 8:
-      pmovzxdq(GetDst(Node), GetSrc(Op->Header.Args[0].ID()));
+      pmovzxdq(GetDst(Node), GetSrc(Op->Vector.ID()));
     break;
     default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize);
   }
@@ -1858,7 +1858,7 @@ DEF_OP(VUXTL2) {
   auto Op = IROp->C<IR::IROp_VUXTL2>();
   uint8_t OpSize = IROp->Size;
 
-  vpsrldq(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), OpSize / 2);
+  vpsrldq(GetDst(Node), GetSrc(Op->Vector.ID()), OpSize / 2);
   switch (Op->Header.ElementSize) {
     case 2:
       pmovzxbw(GetDst(Node), GetDst(Node));
@@ -1877,10 +1877,10 @@ DEF_OP(VSQXTN) {
   auto Op = IROp->C<IR::IROp_VSQXTN>();
   switch (Op->Header.ElementSize) {
     case 1:
-      packsswb(xmm15, GetSrc(Op->Header.Args[0].ID()));
+      packsswb(xmm15, GetSrc(Op->Vector.ID()));
     break;
     case 2:
-      packssdw(xmm15, GetSrc(Op->Header.Args[0].ID()));
+      packssdw(xmm15, GetSrc(Op->Vector.ID()));
     break;
     default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize);
   }
@@ -1890,16 +1890,16 @@ DEF_OP(VSQXTN) {
 
 DEF_OP(VSQXTN2) {
   auto Op = IROp->C<IR::IROp_VSQXTN2>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   // Zero the lower bits
   vpxor(xmm15, xmm15, xmm15);
   switch (Op->Header.ElementSize) {
     case 1:
-      packsswb(xmm15, GetSrc(Op->Header.Args[1].ID()));
+      packsswb(xmm15, GetSrc(Op->VectorUpper.ID()));
     break;
     case 2:
-      packssdw(xmm15, GetSrc(Op->Header.Args[1].ID()));
+      packssdw(xmm15, GetSrc(Op->VectorUpper.ID()));
     break;
     default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize);
   }
@@ -1907,17 +1907,17 @@ DEF_OP(VSQXTN2) {
   if (OpSize == 8) {
     psrldq(xmm15, OpSize / 2);
   }
-  vpor(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), xmm15);
+  vpor(GetDst(Node), GetSrc(Op->VectorLower.ID()), xmm15);
 }
 
 DEF_OP(VSQXTUN) {
   auto Op = IROp->C<IR::IROp_VSQXTUN>();
   switch (Op->Header.ElementSize) {
     case 1:
-      packuswb(xmm15, GetSrc(Op->Header.Args[0].ID()));
+      packuswb(xmm15, GetSrc(Op->Vector.ID()));
     break;
     case 2:
-      packusdw(xmm15, GetSrc(Op->Header.Args[0].ID()));
+      packusdw(xmm15, GetSrc(Op->Vector.ID()));
     break;
     default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize);
   }
@@ -1927,16 +1927,16 @@ DEF_OP(VSQXTUN) {
 
 DEF_OP(VSQXTUN2) {
   auto Op = IROp->C<IR::IROp_VSQXTUN2>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   // Zero the lower bits
   vpxor(xmm15, xmm15, xmm15);
   switch (Op->Header.ElementSize) {
     case 1:
-      packuswb(xmm15, GetSrc(Op->Header.Args[1].ID()));
+      packuswb(xmm15, GetSrc(Op->VectorUpper.ID()));
     break;
     case 2:
-      packusdw(xmm15, GetSrc(Op->Header.Args[1].ID()));
+      packusdw(xmm15, GetSrc(Op->VectorUpper.ID()));
     break;
     default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize);
   }
@@ -1944,18 +1944,18 @@ DEF_OP(VSQXTUN2) {
     psrldq(xmm15, OpSize / 2);
   }
 
-  vpor(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), xmm15);
+  vpor(GetDst(Node), GetSrc(Op->VectorLower.ID()), xmm15);
 }
 
 DEF_OP(VMul) {
   auto Op = IROp->C<IR::IROp_VUMul>();
   switch (Op->Header.ElementSize) {
     case 2: {
-      vpmullw(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpmullw(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
     }
     case 4: {
-      vpmulld(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpmulld(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
       break;
     }
     default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
@@ -1974,8 +1974,8 @@ DEF_OP(VUMull) {
       //
       vpxor(xmm15, xmm15, xmm15);
       vpxor(xmm14, xmm14, xmm14);
-      vpunpcklwd(xmm15, GetSrc(Op->Header.Args[0].ID()), xmm15);
-      vpunpcklwd(xmm14, GetSrc(Op->Header.Args[1].ID()), xmm14);
+      vpunpcklwd(xmm15, GetSrc(Op->Vector1.ID()), xmm15);
+      vpunpcklwd(xmm14, GetSrc(Op->Vector2.ID()), xmm14);
       vpmulld(GetDst(Node), xmm14, xmm15);
       break;
     }
@@ -1983,8 +1983,8 @@ DEF_OP(VUMull) {
       // We need to shuffle the data for this one
       // x86 PMULUDQ wants the 32bit values in [31:0] and [95:64]
       // Which then extends out to [63:0] and [127:64]
-      vpshufd(xmm14, GetSrc(Op->Header.Args[0].ID()), 0b10'10'00'00);
-      vpshufd(xmm15, GetSrc(Op->Header.Args[1].ID()), 0b10'10'00'00);
+      vpshufd(xmm14, GetSrc(Op->Vector1.ID()), 0b10'10'00'00);
+      vpshufd(xmm15, GetSrc(Op->Vector2.ID()), 0b10'10'00'00);
 
       vpmuludq(GetDst(Node), xmm14, xmm15);
     break;
@@ -2005,8 +2005,8 @@ DEF_OP(VSMull) {
       //
       vpxor(xmm15, xmm15, xmm15);
       vpxor(xmm14, xmm14, xmm14);
-      vpunpcklwd(xmm15, GetSrc(Op->Header.Args[0].ID()), xmm15);
-      vpunpcklwd(xmm14, GetSrc(Op->Header.Args[1].ID()), xmm14);
+      vpunpcklwd(xmm15, GetSrc(Op->Vector1.ID()), xmm15);
+      vpunpcklwd(xmm14, GetSrc(Op->Vector2.ID()), xmm14);
       pslld(xmm15, 16);
       pslld(xmm14, 16);
       psrad(xmm15, 16);
@@ -2018,8 +2018,8 @@ DEF_OP(VSMull) {
       // We need to shuffle the data for this one
       // x86 PMULDQ wants the 32bit values in [31:0] and [95:64]
       // Which then extends out to [63:0] and [127:64]
-      vpshufd(xmm14, GetSrc(Op->Header.Args[0].ID()), 0b10'10'00'00);
-      vpshufd(xmm15, GetSrc(Op->Header.Args[1].ID()), 0b10'10'00'00);
+      vpshufd(xmm14, GetSrc(Op->Vector1.ID()), 0b10'10'00'00);
+      vpshufd(xmm15, GetSrc(Op->Vector2.ID()), 0b10'10'00'00);
 
       vpmuldq(GetDst(Node), xmm14, xmm15);
     break;
@@ -2040,8 +2040,8 @@ DEF_OP(VUMull2) {
       //
       vpxor(xmm15, xmm15, xmm15);
       vpxor(xmm14, xmm14, xmm14);
-      vpunpckhwd(xmm15, GetSrc(Op->Header.Args[0].ID()), xmm15);
-      vpunpckhwd(xmm14, GetSrc(Op->Header.Args[1].ID()), xmm14);
+      vpunpckhwd(xmm15, GetSrc(Op->Vector1.ID()), xmm15);
+      vpunpckhwd(xmm14, GetSrc(Op->Vector2.ID()), xmm14);
       vpmulld(GetDst(Node), xmm14, xmm15);
       break;
     }
@@ -2054,8 +2054,8 @@ DEF_OP(VUMull2) {
       // [63:00 ] = src1[31:0 ] * src2[31:0 ]
       // [127:64] = src1[95:64] * src2[95:64]
 
-      vpshufd(xmm14, GetSrc(Op->Header.Args[0].ID()), 0b11'11'10'10);
-      vpshufd(xmm15, GetSrc(Op->Header.Args[1].ID()), 0b11'11'10'10);
+      vpshufd(xmm14, GetSrc(Op->Vector1.ID()), 0b11'11'10'10);
+      vpshufd(xmm15, GetSrc(Op->Vector2.ID()), 0b11'11'10'10);
 
       vpmuludq(GetDst(Node), xmm14, xmm15);
     break;
@@ -2076,8 +2076,8 @@ DEF_OP(VSMull2) {
       //
       vpxor(xmm15, xmm15, xmm15);
       vpxor(xmm14, xmm14, xmm14);
-      vpunpckhwd(xmm15, GetSrc(Op->Header.Args[0].ID()), xmm15);
-      vpunpckhwd(xmm14, GetSrc(Op->Header.Args[1].ID()), xmm14);
+      vpunpckhwd(xmm15, GetSrc(Op->Vector1.ID()), xmm15);
+      vpunpckhwd(xmm14, GetSrc(Op->Vector2.ID()), xmm14);
       pslld(xmm15, 16);
       pslld(xmm14, 16);
       psrad(xmm15, 16);
@@ -2094,8 +2094,8 @@ DEF_OP(VSMull2) {
       // [63:00 ] = src1[31:0 ] * src2[31:0 ]
       // [127:64] = src1[95:64] * src2[95:64]
 
-      vpshufd(xmm14, GetSrc(Op->Header.Args[0].ID()), 0b11'11'10'10);
-      vpshufd(xmm15, GetSrc(Op->Header.Args[1].ID()), 0b11'11'10'10);
+      vpshufd(xmm14, GetSrc(Op->Vector1.ID()), 0b11'11'10'10);
+      vpshufd(xmm15, GetSrc(Op->Vector2.ID()), 0b11'11'10'10);
 
       vpmuldq(GetDst(Node), xmm14, xmm15);
     break;
@@ -2108,15 +2108,15 @@ DEF_OP(VUABDL) {
   auto Op = IROp->C<IR::IROp_VUABDL>();
   switch (Op->Header.ElementSize) {
     case 2: {
-      pmovzxbw(xmm14, GetSrc(Op->Header.Args[0].ID()));
-      pmovzxbw(xmm15, GetSrc(Op->Header.Args[1].ID()));
+      pmovzxbw(xmm14, GetSrc(Op->Vector1.ID()));
+      pmovzxbw(xmm15, GetSrc(Op->Vector2.ID()));
       vpsubw(GetDst(Node), xmm14, xmm15);
       vpabsw(GetDst(Node), GetDst(Node));
       break;
     }
     case 4: {
-      pmovzxwd(xmm14, GetSrc(Op->Header.Args[0].ID()));
-      pmovzxwd(xmm15, GetSrc(Op->Header.Args[1].ID()));
+      pmovzxwd(xmm14, GetSrc(Op->Vector1.ID()));
+      pmovzxwd(xmm15, GetSrc(Op->Vector2.ID()));
       vpsubd(GetDst(Node), xmm14, xmm15);
       vpabsd(GetDst(Node), GetDst(Node));
       break;
@@ -2127,16 +2127,16 @@ DEF_OP(VUABDL) {
 
 DEF_OP(VTBL1) {
   auto Op = IROp->C<IR::IROp_VTBL1>();
-  uint8_t OpSize = IROp->Size;
+  const uint8_t OpSize = IROp->Size;
 
   switch (OpSize) {
     case 8: {
-      vpshufb(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpshufb(GetDst(Node), GetSrc(Op->VectorTable.ID()), GetSrc(Op->VectorIndices.ID()));
       movq(GetDst(Node), GetDst(Node));
       break;
     }
     case 16: {
-      vpshufb(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), GetSrc(Op->Header.Args[1].ID()));
+      vpshufb(GetDst(Node), GetSrc(Op->VectorTable.ID()), GetSrc(Op->VectorIndices.ID()));
       break;
     }
     default: LOGMAN_MSG_A_FMT("Unknown OpSize: {}", OpSize); break;
@@ -2162,7 +2162,7 @@ DEF_OP(VRev64) {
         pinsrq(xmm15, rcx, 1);
       }
 
-      vpshufb(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), xmm15);
+      vpshufb(GetDst(Node), GetSrc(Op->Vector.ID()), xmm15);
       break;
     }
     case 2: {
@@ -2179,13 +2179,13 @@ DEF_OP(VRev64) {
         mov(rcx, 0x80'80'80'80'80'80'80'80); // Upper
         pinsrq(xmm15, rcx, 1);
       }
-      vpshufb(GetDst(Node), GetSrc(Op->Header.Args[0].ID()), xmm15);
+      vpshufb(GetDst(Node), GetSrc(Op->Vector.ID()), xmm15);
       break;
     }
     case 4: {
       if (IROp->Size == 16) {
       vpshufd(GetDst(Node),
-        GetSrc(Op->Header.Args[0].ID()),
+        GetSrc(Op->Vector.ID()),
         (0b11 << 0) |
         (0b10 << 2) |
         (0b01 << 4) |
@@ -2194,7 +2194,7 @@ DEF_OP(VRev64) {
       else {
 
       vpshufd(GetDst(Node),
-        GetSrc(Op->Header.Args[0].ID()),
+        GetSrc(Op->Vector.ID()),
         (0b01 << 0) |
         (0b00 << 2) |
         (0b11 << 4) | // Last two don't matter, will be overwritten with zero


### PR DESCRIPTION
Now all of the existing CPU cores are consistent with each other

This also resolves a benign case where the wrong struct type was used in VRev64 (though no issues arose because layouts are the exact same).