### PR TITLE
ELFCodeLoader: Implement four more auxv values

### DIFF
--- a/Source/Tests/FEXLoader.cpp
+++ b/Source/Tests/FEXLoader.cpp
@@ -393,6 +393,7 @@ int main(int argc, char **argv, char **const envp) {
   // Load VDSO in to memory prior to mapping our ELFs.
   void* VDSOBase = FEX::VDSO::LoadVDSOThunks(Loader.Is64BitMode(), Mapper);
   Loader.SetVDSOBase(VDSOBase);
+  Loader.CalculateHWCaps(CTX);
 
   if (!Loader.MapMemory(Mapper, Unmapper)) {
     // failed to map


### PR DESCRIPTION
Implements AT_PLATFORM: Ends up being `i686` or `x86_64` depending on ELF arch

Implements AT_HWCAP and AT_HWCAP2
AT_HWCAP is just CPUID function 01h EDX result
AT_HWCAP2 only has two defined bits in it, which we don't support either.

Implements AT_RANDOM
Previously we were just sticking hardcoded values in to this. Now we pass along the host's AT_RANDOM, or we generate our own if that doesn't exist

Fixes #788