### PR TITLE
unittests: Expand VPCLMULQDQ unit test

### DIFF
--- a/unittests/ASM/VEX/vpclmulqdq.asm
+++ b/unittests/ASM/VEX/vpclmulqdq.asm
@@ -1,12 +1,13 @@
 %ifdef CONFIG
 {
+  "HostFeatures": ["AVX"],
   "RegData": {
-      "XMM1": ["0xA76C4F06A12BFCE0", "0x9B80767F1E6A060F"],
-      "XMM2": ["0x6868C3F3AAED56E0", "0xF0FCE9E294E6E6DE"],
-      "XMM3": ["0x1E2017C5BEE29400", "0x38358E40CC367C7A"],
-      "XMM4": ["0xE208147952DE57A0", "0x317D360F86C80DC9"],
-      "XMM5": ["0xBBA54C87DA872B40", "0x6495428B7641EBE6"],
-      "XMM6": ["0x170B5A1B5CDD42EA", "0x719F094BB2358CA1"]
+      "XMM1": ["0xA76C4F06A12BFCE0", "0x9B80767F1E6A060F", "0xFFFFFFFFFFFFFFFF", "0xEEEEEEEEEEEEEEEE"],
+      "XMM2": ["0x6868C3F3AAED56E0", "0xF0FCE9E294E6E6DE", "0xDDDDDDDDDDDDDDDD", "0xCCCCCCCCCCCCCCCC"],
+      "XMM3": ["0x1E2017C5BEE29400", "0x38358E40CC367C7A", "0x0000000000000000", "0x0000000000000000"],
+      "XMM4": ["0xE208147952DE57A0", "0x317D360F86C80DC9", "0x0000000000000000", "0x0000000000000000"],
+      "XMM5": ["0xBBA54C87DA872B40", "0x6495428B7641EBE6", "0x0000000000000000", "0x0000000000000000"],
+      "XMM6": ["0x170B5A1B5CDD42EA", "0x719F094BB2358CA1", "0x0000000000000000", "0x0000000000000000"]
   }
 }
 %endif
@@ -14,8 +15,14 @@
 lea rdx, [rel .data]
 
 ; Load inputs
-movaps xmm1, [rdx + 16 * 0]
-movaps xmm2, [rdx + 16 * 1]
+vmovaps ymm1, [rdx + 32 * 0]
+vmovaps ymm2, [rdx + 32 * 1]
+
+; Fill result vectors with junk (ensure proper lane clearing is performed)
+vmovaps ymm3, [rdx + 32 * 0]
+vmovaps ymm4, [rdx + 32 * 0]
+vmovaps ymm5, [rdx + 32 * 0]
+vmovaps ymm6, [rdx + 32 * 0]
 
 ; With imm = 0b00000000
 vpclmulqdq xmm3, xmm1, xmm2, 0
@@ -31,7 +38,13 @@ vpclmulqdq xmm6, xmm1, xmm2, 17
 
 hlt
 
-align 16
+align 32
 .data:
-db 0xe0, 0xfc, 0x2b, 0xa1, 0x06, 0x4f, 0x6c, 0xa7, 0x0f, 0x06, 0x6a, 0x1e, 0x7f, 0x76, 0x80, 0x9b
-db 0xe0, 0x56, 0xed, 0xaa, 0xf3, 0xc3, 0x68, 0x68, 0xde, 0xe6, 0xe6, 0x94, 0xe2, 0xe9, 0xfc, 0xf0
+dq 0xA76C4F06A12BFCE0
+dq 0x9B80767F1E6A060F
+dq 0xFFFFFFFFFFFFFFFF
+dq 0xEEEEEEEEEEEEEEEE
+dq 0x6868C3F3AAED56E0
+dq 0xF0FCE9E294E6E6DE
+dq 0xDDDDDDDDDDDDDDDD
+dq 0xCCCCCCCCCCCCCCCC


### PR DESCRIPTION
Now that we have some AVX instructions in place, we can make the test use them and also enforce correctness behavior in the upper lane.