### PR TITLE
Linux: Fixes hang in close_range 

### DIFF
--- a/Source/Tests/LinuxSyscalls/FileManagement.cpp
+++ b/Source/Tests/LinuxSyscalls/FileManagement.cpp
@@ -438,10 +438,10 @@ uint64_t FileManager::CloseRange(unsigned int first, unsigned int last, unsigned
     // If the flag was set then it doesn't actually close the FDs
     // Just sets the flag on a range
     FHU::ScopedSignalMaskWithMutex lk(FDLock);
-    for (unsigned int i = first; i <= last; ++i) {
-      // We remove from first to last inclusive
-      FDToNameMap.erase(i);
-    }
+    auto Lower = FDToNameMap.lower_bound(first);
+    auto Upper = FDToNameMap.upper_bound(last);
+    // We remove from first to last inclusive
+    FDToNameMap.erase(Lower, Upper);
   }
   return ::syscall(SYSCALL_DEF(close_range), first, last, flags);
 }

--- a/Source/Tests/LinuxSyscalls/FileManagement.h
+++ b/Source/Tests/LinuxSyscalls/FileManagement.h
@@ -72,7 +72,7 @@ private:
   FEX::EmulatedFile::EmulatedFDManager EmuFD;
 
   std::mutex FDLock;
-  std::unordered_map<int32_t, std::string> FDToNameMap;
+  std::map<uint32_t, std::string> FDToNameMap;
   std::map<std::string, std::string, std::less<>> ThunkOverlays;
 
   FEX_CONFIG_OPT(Filename, APP_FILENAME);

--- a/unittests/FEXLinuxTests/tests/fd/test_close_range.cpp
+++ b/unittests/FEXLinuxTests/tests/fd/test_close_range.cpp
@@ -1,0 +1,17 @@
+#include <cstdint>
+#include <unistd.h>
+
+int main() {
+  int fd_base = dup(STDOUT_FILENO);
+  for (size_t i = 0; i < 15; ++i) {
+    dup(fd_base);
+  }
+
+  // Specifically testing last as ~0U to ensure FEX doesn't hang
+  constexpr uint32_t SYS_close_range = 436;
+  ::syscall(SYS_close_range, fd_base + 1, ~0U, 0);
+
+  // Ensure that fd_base itself wasn't closed in close_range
+  int Result = close(fd_base);
+  return Result;
+}


### PR DESCRIPTION
It's common for Linux applications that use close_range to pass in ~0 as
the last FD. This was causing FEX to spin from [2, ~0U] in this loop.
This would take /forever/ to run.

Change over to an ordered map and use the map's range searching and
ranged erase to more quickly remove these elements.

Fixes a hang that occurs with first time Steam setup in
steam-linux-runtime heavy application `steam-runtime-identify-library-abi`.

Thanks to @koss on Discord for discovering and reporting this issue.