### PR TITLE
Core: Removes log about migrating to shared memory mode

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -1212,8 +1212,6 @@ namespace FEXCore::Context {
       IsMemoryShared = true;
 
       if (Config.TSOAutoMigration) {
-        LogMan::Msg::IFmt("Migrating to shared memory mode");
-
         std::lock_guard<std::mutex> lkThreads(ThreadCreationMutex);
         LogMan::Throw::AFmt(Threads.size() == 1, "First MarkMemoryShared called must be before creating any threads");
 


### PR DESCRIPTION
This hasn't ever caused problems and instead just adds a message that appears in logs for nearly every application invocation.

Remove it because it isn't necessary to track.