### PR TITLE
Arm64: Centralize location for register defines

### DIFF
--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
@@ -17,7 +17,6 @@
 #include <utility>
 
 namespace FEXCore::CPU {
-#define STATE x28
 
 // We want vixl to not allocate a default buffer. Jit and dispatcher will manually create one.
 Arm64Emitter::Arm64Emitter(FEXCore::Context::Context *ctx, size_t size)

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
@@ -62,6 +62,21 @@ const std::array<aarch64::VRegister, 12> RAFPR = {
   v8,  v9,  v10, v11, v12, v13, v14, v15
 };
 
+// Contains the address to the currently available CPU state
+#define STATE x28
+
+// GPR temporaries (only x2 and x3 can be used across spill boundaries)
+// so if these ever need to change, be very careful about that.
+#define TMP1 x0
+#define TMP2 x1
+#define TMP3 x2
+#define TMP4 x3
+
+// Vector temporaries
+#define VTMP1 v1
+#define VTMP2 v2
+#define VTMP3 v3
+
 // This class contains common emitter utility functions that can
 // be used by both Arm64 JIT and ARM64 Dispatcher
 class Arm64Emitter : public vixl::aarch64::Assembler {

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
@@ -38,8 +38,7 @@ namespace FEXCore::CPU {
 using namespace vixl;
 using namespace vixl::aarch64;
 
-static constexpr size_t MAX_DISPATCHER_CODE_SIZE = 4096;
-#define STATE x28
+constexpr size_t MAX_DISPATCHER_CODE_SIZE = 4096;
 
 Arm64Dispatcher::Arm64Dispatcher(FEXCore::Context::Context *ctx, const DispatcherConfig &config)
   : FEXCore::CPU::Dispatcher(ctx, config), Arm64Emitter(ctx, MAX_DISPATCHER_CODE_SIZE)

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -23,16 +23,6 @@ $end_info$
 #include <utility>
 #include <vector>
 
-#define STATE x28
-#define TMP1 x0
-#define TMP2 x1
-#define TMP3 x2
-#define TMP4 x3
-
-#define VTMP1 v1
-#define VTMP2 v2
-#define VTMP3 v3
-
 namespace FEXCore::Core {
   struct InternalThreadState;
 }


### PR DESCRIPTION
Gets rid of a few repeated definitions and allows the emitter itself to make use of these defines without causing a circular dependency on the JIT.