### PR TITLE
VectorOps: Extend VAnd/VBic/VOr/VXor

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -154,7 +154,16 @@ DEF_OP(VBic) {
 
 DEF_OP(VOr) {
   auto Op = IROp->C<IR::IROp_VOr>();
-  orr(GetDst(Node).V16B(), GetSrc(Op->Vector1.ID()).V16B(), GetSrc(Op->Vector2.ID()).V16B());
+
+  const auto Dst = GetDst(Node);
+  const auto Vector1 = GetSrc(Op->Vector1.ID());
+  const auto Vector2 = GetSrc(Op->Vector2.ID());
+
+  if (CanUseSVE) {
+    orr(Dst.Z().VnD(), Vector1.Z().VnD(), Vector2.Z().VnD());
+  } else {
+    orr(Dst.V16B(), Vector1.V16B(), Vector2.V16B());
+  }
 }
 
 DEF_OP(VXor) {

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -140,7 +140,16 @@ DEF_OP(VAnd) {
 
 DEF_OP(VBic) {
   auto Op = IROp->C<IR::IROp_VBic>();
-  bic(GetDst(Node).V16B(), GetSrc(Op->Vector1.ID()).V16B(), GetSrc(Op->Vector2.ID()).V16B());
+
+  const auto Dst = GetDst(Node);
+  const auto Vector1 = GetSrc(Op->Vector1.ID());
+  const auto Vector2 = GetSrc(Op->Vector2.ID());
+
+  if (CanUseSVE) {
+    bic(Dst.Z().VnD(), Vector1.Z().VnD(), Vector2.Z().VnD());
+  } else {
+    bic(Dst.V16B(), Vector1.V16B(), Vector2.V16B());
+  }
 }
 
 DEF_OP(VOr) {

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -126,7 +126,16 @@ DEF_OP(VMov) {
 
 DEF_OP(VAnd) {
   auto Op = IROp->C<IR::IROp_VAnd>();
-  and_(GetDst(Node).V16B(), GetSrc(Op->Vector1.ID()).V16B(), GetSrc(Op->Vector2.ID()).V16B());
+
+  const auto Dst = GetDst(Node);
+  const auto Vector1 = GetSrc(Op->Vector1.ID());
+  const auto Vector2 = GetSrc(Op->Vector2.ID());
+
+  if (CanUseSVE) {
+    and_(Dst.Z().VnD(), Vector1.Z().VnD(), Vector2.Z().VnD());
+  } else {
+    and_(Dst.V16B(), Vector1.V16B(), Vector2.V16B());
+  }
 }
 
 DEF_OP(VBic) {

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -168,7 +168,16 @@ DEF_OP(VOr) {
 
 DEF_OP(VXor) {
   auto Op = IROp->C<IR::IROp_VXor>();
-  eor(GetDst(Node).V16B(), GetSrc(Op->Vector1.ID()).V16B(), GetSrc(Op->Vector2.ID()).V16B());
+
+  const auto Dst = GetDst(Node);
+  const auto Vector1 = GetSrc(Op->Vector1.ID());
+  const auto Vector2 = GetSrc(Op->Vector2.ID());
+
+  if (CanUseSVE) {
+    eor(Dst.Z().VnD(), Vector1.Z().VnD(), Vector2.Z().VnD());
+  } else {
+    eor(Dst.V16B(), Vector1.V16B(), Vector2.V16B());
+  }
 }
 
 DEF_OP(VAdd) {

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
@@ -157,7 +157,12 @@ DEF_OP(VBic) {
 
 DEF_OP(VOr) {
   auto Op = IROp->C<IR::IROp_VOr>();
-  vpor(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
+
+  const auto Dst = ToYMM(GetDst(Node));
+  const auto Vector1 = ToYMM(GetSrc(Op->Vector1.ID()));
+  const auto Vector2 = ToYMM(GetSrc(Op->Vector2.ID()));
+
+  vpor(Dst, Vector1, Vector2);
 }
 
 DEF_OP(VXor) {

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
@@ -134,7 +134,12 @@ DEF_OP(VMov) {
 
 DEF_OP(VAnd) {
   auto Op = IROp->C<IR::IROp_VAnd>();
-  vpand(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
+
+  const auto Dst = ToYMM(GetDst(Node));
+  const auto Vector1 = ToYMM(GetSrc(Op->Vector1.ID()));
+  const auto Vector2 = ToYMM(GetSrc(Op->Vector2.ID()));
+
+  vpand(Dst, Vector1, Vector2);
 }
 
 DEF_OP(VBic) {

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
@@ -144,10 +144,15 @@ DEF_OP(VAnd) {
 
 DEF_OP(VBic) {
   auto Op = IROp->C<IR::IROp_VBic>();
+
+  const auto Dst = ToYMM(GetDst(Node));
+  const auto Vector1 = ToYMM(GetSrc(Op->Vector1.ID()));
+  const auto Vector2 = ToYMM(GetSrc(Op->Vector2.ID()));
+
   // This doesn't map directly to ARM
-  vpcmpeqd(xmm15, xmm15, xmm15);
-  vpxor(xmm15, GetSrc(Op->Vector2.ID()), xmm15);
-  vpand(GetDst(Node), GetSrc(Op->Vector1.ID()), xmm15);
+  vpcmpeqd(ymm15, ymm15, ymm15);
+  vpxor(ymm15, Vector2, ymm15);
+  vpand(Dst, Vector1, ymm15);
 }
 
 DEF_OP(VOr) {

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
@@ -167,7 +167,12 @@ DEF_OP(VOr) {
 
 DEF_OP(VXor) {
   auto Op = IROp->C<IR::IROp_VXor>();
-  vpxor(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
+
+  const auto Dst = ToYMM(GetDst(Node));
+  const auto Vector1 = ToYMM(GetSrc(Op->Vector1.ID()));
+  const auto Vector2 = ToYMM(GetSrc(Op->Vector2.ID()));
+
+  vpxor(Dst, Vector1, Vector2);
 }
 
 DEF_OP(VAdd) {


### PR DESCRIPTION
Fairly trivial extending that allows SVE to be used to handle 256-bit vectors