### PR TITLE
Syscalls: Adds support for rt_sigreturn and sigreturn 

### DIFF
--- a/External/FEXCore/Source/Interface/Context/Context.cpp
+++ b/External/FEXCore/Source/Interface/Context/Context.cpp
@@ -118,6 +118,10 @@ namespace FEXCore::Context {
     CTX->HandleCallback(Thread, RIP);
   }
 
+  void HandleSignalHandlerReturn(FEXCore::Context::Context *CTX, bool RT) {
+    CTX->HandleSignalHandlerReturn(RT);
+  }
+
   void RegisterHostSignalHandler(FEXCore::Context::Context *CTX, int Signal, HostSignalDelegatorFunction Func, bool Required) {
       CTX->RegisterHostSignalHandler(Signal, std::move(Func), Required);
   }

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -172,6 +172,7 @@ namespace FEXCore::Context {
     void StartGdbServer();
     void StopGdbServer();
     void HandleCallback(FEXCore::Core::InternalThreadState *Thread, uint64_t RIP);
+    [[noreturn]] void HandleSignalHandlerReturn(bool RT);
     void RegisterHostSignalHandler(int Signal, HostSignalDelegatorFunction Func, bool Required);
     void RegisterFrontendHostSignalHandler(int Signal, HostSignalDelegatorFunction Func, bool Required);
 

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -305,6 +305,13 @@ namespace FEXCore::Context {
     Thread->CTX->Dispatcher->ExecuteJITCallback(Thread->CurrentFrame, RIP);
   }
 
+  void Context::HandleSignalHandlerReturn(bool RT) {
+    using SignalHandlerReturnFunc = void(*)();
+    SignalHandlerReturnFunc SignalHandlerReturn = reinterpret_cast<SignalHandlerReturnFunc>(Dispatcher->SignalHandlerReturnAddress);
+    SignalHandlerReturn();
+    FEX_UNREACHABLE;
+  }
+
   void Context::RegisterHostSignalHandler(int Signal, HostSignalDelegatorFunction Func, bool Required) {
       SignalDelegation->RegisterHostSignalHandler(Signal, Func, Required);
   }

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
@@ -311,6 +311,14 @@ Arm64Dispatcher::Arm64Dispatcher(FEXCore::Context::Context *ctx, const Dispatche
   }
 
   {
+    SignalHandlerReturnAddressRT = GetCursorAddress<uint64_t>();
+
+    // Now to get back to our old location we need to do a fault dance
+    // We can't use SIGTRAP here since gdb catches it and never gives it to the application!
+    hlt(0);
+  }
+
+  {
     SignalHandlerReturnAddress = GetCursorAddress<uint64_t>();
 
     // Now to get back to our old location we need to do a fault dance
@@ -657,7 +665,8 @@ void Arm64Dispatcher::InitThreadPointers(FEXCore::Core::InternalThreadState *Thr
     Common.GuestSignal_SIGILL = GuestSignal_SIGILL;
     Common.GuestSignal_SIGTRAP = GuestSignal_SIGTRAP;
     Common.GuestSignal_SIGSEGV = GuestSignal_SIGSEGV;
-    Common.SignalReturnHandler = SignalHandlerReturnAddress;
+    Common.SignalHandlerReturnAddressRT = SignalHandlerReturnAddressRT;
+    Common.SignalHandlerReturnAddress = SignalHandlerReturnAddress;
 
     auto &AArch64 = Thread->CurrentFrame->Pointers.AArch64;
     AArch64.LUDIVHandler = LUDIVHandlerAddress;

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
@@ -88,15 +88,61 @@ ArchHelpers::Context::ContextBackup* Dispatcher::StoreThreadState(FEXCore::Core:
   return Context;
 }
 
-void Dispatcher::RestoreThreadState(FEXCore::Core::InternalThreadState *Thread, void *ucontext) {
+void Dispatcher::RestoreThreadState(FEXCore::Core::InternalThreadState *Thread, void *ucontext, RestoreType Type) {
+  const bool Is64BitMode = CTX->Config.Is64BitMode;
   uint64_t OldSP{};
-  if (CTX->Config.Core() == FEXCore::Config::CONFIG_IRJIT) {
-    OldSP = ArchHelpers::Context::GetSp(ucontext);
+
+  if (Type == RestoreType::TYPE_PAUSE) [[unlikely]] {
+    if (CTX->Config.Core() == FEXCore::Config::CONFIG_IRJIT) {
+      OldSP = ArchHelpers::Context::GetSp(ucontext);
+    }
+    else {
+      LOGMAN_THROW_A_FMT(!SignalFrames.empty(), "Trying to restore a signal frame when we don't have any");
+      OldSP = SignalFrames.top();
+      SignalFrames.pop();
+    }
   }
   else {
-    LOGMAN_THROW_A_FMT(!SignalFrames.empty(), "Trying to restore a signal frame when we don't have any");
-    OldSP = SignalFrames.top();
-    SignalFrames.pop();
+    // Some fun introspection here.
+    // We store a pointer to our host-stack on the guest stack.
+    // We need to inspect the guest state coming in, so we can get our host stack back.
+    if (Is64BitMode) {
+      struct rt_frame_x64 {
+        // uint64_t restorer; <-- Ret removes this entry
+        uint64_t StackPointer;
+        // ... Additional after
+      };
+
+      rt_frame_x64 *Frame = reinterpret_cast<rt_frame_x64*>(Thread->CurrentFrame->State.gregs[X86State::REG_RSP]);
+      OldSP = Frame->StackPointer;
+    }
+    else {
+      struct FEX_PACKED rt_frame_x32 {
+        // uint32_t restorer; <-- Ret removes this entry
+        uint32_t Signal;
+        uint32_t SigInfoPtr;
+        uint32_t UContextPtr;
+        uint64_t StackPointer;
+        // ... Additional after
+      };
+
+      struct FEX_PACKED frame_x32 {
+        // uint32_t restorer; <-- Ret removes this entry
+        uint32_t Signal;
+        uint32_t UContextPtr;
+        uint64_t StackPointer;
+        // ... Additional after
+      };
+
+      if (Type == RestoreType::TYPE_RT) {
+        rt_frame_x32 *Frame = reinterpret_cast<rt_frame_x32*>(Thread->CurrentFrame->State.gregs[X86State::REG_RSP]);
+        OldSP = Frame->StackPointer;
+      }
+      else {
+        frame_x32 *Frame = reinterpret_cast<frame_x32*>(Thread->CurrentFrame->State.gregs[X86State::REG_RSP]);
+        OldSP = Frame->StackPointer;
+      }
+    }
   }
 
   const bool IsAVXEnabled = CTX->Config.EnableAVX;
@@ -346,7 +392,6 @@ bool Dispatcher::HandleGuestSignal(FEXCore::Core::InternalThreadState *Thread, i
   // Pulling from context here
   const bool Is64BitMode = CTX->Config.Is64BitMode;
   const bool IsAVXEnabled = CTX->Config.EnableAVX;
-  const uint64_t SignalReturn = CTX->X86CodeGen.SignalReturn;
 
   // Spill the SRA regardless of signal handler type
   // We are going to be returning to the top of the dispatcher which will fill again
@@ -423,226 +468,266 @@ bool Dispatcher::HandleGuestSignal(FEXCore::Core::InternalThreadState *Thread, i
   // Backup where we think the RIP currently is
   ContextBackup->OriginalRIP = Frame->State.rip;
 
-  if (GuestAction->sa_flags & SA_SIGINFO) {
-    // Setup ucontext a bit
-    if (Is64BitMode) {
-      if (IsAVXEnabled) {
-        NewGuestSP -= sizeof(x86_64::xstate);
-        NewGuestSP = AlignDown(NewGuestSP, alignof(x86_64::xstate));
-      } else {
-        NewGuestSP -= sizeof(x86_64::_libc_fpstate);
-        NewGuestSP = AlignDown(NewGuestSP, alignof(x86_64::_libc_fpstate));
-      }
-      uint64_t FPStateLocation = NewGuestSP;
+  // Calculate eflags upfront.
+  uint32_t eflags = 0;
+  for (size_t i = 0; i < Core::CPUState::NUM_EFLAG_BITS; ++i) {
+    eflags |= Frame->State.flags[i] << i;
+  }
 
-      NewGuestSP -= sizeof(FEXCore::x86_64::ucontext_t);
-      NewGuestSP = AlignDown(NewGuestSP, alignof(FEXCore::x86_64::ucontext_t));
-      uint64_t UContextLocation = NewGuestSP;
+  if (Is64BitMode) {
+    // On 64-bit the kernel sets up the siginfo_t and ucontext_t regardless of SA_SIGINFO set.
+    // This allows the application to /always/ get the siginfo and ucontext even if it didn't set this flag.
+    //
+    // Signal frame layout on stack needs to be as follows
+    // void* ReturnPointer
+    // ucontext_t
+    // siginfo_t
+    // FP state
+    if (IsAVXEnabled) {
+      NewGuestSP -= sizeof(x86_64::xstate);
+      NewGuestSP = AlignDown(NewGuestSP, alignof(x86_64::xstate));
+    } else {
+      NewGuestSP -= sizeof(x86_64::_libc_fpstate);
+      NewGuestSP = AlignDown(NewGuestSP, alignof(x86_64::_libc_fpstate));
+    }
+    uint64_t FPStateLocation = NewGuestSP;
 
-      NewGuestSP -= sizeof(siginfo_t);
-      NewGuestSP = AlignDown(NewGuestSP, alignof(siginfo_t));
-      uint64_t SigInfoLocation = NewGuestSP;
+    NewGuestSP -= sizeof(siginfo_t);
+    NewGuestSP = AlignDown(NewGuestSP, alignof(siginfo_t));
+    uint64_t SigInfoLocation = NewGuestSP;
 
-      ContextBackup->FPStateLocation = FPStateLocation;
-      ContextBackup->UContextLocation = UContextLocation;
-      ContextBackup->SigInfoLocation = SigInfoLocation;
+    NewGuestSP -= sizeof(FEXCore::x86_64::ucontext_t);
+    NewGuestSP = AlignDown(NewGuestSP, alignof(FEXCore::x86_64::ucontext_t));
+    uint64_t UContextLocation = NewGuestSP;
 
-      FEXCore::x86_64::ucontext_t *guest_uctx = reinterpret_cast<FEXCore::x86_64::ucontext_t*>(UContextLocation);
-      siginfo_t *guest_siginfo = reinterpret_cast<siginfo_t*>(SigInfoLocation);
+    ContextBackup->FPStateLocation = FPStateLocation;
+    ContextBackup->UContextLocation = UContextLocation;
+    ContextBackup->SigInfoLocation = SigInfoLocation;
 
-      // We have extended float information
-      guest_uctx->uc_flags = FEXCore::x86_64::UC_FP_XSTATE;
+    FEXCore::x86_64::ucontext_t *guest_uctx = reinterpret_cast<FEXCore::x86_64::ucontext_t*>(UContextLocation);
+    siginfo_t *guest_siginfo = reinterpret_cast<siginfo_t*>(SigInfoLocation);
 
-      // Pointer to where the fpreg memory is
-      guest_uctx->uc_mcontext.fpregs = reinterpret_cast<x86_64::_libc_fpstate*>(FPStateLocation);
-      auto *xstate = reinterpret_cast<x86_64::xstate*>(FPStateLocation);
-      SetXStateInfo(xstate, IsAVXEnabled);
+    // We have extended float information
+    guest_uctx->uc_flags = FEXCore::x86_64::UC_FP_XSTATE |
+                           FEXCore::x86_64::UC_SIGCONTEXT_SS |
+                           FEXCore::x86_64::UC_STRICT_RESTORE_SS;
 
-      guest_uctx->uc_mcontext.gregs[FEXCore::x86_64::FEX_REG_RIP] = Frame->State.rip;
-      guest_uctx->uc_mcontext.gregs[FEXCore::x86_64::FEX_REG_EFL] = 0;
-      guest_uctx->uc_mcontext.gregs[FEXCore::x86_64::FEX_REG_CSGSFS] = 0;
+    // Pointer to where the fpreg memory is
+    guest_uctx->uc_mcontext.fpregs = reinterpret_cast<x86_64::_libc_fpstate*>(FPStateLocation);
+    auto *xstate = reinterpret_cast<x86_64::xstate*>(FPStateLocation);
+    SetXStateInfo(xstate, IsAVXEnabled);
 
-      // aarch64 and x86_64 siginfo_t matches. We can just copy this over
-      // SI_USER could also potentially have random data in it, needs to be bit perfect
-      // For guest faults we don't have a real way to reconstruct state to a real guest RIP
-      *guest_siginfo = *HostSigInfo;
+    guest_uctx->uc_mcontext.gregs[FEXCore::x86_64::FEX_REG_RIP] = Frame->State.rip;
+    guest_uctx->uc_mcontext.gregs[FEXCore::x86_64::FEX_REG_EFL] = eflags;
+    guest_uctx->uc_mcontext.gregs[FEXCore::x86_64::FEX_REG_CSGSFS] = 0;
 
-      if (ContextBackup->FaultToTopAndGeneratedException) {
-        guest_uctx->uc_mcontext.gregs[FEXCore::x86_64::FEX_REG_TRAPNO] = Frame->SynchronousFaultData.TrapNo;
-        guest_uctx->uc_mcontext.gregs[FEXCore::x86_64::FEX_REG_ERR] = Frame->SynchronousFaultData.err_code;
+    // aarch64 and x86_64 siginfo_t matches. We can just copy this over
+    // SI_USER could also potentially have random data in it, needs to be bit perfect
+    // For guest faults we don't have a real way to reconstruct state to a real guest RIP
+    *guest_siginfo = *HostSigInfo;
+    if (ContextBackup->FaultToTopAndGeneratedException) {
+      // Overwrite si_code
+      guest_siginfo->si_code = Thread->CurrentFrame->SynchronousFaultData.si_code;
+    }
 
-        // Overwrite si_code
-        guest_siginfo->si_code = Thread->CurrentFrame->SynchronousFaultData.si_code;
-        Signal = Frame->SynchronousFaultData.Signal;
-      }
-      else {
-        guest_uctx->uc_mcontext.gregs[FEXCore::x86_64::FEX_REG_TRAPNO] = ConvertSignalToTrapNo(Signal, HostSigInfo);
-        guest_uctx->uc_mcontext.gregs[FEXCore::x86_64::FEX_REG_ERR] = ConvertSignalToError(Signal, HostSigInfo);
-      }
-      guest_uctx->uc_mcontext.gregs[FEXCore::x86_64::FEX_REG_OLDMASK] = 0;
-      guest_uctx->uc_mcontext.gregs[FEXCore::x86_64::FEX_REG_CR2] = 0;
+    if (ContextBackup->FaultToTopAndGeneratedException) {
+      guest_uctx->uc_mcontext.gregs[FEXCore::x86_64::FEX_REG_TRAPNO] = Frame->SynchronousFaultData.TrapNo;
+      guest_uctx->uc_mcontext.gregs[FEXCore::x86_64::FEX_REG_ERR] = Frame->SynchronousFaultData.err_code;
 
-#define COPY_REG(x) \
-      guest_uctx->uc_mcontext.gregs[FEXCore::x86_64::FEX_REG_##x] = Frame->State.gregs[X86State::REG_##x];
-      COPY_REG(R8);
-      COPY_REG(R9);
-      COPY_REG(R10);
-      COPY_REG(R11);
-      COPY_REG(R12);
-      COPY_REG(R13);
-      COPY_REG(R14);
-      COPY_REG(R15);
-      COPY_REG(RDI);
-      COPY_REG(RSI);
-      COPY_REG(RBP);
-      COPY_REG(RBX);
-      COPY_REG(RDX);
-      COPY_REG(RAX);
-      COPY_REG(RCX);
-      COPY_REG(RSP);
-#undef COPY_REG
-
-      auto* fpstate = &xstate->fpstate;
-
-      // Copy float registers
-      memcpy(fpstate->_st, Frame->State.mm, sizeof(Frame->State.mm));
-
-      if (IsAVXEnabled) {
-        for (size_t i = 0; i < Core::CPUState::NUM_XMMS; i++) {
-          memcpy(&fpstate->_xmm[i], &Frame->State.xmm.avx.data[i][0], sizeof(__uint128_t));
-        }
-        for (size_t i = 0; i < Core::CPUState::NUM_XMMS; i++) {
-          memcpy(&xstate->ymmh.ymmh_space[i], &Frame->State.xmm.avx.data[i][2], sizeof(__uint128_t));
-        }
-      } else {
-        memcpy(fpstate->_xmm, Frame->State.xmm.sse.data, sizeof(Frame->State.xmm.sse.data));
-      }
-
-      // FCW store default
-      fpstate->fcw = Frame->State.FCW;
-      fpstate->ftw = Frame->State.FTW;
-
-      // Reconstruct FSW
-      fpstate->fsw =
-        (Frame->State.flags[FEXCore::X86State::X87FLAG_TOP_LOC] << 11) |
-        (Frame->State.flags[FEXCore::X86State::X87FLAG_C0_LOC] << 8) |
-        (Frame->State.flags[FEXCore::X86State::X87FLAG_C1_LOC] << 9) |
-        (Frame->State.flags[FEXCore::X86State::X87FLAG_C2_LOC] << 10) |
-        (Frame->State.flags[FEXCore::X86State::X87FLAG_C3_LOC] << 14);
-
-      // Copy over signal stack information
-      guest_uctx->uc_stack.ss_flags = GuestStack->ss_flags;
-      guest_uctx->uc_stack.ss_sp = GuestStack->ss_sp;
-      guest_uctx->uc_stack.ss_size = GuestStack->ss_size;
-
-      Frame->State.gregs[X86State::REG_RSI] = SigInfoLocation;
-      Frame->State.gregs[X86State::REG_RDX] = UContextLocation;
+      Signal = Frame->SynchronousFaultData.Signal;
     }
     else {
-      ContextBackup->Flags |= ArchHelpers::Context::ContextFlags::CONTEXT_FLAG_32BIT;
-
-      if (IsAVXEnabled) {
-        NewGuestSP -= sizeof(x86::xstate);
-        NewGuestSP = AlignDown(NewGuestSP, alignof(x86::xstate));
-      } else {
-        NewGuestSP -= sizeof(x86::_libc_fpstate);
-        NewGuestSP = AlignDown(NewGuestSP, alignof(x86::_libc_fpstate));
-      }
-      uint64_t FPStateLocation = NewGuestSP;
-
-      NewGuestSP -= sizeof(FEXCore::x86::ucontext_t);
-      NewGuestSP = AlignDown(NewGuestSP, alignof(FEXCore::x86::ucontext_t));
-      uint64_t UContextLocation = NewGuestSP;
-
-      NewGuestSP -= sizeof(FEXCore::x86::siginfo_t);
-      NewGuestSP = AlignDown(NewGuestSP, alignof(FEXCore::x86::siginfo_t));
-      uint64_t SigInfoLocation = NewGuestSP;
-
-      ContextBackup->FPStateLocation = FPStateLocation;
-      ContextBackup->UContextLocation = UContextLocation;
-      ContextBackup->SigInfoLocation = SigInfoLocation;
-
-      FEXCore::x86::ucontext_t *guest_uctx = reinterpret_cast<FEXCore::x86::ucontext_t*>(UContextLocation);
-      FEXCore::x86::siginfo_t *guest_siginfo = reinterpret_cast<FEXCore::x86::siginfo_t*>(SigInfoLocation);
-
-      // We have extended float information
-      guest_uctx->uc_flags = FEXCore::x86::UC_FP_XSTATE;
-
-      // Pointer to where the fpreg memory is
-      guest_uctx->uc_mcontext.fpregs = static_cast<uint32_t>(FPStateLocation);
-      auto *xstate = reinterpret_cast<x86::xstate*>(FPStateLocation);
-      SetXStateInfo(xstate, IsAVXEnabled);
-
-      guest_uctx->uc_mcontext.gregs[FEXCore::x86::FEX_REG_CS] = Frame->State.cs_idx;
-      guest_uctx->uc_mcontext.gregs[FEXCore::x86::FEX_REG_DS] = Frame->State.ds_idx;
-      guest_uctx->uc_mcontext.gregs[FEXCore::x86::FEX_REG_ES] = Frame->State.es_idx;
-      guest_uctx->uc_mcontext.gregs[FEXCore::x86::FEX_REG_FS] = Frame->State.fs_idx;
-      guest_uctx->uc_mcontext.gregs[FEXCore::x86::FEX_REG_GS] = Frame->State.gs_idx;
-      guest_uctx->uc_mcontext.gregs[FEXCore::x86::FEX_REG_SS] = Frame->State.ss_idx;
-
-      if (ContextBackup->FaultToTopAndGeneratedException) {
-        guest_uctx->uc_mcontext.gregs[FEXCore::x86::FEX_REG_TRAPNO] = Frame->SynchronousFaultData.TrapNo;
-        guest_siginfo->si_code = Frame->SynchronousFaultData.si_code;
-        guest_uctx->uc_mcontext.gregs[FEXCore::x86::FEX_REG_ERR] = Frame->SynchronousFaultData.err_code;
-        Signal = Frame->SynchronousFaultData.Signal;
-      }
-      else {
-        guest_uctx->uc_mcontext.gregs[FEXCore::x86::FEX_REG_TRAPNO] = ConvertSignalToTrapNo(Signal, HostSigInfo);
-        guest_siginfo->si_code = HostSigInfo->si_code;
-        guest_uctx->uc_mcontext.gregs[FEXCore::x86::FEX_REG_ERR] = ConvertSignalToError(Signal, HostSigInfo);
-      }
-      guest_uctx->uc_mcontext.gregs[FEXCore::x86::FEX_REG_EIP] = Frame->State.rip;
-      guest_uctx->uc_mcontext.gregs[FEXCore::x86::FEX_REG_EFL] = 0;
-      guest_uctx->uc_mcontext.gregs[FEXCore::x86::FEX_REG_UESP] = 0;
+      guest_uctx->uc_mcontext.gregs[FEXCore::x86_64::FEX_REG_TRAPNO] = ConvertSignalToTrapNo(Signal, HostSigInfo);
+      guest_uctx->uc_mcontext.gregs[FEXCore::x86_64::FEX_REG_ERR] = ConvertSignalToError(Signal, HostSigInfo);
+    }
+    guest_uctx->uc_mcontext.gregs[FEXCore::x86_64::FEX_REG_OLDMASK] = 0;
+    guest_uctx->uc_mcontext.gregs[FEXCore::x86_64::FEX_REG_CR2] = 0;
 
 #define COPY_REG(x) \
-      guest_uctx->uc_mcontext.gregs[FEXCore::x86::FEX_REG_##x] = Frame->State.gregs[X86State::REG_##x];
-      COPY_REG(RDI);
-      COPY_REG(RSI);
-      COPY_REG(RBP);
-      COPY_REG(RBX);
-      COPY_REG(RDX);
-      COPY_REG(RAX);
-      COPY_REG(RCX);
-      COPY_REG(RSP);
+    guest_uctx->uc_mcontext.gregs[FEXCore::x86_64::FEX_REG_##x] = Frame->State.gregs[X86State::REG_##x];
+    COPY_REG(R8);
+    COPY_REG(R9);
+    COPY_REG(R10);
+    COPY_REG(R11);
+    COPY_REG(R12);
+    COPY_REG(R13);
+    COPY_REG(R14);
+    COPY_REG(R15);
+    COPY_REG(RDI);
+    COPY_REG(RSI);
+    COPY_REG(RBP);
+    COPY_REG(RBX);
+    COPY_REG(RDX);
+    COPY_REG(RAX);
+    COPY_REG(RCX);
+    COPY_REG(RSP);
 #undef COPY_REG
 
-      auto *fpstate = &xstate->fpstate;
+    auto* fpstate = &xstate->fpstate;
 
-      // Copy float registers
-      for (size_t i = 0; i < Core::CPUState::NUM_MMS; ++i) {
-        // 32-bit st register size is only 10 bytes. Not padded to 16byte like x86-64
-        memcpy(&fpstate->_st[i], &Frame->State.mm[i], 10);
+    // Copy float registers
+    memcpy(fpstate->_st, Frame->State.mm, sizeof(Frame->State.mm));
+
+    if (IsAVXEnabled) {
+      for (size_t i = 0; i < Core::CPUState::NUM_XMMS; i++) {
+        memcpy(&fpstate->_xmm[i], &Frame->State.xmm.avx.data[i][0], sizeof(__uint128_t));
       }
-
-      // Extended XMM state
-      fpstate->status = FEXCore::x86::fpstate_magic::MAGIC_XFPSTATE;
-      if (IsAVXEnabled) {
-        for (size_t i = 0; i < std::size(Frame->State.xmm.avx.data); i++) {
-          memcpy(&fpstate->_xmm[i], &Frame->State.xmm.avx.data[i][0], sizeof(__uint128_t));
-        }
-        for (size_t i = 0; i < std::size(Frame->State.xmm.avx.data); i++) {
-          memcpy(&xstate->ymmh.ymmh_space[i], &Frame->State.xmm.avx.data[i][2], sizeof(__uint128_t));
-        }
-      } else {
-        memcpy(fpstate->_xmm, Frame->State.xmm.sse.data, sizeof(Frame->State.xmm.sse.data));
+      for (size_t i = 0; i < Core::CPUState::NUM_XMMS; i++) {
+        memcpy(&xstate->ymmh.ymmh_space[i], &Frame->State.xmm.avx.data[i][2], sizeof(__uint128_t));
       }
+    } else {
+      memcpy(fpstate->_xmm, Frame->State.xmm.sse.data, sizeof(Frame->State.xmm.sse.data));
+    }
 
-      // FCW store default
-      fpstate->fcw = Frame->State.FCW;
-      fpstate->ftw = Frame->State.FTW;
-      // Reconstruct FSW
-      fpstate->fsw =
-        (Frame->State.flags[FEXCore::X86State::X87FLAG_TOP_LOC] << 11) |
-        (Frame->State.flags[FEXCore::X86State::X87FLAG_C0_LOC] << 8) |
-        (Frame->State.flags[FEXCore::X86State::X87FLAG_C1_LOC] << 9) |
-        (Frame->State.flags[FEXCore::X86State::X87FLAG_C2_LOC] << 10) |
-        (Frame->State.flags[FEXCore::X86State::X87FLAG_C3_LOC] << 14);
+    // FCW store default
+    fpstate->fcw = Frame->State.FCW;
+    fpstate->ftw = Frame->State.FTW;
 
-      // Copy over signal stack information
-      guest_uctx->uc_stack.ss_flags = GuestStack->ss_flags;
-      guest_uctx->uc_stack.ss_sp = static_cast<uint32_t>(reinterpret_cast<uint64_t>(GuestStack->ss_sp));
-      guest_uctx->uc_stack.ss_size = GuestStack->ss_size;
+    // Reconstruct FSW
+    fpstate->fsw =
+      (Frame->State.flags[FEXCore::X86State::X87FLAG_TOP_LOC] << 11) |
+      (Frame->State.flags[FEXCore::X86State::X87FLAG_C0_LOC] << 8) |
+      (Frame->State.flags[FEXCore::X86State::X87FLAG_C1_LOC] << 9) |
+      (Frame->State.flags[FEXCore::X86State::X87FLAG_C2_LOC] << 10) |
+      (Frame->State.flags[FEXCore::X86State::X87FLAG_C3_LOC] << 14);
+
+    // Copy over signal stack information
+    guest_uctx->uc_stack.ss_flags = GuestStack->ss_flags;
+    guest_uctx->uc_stack.ss_sp = GuestStack->ss_sp;
+    guest_uctx->uc_stack.ss_size = GuestStack->ss_size;
+
+    // Apparently RAX is always set to zero in case of badly misbehaving C applications and variadics.
+    Frame->State.gregs[X86State::REG_RAX] = 0;
+    Frame->State.gregs[X86State::REG_RDI] = Signal;
+    Frame->State.gregs[X86State::REG_RSI] = SigInfoLocation;
+    Frame->State.gregs[X86State::REG_RDX] = UContextLocation;
+
+    // Store the host stack context backup directly in the guest stack.
+    // This allows us to restore host state if we come back through rt_sigreturn.
+    NewGuestSP -= 8;
+    *(uint64_t*)NewGuestSP = (uint64_t)ContextBackup;
+
+    // Host is required to provide us a restorer.
+    // if the guest didn't provide a restorer then the application fails with a SIGSEGV.
+    // TODO: Emulate the SIGSEGV when guest doesn't provide a restorer.
+    NewGuestSP -= 8;
+    *(uint64_t*)NewGuestSP = (uint64_t)GuestAction->restorer;
+  }
+  else {
+    ContextBackup->Flags |= ArchHelpers::Context::ContextFlags::CONTEXT_FLAG_32BIT;
+
+    if (IsAVXEnabled) {
+      NewGuestSP -= sizeof(x86::xstate);
+      NewGuestSP = AlignDown(NewGuestSP, alignof(x86::xstate));
+    } else {
+      NewGuestSP -= sizeof(x86::_libc_fpstate);
+      NewGuestSP = AlignDown(NewGuestSP, alignof(x86::_libc_fpstate));
+    }
+    uint64_t FPStateLocation = NewGuestSP;
+
+    NewGuestSP -= sizeof(FEXCore::x86::ucontext_t);
+    NewGuestSP = AlignDown(NewGuestSP, alignof(FEXCore::x86::ucontext_t));
+    uint64_t UContextLocation = NewGuestSP;
+
+    uint64_t SigInfoLocation{};
+    FEXCore::x86::siginfo_t *guest_siginfo{};
+    if (GuestAction->sa_flags & SA_SIGINFO) {
+      NewGuestSP -= sizeof(FEXCore::x86::siginfo_t);
+      NewGuestSP = AlignDown(NewGuestSP, alignof(FEXCore::x86::siginfo_t));
+      SigInfoLocation = NewGuestSP;
+      guest_siginfo = reinterpret_cast<FEXCore::x86::siginfo_t*>(SigInfoLocation);
+    }
+
+    ContextBackup->FPStateLocation = FPStateLocation;
+    ContextBackup->UContextLocation = UContextLocation;
+    ContextBackup->SigInfoLocation = SigInfoLocation;
+
+    FEXCore::x86::ucontext_t *guest_uctx = reinterpret_cast<FEXCore::x86::ucontext_t*>(UContextLocation);
+
+    // We have extended float information
+    guest_uctx->uc_flags = FEXCore::x86::UC_FP_XSTATE;
+
+    // Pointer to where the fpreg memory is
+    guest_uctx->uc_mcontext.fpregs = static_cast<uint32_t>(FPStateLocation);
+    auto *xstate = reinterpret_cast<x86::xstate*>(FPStateLocation);
+    SetXStateInfo(xstate, IsAVXEnabled);
+
+    guest_uctx->uc_mcontext.gregs[FEXCore::x86::FEX_REG_CS] = Frame->State.cs_idx;
+    guest_uctx->uc_mcontext.gregs[FEXCore::x86::FEX_REG_DS] = Frame->State.ds_idx;
+    guest_uctx->uc_mcontext.gregs[FEXCore::x86::FEX_REG_ES] = Frame->State.es_idx;
+    guest_uctx->uc_mcontext.gregs[FEXCore::x86::FEX_REG_FS] = Frame->State.fs_idx;
+    guest_uctx->uc_mcontext.gregs[FEXCore::x86::FEX_REG_GS] = Frame->State.gs_idx;
+    guest_uctx->uc_mcontext.gregs[FEXCore::x86::FEX_REG_SS] = Frame->State.ss_idx;
+
+    if (ContextBackup->FaultToTopAndGeneratedException) {
+      guest_uctx->uc_mcontext.gregs[FEXCore::x86::FEX_REG_TRAPNO] = Frame->SynchronousFaultData.TrapNo;
+      guest_uctx->uc_mcontext.gregs[FEXCore::x86::FEX_REG_ERR] = Frame->SynchronousFaultData.err_code;
+      Signal = Frame->SynchronousFaultData.Signal;
+    }
+    else {
+      guest_uctx->uc_mcontext.gregs[FEXCore::x86::FEX_REG_TRAPNO] = ConvertSignalToTrapNo(Signal, HostSigInfo);
+      guest_uctx->uc_mcontext.gregs[FEXCore::x86::FEX_REG_ERR] = ConvertSignalToError(Signal, HostSigInfo);
+    }
+    guest_uctx->uc_mcontext.gregs[FEXCore::x86::FEX_REG_EIP] = Frame->State.rip;
+    guest_uctx->uc_mcontext.gregs[FEXCore::x86::FEX_REG_EFL] = eflags;
+    guest_uctx->uc_mcontext.gregs[FEXCore::x86::FEX_REG_UESP] = 0;
+
+#define COPY_REG(x) \
+    guest_uctx->uc_mcontext.gregs[FEXCore::x86::FEX_REG_##x] = Frame->State.gregs[X86State::REG_##x];
+    COPY_REG(RDI);
+    COPY_REG(RSI);
+    COPY_REG(RBP);
+    COPY_REG(RBX);
+    COPY_REG(RDX);
+    COPY_REG(RAX);
+    COPY_REG(RCX);
+    COPY_REG(RSP);
+#undef COPY_REG
+
+    auto *fpstate = &xstate->fpstate;
+
+    // Copy float registers
+    for (size_t i = 0; i < Core::CPUState::NUM_MMS; ++i) {
+      // 32-bit st register size is only 10 bytes. Not padded to 16byte like x86-64
+      memcpy(&fpstate->_st[i], &Frame->State.mm[i], 10);
+    }
+
+    // Extended XMM state
+    fpstate->status = FEXCore::x86::fpstate_magic::MAGIC_XFPSTATE;
+    if (IsAVXEnabled) {
+      for (size_t i = 0; i < std::size(Frame->State.xmm.avx.data); i++) {
+        memcpy(&fpstate->_xmm[i], &Frame->State.xmm.avx.data[i][0], sizeof(__uint128_t));
+      }
+      for (size_t i = 0; i < std::size(Frame->State.xmm.avx.data); i++) {
+        memcpy(&xstate->ymmh.ymmh_space[i], &Frame->State.xmm.avx.data[i][2], sizeof(__uint128_t));
+      }
+    } else {
+      memcpy(fpstate->_xmm, Frame->State.xmm.sse.data, sizeof(Frame->State.xmm.sse.data));
+    }
+
+    // FCW store default
+    fpstate->fcw = Frame->State.FCW;
+    fpstate->ftw = Frame->State.FTW;
+    // Reconstruct FSW
+    fpstate->fsw =
+      (Frame->State.flags[FEXCore::X86State::X87FLAG_TOP_LOC] << 11) |
+      (Frame->State.flags[FEXCore::X86State::X87FLAG_C0_LOC] << 8) |
+      (Frame->State.flags[FEXCore::X86State::X87FLAG_C1_LOC] << 9) |
+      (Frame->State.flags[FEXCore::X86State::X87FLAG_C2_LOC] << 10) |
+      (Frame->State.flags[FEXCore::X86State::X87FLAG_C3_LOC] << 14);
+
+    // Copy over signal stack information
+    guest_uctx->uc_stack.ss_flags = GuestStack->ss_flags;
+    guest_uctx->uc_stack.ss_sp = static_cast<uint32_t>(reinterpret_cast<uint64_t>(GuestStack->ss_sp));
+    guest_uctx->uc_stack.ss_size = GuestStack->ss_size;
+
+    if (GuestAction->sa_flags & SA_SIGINFO) {
+      if (ContextBackup->FaultToTopAndGeneratedException) {
+        guest_siginfo->si_code = Frame->SynchronousFaultData.si_code;
+      }
+      else {
+        guest_siginfo->si_code = HostSigInfo->si_code;
+      }
 
       // These three elements are in every siginfo
       guest_siginfo->si_signo = HostSigInfo->si_signo;
@@ -678,40 +763,38 @@ bool Dispatcher::HandleGuestSignal(FEXCore::Core::InternalThreadState *Thread, i
           LogMan::Msg::EFmt("Unhandled siginfo_t for signal: {}\n", Signal);
           break;
       }
+    }
 
-      NewGuestSP -= 4;
-      *(uint32_t*)NewGuestSP = UContextLocation;
+    // Store the host stack context backup directly in the guest stack.
+    // This allows us to restore host state if we come back through rt_sigreturn.
+    NewGuestSP -= 8;
+    *(uint64_t*)NewGuestSP = (uint64_t)ContextBackup;
+
+    NewGuestSP -= 4;
+    *(uint32_t*)NewGuestSP = UContextLocation;
+
+    if (GuestAction->sa_flags & SA_SIGINFO) {
       NewGuestSP -= 4;
       *(uint32_t*)NewGuestSP = SigInfoLocation;
-      NewGuestSP -= 4;
-      *(uint32_t*)NewGuestSP = Signal;
     }
-
-    Frame->State.rip = reinterpret_cast<uint64_t>(GuestAction->sigaction_handler.sigaction);
-  }
-  else {
-    if (!Is64BitMode) {
-      NewGuestSP -= 4;
-      *(uint32_t*)NewGuestSP = Signal;
-    }
-
-    Frame->State.rip = reinterpret_cast<uint64_t>(GuestAction->sigaction_handler.handler);
-  }
-
-  if (Is64BitMode) {
-    Frame->State.gregs[FEXCore::X86State::REG_RDI] = Signal;
-
-    // Set up the new SP for stack handling
-    NewGuestSP -= 8;
-    *(uint64_t*)NewGuestSP = SignalReturn;
-    Frame->State.gregs[FEXCore::X86State::REG_RSP] = NewGuestSP;
-  }
-  else {
     NewGuestSP -= 4;
-    *(uint32_t*)NewGuestSP = SignalReturn;
-    LOGMAN_THROW_AA_FMT(SignalReturn < 0x1'0000'0000ULL, "This needs to be below 4GB");
-    Frame->State.gregs[FEXCore::X86State::REG_RSP] = NewGuestSP;
+    *(uint32_t*)NewGuestSP = Signal;
+
+    NewGuestSP -= 4;
+
+    // Guest can provide its own restorer or we need to provide our own.
+    // On a real host this restorer will live in VDSO.
+    if (GuestAction->restorer) {
+      *(uint32_t*)NewGuestSP = (uint32_t)(uint64_t)GuestAction->restorer;
+    }
+    else {
+      const uint32_t SignalReturn = CTX->X86CodeGen.x32_rt_sigreturn;
+      *(uint32_t*)NewGuestSP = SignalReturn;
+    }
   }
+
+  Frame->State.rip = reinterpret_cast<uint64_t>(GuestAction->sigaction_handler.sigaction);
+  Frame->State.gregs[FEXCore::X86State::REG_RSP] = NewGuestSP;
 
   // The guest starts its signal frame with a zero initialized FPU
   // Set that up now. Little bit costly but it's a requirement
@@ -726,8 +809,10 @@ bool Dispatcher::HandleGuestSignal(FEXCore::Core::InternalThreadState *Thread, i
 
 bool Dispatcher::HandleSIGILL(FEXCore::Core::InternalThreadState *Thread, int Signal, void *info, void *ucontext) {
 
-  if (ArchHelpers::Context::GetPc(ucontext) == SignalHandlerReturnAddress) {
-    RestoreThreadState(Thread, ucontext);
+  if (ArchHelpers::Context::GetPc(ucontext) == SignalHandlerReturnAddressRT ||
+      ArchHelpers::Context::GetPc(ucontext) == SignalHandlerReturnAddress) {
+    RestoreThreadState(Thread, ucontext,
+      ArchHelpers::Context::GetPc(ucontext) == SignalHandlerReturnAddressRT ? RestoreType::TYPE_RT : RestoreType::TYPE_NONRT);
 
     // Ref count our faults
     // We use this to track if it is safe to clear cache
@@ -736,7 +821,7 @@ bool Dispatcher::HandleSIGILL(FEXCore::Core::InternalThreadState *Thread, int Si
   }
 
   if (ArchHelpers::Context::GetPc(ucontext) == PauseReturnInstruction) {
-    RestoreThreadState(Thread, ucontext);
+    RestoreThreadState(Thread, ucontext, RestoreType::TYPE_PAUSE);
 
     // Ref count our faults
     // We use this to track if it is safe to clear cache
@@ -808,17 +893,6 @@ bool Dispatcher::HandleSignalPause(FEXCore::Core::InternalThreadState *Thread, i
       // Reincrement it here to not break logic
       ++Thread->CTX->IdleWaitRefCount;
     }
-
-    Thread->SignalReason.store(FEXCore::Core::SignalEvent::Nothing);
-    return true;
-  }
-
-  if (SignalReason == FEXCore::Core::SignalEvent::Return) {
-    RestoreThreadState(Thread, ucontext);
-
-    // Ref count our faults
-    // We use this to track if it is safe to clear cache
-    --Thread->CurrentFrame->SignalHandlerRefCounter;
 
     Thread->SignalReason.store(FEXCore::Core::SignalEvent::Nothing);
     return true;

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
@@ -43,6 +43,7 @@ public:
   uint64_t ThreadPauseHandlerAddress{};
   uint64_t ThreadPauseHandlerAddressSpillSRA{};
   uint64_t ExitFunctionLinkerAddress{};
+  uint64_t SignalHandlerReturnAddressRT{};
   uint64_t SignalHandlerReturnAddress{};
   uint64_t GuestSignal_SIGILL{};
   uint64_t GuestSignal_SIGTRAP{};
@@ -91,7 +92,12 @@ protected:
     {}
 
   ArchHelpers::Context::ContextBackup* StoreThreadState(FEXCore::Core::InternalThreadState *Thread, int Signal, void *ucontext);
-  void RestoreThreadState(FEXCore::Core::InternalThreadState *Thread, void *ucontext);
+  enum RestoreType {
+    TYPE_RT,
+    TYPE_NONRT,
+    TYPE_PAUSE,
+  };
+  void RestoreThreadState(FEXCore::Core::InternalThreadState *Thread, void *ucontext, RestoreType Type);
   std::stack<uint64_t, std::vector<uint64_t>> SignalFrames;
 
   virtual void SpillSRA(FEXCore::Core::InternalThreadState *Thread, void *ucontext, uint32_t IgnoreMask) {}

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/X86Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/X86Dispatcher.cpp
@@ -340,6 +340,12 @@ X86Dispatcher::X86Dispatcher(FEXCore::Context::Context *ctx, const DispatcherCon
 
   {
     // Signal return handler
+    SignalHandlerReturnAddressRT = getCurr<uint64_t>();
+    ud2();
+  }
+
+  {
+    // Signal return handler
     SignalHandlerReturnAddress = getCurr<uint64_t>();
     ud2();
   }
@@ -485,7 +491,8 @@ void X86Dispatcher::InitThreadPointers(FEXCore::Core::InternalThreadState *Threa
     Common.GuestSignal_SIGILL = GuestSignal_SIGILL;
     Common.GuestSignal_SIGTRAP = GuestSignal_SIGTRAP;
     Common.GuestSignal_SIGSEGV = GuestSignal_SIGSEGV;
-    Common.SignalReturnHandler = SignalHandlerReturnAddress;
+    Common.SignalHandlerReturnAddressRT = SignalHandlerReturnAddressRT;
+    Common.SignalHandlerReturnAddress = SignalHandlerReturnAddress;
 
     auto &Interpreter = Thread->CurrentFrame->Pointers.Interpreter;
     (uintptr_t&)Interpreter.CallbackReturn = IntCallbackReturnAddress;

--- a/External/FEXCore/Source/Interface/Core/Interpreter/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/BranchOps.cpp
@@ -17,19 +17,7 @@ $end_info$
 #include <unistd.h>
 
 namespace FEXCore::CPU {
-[[noreturn]]
-static void SignalReturn(FEXCore::Core::InternalThreadState *Thread) {
-  Thread->CTX->SignalThread(Thread, FEXCore::Core::SignalEvent::Return);
-
-  LOGMAN_MSG_A_FMT("unreachable");
-  FEX_UNREACHABLE;
-}
-
 #define DEF_OP(x) void InterpreterOps::Op_##x(IR::IROp_Header *IROp, IROpData *Data, IR::NodeID Node)
-
-DEF_OP(SignalReturn) {
-  SignalReturn(Data->State);
-}
 
 DEF_OP(CallbackReturn) {
   Data->State->CurrentFrame->Pointers.Interpreter.CallbackReturn(Data->State, Data->StackEntry);

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -113,7 +113,6 @@ constexpr OpHandlerArray InterpreterOpHandlers = [] {
   REGISTER_OP(ATOMICFETCHNEG,         AtomicFetchNeg);
 
   // Branch ops
-  REGISTER_OP(SIGNALRETURN,           SignalReturn);
   REGISTER_OP(CALLBACKRETURN,         CallbackReturn);
   REGISTER_OP(EXITFUNCTION,           ExitFunction);
   REGISTER_OP(JUMP,                   Jump);

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
@@ -142,7 +142,6 @@ namespace FEXCore::CPU {
   DEF_OP(AtomicFetchNeg);
 
   ///< Branch ops
-  DEF_OP(SignalReturn);
   DEF_OP(CallbackReturn);
   DEF_OP(ExitFunction);
   DEF_OP(Jump);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
@@ -21,16 +21,6 @@ using namespace vixl;
 using namespace vixl::aarch64;
 #define DEF_OP(x) void Arm64JITCore::Op_##x(IR::IROp_Header *IROp, IR::NodeID Node)
 
-DEF_OP(SignalReturn) {
-  // First we must reset the stack
-  ResetStack();
-
-  // Now branch to our signal return helper
-  // This can't be a direct branch since the code needs to live at a constant location
-  ldr(x0, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.SignalReturnHandler)));
-  br(x0);
-}
-
 DEF_OP(CallbackReturn) {
 
   // spill back to CTX
@@ -498,7 +488,6 @@ DEF_OP(CPUID) {
 #undef DEF_OP
 void Arm64JITCore::RegisterBranchHandlers() {
 #define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &Arm64JITCore::Op_##x
-  REGISTER_OP(SIGNALRETURN,      SignalReturn);
   REGISTER_OP(CALLBACKRETURN,    CallbackReturn);
   REGISTER_OP(EXITFUNCTION,      ExitFunction);
   REGISTER_OP(JUMP,              Jump);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -302,7 +302,6 @@ private:
   DEF_OP(AtomicFetchNeg);
 
   ///< Branch ops
-  DEF_OP(SignalReturn);
   DEF_OP(CallbackReturn);
   DEF_OP(ExitFunction);
   DEF_OP(Jump);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
@@ -30,15 +30,6 @@ $end_info$
 namespace FEXCore::CPU {
 #define DEF_OP(x) void X86JITCore::Op_##x(IR::IROp_Header *IROp, IR::NodeID Node)
 
-DEF_OP(SignalReturn) {
-  // Adjust the stack first for a regular return
-  if (SpillSlots) {
-    add(rsp, SpillSlots * MaxSpillSlotSize); // + 8 to consume return address
-  }
-
-  jmp(qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.SignalReturnHandler)]);
-}
-
 DEF_OP(CallbackReturn) {
   // Adjust the stack first for a regular return
   if (SpillSlots) {
@@ -314,7 +305,6 @@ DEF_OP(CPUID) {
 #undef DEF_OP
 void X86JITCore::RegisterBranchHandlers() {
 #define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &X86JITCore::Op_##x
-  REGISTER_OP(SIGNALRETURN,      SignalReturn);
   REGISTER_OP(CALLBACKRETURN,    CallbackReturn);
   REGISTER_OP(EXITFUNCTION,      ExitFunction);
   REGISTER_OP(JUMP,              Jump);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -308,7 +308,6 @@ private:
   DEF_OP(AtomicFetchNeg);
 
   ///< Branch ops
-  DEF_OP(SignalReturn);
   DEF_OP(CallbackReturn);
   DEF_OP(ExitFunction);
   DEF_OP(Jump);

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -277,16 +277,6 @@ void OpDispatchBuilder::IRETOp(OpcodeArgs) {
   BlockSetRIP = true;
 }
 
-void OpDispatchBuilder::SIGRETOp(OpcodeArgs) {
-  const uint8_t GPRSize = CTX->GetGPRSize();
-  // Store the new RIP
-  _SignalReturn();
-  auto NewRIP = _LoadContext(GPRSize, GPRClass, offsetof(FEXCore::Core::CPUState, rip));
-  // This ExitFunction won't actually get hit but needs to exist
-  _ExitFunction(NewRIP);
-  BlockSetRIP = true;
-}
-
 void OpDispatchBuilder::CallbackReturnOp(OpcodeArgs) {
   const uint8_t GPRSize = CTX->GetGPRSize();
   // Store the new RIP
@@ -6128,7 +6118,6 @@ void InstallOpcodeHandlers(Context::OperatingMode Mode) {
     {0xFE, 1, &OpDispatchBuilder::PADDQOp<4>},
 
     // FEX reserved instructions
-    {0x36, 1, &OpDispatchBuilder::SIGRETOp},
     {0x37, 1, &OpDispatchBuilder::CallbackReturnOp},
   };
 

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -175,7 +175,6 @@ public:
   void NOPOp(OpcodeArgs);
   void RETOp(OpcodeArgs);
   void IRETOp(OpcodeArgs);
-  void SIGRETOp(OpcodeArgs);
   void CallbackReturnOp(OpcodeArgs);
   void SecondaryALUOp(OpcodeArgs);
   template<uint32_t SrcIndex>

--- a/External/FEXCore/Source/Interface/Core/X86HelperGen.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86HelperGen.cpp
@@ -23,12 +23,15 @@ X86GeneratedCode::X86GeneratedCode() {
   // Allocate a page for our emulated guest
   CodePtr = AllocateGuestCodeSpace(CODE_SIZE);
 
-  SignalReturn = reinterpret_cast<uint64_t>(CodePtr);
-  CallbackReturn = reinterpret_cast<uint64_t>(CodePtr) + 2;
+  x32_rt_sigreturn = reinterpret_cast<uint64_t>(CodePtr) + 2;
+  CallbackReturn = reinterpret_cast<uint64_t>(CodePtr);
 
   const std::vector<uint8_t> SignalReturnCode = {
-    0x0F, 0x36, // SIGRET FEX instruction
     0x0F, 0x37, // CALLBACKRET FEX Instruction
+
+    // rt_sigreturn
+    0xb8, 0xad, 0x00, 0x00, 0x00, // mov eax, SYS_rt_sigreturn
+    0xcd, 0x80, // int 0x80
   };
 
   memcpy(CodePtr, &SignalReturnCode.at(0), SignalReturnCode.size());

--- a/External/FEXCore/Source/Interface/Core/X86HelperGen.h
+++ b/External/FEXCore/Source/Interface/Core/X86HelperGen.h
@@ -15,7 +15,7 @@ public:
   X86GeneratedCode();
   ~X86GeneratedCode();
 
-  uint64_t SignalReturn{};
+  uint64_t x32_rt_sigreturn{};
   uint64_t CallbackReturn{};
 
 private:

--- a/External/FEXCore/Source/Interface/Core/X86Tables/SecondaryTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/SecondaryTables.cpp
@@ -64,6 +64,7 @@ void InitializeSecondaryTables(Context::OperatingMode Mode) {
     {0x33, 1, X86InstInfo{"RDPMC",      TYPE_PRIV, FLAGS_NO_OVERLAY,                                                                             0, nullptr}},
     {0x34, 1, X86InstInfo{"SYSENTER",   TYPE_PRIV, FLAGS_NO_OVERLAY,                                                                             0, nullptr}},
     {0x35, 1, X86InstInfo{"SYSEXIT",    TYPE_PRIV, FLAGS_NO_OVERLAY,                                                                             0, nullptr}},
+    {0x36, 1, X86InstInfo{"",           TYPE_INVALID, FLAGS_NO_OVERLAY,                                                                          0, nullptr}},
     {0x38, 1, X86InstInfo{"",           TYPE_0F38_TABLE, FLAGS_NO_OVERLAY,                                                                       0, nullptr}},
     {0x39, 1, X86InstInfo{"",           TYPE_INVALID, FLAGS_NO_OVERLAY,                                                                          0, nullptr}},
     {0x3A, 1, X86InstInfo{"",           TYPE_0F3A_TABLE, FLAGS_NO_OVERLAY,                                                                       0, nullptr}},
@@ -257,9 +258,6 @@ void InitializeSecondaryTables(Context::OperatingMode Mode) {
 
     // FEX reserved instructions
     // Unused x86 encoding instruction.
-    // Used by FEX to know when to do a signal return
-    {0x36, 1, X86InstInfo{"SIGRET",       TYPE_INST, FLAGS_BLOCK_END | FLAGS_NO_OVERLAY | FLAGS_SETS_RIP,                                                            0, nullptr}},
-
     {0x37, 1, X86InstInfo{"CALLBACKRET",  TYPE_INST, FLAGS_BLOCK_END | FLAGS_NO_OVERLAY | FLAGS_SETS_RIP,                                                                          0, nullptr}},
 
     // This was originally used by VIA to jump to its alternative instruction set. Used for OP_THUNK

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -22,7 +22,7 @@
     "",
     "Eg:",
     "IR op with no result and no arguments",
-    "  SignalReturn",
+    "  CallbackReturn",
     "",
     "IR op with result and no arguments",
     "  GPR = ProcessorID",
@@ -262,9 +262,6 @@
         "DestSize": "GetOpSize(_NewRIP)"
       },
       "Break BreakDefinition:$Reason": {
-        "HasSideEffects": true
-      },
-      "SignalReturn": {
         "HasSideEffects": true
       },
       "CallbackReturn": {

--- a/External/FEXCore/include/FEXCore/Core/Context.h
+++ b/External/FEXCore/include/FEXCore/Core/Context.h
@@ -244,12 +244,13 @@ namespace FEXCore::Context {
   /**
    * @brief Retrieves a feature struct indicating certain supported aspects from
    *        the hose.
-   * 
+   *
    * @param CTX A valid non-null context instance.
    */
   FEX_DEFAULT_VISIBILITY HostFeatures GetHostFeatures(const FEXCore::Context::Context *CTX);
 
   FEX_DEFAULT_VISIBILITY void HandleCallback(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread, uint64_t RIP);
+  [[noreturn]] FEX_DEFAULT_VISIBILITY void HandleSignalHandlerReturn(FEXCore::Context::Context *CTX, bool RT);
 
   FEX_DEFAULT_VISIBILITY void RegisterHostSignalHandler(FEXCore::Context::Context *CTX, int Signal, HostSignalDelegatorFunction Func, bool Required);
   FEX_DEFAULT_VISIBILITY void RegisterFrontendHostSignalHandler(FEXCore::Context::Context *CTX, int Signal, HostSignalDelegatorFunction Func, bool Required);

--- a/External/FEXCore/include/FEXCore/Core/CoreState.h
+++ b/External/FEXCore/include/FEXCore/Core/CoreState.h
@@ -158,7 +158,8 @@ namespace FEXCore::Core {
       uint64_t GuestSignal_SIGILL{};
       uint64_t GuestSignal_SIGTRAP{};
       uint64_t GuestSignal_SIGSEGV{};
-      uint64_t SignalReturnHandler{};
+      uint64_t SignalHandlerReturnAddressRT{};
+      uint64_t SignalHandlerReturnAddress{};
       uint64_t L1Pointer{};
       uint64_t L2Pointer{};
       /**  @} */

--- a/Source/Tests/LinuxSyscalls/Syscalls/Stubs.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Stubs.cpp
@@ -4,8 +4,11 @@ tags: LinuxSyscalls|syscalls-shared
 $end_info$
 */
 
+#include <FEXCore/Core/CoreState.h>
 #include <FEXCore/Utils/LogManager.h>
 
+#include "FEXCore/Core/Context.h"
+#include <FEXCore/Debug/InternalThreadState.h>
 #include "Tests/LinuxSyscalls/Syscalls.h"
 #include "Tests/LinuxSyscalls/x32/Syscalls.h"
 #include "Tests/LinuxSyscalls/x64/Syscalls.h"
@@ -22,10 +25,6 @@ namespace FEXCore::Core {
 
 namespace FEX::HLE {
   void RegisterStubs(FEX::HLE::SyscallHandler *Handler) {
-
-    REGISTER_SYSCALL_IMPL(rt_sigreturn, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t {
-      SYSCALL_STUB(rt_sigreturn);
-    });
 
     REGISTER_SYSCALL_IMPL(ptrace, [](FEXCore::Core::CpuStateFrame *Frame, int /*enum __ptrace_request*/ request, pid_t pid, void *addr, void *data) -> uint64_t {
       // We don't support this

--- a/Source/Tests/LinuxSyscalls/Syscalls/Thread.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Thread.cpp
@@ -263,6 +263,11 @@ namespace FEX::HLE {
   void RegisterThread(FEX::HLE::SyscallHandler *Handler) {
     using namespace FEXCore::IR;
 
+    REGISTER_SYSCALL_IMPL(rt_sigreturn, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t {
+      FEXCore::Context::HandleSignalHandlerReturn(Frame->Thread->CTX, true);
+      return 0;
+    });
+
     REGISTER_SYSCALL_IMPL_PASS_FLAGS(getpid, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
       [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t {
       uint64_t Result = ::getpid();

--- a/Source/Tests/LinuxSyscalls/x32/Stubs.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Stubs.cpp
@@ -21,10 +21,6 @@ namespace FEXCore::Core {
 
 namespace FEX::HLE::x32 {
   void RegisterStubs(FEX::HLE::SyscallHandler *Handler) {
-    REGISTER_SYSCALL_IMPL_X32(sigreturn, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t {
-      SYSCALL_STUB(sigreturn);
-    });
-
     REGISTER_SYSCALL_IMPL_X32(readdir, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t {
       SYSCALL_STUB(readdir);
     });

--- a/Source/Tests/LinuxSyscalls/x32/Thread.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Thread.cpp
@@ -99,6 +99,11 @@ namespace FEX::HLE::x32 {
   }
 
   void RegisterThread(FEX::HLE::SyscallHandler *Handler) {
+    REGISTER_SYSCALL_IMPL_X32(sigreturn, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t {
+      FEXCore::Context::HandleSignalHandlerReturn(Frame->Thread->CTX, false);
+      return 0;
+    });
+
     REGISTER_SYSCALL_IMPL_X32(clone, ([](FEXCore::Core::CpuStateFrame *Frame, uint32_t flags, void *stack, pid_t *parent_tid, void *tls, pid_t *child_tid) -> uint64_t {
       FEX::HLE::clone3_args args {
         .Type = TypeOfClone::TYPE_CLONE2,


### PR DESCRIPTION
By utilizing the stack unwinding using the guest stack space, we can now
implement these directly.

With all of this work in place, libunwind now successfully unwinds a
stack frame from a signal!

It needed to find the appropriate signal frame to know that it is in a signal stack to unwind accordingly.

Before:
```
*** signal 11
Register dump:

<... Register dump snipped ...>

Backtrace:
/mnt/Work/Projects/work/glibc-build/debug/libSegFault.so(+0x37b4)[0x7f245c9537b4]
[0x7f245c996000]
```

After:
```
*** signal 11
Register dump:

<... Register dump snipped ...>

Backtrace:
/mnt/Work/Work/Unicorn_Tests/ELFLoader/Tests/invalid_int3(+0x1130)[0x5589d3060130]
/mnt/Work/Work/Unicorn_Tests/ELFLoader/Tests/invalid_int3(+0x1146)[0x5589d3060146]
/lib/x86_64-linux-gnu/libc.so.6(+0x29d90)[0x7fffe25d7d90]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x80)[0x7fffe25d7e40]
/mnt/Work/Work/Unicorn_Tests/ELFLoader/Tests/invalid_int3(+0x1065)[0x5589d3060065]
```

This will be a draft for now because this is a fairly spooky change. I don't want this merged without some excessive testing.