### PR TITLE
VectorOps: Extend VectorZero

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -426,6 +426,7 @@ void Arm64JITCore::Op_NoOp(IR::IROp_Header *IROp, IR::NodeID Node) {
 Arm64JITCore::Arm64JITCore(FEXCore::Context::Context *ctx, FEXCore::Core::InternalThreadState *Thread)
   : CPUBackend(Thread, INITIAL_CODE_SIZE, MAX_CODE_SIZE)
   , Arm64Emitter(ctx, 0)
+  , CanUseSVE{ctx->HostFeatures.SupportsAVX}
   , CTX {ctx} {
 
   RAPass = Thread->PassManager->GetPass<IR::RegisterAllocationPass>("RA");

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -66,6 +66,7 @@ public:
 
 private:
   FEX_CONFIG_OPT(ParanoidTSO, PARANOIDTSO);
+  const bool CanUseSVE{};
 
   Label *PendingTargetLabel;
   FEXCore::Context::Context *CTX;

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -12,17 +12,27 @@ using namespace vixl;
 using namespace vixl::aarch64;
 #define DEF_OP(x) void Arm64JITCore::Op_##x(IR::IROp_Header *IROp, IR::NodeID Node)
 DEF_OP(VectorZero) {
-  uint8_t OpSize = IROp->Size;
-  switch (OpSize) {
-    case 8: {
-      eor(GetDst(Node).V8B(), GetDst(Node).V8B(), GetDst(Node).V8B());
-      break;
+  if (CanUseSVE) {
+    const auto Dst = GetDst(Node).Z().VnD();
+    eor(Dst, Dst, Dst);
+  } else {
+    const uint8_t OpSize = IROp->Size;
+
+    switch (OpSize) {
+      case 8: {
+        const auto Dst = GetDst(Node).V8B();
+        eor(Dst, Dst, Dst);
+        break;
+      }
+      case 16: {
+        const auto Dst = GetDst(Node).V16B();
+        eor(Dst, Dst, Dst);
+        break;
+      }
+      default:
+        LOGMAN_MSG_A_FMT("Unknown Op Size: {}", OpSize);
+        break;
     }
-    case 16: {
-       eor(GetDst(Node).V16B(), GetDst(Node).V16B(), GetDst(Node).V16B());
-       break;
-     }
-    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", OpSize); break;
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -181,6 +181,10 @@ private:
   [[nodiscard]] Xbyak::Xmm GetSrc(IR::NodeID Node) const;
   [[nodiscard]] Xbyak::Xmm GetDst(IR::NodeID Node) const;
 
+  [[nodiscard]] static Xbyak::Ymm ToYMM(const Xbyak::Xmm& xmm) {
+    return Xbyak::Ymm{xmm.getIdx()};
+  }
+
   [[nodiscard]] Xbyak::RegExp GenerateModRM(Xbyak::Reg Base, IR::OrderedNodeWrapper Offset,
                                             IR::MemOffsetType OffsetType, uint8_t OffsetScale) const;
 


### PR DESCRIPTION
Initial opening commit to begin bringing forward some ops to support SVE. Particularly the super trivial operations that allow us to get things up and running.

More to follow after this PR, since all of the necessary helper functions and other minor things will be in place.