### PR TITLE
Linux: Emulate classic getdents syscall for x64 and x32

### DIFF
--- a/Source/Tests/LinuxSyscalls/Syscalls.h
+++ b/Source/Tests/LinuxSyscalls/Syscalls.h
@@ -509,6 +509,8 @@ static bool HasSyscallError(const void* Result) {
   return HasSyscallError(reinterpret_cast<uintptr_t>(Result));
 }
 
+template<bool IncrementOffset, typename T>
+uint64_t GetDentsEmulation(int fd, T *dirp, uint32_t count);
 }
 
 // Registers syscall for both 32bit and 64bit

--- a/Source/Tests/LinuxSyscalls/x64/FD.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/FD.cpp
@@ -10,6 +10,7 @@ $end_info$
 #include "Tests/LinuxSyscalls/x64/Types.h"
 
 #include <FEXCore/Utils/CompilerDefs.h>
+#include <FEXCore/Utils/MathUtils.h>
 
 #include <fcntl.h>
 #include <poll.h>
@@ -196,16 +197,7 @@ namespace FEX::HLE::x64 {
     });
 
     REGISTER_SYSCALL_IMPL_X64(getdents, [](FEXCore::Core::CpuStateFrame *Frame, int fd, void *dirp, uint32_t count) -> uint64_t {
-  #ifdef SYS_getdents
-      uint64_t Result = syscall(SYSCALL_DEF(getdents),
-        static_cast<uint64_t>(fd),
-        reinterpret_cast<uint64_t>(dirp),
-        static_cast<uint64_t>(count));
-      SYSCALL_ERRNO();
-  #else
-      // XXX: Emulate
-      return -EFAULT;
-  #endif
+      return GetDentsEmulation<false>(fd, reinterpret_cast<FEX::HLE::x64::linux_dirent*>(dirp), count);
     });
 
     REGISTER_SYSCALL_IMPL_X64_PASS(getdents64, [](FEXCore::Core::CpuStateFrame *Frame, int fd, void *dirp, uint32_t count) -> uint64_t {

--- a/Source/Tests/LinuxSyscalls/x64/Types.h
+++ b/Source/Tests/LinuxSyscalls/x64/Types.h
@@ -194,4 +194,37 @@ using __time_t = time_t;
   // Original definition in `arch/x86/include/uapi/asm/stat.h` for future excavation
   static_assert(std::is_trivial<FEX::HLE::x64::guest_stat>::value, "Needs to be trivial");
   static_assert(sizeof(FEX::HLE::x64::guest_stat) == 144, "Incorrect size");
+
+  // There is no public definition of this struct
+  // Matches the definition of `struct linux_dirent` in fs/readdir.c
+  struct
+  FEX_ANNOTATE("fex-match")
+  linux_dirent {
+    uint64_t d_ino;
+    uint64_t d_off;
+    uint16_t d_reclen;
+    char d_name[1];
+    /* Has hidden null character and d_type */
+  };
+  static_assert(std::is_trivial<linux_dirent>::value, "Needs to be trivial");
+  static_assert(offsetof(linux_dirent, d_ino) == 0, "Incorrect offset");
+  static_assert(offsetof(linux_dirent, d_off) == 8, "Incorrect offset");
+  static_assert(offsetof(linux_dirent, d_reclen) == 16, "Incorrect offset");
+  static_assert(offsetof(linux_dirent, d_name) == 18, "Incorrect offset");
+  static_assert(sizeof(linux_dirent) == 24, "Incorrect size");
+
+  // There is no public definition of this struct
+  // Matches the definition of `struct linux_dirent64` in include/linux/dirent.h
+  struct
+  FEX_ANNOTATE("fex-match")
+  FEX_PACKED
+  linux_dirent_64 {
+    uint64_t d_ino;
+    uint64_t d_off;
+    uint16_t d_reclen;
+    uint8_t  d_type;
+    char d_name[];
+  };
+  static_assert(std::is_trivial<linux_dirent_64>::value, "Needs to be trivial");
+  static_assert(sizeof(linux_dirent_64) == 19, "Incorrect size");
 }


### PR DESCRIPTION
Arm64 doesn't have the classic getdents syscall, only getdents64.
Old glibc versions (like 2.17) don't support getdents64

This fixes 64-bit `ls` with a centos 7 rootfs. Likely also fixes some other very
old applications.

Packing differences between 32-bit and 64-bit getdents means we need to
template this between the two types, otherwise it's quite similar.

No known applications rely on the 32-bit getdents but worked with test
applications.