### PR TITLE
IR: Removes Mov IR op

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -181,7 +181,6 @@ constexpr OpHandlerArray InterpreterOpHandlers = [] {
   // Move ops
   REGISTER_OP(EXTRACTELEMENTPAIR,     ExtractElementPair);
   REGISTER_OP(CREATEELEMENTPAIR,      CreateElementPair);
-  REGISTER_OP(MOV,                    Mov);
 
   // Vector ops
   REGISTER_OP(VECTORZERO,             VectorZero);

--- a/External/FEXCore/Source/Interface/Core/Interpreter/MoveOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/MoveOps.cpp
@@ -30,13 +30,6 @@ DEF_OP(CreateElementPair) {
   memcpy(Dst + IROp->ElementSize, Src_Upper, IROp->ElementSize);
 }
 
-DEF_OP(Mov) {
-  auto Op = IROp->C<IR::IROp_Mov>();
-  const uint8_t OpSize = IROp->Size;
-
-  memcpy(GDP, GetSrc<void*>(Data->SSAData, Op->Value), OpSize);
-}
-
 #undef DEF_OP
 
 } // namespace FEXCore::CPU

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -355,7 +355,6 @@ private:
   ///< Move ops
   DEF_OP(ExtractElementPair);
   DEF_OP(CreateElementPair);
-  DEF_OP(Mov);
 
   ///< Vector ops
   DEF_OP(VectorZero);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MoveOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MoveOps.cpp
@@ -68,17 +68,11 @@ DEF_OP(CreateElementPair) {
   }
 }
 
-DEF_OP(Mov) {
-  auto Op = IROp->C<IR::IROp_Mov>();
-  mov(GetReg<RA_64>(Node), GetReg<RA_64>(Op->Value.ID()));
-}
-
 #undef DEF_OP
 void Arm64JITCore::RegisterMoveHandlers() {
 #define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &Arm64JITCore::Op_##x
   REGISTER_OP(EXTRACTELEMENTPAIR, ExtractElementPair);
   REGISTER_OP(CREATEELEMENTPAIR,  CreateElementPair);
-  REGISTER_OP(MOV,                Mov);
 #undef REGISTER_OP
 }
 }

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -209,7 +209,7 @@ private:
   * @brief Current guest RIP entrypoint
   */
   uint8_t *GuestEntry{};
-  
+
   using SetCC = void (X86JITCore::*)(const Operand& op);
   using CMovCC = void (X86JITCore::*)(const Reg& reg, const Operand& op);
   using JCC = void (X86JITCore::*)(const Label& label, LabelType type);
@@ -366,7 +366,6 @@ private:
   ///< Move ops
   DEF_OP(ExtractElementPair);
   DEF_OP(CreateElementPair);
-  DEF_OP(Mov);
 
   ///< Vector ops
   DEF_OP(VectorZero);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/MoveOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/MoveOps.cpp
@@ -73,17 +73,11 @@ DEF_OP(CreateElementPair) {
   }
 }
 
-DEF_OP(Mov) {
-  auto Op = IROp->C<IR::IROp_Mov>();
-  mov (GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Value.ID()));
-}
-
 #undef DEF_OP
 void X86JITCore::RegisterMoveHandlers() {
 #define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &X86JITCore::Op_##x
   REGISTER_OP(EXTRACTELEMENTPAIR, ExtractElementPair);
   REGISTER_OP(CREATEELEMENTPAIR,  CreateElementPair);
-  REGISTER_OP(MOV,                Mov);
 #undef REGISTER_OP
 }
 }

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -302,10 +302,6 @@
       }
     },
     "Moves": {
-      "GPR = Mov GPR:$Value": {
-        "DestSize": "GetOpSize(_Value)"
-      },
-
       "GPR = ExtractElementPair GPRPair:$Pair, u8:$Element": {
         "Desc": ["Extracts a register for the register pair"],
         "DestSize": "GetOpSize(_Pair) >> 1"


### PR DESCRIPTION
This is unused and shouldn't ever be used.