### PR TITLE
FEXConfig: Some quality of life improvements

### DIFF
--- a/Source/Tools/CommonGUI/IMGui.h
+++ b/Source/Tools/CommonGUI/IMGui.h
@@ -87,10 +87,10 @@ namespace FEX::GUI {
 
   static std::chrono::time_point<std::chrono::high_resolution_clock> LastUpdate{};
   constexpr auto UpdateTimeout = std::chrono::seconds(2);
-  void DrawUI(SDL_Window *window, std::function<void()> DrawFunction) {
-    bool Done{};
+  void DrawUI(SDL_Window *window, std::function<bool()> DrawFunction) {
+    bool Running {true};
     ImGuiIO& io = ImGui::GetIO();
-    while (!Done) {
+    while (Running) {
       SDL_Event event;
       auto Now = std::chrono::high_resolution_clock::now();
       auto Dur = Now - LastUpdate;
@@ -100,16 +100,16 @@ namespace FEX::GUI {
         while (SDL_PollEvent(&event)) {
           ImGui_ImplSDL2_ProcessEvent(&event);
           if (event.type == SDL_QUIT)
-            Done = true;
+            Running = false;
           if (event.type == SDL_WINDOWEVENT && event.window.event == SDL_WINDOWEVENT_CLOSE && event.window.windowID == SDL_GetWindowID(window))
-            Done = true;
+            Running = false;
         }
       }
 
       // Start the Dear ImGui frame
       ImGui_ImplOpenGL3_NewFrame();
       ImGui_ImplSDL2_NewFrame(window);
-      DrawFunction();
+      Running &= DrawFunction();
 
       glClear(GL_COLOR_BUFFER_BIT);
       ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());

--- a/Source/Tools/FEXConfig/Main.cpp
+++ b/Source/Tools/FEXConfig/Main.cpp
@@ -744,7 +744,7 @@ namespace {
     ImGui::EndTabBar();
   }
 
-  void DrawUI() {
+  bool DrawUI() {
     ImGuiIO& io = ImGui::GetIO();
     auto current_time = std::chrono::high_resolution_clock::now();
     auto Diff = std::chrono::duration_cast<std::chrono::milliseconds>(current_time - GlobalTime);
@@ -777,6 +777,7 @@ namespace {
       bool SaveAs{};
       bool SaveDefault{};
       bool Close{};
+      bool Quit{};
     } Selected;
 
     char AppName[256]{};
@@ -793,6 +794,7 @@ namespace {
         ImGui::MenuItem("Save Default", "CTRL+SHIFT+P", &Selected.SaveDefault, true);
 
         ImGui::MenuItem("Close", "CTRL+W", &Selected.Close, true);
+        ImGui::MenuItem("Quit", "CTRL+Q", &Selected.Quit, true);
 
         ImGui::EndMenu();
       }
@@ -921,6 +923,11 @@ namespace {
       ShutdownINotify();
     }
 
+    if (Selected.Quit ||
+        (ImGui::IsKeyPressed(SDL_SCANCODE_Q) && io.KeyCtrl && !io.KeyShift)) {
+      Selected.Quit = true;
+    }
+
     ImGui::End(); // End dockspace
 
     char const *InitialPath;
@@ -942,6 +949,9 @@ namespace {
     SelectedSaveFileAs = false;
 
     ImGui::Render();
+
+    // Return true to keep rendering
+    return !Selected.Quit;
   }
 }
 

--- a/Source/Tools/FEXConfig/Main.cpp
+++ b/Source/Tools/FEXConfig/Main.cpp
@@ -968,6 +968,12 @@ int main(int argc, char **argv) {
       SetupINotify();
     }
   }
+  else {
+    if (OpenFile(FEXCore::Config::GetConfigFileLocation(), true)) {
+      LoadNamedRootFSFolder();
+      SetupINotify();
+    }
+  }
 
   FEX::GUI::DrawUI(window, DrawUI);
 

--- a/Source/Tools/FEXConfig/Main.cpp
+++ b/Source/Tools/FEXConfig/Main.cpp
@@ -785,7 +785,7 @@ namespace {
     if (ImGui::BeginMenuBar()) {
       if (ImGui::BeginMenu("File")) {
         ImGui::MenuItem("Open", "CTRL+O", &Selected.Open, true);
-        ImGui::MenuItem("Open Default", "CTRL+SHIFT+O", &Selected.OpenDefault, true);
+        ImGui::MenuItem("Open from default location", "CTRL+SHIFT+O", &Selected.OpenDefault, true);
         ImGui::MenuItem("Open App profile", "CTRL+I", &Selected.OpenAppProfile, true);
 
         ImGui::MenuItem("Save", "CTRL+S", &Selected.Save, true);


### PR DESCRIPTION
Removes the "Load Default Options" menu option. This option was
confusing for new users and isn't necessary anymore.

Fixes the "Load Default" option so it actually populates the full
configuration layer in the face of partial configuration.

This is a /very/ common use case for new users that ran through
FEXRootFSFetcher, where the only configuration set is the RootFS.
The configuration would be visually confusing since the visual
representation for missing options wouldn't reflect their default
configuration state. "TSO Enabled" is an example where it would appear
disabled in the GUI, but it is default enabled.

Also fixes the issue that the default configuration window would just be
a 320x240 floating window in the center of the screen. This is due to
the window being a floating sub window in the dockspace by default, and
not docked.

Instead just remove the dockspace, it isn't serving us any purpose.
This means the child configuration window now maximizes to the window
size which is the desired behaviour from default.

Additionally only save the config file once. While the msg dialog is
open (2 seconds while it is open, or escape to make it go away
immediately) the program won't save the file again. This fixes an issue
that if you used the shortcut key to save the file, it would save the
file at the refresh rate of your screen. Which is 144hz on my setup, so
it spams my filesystem quite heavily.