### PR TITLE
Thunks: Consolidate all generated code to one file per library per platform

### DIFF
--- a/ThunkLibs/Generator/gen.cpp
+++ b/ThunkLibs/Generator/gen.cpp
@@ -527,23 +527,6 @@ void GenerateThunkLibsAction::EndSourceFileAction() {
             file << ") -> " << data.return_type.getAsString() << ";\n";
         }
 
-        for (std::size_t namespace_idx = 0; namespace_idx < namespaces.size(); ++namespace_idx) {
-            bool empty = true;
-            for (auto& symbol : thunked_api) {
-                if (symbol.symtable_namespace == namespace_idx) {
-                    if (empty) {
-                        file << "static struct { const char* name; void (*fn)(); } " << namespaces[namespace_idx].name << "_symtable[] = {\n";
-                        empty = false;
-                    }
-                    file << "  { \"" << symbol.function_name << "\", (void(*)())&" << symbol.function_name << " },\n";
-                }
-            }
-            if (!empty) {
-                file << "  { nullptr, nullptr }\n";
-                file << "};\n";
-            }
-        }
-
         file << "}\n";
     }
 

--- a/ThunkLibs/Generator/gen.cpp
+++ b/ThunkLibs/Generator/gen.cpp
@@ -471,9 +471,11 @@ void GenerateThunkLibsAction::EndSourceFileAction() {
         return std::string { function_name } + "CBFN" + std::to_string(param_index);
     };
 
