### PR TITLE
IR: Removes the only uses of VSLI and VSRI

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -243,8 +243,6 @@ constexpr OpHandlerArray InterpreterOpHandlers = [] {
   REGISTER_OP(VINSELEMENT,            VInsElement);
   REGISTER_OP(VDUPELEMENT,            VDupElement);
   REGISTER_OP(VEXTR,                  VExtr);
-  REGISTER_OP(VSLI,                   VSLI);
-  REGISTER_OP(VSRI,                   VSRI);
   REGISTER_OP(VUSHRI,                 VUShrI);
   REGISTER_OP(VSSHRI,                 VSShrI);
   REGISTER_OP(VSHLI,                  VShlI);

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
@@ -263,8 +263,6 @@ namespace FEXCore::CPU {
   DEF_OP(VInsElement);
   DEF_OP(VDupElement);
   DEF_OP(VExtr);
-  DEF_OP(VSLI);
-  DEF_OP(VSRI);
   DEF_OP(VUShrI);
   DEF_OP(VSShrI);
   DEF_OP(VShlI);

--- a/External/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
@@ -1641,24 +1641,6 @@ DEF_OP(VExtr) {
   memcpy(GDP, &Dst, OpSize);
 }
 
-DEF_OP(VSLI) {
-  auto Op = IROp->C<IR::IROp_VSLI>();
-  const __uint128_t Src1 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Vector);
-  const __uint128_t Src2 = Op->ByteShift * 8;
-
-  const __uint128_t Dst = Op->ByteShift >= sizeof(__uint128_t) ? 0 : Src1 << Src2;
-  memcpy(GDP, &Dst, 16);
-}
-
-DEF_OP(VSRI) {
-  auto Op = IROp->C<IR::IROp_VSRI>();
-  const __uint128_t Src1 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Vector);
-  const __uint128_t Src2 = Op->ByteShift * 8;
-
-  const __uint128_t Dst = Op->ByteShift >= sizeof(__uint128_t) ? 0 : Src1 >> Src2;
-  memcpy(GDP, &Dst, 16);
-}
-
 DEF_OP(VUShrI) {
   const auto Op = IROp->C<IR::IROp_VUShrI>();
   const uint8_t OpSize = IROp->Size;

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -428,8 +428,6 @@ private:
   DEF_OP(VInsElement);
   DEF_OP(VDupElement);
   DEF_OP(VExtr);
-  DEF_OP(VSLI);
-  DEF_OP(VSRI);
   DEF_OP(VUShrI);
   DEF_OP(VSShrI);
   DEF_OP(VShlI);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -4028,66 +4028,6 @@ DEF_OP(VExtr) {
   }
 }
 
