### PR TITLE
Externals: Update fmt to 9.0.0

### DIFF
--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64.cpp
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64.cpp
@@ -3,6 +3,7 @@
 
 #include <aarch64/cpu-aarch64.h>
 
+#include <FEXCore/Utils/EnumUtils.h>
 #include <FEXCore/Utils/LogManager.h>
 #include <FEXCore/Utils/Telemetry.h>
 
@@ -1986,7 +1987,8 @@ uint64_t HandleAtomicLoadstoreExclusive(void *_ucontext, void *_info) {
         DesiredFunction = NEGDesired;
         break;
       default:
-        LogMan::Msg::EFmt("Unhandled JIT SIGBUS Atomic mem op 0x{:02x}", AtomicOp);
+        LogMan::Msg::EFmt("Unhandled JIT SIGBUS Atomic mem op 0x{:02x}",
+                          ToUnderlying(AtomicOp));
         return false;
     }
 
@@ -2039,7 +2041,8 @@ uint64_t HandleAtomicLoadstoreExclusive(void *_ucontext, void *_info) {
         DesiredFunction = NEGDesired;
         break;
       default:
-        LogMan::Msg::EFmt("Unhandled JIT SIGBUS Atomic mem op 0x{:02x}", AtomicOp);
+        LogMan::Msg::EFmt("Unhandled JIT SIGBUS Atomic mem op 0x{:02x}",
+                          ToUnderlying(AtomicOp));
         return false;
     }
 
@@ -2092,7 +2095,8 @@ uint64_t HandleAtomicLoadstoreExclusive(void *_ucontext, void *_info) {
         DesiredFunction = NEGDesired;
         break;
       default:
-        LogMan::Msg::EFmt("Unhandled JIT SIGBUS Atomic mem op 0x{:02x}", AtomicOp);
+        LogMan::Msg::EFmt("Unhandled JIT SIGBUS Atomic mem op 0x{:02x}",
+                          ToUnderlying(AtomicOp));
         return false;
     }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -27,6 +27,7 @@ $end_info$
 #include <FEXCore/Core/UContext.h>
 #include <FEXCore/Utils/Allocator.h>
 #include <FEXCore/Utils/CompilerDefs.h>
+#include <FEXCore/Utils/EnumUtils.h>
 
 #include "Interface/Core/Interpreter/InterpreterOps.h"
 
@@ -361,7 +362,8 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header *IROp, IR::NodeID Node) {
       case FABI_UNKNOWN:
       default:
 #if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
-        LOGMAN_MSG_A_FMT("Unhandled IR Fallback ABI: {} {}", FEXCore::IR::GetName(IROp->Op), Info.ABI);
+        LOGMAN_MSG_A_FMT("Unhandled IR Fallback ABI: {} {}",
+                         FEXCore::IR::GetName(IROp->Op), ToUnderlying(Info.ABI));
 #endif
       break;
     }

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -17,6 +17,7 @@ $end_info$
 #include <FEXCore/IR/IR.h>
 #include <FEXCore/IR/IREmitter.h>
 #include <FEXCore/IR/IntrusiveIRList.h>
+#include <FEXCore/Utils/EnumUtils.h>
 #include <FEXCore/Utils/LogManager.h>
 
 #include <algorithm>
@@ -350,7 +351,7 @@ void OpDispatchBuilder::SecondaryALUOp(OpcodeArgs) {
         break;
       }
       default:
-        LOGMAN_MSG_A_FMT("Unknown Atomic IR Op: {}", IROp);
+        LOGMAN_MSG_A_FMT("Unknown Atomic IR Op: {}", ToUnderlying(IROp));
         break;
     }
   }
@@ -5048,7 +5049,7 @@ void OpDispatchBuilder::ALUOp(OpcodeArgs) {
         break;
       }
       default:
-        LOGMAN_MSG_A_FMT("Unknown Atomic IR Op: {}", IROp);
+        LOGMAN_MSG_A_FMT("Unknown Atomic IR Op: {}", ToUnderlying(IROp));
         break;
     }
   }

--- a/External/FEXCore/Source/Interface/IR/IREmitter.cpp
+++ b/External/FEXCore/Source/Interface/IR/IREmitter.cpp
@@ -8,6 +8,7 @@ $end_info$
 #include <FEXCore/IR/IR.h>
 #include <FEXCore/IR/IREmitter.h>
 #include <FEXCore/IR/IntrusiveIRList.h>
+#include <FEXCore/Utils/EnumUtils.h>
 #include <FEXCore/Utils/LogManager.h>
 
 #include <array>
@@ -87,7 +88,8 @@ FEXCore::IR::RegisterClassType IREmitter::WalkFindRegClass(OrderedNode *Node) {
       break;
     }
     default:
-      LOGMAN_MSG_A_FMT("Unhandled op type: {} {} in argument class validation", IROp->Op, GetOpName(Node));
+      LOGMAN_MSG_A_FMT("Unhandled op type: {} {} in argument class validation",
+                       ToUnderlying(IROp->Op), GetOpName(Node));
       break;
   }
   return InvalidClass;

--- a/Source/Tests/IRLoader.cpp
+++ b/Source/Tests/IRLoader.cpp
@@ -14,6 +14,7 @@ $end_info$
 #include <FEXCore/Core/CoreState.h>
 #include <FEXCore/Core/HostFeatures.h>
 #include <FEXCore/Utils/Allocator.h>
+#include <FEXCore/Utils/EnumUtils.h>
 #include <FEXCore/Utils/LogManager.h>
 #include <FEXCore/HLE/SyscallHandler.h>
 #include <FEXCore/IR/IREmitter.h>
@@ -230,7 +231,7 @@ int main(int argc, char **argv, char **const envp)
       FEXCore::Context::RunUntilExit(CTX);
     }
 
-    LogMan::Msg::DFmt("Reason we left VM: {}", ShutdownReason);
+    LogMan::Msg::DFmt("Reason we left VM: {}", FEXCore::ToUnderlying(ShutdownReason));
 
     // Just re-use compare state. It also checks against the expected values in config.
     FEXCore::Core::CPUState State;


### PR DESCRIPTION
Keeps the codebase up to date with the latest major version (we were previously on 8.1.1)

Changelog can be seen [here](https://github.com/fmtlib/fmt/releases/tag/9.0.0)