### PR TITLE
OpcodeDispatcher: Explicitly zero upper lanes

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -4971,12 +4971,6 @@ OrderedNode *OpDispatchBuilder::LoadSource_WithOpSize(FEXCore::IR::RegisterClass
       if (OpSize < Core::CPUState::XMM_SSE_REG_SIZE) {
         Src = _VMov(OpSize, Src);
       }
-
-      // OpSize of 16 is special in that it is expected to zero the upper bits of the 256-bit operation.
-      // TODO: Longer term we should enforce the difference between zero and insert.
-      if (regSize == Core::CPUState::XMM_AVX_REG_SIZE && OpSize == Core::CPUState::XMM_SSE_REG_SIZE) {
-        Src = _VMov(OpSize, Src);
-      }
     }
     else {
       Src = _LoadRegister(false, offsetof(FEXCore::Core::CPUState, gregs[gpr]) + (highIndex ? 1 : 0), GPRClass, GPRFixedClass, OpSize);


### PR DESCRIPTION
Makes our intent to zero-extend the upper lanes explicit and lets us remove a special case in the LoadSource implementation.

This also makes things a little nicer since we're not hardcoding 32 byte stores.