### PR TITLE
Thunks: Fix guest targets not being detected by IDEs

### DIFF
--- a/ThunkLibs/GuestLibs/CMakeLists.txt
+++ b/ThunkLibs/GuestLibs/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 3.14)
 project(guest-thunks)
 
-option(BITNESS "Which bitness the thunks are building for" 64)
 option(ENABLE_CLANG_THUNKS "Enable building thunks with clang" FALSE)
 
 if (ENABLE_CLANG_THUNKS)
@@ -34,6 +33,7 @@ else()
   set(GENERATOR_EXE thunkgen)
   set(TARGET_TYPE OBJECT)
   set(GENERATE_GUEST_INSTALL_TARGETS FALSE)
+  set(BITNESS 64)
 endif()
 
 # Syntax: generate(libxyz libxyz-interface.cpp)


### PR DESCRIPTION
The IDE integration path didn't set up the BITNESS variable.

This change also unmarks that variable as a CMake option since it's not a boolean value. (CMake doesn't support non-boolean options.)