### PR TITLE
OpcodeDispatcher: Fixes FPREM1 C2 flag calculation

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
@@ -809,7 +809,8 @@ void OpDispatchBuilder::X87BinaryOp(OpcodeArgs) {
   // Overwrite the op
   result.first->Header.Op = IROp;
 
-  if constexpr (IROp == IR::OP_F80FPREM) {
+  if constexpr (IROp == IR::OP_F80FPREM ||
+    IROp == IR::OP_F80FPREM1) {
     //TODO: Set C0 to Q2, C3 to Q1, C1 to Q0
     SetRFLAG<FEXCore::X86State::X87FLAG_C2_LOC>(_Constant(0));
   }

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87F64.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87F64.cpp
@@ -804,7 +804,8 @@ void OpDispatchBuilder::X87BinaryOpF64(OpcodeArgs) {
   // Overwrite the op
   result.first->Header.Op = IROp;
 
-  if constexpr (IROp == IR::OP_F64FPREM) {
+  if constexpr (IROp == IR::OP_F80FPREM ||
+    IROp == IR::OP_F80FPREM1) {
     //TODO: Set C0 to Q2, C3 to Q1, C1 to Q0
     SetRFLAG<FEXCore::X86State::X87FLAG_C2_LOC>(_Constant(0));
   }


### PR DESCRIPTION
Accidentally didn't implement this for FPREM1 but it /was/ implemented for FPREM. Fixes an infinite loop in cossin implementations.

Test code from the application returns an incorrect result, but it isn't due to FPREM1.

```
$ `which wine` ./hello.exe
Sin 1.22460635382238E-16
Cos -1
$ FEXInterpreter `which wine` ./hello.exe
Sin 1.22460635382238E-16
Cos 0.54030230586814
```

Fixes #2021