### PR TITLE
IR: Handle 256-bit LoadMem/LoadMemTSO/ParanoidLoadMemTSO

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/MemoryOps.cpp
@@ -144,8 +144,8 @@ DEF_OP(StoreFlag) {
 }
 
 DEF_OP(LoadMem) {
-  auto Op = IROp->C<IR::IROp_LoadMem>();
-  uint8_t OpSize = IROp->Size;
+  const auto Op = IROp->C<IR::IROp_LoadMem>();
+  const auto OpSize = IROp->Size;
 
   uint8_t const *MemData = *GetSrc<uint8_t const**>(Data->SSAData, Op->Addr);
 
@@ -158,7 +158,8 @@ DEF_OP(LoadMem) {
       case IR::MEM_OFFSET_SXTW.Val: MemData += (int32_t)Offset; break;
     }
   }
-  memset(GDP, 0, 16);
+
+  memset(GDP, 0, Core::CPUState::XMM_AVX_REG_SIZE);
   switch (OpSize) {
     case 1: {
       auto D = reinterpret_cast<const std::atomic<uint8_t>*>(MemData);
@@ -180,9 +181,8 @@ DEF_OP(LoadMem) {
       GD = D->load();
       break;
     }
-
     default:
-      memcpy(GDP, MemData, IROp->Size);
+      memcpy(GDP, MemData, OpSize);
       break;
   }
 }

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -118,6 +118,17 @@ private:
                                               IR::MemOffsetType OffsetType,
                                               uint8_t OffsetScale);
 
+  // NOTE: Will use TMP1 as a way to encode immediates that happen to fall outside
+  //       the limits of the scalar plus immediate variant of SVE load/stores.
+  //
+  //       TMP1 is safe to use again once this memory operand is used with its
+  //       equivalent loads or stores that this was called for.
+  [[nodiscard]] SVEMemOperand GenerateSVEMemOperand(uint8_t AccessSize,
+                                                    aarch64::Register Base,
+                                                    IR::OrderedNodeWrapper Offset,
+                                                    IR::MemOffsetType OffsetType,
+                                                    uint8_t OffsetScale);
+
   [[nodiscard]] bool IsInlineConstant(const IR::OrderedNodeWrapper& Node, uint64_t* Value = nullptr) const;
   [[nodiscard]] bool IsInlineEntrypointOffset(const IR::OrderedNodeWrapper& WNode, uint64_t* Value) const;
 


### PR DESCRIPTION
Extends LoadMem, LoadMemTSO, and ParanoidLoadMemTSO to handle 256-bit vectors