### PR TITLE
FEXLinuxTests: Adds missing pthread_cancel flake status

### DIFF
--- a/unittests/FEXLinuxTests/Flake_Tests
+++ b/unittests/FEXLinuxTests/Flake_Tests
@@ -3,3 +3,4 @@ smc-mt-2.32
 smc-mt-1.64
 smc-mt-2.64
 pthread_cancel.64
+pthread_cancel.32


### PR DESCRIPTION
Missed the 32-bit version of this test