### PR TITLE
unittests: Disable gvisor pselect test

### DIFF
--- a/unittests/gvisor-tests/Disabled_Tests
+++ b/unittests/gvisor-tests/Disabled_Tests
@@ -187,3 +187,10 @@ inotify_test
 
 # Needs testing
 semaphore_test
+
+# This test does an unsafe timer test. (NoTimeout subtest specifically).
+# Sets a timer for 100ms then starts a pselect with unlimited timeout.
+# If the timer fires before the pselect starts then pselect will hang forever.
+# Since we are running these tests on a fully loaded system, we tend to context switch,
+# causing the chance of a hang to occur quite frequently.
+pselect_test

--- a/unittests/gvisor-tests/Known_Failures
+++ b/unittests/gvisor-tests/Known_Failures
@@ -213,3 +213,10 @@ inotify_test
 
 # Needs testing
 semaphore_test
+
+# This test does an unsafe timer test. (NoTimeout subtest specifically).
+# Sets a timer for 100ms then starts a pselect with unlimited timeout.
+# If the timer fires before the pselect starts then pselect will hang forever.
+# Since we are running these tests on a fully loaded system, we tend to context switch,
+# causing the chance of a hang to occur quite frequently.
+pselect_test


### PR DESCRIPTION
This has a badly coded test that can hang forever. Our timeout kills it at 5 minutes, which causes it to not even fall down the flake path.

Just disable it outright because of the bad test.