### PR TITLE
FEXCore: Fix-up edge case behaviour on faulting instructions 

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
@@ -462,6 +462,7 @@ bool Dispatcher::HandleGuestSignal(FEXCore::Core::InternalThreadState *Thread, i
 
         // Overwrite si_code
         guest_siginfo->si_code = Thread->CurrentFrame->SynchronousFaultData.si_code;
+        Signal = Frame->SynchronousFaultData.Signal;
       }
       else {
         guest_uctx->uc_mcontext.gregs[FEXCore::x86_64::FEX_REG_TRAPNO] = ConvertSignalToTrapNo(Signal, HostSigInfo);
@@ -568,11 +569,12 @@ bool Dispatcher::HandleGuestSignal(FEXCore::Core::InternalThreadState *Thread, i
         guest_uctx->uc_mcontext.gregs[FEXCore::x86::FEX_REG_TRAPNO] = Frame->SynchronousFaultData.TrapNo;
         guest_siginfo->si_code = Frame->SynchronousFaultData.si_code;
         guest_uctx->uc_mcontext.gregs[FEXCore::x86::FEX_REG_ERR] = Frame->SynchronousFaultData.err_code;
+        Signal = Frame->SynchronousFaultData.Signal;
       }
       else {
         guest_uctx->uc_mcontext.gregs[FEXCore::x86::FEX_REG_TRAPNO] = ConvertSignalToTrapNo(Signal, HostSigInfo);
         guest_siginfo->si_code = HostSigInfo->si_code;
-      guest_uctx->uc_mcontext.gregs[FEXCore::x86::FEX_REG_ERR] = ConvertSignalToError(Signal, HostSigInfo);
+        guest_uctx->uc_mcontext.gregs[FEXCore::x86::FEX_REG_ERR] = ConvertSignalToError(Signal, HostSigInfo);
       }
       guest_uctx->uc_mcontext.gregs[FEXCore::x86::FEX_REG_EIP] = Frame->State.rip;
       guest_uctx->uc_mcontext.gregs[FEXCore::x86::FEX_REG_CS] = Frame->State.cs;

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
@@ -44,8 +44,9 @@ public:
   uint64_t ThreadPauseHandlerAddressSpillSRA{};
   uint64_t ExitFunctionLinkerAddress{};
   uint64_t SignalHandlerReturnAddress{};
-  uint64_t UnimplementedInstructionAddress{};
-  uint64_t OverflowExceptionInstructionAddress{};
+  uint64_t GuestSignal_SIGILL{};
+  uint64_t GuestSignal_SIGTRAP{};
+  uint64_t GuestSignal_SIGSEGV{};
   uint64_t IntCallbackReturnAddress{};
 
   uint64_t PauseReturnInstruction{};

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/MiscOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/MiscOps.cpp
@@ -45,56 +45,30 @@ DEF_OP(Fence) {
 
 DEF_OP(Break) {
   auto Op = IROp->C<IR::IROp_Break>();
-  switch (Op->Reason) {
-    case FEXCore::IR::Break_Unimplemented: // Hard fault
-    case FEXCore::IR::Break_Interrupt: // Guest ud2
-      ud2();
-      break;
-    case FEXCore::IR::Break_Overflow: // overflow
-      // Need to be outside of JIT cache space to ensure cache clearing correctness
-      jmp(qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.OverflowExceptionHandler)]);
-      break;
-    case FEXCore::IR::Break_Halt: { // HLT
-      // Time to quit
-      // Set our stack to the starting stack location
-      mov(rsp, qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, ReturningStackLocation)]);
 
-      // Now we need to jump to the thread stop handler
-      jmp(qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.ThreadStopHandlerSpillSRA)]);
-      break;
-    }
-    case FEXCore::IR::Break_Interrupt3: // INT3
-    {
-      if (CTX->GetGdbServerStatus()) {
-        // Adjust the stack first for a regular return
-        if (SpillSlots) {
-          add(rsp, SpillSlots * 16);
-        }
+  if (SpillSlots) {
+    add(rsp, SpillSlots * 16);
+  }
 
-        // This jump target needs to be a constant offset here
-        jmp(qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.ThreadPauseHandlerSpillSRA)]);
-      }
-      else {
-        // If we don't have a gdb server attached then....crash?
-        // Treat this case like HLT
-        mov(rsp, qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, ReturningStackLocation)]);
+  mov(byte [STATE + offsetof(FEXCore::Core::CpuStateFrame, SynchronousFaultData.FaultToTopAndGeneratedException)], 1);
+  mov(byte [STATE + offsetof(FEXCore::Core::CpuStateFrame, SynchronousFaultData.Signal)], Op->Reason.Signal);
+  mov(dword [STATE + offsetof(FEXCore::Core::CpuStateFrame, SynchronousFaultData.TrapNo)], Op->Reason.TrapNumber);
+  mov(dword [STATE + offsetof(FEXCore::Core::CpuStateFrame, SynchronousFaultData.err_code)], Op->Reason.ErrorRegister);
+  mov(dword [STATE + offsetof(FEXCore::Core::CpuStateFrame, SynchronousFaultData.si_code)], Op->Reason.si_code);
 
