### PR TITLE
cmake: Adds uninstall target

### DIFF
--- a/CMakeFiles/cmake_uninstall.cmake.in
+++ b/CMakeFiles/cmake_uninstall.cmake.in
@@ -1,0 +1,21 @@
+if(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
+  message(FATAL_ERROR "Cannot find install manifest: @CMAKE_BINARY_DIR@/install_manifest.txt")
+endif()
+
+file(READ "@CMAKE_BINARY_DIR@/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+foreach(file ${files})
+  message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
+  if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    exec_program(
+      "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+      OUTPUT_VARIABLE rm_out
+      RETURN_VALUE rm_retval
+      )
+    if(NOT "${rm_retval}" STREQUAL 0)
+      message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
+    endif()
+  else(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    message(STATUS "File $ENV{DESTDIR}${file} does not exist.")
+  endif()
+endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,17 @@ option(ENABLE_VIXL_SIMULATOR "Forces the FEX JIT to use the VIXL simulator" FALS
 set (X86_TOOLCHAIN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/toolchain_x86.cmake" CACHE FILEPATH "Toolchain file for the x86 (cross-)compiler")
 set (DATA_DIRECTORY "${CMAKE_INSTALL_PREFIX}/share/fex-emu" CACHE PATH "global data directory")
 
+# uninstall target
+if(NOT TARGET uninstall)
+  configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/CMakeFiles/cmake_uninstall.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/cmake_uninstall.cmake"
+    IMMEDIATE @ONLY)
+
+  add_custom_target(uninstall
+    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/cmake_uninstall.cmake)
+endif()
+
 # These options are meant for package management
 set (TUNE_CPU "native" CACHE STRING "Override the CPU the build is tuned for")
 set (TUNE_ARCH "generic" CACHE STRING "Override the Arch the build is tuned for")
@@ -421,6 +432,13 @@ if (BUILD_THUNKS)
     )"
     DEPENDS guest-libs
   )
+
+  add_custom_target(uninstall_guest-libs
+    COMMAND ${CMAKE_COMMAND} "--build" "." "--target" "uninstall"
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/Guest
+  )
+
+  add_dependencies(uninstall uninstall_guest-libs)
 endif()
 
 set(FEX_VERSION_MAJOR "0")

--- a/Source/Tests/CMakeLists.txt
+++ b/Source/Tests/CMakeLists.txt
@@ -51,10 +51,10 @@ if(TERMUX_BUILD)
   )
 
   install(
-    CODE "MESSAGE(\"-- Installing: ${CMAKE_INSTALL_PREFIX}/bin/FEXInterpreter\")"
+    CODE "MESSAGE(\"-- Installing: $ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/bin/FEXInterpreter\")"
     CODE "
     EXECUTE_PROCESS(COMMAND cp FEXLoader FEXInterpreter
-      WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/bin/
+      WORKING_DIRECTORY $ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/bin/
     )"
   )
 else()
@@ -64,12 +64,20 @@ else()
   )
 
   install(
-    CODE "MESSAGE(\"-- Installing: ${CMAKE_INSTALL_PREFIX}/bin/FEXInterpreter\")"
+    CODE "MESSAGE(\"-- Installing: $ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/bin/FEXInterpreter\")"
     CODE "
     EXECUTE_PROCESS(COMMAND ln -f FEXLoader FEXInterpreter
-      WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/bin/
+      WORKING_DIRECTORY $ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/bin/
     )"
   )
+
+  if(TARGET uninstall)
+    add_custom_target(uninstall_FEXInterpreter
+      COMMAND "rm" "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/bin/FEXInterpreter"
+    )
+
+    add_dependencies(uninstall uninstall_FEXInterpreter)
+  endif()
 endif()
 
 install(PROGRAMS "${PROJECT_SOURCE_DIR}/Scripts/FEXUpdateAOTIRCache.sh" DESTINATION bin RENAME FEXUpdateAOTIRCache)
@@ -101,6 +109,17 @@ if (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
       COMMAND ${CMAKE_COMMAND} -E
       echo "binfmt_misc FEX-x86_64 installed"
     )
+    if(TARGET uninstall)
+      add_custom_target(uninstall_binfmt_misc_32
+        COMMAND update-binfmts --unimport FEX-x86 || (exit 0)
+      )
+      add_custom_target(uninstall_binfmt_misc_64
+        COMMAND update-binfmts --unimport FEX-x86_64 || (exit 0)
+      )
+
+      add_dependencies(uninstall uninstall_binfmt_misc_32)
+      add_dependencies(uninstall uninstall_binfmt_misc_64)
+    endif()
   else()
     # In the case of update-binfmts not being available (Arch for example) then we need to install manually
     add_custom_target(binfmt_misc_32
@@ -129,6 +148,20 @@ if (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
       COMMAND ${CMAKE_COMMAND} -E
         echo "binfmt_misc FEX-x86_64 installed"
       )
+
+    if(TARGET uninstall)
+      add_custom_target(uninstall_binfmt_misc_32
+        COMMAND ${CMAKE_COMMAND} -E
+          echo -1 > /proc/sys/fs/binfmt_misc/FEX-x86 || (exit 0)
+      )
+      add_custom_target(uninstall_binfmt_misc_64
+        COMMAND ${CMAKE_COMMAND} -E
+          echo -1 > /proc/sys/fs/binfmt_misc/FEX-x86_64 || (exit 0)
+      )
+
+      add_dependencies(uninstall uninstall_binfmt_misc_32)
+      add_dependencies(uninstall uninstall_binfmt_misc_64)
+    endif()
   endif()
 
   add_custom_target(binfmt_misc

--- a/ThunkLibs/GuestLibs/CMakeLists.txt
+++ b/ThunkLibs/GuestLibs/CMakeLists.txt
@@ -10,6 +10,17 @@ if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
 
   set(TARGET_TYPE SHARED)
   set(GENERATE_GUEST_INSTALL_TARGETS TRUE)
+
+  # uninstall target
+  if(NOT TARGET uninstall)
+    configure_file(
+      "${FEX_PROJECT_SOURCE_DIR}/CMakeFiles/cmake_uninstall.cmake.in"
+      "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/cmake_uninstall.cmake"
+      IMMEDIATE @ONLY)
+
+    add_custom_target(uninstall
+      COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/cmake_uninstall.cmake)
+  endif()
 else()
   # We've been included using add_subdirectory, so set up targets for IDE integration using the host toolchain
   set(GENERATOR_EXE thunkgen)


### PR DESCRIPTION
Following guidance from cmake's FAQ:
https://gitlab.kitware.com/cmake/community/-/wikis/FAQ#can-i-do-make-uninstall-with-cmake

Due to some of the special handling that we do with installs, we need to do additional uninstall handling that the install manifest doesn't cover.

Specifically we need to add additional uninstall targets for:
- FEXInterpreter
- binfmt_misc
- guest_thunks (Doing its own uninstall target, so passthrough)

While it isn't generally advised to install and uninstall through source systems, this is something that users want to do all the time. This has been asked for a couple of times now.

Fixes #1592