### PR TITLE
ELFCodeLoader: Ensure we set AT_SYSINFO for 32-bit

### DIFF
--- a/Source/Tests/VDSO_Emulation.cpp
+++ b/Source/Tests/VDSO_Emulation.cpp
@@ -8,6 +8,7 @@
 #include <FEXHeaderUtils/Syscalls.h>
 
 #include <dlfcn.h>
+#include <elf.h>
 #include <fcntl.h>
 #include <filesystem>
 #include <sys/mman.h>
@@ -289,6 +290,21 @@ namespace FEX::VDSO {
     }
 
     return VDSOBase;
+  }
+
+  uint64_t GetVSyscallEntry(const void* VDSOBase) {
+    if (!VDSOBase) {
+      return 0;
+    }
+
+    // Extract the vsyscall location from the VDSO header.
+    auto Header = reinterpret_cast<const Elf32_Ehdr*>(VDSOBase);
+
+    if (Header->e_entry) {
+      return reinterpret_cast<uint64_t>(VDSOBase) + Header->e_entry;
+    }
+
+    return 0;
   }
 
   std::vector<FEXCore::IR::ThunkDefinition> const& GetVDSOThunkDefinitions() {

--- a/Source/Tests/VDSO_Emulation.h
+++ b/Source/Tests/VDSO_Emulation.h
@@ -5,5 +5,7 @@ namespace FEX::VDSO {
   using MapperFn = std::function<void *(void *addr, size_t length, int prot, int flags, int fd, off_t offset)>;
   void* LoadVDSOThunks(bool Is64Bit, MapperFn Mapper);
 
+  uint64_t GetVSyscallEntry(const void* VDSOBase);
+
   std::vector<FEXCore::IR::ThunkDefinition> const& GetVDSOThunkDefinitions();
 }


### PR DESCRIPTION
AT_SYSINFO points to the vsyscall location that the kernel provides. This AUXV value isn't used on x86-64.
If we have VDSO installed then we can use the one provided from there, otherwise we need to provide a code page.

It seems like some behaviour changed with glibc provided in Ubuntu 22.10 that it now requires AT_SYSINFO.

Fixes wine 7.0 execution inside the Ubuntu 22.10 rootfs.