### PR TITLE
OpCodeDispatcher: Optimize a case of GOT calculation

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Frontend.h
+++ b/External/FEXCore/Source/Interface/Core/Frontend.h
@@ -58,6 +58,7 @@ private:
   bool DecodeInstruction(uint64_t PC);
 
   void BranchTargetInMultiblockRange();
+  bool BranchTargetCanContinue(bool FinalInstruction) const;
 
   uint8_t ReadByte();
   uint8_t PeekByte(uint8_t Offset) const;

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -783,8 +783,17 @@ void OpDispatchBuilder::CALLOp(OpcodeArgs) {
 
   _StoreMem(GPRClass, GPRSize, NewSP, ConstantPCReturn, GPRSize);
 
-  // Store the RIP
-  _ExitFunction(NewRIP); // If we get here then leave the function now
+  const uint64_t NextRIP = Op->PC + Op->InstSize;
+  LOGMAN_THROW_A_FMT(Op->Src[0].IsLiteral(), "Had wrong operand type");
+  const uint64_t TargetRIP = Op->PC + Op->InstSize + Op->Src[0].Data.Literal.Value;
+
+  if (NextRIP != TargetRIP) {
+    // Store the RIP
+    _ExitFunction(NewRIP); // If we get here then leave the function now
+  }
+  else {
+    NeedsBlockEnd = true;
+  }
 }
 
 void OpDispatchBuilder::CALLAbsoluteOp(OpcodeArgs) {

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -153,8 +153,9 @@ public:
   OpDispatchBuilder(FEXCore::Utils::IntrusivePooledAllocator &Allocator);
 
   void ResetWorkingList();
-  void ResetDecodeFailure() { DecodeFailure = false; }
+  void ResetDecodeFailure() { NeedsBlockEnd = DecodeFailure = false; }
   bool HadDecodeFailure() const { return DecodeFailure; }
+  bool NeedsBlockEnder() const { return NeedsBlockEnd; }
 
   void BeginFunction(uint64_t RIP, std::vector<FEXCore::Frontend::Decoder::DecodedBlocks> const *Blocks);
   void Finalize();
@@ -659,6 +660,7 @@ public:
   bool HandledLock = false;
 private:
   bool DecodeFailure{false};
+  bool NeedsBlockEnd{false};
   FEXCore::IR::IROp_IRHeader *Current_Header{};
   OrderedNode *Current_HeaderNode{};
 

--- a/unittests/32Bit_ASM/FEX_bugs/GOT_calculation.asm
+++ b/unittests/32Bit_ASM/FEX_bugs/GOT_calculation.asm
@@ -1,0 +1,20 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x10011"
+  },
+  "Mode": "32BIT"
+}
+%endif
+
+mov esp, 0xe0000010
+
+; This is a common pattern in 32-bit PIE code.
+; 32-bit GOT calculation needs to do a call+pop to do get the EIP.
+; LEA doesn't work because it there is no EIP relative ops like on x86-64.
+
+call target
+target:
+pop eax
+
+hlt


### PR DESCRIPTION
32-bit GOT calculation needs to do a call+pop to do get the EIP on 32-bit. LEA doesn't work because it there is no EIP relative ops like on x86-64.

This causes a terrible block split on every GOT calculation without the optimization in place.

Now the block can continue through this weird GOT calculation.

This will be worthwhile for our 32-bit thunks where for some reason the GOT calculation can't be removed. The GOT is calculated even though it isn't used.