### PR TITLE
OpcodeDispatcher: Fixes flag calculation on ROR and ROL by immediate

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
@@ -981,10 +981,7 @@ void OpDispatchBuilder::CalculcateFlags_RotateRightImmediate(uint8_t SrcSize, Or
   if (Shift == 0) return;
 
   auto OpSize = SrcSize * 8;
-  if (OpSize < Shift) {
-    Shift &= (OpSize - 1);
-  }
-  auto NewCF = _Bfe(1, OpSize - Shift, Src1);
+  auto NewCF = _Bfe(1, OpSize - 1, Res);
 
   // CF
   {
@@ -1009,7 +1006,7 @@ void OpDispatchBuilder::CalculcateFlags_RotateLeftImmediate(uint8_t SrcSize, Ord
   // CF
   {
     // Extract the last bit shifted in to CF
-    SetRFLAG<FEXCore::X86State::RFLAG_CF_LOC>(_Bfe(1, Shift, Src1));
+    SetRFLAG<FEXCore::X86State::RFLAG_CF_LOC>(_Bfe(1, 0, Res));
   }
 
   // OF

--- a/unittests/ASM/Primary/ROL_Flags.asm
+++ b/unittests/ASM/Primary/ROL_Flags.asm
@@ -1,0 +1,152 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "R15": "0x0000000001060004"
+  }
+}
+%endif
+
+%macro cfmerge 0
+
+; Get CF
+lahf
+shr rax, 8
+and rax, 1
+
+; Merge in to results
+shl r15, 1
+or r15, rax
+
+%endmacro
+
+stc
+cfmerge
+
+; 8-bit
+; Shift 1 past size - Bit Set
+mov rbx, 0x800
+rol bl, 9
+cfmerge
+
+; Shift 1 past size - Bit unset
+mov rbx, 0x000
+rol bl, 9
+cfmerge
+
+; Shift size - Bit Set
+mov rbx, 0x80
+rol bl, 8
+cfmerge
+
+; Shift size - Bit unset
+mov rbx, 0x8000
+rol bl, 8
+cfmerge
+
+; 8-bit - wrapped
+; Shift 1 past size - Bit Set
+mov rbx, 0x01
+rol bl, 9
+cfmerge
+
+; Shift 1 past size - Bit unset
+mov rbx, 0xFFF2
+rol bl, 9
+cfmerge
+
+; Shift size - Bit Set
+mov rbx, 0xFF
+rol bl, 8
+cfmerge
+
+; Shift size - Bit unset
+mov rbx, 0xFF00
+rol bl, 8
+cfmerge
+
+
+; 16-bit
+; Shift 1 past size - Bit Set
+mov rbx, 0x80000
+rol bx, 17
+cfmerge
+
+; Shift 1 past size - Bit unset
+mov rbx, 0x00000
+rol bx, 17
+cfmerge
+
+; Shift size - Bit Set
+mov rbx, 0x8000
+rol bx, 16
+cfmerge
+
+; Shift size - Bit unset
+mov rbx, 0x80000
+rol bx, 16
+cfmerge
+
+; 32-bit
+; Shift 1 past size - Bit Set
+mov rbx, 0x800000000
+rol ebx, 33
+cfmerge
+
+; Shift 1 past size - Bit unset
+mov rbx, 0x000000000
+rol ebx, 33
+cfmerge
+
+; Shift size - Bit Set
+mov rbx, 0x80000000
+rol ebx, 32
+cfmerge
+
+; Shift size - Bit unset
+mov rbx, 0x800000000
+rol ebx, 32
+cfmerge
+
+; 32-bit - Wrapping
+; Shift 1 past size - Bit Set
+mov rbx, 0x02
+rol ebx, 33
+cfmerge
+
+; Shift 1 past size - Bit unset
+mov rbx, 0x01
+rol ebx, 33
+cfmerge
+
+; Shift size - Bit Set
+mov rbx, 0x1
+rol ebx, 32
+cfmerge
+
+; Shift size - Bit unset
+mov rbx, 0x02
+rol ebx, 32
+cfmerge
+
+; 64-bit
+; Shift 1 past size - Bit Set
+mov rbx, 0x02
+rol rbx, 65
+cfmerge
+
+; Shift 1 past size - Bit unset
+mov rbx, 0x8000000000000000
+rol rbx, 65
+cfmerge
+
+; Shift size - Bit Set
+mov rbx, 0x1
+rol rbx, 64
+cfmerge
+
+; Shift size - Bit unset
+mov rbx, 0x02
+rol rbx, 64
+cfmerge
+
+hlt

--- a/unittests/ASM/Primary/ROR_Flags.asm
+++ b/unittests/ASM/Primary/ROR_Flags.asm
@@ -1,0 +1,152 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "R15": "0x00000000012a2040"
+  }
+}
+%endif
+
+%macro cfmerge 0
+
+; Get CF
+lahf
+shr rax, 8
+and rax, 1
+
+; Merge in to results
+shl r15, 1
+or r15, rax
+
+%endmacro
+
+stc
+cfmerge
+
+; 8-bit
+; Shift 1 past size - Bit Set
+mov rbx, 0x800
+ror bl, 9
+cfmerge
+
+; Shift 1 past size - Bit unset
+mov rbx, 0x000
+ror bl, 9
+cfmerge
+
+; Shift size - Bit Set
+mov rbx, 0x80
+ror bl, 8
+cfmerge
+
+; Shift size - Bit unset
+mov rbx, 0x8000
+ror bl, 8
+cfmerge
+
+; 8-bit - wrapped
+; Shift 1 past size - Bit Set
+mov rbx, 0x01
+ror bl, 9
+cfmerge
+
+; Shift 1 past size - Bit unset
+mov rbx, 0xFFF2
+ror bl, 9
+cfmerge
+
+; Shift size - Bit Set
+mov rbx, 0xFF
+ror bl, 8
+cfmerge
+
+; Shift size - Bit unset
+mov rbx, 0xFF00
+ror bl, 8
+cfmerge
+
+
+; 16-bit
+; Shift 1 past size - Bit Set
+mov rbx, 0x80000
+ror bx, 17
+cfmerge
+
+; Shift 1 past size - Bit unset
+mov rbx, 0x00000
+ror bx, 17
+cfmerge
+
+; Shift size - Bit Set
+mov rbx, 0x8000
+ror bx, 16
+cfmerge
+
+; Shift size - Bit unset
+mov rbx, 0x80000
+ror bx, 16
+cfmerge
+
+; 32-bit
+; Shift 1 past size - Bit Set
+mov rbx, 0x800000000
+ror ebx, 33
+cfmerge
+
+; Shift 1 past size - Bit unset
+mov rbx, 0x000000000
+ror ebx, 33
+cfmerge
+
+; Shift size - Bit Set
+mov rbx, 0x80000000
+ror ebx, 32
+cfmerge
+
+; Shift size - Bit unset
+mov rbx, 0x800000000
+ror ebx, 32
+cfmerge
+
+; 32-bit - Wrapping
+; Shift 1 past size - Bit Set
+mov rbx, 0x02
+ror ebx, 33
+cfmerge
+
+; Shift 1 past size - Bit unset
+mov rbx, 0x01
+ror ebx, 33
+cfmerge
+
+; Shift size - Bit Set
+mov rbx, 0x1
+ror ebx, 32
+cfmerge
+
+; Shift size - Bit unset
+mov rbx, 0x02
+ror ebx, 32
+cfmerge
+
+; 64-bit
+; Shift 1 past size - Bit Set
+mov rbx, 0x02
+ror rbx, 65
+cfmerge
+
+; Shift 1 past size - Bit unset
+mov rbx, 0x8000000000000000
+ror rbx, 65
+cfmerge
+
+; Shift size - Bit Set
+mov rbx, 0x1
+ror rbx, 64
+cfmerge
+
+; Shift size - Bit unset
+mov rbx, 0x02
+ror rbx, 64
+cfmerge
+
+hlt