-DEF_OP(VSLI) {
-  auto Op = IROp->C<IR::IROp_VSLI>();
-  const uint8_t OpSize = IROp->Size;
-  const uint8_t BitShift = Op->ByteShift * 8;
-  if (BitShift < 64) {
-    // Move to Pair [TMP2:TMP1]
-    mov(TMP1, GetSrc(Op->Vector.ID()).V2D(), 0);
-    mov(TMP2, GetSrc(Op->Vector.ID()).V2D(), 1);
-    // Left shift low 64bits
-    lsl(TMP3, TMP1, BitShift);
-
-    // Extract high 64bits from [TMP2:TMP1]
-    extr(TMP1, TMP2, TMP1, 64 - BitShift);
-
-    mov(GetDst(Node).V2D(), 0, TMP3);
-    mov(GetDst(Node).V2D(), 1, TMP1);
-  }
-  else {
-    if (Op->ByteShift >= OpSize) {
-      eor(GetDst(Node).V16B(), GetDst(Node).V16B(), GetDst(Node).V16B());
-    }
-    else {
-      mov(TMP1, GetSrc(Op->Vector.ID()).V2D(), 0);
-      lsl(TMP1, TMP1, BitShift - 64);
-      mov(GetDst(Node).V2D(), 0, xzr);
-      mov(GetDst(Node).V2D(), 1, TMP1);
-    }
-  }
-}
-
-DEF_OP(VSRI) {
-  auto Op = IROp->C<IR::IROp_VSRI>();
-  const uint8_t OpSize = IROp->Size;
-  const uint8_t BitShift = Op->ByteShift * 8;
-  if (BitShift < 64) {
-    // Move to Pair [TMP2:TMP1]
-    mov(TMP1, GetSrc(Op->Vector.ID()).V2D(), 0);
-    mov(TMP2, GetSrc(Op->Vector.ID()).V2D(), 1);
-
-    // Extract Low 64bits [TMP2:TMP2] >> BitShift
-    extr(TMP1, TMP2, TMP1, BitShift);
-    // Right shift high bits
-    lsr(TMP2, TMP2, BitShift);
-
-    mov(GetDst(Node).V2D(), 0, TMP1);
-    mov(GetDst(Node).V2D(), 1, TMP2);
-  }
-  else {
-    if (Op->ByteShift >= OpSize) {
-      eor(GetDst(Node).V16B(), GetDst(Node).V16B(), GetDst(Node).V16B());
-    }
-    else {
-      mov(TMP1, GetSrc(Op->Vector.ID()).V2D(), 1);
-      lsr(TMP1, TMP1, BitShift - 64);
-      mov(GetDst(Node).V2D(), 0, TMP1);
-      mov(GetDst(Node).V2D(), 1, xzr);
-    }
-  }
-}
-
 DEF_OP(VUShrI) {
   const auto Op = IROp->C<IR::IROp_VUShrI>();
   const auto OpSize = IROp->Size;
@@ -5354,8 +5294,6 @@ void Arm64JITCore::RegisterVectorHandlers() {
   REGISTER_OP(VINSELEMENT,       VInsElement);
   REGISTER_OP(VDUPELEMENT,       VDupElement);
   REGISTER_OP(VEXTR,             VExtr);
-  REGISTER_OP(VSLI,              VSLI);
-  REGISTER_OP(VSRI,              VSRI);
   REGISTER_OP(VUSHRI,            VUShrI);
   REGISTER_OP(VSSHRI,            VSShrI);
   REGISTER_OP(VSHLI,             VShlI);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -428,8 +428,6 @@ private:
   DEF_OP(VInsElement);
   DEF_OP(VDupElement);
   DEF_OP(VExtr);
-  DEF_OP(VSLI);
-  DEF_OP(VSRI);
   DEF_OP(VUShrI);
   DEF_OP(VSShrI);
   DEF_OP(VShlI);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
@@ -2409,20 +2409,6 @@ DEF_OP(VExtr) {
   }
 }
 
-DEF_OP(VSLI) {
-  auto Op = IROp->C<IR::IROp_VSLI>();
-  movapd(xmm15, GetSrc(Op->Vector.ID()));
-  pslldq(xmm15, Op->ByteShift);
-  movapd(GetDst(Node), xmm15);
-}
-
-DEF_OP(VSRI) {
-  auto Op = IROp->C<IR::IROp_VSRI>();
-  movapd(xmm15, GetSrc(Op->Vector.ID()));
-  psrldq(xmm15, Op->ByteShift);
-  movapd(GetDst(Node), xmm15);
-}
-
 DEF_OP(VUShrI) {
   const auto Op = IROp->C<IR::IROp_VUShrI>();
 
@@ -3661,8 +3647,6 @@ void X86JITCore::RegisterVectorHandlers() {
   REGISTER_OP(VINSELEMENT,       VInsElement);
   REGISTER_OP(VDUPELEMENT,       VDupElement);
   REGISTER_OP(VEXTR,             VExtr);
-  REGISTER_OP(VSLI,              VSLI);
-  REGISTER_OP(VSRI,              VSRI);
   REGISTER_OP(VUSHRI,            VUShrI);
   REGISTER_OP(VSSHRI,            VSShrI);
   REGISTER_OP(VSHLI,             VShlI);

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -926,7 +926,11 @@ void OpDispatchBuilder::PSRLDQ(OpcodeArgs) {
 
   auto Size = GetDstSize(Op);
 
-  auto Result = _VSRI(Size, 16, Dest, Shift);
+  OrderedNode *Result = _VectorZero(Size);
+  if (Shift < Size) {
+    Result = _VExtr(Size, 1, Result, Dest, Shift);
+  }
+
   StoreResult(FPRClass, Op, Result, -1);
 }
 
@@ -938,7 +942,10 @@ void OpDispatchBuilder::PSLLDQ(OpcodeArgs) {
 
   auto Size = GetDstSize(Op);
 
-  auto Result = _VSLI(Size, 16, Dest, Shift);
+  OrderedNode *Result = _VectorZero(Size);
+  if (Shift < Size) {
+    Result = _VExtr(Size, 1, Dest, Result, Size - Shift);
+  }
   StoreResult(FPRClass, Op, Result, -1);
 }
 

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -1006,16 +1006,6 @@
         "DestSize": "RegisterSize",
         "NumElements": "RegisterSize / ElementSize"
       },
-      "FPR = VSLI u8:#RegisterSize, u8:#ElementSize, FPR:$Vector, u8:$ByteShift": {
-        "DestSize": "RegisterSize",
-        "NumElements": "RegisterSize / ElementSize"
-      },
-
-      "FPR = VSRI u8:#RegisterSize, u8:#ElementSize, FPR:$Vector, u8:$ByteShift": {
-        "DestSize": "RegisterSize",
-        "NumElements": "RegisterSize / ElementSize"
-      },
-
       "FPR = VShlI u8:#RegisterSize, u8:#ElementSize, FPR:$Vector, u8:$BitShift": {
         "DestSize": "RegisterSize",
         "NumElements": "RegisterSize / ElementSize"


### PR DESCRIPTION
We use these two IR ops for PSRLQ and PSLLQ respectively, Which is actually implemented in a quite inefficient way.

Instead switch the ops over to using VExtr which maps directly to one instruction and can emulate both.