### PR TITLE
Thunks: Fixes missing thunk librarie so versions

### DIFF
--- a/ThunkLibs/libEGL/libEGL_interface.cpp
+++ b/ThunkLibs/libEGL/libEGL_interface.cpp
@@ -4,6 +4,7 @@
 
 template<auto>
 struct fex_gen_config {
+    unsigned version = 1;
 };
 
 template<> struct fex_gen_config<eglBindAPI> {};

--- a/ThunkLibs/libGL/libGL_interface.cpp
+++ b/ThunkLibs/libGL/libGL_interface.cpp
@@ -13,6 +13,7 @@
 
 template<auto>
 struct fex_gen_config {
+    unsigned version = 1;
 };
 
 template<> struct fex_gen_config<glXGetProcAddress> : fexgen::custom_guest_entrypoint, fexgen::returns_guest_pointer {};

--- a/ThunkLibs/libxcb-dri2/libxcb-dri2_interface.cpp
+++ b/ThunkLibs/libxcb-dri2/libxcb-dri2_interface.cpp
@@ -3,7 +3,9 @@
 #include <xcb/dri2.h>
 
 template<auto>
-struct fex_gen_config;
+struct fex_gen_config {
+    unsigned version = 0;
+};
 
 void FEX_xcb_dri2_init_extension(xcb_connection_t*, xcb_extension_t*);
 size_t FEX_usable_size(void*);

--- a/ThunkLibs/libxcb-dri3/libxcb-dri3_interface.cpp
+++ b/ThunkLibs/libxcb-dri3/libxcb-dri3_interface.cpp
@@ -3,7 +3,9 @@
 #include <xcb/dri3.h>
 
 template<auto>
-struct fex_gen_config;
+struct fex_gen_config {
+    unsigned version = 0;
+};
 
 void FEX_xcb_dri3_init_extension(xcb_connection_t*, xcb_extension_t*);
 size_t FEX_usable_size(void*);

--- a/ThunkLibs/libxcb-glx/libxcb-glx_interface.cpp
+++ b/ThunkLibs/libxcb-glx/libxcb-glx_interface.cpp
@@ -3,7 +3,9 @@
 #include <xcb/glx.h>
 
 template<auto>
-struct fex_gen_config;
+struct fex_gen_config {
+    unsigned version = 0;
+};
 
 void FEX_xcb_glx_init_extension(xcb_connection_t*, xcb_extension_t*);
 size_t FEX_usable_size(void*);

--- a/ThunkLibs/libxcb-present/libxcb-present_interface.cpp
+++ b/ThunkLibs/libxcb-present/libxcb-present_interface.cpp
@@ -3,7 +3,9 @@
 #include <xcb/present.h>
 
 template<auto>
-struct fex_gen_config;
+struct fex_gen_config {
+    unsigned version = 0;
+};
 
 void FEX_xcb_present_init_extension(xcb_connection_t*, xcb_extension_t*);
 size_t FEX_usable_size(void*);

--- a/ThunkLibs/libxcb-randr/libxcb-randr_interface.cpp
+++ b/ThunkLibs/libxcb-randr/libxcb-randr_interface.cpp
@@ -3,7 +3,9 @@
 #include <xcb/randr.h>
 
 template<auto>
-struct fex_gen_config;
+struct fex_gen_config {
+    unsigned version = 0;
+};
 
 void FEX_xcb_randr_init_extension(xcb_connection_t*, xcb_extension_t*);
 size_t FEX_usable_size(void*);

--- a/ThunkLibs/libxcb-shm/libxcb-shm_interface.cpp
+++ b/ThunkLibs/libxcb-shm/libxcb-shm_interface.cpp
@@ -3,7 +3,9 @@
 #include <xcb/shm.h>
 
 template<auto>
-struct fex_gen_config;
+struct fex_gen_config {
+    unsigned version = 0;
+};
 
 void FEX_xcb_shm_init_extension(xcb_connection_t*, xcb_extension_t*);
 size_t FEX_usable_size(void*);

--- a/ThunkLibs/libxcb-xfixes/libxcb-xfixes_interface.cpp
+++ b/ThunkLibs/libxcb-xfixes/libxcb-xfixes_interface.cpp
@@ -3,7 +3,9 @@
 #include <xcb/xfixes.h>
 
 template<auto>
-struct fex_gen_config;
+struct fex_gen_config {
+    unsigned version = 0;
+};
 
 void FEX_xcb_xfixes_init_extension(xcb_connection_t*, xcb_extension_t*);
 size_t FEX_usable_size(void*);

--- a/ThunkLibs/libxcb/libxcb_interface.cpp
+++ b/ThunkLibs/libxcb/libxcb_interface.cpp
@@ -7,7 +7,9 @@
 #include "WorkEventData.h"
 
 template<auto>
-struct fex_gen_config;
+struct fex_gen_config {
+    unsigned version = 1;
+};
 
 void FEX_xcb_init_extension(xcb_connection_t*, xcb_extension_t*);
 size_t FEX_usable_size(void*);


### PR DESCRIPTION
Some libraries were missing these version defines, which was causing dlopen to fail.

This was causing thunks to break in pressure-vessel.