### PR TITLE
FEXLoader: Make `IsInterpreterInstalled` check less horrible.

### DIFF
--- a/Source/Tests/FEXLoader.cpp
+++ b/Source/Tests/FEXLoader.cpp
@@ -191,10 +191,9 @@ bool IsInterpreterInstalled() {
   // The interpreter is installed if both the binfmt_misc handlers are available
   // Or if we were originally executed with FD. Which means the interpreter is installed
 
-  std::error_code ec{};
   return ExecutedWithFD ||
-         (std::filesystem::exists("/proc/sys/fs/binfmt_misc/FEX-x86", ec) &&
-         std::filesystem::exists("/proc/sys/fs/binfmt_misc/FEX-x86_64", ec));
+         (access("/proc/sys/fs/binfmt_misc/FEX-x86", F_OK) == 0 &&
+          access("/proc/sys/fs/binfmt_misc/FEX-x86_64", F_OK) == 0);
 }
 
 int main(int argc, char **argv, char **const envp) {


### PR DESCRIPTION
`std::filesystem::exists` is particularly gnarly in how it checks to see if the file exists.
It allocates memory, it creates lists, it splits things, then eventually checking the status

Remove all this overhead to help out minorly for applications that execve a lot.

Before:
![Image_2022-12-05_02-57-28](https://user-images.githubusercontent.com/1018829/205621446-810e37dd-1740-4db6-95f8-757335bb4543.png)

After:
![Image_2022-12-05_02-57-33](https://user-images.githubusercontent.com/1018829/205621498-b9c6f2c7-0d9d-4d2f-ba13-d6335b669421.png)