-        // Now we need to jump to the thread stop handler
-        jmp(qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.ThreadStopHandlerSpillSRA)]);
-      }
+  switch (Op->Reason.Signal) {
+  case SIGILL:
+    jmp(qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.GuestSignal_SIGILL)]);
     break;
-    }
-    case FEXCore::IR::Break_InvalidInstruction:
-    {
-      if (SpillSlots) {
-        add(rsp, SpillSlots * 16);
-      }
-
-      // Need to be outside of JIT cache space to ensure cache clearing correctness
-      jmp(qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.UnimplementedInstructionHandler)]);
-      break;
-    }
-    default: LOGMAN_MSG_A_FMT("Unknown Break reason: {}", Op->Reason);
+  case SIGTRAP:
+    jmp(qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.GuestSignal_SIGTRAP)]);
+    break;
+  case SIGSEGV:
+    jmp(qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.GuestSignal_SIGSEGV)]);
+    break;
+  default:
+    jmp(qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.GuestSignal_SIGTRAP)]);
+    break;
   }
 }
 

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -123,12 +123,12 @@
     "constexpr FEXCore::IR::MemOffsetType MEM_OFFSET_UXTW {1}",
     "constexpr FEXCore::IR::MemOffsetType MEM_OFFSET_SXTW {2}",
 
-    "constexpr FEXCore::IR::BreakReason Break_Unimplemented      {0}",
-    "constexpr FEXCore::IR::BreakReason Break_Interrupt          {1}",
-    "constexpr FEXCore::IR::BreakReason Break_Interrupt3         {2}",
-    "constexpr FEXCore::IR::BreakReason Break_Halt               {3}",
-    "constexpr FEXCore::IR::BreakReason Break_Overflow           {4}",
-    "constexpr FEXCore::IR::BreakReason Break_InvalidInstruction {5}"
+    "struct BreakDefinition {",
+    "  uint16_t ErrorRegister;",
+    "  uint8_t Signal;",
+    "  uint8_t TrapNumber;",
+    "  uint8_t si_code;",
+    "};"
   ],
   "IRTypes" : {
     "i1":  "bool",
@@ -150,7 +150,7 @@
     "SyscallFlags": "FEXCore::IR::SyscallFlags",
     "SHA256Sum": "SHA256Sum",
     "MemOffsetType": "MemOffsetType",
-    "BreakReason": "BreakReason",
+    "BreakDefinition": "BreakDefinition",
     "RoundType": "RoundType"
   },
   "Ops": {
@@ -261,7 +261,7 @@
         "HasSideEffects": true,
         "DestSize": "GetOpSize(_NewRIP)"
       },
