### PR TITLE
External: Update vixl submodule

### DIFF
--- a/unittests/ASM/Disabled_Tests_Simulator
+++ b/unittests/ASM/Disabled_Tests_Simulator
@@ -70,15 +70,3 @@ Test_H0F3A/66_09.asm
 Test_H0F3A/66_0A.asm
 Test_H0F3A/66_0B.asm
 Test_OpSize/66_5B.asm
-
-# Simulator has a bug in narrowing or widening operations
-Test_H0F38/66_03.asm
-Test_H0F38/66_04.asm
-Test_H0F38/66_07.asm
-Test_H0F38/66_2B.asm
-Test_H0F38/XX_03.asm
-Test_H0F38/XX_04.asm
-Test_H0F38/XX_07.asm
-Test_OpSize/66_63.asm
-Test_OpSize/66_67.asm
-Test_OpSize/66_6B.asm


### PR DESCRIPTION
Brings in a fix for the narrowing and widening operations erroneously clearing the upper portion of the vector register when using lower narrowing instruction variants in the case where the source register and destination register are the same. I've also made a PR upstream to fix this as well (https://github.com/Linaro/vixl/pull/49)

Since this fixes the issue, we can also re-enable the tests that make use of narrowing and widening on the simulator.

This will also let me extend the narrowing and widening IR ops reliably, since I'll now have test cases