### PR TITLE
FEXLinuxTests: Use the build system instead of setting up compile flags via source-code annotations

### DIFF
--- a/unittests/FEXLinuxTests/tests-32/CMakeLists.txt
+++ b/unittests/FEXLinuxTests/tests-32/CMakeLists.txt
@@ -12,45 +12,7 @@ file(GLOB_RECURSE TESTS CONFIGURE_DEPENDS *.cpp)
 
 foreach(TEST ${TESTS})
   get_filename_component(TEST_NAME ${TEST} NAME_WLE)
-
-  # Used to insert a configuration dependency to the test file
-  CONFIGURE_FILE(${TEST} ${CMAKE_BINARY_DIR}/junk.file)
-
-  file(READ ${TEST} TEST_CODE)
-  set(FLAGS_REGEX "//[ ]*append cxxflags: ([^\n]+)")
-
-  string(REGEX MATCH ${FLAGS_REGEX} APPEND_CXX_FLAGS ${TEST_CODE})
-  # if cannot handle multiline variables, so we have to match the line first
-  if(${APPEND_CXX_FLAGS} MATCHES ${FLAGS_REGEX})
-    set(APPEND_CXX_FLAGS "${CMAKE_MATCH_1}")
-  else()
-    set(APPEND_CXX_FLAGS "")
-  endif()
-
-  set(FLAGS_REGEX "//[ ]*append ldflags: ([^\n]+)")
-
-  string(REGEX MATCH ${FLAGS_REGEX} APPEND_LD_FLAGS ${TEST_CODE})
-  # if cannot handle multiline variables, so we have to match the line first
-  if(${APPEND_LD_FLAGS} MATCHES ${FLAGS_REGEX})
-    set(APPEND_LD_FLAGS "${CMAKE_MATCH_1}" )
-  else()
-    set(APPEND_LD_FLAGS "")
-  endif()
-
-  set(FLAGS_REGEX "//[ ]*libs: ([^\n]+)")
-
-  string(REGEX MATCH ${FLAGS_REGEX} LIBS ${TEST_CODE})
-  # if cannot handle multiline variables, so we have to match the line first
-  if(${LIBS} MATCHES ${FLAGS_REGEX})
-    set(LIBS "${CMAKE_MATCH_1}" )
-    string(REGEX REPLACE " |," ";" LIBS "${LIBS}")
-  else()
-    set(LIBS "")
-  endif()
-
-  set(BIN_NAME_32 "${TEST_NAME}.32")
-
-  add_executable(${BIN_NAME_32} ${TEST})
-  set_target_properties(${BIN_NAME_32} PROPERTIES COMPILE_FLAGS "${APPEND_CXX_FLAGS} -m32 -g -O2 " LINK_FLAGS "${APPEND_LD_FLAGS} -m32")
-  target_link_libraries(${BIN_NAME_32} ${LIBS})
+  add_executable(${TEST_NAME}.32 ${TEST})
+  target_compile_options(${TEST_NAME}.32 PRIVATE -m32)
+  target_link_options(${TEST_NAME}.32 PRIVATE -m32)
 endforeach()

--- a/unittests/FEXLinuxTests/tests/CMakeLists.txt
+++ b/unittests/FEXLinuxTests/tests/CMakeLists.txt
@@ -13,50 +13,30 @@ file(GLOB_RECURSE TESTS CONFIGURE_DEPENDS *.cpp)
 foreach(TEST ${TESTS})
   get_filename_component(TEST_NAME ${TEST} NAME_WLE)
 
-  # Used to insert a configuration dependency to the test file
-  CONFIGURE_FILE(${TEST} ${CMAKE_BINARY_DIR}/junk.file)
+  add_executable(${TEST_NAME}.32 ${TEST})
+  target_compile_options(${TEST_NAME}.32 PRIVATE -m32)
+  target_link_options(${TEST_NAME}.32 PRIVATE -m32)
 
-  file(READ ${TEST} TEST_CODE)
-  set(FLAGS_REGEX "//[ ]*append cxxflags: ([^\n]+)")
-
-  string(REGEX MATCH ${FLAGS_REGEX} APPEND_CXX_FLAGS ${TEST_CODE})
-  # if cannot handle multiline variables, so we have to match the line first
-  if(${APPEND_CXX_FLAGS} MATCHES ${FLAGS_REGEX})
-    set(APPEND_CXX_FLAGS "${CMAKE_MATCH_1}")
-  else()
-    set(APPEND_CXX_FLAGS "")
-  endif()
-
-  set(FLAGS_REGEX "//[ ]*append ldflags: ([^\n]+)")
-
-  string(REGEX MATCH ${FLAGS_REGEX} APPEND_LD_FLAGS ${TEST_CODE})
-  # if cannot handle multiline variables, so we have to match the line first
-  if(${APPEND_LD_FLAGS} MATCHES ${FLAGS_REGEX})
-    set(APPEND_LD_FLAGS "${CMAKE_MATCH_1}" )
-  else()
-    set(APPEND_LD_FLAGS "")
-  endif()
-
-  set(FLAGS_REGEX "//[ ]*libs: ([^\n]+)")
-
-  string(REGEX MATCH ${FLAGS_REGEX} LIBS ${TEST_CODE})
-  # if cannot handle multiline variables, so we have to match the line first
-  if(${LIBS} MATCHES ${FLAGS_REGEX})
-    set(LIBS "${CMAKE_MATCH_1}" )
-    string(REGEX REPLACE " |," ";" LIBS "${LIBS}")
-  else()
-    set(LIBS "")
-  endif()
-
-  set(BIN_NAME_32 "${TEST_NAME}.32")
-  set(BIN_NAME_64 "${TEST_NAME}.64")
-
-  add_executable(${BIN_NAME_32} ${TEST})
-  set_target_properties(${BIN_NAME_32} PROPERTIES COMPILE_FLAGS "${APPEND_CXX_FLAGS} -m32 -g -O2 " LINK_FLAGS "${APPEND_LD_FLAGS} -m32")
-  target_link_libraries(${BIN_NAME_32} ${LIBS})
-
-  add_executable(${BIN_NAME_64} ${TEST})
-  set_target_properties(${BIN_NAME_64} PROPERTIES COMPILE_FLAGS "${APPEND_CXX_FLAGS} -g -O2" LINK_FLAGS "${APPEND_LD_FLAGS}")
-  target_link_libraries(${BIN_NAME_64} ${LIBS})
-
+  add_executable(${TEST_NAME}.64 ${TEST})
 endforeach()
