### PR TITLE
Move thunk generator logic from ASTVisitor to ASTFrontendAction

### DIFF
--- a/ThunkLibs/Generator/gen.cpp
+++ b/ThunkLibs/Generator/gen.cpp
@@ -394,6 +394,20 @@ public:
     }
 };
 
+class GenerateThunkLibsAction : public clang::ASTFrontendAction {
+public:
+    GenerateThunkLibsAction(const std::string& libname, const OutputFilenames&);
+
+    void EndSourceFileAction() override;
+
+    std::unique_ptr<clang::ASTConsumer> CreateASTConsumer(clang::CompilerInstance&, clang::StringRef /*file*/) override;
+
+private:
+    const std::string& libfilename;
+    std::string libname; // sanitized filename, usable as part of emitted function names
+    const OutputFilenames& output_filenames;
+};
+
 GenerateThunkLibsAction::GenerateThunkLibsAction(const std::string& libname_, const OutputFilenames& output_filenames_)
     : libfilename(libname_), libname(libname_), output_filenames(output_filenames_) {
     for (auto& c : libname) {
@@ -737,4 +751,8 @@ void GenerateThunkLibsAction::EndSourceFileAction() {
 
 std::unique_ptr<clang::ASTConsumer> GenerateThunkLibsAction::CreateASTConsumer(clang::CompilerInstance&, clang::StringRef) {
     return std::make_unique<ASTConsumer>();
+}
+
+std::unique_ptr<clang::FrontendAction> GenerateThunkLibsActionFactory::create() {
+    return std::make_unique<GenerateThunkLibsAction>(libname, output_filenames);
 }

--- a/ThunkLibs/Generator/gen.cpp
+++ b/ThunkLibs/Generator/gen.cpp
@@ -1,4 +1,5 @@
 #include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Frontend/CompilerInstance.h"
 
 #include <fstream>
 #include <numeric>
@@ -84,12 +85,9 @@ struct ThunkedAPIFunction : FunctionParams {
     std::optional<std::size_t> symtable_namespace;
 };
 
-static std::vector<ThunkedFunction> thunks;
-static std::vector<ThunkedAPIFunction> thunked_api;
-static std::unordered_set<const clang::Type*> funcptr_types;
-static std::optional<unsigned> lib_version;
-
 struct NamespaceInfo {
+    clang::DeclContext* context;
+
     std::string name;
 
     // Function to load native host library functions with.
@@ -101,296 +99,156 @@ struct NamespaceInfo {
     bool indirect_guest_calls;
 };
 
-// List of namespaces with a non-specialized fex_gen_config definition (including the global namespace, represented with an empty name)
-static std::vector<NamespaceInfo> namespaces;
+static std::vector<clang::DeclContext*> decl_contexts;
 
-class ASTVisitor : public clang::RecursiveASTVisitor<ASTVisitor> {
+struct ClangDiagnosticAsException {
+    std::pair<clang::SourceLocation, unsigned> diagnostic;
+
+    void Report(clang::DiagnosticsEngine& diagnostics) const {
+        diagnostics.Report(diagnostic.first, diagnostic.second);
+    }
+};
+
+// Helper class to build a custom DiagID from the given message and store it in a throwable object
+struct ErrorReporter {
     clang::ASTContext& context;
 
-    enum class CallbackStrategy {
-        Default,
-        Stub,
-        Guest,
-    };
-
-    struct NamespaceAnnotations {
-        std::optional<unsigned> version;
-        std::optional<std::string> load_host_endpoint_via;
-        bool generate_guest_symtable = false;
-        bool indirect_guest_calls = false;
-    };
-
-    struct Annotations {
-        bool custom_host_impl = false;
-        bool custom_guest_entrypoint = false;
-
-        bool returns_guest_pointer = false;
-
-        std::optional<clang::QualType> uniform_va_type;
-
-        CallbackStrategy callback_strategy = CallbackStrategy::Default;
-    };
-
-    NamespaceAnnotations GetNamespaceAnnotations(clang::CXXRecordDecl* decl) {
-        if (!decl->hasDefinition()) {
-            return {};
-        }
-
-        NamespaceAnnotations ret;
-
-        for (const clang::CXXBaseSpecifier& base : decl->bases()) {
-            auto annotation = base.getType().getAsString();
-            if (annotation == "fexgen::generate_guest_symtable") {
-                ret.generate_guest_symtable = true;
-            } else if (annotation == "fexgen::indirect_guest_calls") {
-                ret.indirect_guest_calls = true;
-            } else {
-                throw Error(base.getSourceRange().getBegin(), "Unknown namespace annotation");
-            }
-        }
-
-        for (const clang::FieldDecl* field : decl->fields()) {
-            auto name = field->getNameAsString();
-            if (name == "load_host_endpoint_via") {
-                auto loader_function_expr = field->getInClassInitializer()->IgnoreCasts();
-                auto loader_function_str = llvm::dyn_cast_or_null<clang::StringLiteral>(loader_function_expr);
-                if (loader_function_expr && !loader_function_str) {
-                    throw Error(loader_function_expr->getBeginLoc(),
-                                "Must initialize load_host_endpoint_via with a string");
-                }
-                if (loader_function_str) {
-                    ret.load_host_endpoint_via = loader_function_str->getString();
-                }
-            } else if (name == "version") {
-                auto initializer = field->getInClassInitializer()->IgnoreCasts();
-                auto version_literal = llvm::dyn_cast_or_null<clang::IntegerLiteral>(initializer);
-                if (!initializer || !version_literal) {
-                    throw Error(field->getBeginLoc(), "No version given (expected integral typed member, e.g. \"int version = 5;\")");
-                }
-                ret.version = version_literal->getValue().getZExtValue();
-            } else {
-                throw Error(field->getBeginLoc(), "Unknown namespace annotation");
-            }
-        }
-
-        return ret;
-    }
-
-    Annotations GetAnnotations(clang::CXXRecordDecl* decl) {
-        Annotations ret;
-
-        for (const auto& base : decl->bases()) {
-            auto annotation = base.getType().getAsString();
-            if (annotation == "fexgen::returns_guest_pointer") {
-                ret.returns_guest_pointer = true;
-            } else if (annotation == "fexgen::custom_host_impl") {
-                ret.custom_host_impl = true;
-            } else if (annotation == "fexgen::callback_stub") {
-                ret.callback_strategy = CallbackStrategy::Stub;
-            } else if (annotation == "fexgen::callback_guest") {
-                ret.callback_strategy = CallbackStrategy::Guest;
-            } else if (annotation == "fexgen::custom_guest_entrypoint") {
-                ret.custom_guest_entrypoint = true;
-            } else {
-                throw Error(base.getSourceRange().getBegin(), "Unknown annotation");
-            }
-        }
-
-        for (const auto& child_decl : decl->getPrimaryContext()->decls()) {
-            if (auto field = llvm::dyn_cast_or_null<clang::FieldDecl>(child_decl)) {
-                throw Error(field->getBeginLoc(), "Unknown field annotation");
-            } else if (auto type_alias = llvm::dyn_cast_or_null<clang::TypedefNameDecl>(child_decl)) {
-                auto name = type_alias->getNameAsString();
-                if (name == "uniform_va_type") {
-                    ret.uniform_va_type = type_alias->getUnderlyingType();
-                } else {
-                    throw Error(type_alias->getBeginLoc(), "Unknown type alias annotation");
-                }
-            }
-        }
-
-        return ret;
-    }
-
-    using ClangDiagnosticAsException = std::pair<clang::SourceLocation, unsigned>;
-
     template<std::size_t N>
-    [[nodiscard]] ClangDiagnosticAsException Error(clang::SourceLocation loc, const char (&message)[N]) {
+    [[nodiscard]] ClangDiagnosticAsException operator()(clang::SourceLocation loc, const char (&message)[N]) {
         auto id = context.getDiagnostics().getCustomDiagID(clang::DiagnosticsEngine::Error, message);
-        return std::pair(loc, id);
+        return { std::pair(loc, id) };
+    }
+};
+
+struct NamespaceAnnotations {
+    std::optional<unsigned> version;
+    std::optional<std::string> load_host_endpoint_via;
+    bool generate_guest_symtable = false;
+    bool indirect_guest_calls = false;
+};
+
+static NamespaceAnnotations GetNamespaceAnnotations(clang::ASTContext& context, clang::CXXRecordDecl* decl) {
+    if (!decl->hasDefinition()) {
+        return {};
     }
 
+    ErrorReporter report_error { context };
+    NamespaceAnnotations ret;
+
+    for (const clang::CXXBaseSpecifier& base : decl->bases()) {
+        auto annotation = base.getType().getAsString();
+        if (annotation == "fexgen::generate_guest_symtable") {
+            ret.generate_guest_symtable = true;
+        } else if (annotation == "fexgen::indirect_guest_calls") {
+            ret.indirect_guest_calls = true;
+        } else {
+            throw report_error(base.getSourceRange().getBegin(), "Unknown namespace annotation");
+        }
+    }
+
+    for (const clang::FieldDecl* field : decl->fields()) {
+        auto name = field->getNameAsString();
+        if (name == "load_host_endpoint_via") {
+            auto loader_function_expr = field->getInClassInitializer()->IgnoreCasts();
+            auto loader_function_str = llvm::dyn_cast_or_null<clang::StringLiteral>(loader_function_expr);
+            if (loader_function_expr && !loader_function_str) {
+                throw report_error(loader_function_expr->getBeginLoc(),
+                                          "Must initialize load_host_endpoint_via with a string");
+            }
+            if (loader_function_str) {
+                ret.load_host_endpoint_via = loader_function_str->getString();
+            }
+        } else if (name == "version") {
+            auto initializer = field->getInClassInitializer()->IgnoreCasts();
+            auto version_literal = llvm::dyn_cast_or_null<clang::IntegerLiteral>(initializer);
+            if (!initializer || !version_literal) {
+                throw report_error(field->getBeginLoc(), "No version given (expected integral typed member, e.g. \"int version = 5;\")");
+            }
+            ret.version = version_literal->getValue().getZExtValue();
+        } else {
+            throw report_error(field->getBeginLoc(), "Unknown namespace annotation");
+        }
+    }
+
+    return ret;
+}
+
+enum class CallbackStrategy {
+    Default,
+    Stub,
+    Guest,
+};
+
+struct Annotations {
+    bool custom_host_impl = false;
+    bool custom_guest_entrypoint = false;
+
+    bool returns_guest_pointer = false;
+
+    std::optional<clang::QualType> uniform_va_type;
+
+    CallbackStrategy callback_strategy = CallbackStrategy::Default;
+};
+
+static Annotations GetAnnotations(clang::ASTContext& context, clang::CXXRecordDecl* decl) {
+    ErrorReporter report_error { context };
+    Annotations ret;
+
+    for (const auto& base : decl->bases()) {
+        auto annotation = base.getType().getAsString();
+        if (annotation == "fexgen::returns_guest_pointer") {
+            ret.returns_guest_pointer = true;
+        } else if (annotation == "fexgen::custom_host_impl") {
+            ret.custom_host_impl = true;
+        } else if (annotation == "fexgen::callback_stub") {
+            ret.callback_strategy = CallbackStrategy::Stub;
+        } else if (annotation == "fexgen::callback_guest") {
+            ret.callback_strategy = CallbackStrategy::Guest;
+        } else if (annotation == "fexgen::custom_guest_entrypoint") {
+            ret.custom_guest_entrypoint = true;
+        } else {
+            throw report_error(base.getSourceRange().getBegin(), "Unknown annotation");
+        }
+    }
+
+    for (const auto& child_decl : decl->getPrimaryContext()->decls()) {
+        if (auto field = llvm::dyn_cast_or_null<clang::FieldDecl>(child_decl)) {
+            throw report_error(field->getBeginLoc(), "Unknown field annotation");
+        } else if (auto type_alias = llvm::dyn_cast_or_null<clang::TypedefNameDecl>(child_decl)) {
+            auto name = type_alias->getNameAsString();
+            if (name == "uniform_va_type") {
+                ret.uniform_va_type = type_alias->getUnderlyingType();
+            } else {
+                throw report_error(type_alias->getBeginLoc(), "Unknown type alias annotation");
+            }
+        }
+    }
+
+    return ret;
+}
+
+class ASTVisitor : public clang::RecursiveASTVisitor<ASTVisitor> {
 public:
-    ASTVisitor(clang::ASTContext& context_) : context(context_) {
-    }
-
     /**
      * Matches "template<auto> struct fex_gen_config { ... }"
      */
-    bool VisitClassTemplateDecl(clang::ClassTemplateDecl* decl) try {
+    bool VisitClassTemplateDecl(clang::ClassTemplateDecl* decl) {
         if (decl->getName() != "fex_gen_config") {
             return true;
         }
 
-        auto annotations = GetNamespaceAnnotations(decl->getTemplatedDecl());
-
-        auto namespace_decl = llvm::dyn_cast<clang::NamespaceDecl>(decl->getDeclContext());
-        namespaces.push_back({  namespace_decl ? namespace_decl->getNameAsString() : "",
-                                annotations.load_host_endpoint_via.value_or(""),
-                                annotations.generate_guest_symtable,
-                                annotations.indirect_guest_calls });
-
-        if (annotations.version) {
-            if (namespace_decl) {
-                throw Error(decl->getBeginLoc(), "Library version must be defined in the global namespace");
-            }
-            lib_version = annotations.version;
+        if (llvm::dyn_cast<clang::NamespaceDecl>(decl->getDeclContext())) {
+            decl_contexts.push_back(decl->getDeclContext());
         }
 
         return true;
-    } catch (ClangDiagnosticAsException& exception) {
-        context.getDiagnostics().Report(exception.first, exception.second);
-        return false;
-    }
-
-    /**
-     * Matches "template<> struct fex_gen_config<LibraryFunc> { ... }"
-     */
-    bool VisitClassTemplateSpecializationDecl(clang::ClassTemplateSpecializationDecl* decl) try {
-        if (decl->getName() == "fex_gen_type") {
-            const auto& template_args = decl->getTemplateArgs();
-            assert(template_args.size() == 1);
-
-            // NOTE: Function types that are equivalent but use differently
-            //       named types (e.g. GLuint/GLenum) are represented by
-            //       different Type instances. The canonical type they refer
-            //       to is unique, however.
-            auto type = context.getCanonicalType(template_args[0].getAsType()).getTypePtr();
-            funcptr_types.insert(type);
-
-            return true;
-        }
-
-        if (decl->getName() != "fex_gen_config") {
-            return true;
-        }
-
-        if (decl->getSpecializationKind() == clang::TSK_ExplicitInstantiationDefinition) {
-            throw Error(decl->getBeginLoc(), "fex_gen_config may not be partially specialized\n");
-        }
-
-        std::string namespace_name;
-        if (auto namespace_decl = llvm::dyn_cast<clang::NamespaceDecl>(decl->getDeclContext())) {
-            namespace_name = namespace_decl->getNameAsString();
-        }
-        const auto namespace_idx = std::distance(   namespaces.begin(),
-                                                    std::find_if(   namespaces.begin(), namespaces.end(),
-                                                                    [&](auto& info) { return info.name == namespace_name; }));
-        const NamespaceInfo& namespace_info = namespaces[namespace_idx];
-
-        const auto& template_args = decl->getTemplateArgs();
-        assert(template_args.size() == 1);
-
-        auto emitted_function = llvm::dyn_cast<clang::FunctionDecl>(template_args[0].getAsDecl());
-        assert(emitted_function && "Argument is not a function");
-        auto return_type = emitted_function->getReturnType();
-
-        const auto annotations = GetAnnotations(decl);
-        if (return_type->isFunctionPointerType() && !annotations.returns_guest_pointer) {
-            throw Error(decl->getBeginLoc(),
-                        "Function pointer return types require explicit annotation\n");
-        }
-
-        // TODO: Use the types as written in the signature instead?
-        ThunkedFunction data;
-        data.function_name = emitted_function->getName().str();
-        data.return_type = return_type;
-        data.is_variadic = emitted_function->isVariadic();
-
-        data.decl = emitted_function;
-
-        data.custom_host_impl = annotations.custom_host_impl;
-
-        for (std::size_t param_idx = 0; param_idx < emitted_function->param_size(); ++param_idx) {
-            auto* param = emitted_function->getParamDecl(param_idx);
-            data.param_types.push_back(param->getType());
-
-            if (param->getType()->isFunctionPointerType()) {
-                auto funcptr = param->getFunctionType()->getAs<clang::FunctionProtoType>();
-                ThunkedCallback callback;
-                callback.return_type = funcptr->getReturnType();
-                for (auto& cb_param : funcptr->getParamTypes()) {
-                    callback.param_types.push_back(cb_param);
-                }
-                callback.is_stub = annotations.callback_strategy == CallbackStrategy::Stub;
-                callback.is_guest = annotations.callback_strategy == CallbackStrategy::Guest;
-                callback.is_variadic = funcptr->isVariadic();
-
-                if (callback.is_guest && !data.custom_host_impl) {
-                    throw Error(decl->getBeginLoc(), "callback_guest can only be used with custom_host_impl");
-                }
-
-                data.callbacks.emplace(param_idx, callback);
-                if (!callback.is_stub && !callback.is_guest) {
-                    funcptr_types.insert(context.getCanonicalType(funcptr));
-                }
-
-                if (data.callbacks.size() != 1) {
-                    throw Error(decl->getBeginLoc(), "Support for more than one callback is untested");
-                }
-                if (funcptr->isVariadic() && !callback.is_stub) {
-                    throw Error(decl->getBeginLoc(), "Variadic callbacks are not supported");
-                }
-            }
-        }
-
-        thunked_api.push_back(ThunkedAPIFunction { (const FunctionParams&)data, data.function_name, data.return_type,
-                                                    namespace_info.host_loader.empty() ? "dlsym" : namespace_info.host_loader,
-                                                    data.is_variadic || annotations.custom_guest_entrypoint,
-                                                    data.is_variadic,
-                                                    std::nullopt });
-        if (namespace_info.generate_guest_symtable) {
-            thunked_api.back().symtable_namespace = namespace_idx;
-        }
-
-        if (data.is_variadic) {
-            if (!annotations.uniform_va_type) {
-                throw Error(decl->getBeginLoc(), "Variadic functions must be annotated with parameter type using uniform_va_type");
-            }
-
-            // Convert variadic argument list into a count + pointer pair
-            data.param_types.push_back(context.getSizeType());
-            data.param_types.push_back(context.getPointerType(*annotations.uniform_va_type));
-        }
-
-        if (data.is_variadic) {
-            // This function is thunked through an "_internal" symbol since its signature
-            // is different from the one in the native host/guest libraries.
-            data.function_name = data.function_name + "_internal";
-            if (data.custom_host_impl) {
-                throw Error(decl->getBeginLoc(), "Custom host impl requested but this is implied by the function signature already");
-            }
-            data.custom_host_impl = true;
-        }
-
-        // For indirect calls, register the function signature as a function pointer type
-        if (namespace_info.indirect_guest_calls) {
-            funcptr_types.insert(context.getCanonicalType(emitted_function->getFunctionType()));
-        }
-
-        thunks.push_back(std::move(data));
-
-        return true;
-    } catch (ClangDiagnosticAsException& exception) {
-        context.getDiagnostics().Report(exception.first, exception.second);
-        return false;
     }
 };
 
 class ASTConsumer : public clang::ASTConsumer {
 public:
     void HandleTranslationUnit(clang::ASTContext& context) override {
-        ASTVisitor{context}.TraverseDecl(context.getTranslationUnitDecl());
+        ASTVisitor{}.TraverseDecl(context.getTranslationUnitDecl());
     }
 };
 
@@ -398,14 +256,26 @@ class GenerateThunkLibsAction : public clang::ASTFrontendAction {
 public:
     GenerateThunkLibsAction(const std::string& libname, const OutputFilenames&);
 
-    void EndSourceFileAction() override;
+    void ExecuteAction() override;
 
     std::unique_ptr<clang::ASTConsumer> CreateASTConsumer(clang::CompilerInstance&, clang::StringRef /*file*/) override;
 
 private:
+    // Build the internal API representation by processing fex_gen_config and other annotated entities
+    void ParseInterface(clang::ASTContext&);
+
+    // Generate helper code for thunk libraries and write them to the output file
+    void EmitOutput();
+
     const std::string& libfilename;
     std::string libname; // sanitized filename, usable as part of emitted function names
     const OutputFilenames& output_filenames;
+
+    std::vector<ThunkedFunction> thunks;
+    std::vector<ThunkedAPIFunction> thunked_api;
+    std::unordered_set<const clang::Type*> funcptr_types;
+    std::optional<unsigned> lib_version;
+    std::vector<NamespaceInfo> namespaces;
 };
 
 GenerateThunkLibsAction::GenerateThunkLibsAction(const std::string& libname_, const OutputFilenames& output_filenames_)
@@ -416,11 +286,8 @@ GenerateThunkLibsAction::GenerateThunkLibsAction(const std::string& libname_, co
         }
     }
 
-    thunks.clear();
-    thunked_api.clear();
-    funcptr_types.clear();
-    namespaces.clear();
-    lib_version = std::nullopt;
+    decl_contexts.clear();
+    decl_contexts.push_back(nullptr); // global namespace (replaced by getTranslationUnitDecl later)
 }
 
 template<typename Fn>
@@ -434,8 +301,185 @@ static std::string format_function_args(const FunctionParams& params, Fn&& forma
     return ret;
 };
 
-void GenerateThunkLibsAction::EndSourceFileAction() {
+static clang::ClassTemplateDecl*
+FindClassTemplateDeclByName(clang::DeclContext& decl_context, std::string_view symbol_name) {
+    auto& ast_context = decl_context.getParentASTContext();
+    auto* ident = &ast_context.Idents.get(symbol_name);
+    auto declname = ast_context.DeclarationNames.getIdentifier(ident);
+    auto result = decl_context.noload_lookup(declname);
+    if (result.empty()) {
+        return nullptr;
+    } else if (std::next(result.begin()) == result.end()) {
+        return llvm::dyn_cast<clang::ClassTemplateDecl>(*result.begin());
+    } else {
+        throw std::runtime_error("Found multiple matches to symbol " + std::string { symbol_name });
+    }
+}
 
+void GenerateThunkLibsAction::ExecuteAction() {
+    clang::ASTFrontendAction::ExecuteAction();
+
+    // Post-processing happens here rather than in an overridden EndSourceFileAction implementation.
+    // We can't move the logic to the latter since this code might still raise errors, but
+    // clang's diagnostics engine is already shut down by the time EndSourceFileAction is called.
+
+    auto& context = getCompilerInstance().getASTContext();
+    if (context.getDiagnostics().hasErrorOccurred()) {
+        return;
+    }
+    decl_contexts.front() = context.getTranslationUnitDecl();
+
+    try {
+        ParseInterface(context);
+        EmitOutput();
+    } catch (ClangDiagnosticAsException& exception) {
+        exception.Report(context.getDiagnostics());
+    }
+}
+
+void GenerateThunkLibsAction::ParseInterface(clang::ASTContext& context) {
+    ErrorReporter report_error { context };
+
+    if (auto template_decl = FindClassTemplateDeclByName(*context.getTranslationUnitDecl(), "fex_gen_type")) {
+        for (auto* decl : template_decl->specializations()) {
+            const auto& template_args = decl->getTemplateArgs();
+            assert(template_args.size() == 1);
+
+            // NOTE: Function types that are equivalent but use differently
+            //       named types (e.g. GLuint/GLenum) are represented by
+            //       different Type instances. The canonical type they refer
+            //       to is unique, however.
+            auto type = context.getCanonicalType(template_args[0].getAsType()).getTypePtr();
+            funcptr_types.insert(type);
+        }
+    }
+
+    // Process declarations and specializations of fex_gen_config,
+    // i.e. the function descriptions of the thunked API
+    for (auto& decl_context : decl_contexts) {
+        if (const auto template_decl = FindClassTemplateDeclByName(*decl_context, "fex_gen_config")) {
+            // Gather general information about symbols in this namespace
+            const auto annotations = GetNamespaceAnnotations(context, template_decl->getTemplatedDecl());
+
+            auto namespace_decl = llvm::dyn_cast<clang::NamespaceDecl>(decl_context);
+            namespaces.push_back({  namespace_decl,
+                                    namespace_decl ? namespace_decl->getNameAsString() : "",
+                                    annotations.load_host_endpoint_via.value_or(""),
+                                    annotations.generate_guest_symtable,
+                                    annotations.indirect_guest_calls });
+            const auto namespace_idx = namespaces.size() - 1;
+            const NamespaceInfo& namespace_info = namespaces.back();
+
+            if (annotations.version) {
+                if (namespace_decl) {
+                    throw report_error(template_decl->getBeginLoc(), "Library version must be defined in the global namespace");
+                }
+                lib_version = annotations.version;
+            }
+
+            // Process specializations of template fex_gen_config
+            for (auto* decl : template_decl->specializations()) {
+                if (decl->getSpecializationKind() == clang::TSK_ExplicitInstantiationDefinition) {
+                    throw report_error(decl->getBeginLoc(), "fex_gen_config may not be partially specialized\n");
+                }
+
+                const auto& template_args = decl->getTemplateArgs();
+                assert(template_args.size() == 1);
+
+                auto emitted_function = llvm::dyn_cast<clang::FunctionDecl>(template_args[0].getAsDecl());
+                assert(emitted_function && "Argument is not a function");
+                auto return_type = emitted_function->getReturnType();
+
+                const auto annotations = GetAnnotations(context, decl);
+                if (return_type->isFunctionPointerType() && !annotations.returns_guest_pointer) {
+                    throw report_error( decl->getBeginLoc(),
+                                        "Function pointer return types require explicit annotation\n");
+                }
+
+                // TODO: Use the types as written in the signature instead?
+                ThunkedFunction data;
+                data.function_name = emitted_function->getName().str();
+                data.return_type = return_type;
+                data.is_variadic = emitted_function->isVariadic();
+
+                data.decl = emitted_function;
+
+                data.custom_host_impl = annotations.custom_host_impl;
+
+                for (std::size_t param_idx = 0; param_idx < emitted_function->param_size(); ++param_idx) {
+                    auto* param = emitted_function->getParamDecl(param_idx);
+                    data.param_types.push_back(param->getType());
+
+                    if (param->getType()->isFunctionPointerType()) {
+                        auto funcptr = param->getFunctionType()->getAs<clang::FunctionProtoType>();
+                        ThunkedCallback callback;
+                        callback.return_type = funcptr->getReturnType();
+                        for (auto& cb_param : funcptr->getParamTypes()) {
+                            callback.param_types.push_back(cb_param);
+                        }
+                        callback.is_stub = annotations.callback_strategy == CallbackStrategy::Stub;
+                        callback.is_guest = annotations.callback_strategy == CallbackStrategy::Guest;
+                        callback.is_variadic = funcptr->isVariadic();
+
+                        if (callback.is_guest && !data.custom_host_impl) {
+                            throw report_error(decl->getBeginLoc(), "callback_guest can only be used with custom_host_impl");
+                        }
+
+                        data.callbacks.emplace(param_idx, callback);
+                        if (!callback.is_stub && !callback.is_guest) {
+                            funcptr_types.insert(context.getCanonicalType(funcptr));
+                        }
+
+                        if (data.callbacks.size() != 1) {
+                            throw report_error(decl->getBeginLoc(), "Support for more than one callback is untested");
+                        }
+                        if (funcptr->isVariadic() && !callback.is_stub) {
+                            throw report_error(decl->getBeginLoc(), "Variadic callbacks are not supported");
+                        }
+                    }
+                }
+
+                thunked_api.push_back(ThunkedAPIFunction { (const FunctionParams&)data, data.function_name, data.return_type,
+                                                            namespace_info.host_loader.empty() ? "dlsym" : namespace_info.host_loader,
+                                                            data.is_variadic || annotations.custom_guest_entrypoint,
+                                                            data.is_variadic,
+                                                            std::nullopt });
+                if (namespace_info.generate_guest_symtable) {
+                    thunked_api.back().symtable_namespace = namespace_idx;
+                }
+
+                if (data.is_variadic) {
+                    if (!annotations.uniform_va_type) {
+                        throw report_error(decl->getBeginLoc(), "Variadic functions must be annotated with parameter type using uniform_va_type");
+                    }
+
+                    // Convert variadic argument list into a count + pointer pair
+                    data.param_types.push_back(context.getSizeType());
+                    data.param_types.push_back(context.getPointerType(*annotations.uniform_va_type));
+                }
+
+                if (data.is_variadic) {
+                    // This function is thunked through an "_internal" symbol since its signature
+                    // is different from the one in the native host/guest libraries.
+                    data.function_name = data.function_name + "_internal";
+                    if (data.custom_host_impl) {
+                        throw report_error(decl->getBeginLoc(), "Custom host impl requested but this is implied by the function signature already");
+                    }
+                    data.custom_host_impl = true;
+                }
+
+                // For indirect calls, register the function signature as a function pointer type
+                if (namespace_info.indirect_guest_calls) {
+                    funcptr_types.insert(context.getCanonicalType(emitted_function->getFunctionType()));
+                }
+
+                thunks.push_back(std::move(data));
+            }
+        }
+    }
+}
+
+void GenerateThunkLibsAction::EmitOutput() {
     static auto format_decl = [](clang::QualType type, const std::string_view& name) {
         if (type->isFunctionPointerType()) {
             auto signature = type.getAsString();
@@ -745,7 +789,6 @@ void GenerateThunkLibsAction::EndSourceFileAction() {
         }
         file << "  return true;\n";
         file << "}\n";
-
     }
 }
 

--- a/ThunkLibs/Generator/interface.h
+++ b/ThunkLibs/Generator/interface.h
@@ -1,4 +1,3 @@
-#include <clang/Frontend/FrontendAction.h>
 #include <clang/Tooling/Tooling.h>
 
 #include <optional>
@@ -9,29 +8,13 @@ struct OutputFilenames {
     std::string guest;
 };
 
-class GenerateThunkLibsAction : public clang::ASTFrontendAction {
-public:
-    GenerateThunkLibsAction(const std::string& libname, const OutputFilenames&);
-
-    void EndSourceFileAction() override;
-
-    std::unique_ptr<clang::ASTConsumer> CreateASTConsumer(clang::CompilerInstance&, clang::StringRef /*file*/) override;
-
-private:
-    const std::string& libfilename;
-    std::string libname; // sanitized filename, usable as part of emitted function names
-    const OutputFilenames& output_filenames;
-};
-
 class GenerateThunkLibsActionFactory : public clang::tooling::FrontendActionFactory {
 public:
     GenerateThunkLibsActionFactory(std::string_view libname_, OutputFilenames output_filenames_)
         : libname(std::move(libname_)), output_filenames(std::move(output_filenames_)) {
     }
 
-    std::unique_ptr<clang::FrontendAction> create() override {
-        return std::make_unique<GenerateThunkLibsAction>(libname, output_filenames);
-    }
+    std::unique_ptr<clang::FrontendAction> create() override;
 
 private:
     std::string libname;


### PR DESCRIPTION
*NOTE: This change is best viewed with whitespace changes ignored and with a git client that supports highlighting moved lines [see gitconfig's diff.colormoved]*

`ASTVisitor` is great for iterating over AST nodes by type, but most of our analysis is based on symbol names. For this task, a lookup in `DeclContexts` after parsing is complete is better suited. (We only use the `ASTVisitor` for discovering relevant namespaces now.)

Notably, instead of separately "visiting" the `fex_gen_config` template declaration and each of its specializations, this new approach allows us to process them all at once. That makes the processing logic more localized and eliminates the need to refetch namespace information.
