### PR TITLE
unittests/ThunkLibs: Fix warning about "dangerous" use of tmpnam

### DIFF
--- a/unittests/ThunkLibs/generator.cpp
+++ b/unittests/ThunkLibs/generator.cpp
@@ -47,7 +47,10 @@ std::ostream& operator<<(std::ostream& os, const SourceWithAST& ast) {
 
 struct Fixture {
     Fixture() {
-        tmpdir = std::tmpnam(nullptr);
+        tmpdir = std::string { P_tmpdir } + "/thunkgentestXXXXXX";
+        if (!mkdtemp(tmpdir.data())) {
+            std::abort();
+        }
         std::filesystem::create_directory(tmpdir);
         output_filenames = {
             tmpdir + "/function_unpacks",


### PR DESCRIPTION
tmpnam is considered insecure since it's vulnerable to TOCTOU issues (as generating the filename and creating the directory are done separately). This is not an issue for these tests, but replacing tmpnam is not any more complicated than silencing the warning.
