### PR TITLE
Thunks: Adds libOpenCL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -53,3 +53,7 @@
 	shallow = true
 	path = External/Vulkan-Headers
 	url = https://github.com/KhronosGroup/Vulkan-Headers.git
+[submodule "External/OpenCL-Headers"]
+	shallow = true
+	path = External/OpenCL-Headers
+	url = https://github.com/KhronosGroup/OpenCL-Headers.git

--- a/ThunkLibs/GuestLibs/CMakeLists.txt
+++ b/ThunkLibs/GuestLibs/CMakeLists.txt
@@ -247,6 +247,10 @@ if (BITNESS EQUAL 64)
   target_include_directories(libdrm-guest-deps INTERFACE /usr/include/drm/)
   target_include_directories(libdrm-guest-deps INTERFACE /usr/include/libdrm/)
   add_guest_lib(drm "libdrm.so.2")
+
+  generate(libOpenCL ${CMAKE_CURRENT_SOURCE_DIR}/../libOpenCL/libOpenCL_interface.cpp)
+  target_include_directories(libOpenCL-guest-deps INTERFACE ${FEX_PROJECT_SOURCE_DIR}/External/OpenCL-Headers/)
+  add_guest_lib(OpenCL "libOpenCL.so.1")
 endif()
 
 generate(libVDSO ${CMAKE_CURRENT_SOURCE_DIR}/../libVDSO/libVDSO_interface.cpp)

--- a/ThunkLibs/HostLibs/CMakeLists.txt
+++ b/ThunkLibs/HostLibs/CMakeLists.txt
@@ -166,6 +166,10 @@ add_host_lib(xcb-glx)
 generate(libxshmfence ${CMAKE_CURRENT_SOURCE_DIR}/../libxshmfence/libxshmfence_interface.cpp)
 add_host_lib(xshmfence)
 
+generate(libOpenCL ${CMAKE_CURRENT_SOURCE_DIR}/../libOpenCL/libOpenCL_interface.cpp)
+target_include_directories(libOpenCL-deps INTERFACE ${FEX_PROJECT_SOURCE_DIR}/External/OpenCL-Headers/)
+add_host_lib(OpenCL)
+
 generate(libdrm ${CMAKE_CURRENT_SOURCE_DIR}/../libdrm/libdrm_interface.cpp)
 target_include_directories(libdrm-deps INTERFACE /usr/include/drm/)
 target_include_directories(libdrm-deps INTERFACE /usr/include/libdrm/)

--- a/ThunkLibs/libOpenCL/libOpenCL_Common.h
+++ b/ThunkLibs/libOpenCL/libOpenCL_Common.h
@@ -1,0 +1,189 @@
+#pragma once
+
+#include <cstring>
+#include <memory>
+#include <new>
+
+#define CL_VERSION_3_0
+#define CL_USE_DEPRECATED_OPENCL_1_0_APIS
+#define CL_USE_DEPRECATED_OPENCL_1_1_APIS
+#define CL_USE_DEPRECATED_OPENCL_1_2_APIS
+#define CL_USE_DEPRECATED_OPENCL_2_0_APIS
+#define CL_USE_DEPRECATED_OPENCL_2_1_APIS
+#define CL_USE_DEPRECATED_OPENCL_2_2_APIS
+#define CL_TARGET_OPENCL_VERSION 300
+#include <CL/cl.h>
+
+namespace FEX::CL {
+  enum class AsyncCallbackType {
+    // Tied to context
+    TYPE_CLCREATECONTEXT,
+    TYPE_CLCREATECONTEXTFROMTYPE,
+    TYPE_CLSETCONTEXTDESTRUCTORCALLBACK,
+    TYPE_CLSETMEMOBJECTDESTRUCTORCALLBACK,
+    TYPE_CLSETPROGRAMRELEASECALLBACK,
+    TYPE_CLSETEVENTCALLBACK,
+    // Tied to cl_progam
+    TYPE_CLBUILDPROGRAM,
+    TYPE_CLCOMPILEPROGRAM,
+    TYPE_CLLINKPROGRAM,
+    // Tied to command_queue
+    TYPE_CLENQUEUENATIVEKERNEL,
+    TYPE_CLENQUEUESVMFREE,
+  };
+
+  union CallbackData {
+    struct _Header {
+      AsyncCallbackType Type;
+#ifdef GUEST_THUNK_LIBRARY
+      uintptr_t cb;
+#else
+      fex_guest_function_ptr cb;
+#endif
+    };
+  };
+
+  struct Type_SingleUserData {
+    CallbackData::_Header Header;
+
+    // User provided data that we need to keep around
+    void *user_data;
+
+    template <AsyncCallbackType Type>
+    static Type_SingleUserData Create(decltype(CallbackData::_Header::cb) a_0, void * a_1) {
+      static_assert(Type == AsyncCallbackType::TYPE_CLCREATECONTEXT ||
+        Type == AsyncCallbackType::TYPE_CLCREATECONTEXTFROMTYPE ||
+        Type == AsyncCallbackType::TYPE_CLSETCONTEXTDESTRUCTORCALLBACK ||
+        Type == AsyncCallbackType::TYPE_CLSETMEMOBJECTDESTRUCTORCALLBACK ||
+        Type == AsyncCallbackType::TYPE_CLSETPROGRAMRELEASECALLBACK ||
+        Type == AsyncCallbackType::TYPE_CLSETEVENTCALLBACK ||
+        Type == AsyncCallbackType::TYPE_CLBUILDPROGRAM ||
+        Type == AsyncCallbackType::TYPE_CLCOMPILEPROGRAM ||
+        Type == AsyncCallbackType::TYPE_CLLINKPROGRAM ||
+        Type == AsyncCallbackType::TYPE_CLENQUEUESVMFREE
+        ,
+        "Mismatch type for handling clProgram");
+
+      FEX::CL::Type_SingleUserData Data {
+        .Header {
+          .Type = Type,
+          .cb = a_0,
+        },
+        .user_data = a_1,
+      };
+
+      return Data;
+    };
+  };
+
+  struct Type_SingleUserDataCopy {
+    CallbackData::_Header Header;
+
+    // User provided data that we need to keep around
+    void *user_data;
+    size_t size;
+    ~Type_SingleUserDataCopy() {
+      operator delete(user_data);
+    }
+
+    template <AsyncCallbackType Type>
+    static std::unique_ptr<Type_SingleUserDataCopy> Create(decltype(CallbackData::_Header::cb) a_0, void * a_1, size_t size) {
+      static_assert(Type == AsyncCallbackType::TYPE_CLENQUEUENATIVEKERNEL,
+        "Mismatch type for handling clProgram");
+
+      void *Memory = ::operator new (size);
+      memcpy(Memory, a_1, size);
+      return std::make_unique<FEX::CL::Type_SingleUserDataCopy>(FEX::CL::Type_SingleUserDataCopy{
+        .Header {
+          .Type = Type,
+          .cb = a_0,
+        },
+        .user_data = Memory,
+        .size = size,
+      });
+    };
+  };
+
+  union GuestCallbackData {
+    CallbackData::_Header Header;
+
+    template<typename ...>
+    struct PackedArgs;
+
+    template<typename A0>
+    struct PackedArgs<A0> {
+      A0 a_0;
+    };
+
+    template<typename A0, typename A1>
+    struct PackedArgs<A0, A1> {
+      A0 a_0;
+      A1 a_1;
+    };
+
+    template<typename A0, typename A1, typename A2>
+    struct PackedArgs<A0, A1, A2> {
+      A0 a_0;
+      A1 a_1;
+      A2 a_2;
+    };
+
+    template<typename A0, typename A1, typename A2, typename A3>
+    struct PackedArgs<A0, A1, A2, A3> {
+      A0 a_0;
+      A1 a_1;
+      A2 a_2;
+      A3 a_3;
+    };
+
+    struct Type_clCreateContext {
+      CallbackData::_Header Header;
+      PackedArgs<const char*, const void*, size_t, void*> Args;
+    } clCreateContext;
+
+    struct Type_clSetContextDestructorCallback {
+      CallbackData::_Header Header;
+      PackedArgs<cl_context, void*> Args;
+    } clSetContextDestructorCallback;
+
+    struct Type_clProgram {
+      // Callback for this job that is necessary
+      // This gets passed from Host->Guest for the callback arguments
+      CallbackData::_Header Header;
+      PackedArgs<cl_program, void*> Args;
+    } clProgram;
+
+    struct Type_clMem {
+      // Callback for this job that is necessary
+      // This gets passed from Host->Guest for the callback arguments
+      CallbackData::_Header Header;
+      PackedArgs<cl_mem, void*> Args;
+    } clMem;
+
+    struct Type_clUser {
+      // Callback for this job that is necessary
+      // This gets passed from Host->Guest for the callback arguments
+      CallbackData::_Header Header;
+      PackedArgs<void*> Args;
+    } clUser;
+
+    struct Type_clSetEventCallback {
+      CallbackData::_Header Header;
+      PackedArgs<cl_event, cl_int, void*> Args;
+    } clSetEventCallback;
+
+    struct Type_clSVMFree {
+      CallbackData::_Header Header;
+      PackedArgs<cl_command_queue, cl_uint, void**, void*> Args;
+    } clSVMFree;
+
+    template<typename DataType, typename OriginalDataType, typename... T>
+    static DataType Create(OriginalDataType* OriginalData, T... args) {
+      DataType Data;
+      Data.Header.Type = OriginalData->Header.Type;
+      Data.Header.cb = OriginalData->Header.cb;
+      Data.Args = { args..., OriginalData->user_data };
+      return Data;
+    }
+  };
+}

