### PR TITLE
Arm64: Inline Syscall spill optimization

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
@@ -255,10 +255,6 @@ DEF_OP(InlineSyscall) {
       Intersects = true;
     }
   }
-  // XXX: For some reason spilling only the x4, x5, and x8 registers was causing issues
-  // Come back to this once investigation reveals why it fails the gvisor ioctl test
-  // For now override to all GPRs
-  SpillMask = ~0U;
 
   // Ordering is incredibly important here
   // We must spill any overlapping registers first THEN claim we are in a syscall without invalidating state at all


### PR DESCRIPTION
This was likely an issue with signals racing to the spill handler, which we have fixed bugs with over the past few months.

This means we don't need to spill all SRA GPR registers anymore, at most we need to spill three registers that intersect with syscall arguments.