### PR TITLE
Arm64/MemoryOps: Remove lingering unnecessary ptrue instances

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -489,10 +489,8 @@ DEF_OP(SpillRegister) {
       break;
     }
     case 32: {
-      // TODO: Eliminate ptrue with statically allocated predicate register.
-      ptrue(p7.VnB(), SVE_VL32);
       mov(TMP3, SlotOffset);
-      st1b(Src.Z().VnB(), p7, SVEMemOperand(sp, TMP3));
+      st1b(Src.Z().VnB(), PRED_TMP_32B, SVEMemOperand(sp, TMP3));
       break;
     }
     default:
@@ -548,10 +546,8 @@ DEF_OP(FillRegister) {
       break;
     }
     case 32: {
-      // TODO: Eliminate ptrue with statically allocated predicate register.
-      ptrue(p7.VnB(), SVE_VL32);
       mov(TMP3, SlotOffset);
-      ld1b(Dst.Z().VnB(), p7.Zeroing(), SVEMemOperand(sp, TMP3));
+      ld1b(Dst.Z().VnB(), PRED_TMP_32B.Zeroing(), SVEMemOperand(sp, TMP3));
       break;
     }
     default:


### PR DESCRIPTION
Gets rid of some leftover bits from when we didn't have statically allocated predicate registers.