--- a/unittests/ASM/Primary/SHL.asm
+++ b/unittests/ASM/Primary/SHL.asm
@@ -1,0 +1,43 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "R14": "0xffffffffffffffff",
+    "R13": "0xfffffffffffffffe",
+    "R12": "0xfffffffffffffffc",
+    "R11": "0xfffffffffffffff8",
+    "R10": "0xfffffffffffffff0",
+    "R9": "0xffffffffffffffe0",
+    "R8": "0xffffffffffffffc0",
+    "RBP": "0xffffffffffffff80",
+    "RSP": "0xffffffffffffff00",
+    "RDI": "0xffffffffffffff00",
+    "RSI": "0xffffffffffffff00"
+  }
+}
+%endif
+
+mov r14, -1
+mov r13, -1
+mov r12, -1
+mov r11, -1
+mov r10, -1
+mov r9, -1
+mov r8, -1
+mov rbp, -1
+mov rsp, -1
+mov rdi, -1
+mov rsi, -1
+
+shl r14b, 0
+shl r13b, 1
+shl r12b, 2
+shl r11b, 3
+shl r10b, 4
+shl r9b, 5
+shl r8b, 6
+shl bpl, 7
+shl spl, 8
+shl dil, 9
+shl sil, 10
+
+hlt

--- a/unittests/ASM/Primary/SHR.asm
+++ b/unittests/ASM/Primary/SHR.asm
@@ -1,0 +1,43 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "R14": "0xffffffffffffffff",
+    "R13": "0xffffffffffffff7f",
+    "R12": "0xffffffffffffff3f",
+    "R11": "0xffffffffffffff1f",
+    "R10": "0xffffffffffffff0f",
+    "R9": "0xffffffffffffff07",
+    "R8": "0xffffffffffffff03",
+    "RBP": "0xffffffffffffff01",
+    "RSP": "0xffffffffffffff00",
+    "RDI": "0xffffffffffffff00",
+    "RSI": "0xffffffffffffff00"
+  }
+}
+%endif
+
+mov r14, -1
+mov r13, -1
+mov r12, -1
+mov r11, -1
+mov r10, -1
+mov r9, -1
+mov r8, -1
+mov rbp, -1
+mov rsp, -1
+mov rdi, -1
+mov rsi, -1
+
+shr r14b, 0
+shr r13b, 1
+shr r12b, 2
+shr r11b, 3
+shr r10b, 4
+shr r9b, 5
+shr r8b, 6
+shr bpl, 7
+shr spl, 8
+shr dil, 9
+shr sil, 10
+
+hlt


### PR DESCRIPTION
These were being calculated incorrectly in the case of rotating with
values larger than 8-bit or 16-bit