### PR TITLE
Syscalls: Minor optimization with initialization of syscall definition vector

### DIFF
--- a/Source/Tests/LinuxSyscalls/x32/Syscalls.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Syscalls.cpp
@@ -52,8 +52,6 @@ namespace FEX::HLE::x32 {
   }
 
   void x32SyscallHandler::RegisterSyscallHandlers() {
-    Definitions.resize(FEX::HLE::x32::SYSCALL_x86_MAX);
-
     auto cvt = [](auto in) {
       union {
         decltype(in) val;
@@ -63,10 +61,10 @@ namespace FEX::HLE::x32 {
       return raw.raw;
     };
 
-    for (auto &Def : Definitions) {
-      Def.NumArgs = 255;
-      Def.Ptr = cvt(&UnimplementedSyscall);
-    }
+    Definitions.resize(FEX::HLE::x32::SYSCALL_x86_MAX, SyscallFunctionDefinition {
+      .NumArgs = 255,
+      .Ptr = cvt(&UnimplementedSyscall),
+    });
 
     FEX::HLE::RegisterEpoll(this);
     FEX::HLE::RegisterFD(this);

--- a/Source/Tests/LinuxSyscalls/x64/Syscalls.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Syscalls.cpp
@@ -36,7 +36,6 @@ namespace FEX::HLE::x64 {
   }
 
   void x64SyscallHandler::RegisterSyscallHandlers() {
-    Definitions.resize(FEX::HLE::x64::SYSCALL_x64_MAX);
     auto cvt = [](auto in) {
       union {
         decltype(in) val;
@@ -46,11 +45,10 @@ namespace FEX::HLE::x64 {
       return raw.raw;
     };
 
-    // Clear all definitions
-    for (auto &Def : Definitions) {
-      Def.NumArgs = 255;
-      Def.Ptr = cvt(&UnimplementedSyscall);
-    }
+    Definitions.resize(FEX::HLE::x64::SYSCALL_x64_MAX, SyscallFunctionDefinition {
+      .NumArgs = 255,
+      .Ptr = cvt(&UnimplementedSyscall),
+    });
 
     FEX::HLE::RegisterEpoll(this);
     FEX::HLE::RegisterFD(this);


### PR DESCRIPTION
Shaves a couple milliseconds off initialization time.

Noticed this while poking around.