### PR TITLE
OpcodeDispatcher: Fixes ROR imm OF calculation

### DIFF
--- a/unittests/ASM/Primary/ROL_OF.asm
+++ b/unittests/ASM/Primary/ROL_OF.asm
@@ -1,0 +1,72 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "R15": "0x00000000000000aa"
+  }
+}
+%endif
+
+%macro clearof 0
+mov r12, 0
+ror r12, 1
+%endmacro
+
+%macro ofmerge 0
+mov r14, 0
+mov r13, 1
+cmovo r14, r13
+
+or r15, r14
+shl r15, 1
+%endmacro
+
+mov r15, 0
+mov r14, 1
+
+; 1 bit rotate
+; rol OF = XOR of LSB and MSB after rotate
+clearof
+mov rax, 0
+mov rcx, 1
+rol rax, cl
+ofmerge
+
+clearof
+mov rax, 0x8000000000000000
+mov rcx, 1
+rol rax, cl
+ofmerge
+
+clearof
+mov rax, 0xC000000000000000
+mov rcx, 1
+rol rax, cl
+ofmerge
+
+clearof
+mov rax, 0x4000000000000000
+mov rcx, 1
+rol rax, cl
+ofmerge
+
+clearof
+mov rax, 0
+rol rax, 1
+ofmerge
+
+clearof
+mov rax, 0x8000000000000000
+rol rax, 1
+ofmerge
+
+clearof
+mov rax, 0xC000000000000000
+rol rax, 1
+ofmerge
+
+clearof
+mov rax, 0x4000000000000000
+rol rax, 1
+ofmerge
+
+hlt

--- a/unittests/ASM/Primary/ROR_OF.asm
+++ b/unittests/ASM/Primary/ROR_OF.asm
@@ -1,0 +1,72 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "R15": "0x00000000000000cc"
+  }
+}
+%endif
+
+%macro clearof 0
+mov r12, 0
+ror r12, 1
+%endmacro
+
+%macro ofmerge 0
+mov r14, 0
+mov r13, 1
+cmovo r14, r13
+
+or r15, r14
+shl r15, 1
+%endmacro
+
+mov r15, 0
+mov r14, 1
+
+; 1 bit rotate
+; ror OF = XOR or two most significant bits of result
+clearof
+mov rax, 0
+mov rcx, 1
+ror rax, cl
+ofmerge
+
+clearof
+mov rax, 1
+mov rcx, 1
+ror rax, cl
+ofmerge
+
+clearof
+mov rax, 0x8000000000000000
+mov rcx, 1
+ror rax, cl
+ofmerge
+
+clearof
+mov rax, 0x8000000000000001
+mov rcx, 1
+ror rax, cl
+ofmerge
+
+clearof
+mov rax, 0
+ror rax, 1
+ofmerge
+
+clearof
+mov rax, 1
+ror rax, 1
+ofmerge
+
+clearof
+mov rax, 0x8000000000000000
+ror rax, 1
+ofmerge
+
+clearof
+mov rax, 0x8000000000000001
+ror rax, 1
+ofmerge
+
+hlt


### PR DESCRIPTION
Turns out this was calculating OF incorrectly, breaking Denuvo early in its execution.

Changes the ROL imm OF calculation code as well to be more consistent and not keep src1 alive longer than it needs to be.

Also adds two new unit tests to ensure this stays correct.

Denuvo Anti-tamper still crashes, but it gets farther at least.