### PR TITLE
ThunkLibs: X11/Xext: Removes two functions that don't exist on 32-bit

### DIFF
--- a/ThunkLibs/libX11/libX11_interface.cpp
+++ b/ThunkLibs/libX11/libX11_interface.cpp
@@ -601,10 +601,12 @@ template<> struct fex_gen_config<XESetError> : fexgen::returns_guest_pointer {};
 
 template<> struct fex_gen_config<XSetIOErrorHandler> : fexgen::returns_guest_pointer {};
 
+#if __SIZEOF_POINTER__ == 8
+template<> struct fex_gen_config<_XData32> {};
 template<> struct fex_gen_config<_XRead32> {};
+#endif
 template<> struct fex_gen_config<_XRead> {};
 template<> struct fex_gen_config<_XReadPad> {};
-template<> struct fex_gen_config<_XData32> {};
 template<> struct fex_gen_config<_XEatData> {};
 template<> struct fex_gen_config<_XEatDataWords> {};
 

--- a/ThunkLibs/libXext/libXext_interface.cpp
+++ b/ThunkLibs/libXext/libXext_interface.cpp
@@ -126,8 +126,10 @@ template<> struct fex_gen_config<XextRemoveDisplay> {};
 template<> struct fex_gen_config<XextFindDisplay> {};
 template<> struct fex_gen_config<_XGetRequest> {};
 template<> struct fex_gen_config<_XFlushGCCache> {};
+#if __SIZEOF_POINTER__ == 8
 template<> struct fex_gen_config<_XData32> {};
 template<> struct fex_gen_config<_XRead32> {};
+#endif
 template<> struct fex_gen_config<_XDeqAsyncHandler> {};
 template<> struct fex_gen_config<_XError> {};
 template<> struct fex_gen_config<_XIOError> {};


### PR DESCRIPTION
_XData32 and _XRead32 don't exist as real functions in 32-bit versions of these libraries, these end up just being defines that redirect to the non-suffixed versions of the functions.

Noticed this while tinkering around and is easy enough to solve today.