### PR TITLE
OpcodeDispatcher: Handle remaining PEXTRW opcode

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -5915,6 +5915,8 @@ void OpDispatchBuilder::InstallHostSpecificOpcodeHandlers() {
     {OPD(1, 0b01, 0x7F), 1, &OpDispatchBuilder::VMOVAPS_VMOVAPD_Op},
     {OPD(1, 0b10, 0x7F), 1, &OpDispatchBuilder::VMOVUPS_VMOVUPD_Op},
 
+    {OPD(1, 0b01, 0xC5), 1, &OpDispatchBuilder::PExtrOp<2>},
+
     {OPD(1, 0b01, 0xD1), 1, &OpDispatchBuilder::VPSRLDOp<2>},
     {OPD(1, 0b01, 0xD2), 1, &OpDispatchBuilder::VPSRLDOp<4>},
     {OPD(1, 0b01, 0xD3), 1, &OpDispatchBuilder::VPSRLDOp<8>},

--- a/External/FEXCore/Source/Interface/Core/X86Tables/VEXTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/VEXTables.cpp
@@ -103,7 +103,7 @@ void InitializeVEXTables() {
     {OPD(1, 0b11, 0xC2), 1, X86InstInfo{"VCMPccSD",   TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
 
     {OPD(1, 0b01, 0xC4), 1, X86InstInfo{"VPINSRW",    TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
-    {OPD(1, 0b01, 0xC5), 1, X86InstInfo{"VPEXTRW",    TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
+    {OPD(1, 0b01, 0xC5), 1, X86InstInfo{"VPEXTRW",    TYPE_INST, GenFlagsSizes(SIZE_32BIT, SIZE_128BIT) | FLAGS_MODRM | FLAGS_SF_MOD_REG_ONLY | FLAGS_SF_DST_GPR | FLAGS_XMM_FLAGS, 1, nullptr}},
 
     {OPD(1, 0b00, 0xC6), 1, X86InstInfo{"VSHUFPS",    TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
     {OPD(1, 0b01, 0xC6), 1, X86InstInfo{"VSHUFPD",    TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},

--- a/unittests/ASM/VEX/vpextrw.asm
+++ b/unittests/ASM/VEX/vpextrw.asm
@@ -2,6 +2,8 @@
 {
   "HostFeatures": ["AVX"],
   "RegData": {
+    "RAX": "0x000000000000A47F",
+    "RBX": "0x00000000000067D2",
     "RCX": "0x1ED2A2A98A67B953"
   }
 }
@@ -21,6 +23,9 @@ vmovaps xmm8, [rdx + 16 * 7]
 
 mov rax, 0
 mov [rsi + 8 * 0], rax
+
+vpextrw eax, xmm1, 0
+vpextrw ebx, xmm2, 0xFF
 
 vpextrw [rsi + 8 * 0 + 0], xmm3, 2
 vpextrw [rsi + 8 * 0 + 2], xmm4, 0xFF


### PR DESCRIPTION
Whoops. Missed one when implementing the VPEXTR family 