### PR TITLE
cmake: fix incorrect assumption about the value of git's core.abbrev

### DIFF
--- a/External/FEXCore/CMakeLists.txt
+++ b/External/FEXCore/CMakeLists.txt
@@ -46,14 +46,14 @@ if (OVERRIDE_VERSION STREQUAL "detect")
 
   if (GIT_FOUND)
     execute_process(
-      COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
+      COMMAND ${GIT_EXECUTABLE} rev-parse --short=7 HEAD
       WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
       OUTPUT_VARIABLE GIT_SHORT_HASH
       ERROR_QUIET
       OUTPUT_STRIP_TRAILING_WHITESPACE
     )
     execute_process(
-      COMMAND ${GIT_EXECUTABLE} describe
+      COMMAND ${GIT_EXECUTABLE} describe --abbrev=7
       WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
       OUTPUT_VARIABLE GIT_DESCRIBE_STRING
       ERROR_QUIET


### PR DESCRIPTION
While the default value of `git config core.abbrev` is `7` (used to truncate the commit hash in several git commands) and most people don't configure anything else, I happen to prefer when commits hashes stay valid for a while, so I changed that value to `20`.
Because of this, FEX fails to build in [`External/FEXCore/Source/Interface/Core/CPUID.cpp:961`](https://github.com/FEX-Emu/FEX/blob/a2f4f494a9cdfcfffdba52b35da7a1f9378e635c/External/FEXCore/Source/Interface/Core/CPUID.cpp#L961)

Let's be explicit in the git command about what minimum length of commit hash we expect.

---
Note that this is not a proper fix, but should work for enough years that we don't yet need to bother truncating these two variables at 31 chars, but technically any two random commits hashes could have 31 chars in common and need 32 chars to be unique, in which case the fix here would not be enough anymore.