### PR TITLE
Thunks/Guest: Enable SSE2 on thunks and set fpmath to sse

### DIFF
--- a/ThunkLibs/GuestLibs/CMakeLists.txt
+++ b/ThunkLibs/GuestLibs/CMakeLists.txt
@@ -103,6 +103,11 @@ function(add_guest_lib NAME SONAME)
 
   ## Make signed overflow well defined 2's complement overflow
   target_compile_options(${NAME}-guest PRIVATE -fwrapv)
+  if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    ## Compile for SSE2
+    ## Compile with fpmath=sse to remove x87 usage
+    target_compile_options(${NAME}-guest PRIVATE -msse2 -mfpmath=sse)
+  endif()
 
   if (BITNESS EQUAL 32)
     # Makes the GOT/PLT lookups slightly less painful


### PR DESCRIPTION
Clang thunks already have these default enabled, but let's also enable this on the GCC side.

sse2 will enable most things we care about, which matches ASIMD quite closely.
fpmath=sse removes some x87 usage for 32-bit thunks specifically.

Should effectively be a non-functional-change