### PR TITLE
FEXServer: Be robust against invalid packets.

### DIFF
--- a/Source/Tools/FEXServer/ProcessPipe.cpp
+++ b/Source/Tools/FEXServer/ProcessPipe.cpp
@@ -431,6 +431,9 @@ namespace ProcessPipe {
           // Invalid
         case FEXServerClient::PacketType::TYPE_ERROR:
         default:
+          // Something sent us an invalid packet. To ensure we don't spin infinitely, consume all the data.
+          LogMan::Msg::EFmt("[FEXServer] InvalidPacket size received 0x{:x} bytes", CurrentRead - CurrentOffset);
+          CurrentOffset = CurrentRead;
           break;
       }
     }


### PR DESCRIPTION
Chrome seems to like sending us invalid packets of data sometimes. With an invalid packet type just skip parsing the data entirely.

Fixes an infinite loop in Vampire Survivors.