### PR TITLE
Cleanup syscalls headers

### DIFF
--- a/Source/Tests/LinuxSyscalls/Syscalls.h
+++ b/Source/Tests/LinuxSyscalls/Syscalls.h
@@ -393,30 +393,6 @@ std::string CollectArgsFmtString() {
 #define ARG_TO_STR(tpy, str)
 #endif
 
-// Helper that allows us to create a variadic template lambda from a given signature
-// by creating a function that expects a fuction pointer with the given signature as a parameter
-template <typename T>
-struct FunctionToLambda;
-
-template<typename R, typename... Args>
-struct FunctionToLambda<R(*)(Args...)> {
-	using RType = R;
-
-	static R(*ReturnFunctionPointer(R(*fn)(FEXCore::Core::CpuStateFrame *Frame, Args...)))(FEXCore::Core::CpuStateFrame *Frame, Args...) {
-		return fn;
-	}
-};
-
-// copy to match noexcept functions
-template<typename R, typename... Args>
-struct FunctionToLambda<R(*)(Args...) noexcept> {
-	using RType = R;
-
-	static R(*ReturnFunctionPointer(R(*fn)(FEXCore::Core::CpuStateFrame *Frame, Args...)))(FEXCore::Core::CpuStateFrame *Frame, Args...) {
-		return fn;
-	}
-};
-
 struct open_how {
   uint64_t flags;
   uint64_t mode;

--- a/Source/Tests/LinuxSyscalls/Syscalls.h
+++ b/Source/Tests/LinuxSyscalls/Syscalls.h
@@ -363,11 +363,9 @@ extern FEX::HLE::SyscallHandler *_SyscallHandler;
 //////
 
 template<typename T>
-struct ArgToFmtString {
-  // fail on unknown types
-};
+struct ArgToFmtString;
 
-#define ARG_TO_STR(tpy, str) template<> struct FEX::HLE::ArgToFmtString<tpy> { inline static const std::string Format = str; };
+#define ARG_TO_STR(tpy, str) template<> struct FEX::HLE::ArgToFmtString<tpy> { inline static const char* const Format = str; };
 
 // Base types
 ARG_TO_STR(int, "%d")
@@ -382,24 +380,14 @@ ARG_TO_STR(const char*, "%s")
 // Pointers
 template<typename T>
 struct ArgToFmtString<T*> {
-  inline static const std::string Format = "%p";
+  inline static const char* const Format = "%p";
 };
 
 // Use ArgToFmtString and variadic template to create a format string from an args list
 template<typename ...Args>
 std::string CollectArgsFmtString() {
-  std::string array[] = { ArgToFmtString<Args>::Format... };
-
-  std::string rv{};
-  bool first = true;
-
-  for (auto &str: array) {
-    if (!first) rv += ", ";
-    first = false;
-    rv += str;
-  }
-
-  return rv;
+  std::array<const char*, sizeof...(Args)> array = { ArgToFmtString<Args>::Format... };
+  return fmt::format("{}", fmt::join(array, ", "));
 }
 #else
 #define ARG_TO_STR(tpy, str)

--- a/Source/Tests/LinuxSyscalls/Syscalls.h
+++ b/Source/Tests/LinuxSyscalls/Syscalls.h
@@ -537,34 +537,19 @@ static bool HasSyscallError(const void* Result) {
 
 // Registers syscall for both 32bit and 64bit
 #define REGISTER_SYSCALL_IMPL(name, lambda) \
-  struct impl_##name { \
-    impl_##name(FEX::HLE::SyscallHandler *Handler) \
-    { \
-      FEX::HLE::x64::RegisterSyscall(Handler, FEX::HLE::x64::SYSCALL_x64_##name, ~0, FEXCore::IR::SyscallFlags::DEFAULT, #name, lambda); \
-      FEX::HLE::x32::RegisterSyscall(Handler, FEX::HLE::x32::SYSCALL_x86_##name, ~0, FEXCore::IR::SyscallFlags::DEFAULT, #name, lambda); \
-    } } impl_##name(Handler)
+  REGISTER_SYSCALL_IMPL_INTERNAL(name, ~0, FEXCore::IR::SyscallFlags::DEFAULT, lambda)
 
-// Registers syscall for both 32bit and 64bit
 #define REGISTER_SYSCALL_IMPL_PASS(name, lambda) \
-  struct impl_##name { \
-    impl_##name(FEX::HLE::SyscallHandler *Handler) \
-    { \
-      FEX::HLE::x64::RegisterSyscall(Handler, FEX::HLE::x64::SYSCALL_x64_##name, SYSCALL_DEF(name), FEXCore::IR::SyscallFlags::DEFAULT, #name, lambda); \
-      FEX::HLE::x32::RegisterSyscall(Handler, FEX::HLE::x32::SYSCALL_x86_##name, SYSCALL_DEF(name), FEXCore::IR::SyscallFlags::DEFAULT, #name, lambda); \
-    } } impl_##name(Handler)
+  REGISTER_SYSCALL_IMPL_INTERNAL(name, SYSCALL_DEF(name), FEXCore::IR::SyscallFlags::DEFAULT, lambda)
 
 #define REGISTER_SYSCALL_IMPL_FLAGS(name, flags, lambda) \
-  struct impl_##name { \
-    impl_##name(FEX::HLE::SyscallHandler *Handler) \
-    { \
-      FEX::HLE::x64::RegisterSyscall(Handler, FEX::HLE::x64::SYSCALL_x64_##name, ~0, flags, #name, lambda); \
-      FEX::HLE::x32::RegisterSyscall(Handler, FEX::HLE::x32::SYSCALL_x86_##name, ~0, flags, #name, lambda); \
-    } } impl_##name(Handler)
+  REGISTER_SYSCALL_IMPL_INTERNAL(name, ~0, flags, lambda)
 
 #define REGISTER_SYSCALL_IMPL_PASS_FLAGS(name, flags, lambda) \
-  struct impl_##name { \
-    impl_##name(FEX::HLE::SyscallHandler *Handler) \
-    { \
-      FEX::HLE::x64::RegisterSyscall(Handler, FEX::HLE::x64::SYSCALL_x64_##name, SYSCALL_DEF(name), flags, #name, lambda); \
-      FEX::HLE::x32::RegisterSyscall(Handler, FEX::HLE::x32::SYSCALL_x86_##name, SYSCALL_DEF(name), flags, #name, lambda); \
-    } } impl_##name(Handler)
+  REGISTER_SYSCALL_IMPL_INTERNAL(name, SYSCALL_DEF(name), flags, lambda)
+
+#define REGISTER_SYSCALL_IMPL_INTERNAL(name, number, flags, lambda) \
+  do { \
+    FEX::HLE::x64::RegisterSyscall(Handler, FEX::HLE::x64::SYSCALL_x64_##name, (number), (flags), #name, (lambda)); \
+    FEX::HLE::x32::RegisterSyscall(Handler, FEX::HLE::x32::SYSCALL_x86_##name, (number), (flags), #name, (lambda)); \
+  } while (false)

--- a/Source/Tests/LinuxSyscalls/x32/Syscalls.h
+++ b/Source/Tests/LinuxSyscalls/x32/Syscalls.h
@@ -96,23 +96,12 @@ void RegisterSyscall(SyscallHandler *Handler, int SyscallNumber, int32_t HostSys
     reinterpret_cast<void*>(fn), sizeof...(Args));
 }
 
-//LambdaTraits extracts the function signature of a lambda from operator()
-template<typename FPtr>
-struct LambdaTraits;
-
-template<typename T, typename C, typename ...Args>
-struct LambdaTraits<T (C::*)(Args...) const>
-{
-    typedef T(*Type)(Args...);
-};
-
 // Generic RegisterSyscall for lambdas
 // Non-capturing lambdas can be cast to function pointers, but this does not happen on argument matching
 // This is some glue logic that will cast a lambda and call the base RegisterSyscall implementation
 template<class F>
 void RegisterSyscall(SyscallHandler *_Handler, int num, int32_t HostSyscallNumber, FEXCore::IR::SyscallFlags Flags, const char *name, F f){
-  typedef typename LambdaTraits<decltype(&F::operator())>::Type Signature;
-  RegisterSyscall(_Handler, num, HostSyscallNumber, Flags, name, (Signature)f);
+  RegisterSyscall(_Handler, num, HostSyscallNumber, Flags, name, +f);
 }
 
 }

--- a/Source/Tests/LinuxSyscalls/x32/Syscalls.h
+++ b/Source/Tests/LinuxSyscalls/x32/Syscalls.h
@@ -96,7 +96,7 @@ void RegisterSyscall(SyscallHandler *Handler, int SyscallNumber, int32_t HostSys
     reinterpret_cast<void*>(fn), sizeof...(Args));
 }
 
-//LambdaTraits extracts the function singature of a lambda from operator()
+//LambdaTraits extracts the function signature of a lambda from operator()
 template<typename FPtr>
 struct LambdaTraits;
 
@@ -119,44 +119,24 @@ void RegisterSyscall(SyscallHandler *_Handler, int num, int32_t HostSyscallNumbe
 
 // Registers syscall for 32bit only
 #define REGISTER_SYSCALL_IMPL_X32(name, lambda) \
-  struct impl_##name { \
-    impl_##name(FEX::HLE::SyscallHandler *Handler) \
-    { \
-      FEX::HLE::x32::RegisterSyscall(Handler, x32::SYSCALL_x86_##name, ~0, FEXCore::IR::SyscallFlags::DEFAULT, #name, lambda); \
-    } } impl_##name(Handler)
+  REGISTER_SYSCALL_IMPL_X32_INTERNAL(name, ~0, FEXCore::IR::SyscallFlags::DEFAULT, lambda)
 
-// Registers syscall for 32bit only
 #define REGISTER_SYSCALL_IMPL_X32_PASS(name, lambda) \
-  struct impl_##name { \
-    impl_##name(FEX::HLE::SyscallHandler *Handler) \
-    { \
-      FEX::HLE::x32::RegisterSyscall(Handler, x32::SYSCALL_x86_##name, SYSCALL_DEF(name), FEXCore::IR::SyscallFlags::DEFAULT, #name, lambda); \
-    } } impl_##name(Handler)
+  REGISTER_SYSCALL_IMPL_X32_INTERNAL(name, SYSCALL_DEF(name), FEXCore::IR::SyscallFlags::DEFAULT, lambda)
 
 #define REGISTER_SYSCALL_IMPL_X32_PASS_MANUAL(name, hostname, lambda) \
-  struct impl_##name { \
-    impl_##name(FEX::HLE::SyscallHandler *Handler) \
-    { \
-      FEX::HLE::x32::RegisterSyscall(Handler, x32::SYSCALL_x86_##name, SYSCALL_DEF(hostname), FEXCore::IR::SyscallFlags::DEFAULT, #name, lambda); \
-    } } impl_##name(Handler)
+  REGISTER_SYSCALL_IMPL_X32_INTERNAL(name, SYSCALL_DEF(hostname), FEXCore::IR::SyscallFlags::DEFAULT, lambda)
 
 #define REGISTER_SYSCALL_IMPL_X32_FLAGS(name, flags, lambda) \
-  struct impl_##name { \
-    impl_##name(FEX::HLE::SyscallHandler *Handler) \
-    { \
-      FEX::HLE::x32::RegisterSyscall(Handler, x32::SYSCALL_x86_##name, ~0, flags, #name, lambda); \
-    } } impl_##name(Handler)
+  REGISTER_SYSCALL_IMPL_X32_INTERNAL(name, ~0, flags, lambda)
 
 #define REGISTER_SYSCALL_IMPL_X32_PASS_FLAGS(name, flags, lambda) \
-  struct impl_##name { \
-    impl_##name(FEX::HLE::SyscallHandler *Handler) \
-    { \
-      FEX::HLE::x32::RegisterSyscall(Handler, x32::SYSCALL_x86_##name, SYSCALL_DEF(name), flags, #name, lambda); \
-    } } impl_##name(Handler)
+  REGISTER_SYSCALL_IMPL_X32_INTERNAL(name, SYSCALL_DEF(name), flags, lambda)
 
 #define REGISTER_SYSCALL_IMPL_X32_PASS_MANUAL_FLAGS(name, hostname, flags, lambda) \
-  struct impl_##name { \
-    impl_##name(FEX::HLE::SyscallHandler *Handler) \
-    { \
-      FEX::HLE::x32::RegisterSyscall(Handler, x32::SYSCALL_x86_##name, SYSCALL_DEF(hostname), flags, #name, lambda); \
-    } } impl_##name(Handler)
+  REGISTER_SYSCALL_IMPL_X32_INTERNAL(name, SYSCALL_DEF(hostname), flags, lambda)
+
+#define REGISTER_SYSCALL_IMPL_X32_INTERNAL(name, number, flags, lambda) \
+  do { \
+    FEX::HLE::x32::RegisterSyscall(Handler, x32::SYSCALL_x86_##name, number, flags, #name, lambda); \
+  } while (false)

--- a/Source/Tests/LinuxSyscalls/x64/Syscalls.h
+++ b/Source/Tests/LinuxSyscalls/x64/Syscalls.h
@@ -95,23 +95,12 @@ void RegisterSyscall(SyscallHandler *Handler, int SyscallNumber, int32_t HostSys
     reinterpret_cast<void*>(fn), sizeof...(Args));
 }
 
-//LambdaTraits extracts the function singature of a lambda from operator()
-template<typename FPtr>
-struct LambdaTraits;
-
-template<typename T, typename C, typename ...Args>
-struct LambdaTraits<T (C::*)(Args...) const>
-{
-    typedef T(*Type)(Args...);
-};
-
 // Generic RegisterSyscall for lambdas
 // Non-capturing lambdas can be cast to function pointers, but this does not happen on argument matching
 // This is some glue logic that will cast a lambda and call the base RegisterSyscall implementation
 template<class F>
 void RegisterSyscall(SyscallHandler *_Handler, int num, int32_t HostSyscallNumber, FEXCore::IR::SyscallFlags Flags, const char *name, F f){
-  typedef typename LambdaTraits<decltype(&F::operator())>::Type Signature;
-  RegisterSyscall(_Handler, num, HostSyscallNumber, Flags, name, (Signature)f);
+  RegisterSyscall(_Handler, num, HostSyscallNumber, Flags, name, +f);
 }
 
 }

--- a/Source/Tests/LinuxSyscalls/x64/Syscalls.h
+++ b/Source/Tests/LinuxSyscalls/x64/Syscalls.h
@@ -118,29 +118,18 @@ void RegisterSyscall(SyscallHandler *_Handler, int num, int32_t HostSyscallNumbe
 
 // Registers syscall for 64bit only
 #define REGISTER_SYSCALL_IMPL_X64(name, lambda) \
-  struct impl_##name { \
-    impl_##name(FEX::HLE::SyscallHandler *Handler) \
-    { \
-      FEX::HLE::x64::RegisterSyscall(Handler, x64::SYSCALL_x64_##name, ~0, FEXCore::IR::SyscallFlags::DEFAULT, #name, lambda); \
-    } } impl_##name(Handler)
+  REGISTER_SYSCALL_IMPL_X64_INTERNAL(name, ~0, FEXCore::IR::SyscallFlags::DEFAULT, lambda)
 
 #define REGISTER_SYSCALL_IMPL_X64_PASS(name, lambda) \
-  struct impl_##name { \
-    impl_##name(FEX::HLE::SyscallHandler *Handler) \
-    { \
-      FEX::HLE::x64::RegisterSyscall(Handler, x64::SYSCALL_x64_##name, SYSCALL_DEF(name), FEXCore::IR::SyscallFlags::DEFAULT, #name, lambda); \
-    } } impl_##name(Handler)
+  REGISTER_SYSCALL_IMPL_X64_INTERNAL(name, SYSCALL_DEF(name), FEXCore::IR::SyscallFlags::DEFAULT, lambda)
 
 #define REGISTER_SYSCALL_IMPL_X64_FLAGS(name, flags, lambda) \
-  struct impl_##name { \
-    impl_##name(FEX::HLE::SyscallHandler *Handler) \
-    { \
-      FEX::HLE::x64::RegisterSyscall(Handler, x64::SYSCALL_x64_##name, ~0, flags, #name, lambda); \
-    } } impl_##name(Handler)
+  REGISTER_SYSCALL_IMPL_X64_INTERNAL(name, ~0, flags, lambda)
 
 #define REGISTER_SYSCALL_IMPL_X64_PASS_FLAGS(name, flags, lambda) \
-  struct impl_##name { \
-    impl_##name(FEX::HLE::SyscallHandler *Handler) \
-    { \
-      FEX::HLE::x64::RegisterSyscall(Handler, x64::SYSCALL_x64_##name, SYSCALL_DEF(name), flags, #name, lambda); \
-    } } impl_##name(Handler)
+  REGISTER_SYSCALL_IMPL_X64_INTERNAL(name, SYSCALL_DEF(name), flags, lambda)
+
+#define REGISTER_SYSCALL_IMPL_X64_INTERNAL(name, number, flags, lambda) \
+  do { \
+    FEX::HLE::x64::RegisterSyscall(Handler, x64::SYSCALL_x64_##name, (number), (flags), #name, (lambda)); \
+  } while (false)


### PR DESCRIPTION
No interface changes, just throwing out unused code and shortening implementations.