### PR TITLE
Thunks: Support direct thunk config in configuration files 

### DIFF
--- a/External/FEXCore/Source/Interface/Config/Config.cpp
+++ b/External/FEXCore/Source/Interface/Config/Config.cpp
@@ -82,7 +82,7 @@ namespace JSON {
     json_t const* ConfigList = json_getProperty(json, "Config");
 
     if (!ConfigList) {
-      LogMan::Msg::EFmt("Couldn't get config list");
+      // This is a non-error if the configuration file exists but no Config section
       return;
     }
 

--- a/External/FEXCore/Source/Interface/Config/Config.json.in
+++ b/External/FEXCore/Source/Interface/Config/Config.json.in
@@ -375,6 +375,17 @@
         "Type": "str",
         "Default": ""
       },
+      "APP_CONFIG_NAME": {
+        "Type": "str",
+        "Default": "",
+        "Desc": [
+          "This is the application config name that has been loaded.",
+          "This differs from APP_FILENAME in two ways",
+          "Where APP_FILENAME always points to the executable path that FEX-Emu is executing.",
+          "This matches what is used to load the AppLayer configuration name.",
+          "When running through a compatibility layer like wine, this will only be the exe name, instead of wine full path."
+        ]
+      },
       "IS64BIT_MODE": {
         "Type": "bool",
         "Default": "false"

--- a/Source/Tests/FEXLoader.cpp
+++ b/Source/Tests/FEXLoader.cpp
@@ -328,6 +328,7 @@ int main(int argc, char **argv, char **const envp) {
   }
 
   FEXCore::Config::Set(FEXCore::Config::CONFIG_APP_FILENAME, std::filesystem::canonical(Program.first).string());
+  FEXCore::Config::Set(FEXCore::Config::CONFIG_APP_CONFIG_NAME, Program.second);
   FEXCore::Config::Set(FEXCore::Config::CONFIG_IS64BIT_MODE, Loader.Is64BitMode() ? "1" : "0");
 
   std::unique_ptr<FEX::HLE::MemAllocator> Allocator;

--- a/Source/Tests/LinuxSyscalls/FileManagement.h
+++ b/Source/Tests/LinuxSyscalls/FileManagement.h
@@ -80,6 +80,7 @@ private:
   FEX_CONFIG_OPT(ThunkHostLibs, THUNKHOSTLIBS);
   FEX_CONFIG_OPT(ThunkGuestLibs, THUNKGUESTLIBS);
   FEX_CONFIG_OPT(ThunkConfig, THUNKCONFIG);
+  FEX_CONFIG_OPT(AppConfigName, APP_CONFIG_NAME);
   uint32_t CurrentPID{};
 
   void LoadThunkDatabase(bool Global);


### PR DESCRIPTION
Previously in order to enable thunks, we needed an independent
description file of which thunks to be enabled. This is nice for quickly
testing out new games by setting `FEX_THUNKCONFIG` environment variable.

For users that just want to enable thunks this is an unwieldy
indirection that doesn't make much sense at a glance.

Previously this meant you needed two files as an example:
```
  ryanh@ubuntu-linux-20-04-desktop:~/.fex-emu$ cat thunks.json
  {
    "ThunksDB": {
      "GL": 1,
      "Vulkan": 1
    }
  }
  ryanh@ubuntu-linux-20-04-desktop:~/.fex-emu$ cat AppConfig/EnderLiliesSteam-Linux-Shipping.json
  {
    "Config": {
      "ThunkConfig":"~\/.fex-emu\/thunks.json"
    }
  }
```

Instead of this unwieldy redirection just support `ThunksDB` json
directly in the AppConfig.

```
  ryanh@ubuntu-linux-20-04-desktop:~/.fex-emu$ cat AppConfig/EnderLiliesSteam-Linux-Shipping.json
  {
    "Config": {
      <...>
    },
    "ThunksDB": {
      "GL": 1,
      "Vulkan": 1
    }
  }
```

As can be seen this makes this significantly easier for new users
getting in to thunks. Depending on which path to enable thunks the user
is more comfortable with, they can still enable them using the
`ThunkConfig` option or embedding directly in the application
configuration.

Additionally this removes the older non-ThunksDB path to loading thunks.
All users of it have moved on to using ThunksDB.