### PR TITLE
IR: Removes VExtractElement

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -244,7 +244,6 @@ constexpr OpHandlerArray InterpreterOpHandlers = [] {
   REGISTER_OP(VUSHRS,                 VUShrS);
   REGISTER_OP(VSSHRS,                 VSShrS);
   REGISTER_OP(VINSELEMENT,            VInsElement);
-  REGISTER_OP(VEXTRACTELEMENT,        VExtractElement);
   REGISTER_OP(VDUPELEMENT,            VDupElement);
   REGISTER_OP(VEXTR,                  VExtr);
   REGISTER_OP(VSLI,                   VSLI);

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
@@ -263,7 +263,6 @@ namespace FEXCore::CPU {
   DEF_OP(VUShrS);
   DEF_OP(VSShrS);
   DEF_OP(VInsElement);
-  DEF_OP(VExtractElement);
   DEF_OP(VDupElement);
   DEF_OP(VExtr);
   DEF_OP(VSLI);

--- a/External/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
@@ -1389,35 +1389,6 @@ DEF_OP(VInsElement) {
   memcpy(GDP, Tmp, OpSize);
 }
 
-DEF_OP(VExtractElement) {
-  auto Op = IROp->C<IR::IROp_VExtractElement>();
-
-  const uint32_t SourceSize = GetOpSize(Data->CurrentIR, Op->Vector);
-  LOGMAN_THROW_AA_FMT(IROp->Size <= 16, "OpSize is too large for VExtractElement: {}", IROp->Size);
-  if (SourceSize == 16) {
-    __uint128_t SourceMask = (1ULL << (Op->Header.ElementSize * 8)) - 1;
-    uint64_t Shift = Op->Header.ElementSize * Op->Index * 8;
-    if (Op->Header.ElementSize == 8)
-      SourceMask = ~0ULL;
-
-    __uint128_t Src = *GetSrc<__uint128_t*>(Data->SSAData, Op->Vector);
-    Src >>= Shift;
-    Src &= SourceMask;
-    memcpy(GDP, &Src, Op->Header.ElementSize);
-  }
-  else {
-    uint64_t SourceMask = (1ULL << (Op->Header.ElementSize * 8)) - 1;
-    uint64_t Shift = Op->Header.ElementSize * Op->Index * 8;
-    if (Op->Header.ElementSize == 8)
-      SourceMask = ~0ULL;
-
-    uint64_t Src = *GetSrc<uint64_t*>(Data->SSAData, Op->Vector);
-    Src >>= Shift;
-    Src &= SourceMask;
-    GD = Src;
-  }
-}
-
 DEF_OP(VDupElement) {
   auto Op = IROp->C<IR::IROp_VDupElement>();
   const uint8_t OpSize = IROp->Size;

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -418,7 +418,6 @@ private:
   DEF_OP(VUShrS);
   DEF_OP(VSShrS);
   DEF_OP(VInsElement);
-  DEF_OP(VExtractElement);
   DEF_OP(VDupElement);
   DEF_OP(VExtr);
   DEF_OP(VSLI);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -2038,25 +2038,6 @@ DEF_OP(VInsElement) {
   }
 }
 
-DEF_OP(VExtractElement) {
-  auto Op = IROp->C<IR::IROp_VExtractElement>();
-  switch (Op->Header.Size) {
-    case 1:
-      mov(GetDst(Node).B(), GetSrc(Op->Vector.ID()).V16B(), Op->Index);
-    break;
-    case 2:
-      mov(GetDst(Node).H(), GetSrc(Op->Vector.ID()).V8H(), Op->Index);
-    break;
-    case 4:
-      mov(GetDst(Node).S(), GetSrc(Op->Vector.ID()).V4S(), Op->Index);
-    break;
-    case 8:
-      mov(GetDst(Node).D(), GetSrc(Op->Vector.ID()).V2D(), Op->Index);
-    break;
-    default:  LOGMAN_MSG_A_FMT("Unhandled VExtractElement element size: {}", Op->Header.Size);
-  }
-}
-
 DEF_OP(VDupElement) {
   auto Op = IROp->C<IR::IROp_VDupElement>();
   switch (Op->Header.ElementSize) {
@@ -2678,7 +2659,6 @@ void Arm64JITCore::RegisterVectorHandlers() {
   REGISTER_OP(VUSHRS,            VUShrS);
   REGISTER_OP(VSSHRS,            VSShrS);
   REGISTER_OP(VINSELEMENT,       VInsElement);
-  REGISTER_OP(VEXTRACTELEMENT,   VExtractElement);
   REGISTER_OP(VDUPELEMENT,       VDupElement);
   REGISTER_OP(VEXTR,             VExtr);
   REGISTER_OP(VSLI,              VSLI);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -429,7 +429,6 @@ private:
   DEF_OP(VUShrS);
   DEF_OP(VSShrS);
   DEF_OP(VInsElement);
-  DEF_OP(VExtractElement);
   DEF_OP(VDupElement);
   DEF_OP(VExtr);
   DEF_OP(VSLI);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
@@ -1591,34 +1591,6 @@ DEF_OP(VInsElement) {
   movapd(GetDst(Node), xmm15);
 }
 
-DEF_OP(VExtractElement) {
-  auto Op = IROp->C<IR::IROp_VExtractElement>();
-
-  switch (Op->Header.Size) {
-    case 1: {
-      pextrb(eax, GetSrc(Op->Vector.ID()), Op->Index);
-      pinsrb(GetDst(Node), eax, 0);
-      break;
-    }
-    case 2: {
-      pextrw(eax, GetSrc(Op->Vector.ID()), Op->Index);
-      pinsrw(GetDst(Node), eax, 0);
-      break;
-    }
-    case 4: {
-      pextrd(eax, GetSrc(Op->Vector.ID()), Op->Index);
-      pinsrd(GetDst(Node), eax, 0);
-      break;
-    }
-    case 8: {
-      pextrq(rax, GetSrc(Op->Vector.ID()), Op->Index);
-      pinsrq(GetDst(Node), rax, 0);
-      break;
-    }
-    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.Size); break;
-  }
-}
-
 DEF_OP(VDupElement) {
   auto Op = IROp->C<IR::IROp_VDupElement>();
 
@@ -2331,7 +2303,6 @@ void X86JITCore::RegisterVectorHandlers() {
   REGISTER_OP(VUSHRS,            VUShrS);
   REGISTER_OP(VSSHRS,            VSShrS);
   REGISTER_OP(VINSELEMENT,       VInsElement);
-  REGISTER_OP(VEXTRACTELEMENT,   VExtractElement);
   REGISTER_OP(VDUPELEMENT,       VDupElement);
   REGISTER_OP(VEXTR,             VExtr);
   REGISTER_OP(VSLI,              VSLI);

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -74,8 +74,7 @@ void OpDispatchBuilder::MOVLPOp(OpcodeArgs) {
     // xmm, xmm is movhlps special case
     if (Op->Src[0].IsGPR()) {
       OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, 8, 16);
-      Src = _VExtractElement(16, 8, Src, 1);
-      auto Result = _VInsElement(16, 8, 0, 0, Dest, Src);
+      auto Result = _VInsElement(16, 8, 0, 1, Dest, Src);
       StoreResult_WithOpSize(FPRClass, Op, Op->Dest, Result, 16, 16);
     }
     else {
@@ -1715,8 +1714,8 @@ void OpDispatchBuilder::PFNACCOp(OpcodeArgs) {
 
   OrderedNode *ResSubSrc{};
   OrderedNode *ResSubDest{};
-  auto UpperSubDest = _VExtractElement(Size, 4, Dest, 1);
-  auto UpperSubSrc = _VExtractElement(Size, 4, Src, 1);
+  auto UpperSubDest = _VDupElement(Size, 4, Dest, 1);
+  auto UpperSubSrc = _VDupElement(Size, 4, Src, 1);
 
   ResSubDest = _VFSub(4, 4, Dest, UpperSubDest);
   ResSubSrc = _VFSub(4, 4, Src, UpperSubSrc);
@@ -1734,7 +1733,7 @@ void OpDispatchBuilder::PFPNACCOp(OpcodeArgs) {
 
   OrderedNode *ResAdd{};
   OrderedNode *ResSub{};
-  auto UpperSubDest = _VExtractElement(Size, 4, Dest, 1);
+  auto UpperSubDest = _VDupElement(Size, 4, Dest, 1);
 
   ResSub = _VFSub(4, 4, Dest, UpperSubDest);
   ResAdd = _VFAddP(Size, 4, Src, Src);

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
@@ -1185,7 +1185,7 @@ void OpDispatchBuilder::X87FNSAVE(OpcodeArgs) {
   // upper 16 bits [79:64]
   _StoreMem(FPRClass, 8, ST0Location, data, 1);
   ST0Location = _Add(ST0Location, _Constant(8));
-  auto topBytes = _VExtractElement(16, 2, data, 4);
+  auto topBytes = _VDupElement(16, 2, data, 4);
   _StoreMem(FPRClass, 2, ST0Location, topBytes, 1);
 
   // reset to default

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87F64.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87F64.cpp
@@ -996,7 +996,7 @@ void OpDispatchBuilder::X87FNSAVEF64(OpcodeArgs) {
   // upper 16 bits [79:64]
   _StoreMem(FPRClass, 8, ST0Location, data, 1);
   ST0Location = _Add(ST0Location, _Constant(8));
-  auto topBytes = _VExtractElement(16, 2, data, 4);
+  auto topBytes = _VDupElement(16, 2, data, 4);
   _StoreMem(FPRClass, 2, ST0Location, topBytes, 1);
 
   // reset to default

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -1027,9 +1027,6 @@
         "DestSize": "RegisterSize",
         "NumElements": "RegisterSize / ElementSize"
       },
-      "FPR = VExtractElement u8:#RegisterSize, u8:#ElementSize, FPR:$Vector, u8:$Index": {
-        "DestSize": "ElementSize"
-      },
       "FPR = VDupElement u8:#RegisterSize, u8:#ElementSize, FPR:$Vector, u8:$Index": {
         "Desc": ["Duplicates one element from the source register across the whole register"],
         "DestSize": "RegisterSize",


### PR DESCRIPTION
This is a duplicate of VDupElement since AArch64 doesn't support an element extract plus zero of the rest of the register.

Removes and replaces its uses with VDupElement.