### PR TITLE
Telemetry: Support executable names through wineserver

### DIFF
--- a/External/FEXCore/Source/Utils/Telemetry.cpp
+++ b/External/FEXCore/Source/Utils/Telemetry.cpp
@@ -35,9 +35,9 @@ namespace FEXCore::Telemetry {
     }
   }
 
-  void Shutdown(std::filesystem::path &ApplicationName) {
+  void Shutdown(std::string const &ApplicationName) {
     auto DataDirectory = Config::GetDataDirectory();
-    DataDirectory += "Telemetry/" + ApplicationName.string() + ".telem";
+    DataDirectory += "Telemetry/" + ApplicationName + ".telem";
 
     std::error_code ec{};
     if (std::filesystem::exists(DataDirectory, ec)) {

--- a/External/FEXCore/include/FEXCore/Utils/Telemetry.h
+++ b/External/FEXCore/include/FEXCore/Utils/Telemetry.h
@@ -42,7 +42,7 @@ namespace FEXCore::Telemetry {
   Value &GetObject(TelemetryType Type);
 
   FEX_DEFAULT_VISIBILITY void Initialize();
-  FEX_DEFAULT_VISIBILITY void Shutdown(std::filesystem::path &ApplicationName);
+  FEX_DEFAULT_VISIBILITY void Shutdown(std::string const &ApplicationName);
 
 // Telemetry object declaration
 // This returns the internal structure to the telemetry data structures
@@ -61,7 +61,7 @@ namespace FEXCore::Telemetry {
 #define FEXCORE_TELEMETRY_Addr(Name) Name->GetAddr()
 #else
   static inline void Initialize() {}
-  static inline void Shutdown(std::filesystem::path &) {}
+  static inline void Shutdown(std::string const &ApplicationName) {}
 
 #define FEXCORE_TELEMETRY_STATIC_INIT(Name, Type)
 #define FEXCORE_TELEMETRY_INIT(Name, Type)

--- a/Source/Common/Config.cpp
+++ b/Source/Common/Config.cpp
@@ -40,7 +40,7 @@ namespace FEX::Config {
     }
   }
 
-  std::string LoadConfig(
+  std::pair<std::string, std::string> LoadConfig(
     bool NoFEXArguments,
     bool LoadProgramConfig,
     int argc,
@@ -111,7 +111,7 @@ namespace FEX::Config {
 
       FEXCore::Config::AddLayer(FEXCore::Config::CreateAppLayer(ProgramName, true));
       FEXCore::Config::AddLayer(FEXCore::Config::CreateAppLayer(ProgramName, false));
-      return Program;
+      return std::make_pair(Program, ProgramName);
     }
     return {};
   }

--- a/Source/Common/Config.h
+++ b/Source/Common/Config.h
@@ -19,7 +19,7 @@ namespace FEX::Config {
 
   void SaveLayerToJSON(const std::string& Filename, FEXCore::Config::Layer *const Layer);
 
-  std::string LoadConfig(
+  std::pair<std::string, std::string> LoadConfig(
     bool NoFEXArguments,
     bool LoadProgramConfig,
     int argc,


### PR DESCRIPTION
While we were getting the application name for the application layer, we
were failing to store the filename for telemetry.

Save the filename we get for application layers and store it for the
telemetry file.

Otherwise these were just alway ending up as wine or wine-preloader.