### PR TITLE
CMake: Extend AArch64 check to include arm64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,7 @@ if (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
   set (X86_TOOLCHAIN_FILE "")
 endif()
 
-if (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch64|^arm64|^armv8\.*")
   set(_M_ARM_64 1)
   add_definitions(-D_M_ARM_64=1)
 endif()

--- a/External/FEXCore/CMakeLists.txt
+++ b/External/FEXCore/CMakeLists.txt
@@ -9,7 +9,7 @@ if (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcx16")
 endif()
 
-if (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch64|^arm64|^armv8\.*")
   set(_M_ARM_64 1)
 endif()
 


### PR DESCRIPTION
This has been seen in some build environments, forgot to commit this a while ago.