### PR TITLE
IR: Removes SplatVector{2,4}

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -186,8 +186,6 @@ constexpr OpHandlerArray InterpreterOpHandlers = [] {
   // Vector ops
   REGISTER_OP(VECTORZERO,             VectorZero);
   REGISTER_OP(VECTORIMM,              VectorImm);
-  REGISTER_OP(SPLATVECTOR2,           SplatVector);
-  REGISTER_OP(SPLATVECTOR4,           SplatVector);
   REGISTER_OP(VMOV,                   VMov);
   REGISTER_OP(VAND,                   VAnd);
   REGISTER_OP(VBIC,                   VBic);

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
@@ -207,7 +207,6 @@ namespace FEXCore::CPU {
   ///< Vector ops
   DEF_OP(VectorZero);
   DEF_OP(VectorImm);
-  DEF_OP(SplatVector);
   DEF_OP(VMov);
   DEF_OP(VAnd);
   DEF_OP(VBic);

--- a/External/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
@@ -41,41 +41,6 @@ DEF_OP(VectorImm) {
   memcpy(GDP, Tmp, OpSize);
 }
 
-DEF_OP(SplatVector) {
-  auto Op = IROp->C<IR::IROp_SplatVector2>();
-  uint8_t OpSize = IROp->Size;
-
-  LOGMAN_THROW_AA_FMT(OpSize <= 16, "Can't handle a vector of size: {}", OpSize);
-  void *Src = GetSrc<void*>(Data->SSAData, Op->Scalar);
-  uint8_t Tmp[16];
-  uint8_t Elements = 0;
-
-  switch (Op->Header.Op) {
-    case IR::OP_SPLATVECTOR4: Elements = 4; break;
-    case IR::OP_SPLATVECTOR2: Elements = 2; break;
-    default: LOGMAN_MSG_A_FMT("Uknown Splat size"); break;
-  }
-
-  #define CREATE_VECTOR(elementsize, type) \
-    case elementsize: { \
-      auto *Dst_d = reinterpret_cast<type*>(Tmp); \
-      auto *Src_d = reinterpret_cast<type*>(Src); \
-      for (uint8_t i = 0; i < Elements; ++i) \
-        Dst_d[i] = *Src_d;\
-      break; \
-    }
-  uint8_t ElementSize = OpSize / Elements;
-  switch (ElementSize) {
-    CREATE_VECTOR(1, uint8_t)
-    CREATE_VECTOR(2, uint16_t)
-    CREATE_VECTOR(4, uint32_t)
-    CREATE_VECTOR(8, uint64_t)
-    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.Size); break;
-  }
-  #undef CREATE_VECTOR
-  memcpy(GDP, Tmp, OpSize);
-}
-
 DEF_OP(VMov) {
   auto Op = IROp->C<IR::IROp_VMov>();
   const uint8_t OpSize = IROp->Size;

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -360,8 +360,6 @@ private:
   ///< Vector ops
   DEF_OP(VectorZero);
   DEF_OP(VectorImm);
-  DEF_OP(SplatVector2);
-  DEF_OP(SplatVector4);
   DEF_OP(VMov);
   DEF_OP(VAnd);
   DEF_OP(VBic);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -81,42 +81,6 @@ DEF_OP(VectorImm) {
   }
 }
 
-DEF_OP(SplatVector2) {
-  auto Op = IROp->C<IR::IROp_SplatVector2>();
-  const uint8_t OpSize = IROp->Size;
-  LOGMAN_THROW_AA_FMT(OpSize <= 16, "Can't handle a vector of size: {}", OpSize);
-
-  const uint8_t ElementSize = OpSize / 2;
-
-  switch (ElementSize) {
-    case 4:
-      dup(GetDst(Node).V4S(), GetSrc(Op->Scalar.ID()).V4S(), 0);
-    break;
-    case 8:
-      dup(GetDst(Node).V2D(), GetSrc(Op->Scalar.ID()).V2D(), 0);
-    break;
-    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.Size); break;
-  }
-}
-
-DEF_OP(SplatVector4) {
-  auto Op = IROp->C<IR::IROp_SplatVector4>();
-  const uint8_t OpSize = IROp->Size;
-  LOGMAN_THROW_AA_FMT(OpSize <= 16, "Can't handle a vector of size: {}", OpSize);
-
-  const uint8_t ElementSize = OpSize / 4;
-
-  switch (ElementSize) {
-    case 4:
-      dup(GetDst(Node).V4S(), GetSrc(Op->Scalar.ID()).V4S(), 0);
-    break;
-    case 8:
-      dup(GetDst(Node).V2D(), GetSrc(Op->Scalar.ID()).V2D(), 0);
-    break;
-    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.Size); break;
-  }
-}
-
 DEF_OP(VMov) {
   auto Op = IROp->C<IR::IROp_VMov>();
   const uint8_t OpSize = IROp->Size;
@@ -2694,8 +2658,6 @@ void Arm64JITCore::RegisterVectorHandlers() {
 #define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &Arm64JITCore::Op_##x
   REGISTER_OP(VECTORZERO,        VectorZero);
   REGISTER_OP(VECTORIMM,         VectorImm);
-  REGISTER_OP(SPLATVECTOR2,      SplatVector2);
-  REGISTER_OP(SPLATVECTOR4,      SplatVector4);
   REGISTER_OP(VMOV,              VMov);
   REGISTER_OP(VAND,              VAnd);
   REGISTER_OP(VBIC,              VBic);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -371,7 +371,6 @@ private:
   ///< Vector ops
   DEF_OP(VectorZero);
   DEF_OP(VectorImm);
-  DEF_OP(SplatVector);
   DEF_OP(VMov);
   DEF_OP(VAnd);
   DEF_OP(VBic);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
@@ -72,33 +72,6 @@ DEF_OP(VectorImm) {
   }
 }
 
-DEF_OP(SplatVector) {
-  auto Op = IROp->C<IR::IROp_SplatVector2>();
-  const uint8_t OpSize = IROp->Size;
-
-  LOGMAN_THROW_AA_FMT(OpSize <= 16, "Can't handle a vector of size: {}", OpSize);
-  uint8_t Elements = 0;
-
-  switch (Op->Header.Op) {
-    case IR::OP_SPLATVECTOR4: Elements = 4; break;
-    case IR::OP_SPLATVECTOR2: Elements = 2; break;
-    default: LOGMAN_MSG_A_FMT("Unknown Splat size"); break;
-  }
-
-  const uint8_t ElementSize = OpSize / Elements;
-
-  switch (ElementSize) {
-    case 4:
-      movapd(GetDst(Node), GetSrc(Op->Scalar.ID()));
-      shufps(GetDst(Node), GetDst(Node), 0);
-    break;
-    case 8:
-      movddup(GetDst(Node), GetSrc(Op->Scalar.ID()));
-    break;
-    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.Size); break;
-  }
-}
-
 DEF_OP(VMov) {
   auto Op = IROp->C<IR::IROp_VMov>();
   const uint8_t OpSize = IROp->Size;
@@ -2335,8 +2308,6 @@ void X86JITCore::RegisterVectorHandlers() {
 #define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &X86JITCore::Op_##x
   REGISTER_OP(VECTORZERO,        VectorZero);
   REGISTER_OP(VECTORIMM,         VectorImm);
-  REGISTER_OP(SPLATVECTOR2,      SplatVector);
-  REGISTER_OP(SPLATVECTOR4,      SplatVector);
   REGISTER_OP(VMOV,              VMov);
   REGISTER_OP(VAND,              VAnd);
   REGISTER_OP(VBIC,              VBic);

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -978,7 +978,8 @@ void OpDispatchBuilder::PAVGOp<2>(OpcodeArgs);
 
 void OpDispatchBuilder::MOVDDUPOp(OpcodeArgs) {
   OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-  OrderedNode *Res =  _SplatVector2(Src);
+  OrderedNode *Res = _VDupElement(16, GetSrcSize(Op), Src, 0);
+
   StoreResult(FPRClass, Op, Res, -1);
 }
 

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -364,11 +364,11 @@
       },
 
       "StoreContext u8:#ByteSize, RegisterClass:$Class, SSA:$Value, u32:$Offset": {
-				"Desc": ["Stores a value to the context with offset",
-								 "Ctx[Offset] = Value",
-								 "Zero Extends if value's type is too small",
-								 "Truncates if value's type is too large"
-								],
+        "Desc": ["Stores a value to the context with offset",
+                 "Ctx[Offset] = Value",
+                 "Zero Extends if value's type is too small",
+                 "Truncates if value's type is too large"
+                ],
         "HasSideEffects": true,
         "DestSize": "ByteSize",
         "EmitValidation": [
@@ -845,27 +845,25 @@
         "DestSize": "std::max<uint8_t>(4, std::max<uint8_t>(GetOpSize(_TrueVal), GetOpSize(_FalseVal)))"
       },
       "GPR = Extr GPR:$Upper, GPR:$Lower, u8:$LSB": {
-				"Desc": ["Concats the two GPRs to create a value that is the size of the full two GPRs",
-								 "It then extracts a bitfield width that size of a GPR from the LSB",
-								 "Valid LSB range is 0-31 for 32bit and 0-63 for 64bit",
-								 "<Size * 2> ConcatValue = $Upper:$Lower",
-								 "Result = ConcatValue<LSB+Size - 1: LSB>"
-								]
+        "Desc": ["Concats the two GPRs to create a value that is the size of the full two GPRs",
+                 "It then extracts a bitfield width that size of a GPR from the LSB",
+                 "Valid LSB range is 0-31 for 32bit and 0-63 for 64bit",
+                 "<Size * 2> ConcatValue = $Upper:$Lower",
+                 "Result = ConcatValue<LSB+Size - 1: LSB>"
+                ]
       },
       "GPR = PDep GPR:$Input, GPR:$Mask": {
-				"Desc": [
-					"Performs a parallel bit deposit.",
-					"Takes the contiguous low-order bits and deposits them into",
-					"the destination at the locations specified by the Mask."
-				]
+        "Desc": ["Performs a parallel bit deposit.",
+                 "Takes the contiguous low-order bits and deposits them into",
+                 "the destination at the locations specified by the Mask."
+                ]
       },
 
       "GPR = PExt GPR:$Input, GPR:$Mask": {
-				"Desc": [
-					"Performs a parallel bit extract.",
-					"Each bit set in the mask will select the corresponding bit in the Input",
-					"and transfers them to the lower contiguous bits in the destination."
-				]
+        "Desc": ["Performs a parallel bit extract.",
+                 "Each bit set in the mask will select the corresponding bit in the Input",
+                 "and transfers them to the lower contiguous bits in the destination."
+                ]
       },
 
       "GPR = LDiv GPR:$Lower, GPR:$Upper, GPR:$Divisor": {
@@ -924,15 +922,6 @@
       }
     },
     "Vector": {
-      "FPR = SplatVector2 FPR:$Scalar": {
-        "NumElements": "2",
-        "DestSize": "GetOpSize(_Scalar) * 2"
-      },
-      "FPR = SplatVector4 FPR:$Scalar": {
-        "NumElements": "4",
-        "DestSize": "GetOpSize(_Scalar) * 4"
-      },
-
       "FPR = VMov u8:#RegisterSize, FPR:$Source": {
         "Desc" : ["Copy vector register",
                   "When Register size is smaller than Source register size,",
@@ -1124,9 +1113,9 @@
       },
 
       "FPR = VRev64 u8:#RegisterSize, u8:#ElementSize, FPR:$Vector": {
-				"Desc" : ["Reverses elements in 64-bit halfwords",
-									"Available element size: 1byte, 2 byte, 4 byte"
-								 ],
+        "Desc" : ["Reverses elements in 64-bit halfwords",
+                  "Available element size: 1byte, 2 byte, 4 byte"
+                 ],
         "DestSize": "RegisterSize",
         "NumElements": "RegisterSize / ElementSize"
       },
@@ -1587,9 +1576,9 @@
         "DestSize": "16"
       },
       "GPR = F80Cmp FPR:$X80Src1, FPR:$X80Src2, u32:$Flags": {
-				"Desc": ["Does a scalar unordered compare and stores the asked for flags in to a GPR",
-								 "Ordering flag result is true if either float input is NaN"
-								],
+        "Desc": ["Does a scalar unordered compare and stores the asked for flags in to a GPR",
+                 "Ordering flag result is true if either float input is NaN"
+                ],
         "DestSize": "4"
       },
       "FPR = F80BCDLoad FPR:$X80Src": {


### PR DESCRIPTION
These IR ops are redundant and mostly unused.
VDupElement does exactly what these operations were already doing and more closely matches what the hardware wants.