### PR TITLE
AppConfig: Fix bug with filename

### DIFF
--- a/Data/AppConfig/CMakeLists.txt
+++ b/Data/AppConfig/CMakeLists.txt
@@ -11,15 +11,15 @@ endforeach()
 # First generate then install it
 foreach(GEN_CONFIG_SRC ${GEN_CONFIG_SOURCES})
   # Get the filename only component
-  get_filename_component(CONFIG_NAME ${GEN_CONFIG_SRC} NAME_WE)
+  get_filename_component(CONFIG_NAME ${GEN_CONFIG_SRC} NAME_WLE)
 
   # Configure it
   configure_file(
     ${GEN_CONFIG_SRC}
-    ${CMAKE_BINARY_DIR}/Data/AppConfig/${CONFIG_NAME}.json)
+    ${CMAKE_BINARY_DIR}/Data/AppConfig/${CONFIG_NAME})
 
   # Then install the configured json
   install(
-    FILES ${CMAKE_BINARY_DIR}/Data/AppConfig/${CONFIG_NAME}.json
+    FILES ${CMAKE_BINARY_DIR}/Data/AppConfig/${CONFIG_NAME}
     DESTINATION ${DATA_DIRECTORY}/AppConfig/)
 endforeach()


### PR DESCRIPTION
Turns out cmake will cut the filename at the first period, not the last.
Fixes an issue if we have application names with multiple periods in it.