### PR TITLE
Host Deferred Signals

### DIFF
--- a/External/FEXCore/Source/Interface/Context/Context.cpp
+++ b/External/FEXCore/Source/Interface/Context/Context.cpp
@@ -63,8 +63,8 @@ namespace FEXCore::Context {
     CTX->Step();
   }
 
-  void CompileRIP(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP) {
-    Thread->CTX->CompileBlock(Thread->CurrentFrame, GuestRIP);
+  uintptr_t TryCompileRIP(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP) {
+    return Thread->CTX->TryCompileBlock(Thread->CurrentFrame, GuestRIP);
   }
 
   FEXCore::Context::ExitReason RunUntilExit(FEXCore::Context::Context *CTX) {
@@ -203,9 +203,11 @@ namespace FEXCore::Context {
   }
 
 namespace Debug {
+  #if FIXME
   void CompileRIP(FEXCore::Context::Context *CTX, uint64_t RIP) {
     CTX->CompileRIP(CTX->ParentThread, RIP);
   }
+  #endif
   uint64_t GetThreadCount(FEXCore::Context::Context *CTX) {
     return CTX->GetThreadCount();
   }

--- a/External/FEXCore/Source/Interface/Context/Context.cpp
+++ b/External/FEXCore/Source/Interface/Context/Context.cpp
@@ -142,8 +142,8 @@ namespace FEXCore::Context {
     CTX->RunThread(Thread);
   }
 
-  void StopThread(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread) {
-    CTX->StopThread(Thread);
+  void ExitCurrentThread(FEXCore::Core::InternalThreadState *Thread) {
+    FEXCore::Context::Context::ExitCurrentThread(Thread);
   }
 
   void DestroyThread(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread) {

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -206,7 +206,10 @@ namespace FEXCore::Context {
     void RemoveCustomIREntrypoint(uintptr_t Entrypoint);
 
     // Debugger interface
+    #if FIXME
     void CompileRIP(FEXCore::Core::InternalThreadState *Thread, uint64_t RIP);
+    #endif
+
     uint64_t GetThreadCount() const;
     FEXCore::Core::RuntimeStats *GetRuntimeStatsForThread(uint64_t Thread);
     bool GetDebugDataForRIP(uint64_t RIP, FEXCore::Core::DebugData *Data);
@@ -231,11 +234,12 @@ namespace FEXCore::Context {
       uint64_t StartAddr;
       uint64_t Length;
     };
-    [[nodiscard]] CompileCodeResult CompileCode(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP);
-    uintptr_t CompileBlock(FEXCore::Core::CpuStateFrame *Frame, uint64_t GuestRIP);
 
-    // same as CompileBlock, but aborts on failure
-    void CompileBlockJit(FEXCore::Core::CpuStateFrame *Frame, uint64_t GuestRIP);
+    // Aborts on failure
+    void CompileBlockOrAbort(FEXCore::Core::CpuStateFrame *Frame, uint64_t GuestRIP);
+
+    // Returns false on failure
+    uintptr_t TryCompileBlock(FEXCore::Core::CpuStateFrame *Frame, uint64_t GuestRIP);
 
     // Used for thread creation from syscalls
     /**
@@ -337,6 +341,9 @@ namespace FEXCore::Context {
     void ClearCodeCache(FEXCore::Core::InternalThreadState *Thread);
 
   private:
+    [[nodiscard]] uintptr_t CompileBlockInternal(FEXCore::Core::CpuStateFrame *Frame, uint64_t GuestRIP);
+    [[nodiscard]] CompileCodeResult CompileCodeHelper(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP);
+
     /**
      * @brief Does some final thread initialization
      *

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -180,7 +180,7 @@ namespace FEXCore::Context {
 
     template<auto Fn>
     static uint64_t ThreadExitFunctionLink(FEXCore::Core::CpuStateFrame *Frame, uint64_t *record) {
-      FHU::ScopedSignalCheckWithSharedLock lk(Frame->Thread->CTX->CodeInvalidationMutex);
+      FHU::ScopedSignalMaskWithSharedLock lk(Frame->Thread->CTX->CodeInvalidationMutex);
 
       return Fn(Frame, record);
     }
@@ -192,7 +192,7 @@ namespace FEXCore::Context {
       
       LogMan::Throw::AFmt(Thread->ThreadManager.GetTID() == gettid(), "Must be called from owning thread {}, not {}", Thread->ThreadManager.GetTID(), gettid());
 
-      FHU::ScopedSignalCheckWithUniqueLock lk(Thread->CTX->CodeInvalidationMutex);
+      FHU::ScopedSignalMaskWithUniqueLockGuard lk(Thread->CTX->CodeInvalidationMutex);
 
       ThreadRemoveCodeEntry(Thread, GuestRIP);
     }

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -180,6 +180,7 @@ namespace FEXCore::Context {
 
     template<auto Fn>
     static uint64_t ThreadExitFunctionLink(FEXCore::Core::CpuStateFrame *Frame, uint64_t *record) {
+      FHU::ScopedSignalHostDefer hd;
       FHU::ScopedSignalMaskWithSharedLock lk(Frame->Thread->CTX->CodeInvalidationMutex);
 
       return Fn(Frame, record);

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -189,6 +189,8 @@ namespace FEXCore::Context {
     // Wrapper which takes CpuStateFrame instead of InternalThreadState and unique_locks CodeInvalidationMutex
     // Must be called from owning thread
     static void ThreadRemoveCodeEntryFromJit(FEXCore::Core::CpuStateFrame *Frame, uint64_t GuestRIP) {
+      FHU::ScopedSignalHostDefer hd;
+
       auto Thread = Frame->Thread;
       
       LogMan::Throw::AFmt(Thread->ThreadManager.GetTID() == gettid(), "Must be called from owning thread {}, not {}", Thread->ThreadManager.GetTID(), gettid());

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -179,7 +179,7 @@ namespace FEXCore::Context {
 
     template<auto Fn>
     static uint64_t ThreadExitFunctionLink(FEXCore::Core::CpuStateFrame *Frame, uint64_t *record) {
-      FHU::ScopedSignalMaskWithSharedLock lk(Frame->Thread->CTX->CodeInvalidationMutex);
+      FHU::ScopedSignalCheckWithSharedLock lk(Frame->Thread->CTX->CodeInvalidationMutex);
 
       return Fn(Frame, record);
     }
@@ -191,7 +191,7 @@ namespace FEXCore::Context {
       
       LogMan::Throw::AFmt(Thread->ThreadManager.GetTID() == gettid(), "Must be called from owning thread {}, not {}", Thread->ThreadManager.GetTID(), gettid());
 
-      FHU::ScopedSignalMaskWithUniqueLock lk(Thread->CTX->CodeInvalidationMutex);
+      FHU::ScopedSignalCheckWithUniqueLock lk(Thread->CTX->CodeInvalidationMutex);
 
       ThreadRemoveCodeEntry(Thread, GuestRIP);
     }

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -164,7 +164,8 @@ namespace FEXCore::Context {
     void Step();
     void Stop(bool IgnoreCurrentThread);
     void WaitForIdle();
-    void StopThread(FEXCore::Core::InternalThreadState *Thread);
+    static void StopOtherThread(FEXCore::Core::InternalThreadState *Thread);
+    static void ExitCurrentThread(FEXCore::Core::InternalThreadState *Thread);
     void SignalThread(FEXCore::Core::InternalThreadState *Thread, FEXCore::Core::SignalEvent Event);
 
     bool GetGdbServerStatus() const { return DebugServer != nullptr; }

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -1000,6 +1000,8 @@ namespace FEXCore::Context {
   }
 
   void Context::CompileBlockJit(FEXCore::Core::CpuStateFrame *Frame, uint64_t GuestRIP) {
+    FHU::ScopedSignalMask sm;
+    
     auto NewBlock = CompileBlock(Frame, GuestRIP);
 
     if (NewBlock == 0) {
@@ -1189,13 +1191,13 @@ namespace FEXCore::Context {
   }
 
   void InvalidateGuestCodeRange(FEXCore::Context::Context *CTX, uint64_t Start, uint64_t Length) {
-    FHU::ScopedSignalMaskWithUniqueLock CodeInvalidationLock(CTX->CodeInvalidationMutex);
+    FHU::ScopedSignalCheckWithUniqueLock CodeInvalidationLock(CTX->CodeInvalidationMutex);
     
     InvalidateGuestCodeRangeInternal(CTX, Start, Length);
   }
 
   void InvalidateGuestCodeRange(FEXCore::Context::Context *CTX, uint64_t Start, uint64_t Length, std::function<void(uint64_t start, uint64_t Length)> CallAfter) {
-    FHU::ScopedSignalMaskWithUniqueLock CodeInvalidationLock(CTX->CodeInvalidationMutex);
+    FHU::ScopedSignalCheckWithUniqueLock CodeInvalidationLock(CTX->CodeInvalidationMutex);
 
     InvalidateGuestCodeRangeInternal(CTX, Start, Length);
     CallAfter(Start, Length);
@@ -1312,6 +1314,7 @@ namespace FEXCore::Context {
   }
 
   uint64_t HandleSyscall(FEXCore::HLE::SyscallHandler *Handler, FEXCore::Core::CpuStateFrame *Frame, FEXCore::HLE::SyscallArguments *Args) {
+    FHU::ScopedSignalMask sm;
     uint64_t Result{};
     Result = Handler->HandleSyscall(Frame, Args);
     return Result;

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -509,7 +509,7 @@ namespace FEXCore::Context {
   };
 
   static void *ThreadHandler(void* Data) {
-    FHU::ScopedSignalHostDefer sm;
+    FHU::ScopedSignalHostDefer hd;
 
     ExecutionThreadHandler *Handler = reinterpret_cast<ExecutionThreadHandler*>(Data);
     Handler->This->ExecutionThread(Handler->Thread);
@@ -1016,7 +1016,7 @@ namespace FEXCore::Context {
   }
 
   void Context::CompileBlockJit(FEXCore::Core::CpuStateFrame *Frame, uint64_t GuestRIP) {
-    FHU::ScopedSignalHostDefer sm;
+    FHU::ScopedSignalHostDefer hd;
     
     auto NewBlock = CompileBlock(Frame, GuestRIP);
 

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -509,9 +509,12 @@ namespace FEXCore::Context {
   };
 
   static void *ThreadHandler(void* Data) {
+    FHU::ScopedSignalHostDefer sm;
+
     ExecutionThreadHandler *Handler = reinterpret_cast<ExecutionThreadHandler*>(Data);
     Handler->This->ExecutionThread(Handler->Thread);
     FEXCore::Allocator::free(Handler);
+
     return nullptr;
   }
 
@@ -1125,6 +1128,8 @@ namespace FEXCore::Context {
   }
 
   void Context::ExecutionThread(FEXCore::Core::InternalThreadState *Thread) {
+    FHU::ScopedSignalMask sm;
+
     Core::ThreadData.Thread = Thread;
     Thread->ExitReason = FEXCore::Context::ExitReason::EXIT_WAITING;
 

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -8,6 +8,7 @@ $end_info$
 */
 
 #include <cstdint>
+#include "FEXHeaderUtils/ScopedSignalMask.h"
 #include "Interface/Context/Context.h"
 #include "Interface/Core/LookupCache.h"
 #include "Interface/Core/Core.h"
@@ -1012,7 +1013,7 @@ namespace FEXCore::Context {
   }
 
   void Context::CompileBlockJit(FEXCore::Core::CpuStateFrame *Frame, uint64_t GuestRIP) {
-    FHU::ScopedSignalMask sm;
+    FHU::ScopedSignalHostDefer sm;
     
     auto NewBlock = CompileBlock(Frame, GuestRIP);
 
@@ -1209,13 +1210,13 @@ namespace FEXCore::Context {
   }
 
   void InvalidateGuestCodeRange(FEXCore::Context::Context *CTX, uint64_t Start, uint64_t Length) {
-    FHU::ScopedSignalCheckWithUniqueLock CodeInvalidationLock(CTX->CodeInvalidationMutex);
+    FHU::ScopedSignalMaskWithUniqueLockGuard CodeInvalidationLock(CTX->CodeInvalidationMutex);
     
     InvalidateGuestCodeRangeInternal(CTX, Start, Length);
   }
 
   void InvalidateGuestCodeRange(FEXCore::Context::Context *CTX, uint64_t Start, uint64_t Length, std::function<void(uint64_t start, uint64_t Length)> CallAfter) {
-    FHU::ScopedSignalCheckWithUniqueLock CodeInvalidationLock(CTX->CodeInvalidationMutex);
+    FHU::ScopedSignalMaskWithUniqueLockGuard CodeInvalidationLock(CTX->CodeInvalidationMutex);
 
     InvalidateGuestCodeRangeInternal(CTX, Start, Length);
     CallAfter(Start, Length);
@@ -1332,7 +1333,8 @@ namespace FEXCore::Context {
   }
 
   uint64_t HandleSyscall(FEXCore::HLE::SyscallHandler *Handler, FEXCore::Core::CpuStateFrame *Frame, FEXCore::HLE::SyscallArguments *Args) {
-    FHU::ScopedSignalMask sm;
+    FHU::ScopedSignalAutoHostDefer sm;
+
     uint64_t Result{};
     Result = Handler->HandleSyscall(Frame, Args);
     return Result;

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
@@ -57,7 +57,6 @@ Arm64Dispatcher::Arm64Dispatcher(FEXCore::Context::Context *ctx, const Dispatche
 
   Literal l_CTX {reinterpret_cast<uintptr_t>(CTX)};
   Literal l_Sleep {reinterpret_cast<uint64_t>(SleepThread)};
-  Literal l_CompileBlock {GetCompileBlockPtr()};
 
   // Push all the register we need to save
   PushCalleeSavedRegisters();
@@ -178,7 +177,7 @@ Arm64Dispatcher::Arm64Dispatcher(FEXCore::Context::Context *ctx, const Dispatche
     ret();
   }
 
-  constexpr bool SignalSafeCompile = true;
+  constexpr bool SignalSafeCompile = false;
   {
     ExitFunctionLinkerAddress = GetCursorAddress<uint64_t>();
     if (config.StaticRegisterAllocation)
@@ -263,7 +262,7 @@ Arm64Dispatcher::Arm64Dispatcher(FEXCore::Context::Context *ctx, const Dispatche
 
     ldr(x0, &l_CTX);
     mov(x1, STATE);
-    ldr(x3, &l_CompileBlock);
+    ldr(x3, STATE_PTR(CpuStateFrame, Pointers.Common.TranslateGuestCode));
 
     // X2 contains our guest RIP
     blr(x3); // { CTX, Frame, RIP}
@@ -486,7 +485,6 @@ Arm64Dispatcher::Arm64Dispatcher(FEXCore::Context::Context *ctx, const Dispatche
 
   place(&l_CTX);
   place(&l_Sleep);
-  place(&l_CompileBlock);
 
 
   FinalizeCode();

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
@@ -818,16 +818,4 @@ bool Dispatcher::HandleSignalPause(FEXCore::Core::InternalThreadState *Thread, i
   return false;
 }
 
-uint64_t Dispatcher::GetCompileBlockPtr() {
-  using ClassPtrType = void (FEXCore::Context::Context::*)(FEXCore::Core::CpuStateFrame *, uint64_t);
-  union PtrCast {
-    ClassPtrType ClassPtr;
-    uintptr_t Data;
-  };
-
-  PtrCast CompileBlockPtr;
-  CompileBlockPtr.ClassPtr = &FEXCore::Context::Context::CompileBlockJit;
-  return CompileBlockPtr.Data;
-}
-
 }

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
@@ -101,8 +101,6 @@ protected:
 
   static void SleepThread(FEXCore::Context::Context *ctx, FEXCore::Core::CpuStateFrame *Frame);
 
-  static uint64_t GetCompileBlockPtr();
-
   using AsmDispatch = void(*)(FEXCore::Core::CpuStateFrame *Frame);
   using JITCallback = void(*)(FEXCore::Core::CpuStateFrame *Frame, uint64_t RIP);
 

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/X86Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/X86Dispatcher.cpp
@@ -169,7 +169,7 @@ X86Dispatcher::X86Dispatcher(FEXCore::Context::Context *ctx, const DispatcherCon
     ret();
   }
 
-  constexpr bool SignalSafeCompile = true;
+  constexpr bool SignalSafeCompile = false;
   // Block creation
   {
     L(NoBlock);
@@ -203,10 +203,9 @@ X86Dispatcher::X86Dispatcher(FEXCore::Context::Context *ctx, const DispatcherCon
     // {rdi, rsi, rdx}
     mov(rdi, reinterpret_cast<uint64_t>(CTX));
     mov(rsi, STATE);
-    mov(rax, GetCompileBlockPtr());
-
-    call(rax);
-
+    
+    call(qword STATE_PTR(CpuStateFrame, Pointers.Common.TranslateGuestCode));
+    
     if (SignalSafeCompile) {
       // Now restore the signal mask
       // Living in the same location

--- a/External/FEXCore/Source/Interface/Core/GdbServer.cpp
+++ b/External/FEXCore/Source/Interface/Core/GdbServer.cpp
@@ -72,11 +72,14 @@ GdbServer::GdbServer(FEXCore::Context::Context *ctx) : CTX(ctx) {
   // Pass all signals by default
   std::fill(PassSignals.begin(), PassSignals.end(), true);
 
+  //FEX_TODO("FEXCore::Context::ExitReason::EXIT_DEBUG needs to be actually implemented and then call this->Break(SIGTRAP) directly")
+  #if 0
   Context::SetExitHandler(ctx, [this](uint64_t ThreadId, FEXCore::Context::ExitReason ExitReason) {
     if (ExitReason == FEXCore::Context::ExitReason::EXIT_DEBUG) {
       this->Break(SIGTRAP);
     }
   });
+  #endif
 
   // This is a total hack as there is currently no way to resume once hitting a segfault
   // But it's semi-useful for debugging.

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -50,7 +50,7 @@ InterpreterCore::InterpreterCore(Dispatcher *Dispatcher, FEXCore::Core::Internal
 
   auto &Common = Thread->CurrentFrame->Pointers.Common;
   {
-    FEXCore::Utils::MemberFunctionToPointerCast PMF(&FEXCore::Context::Context::CompileBlockJit);
+    FEXCore::Utils::MemberFunctionToPointerCast PMF(&FEXCore::Context::Context::CompileBlockOrAbort);
     Common.TranslateGuestCode = PMF.GetConvertedPointer();
   }
 

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -18,6 +18,8 @@
 
 #include "InterpreterOps.h"
 
+#include "Utils/MemberFunctionToPointer.h"
+
 #if defined(_M_X86_64)
   #include "Interface/Core/Dispatcher/X86Dispatcher.h"
 #elif defined(_M_ARM_64)
@@ -45,6 +47,12 @@ InterpreterCore::InterpreterCore(Dispatcher *Dispatcher, FEXCore::Core::Internal
   auto &Interpreter = Thread->CurrentFrame->Pointers.Interpreter;
 
   Interpreter.FragmentExecuter = reinterpret_cast<uint64_t>(&InterpreterOps::InterpretIR);
+
+  auto &Common = Thread->CurrentFrame->Pointers.Common;
+  {
+    FEXCore::Utils::MemberFunctionToPointerCast PMF(&FEXCore::Context::Context::CompileBlockJit);
+    Common.TranslateGuestCode = PMF.GetConvertedPointer();
+  }
 
   ClearCache();
 }

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -61,7 +61,11 @@ void InterpreterCore::InitializeSignalHandlers(FEXCore::Context::Context *CTX) {
 
 #ifdef _M_ARM_64
   CTX->SignalDelegation->RegisterHostSignalHandler(SIGBUS, [](FEXCore::Core::InternalThreadState *Thread, int Signal, void *info, void *ucontext) -> bool {
-    return FEXCore::ArchHelpers::Arm64::HandleSIGBUS(true, Signal, info, ucontext);
+    // SIGBUS logic might trigger sigsegv
+    SignalDelegator::DeliverThreadHostDeferredSignals();
+    auto rv = FEXCore::ArchHelpers::Arm64::HandleSIGBUS(true, Signal, info, ucontext);
+    SignalDelegator::DeferThreadHostSignals();
+    return rv;
   }, true);
 #endif
 }

--- a/External/FEXCore/Source/Interface/Core/Interpreter/MiscOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/MiscOps.cpp
@@ -19,13 +19,6 @@ $end_info$
 #include <sys/random.h>
 
 namespace FEXCore::CPU {
-[[noreturn]]
-static void StopThread(FEXCore::Core::InternalThreadState *Thread) {
-  Thread->CTX->StopThread(Thread);
-
-  LOGMAN_MSG_A_FMT("unreachable");
-  FEX_UNREACHABLE;
-}
 
 #define DEF_OP(x) void InterpreterOps::Op_##x(IR::IROp_Header *IROp, IROpData *Data, IR::NodeID Node)
 DEF_OP(Fence) {

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -489,7 +489,7 @@ Arm64JITCore::Arm64JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::Intern
     Common.SyscallHandlerFunc = reinterpret_cast<uintptr_t>(&FEXCore::Context::HandleSyscall);
     
     {
-      FEXCore::Utils::MemberFunctionToPointerCast PMF(&FEXCore::Context::Context::CompileBlockJit);
+      FEXCore::Utils::MemberFunctionToPointerCast PMF(&FEXCore::Context::Context::CompileBlockOrAbort);
       Common.TranslateGuestCode = PMF.GetConvertedPointer();
     }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -523,7 +523,10 @@ void Arm64JITCore::InitializeSignalHandlers(FEXCore::Context::Context *CTX) {
       return false;
     }
 
-    return FEXCore::ArchHelpers::Arm64::HandleSIGBUS(Thread->CTX->Config.ParanoidTSO(), Signal, info, ucontext);
+    SignalDelegator::DeliverThreadHostDeferredSignals();
+    auto rv = FEXCore::ArchHelpers::Arm64::HandleSIGBUS(true, Signal, info, ucontext);
+    SignalDelegator::DeferThreadHostSignals();
+    return rv;
   }, true);
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -371,7 +371,7 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header *IROp, IR::NodeID Node) {
 
 
 static uint64_t Arm64JITCore_ExitFunctionLink(FEXCore::Core::CpuStateFrame *Frame, uint64_t *record) {
-  FHU::ScopedSignalMask sm;
+  FHU::ScopedSignalHostDefer sm;
 
   auto Thread = Frame->Thread;
   auto GuestRip = record[1];

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -27,6 +27,7 @@ $end_info$
 #include <FEXCore/Core/UContext.h>
 #include <FEXCore/Utils/Allocator.h>
 #include <FEXCore/Utils/CompilerDefs.h>
+#include <FEXCore/Utils/EnumUtils.h>
 
 #include "Interface/Core/Interpreter/InterpreterOps.h"
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -371,7 +371,7 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header *IROp, IR::NodeID Node) {
 
 
 static uint64_t Arm64JITCore_ExitFunctionLink(FEXCore::Core::CpuStateFrame *Frame, uint64_t *record) {
-  FHU::ScopedSignalHostDefer sm;
+  FHU::ScopedSignalHostDefer hd;
 
   auto Thread = Frame->Thread;
   auto GuestRip = record[1];

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -303,7 +303,7 @@ void X86JITCore::Op_Unhandled(IR::IROp_Header *IROp, IR::NodeID Node) {
 }
 
 static uint64_t X86JITCore_ExitFunctionLink(FEXCore::Core::CpuStateFrame *Frame, uint64_t *record) {
-  FHU::ScopedSignalMask sm;
+  FHU::ScopedSignalHostDefer sm;
   
   auto Thread = Frame->Thread;
   auto GuestRip = record[1];

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -303,7 +303,7 @@ void X86JITCore::Op_Unhandled(IR::IROp_Header *IROp, IR::NodeID Node) {
 }
 
 static uint64_t X86JITCore_ExitFunctionLink(FEXCore::Core::CpuStateFrame *Frame, uint64_t *record) {
-  FHU::ScopedSignalHostDefer sm;
+  FHU::ScopedSignalHostDefer hd;
   
   auto Thread = Frame->Thread;
   auto GuestRip = record[1];

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -377,7 +377,7 @@ X86JITCore::X86JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalTh
     Common.SyscallHandlerFunc = reinterpret_cast<uintptr_t>(&FEXCore::Context::HandleSyscall);
 
     {
-      FEXCore::Utils::MemberFunctionToPointerCast PMF(&FEXCore::Context::Context::CompileBlockJit);
+      FEXCore::Utils::MemberFunctionToPointerCast PMF(&FEXCore::Context::Context::CompileBlockOrAbort);
       Common.TranslateGuestCode = PMF.GetConvertedPointer();
     }
 

--- a/External/FEXCore/Source/Interface/Core/SignalDelegator.cpp
+++ b/External/FEXCore/Source/Interface/Core/SignalDelegator.cpp
@@ -194,6 +194,12 @@ namespace FEXCore {
 
       LOGMAN_THROW_A_FMT(!Previous, "Nested Host Deferred signal, {}", Previous);
 
+      // Store Deferred sigmask
+      memcpy(&ThreadData.HostDeferredSigmask, &_context->uc_sigmask, SIGRTMAX / 8);
+
+      // Block further signals on this thread
+      sigfillset(&_context->uc_sigmask);
+
       if (sigsetjmp(ThreadData.HostDeferredSignalJump, 1)) {
         // Host Deferred Delivery
         ThreadData.HostDeferredSignalPending = false;
@@ -202,12 +208,6 @@ namespace FEXCore {
         memcpy(&_context->uc_sigmask, &ThreadData.HostDeferredSigmask, SIGRTMAX / 8);
         goto DoHandleSignal;
       }
-
-      // Store Deferred sigmask
-      memcpy(&ThreadData.HostDeferredSigmask, &_context->uc_sigmask, SIGRTMAX / 8);
-
-      // Block further signals on this thread
-      sigfillset(&_context->uc_sigmask);
     }
   }
 }

--- a/External/FEXCore/Source/Interface/Core/SignalDelegator.cpp
+++ b/External/FEXCore/Source/Interface/Core/SignalDelegator.cpp
@@ -160,7 +160,7 @@ namespace FEXCore {
       DoHandleSignal: {
         // No signals must be delivered in this scope - should be guaranteed.
         // FEX_TODO("Enforce no signal delivery in this scope")
-        FHU::ScopedSignalHostDefer sm;
+        FHU::ScopedSignalHostDefer hd;
 
         HostSignalHandler &Handler = HostHandlers[Signal];
 

--- a/External/FEXCore/Source/Utils/Allocator/64BitAllocator.cpp
+++ b/External/FEXCore/Source/Utils/Allocator/64BitAllocator.cpp
@@ -183,7 +183,7 @@ void *OSAllocator_64Bit::Mmap(void *addr, size_t length, int prot, int flags, in
   size_t NumberOfPages = length / FHU::FEX_PAGE_SIZE;
 
   // This needs a mutex to be thread safe
-  FHU::ScopedSignalMaskWithMutex lk(AllocationMutex);
+  FHU::ScopedSignalCheckWithLockGuard lk(AllocationMutex);
 
   uint64_t AllocatedOffset{};
   LiveVMARegion *LiveRegion{};
@@ -442,7 +442,7 @@ int OSAllocator_64Bit::Munmap(void *addr, size_t length) {
   }
 
   // This needs a mutex to be thread safe
-  FHU::ScopedSignalMaskWithMutex lk(AllocationMutex);
+  FHU::ScopedSignalCheckWithLockGuard lk(AllocationMutex);
 
   length = FEXCore::AlignUp(length, FHU::FEX_PAGE_SIZE);
 
@@ -622,7 +622,7 @@ OSAllocator_64Bit::OSAllocator_64Bit() {
 
 OSAllocator_64Bit::~OSAllocator_64Bit() {
   // This needs a mutex to be thread safe
-  FHU::ScopedSignalMaskWithMutex lk(AllocationMutex);
+  FHU::ScopedSignalCheckWithLockGuard lk(AllocationMutex);
 
   // Walk the pages and deallocate
   // First walk the live regions

--- a/External/FEXCore/Source/Utils/Allocator/64BitAllocator.cpp
+++ b/External/FEXCore/Source/Utils/Allocator/64BitAllocator.cpp
@@ -183,7 +183,7 @@ void *OSAllocator_64Bit::Mmap(void *addr, size_t length, int prot, int flags, in
   size_t NumberOfPages = length / FHU::FEX_PAGE_SIZE;
 
   // This needs a mutex to be thread safe
-  FHU::ScopedSignalCheckWithLockGuard lk(AllocationMutex);
+  FHU::ScopedSignalMaskWithLockGuard lk(AllocationMutex);
 
   uint64_t AllocatedOffset{};
   LiveVMARegion *LiveRegion{};
@@ -442,7 +442,7 @@ int OSAllocator_64Bit::Munmap(void *addr, size_t length) {
   }
 
   // This needs a mutex to be thread safe
-  FHU::ScopedSignalCheckWithLockGuard lk(AllocationMutex);
+  FHU::ScopedSignalMaskWithLockGuard lk(AllocationMutex);
 
   length = FEXCore::AlignUp(length, FHU::FEX_PAGE_SIZE);
 
@@ -622,7 +622,7 @@ OSAllocator_64Bit::OSAllocator_64Bit() {
 
 OSAllocator_64Bit::~OSAllocator_64Bit() {
   // This needs a mutex to be thread safe
-  FHU::ScopedSignalCheckWithLockGuard lk(AllocationMutex);
+  FHU::ScopedSignalMaskWithLockGuard lk(AllocationMutex);
 
   // Walk the pages and deallocate
   // First walk the live regions

--- a/External/FEXCore/include/FEXCore/Core/Context.h
+++ b/External/FEXCore/include/FEXCore/Core/Context.h
@@ -145,7 +145,7 @@ namespace FEXCore::Context {
    */
   FEX_DEFAULT_VISIBILITY ExitReason RunUntilExit(FEXCore::Context::Context *CTX);
 
-  FEX_DEFAULT_VISIBILITY void CompileRIP(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP);
+  FEX_DEFAULT_VISIBILITY uintptr_t TryCompileRIP(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP);
 
   /**
    * @brief Gets the program exit status

--- a/External/FEXCore/include/FEXCore/Core/Context.h
+++ b/External/FEXCore/include/FEXCore/Core/Context.h
@@ -44,10 +44,10 @@ namespace FEXCore::Context {
   enum ExitReason {
     EXIT_NONE,
     EXIT_WAITING,
-    EXIT_ASYNC_RUN,
+    //EXIT_ASYNC_RUN, // not actually used
     EXIT_SHUTDOWN,
-    EXIT_DEBUG,
-    EXIT_UNKNOWNERROR,
+    //EXIT_DEBUG, // not actually implemented
+    //EXIT_UNKNOWNERROR,  // not actually used
   };
 
   enum OperatingMode {
@@ -257,7 +257,7 @@ namespace FEXCore::Context {
   FEX_DEFAULT_VISIBILITY void ExecutionThread(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread);
   FEX_DEFAULT_VISIBILITY void InitializeThread(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread);
   FEX_DEFAULT_VISIBILITY void RunThread(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread);
-  FEX_DEFAULT_VISIBILITY void StopThread(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread);
+  FEX_DEFAULT_VISIBILITY void ExitCurrentThread(FEXCore::Core::InternalThreadState *Thread);
   FEX_DEFAULT_VISIBILITY void DestroyThread(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread);
   FEX_DEFAULT_VISIBILITY void CleanupAfterFork(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread);
   FEX_DEFAULT_VISIBILITY void SetSignalDelegator(FEXCore::Context::Context *CTX, FEXCore::SignalDelegator *SignalDelegation);

--- a/External/FEXCore/include/FEXCore/Core/CoreState.h
+++ b/External/FEXCore/include/FEXCore/Core/CoreState.h
@@ -134,6 +134,7 @@ namespace FEXCore::Core {
       uint64_t CPUIDFunction{};
       uint64_t SyscallHandlerObj{};
       uint64_t SyscallHandlerFunc{};
+      uint64_t TranslateGuestCode{};
       uint64_t ExitFunctionLink{};
 
       uint64_t FallbackHandlerPointers[FallbackHandlerIndex::OPINDEX_MAX];

--- a/External/FEXCore/include/FEXCore/Core/SignalDelegator.h
+++ b/External/FEXCore/include/FEXCore/Core/SignalDelegator.h
@@ -3,6 +3,7 @@
 #include <FEXCore/Utils/CompilerDefs.h>
 
 #include <array>
+#include <atomic>
 #include <cstdint>
 #include <functional>
 #include <utility>
@@ -86,10 +87,11 @@ namespace Core {
     static void DeferThreadHostSignals();
     static void DeliverThreadHostDeferredSignals();
 
-    #if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
-    static void AcquireHostDeferredSignals();
+    static void EnterAutoHostDefer();
+    static void LeaveAutoHostDefer();
+
+    static bool AcquireHostDeferredSignals();
     static void ReleaseHostDeferredSignals();
-    #endif
 
   protected:
     static FEXCore::Core::InternalThreadState *GetTLSThread();
@@ -119,6 +121,7 @@ namespace Core {
     std::array<HostSignalHandler, MAX_SIGNALS + 1> HostHandlers{};
 
   protected:
+
     void SetHostSignalHandler(int Signal, HostSignalDelegatorFunction Func, bool Required) {
       HostHandlers[Signal].Handlers.push_back(std::move(Func));
     }

--- a/External/FEXCore/include/FEXCore/Core/SignalDelegator.h
+++ b/External/FEXCore/include/FEXCore/Core/SignalDelegator.h
@@ -83,8 +83,16 @@ namespace Core {
     // 64 is used internally by Valgrind
     constexpr static size_t SIGNAL_FOR_PAUSE {63};
 
+    static void DeferThreadHostSignals();
+    static void DeliverThreadHostDeferredSignals();
+
+    #if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
+    static void AcquireHostDeferredSignals();
+    static void ReleaseHostDeferredSignals();
+    #endif
+
   protected:
-    FEXCore::Core::InternalThreadState *GetTLSThread();
+    static FEXCore::Core::InternalThreadState *GetTLSThread();
     virtual void HandleGuestSignal(FEXCore::Core::InternalThreadState *Thread, int Signal, void *info, void *ucontext) = 0;
 
     /**

--- a/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
+++ b/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
@@ -11,6 +11,7 @@
 #include <map>
 #include <unordered_map>
 #include <shared_mutex>
+#include <csetjmp>
 
 namespace FEXCore {
   class LookupCache;
@@ -116,6 +117,8 @@ namespace FEXCore::Core {
     std::shared_mutex ObjectCacheRefCounter{};
     bool DestroyedByParent{false};  // Should the parent destroy this thread, or it destory itself
     
+    jmp_buf ExitJump;
+
     alignas(16) FEXCore::Core::CpuStateFrame BaseFrameState{};
 
   };

--- a/External/FEXCore/include/FEXCore/HLE/SyscallHandler.h
+++ b/External/FEXCore/include/FEXCore/HLE/SyscallHandler.h
@@ -53,7 +53,7 @@ namespace FEXCore::HLE {
   class SourcecodeResolver;
 
   struct AOTIRCacheEntryLookupResult {
-    AOTIRCacheEntryLookupResult(FEXCore::IR::AOTIRCacheEntry *Entry, uintptr_t VAFileStart, FHU::ScopedSignalMaskWithSharedLock &&lk)
+    AOTIRCacheEntryLookupResult(FEXCore::IR::AOTIRCacheEntry *Entry, uintptr_t VAFileStart, FHU::ScopedSignalCheckWithSharedLock &&lk)
       : Entry(Entry), VAFileStart(VAFileStart), lk(std::move(lk))
     {
 
@@ -66,7 +66,7 @@ namespace FEXCore::HLE {
 
     friend class SyscallHandler;
     protected:
-    FHU::ScopedSignalMaskWithSharedLock lk;
+    FHU::ScopedSignalCheckWithSharedLock lk;
   };
 
   class SyscallHandler {

--- a/External/FEXCore/include/FEXCore/HLE/SyscallHandler.h
+++ b/External/FEXCore/include/FEXCore/HLE/SyscallHandler.h
@@ -53,7 +53,7 @@ namespace FEXCore::HLE {
   class SourcecodeResolver;
 
   struct AOTIRCacheEntryLookupResult {
-    AOTIRCacheEntryLookupResult(FEXCore::IR::AOTIRCacheEntry *Entry, uintptr_t VAFileStart, FHU::ScopedSignalCheckWithSharedLock &&lk)
+    AOTIRCacheEntryLookupResult(FEXCore::IR::AOTIRCacheEntry *Entry, uintptr_t VAFileStart, FHU::ScopedSignalMaskWithSharedLock &&lk)
       : Entry(Entry), VAFileStart(VAFileStart), lk(std::move(lk))
     {
 
@@ -66,7 +66,7 @@ namespace FEXCore::HLE {
 
     friend class SyscallHandler;
     protected:
-    FHU::ScopedSignalCheckWithSharedLock lk;
+    FHU::ScopedSignalMaskWithSharedLock lk;
   };
 
   class SyscallHandler {

--- a/FEXHeaderUtils/FEXHeaderUtils/ScopedSignalMask.h
+++ b/FEXHeaderUtils/FEXHeaderUtils/ScopedSignalMask.h
@@ -27,7 +27,7 @@ namespace FHU {
   struct ScopedSignalMask {
     std::atomic<bool> HasAcquired;
     ScopedSignalMask() { HasAcquired.store(FEXCore::SignalDelegator::AcquireHostDeferredSignals(), std::memory_order_relaxed); }
-    ~ScopedSignalMask() { if (HasAcquired.load(std::memory_order_relaxed)) { FEXCore::SignalDelegator::ReleaseHostDeferredSignals(); } }
+    ~ScopedSignalMask() { if (HasAcquired.exchange(false, std::memory_order_relaxed)) { FEXCore::SignalDelegator::ReleaseHostDeferredSignals(); } }
 
     ScopedSignalMask(const ScopedSignalMask&) = delete;
     ScopedSignalMask& operator=(ScopedSignalMask&) = delete;
@@ -60,5 +60,5 @@ namespace FHU {
 
   using ScopedSignalMaskWithUniqueLockGuard = ScopedSignalMaskWith<std::lock_guard<std::shared_mutex>>;
   using ScopedSignalMaskWithUniqueLock = ScopedSignalMaskWith<std::unique_lock<std::shared_mutex>>;
-  using ScopedSignalMaskWithSharedLock = ScopedSignalMaskWith<std::unique_lock<std::shared_mutex>>;
+  using ScopedSignalMaskWithSharedLock = ScopedSignalMaskWith<std::shared_lock<std::shared_mutex>>;
 }

--- a/FEXHeaderUtils/FEXHeaderUtils/ScopedSignalMask.h
+++ b/FEXHeaderUtils/FEXHeaderUtils/ScopedSignalMask.h
@@ -14,16 +14,19 @@
 
 namespace FHU {
 
+  // Marks a scope as deferring host signals
   struct ScopedSignalHostDefer {
     ScopedSignalHostDefer() { FEXCore::SignalDelegator::DeferThreadHostSignals(); }
     ~ScopedSignalHostDefer() { FEXCore::SignalDelegator::DeliverThreadHostDeferredSignals(); }
   };
 
+  // Marks a scope as deferring host signals whenever inside a nested ScopedSignalMask
   struct ScopedSignalAutoHostDefer {
     ScopedSignalAutoHostDefer() { FEXCore::SignalDelegator::EnterAutoHostDefer(); }
     ~ScopedSignalAutoHostDefer() { FEXCore::SignalDelegator::LeaveAutoHostDefer(); }
   };
 
+  // Marks a scope as requiring host deferred signals
   struct ScopedSignalMask {
     std::atomic<bool> HasAcquired;
     ScopedSignalMask() { HasAcquired.store(FEXCore::SignalDelegator::AcquireHostDeferredSignals(), std::memory_order_relaxed); }
@@ -34,31 +37,17 @@ namespace FHU {
     ScopedSignalMask(ScopedSignalMask &&rhs): HasAcquired(rhs.HasAcquired.exchange(false, std::memory_order_relaxed)) { }
   };
 
-  /**
-   * @brief A drop-in replacement for std::lock_guard that masks POSIX signals while the mutex is locked
-   *
-   * Use this class to prevent reentrancy issues of C++ mutexes with certain signal handlers.
-   * Common examples of such issues are:
-   * - C++ mutexes not unlocking due to a signal handler longjmping out of a scope owning the mutex
-   * - The signal handler itself using a mutex that would be re-locked if the handler gets invoked
-   *   again before unlocking
-   *
-   * Ownership of this object may be moved, but it is NOT SAFE to move across threads.
-   *
-   * Constructor order:
-   * 1) Mask signals
-   * 2) Lock Mutex
-   *
-   * Destructor Order:
-   * 1) Unlock Mutex
-   * 2) Unmask signals
-   */
+  // Marks as requiring host deferred signals before T's ctor, and til after T's dtor
   template<typename T>
   struct ScopedSignalMaskWith: ScopedSignalMask, T { using T::T; };
 
+  // std::lock_guard<std::mutex> drop in replacement
   using ScopedSignalMaskWithLockGuard = ScopedSignalMaskWith<std::lock_guard<std::mutex>>;
 
+  // std::lock_guard<std::shared_mutex> drop in replacement
   using ScopedSignalMaskWithUniqueLockGuard = ScopedSignalMaskWith<std::lock_guard<std::shared_mutex>>;
+  // std::unique_lock<std::shared_mutex> drop in replacement
   using ScopedSignalMaskWithUniqueLock = ScopedSignalMaskWith<std::unique_lock<std::shared_mutex>>;
+  // std::shared_lock<std::shared_mutex> drop in replacement
   using ScopedSignalMaskWithSharedLock = ScopedSignalMaskWith<std::shared_lock<std::shared_mutex>>;
 }

--- a/Source/Tests/AOT/AOTGenerator.cpp
+++ b/Source/Tests/AOT/AOTGenerator.cpp
@@ -123,7 +123,9 @@ void AOTGenSection(FEXCore::Context::Context *CTX, const ELFCodeLoader2::LoadedS
 
         // Compile entrypoint
         counter++;
-        FEXCore::Context::CompileRIP(Thread, BranchTarget);
+        if (!FEXCore::Context::TryCompileRIP(Thread, BranchTarget)) {
+          LogMan::Msg::IFmt("Failed to compile: {:x}", BranchTarget);
+        }
 
         // Are there more branches?
         if (ExternalBranchesLocal.size() > 0) {

--- a/Source/Tests/AOT/AOTGenerator.cpp
+++ b/Source/Tests/AOT/AOTGenerator.cpp
@@ -13,7 +13,7 @@
 #include <queue>
 
 namespace FEX::AOT {
-void AOTGenSection(FEXCore::Context::Context *CTX, ELFCodeLoader2::LoadedSection &Section) {
+void AOTGenSection(FEXCore::Context::Context *CTX, const ELFCodeLoader2::LoadedSection &Section) {
   // Make sure this section is executable and big enough
   if (!Section.Executable || Section.Size < 16)
     return;

--- a/Source/Tests/AOT/AOTGenerator.h
+++ b/Source/Tests/AOT/AOTGenerator.h
@@ -3,5 +3,5 @@
 #include "ELFCodeLoader2.h"
 
 namespace FEX::AOT {
-  void AOTGenSection(FEXCore::Context::Context *CTX, ELFCodeLoader2::LoadedSection &Section);
+  void AOTGenSection(FEXCore::Context::Context *CTX, const ELFCodeLoader2::LoadedSection &Section);
 }

--- a/Source/Tests/ELFCodeLoader2.h
+++ b/Source/Tests/ELFCodeLoader2.h
@@ -206,7 +206,6 @@ class ELFCodeLoader2 final : public FEXCore::CodeLoader {
     bool Executable;
   };
 
-  std::vector<LoadedSection> Sections;
   ELFCodeLoader2(std::string const &Filename, std::string const &RootFS, [[maybe_unused]] std::vector<std::string> const &args, std::vector<std::string> const &ParsedArgs, char **const envp = nullptr, FEXCore::Config::Value<std::string> *AdditionalEnvp = nullptr) :
     Args {args} {
 
@@ -297,8 +296,8 @@ class ELFCodeLoader2 final : public FEXCore::CodeLoader {
     }
   }
 
-  void FreeSections() {
-    Sections.clear();
+  std::vector<LoadedSection> PullSections() {
+    return std::move(Sections);
   }
 
   virtual uint64_t StackSize() const override { return STACK_SIZE; }
@@ -652,4 +651,6 @@ class ELFCodeLoader2 final : public FEXCore::CodeLoader {
   uint64_t BaseOffset{};
   FEX_CONFIG_OPT(AdditionalArguments, ADDITIONALARGUMENTS);
 
+  private:
+    std::vector<LoadedSection> Sections;
 };

--- a/Source/Tests/FEXLoader.cpp
+++ b/Source/Tests/FEXLoader.cpp
@@ -196,7 +196,7 @@ bool IsInterpreterInstalled() {
 }
 
 int main(int argc, char **argv, char **const envp) {
-  FHU::ScopedSignalMask sm;
+  FHU::ScopedSignalHostDefer sm;
 
   const bool IsInterpreter = RanAsInterpreter(argv[0]);
 

--- a/Source/Tests/FEXLoader.cpp
+++ b/Source/Tests/FEXLoader.cpp
@@ -195,308 +195,332 @@ bool IsInterpreterInstalled() {
          std::filesystem::exists("/proc/sys/fs/binfmt_misc/FEX-x86_64", ec));
 }
 
+namespace {
+  static FEXCore::Context::Context *CTX = nullptr;
+  static FEXCore::Context::ExitReason ShutdownReason = FEXCore::Context::ExitReason::EXIT_SHUTDOWN;
+  static std::vector<ELFCodeLoader2::LoadedSection> Sections;
+
+  static std::unique_ptr<FEX::HLE::SyscallHandler> SyscallHandler;
+  static std::unique_ptr<FEX::HLE::SignalDelegator> SignalDelegation;
+  static std::string ProgramName;
+
+  static FEXCore::Allocator::PtrCache *Base48Bit;
+}
+
 int main(int argc, char **argv, char **const envp) {
-  const bool IsInterpreter = RanAsInterpreter(argv[0]);
+  // Initialize
+  {
+    FHU::ScopedSignalMask sm;
+    const bool IsInterpreter = RanAsInterpreter(argv[0]);
 
-  ExecutedWithFD = getauxval(AT_EXECFD) != 0;
+    ExecutedWithFD = getauxval(AT_EXECFD) != 0;
 
-  LogMan::Throw::InstallHandler(AssertHandler);
-  LogMan::Msg::InstallHandler(MsgHandler);
+    LogMan::Throw::InstallHandler(AssertHandler);
+    LogMan::Msg::InstallHandler(MsgHandler);
 
-  auto Program = FEX::Config::LoadConfig(
-    IsInterpreter,
-    true,
-    argc, argv, envp
-  );
+    auto [Program, _ProgramName] = FEX::Config::LoadConfig(
+      IsInterpreter,
+      true,
+      argc, argv, envp
+    );
 
-  if (Program.first.empty()) {
-    // Early exit if we weren't passed an argument
-    return 0;
-  }
+    ProgramName = std::move(_ProgramName);
 
-  auto Args = FEX::ArgLoader::Get();
-  auto ParsedArgs = FEX::ArgLoader::GetParsedArgs();
-
-  // Reload the meta layer
-  FEXCore::Config::ReloadMetaLayer();
-  FEXCore::Config::Set(FEXCore::Config::CONFIG_IS_INTERPRETER, IsInterpreter ? "1" : "0");
-  FEXCore::Config::Set(FEXCore::Config::CONFIG_INTERPRETER_INSTALLED, IsInterpreterInstalled() ? "1" : "0");
-
-  // Early check for process stall
-  // Doesn't use CONFIG_ROOTFS and we don't want it to spin up a squashfs instance
-  FEX_CONFIG_OPT(StallProcess, STALLPROCESS);
-  if (StallProcess) {
-    while (1) {
-      // Stall this process out forever
-      select(0, nullptr, nullptr, nullptr, nullptr);
+    if (Program.empty()) {
+      // Early exit if we weren't passed an argument
+      return 0;
     }
+
+    auto Args = FEX::ArgLoader::Get();
+    auto ParsedArgs = FEX::ArgLoader::GetParsedArgs();
+
+    // Reload the meta layer
+    FEXCore::Config::ReloadMetaLayer();
+    FEXCore::Config::Set(FEXCore::Config::CONFIG_IS_INTERPRETER, IsInterpreter ? "1" : "0");
+    FEXCore::Config::Set(FEXCore::Config::CONFIG_INTERPRETER_INSTALLED, IsInterpreterInstalled() ? "1" : "0");
+
+    // These need config to be initialized
+    FEX_CONFIG_OPT(SilentLog, SILENTLOG);
+    FEX_CONFIG_OPT(OutputLog, OUTPUTLOG);
+    FEX_CONFIG_OPT(LDPath, ROOTFS);
+    FEX_CONFIG_OPT(Environment, ENV);
+    FEX_CONFIG_OPT(HostEnvironment, HOSTENV);
+    FEX_CONFIG_OPT(StallProcess, STALLPROCESS);
+    FEX_CONFIG_OPT(Use32BitAllocator, FORCE32BITALLOCATOR);
+
+    // Early check for process stall
+    // Doesn't use CONFIG_ROOTFS and we don't want it to spin up a squashfs instance
+    if (StallProcess) {
+      while (1) {
+        // Stall this process out forever
+        select(0, nullptr, nullptr, nullptr, nullptr);
+      }
+    }
+
+    // Ensure FEXServer is setup before config options try to pull CONFIG_ROOTFS
+    if (!FEXServerClient::SetupClient(argv[0])) {
+      LogMan::Msg::EFmt("FEXServerClient: Failure to setup client");
+      return -1;
+    }
+
+    ::SilentLog = SilentLog();
+
+    if (::SilentLog) {
+      LogMan::Throw::UnInstallHandlers();
+      LogMan::Msg::UnInstallHandlers();
+    }
+    else {
+      auto LogFile = OutputLog();
+      // If stderr or stdout then we need to dup the FD
+      // In some cases some applications will close stderr and stdout
+      // then redirect the FD to either a log OR some cases just not use
+      // stderr/stdout and the FD will be reused for regular FD ops.
+      //
+      // We want to maintain the original output location otherwise we
+      // can run in to problems of writing to some file
+      if (LogFile == "stderr") {
+        OutputFD = dup(STDERR_FILENO);
+      }
+      else if (LogFile == "stdout") {
+        OutputFD = dup(STDOUT_FILENO);
+      }
+      else if (LogFile == "server") {
+        LogMan::Throw::UnInstallHandlers();
+        LogMan::Msg::UnInstallHandlers();
+
+        FEXServerLogging::FEXServerFD = FEXServerClient::RequestLogFD(FEXServerClient::GetServerFD());
+        if (FEXServerLogging::FEXServerFD != -1) {
+          LogMan::Throw::InstallHandler(FEXServerLogging::AssertHandler);
+          LogMan::Msg::InstallHandler(FEXServerLogging::MsgHandler);
+        }
+      }
+      else if (!LogFile.empty()) {
+        OutputFD = open(LogFile.c_str(), O_CREAT | O_CLOEXEC | O_WRONLY);
+      }
+    }
+
+    FEXCore::Telemetry::Initialize();
+
+    RootFSRedirect(&Program, LDPath());
+    InterpreterHandler(&Program, LDPath(), &Args);
+
+    std::error_code ec{};
+    if (!std::filesystem::exists(Program, ec)) {
+      // Early exit if the program passed in doesn't exist
+      // Will prevent a crash later
+      fmt::print(stderr, "{}: command not found\n", Program);
+      return -ENOEXEC;
+    }
+
+    uint32_t KernelVersion = FEX::HLE::SyscallHandler::CalculateHostKernelVersion();
+    if (KernelVersion < FEX::HLE::SyscallHandler::KernelVersion(4, 17)) {
+      // We require 4.17 minimum for MAP_FIXED_NOREPLACE
+      LogMan::Msg::EFmt("FEXLoader requires kernel 4.17 minimum. Expect problems.");
+    }
+
+    // Before we go any further, set all of our host environment variables that the config has provided
+    for (auto &HostEnv : HostEnvironment.All()) {
+      // We are going to keep these alive in memory.
+      // No need to split the string with setenv
+      putenv(HostEnv.data());
+    }
+
+    ELFCodeLoader2 Loader{Program, LDPath(), Args, ParsedArgs, envp, &Environment};
+    //FEX::HarnessHelper::ELFCodeLoader Loader{Program, LDPath(), Args, ParsedArgs, envp, &Environment};
+
+    if (!Loader.ELFWasLoaded()) {
+      // Loader couldn't load this program for some reason
+      fmt::print(stderr, "Invalid or Unsupported elf file.\n");
+  #ifdef _M_ARM_64
+      fmt::print(stderr, "This is likely due to a misconfigured x86-64 RootFS\n");
+      fmt::print(stderr, "Current RootFS path set to '{}'\n", LDPath());
+      std::error_code ec;
+      if (LDPath().empty() ||
+          std::filesystem::exists(LDPath(), ec) == false) {
+        fmt::print(stderr, "RootFS path doesn't exist. This is required on AArch64 hosts\n");
+        fmt::print(stderr, "Use FEXRootFSFetcher to download a RootFS\n");
+      }
+  #endif
+      return -ENOEXEC;
+    }
+
+    Sections = Loader.PullSections();
+
+    FEXCore::Config::Set(FEXCore::Config::CONFIG_APP_FILENAME, std::filesystem::canonical(Program).string());
+    FEXCore::Config::Set(FEXCore::Config::CONFIG_IS64BIT_MODE, Loader.Is64BitMode() ? "1" : "0");
+    
+    std::unique_ptr<FEX::HLE::MemAllocator> Allocator;
+
+    if (Loader.Is64BitMode()) {
+      // Destroy the 48th bit if it exists
+      Base48Bit = FEXCore::Allocator::Steal48BitVA();
+    } else {
+      if (KernelVersion < FEX::HLE::SyscallHandler::KernelVersion(4, 17)) {
+        Use32BitAllocator = true;
+      }
+
+      // Setup our userspace allocator
+      if (!Use32BitAllocator &&
+          KernelVersion >= FEX::HLE::SyscallHandler::KernelVersion(4, 17)) {
+        FEXCore::Allocator::SetupHooks();
+      }
+
+      if (Use32BitAllocator) {
+        Allocator = FEX::HLE::Create32BitAllocator();
+      }
+      else {
+        Allocator = FEX::HLE::CreatePassthroughAllocator();
+      }
+    }
+
+    // System allocator is now system allocator or FEX
+    FEXCore::Context::InitializeStaticTables(Loader.Is64BitMode() ? FEXCore::Context::MODE_64BIT : FEXCore::Context::MODE_32BIT);
+
+    CTX = FEXCore::Context::CreateNewContext();
+    FEXCore::Context::InitializeContext(CTX);
+
+    SignalDelegation = std::make_unique<FEX::HLE::SignalDelegator>();
+
+    SignalDelegation->RegisterFrontendHostSignalHandler(SIGILL, [](FEXCore::Core::InternalThreadState *Thread, int Signal, void *info, void *ucontext) -> bool {
+      ucontext_t* _context = (ucontext_t*)ucontext;
+      auto &mcontext = _context->uc_mcontext;
+      uint64_t PC{};
+  #ifdef _M_ARM_64
+      PC = mcontext.pc;
+  #else
+      PC = mcontext.gregs[REG_RIP];
+  #endif
+      if (PC == reinterpret_cast<uint64_t>(&FEXCore::Assert::ForcedAssert)) {
+        // This is a host side assert. Don't deliver this to the guest
+        // We want to actually break here
+        SignalDelegation->UninstallHostHandler(Signal);
+        return true;
+      }
+      return false;
+    }, true);
+
+    SyscallHandler = Loader.Is64BitMode() ? FEX::HLE::x64::CreateHandler(CTX, SignalDelegation.get())
+                                              : FEX::HLE::x32::CreateHandler(CTX, SignalDelegation.get(), std::move(Allocator));
+
+    auto Mapper = std::bind_front(&FEX::HLE::SyscallHandler::GuestMmap, SyscallHandler.get());
+    auto Unmapper = std::bind_front(&FEX::HLE::SyscallHandler::GuestMunmap, SyscallHandler.get());
+
+    if (!Loader.MapMemory(Mapper, Unmapper)) {
+      // failed to map
+      LogMan::Msg::EFmt("Failed to map %d-bit elf file.", Loader.Is64BitMode() ? 64 : 32);
+      return -ENOEXEC;
+    }
+
+    SyscallHandler->SetCodeLoader(&Loader);
+
+    auto BRKInfo = Loader.GetBRKInfo();
+
+    SyscallHandler->DefaultProgramBreak(BRKInfo.Base, BRKInfo.Size);
+
+    FEXCore::Context::SetSignalDelegator(CTX, SignalDelegation.get());
+    FEXCore::Context::SetSyscallHandler(CTX, SyscallHandler.get());
+    FEXCore::Context::InitCore(CTX, Loader.DefaultRIP(), Loader.GetStackPointer());
+
+    // There might already be an exit handler, leave it installed
+    if(!FEXCore::Context::GetExitHandler(CTX)) {
+      FEXCore::Context::SetExitHandler(CTX, [&](uint64_t thread, FEXCore::Context::ExitReason reason) {
+        if (reason != FEXCore::Context::ExitReason::EXIT_DEBUG) {
+          ShutdownReason = reason;
+          FEXCore::Context::Stop(CTX);
+        }
+      });
+    }
+
+    FEXCore::Context::SetAOTIRLoader(CTX, [](const std::string &fileid) -> int {
+      auto filepath = std::filesystem::path(FEXCore::Config::GetDataDirectory()) / "aotir" / (fileid + ".aotir");
+
+      return open(filepath.c_str(), O_RDONLY);
+    });
+
+    FEXCore::Context::SetAOTIRWriter(CTX, [](const std::string& fileid) -> std::unique_ptr<std::ofstream> {
+      auto filepath = std::filesystem::path(FEXCore::Config::GetDataDirectory()) / "aotir" / (fileid + ".aotir.tmp");
+      auto AOTWrite = std::make_unique<std::ofstream>(filepath, std::ios::out | std::ios::binary);
+      if (*AOTWrite) {
+        std::filesystem::resize_file(filepath, 0);
+        AOTWrite->seekp(0);
+        LogMan::Msg::IFmt("AOTIR: Storing {}", fileid);
+      } else {
+        LogMan::Msg::IFmt("AOTIR: Failed to store {}", fileid);
+      }
+      return AOTWrite;
+    });
+
+    FEXCore::Context::SetAOTIRRenamer(CTX, [](const std::string& fileid) -> void {
+      auto TmpFilepath = std::filesystem::path(FEXCore::Config::GetDataDirectory()) / "aotir" / (fileid + ".aotir.tmp");
+      auto NewFilepath = std::filesystem::path(FEXCore::Config::GetDataDirectory()) / "aotir" / (fileid + ".aotir");
+
+      // Rename the temporary file to atomically update the file
+      std::filesystem::rename(TmpFilepath, NewFilepath);
+    });
   }
 
-  // Ensure FEXServer is setup before config options try to pull CONFIG_ROOTFS
-  if (!FEXServerClient::SetupClient(argv[0])) {
-    LogMan::Msg::EFmt("FEXServerClient: Failure to setup client");
-    return -1;
-  }
-
-  FEX_CONFIG_OPT(SilentLog, SILENTLOG);
   FEX_CONFIG_OPT(AOTIRCapture, AOTIRCAPTURE);
   FEX_CONFIG_OPT(AOTIRGenerate, AOTIRGENERATE);
   FEX_CONFIG_OPT(AOTIRLoad, AOTIRLOAD);
-  FEX_CONFIG_OPT(OutputLog, OUTPUTLOG);
-  FEX_CONFIG_OPT(LDPath, ROOTFS);
-  FEX_CONFIG_OPT(Environment, ENV);
-  FEX_CONFIG_OPT(HostEnvironment, HOSTENV);
-  ::SilentLog = SilentLog();
-
-  if (::SilentLog) {
-    LogMan::Throw::UnInstallHandlers();
-    LogMan::Msg::UnInstallHandlers();
-  }
-  else {
-    auto LogFile = OutputLog();
-    // If stderr or stdout then we need to dup the FD
-    // In some cases some applications will close stderr and stdout
-    // then redirect the FD to either a log OR some cases just not use
-    // stderr/stdout and the FD will be reused for regular FD ops.
-    //
-    // We want to maintain the original output location otherwise we
-    // can run in to problems of writing to some file
-    if (LogFile == "stderr") {
-      OutputFD = dup(STDERR_FILENO);
-    }
-    else if (LogFile == "stdout") {
-      OutputFD = dup(STDOUT_FILENO);
-    }
-    else if (LogFile == "server") {
-      LogMan::Throw::UnInstallHandlers();
-      LogMan::Msg::UnInstallHandlers();
-
-      FEXServerLogging::FEXServerFD = FEXServerClient::RequestLogFD(FEXServerClient::GetServerFD());
-      if (FEXServerLogging::FEXServerFD != -1) {
-        LogMan::Throw::InstallHandler(FEXServerLogging::AssertHandler);
-        LogMan::Msg::InstallHandler(FEXServerLogging::MsgHandler);
-      }
-    }
-    else if (!LogFile.empty()) {
-      OutputFD = open(LogFile.c_str(), O_CREAT | O_CLOEXEC | O_WRONLY);
-    }
-  }
-
-  FEXCore::Telemetry::Initialize();
-
-  RootFSRedirect(&Program.first, LDPath());
-  InterpreterHandler(&Program.first, LDPath(), &Args);
-
-  std::error_code ec{};
-  if (!std::filesystem::exists(Program.first, ec)) {
-    // Early exit if the program passed in doesn't exist
-    // Will prevent a crash later
-    fmt::print(stderr, "{}: command not found\n", Program.first);
-    return -ENOEXEC;
-  }
-
-  uint32_t KernelVersion = FEX::HLE::SyscallHandler::CalculateHostKernelVersion();
-  if (KernelVersion < FEX::HLE::SyscallHandler::KernelVersion(4, 17)) {
-    // We require 4.17 minimum for MAP_FIXED_NOREPLACE
-    LogMan::Msg::EFmt("FEXLoader requires kernel 4.17 minimum. Expect problems.");
-  }
-
-  // Before we go any further, set all of our host environment variables that the config has provided
-  for (auto &HostEnv : HostEnvironment.All()) {
-    // We are going to keep these alive in memory.
-    // No need to split the string with setenv
-    putenv(HostEnv.data());
-  }
-
-  ELFCodeLoader2 Loader{Program.first, LDPath(), Args, ParsedArgs, envp, &Environment};
-  //FEX::HarnessHelper::ELFCodeLoader Loader{Program.first, LDPath(), Args, ParsedArgs, envp, &Environment};
-
-  if (!Loader.ELFWasLoaded()) {
-    // Loader couldn't load this program for some reason
-    fmt::print(stderr, "Invalid or Unsupported elf file.\n");
-#ifdef _M_ARM_64
-    fmt::print(stderr, "This is likely due to a misconfigured x86-64 RootFS\n");
-    fmt::print(stderr, "Current RootFS path set to '{}'\n", LDPath());
-    std::error_code ec;
-    if (LDPath().empty() ||
-        std::filesystem::exists(LDPath(), ec) == false) {
-      fmt::print(stderr, "RootFS path doesn't exist. This is required on AArch64 hosts\n");
-      fmt::print(stderr, "Use FEXRootFSFetcher to download a RootFS\n");
-    }
-#endif
-    return -ENOEXEC;
-  }
-
-  FEXCore::Config::Set(FEXCore::Config::CONFIG_APP_FILENAME, std::filesystem::canonical(Program.first).string());
-  FEXCore::Config::Set(FEXCore::Config::CONFIG_IS64BIT_MODE, Loader.Is64BitMode() ? "1" : "0");
-
-  std::unique_ptr<FEX::HLE::MemAllocator> Allocator;
-  FEXCore::Allocator::PtrCache *Base48Bit{};
-
-  if (Loader.Is64BitMode()) {
-    // Destroy the 48th bit if it exists
-    Base48Bit = FEXCore::Allocator::Steal48BitVA();
-  } else {
-    FEX_CONFIG_OPT(Use32BitAllocator, FORCE32BITALLOCATOR);
-    if (KernelVersion < FEX::HLE::SyscallHandler::KernelVersion(4, 17)) {
-      Use32BitAllocator = true;
-    }
-
-    // Setup our userspace allocator
-    if (!Use32BitAllocator &&
-        KernelVersion >= FEX::HLE::SyscallHandler::KernelVersion(4, 17)) {
-      FEXCore::Allocator::SetupHooks();
-    }
-
-    if (Use32BitAllocator) {
-      Allocator = FEX::HLE::Create32BitAllocator();
-    }
-    else {
-      Allocator = FEX::HLE::CreatePassthroughAllocator();
-    }
-  }
-
-  // System allocator is now system allocator or FEX
-  FEXCore::Context::InitializeStaticTables(Loader.Is64BitMode() ? FEXCore::Context::MODE_64BIT : FEXCore::Context::MODE_32BIT);
-
-  auto CTX = FEXCore::Context::CreateNewContext();
-  FEXCore::Context::InitializeContext(CTX);
-
-  auto SignalDelegation = std::make_unique<FEX::HLE::SignalDelegator>();
-
-  SignalDelegation->RegisterFrontendHostSignalHandler(SIGILL, [&SignalDelegation](FEXCore::Core::InternalThreadState *Thread, int Signal, void *info, void *ucontext) -> bool {
-    ucontext_t* _context = (ucontext_t*)ucontext;
-    auto &mcontext = _context->uc_mcontext;
-    uint64_t PC{};
-#ifdef _M_ARM_64
-    PC = mcontext.pc;
-#else
-    PC = mcontext.gregs[REG_RIP];
-#endif
-    if (PC == reinterpret_cast<uint64_t>(&FEXCore::Assert::ForcedAssert)) {
-      // This is a host side assert. Don't deliver this to the guest
-      // We want to actually break here
-      SignalDelegation->UninstallHostHandler(Signal);
-      return true;
-    }
-    return false;
-  }, true);
-
-  auto SyscallHandler = Loader.Is64BitMode() ? FEX::HLE::x64::CreateHandler(CTX, SignalDelegation.get())
-                                             : FEX::HLE::x32::CreateHandler(CTX, SignalDelegation.get(), std::move(Allocator));
-
-  auto Mapper = std::bind_front(&FEX::HLE::SyscallHandler::GuestMmap, SyscallHandler.get());
-  auto Unmapper = std::bind_front(&FEX::HLE::SyscallHandler::GuestMunmap, SyscallHandler.get());
-
-  if (!Loader.MapMemory(Mapper, Unmapper)) {
-    // failed to map
-    LogMan::Msg::EFmt("Failed to map %d-bit elf file.", Loader.Is64BitMode() ? 64 : 32);
-    return -ENOEXEC;
-  }
-
-  SyscallHandler->SetCodeLoader(&Loader);
-
-  auto BRKInfo = Loader.GetBRKInfo();
-
-  SyscallHandler->DefaultProgramBreak(BRKInfo.Base, BRKInfo.Size);
-
-  FEXCore::Context::SetSignalDelegator(CTX, SignalDelegation.get());
-  FEXCore::Context::SetSyscallHandler(CTX, SyscallHandler.get());
-  FEXCore::Context::InitCore(CTX, Loader.DefaultRIP(), Loader.GetStackPointer());
-
-  FEXCore::Context::ExitReason ShutdownReason = FEXCore::Context::ExitReason::EXIT_SHUTDOWN;
-
-  // There might already be an exit handler, leave it installed
-  if(!FEXCore::Context::GetExitHandler(CTX)) {
-    FEXCore::Context::SetExitHandler(CTX, [&](uint64_t thread, FEXCore::Context::ExitReason reason) {
-      if (reason != FEXCore::Context::ExitReason::EXIT_DEBUG) {
-        ShutdownReason = reason;
-        FEXCore::Context::Stop(CTX);
-      }
-    });
-  }
 
   if (AOTIRLoad() || AOTIRCapture() || AOTIRGenerate()) {
     LogMan::Msg::IFmt("Warning: AOTIR is experimental, and might lead to crashes. "
                       "Capture doesn't work with programs that fork.");
   }
 
-  FEXCore::Context::SetAOTIRLoader(CTX, [](const std::string &fileid) -> int {
-    auto filepath = std::filesystem::path(FEXCore::Config::GetDataDirectory()) / "aotir" / (fileid + ".aotir");
-
-    return open(filepath.c_str(), O_RDONLY);
-  });
-
-  FEXCore::Context::SetAOTIRWriter(CTX, [](const std::string& fileid) -> std::unique_ptr<std::ofstream> {
-    auto filepath = std::filesystem::path(FEXCore::Config::GetDataDirectory()) / "aotir" / (fileid + ".aotir.tmp");
-    auto AOTWrite = std::make_unique<std::ofstream>(filepath, std::ios::out | std::ios::binary);
-    if (*AOTWrite) {
-      std::filesystem::resize_file(filepath, 0);
-      AOTWrite->seekp(0);
-      LogMan::Msg::IFmt("AOTIR: Storing {}", fileid);
-    } else {
-      LogMan::Msg::IFmt("AOTIR: Failed to store {}", fileid);
-    }
-    return AOTWrite;
-  });
-
-  FEXCore::Context::SetAOTIRRenamer(CTX, [](const std::string& fileid) -> void {
-    auto TmpFilepath = std::filesystem::path(FEXCore::Config::GetDataDirectory()) / "aotir" / (fileid + ".aotir.tmp");
-    auto NewFilepath = std::filesystem::path(FEXCore::Config::GetDataDirectory()) / "aotir" / (fileid + ".aotir");
-
-    // Rename the temporary file to atomically update the file
-    std::filesystem::rename(TmpFilepath, NewFilepath);
-  });
-
   if (AOTIRGenerate()) {
-    for(auto &Section: Loader.Sections) {
+    for(const auto &Section: Sections) {
       FEX::AOT::AOTGenSection(CTX, Section);
     }
   } else {
     FEXCore::Context::RunUntilExit(CTX);
   }
 
-  std::filesystem::create_directories(std::filesystem::path(FEXCore::Config::GetDataDirectory()) / "aotir", ec);
-  if (!ec) {
-    FEXCore::Context::WriteFilesWithCode(CTX, [](const std::string& fileid, const std::string& filename) {
-      auto filepath = std::filesystem::path(FEXCore::Config::GetDataDirectory()) / "aotir" / (fileid + ".path");
-      int fd = open(filepath.c_str(), O_CREAT | O_EXCL | O_WRONLY, 0644);
-      if (fd != -1) {
-        write(fd, filename.c_str(), filename.size());
-        close(fd);
-      }
-    });
-  }
+  // Teardown
+  {
+    FHU::ScopedSignalMask sm;
+    std::error_code ec;
 
-  if (AOTIRCapture() || AOTIRGenerate()) {
-    FEXCore::Context::FinalizeAOTIRCache(CTX);
-    LogMan::Msg::IFmt("AOTIR Cache Stored");
-  }
+    std::filesystem::create_directories(std::filesystem::path(FEXCore::Config::GetDataDirectory()) / "aotir", ec);
+    if (!ec) {
+      FEXCore::Context::WriteFilesWithCode(CTX, [](const std::string& fileid, const std::string& filename) {
+        auto filepath = std::filesystem::path(FEXCore::Config::GetDataDirectory()) / "aotir" / (fileid + ".path");
+        int fd = open(filepath.c_str(), O_CREAT | O_EXCL | O_WRONLY, 0644);
+        if (fd != -1) {
+          write(fd, filename.c_str(), filename.size());
+          close(fd);
+        }
+      });
+    }
 
-  auto ProgramStatus = FEXCore::Context::GetProgramStatus(CTX);
+    if (AOTIRCapture() || AOTIRGenerate()) {
+      FEXCore::Context::FinalizeAOTIRCache(CTX);
+      LogMan::Msg::IFmt("AOTIR Cache Stored");
+    }
 
-  SyscallHandler.reset();
-  SignalDelegation.reset();
-  FEXCore::Context::DestroyContext(CTX);
+    auto ProgramStatus = FEXCore::Context::GetProgramStatus(CTX);
 
-  FEXCore::Context::ShutdownStaticTables();
-  FEXCore::Threads::Shutdown();
+    SyscallHandler.reset();
+    SignalDelegation.reset();
+    FEXCore::Context::DestroyContext(CTX);
 
-  Loader.FreeSections();
+    FEXCore::Context::ShutdownStaticTables();
+    FEXCore::Threads::Shutdown();
 
-  FEXCore::Config::Shutdown();
+    FEXCore::Config::Shutdown();
 
-  LogMan::Throw::UnInstallHandlers();
-  LogMan::Msg::UnInstallHandlers();
+    LogMan::Throw::UnInstallHandlers();
+    LogMan::Msg::UnInstallHandlers();
 
-  FEXCore::Allocator::ClearHooks();
-  FEXCore::Allocator::ReclaimMemoryRegion(Base48Bit);
-  // Allocator is now original system allocator
-  FEXCore::Telemetry::Shutdown(Program.second);
-  if (ShutdownReason == FEXCore::Context::ExitReason::EXIT_SHUTDOWN) {
-    return ProgramStatus;
-  }
-  else {
-    return -64 | ShutdownReason;
+    FEXCore::Allocator::ClearHooks();
+    FEXCore::Allocator::ReclaimMemoryRegion(Base48Bit);
+    // Allocator is now original system allocator
+    FEXCore::Telemetry::Shutdown(ProgramName);
+    if (ShutdownReason == FEXCore::Context::ExitReason::EXIT_SHUTDOWN) {
+      return ProgramStatus;
+    }
+    else {
+      return -64 | ShutdownReason;
+    }
   }
 }

--- a/Source/Tests/FEXLoader.cpp
+++ b/Source/Tests/FEXLoader.cpp
@@ -196,7 +196,7 @@ bool IsInterpreterInstalled() {
 }
 
 int main(int argc, char **argv, char **const envp) {
-  FHU::ScopedSignalHostDefer sm;
+  FHU::ScopedSignalHostDefer hd;
 
   const bool IsInterpreter = RanAsInterpreter(argv[0]);
 

--- a/Source/Tests/IRLoader.cpp
+++ b/Source/Tests/IRLoader.cpp
@@ -162,13 +162,13 @@ class DummySyscallHandler: public FEXCore::HLE::SyscallHandler {
   // These are no-ops implementations of the SyscallHandler API
   std::shared_mutex StubMutex;
   FEXCore::HLE::AOTIRCacheEntryLookupResult LookupAOTIRCacheEntry(uint64_t GuestAddr) override {
-    return {0, 0, FHU::ScopedSignalCheckWithSharedLock {StubMutex}};
+    return {0, 0, FHU::ScopedSignalMaskWithSharedLock {StubMutex}};
   }
 };
 
 int main(int argc, char **argv, char **const envp)
 {
-  FHU::ScopedSignalMask sm;
+  FHU::ScopedSignalHostDefer sm;
 
   LogMan::Throw::InstallHandler(AssertHandler);
   LogMan::Msg::InstallHandler(MsgHandler);

--- a/Source/Tests/IRLoader.cpp
+++ b/Source/Tests/IRLoader.cpp
@@ -19,6 +19,8 @@ $end_info$
 #include <FEXCore/HLE/SyscallHandler.h>
 #include <FEXCore/IR/IREmitter.h>
 
+#include <FEXHeaderUtils/ScopedSignalMask.h>
+
 #include <functional>
 #include <memory>
 #include <stdint.h>
@@ -166,6 +168,8 @@ class DummySyscallHandler: public FEXCore::HLE::SyscallHandler {
 
 int main(int argc, char **argv, char **const envp)
 {
+  FHU::ScopedSignalMask sm;
+
   LogMan::Throw::InstallHandler(AssertHandler);
   LogMan::Msg::InstallHandler(MsgHandler);
 

--- a/Source/Tests/IRLoader.cpp
+++ b/Source/Tests/IRLoader.cpp
@@ -168,7 +168,7 @@ class DummySyscallHandler: public FEXCore::HLE::SyscallHandler {
 
 int main(int argc, char **argv, char **const envp)
 {
-  FHU::ScopedSignalHostDefer sm;
+  FHU::ScopedSignalHostDefer hd;
 
   LogMan::Throw::InstallHandler(AssertHandler);
   LogMan::Msg::InstallHandler(MsgHandler);

--- a/Source/Tests/IRLoader.cpp
+++ b/Source/Tests/IRLoader.cpp
@@ -161,7 +161,7 @@ class DummySyscallHandler: public FEXCore::HLE::SyscallHandler {
   // These are no-ops implementations of the SyscallHandler API
   std::shared_mutex StubMutex;
   FEXCore::HLE::AOTIRCacheEntryLookupResult LookupAOTIRCacheEntry(uint64_t GuestAddr) override {
-    return {0, 0, FHU::ScopedSignalMaskWithSharedLock {StubMutex}};
+    return {0, 0, FHU::ScopedSignalCheckWithSharedLock {StubMutex}};
   }
 };
 

--- a/Source/Tests/LinuxSyscalls/FileManagement.cpp
+++ b/Source/Tests/LinuxSyscalls/FileManagement.cpp
@@ -414,7 +414,7 @@ uint64_t FileManager::Open(const char *pathname, [[maybe_unused]] int flags, [[m
   }
 
   if (fd != -1) {
-    FHU::ScopedSignalMaskWithMutex lk(FDLock);
+    FHU::ScopedSignalCheckWithLockGuard lk(FDLock);
     FDToNameMap.insert_or_assign(fd, SelfPath);
   }
 
@@ -423,7 +423,7 @@ uint64_t FileManager::Open(const char *pathname, [[maybe_unused]] int flags, [[m
 
 uint64_t FileManager::Close(int fd) {
   {
-    FHU::ScopedSignalMaskWithMutex lk(FDLock);
+    FHU::ScopedSignalCheckWithLockGuard lk(FDLock);
     FDToNameMap.erase(fd);
   }
   return ::close(fd);
@@ -437,7 +437,7 @@ uint64_t FileManager::CloseRange(unsigned int first, unsigned int last, unsigned
   if (!(flags & CLOSE_RANGE_CLOEXEC)) {
     // If the flag was set then it doesn't actually close the FDs
     // Just sets the flag on a range
-    FHU::ScopedSignalMaskWithMutex lk(FDLock);
+    FHU::ScopedSignalCheckWithLockGuard lk(FDLock);
     auto Lower = FDToNameMap.lower_bound(first);
     auto Upper = FDToNameMap.upper_bound(last);
     // We remove from first to last inclusive
@@ -640,7 +640,7 @@ uint64_t FileManager::Openat([[maybe_unused]] int dirfs, const char *pathname, i
   }
 
   if (fd != -1) {
-    FHU::ScopedSignalMaskWithMutex lk(FDLock);
+    FHU::ScopedSignalCheckWithLockGuard lk(FDLock);
     FDToNameMap.insert_or_assign(fd, SelfPath);
   }
 
@@ -665,7 +665,7 @@ uint64_t FileManager::Openat2(int dirfs, const char *pathname, FEX::HLE::open_ho
   }
 
   if (fd != -1) {
-    FHU::ScopedSignalMaskWithMutex lk(FDLock);
+    FHU::ScopedSignalCheckWithLockGuard lk(FDLock);
     FDToNameMap.insert_or_assign(fd, SelfPath);
   }
 
@@ -738,7 +738,7 @@ uint64_t FileManager::NewFSStatAt64(int dirfd, const char *pathname, struct stat
 }
 
 std::string *FileManager::FindFDName(int fd) {
-  FHU::ScopedSignalMaskWithMutex lk(FDLock);
+  FHU::ScopedSignalCheckWithLockGuard lk(FDLock);
   auto it = FDToNameMap.find(fd);
   if (it == FDToNameMap.end()) {
     return nullptr;

--- a/Source/Tests/LinuxSyscalls/FileManagement.cpp
+++ b/Source/Tests/LinuxSyscalls/FileManagement.cpp
@@ -414,7 +414,7 @@ uint64_t FileManager::Open(const char *pathname, [[maybe_unused]] int flags, [[m
   }
 
   if (fd != -1) {
-    FHU::ScopedSignalCheckWithLockGuard lk(FDLock);
+    FHU::ScopedSignalMaskWithLockGuard lk(FDLock);
     FDToNameMap.insert_or_assign(fd, SelfPath);
   }
 
@@ -423,7 +423,7 @@ uint64_t FileManager::Open(const char *pathname, [[maybe_unused]] int flags, [[m
 
 uint64_t FileManager::Close(int fd) {
   {
-    FHU::ScopedSignalCheckWithLockGuard lk(FDLock);
+    FHU::ScopedSignalMaskWithLockGuard lk(FDLock);
     FDToNameMap.erase(fd);
   }
   return ::close(fd);
@@ -437,7 +437,7 @@ uint64_t FileManager::CloseRange(unsigned int first, unsigned int last, unsigned
   if (!(flags & CLOSE_RANGE_CLOEXEC)) {
     // If the flag was set then it doesn't actually close the FDs
     // Just sets the flag on a range
-    FHU::ScopedSignalCheckWithLockGuard lk(FDLock);
+    FHU::ScopedSignalMaskWithLockGuard lk(FDLock);
     auto Lower = FDToNameMap.lower_bound(first);
     auto Upper = FDToNameMap.upper_bound(last);
     // We remove from first to last inclusive
@@ -640,7 +640,7 @@ uint64_t FileManager::Openat([[maybe_unused]] int dirfs, const char *pathname, i
   }
 
   if (fd != -1) {
-    FHU::ScopedSignalCheckWithLockGuard lk(FDLock);
+    FHU::ScopedSignalMaskWithLockGuard lk(FDLock);
     FDToNameMap.insert_or_assign(fd, SelfPath);
   }
 
@@ -665,7 +665,7 @@ uint64_t FileManager::Openat2(int dirfs, const char *pathname, FEX::HLE::open_ho
   }
 
   if (fd != -1) {
-    FHU::ScopedSignalCheckWithLockGuard lk(FDLock);
+    FHU::ScopedSignalMaskWithLockGuard lk(FDLock);
     FDToNameMap.insert_or_assign(fd, SelfPath);
   }
 
@@ -738,7 +738,7 @@ uint64_t FileManager::NewFSStatAt64(int dirfd, const char *pathname, struct stat
 }
 
 std::string *FileManager::FindFDName(int fd) {
-  FHU::ScopedSignalCheckWithLockGuard lk(FDLock);
+  FHU::ScopedSignalMaskWithLockGuard lk(FDLock);
   auto it = FDToNameMap.find(fd);
   if (it == FDToNameMap.end()) {
     return nullptr;

--- a/Source/Tests/LinuxSyscalls/Syscalls/Thread.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Thread.cpp
@@ -509,8 +509,8 @@ namespace FEX::HLE {
       auto Thread = Frame->Thread;
       Thread->StatusCode = status;
       FEXCore::Context::Stop(Thread->CTX);
-      // This will never be reached
-      std::terminate();
+      // Host Signals are deferred here, thread will get stopped on end of syscall processing
+      return -1;
     });
 
     REGISTER_SYSCALL_IMPL_PASS_FLAGS(prlimit_64, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,

--- a/Source/Tests/LinuxSyscalls/Syscalls/Thread.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Thread.cpp
@@ -300,9 +300,10 @@ namespace FEX::HLE {
       }
 
       Thread->StatusCode = status;
-      FEXCore::Context::StopThread(Thread->CTX, Thread);
+      FEXCore::Context::ExitCurrentThread(Thread);
 
-      return 0;
+      // should never reach here
+      std::terminate();
     });
 
     REGISTER_SYSCALL_IMPL_PASS_FLAGS(kill, SyscallFlags::DEFAULT, [](FEXCore::Core::CpuStateFrame *Frame, pid_t pid, int sig) -> uint64_t {
@@ -509,8 +510,8 @@ namespace FEX::HLE {
       auto Thread = Frame->Thread;
       Thread->StatusCode = status;
       FEXCore::Context::Stop(Thread->CTX);
-      // Host Signals are deferred here, thread will get stopped on end of syscall processing
-      return -1;
+      // This must never be reached
+      std::terminate();
     });
 
     REGISTER_SYSCALL_IMPL_PASS_FLAGS(prlimit_64, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,

--- a/Source/Tests/LinuxSyscalls/SyscallsSMCTracking.cpp
+++ b/Source/Tests/LinuxSyscalls/SyscallsSMCTracking.cpp
@@ -51,7 +51,7 @@ bool SyscallHandler::HandleSegfault(FEXCore::Core::InternalThreadState *Thread, 
   const auto FaultAddress = (uintptr_t)((siginfo_t *)info)->si_addr;
 
   {
-    FHU::ScopedSignalMaskWithSharedLock lk(_SyscallHandler->VMATracking.Mutex);
+    FHU::ScopedSignalCheckWithSharedLock lk(_SyscallHandler->VMATracking.Mutex);
 
     auto VMATracking = &_SyscallHandler->VMATracking;
 
@@ -108,7 +108,7 @@ void SyscallHandler::MarkGuestExecutableRange(uint64_t Start, uint64_t Length) {
       return;
     }
 
-    FHU::ScopedSignalMaskWithSharedLock lk(VMATracking.Mutex);
+    FHU::ScopedSignalCheckWithSharedLock lk(VMATracking.Mutex);
 
     // Find the first mapping at or after the range ends, or ::end().
     // Top points to the address after the end of the range
@@ -163,7 +163,7 @@ void SyscallHandler::MarkGuestExecutableRange(uint64_t Start, uint64_t Length) {
 
 // Used for AOT
 FEXCore::HLE::AOTIRCacheEntryLookupResult SyscallHandler::LookupAOTIRCacheEntry(uint64_t GuestAddr) {
-  FHU::ScopedSignalMaskWithSharedLock lk(_SyscallHandler->VMATracking.Mutex);
+  FHU::ScopedSignalCheckWithSharedLock lk(_SyscallHandler->VMATracking.Mutex);
   auto rv = FEXCore::HLE::AOTIRCacheEntryLookupResult(nullptr, 0, std::move(lk));
 
   // Get the first mapping after GuestAddr, or end
@@ -188,7 +188,7 @@ void SyscallHandler::TrackMmap(uintptr_t Base, uintptr_t Size, int Prot, int Fla
   }
 
   {
-    FHU::ScopedSignalMaskWithUniqueLock lk(_SyscallHandler->VMATracking.Mutex);
+    FHU::ScopedSignalCheckWithUniqueLock lk(_SyscallHandler->VMATracking.Mutex);
 
     static uint64_t AnonSharedId = 1;
 
@@ -232,7 +232,7 @@ void SyscallHandler::TrackMunmap(uintptr_t Base, uintptr_t Size) {
 	Size = FEXCore::AlignUp(Size, FHU::FEX_PAGE_SIZE);
 
   {
-    FHU::ScopedSignalMaskWithUniqueLock lk(_SyscallHandler->VMATracking.Mutex);
+    FHU::ScopedSignalCheckWithUniqueLock lk(_SyscallHandler->VMATracking.Mutex);
 
     VMATracking.ClearUnsafe(CTX, Base, Size);
   }
@@ -246,7 +246,7 @@ void SyscallHandler::TrackMprotect(uintptr_t Base, uintptr_t Size, int Prot) {
 	Size = FEXCore::AlignUp(Size, FHU::FEX_PAGE_SIZE);
 
   {
-    FHU::ScopedSignalMaskWithUniqueLock lk(_SyscallHandler->VMATracking.Mutex);
+    FHU::ScopedSignalCheckWithUniqueLock lk(_SyscallHandler->VMATracking.Mutex);
 
     VMATracking.ChangeUnsafe(Base, Size, VMAProt::fromProt(Prot));
   }
@@ -262,7 +262,7 @@ void SyscallHandler::TrackMremap(uintptr_t OldAddress, size_t OldSize, size_t Ne
 
   {
 
-    FHU::ScopedSignalMaskWithUniqueLock lk(_SyscallHandler->VMATracking.Mutex);
+    FHU::ScopedSignalCheckWithUniqueLock lk(_SyscallHandler->VMATracking.Mutex);
 
     const auto OldVMA = VMATracking.LookupVMAUnsafe(OldAddress);
 
@@ -320,7 +320,7 @@ void SyscallHandler::TrackShmat(int shmid, uintptr_t Base, int shmflg) {
   uint64_t Length = stat.shm_segsz;
 
   {
-    FHU::ScopedSignalMaskWithUniqueLock lk(_SyscallHandler->VMATracking.Mutex);
+    FHU::ScopedSignalCheckWithUniqueLock lk(_SyscallHandler->VMATracking.Mutex);
 
     // TODO
     MRID mrid{SpecialDev::SHM, static_cast<uint64_t>(shmid)};
@@ -340,7 +340,7 @@ void SyscallHandler::TrackShmat(int shmid, uintptr_t Base, int shmflg) {
 }
 
 void SyscallHandler::TrackShmdt(uintptr_t Base) {
-  FHU::ScopedSignalMaskWithUniqueLock lk(_SyscallHandler->VMATracking.Mutex);
+  FHU::ScopedSignalCheckWithUniqueLock lk(_SyscallHandler->VMATracking.Mutex);
 
   auto Length = VMATracking.ClearShmUnsafe(CTX, Base);
 
@@ -353,7 +353,7 @@ void SyscallHandler::TrackShmdt(uintptr_t Base) {
 void SyscallHandler::TrackMadvise(uintptr_t Base, uintptr_t Size, int advice) {
 	Size = FEXCore::AlignUp(Size, FHU::FEX_PAGE_SIZE);
 	{
-		FHU::ScopedSignalMaskWithUniqueLock lk(_SyscallHandler->VMATracking.Mutex);
+		FHU::ScopedSignalCheckWithUniqueLock lk(_SyscallHandler->VMATracking.Mutex);
   	// TODO
 	}
 }

--- a/Source/Tests/LinuxSyscalls/x32/FD.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/FD.cpp
@@ -65,7 +65,7 @@ namespace FEX::HLE::x32 {
     return Result;
   }
 #endif
-  auto fcntlHandler = [](FEXCore::Core::CpuStateFrame *Frame, int fd, int cmd, uint64_t arg) -> uint64_t {
+  auto fcntlHandler = +[](FEXCore::Core::CpuStateFrame *Frame, int fd, int cmd, uint64_t arg) -> uint64_t {
     // fcntl64 struct directly matches the 64bit fcntl op
     // cmd just needs to be fixed up
     // These are redefined to be their non-64bit tagged value on x86-64

--- a/Source/Tests/TestHarnessRunner.cpp
+++ b/Source/Tests/TestHarnessRunner.cpp
@@ -115,7 +115,7 @@ private:
 static bool DidFault = true;
 
 int main(int argc, char **argv, char **const envp) {
-  FHU::ScopedSignalMask sm;
+  FHU::ScopedSignalHostDefer sm;
 
   LogMan::Throw::InstallHandler(AssertHandler);
   LogMan::Msg::InstallHandler(MsgHandler);

--- a/Source/Tests/TestHarnessRunner.cpp
+++ b/Source/Tests/TestHarnessRunner.cpp
@@ -115,7 +115,7 @@ private:
 static bool DidFault = true;
 
 int main(int argc, char **argv, char **const envp) {
-  FHU::ScopedSignalHostDefer sm;
+  FHU::ScopedSignalHostDefer hd;
 
   LogMan::Throw::InstallHandler(AssertHandler);
   LogMan::Msg::InstallHandler(MsgHandler);

--- a/Source/Tests/TestHarnessRunner.cpp
+++ b/Source/Tests/TestHarnessRunner.cpp
@@ -243,9 +243,7 @@ int main(int argc, char **argv, char **const envp) {
       return -ENOEXEC;
     }
 
-    FEX::HLE::SignalDelegator::DeliverThreadHostDeferredSignals();
-    RunAsHost(SignalDelegation, Loader.DefaultRIP(), Loader.GetStackPointer(), &State);
-    FEX::HLE::SignalDelegator::DeferThreadHostSignals();
+    DidFault = !RunAsHost(SignalDelegation, Loader.DefaultRIP(), Loader.GetStackPointer(), &State);
   }
 
   FEXCore::Context::DestroyContext(CTX);

--- a/Source/Tests/TestHarnessRunner/HostRunner.h
+++ b/Source/Tests/TestHarnessRunner/HostRunner.h
@@ -17,4 +17,5 @@ namespace FEX::HLE {
   class SignalDelegator;
 }
 
-void RunAsHost(std::unique_ptr<FEX::HLE::SignalDelegator> &SignalDelegation, uintptr_t InitialRip, uintptr_t StackPointer, FEXCore::Core::CPUState *OutputState);
+// Returns false if abnormally terminated
+bool RunAsHost(std::unique_ptr<FEX::HLE::SignalDelegator> &SignalDelegation, uintptr_t InitialRip, uintptr_t StackPointer, FEXCore::Core::CPUState *OutputState);


### PR DESCRIPTION
### Overview

Implements Deferred Host Signals, and enables it for most of our entry points. See #1715 for more high level details.

#### (a)
`SignalDelegator::AcquireHostDeferredSignals` and `SignalDelegator::ReleaseHostDeferredSignals` are also provided to mark regions where signals should be deferred.

These are used to implement `FHU::ScopedSignalMask`, that marks a scope as requiring Host Deferred Signals.  These scopes must have either signals deferred, or auto deferred.

#### (b)
Nested Host Deferred Signals is added via `SignalDelegator::DeferThreadHostSignals` and `SignalDelegator::DeliverThreadHostDeferredSignals`.

These are used to implement `FHU::ScopedSignalHostDefer`, that marks a scope as having Host Deferred Signals. Any host deferred signals are delivered when the outer scope exists.

#### (c)
`SignalDelegator::EnterAutoHostDefer` and `SignalDelegator::LeaveAutoHostDefer` are also provided to mark regions where signals should be deferred automatically through `AcquireHostDeferredSignals`/`ReleaseHostDeferredSignals`.

These are used to implement `FHU::ScopedSignalAutoHostDefer`, that marks a scope as automatic defer.

#### (d)
`FHU::ScopedSignalMaskWith*` now requires to be inside a Host Deferred Signal scope, and enforces that by using `FHU::ScopedSignalMask`.

#### Finally
Initialization, teardown, code compilation, and host signal handling are modified to setup HDS scopes and syscall handling uses automatic HDS.

Exit and shutdown code logic is simplified, `FEXLoader`, `TestHarnessRunner` and `IRLoader` are modified accordingly.

### Notes
Three different scopes are used to make usage more explicit, so that useful asserts can be provided.

### Assumptions
- That signal reentrancy is manually handled

### Related Tickets
- #1715 #1682