--- a/ThunkLibs/libOpenCL/libOpenCL_Guest.cpp
+++ b/ThunkLibs/libOpenCL/libOpenCL_Guest.cpp
@@ -1,0 +1,191 @@
+/*
+$info$
+tags: thunklibs|OpenCL
+desc: Handles callbacks and varargs
+$end_info$
+*/
+
+#include <cstdint>
+#include <stdio.h>
+#include <cstring>
+#include <map>
+#include <string>
+
+#include <dlfcn.h>
+
+#include <thread>
+#include <functional>
+#include <unordered_map>
+
+#include "libOpenCL_Common.h"
+
+#include "common/Guest.h"
+#include "common/CrossArchEvent.h"
+#include <stdarg.h>
+
+#include "thunkgen_guest_libOpenCL.inl"
+
+static std::thread CBThread{};
+static std::atomic<bool> CBDone{false};
+
+static CrossArchEvent WaitForWork{};
+static CrossArchEvent WorkDone{};
+static void *CBWorkData{};
+
+void FEX_Helper_GiveEvents() {
+  struct {
+    CrossArchEvent *WaitForWork;
+    CrossArchEvent *WorkDone;
+    void **Work;
+  } args;
+
+  args.WaitForWork = &WaitForWork;
+  args.WorkDone = &WorkDone;
+  args.Work = &CBWorkData;
+
+  fexthunks_libOpenCL_FEX_GiveEventHandlers(&args);
+}
+
+static void CallbackThreadFunc() {
+  // Set the thread name to make it easy to know what thread this is
+  pthread_setname_np(pthread_self(), "cl:async_cb");
+
+  // Hand the host our helpers
+  FEX_Helper_GiveEvents();
+  while (!CBDone) {
+    WaitForWorkFunc(&WaitForWork);
+    if (CBDone) {
+      return;
+    }
+
+    auto Data = reinterpret_cast<FEX::CL::GuestCallbackData*>(CBWorkData);
+    switch (Data->Header.Type) {
+      case FEX::CL::AsyncCallbackType::TYPE_CLCREATECONTEXT:
+      case FEX::CL::AsyncCallbackType::TYPE_CLCREATECONTEXTFROMTYPE:
+      {
+        using clCreateContextCBType = void (*) (const char *errinfo, const void *private_info, size_t cb, void *user_data);
+        auto CB = reinterpret_cast<clCreateContextCBType>(Data->Header.cb);
+
+        CB(Data->clCreateContext.Args.a_0,
+           Data->clCreateContext.Args.a_1,
+           Data->clCreateContext.Args.a_2,
+           Data->clCreateContext.Args.a_3
+           );
+
+        break;
+      }
+      case FEX::CL::AsyncCallbackType::TYPE_CLSETCONTEXTDESTRUCTORCALLBACK: {
+        using clCBType = void (*) (cl_context context, void* user_data);
+        auto CB = reinterpret_cast<clCBType>(Data->Header.cb);
+
+        CB(Data->clSetContextDestructorCallback.Args.a_0,
+           Data->clSetContextDestructorCallback.Args.a_1
+           );
+        break;
+      }
+      case FEX::CL::AsyncCallbackType::TYPE_CLSETMEMOBJECTDESTRUCTORCALLBACK: {
+        using clCBType = void (*) (cl_mem mem, void* user_data);
+        auto CB = reinterpret_cast<clCBType>(Data->Header.cb);
+
+        CB(Data->clMem.Args.a_0,
+           Data->clMem.Args.a_1
+           );
+        break;
+      }
+      case FEX::CL::AsyncCallbackType::TYPE_CLBUILDPROGRAM:
+      case FEX::CL::AsyncCallbackType::TYPE_CLCOMPILEPROGRAM:
+      case FEX::CL::AsyncCallbackType::TYPE_CLLINKPROGRAM:
+      case FEX::CL::AsyncCallbackType::TYPE_CLSETPROGRAMRELEASECALLBACK:
+      {
+        using clProgramCBType = void (*) (cl_program program, void * user_data);
+        auto CB = reinterpret_cast<clProgramCBType>(Data->Header.cb);
+
+        CB(Data->clProgram.Args.a_0, Data->clProgram.Args.a_1);
+        break;
+      }
+      case FEX::CL::AsyncCallbackType::TYPE_CLENQUEUENATIVEKERNEL:
+      {
+        using clCBType = void (*) (void* user_data);
+        auto CB = reinterpret_cast<clCBType>(Data->Header.cb);
+        CB(Data->clUser.Args.a_0);
+        break;
+      }
+      case FEX::CL::AsyncCallbackType::TYPE_CLENQUEUESVMFREE:
+      {
+        using clCBType = void (*) (cl_command_queue queue, cl_uint num_svm_pointers, void *svm_pointers[], void* user_data);
+        auto CB = reinterpret_cast<clCBType>(Data->Header.cb);
+
+        CB(Data->clSVMFree.Args.a_0,
+           Data->clSVMFree.Args.a_1,
+           Data->clSVMFree.Args.a_2,
+           Data->clSVMFree.Args.a_3
+           );
+        break;
+      }
+      case FEX::CL::AsyncCallbackType::TYPE_CLSETEVENTCALLBACK:
+      {
+        using clCBType = void (*) (cl_event event, cl_int event_command_exec_status, void *user_data);
+        auto CB = reinterpret_cast<clCBType>(Data->Header.cb);
+
+        CB(Data->clSetEventCallback.Args.a_0,
+           Data->clSetEventCallback.Args.a_1,
+           Data->clSetEventCallback.Args.a_2
+           );
+        break;
+      }
+    }
+    NotifyWorkFunc(&WorkDone);
+  }
+}
+
+extern "C" {
+  static void init_lib() {
+    // Start a guest side thread that allows us to do callbacks from xcb safely
+    if (!CBThread.joinable()) {
+      CBThread = std::thread(CallbackThreadFunc);
+    }
+  }
+  __attribute__((destructor)) static void close_lib() {
+    if (CBThread.joinable()) {
+      CBDone = true;
+      NotifyWorkFunc(&WaitForWork);
+      NotifyWorkFunc(&WorkDone);
+      CBThread.join();
+    }
+  }
+}
+
+typedef void voidFunc();
+
+// Maps OpenGL API function names to the address of a guest function which is
+// linked to the corresponding host function pointer
+const std::unordered_map<std::string_view, uintptr_t /* guest function address */> HostPtrInvokers =
+    std::invoke([]() {
+#define PAIR(name, unused) Ret[#name] = reinterpret_cast<uintptr_t>(GetCallerForHostFunction(name));
+        std::unordered_map<std::string_view, uintptr_t> Ret;
+        FOREACH_internal_SYMBOL(PAIR);
+        return Ret;
+#undef PAIR
+    });
+
+extern "C" {
+  CL_API_ENTRY CL_API_PREFIX__VERSION_1_1_DEPRECATED void * CL_API_CALL
+    clGetExtensionFunctionAddress(const char *procname) CL_API_SUFFIX__VERSION_1_1_DEPRECATED {
+    auto Ret = fexfn_pack_clGetExtensionFunctionAddress(procname);
+    if (!Ret) {
+      return nullptr;
+    }
+
+    auto TargetFuncIt = HostPtrInvokers.find(reinterpret_cast<const char*>(procname));
+    if (TargetFuncIt == HostPtrInvokers.end()) {
+      std::string_view procname_s { reinterpret_cast<const char*>(procname) };
+      fprintf(stderr, "clGetExtensionFunctionAddress: not found %s\n", procname);
+      return nullptr;
+    }
+
+    LinkAddressToFunction((uintptr_t)Ret, TargetFuncIt->second);
+    return Ret;
+  }
+}
+
+LOAD_LIB_INIT(libOpenCL, init_lib)