+
+target_link_libraries(pthread_cancel.32 PRIVATE pthread)
+target_link_libraries(pthread_cancel.64 PRIVATE pthread)
+
+target_link_options(smc-1-dynamic.32 PRIVATE -z execstack)
+target_link_options(smc-1-dynamic.64 PRIVATE -z execstack)
+
+target_link_libraries(smc-mt-1.32 PRIVATE pthread)
+target_link_libraries(smc-mt-1.64 PRIVATE pthread)
+
+target_link_libraries(smc-mt-2.32 PRIVATE pthread)
+target_link_libraries(smc-mt-2.64 PRIVATE pthread)
+
+target_link_libraries(smc-shared-1.32 PRIVATE rt pthread)
+target_link_libraries(smc-shared-1.64 PRIVATE rt pthread)
+
+target_link_libraries(smc-shared-2.32 PRIVATE rt pthread)
+target_link_libraries(smc-shared-2.64 PRIVATE rt pthread)
+
+target_link_libraries(timer-sigev-thread.32 PRIVATE rt pthread)
+target_link_libraries(timer-sigev-thread.64 PRIVATE rt pthread)

--- a/unittests/FEXLinuxTests/tests/signal/pthread_cancel.cpp
+++ b/unittests/FEXLinuxTests/tests/signal/pthread_cancel.cpp
@@ -1,4 +1,3 @@
-//libs: pthread
 #include <atomic>
 #include <errno.h>
 #include <pthread.h>

--- a/unittests/FEXLinuxTests/tests/signal/timer-sigev-thread.cpp
+++ b/unittests/FEXLinuxTests/tests/signal/timer-sigev-thread.cpp
@@ -1,5 +1,3 @@
-//libs: rt pthread
-
 // Simple test of timer_create + SIGEV_THREAD, glibc implements it via SIG32
 
 #include <stdio.h>

--- a/unittests/FEXLinuxTests/tests/smc/smc-1-dynamic.cpp
+++ b/unittests/FEXLinuxTests/tests/smc/smc-1-dynamic.cpp
@@ -1,4 +1,3 @@
-// append ldflags: -z execstack
 auto args = "stack, data_sym, text_sym";
 
 #define EXECSTACK

--- a/unittests/FEXLinuxTests/tests/smc/smc-mt-1.cpp
+++ b/unittests/FEXLinuxTests/tests/smc/smc-mt-1.cpp
@@ -1,5 +1,3 @@
-// libs: pthread
-
 /*
   tests concurrent invalidation of different code from different threads
 

--- a/unittests/FEXLinuxTests/tests/smc/smc-mt-2.cpp
+++ b/unittests/FEXLinuxTests/tests/smc/smc-mt-2.cpp
@@ -1,5 +1,3 @@
-// libs: pthread
-
 /*
   tests one thread modifying another thread's code
 

--- a/unittests/FEXLinuxTests/tests/smc/smc-shared-1.cpp
+++ b/unittests/FEXLinuxTests/tests/smc/smc-shared-1.cpp
@@ -2,8 +2,6 @@
     tests shared / mirrored mappings
 */
 
-// libs: rt pthread
-
 auto args = "mmap_mremap, mmap_mremap_mid, shmat, shmat_mremap, shmat_mremap_mid, mmap_mmap, mmap_mmap_fd_fd2, shm_open_mmap_mmap, shm_open_mmap_mmap_fd_fd2";
 
 #include "smc-common.h"

--- a/unittests/FEXLinuxTests/tests/smc/smc-shared-2.cpp
+++ b/unittests/FEXLinuxTests/tests/smc/smc-shared-2.cpp
@@ -3,8 +3,6 @@
     tests shared / mirrored mappings
 */
 
-// libs: rt pthread
-
 auto args = "mmap_fork, shmat_fork, fork_shmat_same_shmid";
 
 #include "smc-common.h"


### PR DESCRIPTION
Previously, a RegEx was ran over the test source to extract compile flags, which means there was a circular C++ Source <-> CMake dependency. Compile flags are just specified explicitly in CMakeLists.txt now. Combined with #1981 (which removes the `args` annotation), this eliminates the circular dependency.

The intent of these annotations was presumably to make it easier to adjust compile flags on a per-test basis, but doing this in the build system is actually much cleaner.
