### PR TITLE
X87: Claim incoming float was in the range for trancendental ops

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
@@ -782,6 +782,12 @@ void OpDispatchBuilder::X87UnaryOp(OpcodeArgs) {
   // Overwrite the op
   result.first->Header.Op = IROp;
 
+  if constexpr (IROp == IR::OP_F80SIN ||
+                IROp == IR::OP_F80COS) {
+    // TODO: ACCURACY: should check source is in range –2^63 to +2^63
+    SetRFLAG<FEXCore::X86State::X87FLAG_C2_LOC>(_Constant(0));
+  }
+
   // Write to ST[TOP]
   _StoreContextIndexed(result, top, 16, MMBaseOffset(), 16, FPRClass);
 }
@@ -855,6 +861,9 @@ void OpDispatchBuilder::X87SinCos(OpcodeArgs) {
   auto sin = _F80SIN(a);
   auto cos = _F80COS(a);
 
+  // TODO: ACCURACY: should check source is in range –2^63 to +2^63
+  SetRFLAG<FEXCore::X86State::X87FLAG_C2_LOC>(_Constant(0));
+
   // Write to ST[TOP]
   _StoreContextIndexed(sin, orig_top, 16, MMBaseOffset(), 16, FPRClass);
   _StoreContextIndexed(cos, top, 16, MMBaseOffset(), 16, FPRClass);
@@ -900,6 +909,9 @@ void OpDispatchBuilder::X87TAN(OpcodeArgs) {
   auto high = _Constant(0b0'011'1111'1111'1111ULL);
   OrderedNode *data = _VCastFromGPR(16, 8, low);
   data = _VInsGPR(16, 8, 1, data, high);
+
+  // TODO: ACCURACY: should check source is in range –2^63 to +2^63
+  SetRFLAG<FEXCore::X86State::X87FLAG_C2_LOC>(_Constant(0));
 
   // Write to ST[TOP]
   _StoreContextIndexed(result, orig_top, 16, MMBaseOffset(), 16, FPRClass);

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87F64.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87F64.cpp
@@ -778,6 +778,12 @@ void OpDispatchBuilder::X87UnaryOpF64(OpcodeArgs) {
   // Overwrite the op
   result.first->Header.Op = IROp;
 
+  if constexpr (IROp == IR::OP_F64SIN ||
+                IROp == IR::OP_F64COS) {
+    // TODO: ACCURACY: should check source is in range –2^63 to +2^63
+    SetRFLAG<FEXCore::X86State::X87FLAG_C2_LOC>(_Constant(0));
+  }
+
   // Write to ST[TOP]
   _StoreContextIndexed(result, top, 8, MMBaseOffset(), 16, FPRClass);
 }
@@ -832,6 +838,9 @@ void OpDispatchBuilder::X87SinCosF64(OpcodeArgs) {
   auto sin = _F64SIN(a);
   auto cos = _F64COS(a);
 
+  // TODO: ACCURACY: should check source is in range –2^63 to +2^63
+  SetRFLAG<FEXCore::X86State::X87FLAG_C2_LOC>(_Constant(0));
+
   // Write to ST[TOP]
   _StoreContextIndexed(sin, orig_top, 8, MMBaseOffset(), 16, FPRClass);
   _StoreContextIndexed(cos, top, 8, MMBaseOffset(), 16, FPRClass);
@@ -871,6 +880,9 @@ void OpDispatchBuilder::X87TANF64(OpcodeArgs) {
   auto result = _F64TAN(a);
 
   auto one = _VCastFromGPR(8, 8, _Constant(0x3FF0000000000000));
+
+  // TODO: ACCURACY: should check source is in range –2^63 to +2^63
+  SetRFLAG<FEXCore::X86State::X87FLAG_C2_LOC>(_Constant(0));
 
   // Write to ST[TOP]
   _StoreContextIndexed(result, orig_top, 8, MMBaseOffset(), 16, FPRClass);


### PR DESCRIPTION
We don't detect the range of the long F80, so we need to set that the source was in range to fix sin/cos/tan calculations.

If we don't set this flag to zero then glibc will do some additional operations that causes the value to be incorrect.

Fixes the output of the test application in #2021, probably fixes some camera orientation problems in games as well.