### PR TITLE
Config: Fixes global application configs

### DIFF
--- a/External/FEXCore/Source/Interface/Config/Config.cpp
+++ b/External/FEXCore/Source/Interface/Config/Config.cpp
@@ -686,7 +686,7 @@ namespace JSON {
   AppLoader::AppLoader(const std::string& Filename, FEXCore::Config::LayerType Type)
     : FEXCore::Config::OptionMapper(Type) {
     const bool Global = Type == FEXCore::Config::LayerType::LAYER_GLOBAL_STEAM_APP ||
-                        Type == FEXCore::Config::LayerType::LAYER_LOCAL_STEAM_APP;
+                        Type == FEXCore::Config::LayerType::LAYER_GLOBAL_APP;
     Config = FEXCore::Config::GetApplicationConfig(Filename, Global);
 
     // Immediately load so we can reload the meta layer


### PR DESCRIPTION
Accidentally was checking for SteamID layer types twice, rather than global.

Fixes steamwebhelper config not getting loaded from global config.