### PR TITLE
Arm64/MemoryOps: Merge if statement into switch in ParanoidLoadMemTSO

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -1026,27 +1026,23 @@ DEF_OP(ParanoidLoadMemTSO) {
   }
 
   if (Op->Class == FEXCore::IR::GPRClass) {
-    if (OpSize == 1) {
-      // 8bit load is always aligned to natural alignment
-      const auto Dst = GetReg<RA_64>(Node);
-      ldarb(Dst, MemSrc);
-    }
-    else {
-      const auto Dst = GetReg<RA_64>(Node);
-      switch (OpSize) {
-        case 2:
-          ldarh(Dst, MemSrc);
-          break;
-        case 4:
-          ldar(Dst.W(), MemSrc);
-          break;
-        case 8:
-          ldar(Dst, MemSrc);
-          break;
-        default:
-          LOGMAN_MSG_A_FMT("Unhandled ParanoidLoadMemTSO size: {}", OpSize);
-          break;
-      }
+    const auto Dst = GetReg<RA_64>(Node);
+    switch (OpSize) {
+      case 1:
+        ldarb(Dst, MemSrc);
+        break;
+      case 2:
+        ldarh(Dst, MemSrc);
+        break;
+      case 4:
+        ldar(Dst.W(), MemSrc);
+        break;
+      case 8:
+        ldar(Dst, MemSrc);
+        break;
+      default:
+        LOGMAN_MSG_A_FMT("Unhandled ParanoidLoadMemTSO size: {}", OpSize);
+        break;
     }
   }
   else {


### PR DESCRIPTION
There's nothing preventing the `OpSize == 1` case from being merged into the switch, so we can do that to make things a little more consistent.