### PR TITLE
Arm64: Reduce dispatcher to 1 page

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
@@ -38,7 +38,12 @@ namespace FEXCore::CPU {
 using namespace vixl;
 using namespace vixl::aarch64;
 
-constexpr size_t MAX_DISPATCHER_CODE_SIZE = 8192;
+#ifdef VIXL_SIMULATOR
+// Vixl simulator needs at least 4476 bytes for its dispatcher
+constexpr size_t MAX_DISPATCHER_CODE_SIZE = 4096 * 2;
+#else
+constexpr size_t MAX_DISPATCHER_CODE_SIZE = 4096;
+#endif
 
 Arm64Dispatcher::Arm64Dispatcher(FEXCore::Context::Context *ctx, const DispatcherConfig &config)
   : FEXCore::CPU::Dispatcher(ctx, config), Arm64Emitter(ctx, MAX_DISPATCHER_CODE_SIZE)


### PR DESCRIPTION
We currently only use 2236 bytes, no need for two pages. Once #2250 is merged we will use 1716 bytes