### PR TITLE
32-bit VDSO support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -413,8 +413,26 @@ if (BUILD_THUNKS)
     SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ThunkLibs/GuestLibs"
     BINARY_DIR "Guest"
     CMAKE_ARGS
+      "-DBITNESS=64"
       "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
       "-DCMAKE_TOOLCHAIN_FILE:FILEPATH=${X86_64_TOOLCHAIN_FILE}"
+      "-DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}"
+      "-DSTRUCT_VERIFIER=${CMAKE_SOURCE_DIR}/Scripts/StructPackVerifier.py"
+      "-DFEX_PROJECT_SOURCE_DIR=${FEX_PROJECT_SOURCE_DIR}"
+      "-DGENERATOR_EXE=$<TARGET_FILE:thunkgen>"
+    INSTALL_COMMAND ""
+    BUILD_ALWAYS ON
+    DEPENDS thunkgen
+  )
+
+  ExternalProject_Add(guest-libs-32
+    PREFIX guest-libs-32
+    SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ThunkLibs/GuestLibs"
+    BINARY_DIR "Guest_32"
+    CMAKE_ARGS
+      "-DBITNESS=32"
+      "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
+      "-DCMAKE_TOOLCHAIN_FILE:FILEPATH=${X86_32_TOOLCHAIN_FILE}"
       "-DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}"
       "-DSTRUCT_VERIFIER=${CMAKE_SOURCE_DIR}/Scripts/StructPackVerifier.py"
       "-DFEX_PROJECT_SOURCE_DIR=${FEX_PROJECT_SOURCE_DIR}"
@@ -433,12 +451,27 @@ if (BUILD_THUNKS)
     DEPENDS guest-libs
   )
 
+  install(
+    CODE "MESSAGE(\"-- Installing: guest-libs-32\")"
+    CODE "
+    EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} --build . --target install
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/Guest_32
+    )"
+    DEPENDS guest-libs-32
+  )
+
   add_custom_target(uninstall_guest-libs
     COMMAND ${CMAKE_COMMAND} "--build" "." "--target" "uninstall"
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/Guest
   )
 
+  add_custom_target(uninstall_guest-libs-32
+    COMMAND ${CMAKE_COMMAND} "--build" "." "--target" "uninstall"
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/Guest_32
+  )
+
   add_dependencies(uninstall uninstall_guest-libs)
+  add_dependencies(uninstall uninstall_guest-libs-32)
 endif()
 
 set(FEX_VERSION_MAJOR "0")

--- a/External/FEXCore/Source/Interface/Config/Config.json.in
+++ b/External/FEXCore/Source/Interface/Config/Config.json.in
@@ -90,6 +90,13 @@
           "Folder to find the guest-side thunking libraries."
         ]
       },
