### PR TITLE
Thunks: Make GL guest thunks implicitly load libX11.so

### DIFF
--- a/ThunkLibs/GuestLibs/CMakeLists.txt
+++ b/ThunkLibs/GuestLibs/CMakeLists.txt
@@ -91,6 +91,10 @@ add_guest_lib(EGL)
 generate(libGL ${CMAKE_CURRENT_SOURCE_DIR}/../libGL/libGL_interface.cpp thunks function_packs function_packs_public symbol_list)
 add_guest_lib(GL)
 
+# libGL must pull in libX11.so, so generate a placeholder libX11.so to link against
+add_library(X11 SHARED ../libX11/libX11_NativeGuest.cpp)
+target_link_libraries(GL-guest PRIVATE X11)
+
 # disabled for now, headers are platform specific
 # find_package(SDL2 REQUIRED)
 # generate(libSDL2 thunks function_packs function_packs_public)

--- a/ThunkLibs/libGL/libGL_Guest.cpp
+++ b/ThunkLibs/libGL/libGL_Guest.cpp
@@ -65,4 +65,8 @@ extern "C" {
 	}
 }
 
+// libGL.so must pull in libX11.so as a dependency. Referencing some libX11
+// symbol here prevents the linker from optimizing away the unused dependency
+auto implicit_libx11_dependency = XSetErrorHandler;
+
 LOAD_LIB(libGL)

--- a/ThunkLibs/libX11/libX11_NativeGuest.cpp
+++ b/ThunkLibs/libX11/libX11_NativeGuest.cpp
@@ -1,0 +1,7 @@
+// This file only exists to create a placeholder library to link against for
+// libraries that are supposed to implicitly load libX11. At runtime, the guest
+// linker will select the library from the RootFS instead, which is then
+// replaced by libX11-guest.so.
+
+// Define some symbol so that the linker doesn't consider this library unused
+extern "C" void XSetErrorHandler() {}


### PR DESCRIPTION
## Overview

Steam's gameoverlayrenderer.so relies on libX11 symbols to be available without actually loading that library directly. This works on an unthunked system since libGL.so depends on libGLX.so, which in turn pulls in libX11.so at load-time. This PR adds a fake libX11 dependency to the libGL-guest thunks to reproduce this behavior.

The linker is eager to throw out unused libraries from libGL's dependency list, so `libX11_NativeGuest.cpp` exports an arbitrary symbol (`XSetErrorHandler`) which libGL picks up in a dummy variable. That way, the linker considers libX11 to be actually "used" by libGL.

## Considered alternatives

### Link against RootFS libraries

Instead of generating a fake `libX11.so`, just link against libraries from the RootFS. The linker fails to handle these, since transitive dependencies for `libX11.so` use absolute paths that don't match the RootFS structure.

### Load libX11.so manually at libGL loading time

Using a `__attribute__((constructor))` function, `dlopen("libX11.so")` can be used to manually load the library. This works in principle, but in practice it didn't unless a dummy `puts` was added before the `dlopen`:

```cpp
__attribute__((constructor)) static void ImplicitlyLoadX11() {
  puts("");
  dlopen("libX11.so", RTLD_LOCAL | RTLD_NOW);
}
```

### Disable `--as-needed`

Without `--as-needed`, the workaround of exporting `XSetErrorHandler` from `libX11_NativeGuest.cpp` wouldn't be needed. However it can only be disabled for all dependencies (which adds a faux `libm.so` dependency to libGL), or it requires the complicated linker option `--push-state --no-as-needed libX11.so --pop-state` that would be difficult to express in CMake and may not be portable to other linkers.

The workaround has small impact, so this doesn't seem too important either way.

### Linker scripts

Instead of compiling a dummy library to link against (which is done because GCC/LD don't seem to offer an option to add library dependencies purely by name without that library being present), a `DT_NEEDED` entry for libX11 could *probably* be written to `libGL-guest.so` manually using linker scripts. I don't know what that would look like in practice, but I'm guessing it would be more complicated than the current approach.
