### PR TITLE
json_ir_generator: Remove Args() functions from IR structs

### DIFF
--- a/External/FEXCore/Scripts/json_ir_generator.py
+++ b/External/FEXCore/Scripts/json_ir_generator.py
@@ -321,22 +321,12 @@ def print_ir_structs(defines):
 
 
         if op.SSAArgNum > 0:
-            # Add helpers for accessing SSA arguments, given how frequently they're accessed
-
             output_file.write("\t// Get index of argument by name\n")
             SSAArg = 0
             for arg in op.Arguments:
                 if arg.IsSSA:
                     output_file.write("\tstatic constexpr size_t {}_Index = {};\n".format(arg.Name, SSAArg))
                     SSAArg = SSAArg + 1
-
-            output_file.write("\n")
-            output_file.write("\t[[nodiscard]] OrderedNodeWrapper& Args(size_t Index) {\n")
-            output_file.write("\t\treturn Header.Args[Index];\n")
-            output_file.write("\t}\n")
-            output_file.write("\t[[nodiscard]] const OrderedNodeWrapper& Args(size_t Index) const {\n")
-            output_file.write("\t\treturn Header.Args[Index];\n")
-            output_file.write("\t}\n")
 
 
         output_file.write("};\n")

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
@@ -117,9 +117,9 @@ DEF_OP(ExitFunction) {
 
 DEF_OP(Jump) {
   const auto Op = IROp->C<IR::IROp_Jump>();
-  const auto ArgID = Op->Args(0).ID();
+  const auto Target = Op->TargetBlock.ID();
 
-  PendingTargetLabel = &JumpTargets.try_emplace(ArgID).first->second;
+  PendingTargetLabel = &JumpTargets.try_emplace(Target).first->second;
 }
 
 #define GRCMP(Node) (Op->CompareSize == 4 ? GetSrc<RA_32>(Node) : GetSrc<RA_64>(Node))


### PR DESCRIPTION
Since the IR argument can be accessed directly by name, this is no longer needed as a shorthand.

Also results in a decently smaller generated file