### PR TITLE
IntrusiveIRList: Add a utility helper for getting an OrderedNodeWrapper

### DIFF
--- a/External/FEXCore/include/FEXCore/IR/IntrusiveIRList.h
+++ b/External/FEXCore/include/FEXCore/IR/IntrusiveIRList.h
@@ -280,6 +280,11 @@ public:
     return Wrapper.GetNode(GetListData());
   }
 
+  ///< Gets an OrderedNode from the IRListView as an OrderedNodeWrapper.
+  [[nodiscard]] OrderedNodeWrapper WrapNode(OrderedNode *Node) const {
+    return Node->Wrapped(GetListData());
+  }
+
 private:
   struct BlockRange {
     using iterator = NodeIterator;


### PR DESCRIPTION
This is a nice helper that was otherwise missing.