### PR TITLE
IR: Handle 256-bit VNot

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
@@ -723,11 +723,15 @@ DEF_OP(VFNeg) {
 }
 
 DEF_OP(VNot) {
-  auto Op = IROp->C<IR::IROp_VNot>();
-  const auto Src1 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Vector);
+  const auto Op = IROp->C<IR::IROp_VNot>();
+  const auto Src = *GetSrc<InterpVector256*>(Data->SSAData, Op->Vector);
 
-  const auto Dst = ~Src1;
-  memcpy(GDP, &Dst, 16);
+  const auto Dst = InterpVector256{
+    .Lower = ~Src.Lower,
+    .Upper = ~Src.Upper,
+  };
+
+  memcpy(GDP, &Dst, sizeof(Dst));
 }
 
 DEF_OP(VUMin) {

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -1767,8 +1767,18 @@ DEF_OP(VFNeg) {
 }
 
 DEF_OP(VNot) {
-  auto Op = IROp->C<IR::IROp_VNot>();
-  mvn(GetDst(Node).V16B(), GetSrc(Op->Vector.ID()).V16B());
+  const auto Op = IROp->C<IR::IROp_VNot>();
+  const auto OpSize = IROp->Size;
+  const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
+
+  const auto Dst = GetDst(Node);
+  const auto Vector = GetSrc(Op->Vector.ID());
+
+  if (HostSupportsSVE && Is256Bit) {
+    not_(Dst.Z().VnB(), PRED_TMP_32B.Merging(), Vector.Z().VnB());
+  } else {
+    mvn(Dst.V16B(), Vector.V16B());
+  }
 }
 
 DEF_OP(VUMin) {

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
@@ -1069,9 +1069,13 @@ DEF_OP(VFNeg) {
 }
 
 DEF_OP(VNot) {
-  auto Op = IROp->C<IR::IROp_VNot>();
-  pcmpeqd(xmm15, xmm15);
-  vpxor(GetDst(Node), xmm15, GetSrc(Op->Vector.ID()));
+  const auto Op = IROp->C<IR::IROp_VNot>();
+
+  const auto Dst = ToYMM(GetDst(Node));
+  const auto Vector = ToYMM(GetSrc(Op->Vector.ID()));
+
+  vpcmpeqd(ymm15, ymm15, ymm15);
+  vpxor(Dst, ymm15, Vector);
 }
 
 DEF_OP(VUMin) {


### PR DESCRIPTION
Extends VNot to handle 256-bit vectors.