### PR TITLE
Allocator: Expand stack space when stealing virtual address space

### DIFF
--- a/External/FEXCore/Source/Utils/Allocator.cpp
+++ b/External/FEXCore/Source/Utils/Allocator.cpp
@@ -145,8 +145,10 @@ namespace FEXCore::Allocator {
   #define STEAL_LOG(...) // fprintf(stderr, __VA_ARGS__)
 
   std::vector<MemoryRegion> StealMemoryRegion(uintptr_t Begin, uintptr_t End) {
+    void * const StackLocation = alloca(0);
+    const uintptr_t StackLocation_u64 = reinterpret_cast<uintptr_t>(StackLocation);
     std::vector<MemoryRegion> Regions;
-    
+
     int MapsFD = open("/proc/self/maps", O_RDONLY);
     LogMan::Throw::AFmt(MapsFD != -1, "Failed to open /proc/self/maps");
 
@@ -155,6 +157,8 @@ namespace FEXCore::Allocator {
     uintptr_t RegionBegin = 0;
     uintptr_t RegionEnd = 0;
 
+    uintptr_t PreviousMapEnd = 0;
+
     char Buffer[2048];
     const char *Cursor;
     ssize_t Remaining = 0;
@@ -162,7 +166,7 @@ namespace FEXCore::Allocator {
     for(;;) {
 
       if (Remaining == 0) {
-        do { 
+        do {
           Remaining = read(MapsFD, Buffer, sizeof(Buffer));
         } while ( Remaining == -1 && errno == EAGAIN);
 
@@ -172,8 +176,8 @@ namespace FEXCore::Allocator {
       if (Remaining == 0 && State == ParseBegin) {
         STEAL_LOG("[%d] EndOfFile; RegionBegin: %016lX RegionEnd: %016lX\n", __LINE__, RegionBegin, RegionEnd);
 
-        auto MapBegin = std::max(RegionEnd, Begin);
-        auto MapEnd = End;
+        const auto MapBegin = std::max(RegionEnd, Begin);
+        const auto MapEnd = End;
 
         STEAL_LOG("     MapBegin: %016lX MapEnd: %016lX\n", MapBegin, MapEnd);
 
@@ -209,9 +213,12 @@ namespace FEXCore::Allocator {
         if (c == '-') {
           STEAL_LOG("[%d] ParseBegin; RegionBegin: %016lX RegionEnd: %016lX\n", __LINE__, RegionBegin, RegionEnd);
 
-          auto MapBegin = std::max(RegionEnd, Begin);
-          auto MapEnd = std::min(RegionBegin, End);
-          
+          const auto MapBegin = std::max(RegionEnd, Begin);
+          const auto MapEnd = std::min(RegionBegin, End);
+
+          // Store the location we are going to map.
+          PreviousMapEnd = MapEnd;
+
           STEAL_LOG("     MapBegin: %016lX MapEnd: %016lX\n", MapBegin, MapEnd);
 
           if (MapEnd > MapBegin) {
@@ -225,6 +232,7 @@ namespace FEXCore::Allocator {
 
             Regions.push_back({(void*)MapBegin, MapSize});
           }
+
           RegionBegin = 0;
           RegionEnd = 0;
           State = ParseEnd;
@@ -240,6 +248,22 @@ namespace FEXCore::Allocator {
           STEAL_LOG("[%d] ParseEnd; RegionBegin: %016lX RegionEnd: %016lX\n", __LINE__, RegionBegin, RegionEnd);
 
           State = ScanEnd;
+
+          // If the previous map's ending and the region we just parsed overlap the stack then we need to save the stack mapping.
+          // Otherwise we will have severely limited stack size which crashes quickly.
+          if (PreviousMapEnd <= StackLocation_u64 && RegionEnd > StackLocation_u64) {
+            auto BelowStackRegion = Regions.back();
+            LOGMAN_THROW_AA_FMT(reinterpret_cast<uint64_t>(BelowStackRegion.Ptr) + BelowStackRegion.Size == PreviousMapEnd,
+              "This needs to match");
+
+            // Allocate the region under the stack as READ | WRITE so the stack can still grow
+            auto Alloc = mmap(BelowStackRegion.Ptr, BelowStackRegion.Size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_NORESERVE | MAP_PRIVATE | MAP_FIXED, -1, 0);
+
+            LogMan::Throw::AFmt(Alloc != MAP_FAILED, "mmap({:x},{:x}) failed", BelowStackRegion.Ptr, BelowStackRegion.Size);
+            LogMan::Throw::AFmt(Alloc == BelowStackRegion.Ptr, "mmap({},{:x}) returned {} instead of {:x}", Alloc, BelowStackRegion.Ptr);
+
+            Regions.pop_back();
+          }
           continue;
         } else {
           LogMan::Throw::AFmt(std::isalpha(c) || std::isdigit(c), "Unexpected char '{}' in ParseEnd", c);


### PR DESCRIPTION
If we take all of the stack space then the auto expanding stack doesn't work and we get stuck with a small stack that breaks thunks.