### PR TITLE
IR: Check for invalid conversion masks in Float_FromGPR_S

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ConversionOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ConversionOps.cpp
@@ -57,8 +57,11 @@ DEF_OP(VCastFromGPR) {
 }
 
 DEF_OP(Float_FromGPR_S) {
-  auto Op = IROp->C<IR::IROp_Float_FromGPR_S>();
-  const uint16_t Conv = (Op->Header.ElementSize << 8) | Op->SrcElementSize;
+  const auto Op = IROp->C<IR::IROp_Float_FromGPR_S>();
+
+  const uint16_t ElementSize = Op->Header.ElementSize;
+  const uint16_t Conv = (ElementSize << 8) | Op->SrcElementSize;
+
   switch (Conv) {
     case 0x0404: { // Float <- int32_t
       scvtf(GetDst(Node).S(), GetReg<RA_32>(Op->Src.ID()));
@@ -76,6 +79,10 @@ DEF_OP(Float_FromGPR_S) {
       scvtf(GetDst(Node).D(), GetReg<RA_64>(Op->Src.ID()));
       break;
     }
+    default:
+      LOGMAN_MSG_A_FMT("Unhandled conversion mask: Mask=0x{:04x}, ElementSize={}, SrcElementSize={}",
+                       Conv, ElementSize, Op->SrcElementSize);
+      break;
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/ConversionOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/ConversionOps.cpp
@@ -63,8 +63,10 @@ DEF_OP(VCastFromGPR) {
 }
 
 DEF_OP(Float_FromGPR_S) {
-  auto Op = IROp->C<IR::IROp_Float_FromGPR_S>();
-  const uint16_t Conv = (Op->Header.ElementSize << 8) | Op->SrcElementSize;
+  const auto Op = IROp->C<IR::IROp_Float_FromGPR_S>();
+
+  const uint16_t ElementSize = Op->Header.ElementSize;
+  const uint16_t Conv = (ElementSize << 8) | Op->SrcElementSize;
 
   switch (Conv) {
     case 0x0404: { // Float <- int32_t
@@ -83,6 +85,10 @@ DEF_OP(Float_FromGPR_S) {
       cvtsi2sd(GetDst(Node), GetSrc<RA_64>(Op->Src.ID()));
       break;
     }
+    default:
+      LOGMAN_MSG_A_FMT("Unhandled conversion mask: Mask=0x{:04x}, ElementSize={}, SrcElementSize={}",
+                       Conv, ElementSize, Op->SrcElementSize);
+      break;
   }
 }
 


### PR DESCRIPTION
Previously this would silently ignore unhandled masks.