-      "Break BreakReason:$Reason, u8:$Literal": {
+      "Break BreakDefinition:$Reason": {
         "HasSideEffects": true
       },
       "SignalReturn": {

--- a/External/FEXCore/Source/Interface/IR/IRDumper.cpp
+++ b/External/FEXCore/Source/Interface/IR/IRDumper.cpp
@@ -182,7 +182,12 @@ static void PrintArg(std::stringstream *out, [[maybe_unused]] IRListView const* 
   }
 }
 
-
+static void PrintArg(std::stringstream *out, [[maybe_unused]] IRListView const* IR, FEXCore::IR::BreakDefinition Arg) {
+  *out << "{" << Arg.ErrorRegister << ".";
+  *out << static_cast<uint32_t>(Arg.Signal) << ".";
+  *out << static_cast<uint32_t>(Arg.TrapNumber) << ".";
+  *out << static_cast<uint32_t>(Arg.si_code) << "}";
+}
 
 void Dump(std::stringstream *out, IRListView const* IR, IR::RegisterAllocationData *RAData) {
   auto HeaderOp = IR->GetHeader();

--- a/External/FEXCore/include/FEXCore/Core/CoreState.h
+++ b/External/FEXCore/include/FEXCore/Core/CoreState.h
@@ -132,7 +132,9 @@ namespace FEXCore::Core {
       uint64_t ThreadStopHandlerSpillSRA{};
       uint64_t ThreadPauseHandlerSpillSRA{};
       uint64_t UnimplementedInstructionHandler{};
-      uint64_t OverflowExceptionHandler{};
+      uint64_t GuestSignal_SIGILL{};
+      uint64_t GuestSignal_SIGTRAP{};
+      uint64_t GuestSignal_SIGSEGV{};
       uint64_t SignalReturnHandler{};
       uint64_t L1Pointer{};
       uint64_t L2Pointer{};
@@ -195,6 +197,7 @@ namespace FEXCore::Core {
 
     struct SynchronousFaultDataStruct {
       bool FaultToTopAndGeneratedException{};
+      uint8_t Signal;
       uint32_t TrapNo;
       uint32_t err_code;
       uint32_t si_code;

--- a/External/FEXCore/include/FEXCore/IR/IR.h
+++ b/External/FEXCore/include/FEXCore/IR/IR.h
@@ -402,14 +402,6 @@ struct RoundType final {
   [[nodiscard]] friend constexpr bool operator==(const RoundType&, const RoundType&) = default;
 };
 
-struct BreakReason final {
-  uint8_t Val;
-  [[nodiscard]] constexpr operator uint8_t() const {
-    return Val;
-  }
-  [[nodiscard]] friend constexpr bool operator==(const BreakReason&, const BreakReason&) = default;
-};
-
 struct SHA256Sum final {
   uint8_t data[32];
   [[nodiscard]] bool operator<(SHA256Sum const &rhs) const {

--- a/unittests/FEXLinuxTests/tests/signal/invalid_hlt.cpp
+++ b/unittests/FEXLinuxTests/tests/signal/invalid_hlt.cpp
@@ -1,0 +1,49 @@
+#include <atomic>
+#include <signal.h>
+#include <sys/mman.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <cstdlib>
+
+__attribute__((naked, nocf_check))
+  static void InvalidINT() {
+  __asm volatile(R"(
+    hlt;
+    ret; # Just incase it gets past the int
+    )");
+  }
+
+unsigned long EXPECTED_RIP = reinterpret_cast<unsigned long>(&InvalidINT);
+constexpr int EXPECTED_TRAPNO = 0xD;
+constexpr int EXPECTED_ERR = 0;
+constexpr int EXPECTED_SI_CODE = 128;
+constexpr int EXPECTED_SIGNAL = SIGSEGV;
+
+static void handler(int signal, siginfo_t *siginfo, void* context) {
+  ucontext_t* _context = (ucontext_t*)context;
+#ifndef REG_RIP
+#define REG_RIP REG_EIP
+#endif
+  if (_context->uc_mcontext.gregs[REG_RIP] == EXPECTED_RIP &&
+      _context->uc_mcontext.gregs[REG_TRAPNO] == EXPECTED_TRAPNO &&
+      _context->uc_mcontext.gregs[REG_ERR] == EXPECTED_ERR &&
+      siginfo->si_code == EXPECTED_SI_CODE &&
+      signal == EXPECTED_SIGNAL) {
+    exit(0);
+  }
+  else {
+    exit(1);
+  }
+}
+
+int main() {
+  struct sigaction act{};
+  act.sa_sigaction = handler;
+  act.sa_flags = SA_SIGINFO;
+  sigaction(SIGSEGV, &act, nullptr);
+  sigaction(SIGTRAP, &act, nullptr);
+  sigaction(SIGILL, &act, nullptr);
+
+  InvalidINT();
+  return 1;
+}

--- a/unittests/FEXLinuxTests/tests/signal/invalid_int.cpp
+++ b/unittests/FEXLinuxTests/tests/signal/invalid_int.cpp
@@ -1,0 +1,51 @@
+#include <atomic>
+#include <signal.h>
+#include <sys/mman.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <cstdlib>
+
+__attribute__((naked, nocf_check))
+static void InvalidINT() {
+  __asm volatile(R"(
+  int $0x2d;
+  ret; # Just incase it gets past the int
+  )");
+}
+
+unsigned long EXPECTED_RIP = reinterpret_cast<unsigned long>(&InvalidINT);
+constexpr int EXPECTED_TRAPNO = 13;
+constexpr int EXPECTED_ERR = 362;
+constexpr int EXPECTED_SI_CODE = 128;
+constexpr int EXPECTED_SIGNAL = SIGSEGV;
+
+
+static void handler(int signal, siginfo_t *siginfo, void* context) {
+  ucontext_t* _context = (ucontext_t*)context;
+#ifndef REG_RIP
+#define REG_RIP REG_EIP
+#endif
+
+  if (_context->uc_mcontext.gregs[REG_RIP] == EXPECTED_RIP &&
+      _context->uc_mcontext.gregs[REG_TRAPNO] == EXPECTED_TRAPNO &&
+      _context->uc_mcontext.gregs[REG_ERR] == EXPECTED_ERR &&
+      siginfo->si_code == EXPECTED_SI_CODE &&
+      signal == EXPECTED_SIGNAL) {
+    exit(0);
+  }
+  else {
+    exit(1);
+  }
+}
+
+int main() {
+  struct sigaction act{};
+  act.sa_sigaction = handler;
+  act.sa_flags = SA_SIGINFO;
+  sigaction(SIGSEGV, &act, nullptr);
+  sigaction(SIGTRAP, &act, nullptr);
+  sigaction(SIGILL, &act, nullptr);
+
+  InvalidINT();
+  return 1;
+}

--- a/unittests/FEXLinuxTests/tests/signal/invalid_int1.cpp
+++ b/unittests/FEXLinuxTests/tests/signal/invalid_int1.cpp
@@ -1,0 +1,49 @@
+#include <atomic>
+#include <signal.h>
+#include <sys/mman.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <cstdlib>
+
+__attribute__((naked, nocf_check))
+static void InvalidINT() {
+  __asm volatile(R"(
+  .byte 0xF1; # int1
+  ret; # Just incase it gets past the int
+  )");
+}
+
+unsigned long EXPECTED_RIP = reinterpret_cast<unsigned long>(&InvalidINT) + 1;
+constexpr int EXPECTED_TRAPNO = 1;
+constexpr int EXPECTED_ERR = 0;
+constexpr int EXPECTED_SI_CODE = 1;
+constexpr int EXPECTED_SIGNAL = SIGTRAP;
+
+static void handler(int signal, siginfo_t *siginfo, void* context) {
+  ucontext_t* _context = (ucontext_t*)context;
+#ifndef REG_RIP
+#define REG_RIP REG_EIP
+#endif
+  if (_context->uc_mcontext.gregs[REG_RIP] == EXPECTED_RIP &&
+      _context->uc_mcontext.gregs[REG_TRAPNO] == EXPECTED_TRAPNO &&
+      _context->uc_mcontext.gregs[REG_ERR] == EXPECTED_ERR &&
+      siginfo->si_code == EXPECTED_SI_CODE &&
+      signal == EXPECTED_SIGNAL) {
+    exit(0);
+  }
+  else {
+    exit(1);
+  }
+}
+
+int main() {
+  struct sigaction act{};
+  act.sa_sigaction = handler;
+  act.sa_flags = SA_SIGINFO;
+  sigaction(SIGSEGV, &act, nullptr);
+  sigaction(SIGTRAP, &act, nullptr);
+  sigaction(SIGILL, &act, nullptr);
+
+  InvalidINT();
+  return 1;
+}

--- a/unittests/FEXLinuxTests/tests/signal/invalid_int3.cpp
+++ b/unittests/FEXLinuxTests/tests/signal/invalid_int3.cpp
@@ -1,0 +1,50 @@
+#include <atomic>
+#include <signal.h>
+#include <sys/mman.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <cstdlib>
+
+__attribute__((naked, nocf_check))
+  static void InvalidINT() {
+  __asm volatile(R"(
+  int3;
+  ret; # Just incase it gets past the int
+  )");
+  }
+
+unsigned long EXPECTED_RIP = reinterpret_cast<unsigned long>(&InvalidINT) + 1;
+constexpr int EXPECTED_TRAPNO = 3;
+constexpr int EXPECTED_ERR = 0;
+constexpr int EXPECTED_SI_CODE = 128;
+constexpr int EXPECTED_SIGNAL = SIGTRAP;
+
+static void handler(int signal, siginfo_t *siginfo, void* context) {
+  ucontext_t* _context = (ucontext_t*)context;
+#ifndef REG_RIP
+#define REG_RIP REG_EIP
+#endif
+
+  if (_context->uc_mcontext.gregs[REG_RIP] == EXPECTED_RIP &&
+      _context->uc_mcontext.gregs[REG_TRAPNO] == EXPECTED_TRAPNO &&
+      _context->uc_mcontext.gregs[REG_ERR] == EXPECTED_ERR &&
+      siginfo->si_code == EXPECTED_SI_CODE &&
+      signal == EXPECTED_SIGNAL) {
+    exit(0);
+  }
+  else {
+    exit(1);
+  }
+}
+
+int main() {
+  struct sigaction act{};
+  act.sa_sigaction = handler;
+  act.sa_flags = SA_SIGINFO;
+  sigaction(SIGSEGV, &act, nullptr);
+  sigaction(SIGTRAP, &act, nullptr);
+  sigaction(SIGILL, &act, nullptr);
+
+  InvalidINT();
+  return 1;
+}

--- a/unittests/FEXLinuxTests/tests/signal/invalid_ud2.cpp
+++ b/unittests/FEXLinuxTests/tests/signal/invalid_ud2.cpp
@@ -1,0 +1,49 @@
+#include <atomic>
+#include <signal.h>
+#include <sys/mman.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <cstdlib>
+
+__attribute__((naked, nocf_check))
+  static void InvalidINT() {
+  __asm volatile(R"(
+  ud2;
+  ret; # Just incase it gets past the int
+  )");
+  }
+
+unsigned long EXPECTED_RIP = reinterpret_cast<unsigned long>(&InvalidINT);
+constexpr int EXPECTED_TRAPNO = 6;
+constexpr int EXPECTED_ERR = 0;
+constexpr int EXPECTED_SI_CODE = 2;
+constexpr int EXPECTED_SIGNAL = SIGILL;
+
+static void handler(int signal, siginfo_t *siginfo, void* context) {
+  ucontext_t* _context = (ucontext_t*)context;
+#ifndef REG_RIP
+#define REG_RIP REG_EIP
+#endif
+  if (_context->uc_mcontext.gregs[REG_RIP] == EXPECTED_RIP &&
+      _context->uc_mcontext.gregs[REG_TRAPNO] == EXPECTED_TRAPNO &&
+      _context->uc_mcontext.gregs[REG_ERR] == EXPECTED_ERR &&
+      siginfo->si_code == EXPECTED_SI_CODE &&
+      signal == EXPECTED_SIGNAL) {
+    exit(0);
+  }
+  else {
+    exit(1);
+  }
+}
+
+int main() {
+  struct sigaction act{};
+  act.sa_sigaction = handler;
+  act.sa_flags = SA_SIGINFO;
+  sigaction(SIGSEGV, &act, nullptr);
+  sigaction(SIGTRAP, &act, nullptr);
+  sigaction(SIGILL, &act, nullptr);
+
+  InvalidINT();
+  return 1;
+}

--- a/unittests/IR/Basic/MemoryData.ir
+++ b/unittests/IR/Basic/MemoryData.ir
@@ -18,6 +18,6 @@
     %Addr i64 = Constant #0x100000
     %Val i32 = LoadMem GPR, #8, %Addr i64, %Invalid, #8, SXTX, #1
     (%Store i64) StoreContext #8, GPR, %Val i64, #8
-    (%brk i0) Break Halt, #4
+    (%brk i0) Break {0.11.0.128}
     (%end i0) EndBlock %ssa2
 

--- a/unittests/IR/Basic/Sbfe.ir
+++ b/unittests/IR/Basic/Sbfe.ir
@@ -38,5 +38,5 @@
 ; Test with + shift
     %Res5 i64 = Sbfe #0x4, #0x2, %Val2
     (%Store5 i64) StoreContext #8, GPR, %Res5 i64, #0x28
-    (%brk i0) Break Halt, #4
+    (%brk i0) Break {0.11.0.128}
     (%end i0) EndBlock %ssa2

--- a/unittests/IR/Basic/SetGPR.ir
+++ b/unittests/IR/Basic/SetGPR.ir
@@ -11,5 +11,5 @@
     (%ssa6 i0) BeginBlock %ssa2
     %Value i64 = Constant #0x4142434445464748
     (%Store i64) StoreContext #8, GPR, %Value i64, #8
-    (%ssa7 i0) Break Halt, #4
+    (%ssa7 i0) Break {0.11.0.128}
     (%ssa8 i0) EndBlock %ssa2

--- a/unittests/IR/Correctness/AddTruncate.ir
+++ b/unittests/IR/Correctness/AddTruncate.ir
@@ -34,5 +34,5 @@
     %ResultD i64 = Add %ValueC, %ValueD
     (%Store i64) StoreContext #8, GPR, %ResultC i64, #0x18
     (%Store i64) StoreContext #8, GPR, %ResultD i64, #0x20
-    (%ssa7 i0) Break Halt, #4
+    (%ssa7 i0) Break {0.11.0.128}
     (%ssa12 i0) EndBlock %ssa2

--- a/unittests/IR/Correctness/FPRStoreTruncate.ir
+++ b/unittests/IR/Correctness/FPRStoreTruncate.ir
@@ -48,5 +48,5 @@
     (%Store7 i128) StoreContext #0x10, FPR, %Truncated16 i128, #0x160
     (%Store8 i128) StoreContext #0x10, FPR, %Truncated8 i128, #0x180
     (%Store9 i128) StoreContext #0x10, FPR, %MemValueA i128, #0x1A0
-    (%ssa7 i0) Break Halt, #4
+    (%ssa7 i0) Break {0.11.0.128}
     (%end i0) EndBlock %ssa2

--- a/unittests/IR/Correctness/LeftShiftTruncate.ir
+++ b/unittests/IR/Correctness/LeftShiftTruncate.ir
@@ -32,5 +32,5 @@
     %ResultD i64 = Lshl %ValueB, %Shift
     (%Store i64) StoreContext #8, GPR, %ResultC i64, #0x18
     (%Store i64) StoreContext #8, GPR, %ResultD i64, #0x20
-    (%ssa7 i0) Break Halt, #4
+    (%ssa7 i0) Break {0.11.0.128}
     (%ssa12 i0) EndBlock %ssa2

--- a/unittests/IR/Correctness/SubTruncate.ir
+++ b/unittests/IR/Correctness/SubTruncate.ir
@@ -34,5 +34,5 @@
     %ResultD i64 = Sub %ValueC, %ValueD
     (%Store i64) StoreContext #8, GPR, %ResultC i64, #0x18
     (%Store i64) StoreContext #8, GPR, %ResultD i64, #0x20
-    (%ssa7 i0) Break Halt, #4
+    (%ssa7 i0) Break {0.11.0.128}
     (%ssa12 i0) EndBlock %ssa2


### PR DESCRIPTION
x86 has six instructions that will fault on us that we mostly handled. A
few of these weren't being handled correctly.

One problem is that RIP needs to synchronize differently depending on
which fault instruction it is. Some instructions fault at the
instruction RIP, some at the instruction afterwards.

Additionally some of the metadata generated around the signal delegation
wasn't correct.

With behaviour of all of these instructions changed, it will now be
easier to switch over to non-faulting guest synchronous signals off of
these instructions. This doesn't go far enough to change that behaviour
yet.

I noticed this when looking at Elden Ring's weird faulting behaviour
with ud2 and `int 0x2d`. This made me investigate since I had a
suspicion that we weren't handling both cases correctly.

With this change, Elden Ring is now stabilized and works under FEX.