### PR TITLE
FDUtils: Don't make unknown get_fdpath fatal

### DIFF
--- a/Source/Common/FDUtils.h
+++ b/Source/Common/FDUtils.h
@@ -5,12 +5,13 @@
 #include <fcntl.h>
 #include <filesystem>
 #include <linux/limits.h>
+#include <optional>
 #include <unistd.h>
 
 namespace FEX {
 [[maybe_unused]]
 static
-std::string get_fdpath(int fd) {
+std::optional<std::string> get_fdpath(int fd) {
   char SymlinkPath[PATH_MAX];
   std::filesystem::path Path = std::filesystem::path("/proc/self/fd") / std::to_string(fd);
   int Result = readlinkat(AT_FDCWD, Path.c_str(), SymlinkPath, sizeof(SymlinkPath));
@@ -18,8 +19,8 @@ std::string get_fdpath(int fd) {
     return std::string(SymlinkPath, Result);
   }
 
-  LOGMAN_MSG_A_FMT("Couldn't get symlink from /proc/self/fd/{}", fd);
-  return {};
+  // Not fatal if an FD doesn't point to a file
+  return std::nullopt;
 }
 
 }

--- a/Source/Tests/ELFCodeLoader2.h
+++ b/Source/Tests/ELFCodeLoader2.h
@@ -79,7 +79,9 @@ class ELFCodeLoader2 final : public FEXCore::CodeLoader {
       return false;
     } else {
       auto Filename = FEX::get_fdpath(file.fd);
-      Sections.push_back({Base, (uintptr_t)rv, size, (off_t)off, Filename, (prot & PROT_EXEC) != 0});
+      if (Filename.has_value()) {
+        Sections.push_back({Base, (uintptr_t)rv, size, (off_t)off, Filename.value(), (prot & PROT_EXEC) != 0});
+      }
 
       return true;
     }

--- a/Source/Tests/LinuxSyscalls/EmulatedFiles/EmulatedFiles.cpp
+++ b/Source/Tests/LinuxSyscalls/EmulatedFiles/EmulatedFiles.cpp
@@ -714,7 +714,7 @@ namespace FEX::EmulatedFile {
         dirfs != AT_FDCWD) {
       // Passed in a dirfd that isn't magic FDCWD
       // We need to get the path from the fd now
-      Path = FEX::get_fdpath(dirfs);
+      Path = FEX::get_fdpath(dirfs).value_or("");
 
       if (pathname) {
         if (!Path.empty()) {

--- a/Source/Tests/LinuxSyscalls/FileManagement.cpp
+++ b/Source/Tests/LinuxSyscalls/FileManagement.cpp
@@ -575,7 +575,7 @@ uint64_t FileManager::Readlinkat(int dirfd, const char *pathname, char *buf, siz
         dirfd != AT_FDCWD) {
     // Passed in a dirfd that isn't magic FDCWD
     // We need to get the path from the fd now
-    Path = FEX::get_fdpath(dirfd);
+    Path = FEX::get_fdpath(dirfd).value_or("");
 
     if (pathname) {
       if (!Path.empty()) {


### PR DESCRIPTION
Encountered this while running wine things.
Non-fatal so don't explode