+      "ThunkGuestLibs32": {
+        "Type": "str",
+        "Default": "@CMAKE_INSTALL_PREFIX@/share/fex-emu/GuestThunks_32/",
+        "Desc": [
+          "Folder to find the 32-bit guest-side thunking libraries."
+        ]
+      },
       "ThunkConfig": {
         "Type": "str",
         "Default": "",

--- a/Source/Tests/ELFCodeLoader2.h
+++ b/Source/Tests/ELFCodeLoader2.h
@@ -465,17 +465,18 @@ class ELFCodeLoader2 final : public FEXCore::CodeLoader {
 
       // we don't support vsyscall so we don't set those
       //AuxVariables.emplace_back(auxv_t{32, 0}); // AT_SYSINFO - Entry point to syscall
-      if (VDSOBase) {
-        AuxVariables.emplace_back(auxv_t{33, reinterpret_cast<uint64_t>(VDSOBase)}); // AT_SYSINFO_EHDR - Address of the start of VDSO
-      }
     }
     else {
       AuxVariables.emplace_back(auxv_t{4, 0x20}); // AT_PHENT
 
-      // we don't support vsyscall or vDSO so we don't set those
+      // we don't support vsyscall so we don't set those
       //AuxVariables.emplace_back(auxv_t{32, 0}); // AT_SYSINFO - Entry point to syscall
-      //AuxVariables.emplace_back(auxv_t{33, 0}); // AT_SYSINFO_EHDR - Address of the start of VDSO
     }
+
+    if (VDSOBase) {
+      AuxVariables.emplace_back(auxv_t{33, reinterpret_cast<uint64_t>(VDSOBase)}); // AT_SYSINFO_EHDR - Address of the start of VDSO
+    }
+
     AuxVariables.emplace_back(auxv_t{3, MainElfBase + MainElf.ehdr.e_phoff}); // Program header
     AuxVariables.emplace_back(auxv_t{7, InterpeterElfBase}); // AT_BASE - Interpreter address
     AuxVariables.emplace_back(auxv_t{9, MainElfEntrypoint}); // AT_ENTRY

--- a/Source/Tests/FEXLoader.cpp
+++ b/Source/Tests/FEXLoader.cpp
@@ -390,11 +390,9 @@ int main(int argc, char **argv, char **const envp) {
   auto Mapper = std::bind_front(&FEX::HLE::SyscallHandler::GuestMmap, SyscallHandler.get());
   auto Unmapper = std::bind_front(&FEX::HLE::SyscallHandler::GuestMunmap, SyscallHandler.get());
 
-  if (Loader.Is64BitMode()) {
-    // Load VDSO in to memory prior to mapping our ELFs.
-    void* VDSOBase = FEX::VDSO::LoadVDSOThunks(Mapper);
-    Loader.SetVDSOBase(VDSOBase);
-  }
+  // Load VDSO in to memory prior to mapping our ELFs.
+  void* VDSOBase = FEX::VDSO::LoadVDSOThunks(Loader.Is64BitMode(), Mapper);
+  Loader.SetVDSOBase(VDSOBase);
 
   if (!Loader.MapMemory(Mapper, Unmapper)) {
     // failed to map

--- a/Source/Tests/VDSO_Emulation.cpp
+++ b/Source/Tests/VDSO_Emulation.cpp
@@ -1,5 +1,6 @@
 #include "VDSO_Emulation.h"
 #include "FEXCore/IR/IR.h"
+#include "Tests/LinuxSyscalls/x32/Types.h"
 
 #include <FEXCore/Config/Config.h>
 #include <FEXCore/Utils/MathUtils.h>
@@ -74,7 +75,94 @@ namespace FEX::VDSO {
     args->rv = GetCPUPtr(args->cpu, args->node);
   }
 
+  namespace x32 {
+    static void time(void* ArgsRV) {
+      struct ArgsRV_t {
+        HLE::x32::compat_ptr<FEX::HLE::x32::old_time32_t> a_0;
+        int rv;
+      } *args = reinterpret_cast<ArgsRV_t*>(ArgsRV);
+
+      time_t Host{};
+      args->rv = TimePtr(&Host);
+      if (args->a_0) {
+        *args->a_0 = Host;
+      }
+    }
+
+    static void gettimeofday(void* ArgsRV) {
+      struct ArgsRV_t {
+        HLE::x32::compat_ptr<FEX::HLE::x32::timeval32> tv;
+        HLE::x32::compat_ptr<struct timezone> tz;
+        int rv;
+      } *args = reinterpret_cast<ArgsRV_t*>(ArgsRV);
+
+      struct timeval tv64{};
+      struct timeval *tv_ptr{};
+      if (args->tv) {
+        tv_ptr = &tv64;
+      }
+
+      args->rv = GetTimeOfDayPtr(tv_ptr, args->tz);
+
+      if (args->tv) {
+        *args->tv = tv64;
+      }
+    }
+
+    static void clock_gettime(void* ArgsRV) {
+      struct ArgsRV_t {
+        clockid_t clk_id;
+        HLE::x32::compat_ptr<HLE::x32::timespec32> tp;
+        int rv;
+      } *args = reinterpret_cast<ArgsRV_t*>(ArgsRV);
+
+      struct timespec tp64{};
+      args->rv = ClockGetTimePtr(args->clk_id, &tp64);
+
+      if (args->tp) {
+        *args->tp = tp64;
+      }
+    }
+
+    static void clock_gettime64(void* ArgsRV) {
+      struct ArgsRV_t {
+        clockid_t clk_id;
+        HLE::x32::compat_ptr<struct timespec> tp;
+        int rv;
+      } *args = reinterpret_cast<ArgsRV_t*>(ArgsRV);
+
+      args->rv = ClockGetTimePtr(args->clk_id, args->tp);
+    }
+
+    static void clock_getres(void* ArgsRV) {
+      struct ArgsRV_t {
+        clockid_t clk_id;
+        HLE::x32::compat_ptr<HLE::x32::timespec32> tp;
+        int rv;
+      } *args = reinterpret_cast<ArgsRV_t*>(ArgsRV);
+
+      struct timespec tp64{};
+
+      args->rv = ClockGetResPtr(args->clk_id, &tp64);
+
+      if (args->tp) {
+        *args->tp = tp64;
+      }
+    }
+
+    static void getcpu(void* ArgsRV) {
+      struct ArgsRV_t {
+        HLE::x32::compat_ptr<uint32_t> cpu;
+        HLE::x32::compat_ptr<uint32_t> node;
+        int rv;
+      } *args = reinterpret_cast<ArgsRV_t*>(ArgsRV);
+
+      args->rv = GetCPUPtr(args->cpu, args->node);
+    }
+  }
+
   void LoadHostVDSO() {
+
     void *vdso = dlopen("linux-vdso.so.1", RTLD_LAZY | RTLD_LOCAL | RTLD_NOLOAD);
     if (!vdso) {
       vdso = dlopen("linux-gate.so.1", RTLD_LAZY | RTLD_LOCAL | RTLD_NOLOAD);
@@ -117,36 +205,67 @@ namespace FEX::VDSO {
     {
         // sha256(libVDSO:time)
         { 0x37, 0x63, 0x46, 0xb0, 0x79, 0x06, 0x5f, 0x9d, 0x00, 0xb6, 0x8d, 0xfd, 0x9e, 0x4a, 0x62, 0xcd, 0x1e, 0x6c, 0xcc, 0x22, 0xcd, 0xb2, 0xc0, 0x17, 0x7d, 0x42, 0x6a, 0x40, 0xd1, 0xeb, 0xfa, 0xe0 },
-        &FEX::VDSO::time
+        nullptr,
     },
     {
         // sha256(libVDSO:gettimeofday)
         { 0x77, 0x2a, 0xde, 0x1c, 0x13, 0x2d, 0xe9, 0x48, 0xaf, 0xe0, 0xba, 0xcc, 0x6a, 0x89, 0xff, 0xca, 0x4a, 0xdc, 0xd5, 0x63, 0x2c, 0xc5, 0x62, 0x8b, 0x5d, 0xde, 0x0b, 0x15, 0x35, 0xc6, 0xc7, 0x14 },
-        &FEX::VDSO::gettimeofday
+        nullptr,
     },
     {
         // sha256(libVDSO:clock_gettime)
         { 0x3c, 0x96, 0x9b, 0x2d, 0xc3, 0xad, 0x2b, 0x3b, 0x9c, 0x4e, 0x4d, 0xca, 0x1c, 0xe8, 0x18, 0x4a, 0x12, 0x8a, 0xe4, 0xc1, 0x56, 0x92, 0x73, 0xce, 0x65, 0x85, 0x5f, 0x65, 0x7e, 0x94, 0x26, 0xbe },
-        &FEX::VDSO::clock_gettime
+        nullptr,
     },
+
+    {
+        // sha256(libVDSO:clock_gettime64)
+        { 0xba, 0xe9, 0x6d, 0x30, 0xc0, 0x68, 0xc6, 0xd7, 0x59, 0x04, 0xf7, 0x10, 0x06, 0x72, 0x88, 0xfd, 0x4c, 0x57, 0x0f, 0x31, 0xa5, 0xea, 0xa9, 0xb9, 0xd3, 0x8d, 0x03, 0x81, 0x50, 0x16, 0x22, 0x71 },
+        nullptr,
+    },
+
     {
         // sha256(libVDSO:clock_getres)
         { 0xe4, 0xa1, 0xf6, 0x23, 0x35, 0xae, 0xb7, 0xb6, 0xb0, 0x37, 0xc5, 0xc3, 0xa3, 0xfd, 0xbf, 0xa2, 0xa1, 0xc8, 0x95, 0x78, 0xe5, 0x76, 0x86, 0xdb, 0x3e, 0x6c, 0x54, 0xd5, 0x02, 0x60, 0xd8, 0x6d },
-        &FEX::VDSO::clock_getres
+        nullptr,
     },
     {
         // sha256(libVDSO:getcpu)
         { 0x39, 0x83, 0x39, 0x36, 0x0f, 0x68, 0xd6, 0xfc, 0xc2, 0x3a, 0x97, 0x11, 0x85, 0x09, 0xc7, 0x25, 0xbb, 0x50, 0x49, 0x55, 0x6b, 0x0c, 0x9f, 0x50, 0x37, 0xf5, 0x9d, 0xb0, 0x38, 0x58, 0x57, 0x12 },
-        &FEX::VDSO::getcpu
+        nullptr,
     },
   };
 
-  void* LoadVDSOThunks(MapperFn Mapper) {
+  void* LoadVDSOThunks(bool Is64Bit, MapperFn Mapper) {
     void* VDSOBase{};
     FEX_CONFIG_OPT(ThunkGuestLibs, THUNKGUESTLIBS);
+    FEX_CONFIG_OPT(ThunkGuestLibs32, THUNKGUESTLIBS32);
+
+    std::filesystem::path ThunkGuestPath{};
+    if (Is64Bit) {
+      ThunkGuestPath = std::filesystem::path(ThunkGuestLibs()) / "libVDSO-guest.so";
+
+      // Set the Thunk definition pointers for x86-64
+      VDSODefinitions[0].ThunkFunction = &FEX::VDSO::time;
+      VDSODefinitions[1].ThunkFunction = &FEX::VDSO::gettimeofday;
+      VDSODefinitions[2].ThunkFunction = &FEX::VDSO::clock_gettime;
+      VDSODefinitions[3].ThunkFunction = &FEX::VDSO::clock_gettime;
+      VDSODefinitions[4].ThunkFunction = &FEX::VDSO::clock_getres;
+      VDSODefinitions[5].ThunkFunction = &FEX::VDSO::getcpu;
+    }
+    else {
+      ThunkGuestPath = std::filesystem::path(ThunkGuestLibs32()) / "libVDSO-guest.so";
+
+      // Set the Thunk definition pointers for x86
+      VDSODefinitions[0].ThunkFunction = &FEX::VDSO::x32::time;
+      VDSODefinitions[1].ThunkFunction = &FEX::VDSO::x32::gettimeofday;
+      VDSODefinitions[2].ThunkFunction = &FEX::VDSO::x32::clock_gettime;
+      VDSODefinitions[3].ThunkFunction = &FEX::VDSO::x32::clock_gettime64;
+      VDSODefinitions[4].ThunkFunction = &FEX::VDSO::x32::clock_getres;
+      VDSODefinitions[5].ThunkFunction = &FEX::VDSO::x32::getcpu;
+    }
 
     // Load VDSO if we can
-    auto ThunkGuestPath = std::filesystem::path(ThunkGuestLibs()) / "libVDSO-guest.so";
     int VDSOFD = ::open(ThunkGuestPath.string().c_str(), O_RDONLY);
 
     if (VDSOFD != -1) {

--- a/Source/Tests/VDSO_Emulation.h
+++ b/Source/Tests/VDSO_Emulation.h
@@ -3,7 +3,7 @@
 
 namespace FEX::VDSO {
   using MapperFn = std::function<void *(void *addr, size_t length, int prot, int flags, int fd, off_t offset)>;
-  void* LoadVDSOThunks(MapperFn Mapper);
+  void* LoadVDSOThunks(bool Is64Bit, MapperFn Mapper);
 
   std::vector<FEXCore::IR::ThunkDefinition> const& GetVDSOThunkDefinitions();
 }

--- a/ThunkLibs/GuestLibs/CMakeLists.txt
+++ b/ThunkLibs/GuestLibs/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.14)
 project(guest-thunks)
 
+option(BITNESS "Which bitness the thunks are building for" 64)
+
 if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
   # We've been included using ExternalProject_add, so set up the actual thunk libraries to be cross-compiled
   set(CMAKE_CXX_STANDARD 17)
@@ -48,11 +50,16 @@ function(generate NAME SOURCE_FILE)
 
   file(MAKE_DIRECTORY "${OUTFOLDER}")
 
+  set (BITNESS_FLAGS "")
+  if (BITNESS EQUAL 32)
+    set (BITNESS_FLAGS "-m32" "--target=i686-linux-unknown" "-isystem" "/usr/i686-linux-gnu/include/")
+  endif()
+
   add_custom_command(
     OUTPUT "${OUTFILE}"
     DEPENDS "${GENERATOR_EXE}"
     DEPENDS "${SOURCE_FILE}"
-    COMMAND "${GENERATOR_EXE}" "${SOURCE_FILE}" "${NAME}" "-guest" "${OUTFILE}" -- -std=c++17
+    COMMAND "${GENERATOR_EXE}" "${SOURCE_FILE}" "${NAME}" "-guest" "${OUTFILE}" -- -std=c++17 ${BITNESS_FLAGS}
       # Expand compile definitions to space-separated list of -D parameters
       "$<$<BOOL:${compile_prop}>:;-D$<JOIN:${compile_prop},;-D>>"
       # Expand include directories to space-separated list of -isystem parameters
@@ -72,6 +79,9 @@ function(add_guest_lib NAME SONAME)
   set (SOURCE_LDS_FILE ../lib${NAME}/lib${NAME}_Guest.lds)
   get_filename_component(SOURCE_LDS_FILE_ABS "${SOURCE_LDS_FILE}" ABSOLUTE)
 
+  set (SOURCE_LDS_32_FILE ../lib${NAME}/lib${NAME}_Guest_32.lds)
+  get_filename_component(SOURCE_LDS_32_FILE_ABS "${SOURCE_LDS_32_FILE}" ABSOLUTE)
+
   if (NOT EXISTS "${SOURCE_FILE_ABS}")
     set (SOURCE_FILE ../lib${NAME}/Guest.cpp)
     get_filename_component(SOURCE_FILE_ABS "${SOURCE_FILE}" ABSOLUTE)
@@ -88,9 +98,19 @@ function(add_guest_lib NAME SONAME)
   ## Make signed overflow well defined 2's complement overflow
   target_compile_options(${NAME}-guest PRIVATE -fwrapv)
 
+  if (BITNESS EQUAL 32)
+    # Makes the GOT/PLT lookups slightly less painful
+    target_compile_options(${NAME}-guest PRIVATE -fno-plt)
+    target_link_options(VDSO-guest PRIVATE "LINKER:-z,now" "LINKER:-z,relro" "LINKER:-z,notext")
+  endif()
+
   # Add linker script if set
-  if (EXISTS "${SOURCE_LDS_FILE_ABS}")
+  if (BITNESS EQUAL 64 AND EXISTS "${SOURCE_LDS_FILE_ABS}")
     target_link_options(${NAME}-guest PRIVATE "-T" "${CMAKE_CURRENT_SOURCE_DIR}/../lib${NAME}/lib${NAME}_Guest.lds")
+  endif()
+
+  if (BITNESS EQUAL 32 AND EXISTS "${SOURCE_LDS_32_FILE_ABS}")
+    target_link_options(${NAME}-guest PRIVATE "-T" "${CMAKE_CURRENT_SOURCE_DIR}/../lib${NAME}/lib${NAME}_Guest_32.lds")
   endif()
 
   # We need to override the soname for the linker.
@@ -111,108 +131,119 @@ function(add_guest_lib NAME SONAME)
   set_target_properties(${NAME}-guest PROPERTIES NO_SONAME ON)
 
   if (GENERATE_GUEST_INSTALL_TARGETS)
-    install(TARGETS ${NAME}-guest DESTINATION ${DATA_DIRECTORY}/GuestThunks/)
+    if (BITNESS EQUAL 64)
+      install(TARGETS ${NAME}-guest DESTINATION ${DATA_DIRECTORY}/GuestThunks/)
+    else()
+      install(TARGETS ${NAME}-guest DESTINATION ${DATA_DIRECTORY}/GuestThunks_32/)
+    endif()
   endif()
 endfunction()
 
-#add_guest_lib(fex_malloc_loader)
-#target_link_libraries(fex_malloc_loader-guest PRIVATE dl)
+# These thunks only support 64-bit
+if (BITNESS EQUAL 64)
+  #add_guest_lib(fex_malloc_loader)
+  #target_link_libraries(fex_malloc_loader-guest PRIVATE dl)
 
-#generate(libfex_malloc)
-#add_guest_lib(fex_malloc)
+  #generate(libfex_malloc)
+  #add_guest_lib(fex_malloc)
 
-generate(libasound ${CMAKE_CURRENT_SOURCE_DIR}/../libasound/libasound_interface.cpp)
-add_guest_lib(asound "libasound.so.2")
+  generate(libasound ${CMAKE_CURRENT_SOURCE_DIR}/../libasound/libasound_interface.cpp)
+  add_guest_lib(asound "libasound.so.2")
 
-generate(libEGL ${CMAKE_CURRENT_SOURCE_DIR}/../libEGL/libEGL_interface.cpp)
-add_guest_lib(EGL "libEGL.so.1")
+  generate(libEGL ${CMAKE_CURRENT_SOURCE_DIR}/../libEGL/libEGL_interface.cpp)
+  add_guest_lib(EGL "libEGL.so.1")
 
-generate(libGL ${CMAKE_CURRENT_SOURCE_DIR}/../libGL/libGL_interface.cpp)
-add_guest_lib(GL "libGL.so.1")
+  generate(libGL ${CMAKE_CURRENT_SOURCE_DIR}/../libGL/libGL_interface.cpp)
+  add_guest_lib(GL "libGL.so.1")
 
-# libGL must pull in libX11.so, so generate a placeholder libX11.so to link against
-add_library(X11 SHARED ../libX11/libX11_NativeGuest.cpp)
-target_link_libraries(GL-guest PRIVATE X11)
+  # libGL must pull in libX11.so, so generate a placeholder libX11.so to link against
+  add_library(X11 SHARED ../libX11/libX11_NativeGuest.cpp)
+  target_link_libraries(GL-guest PRIVATE X11)
 
-# disabled for now, headers are platform specific
-# find_package(SDL2 REQUIRED)
-# generate(libSDL2)
-# add_guest_lib(SDL2)
-# target_include_directories(SDL2-guest PRIVATE ${SDL2_INCLUDE_DIRS})
-# target_link_libraries(SDL2-guest PRIVATE GL)
-# target_link_libraries(SDL2-guest PRIVATE dl)
+  # disabled for now, headers are platform specific
+  # find_package(SDL2 REQUIRED)
+  # generate(libSDL2)
+  # add_guest_lib(SDL2)
+  # target_include_directories(SDL2-guest PRIVATE ${SDL2_INCLUDE_DIRS})
+  # target_link_libraries(SDL2-guest PRIVATE GL)
+  # target_link_libraries(SDL2-guest PRIVATE dl)
 
-find_package(PkgConfig)
-pkg_search_module(X11 REQUIRED x11)
+  find_package(PkgConfig)
+  pkg_search_module(X11 REQUIRED x11)
 
-string(REGEX MATCH "([0-9]*)\.([0-9]*)\.([0-9]*)" _ "${X11_VERSION}")
-set(X11_VERSION_MAJOR ${CMAKE_MATCH_1})
-set(X11_VERSION_MINOR ${CMAKE_MATCH_2})
-set(X11_VERSION_PATCH ${CMAKE_MATCH_3})
+  string(REGEX MATCH "([0-9]*)\.([0-9]*)\.([0-9]*)" _ "${X11_VERSION}")
+  set(X11_VERSION_MAJOR ${CMAKE_MATCH_1})
+  set(X11_VERSION_MINOR ${CMAKE_MATCH_2})
+  set(X11_VERSION_PATCH ${CMAKE_MATCH_3})
 
-generate(libX11 ${CMAKE_CURRENT_SOURCE_DIR}/../libX11/libX11_interface.cpp)
-add_guest_lib(X11 "libX11.so.6")
+  generate(libX11 ${CMAKE_CURRENT_SOURCE_DIR}/../libX11/libX11_interface.cpp)
+  add_guest_lib(X11 "libX11.so.6")
 
-target_compile_definitions(libX11-guest-deps INTERFACE -DX11_VERSION_MAJOR=${X11_VERSION_MAJOR})
-target_compile_definitions(libX11-guest-deps INTERFACE -DX11_VERSION_MINOR=${X11_VERSION_MINOR})
-target_compile_definitions(libX11-guest-deps INTERFACE -DX11_VERSION_PATCH=${X11_VERSION_PATCH})
+  target_compile_definitions(libX11-guest-deps INTERFACE -DX11_VERSION_MAJOR=${X11_VERSION_MAJOR})
+  target_compile_definitions(libX11-guest-deps INTERFACE -DX11_VERSION_MINOR=${X11_VERSION_MINOR})
+  target_compile_definitions(libX11-guest-deps INTERFACE -DX11_VERSION_PATCH=${X11_VERSION_PATCH})
 
-generate(libXext ${CMAKE_CURRENT_SOURCE_DIR}/../libXext/libXext_interface.cpp)
-add_guest_lib(Xext "libXext.so.6")
+  generate(libXext ${CMAKE_CURRENT_SOURCE_DIR}/../libXext/libXext_interface.cpp)
+  add_guest_lib(Xext "libXext.so.6")
 
-target_compile_definitions(libXext-guest-deps INTERFACE -DX11_VERSION_MAJOR=${X11_VERSION_MAJOR})
-target_compile_definitions(libXext-guest-deps INTERFACE -DX11_VERSION_MINOR=${X11_VERSION_MINOR})
-target_compile_definitions(libXext-guest-deps INTERFACE -DX11_VERSION_PATCH=${X11_VERSION_PATCH})
+  target_compile_definitions(libXext-guest-deps INTERFACE -DX11_VERSION_MAJOR=${X11_VERSION_MAJOR})
+  target_compile_definitions(libXext-guest-deps INTERFACE -DX11_VERSION_MINOR=${X11_VERSION_MINOR})
+  target_compile_definitions(libXext-guest-deps INTERFACE -DX11_VERSION_PATCH=${X11_VERSION_PATCH})
 
-generate(libXrender ${CMAKE_CURRENT_SOURCE_DIR}/../libXrender/libXrender_interface.cpp)
-add_guest_lib(Xrender "libXrender.so.1")
+  generate(libXrender ${CMAKE_CURRENT_SOURCE_DIR}/../libXrender/libXrender_interface.cpp)
+  add_guest_lib(Xrender "libXrender.so.1")
 
-generate(libXfixes ${CMAKE_CURRENT_SOURCE_DIR}/../libXfixes/libXfixes_interface.cpp)
-add_guest_lib(Xfixes "libXfixes.so.3")
+  generate(libXfixes ${CMAKE_CURRENT_SOURCE_DIR}/../libXfixes/libXfixes_interface.cpp)
+  add_guest_lib(Xfixes "libXfixes.so.3")
 
-generate(libvulkan ${CMAKE_CURRENT_SOURCE_DIR}/../libvulkan/libvulkan_interface.cpp)
-target_include_directories(libvulkan-guest-deps INTERFACE ${FEX_PROJECT_SOURCE_DIR}/External/Vulkan-Headers/include/)
-add_guest_lib(vulkan "libvulkan.so.1")
+  generate(libvulkan ${CMAKE_CURRENT_SOURCE_DIR}/../libvulkan/libvulkan_interface.cpp)
+  target_include_directories(libvulkan-guest-deps INTERFACE ${FEX_PROJECT_SOURCE_DIR}/External/Vulkan-Headers/include/)
+  add_guest_lib(vulkan "libvulkan.so.1")
 
-generate(libxcb ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb/libxcb_interface.cpp)
-add_guest_lib(xcb "libxcb.so.1")
+  generate(libxcb ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb/libxcb_interface.cpp)
+  add_guest_lib(xcb "libxcb.so.1")
 
-generate(libxcb-dri2 ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-dri2/libxcb-dri2_interface.cpp)
-add_guest_lib(xcb-dri2 "libxcb-dri2.so.0")
+  generate(libxcb-dri2 ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-dri2/libxcb-dri2_interface.cpp)
+  add_guest_lib(xcb-dri2 "libxcb-dri2.so.0")
 
-generate(libxcb-dri3 ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-dri3/libxcb-dri3_interface.cpp)
-add_guest_lib(xcb-dri3 "libxcb-dri3.so.0")
+  generate(libxcb-dri3 ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-dri3/libxcb-dri3_interface.cpp)
+  add_guest_lib(xcb-dri3 "libxcb-dri3.so.0")
 
-generate(libxcb-xfixes ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-xfixes/libxcb-xfixes_interface.cpp)
-add_guest_lib(xcb-xfixes "libxcb-xfixes.so.0")
+  generate(libxcb-xfixes ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-xfixes/libxcb-xfixes_interface.cpp)
+  add_guest_lib(xcb-xfixes "libxcb-xfixes.so.0")
 
-generate(libxcb-shm ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-shm/libxcb-shm_interface.cpp)
-add_guest_lib(xcb-shm "libxcb-shm.so.0")
+  generate(libxcb-shm ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-shm/libxcb-shm_interface.cpp)
+  add_guest_lib(xcb-shm "libxcb-shm.so.0")
 
-generate(libxcb-sync ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-sync/libxcb-sync_interface.cpp)
-add_guest_lib(xcb-sync "libxcb-sync.so.1")
+  generate(libxcb-sync ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-sync/libxcb-sync_interface.cpp)
+  add_guest_lib(xcb-sync "libxcb-sync.so.1")
 
-generate(libxcb-present ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-present/libxcb-present_interface.cpp)
-add_guest_lib(xcb-present "libxcb-present.so.0")
+  generate(libxcb-present ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-present/libxcb-present_interface.cpp)
+  add_guest_lib(xcb-present "libxcb-present.so.0")
 
-generate(libxcb-randr ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-randr/libxcb-randr_interface.cpp)
-add_guest_lib(xcb-randr "libxcb-randr.so.0")
+  generate(libxcb-randr ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-randr/libxcb-randr_interface.cpp)
+  add_guest_lib(xcb-randr "libxcb-randr.so.0")
 
-generate(libxcb-glx ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-glx/libxcb-glx_interface.cpp)
-add_guest_lib(xcb-glx "libxcb-glx.so.0")
+  generate(libxcb-glx ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-glx/libxcb-glx_interface.cpp)
+  add_guest_lib(xcb-glx "libxcb-glx.so.0")
 
-generate(libxshmfence ${CMAKE_CURRENT_SOURCE_DIR}/../libxshmfence/libxshmfence_interface.cpp)
-add_guest_lib(xshmfence "libxshmfence.so.1")
+  generate(libxshmfence ${CMAKE_CURRENT_SOURCE_DIR}/../libxshmfence/libxshmfence_interface.cpp)
+  add_guest_lib(xshmfence "libxshmfence.so.1")
 
-generate(libdrm ${CMAKE_CURRENT_SOURCE_DIR}/../libdrm/libdrm_interface.cpp)
-target_include_directories(libdrm-guest-deps INTERFACE /usr/include/drm/)
-target_include_directories(libdrm-guest-deps INTERFACE /usr/include/libdrm/)
-add_guest_lib(drm "libdrm.so.2")
+  generate(libdrm ${CMAKE_CURRENT_SOURCE_DIR}/../libdrm/libdrm_interface.cpp)
+  target_include_directories(libdrm-guest-deps INTERFACE /usr/include/drm/)
+  target_include_directories(libdrm-guest-deps INTERFACE /usr/include/libdrm/)
+  add_guest_lib(drm "libdrm.so.2")
+endif()
 
 generate(libVDSO ${CMAKE_CURRENT_SOURCE_DIR}/../libVDSO/libVDSO_interface.cpp)
 add_guest_lib(VDSO "linux-vdso.so.1")
 # Can't use a stack protector because otherwise cross-compiling fails
 # Not necessary anyway because it only trampolines
 target_compile_options(VDSO-guest PRIVATE "-fno-stack-protector")
-target_link_options(VDSO-guest PRIVATE "-T" "${CMAKE_CURRENT_SOURCE_DIR}/../libVDSO/libVDSO_Guest.lds" "-nostdlib"
-  "LINKER:--no-undefined" "LINKER:-z,max-page-size=4096" "LINKER:--hash-style=both")
+target_link_options(VDSO-guest PRIVATE "-nostdlib" "LINKER:--no-undefined" "LINKER:-z,max-page-size=4096" "LINKER:--hash-style=both")
+
+if (BITNESS EQUAL 32)
+  # 32-bit entrypoint points to __kernel_vsyscall and needs to exist
+  target_link_options(VDSO-guest PRIVATE "LINKER:-e,__kernel_vsyscall")
+endif()

--- a/ThunkLibs/include/common/Guest.h
+++ b/ThunkLibs/include/common/Guest.h
@@ -16,11 +16,11 @@ const int (*fexthunks_invoke_callback)(void*);
 
 #ifndef _M_ARM_64
 #define MAKE_THUNK(lib, name, hash) \
-  extern "C" THUNK_ABI int fexthunks_##lib##_##name(void *args); \
+  extern "C" __attribute__((visibility("hidden"))) THUNK_ABI int fexthunks_##lib##_##name(void *args); \
   asm(".text\nfexthunks_" #lib "_" #name ":\n.byte 0xF, 0x3F\n.byte " hash );
 
 #define MAKE_CALLBACK_THUNK(name, signature, hash) \
-  extern "C" THUNK_ABI int fexthunks_##name(void *args); \
+  extern "C" __attribute__((visibility("hidden"))) THUNK_ABI int fexthunks_##name(void *args); \
   asm(".text\nfexthunks_" #name ":\n.byte 0xF, 0x3F\n.byte " hash ); \
   template<> THUNK_ABI inline constexpr int (*fexthunks_invoke_callback<signature>)(void*) = fexthunks_##name;
 

--- a/ThunkLibs/libVDSO/Types.h
+++ b/ThunkLibs/libVDSO/Types.h
@@ -1,0 +1,7 @@
+#pragma once
+#include <cstdint>
+
+struct timespec64 {
+  int64_t tv_sec;
+  int64_t tv_nsec;
+};

--- a/ThunkLibs/libVDSO/libVDSO_Guest.cpp
+++ b/ThunkLibs/libVDSO/libVDSO_Guest.cpp
@@ -13,6 +13,7 @@ $end_info$
 #include <sys/time.h>
 #include <time.h>
 
+#include "Types.h"
 #include "common/Guest.h"
 
 #include "thunkgen_guest_libVDSO.inl"
@@ -23,4 +24,26 @@ int __vdso_gettimeofday(struct timeval *tv, struct timezone *tz) __attribute__((
 int __vdso_clock_gettime(clockid_t, struct timespec *) __attribute__((alias("fexfn_pack_clock_gettime")));
 int __vdso_clock_getres(clockid_t, struct timespec *) __attribute__((alias("fexfn_pack_clock_getres")));
 int __vdso_getcpu(uint32_t *, uint32_t *) __attribute__((alias("fexfn_pack_getcpu")));
+
+#if __SIZEOF_POINTER__ == 4
+int __vdso_clock_gettime64(clockid_t, struct timespec64 *) __attribute__((alias("fexfn_pack_clock_gettime64")));
+
+__attribute__((naked))
+int __kernel_vsyscall() {
+  asm volatile(R"(
+  .intel_syntax noprefix
+  push ecx;
+  push edx;
+  push ebp;
+  mov ebp, ecx;
+  int 0x80;
+  pop ebp;
+  pop edx;
+  pop ecx;
+  ret;
+  .att_syntax prefix
+  )"
+  ::: "memory");
+}
+#endif
 }

--- a/ThunkLibs/libVDSO/libVDSO_Guest_32.lds
+++ b/ThunkLibs/libVDSO/libVDSO_Guest_32.lds
@@ -1,0 +1,59 @@
+SECTIONS {
+  . = SIZEOF_HEADERS;
+  .hash : { *(.hash) } :text
+  .gnu.hash : { *(.gnu.hash) }
+  .dynsym : { *(.dynsym) }
+  .dynstr : { *(.dynstr) }
+  .gnu.version : { *(.gnu.version) }
+  .gnu.version_d : { *(.gnu.version_d) }
+  .gnu.version_r : { *(.gnu.version_r) }
+  .dynamic : { *(.dynamic) } :text :dynamic
+  .rodata : {
+    *(.rodata*)
+      *(.data*)
+      *(.sdata*)
+      *(.got.plt) *(.got)
+      *(.gnu.linkonce.d.*)
+      *(.bss*)
+      *(.dynbss*)
+      *(.gnu.linkonce.b.*)
+  } :text
+
+  /DISCARD/ : {
+    *(.note)
+    *(.note.gnu.property)
+    *(.eh_frame_hdr)
+    *(.eh_frame)
+    *(.symtab)
+  }
+}
+
+PHDRS {
+  text PT_LOAD FLAGS(PF_R | PF_X) FILEHDR PHDRS;
+  dynamic PT_DYNAMIC FLAGS(PF_R);
+  note PT_NOTE FLAGS(PF_R);
+}
+
+VERSION {
+  LINUX_2.6 {
+  global:
+    __vdso_time;
+    time;
+    __vdso_gettimeofday;
+    gettimeofday;
+    __vdso_clock_gettime;
+    clock_gettime;
+    __vdso_clock_getres;
+    clock_getres;
+    __vdso_getcpu;
+    getcpu;
+    __vdso_clock_gettime64;
+    clock_gettime64;
+  local: *;
+  };
+  LINUX_2.5 {
+  global:
+    __kernel_vsyscall;
+  local: *;
+  };
+}

--- a/ThunkLibs/libVDSO/libVDSO_interface.cpp
+++ b/ThunkLibs/libVDSO/libVDSO_interface.cpp
@@ -4,6 +4,8 @@
 #include <sys/time.h>
 #include <time.h>
 
+#include "Types.h"
+
 template<auto>
 struct fex_gen_config {
 };
@@ -13,3 +15,8 @@ template<> struct fex_gen_config<gettimeofday> {};
 template<> struct fex_gen_config<clock_gettime> {};
 template<> struct fex_gen_config<clock_getres> {};
 template<> struct fex_gen_config<getcpu> {};
+
+#if __SIZEOF_POINTER__ == 4
+extern int clock_gettime64 (clockid_t __clock_id, struct timespec64 *__tp) __THROW;
+template<> struct fex_gen_config<clock_gettime64> {};
+#endif


### PR DESCRIPTION
As promised, here is the other half of the hand-written host-side implementation of VDSO.
VDSO for 32-bit and 64-bit are the only thunks that need this handwritten path.

This has ~~#2008~~, ~~#2009~~, and ~~#2010~~ merged in to which needs to be merged before this PR is merged.
Fixes #690

Some special things here
1) Now defaulting to hidden visibility
2) 32-bit thunks compiled with features to make PLT overhead more bearable
3) Only fexthunks_exports_<library> and other required symbols should be publicly exposed.
4) 32-bit VDSO needs clock_gettime64 and vsyscall on top of the other symbols
5) 32-bit thunks use fastcall ABI to reduce overhead

The PLT and hidden things are required to reduce overhead of thunks on 32-bit:
Without:
![Before](https://cdn.discordapp.com/attachments/797528613787926538/1023425457024139346/Image_2022-09-24_19-46-31.png)

With hidden plus PLT compile flags:
![After](https://cdn.discordapp.com/attachments/797528613787926538/1023432166845198366/Image_2022-09-24_20-13-08.png)

As we can see, it removes a function call and some EAX usage.