### PR TITLE
ELFCodeLoader: Pass through AT_SECURE

### DIFF
--- a/Source/Tests/ELFCodeLoader2.h
+++ b/Source/Tests/ELFCodeLoader2.h
@@ -529,7 +529,7 @@ class ELFCodeLoader2 final : public FEXCore::CodeLoader {
     AuxVariables.emplace_back(auxv_t{17, getauxval(AT_CLKTCK)}); // AT_CLKTIK
     AuxVariables.emplace_back(auxv_t{6, 0x1000}); // AT_PAGESIZE
     AuxRandom = &AuxVariables.emplace_back(auxv_t{25, ~0ULL}); // AT_RANDOM
-    AuxVariables.emplace_back(auxv_t{23, 0}); // AT_SECURE
+    AuxVariables.emplace_back(auxv_t{23, getauxval(AT_SECURE)}); // AT_SECURE
     AuxVariables.emplace_back(auxv_t{8, 0}); // AT_FLAGS
     AuxVariables.emplace_back(auxv_t{5, MainElf.phdrs.size()}); // AT_PHNUM
     AuxVariables.emplace_back(auxv_t{16, HWCap}); // AT_HWCAP


### PR DESCRIPTION
When we are installed as a binfmt_misc handler the Linux kernel will assign us AT_SECURE for setuid binaries.

Ensure we are passing this through for any application that will end up needing it.