### PR TITLE
VDSO: Fix vsyscall

### DIFF
--- a/ThunkLibs/libVDSO/libVDSO_Guest.cpp
+++ b/ThunkLibs/libVDSO/libVDSO_Guest.cpp
@@ -32,14 +32,7 @@ __attribute__((naked))
 int __kernel_vsyscall() {
   asm volatile(R"(
   .intel_syntax noprefix
-  push ecx;
-  push edx;
-  push ebp;
-  mov ebp, ecx;
   int 0x80;
-  pop ebp;
-  pop edx;
-  pop ecx;
   ret;
   .att_syntax prefix
   )"


### PR DESCRIPTION
The `mov ebp, ecx` was breaking vsyscall and was expected to be used with the `syscall` instruction rather than `int 0x80`. Remove that to fix it.

Also remove the pushes and pops around the syscall instruction, these are unnecessary in an emulated environment, we won't clobber the registers.

Fixes Steam execution with VDSO.