### PR TITLE
Interpreter: Handle 256-bit VAnd/VBic/VOr/VXor

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
@@ -95,12 +95,26 @@ DEF_OP(VAnd) {
 }
 
 DEF_OP(VBic) {
-  auto Op = IROp->C<IR::IROp_VBic>();
-  const auto Src1 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Vector1);
-  const auto Src2 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Vector2);
+  const auto Op = IROp->C<IR::IROp_VBic>();
+  const auto OpSize = IROp->Size;
 
-  const auto Dst = Src1 & ~Src2;
-  memcpy(GDP, &Dst, 16);
+  if (OpSize == 32) {
+    const auto Src1 = *GetSrc<InterpVector256*>(Data->SSAData, Op->Vector1);
+    const auto Src2 = *GetSrc<InterpVector256*>(Data->SSAData, Op->Vector2);
+
+    const auto Dst = InterpVector256{
+      .Lower = Src1.Lower & ~Src2.Lower,
+      .Upper = Src1.Upper & ~Src2.Upper,
+    };
+
+    memcpy(GDP, &Dst, sizeof(Dst));
+  } else {
+    const auto Src1 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Vector1);
+    const auto Src2 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Vector2);
+
+    const auto Dst = Src1 & ~Src2;
+    memcpy(GDP, &Dst, sizeof(Dst));
+  }
 }
 
 DEF_OP(VOr) {

--- a/External/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
@@ -113,12 +113,26 @@ DEF_OP(VOr) {
 }
 
 DEF_OP(VXor) {
-  auto Op = IROp->C<IR::IROp_VXor>();
-  const auto Src1 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Vector1);
-  const auto Src2 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Vector2);
+  const auto Op = IROp->C<IR::IROp_VXor>();
+  const auto OpSize = IROp->Size;
 
-  const auto Dst = Src1 ^ Src2;
-  memcpy(GDP, &Dst, 16);
+  if (OpSize == 32) {
+    const auto Src1 = *GetSrc<InterpVector256*>(Data->SSAData, Op->Vector1);
+    const auto Src2 = *GetSrc<InterpVector256*>(Data->SSAData, Op->Vector2);
+
+    const auto Dst = InterpVector256{
+      .Lower = Src1.Lower ^ Src2.Lower,
+      .Upper = Src1.Upper ^ Src2.Upper,
+    };
+
+    memcpy(GDP, &Dst, sizeof(Dst));
+  } else {
+    const auto Src1 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Vector1);
+    const auto Src2 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Vector2);
+
+    const auto Dst = Src1 ^ Src2;
+    memcpy(GDP, &Dst, sizeof(Dst));
+  }
 }
 
 DEF_OP(VAdd) {

--- a/External/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
@@ -104,12 +104,26 @@ DEF_OP(VBic) {
 }
 
 DEF_OP(VOr) {
-  auto Op = IROp->C<IR::IROp_VOr>();
-  const auto Src1 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Vector1);
-  const auto Src2 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Vector2);
+  const auto Op = IROp->C<IR::IROp_VOr>();
+  const auto OpSize = IROp->Size;
 
-  const auto Dst = Src1 | Src2;
-  memcpy(GDP, &Dst, 16);
+  if (OpSize == 32) {
+    const auto Src1 = *GetSrc<InterpVector256*>(Data->SSAData, Op->Vector1);
+    const auto Src2 = *GetSrc<InterpVector256*>(Data->SSAData, Op->Vector2);
+
+    const auto Dst = InterpVector256{
+      .Lower = Src1.Lower | Src2.Lower,
+      .Upper = Src1.Upper | Src2.Upper,
+    };
+
+    memcpy(GDP, &Dst, sizeof(Dst));
+  } else {
+    const auto Src1 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Vector1);
+    const auto Src2 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Vector2);
+
+    const auto Dst = Src1 | Src2;
+    memcpy(GDP, &Dst, sizeof(Dst));
+  }
 }
 
 DEF_OP(VXor) {

--- a/External/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
@@ -86,12 +86,26 @@ DEF_OP(VMov) {
 }
 
 DEF_OP(VAnd) {
-  auto Op = IROp->C<IR::IROp_VAnd>();
-  const auto Src1 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Vector1);
-  const auto Src2 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Vector2);
+  const auto Op = IROp->C<IR::IROp_VAnd>();
+  const auto OpSize = IROp->Size;
 
-  const auto Dst = Src1 & Src2;
-  memcpy(GDP, &Dst, 16);
+  if (OpSize == 32) {
+    const auto Src1 = *GetSrc<InterpVector256*>(Data->SSAData, Op->Vector1);
+    const auto Src2 = *GetSrc<InterpVector256*>(Data->SSAData, Op->Vector2);
+
+    const auto Dst = InterpVector256{
+      .Lower = Src1.Lower & Src2.Lower,
+      .Upper = Src1.Upper & Src2.Upper,
+    };
+
+    memcpy(GDP, &Dst, sizeof(Dst));
+  } else {
+    const auto Src1 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Vector1);
+    const auto Src2 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Vector2);
+
+    const auto Dst = Src1 & Src2;
+    memcpy(GDP, &Dst, sizeof(Dst));
+  }
 }
 
 DEF_OP(VBic) {


### PR DESCRIPTION
Provides equal support with the JITs (which do handle 256-bit operations for these IR ops)