### PR TITLE
Arm64: Optimize Break IR op codegen

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
@@ -41,16 +41,19 @@ DEF_OP(Break) {
   // First we must reset the stack
   ResetStack();
 
-  LoadConstant(w1, 1);
-  strb(w1, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, SynchronousFaultData.FaultToTopAndGeneratedException)));
-  LoadConstant(w1, Op->Reason.Signal);
-  strb(w1, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, SynchronousFaultData.Signal)));
-  LoadConstant(w1, Op->Reason.TrapNumber);
-  str(w1, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, SynchronousFaultData.TrapNo)));
-  LoadConstant(w1, Op->Reason.si_code);
-  str(w1, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, SynchronousFaultData.si_code)));
-  LoadConstant(x1, Op->Reason.ErrorRegister);
-  str(w1, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, SynchronousFaultData.err_code)));
+  Core::CpuStateFrame::SynchronousFaultDataStruct State = {
+    .FaultToTopAndGeneratedException = 1,
+    .Signal = Op->Reason.Signal,
+    .TrapNo = Op->Reason.TrapNumber,
+    .si_code = Op->Reason.si_code,
+    .err_code = Op->Reason.ErrorRegister,
+  };
+
+  uint64_t Constant{};
+  memcpy(&Constant, &State, sizeof(State));
+
+  LoadConstant(x1, Constant);
+  str(x1, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, SynchronousFaultData)));
 
   switch (Op->Reason.Signal) {
   case SIGILL:

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/MiscOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/MiscOps.cpp
@@ -50,11 +50,19 @@ DEF_OP(Break) {
     add(rsp, SpillSlots * MaxSpillSlotSize);
   }
 
-  mov(byte [STATE + offsetof(FEXCore::Core::CpuStateFrame, SynchronousFaultData.FaultToTopAndGeneratedException)], 1);
-  mov(byte [STATE + offsetof(FEXCore::Core::CpuStateFrame, SynchronousFaultData.Signal)], Op->Reason.Signal);
-  mov(dword [STATE + offsetof(FEXCore::Core::CpuStateFrame, SynchronousFaultData.TrapNo)], Op->Reason.TrapNumber);
-  mov(dword [STATE + offsetof(FEXCore::Core::CpuStateFrame, SynchronousFaultData.err_code)], Op->Reason.ErrorRegister);
-  mov(dword [STATE + offsetof(FEXCore::Core::CpuStateFrame, SynchronousFaultData.si_code)], Op->Reason.si_code);
+  Core::CpuStateFrame::SynchronousFaultDataStruct State = {
+    .FaultToTopAndGeneratedException = 1,
+    .Signal = Op->Reason.Signal,
+    .TrapNo = Op->Reason.TrapNumber,
+    .si_code = Op->Reason.si_code,
+    .err_code = Op->Reason.ErrorRegister,
+  };
+
+  uint64_t Constant{};
+  memcpy(&Constant, &State, sizeof(State));
+
+  mov(TMP1, Constant);
+  mov(qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, SynchronousFaultData)], TMP1);
 
   switch (Op->Reason.Signal) {
   case SIGILL:

--- a/External/FEXCore/include/FEXCore/Core/CoreState.h
+++ b/External/FEXCore/include/FEXCore/Core/CoreState.h
@@ -218,12 +218,13 @@ namespace FEXCore::Core {
 
     uint32_t SignalHandlerRefCounter{};
 
-    struct SynchronousFaultDataStruct {
+    struct alignas(8) SynchronousFaultDataStruct {
       bool FaultToTopAndGeneratedException{};
       uint8_t Signal;
-      uint32_t TrapNo;
-      uint32_t err_code;
-      uint32_t si_code;
+      uint8_t TrapNo;
+      uint8_t si_code;
+      uint16_t err_code;
+      uint32_t _pad : 16;
     } SynchronousFaultData;
 
     InternalThreadState* Thread;
@@ -237,6 +238,9 @@ namespace FEXCore::Core {
   static_assert(offsetof(CpuStateFrame, Pointers) + sizeof(CpuStateFrame::Pointers) <= 32760, "JITPointers maximum pointer needs to be less than architecture maximum 32768");
 
   static_assert(std::is_standard_layout<CpuStateFrame>::value, "This needs to be standard layout");
+  static_assert(sizeof(CpuStateFrame::SynchronousFaultData) == 8, "This needs to be 8 bytes");
+  static_assert(std::alignment_of_v<CpuStateFrame::SynchronousFaultDataStruct> == 8, "This needs to be 8 bytes");
+  static_assert(offsetof(CpuStateFrame, SynchronousFaultData) % 8 == 0, "This needs to be aligned");
 
   FEX_DEFAULT_VISIBILITY std::string_view const& GetFlagName(unsigned Flag);
   FEX_DEFAULT_VISIBILITY std::string_view const& GetGRegName(unsigned Reg);


### PR DESCRIPTION
This isn't really a performance issue, more just something that is gross looking at while looking at unit tests.

Break /usually/ isn't abused heavily by games (Except Denuvo) so not really a perf concern regardless.