### PR TITLE
JitSymbols: Only initialize perf map file if using

### DIFF
--- a/External/FEXCore/Source/Common/JitSymbols.cpp
+++ b/External/FEXCore/Source/Common/JitSymbols.cpp
@@ -7,6 +7,11 @@
 
 namespace FEXCore {
   JITSymbols::JITSymbols() : fp{nullptr, std::fclose} {
+  }
+
+  JITSymbols::~JITSymbols() = default;
+
+  void JITSymbols::InitFile() {
     const auto PerfMap = fmt::format("/tmp/perf-{}.map", getpid());
 
     fp.reset(fopen(PerfMap.c_str(), "wb"));
@@ -15,8 +20,6 @@ namespace FEXCore {
       setvbuf(fp.get(), nullptr, _IONBF, 0);
     }
   }
-
-  JITSymbols::~JITSymbols() = default;
 
   void JITSymbols::Register(const void *HostAddr, uint64_t GuestAddr, uint32_t CodeSize) {
     if (!fp) return;

--- a/External/FEXCore/Source/Common/JitSymbols.h
+++ b/External/FEXCore/Source/Common/JitSymbols.h
@@ -11,6 +11,7 @@ public:
   JITSymbols();
   ~JITSymbols();
 
+  void InitFile();
   void Register(const void *HostAddr, uint64_t GuestAddr, uint32_t CodeSize);
   void Register(const void *HostAddr, uint32_t CodeSize, std::string_view Name);
   void Register(const void *HostAddr, uint32_t CodeSize, std::string_view Name, uintptr_t Offset);

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -157,6 +157,13 @@ namespace FEXCore::Context {
     if (!Config.EnableAVX) {
       HostFeatures.SupportsAVX = false;
     }
+
+    if (Config.BlockJITNaming() ||
+        Config.GlobalJITNaming() ||
+        Config.LibraryJITNaming()) {
+      // Only initialize symbols file if enabled. Ensures we don't pollute /tmp with empty files.
+      Symbols.InitFile();
+    }
   }
 
   Context::~Context() {


### PR DESCRIPTION
In most cases we aren't using JIT symbols but still creating the perf
map file.

Early check if we should generate the file or not, this way we stop
polluting the /tmp folder.