### PR TITLE
unittests/asm: Adds more extensive FPREM/FPREM1 tests 

### DIFF
--- a/Scripts/testharness_runner.py
+++ b/Scripts/testharness_runner.py
@@ -4,7 +4,7 @@ import subprocess
 import os.path
 from os import path
 
-# Args: <Known Failures file> <DisabledTestsFile> <DisabledTestsTypeFile> <DisabledTestsRunnerFile> <TestName> <Test Harness Executable> <Args>...
+# Args: <Known Failures file> <Known Failures Type File> <DisabledTestsFile> <DisabledTestsTypeFile> <DisabledTestsRunnerFile> <TestName> <Test Harness Executable> <Args>...
 
 if (len(sys.argv) < 7):
     sys.exit()
@@ -12,18 +12,24 @@ if (len(sys.argv) < 7):
 known_failures = {}
 disabled_tests = {}
 known_failures_file = sys.argv[1]
-disabled_tests_file = sys.argv[2]
-disabled_tests_type_file = sys.argv[3]
-disabled_tests_runner_file = sys.argv[4]
+known_failures_type_file = sys.argv[2]
+disabled_tests_file = sys.argv[3]
+disabled_tests_type_file = sys.argv[4]
+disabled_tests_runner_file = sys.argv[5]
 
-current_test = sys.argv[5]
-runner = sys.argv[6]
-args_start_index = 7
+current_test = sys.argv[6]
+runner = sys.argv[7]
+args_start_index = 8
 
 # Open the known failures file and add it to a dictionary
 with open(known_failures_file) as kff:
     for line in kff:
         known_failures[line.strip()] = 1
+
+if path.exists(known_failures_type_file):
+    with open(known_failures_type_file) as dtf:
+        for line in dtf:
+            known_failures[line.strip()] = 1
 
 with open(disabled_tests_file) as dtf:
     for line in dtf:

--- a/unittests/32Bit_ASM/CMakeLists.txt
+++ b/unittests/32Bit_ASM/CMakeLists.txt
@@ -84,6 +84,7 @@ foreach(ASM_SRC ${ASM_SOURCES})
     add_test(NAME ${TEST_NAME}
       COMMAND "python3" "${CMAKE_SOURCE_DIR}/Scripts/testharness_runner.py"
       "${CMAKE_SOURCE_DIR}/unittests/32Bit_ASM/Known_Failures"
+      "${CMAKE_SOURCE_DIR}/unittests/32Bit_ASM/Known_Failures_${TEST_TYPE}"
       "${CMAKE_SOURCE_DIR}/unittests/32Bit_ASM/Disabled_Tests"
       "${CMAKE_SOURCE_DIR}/unittests/32Bit_ASM/Disabled_Tests_${TEST_TYPE}"
       "${CMAKE_SOURCE_DIR}/unittests/32Bit_ASM/Disabled_Tests_${CPU_CLASS}"

--- a/unittests/ASM/CMakeLists.txt
+++ b/unittests/ASM/CMakeLists.txt
@@ -92,6 +92,7 @@ foreach(ASM_SRC ${ASM_SOURCES})
     add_test(NAME ${TEST_NAME}
       COMMAND "python3" "${CMAKE_SOURCE_DIR}/Scripts/testharness_runner.py"
       "${CMAKE_SOURCE_DIR}/unittests/ASM/Known_Failures"
+      "${CMAKE_SOURCE_DIR}/unittests/ASM/Known_Failures_${TEST_TYPE}"
       "${CMAKE_SOURCE_DIR}/unittests/ASM/Disabled_Tests"
       "${CMAKE_SOURCE_DIR}/unittests/ASM/Disabled_Tests_${TEST_TYPE}"
       "${CMAKE_SOURCE_DIR}/unittests/ASM/Disabled_Tests_${CPU_CLASS}"

--- a/unittests/ASM/Known_Failures_int
+++ b/unittests/ASM/Known_Failures_int
@@ -1,0 +1,3 @@
+# FPREM is incorrect
+Test_X87/D9_F5_2.asm
+Test_X87/D9_F5_3.asm

--- a/unittests/ASM/Known_Failures_jit
+++ b/unittests/ASM/Known_Failures_jit
@@ -1,0 +1,3 @@
+# FPREM is incorrect
+Test_X87/D9_F5_2.asm
+Test_X87/D9_F5_3.asm

--- a/unittests/ASM/X87/D9_F5_2.asm
+++ b/unittests/ASM/X87/D9_F5_2.asm
@@ -1,0 +1,55 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM6":  ["0xC000000000000000", "0xC000"],
+    "MM7":  ["0x8000000000000000", "0x4001"]
+  }
+}
+%endif
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+lea rdx, [rel data2]
+fld tword [rdx + 8 * 0]
+
+fprem
+
+lea rdx, [rel result1]
+fstp tword [rdx + 8 * 0]
+
+lea rdx, [rel data2]
+fld tword [rdx + 8 * 0]
+
+fprem1
+
+lea rdx, [rel result2]
+fstp tword [rdx + 8 * 0]
+
+ffreep st0
+
+lea rdx, [rel result1]
+fld tword [rdx + 8 * 0]
+
+lea rdx, [rel result2]
+fld tword [rdx + 8 * 0]
+
+; MM6 contains result2 (fprem1)
+; MM7 contains result1 (fprem)
+
+hlt
+
+align 8
+data:
+  dt 7.0
+  dq 0
+data2:
+  dt 11.0
+  dq 0
+
+result1:
+  dt 0.0
+  dq 0.0
+result2:
+  dt 0.0
+  dq 0.0

