### PR TITLE
FEXConfig: Sort named rootfs vector

### DIFF
--- a/Source/Tools/FEXConfig/Main.cpp
+++ b/Source/Tools/FEXConfig/Main.cpp
@@ -141,6 +141,7 @@ namespace {
         }
       }
     }
+    std::sort(NamedRootFS.begin(), NamedRootFS.end());
   }
 
   void INotifyThread() {


### PR DESCRIPTION
This was driving me nuts that this wasn't sorted by name.