### PR TITLE
JITs: Handle spilling/filling 256-bit vectors

### DIFF
--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
@@ -260,6 +260,13 @@ void Arm64Emitter::FillStaticRegs(bool FPRs, uint32_t GPRFillMask, uint32_t FPRF
 
     if (FPRs) {
       if (EmitterCTX->HostFeatures.SupportsAVX) {
+        // Set up predicate registers.
+        // We don't bother spilling these in SpillStaticRegs,
+        // since all that matters is we restore them on a fill.
+        // It's not a concern if they get trounced by something else.
+        ptrue(PRED_TMP_16B.VnB(), SVE_VL16);
+        ptrue(PRED_TMP_32B.VnB(), SVE_VL32);
+
         for (size_t i = 0; i < SRAFPR.size(); i++) {
           const auto Reg = SRAFPR[i];
 

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
@@ -217,7 +217,8 @@ void Arm64Emitter::SpillStaticRegs(bool FPRs, uint32_t GPRSpillMask, uint32_t FP
           const auto Reg = SRAFPR[i];
 
           if (((1U << Reg.GetCode()) & FPRSpillMask) != 0) {
-            str(Reg.Q(), MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, State.xmm.avx.data[i][0])));
+            mov(TMP4, offsetof(Core::CpuStateFrame, State.xmm.avx.data[i][0]));
+            st1b(Reg.Z().VnB(), PRED_TMP_32B, SVEMemOperand(STATE, TMP4));
           }
         }
       } else {
@@ -271,7 +272,8 @@ void Arm64Emitter::FillStaticRegs(bool FPRs, uint32_t GPRFillMask, uint32_t FPRF
           const auto Reg = SRAFPR[i];
 
           if (((1U << Reg.GetCode()) & FPRFillMask) != 0) {
-            ldr(Reg.Q(), MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, State.xmm.avx.data[i][0])));
+            mov(TMP4, offsetof(Core::CpuStateFrame, State.xmm.avx.data[i][0]));
+            ld1b(Reg.Z().VnB(), PRED_TMP_32B.Zeroing(), SVEMemOperand(STATE, TMP4));
           }
         }
       } else {

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
@@ -77,6 +77,12 @@ const std::array<aarch64::VRegister, 12> RAFPR = {
 #define VTMP2 v2
 #define VTMP3 v3
 
+// Predicate register temporaries (used when AVX support is enabled)
+// PRED_TMP_16B indicates a predicate register that indicates the first 16 bytes set to 1.
+// PRED_TMP_32B indicates a predicate register that indicates the first 32 bytes set to 1.
+#define PRED_TMP_16B p6
+#define PRED_TMP_32B p7
+
 // This class contains common emitter utility functions that can
 // be used by both Arm64 JIT and ARM64 Dispatcher
 class Arm64Emitter : public vixl::aarch64::Assembler {

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
@@ -92,6 +92,10 @@ protected:
   FEXCore::Context::Context *EmitterCTX;
   vixl::aarch64::CPU CPU;
   void LoadConstant(vixl::aarch64::Register Reg, uint64_t Constant, bool NOPPad = false);
+
+  // NOTE: These functions WILL clobber the register TMP4 if AVX support is enabled
+  //       and FPRs are being spilled or filled. If only GPRs are spilled/filled, then
+  //       TMP4 is left alone.
   void SpillStaticRegs(bool FPRs = true, uint32_t GPRSpillMask = ~0U, uint32_t FPRSpillMask = ~0U);
   void FillStaticRegs(bool FPRs = true, uint32_t GPRFillMask = ~0U, uint32_t FPRFillMask = ~0U);
 

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
@@ -65,7 +65,7 @@ const std::array<aarch64::VRegister, 12> RAFPR = {
 // Contains the address to the currently available CPU state
 #define STATE x28
 
-// GPR temporaries (only x2 and x3 can be used across spill boundaries)
+// GPR temporaries. Only x3 can be used across spill boundaries
 // so if these ever need to change, be very careful about that.
 #define TMP1 x0
 #define TMP2 x1

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
@@ -437,10 +437,9 @@ Arm64Dispatcher::Arm64Dispatcher(FEXCore::Context::Context *ctx, const Dispatche
     LUDIVHandlerAddress = GetCursorAddress<uint64_t>();
 
     PushDynamicRegsAndLR();
+    SpillStaticRegs();
 
     ldr(x3, STATE_PTR(CpuStateFrame, Pointers.AArch64.LUDIV));
-
-    SpillStaticRegs();
 #ifdef VIXL_SIMULATOR
     GenerateIndirectRuntimeCall<uint64_t, uint64_t, uint64_t, uint64_t>(x3);
 #else
@@ -460,10 +459,9 @@ Arm64Dispatcher::Arm64Dispatcher(FEXCore::Context::Context *ctx, const Dispatche
     LDIVHandlerAddress = GetCursorAddress<uint64_t>();
 
     PushDynamicRegsAndLR();
+    SpillStaticRegs();
 
     ldr(x3, STATE_PTR(CpuStateFrame, Pointers.AArch64.LDIV));
-
-    SpillStaticRegs();
 #ifdef VIXL_SIMULATOR
     GenerateIndirectRuntimeCall<uint64_t, uint64_t, uint64_t, uint64_t>(x3);
 #else
@@ -483,10 +481,9 @@ Arm64Dispatcher::Arm64Dispatcher(FEXCore::Context::Context *ctx, const Dispatche
     LUREMHandlerAddress = GetCursorAddress<uint64_t>();
 
     PushDynamicRegsAndLR();
+    SpillStaticRegs();
 
     ldr(x3, STATE_PTR(CpuStateFrame, Pointers.AArch64.LUREM));
-
-    SpillStaticRegs();
 #ifdef VIXL_SIMULATOR
     GenerateIndirectRuntimeCall<uint64_t, uint64_t, uint64_t, uint64_t>(x3);
 #else
@@ -506,10 +503,9 @@ Arm64Dispatcher::Arm64Dispatcher(FEXCore::Context::Context *ctx, const Dispatche
     LREMHandlerAddress = GetCursorAddress<uint64_t>();
 
     PushDynamicRegsAndLR();
+    SpillStaticRegs();
 
     ldr(x3, STATE_PTR(CpuStateFrame, Pointers.AArch64.LREM));
-
-    SpillStaticRegs();
 #ifdef VIXL_SIMULATOR
     GenerateIndirectRuntimeCall<uint64_t, uint64_t, uint64_t, uint64_t>(x3);
 #else

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
@@ -38,7 +38,7 @@ namespace FEXCore::CPU {
 using namespace vixl;
 using namespace vixl::aarch64;
 
-constexpr size_t MAX_DISPATCHER_CODE_SIZE = 4096;
+constexpr size_t MAX_DISPATCHER_CODE_SIZE = 8192;
 
 Arm64Dispatcher::Arm64Dispatcher(FEXCore::Context::Context *ctx, const DispatcherConfig &config)
   : FEXCore::CPU::Dispatcher(ctx, config), Arm64Emitter(ctx, MAX_DISPATCHER_CODE_SIZE)

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
@@ -471,6 +471,7 @@ DEF_OP(CPUID) {
   auto Op = IROp->C<IR::IROp_CPUID>();
 
   PushDynamicRegsAndLR();
+  SpillStaticRegs();
 
   // x0 = CPUID Handler
   // x1 = CPUID Function
@@ -479,14 +480,13 @@ DEF_OP(CPUID) {
   ldr(x3, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.CPUIDFunction)));
   mov(x1, GetReg<RA_64>(Op->Function.ID()));
   mov(x2, GetReg<RA_64>(Op->Leaf.ID()));
-  SpillStaticRegs();
 #ifdef VIXL_SIMULATOR
   GenerateIndirectRuntimeCall<__uint128_t, void*, uint64_t, uint64_t>(x3);
 #else
   blr(x3);
 #endif
-  FillStaticRegs();
 
+  FillStaticRegs();
   PopDynamicRegsAndLR();
 
   // Results are in x0, x1

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
@@ -137,6 +137,7 @@ DEF_OP(Print) {
   auto Op = IROp->C<IR::IROp_Print>();
 
   PushDynamicRegsAndLR();
+  SpillStaticRegs();
 
   if (IsGPR(Op->Value.ID())) {
     mov(x0, GetReg<RA_64>(Op->Value.ID()));
@@ -148,10 +149,10 @@ DEF_OP(Print) {
     fmov(x1, GetSrc(Op->Value.ID()).V1D(), 1);
     ldr(x3, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.PrintVectorValue)));
   }
-  SpillStaticRegs();
-  blr(x3);
-  FillStaticRegs();
 
+  blr(x3);
+
+  FillStaticRegs();
   PopDynamicRegsAndLR();
 }
 


### PR DESCRIPTION
Adds in support for dealing with 256-bit vectors when AVX support is enabled.