### PR TITLE
Config: Support a global configuration file

### DIFF
--- a/External/FEXCore/include/FEXCore/Config/Config.h
+++ b/External/FEXCore/include/FEXCore/Config/Config.h
@@ -71,6 +71,7 @@ namespace Handler {
   };
 
   enum class LayerType {
+    LAYER_GLOBAL_MAIN, ///< /usr/share/fex-emu/Config.json by default
     LAYER_MAIN,
     LAYER_ARGUMENTS,
     LAYER_GLOBAL_APP,
@@ -100,7 +101,7 @@ namespace Type {
 
   FEX_DEFAULT_VISIBILITY std::string GetDataDirectory();
   FEX_DEFAULT_VISIBILITY std::string GetConfigDirectory(bool Global);
-  FEX_DEFAULT_VISIBILITY std::string GetConfigFileLocation();
+  FEX_DEFAULT_VISIBILITY std::string GetConfigFileLocation(bool Global = false);
   FEX_DEFAULT_VISIBILITY std::string GetApplicationConfig(const std::string &Filename, bool Global);
 
   using LayerValue = std::list<std::string>;
@@ -245,6 +246,13 @@ namespace Type {
   protected:
     void MapNameToOption(const char *ConfigName, const char *ConfigString);
   };
+
+  /**
+   * @brief Loads the global FEX config
+   *
+   * @return unique_ptr for that layer
+   */
+  FEX_DEFAULT_VISIBILITY std::unique_ptr<FEXCore::Config::Layer> CreateGlobalMainLayer();
 
   /**
    * @brief Loads the main application config

--- a/Source/Common/Config.cpp
+++ b/Source/Common/Config.cpp
@@ -47,6 +47,7 @@ namespace FEX::Config {
     char **argv,
     char **const envp) {
     FEXCore::Config::Initialize();
+    FEXCore::Config::AddLayer(FEXCore::Config::CreateGlobalMainLayer());
     FEXCore::Config::AddLayer(FEXCore::Config::CreateMainLayer());
 
     if (NoFEXArguments) {

--- a/Source/Tests/FEXBash.cpp
+++ b/Source/Tests/FEXBash.cpp
@@ -22,6 +22,7 @@ $end_info$
 
 int main(int argc, char **argv, char **const envp) {
   FEXCore::Config::Initialize();
+  FEXCore::Config::AddLayer(FEXCore::Config::CreateGlobalMainLayer());
   FEXCore::Config::AddLayer(FEXCore::Config::CreateMainLayer());
   FEX::ArgLoader::LoadWithoutArguments(argc, argv);
   FEXCore::Config::AddLayer(FEXCore::Config::CreateEnvironmentLayer(envp));

--- a/Source/Tools/FEXGetConfig/Main.cpp
+++ b/Source/Tools/FEXGetConfig/Main.cpp
@@ -10,6 +10,7 @@
 
 int main(int argc, char **argv, char **envp) {
   FEXCore::Config::Initialize();
+  FEXCore::Config::AddLayer(FEXCore::Config::CreateGlobalMainLayer());
   FEXCore::Config::AddLayer(FEXCore::Config::CreateMainLayer());
   // No FEX arguments passed through command line
   FEXCore::Config::AddLayer(FEXCore::Config::CreateEnvironmentLayer(envp));


### PR DESCRIPTION
By default this file ends up in `/usr/share/fex-emu/Config.json`.

Some documentation here: https://wiki.fex-emu.org/index.php/Development:Configuration