--- a/ThunkLibs/libOpenCL/libOpenCL_Guest.lds
+++ b/ThunkLibs/libOpenCL/libOpenCL_Guest.lds
@@ -1,0 +1,16 @@
+VERSION {
+  OPENCL_1.0 {
+  };
+  OPENCL_1.1 {
+  };
+  OPENCL_1.2 {
+  };
+  OPENCL_2.0 {
+  };
+  OPENCL_2.1 {
+  };
+  OPENCL_2.2 {
+  };
+  OPENCL_3.0 {
+  };
+}

--- a/ThunkLibs/libOpenCL/libOpenCL_Host.cpp
+++ b/ThunkLibs/libOpenCL/libOpenCL_Host.cpp
@@ -1,0 +1,608 @@
+/*
+$info$
+tags: thunklibs|X11
+desc: Handles callbacks and varargs
+$end_info$
+*/
+
+#include <cstdlib>
+#include <stdio.h>
+
+#include <dlfcn.h>
+#include <unordered_map>
+#include <shared_mutex>
+
+#include "common/CrossArchEvent.h"
+#include "common/Host.h"
+#include <vector>
+
+#include "libOpenCL_Common.h"
+
+#include "thunkgen_host_libOpenCL.inl"
+
+// OpenCL as an API has multiple functions that have a callback associated with it.
+// The lifetime of the callback passed to these functions is associated with the object created, not the library.
+//
+// Each of the objects that OpenCL creates is refcounted by the driver. Our callback tracking needs to stay aligned with this refcounting.
+// Because FEX thunks need to rewrite the callback function and arguments, we also need to to keep the application's data around with refcounting.
+//
+// We need to be quite careful with these refcounted callbacks since the guest application can be utterly mean to us where it is also tracking
+// lifetimes and deleting things as they go away.
+//
+// Common use case is just a hardcoded handler function in their application that returns results and would still work beyond the object's lifetime.
+//
+// List of OpenCL functions with callbacks that have lifetimes.
+//
+// clCreateContext - pfn_notify - Is live until context is destroyed (with refcount)
+//   - clCreateContextFromType - Same
+//   - clSetContextDestructorCallback - Same
+//
+// clSetEventCallback - Live until cl_event is destroyed (with refcount)
+//
+// clSetMemObjectDestructorCallback - Is live until cl_mem is destroyed (with refcount)
+//
+// clBuildProgram - pfn_notify - Is live until program is built (Stays around until refcount is zero)
+//   - clCompileProgram - Same
+//   - clLinkProgram - Same
+//   - clSetProgramReleaseCallback - Same
+//
+// clEnqueueNativeKernel - Links a user_func to a command_queue that it can execute.
+//   - Live until command queue deleted (with refcount)
+//   - clEnqueueSVMFree - Same
+
+extern "C" {
+  struct ContextCallbacks {
+    std::atomic<size_t> RefCount{};
+    // CreateContext and CreateContextFromType share this callback
+    FEX::CL::Type_SingleUserData CreateContextCallback{};
+    FEX::CL::Type_SingleUserData SetContextDestructorCallback{};
+  };
+
+  struct ProgramCallbacks {
+    std::atomic<size_t> RefCount{};
+    FEX::CL::Type_SingleUserData BuildCallback{};
+    FEX::CL::Type_SingleUserData CompileCallback{};
+    FEX::CL::Type_SingleUserData LinkCallback{};
+    FEX::CL::Type_SingleUserData SetProgramReleaseCallback{};
+  };
+
+  struct CommandQueueCallbacks {
+    std::atomic<size_t> RefCount{};
+    std::vector<std::unique_ptr<FEX::CL::Type_SingleUserDataCopy>> UserFunc{};
+    FEX::CL::Type_SingleUserData SVMFreeCallback{};
+  };
+
+  struct EventCallbacks {
+    std::atomic<size_t> RefCount{};
+    std::vector<FEX::CL::Type_SingleUserData> EventCallbacks{};
+  };
+
+  struct MemoryObjectCallbacks {
+    std::atomic<size_t> RefCount{};
+    FEX::CL::Type_SingleUserData MemObjectDestructorCallback{};
+  };
+
+  // Delete map members with clReleaseContext once refcount is zero
+  std::shared_mutex ContextCBsMutex{};
+  std::unordered_map<cl_context, ContextCallbacks> ContextCBs{};
+  // Delete map members with clReleaseProgram once refcount is zero
+  std::shared_mutex ProgramCBsMutex{};
+  std::unordered_map<cl_program, ProgramCallbacks> ProgramCBs{};
+  // Delete map members with clReleaseCommandQueue once refcount is zero
+  std::shared_mutex CommandCBsMutex{};
+  std::unordered_map<cl_command_queue, CommandQueueCallbacks> CommandQueueCBs{};
+  // Delete map members with clReleaseMemObject once refcount is zero
+  std::shared_mutex MemCBsMutex{};
+  std::unordered_map<cl_mem, MemoryObjectCallbacks> MemCBs{};
+  // Delete map members with clReleaseEvent once refcount is zero
+  std::shared_mutex EventCBsMutex{};
+  std::unordered_map<cl_event, EventCallbacks> EventCBs{};
+
+  CrossArchEvent *WaitForWork{};
+  CrossArchEvent *WorkDone{};
+  void **Work{};
+
+  static void fexfn_impl_libOpenCL_FEX_GiveEventHandlers(CrossArchEvent* a_0, CrossArchEvent* a_1, void** a_2){
+    WaitForWork = a_0;
+    WorkDone = a_1;
+    Work = a_2;
+  }
+
+  static void clCreateContext_async_callback(const char * errinfo, const void * private_info, size_t cb, void *user_data) {
+    auto FEX_user_data = reinterpret_cast<FEX::CL::Type_SingleUserData*>(user_data);
+    auto CBData = FEX::CL::GuestCallbackData::Create<FEX::CL::GuestCallbackData::Type_clCreateContext>(FEX_user_data, errinfo, private_info, cb);
+    *Work = &CBData;
+
+    // Tell the thread it has work
+    NotifyWorkFunc(WaitForWork);
+    // Wait for the work to be done
+    WaitForWorkFunc(WorkDone);
+  }
+
+  static void clProgram_async_callback(cl_program a_0, void *a_1) {
+    auto FEX_user_data = reinterpret_cast<FEX::CL::Type_SingleUserData*>(a_1);
+    auto CBData = FEX::CL::GuestCallbackData::Create<FEX::CL::GuestCallbackData::Type_clProgram>(FEX_user_data, a_0);
+    *Work = &CBData;
+
+    // Tell the thread it has work
+    NotifyWorkFunc(WaitForWork);
+    // Wait for the work to be done
+    WaitForWorkFunc(WorkDone);
+  }
+
+  static void clSetMemObjectDestructorCallback_async_callback(cl_mem a_0, void *a_1) {
+    auto FEX_user_data = reinterpret_cast<FEX::CL::Type_SingleUserData*>(a_1);
+    auto CBData = FEX::CL::GuestCallbackData::Create<FEX::CL::GuestCallbackData::Type_clMem>(FEX_user_data, a_0);
+    *Work = &CBData;
+
+    // Tell the thread it has work
+    NotifyWorkFunc(WaitForWork);
+    // Wait for the work to be done
+    WaitForWorkFunc(WorkDone);
+  }
+
+  static void clSetContextDestructorCallback_async_callback(cl_context a_0, void *a_1) {
+    auto FEX_user_data = reinterpret_cast<FEX::CL::Type_SingleUserData*>(a_1);
+    auto CBData = FEX::CL::GuestCallbackData::Create<FEX::CL::GuestCallbackData::Type_clSetContextDestructorCallback>(FEX_user_data, a_0);
+    *Work = &CBData;
+
+    // Tell the thread it has work
+    NotifyWorkFunc(WaitForWork);
+    // Wait for the work to be done
+    WaitForWorkFunc(WorkDone);
+  }
+
+  static void clUser_async_callback(void *a_0) {
+    auto FEX_user_data = reinterpret_cast<FEX::CL::Type_SingleUserDataCopy*>(a_0);
+    // Unlike other callbacks, the a_0
+    auto CBData = FEX::CL::GuestCallbackData::Create<FEX::CL::GuestCallbackData::Type_clUser>(FEX_user_data);
+    *Work = &CBData;
+
+    // Tell the thread it has work
+    NotifyWorkFunc(WaitForWork);
+    // Wait for the work to be done
+    WaitForWorkFunc(WorkDone);
+  }
+
+  static void clSVMFree_async_callback(cl_command_queue a_0, cl_uint a_1, void *a_2[], void *a_3) {
+    auto FEX_user_data = reinterpret_cast<FEX::CL::Type_SingleUserData*>(a_3);
+    auto CBData = FEX::CL::GuestCallbackData::Create<FEX::CL::GuestCallbackData::Type_clSVMFree>(FEX_user_data, a_0, a_1, a_2);
+    *Work = &CBData;
+
+    // Tell the thread it has work
+    NotifyWorkFunc(WaitForWork);
+    // Wait for the work to be done
+    WaitForWorkFunc(WorkDone);
+  }
+
+  static void clSetEventCallback_async_callback(cl_event a_0, cl_int a_1, void *a_2) {
+    auto FEX_user_data = reinterpret_cast<FEX::CL::Type_SingleUserData*>(a_2);
+    auto CBData = FEX::CL::GuestCallbackData::Create<FEX::CL::GuestCallbackData::Type_clSetEventCallback>(FEX_user_data, a_0, a_1);
+    *Work = &CBData;
+
+    // Tell the thread it has work
+    NotifyWorkFunc(WaitForWork);
+    // Wait for the work to be done
+    WaitForWorkFunc(WorkDone);
+  }
+}
+
+static auto fexfn_impl_libOpenCL_clCreateContext (const cl_context_properties * a_0, cl_uint a_1, const cl_device_id * a_2, fex_guest_function_ptr a_3, void * a_4, cl_int * a_5) -> cl_context {
+  auto CBData = FEX::CL::Type_SingleUserData::Create<FEX::CL::AsyncCallbackType::TYPE_CLCREATECONTEXT>(a_3, a_4);
+
+  using CallbackType = decltype(&clCreateContext_async_callback);
+  CallbackType CB{};
+  FEX::CL::Type_SingleUserData *CBDataPtr{};
+
+  if (a_3) {
+    CB = clCreateContext_async_callback;
+    CBDataPtr = &CBData;
+  }
+
+  auto Result = fexldr_ptr_libOpenCL_clCreateContext(a_0, a_1, a_2, CB, CBDataPtr, a_5);
+
+  if (Result && a_3) {
+    std::unique_lock lk{ContextCBsMutex};
+
+    auto ContextCB = ContextCBs.try_emplace(Result);
+
+    // Refcount increase
+    ContextCB.first->second.RefCount++;
+
+    // Add the callback to the tracking map
+    ContextCB.first->second.CreateContextCallback = CBData;
+  }
+  return Result;
+}
+
+static auto fexfn_impl_libOpenCL_clCreateContextFromType(const cl_context_properties * a_0, cl_device_type a_1, fex_guest_function_ptr a_2, void * a_3, cl_int * a_4) -> cl_context {
+  auto CBData = FEX::CL::Type_SingleUserData::Create<FEX::CL::AsyncCallbackType::TYPE_CLCREATECONTEXTFROMTYPE>(a_2, a_3);
+
+  using CallbackType = decltype(&clCreateContext_async_callback);
+  CallbackType CB{};
+  FEX::CL::Type_SingleUserData *CBDataPtr{};
+
+  if (a_3) {
+    CB = clCreateContext_async_callback;
+    CBDataPtr = &CBData;
+  }
+
+  auto Result = fexldr_ptr_libOpenCL_clCreateContextFromType(a_0, a_1, CB, CBDataPtr, a_4);
+  if (Result && a_2) {
+    std::unique_lock lk{ContextCBsMutex};
+
+    auto ContextCB = ContextCBs.try_emplace(Result);
+
+    // Refcount increase
+    ContextCB.first->second.RefCount++;
+
+    // Add the callback to the tracking map
+    ContextCB.first->second.CreateContextCallback = CBData;
+  }
+
+  return Result;
+}
+
+static auto fexfn_impl_libOpenCL_clSetContextDestructorCallback(cl_context a_0, fex_guest_function_ptr a_1, void * a_2) -> cl_int {
+  using CallbackType = decltype(&clSetContextDestructorCallback_async_callback);
+  CallbackType CB{};
+  FEX::CL::Type_SingleUserData *CBDataPtr{};
+
+  if (a_1) {
+    CB = clSetContextDestructorCallback_async_callback;
+
+    std::unique_lock lk{ContextCBsMutex};
+
+    // Add the callback to the tracking map
+    auto CBData = ContextCBs.try_emplace(a_0);
+
+    CBData.first->second.SetContextDestructorCallback = FEX::CL::Type_SingleUserData::Create<FEX::CL::AsyncCallbackType::TYPE_CLSETCONTEXTDESTRUCTORCALLBACK>(a_1, a_2);
+    CBDataPtr = &CBData.first->second.SetContextDestructorCallback;
+  }
+
+  return fexldr_ptr_libOpenCL_clSetContextDestructorCallback(a_0, CB, CBDataPtr);
+}
+
+static auto fexfn_impl_libOpenCL_clRetainContext(cl_context a_0) -> cl_int {
+  {
+    std::shared_lock lk{ContextCBsMutex};
+    auto CB = ContextCBs.find(a_0);
+    if (CB != ContextCBs.end()) {
+      CB->second.RefCount++;
+    }
+  }
+  return fexldr_ptr_libOpenCL_clRetainContext(a_0);
+}
+
+static auto fexfn_impl_libOpenCL_clReleaseContext(cl_context a_0) -> cl_int {
+  auto Result = fexldr_ptr_libOpenCL_clReleaseContext(a_0);
+
+  std::unique_lock lk{ContextCBsMutex};
+  auto CB = ContextCBs.find(a_0);
+  if (CB != ContextCBs.end()) {
+    auto RefCount = CB->second.RefCount.fetch_sub(1);;
+    if (RefCount == 1) {
+      // Remove the tracking once this has been refcount to zero
+      ContextCBs.erase(CB);
+    }
+  }
+
+  return Result;
+}
+
+static auto fexfn_impl_libOpenCL_clBuildProgram(cl_program a_0, cl_uint a_1, const cl_device_id * a_2, const char * a_3, fex_guest_function_ptr a_4, void * a_5) -> cl_int {
+  FEX::CL::Type_SingleUserData *CBDataPtr{};
+
+  using CallbackType = decltype(&clProgram_async_callback);
+  CallbackType CB{};
+
+  if (a_4) {
+    CB = clProgram_async_callback;
+
+    std::unique_lock lk{ProgramCBsMutex};
+
+    // Add the callback to the tracking map
+    auto CBData = ProgramCBs.try_emplace(a_0);
+
+    // Refcount increase
+    CBData.first->second.RefCount++;
+
+    CBData.first->second.BuildCallback = FEX::CL::Type_SingleUserData::Create<FEX::CL::AsyncCallbackType::TYPE_CLBUILDPROGRAM>(a_4, a_5);
+    CBDataPtr = &CBData.first->second.BuildCallback;
+  }
+  return fexldr_ptr_libOpenCL_clBuildProgram(a_0, a_1, a_2, a_3, CB, CBDataPtr);
+}
+
+static auto fexfn_impl_libOpenCL_clCompileProgram(cl_program a_0, cl_uint a_1, const cl_device_id * a_2, const char * a_3, cl_uint a_4, const cl_program * a_5, const char ** a_6, fex_guest_function_ptr a_7, void * a_8) -> cl_int {
+  FEX::CL::Type_SingleUserData *CBDataPtr{};
+
+  using CallbackType = decltype(&clProgram_async_callback);
+  CallbackType CB{};
+
+  if (a_7) {
+    CB = clProgram_async_callback;
+
+    std::unique_lock lk{ProgramCBsMutex};
+
+    // Add the callback to the tracking map
+    auto CBData = ProgramCBs.try_emplace(a_0);
+
+    // Refcount increase
+    CBData.first->second.RefCount++;
+
+    CBData.first->second.CompileCallback = FEX::CL::Type_SingleUserData::Create<FEX::CL::AsyncCallbackType::TYPE_CLCOMPILEPROGRAM>(a_7, a_8);
+    CBDataPtr = &CBData.first->second.CompileCallback;
+  }
+
+  return fexldr_ptr_libOpenCL_clCompileProgram(a_0, a_1, a_2, a_3, a_4, a_5, a_6, CB, CBDataPtr);
+}
+
+static auto fexfn_impl_libOpenCL_clLinkProgram(cl_context a_0, cl_uint a_1, const cl_device_id * a_2, const char * a_3, cl_uint a_4, const cl_program * a_5, fex_guest_function_ptr a_6, void * a_7, cl_int * a_8) -> cl_program {
+  FEX::CL::Type_SingleUserData *CBDataPtr{};
+
+  using CallbackType = decltype(&clProgram_async_callback);
+  CallbackType CB{};
+
+  if (a_7) {
+    CB = clProgram_async_callback;
+
+    std::unique_lock lk{ProgramCBsMutex};
+
+    for (size_t i = 0; i < a_4; ++i) {
+      const cl_program program = a_5[i];
+
+      // Add the callback to the tracking map
+      auto CBData = ProgramCBs.try_emplace(program);
+
+      // Refcount increase
+      CBData.first->second.RefCount++;
+
+      CBData.first->second.LinkCallback = FEX::CL::Type_SingleUserData::Create<FEX::CL::AsyncCallbackType::TYPE_CLLINKPROGRAM>(a_6, a_7);
+      CBDataPtr = &CBData.first->second.CompileCallback;
+    }
+  }
+
+  return fexldr_ptr_libOpenCL_clLinkProgram(a_0, a_1, a_2, a_3, a_4, a_5, CB, CBDataPtr, a_8);
+}
+
+static auto fexfn_impl_libOpenCL_clSetProgramReleaseCallback(cl_program a_0, fex_guest_function_ptr a_1, void * a_2) -> cl_int {
+  FEX::CL::Type_SingleUserData *CBDataPtr{};
+
+  using CallbackType = decltype(&clProgram_async_callback);
+  CallbackType CB{};
+
+  if (a_1) {
+    CB = clProgram_async_callback;
+
+    std::unique_lock lk{ProgramCBsMutex};
+
+    // Add the callback to the tracking map
+    auto CBData = ProgramCBs.try_emplace(a_0);
+
+    CBData.first->second.CompileCallback = FEX::CL::Type_SingleUserData::Create<FEX::CL::AsyncCallbackType::TYPE_CLSETPROGRAMRELEASECALLBACK>(a_1, a_2);
+    CBDataPtr = &CBData.first->second.CompileCallback;
+  }
+
+  return fexldr_ptr_libOpenCL_clSetProgramReleaseCallback(a_0, CB, CBDataPtr);
+}
+
+static auto fexfn_impl_libOpenCL_clRetainProgram(cl_program a_0) -> cl_int {
+  {
+    std::shared_lock lk{ContextCBsMutex};
+    auto CB = ProgramCBs.find(a_0);
+    if (CB != ProgramCBs.end()) {
+      CB->second.RefCount++;
+    }
+  }
+  return fexldr_ptr_libOpenCL_clRetainProgram(a_0);
+}
+static auto fexfn_impl_libOpenCL_clReleaseProgram(cl_program a_0) -> cl_int {
+  auto Result = fexldr_ptr_libOpenCL_clReleaseProgram(a_0);
+
+  std::unique_lock lk{ContextCBsMutex};
+  auto CB = ProgramCBs.find(a_0);
+  if (CB != ProgramCBs.end()) {
+    auto RefCount = CB->second.RefCount.fetch_sub(1);;
+    if (RefCount == 1) {
+      // Remove the tracking once this has been refcount to zero
+      ProgramCBs.erase(CB);
+    }
+  }
+
+  return Result;
+}
+
+static auto fexfn_impl_libOpenCL_clEnqueueNativeKernel(cl_command_queue a_0, fex_guest_function_ptr a_1, void * a_2, size_t a_3, cl_uint a_4, const cl_mem * a_5, const void ** a_6, cl_uint a_7, const cl_event * a_8, cl_event * a_9) -> cl_int {
+  using CallbackType = decltype(&clUser_async_callback);
+  CallbackType CB{};
+  void *MemoryPtr {a_2};
+  size_t Size = a_3;
+
+  if (a_1) {
+    CB = clUser_async_callback;
+
+    std::unique_lock lk{CommandCBsMutex};
+
+    // Add the callback to the tracking map
+    auto CBData = CommandQueueCBs.try_emplace(a_0);
+    auto UserPtr = CBData.first->second.UserFunc.emplace_back(FEX::CL::Type_SingleUserDataCopy::Create<FEX::CL::AsyncCallbackType::TYPE_CLENQUEUENATIVEKERNEL>(a_1, a_2, a_3)).get();
+
+    // Change memory pointer over to our tracking data
+    MemoryPtr = UserPtr;
+    Size = sizeof(*UserPtr);
+  }
+
+  return fexldr_ptr_libOpenCL_clEnqueueNativeKernel(a_0, CB, MemoryPtr, Size, a_4, a_5, a_6, a_7, a_8, a_9);
+}
+
+static auto fexfn_impl_libOpenCL_clCreateCommandQueue(cl_context a_0, cl_device_id a_1, cl_command_queue_properties a_2, cl_int * a_3) -> cl_command_queue {
+  auto Result = fexldr_ptr_libOpenCL_clCreateCommandQueue(a_0, a_1, a_2, a_3);
+
+  if (Result && a_3) {
+    std::unique_lock lk{CommandCBsMutex};
+
+    auto ContextCB = CommandQueueCBs.try_emplace(Result);
+
+    // Refcount increase
+    ContextCB.first->second.RefCount++;
+  }
+  return Result;
+}
+
+static auto fexfn_impl_libOpenCL_clCreateCommandQueueWithProperties(cl_context a_0, cl_device_id a_1, const cl_queue_properties * a_2, cl_int * a_3) -> cl_command_queue {
+  auto Result = fexldr_ptr_libOpenCL_clCreateCommandQueueWithProperties(a_0, a_1, a_2, a_3);
+
+  if (Result && a_3) {
+    std::unique_lock lk{CommandCBsMutex};
+
+    auto ContextCB = CommandQueueCBs.try_emplace(Result);
+
+    // Refcount increase
+    ContextCB.first->second.RefCount++;
+  }
+  return Result;
+}
+
+static auto fexfn_impl_libOpenCL_clEnqueueSVMFree(cl_command_queue a_0, cl_uint a_1, void ** a_2, fex_guest_function_ptr a_3, void * a_4, cl_uint a_5, const cl_event * a_6, cl_event * a_7) -> cl_int {
+  FEX::CL::Type_SingleUserData *CBDataPtr{};
+
+  using CallbackType = decltype(&clSVMFree_async_callback);
+  CallbackType CB{};
+
+  if (a_7) {
+    CB = clSVMFree_async_callback;
+
+    std::unique_lock lk{ContextCBsMutex};
+
+    // Add the callback to the tracking map
+    auto CBData = CommandQueueCBs.try_emplace(a_0);
+
+    CBData.first->second.SVMFreeCallback = FEX::CL::Type_SingleUserData::Create<FEX::CL::AsyncCallbackType::TYPE_CLENQUEUESVMFREE>(a_3, a_4);
+    CBDataPtr = &CBData.first->second.SVMFreeCallback;
+  }
+
+  return fexldr_ptr_libOpenCL_clEnqueueSVMFree(a_0, a_1, a_2, CB, CBDataPtr, a_5, a_6, a_7);
+}
+
+static auto fexfn_impl_libOpenCL_clRetainCommandQueue(cl_command_queue a_0) -> cl_int {
+  {
+    std::shared_lock lk{CommandCBsMutex};
+    auto CB = CommandQueueCBs.find(a_0);
+    if (CB != CommandQueueCBs.end()) {
+      CB->second.RefCount++;
+    }
+  }
+  return fexldr_ptr_libOpenCL_clRetainCommandQueue(a_0);
+}
+
+static auto fexfn_impl_libOpenCL_clReleaseCommandQueue(cl_command_queue a_0) -> cl_int {
+  auto Result = fexldr_ptr_libOpenCL_clReleaseCommandQueue(a_0);
+
+  std::unique_lock lk{CommandCBsMutex};
+  auto CB = CommandQueueCBs.find(a_0);
+  if (CB != CommandQueueCBs.end()) {
+    auto RefCount = CB->second.RefCount.fetch_sub(1);;
+    if (RefCount == 1) {
+      // Remove the tracking once this has been refcount to zero
+      CommandQueueCBs.erase(CB);
+    }
+  }
+
+  return Result;
+}
+
+static auto fexfn_impl_libOpenCL_clSetMemObjectDestructorCallback(cl_mem a_0, fex_guest_function_ptr a_1, void * a_2) -> cl_int {
+  using CallbackType = decltype(&clSetMemObjectDestructorCallback_async_callback);
+  CallbackType CB{};
+  FEX::CL::Type_SingleUserData *CBDataPtr{};
+
+  if (a_1) {
+    CB = clSetMemObjectDestructorCallback_async_callback;
+
+    std::unique_lock lk{ContextCBsMutex};
+
+    // Add the callback to the tracking map
+    auto CBData = MemCBs.try_emplace(a_0);
+
+    CBData.first->second.MemObjectDestructorCallback = FEX::CL::Type_SingleUserData::Create<FEX::CL::AsyncCallbackType::TYPE_CLSETMEMOBJECTDESTRUCTORCALLBACK>(a_1, a_2);
+    CBDataPtr = &CBData.first->second.MemObjectDestructorCallback;
+  }
+
+  return fexldr_ptr_libOpenCL_clSetMemObjectDestructorCallback(a_0, CB, CBDataPtr);
+}
+
+static auto fexfn_impl_libOpenCL_clSetEventCallback(cl_event a_0, cl_int a_1, fex_guest_function_ptr a_2, void * a_3) -> cl_int {
+  using CallbackType = decltype(&clSetEventCallback_async_callback);
+  CallbackType CB{};
+  FEX::CL::Type_SingleUserData *CBDataPtr{};
+
+  if (a_1) {
+    CB = clSetEventCallback_async_callback;
+
+    std::unique_lock lk{EventCBsMutex};
+
+    // Add the callback to the tracking map
+    auto CBData = EventCBs.try_emplace(a_0);
+
+    auto Ptr = CBData.first->second.EventCallbacks.emplace_back(FEX::CL::Type_SingleUserData::Create<FEX::CL::AsyncCallbackType::TYPE_CLSETEVENTCALLBACK>(a_2, a_3));
+    CBDataPtr = &Ptr;
+  }
+
+  return fexldr_ptr_libOpenCL_clSetEventCallback(a_0, a_1, CB, CBDataPtr);
+
+}
+
+static auto fexfn_impl_libOpenCL_clRetainMemObject(cl_mem a_0) -> cl_int {
+  {
+    std::shared_lock lk{ContextCBsMutex};
+    auto CB = MemCBs.find(a_0);
+    if (CB != MemCBs.end()) {
+      CB->second.RefCount++;
+    }
+  }
+  return fexldr_ptr_libOpenCL_clRetainMemObject(a_0);
+}
+
+static auto fexfn_impl_libOpenCL_clReleaseMemObject(cl_mem a_0) -> cl_int {
+  auto Result = fexldr_ptr_libOpenCL_clReleaseMemObject(a_0);
+
+  std::unique_lock lk{ContextCBsMutex};
+  auto CB = MemCBs.find(a_0);
+  if (CB != MemCBs.end()) {
+    auto RefCount = CB->second.RefCount.fetch_sub(1);;
+    if (RefCount == 1) {
+      // Remove the tracking once this has been refcount to zero
+      MemCBs.erase(CB);
+    }
+  }
+
+  return Result;
+}
+
+static auto fexfn_impl_libOpenCL_clRetainEvent(cl_event a_0) -> cl_int {
+  {
+    std::shared_lock lk{EventCBsMutex};
+    auto CB = EventCBs.find(a_0);
+    if (CB != EventCBs.end()) {
+      CB->second.RefCount++;
+    }
+  }
+  return fexldr_ptr_libOpenCL_clRetainEvent(a_0);
+}
+static auto fexfn_impl_libOpenCL_clReleaseEvent(cl_event a_0) -> cl_int {
+  auto Result = fexldr_ptr_libOpenCL_clReleaseEvent(a_0);
+
+  std::unique_lock lk{EventCBsMutex};
+  auto CB = EventCBs.find(a_0);
+  if (CB != EventCBs.end()) {
+    auto RefCount = CB->second.RefCount.fetch_sub(1);;
+    if (RefCount == 1) {
+      // Remove the tracking once this has been refcount to zero
+      EventCBs.erase(CB);
+    }
+  }
+
+  return Result;
+}
+
+EXPORTS(libOpenCL)

