### PR TITLE
Syscalls: Removes staging vector usage

### DIFF
--- a/Source/Tests/LinuxSyscalls/Syscalls.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls.cpp
@@ -58,16 +58,6 @@ namespace FEX::HLE {
 class SignalDelegator;
 SyscallHandler *_SyscallHandler{};
 
-void RegisterSyscallInternalNop(int SyscallNumber,
-  int32_t HostSyscallNumber,
-  FEXCore::IR::SyscallFlags Flags,
-#ifdef DEBUG_STRACE
-  const std::string& TraceFormatString,
-#endif
-  void* SyscallHandler, int ArgumentCount) {
-  // Do nothing
-}
-
 static bool IsSupportedByInterpreter(std::string const &Filename) {
   // If it is a supported ELF then we can
   if (ELFLoader::ELFContainer::IsSupportedELF(Filename.c_str())) {

--- a/Source/Tests/LinuxSyscalls/Syscalls/EPoll.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/EPoll.cpp
@@ -15,7 +15,7 @@ $end_info$
 #include <sys/epoll.h>
 
 namespace FEX::HLE {
-  void RegisterEpoll() {
+  void RegisterEpoll(FEX::HLE::SyscallHandler *Handler) {
     using namespace FEXCore::IR;
 
     REGISTER_SYSCALL_IMPL_PASS_FLAGS(epoll_create, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,

--- a/Source/Tests/LinuxSyscalls/Syscalls/FD.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/FD.cpp
@@ -28,7 +28,7 @@ $end_info$
 #include <sys/syscall.h>
 
 namespace FEX::HLE {
-  void RegisterFD(FEX::HLE::SyscallHandler *const Handler) {
+  void RegisterFD(FEX::HLE::SyscallHandler *Handler) {
     using namespace FEXCore::IR;
 
     REGISTER_SYSCALL_IMPL_PASS_FLAGS(read, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,

--- a/Source/Tests/LinuxSyscalls/Syscalls/FS.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/FS.cpp
@@ -21,7 +21,7 @@ $end_info$
 #include <sys/xattr.h>
 
 namespace FEX::HLE {
-  void RegisterFS(FEX::HLE::SyscallHandler *const Handler) {
+  void RegisterFS(FEX::HLE::SyscallHandler *Handler) {
     using namespace FEXCore::IR;
 
     REGISTER_SYSCALL_IMPL_PASS_FLAGS(getcwd, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,

--- a/Source/Tests/LinuxSyscalls/Syscalls/IO.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/IO.cpp
@@ -15,7 +15,7 @@ $end_info$
 #include <unistd.h>
 
 namespace FEX::HLE {
-  void RegisterIO() {
+  void RegisterIO(FEX::HLE::SyscallHandler *Handler) {
     using namespace FEXCore::IR;
 
     REGISTER_SYSCALL_IMPL_PASS_FLAGS(iopl, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,

--- a/Source/Tests/LinuxSyscalls/Syscalls/IOUring.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/IOUring.cpp
@@ -21,7 +21,7 @@ namespace SignalDelegator {
 
 
 namespace FEX::HLE {
-  void RegisterIOUring(FEX::HLE::SyscallHandler *const Handler) {
+  void RegisterIOUring(FEX::HLE::SyscallHandler *Handler) {
     using namespace FEXCore::IR;
 
     if (Handler->IsHostKernelVersionAtLeast(5, 1, 0)) {

--- a/Source/Tests/LinuxSyscalls/Syscalls/Info.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Info.cpp
@@ -31,7 +31,7 @@ namespace FEX::HLE {
   using cap_user_header_t = void*;
   using cap_user_data_t = void*;
 
-  void RegisterInfo() {
+  void RegisterInfo(FEX::HLE::SyscallHandler *Handler) {
     using namespace FEXCore::IR;
 
     REGISTER_SYSCALL_IMPL_FLAGS(uname, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,

--- a/Source/Tests/LinuxSyscalls/Syscalls/Key.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Key.cpp
@@ -16,7 +16,7 @@ $end_info$
 #include <unistd.h>
 
 namespace FEX::HLE {
-  void RegisterKey() {
+  void RegisterKey(FEX::HLE::SyscallHandler *Handler) {
     using namespace FEXCore::IR;
 
     REGISTER_SYSCALL_IMPL_PASS_FLAGS(add_key, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,

--- a/Source/Tests/LinuxSyscalls/Syscalls/Memory.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Memory.cpp
@@ -17,7 +17,7 @@ $end_info$
 #include <unistd.h>
 
 namespace FEX::HLE {
-  void RegisterMemory(FEX::HLE::SyscallHandler *const Handler) {
+  void RegisterMemory(FEX::HLE::SyscallHandler *Handler) {
     using namespace FEXCore::IR;
 
     REGISTER_SYSCALL_IMPL_FLAGS(brk, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,

--- a/Source/Tests/LinuxSyscalls/Syscalls/Msg.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Msg.cpp
@@ -16,7 +16,7 @@ $end_info$
 #include <unistd.h>
 
 namespace FEX::HLE {
-  void RegisterMsg() {
+  void RegisterMsg(FEX::HLE::SyscallHandler *Handler) {
     using namespace FEXCore::IR;
 
     REGISTER_SYSCALL_IMPL_PASS_FLAGS(msgget, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,

--- a/Source/Tests/LinuxSyscalls/Syscalls/Namespace.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Namespace.cpp
@@ -21,7 +21,7 @@ namespace SignalDelegator {
 
 
 namespace FEX::HLE {
-  void RegisterNamespace(FEX::HLE::SyscallHandler *const Handler) {
+  void RegisterNamespace(FEX::HLE::SyscallHandler *Handler) {
     using namespace FEXCore::IR;
 
     if (Handler->GetHostKernelVersion() >= FEX::HLE::SyscallHandler::KernelVersion(5, 1, 0)) {

--- a/Source/Tests/LinuxSyscalls/Syscalls/NotImplemented.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/NotImplemented.cpp
@@ -28,7 +28,7 @@ $end_info$
 namespace FEX::HLE {
   // these are removed/not implemented in the linux kernel we present
 
-  void RegisterNotImplemented() {
+  void RegisterNotImplemented(FEX::HLE::SyscallHandler *Handler) {
       REGISTER_SYSCALL_NOT_IMPL(uselib);
       REGISTER_SYSCALL_NOT_IMPL(create_module);
       REGISTER_SYSCALL_NOT_IMPL(get_kernel_syms);

--- a/Source/Tests/LinuxSyscalls/Syscalls/SHM.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/SHM.cpp
@@ -15,7 +15,7 @@ $end_info$
 #include <sys/shm.h>
 
 namespace FEX::HLE {
-  void RegisterSHM() {
+  void RegisterSHM(FEX::HLE::SyscallHandler *Handler) {
     using namespace FEXCore::IR;
 
     REGISTER_SYSCALL_IMPL_PASS_FLAGS(shmget, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,

--- a/Source/Tests/LinuxSyscalls/Syscalls/Sched.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Sched.cpp
@@ -20,7 +20,7 @@ $end_info$
 #include <unistd.h>
 
 namespace FEX::HLE {
-  void RegisterSched() {
+  void RegisterSched(FEX::HLE::SyscallHandler *Handler) {
     using namespace FEXCore::IR;
 
     REGISTER_SYSCALL_IMPL_PASS_FLAGS(sched_yield, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,

--- a/Source/Tests/LinuxSyscalls/Syscalls/Semaphore.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Semaphore.cpp
@@ -14,7 +14,7 @@ $end_info$
 #include <sys/types.h>
 
 namespace FEX::HLE {
-  void RegisterSemaphore() {
+  void RegisterSemaphore(FEX::HLE::SyscallHandler *Handler) {
     using namespace FEXCore::IR;
 
     REGISTER_SYSCALL_IMPL_PASS_FLAGS(semget, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,

--- a/Source/Tests/LinuxSyscalls/Syscalls/Signals.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Signals.cpp
@@ -22,7 +22,7 @@ namespace SignalDelegator {
 }
 
 namespace FEX::HLE {
-  void RegisterSignals(FEX::HLE::SyscallHandler *const Handler) {
+  void RegisterSignals(FEX::HLE::SyscallHandler *Handler) {
     REGISTER_SYSCALL_IMPL(rt_sigprocmask, [](FEXCore::Core::CpuStateFrame *Frame, int how, const uint64_t *set, uint64_t *oldset) -> uint64_t {
       return FEX::HLE::_SyscallHandler->GetSignalDelegator()->GuestSigProcMask(how, set, oldset);
     });

--- a/Source/Tests/LinuxSyscalls/Syscalls/Socket.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Socket.cpp
@@ -15,7 +15,7 @@ $end_info$
 #include <sys/socket.h>
 
 namespace FEX::HLE {
-  void RegisterSocket() {
+  void RegisterSocket(FEX::HLE::SyscallHandler *Handler) {
     using namespace FEXCore::IR;
 
     REGISTER_SYSCALL_IMPL_PASS_FLAGS(socket, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,

--- a/Source/Tests/LinuxSyscalls/Syscalls/Stubs.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Stubs.cpp
@@ -21,7 +21,7 @@ namespace FEXCore::Core {
 }
 
 namespace FEX::HLE {
-  void RegisterStubs() {
+  void RegisterStubs(FEX::HLE::SyscallHandler *Handler) {
 
     REGISTER_SYSCALL_IMPL(rt_sigreturn, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t {
       SYSCALL_STUB(rt_sigreturn);

--- a/Source/Tests/LinuxSyscalls/Syscalls/Thread.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Thread.cpp
@@ -260,7 +260,7 @@ namespace FEX::HLE {
     }
   }
 
-  void RegisterThread(FEX::HLE::SyscallHandler *const Handler) {
+  void RegisterThread(FEX::HLE::SyscallHandler *Handler) {
     using namespace FEXCore::IR;
 
     REGISTER_SYSCALL_IMPL_PASS_FLAGS(getpid, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,

--- a/Source/Tests/LinuxSyscalls/Syscalls/Time.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Time.cpp
@@ -13,7 +13,7 @@ $end_info$
 #include <unistd.h>
 
 namespace FEX::HLE {
-  void RegisterTime() {
+  void RegisterTime(FEX::HLE::SyscallHandler *Handler) {
     using namespace FEXCore::IR;
 
     REGISTER_SYSCALL_IMPL_PASS_FLAGS(pause, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,

--- a/Source/Tests/LinuxSyscalls/Syscalls/Timer.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Timer.cpp
@@ -20,7 +20,7 @@ $end_info$
 #include <unistd.h>
 
 namespace FEX::HLE {
-  void RegisterTimer() {
+  void RegisterTimer(FEX::HLE::SyscallHandler *Handler) {
     using namespace FEXCore::IR;
 
     REGISTER_SYSCALL_IMPL_PASS_FLAGS(alarm, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,

--- a/Source/Tests/LinuxSyscalls/x32/EPoll.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/EPoll.cpp
@@ -27,7 +27,7 @@ namespace FEXCore::Core {
 }
 
 namespace FEX::HLE::x32 {
-  void RegisterEpoll(FEX::HLE::SyscallHandler *const Handler) {
+  void RegisterEpoll(FEX::HLE::SyscallHandler *Handler) {
     REGISTER_SYSCALL_IMPL_X32(epoll_wait, [](FEXCore::Core::CpuStateFrame *Frame, int epfd, compat_ptr<FEX::HLE::x32::epoll_event32> events, int maxevents, int timeout) -> uint64_t {
       std::vector<struct epoll_event> Events(std::max(0, maxevents));
       uint64_t Result = ::syscall(SYSCALL_DEF(epoll_pwait), epfd, Events.data(), maxevents, timeout, nullptr, 8);

--- a/Source/Tests/LinuxSyscalls/x32/FD.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/FD.cpp
@@ -251,7 +251,7 @@ namespace FEX::HLE::x32 {
     SYSCALL_ERRNO();
   };
 
-  void RegisterFD() {
+  void RegisterFD(FEX::HLE::SyscallHandler *Handler) {
     REGISTER_SYSCALL_IMPL_X32_PASS(poll, [](FEXCore::Core::CpuStateFrame *Frame, struct pollfd *fds, nfds_t nfds, int timeout) -> uint64_t {
       uint64_t Result = ::poll(fds, nfds, timeout);
       SYSCALL_ERRNO();

--- a/Source/Tests/LinuxSyscalls/x32/FS.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/FS.cpp
@@ -14,7 +14,7 @@ $end_info$
 #include <unistd.h>
 
 namespace FEX::HLE::x32 {
-  void RegisterFS() {
+  void RegisterFS(FEX::HLE::SyscallHandler *Handler) {
     REGISTER_SYSCALL_IMPL_X32(umount, [](FEXCore::Core::CpuStateFrame *Frame, const char *target) -> uint64_t {
       uint64_t Result = ::umount(target);
       SYSCALL_ERRNO();

--- a/Source/Tests/LinuxSyscalls/x32/IO.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/IO.cpp
@@ -15,7 +15,7 @@ $end_info$
 #include <unistd.h>
 
 namespace FEX::HLE::x32 {
-  void RegisterIO() {
+  void RegisterIO(FEX::HLE::SyscallHandler *Handler) {
     REGISTER_SYSCALL_IMPL_X32(io_getevents, [](FEXCore::Core::CpuStateFrame *Frame, aio_context_t ctx_id, long min_nr, long nr, struct io_event *events, struct timespec32 *timeout) -> uint64_t {
       struct timespec* timeout_ptr{};
       struct timespec tp64{};

--- a/Source/Tests/LinuxSyscalls/x32/Info.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Info.cpp
@@ -45,7 +45,7 @@ namespace FEX::HLE::x32 {
 
   static_assert(sizeof(sysinfo32) == 64, "Needs to be 64bytes");
 
-  void RegisterInfo() {
+  void RegisterInfo(FEX::HLE::SyscallHandler *Handler) {
     REGISTER_SYSCALL_IMPL_X32(oldolduname, [](FEXCore::Core::CpuStateFrame *Frame, struct oldold_utsname *buf) -> uint64_t {
       struct utsname Local{};
 

--- a/Source/Tests/LinuxSyscalls/x32/Memory.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Memory.cpp
@@ -51,7 +51,7 @@ namespace FEX::HLE::x32 {
     }
   }
 
-  void RegisterMemory() {
+  void RegisterMemory(FEX::HLE::SyscallHandler *Handler) {
     struct old_mmap_struct {
       uint32_t addr;
       uint32_t len;

--- a/Source/Tests/LinuxSyscalls/x32/Msg.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Msg.cpp
@@ -19,7 +19,7 @@ ARG_TO_STR(FEX::HLE::x32::compat_ptr<FEX::HLE::x32::mq_attr32>, "%lx")
 ARG_TO_STR(FEX::HLE::x32::compat_ptr<FEX::HLE::x32::sigevent32>, "%lx")
 
 namespace FEX::HLE::x32 {
-  void RegisterMsg() {
+  void RegisterMsg(FEX::HLE::SyscallHandler *Handler) {
     REGISTER_SYSCALL_IMPL_X32(mq_timedsend, [](FEXCore::Core::CpuStateFrame *Frame, FEX::HLE::mqd_t mqdes, const char *msg_ptr, size_t msg_len, unsigned int msg_prio, const struct timespec32 *abs_timeout) -> uint64_t {
       struct timespec tp64{};
       struct timespec *timed_ptr{};

--- a/Source/Tests/LinuxSyscalls/x32/NotImplemented.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/NotImplemented.cpp
@@ -24,7 +24,7 @@ namespace FEX::HLE::x32 {
 });
 
   // these are removed/not implemented in the linux kernel we present
-  void RegisterNotImplemented() {
+  void RegisterNotImplemented(FEX::HLE::SyscallHandler *Handler) {
     REGISTER_SYSCALL_NOT_IMPL_X32(break);
     REGISTER_SYSCALL_NOT_IMPL_X32(stty);
     REGISTER_SYSCALL_NOT_IMPL_X32(gtty);

--- a/Source/Tests/LinuxSyscalls/x32/Sched.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Sched.cpp
@@ -19,7 +19,7 @@ namespace FEXCore::Core {
 }
 
 namespace FEX::HLE::x32 {
-  void RegisterSched() {
+  void RegisterSched(FEX::HLE::SyscallHandler *Handler) {
     REGISTER_SYSCALL_IMPL_X32(sched_rr_get_interval, [](FEXCore::Core::CpuStateFrame *Frame, pid_t pid, struct timespec32 *tp) -> uint64_t {
       struct timespec tp64{};
       uint64_t Result = ::sched_rr_get_interval(pid, tp ? &tp64 : nullptr);

--- a/Source/Tests/LinuxSyscalls/x32/Semaphore.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Semaphore.cpp
@@ -380,7 +380,7 @@ namespace FEX::HLE::x32 {
     }
     SYSCALL_ERRNO();
   }
-  void RegisterSemaphore() {
+  void RegisterSemaphore(FEX::HLE::SyscallHandler *Handler) {
     REGISTER_SYSCALL_IMPL_X32(ipc, _ipc);
 
     REGISTER_SYSCALL_IMPL_X32_PASS_MANUAL(semtimedop_time64, semtimedop, [](FEXCore::Core::CpuStateFrame *Frame, int semid, struct sembuf *sops, size_t nsops, const struct timespec *timeout) -> uint64_t {

--- a/Source/Tests/LinuxSyscalls/x32/Signals.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Signals.cpp
@@ -74,7 +74,7 @@ namespace FEX::HLE::x32 {
     }
   }
 
-  void RegisterSignals(FEX::HLE::SyscallHandler *const Handler) {
+  void RegisterSignals(FEX::HLE::SyscallHandler *Handler) {
 
     // Only gets the lower 32-bits of the signal mask
     REGISTER_SYSCALL_IMPL_X32(sgetmask, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t {

--- a/Source/Tests/LinuxSyscalls/x32/Socket.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Socket.cpp
@@ -588,7 +588,7 @@ namespace FEX::HLE::x32 {
     SYSCALL_ERRNO();
   }
 
-  void RegisterSocket() {
+  void RegisterSocket(FEX::HLE::SyscallHandler *Handler) {
     REGISTER_SYSCALL_IMPL_X32(socketcall, [](FEXCore::Core::CpuStateFrame *Frame, uint32_t call, uint32_t *Arguments) -> uint64_t {
       uint64_t Result{};
 

--- a/Source/Tests/LinuxSyscalls/x32/Stubs.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Stubs.cpp
@@ -20,7 +20,7 @@ namespace FEXCore::Core {
 }
 
 namespace FEX::HLE::x32 {
-  void RegisterStubs() {
+  void RegisterStubs(FEX::HLE::SyscallHandler *Handler) {
     REGISTER_SYSCALL_IMPL_X32(sigreturn, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t {
       SYSCALL_STUB(sigreturn);
     });

--- a/Source/Tests/LinuxSyscalls/x32/Thread.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Thread.cpp
@@ -75,7 +75,7 @@ namespace FEX::HLE::x32 {
     Frame->State.rip += 2;
   }
 
-  void RegisterThread() {
+  void RegisterThread(FEX::HLE::SyscallHandler *Handler) {
     REGISTER_SYSCALL_IMPL_X32(clone, ([](FEXCore::Core::CpuStateFrame *Frame, uint32_t flags, void *stack, pid_t *parent_tid, void *tls, pid_t *child_tid) -> uint64_t {
       FEX::HLE::clone3_args args {
         .Type = TypeOfClone::TYPE_CLONE2,

--- a/Source/Tests/LinuxSyscalls/x32/Time.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Time.cpp
@@ -28,7 +28,7 @@ namespace FEXCore::Core {
 }
 
 namespace FEX::HLE::x32 {
-  void RegisterTime() {
+  void RegisterTime(FEX::HLE::SyscallHandler *Handler) {
 
     REGISTER_SYSCALL_IMPL_X32(time, [](FEXCore::Core::CpuStateFrame *Frame, FEX::HLE::x32::old_time32_t *tloc) -> uint64_t {
       time_t Host{};

--- a/Source/Tests/LinuxSyscalls/x32/Timer.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Timer.cpp
@@ -23,7 +23,7 @@ namespace FEXCore::Core {
 ARG_TO_STR(FEX::HLE::x32::compat_ptr<FEX::HLE::x32::sigevent32>, "%lx")
 
 namespace FEX::HLE::x32 {
-  void RegisterTimer() {
+  void RegisterTimer(FEX::HLE::SyscallHandler *Handler) {
     REGISTER_SYSCALL_IMPL_X32(timer_settime, [](FEXCore::Core::CpuStateFrame *Frame,
       kernel_timer_t timerid,
       int flags,

--- a/Source/Tests/LinuxSyscalls/x64/EPoll.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/EPoll.cpp
@@ -24,7 +24,7 @@ namespace FEXCore::Core {
 }
 
 namespace FEX::HLE::x64 {
-  void RegisterEpoll(FEX::HLE::SyscallHandler *const Handler) {
+  void RegisterEpoll(FEX::HLE::SyscallHandler *Handler) {
     REGISTER_SYSCALL_IMPL_X64(epoll_wait, [](FEXCore::Core::CpuStateFrame *Frame, int epfd, FEX::HLE::epoll_event_x86 *events, int maxevents, int timeout) -> uint64_t {
       std::vector<struct epoll_event> Events(std::max(0, maxevents));
       uint64_t Result = ::syscall(SYSCALL_DEF(epoll_pwait), epfd, Events.data(), maxevents, timeout, nullptr, 8);

--- a/Source/Tests/LinuxSyscalls/x64/FD.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/FD.cpp
@@ -26,7 +26,7 @@ $end_info$
 #include <unistd.h>
 
 namespace FEX::HLE::x64 {
-  void RegisterFD() {
+  void RegisterFD(FEX::HLE::SyscallHandler *Handler) {
     REGISTER_SYSCALL_IMPL_X64_PASS(poll, [](FEXCore::Core::CpuStateFrame *Frame, struct pollfd *fds, nfds_t nfds, int timeout) -> uint64_t {
       uint64_t Result = ::poll(fds, nfds, timeout);
       SYSCALL_ERRNO();

--- a/Source/Tests/LinuxSyscalls/x64/IO.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/IO.cpp
@@ -17,7 +17,7 @@ namespace FEXCore::Core {
 }
 
 namespace FEX::HLE::x64 {
-  void RegisterIO() {
+  void RegisterIO(FEX::HLE::SyscallHandler *Handler) {
     REGISTER_SYSCALL_IMPL_X64_PASS(io_getevents, [](FEXCore::Core::CpuStateFrame *Frame, aio_context_t ctx_id, long min_nr, long nr, struct io_event *events, struct timespec *timeout) -> uint64_t {
       uint64_t Result = ::syscall(SYSCALL_DEF(io_getevents), ctx_id, min_nr, nr, events, timeout);
       SYSCALL_ERRNO();

--- a/Source/Tests/LinuxSyscalls/x64/Info.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Info.cpp
@@ -14,7 +14,7 @@ $end_info$
 #include <sys/sysinfo.h>
 
 namespace FEX::HLE::x64 {
-  void RegisterInfo() {
+  void RegisterInfo(FEX::HLE::SyscallHandler *Handler) {
     REGISTER_SYSCALL_IMPL_X64_PASS(sysinfo, [](FEXCore::Core::CpuStateFrame *Frame, struct sysinfo *info) -> uint64_t {
       uint64_t Result = ::sysinfo(info);
       SYSCALL_ERRNO();

--- a/Source/Tests/LinuxSyscalls/x64/Ioctl.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Ioctl.cpp
@@ -15,7 +15,7 @@ namespace FEXCore::Core {
 }
 
 namespace FEX::HLE::x64 {
-  void RegisterIoctl() {
+  void RegisterIoctl(FEX::HLE::SyscallHandler *Handler) {
     REGISTER_SYSCALL_IMPL_X64_PASS(ioctl, [](FEXCore::Core::CpuStateFrame *Frame, int fd, uint64_t request, void *args) -> uint64_t {
       uint64_t Result = ::ioctl(fd, request, args);
       SYSCALL_ERRNO();

--- a/Source/Tests/LinuxSyscalls/x64/Memory.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Memory.cpp
@@ -66,7 +66,7 @@ namespace FEX::HLE::x64 {
     return Result;
   }
 
-  void RegisterMemory(FEX::HLE::SyscallHandler *const Handler) {
+  void RegisterMemory(FEX::HLE::SyscallHandler *Handler) {
     using namespace FEXCore::IR;
 
     REGISTER_SYSCALL_IMPL_X64_FLAGS(mmap, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,

--- a/Source/Tests/LinuxSyscalls/x64/Msg.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Msg.cpp
@@ -18,7 +18,7 @@ namespace FEXCore::Core {
 }
 
 namespace FEX::HLE::x64 {
-  void RegisterMsg() {
+  void RegisterMsg(FEX::HLE::SyscallHandler *Handler) {
     REGISTER_SYSCALL_IMPL_X64_PASS(mq_timedsend, [](FEXCore::Core::CpuStateFrame *Frame, FEX::HLE::mqd_t mqdes, const char *msg_ptr, size_t msg_len, unsigned int msg_prio, const struct timespec *abs_timeout) -> uint64_t {
       uint64_t Result = ::syscall(SYSCALL_DEF(mq_timedsend), mqdes, msg_ptr, msg_len, msg_prio, abs_timeout);
       SYSCALL_ERRNO();

--- a/Source/Tests/LinuxSyscalls/x64/NotImplemented.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/NotImplemented.cpp
@@ -25,7 +25,7 @@ namespace FEX::HLE::x64 {
 });
 
   // these are removed/not implemented in the linux kernel we present
-  void RegisterNotImplemented() {
+  void RegisterNotImplemented(FEX::HLE::SyscallHandler *Handler) {
     REGISTER_SYSCALL_NOT_IMPL_X64(tuxcall);
     REGISTER_SYSCALL_NOT_IMPL_X64(security);
     REGISTER_SYSCALL_NOT_IMPL_X64(set_thread_area);

--- a/Source/Tests/LinuxSyscalls/x64/Sched.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Sched.cpp
@@ -16,7 +16,7 @@ namespace FEXCore::Core {
 }
 
 namespace FEX::HLE::x64 {
-  void RegisterSched() {
+  void RegisterSched(FEX::HLE::SyscallHandler *Handler) {
     REGISTER_SYSCALL_IMPL_X64_PASS(sched_rr_get_interval, [](FEXCore::Core::CpuStateFrame *Frame, pid_t pid, struct timespec *tp) -> uint64_t {
       uint64_t Result = ::sched_rr_get_interval(pid, tp);
       SYSCALL_ERRNO();

--- a/Source/Tests/LinuxSyscalls/x64/Semaphore.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Semaphore.cpp
@@ -21,7 +21,7 @@ namespace FEXCore::Core {
 ARG_TO_STR(FEX::HLE::x64::semun, "%lx")
 
 namespace FEX::HLE::x64 {
-  void RegisterSemaphore() {
+  void RegisterSemaphore(FEX::HLE::SyscallHandler *Handler) {
    REGISTER_SYSCALL_IMPL_X64_PASS(semop, [](FEXCore::Core::CpuStateFrame *Frame, int semid, struct sembuf *sops, size_t nsops) -> uint64_t {
       uint64_t Result = ::syscall(SYSCALL_DEF(semop), semid, sops, nsops);
       SYSCALL_ERRNO();

--- a/Source/Tests/LinuxSyscalls/x64/Signals.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Signals.cpp
@@ -18,7 +18,7 @@ $end_info$
 #include <unistd.h>
 
 namespace FEX::HLE::x64 {
-  void RegisterSignals(FEX::HLE::SyscallHandler *const Handler) {
+  void RegisterSignals(FEX::HLE::SyscallHandler *Handler) {
     REGISTER_SYSCALL_IMPL_X64(rt_sigaction, [](FEXCore::Core::CpuStateFrame *Frame, int signum, const FEXCore::GuestSigAction *act, FEXCore::GuestSigAction *oldact, size_t sigsetsize) -> uint64_t {
       if (sigsetsize != 8) {
         return -EINVAL;

--- a/Source/Tests/LinuxSyscalls/x64/Socket.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Socket.cpp
@@ -15,7 +15,7 @@ namespace FEXCore::Core {
 }
 
 namespace FEX::HLE::x64 {
-  void RegisterSocket() {
+  void RegisterSocket(FEX::HLE::SyscallHandler *Handler) {
     REGISTER_SYSCALL_IMPL_X64_PASS(accept, [](FEXCore::Core::CpuStateFrame *Frame, int sockfd, struct sockaddr *addr, socklen_t *addrlen) -> uint64_t {
       uint64_t Result = ::accept(sockfd, addr, addrlen);
       SYSCALL_ERRNO();

--- a/Source/Tests/LinuxSyscalls/x64/Syscalls.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Syscalls.cpp
@@ -13,74 +13,24 @@ $end_info$
 #include <map>
 
 namespace FEX::HLE::x64 {
-  RegisterSyscallInternalType SyscallRegisterHandler = FEX::HLE::RegisterSyscallInternalNop;
-
-  void RegisterEpoll(FEX::HLE::SyscallHandler *const Handler);
-  void RegisterFD();
-  void RegisterInfo();
-  void RegisterIO();
-  void RegisterIoctl();
-  void RegisterMemory(FEX::HLE::SyscallHandler *const Handler);
-  void RegisterMsg();
-  void RegisterSched();
-  void RegisterSocket();
-  void RegisterSemaphore();
-  void RegisterSignals(FEX::HLE::SyscallHandler *const Handler);
-  void RegisterThread();
-  void RegisterTime();
-  void RegisterNotImplemented();
-
-#if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
-  [[nodiscard]] static const char* GetSyscallName(int SyscallNumber) {
-    static const std::map<int, const char*> SyscallNames = {
-      #include "SyscallsNames.inl"
-    };
-
-    const auto EntryIter = SyscallNames.find(SyscallNumber);
-    if (EntryIter == SyscallNames.cend()) {
-      return "[unknown syscall]";
-    }
-
-    return EntryIter->second;
-  }
-#endif
-
-  struct InternalSyscallDefinition {
-    int SyscallNumber;
-    void* SyscallHandler;
-    int ArgumentCount;
-    int32_t HostSyscallNumber;
-    FEXCore::IR::SyscallFlags Flags;
-#ifdef DEBUG_STRACE
-    std::string TraceFormatString;
-#endif
-  };
-
-  std::vector<InternalSyscallDefinition> syscalls_x64;
-
-  void RegisterSyscallInternal(int SyscallNumber,
-    int32_t HostSyscallNumber,
-    FEXCore::IR::SyscallFlags Flags,
-#ifdef DEBUG_STRACE
-    const std::string& TraceFormatString,
-#endif
-    void* SyscallHandler, int ArgumentCount) {
-    syscalls_x64.push_back({SyscallNumber,
-      SyscallHandler,
-      ArgumentCount,
-      HostSyscallNumber,
-      Flags,
-#ifdef DEBUG_STRACE
-      TraceFormatString
-#endif
-      });
-  }
-
+  void RegisterEpoll(FEX::HLE::SyscallHandler *Handler);
+  void RegisterFD(FEX::HLE::SyscallHandler *Handler);
+  void RegisterInfo(FEX::HLE::SyscallHandler *Handler);
+  void RegisterIO(FEX::HLE::SyscallHandler *Handler);
+  void RegisterIoctl(FEX::HLE::SyscallHandler *Handler);
+  void RegisterMemory(FEX::HLE::SyscallHandler *Handler);
+  void RegisterMsg(FEX::HLE::SyscallHandler *Handler);
+  void RegisterSched(FEX::HLE::SyscallHandler *Handler);
+  void RegisterSocket(FEX::HLE::SyscallHandler *Handler);
+  void RegisterSemaphore(FEX::HLE::SyscallHandler *Handler);
+  void RegisterSignals(FEX::HLE::SyscallHandler *Handler);
+  void RegisterThread(FEX::HLE::SyscallHandler *Handler);
+  void RegisterTime(FEX::HLE::SyscallHandler *Handler);
+  void RegisterNotImplemented(FEX::HLE::SyscallHandler *Handler);
 
   x64SyscallHandler::x64SyscallHandler(FEXCore::Context::Context *ctx, FEX::HLE::SignalDelegator *_SignalDelegation)
     : SyscallHandler {ctx, _SignalDelegation} {
     OSABI = FEXCore::HLE::SyscallOSABI::OS_LINUX64;
-    FEX::HLE::x64::SyscallRegisterHandler = FEX::HLE::x64::RegisterSyscallInternal;
 
     RegisterSyscallHandlers();
   }
@@ -102,62 +52,42 @@ namespace FEX::HLE::x64 {
       Def.Ptr = cvt(&UnimplementedSyscall);
     }
 
-    FEX::HLE::RegisterEpoll();
+    FEX::HLE::RegisterEpoll(this);
     FEX::HLE::RegisterFD(this);
     FEX::HLE::RegisterFS(this);
-    FEX::HLE::RegisterInfo();
-    FEX::HLE::RegisterIO();
+    FEX::HLE::RegisterInfo(this);
+    FEX::HLE::RegisterIO(this);
     FEX::HLE::RegisterIOUring(this);
-    FEX::HLE::RegisterKey();
+    FEX::HLE::RegisterKey(this);
     FEX::HLE::RegisterMemory(this);
-    FEX::HLE::RegisterMsg();
+    FEX::HLE::RegisterMsg(this);
     FEX::HLE::RegisterNamespace(this);
-    FEX::HLE::RegisterSched();
-    FEX::HLE::RegisterSemaphore();
-    FEX::HLE::RegisterSHM();
+    FEX::HLE::RegisterSched(this);
+    FEX::HLE::RegisterSemaphore(this);
+    FEX::HLE::RegisterSHM(this);
     FEX::HLE::RegisterSignals(this);
-    FEX::HLE::RegisterSocket();
+    FEX::HLE::RegisterSocket(this);
     FEX::HLE::RegisterThread(this);
-    FEX::HLE::RegisterTime();
-    FEX::HLE::RegisterTimer();
-    FEX::HLE::RegisterNotImplemented();
-    FEX::HLE::RegisterStubs();
+    FEX::HLE::RegisterTime(this);
+    FEX::HLE::RegisterTimer(this);
+    FEX::HLE::RegisterNotImplemented(this);
+    FEX::HLE::RegisterStubs(this);
 
     // 64bit specific
     FEX::HLE::x64::RegisterEpoll(this);
-    FEX::HLE::x64::RegisterFD();
-    FEX::HLE::x64::RegisterInfo();
-    FEX::HLE::x64::RegisterIO();
-    FEX::HLE::x64::RegisterIoctl();
+    FEX::HLE::x64::RegisterFD(this);
+    FEX::HLE::x64::RegisterInfo(this);
+    FEX::HLE::x64::RegisterIO(this);
+    FEX::HLE::x64::RegisterIoctl(this);
     FEX::HLE::x64::RegisterMemory(this);
-    FEX::HLE::x64::RegisterMsg();
-    FEX::HLE::x64::RegisterSched();
-    FEX::HLE::x64::RegisterSocket();
-    FEX::HLE::x64::RegisterSemaphore();
+    FEX::HLE::x64::RegisterMsg(this);
+    FEX::HLE::x64::RegisterSched(this);
+    FEX::HLE::x64::RegisterSocket(this);
+    FEX::HLE::x64::RegisterSemaphore(this);
     FEX::HLE::x64::RegisterSignals(this);
-    FEX::HLE::x64::RegisterThread();
-    FEX::HLE::x64::RegisterTime();
-    FEX::HLE::x64::RegisterNotImplemented();
-
-    // Set all the new definitions
-    for (auto &Syscall : syscalls_x64) {
-      auto SyscallNumber = Syscall.SyscallNumber;
-      auto &Def = Definitions.at(SyscallNumber);
-#if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
-      auto Name = GetSyscallName(SyscallNumber);
-      LOGMAN_THROW_A_FMT(Def.Ptr == cvt(&UnimplementedSyscall), "Oops overwriting sysall problem, {}, {}", SyscallNumber, Name);
-#endif
-      Def.Ptr = Syscall.SyscallHandler;
-      Def.NumArgs = Syscall.ArgumentCount;
-      Def.Flags = Syscall.Flags;
-      Def.HostSyscallNumber = Syscall.HostSyscallNumber;
-#ifdef DEBUG_STRACE
-      Def.StraceFmt = Syscall.TraceFormatString;
-#endif
-    }
-
-    // Clear the registration vector
-    syscalls_x64 = {};
+    FEX::HLE::x64::RegisterThread(this);
+    FEX::HLE::x64::RegisterTime(this);
+    FEX::HLE::x64::RegisterNotImplemented(this);
 
     // x86-64 has a gap of syscalls in the range of [335, 424) where there aren't any
     // These are defined that these must return -ENOSYS

--- a/Source/Tests/LinuxSyscalls/x64/Syscalls.h
+++ b/Source/Tests/LinuxSyscalls/x64/Syscalls.h
@@ -37,20 +37,40 @@ class x64SyscallHandler final : public FEX::HLE::SyscallHandler {
     void *GuestMmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset) override;
     int GuestMunmap(void *addr, uint64_t length) override;
 
+
+  void RegisterSyscall_64(int SyscallNumber,
+    int32_t HostSyscallNumber,
+    FEXCore::IR::SyscallFlags Flags,
+#ifdef DEBUG_STRACE
+    const std::string& TraceFormatString,
+#endif
+    void* SyscallHandler, int ArgumentCount) override {
+    auto &Def = Definitions.at(SyscallNumber);
+#if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
+    auto cvt = [](auto in) {
+      union {
+        decltype(in) val;
+        void *raw;
+      } raw;
+      raw.val = in;
+      return raw.raw;
+    };
+    LOGMAN_THROW_A_FMT(Def.Ptr == cvt(&UnimplementedSyscall), "Oops overwriting sysall problem, {}", SyscallNumber);
+#endif
+    Def.Ptr = SyscallHandler;
+    Def.NumArgs = ArgumentCount;
+    Def.Flags = Flags;
+    Def.HostSyscallNumber = HostSyscallNumber;
+#ifdef DEBUG_STRACE
+    Def.StraceFmt = TraceFormatString;
+#endif
+  }
+
   private:
     void RegisterSyscallHandlers();
 };
 
 std::unique_ptr<FEX::HLE::SyscallHandler> CreateHandler(FEXCore::Context::Context *ctx, FEX::HLE::SignalDelegator *_SignalDelegation);
-
-extern RegisterSyscallInternalType SyscallRegisterHandler;
-void RegisterSyscallInternal(int SyscallNumber,
-  int32_t HostSyscallNumber,
-  FEXCore::IR::SyscallFlags Flags,
-#ifdef DEBUG_STRACE
-  const std::string& TraceFormatString,
-#endif
-  void* SyscallHandler, int ArgumentCount);
 
 //////
 // REGISTER_SYSCALL_IMPL implementation
@@ -62,11 +82,11 @@ void RegisterSyscallInternal(int SyscallNumber,
 // Deduces return, args... from the function passed
 // Does not work with lambas, because they are objects with operator (), not functions
 template<typename R, typename ...Args>
-void RegisterSyscall(int SyscallNumber, int32_t HostSyscallNumber, FEXCore::IR::SyscallFlags Flags, const char *Name, R(*fn)(FEXCore::Core::CpuStateFrame *Frame, Args...)) {
+void RegisterSyscall(SyscallHandler *Handler, int SyscallNumber, int32_t HostSyscallNumber, FEXCore::IR::SyscallFlags Flags, const char *Name, R(*fn)(FEXCore::Core::CpuStateFrame *Frame, Args...)) {
 #ifdef DEBUG_STRACE
   auto TraceFormatString = std::string(Name) + "(" + CollectArgsFmtString<Args...>() + ") = %ld";
 #endif
-  FEX::HLE::x64::SyscallRegisterHandler(SyscallNumber,
+  Handler->RegisterSyscall_64(SyscallNumber,
     HostSyscallNumber,
     Flags,
 #ifdef DEBUG_STRACE
@@ -89,9 +109,9 @@ struct LambdaTraits<T (C::*)(Args...) const>
 // Non-capturing lambdas can be cast to function pointers, but this does not happen on argument matching
 // This is some glue logic that will cast a lambda and call the base RegisterSyscall implementation
 template<class F>
-void RegisterSyscall(int num, int32_t HostSyscallNumber, FEXCore::IR::SyscallFlags Flags, const char *name, F f){
+void RegisterSyscall(SyscallHandler *_Handler, int num, int32_t HostSyscallNumber, FEXCore::IR::SyscallFlags Flags, const char *name, F f){
   typedef typename LambdaTraits<decltype(&F::operator())>::Type Signature;
-  RegisterSyscall(num, HostSyscallNumber, Flags, name, (Signature)f);
+  RegisterSyscall(_Handler, num, HostSyscallNumber, Flags, name, (Signature)f);
 }
 
 }
@@ -99,28 +119,28 @@ void RegisterSyscall(int num, int32_t HostSyscallNumber, FEXCore::IR::SyscallFla
 // Registers syscall for 64bit only
 #define REGISTER_SYSCALL_IMPL_X64(name, lambda) \
   struct impl_##name { \
-    impl_##name() \
+    impl_##name(FEX::HLE::SyscallHandler *Handler) \
     { \
-      FEX::HLE::x64::RegisterSyscall(x64::SYSCALL_x64_##name, ~0, FEXCore::IR::SyscallFlags::DEFAULT, #name, lambda); \
-    } } impl_##name
+      FEX::HLE::x64::RegisterSyscall(Handler, x64::SYSCALL_x64_##name, ~0, FEXCore::IR::SyscallFlags::DEFAULT, #name, lambda); \
+    } } impl_##name(Handler)
 
 #define REGISTER_SYSCALL_IMPL_X64_PASS(name, lambda) \
   struct impl_##name { \
-    impl_##name() \
+    impl_##name(FEX::HLE::SyscallHandler *Handler) \
     { \
-      FEX::HLE::x64::RegisterSyscall(x64::SYSCALL_x64_##name, SYSCALL_DEF(name), FEXCore::IR::SyscallFlags::DEFAULT, #name, lambda); \
-    } } impl_##name
+      FEX::HLE::x64::RegisterSyscall(Handler, x64::SYSCALL_x64_##name, SYSCALL_DEF(name), FEXCore::IR::SyscallFlags::DEFAULT, #name, lambda); \
+    } } impl_##name(Handler)
 
 #define REGISTER_SYSCALL_IMPL_X64_FLAGS(name, flags, lambda) \
   struct impl_##name { \
-    impl_##name() \
+    impl_##name(FEX::HLE::SyscallHandler *Handler) \
     { \
-      FEX::HLE::x64::RegisterSyscall(x64::SYSCALL_x64_##name, ~0, flags, #name, lambda); \
-    } } impl_##name
+      FEX::HLE::x64::RegisterSyscall(Handler, x64::SYSCALL_x64_##name, ~0, flags, #name, lambda); \
+    } } impl_##name(Handler)
 
 #define REGISTER_SYSCALL_IMPL_X64_PASS_FLAGS(name, flags, lambda) \
   struct impl_##name { \
-    impl_##name() \
+    impl_##name(FEX::HLE::SyscallHandler *Handler) \
     { \
-      FEX::HLE::x64::RegisterSyscall(x64::SYSCALL_x64_##name, SYSCALL_DEF(name), flags, #name, lambda); \
-    } } impl_##name
+      FEX::HLE::x64::RegisterSyscall(Handler, x64::SYSCALL_x64_##name, SYSCALL_DEF(name), flags, #name, lambda); \
+    } } impl_##name(Handler)

--- a/Source/Tests/LinuxSyscalls/x64/Thread.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Thread.cpp
@@ -32,7 +32,7 @@ namespace FEX::HLE::x64 {
     Frame->State.rip += 2;
   }
 
-  void RegisterThread() {
+  void RegisterThread(FEX::HLE::SyscallHandler *Handler) {
     using namespace FEXCore::IR;
 
     REGISTER_SYSCALL_IMPL_X64_FLAGS(clone, SyscallFlags::DEFAULT,

--- a/Source/Tests/LinuxSyscalls/x64/Time.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Time.cpp
@@ -19,7 +19,7 @@ $end_info$
 #include <utime.h>
 
 namespace FEX::HLE::x64 {
-  void RegisterTime() {
+  void RegisterTime(FEX::HLE::SyscallHandler *Handler) {
     REGISTER_SYSCALL_IMPL_X64_PASS(time, [](FEXCore::Core::CpuStateFrame *Frame, time_t *tloc) -> uint64_t {
       uint64_t Result = ::time(tloc);
       SYSCALL_ERRNO();


### PR DESCRIPTION
This removes about half a millisecond from syscall handler registration. But it is a bit noisy so hard to get exact numbers.