### PR TITLE
Thunks/gen: Use fmt for writing formatted output

### DIFF
--- a/ThunkLibs/Generator/CMakeLists.txt
+++ b/ThunkLibs/Generator/CMakeLists.txt
@@ -6,6 +6,7 @@ target_include_directories(thunkgenlib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(thunkgenlib SYSTEM PUBLIC ${CLANG_INCLUDE_DIRS})
 target_link_libraries(thunkgenlib PUBLIC clang-cpp LLVM)
 target_link_libraries(thunkgenlib PRIVATE OpenSSL::Crypto)
+target_link_libraries(thunkgenlib PRIVATE fmt::fmt)
 
 # Query clang's global resource directory for system include directories
 if (NOT CLANG_RESOURCE_DIR)


### PR DESCRIPTION
Makes a few things easier to read, particularly when formatting hex numbers or arrays. The only drawback is that emitting `{`/`}` requires escaping, since those characters are used by the fmt syntax.

Good example:
```diff
-file << "{(uint8_t*)\"";
-for (auto c : sha256) {
-  file << "\\x" << std::hex << std::setw(2) << std::setfill('0') << +c << std::dec;
-}
-file << "\", (void(*)(void *))&fexfn_unpack_" << libname << "_" << function_name << "}, // " << libname << ":" << function_name << "\n";
+fmt::print(file, "  {{(uint8_t*)\"\\x{:02x}\", (void(*)(void *))&fexfn_unpack_{}_{}}}, // {}:{}\n",
+           fmt::join(sha256, "\\x"), libname, function_name, libname, function_name);
```

I only applied fmt formatting to the lines that clearly benefit from it. For lines that just concatenate strings, the iostream infix notation (`file << "hello " << world << "\n";`) is more clear than having to "jump around" to past the format string IMO.
