### PR TITLE
FEXServerClient: Disable confusing connection log

### DIFF
--- a/Source/Common/FEXServerClient.h
+++ b/Source/Common/FEXServerClient.h
@@ -63,12 +63,16 @@ namespace FEXServerClient {
    */
   int ConnectToAndStartServer(char *InterpreterPath);
 
+  enum class ConnectionOption {
+    Default,
+    NoPrintConnectionError,
+  };
   /**
    * @brief Connect to a FEXServer instance if it exists
    *
    * @return socket FD for communicating with server
    */
-  int ConnectToServer();
+  int ConnectToServer(ConnectionOption ConnectionOption = ConnectionOption::Default);
 
   /**
    * @name Packet request functions


### PR DESCRIPTION
On first FEXInterpreter execution, it is expected that `ConnectToServer` will fail with `ECONNREFUSED` because FEXServer won't be running.

Skip printing this first messaage to stderr if configured. If it is some other error message then ensure it is still printed.