### PR TITLE
FEXRootFSFetcher: Adds runtime checks for image mounting tools

### DIFF
--- a/Source/Tools/FEXRootFSFetcher/Main.cpp
+++ b/Source/Tools/FEXRootFSFetcher/Main.cpp
@@ -1100,6 +1100,13 @@ int main(int argc, char **argv, char **const envp) {
     ExecWithInfo("curl is required to use this tool. Please install curl before using.");
     return -1;
   }
+  if (!WorkingAppsTester::Has_Squashfuse &&
+      !WorkingAppsTester::Has_Unsquashfs &&
+      !WorkingAppsTester::Has_EroFSFuse) {
+    // We need at least one tool to mount or extract image files
+    ExecWithInfo("squashfuse, unsquashfs, or erofsfuse is required to use this tool. Please install one before using.");
+    return -1;
+  }
 
   FEX_CONFIG_OPT(LDPath, ROOTFS);
 


### PR DESCRIPTION
If the user doesn't have any of the tools necessary for handling FEX's
images then the tool would spuriously fail with `Couldn't parse rootfs definition URL.`
With zero indication as to why we removed images from the parsed json.

If the user has at least one of these tools installed then they won't
get this error message.