### PR TITLE
Arm64/VectorOps: Simplify VMov IR op on SVE 

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -122,6 +122,10 @@ DEF_OP(VMov) {
       break;
     }
     case 32: {
+      // NOTE: If, in the distant future we support larger moves, or registers
+      //       (*cough* AVX-512 *cough*) make sure to change this to treat
+      //       256-bit moves with zero extending behavior instead of doing only
+      //       a regular SVE move into a 512-bit register.
       if (Dst.GetCode() != Source.GetCode()) {
         mov(Dst.Z().VnD(), Source.Z().VnD());
       }


### PR DESCRIPTION
Initially I put this in very conservatively to make sure we always clear out the upper lanes, but since Adv. SIMD operations have zero-extending behavior when storing results, we can just use a few operations as is without needing to unnecessarily do the same work twice.