### PR TITLE
FEXServerClient: Add some debug logs for when FEX can't connect to se…

### DIFF
--- a/Source/Common/FEXServerClient.cpp
+++ b/Source/Common/FEXServerClient.cpp
@@ -127,6 +127,7 @@ namespace FEXServerClient {
     // Create the initial unix socket
     int SocketFD = socket(AF_UNIX, SOCK_STREAM, 0);
     if (SocketFD == -1) {
+      LogMan::Msg::EFmt("Couldn't open AF_UNIX socket {} {}", errno, strerror(errno));
       return -1;
     }
 
@@ -135,6 +136,7 @@ namespace FEXServerClient {
     strncpy(addr.sun_path, ServerSocketFile.data(), std::min(ServerSocketFile.size(), sizeof(addr.sun_path)));
 
     if (connect(SocketFD, reinterpret_cast<struct sockaddr*>(&addr), sizeof(addr)) == -1) {
+      LogMan::Msg::EFmt("Couldn't connect to FEXServer socket {} {} {}", ServerSocketFile, errno, strerror(errno));
       close(SocketFD);
       return -1;
     }


### PR DESCRIPTION
…rver

Sometimes when the socket fails to connect we have no debug information at all as to why.

This at least gives us a little bit more.