### PR TITLE
VectorOps: Handle 256-bit VURAvg

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
@@ -424,20 +424,23 @@ DEF_OP(VUMinV) {
 }
 
 DEF_OP(VURAvg) {
-  auto Op = IROp->C<IR::IROp_VURAvg>();
+  const auto Op = IROp->C<IR::IROp_VURAvg>();
   const uint8_t OpSize = IROp->Size;
 
   void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector1);
   void *Src2 = GetSrc<void*>(Data->SSAData, Op->Vector2);
-  uint8_t Tmp[16];
+  uint8_t Tmp[32];
 
-  const uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t ElementSize = Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / ElementSize;
 
   const auto Func = [](auto a, auto b) { return (a + b + 1) >> 1; };
-  switch (Op->Header.ElementSize) {
+  switch (ElementSize) {
     DO_VECTOR_OP(1, uint8_t,  Func)
     DO_VECTOR_OP(2, uint16_t, Func)
-    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
+    default:
+      LOGMAN_MSG_A_FMT("Unknown Element Size: {}", ElementSize);
+      break;
   }
   memcpy(GDP, Tmp, OpSize);
 }

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
@@ -490,17 +490,26 @@ DEF_OP(VUMinV) {
 }
 
 DEF_OP(VURAvg) {
-  auto Op = IROp->C<IR::IROp_VURAvg>();
-  switch (Op->Header.ElementSize) {
+  const auto Op = IROp->C<IR::IROp_VURAvg>();
+
+  const auto ElementSize = Op->Header.ElementSize;
+
+  const auto Dst = ToYMM(GetDst(Node));
+  const auto Vector1 = ToYMM(GetSrc(Op->Vector1.ID()));
+  const auto Vector2 = ToYMM(GetSrc(Op->Vector2.ID()));
+
+  switch (ElementSize) {
     case 1: {
-      vpavgb(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
+      vpavgb(Dst, Vector1, Vector2);
       break;
     }
     case 2: {
-      vpavgw(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
+      vpavgw(Dst, Vector1, Vector2);
       break;
     }
-    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
+    default:
+      LOGMAN_MSG_A_FMT("Unknown Element Size: {}", ElementSize);
+      break;
   }
 }
 


### PR DESCRIPTION
Extends VURAvg to be able to handle 256-bit vector lengths