### PR TITLE
Ensure Arm64Emitter uses FEX allocator

### DIFF
--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
@@ -20,7 +20,9 @@ namespace FEXCore::CPU {
 
 // We want vixl to not allocate a default buffer. Jit and dispatcher will manually create one.
 Arm64Emitter::Arm64Emitter(FEXCore::Context::Context *ctx, size_t size)
-  : vixl::aarch64::Assembler(size, vixl::aarch64::PositionDependentCode)
+  : vixl::aarch64::Assembler(size ? (byte*)FEXCore::Allocator::mmap(nullptr, size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0) : reinterpret_cast<byte*>(~0ULL),
+                             size,
+                             vixl::aarch64::PositionDependentCode)
   , EmitterCTX {ctx} {
   CPU.SetUp();
 
@@ -35,6 +37,13 @@ Arm64Emitter::Arm64Emitter(FEXCore::Context::Context *ctx, size_t size)
 #endif
 
   SetCPUFeatures(Features);
+}
+
+Arm64Emitter::~Arm64Emitter() {
+  auto CodeBuffer = GetBuffer();
+  if (CodeBuffer->GetCapacity()) {
+    FEXCore::Allocator::munmap(CodeBuffer->GetStartAddress<void*>(), CodeBuffer->GetCapacity());
+  }
 }
 
 void Arm64Emitter::LoadConstant(vixl::aarch64::Register Reg, uint64_t Constant, bool NOPPad) {

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
@@ -88,6 +88,7 @@ const std::array<aarch64::VRegister, 12> RAFPR = {
 class Arm64Emitter : public vixl::aarch64::Assembler {
 protected:
   Arm64Emitter(FEXCore::Context::Context *ctx, size_t size);
+  ~Arm64Emitter();
 
   FEXCore::Context::Context *EmitterCTX;
   vixl::aarch64::CPU CPU;


### PR DESCRIPTION
Otherwise we will end up allocating code buffers in the lower 32-bits, consuming precious virtual address space.