### PR TITLE
FEXBash: Changes PS1 to hopefully help users

### DIFF
--- a/Source/Tests/FEXBash.cpp
+++ b/Source/Tests/FEXBash.cpp
@@ -94,11 +94,11 @@ int main(int argc, char **argv, char **const envp) {
       PS1Env = envp[i];
     }
     else {
-	Envp.emplace_back(envp[i]);
+      Envp.emplace_back(envp[i]);
     }
   }
 
-  std::string PS1 = "PS1=FEXBash> ";
+  std::string PS1 = "PS1=FEXBash-\\u@\\h:\\w> ";
   if (PS1Env) {
     PS1 += &PS1Env[strlen("PS1=")];
   }


### PR DESCRIPTION
Currently FEXBash only outputs `FEXBash>` which gives weird docker
vibes. This can confuse users since they no longer see what folder they
are in.

Change this so it still has the user and path exposed like a typical PS1

eg: `FEXBash-ryanh@ryanh-TR2:/mnt/Work/Work/work/FEXNew/Build>`