### PR TITLE
Syscalls: Fixes 64-bit mmap and munmap

### DIFF
--- a/Source/Tests/LinuxSyscalls/x64/Memory.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Memory.cpp
@@ -36,7 +36,7 @@ namespace FEX::HLE::x64 {
         Result = -1;
       }
     } else {
-      Result = reinterpret_cast<uint64_t>(FEXCore::Allocator::mmap(reinterpret_cast<void*>(addr), length, prot, flags, fd, offset));
+      Result = reinterpret_cast<uint64_t>(::mmap(reinterpret_cast<void*>(addr), length, prot, flags, fd, offset));
     }
 
     if (Result != -1) {
@@ -56,7 +56,7 @@ namespace FEX::HLE::x64 {
         Result = -1;
       }
     } else {
-      Result = FEXCore::Allocator::munmap(addr, length);
+      Result = ::munmap(addr, length);
     }
 
     if (Result != -1) {


### PR DESCRIPTION
These should be using the real syscalls, not our provided allocators.

While not a problem currently since these redirect to host mmap and munmap, it will become an issue once we have an allocator that lives outside of x86-64 space.