### PR TITLE
ELFCodeLoader: Fixes dynamic non-interpreter ELFs

### DIFF
--- a/Source/Tests/ELFCodeLoader2.h
+++ b/Source/Tests/ELFCodeLoader2.h
@@ -407,9 +407,6 @@ class ELFCodeLoader2 final : public FEXCore::CodeLoader {
 
       InterpeterElfBase = InterpLoadBase + InterpElf.phdrs.front().p_vaddr - InterpElf.phdrs.front().p_offset;
       Entrypoint = InterpLoadBase + InterpElf.ehdr.e_entry;
-    } else {
-      InterpeterElfBase = 0;
-      Entrypoint = MainElfEntrypoint;
     }
 
     // load the main elf
@@ -439,6 +436,11 @@ class ELFCodeLoader2 final : public FEXCore::CodeLoader {
 
     MainElfBase = LoadBase + MainElf.phdrs.front().p_vaddr - MainElf.phdrs.front().p_offset;
     MainElfEntrypoint = LoadBase + MainElf.ehdr.e_entry;
+
+    if (MainElf.InterpreterElf.empty()) {
+      InterpeterElfBase = 0;
+      Entrypoint = MainElfEntrypoint;
+    }
 
     // All done
 


### PR DESCRIPTION
Specifically fixes /sbin/ldconfig.
Fixes 8df7c2d84f03ef092ae2474ade1d80369b8f542f
Fixes Steam launching

I failed to test ELF files that are dynamic with no interpreter here, so EntryPoint ended up being set to zero, which results in an instant crash.

Ensure these values are set correctly after the primary ELF and interpreter are loaded so starting RIP is correct.