### PR TITLE
Config: Add support for steamid based configurations.

### DIFF
--- a/External/FEXCore/Source/Interface/Config/Config.cpp
+++ b/External/FEXCore/Source/Interface/Config/Config.cpp
@@ -211,10 +211,12 @@ namespace JSON {
   static std::map<FEXCore::Config::LayerType, std::unique_ptr<FEXCore::Config::Layer>> ConfigLayers;
   static FEXCore::Config::Layer *Meta{};
 
-  constexpr std::array<FEXCore::Config::LayerType, 7> LoadOrder = {
+  constexpr std::array<FEXCore::Config::LayerType, 9> LoadOrder = {
     FEXCore::Config::LayerType::LAYER_GLOBAL_MAIN,
     FEXCore::Config::LayerType::LAYER_MAIN,
+    FEXCore::Config::LayerType::LAYER_GLOBAL_STEAM_APP,
     FEXCore::Config::LayerType::LAYER_GLOBAL_APP,
+    FEXCore::Config::LayerType::LAYER_LOCAL_STEAM_APP,
     FEXCore::Config::LayerType::LAYER_LOCAL_APP,
     FEXCore::Config::LayerType::LAYER_ARGUMENTS,
     FEXCore::Config::LayerType::LAYER_ENVIRONMENT,
@@ -629,7 +631,7 @@ namespace JSON {
 
   class AppLoader final : public FEXCore::Config::OptionMapper {
   public:
-    explicit AppLoader(const std::string& Filename, bool Global);
+    explicit AppLoader(const std::string& Filename, FEXCore::Config::LayerType Type);
     void Load();
 
   private:
@@ -681,8 +683,10 @@ namespace JSON {
     });
   }
 
-  AppLoader::AppLoader(const std::string& Filename, bool Global)
-    : FEXCore::Config::OptionMapper(Global ? FEXCore::Config::LayerType::LAYER_GLOBAL_APP : FEXCore::Config::LayerType::LAYER_LOCAL_APP) {
+  AppLoader::AppLoader(const std::string& Filename, FEXCore::Config::LayerType Type)
+    : FEXCore::Config::OptionMapper(Type) {
+    const bool Global = Type == FEXCore::Config::LayerType::LAYER_GLOBAL_STEAM_APP ||
+                        Type == FEXCore::Config::LayerType::LAYER_LOCAL_STEAM_APP;
     Config = FEXCore::Config::GetApplicationConfig(Filename, Global);
 
     // Immediately load so we can reload the meta layer
@@ -754,8 +758,8 @@ namespace JSON {
     }
   }
 
-  std::unique_ptr<FEXCore::Config::Layer> CreateAppLayer(const std::string& Filename, bool Global) {
-    return std::make_unique<FEXCore::Config::AppLoader>(Filename, Global);
+  std::unique_ptr<FEXCore::Config::Layer> CreateAppLayer(const std::string& Filename, FEXCore::Config::LayerType Type) {
+    return std::make_unique<FEXCore::Config::AppLoader>(Filename, Type);
   }
 
   std::unique_ptr<FEXCore::Config::Layer> CreateEnvironmentLayer(char *const _envp[]) {

--- a/External/FEXCore/include/FEXCore/Config/Config.h
+++ b/External/FEXCore/include/FEXCore/Config/Config.h
@@ -74,7 +74,9 @@ namespace Handler {
     LAYER_GLOBAL_MAIN, ///< /usr/share/fex-emu/Config.json by default
     LAYER_MAIN,
     LAYER_ARGUMENTS,
+    LAYER_GLOBAL_STEAM_APP,
     LAYER_GLOBAL_APP,
+    LAYER_LOCAL_STEAM_APP,
     LAYER_LOCAL_APP,
     LAYER_ENVIRONMENT,
     LAYER_TOP,
@@ -272,7 +274,7 @@ namespace Type {
    *
    * @return unique_ptr for that layer
    */
-  FEX_DEFAULT_VISIBILITY std::unique_ptr<FEXCore::Config::Layer> CreateAppLayer(const std::string& Filename, bool Global);
+  FEX_DEFAULT_VISIBILITY std::unique_ptr<FEXCore::Config::Layer> CreateAppLayer(const std::string& Filename, FEXCore::Config::LayerType Type);
 
   /**
    * @brief iCreate an environment configuration loader

--- a/Source/Common/Config.cpp
+++ b/Source/Common/Config.cpp
@@ -109,8 +109,18 @@ namespace FEX::Config {
         }
       }
 
-      FEXCore::Config::AddLayer(FEXCore::Config::CreateAppLayer(ProgramName, true));
-      FEXCore::Config::AddLayer(FEXCore::Config::CreateAppLayer(ProgramName, false));
+      FEXCore::Config::AddLayer(FEXCore::Config::CreateAppLayer(ProgramName, FEXCore::Config::LayerType::LAYER_GLOBAL_APP));
+      FEXCore::Config::AddLayer(FEXCore::Config::CreateAppLayer(ProgramName, FEXCore::Config::LayerType::LAYER_LOCAL_APP));
+
+      auto SteamID = getenv("SteamAppId");
+      if (SteamID) {
+        // If a SteamID exists then let's search for Steam application configs as well.
+        // We want to key off both the SteamAppId number /and/ the executable since we may not want to thunk all binaries.
+        auto SteamAppName = fmt::format("Steam_{}_{}", SteamID, ProgramName.string());
+        FEXCore::Config::AddLayer(FEXCore::Config::CreateAppLayer(SteamAppName, FEXCore::Config::LayerType::LAYER_GLOBAL_STEAM_APP));
+        FEXCore::Config::AddLayer(FEXCore::Config::CreateAppLayer(SteamAppName, FEXCore::Config::LayerType::LAYER_LOCAL_STEAM_APP));
+      }
+
       return std::make_pair(Program, ProgramName);
     }
     return {};

--- a/Source/Tools/FEXGetConfig/Main.cpp
+++ b/Source/Tools/FEXGetConfig/Main.cpp
@@ -40,8 +40,17 @@ int main(int argc, char **argv, char **envp) {
   if (Options.is_set_by_user("app")) {
     // Load the application config if one was provided
     auto ProgramName = std::filesystem::path(Options["app"]).filename();
-    FEXCore::Config::AddLayer(FEXCore::Config::CreateAppLayer(ProgramName, true));
-    FEXCore::Config::AddLayer(FEXCore::Config::CreateAppLayer(ProgramName, false));
+    FEXCore::Config::AddLayer(FEXCore::Config::CreateAppLayer(ProgramName, FEXCore::Config::LayerType::LAYER_GLOBAL_APP));
+    FEXCore::Config::AddLayer(FEXCore::Config::CreateAppLayer(ProgramName, FEXCore::Config::LayerType::LAYER_LOCAL_APP));
+
+    auto SteamID = getenv("SteamAppId");
+    if (SteamID) {
+      // If a SteamID exists then let's search for Steam application configs as well.
+      // We want to key off both the SteamAppId number /and/ the executable since we may not want to thunk all binaries.
+      auto SteamAppName = fmt::format("Steam_{}_{}", SteamID, ProgramName.string());
+      FEXCore::Config::AddLayer(FEXCore::Config::CreateAppLayer(SteamAppName, FEXCore::Config::LayerType::LAYER_GLOBAL_STEAM_APP));
+      FEXCore::Config::AddLayer(FEXCore::Config::CreateAppLayer(SteamAppName, FEXCore::Config::LayerType::LAYER_LOCAL_STEAM_APP));
+    }
   }
 
   // Reload the meta layer


### PR DESCRIPTION
This will be useful for keying specific executables to steamids. This is sadly required because a bunch of games end up naming themselves "game.exe" so we can't safely enable thunks for all things shipping a generic name.