### PR TITLE
OpcodeDispatcher: Implement SGDT 

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -298,6 +298,8 @@ public:
   void WriteSegmentReg(OpcodeArgs);
   void EnterOp(OpcodeArgs);
 
+  void SGDTOp(OpcodeArgs);
+
   // SSE
   void MOVAPSOp(OpcodeArgs);
   void MOVUPSOp(OpcodeArgs);

--- a/External/FEXCore/Source/Interface/Core/X86Tables/SecondaryGroupTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/SecondaryGroupTables.cpp
@@ -67,7 +67,7 @@ void InitializeSecondaryGroupTables() {
     {OPD(TYPE_GROUP_6, PF_F2, 7), 1, X86InstInfo{"",        TYPE_INVALID, FLAGS_NONE,    0, nullptr}},
 
     // GROUP 7
-    {OPD(TYPE_GROUP_7, PF_NONE, 0), 1, X86InstInfo{"SGDT", TYPE_UNDEC, FLAGS_MODRM | FLAGS_SF_MOD_DST,         0, nullptr}},
+    {OPD(TYPE_GROUP_7, PF_NONE, 0), 1, X86InstInfo{"SGDT", TYPE_INST, FLAGS_MODRM | FLAGS_SF_MOD_DST,         0, nullptr}},
     {OPD(TYPE_GROUP_7, PF_NONE, 1), 1, X86InstInfo{"",     TYPE_SECOND_GROUP_MODRM, FLAGS_NONE, 0, nullptr}},
     {OPD(TYPE_GROUP_7, PF_NONE, 2), 1, X86InstInfo{"",     TYPE_SECOND_GROUP_MODRM, FLAGS_NONE, 0, nullptr}},
     {OPD(TYPE_GROUP_7, PF_NONE, 3), 1, X86InstInfo{"",     TYPE_SECOND_GROUP_MODRM, FLAGS_NONE, 0, nullptr}},
@@ -76,7 +76,7 @@ void InitializeSecondaryGroupTables() {
     {OPD(TYPE_GROUP_7, PF_NONE, 6), 1, X86InstInfo{"LMSW", TYPE_PRIV, FLAGS_MODRM,          0, nullptr}},
     {OPD(TYPE_GROUP_7, PF_NONE, 7), 1, X86InstInfo{"",     TYPE_SECOND_GROUP_MODRM, FLAGS_NONE, 0, nullptr}},
 
-    {OPD(TYPE_GROUP_7, PF_F3, 0), 1, X86InstInfo{"SGDT", TYPE_UNDEC, FLAGS_MODRM | FLAGS_SF_MOD_DST,           0, nullptr}},
+    {OPD(TYPE_GROUP_7, PF_F3, 0), 1, X86InstInfo{"SGDT", TYPE_INST, FLAGS_MODRM | FLAGS_SF_MOD_DST,           0, nullptr}},
     {OPD(TYPE_GROUP_7, PF_F3, 1), 1, X86InstInfo{"",     TYPE_SECOND_GROUP_MODRM, FLAGS_NONE,   0, nullptr}},
     {OPD(TYPE_GROUP_7, PF_F3, 2), 1, X86InstInfo{"",     TYPE_SECOND_GROUP_MODRM, FLAGS_NONE,   0, nullptr}},
     {OPD(TYPE_GROUP_7, PF_F3, 3), 1, X86InstInfo{"",     TYPE_SECOND_GROUP_MODRM, FLAGS_NONE,   0, nullptr}},
@@ -85,7 +85,7 @@ void InitializeSecondaryGroupTables() {
     {OPD(TYPE_GROUP_7, PF_F3, 6), 1, X86InstInfo{"LMSW", TYPE_PRIV, FLAGS_MODRM,            0, nullptr}},
     {OPD(TYPE_GROUP_7, PF_F3, 7), 1, X86InstInfo{"",     TYPE_SECOND_GROUP_MODRM, FLAGS_NONE,   0, nullptr}},
 
-    {OPD(TYPE_GROUP_7, PF_66, 0), 1, X86InstInfo{"SGDT", TYPE_UNDEC, FLAGS_MODRM | FLAGS_SF_MOD_DST,           0, nullptr}},
+    {OPD(TYPE_GROUP_7, PF_66, 0), 1, X86InstInfo{"SGDT", TYPE_INST, FLAGS_MODRM | FLAGS_SF_MOD_DST,           0, nullptr}},
     {OPD(TYPE_GROUP_7, PF_66, 1), 1, X86InstInfo{"",     TYPE_SECOND_GROUP_MODRM, FLAGS_NONE,   0, nullptr}},
     {OPD(TYPE_GROUP_7, PF_66, 2), 1, X86InstInfo{"",     TYPE_SECOND_GROUP_MODRM, FLAGS_NONE,   0, nullptr}},
     {OPD(TYPE_GROUP_7, PF_66, 3), 1, X86InstInfo{"",     TYPE_SECOND_GROUP_MODRM, FLAGS_NONE,   0, nullptr}},
@@ -94,7 +94,7 @@ void InitializeSecondaryGroupTables() {
     {OPD(TYPE_GROUP_7, PF_66, 6), 1, X86InstInfo{"LMSW", TYPE_PRIV, FLAGS_MODRM,            0, nullptr}},
     {OPD(TYPE_GROUP_7, PF_66, 7), 1, X86InstInfo{"",     TYPE_SECOND_GROUP_MODRM, FLAGS_NONE,   0, nullptr}},
 
-    {OPD(TYPE_GROUP_7, PF_F2, 0), 1, X86InstInfo{"SGDT", TYPE_UNDEC, FLAGS_MODRM | FLAGS_SF_MOD_DST,           0, nullptr}},
+    {OPD(TYPE_GROUP_7, PF_F2, 0), 1, X86InstInfo{"SGDT", TYPE_INST, FLAGS_MODRM | FLAGS_SF_MOD_DST,           0, nullptr}},
     {OPD(TYPE_GROUP_7, PF_F2, 1), 1, X86InstInfo{"",     TYPE_SECOND_GROUP_MODRM, FLAGS_NONE,   0, nullptr}},
     {OPD(TYPE_GROUP_7, PF_F2, 2), 1, X86InstInfo{"",     TYPE_SECOND_GROUP_MODRM, FLAGS_NONE,   0, nullptr}},
     {OPD(TYPE_GROUP_7, PF_F2, 3), 1, X86InstInfo{"",     TYPE_SECOND_GROUP_MODRM, FLAGS_NONE,   0, nullptr}},

--- a/unittests/32Bit_ASM/Disabled_Tests_host
+++ b/unittests/32Bit_ASM/Disabled_Tests_host
@@ -10,3 +10,6 @@ Test_32Bit_Primary/Primary_8C_2.asm
 # Hecks with CS
 # Causing our host runner a bit of pain
 Test_32Bit_Primary/Primary_CF.asm
+
+# Zen+ CI doesn't support UMIP so it returns "real" values
+Test_32Bit_Secondary/07_XX_00.asm

--- a/unittests/32Bit_ASM/Secondary/07_XX_00.asm
+++ b/unittests/32Bit_ASM/Secondary/07_XX_00.asm
@@ -1,0 +1,21 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0",
+    "RBX": "0x00000000FFFE0000"
+  },
+  "Mode": "32BIT"
+}
+%endif
+
+sgdt [rel data]
+
+movzx eax, word [rel data]
+mov ebx, dword [rel data + 2]
+hlt
+
+data:
+; Limit
+dw 0
+; Base
+dd 0

--- a/unittests/ASM/Disabled_Tests_host
+++ b/unittests/ASM/Disabled_Tests_host
@@ -12,3 +12,6 @@ Test_Secondary/15_F3_02.asm
 Test_Secondary/15_F3_03.asm
 Test_Secondary/15_F3_02_2.asm
 Test_Secondary/15_F3_03_2.asm
+
+# Zen+ CI doesn't support UMIP so it returns "real" values
+Test_Secondary/07_XX_00.asm

--- a/unittests/ASM/Secondary/07_XX_00.asm
+++ b/unittests/ASM/Secondary/07_XX_00.asm
@@ -1,0 +1,20 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0",
+    "RBX": "0xFFFFFFFFFFFE0000"
+  }
+}
+%endif
+
+sgdt [rel data]
+
+movzx rax, word [rel data]
+mov rbx, qword [rel data + 2]
+hlt
+
+data:
+; Limit
+dw 0
+; Base
+dq 0


### PR DESCRIPTION
Ran in to this when running Team Sonic Racing.
This game uses Denuvo Anti-Tamper which some versions rely on SGDT.

The Linux kernel catches and emulates this instruction.
It will always return a limit of 0 and a base of `0xFFFFFFFFFFFE0000ULL`
which is guaranteed to be in kernel space.

This gets the game slightly farther but still not running entirely.