### PR TITLE
Github: Fix fresh runner rootfs checkout

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -40,7 +40,6 @@ jobs:
       # Use a bash shell so we can use the same syntax for environment variable
       # access regardless of the host operating system
       shell: bash
-      working-directory: ${{runner.workspace}}/build
       run: $GITHUB_WORKSPACE/Scripts/CI_FetchRootFS.py
 
     - name : submodule checkout


### PR DESCRIPTION
build folder doesn't exist on a freshly started runner.
Executing the rootfs fetch script doesn't care what the working
directory is. Doesn't need to be in `build/` which doesn't exist on a
fresh runner and will fail chdir.