### PR TITLE
InterpreterOps: Extend SSAData size to accomodate 256-bit operations

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterDefines.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterDefines.h
@@ -159,21 +159,26 @@
   break;                                            \
   }
 
+struct InterpVector256 {
+  __uint128_t Lower;
+  __uint128_t Upper;
+};
+
 template<typename Res>
 Res GetDest(void* SSAData, FEXCore::IR::OrderedNodeWrapper Op) {
-  auto DstPtr = &reinterpret_cast<__uint128_t*>(SSAData)[Op.ID().Value];
+  auto DstPtr = &reinterpret_cast<InterpVector256*>(SSAData)[Op.ID().Value];
   return reinterpret_cast<Res>(DstPtr);
 }
 
 template<typename Res>
 Res GetDest(void* SSAData, FEXCore::IR::NodeID Op) {
-  auto DstPtr = &reinterpret_cast<__uint128_t*>(SSAData)[Op.Value];
+  auto DstPtr = &reinterpret_cast<InterpVector256*>(SSAData)[Op.Value];
   return reinterpret_cast<Res>(DstPtr);
 }
 
 
 template<typename Res>
 Res GetSrc(void* SSAData, FEXCore::IR::OrderedNodeWrapper Src) {
-  auto DstPtr = &reinterpret_cast<__uint128_t*>(SSAData)[Src.ID().Value];
+  auto DstPtr = &reinterpret_cast<InterpVector256*>(SSAData)[Src.ID().Value];
   return reinterpret_cast<Res>(DstPtr);
 }

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -347,15 +347,17 @@ void InterpreterOps::InterpretIR(FEXCore::Core::CpuStateFrame *Frame, FEXCore::I
   constexpr size_t ListEntrySizeInBytes = sizeof(InterpVector256);
   const size_t SSADataSize = ListSize * ListEntrySizeInBytes;
 
-  InterpreterOps::IROpData OpData{};
-  OpData.State = Frame->Thread;
-  OpData.SSAData = alloca(SSADataSize);
-  OpData.CurrentEntry = Frame->State.rip;
-  OpData.CurrentIR = CurrentIR;
-  OpData.StackEntry = StackEntry;
-  OpData.BlockIterator = CurrentIR->GetBlocks().begin();
+  InterpreterOps::IROpData OpData{
+    .State = Frame->Thread,
+    .CurrentEntry = Frame->State.rip,
+    .CurrentIR = CurrentIR,
+    .StackEntry = StackEntry,
+    .SSAData = alloca(SSADataSize),
+    .BlockResults = {},
+    .BlockIterator = CurrentIR->GetBlocks().begin(),
+  };
 
-  // Clear them all to zero. Required for Zero-extend semantics
+  // Clear all SSAData entries to zero. Required for Zero-extend semantics
   memset(OpData.SSAData, 0, SSADataSize);
 
   while (1) {


### PR DESCRIPTION
Extends how the SSAData block is allocated so that 256-bit operations can be implemented safely.

One other point to bring up is the preferred path forward to supporting those operations in the interpreter. We use `__uint128_t` fairly extensively, but there is no `__uint256_t` equivalent to translate over to.  Currently I was thinking of using an existing solution like [this project](https://github.com/calccrypto/uint256_t) that provides a uint256_t type, but wanted to hear other ideas if anyone had them.