--- a/ThunkLibs/libOpenCL/libOpenCL_interface.cpp
+++ b/ThunkLibs/libOpenCL/libOpenCL_interface.cpp
@@ -1,0 +1,149 @@
+#include <common/CrossArchEvent.h>
+#include <common/GeneratorInterface.h>
+
+#define CL_VERSION_3_0
+#define CL_USE_DEPRECATED_OPENCL_1_0_APIS
+#define CL_USE_DEPRECATED_OPENCL_1_1_APIS
+#define CL_USE_DEPRECATED_OPENCL_1_2_APIS
+#define CL_USE_DEPRECATED_OPENCL_2_0_APIS
+#define CL_USE_DEPRECATED_OPENCL_2_1_APIS
+#define CL_USE_DEPRECATED_OPENCL_2_2_APIS
+#include <CL/cl.h>
+
+template<auto>
+struct fex_gen_config {
+    unsigned version = 1;
+};
+
+
+void FEX_GiveEventHandlers(CrossArchEvent*, CrossArchEvent*, void**);
+template<> struct fex_gen_config<FEX_GiveEventHandlers> : fexgen::custom_host_impl, fexgen::custom_guest_entrypoint {};
+
+template<> struct fex_gen_config<clGetExtensionFunctionAddress> : fexgen::custom_guest_entrypoint, fexgen::returns_guest_pointer {};
+
+// Symbols queryable through clGetExtensionFunctionAddress
+namespace internal {
+template<auto>
+struct fex_gen_config : fexgen::generate_guest_symtable, fexgen::indirect_guest_calls {
+};
+
+template<> struct fex_gen_config<clGetPlatformIDs> {};
+template<> struct fex_gen_config<clGetPlatformInfo> {};
+template<> struct fex_gen_config<clGetDeviceIDs> {};
+template<> struct fex_gen_config<clGetDeviceInfo> {};
+template<> struct fex_gen_config<clCreateSubDevices> {};
+template<> struct fex_gen_config<clRetainDevice> {};
+template<> struct fex_gen_config<clReleaseDevice> {};
+template<> struct fex_gen_config<clSetDefaultDeviceCommandQueue> {};
+template<> struct fex_gen_config<clGetDeviceAndHostTimer> {};
+template<> struct fex_gen_config<clGetHostTimer> {};
+template<> struct fex_gen_config<clCreateContext> : fexgen::custom_host_impl, fexgen::callback_guest {};
+template<> struct fex_gen_config<clCreateContextFromType> : fexgen::custom_host_impl, fexgen::callback_guest {};
+template<> struct fex_gen_config<clRetainContext> : fexgen::custom_host_impl {};
+template<> struct fex_gen_config<clReleaseContext> : fexgen::custom_host_impl {};
+template<> struct fex_gen_config<clGetContextInfo> {};
+template<> struct fex_gen_config<clSetContextDestructorCallback> : fexgen::custom_host_impl, fexgen::callback_guest {};
+template<> struct fex_gen_config<clCreateCommandQueueWithProperties> : fexgen::custom_host_impl {};
+template<> struct fex_gen_config<clRetainCommandQueue> : fexgen::custom_host_impl {};
+template<> struct fex_gen_config<clReleaseCommandQueue> : fexgen::custom_host_impl {};
+template<> struct fex_gen_config<clGetCommandQueueInfo> {};
+template<> struct fex_gen_config<clCreateBuffer> {};
+template<> struct fex_gen_config<clCreateSubBuffer> {};
+template<> struct fex_gen_config<clCreateImage> {};
+template<> struct fex_gen_config<clCreatePipe> {};
+template<> struct fex_gen_config<clCreateBufferWithProperties> {};
+template<> struct fex_gen_config<clCreateImageWithProperties> {};
+template<> struct fex_gen_config<clRetainMemObject> : fexgen::custom_host_impl {};
+template<> struct fex_gen_config<clReleaseMemObject> : fexgen::custom_host_impl {};
+template<> struct fex_gen_config<clGetSupportedImageFormats> {};
+template<> struct fex_gen_config<clGetMemObjectInfo> {};
+template<> struct fex_gen_config<clGetImageInfo> {};
+template<> struct fex_gen_config<clGetPipeInfo> {};
+template<> struct fex_gen_config<clSetMemObjectDestructorCallback> : fexgen::custom_host_impl, fexgen::callback_guest {};
+template<> struct fex_gen_config<clSVMAlloc> {};
+template<> struct fex_gen_config<clSVMFree> {};
+template<> struct fex_gen_config<clCreateSamplerWithProperties> {};
+template<> struct fex_gen_config<clRetainSampler> {};
+template<> struct fex_gen_config<clReleaseSampler> {};
+template<> struct fex_gen_config<clGetSamplerInfo> {};
+template<> struct fex_gen_config<clCreateProgramWithSource> {};
+template<> struct fex_gen_config<clCreateProgramWithBinary> {};
+template<> struct fex_gen_config<clCreateProgramWithBuiltInKernels> {};
+template<> struct fex_gen_config<clCreateProgramWithIL> {};
+template<> struct fex_gen_config<clRetainProgram> : fexgen::custom_host_impl {};
+template<> struct fex_gen_config<clReleaseProgram> : fexgen::custom_host_impl {};
+template<> struct fex_gen_config<clBuildProgram> : fexgen::custom_host_impl, fexgen::callback_guest {};
+template<> struct fex_gen_config<clCompileProgram> : fexgen::custom_host_impl, fexgen::callback_guest {};
+template<> struct fex_gen_config<clLinkProgram> : fexgen::custom_host_impl, fexgen::callback_guest {};
+template<> struct fex_gen_config<clSetProgramReleaseCallback> : fexgen::custom_host_impl, fexgen::callback_guest {};
+template<> struct fex_gen_config<clSetProgramSpecializationConstant> {};
+template<> struct fex_gen_config<clUnloadPlatformCompiler> {};
+template<> struct fex_gen_config<clGetProgramInfo> {};
+template<> struct fex_gen_config<clGetProgramBuildInfo> {};
+template<> struct fex_gen_config<clCreateKernel> {};
+template<> struct fex_gen_config<clCreateKernelsInProgram> {};
+template<> struct fex_gen_config<clCloneKernel> {};
+template<> struct fex_gen_config<clRetainKernel> {};
+template<> struct fex_gen_config<clReleaseKernel> {};
+template<> struct fex_gen_config<clSetKernelArg> {};
+template<> struct fex_gen_config<clSetKernelArgSVMPointer> {};
+template<> struct fex_gen_config<clSetKernelExecInfo> {};
+template<> struct fex_gen_config<clGetKernelInfo> {};
+template<> struct fex_gen_config<clGetKernelArgInfo> {};
+template<> struct fex_gen_config<clGetKernelWorkGroupInfo> {};
+template<> struct fex_gen_config<clGetKernelSubGroupInfo> {};
+template<> struct fex_gen_config<clWaitForEvents> {};
+template<> struct fex_gen_config<clGetEventInfo> {};
+template<> struct fex_gen_config<clCreateUserEvent> {};
+template<> struct fex_gen_config<clRetainEvent> : fexgen::custom_host_impl {};
+template<> struct fex_gen_config<clReleaseEvent> : fexgen::custom_host_impl {};
+template<> struct fex_gen_config<clSetUserEventStatus> {};
+template<> struct fex_gen_config<clSetEventCallback> : fexgen::custom_host_impl, fexgen::callback_guest {};
+template<> struct fex_gen_config<clGetEventProfilingInfo> {};
+template<> struct fex_gen_config<clFlush> {};
+template<> struct fex_gen_config<clFinish> {};
+template<> struct fex_gen_config<clEnqueueReadBuffer> {};
+template<> struct fex_gen_config<clEnqueueReadBufferRect> {};
+template<> struct fex_gen_config<clEnqueueWriteBuffer> {};
+template<> struct fex_gen_config<clEnqueueWriteBufferRect> {};
+template<> struct fex_gen_config<clEnqueueFillBuffer> {};
+template<> struct fex_gen_config<clEnqueueCopyBuffer> {};
+template<> struct fex_gen_config<clEnqueueCopyBufferRect> {};
+template<> struct fex_gen_config<clEnqueueReadImage> {};
+template<> struct fex_gen_config<clEnqueueWriteImage> {};
+template<> struct fex_gen_config<clEnqueueFillImage> {};
+template<> struct fex_gen_config<clEnqueueCopyImage> {};
+template<> struct fex_gen_config<clEnqueueCopyImageToBuffer> {};
+template<> struct fex_gen_config<clEnqueueCopyBufferToImage> {};
+template<> struct fex_gen_config<clEnqueueMapBuffer> {};
+template<> struct fex_gen_config<clEnqueueMapImage> {};
+template<> struct fex_gen_config<clEnqueueUnmapMemObject> {};
+template<> struct fex_gen_config<clEnqueueMigrateMemObjects> {};
+template<> struct fex_gen_config<clEnqueueNDRangeKernel> {};
+template<> struct fex_gen_config<clEnqueueNativeKernel> : fexgen::custom_host_impl, fexgen::callback_guest {};
+template<> struct fex_gen_config<clEnqueueMarkerWithWaitList> {};
+template<> struct fex_gen_config<clEnqueueBarrierWithWaitList> {};
+template<> struct fex_gen_config<clEnqueueSVMFree> : fexgen::custom_host_impl, fexgen::callback_guest {};
+template<> struct fex_gen_config<clEnqueueSVMMemcpy> {};
+template<> struct fex_gen_config<clEnqueueSVMMemFill> {};
+template<> struct fex_gen_config<clEnqueueSVMMap> {};
+template<> struct fex_gen_config<clEnqueueSVMUnmap> {};
+template<> struct fex_gen_config<clEnqueueSVMMigrateMem> {};
+template<> struct fex_gen_config<clGetExtensionFunctionAddressForPlatform> {};
+template<> struct fex_gen_config<clSetCommandQueueProperty> {};
+template<> struct fex_gen_config<clCreateImage2D> {};
+template<> struct fex_gen_config<clCreateImage3D> {};
+template<> struct fex_gen_config<clEnqueueMarker> {};
+template<> struct fex_gen_config<clEnqueueWaitForEvents> {};
+template<> struct fex_gen_config<clEnqueueBarrier> {};
+template<> struct fex_gen_config<clUnloadCompiler> {};
+template<> struct fex_gen_config<clCreateCommandQueue> : fexgen::custom_host_impl {};
+template<> struct fex_gen_config<clCreateSampler> {};
+template<> struct fex_gen_config<clEnqueueTask> {};
+
+// Special undocumented `clGetICDLoaderInfoOCLICD` function from the ICD. Only documented in ICD source.
+cl_int clGetICDLoaderInfoOCLICD(uint32_t, size_t, void*, size_t*);
+
+template<> struct fex_gen_config<clGetICDLoaderInfoOCLICD> {};
+
+}


### PR DESCRIPTION
This takes a bit of faff due to all of the different style of callbacks that it does. These have different lifetimes depending on the object which means that a generator for these can't really exist.

Depends on the previous PRs to be merged before use.

Needs functional testing which I'll open a PR after this.