### PR TITLE
Interpreter/MiscOps: Remove unused StopThread() function

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/MiscOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/MiscOps.cpp
@@ -19,13 +19,6 @@ $end_info$
 #include <sys/random.h>
 
 namespace FEXCore::CPU {
-[[noreturn]]
-static void StopThread(FEXCore::Core::InternalThreadState *Thread) {
-  Thread->CTX->StopThread(Thread);
-
-  LOGMAN_MSG_A_FMT("unreachable");
-  FEX_UNREACHABLE;
-}
 
 #define DEF_OP(x) void InterpreterOps::Op_##x(IR::IROp_Header *IROp, IROpData *Data, IR::NodeID Node)
 DEF_OP(Fence) {


### PR DESCRIPTION
This has been unused since ff1d51c7bda3a4151ffb13fc0f2caec5d8c5e3a5

Silences a compiler warning.