--- a/unittests/ASM/X87/D9_F5_3.asm
+++ b/unittests/ASM/X87/D9_F5_3.asm
@@ -1,0 +1,55 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM6":  ["0xC000000000000000", "0x4000"],
+    "MM7":  ["0x8000000000000000", "0xC001"]
+  }
+}
+%endif
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+lea rdx, [rel data2]
+fld tword [rdx + 8 * 0]
+
+fprem
+
+lea rdx, [rel result1]
+fstp tword [rdx + 8 * 0]
+
+lea rdx, [rel data2]
+fld tword [rdx + 8 * 0]
+
+fprem1
+
+lea rdx, [rel result2]
+fstp tword [rdx + 8 * 0]
+
+ffreep st0
+
+lea rdx, [rel result1]
+fld tword [rdx + 8 * 0]
+
+lea rdx, [rel result2]
+fld tword [rdx + 8 * 0]
+
+; MM6 contains result2 (fprem1)
+; MM7 contains result1 (fprem)
+
+hlt
+
+align 8
+data:
+  dt 7.0
+  dq 0
+data2:
+  dt -11.0
+  dq 0
+
+result1:
+  dt 0.0
+  dq 0.0
+result2:
+  dt 0.0
+  dq 0.0

--- a/unittests/IR/CMakeLists.txt
+++ b/unittests/IR/CMakeLists.txt
@@ -54,6 +54,7 @@ foreach(IR_SRC ${IR_SOURCES})
     add_test(NAME ${TEST_NAME}
       COMMAND "python3" "${CMAKE_SOURCE_DIR}/Scripts/testharness_runner.py"
       "${CMAKE_SOURCE_DIR}/unittests/IR/Known_Failures"
+      "${CMAKE_SOURCE_DIR}/unittests/IR/Known_Failures_${TEST_TYPE}"
       "${CMAKE_SOURCE_DIR}/unittests/IR/Disabled_Tests"
       "${CMAKE_SOURCE_DIR}/unittests/IR/Disabled_Tests_${TEST_TYPE}"
       "${RUNNER_DISABLED}"


### PR DESCRIPTION
unit tests that show the difference of output between FPREM and FPREM1.
Setup as known failures on everything except for host since we don't
implement fprem correctly.

An incorrect fix to FPREM is as follows:
```diff
--- a/External/FEXCore/Source/Common/SoftFloat.h
+++ b/External/FEXCore/Source/Common/SoftFloat.h
@@ -158,6 +158,10 @@ struct X80SoftFloat {

     return Result;
 #else
+    BIGFLOAT lhs_ = lhs;
+    BIGFLOAT rhs_ = rhs;
+    BIGFLOAT Result = fmodl(lhs_, rhs_);
+    return Result;
     return extF80_rem(lhs, rhs);
 #endif
   }
```

But we shouldn't implement this fix. We should instead implement a new `extF80_mod`
function that handles the rounding differences between FPREM and FPREM1.

Fixes https://github.com/FEX-Emu/FEX/issues/2097.
Doesn't attempt to resolve - https://github.com/FEX-Emu/FEX/issues/1538