### PR TITLE
Config: Disable multiblock by default

### DIFF
--- a/External/FEXCore/Source/Interface/Config/Config.json.in
+++ b/External/FEXCore/Source/Interface/Config/Config.json.in
@@ -16,10 +16,11 @@
       },
       "Multiblock": {
         "Type": "bool",
-        "Default": "true",
+        "Default": "false",
         "ShortArg": "m",
         "Desc": [
-          "Controls multiblock code compilation"
+          "Controls multiblock code compilation",
+          "Can cause long JIT compilation times and stutter"
         ]
       },
       "MaxInst": {


### PR DESCRIPTION
This causes users pain currently since the JIT isn't doing any caching and our RA being a hack mess means it is quite slow.

Disable by default to improve JIT time performance.

When testing I'm usually running with multiblock disabled myself because of the performance hit.