### PR TITLE
IR: Removes unnecessary VBitcast IR op

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -254,7 +254,6 @@ constexpr OpHandlerArray InterpreterOpHandlers = [] {
   REGISTER_OP(VSHLI,                  VShlI);
   REGISTER_OP(VUSHRNI,                VUShrNI);
   REGISTER_OP(VUSHRNI2,               VUShrNI2);
-  REGISTER_OP(VBITCAST,               VBitcast);
   REGISTER_OP(VSXTL,                  VSXTL);
   REGISTER_OP(VSXTL2,                 VSXTL2);
   REGISTER_OP(VUXTL,                  VUXTL);

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
@@ -273,7 +273,6 @@ namespace FEXCore::CPU {
   DEF_OP(VShlI);
   DEF_OP(VUShrNI);
   DEF_OP(VUShrNI2);
-  DEF_OP(VBitcast);
   DEF_OP(VSXTL);
   DEF_OP(VSXTL2);
   DEF_OP(VUXTL);

--- a/External/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
@@ -1606,11 +1606,6 @@ DEF_OP(VUShrNI2) {
   memcpy(GDP, Tmp, OpSize);
 }
 
-DEF_OP(VBitcast) {
-  auto Op = IROp->C<IR::IROp_VBitcast>();
-  memcpy(GDP, GetSrc<void*>(Data->SSAData, Op->Source), 16);
-}
-
 DEF_OP(VSXTL) {
   auto Op = IROp->C<IR::IROp_VSXTL>();
   const uint8_t OpSize = IROp->Size;

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -428,7 +428,6 @@ private:
   DEF_OP(VShlI);
   DEF_OP(VUShrNI);
   DEF_OP(VUShrNI2);
-  DEF_OP(VBitcast);
   DEF_OP(VSXTL);
   DEF_OP(VSXTL2);
   DEF_OP(VUXTL);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -2287,11 +2287,6 @@ DEF_OP(VUShrNI2) {
   mov(GetDst(Node), VTMP1);
 }
 
-DEF_OP(VBitcast) {
-  auto Op = IROp->C<IR::IROp_VBitcast>();
-  mov(GetDst(Node), GetSrc(Op->Source.ID()));
-}
-
 DEF_OP(VSXTL) {
   auto Op = IROp->C<IR::IROp_VSXTL>();
   switch (Op->Header.ElementSize) {
@@ -2688,7 +2683,6 @@ void Arm64JITCore::RegisterVectorHandlers() {
   REGISTER_OP(VSHLI,             VShlI);
   REGISTER_OP(VUSHRNI,           VUShrNI);
   REGISTER_OP(VUSHRNI2,          VUShrNI2);
-  REGISTER_OP(VBITCAST,          VBitcast);
   REGISTER_OP(VSXTL,             VSXTL);
   REGISTER_OP(VSXTL2,            VSXTL2);
   REGISTER_OP(VUXTL,             VUXTL);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -439,7 +439,6 @@ private:
   DEF_OP(VShlI);
   DEF_OP(VUShrNI);
   DEF_OP(VUShrNI2);
-  DEF_OP(VBitcast);
   DEF_OP(VSXTL);
   DEF_OP(VSXTL2);
   DEF_OP(VUXTL);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
@@ -1855,11 +1855,6 @@ DEF_OP(VUShrNI2) {
   vpor(GetDst(Node), xmm14, GetSrc(Op->VectorLower.ID()));
 }
 
-DEF_OP(VBitcast) {
-  auto Op = IROp->C<IR::IROp_VBitcast>();
-  movaps(GetDst(Node), GetSrc(Op->Source.ID()));
-}
-
 DEF_OP(VSXTL) {
   auto Op = IROp->C<IR::IROp_VSXTL>();
   switch (Op->Header.ElementSize) {
@@ -2341,7 +2336,6 @@ void X86JITCore::RegisterVectorHandlers() {
   REGISTER_OP(VSHLI,             VShlI);
   REGISTER_OP(VUSHRNI,           VUShrNI);
   REGISTER_OP(VUSHRNI2,          VUShrNI2);
-  REGISTER_OP(VBITCAST,          VBitcast);
   REGISTER_OP(VSXTL,             VSXTL);
   REGISTER_OP(VSXTL2,            VSXTL2);
   REGISTER_OP(VUXTL,             VUXTL);

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -1867,8 +1867,6 @@ void OpDispatchBuilder::PMADDWD(OpcodeArgs) {
 
   if (Size == 8) {
     Size <<= 1;
-    Src1 = _VBitcast(Size, 2, Src1);
-    Src2 = _VBitcast(Size, 2, Src2);
   }
 
   auto Src1_L = _VSXTL(Size, 2, Src1);  // [15:0 ], [31:16], [32:47 ], [63:48  ]
@@ -1955,9 +1953,6 @@ void OpDispatchBuilder::PMULHW(OpcodeArgs) {
 
   OrderedNode *Res{};
   if (Size == 8) {
-    Dest = _VBitcast(Size * 2, 2, Dest);
-    Src = _VBitcast(Size * 2, 2, Src);
-
     // Implementation is more efficient for 8byte registers
     if (Signed)
       Res = _VSMull(Size * 2, 2, Dest, Src);

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -930,12 +930,6 @@
         "DestSize": "RegisterSize"
       },
 
-      "FPR = VBitcast u8:#RegisterSize, u8:#ElementSize, FPR:$Source": {
-        "Desc": ["Workaround for issue with LLVM breaking when loading scalar elements to vectors"],
-        "DestSize": "RegisterSize",
-        "NumElements": "RegisterSize / ElementSize"
-      },
-
       "FPR = VectorZero u8:#RegisterSize": {
         "Desc": ["Generates a vector zero",
                  "Useful to generate a zero vector without any previous dependencies"

--- a/External/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
@@ -449,7 +449,6 @@ void RCLSE::CalculateControlFlowInfo(FEXCore::IR::IREmitter *IREmit) {
  *   %ssa26 i128 = LoadMem %ssa25 i64, 0x10
  *   (%%ssa27) StoreContext %ssa26 i128, 0x10, 0xb0
  *   %ssa28 i128 = LoadContext 0x10, 0x90
- *   %ssa29 i128 = VBitcast %ssa26 i128
  *
  * eg.
  * 		%ssa6 i128 = LoadContext 0x10, 0x90
@@ -462,13 +461,11 @@ void RCLSE::CalculateControlFlowInfo(FEXCore::IR::IREmitter *IREmit) {
  * eg.
  *   (%%ssa189) StoreContext %ssa188 i128, 0x10, 0xa0
  *   %ssa190 i128 = LoadContext 0x10, 0x90
- *   %ssa191 i128 = VBitcast %ssa188 i128
- *   %ssa192 i128 = VAdd %ssa191 i128, %ssa190 i128, 0x10, 0x4
+ *   %ssa192 i128 = VAdd %ssa188 i128, %ssa190 i128, 0x10, 0x4
  *   (%%ssa193) StoreContext %ssa192 i128, 0x10, 0xa0
  * Converts to
  *   %ssa173 i128 = LoadContext 0x10, 0x90
- *   %ssa174 i128 = VBitcast %ssa172 i128
- *   %ssa175 i128 = VAdd %ssa174 i128, %ssa173 i128, 0x10, 0x4
+ *   %ssa175 i128 = VAdd %ssa172 i128, %ssa173 i128, 0x10, 0x4
  *   (%%ssa176) StoreContext %ssa175 i128, 0x10, 0xa0
 
  */


### PR DESCRIPTION
This instruction was purely a move that did format reinterpretation. This was necessary with LLVM when we had implicit IR op sizes.

Now that all vector ops are explicitly sized, this is not only redundant, but also completely unnecessary sicne we don't support LLVM anymore.

Remove the op, which technically is a very minor optimization for the two instructions that still used it.