### PR TITLE
FEXServer: More Systemd fixes

### DIFF
--- a/Source/Common/FEXServerClient.cpp
+++ b/Source/Common/FEXServerClient.cpp
@@ -162,14 +162,14 @@ namespace FEXServerClient {
     // The entirety of the name is used as a path to a socket that doesn't have any filesystem backing.
     struct sockaddr_un addr{};
     addr.sun_family = AF_UNIX;
-    // + 1 for null character initializer.
-    size_t SizeOfSocketString = std::min(ServerSocketName.size(), sizeof(addr.sun_path) - 2);
+    size_t SizeOfSocketString = std::min(ServerSocketName.size() + 1, sizeof(addr.sun_path) - 1);
+    addr.sun_path[0] = 0; // Abstract AF_UNIX sockets start with \0
     strncpy(addr.sun_path + 1, ServerSocketName.data(), SizeOfSocketString);
     // Include final null character.
-    size_t SizeOfAddr = sizeof(addr.sun_family) + SizeOfSocketString + 1;
+    size_t SizeOfAddr = sizeof(addr.sun_family) + SizeOfSocketString;
 
     if (connect(SocketFD, reinterpret_cast<struct sockaddr*>(&addr), SizeOfAddr) == -1) {
-      LogMan::Msg::EFmt("Couldn't connect to FEXServer socket {} {} {}", ServerSocketFile, errno, strerror(errno));
+      LogMan::Msg::EFmt("Couldn't connect to FEXServer socket {} {} {}", ServerSocketName, errno, strerror(errno));
       close(SocketFD);
       return -1;
     }

--- a/Source/Common/FEXServerClient.h
+++ b/Source/Common/FEXServerClient.h
@@ -50,7 +50,7 @@ namespace FEXServerClient {
   std::string GetServerLockFolder();
   std::string GetServerLockFile();
   std::string GetServerRootFSLockFile();
-  std::string GetServerTempFolder();
+  std::string GetServerMountFolder();
   std::string GetServerSocketName();
   int GetServerFD();
 

--- a/Source/Common/FEXServerClient.h
+++ b/Source/Common/FEXServerClient.h
@@ -50,7 +50,8 @@ namespace FEXServerClient {
   std::string GetServerLockFolder();
   std::string GetServerLockFile();
   std::string GetServerRootFSLockFile();
-  std::string GetServerSocketFile();
+  std::string GetServerTempFolder();
+  std::string GetServerSocketName();
   int GetServerFD();
 
   bool SetupClient(char *InterpreterPath);

--- a/Source/Tools/FEXServer/ProcessPipe.cpp
+++ b/Source/Tools/FEXServer/ProcessPipe.cpp
@@ -190,11 +190,11 @@ namespace ProcessPipe {
 
     struct sockaddr_un addr{};
     addr.sun_family = AF_UNIX;
-    // + 1 for null character initializer.
-    size_t SizeOfSocketString = std::min(ServerSocketName.size(), sizeof(addr.sun_path) - 2);
+    size_t SizeOfSocketString = std::min(ServerSocketName.size() + 1, sizeof(addr.sun_path) - 1);
+    addr.sun_path[0] = 0; // Abstract AF_UNIX sockets start with \0
     strncpy(addr.sun_path + 1, ServerSocketName.data(), SizeOfSocketString);
     // Include final null character.
-    size_t SizeOfAddr = sizeof(addr.sun_family) + SizeOfSocketString + 1;
+    size_t SizeOfAddr = sizeof(addr.sun_family) + SizeOfSocketString;
 
     // Bind the socket to the path
     int Result = bind(ServerSocketFD, reinterpret_cast<struct sockaddr*>(&addr), SizeOfAddr);

--- a/Source/Tools/FEXServer/SquashFS.cpp
+++ b/Source/Tools/FEXServer/SquashFS.cpp
@@ -106,7 +106,7 @@ namespace SquashFS {
 
   bool MountRootFSImagePath(std::string SquashFS, bool EroFS) {
     pid_t ParentTID = ::getpid();
-    MountFolder = fmt::format("{}/.FEXMount{}-XXXXXX", std::filesystem::temp_directory_path().string(), ParentTID);
+    MountFolder = fmt::format("{}/.FEXMount{}-XXXXXX", FEXServerClient::GetServerTempFolder(), ParentTID);
     char *MountFolderStr = MountFolder.data();
 
     // Make the temporary mount folder

--- a/Source/Tools/FEXServer/SquashFS.cpp
+++ b/Source/Tools/FEXServer/SquashFS.cpp
@@ -106,7 +106,7 @@ namespace SquashFS {
 
   bool MountRootFSImagePath(std::string SquashFS, bool EroFS) {
     pid_t ParentTID = ::getpid();
-    MountFolder = fmt::format("{}/.FEXMount{}-XXXXXX", FEXServerClient::GetServerTempFolder(), ParentTID);
+    MountFolder = fmt::format("{}/.FEXMount{}-XXXXXX", FEXServerClient::GetServerMountFolder(), ParentTID);
     char *MountFolderStr = MountFolder.data();
 
     // Make the temporary mount folder


### PR DESCRIPTION
Two changes here.

- Make the mount path follow server temp folder requirements.
  - Will be mounted in `/tmp/` or `$XDG_RUNTIME_DIR/` now
- Switch the FEXServer socket to an "abstract" AF_UNIX socket.
  - If the socket is in `/tmp/` then systemd will put the service in a private `/tmp` folder that only exists for the service.
  - If the socket is in `$XDG_RUNTIME_DIR` then pressure-vessel can't chroot anymore since they make their own runtime directory.
  - If it is in `$HOME/.fex-emu/` then it breaks usage where the filesystem is a mount that doesn't support AF_UNIX like sshfs.

The only reasonable thing to do is to switch over to `abstract` sockets which will work in all cases.
Tested with pressure-vessel and systemd and now it works in all situations.