### PR TITLE
IR: Remove HasDest and NumArgs from IR ops.

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -329,7 +329,6 @@ void InterpreterOps::InterpretIR(FEXCore::Core::CpuStateFrame *Frame, FEXCore::I
 
   const uintptr_t ListSize = CurrentIR->GetSSACount();
 
-  static_assert(sizeof(FEXCore::IR::IROp_Header) == 4);
   static_assert(sizeof(FEXCore::IR::OrderedNode) == 16);
 
   auto BlockEnd = CurrentIR->GetBlocks().end();

--- a/External/FEXCore/Source/Interface/IR/IRDumper.cpp
+++ b/External/FEXCore/Source/Interface/IR/IRDumper.cpp
@@ -23,6 +23,7 @@ namespace FEXCore::IR {
 #define IROP_REG_CLASSES_IMPL
 #define IROP_HASSIDEEFFECTS_IMPL
 #define IROP_SIZES_IMPL
+#define IROP_GETHASDEST_IMPL
 
 #include <FEXCore/IR/IRDefines.inc>
 
@@ -125,7 +126,7 @@ static void PrintArg(std::stringstream *out, IRListView const* IR, OrderedNodeWr
     }
   }
 
-  if (IROp->HasDest) {
+  if (GetHasDest(IROp->Op)) {
     uint32_t ElementSize = IROp->ElementSize;
     uint32_t NumElements = IROp->Size;
     if (!IROp->ElementSize) {
@@ -231,7 +232,7 @@ void Dump(std::stringstream *out, IRListView const* IR, IR::RegisterAllocationDa
 
       if (!Skip) {
         AddIndent();
-        if (IROp->HasDest) {
+        if (GetHasDest(IROp->Op)) {
 
           uint32_t ElementSize = IROp->ElementSize;
           uint32_t NumElements = IROp->Size;

--- a/External/FEXCore/Source/Interface/IR/IREmitter.cpp
+++ b/External/FEXCore/Source/Interface/IR/IREmitter.cpp
@@ -148,7 +148,7 @@ void IREmitter::RemoveArgUses(OrderedNode *Node) {
 
   FEXCore::IR::IROp_Header *IROp = Node->Op(DataBegin);
 
-  uint8_t NumArgs = IR::GetArgs(IROp->Op);
+  const uint8_t NumArgs = IR::GetArgs(IROp->Op);
   for (uint8_t i = 0; i < NumArgs; ++i) {
     auto ArgNode = IROp->Args[i].GetNode(ListBegin);
     ArgNode->RemoveUse();
@@ -201,7 +201,6 @@ void IREmitter::ReplaceWithConstant(OrderedNode *Node, uint64_t Value) {
 
       // Overwrite data with the new constant op
       Header->Op = OP_CONSTANT;
-      Header->NumArgs = 0;
       auto Const = Header->CW<IROp_Constant>();
       Const->Constant = Value;
     } else {

--- a/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -233,7 +233,7 @@ void ConstProp::CodeMotionAroundSelects(IREmitter *IREmit, const IRListView& Cur
   for (auto [BlockNode, BlockIROp] : CurrentIR.GetBlocks()) {
     auto BlockOp = BlockIROp->CW<FEXCore::IR::IROp_CodeBlock>();
     for (auto [UnaryOpNode, UnaryOpHdr] : CurrentIR.GetCode(BlockNode)) {
-      if (UnaryOpHdr->NumArgs == 1 && !HasSideEffects(UnaryOpHdr->Op)) {
+      if (IR::GetArgs(UnaryOpHdr->Op) == 1 && !HasSideEffects(UnaryOpHdr->Op)) {
         // could be moved
         auto SelectOpNode = IREmit->UnwrapNode(UnaryOpHdr->Args[0]);
         auto SelectOpHdr = IREmit->GetOpHeader(UnaryOpHdr->Args[0]);
@@ -255,7 +255,7 @@ void ConstProp::CodeMotionAroundSelects(IREmitter *IREmit, const IRListView& Cur
           // Copy over the op
           memcpy(NewUnaryOp1.first, UnaryOpHdr, OpSize);
 
-          for (int i = 0; i < NewUnaryOp1.first->NumArgs; i++) {
+          for (int i = 0; i < IR::GetArgs(NewUnaryOp1.first->Op); i++) {
             NewUnaryOp1.first->Args[i] = IREmit->WrapNode(IREmit->Invalid());
           }
           // Set New Op to operate on the constant
@@ -269,7 +269,7 @@ void ConstProp::CodeMotionAroundSelects(IREmitter *IREmit, const IRListView& Cur
           // Copy over the op
           memcpy(NewUnaryOp2.first, UnaryOpHdr, OpSize);
 
-          for (int i = 0; i < NewUnaryOp2.first->NumArgs; i++) {
+          for (int i = 0; i < IR::GetArgs(NewUnaryOp2.first->Op); i++) {
             NewUnaryOp2.first->Args[i] = IREmit->WrapNode(IREmit->Invalid());
           }
           // Set New Op to operate on the constant
@@ -366,7 +366,7 @@ bool ConstProp::ZextAndMaskingElimination(IREmitter *IREmit, const IRListView& C
     case OP_ASHR:
     case OP_LSHL:
     case OP_ROR: {
-      for (int i = 0; i < IROp->NumArgs; i++) {
+      for (int i = 0; i < IR::GetArgs(IROp->Op); i++) {
         auto newArg = RemoveUselessMasking(IREmit, IROp->Args[i], getMask(IROp));
         if (newArg.ID() != IROp->Args[i].ID()) {
           IREmit->ReplaceNodeArgument(CodeNode, i, IREmit->UnwrapNode(newArg));
@@ -378,7 +378,7 @@ bool ConstProp::ZextAndMaskingElimination(IREmitter *IREmit, const IRListView& C
 
     case OP_AND: {
       // if AND's arguments are imms, they are masking
-      for (int i = 0; i < IROp->NumArgs; i++) {
+      for (int i = 0; i < IR::GetArgs(IROp->Op); i++) {
         auto mask = getMask(IROp);
         uint64_t imm = 0;
         if (IREmit->IsValueConstant(IROp->Args[i^1], &imm))
@@ -457,7 +457,7 @@ bool ConstProp::ZextAndMaskingElimination(IREmitter *IREmit, const IRListView& C
     case OP_VFDIV:
     case OP_FCMP: {
       auto flopSize = IROp->Size;
-      for (int i = 0; i < IROp->NumArgs; i++) {
+      for (int i = 0; i < IR::GetArgs(IROp->Op); i++) {
         auto argHeader = IREmit->GetOpHeader(IROp->Args[i]);
 
         if (argHeader->Op == OP_VMOV) {

--- a/External/FEXCore/Source/Interface/IR/Passes/IRCompaction.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/IRCompaction.cpp
@@ -176,7 +176,7 @@ bool IRCompaction::Run(IREmitter *IREmit) {
         // Now that we have the op copied over, we need to modify SSA values to point to the new correct locations
         // This doesn't use IR::GetArgs(Op) because we need to remap all SSA nodes
         // Including ones that we don't RA
-        const uint8_t NumArgs = LocalIROp->NumArgs;
+        const uint8_t NumArgs = IR::GetArgs(LocalIROp->Op);
         for (uint8_t i = 0; i < NumArgs; ++i) {
           const auto OldArg = LocalIROp->Args[i].ID();
           const auto NewArg = OldToNewRemap[OldArg.Value].NodeID;

--- a/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
@@ -79,7 +79,7 @@ bool IRValidation::Run(IREmitter *IREmit) {
       const auto ID = CurrentIR.GetID(CodeNode);
       const uint8_t OpSize = IROp->Size;
 
-      if (IROp->HasDest) {
+      if (GetHasDest(IROp->Op)) {
         HadError |= OpSize == 0;
         // Does the op have a destination of size 0?
         if (OpSize == 0) {
@@ -121,22 +121,6 @@ bool IRValidation::Run(IREmitter *IREmit) {
       }
 
       uint8_t NumArgs = IR::GetArgs(IROp->Op);
-
-      if (NumArgs != IROp->NumArgs) {
-        switch (IROp->Op) {
-          case OP_BEGINBLOCK:
-          case OP_ENDBLOCK:
-          case OP_PHI:
-          case OP_PHIVALUE:
-          case OP_CONDJUMP:
-          case OP_JUMP:
-            // These override the number of args for RA, so ignore them.
-            break;
-          default:
-            HadError |= true;
-            Errors << "%ssa" << ID << ": Has wrong number of Args" << std::endl;
-        }
-      }
       for (uint32_t i = 0; i < NumArgs; ++i) {
         OrderedNodeWrapper Arg = IROp->Args[i];
         const auto ArgID = Arg.ID();

--- a/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -257,7 +257,7 @@ namespace {
   void FindNodeClasses(RegisterGraph *Graph, FEXCore::IR::IRListView *IR) {
     for (auto [CodeNode, IROp] : IR->GetAllCode()) {
       // If the destination hasn't yet been set then set it now
-      if (IROp->HasDest) {
+      if (GetHasDest(IROp->Op)) {
         const auto ID = IR->GetID(CodeNode);
         Graph->AllocData->Map[ID.Value] = PhysicalRegister(GetRegClassFromNode(IR, IROp), INVALID_REG);
       } else {
@@ -455,7 +455,7 @@ namespace {
         auto& NodeLiveRange = LiveRanges[Node.Value];
 
         // If the destination hasn't yet been set then set it now
-        if (IROp->HasDest) {
+        if (GetHasDest(IROp->Op)) {
           LOGMAN_THROW_AA_FMT(NodeLiveRange.Begin.Value == UINT32_MAX,
                              "Node begin already defined?");
           NodeLiveRange.Begin = Node;
@@ -709,7 +709,7 @@ namespace {
         }
 
         // This op defines a span
-        if (IROp->HasDest) {
+        if (GetHasDest(IROp->Op)) {
           // If this is a pre-write, update the StaticMap so we track writes
           if (!NodeLiveRange.PrefferedRegister.IsInvalid()) {
             SRA_DEBUG("ssa{} is a pre-write\n", Node);
@@ -1297,7 +1297,8 @@ namespace {
 
           CurrentNodes.insert(NodeOpBegin.ID());
 
-          for (int i = 0; i < IROp->NumArgs; i++) {
+          const uint8_t NumArgs = IR::GetArgs(IROp->Op);
+          for (int i = 0; i < NumArgs; i++) {
             CurrentNodes.insert(IROp->Args[i].ID());
           }
       }
@@ -1370,7 +1371,7 @@ namespace {
     auto LastCursor = IREmit->GetWriteCursor();
     auto [CodeNode, IROp] = IR.at(SpillPointId)();
 
-    LOGMAN_THROW_AA_FMT(IROp->HasDest, "Can't spill with no dest");
+    LOGMAN_THROW_AA_FMT(GetHasDest(IROp->Op), "Can't spill with no dest");
 
     const auto Node = IR.GetID(CodeNode);
     RegisterNode *CurrentNode = &Graph->Nodes[Node.Value];

--- a/External/FEXCore/include/FEXCore/IR/IREmitter.h
+++ b/External/FEXCore/include/FEXCore/IR/IREmitter.h
@@ -58,8 +58,6 @@ friend class FEXCore::IR::PassManager;
     Op.first->Constant = (Constant & Mask);
     Op.first->Header.Size = Size / 8;
     Op.first->Header.ElementSize = Size / 8;
-    Op.first->Header.NumArgs = 0;
-    Op.first->Header.HasDest = true;
     return Op;
   }
   IRPair<IROp_Bfe> _Bfe(uint8_t Width, uint8_t lsb, OrderedNode *ssa0) {


### PR DESCRIPTION
Shaves 8-bits off of each IR op.
Reduces what is necessary to generate an IR op by no longer needing to set NumArgs and HasDest bits.

No need to cart around this data when it is an IR op constant for each op, especially since most optimization passes don't need the data anyway.