### PR TITLE
FEXServer: Support socket path override

### DIFF
--- a/External/FEXCore/Source/Interface/Config/Config.json.in
+++ b/External/FEXCore/Source/Interface/Config/Config.json.in
@@ -351,6 +351,13 @@
         "Desc": [
           "Loads an AOT IR cache for the loaded executable."
         ]
+      },
+      "ServerSocketPath": {
+        "Type": "str",
+        "Default": "",
+        "Desc": [
+          "Override for a FEXServer socket path. Only useful for chroots."
+        ]
       }
     }
   },

--- a/Source/Common/FEXServerClient.cpp
+++ b/Source/Common/FEXServerClient.cpp
@@ -101,7 +101,12 @@ namespace FEXServerClient {
   }
 
   std::string GetServerSocketFile() {
-    return fmt::format("{}/{}.FEXServer.socket", std::filesystem::temp_directory_path().string(), ::geteuid());
+    FEX_CONFIG_OPT(ServerSocketPath, SERVERSOCKETPATH);
+    if (ServerSocketPath().empty()) {
+      return fmt::format("{}/{}.FEXServer.socket", std::filesystem::temp_directory_path().string(), ::geteuid());
+    }
+
+    return ServerSocketPath;
   }
 
   int GetServerFD() {


### PR DESCRIPTION
This is necessary for the fexserver to function correctly when chrooting
in to our rootfs and doing things.

Requires independent rootfs script modifications which will come with
the next rootfs update.

Problem comes down to a chroot supporting multiple users, where our
typical use case is only one user. Bind the server file to a single
server for the entire chroot session regardless of users, solving this
problem inside the chroot.

Fixes apt-get inside of chroot, which runs as user _apt.