### PR TITLE
CI: Build Thunks

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -178,6 +178,17 @@ jobs:
       working-directory: ${{runner.workspace}}/build
       run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_FEXLinuxTests.log || true
 
+    - name: Thunkgen tests
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      run: cmake --build . --config $BUILD_TYPE --target thunkgen_tests
+
+    - name: Thunkgen Results move
+      if: ${{ always() }}
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_ThunkgenTests.log || true
+
     - name: Truncate test results
       if: ${{ always() }}
       shell: bash

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -65,7 +65,7 @@ jobs:
       # Note the current convention is to use the -S and -B options here to specify source
       # and build directories, but this is only available with CMake 3.13 and higher.
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -G Ninja -DENABLE_LTO=False -DENABLE_ASSERTIONS=True -DENABLE_X86_HOST_DEBUG=True -DENABLE_INTERPRETER=True -DBUILD_FEX_LINUX_TESTS=True
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -G Ninja -DENABLE_LTO=False -DENABLE_ASSERTIONS=True -DENABLE_X86_HOST_DEBUG=True -DENABLE_INTERPRETER=True -DBUILD_FEX_LINUX_TESTS=True -DBUILD_THUNKS=True
 
     - name: Build
       working-directory: ${{runner.workspace}}/build

--- a/ThunkLibs/GuestLibs/CMakeLists.txt
+++ b/ThunkLibs/GuestLibs/CMakeLists.txt
@@ -125,6 +125,10 @@ target_compile_definitions(libX11-guest-deps INTERFACE -DX11_VERSION_PATCH=${X11
 generate(libXext ${CMAKE_CURRENT_SOURCE_DIR}/../libXext/libXext_interface.cpp thunks function_packs function_packs_public)
 add_guest_lib(Xext)
 
+target_compile_definitions(libXext-guest-deps INTERFACE -DX11_VERSION_MAJOR=${X11_VERSION_MAJOR})
+target_compile_definitions(libXext-guest-deps INTERFACE -DX11_VERSION_MINOR=${X11_VERSION_MINOR})
+target_compile_definitions(libXext-guest-deps INTERFACE -DX11_VERSION_PATCH=${X11_VERSION_PATCH})
+
 generate(libXrender ${CMAKE_CURRENT_SOURCE_DIR}/../libXrender/libXrender_interface.cpp thunks function_packs function_packs_public)
 add_guest_lib(Xrender)
 

--- a/ThunkLibs/GuestLibs/CMakeLists.txt
+++ b/ThunkLibs/GuestLibs/CMakeLists.txt
@@ -25,9 +25,11 @@ function(generate NAME SOURCE_FILE)
   # Interface target for the user to add include directories
   add_library(${NAME}-guest-deps INTERFACE)
   target_include_directories(${NAME}-guest-deps INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/../include")
+  target_compile_definitions(${NAME}-guest-deps INTERFACE GUEST_THUNK_LIBRARY)
   # Shorthand for the include directories added after calling this function.
   # This is not evaluated directly, hence directories added after return are still picked up
   set(prop "$<TARGET_PROPERTY:${NAME}-guest-deps,INTERFACE_INCLUDE_DIRECTORIES>")
+  set(compile_prop "$<TARGET_PROPERTY:${NAME}-guest-deps,INTERFACE_COMPILE_DEFINITIONS>")
 
   # Run thunk generator for each of the given output files
   foreach(WHAT IN LISTS ARGN)
@@ -40,9 +42,11 @@ function(generate NAME SOURCE_FILE)
       OUTPUT "${OUTFILE}"
       DEPENDS "${GENERATOR_EXE}"
       DEPENDS "${SOURCE_FILE}"
-      COMMAND "${GENERATOR_EXE}" "${SOURCE_FILE}" "${NAME}" "-${WHAT}" "${OUTFILE}" -- -std=c++17 -DGUEST_THUNK_LIBRARY
-            # Expand include directories to space-separated list of -isystem parameters
-           "$<$<BOOL:${prop}>:;-isystem$<JOIN:${prop},;-isystem>>"
+      COMMAND "${GENERATOR_EXE}" "${SOURCE_FILE}" "${NAME}" "-${WHAT}" "${OUTFILE}" -- -std=c++17
+        # Expand compile definitions to space-separated list of -D parameters
+        "$<$<BOOL:${compile_prop}>:;-D$<JOIN:${compile_prop},;-D>>"
+        # Expand include directories to space-separated list of -isystem parameters
+        "$<$<BOOL:${prop}>:;-isystem$<JOIN:${prop},;-isystem>>"
       VERBATIM
       COMMAND_EXPAND_LISTS
       )
@@ -103,8 +107,20 @@ target_link_libraries(GL-guest PRIVATE X11)
 # target_link_libraries(SDL2-guest PRIVATE GL)
 # target_link_libraries(SDL2-guest PRIVATE dl)
 
+find_package(PkgConfig)
+pkg_search_module(X11 REQUIRED x11)
+
+string(REGEX MATCH "([0-9]*)\.([0-9]*)\.([0-9]*)" _ "${X11_VERSION}")
+set(X11_VERSION_MAJOR ${CMAKE_MATCH_1})
+set(X11_VERSION_MINOR ${CMAKE_MATCH_2})
+set(X11_VERSION_PATCH ${CMAKE_MATCH_3})
+
 generate(libX11 ${CMAKE_CURRENT_SOURCE_DIR}/../libX11/libX11_interface.cpp thunks function_packs function_packs_public)
 add_guest_lib(X11)
+
+target_compile_definitions(libX11-guest-deps INTERFACE -DX11_VERSION_MAJOR=${X11_VERSION_MAJOR})
+target_compile_definitions(libX11-guest-deps INTERFACE -DX11_VERSION_MINOR=${X11_VERSION_MINOR})
+target_compile_definitions(libX11-guest-deps INTERFACE -DX11_VERSION_PATCH=${X11_VERSION_PATCH})
 
 generate(libXext ${CMAKE_CURRENT_SOURCE_DIR}/../libXext/libXext_interface.cpp thunks function_packs function_packs_public)
 add_guest_lib(Xext)

--- a/ThunkLibs/HostLibs/CMakeLists.txt
+++ b/ThunkLibs/HostLibs/CMakeLists.txt
@@ -113,6 +113,10 @@ target_compile_definitions(libX11-deps INTERFACE -DX11_VERSION_PATCH=${X11_VERSI
 generate(libXext ${CMAKE_CURRENT_SOURCE_DIR}/../libXext/libXext_interface.cpp function_unpacks tab_function_unpacks ldr ldr_ptrs)
 add_host_lib(Xext)
 
+target_compile_definitions(libXext-deps INTERFACE -DX11_VERSION_MAJOR=${X11_VERSION_MAJOR})
+target_compile_definitions(libXext-deps INTERFACE -DX11_VERSION_MINOR=${X11_VERSION_MINOR})
+target_compile_definitions(libXext-deps INTERFACE -DX11_VERSION_PATCH=${X11_VERSION_PATCH})
+
 generate(libXrender ${CMAKE_CURRENT_SOURCE_DIR}/../libXrender/libXrender_interface.cpp function_unpacks tab_function_unpacks ldr ldr_ptrs)
 add_host_lib(Xrender)
 

--- a/ThunkLibs/HostLibs/CMakeLists.txt
+++ b/ThunkLibs/HostLibs/CMakeLists.txt
@@ -17,6 +17,7 @@ function(generate NAME SOURCE_FILE)
   # Shorthand for the include directories added after calling this function.
   # This is not evaluated directly, hence directories added after return are still picked up
   set(prop "$<TARGET_PROPERTY:${NAME}-deps,INTERFACE_INCLUDE_DIRECTORIES>")
+  set(compile_prop "$<TARGET_PROPERTY:${NAME}-deps,INTERFACE_COMPILE_DEFINITIONS>")
 
   # Target for IDE integration
   add_library(${NAME}-interface EXCLUDE_FROM_ALL ${SOURCE_FILE})
@@ -34,8 +35,10 @@ function(generate NAME SOURCE_FILE)
       DEPENDS "${SOURCE_FILE}"
       DEPENDS thunkgen
       COMMAND thunkgen "${SOURCE_FILE}" "${NAME}" "-${WHAT}" "${OUTFILE}" -- -std=c++17
-            # Expand include directories to space-separated list of -isystem parameters
-           "$<$<BOOL:${prop}>:;-isystem$<JOIN:${prop},;-isystem>>"
+        # Expand compile definitions to space-separated list of -D parameters
+        "$<$<BOOL:${compile_prop}>:;-D$<JOIN:${compile_prop},;-D>>"
+        # Expand include directories to space-separated list of -isystem parameters
+        "$<$<BOOL:${prop}>:;-isystem$<JOIN:${prop},;-isystem>>"
       VERBATIM
       COMMAND_EXPAND_LISTS
       )
@@ -92,8 +95,20 @@ target_link_libraries(GL-host PRIVATE OpenGL::GL)
 # add_host_lib(SDL2)
 # target_include_directories(SDL2-host PRIVATE ${SDL2_INCLUDE_DIRS})
 
+find_package(PkgConfig)
+pkg_search_module(X11 REQUIRED x11)
+
+string(REGEX MATCH "([0-9]*)\.([0-9]*)\.([0-9]*)" _ "${X11_VERSION}")
+set(X11_VERSION_MAJOR ${CMAKE_MATCH_1})
+set(X11_VERSION_MINOR ${CMAKE_MATCH_2})
+set(X11_VERSION_PATCH ${CMAKE_MATCH_3})
+
 generate(libX11 ${CMAKE_CURRENT_SOURCE_DIR}/../libX11/libX11_interface.cpp function_unpacks tab_function_unpacks ldr ldr_ptrs)
 add_host_lib(X11)
+
+target_compile_definitions(libX11-deps INTERFACE -DX11_VERSION_MAJOR=${X11_VERSION_MAJOR})
+target_compile_definitions(libX11-deps INTERFACE -DX11_VERSION_MINOR=${X11_VERSION_MINOR})
+target_compile_definitions(libX11-deps INTERFACE -DX11_VERSION_PATCH=${X11_VERSION_PATCH})
 
 generate(libXext ${CMAKE_CURRENT_SOURCE_DIR}/../libXext/libXext_interface.cpp function_unpacks tab_function_unpacks ldr ldr_ptrs)
 add_host_lib(Xext)

--- a/ThunkLibs/libX11/libX11_Guest.cpp
+++ b/ThunkLibs/libX11/libX11_Guest.cpp
@@ -206,7 +206,10 @@ extern "C" {
 
     MakeHostFunctionGuestCallable(ret->resource_alloc);
     MakeHostFunctionGuestCallable(ret->idlist_alloc);
+#if (X11_VERSION_MAJOR >= 1 && X11_VERSION_MINOR >= 7 && X11_VERSION_PATCH >= 0)
+    // Doesn't exist on older X11
     MakeHostFunctionGuestCallable(ret->exit_handler);
+#endif
 
     return ret;
   }

--- a/ThunkLibs/libX11/libX11_interface.cpp
+++ b/ThunkLibs/libX11/libX11_interface.cpp
@@ -472,6 +472,12 @@ template<> struct fex_gen_type<XID(Display*)> {}; // XDisplay::resource_alloc
 template<> struct fex_gen_type<void(Display*/*, char*, int*/)> {}; // XDisplay::lock_fns->lock_display
 
 template<> struct fex_gen_type<void(_XDisplay*, XID*, int)> {}; // XDisplay::idlist_alloc
+
+#if !(X11_VERSION_MAJOR >= 1 && X11_VERSION_MINOR >= 7 && X11_VERSION_PATCH >= 0)
+// Doesn't exist on older X11
+typedef void (*XIOErrorExitHandler)(Display*, void*);
+#endif
+
 template<> struct fex_gen_type<std::remove_pointer_t<XIOErrorExitHandler>> {}; // XDisplay::exit_handler
 template<> struct fex_gen_config<XOpenDisplay> : fexgen::custom_guest_entrypoint {};
 

--- a/ThunkLibs/libXext/libXext_interface.cpp
+++ b/ThunkLibs/libXext/libXext_interface.cpp
@@ -172,7 +172,14 @@ template<> struct fex_gen_config<_XF86LoadQueryLocaleFont> {};
 template<> struct fex_gen_config<_XProcessWindowAttributes> {};
 template<> struct fex_gen_config<_XDefaultError> {};
 template<> struct fex_gen_config<_XDefaultIOError> {};
+
+#if !(X11_VERSION_MAJOR >= 1 && X11_VERSION_MINOR >= 7 && X11_VERSION_PATCH >= 0)
+// Doesn't exist on older X11
+extern void _XDefaultIOErrorExit(Display *dpy, void *user_data);
+#endif
+
 template<> struct fex_gen_config<_XDefaultIOErrorExit> {};
+
 template<> struct fex_gen_config<_XSetClipRectangles> {};
 template<> struct fex_gen_config<_XGetWindowAttributes> {};
 template<> struct fex_gen_config<_XPutBackEvent> {};

--- a/ThunkLibs/libasound/libasound_interface.cpp
+++ b/ThunkLibs/libasound/libasound_interface.cpp
@@ -1,6 +1,7 @@
 #include <common/GeneratorInterface.h>
 
 #include <alsa/asoundlib.h>
+#include <alsa/version.h>
 
 template<auto>
 struct fex_gen_config {
@@ -8,6 +9,10 @@ struct fex_gen_config {
 };
 
 template<> struct fex_gen_config<snd_asoundlib_version> {};
+#if SND_LIB_VERSION < ((1 << 16) | (2 << 8) | (6))
+// Exists on 1.2.6
+int snd_dlpath(char *path, size_t path_len, const char *name);
+#endif
 template<> struct fex_gen_config<snd_dlpath> {};
 template<> struct fex_gen_config<snd_dlopen> {};
 template<> struct fex_gen_config<snd_dlsym> {};


### PR DESCRIPTION
To ensure that our thunks don't become horribly broken with our changes. Build them in CI.

Requires some tinkering because the 20.04 requirement, but otherwise works.