-    if (!output_filenames.thunks.empty()) {
-        std::ofstream file(output_filenames.thunks);
+    // Files used guest-side
+    if (!output_filenames.guest.empty()) {
+        std::ofstream file(output_filenames.guest);
 
+        // Guest->Host transition points for API functions
         file << "extern \"C\" {\n";
         for (auto& thunk : thunks) {
             const auto& function_name = thunk.function_name;
@@ -481,13 +483,14 @@ void GenerateThunkLibsAction::EndSourceFileAction() {
             file << "MAKE_THUNK(" << libname << ", " << function_name << ", \"";
             bool first = true;
             for (auto c : sha256) {
-                file << (first ? "" : ", ") << "0x" << std::hex << std::setw(2) << std::setfill('0') << +c;
+                file << (first ? "" : ", ") << "0x" << std::hex << std::setw(2) << std::setfill('0') << +c << std::dec;
                 first = false;
             }
             file << "\")\n";
         }
         file << "}\n";
 
+        // Guest->Host transition points for invoking runtime host-function pointers based on their signature
         for (auto type_it = funcptr_types.begin(); type_it != funcptr_types.end(); ++type_it) {
             auto* type = *type_it;
             std::string funcptr_signature = clang::QualType { type, 0 }.getAsString();
@@ -506,33 +509,8 @@ void GenerateThunkLibsAction::EndSourceFileAction() {
             auto funcptr_idx = std::distance(funcptr_types.begin(), type_it);
             file << "  MAKE_CALLBACK_THUNK(callback_" << funcptr_idx << ", " << funcptr_signature << ", \"" << cb_sha256_str << "\");\n";
         }
-    }
 
-    if (!output_filenames.function_packs_public.empty()) {
-        std::ofstream file(output_filenames.function_packs_public);
-
-        file << "extern \"C\" {\n";
-        for (auto& data : thunked_api) {
-            if (data.custom_guest_impl) {
-                continue;
-            }
-
-            const auto& function_name = data.function_name;
-
-            file << "__attribute__((alias(\"fexfn_pack_" << function_name << "\"))) auto " << function_name << "(";
-            for (std::size_t idx = 0; idx < data.param_types.size(); ++idx) {
-                auto& type = data.param_types[idx];
-                file << (idx == 0 ? "" : ", ") << format_decl(type, "a_" + std::to_string(idx));
-            }
-            file << ") -> " << data.return_type.getAsString() << ";\n";
-        }
-
-        file << "}\n";
-    }
-
-    if (!output_filenames.function_packs.empty()) {
-        std::ofstream file(output_filenames.function_packs);
-
+        // Thunks-internal packing functions
         file << "extern \"C\" {\n";
         for (auto& data : thunks) {
             const auto& function_name = data.function_name;
@@ -575,15 +553,89 @@ void GenerateThunkLibsAction::EndSourceFileAction() {
             file << "}\n";
         }
         file << "}\n";
+
+        // Publicly exports equivalent to symbols exported from the native guest library
+        file << "extern \"C\" {\n";
+        for (auto& data : thunked_api) {
+            if (data.custom_guest_impl) {
+                continue;
+            }
+
+            const auto& function_name = data.function_name;
+
+            file << "__attribute__((alias(\"fexfn_pack_" << function_name << "\"))) auto " << function_name << "(";
+            for (std::size_t idx = 0; idx < data.param_types.size(); ++idx) {
+                auto& type = data.param_types[idx];
+                file << (idx == 0 ? "" : ", ") << format_decl(type, "a_" + std::to_string(idx));
+            }
+            file << ") -> " << data.return_type.getAsString() << ";\n";
+        }
+        file << "}\n";
+
+        // Symbol enumerators
+        for (std::size_t namespace_idx = 0; namespace_idx < namespaces.size(); ++namespace_idx) {
+            const auto& ns = namespaces[namespace_idx];
+            file << "#define FOREACH_" << ns.name << (ns.name.empty() ? "" : "_") << "SYMBOL(EXPAND) \\\n";
+            for (auto& symbol : thunked_api) {
+                if (symbol.symtable_namespace.value_or(0) == namespace_idx) {
+                    file << "  EXPAND(" << symbol.function_name << ", \"TODO\") \\\n";
+                }
+            }
+            file << "\n";
+        }
     }
 
-    if (!output_filenames.function_unpacks.empty()) {
-        std::ofstream file(output_filenames.function_unpacks);
+    // Files used host-side
+    if (!output_filenames.host.empty()) {
+        std::ofstream file(output_filenames.host);
+
+        // Forward declarations for symbols loaded from the native host library
+        for (auto& import : thunked_api) {
+            const auto& function_name = import.function_name;
+            const char* variadic_ellipsis = import.is_variadic ? ", ..." : "";
+            file << "using fexldr_type_" << libname << "_" << function_name << " = auto " << "(" << format_function_params(import) << variadic_ellipsis << ") -> " << import.return_type.getAsString() << ";\n";
+            file << "static fexldr_type_" << libname << "_" << function_name << " *fexldr_ptr_" << libname << "_" << function_name << ";\n";
+        }
 
         file << "extern \"C\" {\n";
         for (auto& thunk : thunks) {
             const auto& function_name = thunk.function_name;
 
+            // Generate stub callbacks
+            for (auto& [cb_idx, cb] : thunk.callbacks) {
+                if (cb.is_stub) {
+                    const char* variadic_ellipsis = cb.is_variadic ? ", ..." : "";
+                    auto cb_function_name = "fexfn_unpack_" + get_callback_name(function_name, cb_idx) + "_stub";
+                    file << "[[noreturn]] static " << cb.return_type.getAsString() << " "
+                         << cb_function_name << "("
+                         << format_function_params(cb) << variadic_ellipsis << ") {\n";
+                    file << "  fprintf(stderr, \"FATAL: Attempted to invoke callback stub for " << function_name << "\\n\");\n";
+                    file << "  std::abort();\n";
+                    file << "}\n";
+                }
+            }
+
+            // Forward declarations for user-provided implementations
+            if (thunk.custom_host_impl) {
+                file << "static auto fexfn_impl_" << libname << "_" << function_name << "(";
+                for (std::size_t idx = 0; idx < thunk.param_types.size(); ++idx) {
+                    // TODO: fex_guest_function_ptr for guest callbacks?
+                    auto& type = thunk.param_types[idx];
+
+                    file << (idx == 0 ? "" : ", ");
+
+                    auto cb = thunk.callbacks.find(idx);
+                    if (cb != thunk.callbacks.end() && cb->second.is_guest) {
+                        file << "fex_guest_function_ptr a_" << idx;
+                    } else {
+                      file << format_decl(type, "a_" + std::to_string(idx));
+                    }
+                }
+                // Using trailing return type as it makes handling function pointer returns much easier
+                file << ") -> " << thunk.return_type.getAsString() << ";\n";
+            }
+
+            // Packed argument structs used in fexfn_unpack_*
             auto GeneratePackedArgs = [&](const auto &function_name, const auto &thunk) -> std::string {
                 std::string struct_name = "fexfn_packed_args_" + libname + "_" + function_name;
                 file << "struct " << struct_name << " {\n";
@@ -598,24 +650,9 @@ void GenerateThunkLibsAction::EndSourceFileAction() {
                 file << "};\n";
                 return struct_name;
             };
-
-            /* Generate stub callbacks */
-            for (auto& [cb_idx, cb] : thunk.callbacks) {
-                if (cb.is_stub) {
-                    const char* variadic_ellipsis = cb.is_variadic ? ", ..." : "";
-                    auto cb_function_name = "fexfn_unpack_" + get_callback_name(function_name, cb_idx) + "_stub";
-                    file << "[[noreturn]] static " << cb.return_type.getAsString() << " "
-                         << cb_function_name << "("
-                         << format_function_params(cb) << variadic_ellipsis << ") {\n";
-                    file << "  fprintf(stderr, \"FATAL: Attempted to invoke callback stub for " << function_name << "\\n\");\n";
-                    file << "  std::abort();\n";
-                    file << "}\n";
-                }
-            }
-
             auto struct_name = GeneratePackedArgs(function_name, thunk);
 
-            FunctionParams args = thunk;
+            // Unpacking functions
             auto function_to_call = "fexldr_ptr_" + libname + "_" + function_name;
             if (thunk.custom_host_impl) {
                 function_to_call = "fexfn_impl_" + libname + "_" + function_name;
@@ -640,29 +677,27 @@ void GenerateThunkLibsAction::EndSourceFileAction() {
                     }
                 };
 
-                file << format_function_args(args, format_param);
+                file << format_function_args(thunk, format_param);
             }
             file << ");\n";
             file << "}\n";
         }
-
         file << "}\n";
-    }
 
-    if (!output_filenames.tab_function_unpacks.empty()) {
-        std::ofstream file(output_filenames.tab_function_unpacks);
-
+        // Endpoints for Guest->Host invocation of API functions
+        file << "static ExportEntry exports[] = {\n";
         for (auto& thunk : thunks) {
             const auto& function_name = thunk.function_name;
             auto sha256 = get_sha256(function_name);
 
             file << "{(uint8_t*)\"";
             for (auto c : sha256) {
-                file << "\\x" << std::hex << std::setw(2) << std::setfill('0') << +c;
+                file << "\\x" << std::hex << std::setw(2) << std::setfill('0') << +c << std::dec;
             }
             file << "\", (void(*)(void *))&fexfn_unpack_" << libname << "_" << function_name << "}, // " << libname << ":" << function_name << "\n";
         }
 
+        // Endpoints for Guest->Host invocation of runtime host-function pointers
         for (auto& type : funcptr_types) {
             std::string mangled_name = clang::QualType { type, 0 }.getAsString();
             {
@@ -676,11 +711,10 @@ void GenerateThunkLibsAction::EndSourceFileAction() {
                 file << "  {(uint8_t*)\"" << cb_sha256_str << "\", (void(*)(void *))&CallbackUnpack<" << mangled_name << ">::ForIndirectCall},\n";
             }
         }
-    }
+        file << "  { nullptr, nullptr }\n";
+        file << "};\n";
 
-    if (!output_filenames.ldr.empty()) {
-        std::ofstream file(output_filenames.ldr);
-
+        // Symbol lookup from native host library
         file << "static void* fexldr_ptr_" << libname << "_so;\n";
         file << "extern \"C\" bool fexldr_init_" << libname << "() {\n";
 
@@ -697,32 +731,7 @@ void GenerateThunkLibsAction::EndSourceFileAction() {
         }
         file << "  return true;\n";
         file << "}\n";
-    }
 
-    if (!output_filenames.ldr_ptrs.empty()) {
-        std::ofstream file(output_filenames.ldr_ptrs);
-
-        for (auto& import : thunked_api) {
-            const auto& function_name = import.function_name;
-            const char* variadic_ellipsis = import.is_variadic ? ", ..." : "";
-            file << "using fexldr_type_" << libname << "_" << function_name << " = auto " << "(" << format_function_params(import) << variadic_ellipsis << ") -> " << import.return_type.getAsString() << ";\n";
-            file << "static fexldr_type_" << libname << "_" << function_name << " *fexldr_ptr_" << libname << "_" << function_name << ";\n";
-        }
-    }
-
-    if (!output_filenames.symbol_list.empty()) {
-        std::ofstream file(output_filenames.symbol_list);
-
-        for (std::size_t namespace_idx = 0; namespace_idx < namespaces.size(); ++namespace_idx) {
-            const auto& ns = namespaces[namespace_idx];
-            file << "#define FOREACH_" << ns.name << (ns.name.empty() ? "" : "_") << "SYMBOL(EXPAND) \\\n";
-            for (auto& symbol : thunked_api) {
-                if (symbol.symtable_namespace.value_or(0) == namespace_idx) {
-                    file << "  EXPAND(" << symbol.function_name << ", \"TODO\") \\\n";
-                }
-            }
-            file << "\n";
-        }
     }
 }
 

--- a/ThunkLibs/Generator/interface.h
+++ b/ThunkLibs/Generator/interface.h
@@ -5,19 +5,8 @@
 #include <string>
 
 struct OutputFilenames {
-    // Host
-    std::string function_unpacks;
-    std::string tab_function_unpacks;
-    std::string ldr;
-    std::string ldr_ptrs;
-
-    // Guest
-    std::string thunks;
-    std::string function_packs;
-    std::string function_packs_public;
-
-    // Guest + Host
-    std::string symbol_list;
+    std::string host;
+    std::string guest;
 };
 
 class GenerateThunkLibsAction : public clang::ASTFrontendAction {

--- a/ThunkLibs/Generator/main.cpp
+++ b/ThunkLibs/Generator/main.cpp
@@ -26,37 +26,27 @@ int main(int argc, char* argv[]) {
         std::cerr << "\nError: " << error << "\n";
         return EXIT_FAILURE;
     }
-    char** const last_internal_arg = argv + argc;
+
+    // Process arguments before the "--" separator
+    if (argc != 5) {
+        print_usage(argv[0]);
+        return EXIT_FAILURE;
+    }
 
     char** arg = argv + 1;
     const auto filename = *arg++;
     const std::string libname = *arg++;
+    const std::string target_abi = *arg++;
+    const std::string output_filename = *arg++;
 
-    // Iterate over generator targets (remaining arguments up to "--" separator)
     OutputFilenames output_filenames;
-    while (arg < last_internal_arg) {
-        auto target = std::string { *arg++ };
-        auto out_filename = *arg++;
-        if (target == "-function_unpacks") {
-            output_filenames.function_unpacks = out_filename;
-        } else if (target == "-tab_function_unpacks") {
-            output_filenames.tab_function_unpacks = out_filename;
-        } else if (target == "-ldr") {
-            output_filenames.ldr = out_filename;
-        } else if (target == "-ldr_ptrs") {
-            output_filenames.ldr_ptrs = out_filename;
-        } else if (target == "-thunks") {
-            output_filenames.thunks = out_filename;
-        } else if (target == "-function_packs") {
-            output_filenames.function_packs = out_filename;
-        } else if (target == "-function_packs_public") {
-            output_filenames.function_packs_public = out_filename;
-        } else if (target == "-symbol_list") {
-            output_filenames.symbol_list = out_filename;
-        } else {
-            std::cerr << "Unrecognized generator target \"" << target << "\"\n";
-            return EXIT_FAILURE;
-        }
+    if (target_abi == "-host") {
+        output_filenames.host = output_filename;
+    } else if (target_abi == "-guest") {
+        output_filenames.guest = output_filename;
+    } else {
+        std::cerr << "Unrecognized generator target ABI \"" << target_abi << "\"\n";
+        return EXIT_FAILURE;
     }
 
     ClangTool Tool(*compile_db, { filename });

--- a/ThunkLibs/GuestLibs/CMakeLists.txt
+++ b/ThunkLibs/GuestLibs/CMakeLists.txt
@@ -17,7 +17,7 @@ else()
   set(GENERATE_GUEST_INSTALL_TARGETS FALSE)
 endif()
 
-# Syntax: generate(libxyz libxyz-interface.cpp generator-targets...)
+# Syntax: generate(libxyz libxyz-interface.cpp)
 # This defines a target and a custom command:
 # - custom command: Main build step that runs the thunk generator on the given interface definition
 # - libxyz-guest-deps: Interface target to read include directories from which are passed to libclang when parsing the interface definition
@@ -32,27 +32,25 @@ function(generate NAME SOURCE_FILE)
   set(compile_prop "$<TARGET_PROPERTY:${NAME}-guest-deps,INTERFACE_COMPILE_DEFINITIONS>")
 
   # Run thunk generator for each of the given output files
-  foreach(WHAT IN LISTS ARGN)
-    set(OUTFOLDER "${CMAKE_CURRENT_BINARY_DIR}/gen/${NAME}")
-    set(OUTFILE "${OUTFOLDER}/${WHAT}.inl")
+  set(OUTFOLDER "${CMAKE_CURRENT_BINARY_DIR}/gen")
+  set(OUTFILE "${OUTFOLDER}/thunkgen_guest_${NAME}.inl")
 
-    file(MAKE_DIRECTORY "${OUTFOLDER}")
+  file(MAKE_DIRECTORY "${OUTFOLDER}")
 
-    add_custom_command(
-      OUTPUT "${OUTFILE}"
-      DEPENDS "${GENERATOR_EXE}"
-      DEPENDS "${SOURCE_FILE}"
-      COMMAND "${GENERATOR_EXE}" "${SOURCE_FILE}" "${NAME}" "-${WHAT}" "${OUTFILE}" -- -std=c++17
-        # Expand compile definitions to space-separated list of -D parameters
-        "$<$<BOOL:${compile_prop}>:;-D$<JOIN:${compile_prop},;-D>>"
-        # Expand include directories to space-separated list of -isystem parameters
-        "$<$<BOOL:${prop}>:;-isystem$<JOIN:${prop},;-isystem>>"
-      VERBATIM
-      COMMAND_EXPAND_LISTS
-      )
+  add_custom_command(
+    OUTPUT "${OUTFILE}"
+    DEPENDS "${GENERATOR_EXE}"
+    DEPENDS "${SOURCE_FILE}"
+    COMMAND "${GENERATOR_EXE}" "${SOURCE_FILE}" "${NAME}" "-guest" "${OUTFILE}" -- -std=c++17
+      # Expand compile definitions to space-separated list of -D parameters
+      "$<$<BOOL:${compile_prop}>:;-D$<JOIN:${compile_prop},;-D>>"
+      # Expand include directories to space-separated list of -isystem parameters
+      "$<$<BOOL:${prop}>:;-isystem$<JOIN:${prop},;-isystem>>"
+    VERBATIM
+    COMMAND_EXPAND_LISTS
+    )
 
-    list(APPEND OUTPUTS "${OUTFILE}")
-  endforeach()
+  list(APPEND OUTPUTS "${OUTFILE}")
   set(GEN_${NAME} ${OUTPUTS} PARENT_SCOPE)
 endfunction()
 
@@ -72,7 +70,7 @@ function(add_guest_lib NAME SONAME)
   endif()
 
   add_library(${NAME}-guest ${TARGET_TYPE} ${SOURCE_FILE} ${GEN_lib${NAME}})
-  target_include_directories(${NAME}-guest PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/gen/lib${NAME}")
+  target_include_directories(${NAME}-guest PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/gen/")
   target_compile_definitions(${NAME}-guest PRIVATE GUEST_THUNK_LIBRARY)
   target_link_libraries(${NAME}-guest PRIVATE lib${NAME}-guest-deps)
 
@@ -109,16 +107,16 @@ endfunction()
 #add_guest_lib(fex_malloc_loader)
 #target_link_libraries(fex_malloc_loader-guest PRIVATE dl)
 
-#generate(libfex_malloc thunks function_packs function_packs_public)
+#generate(libfex_malloc)
 #add_guest_lib(fex_malloc)
 
-generate(libasound ${CMAKE_CURRENT_SOURCE_DIR}/../libasound/libasound_interface.cpp thunks function_packs function_packs_public)
+generate(libasound ${CMAKE_CURRENT_SOURCE_DIR}/../libasound/libasound_interface.cpp)
 add_guest_lib(asound "libasound.so.2")
 
-generate(libEGL ${CMAKE_CURRENT_SOURCE_DIR}/../libEGL/libEGL_interface.cpp thunks function_packs function_packs_public)
+generate(libEGL ${CMAKE_CURRENT_SOURCE_DIR}/../libEGL/libEGL_interface.cpp)
 add_guest_lib(EGL "libEGL.so.1")
 
-generate(libGL ${CMAKE_CURRENT_SOURCE_DIR}/../libGL/libGL_interface.cpp thunks function_packs function_packs_public symbol_list)
+generate(libGL ${CMAKE_CURRENT_SOURCE_DIR}/../libGL/libGL_interface.cpp)
 add_guest_lib(GL "libGL.so.1")
 
 # libGL must pull in libX11.so, so generate a placeholder libX11.so to link against
@@ -127,7 +125,7 @@ target_link_libraries(GL-guest PRIVATE X11)
 
 # disabled for now, headers are platform specific
 # find_package(SDL2 REQUIRED)
-# generate(libSDL2 thunks function_packs function_packs_public)
+# generate(libSDL2)
 # add_guest_lib(SDL2)
 # target_include_directories(SDL2-guest PRIVATE ${SDL2_INCLUDE_DIRS})
 # target_link_libraries(SDL2-guest PRIVATE GL)
@@ -141,66 +139,66 @@ set(X11_VERSION_MAJOR ${CMAKE_MATCH_1})
 set(X11_VERSION_MINOR ${CMAKE_MATCH_2})
 set(X11_VERSION_PATCH ${CMAKE_MATCH_3})
 
-generate(libX11 ${CMAKE_CURRENT_SOURCE_DIR}/../libX11/libX11_interface.cpp thunks function_packs function_packs_public)
+generate(libX11 ${CMAKE_CURRENT_SOURCE_DIR}/../libX11/libX11_interface.cpp)
 add_guest_lib(X11 "libX11.so.6")
 
 target_compile_definitions(libX11-guest-deps INTERFACE -DX11_VERSION_MAJOR=${X11_VERSION_MAJOR})
 target_compile_definitions(libX11-guest-deps INTERFACE -DX11_VERSION_MINOR=${X11_VERSION_MINOR})
 target_compile_definitions(libX11-guest-deps INTERFACE -DX11_VERSION_PATCH=${X11_VERSION_PATCH})
 
-generate(libXext ${CMAKE_CURRENT_SOURCE_DIR}/../libXext/libXext_interface.cpp thunks function_packs function_packs_public)
+generate(libXext ${CMAKE_CURRENT_SOURCE_DIR}/../libXext/libXext_interface.cpp)
 add_guest_lib(Xext "libXext.so.6")
 
 target_compile_definitions(libXext-guest-deps INTERFACE -DX11_VERSION_MAJOR=${X11_VERSION_MAJOR})
 target_compile_definitions(libXext-guest-deps INTERFACE -DX11_VERSION_MINOR=${X11_VERSION_MINOR})
 target_compile_definitions(libXext-guest-deps INTERFACE -DX11_VERSION_PATCH=${X11_VERSION_PATCH})
 
-generate(libXrender ${CMAKE_CURRENT_SOURCE_DIR}/../libXrender/libXrender_interface.cpp thunks function_packs function_packs_public)
+generate(libXrender ${CMAKE_CURRENT_SOURCE_DIR}/../libXrender/libXrender_interface.cpp)
 add_guest_lib(Xrender "libXrender.so.1")
 
-generate(libXfixes ${CMAKE_CURRENT_SOURCE_DIR}/../libXfixes/libXfixes_interface.cpp thunks function_packs function_packs_public)
+generate(libXfixes ${CMAKE_CURRENT_SOURCE_DIR}/../libXfixes/libXfixes_interface.cpp)
 add_guest_lib(Xfixes "libXfixes.so.3")
 
-generate(libvulkan ${CMAKE_CURRENT_SOURCE_DIR}/../libvulkan/libvulkan_interface.cpp thunks function_packs function_packs_public symbol_list)
+generate(libvulkan ${CMAKE_CURRENT_SOURCE_DIR}/../libvulkan/libvulkan_interface.cpp)
 target_include_directories(libvulkan-guest-deps INTERFACE ${FEX_PROJECT_SOURCE_DIR}/External/Vulkan-Headers/include/)
 add_guest_lib(vulkan "libvulkan.so.1")
 
-generate(libxcb ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb/libxcb_interface.cpp thunks function_packs function_packs_public)
+generate(libxcb ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb/libxcb_interface.cpp)
 add_guest_lib(xcb "libxcb.so.1")
 
-generate(libxcb-dri2 ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-dri2/libxcb-dri2_interface.cpp thunks function_packs function_packs_public)
+generate(libxcb-dri2 ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-dri2/libxcb-dri2_interface.cpp)
 add_guest_lib(xcb-dri2 "libxcb-dri2.so.0")
 
-generate(libxcb-dri3 ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-dri3/libxcb-dri3_interface.cpp thunks function_packs function_packs_public)
+generate(libxcb-dri3 ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-dri3/libxcb-dri3_interface.cpp)
 add_guest_lib(xcb-dri3 "libxcb-dri3.so.0")
 
-generate(libxcb-xfixes ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-xfixes/libxcb-xfixes_interface.cpp thunks function_packs function_packs_public)
+generate(libxcb-xfixes ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-xfixes/libxcb-xfixes_interface.cpp)
 add_guest_lib(xcb-xfixes "libxcb-xfixes.so.0")
 
-generate(libxcb-shm ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-shm/libxcb-shm_interface.cpp thunks function_packs function_packs_public)
+generate(libxcb-shm ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-shm/libxcb-shm_interface.cpp)
 add_guest_lib(xcb-shm "libxcb-shm.so.0")
 
-generate(libxcb-sync ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-sync/libxcb-sync_interface.cpp thunks function_packs function_packs_public)
+generate(libxcb-sync ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-sync/libxcb-sync_interface.cpp)
 add_guest_lib(xcb-sync "libxcb-sync.so.1")
 
-generate(libxcb-present ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-present/libxcb-present_interface.cpp thunks function_packs function_packs_public)
+generate(libxcb-present ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-present/libxcb-present_interface.cpp)
 add_guest_lib(xcb-present "libxcb-present.so.0")
 
-generate(libxcb-randr ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-randr/libxcb-randr_interface.cpp thunks function_packs function_packs_public)
+generate(libxcb-randr ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-randr/libxcb-randr_interface.cpp)
 add_guest_lib(xcb-randr "libxcb-randr.so.0")
 
-generate(libxcb-glx ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-glx/libxcb-glx_interface.cpp thunks function_packs function_packs_public)
+generate(libxcb-glx ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-glx/libxcb-glx_interface.cpp)
 add_guest_lib(xcb-glx "libxcb-glx.so.0")
 
-generate(libxshmfence ${CMAKE_CURRENT_SOURCE_DIR}/../libxshmfence/libxshmfence_interface.cpp thunks function_packs function_packs_public)
+generate(libxshmfence ${CMAKE_CURRENT_SOURCE_DIR}/../libxshmfence/libxshmfence_interface.cpp)
 add_guest_lib(xshmfence "libxshmfence.so.1")
 
-generate(libdrm ${CMAKE_CURRENT_SOURCE_DIR}/../libdrm/libdrm_interface.cpp thunks function_packs function_packs_public)
+generate(libdrm ${CMAKE_CURRENT_SOURCE_DIR}/../libdrm/libdrm_interface.cpp)
 target_include_directories(libdrm-guest-deps INTERFACE /usr/include/drm/)
 target_include_directories(libdrm-guest-deps INTERFACE /usr/include/libdrm/)
 add_guest_lib(drm "libdrm.so.2")
 
-generate(libVDSO ${CMAKE_CURRENT_SOURCE_DIR}/../libVDSO/libVDSO_interface.cpp thunks function_packs function_packs_public)
+generate(libVDSO ${CMAKE_CURRENT_SOURCE_DIR}/../libVDSO/libVDSO_interface.cpp)
 add_guest_lib(VDSO "linux-vdso.so.1")
 # Can't use a stack protector because otherwise cross-compiling fails
 # Not necessary anyway because it only trampolines

--- a/ThunkLibs/HostLibs/CMakeLists.txt
+++ b/ThunkLibs/HostLibs/CMakeLists.txt
@@ -4,7 +4,7 @@ project(host-thunks)
 set(CMAKE_CXX_STANDARD 17)
 set (HOSTLIBS_DATA_DIRECTORY "${CMAKE_INSTALL_PREFIX}/lib/fex-emu" CACHE PATH "global data directory")
 
-# Syntax: generate(libxyz libxyz-interface.cpp generator-targets...)
+# Syntax: generate(libxyz libxyz-interface.cpp)
 # This defines two targets and a custom command:
 # - custom command: Main build step that runs the thunk generator on the given interface definition
 # - libxyz-interface: Target for IDE integration (making sure libxyz-interface.cpp shows up as a source file in the project tree)
@@ -29,27 +29,25 @@ function(generate NAME SOURCE_FILE)
   target_link_libraries(${NAME}-interface PRIVATE ${NAME}-deps)
 
   # Run thunk generator for each of the given output files
-  foreach(WHAT IN LISTS ARGN)
-    set(OUTFOLDER "${CMAKE_CURRENT_BINARY_DIR}/gen/${NAME}")
-    set(OUTFILE "${OUTFOLDER}/${WHAT}.inl")
+  set(OUTFOLDER "${CMAKE_CURRENT_BINARY_DIR}/gen")
+  set(OUTFILE "${OUTFOLDER}/thunkgen_host_${NAME}.inl")
 
-    file(MAKE_DIRECTORY "${OUTFOLDER}")
+  file(MAKE_DIRECTORY "${OUTFOLDER}")
 
-    add_custom_command(
-      OUTPUT "${OUTFILE}"
-      DEPENDS "${SOURCE_FILE}"
-      DEPENDS thunkgen
-      COMMAND thunkgen "${SOURCE_FILE}" "${NAME}" "-${WHAT}" "${OUTFILE}" -- -std=c++17
-        # Expand compile definitions to space-separated list of -D parameters
-        "$<$<BOOL:${compile_prop}>:;-D$<JOIN:${compile_prop},;-D>>"
-        # Expand include directories to space-separated list of -isystem parameters
-        "$<$<BOOL:${prop}>:;-isystem$<JOIN:${prop},;-isystem>>"
-      VERBATIM
-      COMMAND_EXPAND_LISTS
-      )
+  add_custom_command(
+    OUTPUT "${OUTFILE}"
+    DEPENDS "${SOURCE_FILE}"
+    DEPENDS thunkgen
+    COMMAND thunkgen "${SOURCE_FILE}" "${NAME}" "-host" "${OUTFILE}" -- -std=c++17
+      # Expand compile definitions to space-separated list of -D parameters
+      "$<$<BOOL:${compile_prop}>:;-D$<JOIN:${compile_prop},;-D>>"
+      # Expand include directories to space-separated list of -isystem parameters
+      "$<$<BOOL:${prop}>:;-isystem$<JOIN:${prop},;-isystem>>"
+    VERBATIM
+    COMMAND_EXPAND_LISTS
+    )
 
-    list(APPEND OUTPUTS "${OUTFILE}")
-  endforeach()
+  list(APPEND OUTPUTS "${OUTFILE}")
   set(GEN_${NAME} ${OUTPUTS} PARENT_SCOPE)
 endfunction()
 
@@ -65,7 +63,7 @@ function(add_host_lib NAME)
   endif()
 
   add_library(${NAME}-host SHARED ${SOURCE_FILE} ${GEN_lib${NAME}})
-  target_include_directories(${NAME}-host PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/gen/lib${NAME}")
+  target_include_directories(${NAME}-host PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/gen/")
   target_link_libraries(${NAME}-host PRIVATE dl)
   target_link_libraries(${NAME}-host PRIVATE lib${NAME}-deps)
   ## Make signed overflow well defined 2's complement overflow
@@ -79,16 +77,16 @@ endfunction()
 
 #add_host_lib(fex_malloc_symbols)
 
-#generate(libfex_malloc function_unpacks tab_function_unpacks ldr ldr_ptrs)
+#generate(libfex_malloc)
 #add_host_lib(fex_malloc)
 
-generate(libasound ${CMAKE_CURRENT_SOURCE_DIR}/../libasound/libasound_interface.cpp function_unpacks tab_function_unpacks ldr ldr_ptrs)
+generate(libasound ${CMAKE_CURRENT_SOURCE_DIR}/../libasound/libasound_interface.cpp)
 add_host_lib(asound)
 
-generate(libEGL ${CMAKE_CURRENT_SOURCE_DIR}/../libEGL/libEGL_interface.cpp function_unpacks tab_function_unpacks ldr ldr_ptrs)
+generate(libEGL ${CMAKE_CURRENT_SOURCE_DIR}/../libEGL/libEGL_interface.cpp)
 add_host_lib(EGL)
 
-generate(libGL ${CMAKE_CURRENT_SOURCE_DIR}/../libGL/libGL_interface.cpp function_unpacks tab_function_unpacks ldr ldr_ptrs)
+generate(libGL ${CMAKE_CURRENT_SOURCE_DIR}/../libGL/libGL_interface.cpp)
 add_host_lib(GL)
 
 find_package(OpenGL REQUIRED)
@@ -96,7 +94,7 @@ target_link_libraries(GL-host PRIVATE OpenGL::GL)
 
 # disabled for now, headers are platform specific
 # find_package(SDL2 REQUIRED)
-# generate(libSDL2 function_unpacks tab_function_unpacks ldr ldr_ptrs)
+# generate(libSDL2)
 # add_host_lib(SDL2)
 # target_include_directories(SDL2-host PRIVATE ${SDL2_INCLUDE_DIRS})
 
@@ -108,61 +106,61 @@ set(X11_VERSION_MAJOR ${CMAKE_MATCH_1})
 set(X11_VERSION_MINOR ${CMAKE_MATCH_2})
 set(X11_VERSION_PATCH ${CMAKE_MATCH_3})
 
-generate(libX11 ${CMAKE_CURRENT_SOURCE_DIR}/../libX11/libX11_interface.cpp function_unpacks tab_function_unpacks ldr ldr_ptrs)
+generate(libX11 ${CMAKE_CURRENT_SOURCE_DIR}/../libX11/libX11_interface.cpp)
 add_host_lib(X11)
 
 target_compile_definitions(libX11-deps INTERFACE -DX11_VERSION_MAJOR=${X11_VERSION_MAJOR})
 target_compile_definitions(libX11-deps INTERFACE -DX11_VERSION_MINOR=${X11_VERSION_MINOR})
 target_compile_definitions(libX11-deps INTERFACE -DX11_VERSION_PATCH=${X11_VERSION_PATCH})
 
-generate(libXext ${CMAKE_CURRENT_SOURCE_DIR}/../libXext/libXext_interface.cpp function_unpacks tab_function_unpacks ldr ldr_ptrs)
+generate(libXext ${CMAKE_CURRENT_SOURCE_DIR}/../libXext/libXext_interface.cpp)
 add_host_lib(Xext)
 
 target_compile_definitions(libXext-deps INTERFACE -DX11_VERSION_MAJOR=${X11_VERSION_MAJOR})
 target_compile_definitions(libXext-deps INTERFACE -DX11_VERSION_MINOR=${X11_VERSION_MINOR})
 target_compile_definitions(libXext-deps INTERFACE -DX11_VERSION_PATCH=${X11_VERSION_PATCH})
 
-generate(libXrender ${CMAKE_CURRENT_SOURCE_DIR}/../libXrender/libXrender_interface.cpp function_unpacks tab_function_unpacks ldr ldr_ptrs)
+generate(libXrender ${CMAKE_CURRENT_SOURCE_DIR}/../libXrender/libXrender_interface.cpp)
 add_host_lib(Xrender)
 
-generate(libXfixes ${CMAKE_CURRENT_SOURCE_DIR}/../libXfixes/libXfixes_interface.cpp function_unpacks tab_function_unpacks ldr ldr_ptrs)
+generate(libXfixes ${CMAKE_CURRENT_SOURCE_DIR}/../libXfixes/libXfixes_interface.cpp)
 add_host_lib(Xfixes)
 
-generate(libvulkan ${CMAKE_CURRENT_SOURCE_DIR}/../libvulkan/libvulkan_interface.cpp function_unpacks tab_function_unpacks ldr ldr_ptrs symbol_list)
+generate(libvulkan ${CMAKE_CURRENT_SOURCE_DIR}/../libvulkan/libvulkan_interface.cpp)
 target_include_directories(libvulkan-deps INTERFACE ${FEX_PROJECT_SOURCE_DIR}/External/Vulkan-Headers/include/)
 add_host_lib(vulkan)
 
-generate(libxcb ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb/libxcb_interface.cpp function_unpacks tab_function_unpacks ldr ldr_ptrs)
+generate(libxcb ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb/libxcb_interface.cpp)
 add_host_lib(xcb)
 
-generate(libxcb-dri2 ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-dri2/libxcb-dri2_interface.cpp function_unpacks tab_function_unpacks ldr ldr_ptrs)
+generate(libxcb-dri2 ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-dri2/libxcb-dri2_interface.cpp)
 add_host_lib(xcb-dri2)
 
-generate(libxcb-dri3 ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-dri3/libxcb-dri3_interface.cpp function_unpacks tab_function_unpacks ldr ldr_ptrs)
+generate(libxcb-dri3 ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-dri3/libxcb-dri3_interface.cpp)
 add_host_lib(xcb-dri3)
 
-generate(libxcb-xfixes ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-xfixes/libxcb-xfixes_interface.cpp function_unpacks tab_function_unpacks ldr ldr_ptrs)
+generate(libxcb-xfixes ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-xfixes/libxcb-xfixes_interface.cpp)
 add_host_lib(xcb-xfixes)
 
-generate(libxcb-shm ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-shm/libxcb-shm_interface.cpp function_unpacks tab_function_unpacks ldr ldr_ptrs)
+generate(libxcb-shm ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-shm/libxcb-shm_interface.cpp)
 add_host_lib(xcb-shm)
 
-generate(libxcb-sync ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-sync/libxcb-sync_interface.cpp function_unpacks tab_function_unpacks ldr ldr_ptrs)
+generate(libxcb-sync ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-sync/libxcb-sync_interface.cpp)
 add_host_lib(xcb-sync)
 
-generate(libxcb-present ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-present/libxcb-present_interface.cpp function_unpacks tab_function_unpacks ldr ldr_ptrs)
+generate(libxcb-present ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-present/libxcb-present_interface.cpp)
 add_host_lib(xcb-present)
 
-generate(libxcb-randr ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-randr/libxcb-randr_interface.cpp function_unpacks tab_function_unpacks ldr ldr_ptrs)
+generate(libxcb-randr ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-randr/libxcb-randr_interface.cpp)
 add_host_lib(xcb-randr)
 
-generate(libxcb-glx ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-glx/libxcb-glx_interface.cpp function_unpacks tab_function_unpacks ldr ldr_ptrs)
+generate(libxcb-glx ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-glx/libxcb-glx_interface.cpp)
 add_host_lib(xcb-glx)
 
-generate(libxshmfence ${CMAKE_CURRENT_SOURCE_DIR}/../libxshmfence/libxshmfence_interface.cpp function_unpacks tab_function_unpacks ldr ldr_ptrs)
+generate(libxshmfence ${CMAKE_CURRENT_SOURCE_DIR}/../libxshmfence/libxshmfence_interface.cpp)
 add_host_lib(xshmfence)
 
-generate(libdrm ${CMAKE_CURRENT_SOURCE_DIR}/../libdrm/libdrm_interface.cpp function_unpacks tab_function_unpacks ldr ldr_ptrs)
+generate(libdrm ${CMAKE_CURRENT_SOURCE_DIR}/../libdrm/libdrm_interface.cpp)
 target_include_directories(libdrm-deps INTERFACE /usr/include/drm/)
 target_include_directories(libdrm-deps INTERFACE /usr/include/libdrm/)
 add_host_lib(drm)

--- a/ThunkLibs/libEGL/libEGL_Guest.cpp
+++ b/ThunkLibs/libEGL/libEGL_Guest.cpp
@@ -13,9 +13,7 @@ $end_info$
 
 #include "common/Guest.h"
 
-#include "thunks.inl"
-#include "function_packs.inl"
-#include "function_packs_public.inl"
+#include "thunkgen_guest_libEGL.inl"
 
 typedef void voidFunc();
 

--- a/ThunkLibs/libEGL/libEGL_Host.cpp
+++ b/ThunkLibs/libEGL/libEGL_Host.cpp
@@ -12,14 +12,6 @@ $end_info$
 #include "common/Host.h"
 #include <dlfcn.h>
 
-#include "ldr_ptrs.inl"
-#include "function_unpacks.inl"
+#include "thunkgen_host_libEGL.inl"
 
-static ExportEntry exports[] = {
-    #include "tab_function_unpacks.inl"
-    { nullptr, nullptr }
-};
-
-#include "ldr.inl"
-
-EXPORTS(libEGL) 
+EXPORTS(libEGL)

--- a/ThunkLibs/libGL/libGL_Guest.cpp
+++ b/ThunkLibs/libGL/libGL_Guest.cpp
@@ -24,10 +24,7 @@ $end_info$
 
 #include "common/Guest.h"
 
-#include "thunks.inl"
-#include "function_packs.inl"
-#include "function_packs_public.inl"
-#include "symbol_list.inl"
+#include "thunkgen_guest_libGL.inl"
 
 typedef void voidFunc();
 

--- a/ThunkLibs/libGL/libGL_Host.cpp
+++ b/ThunkLibs/libGL/libGL_Host.cpp
@@ -22,18 +22,10 @@ $end_info$
 
 #include "common/Host.h"
 
+#include "thunkgen_host_libGL.inl"
+
 void* symbolFromGlXGetProcAddr(void*, const char* name) {
     return (void*)glXGetProcAddress((const GLubyte*)name);
 }
-
-#include "ldr_ptrs.inl"
-#include "function_unpacks.inl"
-
-static ExportEntry exports[] = {
-    #include "tab_function_unpacks.inl"
-    { nullptr, nullptr }
-};
-
-#include "ldr.inl"
 
 EXPORTS(libGL)

--- a/ThunkLibs/libSDL2/libSDL2_Guest.cpp
+++ b/ThunkLibs/libSDL2/libSDL2_Guest.cpp
@@ -19,9 +19,7 @@ $end_info$
 
 #include "common/Guest.h"
 
-#include "thunks.inl"
-#include "function_packs.inl"
-#include "function_packs_public.inl"
+#include "thunkgen_guest_libSDL2.inl"
 
 LOAD_LIB(libSDL2)
 

--- a/ThunkLibs/libSDL2/libSDL2_Host.cpp
+++ b/ThunkLibs/libSDL2/libSDL2_Host.cpp
@@ -12,15 +12,6 @@ $end_info$
 #include "common/Host.h"
 #include <dlfcn.h>
 
-#include "ldr_ptrs.inl"
-#include "function_unpacks.inl"
-
-static ExportEntry exports[] = {
-    #include "tab_function_unpacks.inl"
-    { nullptr, nullptr }
-};
-
-#include "ldr.inl"
+#include "thunkgen_host_libSDL2.inl"
 
 EXPORTS(libSDL2)
-

--- a/ThunkLibs/libVDSO/libVDSO_Guest.cpp
+++ b/ThunkLibs/libVDSO/libVDSO_Guest.cpp
@@ -15,9 +15,7 @@ $end_info$
 
 #include "common/Guest.h"
 
-#include "thunks.inl"
-#include "function_packs.inl"
-#include "function_packs_public.inl"
+#include "thunkgen_guest_libVDSO.inl"
 
 extern "C" {
 time_t __vdso_time(time_t *tloc) __attribute__((alias("fexfn_pack_time")));

--- a/ThunkLibs/libX11/libX11_Guest.cpp
+++ b/ThunkLibs/libX11/libX11_Guest.cpp
@@ -26,10 +26,7 @@ $end_info$
 #include "common/Guest.h"
 #include <stdarg.h>
 
-#include "thunks.inl"
-
-#include "function_packs.inl"
-#include "function_packs_public.inl"
+#include "thunkgen_guest_libX11.inl"
 
 
 // Custom implementations //

--- a/ThunkLibs/libX11/libX11_Host.cpp
+++ b/ThunkLibs/libX11/libX11_Host.cpp
@@ -24,7 +24,8 @@ $end_info$
 #include <dlfcn.h>
 #include <utility>
 
-#include "ldr_ptrs.inl"
+#include "thunkgen_host_libX11.inl"
+
 #ifdef _M_ARM_64
 // This Variadic asm only works for one signature
 // ({uint32_t,uint64_t} a_0, size_t count, uint64_t *list)
@@ -323,15 +324,6 @@ XVaNestedList fexfn_impl_libX11_XVaCreateNestedList_internal(int unused_arg, siz
 Status fexfn_impl_libX11_XInitThreadsInternal(uintptr_t, uintptr_t);
 
 Status fexfn_impl_libX11__XReply(Display*, xReply*, int, Bool);
-
-#include "function_unpacks.inl"
-
-static ExportEntry exports[] = {
-    #include "tab_function_unpacks.inl"
-    { nullptr, nullptr }
-};
-
-#include "ldr.inl"
 
 static int (*ACTUAL_XInitDisplayLock_fn)(Display*) = nullptr;
 static int (*INTERNAL_XInitDisplayLock_fn)(Display*) = nullptr;

--- a/ThunkLibs/libXext/libXext_Guest.cpp
+++ b/ThunkLibs/libXext/libXext_Guest.cpp
@@ -39,9 +39,6 @@ extern "C" {
 
 #include "common/Guest.h"
 
-#include "thunks.inl"
-
-#include "function_packs.inl"
-#include "function_packs_public.inl"
+#include "thunkgen_guest_libXext.inl"
 
 LOAD_LIB(libXext)

--- a/ThunkLibs/libXext/libXext_Host.cpp
+++ b/ThunkLibs/libXext/libXext_Host.cpp
@@ -41,15 +41,6 @@ extern "C" {
 #include "common/Host.h"
 #include <dlfcn.h>
 
-#include "ldr_ptrs.inl"
-#include "function_unpacks.inl"
-
-static ExportEntry exports[] = {
-    #include "tab_function_unpacks.inl"
-    { nullptr, nullptr }
-};
-
-#include "ldr.inl"
+#include "thunkgen_host_libXext.inl"
 
 EXPORTS(libXext)
-

--- a/ThunkLibs/libXfixes/libXfixes_Guest.cpp
+++ b/ThunkLibs/libXfixes/libXfixes_Guest.cpp
@@ -11,8 +11,6 @@ $end_info$
 
 #include "common/Guest.h"
 
-#include "thunks.inl"
-#include "function_packs.inl"
-#include "function_packs_public.inl"
+#include "thunkgen_guest_libXfixes.inl"
 
 LOAD_LIB(libXfixes)

--- a/ThunkLibs/libXfixes/libXfixes_Host.cpp
+++ b/ThunkLibs/libXfixes/libXfixes_Host.cpp
@@ -13,14 +13,6 @@ $end_info$
 #include "common/Host.h"
 #include <dlfcn.h>
 
-#include "ldr_ptrs.inl"
-#include "function_unpacks.inl"
+#include "thunkgen_host_libXfixes.inl"
 
-static ExportEntry exports[] = {
-    #include "tab_function_unpacks.inl"
-    { nullptr, nullptr }
-};
-
-#include "ldr.inl"
-EXPORTS(libXfixes) 
-
+EXPORTS(libXfixes)

--- a/ThunkLibs/libXrender/libXrender_Guest.cpp
+++ b/ThunkLibs/libXrender/libXrender_Guest.cpp
@@ -12,8 +12,6 @@ $end_info$
 
 #include "common/Guest.h"
 
-#include "thunks.inl"
-#include "function_packs.inl"
-#include "function_packs_public.inl"
+#include "thunkgen_guest_libXrender.inl"
 
 LOAD_LIB(libXrender)

--- a/ThunkLibs/libXrender/libXrender_Host.cpp
+++ b/ThunkLibs/libXrender/libXrender_Host.cpp
@@ -13,15 +13,6 @@ $end_info$
 #include "common/Host.h"
 #include <dlfcn.h>
 
-#include "ldr_ptrs.inl"
-#include "function_unpacks.inl"
+#include "thunkgen_host_libXrender.inl"
 
-static ExportEntry exports[] = {
-    #include "tab_function_unpacks.inl"
-    { nullptr, nullptr }
-};
-
-#include "ldr.inl"
-
-EXPORTS(libXrender) 
-
+EXPORTS(libXrender)

--- a/ThunkLibs/libasound/libasound_Guest.cpp
+++ b/ThunkLibs/libasound/libasound_Guest.cpp
@@ -16,8 +16,6 @@ extern "C" {
 #include "common/Guest.h"
 #include <stdarg.h>
 
-#include "thunks.inl"
-#include "function_packs.inl"
-#include "function_packs_public.inl"
+#include "thunkgen_guest_libasound.inl"
 
 LOAD_LIB(libasound)

--- a/ThunkLibs/libasound/libasound_Host.cpp
+++ b/ThunkLibs/libasound/libasound_Host.cpp
@@ -11,15 +11,6 @@ $end_info$
 #include "common/Host.h"
 #include <dlfcn.h>
 
-#include "ldr_ptrs.inl"
-#include "function_unpacks.inl"
+#include "thunkgen_host_libasound.inl"
 
-static ExportEntry exports[] = {
-    #include "tab_function_unpacks.inl"
-    { nullptr, nullptr }
-};
-
-#include "ldr.inl"
-
-EXPORTS(libasound) 
-
+EXPORTS(libasound)

--- a/ThunkLibs/libdrm/Guest.cpp
+++ b/ThunkLibs/libdrm/Guest.cpp
@@ -14,9 +14,7 @@ $end_info$
 #include "common/Guest.h"
 #include <stdarg.h>
 
-#include "thunks.inl"
-#include "function_packs.inl"
-#include "function_packs_public.inl"
+#include "thunkgen_guest_libdrm.inl"
 
 extern "C" {
   void FEX_malloc_free_on_host(void *Ptr) {

--- a/ThunkLibs/libdrm/Host.cpp
+++ b/ThunkLibs/libdrm/Host.cpp
@@ -12,7 +12,7 @@ $end_info$
 #include <dlfcn.h>
 #include <malloc.h>
 
-#include "ldr_ptrs.inl"
+#include "thunkgen_host_libdrm.inl"
 
 static size_t fexfn_impl_libdrm_FEX_usable_size(void *a_0){
   return malloc_usable_size(a_0);
@@ -22,14 +22,4 @@ static void fexfn_impl_libdrm_FEX_free_on_host(void *a_0){
   free(a_0);
 }
 
-#include "function_unpacks.inl"
-
-static ExportEntry exports[] = {
-    #include "tab_function_unpacks.inl"
-    { nullptr, nullptr }
-};
-
-#include "ldr.inl"
-
 EXPORTS(libdrm)
-

--- a/ThunkLibs/libfex_malloc/Guest.cpp
+++ b/ThunkLibs/libfex_malloc/Guest.cpp
@@ -14,9 +14,7 @@ $end_info$
 
 #include "Types.h"
 
-#include "thunks.inl"
-#include "function_packs.inl"
-#include "function_packs_public.inl"
+#include "thunkgen_guest_libfex_malloc.inl"
 
 #include <vector>
 

--- a/ThunkLibs/libfex_malloc/Host.cpp
+++ b/ThunkLibs/libfex_malloc/Host.cpp
@@ -15,9 +15,7 @@ $end_info$
 
 #include "Types.h"
 
-#include "ldr_ptrs.inl"
-
-#include "function_unpacks.inl"
+#include "thunkgen_host_libfex_malloc.inl"
 
 void fexfn_impl_libfex_malloc_fex_get_allocation_ptrs(AllocationPtrs *Ptrs);
 
@@ -182,13 +180,6 @@ void *(*__realloc_hook)(void *ptr, size_t size) = fex_realloc;
 void *(*__memalign_hook)(size_t alignment, size_t size) =
     fex_memalign;
 }
-
-static ExportEntry exports[] = {
-    #include "tab_function_unpacks.inl"
-    { nullptr, nullptr }
-};
-
-#include "ldr.inl"
 
 void fexfn_impl_libfex_malloc_fex_get_allocation_ptrs(AllocationPtrs *Ptrs) {
   *Ptrs = AllocationPointers;

--- a/ThunkLibs/libvulkan/Guest.cpp
+++ b/ThunkLibs/libvulkan/Guest.cpp
@@ -18,10 +18,7 @@ $end_info$
 #include <string_view>
 #include <unordered_map>
 
-#include "thunks.inl"
-#include "function_packs.inl"
-#include "function_packs_public.inl"
-#include "symbol_list.inl"
+#include "thunkgen_guest_libvulkan.inl"
 
 extern "C" {
 

--- a/ThunkLibs/libvulkan/Host.cpp
+++ b/ThunkLibs/libvulkan/Host.cpp
@@ -18,7 +18,7 @@ $end_info$
 
 #include <dlfcn.h>
 
-#include "ldr_ptrs.inl"
+#include "thunkgen_host_libvulkan.inl"
 
 static bool SetupInstance{};
 static std::mutex SetupMutex{};
@@ -134,15 +134,5 @@ static PFN_vkVoidFunction FEXFN_IMPL(vkGetInstanceProcAddr)(VkInstance a_0, cons
   auto ret = LDR_PTR(vkGetInstanceProcAddr)(a_0, a_1);
   return ret;
 }
-
-
-#include "function_unpacks.inl"
-
-static ExportEntry exports[] = {
-    #include "tab_function_unpacks.inl"
-    { nullptr, nullptr }
-};
-
-#include "ldr.inl"
 
 EXPORTS(libvulkan)

--- a/ThunkLibs/libxcb-dri2/libxcb-dri2_Guest.cpp
+++ b/ThunkLibs/libxcb-dri2/libxcb-dri2_Guest.cpp
@@ -15,9 +15,7 @@ $end_info$
 #include "common/Guest.h"
 #include <stdarg.h>
 
-#include "thunks.inl"
-#include "function_packs.inl"
-#include "function_packs_public.inl"
+#include "thunkgen_guest_libxcb-dri2.inl"
 
 
 extern "C" {

--- a/ThunkLibs/libxcb-dri2/libxcb-dri2_Host.cpp
+++ b/ThunkLibs/libxcb-dri2/libxcb-dri2_Host.cpp
@@ -14,7 +14,7 @@ $end_info$
 #include <dlfcn.h>
 #include <malloc.h>
 
-#include "ldr_ptrs.inl"
+#include "thunkgen_host_libxcb-dri2.inl"
 
 static void fexfn_impl_libxcb_dri2_FEX_xcb_dri2_init_extension(xcb_connection_t * a_0, xcb_extension_t * a_1);
 
@@ -25,15 +25,6 @@ static size_t fexfn_impl_libxcb_dri2_FEX_usable_size(void *a_0){
 static void fexfn_impl_libxcb_dri2_FEX_free_on_host(void *a_0){
   free(a_0);
 }
-
-#include "function_unpacks.inl"
-
-static ExportEntry exports[] = {
-    #include "tab_function_unpacks.inl"
-    { nullptr, nullptr }
-};
-
-#include "ldr.inl"
 
 static void fexfn_impl_libxcb_dri2_FEX_xcb_dri2_init_extension(xcb_connection_t * a_0, xcb_extension_t * a_1){
   xcb_extension_t *ext{};

--- a/ThunkLibs/libxcb-dri3/libxcb-dri3_Guest.cpp
+++ b/ThunkLibs/libxcb-dri3/libxcb-dri3_Guest.cpp
@@ -15,9 +15,7 @@ $end_info$
 #include "common/Guest.h"
 #include <stdarg.h>
 
-#include "thunks.inl"
-#include "function_packs.inl"
-#include "function_packs_public.inl"
+#include "thunkgen_guest_libxcb-dri3.inl"
 
 extern "C" {
   xcb_extension_t xcb_dri3_id = {

--- a/ThunkLibs/libxcb-dri3/libxcb-dri3_Host.cpp
+++ b/ThunkLibs/libxcb-dri3/libxcb-dri3_Host.cpp
@@ -14,7 +14,7 @@ $end_info$
 #include <dlfcn.h>
 #include <malloc.h>
 
-#include "ldr_ptrs.inl"
+#include "thunkgen_host_libxcb-dri3.inl"
 
 static void fexfn_impl_libxcb_dri3_FEX_xcb_dri3_init_extension(xcb_connection_t * a_0, xcb_extension_t * a_1);
 
@@ -25,16 +25,6 @@ static size_t fexfn_impl_libxcb_dri3_FEX_usable_size(void *a_0){
 static void fexfn_impl_libxcb_dri3_FEX_free_on_host(void *a_0){
   free(a_0);
 }
-
-#include "function_unpacks.inl"
-
-static ExportEntry exports[] = {
-    #include "tab_function_unpacks.inl"
-    { nullptr, nullptr }
-};
-
-
-#include "ldr.inl"
 
 static void fexfn_impl_libxcb_dri3_FEX_xcb_dri3_init_extension(xcb_connection_t * a_0, xcb_extension_t * a_1){
   xcb_extension_t *ext{};

--- a/ThunkLibs/libxcb-glx/Guest.cpp
+++ b/ThunkLibs/libxcb-glx/Guest.cpp
@@ -15,9 +15,7 @@ $end_info$
 #include "common/Guest.h"
 #include <stdarg.h>
 
-#include "thunks.inl"
-#include "function_packs.inl"
-#include "function_packs_public.inl"
+#include "thunkgen_guest_libxcb-glx.inl"
 
 extern "C" {
   xcb_extension_t xcb_glx_id = {

--- a/ThunkLibs/libxcb-glx/Host.cpp
+++ b/ThunkLibs/libxcb-glx/Host.cpp
@@ -14,7 +14,7 @@ $end_info$
 #include <dlfcn.h>
 #include <malloc.h>
 
-#include "ldr_ptrs.inl"
+#include "thunkgen_host_libxcb-glx.inl"
 
 static void fexfn_impl_libxcb_glx_FEX_xcb_glx_init_extension(xcb_connection_t * a_0, xcb_extension_t * a_1);
 
@@ -25,15 +25,6 @@ static size_t fexfn_impl_libxcb_glx_FEX_usable_size(void *a_0){
 static void fexfn_impl_libxcb_glx_FEX_free_on_host(void *a_0){
   free(a_0);
 }
-
-#include "function_unpacks.inl"
-
-static ExportEntry exports[] = {
-    #include "tab_function_unpacks.inl"
-    { nullptr, nullptr }
-};
-
-#include "ldr.inl"
 
 void fexfn_impl_libxcb_glx_FEX_xcb_glx_init_extension(xcb_connection_t * a_0, xcb_extension_t * a_1){
   xcb_extension_t *ext{};

--- a/ThunkLibs/libxcb-present/Guest.cpp
+++ b/ThunkLibs/libxcb-present/Guest.cpp
@@ -15,9 +15,7 @@ $end_info$
 #include "common/Guest.h"
 #include <stdarg.h>
 
-#include "thunks.inl"
-#include "function_packs.inl"
-#include "function_packs_public.inl"
+#include "thunkgen_guest_libxcb-present.inl"
 
 extern "C" {
   xcb_extension_t xcb_present_id = {

--- a/ThunkLibs/libxcb-present/Host.cpp
+++ b/ThunkLibs/libxcb-present/Host.cpp
@@ -14,7 +14,7 @@ $end_info$
 #include <dlfcn.h>
 #include <malloc.h>
 
-#include "ldr_ptrs.inl"
+#include "thunkgen_host_libxcb-present.inl"
 
 static void fexfn_impl_libxcb_present_FEX_xcb_present_init_extension(xcb_connection_t * a_0, xcb_extension_t * a_1);
 
@@ -25,15 +25,6 @@ static size_t fexfn_impl_libxcb_present_FEX_usable_size(void *a_0){
 static void fexfn_impl_libxcb_present_FEX_free_on_host(void *a_0){
   free(a_0);
 }
-
-#include "function_unpacks.inl"
-
-static ExportEntry exports[] = {
-    #include "tab_function_unpacks.inl"
-    { nullptr, nullptr }
-};
-
-#include "ldr.inl"
 
 static void fexfn_impl_libxcb_present_FEX_xcb_present_init_extension(xcb_connection_t * a_0, xcb_extension_t * a_1) {
   xcb_extension_t *ext{};

--- a/ThunkLibs/libxcb-randr/Guest.cpp
+++ b/ThunkLibs/libxcb-randr/Guest.cpp
@@ -15,9 +15,7 @@ $end_info$
 #include "common/Guest.h"
 #include <stdarg.h>
 
-#include "thunks.inl"
-#include "function_packs.inl"
-#include "function_packs_public.inl"
+#include "thunkgen_guest_libxcb-randr.inl"
 
 extern "C" {
   xcb_extension_t xcb_randr_id = {

--- a/ThunkLibs/libxcb-randr/Host.cpp
+++ b/ThunkLibs/libxcb-randr/Host.cpp
@@ -14,7 +14,7 @@ $end_info$
 #include <dlfcn.h>
 #include <malloc.h>
 
-#include "ldr_ptrs.inl"
+#include "thunkgen_host_libxcb-randr.inl"
 
 static void fexfn_impl_libxcb_randr_FEX_xcb_randr_init_extension(xcb_connection_t * a_0, xcb_extension_t * a_1);
 
@@ -25,15 +25,6 @@ static size_t fexfn_impl_libxcb_randr_FEX_usable_size(void *a_0){
 static void fexfn_impl_libxcb_randr_FEX_free_on_host(void *a_0){
   free(a_0);
 }
-
-#include "function_unpacks.inl"
-
-static ExportEntry exports[] = {
-    #include "tab_function_unpacks.inl"
-    { nullptr, nullptr }
-};
-
-#include "ldr.inl"
 
 static void fexfn_impl_libxcb_randr_FEX_xcb_randr_init_extension(xcb_connection_t * a_0, xcb_extension_t * a_1) {
   xcb_extension_t *ext{};

--- a/ThunkLibs/libxcb-shm/libxcb-shm_Guest.cpp
+++ b/ThunkLibs/libxcb-shm/libxcb-shm_Guest.cpp
@@ -15,9 +15,7 @@ $end_info$
 #include "common/Guest.h"
 #include <stdarg.h>
 
-#include "thunks.inl"
-#include "function_packs.inl"
-#include "function_packs_public.inl"
+#include "thunkgen_guest_libxcb-shm.inl"
 
 extern "C" {
   xcb_extension_t xcb_shm_id = {

--- a/ThunkLibs/libxcb-shm/libxcb-shm_Host.cpp
+++ b/ThunkLibs/libxcb-shm/libxcb-shm_Host.cpp
@@ -14,7 +14,7 @@ $end_info$
 #include <dlfcn.h>
 #include <malloc.h>
 
-#include "ldr_ptrs.inl"
+#include "thunkgen_host_libxcb-shm.inl"
 
 static void fexfn_impl_libxcb_shm_FEX_xcb_shm_init_extension(xcb_connection_t * a_0, xcb_extension_t * a_1);
 
@@ -25,15 +25,6 @@ static size_t fexfn_impl_libxcb_shm_FEX_usable_size(void *a_0){
 static void fexfn_impl_libxcb_shm_FEX_free_on_host(void *a_0){
   free(a_0);
 }
-
-#include "function_unpacks.inl"
-
-static ExportEntry exports[] = {
-    #include "tab_function_unpacks.inl"
-    { nullptr, nullptr }
-};
-
-#include "ldr.inl"
 
 static void fexfn_impl_libxcb_shm_FEX_xcb_shm_init_extension(xcb_connection_t * a_0, xcb_extension_t * a_1) {
   xcb_extension_t *ext{};

--- a/ThunkLibs/libxcb-sync/Guest.cpp
+++ b/ThunkLibs/libxcb-sync/Guest.cpp
@@ -15,9 +15,7 @@ $end_info$
 #include "common/Guest.h"
 #include <stdarg.h>
 
-#include "thunks.inl"
-#include "function_packs.inl"
-#include "function_packs_public.inl"
+#include "thunkgen_guest_libxcb-sync.inl"
 
 extern "C" {
   xcb_extension_t xcb_sync_id = {

--- a/ThunkLibs/libxcb-sync/Host.cpp
+++ b/ThunkLibs/libxcb-sync/Host.cpp
@@ -14,8 +14,7 @@ $end_info$
 #include <dlfcn.h>
 #include <malloc.h>
 
-#include "ldr_ptrs.inl"
-
+#include "thunkgen_host_libxcb-sync.inl"
 
 static void fexfn_impl_libxcb_sync_FEX_xcb_sync_init_extension(xcb_connection_t * a_0, xcb_extension_t * a_1);
 
@@ -26,15 +25,6 @@ static size_t fexfn_impl_libxcb_sync_FEX_usable_size(void *a_0){
 static void fexfn_impl_libxcb_sync_FEX_free_on_host(void *a_0){
   free(a_0);
 }
-
-#include "function_unpacks.inl"
-
-static ExportEntry exports[] = {
-    #include "tab_function_unpacks.inl"
-    { nullptr, nullptr }
-};
-
-#include "ldr.inl"
 
 static void fexfn_impl_libxcb_sync_FEX_xcb_sync_init_extension(xcb_connection_t * a_0, xcb_extension_t * a_1) {
   xcb_extension_t *ext{};

--- a/ThunkLibs/libxcb-xfixes/libxcb-xfixes_Guest.cpp
+++ b/ThunkLibs/libxcb-xfixes/libxcb-xfixes_Guest.cpp
@@ -15,9 +15,7 @@ $end_info$
 #include "common/Guest.h"
 #include <stdarg.h>
 
-#include "thunks.inl"
-#include "function_packs.inl"
-#include "function_packs_public.inl"
+#include "thunkgen_guest_libxcb-xfixes.inl"
 
 extern "C" {
   xcb_extension_t xcb_xfixes_id = {

--- a/ThunkLibs/libxcb-xfixes/libxcb-xfixes_Host.cpp
+++ b/ThunkLibs/libxcb-xfixes/libxcb-xfixes_Host.cpp
@@ -14,8 +14,7 @@ $end_info$
 #include <dlfcn.h>
 #include <malloc.h>
 
-#include "ldr_ptrs.inl"
-
+#include "thunkgen_host_libxcb-xfixes.inl"
 
 static void fexfn_impl_libxcb_xfixes_FEX_xcb_xfixes_init_extension(xcb_connection_t * a_0, xcb_extension_t * a_1);
 
@@ -26,15 +25,6 @@ static size_t fexfn_impl_libxcb_xfixes_FEX_usable_size(void *a_0){
 static void fexfn_impl_libxcb_xfixes_FEX_free_on_host(void *a_0){
   free(a_0);
 }
-
-#include "function_unpacks.inl"
-
-static ExportEntry exports[] = {
-    #include "tab_function_unpacks.inl"
-    { nullptr, nullptr }
-};
-
-#include "ldr.inl"
 
 static void fexfn_impl_libxcb_xfixes_FEX_xcb_xfixes_init_extension(xcb_connection_t * a_0, xcb_extension_t * a_1) {
   xcb_extension_t *ext{};
@@ -57,4 +47,5 @@ static void fexfn_impl_libxcb_xfixes_FEX_xcb_xfixes_init_extension(xcb_connectio
   // Copy over the global id
   a_1->global_id = ext->global_id;
 }
+
 EXPORTS(libxcb_xfixes)

--- a/ThunkLibs/libxcb/libxcb_Guest.cpp
+++ b/ThunkLibs/libxcb/libxcb_Guest.cpp
@@ -26,9 +26,7 @@ $end_info$
 
 #include <stdarg.h>
 
-#include "thunks.inl"
-#include "function_packs.inl"
-#include "function_packs_public.inl"
+#include "thunkgen_guest_libxcb.inl"
 
 static std::thread CBThread{};
 static std::atomic<bool> CBDone{false};

--- a/ThunkLibs/libxcb/libxcb_Host.cpp
+++ b/ThunkLibs/libxcb/libxcb_Host.cpp
@@ -23,7 +23,7 @@ $end_info$
 
 #include "WorkEventData.h"
 
-#include "ldr_ptrs.inl"
+#include "thunkgen_host_libxcb.inl"
 
 static void fexfn_impl_libxcb_FEX_xcb_init_extension(xcb_connection_t*, xcb_extension_t*);
 static size_t fexfn_impl_libxcb_FEX_usable_size(void*);
@@ -31,8 +31,6 @@ static void fexfn_impl_libxcb_FEX_free_on_host(void*);
 static void fexfn_impl_libxcb_FEX_GiveEvents(CrossArchEvent*, CrossArchEvent*, CBWork*);
 
 static int fexfn_impl_libxcb_xcb_take_socket(xcb_connection_t * a_0, fex_guest_function_ptr a_1, void * a_2, int a_3, uint64_t * a_4);
-
-#include "function_unpacks.inl"
 
 struct xcb_take_socket_CB_args {
   xcb_connection_t * conn;
@@ -88,13 +86,6 @@ static int fexfn_impl_libxcb_xcb_take_socket(xcb_connection_t * a_0, fex_guest_f
      a_3,
      a_4);
 }
-
-static ExportEntry exports[] = {
-    #include "tab_function_unpacks.inl"
-    { nullptr, nullptr }
-};
-
-#include "ldr.inl"
 
 static void fexfn_impl_libxcb_FEX_xcb_init_extension(xcb_connection_t * a_0, xcb_extension_t * a_1){
   xcb_extension_t *ext{};

--- a/ThunkLibs/libxshmfence/Guest.cpp
+++ b/ThunkLibs/libxshmfence/Guest.cpp
@@ -16,8 +16,6 @@ extern "C" {
 #include "common/Guest.h"
 #include <stdarg.h>
 
-#include "thunks.inl"
-#include "function_packs.inl"
-#include "function_packs_public.inl"
+#include "thunkgen_guest_libxshmfence.inl"
 
 LOAD_LIB(libxshmfence)

--- a/ThunkLibs/libxshmfence/Host.cpp
+++ b/ThunkLibs/libxshmfence/Host.cpp
@@ -11,15 +11,6 @@ $end_info$
 #include "common/Host.h"
 #include <dlfcn.h>
 
-#include "ldr_ptrs.inl"
-#include "function_unpacks.inl"
-
-static ExportEntry exports[] = {
-    #include "tab_function_unpacks.inl"
-    { nullptr, nullptr }
-};
-
-#include "ldr.inl"
+#include "thunkgen_host_libxshmfence.inl"
 
 EXPORTS(libxshmfence)
-


### PR DESCRIPTION
*NOTE: This change is best viewed in a git client that supports highlighting moved files [see gitconfig's diff.colormoved]*

Previously, the thunk generator created 8 different files. In practice, all thunked libraries used those files in the same way, so splitting the output across multiple files provides no benefit. (It could be argued that things are more structured like this, but since there's no clear naming scheme, looking up specific definitions still often required to dig through multiple of these files.)

Instead of splitting generator across multiple files, the generator output is now consolidated into 2 files in total (one host-side header and one guest-side header).

As a nice side-effect, this makes some of the iteration patterns ("For each API function") more straightforward, making it more predictable what code will be generated from looking at `gen.cpp`. I'm hoping this will particularly pay off for struct-repacking (#1611), since that PR adds a few more generated symbols into the existing mix.
