### PR TITLE
Arm64: Rename GetSrcPair, GetDst, and GetSrc

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -20,8 +20,8 @@ DEF_OP(TruncElementPair) {
 
   switch (IROp->Size) {
     case 4: {
-      auto Dst = GetSrcPair<RA_32>(Node);
-      auto Src = GetSrcPair<RA_32>(Op->Pair.ID());
+      auto Dst = GetRegPair<RA_32>(Node);
+      auto Src = GetRegPair<RA_32>(Op->Pair.ID());
       mov(Dst.first, Src.first);
       mov(Dst.second, Src.second);
       break;

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -1105,7 +1105,7 @@ DEF_OP(Sbfe) {
 
 #define GRCMP(Node) (Op->CompareSize == 4 ? GetReg<RA_32>(Node) : GetReg<RA_64>(Node))
 
-#define GRFCMP(Node) (Op->CompareSize == 4 ? GetDst(Node).S() : GetDst(Node).D())
+#define GRFCMP(Node) (Op->CompareSize == 4 ? GetVReg(Node).S() : GetVReg(Node).D())
 
 Condition MapSelectCC(IR::CondClassType Cond) {
   switch (Cond.Val) {
@@ -1178,7 +1178,7 @@ DEF_OP(VExtractToGPR) {
   const auto Offset = ElementSizeBits * Op->Index;
   const auto Is256Bit = Offset >= SSERegBitSize;
 
-  const auto Vector = GetSrc(Op->Vector.ID());
+  const auto Vector = GetVReg(Op->Vector.ID());
 
   const auto PerformMove = [&](const aarch64::VRegister& reg, int index) {
     switch (OpSize) {
@@ -1249,10 +1249,10 @@ DEF_OP(Float_ToGPR_ZS) {
   aarch64::Register Dst{};
   aarch64::VRegister Src{};
   if (Op->SrcElementSize == 8) {
-    Src = GetSrc(Op->Scalar.ID()).D();
+    Src = GetVReg(Op->Scalar.ID()).D();
   }
   else {
-    Src = GetSrc(Op->Scalar.ID()).S();
+    Src = GetVReg(Op->Scalar.ID()).S();
   }
 
   if (IROp->Size == 8) {
@@ -1271,11 +1271,11 @@ DEF_OP(Float_ToGPR_S) {
   aarch64::Register Dst{};
   aarch64::VRegister Src{};
   if (Op->SrcElementSize == 8) {
-    frinti(VTMP1.D(), GetSrc(Op->Scalar.ID()).D());
+    frinti(VTMP1.D(), GetVReg(Op->Scalar.ID()).D());
     Src = VTMP1.D();
   }
   else {
-    frinti(VTMP1.S(), GetSrc(Op->Scalar.ID()).S());
+    frinti(VTMP1.S(), GetVReg(Op->Scalar.ID()).S());
     Src = VTMP1.S();
   }
 
@@ -1293,10 +1293,10 @@ DEF_OP(FCmp) {
   auto Op = IROp->C<IR::IROp_FCmp>();
 
   if (Op->ElementSize == 4) {
-    fcmp(GetSrc(Op->Scalar1.ID()).S(), GetSrc(Op->Scalar2.ID()).S());
+    fcmp(GetVReg(Op->Scalar1.ID()).S(), GetVReg(Op->Scalar2.ID()).S());
   }
   else {
-    fcmp(GetSrc(Op->Scalar1.ID()).D(), GetSrc(Op->Scalar2.ID()).D());
+    fcmp(GetVReg(Op->Scalar1.ID()).D(), GetVReg(Op->Scalar2.ID()).D());
   }
   auto Dst = GetReg<RA_64>(Node);
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/AtomicOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/AtomicOps.cpp
@@ -14,9 +14,9 @@ using namespace vixl::aarch64;
 DEF_OP(CASPair) {
   auto Op = IROp->C<IR::IROp_CASPair>();
   // Size is the size of each pair element
-  auto Dst = GetSrcPair<RA_64>(Node);
-  auto Expected = GetSrcPair<RA_64>(Op->Expected.ID());
-  auto Desired = GetSrcPair<RA_64>(Op->Desired.ID());
+  auto Dst = GetRegPair<RA_64>(Node);
+  auto Expected = GetRegPair<RA_64>(Op->Expected.ID());
+  auto Desired = GetRegPair<RA_64>(Op->Desired.ID());
   auto MemSrc = GetReg<RA_64>(Op->Addr.ID());
 
   if (CTX->HostFeatures.SupportsAtomics) {

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
@@ -104,7 +104,7 @@ DEF_OP(Jump) {
 }
 
 #define GRCMP(Node) (Op->CompareSize == 4 ? GetReg<RA_32>(Node) : GetReg<RA_64>(Node))
-#define GRFCMP(Node) (Op->CompareSize == 4 ? GetDst(Node).S() : GetDst(Node).D())
+#define GRFCMP(Node) (Op->CompareSize == 4 ? GetVReg(Node).S() : GetVReg(Node).D())
 
 static Condition MapBranchCC(IR::CondClassType Cond) {
   switch (Cond.Val) {

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
@@ -486,7 +486,7 @@ DEF_OP(CPUID) {
 
   // Results are in x0, x1
   // Results want to be in a i64v2 vector
-  auto Dst = GetSrcPair<RA_64>(Node);
+  auto Dst = GetRegPair<RA_64>(Node);
   mov(Dst.first,  x0);
   mov(Dst.second, x1);
 }

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ConversionOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ConversionOps.cpp
@@ -19,8 +19,8 @@ DEF_OP(VInsGPR) {
   const auto ElementSize = Op->Header.ElementSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto DestVector = GetSrc(Op->DestVector.ID());
+  const auto Dst = GetVReg(Node);
+  const auto DestVector = GetVReg(Op->DestVector.ID());
 
   if (HostSupportsSVE && Is256Bit) {
     const auto ElementSizeBits = ElementSize * 8;
@@ -129,17 +129,17 @@ DEF_OP(VCastFromGPR) {
   switch (Op->Header.ElementSize) {
     case 1:
       uxtb(TMP1.W(), GetReg<RA_32>(Op->Src.ID()));
-      fmov(GetDst(Node).S(), TMP1.W());
+      fmov(GetVReg(Node).S(), TMP1.W());
       break;
     case 2:
       uxth(TMP1.W(), GetReg<RA_32>(Op->Src.ID()));
-      fmov(GetDst(Node).S(), TMP1.W());
+      fmov(GetVReg(Node).S(), TMP1.W());
       break;
     case 4:
-      fmov(GetDst(Node).S(), GetReg<RA_32>(Op->Src.ID()).W());
+      fmov(GetVReg(Node).S(), GetReg<RA_32>(Op->Src.ID()).W());
       break;
     case 8:
-      fmov(GetDst(Node).D(), GetReg<RA_64>(Op->Src.ID()).X());
+      fmov(GetVReg(Node).D(), GetReg<RA_64>(Op->Src.ID()).X());
       break;
     default: LOGMAN_MSG_A_FMT("Unknown castGPR element size: {}", Op->Header.ElementSize);
   }
@@ -153,19 +153,19 @@ DEF_OP(Float_FromGPR_S) {
 
   switch (Conv) {
     case 0x0404: { // Float <- int32_t
-      scvtf(GetDst(Node).S(), GetReg<RA_32>(Op->Src.ID()));
+      scvtf(GetVReg(Node).S(), GetReg<RA_32>(Op->Src.ID()));
       break;
     }
     case 0x0408: { // Float <- int64_t
-      scvtf(GetDst(Node).S(), GetReg<RA_64>(Op->Src.ID()));
+      scvtf(GetVReg(Node).S(), GetReg<RA_64>(Op->Src.ID()));
       break;
     }
     case 0x0804: { // Double <- int32_t
-      scvtf(GetDst(Node).D(), GetReg<RA_32>(Op->Src.ID()));
+      scvtf(GetVReg(Node).D(), GetReg<RA_32>(Op->Src.ID()));
       break;
     }
     case 0x0808: { // Double <- int64_t
-      scvtf(GetDst(Node).D(), GetReg<RA_64>(Op->Src.ID()));
+      scvtf(GetVReg(Node).D(), GetReg<RA_64>(Op->Src.ID()));
       break;
     }
     default:
@@ -180,11 +180,11 @@ DEF_OP(Float_FToF) {
   const uint16_t Conv = (Op->Header.ElementSize << 8) | Op->SrcElementSize;
   switch (Conv) {
     case 0x0804: { // Double <- Float
-      fcvt(GetDst(Node).D(), GetSrc(Op->Scalar.ID()).S());
+      fcvt(GetVReg(Node).D(), GetVReg(Op->Scalar.ID()).S());
       break;
     }
     case 0x0408: { // Float <- Double
-      fcvt(GetDst(Node).S(), GetSrc(Op->Scalar.ID()).D());
+      fcvt(GetVReg(Node).S(), GetVReg(Op->Scalar.ID()).D());
       break;
     }
     default: LOGMAN_MSG_A_FMT("Unknown FCVT sizes: 0x{:x}", Conv);
@@ -198,8 +198,8 @@ DEF_OP(Vector_SToF) {
   const auto ElementSize = Op->Header.ElementSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector = GetSrc(Op->Vector.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector = GetVReg(Op->Vector.ID());
 
   if (HostSupportsSVE && Is256Bit) {
     const auto Mask = PRED_TMP_32B.Merging();
@@ -243,8 +243,8 @@ DEF_OP(Vector_FToZS) {
   const auto ElementSize = Op->Header.ElementSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector = GetSrc(Op->Vector.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector = GetVReg(Op->Vector.ID());
 
   if (HostSupportsSVE && Is256Bit) {
     const auto Mask = PRED_TMP_32B.Merging();
@@ -288,8 +288,8 @@ DEF_OP(Vector_FToS) {
   const auto ElementSize = Op->Header.ElementSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector = GetSrc(Op->Vector.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector = GetVReg(Op->Vector.ID());
 
   if (HostSupportsSVE && Is256Bit) {
     const auto Mask = PRED_TMP_32B.Merging();
@@ -340,8 +340,8 @@ DEF_OP(Vector_FToF) {
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
   const auto Conv = (ElementSize << 8) | Op->SrcElementSize;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector = GetSrc(Op->Vector.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector = GetVReg(Op->Vector.ID());
 
   if (HostSupportsSVE && Is256Bit) {
     // Curiously, FCVTLT and FCVTNT have no bottom variants,
@@ -416,8 +416,8 @@ DEF_OP(Vector_FToI) {
   const auto ElementSize = Op->Header.ElementSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector = GetSrc(Op->Vector.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector = GetVReg(Op->Vector.ID());
 
   if (HostSupportsSVE && Is256Bit) {
     const auto Mask = PRED_TMP_32B.Merging();

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/EncryptionOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/EncryptionOps.cpp
@@ -14,41 +14,41 @@ using namespace vixl::aarch64;
 
 DEF_OP(AESImc) {
   auto Op = IROp->C<IR::IROp_VAESImc>();
-  aesimc(GetDst(Node).V16B(), GetSrc(Op->Vector.ID()).V16B());
+  aesimc(GetVReg(Node).V16B(), GetVReg(Op->Vector.ID()).V16B());
 }
 
 DEF_OP(AESEnc) {
   auto Op = IROp->C<IR::IROp_VAESEnc>();
   eor(VTMP2.V16B(), VTMP2.V16B(), VTMP2.V16B());
-  mov(VTMP1.V16B(), GetSrc(Op->State.ID()).V16B());
+  mov(VTMP1.V16B(), GetVReg(Op->State.ID()).V16B());
   aese(VTMP1.V16B(), VTMP2.V16B());
   aesmc(VTMP1.V16B(), VTMP1.V16B());
-  eor(GetDst(Node).V16B(), VTMP1.V16B(), GetSrc(Op->Key.ID()).V16B());
+  eor(GetVReg(Node).V16B(), VTMP1.V16B(), GetVReg(Op->Key.ID()).V16B());
 }
 
 DEF_OP(AESEncLast) {
   auto Op = IROp->C<IR::IROp_VAESEncLast>();
   eor(VTMP2.V16B(), VTMP2.V16B(), VTMP2.V16B());
-  mov(VTMP1.V16B(), GetSrc(Op->State.ID()).V16B());
+  mov(VTMP1.V16B(), GetVReg(Op->State.ID()).V16B());
   aese(VTMP1.V16B(), VTMP2.V16B());
-  eor(GetDst(Node).V16B(), VTMP1.V16B(), GetSrc(Op->Key.ID()).V16B());
+  eor(GetVReg(Node).V16B(), VTMP1.V16B(), GetVReg(Op->Key.ID()).V16B());
 }
 
 DEF_OP(AESDec) {
   auto Op = IROp->C<IR::IROp_VAESDec>();
   eor(VTMP2.V16B(), VTMP2.V16B(), VTMP2.V16B());
-  mov(VTMP1.V16B(), GetSrc(Op->State.ID()).V16B());
+  mov(VTMP1.V16B(), GetVReg(Op->State.ID()).V16B());
   aesd(VTMP1.V16B(), VTMP2.V16B());
   aesimc(VTMP1.V16B(), VTMP1.V16B());
-  eor(GetDst(Node).V16B(), VTMP1.V16B(), GetSrc(Op->Key.ID()).V16B());
+  eor(GetVReg(Node).V16B(), VTMP1.V16B(), GetVReg(Op->Key.ID()).V16B());
 }
 
 DEF_OP(AESDecLast) {
   auto Op = IROp->C<IR::IROp_VAESDecLast>();
   eor(VTMP2.V16B(), VTMP2.V16B(), VTMP2.V16B());
-  mov(VTMP1.V16B(), GetSrc(Op->State.ID()).V16B());
+  mov(VTMP1.V16B(), GetVReg(Op->State.ID()).V16B());
   aesd(VTMP1.V16B(), VTMP2.V16B());
-  eor(GetDst(Node).V16B(), VTMP1.V16B(), GetSrc(Op->Key.ID()).V16B());
+  eor(GetVReg(Node).V16B(), VTMP1.V16B(), GetVReg(Op->Key.ID()).V16B());
 }
 
 DEF_OP(AESKeyGenAssist) {
@@ -59,7 +59,7 @@ DEF_OP(AESKeyGenAssist) {
 
   // Do a "regular" AESE step
   eor(VTMP2.V16B(), VTMP2.V16B(), VTMP2.V16B());
-  mov(VTMP1.V16B(), GetSrc(Op->Src.ID()).V16B());
+  mov(VTMP1.V16B(), GetVReg(Op->Src.ID()).V16B());
   aese(VTMP1.V16B(), VTMP2.V16B());
 
   // Do a table shuffle to undo ShiftRows
@@ -71,10 +71,10 @@ DEF_OP(AESKeyGenAssist) {
 
     LoadConstant(TMP1, static_cast<uint64_t>(Op->RCON) << 32);
     dup(VTMP2.V2D(), TMP1);
-    eor(GetDst(Node).V16B(), VTMP1.V16B(), VTMP2.V16B());
+    eor(GetVReg(Node).V16B(), VTMP1.V16B(), VTMP2.V16B());
   }
   else {
-    tbl(GetDst(Node).V16B(), VTMP1.V16B(), VTMP3.V16B());
+    tbl(GetVReg(Node).V16B(), VTMP1.V16B(), VTMP3.V16B());
   }
 
   b(&PastConstant);
@@ -104,9 +104,9 @@ DEF_OP(CRC32) {
 DEF_OP(PCLMUL) {
   auto Op = IROp->C<IR::IROp_PCLMUL>();
 
-  auto Dst  = GetDst(Node).Q();
-  auto Src1 = GetSrc(Op->Src1.ID()).V2D();
-  auto Src2 = GetSrc(Op->Src2.ID()).V2D();
+  auto Dst  = GetVReg(Node).Q();
+  auto Src1 = GetVReg(Op->Src1.ID()).V2D();
+  auto Src2 = GetVReg(Op->Src2.ID()).V2D();
 
   switch (Op->Selector) {
   case 0b00000000:

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -113,7 +113,7 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header const *IROp, IR::NodeID Node) {
 
         PushDynamicRegsAndLR(TMP1);
 
-        fmov(v0.S(), GetSrc(IROp->Args[0].ID()).S()) ;
+        fmov(v0.S(), GetVReg(IROp->Args[0].ID()).S()) ;
         ldr(x0, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.FallbackHandlerPointers[Info.HandlerIndex])));
 #ifdef VIXL_SIMULATOR
         GenerateIndirectRuntimeCall<__uint128_t, float>(x0);
@@ -125,9 +125,9 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header const *IROp, IR::NodeID Node) {
 
         FillStaticRegs();
 
-        eor(GetDst(Node).V16B(), GetDst(Node).V16B(), GetDst(Node).V16B());
-        ins(GetDst(Node).V2D(), 0, x0);
-        ins(GetDst(Node).V8H(), 4, w1);
+        eor(GetVReg(Node).V16B(), GetVReg(Node).V16B(), GetVReg(Node).V16B());
+        ins(GetVReg(Node).V2D(), 0, x0);
+        ins(GetVReg(Node).V8H(), 4, w1);
       }
       break;
 
@@ -136,7 +136,7 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header const *IROp, IR::NodeID Node) {
 
         PushDynamicRegsAndLR(TMP1);
 
-        mov(v0.D(), GetSrc(IROp->Args[0].ID()).D());
+        mov(v0.D(), GetVReg(IROp->Args[0].ID()).D());
         ldr(x0, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.FallbackHandlerPointers[Info.HandlerIndex])));
 #ifdef VIXL_SIMULATOR
         GenerateIndirectRuntimeCall<__uint128_t, double>(x0);
@@ -148,9 +148,9 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header const *IROp, IR::NodeID Node) {
 
         FillStaticRegs();
 
-        eor(GetDst(Node).V16B(), GetDst(Node).V16B(), GetDst(Node).V16B());
-        ins(GetDst(Node).V2D(), 0, x0);
-        ins(GetDst(Node).V8H(), 4, w1);
+        eor(GetVReg(Node).V16B(), GetVReg(Node).V16B(), GetVReg(Node).V16B());
+        ins(GetVReg(Node).V2D(), 0, x0);
+        ins(GetVReg(Node).V8H(), 4, w1);
       }
       break;
 
@@ -177,9 +177,9 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header const *IROp, IR::NodeID Node) {
 
         FillStaticRegs();
 
-        eor(GetDst(Node).V16B(), GetDst(Node).V16B(), GetDst(Node).V16B());
-        ins(GetDst(Node).V2D(), 0, x0);
-        ins(GetDst(Node).V8H(), 4, w1);
+        eor(GetVReg(Node).V16B(), GetVReg(Node).V16B(), GetVReg(Node).V16B());
+        ins(GetVReg(Node).V2D(), 0, x0);
+        ins(GetVReg(Node).V8H(), 4, w1);
       }
       break;
 
@@ -188,8 +188,8 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header const *IROp, IR::NodeID Node) {
 
         PushDynamicRegsAndLR(TMP1);
 
-        umov(x0, GetSrc(IROp->Args[0].ID()).V2D(), 0);
-        umov(w1, GetSrc(IROp->Args[0].ID()).V8H(), 4);
+        umov(x0, GetVReg(IROp->Args[0].ID()).V2D(), 0);
+        umov(w1, GetVReg(IROp->Args[0].ID()).V8H(), 4);
 
         ldr(x2, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.FallbackHandlerPointers[Info.HandlerIndex])));
 #ifdef VIXL_SIMULATOR
@@ -202,7 +202,7 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header const *IROp, IR::NodeID Node) {
 
         FillStaticRegs();
 
-        fmov(GetDst(Node).S(), v0.S());
+        fmov(GetVReg(Node).S(), v0.S());
       }
       break;
 
@@ -211,8 +211,8 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header const *IROp, IR::NodeID Node) {
 
         PushDynamicRegsAndLR(TMP1);
 
-        umov(x0, GetSrc(IROp->Args[0].ID()).V2D(), 0);
-        umov(w1, GetSrc(IROp->Args[0].ID()).V8H(), 4);
+        umov(x0, GetVReg(IROp->Args[0].ID()).V2D(), 0);
+        umov(w1, GetVReg(IROp->Args[0].ID()).V8H(), 4);
 
         ldr(x2, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.FallbackHandlerPointers[Info.HandlerIndex])));
 #ifdef VIXL_SIMULATOR
@@ -225,7 +225,7 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header const *IROp, IR::NodeID Node) {
 
         FillStaticRegs();
 
-        mov(GetDst(Node).D(), v0.D());
+        mov(GetVReg(Node).D(), v0.D());
       }
       break;
 
@@ -234,7 +234,7 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header const *IROp, IR::NodeID Node) {
 
         PushDynamicRegsAndLR(TMP1);
 
-        mov(v0.D(), GetSrc(IROp->Args[0].ID()).D());
+        mov(v0.D(), GetVReg(IROp->Args[0].ID()).D());
         ldr(x0, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.FallbackHandlerPointers[Info.HandlerIndex])));
 #ifdef VIXL_SIMULATOR
         GenerateIndirectRuntimeCall<double, double>(x0);
@@ -246,7 +246,7 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header const *IROp, IR::NodeID Node) {
 
         FillStaticRegs();
 
-        mov(GetDst(Node).D(), v0.D());
+        mov(GetVReg(Node).D(), v0.D());
 
       }
       break;
@@ -256,8 +256,8 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header const *IROp, IR::NodeID Node) {
 
         PushDynamicRegsAndLR(TMP1);
 
-        mov(v0.D(), GetSrc(IROp->Args[0].ID()).D());
-        mov(v1.D(), GetSrc(IROp->Args[1].ID()).D());
+        mov(v0.D(), GetVReg(IROp->Args[0].ID()).D());
+        mov(v1.D(), GetVReg(IROp->Args[1].ID()).D());
         ldr(x0, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.FallbackHandlerPointers[Info.HandlerIndex])));
 #ifdef VIXL_SIMULATOR
         GenerateIndirectRuntimeCall<double, double, double>(x0);
@@ -269,7 +269,7 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header const *IROp, IR::NodeID Node) {
 
         FillStaticRegs();
 
-        mov(GetDst(Node).D(), v0.D());
+        mov(GetVReg(Node).D(), v0.D());
 
       }
       break;
@@ -279,8 +279,8 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header const *IROp, IR::NodeID Node) {
 
         PushDynamicRegsAndLR(TMP1);
 
-        umov(x0, GetSrc(IROp->Args[0].ID()).V2D(), 0);
-        umov(w1, GetSrc(IROp->Args[0].ID()).V8H(), 4);
+        umov(x0, GetVReg(IROp->Args[0].ID()).V2D(), 0);
+        umov(w1, GetVReg(IROp->Args[0].ID()).V8H(), 4);
 
         ldr(x2, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.FallbackHandlerPointers[Info.HandlerIndex])));
 #ifdef VIXL_SIMULATOR
@@ -301,8 +301,8 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header const *IROp, IR::NodeID Node) {
 
         PushDynamicRegsAndLR(TMP1);
 
-        umov(x0, GetSrc(IROp->Args[0].ID()).V2D(), 0);
-        umov(w1, GetSrc(IROp->Args[0].ID()).V8H(), 4);
+        umov(x0, GetVReg(IROp->Args[0].ID()).V2D(), 0);
+        umov(w1, GetVReg(IROp->Args[0].ID()).V8H(), 4);
 
         ldr(x2, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.FallbackHandlerPointers[Info.HandlerIndex])));
 #ifdef VIXL_SIMULATOR
@@ -323,8 +323,8 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header const *IROp, IR::NodeID Node) {
 
         PushDynamicRegsAndLR(TMP1);
 
-        umov(x0, GetSrc(IROp->Args[0].ID()).V2D(), 0);
-        umov(w1, GetSrc(IROp->Args[0].ID()).V8H(), 4);
+        umov(x0, GetVReg(IROp->Args[0].ID()).V2D(), 0);
+        umov(w1, GetVReg(IROp->Args[0].ID()).V8H(), 4);
 
         ldr(x2, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.FallbackHandlerPointers[Info.HandlerIndex])));
 #ifdef VIXL_SIMULATOR
@@ -345,11 +345,11 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header const *IROp, IR::NodeID Node) {
 
         PushDynamicRegsAndLR(TMP1);
 
-        umov(x0, GetSrc(IROp->Args[0].ID()).V2D(), 0);
-        umov(w1, GetSrc(IROp->Args[0].ID()).V8H(), 4);
+        umov(x0, GetVReg(IROp->Args[0].ID()).V2D(), 0);
+        umov(w1, GetVReg(IROp->Args[0].ID()).V8H(), 4);
 
-        umov(x2, GetSrc(IROp->Args[1].ID()).V2D(), 0);
-        umov(w3, GetSrc(IROp->Args[1].ID()).V8H(), 4);
+        umov(x2, GetVReg(IROp->Args[1].ID()).V2D(), 0);
+        umov(w3, GetVReg(IROp->Args[1].ID()).V8H(), 4);
 
         ldr(x4, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.FallbackHandlerPointers[Info.HandlerIndex])));
 #ifdef VIXL_SIMULATOR
@@ -369,8 +369,8 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header const *IROp, IR::NodeID Node) {
 
         PushDynamicRegsAndLR(TMP1);
 
-        umov(x0, GetSrc(IROp->Args[0].ID()).V2D(), 0);
-        umov(w1, GetSrc(IROp->Args[0].ID()).V8H(), 4);
+        umov(x0, GetVReg(IROp->Args[0].ID()).V2D(), 0);
+        umov(w1, GetVReg(IROp->Args[0].ID()).V8H(), 4);
 
         ldr(x2, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.FallbackHandlerPointers[Info.HandlerIndex])));
 #ifdef VIXL_SIMULATOR
@@ -383,9 +383,9 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header const *IROp, IR::NodeID Node) {
 
         FillStaticRegs();
 
-        eor(GetDst(Node).V16B(), GetDst(Node).V16B(), GetDst(Node).V16B());
-        ins(GetDst(Node).V2D(), 0, x0);
-        ins(GetDst(Node).V8H(), 4, w1);
+        eor(GetVReg(Node).V16B(), GetVReg(Node).V16B(), GetVReg(Node).V16B());
+        ins(GetVReg(Node).V2D(), 0, x0);
+        ins(GetVReg(Node).V8H(), 4, w1);
       }
       break;
       case FABI_F80_F80_F80:{
@@ -393,11 +393,11 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header const *IROp, IR::NodeID Node) {
 
         PushDynamicRegsAndLR(TMP1);
 
-        umov(x0, GetSrc(IROp->Args[0].ID()).V2D(), 0);
-        umov(w1, GetSrc(IROp->Args[0].ID()).V8H(), 4);
+        umov(x0, GetVReg(IROp->Args[0].ID()).V2D(), 0);
+        umov(w1, GetVReg(IROp->Args[0].ID()).V8H(), 4);
 
-        umov(x2, GetSrc(IROp->Args[1].ID()).V2D(), 0);
-        umov(w3, GetSrc(IROp->Args[1].ID()).V8H(), 4);
+        umov(x2, GetVReg(IROp->Args[1].ID()).V2D(), 0);
+        umov(w3, GetVReg(IROp->Args[1].ID()).V8H(), 4);
 
         ldr(x4, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.FallbackHandlerPointers[Info.HandlerIndex])));
 #ifdef VIXL_SIMULATOR
@@ -410,9 +410,9 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header const *IROp, IR::NodeID Node) {
 
         FillStaticRegs();
 
-        eor(GetDst(Node).V16B(), GetDst(Node).V16B(), GetDst(Node).V16B());
-        ins(GetDst(Node).V2D(), 0, x0);
-        ins(GetDst(Node).V8H(), 4, w1);
+        eor(GetVReg(Node).V16B(), GetVReg(Node).V16B(), GetVReg(Node).V16B());
+        ins(GetVReg(Node).V2D(), 0, x0);
+        ins(GetVReg(Node).V8H(), 4, w1);
       }
       break;
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -90,7 +90,7 @@ private:
   [[nodiscard]] aarch64::Register GetReg(IR::NodeID Node) const;
 
   template<uint8_t RAType>
-  [[nodiscard]] std::pair<aarch64::Register, aarch64::Register> GetSrcPair(IR::NodeID Node) const;
+  [[nodiscard]] std::pair<aarch64::Register, aarch64::Register> GetRegPair(IR::NodeID Node) const;
 
   [[nodiscard]] FEXCore::IR::RegisterClassType GetRegClass(IR::NodeID Node) const;
 
@@ -115,14 +115,14 @@ private:
   }
 
   template<>
-  [[nodiscard]] std::pair<aarch64::Register, aarch64::Register> GetSrcPair<Arm64JITCore::RA_32>(IR::NodeID Node) const {
+  [[nodiscard]] std::pair<aarch64::Register, aarch64::Register> GetRegPair<Arm64JITCore::RA_32>(IR::NodeID Node) const {
     uint32_t Reg = GetPhys(Node).Reg;
     auto Pair = RA64Pair[Reg];
     return std::make_pair(Pair.first.W(), Pair.second.W());
   }
 
   template<>
-  [[nodiscard]] std::pair<aarch64::Register, aarch64::Register> GetSrcPair<Arm64JITCore::RA_64>(IR::NodeID Node) const {
+  [[nodiscard]] std::pair<aarch64::Register, aarch64::Register> GetRegPair<Arm64JITCore::RA_64>(IR::NodeID Node) const {
     uint32_t Reg = GetPhys(Node).Reg;
     return RA64Pair[Reg];
   }

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -127,21 +127,8 @@ private:
     return RA64Pair[Reg];
   }
 
-  [[nodiscard]] aarch64::VRegister GetSrc(IR::NodeID Node) const {
-    auto Reg = GetPhys(Node);
 
-    LOGMAN_THROW_AA_FMT(Reg.Class == IR::FPRFixedClass.Val || Reg.Class == IR::FPRClass.Val, "Unexpected Class: {}", Reg.Class);
-
-    if (Reg.Class == IR::FPRFixedClass.Val) {
-      return SRAFPR[Reg.Reg];
-    } else if (Reg.Class == IR::FPRClass.Val) {
-      return RAFPR[Reg.Reg];
-    }
-
-    FEX_UNREACHABLE;
-  }
-
-  [[nodiscard]] aarch64::VRegister GetDst(IR::NodeID Node) const {
+  [[nodiscard]] aarch64::VRegister GetVReg(IR::NodeID Node) const {
     auto Reg = GetPhys(Node);
 
     LOGMAN_THROW_AA_FMT(Reg.Class == IR::FPRFixedClass.Val || Reg.Class == IR::FPRClass.Val, "Unexpected Class: {}", Reg.Class);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -41,7 +41,7 @@ DEF_OP(LoadContext) {
     }
   }
   else {
-    const auto Dst = GetDst(Node);
+    const auto Dst = GetVReg(Node);
 
     switch (OpSize) {
     case 1:
@@ -96,7 +96,7 @@ DEF_OP(StoreContext) {
     }
   }
   else {
-    const auto Src =  GetSrc(Op->Value.ID());
+    const auto Src = GetVReg(Op->Value.ID());
 
     switch (OpSize) {
     case 1:
@@ -174,7 +174,7 @@ DEF_OP(LoadRegister) {
     LOGMAN_THROW_A_FMT(regId < SRAFPR.size(), "out of range regId");
 
     const auto guest = SRAFPR[regId];
-    const auto host = GetSrc(Node);
+    const auto host = GetVReg(Node);
 
     if (HostSupportsSVE) {
       const auto regOffs = Op->Offset & 31;
@@ -365,7 +365,7 @@ DEF_OP(StoreRegister) {
     LOGMAN_THROW_A_FMT(regId < SRAFPR.size(), "regId out of range");
 
     const auto guest = SRAFPR[regId];
-    const auto host = GetSrc(Op->Value.ID());
+    const auto host = GetVReg(Op->Value.ID());
 
     if (HostSupportsSVE) {
       // 256-bit capable hardware allows us to expand the allowed
@@ -569,7 +569,7 @@ DEF_OP(LoadContextIndexed) {
       mul(TMP1, Index, TMP1);
       add(TMP1, STATE, TMP1);
 
-      const auto Dst = GetDst(Node);
+      const auto Dst = GetVReg(Node);
 
       switch (OpSize) {
       case 1:
@@ -653,7 +653,7 @@ DEF_OP(StoreContextIndexed) {
     }
   }
   else {
-    const auto Value = GetSrc(Op->Value.ID());
+    const auto Value = GetVReg(Op->Value.ID());
 
     switch (Op->Stride) {
     case 1:
@@ -728,7 +728,7 @@ DEF_OP(SpillRegister) {
       break;
     }
   } else if (Op->Class == FEXCore::IR::FPRClass) {
-    const auto Src = GetSrc(Op->Value.ID());
+    const auto Src = GetVReg(Op->Value.ID());
 
     switch (OpSize) {
     case 4: {
@@ -785,7 +785,7 @@ DEF_OP(FillRegister) {
       break;
     }
   } else if (Op->Class == FEXCore::IR::FPRClass) {
-    const auto Dst = GetDst(Node);
+    const auto Dst = GetVReg(Node);
 
     switch (OpSize) {
     case 4: {
@@ -934,7 +934,7 @@ DEF_OP(LoadMem) {
     }
   }
   else {
-    const auto Dst = GetDst(Node);
+    const auto Dst = GetVReg(Node);
 
     switch (OpSize) {
       case 1:
@@ -1068,7 +1068,7 @@ DEF_OP(LoadMemTSO) {
   }
   else {
     dmb(InnerShareable, BarrierAll);
-    const auto Dst = GetDst(Node);
+    const auto Dst = GetVReg(Node);
     switch (OpSize) {
       case 1:
       case 2:
@@ -1121,7 +1121,7 @@ DEF_OP(StoreMem) {
     }
   }
   else {
-    const auto Src = GetSrc(Op->Value.ID());
+    const auto Src = GetVReg(Op->Value.ID());
 
     switch (OpSize) {
       case 1:
@@ -1220,7 +1220,7 @@ DEF_OP(StoreMemTSO) {
   }
   else {
     dmb(InnerShareable, BarrierAll);
-    const auto Src = GetSrc(Op->Value.ID());
+    const auto Src = GetVReg(Op->Value.ID());
     switch (OpSize) {
       case 1:
       case 2:
@@ -1277,7 +1277,7 @@ DEF_OP(ParanoidLoadMemTSO) {
     }
   }
   else {
-    const auto Dst = GetDst(Node);
+    const auto Dst = GetVReg(Node);
     switch (OpSize) {
       case 1:
         ldarb(TMP1.W(), MemSrc);
@@ -1345,7 +1345,7 @@ DEF_OP(ParanoidStoreMemTSO) {
     }
   }
   else {
-    const auto Src = GetSrc(Op->Value.ID());
+    const auto Src = GetVReg(Op->Value.ID());
 
     switch (OpSize) {
       case 1:

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
@@ -147,9 +147,9 @@ DEF_OP(Print) {
     ldr(x3, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.PrintValue)));
   }
   else {
-    fmov(x0, GetSrc(Op->Value.ID()).V1D());
+    fmov(x0, GetVReg(Op->Value.ID()).V1D());
     // Bug in vixl that source vector needs to b V1D rather than V2D?
-    fmov(x1, GetSrc(Op->Value.ID()).V1D(), 1);
+    fmov(x1, GetVReg(Op->Value.ID()).V1D(), 1);
     ldr(x3, MemOperand(STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.PrintVectorValue)));
   }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
@@ -216,7 +216,7 @@ DEF_OP(RDRAND) {
 
   // Results are in x0, x1
   // Results want to be in a i64v2 vector
-  auto Dst = GetSrcPair<RA_64>(Node);
+  auto Dst = GetRegPair<RA_64>(Node);
 
   if (Op->GetReseeded) {
     mrs(Dst.first, RNDRRS);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MoveOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MoveOps.cpp
@@ -15,13 +15,13 @@ DEF_OP(ExtractElementPair) {
   auto Op = IROp->C<IR::IROp_ExtractElementPair>();
   switch (Op->Header.Size) {
     case 4: {
-      auto Src = GetSrcPair<RA_32>(Op->Pair.ID());
+      auto Src = GetRegPair<RA_32>(Op->Pair.ID());
       std::array<aarch64::Register, 2> Regs = {Src.first, Src.second};
       mov (GetReg<RA_32>(Node), Regs[Op->Element]);
       break;
     }
     case 8: {
-      auto Src = GetSrcPair<RA_64>(Op->Pair.ID());
+      auto Src = GetRegPair<RA_64>(Op->Pair.ID());
       std::array<aarch64::Register, 2> Regs = {Src.first, Src.second};
       mov (GetReg<RA_64>(Node), Regs[Op->Element]);
       break;
@@ -39,14 +39,14 @@ DEF_OP(CreateElementPair) {
 
   switch (IROp->ElementSize) {
     case 4: {
-      Dst = GetSrcPair<RA_32>(Node);
+      Dst = GetRegPair<RA_32>(Node);
       RegFirst = GetReg<RA_32>(Op->Lower.ID());
       RegSecond = GetReg<RA_32>(Op->Upper.ID());
       RegTmp = w0;
       break;
     }
     case 8: {
-      Dst = GetSrcPair<RA_64>(Node);
+      Dst = GetRegPair<RA_64>(Node);
       RegFirst = GetReg<RA_64>(Op->Lower.ID());
       RegSecond = GetReg<RA_64>(Op->Upper.ID());
       RegTmp = x0;

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -13,19 +13,19 @@ using namespace vixl::aarch64;
 #define DEF_OP(x) void Arm64JITCore::Op_##x(IR::IROp_Header const *IROp, IR::NodeID Node)
 DEF_OP(VectorZero) {
   if (HostSupportsSVE) {
-    const auto Dst = GetDst(Node).Z().VnD();
+    const auto Dst = GetVReg(Node).Z().VnD();
     eor(Dst, Dst, Dst);
   } else {
     const uint8_t OpSize = IROp->Size;
 
     switch (OpSize) {
       case 8: {
-        const auto Dst = GetDst(Node).V8B();
+        const auto Dst = GetVReg(Node).V8B();
         eor(Dst, Dst, Dst);
         break;
       }
       case 16: {
-        const auto Dst = GetDst(Node).V16B();
+        const auto Dst = GetVReg(Node).V16B();
         eor(Dst, Dst, Dst);
         break;
       }
@@ -45,7 +45,7 @@ DEF_OP(VectorImm) {
 
   if (HostSupportsSVE) {
     const auto Dst = [&] {
-      const auto Tmp = GetDst(Node).Z();
+      const auto Tmp = GetVReg(Node).Z();
       switch (ElementSize) {
       case 1:
         return Tmp.VnB();
@@ -73,10 +73,10 @@ DEF_OP(VectorImm) {
     if (ElementSize == 8) {
       // movi with 64bit element size doesn't do what we want here
       LoadConstant(TMP1.X(), Op->Immediate);
-      dup(GetDst(Node).V2D(), TMP1.X());
+      dup(GetVReg(Node).V2D(), TMP1.X());
     }
     else {
-      movi(GetDst(Node).VCast(OpSize * 8, Elements), Op->Immediate);
+      movi(GetVReg(Node).VCast(OpSize * 8, Elements), Op->Immediate);
     }
   }
 }
@@ -85,8 +85,8 @@ DEF_OP(VMov) {
   const auto Op = IROp->C<IR::IROp_VMov>();
   const auto OpSize = IROp->Size;
 
-  const auto Dst = GetDst(Node);
-  const auto Source = GetSrc(Op->Source.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Source = GetVReg(Op->Source.ID());
 
   switch (OpSize) {
     case 1: {
@@ -140,9 +140,9 @@ DEF_OP(VMov) {
 DEF_OP(VAnd) {
   auto Op = IROp->C<IR::IROp_VAnd>();
 
-  const auto Dst = GetDst(Node);
-  const auto Vector1 = GetSrc(Op->Vector1.ID());
-  const auto Vector2 = GetSrc(Op->Vector2.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector1 = GetVReg(Op->Vector1.ID());
+  const auto Vector2 = GetVReg(Op->Vector2.ID());
 
   if (HostSupportsSVE) {
     and_(Dst.Z().VnD(), Vector1.Z().VnD(), Vector2.Z().VnD());
@@ -154,9 +154,9 @@ DEF_OP(VAnd) {
 DEF_OP(VBic) {
   auto Op = IROp->C<IR::IROp_VBic>();
 
-  const auto Dst = GetDst(Node);
-  const auto Vector1 = GetSrc(Op->Vector1.ID());
-  const auto Vector2 = GetSrc(Op->Vector2.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector1 = GetVReg(Op->Vector1.ID());
+  const auto Vector2 = GetVReg(Op->Vector2.ID());
 
   if (HostSupportsSVE) {
     bic(Dst.Z().VnD(), Vector1.Z().VnD(), Vector2.Z().VnD());
@@ -168,9 +168,9 @@ DEF_OP(VBic) {
 DEF_OP(VOr) {
   auto Op = IROp->C<IR::IROp_VOr>();
 
-  const auto Dst = GetDst(Node);
-  const auto Vector1 = GetSrc(Op->Vector1.ID());
-  const auto Vector2 = GetSrc(Op->Vector2.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector1 = GetVReg(Op->Vector1.ID());
+  const auto Vector2 = GetVReg(Op->Vector2.ID());
 
   if (HostSupportsSVE) {
     orr(Dst.Z().VnD(), Vector1.Z().VnD(), Vector2.Z().VnD());
@@ -182,9 +182,9 @@ DEF_OP(VOr) {
 DEF_OP(VXor) {
   auto Op = IROp->C<IR::IROp_VXor>();
 
-  const auto Dst = GetDst(Node);
-  const auto Vector1 = GetSrc(Op->Vector1.ID());
-  const auto Vector2 = GetSrc(Op->Vector2.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector1 = GetVReg(Op->Vector1.ID());
+  const auto Vector2 = GetVReg(Op->Vector2.ID());
 
   if (HostSupportsSVE) {
     eor(Dst.Z().VnD(), Vector1.Z().VnD(), Vector2.Z().VnD());
@@ -198,9 +198,9 @@ DEF_OP(VAdd) {
 
   const auto ElementSize = Op->Header.ElementSize;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector1 = GetSrc(Op->Vector1.ID());
-  const auto Vector2 = GetSrc(Op->Vector2.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector1 = GetVReg(Op->Vector1.ID());
+  const auto Vector2 = GetVReg(Op->Vector2.ID());
 
   switch (ElementSize) {
     case 1: {
@@ -246,9 +246,9 @@ DEF_OP(VSub) {
 
   const auto ElementSize = Op->Header.ElementSize;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector1 = GetSrc(Op->Vector1.ID());
-  const auto Vector2 = GetSrc(Op->Vector2.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector1 = GetVReg(Op->Vector1.ID());
+  const auto Vector2 = GetVReg(Op->Vector2.ID());
 
   switch (ElementSize) {
     case 1: {
@@ -294,9 +294,9 @@ DEF_OP(VUQAdd) {
 
   const auto ElementSize = Op->Header.ElementSize;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector1 = GetSrc(Op->Vector1.ID());
-  const auto Vector2 = GetSrc(Op->Vector2.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector1 = GetVReg(Op->Vector1.ID());
+  const auto Vector2 = GetVReg(Op->Vector2.ID());
 
   switch (ElementSize) {
     case 1: {
@@ -342,9 +342,9 @@ DEF_OP(VUQSub) {
 
   const auto ElementSize = Op->Header.ElementSize;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector1 = GetSrc(Op->Vector1.ID());
-  const auto Vector2 = GetSrc(Op->Vector2.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector1 = GetVReg(Op->Vector1.ID());
+  const auto Vector2 = GetVReg(Op->Vector2.ID());
 
   switch (ElementSize) {
     case 1: {
@@ -390,9 +390,9 @@ DEF_OP(VSQAdd) {
 
   const auto ElementSize = Op->Header.ElementSize;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector1 = GetSrc(Op->Vector1.ID());
-  const auto Vector2 = GetSrc(Op->Vector2.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector1 = GetVReg(Op->Vector1.ID());
+  const auto Vector2 = GetVReg(Op->Vector2.ID());
 
   switch (ElementSize) {
     case 1: {
@@ -438,9 +438,9 @@ DEF_OP(VSQSub) {
 
   const auto ElementSize = Op->Header.ElementSize;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector1 = GetSrc(Op->Vector1.ID());
-  const auto Vector2 = GetSrc(Op->Vector2.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector1 = GetVReg(Op->Vector1.ID());
+  const auto Vector2 = GetVReg(Op->Vector2.ID());
 
   switch (ElementSize) {
     case 1: {
@@ -489,9 +489,9 @@ DEF_OP(VAddP) {
 
   const auto ElementSize = Op->Header.ElementSize;
 
-  const auto Dst = GetDst(Node);
-  const auto VectorLower = GetSrc(Op->VectorLower.ID());
-  const auto VectorUpper = GetSrc(Op->VectorUpper.ID());
+  const auto Dst = GetVReg(Node);
+  const auto VectorLower = GetVReg(Op->VectorLower.ID());
+  const auto VectorUpper = GetVReg(Op->VectorUpper.ID());
 
   if (HostSupportsSVE && Is256Bit && !IsScalar) {
     const auto Pred = PRED_TMP_32B.Merging();
@@ -589,8 +589,8 @@ DEF_OP(VAddV) {
   const auto Elements = OpSize / ElementSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector = GetSrc(Op->Vector.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector = GetVReg(Op->Vector.ID());
 
   if (HostSupportsSVE && Is256Bit) {
     // SVE doesn't have an equivalent ADDV instruction, so we make do
@@ -656,8 +656,8 @@ DEF_OP(VUMinV) {
   const auto ElementSize = Op->Header.ElementSize;
   const auto Elements = OpSize / ElementSize;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector = GetSrc(Op->Vector.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector = GetVReg(Op->Vector.ID());
 
   if (HostSupportsSVE) {
     LOGMAN_THROW_AA_FMT(OpSize == 16 || OpSize == 32,
@@ -705,9 +705,9 @@ DEF_OP(VURAvg) {
   const auto ElementSize = Op->Header.ElementSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector1 = GetSrc(Op->Vector1.ID());
-  const auto Vector2 = GetSrc(Op->Vector2.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector1 = GetVReg(Op->Vector1.ID());
+  const auto Vector2 = GetVReg(Op->Vector2.ID());
 
   if (HostSupportsSVE && Is256Bit) {
     const auto Mask = PRED_TMP_32B.Merging();
@@ -771,8 +771,8 @@ DEF_OP(VAbs) {
   const uint8_t ElementSize = Op->Header.ElementSize;
   const uint8_t Elements = OpSize / Op->Header.ElementSize;
 
-  const auto Dst = GetDst(Node);
-  const auto Src = GetSrc(Op->Vector.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Src = GetVReg(Op->Vector.ID());
 
   if (HostSupportsSVE && OpSize == 32) {
     switch (ElementSize) {
@@ -832,8 +832,8 @@ DEF_OP(VPopcount) {
 
   const auto ElementSize = Op->Header.ElementSize;
 
-  const auto Dst = GetDst(Node);
-  const auto Src = GetSrc(Op->Vector.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Src = GetVReg(Op->Vector.ID());
 
   if (HostSupportsSVE && !IsScalar) {
     const auto Pred = OpSize == 16 ? PRED_TMP_16B.Merging()
@@ -889,9 +889,9 @@ DEF_OP(VFAdd) {
   const auto ElementSize = Op->Header.ElementSize;
   const auto IsScalar = ElementSize == OpSize;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector1 = GetSrc(Op->Vector1.ID());
-  const auto Vector2 = GetSrc(Op->Vector2.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector1 = GetVReg(Op->Vector1.ID());
+  const auto Vector2 = GetVReg(Op->Vector2.ID());
 
   if (HostSupportsSVE && !IsScalar) {
     switch (ElementSize) {
@@ -958,9 +958,9 @@ DEF_OP(VFAddP) {
 
   const auto ElementSize = Op->Header.ElementSize;
 
-  const auto Dst = GetDst(Node);
-  const auto VectorLower = GetSrc(Op->VectorLower.ID());
-  const auto VectorUpper = GetSrc(Op->VectorUpper.ID());
+  const auto Dst = GetVReg(Node);
+  const auto VectorLower = GetVReg(Op->VectorLower.ID());
+  const auto VectorUpper = GetVReg(Op->VectorUpper.ID());
 
   const bool Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
@@ -1029,9 +1029,9 @@ DEF_OP(VFSub) {
   const auto ElementSize = Op->Header.ElementSize;
   const auto IsScalar = ElementSize == OpSize;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector1 = GetSrc(Op->Vector1.ID());
-  const auto Vector2 = GetSrc(Op->Vector2.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector1 = GetVReg(Op->Vector1.ID());
+  const auto Vector2 = GetVReg(Op->Vector2.ID());
 
   if (HostSupportsSVE && !IsScalar) {
     switch (ElementSize) {
@@ -1099,9 +1099,9 @@ DEF_OP(VFMul) {
   const auto ElementSize = Op->Header.ElementSize;
   const auto IsScalar = ElementSize == OpSize;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector1 = GetSrc(Op->Vector1.ID());
-  const auto Vector2 = GetSrc(Op->Vector2.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector1 = GetVReg(Op->Vector1.ID());
+  const auto Vector2 = GetVReg(Op->Vector2.ID());
 
   if (HostSupportsSVE && !IsScalar) {
     switch (ElementSize) {
@@ -1170,9 +1170,9 @@ DEF_OP(VFDiv) {
   const auto IsScalar = ElementSize == OpSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector1 = GetSrc(Op->Vector1.ID());
-  const auto Vector2 = GetSrc(Op->Vector2.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector1 = GetVReg(Op->Vector1.ID());
+  const auto Vector2 = GetVReg(Op->Vector2.ID());
 
   if (HostSupportsSVE && Is256Bit && !IsScalar) {
     const auto Mask = PRED_TMP_32B.Merging();
@@ -1251,9 +1251,9 @@ DEF_OP(VFMin) {
   const auto IsScalar = ElementSize == OpSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector1 = GetSrc(Op->Vector1.ID());
-  const auto Vector2 = GetSrc(Op->Vector2.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector1 = GetVReg(Op->Vector1.ID());
+  const auto Vector2 = GetVReg(Op->Vector2.ID());
 
   // NOTE: We don't directly use FMIN here for any of the implementations,
   //       because it has undesirable NaN handling behavior (it sets
@@ -1369,9 +1369,9 @@ DEF_OP(VFMax) {
   const auto IsScalar = ElementSize == OpSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector1 = GetSrc(Op->Vector1.ID());
-  const auto Vector2 = GetSrc(Op->Vector2.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector1 = GetVReg(Op->Vector1.ID());
+  const auto Vector2 = GetVReg(Op->Vector2.ID());
 
   // NOTE: See VFMin implementation for reasons why we
   //       don't just use FMAX/FMIN for these implementations.
@@ -1470,8 +1470,8 @@ DEF_OP(VFRecp) {
   const auto IsScalar = Op->Header.ElementSize == OpSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector = GetSrc(Op->Vector.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector = GetVReg(Op->Vector.ID());
 
   if (HostSupportsSVE && !IsScalar) {
     const auto Pred = Is256Bit ? PRED_TMP_32B.Merging()
@@ -1554,8 +1554,8 @@ DEF_OP(VFSqrt) {
   const auto IsScalar = ElementSize == OpSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector = GetSrc(Op->Vector.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector = GetVReg(Op->Vector.ID());
 
   if (HostSupportsSVE && !IsScalar) {
     const auto Pred = Is256Bit ? PRED_TMP_32B.Merging()
@@ -1627,8 +1627,8 @@ DEF_OP(VFRSqrt) {
   const auto IsScalar = ElementSize == OpSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector = GetSrc(Op->Vector.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector = GetVReg(Op->Vector.ID());
 
   if (HostSupportsSVE && Is256Bit && !IsScalar) {
     const auto Pred = PRED_TMP_32B.Merging();
@@ -1718,8 +1718,8 @@ DEF_OP(VNeg) {
   const auto ElementSize = Op->Header.ElementSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector = GetSrc(Op->Vector.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector = GetVReg(Op->Vector.ID());
 
   if (HostSupportsSVE) {
     const auto Pred = Is256Bit ? PRED_TMP_32B.Merging()
@@ -1770,8 +1770,8 @@ DEF_OP(VFNeg) {
   const auto ElementSize = Op->Header.ElementSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector = GetSrc(Op->Vector.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector = GetVReg(Op->Vector.ID());
 
   if (HostSupportsSVE) {
     const auto Pred = Is256Bit ? PRED_TMP_32B.Merging()
@@ -1814,8 +1814,8 @@ DEF_OP(VNot) {
   const auto OpSize = IROp->Size;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector = GetSrc(Op->Vector.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector = GetVReg(Op->Vector.ID());
 
   if (HostSupportsSVE && Is256Bit) {
     not_(Dst.Z().VnB(), PRED_TMP_32B.Merging(), Vector.Z().VnB());
@@ -1832,9 +1832,9 @@ DEF_OP(VUMin) {
   const auto IsScalar = ElementSize == OpSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector1 = GetSrc(Op->Vector1.ID());
-  const auto Vector2 = GetSrc(Op->Vector2.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector1 = GetVReg(Op->Vector1.ID());
+  const auto Vector2 = GetVReg(Op->Vector2.ID());
 
   if (HostSupportsSVE && Is256Bit && !IsScalar) {
     const auto Pred = PRED_TMP_32B.Merging();
@@ -1901,9 +1901,9 @@ DEF_OP(VSMin) {
   const auto IsScalar = ElementSize == OpSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector1 = GetSrc(Op->Vector1.ID());
-  const auto Vector2 = GetSrc(Op->Vector2.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector1 = GetVReg(Op->Vector1.ID());
+  const auto Vector2 = GetVReg(Op->Vector2.ID());
 
   if (HostSupportsSVE && Is256Bit && !IsScalar) {
     const auto Pred = PRED_TMP_32B.Merging();
@@ -1970,9 +1970,9 @@ DEF_OP(VUMax) {
   const auto IsScalar = ElementSize == OpSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector1 = GetSrc(Op->Vector1.ID());
-  const auto Vector2 = GetSrc(Op->Vector2.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector1 = GetVReg(Op->Vector1.ID());
+  const auto Vector2 = GetVReg(Op->Vector2.ID());
 
   if (HostSupportsSVE && Is256Bit && !IsScalar) {
     const auto Pred = PRED_TMP_32B.Merging();
@@ -2039,9 +2039,9 @@ DEF_OP(VSMax) {
   const auto IsScalar = ElementSize == OpSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector1 = GetSrc(Op->Vector1.ID());
-  const auto Vector2 = GetSrc(Op->Vector2.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector1 = GetVReg(Op->Vector1.ID());
+  const auto Vector2 = GetVReg(Op->Vector2.ID());
 
   if (HostSupportsSVE && Is256Bit && !IsScalar) {
     const auto Pred = PRED_TMP_32B.Merging();
@@ -2107,9 +2107,9 @@ DEF_OP(VZip) {
   const auto ElementSize = Op->Header.ElementSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto VectorLower = GetSrc(Op->VectorLower.ID());
-  const auto VectorUpper = GetSrc(Op->VectorUpper.ID());
+  const auto Dst = GetVReg(Node);
+  const auto VectorLower = GetVReg(Op->VectorLower.ID());
+  const auto VectorUpper = GetVReg(Op->VectorUpper.ID());
 
   if (HostSupportsSVE && Is256Bit) {
     switch (ElementSize) {
@@ -2185,9 +2185,9 @@ DEF_OP(VZip2) {
   const auto ElementSize = Op->Header.ElementSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto VectorLower = GetSrc(Op->VectorLower.ID());
-  const auto VectorUpper = GetSrc(Op->VectorUpper.ID());
+  const auto Dst = GetVReg(Node);
+  const auto VectorLower = GetVReg(Op->VectorLower.ID());
+  const auto VectorUpper = GetVReg(Op->VectorUpper.ID());
 
   if (HostSupportsSVE && Is256Bit) {
     switch (ElementSize) {
@@ -2263,9 +2263,9 @@ DEF_OP(VUnZip) {
   const auto ElementSize = Op->Header.ElementSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto VectorLower = GetSrc(Op->VectorLower.ID());
-  const auto VectorUpper = GetSrc(Op->VectorUpper.ID());
+  const auto Dst = GetVReg(Node);
+  const auto VectorLower = GetVReg(Op->VectorLower.ID());
+  const auto VectorUpper = GetVReg(Op->VectorUpper.ID());
 
   if (HostSupportsSVE && Is256Bit) {
     switch (ElementSize) {
@@ -2341,9 +2341,9 @@ DEF_OP(VUnZip2) {
   const auto ElementSize = Op->Header.ElementSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto VectorLower = GetSrc(Op->VectorLower.ID());
-  const auto VectorUpper = GetSrc(Op->VectorUpper.ID());
+  const auto Dst = GetVReg(Node);
+  const auto VectorLower = GetVReg(Op->VectorLower.ID());
+  const auto VectorUpper = GetVReg(Op->VectorUpper.ID());
 
   if (HostSupportsSVE && Is256Bit) {
     switch (ElementSize) {
@@ -2416,10 +2416,10 @@ DEF_OP(VBSL) {
   const auto Op = IROp->C<IR::IROp_VBSL>();
   const auto OpSize = IROp->Size;
 
-  const auto Dst = GetDst(Node);
-  const auto VectorFalse = GetSrc(Op->VectorFalse.ID());
-  const auto VectorTrue = GetSrc(Op->VectorTrue.ID());
-  const auto VectorMask = GetSrc(Op->VectorMask.ID());
+  const auto Dst = GetVReg(Node);
+  const auto VectorFalse = GetVReg(Op->VectorFalse.ID());
+  const auto VectorTrue = GetVReg(Op->VectorTrue.ID());
+  const auto VectorMask = GetVReg(Op->VectorMask.ID());
 
   if (HostSupportsSVE) {
     // NOTE: Slight parameter difference from ASIMD
@@ -2449,9 +2449,9 @@ DEF_OP(VCMPEQ) {
   const auto IsScalar = ElementSize == OpSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector1 = GetSrc(Op->Vector1.ID());
-  const auto Vector2 = GetSrc(Op->Vector2.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector1 = GetVReg(Op->Vector1.ID());
+  const auto Vector2 = GetVReg(Op->Vector2.ID());
 
   if (HostSupportsSVE && Is256Bit && !IsScalar) {
     const auto Mask = PRED_TMP_32B.Zeroing();
@@ -2545,8 +2545,8 @@ DEF_OP(VCMPEQZ) {
   const auto IsScalar = ElementSize == OpSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector = GetSrc(Op->Vector.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector = GetVReg(Op->Vector.ID());
 
   if (HostSupportsSVE && Is256Bit && !IsScalar) {
     const auto Mask = PRED_TMP_32B.Zeroing();
@@ -2636,9 +2636,9 @@ DEF_OP(VCMPGT) {
   const auto IsScalar = ElementSize == OpSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector1 = GetSrc(Op->Vector1.ID());
-  const auto Vector2 = GetSrc(Op->Vector2.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector1 = GetVReg(Op->Vector1.ID());
+  const auto Vector2 = GetVReg(Op->Vector2.ID());
 
   if (HostSupportsSVE && Is256Bit && !IsScalar) {
     const auto Mask = PRED_TMP_32B.Zeroing();
@@ -2732,8 +2732,8 @@ DEF_OP(VCMPGTZ) {
   const auto IsScalar = ElementSize == OpSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector = GetSrc(Op->Vector.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector = GetVReg(Op->Vector.ID());
 
   if (HostSupportsSVE && Is256Bit && !IsScalar) {
     const auto Mask = PRED_TMP_32B.Zeroing();
@@ -2823,8 +2823,8 @@ DEF_OP(VCMPLTZ) {
   const auto IsScalar = ElementSize == OpSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector = GetSrc(Op->Vector.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector = GetVReg(Op->Vector.ID());
 
   if (HostSupportsSVE && Is256Bit && !IsScalar) {
     const auto Mask = PRED_TMP_32B.Zeroing();
@@ -2914,9 +2914,9 @@ DEF_OP(VFCMPEQ) {
   const auto IsScalar = ElementSize == OpSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector1 = GetSrc(Op->Vector1.ID());
-  const auto Vector2 = GetSrc(Op->Vector2.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector1 = GetVReg(Op->Vector1.ID());
+  const auto Vector2 = GetVReg(Op->Vector2.ID());
 
   if (HostSupportsSVE && Is256Bit && !IsScalar) {
     const auto Mask = PRED_TMP_32B.Zeroing();
@@ -2999,9 +2999,9 @@ DEF_OP(VFCMPNEQ) {
   const auto IsScalar = ElementSize == OpSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector1 = GetSrc(Op->Vector1.ID());
-  const auto Vector2 = GetSrc(Op->Vector2.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector1 = GetVReg(Op->Vector1.ID());
+  const auto Vector2 = GetVReg(Op->Vector2.ID());
 
   if (HostSupportsSVE && Is256Bit && !IsScalar) {
     const auto Mask = PRED_TMP_32B.Zeroing();
@@ -3085,9 +3085,9 @@ DEF_OP(VFCMPLT) {
   const auto IsScalar = ElementSize == OpSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector1 = GetSrc(Op->Vector1.ID());
-  const auto Vector2 = GetSrc(Op->Vector2.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector1 = GetVReg(Op->Vector1.ID());
+  const auto Vector2 = GetVReg(Op->Vector2.ID());
 
   if (HostSupportsSVE && Is256Bit && !IsScalar) {
     const auto Mask = PRED_TMP_32B.Zeroing();
@@ -3170,9 +3170,9 @@ DEF_OP(VFCMPGT) {
   const auto IsScalar = ElementSize == OpSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector1 = GetSrc(Op->Vector1.ID());
-  const auto Vector2 = GetSrc(Op->Vector2.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector1 = GetVReg(Op->Vector1.ID());
+  const auto Vector2 = GetVReg(Op->Vector2.ID());
 
   if (HostSupportsSVE && Is256Bit && !IsScalar) {
     const auto Mask = PRED_TMP_32B.Zeroing();
@@ -3255,9 +3255,9 @@ DEF_OP(VFCMPLE) {
   const auto IsScalar = ElementSize == OpSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector1 = GetSrc(Op->Vector1.ID());
-  const auto Vector2 = GetSrc(Op->Vector2.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector1 = GetVReg(Op->Vector1.ID());
+  const auto Vector2 = GetVReg(Op->Vector2.ID());
 
   if (HostSupportsSVE && Is256Bit && !IsScalar) {
     const auto Mask = PRED_TMP_32B.Zeroing();
@@ -3340,9 +3340,9 @@ DEF_OP(VFCMPORD) {
   const auto IsScalar = ElementSize == OpSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector1 = GetSrc(Op->Vector1.ID());
-  const auto Vector2 = GetSrc(Op->Vector2.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector1 = GetVReg(Op->Vector1.ID());
+  const auto Vector2 = GetVReg(Op->Vector2.ID());
 
   if (HostSupportsSVE && Is256Bit && !IsScalar) {
     const auto Mask = PRED_TMP_32B.Zeroing();
@@ -3444,9 +3444,9 @@ DEF_OP(VFCMPUNO) {
   const auto IsScalar = ElementSize == OpSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector1 = GetSrc(Op->Vector1.ID());
-  const auto Vector2 = GetSrc(Op->Vector2.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector1 = GetVReg(Op->Vector1.ID());
+  const auto Vector2 = GetVReg(Op->Vector2.ID());
 
   if (HostSupportsSVE && Is256Bit && !IsScalar) {
     const auto Mask = PRED_TMP_32B.Zeroing();
@@ -3558,9 +3558,9 @@ DEF_OP(VUShlS) {
   const auto ElementSize = Op->Header.ElementSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto ShiftScalar = GetSrc(Op->ShiftScalar.ID());
-  const auto Vector = GetSrc(Op->Vector.ID());
+  const auto Dst = GetVReg(Node);
+  const auto ShiftScalar = GetVReg(Op->ShiftScalar.ID());
+  const auto Vector = GetVReg(Op->Vector.ID());
 
   if (HostSupportsSVE && Is256Bit) {
     const auto Mask = PRED_TMP_32B.Merging();
@@ -3632,9 +3632,9 @@ DEF_OP(VUShrS) {
   const auto ElementSize = Op->Header.ElementSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto ShiftScalar = GetSrc(Op->ShiftScalar.ID());
-  const auto Vector = GetSrc(Op->Vector.ID());
+  const auto Dst = GetVReg(Node);
+  const auto ShiftScalar = GetVReg(Op->ShiftScalar.ID());
+  const auto Vector = GetVReg(Op->Vector.ID());
 
   if (HostSupportsSVE && Is256Bit) {
     const auto Mask = PRED_TMP_32B.Merging();
@@ -3710,9 +3710,9 @@ DEF_OP(VSShrS) {
   const auto ElementSize = Op->Header.ElementSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto ShiftScalar = GetSrc(Op->ShiftScalar.ID());
-  const auto Vector = GetSrc(Op->Vector.ID());
+  const auto Dst = GetVReg(Node);
+  const auto ShiftScalar = GetVReg(Op->ShiftScalar.ID());
+  const auto Vector = GetVReg(Op->Vector.ID());
 
   if (HostSupportsSVE && Is256Bit) {
     const auto Mask = PRED_TMP_32B.Merging();
@@ -3791,9 +3791,9 @@ DEF_OP(VInsElement) {
   const auto DestIdx = Op->DestIdx;
   const auto SrcIdx = Op->SrcIdx;
 
-  const auto Dst = GetDst(Node);
-  const auto SrcVector = GetSrc(Op->SrcVector.ID());
-  auto Reg = GetSrc(Op->DestVector.ID());
+  const auto Dst = GetVReg(Node);
+  const auto SrcVector = GetVReg(Op->SrcVector.ID());
+  auto Reg = GetVReg(Op->DestVector.ID());
 
   if (HostSupportsSVE && Is256Bit) {
     // We're going to use this to create our predicate register literal.
@@ -3923,8 +3923,8 @@ DEF_OP(VDupElement) {
   const auto ElementSize = Op->Header.ElementSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector = GetSrc(Op->Vector.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector = GetVReg(Op->Vector.ID());
 
   if (HostSupportsSVE && Is256Bit) {
     switch (ElementSize) {
@@ -3974,9 +3974,9 @@ DEF_OP(VExtr) {
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
   // AArch64 ext op has bit arrangement as [Vm:Vn] so arguments need to be swapped
-  const auto Dst = GetDst(Node);
-  auto UpperBits = GetSrc(Op->VectorLower.ID());
-  auto LowerBits = GetSrc(Op->VectorUpper.ID());
+  const auto Dst = GetVReg(Node);
+  auto UpperBits = GetVReg(Op->VectorLower.ID());
+  auto LowerBits = GetVReg(Op->VectorUpper.ID());
 
   const auto ElementSize = Op->Header.ElementSize;
   auto Index = Op->Index;
@@ -4014,8 +4014,8 @@ DEF_OP(VUShrI) {
   const auto ElementSize = Op->Header.ElementSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector = GetSrc(Op->Vector.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector = GetVReg(Op->Vector.ID());
 
   if (BitShift >= (ElementSize * 8)) {
     eor(Dst.V16B(), Dst.V16B(), Dst.V16B());
@@ -4081,8 +4081,8 @@ DEF_OP(VSShrI) {
   const auto Shift = std::min(uint8_t(ElementSize * 8 - 1), Op->BitShift);
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector = GetSrc(Op->Vector.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector = GetVReg(Op->Vector.ID());
 
   if (HostSupportsSVE && Is256Bit) {
     const auto Mask = PRED_TMP_32B.Merging();
@@ -4144,8 +4144,8 @@ DEF_OP(VShlI) {
   const auto ElementSize = Op->Header.ElementSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector = GetSrc(Op->Vector.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector = GetVReg(Op->Vector.ID());
 
   if (BitShift >= (ElementSize * 8)) {
     eor(Dst.V16B(), Dst.V16B(), Dst.V16B());
@@ -4211,8 +4211,8 @@ DEF_OP(VUShrNI) {
   const auto ElementSize = Op->Header.ElementSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector = GetSrc(Op->Vector.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector = GetVReg(Op->Vector.ID());
 
   if (HostSupportsSVE && Is256Bit) {
     switch (ElementSize) {
@@ -4264,9 +4264,9 @@ DEF_OP(VUShrNI2) {
   const auto ElementSize = Op->Header.ElementSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto VectorLower = GetSrc(Op->VectorLower.ID());
-  const auto VectorUpper = GetSrc(Op->VectorUpper.ID());
+  const auto Dst = GetVReg(Node);
+  const auto VectorLower = GetVReg(Op->VectorLower.ID());
+  const auto VectorUpper = GetVReg(Op->VectorUpper.ID());
 
   if (HostSupportsSVE && Is256Bit) {
     mov(VTMP1.Z().VnD(), VectorLower.Z().VnD());
@@ -4330,8 +4330,8 @@ DEF_OP(VSXTL) {
   const auto ElementSize = Op->Header.ElementSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector = GetSrc(Op->Vector.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector = GetVReg(Op->Vector.ID());
 
   if (HostSupportsSVE && Is256Bit) {
     switch (ElementSize) {
@@ -4373,8 +4373,8 @@ DEF_OP(VSXTL2) {
   const auto ElementSize = Op->Header.ElementSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector = GetSrc(Op->Vector.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector = GetVReg(Op->Vector.ID());
 
   if (HostSupportsSVE && Is256Bit) {
     switch (ElementSize) {
@@ -4416,8 +4416,8 @@ DEF_OP(VUXTL) {
   const auto ElementSize = Op->Header.ElementSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector = GetSrc(Op->Vector.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector = GetVReg(Op->Vector.ID());
 
   if (HostSupportsSVE && Is256Bit) {
     switch (ElementSize) {
@@ -4460,8 +4460,8 @@ DEF_OP(VUXTL2) {
   const auto ElementSize = Op->Header.ElementSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector = GetSrc(Op->Vector.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector = GetVReg(Op->Vector.ID());
 
   if (HostSupportsSVE && Is256Bit) {
     switch (ElementSize) {
@@ -4503,8 +4503,8 @@ DEF_OP(VSQXTN) {
   const auto ElementSize = Op->Header.ElementSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector = GetSrc(Op->Vector.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector = GetVReg(Op->Vector.ID());
 
   if (HostSupportsSVE && Is256Bit) {
     // Note that SVE SQXTNB and SQXTNT are a tad different
@@ -4582,9 +4582,9 @@ DEF_OP(VSQXTN2) {
   const auto ElementSize = Op->Header.ElementSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto VectorLower = GetSrc(Op->VectorLower.ID());
-  const auto VectorUpper = GetSrc(Op->VectorUpper.ID());
+  const auto Dst = GetVReg(Node);
+  const auto VectorLower = GetVReg(Op->VectorLower.ID());
+  const auto VectorUpper = GetVReg(Op->VectorUpper.ID());
 
   if (HostSupportsSVE && Is256Bit) {
     // Need to use the destructive variant of SPLICE, since
@@ -4671,8 +4671,8 @@ DEF_OP(VSQXTUN) {
   const auto ElementSize = Op->Header.ElementSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector = GetSrc(Op->Vector.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector = GetVReg(Op->Vector.ID());
 
   if (HostSupportsSVE && Is256Bit) {
     switch (ElementSize) {
@@ -4717,9 +4717,9 @@ DEF_OP(VSQXTUN2) {
   const auto ElementSize = Op->Header.ElementSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto VectorLower = GetSrc(Op->VectorLower.ID());
-  const auto VectorUpper = GetSrc(Op->VectorUpper.ID());
+  const auto Dst = GetVReg(Node);
+  const auto VectorLower = GetVReg(Op->VectorLower.ID());
+  const auto VectorUpper = GetVReg(Op->VectorUpper.ID());
 
   if (HostSupportsSVE && Is256Bit) {
     // NOTE: See VSQXTN2 implementation for an in-depth explanation
@@ -4796,9 +4796,9 @@ DEF_OP(VMul) {
 
   const auto ElementSize = Op->Header.ElementSize;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector1 = GetSrc(Op->Vector1.ID());
-  const auto Vector2 = GetSrc(Op->Vector2.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector1 = GetVReg(Op->Vector1.ID());
+  const auto Vector2 = GetVReg(Op->Vector2.ID());
 
   if (HostSupportsSVE) {
     switch (ElementSize) {
@@ -4854,9 +4854,9 @@ DEF_OP(VUMull) {
   const auto ElementSize = Op->Header.ElementSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector1 = GetSrc(Op->Vector1.ID());
-  const auto Vector2 = GetSrc(Op->Vector2.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector1 = GetVReg(Op->Vector1.ID());
+  const auto Vector2 = GetVReg(Op->Vector2.ID());
 
   if (HostSupportsSVE && Is256Bit) {
     switch (ElementSize) {
@@ -4910,9 +4910,9 @@ DEF_OP(VSMull) {
   const auto ElementSize = Op->Header.ElementSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector1 = GetSrc(Op->Vector1.ID());
-  const auto Vector2 = GetSrc(Op->Vector2.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector1 = GetVReg(Op->Vector1.ID());
+  const auto Vector2 = GetVReg(Op->Vector2.ID());
 
   if (HostSupportsSVE && Is256Bit) {
     switch (ElementSize) {
@@ -4966,9 +4966,9 @@ DEF_OP(VUMull2) {
   const auto ElementSize = Op->Header.ElementSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector1 = GetSrc(Op->Vector1.ID());
-  const auto Vector2 = GetSrc(Op->Vector2.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector1 = GetVReg(Op->Vector1.ID());
+  const auto Vector2 = GetVReg(Op->Vector2.ID());
 
   if (HostSupportsSVE && Is256Bit) {
     switch (ElementSize) {
@@ -5022,9 +5022,9 @@ DEF_OP(VSMull2) {
   const auto ElementSize = Op->Header.ElementSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector1 = GetSrc(Op->Vector1.ID());
-  const auto Vector2 = GetSrc(Op->Vector2.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector1 = GetVReg(Op->Vector1.ID());
+  const auto Vector2 = GetVReg(Op->Vector2.ID());
 
   if (HostSupportsSVE && Is256Bit) {
     switch (ElementSize) {
@@ -5078,9 +5078,9 @@ DEF_OP(VUABDL) {
   const auto ElementSize = Op->Header.ElementSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector1 = GetSrc(Op->Vector1.ID());
-  const auto Vector2 = GetSrc(Op->Vector2.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector1 = GetVReg(Op->Vector1.ID());
+  const auto Vector2 = GetVReg(Op->Vector2.ID());
 
   if (HostSupportsSVE && Is256Bit) {
     // To mimic the behavior of AdvSIMD UABDL, we need to get the
@@ -5136,9 +5136,9 @@ DEF_OP(VTBL1) {
   const auto Op = IROp->C<IR::IROp_VTBL1>();
   const auto OpSize = IROp->Size;
 
-  const auto Dst = GetDst(Node);
-  const auto VectorIndices = GetSrc(Op->VectorIndices.ID());
-  const auto VectorTable = GetSrc(Op->VectorTable.ID());
+  const auto Dst = GetVReg(Node);
+  const auto VectorIndices = GetVReg(Op->VectorIndices.ID());
+  const auto VectorTable = GetVReg(Op->VectorTable.ID());
 
   switch (OpSize) {
     case 8: {
@@ -5170,8 +5170,8 @@ DEF_OP(VRev64) {
   const auto Elements = OpSize / ElementSize;
   const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  const auto Dst = GetDst(Node);
-  const auto Vector = GetSrc(Op->Vector.ID());
+  const auto Dst = GetVReg(Node);
+  const auto Vector = GetVReg(Op->Vector.ID());
 
   if (HostSupportsSVE && Is256Bit) {
     const auto Mask = PRED_TMP_32B.Merging();


### PR DESCRIPTION
GetDst and GetSrc renamed to GetVReg. Makes it less confusing that these are for vector registers and having two implementations makes no sense now.

Renamed GetSrcPair to GetRegPair to match naming of all these register helpers.