### PR TITLE
OpcodeDispatcher: Handle VMOVQ

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -5827,7 +5827,7 @@ void OpDispatchBuilder::InstallHostSpecificOpcodeHandlers() {
     {OPD(1, 0b00, 0x2B), 1, &OpDispatchBuilder::VMOVVectorNTOp},
     {OPD(1, 0b01, 0x2B), 1, &OpDispatchBuilder::VMOVVectorNTOp},
 
-    {OPD(1, 0b01, 0x6E), 1, &OpDispatchBuilder::UnimplementedOp},
+    {OPD(1, 0b01, 0x6E), 1, &OpDispatchBuilder::MOVBetweenGPR_FPR},
 
     {OPD(1, 0b01, 0x6F), 1, &OpDispatchBuilder::VMOVAPS_VMOVAPD_Op},
     {OPD(1, 0b10, 0x6F), 1, &OpDispatchBuilder::VMOVUPS_VMOVUPD_Op},
@@ -5836,7 +5836,7 @@ void OpDispatchBuilder::InstallHostSpecificOpcodeHandlers() {
 
     {OPD(1, 0b00, 0x77), 1, &OpDispatchBuilder::UnimplementedOp},
 
-    {OPD(1, 0b01, 0x7E), 1, &OpDispatchBuilder::UnimplementedOp},
+    {OPD(1, 0b01, 0x7E), 1, &OpDispatchBuilder::MOVBetweenGPR_FPR},
     {OPD(1, 0b10, 0x7E), 1, &OpDispatchBuilder::MOVQOp},
 
     {OPD(1, 0b01, 0x7F), 1, &OpDispatchBuilder::VMOVAPS_VMOVAPD_Op},

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -5837,11 +5837,14 @@ void OpDispatchBuilder::InstallHostSpecificOpcodeHandlers() {
     {OPD(1, 0b00, 0x77), 1, &OpDispatchBuilder::UnimplementedOp},
 
     {OPD(1, 0b01, 0x7E), 1, &OpDispatchBuilder::UnimplementedOp},
+    {OPD(1, 0b10, 0x7E), 1, &OpDispatchBuilder::MOVQOp},
 
     {OPD(1, 0b01, 0x7F), 1, &OpDispatchBuilder::VMOVAPS_VMOVAPD_Op},
     {OPD(1, 0b10, 0x7F), 1, &OpDispatchBuilder::VMOVUPS_VMOVUPD_Op},
 
+    {OPD(1, 0b01, 0xD6), 1, &OpDispatchBuilder::MOVQOp},
     {OPD(1, 0b01, 0xD7), 1, &OpDispatchBuilder::UnimplementedOp},
+  
     {OPD(1, 0b01, 0xEB), 1, &OpDispatchBuilder::UnimplementedOp},
     {OPD(1, 0b01, 0xE7), 1, &OpDispatchBuilder::VMOVVectorNTOp},
     {OPD(1, 0b01, 0xEF), 1, &OpDispatchBuilder::UnimplementedOp},

--- a/External/FEXCore/Source/Interface/Core/X86Tables/VEXTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/VEXTables.cpp
@@ -188,7 +188,7 @@ void InitializeVEXTables() {
     {OPD(1, 0b01, 0x7D), 1, X86InstInfo{"VHSUBPD",     TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
     {OPD(1, 0b11, 0x7D), 1, X86InstInfo{"VHSUBPS",     TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
 
-    {OPD(1, 0b01, 0x7E), 1, X86InstInfo{"VMOV*",     TYPE_INST, FLAGS_MODRM | FLAGS_XMM_FLAGS, 0, nullptr}},
+    {OPD(1, 0b01, 0x7E), 1, X86InstInfo{"VMOV*",     TYPE_INST, FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_SF_DST_GPR | FLAGS_XMM_FLAGS, 0, nullptr}},
     {OPD(1, 0b10, 0x7E), 1, X86InstInfo{"VMOVQ",     TYPE_INST, GenFlagsSameSize(SIZE_64BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS, 0, nullptr}},
 
     {OPD(1, 0b01, 0x7F), 1, X86InstInfo{"VMOVDQA",     TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_XMM_FLAGS, 0, nullptr}},

--- a/External/FEXCore/Source/Interface/Core/X86Tables/VEXTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/VEXTables.cpp
@@ -189,7 +189,7 @@ void InitializeVEXTables() {
     {OPD(1, 0b11, 0x7D), 1, X86InstInfo{"VHSUBPS",     TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
 
     {OPD(1, 0b01, 0x7E), 1, X86InstInfo{"VMOV*",     TYPE_INST, FLAGS_MODRM | FLAGS_XMM_FLAGS, 0, nullptr}},
-    {OPD(1, 0b10, 0x7E), 1, X86InstInfo{"VMOVQ",     TYPE_INST, FLAGS_MODRM | FLAGS_XMM_FLAGS, 0, nullptr}},
+    {OPD(1, 0b10, 0x7E), 1, X86InstInfo{"VMOVQ",     TYPE_INST, GenFlagsSameSize(SIZE_64BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS, 0, nullptr}},
 
     {OPD(1, 0b01, 0x7F), 1, X86InstInfo{"VMOVDQA",     TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_XMM_FLAGS, 0, nullptr}},
     {OPD(1, 0b10, 0x7F), 1, X86InstInfo{"VMOVDQU",     TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_XMM_FLAGS, 0, nullptr}},
@@ -207,7 +207,7 @@ void InitializeVEXTables() {
     {OPD(1, 0b01, 0xD3), 1, X86InstInfo{"VPSRLQ",      TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
     {OPD(1, 0b01, 0xD4), 1, X86InstInfo{"VPADDQ",      TYPE_INST, GenFlagsSameSize(SIZE_256BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS, 0, nullptr}},
     {OPD(1, 0b01, 0xD5), 1, X86InstInfo{"VPMULLW",     TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
-    {OPD(1, 0b01, 0xD6), 1, X86InstInfo{"VMOVQ",       TYPE_INST, FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_XMM_FLAGS, 0, nullptr}},
+    {OPD(1, 0b01, 0xD6), 1, X86InstInfo{"VMOVQ",       TYPE_INST, GenFlagsSameSize(SIZE_64BIT) | FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_XMM_FLAGS, 0, nullptr}},
     {OPD(1, 0b01, 0xD7), 1, X86InstInfo{"VPMOVMSKB",   TYPE_INST, FLAGS_MODRM | FLAGS_XMM_FLAGS | FLAGS_SF_DST_GPR | FLAGS_SF_MOD_REG_ONLY, 0, nullptr}},
 
     {OPD(1, 0b01, 0xD8), 1, X86InstInfo{"VPSUBUSB", TYPE_INST, FLAGS_MODRM | FLAGS_XMM_FLAGS, 0, nullptr}},

--- a/unittests/ASM/VEX/vmovq.asm
+++ b/unittests/ASM/VEX/vmovq.asm
@@ -1,0 +1,39 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x4142434445464748", "0x0000000000000000", "0x0000000000000000", "0x0000000000000000"],
+    "XMM1": ["0x4142434445464748", "0x0000000000000000", "0x0000000000000000", "0x0000000000000000"],
+    "XMM2": ["0x4142434445464748", "0x5152535455565758", "0x4142434445464748", "0x7172737475767778"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rdx + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [rdx + 8 * 1], rax
+
+mov rax, 0x6162636465666768
+mov [rdx + 8 * 2], rax
+mov rax, 0x7172737475767778
+mov [rdx + 8 * 3], rax
+
+; Load from memory (fill with junk and ensure load zeroes out upper 64-bit lanes)
+vmovapd xmm0, [rdx]
+vmovq xmm0, [rdx]
+
+; Load and truncate same register
+vmovapd ymm1, [rdx]
+vmovq xmm1, xmm1
+
+; Store and reload
+vmovq [rdx + 8 * 2], xmm1
+vmovapd ymm2, [rdx]
+
+hlt

--- a/unittests/ASM/VEX/vmovq_vmovd_reg.asm
+++ b/unittests/ASM/VEX/vmovq_vmovd_reg.asm
@@ -1,0 +1,55 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "RBX": "0x4142434445464748",
+    "RCX": "0x0000000045464748",
+    "XMM0": ["0x7172737475767778", "0x0000000000000000", "0x0000000000000000", "0x0000000000000000"],
+    "XMM1": ["0x0000000075767778", "0x0000000000000000", "0x0000000000000000", "0x0000000000000000"],
+    "XMM2": ["0x0000000045464748", "0x0000000000000000", "0x0000000000000000", "0x0000000000000000"],
+    "XMM3": ["0x4142434445464748", "0x5152535455565758", "0x0000000000000000", "0x0000000000000000"],
+    "XMM4": ["0x6162636465666768", "0x7172737475767778", "0x0000000000000000", "0x0000000000000000"],
+    "XMM5": ["0x4142434465666768", "0x6162636465666768", "0x6162636465666768", "0x7172737475767778"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+
+mov rax, 0x4142434445464748
+mov [rdx + 8 * 0], rax
+mov rax, 0x5152535455565758
+mov [rdx + 8 * 1], rax
+
+mov rax, 0x6162636465666768
+mov [rdx + 8 * 2], rax
+mov rax, 0x7172737475767778
+mov [rdx + 8 * 3], rax
+
+; Load from GPR (64-bit)
+vmovapd xmm0, [rdx]
+vmovq xmm0, rax
+
+; Load from GPR (32-bit)
+vmovapd xmm1, [rdx]
+vmovd xmm1, eax
+
+; Load 32-bit value
+vmovapd xmm2, [rdx]
+vmovd xmm2, [edx]
+
+; Store into GPR
+vmovapd xmm3, [rdx]
+vmovq rbx, xmm3
+vmovd ecx, xmm3
+
+; Store into mem
+vmovapd xmm4, [rdx + 8 * 2]
+vmovd [rdx + 0], xmm4
+vmovq [rdx + 8], xmm4
+vmovapd ymm5, [rdx]
+
+hlt


### PR DESCRIPTION
Fairly trivial, we can reuse the existing implementation for MOVQ.