### PR TITLE
Linux: Improve performance of hot paths in path searching

### DIFF
--- a/Source/Tests/LinuxSyscalls/EmulatedFiles/EmulatedFiles.cpp
+++ b/Source/Tests/LinuxSyscalls/EmulatedFiles/EmulatedFiles.cpp
@@ -737,7 +737,7 @@ namespace FEX::EmulatedFile {
     }
 
     std::error_code ec;
-    bool exists = std::filesystem::exists(Path, ec);
+    bool exists = access(Path.c_str(), F_OK) == 0;
     if (ec) {
       return -1;
     }

--- a/Source/Tests/LinuxSyscalls/FileManagement.h
+++ b/Source/Tests/LinuxSyscalls/FileManagement.h
@@ -15,6 +15,7 @@ $end_info$
 #include <stddef.h>
 #include <string>
 #include <sys/stat.h>
+#include <unistd.h>
 #include <vector>
 
 #include <unordered_map>
@@ -27,6 +28,18 @@ struct Context;
 }
 
 namespace FEX::HLE {
+[[maybe_unused]]
+static bool IsSymlink(const std::string &Filename) {
+  // Checks to see if a filepath is a symlink.
+  struct stat Buffer{};
+  int Result = lstat(Filename.c_str(), &Buffer);
+  return Result == 0 && S_ISLNK(Buffer.st_mode);
+}
+
+[[maybe_unused]]
+static ssize_t GetSymlink(const std::string &Filename, char *ResultBuffer, size_t ResultBufferSize) {
+  return readlink(Filename.c_str(), ResultBuffer, ResultBufferSize);
+}
 
 struct open_how;
 


### PR DESCRIPTION
`GetEmulatedPath` and `OpenAt` are called a /lot/ in applications. std::filesystem::path handling here is quite heavy and costly for what we are trying to achieve.

Remove this usage and instead use lstat, access, and readlink directly which is a heck of a lot faster.

In particular this helps out pressure-vessel, shaving off launch times by 1-2 seconds.
Going from ~22 seconds down to ~20 seconds.