### PR TITLE
IR: Handle 256-bit VCMPGT/VCMPGTZ/VCMPLTZ

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
@@ -1007,22 +1007,25 @@ DEF_OP(VCMPEQZ) {
 }
 
 DEF_OP(VCMPGT) {
-  auto Op = IROp->C<IR::IROp_VCMPGT>();
+  const auto Op = IROp->C<IR::IROp_VCMPGT>();
   const uint8_t OpSize = IROp->Size;
 
   void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector1);
   void *Src2 = GetSrc<void*>(Data->SSAData, Op->Vector2);
-  uint8_t Tmp[16];
+  uint8_t Tmp[Core::CPUState::XMM_AVX_REG_SIZE];
 
-  const uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t ElementSize = Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / ElementSize;
+
   const auto Func = [](auto a, auto b) { return a > b ? ~0ULL : 0; };
-
-  switch (Op->Header.ElementSize) {
+  switch (ElementSize) {
     DO_VECTOR_OP(1, int8_t,   Func)
     DO_VECTOR_OP(2, int16_t,  Func)
     DO_VECTOR_OP(4, int32_t,  Func)
     DO_VECTOR_OP(8, int64_t,  Func)
-    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
+    default:
+      LOGMAN_MSG_A_FMT("Unknown Element Size: {}", ElementSize);
+      break;
   }
 
   memcpy(GDP, Tmp, OpSize);

--- a/External/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
@@ -1057,22 +1057,25 @@ DEF_OP(VCMPGTZ) {
 }
 
 DEF_OP(VCMPLTZ) {
-  auto Op = IROp->C<IR::IROp_VCMPLTZ>();
+  const auto Op = IROp->C<IR::IROp_VCMPLTZ>();
   const uint8_t OpSize = IROp->Size;
 
   void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector);
-  uint8_t Src2[16]{};
-  uint8_t Tmp[16];
+  uint8_t Src2[Core::CPUState::XMM_AVX_REG_SIZE]{};
+  uint8_t Tmp[Core::CPUState::XMM_AVX_REG_SIZE];
 
-  const uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t ElementSize = Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / ElementSize;
+
   const auto Func = [](auto a, auto b) { return a < b ? ~0ULL : 0; };
-
-  switch (Op->Header.ElementSize) {
+  switch (ElementSize) {
     DO_VECTOR_OP(1, int8_t,   Func)
     DO_VECTOR_OP(2, int16_t,  Func)
     DO_VECTOR_OP(4, int32_t,  Func)
     DO_VECTOR_OP(8, int64_t,  Func)
-    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
+    default:
+      LOGMAN_MSG_A_FMT("Unknown Element Size: {}", ElementSize);
+      break;
   }
 
   memcpy(GDP, Tmp, OpSize);

--- a/External/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
@@ -1032,22 +1032,25 @@ DEF_OP(VCMPGT) {
 }
 
 DEF_OP(VCMPGTZ) {
-  auto Op = IROp->C<IR::IROp_VCMPGTZ>();
+  const auto Op = IROp->C<IR::IROp_VCMPGTZ>();
   const uint8_t OpSize = IROp->Size;
 
   void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector);
-  uint8_t Src2[16]{};
-  uint8_t Tmp[16];
+  uint8_t Src2[Core::CPUState::XMM_AVX_REG_SIZE]{};
+  uint8_t Tmp[Core::CPUState::XMM_AVX_REG_SIZE];
 
-  const uint8_t Elements = OpSize / Op->Header.ElementSize;
+  const uint8_t ElementSize = Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / ElementSize;
+
   const auto Func = [](auto a, auto b) { return a > b ? ~0ULL : 0; };
-
-  switch (Op->Header.ElementSize) {
+  switch (ElementSize) {
     DO_VECTOR_OP(1, int8_t,   Func)
     DO_VECTOR_OP(2, int16_t,  Func)
     DO_VECTOR_OP(4, int32_t,  Func)
     DO_VECTOR_OP(8, int64_t,  Func)
-    default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
+    default:
+      LOGMAN_MSG_A_FMT("Unknown Element Size: {}", ElementSize);
+      break;
   }
 
   memcpy(GDP, Tmp, OpSize);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -2359,42 +2359,97 @@ DEF_OP(VCMPEQZ) {
 }
 
 DEF_OP(VCMPGT) {
-  auto Op = IROp->C<IR::IROp_VCMPGT>();
-  const uint8_t OpSize = IROp->Size;
-  if (Op->Header.ElementSize == OpSize) {
-    // Scalar
-    switch (Op->Header.ElementSize) {
-      case 4: {
-        cmgt(GetDst(Node).S(), GetSrc(Op->Vector1.ID()).S(), GetSrc(Op->Vector2.ID()).S());
-      break;
-      }
-      case 8: {
-        cmgt(GetDst(Node).D(), GetSrc(Op->Vector1.ID()).D(), GetSrc(Op->Vector2.ID()).D());
-      break;
-      }
-      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
-    }
-  }
-  else {
-    // Vector
-    switch (Op->Header.ElementSize) {
+  const auto Op = IROp->C<IR::IROp_VCMPGT>();
+  const auto OpSize = IROp->Size;
+
+  const auto ElementSize = Op->Header.ElementSize;
+  const auto IsScalar = ElementSize == OpSize;
+  const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
+
+  const auto Dst = GetDst(Node);
+  const auto Vector1 = GetSrc(Op->Vector1.ID());
+  const auto Vector2 = GetSrc(Op->Vector2.ID());
+
+  if (HostSupportsSVE && Is256Bit && !IsScalar) {
+    const auto Mask = PRED_TMP_32B.Zeroing();
+    const auto ComparePred = p0;
+
+    // Ensure no junk is in the temp (important for ensuring
+    // non greater-than values remain as zero).
+    eor(VTMP1.Z().VnD(), VTMP1.Z().VnD(), VTMP1.Z().VnD());
+
+    // General idea is to compare for greater-than, bitwise NOT
+    // the valid values, then ORR the NOTed values with the original
+    // values to form entries that are all 1s.
+
+    switch (ElementSize) {
       case 1: {
-        cmgt(GetDst(Node).V16B(), GetSrc(Op->Vector1.ID()).V16B(), GetSrc(Op->Vector2.ID()).V16B());
-      break;
+        cmpgt(ComparePred.VnB(), Mask, Vector1.Z().VnB(), Vector2.Z().VnB());
+        not_(VTMP1.Z().VnB(), ComparePred.Merging(), Vector1.Z().VnB());
+        orr(VTMP1.Z().VnB(), ComparePred.Merging(), VTMP1.Z().VnB(), Vector1.Z().VnB());
+        break;
       }
       case 2: {
-        cmgt(GetDst(Node).V8H(), GetSrc(Op->Vector1.ID()).V8H(), GetSrc(Op->Vector2.ID()).V8H());
-      break;
+        cmpgt(ComparePred.VnH(), Mask, Vector1.Z().VnH(), Vector2.Z().VnH());
+        not_(VTMP1.Z().VnH(), ComparePred.Merging(), Vector1.Z().VnH());
+        orr(VTMP1.Z().VnH(), ComparePred.Merging(), VTMP1.Z().VnH(), Vector1.Z().VnH());
+        break;
       }
       case 4: {
-        cmgt(GetDst(Node).V4S(), GetSrc(Op->Vector1.ID()).V4S(), GetSrc(Op->Vector2.ID()).V4S());
-      break;
+        cmpgt(ComparePred.VnS(), Mask, Vector1.Z().VnS(), Vector2.Z().VnS());
+        not_(VTMP1.Z().VnS(), ComparePred.Merging(), Vector1.Z().VnS());
+        orr(VTMP1.Z().VnS(), ComparePred.Merging(), VTMP1.Z().VnS(), Vector1.Z().VnS());
+        break;
       }
       case 8: {
-        cmgt(GetDst(Node).V2D(), GetSrc(Op->Vector1.ID()).V2D(), GetSrc(Op->Vector2.ID()).V2D());
-      break;
+        cmpgt(ComparePred.VnD(), Mask, Vector1.Z().VnD(), Vector2.Z().VnD());
+        not_(VTMP1.Z().VnD(), ComparePred.Merging(), Vector1.Z().VnD());
+        orr(VTMP1.Z().VnD(), ComparePred.Merging(), VTMP1.Z().VnD(), Vector1.Z().VnD());
+        break;
       }
-      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
+      default:
+        LOGMAN_MSG_A_FMT("Unknown Element Size: {}", ElementSize);
+        return;
+    }
+
+    mov(Dst.Z().VnD(), VTMP1.Z().VnD());
+  } else {
+    if (IsScalar) {
+      switch (ElementSize) {
+        case 4: {
+          cmgt(Dst.S(), Vector1.S(), Vector2.S());
+          break;
+        }
+        case 8: {
+          cmgt(Dst.D(), Vector1.D(), Vector2.D());
+          break;
+        }
+        default:
+          LOGMAN_MSG_A_FMT("Unknown Element Size: {}", ElementSize);
+          break;
+      }
+    } else {
+      switch (ElementSize) {
+        case 1: {
+          cmgt(Dst.V16B(), Vector1.V16B(), Vector2.V16B());
+          break;
+        }
+        case 2: {
+          cmgt(Dst.V8H(), Vector1.V8H(), Vector2.V8H());
+          break;
+        }
+        case 4: {
+          cmgt(Dst.V4S(), Vector1.V4S(), Vector2.V4S());
+          break;
+        }
+        case 8: {
+          cmgt(Dst.V2D(), Vector1.V2D(), Vector2.V2D());
+          break;
+        }
+        default:
+          LOGMAN_MSG_A_FMT("Unknown Element Size: {}", ElementSize);
+          break;
+      }
     }
   }
 }

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -2455,42 +2455,92 @@ DEF_OP(VCMPGT) {
 }
 
 DEF_OP(VCMPGTZ) {
-  auto Op = IROp->C<IR::IROp_VCMPGTZ>();
-  const uint8_t OpSize = IROp->Size;
-  if (Op->Header.ElementSize == OpSize) {
-    // Scalar
-    switch (Op->Header.ElementSize) {
-      case 4: {
-        cmgt(GetDst(Node).S(), GetSrc(Op->Vector.ID()).S(), 0);
-      break;
-      }
-      case 8: {
-        cmgt(GetDst(Node).D(), GetSrc(Op->Vector.ID()).D(), 0);
-      break;
-      }
-      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
-    }
-  }
-  else {
-    // Vector
-    switch (Op->Header.ElementSize) {
+  const auto Op = IROp->C<IR::IROp_VCMPGTZ>();
+  const auto OpSize = IROp->Size;
+
+  const auto ElementSize = Op->Header.ElementSize;
+  const auto IsScalar = ElementSize == OpSize;
+  const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
+
+  const auto Dst = GetDst(Node);
+  const auto Vector = GetSrc(Op->Vector.ID());
+
+  if (HostSupportsSVE && Is256Bit && !IsScalar) {
+    const auto Mask = PRED_TMP_32B.Zeroing();
+    const auto ComparePred = p0;
+
+    // Ensure no junk is in the temp (important for ensuring
+    // non greater-than values remain as zero).
+    eor(VTMP1.Z().VnD(), VTMP1.Z().VnD(), VTMP1.Z().VnD());
+
+    switch (ElementSize) {
       case 1: {
-        cmgt(GetDst(Node).V16B(), GetSrc(Op->Vector.ID()).V16B(), 0);
-      break;
+        cmpgt(ComparePred.VnB(), Mask, Vector.Z().VnB(), 0);
+        not_(VTMP1.Z().VnB(), ComparePred.Merging(), Vector.Z().VnB());
+        orr(VTMP1.Z().VnB(), ComparePred.Merging(), VTMP1.Z().VnB(), Vector.Z().VnB());
+        break;
       }
       case 2: {
-        cmgt(GetDst(Node).V8H(), GetSrc(Op->Vector.ID()).V8H(), 0);
-      break;
+        cmpgt(ComparePred.VnH(), Mask, Vector.Z().VnH(), 0);
+        not_(VTMP1.Z().VnH(), ComparePred.Merging(), Vector.Z().VnH());
+        orr(VTMP1.Z().VnH(), ComparePred.Merging(), VTMP1.Z().VnH(), Vector.Z().VnH());
+        break;
       }
       case 4: {
-        cmgt(GetDst(Node).V4S(), GetSrc(Op->Vector.ID()).V4S(), 0);
-      break;
+        cmpgt(ComparePred.VnS(), Mask, Vector.Z().VnS(), 0);
+        not_(VTMP1.Z().VnS(), ComparePred.Merging(), Vector.Z().VnS());
+        orr(VTMP1.Z().VnS(), ComparePred.Merging(), VTMP1.Z().VnS(), Vector.Z().VnS());
+        break;
       }
       case 8: {
-        cmgt(GetDst(Node).V2D(), GetSrc(Op->Vector.ID()).V2D(), 0);
-      break;
+        cmpgt(ComparePred.VnD(), Mask, Vector.Z().VnD(), 0);
+        not_(VTMP1.Z().VnD(), ComparePred.Merging(), Vector.Z().VnD());
+        orr(VTMP1.Z().VnD(), ComparePred.Merging(), VTMP1.Z().VnD(), Vector.Z().VnD());
+        break;
       }
-      default: LOGMAN_MSG_A_FMT("Unknown Element Size: {}", Op->Header.ElementSize); break;
+      default:
+        LOGMAN_MSG_A_FMT("Unknown Element Size: {}", ElementSize);
+        return;
+    }
+
+    mov(Dst.Z().VnD(), VTMP1.Z().VnD());
+  } else {
+    if (IsScalar) {
+      switch (ElementSize) {
+        case 4: {
+          cmgt(Dst.S(), Vector.S(), 0);
+          break;
+        }
+        case 8: {
+          cmgt(Dst.D(), Vector.D(), 0);
+          break;
+        }
+        default:
+          LOGMAN_MSG_A_FMT("Unknown Element Size: {}", ElementSize);
+          break;
+      }
+    } else {
+      switch (ElementSize) {
+        case 1: {
+          cmgt(Dst.V16B(), Vector.V16B(), 0);
+          break;
+        }
+        case 2: {
+          cmgt(Dst.V8H(), Vector.V8H(), 0);
+          break;
+        }
+        case 4: {
+          cmgt(Dst.V4S(), Vector.V4S(), 0);
+          break;
+        }
+        case 8: {
+          cmgt(Dst.V2D(), Vector.V2D(), 0);
+          break;
+        }
+        default:
+          LOGMAN_MSG_A_FMT("Unknown Element Size: {}", ElementSize);
+          break;
+      }
     }
   }
 }

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
@@ -1458,22 +1458,30 @@ DEF_OP(VCMPEQZ) {
 }
 
 DEF_OP(VCMPGT) {
-  auto Op = IROp->C<IR::IROp_VCMPGT>();
+  const auto Op = IROp->C<IR::IROp_VCMPGT>();
 
-  switch (Op->Header.ElementSize) {
+  const auto ElementSize = Op->Header.ElementSize;
+
+  const auto Dst = ToYMM(GetDst(Node));
+  const auto Vector1 = ToYMM(GetSrc(Op->Vector1.ID()));
+  const auto Vector2 = ToYMM(GetSrc(Op->Vector2.ID()));
+
+  switch (ElementSize) {
     case 1:
-      vpcmpgtb(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
+      vpcmpgtb(Dst, Vector1, Vector2);
       break;
     case 2:
-      vpcmpgtw(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
+      vpcmpgtw(Dst, Vector1, Vector2);
       break;
     case 4:
-      vpcmpgtd(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
+      vpcmpgtd(Dst, Vector1, Vector2);
       break;
     case 8:
-      vpcmpgtq(GetDst(Node), GetSrc(Op->Vector1.ID()), GetSrc(Op->Vector2.ID()));
+      vpcmpgtq(Dst, Vector1, Vector2);
       break;
-    default: LOGMAN_MSG_A_FMT("Unsupported element size: {}", Op->Header.ElementSize);
+    default:
+      LOGMAN_MSG_A_FMT("Unsupported element size: {}", ElementSize);
+      break;
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
@@ -1515,23 +1515,31 @@ DEF_OP(VCMPGTZ) {
 }
 
 DEF_OP(VCMPLTZ) {
-  auto Op = IROp->C<IR::IROp_VCMPLTZ>();
-  vpxor(xmm15, xmm15, xmm15);
+  const auto Op = IROp->C<IR::IROp_VCMPLTZ>();
 
-  switch (Op->Header.ElementSize) {
+  const auto ElementSize = Op->Header.ElementSize;
+
+  const auto Dst = ToYMM(GetDst(Node));
+  const auto Vector = ToYMM(GetSrc(Op->Vector.ID()));
+  const auto ZeroVector = ymm15;
+
+  vpxor(ZeroVector, ZeroVector, ZeroVector);
+  switch (ElementSize) {
     case 1:
-      vpcmpgtb(GetDst(Node), xmm15, GetSrc(Op->Vector.ID()));
+      vpcmpgtb(Dst, ZeroVector, Vector);
       break;
     case 2:
-      vpcmpgtw(GetDst(Node), xmm15, GetSrc(Op->Vector.ID()));
+      vpcmpgtw(Dst, ZeroVector, Vector);
       break;
     case 4:
-      vpcmpgtd(GetDst(Node), xmm15, GetSrc(Op->Vector.ID()));
+      vpcmpgtd(Dst, ZeroVector, Vector);
       break;
     case 8:
-      vpcmpgtq(GetDst(Node), xmm15, GetSrc(Op->Vector.ID()));
+      vpcmpgtq(Dst, ZeroVector, Vector);
       break;
-    default: LOGMAN_MSG_A_FMT("Unsupported element size: {}", Op->Header.ElementSize);
+    default:
+      LOGMAN_MSG_A_FMT("Unsupported element size: {}", ElementSize);
+      break;
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
@@ -1486,23 +1486,31 @@ DEF_OP(VCMPGT) {
 }
 
 DEF_OP(VCMPGTZ) {
-  auto Op = IROp->C<IR::IROp_VCMPGTZ>();
-  vpxor(xmm15, xmm15, xmm15);
+  const auto Op = IROp->C<IR::IROp_VCMPGTZ>();
 
-  switch (Op->Header.ElementSize) {
+  const auto ElementSize = Op->Header.ElementSize;
+
+  const auto Dst = ToYMM(GetDst(Node));
+  const auto Vector = ToYMM(GetSrc(Op->Vector.ID()));
+  const auto ZeroVector = ymm15;
+
+  vpxor(ZeroVector, ZeroVector, ZeroVector);
+  switch (ElementSize) {
     case 1:
-      vpcmpgtb(GetDst(Node), GetSrc(Op->Vector.ID()), xmm15);
+      vpcmpgtb(Dst, Vector, ZeroVector);
       break;
     case 2:
-      vpcmpgtw(GetDst(Node), GetSrc(Op->Vector.ID()), xmm15);
+      vpcmpgtw(Dst, Vector, ZeroVector);
       break;
     case 4:
-      vpcmpgtd(GetDst(Node), GetSrc(Op->Vector.ID()), xmm15);
+      vpcmpgtd(Dst, Vector, ZeroVector);
       break;
     case 8:
-      vpcmpgtq(GetDst(Node), GetSrc(Op->Vector.ID()), xmm15);
+      vpcmpgtq(Dst, Vector, ZeroVector);
       break;
-    default: LOGMAN_MSG_A_FMT("Unsupported element size: {}", Op->Header.ElementSize);
+    default:
+      LOGMAN_MSG_A_FMT("Unsupported element size: {}", ElementSize);
+      break;
   }
 }
 


### PR DESCRIPTION
Extends VCMPGT, VCMPGTZ, and VCMPLTZ to be able to handle 256-bit vectors.

Finishes up the regular vector integer comparisons