### PR TITLE
Create a new ARM64 Emitter and move JIT over to it.

### DIFF
--- a/External/FEXCore/CMakeLists.txt
+++ b/External/FEXCore/CMakeLists.txt
@@ -82,3 +82,7 @@ add_subdirectory(Source/)
 install (DIRECTORY include/FEXCore ${CMAKE_BINARY_DIR}/include/FEXCore
   DESTINATION include
   COMPONENT Development)
+
+if (BUILD_TESTS)
+  add_subdirectory(unittests/)
+endif()

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64.cpp
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64.cpp
@@ -1,7 +1,6 @@
 #include "Interface/Core/ArchHelpers/Arm64.h"
 #include "Interface/Core/ArchHelpers/MContext.h"
-
-#include <aarch64/cpu-aarch64.h>
+#include "Interface/Core/ArchHelpers/CodeEmitter/Buffer.h"
 
 #include <FEXCore/Utils/EnumUtils.h>
 #include <FEXCore/Utils/LogManager.h>
@@ -572,7 +571,7 @@ bool HandleAtomicVectorStore(void *_ucontext, void *_info, uint32_t Instr) {
       PC[1] = STP;
       PC[2] = DMB;
       // Back up one instruction and have another go
-      vixl::aarch64::CPU::EnsureIAndDCacheCoherency(&PC[0], 16);
+      FEXCore::ARMEmitter::Buffer::ClearICache(&PC[0], 16);
       return true;
     }
   }
@@ -2311,7 +2310,7 @@ bool HandleSIGBUS(bool ParanoidTSO, int Signal, void *info, void *ucontext) {
       return false;
     }
 
-    vixl::aarch64::CPU::EnsureIAndDCacheCoherency(&PC[-1], 16);
+    FEXCore::ARMEmitter::Buffer::ClearICache(&PC[-1], 16);
     return true;
   }
   return false;

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "FEXCore/Utils/EnumUtils.h"
+#include "Interface/Core/ArchHelpers/CodeEmitter/Emitter.h"
+#include "Interface/Core/ArchHelpers/CodeEmitter/Registers.h"
+
 #include "Interface/Core/Dispatcher/Dispatcher.h"
 #include "Interface/Core/ObjectCache/Relocations.h"
 
@@ -24,72 +28,70 @@
 #include <utility>
 
 namespace FEXCore::CPU {
-using namespace vixl;
-using namespace vixl::aarch64;
-
 // All but x29 are caller saved
-const std::array<aarch64::Register, 16> SRA64 = {
-  x4, x5, x6, x7, x8, x9, x10, x11,
-  x12, x18, x17, x16, x15, x14, x13, x29
+constexpr std::array<FEXCore::ARMEmitter::Register, 16> SRA64 = {
+  FEXCore::ARMEmitter::Reg::r4, FEXCore::ARMEmitter::Reg::r5, FEXCore::ARMEmitter::Reg::r6, FEXCore::ARMEmitter::Reg::r7, FEXCore::ARMEmitter::Reg::r8, FEXCore::ARMEmitter::Reg::r9, FEXCore::ARMEmitter::Reg::r10, FEXCore::ARMEmitter::Reg::r11,
+  FEXCore::ARMEmitter::Reg::r12, FEXCore::ARMEmitter::Reg::r18, FEXCore::ARMEmitter::Reg::r17, FEXCore::ARMEmitter::Reg::r16, FEXCore::ARMEmitter::Reg::r15, FEXCore::ARMEmitter::Reg::r14, FEXCore::ARMEmitter::Reg::r13, FEXCore::ARMEmitter::Reg::r29
 };
 
 // All are callee saved
-const std::array<aarch64::Register, 9> RA64 = {
-  x20, x21, x22, x23, x24, x25, x26, x27,
-  x19
+constexpr std::array<FEXCore::ARMEmitter::Register, 9> RA64 = {
+  FEXCore::ARMEmitter::Reg::r20, FEXCore::ARMEmitter::Reg::r21, FEXCore::ARMEmitter::Reg::r22, FEXCore::ARMEmitter::Reg::r23, FEXCore::ARMEmitter::Reg::r24, FEXCore::ARMEmitter::Reg::r25, FEXCore::ARMEmitter::Reg::r26, FEXCore::ARMEmitter::Reg::r27,
+  FEXCore::ARMEmitter::Reg::r19
 };
 
-const std::array<std::pair<aarch64::Register, aarch64::Register>, 4>  RA64Pair = {{
-  {x20, x21},
-  {x22, x23},
-  {x24, x25},
-  {x26, x27},
+constexpr std::array<std::pair<FEXCore::ARMEmitter::Register, FEXCore::ARMEmitter::Register>, 4>  RA64Pair = {{
+  {FEXCore::ARMEmitter::Reg::r20, FEXCore::ARMEmitter::Reg::r21},
+  {FEXCore::ARMEmitter::Reg::r22, FEXCore::ARMEmitter::Reg::r23},
+  {FEXCore::ARMEmitter::Reg::r24, FEXCore::ARMEmitter::Reg::r25},
+  {FEXCore::ARMEmitter::Reg::r26, FEXCore::ARMEmitter::Reg::r27},
 }};
 
 // All are caller saved
-const std::array<aarch64::VRegister, 16> SRAFPR = {
-  v16, v17, v18, v19, v20, v21, v22, v23,
-  v24, v25, v26, v27, v28, v29, v30, v31
+constexpr std::array<FEXCore::ARMEmitter::VRegister, 16> SRAFPR = {
+  FEXCore::ARMEmitter::VReg::v16, FEXCore::ARMEmitter::VReg::v17, FEXCore::ARMEmitter::VReg::v18, FEXCore::ARMEmitter::VReg::v19, FEXCore::ARMEmitter::VReg::v20, FEXCore::ARMEmitter::VReg::v21, FEXCore::ARMEmitter::VReg::v22, FEXCore::ARMEmitter::VReg::v23,
+  FEXCore::ARMEmitter::VReg::v24, FEXCore::ARMEmitter::VReg::v25, FEXCore::ARMEmitter::VReg::v26, FEXCore::ARMEmitter::VReg::v27, FEXCore::ARMEmitter::VReg::v28, FEXCore::ARMEmitter::VReg::v29, FEXCore::ARMEmitter::VReg::v30, FEXCore::ARMEmitter::VReg::v31
 };
 
 //  v8..v15 = (lower 64bits) Callee saved
-const std::array<aarch64::VRegister, 12> RAFPR = {
-/*v0,  v1,  v2,  v3,*/v4,  v5,  v6,  v7,  // v0 ~ v3 are used as temps
-  v8,  v9,  v10, v11, v12, v13, v14, v15
+constexpr std::array<FEXCore::ARMEmitter::VRegister, 12> RAFPR = {
+/*FEXCore::ARMEmitter::VReg::v0,  FEXCore::ARMEmitter::VReg::v1,  FEXCore::ARMEmitter::VReg::v2,  FEXCore::ARMEmitter::VReg::v3,*/FEXCore::ARMEmitter::VReg::v4,  FEXCore::ARMEmitter::VReg::v5,  FEXCore::ARMEmitter::VReg::v6,  FEXCore::ARMEmitter::VReg::v7,  // FEXCore::ARMEmitter::VReg::v0 ~ FEXCore::ARMEmitter::VReg::v3 are used as temps
+  FEXCore::ARMEmitter::VReg::v8,  FEXCore::ARMEmitter::VReg::v9,  FEXCore::ARMEmitter::VReg::v10, FEXCore::ARMEmitter::VReg::v11, FEXCore::ARMEmitter::VReg::v12, FEXCore::ARMEmitter::VReg::v13, FEXCore::ARMEmitter::VReg::v14, FEXCore::ARMEmitter::VReg::v15
 };
 
 // Contains the address to the currently available CPU state
-#define STATE x28
+constexpr auto STATE = FEXCore::ARMEmitter::XReg::x28;
 
 // GPR temporaries. Only x3 can be used across spill boundaries
 // so if these ever need to change, be very careful about that.
-#define TMP1 x0
-#define TMP2 x1
-#define TMP3 x2
-#define TMP4 x3
+constexpr auto TMP1 = FEXCore::ARMEmitter::XReg::x0;
+constexpr auto TMP2 = FEXCore::ARMEmitter::XReg::x1;
+constexpr auto TMP3 = FEXCore::ARMEmitter::XReg::x2;
+constexpr auto TMP4 = FEXCore::ARMEmitter::XReg::x3;
 
 // Vector temporaries
-#define VTMP1 v0
-#define VTMP2 v1
-#define VTMP3 v2
-#define VTMP4 v3
+constexpr auto VTMP1 = FEXCore::ARMEmitter::VReg::v0;
+constexpr auto VTMP2 = FEXCore::ARMEmitter::VReg::v1;
+constexpr auto VTMP3 = FEXCore::ARMEmitter::VReg::v2;
+constexpr auto VTMP4 = FEXCore::ARMEmitter::VReg::v3;
 
 // Predicate register temporaries (used when AVX support is enabled)
 // PRED_TMP_16B indicates a predicate register that indicates the first 16 bytes set to 1.
 // PRED_TMP_32B indicates a predicate register that indicates the first 32 bytes set to 1.
-#define PRED_TMP_16B p6
-#define PRED_TMP_32B p7
+constexpr FEXCore::ARMEmitter::PRegister PRED_TMP_16B = FEXCore::ARMEmitter::PReg::p6;
+constexpr FEXCore::ARMEmitter::PRegister PRED_TMP_32B = FEXCore::ARMEmitter::PReg::p7;
 
 // This class contains common emitter utility functions that can
 // be used by both Arm64 JIT and ARM64 Dispatcher
-class Arm64Emitter : public vixl::aarch64::Assembler {
+class Arm64Emitter : public FEXCore::ARMEmitter::Emitter {
 protected:
   Arm64Emitter(FEXCore::Context::Context *ctx, size_t size);
   ~Arm64Emitter();
 
   FEXCore::Context::Context *EmitterCTX;
   vixl::aarch64::CPU CPU;
-  void LoadConstant(vixl::aarch64::Register Reg, uint64_t Constant, bool NOPPad = false);
+  void LoadConstant(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register Reg, uint64_t Constant, bool NOPPad = false);
+
 
   // NOTE: These functions WILL clobber the register TMP4 if AVX support is enabled
   //       and FPRs are being spilled or filled. If only GPRs are spilled/filled, then
@@ -103,13 +105,14 @@ protected:
   // We can't guarantee only the lower 64bits are used so flush everything
   static constexpr uint32_t CALLER_FPR_MASK = ~0U;
 
-  void PushDynamicRegsAndLR(aarch64::Register TmpReg);
+  void PushDynamicRegsAndLR(FEXCore::ARMEmitter::Register TmpReg);
   void PopDynamicRegsAndLR();
 
   void PushCalleeSavedRegisters();
   void PopCalleeSavedRegisters();
 
   void Align16B();
+
 #ifdef VIXL_SIMULATOR
   // Generates a vixl simulator runtime call.
   //
@@ -121,57 +124,58 @@ protected:
   // 2) Simulator wrapper handler
   // 3) Function to call
   // 4) Style of the function call (Call versus tail-call)
+
   template<typename R, typename... P>
   void GenerateRuntimeCall(R (*Function)(P...)) {
     uintptr_t SimulatorWrapperAddress = reinterpret_cast<uintptr_t>(
-      &(Simulator::RuntimeCallStructHelper<R, P...>::Wrapper));
+      &(vixl::aarch64::Simulator::RuntimeCallStructHelper<R, P...>::Wrapper));
 
     uintptr_t FunctionAddress = reinterpret_cast<uintptr_t>(Function);
 
-    hlt(kRuntimeCallOpcode);
+    hlt(vixl::aarch64::kRuntimeCallOpcode);
 
     // Simulator wrapper address pointer.
-    dc(SimulatorWrapperAddress);
+    dc64(SimulatorWrapperAddress);
 
     // Runtime function address to call
-    dc(FunctionAddress);
+    dc64(FunctionAddress);
 
     // Call type
-    dc32(kCallRuntime);
+    dc32(vixl::aarch64::kCallRuntime);
   }
 
   template<typename R, typename... P>
-  void GenerateIndirectRuntimeCall(vixl::aarch64::Register Reg) {
+  void GenerateIndirectRuntimeCall(ARMEmitter::Register Reg) {
     uintptr_t SimulatorWrapperAddress = reinterpret_cast<uintptr_t>(
-      &(Simulator::RuntimeCallStructHelper<R, P...>::Wrapper));
+      &(vixl::aarch64::Simulator::RuntimeCallStructHelper<R, P...>::Wrapper));
 
-    hlt(kIndirectRuntimeCallOpcode);
+    hlt(vixl::aarch64::kIndirectRuntimeCallOpcode);
 
     // Simulator wrapper address pointer.
-    dc(SimulatorWrapperAddress);
+    dc64(SimulatorWrapperAddress);
 
     // Register that contains the function to call
-    dc(Reg.GetCode());
+    dc32(Reg.Idx());
 
     // Call type
-    dc32(kCallRuntime);
+    dc32(vixl::aarch64::kCallRuntime);
   }
 
   template<>
-  void GenerateIndirectRuntimeCall<float, __uint128_t>(vixl::aarch64::Register Reg) {
+  void GenerateIndirectRuntimeCall<float, __uint128_t>(ARMEmitter::Register Reg) {
     uintptr_t SimulatorWrapperAddress = reinterpret_cast<uintptr_t>(
-      &(Simulator::RuntimeCallStructHelper<float, __uint128_t>::Wrapper));
+      &(vixl::aarch64::Simulator::RuntimeCallStructHelper<float, __uint128_t>::Wrapper));
 
-    hlt(kIndirectRuntimeCallOpcode);
+    hlt(vixl::aarch64::kIndirectRuntimeCallOpcode);
 
     // Simulator wrapper address pointer.
-    dc(SimulatorWrapperAddress);
+    dc64(SimulatorWrapperAddress);
 
     // Register that contains the function to call
-    dc(Reg.GetCode());
+    dc32(Reg.Idx());
 
     // Call type
-    dc32(kCallRuntime);
+    dc32(vixl::aarch64::kCallRuntime);
   }
 
 #endif

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ALUOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ALUOps.inl
@@ -1,0 +1,912 @@
+/* ALU instruction emitters.
+ *
+ * Almost all of these operations have `ARMEmitter::Size` as their first argument.
+ * This allows both 32-bit and 64-bit selection of how that instruction is going to operate.
+ *
+ * Some emitter operations explicitly use `XRegister` or `WRegister`.
+ * This is usually due to the instruction only supporting one operating size.
+ * Although in some cases is a minor convenience without any performance implications.
+ *
+ * FEX-Emu ALU operations usually have a 32-bit or 64-bit operating size encoded in the IR operation,
+ * This allows FEX to use a single helper function which decodes to both handlers.
+ */
+public:
+  // PC relative
+  void adr(FEXCore::ARMEmitter::Register rd, uint32_t Imm) {
+    constexpr uint32_t Op = 0b0001'0000 << 24;
+    DataProcessing_PCRel_Imm(Op, rd, Imm);
+  }
+
+  void adr(FEXCore::ARMEmitter::Register rd, BackwardLabel const* Label) {
+    int32_t Imm = static_cast<int32_t>(Label->Location - GetCursorAddress<uint8_t*>());
+    LOGMAN_THROW_A_FMT(Imm >= -1048576 && Imm <= 1048575, "Unscaled offset too large");
+
+    constexpr uint32_t Op = 0b0001'0000 << 24;
+    DataProcessing_PCRel_Imm(Op, rd, Imm);
+  }
+  void adr(FEXCore::ARMEmitter::Register rd, ForwardLabel *Label) {
+    Label->Insts.emplace_back(ForwardLabel::Instructions{ .Location = GetCursorAddress<uint8_t*>(), .Type = ForwardLabel::Instructions::InstType::ADR });
+    constexpr uint32_t Op = 0b0001'0000 << 24;
+    DataProcessing_PCRel_Imm(Op, rd, 0);
+  }
+
+  void adr(FEXCore::ARMEmitter::Register rd, BiDirectionalLabel *Label) {
+    if (Label->Backward.Location) {
+      adr(rd, &Label->Backward);
+    }
+    else {
+      adr(rd, &Label->Forward);
+    }
+  }
+
+  void adrp(FEXCore::ARMEmitter::Register rd, uint32_t Imm) {
+    constexpr uint32_t Op = 0b1001'0000 << 24;
+    DataProcessing_PCRel_Imm(Op, rd, Imm);
+  }
+
+  void adrp(FEXCore::ARMEmitter::Register rd, BackwardLabel const* Label) {
+    int64_t Imm = reinterpret_cast<int64_t>(Label->Location) - (GetCursorAddress<int64_t>() & ~0xFFFLL);
+    LOGMAN_THROW_A_FMT(Imm >= -4294967296 && Imm <= 4294963200 && (Imm & 0xFFF) == 0, "Unscaled offset too large");
+
+    constexpr uint32_t Op = 0b1001'0000 << 24;
+    DataProcessing_PCRel_Imm(Op, rd, Imm);
+  }
+  void adrp(FEXCore::ARMEmitter::Register rd, ForwardLabel *Label) {
+    Label->Insts.emplace_back(ForwardLabel::Instructions{ .Location = GetCursorAddress<uint8_t*>(), .Type = ForwardLabel::Instructions::InstType::ADRP });
+    constexpr uint32_t Op = 0b1001'0000 << 24;
+    DataProcessing_PCRel_Imm(Op, rd, 0);
+  }
+
+  void adrp(FEXCore::ARMEmitter::Register rd, BiDirectionalLabel *Label) {
+    if (Label->Backward.Location) {
+      adrp(rd, &Label->Backward);
+    }
+    else {
+      adrp(rd, &Label->Forward);
+    }
+  }
+
+  // Add/subtract immediate
+  void add(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, uint32_t Imm, bool LSL12 = false) {
+    constexpr uint32_t Op = 0b0001'0001'0 << 23;
+    DataProcessing_AddSub_Imm(Op, s, rd, rn, Imm, LSL12);
+  }
+
+  void adds(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, uint32_t Imm, bool LSL12 = false) {
+    constexpr uint32_t Op = 0b0011'0001'0 << 23;
+    DataProcessing_AddSub_Imm(Op, s, rd, rn, Imm, LSL12);
+  }
+
+  void sub(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, uint32_t Imm, bool LSL12 = false) {
+    constexpr uint32_t Op = 0b0101'0001'0 << 23;
+    DataProcessing_AddSub_Imm(Op, s, rd, rn, Imm, LSL12);
+  }
+
+  void cmp(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rn, uint32_t Imm, bool LSL12 = false) {
+    constexpr uint32_t Op = 0b0111'0001'0 << 23;
+    DataProcessing_AddSub_Imm(Op, s, FEXCore::ARMEmitter::Reg::rsp, rn, Imm, LSL12);
+  }
+
+  void subs(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, uint32_t Imm, bool LSL12 = false) {
+    constexpr uint32_t Op = 0b0111'0001'0 << 23;
+    DataProcessing_AddSub_Imm(Op, s, rd, rn, Imm, LSL12);
+  }
+
+  // Logical immediate
+  void and_(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, uint64_t Imm) {
+    uint32_t n, immr, imms;
+    [[maybe_unused]] const auto IsImm = vixl::aarch64::Assembler::IsImmLogical(Imm,
+                           RegSizeInBits(s),
+                           &n,
+                           &imms,
+                           &immr);
+    LOGMAN_THROW_A_FMT(IsImm, "Couldn't encode immediate to logical op");
+    and_(s, rd, rn, n, immr, imms);
+  }
+
+  void bic(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, uint64_t Imm) {
+    and_(s, rd, rn, ~Imm);
+  }
+
+  void ands(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, uint64_t Imm) {
+    uint32_t n, immr, imms;
+    [[maybe_unused]] const auto IsImm = vixl::aarch64::Assembler::IsImmLogical(Imm,
+                           RegSizeInBits(s),
+                           &n,
+                           &imms,
+                           &immr);
+    LOGMAN_THROW_A_FMT(IsImm, "Couldn't encode immediate to logical op");
+    ands(s, rd, rn, n, immr, imms);
+  }
+
+  void bics(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, uint64_t Imm) {
+    ands(s, rd, rn, ~Imm);
+  }
+
+  void orr(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, uint64_t Imm) {
+    uint32_t n, immr, imms;
+    [[maybe_unused]] const auto IsImm = vixl::aarch64::Assembler::IsImmLogical(Imm,
+                           RegSizeInBits(s),
+                           &n,
+                           &imms,
+                           &immr);
+    LOGMAN_THROW_A_FMT(IsImm, "Couldn't encode immediate to logical op");
+    orr(s, rd, rn, n, immr, imms);
+  }
+
+  void eor(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, uint64_t Imm) {
+    uint32_t n, immr, imms;
+    [[maybe_unused]] const auto IsImm = vixl::aarch64::Assembler::IsImmLogical(Imm,
+                           RegSizeInBits(s),
+                           &n,
+                           &imms,
+                           &immr);
+    LOGMAN_THROW_A_FMT(IsImm, "Couldn't encode immediate to logical op");
+    eor(s, rd, rn, n, immr, imms);
+  }
+
+  // Move wide immediate
+  void movn(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, uint32_t Imm, uint32_t Offset = 0) {
+    LOGMAN_THROW_A_FMT((Imm & 0xFFFF0000U) == 0, "Upper bits of move wide not valid");
+    LOGMAN_THROW_A_FMT((Offset % 16) == 0, "Offset must be 16bit aligned");
+
+    constexpr uint32_t Op = 0b001'0010'100 << 21;
+    DataProcessing_MoveWide(Op, s, rd, Imm, Offset >> 4);
+  }
+  void mov(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, uint32_t Imm) {
+    movz(s, rd, Imm, 0);
+  }
+  void mov(FEXCore::ARMEmitter::XRegister rd, uint32_t Imm) {
+    movz(FEXCore::ARMEmitter::Size::i64Bit, rd.R(), Imm, 0);
+  }
+  void mov(FEXCore::ARMEmitter::WRegister rd, uint32_t Imm) {
+    movz(FEXCore::ARMEmitter::Size::i32Bit, rd.R(), Imm, 0);
+  }
+
+  void movz(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, uint32_t Imm, uint32_t Offset = 0) {
+    LOGMAN_THROW_A_FMT((Imm & 0xFFFF0000U) == 0, "Upper bits of move wide not valid");
+    LOGMAN_THROW_A_FMT((Offset % 16) == 0, "Offset must be 16bit aligned");
+
+    constexpr uint32_t Op = 0b101'0010'100 << 21;
+    DataProcessing_MoveWide(Op, s, rd, Imm, Offset >> 4);
+  }
+  void movk(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, uint32_t Imm, uint32_t Offset = 0) {
+    LOGMAN_THROW_A_FMT((Imm & 0xFFFF0000U) == 0, "Upper bits of move wide not valid");
+    LOGMAN_THROW_A_FMT((Offset % 16) == 0, "Offset must be 16bit aligned");
+
+    constexpr uint32_t Op = 0b111'0010'100 << 21;
+    DataProcessing_MoveWide(Op, s, rd, Imm, Offset >> 4);
+  }
+
+  void movn(FEXCore::ARMEmitter::XRegister rd, uint32_t Imm, uint32_t Offset = 0) {
+    movn(FEXCore::ARMEmitter::Size::i64Bit, rd.R(), Imm, Offset);
+  }
+  void movz(FEXCore::ARMEmitter::XRegister rd, uint32_t Imm, uint32_t Offset = 0) {
+    movz(FEXCore::ARMEmitter::Size::i64Bit, rd.R(), Imm, Offset);
+  }
+  void movk(FEXCore::ARMEmitter::XRegister rd, uint32_t Imm, uint32_t Offset = 0) {
+    movk(FEXCore::ARMEmitter::Size::i64Bit, rd.R(), Imm, Offset);
+  }
+  void movn(FEXCore::ARMEmitter::WRegister rd, uint32_t Imm, uint32_t Offset = 0) {
+    movn(FEXCore::ARMEmitter::Size::i32Bit, rd.R(), Imm, Offset);
+  }
+  void movz(FEXCore::ARMEmitter::WRegister rd, uint32_t Imm, uint32_t Offset = 0) {
+    movz(FEXCore::ARMEmitter::Size::i32Bit, rd.R(), Imm, Offset);
+  }
+  void movk(FEXCore::ARMEmitter::WRegister rd, uint32_t Imm, uint32_t Offset = 0) {
+    movk(FEXCore::ARMEmitter::Size::i32Bit, rd.R(), Imm, Offset);
+  }
+
+  // Bitfield
+  void sxtb(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn) {
+    sbfm(s, rd, rn, 0, 7);
+  }
+  void sxth(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn) {
+    sbfm(s, rd, rn, 0, 15);
+  }
+  void sxtw(FEXCore::ARMEmitter::XRegister rd, FEXCore::ARMEmitter::XRegister rn) {
+    sbfm(ARMEmitter::Size::i64Bit, rd, rn, 0, 31);
+  }
+  void sbfx(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, uint32_t lsb, uint32_t width) {
+    LOGMAN_THROW_A_FMT(width > 0, "sbfx needs width > 0");
+    LOGMAN_THROW_A_FMT((lsb + width) <= RegSizeInBits(s), "Tried to sbfx a region larger than the register");
+    sbfm(s, rd, rn, lsb, lsb + width - 1);
+  }
+  void asr(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, uint32_t shift) {
+    LOGMAN_THROW_A_FMT(shift <= RegSizeInBits(s), "Tried to asr a region larger than the register");
+    sbfm(s, rd, rn, shift, RegSizeInBits(s) - 1);
+  }
+
+  void uxtb(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn) {
+    ubfm(s, rd, rn, 0, 7);
+  }
+  void uxth(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn) {
+    ubfm(s, rd, rn, 0, 15);
+  }
+  void uxtw(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn) {
+    ubfm(s, rd, rn, 0, 31);
+  }
+
+  void ubfm(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, uint32_t immr, uint32_t imms) {
+    constexpr uint32_t Op = 0b0101'0011'00 << 22;
+    DataProcessing_Logical_Imm(Op, s, rd, rn, s == ARMEmitter::Size::i64Bit, immr, imms);
+  }
+
+  void lsl(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, uint32_t shift) {
+    const auto RegSize = RegSizeInBits(s);
+    LOGMAN_THROW_A_FMT(shift < RegSize, "Tried to asr a region larger than the register");
+    ubfm(s, rd, rn, (RegSize - shift) % RegSize, RegSize - shift - 1);
+  }
+  void lsr(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, uint32_t shift) {
+    const auto RegSize = RegSizeInBits(s);
+    LOGMAN_THROW_A_FMT(shift < RegSize, "Tried to asr a region larger than the register");
+    ubfm(s, rd, rn, shift, RegSize - 1);
+  }
+  void ubfx(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, uint32_t lsb, uint32_t width) {
+    LOGMAN_THROW_A_FMT(width > 0, "ubfx needs width > 0");
+    LOGMAN_THROW_A_FMT((lsb + width) <= RegSizeInBits(s), "Tried to ubfx a region larger than the register");
+    ubfm(s, rd, rn, lsb, lsb + width - 1);
+  }
+
+  void bfi(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, uint32_t lsb, uint32_t width) {
+    const auto RegSize = RegSizeInBits(s);
+    LOGMAN_THROW_A_FMT(width > 0, "sbfx needs width > 0");
+    LOGMAN_THROW_A_FMT((lsb + width) <= RegSize, "Tried to sbfx a region larger than the register");
+    bfm(s, rd, rn, (RegSize - lsb) & (RegSize - 1), width - 1);
+  }
+
+  // Extract
+  void extr(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, uint32_t Imm) {
+    constexpr uint32_t Op = 0b001'0011'100 << 21;
+    LOGMAN_THROW_A_FMT(Imm < RegSizeInBits(s), "Tried to extr a region larger than the register");
+    DataProcessing_Extract(Op, s, rd, rn, rm, Imm);
+  }
+
+  void ror(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, uint32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm < RegSizeInBits(s), "Tried to extr a region larger than the register");
+    extr(s, rd, rn, rn, Imm);
+  }
+
+  // Data processing - 2 source
+  void udiv(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    constexpr uint32_t Op = (0b001'1010'110U << 21) |
+                        (0b0000'10U << 10);
+    DataProcessing_2Source(Op, s, rd, rn, rm);
+  }
+  void sdiv(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    constexpr uint32_t Op = (0b001'1010'110U << 21) |
+                        (0b0000'11U << 10);
+    DataProcessing_2Source(Op, s, rd, rn, rm);
+  }
+
+  void lslv(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    constexpr uint32_t Op = (0b001'1010'110U << 21) |
+                        (0b0010'00U << 10);
+    DataProcessing_2Source(Op, s, rd, rn, rm);
+  }
+  void lsrv(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    constexpr uint32_t Op = (0b001'1010'110U << 21) |
+                        (0b0010'01U << 10);
+    DataProcessing_2Source(Op, s, rd, rn, rm);
+  }
+  void asrv(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    constexpr uint32_t Op = (0b001'1010'110U << 21) |
+                        (0b0010'10U << 10);
+    DataProcessing_2Source(Op, s, rd, rn, rm);
+  }
+  void rorv(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    constexpr uint32_t Op = (0b001'1010'110U << 21) |
+                        (0b0010'11U << 10);
+    DataProcessing_2Source(Op, s, rd, rn, rm);
+  }
+  void crc32b(FEXCore::ARMEmitter::WRegister rd, FEXCore::ARMEmitter::WRegister rn, FEXCore::ARMEmitter::WRegister rm) {
+    constexpr uint32_t Op = (0b001'1010'110U << 21) |
+                        (0b0100'00U << 10);
+    DataProcessing_2Source(Op, ARMEmitter::Size::i32Bit, rd, rn, rm);
+  }
+  void crc32h(FEXCore::ARMEmitter::WRegister rd, FEXCore::ARMEmitter::WRegister rn, FEXCore::ARMEmitter::WRegister rm) {
+    constexpr uint32_t Op = (0b001'1010'110U << 21) |
+                        (0b0100'01U << 10);
+    DataProcessing_2Source(Op, ARMEmitter::Size::i32Bit, rd, rn, rm);
+  }
+  void crc32w(FEXCore::ARMEmitter::WRegister rd, FEXCore::ARMEmitter::WRegister rn, FEXCore::ARMEmitter::WRegister rm) {
+    constexpr uint32_t Op = (0b001'1010'110U << 21) |
+                        (0b0100'10U << 10);
+    DataProcessing_2Source(Op, ARMEmitter::Size::i32Bit, rd, rn, rm);
+  }
+  void crc32cb(FEXCore::ARMEmitter::WRegister rd, FEXCore::ARMEmitter::WRegister rn, FEXCore::ARMEmitter::WRegister rm) {
+    constexpr uint32_t Op = (0b001'1010'110U << 21) |
+                        (0b0101'00U << 10);
+    DataProcessing_2Source(Op, ARMEmitter::Size::i32Bit, rd, rn, rm);
+  }
+  void crc32ch(FEXCore::ARMEmitter::WRegister rd, FEXCore::ARMEmitter::WRegister rn, FEXCore::ARMEmitter::WRegister rm) {
+    constexpr uint32_t Op = (0b001'1010'110U << 21) |
+                        (0b0101'01U << 10);
+    DataProcessing_2Source(Op, ARMEmitter::Size::i32Bit, rd, rn, rm);
+  }
+  void crc32cw(FEXCore::ARMEmitter::WRegister rd, FEXCore::ARMEmitter::WRegister rn, FEXCore::ARMEmitter::WRegister rm) {
+    constexpr uint32_t Op = (0b001'1010'110U << 21) |
+                        (0b0101'10U << 10);
+    DataProcessing_2Source(Op, ARMEmitter::Size::i32Bit, rd, rn, rm);
+  }
+  void subp(FEXCore::ARMEmitter::XRegister rd, FEXCore::ARMEmitter::XRegister rn, FEXCore::ARMEmitter::XRegister rm) {
+    constexpr uint32_t Op = (0b001'1010'110U << 21) |
+                        (0b0000'00U << 10);
+    DataProcessing_2Source(Op, FEXCore::ARMEmitter::Size::i64Bit, rd, rn, rm);
+  }
+  void irg(FEXCore::ARMEmitter::XRegister rd, FEXCore::ARMEmitter::XRegister rn, FEXCore::ARMEmitter::XRegister rm) {
+    constexpr uint32_t Op = (0b001'1010'110U << 21) |
+                        (0b0001'00U << 10);
+    DataProcessing_2Source(Op, FEXCore::ARMEmitter::Size::i64Bit, rd, rn, rm);
+  }
+  void gmi(FEXCore::ARMEmitter::XRegister rd, FEXCore::ARMEmitter::XRegister rn, FEXCore::ARMEmitter::XRegister rm) {
+    constexpr uint32_t Op = (0b001'1010'110U << 21) |
+                        (0b0001'01U << 10);
+    DataProcessing_2Source(Op, FEXCore::ARMEmitter::Size::i64Bit, rd, rn, rm);
+  }
+  void pacga(FEXCore::ARMEmitter::XRegister rd, FEXCore::ARMEmitter::XRegister rn, FEXCore::ARMEmitter::XRegister rm) {
+    constexpr uint32_t Op = (0b001'1010'110U << 21) |
+                        (0b0011'00U << 10);
+    DataProcessing_2Source(Op, FEXCore::ARMEmitter::Size::i64Bit, rd, rn, rm);
+  }
+  void crc32x(FEXCore::ARMEmitter::XRegister rd, FEXCore::ARMEmitter::XRegister rn, FEXCore::ARMEmitter::XRegister rm) {
+    constexpr uint32_t Op = (0b001'1010'110U << 21) |
+                        (0b0100'11U << 10);
+    DataProcessing_2Source(Op, FEXCore::ARMEmitter::Size::i64Bit, rd, rn, rm);
+  }
+  void crc32cx(FEXCore::ARMEmitter::XRegister rd, FEXCore::ARMEmitter::XRegister rn, FEXCore::ARMEmitter::XRegister rm) {
+    constexpr uint32_t Op = (0b001'1010'110U << 21) |
+                        (0b0101'11U << 10);
+    DataProcessing_2Source(Op, FEXCore::ARMEmitter::Size::i64Bit, rd, rn, rm);
+  }
+  void subps(FEXCore::ARMEmitter::XRegister rd, FEXCore::ARMEmitter::XRegister rn, FEXCore::ARMEmitter::XRegister rm) {
+    constexpr uint32_t Op = (0b011'1010'110U << 21) |
+                        (0b0000'00U << 10);
+    DataProcessing_2Source(Op, FEXCore::ARMEmitter::Size::i64Bit, rd, rn, rm);
+  }
+
+  // Data processing - 1 source
+  void rbit(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = (0b101'1010'110U << 21) |
+                        (0b0'0000U << 16) |
+                        (0b0000'00U << 10);
+    DataProcessing_1Source(Op, s, rd, rn);
+  }
+  void rev16(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = (0b101'1010'110U << 21) |
+                        (0b0'0000U << 16) |
+                        (0b0000'01U << 10);
+    DataProcessing_1Source(Op, s, rd, rn);
+  }
+  void rev(FEXCore::ARMEmitter::WRegister rd, FEXCore::ARMEmitter::WRegister rn) {
+    constexpr uint32_t Op = (0b101'1010'110U << 21) |
+                        (0b0'0000U << 16) |
+                        (0b0000'10U << 10);
+    DataProcessing_1Source(Op, FEXCore::ARMEmitter::Size::i32Bit, rd, rn);
+  }
+  void rev32(FEXCore::ARMEmitter::XRegister rd, FEXCore::ARMEmitter::XRegister rn) {
+    constexpr uint32_t Op = (0b101'1010'110U << 21) |
+                        (0b0'0000U << 16) |
+                        (0b0000'10U << 10);
+    DataProcessing_1Source(Op, FEXCore::ARMEmitter::Size::i64Bit, rd, rn);
+  }
+  void clz(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = (0b101'1010'110U << 21) |
+                        (0b0'0000U << 16) |
+                        (0b0001'00U << 10);
+    DataProcessing_1Source(Op, s, rd, rn);
+  }
+  void cls(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = (0b101'1010'110U << 21) |
+                        (0b0'0000U << 16) |
+                        (0b0001'01U << 10);
+    DataProcessing_1Source(Op, s, rd, rn);
+  }
+  void rev(FEXCore::ARMEmitter::XRegister rd, FEXCore::ARMEmitter::XRegister rn) {
+    constexpr uint32_t Op = (0b101'1010'110U << 21) |
+                        (0b0'0000U << 16) |
+                        (0b0000'11U << 10);
+    DataProcessing_1Source(Op, FEXCore::ARMEmitter::Size::i64Bit, rd, rn);
+  }
+  void rev(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn) {
+    uint32_t Op = (0b101'1010'110U << 21) |
+                        (0b0'0000U << 16) |
+                        (0b0000'10U << 10) |
+                        (s == ARMEmitter::Size::i64Bit ? (1U << 10) : 0);
+    DataProcessing_1Source(Op, s, rd, rn);
+  }
+
+
+  // TODO: PAUTH
+
+  // Logical - shifted register
+  void mov(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn) {
+    orr(s, rd, FEXCore::ARMEmitter::Reg::zr, rn, ARMEmitter::ShiftType::LSL, 0);
+  }
+  void mov(FEXCore::ARMEmitter::XRegister rd, FEXCore::ARMEmitter::XRegister rn) {
+    orr(FEXCore::ARMEmitter::Size::i64Bit, rd.R(), FEXCore::ARMEmitter::Reg::zr, rn.R(), ARMEmitter::ShiftType::LSL, 0);
+  }
+  void mov(FEXCore::ARMEmitter::WRegister rd, FEXCore::ARMEmitter::WRegister rn) {
+    orr(FEXCore::ARMEmitter::Size::i32Bit, rd.R(), FEXCore::ARMEmitter::Reg::zr, rn.R(), ARMEmitter::ShiftType::LSL, 0);
+  }
+
+  void mvn(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::ShiftType Shift = FEXCore::ARMEmitter::ShiftType::LSL, uint32_t amt = 0) {
+    orn(s, rd, FEXCore::ARMEmitter::Reg::zr, rn, Shift, amt);
+  }
+
+  void and_(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ShiftType Shift = FEXCore::ARMEmitter::ShiftType::LSL, uint32_t amt = 0) {
+    constexpr uint32_t Op = 0b000'1010'000U << 21;
+    DataProcessing_Shifted_Reg(Op, s, rd, rn, rm, Shift, amt);
+  }
+  void ands(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ShiftType Shift = FEXCore::ARMEmitter::ShiftType::LSL, uint32_t amt = 0) {
+    constexpr uint32_t Op = 0b110'1010'000U << 21;
+    DataProcessing_Shifted_Reg(Op, s, rd, rn, rm, Shift, amt);
+  }
+  void bic(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ShiftType Shift = FEXCore::ARMEmitter::ShiftType::LSL, uint32_t amt = 0) {
+    constexpr uint32_t Op = 0b000'1010'001U << 21;
+    DataProcessing_Shifted_Reg(Op, s, rd, rn, rm, Shift, amt);
+  }
+  void bics(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ShiftType Shift = FEXCore::ARMEmitter::ShiftType::LSL, uint32_t amt = 0) {
+    constexpr uint32_t Op = 0b110'1010'001U << 21;
+    DataProcessing_Shifted_Reg(Op, s, rd, rn, rm, Shift, amt);
+  }
+  void orr(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ShiftType Shift = FEXCore::ARMEmitter::ShiftType::LSL, uint32_t amt = 0) {
+    constexpr uint32_t Op = 0b010'1010'000U << 21;
+    DataProcessing_Shifted_Reg(Op, s, rd, rn, rm, Shift, amt);
+  }
+
+  void orn(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ShiftType Shift = FEXCore::ARMEmitter::ShiftType::LSL, uint32_t amt = 0) {
+    constexpr uint32_t Op = 0b010'1010'001U << 21;
+    DataProcessing_Shifted_Reg(Op, s, rd, rn, rm, Shift, amt);
+  }
+  void eor(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ShiftType Shift = FEXCore::ARMEmitter::ShiftType::LSL, uint32_t amt = 0) {
+    constexpr uint32_t Op = 0b100'1010'000U << 21;
+    DataProcessing_Shifted_Reg(Op, s, rd, rn, rm, Shift, amt);
+  }
+  void eon(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ShiftType Shift = FEXCore::ARMEmitter::ShiftType::LSL, uint32_t amt = 0) {
+    constexpr uint32_t Op = 0b100'1010'001U << 21;
+    DataProcessing_Shifted_Reg(Op, s, rd, rn, rm, Shift, amt);
+  }
+
+  // AddSub - shifted register
+  void add(FEXCore::ARMEmitter::XRegister rd, FEXCore::ARMEmitter::XRegister rn, FEXCore::ARMEmitter::XRegister rm, FEXCore::ARMEmitter::ShiftType Shift = FEXCore::ARMEmitter::ShiftType::LSL, uint32_t amt = 0) {
+    add(ARMEmitter::Size::i64Bit, rd.R(), rn.R(), rm.R(), Shift, amt);
+  }
+  void adds(FEXCore::ARMEmitter::XRegister rd, FEXCore::ARMEmitter::XRegister rn, FEXCore::ARMEmitter::XRegister rm, FEXCore::ARMEmitter::ShiftType Shift = FEXCore::ARMEmitter::ShiftType::LSL, uint32_t amt = 0) {
+    adds(ARMEmitter::Size::i64Bit, rd.R(), rn.R(), rm.R(), Shift, amt);
+  }
+  void sub(FEXCore::ARMEmitter::XRegister rd, FEXCore::ARMEmitter::XRegister rn, FEXCore::ARMEmitter::XRegister rm, FEXCore::ARMEmitter::ShiftType Shift = FEXCore::ARMEmitter::ShiftType::LSL, uint32_t amt = 0) {
+    sub(ARMEmitter::Size::i64Bit, rd.R(), rn.R(), rm.R(), Shift, amt);
+  }
+  void neg(FEXCore::ARMEmitter::XRegister rd, FEXCore::ARMEmitter::XRegister rm, FEXCore::ARMEmitter::ShiftType Shift = FEXCore::ARMEmitter::ShiftType::LSL, uint32_t amt = 0) {
+    sub(rd, FEXCore::ARMEmitter::XReg::zr, rm, Shift, amt);
+  }
+  void cmp(FEXCore::ARMEmitter::XRegister rn, FEXCore::ARMEmitter::XRegister rm, FEXCore::ARMEmitter::ShiftType Shift = FEXCore::ARMEmitter::ShiftType::LSL, uint32_t amt = 0) {
+    subs(ARMEmitter::Size::i64Bit, FEXCore::ARMEmitter::Reg::rsp, rn.R(), rm.R(), Shift, amt);
+  }
+  void subs(FEXCore::ARMEmitter::XRegister rd, FEXCore::ARMEmitter::XRegister rn, FEXCore::ARMEmitter::XRegister rm, FEXCore::ARMEmitter::ShiftType Shift = FEXCore::ARMEmitter::ShiftType::LSL, uint32_t amt = 0) {
+    subs(ARMEmitter::Size::i64Bit, rd.R(), rn.R(), rm.R(), Shift, amt);
+  }
+  void negs(FEXCore::ARMEmitter::XRegister rd, FEXCore::ARMEmitter::XRegister rm, FEXCore::ARMEmitter::ShiftType Shift = FEXCore::ARMEmitter::ShiftType::LSL, uint32_t amt = 0) {
+    subs(rd, FEXCore::ARMEmitter::XReg::zr, rm, Shift, amt);
+  }
+
+  void add(FEXCore::ARMEmitter::WRegister rd, FEXCore::ARMEmitter::WRegister rn, FEXCore::ARMEmitter::WRegister rm, FEXCore::ARMEmitter::ShiftType Shift = FEXCore::ARMEmitter::ShiftType::LSL, uint32_t amt = 0) {
+    add(ARMEmitter::Size::i32Bit, rd.R(), rn.R(), rm.R(), Shift, amt);
+  }
+  void adds(FEXCore::ARMEmitter::WRegister rd, FEXCore::ARMEmitter::WRegister rn, FEXCore::ARMEmitter::WRegister rm, FEXCore::ARMEmitter::ShiftType Shift = FEXCore::ARMEmitter::ShiftType::LSL, uint32_t amt = 0) {
+    adds(ARMEmitter::Size::i32Bit, rd.R(), rn.R(), rm.R(), Shift, amt);
+  }
+  void sub(FEXCore::ARMEmitter::WRegister rd, FEXCore::ARMEmitter::WRegister rn, FEXCore::ARMEmitter::WRegister rm, FEXCore::ARMEmitter::ShiftType Shift = FEXCore::ARMEmitter::ShiftType::LSL, uint32_t amt = 0) {
+    sub(ARMEmitter::Size::i32Bit, rd.R(), rn.R(), rm.R(), Shift, amt);
+  }
+  void neg(FEXCore::ARMEmitter::WRegister rd, FEXCore::ARMEmitter::WRegister rm, FEXCore::ARMEmitter::ShiftType Shift = FEXCore::ARMEmitter::ShiftType::LSL, uint32_t amt = 0) {
+    sub(rd, FEXCore::ARMEmitter::WReg::zr, rm, Shift, amt);
+  }
+  void cmp(FEXCore::ARMEmitter::WRegister rn, FEXCore::ARMEmitter::WRegister rm, FEXCore::ARMEmitter::ShiftType Shift = FEXCore::ARMEmitter::ShiftType::LSL, uint32_t amt = 0) {
+    subs(ARMEmitter::Size::i32Bit, FEXCore::ARMEmitter::Reg::rsp, rn.R(), rm.R(), Shift, amt);
+  }
+  void subs(FEXCore::ARMEmitter::WRegister rd, FEXCore::ARMEmitter::WRegister rn, FEXCore::ARMEmitter::WRegister rm, FEXCore::ARMEmitter::ShiftType Shift = FEXCore::ARMEmitter::ShiftType::LSL, uint32_t amt = 0) {
+    subs(ARMEmitter::Size::i32Bit, rd.R(), rn.R(), rm.R(), Shift, amt);
+  }
+  void negs(FEXCore::ARMEmitter::WRegister rd, FEXCore::ARMEmitter::WRegister rm, FEXCore::ARMEmitter::ShiftType Shift = FEXCore::ARMEmitter::ShiftType::LSL, uint32_t amt = 0) {
+    subs(rd, FEXCore::ARMEmitter::WReg::zr, rm, Shift, amt);
+  }
+
+  void add(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ShiftType Shift = FEXCore::ARMEmitter::ShiftType::LSL, uint32_t amt = 0) {
+    LOGMAN_THROW_AA_FMT(Shift != FEXCore::ARMEmitter::ShiftType::ROR, "Doesn't support ROR");
+    constexpr uint32_t Op = 0b000'1011'000U << 21;
+    DataProcessing_Shifted_Reg(Op, s, rd, rn, rm, Shift, amt);
+  }
+  void adds(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ShiftType Shift = FEXCore::ARMEmitter::ShiftType::LSL, uint32_t amt = 0) {
+    LOGMAN_THROW_AA_FMT(Shift != FEXCore::ARMEmitter::ShiftType::ROR, "Doesn't support ROR");
+    constexpr uint32_t Op = 0b010'1011'000U << 21;
+    DataProcessing_Shifted_Reg(Op, s, rd, rn, rm, Shift, amt);
+  }
+  void sub(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ShiftType Shift = FEXCore::ARMEmitter::ShiftType::LSL, uint32_t amt = 0) {
+    LOGMAN_THROW_AA_FMT(Shift != FEXCore::ARMEmitter::ShiftType::ROR, "Doesn't support ROR");
+    constexpr uint32_t Op = 0b100'1011'000U << 21;
+    DataProcessing_Shifted_Reg(Op, s, rd, rn, rm, Shift, amt);
+  }
+  void neg(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ShiftType Shift = FEXCore::ARMEmitter::ShiftType::LSL, uint32_t amt = 0) {
+    sub(s, rd, FEXCore::ARMEmitter::Reg::zr, rm, Shift, amt);
+  }
+  void cmp(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ShiftType Shift = FEXCore::ARMEmitter::ShiftType::LSL, uint32_t amt = 0) {
+    subs(s, FEXCore::ARMEmitter::Reg::zr, rn, rm, Shift, amt);
+  }
+
+  void subs(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ShiftType Shift = FEXCore::ARMEmitter::ShiftType::LSL, uint32_t amt = 0) {
+    LOGMAN_THROW_AA_FMT(Shift != FEXCore::ARMEmitter::ShiftType::ROR, "Doesn't support ROR");
+    constexpr uint32_t Op = 0b110'1011'000U << 21;
+    DataProcessing_Shifted_Reg(Op, s, rd, rn, rm, Shift, amt);
+  }
+  void negs(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ShiftType Shift = FEXCore::ARMEmitter::ShiftType::LSL, uint32_t amt = 0) {
+    subs(s, rd, FEXCore::ARMEmitter::Reg::zr, rm, Shift, amt);
+  }
+
+  // AddSub - extended register
+  void add(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ExtendedType Option, uint32_t Shift = 0) {
+    LOGMAN_THROW_AA_FMT(Shift <= 4, "Shift amount is too large");
+    constexpr uint32_t Op = 0b000'1011'001U << 21;
+    DataProcessing_Extended_Reg(Op, s, rd, rn, rm, Option, Shift);
+  }
+  void adds(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ExtendedType Option, uint32_t Shift = 0) {
+    constexpr uint32_t Op = 0b010'1011'001U << 21;
+    DataProcessing_Extended_Reg(Op, s, rd, rn, rm, Option, Shift);
+  }
+  void sub(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ExtendedType Option, uint32_t Shift = 0) {
+    constexpr uint32_t Op = 0b100'1011'001U << 21;
+    DataProcessing_Extended_Reg(Op, s, rd, rn, rm, Option, Shift);
+  }
+  void subs(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ExtendedType Option, uint32_t Shift = 0) {
+    constexpr uint32_t Op = 0b110'1011'001U << 21;
+    DataProcessing_Extended_Reg(Op, s, rd, rn, rm, Option, Shift);
+  }
+  void cmp(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ExtendedType Option, uint32_t Shift = 0) {
+    constexpr uint32_t Op = 0b110'1011'001U << 21;
+    DataProcessing_Extended_Reg(Op, s, FEXCore::ARMEmitter::Reg::zr, rn, rm, Option, Shift);
+  }
+
+  // AddSub - with carry
+  void adc(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    constexpr uint32_t Op = 0b0001'1010'000U << 21;
+    DataProcessing_Extended_Reg(Op, s, rd, rn, rm, FEXCore::ARMEmitter::ExtendedType::UXTB, 0);
+  }
+  void adcs(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    constexpr uint32_t Op = 0b0011'1010'000U << 21;
+    DataProcessing_Extended_Reg(Op, s, rd, rn, rm, FEXCore::ARMEmitter::ExtendedType::UXTB, 0);
+  }
+  void sbc(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    constexpr uint32_t Op = 0b0101'1010'000U << 21;
+    DataProcessing_Extended_Reg(Op, s, rd, rn, rm, FEXCore::ARMEmitter::ExtendedType::UXTB, 0);
+  }
+  void sbcs(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    constexpr uint32_t Op = 0b0111'1010'000U << 21;
+    DataProcessing_Extended_Reg(Op, s, rd, rn, rm, FEXCore::ARMEmitter::ExtendedType::UXTB, 0);
+  }
+  // Rotate right into flags
+  // TODO
+  // Evaluate into flags
+  // TODO
+  // Conditional compare - register
+  void ccmn(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::StatusFlags flags, FEXCore::ARMEmitter::Condition Cond) {
+    constexpr uint32_t Op = 0b0011'1010'010 << 21;
+    ConditionalCompare(Op, 0, 0b00, 0, s, rn, rm, flags, Cond);
+  }
+  void ccmp(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::StatusFlags flags, FEXCore::ARMEmitter::Condition Cond) {
+    constexpr uint32_t Op = 0b0011'1010'010 << 21;
+    ConditionalCompare(Op, 1, 0b00, 0, s, rn, rm, flags, Cond);
+  }
+
+  // Conditional compare - immediate
+  void ccmn(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rn, uint32_t rm, FEXCore::ARMEmitter::StatusFlags flags, FEXCore::ARMEmitter::Condition Cond) {
+    LOGMAN_THROW_A_FMT((rm & ~0b1'1111) == 0, "Comparison imm too large");
+    constexpr uint32_t Op = 0b0011'1010'010 << 21;
+    ConditionalCompare(Op, 0, 0b10, 0, s, rn, rm, flags, Cond);
+  }
+  void ccmp(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rn, uint32_t rm, FEXCore::ARMEmitter::StatusFlags flags, FEXCore::ARMEmitter::Condition Cond) {
+    LOGMAN_THROW_A_FMT((rm & ~0b1'1111) == 0, "Comparison imm too large");
+    constexpr uint32_t Op = 0b0011'1010'010 << 21;
+    ConditionalCompare(Op, 1, 0b10, 0, s, rn, rm, flags, Cond);
+  }
+
+  // Conditional select
+  void csel(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::Condition Cond) {
+    constexpr uint32_t Op = 0b0001'1010'100 << 21;
+    ConditionalCompare(Op, 0, 0b00, s, rd, rn, rm, Cond);
+  }
+  void cset(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Condition Cond) {
+    constexpr uint32_t Op = 0b0001'1010'100 << 21;
+    ConditionalCompare(Op, 0, 0b01, s, rd, FEXCore::ARMEmitter::Reg::zr, FEXCore::ARMEmitter::Reg::zr, static_cast<FEXCore::ARMEmitter::Condition>(FEXCore::ToUnderlying(Cond) ^ FEXCore::ToUnderlying(FEXCore::ARMEmitter::Condition::CC_NE)));
+  }
+  void csinc(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::Condition Cond) {
+    constexpr uint32_t Op = 0b0001'1010'100 << 21;
+    ConditionalCompare(Op, 0, 0b01, s, rd, rn, rm, Cond);
+  }
+  void csinv(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::Condition Cond) {
+    constexpr uint32_t Op = 0b0001'1010'100 << 21;
+    ConditionalCompare(Op, 1, 0b00, s, rd, rn, rm, Cond);
+  }
+  void csneg(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::Condition Cond) {
+    constexpr uint32_t Op = 0b0001'1010'100 << 21;
+    ConditionalCompare(Op, 1, 0b01, s, rd, rn, rm, Cond);
+  }
+
+  // Data processing - 3 source
+  void madd(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::Register ra) {
+    constexpr uint32_t Op = 0b001'1011'000U << 21;
+    DataProcessing_3Source(Op, 0, s, rd, rn, rm, ra);
+  }
+  void mul(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    madd(s, rd, rn, rm, FEXCore::ARMEmitter::Reg::zr);
+  }
+  void msub(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::Register ra) {
+    constexpr uint32_t Op = 0b001'1011'000U << 21;
+    DataProcessing_3Source(Op, 1, s, rd, rn, rm, ra);
+  }
+  void mneg(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    msub(s, rd, rn, rm, FEXCore::ARMEmitter::Reg::zr);
+  }
+  void smaddl(FEXCore::ARMEmitter::XRegister rd, FEXCore::ARMEmitter::WRegister rn, FEXCore::ARMEmitter::WRegister rm, FEXCore::ARMEmitter::XRegister ra) {
+    constexpr uint32_t Op = 0b001'1011'001U << 21;
+    DataProcessing_3Source(Op, 0, FEXCore::ARMEmitter::Size::i64Bit, rd, rn, rm, ra);
+  }
+  void smull(FEXCore::ARMEmitter::XRegister rd, FEXCore::ARMEmitter::WRegister rn, FEXCore::ARMEmitter::WRegister rm) {
+    smaddl(rd, rn, rm, FEXCore::ARMEmitter::Reg::zr);
+  }
+  void smsubl(FEXCore::ARMEmitter::XRegister rd, FEXCore::ARMEmitter::WRegister rn, FEXCore::ARMEmitter::WRegister rm, FEXCore::ARMEmitter::XRegister ra) {
+    constexpr uint32_t Op = 0b001'1011'001U << 21;
+    DataProcessing_3Source(Op, 1, FEXCore::ARMEmitter::Size::i64Bit, rd, rn, rm, ra);
+  }
+  void smnegl(FEXCore::ARMEmitter::XRegister rd, FEXCore::ARMEmitter::WRegister rn, FEXCore::ARMEmitter::WRegister rm) {
+    smsubl(rd, rn, rm, FEXCore::ARMEmitter::Reg::zr);
+  }
+  void smulh(FEXCore::ARMEmitter::XRegister rd, FEXCore::ARMEmitter::XRegister rn, FEXCore::ARMEmitter::XRegister rm) {
+    constexpr uint32_t Op = 0b001'1011'010U << 21;
+    DataProcessing_3Source(Op, 0, FEXCore::ARMEmitter::Size::i64Bit, rd, rn, rm, FEXCore::ARMEmitter::Reg::zr);
+  }
+  void umaddl(FEXCore::ARMEmitter::XRegister rd, FEXCore::ARMEmitter::WRegister rn, FEXCore::ARMEmitter::WRegister rm, FEXCore::ARMEmitter::XRegister ra) {
+    constexpr uint32_t Op = 0b001'1011'101U << 21;
+    DataProcessing_3Source(Op, 0, FEXCore::ARMEmitter::Size::i64Bit, rd, rn, rm, ra);
+  }
+  void umull(FEXCore::ARMEmitter::XRegister rd, FEXCore::ARMEmitter::WRegister rn, FEXCore::ARMEmitter::WRegister rm) {
+    umaddl(rd, rn, rm, FEXCore::ARMEmitter::Reg::zr);
+  }
+  void umsubl(FEXCore::ARMEmitter::XRegister rd, FEXCore::ARMEmitter::WRegister rn, FEXCore::ARMEmitter::WRegister rm, FEXCore::ARMEmitter::XRegister ra) {
+    constexpr uint32_t Op = 0b001'1011'101U << 21;
+    DataProcessing_3Source(Op, 1, FEXCore::ARMEmitter::Size::i64Bit, rd, rn, rm, ra);
+  }
+  void umnegl(FEXCore::ARMEmitter::XRegister rd, FEXCore::ARMEmitter::WRegister rn, FEXCore::ARMEmitter::WRegister rm) {
+    umsubl(rd, rn, rm, FEXCore::ARMEmitter::Reg::zr);
+  }
+  void umulh(FEXCore::ARMEmitter::XRegister rd, FEXCore::ARMEmitter::XRegister rn, FEXCore::ARMEmitter::XRegister rm) {
+    constexpr uint32_t Op = 0b001'1011'110U << 21;
+    DataProcessing_3Source(Op, 0, FEXCore::ARMEmitter::Size::i64Bit, rd, rn, rm, FEXCore::ARMEmitter::Reg::zr);
+  }
+
+private:
+  void and_(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, uint32_t n, uint32_t immr, uint32_t imms) {
+    constexpr uint32_t Op = 0b001'0010'00 << 22;
+    DataProcessing_Logical_Imm(Op, s, rd, rn, n, immr, imms);
+  }
+  void ands(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, uint32_t n, uint32_t immr, uint32_t imms) {
+    constexpr uint32_t Op = 0b111'0010'00 << 22;
+    DataProcessing_Logical_Imm(Op, s, rd, rn, n, immr, imms);
+  }
+  void orr(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, uint32_t n, uint32_t immr, uint32_t imms) {
+    constexpr uint32_t Op = 0b011'0010'00 << 22;
+    DataProcessing_Logical_Imm(Op, s, rd, rn, n, immr, imms);
+  }
+  void eor(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, uint32_t n, uint32_t immr, uint32_t imms) {
+    constexpr uint32_t Op = 0b101'0010'00 << 22;
+    DataProcessing_Logical_Imm(Op, s, rd, rn, n, immr, imms);
+  }
+
+  void sbfm(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, uint32_t immr, uint32_t imms) {
+    constexpr uint32_t Op = 0b0001'0011'00 << 22;
+    DataProcessing_Logical_Imm(Op, s, rd, rn, s == ARMEmitter::Size::i64Bit, immr, imms);
+  }
+  void bfm(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, uint32_t immr, uint32_t imms) {
+    constexpr uint32_t Op = 0b0011'0011'00 << 22;
+    DataProcessing_Logical_Imm(Op, s, rd, rn, s == ARMEmitter::Size::i64Bit, immr, imms);
+  }
+  // 4.1.64 - Data processing - Immediate
+  void DataProcessing_PCRel_Imm(uint32_t Op, FEXCore::ARMEmitter::Register rd, uint32_t Imm) {
+    // Ensure the immediate is masked.
+    Imm &= 0b1'1111'1111'1111'1111'1111U;
+
+    uint32_t Instr = Op;
+
+    Instr |= (Imm & 0b11) << 29;
+    Instr |= (Imm >> 2) << 5;
+    Instr |= Encode_rd(rd);
+
+    dc32(Instr);
+  }
+
+  void DataProcessing_AddSub_Imm(uint32_t Op, FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, uint32_t Imm, bool LSL12) {
+    bool TooLarge = (Imm & ~0b1111'1111'1111U) != 0;
+    if (TooLarge && !LSL12 && ((Imm >> 12) & ~0b1111'1111'1111U) == 0) {
+      // We can convert an immediate
+      TooLarge = false;
+      LSL12 = true;
+      Imm >>= 12;
+    }
+    LOGMAN_THROW_AA_FMT(TooLarge == false, "Imm amount too large: 0x{:x}", Imm);
+
+    const uint32_t SF = s == FEXCore::ARMEmitter::Size::i64Bit ? (1U << 31) : 0;
+
+    uint32_t Instr = Op;
+
+    Instr |= SF;
+    Instr |= LSL12 << 22;
+    Instr |= Imm << 10;
+    Instr |= Encode_rn(rn);
+    Instr |= Encode_rd(rd);
+
+    dc32(Instr);
+  }
+
+  // Move Wide
+  void DataProcessing_MoveWide(uint32_t Op, FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, uint32_t Imm, uint32_t Offset) {
+    const uint32_t SF = s == FEXCore::ARMEmitter::Size::i64Bit ? (1U << 31) : 0;
+
+    uint32_t Instr = Op;
+
+    Instr |= SF;
+    Instr |= Imm << 5;
+    Instr |= Offset << 21;
+    Instr |= Encode_rd(rd);
+
+    dc32(Instr);
+  }
+
+  // Logical immediate
+  void DataProcessing_Logical_Imm(uint32_t Op, FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, uint32_t n, uint32_t immr, uint32_t imms) {
+    const uint32_t SF = s == FEXCore::ARMEmitter::Size::i64Bit ? (1U << 31) : 0;
+
+    uint32_t Instr = Op;
+
+    Instr |= SF;
+    Instr |= n << 22;
+    Instr |= immr << 16;
+    Instr |= imms << 10;
+    Instr |= Encode_rn(rn);
+    Instr |= Encode_rd(rd);
+
+    dc32(Instr);
+  }
+
+  void DataProcessing_Extract(uint32_t Op, FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, uint32_t Imm) {
+    const uint32_t SF = s == FEXCore::ARMEmitter::Size::i64Bit ? (1U << 31) : 0;
+
+    // Current ARMv8 spec hardcodes SF == N for this class of instructions.
+    // Anythign else is undefined behaviour.
+    const uint32_t N  = s == FEXCore::ARMEmitter::Size::i64Bit ? (1U << 22) : 0;
+
+    uint32_t Instr = Op;
+
+    Instr |= SF;
+    Instr |= N;
+    Instr |= Encode_rm(rm);
+    Instr |= Imm << 10;
+    Instr |= Encode_rn(rn);
+    Instr |= Encode_rd(rd);
+
+    dc32(Instr);
+  }
+
+  // Data-processing - 2 source
+  void DataProcessing_2Source(uint32_t Op, FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    const uint32_t SF = s == FEXCore::ARMEmitter::Size::i64Bit ? (1U << 31) : 0;
+
+    uint32_t Instr = Op;
+
+    Instr |= SF;
+    Instr |= Encode_rm(rm);
+    Instr |= Encode_rn(rn);
+    Instr |= Encode_rd(rd);
+
+    dc32(Instr);
+  }
+
+  // Data processing - 1 source
+  template<typename T>
+  void DataProcessing_1Source(uint32_t Op, FEXCore::ARMEmitter::Size s, T rd, T rn) {
+    const uint32_t SF = s == FEXCore::ARMEmitter::Size::i64Bit ? (1U << 31) : 0;
+
+    uint32_t Instr = Op;
+
+    Instr |= SF;
+    Instr |= Encode_rn(rn);
+    Instr |= Encode_rd(rd);
+
+    dc32(Instr);
+  }
+
+  // AddSub - shifted register
+  void DataProcessing_Shifted_Reg(uint32_t Op, FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ShiftType Shift, uint32_t amt) {
+    LOGMAN_THROW_AA_FMT((amt & ~0b11'1111U) == 0, "Shift amount too large");
+
+    const uint32_t SF = s == FEXCore::ARMEmitter::Size::i64Bit ? (1U << 31) : 0;
+
+    uint32_t Instr = Op;
+
+    Instr |= SF;
+    Instr |= FEXCore::ToUnderlying(Shift) << 22;
+    Instr |= Encode_rm(rm);
+    Instr |= static_cast<uint32_t>(amt) << 10;
+    Instr |= Encode_rn(rn);
+    Instr |= Encode_rd(rd);
+
+    dc32(Instr);
+  }
+
+  // AddSub - extended register
+  void DataProcessing_Extended_Reg(uint32_t Op, FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ExtendedType Option, uint32_t Shift) {
+    const uint32_t SF = s == FEXCore::ARMEmitter::Size::i64Bit ? (1U << 31) : 0;
+
+    uint32_t Instr = Op;
+
+    Instr |= SF;
+    Instr |= Encode_rm(rm);
+    Instr |= FEXCore::ToUnderlying(Option) << 13;
+    Instr |= static_cast<uint32_t>(Shift) << 10;
+    Instr |= Encode_rn(rn);
+    Instr |= Encode_rd(rd);
+
+    dc32(Instr);
+  }
+  // Conditional compare - register
+  template<typename T>
+  void ConditionalCompare(uint32_t Op, uint32_t o1, uint32_t o2, uint32_t o3, FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rn, T rm, FEXCore::ARMEmitter::StatusFlags flags, FEXCore::ARMEmitter::Condition Cond) {
+    const uint32_t SF = s == FEXCore::ARMEmitter::Size::i64Bit ? (1U << 31) : 0;
+
+    uint32_t Instr = Op;
+
+    Instr |= SF;
+    Instr |= o1 << 30;
+    Instr |= Encode_rm(rm);
+    Instr |= FEXCore::ToUnderlying(Cond) << 12;
+    Instr |= o2 << 10;
+    Instr |= Encode_rn(rn);
+    Instr |= o3 << 4;
+    Instr |= FEXCore::ToUnderlying(flags);
+
+    dc32(Instr);
+  }
+
+  template<typename T>
+  void ConditionalCompare(uint32_t Op, uint32_t o1, uint32_t o2, FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, T rm, FEXCore::ARMEmitter::Condition Cond) {
+    const uint32_t SF = s == FEXCore::ARMEmitter::Size::i64Bit ? (1U << 31) : 0;
+
+    uint32_t Instr = Op;
+
+    Instr |= SF;
+    Instr |= o1 << 30;
+    Instr |= Encode_rm(rm);
+    Instr |= FEXCore::ToUnderlying(Cond) << 12;
+    Instr |= o2 << 10;
+    Instr |= Encode_rn(rn);
+    Instr |= Encode_rd(rd);
+
+    dc32(Instr);
+  }
+
+  // Data-processing - 3 source
+  void DataProcessing_3Source(uint32_t Op, uint32_t Op0, FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::Register ra) {
+    const uint32_t SF = s == FEXCore::ARMEmitter::Size::i64Bit ? (1U << 31) : 0;
+
+    uint32_t Instr = Op;
+
+    Instr |= SF;
+    Instr |= Encode_rm(rm);
+    Instr |= Op0 << 15;
+    Instr |= Encode_ra(ra);
+    Instr |= Encode_rn(rn);
+    Instr |= Encode_rd(rd);
+
+    dc32(Instr);
+  }
+
+

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ASIMDOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ASIMDOps.inl
@@ -1,0 +1,4023 @@
+/* ASIMD instruction emitters.
+ *
+ * This contains emitters for vector operations explicitly.
+ * Most instructions have a `SubRegSize` as their first argument to select element size while operating.
+ * Additionally most emitters accept templated vector register arguments of both `QRegister` and `DRegister` types.
+ * Based on the combination of those two arguments, it will emit an instruction operating on a 64-bit or 128-bit wide register
+ * with the selected element size.
+ *
+ * Some vector operations are unsized and only operate at the one width. In these cases the instruction only
+ * operates at one size, the width depends on the instruction.
+ * The arguments for these instructions are usually `VRegister` but might be one of the other sized types as well.
+ *
+ * Only two instructions support the `i128Bit` ElementSize.
+ */
+public:
+  // Data Processing -- Scalar Floating-Point and Advanced SIMD
+  // Cryptographic AES
+  void aese(FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    constexpr uint32_t Op = 0b0100'1110'0010'1000'0000'10 << 10;
+    CryptoAES(Op, 0b00100, rd, rn);
+  }
+  void aesd(FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    constexpr uint32_t Op = 0b0100'1110'0010'1000'0000'10 << 10;
+    CryptoAES(Op, 0b00101, rd, rn);
+  }
+  void aesmc(FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    constexpr uint32_t Op = 0b0100'1110'0010'1000'0000'10 << 10;
+    CryptoAES(Op, 0b00110, rd, rn);
+  }
+  void aesimc(FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    constexpr uint32_t Op = 0b0100'1110'0010'1000'0000'10 << 10;
+    CryptoAES(Op, 0b00111, rd, rn);
+  }
+
+  // Cryptographic three-register SHA
+  void sha1c(FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::SRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    constexpr uint32_t Op = 0b0101'1110'0000'0000'0000'00 << 10;
+    Crypto3RegSHA(Op, 0b000, rd, rn.V(), rm);
+  }
+  void sha1p(FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::SRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    constexpr uint32_t Op = 0b0101'1110'0000'0000'0000'00 << 10;
+    Crypto3RegSHA(Op, 0b001, rd, rn.V(), rm);
+  }
+  void sha1m(FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::SRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    constexpr uint32_t Op = 0b0101'1110'0000'0000'0000'00 << 10;
+    Crypto3RegSHA(Op, 0b010, rd, rn.V(), rm);
+  }
+  void sha1su0(FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    constexpr uint32_t Op = 0b0101'1110'0000'0000'0000'00 << 10;
+    Crypto3RegSHA(Op, 0b011, rd, rn, rm);
+  }
+  void sha256h(FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    constexpr uint32_t Op = 0b0101'1110'0000'0000'0000'00 << 10;
+    Crypto3RegSHA(Op, 0b100, rd, rn, rm);
+  }
+  void sha256h2(FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    constexpr uint32_t Op = 0b0101'1110'0000'0000'0000'00 << 10;
+    Crypto3RegSHA(Op, 0b100, rd, rn, rm);
+  }
+  void sha256su1(FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    constexpr uint32_t Op = 0b0101'1110'0000'0000'0000'00 << 10;
+    Crypto3RegSHA(Op, 0b100, rd, rn, rm);
+  }
+
+  // Cryptographic two-register SHA
+  void sha1h(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn) {
+    constexpr uint32_t Op = 0b0101'1110'0010'1000'0000'10 << 10;
+    Crypto2RegSHA(Op, 0b00000, rd.V(), rn.V());
+  }
+  void sha1su1(FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    constexpr uint32_t Op = 0b0101'1110'0010'1000'0000'10 << 10;
+    Crypto2RegSHA(Op, 0b00001, rd, rn);
+  }
+  void sha256su0(FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    constexpr uint32_t Op = 0b0101'1110'0010'1000'0000'10 << 10;
+    Crypto2RegSHA(Op, 0b00010, rd, rn);
+  }
+  // Advanced SIMD table lookup
+  void tbl(FEXCore::ARMEmitter::QRegister rd, FEXCore::ARMEmitter::QRegister rn, FEXCore::ARMEmitter::QRegister rm) {
+    constexpr uint32_t Op = 0b0000'1110'000 << 21;
+    ASIMDTable(Op, 1, 0b00, 0b00, 0b0, rd.V(), rn.V(), rm.V());
+  }
+  void tbl(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::QRegister rn, FEXCore::ARMEmitter::DRegister rm) {
+    constexpr uint32_t Op = 0b0000'1110'000 << 21;
+    ASIMDTable(Op, 0, 0b00, 0b00, 0b0, rd.V(), rn.V(), rm.V());
+  }
+  void tbx(FEXCore::ARMEmitter::QRegister rd, FEXCore::ARMEmitter::QRegister rn, FEXCore::ARMEmitter::QRegister rm) {
+    constexpr uint32_t Op = 0b0000'1110'000 << 21;
+    ASIMDTable(Op, 1, 0b00, 0b00, 0b1, rd.V(), rn.V(), rm.V());
+  }
+  void tbx(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::QRegister rn, FEXCore::ARMEmitter::DRegister rm) {
+    constexpr uint32_t Op = 0b0000'1110'000 << 21;
+    ASIMDTable(Op, 0, 0b00, 0b00, 0b1, rd.V(), rn.V(), rm.V());
+  }
+
+  void tbl(FEXCore::ARMEmitter::QRegister rd, FEXCore::ARMEmitter::QRegister rn, FEXCore::ARMEmitter::QRegister rn2, FEXCore::ARMEmitter::QRegister rm) {
+    LOGMAN_THROW_A_FMT((rn.Idx() + 1) == rn2.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1110'000 << 21;
+    ASIMDTable(Op, 1, 0b00, 0b01, 0b0, rd.V(), rn.V(), rm.V());
+  }
+  void tbl(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::QRegister rn, FEXCore::ARMEmitter::QRegister rn2, FEXCore::ARMEmitter::DRegister rm) {
+    LOGMAN_THROW_A_FMT((rn.Idx() + 1) == rn2.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1110'000 << 21;
+    ASIMDTable(Op, 0, 0b00, 0b01, 0b0, rd.V(), rn.V(), rm.V());
+  }
+  void tbx(FEXCore::ARMEmitter::QRegister rd, FEXCore::ARMEmitter::QRegister rn, FEXCore::ARMEmitter::QRegister rn2, FEXCore::ARMEmitter::QRegister rm) {
+    LOGMAN_THROW_A_FMT((rn.Idx() + 1) == rn2.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1110'000 << 21;
+    ASIMDTable(Op, 1, 0b00, 0b01, 0b1, rd.V(), rn.V(), rm.V());
+  }
+  void tbx(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::QRegister rn, FEXCore::ARMEmitter::QRegister rn2, FEXCore::ARMEmitter::DRegister rm) {
+    LOGMAN_THROW_A_FMT((rn.Idx() + 1) == rn2.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1110'000 << 21;
+    ASIMDTable(Op, 0, 0b00, 0b01, 0b1, rd.V(), rn.V(), rm.V());
+  }
+
+  void tbl(FEXCore::ARMEmitter::QRegister rd, FEXCore::ARMEmitter::QRegister rn, FEXCore::ARMEmitter::QRegister rn2, FEXCore::ARMEmitter::QRegister rn3, FEXCore::ARMEmitter::QRegister rm) {
+    LOGMAN_THROW_A_FMT((rn.Idx() + 1) == rn2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rn2.Idx() + 1) == rn3.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1110'000 << 21;
+    ASIMDTable(Op, 1, 0b00, 0b10, 0b0, rd.V(), rn.V(), rm.V());
+  }
+  void tbl(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::QRegister rn, FEXCore::ARMEmitter::QRegister rn2, FEXCore::ARMEmitter::QRegister rn3, FEXCore::ARMEmitter::DRegister rm) {
+    LOGMAN_THROW_A_FMT((rn.Idx() + 1) == rn2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rn2.Idx() + 1) == rn3.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1110'000 << 21;
+    ASIMDTable(Op, 0, 0b00, 0b10, 0b0, rd.V(), rn.V(), rm.V());
+  }
+  void tbx(FEXCore::ARMEmitter::QRegister rd, FEXCore::ARMEmitter::QRegister rn, FEXCore::ARMEmitter::QRegister rn2, FEXCore::ARMEmitter::QRegister rn3, FEXCore::ARMEmitter::QRegister rm) {
+    LOGMAN_THROW_A_FMT((rn.Idx() + 1) == rn2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rn2.Idx() + 1) == rn3.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1110'000 << 21;
+    ASIMDTable(Op, 1, 0b00, 0b10, 0b1, rd.V(), rn.V(), rm.V());
+  }
+  void tbx(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::QRegister rn, FEXCore::ARMEmitter::QRegister rn2, FEXCore::ARMEmitter::QRegister rn3, FEXCore::ARMEmitter::DRegister rm) {
+    LOGMAN_THROW_A_FMT((rn.Idx() + 1) == rn2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rn2.Idx() + 1) == rn3.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1110'000 << 21;
+    ASIMDTable(Op, 0, 0b00, 0b10, 0b1, rd.V(), rn.V(), rm.V());
+  }
+
+  void tbl(FEXCore::ARMEmitter::QRegister rd, FEXCore::ARMEmitter::QRegister rn, FEXCore::ARMEmitter::QRegister rn2, FEXCore::ARMEmitter::QRegister rn3, FEXCore::ARMEmitter::QRegister rn4, FEXCore::ARMEmitter::QRegister rm) {
+    LOGMAN_THROW_A_FMT((rn.Idx() + 1) == rn2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rn2.Idx() + 1) == rn3.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rn3.Idx() + 1) == rn4.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1110'000 << 21;
+    ASIMDTable(Op, 1, 0b00, 0b11, 0b0, rd.V(), rn.V(), rm.V());
+  }
+  void tbl(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::QRegister rn, FEXCore::ARMEmitter::QRegister rn2, FEXCore::ARMEmitter::QRegister rn3, FEXCore::ARMEmitter::QRegister rn4, FEXCore::ARMEmitter::DRegister rm) {
+    LOGMAN_THROW_A_FMT((rn.Idx() + 1) == rn2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rn2.Idx() + 1) == rn3.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rn3.Idx() + 1) == rn4.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1110'000 << 21;
+    ASIMDTable(Op, 0, 0b00, 0b11, 0b0, rd.V(), rn.V(), rm.V());
+  }
+  void tbx(FEXCore::ARMEmitter::QRegister rd, FEXCore::ARMEmitter::QRegister rn, FEXCore::ARMEmitter::QRegister rn2, FEXCore::ARMEmitter::QRegister rn3, FEXCore::ARMEmitter::QRegister rn4, FEXCore::ARMEmitter::QRegister rm) {
+    LOGMAN_THROW_A_FMT((rn.Idx() + 1) == rn2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rn2.Idx() + 1) == rn3.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rn3.Idx() + 1) == rn4.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1110'000 << 21;
+    ASIMDTable(Op, 1, 0b00, 0b11, 0b1, rd.V(), rn.V(), rm.V());
+  }
+  void tbx(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::QRegister rn, FEXCore::ARMEmitter::QRegister rn2, FEXCore::ARMEmitter::QRegister rn3, FEXCore::ARMEmitter::QRegister rn4, FEXCore::ARMEmitter::DRegister rm) {
+    LOGMAN_THROW_A_FMT((rn.Idx() + 1) == rn2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rn2.Idx() + 1) == rn3.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rn3.Idx() + 1) == rn4.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1110'000 << 21;
+    ASIMDTable(Op, 0, 0b00, 0b11, 0b1, rd.V(), rn.V(), rm.V());
+  }
+
+  // Advanced SIMD permute
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void uzp1(FEXCore::ARMEmitter::QRegister rd, FEXCore::ARMEmitter::QRegister rn, FEXCore::ARMEmitter::QRegister rm) {
+    constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'10 << 10;
+    ASIMDPermute(Op, 1, size, 0b001, rd.V(), rn.V(), rm.V());
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  requires (size != FEXCore::ARMEmitter::SubRegSize::i64Bit)
+  void uzp1(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm) {
+    constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'10 << 10;
+    ASIMDPermute(Op, 0, size, 0b001, rd.V(), rn.V(), rm.V());
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void trn1(FEXCore::ARMEmitter::QRegister rd, FEXCore::ARMEmitter::QRegister rn, FEXCore::ARMEmitter::QRegister rm) {
+    constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'10 << 10;
+    ASIMDPermute(Op, 1, size, 0b010, rd.V(), rn.V(), rm.V());
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  requires (size != FEXCore::ARMEmitter::SubRegSize::i64Bit)
+  void trn1(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm) {
+    constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'10 << 10;
+    ASIMDPermute(Op, 0, size, 0b010, rd.V(), rn.V(), rm.V());
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void zip1(FEXCore::ARMEmitter::QRegister rd, FEXCore::ARMEmitter::QRegister rn, FEXCore::ARMEmitter::QRegister rm) {
+    constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'10 << 10;
+    ASIMDPermute(Op, 1, size, 0b011, rd.V(), rn.V(), rm.V());
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  requires (size != FEXCore::ARMEmitter::SubRegSize::i64Bit)
+  void zip1(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm) {
+    constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'10 << 10;
+    ASIMDPermute(Op, 0, size, 0b011, rd.V(), rn.V(), rm.V());
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void uzp2(FEXCore::ARMEmitter::QRegister rd, FEXCore::ARMEmitter::QRegister rn, FEXCore::ARMEmitter::QRegister rm) {
+    constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'10 << 10;
+    ASIMDPermute(Op, 1, size, 0b101, rd.V(), rn.V(), rm.V());
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  requires (size != FEXCore::ARMEmitter::SubRegSize::i64Bit)
+  void uzp2(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm) {
+    constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'10 << 10;
+    ASIMDPermute(Op, 0, size, 0b101, rd.V(), rn.V(), rm.V());
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void trn2(FEXCore::ARMEmitter::QRegister rd, FEXCore::ARMEmitter::QRegister rn, FEXCore::ARMEmitter::QRegister rm) {
+    constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'10 << 10;
+    ASIMDPermute(Op, 1, size, 0b110, rd.V(), rn.V(), rm.V());
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  requires (size != FEXCore::ARMEmitter::SubRegSize::i64Bit)
+  void trn2(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm) {
+    constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'10 << 10;
+    ASIMDPermute(Op, 0, size, 0b110, rd.V(), rn.V(), rm.V());
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void zip2(FEXCore::ARMEmitter::QRegister rd, FEXCore::ARMEmitter::QRegister rn, FEXCore::ARMEmitter::QRegister rm) {
+    constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'10 << 10;
+    ASIMDPermute(Op, 1, size, 0b111, rd.V(), rn.V(), rm.V());
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  requires (size != FEXCore::ARMEmitter::SubRegSize::i64Bit)
+  void zip2(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm) {
+    constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'10 << 10;
+    ASIMDPermute(Op, 0, size, 0b111, rd.V(), rn.V(), rm.V());
+  }
+
+
+  void uzp1(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::QRegister rd, FEXCore::ARMEmitter::QRegister rn, FEXCore::ARMEmitter::QRegister rm) {
+    constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'10 << 10;
+    ASIMDPermute(Op, 1, size, 0b001, rd.V(), rn.V(), rm.V());
+  }
+  void uzp1(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid 64-bit size on 64-bit permute");
+    constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'10 << 10;
+    ASIMDPermute(Op, 0, size, 0b001, rd.V(), rn.V(), rm.V());
+  }
+  void trn1(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::QRegister rd, FEXCore::ARMEmitter::QRegister rn, FEXCore::ARMEmitter::QRegister rm) {
+    constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'10 << 10;
+    ASIMDPermute(Op, 1, size, 0b010, rd.V(), rn.V(), rm.V());
+  }
+  void trn1(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid 64-bit size on 64-bit permute");
+    constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'10 << 10;
+    ASIMDPermute(Op, 0, size, 0b010, rd.V(), rn.V(), rm.V());
+  }
+  void zip1(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::QRegister rd, FEXCore::ARMEmitter::QRegister rn, FEXCore::ARMEmitter::QRegister rm) {
+    constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'10 << 10;
+    ASIMDPermute(Op, 1, size, 0b011, rd.V(), rn.V(), rm.V());
+  }
+  void zip1(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid 64-bit size on 64-bit permute");
+    constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'10 << 10;
+    ASIMDPermute(Op, 0, size, 0b011, rd.V(), rn.V(), rm.V());
+  }
+  void uzp2(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::QRegister rd, FEXCore::ARMEmitter::QRegister rn, FEXCore::ARMEmitter::QRegister rm) {
+    constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'10 << 10;
+    ASIMDPermute(Op, 1, size, 0b101, rd.V(), rn.V(), rm.V());
+  }
+  void uzp2(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid 64-bit size on 64-bit permute");
+    constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'10 << 10;
+    ASIMDPermute(Op, 0, size, 0b101, rd.V(), rn.V(), rm.V());
+  }
+  void trn2(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::QRegister rd, FEXCore::ARMEmitter::QRegister rn, FEXCore::ARMEmitter::QRegister rm) {
+    constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'10 << 10;
+    ASIMDPermute(Op, 1, size, 0b110, rd.V(), rn.V(), rm.V());
+  }
+  void trn2(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid 64-bit size on 64-bit permute");
+    constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'10 << 10;
+    ASIMDPermute(Op, 0, size, 0b110, rd.V(), rn.V(), rm.V());
+  }
+  void zip2(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::QRegister rd, FEXCore::ARMEmitter::QRegister rn, FEXCore::ARMEmitter::QRegister rm) {
+    constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'10 << 10;
+    ASIMDPermute(Op, 1, size, 0b111, rd.V(), rn.V(), rm.V());
+  }
+  void zip2(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid 64-bit size on 64-bit permute");
+    constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'10 << 10;
+    ASIMDPermute(Op, 0, size, 0b111, rd.V(), rn.V(), rm.V());
+  }
+
+  // Advanced SIMD extract
+  void ext(FEXCore::ARMEmitter::QRegister rd, FEXCore::ARMEmitter::QRegister rn, FEXCore::ARMEmitter::QRegister rm, uint32_t Index) {
+    LOGMAN_THROW_AA_FMT(Index < 16, "Index can't be more than 15");
+    constexpr uint32_t Op = 0b0010'1110'000 << 21;
+    ASIMDExtract(Op, 1, 0b00, Index, rd.V(), rn.V(), rm.V());
+  }
+  void ext(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm, uint32_t Index) {
+    LOGMAN_THROW_AA_FMT(Index < 8, "Index can't be more than 7");
+    constexpr uint32_t Op = 0b0010'1110'000 << 21;
+    ASIMDExtract(Op, 0, 0b00, Index, rd.V(), rn.V(), rm.V());
+  }
+
+  // Advanced SIMD copy
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void dup(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, uint32_t Index) {
+    if constexpr(std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit dup");
+    }
+    constexpr uint32_t Q = std::is_same_v<FEXCore::ARMEmitter::QRegister, T> ? 1 : 0;
+
+    constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'01 << 10;
+    uint32_t imm5 = 0b00000;
+    if (size == SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 16, "Index too large");
+      imm5 = (Index << 1) | 1;
+    }
+    else if (size == SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 8, "Index too large");
+      imm5 = (Index << 2) | 0b10;
+    }
+    else if (size == SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 4, "Index too large");
+      imm5 = (Index << 3) | 0b100;
+    }
+    else if (size == SubRegSize::i64Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 2, "Index too large");
+      imm5 = (Index << 4) | 0b1000;
+    }
+
+    ASIMDScalarCopy(Op, Q, imm5, 0b0000, rd.V(), rn.V());
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void dup(FEXCore::ARMEmitter::SubRegSize size, T rd, FEXCore::ARMEmitter::Register rn) {
+    if constexpr(std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit dup");
+    }
+    constexpr uint32_t Q = std::is_same_v<FEXCore::ARMEmitter::QRegister, T> ? 1 : 0;
+
+    constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'01 << 10;
+
+    // Upper bits of imm5 are ignored for GPR dup
+    uint32_t imm5 = 0b00000;
+    if (size == SubRegSize::i8Bit) {
+      imm5 = 1;
+    }
+    else if (size == SubRegSize::i16Bit) {
+      imm5 = 0b10;
+    }
+    else if (size == SubRegSize::i32Bit) {
+      imm5 = 0b100;
+    }
+    else if (size == SubRegSize::i64Bit) {
+      imm5 = 0b1000;
+    }
+
+    ASIMDScalarCopy(Op, Q, imm5, 0b0001, rd, ToVReg(rn));
+  }
+
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  requires(size == FEXCore::ARMEmitter::SubRegSize::i8Bit || size == FEXCore::ARMEmitter::SubRegSize::i16Bit || size == FEXCore::ARMEmitter::SubRegSize::i32Bit)
+  void smov(FEXCore::ARMEmitter::XRegister rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Index) {
+    static_assert(size == FEXCore::ARMEmitter::SubRegSize::i8Bit ||
+                  size == FEXCore::ARMEmitter::SubRegSize::i16Bit ||
+                  size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Unsupported smov size");
+
+    constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'01 << 10;
+    uint32_t imm5 = 0b00000;
+    if constexpr (size == SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 16, "Index too large");
+      imm5 = (Index << 1) | 1;
+    }
+    else if constexpr (size == SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 8, "Index too large");
+      imm5 = (Index << 2) | 0b10;
+    }
+    else if constexpr (size == SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 4, "Index too large");
+      imm5 = (Index << 3) | 0b100;
+    }
+
+    ASIMDScalarCopy(Op, 1, imm5, 0b0101, ToVReg(rd), rn);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  requires(size == FEXCore::ARMEmitter::SubRegSize::i8Bit || size == FEXCore::ARMEmitter::SubRegSize::i16Bit)
+  void smov(FEXCore::ARMEmitter::WRegister rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Index) {
+    static_assert(size == FEXCore::ARMEmitter::SubRegSize::i8Bit ||
+                  size == FEXCore::ARMEmitter::SubRegSize::i16Bit, "Unsupported smov size");
+
+    constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'01 << 10;
+    uint32_t imm5 = 0b00000;
+    if constexpr (size == SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 16, "Index too large");
+      imm5 = (Index << 1) | 1;
+    }
+    else if constexpr (size == SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 8, "Index too large");
+      imm5 = (Index << 2) | 0b10;
+    }
+
+    ASIMDScalarCopy(Op, 0, imm5, 0b0101, ToVReg(rd), rn);
+  }
+
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void umov(FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Index) {
+    static_assert(size == FEXCore::ARMEmitter::SubRegSize::i8Bit ||
+                  size == FEXCore::ARMEmitter::SubRegSize::i16Bit ||
+                  size == FEXCore::ARMEmitter::SubRegSize::i32Bit ||
+                  size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Unsupported smov size");
+
+
+    constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'01 << 10;
+    uint32_t imm5 = 0b00000;
+    uint32_t Q = 0;
+    if constexpr (size == SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 16, "Index too large");
+      imm5 = (Index << 1) | 1;
+    }
+    else if constexpr (size == SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 8, "Index too large");
+      imm5 = (Index << 2) | 0b10;
+    }
+    else if constexpr (size == SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 4, "Index too large");
+      imm5 = (Index << 3) | 0b100;
+    }
+    else if constexpr (size == SubRegSize::i64Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 2, "Index too large");
+      imm5 = (Index << 4) | 0b1000;
+      Q = 1;
+    }
+
+    ASIMDScalarCopy(Op, Q, imm5, 0b0111, ToVReg(rd), rn);
+  }
+
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void ins(FEXCore::ARMEmitter::VRegister rd, uint32_t Index, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'01 << 10;
+    uint32_t imm5 = 0b00000;
+    if constexpr (size == SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 16, "Index too large");
+      imm5 = (Index << 1) | 1;
+    }
+    else if constexpr (size == SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 8, "Index too large");
+      imm5 = (Index << 2) | 0b10;
+    }
+    else if constexpr (size == SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 4, "Index too large");
+      imm5 = (Index << 3) | 0b100;
+    }
+    else if constexpr (size == SubRegSize::i64Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 2, "Index too large");
+      imm5 = (Index << 4) | 0b1000;
+    }
+
+    ASIMDScalarCopy(Op, 1, imm5, 0b0011, rd, ToVReg(rn));
+  }
+
+  void ins(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::VRegister rd, uint32_t Index, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'01 << 10;
+    uint32_t imm5 = 0b00000;
+    if (size == SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 16, "Index too large");
+      imm5 = (Index << 1) | 1;
+    }
+    else if (size == SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 8, "Index too large");
+      imm5 = (Index << 2) | 0b10;
+    }
+    else if (size == SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 4, "Index too large");
+      imm5 = (Index << 3) | 0b100;
+    }
+    else if (size == SubRegSize::i64Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 2, "Index too large");
+      imm5 = (Index << 4) | 0b1000;
+    }
+
+    ASIMDScalarCopy(Op, 1, imm5, 0b0011, rd, ToVReg(rn));
+  }
+
+  void ins(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::VRegister rd, uint32_t Index, FEXCore::ARMEmitter::VRegister rn, uint32_t Index2) {
+    constexpr uint32_t Op = 0b0110'1110'0000'0000'0000'01 << 10;
+    uint32_t imm5 = 0b00000;
+    if (size == SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 16, "Index too large");
+      imm5 = (Index << 1) | 1;
+    }
+    else if (size == SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 8, "Index too large");
+      imm5 = (Index << 2) | 0b10;
+    }
+    else if (size == SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 4, "Index too large");
+      imm5 = (Index << 3) | 0b100;
+    }
+    else if (size == SubRegSize::i64Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 2, "Index too large");
+      imm5 = (Index << 4) | 0b1000;
+    }
+
+    uint32_t imm4 = 0b0000;
+    if (size == SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 16, "Index too large");
+      imm4 = Index2;
+    }
+    else if (size == SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 8, "Index too large");
+      imm4 = Index2 << 1;
+      // bit 0 ignored
+    }
+    else if (size == SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 4, "Index too large");
+      imm4 = Index2 << 2;
+      // bits [1:0] ignored
+    }
+    else if (size == SubRegSize::i64Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 2, "Index too large");
+      imm4 = Index2 << 3;
+      // bits [2:0] ignored
+    }
+
+    ASIMDScalarCopy(Op, 1, imm5, imm4, rd, rn);
+  }
+
+
+  // Advanced SIMD three same (FP16)
+  // TODO
+  // Advanced SIMD two-register miscellaneous (FP16)
+  // TODO
+  // Advanced SIMD three-register extension
+  // TODO
+  // Advanced SIMD two-register miscellaneous
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void rev64(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc<T>(Op, 0, size, 0b00000, rd, rn);
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void rev16(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i8Bit, "Only 8-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc<T>(Op, 0, size, 0b00001, rd, rn);
+  }
+
+  ///< size is the destination size.
+  ///< source size is the next size up.
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void saddlp(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "Destination 8-bit subregsize unsupported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    const auto ConvertedSize =
+      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i32Bit :
+      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i16Bit :
+      size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD2RegMisc<T>(Op, 0, ConvertedSize, 0b00010, rd, rn);
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void suqadd(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    }
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc<T>(Op, 0, size, 0b00011, rd, rn);
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void cls(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc<T>(Op, 0, size, 0b00100, rd, rn);
+  }
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void cnt(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i8Bit, "Only 8-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc<T>(Op, 0, size, 0b00101, rd, rn);
+  }
+
+  ///< size is the destination size.
+  ///< source size is the next size up.
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void sadalp(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "Destination 8-bit subregsize unsupported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    const auto ConvertedSize =
+      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i32Bit :
+      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i16Bit :
+      size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD2RegMisc<T>(Op, 0, ConvertedSize, 0b00110, rd, rn);
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void sqabs(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    }
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc<T>(Op, 0, size, 0b00111, rd, rn);
+  }
+  // Comparison against zero
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void cmgt(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    }
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc<T>(Op, 0, size, 0b01000, rd, rn);
+  }
+  // Comparison against zero
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void cmeq(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    }
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc<T>(Op, 0, size, 0b01001, rd, rn);
+  }
+  // Comparison against zero
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void cmlt(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    }
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc<T>(Op, 0, size, 0b01010, rd, rn);
+  }
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void abs(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    }
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc<T>(Op, 0, size, 0b01011, rd, rn);
+  }
+
+  ///< size is the destination size.
+  ///< source size is the next size up.
+  void xtn(FEXCore::ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit destination subregsize not supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc(Op, 0, size, 0b10010, rd.D(), rn.D());
+  }
+  ///< size is the destination size.
+  ///< source size is the next size up.
+  void xtn2(FEXCore::ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit destination subregsize not supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc(Op, 0, size, 0b10010, rd.Q(), rn.Q());
+  }
+
+  ///< size is the destination size.
+  ///< source size is the next size up.
+  void sqxtn(FEXCore::ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit destination subregsize not supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc(Op, 0, size, 0b10100, rd.D(), rn.D());
+  }
+  ///< size is the destination size.
+  ///< source size is the next size up.
+  void sqxtn2(FEXCore::ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit destination subregsize not supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc(Op, 0, size, 0b10100, rd.Q(), rn.Q());
+  }
+
+  ///< size is the destination size.
+  ///< source size is the next size up.
+  void fcvtn(FEXCore::ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i32Bit ||
+                       size == FEXCore::ARMEmitter::SubRegSize::i16Bit, "Only 16-bit & 32-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    const auto ConvertedSize =
+      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i16Bit :
+      size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD2RegMisc(Op, 0, ConvertedSize, 0b10110, rd.D(), rn.D());
+  }
+  ///< size is the destination size.
+  ///< source size is the next size up.
+  void fcvtn2(FEXCore::ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i32Bit ||
+                       size == FEXCore::ARMEmitter::SubRegSize::i16Bit, "Only 16-bit & 32-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    const auto ConvertedSize =
+      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i16Bit :
+      size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD2RegMisc(Op, 0, ConvertedSize, 0b10110, rd.Q(), rn.Q());
+  }
+
+  ///< size is the destination size.
+  ///< source size is the next size up.
+  void fcvtl(FEXCore::ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                       size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    const auto ConvertedSize =
+      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
+      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD2RegMisc(Op, 0, ConvertedSize, 0b10111, rd.D(), rn.D());
+  }
+  ///< size is the destination size.
+  ///< source size is the next size up.
+  void fcvtl2(FEXCore::ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                       size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    const auto ConvertedSize =
+      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
+      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD2RegMisc(Op, 0, ConvertedSize, 0b10111, rd.Q(), rn.Q());
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void frintn(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                       size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    const auto ConvertedSize =
+      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
+      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD2RegMisc<T>(Op, 0, ConvertedSize, 0b11000, rd, rn);
+  }
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void frintm(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                       size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    const auto ConvertedSize =
+      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
+      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD2RegMisc<T>(Op, 0, ConvertedSize, 0b11001, rd, rn);
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void fcvtns(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                       size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    const auto ConvertedSize =
+      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
+      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD2RegMisc<T>(Op, 0, ConvertedSize, 0b11010, rd, rn);
+  }
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void fcvtms(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                       size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    const auto ConvertedSize =
+      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
+      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD2RegMisc<T>(Op, 0, ConvertedSize, 0b11011, rd, rn);
+  }
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void fcvtas(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                       size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    const auto ConvertedSize =
+      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
+      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD2RegMisc<T>(Op, 0, ConvertedSize, 0b11100, rd, rn);
+  }
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void scvtf(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                       size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    const auto ConvertedSize =
+      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
+      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD2RegMisc<T>(Op, 0, ConvertedSize, 0b11101, rd, rn);
+  }
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void frint32z(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                       size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    const auto ConvertedSize =
+      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
+      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD2RegMisc<T>(Op, 0, ConvertedSize, 0b11110, rd, rn);
+  }
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void frint64z(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                       size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    const auto ConvertedSize =
+      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
+      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD2RegMisc<T>(Op, 0, ConvertedSize, 0b11111, rd, rn);
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void fcmgt(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                       size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc<T>(Op, 0, size, 0b01100, rd, rn);
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void fcmeq(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                       size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc<T>(Op, 0, size, 0b01101, rd, rn);
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void fcmlt(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                       size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc<T>(Op, 0, size, 0b01110, rd, rn);
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void fabs(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                       size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc<T>(Op, 0, size, 0b01111, rd, rn);
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void frintp(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                       size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc<T>(Op, 0, size, 0b11000, rd, rn);
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void frintz(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                       size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc<T>(Op, 0, size, 0b11001, rd, rn);
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void fcvtps(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                       size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc<T>(Op, 0, size, 0b11010, rd, rn);
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void fcvtzs(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                       size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc<T>(Op, 0, size, 0b11011, rd, rn);
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void urecpe(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc<T>(Op, 0, size, 0b11100, rd, rn);
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void frecpe(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                       size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc<T>(Op, 0, size, 0b11101, rd, rn);
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void rev32(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i8Bit ||
+                       size == FEXCore::ARMEmitter::SubRegSize::i16Bit, "Only 8-bit & 16-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc<T>(Op, 1, size, 0b00000, rd, rn);
+  }
+
+  ///< size is the destination size.
+  ///< source size is the next size up.
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void uaddlp(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "Destination 8-bit subregsize unsupported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    const auto ConvertedSize =
+      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i32Bit :
+      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i16Bit :
+      size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD2RegMisc<T>(Op, 1, ConvertedSize, 0b00010, rd, rn);
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void usqadd(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    }
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc<T>(Op, 1, size, 0b00011, rd, rn);
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void clz(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc<T>(Op, 1, size, 0b00100, rd, rn);
+  }
+
+  ///< size is the destination size.
+  ///< source size is the next size up.
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void uadalp(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "Destination 8-bit subregsize unsupported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    const auto ConvertedSize =
+      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i32Bit :
+      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i16Bit :
+      size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD2RegMisc<T>(Op, 1, ConvertedSize, 0b00110, rd, rn);
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void sqneg(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    }
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc<T>(Op, 1, size, 0b00111, rd, rn);
+  }
+
+  // Comparison against zero
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void cmge(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    }
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc<T>(Op, 1, size, 0b01000, rd, rn);
+  }
+  // Comparison against zero
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void cmle(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    }
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc<T>(Op, 1, size, 0b01001, rd, rn);
+  }
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void neg(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    }
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc<T>(Op, 1, size, 0b01011, rd, rn);
+  }
+  ///< size is the destination size.
+  ///< source size is the next size up.
+  void sqxtun(FEXCore::ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit destination subregsize not supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc(Op, 1, size, 0b10010, rd.D(), rn.D());
+  }
+  ///< size is the destination size.
+  ///< source size is the next size up.
+  void sqxtun2(FEXCore::ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit destination subregsize not supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc(Op, 1, size, 0b10010, rd.Q(), rn.Q());
+  }
+
+  ///< size is the destination size.
+  ///< source size is the next size up.
+  void shll(FEXCore::ARMEmitter::SubRegSize size, ARMEmitter::DRegister rd, ARMEmitter::DRegister rn) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "Destination 8-bit subregsize unsupported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    const auto ConvertedSize =
+      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i32Bit :
+      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i16Bit :
+      size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD2RegMisc(Op, 1, ConvertedSize, 0b10011, rd, rn);
+  }
+  ///< size is the destination size.
+  ///< source size is the next size up.
+  void shll2(FEXCore::ARMEmitter::SubRegSize size, ARMEmitter::QRegister rd, ARMEmitter::QRegister rn) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "Destination 8-bit subregsize unsupported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    const auto ConvertedSize =
+      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i32Bit :
+      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i16Bit :
+      size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD2RegMisc(Op, 1, ConvertedSize, 0b10011, rd, rn);
+  }
+  ///< size is the destination size.
+  ///< source size is the next size up.
+  void uqxtn(FEXCore::ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn) {
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc(Op, 1, size, 0b10100, rd.D(), rn.D());
+  }
+  ///< size is the destination size.
+  ///< source size is the next size up.
+  void uqxtn2(FEXCore::ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn) {
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc(Op, 1, size, 0b10100, rd.Q(), rn.Q());
+  }
+  ///< size is the destination size.
+  ///< source size is the next size up.
+  void fcvtxn(FEXCore::ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    const auto ConvertedSize =
+      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i16Bit :
+      size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD2RegMisc(Op, 1, ConvertedSize, 0b10110, rd.D(), rn.D());
+  }
+  ///< size is the destination size.
+  ///< source size is the next size up.
+  void fcvtxn2(FEXCore::ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    const auto ConvertedSize =
+      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i16Bit :
+      size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD2RegMisc(Op, 1, ConvertedSize, 0b10110, rd.Q(), rn.Q());
+  }
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void frinta(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                       size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    const auto ConvertedSize =
+      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
+      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD2RegMisc<T>(Op, 1, ConvertedSize, 0b11000, rd, rn);
+  }
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void frintx(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                       size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    const auto ConvertedSize =
+      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
+      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD2RegMisc<T>(Op, 1, ConvertedSize, 0b11001, rd, rn);
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void fcvtnu(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                       size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    const auto ConvertedSize =
+      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
+      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD2RegMisc<T>(Op, 1, ConvertedSize, 0b11010, rd, rn);
+  }
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void fcvtmu(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                       size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    const auto ConvertedSize =
+      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
+      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD2RegMisc<T>(Op, 1, ConvertedSize, 0b11011, rd, rn);
+  }
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void fcvtau(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                       size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    const auto ConvertedSize =
+      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
+      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD2RegMisc<T>(Op, 1, ConvertedSize, 0b11100, rd, rn);
+  }
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void ucvtf(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                       size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    const auto ConvertedSize =
+      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
+      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD2RegMisc<T>(Op, 1, ConvertedSize, 0b11101, rd, rn);
+  }
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void frint32x(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                       size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    const auto ConvertedSize =
+      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
+      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD2RegMisc<T>(Op, 1, ConvertedSize, 0b11110, rd, rn);
+  }
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void frint64x(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                       size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    const auto ConvertedSize =
+      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
+      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD2RegMisc<T>(Op, 1, ConvertedSize, 0b11111, rd, rn);
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void not_(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i8Bit, "Only 8-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc<T>(Op, 1, FEXCore::ARMEmitter::SubRegSize::i8Bit, 0b00101, rd, rn);
+  }
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void mvn(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i8Bit, "Only 8-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc<T>(Op, 1, FEXCore::ARMEmitter::SubRegSize::i8Bit, 0b00101, rd, rn);
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void rbit(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i8Bit, "Only 8-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc<T>(Op, 1, FEXCore::ARMEmitter::SubRegSize::i16Bit, 0b00101, rd, rn);
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void fcmge(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                       size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc<T>(Op, 1, size, 0b01100, rd, rn);
+  }
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void fcmle(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                       size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc<T>(Op, 1, size, 0b01101, rd, rn);
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void fneg(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                       size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc<T>(Op, 1, size, 0b01111, rd, rn);
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void frinti(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                       size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc<T>(Op, 1, size, 0b11001, rd, rn);
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void fcvtpu(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                       size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc<T>(Op, 1, size, 0b11010, rd, rn);
+  }
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void fcvtzu(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                       size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc<T>(Op, 1, size, 0b11011, rd, rn);
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void ursqrte(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc<T>(Op, 1, size, 0b11100, rd, rn);
+  }
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void frsqrte(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                       size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc<T>(Op, 1, size, 0b11101, rd, rn);
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void fsqrt(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                       size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
+    ASIMD2RegMisc<T>(Op, 1, size, 0b11111, rd, rn);
+  }
+
+  // Advanced SIMD across lanes
+  ///< size is the destination size.
+  ///< source size is the next size up.
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void saddlv(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    }
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "Destination 8-bit subregsize unsupported");
+    constexpr uint32_t Op = 0b0000'1110'0011'0000'0000'10 << 10;
+    const auto ConvertedSize =
+      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i32Bit :
+      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i16Bit :
+      size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMDAcrossLanes<T>(Op, 0, ConvertedSize, 0b00011, rd, rn);
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void smaxv(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i32Bit && size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "32/64-bit subregsize not supported");
+    }
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Destination 64-bit subregsize unsupported");
+    constexpr uint32_t Op = 0b0000'1110'0011'0000'0000'10 << 10;
+    ASIMDAcrossLanes<T>(Op, 0, size, 0b01010, rd, rn);
+  }
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void sminv(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i32Bit && size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "32/64-bit subregsize not supported");
+    }
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Destination 64-bit subregsize unsupported");
+    constexpr uint32_t Op = 0b0000'1110'0011'0000'0000'10 << 10;
+    ASIMDAcrossLanes<T>(Op, 0, size, 0b11010, rd, rn);
+  }
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void addv(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i32Bit && size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "32/64-bit subregsize not supported");
+    }
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Destination 64-bit subregsize unsupported");
+    constexpr uint32_t Op = 0b0000'1110'0011'0000'0000'10 << 10;
+    ASIMDAcrossLanes<T>(Op, 0, size, 0b11011, rd, rn);
+  }
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void uaddlv(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    }
+    constexpr uint32_t Op = 0b0000'1110'0011'0000'0000'10 << 10;
+    const auto ConvertedSize =
+      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i32Bit :
+      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i16Bit :
+      size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMDAcrossLanes<T>(Op, 1, ConvertedSize, 0b00011, rd, rn);
+  }
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void umaxv(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i32Bit && size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "32/64-bit subregsize not supported");
+    }
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Destination 64-bit subregsize unsupported");
+    constexpr uint32_t Op = 0b0000'1110'0011'0000'0000'10 << 10;
+    ASIMDAcrossLanes<T>(Op, 1, size, 0b01010, rd, rn);
+  }
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void uminv(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i32Bit && size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "32/64-bit subregsize not supported");
+    }
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Destination 64-bit subregsize unsupported");
+    constexpr uint32_t Op = 0b0000'1110'0011'0000'0000'10 << 10;
+    ASIMDAcrossLanes<T>(Op, 1, size, 0b11010, rd, rn);
+  }
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void fmaxnmv(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i32Bit, "32-bit subregsize not supported");
+    }
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit && size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Destination 8/64-bit subregsize unsupported");
+    constexpr uint32_t Op = 0b0000'1110'0011'0000'0000'10 << 10;
+    const auto ConvertedSize =
+      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
+      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit :
+      size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+
+    const auto U = size == ARMEmitter::SubRegSize::i16Bit ? 0 : 1;
+
+    ASIMDAcrossLanes<T>(Op, U, ConvertedSize, 0b01100, rd, rn);
+  }
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void fmaxv(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i32Bit, "32-bit subregsize not supported");
+    }
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit && size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Destination 8/64-bit subregsize unsupported");
+    constexpr uint32_t Op = 0b0000'1110'0011'0000'0000'10 << 10;
+    const auto ConvertedSize =
+      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
+      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit :
+      size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+
+    const auto U = size == ARMEmitter::SubRegSize::i16Bit ? 0 : 1;
+
+    ASIMDAcrossLanes<T>(Op, U, ConvertedSize, 0b01111, rd, rn);
+  }
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void fminnmv(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i32Bit, "32-bit subregsize not supported");
+    }
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit && size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Destination 8/64-bit subregsize unsupported");
+    constexpr uint32_t Op = 0b0000'1110'0011'0000'0000'10 << 10;
+    const auto ConvertedSize =
+      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i64Bit :
+      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i32Bit :
+      size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i32Bit : ARMEmitter::SubRegSize::i32Bit;
+
+    const auto U = size == ARMEmitter::SubRegSize::i16Bit ? 0 : 1;
+
+    ASIMDAcrossLanes<T>(Op, U, ConvertedSize, 0b01100, rd, rn);
+  }
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void fminv(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i32Bit, "32-bit subregsize not supported");
+    }
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit && size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Destination 8/64-bit subregsize unsupported");
+    constexpr uint32_t Op = 0b0000'1110'0011'0000'0000'10 << 10;
+    const auto ConvertedSize =
+      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i64Bit :
+      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i32Bit :
+      size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i32Bit : ARMEmitter::SubRegSize::i32Bit;
+
+    const auto U = size == ARMEmitter::SubRegSize::i16Bit ? 0 : 1;
+
+    ASIMDAcrossLanes<T>(Op, U, ConvertedSize, 0b01111, rd, rn);
+  }
+
+  // Advanced SIMD three different
+  // TODO: Double check narrowing op size limits.
+  // TODO: Don't enforce DRegister/QRegister for Q check
+  ///< Size is dest size
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void saddl(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "No 8-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? FEXCore::ARMEmitter::SubRegSize::i32Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? FEXCore::ARMEmitter::SubRegSize::i16Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? FEXCore::ARMEmitter::SubRegSize::i8Bit : FEXCore::ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Different<T>(Op, 0, 0b0000, ConvertedSize, rd, rn, rm);
+  }
+  ///< Size is dest size
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T>)
+  void saddl2(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "No 8-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? FEXCore::ARMEmitter::SubRegSize::i32Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? FEXCore::ARMEmitter::SubRegSize::i16Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? FEXCore::ARMEmitter::SubRegSize::i8Bit : FEXCore::ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Different<T>(Op, 0, 0b0000, ConvertedSize, rd, rn, rm);
+  }
+  ///< Size is dest size
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void saddw(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "No 8-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? FEXCore::ARMEmitter::SubRegSize::i32Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? FEXCore::ARMEmitter::SubRegSize::i16Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? FEXCore::ARMEmitter::SubRegSize::i8Bit : FEXCore::ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Different<T>(Op, 0, 0b0001, ConvertedSize, rd, rn, rm);
+  }
+  ///< Size is dest size
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T>)
+  void saddw2(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "No 8-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? FEXCore::ARMEmitter::SubRegSize::i32Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? FEXCore::ARMEmitter::SubRegSize::i16Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? FEXCore::ARMEmitter::SubRegSize::i8Bit : FEXCore::ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Different<T>(Op, 0, 0b0001, ConvertedSize, rd, rn, rm);
+  }
+  ///< Size is dest size
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void ssubl(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "No 8-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? FEXCore::ARMEmitter::SubRegSize::i32Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? FEXCore::ARMEmitter::SubRegSize::i16Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? FEXCore::ARMEmitter::SubRegSize::i8Bit : FEXCore::ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Different<T>(Op, 0, 0b0010, ConvertedSize, rd, rn, rm);
+  }
+  ///< Size is dest size
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T>)
+  void ssubl2(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "No 8-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? FEXCore::ARMEmitter::SubRegSize::i32Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? FEXCore::ARMEmitter::SubRegSize::i16Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? FEXCore::ARMEmitter::SubRegSize::i8Bit : FEXCore::ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Different<T>(Op, 0, 0b0010, ConvertedSize, rd, rn, rm);
+  }
+  ///< Size is dest size
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void ssubw(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "No 8-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? FEXCore::ARMEmitter::SubRegSize::i32Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? FEXCore::ARMEmitter::SubRegSize::i16Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? FEXCore::ARMEmitter::SubRegSize::i8Bit : FEXCore::ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Different<T>(Op, 0, 0b0011, ConvertedSize, rd, rn, rm);
+  }
+  ///< Size is dest size
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T>)
+  void ssubw2(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "No 8-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? FEXCore::ARMEmitter::SubRegSize::i32Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? FEXCore::ARMEmitter::SubRegSize::i16Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? FEXCore::ARMEmitter::SubRegSize::i8Bit : FEXCore::ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Different<T>(Op, 0, 0b0011, ConvertedSize, rd, rn, rm);
+  }
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void addhn(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "No 64-bit dest support.");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    ASIMD3Different<T>(Op, 0, 0b0100, size, rd, rn, rm);
+  }
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T>)
+  void addhn2(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "No 64-bit dest support.");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    ASIMD3Different<T>(Op, 0, 0b0100, size, rd, rn, rm);
+  }
+  ///< Size is dest size
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void sabal(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "No 8-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? FEXCore::ARMEmitter::SubRegSize::i32Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? FEXCore::ARMEmitter::SubRegSize::i16Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? FEXCore::ARMEmitter::SubRegSize::i8Bit : FEXCore::ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Different<T>(Op, 0, 0b0101, ConvertedSize, rd, rn, rm);
+  }
+  ///< Size is dest size
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T>)
+  void sabal2(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "No 8-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? FEXCore::ARMEmitter::SubRegSize::i32Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? FEXCore::ARMEmitter::SubRegSize::i16Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? FEXCore::ARMEmitter::SubRegSize::i8Bit : FEXCore::ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Different<T>(Op, 0, 0b0101, ConvertedSize, rd, rn, rm);
+  }
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void subhn(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "No 64-bit dest support.");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    ASIMD3Different<T>(Op, 0, 0b0110, size, rd, rn, rm);
+  }
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T>)
+  void subhn2(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "No 64-bit dest support.");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    ASIMD3Different<T>(Op, 0, 0b0110, size, rd, rn, rm);
+  }
+  ///< Size is dest size
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void sabdl(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "No 8-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? FEXCore::ARMEmitter::SubRegSize::i32Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? FEXCore::ARMEmitter::SubRegSize::i16Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? FEXCore::ARMEmitter::SubRegSize::i8Bit : FEXCore::ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Different<T>(Op, 0, 0b0111, ConvertedSize, rd, rn, rm);
+  }
+  ///< Size is dest size
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T>)
+  void sabdl2(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "No 8-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? FEXCore::ARMEmitter::SubRegSize::i32Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? FEXCore::ARMEmitter::SubRegSize::i16Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? FEXCore::ARMEmitter::SubRegSize::i8Bit : FEXCore::ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Different<T>(Op, 0, 0b0111, ConvertedSize, rd, rn, rm);
+  }
+  ///< Size is dest size
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void smlal(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "No 8-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? FEXCore::ARMEmitter::SubRegSize::i32Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? FEXCore::ARMEmitter::SubRegSize::i16Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? FEXCore::ARMEmitter::SubRegSize::i8Bit : FEXCore::ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Different<T>(Op, 0, 0b1000, ConvertedSize, rd, rn, rm);
+  }
+  ///< Size is dest size
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T>)
+  void smlal2(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "No 8-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? FEXCore::ARMEmitter::SubRegSize::i32Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? FEXCore::ARMEmitter::SubRegSize::i16Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? FEXCore::ARMEmitter::SubRegSize::i8Bit : FEXCore::ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Different<T>(Op, 0, 0b1000, ConvertedSize, rd, rn, rm);
+  }
+  ///< Size is dest size
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void sqdmlal(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit && size != FEXCore::ARMEmitter::SubRegSize::i16Bit, "No 8/16-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? FEXCore::ARMEmitter::SubRegSize::i32Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? FEXCore::ARMEmitter::SubRegSize::i16Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? FEXCore::ARMEmitter::SubRegSize::i8Bit : FEXCore::ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Different<T>(Op, 0, 0b1001, ConvertedSize, rd, rn, rm);
+  }
+  ///< Size is dest size
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T>)
+  void sqdmlal2(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit && size != FEXCore::ARMEmitter::SubRegSize::i16Bit, "No 8/16-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? FEXCore::ARMEmitter::SubRegSize::i32Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? FEXCore::ARMEmitter::SubRegSize::i16Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? FEXCore::ARMEmitter::SubRegSize::i8Bit : FEXCore::ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Different<T>(Op, 0, 0b1001, ConvertedSize, rd, rn, rm);
+  }
+  ///< Size is dest size
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void smlsl(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "No 8-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? FEXCore::ARMEmitter::SubRegSize::i32Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? FEXCore::ARMEmitter::SubRegSize::i16Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? FEXCore::ARMEmitter::SubRegSize::i8Bit : FEXCore::ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Different<T>(Op, 0, 0b1010, ConvertedSize, rd, rn, rm);
+  }
+  ///< Size is dest size
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T>)
+  void smlsl2(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "No 8-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? FEXCore::ARMEmitter::SubRegSize::i32Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? FEXCore::ARMEmitter::SubRegSize::i16Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? FEXCore::ARMEmitter::SubRegSize::i8Bit : FEXCore::ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Different<T>(Op, 0, 0b1010, ConvertedSize, rd, rn, rm);
+  }
+  ///< Size is dest size
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void sqdmlsl(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit && size != FEXCore::ARMEmitter::SubRegSize::i16Bit, "No 8/16-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? FEXCore::ARMEmitter::SubRegSize::i32Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? FEXCore::ARMEmitter::SubRegSize::i16Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? FEXCore::ARMEmitter::SubRegSize::i8Bit : FEXCore::ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Different<T>(Op, 0, 0b1011, ConvertedSize, rd, rn, rm);
+  }
+  ///< Size is dest size
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T>)
+  void sqdmlsl2(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit && size != FEXCore::ARMEmitter::SubRegSize::i16Bit, "No 8/16-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? FEXCore::ARMEmitter::SubRegSize::i32Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? FEXCore::ARMEmitter::SubRegSize::i16Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? FEXCore::ARMEmitter::SubRegSize::i8Bit : FEXCore::ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Different<T>(Op, 0, 0b1011, ConvertedSize, rd, rn, rm);
+  }
+  ///< Size is dest size
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void smull(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "No 8-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? FEXCore::ARMEmitter::SubRegSize::i32Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? FEXCore::ARMEmitter::SubRegSize::i16Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? FEXCore::ARMEmitter::SubRegSize::i8Bit : FEXCore::ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Different<T>(Op, 0, 0b1100, ConvertedSize, rd, rn, rm);
+  }
+  ///< Size is dest size
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T>)
+  void smull2(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "No 8-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? FEXCore::ARMEmitter::SubRegSize::i32Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? FEXCore::ARMEmitter::SubRegSize::i16Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? FEXCore::ARMEmitter::SubRegSize::i8Bit : FEXCore::ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Different<T>(Op, 0, 0b1100, ConvertedSize, rd, rn, rm);
+  }
+  ///< Size is dest size
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void sqdmull(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit && size != FEXCore::ARMEmitter::SubRegSize::i16Bit, "No 8/16-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? FEXCore::ARMEmitter::SubRegSize::i32Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? FEXCore::ARMEmitter::SubRegSize::i16Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? FEXCore::ARMEmitter::SubRegSize::i8Bit : FEXCore::ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Different<T>(Op, 0, 0b1101, ConvertedSize, rd, rn, rm);
+  }
+  ///< Size is dest size
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T>)
+  void sqdmull2(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit && size != FEXCore::ARMEmitter::SubRegSize::i16Bit, "No 8/16-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? FEXCore::ARMEmitter::SubRegSize::i32Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? FEXCore::ARMEmitter::SubRegSize::i16Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? FEXCore::ARMEmitter::SubRegSize::i8Bit : FEXCore::ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Different<T>(Op, 0, 0b1101, ConvertedSize, rd, rn, rm);
+  }
+  ///< Size is dest size
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void pmull(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i16Bit || size == FEXCore::ARMEmitter::SubRegSize::i128Bit, "Only 16-bit and 128-bit destination supported");
+    const auto ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? FEXCore::ARMEmitter::SubRegSize::i8Bit : FEXCore::ARMEmitter::SubRegSize::i64Bit;
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    ASIMD3Different<T>(Op, 0, 0b1110, ConvertedSize, rd, rn, rm);
+  }
+  ///< Size is dest size
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T>)
+  void pmull2(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i16Bit || size == FEXCore::ARMEmitter::SubRegSize::i128Bit, "Only 16-bit and 128-bit destination supported");
+    const auto ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? FEXCore::ARMEmitter::SubRegSize::i8Bit : FEXCore::ARMEmitter::SubRegSize::i64Bit;
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    ASIMD3Different<T>(Op, 0, 0b1110, ConvertedSize, rd, rn, rm);
+  }
+  ///< Size is dest size
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void uaddl(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "No 8-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? FEXCore::ARMEmitter::SubRegSize::i32Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? FEXCore::ARMEmitter::SubRegSize::i16Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? FEXCore::ARMEmitter::SubRegSize::i8Bit : FEXCore::ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Different<T>(Op, 1, 0b0000, ConvertedSize, rd, rn, rm);
+  }
+  ///< Size is dest size
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T>)
+  void uaddl2(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "No 8-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? FEXCore::ARMEmitter::SubRegSize::i32Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? FEXCore::ARMEmitter::SubRegSize::i16Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? FEXCore::ARMEmitter::SubRegSize::i8Bit : FEXCore::ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Different<T>(Op, 1, 0b0000, ConvertedSize, rd, rn, rm);
+  }
+  ///< Size is dest size
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void uaddw(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "No 8-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? FEXCore::ARMEmitter::SubRegSize::i32Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? FEXCore::ARMEmitter::SubRegSize::i16Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? FEXCore::ARMEmitter::SubRegSize::i8Bit : FEXCore::ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Different<T>(Op, 1, 0b0001, ConvertedSize, rd, rn, rm);
+  }
+  ///< Size is dest size
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T>)
+  void uaddw2(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "No 8-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? FEXCore::ARMEmitter::SubRegSize::i32Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? FEXCore::ARMEmitter::SubRegSize::i16Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? FEXCore::ARMEmitter::SubRegSize::i8Bit : FEXCore::ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Different<T>(Op, 1, 0b0001, ConvertedSize, rd, rn, rm);
+  }
+  ///< Size is dest size
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void usubl(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "No 8-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? FEXCore::ARMEmitter::SubRegSize::i32Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? FEXCore::ARMEmitter::SubRegSize::i16Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? FEXCore::ARMEmitter::SubRegSize::i8Bit : FEXCore::ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Different<T>(Op, 1, 0b0010, ConvertedSize, rd, rn, rm);
+  }
+  ///< Size is dest size
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T>)
+  void usubl2(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "No 8-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? FEXCore::ARMEmitter::SubRegSize::i32Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? FEXCore::ARMEmitter::SubRegSize::i16Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? FEXCore::ARMEmitter::SubRegSize::i8Bit : FEXCore::ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Different<T>(Op, 1, 0b0010, ConvertedSize, rd, rn, rm);
+  }
+  ///< Size is dest size
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void usubw(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "No 8-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? FEXCore::ARMEmitter::SubRegSize::i32Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? FEXCore::ARMEmitter::SubRegSize::i16Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? FEXCore::ARMEmitter::SubRegSize::i8Bit : FEXCore::ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Different<T>(Op, 1, 0b0011, ConvertedSize, rd, rn, rm);
+  }
+  ///< Size is dest size
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T>)
+  void usubw2(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "No 8-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? FEXCore::ARMEmitter::SubRegSize::i32Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? FEXCore::ARMEmitter::SubRegSize::i16Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? FEXCore::ARMEmitter::SubRegSize::i8Bit : FEXCore::ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Different<T>(Op, 1, 0b0011, ConvertedSize, rd, rn, rm);
+  }
+  // XXX: RADDHN/2
+  ///< Size is dest size
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void uabal(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "No 8-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? FEXCore::ARMEmitter::SubRegSize::i32Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? FEXCore::ARMEmitter::SubRegSize::i16Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? FEXCore::ARMEmitter::SubRegSize::i8Bit : FEXCore::ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Different<T>(Op, 1, 0b0101, ConvertedSize, rd, rn, rm);
+  }
+  ///< Size is dest size
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T>)
+  void uabal2(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "No 8-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? FEXCore::ARMEmitter::SubRegSize::i32Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? FEXCore::ARMEmitter::SubRegSize::i16Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? FEXCore::ARMEmitter::SubRegSize::i8Bit : FEXCore::ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Different<T>(Op, 1, 0b0101, ConvertedSize, rd, rn, rm);
+  }
+  // XXX: RSUBHN/2
+  ///< Size is dest size
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void uabdl(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "No 8-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? FEXCore::ARMEmitter::SubRegSize::i32Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? FEXCore::ARMEmitter::SubRegSize::i16Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? FEXCore::ARMEmitter::SubRegSize::i8Bit : FEXCore::ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Different(Op, 1, 0b0111, ConvertedSize, rd, rn, rm);
+  }
+  ///< Size is dest size
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T>)
+  void uabdl2(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "No 8-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? FEXCore::ARMEmitter::SubRegSize::i32Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? FEXCore::ARMEmitter::SubRegSize::i16Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? FEXCore::ARMEmitter::SubRegSize::i8Bit : FEXCore::ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Different(Op, 1, 0b0111, ConvertedSize, rd, rn, rm);
+  }
+  ///< Size is dest size
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void umlal(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "No 8-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? FEXCore::ARMEmitter::SubRegSize::i32Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? FEXCore::ARMEmitter::SubRegSize::i16Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? FEXCore::ARMEmitter::SubRegSize::i8Bit : FEXCore::ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Different<T>(Op, 1, 0b1000, ConvertedSize, rd, rn, rm);
+  }
+  ///< Size is dest size
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T>)
+  void umlal2(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "No 8-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? FEXCore::ARMEmitter::SubRegSize::i32Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? FEXCore::ARMEmitter::SubRegSize::i16Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? FEXCore::ARMEmitter::SubRegSize::i8Bit : FEXCore::ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Different<T>(Op, 1, 0b1000, ConvertedSize, rd, rn, rm);
+  }
+  ///< Size is dest size
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void umlsl(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "No 8-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? FEXCore::ARMEmitter::SubRegSize::i32Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? FEXCore::ARMEmitter::SubRegSize::i16Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? FEXCore::ARMEmitter::SubRegSize::i8Bit : FEXCore::ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Different<T>(Op, 1, 0b1010, ConvertedSize, rd, rn, rm);
+  }
+  ///< Size is dest size
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T>)
+  void umlsl2(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "No 8-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? FEXCore::ARMEmitter::SubRegSize::i32Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? FEXCore::ARMEmitter::SubRegSize::i16Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? FEXCore::ARMEmitter::SubRegSize::i8Bit : FEXCore::ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Different<T>(Op, 1, 0b1010, ConvertedSize, rd, rn, rm);
+  }
+  ///< Size is dest size
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void umull(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "No 8-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? FEXCore::ARMEmitter::SubRegSize::i32Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? FEXCore::ARMEmitter::SubRegSize::i16Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? FEXCore::ARMEmitter::SubRegSize::i8Bit : FEXCore::ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Different<T>(Op, 1, 0b1100, ConvertedSize, rd, rn, rm);
+  }
+  ///< Size is dest size
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T>)
+  void umull2(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "No 8-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? FEXCore::ARMEmitter::SubRegSize::i32Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? FEXCore::ARMEmitter::SubRegSize::i16Bit :
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? FEXCore::ARMEmitter::SubRegSize::i8Bit : FEXCore::ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Different<T>(Op, 1, 0b1100, ConvertedSize, rd, rn, rm);
+  }
+
+  // Advanced SIMD three same
+  template<typename T>
+  void shadd(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 0, size, 0b00000, rd, rn, rm);
+  }
+
+  template<typename T>
+  void sqadd(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit dup");
+    }
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 0, size, 0b00001, rd, rn, rm);
+  }
+
+  template<typename T>
+  void srhadd(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 0, size, 0b00010, rd, rn, rm);
+  }
+  template<typename T>
+  void shsub(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 0, size, 0b00100, rd, rn, rm);
+  }
+  template<typename T>
+  void sqsub(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit dup");
+    }
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 0, size, 0b00101, rd, rn, rm);
+  }
+  template<typename T>
+  void cmgt(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit dup");
+    }
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 0, size, 0b00110, rd, rn, rm);
+  }
+  template<typename T>
+  void cmge(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit dup");
+    }
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 0, size, 0b00111, rd, rn, rm);
+  }
+  template<typename T>
+  void sshl(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit dup");
+    }
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 0, size, 0b01000, rd, rn, rm);
+  }
+  template<typename T>
+  void sqshl(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit dup");
+    }
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 0, size, 0b01001, rd, rn, rm);
+  }
+  template<typename T>
+  void srshl(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit dup");
+    }
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 0, size, 0b01010, rd, rn, rm);
+  }
+  template<typename T>
+  void sqrshl(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit dup");
+    }
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 0, size, 0b01011, rd, rn, rm);
+  }
+  template<typename T>
+  void smax(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 0, size, 0b01100, rd, rn, rm);
+  }
+  template<typename T>
+  void smin(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 0, size, 0b01101, rd, rn, rm);
+  }
+  template<typename T>
+  void sabd(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 0, size, 0b01110, rd, rn, rm);
+  }
+  template<typename T>
+  void saba(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 0, size, 0b01111, rd, rn, rm);
+  }
+  template<typename T>
+  void add(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit dup");
+    }
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 0, size, 0b10000, rd, rn, rm);
+  }
+  template<typename T>
+  void cmtst(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit dup");
+    }
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 0, size, 0b10001, rd, rn, rm);
+  }
+  template<typename T>
+  void mla(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 0, size, 0b10010, rd, rn, rm);
+  }
+  template<typename T>
+  void mul(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 0, size, 0b10011, rd, rn, rm);
+  }
+  template<typename T>
+  void smaxp(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 0, size, 0b10100, rd, rn, rm);
+  }
+  template<typename T>
+  void sminp(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 0, size, 0b10101, rd, rn, rm);
+  }
+  template<typename T>
+  void sqdmulh(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "No 8-bit dest support.");
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 0, size, 0b10110, rd, rn, rm);
+  }
+  template<typename T>
+  void addp(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 0, size, 0b10111, rd, rn, rm);
+  }
+  template<typename T>
+  void fmaxnm(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                        size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    const FEXCore::ARMEmitter::SubRegSize ConvertedSize =
+      size == ARMEmitter::SubRegSize::i64Bit ?
+        ARMEmitter::SubRegSize::i16Bit :
+        ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Same<T>(Op, 0, ConvertedSize, 0b11000, rd, rn, rm);
+  }
+  template<typename T>
+  void fmla(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                        size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    const FEXCore::ARMEmitter::SubRegSize ConvertedSize =
+      size == ARMEmitter::SubRegSize::i64Bit ?
+        ARMEmitter::SubRegSize::i16Bit :
+        ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Same<T>(Op, 0, ConvertedSize, 0b11001, rd, rn, rm);
+  }
+  template<typename T>
+  void fadd(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                        size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    const FEXCore::ARMEmitter::SubRegSize ConvertedSize =
+      size == ARMEmitter::SubRegSize::i64Bit ?
+        ARMEmitter::SubRegSize::i16Bit :
+        ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Same<T>(Op, 0, ConvertedSize, 0b11010, rd, rn, rm);
+  }
+  template<typename T>
+  void fmulx(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                        size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    const FEXCore::ARMEmitter::SubRegSize ConvertedSize =
+      size == ARMEmitter::SubRegSize::i64Bit ?
+        ARMEmitter::SubRegSize::i16Bit :
+        ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Same<T>(Op, 0, ConvertedSize, 0b11011, rd, rn, rm);
+  }
+  template<typename T>
+  void fcmeq(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                        size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    const FEXCore::ARMEmitter::SubRegSize ConvertedSize =
+      size == ARMEmitter::SubRegSize::i64Bit ?
+        ARMEmitter::SubRegSize::i16Bit :
+        ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Same<T>(Op, 0, ConvertedSize, 0b11100, rd, rn, rm);
+  }
+  template<typename T>
+  void fmax(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                        size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    const FEXCore::ARMEmitter::SubRegSize ConvertedSize =
+      size == ARMEmitter::SubRegSize::i64Bit ?
+        ARMEmitter::SubRegSize::i16Bit :
+        ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Same<T>(Op, 0, ConvertedSize, 0b11110, rd, rn, rm);
+  }
+  template<typename T>
+  void frecps(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                        size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    const FEXCore::ARMEmitter::SubRegSize ConvertedSize =
+      size == ARMEmitter::SubRegSize::i64Bit ?
+        ARMEmitter::SubRegSize::i16Bit :
+        ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Same<T>(Op, 0, ConvertedSize, 0b11111, rd, rn, rm);
+  }
+  template<typename T>
+  void and_(T rd, T rn, T rm) {
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 0, ARMEmitter::SubRegSize::i8Bit, 0b00011, rd, rn, rm);
+  }
+  template<typename T>
+  void fmlal(T rd, T rn, T rm) {
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 0, ARMEmitter::SubRegSize::i8Bit, 0b11101, rd, rn, rm);
+  }
+  template<typename T>
+  void fmlal2(T rd, T rn, T rm) {
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 1, ARMEmitter::SubRegSize::i8Bit, 0b11001, rd, rn, rm);
+  }
+  template<typename T>
+  void bic(T rd, T rn, T rm) {
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 0, ARMEmitter::SubRegSize::i16Bit, 0b00011, rd, rn, rm);
+  }
+  template<typename T>
+  void fminnm(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                        size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 0, size, 0b11000, rd, rn, rm);
+  }
+  template<typename T>
+  void fmls(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                        size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 0, size, 0b11001, rd, rn, rm);
+  }
+  template<typename T>
+  void fsub(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                        size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 0, size, 0b11010, rd, rn, rm);
+  }
+  template<typename T>
+  void fmin(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                        size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 0, size, 0b11110, rd, rn, rm);
+  }
+  template<typename T>
+  void frsqrts(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                        size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 0, size, 0b11111, rd, rn, rm);
+  }
+  template<typename T>
+  void orr(T rd, T rn, T rm) {
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 0, ARMEmitter::SubRegSize::i32Bit, 0b00011, rd, rn, rm);
+  }
+  template<typename T>
+  void mov(T rd, T rn) {
+    orr<T>(rd, rn, rn);
+  }
+  template<typename T>
+  void fmlsl(T rd, T rn, T rm) {
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 0, ARMEmitter::SubRegSize::i32Bit, 0b11101, rd, rn, rm);
+  }
+  template<typename T>
+  void fmlsl2(T rd, T rn, T rm) {
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 1, ARMEmitter::SubRegSize::i32Bit, 0b11001, rd, rn, rm);
+  }
+  template<typename T>
+  void orn(T rd, T rn, T rm) {
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 0, ARMEmitter::SubRegSize::i64Bit, 0b00011, rd, rn, rm);
+  }
+  template<typename T>
+  void uhadd(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 1, size, 0b00000, rd, rn, rm);
+  }
+  template<typename T>
+  void uqadd(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 1, size, 0b00001, rd, rn, rm);
+  }
+  template<typename T>
+  void urhadd(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 1, size, 0b00010, rd, rn, rm);
+  }
+  template<typename T>
+  void uhsub(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 1, size, 0b00100, rd, rn, rm);
+  }
+  template<typename T>
+  void uqsub(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 1, size, 0b00101, rd, rn, rm);
+  }
+  template<typename T>
+  void cmhi(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 1, size, 0b00110, rd, rn, rm);
+  }
+  template<typename T>
+  void cmhs(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 1, size, 0b00111, rd, rn, rm);
+  }
+  template<typename T>
+  void ushl(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 1, size, 0b01000, rd, rn, rm);
+  }
+  template<typename T>
+  void uqshl(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 1, size, 0b01001, rd, rn, rm);
+  }
+  template<typename T>
+  void urshl(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 1, size, 0b01010, rd, rn, rm);
+  }
+  template<typename T>
+  void uqrshl(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 1, size, 0b01011, rd, rn, rm);
+  }
+  template<typename T>
+  void umax(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 1, size, 0b01100, rd, rn, rm);
+  }
+  template<typename T>
+  void umin(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 1, size, 0b01101, rd, rn, rm);
+  }
+  template<typename T>
+  void uabd(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 1, size, 0b01110, rd, rn, rm);
+  }
+  template<typename T>
+  void uaba(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 1, size, 0b01111, rd, rn, rm);
+  }
+  template<typename T>
+  void sub(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 1, size, 0b10000, rd, rn, rm);
+  }
+  template<typename T>
+  void cmeq(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 1, size, 0b10001, rd, rn, rm);
+  }
+  template<typename T>
+  void mls(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 1, size, 0b10010, rd, rn, rm);
+  }
+  template<typename T>
+  void pmul(T rd, T rn, T rm) {
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 1, ARMEmitter::SubRegSize::i8Bit, 0b10011, rd, rn, rm);
+  }
+  template<typename T>
+  void umaxp(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 1, size, 0b10100, rd, rn, rm);
+  }
+  template<typename T>
+  void uminp(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 1, size, 0b10101, rd, rn, rm);
+  }
+  template<typename T>
+  void sqrdmulh(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit && size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "8/64-bit subregsize not supported");
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 1, size, 0b10110, rd, rn, rm);
+  }
+  template<typename T>
+  void fmaxnmp(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                        size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    const FEXCore::ARMEmitter::SubRegSize ConvertedSize =
+      size == ARMEmitter::SubRegSize::i64Bit ?
+        ARMEmitter::SubRegSize::i16Bit :
+        ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Same<T>(Op, 1, ConvertedSize, 0b11000, rd, rn, rm);
+  }
+  template<typename T>
+  void faddp(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                        size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    const FEXCore::ARMEmitter::SubRegSize ConvertedSize =
+      size == ARMEmitter::SubRegSize::i64Bit ?
+        ARMEmitter::SubRegSize::i16Bit :
+        ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Same<T>(Op, 1, ConvertedSize, 0b11010, rd, rn, rm);
+  }
+  template<typename T>
+  void fmul(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                        size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    const FEXCore::ARMEmitter::SubRegSize ConvertedSize =
+      size == ARMEmitter::SubRegSize::i64Bit ?
+        ARMEmitter::SubRegSize::i16Bit :
+        ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Same<T>(Op, 1, ConvertedSize, 0b11011, rd, rn, rm);
+  }
+  template<typename T>
+  void fcmge(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                        size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    const FEXCore::ARMEmitter::SubRegSize ConvertedSize =
+      size == ARMEmitter::SubRegSize::i64Bit ?
+        ARMEmitter::SubRegSize::i16Bit :
+        ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Same<T>(Op, 1, ConvertedSize, 0b11100, rd, rn, rm);
+  }
+  template<typename T>
+  void facge(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                        size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    const FEXCore::ARMEmitter::SubRegSize ConvertedSize =
+      size == ARMEmitter::SubRegSize::i64Bit ?
+        ARMEmitter::SubRegSize::i16Bit :
+        ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Same<T>(Op, 1, ConvertedSize, 0b11101, rd, rn, rm);
+  }
+  template<typename T>
+  void fmaxp(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                        size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    const FEXCore::ARMEmitter::SubRegSize ConvertedSize =
+      size == ARMEmitter::SubRegSize::i64Bit ?
+        ARMEmitter::SubRegSize::i16Bit :
+        ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Same<T>(Op, 1, ConvertedSize, 0b11110, rd, rn, rm);
+  }
+  template<typename T>
+  void fdiv(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                        size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    const FEXCore::ARMEmitter::SubRegSize ConvertedSize =
+      size == ARMEmitter::SubRegSize::i64Bit ?
+        ARMEmitter::SubRegSize::i16Bit :
+        ARMEmitter::SubRegSize::i8Bit;
+
+    ASIMD3Same<T>(Op, 1, ConvertedSize, 0b11111, rd, rn, rm);
+  }
+  template<typename T>
+  void eor(T rd, T rn, T rm) {
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 1, ARMEmitter::SubRegSize::i8Bit, 0b00011, rd, rn, rm);
+  }
+  template<typename T>
+  void bsl(T rd, T rn, T rm) {
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 1, ARMEmitter::SubRegSize::i16Bit, 0b00011, rd, rn, rm);
+  }
+  template<typename T>
+  void fminnmp(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                        size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 1, size, 0b11000, rd, rn, rm);
+  }
+  template<typename T>
+  void fabd(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                        size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 1, size, 0b11010, rd, rn, rm);
+  }
+  template<typename T>
+  void fcmgt(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                        size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 1, size, 0b11100, rd, rn, rm);
+  }
+  template<typename T>
+  void facgt(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                        size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 1, size, 0b11101, rd, rn, rm);
+  }
+  template<typename T>
+  void fminp(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+                        size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 1, size, 0b11110, rd, rn, rm);
+  }
+  template<typename T>
+  void bit(T rd, T rn, T rm) {
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 1, ARMEmitter::SubRegSize::i32Bit, 0b00011, rd, rn, rm);
+  }
+  template<typename T>
+  void bif(T rd, T rn, T rm) {
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
+    ASIMD3Same<T>(Op, 1, ARMEmitter::SubRegSize::i64Bit, 0b00011, rd, rn, rm);
+  }
+
+  // Advanced SIMD modified immediate
+  // XXX: ORR - 32-bit/16-bit
+  // XXX: MOVI - Shifting ones
+  template<typename T>
+  void fmov(FEXCore::ARMEmitter::SubRegSize size, T rd, float Value) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i16Bit ||
+                        size == FEXCore::ARMEmitter::SubRegSize::i32Bit ||
+                        size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Unsupported fmov size");
+
+    constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
+    uint32_t op;
+    uint32_t cmode = 0b1111;
+    uint32_t o2;
+    uint32_t Imm;
+    if (size == SubRegSize::i16Bit) {
+      LOGMAN_THROW_A_FMT(vixl::aarch64::Assembler::IsImmFP16(vixl::Float16(Value)), "Invalid float");
+      op = 0;
+      o2 = 1;
+      Imm = vixl::VFP::FP16ToImm8(vixl::Float16(Value));
+    }
+    else if (size == SubRegSize::i32Bit) {
+      LOGMAN_THROW_A_FMT(vixl::VFP::IsImmFP32(Value), "Invalid float");
+      op = 0;
+      o2 = 0;
+      Imm = vixl::VFP::FP32ToImm8(Value);
+    }
+    else if (size == SubRegSize::i64Bit) {
+      LOGMAN_THROW_A_FMT(vixl::VFP::IsImmFP64(Value), "Invalid float");
+      op = 1;
+      o2 = 0;
+      Imm = vixl::VFP::FP64ToImm8(Value);
+    }
+    else {
+      LOGMAN_MSG_A_FMT("Invalid subregsize");
+      FEX_UNREACHABLE;
+    }
+
+    ASIMDModifiedImm(Op, op, cmode, o2, Imm, rd);
+  }
+  // XXX: MVNI - Shifted immediate
+  // XXX: BIC
+  //void ASIMDModifiedImm(uint32_t Op, uint32_t op, uint32_t cmode, uint32_t o2, uint32_t imm, T rd) {
+
+  template<typename T>
+  void movi(FEXCore::ARMEmitter::SubRegSize size, T rd, uint64_t Imm, uint16_t Shift = 0) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i8Bit ||
+                        size == FEXCore::ARMEmitter::SubRegSize::i16Bit ||
+                        size == FEXCore::ARMEmitter::SubRegSize::i32Bit ||
+                        size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Unsupported smov size");
+
+    constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
+    uint32_t cmode;
+    uint32_t op;
+    if (size == SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Shift == 0, "8-bit can't have shift");
+      LOGMAN_THROW_AA_FMT((Imm & ~0xFF) == 0, "Larger than 8-bit Imm not supported");
+      cmode = 0b1110;
+      op = 0;
+    }
+    else if (size == SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Shift == 0 || Shift == 8, "Shift by invalid amount");
+      LOGMAN_THROW_AA_FMT((Imm & ~0xFF) == 0, "Larger than 8-bit Imm not supported");
+      cmode = 0b1000 | (Shift ? 0b10 : 0b00);
+      op = 0;
+    }
+    else if (size == SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Shift == 0 || Shift == 8 || Shift == 16 || Shift == 24, "Shift by invalid amount");
+      LOGMAN_THROW_AA_FMT((Imm & ~0xFF) == 0, "Larger than 8-bit Imm not supported");
+      cmode = 0b0000 | ((Shift >> 3) << 1);
+      op = 0;
+    }
+    else if (size == SubRegSize::i64Bit) {
+      LOGMAN_THROW_AA_FMT(Shift == 0, "64-bit can't have shift");
+      cmode = 0b1110;
+      op = 1;
+
+      // 64-bit movi doesn't behave like the smaller types
+      // Each bit of the 8-bit imm encoding is expanded to a full 8-bits.
+      // This gives us a full 64-bits for the final result but needs special handling.
+      uint8_t NewImm{};
+      for (size_t i = 0; i < 8; ++i) {
+        const size_t BitOffset = i * 8;
+        uint8_t Section = (Imm >> BitOffset) & 0xFF;
+        LOGMAN_THROW_AA_FMT(Section == 0 || Section == 0xFF, "Invalid 64-bit constant encoding");
+        if (Section == 0xFF) {
+          NewImm |= (1 << i);
+        }
+      }
+      Imm = NewImm;
+    }
+    else {
+      LOGMAN_MSG_A_FMT("Invalid subregsize");
+      FEX_UNREACHABLE;
+    }
+
+    ASIMDModifiedImm(Op, op, cmode, 0, Imm, rd);
+  }
+
+  // Advanced SIMD shift by immediate
+  template<typename T>
+  void sshr(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, uint32_t Shift) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+    constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = SubRegSizeInBits(size);
+
+    // Shift encoded a bit weirdly.
+    // shift = (esize * 2) - immh:immb but immh is /also/ used for element size.
+    const uint32_t InvertedShift = (SubregSizeInBits * 2) - (Shift);
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+
+    ASIMDShiftByImm<T>(Op, 0, immh, immb, 0b00000, rn, rd);
+  }
+  template<typename T>
+  void ssra(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, uint32_t Shift) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+    constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = SubRegSizeInBits(size);
+
+    // Shift encoded a bit weirdly.
+    // shift = (esize * 2) - immh:immb but immh is /also/ used for element size.
+    const uint32_t InvertedShift = (SubregSizeInBits * 2) - (Shift);
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+
+    ASIMDShiftByImm<T>(Op, 0, immh, immb, 0b00010, rn, rd);
+  }
+  template<typename T>
+  void srshr(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, uint32_t Shift) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+    constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = SubRegSizeInBits(size);
+
+    // Shift encoded a bit weirdly.
+    // shift = (esize * 2) - immh:immb but immh is /also/ used for element size.
+    const uint32_t InvertedShift = (SubregSizeInBits * 2) - (Shift);
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+
+    ASIMDShiftByImm<T>(Op, 0, immh, immb, 0b00100, rn, rd);
+  }
+  template<typename T>
+  void srsra(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, uint32_t Shift) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+    constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = SubRegSizeInBits(size);
+
+    // Shift encoded a bit weirdly.
+    // shift = (esize * 2) - immh:immb but immh is /also/ used for element size.
+    const uint32_t InvertedShift = (SubregSizeInBits * 2) - (Shift);
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+
+    ASIMDShiftByImm<T>(Op, 0, immh, immb, 0b00110, rn, rd);
+  }
+  template<typename T>
+  void shl(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, uint32_t Shift) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+    constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = SubRegSizeInBits(size);
+
+    // Shift encoded a bit weirdly.
+    // shift = immh:immb - esize but immh is /also/ used for element size.
+    const uint32_t InvertedShift = SubregSizeInBits + Shift;
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+
+    ASIMDShiftByImm<T>(Op, 0, immh, immb, 0b01010, rn, rd);
+  }
+  template<typename T>
+  void sqshl(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, uint32_t Shift) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+    constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = SubRegSizeInBits(size);
+
+    // Shift encoded a bit weirdly.
+    // shift = immh:immb - esize but immh is /also/ used for element size.
+    const uint32_t InvertedShift = SubregSizeInBits + Shift;
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+
+    ASIMDShiftByImm<T>(Op, 0, immh, immb, 0b01110, rn, rd);
+  }
+  ///< size is destination size
+  void shrn(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = SubRegSizeInBits(size);
+
+    // Shift encoded a bit weirdly.
+    // shift = (esize * 2) - immh:immb but immh is /also/ used for element size.
+    const uint32_t InvertedShift = (SubregSizeInBits * 2) - (Shift);
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+
+    ASIMDShiftByImm(Op, 0, immh, immb, 0b10000, rn, rd);
+  }
+  ///< size is destination size
+  void shrn2(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::QRegister rd, FEXCore::ARMEmitter::QRegister rn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = SubRegSizeInBits(size);
+
+    // Shift encoded a bit weirdly.
+    // shift = (esize * 2) - immh:immb but immh is /also/ used for element size.
+    const uint32_t InvertedShift = (SubregSizeInBits * 2) - (Shift);
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+
+    ASIMDShiftByImm(Op, 0, immh, immb, 0b10000, rn, rd);
+  }
+  ///< size is destination size
+  void rshrn(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = SubRegSizeInBits(size);
+
+    // Shift encoded a bit weirdly.
+    // shift = (esize * 2) - immh:immb but immh is /also/ used for element size.
+    const uint32_t InvertedShift = (SubregSizeInBits * 2) - (Shift);
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+
+    ASIMDShiftByImm(Op, 0, immh, immb, 0b10001, rn, rd);
+  }
+  ///< size is destination size
+  void rshrn2(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::QRegister rd, FEXCore::ARMEmitter::QRegister rn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = SubRegSizeInBits(size);
+
+    // Shift encoded a bit weirdly.
+    // shift = (esize * 2) - immh:immb but immh is /also/ used for element size.
+    const uint32_t InvertedShift = (SubregSizeInBits * 2) - (Shift);
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+
+    ASIMDShiftByImm(Op, 0, immh, immb, 0b10001, rn, rd);
+  }
+  ///< size is destination size
+  void sqshrn(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = SubRegSizeInBits(size);
+
+    // Shift encoded a bit weirdly.
+    // shift = (esize * 2) - immh:immb but immh is /also/ used for element size.
+    const uint32_t InvertedShift = (SubregSizeInBits * 2) - (Shift);
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+
+    ASIMDShiftByImm(Op, 0, immh, immb, 0b10010, rn, rd);
+  }
+  ///< size is destination size
+  void sqshrn2(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::QRegister rd, FEXCore::ARMEmitter::QRegister rn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = SubRegSizeInBits(size);
+
+    // Shift encoded a bit weirdly.
+    // shift = (esize * 2) - immh:immb but immh is /also/ used for element size.
+    const uint32_t InvertedShift = (SubregSizeInBits * 2) - (Shift);
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+
+    ASIMDShiftByImm(Op, 0, immh, immb, 0b10010, rn, rd);
+  }
+  ///< size is destination size
+  void sqrshrn(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = SubRegSizeInBits(size);
+
+    // Shift encoded a bit weirdly.
+    // shift = (esize * 2) - immh:immb but immh is /also/ used for element size.
+    const uint32_t InvertedShift = (SubregSizeInBits * 2) - (Shift);
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+
+    ASIMDShiftByImm(Op, 0, immh, immb, 0b10011, rn, rd);
+  }
+  ///< size is destination size
+  void sqrshrn2(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::QRegister rd, FEXCore::ARMEmitter::QRegister rn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = SubRegSizeInBits(size);
+
+    // Shift encoded a bit weirdly.
+    // shift = (esize * 2) - immh:immb but immh is /also/ used for element size.
+    const uint32_t InvertedShift = (SubregSizeInBits * 2) - (Shift);
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+
+    ASIMDShiftByImm(Op, 0, immh, immb, 0b10011, rn, rd);
+  }
+  ///< size is destination size
+  void sshll(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "Invalid size");
+    size = FEXCore::ARMEmitter::SubRegSize(FEXCore::ToUnderlying(size) - 1);
+
+    constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = SubRegSizeInBits(size);
+    LOGMAN_THROW_AA_FMT(Shift < SubregSizeInBits, "Shift must not be larger than incoming element size");
+
+    // Shift encoded a bit weirdly.
+    // shift = immh:immb - esize but immh is /also/ used for element size.
+    const uint32_t InvertedShift = SubregSizeInBits + Shift;
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+
+    ASIMDShiftByImm(Op, 0, immh, immb, 0b10100, rn, rd);
+  }
+
+  ///< size is destination size
+  void sshll2(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::QRegister rd, FEXCore::ARMEmitter::QRegister rn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "Invalid size");
+    size = FEXCore::ARMEmitter::SubRegSize(FEXCore::ToUnderlying(size) - 1);
+
+    constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = SubRegSizeInBits(size);
+    LOGMAN_THROW_AA_FMT(Shift < SubregSizeInBits, "Shift must not be larger than incoming element size");
+
+    // Shift encoded a bit weirdly.
+    // shift = immh:immb - esize but immh is /also/ used for element size.
+    const uint32_t InvertedShift = SubregSizeInBits + Shift;
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+
+    ASIMDShiftByImm(Op, 0, immh, immb, 0b10100, rn, rd);
+  }
+  ///< size is destination size
+  void sxtl(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    sshll(size, rd, rn, 0);
+  }
+  ///< size is destination size
+  void sxtl2(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    sshll2(size, rd, rn, 0);
+  }
+
+  // TODO: SCVTF, FCVTZS
+  template<typename T>
+  void ushr(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, uint32_t Shift) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+    constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = SubRegSizeInBits(size);
+
+    // Shift encoded a bit weirdly.
+    // shift = (esize * 2) - immh:immb but immh is /also/ used for element size.
+    const uint32_t InvertedShift = (SubregSizeInBits * 2) - Shift;
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+
+    ASIMDShiftByImm<T>(Op, 1, immh, immb, 0b00000, rn, rd);
+  }
+  template<typename T>
+  void usra(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, uint32_t Shift) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+    constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = SubRegSizeInBits(size);
+
+    // Shift encoded a bit weirdly.
+    // shift = (esize * 2) - immh:immb but immh is /also/ used for element size.
+    const uint32_t InvertedShift = (SubregSizeInBits * 2) - Shift;
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+
+    ASIMDShiftByImm<T>(Op, 1, immh, immb, 0b00010, rn, rd);
+  }
+  template<typename T>
+  void urshr(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, uint32_t Shift) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+    constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = SubRegSizeInBits(size);
+
+    // Shift encoded a bit weirdly.
+    // shift = (esize * 2) - immh:immb but immh is /also/ used for element size.
+    const uint32_t InvertedShift = (SubregSizeInBits * 2) - Shift;
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+
+    ASIMDShiftByImm<T>(Op, 1, immh, immb, 0b00100, rn, rd);
+  }
+  template<typename T>
+  void ursra(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, uint32_t Shift) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+    constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = SubRegSizeInBits(size);
+
+    // Shift encoded a bit weirdly.
+    // shift = (esize * 2) - immh:immb but immh is /also/ used for element size.
+    const uint32_t InvertedShift = (SubregSizeInBits * 2) - Shift;
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+
+    ASIMDShiftByImm<T>(Op, 1, immh, immb, 0b00110, rn, rd);
+  }
+  template<typename T>
+  void sri(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, uint32_t Shift) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+    constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = SubRegSizeInBits(size);
+
+    // Shift encoded a bit weirdly.
+    // shift = (esize * 2) - immh:immb but immh is /also/ used for element size.
+    const uint32_t InvertedShift = (SubregSizeInBits * 2) - Shift;
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+
+    ASIMDShiftByImm<T>(Op, 1, immh, immb, 0b01000, rn, rd);
+  }
+  template<typename T>
+  void sli(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, uint32_t Shift) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+    constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = SubRegSizeInBits(size);
+
+    // Shift encoded a bit weirdly.
+    // shift = immh:immb - esize but immh is /also/ used for element size.
+    const uint32_t InvertedShift = SubregSizeInBits + Shift;
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+
+    ASIMDShiftByImm<T>(Op, 1, immh, immb, 0b01010, rn, rd);
+  }
+  template<typename T>
+  void sqshlu(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, uint32_t Shift) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+    constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = SubRegSizeInBits(size);
+
+    // Shift encoded a bit weirdly.
+    // shift = immh:immb - esize but immh is /also/ used for element size.
+    const uint32_t InvertedShift = SubregSizeInBits + Shift;
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+
+    ASIMDShiftByImm<T>(Op, 1, immh, immb, 0b01100, rn, rd);
+  }
+  ///< size is destination size
+  template<typename T>
+  void uqshl(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, uint32_t Shift) {
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+    constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = SubRegSizeInBits(size);
+
+    // Shift encoded a bit weirdly.
+    // shift = immh:immb - esize but immh is /also/ used for element size.
+    const uint32_t InvertedShift = SubregSizeInBits + Shift;
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+
+    ASIMDShiftByImm<T>(Op, 1, immh, immb, 0b01110, rn, rd);
+  }
+  ///< size is destination size
+  void sqshrun(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = SubRegSizeInBits(size);
+
+    // Shift encoded a bit weirdly.
+    // shift = (esize * 2) - immh:immb but immh is /also/ used for element size.
+    const uint32_t InvertedShift = (SubregSizeInBits * 2) - Shift;
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+
+    ASIMDShiftByImm(Op, 1, immh, immb, 0b10000, rn, rd);
+  }
+  ///< size is destination size
+  void sqshrun2(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::QRegister rd, FEXCore::ARMEmitter::QRegister rn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = SubRegSizeInBits(size);
+
+    // Shift encoded a bit weirdly.
+    // shift = (esize * 2) - immh:immb but immh is /also/ used for element size.
+    const uint32_t InvertedShift = (SubregSizeInBits * 2) - Shift;
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+
+    ASIMDShiftByImm(Op, 1, immh, immb, 0b10000, rn, rd);
+  }
+  ///< size is destination size
+  void sqrshrun(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = SubRegSizeInBits(size);
+
+    // Shift encoded a bit weirdly.
+    // shift = (esize * 2) - immh:immb but immh is /also/ used for element size.
+    const uint32_t InvertedShift = (SubregSizeInBits * 2) - Shift;
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+
+    ASIMDShiftByImm(Op, 1, immh, immb, 0b10001, rn, rd);
+  }
+  ///< size is destination size
+  void sqrshrun2(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::QRegister rd, FEXCore::ARMEmitter::QRegister rn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = SubRegSizeInBits(size);
+
+    // Shift encoded a bit weirdly.
+    // shift = (esize * 2) - immh:immb but immh is /also/ used for element size.
+    const uint32_t InvertedShift = (SubregSizeInBits * 2) - Shift;
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+
+    ASIMDShiftByImm(Op, 1, immh, immb, 0b10001, rn, rd);
+  }
+  ///< size is destination size
+  void uqshrn(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, uint32_t Shift) {
+    constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = SubRegSizeInBits(size);
+
+    // Shift encoded a bit weirdly.
+    // shift = (esize * 2) - immh:immb but immh is /also/ used for element size.
+    const uint32_t InvertedShift = (SubregSizeInBits * 2) - Shift;
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+
+    ASIMDShiftByImm(Op, 1, immh, immb, 0b10010, rn, rd);
+  }
+  ///< size is destination size
+  void uqshrn2(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::QRegister rd, FEXCore::ARMEmitter::QRegister rn, uint32_t Shift) {
+    constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = SubRegSizeInBits(size);
+
+    // Shift encoded a bit weirdly.
+    // shift = (esize * 2) - immh:immb but immh is /also/ used for element size.
+    const uint32_t InvertedShift = (SubregSizeInBits * 2) - Shift;
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+
+    ASIMDShiftByImm(Op, 1, immh, immb, 0b10010, rn, rd);
+  }
+  ///< size is destination size
+  void uqrshrn(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, uint32_t Shift) {
+    constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = SubRegSizeInBits(size);
+
+    // Shift encoded a bit weirdly.
+    // shift = (esize * 2) - immh:immb but immh is /also/ used for element size.
+    const uint32_t InvertedShift = (SubregSizeInBits * 2) - Shift;
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+
+    ASIMDShiftByImm(Op, 1, immh, immb, 0b10011, rn, rd);
+  }
+  ///< size is destination size
+  void uqrshrn2(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::QRegister rd, FEXCore::ARMEmitter::QRegister rn, uint32_t Shift) {
+    constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = SubRegSizeInBits(size);
+
+    // Shift encoded a bit weirdly.
+    // shift = (esize * 2) - immh:immb but immh is /also/ used for element size.
+    const uint32_t InvertedShift = (SubregSizeInBits * 2) - Shift;
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+
+    ASIMDShiftByImm(Op, 1, immh, immb, 0b10011, rn, rd);
+  }
+  ///< size is destination size
+  void ushll(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, uint32_t Shift) {
+    constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
+    size = FEXCore::ARMEmitter::SubRegSize(FEXCore::ToUnderlying(size) - 1);
+    const size_t SubregSizeInBits = SubRegSizeInBits(size);
+
+    // Shift encoded a bit weirdly.
+    // shift = immh:immb - esize but immh is /also/ used for element size.
+    const uint32_t InvertedShift = SubregSizeInBits + Shift;
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+
+    ASIMDShiftByImm(Op, 1, immh, immb, 0b10100, rn, rd);
+  }
+  ///< size is destination size
+  void ushll2(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::QRegister rd, FEXCore::ARMEmitter::QRegister rn, uint32_t Shift) {
+    constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
+    size = FEXCore::ARMEmitter::SubRegSize(FEXCore::ToUnderlying(size) - 1);
+    const size_t SubregSizeInBits = SubRegSizeInBits(size);
+
+    // Shift encoded a bit weirdly.
+    // shift = immh:immb - esize but immh is /also/ used for element size.
+    const uint32_t InvertedShift = SubregSizeInBits + Shift;
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+
+
+    ASIMDShiftByImm(Op, 1, immh, immb, 0b10100, rn, rd);
+  }
+  void uxtl(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn) {
+    ushll(size, rd, rn, 0);
+  }
+  void uxtl2(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::QRegister rd, FEXCore::ARMEmitter::QRegister rn) {
+    ushll2(size, rd, rn, 0);
+  }
+  // XXX: UCVTF/FCVTZU
+
+  // Advanced SIMD vector x indexed element
+  // TODO
+  // Cryptographic three-register, imm2
+  // TODO
+  // Cryptographic three-register SHA 512
+  // TODO
+  // Cryptographic four-register
+  // TODO
+  // Cryptographic two-register SHA 512
+  // TODO
+  // Conversion between floating-point and fixed-point
+  // TODO
+  // Conversion between floating-point and integer
+  void fcvtns(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21;
+    ASIMDFloatConvBetweenInt(Op, size, 0, 0b11, 0b00, 0b000, rd, FEXCore::ARMEmitter::ToReg(rn));
+  }
+  void fcvtns(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::SRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21;
+    ASIMDFloatConvBetweenInt(Op, size, 0, 0b00, 0b00, 0b000, rd, FEXCore::ARMEmitter::ToReg(rn));
+  }
+  void fcvtns(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::DRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21;
+    ASIMDFloatConvBetweenInt(Op, size, 0, 0b01, 0b00, 0b000, rd, FEXCore::ARMEmitter::ToReg(rn));
+  }
+  void fcvtnu(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21;
+    ASIMDFloatConvBetweenInt(Op, size, 0, 0b11, 0b00, 0b001, rd, FEXCore::ARMEmitter::ToReg(rn));
+  }
+  void fcvtnu(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::SRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21;
+    ASIMDFloatConvBetweenInt(Op, size, 0, 0b00, 0b00, 0b001, rd, FEXCore::ARMEmitter::ToReg(rn));
+  }
+  void fcvtnu(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::DRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21;
+    ASIMDFloatConvBetweenInt(Op, size, 0, 0b01, 0b00, 0b001, rd, FEXCore::ARMEmitter::ToReg(rn));
+  }
+  void scvtf(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21;
+    ASIMDFloatConvBetweenInt(Op, size, 0, 0b11, 0b00, 0b010, FEXCore::ARMEmitter::ToReg(rd), rn);
+  }
+  void scvtf(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21;
+    ASIMDFloatConvBetweenInt(Op, size, 0, 0b00, 0b00, 0b010, FEXCore::ARMEmitter::ToReg(rd), rn);
+  }
+  void scvtf(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21;
+    ASIMDFloatConvBetweenInt(Op, size, 0, 0b01, 0b00, 0b010, FEXCore::ARMEmitter::ToReg(rd), rn);
+  }
+  void ucvtf(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21;
+    ASIMDFloatConvBetweenInt(Op, size, 0, 0b11, 0b00, 0b011, FEXCore::ARMEmitter::ToReg(rd), rn);
+  }
+  void ucvtf(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21;
+    ASIMDFloatConvBetweenInt(Op, size, 0, 0b00, 0b00, 0b011, FEXCore::ARMEmitter::ToReg(rd), rn);
+  }
+  void ucvtf(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21;
+    ASIMDFloatConvBetweenInt(Op, size, 0, 0b01, 0b00, 0b011, FEXCore::ARMEmitter::ToReg(rd), rn);
+  }
+  void fcvtas(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21;
+    ASIMDFloatConvBetweenInt(Op, size, 0, 0b11, 0b00, 0b100, rd, FEXCore::ARMEmitter::ToReg(rn));
+  }
+  void fcvtas(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::SRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21;
+    ASIMDFloatConvBetweenInt(Op, size, 0, 0b00, 0b00, 0b100, rd, FEXCore::ARMEmitter::ToReg(rn));
+  }
+  void fcvtas(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::DRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21;
+    ASIMDFloatConvBetweenInt(Op, size, 0, 0b01, 0b00, 0b100, rd, FEXCore::ARMEmitter::ToReg(rn));
+  }
+  void fcvtau(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21;
+    ASIMDFloatConvBetweenInt(Op, size, 0, 0b11, 0b00, 0b101, rd, FEXCore::ARMEmitter::ToReg(rn));
+  }
+  void fcvtau(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::SRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21;
+    ASIMDFloatConvBetweenInt(Op, size, 0, 0b00, 0b00, 0b101, rd, FEXCore::ARMEmitter::ToReg(rn));
+  }
+  void fcvtau(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::DRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21;
+    ASIMDFloatConvBetweenInt(Op, size, 0, 0b01, 0b00, 0b101, rd, FEXCore::ARMEmitter::ToReg(rn));
+  }
+  void fmov(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21;
+    ASIMDFloatConvBetweenInt(Op, size, 0, 0b11, 0b00, 0b110, rd, FEXCore::ARMEmitter::ToReg(rn));
+  }
+  void fmov(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::SRegister rn) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::Size::i64Bit, "Can't move SReg to 64-bit");
+    constexpr uint32_t Op = 0b0001'1110'001 << 21;
+    ASIMDFloatConvBetweenInt(Op, size, 0, 0b00, 0b00, 0b110, rd, FEXCore::ARMEmitter::ToReg(rn));
+  }
+  void fmov(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::DRegister rn) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::Size::i32Bit, "Can't move DReg to 32-bit");
+    constexpr uint32_t Op = 0b0001'1110'001 << 21;
+    ASIMDFloatConvBetweenInt(Op, size, 0, 0b01, 0b00, 0b110, rd, FEXCore::ARMEmitter::ToReg(rn));
+  }
+  void fmov(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::VRegister rn, bool Upper) {
+    if (Upper) {
+      LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::Size::i64Bit, "Can only move upper with 64-bit elements");
+    }
+    constexpr uint32_t Op = 0b0001'1110'001 << 21;
+    ASIMDFloatConvBetweenInt(Op, size, 0, Upper ? 0b10 : 0b01, Upper ? 0b01 : 0b00, 0b110, rd, FEXCore::ARMEmitter::ToReg(rn));
+  }
+  void fmov(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21;
+    ASIMDFloatConvBetweenInt(Op, size, 0, 0b11, 0b00, 0b111, FEXCore::ARMEmitter::ToReg(rd), rn);
+  }
+  void fmov(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::Register rn) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::Size::i64Bit, "Can't move SReg to 64-bit");
+    constexpr uint32_t Op = 0b0001'1110'001 << 21;
+    ASIMDFloatConvBetweenInt(Op, size, 0, 0b00, 0b00, 0b111, FEXCore::ARMEmitter::ToReg(rd), rn);
+  }
+  void fmov(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::Register rn) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::Size::i32Bit, "Can't move DReg to 32-bit");
+    constexpr uint32_t Op = 0b0001'1110'001 << 21;
+    ASIMDFloatConvBetweenInt(Op, size, 0, 0b01, 0b00, 0b111, FEXCore::ARMEmitter::ToReg(rd), rn);
+  }
+  void fmov(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::Register rn, bool Upper) {
+    if (Upper) {
+      LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::Size::i64Bit, "Can only move upper with 64-bit elements");
+    }
+    constexpr uint32_t Op = 0b0001'1110'001 << 21;
+    ASIMDFloatConvBetweenInt(Op, size, 0, Upper ? 0b10 : 0b01, Upper ? 0b01 : 0b00, 0b111, FEXCore::ARMEmitter::ToReg(rd), rn);
+  }
+  void fcvtps(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21;
+    ASIMDFloatConvBetweenInt(Op, size, 0, 0b11, 0b01, 0b000, rd, FEXCore::ARMEmitter::ToReg(rn));
+  }
+  void fcvtps(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::SRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21;
+    ASIMDFloatConvBetweenInt(Op, size, 0, 0b00, 0b01, 0b000, rd, FEXCore::ARMEmitter::ToReg(rn));
+  }
+  void fcvtps(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::DRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21;
+    ASIMDFloatConvBetweenInt(Op, size, 0, 0b01, 0b01, 0b000, rd, FEXCore::ARMEmitter::ToReg(rn));
+  }
+  void fcvtpu(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21;
+    ASIMDFloatConvBetweenInt(Op, size, 0, 0b11, 0b01, 0b001, rd, FEXCore::ARMEmitter::ToReg(rn));
+  }
+  void fcvtpu(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::SRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21;
+    ASIMDFloatConvBetweenInt(Op, size, 0, 0b00, 0b01, 0b001, rd, FEXCore::ARMEmitter::ToReg(rn));
+  }
+  void fcvtpu(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::DRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21;
+    ASIMDFloatConvBetweenInt(Op, size, 0, 0b01, 0b01, 0b001, rd, FEXCore::ARMEmitter::ToReg(rn));
+  }
+  void fcvtms(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21;
+    ASIMDFloatConvBetweenInt(Op, size, 0, 0b11, 0b10, 0b000, rd, FEXCore::ARMEmitter::ToReg(rn));
+  }
+  void fcvtms(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::SRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21;
+    ASIMDFloatConvBetweenInt(Op, size, 0, 0b00, 0b10, 0b000, rd, FEXCore::ARMEmitter::ToReg(rn));
+  }
+  void fcvtms(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::DRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21;
+    ASIMDFloatConvBetweenInt(Op, size, 0, 0b01, 0b10, 0b000, rd, FEXCore::ARMEmitter::ToReg(rn));
+  }
+  void fcvtmu(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21;
+    ASIMDFloatConvBetweenInt(Op, size, 0, 0b11, 0b10, 0b001, rd, FEXCore::ARMEmitter::ToReg(rn));
+  }
+  void fcvtmu(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::SRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21;
+    ASIMDFloatConvBetweenInt(Op, size, 0, 0b00, 0b10, 0b001, rd, FEXCore::ARMEmitter::ToReg(rn));
+  }
+  void fcvtmu(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::DRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21;
+    ASIMDFloatConvBetweenInt(Op, size, 0, 0b01, 0b10, 0b001, rd, FEXCore::ARMEmitter::ToReg(rn));
+  }
+  void fcvtzs(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21;
+    ASIMDFloatConvBetweenInt(Op, size, 0, 0b11, 0b11, 0b000, rd, FEXCore::ARMEmitter::ToReg(rn));
+  }
+  void fcvtzs(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::SRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21;
+    ASIMDFloatConvBetweenInt(Op, size, 0, 0b00, 0b11, 0b000, rd, FEXCore::ARMEmitter::ToReg(rn));
+  }
+  void fcvtzs(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::DRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21;
+    ASIMDFloatConvBetweenInt(Op, size, 0, 0b01, 0b11, 0b000, rd, FEXCore::ARMEmitter::ToReg(rn));
+  }
+  void fcvtzs(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::VRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21;
+    ASIMDFloatConvBetweenInt(Op, size, 0, 0b01, 0b11, 0b000, rd, FEXCore::ARMEmitter::ToReg(rn));
+  }
+  void fcvtzu(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21;
+    ASIMDFloatConvBetweenInt(Op, size, 0, 0b11, 0b11, 0b001, rd, FEXCore::ARMEmitter::ToReg(rn));
+  }
+  void fcvtzu(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::SRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21;
+    ASIMDFloatConvBetweenInt(Op, size, 0, 0b00, 0b11, 0b001, rd, FEXCore::ARMEmitter::ToReg(rn));
+  }
+  void fcvtzu(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::DRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21;
+    ASIMDFloatConvBetweenInt(Op, size, 0, 0b01, 0b11, 0b001, rd, FEXCore::ARMEmitter::ToReg(rn));
+  }
+
+private:
+  // Cryptographic AES
+  void CryptoAES(uint32_t Op, uint32_t opcode, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    uint32_t Instr = Op;
+
+    Instr |= opcode << 12;
+    Instr |= Encode_rn(rn);
+    Instr |= Encode_rd(rd);
+    dc32(Instr);
+  }
+
+  // Cryptographic three-register SHA
+  void Crypto3RegSHA(uint32_t Op, uint32_t opcode, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    uint32_t Instr = Op;
+
+    Instr |= Encode_rm(rm);
+    Instr |= opcode << 12;
+    Instr |= Encode_rn(rn);
+    Instr |= Encode_rd(rd);
+    dc32(Instr);
+  }
+
+  // Cryptographic two-register SHA
+  void Crypto2RegSHA(uint32_t Op, uint32_t opcode, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    uint32_t Instr = Op;
+
+    Instr |= opcode << 12;
+    Instr |= Encode_rn(rn);
+    Instr |= Encode_rd(rd);
+    dc32(Instr);
+  }
+
+  // Advanced SIMD table lookup
+  void ASIMDTable(uint32_t Op, uint32_t Q, uint32_t op2, uint32_t len, uint32_t op, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    uint32_t Instr = Op;
+
+    Instr |= Q << 30;
+    Instr |= op2 << 22;
+    Instr |= Encode_rm(rm);
+    Instr |= len << 13;
+    Instr |= op << 12;
+    Instr |= Encode_rn(rn);
+    Instr |= Encode_rd(rd);
+    dc32(Instr);
+  }
+
+  // Advanced SIMD permute
+  void ASIMDPermute(uint32_t Op, uint32_t Q, FEXCore::ARMEmitter::SubRegSize size, uint32_t opcode, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    uint32_t Instr = Op;
+
+    Instr |= Q << 30;
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= Encode_rm(rm);
+    Instr |= opcode << 12;
+    Instr |= Encode_rn(rn);
+    Instr |= Encode_rd(rd);
+    dc32(Instr);
+  }
+
+  // Advanced SIMD extract
+  void ASIMDExtract(uint32_t Op, uint32_t Q, uint32_t op2, uint32_t imm4, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    uint32_t Instr = Op;
+
+    Instr |= Q << 30;
+    Instr |= op2 << 22;
+    Instr |= Encode_rm(rm);
+    Instr |= imm4 << 11;
+    Instr |= Encode_rn(rn);
+    Instr |= Encode_rd(rd);
+    dc32(Instr);
+  }
+
+  // Advanced SIMD two-register miscellaneous
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void ASIMD2RegMisc(uint32_t Op, uint32_t U, FEXCore::ARMEmitter::SubRegSize size, uint32_t opcode, T rd, T rn) {
+    constexpr uint32_t Q = std::is_same_v<FEXCore::ARMEmitter::QRegister, T> ? 1U << 30 : 0;
+
+    uint32_t Instr = Op;
+    Instr |= Q;
+    Instr |= U << 29;
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= opcode << 12;
+    Instr |= Encode_rn(rn);
+    Instr |= Encode_rd(rd);
+    dc32(Instr);
+  }
+
+  // Advanced SIMD across lanes
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void ASIMDAcrossLanes(uint32_t Op, uint32_t U, FEXCore::ARMEmitter::SubRegSize size, uint32_t opcode, T rd, T rn) {
+    constexpr uint32_t Q = std::is_same_v<FEXCore::ARMEmitter::QRegister, T> ? 1U << 30 : 0;
+
+    uint32_t Instr = Op;
+    Instr |= Q;
+    Instr |= U << 29;
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= opcode << 12;
+    Instr |= Encode_rn(rn);
+    Instr |= Encode_rd(rd);
+    dc32(Instr);
+  }
+
+  // Advanced SIMD three different
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void ASIMD3Different(uint32_t Op, uint32_t U, uint32_t opcode, FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
+    constexpr uint32_t Q = std::is_same_v<FEXCore::ARMEmitter::QRegister, T> ? 1U << 30 : 0;
+
+    uint32_t Instr = Op;
+    Instr |= Q;
+    Instr |= U << 29;
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= Encode_rm(rm);
+    Instr |= opcode << 12;
+    Instr |= Encode_rn(rn);
+    Instr |= Encode_rd(rd);
+    dc32(Instr);
+  }
+
+  // Advanced SIMD three same
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void ASIMD3Same(uint32_t Op, uint32_t U, FEXCore::ARMEmitter::SubRegSize size, uint32_t opcode, T rd, T rn, T rm) {
+    constexpr uint32_t Q = std::is_same_v<FEXCore::ARMEmitter::QRegister, T> ? 1U << 30 : 0;
+
+    uint32_t Instr = Op;
+    Instr |= Q;
+    Instr |= U << 29;
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= Encode_rm(rm);
+    Instr |= opcode << 11;
+    Instr |= Encode_rn(rn);
+    Instr |= Encode_rd(rd);
+    dc32(Instr);
+  }
+
+  // Advanced SIMD modified immediate
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void ASIMDModifiedImm(uint32_t Op, uint32_t op, uint32_t cmode, uint32_t o2, uint32_t imm, T rd) {
+    constexpr uint32_t Q = std::is_same_v<FEXCore::ARMEmitter::QRegister, T> ? 1U << 30 : 0;
+
+    uint32_t Instr = Op;
+    Instr |= Q;
+    Instr |= op << 29;
+    Instr |= ((imm >> 7) & 1) << 18;
+    Instr |= ((imm >> 6) & 1) << 17;
+    Instr |= ((imm >> 5) & 1) << 16;
+    Instr |= cmode << 12;
+    Instr |= o2 << 11;
+    Instr |= ((imm >> 4) & 1) << 9;
+    Instr |= ((imm >> 3) & 1) << 8;
+    Instr |= ((imm >> 2) & 1) << 7;
+    Instr |= ((imm >> 1) & 1) << 6;
+    Instr |= ((imm >> 0) & 1) << 5;
+
+    Instr |= Encode_rd(rd);
+    dc32(Instr);
+  }
+
+  // Advanced SIMD shift by immediate
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void ASIMDShiftByImm(uint32_t Op, uint32_t U, uint32_t immh, uint32_t immb, uint32_t opcode, T rn, T rd) {
+    constexpr uint32_t Q = std::is_same_v<FEXCore::ARMEmitter::QRegister, T> ? 1U << 30 : 0;
+    LOGMAN_THROW_A_FMT(immh != 0, "ImmH needs to not be zero");
+
+    uint32_t Instr = Op;
+
+    Instr |= Q;
+    Instr |= U << 29;
+    Instr |= immh << 19;
+    Instr |= immb << 16;
+    Instr |= opcode << 11;
+    Instr |= Encode_rn(rn);
+    Instr |= Encode_rd(rd);
+    dc32(Instr);
+  }
+
+  // Conversion between floating-point and integer
+  void ASIMDFloatConvBetweenInt(uint32_t Op, FEXCore::ARMEmitter::Size s, uint32_t S, uint32_t ptype, uint32_t rmode, uint32_t opcode, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn) {
+    const uint32_t SF = s == FEXCore::ARMEmitter::Size::i64Bit ? (1U << 31) : 0;
+
+    uint32_t Instr = Op;
+
+    Instr |= SF;
+    Instr |= S << 29;
+    Instr |= ptype << 22;
+    Instr |= rmode << 19;
+    Instr |= opcode << 16;
+    Instr |= Encode_rn(rn);
+    Instr |= Encode_rd(rd);
+    dc32(Instr);
+  }
+
+  template<FEXCore::ARMEmitter::SubRegSize size, bool Load, typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void ASIMDLoadStoreMultipleStructure(uint32_t Op, uint32_t opcode, T rt, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    constexpr uint32_t Q = std::is_same_v<FEXCore::ARMEmitter::QRegister, T> ? 1U << 30 : 0;
+
+    uint32_t Instr = Op;
+
+    Instr |= Q;
+    Instr |= Load ? 1 << 22: 0;
+    Instr |= Encode_rm(rm);
+    Instr |= opcode;
+    Instr |= FEXCore::ToUnderlying(size) << 10;
+    Instr |= Encode_rn(rn);
+    Instr |= Encode_rt(rt);
+    dc32(Instr);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, bool Load, uint32_t Count>
+  void ASIMDSTLD(uint32_t Op, uint32_t Opcode, FEXCore::ARMEmitter::VRegister rt, uint32_t Index, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    LOGMAN_THROW_A_FMT(
+      (size == SubRegSize::i8Bit && Index < 16) ||
+      (size == SubRegSize::i16Bit && Index < 8) ||
+      (size == SubRegSize::i32Bit && Index < 4) ||
+      (size == SubRegSize::i64Bit && Index < 2),
+      "Invalid Index selected");
+
+    uint32_t Q{};
+    uint32_t S{};
+    uint32_t Size{};
+
+    // selem is for determining if we are doing 1-3 loadstore single structure operations
+    // eg: ST1/2/3/4 or LD1/2/3/4
+    constexpr uint32_t selem = Count - 1;
+    const uint32_t opcode = Opcode | (selem >> 1);
+
+    // Index is encoded as:
+    // 8-bit:  Q:S:size
+    // 16-bit  Q:S:size<1>
+    // 32-bit: Q:S
+    // 64-bit: Q
+    if constexpr (size == SubRegSize::i8Bit) {
+      Q = ((Index & 0b1000) >> 3) << 30;
+      S = ((Index & 0b0100) >> 2);
+      Size = Index & 0b11;
+    }
+    else if constexpr (size == SubRegSize::i16Bit) {
+      Q = ((Index & 0b0100) >> 2) << 30;
+      S = ((Index & 0b0010) >> 1);
+      Size = (Index & 0b1) << 1;
+    }
+    else if constexpr (size == SubRegSize::i32Bit) {
+      Q = ((Index & 0b0010) >> 1) << 30;
+      S = Index & 0b0001;
+    }
+    else if constexpr (size == SubRegSize::i64Bit) {
+      Q = (Index & 0b0001) << 30;
+      Size = 1;
+    }
+
+    // scale = opcode<2:1>
+    // selem = opcode<0>:R + 1
+    //
+    // scale:
+    // - 0
+    //   - Index = Q:S:size - aka B[0-15]
+    // - 1
+    //   - Index = Q:S:size<1> - aka H[0-7]
+    // - 2
+    //   if (size == i32)
+    //     - Index = Q:S - aka S[0-3]
+    //   if (size == i64)
+    //     - Index = Q - aka D[0-1]
+    //   if (size == i128) undefined
+    // - 3
+    //   Load+Replicate
+    //   scale = size
+
+    ASIMDLoadStore(Op | Q, Load, selem & 1, opcode, S, Size, rt, rn, rm);
+  }
+
+  template<FEXCore::ARMEmitter::SubRegSize size, bool Load, uint32_t Count, typename T>
+  void ASIMDSTLD(uint32_t Op, uint32_t Opcode, T rt, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    constexpr uint32_t Q = std::is_same_v<FEXCore::ARMEmitter::QRegister, T> ? 1U << 30 : 0;
+    constexpr uint32_t S = 0;
+
+    // selem is for determining if we are doing 1-3 loadstore single structure operations
+    // eg: ST1/2/3/4 or LD1/2/3/4
+    constexpr uint32_t selem = Count - 1;
+    const uint32_t opcode = Opcode | (selem >> 1);
+
+    // scale = opcode<2:1>
+    // selem = opcode<0>:R + 1
+    //
+    // scale:
+    // - 0
+    //   - Index = Q:S:size - aka B[0-15]
+    // - 1
+    //   - Index = Q:S:size<1> - aka H[0-7]
+    // - 2
+    //   if (size == i32)
+    //     - Index = Q:S - aka S[0-3]
+    //   if (size == i64)
+    //     - Index = Q - aka D[0-1]
+    //   if (size == i128) undefined
+    // - 3
+    //   Load+Replicate
+    //   scale = size
+
+    ASIMDLoadStore(Op | Q, Load, selem & 1, opcode, S, FEXCore::ToUnderlying(size), rt, rn, rm);
+  }
+  void ASIMDLoadStore(uint32_t Op, uint32_t L, uint32_t R, uint32_t opcode, uint32_t S, uint32_t size, FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    uint32_t Instr = Op;
+
+    Instr |= L << 22;
+    Instr |= R << 21;
+    Instr |= Encode_rm(rm);
+    Instr |= opcode << 13;
+    Instr |= S << 12;
+    Instr |= size << 10;
+    Instr |= Encode_rn(rn);
+    Instr |= Encode_rt(rt);
+
+    dc32(Instr);
+  }
+
+

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/BranchOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/BranchOps.inl
@@ -1,0 +1,322 @@
+/* Branch instruction emitters.
+ *
+ * Most of these instructions will use `BackwardLabel`, `ForwardLabel`, or `BiDirectionLabel` to determine where a branch targets.
+ */
+public:
+  // Branches, Exception Generating and System instructions
+  public:
+    // Conditional branch immediate
+    ///< Branch conditional
+    void b(FEXCore::ARMEmitter::Condition Cond, uint32_t Imm) {
+      constexpr uint32_t Op = 0b0101'010 << 25;
+      Branch_Conditional(Op, 0, 0, Cond, Imm);
+    }
+    void b(FEXCore::ARMEmitter::Condition Cond, BackwardLabel const* Label) {
+      int32_t Imm = static_cast<int32_t>(Label->Location - GetCursorAddress<uint8_t*>());
+      LOGMAN_THROW_A_FMT(Imm >= -1048576 && Imm <= 1048575 && ((Imm & 0b11) == 0), "Unscaled offset too large");
+      constexpr uint32_t Op = 0b0101'010 << 25;
+      Branch_Conditional(Op, 0, 0, Cond, Imm >> 2);
+    }
+    void b(FEXCore::ARMEmitter::Condition Cond, ForwardLabel *Label) {
+      Label->Insts.emplace_back(ForwardLabel::Instructions{ .Location = GetCursorAddress<uint8_t*>(), .Type = ForwardLabel::Instructions::InstType::BC });
+      constexpr uint32_t Op = 0b0101'010 << 25;
+      Branch_Conditional(Op, 0, 0, Cond, 0);
+    }
+
+    void b(FEXCore::ARMEmitter::Condition Cond, BiDirectionalLabel *Label) {
+      if (Label->Backward.Location) {
+        b(Cond, &Label->Backward);
+      }
+      else {
+        b(Cond, &Label->Forward);
+      }
+    }
+
+    ///< Branch consistent conditional
+    void bc(FEXCore::ARMEmitter::Condition Cond, uint32_t Imm) {
+      constexpr uint32_t Op = 0b0101'010 << 25;
+      Branch_Conditional(Op, 0, 1, Cond, Imm);
+    }
+    void bc(FEXCore::ARMEmitter::Condition Cond, BackwardLabel const* Label) {
+      int32_t Imm = static_cast<int32_t>(Label->Location - GetCursorAddress<uint8_t*>());
+      LOGMAN_THROW_A_FMT(Imm >= -1048576 && Imm <= 1048575 && ((Imm & 0b11) == 0), "Unscaled offset too large");
+      constexpr uint32_t Op = 0b0101'010 << 25;
+      Branch_Conditional(Op, 0, 1, Cond, Imm >> 2);
+    }
+
+    void bc(FEXCore::ARMEmitter::Condition Cond, ForwardLabel *Label) {
+      Label->Insts.emplace_back(ForwardLabel::Instructions{ .Location = GetCursorAddress<uint8_t*>(), .Type = ForwardLabel::Instructions::InstType::BC });
+      constexpr uint32_t Op = 0b0101'010 << 25;
+      Branch_Conditional(Op, 0, 1, Cond, 0);
+    }
+
+    void bc(FEXCore::ARMEmitter::Condition Cond, BiDirectionalLabel *Label) {
+      if (Label->Backward.Location) {
+        bc(Cond, &Label->Backward);
+      }
+      else {
+        bc(Cond, &Label->Forward);
+      }
+    }
+
+    // Unconditional branch register
+    void br(FEXCore::ARMEmitter::Register rn) {
+      constexpr uint32_t Op = 0b1101011 << 25 |
+                              0b0'000 << 21 |   // opc
+                              0b1'1111 << 16 |  // op2
+                              0b0000'00 << 10 | // op3
+                              0b0'0000;         // op4
+
+      UnconditionalBranch(Op, rn);
+    }
+    void blr(FEXCore::ARMEmitter::Register rn) {
+      constexpr uint32_t Op = 0b1101011 << 25 |
+                              0b0'001 << 21 |   // opc
+                              0b1'1111 << 16 |  // op2
+                              0b0000'00 << 10 | // op3
+                              0b0'0000;         // op4
+
+      UnconditionalBranch(Op, rn);
+    }
+    void ret(FEXCore::ARMEmitter::Register rn = FEXCore::ARMEmitter::Reg::r30) {
+      constexpr uint32_t Op = 0b1101011 << 25 |
+                              0b0'010 << 21 |   // opc
+                              0b1'1111 << 16 |  // op2
+                              0b0000'00 << 10 | // op3
+                              0b0'0000;         // op4
+
+      UnconditionalBranch(Op, rn);
+    }
+
+    // Unconditional branch immediate
+    void b(uint32_t Imm) {
+      constexpr uint32_t Op = 0b0001'01 << 26;
+
+      UnconditionalBranch(Op, Imm);
+    }
+    void b(BackwardLabel const* Label) {
+      int32_t Imm = static_cast<int32_t>(Label->Location - GetCursorAddress<uint8_t*>());
+      LOGMAN_THROW_A_FMT(Imm >= -134217728 && Imm <= 134217724 && ((Imm & 0b11) == 0), "Unscaled offset too large");
+      constexpr uint32_t Op = 0b0001'01 << 26;
+
+      UnconditionalBranch(Op, Imm >> 2);
+    }
+    void b(ForwardLabel *Label) {
+      Label->Insts.emplace_back(ForwardLabel::Instructions{ .Location = GetCursorAddress<uint8_t*>(), .Type = ForwardLabel::Instructions::InstType::B });
+      constexpr uint32_t Op = 0b0001'01 << 26;
+
+      UnconditionalBranch(Op, 0);
+    }
+
+    void b(BiDirectionalLabel *Label) {
+      if (Label->Backward.Location) {
+        b(&Label->Backward);
+      }
+      else {
+        b(&Label->Forward);
+      }
+    }
+
+    void bl(uint32_t Imm) {
+      constexpr uint32_t Op = 0b1001'01 << 26;
+
+      UnconditionalBranch(Op, Imm);
+    }
+
+    void bl(BackwardLabel const* Label) {
+      int32_t Imm = static_cast<int32_t>(Label->Location - GetCursorAddress<uint8_t*>());
+      LOGMAN_THROW_A_FMT(Imm >= -134217728 && Imm <= 134217724 && ((Imm & 0b11) == 0), "Unscaled offset too large");
+      constexpr uint32_t Op = 0b1001'01 << 26;
+
+      UnconditionalBranch(Op, Imm >> 2);
+    }
+    void bl(ForwardLabel *Label) {
+      Label->Insts.emplace_back(ForwardLabel::Instructions{ .Location = GetCursorAddress<uint8_t*>(), .Type = ForwardLabel::Instructions::InstType::B });
+      constexpr uint32_t Op = 0b1001'01 << 26;
+
+      UnconditionalBranch(Op, 0);
+    }
+
+    void bl(BiDirectionalLabel *Label) {
+      if (Label->Backward.Location) {
+        bl(&Label->Backward);
+      }
+      else {
+        bl(&Label->Forward);
+      }
+    }
+
+    // Compare and branch
+    void cbz(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rt, uint32_t Imm) {
+      constexpr uint32_t Op = 0b0011'0100 << 24;
+
+      CompareAndBranch(Op, s, rt, Imm);
+    }
+
+    void cbz(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rt, BackwardLabel const* Label) {
+      int32_t Imm = static_cast<int32_t>(Label->Location - GetCursorAddress<uint8_t*>());
+      LOGMAN_THROW_A_FMT(Imm >= -1048576 && Imm <= 1048575 && ((Imm & 0b11) == 0), "Unscaled offset too large");
+
+      constexpr uint32_t Op = 0b0011'0100 << 24;
+
+      CompareAndBranch(Op, s, rt, Imm >> 2);
+    }
+
+    void cbz(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rt, ForwardLabel *Label) {
+      Label->Insts.emplace_back(ForwardLabel::Instructions{ .Location = GetCursorAddress<uint8_t*>(), .Type = ForwardLabel::Instructions::InstType::BC });
+
+      constexpr uint32_t Op = 0b0011'0100 << 24;
+
+      CompareAndBranch(Op, s, rt, 0);
+    }
+
+    void cbz(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rt, BiDirectionalLabel *Label) {
+      if (Label->Backward.Location) {
+        cbz(s, rt, &Label->Backward);
+      }
+      else {
+        cbz(s, rt, &Label->Forward);
+      }
+    }
+
+    void cbnz(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rt, uint32_t Imm) {
+      constexpr uint32_t Op = 0b0011'0101 << 24;
+
+      CompareAndBranch(Op, s, rt, Imm);
+    }
+
+    void cbnz(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rt, BackwardLabel const* Label) {
+      int32_t Imm = static_cast<int32_t>(Label->Location - GetCursorAddress<uint8_t*>());
+      LOGMAN_THROW_A_FMT(Imm >= -1048576 && Imm <= 1048575 && ((Imm & 0b11) == 0), "Unscaled offset too large");
+
+      constexpr uint32_t Op = 0b0011'0101 << 24;
+
+      CompareAndBranch(Op, s, rt, Imm >> 2);
+    }
+
+    void cbnz(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rt, ForwardLabel *Label) {
+      Label->Insts.emplace_back(ForwardLabel::Instructions{ .Location = GetCursorAddress<uint8_t*>(), .Type = ForwardLabel::Instructions::InstType::BC });
+
+      constexpr uint32_t Op = 0b0011'0101 << 24;
+
+      CompareAndBranch(Op, s, rt, 0);
+    }
+
+    void cbnz(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rt, BiDirectionalLabel *Label) {
+      if (Label->Backward.Location) {
+        cbnz(s, rt, &Label->Backward);
+      }
+      else {
+        cbnz(s, rt, &Label->Forward);
+      }
+    }
+
+    // Test and branch immediate
+    void tbz(FEXCore::ARMEmitter::Register rt, uint32_t Bit, uint32_t Imm) {
+      constexpr uint32_t Op = 0b0011'0110 << 24;
+
+      TestAndBranch(Op, rt, Bit, Imm);
+    }
+    void tbz(FEXCore::ARMEmitter::Register rt, uint32_t Bit, BackwardLabel const* Label) {
+      int32_t Imm = static_cast<int32_t>(Label->Location - GetCursorAddress<uint8_t*>());
+      LOGMAN_THROW_A_FMT(Imm >= -32768 && Imm <= 32764 && ((Imm & 0b11) == 0), "Unscaled offset too large");
+
+      constexpr uint32_t Op = 0b0011'0110 << 24;
+
+      TestAndBranch(Op, rt, Bit, Imm >> 2);
+    }
+    void tbz(FEXCore::ARMEmitter::Register rt, uint32_t Bit, ForwardLabel *Label) {
+      Label->Insts.emplace_back(ForwardLabel::Instructions{ .Location = GetCursorAddress<uint8_t*>(), .Type = ForwardLabel::Instructions::InstType::TEST_BRANCH });
+
+      constexpr uint32_t Op = 0b0011'0110 << 24;
+
+      TestAndBranch(Op, rt, Bit, 0);
+    }
+
+    void tbz(FEXCore::ARMEmitter::Register rt, uint32_t Bit, BiDirectionalLabel *Label) {
+      if (Label->Backward.Location) {
+        tbz(rt, Bit, &Label->Backward);
+      }
+      else {
+        tbz(rt, Bit, &Label->Forward);
+      }
+    }
+
+    void tbnz(FEXCore::ARMEmitter::Register rt, uint32_t Bit, uint32_t Imm) {
+      constexpr uint32_t Op = 0b0011'0111 << 24;
+
+      TestAndBranch(Op, rt, Bit, Imm);
+    }
+    void tbnz(FEXCore::ARMEmitter::Register rt, uint32_t Bit, BackwardLabel const* Label) {
+      int32_t Imm = static_cast<int32_t>(Label->Location - GetCursorAddress<uint8_t*>());
+      LOGMAN_THROW_A_FMT(Imm >= -32768 && Imm <= 32764 && ((Imm & 0b11) == 0), "Unscaled offset too large");
+
+      constexpr uint32_t Op = 0b0011'0111 << 24;
+
+      TestAndBranch(Op, rt, Bit, Imm >> 2);
+    }
+    void tbnz(FEXCore::ARMEmitter::Register rt, uint32_t Bit, ForwardLabel *Label) {
+      Label->Insts.emplace_back(ForwardLabel::Instructions{ .Location = GetCursorAddress<uint8_t*>(), .Type = ForwardLabel::Instructions::InstType::TEST_BRANCH });
+      constexpr uint32_t Op = 0b0011'0111 << 24;
+
+      TestAndBranch(Op, rt, Bit, 0);
+    }
+
+    void tbnz(FEXCore::ARMEmitter::Register rt, uint32_t Bit, BiDirectionalLabel *Label) {
+      if (Label->Backward.Location) {
+        tbnz(rt, Bit, &Label->Backward);
+      }
+      else {
+        tbnz(rt, Bit, &Label->Forward);
+      }
+    }
+
+private:
+    // Conditional branch immediate
+    void Branch_Conditional(uint32_t Op, uint32_t Op1, uint32_t Op0, FEXCore::ARMEmitter::Condition Cond, uint32_t Imm) {
+      uint32_t Instr = Op;
+
+      Instr |= Op1 << 24;
+      Instr |= (Imm & 0x7'FFFF) << 5;
+      Instr |= Op0 << 4;
+      Instr |= FEXCore::ToUnderlying(Cond);
+
+      dc32(Instr);
+    }
+
+    // Unconditional branch register
+    void UnconditionalBranch(uint32_t Op, FEXCore::ARMEmitter::Register rn) {
+      uint32_t Instr = Op;
+      Instr |= Encode_rn(rn);
+      dc32(Instr);
+    }
+
+    // Unconditional branch - immediate
+    void UnconditionalBranch(uint32_t Op, uint32_t Imm) {
+      uint32_t Instr = Op;
+      Instr |= Imm & 0x3FF'FFFF;
+      dc32(Instr);
+    }
+
+    // Compare and branch
+    void CompareAndBranch(uint32_t Op, FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rt, uint32_t Imm) {
+      const uint32_t SF = s == FEXCore::ARMEmitter::Size::i64Bit ? (1U << 31) : 0;
+
+      uint32_t Instr = Op;
+
+      Instr |= SF;
+      Instr |= (Imm & 0x7'FFFF) << 5;
+      Instr |= Encode_rt(rt);
+      dc32(Instr);
+    }
+
+    // Test and branch - immediate
+    void TestAndBranch(uint32_t Op, FEXCore::ARMEmitter::Register rt, uint32_t Bit, uint32_t Imm) {
+      uint32_t Instr = Op;
+
+      Instr |= (Bit >> 5) << 31;
+      Instr |= (Bit & 0b1'1111) << 19;
+      Instr |= (Imm & 0x3FFF) << 5;
+      Instr |= Encode_rt(rt);
+      dc32(Instr);
+    }

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/Buffer.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/Buffer.h
@@ -1,0 +1,100 @@
+#pragma once
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+namespace FEXCore::ARMEmitter {
+  class Buffer {
+    public:
+      Buffer() {
+        SetBuffer(nullptr, 0);
+      }
+
+      Buffer(uint8_t* Base, uint64_t BaseSize) {
+        SetBuffer(Base, BaseSize);
+      }
+
+      void SetBuffer(uint8_t* Base, uint64_t BaseSize) {
+        BufferBase = Base;
+        CurrentOffset = BufferBase;
+        Size = BaseSize;
+      }
+
+      void dc8(uint8_t Data) {
+        decltype(Data) *Memory = reinterpret_cast<decltype(Data)*>(CurrentOffset);
+        *Memory = Data;
+        CurrentOffset += sizeof(Data);
+      }
+
+      void dc16(uint16_t Data) {
+        decltype(Data) *Memory = reinterpret_cast<decltype(Data)*>(CurrentOffset);
+        *Memory = Data;
+        CurrentOffset += sizeof(Data);
+      }
+
+      void dc32(uint32_t Data) {
+        decltype(Data) *Memory = reinterpret_cast<decltype(Data)*>(CurrentOffset);
+        *Memory = Data;
+        CurrentOffset += sizeof(Data);
+      }
+
+      void dc64(uint64_t Data) {
+        decltype(Data) *Memory = reinterpret_cast<decltype(Data)*>(CurrentOffset);
+        *Memory = Data;
+        CurrentOffset += sizeof(Data);
+      }
+      void EmitString(const char *String) {
+        const auto StringLength = strlen(String);
+        memcpy(CurrentOffset, String, StringLength);
+        CurrentOffset += StringLength;
+      }
+
+      void Align() {
+        // Align the buffer to instruction size
+        auto CurrentAlignment = reinterpret_cast<uint64_t>(CurrentOffset) & 0b11;
+        if (!CurrentAlignment) {
+          return;
+        }
+        CurrentOffset += 4 - CurrentAlignment;
+      }
+
+      template<typename T>
+      T GetCursorAddress() const {
+        return reinterpret_cast<T>(CurrentOffset);
+      }
+
+      static void ClearICache(void* Begin, std::size_t Length) {
+        __builtin___clear_cache(static_cast<char*>(Begin), static_cast<char*>(Begin) + Length);
+      }
+
+      size_t GetCursorOffset() const {
+        return static_cast<size_t>(CurrentOffset - BufferBase);
+      }
+
+      uint8_t *GetBufferBase() const {
+        return BufferBase;
+      }
+
+      void CursorIncrement(size_t Size) {
+        CurrentOffset += Size;
+      }
+
+      void SetCursorOffset(size_t Offset) {
+        CurrentOffset = BufferBase + Offset;
+      }
+
+      uint64_t GetBufferSize() const {
+        return Size;
+      }
+
+    protected:
+
+      void ResetBuffer() {
+        CurrentOffset = BufferBase;
+      }
+
+      uint8_t* BufferBase;
+      uint8_t* CurrentOffset;
+      uint64_t Size;
+  };
+}

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/Emitter.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/Emitter.h
@@ -1,0 +1,721 @@
+#pragma once
+
+#include "Interface/Core/ArchHelpers/CodeEmitter/Buffer.h"
+#include "Interface/Core/ArchHelpers/CodeEmitter/Registers.h"
+
+#include <FEXCore/Utils/CompilerDefs.h>
+#include <FEXCore/Utils/EnumUtils.h>
+#include <FEXCore/Utils/LogManager.h>
+
+#include <aarch64/assembler-aarch64.h>
+
+#include <cstdint>
+#include <utility>
+#include <type_traits>
+#include <vector>
+
+/*
+ * Welcome to FEX-Emu's custom AArch64 emitter.
+ * This was written specifically to avoid the performance cost of the vixl emitter.
+ *
+ * There are some specific design constraints in this design to target a couple features:
+ *   - High performance
+ *   - Low CPU cache performance hit
+ *   - Significantly reduced code footprint
+ *   - Low number of branches
+ *
+ * These requirements are mostly achieved by removing a bunch of developer conveniences
+ * that vixl provides. The developer needs to take a lot of care to not shoot themselves in the foot.
+ *
+ * Misc design decisions:
+ * - Registers are encoded as basic uint32_t enums.
+ *   - Converting between different registers is zero-cost.
+ *   - Passing around as arguments are as cheap as registers
+ *     - Contrast to vixl where every register requires living on the stack.
+ *   - Registers can get encoded in to instructions with a simple `BFM` instruction.
+ *
+ * - Instructions are very simply emitted, allowing direct inlining most of the time.
+ *   - These are simple enough that multiple back-to-back instructions get optimized to 128-bit load-store operations.
+ *     - Contrast to vixl where pretty much no instruction emitter gets inlined.
+ *
+ * - Instruction emitters are /mostly/ unsized. Most instructions take a size argument first, which gets encoded
+ *   directly in to the instruction.
+ *   - Contrast to vixl where the register arguments are how the instructions determine operating size.
+ *   - Size argument allows FEX to use `CSEL` to select a size at runtime, instead of branching.
+ *   - Some instructions are explicitly sized based on register type. Read comments in the respective `inl` files to
+ *     see why.
+ *     Some scalar/vector operations are an example of this.
+ *
+ * - Almost zero helper functions.
+ *   - Primary exception to this rule is load-store operations. These will use a helper to make
+ *     it easier to select the correct load-store instruction. Mostly because these are a nightmare selecting
+ *     the right instruction.
+ */
+namespace FEXCore::ARMEmitter {
+  /*
+   * This `Size` enum is used for most ALU operations.
+   * These follow the AArch64 encoding style in most cases.
+   */
+  enum class Size : uint32_t {
+    i32Bit = 0,
+    i64Bit,
+  };
+
+  // This allows us to get the `Size` enum in bits.
+  template<Size size>
+  constexpr size_t RegSizeInBits() {
+    constexpr size_t RegSize[] = {
+      32, 64, 128,
+    };
+    return RegSize[FEXCore::ToUnderlying(size)];
+  }
+
+  [[maybe_unused]]
+  static inline size_t RegSizeInBits(Size size) {
+    constexpr size_t RegSize[] = {
+      32, 64, 128,
+    };
+    return RegSize[FEXCore::ToUnderlying(size)];
+  }
+
+  /* This `SubRegSize` enum is used for most ASIMD operations.
+   * These follow the AArch64 encoding style in most cases.
+   */
+  enum class SubRegSize : uint32_t {
+    i8Bit   = 0b00,
+    i16Bit  = 0b01,
+    i32Bit  = 0b10,
+    i64Bit  = 0b11,
+    i128Bit = 0b100,
+  };
+
+  // This allows us to get the `SubRegSize` in bits.
+  template<SubRegSize size>
+  constexpr size_t SubRegSizeInBits() {
+    return (1 << FEXCore::ToUnderlying(size)) * 8;
+  }
+
+  [[maybe_unused]]
+  static inline size_t SubRegSizeInBits(SubRegSize size) {
+    return (1 << FEXCore::ToUnderlying(size)) * 8;
+  }
+
+  /* This `ScalarRegSize` enum is used for most scalar float
+   * operations.
+   *
+   * This is specifically duplicated from `SubRegSize` to have strongly
+   * typed functions.
+   *
+   * `ScalarRegSize` specifically doesn't have `i128Bit` because scalar operations
+   * can't operate at 128-bit.
+   */
+  enum class ScalarRegSize : uint32_t {
+    i8Bit   = 0b00,
+    i16Bit  = 0b01,
+    i32Bit  = 0b10,
+    i64Bit  = 0b11,
+  };
+
+  // This allows us to get the `ScalarRegSize` in bits.
+  template<ScalarRegSize size>
+  constexpr size_t ScalarRegSizeInBits() {
+    return (1 << FEXCore::ToUnderlying(size)) * 8;
+  }
+
+  [[maybe_unused]]
+  static inline size_t ScalarRegSizeInBits(ScalarRegSize size) {
+    return (1 << FEXCore::ToUnderlying(size)) * 8;
+  }
+
+  /* This `VectorRegSizePair` union allows us to have an overlapping type
+   * to select a scalar operation or a vector depending on which operation
+   * we pass in.
+   * Useful in FEX's vector operations that behave as scalar or vector
+   * depending on various factors. But since the operation will have the sa,e
+   * element size, we want to choose the operation more easily
+   */
+  union VectorRegSizePair {
+    ScalarRegSize Scalar;
+    SubRegSize Vector;
+  };
+
+  // This allows us to create a `VectorRegSizePair` union.
+  [[maybe_unused]]
+  static inline VectorRegSizePair ToVectorSizePair(SubRegSize size) {
+    return VectorRegSizePair {.Vector = size};
+  }
+  [[maybe_unused]]
+  static inline VectorRegSizePair ToVectorSizePair(ScalarRegSize size) {
+    return VectorRegSizePair {.Scalar = size};
+  }
+
+  // This `ShiftType` enum is used for ALU shift-register encoded instructions.
+  enum class ShiftType : uint32_t {
+    LSL = 0,
+    LSR,
+    ASR,
+    ROR,
+  };
+
+  // This `ExtendedType` enum is used for ALU extended-register encoded instructions.
+  enum class ExtendedType : uint32_t {
+    UXTB = 0b000,
+    UXTH = 0b001,
+    UXTW = 0b010,
+    UXTX = 0b011,
+    SXTB = 0b100,
+    SXTH = 0b101,
+    SXTW = 0b110,
+    SXTX = 0b111,
+    LSL_32 = UXTW,
+    LSL_64 = UXTX,
+  };
+
+  // This `Condition` enum is used for various conditional instructions.
+  enum class Condition : uint32_t {
+    // Meaning:   Int                    - Float
+    CC_EQ = 0, // Equal                  - Equal
+    CC_NE,     // Not Eq                 - Not Eq or unordered
+    CC_CS,     // Carry set              - Greater than, equal, or unordered
+    CC_CC,     // Carry clear            - Less than
+    CC_MI,     // Minus/Negative         - Less than
+    CC_PL,     // Plus, positive or zero - GT, equal, or unordered
+    CC_VS,     // Overflow               - Unordered
+    CC_VC,     // No Overflow            - Ordered
+    CC_HI,     // Unsigned higher        - GT, or unordered
+    CC_LS,     // Unsigned lower or same - LT or EQ
+    CC_GE,     // Signed GT or EQ        - GT or EQ
+    CC_LT,     // Signed LT              - LT or Unordered
+    CC_GT,     // Signed GT              - GT
+    CC_LE,     // Signed LT or EQ        - LT, EQ, or Unordered
+    CC_AL,     // Always                 - Always
+    CC_NV,     // Always                 - Always
+
+    // Aliases
+    CC_HS = CC_CS,
+    CC_LO = CC_CC,
+  };
+
+  /*
+   * This `StatusFlags` enum is used for conditional compare encoded instructions.
+   * These directly encode to the `nzcv` flags.
+   */
+  enum class StatusFlags : uint32_t {
+    None = 0,
+    Flag_V = 0b0001,
+    Flag_C = 0b0010,
+    Flag_Z = 0b0100,
+    Flag_N = 0b1000,
+
+    Flag_NZCV = Flag_N | Flag_Z | Flag_C | Flag_V,
+  };
+
+
+  /*
+   * This `IndexType` enum is used for load-store instructions.
+   * Not all load-store instructions use this, so the user needs to be careful.
+   */
+  enum class IndexType {
+    POST,
+    OFFSET,
+    PRE,
+
+    UNPRIVILEGED,
+  };
+
+  /* This `SVEMemOperand` class is used for the helper SVE load-store instructions.
+   * Load-store instructions are quite expressive, so having a helper that handles these differences is worth it.
+   */
+  class SVEMemOperand final {
+    public:
+      SVEMemOperand(XRegister rn, XRegister rm = XReg::zr)
+        : rn {rn}
+        , MetaType {
+          .ScalarScalarType {
+            .Header = { .MemType = TYPE_SCALAR_SCALAR },
+            .rm = rm,
+          }
+        } {}
+      SVEMemOperand(XRegister rn, int32_t imm = 0)
+        : rn {rn}
+        , MetaType {
+          .ScalarImmType {
+            .Header = { .MemType = TYPE_SCALAR_IMM },
+            .Imm = imm,
+          }
+        } {}
+
+      Register rn;
+      enum Type {
+        TYPE_SCALAR_SCALAR,
+        TYPE_SCALAR_IMM,
+        TYPE_SCALAR_VECTOR,
+        TYPE_VECTOR_IMM,
+      };
+      struct HeaderStruct {
+        Type MemType;
+      };
+
+      union {
+        HeaderStruct Header;
+        struct {
+          HeaderStruct Header;
+          Register rm;
+        } ScalarScalarType;
+
+        struct {
+          HeaderStruct Header;
+          int32_t Imm;
+        } ScalarImmType;
+
+        struct {
+          HeaderStruct Header;
+          ZRegister zm;
+          // TODO: Implement support for modifier
+        } ScalarVectorType;
+
+        struct {
+          HeaderStruct Header;
+          // rn will be a ZRegister
+          int32_t Imm;
+        } VectorImmType;
+      } MetaType;
+  };
+
+  /* This `ExtendedMemOperand` class is used for the helper load-store instructions.
+   * Load-store instructions are quite expressive, so having a helper that handles these differences is worth it.
+   */
+  class ExtendedMemOperand final {
+    public:
+      ExtendedMemOperand(XRegister rn, XRegister rm = XReg::zr, ExtendedType Option = ExtendedType::LSL_64, uint32_t Shift = 0)
+        : rn {rn}
+        , MetaType {
+          .ExtendedType {
+            .Header = { .MemType = TYPE_EXTENDED },
+            .rm = rm,
+            .Option = Option,
+            .Shift = Shift,
+          }
+        } {}
+      ExtendedMemOperand(XRegister rn, IndexType Index = IndexType::OFFSET, int32_t Imm = 0)
+        : rn {rn}
+        , MetaType {
+          .ImmType {
+            .Header = { .MemType = TYPE_IMM },
+            .Index = Index,
+            .Imm = Imm,
+          }
+        } {}
+
+      Register rn;
+      enum Type {
+        TYPE_EXTENDED,
+        TYPE_IMM,
+      };
+      struct HeaderStruct {
+        Type MemType;
+      };
+      union {
+        HeaderStruct Header;
+        struct {
+          HeaderStruct Header;
+          Register rm;
+          ExtendedType Option;
+          uint32_t Shift;
+        } ExtendedType;
+        struct {
+          HeaderStruct Header;
+          IndexType Index;
+          int32_t Imm;
+        } ImmType;
+      } MetaType;
+  };
+
+  template<uint32_t op0, uint32_t op1, uint32_t CRn, uint32_t CRm, uint32_t op2>
+  constexpr uint32_t GenSystemReg() {
+    return op0 << 19 |
+      op1 << 16 |
+      CRn << 12 |
+      CRm << 8 |
+      op2 << 5;
+  };
+
+  // This `SystemRegister` enum is used for the mrs/msr instructions.
+  enum class SystemRegister : uint32_t {
+    CTR_EL0    = GenSystemReg<0b11, 0b011, 0b0000, 0b0000, 0b001>(),
+    DCZID_EL0  = GenSystemReg<0b11, 0b011, 0b0000, 0b0000, 0b111>(),
+    TPIDR_EL0  = GenSystemReg<0b11, 0b011, 0b1101, 0b0000, 0b010>(),
+    RNDR       = GenSystemReg<0b11, 0b011, 0b0010, 0b0100, 0b000>(),
+    RNDRRS     = GenSystemReg<0b11, 0b011, 0b0010, 0b0100, 0b001>(),
+    NZCV       = GenSystemReg<0b11, 0b011, 0b0100, 0b0010, 0b000>(),
+    FPCR       = GenSystemReg<0b11, 0b011, 0b0100, 0b0100, 0b000>(),
+    CNTFRQ_EL0 = GenSystemReg<0b11, 0b011, 0b1110, 0b0000, 0b000>(),
+    CNTVCT_EL0 = GenSystemReg<0b11, 0b011, 0b1110, 0b0000, 0b010>(),
+  };
+
+  template<uint32_t op1, uint32_t CRm, uint32_t op2>
+  constexpr uint32_t GenDCReg() {
+    return op1 << 16 |
+      CRm << 8 |
+      op2 << 5;
+  };
+
+  // This `DataCacheOperation` enum is used for the dc instruction.
+  enum class DataCacheOperation : uint32_t {
+    IVAC  = GenDCReg<0b000, 0b0110, 0b001>(),
+    ISW   = GenDCReg<0b000, 0b0110, 0b010>(),
+    CSW   = GenDCReg<0b000, 0b1010, 0b010>(),
+    CISW  = GenDCReg<0b000, 0b1110, 0b010>(),
+    ZVA   = GenDCReg<0b011, 0b0100, 0b001>(),
+    CVAC  = GenDCReg<0b011, 0b1010, 0b001>(),
+    CVAU  = GenDCReg<0b011, 0b1011, 0b001>(),
+    CIVAC = GenDCReg<0b011, 0b1110, 0b001>(),
+
+    // MTE2
+    IGVAC  = GenDCReg<0b000, 0b0110, 0b011>(),
+    IGSW   = GenDCReg<0b000, 0b0110, 0b100>(),
+    IGDVAC = GenDCReg<0b000, 0b0110, 0b101>(),
+    IGDSW  = GenDCReg<0b000, 0b0110, 0b110>(),
+    CGSW   = GenDCReg<0b000, 0b1010, 0b100>(),
+    CGDSW  = GenDCReg<0b000, 0b1010, 0b110>(),
+    CIGSW  = GenDCReg<0b000, 0b1110, 0b100>(),
+    CIGDSW = GenDCReg<0b000, 0b1110, 0b110>(),
+
+    // MTE
+    GVA      = GenDCReg<0b011, 0b0100, 0b011>(),
+    GZVA     = GenDCReg<0b011, 0b0100, 0b100>(),
+    CGVAC    = GenDCReg<0b011, 0b1010, 0b011>(),
+    CGDVAC   = GenDCReg<0b011, 0b1010, 0b101>(),
+    CGVAP    = GenDCReg<0b011, 0b1100, 0b011>(),
+    CGDVAP   = GenDCReg<0b011, 0b1100, 0b101>(),
+    CGVADP   = GenDCReg<0b011, 0b1101, 0b011>(),
+    CGDVADP  = GenDCReg<0b011, 0b1101, 0b101>(),
+    CIGVAC   = GenDCReg<0b011, 0b1110, 0b011>(),
+    CIGDVAC  = GenDCReg<0b011, 0b1110, 0b101>(),
+
+    // DPB
+    CVAP = GenDCReg<0b011, 0b1100, 0b001>(),
+
+    // DPB2
+    CVADP = GenDCReg<0b011, 0b1101, 0b001>(),
+  };
+
+  template<uint32_t CRm, uint32_t op2>
+  constexpr uint32_t GenHintBarrierReg() {
+    return CRm << 8 |
+      op2 << 5;
+  }
+
+  // This `HintRegister` enum is used for the hint instruction.
+  enum class HintRegister : uint32_t {
+    NOP   = GenHintBarrierReg<0b0000, 0b000>(),
+    YIELD = GenHintBarrierReg<0b0000, 0b001>(),
+    WFE   = GenHintBarrierReg<0b0000, 0b010>(),
+    WFI   = GenHintBarrierReg<0b0000, 0b011>(),
+    SEV   = GenHintBarrierReg<0b0000, 0b100>(),
+    SEVL  = GenHintBarrierReg<0b0000, 0b101>(),
+    DGH   = GenHintBarrierReg<0b0000, 0b110>(),
+    CSDB  = GenHintBarrierReg<0b0010, 0b100>(),
+  };
+
+  // This `BarrierRegister` enum is used for the various barrier instructions.
+  enum class BarrierRegister : uint32_t {
+    CLREX   = GenHintBarrierReg<0b0000, 0b010>(),
+    TCOMMIT = GenHintBarrierReg<0b0000, 0b011>(),
+    DSB     = GenHintBarrierReg<0b0000, 0b100>(),
+    DMB     = GenHintBarrierReg<0b0000, 0b101>(),
+    ISB     = GenHintBarrierReg<0b0000, 0b110>(),
+    SB      = GenHintBarrierReg<0b0000, 0b111>(),
+  };
+
+  // This `BarrierScope` enum is used for the dsb/dmb instructions.
+  enum class BarrierScope : uint32_t {
+    // Outer shareable
+    OSHLD  = 0b0001,
+    OSHST  = 0b0010,
+    OSH    = 0b0011,
+    // Non shareable
+    NSHLD  = 0b0101,
+    NSHST  = 0b0110,
+    NSH    = 0b0111,
+    // Inner shareable
+    ISHLD  = 0b1001,
+    ISHST  = 0b1010,
+    ISH    = 0b1011,
+    // Full System visibility
+    LD     = 0b1101,
+    ST     = 0b1110,
+    SY     = 0b1111,
+  };
+
+  // This `Prefetch` enum is used for prefetch instructions.
+  enum class Prefetch : uint32_t {
+    // Prefetch for load
+    PLDL1KEEP = 0b00000,
+    PLDL1STRM = 0b00001,
+    PLDL2KEEP = 0b00010,
+    PLDL2STRM = 0b00011,
+    PLDL3KEEP = 0b00100,
+    PLDL3STRM = 0b00101,
+
+    // Preload instructions
+    PLIL1KEEP = 0b01000,
+    PLIL1STRM = 0b01001,
+    PLIL2KEEP = 0b01010,
+    PLIL2STRM = 0b01011,
+    PLIL3KEEP = 0b01100,
+    PLIL3STRM = 0b01101,
+
+    // Preload for store
+    PSTL1KEEP = 0b10000,
+    PSTL1STRM = 0b10001,
+    PSTL2KEEP = 0b10010,
+    PSTL2STRM = 0b10011,
+    PSTL3KEEP = 0b10100,
+    PSTL3STRM = 0b10101,
+  };
+
+  // This `PredicatePattern` enun is used for some SVE instructions.
+  enum class PredicatePattern : uint32_t {
+    SVE_POW2  = 0b00000,
+    SVE_VL1   = 0b00001,
+    SVE_VL2   = 0b00010,
+    SVE_VL3   = 0b00011,
+    SVE_VL4   = 0b00100,
+    SVE_VL5   = 0b00101,
+    SVE_VL6   = 0b00110,
+    SVE_VL7   = 0b00111,
+    SVE_VL8   = 0b01000,
+    SVE_VL16  = 0b01001,
+    SVE_VL32  = 0b01010,
+    SVE_VL64  = 0b01011,
+    SVE_VL128 = 0b01100,
+    SVE_VL256 = 0b01101,
+    SVE_MUL4  = 0b11101,
+    SVE_MUL3  = 0b11110,
+    SVE_ALL   = 0b11111,
+  };
+
+  /* This `BackwardLabel` struct used for retaining a location for PC-Relative instructions.
+   * This is specifically a label for a target that is logically `below` an instruction that uses it.
+   * Which means that a branch would jump backwards.
+   */
+  struct BackwardLabel {
+    uint8_t *Location{};
+  };
+
+  /* This `ForwardLabel` struct used for retaining a location for PC-Relative instructions.
+   * This is specifically a label for a target that is logically `above` an instruction that uses it.
+   * Which means that a branch would jump forwards.
+   *
+   * This can be bound to multiple instructions, so it needs a vector for each bind instruction type.
+   */
+  struct ForwardLabel {
+    struct Instructions {
+      enum class InstType {
+        ADR,
+        ADRP,
+        B,
+        BC,
+        TEST_BRANCH,
+        RELATIVE_LOAD,
+      };
+      uint8_t *Location{};
+      InstType Type;
+    };
+    std::vector<Instructions> Insts{};
+  };
+
+  /* This `BiDirectionalLabel` struct used for retaining a location for PC-Relative instructions.
+   * This is specifically a label for a target that is in either direction of an instruction that uses it.
+   * Which means a branch could jump backwards or forwards depending on situation.
+   */
+  struct BiDirectionalLabel {
+    BackwardLabel Backward;
+    ForwardLabel Forward;
+  };
+
+  // This is an emitter that is designed around the smallest code bloat as possible.
+  // Eschewing most developer convenience in order to keep code as small as possible.
+
+  // Choices:
+  // - Size of ops passed as an argument rather than template to let the compiler use csel instead of branching.
+  // - Registers are unsized so they can be passed in a GPR and not need conversion operations
+  class Emitter : public FEXCore::ARMEmitter::Buffer {
+  public:
+    Emitter() = default;
+
+    Emitter(uint8_t* Base, uint64_t BaseSize)
+      : Buffer (Base, BaseSize) {
+    }
+
+    // Bind a backward label to an address.
+    // Address that is bound is the current emitter location.
+    void Bind(BackwardLabel *Label) {
+      LOGMAN_THROW_AA_FMT(Label->Location == nullptr, "Trying to bind a label twice");
+      Label->Location = GetCursorAddress<uint8_t*>();
+    }
+
+    // Bind a forward label to a location.
+    // This walks all the instructions in the label's vector.
+    // Then backpatching all instructions that have used the label.
+    template<bool WarnAboutEmpty = false>
+    void Bind(ForwardLabel *Label) {
+      if constexpr (WarnAboutEmpty) {
+        LOGMAN_THROW_A_FMT(Label->Insts.empty() == false, "Binding forward label that didn't have any instructions using it");
+      }
+      uint8_t *CurrentAddress = GetCursorAddress<uint8_t*>();
+      for (const auto &Inst : Label->Insts) {
+        // Patch up the instructions
+        switch (Inst.Type) {
+          case ForwardLabel::Instructions::InstType::ADR: {
+            uint32_t *Instruction = reinterpret_cast<uint32_t*>(Inst.Location);
+            int64_t Imm = reinterpret_cast<int64_t>(CurrentAddress) - reinterpret_cast<int64_t>(Instruction);
+            LOGMAN_THROW_A_FMT(Imm >= -1048576 && Imm <= 1048575, "Unscaled offset too large");
+            uint32_t InstMask = 0b11 << 29 | 0b1111'1111'1111'1111'111 << 5;
+            uint32_t Offset = static_cast<uint32_t>(Imm) & 0x3F'FFFF;
+            uint32_t Inst = *Instruction & ~InstMask;
+            Inst |= (Offset & 0b11) << 29;
+            Inst |= (Offset >> 2) << 5;
+            *Instruction = Inst;
+            break;
+          }
+          case ForwardLabel::Instructions::InstType::ADRP: {
+            uint32_t *Instruction = reinterpret_cast<uint32_t*>(Inst.Location);
+            int64_t Imm = reinterpret_cast<int64_t>(CurrentAddress) - reinterpret_cast<int64_t>(Instruction);
+            LOGMAN_THROW_A_FMT(Imm >= -4294967296 && Imm <= 4294963200 && (Imm & 0xFFF) == 0, "Unscaled offset too large");
+            Imm >>= 12;
+            uint32_t InstMask = 0b11 << 29 | 0b1111'1111'1111'1111'111 << 5;
+            uint32_t Offset = static_cast<uint32_t>(Imm) & 0x3F'FFFF;
+            uint32_t Inst = *Instruction & ~InstMask;
+            Inst |= (Offset & 0b11) << 29;
+            Inst |= (Offset >> 2) << 5;
+            *Instruction = Inst;
+            break;
+          }
+
+          case ForwardLabel::Instructions::InstType::B: {
+            uint32_t *Instruction = reinterpret_cast<uint32_t*>(Inst.Location);
+            int64_t Imm = reinterpret_cast<int64_t>(CurrentAddress) - reinterpret_cast<int64_t>(Instruction);
+            LOGMAN_THROW_A_FMT(Imm >= -134217728 && Imm <= 134217724 && ((Imm & 0b11) == 0), "Unscaled offset too large");
+            Imm >>= 2;
+            uint32_t InstMask = 0x3FF'FFFF;
+            uint32_t Offset = static_cast<uint32_t>(Imm) & InstMask;
+            uint32_t Inst = *Instruction & ~InstMask;
+            Inst |= Offset;
+            *Instruction = Inst;
+
+            break;
+          }
+
+          case ForwardLabel::Instructions::InstType::TEST_BRANCH: {
+            uint32_t *Instruction = reinterpret_cast<uint32_t*>(Inst.Location);
+            int64_t Imm = reinterpret_cast<int64_t>(CurrentAddress) - reinterpret_cast<int64_t>(Instruction);
+            LOGMAN_THROW_A_FMT(Imm >= -32768 && Imm <= 32764 && ((Imm & 0b11) == 0), "Unscaled offset too large");
+            Imm >>= 2;
+            uint32_t InstMask = 0x3FFF;
+            uint32_t Offset = static_cast<uint32_t>(Imm) & InstMask;
+            uint32_t Inst = *Instruction & ~(InstMask << 5);
+            Inst |= Offset << 5;
+            *Instruction = Inst;
+
+            break;
+          }
+          case ForwardLabel::Instructions::InstType::BC:
+          case ForwardLabel::Instructions::InstType::RELATIVE_LOAD: {
+            uint32_t *Instruction = reinterpret_cast<uint32_t*>(Inst.Location);
+            int64_t Imm = reinterpret_cast<int64_t>(CurrentAddress) - reinterpret_cast<int64_t>(Instruction);
+            LOGMAN_THROW_A_FMT(Imm >= -1048576 && Imm <= 1048575 && ((Imm & 0b11) == 0), "Unscaled offset too large");
+            Imm >>= 2;
+            uint32_t InstMask = 0x7'FFFF;
+            uint32_t Offset = static_cast<uint32_t>(Imm) & InstMask;
+            uint32_t Inst = *Instruction & ~(InstMask << 5);
+            Inst |= Offset << 5;
+            *Instruction = Inst;
+            break;
+          }
+          default: LOGMAN_MSG_A_FMT("Unexpected inst type in label fixup");
+        }
+      }
+    }
+
+    // Bind a bidirectional location to a location.
+    // Binds both forwards and backwards depending on how the label was used.
+    void Bind(BiDirectionalLabel *Label) {
+      if (!Label->Backward.Location) {
+        Bind(&Label->Backward);
+      }
+      Bind<false>(&Label->Forward);
+    }
+
+  public:
+  // TODO: Implement SME when it matters.
+#include "Interface/Core/ArchHelpers/CodeEmitter/ALUOps.inl"
+#include "Interface/Core/ArchHelpers/CodeEmitter/BranchOps.inl"
+#include "Interface/Core/ArchHelpers/CodeEmitter/LoadstoreOps.inl"
+#include "Interface/Core/ArchHelpers/CodeEmitter/SystemOps.inl"
+#include "Interface/Core/ArchHelpers/CodeEmitter/ScalarOps.inl"
+#include "Interface/Core/ArchHelpers/CodeEmitter/ASIMDOps.inl"
+#include "Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl"
+
+  private:
+    template<typename T>
+    uint32_t Encode_ra(T Reg) const {
+      return Reg.Idx() << 10;
+    }
+    uint32_t Encode_ra(uint32_t Reg) const {
+      return Reg << 10;
+    }
+    template<typename T>
+    uint32_t Encode_rt2(T Reg) const {
+      return Reg.Idx() << 10;
+    }
+    template<>
+    uint32_t Encode_rt2(uint32_t Reg) const {
+      return Reg << 10;
+    }
+    template<typename T>
+    uint32_t Encode_rm(T Reg) const {
+      return Reg.Idx() << 16;
+    }
+    uint32_t Encode_rm(uint32_t Reg) const {
+      return Reg << 16;
+    }
+    template<typename T>
+    uint32_t Encode_rs(T Reg) const {
+      return Reg.Idx() << 16;
+    }
+    uint32_t Encode_rs(uint32_t Reg) const {
+      return Reg << 16;
+    }
+    template<typename T>
+    uint32_t Encode_rn(T Reg) const {
+      return Reg.Idx() << 5;
+    }
+    uint32_t Encode_rn(uint32_t Reg) const {
+      return Reg << 5;
+    }
+    template<typename T>
+    uint32_t Encode_rd(T Reg) const {
+      return Reg.Idx();
+    }
+    uint32_t Encode_rd(uint32_t Reg) const {
+      return Reg;
+    }
+    template<typename T>
+    uint32_t Encode_rt(T Reg) const {
+      return Reg.Idx();
+    }
+    template<>
+    uint32_t Encode_rt(Prefetch Reg) const {
+      return FEXCore::ToUnderlying(Reg);
+    }
+    uint32_t Encode_rt(uint32_t Reg) const {
+      return Reg;
+    }
+    template<typename T>
+    uint32_t Encode_pd(T Reg) const {
+      return FEXCore::ToUnderlying(Reg);
+    }
+  };
+}

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/LoadstoreOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/LoadstoreOps.inl
@@ -1,0 +1,4906 @@
+/* Load-store instruction emitters
+ *
+ * For GPR load-stores that take a `Size` argument as their first argument can be 32-bit or 64-bit.
+ * For GPR load-stores that don't take a `Size` argument, then their operating size is determined by the name of the instruction.
+ *
+ * For Vector load-stores, most take a `SubRegSize` to determine the size of the elements getting loaded or stored.
+ * Depending on the instruction it can be an single element or the full instruction, it depends on the instruction.
+ *
+ * There are some load-store helper functions which take a `ExtendedMemOperand` argument.
+ * This helper will select the viable load-store that can work with the provided encapsulated arguments.
+ */
+public:
+  // Compare and swap pair
+  void casp(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rs2, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rt2, FEXCore::ARMEmitter::Register rn) {
+    LOGMAN_THROW_A_FMT((rs.Idx() + 1) == rs2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1000'001 << 21;
+    AtomicOp(Op, s, 0, 0, rs, rt, FEXCore::ARMEmitter::Reg::r31, rn);
+  }
+  void caspa(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rs2, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rt2, FEXCore::ARMEmitter::Register rn) {
+    LOGMAN_THROW_A_FMT((rs.Idx() + 1) == rs2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1000'001 << 21;
+    AtomicOp(Op, s, 1, 0, rs, rt, FEXCore::ARMEmitter::Reg::r31, rn);
+  }
+  void caspl(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rs2, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rt2, FEXCore::ARMEmitter::Register rn) {
+    LOGMAN_THROW_A_FMT((rs.Idx() + 1) == rs2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1000'001 << 21;
+    AtomicOp(Op, s, 0, 1, rs, rt, FEXCore::ARMEmitter::Reg::r31, rn);
+  }
+  void caspal(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rs2, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rt2, FEXCore::ARMEmitter::Register rn) {
+    LOGMAN_THROW_A_FMT((rs.Idx() + 1) == rs2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1000'001 << 21;
+    AtomicOp(Op, s, 1, 1, rs, rt, FEXCore::ARMEmitter::Reg::r31, rn);
+  }
+
+  // Advanced SIMD load/store multiple structures
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void ld1(T rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1100'000 << 21;
+    constexpr uint32_t Opcode = 0b0111 << 12;
+    ASIMDLoadStoreMultipleStructure<size, true>(Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r0);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void ld1(T rt, T rt2, FEXCore::ARMEmitter::Register rn) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1100'000 << 21;
+    constexpr uint32_t Opcode = 0b1010 << 12;
+    ASIMDLoadStoreMultipleStructure<size, true>(Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r0);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void ld1(T rt, T rt2, T rt3, FEXCore::ARMEmitter::Register rn) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1100'000 << 21;
+    constexpr uint32_t Opcode = 0b0110 << 12;
+    ASIMDLoadStoreMultipleStructure<size, true>(Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r0);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void ld1(T rt, T rt2, T rt3, T rt4, FEXCore::ARMEmitter::Register rn) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1100'000 << 21;
+    constexpr uint32_t Opcode = 0b0010 << 12;
+    ASIMDLoadStoreMultipleStructure<size, true>(Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r0);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void st1(T rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1100'000 << 21;
+    constexpr uint32_t Opcode = 0b0111 << 12;
+    ASIMDLoadStoreMultipleStructure<size, false>(Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r0);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void st1(T rt, T rt2, FEXCore::ARMEmitter::Register rn) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1100'000 << 21;
+    constexpr uint32_t Opcode = 0b1010 << 12;
+    ASIMDLoadStoreMultipleStructure<size, false>(Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r0);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void st1(T rt, T rt2, T rt3, FEXCore::ARMEmitter::Register rn) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1100'000 << 21;
+    constexpr uint32_t Opcode = 0b0110 << 12;
+    ASIMDLoadStoreMultipleStructure<size, false>(Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r0);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void st1(T rt, T rt2, T rt3, T rt4, FEXCore::ARMEmitter::Register rn) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1100'000 << 21;
+    constexpr uint32_t Opcode = 0b0010 << 12;
+    ASIMDLoadStoreMultipleStructure<size, false>(Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r0);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void ld2(T rt, T rt2, FEXCore::ARMEmitter::Register rn) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1100'000 << 21;
+    constexpr uint32_t Opcode = 0b1000 << 12;
+    ASIMDLoadStoreMultipleStructure<size, true>(Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r0);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void st2(T rt, T rt2, FEXCore::ARMEmitter::Register rn) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1100'000 << 21;
+    constexpr uint32_t Opcode = 0b1000 << 12;
+    ASIMDLoadStoreMultipleStructure<size, false>(Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r0);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void ld3(T rt, T rt2, T rt3, FEXCore::ARMEmitter::Register rn) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1100'000 << 21;
+    constexpr uint32_t Opcode = 0b0100 << 12;
+    ASIMDLoadStoreMultipleStructure<size, true>(Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r0);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void st3(T rt, T rt2, T rt3, FEXCore::ARMEmitter::Register rn) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1100'000 << 21;
+    constexpr uint32_t Opcode = 0b0100 << 12;
+    ASIMDLoadStoreMultipleStructure<size, false>(Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r0);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void ld4(T rt, T rt2, T rt3, T rt4, FEXCore::ARMEmitter::Register rn) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1100'000 << 21;
+    constexpr uint32_t Opcode = 0b0000 << 12;
+    ASIMDLoadStoreMultipleStructure<size, true>(Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r0);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void st4(T rt, T rt2, T rt3, T rt4, FEXCore::ARMEmitter::Register rn) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1100'000 << 21;
+    constexpr uint32_t Opcode = 0b0000 << 12;
+    ASIMDLoadStoreMultipleStructure<size, false>(Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r0);
+  }
+  // Advanced SIMD load/store multiple structures (post-indexed)
+  static constexpr uint32_t ASIMDLoadstoreMultiplePost_Op = 0b0000'1100'100 << 21;
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void ld1(T rt, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    constexpr uint32_t Opcode = 0b0111 << 12;
+    ASIMDLoadStoreMultipleStructure<size, true>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, rm);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void ld1(T rt, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT(
+      (std::is_same_v<FEXCore::ARMEmitter::QRegister, T> && (PostOffset == 16)) ||
+      (std::is_same_v<FEXCore::ARMEmitter::DRegister, T> && (PostOffset == 8)),
+      "Post-index offset needs to match number of elements times their size");
+
+    constexpr uint32_t Opcode = 0b0111 << 12;
+    ASIMDLoadStoreMultipleStructure<size, true>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r31);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void ld1(T rt, T rt2, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    constexpr uint32_t Opcode = 0b1010 << 12;
+    ASIMDLoadStoreMultipleStructure<size, true>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, rm);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void ld1(T rt, T rt2, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT(
+      (std::is_same_v<FEXCore::ARMEmitter::QRegister, T> && (PostOffset == 32)) ||
+      (std::is_same_v<FEXCore::ARMEmitter::DRegister, T> && (PostOffset == 16)),
+      "Post-index offset needs to match number of elements times their size");
+
+    constexpr uint32_t Opcode = 0b1010 << 12;
+    ASIMDLoadStoreMultipleStructure<size, true>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r31);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void ld1(T rt, T rt2, T rt3, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    constexpr uint32_t Opcode = 0b0110 << 12;
+    ASIMDLoadStoreMultipleStructure<size, true>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, rm);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void ld1(T rt, T rt2, T rt3, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT(
+      (std::is_same_v<FEXCore::ARMEmitter::QRegister, T> && (PostOffset == 48)) ||
+      (std::is_same_v<FEXCore::ARMEmitter::DRegister, T> && (PostOffset == 24)),
+      "Post-index offset needs to match number of elements times their size");
+
+    constexpr uint32_t Opcode = 0b0110 << 12;
+    ASIMDLoadStoreMultipleStructure<size, true>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r31);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void ld1(T rt, T rt2, T rt3, T rt4, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+    constexpr uint32_t Opcode = 0b0010 << 12;
+    ASIMDLoadStoreMultipleStructure<size, true>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, rm);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void ld1(T rt, T rt2, T rt3, T rt4, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT(
+      (std::is_same_v<FEXCore::ARMEmitter::QRegister, T> && (PostOffset == 64)) ||
+      (std::is_same_v<FEXCore::ARMEmitter::DRegister, T> && (PostOffset == 32)),
+      "Post-index offset needs to match number of elements times their size");
+
+    constexpr uint32_t Opcode = 0b0010 << 12;
+    ASIMDLoadStoreMultipleStructure<size, true>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r31);
+  }
+
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void st1(T rt, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    constexpr uint32_t Opcode = 0b0111 << 12;
+    ASIMDLoadStoreMultipleStructure<size, false>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, rm);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void st1(T rt, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT(
+      (std::is_same_v<FEXCore::ARMEmitter::QRegister, T> && (PostOffset == 16)) ||
+      (std::is_same_v<FEXCore::ARMEmitter::DRegister, T> && (PostOffset == 8)),
+      "Post-index offset needs to match number of elements times their size");
+
+    constexpr uint32_t Opcode = 0b0111 << 12;
+    ASIMDLoadStoreMultipleStructure<size, false>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r31);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void st1(T rt, T rt2, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    constexpr uint32_t Opcode = 0b1010 << 12;
+    ASIMDLoadStoreMultipleStructure<size, false>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, rm);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void st1(T rt, T rt2, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT(
+      (std::is_same_v<FEXCore::ARMEmitter::QRegister, T> && (PostOffset == 32)) ||
+      (std::is_same_v<FEXCore::ARMEmitter::DRegister, T> && (PostOffset == 16)),
+      "Post-index offset needs to match number of elements times their size");
+
+    constexpr uint32_t Opcode = 0b1010 << 12;
+    ASIMDLoadStoreMultipleStructure<size, false>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r31);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void st1(T rt, T rt2, T rt3, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    constexpr uint32_t Opcode = 0b0110 << 12;
+    ASIMDLoadStoreMultipleStructure<size, false>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, rm);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void st1(T rt, T rt2, T rt3, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT(
+      (std::is_same_v<FEXCore::ARMEmitter::QRegister, T> && (PostOffset == 48)) ||
+      (std::is_same_v<FEXCore::ARMEmitter::DRegister, T> && (PostOffset == 24)),
+      "Post-index offset needs to match number of elements times their size");
+
+    constexpr uint32_t Opcode = 0b0110 << 12;
+    ASIMDLoadStoreMultipleStructure<size, false>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r31);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void st1(T rt, T rt2, T rt3, T rt4, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+    constexpr uint32_t Opcode = 0b0010 << 12;
+    ASIMDLoadStoreMultipleStructure<size, false>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, rm);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void st1(T rt, T rt2, T rt3, T rt4, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT(
+      (std::is_same_v<FEXCore::ARMEmitter::QRegister, T> && (PostOffset == 64)) ||
+      (std::is_same_v<FEXCore::ARMEmitter::DRegister, T> && (PostOffset == 32)),
+      "Post-index offset needs to match number of elements times their size");
+
+    constexpr uint32_t Opcode = 0b0010 << 12;
+    ASIMDLoadStoreMultipleStructure<size, false>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r31);
+  }
+
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void ld2(T rt, T rt2, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    constexpr uint32_t Opcode = 0b1000 << 12;
+    ASIMDLoadStoreMultipleStructure<size, true>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, rm);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void ld2(T rt, T rt2, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT(
+      (std::is_same_v<FEXCore::ARMEmitter::QRegister, T> && (PostOffset == 32)) ||
+      (std::is_same_v<FEXCore::ARMEmitter::DRegister, T> && (PostOffset == 16)),
+      "Post-index offset needs to match number of elements times their size");
+
+    constexpr uint32_t Opcode = 0b1000 << 12;
+    ASIMDLoadStoreMultipleStructure<size, true>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r31);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void st2(T rt, T rt2, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    constexpr uint32_t Opcode = 0b1000 << 12;
+    ASIMDLoadStoreMultipleStructure<size, false>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, rm);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void st2(T rt, T rt2, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT(
+      (std::is_same_v<FEXCore::ARMEmitter::QRegister, T> && (PostOffset == 32)) ||
+      (std::is_same_v<FEXCore::ARMEmitter::DRegister, T> && (PostOffset == 16)),
+      "Post-index offset needs to match number of elements times their size");
+
+    constexpr uint32_t Opcode = 0b1000 << 12;
+    ASIMDLoadStoreMultipleStructure<size, false>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r31);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void ld3(T rt, T rt2, T rt3, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    constexpr uint32_t Opcode = 0b0100 << 12;
+    ASIMDLoadStoreMultipleStructure<size, true>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, rm);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void ld3(T rt, T rt2, T rt3, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT(
+      (std::is_same_v<FEXCore::ARMEmitter::QRegister, T> && (PostOffset == 48)) ||
+      (std::is_same_v<FEXCore::ARMEmitter::DRegister, T> && (PostOffset == 24)),
+      "Post-index offset needs to match number of elements times their size");
+
+    constexpr uint32_t Opcode = 0b0100 << 12;
+    ASIMDLoadStoreMultipleStructure<size, true>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r31);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void st3(T rt, T rt2, T rt3, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    constexpr uint32_t Opcode = 0b0100 << 12;
+    ASIMDLoadStoreMultipleStructure<size, false>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, rm);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void st3(T rt, T rt2, T rt3, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT(
+      (std::is_same_v<FEXCore::ARMEmitter::QRegister, T> && (PostOffset == 48)) ||
+      (std::is_same_v<FEXCore::ARMEmitter::DRegister, T> && (PostOffset == 24)),
+      "Post-index offset needs to match number of elements times their size");
+
+    constexpr uint32_t Opcode = 0b0100 << 12;
+    ASIMDLoadStoreMultipleStructure<size, false>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r31);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void ld4(T rt, T rt2, T rt3, T rt4, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+    constexpr uint32_t Opcode = 0b0000 << 12;
+    ASIMDLoadStoreMultipleStructure<size, true>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, rm);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void ld4(T rt, T rt2, T rt3, T rt4, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT(
+      (std::is_same_v<FEXCore::ARMEmitter::QRegister, T> && (PostOffset == 64)) ||
+      (std::is_same_v<FEXCore::ARMEmitter::DRegister, T> && (PostOffset == 32)),
+      "Post-index offset needs to match number of elements times their size");
+
+    constexpr uint32_t Opcode = 0b0000 << 12;
+    ASIMDLoadStoreMultipleStructure<size, true>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r31);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void st4(T rt, T rt2, T rt3, T rt4, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+    constexpr uint32_t Opcode = 0b0000 << 12;
+    ASIMDLoadStoreMultipleStructure<size, false>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, rm);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void st4(T rt, T rt2, T rt3, T rt4, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT(
+      (std::is_same_v<FEXCore::ARMEmitter::QRegister, T> && (PostOffset == 64)) ||
+      (std::is_same_v<FEXCore::ARMEmitter::DRegister, T> && (PostOffset == 32)),
+      "Post-index offset needs to match number of elements times their size");
+
+    constexpr uint32_t Opcode = 0b0000 << 12;
+    ASIMDLoadStoreMultipleStructure<size, false>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r31);
+  }
+
+  // ASIMD loadstore single
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void st1(FEXCore::ARMEmitter::VRegister rt, uint32_t Index, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1101'000 << 21;
+    constexpr uint32_t Opcode =
+        size == SubRegSize::i8Bit  ? 0b000 : // Scale = 0
+        size == SubRegSize::i16Bit ? 0b010 : // Scale = 1
+        size == SubRegSize::i32Bit ? 0b100 : // Scale = 2
+        size == SubRegSize::i64Bit ? 0b100 : // Scale = 2 (Uses size to determine difference between 32-bit).
+        0;
+    ASIMDSTLD<size, false, 1>(Op, Opcode, rt, Index, rn, FEXCore::ARMEmitter::Reg::r0);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void st2(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::VRegister rt2, uint32_t Index, FEXCore::ARMEmitter::Register rn) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1101'000 << 21;
+    constexpr uint32_t Opcode =
+        size == SubRegSize::i8Bit  ? 0b000 : // Scale = 0
+        size == SubRegSize::i16Bit ? 0b010 : // Scale = 1
+        size == SubRegSize::i32Bit ? 0b100 : // Scale = 2
+        size == SubRegSize::i64Bit ? 0b100 : // Scale = 2 (Uses size to determine difference between 32-bit).
+        0;
+    ASIMDSTLD<size, false, 2>(Op, Opcode, rt, Index, rn, FEXCore::ARMEmitter::Reg::r0);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void st3(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::VRegister rt2, FEXCore::ARMEmitter::VRegister rt3, uint32_t Index, FEXCore::ARMEmitter::Register rn) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1101'000 << 21;
+    constexpr uint32_t Opcode =
+        size == SubRegSize::i8Bit  ? 0b000 : // Scale = 0
+        size == SubRegSize::i16Bit ? 0b010 : // Scale = 1
+        size == SubRegSize::i32Bit ? 0b100 : // Scale = 2
+        size == SubRegSize::i64Bit ? 0b100 : // Scale = 2 (Uses size to determine difference between 32-bit).
+        0;
+    ASIMDSTLD<size, false, 3>(Op, Opcode, rt, Index, rn, FEXCore::ARMEmitter::Reg::r0);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void st4(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::VRegister rt2, FEXCore::ARMEmitter::VRegister rt3, FEXCore::ARMEmitter::VRegister rt4, uint32_t Index, FEXCore::ARMEmitter::Register rn) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1101'000 << 21;
+    constexpr uint32_t Opcode =
+        size == SubRegSize::i8Bit  ? 0b000 : // Scale = 0
+        size == SubRegSize::i16Bit ? 0b010 : // Scale = 1
+        size == SubRegSize::i32Bit ? 0b100 : // Scale = 2
+        size == SubRegSize::i64Bit ? 0b100 : // Scale = 2 (Uses size to determine difference between 32-bit).
+        0;
+    ASIMDSTLD<size, false, 4>(Op, Opcode, rt, Index, rn, FEXCore::ARMEmitter::Reg::r0);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void ld1(FEXCore::ARMEmitter::VRegister rt, uint32_t Index, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1101'000 << 21;
+    constexpr uint32_t Opcode =
+        size == SubRegSize::i8Bit  ? 0b000 : // Scale = 0
+        size == SubRegSize::i16Bit ? 0b010 : // Scale = 1
+        size == SubRegSize::i32Bit ? 0b100 : // Scale = 2
+        size == SubRegSize::i64Bit ? 0b100 : // Scale = 2 (Uses size to determine difference between 32-bit).
+        0;
+    ASIMDSTLD<size, true, 1>(Op, Opcode, rt, Index, rn, FEXCore::ARMEmitter::Reg::r0);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void ld1r(T rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1101'000 << 21;
+    constexpr uint32_t Opcode = 0b110;
+    ASIMDSTLD<size, true, 1>(Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r0);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void ld2(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::VRegister rt2, uint32_t Index, FEXCore::ARMEmitter::Register rn) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1101'000 << 21;
+    constexpr uint32_t Opcode =
+        size == SubRegSize::i8Bit  ? 0b000 : // Scale = 0
+        size == SubRegSize::i16Bit ? 0b010 : // Scale = 1
+        size == SubRegSize::i32Bit ? 0b100 : // Scale = 2
+        size == SubRegSize::i64Bit ? 0b100 : // Scale = 2 (Uses size to determine difference between 32-bit).
+        0;
+    ASIMDSTLD<size, true, 2>(Op, Opcode, rt, Index, rn, FEXCore::ARMEmitter::Reg::r0);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void ld2r(T rt, T rt2, FEXCore::ARMEmitter::Register rn) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1101'000 << 21;
+    constexpr uint32_t Opcode = 0b110;
+    ASIMDSTLD<size, true, 2>(Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r0);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void ld3(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::VRegister rt2, FEXCore::ARMEmitter::VRegister rt3, uint32_t Index, FEXCore::ARMEmitter::Register rn) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1101'000 << 21;
+    constexpr uint32_t Opcode =
+        size == SubRegSize::i8Bit  ? 0b000 : // Scale = 0
+        size == SubRegSize::i16Bit ? 0b010 : // Scale = 1
+        size == SubRegSize::i32Bit ? 0b100 : // Scale = 2
+        size == SubRegSize::i64Bit ? 0b100 : // Scale = 2 (Uses size to determine difference between 32-bit).
+        0;
+    ASIMDSTLD<size, true, 3>(Op, Opcode, rt, Index, rn, FEXCore::ARMEmitter::Reg::r0);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void ld3r(T rt, T rt2, T rt3, FEXCore::ARMEmitter::Register rn) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1101'000 << 21;
+    constexpr uint32_t Opcode = 0b110;
+    ASIMDSTLD<size, true, 3>(Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r0);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void ld4(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::VRegister rt2, FEXCore::ARMEmitter::VRegister rt3, FEXCore::ARMEmitter::VRegister rt4, uint32_t Index, FEXCore::ARMEmitter::Register rn) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1101'000 << 21;
+    constexpr uint32_t Opcode =
+        size == SubRegSize::i8Bit  ? 0b000 : // Scale = 0
+        size == SubRegSize::i16Bit ? 0b010 : // Scale = 1
+        size == SubRegSize::i32Bit ? 0b100 : // Scale = 2
+        size == SubRegSize::i64Bit ? 0b100 : // Scale = 2 (Uses size to determine difference between 32-bit).
+        0;
+    ASIMDSTLD<size, true, 4>(Op, Opcode, rt, Index, rn, FEXCore::ARMEmitter::Reg::r0);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void ld4r(T rt, T rt2, T rt3, T rt4, FEXCore::ARMEmitter::Register rn) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1101'000 << 21;
+    constexpr uint32_t Opcode = 0b110;
+    ASIMDSTLD<size, true, 4>(Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r0);
+  }
+
+  // ASIMD loadstore single post-indexed
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void st1(FEXCore::ARMEmitter::VRegister rt, uint32_t Index, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    constexpr uint32_t Op = 0b0000'1101'100 << 21;
+    constexpr uint32_t Opcode =
+        size == SubRegSize::i8Bit  ? 0b000 : // Scale = 0
+        size == SubRegSize::i16Bit ? 0b010 : // Scale = 1
+        size == SubRegSize::i32Bit ? 0b100 : // Scale = 2
+        size == SubRegSize::i64Bit ? 0b100 : // Scale = 2 (Uses size to determine difference between 32-bit).
+        0;
+    ASIMDSTLD<size, false, 1>(Op, Opcode, rt, Index, rn, rm);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void st1(FEXCore::ARMEmitter::VRegister rt, uint32_t Index, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT(
+      (size == SubRegSize::i8Bit && (PostOffset == 1)) ||
+      (size == SubRegSize::i16Bit && (PostOffset == 2)) ||
+      (size == SubRegSize::i32Bit && (PostOffset == 4)) ||
+      (size == SubRegSize::i64Bit && (PostOffset == 8)), "Post-index offset needs to match number of elements times their size");
+
+    constexpr uint32_t Op = 0b0000'1101'100 << 21;
+    constexpr uint32_t Opcode =
+        size == SubRegSize::i8Bit  ? 0b000 : // Scale = 0
+        size == SubRegSize::i16Bit ? 0b010 : // Scale = 1
+        size == SubRegSize::i32Bit ? 0b100 : // Scale = 2
+        size == SubRegSize::i64Bit ? 0b100 : // Scale = 2 (Uses size to determine difference between 32-bit).
+        0;
+    ASIMDSTLD<size, false, 1>(Op, Opcode, rt, Index, rn, FEXCore::ARMEmitter::Reg::r31);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void st2(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::VRegister rt2, uint32_t Index, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1101'100 << 21;
+    constexpr uint32_t Opcode =
+        size == SubRegSize::i8Bit  ? 0b000 : // Scale = 0
+        size == SubRegSize::i16Bit ? 0b010 : // Scale = 1
+        size == SubRegSize::i32Bit ? 0b100 : // Scale = 2
+        size == SubRegSize::i64Bit ? 0b100 : // Scale = 2 (Uses size to determine difference between 32-bit).
+        0;
+    ASIMDSTLD<size, false, 2>(Op, Opcode, rt, Index, rn, rm);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void st2(FEXCore::ARMEmitter::VRegister rt, uint32_t Index, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT(
+      (size == SubRegSize::i8Bit && (PostOffset == 2)) ||
+      (size == SubRegSize::i16Bit && (PostOffset == 4)) ||
+      (size == SubRegSize::i32Bit && (PostOffset == 8)) ||
+      (size == SubRegSize::i64Bit && (PostOffset == 16)), "Post-index offset needs to match number of elements times their size");
+
+    constexpr uint32_t Op = 0b0000'1101'100 << 21;
+    constexpr uint32_t Opcode =
+        size == SubRegSize::i8Bit  ? 0b000 : // Scale = 0
+        size == SubRegSize::i16Bit ? 0b010 : // Scale = 1
+        size == SubRegSize::i32Bit ? 0b100 : // Scale = 2
+        size == SubRegSize::i64Bit ? 0b100 : // Scale = 2 (Uses size to determine difference between 32-bit).
+        0;
+    ASIMDSTLD<size, false, 2>(Op, Opcode, rt, Index, rn, FEXCore::ARMEmitter::Reg::r31);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void st3(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::VRegister rt2, FEXCore::ARMEmitter::VRegister rt3, uint32_t Index, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1101'100 << 21;
+    constexpr uint32_t Opcode =
+        size == SubRegSize::i8Bit  ? 0b000 : // Scale = 0
+        size == SubRegSize::i16Bit ? 0b010 : // Scale = 1
+        size == SubRegSize::i32Bit ? 0b100 : // Scale = 2
+        size == SubRegSize::i64Bit ? 0b100 : // Scale = 2 (Uses size to determine difference between 32-bit).
+        0;
+    ASIMDSTLD<size, false, 3>(Op, Opcode, rt, Index, rn, rm);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void st3(FEXCore::ARMEmitter::VRegister rt, uint32_t Index, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT(
+      (size == SubRegSize::i8Bit && (PostOffset == 3)) ||
+      (size == SubRegSize::i16Bit && (PostOffset == 6)) ||
+      (size == SubRegSize::i32Bit && (PostOffset == 8)) ||
+      (size == SubRegSize::i64Bit && (PostOffset == 24)), "Post-index offset needs to match number of elements times their size");
+
+    constexpr uint32_t Op = 0b0000'1101'100 << 21;
+    constexpr uint32_t Opcode =
+        size == SubRegSize::i8Bit  ? 0b000 : // Scale = 0
+        size == SubRegSize::i16Bit ? 0b010 : // Scale = 1
+        size == SubRegSize::i32Bit ? 0b100 : // Scale = 2
+        size == SubRegSize::i64Bit ? 0b100 : // Scale = 2 (Uses size to determine difference between 32-bit).
+        0;
+    ASIMDSTLD<size, false, 3>(Op, Opcode, rt, Index, rn, FEXCore::ARMEmitter::Reg::r31);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void st4(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::VRegister rt2, FEXCore::ARMEmitter::VRegister rt3, FEXCore::ARMEmitter::VRegister rt4, uint32_t Index, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1101'100 << 21;
+    constexpr uint32_t Opcode =
+        size == SubRegSize::i8Bit  ? 0b000 : // Scale = 0
+        size == SubRegSize::i16Bit ? 0b010 : // Scale = 1
+        size == SubRegSize::i32Bit ? 0b100 : // Scale = 2
+        size == SubRegSize::i64Bit ? 0b100 : // Scale = 2 (Uses size to determine difference between 32-bit).
+        0;
+    ASIMDSTLD<size, false, 4>(Op, Opcode, rt, Index, rn, rm);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void st4(FEXCore::ARMEmitter::VRegister rt, uint32_t Index, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT(
+      (size == SubRegSize::i8Bit && (PostOffset == 4)) ||
+      (size == SubRegSize::i16Bit && (PostOffset == 8)) ||
+      (size == SubRegSize::i32Bit && (PostOffset == 16)) ||
+      (size == SubRegSize::i64Bit && (PostOffset == 32)), "Post-index offset needs to match number of elements times their size");
+
+    constexpr uint32_t Op = 0b0000'1101'100 << 21;
+    constexpr uint32_t Opcode =
+        size == SubRegSize::i8Bit  ? 0b000 : // Scale = 0
+        size == SubRegSize::i16Bit ? 0b010 : // Scale = 1
+        size == SubRegSize::i32Bit ? 0b100 : // Scale = 2
+        size == SubRegSize::i64Bit ? 0b100 : // Scale = 2 (Uses size to determine difference between 32-bit).
+        0;
+    ASIMDSTLD<size, false, 4>(Op, Opcode, rt, Index, rn, FEXCore::ARMEmitter::Reg::r31);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void ld1(FEXCore::ARMEmitter::VRegister rt, uint32_t Index, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    constexpr uint32_t Op = 0b0000'1101'100 << 21;
+    constexpr uint32_t Opcode =
+        size == SubRegSize::i8Bit  ? 0b000 : // Scale = 0
+        size == SubRegSize::i16Bit ? 0b010 : // Scale = 1
+        size == SubRegSize::i32Bit ? 0b100 : // Scale = 2
+        size == SubRegSize::i64Bit ? 0b100 : // Scale = 2 (Uses size to determine difference between 32-bit).
+        0;
+    ASIMDSTLD<size, true, 1>(Op, Opcode, rt, Index, rn, rm);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void ld1(FEXCore::ARMEmitter::VRegister rt, uint32_t Index, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT(
+      (size == SubRegSize::i8Bit && (PostOffset == 1)) ||
+      (size == SubRegSize::i16Bit && (PostOffset == 2)) ||
+      (size == SubRegSize::i32Bit && (PostOffset == 4)) ||
+      (size == SubRegSize::i64Bit && (PostOffset == 8)), "Post-index offset needs to match number of elements times their size");
+    constexpr uint32_t Op = 0b0000'1101'100 << 21;
+    constexpr uint32_t Opcode =
+        size == SubRegSize::i8Bit  ? 0b000 : // Scale = 0
+        size == SubRegSize::i16Bit ? 0b010 : // Scale = 1
+        size == SubRegSize::i32Bit ? 0b100 : // Scale = 2
+        size == SubRegSize::i64Bit ? 0b100 : // Scale = 2 (Uses size to determine difference between 32-bit).
+        0;
+    ASIMDSTLD<size, true, 1>(Op, Opcode, rt, Index, rn, FEXCore::ARMEmitter::Reg::r31);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void ld1r(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    constexpr uint32_t Op = 0b0000'1101'100 << 21;
+    constexpr uint32_t Opcode = 0b110;
+    ASIMDSTLD<size, true, 1>(Op, Opcode, rt, 0, rn, rm);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void ld1r(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT(
+      (size == SubRegSize::i8Bit && (PostOffset == 1)) ||
+      (size == SubRegSize::i16Bit && (PostOffset == 2)) ||
+      (size == SubRegSize::i32Bit && (PostOffset == 4)) ||
+      (size == SubRegSize::i64Bit && (PostOffset == 8)), "Post-index offset needs to match number of elements times their size");
+    constexpr uint32_t Op = 0b0000'1101'100 << 21;
+    constexpr uint32_t Opcode = 0b110;
+    ASIMDSTLD<size, true, 1>(Op, Opcode, rt, 0, rn, FEXCore::ARMEmitter::Reg::r31);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void ld2(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::VRegister rt2, uint32_t Index, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1101'100 << 21;
+    constexpr uint32_t Opcode =
+        size == SubRegSize::i8Bit  ? 0b000 : // Scale = 0
+        size == SubRegSize::i16Bit ? 0b010 : // Scale = 1
+        size == SubRegSize::i32Bit ? 0b100 : // Scale = 2
+        size == SubRegSize::i64Bit ? 0b100 : // Scale = 2 (Uses size to determine difference between 32-bit).
+        0;
+    ASIMDSTLD<size, true, 2>(Op, Opcode, rt, Index, rn, rm);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void ld2(FEXCore::ARMEmitter::VRegister rt, uint32_t Index, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT(
+      (size == SubRegSize::i8Bit && (PostOffset == 2)) ||
+      (size == SubRegSize::i16Bit && (PostOffset == 4)) ||
+      (size == SubRegSize::i32Bit && (PostOffset == 8)) ||
+      (size == SubRegSize::i64Bit && (PostOffset == 16)), "Post-index offset needs to match number of elements times their size");
+    constexpr uint32_t Op = 0b0000'1101'100 << 21;
+    constexpr uint32_t Opcode =
+        size == SubRegSize::i8Bit  ? 0b000 : // Scale = 0
+        size == SubRegSize::i16Bit ? 0b010 : // Scale = 1
+        size == SubRegSize::i32Bit ? 0b100 : // Scale = 2
+        size == SubRegSize::i64Bit ? 0b100 : // Scale = 2 (Uses size to determine difference between 32-bit).
+        0;
+    ASIMDSTLD<size, true, 2>(Op, Opcode, rt, Index, rn, FEXCore::ARMEmitter::Reg::r31);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void ld2r(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::VRegister rt2, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1101'100 << 21;
+    constexpr uint32_t Opcode = 0b110;
+    ASIMDSTLD<size, true, 2>(Op, Opcode, rt, 0, rn, rm);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void ld2r(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::VRegister rt2, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT(
+      (size == SubRegSize::i8Bit && (PostOffset == 2)) ||
+      (size == SubRegSize::i16Bit && (PostOffset == 4)) ||
+      (size == SubRegSize::i32Bit && (PostOffset == 8)) ||
+      (size == SubRegSize::i64Bit && (PostOffset == 16)), "Post-index offset needs to match number of elements times their size");
+    constexpr uint32_t Op = 0b0000'1101'100 << 21;
+    constexpr uint32_t Opcode = 0b110;
+    ASIMDSTLD<size, true, 2>(Op, Opcode, rt, 0, rn, FEXCore::ARMEmitter::Reg::r31);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void ld3(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::VRegister rt2, FEXCore::ARMEmitter::VRegister rt3, uint32_t Index, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1101'100 << 21;
+    constexpr uint32_t Opcode =
+        size == SubRegSize::i8Bit  ? 0b000 : // Scale = 0
+        size == SubRegSize::i16Bit ? 0b010 : // Scale = 1
+        size == SubRegSize::i32Bit ? 0b100 : // Scale = 2
+        size == SubRegSize::i64Bit ? 0b100 : // Scale = 2 (Uses size to determine difference between 32-bit).
+        0;
+    ASIMDSTLD<size, true, 3>(Op, Opcode, rt, Index, rn, rm);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void ld3(FEXCore::ARMEmitter::VRegister rt, uint32_t Index, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT(
+      (size == SubRegSize::i8Bit && (PostOffset == 3)) ||
+      (size == SubRegSize::i16Bit && (PostOffset == 6)) ||
+      (size == SubRegSize::i32Bit && (PostOffset == 12)) ||
+      (size == SubRegSize::i64Bit && (PostOffset == 16)), "Post-index offset needs to match number of elements times their size");
+    constexpr uint32_t Op = 0b0000'1101'100 << 21;
+    constexpr uint32_t Opcode =
+        size == SubRegSize::i8Bit  ? 0b000 : // Scale = 0
+        size == SubRegSize::i16Bit ? 0b010 : // Scale = 1
+        size == SubRegSize::i32Bit ? 0b100 : // Scale = 2
+        size == SubRegSize::i64Bit ? 0b100 : // Scale = 2 (Uses size to determine difference between 32-bit).
+        0;
+    ASIMDSTLD<size, true, 3>(Op, Opcode, rt, Index, rn, FEXCore::ARMEmitter::Reg::r31);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void ld3r(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::VRegister rt2, FEXCore::ARMEmitter::VRegister rt3, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1101'100 << 21;
+    constexpr uint32_t Opcode = 0b110;
+    ASIMDSTLD<size, true, 3>(Op, Opcode, rt, 0, rn, rm);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void ld3r(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::VRegister rt2, FEXCore::ARMEmitter::VRegister rt3, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT(
+      (size == SubRegSize::i8Bit && (PostOffset == 3)) ||
+      (size == SubRegSize::i16Bit && (PostOffset == 6)) ||
+      (size == SubRegSize::i32Bit && (PostOffset == 12)) ||
+      (size == SubRegSize::i64Bit && (PostOffset == 16)), "Post-index offset needs to match number of elements times their size");
+    constexpr uint32_t Op = 0b0000'1101'100 << 21;
+    constexpr uint32_t Opcode = 0b110;
+    ASIMDSTLD<size, true, 3>(Op, Opcode, rt, 0, rn, FEXCore::ARMEmitter::Reg::r31);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void ld4(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::VRegister rt2, FEXCore::ARMEmitter::VRegister rt3, FEXCore::ARMEmitter::VRegister rt4, uint32_t Index, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1101'100 << 21;
+    constexpr uint32_t Opcode =
+        size == SubRegSize::i8Bit  ? 0b000 : // Scale = 0
+        size == SubRegSize::i16Bit ? 0b010 : // Scale = 1
+        size == SubRegSize::i32Bit ? 0b100 : // Scale = 2
+        size == SubRegSize::i64Bit ? 0b100 : // Scale = 2 (Uses size to determine difference between 32-bit).
+        0;
+    ASIMDSTLD<size, true, 4>(Op, Opcode, rt, Index, rn, rm);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void ld4(FEXCore::ARMEmitter::VRegister rt, uint32_t Index, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT(
+      (size == SubRegSize::i8Bit && (PostOffset == 4)) ||
+      (size == SubRegSize::i16Bit && (PostOffset == 8)) ||
+      (size == SubRegSize::i32Bit && (PostOffset == 16)) ||
+      (size == SubRegSize::i64Bit && (PostOffset == 32)), "Post-index offset needs to match number of elements times their size");
+    constexpr uint32_t Op = 0b0000'1101'100 << 21;
+    constexpr uint32_t Opcode =
+        size == SubRegSize::i8Bit  ? 0b000 : // Scale = 0
+        size == SubRegSize::i16Bit ? 0b010 : // Scale = 1
+        size == SubRegSize::i32Bit ? 0b100 : // Scale = 2
+        size == SubRegSize::i64Bit ? 0b100 : // Scale = 2 (Uses size to determine difference between 32-bit).
+        0;
+    ASIMDSTLD<size, true, 4>(Op, Opcode, rt, Index, rn, FEXCore::ARMEmitter::Reg::r31);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void ld4r(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::VRegister rt2, FEXCore::ARMEmitter::VRegister rt3, FEXCore::ARMEmitter::VRegister rt4, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1101'100 << 21;
+    constexpr uint32_t Opcode = 0b110;
+    ASIMDSTLD<size, true, 4>(Op, Opcode, rt, 0, rn, rm);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void ld4r(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::VRegister rt2, FEXCore::ARMEmitter::VRegister rt3, FEXCore::ARMEmitter::VRegister rt4, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT(
+      (size == SubRegSize::i8Bit && (PostOffset == 4)) ||
+      (size == SubRegSize::i16Bit && (PostOffset == 8)) ||
+      (size == SubRegSize::i32Bit && (PostOffset == 16)) ||
+      (size == SubRegSize::i64Bit && (PostOffset == 32)), "Post-index offset needs to match number of elements times their size");
+    constexpr uint32_t Op = 0b0000'1101'100 << 21;
+    constexpr uint32_t Opcode = 0b110;
+    ASIMDSTLD<size, true, 4>(Op, Opcode, rt, 0, rn, FEXCore::ARMEmitter::Reg::r31);
+  }
+
+  // Advanced SIMD load/store single structure (post-indexed)
+  template<typename T>
+  void st1(FEXCore::ARMEmitter::SubRegSize size, T rt, uint32_t Index, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    constexpr uint32_t Op = 0b0000'1101'1 << 23;
+    uint32_t Q;
+    uint32_t R = 0;
+    uint32_t opcode;
+    uint32_t S;
+    uint32_t Size;
+    if (size == SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 16, "Index too large");
+      Q = Index >> 3;
+      S = (Index >> 2) & 1;
+      opcode = 0b000;
+      Size = Index & 0b11;
+    }
+    else if (size == SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 8, "Index too large");
+      Q = Index >> 2;
+      S = (Index >> 1) & 1;
+      opcode = 0b010;
+      Size = (Index & 0b1) << 1;
+    }
+    else if (size == SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 4, "Index too large");
+      Q = Index >> 1;
+      S = Index & 1;
+      opcode = 0b100;
+      Size = 0b00;
+    }
+    else if (size == SubRegSize::i64Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 2, "Index too large");
+      Q = Index;
+      S = 0;
+      opcode = 0b100;
+      Size = 0b01;
+    }
+    else {
+      LOGMAN_MSG_A_FMT("Unknown size");
+      FEX_UNREACHABLE;
+    }
+
+    ASIMDLoadStoreSinglePost(Op, Q, 0, R, opcode, S, Size, FEXCore::ARMEmitter::Reg::r31, rn, rt.Q());
+  }
+  template<typename T>
+  void ld1(FEXCore::ARMEmitter::SubRegSize size, T rt, uint32_t Index, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    constexpr uint32_t Op = 0b0000'1101'1 << 23;
+    uint32_t Q;
+    uint32_t R = 0;
+    uint32_t opcode;
+    uint32_t S;
+    uint32_t Size;
+    if (size == SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 16, "Index too large");
+      Q = Index >> 3;
+      S = (Index >> 2) & 1;
+      opcode = 0b001;
+      Size = Index & 0b11;
+    }
+    else if (size == SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 8, "Index too large");
+      Q = Index >> 2;
+      S = (Index >> 1) & 1;
+      opcode = 0b011;
+      Size = (Index & 0b1) << 1;
+    }
+    else if (size == SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 4, "Index too large");
+      Q = Index >> 1;
+      S = Index & 1;
+      opcode = 0b100;
+      Size = 0b00;
+    }
+    else if (size == SubRegSize::i64Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 2, "Index too large");
+      Q = Index;
+      S = 0;
+      opcode = 0b101;
+      Size = 0b01;
+    }
+    else {
+      LOGMAN_MSG_A_FMT("Unknown size");
+      FEX_UNREACHABLE;
+    }
+
+    ASIMDLoadStoreSinglePost(Op, Q, 1, R, opcode, S, Size, FEXCore::ARMEmitter::Reg::r31, rn, rt.Q());
+  }
+  template<typename T>
+  void ld1r(FEXCore::ARMEmitter::SubRegSize size, T rt, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_AA_FMT(PostOffset == 1 || PostOffset == 2 || PostOffset == 4 || PostOffset == 8, "Index too large");
+    constexpr uint32_t Op = 0b0000'1101'1 << 23;
+    constexpr uint32_t Q = std::is_same_v<FEXCore::ARMEmitter::QRegister, T> ? 1 : 0;
+    uint32_t R = 0;
+    uint32_t opcode = 0b110;
+    uint32_t S = 0;
+    uint32_t Size = FEXCore::ToUnderlying(size);
+    ASIMDLoadStoreSinglePost<T>(Op, Q, 1, R, opcode, S, Size, FEXCore::ARMEmitter::Reg::r31, rn, rt);
+  }
+
+  template<typename T>
+  void ld2r(FEXCore::ARMEmitter::SubRegSize size, T rt, T rt2, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_AA_FMT(PostOffset == 2 || PostOffset == 4 || PostOffset == 8 || PostOffset == 16, "Index too large");
+    constexpr uint32_t Op = 0b0000'1101'1 << 23;
+    constexpr uint32_t Q = std::is_same_v<FEXCore::ARMEmitter::QRegister, T> ? 1 : 0;
+    uint32_t R = 1;
+    uint32_t opcode = 0b110;
+    uint32_t S = 0;
+    uint32_t Size = FEXCore::ToUnderlying(size);
+    ASIMDLoadStoreSinglePost<T>(Op, Q, 1, R, opcode, S, Size, FEXCore::ARMEmitter::Reg::r31, rn, rt);
+  }
+
+  template<typename T>
+  void ld3r(FEXCore::ARMEmitter::SubRegSize size, T rt, T rt2, T rt3, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    LOGMAN_THROW_AA_FMT(PostOffset == 3 || PostOffset == 6 || PostOffset == 12 || PostOffset == 24, "Index too large");
+    constexpr uint32_t Op = 0b0000'1101'1 << 23;
+    constexpr uint32_t Q = std::is_same_v<FEXCore::ARMEmitter::QRegister, T> ? 1 : 0;
+    uint32_t R = 0;
+    uint32_t opcode = 0b111;
+    uint32_t S = 0;
+    uint32_t Size = FEXCore::ToUnderlying(size);
+    ASIMDLoadStoreSinglePost<T>(Op, Q, 1, R, opcode, S, Size, FEXCore::ARMEmitter::Reg::r31, rn, rt);
+  }
+  template<typename T>
+  void ld4r(FEXCore::ARMEmitter::SubRegSize size, T rt, T rt2, T rt3, T rt4, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+    LOGMAN_THROW_AA_FMT(PostOffset == 4 || PostOffset == 8 || PostOffset == 16 || PostOffset == 32, "Index too large");
+    constexpr uint32_t Op = 0b0000'1101'1 << 23;
+    constexpr uint32_t Q = std::is_same_v<FEXCore::ARMEmitter::QRegister, T> ? 1 : 0;
+    uint32_t R = 1;
+    uint32_t opcode = 0b111;
+    uint32_t S = 0;
+    uint32_t Size = FEXCore::ToUnderlying(size);
+    ASIMDLoadStoreSinglePost<T>(Op, Q, 1, R, opcode, S, Size, FEXCore::ARMEmitter::Reg::r31, rn, rt);
+  }
+
+  template<typename T>
+  void st2(FEXCore::ARMEmitter::SubRegSize size, T rt, T rt2, uint32_t Index, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+
+    constexpr uint32_t Op = 0b0000'1101'1 << 23;
+    uint32_t Q;
+    uint32_t R = 1;
+    uint32_t opcode;
+    uint32_t S;
+    uint32_t Size;
+    if (size == SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 16, "Index too large");
+      Q = Index >> 3;
+      S = (Index >> 2) & 1;
+      opcode = 0b000;
+      Size = Index & 0b11;
+    }
+    else if (size == SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 8, "Index too large");
+      Q = Index >> 2;
+      S = (Index >> 1) & 1;
+      opcode = 0b010;
+      Size = (Index & 0b1) << 1;
+    }
+    else if (size == SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 4, "Index too large");
+      Q = Index >> 1;
+      S = Index & 1;
+      opcode = 0b100;
+      Size = 0b00;
+    }
+    else if (size == SubRegSize::i64Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 2, "Index too large");
+      Q = Index;
+      S = 0;
+      opcode = 0b100;
+      Size = 0b01;
+    }
+    else {
+      LOGMAN_MSG_A_FMT("Unknown size");
+      FEX_UNREACHABLE;
+    }
+
+    ASIMDLoadStoreSinglePost(Op, Q, 0, R, opcode, S, Size, FEXCore::ARMEmitter::Reg::r31, rn, rt.Q());
+  }
+  template<typename T>
+  void ld2(FEXCore::ARMEmitter::SubRegSize size, T rt, T rt2, uint32_t Index, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+
+    constexpr uint32_t Op = 0b0000'1101'1 << 23;
+    uint32_t Q;
+    uint32_t R = 1;
+    uint32_t opcode;
+    uint32_t S;
+    uint32_t Size;
+    if (size == SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 16, "Index too large");
+      Q = Index >> 3;
+      S = (Index >> 2) & 1;
+      opcode = 0b000;
+      Size = Index & 0b11;
+    }
+    else if (size == SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 8, "Index too large");
+      Q = Index >> 2;
+      S = (Index >> 1) & 1;
+      opcode = 0b010;
+      Size = (Index & 0b1) << 1;
+    }
+    else if (size == SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 4, "Index too large");
+      Q = Index >> 1;
+      S = Index & 1;
+      opcode = 0b100;
+      Size = 0b00;
+    }
+    else if (size == SubRegSize::i64Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 2, "Index too large");
+      Q = Index;
+      S = 0;
+      opcode = 0b100;
+      Size = 0b01;
+    }
+    else {
+      LOGMAN_MSG_A_FMT("Unknown size");
+      FEX_UNREACHABLE;
+    }
+
+    ASIMDLoadStoreSinglePost(Op, Q, 1, R, opcode, S, Size, FEXCore::ARMEmitter::Reg::r31, rn, rt.Q());
+  }
+  template<typename T>
+  void st3(FEXCore::ARMEmitter::SubRegSize size, T rt, T rt2, T rt3, uint32_t Index, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+
+    constexpr uint32_t Op = 0b0000'1101'1 << 23;
+    uint32_t Q;
+    uint32_t R = 0;
+    uint32_t opcode;
+    uint32_t S;
+    uint32_t Size;
+    if (size == SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 16, "Index too large");
+      Q = Index >> 3;
+      S = (Index >> 2) & 1;
+      opcode = 0b001;
+      Size = Index & 0b11;
+    }
+    else if (size == SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 8, "Index too large");
+      Q = Index >> 2;
+      S = (Index >> 1) & 1;
+      opcode = 0b011;
+      Size = (Index & 0b1) << 1;
+    }
+    else if (size == SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 4, "Index too large");
+      Q = Index >> 1;
+      S = Index & 1;
+      opcode = 0b101;
+      Size = 0b00;
+    }
+    else if (size == SubRegSize::i64Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 2, "Index too large");
+      Q = Index;
+      S = 0;
+      opcode = 0b101;
+      Size = 0b01;
+    }
+    else {
+      LOGMAN_MSG_A_FMT("Unknown size");
+      FEX_UNREACHABLE;
+    }
+
+    ASIMDLoadStoreSinglePost(Op, Q, 0, R, opcode, S, Size, FEXCore::ARMEmitter::Reg::r31, rn, rt.Q());
+  }
+  template<typename T>
+  void ld3(FEXCore::ARMEmitter::SubRegSize size, T rt, T rt2, T rt3, uint32_t Index, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+
+    constexpr uint32_t Op = 0b0000'1101'1 << 23;
+    uint32_t Q;
+    uint32_t R = 0;
+    uint32_t opcode;
+    uint32_t S;
+    uint32_t Size;
+    if (size == SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 16, "Index too large");
+      Q = Index >> 3;
+      S = (Index >> 2) & 1;
+      opcode = 0b001;
+      Size = Index & 0b11;
+    }
+    else if (size == SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 8, "Index too large");
+      Q = Index >> 2;
+      S = (Index >> 1) & 1;
+      opcode = 0b011;
+      Size = (Index & 0b1) << 1;
+    }
+    else if (size == SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 4, "Index too large");
+      Q = Index >> 1;
+      S = Index & 1;
+      opcode = 0b101;
+      Size = 0b00;
+    }
+    else if (size == SubRegSize::i64Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 2, "Index too large");
+      Q = Index;
+      S = 0;
+      opcode = 0b101;
+      Size = 0b01;
+    }
+    else {
+      LOGMAN_MSG_A_FMT("Unknown size");
+      FEX_UNREACHABLE;
+    }
+
+    ASIMDLoadStoreSinglePost(Op, Q, 1, R, opcode, S, Size, FEXCore::ARMEmitter::Reg::r31, rn, rt.Q());
+  }
+  template<typename T>
+  void st4(FEXCore::ARMEmitter::SubRegSize size, T rt, T rt2, T rt3, T rt4, uint32_t Index, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+
+    constexpr uint32_t Op = 0b0000'1101'1 << 23;
+    uint32_t Q;
+    uint32_t R = 1;
+    uint32_t opcode;
+    uint32_t S;
+    uint32_t Size;
+    if (size == SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 16, "Index too large");
+      Q = Index >> 3;
+      S = (Index >> 2) & 1;
+      opcode = 0b001;
+      Size = Index & 0b11;
+    }
+    else if (size == SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 8, "Index too large");
+      Q = Index >> 2;
+      S = (Index >> 1) & 1;
+      opcode = 0b011;
+      Size = (Index & 0b1) << 1;
+    }
+    else if (size == SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 4, "Index too large");
+      Q = Index >> 1;
+      S = Index & 1;
+      opcode = 0b101;
+      Size = 0b00;
+    }
+    else if (size == SubRegSize::i64Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 2, "Index too large");
+      Q = Index;
+      S = 0;
+      opcode = 0b101;
+      Size = 0b01;
+    }
+    else {
+      LOGMAN_MSG_A_FMT("Unknown size");
+      FEX_UNREACHABLE;
+    }
+
+    ASIMDLoadStoreSinglePost(Op, Q, 0, R, opcode, S, Size, FEXCore::ARMEmitter::Reg::r31, rn, rt.Q());
+  }
+  template<typename T>
+  void ld4(FEXCore::ARMEmitter::SubRegSize size, T rt, T rt2, T rt3, T rt4, uint32_t Index, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+
+    constexpr uint32_t Op = 0b0000'1101'1 << 23;
+    uint32_t Q;
+    uint32_t R = 1;
+    uint32_t opcode;
+    uint32_t S;
+    uint32_t Size;
+    if (size == SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 16, "Index too large");
+      Q = Index >> 3;
+      S = (Index >> 2) & 1;
+      opcode = 0b001;
+      Size = Index & 0b11;
+    }
+    else if (size == SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 8, "Index too large");
+      Q = Index >> 2;
+      S = (Index >> 1) & 1;
+      opcode = 0b011;
+      Size = (Index & 0b1) << 1;
+    }
+    else if (size == SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 4, "Index too large");
+      Q = Index >> 1;
+      S = Index & 1;
+      opcode = 0b101;
+      Size = 0b00;
+    }
+    else if (size == SubRegSize::i64Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 2, "Index too large");
+      Q = Index;
+      S = 0;
+      opcode = 0b101;
+      Size = 0b01;
+    }
+    else {
+      LOGMAN_MSG_A_FMT("Unknown size");
+      FEX_UNREACHABLE;
+    }
+
+    ASIMDLoadStoreSinglePost(Op, Q, 1, R, opcode, S, Size, FEXCore::ARMEmitter::Reg::r31, rn, rt.Q());
+  }
+
+  template<typename T>
+  void st1(FEXCore::ARMEmitter::SubRegSize size, T rt, uint32_t Index, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    constexpr uint32_t Op = 0b0000'1101'1 << 23;
+    uint32_t Q;
+    uint32_t R = 0;
+    uint32_t opcode;
+    uint32_t S;
+    uint32_t Size;
+    if (size == SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 16, "Index too large");
+      Q = Index >> 3;
+      S = (Index >> 2) & 1;
+      opcode = 0b000;
+      Size = Index & 0b11;
+    }
+    else if (size == SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 8, "Index too large");
+      Q = Index >> 2;
+      S = (Index >> 1) & 1;
+      opcode = 0b010;
+      Size = (Index & 0b1) << 1;
+    }
+    else if (size == SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 4, "Index too large");
+      Q = Index >> 1;
+      S = Index & 1;
+      opcode = 0b100;
+      Size = 0b00;
+    }
+    else if (size == SubRegSize::i64Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 2, "Index too large");
+      Q = Index;
+      S = 0;
+      opcode = 0b100;
+      Size = 0b01;
+    }
+    else {
+      LOGMAN_MSG_A_FMT("Unknown size");
+      FEX_UNREACHABLE;
+    }
+
+    ASIMDLoadStoreSinglePost(Op, Q, 0, R, opcode, S, Size, rm, rn, rt.Q());
+  }
+  template<typename T>
+  void ld1(FEXCore::ARMEmitter::SubRegSize size, T rt, uint32_t Index, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    constexpr uint32_t Op = 0b0000'1101'1 << 23;
+    uint32_t Q;
+    uint32_t R = 0;
+    uint32_t opcode;
+    uint32_t S;
+    uint32_t Size;
+    if (size == SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 16, "Index too large");
+      Q = Index >> 3;
+      S = (Index >> 2) & 1;
+      opcode = 0b001;
+      Size = Index & 0b11;
+    }
+    else if (size == SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 8, "Index too large");
+      Q = Index >> 2;
+      S = (Index >> 1) & 1;
+      opcode = 0b011;
+      Size = (Index & 0b1) << 1;
+    }
+    else if (size == SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 4, "Index too large");
+      Q = Index >> 1;
+      S = Index & 1;
+      opcode = 0b100;
+      Size = 0b00;
+    }
+    else if (size == SubRegSize::i64Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 2, "Index too large");
+      Q = Index;
+      S = 0;
+      opcode = 0b101;
+      Size = 0b01;
+    }
+    else {
+      LOGMAN_MSG_A_FMT("Unknown size");
+      FEX_UNREACHABLE;
+    }
+
+    ASIMDLoadStoreSinglePost(Op, Q, 1, R, opcode, S, Size, rm, rn, rt.Q());
+  }
+  template<typename T>
+  void ld1r(FEXCore::ARMEmitter::SubRegSize size, T rt, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    constexpr uint32_t Op = 0b0000'1101'1 << 23;
+    constexpr uint32_t Q = std::is_same_v<FEXCore::ARMEmitter::QRegister, T> ? 1 : 0;
+    uint32_t R = 0;
+    uint32_t opcode = 0b110;
+    uint32_t S = 0;
+    uint32_t Size = FEXCore::ToUnderlying(size);
+    ASIMDLoadStoreSinglePost<T>(Op, Q, 1, R, opcode, S, Size, rm, rn, rt);
+  }
+
+  template<typename T>
+  void ld2r(FEXCore::ARMEmitter::SubRegSize size, T rt, T rt2, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1101'1 << 23;
+    constexpr uint32_t Q = std::is_same_v<FEXCore::ARMEmitter::QRegister, T> ? 1 : 0;
+    uint32_t R = 1;
+    uint32_t opcode = 0b110;
+    uint32_t S = 0;
+    uint32_t Size = FEXCore::ToUnderlying(size);
+    ASIMDLoadStoreSinglePost<T>(Op, Q, 1, R, opcode, S, Size, rm, rn, rt);
+  }
+
+  template<typename T>
+  void ld3r(FEXCore::ARMEmitter::SubRegSize size, T rt, T rt2, T rt3, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1101'1 << 23;
+    constexpr uint32_t Q = std::is_same_v<FEXCore::ARMEmitter::QRegister, T> ? 1 : 0;
+    uint32_t R = 0;
+    uint32_t opcode = 0b111;
+    uint32_t S = 0;
+    uint32_t Size = FEXCore::ToUnderlying(size);
+    ASIMDLoadStoreSinglePost<T>(Op, Q, 1, R, opcode, S, Size, rm, rn, rt);
+  }
+  template<typename T>
+  void ld4r(FEXCore::ARMEmitter::SubRegSize size, T rt, T rt2, T rt3, T rt4, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+    constexpr uint32_t Op = 0b0000'1101'1 << 23;
+    constexpr uint32_t Q = std::is_same_v<FEXCore::ARMEmitter::QRegister, T> ? 1 : 0;
+    uint32_t R = 1;
+    uint32_t opcode = 0b111;
+    uint32_t S = 0;
+    uint32_t Size = FEXCore::ToUnderlying(size);
+    ASIMDLoadStoreSinglePost<T>(Op, Q, 1, R, opcode, S, Size, rm, rn, rt);
+  }
+
+  template<typename T>
+  void st2(FEXCore::ARMEmitter::SubRegSize size, T rt, T rt2, uint32_t Index, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+
+    constexpr uint32_t Op = 0b0000'1101'1 << 23;
+    uint32_t Q;
+    uint32_t R = 1;
+    uint32_t opcode;
+    uint32_t S;
+    uint32_t Size;
+    if (size == SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 16, "Index too large");
+      Q = Index >> 3;
+      S = (Index >> 2) & 1;
+      opcode = 0b000;
+      Size = Index & 0b11;
+    }
+    else if (size == SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 8, "Index too large");
+      Q = Index >> 2;
+      S = (Index >> 1) & 1;
+      opcode = 0b010;
+      Size = (Index & 0b1) << 1;
+    }
+    else if (size == SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 4, "Index too large");
+      Q = Index >> 1;
+      S = Index & 1;
+      opcode = 0b100;
+      Size = 0b00;
+    }
+    else if (size == SubRegSize::i64Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 2, "Index too large");
+      Q = Index;
+      S = 0;
+      opcode = 0b100;
+      Size = 0b01;
+    }
+    else {
+      LOGMAN_MSG_A_FMT("Unknown size");
+      FEX_UNREACHABLE;
+    }
+
+    ASIMDLoadStoreSinglePost(Op, Q, 0, R, opcode, S, Size, rm, rn, rt.Q());
+  }
+  template<typename T>
+  void ld2(FEXCore::ARMEmitter::SubRegSize size, T rt, T rt2, uint32_t Index, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+
+    constexpr uint32_t Op = 0b0000'1101'1 << 23;
+    uint32_t Q;
+    uint32_t R = 1;
+    uint32_t opcode;
+    uint32_t S;
+    uint32_t Size;
+    if (size == SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 16, "Index too large");
+      Q = Index >> 3;
+      S = (Index >> 2) & 1;
+      opcode = 0b000;
+      Size = Index & 0b11;
+    }
+    else if (size == SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 8, "Index too large");
+      Q = Index >> 2;
+      S = (Index >> 1) & 1;
+      opcode = 0b010;
+      Size = (Index & 0b1) << 1;
+    }
+    else if (size == SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 4, "Index too large");
+      Q = Index >> 1;
+      S = Index & 1;
+      opcode = 0b100;
+      Size = 0b00;
+    }
+    else if (size == SubRegSize::i64Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 2, "Index too large");
+      Q = Index;
+      S = 0;
+      opcode = 0b100;
+      Size = 0b01;
+    }
+    else {
+      LOGMAN_MSG_A_FMT("Unknown size");
+      FEX_UNREACHABLE;
+    }
+
+    ASIMDLoadStoreSinglePost(Op, Q, 1, R, opcode, S, Size, rm, rn, rt.Q());
+  }
+  template<typename T>
+  void st3(FEXCore::ARMEmitter::SubRegSize size, T rt, T rt2, T rt3, uint32_t Index, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+
+    constexpr uint32_t Op = 0b0000'1101'1 << 23;
+    uint32_t Q;
+    uint32_t R = 0;
+    uint32_t opcode;
+    uint32_t S;
+    uint32_t Size;
+    if (size == SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 16, "Index too large");
+      Q = Index >> 3;
+      S = (Index >> 2) & 1;
+      opcode = 0b001;
+      Size = Index & 0b11;
+    }
+    else if (size == SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 8, "Index too large");
+      Q = Index >> 2;
+      S = (Index >> 1) & 1;
+      opcode = 0b011;
+      Size = (Index & 0b1) << 1;
+    }
+    else if (size == SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 4, "Index too large");
+      Q = Index >> 1;
+      S = Index & 1;
+      opcode = 0b101;
+      Size = 0b00;
+    }
+    else if (size == SubRegSize::i64Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 2, "Index too large");
+      Q = Index;
+      S = 0;
+      opcode = 0b101;
+      Size = 0b01;
+    }
+    else {
+      LOGMAN_MSG_A_FMT("Unknown size");
+      FEX_UNREACHABLE;
+    }
+
+    ASIMDLoadStoreSinglePost(Op, Q, 0, R, opcode, S, Size, rm, rn, rt.Q());
+  }
+  template<typename T>
+  void ld3(FEXCore::ARMEmitter::SubRegSize size, T rt, T rt2, T rt3, uint32_t Index, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+
+    constexpr uint32_t Op = 0b0000'1101'1 << 23;
+    uint32_t Q;
+    uint32_t R = 0;
+    uint32_t opcode;
+    uint32_t S;
+    uint32_t Size;
+    if (size == SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 16, "Index too large");
+      Q = Index >> 3;
+      S = (Index >> 2) & 1;
+      opcode = 0b001;
+      Size = Index & 0b11;
+    }
+    else if (size == SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 8, "Index too large");
+      Q = Index >> 2;
+      S = (Index >> 1) & 1;
+      opcode = 0b011;
+      Size = (Index & 0b1) << 1;
+    }
+    else if (size == SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 4, "Index too large");
+      Q = Index >> 1;
+      S = Index & 1;
+      opcode = 0b101;
+      Size = 0b00;
+    }
+    else if (size == SubRegSize::i64Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 2, "Index too large");
+      Q = Index;
+      S = 0;
+      opcode = 0b101;
+      Size = 0b01;
+    }
+    else {
+      LOGMAN_MSG_A_FMT("Unknown size");
+      FEX_UNREACHABLE;
+    }
+
+    ASIMDLoadStoreSinglePost(Op, Q, 1, R, opcode, S, Size, rm, rn, rt.Q());
+  }
+  template<typename T>
+  void st4(FEXCore::ARMEmitter::SubRegSize size, T rt, T rt2, T rt3, T rt4, uint32_t Index, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+
+    constexpr uint32_t Op = 0b0000'1101'1 << 23;
+    uint32_t Q;
+    uint32_t R = 1;
+    uint32_t opcode;
+    uint32_t S;
+    uint32_t Size;
+    if (size == SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 16, "Index too large");
+      Q = Index >> 3;
+      S = (Index >> 2) & 1;
+      opcode = 0b001;
+      Size = Index & 0b11;
+    }
+    else if (size == SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 8, "Index too large");
+      Q = Index >> 2;
+      S = (Index >> 1) & 1;
+      opcode = 0b011;
+      Size = (Index & 0b1) << 1;
+    }
+    else if (size == SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 4, "Index too large");
+      Q = Index >> 1;
+      S = Index & 1;
+      opcode = 0b101;
+      Size = 0b00;
+    }
+    else if (size == SubRegSize::i64Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 2, "Index too large");
+      Q = Index;
+      S = 0;
+      opcode = 0b101;
+      Size = 0b01;
+    }
+    else {
+      LOGMAN_MSG_A_FMT("Unknown size");
+      FEX_UNREACHABLE;
+    }
+
+    ASIMDLoadStoreSinglePost(Op, Q, 0, R, opcode, S, Size, rm, rn, rt.Q());
+  }
+  template<typename T>
+  void ld4(FEXCore::ARMEmitter::SubRegSize size, T rt, T rt2, T rt3, T rt4, uint32_t Index, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+
+    constexpr uint32_t Op = 0b0000'1101'1 << 23;
+    uint32_t Q;
+    uint32_t R = 1;
+    uint32_t opcode;
+    uint32_t S;
+    uint32_t Size;
+    if (size == SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 16, "Index too large");
+      Q = Index >> 3;
+      S = (Index >> 2) & 1;
+      opcode = 0b001;
+      Size = Index & 0b11;
+    }
+    else if (size == SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 8, "Index too large");
+      Q = Index >> 2;
+      S = (Index >> 1) & 1;
+      opcode = 0b011;
+      Size = (Index & 0b1) << 1;
+    }
+    else if (size == SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 4, "Index too large");
+      Q = Index >> 1;
+      S = Index & 1;
+      opcode = 0b101;
+      Size = 0b00;
+    }
+    else if (size == SubRegSize::i64Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 2, "Index too large");
+      Q = Index;
+      S = 0;
+      opcode = 0b101;
+      Size = 0b01;
+    }
+    else {
+      LOGMAN_MSG_A_FMT("Unknown size");
+      FEX_UNREACHABLE;
+    }
+
+    ASIMDLoadStoreSinglePost(Op, Q, 1, R, opcode, S, Size, rm, rn, rt.Q());
+  }
+
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void st1(T rt, uint32_t Index, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    st1(size, rt, Index, rn, PostOffset);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void ld1(T rt, uint32_t Index, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    ld1(size, rt, Index, rn, PostOffset);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void ld1r(T rt, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    ld1r(size, rt, rn, PostOffset);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void ld2r(T rt, T rt2, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    ld2r(size, rt, rt2, rn, PostOffset);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void ld3r(T rt, T rt2, T rt3, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    ld3r(size, rt, rt2, rt3, rn, PostOffset);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void ld4r(T rt, T rt2, T rt3, T rt4, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    ld4r(size, rt, rt2, rt3, rt4, rn, PostOffset);
+  }
+
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void st2(T rt, T rt2, uint32_t Index, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    st2(size, rt, rt2, Index, rn, PostOffset);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void ld2(T rt, T rt2, uint32_t Index, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    ld2(size, rt, rt2, Index, rn, PostOffset);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void st3(T rt, T rt2, T rt3, uint32_t Index, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    st3(size, rt, rt2, rt3, Index, rn, PostOffset);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void ld3(T rt, T rt2, T rt3, uint32_t Index, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    ld3(size, rt, rt2, rt3, Index, rn, PostOffset);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void st4(T rt, T rt2, T rt3, T rt4, uint32_t Index, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    st4(size, rt, rt2, rt3, rt4, Index, rn, PostOffset);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void ld4(T rt, T rt2, T rt3, T rt4, uint32_t Index, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+    ld4(size, rt, rt2, rt3, rt4, Index, rn, PostOffset);
+  }
+
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void st1(T rt, uint32_t Index, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    st1(size, rt, Index, rn, rm);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void ld1(T rt, uint32_t Index, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    ld1(size, rt, Index, rn, rm);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void ld1r(T rt, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    ld1r(size, rt, rn, rm);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void ld2r(T rt, T rt2, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    ld2r(size, rt, rt2, rn, rm);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void ld3r(T rt, T rt2, T rt3, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    ld3r(size, rt, rt2, rt3, rn, rm);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void ld4r(T rt, T rt2, T rt3, T rt4, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    ld4r(size, rt, rt2, rt3, rt4, rn, rm);
+  }
+
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void st2(T rt, T rt2, uint32_t Index, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    st2(size, rt, rt2, Index, rn, rm);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void ld2(T rt, T rt2, uint32_t Index, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    ld2(size, rt, rt2, Index, rn, rm);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void st3(T rt, T rt2, T rt3, uint32_t Index, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    st3(size, rt, rt2, rt3, Index, rn, rm);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void ld3(T rt, T rt2, T rt3, uint32_t Index, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    ld3(size, rt, rt2, rt3, Index, rn, rm);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void st4(T rt, T rt2, T rt3, T rt4, uint32_t Index, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    st4(size, rt, rt2, rt3, rt4, Index, rn, rm);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
+  void ld4(T rt, T rt2, T rt3, T rt4, uint32_t Index, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    ld4(size, rt, rt2, rt3, rt4, Index, rn, rm);
+  }
+
+  template<typename T>
+  void ASIMDLoadStoreSinglePost(uint32_t Op, uint32_t Q, uint32_t L, uint32_t R, uint32_t opcode, uint32_t S, uint32_t size, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::Register rn, T rt) {
+    LOGMAN_THROW_A_FMT(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>, "Only supports 128-bit and 64-bit vector registers.");
+    uint32_t Instr = Op;
+
+    Instr |= Q << 30;
+    Instr |= L << 22;
+    Instr |= R << 21;
+    Instr |= Encode_rm(rm);
+    Instr |= opcode << 13;
+    Instr |= S << 12;
+    Instr |= size << 10;
+    Instr |= Encode_rn(rn);
+    Instr |= Encode_rt(rt);
+    dc32(Instr);
+  }
+  // Loadstore exclusive pair
+  void stxp(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rt2, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b1000'1000'001 << 21;
+    AtomicOp(Op, s, 0, 0, rs, rt, rt2, rn);
+  }
+  void stlxp(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rt2, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b1000'1000'001 << 21;
+    AtomicOp(Op, s, 0, 1, rs, rt, rt2, rn);
+  }
+  void ldxp(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rt2, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b1000'1000'001 << 21;
+    AtomicOp(Op, s, 1, 0, FEXCore::ARMEmitter::Reg::r31, rt, rt2, rn);
+  }
+  void ldaxp(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rt2, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b1000'1000'001 << 21;
+    AtomicOp(Op, s, 1, 1, FEXCore::ARMEmitter::Reg::r31, rt, rt2, rn);
+  }
+  // Loadstore exclusive register
+  void stxrb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1000'000 << 21;
+    SubAtomicOp(Op, FEXCore::ARMEmitter::SubRegSize::i8Bit, 0, 0, rs, rt, FEXCore::ARMEmitter::Reg::r31, rn);
+  }
+  void stlxrb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1000'000 << 21;
+    SubAtomicOp(Op, FEXCore::ARMEmitter::SubRegSize::i8Bit, 0, 1, rs, rt, FEXCore::ARMEmitter::Reg::r31, rn);
+  }
+  void ldxrb(FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1000'000 << 21;
+    SubAtomicOp(Op, FEXCore::ARMEmitter::SubRegSize::i8Bit, 1, 0, FEXCore::ARMEmitter::Reg::r31, rt, FEXCore::ARMEmitter::Reg::r31, rn);
+  }
+  void ldaxrb(FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1000'000 << 21;
+    SubAtomicOp(Op, FEXCore::ARMEmitter::SubRegSize::i8Bit, 1, 1, FEXCore::ARMEmitter::Reg::r31, rt, FEXCore::ARMEmitter::Reg::r31, rn);
+  }
+  void stxrh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1000'000 << 21;
+    SubAtomicOp(Op, FEXCore::ARMEmitter::SubRegSize::i16Bit, 0, 0, rs, rt, FEXCore::ARMEmitter::Reg::r31, rn);
+  }
+  void stlxrh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1000'000 << 21;
+    SubAtomicOp(Op, FEXCore::ARMEmitter::SubRegSize::i16Bit, 0, 1, rs, rt, FEXCore::ARMEmitter::Reg::r31, rn);
+  }
+  void ldxrh(FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1000'000 << 21;
+    SubAtomicOp(Op, FEXCore::ARMEmitter::SubRegSize::i16Bit, 1, 0, FEXCore::ARMEmitter::Reg::r31, rt, FEXCore::ARMEmitter::Reg::r31, rn);
+  }
+  void ldaxrh(FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1000'000 << 21;
+    SubAtomicOp(Op, FEXCore::ARMEmitter::SubRegSize::i16Bit, 1, 1, FEXCore::ARMEmitter::Reg::r31, rt, FEXCore::ARMEmitter::Reg::r31, rn);
+  }
+  void stxr(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1000'000 << 21;
+    SubAtomicOp(Op, FEXCore::ARMEmitter::SubRegSize::i32Bit, 0, 0, rs, rt, FEXCore::ARMEmitter::WReg::w31, rn);
+  }
+  void stlxr(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1000'000 << 21;
+    SubAtomicOp(Op, FEXCore::ARMEmitter::SubRegSize::i32Bit, 0, 1, rs, rt, FEXCore::ARMEmitter::WReg::w31, rn);
+  }
+  void ldxr(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1000'000 << 21;
+    SubAtomicOp(Op, FEXCore::ARMEmitter::SubRegSize::i32Bit, 1, 0, FEXCore::ARMEmitter::WReg::w31, rt, FEXCore::ARMEmitter::WReg::w31, rn);
+  }
+  void ldaxr(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1000'000 << 21;
+    SubAtomicOp(Op, FEXCore::ARMEmitter::SubRegSize::i32Bit, 1, 1, FEXCore::ARMEmitter::WReg::w31, rt, FEXCore::ARMEmitter::WReg::w31, rn);
+  }
+  void stxr(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1000'000 << 21;
+    SubAtomicOp(Op, FEXCore::ARMEmitter::SubRegSize::i64Bit, 0, 0, rs, rt, FEXCore::ARMEmitter::XReg::x31, rn);
+  }
+  void stlxr(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1000'000 << 21;
+    SubAtomicOp(Op, FEXCore::ARMEmitter::SubRegSize::i64Bit, 0, 1, rs.R(), rt.R(), FEXCore::ARMEmitter::Reg::r31, rn);
+  }
+  void ldxr(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1000'000 << 21;
+    SubAtomicOp(Op, FEXCore::ARMEmitter::SubRegSize::i64Bit, 1, 0, FEXCore::ARMEmitter::XReg::x31, rt, FEXCore::ARMEmitter::XReg::x31, rn);
+  }
+  void ldaxr(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1000'000 << 21;
+    SubAtomicOp(Op, FEXCore::ARMEmitter::SubRegSize::i64Bit, 1, 1, FEXCore::ARMEmitter::XReg::x31, rt, FEXCore::ARMEmitter::XReg::x31, rn);
+  }
+  void stxr(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1000'000 << 21;
+    SubAtomicOp(Op, size, 0, 0, rs, rt, FEXCore::ARMEmitter::Reg::r31, rn);
+  }
+  void stlxr(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1000'000 << 21;
+    SubAtomicOp(Op, size, 0, 1, rs, rt, FEXCore::ARMEmitter::Reg::r31, rn);
+  }
+  void ldxr(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1000'000 << 21;
+    SubAtomicOp(Op, size, 1, 0, FEXCore::ARMEmitter::Reg::r31, rt, FEXCore::ARMEmitter::Reg::r31, rn);
+  }
+  void ldaxr(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1000'000 << 21;
+    SubAtomicOp(Op, size, 1, 1, FEXCore::ARMEmitter::Reg::r31, rt, FEXCore::ARMEmitter::Reg::r31, rn);
+  }
+
+  // Load/store ordered
+  static constexpr uint32_t LoadStoreOrdered_Op = 0b0000'1000'100 << 21;
+  void stllrb(FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    SubAtomicOp(LoadStoreOrdered_Op, FEXCore::ARMEmitter::SubRegSize::i8Bit, 0, 0, FEXCore::ARMEmitter::Reg::r31, rt, FEXCore::ARMEmitter::Reg::r31, rn);
+  }
+  void stlrb(FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    SubAtomicOp(LoadStoreOrdered_Op, FEXCore::ARMEmitter::SubRegSize::i8Bit, 0, 1, FEXCore::ARMEmitter::Reg::r31, rt, FEXCore::ARMEmitter::Reg::r31, rn);
+  }
+  void ldlarb(FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    SubAtomicOp(LoadStoreOrdered_Op, FEXCore::ARMEmitter::SubRegSize::i8Bit, 1, 0, FEXCore::ARMEmitter::Reg::r31, rt, FEXCore::ARMEmitter::Reg::r31, rn);
+  }
+  void ldarb(FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    SubAtomicOp(LoadStoreOrdered_Op, FEXCore::ARMEmitter::SubRegSize::i8Bit, 1, 1, FEXCore::ARMEmitter::Reg::r31, rt, FEXCore::ARMEmitter::Reg::r31, rn);
+  }
+  void stllrh(FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    SubAtomicOp(LoadStoreOrdered_Op, FEXCore::ARMEmitter::SubRegSize::i16Bit, 0, 0, FEXCore::ARMEmitter::Reg::r31, rt, FEXCore::ARMEmitter::Reg::r31, rn);
+  }
+  void stlrh(FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    SubAtomicOp(LoadStoreOrdered_Op, FEXCore::ARMEmitter::SubRegSize::i16Bit, 0, 1, FEXCore::ARMEmitter::Reg::r31, rt, FEXCore::ARMEmitter::Reg::r31, rn);
+  }
+  void ldlarh(FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    SubAtomicOp(LoadStoreOrdered_Op, FEXCore::ARMEmitter::SubRegSize::i16Bit, 1, 0, FEXCore::ARMEmitter::Reg::r31, rt, FEXCore::ARMEmitter::Reg::r31, rn);
+  }
+  void ldarh(FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    SubAtomicOp(LoadStoreOrdered_Op, FEXCore::ARMEmitter::SubRegSize::i16Bit, 1, 1, FEXCore::ARMEmitter::Reg::r31, rt, FEXCore::ARMEmitter::Reg::r31, rn);
+  }
+  void stllr(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    SubAtomicOp(LoadStoreOrdered_Op, FEXCore::ARMEmitter::SubRegSize::i32Bit, 0, 0, FEXCore::ARMEmitter::WReg::w31, rt, FEXCore::ARMEmitter::WReg::w31, rn);
+  }
+  void stlr(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    SubAtomicOp(LoadStoreOrdered_Op, FEXCore::ARMEmitter::SubRegSize::i32Bit, 0, 1, FEXCore::ARMEmitter::WReg::w31, rt, FEXCore::ARMEmitter::WReg::w31, rn);
+  }
+  void ldlar(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    SubAtomicOp(LoadStoreOrdered_Op, FEXCore::ARMEmitter::SubRegSize::i32Bit, 1, 0, FEXCore::ARMEmitter::WReg::w31, rt, FEXCore::ARMEmitter::WReg::w31, rn);
+  }
+  void ldar(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    SubAtomicOp(LoadStoreOrdered_Op, FEXCore::ARMEmitter::SubRegSize::i32Bit, 1, 1, FEXCore::ARMEmitter::WReg::w31, rt, FEXCore::ARMEmitter::WReg::w31, rn);
+  }
+  void stllr(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    SubAtomicOp(LoadStoreOrdered_Op, FEXCore::ARMEmitter::SubRegSize::i64Bit, 0, 0, FEXCore::ARMEmitter::XReg::x31, rt, FEXCore::ARMEmitter::XReg::x31, rn);
+  }
+  void stlr(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    SubAtomicOp(LoadStoreOrdered_Op, FEXCore::ARMEmitter::SubRegSize::i64Bit, 0, 1, FEXCore::ARMEmitter::XReg::x31, rt, FEXCore::ARMEmitter::XReg::x31, rn);
+  }
+  void ldlar(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    SubAtomicOp(LoadStoreOrdered_Op, FEXCore::ARMEmitter::SubRegSize::i64Bit, 1, 0, FEXCore::ARMEmitter::XReg::x31, rt, FEXCore::ARMEmitter::XReg::x31, rn);
+  }
+  void ldar(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    SubAtomicOp(LoadStoreOrdered_Op, FEXCore::ARMEmitter::SubRegSize::i64Bit, 1, 1, FEXCore::ARMEmitter::XReg::x31, rt, FEXCore::ARMEmitter::XReg::x31, rn);
+  }
+  // Compare and swap
+  void casb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1000'101 << 21;
+    SubAtomicOp(Op, FEXCore::ARMEmitter::SubRegSize::i8Bit, 0, 0, rs, rt, FEXCore::ARMEmitter::Reg::r31, rn);
+  }
+  void caslb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1000'101 << 21;
+    SubAtomicOp(Op, FEXCore::ARMEmitter::SubRegSize::i8Bit, 0, 1, rs, rt, FEXCore::ARMEmitter::Reg::r31, rn);
+  }
+  void casab(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1000'101 << 21;
+    SubAtomicOp(Op, FEXCore::ARMEmitter::SubRegSize::i8Bit, 1, 0, rs, rt, FEXCore::ARMEmitter::Reg::r31, rn);
+  }
+  void casalb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1000'101 << 21;
+    SubAtomicOp(Op, FEXCore::ARMEmitter::SubRegSize::i8Bit, 1, 1, rs, rt, FEXCore::ARMEmitter::Reg::r31, rn);
+  }
+  void cash(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1000'101 << 21;
+    SubAtomicOp(Op, FEXCore::ARMEmitter::SubRegSize::i16Bit, 0, 0, rs, rt, FEXCore::ARMEmitter::Reg::r31, rn);
+  }
+  void caslh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1000'101 << 21;
+    SubAtomicOp(Op, FEXCore::ARMEmitter::SubRegSize::i16Bit, 0, 1, rs, rt, FEXCore::ARMEmitter::Reg::r31, rn);
+  }
+  void casah(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1000'101 << 21;
+    SubAtomicOp(Op, FEXCore::ARMEmitter::SubRegSize::i16Bit, 1, 0, rs, rt, FEXCore::ARMEmitter::Reg::r31, rn);
+  }
+  void casalh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1000'101 << 21;
+    SubAtomicOp(Op, FEXCore::ARMEmitter::SubRegSize::i16Bit, 1, 1, rs, rt, FEXCore::ARMEmitter::Reg::r31, rn);
+  }
+  void cas(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1000'101 << 21;
+    SubAtomicOp(Op, FEXCore::ARMEmitter::SubRegSize::i32Bit, 0, 0, rs.R(), rt.R(), FEXCore::ARMEmitter::Reg::r31, rn);
+  }
+  void casl(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1000'101 << 21;
+    SubAtomicOp(Op, FEXCore::ARMEmitter::SubRegSize::i32Bit, 0, 1, rs.R(), rt.R(), FEXCore::ARMEmitter::Reg::r31, rn);
+  }
+  void casa(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1000'101 << 21;
+    SubAtomicOp(Op, FEXCore::ARMEmitter::SubRegSize::i32Bit, 1, 0, rs.R(), rt.R(), FEXCore::ARMEmitter::Reg::r31, rn);
+  }
+  void casal(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1000'101 << 21;
+    SubAtomicOp(Op, FEXCore::ARMEmitter::SubRegSize::i32Bit, 1, 1, rs.R(), rt.R(), FEXCore::ARMEmitter::Reg::r31, rn);
+  }
+  void cas(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1000'101 << 21;
+    SubAtomicOp(Op, FEXCore::ARMEmitter::SubRegSize::i64Bit, 0, 0, rs.R(), rt.R(), FEXCore::ARMEmitter::Reg::r31, rn);
+  }
+  void casl(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1000'101 << 21;
+    SubAtomicOp(Op, FEXCore::ARMEmitter::SubRegSize::i64Bit, 0, 1, rs.R(), rt.R(), FEXCore::ARMEmitter::Reg::r31, rn);
+  }
+  void casa(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1000'101 << 21;
+    SubAtomicOp(Op, FEXCore::ARMEmitter::SubRegSize::i64Bit, 1, 0, rs.R(), rt.R(), FEXCore::ARMEmitter::Reg::r31, rn);
+  }
+  void casal(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1000'101 << 21;
+    SubAtomicOp(Op, FEXCore::ARMEmitter::SubRegSize::i64Bit, 1, 1, rs.R(), rt.R(), FEXCore::ARMEmitter::Reg::r31, rn);
+  }
+
+  void cas(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1000'101 << 21;
+    SubAtomicOp(Op, size, 0, 0, rs, rt, FEXCore::ARMEmitter::Reg::r31, rn);
+  }
+  void casl(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1000'101 << 21;
+    SubAtomicOp(Op, size, 0, 1, rs, rt, FEXCore::ARMEmitter::Reg::r31, rn);
+  }
+  void casa(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1000'101 << 21;
+    SubAtomicOp(Op, size, 1, 0, rs, rt, FEXCore::ARMEmitter::Reg::r31, rn);
+  }
+  void casal(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0000'1000'101 << 21;
+    SubAtomicOp(Op, size, 1, 1, rs, rt, FEXCore::ARMEmitter::Reg::r31, rn);
+  }
+  // LDAPR/STLR unscaled immediate
+  void stlurb(FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
+    constexpr uint32_t Op = 0b0001'1001'000 << 21;
+    SubAtomicImm(Op, FEXCore::ARMEmitter::SubRegSize::i8Bit, 0b00, rt, rn, static_cast<uint32_t>(Imm) & 0x1'FF);
+  }
+  void ldapurb(FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
+    constexpr uint32_t Op = 0b0001'1001'000 << 21;
+    SubAtomicImm(Op, FEXCore::ARMEmitter::SubRegSize::i8Bit, 0b01, rt, rn, static_cast<uint32_t>(Imm) & 0x1'FF);
+  }
+  void ldapursb(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
+    constexpr uint32_t Op = 0b0001'1001'000 << 21;
+    SubAtomicImm(Op, FEXCore::ARMEmitter::SubRegSize::i8Bit, 0b11, rt, rn, static_cast<uint32_t>(Imm) & 0x1'FF);
+  }
+  void ldapursb(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
+    constexpr uint32_t Op = 0b0001'1001'000 << 21;
+    SubAtomicImm(Op, FEXCore::ARMEmitter::SubRegSize::i8Bit, 0b10, rt, rn, static_cast<uint32_t>(Imm) & 0x1'FF);
+  }
+  void stlurh(FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
+    constexpr uint32_t Op = 0b0001'1001'000 << 21;
+    SubAtomicImm(Op, FEXCore::ARMEmitter::SubRegSize::i16Bit, 0b00, rt, rn, static_cast<uint32_t>(Imm) & 0x1'FF);
+  }
+  void ldapurh(FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
+    constexpr uint32_t Op = 0b0001'1001'000 << 21;
+    SubAtomicImm(Op, FEXCore::ARMEmitter::SubRegSize::i16Bit, 0b01, rt, rn, static_cast<uint32_t>(Imm) & 0x1'FF);
+  }
+  void ldapursh(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
+    constexpr uint32_t Op = 0b0001'1001'000 << 21;
+    SubAtomicImm(Op, FEXCore::ARMEmitter::SubRegSize::i16Bit, 0b11, rt, rn, static_cast<uint32_t>(Imm) & 0x1'FF);
+  }
+  void ldapursh(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
+    constexpr uint32_t Op = 0b0001'1001'000 << 21;
+    SubAtomicImm(Op, FEXCore::ARMEmitter::SubRegSize::i16Bit, 0b10, rt, rn, static_cast<uint32_t>(Imm) & 0x1'FF);
+  }
+  void stlur(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
+    constexpr uint32_t Op = 0b0001'1001'000 << 21;
+    SubAtomicImm(Op, FEXCore::ARMEmitter::SubRegSize::i32Bit, 0b00, rt, rn, static_cast<uint32_t>(Imm) & 0x1'FF);
+  }
+  void ldapur(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
+    constexpr uint32_t Op = 0b0001'1001'000 << 21;
+    SubAtomicImm(Op, FEXCore::ARMEmitter::SubRegSize::i32Bit, 0b01, rt, rn, static_cast<uint32_t>(Imm) & 0x1'FF);
+  }
+  void ldapursw(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
+    constexpr uint32_t Op = 0b0001'1001'000 << 21;
+    SubAtomicImm(Op, FEXCore::ARMEmitter::SubRegSize::i32Bit, 0b10, rt, rn, static_cast<uint32_t>(Imm) & 0x1'FF);
+  }
+  void stlur(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
+    constexpr uint32_t Op = 0b0001'1001'000 << 21;
+    SubAtomicImm(Op, FEXCore::ARMEmitter::SubRegSize::i64Bit, 0b00, rt, rn, static_cast<uint32_t>(Imm) & 0x1'FF);
+  }
+  void ldapur(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
+    constexpr uint32_t Op = 0b0001'1001'000 << 21;
+    SubAtomicImm(Op, FEXCore::ARMEmitter::SubRegSize::i64Bit, 0b01, rt, rn, static_cast<uint32_t>(Imm) & 0x1'FF);
+  }
+  // Load register literal
+  void ldr(FEXCore::ARMEmitter::WRegister rt, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -1048576 && Imm <= 1048575 && ((Imm & 0b11) == 0), "Unscaled offset too large");
+    constexpr uint32_t Op = 0b0001'1000 << 24;
+    LoadStoreLiteral(Op, rt, static_cast<uint32_t>(Imm >> 2) & 0x7'FFFF);
+  }
+  void ldr(FEXCore::ARMEmitter::SRegister rt, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -1048576 && Imm <= 1048575 && ((Imm & 0b11) == 0), "Unscaled offset too large");
+    constexpr uint32_t Op = 0b0001'1100 << 24;
+    LoadStoreLiteral(Op, rt, static_cast<uint32_t>(Imm >> 2) & 0x7'FFFF);
+  }
+  void ldr(FEXCore::ARMEmitter::XRegister rt, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -1048576 && Imm <= 1048575 && ((Imm & 0b11) == 0), "Unscaled offset too large");
+    constexpr uint32_t Op = 0b0101'1000 << 24;
+    LoadStoreLiteral(Op, rt, static_cast<uint32_t>(Imm >> 2) & 0x7'FFFF);
+  }
+  void ldr(FEXCore::ARMEmitter::DRegister rt, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -1048576 && Imm <= 1048575 && ((Imm & 0b11) == 0), "Unscaled offset too large");
+    constexpr uint32_t Op = 0b0101'1100 << 24;
+    LoadStoreLiteral(Op, rt, static_cast<uint32_t>(Imm >> 2) & 0x7'FFFF);
+  }
+  void ldrs(FEXCore::ARMEmitter::WRegister rt, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -1048576 && Imm <= 1048575 && ((Imm & 0b11) == 0), "Unscaled offset too large");
+    constexpr uint32_t Op = 0b1001'1000 << 24;
+    LoadStoreLiteral(Op, rt, static_cast<uint32_t>(Imm >> 2) & 0x7'FFFF);
+  }
+  void ldr(FEXCore::ARMEmitter::QRegister rt, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -1048576 && Imm <= 1048575 && ((Imm & 0b11) == 0), "Unscaled offset too large");
+    constexpr uint32_t Op = 0b1001'1100 << 24;
+    LoadStoreLiteral(Op, rt, static_cast<uint32_t>(Imm >> 2) & 0x7'FFFF);
+  }
+  void prfm(FEXCore::ARMEmitter::Prefetch prfop, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -1048576 && Imm <= 1048575 && ((Imm & 0b11) == 0), "Unscaled offset too large");
+    constexpr uint32_t Op = 0b1101'1000 << 24;
+    LoadStoreLiteral(Op, prfop, static_cast<uint32_t>(Imm >> 2) & 0x7'FFFF);
+  }
+  void ldr(FEXCore::ARMEmitter::WRegister rt, BackwardLabel const* Label) {
+    int32_t Imm = static_cast<int32_t>(Label->Location - GetCursorAddress<uint8_t*>());
+    LOGMAN_THROW_A_FMT(Imm >= -1048576 && Imm <= 1048575 && ((Imm & 0b11) == 0), "Unscaled offset too large");
+    constexpr uint32_t Op = 0b0001'1000 << 24;
+    LoadStoreLiteral(Op, rt, static_cast<uint32_t>(Imm >> 2) & 0x7'FFFF);
+  }
+  void ldr(FEXCore::ARMEmitter::SRegister rt, BackwardLabel const* Label) {
+    int32_t Imm = static_cast<int32_t>(Label->Location - GetCursorAddress<uint8_t*>());
+    LOGMAN_THROW_A_FMT(Imm >= -1048576 && Imm <= 1048575 && ((Imm & 0b11) == 0), "Unscaled offset too large");
+    constexpr uint32_t Op = 0b0001'1100 << 24;
+    LoadStoreLiteral(Op, rt, static_cast<uint32_t>(Imm >> 2) & 0x7'FFFF);
+  }
+  void ldr(FEXCore::ARMEmitter::XRegister rt, BackwardLabel const* Label) {
+    int32_t Imm = static_cast<int32_t>(Label->Location - GetCursorAddress<uint8_t*>());
+    LOGMAN_THROW_A_FMT(Imm >= -1048576 && Imm <= 1048575 && ((Imm & 0b11) == 0), "Unscaled offset too large");
+    constexpr uint32_t Op = 0b0101'1000 << 24;
+    LoadStoreLiteral(Op, rt, static_cast<uint32_t>(Imm >> 2) & 0x7'FFFF);
+  }
+  void ldr(FEXCore::ARMEmitter::DRegister rt, BackwardLabel const* Label) {
+    int32_t Imm = static_cast<int32_t>(Label->Location - GetCursorAddress<uint8_t*>());
+    LOGMAN_THROW_A_FMT(Imm >= -1048576 && Imm <= 1048575 && ((Imm & 0b11) == 0), "Unscaled offset too large");
+    constexpr uint32_t Op = 0b0101'1100 << 24;
+    LoadStoreLiteral(Op, rt, static_cast<uint32_t>(Imm >> 2) & 0x7'FFFF);
+  }
+  void ldrsw(FEXCore::ARMEmitter::XRegister rt, BackwardLabel const* Label) {
+    int32_t Imm = static_cast<int32_t>(Label->Location - GetCursorAddress<uint8_t*>());
+    LOGMAN_THROW_A_FMT(Imm >= -1048576 && Imm <= 1048575 && ((Imm & 0b11) == 0), "Unscaled offset too large");
+    constexpr uint32_t Op = 0b1001'1000 << 24;
+    LoadStoreLiteral(Op, rt, static_cast<uint32_t>(Imm >> 2) & 0x7'FFFF);
+  }
+  void ldr(FEXCore::ARMEmitter::QRegister rt, BackwardLabel const* Label) {
+    int32_t Imm = static_cast<int32_t>(Label->Location - GetCursorAddress<uint8_t*>());
+    LOGMAN_THROW_A_FMT(Imm >= -1048576 && Imm <= 1048575 && ((Imm & 0b11) == 0), "Unscaled offset too large");
+    constexpr uint32_t Op = 0b1001'1100 << 24;
+    LoadStoreLiteral(Op, rt, static_cast<uint32_t>(Imm >> 2) & 0x7'FFFF);
+  }
+  void prfm(FEXCore::ARMEmitter::Prefetch prfop, BackwardLabel const* Label) {
+    int32_t Imm = static_cast<int32_t>(Label->Location - GetCursorAddress<uint8_t*>());
+    LOGMAN_THROW_A_FMT(Imm >= -1048576 && Imm <= 1048575 && ((Imm & 0b11) == 0), "Unscaled offset too large");
+    constexpr uint32_t Op = 0b1101'1000 << 24;
+    LoadStoreLiteral(Op, prfop, static_cast<uint32_t>(Imm >> 2) & 0x7'FFFF);
+  }
+
+  void ldr(FEXCore::ARMEmitter::WRegister rt, ForwardLabel *Label) {
+    Label->Insts.emplace_back(ForwardLabel::Instructions{ .Location = GetCursorAddress<uint8_t*>(), .Type = ForwardLabel::Instructions::InstType::RELATIVE_LOAD });
+    constexpr uint32_t Op = 0b0001'1000 << 24;
+    LoadStoreLiteral(Op, rt, 0);
+  }
+  void ldr(FEXCore::ARMEmitter::SRegister rt, ForwardLabel *Label) {
+    Label->Insts.emplace_back(ForwardLabel::Instructions{ .Location = GetCursorAddress<uint8_t*>(), .Type = ForwardLabel::Instructions::InstType::RELATIVE_LOAD });
+    constexpr uint32_t Op = 0b0001'1100 << 24;
+    LoadStoreLiteral(Op, rt, 0);
+  }
+  void ldr(FEXCore::ARMEmitter::XRegister rt, ForwardLabel *Label) {
+    Label->Insts.emplace_back(ForwardLabel::Instructions{ .Location = GetCursorAddress<uint8_t*>(), .Type = ForwardLabel::Instructions::InstType::RELATIVE_LOAD });
+    constexpr uint32_t Op = 0b0101'1000 << 24;
+    LoadStoreLiteral(Op, rt, 0);
+  }
+  void ldr(FEXCore::ARMEmitter::DRegister rt, ForwardLabel *Label) {
+    Label->Insts.emplace_back(ForwardLabel::Instructions{ .Location = GetCursorAddress<uint8_t*>(), .Type = ForwardLabel::Instructions::InstType::RELATIVE_LOAD });
+    constexpr uint32_t Op = 0b0101'1100 << 24;
+    LoadStoreLiteral(Op, rt, 0);
+  }
+  void ldrsw(FEXCore::ARMEmitter::XRegister rt, ForwardLabel *Label) {
+    Label->Insts.emplace_back(ForwardLabel::Instructions{ .Location = GetCursorAddress<uint8_t*>(), .Type = ForwardLabel::Instructions::InstType::RELATIVE_LOAD });
+    constexpr uint32_t Op = 0b1001'1000 << 24;
+    LoadStoreLiteral(Op, rt, 0);
+  }
+  void ldr(FEXCore::ARMEmitter::QRegister rt, ForwardLabel *Label) {
+    Label->Insts.emplace_back(ForwardLabel::Instructions{ .Location = GetCursorAddress<uint8_t*>(), .Type = ForwardLabel::Instructions::InstType::RELATIVE_LOAD });
+    constexpr uint32_t Op = 0b1001'1100 << 24;
+    LoadStoreLiteral(Op, rt, 0);
+  }
+  void prfm(FEXCore::ARMEmitter::Prefetch prfop, ForwardLabel *Label) {
+    Label->Insts.emplace_back(ForwardLabel::Instructions{ .Location = GetCursorAddress<uint8_t*>(), .Type = ForwardLabel::Instructions::InstType::RELATIVE_LOAD });
+    constexpr uint32_t Op = 0b1101'1000 << 24;
+    LoadStoreLiteral(Op, prfop, 0);
+  }
+
+  void ldr(FEXCore::ARMEmitter::WRegister rt, BiDirectionalLabel *Label) {
+    if (Label->Backward.Location) {
+      ldr(rt, &Label->Backward);
+    }
+    else {
+      ldr(rt, &Label->Forward);
+    }
+  }
+  void ldr(FEXCore::ARMEmitter::SRegister rt, BiDirectionalLabel *Label) {
+    if (Label->Backward.Location) {
+      ldr(rt, &Label->Backward);
+    }
+    else {
+      ldr(rt, &Label->Forward);
+    }
+  }
+  void ldr(FEXCore::ARMEmitter::XRegister rt, BiDirectionalLabel *Label) {
+    if (Label->Backward.Location) {
+      ldr(rt, &Label->Backward);
+    }
+    else {
+      ldr(rt, &Label->Forward);
+    }
+  }
+  void ldr(FEXCore::ARMEmitter::DRegister rt, BiDirectionalLabel *Label) {
+    if (Label->Backward.Location) {
+      ldr(rt, &Label->Backward);
+    }
+    else {
+      ldr(rt, &Label->Forward);
+    }
+  }
+  void ldrs(FEXCore::ARMEmitter::WRegister rt, BiDirectionalLabel *Label) {
+    if (Label->Backward.Location) {
+      ldr(rt, &Label->Backward);
+    }
+    else {
+      ldr(rt, &Label->Forward);
+    }
+  }
+  void ldr(FEXCore::ARMEmitter::QRegister rt, BiDirectionalLabel *Label) {
+    if (Label->Backward.Location) {
+      ldr(rt, &Label->Backward);
+    }
+    else {
+      ldr(rt, &Label->Forward);
+    }
+  }
+  void prfm(FEXCore::ARMEmitter::Prefetch prfop, BiDirectionalLabel *Label) {
+    if (Label->Backward.Location) {
+      prfm(prfop, &Label->Backward);
+    }
+    else {
+      prfm(prfop, &Label->Forward);
+    }
+  }
+
+  // Memory copy/set
+  // TODO
+  // Loadstore no-allocate pair
+  void stnp(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::WRegister rt2, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 252 && ((Imm & 0b11) == 0), "Unscaled offset too large");
+    constexpr uint32_t Op = 0b0010'1000'00 << 22;
+    LoadStoreNoAllocate(Op, rt, rt2, rn, static_cast<uint32_t>(Imm >> 2) & 0b111'1111);
+  }
+  void ldnp(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::WRegister rt2, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 252 && ((Imm & 0b11) == 0), "Unscaled offset too large");
+    constexpr uint32_t Op = 0b0010'1000'01 << 22;
+    LoadStoreNoAllocate(Op, rt, rt2, rn, static_cast<uint32_t>(Imm >> 2) & 0b111'1111);
+  }
+  void stnp(FEXCore::ARMEmitter::SRegister rt, FEXCore::ARMEmitter::SRegister rt2, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 252 && ((Imm & 0b11) == 0), "Unscaled offset too large");
+    constexpr uint32_t Op = 0b0010'1100'00 << 22;
+    LoadStoreNoAllocate(Op, rt, rt2, rn, static_cast<uint32_t>(Imm >> 2) & 0b111'1111);
+  }
+  void ldnp(FEXCore::ARMEmitter::SRegister rt, FEXCore::ARMEmitter::SRegister rt2, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 252 && ((Imm & 0b11) == 0), "Unscaled offset too large");
+    constexpr uint32_t Op = 0b0010'1100'01 << 22;
+    LoadStoreNoAllocate(Op, rt, rt2, rn, static_cast<uint32_t>(Imm >> 2) & 0b111'1111);
+  }
+  void stnp(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::XRegister rt2, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -512 && Imm <= 504 && ((Imm & 0b111) == 0), "Unscaled offset too large");
+    constexpr uint32_t Op = 0b1010'1000'00 << 22;
+    LoadStoreNoAllocate(Op, rt, rt2, rn, static_cast<uint32_t>(Imm >> 3) & 0b111'1111);
+  }
+  void ldnp(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::XRegister rt2, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -512 && Imm <= 504 && ((Imm & 0b111) == 0), "Unscaled offset too large");
+    constexpr uint32_t Op = 0b1010'1000'01 << 22;
+    LoadStoreNoAllocate(Op, rt, rt2, rn, static_cast<uint32_t>(Imm >> 3) & 0b111'1111);
+  }
+  void stnp(FEXCore::ARMEmitter::DRegister rt, FEXCore::ARMEmitter::DRegister rt2, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -512 && Imm <= 504 && ((Imm & 0b111) == 0), "Unscaled offset too large");
+    constexpr uint32_t Op = 0b0110'1100'00 << 22;
+    LoadStoreNoAllocate(Op, rt, rt2, rn, static_cast<uint32_t>(Imm >> 3) & 0b111'1111);
+  }
+  void ldnp(FEXCore::ARMEmitter::DRegister rt, FEXCore::ARMEmitter::DRegister rt2, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -512 && Imm <= 504 && ((Imm & 0b111) == 0), "Unscaled offset too large");
+    constexpr uint32_t Op = 0b0110'1100'01 << 22;
+    LoadStoreNoAllocate(Op, rt, rt2, rn, static_cast<uint32_t>(Imm >> 3) & 0b111'1111);
+  }
+  void stnp(FEXCore::ARMEmitter::QRegister rt, FEXCore::ARMEmitter::QRegister rt2, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -1024 && Imm <= 1008 && ((Imm & 0b1111) == 0), "Unscaled offset too large");
+    constexpr uint32_t Op = 0b1010'1100'00 << 22;
+    LoadStoreNoAllocate(Op, rt, rt2, rn, static_cast<uint32_t>(Imm >> 4) & 0b111'1111);
+  }
+  void ldnp(FEXCore::ARMEmitter::QRegister rt, FEXCore::ARMEmitter::QRegister rt2, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -1024 && Imm <= 1008 && ((Imm & 0b1111) == 0), "Unscaled offset too large");
+    constexpr uint32_t Op = 0b1010'1100'01 << 22;
+    LoadStoreNoAllocate(Op, rt, rt2, rn, static_cast<uint32_t>(Imm >> 4) & 0b111'1111);
+  }
+  // Loadstore register pair post-indexed
+  // Loadstore register pair offset
+  // Loadstore register pair pre-indexed
+  template<IndexType Index>
+  void stp(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::WRegister rt2, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 252 && ((Imm & 0b11) == 0), "Unscaled offset too large");
+    constexpr uint32_t Op = (0b0010'1000'00 << 22) |
+      (
+        Index == IndexType::POST   ? (0b01 << 23) :
+        Index == IndexType::PRE    ? (0b11 << 23) :
+        Index == IndexType::OFFSET ? (0b10 << 23) : -1
+      );
+
+    LoadStorePair(Op, rt, rt2, rn, (Imm >> 2) & 0b111'1111);
+  }
+  template<IndexType Index>
+  void ldp(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::WRegister rt2, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 252 && ((Imm & 0b11) == 0), "Unscaled offset too large");
+    constexpr uint32_t Op = (0b0010'1000'01 << 22) |
+      (
+        Index == IndexType::POST   ? (0b01 << 23) :
+        Index == IndexType::PRE    ? (0b11 << 23) :
+        Index == IndexType::OFFSET ? (0b10 << 23) : -1
+      );
+
+    LoadStorePair(Op, rt, rt2, rn, (Imm >> 2) & 0b111'1111);
+  }
+  template <IndexType Index>
+  void ldpsw(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::XRegister rt2, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 252 && ((Imm & 0b11) == 0), "Unscaled offset too large");
+    constexpr uint32_t Op = (0b0110'1000'01 << 22) |
+      (
+        Index == IndexType::POST   ? (0b01 << 23) :
+        Index == IndexType::PRE    ? (0b11 << 23) :
+        Index == IndexType::OFFSET ? (0b10 << 23) : -1
+      );
+    LoadStorePair(Op, rt, rt2, rn, (Imm >> 2) & 0b111'1111);
+  }
+  template<IndexType Index>
+  void stp(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::XRegister rt2, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    LOGMAN_THROW_A_FMT(Imm >= -512 && Imm <= 504 && ((Imm & 0b111) == 0), "Unscaled offset too large");
+    constexpr uint32_t Op = (0b1010'1000'00 << 22) |
+      (
+        Index == IndexType::POST   ? (0b01 << 23) :
+        Index == IndexType::PRE    ? (0b11 << 23) :
+        Index == IndexType::OFFSET ? (0b10 << 23) : -1
+      );
+
+    LoadStorePair(Op, rt, rt2, rn, (Imm >> 3) & 0b111'1111);
+  }
+  template<IndexType Index>
+  void ldp(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::XRegister rt2, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    LOGMAN_THROW_A_FMT(Imm >= -512 && Imm <= 504 && ((Imm & 0b111) == 0), "Unscaled offset too large");
+    constexpr uint32_t Op = (0b1010'1000'01 << 22) |
+      (
+        Index == IndexType::POST   ? (0b01 << 23) :
+        Index == IndexType::PRE    ? (0b11 << 23) :
+        Index == IndexType::OFFSET ? (0b10 << 23) : -1
+      );
+
+    LoadStorePair(Op, rt, rt2, rn, (Imm >> 3) & 0b111'1111);
+  }
+  template <IndexType Index>
+  void stp(FEXCore::ARMEmitter::SRegister rt, FEXCore::ARMEmitter::SRegister rt2, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    stp_w<Index>(rt.V(), rt2.V(), rn, Imm);
+  }
+  template <IndexType Index>
+  void ldp(FEXCore::ARMEmitter::SRegister rt, FEXCore::ARMEmitter::SRegister rt2, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    ldp_w<Index>(rt.V(), rt2.V(), rn, Imm);
+  }
+  template <IndexType Index>
+  void stp(FEXCore::ARMEmitter::DRegister rt, FEXCore::ARMEmitter::DRegister rt2, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    stp_x<Index>(rt.V(), rt2.V(), rn, Imm);
+  }
+  template <IndexType Index>
+  void ldp(FEXCore::ARMEmitter::DRegister rt, FEXCore::ARMEmitter::DRegister rt2, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    ldp_x<Index>(rt.V(), rt2.V(), rn, Imm);
+  }
+  template <IndexType Index>
+  void stp(FEXCore::ARMEmitter::QRegister rt, FEXCore::ARMEmitter::QRegister rt2, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    stp_q<Index>(rt.V(), rt2.V(), rn, Imm);
+  }
+  template <IndexType Index>
+  void ldp(FEXCore::ARMEmitter::QRegister rt, FEXCore::ARMEmitter::QRegister rt2, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    ldp_q<Index>(rt.V(), rt2.V(), rn, Imm);
+  }
+
+  // Loadstore register unscaled immediate
+  void sturb(FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    stXrb<IndexType::OFFSET>(rt, rn, Imm);
+  }
+  void ldurb(FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    ldXrb<IndexType::OFFSET>(rt, rn, Imm);
+  }
+  void sturb(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    stXrb<IndexType::OFFSET>(rt, rn, Imm);
+  }
+  void ldurb(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    ldXrb<IndexType::OFFSET>(rt, rn, Imm);
+  }
+  void ldursb(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    ldXrsb<IndexType::OFFSET>(rt, rn, Imm);
+  }
+  void ldursb(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    ldXrsb<IndexType::OFFSET>(rt, rn, Imm);
+  }
+  void sturh(FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    stXrh<IndexType::OFFSET>(rt, rn, Imm);
+  }
+  void ldurh(FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    ldXrh<IndexType::OFFSET>(rt, rn, Imm);
+  }
+  void sturh(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    stXrh<IndexType::OFFSET>(rt, rn, Imm);
+  }
+  void ldurh(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    ldXrh<IndexType::OFFSET>(rt, rn, Imm);
+  }
+  void ldursh(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    ldXrsh<IndexType::OFFSET>(rt, rn, Imm);
+  }
+  void ldursh(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    ldXrsh<IndexType::OFFSET>(rt, rn, Imm);
+  }
+  void stur(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    stXr<IndexType::OFFSET>(rt, rn, Imm);
+  }
+  void ldur(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    ldXr<IndexType::OFFSET>(rt, rn, Imm);
+  }
+  void stur(FEXCore::ARMEmitter::SRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    stXr<IndexType::OFFSET>(rt, rn, Imm);
+  }
+  void ldur(FEXCore::ARMEmitter::SRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    ldXr<IndexType::OFFSET>(rt, rn, Imm);
+  }
+  void ldursw(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    ldXrsw<IndexType::OFFSET>(rt, rn, Imm);
+  }
+  void stur(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    stXr<IndexType::OFFSET>(rt, rn, Imm);
+  }
+  void ldur(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    ldXr<IndexType::OFFSET>(rt, rn, Imm);
+  }
+  void stur(FEXCore::ARMEmitter::DRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    stXr<IndexType::OFFSET>(rt, rn, Imm);
+  }
+  void ldur(FEXCore::ARMEmitter::DRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    ldXr<IndexType::OFFSET>(rt, rn, Imm);
+  }
+  void stur(FEXCore::ARMEmitter::QRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    stXr<IndexType::OFFSET>(rt, rn, Imm);
+  }
+  void ldur(FEXCore::ARMEmitter::QRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    ldXr<IndexType::OFFSET>(rt, rn, Imm);
+  }
+  template <IndexType Index>
+  void prfum(FEXCore::ARMEmitter::Prefetch prfop, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
+    static_assert(Index == IndexType::OFFSET, "Doesn't support another index type");
+
+    constexpr uint32_t Op = 0b1111'1000'10 << 22;
+    constexpr uint32_t o2 = 0b00;
+
+    LoadStoreImm(Op, o2, prfop, rn, Imm);
+  }
+
+  // Loadstore register immediate post-indexed
+  // Loadstore register immediate pre-indexed
+  template <IndexType Index>
+  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  void strb(FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    stXrb<Index>(rt, rn, Imm);
+  }
+  template <IndexType Index>
+  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  void ldrb(FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    ldXrb<Index>(rt, rn, Imm);
+  }
+  template <IndexType Index>
+  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  void strb(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    stXrb<Index>(rt, rn, Imm);
+  }
+  template <IndexType Index>
+  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  void ldrb(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    ldXrb<Index>(rt, rn, Imm);
+  }
+  template <IndexType Index>
+  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  void ldrsb(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    ldXrsb<Index>(rt, rn, Imm);
+  }
+  template <IndexType Index>
+  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  void ldrsb(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    ldXrsb<Index>(rt, rn, Imm);
+  }
+  template <IndexType Index>
+  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  void strh(FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    stXrh<Index>(rt, rn, Imm);
+  }
+  template <IndexType Index>
+  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  void ldrh(FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    ldXrh<Index>(rt, rn, Imm);
+  }
+  template <IndexType Index>
+  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  void strh(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    stXrh<Index>(rt, rn, Imm);
+  }
+  template <IndexType Index>
+  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  void ldrh(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    ldXrh<Index>(rt, rn, Imm);
+  }
+  template <IndexType Index>
+  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  void ldrsh(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    ldXrsh<Index>(rt, rn, Imm);
+  }
+  template <IndexType Index>
+  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  void ldrsh(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    ldXrsh<Index>(rt, rn, Imm);
+  }
+  template <IndexType Index>
+  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  void str(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    stXr<Index>(rt, rn, Imm);
+  }
+  template <IndexType Index>
+  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  void ldr(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    ldXr<Index>(rt, rn, Imm);
+  }
+  template <IndexType Index>
+  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  void str(FEXCore::ARMEmitter::SRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    stXr<Index>(rt, rn, Imm);
+  }
+  template <IndexType Index>
+  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  void ldr(FEXCore::ARMEmitter::SRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    ldXr<Index>(rt, rn, Imm);
+  }
+  template <IndexType Index>
+  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  void ldrsw(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    ldXrsw<Index>(rt, rn, Imm);
+  }
+  template <IndexType Index>
+  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  void str(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    stXr<Index>(rt, rn, Imm);
+  }
+  template <IndexType Index>
+  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  void ldr(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    ldXr<Index>(rt, rn, Imm);
+  }
+  template <IndexType Index>
+  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  void str(FEXCore::ARMEmitter::DRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    stXr<Index>(rt, rn, Imm);
+  }
+  template <IndexType Index>
+  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  void ldr(FEXCore::ARMEmitter::DRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    ldXr<Index>(rt, rn, Imm);
+  }
+  template <IndexType Index>
+  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  void str(FEXCore::ARMEmitter::QRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    stXr<Index>(rt, rn, Imm);
+  }
+  template <IndexType Index>
+  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  void ldr(FEXCore::ARMEmitter::QRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    ldXr<Index>(rt, rn, Imm);
+  }
+
+  // Loadstore register unprivileged
+  void sttrb(FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    stXrb<IndexType::UNPRIVILEGED>(rt, rn, Imm);
+  }
+  void ldtrb(FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    ldXrb<IndexType::UNPRIVILEGED>(rt, rn, Imm);
+  }
+  void ldtrsb(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    ldXrsb<IndexType::UNPRIVILEGED>(rt, rn, Imm);
+  }
+  void ldtrsb(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    ldXrsb<IndexType::UNPRIVILEGED>(rt, rn, Imm);
+  }
+  void sttrh(FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    stXrh<IndexType::UNPRIVILEGED>(rt, rn, Imm);
+  }
+  void ldtrh(FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    ldXrh<IndexType::UNPRIVILEGED>(rt, rn, Imm);
+  }
+  void ldtrsh(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    ldXrsh<IndexType::UNPRIVILEGED>(rt, rn, Imm);
+  }
+  void ldtrsh(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    ldXrsh<IndexType::UNPRIVILEGED>(rt, rn, Imm);
+  }
+  void sttr(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    stXr<IndexType::UNPRIVILEGED>(rt, rn, Imm);
+  }
+  void ldtr(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    ldXr<IndexType::UNPRIVILEGED>(rt, rn, Imm);
+  }
+  void ldtrsw(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    ldXrsw<IndexType::UNPRIVILEGED>(rt, rn, Imm);
+  }
+  void sttr(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    stXr<IndexType::UNPRIVILEGED>(rt, rn, Imm);
+  }
+  void ldtr(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    ldXr<IndexType::UNPRIVILEGED>(rt, rn, Imm);
+  }
+  // Atomic memory operations
+  void stadd(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, size, 0, 0, 0, 0b000, rs, FEXCore::ARMEmitter::Reg::zr, rn);
+  }
+  void staddl(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, size, 0, 1, 0, 0b000, rs, FEXCore::ARMEmitter::Reg::zr, rn);
+  }
+  void stclr(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, size, 0, 0, 0, 0b001, rs, FEXCore::ARMEmitter::Reg::zr, rn);
+  }
+  void stclrl(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, size, 0, 1, 0, 0b001, rs, FEXCore::ARMEmitter::Reg::zr, rn);
+  }
+  void stset(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, size, 0, 0, 0, 0b011, rs, FEXCore::ARMEmitter::Reg::zr, rn);
+  }
+  void stsetl(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, size, 0, 1, 0, 0b011, rs, FEXCore::ARMEmitter::Reg::zr, rn);
+  }
+  void steor(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, size, 0, 0, 0, 0b010, rs, FEXCore::ARMEmitter::Reg::zr, rn);
+  }
+  void steorl(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, size, 0, 1, 0, 0b010, rs, FEXCore::ARMEmitter::Reg::zr, rn);
+  }
+  void ldswp(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, size, 0, 0, 1, 0b000, rs, rt, rn);
+  }
+  void ldswpl(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, size, 0, 1, 1, 0b000, rs, rt, rn);
+  }
+  void ldswpa(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, size, 1, 0, 1, 0b000, rs, rt, rn);
+  }
+  void ldswpal(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, size, 1, 1, 1, 0b000, rs, rt, rn);
+  }
+
+  void ldadd(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, size, 0, 0, 0, 0b000, rs, rt, rn);
+  }
+  void ldadda(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, size, 1, 0, 0, 0b000, rs, rt, rn);
+  }
+  void ldaddl(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, size, 0, 1, 0, 0b000, rs, rt, rn);
+  }
+  void ldaddal(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, size, 1, 1, 0, 0b000, rs, rt, rn);
+  }
+  void ldclr(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, size, 0, 0, 0, 0b001, rs, rt, rn);
+  }
+  void ldclra(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, size, 1, 0, 0, 0b001, rs, rt, rn);
+  }
+  void ldclrl(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, size, 0, 1, 0, 0b001, rs, rt, rn);
+  }
+  void ldclral(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, size, 1, 1, 0, 0b001, rs, rt, rn);
+  }
+
+  void ldset(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, size, 0, 0, 0, 0b011, rs, rt, rn);
+  }
+  void ldseta(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, size, 1, 0, 0, 0b011, rs, rt, rn);
+  }
+  void ldsetl(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, size, 0, 1, 0, 0b011, rs, rt, rn);
+  }
+  void ldsetal(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, size, 1, 1, 0, 0b011, rs, rt, rn);
+  }
+  void ldeor(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, size, 0, 0, 0, 0b010, rs, rt, rn);
+  }
+  void ldeora(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, size, 1, 0, 0, 0b010, rs, rt, rn);
+  }
+  void ldeorl(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, size, 0, 1, 0, 0b010, rs, rt, rn);
+  }
+  void ldeoral(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, size, 1, 1, 0, 0b010, rs, rt, rn);
+  }
+
+
+  // 8-bit
+  void ldaddb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 0, 0, 0, 0b000, rs, rt, rn);
+  }
+  void ldclrb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 0, 0, 0, 0b001, rs, rt, rn);
+  }
+  void ldeorb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 0, 0, 0, 0b010, rs, rt, rn);
+  }
+  void ldsetb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 0, 0, 0, 0b011, rs, rt, rn);
+  }
+  void ldsmaxb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 0, 0, 0, 0b100, rs, rt, rn);
+  }
+  void ldsminb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 0, 0, 0, 0b101, rs, rt, rn);
+  }
+  void ldumaxb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 0, 0, 0, 0b110, rs, rt, rn);
+  }
+  void lduminb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 0, 0, 0, 0b111, rs, rt, rn);
+  }
+  void ldswpb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 0, 0, 1, 0b000, rs, rt, rn);
+  }
+  void ldaddlb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 0, 1, 0, 0b000, rs, rt, rn);
+  }
+  void ldclrlb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 0, 1, 0, 0b001, rs, rt, rn);
+  }
+  void ldeorlb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 0, 1, 0, 0b010, rs, rt, rn);
+  }
+  void ldsetlb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 0, 1, 0, 0b011, rs, rt, rn);
+  }
+  void ldsmaxlb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 0, 1, 0, 0b100, rs, rt, rn);
+  }
+  void ldsminlb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 0, 1, 0, 0b101, rs, rt, rn);
+  }
+  void ldumaxlb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 0, 1, 0, 0b110, rs, rt, rn);
+  }
+  void lduminlb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 0, 1, 0, 0b111, rs, rt, rn);
+  }
+  void ldswplb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 0, 1, 1, 0b000, rs, rt, rn);
+  }
+  void ldaddab(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 1, 0, 0, 0b000, rs, rt, rn);
+  }
+  void ldclrab(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 1, 0, 0, 0b001, rs, rt, rn);
+  }
+  void ldeorab(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 1, 0, 0, 0b010, rs, rt, rn);
+  }
+  void ldsetab(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 1, 0, 0, 0b011, rs, rt, rn);
+  }
+  void ldsmaxab(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 1, 0, 0, 0b100, rs, rt, rn);
+  }
+  void ldsminab(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 1, 0, 0, 0b101, rs, rt, rn);
+  }
+  void ldumaxab(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 1, 0, 0, 0b110, rs, rt, rn);
+  }
+  void lduminab(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 1, 0, 0, 0b111, rs, rt, rn);
+  }
+  void ldswpab(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 1, 0, 1, 0b000, rs, rt, rn);
+  }
+  void ldaddalb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 1, 1, 0, 0b000, rs, rt, rn);
+  }
+  void ldclralb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 1, 1, 0, 0b001, rs, rt, rn);
+  }
+  void ldeoralb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 1, 1, 0, 0b010, rs, rt, rn);
+  }
+  void ldsetalb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 1, 1, 0, 0b011, rs, rt, rn);
+  }
+  void ldsmaxalb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 1, 1, 0, 0b100, rs, rt, rn);
+  }
+  void ldsminalb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 1, 1, 0, 0b101, rs, rt, rn);
+  }
+  void ldumaxalb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 1, 1, 0, 0b110, rs, rt, rn);
+  }
+  void lduminalb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 1, 1, 0, 0b111, rs, rt, rn);
+  }
+  void ldswpalb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 1, 1, 1, 0b000, rs, rt, rn);
+  }
+  // 16-bit
+  void ldaddh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 0, 0, 0, 0b000, rs, rt, rn);
+  }
+  void ldclrh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 0, 0, 0, 0b001, rs, rt, rn);
+  }
+  void ldeorh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 0, 0, 0, 0b010, rs, rt, rn);
+  }
+  void ldseth(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 0, 0, 0, 0b011, rs, rt, rn);
+  }
+  void ldsmaxh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 0, 0, 0, 0b100, rs, rt, rn);
+  }
+  void ldsminh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 0, 0, 0, 0b101, rs, rt, rn);
+  }
+  void ldumaxh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 0, 0, 0, 0b110, rs, rt, rn);
+  }
+  void lduminh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 0, 0, 0, 0b111, rs, rt, rn);
+  }
+  void ldswph(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 0, 0, 1, 0b000, rs, rt, rn);
+  }
+  void ldaddlh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 0, 1, 0, 0b000, rs, rt, rn);
+  }
+  void ldclrlh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 0, 1, 0, 0b001, rs, rt, rn);
+  }
+  void ldeorlh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 0, 1, 0, 0b010, rs, rt, rn);
+  }
+  void ldsetlh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 0, 1, 0, 0b011, rs, rt, rn);
+  }
+  void ldsmaxlh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 0, 1, 0, 0b100, rs, rt, rn);
+  }
+  void ldsminlh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 0, 1, 0, 0b101, rs, rt, rn);
+  }
+  void ldumaxlh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 0, 1, 0, 0b110, rs, rt, rn);
+  }
+  void lduminlh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 0, 1, 0, 0b111, rs, rt, rn);
+  }
+  void ldswplh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 0, 1, 1, 0b000, rs, rt, rn);
+  }
+  void ldaddah(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 1, 0, 0, 0b000, rs, rt, rn);
+  }
+  void ldclrah(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 1, 0, 0, 0b001, rs, rt, rn);
+  }
+  void ldeorah(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 1, 0, 0, 0b010, rs, rt, rn);
+  }
+  void ldsetah(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 1, 0, 0, 0b011, rs, rt, rn);
+  }
+  void ldsmaxah(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 1, 0, 0, 0b100, rs, rt, rn);
+  }
+  void ldsminah(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 1, 0, 0, 0b101, rs, rt, rn);
+  }
+  void ldumaxah(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 1, 0, 0, 0b110, rs, rt, rn);
+  }
+  void lduminah(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 1, 0, 0, 0b111, rs, rt, rn);
+  }
+  void ldswpah(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 1, 0, 1, 0b000, rs, rt, rn);
+  }
+  void ldaddalh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 1, 1, 0, 0b000, rs, rt, rn);
+  }
+  void ldclralh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 1, 1, 0, 0b001, rs, rt, rn);
+  }
+  void ldeoralh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 1, 1, 0, 0b010, rs, rt, rn);
+  }
+  void ldsetalh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 1, 1, 0, 0b011, rs, rt, rn);
+  }
+  void ldsmaxalh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 1, 1, 0, 0b100, rs, rt, rn);
+  }
+  void ldsminalh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 1, 1, 0, 0b101, rs, rt, rn);
+  }
+  void ldumaxalh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 1, 1, 0, 0b110, rs, rt, rn);
+  }
+  void lduminalh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 1, 1, 0, 0b111, rs, rt, rn);
+  }
+  void ldswpalh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 1, 1, 1, 0b000, rs, rt, rn);
+  }
+  // 32-bit
+  void ldadd(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 0, 0, 0, 0b000, rs, rt, rn);
+  }
+  void ldclr(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 0, 0, 0, 0b001, rs, rt, rn);
+  }
+  void ldeor(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 0, 0, 0, 0b010, rs, rt, rn);
+  }
+  void ldset(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 0, 0, 0, 0b011, rs, rt, rn);
+  }
+  void ldsmax(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 0, 0, 0, 0b100, rs, rt, rn);
+  }
+  void ldsmin(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 0, 0, 0, 0b101, rs, rt, rn);
+  }
+  void ldumax(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 0, 0, 0, 0b110, rs, rt, rn);
+  }
+  void ldumin(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 0, 0, 0, 0b111, rs, rt, rn);
+  }
+  void ldswp(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 0, 0, 1, 0b000, rs, rt, rn);
+  }
+  void ldaddl(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 0, 1, 0, 0b000, rs, rt, rn);
+  }
+  void ldclrl(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 0, 1, 0, 0b001, rs, rt, rn);
+  }
+  void ldeorl(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 0, 1, 0, 0b010, rs, rt, rn);
+  }
+  void ldsetl(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 0, 1, 0, 0b011, rs, rt, rn);
+  }
+  void ldsmaxl(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 0, 1, 0, 0b100, rs, rt, rn);
+  }
+  void ldsminl(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 0, 1, 0, 0b101, rs, rt, rn);
+  }
+  void ldumaxl(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 0, 1, 0, 0b110, rs, rt, rn);
+  }
+  void lduminl(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 0, 1, 0, 0b111, rs, rt, rn);
+  }
+  void ldswpl(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 0, 1, 1, 0b000, rs, rt, rn);
+  }
+  void ldadda(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 1, 0, 0, 0b000, rs, rt, rn);
+  }
+  void ldclra(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 1, 0, 0, 0b001, rs, rt, rn);
+  }
+  void ldeora(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 1, 0, 0, 0b010, rs, rt, rn);
+  }
+  void ldseta(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 1, 0, 0, 0b011, rs, rt, rn);
+  }
+  void ldsmaxa(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 1, 0, 0, 0b100, rs, rt, rn);
+  }
+  void ldsmina(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 1, 0, 0, 0b101, rs, rt, rn);
+  }
+  void ldumaxa(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 1, 0, 0, 0b110, rs, rt, rn);
+  }
+  void ldumina(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 1, 0, 0, 0b111, rs, rt, rn);
+  }
+  void ldswpa(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 1, 0, 1, 0b000, rs, rt, rn);
+  }
+  void ldaddal(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 1, 1, 0, 0b000, rs, rt, rn);
+  }
+  void ldclral(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 1, 1, 0, 0b001, rs, rt, rn);
+  }
+  void ldeoral(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 1, 1, 0, 0b010, rs, rt, rn);
+  }
+  void ldsetal(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 1, 1, 0, 0b011, rs, rt, rn);
+  }
+  void ldsmaxal(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 1, 1, 0, 0b100, rs, rt, rn);
+  }
+  void ldsminal(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 1, 1, 0, 0b101, rs, rt, rn);
+  }
+  void ldumaxal(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 1, 1, 0, 0b110, rs, rt, rn);
+  }
+  void lduminal(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 1, 1, 0, 0b111, rs, rt, rn);
+  }
+  void ldswpal(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 1, 1, 1, 0b000, rs, rt, rn);
+  }
+  // 64-bit
+  void ldadd(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 0, 0, 0, 0b000, rs, rt, rn);
+  }
+  void ldclr(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 0, 0, 0, 0b001, rs, rt, rn);
+  }
+  void ldeor(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 0, 0, 0, 0b010, rs, rt, rn);
+  }
+  void ldset(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 0, 0, 0, 0b011, rs, rt, rn);
+  }
+  void ldsmax(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 0, 0, 0, 0b100, rs, rt, rn);
+  }
+  void ldsmin(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 0, 0, 0, 0b101, rs, rt, rn);
+  }
+  void ldumax(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 0, 0, 0, 0b110, rs, rt, rn);
+  }
+  void ldumin(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 0, 0, 0, 0b111, rs, rt, rn);
+  }
+  void ldswp(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 0, 0, 1, 0b000, rs, rt, rn);
+  }
+  void ldaddl(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 0, 1, 0, 0b000, rs, rt, rn);
+  }
+  void ldclrl(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 0, 1, 0, 0b001, rs, rt, rn);
+  }
+  void ldeorl(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 0, 1, 0, 0b010, rs, rt, rn);
+  }
+  void ldsetl(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 0, 1, 0, 0b011, rs, rt, rn);
+  }
+  void ldsmaxl(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 0, 1, 0, 0b100, rs, rt, rn);
+  }
+  void ldsminl(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 0, 1, 0, 0b101, rs, rt, rn);
+  }
+  void ldumaxl(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 0, 1, 0, 0b110, rs, rt, rn);
+  }
+  void lduminl(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 0, 1, 0, 0b111, rs, rt, rn);
+  }
+  void ldswpl(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 0, 1, 1, 0b000, rs, rt, rn);
+  }
+  void ldadda(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 1, 0, 0, 0b000, rs, rt, rn);
+  }
+  void ldclra(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 1, 0, 0, 0b001, rs, rt, rn);
+  }
+  void ldeora(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 1, 0, 0, 0b010, rs, rt, rn);
+  }
+  void ldseta(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 1, 0, 0, 0b011, rs, rt, rn);
+  }
+  void ldsmaxa(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 1, 0, 0, 0b100, rs, rt, rn);
+  }
+  void ldsmina(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 1, 0, 0, 0b101, rs, rt, rn);
+  }
+  void ldumaxa(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 1, 0, 0, 0b110, rs, rt, rn);
+  }
+  void ldumina(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 1, 0, 0, 0b111, rs, rt, rn);
+  }
+  void ldswpa(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 1, 0, 1, 0b000, rs, rt, rn);
+  }
+  void ldaddal(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 1, 1, 0, 0b000, rs, rt, rn);
+  }
+  void ldclral(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 1, 1, 0, 0b001, rs, rt, rn);
+  }
+  void ldeoral(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 1, 1, 0, 0b010, rs, rt, rn);
+  }
+  void ldsetal(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 1, 1, 0, 0b011, rs, rt, rn);
+  }
+  void ldsmaxal(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 1, 1, 0, 0b100, rs, rt, rn);
+  }
+  void ldsminal(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 1, 1, 0, 0b101, rs, rt, rn);
+  }
+  void ldumaxal(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 1, 1, 0, 0b110, rs, rt, rn);
+  }
+  void lduminal(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 1, 1, 0, 0b111, rs, rt, rn);
+  }
+  void ldswpal(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 1, 1, 1, 0b000, rs, rt, rn);
+  }
+  void ldaprb(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 1, 0, 1, 0b100, FEXCore::ARMEmitter::WReg::w31, rt, rn);
+  }
+  void ldaprh(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 1, 0, 1, 0b100, FEXCore::ARMEmitter::WReg::w31, rt, rn);
+  }
+  void ldapr(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 1, 0, 1, 0b100, FEXCore::ARMEmitter::WReg::w31, rt, rn);
+  }
+  void ldapr(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 1, 0, 1, 0b100, FEXCore::ARMEmitter::XReg::x31, rt, rn);
+  }
+  void st64bv0(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 0, 0, 1, 0b010, rs, rt, rn);
+  }
+  void st64bv(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 0, 0, 1, 0b011, rs, rt, rn);
+  }
+  void st64b(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 0, 0, 1, 0b001, FEXCore::ARMEmitter::XReg::x31, rt, rn);
+  }
+  void ld64b(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
+    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 0, 0, 1, 0b101, FEXCore::ARMEmitter::XReg::x31, rt, rn);
+  }
+
+  // Loadstore register-register offset
+  void strb(FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ExtendedType Option, bool Shift = false) {
+    LOGMAN_THROW_A_FMT((FEXCore::ToUnderlying(Option) & 0b010) == 0b010, "Unsupported Extendtype");
+    constexpr uint32_t Op = 0b0011'1000'001 << 21 | (0b10 << 10);
+    LoadStoreRegisterOffset(Op, 0b00, rt, rn, rm, Option, Shift ? 1 : 0);
+  }
+  void ldrb(FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ExtendedType Option, bool Shift = false) {
+    LOGMAN_THROW_A_FMT((FEXCore::ToUnderlying(Option) & 0b010) == 0b010, "Unsupported Extendtype");
+    constexpr uint32_t Op = 0b0011'1000'001 << 21 | (0b10 << 10);
+    LoadStoreRegisterOffset(Op, 0b01, rt, rn, rm, Option, Shift ? 1 : 0);
+  }
+  void ldrsb(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ExtendedType Option, bool Shift = false) {
+    LOGMAN_THROW_A_FMT((FEXCore::ToUnderlying(Option) & 0b010) == 0b010, "Unsupported Extendtype");
+    constexpr uint32_t Op = 0b0011'1000'001 << 21 | (0b10 << 10);
+    LoadStoreRegisterOffset(Op, 0b10, rt, rn, rm, Option, Shift ? 1 : 0);
+  }
+  void ldrsb(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ExtendedType Option, bool Shift = false) {
+    LOGMAN_THROW_A_FMT((FEXCore::ToUnderlying(Option) & 0b010) == 0b010, "Unsupported Extendtype");
+    constexpr uint32_t Op = 0b0011'1000'001 << 21 | (0b10 << 10);
+    LoadStoreRegisterOffset(Op, 0b11, rt, rn, rm, Option, Shift ? 1 : 0);
+  }
+  void strh(FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ExtendedType Option, uint32_t Shift) {
+    LOGMAN_THROW_A_FMT((FEXCore::ToUnderlying(Option) & 0b010) == 0b010, "Unsupported Extendtype");
+    LOGMAN_THROW_A_FMT(Shift == 0 || Shift == 1, "Unsupported shift amount");
+    constexpr uint32_t Op = 0b0111'1000'001 << 21 | (0b10 << 10);
+    LoadStoreRegisterOffset(Op, 0b00, rt, rn, rm, Option, Shift ? 1 : 0);
+  }
+  void ldrh(FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ExtendedType Option, uint32_t Shift) {
+    LOGMAN_THROW_A_FMT((FEXCore::ToUnderlying(Option) & 0b010) == 0b010, "Unsupported Extendtype");
+    LOGMAN_THROW_A_FMT(Shift == 0 || Shift == 1, "Unsupported shift amount");
+    constexpr uint32_t Op = 0b0111'1000'001 << 21 | (0b10 << 10);
+    LoadStoreRegisterOffset(Op, 0b01, rt, rn, rm, Option, Shift ? 1 : 0);
+  }
+  void ldrsh(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ExtendedType Option, uint32_t Shift) {
+    LOGMAN_THROW_A_FMT((FEXCore::ToUnderlying(Option) & 0b010) == 0b010, "Unsupported Extendtype");
+    LOGMAN_THROW_A_FMT(Shift == 0 || Shift == 1, "Unsupported shift amount");
+    constexpr uint32_t Op = 0b0111'1000'001 << 21 | (0b10 << 10);
+    LoadStoreRegisterOffset(Op, 0b10, rt, rn, rm, Option, Shift ? 1 : 0);
+  }
+  void ldrsh(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ExtendedType Option, uint32_t Shift) {
+    LOGMAN_THROW_A_FMT((FEXCore::ToUnderlying(Option) & 0b010) == 0b010, "Unsupported Extendtype");
+    LOGMAN_THROW_A_FMT(Shift == 0 || Shift == 1, "Unsupported shift amount");
+    constexpr uint32_t Op = 0b0111'1000'001 << 21 | (0b10 << 10);
+    LoadStoreRegisterOffset(Op, 0b11, rt, rn, rm, Option, Shift ? 1 : 0);
+  }
+  void str(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ExtendedType Option, uint32_t Shift) {
+    LOGMAN_THROW_A_FMT((FEXCore::ToUnderlying(Option) & 0b010) == 0b010, "Unsupported Extendtype");
+    LOGMAN_THROW_A_FMT(Shift == 0 || Shift == 2, "Unsupported shift amount");
+    constexpr uint32_t Op = 0b1011'1000'001 << 21 | (0b10 << 10);
+    LoadStoreRegisterOffset(Op, 0b00, rt, rn, rm, Option, Shift ? 1 : 0);
+  }
+  void ldr(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ExtendedType Option, uint32_t Shift) {
+    LOGMAN_THROW_A_FMT((FEXCore::ToUnderlying(Option) & 0b010) == 0b010, "Unsupported Extendtype");
+    LOGMAN_THROW_A_FMT(Shift == 0 || Shift == 2, "Unsupported shift amount: {}", Shift);
+    constexpr uint32_t Op = 0b1011'1000'001 << 21 | (0b10 << 10);
+    LoadStoreRegisterOffset(Op, 0b01, rt, rn, rm, Option, Shift ? 1 : 0);
+  }
+  void ldrsw(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ExtendedType Option, uint32_t Shift) {
+    LOGMAN_THROW_A_FMT((FEXCore::ToUnderlying(Option) & 0b010) == 0b010, "Unsupported Extendtype");
+    LOGMAN_THROW_A_FMT(Shift == 0 || Shift == 2, "Unsupported shift amount");
+    constexpr uint32_t Op = 0b1011'1000'001 << 21 | (0b10 << 10);
+    LoadStoreRegisterOffset(Op, 0b10, rt, rn, rm, Option, Shift ? 1 : 0);
+  }
+  void str(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ExtendedType Option, uint32_t Shift) {
+    LOGMAN_THROW_A_FMT((FEXCore::ToUnderlying(Option) & 0b010) == 0b010, "Unsupported Extendtype");
+    LOGMAN_THROW_A_FMT(Shift == 0 || Shift == 3, "Unsupported shift amount");
+    constexpr uint32_t Op = 0b1111'1000'001 << 21 | (0b10 << 10);
+    LoadStoreRegisterOffset(Op, 0b00, rt, rn, rm, Option, Shift ? 1 : 0);
+  }
+  void ldr(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ExtendedType Option, uint32_t Shift) {
+    LOGMAN_THROW_A_FMT((FEXCore::ToUnderlying(Option) & 0b010) == 0b010, "Unsupported Extendtype");
+    LOGMAN_THROW_A_FMT(Shift == 0 || Shift == 3, "Unsupported shift amount");
+    constexpr uint32_t Op = 0b1111'1000'001 << 21 | (0b10 << 10);
+    LoadStoreRegisterOffset(Op, 0b01, rt, rn, rm, Option, Shift ? 1 : 0);
+  }
+  void prfm(FEXCore::ARMEmitter::Prefetch prfop, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ExtendedType Option, uint32_t Shift) {
+    LOGMAN_THROW_A_FMT((FEXCore::ToUnderlying(Option) & 0b010) == 0b010, "Unsupported Extendtype");
+    LOGMAN_THROW_A_FMT(Shift == 0 || Shift == 3, "Unsupported shift amount");
+    constexpr uint32_t Op = 0b1111'1000'001 << 21 | (0b10 << 10);
+    LoadStoreRegisterOffset(Op, 0b10, prfop, rn, rm, Option, Shift ? 1 : 0);
+  }
+  void strb(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ExtendedType Option) {
+    LOGMAN_THROW_A_FMT((FEXCore::ToUnderlying(Option) & 0b010) == 0b010, "Unsupported Extendtype");
+    constexpr uint32_t Op = 0b0011'1100'001 << 21 | (0b10 << 10);
+    LoadStoreRegisterOffset(Op, 0b00, rt, rn, rm, Option, 0);
+  }
+  void ldrb(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ExtendedType Option) {
+    LOGMAN_THROW_A_FMT((FEXCore::ToUnderlying(Option) & 0b010) == 0b010, "Unsupported Extendtype");
+    constexpr uint32_t Op = 0b0011'1100'001 << 21 | (0b10 << 10);
+    LoadStoreRegisterOffset(Op, 0b01, rt, rn, rm, Option, 0);
+  }
+  void strh(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ExtendedType Option, uint32_t Shift) {
+    LOGMAN_THROW_A_FMT((FEXCore::ToUnderlying(Option) & 0b010) == 0b010, "Unsupported Extendtype");
+    LOGMAN_THROW_A_FMT(Shift == 0 || Shift == 1, "Unsupported shift amount");
+    constexpr uint32_t Op = 0b0111'1100'001 << 21 | (0b10 << 10);
+    LoadStoreRegisterOffset(Op, 0b00, rt, rn, rm, Option, Shift ? 1 : 0);
+  }
+  void ldrh(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ExtendedType Option, uint32_t Shift) {
+    LOGMAN_THROW_A_FMT((FEXCore::ToUnderlying(Option) & 0b010) == 0b010, "Unsupported Extendtype");
+    LOGMAN_THROW_A_FMT(Shift == 0 || Shift == 1, "Unsupported shift amount");
+    constexpr uint32_t Op = 0b0111'1100'001 << 21 | (0b10 << 10);
+    LoadStoreRegisterOffset(Op, 0b01, rt, rn, rm, Option, Shift ? 1 : 0);
+  }
+  void str(FEXCore::ARMEmitter::SRegister rt, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ExtendedType Option, uint32_t Shift) {
+    LOGMAN_THROW_A_FMT((FEXCore::ToUnderlying(Option) & 0b010) == 0b010, "Unsupported Extendtype");
+    LOGMAN_THROW_A_FMT(Shift == 0 || Shift == 2, "Unsupported shift amount");
+    constexpr uint32_t Op = 0b1011'1100'001 << 21 | (0b10 << 10);
+    LoadStoreRegisterOffset(Op, 0b00, rt, rn, rm, Option, Shift ? 1 : 0);
+  }
+  void ldr(FEXCore::ARMEmitter::SRegister rt, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ExtendedType Option, uint32_t Shift) {
+    LOGMAN_THROW_A_FMT((FEXCore::ToUnderlying(Option) & 0b010) == 0b010, "Unsupported Extendtype");
+    LOGMAN_THROW_A_FMT(Shift == 0 || Shift == 2, "Unsupported shift amount");
+    constexpr uint32_t Op = 0b1011'1100'001 << 21 | (0b10 << 10);
+    LoadStoreRegisterOffset(Op, 0b01, rt, rn, rm, Option, Shift ? 1 : 0);
+  }
+  void str(FEXCore::ARMEmitter::DRegister rt, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ExtendedType Option, uint32_t Shift) {
+    LOGMAN_THROW_A_FMT((FEXCore::ToUnderlying(Option) & 0b010) == 0b010, "Unsupported Extendtype");
+    LOGMAN_THROW_A_FMT(Shift == 0 || Shift == 3, "Unsupported shift amount");
+    constexpr uint32_t Op = 0b1111'1100'001 << 21 | (0b10 << 10);
+    LoadStoreRegisterOffset(Op, 0b00, rt, rn, rm, Option, Shift ? 1 : 0);
+  }
+  void ldr(FEXCore::ARMEmitter::DRegister rt, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ExtendedType Option, uint32_t Shift) {
+    LOGMAN_THROW_A_FMT((FEXCore::ToUnderlying(Option) & 0b010) == 0b010, "Unsupported Extendtype");
+    LOGMAN_THROW_A_FMT(Shift == 0 || Shift == 3, "Unsupported shift amount");
+    constexpr uint32_t Op = 0b1111'1100'001 << 21 | (0b10 << 10);
+    LoadStoreRegisterOffset(Op, 0b01, rt, rn, rm, Option, Shift ? 1 : 0);
+  }
+  void str(FEXCore::ARMEmitter::QRegister rt, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ExtendedType Option, uint32_t Shift) {
+    LOGMAN_THROW_A_FMT((FEXCore::ToUnderlying(Option) & 0b010) == 0b010, "Unsupported Extendtype");
+    LOGMAN_THROW_A_FMT(Shift == 0 || Shift == 4, "Unsupported shift amount");
+    constexpr uint32_t Op = 0b0011'1100'001 << 21 | (0b10 << 10);
+    LoadStoreRegisterOffset(Op, 0b10, rt, rn, rm, Option, Shift ? 1 : 0);
+  }
+  void ldr(FEXCore::ARMEmitter::QRegister rt, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ExtendedType Option, uint32_t Shift) {
+    LOGMAN_THROW_A_FMT((FEXCore::ToUnderlying(Option) & 0b010) == 0b010, "Unsupported Extendtype");
+    LOGMAN_THROW_A_FMT(Shift == 0 || Shift == 4, "Unsupported shift amount");
+    constexpr uint32_t Op = 0b0011'1100'001 << 21 | (0b10 << 10);
+    LoadStoreRegisterOffset(Op, 0b11, rt, rn, rm, Option, Shift ? 1 : 0);
+  }
+
+  void strb(FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::ExtendedMemOperand MemSrc) {
+    if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
+        MemSrc.MetaType.ExtendedType.rm.Idx() != FEXCore::ARMEmitter::Reg::r31.Idx()) {
+      strb(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option, MemSrc.MetaType.ExtendedType.Shift);
+    }
+    else if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+      strb(rt, MemSrc.rn);
+    }
+    else {
+      if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
+        if (MemSrc.MetaType.ImmType.Imm < 0) {
+          sturb(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+        else {
+          strb(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+        strb<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+        strb<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else {
+        LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
+        FEX_UNREACHABLE;
+      }
+    }
+  }
+  void ldrb(FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::ExtendedMemOperand MemSrc) {
+    if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
+        MemSrc.MetaType.ExtendedType.rm.Idx() != FEXCore::ARMEmitter::Reg::r31.Idx()) {
+      ldrb(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option, MemSrc.MetaType.ExtendedType.Shift);
+    }
+    else if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+      ldrb(rt, MemSrc.rn);
+    }
+    else {
+      if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
+        if (MemSrc.MetaType.ImmType.Imm < 0) {
+          ldurb(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+        else {
+          ldrb(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+        ldrb<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+        ldrb<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else {
+        LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
+        FEX_UNREACHABLE;
+      }
+    }
+  }
+  void ldrsb(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::ExtendedMemOperand MemSrc) {
+    if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
+        MemSrc.MetaType.ExtendedType.rm.Idx() != FEXCore::ARMEmitter::Reg::r31.Idx()) {
+      ldrsb(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option, MemSrc.MetaType.ExtendedType.Shift);
+    }
+    else if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+      ldrsb(rt, MemSrc.rn);
+    }
+    else {
+      if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
+        if (MemSrc.MetaType.ImmType.Imm < 0) {
+          ldursb(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+        else {
+          ldrsb(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+        ldrsb<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+        ldrsb<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else {
+        LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
+        FEX_UNREACHABLE;
+      }
+    }
+  }
+  void ldrsb(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::ExtendedMemOperand MemSrc) {
+    if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
+        MemSrc.MetaType.ExtendedType.rm.Idx() != FEXCore::ARMEmitter::Reg::r31.Idx()) {
+      ldrsb(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option, MemSrc.MetaType.ExtendedType.Shift);
+    }
+    else if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+      ldrsb(rt, MemSrc.rn);
+    }
+    else {
+      if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
+        if (MemSrc.MetaType.ImmType.Imm < 0) {
+          ldursb(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+        else {
+          ldrsb(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+        ldrsb<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+        ldrsb<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else {
+        LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
+        FEX_UNREACHABLE;
+      }
+    }
+  }
+  void strh(FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::ExtendedMemOperand MemSrc) {
+    if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
+        MemSrc.MetaType.ExtendedType.rm.Idx() != FEXCore::ARMEmitter::Reg::r31.Idx()) {
+      strh(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option, MemSrc.MetaType.ExtendedType.Shift);
+    }
+    else if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+      strh(rt, MemSrc.rn);
+    }
+    else {
+      if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
+        if ((MemSrc.MetaType.ImmType.Imm & 0b1) || MemSrc.MetaType.ImmType.Imm < 0) {
+          sturh(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+        else {
+          strh(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+        strh<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+        strh<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else {
+        LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
+        FEX_UNREACHABLE;
+      }
+    }
+  }
+  void ldrh(FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::ExtendedMemOperand MemSrc) {
+    if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
+        MemSrc.MetaType.ExtendedType.rm.Idx() != FEXCore::ARMEmitter::Reg::r31.Idx()) {
+      ldrh(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option, MemSrc.MetaType.ExtendedType.Shift);
+    }
+    else if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+      ldrh(rt, MemSrc.rn);
+    }
+    else {
+      if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
+        if ((MemSrc.MetaType.ImmType.Imm & 0b1) || MemSrc.MetaType.ImmType.Imm < 0) {
+          ldurh(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+        else {
+          ldrh(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+        ldrh<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+        ldrh<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else {
+        LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
+        FEX_UNREACHABLE;
+      }
+    }
+  }
+  void ldrsh(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::ExtendedMemOperand MemSrc) {
+    if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
+        MemSrc.MetaType.ExtendedType.rm.Idx() != FEXCore::ARMEmitter::Reg::r31.Idx()) {
+      ldrsh(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option, MemSrc.MetaType.ExtendedType.Shift);
+    }
+    else if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+      ldrsh(rt, MemSrc.rn);
+    }
+    else {
+      if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
+        if ((MemSrc.MetaType.ImmType.Imm & 0b1) || MemSrc.MetaType.ImmType.Imm < 0) {
+          ldursh(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+        else {
+          ldrsh(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+        ldrsh<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+        ldrsh<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else {
+        LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
+        FEX_UNREACHABLE;
+      }
+    }
+  }
+  void ldrsh(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::ExtendedMemOperand MemSrc) {
+    if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
+        MemSrc.MetaType.ExtendedType.rm.Idx() != FEXCore::ARMEmitter::Reg::r31.Idx()) {
+      ldrsh(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option, MemSrc.MetaType.ExtendedType.Shift);
+    }
+    else if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+      ldrsh(rt, MemSrc.rn);
+    }
+    else {
+      if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
+        if ((MemSrc.MetaType.ImmType.Imm & 0b1) || MemSrc.MetaType.ImmType.Imm < 0) {
+          ldursh(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+        else {
+          ldrsh(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+        ldrsh<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+        ldrsh<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else {
+        LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
+        FEX_UNREACHABLE;
+      }
+    }
+  }
+  void str(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::ExtendedMemOperand MemSrc) {
+    if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
+        MemSrc.MetaType.ExtendedType.rm.Idx() != FEXCore::ARMEmitter::Reg::r31.Idx()) {
+      str(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option, MemSrc.MetaType.ExtendedType.Shift);
+    }
+    else if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+      str(rt, MemSrc.rn);
+    }
+    else {
+      if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
+        if ((MemSrc.MetaType.ImmType.Imm & 0b11) || MemSrc.MetaType.ImmType.Imm < 0) {
+          stur(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+        else {
+          str(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+        str<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+        str<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else {
+        LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
+        FEX_UNREACHABLE;
+      }
+    }
+  }
+  void ldr(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::ExtendedMemOperand MemSrc) {
+    if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
+        MemSrc.MetaType.ExtendedType.rm.Idx() != FEXCore::ARMEmitter::Reg::r31.Idx()) {
+      ldr(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option, MemSrc.MetaType.ExtendedType.Shift);
+    }
+    else if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+      ldr(rt, MemSrc.rn);
+    }
+    else {
+      if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
+        if ((MemSrc.MetaType.ImmType.Imm & 0b11) || MemSrc.MetaType.ImmType.Imm < 0) {
+          ldur(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+        else {
+          ldr(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+        ldr<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+        ldr<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else {
+        LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
+        FEX_UNREACHABLE;
+      }
+    }
+  }
+  void ldrsw(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::ExtendedMemOperand MemSrc) {
+    if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
+        MemSrc.MetaType.ExtendedType.rm.Idx() != FEXCore::ARMEmitter::Reg::r31.Idx()) {
+      ldrsw(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option, MemSrc.MetaType.ExtendedType.Shift);
+    }
+    else if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+      ldrsw(rt, MemSrc.rn);
+    }
+    else {
+      if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
+        if ((MemSrc.MetaType.ImmType.Imm & 0b11) || MemSrc.MetaType.ImmType.Imm < 0) {
+          ldursw(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+        else {
+          ldrsw(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+        ldrsw<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+        ldrsw<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else {
+        LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
+        FEX_UNREACHABLE;
+      }
+    }
+  }
+  void str(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::ExtendedMemOperand MemSrc) {
+    if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
+        MemSrc.MetaType.ExtendedType.rm.Idx() != FEXCore::ARMEmitter::Reg::r31.Idx()) {
+      str(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option, MemSrc.MetaType.ExtendedType.Shift);
+    }
+    else if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+      str(rt, MemSrc.rn);
+    }
+    else {
+      if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
+        if ((MemSrc.MetaType.ImmType.Imm & 0b111) || MemSrc.MetaType.ImmType.Imm < 0) {
+          stur(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+        else {
+          str(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+        str<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+        str<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else {
+        LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
+        FEX_UNREACHABLE;
+      }
+    }
+  }
+  void ldr(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::ExtendedMemOperand MemSrc) {
+    if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
+        MemSrc.MetaType.ExtendedType.rm.Idx() != FEXCore::ARMEmitter::Reg::r31.Idx()) {
+      ldr(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option, MemSrc.MetaType.ExtendedType.Shift);
+    }
+    else if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+      ldr(rt, MemSrc.rn);
+    }
+    else {
+      if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
+        if ((MemSrc.MetaType.ImmType.Imm & 0b111) || MemSrc.MetaType.ImmType.Imm < 0) {
+          ldur(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+        else {
+          ldr(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+        ldr<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+        ldr<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else {
+        LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
+        FEX_UNREACHABLE;
+      }
+    }
+  }
+  void prfm(FEXCore::ARMEmitter::Prefetch prfop, FEXCore::ARMEmitter::ExtendedMemOperand MemSrc) {
+    if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
+        MemSrc.MetaType.ExtendedType.rm.Idx() != FEXCore::ARMEmitter::Reg::r31.Idx()) {
+      prfm(prfop, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option, MemSrc.MetaType.ExtendedType.Shift);
+    }
+    else if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+      prfm(prfop, MemSrc.rn);
+    }
+    else {
+      if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
+        prfm(prfop, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else {
+        LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
+        FEX_UNREACHABLE;
+      }
+    }
+  }
+
+  void strb(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::ExtendedMemOperand MemSrc) {
+    if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
+        MemSrc.MetaType.ExtendedType.rm.Idx() != FEXCore::ARMEmitter::Reg::r31.Idx()) {
+      LOGMAN_THROW_AA_FMT(MemSrc.MetaType.ExtendedType.Shift == false, "Can't shift byte");
+      LOGMAN_MSG_A_FMT("Nope"); // XXX: Implement
+      // strb(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option);
+    }
+    else if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+      strb(rt, MemSrc.rn);
+    }
+    else {
+      if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
+        if (MemSrc.MetaType.ImmType.Imm < 0) {
+          sturb(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+        else {
+          strb(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+        strb<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+        strb<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else {
+        LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
+        FEX_UNREACHABLE;
+      }
+    }
+  }
+  void ldrb(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::ExtendedMemOperand MemSrc) {
+    if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
+        MemSrc.MetaType.ExtendedType.rm.Idx() != FEXCore::ARMEmitter::Reg::r31.Idx()) {
+      LOGMAN_THROW_AA_FMT(MemSrc.MetaType.ExtendedType.Shift == false, "Can't shift byte");
+      LOGMAN_MSG_A_FMT("Nope"); // XXX: Implement
+      // ldrb(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option);
+    }
+    else if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+      ldrb(rt, MemSrc.rn);
+    }
+    else {
+      if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
+        if (MemSrc.MetaType.ImmType.Imm < 0) {
+          ldurb(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+        else {
+          ldrb(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+        ldrb<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+        ldrb<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else {
+        LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
+        FEX_UNREACHABLE;
+      }
+    }
+  }
+  void strh(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::ExtendedMemOperand MemSrc) {
+    if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
+        MemSrc.MetaType.ExtendedType.rm.Idx() != FEXCore::ARMEmitter::Reg::r31.Idx()) {
+      LOGMAN_THROW_AA_FMT(MemSrc.MetaType.ExtendedType.Shift == false, "Can't shift byte");
+      LOGMAN_MSG_A_FMT("Nope"); // XXX: Implement
+      // strh(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option);
+    }
+    else if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+      strh(rt, MemSrc.rn);
+    }
+    else {
+      if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
+        if ((MemSrc.MetaType.ImmType.Imm & 0b1) || MemSrc.MetaType.ImmType.Imm < 0) {
+          sturh(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+        else {
+          strh(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+        strh<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+        strh<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else {
+        LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
+        FEX_UNREACHABLE;
+      }
+    }
+  }
+  void ldrh(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::ExtendedMemOperand MemSrc) {
+    if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
+        MemSrc.MetaType.ExtendedType.rm.Idx() != FEXCore::ARMEmitter::Reg::r31.Idx()) {
+      LOGMAN_THROW_AA_FMT(MemSrc.MetaType.ExtendedType.Shift == false, "Can't shift byte");
+      LOGMAN_MSG_A_FMT("Nope"); // XXX: Implement
+      // ldrh(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option);
+    }
+    else if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+      ldrh(rt, MemSrc.rn);
+    }
+    else {
+      if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
+        if ((MemSrc.MetaType.ImmType.Imm & 0b1) || MemSrc.MetaType.ImmType.Imm < 0) {
+          ldurh(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+        else {
+          ldrh(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+        ldrh<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+        ldrh<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else {
+        LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
+        FEX_UNREACHABLE;
+      }
+    }
+  }
+  void str(FEXCore::ARMEmitter::SRegister rt, FEXCore::ARMEmitter::ExtendedMemOperand MemSrc) {
+    if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
+        MemSrc.MetaType.ExtendedType.rm.Idx() != FEXCore::ARMEmitter::Reg::r31.Idx()) {
+      str(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option, MemSrc.MetaType.ExtendedType.Shift);
+    }
+    else if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+      str(rt, MemSrc.rn);
+    }
+    else {
+      if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
+        if ((MemSrc.MetaType.ImmType.Imm & 0b11) || MemSrc.MetaType.ImmType.Imm < 0) {
+          stur(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+        else {
+          str(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+        str<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+        str<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else {
+        LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
+        FEX_UNREACHABLE;
+      }
+    }
+  }
+  void ldr(FEXCore::ARMEmitter::SRegister rt, FEXCore::ARMEmitter::ExtendedMemOperand MemSrc) {
+    if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
+        MemSrc.MetaType.ExtendedType.rm.Idx() != FEXCore::ARMEmitter::Reg::r31.Idx()) {
+      ldr(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option, MemSrc.MetaType.ExtendedType.Shift);
+    }
+    else if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+      ldr(rt, MemSrc.rn);
+    }
+    else {
+      if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
+        if ((MemSrc.MetaType.ImmType.Imm & 0b11) || MemSrc.MetaType.ImmType.Imm < 0) {
+          ldur(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+        else {
+          ldr(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+        ldr<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+        ldr<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else {
+        LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
+        FEX_UNREACHABLE;
+      }
+    }
+  }
+  void str(FEXCore::ARMEmitter::DRegister rt, FEXCore::ARMEmitter::ExtendedMemOperand MemSrc) {
+    if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
+        MemSrc.MetaType.ExtendedType.rm.Idx() != FEXCore::ARMEmitter::Reg::r31.Idx()) {
+      str(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option, MemSrc.MetaType.ExtendedType.Shift);
+    }
+    else if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+      str(rt, MemSrc.rn);
+    }
+    else {
+      if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
+        if ((MemSrc.MetaType.ImmType.Imm & 0b111) || MemSrc.MetaType.ImmType.Imm < 0) {
+          stur(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+        else {
+          str(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+        str<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+        str<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else {
+        LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
+        FEX_UNREACHABLE;
+      }
+    }
+  }
+  void ldr(FEXCore::ARMEmitter::DRegister rt, FEXCore::ARMEmitter::ExtendedMemOperand MemSrc) {
+    if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
+        MemSrc.MetaType.ExtendedType.rm.Idx() != FEXCore::ARMEmitter::Reg::r31.Idx()) {
+      ldr(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option, MemSrc.MetaType.ExtendedType.Shift);
+    }
+    else if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+      ldr(rt, MemSrc.rn);
+    }
+    else {
+      if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
+        if ((MemSrc.MetaType.ImmType.Imm & 0b111) || MemSrc.MetaType.ImmType.Imm < 0) {
+          ldur(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+        else {
+          ldr(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+        ldr<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+        ldr<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else {
+        LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
+        FEX_UNREACHABLE;
+      }
+    }
+  }
+  void str(FEXCore::ARMEmitter::QRegister rt, FEXCore::ARMEmitter::ExtendedMemOperand MemSrc) {
+    if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
+        MemSrc.MetaType.ExtendedType.rm.Idx() != FEXCore::ARMEmitter::Reg::r31.Idx()) {
+      str(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option, MemSrc.MetaType.ExtendedType.Shift);
+    }
+    else if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+      str(rt, MemSrc.rn);
+    }
+    else {
+      if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
+        if ((MemSrc.MetaType.ImmType.Imm & 0b1111) || MemSrc.MetaType.ImmType.Imm < 0) {
+          stur(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+        else {
+          str(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+        str<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+        str<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else {
+        LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
+        FEX_UNREACHABLE;
+      }
+    }
+  }
+  void ldr(FEXCore::ARMEmitter::QRegister rt, FEXCore::ARMEmitter::ExtendedMemOperand MemSrc) {
+    if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
+        MemSrc.MetaType.ExtendedType.rm.Idx() != FEXCore::ARMEmitter::Reg::r31.Idx()) {
+      ldr(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option, MemSrc.MetaType.ExtendedType.Shift);
+    }
+    else if (MemSrc.MetaType.Header.MemType == FEXCore::ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+      ldr(rt, MemSrc.rn);
+    }
+    else {
+      if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
+        if ((MemSrc.MetaType.ImmType.Imm & 0b1111) || MemSrc.MetaType.ImmType.Imm < 0) {
+          ldur(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+        else {
+          ldr(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+        ldr<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+        ldr<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+      }
+      else {
+        LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
+        FEX_UNREACHABLE;
+      }
+    }
+  }
+
+  // Loadstore PAC
+  // TODO
+  // Loadstore unsigned immediate
+  void strb(FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn, uint32_t Imm = 0) {
+    LOGMAN_THROW_A_FMT(Imm <= 4095, "Offset not valid: {} 0x{:x}", __func__, Imm);
+    constexpr uint32_t Op = 0b0011'1001'00 << 22;
+    LoadStoreUnsigned(Op, rt, rn, Imm);
+  }
+  void ldrb(FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn, uint32_t Imm = 0) {
+    LOGMAN_THROW_A_FMT(Imm <= 4095, "Offset not valid: {} 0x{:x}", __func__, Imm);
+    constexpr uint32_t Op = 0b0011'1001'01 << 22;
+    LoadStoreUnsigned(Op, rt, rn, Imm);
+  }
+  void ldrsb(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn, uint32_t Imm = 0) {
+    LOGMAN_THROW_A_FMT(Imm <= 4095, "Offset not valid: {} 0x{:x}", __func__, Imm);
+    constexpr uint32_t Op = 0b0011'1001'10 << 22;
+    LoadStoreUnsigned(Op, rt, rn, Imm);
+  }
+  void ldrsb(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn, uint32_t Imm = 0) {
+    LOGMAN_THROW_A_FMT(Imm <= 4095, "Offset not valid: {} 0x{:x}", __func__, Imm);
+    constexpr uint32_t Op = 0b0011'1001'11 << 22;
+    LoadStoreUnsigned(Op, rt, rn, Imm);
+  }
+  void strb(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::Register rn, uint32_t Imm = 0) {
+    LOGMAN_THROW_A_FMT(Imm <= 4095, "Offset not valid: {} 0x{:x}", __func__, Imm);
+    constexpr uint32_t Op = 0b0011'1101'00 << 22;
+    LoadStoreUnsigned(Op, rt, rn, Imm);
+  }
+  void ldrb(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::Register rn, uint32_t Imm = 0) {
+    LOGMAN_THROW_A_FMT(Imm <= 4095, "Offset not valid: {} 0x{:x}", __func__, Imm);
+    constexpr uint32_t Op = 0b0011'1101'01 << 22;
+    LoadStoreUnsigned(Op, rt, rn, Imm);
+  }
+  void strh(FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn, uint32_t Imm = 0) {
+    LOGMAN_THROW_A_FMT(Imm <= 8190 && (Imm & 0b1) == 0, "Offset not valid: {} 0x{:x}", __func__, Imm);
+    constexpr uint32_t Op = 0b0111'1001'00 << 22;
+    LoadStoreUnsigned(Op, rt, rn, Imm >> 1);
+  }
+  void ldrh(FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn, uint32_t Imm = 0) {
+    LOGMAN_THROW_A_FMT(Imm <= 8190 && (Imm & 0b1) == 0, "Offset not valid: {} 0x{:x}", __func__, Imm);
+    constexpr uint32_t Op = 0b0111'1001'01 << 22;
+    LoadStoreUnsigned(Op, rt, rn, Imm >> 1);
+  }
+  void ldrsh(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn, uint32_t Imm = 0) {
+    LOGMAN_THROW_A_FMT(Imm <= 8190 && (Imm & 0b1) == 0, "Offset not valid: {} 0x{:x}", __func__, Imm);
+    constexpr uint32_t Op = 0b0111'1001'10 << 22;
+    LoadStoreUnsigned(Op, rt, rn, Imm >> 1);
+  }
+  void ldrsh(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn, uint32_t Imm = 0) {
+    LOGMAN_THROW_A_FMT(Imm <= 8190 && (Imm & 0b1) == 0, "Offset not valid: {} 0x{:x}", __func__, Imm);
+    constexpr uint32_t Op = 0b0111'1001'11 << 22;
+    LoadStoreUnsigned(Op, rt, rn, Imm >> 1);
+  }
+  void strh(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::Register rn, uint32_t Imm = 0) {
+    LOGMAN_THROW_A_FMT(Imm <= 8190 && (Imm & 0b1) == 0, "Offset not valid: {} 0x{:x}", __func__, Imm);
+    constexpr uint32_t Op = 0b0111'1101'00 << 22;
+    LoadStoreUnsigned(Op, rt, rn, Imm >> 1);
+  }
+  void ldrh(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::Register rn, uint32_t Imm = 0) {
+    LOGMAN_THROW_A_FMT(Imm <= 8190 && (Imm & 0b1) == 0, "Offset not valid: {} 0x{:x}", __func__, Imm);
+    constexpr uint32_t Op = 0b0111'1101'01 << 22;
+    LoadStoreUnsigned(Op, rt, rn, Imm >> 1);
+  }
+  void str(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn, uint32_t Imm = 0) {
+    LOGMAN_THROW_A_FMT(Imm <= 16380 && (Imm & 0b11) == 0, "Offset not valid: {} 0x{:x}", __func__, Imm);
+    constexpr uint32_t Op = 0b1011'1001'00 << 22;
+    LoadStoreUnsigned(Op, rt, rn, Imm >> 2);
+  }
+  void ldr(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn, uint32_t Imm = 0) {
+    LOGMAN_THROW_A_FMT(Imm <= 16380 && (Imm & 0b11) == 0, "Offset not valid: {} 0x{:x}", __func__, Imm);
+    constexpr uint32_t Op = 0b1011'1001'01 << 22;
+    LoadStoreUnsigned(Op, rt, rn, Imm >> 2);
+  }
+  void ldrsw(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn, uint32_t Imm = 0) {
+    LOGMAN_THROW_A_FMT(Imm <= 16380 && (Imm & 0b11) == 0, "Offset not valid: {} 0x{:x}", __func__, Imm);
+    constexpr uint32_t Op = 0b1011'1001'10 << 22;
+    LoadStoreUnsigned(Op, rt, rn, Imm >> 2);
+  }
+  void str(FEXCore::ARMEmitter::SRegister rt, FEXCore::ARMEmitter::Register rn, uint32_t Imm = 0) {
+    LOGMAN_THROW_A_FMT(Imm <= 16380 && (Imm & 0b11) == 0, "Offset not valid: {} 0x{:x}", __func__, Imm);
+    constexpr uint32_t Op = 0b1011'1101'00 << 22;
+    LoadStoreUnsigned(Op, rt, rn, Imm >> 2);
+  }
+  void ldr(FEXCore::ARMEmitter::SRegister rt, FEXCore::ARMEmitter::Register rn, uint32_t Imm = 0) {
+    LOGMAN_THROW_A_FMT(Imm <= 16380 && (Imm & 0b11) == 0, "Offset not valid: {} 0x{:x}", __func__, Imm);
+    constexpr uint32_t Op = 0b1011'1101'01 << 22;
+    LoadStoreUnsigned(Op, rt, rn, Imm >> 2);
+  }
+  void str(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn, uint32_t Imm = 0) {
+    LOGMAN_THROW_A_FMT(Imm <= 32760 && (Imm & 0b111) == 0, "Offset not valid: {} 0x{:x}", __func__, Imm);
+    constexpr uint32_t Op = 0b1111'1001'00 << 22;
+    LoadStoreUnsigned(Op, rt, rn, Imm >> 3);
+  }
+  void ldr(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn, uint32_t Imm = 0) {
+    LOGMAN_THROW_A_FMT(Imm <= 32760 && (Imm & 0b111) == 0, "Offset not valid: {} 0x{:x}", __func__, Imm);
+    constexpr uint32_t Op = 0b1111'1001'01 << 22;
+    LoadStoreUnsigned(Op, rt, rn, Imm >> 3);
+  }
+  void ldr(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn, uint32_t Imm = 0) {
+    uint32_t Op = (0b0011'1001'01 << 22) |
+                  (FEXCore::ToUnderlying(size) << 30);
+    if (size == ARMEmitter::SubRegSize::i8Bit) {
+      LOGMAN_THROW_A_FMT(Imm <= 4095, "Offset not valid: {} 0x{:x}", __func__, Imm);
+    }
+    else if (size == ARMEmitter::SubRegSize::i16Bit) {
+      LOGMAN_THROW_A_FMT(Imm <= 8190 && (Imm & 0b1) == 0, "Offset not valid: {} 0x{:x}", __func__, Imm);
+      Imm >>= 1;
+    }
+    else if (size == ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_A_FMT(Imm <= 16380 && (Imm & 0b11) == 0, "Offset not valid: {} 0x{:x}", __func__, Imm);
+      Imm >>= 2;
+    }
+    else if (size == ARMEmitter::SubRegSize::i64Bit) {
+      LOGMAN_THROW_A_FMT(Imm <= 32760 && (Imm & 0b111) == 0, "Offset not valid: {} 0x{:x}", __func__, Imm);
+      Imm >>= 3;
+    }
+    LoadStoreUnsigned(Op, rt, rn, Imm);
+  }
+  void str(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn, uint32_t Imm = 0) {
+    uint32_t Op = (0b0011'1001'00 << 22) |
+                  (FEXCore::ToUnderlying(size) << 30);
+    if (size == ARMEmitter::SubRegSize::i8Bit) {
+      LOGMAN_THROW_A_FMT(Imm <= 4095, "Offset not valid: {} 0x{:x}", __func__, Imm);
+    }
+    else if (size == ARMEmitter::SubRegSize::i16Bit) {
+      LOGMAN_THROW_A_FMT(Imm <= 8190 && (Imm & 0b1) == 0, "Offset not valid: {} 0x{:x}", __func__, Imm);
+      Imm >>= 1;
+    }
+    else if (size == ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_A_FMT(Imm <= 16380 && (Imm & 0b11) == 0, "Offset not valid: {} 0x{:x}", __func__, Imm);
+      Imm >>= 2;
+    }
+    else if (size == ARMEmitter::SubRegSize::i64Bit) {
+      LOGMAN_THROW_A_FMT(Imm <= 32760 && (Imm & 0b111) == 0, "Offset not valid: {} 0x{:x}", __func__, Imm);
+      Imm >>= 3;
+    }
+    LoadStoreUnsigned(Op, rt, rn, Imm);
+  }
+
+  void prfm(FEXCore::ARMEmitter::Prefetch prfop, FEXCore::ARMEmitter::Register rn, uint32_t Imm = 0) {
+    LOGMAN_THROW_A_FMT(Imm <= 32760 && (Imm & 0b111) == 0, "Offset not valid: {} 0x{:x}", __func__, Imm);
+    constexpr uint32_t Op = 0b1111'1001'10 << 22;
+    LoadStoreUnsigned(Op, prfop, rn, Imm >> 3);
+  }
+  void str(FEXCore::ARMEmitter::DRegister rt, FEXCore::ARMEmitter::Register rn, uint32_t Imm = 0) {
+    LOGMAN_THROW_A_FMT(Imm <= 32760 && (Imm & 0b111) == 0, "Offset not valid: {} 0x{:x}", __func__, Imm);
+    constexpr uint32_t Op = 0b1111'1101'00 << 22;
+    LoadStoreUnsigned(Op, rt, rn, Imm >> 3);
+  }
+  void ldr(FEXCore::ARMEmitter::DRegister rt, FEXCore::ARMEmitter::Register rn, uint32_t Imm = 0) {
+    LOGMAN_THROW_A_FMT(Imm <= 32760 && (Imm & 0b111) == 0, "Offset not valid: {} 0x{:x}", __func__, Imm);
+    constexpr uint32_t Op = 0b1111'1101'01 << 22;
+    LoadStoreUnsigned(Op, rt, rn, Imm >> 3);
+  }
+  void str(FEXCore::ARMEmitter::QRegister rt, FEXCore::ARMEmitter::Register rn, uint32_t Imm = 0) {
+    LOGMAN_THROW_A_FMT(Imm <= 65520 && (Imm & 0b1111) == 0, "Offset not valid: {} 0x{:x}", __func__, Imm);
+    constexpr uint32_t Op = 0b0011'1101'10 << 22;
+    LoadStoreUnsigned(Op, rt, rn, Imm >> 4);
+  }
+  void ldr(FEXCore::ARMEmitter::QRegister rt, FEXCore::ARMEmitter::Register rn, uint32_t Imm = 0) {
+    LOGMAN_THROW_A_FMT(Imm <= 65520 && (Imm & 0b1111) == 0, "Offset not valid: {} 0x{:x}", __func__, Imm);
+    constexpr uint32_t Op = 0b0011'1101'11 << 22;
+    LoadStoreUnsigned(Op, rt, rn, Imm >> 4);
+  }
+
+private:
+  void AtomicOp(uint32_t Op, FEXCore::ARMEmitter::Size s, uint32_t L, uint32_t o0, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rt2, FEXCore::ARMEmitter::Register rn) {
+    const uint32_t sz = s == FEXCore::ARMEmitter::Size::i64Bit ? (1U << 30) : 0;
+    uint32_t Instr = Op;
+
+    Instr |= sz;
+    Instr |= L << 22;
+    Instr |= Encode_rs(rs);
+    Instr |= o0 << 15;
+    Instr |= Encode_rt2(rt2);
+    Instr |= Encode_rn(rn);
+    Instr |= Encode_rt(rt);
+
+    dc32(Instr);
+  }
+
+  template<typename T>
+  void SubAtomicOp(uint32_t Op, FEXCore::ARMEmitter::SubRegSize s, uint32_t L, uint32_t o0, T rs, T rt, T rt2, FEXCore::ARMEmitter::Register rn) {
+    const uint32_t sz = FEXCore::ToUnderlying(s) << 30;
+    uint32_t Instr = Op;
+
+    Instr |= sz;
+    Instr |= L << 22;
+    Instr |= Encode_rs(rs);
+    Instr |= o0 << 15;
+    Instr |= Encode_rt2(rt2);
+    Instr |= Encode_rn(rn);
+    Instr |= Encode_rt(rt);
+
+    dc32(Instr);
+  }
+
+  template<typename T>
+  void SubAtomicImm(uint32_t Op, FEXCore::ARMEmitter::SubRegSize s, uint32_t opc, T rt, FEXCore::ARMEmitter::Register rn, uint32_t Imm) {
+    const uint32_t sz = FEXCore::ToUnderlying(s) << 30;
+    uint32_t Instr = Op;
+
+    Instr |= sz;
+    Instr |= opc << 22;
+    Instr |= Imm << 12;
+    Instr |= Encode_rn(rn);
+    Instr |= Encode_rt(rt);
+
+    dc32(Instr);
+  }
+  // Load register literal
+  template<typename T>
+  void LoadStoreLiteral(uint32_t Op, T rt, uint32_t Imm) {
+    uint32_t Instr = Op;
+
+    Instr |= Imm << 5;
+    Instr |= Encode_rt(rt);
+    dc32(Instr);
+  }
+
+  // Loadstore no-allocate pair
+  template<typename T>
+  void LoadStoreNoAllocate(uint32_t Op, T rt, T rt2, FEXCore::ARMEmitter::Register rn, uint32_t Imm) {
+    uint32_t Instr = Op;
+
+    Instr |= Imm << 15;
+    Instr |= Encode_rt2(rt2);
+    Instr |= Encode_rn(rn);
+    Instr |= Encode_rt(rt);
+    dc32(Instr);
+  }
+  // Loadstore register pair post-indexed
+  template<typename T>
+  void LoadStorePair(uint32_t Op, T rt, T rt2, FEXCore::ARMEmitter::Register rn, uint32_t Imm) {
+    uint32_t Instr = Op;
+    Instr |= Imm << 15;
+    Instr |= Encode_rt2(rt2);
+    Instr |= Encode_rn(rn);
+    Instr |= Encode_rt(rt);
+    dc32(Instr);
+  }
+
+  // Loadstore register unscaled immediate
+  // Loadstore register immediate post-indexed
+  // Loadstore register unprivileged
+  // Loadstore register immediate pre-indexed
+  template<typename T>
+  void LoadStoreImm(uint32_t Op, uint32_t o2, T rt, FEXCore::ARMEmitter::Register rn, uint32_t Imm) {
+    uint32_t Instr = Op;
+
+    Instr |= Imm << 12;
+    Instr |= o2 << 10;
+    Instr |= Encode_rn(rn);
+    Instr |= Encode_rt(rt);
+    dc32(Instr);
+  }
+
+  // Atomic memory operations
+  template<typename T>
+  void LoadStoreAtomicLSE(uint32_t Op, FEXCore::ARMEmitter::SubRegSize s, uint32_t A, uint32_t R, uint32_t o3, uint32_t opc, T rs, T rt, FEXCore::ARMEmitter::Register rn) {
+    const uint32_t sz = FEXCore::ToUnderlying(s) << 30;
+    uint32_t Instr = Op;
+
+    Instr |= sz;
+    Instr |= A << 23;
+    Instr |= R << 22;
+    Instr |= Encode_rs(rs);
+    Instr |= o3 << 15;
+    Instr |= opc << 12;
+    Instr |= Encode_rn(rn);
+    Instr |= Encode_rt(rt);
+    dc32(Instr);
+  }
+
+  // Loadstore register-register offset
+  template<typename T>
+  void LoadStoreRegisterOffset(uint32_t Op, uint32_t opc, T rt, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::ExtendedType Option, uint32_t Shift) {
+    uint32_t Instr = Op;
+
+    Instr |= opc << 22;
+    Instr |= Encode_rt(rt);
+    Instr |= FEXCore::ToUnderlying(Option) << 13;
+    Instr |= Shift << 12;
+    Instr |= Encode_rn(rn);
+    Instr |= Encode_rm(rm);
+    dc32(Instr);
+  }
+
+  // Loadstore unsigned immediate
+  template<typename T>
+  void LoadStoreUnsigned(uint32_t Op, T rt, FEXCore::ARMEmitter::Register rn, uint32_t Imm) {
+    uint32_t Instr = Op;
+
+    Instr |= Imm << 10;
+    Instr |= Encode_rn(rn);
+    Instr |= Encode_rt(rt);
+    dc32(Instr);
+  }
+  template<IndexType Index>
+  void ldp_w(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::VRegister rt2, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 252 && ((Imm & 0b11) == 0), "Unscaled offset too large");
+    constexpr uint32_t Op = (0b0010'1100'01 << 22) |
+      (
+        Index == IndexType::POST   ? (0b01 << 23) :
+        Index == IndexType::PRE    ? (0b11 << 23) :
+        Index == IndexType::OFFSET ? (0b10 << 23) : -1
+      );
+
+    LoadStorePair(Op, rt, rt2, rn, (Imm >> 2) & 0b111'1111);
+  }
+  template<IndexType Index>
+  void ldp_x(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::VRegister rt2, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -512 && Imm <= 504 && ((Imm & 0b111) == 0), "Unscaled offset too large");
+    constexpr uint32_t Op = (0b0110'1100'01 << 22) |
+      (
+        Index == IndexType::POST   ? (0b01 << 23) :
+        Index == IndexType::PRE    ? (0b11 << 23) :
+        Index == IndexType::OFFSET ? (0b10 << 23) : -1
+      );
+
+    LoadStorePair(Op, rt, rt2, rn, (Imm >> 3) & 0b111'1111);
+  }
+  template<IndexType Index>
+  void stp_w(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::VRegister rt2, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 252 && ((Imm & 0b11) == 0), "Unscaled offset too large");
+    constexpr uint32_t Op = (0b0010'1100'00 << 22) |
+      (
+        Index == IndexType::POST   ? (0b01 << 23) :
+        Index == IndexType::PRE    ? (0b11 << 23) :
+        Index == IndexType::OFFSET ? (0b10 << 23) : -1
+      );
+
+    LoadStorePair(Op, rt, rt2, rn, (Imm >> 2) & 0b111'1111);
+  }
+  template<IndexType Index>
+  void stp_x(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::VRegister rt2, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -512 && Imm <= 504 && ((Imm & 0b111) == 0), "Unscaled offset too large");
+    constexpr uint32_t Op = (0b0110'1100'00 << 22) |
+      (
+        Index == IndexType::POST   ? (0b01 << 23) :
+        Index == IndexType::PRE    ? (0b11 << 23) :
+        Index == IndexType::OFFSET ? (0b10 << 23) : -1
+      );
+
+    LoadStorePair(Op, rt, rt2, rn, (Imm >> 3) & 0b111'1111);
+  }
+  template<IndexType Index>
+  void ldp_q(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::VRegister rt2, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -1024 && Imm <= 1008 && ((Imm & 0b1111) == 0), "Unscaled offset too large");
+    constexpr uint32_t Op = (0b1010'1100'01 << 22) |
+      (
+        Index == IndexType::POST   ? (0b01 << 23) :
+        Index == IndexType::PRE    ? (0b11 << 23) :
+        Index == IndexType::OFFSET ? (0b10 << 23) : -1
+      );
+
+    LoadStorePair(Op, rt, rt2, rn, (Imm >> 4) & 0b111'1111);
+  }
+  template<IndexType Index>
+  void stp_q(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::VRegister rt2, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -1024 && Imm <= 1008 && ((Imm & 0b1111) == 0), "Unscaled offset too large");
+    constexpr uint32_t Op = (0b1010'1100'00 << 22) |
+      (
+        Index == IndexType::POST   ? (0b01 << 23) :
+        Index == IndexType::PRE    ? (0b11 << 23) :
+        Index == IndexType::OFFSET ? (0b10 << 23) : -1
+      );
+
+    LoadStorePair(Op, rt, rt2, rn, (Imm >> 4) & 0b111'1111);
+  }
+
+  template <IndexType Index>
+  void stXrb(FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
+
+    constexpr uint32_t Op = 0b0011'1000'00 << 22;
+    constexpr uint32_t o2 =
+      Index == IndexType::POST   ? 0b01 :
+      Index == IndexType::PRE    ? 0b11 :
+      Index == IndexType::OFFSET ? 0b00 :
+      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+
+    LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
+  }
+  template <IndexType Index>
+  void ldXrb(FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
+
+    constexpr uint32_t Op = 0b0011'1000'01 << 22;
+    constexpr uint32_t o2 =
+      Index == IndexType::POST   ? 0b01 :
+      Index == IndexType::PRE    ? 0b11 :
+      Index == IndexType::OFFSET ? 0b00 :
+      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+
+    LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
+  }
+  template <IndexType Index>
+  void stXrb(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
+
+    constexpr uint32_t Op = 0b0011'1100'00 << 22;
+    constexpr uint32_t o2 =
+      Index == IndexType::POST   ? 0b01 :
+      Index == IndexType::PRE    ? 0b11 :
+      Index == IndexType::OFFSET ? 0b00 :
+      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+
+    LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
+  }
+  template <IndexType Index>
+  void ldXrb(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
+
+    constexpr uint32_t Op = 0b0011'1100'01 << 22;
+    constexpr uint32_t o2 =
+      Index == IndexType::POST   ? 0b01 :
+      Index == IndexType::PRE    ? 0b11 :
+      Index == IndexType::OFFSET ? 0b00 :
+      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+
+    LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
+  }
+  template <IndexType Index>
+  void ldXrsb(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
+
+    constexpr uint32_t Op = 0b0011'1000'10 << 22;
+    constexpr uint32_t o2 =
+      Index == IndexType::POST   ? 0b01 :
+      Index == IndexType::PRE    ? 0b11 :
+      Index == IndexType::OFFSET ? 0b00 :
+      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+
+    LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
+  }
+  template <IndexType Index>
+  void ldXrsb(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
+
+    constexpr uint32_t Op = 0b0011'1000'11 << 22;
+    constexpr uint32_t o2 =
+      Index == IndexType::POST   ? 0b01 :
+      Index == IndexType::PRE    ? 0b11 :
+      Index == IndexType::OFFSET ? 0b00 :
+      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+
+    LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
+  }
+  template <IndexType Index>
+  void stXrh(FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
+
+    constexpr uint32_t Op = 0b0111'1000'00 << 22;
+    constexpr uint32_t o2 =
+      Index == IndexType::POST   ? 0b01 :
+      Index == IndexType::PRE    ? 0b11 :
+      Index == IndexType::OFFSET ? 0b00 :
+      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+
+    LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
+  }
+  template <IndexType Index>
+  void ldXrh(FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
+
+    constexpr uint32_t Op = 0b0111'1000'01 << 22;
+    constexpr uint32_t o2 =
+      Index == IndexType::POST   ? 0b01 :
+      Index == IndexType::PRE    ? 0b11 :
+      Index == IndexType::OFFSET ? 0b00 :
+      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+
+    LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
+  }
+  template <IndexType Index>
+  void stXrh(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
+
+    constexpr uint32_t Op = 0b0111'1100'00 << 22;
+    constexpr uint32_t o2 =
+      Index == IndexType::POST   ? 0b01 :
+      Index == IndexType::PRE    ? 0b11 :
+      Index == IndexType::OFFSET ? 0b00 :
+      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+
+    LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
+  }
+  template <IndexType Index>
+  void ldXrh(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
+
+    constexpr uint32_t Op = 0b0111'1100'01 << 22;
+    constexpr uint32_t o2 =
+      Index == IndexType::POST   ? 0b01 :
+      Index == IndexType::PRE    ? 0b11 :
+      Index == IndexType::OFFSET ? 0b00 :
+      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+
+    LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
+  }
+  template <IndexType Index>
+  void ldXrsh(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
+
+    constexpr uint32_t Op = 0b0111'1000'10 << 22;
+    constexpr uint32_t o2 =
+      Index == IndexType::POST   ? 0b01 :
+      Index == IndexType::PRE    ? 0b11 :
+      Index == IndexType::OFFSET ? 0b00 :
+      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+
+    LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
+  }
+  template <IndexType Index>
+  void ldXrsh(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
+
+    constexpr uint32_t Op = 0b0111'1000'11 << 22;
+    constexpr uint32_t o2 =
+      Index == IndexType::POST   ? 0b01 :
+      Index == IndexType::PRE    ? 0b11 :
+      Index == IndexType::OFFSET ? 0b00 :
+      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+
+    LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
+  }
+  template <IndexType Index>
+  void stXr(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
+
+    constexpr uint32_t Op = 0b1011'1000'00 << 22;
+    constexpr uint32_t o2 =
+      Index == IndexType::POST   ? 0b01 :
+      Index == IndexType::PRE    ? 0b11 :
+      Index == IndexType::OFFSET ? 0b00 :
+      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+
+    LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
+  }
+  template <IndexType Index>
+  void ldXr(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
+
+    constexpr uint32_t Op = 0b1011'1000'01 << 22;
+    constexpr uint32_t o2 =
+      Index == IndexType::POST   ? 0b01 :
+      Index == IndexType::PRE    ? 0b11 :
+      Index == IndexType::OFFSET ? 0b00 :
+      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+
+    LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
+  }
+  template <IndexType Index>
+  void stXr(FEXCore::ARMEmitter::SRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
+
+    constexpr uint32_t Op = 0b1011'1100'00 << 22;
+    constexpr uint32_t o2 =
+      Index == IndexType::POST   ? 0b01 :
+      Index == IndexType::PRE    ? 0b11 :
+      Index == IndexType::OFFSET ? 0b00 :
+      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+
+    LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
+  }
+  template <IndexType Index>
+  void ldXr(FEXCore::ARMEmitter::SRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
+
+    constexpr uint32_t Op = 0b1011'1100'01 << 22;
+    constexpr uint32_t o2 =
+      Index == IndexType::POST   ? 0b01 :
+      Index == IndexType::PRE    ? 0b11 :
+      Index == IndexType::OFFSET ? 0b00 :
+      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+
+    LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
+  }
+  template <IndexType Index>
+  void ldXrsw(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
+
+    constexpr uint32_t Op = 0b1011'1000'10 << 22;
+    constexpr uint32_t o2 =
+      Index == IndexType::POST   ? 0b01 :
+      Index == IndexType::PRE    ? 0b11 :
+      Index == IndexType::OFFSET ? 0b00 :
+      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+
+    LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
+  }
+  template <IndexType Index>
+  void stXr(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
+
+    constexpr uint32_t Op = 0b1111'1000'00 << 22;
+    constexpr uint32_t o2 =
+      Index == IndexType::POST   ? 0b01 :
+      Index == IndexType::PRE    ? 0b11 :
+      Index == IndexType::OFFSET ? 0b00 :
+      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+
+    LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
+  }
+  template <IndexType Index>
+  void ldXr(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
+
+    constexpr uint32_t Op = 0b1111'1000'01 << 22;
+    constexpr uint32_t o2 =
+      Index == IndexType::POST   ? 0b01 :
+      Index == IndexType::PRE    ? 0b11 :
+      Index == IndexType::OFFSET ? 0b00 :
+      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+
+    LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
+  }
+  template <IndexType Index>
+  void stXr(FEXCore::ARMEmitter::DRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
+
+    constexpr uint32_t Op = 0b1111'1100'00 << 22;
+    constexpr uint32_t o2 =
+      Index == IndexType::POST   ? 0b01 :
+      Index == IndexType::PRE    ? 0b11 :
+      Index == IndexType::OFFSET ? 0b00 :
+      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+
+    LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
+  }
+  template <IndexType Index>
+  void ldXr(FEXCore::ARMEmitter::DRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
+
+    constexpr uint32_t Op = 0b1111'1100'01 << 22;
+    constexpr uint32_t o2 =
+      Index == IndexType::POST   ? 0b01 :
+      Index == IndexType::PRE    ? 0b11 :
+      Index == IndexType::OFFSET ? 0b00 :
+      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+
+    LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
+  }
+  template <IndexType Index>
+  void stXr(FEXCore::ARMEmitter::QRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
+
+    constexpr uint32_t Op = 0b0011'1100'10 << 22;
+    constexpr uint32_t o2 =
+      Index == IndexType::POST   ? 0b01 :
+      Index == IndexType::PRE    ? 0b11 :
+      Index == IndexType::OFFSET ? 0b00 :
+      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+
+    LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
+  }
+  template <IndexType Index>
+  void ldXr(FEXCore::ARMEmitter::QRegister rt, FEXCore::ARMEmitter::Register rn, int32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
+
+    constexpr uint32_t Op = 0b0011'1100'11 << 22;
+    constexpr uint32_t o2 =
+      Index == IndexType::POST   ? 0b01 :
+      Index == IndexType::PRE    ? 0b11 :
+      Index == IndexType::OFFSET ? 0b00 :
+      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+
+    LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
+  }
+
+

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/Registers.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/Registers.h
@@ -1,0 +1,1229 @@
+#pragma once
+#include <FEXCore/Utils/EnumUtils.h>
+#include <compare>
+#include <cstdint>
+
+namespace FEXCore::ARMEmitter {
+  class WRegister;
+  class XRegister;
+
+  /* Unsized GPR register class
+   * This class doesn't imply a size when used
+   */
+  class Register {
+    public:
+      Register() = delete;
+      constexpr explicit Register(uint32_t Idx)
+        : Index {Idx} {}
+
+      uint32_t Idx() const {
+        return Index;
+      }
+
+      operator WRegister() const;
+      operator XRegister() const;
+
+      WRegister W() const;
+      XRegister X() const;
+
+    private:
+      uint32_t Index;
+  };
+  static_assert(sizeof(Register) == sizeof(uint32_t), "Needs to be uint32_t");
+  static_assert(std::is_trivial_v<Register>, "Needs to be trivial");
+  static_assert(std::is_standard_layout_v<Register>, "Needs to be standard");
+
+  /* 32-bit GPR register class.
+   * This class will imply a 32-bit register size being used.
+   */
+  class WRegister {
+    public:
+      WRegister() = delete;
+      constexpr explicit WRegister(uint32_t Idx)
+        : Index {Idx} {}
+
+      bool operator==(const WRegister &rhs) {
+        return Idx() == rhs.Idx();
+      }
+
+      uint32_t Idx() const {
+        return Index;
+      }
+
+      operator Register() const {
+        return Register(Index);
+      }
+
+      operator XRegister() const;
+
+      XRegister X() const;
+
+      Register R() const;
+
+    private:
+      uint32_t Index;
+  };
+  static_assert(sizeof(Register) == sizeof(uint32_t), "Needs to be uint32_t");
+  static_assert(std::is_trivial_v<Register>, "Needs to be trivial");
+  static_assert(std::is_standard_layout_v<Register>, "Needs to be standard");
+
+  /* 64-bit GPR register class.
+   * This class will imply a 64-bit register size being used.
+   */
+  class XRegister {
+    public:
+      XRegister() = delete;
+      constexpr explicit XRegister(uint32_t Idx)
+        : Index {Idx} {}
+
+      bool operator==(const XRegister &rhs) {
+        return Idx() == rhs.Idx();
+      }
+
+      uint32_t Idx() const {
+        return Index;
+      }
+
+      operator Register() const {
+        return Register(Index);
+      }
+
+      operator WRegister() const;
+
+      WRegister W() const;
+
+      Register R() const;
+
+    private:
+      uint32_t Index;
+  };
+  static_assert(sizeof(Register) == sizeof(uint32_t), "Needs to be uint32_t");
+  static_assert(std::is_trivial_v<Register>, "Needs to be trivial");
+  static_assert(std::is_standard_layout_v<Register>, "Needs to be standard");
+
+  inline WRegister Register::W() const {
+    return *this;
+  }
+
+  inline XRegister Register::X() const {
+    return *this;
+  }
+
+  inline Register::operator WRegister () const {
+    return WRegister(Index);
+  }
+
+  inline Register::operator XRegister () const {
+    return XRegister(Index);
+  }
+
+  inline XRegister WRegister::X() const {
+    return *this;
+  }
+
+  inline Register WRegister::R() const {
+    return *this;
+  }
+
+  inline WRegister::operator XRegister () const {
+    return XRegister(Index);
+  }
+
+  inline WRegister XRegister::W() const {
+    return *this;
+  }
+
+  inline Register XRegister::R() const {
+    return *this;
+  }
+
+  inline XRegister::operator WRegister () const {
+    return WRegister(Index);
+  }
+
+  // Namespace containing all unsized GPR register objects.
+  namespace Reg {
+    constexpr static Register r0(0);
+    constexpr static Register r1(1);
+    constexpr static Register r2(2);
+    constexpr static Register r3(3);
+    constexpr static Register r4(4);
+    constexpr static Register r5(5);
+    constexpr static Register r6(6);
+    constexpr static Register r7(7);
+    constexpr static Register r8(8);
+    constexpr static Register r9(9);
+    constexpr static Register r10(10);
+    constexpr static Register r11(11);
+    constexpr static Register r12(12);
+    constexpr static Register r13(13);
+    constexpr static Register r14(14);
+    constexpr static Register r15(15);
+    constexpr static Register r16(16);
+    constexpr static Register r17(17);
+    constexpr static Register r18(18);
+    constexpr static Register r19(19);
+    constexpr static Register r20(20);
+    constexpr static Register r21(21);
+    constexpr static Register r22(22);
+    constexpr static Register r23(23);
+    constexpr static Register r24(24);
+    constexpr static Register r25(25);
+    constexpr static Register r26(26);
+    constexpr static Register r27(27);
+    constexpr static Register r28(28);
+    constexpr static Register r29(29);
+    constexpr static Register r30(30);
+    constexpr static Register r31(31);
+
+    // Named registers
+    constexpr static Register ip0(16);
+    constexpr static Register ip1(17);
+
+    constexpr static Register fp(29);
+    constexpr static Register lr(30);
+    constexpr static Register rsp(31);
+    constexpr static Register zr(31);
+  }
+
+  // Namespace containing all 64-bit GPR register objects.
+  namespace XReg {
+    constexpr static XRegister x0(0);
+    constexpr static XRegister x1(1);
+    constexpr static XRegister x2(2);
+    constexpr static XRegister x3(3);
+    constexpr static XRegister x4(4);
+    constexpr static XRegister x5(5);
+    constexpr static XRegister x6(6);
+    constexpr static XRegister x7(7);
+    constexpr static XRegister x8(8);
+    constexpr static XRegister x9(9);
+    constexpr static XRegister x10(10);
+    constexpr static XRegister x11(11);
+    constexpr static XRegister x12(12);
+    constexpr static XRegister x13(13);
+    constexpr static XRegister x14(14);
+    constexpr static XRegister x15(15);
+    constexpr static XRegister x16(16);
+    constexpr static XRegister x17(17);
+    constexpr static XRegister x18(18);
+    constexpr static XRegister x19(19);
+    constexpr static XRegister x20(20);
+    constexpr static XRegister x21(21);
+    constexpr static XRegister x22(22);
+    constexpr static XRegister x23(23);
+    constexpr static XRegister x24(24);
+    constexpr static XRegister x25(25);
+    constexpr static XRegister x26(26);
+    constexpr static XRegister x27(27);
+    constexpr static XRegister x28(28);
+    constexpr static XRegister x29(29);
+    constexpr static XRegister x30(30);
+    constexpr static XRegister x31(31);
+
+    // Named registers
+    constexpr static XRegister ip0(16);
+    constexpr static XRegister ip1(17);
+
+    constexpr static XRegister fp(29);
+    constexpr static XRegister lr(30);
+    constexpr static XRegister rsp(31);
+    constexpr static XRegister zr(31);
+  }
+
+  // Namespace containing all 32-bit GPR register objects.
+  namespace WReg {
+    constexpr static WRegister w0(0);
+    constexpr static WRegister w1(1);
+    constexpr static WRegister w2(2);
+    constexpr static WRegister w3(3);
+    constexpr static WRegister w4(4);
+    constexpr static WRegister w5(5);
+    constexpr static WRegister w6(6);
+    constexpr static WRegister w7(7);
+    constexpr static WRegister w8(8);
+    constexpr static WRegister w9(9);
+    constexpr static WRegister w10(10);
+    constexpr static WRegister w11(11);
+    constexpr static WRegister w12(12);
+    constexpr static WRegister w13(13);
+    constexpr static WRegister w14(14);
+    constexpr static WRegister w15(15);
+    constexpr static WRegister w16(16);
+    constexpr static WRegister w17(17);
+    constexpr static WRegister w18(18);
+    constexpr static WRegister w19(19);
+    constexpr static WRegister w20(20);
+    constexpr static WRegister w21(21);
+    constexpr static WRegister w22(22);
+    constexpr static WRegister w23(23);
+    constexpr static WRegister w24(24);
+    constexpr static WRegister w25(25);
+    constexpr static WRegister w26(26);
+    constexpr static WRegister w27(27);
+    constexpr static WRegister w28(28);
+    constexpr static WRegister w29(29);
+    constexpr static WRegister w30(30);
+    constexpr static WRegister w31(31);
+
+    // Named registers
+    constexpr static WRegister ip0(16);
+    constexpr static WRegister ip1(17);
+
+    constexpr static WRegister fp(29);
+    constexpr static WRegister lr(30);
+    constexpr static WRegister rsp(31);
+    constexpr static WRegister zr(31);
+  }
+
+  class VRegister;
+  class BRegister;
+  class HRegister;
+  class SRegister;
+  class DRegister;
+  class QRegister;
+  class ZRegister;
+
+
+  /* Unsized ASIMD register class
+   * This class doesn't imply a size when used, nor implies Vector or Scalar.
+   * It does imply that this instruction isn't using the register for SVE.
+   */
+  class VRegister {
+    public:
+      VRegister() = delete;
+      constexpr VRegister(uint32_t Idx)
+        : Index {Idx} {}
+
+      uint32_t Idx() const {
+        return Index;
+      }
+
+      operator BRegister() const;
+      operator HRegister() const;
+      operator SRegister() const;
+      operator DRegister() const;
+      operator QRegister() const;
+      operator ZRegister() const;
+
+      BRegister B() const;
+      HRegister H() const;
+      SRegister S() const;
+      DRegister D() const;
+      QRegister Q() const;
+      ZRegister Z() const;
+
+    private:
+      uint32_t Index;
+  };
+  static_assert(sizeof(VRegister) == sizeof(uint32_t), "Needs to be uint32_t");
+  static_assert(std::is_trivial_v<VRegister>, "Needs to be trivial");
+  static_assert(std::is_standard_layout_v<VRegister>, "Needs to be standard");
+
+  /* 8-bit ASIMD register class
+   * This class implies 8-bit scalar register.
+   */
+  class BRegister {
+    public:
+      BRegister() = delete;
+      constexpr explicit BRegister(uint32_t Idx)
+        : Index {Idx} {}
+
+      uint32_t Idx() const {
+        return Index;
+      }
+
+      operator VRegister() const;
+      operator HRegister() const;
+      operator SRegister() const;
+      operator DRegister() const;
+      operator QRegister() const;
+      operator ZRegister() const;
+
+      BRegister V() const;
+      HRegister H() const;
+      SRegister S() const;
+      DRegister D() const;
+      QRegister Q() const;
+      ZRegister Z() const;
+
+    private:
+      uint32_t Index;
+  };
+  static_assert(sizeof(BRegister) == sizeof(uint32_t), "Needs to be uint32_t");
+  static_assert(std::is_trivial_v<BRegister>, "Needs to be trivial");
+  static_assert(std::is_standard_layout_v<BRegister>, "Needs to be standard");
+
+  /* 16-bit ASIMD register class
+   * This class implies 16-bit scalar register.
+   */
+  class HRegister {
+    public:
+      HRegister() = delete;
+      constexpr explicit HRegister(uint32_t Idx)
+        : Index {Idx} {}
+
+      uint32_t Idx() const {
+        return Index;
+      }
+
+      operator VRegister() const;
+      operator BRegister() const;
+      operator SRegister() const;
+      operator DRegister() const;
+      operator QRegister() const;
+      operator ZRegister() const;
+
+      HRegister V() const;
+      BRegister B() const;
+      SRegister S() const;
+      DRegister D() const;
+      QRegister Q() const;
+      ZRegister Z() const;
+
+    private:
+      uint32_t Index;
+  };
+  static_assert(sizeof(HRegister) == sizeof(uint32_t), "Needs to be uint32_t");
+  static_assert(std::is_trivial_v<HRegister>, "Needs to be trivial");
+  static_assert(std::is_standard_layout_v<HRegister>, "Needs to be standard");
+
+  /* 32-bit ASIMD register class
+   * This class implies 32-bit scalar register.
+   */
+  class SRegister {
+    public:
+      SRegister() = delete;
+      constexpr explicit SRegister(uint32_t Idx)
+        : Index {Idx} {}
+
+      uint32_t Idx() const {
+        return Index;
+      }
+
+      operator VRegister() const;
+      operator BRegister() const;
+      operator HRegister() const;
+      operator DRegister() const;
+      operator QRegister() const;
+      operator ZRegister() const;
+
+      SRegister V() const;
+      BRegister B() const;
+      HRegister H() const;
+      DRegister D() const;
+      QRegister Q() const;
+      ZRegister Z() const;
+
+    private:
+      uint32_t Index;
+  };
+  static_assert(sizeof(SRegister) == sizeof(uint32_t), "Needs to be uint32_t");
+  static_assert(std::is_trivial_v<SRegister>, "Needs to be trivial");
+  static_assert(std::is_standard_layout_v<SRegister>, "Needs to be standard");
+
+  /* 64-bit ASIMD register class
+   * This class doesn't imply Vector or Scalar.
+   * Associated with operating the instruction at 64-bit.
+   */
+  class DRegister {
+    public:
+      DRegister() = delete;
+      constexpr explicit DRegister(uint32_t Idx)
+        : Index {Idx} {}
+
+      uint32_t Idx() const {
+        return Index;
+      }
+
+      operator VRegister() const;
+      operator BRegister() const;
+      operator HRegister() const;
+      operator SRegister() const;
+      operator QRegister() const;
+      operator ZRegister() const;
+
+      DRegister V() const;
+      BRegister B() const;
+      HRegister H() const;
+      SRegister S() const;
+      QRegister Q() const;
+      ZRegister Z() const;
+
+    private:
+      uint32_t Index;
+  };
+  static_assert(sizeof(DRegister) == sizeof(uint32_t), "Needs to be uint32_t");
+  static_assert(std::is_trivial_v<DRegister>, "Needs to be trivial");
+  static_assert(std::is_standard_layout_v<DRegister>, "Needs to be standard");
+
+  /* 128-bit ASIMD register class
+   * This class doesn't imply Vector or Scalar.
+   * Associated with operating the instruction at 128-bit.
+   */
+  class QRegister {
+    public:
+      QRegister() = delete;
+      constexpr explicit QRegister(uint32_t Idx)
+        : Index {Idx} {}
+
+      uint32_t Idx() const {
+        return Index;
+      }
+
+      operator VRegister() const;
+      operator BRegister() const;
+      operator HRegister() const;
+      operator SRegister() const;
+      operator DRegister() const;
+      operator ZRegister() const;
+
+      QRegister V() const;
+      BRegister B() const;
+      HRegister H() const;
+      SRegister S() const;
+      DRegister D() const;
+      ZRegister Z() const;
+
+    private:
+      uint32_t Index;
+  };
+  static_assert(sizeof(QRegister) == sizeof(uint32_t), "Needs to be uint32_t");
+  static_assert(std::is_trivial_v<QRegister>, "Needs to be trivial");
+  static_assert(std::is_standard_layout_v<QRegister>, "Needs to be standard");
+
+  /* Unsized SVE register class.
+   * This class explicitly implies the instruction will operate using SVE.
+   */
+  class ZRegister {
+    public:
+      ZRegister() = delete;
+      constexpr explicit ZRegister(uint32_t Idx)
+        : Index {Idx} {}
+
+      uint32_t Idx() const {
+        return Index;
+      }
+
+      VRegister V() const;
+      BRegister B() const;
+      HRegister H() const;
+      SRegister S() const;
+      DRegister D() const;
+      QRegister Q() const;
+
+    private:
+      uint32_t Index;
+  };
+  static_assert(sizeof(ZRegister) == sizeof(uint32_t), "Needs to be uint32_t");
+  static_assert(std::is_trivial_v<ZRegister>, "Needs to be trivial");
+  static_assert(std::is_standard_layout_v<ZRegister>, "Needs to be standard");
+
+  // VRegister
+  inline BRegister VRegister::B() const {
+    return *this;
+  }
+  inline HRegister VRegister::H() const {
+    return *this;
+  }
+  inline SRegister VRegister::S() const {
+    return *this;
+  }
+  inline DRegister VRegister::D() const {
+    return *this;
+  }
+  inline QRegister VRegister::Q() const {
+    return *this;
+  }
+  inline ZRegister VRegister::Z() const {
+    return *this;
+  }
+
+  inline VRegister::operator BRegister () const {
+    return BRegister(Index);
+  }
+  inline VRegister::operator HRegister () const {
+    return HRegister(Index);
+  }
+  inline VRegister::operator SRegister () const {
+    return SRegister(Index);
+  }
+  inline VRegister::operator DRegister () const {
+    return DRegister(Index);
+  }
+  inline VRegister::operator QRegister () const {
+    return QRegister(Index);
+  }
+  inline VRegister::operator ZRegister () const {
+    return ZRegister(Index);
+  }
+
+  // BRegister
+  inline BRegister BRegister::V() const {
+    return *this;
+  }
+  inline HRegister BRegister::H() const {
+    return *this;
+  }
+  inline SRegister BRegister::S() const {
+    return *this;
+  }
+  inline DRegister BRegister::D() const {
+    return *this;
+  }
+  inline QRegister BRegister::Q() const {
+    return *this;
+  }
+  inline ZRegister BRegister::Z() const {
+    return *this;
+  }
+
+  inline BRegister::operator VRegister () const {
+    return VRegister(Index);
+  }
+  inline BRegister::operator HRegister () const {
+    return HRegister(Index);
+  }
+  inline BRegister::operator SRegister () const {
+    return SRegister(Index);
+  }
+  inline BRegister::operator DRegister () const {
+    return DRegister(Index);
+  }
+  inline BRegister::operator QRegister () const {
+    return QRegister(Index);
+  }
+  inline BRegister::operator ZRegister () const {
+    return ZRegister(Index);
+  }
+
+  // HRegister
+  inline HRegister HRegister::V() const {
+    return *this;
+  }
+  inline BRegister HRegister::B() const {
+    return *this;
+  }
+  inline SRegister HRegister::S() const {
+    return *this;
+  }
+  inline DRegister HRegister::D() const {
+    return *this;
+  }
+  inline QRegister HRegister::Q() const {
+    return *this;
+  }
+  inline ZRegister HRegister::Z() const {
+    return *this;
+  }
+
+  inline HRegister::operator VRegister () const {
+    return VRegister(Index);
+  }
+  inline HRegister::operator BRegister () const {
+    return BRegister(Index);
+  }
+  inline HRegister::operator SRegister () const {
+    return SRegister(Index);
+  }
+  inline HRegister::operator DRegister () const {
+    return DRegister(Index);
+  }
+  inline HRegister::operator QRegister () const {
+    return QRegister(Index);
+  }
+  inline HRegister::operator ZRegister () const {
+    return ZRegister(Index);
+  }
+
+  // SRegister
+  inline SRegister SRegister::V() const {
+    return *this;
+  }
+  inline BRegister SRegister::B() const {
+    return *this;
+  }
+  inline HRegister SRegister::H() const {
+    return *this;
+  }
+  inline DRegister SRegister::D() const {
+    return *this;
+  }
+  inline QRegister SRegister::Q() const {
+    return *this;
+  }
+  inline ZRegister SRegister::Z() const {
+    return *this;
+  }
+
+  inline SRegister::operator VRegister () const {
+    return VRegister(Index);
+  }
+  inline SRegister::operator BRegister () const {
+    return BRegister(Index);
+  }
+  inline SRegister::operator HRegister () const {
+    return HRegister(Index);
+  }
+  inline SRegister::operator DRegister () const {
+    return DRegister(Index);
+  }
+  inline SRegister::operator QRegister () const {
+    return QRegister(Index);
+  }
+  inline SRegister::operator ZRegister () const {
+    return ZRegister(Index);
+  }
+
+  // DRegister
+  inline DRegister DRegister::V() const {
+    return *this;
+  }
+  inline BRegister DRegister::B() const {
+    return *this;
+  }
+  inline HRegister DRegister::H() const {
+    return *this;
+  }
+  inline SRegister DRegister::S() const {
+    return *this;
+  }
+  inline QRegister DRegister::Q() const {
+    return *this;
+  }
+  inline ZRegister DRegister::Z() const {
+    return *this;
+  }
+
+  inline DRegister::operator VRegister () const {
+    return VRegister(Index);
+  }
+  inline DRegister::operator BRegister () const {
+    return BRegister(Index);
+  }
+  inline DRegister::operator HRegister () const {
+    return HRegister(Index);
+  }
+  inline DRegister::operator SRegister () const {
+    return SRegister(Index);
+  }
+  inline DRegister::operator QRegister () const {
+    return QRegister(Index);
+  }
+  inline DRegister::operator ZRegister () const {
+    return ZRegister(Index);
+  }
+
+  // QRegister
+  inline QRegister QRegister::V() const {
+    return *this;
+  }
+  inline BRegister QRegister::B() const {
+    return *this;
+  }
+  inline HRegister QRegister::H() const {
+    return *this;
+  }
+  inline SRegister QRegister::S() const {
+    return *this;
+  }
+  inline DRegister QRegister::D() const {
+    return *this;
+  }
+  inline ZRegister QRegister::Z() const {
+    return *this;
+  }
+
+  inline QRegister::operator VRegister () const {
+    return VRegister(Index);
+  }
+  inline QRegister::operator BRegister () const {
+    return BRegister(Index);
+  }
+  inline QRegister::operator HRegister () const {
+    return HRegister(Index);
+  }
+  inline QRegister::operator SRegister () const {
+    return SRegister(Index);
+  }
+  inline QRegister::operator DRegister () const {
+    return DRegister(Index);
+  }
+  inline QRegister::operator ZRegister () const {
+    return ZRegister(Index);
+  }
+
+  // ZRegister
+  inline VRegister ZRegister::V() const {
+    return VRegister(Index);
+  }
+  inline BRegister ZRegister::B() const {
+    return BRegister(Index);
+  }
+  inline HRegister ZRegister::H() const {
+    return HRegister(Index);
+  }
+  inline SRegister ZRegister::S() const {
+    return SRegister(Index);
+  }
+  inline DRegister ZRegister::D() const {
+    return DRegister(Index);
+  }
+  inline QRegister ZRegister::Q() const {
+    return QRegister(Index);
+  }
+
+  // Namespace containing all unsized ASIMD register objects.
+  namespace VReg {
+    constexpr static VRegister v0(0);
+    constexpr static VRegister v1(1);
+    constexpr static VRegister v2(2);
+    constexpr static VRegister v3(3);
+    constexpr static VRegister v4(4);
+    constexpr static VRegister v5(5);
+    constexpr static VRegister v6(6);
+    constexpr static VRegister v7(7);
+    constexpr static VRegister v8(8);
+    constexpr static VRegister v9(9);
+    constexpr static VRegister v10(10);
+    constexpr static VRegister v11(11);
+    constexpr static VRegister v12(12);
+    constexpr static VRegister v13(13);
+    constexpr static VRegister v14(14);
+    constexpr static VRegister v15(15);
+    constexpr static VRegister v16(16);
+    constexpr static VRegister v17(17);
+    constexpr static VRegister v18(18);
+    constexpr static VRegister v19(19);
+    constexpr static VRegister v20(20);
+    constexpr static VRegister v21(21);
+    constexpr static VRegister v22(22);
+    constexpr static VRegister v23(23);
+    constexpr static VRegister v24(24);
+    constexpr static VRegister v25(25);
+    constexpr static VRegister v26(26);
+    constexpr static VRegister v27(27);
+    constexpr static VRegister v28(28);
+    constexpr static VRegister v29(29);
+    constexpr static VRegister v30(30);
+    constexpr static VRegister v31(31);
+  }
+
+  // Namespace containing all 8-bit ASIMD register objects.
+  namespace BReg {
+    constexpr static BRegister b0(0);
+    constexpr static BRegister b1(1);
+    constexpr static BRegister b2(2);
+    constexpr static BRegister b3(3);
+    constexpr static BRegister b4(4);
+    constexpr static BRegister b5(5);
+    constexpr static BRegister b6(6);
+    constexpr static BRegister b7(7);
+    constexpr static BRegister b8(8);
+    constexpr static BRegister b9(9);
+    constexpr static BRegister b10(10);
+    constexpr static BRegister b11(11);
+    constexpr static BRegister b12(12);
+    constexpr static BRegister b13(13);
+    constexpr static BRegister b14(14);
+    constexpr static BRegister b15(15);
+    constexpr static BRegister b16(16);
+    constexpr static BRegister b17(17);
+    constexpr static BRegister b18(18);
+    constexpr static BRegister b19(19);
+    constexpr static BRegister b20(20);
+    constexpr static BRegister b21(21);
+    constexpr static BRegister b22(22);
+    constexpr static BRegister b23(23);
+    constexpr static BRegister b24(24);
+    constexpr static BRegister b25(25);
+    constexpr static BRegister b26(26);
+    constexpr static BRegister b27(27);
+    constexpr static BRegister b28(28);
+    constexpr static BRegister b29(29);
+    constexpr static BRegister b30(30);
+    constexpr static BRegister b31(31);
+  }
+
+  // Namespace containing all 16-bit ASIMD register objects.
+  namespace HReg {
+    constexpr static HRegister h0(0);
+    constexpr static HRegister h1(1);
+    constexpr static HRegister h2(2);
+    constexpr static HRegister h3(3);
+    constexpr static HRegister h4(4);
+    constexpr static HRegister h5(5);
+    constexpr static HRegister h6(6);
+    constexpr static HRegister h7(7);
+    constexpr static HRegister h8(8);
+    constexpr static HRegister h9(9);
+    constexpr static HRegister h10(10);
+    constexpr static HRegister h11(11);
+    constexpr static HRegister h12(12);
+    constexpr static HRegister h13(13);
+    constexpr static HRegister h14(14);
+    constexpr static HRegister h15(15);
+    constexpr static HRegister h16(16);
+    constexpr static HRegister h17(17);
+    constexpr static HRegister h18(18);
+    constexpr static HRegister h19(19);
+    constexpr static HRegister h20(20);
+    constexpr static HRegister h21(21);
+    constexpr static HRegister h22(22);
+    constexpr static HRegister h23(23);
+    constexpr static HRegister h24(24);
+    constexpr static HRegister h25(25);
+    constexpr static HRegister h26(26);
+    constexpr static HRegister h27(27);
+    constexpr static HRegister h28(28);
+    constexpr static HRegister h29(29);
+    constexpr static HRegister h30(30);
+    constexpr static HRegister h31(31);
+  }
+
+  // Namespace containing all 32-bit ASIMD register objects.
+  namespace SReg {
+    constexpr static SRegister s0(0);
+    constexpr static SRegister s1(1);
+    constexpr static SRegister s2(2);
+    constexpr static SRegister s3(3);
+    constexpr static SRegister s4(4);
+    constexpr static SRegister s5(5);
+    constexpr static SRegister s6(6);
+    constexpr static SRegister s7(7);
+    constexpr static SRegister s8(8);
+    constexpr static SRegister s9(9);
+    constexpr static SRegister s10(10);
+    constexpr static SRegister s11(11);
+    constexpr static SRegister s12(12);
+    constexpr static SRegister s13(13);
+    constexpr static SRegister s14(14);
+    constexpr static SRegister s15(15);
+    constexpr static SRegister s16(16);
+    constexpr static SRegister s17(17);
+    constexpr static SRegister s18(18);
+    constexpr static SRegister s19(19);
+    constexpr static SRegister s20(20);
+    constexpr static SRegister s21(21);
+    constexpr static SRegister s22(22);
+    constexpr static SRegister s23(23);
+    constexpr static SRegister s24(24);
+    constexpr static SRegister s25(25);
+    constexpr static SRegister s26(26);
+    constexpr static SRegister s27(27);
+    constexpr static SRegister s28(28);
+    constexpr static SRegister s29(29);
+    constexpr static SRegister s30(30);
+    constexpr static SRegister s31(31);
+  }
+
+  // Namespace containing all 64-bit ASIMD register objects.
+  namespace DReg {
+    constexpr static DRegister d0(0);
+    constexpr static DRegister d1(1);
+    constexpr static DRegister d2(2);
+    constexpr static DRegister d3(3);
+    constexpr static DRegister d4(4);
+    constexpr static DRegister d5(5);
+    constexpr static DRegister d6(6);
+    constexpr static DRegister d7(7);
+    constexpr static DRegister d8(8);
+    constexpr static DRegister d9(9);
+    constexpr static DRegister d10(10);
+    constexpr static DRegister d11(11);
+    constexpr static DRegister d12(12);
+    constexpr static DRegister d13(13);
+    constexpr static DRegister d14(14);
+    constexpr static DRegister d15(15);
+    constexpr static DRegister d16(16);
+    constexpr static DRegister d17(17);
+    constexpr static DRegister d18(18);
+    constexpr static DRegister d19(19);
+    constexpr static DRegister d20(20);
+    constexpr static DRegister d21(21);
+    constexpr static DRegister d22(22);
+    constexpr static DRegister d23(23);
+    constexpr static DRegister d24(24);
+    constexpr static DRegister d25(25);
+    constexpr static DRegister d26(26);
+    constexpr static DRegister d27(27);
+    constexpr static DRegister d28(28);
+    constexpr static DRegister d29(29);
+    constexpr static DRegister d30(30);
+    constexpr static DRegister d31(31);
+  }
+
+  // Namespace containing all 128-bit ASIMD register objects.
+  namespace QReg {
+    constexpr static QRegister q0(0);
+    constexpr static QRegister q1(1);
+    constexpr static QRegister q2(2);
+    constexpr static QRegister q3(3);
+    constexpr static QRegister q4(4);
+    constexpr static QRegister q5(5);
+    constexpr static QRegister q6(6);
+    constexpr static QRegister q7(7);
+    constexpr static QRegister q8(8);
+    constexpr static QRegister q9(9);
+    constexpr static QRegister q10(10);
+    constexpr static QRegister q11(11);
+    constexpr static QRegister q12(12);
+    constexpr static QRegister q13(13);
+    constexpr static QRegister q14(14);
+    constexpr static QRegister q15(15);
+    constexpr static QRegister q16(16);
+    constexpr static QRegister q17(17);
+    constexpr static QRegister q18(18);
+    constexpr static QRegister q19(19);
+    constexpr static QRegister q20(20);
+    constexpr static QRegister q21(21);
+    constexpr static QRegister q22(22);
+    constexpr static QRegister q23(23);
+    constexpr static QRegister q24(24);
+    constexpr static QRegister q25(25);
+    constexpr static QRegister q26(26);
+    constexpr static QRegister q27(27);
+    constexpr static QRegister q28(28);
+    constexpr static QRegister q29(29);
+    constexpr static QRegister q30(30);
+    constexpr static QRegister q31(31);
+  }
+
+  // Namespace containing all unsigned SVE register objects.
+  namespace ZReg {
+    constexpr static ZRegister z0(0);
+    constexpr static ZRegister z1(1);
+    constexpr static ZRegister z2(2);
+    constexpr static ZRegister z3(3);
+    constexpr static ZRegister z4(4);
+    constexpr static ZRegister z5(5);
+    constexpr static ZRegister z6(6);
+    constexpr static ZRegister z7(7);
+    constexpr static ZRegister z8(8);
+    constexpr static ZRegister z9(9);
+    constexpr static ZRegister z10(10);
+    constexpr static ZRegister z11(11);
+    constexpr static ZRegister z12(12);
+    constexpr static ZRegister z13(13);
+    constexpr static ZRegister z14(14);
+    constexpr static ZRegister z15(15);
+    constexpr static ZRegister z16(16);
+    constexpr static ZRegister z17(17);
+    constexpr static ZRegister z18(18);
+    constexpr static ZRegister z19(19);
+    constexpr static ZRegister z20(20);
+    constexpr static ZRegister z21(21);
+    constexpr static ZRegister z22(22);
+    constexpr static ZRegister z23(23);
+    constexpr static ZRegister z24(24);
+    constexpr static ZRegister z25(25);
+    constexpr static ZRegister z26(26);
+    constexpr static ZRegister z27(27);
+    constexpr static ZRegister z28(28);
+    constexpr static ZRegister z29(29);
+    constexpr static ZRegister z30(30);
+    constexpr static ZRegister z31(31);
+  }
+
+  // Zero-cost FPR->GPR
+  inline
+  Register ToReg(HRegister Reg) {
+    return static_cast<Register>(Reg.Idx());
+  }
+  inline
+  Register ToReg(SRegister Reg) {
+    return static_cast<Register>(Reg.Idx());
+  }
+  inline
+  Register ToReg(DRegister Reg) {
+    return static_cast<Register>(Reg.Idx());
+  }
+
+  inline
+  Register ToReg(VRegister Reg) {
+    return static_cast<Register>(Reg.Idx());
+  }
+
+  // Zero-cost GPR->FPR
+  inline
+  VRegister ToVReg(Register Reg) {
+    return static_cast<VRegister>(Reg.Idx());
+  }
+  inline
+  VRegister ToVReg(XRegister Reg) {
+    return static_cast<VRegister>(Reg.Idx());
+  }
+  inline
+  VRegister ToVReg(WRegister Reg) {
+    return static_cast<VRegister>(Reg.Idx());
+  }
+
+  class PRegisterZero;
+  class PRegisterMerge;
+
+  /* Unsized predicate register for SVE.
+   * This is unsized because of how SVE operates.
+   */
+  class PRegister {
+    public:
+      PRegister() = delete;
+      constexpr PRegister(uint32_t Idx)
+        : Index {Idx} {}
+
+      operator uint32_t() const {
+        return Index;
+      }
+
+      uint32_t Idx() const {
+        return Index;
+      }
+
+      operator PRegisterZero() const;
+      operator PRegisterMerge() const;
+
+      PRegisterZero Zeroing() const;
+      PRegisterMerge Merging() const;
+
+    private:
+      uint32_t Index;
+  };
+  static_assert(sizeof(PRegister) == sizeof(uint32_t), "Needs to be uint32_t");
+  static_assert(std::is_trivial_v<PRegister>, "Needs to be trivial");
+  static_assert(std::is_standard_layout_v<PRegister>, "Needs to be standard");
+
+  // Unsized predicate register for SVE with zeroing semantics.
+  class PRegisterZero {
+    public:
+      PRegisterZero() = delete;
+      constexpr PRegisterZero(uint32_t Idx)
+        : Index {Idx} {}
+
+      operator uint32_t() const {
+        return Index;
+      }
+
+      uint32_t Idx() const {
+        return Index;
+      }
+
+      operator PRegister() const;
+      operator PRegisterMerge() const;
+
+      PRegister P() const;
+      PRegisterMerge Merging() const;
+
+    private:
+      uint32_t Index;
+  };
+  static_assert(sizeof(PRegisterZero) == sizeof(uint32_t), "Needs to be uint32_t");
+  static_assert(std::is_trivial_v<PRegisterZero>, "Needs to be trivial");
+  static_assert(std::is_standard_layout_v<PRegisterZero>, "Needs to be standard");
+
+  // Unsized predicate register for SVE with merging semantics.
+  class PRegisterMerge {
+    public:
+      PRegisterMerge() = delete;
+      constexpr PRegisterMerge(uint32_t Idx)
+        : Index {Idx} {}
+
+      operator uint32_t() const {
+        return Index;
+      }
+
+      uint32_t Idx() const {
+        return Index;
+      }
+
+      operator PRegister() const;
+      operator PRegisterZero() const;
+
+      PRegister P() const;
+      PRegisterZero Zeroing() const;
+
+    private:
+      uint32_t Index;
+  };
+  static_assert(sizeof(PRegisterZero) == sizeof(uint32_t), "Needs to be uint32_t");
+  static_assert(std::is_trivial_v<PRegisterZero>, "Needs to be trivial");
+  static_assert(std::is_standard_layout_v<PRegisterZero>, "Needs to be standard");
+
+
+  // PRegister
+  inline PRegister::operator PRegisterZero() const {
+    return PRegisterZero(Index);
+  }
+
+  inline PRegister::operator PRegisterMerge() const {
+    return PRegisterMerge(Index);
+  }
+
+  inline PRegisterZero PRegister::Zeroing() const {
+    return PRegisterZero(Idx());
+  }
+
+  inline PRegisterMerge PRegister::Merging() const {
+    return PRegisterMerge(Idx());
+  }
+
+  // PRegisterZero
+  inline PRegisterZero::operator PRegister() const {
+    return PRegister(Index);
+  }
+
+  inline PRegisterZero::operator PRegisterMerge() const {
+    return PRegisterMerge(Index);
+  }
+
+  inline PRegister PRegisterZero::P() const {
+    return PRegister(Idx());
+  }
+
+  inline PRegisterMerge PRegisterZero::Merging() const {
+    return PRegisterMerge(Idx());
+  }
+
+  // PRegisterMerge
+  inline PRegisterMerge::operator PRegister() const {
+    return PRegisterZero(Index);
+  }
+
+  inline PRegisterMerge::operator PRegisterZero() const {
+    return PRegisterZero(Index);
+  }
+
+  inline PRegister PRegisterMerge::P() const {
+    return PRegister(Idx());
+  }
+
+  inline PRegisterZero PRegisterMerge::Zeroing() const {
+    return PRegisterZero(Idx());
+  }
+
+  // Namespace containing all unsigned SVE predicate register objects.
+  namespace PReg {
+    constexpr static PRegister p0(0);
+    constexpr static PRegister p1(1);
+    constexpr static PRegister p2(2);
+    constexpr static PRegister p3(3);
+    constexpr static PRegister p4(4);
+    constexpr static PRegister p5(5);
+    constexpr static PRegister p6(6);
+    constexpr static PRegister p7(7);
+    constexpr static PRegister p8(8);
+    constexpr static PRegister p9(9);
+    constexpr static PRegister p10(10);
+    constexpr static PRegister p11(11);
+    constexpr static PRegister p12(12);
+    constexpr static PRegister p13(13);
+    constexpr static PRegister p14(14);
+    constexpr static PRegister p15(15);
+  }
+
+  /* `OpType` enum describes how some SVE instructions operate if they support both forms.
+   * Not all SVE instructions support this.
+   */
+  enum class OpType : uint32_t {
+    Destructive = 0,
+    Constructive,
+  };
+}

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
@@ -1,0 +1,3959 @@
+/* SVE instruction emitters
+ * These contain instruction emitters for AArch64 SVE and SVE2 operations.
+ *
+ * All of these SVE emitters have a `SubRegSize` as their first argument to set the element size on the instruction.
+ * Since nearly every SVE instruction is unsized they don't need more than `ZRegister` and `PRegister` arguments.
+ *
+ * Most predicated instructions take a `PRegister` argument, not explicitly stating if it is merging or zeroing behaviour.
+ * This is because the instruction only supports one style.
+ * For instructions that take an explicit `PRegisterMerge` or `PRegisterZero`, then this instruction likely
+ * supports both so we support both implementations depending on predicate register type.
+ *
+ * Some instructions take a templated `OpType` to choose between a destructive or constructive version of the instruction.
+ *
+ * Some instructions support the `i128Bit` SubRegSize, mostly around data movement.
+ *
+ * There are some SVE load-store helper functions which take a `SVEMemOperand` argument.
+ * This helper will select the viable SVE load-store that can work with the provided encapsulated arguments.
+ */
+public:
+  // SVE encodings
+  void dup(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, uint32_t Index) {
+    constexpr uint32_t Op = 0b0000'0101'0010'0000'0010'00 << 10;
+    uint32_t imm2{};
+    uint32_t tsz{};
+
+    // We can index up to 512-bit registers with dup
+    if (size == FEXCore::ARMEmitter::SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 64, "Index too large");
+      tsz = 0b00001 | ((Index & 0b1111) << 1);
+      imm2 = Index >> 4;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 32, "Index too large");
+      tsz = 0b00010 | ((Index & 0b111) << 2);
+      imm2 = Index >> 3;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 16, "Index too large");
+      tsz = 0b00100 | ((Index & 0b11) << 3);
+      imm2 = Index >> 2;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i64Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 8, "Index too large");
+      tsz = 0b01000 | ((Index & 0b1) << 4);
+      imm2 = Index >> 1;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i128Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 4, "Index too large");
+      tsz = 0b10000;
+      imm2 = Index;
+    }
+
+    SVEDup(Op, imm2, tsz, zn, zd);
+  }
+  // TODO: TBL
+
+  void sel(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegister pv, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    constexpr uint32_t Op = 0b0000'0101'0010'0000'11 << 14;
+    SVESel(Op, size, zm, pv, zn, zd);
+  }
+
+  void mov(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pv, FEXCore::ARMEmitter::ZRegister zn) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    constexpr uint32_t Op = 0b0000'0101'0010'0000'11 << 14;
+    SVESel(Op, size, zd, pv, zn, zd);
+  }
+
+  // TODO: HISTCNT
+  // TODO: FCMLA
+  // TODO: FCADD
+
+  // SVE integer add/subtract vectors (unpredicated)
+  void add(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    constexpr uint32_t Op = 0b0000'0100'0010'0000'000 << 13;
+    SVEIntegerAddSubUnpredicated(Op, 0b000, size, zm, zn, zd);
+  }
+  void sub(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    constexpr uint32_t Op = 0b0000'0100'0010'0000'000 << 13;
+    SVEIntegerAddSubUnpredicated(Op, 0b001, size, zm, zn, zd);
+  }
+  void sqadd(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    constexpr uint32_t Op = 0b0000'0100'0010'0000'000 << 13;
+    SVEIntegerAddSubUnpredicated(Op, 0b100, size, zm, zn, zd);
+  }
+  void uqadd(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    constexpr uint32_t Op = 0b0000'0100'0010'0000'000 << 13;
+    SVEIntegerAddSubUnpredicated(Op, 0b101, size, zm, zn, zd);
+  }
+  void sqsub(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    constexpr uint32_t Op = 0b0000'0100'0010'0000'000 << 13;
+    SVEIntegerAddSubUnpredicated(Op, 0b110, size, zm, zn, zd);
+  }
+  void uqsub(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    constexpr uint32_t Op = 0b0000'0100'0010'0000'000 << 13;
+    SVEIntegerAddSubUnpredicated(Op, 0b111, size, zm, zn, zd);
+  }
+
+  // SVE address generation
+  // XXX:
+  // SVE table lookup (three sources)
+  void tbl(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    constexpr uint32_t Op = 0b0000'0101'0010'0000'0011'0 << 11;
+    SVETableLookup(Op, 0, size, zm, zn, zd);
+  }
+  void tbx(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    constexpr uint32_t Op = 0b0000'0101'0010'0000'0010'1 << 11;
+    SVETableLookup(Op, 1, size, zm, zn, zd);
+  }
+  // SVE permute vector elements
+  void zip1(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    constexpr uint32_t Op = 0b0000'0101'0010'0000'011 << 13;
+    SVEPermute(Op, 0b000, size, zm, zn, zd);
+  }
+  void zip2(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    constexpr uint32_t Op = 0b0000'0101'0010'0000'011 << 13;
+    SVEPermute(Op, 0b001, size, zm, zn, zd);
+  }
+  void uzp1(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    constexpr uint32_t Op = 0b0000'0101'0010'0000'011 << 13;
+    SVEPermute(Op, 0b010, size, zm, zn, zd);
+  }
+  void uzp2(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    constexpr uint32_t Op = 0b0000'0101'0010'0000'011 << 13;
+    SVEPermute(Op, 0b011, size, zm, zn, zd);
+  }
+  void trn1(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    constexpr uint32_t Op = 0b0000'0101'0010'0000'011 << 13;
+    SVEPermute(Op, 0b100, size, zm, zn, zd);
+  }
+  void trn2(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    constexpr uint32_t Op = 0b0000'0101'0010'0000'011 << 13;
+    SVEPermute(Op, 0b101, size, zm, zn, zd);
+  }
+
+  // SVE integer compare with unsigned immediate
+  void cmphi(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::ZRegister zn, uint32_t imm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_AA_FMT(imm < 128, "Invalid imm");
+    SVEIntegerCompareImm(0, 1, imm, size, pg, zn, pd);
+  }
+
+  void cmphs(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::ZRegister zn, uint32_t imm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_AA_FMT(imm < 128, "Invalid imm");
+    SVEIntegerCompareImm(0, 0, imm, size, pg, zn, pd);
+  }
+
+  void cmplo(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::ZRegister zn, uint32_t imm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_AA_FMT(imm < 128, "Invalid imm");
+    SVEIntegerCompareImm(1, 0, imm, size, pg, zn, pd);
+  }
+
+  void cmpls(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::ZRegister zn, uint32_t imm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_AA_FMT(imm < 128, "Invalid imm");
+    SVEIntegerCompareImm(1, 1, imm, size, pg, zn, pd);
+  }
+
+  void SVEIntegerCompareImm(uint32_t lt, uint32_t ne, uint32_t imm7, FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::PRegister pd) {
+    constexpr uint32_t Op = 0b0010'0100'0010'0000'0000 << 12;
+    uint32_t Instr = Op;
+
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= imm7 << 14;
+    Instr |= lt << 13;
+    Instr |= pg.Idx() << 10;
+    Instr |= zn.Idx() << 5;
+    Instr |= ne << 4;
+    Instr |= pd.Idx();
+    dc32(Instr);
+  }
+  // SVE integer compare with signed immediate
+  void cmpeq(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::ZRegister zn, int32_t imm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_AA_FMT(imm >= -16 && imm <= 15, "Invalid imm");
+    SVEIntegerCompareSignedImm(1, 0, 0, imm, size, pg, zn, pd);
+  }
+
+  void cmpgt(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::ZRegister zn, int32_t imm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_AA_FMT(imm >= -16 && imm <= 15, "Invalid imm");
+    SVEIntegerCompareSignedImm(0, 0, 1, imm, size, pg, zn, pd);
+  }
+
+  void cmpge(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::ZRegister zn, int32_t imm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_AA_FMT(imm >= -16 && imm <= 15, "Invalid imm");
+    SVEIntegerCompareSignedImm(0, 0, 0, imm, size, pg, zn, pd);
+  }
+
+  void cmplt(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::ZRegister zn, int32_t imm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_AA_FMT(imm >= -16 && imm <= 15, "Invalid imm");
+    SVEIntegerCompareSignedImm(0, 1, 0, imm, size, pg, zn, pd);
+  }
+
+  void cmple(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::ZRegister zn, int32_t imm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_AA_FMT(imm >= -16 && imm <= 15, "Invalid imm");
+    SVEIntegerCompareSignedImm(0, 1, 1, imm, size, pg, zn, pd);
+  }
+
+  void SVEIntegerCompareSignedImm(uint32_t op, uint32_t o2, uint32_t ne, uint32_t imm5, FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::PRegister pd) {
+    constexpr uint32_t Op = 0b0010'0101'0000'0000'000 << 13;;
+    uint32_t Instr = Op;
+
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= (imm5 & 0b1'1111) << 16;
+    Instr |= op << 15;
+    Instr |= o2 << 13;
+    Instr |= pg.Idx() << 10;
+    Instr |= zn.Idx() << 5;
+    Instr |= ne << 4;
+    Instr |= pd.Idx();
+    dc32(Instr);
+  }
+  // SVE predicate logical operations
+  void and_(FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::PRegister pn, FEXCore::ARMEmitter::PRegister pm) {
+    constexpr uint32_t Op = 0b0010'0101'0000'0000'01 << 14;
+    SVEPredicateLogical(Op, 0, 0, 0, 0, pm, pg, pn, pd);
+  }
+
+  void ands(FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::PRegister pn, FEXCore::ARMEmitter::PRegister pm) {
+    constexpr uint32_t Op = 0b0010'0101'0000'0000'01 << 14;
+    SVEPredicateLogical(Op, 0, 1, 0, 0, pm, pg, pn, pd);
+  }
+
+  void mov(FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::PRegister pn) {
+    constexpr uint32_t Op = 0b0010'0101'0000'0000'01 << 14;
+    SVEPredicateLogical(Op, 0, 0, 1, 1, pd, pg, pn, pd);
+  }
+
+  void mov(FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::PRegister pn) {
+    constexpr uint32_t Op = 0b0010'0101'0000'0000'01 << 14;
+    SVEPredicateLogical(Op, 0, 0, 0, 0, pn, pg, pn, pd);
+  }
+
+  void movs(FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::PRegister pn) {
+    constexpr uint32_t Op = 0b0010'0101'0000'0000'01 << 14;
+    SVEPredicateLogical(Op, 0, 1, 0, 0, pn, pg, pn, pd);
+  }
+  void bic(FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::PRegister pn, FEXCore::ARMEmitter::PRegister pm) {
+    constexpr uint32_t Op = 0b0010'0101'0000'0000'01 << 14;
+    SVEPredicateLogical(Op, 0, 0, 0, 1, pm, pg, pn, pd);
+  }
+  void bics(FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::PRegister pn, FEXCore::ARMEmitter::PRegister pm) {
+    constexpr uint32_t Op = 0b0010'0101'0000'0000'01 << 14;
+    SVEPredicateLogical(Op, 0, 1, 0, 1, pm, pg, pn, pd);
+  }
+
+  void eor(FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::PRegister pn, FEXCore::ARMEmitter::PRegister pm) {
+    constexpr uint32_t Op = 0b0010'0101'0000'0000'01 << 14;
+    SVEPredicateLogical(Op, 0, 0, 1, 0, pm, pg, pn, pd);
+  }
+  void eors(FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::PRegister pn, FEXCore::ARMEmitter::PRegister pm) {
+    constexpr uint32_t Op = 0b0010'0101'0000'0000'01 << 14;
+    SVEPredicateLogical(Op, 0, 1, 1, 0, pm, pg, pn, pd);
+  }
+
+  void not_(FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::PRegister pn) {
+    constexpr uint32_t Op = 0b0010'0101'0000'0000'01 << 14;
+    SVEPredicateLogical(Op, 0, 0, 1, 0, pg, pg, pn, pd);
+  }
+  void sel(FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::PRegister pn, FEXCore::ARMEmitter::PRegister pm) {
+    constexpr uint32_t Op = 0b0010'0101'0000'0000'01 << 14;
+    SVEPredicateLogical(Op, 0, 0, 1, 1, pm, pg, pn, pd);
+  }
+  void orr(FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::PRegister pn, FEXCore::ARMEmitter::PRegister pm) {
+    constexpr uint32_t Op = 0b0010'0101'0000'0000'01 << 14;
+    SVEPredicateLogical(Op, 1, 0, 0, 0, pm, pg, pn, pd);
+  }
+  void mov(FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PRegister pn) {
+    constexpr uint32_t Op = 0b0010'0101'0000'0000'01 << 14;
+    SVEPredicateLogical(Op, 1, 0, 0, 0, pn, pn, pn, pd);
+  }
+  void orn(FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::PRegister pn, FEXCore::ARMEmitter::PRegister pm) {
+    constexpr uint32_t Op = 0b0010'0101'0000'0000'01 << 14;
+    SVEPredicateLogical(Op, 1, 0, 0, 1, pm, pg, pn, pd);
+  }
+  void nor(FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::PRegister pn, FEXCore::ARMEmitter::PRegister pm) {
+    constexpr uint32_t Op = 0b0010'0101'0000'0000'01 << 14;
+    SVEPredicateLogical(Op, 1, 0, 1, 0, pm, pg, pn, pd);
+  }
+  void nand(FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::PRegister pn, FEXCore::ARMEmitter::PRegister pm) {
+    constexpr uint32_t Op = 0b0010'0101'0000'0000'01 << 14;
+    SVEPredicateLogical(Op, 1, 0, 1, 1, pm, pg, pn, pd);
+  }
+  void orrs(FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::PRegister pn, FEXCore::ARMEmitter::PRegister pm) {
+    constexpr uint32_t Op = 0b0010'0101'0000'0000'01 << 14;
+    SVEPredicateLogical(Op, 1, 1, 0, 0, pm, pg, pn, pd);
+  }
+  void movs(FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PRegister pn) {
+    constexpr uint32_t Op = 0b0010'0101'0000'0000'01 << 14;
+    SVEPredicateLogical(Op, 1, 1, 0, 0, pn, pn, pn, pd);
+  }
+  void orns(FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::PRegister pn, FEXCore::ARMEmitter::PRegister pm) {
+    constexpr uint32_t Op = 0b0010'0101'0000'0000'01 << 14;
+    SVEPredicateLogical(Op, 1, 1, 0, 1, pm, pg, pn, pd);
+  }
+  void nors(FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::PRegister pn, FEXCore::ARMEmitter::PRegister pm) {
+    constexpr uint32_t Op = 0b0010'0101'0000'0000'01 << 14;
+    SVEPredicateLogical(Op, 1, 1, 1, 0, pm, pg, pn, pd);
+  }
+  void nands(FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::PRegister pn, FEXCore::ARMEmitter::PRegister pm) {
+    constexpr uint32_t Op = 0b0010'0101'0000'0000'01 << 14;
+    SVEPredicateLogical(Op, 1, 1, 1, 1, pm, pg, pn, pd);
+  }
+
+  // SVE broadcast predicate element
+  // XXX:
+  // SVE integer clamp
+  // XXX:
+  // SVE2 character match
+  // XXX:
+  // SVE floating-point convert precision odd elements
+  void fcvtxnt(FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zn) {
+    constexpr uint32_t Op = 0b0110'0100'0000'1000'101 << 13;
+    SVEFloatConvertOdd(Op, 0b00, 0b10, pg, zn, zd);
+  }
+  ///< Size is destination size
+  void fcvtnt(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zn) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i32Bit ||
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit, "Unsupported size in {}", __func__);
+
+    constexpr uint32_t Op = 0b0110'0100'0000'1000'101 << 13;
+
+    const auto ConvertedDestSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? 0b00 :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? 0b10 : 0b00;
+
+    const auto ConvertedSrcSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? 0b10 :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? 0b11 : 0b00;
+
+    SVEFloatConvertOdd(Op, ConvertedSrcSize, ConvertedDestSize, pg, zn, zd);
+  }
+
+  ///< Size is destination size
+  void fcvtlt(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zn) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Unsupported size in {}", __func__);
+
+    constexpr uint32_t Op = 0b0110'0100'0000'1000'101 << 13;
+
+    const auto ConvertedDestSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? 0b01 :
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? 0b11 : 0b00;
+
+    const auto ConvertedSrcSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? 0b10 :
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? 0b11 : 0b00;
+
+    SVEFloatConvertOdd(Op, ConvertedSrcSize, ConvertedDestSize, pg, zn, zd);
+  }
+
+  // XXX: BFCVTNT
+  // SVE2 floating-point pairwise operations
+  void faddp(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    LOGMAN_THROW_A_FMT(size == FEXCore::ARMEmitter::SubRegSize::i16Bit || size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid float size");
+
+    constexpr uint32_t Op = 0b0110'0100'0001'0000'100 << 13;;
+    SVEFloatPairwiseArithmetic(Op, 0b000, size, pg, zm, zd);
+  }
+
+  void fmaxnmp(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    LOGMAN_THROW_A_FMT(size == FEXCore::ARMEmitter::SubRegSize::i16Bit || size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid float size");
+
+    constexpr uint32_t Op = 0b0110'0100'0001'0000'100 << 13;;
+    SVEFloatPairwiseArithmetic(Op, 0b100, size, pg, zm, zd);
+  }
+  void fminnmp(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    LOGMAN_THROW_A_FMT(size == FEXCore::ARMEmitter::SubRegSize::i16Bit || size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid float size");
+
+    constexpr uint32_t Op = 0b0110'0100'0001'0000'100 << 13;;
+    SVEFloatPairwiseArithmetic(Op, 0b101, size, pg, zm, zd);
+  }
+  void fmaxp(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    LOGMAN_THROW_A_FMT(size == FEXCore::ARMEmitter::SubRegSize::i16Bit || size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid float size");
+
+    constexpr uint32_t Op = 0b0110'0100'0001'0000'100 << 13;;
+    SVEFloatPairwiseArithmetic(Op, 0b110, size, pg, zm, zd);
+  }
+  void fminp(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    LOGMAN_THROW_A_FMT(size == FEXCore::ARMEmitter::SubRegSize::i16Bit || size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid float size");
+
+    constexpr uint32_t Op = 0b0110'0100'0001'0000'100 << 13;;
+    SVEFloatPairwiseArithmetic(Op, 0b111, size, pg, zm, zd);
+  }
+
+  // SVE floating-point multiply-add (indexed)
+  // XXX:
+  // SVE floating-point complex multiply-add (indexed)
+  // XXX:
+  // SVE floating-point multiply (indexed)
+  // XXX:
+  // SVE floating point matrix multiply accumulate
+  // XXX:
+  // SVE floating-point compare vectors
+  void fcmeq(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "Can't use 8-bit size");
+    SVEFloatCompareVector(0, 1, 0, size, zm, pg, zn, pd);
+  }
+
+  void fcmgt(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "Can't use 8-bit size");
+    SVEFloatCompareVector(0, 0, 1, size, zm, pg, zn, pd);
+  }
+
+  void fcmge(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "Can't use 8-bit size");
+    SVEFloatCompareVector(0, 0, 0, size, zm, pg, zn, pd);
+  }
+  void fcmne(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "Can't use 8-bit size");
+    SVEFloatCompareVector(0, 1, 1, size, zm, pg, zn, pd);
+  }
+
+  void fcmuo(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "Can't use 8-bit size");
+    SVEFloatCompareVector(1, 0, 0, size, zm, pg, zn, pd);
+  }
+
+  void SVEFloatCompareVector(uint32_t op, uint32_t o2, uint32_t o3, FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zm, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::PRegister pd) {
+    constexpr uint32_t Op = 0b0110'0101'0000'0000'010 << 13;
+    uint32_t Instr = Op;
+
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= zm.Idx() << 16;
+    Instr |= op << 15;
+    Instr |= o2 << 13;
+    Instr |= pg.Idx() << 10;
+    Instr |= zn.Idx() << 5;
+    Instr |= o3 << 4;
+    Instr |= pd.Idx();
+    dc32(Instr);
+  }
+
+  // SVE floating-point arithmetic (unpredicated)
+  void fadd(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_A_FMT(size == FEXCore::ARMEmitter::SubRegSize::i16Bit || size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid float size");
+    constexpr uint32_t Op = 0b0110'0101'0000'0000'000 << 13;
+    SVEFloatArithmeticUnpredicated(Op, 0b000, size, zm, zn, zd);
+  }
+  void fsub(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_A_FMT(size == FEXCore::ARMEmitter::SubRegSize::i16Bit || size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid float size");
+    constexpr uint32_t Op = 0b0110'0101'0000'0000'000 << 13;
+    SVEFloatArithmeticUnpredicated(Op, 0b001, size, zm, zn, zd);
+  }
+  void fmul(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_A_FMT(size == FEXCore::ARMEmitter::SubRegSize::i16Bit || size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid float size");
+    constexpr uint32_t Op = 0b0110'0101'0000'0000'000 << 13;
+    SVEFloatArithmeticUnpredicated(Op, 0b010, size, zm, zn, zd);
+  }
+  void ftsmul(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_A_FMT(size == FEXCore::ARMEmitter::SubRegSize::i16Bit || size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid float size");
+    constexpr uint32_t Op = 0b0110'0101'0000'0000'000 << 13;
+    SVEFloatArithmeticUnpredicated(Op, 0b011, size, zm, zn, zd);
+  }
+  void frecps(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_A_FMT(size == FEXCore::ARMEmitter::SubRegSize::i16Bit || size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid float size");
+    constexpr uint32_t Op = 0b0110'0101'0000'0000'000 << 13;
+    SVEFloatArithmeticUnpredicated(Op, 0b110, size, zm, zn, zd);
+  }
+  void frsqrts(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_A_FMT(size == FEXCore::ARMEmitter::SubRegSize::i16Bit || size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid float size");
+    constexpr uint32_t Op = 0b0110'0101'0000'0000'000 << 13;
+    SVEFloatArithmeticUnpredicated(Op, 0b111, size, zm, zn, zd);
+  }
+
+  // SVE floating-point recursive reduction
+  // XXX:
+
+  // SVE integer Multiply-Add - Predicated
+  // SVE integer multiply-accumulate writing addend (predicated)
+  // XXX:
+  // SVE integer multiply-add writing multiplicand (predicated)
+  // XXX:
+
+  // SVE Integer Binary Arithmetic - Predicated
+  // SVE integer add/subtract vectors (predicated)
+  // XXX:
+  // SVE integer min/max/difference (predicated)
+  void smax(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    SVEIntegerMinMaxDifferencePredicated(0b00, 0, size, pg, zm, zd);
+  }
+  void umax(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    SVEIntegerMinMaxDifferencePredicated(0b00, 1, size, pg, zm, zd);
+  }
+  void smin(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    SVEIntegerMinMaxDifferencePredicated(0b01, 0, size, pg, zm, zd);
+  }
+  void umin(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    SVEIntegerMinMaxDifferencePredicated(0b01, 1, size, pg, zm, zd);
+  }
+  void sabd(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    SVEIntegerMinMaxDifferencePredicated(0b10, 0, size, pg, zm, zd);
+  }
+  void uabd(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    SVEIntegerMinMaxDifferencePredicated(0b10, 1, size, pg, zm, zd);
+  }
+
+  void SVEIntegerMinMaxDifferencePredicated(uint32_t opc, uint32_t U, FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::ZRegister zm, FEXCore::ARMEmitter::ZRegister zd) {
+    constexpr uint32_t Op = 0b0000'0100'0000'1000'000 << 13;
+    uint32_t Instr = Op;
+
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= opc << 17;
+    Instr |= U << 16;
+    Instr |= pg.Idx() << 10;
+    Instr |= zm.Idx() << 5;
+    Instr |= zd.Idx();
+    dc32(Instr);
+  }
+
+  // SVE integer multiply vectors (predicated)
+  // XXX:
+  // SVE integer divide vectors (predicated)
+  // XXX:
+  // SVE bitwise logical operations (predicated)
+  void orr(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    constexpr uint32_t Op = 0b0000'0100'0001'1000'000 << 13;
+    SVEBitwiseLogicalPredicated(Op, 0b000, size, pg, zm, zd);
+  }
+  void eor(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    constexpr uint32_t Op = 0b0000'0100'0001'1000'000 << 13;
+    SVEBitwiseLogicalPredicated(Op, 0b001, size, pg, zm, zd);
+  }
+  void and_(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    constexpr uint32_t Op = 0b0000'0100'0001'1000'000 << 13;
+    SVEBitwiseLogicalPredicated(Op, 0b010, size, pg, zm, zd);
+  }
+  void bic(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    constexpr uint32_t Op = 0b0000'0100'0001'1000'000 << 13;
+    SVEBitwiseLogicalPredicated(Op, 0b011, size, pg, zm, zd);
+  }
+
+  // SVE Integer Reduction
+  // SVE integer add reduction (predicated)
+  // XXX:
+  // SVE integer min/max reduction (predicated)
+  void smaxv(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::ZRegister zn) {
+    LOGMAN_THROW_A_FMT(size == FEXCore::ARMEmitter::SubRegSize::i8Bit || size == FEXCore::ARMEmitter::SubRegSize::i16Bit || size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Invalid subregsize size");
+    constexpr uint32_t Op = 0b0000'0100'0000'1000'001 << 13;
+    SVEIntegerMinMaxReduction(Op, 0, 0, size, pg, zn, zd);
+  }
+  void umaxv(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::ZRegister zn) {
+    LOGMAN_THROW_A_FMT(size == FEXCore::ARMEmitter::SubRegSize::i8Bit || size == FEXCore::ARMEmitter::SubRegSize::i16Bit || size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Invalid subregsize size");
+    constexpr uint32_t Op = 0b0000'0100'0000'1000'001 << 13;
+    SVEIntegerMinMaxReduction(Op, 0, 1, size, pg, zn, zd);
+  }
+  void sminv(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::ZRegister zn) {
+    LOGMAN_THROW_A_FMT(size == FEXCore::ARMEmitter::SubRegSize::i8Bit || size == FEXCore::ARMEmitter::SubRegSize::i16Bit || size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Invalid subregsize size");
+    constexpr uint32_t Op = 0b0000'0100'0000'1000'001 << 13;
+    SVEIntegerMinMaxReduction(Op, 1, 0, size, pg, zn, zd);
+  }
+  void uminv(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::ZRegister zn) {
+    LOGMAN_THROW_A_FMT(size == FEXCore::ARMEmitter::SubRegSize::i8Bit || size == FEXCore::ARMEmitter::SubRegSize::i16Bit || size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Invalid subregsize size");
+    constexpr uint32_t Op = 0b0000'0100'0000'1000'001 << 13;
+    SVEIntegerMinMaxReduction(Op, 1, 1, size, pg, zn, zd);
+  }
+
+  // SVE constructive prefix (predicated)
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::PRegisterZero, T> || std::is_same_v<FEXCore::ARMEmitter::PRegisterMerge, T>)
+  void movprfx(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, T pg, FEXCore::ARMEmitter::ZRegister zn) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    constexpr uint32_t M = std::is_same_v<FEXCore::ARMEmitter::PRegisterMerge, T> ? 1 : 0;
+    constexpr uint32_t Op = 0b0000'0100'0001'0000'001 << 13;
+    SVEConstructivePrefixPredicated(Op, 0b00, M, size, pg, zn, zd);
+  }
+
+  // SVE bitwise logical reduction (predicated)
+  // XXX
+
+  // SVE Bitwise Shift - Predicated
+  // SVE bitwise shift by immediate (predicated)
+  void asr(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+
+    uint32_t tszh, tszl;
+    uint32_t imm3;
+    const uint32_t InverseShift = (2 * SubRegSizeInBits(size)) - Shift;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 8, "Incorrect shift");
+      tszh = 0b00;
+      tszl = 0b01;
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 16, "Incorrect shift");
+      tszh = 0b00;
+      tszl = 0b10 | ((InverseShift >> 3) & 0b1);
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 32, "Incorrect shift");
+      tszh = 0b01;
+      tszl = (InverseShift >> 3) & 0b11;
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i64Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 64, "Incorrect shift");
+      tszh = 0b10 | ((InverseShift >> 5) & 1);
+      tszl = (InverseShift >> 3) & 0b11;
+      imm3 = InverseShift & 0b111;
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+
+    SVEBitWiseShiftImmediatePred(tszh, 0b00, 0, 0, pg, tszl, imm3, zd);
+  }
+  void lsr(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+
+    uint32_t tszh, tszl;
+    uint32_t imm3;
+    const uint32_t InverseShift = (2 * SubRegSizeInBits(size)) - Shift;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 8, "Incorrect shift");
+      tszh = 0b00;
+      tszl = 0b01;
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 16, "Incorrect shift");
+      tszh = 0b00;
+      tszl = 0b10 | ((InverseShift >> 3) & 0b1);
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 32, "Incorrect shift");
+      tszh = 0b01;
+      tszl = (InverseShift >> 3) & 0b11;
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i64Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 64, "Incorrect shift");
+      tszh = 0b10 | ((InverseShift >> 5) & 1);
+      tszl = (InverseShift >> 3) & 0b11;
+      imm3 = InverseShift & 0b111;
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+
+    SVEBitWiseShiftImmediatePred(tszh, 0b00, 0, 1, pg, tszl, imm3, zd);
+  }
+  void lsl(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+
+    uint32_t tszh, tszl;
+    uint32_t imm3;
+    const uint32_t InverseShift = Shift;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Shift >= 0 && Shift < 8, "Incorrect shift");
+      tszh = 0b00;
+      tszl = 0b01;
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Shift >= 0 && Shift < 16, "Incorrect shift");
+      tszh = 0b00;
+      tszl = 0b10 | ((InverseShift >> 3) & 0b1);
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Shift >= 0 && Shift < 32, "Incorrect shift");
+      tszh = 0b01;
+      tszl = (InverseShift >> 3) & 0b11;
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i64Bit) {
+      LOGMAN_THROW_AA_FMT(Shift >= 0 && Shift < 64, "Incorrect shift");
+      tszh = 0b10 | ((InverseShift >> 5) & 1);
+      tszl = (InverseShift >> 3) & 0b11;
+      imm3 = InverseShift & 0b111;
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+
+    SVEBitWiseShiftImmediatePred(tszh, 0b00, 1, 1, pg, tszl, imm3, zd);
+  }
+  void asrd(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+
+    uint32_t tszh, tszl;
+    uint32_t imm3;
+    const uint32_t InverseShift = (2 * SubRegSizeInBits(size)) - Shift;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 8, "Incorrect shift");
+      tszh = 0b00;
+      tszl = 0b01;
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 16, "Incorrect shift");
+      tszh = 0b00;
+      tszl = 0b10 | ((InverseShift >> 3) & 0b1);
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 32, "Incorrect shift");
+      tszh = 0b01;
+      tszl = (InverseShift >> 3) & 0b11;
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i64Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 64, "Incorrect shift");
+      tszh = 0b10 | ((InverseShift >> 5) & 1);
+      tszl = (InverseShift >> 3) & 0b11;
+      imm3 = InverseShift & 0b111;
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+
+    SVEBitWiseShiftImmediatePred(tszh, 0b01, 0, 0, pg, tszl, imm3, zd);
+  }
+  void sqshl(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+
+    uint32_t tszh, tszl;
+    uint32_t imm3;
+    const uint32_t InverseShift = Shift;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Shift >= 0 && Shift < 8, "Incorrect shift");
+      tszh = 0b00;
+      tszl = 0b01;
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Shift >= 0 && Shift < 16, "Incorrect shift");
+      tszh = 0b00;
+      tszl = 0b10 | ((InverseShift >> 3) & 0b1);
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Shift >= 0 && Shift < 32, "Incorrect shift");
+      tszh = 0b01;
+      tszl = (InverseShift >> 3) & 0b11;
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i64Bit) {
+      LOGMAN_THROW_AA_FMT(Shift >= 0 && Shift < 64, "Incorrect shift");
+      tszh = 0b10 | ((InverseShift >> 5) & 1);
+      tszl = (InverseShift >> 3) & 0b11;
+      imm3 = InverseShift & 0b111;
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+
+    SVEBitWiseShiftImmediatePred(tszh, 0b01, 1, 0, pg, tszl, imm3, zd);
+  }
+  void uqshl(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+
+    uint32_t tszh, tszl;
+    uint32_t imm3;
+    const uint32_t InverseShift = Shift;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Shift >= 0 && Shift < 8, "Incorrect shift");
+      tszh = 0b00;
+      tszl = 0b01;
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Shift >= 0 && Shift < 16, "Incorrect shift");
+      tszh = 0b00;
+      tszl = 0b10 | ((InverseShift >> 3) & 0b1);
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Shift >= 0 && Shift < 32, "Incorrect shift");
+      tszh = 0b01;
+      tszl = (InverseShift >> 3) & 0b11;
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i64Bit) {
+      LOGMAN_THROW_AA_FMT(Shift >= 0 && Shift < 64, "Incorrect shift");
+      tszh = 0b10 | ((InverseShift >> 5) & 1);
+      tszl = (InverseShift >> 3) & 0b11;
+      imm3 = InverseShift & 0b111;
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+
+    SVEBitWiseShiftImmediatePred(tszh, 0b01, 1, 1, pg, tszl, imm3, zd);
+  }
+  void srshr(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+
+    uint32_t tszh, tszl;
+    uint32_t imm3;
+    const uint32_t InverseShift = (2 * SubRegSizeInBits(size)) - Shift;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 8, "Incorrect shift");
+      tszh = 0b00;
+      tszl = 0b01;
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 16, "Incorrect shift");
+      tszh = 0b00;
+      tszl = 0b10 | ((InverseShift >> 3) & 0b1);
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 32, "Incorrect shift");
+      tszh = 0b01;
+      tszl = (InverseShift >> 3) & 0b11;
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i64Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 64, "Incorrect shift");
+      tszh = 0b10 | ((InverseShift >> 5) & 1);
+      tszl = (InverseShift >> 3) & 0b11;
+      imm3 = InverseShift & 0b111;
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+
+    SVEBitWiseShiftImmediatePred(tszh, 0b11, 0, 0, pg, tszl, imm3, zd);
+  }
+  void urshr(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+
+    uint32_t tszh, tszl;
+    uint32_t imm3;
+    const uint32_t InverseShift = (2 * SubRegSizeInBits(size)) - Shift;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 8, "Incorrect shift");
+      tszh = 0b00;
+      tszl = 0b01;
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 16, "Incorrect shift");
+      tszh = 0b00;
+      tszl = 0b10 | ((InverseShift >> 3) & 0b1);
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 32, "Incorrect shift");
+      tszh = 0b01;
+      tszl = (InverseShift >> 3) & 0b11;
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i64Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 64, "Incorrect shift");
+      tszh = 0b10 | ((InverseShift >> 5) & 1);
+      tszl = (InverseShift >> 3) & 0b11;
+      imm3 = InverseShift & 0b111;
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+
+    SVEBitWiseShiftImmediatePred(tszh, 0b11, 0, 1, pg, tszl, imm3, zd);
+  }
+  void sqshlu(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+
+    uint32_t tszh, tszl;
+    uint32_t imm3;
+    const uint32_t InverseShift = Shift;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Shift >= 0 && Shift < 8, "Incorrect shift");
+      tszh = 0b00;
+      tszl = 0b01;
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Shift >= 0 && Shift < 16, "Incorrect shift");
+      tszh = 0b00;
+      tszl = 0b10 | ((InverseShift >> 3) & 0b1);
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Shift >= 0 && Shift < 32, "Incorrect shift");
+      tszh = 0b01;
+      tszl = (InverseShift >> 3) & 0b11;
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i64Bit) {
+      LOGMAN_THROW_AA_FMT(Shift >= 0 && Shift < 64, "Incorrect shift");
+      tszh = 0b10 | ((InverseShift >> 5) & 1);
+      tszl = (InverseShift >> 3) & 0b11;
+      imm3 = InverseShift & 0b111;
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+
+    SVEBitWiseShiftImmediatePred(tszh, 0b11, 1, 1, pg, tszl, imm3, zd);
+  }
+
+  void SVEBitWiseShiftImmediatePred(uint32_t tszh, uint32_t opc, uint32_t L, uint32_t U, FEXCore::ARMEmitter::PRegister pg, uint32_t tszl, uint32_t imm3, FEXCore::ARMEmitter::ZRegister zd) {
+    constexpr uint32_t Op = 0b0000'0100'0000'0000'100 << 13;
+    uint32_t Instr = Op;
+
+    Instr |= tszh << 22;
+    Instr |= opc << 18;
+    Instr |= L << 17;
+    Instr |= U << 16;
+    Instr |= pg.Idx() << 10;
+    Instr |= tszl << 8;
+    Instr |= imm3 << 5;
+    Instr |= zd.Idx();
+    dc32(Instr);
+  }
+  // SVE bitwise shift by vector (predicated)
+  void asr(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    SVEBitwiseShiftbyVector(0, 0, 0, size, pg, zm, zd);
+  }
+
+  void lsr(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    SVEBitwiseShiftbyVector(0, 0, 1, size, pg, zm, zd);
+  }
+  void lsl(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    SVEBitwiseShiftbyVector(0, 1, 1, size, pg, zm, zd);
+  }
+
+  void asrr(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    SVEBitwiseShiftbyVector(1, 0, 0, size, pg, zm, zd);
+  }
+  void lsrr(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    SVEBitwiseShiftbyVector(1, 0, 1, size, pg, zm, zd);
+  }
+
+  void lslr(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    SVEBitwiseShiftbyVector(1, 1, 1, size, pg, zm, zd);
+  }
+
+  void SVEBitwiseShiftbyVector(uint32_t R, uint32_t L, uint32_t U, FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::ZRegister zm, FEXCore::ARMEmitter::ZRegister zd) {
+    constexpr uint32_t Op = 0b0000'0100'0001'0000'100 << 13;
+    uint32_t Instr = Op;
+
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= R << 18;
+    Instr |= L << 17;
+    Instr |= U << 16;
+    Instr |= pg.Idx() << 10;
+    Instr |= zm.Idx() << 5;
+    Instr |= zd.Idx();
+    dc32(Instr);
+  }
+
+  // SVE bitwise shift by wide elements (predicated)
+  // XXX:
+
+  // SVE Integer Unary Arithmetic - Predicated
+  // SVE integer unary operations (predicated)
+  void sxtb(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zn) {
+    LOGMAN_THROW_A_FMT(size == FEXCore::ARMEmitter::SubRegSize::i16Bit || size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid subregsize size");
+    constexpr uint32_t Op = 0b0000'0100'0001'0000'101 << 13;;
+    SVEIntegerUnaryPredicated(Op, 0b000, size, pg, zn, zd);
+  }
+  void uxtb(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zn) {
+    LOGMAN_THROW_A_FMT(size == FEXCore::ARMEmitter::SubRegSize::i16Bit || size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid subregsize size");
+    constexpr uint32_t Op = 0b0000'0100'0001'0000'101 << 13;;
+    SVEIntegerUnaryPredicated(Op, 0b001, size, pg, zn, zd);
+  }
+  void sxth(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zn) {
+    LOGMAN_THROW_A_FMT(size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid subregsize size");
+    constexpr uint32_t Op = 0b0000'0100'0001'0000'101 << 13;;
+    SVEIntegerUnaryPredicated(Op, 0b010, size, pg, zn, zd);
+  }
+  void uxth(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zn) {
+    LOGMAN_THROW_A_FMT(size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid subregsize size");
+    constexpr uint32_t Op = 0b0000'0100'0001'0000'101 << 13;;
+    SVEIntegerUnaryPredicated(Op, 0b011, size, pg, zn, zd);
+  }
+  void sxtw(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zn) {
+    LOGMAN_THROW_A_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid subregsize size");
+    constexpr uint32_t Op = 0b0000'0100'0001'0000'101 << 13;;
+    SVEIntegerUnaryPredicated(Op, 0b100, size, pg, zn, zd);
+  }
+  void uxtw(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zn) {
+    LOGMAN_THROW_A_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid subregsize size");
+    constexpr uint32_t Op = 0b0000'0100'0001'0000'101 << 13;;
+    SVEIntegerUnaryPredicated(Op, 0b101, size, pg, zn, zd);
+  }
+  void abs(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zn) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    constexpr uint32_t Op = 0b0000'0100'0001'0000'101 << 13;;
+    SVEIntegerUnaryPredicated(Op, 0b110, size, pg, zn, zd);
+  }
+  void neg(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zn) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    constexpr uint32_t Op = 0b0000'0100'0001'0000'101 << 13;;
+    SVEIntegerUnaryPredicated(Op, 0b111, size, pg, zn, zd);
+  }
+
+  // SVE bitwise unary operations (predicated)
+  void cls(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zn) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    constexpr uint32_t Op = 0b0000'0100'0001'1000'101 << 13;
+    SVEIntegerUnaryPredicated(Op, 0b000, size, pg, zn, zd);
+  }
+  void clz(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zn) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    constexpr uint32_t Op = 0b0000'0100'0001'1000'101 << 13;
+    SVEIntegerUnaryPredicated(Op, 0b001, size, pg, zn, zd);
+  }
+  void cnt(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zn) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    constexpr uint32_t Op = 0b0000'0100'0001'1000'101 << 13;
+    SVEIntegerUnaryPredicated(Op, 0b010, size, pg, zn, zd);
+  }
+  void cnot(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zn) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    constexpr uint32_t Op = 0b0000'0100'0001'1000'101 << 13;
+    SVEIntegerUnaryPredicated(Op, 0b011, size, pg, zn, zd);
+  }
+  void fabs(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zn) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "Invalid size");
+    constexpr uint32_t Op = 0b0000'0100'0001'1000'101 << 13;
+    SVEIntegerUnaryPredicated(Op, 0b100, size, pg, zn, zd);
+  }
+  void fneg(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zn) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "Invalid size");
+    constexpr uint32_t Op = 0b0000'0100'0001'1000'101 << 13;
+    SVEIntegerUnaryPredicated(Op, 0b101, size, pg, zn, zd);
+  }
+  void not_(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zn) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    constexpr uint32_t Op = 0b0000'0100'0001'1000'101 << 13;
+    SVEIntegerUnaryPredicated(Op, 0b110, size, pg, zn, zd);
+  }
+
+  // SVE Bitwise Logical - Unpredicated
+  // SVE bitwise logical operations (unpredicated)
+  void and_(FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    constexpr uint32_t Op = 0b0000'0100'0010'0000'0011'00 << 10;
+    SVEBitwiseLogicalUnpredicated(Op, 0b00, zm, zn, zd);
+  }
+  void orr(FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    constexpr uint32_t Op = 0b0000'0100'0010'0000'0011'00 << 10;
+    SVEBitwiseLogicalUnpredicated(Op, 0b01, zm, zn, zd);
+  }
+  void mov(FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn) {
+    constexpr uint32_t Op = 0b0000'0100'0010'0000'0011'00 << 10;
+    SVEBitwiseLogicalUnpredicated(Op, 0b01, zn, zn, zd);
+  }
+  void eor(FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    constexpr uint32_t Op = 0b0000'0100'0010'0000'0011'00 << 10;
+    SVEBitwiseLogicalUnpredicated(Op, 0b10, zm, zn, zd);
+  }
+  void bic(FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    constexpr uint32_t Op = 0b0000'0100'0010'0000'0011'00 << 10;
+    SVEBitwiseLogicalUnpredicated(Op, 0b11, zm, zn, zd);
+  }
+
+  // SVE2 bitwise ternary operations
+  void eor3(FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm, FEXCore::ARMEmitter::ZRegister zk) {
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    SVE2BitwiseTernary(0b00, 0, zm, zk, zd);
+  }
+  void bsl(FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm, FEXCore::ARMEmitter::ZRegister zk) {
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    SVE2BitwiseTernary(0b00, 1, zm, zk, zd);
+  }
+  void bcax(FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm, FEXCore::ARMEmitter::ZRegister zk) {
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    SVE2BitwiseTernary(0b01, 0, zm, zk, zd);
+  }
+  void bsl1n(FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm, FEXCore::ARMEmitter::ZRegister zk) {
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    SVE2BitwiseTernary(0b01, 1, zm, zk, zd);
+  }
+  void bsl2n(FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm, FEXCore::ARMEmitter::ZRegister zk) {
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    SVE2BitwiseTernary(0b10, 1, zm, zk, zd);
+  }
+  void nbsl(FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm, FEXCore::ARMEmitter::ZRegister zk) {
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    SVE2BitwiseTernary(0b11, 1, zm, zk, zd);
+  }
+
+  void SVE2BitwiseTernary(uint32_t opc, uint32_t o2, FEXCore::ARMEmitter::ZRegister zm, FEXCore::ARMEmitter::ZRegister zk, FEXCore::ARMEmitter::ZRegister zdn) {
+    constexpr uint32_t Op = 0b0000'0100'0010'0000'0011'1 << 11;
+    uint32_t Instr = Op;
+
+    Instr |= opc << 22;
+    Instr |= zm.Idx() << 16;
+    Instr |= o2 << 10;
+    Instr |= zk.Idx() << 5;
+    Instr |= zdn.Idx();
+    dc32(Instr);
+  }
+  // SVE Index Generation
+  // XXX:
+
+  // SVE Stack Allocation
+  // SVE stack frame adjustment
+  // XXX:
+  // Streaming SVE stack frame adjustment
+  // XXX:
+  // SVE stack frame size
+  // XXX:
+  // Streaming SVE stack frame size
+  // XXX:
+
+  // SVE2 Integer Multiply - Unpredicated
+  // SVE2 integer multiply vectors (unpredicated)
+  void mul(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    SVE2IntegerMultiplyVectors(0b00, size, zm, zn, zd);
+  }
+  void smulh(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    SVE2IntegerMultiplyVectors(0b10, size, zm, zn, zd);
+  }
+
+  void umulh(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    SVE2IntegerMultiplyVectors(0b11, size, zm, zn, zd);
+  }
+
+  void pmul(FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    SVE2IntegerMultiplyVectors(0b01, FEXCore::ARMEmitter::SubRegSize::i8Bit, zm, zn, zd);
+  }
+
+  void SVE2IntegerMultiplyVectors(uint32_t opc, FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zm, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zd) {
+    constexpr uint32_t Op = 0b0000'0100'0010'0000'0110 << 12;
+    uint32_t Instr = Op;
+
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= zm.Idx() << 16;
+    Instr |= opc << 10;
+    Instr |= zn.Idx() << 5;
+    Instr |= zd.Idx();
+    dc32(Instr);
+  }
+
+  // XXX:
+  // SVE2 signed saturating doubling multiply high (unpredicated)
+  // XXX:
+
+  // SVE Bitwise Shift - Unpredicated
+  // SVE bitwise shift by wide elements (unpredicated)
+  // XXX:
+  // SVE bitwise shift by immediate (unpredicated)
+  // XXX:
+
+  // SVE Integer Misc - Unpredicated
+  // SVE floating-point trig select coefficient
+  // XXX:
+  // SVE floating-point exponential accelerator
+  // XXX:
+  // SVE constructive prefix (unpredicated)
+  void movprfx(FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn) {
+    const uint32_t Op = 0b0000'0100'0010'0000'1011'11 << 10;
+    SVEConstructivePrefixUnpredicated(Op, 0b00, 0b00000, zn, zd);
+  }
+
+  // SVE Element Count
+  // SVE saturating inc/dec vector by element count
+  // XXX:
+  // SVE element count
+  // XXX:
+  // SVE inc/dec vector by element count
+  // XXX:
+  // SVE inc/dec register by element count
+  // XXX:
+  // SVE saturating inc/dec register by element count
+  // XXX:
+
+  // SVE Bitwise Immediate
+  // XXX: DUPM
+  // SVE bitwise logical with immediate (unpredicated)
+
+  // SVE Integer Wide Immediate - Predicated
+  // XXX: FCPY
+  // SVE copy integer immediate (predicated)
+  // XXX:
+  // SVE Permute Vector - Unpredicated
+  void dup(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::Register rn) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    constexpr uint32_t Op = 0b0000'0101'0010'0000'0011'10 << 10;
+    SVEPermuteUnpredicated(Op, 0b00, 0b000, size, rn, zd);
+  }
+  void mov(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::Register rn) {
+    dup(size, zd, rn);
+  }
+
+  // XXX: INSR
+  // XXX: INSR SIMD
+  // XXX: REV
+
+  // SVE unpack vector elements
+  void sunpklo(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn) {
+    LOGMAN_THROW_A_FMT(size == FEXCore::ARMEmitter::SubRegSize::i16Bit || size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid subregsize size");
+    constexpr uint32_t Op = 0b0000'0101'0011'0000'0011'10 << 10;
+    SVEUnpackVectorElements(Op, 0, 0, size, zn, zd);
+  }
+  void sunpkhi(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn) {
+    LOGMAN_THROW_A_FMT(size == FEXCore::ARMEmitter::SubRegSize::i16Bit || size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid subregsize size");
+    constexpr uint32_t Op = 0b0000'0101'0011'0000'0011'10 << 10;
+    SVEUnpackVectorElements(Op, 0, 1, size, zn, zd);
+  }
+  void uunpklo(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn) {
+    LOGMAN_THROW_A_FMT(size == FEXCore::ARMEmitter::SubRegSize::i16Bit || size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid subregsize size");
+    constexpr uint32_t Op = 0b0000'0101'0011'0000'0011'10 << 10;
+    SVEUnpackVectorElements(Op, 1, 0, size, zn, zd);
+  }
+  void uunpkhi(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn) {
+    LOGMAN_THROW_A_FMT(size == FEXCore::ARMEmitter::SubRegSize::i16Bit || size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid subregsize size");
+    constexpr uint32_t Op = 0b0000'0101'0011'0000'0011'10 << 10;
+    SVEUnpackVectorElements(Op, 1, 1, size, zn, zd);
+  }
+
+  // SVE Permute Predicate
+  // XXX: REV (predicate)
+  // sve unpack predicate elements
+  // XXX:
+  // SVE permute predicate elements
+  // XXX:
+
+  // SVE Permute Vector - Predicated - Base
+  // XXX: CPY (SIMD&FP scalar)
+  void compact(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::ZRegister zn) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Invalid size");
+    constexpr uint32_t Op = 0b0000'0101'0010'0001'100 << 13;
+
+    const uint32_t ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? 0b10 :
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? 0b11 : 0b00;
+
+    uint32_t Instr = Op;
+
+    Instr |= ConvertedSize << 22;
+    Instr |= 0 << 20; // op0
+    Instr |= 0b000 << 17; // op1
+    Instr |= 0 << 16; // op2
+    Instr |= 0 << 13; // op3
+    Instr |= pg.Idx() << 10;
+    Instr |= zn.Idx() << 5;
+    Instr |= zd.Idx();
+    dc32(Instr);
+  }
+  // XXX: CPY (scalar)
+
+  template<FEXCore::ARMEmitter::OpType optype>
+  requires(optype == FEXCore::ARMEmitter::OpType::Constructive)
+  void splice(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegister pv, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zn2) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+
+    constexpr uint32_t Op = 0b0000'0101'0010'1101'100 << 13;
+
+    uint32_t Instr = Op;
+
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= FEXCore::ToUnderlying(optype) << 16;
+    Instr |= pv.Idx() << 10;
+    Instr |= zn.Idx() << 5;
+    Instr |= zd.Idx();
+    dc32(Instr);
+  }
+
+  template<FEXCore::ARMEmitter::OpType optype>
+  requires(optype == FEXCore::ARMEmitter::OpType::Destructive)
+  void splice(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegister pv, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zn) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+
+    constexpr uint32_t Op = 0b0000'0101'0010'1100'100 << 13;
+
+    uint32_t Instr = Op;
+
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= FEXCore::ToUnderlying(optype) << 16;
+    Instr |= pv.Idx() << 10;
+    Instr |= zn.Idx() << 5;
+    Instr |= zd.Idx();
+    dc32(Instr);
+  }
+
+  // SVE Permute Vector - Predicated
+  // XXX:
+  // XXX: LASTA
+  // XXX: LASTB
+  // SVE extract element to SIMD&FP scalar register
+  // XXX:
+  // SVE reverse within elements
+  void revb(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zn) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "Can't use 8-bit size");
+    SVEReverseWithinElements(0b00, size, pg, zn, zd);
+  }
+
+  void revh(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zn) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit &&
+                        size != FEXCore::ARMEmitter::SubRegSize::i8Bit &&
+                        size != FEXCore::ARMEmitter::SubRegSize::i16Bit, "Can't use 8/16/128-bit size");
+
+    SVEReverseWithinElements(0b01, size, pg, zn, zd);
+  }
+
+  void revw(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zn) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Can't use 8/16/32/128-bit size");
+    SVEReverseWithinElements(0b10, size, pg, zn, zd);
+  }
+
+  void rbit(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zn) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    SVEReverseWithinElements(0b11, size, pg, zn, zd);
+  }
+
+  // SVE conditionally broadcast element to vector
+  // XXX:
+  // SVE conditionally extract element to SIMD&FP scalar
+  // XXX:
+  // SVE reverse doublewords
+  // XXX:
+  // SVE conditionally extract element to general register
+  // XXX:
+
+  // SVE Permute Vector - Extract
+  // Constructive
+  template<FEXCore::ARMEmitter::OpType optype>
+  requires(optype == FEXCore::ARMEmitter::OpType::Constructive)
+  void ext(FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zn2, uint8_t Imm) {
+    LOGMAN_THROW_A_FMT((zn.Idx() + 1) == zn2.Idx(), "zn needs to be consecutive");
+    SVEPermuteVector(1, zd, zn, Imm);
+  }
+
+  // Destructive
+  template<FEXCore::ARMEmitter::OpType optype>
+  requires(optype == FEXCore::ARMEmitter::OpType::Destructive)
+  void ext(FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm, uint8_t Imm) {
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    SVEPermuteVector(0, zd, zm, Imm);
+  }
+
+  void SVEPermuteVector(uint32_t op0, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zm, uint32_t Imm) {
+    constexpr uint32_t Op = 0b0000'0101'0010'0000'000 << 13;
+    uint32_t Instr = Op;
+
+    Instr |= op0 << 22;
+    Instr |= (Imm >> 3) << 16;
+    Instr |= (Imm & 0b111) << 10;
+    Instr |= zm.Idx() << 5;
+    Instr |= zd.Idx();
+    dc32(Instr);
+  }
+
+  // SVE Permute Vector - Segments
+  // SVE permute vector segments
+  // XXX:
+
+  // SVE Integer Compare - Vectors
+  // SVE integer compare vectors
+  void cmpeq(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    SVEIntegerCompareVector(1, 1, 0, size, zm, pg, zn, pd);
+  }
+  void cmpge(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    SVEIntegerCompareVector(1, 0, 0, size, zm, pg, zn, pd);
+  }
+  void cmpgt(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    SVEIntegerCompareVector(1, 0, 1, size, zm, pg, zn, pd);
+  }
+  void cmphi(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    SVEIntegerCompareVector(0, 0, 1, size, zm, pg, zn, pd);
+  }
+  void cmphs(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    SVEIntegerCompareVector(0, 0, 0, size, zm, pg, zn, pd);
+  }
+  void cmpne(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    SVEIntegerCompareVector(1, 1, 1, size, zm, pg, zn, pd);
+  }
+
+  void SVEIntegerCompareVector(uint32_t op, uint32_t o2, uint32_t ne, FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zm, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::PRegister pd) {
+    constexpr uint32_t Op = 0b0010'0100'0000'0000'000 << 13;
+    uint32_t Instr = Op;
+
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= zm.Idx() << 16;
+    Instr |= op << 15;
+    Instr |= o2 << 13;
+    Instr |= pg.Idx() << 10;
+    Instr |= zn.Idx() << 5;
+    Instr |= ne << 4;
+    Instr |= pd.Idx();
+    dc32(Instr);
+  }
+  // SVE integer compare with wide elements
+  // XXX:
+
+  // SVE Propagate Break
+  // SVE propagate break from previous partition
+  // XXX:
+
+  // SVE Predicate Misc
+  // XXX:
+  // XXX: PNEXT
+  // SVE predicate test
+  void ptest(FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::PRegister pn) {
+    constexpr uint32_t Op = 0b0010'0101'0001'0000'11 << 14;
+    SVEPredicateTest(Op, 0, 1, 0b0000, pg, pn);
+  }
+
+  // SVE predicate first active
+  void pfirst(FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::PRegister pn) {
+    LOGMAN_THROW_A_FMT(pd == pn, "pd and pn need to be the same");
+    constexpr uint32_t Op = 0b0010'0101'0001'1000'1100 << 12;
+    SVEPredicateReadFFRPredicated(Op, 0, 1, pg, pd);
+  }
+
+  // SVE predicate zero
+  void pfalse(FEXCore::ARMEmitter::PRegister pd) {
+    constexpr uint32_t Op = 0b0010'0101'0001'1000'1110'01 << 10;
+    SVEPredicateReadFFR(Op, 0, 0, pd);
+  }
+
+  // SVE predicate read from FFR (predicated)
+  void rdffr(FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PRegister pg) {
+    constexpr uint32_t Op = 0b0010'0101'0001'1000'1111 << 12;
+    SVEPredicateReadFFRPredicated(Op, 0, 0, pg, pd);
+  }
+
+  void rdffrs(FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PRegister pg) {
+    constexpr uint32_t Op = 0b0010'0101'0001'1000'1111 << 12;
+    SVEPredicateReadFFRPredicated(Op, 0, 1, pg, pd);
+  }
+
+  // SVE predicate read from FFR (unpredicated)
+  void rdffr(FEXCore::ARMEmitter::PRegister pd) {
+    constexpr uint32_t Op = 0b0010'0101'0001'1001'1111 << 12;
+    SVEPredicateReadFFR(Op, 0, 0, pd);
+  }
+
+  // SVE predicate initialize
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void ptrue(FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PredicatePattern pattern) {
+    constexpr uint32_t Op = 0b0010'0101'0001'1000'1110 << 12;
+    SVEPredicateInit(Op, size, 0, pattern, pd);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void ptrues(FEXCore::ARMEmitter::PRegister pd, FEXCore::ARMEmitter::PredicatePattern pattern) {
+    constexpr uint32_t Op = 0b0010'0101'0001'1000'1110 << 12;
+    SVEPredicateInit(Op, size, 1, pattern, pd);
+  }
+
+  // SVE Integer Compare - Scalars
+  // SVE integer compare scalar count and limit
+  // XXX:
+  // SVE conditionally terminate scalars
+  // XXX:
+  // SVE pointer conflict compare
+  // XXX:
+
+  // SVE Integer Wide Immediate - Unpredicated
+  // SVE integer add/subtract immediate (unpredicated)
+  // XXX:
+  // SVE integer min/max immediate (unpredicated)
+  // XXX:
+  // SVE integer multiply immediate (unpredicated)
+  // XXX:
+  // SVE broadcast integer immediate (unpredicated)
+  void dup_imm(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, int32_t Value, bool LSL8 = false) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_AA_FMT(Value >= -128 && Value <= 127, "Immediate out of range");
+    if (size == FEXCore::ARMEmitter::SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(LSL8 == false, "Can't shift immediate with 8-bit elements");
+    }
+    SVEBroadcastImm(0b00, LSL8, Value, size, zd);
+  }
+  void mov_imm(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, int32_t Value, bool LSL8 = false) {
+    dup_imm(size, zd, Value, LSL8);
+  }
+
+  void SVEBroadcastImm(uint32_t opc, uint32_t sh, uint32_t imm, FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd) {
+    constexpr uint32_t Op = 0b0010'0101'0011'1000'110 << 13;
+    uint32_t Instr = Op;
+
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= opc << 17;
+    Instr |= sh << 13;
+    Instr |= (imm & 0xFF) << 5;
+    Instr |= zd.Idx();
+    dc32(Instr);
+  }
+
+  // SVE broadcast floating-point immediate (unpredicated)
+  void fdup(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, float Value) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i16Bit ||
+                        size == FEXCore::ARMEmitter::SubRegSize::i32Bit ||
+                        size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Unsupported fmov size");
+    uint32_t Imm;
+    if (size == SubRegSize::i16Bit) {
+      LOGMAN_THROW_A_FMT(vixl::aarch64::Assembler::IsImmFP16(vixl::Float16(Value)), "Invalid float");
+      Imm = vixl::VFP::FP16ToImm8(vixl::Float16(Value));
+    }
+    else if (size == SubRegSize::i32Bit) {
+      LOGMAN_THROW_A_FMT(vixl::VFP::IsImmFP32(Value), "Invalid float");
+      Imm = vixl::VFP::FP32ToImm8(Value);
+
+    }
+    else if (size == SubRegSize::i64Bit) {
+      LOGMAN_THROW_A_FMT(vixl::VFP::IsImmFP64(Value), "Invalid float");
+      Imm = vixl::VFP::FP64ToImm8(Value);
+    }
+    else {
+      LOGMAN_MSG_A_FMT("Invalid subregsize");
+      FEX_UNREACHABLE;
+    }
+
+    SVEBroadcastFloatImm(0b00, 0, Imm, size, zd);
+  }
+  void fmov(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, float Value) {
+    fdup(size, zd, Value);
+  }
+
+  void SVEBroadcastFloatImm(uint32_t opc, uint32_t o2, uint32_t imm, FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd) {
+    constexpr uint32_t Op = 0b0010'0101'0011'1001'110 << 13;
+    uint32_t Instr = Op;
+
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= opc << 17;
+    Instr |= o2 << 13;
+    Instr |= imm << 5;
+    Instr |= zd.Idx();
+    dc32(Instr);
+  }
+  // XXX:
+
+  // SVE Predicate Count
+  // SVE predicate count
+  // XXX:
+
+  // SVE Inc/Dec by Predicate Count
+  // SVE saturating inc/dec vector by predicate count
+  // XXX:
+  // SVE saturating inc/dec register by predicate count
+  // XXX:
+  // SVE inc/dec vector by predicate count
+  // XXX:
+  // SVE inc/dec register by predicate count
+  // XXX:
+
+  // SVE Write FFR
+  // SVE FFR write from predicate
+  // XXX:
+  // SVE FFR initialise
+  // XXX:
+
+  // SVE Integer Multiply-Add - Unpredicated
+  // XXX: CDOT
+  // SVE integer dot product (unpredicated)
+  // XXX:
+  // SVE2 saturating multiply-add interleaved long
+  // XXX:
+  // SVE2 complex integer multiply-add
+  // XXX:
+  // SVE2 integer multiply-add long
+  // XXX:
+  // SVE2 saturating multiply-add long
+  // XXX:
+  // SVE2 saturating multiply-add high
+  // XXX:
+  // SVE mixed sign dot product
+  // XXX:
+
+  // SVE2 Integer - Predicated
+  // SVE2 integer pairwise add and accumulate long
+  // XXX:
+  // SVE2 integer unary operations (predicated)
+  // XXX:
+  // SVE2 saturating/rounding bitwise shift left (predicated)
+  // XXX
+  // SVE2 integer halving add/subtract (predicated)
+  void shadd(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    constexpr uint32_t Op = 0b0100'0100'0001'0000'100 << 13;
+    SVE2IntegerHalvingPredicated(Op, 0, 0, 0, size, pg, zm, zd);
+  }
+  void uhadd(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    constexpr uint32_t Op = 0b0100'0100'0001'0000'100 << 13;
+    SVE2IntegerHalvingPredicated(Op, 0, 0, 1, size, pg, zm, zd);
+  }
+  void shsub(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    constexpr uint32_t Op = 0b0100'0100'0001'0000'100 << 13;
+    SVE2IntegerHalvingPredicated(Op, 0, 1, 0, size, pg, zm, zd);
+  }
+  void uhsub(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    constexpr uint32_t Op = 0b0100'0100'0001'0000'100 << 13;
+    SVE2IntegerHalvingPredicated(Op, 0, 1, 1, size, pg, zm, zd);
+  }
+  void srhadd(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    constexpr uint32_t Op = 0b0100'0100'0001'0000'100 << 13;
+    SVE2IntegerHalvingPredicated(Op, 1, 0, 0, size, pg, zm, zd);
+  }
+  void urhadd(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    constexpr uint32_t Op = 0b0100'0100'0001'0000'100 << 13;
+    SVE2IntegerHalvingPredicated(Op, 1, 0, 1, size, pg, zm, zd);
+  }
+  void shsubr(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    constexpr uint32_t Op = 0b0100'0100'0001'0000'100 << 13;
+    SVE2IntegerHalvingPredicated(Op, 1, 1, 0, size, pg, zm, zd);
+  }
+  void uhsubr(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    constexpr uint32_t Op = 0b0100'0100'0001'0000'100 << 13;
+    SVE2IntegerHalvingPredicated(Op, 1, 1, 1, size, pg, zm, zd);
+  }
+
+  // SVE2 integer pairwise arithmetic
+  void addp(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    constexpr uint32_t Op = 0b0100'0100'0001'0000'101 << 13;
+    SVEIntegerPairwiseArithmetic(Op, 0b00, 1, size, pg, zm, zd);
+  }
+  void smaxp(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    constexpr uint32_t Op = 0b0100'0100'0001'0000'101 << 13;
+    SVEIntegerPairwiseArithmetic(Op, 0b10, 0, size, pg, zm, zd);
+  }
+  void umaxp(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    constexpr uint32_t Op = 0b0100'0100'0001'0000'101 << 13;
+    SVEIntegerPairwiseArithmetic(Op, 0b10, 1, size, pg, zm, zd);
+  }
+  void sminp(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    constexpr uint32_t Op = 0b0100'0100'0001'0000'101 << 13;
+    SVEIntegerPairwiseArithmetic(Op, 0b11, 0, size, pg, zm, zd);
+  }
+  void uminp(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    constexpr uint32_t Op = 0b0100'0100'0001'0000'101 << 13;
+    SVEIntegerPairwiseArithmetic(Op, 0b11, 1, size, pg, zm, zd);
+  }
+
+  // SVE2 saturating add/subtract
+  // XXX:
+  //
+  // SVE2 Widening Integer Arithmetic
+  // SVE2 integer add/subtract long
+  void saddlb(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit && size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "Can't use 8/128-bit size");
+    SVE2IntegerAddSubLong(0, 0, 0, 0, size, zd, zn, zm);
+  }
+
+  void saddlt(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit && size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "Can't use 8/128-bit size");
+    SVE2IntegerAddSubLong(0, 0, 0, 1, size, zd, zn, zm);
+  }
+
+  void uaddlb(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit && size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "Can't use 8/128-bit size");
+    SVE2IntegerAddSubLong(0, 0, 1, 0, size, zd, zn, zm);
+  }
+
+  void uaddlt(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit && size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "Can't use 8/128-bit size");
+    SVE2IntegerAddSubLong(0, 0, 1, 1, size, zd, zn, zm);
+  }
+
+  void ssublb(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit && size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "Can't use 8/128-bit size");
+    SVE2IntegerAddSubLong(0, 1, 0, 0, size, zd, zn, zm);
+  }
+
+  void ssublt(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit && size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "Can't use 8/128-bit size");
+    SVE2IntegerAddSubLong(0, 1, 0, 1, size, zd, zn, zm);
+  }
+
+  void usublb(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit && size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "Can't use 8/128-bit size");
+    SVE2IntegerAddSubLong(0, 1, 1, 0, size, zd, zn, zm);
+  }
+
+  void usublt(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit && size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "Can't use 8/128-bit size");
+    SVE2IntegerAddSubLong(0, 1, 1, 1, size, zd, zn, zm);
+  }
+
+  void sabdlb(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit && size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "Can't use 8/128-bit size");
+    SVE2IntegerAddSubLong(1, 1, 0, 0, size, zd, zn, zm);
+  }
+
+  void sabdlt(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit && size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "Can't use 8/128-bit size");
+    SVE2IntegerAddSubLong(1, 1, 0, 1, size, zd, zn, zm);
+  }
+
+  void uabdlb(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit && size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "Can't use 8/128-bit size");
+    SVE2IntegerAddSubLong(1, 1, 1, 0, size, zd, zn, zm);
+  }
+
+  void uabdlt(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit && size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "Can't use 8/128-bit size");
+    SVE2IntegerAddSubLong(1, 1, 1, 1, size, zd, zn, zm);
+  }
+
+  void SVE2IntegerAddSubLong(uint32_t op, uint32_t S, uint32_t U, uint32_t T, FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    constexpr uint32_t Op = 0b0100'0101'0000'0000'00 << 14;
+    uint32_t Instr = Op;
+
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= zm.Idx() << 16;
+    Instr |= op << 13;
+    Instr |= S << 12;
+    Instr |= U << 11;
+    Instr |= T << 10;
+    Instr |= zn.Idx() << 5;
+    Instr |= zd.Idx();
+    dc32(Instr);
+  }
+  // SVE2 integer add/subtract wide
+  // XXX:
+  // SVE2 integer multiply long
+  void sqdmullb(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit && size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "Can't use 8/128-bit size");
+    SVE2IntegerMultiplyLong(0, 0, 0, size, zd, zn, zm);
+  }
+  void sqdmullt(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit && size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "Can't use 8/128-bit size");
+    SVE2IntegerMultiplyLong(0, 0, 1, size, zd, zn, zm);
+  }
+  void pmullb(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit && size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "Can't use 8/128-bit size");
+    SVE2IntegerMultiplyLong(0, 1, 0, size, zd, zn, zm);
+  }
+  void pmullt(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit && size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "Can't use 8/128-bit size");
+    SVE2IntegerMultiplyLong(0, 1, 1, size, zd, zn, zm);
+  }
+  void smullb(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit && size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "Can't use 8/128-bit size");
+    SVE2IntegerMultiplyLong(1, 0, 0, size, zd, zn, zm);
+  }
+  void smullt(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit && size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "Can't use 8/128-bit size");
+    SVE2IntegerMultiplyLong(1, 0, 1, size, zd, zn, zm);
+  }
+  void umullb(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit && size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "Can't use 8/128-bit size");
+    SVE2IntegerMultiplyLong(1, 1, 0, size, zd, zn, zm);
+  }
+  void umullt(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit && size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "Can't use 8/128-bit size");
+    SVE2IntegerMultiplyLong(1, 1, 1, size, zd, zn, zm);
+  }
+
+  void SVE2IntegerMultiplyLong(uint32_t op, uint32_t U, uint32_t T, FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {
+    constexpr uint32_t Op = 0b0100'0101'0000'0000'011 << 13;
+    uint32_t Instr = Op;
+
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= zm.Idx() << 16;
+    Instr |= op << 12;
+    Instr |= U << 11;
+    Instr |= T << 10;
+    Instr |= zn.Idx() << 5;
+    Instr |= zd.Idx();
+    dc32(Instr);
+  }
+  //
+  // SVE Misc
+  // SVE2 bitwise shift left long
+  // XXX:
+  // SVE2 integer add/subtract interleaved long
+  // XXX:
+  // SVE2 bitwise exclusive-or interleaved
+  // XXX:
+  // SVE integer matrix multiply accumulate
+  // XXX:
+  // SVE2 bitwise permute
+  // XXX:
+  //
+  // SVE2 Accumulate
+  // SVE2 complex integer add
+  // XXX:
+  // SVE2 integer absolute difference and accumulate long
+  // XXX:
+  // SVE2 integer add/subtract long with carry
+  // XXX:
+  // SVE2 bitwise shift right and accumulate
+  // XXX:
+  // SVE2 bitwise shift and insert
+  // XXX:
+  // SVE2 integer absolute difference and accumulate
+  // XXX:
+  //
+  // SVE2 Narrowing
+  // SVE2 saturating extract narrow
+  void sqxtnb(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit && size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Can't use 64/128-bit size");
+    uint32_t tszh, tszl;
+
+    if (size == FEXCore::ARMEmitter::SubRegSize::i8Bit) {
+      tszh = 0;
+      tszl = 0b01;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      tszh = 0;
+      tszl = 0b10;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      tszh = 1;
+      tszl = 0b00;
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+
+    SVE2SaturatingExtractNarrow(tszh, tszl, 0b00, 0, zn, zd);
+  }
+  void sqxtnt(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit && size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Can't use 64/128-bit size");
+    uint32_t tszh, tszl;
+
+    if (size == FEXCore::ARMEmitter::SubRegSize::i8Bit) {
+      tszh = 0;
+      tszl = 0b01;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      tszh = 0;
+      tszl = 0b10;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      tszh = 1;
+      tszl = 0b00;
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+
+    SVE2SaturatingExtractNarrow(tszh, tszl, 0b00, 1, zn, zd);
+  }
+  void uqxtnb(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit && size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Can't use 64/128-bit size");
+    uint32_t tszh, tszl;
+
+    if (size == FEXCore::ARMEmitter::SubRegSize::i8Bit) {
+      tszh = 0;
+      tszl = 0b01;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      tszh = 0;
+      tszl = 0b10;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      tszh = 1;
+      tszl = 0b00;
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+
+    SVE2SaturatingExtractNarrow(tszh, tszl, 0b01, 0, zn, zd);
+  }
+  void uqxtnt(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit && size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Can't use 64/128-bit size");
+    uint32_t tszh, tszl;
+
+    if (size == FEXCore::ARMEmitter::SubRegSize::i8Bit) {
+      tszh = 0;
+      tszl = 0b01;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      tszh = 0;
+      tszl = 0b10;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      tszh = 1;
+      tszl = 0b00;
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+
+    SVE2SaturatingExtractNarrow(tszh, tszl, 0b01, 1, zn, zd);
+  }
+  void sqxtunb(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit && size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Can't use 64/128-bit size");
+    uint32_t tszh, tszl;
+
+    if (size == FEXCore::ARMEmitter::SubRegSize::i8Bit) {
+      tszh = 0;
+      tszl = 0b01;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      tszh = 0;
+      tszl = 0b10;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      tszh = 1;
+      tszl = 0b00;
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+
+    SVE2SaturatingExtractNarrow(tszh, tszl, 0b10, 0, zn, zd);
+  }
+  void sqxtunt(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit && size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Can't use 64/128-bit size");
+    uint32_t tszh, tszl;
+
+    if (size == FEXCore::ARMEmitter::SubRegSize::i8Bit) {
+      tszh = 0;
+      tszl = 0b01;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      tszh = 0;
+      tszl = 0b10;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      tszh = 1;
+      tszl = 0b00;
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+
+    SVE2SaturatingExtractNarrow(tszh, tszl, 0b10, 1, zn, zd);
+  }
+
+  void SVE2SaturatingExtractNarrow(uint32_t tszh, uint32_t tszl, uint32_t opc, uint32_t T, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zd) {
+    constexpr uint32_t Op = 0b0100'0101'0010'0000'010 << 13;
+    uint32_t Instr = Op;
+
+    Instr |= tszh << 22;
+    Instr |= tszl << 19;
+    Instr |= opc << 11;
+    Instr |= T << 10;
+    Instr |= zn.Idx() << 5;
+    Instr |= zd.Idx();
+    dc32(Instr);
+  }
+
+  // SVE2 bitwise shift right narrow
+  void sqshrunb(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit && size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Can't use 8/128-bit size");
+
+    uint32_t tszh, tszl;
+    uint32_t imm3;
+    const uint32_t InverseShift = (2 * SubRegSizeInBits(size)) - Shift;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 8, "Incorrect shift");
+      tszh = 0;
+      tszl = 0b01;
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 16, "Incorrect shift");
+      tszh = 0;
+      tszl = 0b10 | ((InverseShift >> 3) & 0b1);
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 32, "Incorrect shift");
+      tszh = 1;
+      tszl = (InverseShift >> 3) & 0b11;
+      imm3 = InverseShift & 0b111;
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+
+    SVE2BitwiseShiftRightNarrow(tszh, tszl, imm3, 0, 0, 0, 0, zn, zd);
+  }
+  void sqshrunt(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit && size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Can't use 8/128-bit size");
+
+    uint32_t tszh, tszl;
+    uint32_t imm3;
+    const uint32_t InverseShift = (2 * SubRegSizeInBits(size)) - Shift;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 8, "Incorrect shift");
+      tszh = 0;
+      tszl = 0b01;
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 16, "Incorrect shift");
+      tszh = 0;
+      tszl = 0b10 | ((InverseShift >> 3) & 0b1);
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 32, "Incorrect shift");
+      tszh = 1;
+      tszl = (InverseShift >> 3) & 0b11;
+      imm3 = InverseShift & 0b111;
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+
+    SVE2BitwiseShiftRightNarrow(tszh, tszl, imm3, 0, 0, 0, 1, zn, zd);
+  }
+  void sqrshrunb(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit && size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Can't use 8/128-bit size");
+
+    uint32_t tszh, tszl;
+    uint32_t imm3;
+    const uint32_t InverseShift = (2 * SubRegSizeInBits(size)) - Shift;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 8, "Incorrect shift");
+      tszh = 0;
+      tszl = 0b01;
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 16, "Incorrect shift");
+      tszh = 0;
+      tszl = 0b10 | ((InverseShift >> 3) & 0b1);
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 32, "Incorrect shift");
+      tszh = 1;
+      tszl = (InverseShift >> 3) & 0b11;
+      imm3 = InverseShift & 0b111;
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+
+    SVE2BitwiseShiftRightNarrow(tszh, tszl, imm3, 0, 0, 1, 0, zn, zd);
+  }
+  void sqrshrunt(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit && size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Can't use 8/128-bit size");
+
+    uint32_t tszh, tszl;
+    uint32_t imm3;
+    const uint32_t InverseShift = (2 * SubRegSizeInBits(size)) - Shift;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 8, "Incorrect shift");
+      tszh = 0;
+      tszl = 0b01;
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 16, "Incorrect shift");
+      tszh = 0;
+      tszl = 0b10 | ((InverseShift >> 3) & 0b1);
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 32, "Incorrect shift");
+      tszh = 1;
+      tszl = (InverseShift >> 3) & 0b11;
+      imm3 = InverseShift & 0b111;
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+
+    SVE2BitwiseShiftRightNarrow(tszh, tszl, imm3, 0, 0, 1, 1, zn, zd);
+  }
+  void shrnb(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit && size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Can't use 8/128-bit size");
+
+    uint32_t tszh, tszl;
+    uint32_t imm3;
+    const uint32_t InverseShift = (2 * SubRegSizeInBits(size)) - Shift;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 8, "Incorrect shift");
+      tszh = 0;
+      tszl = 0b01;
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 16, "Incorrect shift");
+      tszh = 0;
+      tszl = 0b10 | ((InverseShift >> 3) & 0b1);
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 32, "Incorrect shift");
+      tszh = 1;
+      tszl = (InverseShift >> 3) & 0b11;
+      imm3 = InverseShift & 0b111;
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+
+    SVE2BitwiseShiftRightNarrow(tszh, tszl, imm3, 0, 1, 0, 0, zn, zd);
+  }
+  void shrnt(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit && size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Can't use 8/128-bit size");
+
+    uint32_t tszh, tszl;
+    uint32_t imm3;
+    const uint32_t InverseShift = (2 * SubRegSizeInBits(size)) - Shift;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 8, "Incorrect shift");
+      tszh = 0;
+      tszl = 0b01;
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 16, "Incorrect shift");
+      tszh = 0;
+      tszl = 0b10 | ((InverseShift >> 3) & 0b1);
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 32, "Incorrect shift");
+      tszh = 1;
+      tszl = (InverseShift >> 3) & 0b11;
+      imm3 = InverseShift & 0b111;
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+
+    SVE2BitwiseShiftRightNarrow(tszh, tszl, imm3, 0, 1, 0, 1, zn, zd);
+  }
+  void rshrnb(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit && size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Can't use 8/128-bit size");
+
+    uint32_t tszh, tszl;
+    uint32_t imm3;
+    const uint32_t InverseShift = (2 * SubRegSizeInBits(size)) - Shift;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 8, "Incorrect shift");
+      tszh = 0;
+      tszl = 0b01;
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 16, "Incorrect shift");
+      tszh = 0;
+      tszl = 0b10 | ((InverseShift >> 3) & 0b1);
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 32, "Incorrect shift");
+      tszh = 1;
+      tszl = (InverseShift >> 3) & 0b11;
+      imm3 = InverseShift & 0b111;
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+
+    SVE2BitwiseShiftRightNarrow(tszh, tszl, imm3, 0, 1, 1, 0, zn, zd);
+  }
+  void rshrnt(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit && size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Can't use 8/128-bit size");
+
+    uint32_t tszh, tszl;
+    uint32_t imm3;
+    const uint32_t InverseShift = (2 * SubRegSizeInBits(size)) - Shift;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 8, "Incorrect shift");
+      tszh = 0;
+      tszl = 0b01;
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 16, "Incorrect shift");
+      tszh = 0;
+      tszl = 0b10 | ((InverseShift >> 3) & 0b1);
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 32, "Incorrect shift");
+      tszh = 1;
+      tszl = (InverseShift >> 3) & 0b11;
+      imm3 = InverseShift & 0b111;
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+
+    SVE2BitwiseShiftRightNarrow(tszh, tszl, imm3, 0, 1, 1, 1, zn, zd);
+  }
+  void sqshrnb(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit && size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Can't use 8/128-bit size");
+
+    uint32_t tszh, tszl;
+    uint32_t imm3;
+    const uint32_t InverseShift = (2 * SubRegSizeInBits(size)) - Shift;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 8, "Incorrect shift");
+      tszh = 0;
+      tszl = 0b01;
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 16, "Incorrect shift");
+      tszh = 0;
+      tszl = 0b10 | ((InverseShift >> 3) & 0b1);
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 32, "Incorrect shift");
+      tszh = 1;
+      tszl = (InverseShift >> 3) & 0b11;
+      imm3 = InverseShift & 0b111;
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+
+    SVE2BitwiseShiftRightNarrow(tszh, tszl, imm3, 1, 0, 0, 0, zn, zd);
+  }
+  void sqshrnt(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit && size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Can't use 8/128-bit size");
+
+    uint32_t tszh, tszl;
+    uint32_t imm3;
+    const uint32_t InverseShift = (2 * SubRegSizeInBits(size)) - Shift;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 8, "Incorrect shift");
+      tszh = 0;
+      tszl = 0b01;
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 16, "Incorrect shift");
+      tszh = 0;
+      tszl = 0b10 | ((InverseShift >> 3) & 0b1);
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 32, "Incorrect shift");
+      tszh = 1;
+      tszl = (InverseShift >> 3) & 0b11;
+      imm3 = InverseShift & 0b111;
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+
+    SVE2BitwiseShiftRightNarrow(tszh, tszl, imm3, 1, 0, 0, 1, zn, zd);
+  }
+  void sqrshrnb(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit && size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Can't use 8/128-bit size");
+
+    uint32_t tszh, tszl;
+    uint32_t imm3;
+    const uint32_t InverseShift = (2 * SubRegSizeInBits(size)) - Shift;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 8, "Incorrect shift");
+      tszh = 0;
+      tszl = 0b01;
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 16, "Incorrect shift");
+      tszh = 0;
+      tszl = 0b10 | ((InverseShift >> 3) & 0b1);
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 32, "Incorrect shift");
+      tszh = 1;
+      tszl = (InverseShift >> 3) & 0b11;
+      imm3 = InverseShift & 0b111;
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+
+    SVE2BitwiseShiftRightNarrow(tszh, tszl, imm3, 1, 0, 1, 0, zn, zd);
+  }
+  void sqrshrnt(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit && size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Can't use 8/128-bit size");
+
+    uint32_t tszh, tszl;
+    uint32_t imm3;
+    const uint32_t InverseShift = (2 * SubRegSizeInBits(size)) - Shift;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 8, "Incorrect shift");
+      tszh = 0;
+      tszl = 0b01;
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 16, "Incorrect shift");
+      tszh = 0;
+      tszl = 0b10 | ((InverseShift >> 3) & 0b1);
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 32, "Incorrect shift");
+      tszh = 1;
+      tszl = (InverseShift >> 3) & 0b11;
+      imm3 = InverseShift & 0b111;
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+
+    SVE2BitwiseShiftRightNarrow(tszh, tszl, imm3, 1, 0, 1, 1, zn, zd);
+  }
+  void uqshrnb(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit && size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Can't use 8/128-bit size");
+
+    uint32_t tszh, tszl;
+    uint32_t imm3;
+    const uint32_t InverseShift = (2 * SubRegSizeInBits(size)) - Shift;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 8, "Incorrect shift");
+      tszh = 0;
+      tszl = 0b01;
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 16, "Incorrect shift");
+      tszh = 0;
+      tszl = 0b10 | ((InverseShift >> 3) & 0b1);
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 32, "Incorrect shift");
+      tszh = 1;
+      tszl = (InverseShift >> 3) & 0b11;
+      imm3 = InverseShift & 0b111;
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+
+    SVE2BitwiseShiftRightNarrow(tszh, tszl, imm3, 1, 1, 0, 0, zn, zd);
+  }
+  void uqshrnt(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit && size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Can't use 8/128-bit size");
+
+    uint32_t tszh, tszl;
+    uint32_t imm3;
+    const uint32_t InverseShift = (2 * SubRegSizeInBits(size)) - Shift;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 8, "Incorrect shift");
+      tszh = 0;
+      tszl = 0b01;
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 16, "Incorrect shift");
+      tszh = 0;
+      tszl = 0b10 | ((InverseShift >> 3) & 0b1);
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 32, "Incorrect shift");
+      tszh = 1;
+      tszl = (InverseShift >> 3) & 0b11;
+      imm3 = InverseShift & 0b111;
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+
+    SVE2BitwiseShiftRightNarrow(tszh, tszl, imm3, 1, 1, 0, 1, zn, zd);
+  }
+  void uqrshrnb(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit && size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Can't use 8/128-bit size");
+
+    uint32_t tszh, tszl;
+    uint32_t imm3;
+    const uint32_t InverseShift = (2 * SubRegSizeInBits(size)) - Shift;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 8, "Incorrect shift");
+      tszh = 0;
+      tszl = 0b01;
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 16, "Incorrect shift");
+      tszh = 0;
+      tszl = 0b10 | ((InverseShift >> 3) & 0b1);
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 32, "Incorrect shift");
+      tszh = 1;
+      tszl = (InverseShift >> 3) & 0b11;
+      imm3 = InverseShift & 0b111;
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+
+    SVE2BitwiseShiftRightNarrow(tszh, tszl, imm3, 1, 1, 1, 0, zn, zd);
+  }
+  void uqrshrnt(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit && size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Can't use 8/128-bit size");
+
+    uint32_t tszh, tszl;
+    uint32_t imm3;
+    const uint32_t InverseShift = (2 * SubRegSizeInBits(size)) - Shift;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 8, "Incorrect shift");
+      tszh = 0;
+      tszl = 0b01;
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 16, "Incorrect shift");
+      tszh = 0;
+      tszl = 0b10 | ((InverseShift >> 3) & 0b1);
+      imm3 = InverseShift & 0b111;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Shift > 0 && Shift <= 32, "Incorrect shift");
+      tszh = 1;
+      tszl = (InverseShift >> 3) & 0b11;
+      imm3 = InverseShift & 0b111;
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+
+    SVE2BitwiseShiftRightNarrow(tszh, tszl, imm3, 1, 1, 1, 1, zn, zd);
+  }
+
+  void SVE2BitwiseShiftRightNarrow(uint32_t tszh, uint32_t tszl, uint32_t imm3, uint32_t op, uint32_t U, uint32_t R, uint32_t T, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zd) {
+    constexpr uint32_t Op = 0b0100'0101'0010'0000'00 << 14;
+    uint32_t Instr = Op;
+
+    Instr |= tszh << 22;
+    Instr |= tszl << 19;
+    Instr |= imm3 << 16;
+    Instr |= op << 13;
+    Instr |= U << 12;
+    Instr |= R << 11;
+    Instr |= T << 10;
+    Instr |= zn.Idx() << 5;
+    Instr |= zd.Idx();
+    dc32(Instr);
+  }
+  // SVE2 integer add/subtract narrow high part
+  // XXX:
+  //
+  // SVE2 Histogram Computation - Segment
+  // XXX:
+  //
+  // SVE2 Crypto Extensions
+  // SVE2 crypto unary operations
+  // XXX:
+  // SVE2 crypto destructive binary operations
+  // XXX:
+  // SVE2 crypto constructive binary operations
+  // XXX:
+  //
+  // SVE Floating Point Widening Multiply-Add - Indexed
+  // SVE BFloat16 floating-point dot product (indexed)
+  // XXX:
+  // SVE floating-point multiply-add long (indexed)
+  // XXX:
+  //
+  // SVE Floating Point Widening Multiply-Add
+  // SVE BFloat16 floating-point dot product
+  // XXX:
+  // SVE floating-point multiply-add long
+  // XXX:
+  //
+  // SVE Floating Point Arithmetic - Predicated
+  // XXX: FTMAD
+  // SVE floating-point arithmetic (predicated)
+  void fadd(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    LOGMAN_THROW_A_FMT(size == FEXCore::ARMEmitter::SubRegSize::i16Bit || size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid float size");
+    constexpr uint32_t Op = 0b0110'0101'0000'0000'100 << 13;
+    SVEFloatArithmeticPredicated(Op, 0b0000, size, pg, zm, zd);
+  }
+  void fsub(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    LOGMAN_THROW_A_FMT(size == FEXCore::ARMEmitter::SubRegSize::i16Bit || size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid float size");
+    constexpr uint32_t Op = 0b0110'0101'0000'0000'100 << 13;
+    SVEFloatArithmeticPredicated(Op, 0b0001, size, pg, zm, zd);
+  }
+  void fmul(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    LOGMAN_THROW_A_FMT(size == FEXCore::ARMEmitter::SubRegSize::i16Bit || size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid float size");
+    constexpr uint32_t Op = 0b0110'0101'0000'0000'100 << 13;
+    SVEFloatArithmeticPredicated(Op, 0b0010, size, pg, zm, zd);
+  }
+  void fsubr(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    LOGMAN_THROW_A_FMT(size == FEXCore::ARMEmitter::SubRegSize::i16Bit || size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid float size");
+    constexpr uint32_t Op = 0b0110'0101'0000'0000'100 << 13;
+    SVEFloatArithmeticPredicated(Op, 0b0011, size, pg, zm, zd);
+  }
+  void fmaxnm(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    LOGMAN_THROW_A_FMT(size == FEXCore::ARMEmitter::SubRegSize::i16Bit || size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid float size");
+    constexpr uint32_t Op = 0b0110'0101'0000'0000'100 << 13;
+    SVEFloatArithmeticPredicated(Op, 0b0100, size, pg, zm, zd);
+  }
+  void fminnm(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    LOGMAN_THROW_A_FMT(size == FEXCore::ARMEmitter::SubRegSize::i16Bit || size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid float size");
+    constexpr uint32_t Op = 0b0110'0101'0000'0000'100 << 13;
+    SVEFloatArithmeticPredicated(Op, 0b0101, size, pg, zm, zd);
+  }
+  void fmax(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    LOGMAN_THROW_A_FMT(size == FEXCore::ARMEmitter::SubRegSize::i16Bit || size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid float size");
+    constexpr uint32_t Op = 0b0110'0101'0000'0000'100 << 13;
+    SVEFloatArithmeticPredicated(Op, 0b0110, size, pg, zm, zd);
+  }
+  void fmin(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    LOGMAN_THROW_A_FMT(size == FEXCore::ARMEmitter::SubRegSize::i16Bit || size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid float size");
+    constexpr uint32_t Op = 0b0110'0101'0000'0000'100 << 13;
+    SVEFloatArithmeticPredicated(Op, 0b0111, size, pg, zm, zd);
+  }
+  void fabd(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    LOGMAN_THROW_A_FMT(size == FEXCore::ARMEmitter::SubRegSize::i16Bit || size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid float size");
+    constexpr uint32_t Op = 0b0110'0101'0000'0000'100 << 13;
+    SVEFloatArithmeticPredicated(Op, 0b1000, size, pg, zm, zd);
+  }
+  void fscale(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    LOGMAN_THROW_A_FMT(size == FEXCore::ARMEmitter::SubRegSize::i16Bit || size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid float size");
+    constexpr uint32_t Op = 0b0110'0101'0000'0000'100 << 13;
+    SVEFloatArithmeticPredicated(Op, 0b1001, size, pg, zm, zd);
+  }
+  void fmulx(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    LOGMAN_THROW_A_FMT(size == FEXCore::ARMEmitter::SubRegSize::i16Bit || size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid float size");
+    constexpr uint32_t Op = 0b0110'0101'0000'0000'100 << 13;
+    SVEFloatArithmeticPredicated(Op, 0b1010, size, pg, zm, zd);
+  }
+  void fdivr(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    LOGMAN_THROW_A_FMT(size == FEXCore::ARMEmitter::SubRegSize::i16Bit || size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid float size");
+    constexpr uint32_t Op = 0b0110'0101'0000'0000'100 << 13;
+    SVEFloatArithmeticPredicated(Op, 0b1100, size, pg, zm, zd);
+  }
+  void fdiv(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm) {
+    LOGMAN_THROW_A_FMT(zd.Idx() == zdn.Idx(), "Dest needs to equal zdn");
+    LOGMAN_THROW_A_FMT(size == FEXCore::ARMEmitter::SubRegSize::i16Bit || size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid float size");
+    constexpr uint32_t Op = 0b0110'0101'0000'0000'100 << 13;
+    SVEFloatArithmeticPredicated(Op, 0b1101, size, pg, zm, zd);
+  }
+  // SVE floating-point arithmetic with immediate (predicated)
+  // XXX:
+
+  // SVE Floating Point Unary Operations - Predicated
+  // SVE floating-point round to integral value
+  void frinti(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zn) {
+    frintX(0b111, size, zd, pg, zn);
+  }
+  void frintx(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zn) {
+    frintX(0b110, size, zd, pg, zn);
+  }
+  void frinta(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zn) {
+    frintX(0b100, size, zd, pg, zn);
+  }
+  void frintn(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zn) {
+    frintX(0b000, size, zd, pg, zn);
+  }
+  void frintz(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zn) {
+    frintX(0b011, size, zd, pg, zn);
+  }
+  void frintm(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zn) {
+    frintX(0b010, size, zd, pg, zn);
+  }
+  void frintp(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zn) {
+    frintX(0b001, size, zd, pg, zn);
+  }
+
+  // SVE floating-point convert precision
+  // XXX:
+  // SVE floating-point unary operations
+  void frecpx(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zn) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ||
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit, "Unsupported size in {}", __func__);
+    SVEFloatUnary(0b00, size, pg, zn, zd);
+  }
+
+  void fsqrt(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zn) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ||
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit, "Unsupported size in {}", __func__);
+    SVEFloatUnary(0b01, size, pg, zn, zd);
+  }
+
+  void SVEFloatUnary(uint32_t opc, FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zd) {
+    constexpr uint32_t Op = 0b0110'0101'0000'1100'101 << 13;
+    uint32_t Instr = Op;
+
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= opc << 16;
+    Instr |= pg.Idx() << 10;
+    Instr |= zn.Idx() << 5;
+    Instr |= zd.Idx();
+    dc32(Instr);
+  }
+
+  // SVE integer convert to floating-point
+  // XXX:
+  // SVE floating-point convert to integer
+  void flogb(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zn) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ||
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit, "Unsupported size in {}", __func__);
+
+    constexpr uint32_t Op = 0b0110'0101'0001'1000'101 << 13;
+    const auto ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? 0b11 :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? 0b10 :
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? 0b01 : 0b00;
+
+    SVEFloatConvertToInt(Op, 0b00, ConvertedSize, 0, pg, zn, zd);
+  }
+
+  void scvtf(FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::SubRegSize dstsize, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::SubRegSize srcsize) {
+    LOGMAN_THROW_AA_FMT(dstsize == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+      dstsize == FEXCore::ARMEmitter::SubRegSize::i32Bit ||
+      dstsize == FEXCore::ARMEmitter::SubRegSize::i16Bit, "Unsupported size in {}", __func__);
+
+    LOGMAN_THROW_AA_FMT(srcsize == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+      srcsize == FEXCore::ARMEmitter::SubRegSize::i32Bit ||
+      srcsize == FEXCore::ARMEmitter::SubRegSize::i16Bit, "Unsupported size in {}", __func__);
+
+    constexpr uint32_t Op = 0b0110'0101'0001'0000'101 << 13;
+    uint32_t opc1, opc2;
+    if (srcsize == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      // Srcsize = fp16, opc2 encodes dst size
+      LOGMAN_THROW_AA_FMT(dstsize == FEXCore::ARMEmitter::SubRegSize::i16Bit, "Unsupported size in {}", __func__);
+      opc1 = 0b01;
+      opc2 = 0b01;
+    }
+    else if (srcsize == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      // Srcsize = fp32, opc1 encodes dst size
+      opc1 =
+        dstsize == FEXCore::ARMEmitter::SubRegSize::i64Bit ? 0b11 :
+        dstsize == FEXCore::ARMEmitter::SubRegSize::i32Bit ? 0b10 :
+        dstsize == FEXCore::ARMEmitter::SubRegSize::i16Bit ? 0b01 :0b00;
+
+      opc2 =
+        dstsize == FEXCore::ARMEmitter::SubRegSize::i64Bit ? 0b00 :
+        dstsize == FEXCore::ARMEmitter::SubRegSize::i32Bit ? 0b10 :
+        dstsize == FEXCore::ARMEmitter::SubRegSize::i16Bit ? 0b10 :0b00;
+    }
+    else if (srcsize == FEXCore::ARMEmitter::SubRegSize::i64Bit) {
+      // SrcSize = fp64, opc2 encodes dst size
+      opc1 =
+        dstsize == FEXCore::ARMEmitter::SubRegSize::i64Bit ? 0b11 :
+        dstsize == FEXCore::ARMEmitter::SubRegSize::i32Bit ? 0b11 :
+        dstsize == FEXCore::ARMEmitter::SubRegSize::i16Bit ? 0b01 :0b00;
+      opc2 =
+        dstsize == FEXCore::ARMEmitter::SubRegSize::i64Bit ? 0b11 :
+        dstsize == FEXCore::ARMEmitter::SubRegSize::i32Bit ? 0b10 :
+        dstsize == FEXCore::ARMEmitter::SubRegSize::i16Bit ? 0b11 :0b00;
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+    SVEFloatConvertToInt(Op, opc1, opc2, 0, pg, zn, zd);
+  }
+  void ucvtf(FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::SubRegSize dstsize, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::SubRegSize srcsize) {
+    LOGMAN_THROW_AA_FMT(dstsize == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+      dstsize == FEXCore::ARMEmitter::SubRegSize::i32Bit ||
+      dstsize == FEXCore::ARMEmitter::SubRegSize::i16Bit, "Unsupported size in {}", __func__);
+
+    LOGMAN_THROW_AA_FMT(srcsize == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+      srcsize == FEXCore::ARMEmitter::SubRegSize::i32Bit ||
+      srcsize == FEXCore::ARMEmitter::SubRegSize::i16Bit, "Unsupported size in {}", __func__);
+
+    constexpr uint32_t Op = 0b0110'0101'0001'0000'101 << 13;
+    uint32_t opc1, opc2;
+    if (srcsize == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      // Srcsize = fp16, opc2 encodes dst size
+      LOGMAN_THROW_AA_FMT(dstsize == FEXCore::ARMEmitter::SubRegSize::i16Bit, "Unsupported size in {}", __func__);
+      opc1 = 0b01;
+      opc2 = 0b01;
+    }
+    else if (srcsize == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      // Srcsize = fp32, opc1 encodes dst size
+      opc1 =
+        dstsize == FEXCore::ARMEmitter::SubRegSize::i64Bit ? 0b11 :
+        dstsize == FEXCore::ARMEmitter::SubRegSize::i32Bit ? 0b10 :
+        dstsize == FEXCore::ARMEmitter::SubRegSize::i16Bit ? 0b01 :0b00;
+
+      opc2 =
+        dstsize == FEXCore::ARMEmitter::SubRegSize::i64Bit ? 0b00 :
+        dstsize == FEXCore::ARMEmitter::SubRegSize::i32Bit ? 0b10 :
+        dstsize == FEXCore::ARMEmitter::SubRegSize::i16Bit ? 0b10 :0b00;
+    }
+    else if (srcsize == FEXCore::ARMEmitter::SubRegSize::i64Bit) {
+      // SrcSize = fp64, opc2 encodes dst size
+      opc1 =
+        dstsize == FEXCore::ARMEmitter::SubRegSize::i64Bit ? 0b11 :
+        dstsize == FEXCore::ARMEmitter::SubRegSize::i32Bit ? 0b11 :
+        dstsize == FEXCore::ARMEmitter::SubRegSize::i16Bit ? 0b01 :0b00;
+      opc2 =
+        dstsize == FEXCore::ARMEmitter::SubRegSize::i64Bit ? 0b11 :
+        dstsize == FEXCore::ARMEmitter::SubRegSize::i32Bit ? 0b10 :
+        dstsize == FEXCore::ARMEmitter::SubRegSize::i16Bit ? 0b11 :0b00;
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+    SVEFloatConvertToInt(Op, opc1, opc2, 1, pg, zn, zd);
+  }
+  void fcvtzs(FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::SubRegSize dstsize, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::SubRegSize srcsize) {
+    LOGMAN_THROW_AA_FMT(dstsize == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+      dstsize == FEXCore::ARMEmitter::SubRegSize::i32Bit ||
+      dstsize == FEXCore::ARMEmitter::SubRegSize::i16Bit, "Unsupported size in {}", __func__);
+
+    LOGMAN_THROW_AA_FMT(srcsize == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+      srcsize == FEXCore::ARMEmitter::SubRegSize::i32Bit ||
+      srcsize == FEXCore::ARMEmitter::SubRegSize::i16Bit, "Unsupported size in {}", __func__);
+
+    constexpr uint32_t Op = 0b0110'0101'0001'1000'101 << 13;
+    uint32_t opc1, opc2;
+    if (srcsize == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      // Srcsize = fp16, opc2 encodes dst size
+      opc1 = 0b01;
+      opc2 =
+        dstsize == FEXCore::ARMEmitter::SubRegSize::i64Bit ? 0b11 :
+        dstsize == FEXCore::ARMEmitter::SubRegSize::i32Bit ? 0b10 :
+        dstsize == FEXCore::ARMEmitter::SubRegSize::i16Bit ? 0b01 : 0b00;
+    }
+    else if (srcsize == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      // Srcsize = fp32, opc1 encodes dst size
+      LOGMAN_THROW_AA_FMT(dstsize != FEXCore::ARMEmitter::SubRegSize::i16Bit, "Unsupported size in {}", __func__);
+      opc2 = 0b10;
+      opc1 = dstsize == FEXCore::ARMEmitter::SubRegSize::i64Bit ? 0b11 :
+        dstsize == FEXCore::ARMEmitter::SubRegSize::i32Bit ? 0b10 : 0b00;
+    }
+    else if (srcsize == FEXCore::ARMEmitter::SubRegSize::i64Bit) {
+      LOGMAN_THROW_AA_FMT(dstsize != FEXCore::ARMEmitter::SubRegSize::i16Bit, "Unsupported size in {}", __func__);
+      // SrcSize = fp64, opc2 encodes dst size
+      opc1 = 0b11;
+      opc2 = dstsize == FEXCore::ARMEmitter::SubRegSize::i64Bit ? 0b11 :
+        dstsize == FEXCore::ARMEmitter::SubRegSize::i32Bit ? 0b00 : 0b00;
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+    SVEFloatConvertToInt(Op, opc1, opc2, 0, pg, zn, zd);
+  }
+  void fcvtzu(FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::SubRegSize dstsize, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::SubRegSize srcsize) {
+    LOGMAN_THROW_AA_FMT(dstsize == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+      dstsize == FEXCore::ARMEmitter::SubRegSize::i32Bit ||
+      dstsize == FEXCore::ARMEmitter::SubRegSize::i16Bit, "Unsupported size in {}", __func__);
+
+    LOGMAN_THROW_AA_FMT(srcsize == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+      srcsize == FEXCore::ARMEmitter::SubRegSize::i32Bit ||
+      srcsize == FEXCore::ARMEmitter::SubRegSize::i16Bit, "Unsupported size in {}", __func__);
+
+    constexpr uint32_t Op = 0b0110'0101'0001'1000'101 << 13;
+    uint32_t opc1, opc2;
+    if (srcsize == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      // Srcsize = fp16, opc2 encodes dst size
+      opc1 = 0b01;
+      opc2 =
+        dstsize == FEXCore::ARMEmitter::SubRegSize::i64Bit ? 0b11 :
+        dstsize == FEXCore::ARMEmitter::SubRegSize::i32Bit ? 0b10 :
+        dstsize == FEXCore::ARMEmitter::SubRegSize::i16Bit ? 0b01 : 0b00;
+    }
+    else if (srcsize == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      // Srcsize = fp32, opc1 encodes dst size
+      LOGMAN_THROW_AA_FMT(dstsize != FEXCore::ARMEmitter::SubRegSize::i16Bit, "Unsupported size in {}", __func__);
+      opc2 = 0b10;
+      opc1 = dstsize == FEXCore::ARMEmitter::SubRegSize::i64Bit ? 0b11 :
+        dstsize == FEXCore::ARMEmitter::SubRegSize::i32Bit ? 0b10 : 0b00;
+    }
+    else if (srcsize == FEXCore::ARMEmitter::SubRegSize::i64Bit) {
+      LOGMAN_THROW_AA_FMT(dstsize != FEXCore::ARMEmitter::SubRegSize::i16Bit, "Unsupported size in {}", __func__);
+      // SrcSize = fp64, opc2 encodes dst size
+      opc1 = 0b11;
+      opc2 = dstsize == FEXCore::ARMEmitter::SubRegSize::i64Bit ? 0b11 :
+        dstsize == FEXCore::ARMEmitter::SubRegSize::i32Bit ? 0b00 : 0b00;
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+    SVEFloatConvertToInt(Op, opc1, opc2, 1, pg, zn, zd);
+  }
+
+  // SVE Floating Point Unary Operations - Unpredicated
+  // SVE floating-point reciprocal estimate (unpredicated)
+  // XXX:
+
+  // SVE Floating Point Compare - with Zero
+  // SVE floating-point compare with zero
+  // XXX:
+
+  // SVE Floating Point Accumulating Reduction
+  // SVE floating-point serial reduction (predicated)
+  // XXX:
+
+  // SVE Floating Point Multiply-Add
+  // SVE floating-point multiply-accumulate writing addend
+  // XXX:
+  // SVE floating-point multiply-accumulate writing multiplicand
+  // XXX:
+
+  // SVE Memory - 32-bit Gather and Unsized Contiguous
+  void ldr(FEXCore::ARMEmitter::PRegister pt, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    LOGMAN_THROW_AA_FMT(Imm >= -256 && Imm <= 255, "Immediate offset too large");
+    constexpr uint32_t Op = 0b1000'0101'10 << 22;
+    SVEGatherAndUnsizedContiguous(Op, Imm & 0b1'1111'1111, pt, rn);
+  }
+  // XXX: LDR (vector)
+
+  // SVE 32-bit gather prefetch (scalar plus 32-bit scaled offsets)
+  // XXX:
+  // SVE 32-bit gather load halfwords (scalar plus 32-bit scaled offsets)
+  // XXX:
+  // SVE 32-bit gather load words (scalar plus 32-bit scaled offsets)
+  // XXX:
+  // SVE contiguous prefetch (scalar plus immediate)
+  // XXX:
+  // SVE 32-bit gather load (scalar plus 32-bit unscaled offsets)
+  // XXX:
+  // SVE2 32-bit gather non-temporal load (vector plus scalar)
+  // XXX:
+  // SVE contiguous prefetch (scalar plus scalar)
+  // XXX:
+  // SVE 32-bit gather prefetch (vector plus immediate)
+  // XXX:
+  // SVE 32-bit gather load (vector plus immediate)
+  // XXX:
+  // SVE load and broadcast element
+  // XXX:
+
+  // SVE contiguous non-temporal load (scalar plus immediate)
+  // XXX:
+  // SVE contiguous non-temporal load (scalar plus scalar)
+  // XXX:
+  // SVE load multiple structures (scalar plus immediate)
+  void ld2b(FEXCore::ARMEmitter::ZRegister zt1, FEXCore::ARMEmitter::ZRegister zt2, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    LOGMAN_THROW_AA_FMT(Imm >= -16 && Imm <= 14 && ((Imm % 2) == 0), "Invalid sized loadstore offset size");
+    LOGMAN_THROW_A_FMT((zt1.Idx() + 1) == zt2.Idx(), "Registers need to be contiguous");
+    constexpr uint32_t Op = 0b1010'0100'0000'0000'111 << 13;
+    SVEContiguousMultipleStructures(Op, 0b00, 0b01, Imm / 2, zt1, pg, rn);
+  }
+  void ld3b(FEXCore::ARMEmitter::ZRegister zt1, FEXCore::ARMEmitter::ZRegister zt2, FEXCore::ARMEmitter::ZRegister zt3, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    LOGMAN_THROW_AA_FMT(Imm >= -24 && Imm <= 21 && ((Imm % 3) == 0), "Invalid sized loadstore offset size");
+    LOGMAN_THROW_A_FMT((zt1.Idx() + 1) == zt2.Idx(), "Registers need to be contiguous");
+    LOGMAN_THROW_A_FMT((zt2.Idx() + 1) == zt3.Idx(), "Registers need to be contiguous");
+    constexpr uint32_t Op = 0b1010'0100'0000'0000'111 << 13;
+    SVEContiguousMultipleStructures(Op, 0b00, 0b10, Imm / 3, zt1, pg, rn);
+  }
+  void ld4b(FEXCore::ARMEmitter::ZRegister zt1, FEXCore::ARMEmitter::ZRegister zt2, FEXCore::ARMEmitter::ZRegister zt3, FEXCore::ARMEmitter::ZRegister zt4, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    LOGMAN_THROW_AA_FMT(Imm >= -32 && Imm <= 28 && ((Imm % 4) == 0), "Invalid sized loadstore offset size");
+    LOGMAN_THROW_A_FMT((zt1.Idx() + 1) == zt2.Idx(), "Registers need to be contiguous");
+    LOGMAN_THROW_A_FMT((zt2.Idx() + 1) == zt3.Idx(), "Registers need to be contiguous");
+    LOGMAN_THROW_A_FMT((zt3.Idx() + 1) == zt4.Idx(), "Registers need to be contiguous");
+
+    constexpr uint32_t Op = 0b1010'0100'0000'0000'111 << 13;
+    SVEContiguousMultipleStructures(Op, 0b00, 0b11, Imm / 4, zt1, pg, rn);
+  }
+  void ld2h(FEXCore::ARMEmitter::ZRegister zt1, FEXCore::ARMEmitter::ZRegister zt2, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    LOGMAN_THROW_AA_FMT(Imm >= -16 && Imm <= 14 && ((Imm % 2) == 0), "Invalid sized loadstore offset size");
+    LOGMAN_THROW_A_FMT((zt1.Idx() + 1) == zt2.Idx(), "Registers need to be contiguous");
+    constexpr uint32_t Op = 0b1010'0100'0000'0000'111 << 13;
+    SVEContiguousMultipleStructures(Op, 0b01, 0b01, Imm / 2, zt1, pg, rn);
+  }
+  void ld3h(FEXCore::ARMEmitter::ZRegister zt1, FEXCore::ARMEmitter::ZRegister zt2, FEXCore::ARMEmitter::ZRegister zt3, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    LOGMAN_THROW_AA_FMT(Imm >= -24 && Imm <= 21 && ((Imm % 3) == 0), "Invalid sized loadstore offset size");
+    LOGMAN_THROW_A_FMT((zt1.Idx() + 1) == zt2.Idx(), "Registers need to be contiguous");
+    LOGMAN_THROW_A_FMT((zt2.Idx() + 1) == zt3.Idx(), "Registers need to be contiguous");
+    constexpr uint32_t Op = 0b1010'0100'0000'0000'111 << 13;
+    SVEContiguousMultipleStructures(Op, 0b01, 0b10, Imm / 3, zt1, pg, rn);
+  }
+  void ld4h(FEXCore::ARMEmitter::ZRegister zt1, FEXCore::ARMEmitter::ZRegister zt2, FEXCore::ARMEmitter::ZRegister zt3, FEXCore::ARMEmitter::ZRegister zt4, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    LOGMAN_THROW_AA_FMT(Imm >= -32 && Imm <= 28 && ((Imm % 4) == 0), "Invalid sized loadstore offset size");
+    LOGMAN_THROW_A_FMT((zt1.Idx() + 1) == zt2.Idx(), "Registers need to be contiguous");
+    LOGMAN_THROW_A_FMT((zt2.Idx() + 1) == zt3.Idx(), "Registers need to be contiguous");
+    LOGMAN_THROW_A_FMT((zt3.Idx() + 1) == zt4.Idx(), "Registers need to be contiguous");
+
+    constexpr uint32_t Op = 0b1010'0100'0000'0000'111 << 13;
+    SVEContiguousMultipleStructures(Op, 0b01, 0b11, Imm / 4, zt1, pg, rn);
+  }
+  void ld2w(FEXCore::ARMEmitter::ZRegister zt1, FEXCore::ARMEmitter::ZRegister zt2, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    LOGMAN_THROW_AA_FMT(Imm >= -16 && Imm <= 14 && ((Imm % 2) == 0), "Invalid sized loadstore offset size");
+    LOGMAN_THROW_A_FMT((zt1.Idx() + 1) == zt2.Idx(), "Registers need to be contiguous");
+    constexpr uint32_t Op = 0b1010'0100'0000'0000'111 << 13;
+    SVEContiguousMultipleStructures(Op, 0b10, 0b01, Imm / 2, zt1, pg, rn);
+  }
+  void ld3w(FEXCore::ARMEmitter::ZRegister zt1, FEXCore::ARMEmitter::ZRegister zt2, FEXCore::ARMEmitter::ZRegister zt3, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    LOGMAN_THROW_AA_FMT(Imm >= -24 && Imm <= 21 && ((Imm % 3) == 0), "Invalid sized loadstore offset size");
+    LOGMAN_THROW_A_FMT((zt1.Idx() + 1) == zt2.Idx(), "Registers need to be contiguous");
+    LOGMAN_THROW_A_FMT((zt2.Idx() + 1) == zt3.Idx(), "Registers need to be contiguous");
+    constexpr uint32_t Op = 0b1010'0100'0000'0000'111 << 13;
+    SVEContiguousMultipleStructures(Op, 0b10, 0b10, Imm / 3, zt1, pg, rn);
+  }
+  void ld4w(FEXCore::ARMEmitter::ZRegister zt1, FEXCore::ARMEmitter::ZRegister zt2, FEXCore::ARMEmitter::ZRegister zt3, FEXCore::ARMEmitter::ZRegister zt4, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    LOGMAN_THROW_AA_FMT(Imm >= -32 && Imm <= 28 && ((Imm % 4) == 0), "Invalid sized loadstore offset size");
+    LOGMAN_THROW_A_FMT((zt1.Idx() + 1) == zt2.Idx(), "Registers need to be contiguous");
+    LOGMAN_THROW_A_FMT((zt2.Idx() + 1) == zt3.Idx(), "Registers need to be contiguous");
+    LOGMAN_THROW_A_FMT((zt3.Idx() + 1) == zt4.Idx(), "Registers need to be contiguous");
+
+    constexpr uint32_t Op = 0b1010'0100'0000'0000'111 << 13;
+    SVEContiguousMultipleStructures(Op, 0b10, 0b11, Imm / 4, zt1, pg, rn);
+  }
+  void ld2d(FEXCore::ARMEmitter::ZRegister zt1, FEXCore::ARMEmitter::ZRegister zt2, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    LOGMAN_THROW_AA_FMT(Imm >= -16 && Imm <= 14 && ((Imm % 2) == 0), "Invalid sized loadstore offset size");
+    LOGMAN_THROW_A_FMT((zt1.Idx() + 1) == zt2.Idx(), "Registers need to be contiguous");
+    constexpr uint32_t Op = 0b1010'0100'0000'0000'111 << 13;
+    SVEContiguousMultipleStructures(Op, 0b11, 0b01, Imm / 2, zt1, pg, rn);
+  }
+  void ld3d(FEXCore::ARMEmitter::ZRegister zt1, FEXCore::ARMEmitter::ZRegister zt2, FEXCore::ARMEmitter::ZRegister zt3, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    LOGMAN_THROW_AA_FMT(Imm >= -24 && Imm <= 21 && ((Imm % 3) == 0), "Invalid sized loadstore offset size");
+    LOGMAN_THROW_A_FMT((zt1.Idx() + 1) == zt2.Idx(), "Registers need to be contiguous");
+    LOGMAN_THROW_A_FMT((zt2.Idx() + 1) == zt3.Idx(), "Registers need to be contiguous");
+    constexpr uint32_t Op = 0b1010'0100'0000'0000'111 << 13;
+    SVEContiguousMultipleStructures(Op, 0b11, 0b10, Imm / 3, zt1, pg, rn);
+  }
+  void ld4d(FEXCore::ARMEmitter::ZRegister zt1, FEXCore::ARMEmitter::ZRegister zt2, FEXCore::ARMEmitter::ZRegister zt3, FEXCore::ARMEmitter::ZRegister zt4, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    LOGMAN_THROW_AA_FMT(Imm >= -32 && Imm <= 28 && ((Imm % 4) == 0), "Invalid sized loadstore offset size");
+    LOGMAN_THROW_A_FMT((zt1.Idx() + 1) == zt2.Idx(), "Registers need to be contiguous");
+    LOGMAN_THROW_A_FMT((zt2.Idx() + 1) == zt3.Idx(), "Registers need to be contiguous");
+    LOGMAN_THROW_A_FMT((zt3.Idx() + 1) == zt4.Idx(), "Registers need to be contiguous");
+
+    constexpr uint32_t Op = 0b1010'0100'0000'0000'111 << 13;
+    SVEContiguousMultipleStructures(Op, 0b11, 0b11, Imm / 4, zt1, pg, rn);
+  }
+
+  // SVE helper implementations
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void ld1b(FEXCore::ARMEmitter::ZRegister zt, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::SVEMemOperand Src) {
+    if (Src.MetaType.Header.MemType == FEXCore::ARMEmitter::SVEMemOperand::Type::TYPE_SCALAR_SCALAR) {
+      ld1b<size>(zt, pg, Src.rn, Src.MetaType.ScalarScalarType.rm);
+    }
+    else if (Src.MetaType.Header.MemType == FEXCore::ARMEmitter::SVEMemOperand::Type::TYPE_SCALAR_IMM) {
+      ld1b<size>(zt, pg, Src.rn, Src.MetaType.ScalarImmType.Imm);
+    }
+    else if (Src.MetaType.Header.MemType == FEXCore::ARMEmitter::SVEMemOperand::Type::TYPE_SCALAR_VECTOR) {
+      LOGMAN_THROW_A_FMT(false, "Not yet implemented");
+    }
+    else if (Src.MetaType.Header.MemType == FEXCore::ARMEmitter::SVEMemOperand::Type::TYPE_VECTOR_IMM) {
+      LOGMAN_THROW_A_FMT(false, "Not yet implemented");
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+  }
+
+  void ld1sw(FEXCore::ARMEmitter::ZRegister zt, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::SVEMemOperand Src) {
+    if (Src.MetaType.Header.MemType == FEXCore::ARMEmitter::SVEMemOperand::Type::TYPE_SCALAR_SCALAR) {
+      ld1sw(zt, pg, Src.rn, Src.MetaType.ScalarScalarType.rm);
+    }
+    else if (Src.MetaType.Header.MemType == FEXCore::ARMEmitter::SVEMemOperand::Type::TYPE_SCALAR_IMM) {
+      ld1sw(zt, pg, Src.rn, Src.MetaType.ScalarImmType.Imm);
+    }
+    else if (Src.MetaType.Header.MemType == FEXCore::ARMEmitter::SVEMemOperand::Type::TYPE_SCALAR_VECTOR) {
+      LOGMAN_THROW_A_FMT(false, "Not yet implemented");
+    }
+    else if (Src.MetaType.Header.MemType == FEXCore::ARMEmitter::SVEMemOperand::Type::TYPE_VECTOR_IMM) {
+      LOGMAN_THROW_A_FMT(false, "Not yet implemented");
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+  }
+
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void ld1h(FEXCore::ARMEmitter::ZRegister zt, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::SVEMemOperand Src) {
+    if (Src.MetaType.Header.MemType == FEXCore::ARMEmitter::SVEMemOperand::Type::TYPE_SCALAR_SCALAR) {
+      ld1h<size>(zt, pg, Src.rn, Src.MetaType.ScalarScalarType.rm);
+    }
+    else if (Src.MetaType.Header.MemType == FEXCore::ARMEmitter::SVEMemOperand::Type::TYPE_SCALAR_IMM) {
+      ld1h<size>(zt, pg, Src.rn, Src.MetaType.ScalarImmType.Imm);
+    }
+    else if (Src.MetaType.Header.MemType == FEXCore::ARMEmitter::SVEMemOperand::Type::TYPE_SCALAR_VECTOR) {
+      LOGMAN_THROW_A_FMT(false, "Not yet implemented");
+    }
+    else if (Src.MetaType.Header.MemType == FEXCore::ARMEmitter::SVEMemOperand::Type::TYPE_VECTOR_IMM) {
+      LOGMAN_THROW_A_FMT(false, "Not yet implemented");
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+  }
+
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void ld1sh(FEXCore::ARMEmitter::ZRegister zt, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::SVEMemOperand Src) {
+    if (Src.MetaType.Header.MemType == FEXCore::ARMEmitter::SVEMemOperand::Type::TYPE_SCALAR_SCALAR) {
+      ld1sh<size>(zt, pg, Src.rn, Src.MetaType.ScalarScalarType.rm);
+    }
+    else if (Src.MetaType.Header.MemType == FEXCore::ARMEmitter::SVEMemOperand::Type::TYPE_SCALAR_IMM) {
+      ld1sh<size>(zt, pg, Src.rn, Src.MetaType.ScalarImmType.Imm);
+    }
+    else if (Src.MetaType.Header.MemType == FEXCore::ARMEmitter::SVEMemOperand::Type::TYPE_SCALAR_VECTOR) {
+      LOGMAN_THROW_A_FMT(false, "Not yet implemented");
+    }
+    else if (Src.MetaType.Header.MemType == FEXCore::ARMEmitter::SVEMemOperand::Type::TYPE_VECTOR_IMM) {
+      LOGMAN_THROW_A_FMT(false, "Not yet implemented");
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+  }
+
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void ld1w(FEXCore::ARMEmitter::ZRegister zt, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::SVEMemOperand Src) {
+    if (Src.MetaType.Header.MemType == FEXCore::ARMEmitter::SVEMemOperand::Type::TYPE_SCALAR_SCALAR) {
+      ld1w<size>(zt, pg, Src.rn, Src.MetaType.ScalarScalarType.rm);
+    }
+    else if (Src.MetaType.Header.MemType == FEXCore::ARMEmitter::SVEMemOperand::Type::TYPE_SCALAR_IMM) {
+      ld1w<size>(zt, pg, Src.rn, Src.MetaType.ScalarImmType.Imm);
+    }
+    else if (Src.MetaType.Header.MemType == FEXCore::ARMEmitter::SVEMemOperand::Type::TYPE_SCALAR_VECTOR) {
+      LOGMAN_THROW_A_FMT(false, "Not yet implemented");
+    }
+    else if (Src.MetaType.Header.MemType == FEXCore::ARMEmitter::SVEMemOperand::Type::TYPE_VECTOR_IMM) {
+      LOGMAN_THROW_A_FMT(false, "Not yet implemented");
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+  }
+
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void ld1sb(FEXCore::ARMEmitter::ZRegister zt, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::SVEMemOperand Src) {
+    if (Src.MetaType.Header.MemType == FEXCore::ARMEmitter::SVEMemOperand::Type::TYPE_SCALAR_SCALAR) {
+      ld1sb<size>(zt, pg, Src.rn, Src.MetaType.ScalarScalarType.rm);
+    }
+    else if (Src.MetaType.Header.MemType == FEXCore::ARMEmitter::SVEMemOperand::Type::TYPE_SCALAR_IMM) {
+      ld1sb<size>(zt, pg, Src.rn, Src.MetaType.ScalarImmType.Imm);
+    }
+    else if (Src.MetaType.Header.MemType == FEXCore::ARMEmitter::SVEMemOperand::Type::TYPE_SCALAR_VECTOR) {
+      LOGMAN_THROW_A_FMT(false, "Not yet implemented");
+    }
+    else if (Src.MetaType.Header.MemType == FEXCore::ARMEmitter::SVEMemOperand::Type::TYPE_VECTOR_IMM) {
+      LOGMAN_THROW_A_FMT(false, "Not yet implemented");
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+  }
+
+  void ld1d(FEXCore::ARMEmitter::ZRegister zt, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::SVEMemOperand Src) {
+    if (Src.MetaType.Header.MemType == FEXCore::ARMEmitter::SVEMemOperand::Type::TYPE_SCALAR_SCALAR) {
+      ld1d(zt, pg, Src.rn, Src.MetaType.ScalarScalarType.rm);
+    }
+    else if (Src.MetaType.Header.MemType == FEXCore::ARMEmitter::SVEMemOperand::Type::TYPE_SCALAR_IMM) {
+      ld1d(zt, pg, Src.rn, Src.MetaType.ScalarImmType.Imm);
+    }
+    else if (Src.MetaType.Header.MemType == FEXCore::ARMEmitter::SVEMemOperand::Type::TYPE_SCALAR_VECTOR) {
+      LOGMAN_THROW_A_FMT(false, "Not yet implemented");
+    }
+    else if (Src.MetaType.Header.MemType == FEXCore::ARMEmitter::SVEMemOperand::Type::TYPE_VECTOR_IMM) {
+      LOGMAN_THROW_A_FMT(false, "Not yet implemented");
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+  }
+
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void st1b(FEXCore::ARMEmitter::ZRegister zt, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::SVEMemOperand Src) {
+    if (Src.MetaType.Header.MemType == FEXCore::ARMEmitter::SVEMemOperand::Type::TYPE_SCALAR_SCALAR) {
+      st1b<size>(zt, pg, Src.rn, Src.MetaType.ScalarScalarType.rm);
+    }
+    else if (Src.MetaType.Header.MemType == FEXCore::ARMEmitter::SVEMemOperand::Type::TYPE_SCALAR_IMM) {
+      st1b<size>(zt, pg, Src.rn, Src.MetaType.ScalarImmType.Imm);
+    }
+    else if (Src.MetaType.Header.MemType == FEXCore::ARMEmitter::SVEMemOperand::Type::TYPE_SCALAR_VECTOR) {
+      LOGMAN_THROW_A_FMT(false, "Not yet implemented");
+    }
+    else if (Src.MetaType.Header.MemType == FEXCore::ARMEmitter::SVEMemOperand::Type::TYPE_VECTOR_IMM) {
+      LOGMAN_THROW_A_FMT(false, "Not yet implemented");
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+  }
+
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void st1h(FEXCore::ARMEmitter::ZRegister zt, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::SVEMemOperand Src) {
+    if (Src.MetaType.Header.MemType == FEXCore::ARMEmitter::SVEMemOperand::Type::TYPE_SCALAR_SCALAR) {
+      st1h<size>(zt, pg, Src.rn, Src.MetaType.ScalarScalarType.rm);
+    }
+    else if (Src.MetaType.Header.MemType == FEXCore::ARMEmitter::SVEMemOperand::Type::TYPE_SCALAR_IMM) {
+      st1h<size>(zt, pg, Src.rn, Src.MetaType.ScalarImmType.Imm);
+    }
+    else if (Src.MetaType.Header.MemType == FEXCore::ARMEmitter::SVEMemOperand::Type::TYPE_SCALAR_VECTOR) {
+      LOGMAN_THROW_A_FMT(false, "Not yet implemented");
+    }
+    else if (Src.MetaType.Header.MemType == FEXCore::ARMEmitter::SVEMemOperand::Type::TYPE_VECTOR_IMM) {
+      LOGMAN_THROW_A_FMT(false, "Not yet implemented");
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+  }
+
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void st1w(FEXCore::ARMEmitter::ZRegister zt, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::SVEMemOperand Src) {
+    if (Src.MetaType.Header.MemType == FEXCore::ARMEmitter::SVEMemOperand::Type::TYPE_SCALAR_SCALAR) {
+      st1w<size>(zt, pg, Src.rn, Src.MetaType.ScalarScalarType.rm);
+    }
+    else if (Src.MetaType.Header.MemType == FEXCore::ARMEmitter::SVEMemOperand::Type::TYPE_SCALAR_IMM) {
+      st1w<size>(zt, pg, Src.rn, Src.MetaType.ScalarImmType.Imm);
+    }
+    else if (Src.MetaType.Header.MemType == FEXCore::ARMEmitter::SVEMemOperand::Type::TYPE_SCALAR_VECTOR) {
+      LOGMAN_THROW_A_FMT(false, "Not yet implemented");
+    }
+    else if (Src.MetaType.Header.MemType == FEXCore::ARMEmitter::SVEMemOperand::Type::TYPE_VECTOR_IMM) {
+      LOGMAN_THROW_A_FMT(false, "Not yet implemented");
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+  }
+
+  void st1d(FEXCore::ARMEmitter::ZRegister zt, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::SVEMemOperand Src) {
+    if (Src.MetaType.Header.MemType == FEXCore::ARMEmitter::SVEMemOperand::Type::TYPE_SCALAR_SCALAR) {
+      st1d(zt, pg, Src.rn, Src.MetaType.ScalarScalarType.rm);
+    }
+    else if (Src.MetaType.Header.MemType == FEXCore::ARMEmitter::SVEMemOperand::Type::TYPE_SCALAR_IMM) {
+      st1d(zt, pg, Src.rn, Src.MetaType.ScalarImmType.Imm);
+    }
+    else if (Src.MetaType.Header.MemType == FEXCore::ARMEmitter::SVEMemOperand::Type::TYPE_SCALAR_VECTOR) {
+      LOGMAN_THROW_A_FMT(false, "Not yet implemented");
+    }
+    else if (Src.MetaType.Header.MemType == FEXCore::ARMEmitter::SVEMemOperand::Type::TYPE_VECTOR_IMM) {
+      LOGMAN_THROW_A_FMT(false, "Not yet implemented");
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+  }
+
+  // SVE load multiple structures (scalar plus scalar)
+  // XXX:
+  // SVE load and broadcast quadword (scalar plus immediate)
+  // XXX:
+  // SVE contiguous load (scalar plus immediate)
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void ld1b(FEXCore::ARMEmitter::ZRegister zt, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    LOGMAN_THROW_AA_FMT(Imm >= -8 && Imm <= 7, "Invalid sized loadstore offset size");
+    constexpr uint32_t Op = 0b1010'0100'0000'0000'101 << 13;
+    SVEContiguousLoadImm(Op, 0b0000 | FEXCore::ToUnderlying(size), Imm, pg, rn, zt);
+  }
+
+  void ld1sw(FEXCore::ARMEmitter::ZRegister zt, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    LOGMAN_THROW_AA_FMT(Imm >= -8 && Imm <= 7, "Invalid sized loadstore offset size");
+    constexpr uint32_t Op = 0b1010'0100'0000'0000'101 << 13;
+    SVEContiguousLoadImm(Op, 0b0100, Imm, pg, rn, zt);
+  }
+
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void ld1h(FEXCore::ARMEmitter::ZRegister zt, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    LOGMAN_THROW_AA_FMT(Imm >= -8 && Imm <= 7, "Invalid sized loadstore offset size");
+    static_assert(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "Invalid size");
+    constexpr uint32_t Op = 0b1010'0100'0000'0000'101 << 13;
+    SVEContiguousLoadImm(Op, 0b0100 | FEXCore::ToUnderlying(size), Imm, pg, rn, zt);
+  }
+
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void ld1sh(FEXCore::ARMEmitter::ZRegister zt, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    LOGMAN_THROW_AA_FMT(Imm >= -8 && Imm <= 7, "Invalid sized loadstore offset size");
+    static_assert(size == FEXCore::ARMEmitter::SubRegSize::i32Bit ||
+                  size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid size");
+    constexpr uint32_t Op = 0b1010'0100'0000'0000'101 << 13;
+    constexpr uint32_t ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? 1 :
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? 0 : -1;
+
+    SVEContiguousLoadImm(Op, 0b1000 | ConvertedSize, Imm, pg, rn, zt);
+  }
+
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void ld1w(FEXCore::ARMEmitter::ZRegister zt, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    LOGMAN_THROW_AA_FMT(Imm >= -8 && Imm <= 7, "Invalid sized loadstore offset size");
+    static_assert(size == FEXCore::ARMEmitter::SubRegSize::i32Bit ||
+                  size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid size");
+    constexpr uint32_t Op = 0b1010'0100'0000'0000'101 << 13;
+    constexpr uint32_t ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? 1 :
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? 0 : -1;
+
+    SVEContiguousLoadImm(Op, 0b1010 | ConvertedSize, Imm, pg, rn, zt);
+  }
+
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void ld1sb(FEXCore::ARMEmitter::ZRegister zt, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    LOGMAN_THROW_AA_FMT(Imm >= -8 && Imm <= 7, "Invalid sized loadstore offset size");
+    static_assert(size == FEXCore::ARMEmitter::SubRegSize::i16Bit ||
+                  size == FEXCore::ARMEmitter::SubRegSize::i32Bit ||
+                  size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid size");
+    constexpr uint32_t Op = 0b1010'0100'0000'0000'101 << 13;
+    constexpr uint32_t ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? 0b10 :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? 0b01 :
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? 0b00 : -1;
+    SVEContiguousLoadImm(Op, 0b1100 | ConvertedSize, Imm, pg, rn, zt);
+  }
+  void ld1d(FEXCore::ARMEmitter::ZRegister zt, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    LOGMAN_THROW_AA_FMT(Imm >= -8 && Imm <= 7, "Invalid sized loadstore offset size");
+    constexpr uint32_t Op = 0b1010'0100'0000'0000'101 << 13;
+    SVEContiguousLoadImm(Op, 0b1111, Imm, pg, rn, zt);
+  }
+
+  // SVE contiguous non-fault load (scalar plus immediate)
+  // XXX:
+  // SVE load and broadcast quadword (scalar plus scalar)
+  // XXX:
+  // SVE contiguous load (scalar plus scalar)
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void ld1b(FEXCore::ARMEmitter::ZRegister zt, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    constexpr uint32_t Op = 0b1010'0100'0000'0000'010 << 13;
+    SVEContiguousLoadStore(Op, 0b0000 | FEXCore::ToUnderlying(size), rm, pg, rn, zt);
+  }
+
+  void ld1sw(FEXCore::ARMEmitter::ZRegister zt, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    constexpr uint32_t Op = 0b1010'0100'0000'0000'010 << 13;
+    SVEContiguousLoadStore(Op, 0b0100, rm, pg, rn, zt);
+  }
+
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void ld1h(FEXCore::ARMEmitter::ZRegister zt, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    static_assert(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "Invalid size");
+    constexpr uint32_t Op = 0b1010'0100'0000'0000'010 << 13;
+    SVEContiguousLoadStore(Op, 0b0100 | FEXCore::ToUnderlying(size), rm, pg, rn, zt);
+  }
+
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void ld1sh(FEXCore::ARMEmitter::ZRegister zt, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    static_assert(size == FEXCore::ARMEmitter::SubRegSize::i32Bit ||
+                  size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid size");
+    constexpr uint32_t Op = 0b1010'0100'0000'0000'010 << 13;
+    constexpr uint32_t ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? 1 :
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? 0 : -1;
+    SVEContiguousLoadStore(Op, 0b1000 | ConvertedSize, rm, pg, rn, zt);
+  }
+
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void ld1w(FEXCore::ARMEmitter::ZRegister zt, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    static_assert(size == FEXCore::ARMEmitter::SubRegSize::i32Bit ||
+                  size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid size");
+    constexpr uint32_t Op = 0b1010'0100'0000'0000'010 << 13;
+    constexpr uint32_t ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? 0 :
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? 1 : -1;
+    SVEContiguousLoadStore(Op, 0b1010 | ConvertedSize, rm, pg, rn, zt);
+  }
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void ld1sb(FEXCore::ARMEmitter::ZRegister zt, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    static_assert(size == FEXCore::ARMEmitter::SubRegSize::i16Bit ||
+                  size == FEXCore::ARMEmitter::SubRegSize::i32Bit ||
+                  size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid size");
+    constexpr uint32_t Op = 0b1010'0100'0000'0000'010 << 13;
+    constexpr uint32_t ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit ? 0b10 :
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? 0b01 :
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? 0b00 : -1;
+    SVEContiguousLoadStore(Op, 0b1100 | ConvertedSize, rm, pg, rn, zt);
+  }
+
+  void ld1d(FEXCore::ARMEmitter::ZRegister zt, FEXCore::ARMEmitter::PRegisterZero pg, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    constexpr uint32_t Op = 0b1010'0100'0000'0000'010 << 13;
+    SVEContiguousLoadStore(Op, 0b1111, rm, pg, rn, zt);
+  }
+
+  // SVE contiguous first-fault load (scalar plus scalar)
+  // XXX:
+
+  // SVE Memory - 64-bit Gather
+  // SVE 64-bit gather prefetch (scalar plus 64-bit scaled offsets)
+  // XXX:
+  // SVE 64-bit gather prefetch (scalar plus unpacked 32-bit scaled offsets)
+  // XXX:
+  // SVE 64-bit gather load (scalar plus 64-bit scaled offsets)
+  // XXX:
+  // SVE 64-bit gather load (scalar plus 32-bit unpacked scaled offsets)
+  // XXX:
+  // SVE 64-bit gather prefetch (vector plus immediate)
+  // XXX:
+  // SVE2 64-bit gather non-temporal load (vector plus scalar)
+  // XXX:
+  // SVE 64-bit gather load (vector plus immediate)
+  // XXX:
+  // SVE 64-bit gather load (scalar plus 64-bit unscaled offsets)
+  // XXX:
+  // SVE 64-bit gather load (scalar plus unpacked 32-bit unscaled offsets)
+  // XXX:
+
+  // SVE Memory - Contiguous Store and Unsized Contiguous
+  // XXX: STR (predicate)
+  // XXX: STR (vector)
+  //
+  // SVE contiguous store (scalar plus scalar)
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void st1b(FEXCore::ARMEmitter::ZRegister zt, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    constexpr uint32_t Op = 0b1110'0100'0000'0000'010 << 13;
+    SVEContiguousLoadStore(Op, 0b0000 | FEXCore::ToUnderlying(size), rm, pg, rn, zt);
+  }
+
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void st1h(FEXCore::ARMEmitter::ZRegister zt, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    static_assert(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "Invalid size");
+    constexpr uint32_t Op = 0b1110'0100'0000'0000'010 << 13;
+    SVEContiguousLoadStore(Op, 0b0100 | FEXCore::ToUnderlying(size), rm, pg, rn, zt);
+  }
+
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void st1w(FEXCore::ARMEmitter::ZRegister zt, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    static_assert(size == FEXCore::ARMEmitter::SubRegSize::i32Bit ||
+                  size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid size");
+    constexpr uint32_t Op = 0b1110'0100'0000'0000'010 << 13;
+    constexpr uint32_t ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? 0 :
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? 1 : -1;
+
+    SVEContiguousLoadStore(Op, 0b1010 | ConvertedSize, rm, pg, rn, zt);
+  }
+  void st1d(FEXCore::ARMEmitter::ZRegister zt, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+    constexpr uint32_t Op = 0b1110'0100'0000'0000'010 << 13;
+
+    SVEContiguousLoadStore(Op, 0b1111, rm, pg, rn, zt);
+  }
+
+  // SVE Memory - Non-temporal and Multi-register Store
+  // SVE2 64-bit scatter non-temporal store (vector plus scalar)
+  // XXX:
+  // SVE contiguous non-temporal store (scalar plus scalar)
+  // XXX:
+  // SVE2 32-bit scatter non-temporal store (vector plus scalar)
+  // XXX:
+  // SVE store multiple structures (scalar plus scalar)
+  // XXX:
+
+  // SVE Memory - Scatter with Optional Sign Extend
+  // SVE 64-bit scatter store (scalar plus unpacked 32-bit unscaled offsets)
+  // XXX:
+  // SVE 64-bit scatter store (scalar plus unpacked 32-bit scaled offsets)
+  // XXX:
+  // SVE 32-bit scatter store (scalar plus 32-bit unscaled offsets)
+  // XXX:
+  // SVE 32-bit scatter store (scalar plus 32-bit scaled offsets)
+  // XXX:
+
+  // SVE Memory - Scatter
+  // SVE 64-bit scatter store (scalar plus 64-bit unscaled offsets)
+  // XXX:
+  // SVE 64-bit scatter store (scalar plus 64-bit scaled offsets)
+  // XXX:
+  // SVE 64-bit scatter store (vector plus immediate)
+  // XXX:
+  // SVE 32-bit scatter store (vector plus immediate)
+  // XXX:
+
+  // SVE Memory - Contiguous Store with Immediate Offset
+  // SVE contiguous non-temporal store (scalar plus immediate)
+  // XXX:
+  // SVE store multiple structures (scalar plus immediate)
+  void st2b(FEXCore::ARMEmitter::ZRegister zt1, FEXCore::ARMEmitter::ZRegister zt2, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    LOGMAN_THROW_AA_FMT(Imm >= -16 && Imm <= 14 && ((Imm % 2) == 0), "Invalid sized loadstore offset size");
+    LOGMAN_THROW_A_FMT((zt1.Idx() + 1) == zt2.Idx(), "Registers need to be contiguous");
+    constexpr uint32_t Op = 0b1110'0100'0001'0000'111 << 13;
+    SVEContiguousMultipleStructures(Op, 0b00, 0b01, Imm / 2, zt1, pg, rn);
+  }
+  void st3b(FEXCore::ARMEmitter::ZRegister zt1, FEXCore::ARMEmitter::ZRegister zt2, FEXCore::ARMEmitter::ZRegister zt3, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    LOGMAN_THROW_AA_FMT(Imm >= -24 && Imm <= 21 && ((Imm % 3) == 0), "Invalid sized loadstore offset size");
+    LOGMAN_THROW_A_FMT((zt1.Idx() + 1) == zt2.Idx(), "Registers need to be contiguous");
+    LOGMAN_THROW_A_FMT((zt2.Idx() + 1) == zt3.Idx(), "Registers need to be contiguous");
+    constexpr uint32_t Op = 0b1110'0100'0001'0000'111 << 13;
+    SVEContiguousMultipleStructures(Op, 0b00, 0b10, Imm / 3, zt1, pg, rn);
+  }
+  void st4b(FEXCore::ARMEmitter::ZRegister zt1, FEXCore::ARMEmitter::ZRegister zt2, FEXCore::ARMEmitter::ZRegister zt3, FEXCore::ARMEmitter::ZRegister zt4, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    LOGMAN_THROW_AA_FMT(Imm >= -32 && Imm <= 28 && ((Imm % 4) == 0), "Invalid sized loadstore offset size");
+    LOGMAN_THROW_A_FMT((zt1.Idx() + 1) == zt2.Idx(), "Registers need to be contiguous");
+    LOGMAN_THROW_A_FMT((zt2.Idx() + 1) == zt3.Idx(), "Registers need to be contiguous");
+    LOGMAN_THROW_A_FMT((zt3.Idx() + 1) == zt4.Idx(), "Registers need to be contiguous");
+
+    constexpr uint32_t Op = 0b1110'0100'0001'0000'111 << 13;
+    SVEContiguousMultipleStructures(Op, 0b00, 0b11, Imm / 4, zt1, pg, rn);
+  }
+  void st2h(FEXCore::ARMEmitter::ZRegister zt1, FEXCore::ARMEmitter::ZRegister zt2, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    LOGMAN_THROW_AA_FMT(Imm >= -16 && Imm <= 14 && ((Imm % 2) == 0), "Invalid sized loadstore offset size");
+    LOGMAN_THROW_A_FMT((zt1.Idx() + 1) == zt2.Idx(), "Registers need to be contiguous");
+    constexpr uint32_t Op = 0b1110'0100'0001'0000'111 << 13;
+    SVEContiguousMultipleStructures(Op, 0b01, 0b01, Imm / 2, zt1, pg, rn);
+  }
+  void st3h(FEXCore::ARMEmitter::ZRegister zt1, FEXCore::ARMEmitter::ZRegister zt2, FEXCore::ARMEmitter::ZRegister zt3, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    LOGMAN_THROW_AA_FMT(Imm >= -24 && Imm <= 21 && ((Imm % 3) == 0), "Invalid sized loadstore offset size");
+    LOGMAN_THROW_A_FMT((zt1.Idx() + 1) == zt2.Idx(), "Registers need to be contiguous");
+    LOGMAN_THROW_A_FMT((zt2.Idx() + 1) == zt3.Idx(), "Registers need to be contiguous");
+    constexpr uint32_t Op = 0b1110'0100'0001'0000'111 << 13;
+    SVEContiguousMultipleStructures(Op, 0b01, 0b10, Imm / 3, zt1, pg, rn);
+  }
+  void st4h(FEXCore::ARMEmitter::ZRegister zt1, FEXCore::ARMEmitter::ZRegister zt2, FEXCore::ARMEmitter::ZRegister zt3, FEXCore::ARMEmitter::ZRegister zt4, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    LOGMAN_THROW_AA_FMT(Imm >= -32 && Imm <= 28 && ((Imm % 4) == 0), "Invalid sized loadstore offset size");
+    LOGMAN_THROW_A_FMT((zt1.Idx() + 1) == zt2.Idx(), "Registers need to be contiguous");
+    LOGMAN_THROW_A_FMT((zt2.Idx() + 1) == zt3.Idx(), "Registers need to be contiguous");
+    LOGMAN_THROW_A_FMT((zt3.Idx() + 1) == zt4.Idx(), "Registers need to be contiguous");
+
+    constexpr uint32_t Op = 0b1110'0100'0001'0000'111 << 13;
+    SVEContiguousMultipleStructures(Op, 0b01, 0b11, Imm / 4, zt1, pg, rn);
+  }
+  void st2w(FEXCore::ARMEmitter::ZRegister zt1, FEXCore::ARMEmitter::ZRegister zt2, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    LOGMAN_THROW_AA_FMT(Imm >= -16 && Imm <= 14 && ((Imm % 2) == 0), "Invalid sized loadstore offset size");
+    LOGMAN_THROW_A_FMT((zt1.Idx() + 1) == zt2.Idx(), "Registers need to be contiguous");
+    constexpr uint32_t Op = 0b1110'0100'0001'0000'111 << 13;
+    SVEContiguousMultipleStructures(Op, 0b10, 0b01, Imm / 2, zt1, pg, rn);
+  }
+  void st3w(FEXCore::ARMEmitter::ZRegister zt1, FEXCore::ARMEmitter::ZRegister zt2, FEXCore::ARMEmitter::ZRegister zt3, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    LOGMAN_THROW_AA_FMT(Imm >= -24 && Imm <= 21 && ((Imm % 3) == 0), "Invalid sized loadstore offset size");
+    LOGMAN_THROW_A_FMT((zt1.Idx() + 1) == zt2.Idx(), "Registers need to be contiguous");
+    LOGMAN_THROW_A_FMT((zt2.Idx() + 1) == zt3.Idx(), "Registers need to be contiguous");
+    constexpr uint32_t Op = 0b1110'0100'0001'0000'111 << 13;
+    SVEContiguousMultipleStructures(Op, 0b10, 0b10, Imm / 3, zt1, pg, rn);
+  }
+  void st4w(FEXCore::ARMEmitter::ZRegister zt1, FEXCore::ARMEmitter::ZRegister zt2, FEXCore::ARMEmitter::ZRegister zt3, FEXCore::ARMEmitter::ZRegister zt4, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    LOGMAN_THROW_AA_FMT(Imm >= -32 && Imm <= 28 && ((Imm % 4) == 0), "Invalid sized loadstore offset size");
+    LOGMAN_THROW_A_FMT((zt1.Idx() + 1) == zt2.Idx(), "Registers need to be contiguous");
+    LOGMAN_THROW_A_FMT((zt2.Idx() + 1) == zt3.Idx(), "Registers need to be contiguous");
+    LOGMAN_THROW_A_FMT((zt3.Idx() + 1) == zt4.Idx(), "Registers need to be contiguous");
+
+    constexpr uint32_t Op = 0b1110'0100'0001'0000'111 << 13;
+    SVEContiguousMultipleStructures(Op, 0b10, 0b11, Imm / 4, zt1, pg, rn);
+  }
+  void st2d(FEXCore::ARMEmitter::ZRegister zt1, FEXCore::ARMEmitter::ZRegister zt2, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    LOGMAN_THROW_AA_FMT(Imm >= -16 && Imm <= 14 && ((Imm % 2) == 0), "Invalid sized loadstore offset size");
+    LOGMAN_THROW_A_FMT((zt1.Idx() + 1) == zt2.Idx(), "Registers need to be contiguous");
+    constexpr uint32_t Op = 0b1110'0100'0001'0000'111 << 13;
+    SVEContiguousMultipleStructures(Op, 0b11, 0b01, Imm / 2, zt1, pg, rn);
+  }
+  void st3d(FEXCore::ARMEmitter::ZRegister zt1, FEXCore::ARMEmitter::ZRegister zt2, FEXCore::ARMEmitter::ZRegister zt3, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    LOGMAN_THROW_AA_FMT(Imm >= -24 && Imm <= 21 && ((Imm % 3) == 0), "Invalid sized loadstore offset size");
+    LOGMAN_THROW_A_FMT((zt1.Idx() + 1) == zt2.Idx(), "Registers need to be contiguous");
+    LOGMAN_THROW_A_FMT((zt2.Idx() + 1) == zt3.Idx(), "Registers need to be contiguous");
+    constexpr uint32_t Op = 0b1110'0100'0001'0000'111 << 13;
+    SVEContiguousMultipleStructures(Op, 0b11, 0b10, Imm / 3, zt1, pg, rn);
+  }
+  void st4d(FEXCore::ARMEmitter::ZRegister zt1, FEXCore::ARMEmitter::ZRegister zt2, FEXCore::ARMEmitter::ZRegister zt3, FEXCore::ARMEmitter::ZRegister zt4, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    LOGMAN_THROW_AA_FMT(Imm >= -32 && Imm <= 28 && ((Imm % 4) == 0), "Invalid sized loadstore offset size");
+    LOGMAN_THROW_A_FMT((zt1.Idx() + 1) == zt2.Idx(), "Registers need to be contiguous");
+    LOGMAN_THROW_A_FMT((zt2.Idx() + 1) == zt3.Idx(), "Registers need to be contiguous");
+    LOGMAN_THROW_A_FMT((zt3.Idx() + 1) == zt4.Idx(), "Registers need to be contiguous");
+
+    constexpr uint32_t Op = 0b1110'0100'0001'0000'111 << 13;
+    SVEContiguousMultipleStructures(Op, 0b11, 0b11, Imm / 4, zt1, pg, rn);
+  }
+
+  // SVE contiguous store (scalar plus immediate)
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void st1b(FEXCore::ARMEmitter::ZRegister zt, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    LOGMAN_THROW_AA_FMT(Imm >= -8 && Imm <= 7, "Invalid sized loadstore offset size");
+    constexpr uint32_t Op = 0b1110'0100'0000'0000'111 << 13;
+    SVEContiguousLoadImm(Op, 0b0000 | FEXCore::ToUnderlying(size), Imm, pg, rn, zt);
+  }
+
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void st1h(FEXCore::ARMEmitter::ZRegister zt, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    LOGMAN_THROW_AA_FMT(Imm >= -8 && Imm <= 7, "Invalid sized loadstore offset size");
+    static_assert(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "Invalid size");
+    constexpr uint32_t Op = 0b1110'0100'0000'0000'111 << 13;
+    SVEContiguousLoadImm(Op, 0b0100 | FEXCore::ToUnderlying(size), Imm, pg, rn, zt);
+  }
+
+  template<FEXCore::ARMEmitter::SubRegSize size>
+  void st1w(FEXCore::ARMEmitter::ZRegister zt, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    LOGMAN_THROW_AA_FMT(Imm >= -8 && Imm <= 7, "Invalid sized loadstore offset size");
+    static_assert(size == FEXCore::ARMEmitter::SubRegSize::i32Bit ||
+                  size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid size");
+    constexpr uint32_t Op = 0b1110'0100'0000'0000'111 << 13;
+    constexpr uint32_t ConvertedSize =
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ? 0 :
+      size == FEXCore::ARMEmitter::SubRegSize::i64Bit ? 1 : -1;
+
+    SVEContiguousLoadImm(Op, 0b1010 | ConvertedSize, Imm, pg, rn, zt);
+  }
+
+  void st1d(FEXCore::ARMEmitter::ZRegister zt, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::Register rn, int32_t Imm = 0) {
+    LOGMAN_THROW_AA_FMT(Imm >= -8 && Imm <= 7, "Invalid sized loadstore offset size");
+    constexpr uint32_t Op = 0b1110'0100'0000'0000'111 << 13;
+    SVEContiguousLoadImm(Op, 0b1111, Imm, pg, rn, zt);
+  }
+private:
+  // SVE encodings
+  void SVEDup(uint32_t Op, uint32_t imm2, uint32_t tsz, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zd) {
+    uint32_t Instr = Op;
+
+    Instr |= imm2 << 22;
+    Instr |= tsz << 16;
+    Instr |= Encode_rn(zn);
+    Instr |= Encode_rd(zd);
+    dc32(Instr);
+  }
+
+  void SVESel(uint32_t Op, FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zm, FEXCore::ARMEmitter::PRegister pv, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zd) {
+    uint32_t Instr = Op;
+
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= zm.Idx() << 16;
+    Instr |= pv.Idx() << 10;
+    Instr |= Encode_rn(zn);
+    Instr |= Encode_rd(zd);
+    dc32(Instr);
+  }
+
+  // SVE integer add/subtract vectors (unpredicated)
+  void SVEIntegerAddSubUnpredicated(uint32_t Op, uint32_t opc, FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zm, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zd) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    uint32_t Instr = Op;
+
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= zm.Idx() << 16;
+    Instr |= opc << 10;
+    Instr |= zn.Idx() << 5;
+    Instr |= zd.Idx();
+    dc32(Instr);
+  }
+
+  // SVE table lookup (three sources)
+  void SVETableLookup(uint32_t Op, uint32_t op, FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zm, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zd) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    uint32_t Instr = Op;
+
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= zm.Idx() << 16;
+    Instr |= op << 10;
+    Instr |= zn.Idx() << 5;
+    Instr |= zd.Idx();
+    dc32(Instr);
+  }
+
+  // SVE permute vector elements
+  void SVEPermute(uint32_t Op, uint32_t opc, FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zm, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zd) {
+    uint32_t Instr = Op;
+
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= zm.Idx() << 16;
+    Instr |= opc << 10;
+    Instr |= zn.Idx() << 5;
+    Instr |= zd.Idx();
+    dc32(Instr);
+  }
+
+  // SVE predicate logical operations
+  void SVEPredicateLogical(uint32_t Op, uint32_t op, uint32_t S, uint32_t o2, uint32_t o3, FEXCore::ARMEmitter::PRegister pm, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::PRegister pn, FEXCore::ARMEmitter::PRegister pd) {
+    uint32_t Instr = Op;
+
+    Instr |= op << 23;
+    Instr |= S << 22;
+    Instr |= pm.Idx() << 16;
+    Instr |= pg.Idx() << 10;
+    Instr |= o2 << 9;
+    Instr |= pn.Idx() << 5;
+    Instr |= o3 << 4;
+    Instr |= pd.Idx();
+    dc32(Instr);
+  }
+
+  // SVE floating-point convert precision odd elements
+  void SVEFloatConvertOdd(uint32_t Op, uint32_t opc, uint32_t opc2, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zd) {
+    uint32_t Instr = Op;
+
+    Instr |= opc << 22;
+    Instr |= opc2 << 16;
+    Instr |= pg.Idx() << 10;
+    Instr |= zn.Idx() << 5;
+    Instr |= zd.Idx();
+    dc32(Instr);
+  }
+
+  // SVE2 floating-point pairwise operations
+  void SVEFloatPairwiseArithmetic(uint32_t Op, uint32_t opc, FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::ZRegister zm, FEXCore::ARMEmitter::ZRegister zd) {
+    uint32_t Instr = Op;
+
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= opc << 16;
+    Instr |= pg.Idx() << 10;
+    Instr |= zm.Idx() << 5;
+    Instr |= zd.Idx();
+    dc32(Instr);
+  }
+
+  // SVE floating-point arithmetic (unpredicated)
+  void SVEFloatArithmeticUnpredicated(uint32_t Op, uint32_t opc, FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zm, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zd) {
+    uint32_t Instr = Op;
+
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= zm.Idx() << 16;
+    Instr |= opc << 10;
+    Instr |= zn.Idx() << 5;
+    Instr |= zd.Idx();
+    dc32(Instr);
+  }
+
+  // SVE bitwise logical operations (predicated)
+  void SVEBitwiseLogicalPredicated(uint32_t Op, uint32_t opc, FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::ZRegister zm, FEXCore::ARMEmitter::ZRegister zd) {
+    uint32_t Instr = Op;
+
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= opc << 16;
+    Instr |= pg.Idx() << 10;
+    Instr |= zm.Idx() << 5;
+    Instr |= zd.Idx();
+    dc32(Instr);
+  }
+
+  // SVE integer min/max reduction (predicated)
+  void SVEIntegerMinMaxReduction(uint32_t Op, uint32_t op, uint32_t U, FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zd) {
+    uint32_t Instr = Op;
+
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= op << 17;
+    Instr |= U << 16;
+    Instr |= pg.Idx() << 10;
+    Instr |= Encode_rn(zn);
+    Instr |= Encode_rd(zd);
+    dc32(Instr);
+  }
+
+  // SVE constructive prefix (predicated)
+  void SVEConstructivePrefixPredicated(uint32_t Op, uint32_t opc, uint32_t M, FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zd) {
+    uint32_t Instr = Op;
+
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= opc << 17;
+    Instr |= M << 16;
+    Instr |= pg.Idx() << 10;
+    Instr |= Encode_rn(zn);
+    Instr |= Encode_rd(zd);
+    dc32(Instr);
+  }
+
+  // SVE bitwise unary operations (predicated)
+  void SVEIntegerUnaryPredicated(uint32_t Op, uint32_t opc, FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zd) {
+    uint32_t Instr = Op;
+
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= opc << 16;
+    Instr |= pg.Idx() << 10;
+    Instr |= zn.Idx() << 5;
+    Instr |= zd.Idx();
+    dc32(Instr);
+  }
+
+  // SVE bitwise logical operations (unpredicated)
+  void SVEBitwiseLogicalUnpredicated(uint32_t Op, uint32_t opc, FEXCore::ARMEmitter::ZRegister zm, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zd) {
+    uint32_t Instr = Op;
+
+    Instr |= opc << 22;
+    Instr |= zm.Idx() << 16;
+    Instr |= zn.Idx() << 5;
+    Instr |= zd.Idx();
+    dc32(Instr);
+  }
+
+  // SVE Permute Vector - Unpredicated
+  void SVEPermuteUnpredicated(uint32_t Op, uint32_t op0, uint32_t op1, FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::ZRegister zd) {
+    uint32_t Instr = Op;
+
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= op0 << 19;
+    Instr |= op1 << 16;
+    Instr |= Encode_rn(rn);
+    Instr |= zd.Idx();
+    dc32(Instr);
+  }
+
+  // SVE unpack vector elements
+  void SVEUnpackVectorElements(uint32_t Op, uint32_t U, uint32_t H, FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zd) {
+    uint32_t Instr = Op;
+
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= U << 17;
+    Instr |= H << 16;
+    Instr |= Encode_rn(zn);
+    Instr |= Encode_rd(zd);
+    dc32(Instr);
+  }
+
+  // SVE reverse within elements
+  void SVEReverseWithinElements(uint32_t opc, FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zd) {
+    constexpr uint32_t Op = 0b0000'0101'0010'0100'100 << 13;
+    uint32_t Instr = Op;
+
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= opc << 16;
+    Instr |= pg.Idx() << 10;
+    Instr |= zn.Idx() << 5;
+    Instr |= zd.Idx();
+    dc32(Instr);
+  }
+
+  // SVE constructive prefix (unpredicated)
+  void SVEConstructivePrefixUnpredicated(uint32_t Op, uint32_t opc, uint32_t opc2, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zd) {
+    uint32_t Instr = Op;
+
+    Instr |= opc << 22;
+    Instr |= opc2 << 16;
+    Instr |= Encode_rn(zn);
+    Instr |= Encode_rd(zd);
+    dc32(Instr);
+  }
+
+  // SVE2 integer halving add/subtract (predicated)
+  void SVE2IntegerHalvingPredicated(uint32_t Op, uint32_t R, uint32_t S, uint32_t U, FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::ZRegister zm, FEXCore::ARMEmitter::ZRegister zd) {
+    uint32_t Instr = Op;
+
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= R << 18;
+    Instr |= S << 17;
+    Instr |= U << 16;
+    Instr |= pg.Idx() << 10;
+    Instr |= zm.Idx() << 5;
+    Instr |= zd.Idx();
+    dc32(Instr);
+  }
+
+  // SVE2 integer pairwise arithmetic
+  void SVEIntegerPairwiseArithmetic(uint32_t Op, uint32_t opc, uint32_t U, FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::ZRegister zm, FEXCore::ARMEmitter::ZRegister zd) {
+    uint32_t Instr = Op;
+
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= opc << 17;
+    Instr |= U << 16;
+    Instr |= pg.Idx() << 10;
+    Instr |= zm.Idx() << 5;
+    Instr |= zd.Idx();
+    dc32(Instr);
+  }
+
+  // SVE floating-point arithmetic (predicated)
+  void SVEFloatArithmeticPredicated(uint32_t Op, uint32_t opc, FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::ZRegister zm, FEXCore::ARMEmitter::ZRegister zd) {
+    uint32_t Instr = Op;
+
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= opc << 16;
+    Instr |= pg.Idx() << 10;
+    Instr |= zm.Idx() << 5;
+    Instr |= zd.Idx();
+    dc32(Instr);
+  }
+
+  // SVE floating-point round to integral value
+  void frintX(uint32_t opc, FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::ZRegister zn) {
+    // opc = round mode
+    // 0b000 - N - Neaest ties to even
+    // 0b001 - P - Towards +inf
+    // 0b010 - M - Towards -inf
+    // 0b011 - Z - Towards zero
+    // 0b100 - A - Nearest away from zero
+    // 0b101 - Unallocated
+    // 0b110 - X - Current signalling inexact
+    // 0b111 - I - Current
+    constexpr uint32_t Op = 0b0110'0101'0000'0000'101 << 13;
+    SVEFloatRoundIntegral(Op, opc, size, zd, pg, zn);
+  }
+
+  void SVEFloatRoundIntegral(uint32_t Op, uint32_t opc, FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::ZRegister zn) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
+      size == FEXCore::ARMEmitter::SubRegSize::i32Bit ||
+      size == FEXCore::ARMEmitter::SubRegSize::i16Bit, "Unsupported size in {}", __func__);
+
+    uint32_t Instr = Op;
+
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= opc << 16;
+    Instr |= pg.Idx() << 10;
+    Instr |= zn.Idx() << 5;
+    Instr |= zd.Idx();
+    dc32(Instr);
+  }
+
+  // SVE floating-point convert to integer
+  void SVEFloatConvertToInt(uint32_t Op, uint32_t opc, uint32_t opc2, uint32_t U, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zd) {
+    uint32_t Instr = Op;
+
+    Instr |= opc << 22;
+    Instr |= opc2 << 17;
+    Instr |= U << 16;
+    Instr |= pg.Idx() << 10;
+    Instr |= zn.Idx() << 5;
+    Instr |= zd.Idx();
+    dc32(Instr);
+  }
+
+  // SVE Memory - 32-bit Gather and Unsized Contiguous
+  void SVEGatherAndUnsizedContiguous(uint32_t Op, uint32_t imm9, FEXCore::ARMEmitter::PRegister pt, FEXCore::ARMEmitter::Register rn) {
+    uint32_t Instr = Op;
+
+    Instr |= (imm9 >> 3) << 16;
+    Instr |= (imm9 & 0b111) << 10;
+    Instr |= rn.Idx() << 5;
+    Instr |= pt.Idx();
+
+    dc32(Instr);
+  }
+
+  // SVE store multiple structures (scalar plus immediate)
+  void SVEContiguousMultipleStructures(uint32_t Op, uint32_t msz, uint32_t opc, uint32_t imm4, FEXCore::ARMEmitter::ZRegister zt, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::Register rn) {
+    uint32_t Instr = Op;
+
+    Instr |= msz << 23;
+    Instr |= opc << 21;
+    Instr |= (imm4 & 0xF) << 16;
+    Instr |= pg.Idx() << 10;
+    Instr |= Encode_rn(rn);
+    Instr |= zt.Idx();
+    dc32(Instr);
+  }
+
+  void SVEContiguousLoadImm(uint32_t Op, uint32_t dtype, uint32_t Imm, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::ZRegister zt) {
+    uint32_t Instr = Op;
+
+    Instr |= dtype << 21;
+    Instr |= (Imm & 0xF) << 16;
+    Instr |= pg.Idx() << 10;
+    Instr |= Encode_rn(rn);
+    Instr |= zt.Idx();
+    dc32(Instr);
+  }
+
+  // zt.b, pg/z, xn, xm
+  void SVEContiguousLoadStore(uint32_t Op, uint32_t dtype, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::ZRegister zt) {
+    uint32_t Instr = Op;
+
+    Instr |= dtype << 21;
+    Instr |= Encode_rm(rm);
+    Instr |= pg.Idx() << 10;
+    Instr |= Encode_rn(rn);
+    Instr |= zt.Idx();
+    dc32(Instr);
+  }
+  void SVEPredicateTest(uint32_t Op, uint32_t op, uint32_t S, uint32_t opc2, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::PRegister pn) {
+    uint32_t Instr = Op;
+
+    Instr |= op << 23;
+    Instr |= S << 22;
+    Instr |= pg.Idx() << 10;
+    Instr |= pn.Idx() << 5;
+    Instr |= opc2;
+    dc32(Instr);
+  }
+
+  void SVEPredicateReadFFRPredicated(uint32_t Op, uint32_t op, uint32_t S, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::PRegister pd) {
+    uint32_t Instr = Op;
+
+    Instr |= op << 23;
+    Instr |= S << 22;
+    Instr |= pg.Idx() << 5;
+    Instr |= pd.Idx();
+    dc32(Instr);
+  }
+
+  void SVEPredicateReadFFR(uint32_t Op, uint32_t op, uint32_t S, FEXCore::ARMEmitter::PRegister pd) {
+    uint32_t Instr = Op;
+
+    Instr |= op << 23;
+    Instr |= S << 16;
+    Instr |= pd.Idx();
+    dc32(Instr);
+  }
+
+  void SVEPredicateInit(uint32_t Op, FEXCore::ARMEmitter::SubRegSize size, uint32_t S, FEXCore::ARMEmitter::PredicatePattern pattern, FEXCore::ARMEmitter::PRegister pd) {
+    uint32_t Instr = Op;
+
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= S << 16;
+    Instr |= FEXCore::ToUnderlying(pattern) << 5;
+    Instr |= pd.Idx();
+    dc32(Instr);
+  }
+

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ScalarOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ScalarOps.inl
@@ -1,0 +1,1793 @@
+/* Scalar instruction emitters.
+ *
+ * These contain instruction emitters for scalar ASIMD operations explicitly.
+ * Some of these emitter arguments might seem a bit strange at first glance,
+ * but is because ARM's instruction encodings for these instructions are a hot mess.
+ *
+ * Specifically FP16 was an afterthought for these scalar operations, using a `ScalarRegSize` with
+ * 16-bit wouldn't encode an FP16 instruction because they are a different instruction class instead.
+ *
+ * Most FP16 operations instead have their own freestanding implementation using `HRegister` arguments.
+ *
+ * Meanwhile other FP32 and FP64 instructions will use `ScalarRegSize`, supporting both those sizes.
+ *
+ * For Scalar integer operations, these instructions will mostly support all `ScalarRegSize` operations.
+ * Exceptions to this rule will have asserts in the emitter implementation when misused.
+ *
+ */
+public:
+// Advanced SIMD scalar copy
+  void dup(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Index) {
+    constexpr uint32_t Op = 0b0101'1110'0000'0000'0000'01 << 10;
+    uint32_t imm5 = 0b00000;
+    if (size == ScalarRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 16, "Index too large");
+      imm5 = (Index << 1) | 1;
+    }
+    else if (size == ScalarRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 8, "Index too large");
+      imm5 = (Index << 2) | 0b10;
+    }
+    else if (size == ScalarRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 4, "Index too large");
+      imm5 = (Index << 3) | 0b100;
+    }
+    else if (size == ScalarRegSize::i64Bit) {
+      LOGMAN_THROW_AA_FMT(Index < 2, "Index too large");
+      imm5 = (Index << 4) | 0b1000;
+    }
+
+    ASIMDScalarCopy(Op, 1, imm5, 0b0000, rd, rn);
+  }
+
+  void mov(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Index) {
+    dup(size, rd, rn, Index);
+  }
+
+// Advanced SIMD scalar three same FP16
+  void fmulx(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm) {
+    constexpr uint32_t Op = 0b0101'1110'0100'0000'0000'01 << 10;
+    ASIMDScalarThreeSameFP16(Op, 0, 0, 0b011, rm, rn, rd);
+  }
+  void fcmeq(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm) {
+    constexpr uint32_t Op = 0b0101'1110'0100'0000'0000'01 << 10;
+    ASIMDScalarThreeSameFP16(Op, 0, 0, 0b100, rm, rn, rd);
+  }
+  void frecps(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm) {
+    constexpr uint32_t Op = 0b0101'1110'0100'0000'0000'01 << 10;
+    ASIMDScalarThreeSameFP16(Op, 0, 0, 0b111, rm, rn, rd);
+  }
+  void frsqrts(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm) {
+    constexpr uint32_t Op = 0b0101'1110'0100'0000'0000'01 << 10;
+    ASIMDScalarThreeSameFP16(Op, 0, 1, 0b111, rm, rn, rd);
+  }
+  void fcmge(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm) {
+    constexpr uint32_t Op = 0b0101'1110'0100'0000'0000'01 << 10;
+    ASIMDScalarThreeSameFP16(Op, 1, 0, 0b100, rm, rn, rd);
+  }
+  void facge(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm) {
+    constexpr uint32_t Op = 0b0101'1110'0100'0000'0000'01 << 10;
+    ASIMDScalarThreeSameFP16(Op, 1, 0, 0b101, rm, rn, rd);
+  }
+  void fabd(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm) {
+    constexpr uint32_t Op = 0b0101'1110'0100'0000'0000'01 << 10;
+    ASIMDScalarThreeSameFP16(Op, 1, 1, 0b010, rm, rn, rd);
+  }
+  void fcmgt(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm) {
+    constexpr uint32_t Op = 0b0101'1110'0100'0000'0000'01 << 10;
+    ASIMDScalarThreeSameFP16(Op, 1, 1, 0b100, rm, rn, rd);
+  }
+  void facgt(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm) {
+    constexpr uint32_t Op = 0b0101'1110'0100'0000'0000'01 << 10;
+    ASIMDScalarThreeSameFP16(Op, 1, 1, 0b101, rm, rn, rd);
+  }
+
+// Advanced SIMD scalar two-register miscellaneous FP16
+  void fcvtns(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0101'1110'0111'1000'0000'10 << 10;
+    ASIMDScalarTwoRegMiscFP16(Op, 0, 0, 0b11010, rn, rd);
+  }
+  void fcvtms(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0101'1110'0111'1000'0000'10 << 10;
+    ASIMDScalarTwoRegMiscFP16(Op, 0, 0, 0b11011, rn, rd);
+  }
+  void fcvtas(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0101'1110'0111'1000'0000'10 << 10;
+    ASIMDScalarTwoRegMiscFP16(Op, 0, 0, 0b11100, rn, rd);
+  }
+  void scvtf(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0101'1110'0111'1000'0000'10 << 10;
+    ASIMDScalarTwoRegMiscFP16(Op, 0, 0, 0b11101, rn, rd);
+  }
+  void fcmgt(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0101'1110'0111'1000'0000'10 << 10;
+    ASIMDScalarTwoRegMiscFP16(Op, 0, 1, 0b01100, rn, rd);
+  }
+  void fcmeq(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0101'1110'0111'1000'0000'10 << 10;
+    ASIMDScalarTwoRegMiscFP16(Op, 0, 1, 0b01101, rn, rd);
+  }
+  void fcmlt(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0101'1110'0111'1000'0000'10 << 10;
+    ASIMDScalarTwoRegMiscFP16(Op, 0, 1, 0b01110, rn, rd);
+  }
+  void fcvtps(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0101'1110'0111'1000'0000'10 << 10;
+    ASIMDScalarTwoRegMiscFP16(Op, 0, 1, 0b11010, rn, rd);
+  }
+  void fcvtzs(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0101'1110'0111'1000'0000'10 << 10;
+    ASIMDScalarTwoRegMiscFP16(Op, 0, 1, 0b11011, rn, rd);
+  }
+  void frecpe(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0101'1110'0111'1000'0000'10 << 10;
+    ASIMDScalarTwoRegMiscFP16(Op, 0, 1, 0b11101, rn, rd);
+  }
+  void frecpx(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0101'1110'0111'1000'0000'10 << 10;
+    ASIMDScalarTwoRegMiscFP16(Op, 0, 1, 0b11111, rn, rd);
+  }
+  void fcvtnu(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0101'1110'0111'1000'0000'10 << 10;
+    ASIMDScalarTwoRegMiscFP16(Op, 1, 0, 0b11010, rn, rd);
+  }
+  void fcvtmu(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0101'1110'0111'1000'0000'10 << 10;
+    ASIMDScalarTwoRegMiscFP16(Op, 1, 0, 0b11011, rn, rd);
+  }
+  void fcvtau(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0101'1110'0111'1000'0000'10 << 10;
+    ASIMDScalarTwoRegMiscFP16(Op, 1, 0, 0b11100, rn, rd);
+  }
+  void ucvtf(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0101'1110'0111'1000'0000'10 << 10;
+    ASIMDScalarTwoRegMiscFP16(Op, 1, 0, 0b11101, rn, rd);
+  }
+  void fcmge(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0101'1110'0111'1000'0000'10 << 10;
+    ASIMDScalarTwoRegMiscFP16(Op, 1, 1, 0b01100, rn, rd);
+  }
+  void fcmle(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0101'1110'0111'1000'0000'10 << 10;
+    ASIMDScalarTwoRegMiscFP16(Op, 1, 1, 0b01101, rn, rd);
+  }
+  void fcvtpu(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0101'1110'0111'1000'0000'10 << 10;
+    ASIMDScalarTwoRegMiscFP16(Op, 1, 1, 0b11010, rn, rd);
+  }
+  void fcvtzu(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0101'1110'0111'1000'0000'10 << 10;
+    ASIMDScalarTwoRegMiscFP16(Op, 1, 1, 0b11011, rn, rd);
+  }
+  void frsqrte(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0101'1110'0111'1000'0000'10 << 10;
+    ASIMDScalarTwoRegMiscFP16(Op, 1, 1, 0b11101, rn, rd);
+  }
+
+// Advanced SIMD scalar three same extra
+// XXX:
+// Advanced SIMD scalar two-register miscellaneous
+  void suqadd(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
+
+    ASIMDScalar2RegMisc(Op, 0, size, 0b00011, rd, rn);
+  }
+  void sqabs(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
+
+    ASIMDScalar2RegMisc(Op, 0, size, 0b00111, rd, rn);
+  }
+
+  ///< Comparison against 0.0
+  void cmgt(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::ScalarRegSize::i64Bit, "Only supports 64-bit");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
+
+    ASIMDScalar2RegMisc(Op, 0, size, 0b01000, rd, rn);
+  }
+  ///< Comparison against 0.0
+  void cmeq(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::ScalarRegSize::i64Bit, "Only supports 64-bit");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
+
+    ASIMDScalar2RegMisc(Op, 0, size, 0b01001, rd, rn);
+  }
+
+  ///< Comparison against 0.0
+  void cmlt(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::ScalarRegSize::i64Bit, "Only supports 64-bit");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
+
+    ASIMDScalar2RegMisc(Op, 0, size, 0b01010, rd, rn);
+  }
+  void abs(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::ScalarRegSize::i64Bit, "Only supports 64-bit");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
+
+    ASIMDScalar2RegMisc(Op, 0, size, 0b01011, rd, rn);
+  }
+  ///< size is destination size.
+  void sqxtn(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::ScalarRegSize::i64Bit, "64-bit destination not supported");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
+
+    ASIMDScalar2RegMisc(Op, 0, size, 0b10100, rd, rn);
+  }
+
+  void fcvtns(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
+    const FEXCore::ARMEmitter::ScalarRegSize ConvertedSize =
+      size == ARMEmitter::ScalarRegSize::i64Bit ?
+        ARMEmitter::ScalarRegSize::i16Bit :
+        ARMEmitter::ScalarRegSize::i8Bit;
+
+    ASIMDScalar2RegMisc(Op, 0, ConvertedSize, 0b11010, rd, rn);
+  }
+  void fcvtms(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
+    const FEXCore::ARMEmitter::ScalarRegSize ConvertedSize =
+      size == ARMEmitter::ScalarRegSize::i64Bit ?
+        ARMEmitter::ScalarRegSize::i16Bit :
+        ARMEmitter::ScalarRegSize::i8Bit;
+
+    ASIMDScalar2RegMisc(Op, 0, ConvertedSize, 0b11011, rd, rn);
+  }
+  void fcvtas(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
+    const FEXCore::ARMEmitter::ScalarRegSize ConvertedSize =
+      size == ARMEmitter::ScalarRegSize::i64Bit ?
+        ARMEmitter::ScalarRegSize::i16Bit :
+        ARMEmitter::ScalarRegSize::i8Bit;
+
+    ASIMDScalar2RegMisc(Op, 0, ConvertedSize, 0b11100, rd, rn);
+  }
+  void scvtf(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
+    const FEXCore::ARMEmitter::ScalarRegSize ConvertedSize =
+      size == ARMEmitter::ScalarRegSize::i64Bit ?
+        ARMEmitter::ScalarRegSize::i16Bit :
+        ARMEmitter::ScalarRegSize::i8Bit;
+
+    ASIMDScalar2RegMisc(Op, 0, ConvertedSize, 0b11101, rd, rn);
+  }
+
+  ///< Comparison against 0.0
+  void fcmgt(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float compare");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
+
+    ASIMDScalar2RegMisc(Op, 0, size, 0b01100, rd, rn);
+  }
+  ///< Comparison against 0.0
+  void fcmeq(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float compare");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
+
+    ASIMDScalar2RegMisc(Op, 0, size, 0b01101, rd, rn);
+  }
+  ///< Comparison against 0.0
+  void fcmlt(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float compare");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
+
+    ASIMDScalar2RegMisc(Op, 0, size, 0b01110, rd, rn);
+  }
+  void fcvtps(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
+
+    ASIMDScalar2RegMisc(Op, 0, size, 0b11010, rd, rn);
+  }
+  void fcvtzs(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
+
+    ASIMDScalar2RegMisc(Op, 0, size, 0b11011, rd, rn);
+  }
+  void frecpe(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
+
+    ASIMDScalar2RegMisc(Op, 0, size, 0b11101, rd, rn);
+  }
+  void frecpx(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
+
+    ASIMDScalar2RegMisc(Op, 0, size, 0b11111, rd, rn);
+  }
+  void usqadd(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
+
+    ASIMDScalar2RegMisc(Op, 1, size, 0b00011, rd, rn);
+  }
+  void sqneg(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
+
+    ASIMDScalar2RegMisc(Op, 1, size, 0b00111, rd, rn);
+  }
+  ///< Comparison against 0.0
+  void cmge(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::ScalarRegSize::i64Bit, "Only supports 64-bit");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
+
+    ASIMDScalar2RegMisc(Op, 1, size, 0b01000, rd, rn);
+  }
+  ///< Comparison against 0.0
+  void cmle(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::ScalarRegSize::i64Bit, "Only supports 64-bit");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
+
+    ASIMDScalar2RegMisc(Op, 1, size, 0b01001, rd, rn);
+  }
+  void neg(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::ScalarRegSize::i64Bit, "Only supports 64-bit");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
+
+    ASIMDScalar2RegMisc(Op, 1, size, 0b01011, rd, rn);
+  }
+  ///< size is destination.
+  void sqxtun(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::ScalarRegSize::i64Bit, "64-bit destination not supported");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
+
+    ASIMDScalar2RegMisc(Op, 1, size, 0b10010, rd, rn);
+  }
+  ///< size is destination.
+  void uqxtn(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::ScalarRegSize::i64Bit, "64-bit destination not supported");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
+
+    ASIMDScalar2RegMisc(Op, 1, size, 0b10100, rd, rn);
+  }
+  ///< size is destination.
+  void fcvtxn(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
+    ASIMDScalar2RegMisc(Op, 1, ARMEmitter::ScalarRegSize::i16Bit, 0b10110, rd, rn);
+  }
+  void fcvtnu(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
+    const FEXCore::ARMEmitter::ScalarRegSize ConvertedSize =
+      size == ARMEmitter::ScalarRegSize::i64Bit ?
+        ARMEmitter::ScalarRegSize::i16Bit :
+        ARMEmitter::ScalarRegSize::i8Bit;
+
+    ASIMDScalar2RegMisc(Op, 1, ConvertedSize, 0b11010, rd, rn);
+  }
+  void fcvtmu(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
+    const FEXCore::ARMEmitter::ScalarRegSize ConvertedSize =
+      size == ARMEmitter::ScalarRegSize::i64Bit ?
+        ARMEmitter::ScalarRegSize::i16Bit :
+        ARMEmitter::ScalarRegSize::i8Bit;
+
+    ASIMDScalar2RegMisc(Op, 1, ConvertedSize, 0b11011, rd, rn);
+  }
+  void fcvtau(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
+    const FEXCore::ARMEmitter::ScalarRegSize ConvertedSize =
+      size == ARMEmitter::ScalarRegSize::i64Bit ?
+        ARMEmitter::ScalarRegSize::i16Bit :
+        ARMEmitter::ScalarRegSize::i8Bit;
+
+    ASIMDScalar2RegMisc(Op, 1, ConvertedSize, 0b11100, rd, rn);
+  }
+  void ucvtf(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
+    const FEXCore::ARMEmitter::ScalarRegSize ConvertedSize =
+      size == ARMEmitter::ScalarRegSize::i64Bit ?
+        ARMEmitter::ScalarRegSize::i16Bit :
+        ARMEmitter::ScalarRegSize::i8Bit;
+
+    ASIMDScalar2RegMisc(Op, 1, ConvertedSize, 0b11101, rd, rn);
+  }
+  ///< Comparison against 0.0
+  void fcmge(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
+
+    ASIMDScalar2RegMisc(Op, 1, size, 0b01100, rd, rn);
+  }
+  ///< Comparison against 0.0
+  void fcmle(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
+
+    ASIMDScalar2RegMisc(Op, 1, size, 0b01101, rd, rn);
+  }
+  void fcvtpu(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
+
+    ASIMDScalar2RegMisc(Op, 1, size, 0b11010, rd, rn);
+  }
+  void fcvtzu(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
+
+    ASIMDScalar2RegMisc(Op, 1, size, 0b11011, rd, rn);
+  }
+  void frsqrte(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
+
+    ASIMDScalar2RegMisc(Op, 1, size, 0b11101, rd, rn);
+  }
+  // Advanced SIMD scalar pairwise
+  void addp(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for addp");
+    constexpr uint32_t Op = 0b0101'1110'0011'0000'0000'10 << 10;
+
+    ASIMDScalar2RegMisc(Op, 0, size, 0b11011, rd, rn);
+  }
+
+  void fmaxnmp(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0101'1110'0011'0000'0000'10 << 10;
+    ASIMDScalar2RegMisc(Op, 0, ARMEmitter::ScalarRegSize::i8Bit, 0b01100, rd.V(), rn.V());
+  }
+  void faddp(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0101'1110'0011'0000'0000'10 << 10;
+    ASIMDScalar2RegMisc(Op, 0, ARMEmitter::ScalarRegSize::i8Bit, 0b01101, rd.V(), rn.V());
+  }
+  void fmaxp(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0101'1110'0011'0000'0000'10 << 10;
+    ASIMDScalar2RegMisc(Op, 0, ARMEmitter::ScalarRegSize::i8Bit, 0b01111, rd.V(), rn.V());
+  }
+  void fminnmp(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0101'1110'0011'0000'0000'10 << 10;
+    ASIMDScalar2RegMisc(Op, 0, ARMEmitter::ScalarRegSize::i32Bit, 0b01100, rd.V(), rn.V());
+  }
+  void fminp(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0101'1110'0011'0000'0000'10 << 10;
+    ASIMDScalar2RegMisc(Op, 0, ARMEmitter::ScalarRegSize::i32Bit, 0b01111, rd.V(), rn.V());
+  }
+
+  void fmaxnmp(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    constexpr uint32_t Op = 0b0101'1110'0011'0000'0000'10 << 10;
+    const FEXCore::ARMEmitter::ScalarRegSize ConvertedSize =
+      size == ARMEmitter::ScalarRegSize::i64Bit ?
+        ARMEmitter::ScalarRegSize::i16Bit :
+        ARMEmitter::ScalarRegSize::i8Bit;
+
+    ASIMDScalar2RegMisc(Op, 1, ConvertedSize, 0b01100, rd, rn);
+  }
+  void faddp(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    constexpr uint32_t Op = 0b0101'1110'0011'0000'0000'10 << 10;
+    const FEXCore::ARMEmitter::ScalarRegSize ConvertedSize =
+      size == ARMEmitter::ScalarRegSize::i64Bit ?
+        ARMEmitter::ScalarRegSize::i16Bit :
+        ARMEmitter::ScalarRegSize::i8Bit;
+
+    ASIMDScalar2RegMisc(Op, 1, ConvertedSize, 0b01101, rd, rn);
+  }
+  void fmaxp(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    constexpr uint32_t Op = 0b0101'1110'0011'0000'0000'10 << 10;
+    const FEXCore::ARMEmitter::ScalarRegSize ConvertedSize =
+      size == ARMEmitter::ScalarRegSize::i64Bit ?
+        ARMEmitter::ScalarRegSize::i16Bit :
+        ARMEmitter::ScalarRegSize::i8Bit;
+
+    ASIMDScalar2RegMisc(Op, 1, ConvertedSize, 0b01111, rd, rn);
+  }
+  void fminnmp(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    constexpr uint32_t Op = 0b0101'1110'0011'0000'0000'10 << 10;
+    ASIMDScalar2RegMisc(Op, 1, size, 0b01100, rd, rn);
+  }
+  void fminp(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    constexpr uint32_t Op = 0b0101'1110'0011'0000'0000'10 << 10;
+    ASIMDScalar2RegMisc(Op, 1, size, 0b01111, rd, rn);
+  }
+// Advanced SIMD scalar three different
+  ///< size is destination.
+  void sqdmlal(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'00 << 10;
+    const FEXCore::ARMEmitter::ScalarRegSize ConvertedSize =
+      size == ARMEmitter::ScalarRegSize::i64Bit ?
+        ARMEmitter::ScalarRegSize::i32Bit :
+        ARMEmitter::ScalarRegSize::i16Bit;
+    ASIMD3RegDifferent(Op, 0, ConvertedSize, 0b1001, rd, rn, rm);
+  }
+  ///< size is destination.
+  void sqdmlsl(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'00 << 10;
+    const FEXCore::ARMEmitter::ScalarRegSize ConvertedSize =
+      size == ARMEmitter::ScalarRegSize::i64Bit ?
+        ARMEmitter::ScalarRegSize::i32Bit :
+        ARMEmitter::ScalarRegSize::i16Bit;
+    ASIMD3RegDifferent(Op, 0, ConvertedSize, 0b1011, rd, rn, rm);
+  }
+
+  ///< size is destination.
+  void sqdmull(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'00 << 10;
+    const FEXCore::ARMEmitter::ScalarRegSize ConvertedSize =
+      size == ARMEmitter::ScalarRegSize::i64Bit ?
+        ARMEmitter::ScalarRegSize::i32Bit :
+        ARMEmitter::ScalarRegSize::i16Bit;
+    ASIMD3RegDifferent(Op, 0, ConvertedSize, 0b1101, rd, rn, rm);
+  }
+// Advanced SIMD scalar three same
+  void sqadd(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
+    ASIMD3RegSame(Op, 0, size, 0b00001, rd, rn, rm);
+  }
+  void sqsub(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
+    ASIMD3RegSame(Op, 0, size, 0b00101, rd, rn, rm);
+  }
+  void cmgt(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::ScalarRegSize::i64Bit, "Only supports 64-bit");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
+    ASIMD3RegSame(Op, 0, size, 0b00110, rd, rn, rm);
+  }
+  void cmge(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::ScalarRegSize::i64Bit, "Only supports 64-bit");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
+    ASIMD3RegSame(Op, 0, size, 0b00111, rd, rn, rm);
+  }
+  void sshl(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::ScalarRegSize::i64Bit, "Only supports 64-bit");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
+    ASIMD3RegSame(Op, 0, size, 0b01000, rd, rn, rm);
+  }
+  void sqshl(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
+    ASIMD3RegSame(Op, 0, size, 0b01001, rd, rn, rm);
+  }
+  void srshl(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::ScalarRegSize::i64Bit, "Only supports 64-bit");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
+    ASIMD3RegSame(Op, 0, size, 0b01010, rd, rn, rm);
+  }
+  void sqrshl(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
+    ASIMD3RegSame(Op, 0, size, 0b01011, rd, rn, rm);
+  }
+  void add(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::ScalarRegSize::i64Bit, "Only supports 64-bit");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
+    ASIMD3RegSame(Op, 0, size, 0b10000, rd, rn, rm);
+  }
+  void cmtst(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::ScalarRegSize::i64Bit, "Only supports 64-bit");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
+    ASIMD3RegSame(Op, 0, size, 0b10001, rd, rn, rm);
+  }
+  void sqdmulh(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i32Bit || size == ARMEmitter::ScalarRegSize::i16Bit, "Invalid size");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
+    ASIMD3RegSame(Op, 0, size, 0b10110, rd, rn, rm);
+  }
+  void fmulx(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
+    const FEXCore::ARMEmitter::ScalarRegSize ConvertedSize =
+      size == ARMEmitter::ScalarRegSize::i64Bit ?
+        ARMEmitter::ScalarRegSize::i16Bit :
+        ARMEmitter::ScalarRegSize::i8Bit;
+
+    ASIMD3RegSame(Op, 0, ConvertedSize, 0b11011, rd, rn, rm);
+  }
+  void fcmeq(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
+    const FEXCore::ARMEmitter::ScalarRegSize ConvertedSize =
+      size == ARMEmitter::ScalarRegSize::i64Bit ?
+        ARMEmitter::ScalarRegSize::i16Bit :
+        ARMEmitter::ScalarRegSize::i8Bit;
+
+    ASIMD3RegSame(Op, 0, ConvertedSize, 0b11100, rd, rn, rm);
+  }
+  void frecps(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
+    const FEXCore::ARMEmitter::ScalarRegSize ConvertedSize =
+      size == ARMEmitter::ScalarRegSize::i64Bit ?
+        ARMEmitter::ScalarRegSize::i16Bit :
+        ARMEmitter::ScalarRegSize::i8Bit;
+
+    ASIMD3RegSame(Op, 0, ConvertedSize, 0b11111, rd, rn, rm);
+  }
+  void frsqrts(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
+    ASIMD3RegSame(Op, 0, size, 0b11111, rd, rn, rm);
+  }
+  void uqadd(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
+    ASIMD3RegSame(Op, 1, size, 0b00001, rd, rn, rm);
+  }
+  void uqsub(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
+    ASIMD3RegSame(Op, 1, size, 0b00101, rd, rn, rm);
+  }
+  void cmhi(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::ScalarRegSize::i64Bit, "Only supports 64-bit");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
+    ASIMD3RegSame(Op, 1, size, 0b00110, rd, rn, rm);
+  }
+  void cmhs(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::ScalarRegSize::i64Bit, "Only supports 64-bit");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
+    ASIMD3RegSame(Op, 1, size, 0b00111, rd, rn, rm);
+  }
+  void ushl(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::ScalarRegSize::i64Bit, "Only supports 64-bit");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
+    ASIMD3RegSame(Op, 1, size, 0b01000, rd, rn, rm);
+  }
+  void uqshl(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
+    ASIMD3RegSame(Op, 1, size, 0b01001, rd, rn, rm);
+  }
+  void urshl(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::ScalarRegSize::i64Bit, "Only supports 64-bit");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
+    ASIMD3RegSame(Op, 1, size, 0b01010, rd, rn, rm);
+  }
+  void uqrshl(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
+    ASIMD3RegSame(Op, 1, size, 0b01011, rd, rn, rm);
+  }
+  void sub(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::ScalarRegSize::i64Bit, "Only supports 64-bit");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
+    ASIMD3RegSame(Op, 1, size, 0b10000, rd, rn, rm);
+  }
+  void cmeq(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::ScalarRegSize::i64Bit, "Only supports 64-bit");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
+    ASIMD3RegSame(Op, 1, size, 0b10001, rd, rn, rm);
+  }
+  void sqrdmulh(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i32Bit || size == ARMEmitter::ScalarRegSize::i16Bit, "Invalid size");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
+    ASIMD3RegSame(Op, 1, size, 0b10110, rd, rn, rm);
+  }
+  void fcmge(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
+    const FEXCore::ARMEmitter::ScalarRegSize ConvertedSize =
+      size == ARMEmitter::ScalarRegSize::i64Bit ?
+        ARMEmitter::ScalarRegSize::i16Bit :
+        ARMEmitter::ScalarRegSize::i8Bit;
+
+    ASIMD3RegSame(Op, 1, ConvertedSize, 0b11100, rd, rn, rm);
+  }
+  void facge(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
+    const FEXCore::ARMEmitter::ScalarRegSize ConvertedSize =
+      size == ARMEmitter::ScalarRegSize::i64Bit ?
+        ARMEmitter::ScalarRegSize::i16Bit :
+        ARMEmitter::ScalarRegSize::i8Bit;
+
+    ASIMD3RegSame(Op, 1, ConvertedSize, 0b11101, rd, rn, rm);
+  }
+  void fabd(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
+    ASIMD3RegSame(Op, 1, size, 0b11010, rd, rn, rm);
+  }
+  void fcmgt(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
+    ASIMD3RegSame(Op, 1, size, 0b11100, rd, rn, rm);
+  }
+  void facgt(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
+    ASIMD3RegSame(Op, 1, size, 0b11101, rd, rn, rm);
+  }
+// Advanced SIMD scalar shift by immediate
+  void sshr(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(Shift > 0 && Shift < 64, "Invalid shift for sshr");
+    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sshr");
+    constexpr uint32_t Op = 0b0101'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = ScalarRegSizeInBits(size);
+    // Shift encoded in immh:immb, but inverted with 128-bit source
+    // shift = (esize * 2) - immh:immb
+    const uint32_t InvertedShift = (SubregSizeInBits * 2) - Shift;
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+    ASIMDScalarShiftByImm(Op, 0, immh, immb, 0b00000, rd, rn);
+  }
+  void ssra(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(Shift > 0 && Shift < 64, "Invalid shift for sshr");
+    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sshr");
+    constexpr uint32_t Op = 0b0101'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = ScalarRegSizeInBits(size);
+    // Shift encoded in immh:immb, but inverted with 128-bit source
+    // shift = (esize * 2) - immh:immb
+    const uint32_t InvertedShift = (SubregSizeInBits * 2) - Shift;
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+    ASIMDScalarShiftByImm(Op, 0, immh, immb, 0b00010, rd, rn);
+  }
+  void srshr(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(Shift > 0 && Shift < 64, "Invalid shift for sshr");
+    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sshr");
+    constexpr uint32_t Op = 0b0101'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = ScalarRegSizeInBits(size);
+    // Shift encoded in immh:immb, but inverted with 128-bit source
+    // shift = (esize * 2) - immh:immb
+    const uint32_t InvertedShift = (SubregSizeInBits * 2) - Shift;
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+    ASIMDScalarShiftByImm(Op, 0, immh, immb, 0b00100, rd, rn);
+  }
+  void srsra(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(Shift > 0 && Shift < 64, "Invalid shift for sshr");
+    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sshr");
+    constexpr uint32_t Op = 0b0101'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = ScalarRegSizeInBits(size);
+    // Shift encoded in immh:immb, but inverted with 128-bit source
+    // shift = (esize * 2) - immh:immb
+    const uint32_t InvertedShift = (SubregSizeInBits * 2) - Shift;
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+    ASIMDScalarShiftByImm(Op, 0, immh, immb, 0b00110, rd, rn);
+  }
+  void shl(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(Shift > 0 && Shift < 64, "Invalid shift for sshr");
+    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sshr");
+    constexpr uint32_t Op = 0b0101'1111'0000'0000'0000'01 << 10;
+    // Shift encoded a bit weirdly.
+    // shift = immh:immb - elementsize but immh is /also/ used for element size.
+    const uint32_t immh = 1 << FEXCore::ToUnderlying(size) | (Shift >> 3);
+    const uint32_t immb = Shift & 0b111;
+    ASIMDScalarShiftByImm(Op, 0, immh, immb, 0b01010, rd, rn);
+  }
+  void sqshl(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Shift) {
+    LOGMAN_THROW_A_FMT(Shift > 0 && Shift < ScalarRegSizeInBits(size), "Invalid shift for sshr");
+    constexpr uint32_t Op = 0b0101'1111'0000'0000'0000'01 << 10;
+    // Shift encoded a bit weirdly.
+    // shift = immh:immb - elementsize but immh is /also/ used for element size.
+    const uint32_t immh = 1 << FEXCore::ToUnderlying(size) | (Shift >> 3);
+    const uint32_t immb = Shift & 0b111;
+    ASIMDScalarShiftByImm(Op, 0, immh, immb, 0b01110, rd, rn);
+  }
+  ///< size is destination
+  void sqshrn(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Shift) {
+    LOGMAN_THROW_A_FMT(Shift > 0 && Shift < ScalarRegSizeInBits(size), "Invalid shift for sshr");
+    LOGMAN_THROW_AA_FMT(size != ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sqshrn");
+    constexpr uint32_t Op = 0b0101'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = ScalarRegSizeInBits(size);
+    // Shift encoded in immh:immb, but inverted with 128-bit source
+    // shift = (esize * 2) - immh:immb
+    const uint32_t InvertedShift = (SubregSizeInBits * 2) - Shift;
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+    ASIMDScalarShiftByImm(Op, 0, immh, immb, 0b10010, rd, rn);
+  }
+  void sqrshrn(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Shift) {
+    LOGMAN_THROW_A_FMT(Shift > 0 && Shift < ScalarRegSizeInBits(size), "Invalid shift for sshr");
+    LOGMAN_THROW_AA_FMT(size != ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sqshrn");
+    constexpr uint32_t Op = 0b0101'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = ScalarRegSizeInBits(size);
+    // Shift encoded in immh:immb, but inverted with 128-bit source
+    // shift = (esize * 2) - immh:immb
+    const uint32_t InvertedShift = (SubregSizeInBits * 2) - Shift;
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+    ASIMDScalarShiftByImm(Op, 0, immh, immb, 0b10011, rd, rn);
+  }
+  // TODO: SCVTF, FCVTZS
+  void ushr(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(Shift > 0 && Shift < 64, "Invalid shift for sshr");
+    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sshr");
+    constexpr uint32_t Op = 0b0101'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = ScalarRegSizeInBits(size);
+    // Shift encoded in immh:immb, but inverted with 128-bit source
+    // shift = (esize * 2) - immh:immb
+    const uint32_t InvertedShift = (SubregSizeInBits * 2) - Shift;
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+    ASIMDScalarShiftByImm(Op, 1, immh, immb, 0b00000, rd, rn);
+  }
+  void usra(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(Shift > 0 && Shift < 64, "Invalid shift for sshr");
+    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sshr");
+    constexpr uint32_t Op = 0b0101'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = ScalarRegSizeInBits(size);
+    // Shift encoded in immh:immb, but inverted with 128-bit source
+    // shift = (esize * 2) - immh:immb
+    const uint32_t InvertedShift = (SubregSizeInBits * 2) - Shift;
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+    ASIMDScalarShiftByImm(Op, 1, immh, immb, 0b00010, rd, rn);
+  }
+  void urshr(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(Shift > 0 && Shift < 64, "Invalid shift for sshr");
+    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sshr");
+    constexpr uint32_t Op = 0b0101'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = ScalarRegSizeInBits(size);
+    // Shift encoded in immh:immb, but inverted with 128-bit source
+    // shift = (esize * 2) - immh:immb
+    const uint32_t InvertedShift = (SubregSizeInBits * 2) - Shift;
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+    ASIMDScalarShiftByImm(Op, 1, immh, immb, 0b00100, rd, rn);
+  }
+  void ursra(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(Shift > 0 && Shift < 64, "Invalid shift for sshr");
+    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sshr");
+    constexpr uint32_t Op = 0b0101'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = ScalarRegSizeInBits(size);
+    // Shift encoded in immh:immb, but inverted with 128-bit source
+    // shift = (esize * 2) - immh:immb
+    const uint32_t InvertedShift = (SubregSizeInBits * 2) - Shift;
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+    ASIMDScalarShiftByImm(Op, 1, immh, immb, 0b00110, rd, rn);
+  }
+  void sri(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(Shift > 0 && Shift < 64, "Invalid shift for sshr");
+    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sshr");
+    constexpr uint32_t Op = 0b0101'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = ScalarRegSizeInBits(size);
+    // Shift encoded in immh:immb, but inverted with 128-bit source
+    // shift = (esize * 2) - immh:immb
+    const uint32_t InvertedShift = (SubregSizeInBits * 2) - Shift;
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+    ASIMDScalarShiftByImm(Op, 1, immh, immb, 0b01000, rd, rn);
+  }
+  void sli(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Shift) {
+    LOGMAN_THROW_AA_FMT(Shift > 0 && Shift < 64, "Invalid shift for sshr");
+    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sshr");
+    constexpr uint32_t Op = 0b0101'1111'0000'0000'0000'01 << 10;
+    // Shift encoded a bit weirdly.
+    // shift = immh:immb - elementsize but immh is /also/ used for element size.
+    const uint32_t immh = 1 << FEXCore::ToUnderlying(size) | (Shift >> 3);
+    const uint32_t immb = Shift & 0b111;
+    ASIMDScalarShiftByImm(Op, 1, immh, immb, 0b01010, rd, rn);
+  }
+  void sqshlu(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Shift) {
+    LOGMAN_THROW_A_FMT(Shift > 0 && Shift < ScalarRegSizeInBits(size), "Invalid shift for sshr");
+    constexpr uint32_t Op = 0b0101'1111'0000'0000'0000'01 << 10;
+    // Shift encoded a bit weirdly.
+    // shift = immh:immb - elementsize but immh is /also/ used for element size.
+    const uint32_t immh = 1 << FEXCore::ToUnderlying(size) | (Shift >> 3);
+    const uint32_t immb = Shift & 0b111;
+    ASIMDScalarShiftByImm(Op, 1, immh, immb, 0b01100, rd, rn);
+  }
+  void uqshl(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Shift) {
+    LOGMAN_THROW_A_FMT(Shift > 0 && Shift < ScalarRegSizeInBits(size), "Invalid shift for sshr");
+    constexpr uint32_t Op = 0b0101'1111'0000'0000'0000'01 << 10;
+    // Shift encoded a bit weirdly.
+    // shift = immh:immb - elementsize but immh is /also/ used for element size.
+    const uint32_t immh = 1 << FEXCore::ToUnderlying(size) | (Shift >> 3);
+    const uint32_t immb = Shift & 0b111;
+    ASIMDScalarShiftByImm(Op, 1, immh, immb, 0b01110, rd, rn);
+  }
+  ///< size is destination.
+  void sqshrun(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Shift) {
+    LOGMAN_THROW_A_FMT(Shift > 0 && Shift < ScalarRegSizeInBits(size), "Invalid shift for sshr");
+    LOGMAN_THROW_AA_FMT(size != ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sqshrun");
+    constexpr uint32_t Op = 0b0101'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = ScalarRegSizeInBits(size);
+    // Shift encoded in immh:immb, but inverted with 128-bit source
+    // shift = (esize * 2) - immh:immb
+    const uint32_t InvertedShift = (SubregSizeInBits * 2) - Shift;
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+    ASIMDScalarShiftByImm(Op, 1, immh, immb, 0b10000, rd, rn);
+  }
+  ///< size is destination.
+  void sqrshrun(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Shift) {
+    LOGMAN_THROW_A_FMT(Shift > 0 && Shift < ScalarRegSizeInBits(size), "Invalid shift for sshr");
+    LOGMAN_THROW_AA_FMT(size != ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sqrshrun");
+    constexpr uint32_t Op = 0b0101'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = ScalarRegSizeInBits(size);
+    // Shift encoded in immh:immb, but inverted with 128-bit source
+    // shift = (esize * 2) - immh:immb
+    const uint32_t InvertedShift = (SubregSizeInBits * 2) - Shift;
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+    ASIMDScalarShiftByImm(Op, 1, immh, immb, 0b10001, rd, rn);
+  }
+  ///< size is destination.
+  void uqshrn(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Shift) {
+    LOGMAN_THROW_A_FMT(Shift > 0 && Shift < ScalarRegSizeInBits(size), "Invalid shift for sshr");
+    LOGMAN_THROW_AA_FMT(size != ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sqrshrun");
+    constexpr uint32_t Op = 0b0101'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = ScalarRegSizeInBits(size);
+    // Shift encoded in immh:immb, but inverted with 128-bit source
+    // shift = (esize * 2) - immh:immb
+    const uint32_t InvertedShift = (SubregSizeInBits * 2) - Shift;
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+    ASIMDScalarShiftByImm(Op, 1, immh, immb, 0b10010, rd, rn);
+  }
+  ///< size is destination.
+  void uqrshrn(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Shift) {
+    LOGMAN_THROW_A_FMT(Shift > 0 && Shift < ScalarRegSizeInBits(size), "Invalid shift for sshr");
+    LOGMAN_THROW_AA_FMT(size != ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sqrshrun");
+    constexpr uint32_t Op = 0b0101'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = ScalarRegSizeInBits(size);
+    // Shift encoded in immh:immb, but inverted with 128-bit source
+    // shift = (esize * 2) - immh:immb
+    const uint32_t InvertedShift = (SubregSizeInBits * 2) - Shift;
+    const uint32_t immh = InvertedShift >> 3;
+    const uint32_t immb = InvertedShift & 0b111;
+    ASIMDScalarShiftByImm(Op, 1, immh, immb, 0b10011, rd, rn);
+  }
+  // TODO: UCVTF, FCVTZU
+// Advanced SIMD scalar x indexed element
+// XXX:
+//
+// Floating-point data-processing (1 source)
+  void fmov(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b00, 0b000000, rd.V(), rn.V());
+  }
+  void fabs(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b00, 0b000001, rd.V(), rn.V());
+  }
+  void fneg(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b00, 0b000010, rd.V(), rn.V());
+  }
+  void fsqrt(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b00, 0b000011, rd.V(), rn.V());
+  }
+  void fcvt(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::SRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b00, 0b000101, rd.V(), rn.V());
+  }
+  void fcvt(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::SRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b00, 0b000111, rd.V(), rn.V());
+  }
+  void frintn(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b00, 0b001000, rd.V(), rn.V());
+  }
+  void frintp(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b00, 0b001001, rd.V(), rn.V());
+  }
+  void frintm(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b00, 0b001010, rd.V(), rn.V());
+  }
+  void frintz(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b00, 0b001011, rd.V(), rn.V());
+  }
+  void frinta(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b00, 0b001100, rd.V(), rn.V());
+  }
+  void frintx(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b00, 0b001110, rd.V(), rn.V());
+  }
+  void frinti(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b00, 0b001111, rd.V(), rn.V());
+  }
+  void frint32z(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b00, 0b010000, rd.V(), rn.V());
+  }
+  void frint32x(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b00, 0b010001, rd.V(), rn.V());
+  }
+  void frint64z(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b00, 0b010010, rd.V(), rn.V());
+  }
+  void frint64x(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b00, 0b010011, rd.V(), rn.V());
+  }
+
+  void fmov(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b01, 0b000000, rd.V(), rn.V());
+  }
+  void fabs(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b01, 0b000001, rd.V(), rn.V());
+  }
+  void fneg(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b01, 0b000010, rd.V(), rn.V());
+  }
+  void fsqrt(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b01, 0b000011, rd.V(), rn.V());
+  }
+  void fcvt(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::DRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b01, 0b000100, rd.V(), rn.V());
+  }
+  void bfcvt(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::SRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b01, 0b000110, rd.V(), rn.V());
+  }
+  void fcvt(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::DRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b01, 0b000111, rd.V(), rn.V());
+  }
+  void frintn(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b01, 0b001000, rd.V(), rn.V());
+  }
+  void frintp(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b01, 0b001001, rd.V(), rn.V());
+  }
+  void frintm(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b01, 0b001010, rd.V(), rn.V());
+  }
+  void frintz(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b01, 0b001011, rd.V(), rn.V());
+  }
+  void frinta(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b01, 0b001100, rd.V(), rn.V());
+  }
+  void frintx(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b01, 0b001110, rd.V(), rn.V());
+  }
+  void frinti(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b01, 0b001111, rd.V(), rn.V());
+  }
+  void frint32z(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b01, 0b010000, rd.V(), rn.V());
+  }
+  void frint32x(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b01, 0b010001, rd.V(), rn.V());
+  }
+  void frint64z(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b01, 0b010010, rd.V(), rn.V());
+  }
+  void frint64x(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b01, 0b010011, rd.V(), rn.V());
+  }
+
+  void fmov(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b11, 0b000000, rd.V(), rn.V());
+  }
+  void fabs(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b11, 0b000001, rd.V(), rn.V());
+  }
+  void fneg(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b11, 0b000010, rd.V(), rn.V());
+  }
+  void fsqrt(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b11, 0b000011, rd.V(), rn.V());
+  }
+  void fcvt(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b11, 0b000100, rd.V(), rn.V());
+  }
+  void fcvt(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b11, 0b000101, rd.V(), rn.V());
+  }
+  void frintn(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b11, 0b001000, rd.V(), rn.V());
+  }
+  void frintp(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b11, 0b001001, rd.V(), rn.V());
+  }
+  void frintm(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b11, 0b001010, rd.V(), rn.V());
+  }
+  void frintz(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b11, 0b001011, rd.V(), rn.V());
+  }
+  void frinta(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b11, 0b001100, rd.V(), rn.V());
+  }
+  void frintx(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b11, 0b001110, rd.V(), rn.V());
+  }
+  void frinti(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b100'00 << 10;
+
+    Float1Source(Op, 0, 0, 0b11, 0b001111, rd.V(), rn.V());
+  }
+
+// Floating-point compare
+  void fcmp(FEXCore::ARMEmitter::ScalarRegSize Size, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    LOGMAN_THROW_AA_FMT(Size != FEXCore::ARMEmitter::ScalarRegSize::i8Bit, "8-bit destination not supported");
+
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b1000 << 10;
+    const auto ConvertedSize =
+      Size == ARMEmitter::ScalarRegSize::i64Bit ? 0b01 :
+      Size == ARMEmitter::ScalarRegSize::i32Bit ? 0b00 :
+      Size == ARMEmitter::ScalarRegSize::i16Bit ? 0b11 : 0;
+
+    FloatCompare(Op, 0, 0, ConvertedSize, 0b00, 0b00000, rn, rm);
+  }
+
+  void fcmp(FEXCore::ARMEmitter::SRegister rn, FEXCore::ARMEmitter::SRegister rm) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b1000 << 10;
+    FloatCompare(Op, 0, 0, 0b00, 0b00, 0b00000, rn.V(), rm.V());
+  }
+  ///< Compare to #0.0
+  void fcmp(FEXCore::ARMEmitter::SRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b1000 << 10;
+    FloatCompare(Op, 0, 0, 0b00, 0b00, 0b01000, rn.V(), FEXCore::ARMEmitter::VReg::v0);
+  }
+  void fcmpe(FEXCore::ARMEmitter::SRegister rn, FEXCore::ARMEmitter::SRegister rm) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b1000 << 10;
+    FloatCompare(Op, 0, 0, 0b00, 0b00, 0b10000, rn.V(), rm.V());
+  }
+
+  ///< Compare to #0.0
+  void fcmpe(FEXCore::ARMEmitter::SRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b1000 << 10;
+    FloatCompare(Op, 0, 0, 0b00, 0b00, 0b11000, rn.V(), FEXCore::ARMEmitter::VReg::v0);
+  }
+  void fcmp(FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b1000 << 10;
+    FloatCompare(Op, 0, 0, 0b01, 0b00, 0b00000, rn.V(), rm.V());
+  }
+
+  ///< Compare to #0.0
+  void fcmp(FEXCore::ARMEmitter::DRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b1000 << 10;
+    FloatCompare(Op, 0, 0, 0b01, 0b00, 0b01000, rn.V(), FEXCore::ARMEmitter::VReg::v0);
+  }
+  void fcmpe(FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b1000 << 10;
+    FloatCompare(Op, 0, 0, 0b01, 0b00, 0b10000, rn.V(), rm.V());
+  }
+
+  ///< Compare to #0.0
+  void fcmpe(FEXCore::ARMEmitter::DRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b1000 << 10;
+    FloatCompare(Op, 0, 0, 0b01, 0b00, 0b11000, rn.V(), FEXCore::ARMEmitter::VReg::v0);
+  }
+  void fcmp(FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b1000 << 10;
+    FloatCompare(Op, 0, 0, 0b11, 0b00, 0b00000, rn.V(), rm.V());
+  }
+
+  ///< Compare to #0.0
+  void fcmp(FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b1000 << 10;
+    FloatCompare(Op, 0, 0, 0b11, 0b00, 0b01000, rn.V(), FEXCore::ARMEmitter::VReg::v0);
+  }
+  void fcmpe(FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b1000 << 10;
+    FloatCompare(Op, 0, 0, 0b11, 0b00, 0b10000, rn.V(), rm.V());
+  }
+
+  ///< Compare to #0.0
+  void fcmpe(FEXCore::ARMEmitter::HRegister rn) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b1000 << 10;
+    FloatCompare(Op, 0, 0, 0b11, 0b00, 0b11000, rn.V(), FEXCore::ARMEmitter::VReg::v0);
+  }
+
+// Floating-point immediate
+  void fmov(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, float Value) {
+    uint32_t M = 0;
+    uint32_t S = 0;
+    uint32_t ptype;
+    uint32_t imm8;
+    uint32_t imm5 = 0b0'0000;
+    if (size == FEXCore::ARMEmitter::ScalarRegSize::i16Bit) {
+      ptype = 0b11;
+      LOGMAN_THROW_A_FMT(vixl::aarch64::Assembler::IsImmFP16(vixl::Float16(Value)), "Invalid float");
+      imm8 = vixl::VFP::FP16ToImm8(vixl::Float16(Value));
+    }
+    else if (size == FEXCore::ARMEmitter::ScalarRegSize::i32Bit) {
+      ptype = 0b00;
+      LOGMAN_THROW_A_FMT(vixl::VFP::IsImmFP32(Value), "Invalid float");
+      imm8 = vixl::VFP::FP32ToImm8(Value);
+    }
+    else if (size == FEXCore::ARMEmitter::ScalarRegSize::i64Bit) {
+      ptype = 0b01;
+      LOGMAN_THROW_A_FMT(vixl::VFP::IsImmFP64(Value), "Invalid float");
+      imm8 = vixl::VFP::FP64ToImm8(Value);
+    }
+    else {
+      FEX_UNREACHABLE;
+    }
+
+    FloatScalarImmediate(M, S, ptype, imm8, imm5, rd);
+  }
+
+  void FloatScalarImmediate(uint32_t M, uint32_t S, uint32_t ptype, uint32_t imm8, uint32_t imm5, FEXCore::ARMEmitter::VRegister rd) {
+    constexpr uint32_t Op = 0b0001'1110'0010'0000'0001'00 << 10;
+    uint32_t Instr = Op;
+
+    Instr |= M << 31;
+    Instr |= S << 29;
+    Instr |= ptype << 22;
+    Instr |= imm8 << 13;
+    Instr |= imm5 << 5;
+    Instr |= rd.Idx();
+    dc32(Instr);
+  }
+
+// Floating-point conditional compare
+  void fccmp(FEXCore::ARMEmitter::SRegister rn, FEXCore::ARMEmitter::SRegister rm, FEXCore::ARMEmitter::StatusFlags flags, FEXCore::ARMEmitter::Condition Cond) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b01 << 10;
+
+    FloatConditionalCompare(Op, 0, 0, 0b00, 0b0, rn.V(), rm.V(), flags, Cond);
+  }
+  void fccmpe(FEXCore::ARMEmitter::SRegister rn, FEXCore::ARMEmitter::SRegister rm, FEXCore::ARMEmitter::StatusFlags flags, FEXCore::ARMEmitter::Condition Cond) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b01 << 10;
+
+    FloatConditionalCompare(Op, 0, 0, 0b00, 0b1, rn.V(), rm.V(), flags, Cond);
+  }
+  void fccmp(FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm, FEXCore::ARMEmitter::StatusFlags flags, FEXCore::ARMEmitter::Condition Cond) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b01 << 10;
+
+    FloatConditionalCompare(Op, 0, 0, 0b01, 0b0, rn.V(), rm.V(), flags, Cond);
+  }
+  void fccmpe(FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm, FEXCore::ARMEmitter::StatusFlags flags, FEXCore::ARMEmitter::Condition Cond) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b01 << 10;
+
+    FloatConditionalCompare(Op, 0, 0, 0b01, 0b1, rn.V(), rm.V(), flags, Cond);
+  }
+  void fccmp(FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm, FEXCore::ARMEmitter::StatusFlags flags, FEXCore::ARMEmitter::Condition Cond) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b01 << 10;
+
+    FloatConditionalCompare(Op, 0, 0, 0b11, 0b0, rn.V(), rm.V(), flags, Cond);
+  }
+  void fccmpe(FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm, FEXCore::ARMEmitter::StatusFlags flags, FEXCore::ARMEmitter::Condition Cond) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b01 << 10;
+
+    FloatConditionalCompare(Op, 0, 0, 0b11, 0b1, rn.V(), rm.V(), flags, Cond);
+  }
+
+// Floating-point data-processing (2 source)
+  void fmul(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn, FEXCore::ARMEmitter::SRegister rm) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b10 << 10;
+    Float2Source(Op, 0, 0, 0b00, 0b0000, rd.V(), rn.V(), rm.V());
+  }
+  void fdiv(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn, FEXCore::ARMEmitter::SRegister rm) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b10 << 10;
+    Float2Source(Op, 0, 0, 0b00, 0b0001, rd.V(), rn.V(), rm.V());
+  }
+  void fadd(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn, FEXCore::ARMEmitter::SRegister rm) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b10 << 10;
+    Float2Source(Op, 0, 0, 0b00, 0b0010, rd.V(), rn.V(), rm.V());
+  }
+  void fsub(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn, FEXCore::ARMEmitter::SRegister rm) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b10 << 10;
+    Float2Source(Op, 0, 0, 0b00, 0b0011, rd.V(), rn.V(), rm.V());
+  }
+  void fmax(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn, FEXCore::ARMEmitter::SRegister rm) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b10 << 10;
+    Float2Source(Op, 0, 0, 0b00, 0b0100, rd.V(), rn.V(), rm.V());
+  }
+  void fmin(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn, FEXCore::ARMEmitter::SRegister rm) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b10 << 10;
+    Float2Source(Op, 0, 0, 0b00, 0b0101, rd.V(), rn.V(), rm.V());
+  }
+  void fmaxnm(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn, FEXCore::ARMEmitter::SRegister rm) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b10 << 10;
+    Float2Source(Op, 0, 0, 0b00, 0b0110, rd.V(), rn.V(), rm.V());
+  }
+  void fminnm(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn, FEXCore::ARMEmitter::SRegister rm) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b10 << 10;
+    Float2Source(Op, 0, 0, 0b00, 0b0111, rd.V(), rn.V(), rm.V());
+  }
+  void fnmul(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn, FEXCore::ARMEmitter::SRegister rm) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b10 << 10;
+    Float2Source(Op, 0, 0, 0b00, 0b1000, rd.V(), rn.V(), rm.V());
+  }
+
+  void fmul(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b10 << 10;
+    Float2Source(Op, 0, 0, 0b01, 0b0000, rd.V(), rn.V(), rm.V());
+  }
+  void fdiv(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b10 << 10;
+    Float2Source(Op, 0, 0, 0b01, 0b0001, rd.V(), rn.V(), rm.V());
+  }
+  void fadd(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b10 << 10;
+    Float2Source(Op, 0, 0, 0b01, 0b0010, rd.V(), rn.V(), rm.V());
+  }
+  void fsub(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b10 << 10;
+    Float2Source(Op, 0, 0, 0b01, 0b0011, rd.V(), rn.V(), rm.V());
+  }
+  void fmax(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b10 << 10;
+    Float2Source(Op, 0, 0, 0b01, 0b0100, rd.V(), rn.V(), rm.V());
+  }
+  void fmin(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b10 << 10;
+    Float2Source(Op, 0, 0, 0b01, 0b0101, rd.V(), rn.V(), rm.V());
+  }
+  void fmaxnm(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b10 << 10;
+    Float2Source(Op, 0, 0, 0b01, 0b0110, rd.V(), rn.V(), rm.V());
+  }
+  void fminnm(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b10 << 10;
+    Float2Source(Op, 0, 0, 0b01, 0b0111, rd.V(), rn.V(), rm.V());
+  }
+  void fnmul(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b10 << 10;
+    Float2Source(Op, 0, 0, 0b01, 0b1000, rd.V(), rn.V(), rm.V());
+  }
+
+  void fmul(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b10 << 10;
+    Float2Source(Op, 0, 0, 0b11, 0b0000, rd.V(), rn.V(), rm.V());
+  }
+  void fdiv(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b10 << 10;
+    Float2Source(Op, 0, 0, 0b11, 0b0001, rd.V(), rn.V(), rm.V());
+  }
+  void fadd(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b10 << 10;
+    Float2Source(Op, 0, 0, 0b11, 0b0010, rd.V(), rn.V(), rm.V());
+  }
+  void fsub(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b10 << 10;
+    Float2Source(Op, 0, 0, 0b11, 0b0011, rd.V(), rn.V(), rm.V());
+  }
+  void fmax(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b10 << 10;
+    Float2Source(Op, 0, 0, 0b11, 0b0100, rd.V(), rn.V(), rm.V());
+  }
+  void fmin(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b10 << 10;
+    Float2Source(Op, 0, 0, 0b11, 0b0101, rd.V(), rn.V(), rm.V());
+  }
+  void fmaxnm(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b10 << 10;
+    Float2Source(Op, 0, 0, 0b11, 0b0110, rd.V(), rn.V(), rm.V());
+  }
+  void fminnm(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b10 << 10;
+    Float2Source(Op, 0, 0, 0b11, 0b0111, rd.V(), rn.V(), rm.V());
+  }
+  void fnmul(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b10 << 10;
+    Float2Source(Op, 0, 0, 0b11, 0b1000, rd.V(), rn.V(), rm.V());
+  }
+
+  // Floating-point conditional select
+  void fcsel(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn, FEXCore::ARMEmitter::SRegister rm, FEXCore::ARMEmitter::Condition Cond) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b11 << 10;
+    Float2Source(Op, 0, 0, 0b00, FEXCore::ToUnderlying(Cond), rd.V(), rn.V(), rm.V());
+  }
+  void fcsel(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm, FEXCore::ARMEmitter::Condition Cond) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b11 << 10;
+    Float2Source(Op, 0, 0, 0b01, FEXCore::ToUnderlying(Cond), rd.V(), rn.V(), rm.V());
+  }
+  void fcsel(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm, FEXCore::ARMEmitter::Condition Cond) {
+    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
+                            0b11 << 10;
+    Float2Source(Op, 0, 0, 0b11, FEXCore::ToUnderlying(Cond), rd.V(), rn.V(), rm.V());
+  }
+
+// Floating-point data-processing (3 source)
+  void fmadd(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn, FEXCore::ARMEmitter::SRegister rm, FEXCore::ARMEmitter::SRegister ra) {
+    constexpr uint32_t Op = 0b0001'1111'000 << 21;
+
+    Float3Source(Op, 0, 0, 0b00, 0, 0, rd.V(), rn.V(), rm.V(), ra.V());
+  }
+  void fmsub(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn, FEXCore::ARMEmitter::SRegister rm, FEXCore::ARMEmitter::SRegister ra) {
+    constexpr uint32_t Op = 0b0001'1111'000 << 21;
+
+    Float3Source(Op, 0, 0, 0b00, 0, 1, rd.V(), rn.V(), rm.V(), ra.V());
+  }
+  void fnmadd(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn, FEXCore::ARMEmitter::SRegister rm, FEXCore::ARMEmitter::SRegister ra) {
+    constexpr uint32_t Op = 0b0001'1111'000 << 21;
+
+    Float3Source(Op, 0, 0, 0b00, 1, 0, rd.V(), rn.V(), rm.V(), ra.V());
+  }
+  void fnmsub(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn, FEXCore::ARMEmitter::SRegister rm, FEXCore::ARMEmitter::SRegister ra) {
+    constexpr uint32_t Op = 0b0001'1111'000 << 21;
+
+    Float3Source(Op, 0, 0, 0b00, 1, 1, rd.V(), rn.V(), rm.V(), ra.V());
+  }
+
+  void fmadd(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm, FEXCore::ARMEmitter::DRegister ra) {
+    constexpr uint32_t Op = 0b0001'1111'000 << 21;
+
+    Float3Source(Op, 0, 0, 0b01, 0, 0, rd.V(), rn.V(), rm.V(), ra.V());
+  }
+  void fmsub(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm, FEXCore::ARMEmitter::DRegister ra) {
+    constexpr uint32_t Op = 0b0001'1111'000 << 21;
+
+    Float3Source(Op, 0, 0, 0b01, 0, 1, rd.V(), rn.V(), rm.V(), ra.V());
+  }
+  void fnmadd(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm, FEXCore::ARMEmitter::DRegister ra) {
+    constexpr uint32_t Op = 0b0001'1111'000 << 21;
+
+    Float3Source(Op, 0, 0, 0b01, 1, 0, rd.V(), rn.V(), rm.V(), ra.V());
+  }
+  void fnmsub(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm, FEXCore::ARMEmitter::DRegister ra) {
+    constexpr uint32_t Op = 0b0001'1111'000 << 21;
+
+    Float3Source(Op, 0, 0, 0b01, 1, 1, rd.V(), rn.V(), rm.V(), ra.V());
+  }
+
+  void fmadd(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm, FEXCore::ARMEmitter::HRegister ra) {
+    constexpr uint32_t Op = 0b0001'1111'000 << 21;
+
+    Float3Source(Op, 0, 0, 0b11, 0, 0, rd.V(), rn.V(), rm.V(), ra.V());
+  }
+  void fmsub(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm, FEXCore::ARMEmitter::HRegister ra) {
+    constexpr uint32_t Op = 0b0001'1111'000 << 21;
+
+    Float3Source(Op, 0, 0, 0b11, 0, 1, rd.V(), rn.V(), rm.V(), ra.V());
+  }
+  void fnmadd(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm, FEXCore::ARMEmitter::HRegister ra) {
+    constexpr uint32_t Op = 0b0001'1111'000 << 21;
+
+    Float3Source(Op, 0, 0, 0b11, 1, 0, rd.V(), rn.V(), rm.V(), ra.V());
+  }
+  void fnmsub(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm, FEXCore::ARMEmitter::HRegister ra) {
+    constexpr uint32_t Op = 0b0001'1111'000 << 21;
+
+    Float3Source(Op, 0, 0, 0b11, 1, 1, rd.V(), rn.V(), rm.V(), ra.V());
+  }
+
+private:
+// Advanced SIMD scalar copy
+  void ASIMDScalarCopy(uint32_t Op, uint32_t Q, uint32_t imm5, uint32_t imm4, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    uint32_t Instr = Op;
+
+    Instr |= Q << 30;
+    Instr |= imm5 << 16;
+    Instr |= imm4 << 11;
+    Instr |= Encode_rn(rn);
+    Instr |= Encode_rd(rd);
+    dc32(Instr);
+  }
+
+// Advanced SIMD scalar three same FP16
+  void ASIMDScalarThreeSameFP16(uint32_t Op, uint32_t U, uint32_t a, uint32_t opcode, FEXCore::ARMEmitter::HRegister rm, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rd) {
+    uint32_t Instr = Op;
+
+    Instr |= U << 29;
+    Instr |= a << 23;
+    Instr |= rm.Idx() << 16;
+    Instr |= opcode << 11;
+    Instr |= rn.Idx() << 5;
+    Instr |= rd.Idx();
+    dc32(Instr);
+  }
+// Advanced SIMD scalar two-register miscellaneous FP16
+  void ASIMDScalarTwoRegMiscFP16(uint32_t Op, uint32_t U, uint32_t a, uint32_t opcode, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rd) {
+    uint32_t Instr = Op;
+
+    Instr |= U << 29;
+    Instr |= a << 23;
+    Instr |= opcode << 12;
+    Instr |= rn.Idx() << 5;
+    Instr |= rd.Idx();
+    dc32(Instr);
+  }
+
+// Advanced SIMD scalar three same extra
+// XXX:
+// Advanced SIMD scalar two-register miscellaneous
+  void ASIMDScalar2RegMisc(uint32_t Op, uint32_t U, FEXCore::ARMEmitter::ScalarRegSize size, uint32_t opcode, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    uint32_t Instr = Op;
+
+    Instr |= U << 29;
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= opcode << 12;
+    Instr |= rn.Idx() << 5;
+    Instr |= rd.Idx();
+    dc32(Instr);
+  }
+
+// Advanced SIMD scalar pairwise
+// XXX:
+// Advanced SIMD scalar three different
+  void ASIMD3RegDifferent(uint32_t Op, uint32_t U, FEXCore::ARMEmitter::ScalarRegSize size, uint32_t opcode, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    uint32_t Instr = Op;
+
+    Instr |= U << 29;
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= Encode_rm(rm);
+    Instr |= opcode << 12;
+    Instr |= Encode_rn(rn);
+    Instr |= Encode_rd(rd);
+    dc32(Instr);
+  }
+// Advanced SIMD scalar three same
+  void ASIMD3RegSame(uint32_t Op, uint32_t U, FEXCore::ARMEmitter::ScalarRegSize size, uint32_t opcode, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    uint32_t Instr = Op;
+
+    Instr |= U << 29;
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= Encode_rm(rm);
+    Instr |= opcode << 11;
+    Instr |= Encode_rn(rn);
+    Instr |= Encode_rd(rd);
+    dc32(Instr);
+  }
+// Advanced SIMD scalar shift by immediate
+  void ASIMDScalarShiftByImm(uint32_t Op, uint32_t U, uint32_t immh, uint32_t immb, uint32_t opcode, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    uint32_t Instr = Op;
+
+    Instr |= U << 29;
+    Instr |= immh << 19;
+    Instr |= immb << 16;
+    Instr |= opcode << 11;
+    Instr |= Encode_rn(rn);
+    Instr |= Encode_rd(rd);
+    dc32(Instr);
+  }
+// Advanced SIMD scalar x indexed element
+// XXX:
+// Floating-point data-processing (1 source)
+  void Float1Source(uint32_t Op, uint32_t M, uint32_t S, uint32_t ptype, uint32_t opcode, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
+    uint32_t Instr = Op;
+
+    Instr |= M << 31;
+    Instr |= S << 29;
+    Instr |= ptype << 22;
+    Instr |= opcode << 15;
+    Instr |= Encode_rn(rn);
+    Instr |= Encode_rd(rd);
+
+    dc32(Instr);
+  }
+// Floating-point compare
+  void FloatCompare(uint32_t Op, uint32_t M, uint32_t S, uint32_t ftype, uint32_t op, uint32_t opcode2, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    uint32_t Instr = Op;
+
+    Instr |= M << 31;
+    Instr |= S << 29;
+    Instr |= ftype << 22;
+    Instr |= Encode_rm(rm);
+    Instr |= op << 14;
+    Instr |= Encode_rn(rn);
+    Instr |= opcode2;
+
+    dc32(Instr);
+  }
+// Floating-point immediate
+// XXX:
+// Floating-point conditional compare
+  void FloatConditionalCompare(uint32_t Op, uint32_t M, uint32_t S, uint32_t ptype, uint32_t op, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm, FEXCore::ARMEmitter::StatusFlags flags, FEXCore::ARMEmitter::Condition Cond) {
+    uint32_t Instr = Op;
+
+    Instr |= M << 31;
+    Instr |= S << 29;
+    Instr |= ptype << 22;
+    Instr |= Encode_rm(rm);
+    Instr |= FEXCore::ToUnderlying(Cond) << 12;
+    Instr |= Encode_rn(rn);
+    Instr |= op << 4;
+    Instr |= FEXCore::ToUnderlying(flags);
+
+    dc32(Instr);
+  }
+// Floating-point data-processing (2 source)
+  void Float2Source(uint32_t Op, uint32_t M, uint32_t S, uint32_t ptype, uint32_t opcode, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
+    uint32_t Instr = Op;
+
+    Instr |= M << 31;
+    Instr |= S << 29;
+    Instr |= ptype << 22;
+    Instr |= Encode_rm(rm);
+    Instr |= opcode << 12;
+    Instr |= Encode_rn(rn);
+    Instr |= Encode_rd(rd);
+
+    dc32(Instr);
+  }
+
+// Floating-point conditional select
+  void FloatConditionalSelect(uint32_t Op, uint32_t M, uint32_t S, uint32_t ptype, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm, FEXCore::ARMEmitter::Condition Cond) {
+    uint32_t Instr = Op;
+
+    Instr |= M << 31;
+    Instr |= S << 29;
+    Instr |= ptype << 22;
+    Instr |= rm.Idx() << 16;
+    Instr |= FEXCore::ToUnderlying(Cond) << 12;
+    Instr |= rn.Idx() << 5;
+    Instr |= rd.Idx();
+    dc32(Instr);
+  }
+
+// Floating-point data-processing (3 source)
+  void Float3Source(uint32_t Op, uint32_t M, uint32_t S, uint32_t ptype, uint32_t o1, uint32_t o0, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm, FEXCore::ARMEmitter::VRegister ra) {
+    uint32_t Instr = Op;
+
+    Instr |= M << 31;
+    Instr |= S << 29;
+    Instr |= ptype << 22;
+    Instr |= o1 << 21;
+    Instr |= Encode_rm(rm);
+    Instr |= o0 << 15;
+    Instr |= Encode_ra(ra);
+    Instr |= Encode_rn(rn);
+    Instr |= Encode_rd(rd);
+    dc32(Instr);
+  }

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SystemOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SystemOps.inl
@@ -1,0 +1,175 @@
+/* System instruction emitters.
+ *
+ * This is mostly a mashup of various instruction types.
+ * Nothing follows an explicit pattern since they are mostly different.
+ */
+public:
+    // System with result
+    // TODO: SYSL
+    // System Instruction
+    // TODO: AT
+    // TODO: CFP
+    // TODO: CPP
+    void dc(FEXCore::ARMEmitter::DataCacheOperation DCOp, FEXCore::ARMEmitter::Register rt) {
+      constexpr uint32_t Op = 0b1101'0101'0000'1000'0111 << 12;
+      SystemInstruction(Op, 0, FEXCore::ToUnderlying(DCOp), rt);
+    }
+    // TODO: DVP
+    // TODO: IC
+    // TODO: TLBI
+
+    // Exception generation
+    void svc(uint32_t Imm) {
+      ExceptionGeneration(0b000, 0b000, 0b01, Imm);
+    }
+    void hvc(uint32_t Imm) {
+      ExceptionGeneration(0b000, 0b000, 0b10, Imm);
+    }
+    void smc(uint32_t Imm) {
+      ExceptionGeneration(0b000, 0b000, 0b11, Imm);
+    }
+    void brk(uint32_t Imm) {
+      ExceptionGeneration(0b001, 0b000, 0b00, Imm);
+    }
+    void hlt(uint32_t Imm) {
+      ExceptionGeneration(0b010, 0b000, 0b00, Imm);
+    }
+    void tcancel(uint32_t Imm) {
+      ExceptionGeneration(0b011, 0b000, 0b00, Imm);
+    }
+    void dcps1(uint32_t Imm) {
+      ExceptionGeneration(0b101, 0b000, 0b01, Imm);
+    }
+    void dcps2(uint32_t Imm) {
+      ExceptionGeneration(0b101, 0b000, 0b10, Imm);
+    }
+    void dcps3(uint32_t Imm) {
+      ExceptionGeneration(0b101, 0b000, 0b11, Imm);
+    }
+    // System instructions with register argument
+    void wfet(FEXCore::ARMEmitter::Register rt) {
+      SystemInstructionWithReg(0b0000, 0b000, rt);
+    }
+    void wfit(FEXCore::ARMEmitter::Register rt) {
+      SystemInstructionWithReg(0b0000, 0b001, rt);
+    }
+
+    // Hints
+    void nop() {
+      Hint(FEXCore::ARMEmitter::HintRegister::NOP);
+    }
+    void yield() {
+      Hint(FEXCore::ARMEmitter::HintRegister::YIELD);
+    }
+    void wfe() {
+      Hint(FEXCore::ARMEmitter::HintRegister::WFE);
+    }
+    void wfi() {
+      Hint(FEXCore::ARMEmitter::HintRegister::WFI);
+    }
+    void sev() {
+      Hint(FEXCore::ARMEmitter::HintRegister::SEV);
+    }
+    void sevl() {
+      Hint(FEXCore::ARMEmitter::HintRegister::SEVL);
+    }
+    void dgh() {
+      Hint(FEXCore::ARMEmitter::HintRegister::DGH);
+    }
+    void csdb() {
+      Hint(FEXCore::ARMEmitter::HintRegister::CSDB);
+    }
+
+    // Barriers
+    void clrex(uint32_t imm = 15) {
+      LOGMAN_THROW_AA_FMT(imm < 16, "Immediate out of range");
+      Barrier(FEXCore::ARMEmitter::BarrierRegister::CLREX, imm);
+    }
+    void dsb(FEXCore::ARMEmitter::BarrierScope Scope) {
+      Barrier(FEXCore::ARMEmitter::BarrierRegister::DSB, FEXCore::ToUnderlying(Scope));
+    }
+    void dmb(FEXCore::ARMEmitter::BarrierScope Scope) {
+      Barrier(FEXCore::ARMEmitter::BarrierRegister::DMB, FEXCore::ToUnderlying(Scope));
+    }
+    void isb() {
+      Barrier(FEXCore::ARMEmitter::BarrierRegister::ISB, FEXCore::ToUnderlying(FEXCore::ARMEmitter::BarrierScope::SY));
+    }
+    void sb() {
+      Barrier(FEXCore::ARMEmitter::BarrierRegister::SB, 0);
+    }
+    void tcommit() {
+      Barrier(FEXCore::ARMEmitter::BarrierRegister::TCOMMIT, 0);
+    }
+
+    // System register move
+    void msr(FEXCore::ARMEmitter::SystemRegister reg, FEXCore::ARMEmitter::Register rt) {
+      constexpr uint32_t Op = 0b1101'0101'0001 << 20;
+      SystemRegisterMove(Op, rt, reg);
+    }
+
+    void mrs(FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::SystemRegister reg) {
+      constexpr uint32_t Op = 0b1101'0101'0011 << 20;
+      SystemRegisterMove(Op, rd, reg);
+    }
+
+private:
+
+    // Exception Generation
+    void ExceptionGeneration(uint32_t opc, uint32_t op2, uint32_t LL, uint32_t Imm) {
+      LOGMAN_THROW_AA_FMT((Imm & 0xFFFF'0000) == 0, "Imm amount too large");
+
+      uint32_t Instr = 0b1101'0100 << 24;
+
+      Instr |= opc << 21;
+      Instr |= Imm << 5;
+      Instr |= op2 << 2;
+      Instr |= LL;
+
+      dc32(Instr);
+    }
+
+    // System instructions with register argument
+    void SystemInstructionWithReg(uint32_t CRm, uint32_t op2, FEXCore::ARMEmitter::Register rt) {
+      uint32_t Instr = 0b1101'0101'0000'0011'0001 << 12;
+
+      Instr |= CRm << 8;
+      Instr |= op2 << 5;
+      Instr |= Encode_rt(rt);
+      dc32(Instr);
+    }
+
+    // Hints
+    void Hint(FEXCore::ARMEmitter::HintRegister Reg) {
+      uint32_t Instr = 0b1101'0101'0000'0011'0010'0000'0001'1111U;
+      Instr |= FEXCore::ToUnderlying(Reg);
+      dc32(Instr);
+    }
+    // Barriers
+    void Barrier(FEXCore::ARMEmitter::BarrierRegister Reg, uint32_t CRm) {
+      uint32_t Instr = 0b1101'0101'0000'0011'0011'0000'0001'1111U;
+      Instr |= CRm << 8;
+      Instr |= FEXCore::ToUnderlying(Reg);
+      dc32(Instr);
+    }
+
+    // System Instruction
+    void SystemInstruction(uint32_t Op, uint32_t L, uint32_t SubOp, FEXCore::ARMEmitter::Register rt) {
+      uint32_t Instr = Op;
+
+      Instr |= L << 21;
+      Instr |= SubOp;
+      Instr |= Encode_rt(rt);
+
+      dc32(Instr);
+    }
+
+    // System register move
+    void SystemRegisterMove(uint32_t Op, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::SystemRegister reg) {
+      uint32_t Instr = Op;
+
+      Instr |= FEXCore::ToUnderlying(reg);
+      Instr |= Encode_rt(rt);
+
+      dc32(Instr);
+    }
+

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.h
@@ -15,6 +15,9 @@ namespace FEXCore::Core {
 struct InternalThreadState;
 }
 
+#define STATE_PTR(STATE_TYPE, FIELD) \
+  STATE.R(), offsetof(FEXCore::Core::STATE_TYPE, FIELD)
+
 namespace FEXCore::CPU {
 
 class Arm64Dispatcher final : public Dispatcher, public Arm64Emitter {
@@ -28,6 +31,8 @@ class Arm64Dispatcher final : public Dispatcher, public Arm64Emitter {
   void ExecuteDispatch(FEXCore::Core::CpuStateFrame *Frame) override;
   void ExecuteJITCallback(FEXCore::Core::CpuStateFrame *Frame, uint64_t RIP) override;
 #endif
+
+  void EmitDispatcher();
 
   protected:
     void SpillSRA(FEXCore::Core::InternalThreadState *Thread, void *ucontext, uint32_t IgnoreMask) override;

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/Arm64Relocations.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/Arm64Relocations.cpp
@@ -9,7 +9,7 @@ $end_info$
 #include "Interface/HLE/Thunks/Thunks.h"
 
 namespace FEXCore::CPU {
-    
+
 uint64_t Arm64JITCore::GetNamedSymbolLiteral(FEXCore::CPU::RelocNamedSymbolLiteral::NamedSymbol Op) {
   switch (Op) {
     case FEXCore::CPU::RelocNamedSymbolLiteral::NamedSymbol::SYMBOL_LITERAL_EXITFUNCTION_LINKER:
@@ -22,18 +22,18 @@ uint64_t Arm64JITCore::GetNamedSymbolLiteral(FEXCore::CPU::RelocNamedSymbolLiter
   return ~0ULL;
 }
 
-void Arm64JITCore::InsertNamedThunkRelocation(vixl::aarch64::Register Reg, const IR::SHA256Sum &Sum) {
+void Arm64JITCore::InsertNamedThunkRelocation(ARMEmitter::Register Reg, const IR::SHA256Sum &Sum) {
   Relocation MoveABI{};
   MoveABI.NamedThunkMove.Header.Type = FEXCore::CPU::RelocationTypes::RELOC_NAMED_THUNK_MOVE;
   // Offset is the offset from the entrypoint of the block
   auto CurrentCursor = GetCursorAddress<uint8_t *>();
   MoveABI.NamedThunkMove.Offset = CurrentCursor - GuestEntry;
   MoveABI.NamedThunkMove.Symbol = Sum;
-  MoveABI.NamedThunkMove.RegisterIndex = Reg.GetCode();
+  MoveABI.NamedThunkMove.RegisterIndex = Reg.Idx();
 
   uint64_t Pointer = reinterpret_cast<uint64_t>(EmitterCTX->ThunkHandler->LookupThunk(Sum));
 
-  LoadConstant(Reg, Pointer, EmitterCTX->Config.CacheObjectCodeCompilation());
+  LoadConstant(ARMEmitter::Size::i64Bit, Reg, Pointer, EmitterCTX->Config.CacheObjectCodeCompilation());
   Relocations.emplace_back(MoveABI);
 }
 
@@ -41,7 +41,7 @@ Arm64JITCore::NamedSymbolLiteralPair Arm64JITCore::InsertNamedSymbolLiteral(FEXC
   uint64_t Pointer = GetNamedSymbolLiteral(Op);
 
   Arm64JITCore::NamedSymbolLiteralPair Lit {
-    .Lit = Literal(Pointer),
+    .Lit = Pointer,
     .MoveABI = {
       .NamedSymbolLiteral = {
         .Header = {
@@ -60,20 +60,21 @@ void Arm64JITCore::PlaceNamedSymbolLiteral(NamedSymbolLiteralPair &Lit) {
   auto CurrentCursor = GetCursorAddress<uint8_t *>();
   Lit.MoveABI.NamedSymbolLiteral.Offset = CurrentCursor - GuestEntry;
 
-  place(&Lit.Lit);
+  Bind(&Lit.Loc);
+  dc64(Lit.Lit);
   Relocations.emplace_back(Lit.MoveABI);
 }
 
-void Arm64JITCore::InsertGuestRIPMove(vixl::aarch64::Register Reg, uint64_t Constant) {
+void Arm64JITCore::InsertGuestRIPMove(ARMEmitter::Register Reg, uint64_t Constant) {
   Relocation MoveABI{};
   MoveABI.GuestRIPMove.Header.Type = FEXCore::CPU::RelocationTypes::RELOC_GUEST_RIP_MOVE;
   // Offset is the offset from the entrypoint of the block
   auto CurrentCursor = GetCursorAddress<uint8_t *>();
   MoveABI.GuestRIPMove.Offset = CurrentCursor - GuestEntry;
   MoveABI.GuestRIPMove.GuestRIP = Constant;
-  MoveABI.GuestRIPMove.RegisterIndex = Reg.GetCode();
+  MoveABI.GuestRIPMove.RegisterIndex = Reg.Idx();
 
-  LoadConstant(Reg, Constant, EmitterCTX->Config.CacheObjectCodeCompilation());
+  LoadConstant(ARMEmitter::Size::i64Bit, Reg, Constant, EmitterCTX->Config.CacheObjectCodeCompilation());
   Relocations.emplace_back(MoveABI);
 }
 
@@ -87,11 +88,10 @@ bool Arm64JITCore::ApplyRelocations(uint64_t GuestEntry, uint64_t CodeEntry, uin
       case FEXCore::CPU::RelocationTypes::RELOC_NAMED_SYMBOL_LITERAL: {
         uint64_t Pointer = GetNamedSymbolLiteral(Reloc->NamedSymbolLiteral.Symbol);
         // Relocation occurs at the cursorEntry + offset relative to that cursor
-        GetBuffer()->SetCursorOffset(CursorEntry + Reloc->NamedSymbolLiteral.Offset);
+        SetCursorOffset(CursorEntry + Reloc->NamedSymbolLiteral.Offset);
 
         // Generate a literal so we can place it
-        Literal<uint64_t> Lit(Pointer);
-        place(&Lit);
+        dc64(Pointer);
 
         DataIndex += sizeof(Reloc->NamedSymbolLiteral);
         break;
@@ -103,8 +103,8 @@ bool Arm64JITCore::ApplyRelocations(uint64_t GuestEntry, uint64_t CodeEntry, uin
         }
 
         // Relocation occurs at the cursorEntry + offset relative to that cursor.
-        GetBuffer()->SetCursorOffset(CursorEntry + Reloc->NamedThunkMove.Offset);
-        LoadConstant(vixl::aarch64::XRegister(Reloc->NamedThunkMove.RegisterIndex), Pointer, true);
+        SetCursorOffset(CursorEntry + Reloc->NamedThunkMove.Offset);
+        LoadConstant(ARMEmitter::Size::i64Bit, ARMEmitter::Register(Reloc->NamedThunkMove.RegisterIndex), Pointer, true);
         DataIndex += sizeof(Reloc->NamedThunkMove);
         break;
       }
@@ -117,8 +117,8 @@ bool Arm64JITCore::ApplyRelocations(uint64_t GuestEntry, uint64_t CodeEntry, uin
         }
 
         // Relocation occurs at the cursorEntry + offset relative to that cursor.
-        GetBuffer()->SetCursorOffset(CursorEntry + Reloc->GuestRIPMove.Offset);
-        LoadConstant(vixl::aarch64::XRegister(Reloc->GuestRIPMove.RegisterIndex), Pointer, true);
+        SetCursorOffset(CursorEntry + Reloc->GuestRIPMove.Offset);
+        LoadConstant(ARMEmitter::Size::i64Bit, ARMEmitter::Register(Reloc->GuestRIPMove.RegisterIndex), Pointer, true);
         DataIndex += sizeof(Reloc->GuestRIPMove);
         break;
       }

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/FlagOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/FlagOps.cpp
@@ -7,13 +7,10 @@ $end_info$
 #include "Interface/Core/JIT/Arm64/JITClass.h"
 
 namespace FEXCore::CPU {
-
-using namespace vixl;
-using namespace vixl::aarch64;
 #define DEF_OP(x) void Arm64JITCore::Op_##x(IR::IROp_Header const *IROp, IR::NodeID Node)
 DEF_OP(GetHostFlag) {
   auto Op = IROp->C<IR::IROp_GetHostFlag>();
-  ubfx(GetReg<RA_64>(Node), GetReg<RA_64>(Op->Value.ID()), Op->Flag, 1);
+  ubfx(ARMEmitter::Size::i64Bit, GetReg(Node), GetReg(Op->Value.ID()), Op->Flag, 1);
 }
 
 #undef DEF_OP

--- a/External/FEXCore/include/FEXCore/IR/RegisterAllocationData.h
+++ b/External/FEXCore/include/FEXCore/IR/RegisterAllocationData.h
@@ -77,7 +77,9 @@ struct RegisterAllocationDataDeleter {
 inline auto RegisterAllocationData::Create(uint32_t NodeCount) -> UniquePtr {
   auto Ret = (RegisterAllocationData*)FEXCore::Allocator::malloc(Size(NodeCount));
   memset(&Ret->Map[0], PhysicalRegister::Invalid().Raw, NodeCount);
+  Ret->SpillSlotCount = 0;
   Ret->MapCount = NodeCount;
+  Ret->IsShared = false;
   return UniquePtr { Ret };
 }
 

--- a/External/FEXCore/unittests/CMakeLists.txt
+++ b/External/FEXCore/unittests/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(Emitter/)

--- a/External/FEXCore/unittests/Emitter/ALU_Tests.cpp
+++ b/External/FEXCore/unittests/Emitter/ALU_Tests.cpp
@@ -1,0 +1,1574 @@
+#include "TestDisassembler.h"
+
+#include <catch2/catch.hpp>
+#include <fcntl.h>
+
+using namespace FEXCore::ARMEmitter;
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: ALU: PC relative") {
+  {
+    BackwardLabel Label;
+    Bind(&Label);
+    dc32(0);
+    adr(Reg::r30, &Label);
+
+    CHECK(DisassembleEncoding(1) == 0x10fffffe);
+  }
+
+  {
+    ForwardLabel Label;
+    adr(Reg::r30, &Label);
+    Bind(&Label);
+    dc32(0);
+
+    CHECK(DisassembleEncoding(0) == 0x1000003e);
+  }
+
+  {
+    BiDirectionalLabel Label;
+    Bind(&Label);
+    dc32(0);
+    adr(Reg::r30, &Label);
+
+    CHECK(DisassembleEncoding(1) == 0x10fffffe);
+  }
+
+  {
+    BiDirectionalLabel Label;
+    adr(Reg::r30, &Label);
+    Bind(&Label);
+    dc32(0);
+
+    CHECK(DisassembleEncoding(0) == 0x1000003e);
+  }
+
+  {
+    BackwardLabel Label;
+    Bind(&Label);
+    dc32(0);
+    adrp(Reg::r30, &Label);
+
+    CHECK(DisassembleEncoding(1) == 0x9000001e);
+  }
+
+  {
+    ForwardLabel Label;
+    adrp(Reg::r30, &Label);
+    // Move label a page away
+    for (size_t i = 0; i < 1023; ++i) {
+      nop();
+    }
+    Bind(&Label);
+
+    CHECK(DisassembleEncoding(0) == 0xb000001e);
+  }
+
+  {
+    BiDirectionalLabel Label;
+    Bind(&Label);
+    dc32(0);
+    adrp(Reg::r30, &Label);
+
+    CHECK(DisassembleEncoding(1) == 0x9000001e);
+  }
+
+  {
+    BiDirectionalLabel Label;
+    adrp(Reg::r30, &Label);
+    // Move label a page away
+    for (size_t i = 0; i < 1023; ++i) {
+      nop();
+    }
+    Bind(&Label);
+
+    CHECK(DisassembleEncoding(0) == 0xb000001e);
+  }
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: ALU: Add/subtract immediate") {
+  TEST_SINGLE(add(Size::i32Bit, Reg::r29, Reg::r28, 0, false), "add w29, w28, #0x0 (0)");
+  TEST_SINGLE(add(Size::i32Bit, Reg::r29, Reg::r28, 4095, false), "add w29, w28, #0xfff (4095)");
+  TEST_SINGLE(add(Size::i32Bit, Reg::r29, Reg::r28, 0, true), "add w29, w28, #0x0 (0)");
+  TEST_SINGLE(add(Size::i32Bit, Reg::r29, Reg::r28, 4095, true), "add w29, w28, #0xfff000 (16773120)");
+  TEST_SINGLE(add(Size::i32Bit, Reg::r29, Reg::r28, 16773120), "add w29, w28, #0xfff000 (16773120)");
+
+  TEST_SINGLE(add(Size::i64Bit, Reg::r29, Reg::r28, 0, false), "add x29, x28, #0x0 (0)");
+  TEST_SINGLE(add(Size::i64Bit, Reg::r29, Reg::r28, 4095, false), "add x29, x28, #0xfff (4095)");
+  TEST_SINGLE(add(Size::i64Bit, Reg::r29, Reg::r28, 0, true), "add x29, x28, #0x0 (0)");
+  TEST_SINGLE(add(Size::i64Bit, Reg::r29, Reg::r28, 4095, true), "add x29, x28, #0xfff000 (16773120)");
+  TEST_SINGLE(add(Size::i64Bit, Reg::r29, Reg::r28, 16773120), "add x29, x28, #0xfff000 (16773120)");
+
+  TEST_SINGLE(add(Size::i64Bit, Reg::rsp, Reg::rsp, 0, false), "mov sp, sp");
+  TEST_SINGLE(add(Size::i64Bit, Reg::rsp, Reg::rsp, 4095, false), "add sp, sp, #0xfff (4095)");
+  TEST_SINGLE(add(Size::i64Bit, Reg::rsp, Reg::rsp, 0, true), "mov sp, sp");
+  TEST_SINGLE(add(Size::i64Bit, Reg::rsp, Reg::rsp, 4095, true), "add sp, sp, #0xfff000 (16773120)");
+  TEST_SINGLE(add(Size::i64Bit, Reg::rsp, Reg::rsp, 16773120), "add sp, sp, #0xfff000 (16773120)");
+
+  TEST_SINGLE(adds(Size::i32Bit, Reg::r29, Reg::r28, 0, false), "adds w29, w28, #0x0 (0)");
+  TEST_SINGLE(adds(Size::i32Bit, Reg::r29, Reg::r28, 4095, false), "adds w29, w28, #0xfff (4095)");
+  TEST_SINGLE(adds(Size::i32Bit, Reg::r29, Reg::r28, 0, true), "adds w29, w28, #0x0 (0)");
+  TEST_SINGLE(adds(Size::i32Bit, Reg::r29, Reg::r28, 4095, true), "adds w29, w28, #0xfff000 (16773120)");
+  TEST_SINGLE(adds(Size::i32Bit, Reg::r29, Reg::r28, 16773120), "adds w29, w28, #0xfff000 (16773120)");
+
+  TEST_SINGLE(adds(Size::i64Bit, Reg::r29, Reg::r28, 0, false), "adds x29, x28, #0x0 (0)");
+  TEST_SINGLE(adds(Size::i64Bit, Reg::r29, Reg::r28, 4095, false), "adds x29, x28, #0xfff (4095)");
+  TEST_SINGLE(adds(Size::i64Bit, Reg::r29, Reg::r28, 0, true), "adds x29, x28, #0x0 (0)");
+  TEST_SINGLE(adds(Size::i64Bit, Reg::r29, Reg::r28, 4095, true), "adds x29, x28, #0xfff000 (16773120)");
+  TEST_SINGLE(adds(Size::i64Bit, Reg::r29, Reg::r28, 16773120), "adds x29, x28, #0xfff000 (16773120)");
+
+  TEST_SINGLE(sub(Size::i32Bit, Reg::r29, Reg::r28, 0, false), "sub w29, w28, #0x0 (0)");
+  TEST_SINGLE(sub(Size::i32Bit, Reg::r29, Reg::r28, 4095, false), "sub w29, w28, #0xfff (4095)");
+  TEST_SINGLE(sub(Size::i32Bit, Reg::r29, Reg::r28, 0, true), "sub w29, w28, #0x0 (0)");
+  TEST_SINGLE(sub(Size::i32Bit, Reg::r29, Reg::r28, 4095, true), "sub w29, w28, #0xfff000 (16773120)");
+  TEST_SINGLE(sub(Size::i32Bit, Reg::r29, Reg::r28, 16773120), "sub w29, w28, #0xfff000 (16773120)");
+
+  TEST_SINGLE(sub(Size::i64Bit, Reg::r29, Reg::r28, 0, false), "sub x29, x28, #0x0 (0)");
+  TEST_SINGLE(sub(Size::i64Bit, Reg::r29, Reg::r28, 4095, false), "sub x29, x28, #0xfff (4095)");
+  TEST_SINGLE(sub(Size::i64Bit, Reg::r29, Reg::r28, 0, true), "sub x29, x28, #0x0 (0)");
+  TEST_SINGLE(sub(Size::i64Bit, Reg::r29, Reg::r28, 4095, true), "sub x29, x28, #0xfff000 (16773120)");
+  TEST_SINGLE(sub(Size::i64Bit, Reg::r29, Reg::r28, 16773120), "sub x29, x28, #0xfff000 (16773120)");
+
+  TEST_SINGLE(sub(Size::i64Bit, Reg::rsp, Reg::rsp, 0, false), "sub sp, sp, #0x0 (0)");
+  TEST_SINGLE(sub(Size::i64Bit, Reg::rsp, Reg::rsp, 4095, false), "sub sp, sp, #0xfff (4095)");
+  TEST_SINGLE(sub(Size::i64Bit, Reg::rsp, Reg::rsp, 0, true), "sub sp, sp, #0x0 (0)");
+  TEST_SINGLE(sub(Size::i64Bit, Reg::rsp, Reg::rsp, 4095, true), "sub sp, sp, #0xfff000 (16773120)");
+  TEST_SINGLE(sub(Size::i64Bit, Reg::rsp, Reg::rsp, 16773120), "sub sp, sp, #0xfff000 (16773120)");
+
+  TEST_SINGLE(subs(Size::i32Bit, Reg::r29, Reg::r28, 0, false), "subs w29, w28, #0x0 (0)");
+  TEST_SINGLE(subs(Size::i32Bit, Reg::r29, Reg::r28, 4095, false), "subs w29, w28, #0xfff (4095)");
+  TEST_SINGLE(subs(Size::i32Bit, Reg::r29, Reg::r28, 0, true), "subs w29, w28, #0x0 (0)");
+  TEST_SINGLE(subs(Size::i32Bit, Reg::r29, Reg::r28, 4095, true), "subs w29, w28, #0xfff000 (16773120)");
+  TEST_SINGLE(subs(Size::i32Bit, Reg::r29, Reg::r28, 16773120), "subs w29, w28, #0xfff000 (16773120)");
+
+  TEST_SINGLE(subs(Size::i64Bit, Reg::r29, Reg::r28, 0, false), "subs x29, x28, #0x0 (0)");
+  TEST_SINGLE(subs(Size::i64Bit, Reg::r29, Reg::r28, 4095, false), "subs x29, x28, #0xfff (4095)");
+  TEST_SINGLE(subs(Size::i64Bit, Reg::r29, Reg::r28, 0, true), "subs x29, x28, #0x0 (0)");
+  TEST_SINGLE(subs(Size::i64Bit, Reg::r29, Reg::r28, 4095, true), "subs x29, x28, #0xfff000 (16773120)");
+  TEST_SINGLE(subs(Size::i64Bit, Reg::r29, Reg::r28, 16773120), "subs x29, x28, #0xfff000 (16773120)");
+
+  TEST_SINGLE(cmp(Size::i32Bit, Reg::r28, 0, false), "cmp w28, #0x0 (0)");
+  TEST_SINGLE(cmp(Size::i32Bit, Reg::r28, 4095, false), "cmp w28, #0xfff (4095)");
+  TEST_SINGLE(cmp(Size::i32Bit, Reg::r28, 0, true), "cmp w28, #0x0 (0)");
+  TEST_SINGLE(cmp(Size::i32Bit, Reg::r28, 4095, true), "cmp w28, #0xfff000 (16773120)");
+  TEST_SINGLE(cmp(Size::i32Bit, Reg::r28, 16773120), "cmp w28, #0xfff000 (16773120)");
+
+  TEST_SINGLE(cmp(Size::i64Bit, Reg::r28, 0, false), "cmp x28, #0x0 (0)");
+  TEST_SINGLE(cmp(Size::i64Bit, Reg::r28, 4095, false), "cmp x28, #0xfff (4095)");
+  TEST_SINGLE(cmp(Size::i64Bit, Reg::r28, 0, true), "cmp x28, #0x0 (0)");
+  TEST_SINGLE(cmp(Size::i64Bit, Reg::r28, 4095, true), "cmp x28, #0xfff000 (16773120)");
+  TEST_SINGLE(cmp(Size::i64Bit, Reg::r28, 16773120), "cmp x28, #0xfff000 (16773120)");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: ALU: Logical immediate") {
+  TEST_SINGLE(and_(Size::i32Bit, Reg::r29, Reg::r28, 1), "and w29, w28, #0x1");
+  TEST_SINGLE(and_(Size::i32Bit, Reg::r29, Reg::r28, -2), "and w29, w28, #0xfffffffe");
+  TEST_SINGLE(and_(Size::i64Bit, Reg::r29, Reg::r28, 1), "and x29, x28, #0x1");
+  TEST_SINGLE(and_(Size::i64Bit, Reg::r29, Reg::r28, -2), "and x29, x28, #0xfffffffffffffffe");
+
+  TEST_SINGLE(bic(Size::i32Bit, Reg::r29, Reg::r28, 1), "and w29, w28, #0xfffffffe");
+  TEST_SINGLE(bic(Size::i32Bit, Reg::r29, Reg::r28, -2), "and w29, w28, #0x1");
+  TEST_SINGLE(bic(Size::i64Bit, Reg::r29, Reg::r28, 1), "and x29, x28, #0xfffffffffffffffe");
+  TEST_SINGLE(bic(Size::i64Bit, Reg::r29, Reg::r28, -2), "and x29, x28, #0x1");
+
+  TEST_SINGLE(ands(Size::i32Bit, Reg::r29, Reg::r28, 1), "ands w29, w28, #0x1");
+  TEST_SINGLE(ands(Size::i32Bit, Reg::r29, Reg::r28, -2), "ands w29, w28, #0xfffffffe");
+  TEST_SINGLE(ands(Size::i64Bit, Reg::r29, Reg::r28, 1), "ands x29, x28, #0x1");
+  TEST_SINGLE(ands(Size::i64Bit, Reg::r29, Reg::r28, -2), "ands x29, x28, #0xfffffffffffffffe");
+
+  TEST_SINGLE(bics(Size::i32Bit, Reg::r29, Reg::r28, 1), "ands w29, w28, #0xfffffffe");
+  TEST_SINGLE(bics(Size::i32Bit, Reg::r29, Reg::r28, -2), "ands w29, w28, #0x1");
+  TEST_SINGLE(bics(Size::i64Bit, Reg::r29, Reg::r28, 1), "ands x29, x28, #0xfffffffffffffffe");
+  TEST_SINGLE(bics(Size::i64Bit, Reg::r29, Reg::r28, -2), "ands x29, x28, #0x1");
+
+  TEST_SINGLE(orr(Size::i32Bit, Reg::r29, Reg::r28, 1), "orr w29, w28, #0x1");
+  TEST_SINGLE(orr(Size::i32Bit, Reg::r29, Reg::r28, -2), "orr w29, w28, #0xfffffffe");
+  TEST_SINGLE(orr(Size::i64Bit, Reg::r29, Reg::r28, 1), "orr x29, x28, #0x1");
+  TEST_SINGLE(orr(Size::i64Bit, Reg::r29, Reg::r28, -2), "orr x29, x28, #0xfffffffffffffffe");
+
+  TEST_SINGLE(eor(Size::i32Bit, Reg::r29, Reg::r28, 1), "eor w29, w28, #0x1");
+  TEST_SINGLE(eor(Size::i32Bit, Reg::r29, Reg::r28, -2), "eor w29, w28, #0xfffffffe");
+  TEST_SINGLE(eor(Size::i64Bit, Reg::r29, Reg::r28, 1), "eor x29, x28, #0x1");
+  TEST_SINGLE(eor(Size::i64Bit, Reg::r29, Reg::r28, -2), "eor x29, x28, #0xfffffffffffffffe");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: ALU: Move wide immediate") {
+  TEST_SINGLE(movn(Size::i32Bit, Reg::r29, 0x4243, 0), "mov w29, #0xffffbdbc");
+  TEST_SINGLE(movn(Size::i32Bit, Reg::r29, 0x4243, 16), "mov w29, #0xbdbcffff");
+
+  TEST_SINGLE(movn(Size::i64Bit, Reg::r29, 0x4243, 0), "mov x29, #0xffffffffffffbdbc");
+  TEST_SINGLE(movn(Size::i64Bit, Reg::r29, 0x4243, 16), "mov x29, #0xffffffffbdbcffff");
+  TEST_SINGLE(movn(Size::i64Bit, Reg::r29, 0x4243, 32), "mov x29, #0xffffbdbcffffffff");
+  TEST_SINGLE(movn(Size::i64Bit, Reg::r29, 0x4243, 48), "mov x29, #0xbdbcffffffffffff");
+
+  TEST_SINGLE(mov(Size::i32Bit, Reg::r29, 0x4243), "mov w29, #0x4243");
+  TEST_SINGLE(mov(Size::i64Bit, Reg::r29, 0x4243), "mov x29, #0x4243");
+
+  TEST_SINGLE(mov(WReg::w29, 0x4243), "mov w29, #0x4243");
+  TEST_SINGLE(mov(XReg::x29, 0x4243), "mov x29, #0x4243");
+
+  TEST_SINGLE(movz(Size::i32Bit, Reg::r29, 0x4243, 0), "mov w29, #0x4243");
+  TEST_SINGLE(movz(Size::i32Bit, Reg::r29, 0x4243, 16), "mov w29, #0x42430000");
+
+  TEST_SINGLE(movz(Size::i64Bit, Reg::r29, 0x4243, 0), "mov x29, #0x4243");
+  TEST_SINGLE(movz(Size::i64Bit, Reg::r29, 0x4243, 16), "mov x29, #0x42430000");
+  TEST_SINGLE(movz(Size::i64Bit, Reg::r29, 0x4243, 32), "mov x29, #0x424300000000");
+  TEST_SINGLE(movz(Size::i64Bit, Reg::r29, 0x4243, 48), "mov x29, #0x4243000000000000");
+
+  TEST_SINGLE(movk(Size::i32Bit, Reg::r29, 0x4243, 0), "movk w29, #0x4243");
+  TEST_SINGLE(movk(Size::i32Bit, Reg::r29, 0x4243, 16), "movk w29, #0x4243, lsl #16");
+
+  TEST_SINGLE(movk(Size::i64Bit, Reg::r29, 0x4243, 0), "movk x29, #0x4243");
+  TEST_SINGLE(movk(Size::i64Bit, Reg::r29, 0x4243, 16), "movk x29, #0x4243, lsl #16");
+  TEST_SINGLE(movk(Size::i64Bit, Reg::r29, 0x4243, 32), "movk x29, #0x4243, lsl #32");
+  TEST_SINGLE(movk(Size::i64Bit, Reg::r29, 0x4243, 48), "movk x29, #0x4243, lsl #48");
+
+  TEST_SINGLE(movn(WReg::w29, 0x4243, 0), "mov w29, #0xffffbdbc");
+  TEST_SINGLE(movn(WReg::w29, 0x4243, 16), "mov w29, #0xbdbcffff");
+  TEST_SINGLE(movz(WReg::w29, 0x4243, 0), "mov w29, #0x4243");
+  TEST_SINGLE(movz(WReg::w29, 0x4243, 16), "mov w29, #0x42430000");
+  TEST_SINGLE(movk(WReg::w29, 0x4243, 0), "movk w29, #0x4243");
+  TEST_SINGLE(movk(WReg::w29, 0x4243, 16), "movk w29, #0x4243, lsl #16");
+
+  TEST_SINGLE(movn(XReg::x29, 0x4243, 0), "mov x29, #0xffffffffffffbdbc");
+  TEST_SINGLE(movn(XReg::x29, 0x4243, 16), "mov x29, #0xffffffffbdbcffff");
+  TEST_SINGLE(movn(XReg::x29, 0x4243, 32), "mov x29, #0xffffbdbcffffffff");
+  TEST_SINGLE(movn(XReg::x29, 0x4243, 48), "mov x29, #0xbdbcffffffffffff");
+  TEST_SINGLE(movz(XReg::x29, 0x4243, 0), "mov x29, #0x4243");
+  TEST_SINGLE(movz(XReg::x29, 0x4243, 16), "mov x29, #0x42430000");
+  TEST_SINGLE(movz(XReg::x29, 0x4243, 32), "mov x29, #0x424300000000");
+  TEST_SINGLE(movz(XReg::x29, 0x4243, 48), "mov x29, #0x4243000000000000");
+  TEST_SINGLE(movk(XReg::x29, 0x4243, 0), "movk x29, #0x4243");
+  TEST_SINGLE(movk(XReg::x29, 0x4243, 16), "movk x29, #0x4243, lsl #16");
+  TEST_SINGLE(movk(XReg::x29, 0x4243, 32), "movk x29, #0x4243, lsl #32");
+  TEST_SINGLE(movk(XReg::x29, 0x4243, 48), "movk x29, #0x4243, lsl #48");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: ALU: Bitfield") {
+  TEST_SINGLE(sxtb(Size::i32Bit, Reg::r29, Reg::r28), "sxtb w29, w28");
+  TEST_SINGLE(sxtb(Size::i64Bit, Reg::r29, Reg::r28), "sxtb x29, w28");
+
+  TEST_SINGLE(sxth(Size::i32Bit, Reg::r29, Reg::r28), "sxth w29, w28");
+  TEST_SINGLE(sxth(Size::i64Bit, Reg::r29, Reg::r28), "sxth x29, w28");
+
+  TEST_SINGLE(sxtw(XReg::x29, XReg::x28), "sxtw x29, w28");
+
+  TEST_SINGLE(sbfx(Size::i32Bit, Reg::r29, Reg::r28, 4, 16), "sbfx w29, w28, #4, #16");
+  TEST_SINGLE(sbfx(Size::i64Bit, Reg::r29, Reg::r28, 4, 16), "sbfx x29, x28, #4, #16");
+
+  TEST_SINGLE(asr(Size::i32Bit, Reg::r29, Reg::r28, 17), "asr w29, w28, #17");
+  TEST_SINGLE(asr(Size::i64Bit, Reg::r29, Reg::r28, 17), "asr x29, x28, #17");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: ALU: Extract") {
+  TEST_SINGLE(extr(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, 0), "extr w29, w28, w27, #0");
+  TEST_SINGLE(extr(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, 16), "extr w29, w28, w27, #16");
+
+  TEST_SINGLE(extr(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, 0), "extr x29, x28, x27, #0");
+  TEST_SINGLE(extr(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, 16), "extr x29, x28, x27, #16");
+  TEST_SINGLE(extr(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, 32), "extr x29, x28, x27, #32");
+  TEST_SINGLE(extr(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, 48), "extr x29, x28, x27, #48");
+
+  TEST_SINGLE(ror(Size::i32Bit, Reg::r29, Reg::r28, 0), "ror w29, w28, #0");
+  TEST_SINGLE(ror(Size::i32Bit, Reg::r29, Reg::r28, 16), "ror w29, w28, #16");
+
+  TEST_SINGLE(ror(Size::i64Bit, Reg::r29, Reg::r28, 0), "ror x29, x28, #0");
+  TEST_SINGLE(ror(Size::i64Bit, Reg::r29, Reg::r28, 16), "ror x29, x28, #16");
+  TEST_SINGLE(ror(Size::i64Bit, Reg::r29, Reg::r28, 32), "ror x29, x28, #32");
+  TEST_SINGLE(ror(Size::i64Bit, Reg::r29, Reg::r28, 48), "ror x29, x28, #48");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: ALU: Data processing - 2 source") {
+  TEST_SINGLE(udiv(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27), "udiv w29, w28, w27");
+  TEST_SINGLE(sdiv(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27), "sdiv w29, w28, w27");
+  TEST_SINGLE(lslv(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27), "lsl w29, w28, w27");
+  TEST_SINGLE(lsrv(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27), "lsr w29, w28, w27");
+  TEST_SINGLE(asrv(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27), "asr w29, w28, w27");
+  TEST_SINGLE(rorv(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27), "ror w29, w28, w27");
+  TEST_SINGLE(crc32b(WReg::w29, WReg::w28, WReg::w27), "crc32b w29, w28, w27");
+  TEST_SINGLE(crc32h(WReg::w29, WReg::w28, WReg::w27), "crc32h w29, w28, w27");
+  TEST_SINGLE(crc32w(WReg::w29, WReg::w28, WReg::w27), "crc32w w29, w28, w27");
+  TEST_SINGLE(crc32cb(WReg::w29, WReg::w28, WReg::w27), "crc32cb w29, w28, w27");
+  TEST_SINGLE(crc32ch(WReg::w29, WReg::w28, WReg::w27), "crc32ch w29, w28, w27");
+  TEST_SINGLE(crc32cw(WReg::w29, WReg::w28, WReg::w27), "crc32cw w29, w28, w27");
+
+  TEST_SINGLE(udiv(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27), "udiv x29, x28, x27");
+  TEST_SINGLE(sdiv(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27), "sdiv x29, x28, x27");
+  TEST_SINGLE(lslv(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27), "lsl x29, x28, x27");
+  TEST_SINGLE(lsrv(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27), "lsr x29, x28, x27");
+  TEST_SINGLE(asrv(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27), "asr x29, x28, x27");
+  TEST_SINGLE(rorv(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27), "ror x29, x28, x27");
+
+  if (false) {
+    // vixl doesn't support this instruction.
+    TEST_SINGLE(subp(XReg::x29, XReg::x28, XReg::x27), "subp x29, x28, x27");
+    TEST_SINGLE(irg(XReg::x29, XReg::x28, XReg::x27), "irg x29, x28, x27");
+    TEST_SINGLE(gmi(XReg::x29, XReg::x28, XReg::x27), "gmi x29, x28, x27");
+  }
+
+  TEST_SINGLE(pacga(XReg::x29, XReg::x28, XReg::x27), "pacga x29, x28, x27");
+  TEST_SINGLE(crc32x(XReg::x29, XReg::x28, XReg::x27), "crc32x w29, w28, x27");
+  TEST_SINGLE(crc32cx(XReg::x29, XReg::x28, XReg::x27), "crc32cx w29, w28, x27");
+
+  if (false) {
+    // vixl doesn't support this instruction.
+    TEST_SINGLE(subps(XReg::x29, XReg::x28, XReg::x27), "subps x29, x28, x27");
+  }
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: ALU: Data processing - 1 source") {
+  TEST_SINGLE(rbit(Size::i32Bit, Reg::r29, Reg::r28), "rbit w29, w28");
+  TEST_SINGLE(rbit(Size::i64Bit, Reg::r29, Reg::r28), "rbit x29, x28");
+
+  TEST_SINGLE(rev16(Size::i32Bit, Reg::r29, Reg::r28), "rev16 w29, w28");
+  TEST_SINGLE(rev16(Size::i64Bit, Reg::r29, Reg::r28), "rev16 x29, x28");
+
+  TEST_SINGLE(rev(WReg::w29, WReg::w28), "rev w29, w28");
+  TEST_SINGLE(rev32(XReg::x29, XReg::x28), "rev32 x29, x28");
+
+  TEST_SINGLE(clz(Size::i32Bit, Reg::r29, Reg::r28), "clz w29, w28");
+  TEST_SINGLE(clz(Size::i64Bit, Reg::r29, Reg::r28), "clz x29, x28");
+
+  TEST_SINGLE(cls(Size::i32Bit, Reg::r29, Reg::r28), "cls w29, w28");
+  TEST_SINGLE(cls(Size::i64Bit, Reg::r29, Reg::r28), "cls x29, x28");
+
+  TEST_SINGLE(rev(XReg::x29, XReg::x28), "rev x29, x28");
+  TEST_SINGLE(rev(Size::i32Bit, Reg::r29, Reg::r28), "rev w29, w28");
+  TEST_SINGLE(rev(Size::i64Bit, Reg::r29, Reg::r28), "rev x29, x28");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: ALU: PAUTH") {
+  // TODO: Implement in the emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: ALU: Logical - shifted register") {
+  TEST_SINGLE(mov(Size::i32Bit, Reg::r29, Reg::r28), "mov w29, w28");
+  TEST_SINGLE(mov(Size::i64Bit, Reg::r29, Reg::r28), "mov x29, x28");
+
+  TEST_SINGLE(mov(WReg::w29, WReg::w28), "mov w29, w28");
+  TEST_SINGLE(mov(XReg::x29, XReg::x28), "mov x29, x28");
+
+  TEST_SINGLE(mvn(Size::i32Bit, Reg::r29, Reg::r28, ShiftType::LSL, 0), "mvn w29, w28");
+  TEST_SINGLE(mvn(Size::i32Bit, Reg::r29, Reg::r28, ShiftType::LSL, 1), "mvn w29, w28, lsl #1");
+  TEST_SINGLE(mvn(Size::i32Bit, Reg::r29, Reg::r28, ShiftType::LSL, 31), "mvn w29, w28, lsl #31");
+
+  TEST_SINGLE(mvn(Size::i32Bit, Reg::r29, Reg::r28, ShiftType::LSR, 0), "mvn w29, w28");
+  TEST_SINGLE(mvn(Size::i32Bit, Reg::r29, Reg::r28, ShiftType::LSR, 1), "mvn w29, w28, lsr #1");
+  TEST_SINGLE(mvn(Size::i32Bit, Reg::r29, Reg::r28, ShiftType::LSR, 31), "mvn w29, w28, lsr #31");
+
+  TEST_SINGLE(mvn(Size::i32Bit, Reg::r29, Reg::r28, ShiftType::ASR, 0), "mvn w29, w28");
+  TEST_SINGLE(mvn(Size::i32Bit, Reg::r29, Reg::r28, ShiftType::ASR, 1), "mvn w29, w28, asr #1");
+  TEST_SINGLE(mvn(Size::i32Bit, Reg::r29, Reg::r28, ShiftType::ASR, 31), "mvn w29, w28, asr #31");
+
+  TEST_SINGLE(mvn(Size::i32Bit, Reg::r29, Reg::r28, ShiftType::ROR, 0), "mvn w29, w28");
+  TEST_SINGLE(mvn(Size::i32Bit, Reg::r29, Reg::r28, ShiftType::ROR, 1), "mvn w29, w28, ror #1");
+  TEST_SINGLE(mvn(Size::i32Bit, Reg::r29, Reg::r28, ShiftType::ROR, 31), "mvn w29, w28, ror #31");
+
+  TEST_SINGLE(mvn(Size::i64Bit, Reg::r29, Reg::r28, ShiftType::LSL, 0), "mvn x29, x28");
+  TEST_SINGLE(mvn(Size::i64Bit, Reg::r29, Reg::r28, ShiftType::LSL, 1), "mvn x29, x28, lsl #1");
+  TEST_SINGLE(mvn(Size::i64Bit, Reg::r29, Reg::r28, ShiftType::LSL, 63), "mvn x29, x28, lsl #63");
+
+  TEST_SINGLE(mvn(Size::i64Bit, Reg::r29, Reg::r28, ShiftType::LSR, 0), "mvn x29, x28");
+  TEST_SINGLE(mvn(Size::i64Bit, Reg::r29, Reg::r28, ShiftType::LSR, 1), "mvn x29, x28, lsr #1");
+  TEST_SINGLE(mvn(Size::i64Bit, Reg::r29, Reg::r28, ShiftType::LSR, 63), "mvn x29, x28, lsr #63");
+
+  TEST_SINGLE(mvn(Size::i64Bit, Reg::r29, Reg::r28, ShiftType::ASR, 0), "mvn x29, x28");
+  TEST_SINGLE(mvn(Size::i64Bit, Reg::r29, Reg::r28, ShiftType::ASR, 1), "mvn x29, x28, asr #1");
+  TEST_SINGLE(mvn(Size::i64Bit, Reg::r29, Reg::r28, ShiftType::ASR, 63), "mvn x29, x28, asr #63");
+
+  TEST_SINGLE(mvn(Size::i64Bit, Reg::r29, Reg::r28, ShiftType::ROR, 0), "mvn x29, x28");
+  TEST_SINGLE(mvn(Size::i64Bit, Reg::r29, Reg::r28, ShiftType::ROR, 1), "mvn x29, x28, ror #1");
+  TEST_SINGLE(mvn(Size::i64Bit, Reg::r29, Reg::r28, ShiftType::ROR, 63), "mvn x29, x28, ror #63");
+
+  TEST_SINGLE(and_(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 0), "and w29, w28, w27");
+  TEST_SINGLE(and_(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 1), "and w29, w28, w27, lsl #1");
+  TEST_SINGLE(and_(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 31), "and w29, w28, w27, lsl #31");
+
+  TEST_SINGLE(and_(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 0), "and w29, w28, w27");
+  TEST_SINGLE(and_(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 1), "and w29, w28, w27, lsr #1");
+  TEST_SINGLE(and_(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 31), "and w29, w28, w27, lsr #31");
+
+  TEST_SINGLE(and_(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 0), "and w29, w28, w27");
+  TEST_SINGLE(and_(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 1), "and w29, w28, w27, asr #1");
+  TEST_SINGLE(and_(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 31), "and w29, w28, w27, asr #31");
+
+  TEST_SINGLE(and_(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 0), "and w29, w28, w27");
+  TEST_SINGLE(and_(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 1), "and w29, w28, w27, ror #1");
+  TEST_SINGLE(and_(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 31), "and w29, w28, w27, ror #31");
+
+  TEST_SINGLE(and_(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 0), "and x29, x28, x27");
+  TEST_SINGLE(and_(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 1), "and x29, x28, x27, lsl #1");
+  TEST_SINGLE(and_(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 63), "and x29, x28, x27, lsl #63");
+
+  TEST_SINGLE(and_(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 0), "and x29, x28, x27");
+  TEST_SINGLE(and_(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 1), "and x29, x28, x27, lsr #1");
+  TEST_SINGLE(and_(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 63), "and x29, x28, x27, lsr #63");
+
+  TEST_SINGLE(and_(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 0), "and x29, x28, x27");
+  TEST_SINGLE(and_(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 1), "and x29, x28, x27, asr #1");
+  TEST_SINGLE(and_(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 63), "and x29, x28, x27, asr #63");
+
+  TEST_SINGLE(and_(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 0), "and x29, x28, x27");
+  TEST_SINGLE(and_(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 1), "and x29, x28, x27, ror #1");
+  TEST_SINGLE(and_(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 63), "and x29, x28, x27, ror #63");
+
+  TEST_SINGLE(ands(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 0), "ands w29, w28, w27");
+  TEST_SINGLE(ands(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 1), "ands w29, w28, w27, lsl #1");
+  TEST_SINGLE(ands(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 31), "ands w29, w28, w27, lsl #31");
+
+  TEST_SINGLE(ands(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 0), "ands w29, w28, w27");
+  TEST_SINGLE(ands(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 1), "ands w29, w28, w27, lsr #1");
+  TEST_SINGLE(ands(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 31), "ands w29, w28, w27, lsr #31");
+
+  TEST_SINGLE(ands(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 0), "ands w29, w28, w27");
+  TEST_SINGLE(ands(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 1), "ands w29, w28, w27, asr #1");
+  TEST_SINGLE(ands(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 31), "ands w29, w28, w27, asr #31");
+
+  TEST_SINGLE(ands(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 0), "ands w29, w28, w27");
+  TEST_SINGLE(ands(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 1), "ands w29, w28, w27, ror #1");
+  TEST_SINGLE(ands(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 31), "ands w29, w28, w27, ror #31");
+
+  TEST_SINGLE(ands(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 0), "ands x29, x28, x27");
+  TEST_SINGLE(ands(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 1), "ands x29, x28, x27, lsl #1");
+  TEST_SINGLE(ands(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 63), "ands x29, x28, x27, lsl #63");
+
+  TEST_SINGLE(ands(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 0), "ands x29, x28, x27");
+  TEST_SINGLE(ands(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 1), "ands x29, x28, x27, lsr #1");
+  TEST_SINGLE(ands(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 63), "ands x29, x28, x27, lsr #63");
+
+  TEST_SINGLE(ands(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 0), "ands x29, x28, x27");
+  TEST_SINGLE(ands(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 1), "ands x29, x28, x27, asr #1");
+  TEST_SINGLE(ands(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 63), "ands x29, x28, x27, asr #63");
+
+  TEST_SINGLE(ands(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 0), "ands x29, x28, x27");
+  TEST_SINGLE(ands(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 1), "ands x29, x28, x27, ror #1");
+  TEST_SINGLE(ands(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 63), "ands x29, x28, x27, ror #63");
+
+  TEST_SINGLE(bic(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 0), "bic w29, w28, w27");
+  TEST_SINGLE(bic(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 1), "bic w29, w28, w27, lsl #1");
+  TEST_SINGLE(bic(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 31), "bic w29, w28, w27, lsl #31");
+
+  TEST_SINGLE(bic(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 0), "bic w29, w28, w27");
+  TEST_SINGLE(bic(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 1), "bic w29, w28, w27, lsr #1");
+  TEST_SINGLE(bic(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 31), "bic w29, w28, w27, lsr #31");
+
+  TEST_SINGLE(bic(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 0), "bic w29, w28, w27");
+  TEST_SINGLE(bic(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 1), "bic w29, w28, w27, asr #1");
+  TEST_SINGLE(bic(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 31), "bic w29, w28, w27, asr #31");
+
+  TEST_SINGLE(bic(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 0), "bic w29, w28, w27");
+  TEST_SINGLE(bic(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 1), "bic w29, w28, w27, ror #1");
+  TEST_SINGLE(bic(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 31), "bic w29, w28, w27, ror #31");
+
+  TEST_SINGLE(bic(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 0), "bic x29, x28, x27");
+  TEST_SINGLE(bic(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 1), "bic x29, x28, x27, lsl #1");
+  TEST_SINGLE(bic(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 63), "bic x29, x28, x27, lsl #63");
+
+  TEST_SINGLE(bic(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 0), "bic x29, x28, x27");
+  TEST_SINGLE(bic(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 1), "bic x29, x28, x27, lsr #1");
+  TEST_SINGLE(bic(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 63), "bic x29, x28, x27, lsr #63");
+
+  TEST_SINGLE(bic(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 0), "bic x29, x28, x27");
+  TEST_SINGLE(bic(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 1), "bic x29, x28, x27, asr #1");
+  TEST_SINGLE(bic(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 63), "bic x29, x28, x27, asr #63");
+
+  TEST_SINGLE(bic(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 0), "bic x29, x28, x27");
+  TEST_SINGLE(bic(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 1), "bic x29, x28, x27, ror #1");
+  TEST_SINGLE(bic(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 63), "bic x29, x28, x27, ror #63");
+
+  TEST_SINGLE(bics(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 0), "bics w29, w28, w27");
+  TEST_SINGLE(bics(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 1), "bics w29, w28, w27, lsl #1");
+  TEST_SINGLE(bics(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 31), "bics w29, w28, w27, lsl #31");
+
+  TEST_SINGLE(bics(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 0), "bics w29, w28, w27");
+  TEST_SINGLE(bics(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 1), "bics w29, w28, w27, lsr #1");
+  TEST_SINGLE(bics(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 31), "bics w29, w28, w27, lsr #31");
+
+  TEST_SINGLE(bics(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 0), "bics w29, w28, w27");
+  TEST_SINGLE(bics(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 1), "bics w29, w28, w27, asr #1");
+  TEST_SINGLE(bics(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 31), "bics w29, w28, w27, asr #31");
+
+  TEST_SINGLE(bics(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 0), "bics w29, w28, w27");
+  TEST_SINGLE(bics(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 1), "bics w29, w28, w27, ror #1");
+  TEST_SINGLE(bics(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 31), "bics w29, w28, w27, ror #31");
+
+  TEST_SINGLE(bics(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 0), "bics x29, x28, x27");
+  TEST_SINGLE(bics(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 1), "bics x29, x28, x27, lsl #1");
+  TEST_SINGLE(bics(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 63), "bics x29, x28, x27, lsl #63");
+
+  TEST_SINGLE(bics(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 0), "bics x29, x28, x27");
+  TEST_SINGLE(bics(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 1), "bics x29, x28, x27, lsr #1");
+  TEST_SINGLE(bics(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 63), "bics x29, x28, x27, lsr #63");
+
+  TEST_SINGLE(bics(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 0), "bics x29, x28, x27");
+  TEST_SINGLE(bics(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 1), "bics x29, x28, x27, asr #1");
+  TEST_SINGLE(bics(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 63), "bics x29, x28, x27, asr #63");
+
+  TEST_SINGLE(bics(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 0), "bics x29, x28, x27");
+  TEST_SINGLE(bics(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 1), "bics x29, x28, x27, ror #1");
+  TEST_SINGLE(bics(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 63), "bics x29, x28, x27, ror #63");
+
+  TEST_SINGLE(orr(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 0), "orr w29, w28, w27");
+  TEST_SINGLE(orr(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 1), "orr w29, w28, w27, lsl #1");
+  TEST_SINGLE(orr(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 31), "orr w29, w28, w27, lsl #31");
+
+  TEST_SINGLE(orr(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 0), "orr w29, w28, w27");
+  TEST_SINGLE(orr(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 1), "orr w29, w28, w27, lsr #1");
+  TEST_SINGLE(orr(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 31), "orr w29, w28, w27, lsr #31");
+
+  TEST_SINGLE(orr(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 0), "orr w29, w28, w27");
+  TEST_SINGLE(orr(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 1), "orr w29, w28, w27, asr #1");
+  TEST_SINGLE(orr(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 31), "orr w29, w28, w27, asr #31");
+
+  TEST_SINGLE(orr(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 0), "orr w29, w28, w27");
+  TEST_SINGLE(orr(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 1), "orr w29, w28, w27, ror #1");
+  TEST_SINGLE(orr(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 31), "orr w29, w28, w27, ror #31");
+
+  TEST_SINGLE(orr(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 0), "orr x29, x28, x27");
+  TEST_SINGLE(orr(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 1), "orr x29, x28, x27, lsl #1");
+  TEST_SINGLE(orr(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 63), "orr x29, x28, x27, lsl #63");
+
+  TEST_SINGLE(orr(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 0), "orr x29, x28, x27");
+  TEST_SINGLE(orr(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 1), "orr x29, x28, x27, lsr #1");
+  TEST_SINGLE(orr(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 63), "orr x29, x28, x27, lsr #63");
+
+  TEST_SINGLE(orr(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 0), "orr x29, x28, x27");
+  TEST_SINGLE(orr(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 1), "orr x29, x28, x27, asr #1");
+  TEST_SINGLE(orr(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 63), "orr x29, x28, x27, asr #63");
+
+  TEST_SINGLE(orr(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 0), "orr x29, x28, x27");
+  TEST_SINGLE(orr(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 1), "orr x29, x28, x27, ror #1");
+  TEST_SINGLE(orr(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 63), "orr x29, x28, x27, ror #63");
+
+  TEST_SINGLE(orn(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 0), "orn w29, w28, w27");
+  TEST_SINGLE(orn(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 1), "orn w29, w28, w27, lsl #1");
+  TEST_SINGLE(orn(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 31), "orn w29, w28, w27, lsl #31");
+
+  TEST_SINGLE(orn(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 0), "orn w29, w28, w27");
+  TEST_SINGLE(orn(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 1), "orn w29, w28, w27, lsr #1");
+  TEST_SINGLE(orn(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 31), "orn w29, w28, w27, lsr #31");
+
+  TEST_SINGLE(orn(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 0), "orn w29, w28, w27");
+  TEST_SINGLE(orn(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 1), "orn w29, w28, w27, asr #1");
+  TEST_SINGLE(orn(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 31), "orn w29, w28, w27, asr #31");
+
+  TEST_SINGLE(orn(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 0), "orn w29, w28, w27");
+  TEST_SINGLE(orn(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 1), "orn w29, w28, w27, ror #1");
+  TEST_SINGLE(orn(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 31), "orn w29, w28, w27, ror #31");
+
+  TEST_SINGLE(orn(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 0), "orn x29, x28, x27");
+  TEST_SINGLE(orn(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 1), "orn x29, x28, x27, lsl #1");
+  TEST_SINGLE(orn(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 63), "orn x29, x28, x27, lsl #63");
+
+  TEST_SINGLE(orn(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 0), "orn x29, x28, x27");
+  TEST_SINGLE(orn(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 1), "orn x29, x28, x27, lsr #1");
+  TEST_SINGLE(orn(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 63), "orn x29, x28, x27, lsr #63");
+
+  TEST_SINGLE(orn(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 0), "orn x29, x28, x27");
+  TEST_SINGLE(orn(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 1), "orn x29, x28, x27, asr #1");
+  TEST_SINGLE(orn(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 63), "orn x29, x28, x27, asr #63");
+
+  TEST_SINGLE(orn(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 0), "orn x29, x28, x27");
+  TEST_SINGLE(orn(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 1), "orn x29, x28, x27, ror #1");
+  TEST_SINGLE(orn(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 63), "orn x29, x28, x27, ror #63");
+
+  TEST_SINGLE(eor(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 0), "eor w29, w28, w27");
+  TEST_SINGLE(eor(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 1), "eor w29, w28, w27, lsl #1");
+  TEST_SINGLE(eor(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 31), "eor w29, w28, w27, lsl #31");
+
+  TEST_SINGLE(eor(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 0), "eor w29, w28, w27");
+  TEST_SINGLE(eor(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 1), "eor w29, w28, w27, lsr #1");
+  TEST_SINGLE(eor(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 31), "eor w29, w28, w27, lsr #31");
+
+  TEST_SINGLE(eor(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 0), "eor w29, w28, w27");
+  TEST_SINGLE(eor(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 1), "eor w29, w28, w27, asr #1");
+  TEST_SINGLE(eor(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 31), "eor w29, w28, w27, asr #31");
+
+  TEST_SINGLE(eor(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 0), "eor w29, w28, w27");
+  TEST_SINGLE(eor(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 1), "eor w29, w28, w27, ror #1");
+  TEST_SINGLE(eor(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 31), "eor w29, w28, w27, ror #31");
+
+  TEST_SINGLE(eor(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 0), "eor x29, x28, x27");
+  TEST_SINGLE(eor(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 1), "eor x29, x28, x27, lsl #1");
+  TEST_SINGLE(eor(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 63), "eor x29, x28, x27, lsl #63");
+
+  TEST_SINGLE(eor(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 0), "eor x29, x28, x27");
+  TEST_SINGLE(eor(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 1), "eor x29, x28, x27, lsr #1");
+  TEST_SINGLE(eor(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 63), "eor x29, x28, x27, lsr #63");
+
+  TEST_SINGLE(eor(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 0), "eor x29, x28, x27");
+  TEST_SINGLE(eor(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 1), "eor x29, x28, x27, asr #1");
+  TEST_SINGLE(eor(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 63), "eor x29, x28, x27, asr #63");
+
+  TEST_SINGLE(eor(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 0), "eor x29, x28, x27");
+  TEST_SINGLE(eor(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 1), "eor x29, x28, x27, ror #1");
+  TEST_SINGLE(eor(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 63), "eor x29, x28, x27, ror #63");
+
+  TEST_SINGLE(eon(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 0), "eon w29, w28, w27");
+  TEST_SINGLE(eon(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 1), "eon w29, w28, w27, lsl #1");
+  TEST_SINGLE(eon(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 31), "eon w29, w28, w27, lsl #31");
+
+  TEST_SINGLE(eon(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 0), "eon w29, w28, w27");
+  TEST_SINGLE(eon(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 1), "eon w29, w28, w27, lsr #1");
+  TEST_SINGLE(eon(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 31), "eon w29, w28, w27, lsr #31");
+
+  TEST_SINGLE(eon(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 0), "eon w29, w28, w27");
+  TEST_SINGLE(eon(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 1), "eon w29, w28, w27, asr #1");
+  TEST_SINGLE(eon(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 31), "eon w29, w28, w27, asr #31");
+
+  TEST_SINGLE(eon(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 0), "eon w29, w28, w27");
+  TEST_SINGLE(eon(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 1), "eon w29, w28, w27, ror #1");
+  TEST_SINGLE(eon(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 31), "eon w29, w28, w27, ror #31");
+
+  TEST_SINGLE(eon(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 0), "eon x29, x28, x27");
+  TEST_SINGLE(eon(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 1), "eon x29, x28, x27, lsl #1");
+  TEST_SINGLE(eon(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSL, 63), "eon x29, x28, x27, lsl #63");
+
+  TEST_SINGLE(eon(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 0), "eon x29, x28, x27");
+  TEST_SINGLE(eon(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 1), "eon x29, x28, x27, lsr #1");
+  TEST_SINGLE(eon(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::LSR, 63), "eon x29, x28, x27, lsr #63");
+
+  TEST_SINGLE(eon(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 0), "eon x29, x28, x27");
+  TEST_SINGLE(eon(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 1), "eon x29, x28, x27, asr #1");
+  TEST_SINGLE(eon(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ASR, 63), "eon x29, x28, x27, asr #63");
+
+  TEST_SINGLE(eon(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 0), "eon x29, x28, x27");
+  TEST_SINGLE(eon(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 1), "eon x29, x28, x27, ror #1");
+  TEST_SINGLE(eon(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ShiftType::ROR, 63), "eon x29, x28, x27, ror #63");
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: ALU: AddSub - shifted register") {
+  {
+    TEST_SINGLE(add(Size::i64Bit, Reg::r30, Reg::r29, Reg::r28), "add x30, x29, x28");
+    TEST_SINGLE(add(Size::i32Bit, Reg::r30, Reg::r29, Reg::r28), "add w30, w29, w28");
+
+    // LSL
+    TEST_SINGLE(add(Size::i64Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::LSL, 1), "add x30, x29, x28, lsl #1");
+    TEST_SINGLE(add(Size::i32Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::LSL, 1), "add w30, w29, w28, lsl #1");
+    TEST_SINGLE(add(Size::i64Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::LSL, 63), "add x30, x29, x28, lsl #63");
+    TEST_SINGLE(add(Size::i32Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::LSL, 31), "add w30, w29, w28, lsl #31");
+
+    TEST_SINGLE(add(Size::i32Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::LSL, 32), "unallocated (Unallocated)");
+
+    // LSR
+    TEST_SINGLE(add(Size::i64Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::LSR, 1), "add x30, x29, x28, lsr #1");
+    TEST_SINGLE(add(Size::i32Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::LSR, 1), "add w30, w29, w28, lsr #1");
+    TEST_SINGLE(add(Size::i64Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::LSR, 63), "add x30, x29, x28, lsr #63");
+    TEST_SINGLE(add(Size::i32Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::LSR, 31), "add w30, w29, w28, lsr #31");
+
+    TEST_SINGLE(add(Size::i32Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::LSR, 32), "unallocated (Unallocated)");
+
+    // ASR
+    TEST_SINGLE(add(Size::i64Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::ASR, 1), "add x30, x29, x28, asr #1");
+    TEST_SINGLE(add(Size::i32Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::ASR, 1), "add w30, w29, w28, asr #1");
+    TEST_SINGLE(add(Size::i64Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::ASR, 63), "add x30, x29, x28, asr #63");
+    TEST_SINGLE(add(Size::i32Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::ASR, 31), "add w30, w29, w28, asr #31");
+
+    TEST_SINGLE(add(Size::i32Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::ASR, 32), "unallocated (Unallocated)");
+
+    // ROR
+    // Unsupported
+  }
+
+  {
+    TEST_SINGLE(adds(Size::i64Bit, Reg::r30, Reg::r29, Reg::r28), "adds x30, x29, x28");
+    TEST_SINGLE(adds(Size::i32Bit, Reg::r30, Reg::r29, Reg::r28), "adds w30, w29, w28");
+
+    // LSL
+    TEST_SINGLE(adds(Size::i64Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::LSL, 1), "adds x30, x29, x28, lsl #1");
+    TEST_SINGLE(adds(Size::i32Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::LSL, 1), "adds w30, w29, w28, lsl #1");
+    TEST_SINGLE(adds(Size::i64Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::LSL, 63), "adds x30, x29, x28, lsl #63");
+    TEST_SINGLE(adds(Size::i32Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::LSL, 31), "adds w30, w29, w28, lsl #31");
+
+    TEST_SINGLE(adds(Size::i32Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::LSL, 32), "unallocated (Unallocated)");
+
+    // LSR
+    TEST_SINGLE(adds(Size::i64Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::LSR, 1), "adds x30, x29, x28, lsr #1");
+    TEST_SINGLE(adds(Size::i32Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::LSR, 1), "adds w30, w29, w28, lsr #1");
+    TEST_SINGLE(adds(Size::i64Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::LSR, 63), "adds x30, x29, x28, lsr #63");
+    TEST_SINGLE(adds(Size::i32Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::LSR, 31), "adds w30, w29, w28, lsr #31");
+
+    TEST_SINGLE(adds(Size::i32Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::LSR, 32), "unallocated (Unallocated)");
+
+    // ASR
+    TEST_SINGLE(adds(Size::i64Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::ASR, 1), "adds x30, x29, x28, asr #1");
+    TEST_SINGLE(adds(Size::i32Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::ASR, 1), "adds w30, w29, w28, asr #1");
+    TEST_SINGLE(adds(Size::i64Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::ASR, 63), "adds x30, x29, x28, asr #63");
+    TEST_SINGLE(adds(Size::i32Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::ASR, 31), "adds w30, w29, w28, asr #31");
+
+    TEST_SINGLE(adds(Size::i32Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::ASR, 32), "unallocated (Unallocated)");
+
+    // ROR
+    // Unsupported
+  }
+
+  // FEX had a bug with this
+  TEST_SINGLE(sub(Size::i64Bit, Reg::rsp, Reg::rsp, Reg::r0, ShiftType::LSL, 0), "neg xzr, x0");
+
+  {
+    TEST_SINGLE(sub(Size::i64Bit, Reg::r30, Reg::r29, Reg::r28), "sub x30, x29, x28");
+    TEST_SINGLE(sub(Size::i32Bit, Reg::r30, Reg::r29, Reg::r28), "sub w30, w29, w28");
+
+    // LSL
+    TEST_SINGLE(sub(Size::i64Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::LSL, 1), "sub x30, x29, x28, lsl #1");
+    TEST_SINGLE(sub(Size::i32Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::LSL, 1), "sub w30, w29, w28, lsl #1");
+    TEST_SINGLE(sub(Size::i64Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::LSL, 63), "sub x30, x29, x28, lsl #63");
+    TEST_SINGLE(sub(Size::i32Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::LSL, 31), "sub w30, w29, w28, lsl #31");
+
+    TEST_SINGLE(sub(Size::i32Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::LSL, 32), "unallocated (Unallocated)");
+
+    // LSR
+    TEST_SINGLE(sub(Size::i64Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::LSR, 1), "sub x30, x29, x28, lsr #1");
+    TEST_SINGLE(sub(Size::i32Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::LSR, 1), "sub w30, w29, w28, lsr #1");
+    TEST_SINGLE(sub(Size::i64Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::LSR, 63), "sub x30, x29, x28, lsr #63");
+    TEST_SINGLE(sub(Size::i32Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::LSR, 31), "sub w30, w29, w28, lsr #31");
+
+    TEST_SINGLE(sub(Size::i32Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::LSR, 32), "unallocated (Unallocated)");
+
+    // ASR
+    TEST_SINGLE(sub(Size::i64Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::ASR, 1), "sub x30, x29, x28, asr #1");
+    TEST_SINGLE(sub(Size::i32Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::ASR, 1), "sub w30, w29, w28, asr #1");
+    TEST_SINGLE(sub(Size::i64Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::ASR, 63), "sub x30, x29, x28, asr #63");
+    TEST_SINGLE(sub(Size::i32Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::ASR, 31), "sub w30, w29, w28, asr #31");
+
+    TEST_SINGLE(sub(Size::i32Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::ASR, 32), "unallocated (Unallocated)");
+
+    // ROR
+    // Unsupported
+  }
+
+  {
+    TEST_SINGLE(subs(Size::i64Bit, Reg::r30, Reg::r29, Reg::r28), "subs x30, x29, x28");
+    TEST_SINGLE(subs(Size::i32Bit, Reg::r30, Reg::r29, Reg::r28), "subs w30, w29, w28");
+
+    // LSL
+    TEST_SINGLE(subs(Size::i64Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::LSL, 1), "subs x30, x29, x28, lsl #1");
+    TEST_SINGLE(subs(Size::i32Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::LSL, 1), "subs w30, w29, w28, lsl #1");
+    TEST_SINGLE(subs(Size::i64Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::LSL, 63), "subs x30, x29, x28, lsl #63");
+    TEST_SINGLE(subs(Size::i32Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::LSL, 31), "subs w30, w29, w28, lsl #31");
+
+    TEST_SINGLE(subs(Size::i32Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::LSL, 32), "unallocated (Unallocated)");
+
+    // LSR
+    TEST_SINGLE(subs(Size::i64Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::LSR, 1), "subs x30, x29, x28, lsr #1");
+    TEST_SINGLE(subs(Size::i32Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::LSR, 1), "subs w30, w29, w28, lsr #1");
+    TEST_SINGLE(subs(Size::i64Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::LSR, 63), "subs x30, x29, x28, lsr #63");
+    TEST_SINGLE(subs(Size::i32Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::LSR, 31), "subs w30, w29, w28, lsr #31");
+
+    TEST_SINGLE(subs(Size::i32Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::LSR, 32), "unallocated (Unallocated)");
+
+    // ASR
+    TEST_SINGLE(subs(Size::i64Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::ASR, 1), "subs x30, x29, x28, asr #1");
+    TEST_SINGLE(subs(Size::i32Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::ASR, 1), "subs w30, w29, w28, asr #1");
+    TEST_SINGLE(subs(Size::i64Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::ASR, 63), "subs x30, x29, x28, asr #63");
+    TEST_SINGLE(subs(Size::i32Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::ASR, 31), "subs w30, w29, w28, asr #31");
+
+    TEST_SINGLE(subs(Size::i32Bit, Reg::r30, Reg::r29, Reg::r28, ShiftType::ASR, 32), "unallocated (Unallocated)");
+
+    // ROR
+    // Unsupported
+  }
+
+  {
+    TEST_SINGLE(neg(Size::i64Bit, Reg::r30, Reg::r29), "neg x30, x29");
+    TEST_SINGLE(neg(Size::i32Bit, Reg::r30, Reg::r29), "neg w30, w29");
+
+    // LSL
+    TEST_SINGLE(neg(Size::i64Bit, Reg::r30, Reg::r29, ShiftType::LSL, 1), "neg x30, x29, lsl #1");
+    TEST_SINGLE(neg(Size::i32Bit, Reg::r30, Reg::r29, ShiftType::LSL, 1), "neg w30, w29, lsl #1");
+    TEST_SINGLE(neg(Size::i64Bit, Reg::r30, Reg::r29, ShiftType::LSL, 63), "neg x30, x29, lsl #63");
+    TEST_SINGLE(neg(Size::i32Bit, Reg::r30, Reg::r29, ShiftType::LSL, 31), "neg w30, w29, lsl #31");
+
+    TEST_SINGLE(neg(Size::i32Bit, Reg::r30, Reg::r29, ShiftType::LSL, 32), "unallocated (Unallocated)");
+
+    // LSR
+    TEST_SINGLE(neg(Size::i64Bit, Reg::r30, Reg::r29, ShiftType::LSR, 1), "neg x30, x29, lsr #1");
+    TEST_SINGLE(neg(Size::i32Bit, Reg::r30, Reg::r29, ShiftType::LSR, 1), "neg w30, w29, lsr #1");
+    TEST_SINGLE(neg(Size::i64Bit, Reg::r30, Reg::r29, ShiftType::LSR, 63), "neg x30, x29, lsr #63");
+    TEST_SINGLE(neg(Size::i32Bit, Reg::r30, Reg::r29, ShiftType::LSR, 31), "neg w30, w29, lsr #31");
+
+    TEST_SINGLE(neg(Size::i32Bit, Reg::r30, Reg::r29, ShiftType::LSR, 32), "unallocated (Unallocated)");
+
+    // ASR
+    TEST_SINGLE(neg(Size::i64Bit, Reg::r30, Reg::r29, ShiftType::ASR, 1), "neg x30, x29, asr #1");
+    TEST_SINGLE(neg(Size::i32Bit, Reg::r30, Reg::r29, ShiftType::ASR, 1), "neg w30, w29, asr #1");
+    TEST_SINGLE(neg(Size::i64Bit, Reg::r30, Reg::r29, ShiftType::ASR, 63), "neg x30, x29, asr #63");
+    TEST_SINGLE(neg(Size::i32Bit, Reg::r30, Reg::r29, ShiftType::ASR, 31), "neg w30, w29, asr #31");
+
+    TEST_SINGLE(neg(Size::i32Bit, Reg::r30, Reg::r29, ShiftType::ASR, 32), "unallocated (Unallocated)");
+
+    // ROR
+    // Unsupported
+  }
+
+  {
+    TEST_SINGLE(cmp(Size::i64Bit, Reg::r30, Reg::r29), "cmp x30, x29");
+    TEST_SINGLE(cmp(Size::i32Bit, Reg::r30, Reg::r29), "cmp w30, w29");
+
+    // LSL
+    TEST_SINGLE(cmp(Size::i64Bit, Reg::r30, Reg::r29, ShiftType::LSL, 1), "cmp x30, x29, lsl #1");
+    TEST_SINGLE(cmp(Size::i32Bit, Reg::r30, Reg::r29, ShiftType::LSL, 1), "cmp w30, w29, lsl #1");
+    TEST_SINGLE(cmp(Size::i64Bit, Reg::r30, Reg::r29, ShiftType::LSL, 63), "cmp x30, x29, lsl #63");
+    TEST_SINGLE(cmp(Size::i32Bit, Reg::r30, Reg::r29, ShiftType::LSL, 31), "cmp w30, w29, lsl #31");
+
+    TEST_SINGLE(cmp(Size::i32Bit, Reg::r30, Reg::r29, ShiftType::LSL, 32), "unallocated (Unallocated)");
+
+    // LSR
+    TEST_SINGLE(cmp(Size::i64Bit, Reg::r30, Reg::r29, ShiftType::LSR, 1), "cmp x30, x29, lsr #1");
+    TEST_SINGLE(cmp(Size::i32Bit, Reg::r30, Reg::r29, ShiftType::LSR, 1), "cmp w30, w29, lsr #1");
+    TEST_SINGLE(cmp(Size::i64Bit, Reg::r30, Reg::r29, ShiftType::LSR, 63), "cmp x30, x29, lsr #63");
+    TEST_SINGLE(cmp(Size::i32Bit, Reg::r30, Reg::r29, ShiftType::LSR, 31), "cmp w30, w29, lsr #31");
+
+    TEST_SINGLE(cmp(Size::i32Bit, Reg::r30, Reg::r29, ShiftType::LSR, 32), "unallocated (Unallocated)");
+
+    // ASR
+    TEST_SINGLE(cmp(Size::i64Bit, Reg::r30, Reg::r29, ShiftType::ASR, 1), "cmp x30, x29, asr #1");
+    TEST_SINGLE(cmp(Size::i32Bit, Reg::r30, Reg::r29, ShiftType::ASR, 1), "cmp w30, w29, asr #1");
+    TEST_SINGLE(cmp(Size::i64Bit, Reg::r30, Reg::r29, ShiftType::ASR, 63), "cmp x30, x29, asr #63");
+    TEST_SINGLE(cmp(Size::i32Bit, Reg::r30, Reg::r29, ShiftType::ASR, 31), "cmp w30, w29, asr #31");
+
+    TEST_SINGLE(cmp(Size::i32Bit, Reg::r30, Reg::r29, ShiftType::ASR, 32), "unallocated (Unallocated)");
+
+    // ROR
+    // Unsupported
+  }
+
+  {
+    TEST_SINGLE(negs(Size::i64Bit, Reg::r30, Reg::r29), "negs x30, x29");
+    TEST_SINGLE(negs(Size::i32Bit, Reg::r30, Reg::r29), "negs w30, w29");
+
+    // LSL
+    TEST_SINGLE(negs(Size::i64Bit, Reg::r30, Reg::r29, ShiftType::LSL, 1), "negs x30, x29, lsl #1");
+    TEST_SINGLE(negs(Size::i32Bit, Reg::r30, Reg::r29, ShiftType::LSL, 1), "negs w30, w29, lsl #1");
+    TEST_SINGLE(negs(Size::i64Bit, Reg::r30, Reg::r29, ShiftType::LSL, 63), "negs x30, x29, lsl #63");
+    TEST_SINGLE(negs(Size::i32Bit, Reg::r30, Reg::r29, ShiftType::LSL, 31), "negs w30, w29, lsl #31");
+
+    TEST_SINGLE(negs(Size::i32Bit, Reg::r30, Reg::r29, ShiftType::LSL, 32), "unallocated (Unallocated)");
+
+    // LSR
+    TEST_SINGLE(negs(Size::i64Bit, Reg::r30, Reg::r29, ShiftType::LSR, 1), "negs x30, x29, lsr #1");
+    TEST_SINGLE(negs(Size::i32Bit, Reg::r30, Reg::r29, ShiftType::LSR, 1), "negs w30, w29, lsr #1");
+    TEST_SINGLE(negs(Size::i64Bit, Reg::r30, Reg::r29, ShiftType::LSR, 63), "negs x30, x29, lsr #63");
+    TEST_SINGLE(negs(Size::i32Bit, Reg::r30, Reg::r29, ShiftType::LSR, 31), "negs w30, w29, lsr #31");
+
+    TEST_SINGLE(negs(Size::i32Bit, Reg::r30, Reg::r29, ShiftType::LSR, 32), "unallocated (Unallocated)");
+
+    // ASR
+    TEST_SINGLE(negs(Size::i64Bit, Reg::r30, Reg::r29, ShiftType::ASR, 1), "negs x30, x29, asr #1");
+    TEST_SINGLE(negs(Size::i32Bit, Reg::r30, Reg::r29, ShiftType::ASR, 1), "negs w30, w29, asr #1");
+    TEST_SINGLE(negs(Size::i64Bit, Reg::r30, Reg::r29, ShiftType::ASR, 63), "negs x30, x29, asr #63");
+    TEST_SINGLE(negs(Size::i32Bit, Reg::r30, Reg::r29, ShiftType::ASR, 31), "negs w30, w29, asr #31");
+
+    TEST_SINGLE(negs(Size::i32Bit, Reg::r30, Reg::r29, ShiftType::ASR, 32), "unallocated (Unallocated)");
+
+    // ROR
+    // Unsupported
+  }
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: ALU: AddSub - extended register") {
+  TEST_SINGLE(add(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTB, 0), "add w29, w28, w27, uxtb");
+  TEST_SINGLE(add(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTB, 1), "add w29, w28, w27, uxtb #1");
+  TEST_SINGLE(add(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTB, 2), "add w29, w28, w27, uxtb #2");
+  TEST_SINGLE(add(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTB, 3), "add w29, w28, w27, uxtb #3");
+  TEST_SINGLE(add(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTB, 4), "add w29, w28, w27, uxtb #4");
+
+  TEST_SINGLE(add(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTH, 0), "add w29, w28, w27, uxth");
+  TEST_SINGLE(add(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTH, 1), "add w29, w28, w27, uxth #1");
+  TEST_SINGLE(add(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTH, 2), "add w29, w28, w27, uxth #2");
+  TEST_SINGLE(add(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTH, 3), "add w29, w28, w27, uxth #3");
+  TEST_SINGLE(add(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTH, 4), "add w29, w28, w27, uxth #4");
+
+  TEST_SINGLE(add(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTW, 0), "add w29, w28, w27, uxtw");
+  TEST_SINGLE(add(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTW, 1), "add w29, w28, w27, uxtw #1");
+  TEST_SINGLE(add(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTW, 2), "add w29, w28, w27, uxtw #2");
+  TEST_SINGLE(add(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTW, 3), "add w29, w28, w27, uxtw #3");
+  TEST_SINGLE(add(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTW, 4), "add w29, w28, w27, uxtw #4");
+
+  TEST_SINGLE(add(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTX, 0), "add w29, w28, x27, uxtx");
+  TEST_SINGLE(add(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTX, 1), "add w29, w28, x27, uxtx #1");
+  TEST_SINGLE(add(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTX, 2), "add w29, w28, x27, uxtx #2");
+  TEST_SINGLE(add(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTX, 3), "add w29, w28, x27, uxtx #3");
+  TEST_SINGLE(add(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTX, 4), "add w29, w28, x27, uxtx #4");
+
+  TEST_SINGLE(add(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTB, 0), "add w29, w28, w27, sxtb");
+  TEST_SINGLE(add(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTB, 1), "add w29, w28, w27, sxtb #1");
+  TEST_SINGLE(add(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTB, 2), "add w29, w28, w27, sxtb #2");
+  TEST_SINGLE(add(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTB, 3), "add w29, w28, w27, sxtb #3");
+  TEST_SINGLE(add(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTB, 4), "add w29, w28, w27, sxtb #4");
+
+  TEST_SINGLE(add(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTH, 0), "add w29, w28, w27, sxth");
+  TEST_SINGLE(add(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTH, 1), "add w29, w28, w27, sxth #1");
+  TEST_SINGLE(add(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTH, 2), "add w29, w28, w27, sxth #2");
+  TEST_SINGLE(add(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTH, 3), "add w29, w28, w27, sxth #3");
+  TEST_SINGLE(add(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTH, 4), "add w29, w28, w27, sxth #4");
+
+  TEST_SINGLE(add(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTW, 0), "add w29, w28, w27, sxtw");
+  TEST_SINGLE(add(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTW, 1), "add w29, w28, w27, sxtw #1");
+  TEST_SINGLE(add(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTW, 2), "add w29, w28, w27, sxtw #2");
+  TEST_SINGLE(add(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTW, 3), "add w29, w28, w27, sxtw #3");
+  TEST_SINGLE(add(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTW, 4), "add w29, w28, w27, sxtw #4");
+
+  TEST_SINGLE(add(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTX, 0), "add w29, w28, x27, sxtx");
+  TEST_SINGLE(add(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTX, 1), "add w29, w28, x27, sxtx #1");
+  TEST_SINGLE(add(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTX, 2), "add w29, w28, x27, sxtx #2");
+  TEST_SINGLE(add(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTX, 3), "add w29, w28, x27, sxtx #3");
+  TEST_SINGLE(add(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTX, 4), "add w29, w28, x27, sxtx #4");
+
+  TEST_SINGLE(add(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTB, 0), "add x29, x28, w27, uxtb");
+  TEST_SINGLE(add(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTB, 1), "add x29, x28, w27, uxtb #1");
+  TEST_SINGLE(add(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTB, 2), "add x29, x28, w27, uxtb #2");
+  TEST_SINGLE(add(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTB, 3), "add x29, x28, w27, uxtb #3");
+  TEST_SINGLE(add(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTB, 4), "add x29, x28, w27, uxtb #4");
+
+  TEST_SINGLE(add(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTH, 0), "add x29, x28, w27, uxth");
+  TEST_SINGLE(add(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTH, 1), "add x29, x28, w27, uxth #1");
+  TEST_SINGLE(add(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTH, 2), "add x29, x28, w27, uxth #2");
+  TEST_SINGLE(add(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTH, 3), "add x29, x28, w27, uxth #3");
+  TEST_SINGLE(add(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTH, 4), "add x29, x28, w27, uxth #4");
+
+  TEST_SINGLE(add(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTW, 0), "add x29, x28, w27, uxtw");
+  TEST_SINGLE(add(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTW, 1), "add x29, x28, w27, uxtw #1");
+  TEST_SINGLE(add(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTW, 2), "add x29, x28, w27, uxtw #2");
+  TEST_SINGLE(add(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTW, 3), "add x29, x28, w27, uxtw #3");
+  TEST_SINGLE(add(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTW, 4), "add x29, x28, w27, uxtw #4");
+
+  TEST_SINGLE(add(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTX, 0), "add x29, x28, x27, uxtx");
+  TEST_SINGLE(add(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTX, 1), "add x29, x28, x27, uxtx #1");
+  TEST_SINGLE(add(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTX, 2), "add x29, x28, x27, uxtx #2");
+  TEST_SINGLE(add(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTX, 3), "add x29, x28, x27, uxtx #3");
+  TEST_SINGLE(add(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTX, 4), "add x29, x28, x27, uxtx #4");
+
+  TEST_SINGLE(add(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTB, 0), "add x29, x28, w27, sxtb");
+  TEST_SINGLE(add(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTB, 1), "add x29, x28, w27, sxtb #1");
+  TEST_SINGLE(add(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTB, 2), "add x29, x28, w27, sxtb #2");
+  TEST_SINGLE(add(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTB, 3), "add x29, x28, w27, sxtb #3");
+  TEST_SINGLE(add(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTB, 4), "add x29, x28, w27, sxtb #4");
+
+  TEST_SINGLE(add(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTH, 0), "add x29, x28, w27, sxth");
+  TEST_SINGLE(add(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTH, 1), "add x29, x28, w27, sxth #1");
+  TEST_SINGLE(add(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTH, 2), "add x29, x28, w27, sxth #2");
+  TEST_SINGLE(add(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTH, 3), "add x29, x28, w27, sxth #3");
+  TEST_SINGLE(add(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTH, 4), "add x29, x28, w27, sxth #4");
+
+  TEST_SINGLE(add(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTW, 0), "add x29, x28, w27, sxtw");
+  TEST_SINGLE(add(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTW, 1), "add x29, x28, w27, sxtw #1");
+  TEST_SINGLE(add(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTW, 2), "add x29, x28, w27, sxtw #2");
+  TEST_SINGLE(add(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTW, 3), "add x29, x28, w27, sxtw #3");
+  TEST_SINGLE(add(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTW, 4), "add x29, x28, w27, sxtw #4");
+
+  TEST_SINGLE(add(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTX, 0), "add x29, x28, x27, sxtx");
+  TEST_SINGLE(add(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTX, 1), "add x29, x28, x27, sxtx #1");
+  TEST_SINGLE(add(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTX, 2), "add x29, x28, x27, sxtx #2");
+  TEST_SINGLE(add(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTX, 3), "add x29, x28, x27, sxtx #3");
+  TEST_SINGLE(add(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTX, 4), "add x29, x28, x27, sxtx #4");
+
+
+  TEST_SINGLE(adds(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTB, 0), "adds w29, w28, w27, uxtb");
+  TEST_SINGLE(adds(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTB, 1), "adds w29, w28, w27, uxtb #1");
+  TEST_SINGLE(adds(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTB, 2), "adds w29, w28, w27, uxtb #2");
+  TEST_SINGLE(adds(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTB, 3), "adds w29, w28, w27, uxtb #3");
+  TEST_SINGLE(adds(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTB, 4), "adds w29, w28, w27, uxtb #4");
+
+  TEST_SINGLE(adds(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTH, 0), "adds w29, w28, w27, uxth");
+  TEST_SINGLE(adds(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTH, 1), "adds w29, w28, w27, uxth #1");
+  TEST_SINGLE(adds(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTH, 2), "adds w29, w28, w27, uxth #2");
+  TEST_SINGLE(adds(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTH, 3), "adds w29, w28, w27, uxth #3");
+  TEST_SINGLE(adds(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTH, 4), "adds w29, w28, w27, uxth #4");
+
+  TEST_SINGLE(adds(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTW, 0), "adds w29, w28, w27, uxtw");
+  TEST_SINGLE(adds(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTW, 1), "adds w29, w28, w27, uxtw #1");
+  TEST_SINGLE(adds(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTW, 2), "adds w29, w28, w27, uxtw #2");
+  TEST_SINGLE(adds(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTW, 3), "adds w29, w28, w27, uxtw #3");
+  TEST_SINGLE(adds(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTW, 4), "adds w29, w28, w27, uxtw #4");
+
+  TEST_SINGLE(adds(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTX, 0), "adds w29, w28, x27, uxtx");
+  TEST_SINGLE(adds(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTX, 1), "adds w29, w28, x27, uxtx #1");
+  TEST_SINGLE(adds(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTX, 2), "adds w29, w28, x27, uxtx #2");
+  TEST_SINGLE(adds(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTX, 3), "adds w29, w28, x27, uxtx #3");
+  TEST_SINGLE(adds(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTX, 4), "adds w29, w28, x27, uxtx #4");
+
+  TEST_SINGLE(adds(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTB, 0), "adds w29, w28, w27, sxtb");
+  TEST_SINGLE(adds(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTB, 1), "adds w29, w28, w27, sxtb #1");
+  TEST_SINGLE(adds(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTB, 2), "adds w29, w28, w27, sxtb #2");
+  TEST_SINGLE(adds(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTB, 3), "adds w29, w28, w27, sxtb #3");
+  TEST_SINGLE(adds(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTB, 4), "adds w29, w28, w27, sxtb #4");
+
+  TEST_SINGLE(adds(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTH, 0), "adds w29, w28, w27, sxth");
+  TEST_SINGLE(adds(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTH, 1), "adds w29, w28, w27, sxth #1");
+  TEST_SINGLE(adds(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTH, 2), "adds w29, w28, w27, sxth #2");
+  TEST_SINGLE(adds(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTH, 3), "adds w29, w28, w27, sxth #3");
+  TEST_SINGLE(adds(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTH, 4), "adds w29, w28, w27, sxth #4");
+
+  TEST_SINGLE(adds(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTW, 0), "adds w29, w28, w27, sxtw");
+  TEST_SINGLE(adds(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTW, 1), "adds w29, w28, w27, sxtw #1");
+  TEST_SINGLE(adds(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTW, 2), "adds w29, w28, w27, sxtw #2");
+  TEST_SINGLE(adds(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTW, 3), "adds w29, w28, w27, sxtw #3");
+  TEST_SINGLE(adds(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTW, 4), "adds w29, w28, w27, sxtw #4");
+
+  TEST_SINGLE(adds(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTX, 0), "adds w29, w28, x27, sxtx");
+  TEST_SINGLE(adds(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTX, 1), "adds w29, w28, x27, sxtx #1");
+  TEST_SINGLE(adds(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTX, 2), "adds w29, w28, x27, sxtx #2");
+  TEST_SINGLE(adds(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTX, 3), "adds w29, w28, x27, sxtx #3");
+  TEST_SINGLE(adds(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTX, 4), "adds w29, w28, x27, sxtx #4");
+
+  TEST_SINGLE(adds(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTB, 0), "adds x29, x28, w27, uxtb");
+  TEST_SINGLE(adds(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTB, 1), "adds x29, x28, w27, uxtb #1");
+  TEST_SINGLE(adds(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTB, 2), "adds x29, x28, w27, uxtb #2");
+  TEST_SINGLE(adds(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTB, 3), "adds x29, x28, w27, uxtb #3");
+  TEST_SINGLE(adds(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTB, 4), "adds x29, x28, w27, uxtb #4");
+
+  TEST_SINGLE(adds(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTH, 0), "adds x29, x28, w27, uxth");
+  TEST_SINGLE(adds(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTH, 1), "adds x29, x28, w27, uxth #1");
+  TEST_SINGLE(adds(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTH, 2), "adds x29, x28, w27, uxth #2");
+  TEST_SINGLE(adds(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTH, 3), "adds x29, x28, w27, uxth #3");
+  TEST_SINGLE(adds(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTH, 4), "adds x29, x28, w27, uxth #4");
+
+  TEST_SINGLE(adds(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTW, 0), "adds x29, x28, w27, uxtw");
+  TEST_SINGLE(adds(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTW, 1), "adds x29, x28, w27, uxtw #1");
+  TEST_SINGLE(adds(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTW, 2), "adds x29, x28, w27, uxtw #2");
+  TEST_SINGLE(adds(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTW, 3), "adds x29, x28, w27, uxtw #3");
+  TEST_SINGLE(adds(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTW, 4), "adds x29, x28, w27, uxtw #4");
+
+  TEST_SINGLE(adds(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTX, 0), "adds x29, x28, x27, uxtx");
+  TEST_SINGLE(adds(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTX, 1), "adds x29, x28, x27, uxtx #1");
+  TEST_SINGLE(adds(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTX, 2), "adds x29, x28, x27, uxtx #2");
+  TEST_SINGLE(adds(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTX, 3), "adds x29, x28, x27, uxtx #3");
+  TEST_SINGLE(adds(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTX, 4), "adds x29, x28, x27, uxtx #4");
+
+  TEST_SINGLE(adds(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTB, 0), "adds x29, x28, w27, sxtb");
+  TEST_SINGLE(adds(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTB, 1), "adds x29, x28, w27, sxtb #1");
+  TEST_SINGLE(adds(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTB, 2), "adds x29, x28, w27, sxtb #2");
+  TEST_SINGLE(adds(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTB, 3), "adds x29, x28, w27, sxtb #3");
+  TEST_SINGLE(adds(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTB, 4), "adds x29, x28, w27, sxtb #4");
+
+  TEST_SINGLE(adds(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTH, 0), "adds x29, x28, w27, sxth");
+  TEST_SINGLE(adds(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTH, 1), "adds x29, x28, w27, sxth #1");
+  TEST_SINGLE(adds(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTH, 2), "adds x29, x28, w27, sxth #2");
+  TEST_SINGLE(adds(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTH, 3), "adds x29, x28, w27, sxth #3");
+  TEST_SINGLE(adds(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTH, 4), "adds x29, x28, w27, sxth #4");
+
+  TEST_SINGLE(adds(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTW, 0), "adds x29, x28, w27, sxtw");
+  TEST_SINGLE(adds(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTW, 1), "adds x29, x28, w27, sxtw #1");
+  TEST_SINGLE(adds(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTW, 2), "adds x29, x28, w27, sxtw #2");
+  TEST_SINGLE(adds(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTW, 3), "adds x29, x28, w27, sxtw #3");
+  TEST_SINGLE(adds(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTW, 4), "adds x29, x28, w27, sxtw #4");
+
+  TEST_SINGLE(adds(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTX, 0), "adds x29, x28, x27, sxtx");
+  TEST_SINGLE(adds(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTX, 1), "adds x29, x28, x27, sxtx #1");
+  TEST_SINGLE(adds(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTX, 2), "adds x29, x28, x27, sxtx #2");
+  TEST_SINGLE(adds(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTX, 3), "adds x29, x28, x27, sxtx #3");
+  TEST_SINGLE(adds(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTX, 4), "adds x29, x28, x27, sxtx #4");
+
+  TEST_SINGLE(sub(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTB, 0), "sub w29, w28, w27, uxtb");
+  TEST_SINGLE(sub(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTB, 1), "sub w29, w28, w27, uxtb #1");
+  TEST_SINGLE(sub(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTB, 2), "sub w29, w28, w27, uxtb #2");
+  TEST_SINGLE(sub(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTB, 3), "sub w29, w28, w27, uxtb #3");
+  TEST_SINGLE(sub(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTB, 4), "sub w29, w28, w27, uxtb #4");
+
+  TEST_SINGLE(sub(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTH, 0), "sub w29, w28, w27, uxth");
+  TEST_SINGLE(sub(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTH, 1), "sub w29, w28, w27, uxth #1");
+  TEST_SINGLE(sub(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTH, 2), "sub w29, w28, w27, uxth #2");
+  TEST_SINGLE(sub(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTH, 3), "sub w29, w28, w27, uxth #3");
+  TEST_SINGLE(sub(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTH, 4), "sub w29, w28, w27, uxth #4");
+
+  TEST_SINGLE(sub(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTW, 0), "sub w29, w28, w27, uxtw");
+  TEST_SINGLE(sub(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTW, 1), "sub w29, w28, w27, uxtw #1");
+  TEST_SINGLE(sub(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTW, 2), "sub w29, w28, w27, uxtw #2");
+  TEST_SINGLE(sub(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTW, 3), "sub w29, w28, w27, uxtw #3");
+  TEST_SINGLE(sub(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTW, 4), "sub w29, w28, w27, uxtw #4");
+
+  TEST_SINGLE(sub(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTX, 0), "sub w29, w28, x27, uxtx");
+  TEST_SINGLE(sub(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTX, 1), "sub w29, w28, x27, uxtx #1");
+  TEST_SINGLE(sub(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTX, 2), "sub w29, w28, x27, uxtx #2");
+  TEST_SINGLE(sub(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTX, 3), "sub w29, w28, x27, uxtx #3");
+  TEST_SINGLE(sub(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTX, 4), "sub w29, w28, x27, uxtx #4");
+
+  TEST_SINGLE(sub(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTB, 0), "sub w29, w28, w27, sxtb");
+  TEST_SINGLE(sub(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTB, 1), "sub w29, w28, w27, sxtb #1");
+  TEST_SINGLE(sub(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTB, 2), "sub w29, w28, w27, sxtb #2");
+  TEST_SINGLE(sub(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTB, 3), "sub w29, w28, w27, sxtb #3");
+  TEST_SINGLE(sub(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTB, 4), "sub w29, w28, w27, sxtb #4");
+
+  TEST_SINGLE(sub(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTH, 0), "sub w29, w28, w27, sxth");
+  TEST_SINGLE(sub(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTH, 1), "sub w29, w28, w27, sxth #1");
+  TEST_SINGLE(sub(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTH, 2), "sub w29, w28, w27, sxth #2");
+  TEST_SINGLE(sub(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTH, 3), "sub w29, w28, w27, sxth #3");
+  TEST_SINGLE(sub(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTH, 4), "sub w29, w28, w27, sxth #4");
+
+  TEST_SINGLE(sub(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTW, 0), "sub w29, w28, w27, sxtw");
+  TEST_SINGLE(sub(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTW, 1), "sub w29, w28, w27, sxtw #1");
+  TEST_SINGLE(sub(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTW, 2), "sub w29, w28, w27, sxtw #2");
+  TEST_SINGLE(sub(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTW, 3), "sub w29, w28, w27, sxtw #3");
+  TEST_SINGLE(sub(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTW, 4), "sub w29, w28, w27, sxtw #4");
+
+  TEST_SINGLE(sub(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTX, 0), "sub w29, w28, x27, sxtx");
+  TEST_SINGLE(sub(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTX, 1), "sub w29, w28, x27, sxtx #1");
+  TEST_SINGLE(sub(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTX, 2), "sub w29, w28, x27, sxtx #2");
+  TEST_SINGLE(sub(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTX, 3), "sub w29, w28, x27, sxtx #3");
+  TEST_SINGLE(sub(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTX, 4), "sub w29, w28, x27, sxtx #4");
+
+  TEST_SINGLE(sub(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTB, 0), "sub x29, x28, w27, uxtb");
+  TEST_SINGLE(sub(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTB, 1), "sub x29, x28, w27, uxtb #1");
+  TEST_SINGLE(sub(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTB, 2), "sub x29, x28, w27, uxtb #2");
+  TEST_SINGLE(sub(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTB, 3), "sub x29, x28, w27, uxtb #3");
+  TEST_SINGLE(sub(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTB, 4), "sub x29, x28, w27, uxtb #4");
+
+  TEST_SINGLE(sub(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTH, 0), "sub x29, x28, w27, uxth");
+  TEST_SINGLE(sub(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTH, 1), "sub x29, x28, w27, uxth #1");
+  TEST_SINGLE(sub(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTH, 2), "sub x29, x28, w27, uxth #2");
+  TEST_SINGLE(sub(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTH, 3), "sub x29, x28, w27, uxth #3");
+  TEST_SINGLE(sub(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTH, 4), "sub x29, x28, w27, uxth #4");
+
+  TEST_SINGLE(sub(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTW, 0), "sub x29, x28, w27, uxtw");
+  TEST_SINGLE(sub(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTW, 1), "sub x29, x28, w27, uxtw #1");
+  TEST_SINGLE(sub(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTW, 2), "sub x29, x28, w27, uxtw #2");
+  TEST_SINGLE(sub(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTW, 3), "sub x29, x28, w27, uxtw #3");
+  TEST_SINGLE(sub(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTW, 4), "sub x29, x28, w27, uxtw #4");
+
+  TEST_SINGLE(sub(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTX, 0), "sub x29, x28, x27, uxtx");
+  TEST_SINGLE(sub(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTX, 1), "sub x29, x28, x27, uxtx #1");
+  TEST_SINGLE(sub(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTX, 2), "sub x29, x28, x27, uxtx #2");
+  TEST_SINGLE(sub(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTX, 3), "sub x29, x28, x27, uxtx #3");
+  TEST_SINGLE(sub(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTX, 4), "sub x29, x28, x27, uxtx #4");
+
+  TEST_SINGLE(sub(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTB, 0), "sub x29, x28, w27, sxtb");
+  TEST_SINGLE(sub(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTB, 1), "sub x29, x28, w27, sxtb #1");
+  TEST_SINGLE(sub(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTB, 2), "sub x29, x28, w27, sxtb #2");
+  TEST_SINGLE(sub(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTB, 3), "sub x29, x28, w27, sxtb #3");
+  TEST_SINGLE(sub(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTB, 4), "sub x29, x28, w27, sxtb #4");
+
+  TEST_SINGLE(sub(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTH, 0), "sub x29, x28, w27, sxth");
+  TEST_SINGLE(sub(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTH, 1), "sub x29, x28, w27, sxth #1");
+  TEST_SINGLE(sub(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTH, 2), "sub x29, x28, w27, sxth #2");
+  TEST_SINGLE(sub(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTH, 3), "sub x29, x28, w27, sxth #3");
+  TEST_SINGLE(sub(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTH, 4), "sub x29, x28, w27, sxth #4");
+
+  TEST_SINGLE(sub(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTW, 0), "sub x29, x28, w27, sxtw");
+  TEST_SINGLE(sub(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTW, 1), "sub x29, x28, w27, sxtw #1");
+  TEST_SINGLE(sub(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTW, 2), "sub x29, x28, w27, sxtw #2");
+  TEST_SINGLE(sub(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTW, 3), "sub x29, x28, w27, sxtw #3");
+  TEST_SINGLE(sub(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTW, 4), "sub x29, x28, w27, sxtw #4");
+
+  TEST_SINGLE(sub(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTX, 0), "sub x29, x28, x27, sxtx");
+  TEST_SINGLE(sub(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTX, 1), "sub x29, x28, x27, sxtx #1");
+  TEST_SINGLE(sub(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTX, 2), "sub x29, x28, x27, sxtx #2");
+  TEST_SINGLE(sub(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTX, 3), "sub x29, x28, x27, sxtx #3");
+  TEST_SINGLE(sub(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTX, 4), "sub x29, x28, x27, sxtx #4");
+
+  TEST_SINGLE(subs(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTB, 0), "subs w29, w28, w27, uxtb");
+  TEST_SINGLE(subs(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTB, 1), "subs w29, w28, w27, uxtb #1");
+  TEST_SINGLE(subs(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTB, 2), "subs w29, w28, w27, uxtb #2");
+  TEST_SINGLE(subs(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTB, 3), "subs w29, w28, w27, uxtb #3");
+  TEST_SINGLE(subs(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTB, 4), "subs w29, w28, w27, uxtb #4");
+
+  TEST_SINGLE(subs(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTH, 0), "subs w29, w28, w27, uxth");
+  TEST_SINGLE(subs(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTH, 1), "subs w29, w28, w27, uxth #1");
+  TEST_SINGLE(subs(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTH, 2), "subs w29, w28, w27, uxth #2");
+  TEST_SINGLE(subs(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTH, 3), "subs w29, w28, w27, uxth #3");
+  TEST_SINGLE(subs(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTH, 4), "subs w29, w28, w27, uxth #4");
+
+  TEST_SINGLE(subs(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTW, 0), "subs w29, w28, w27, uxtw");
+  TEST_SINGLE(subs(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTW, 1), "subs w29, w28, w27, uxtw #1");
+  TEST_SINGLE(subs(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTW, 2), "subs w29, w28, w27, uxtw #2");
+  TEST_SINGLE(subs(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTW, 3), "subs w29, w28, w27, uxtw #3");
+  TEST_SINGLE(subs(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTW, 4), "subs w29, w28, w27, uxtw #4");
+
+  TEST_SINGLE(subs(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTX, 0), "subs w29, w28, x27, uxtx");
+  TEST_SINGLE(subs(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTX, 1), "subs w29, w28, x27, uxtx #1");
+  TEST_SINGLE(subs(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTX, 2), "subs w29, w28, x27, uxtx #2");
+  TEST_SINGLE(subs(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTX, 3), "subs w29, w28, x27, uxtx #3");
+  TEST_SINGLE(subs(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTX, 4), "subs w29, w28, x27, uxtx #4");
+
+  TEST_SINGLE(subs(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTB, 0), "subs w29, w28, w27, sxtb");
+  TEST_SINGLE(subs(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTB, 1), "subs w29, w28, w27, sxtb #1");
+  TEST_SINGLE(subs(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTB, 2), "subs w29, w28, w27, sxtb #2");
+  TEST_SINGLE(subs(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTB, 3), "subs w29, w28, w27, sxtb #3");
+  TEST_SINGLE(subs(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTB, 4), "subs w29, w28, w27, sxtb #4");
+
+  TEST_SINGLE(subs(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTH, 0), "subs w29, w28, w27, sxth");
+  TEST_SINGLE(subs(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTH, 1), "subs w29, w28, w27, sxth #1");
+  TEST_SINGLE(subs(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTH, 2), "subs w29, w28, w27, sxth #2");
+  TEST_SINGLE(subs(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTH, 3), "subs w29, w28, w27, sxth #3");
+  TEST_SINGLE(subs(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTH, 4), "subs w29, w28, w27, sxth #4");
+
+  TEST_SINGLE(subs(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTW, 0), "subs w29, w28, w27, sxtw");
+  TEST_SINGLE(subs(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTW, 1), "subs w29, w28, w27, sxtw #1");
+  TEST_SINGLE(subs(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTW, 2), "subs w29, w28, w27, sxtw #2");
+  TEST_SINGLE(subs(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTW, 3), "subs w29, w28, w27, sxtw #3");
+  TEST_SINGLE(subs(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTW, 4), "subs w29, w28, w27, sxtw #4");
+
+  TEST_SINGLE(subs(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTX, 0), "subs w29, w28, x27, sxtx");
+  TEST_SINGLE(subs(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTX, 1), "subs w29, w28, x27, sxtx #1");
+  TEST_SINGLE(subs(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTX, 2), "subs w29, w28, x27, sxtx #2");
+  TEST_SINGLE(subs(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTX, 3), "subs w29, w28, x27, sxtx #3");
+  TEST_SINGLE(subs(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTX, 4), "subs w29, w28, x27, sxtx #4");
+
+  TEST_SINGLE(subs(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTB, 0), "subs x29, x28, w27, uxtb");
+  TEST_SINGLE(subs(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTB, 1), "subs x29, x28, w27, uxtb #1");
+  TEST_SINGLE(subs(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTB, 2), "subs x29, x28, w27, uxtb #2");
+  TEST_SINGLE(subs(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTB, 3), "subs x29, x28, w27, uxtb #3");
+  TEST_SINGLE(subs(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTB, 4), "subs x29, x28, w27, uxtb #4");
+
+  TEST_SINGLE(subs(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTH, 0), "subs x29, x28, w27, uxth");
+  TEST_SINGLE(subs(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTH, 1), "subs x29, x28, w27, uxth #1");
+  TEST_SINGLE(subs(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTH, 2), "subs x29, x28, w27, uxth #2");
+  TEST_SINGLE(subs(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTH, 3), "subs x29, x28, w27, uxth #3");
+  TEST_SINGLE(subs(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTH, 4), "subs x29, x28, w27, uxth #4");
+
+  TEST_SINGLE(subs(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTW, 0), "subs x29, x28, w27, uxtw");
+  TEST_SINGLE(subs(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTW, 1), "subs x29, x28, w27, uxtw #1");
+  TEST_SINGLE(subs(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTW, 2), "subs x29, x28, w27, uxtw #2");
+  TEST_SINGLE(subs(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTW, 3), "subs x29, x28, w27, uxtw #3");
+  TEST_SINGLE(subs(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTW, 4), "subs x29, x28, w27, uxtw #4");
+
+  TEST_SINGLE(subs(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTX, 0), "subs x29, x28, x27, uxtx");
+  TEST_SINGLE(subs(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTX, 1), "subs x29, x28, x27, uxtx #1");
+  TEST_SINGLE(subs(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTX, 2), "subs x29, x28, x27, uxtx #2");
+  TEST_SINGLE(subs(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTX, 3), "subs x29, x28, x27, uxtx #3");
+  TEST_SINGLE(subs(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::UXTX, 4), "subs x29, x28, x27, uxtx #4");
+
+  TEST_SINGLE(subs(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTB, 0), "subs x29, x28, w27, sxtb");
+  TEST_SINGLE(subs(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTB, 1), "subs x29, x28, w27, sxtb #1");
+  TEST_SINGLE(subs(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTB, 2), "subs x29, x28, w27, sxtb #2");
+  TEST_SINGLE(subs(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTB, 3), "subs x29, x28, w27, sxtb #3");
+  TEST_SINGLE(subs(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTB, 4), "subs x29, x28, w27, sxtb #4");
+
+  TEST_SINGLE(subs(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTH, 0), "subs x29, x28, w27, sxth");
+  TEST_SINGLE(subs(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTH, 1), "subs x29, x28, w27, sxth #1");
+  TEST_SINGLE(subs(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTH, 2), "subs x29, x28, w27, sxth #2");
+  TEST_SINGLE(subs(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTH, 3), "subs x29, x28, w27, sxth #3");
+  TEST_SINGLE(subs(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTH, 4), "subs x29, x28, w27, sxth #4");
+
+  TEST_SINGLE(subs(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTW, 0), "subs x29, x28, w27, sxtw");
+  TEST_SINGLE(subs(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTW, 1), "subs x29, x28, w27, sxtw #1");
+  TEST_SINGLE(subs(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTW, 2), "subs x29, x28, w27, sxtw #2");
+  TEST_SINGLE(subs(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTW, 3), "subs x29, x28, w27, sxtw #3");
+  TEST_SINGLE(subs(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTW, 4), "subs x29, x28, w27, sxtw #4");
+
+  TEST_SINGLE(subs(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTX, 0), "subs x29, x28, x27, sxtx");
+  TEST_SINGLE(subs(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTX, 1), "subs x29, x28, x27, sxtx #1");
+  TEST_SINGLE(subs(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTX, 2), "subs x29, x28, x27, sxtx #2");
+  TEST_SINGLE(subs(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTX, 3), "subs x29, x28, x27, sxtx #3");
+  TEST_SINGLE(subs(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, ExtendedType::SXTX, 4), "subs x29, x28, x27, sxtx #4");
+
+  TEST_SINGLE(cmp(Size::i32Bit, Reg::r29, Reg::r28, ExtendedType::UXTB, 0), "cmp w29, w28, uxtb");
+  TEST_SINGLE(cmp(Size::i32Bit, Reg::r29, Reg::r28, ExtendedType::UXTB, 1), "cmp w29, w28, uxtb #1");
+  TEST_SINGLE(cmp(Size::i32Bit, Reg::r29, Reg::r28, ExtendedType::UXTB, 2), "cmp w29, w28, uxtb #2");
+  TEST_SINGLE(cmp(Size::i32Bit, Reg::r29, Reg::r28, ExtendedType::UXTB, 3), "cmp w29, w28, uxtb #3");
+  TEST_SINGLE(cmp(Size::i32Bit, Reg::r29, Reg::r28, ExtendedType::UXTB, 4), "cmp w29, w28, uxtb #4");
+
+  TEST_SINGLE(cmp(Size::i32Bit, Reg::r29, Reg::r28, ExtendedType::UXTH, 0), "cmp w29, w28, uxth");
+  TEST_SINGLE(cmp(Size::i32Bit, Reg::r29, Reg::r28, ExtendedType::UXTH, 1), "cmp w29, w28, uxth #1");
+  TEST_SINGLE(cmp(Size::i32Bit, Reg::r29, Reg::r28, ExtendedType::UXTH, 2), "cmp w29, w28, uxth #2");
+  TEST_SINGLE(cmp(Size::i32Bit, Reg::r29, Reg::r28, ExtendedType::UXTH, 3), "cmp w29, w28, uxth #3");
+  TEST_SINGLE(cmp(Size::i32Bit, Reg::r29, Reg::r28, ExtendedType::UXTH, 4), "cmp w29, w28, uxth #4");
+
+  TEST_SINGLE(cmp(Size::i32Bit, Reg::r29, Reg::r28, ExtendedType::LSL_32, 0), "cmp w29, w28");
+  TEST_SINGLE(cmp(Size::i32Bit, Reg::r29, Reg::r28, ExtendedType::LSL_32, 1), "cmp w29, w28, lsl #1");
+  TEST_SINGLE(cmp(Size::i32Bit, Reg::r29, Reg::r28, ExtendedType::LSL_32, 2), "cmp w29, w28, lsl #2");
+  TEST_SINGLE(cmp(Size::i32Bit, Reg::r29, Reg::r28, ExtendedType::LSL_32, 3), "cmp w29, w28, lsl #3");
+  TEST_SINGLE(cmp(Size::i32Bit, Reg::r29, Reg::r28, ExtendedType::LSL_32, 4), "cmp w29, w28, lsl #4");
+
+  TEST_SINGLE(cmp(Size::i32Bit, Reg::r29, Reg::r28, ExtendedType::LSL_64, 0), "cmp w29, x28");
+  TEST_SINGLE(cmp(Size::i32Bit, Reg::r29, Reg::r28, ExtendedType::LSL_64, 1), "cmp w29, x28, lsl #1");
+  TEST_SINGLE(cmp(Size::i32Bit, Reg::r29, Reg::r28, ExtendedType::LSL_64, 2), "cmp w29, x28, lsl #2");
+  TEST_SINGLE(cmp(Size::i32Bit, Reg::r29, Reg::r28, ExtendedType::LSL_64, 3), "cmp w29, x28, lsl #3");
+  TEST_SINGLE(cmp(Size::i32Bit, Reg::r29, Reg::r28, ExtendedType::LSL_64, 4), "cmp w29, x28, lsl #4");
+
+  TEST_SINGLE(cmp(Size::i32Bit, Reg::r29, Reg::r28, ExtendedType::SXTB, 0), "cmp w29, w28, sxtb");
+  TEST_SINGLE(cmp(Size::i32Bit, Reg::r29, Reg::r28, ExtendedType::SXTB, 1), "cmp w29, w28, sxtb #1");
+  TEST_SINGLE(cmp(Size::i32Bit, Reg::r29, Reg::r28, ExtendedType::SXTB, 2), "cmp w29, w28, sxtb #2");
+  TEST_SINGLE(cmp(Size::i32Bit, Reg::r29, Reg::r28, ExtendedType::SXTB, 3), "cmp w29, w28, sxtb #3");
+  TEST_SINGLE(cmp(Size::i32Bit, Reg::r29, Reg::r28, ExtendedType::SXTB, 4), "cmp w29, w28, sxtb #4");
+
+  TEST_SINGLE(cmp(Size::i32Bit, Reg::r29, Reg::r28, ExtendedType::SXTH, 0), "cmp w29, w28, sxth");
+  TEST_SINGLE(cmp(Size::i32Bit, Reg::r29, Reg::r28, ExtendedType::SXTH, 1), "cmp w29, w28, sxth #1");
+  TEST_SINGLE(cmp(Size::i32Bit, Reg::r29, Reg::r28, ExtendedType::SXTH, 2), "cmp w29, w28, sxth #2");
+  TEST_SINGLE(cmp(Size::i32Bit, Reg::r29, Reg::r28, ExtendedType::SXTH, 3), "cmp w29, w28, sxth #3");
+  TEST_SINGLE(cmp(Size::i32Bit, Reg::r29, Reg::r28, ExtendedType::SXTH, 4), "cmp w29, w28, sxth #4");
+
+  TEST_SINGLE(cmp(Size::i32Bit, Reg::r29, Reg::r28, ExtendedType::SXTW, 0), "cmp w29, w28, sxtw");
+  TEST_SINGLE(cmp(Size::i32Bit, Reg::r29, Reg::r28, ExtendedType::SXTW, 1), "cmp w29, w28, sxtw #1");
+  TEST_SINGLE(cmp(Size::i32Bit, Reg::r29, Reg::r28, ExtendedType::SXTW, 2), "cmp w29, w28, sxtw #2");
+  TEST_SINGLE(cmp(Size::i32Bit, Reg::r29, Reg::r28, ExtendedType::SXTW, 3), "cmp w29, w28, sxtw #3");
+  TEST_SINGLE(cmp(Size::i32Bit, Reg::r29, Reg::r28, ExtendedType::SXTW, 4), "cmp w29, w28, sxtw #4");
+
+  TEST_SINGLE(cmp(Size::i32Bit, Reg::r29, Reg::r28, ExtendedType::SXTX, 0), "cmp w29, x28, sxtx");
+  TEST_SINGLE(cmp(Size::i32Bit, Reg::r29, Reg::r28, ExtendedType::SXTX, 1), "cmp w29, x28, sxtx #1");
+  TEST_SINGLE(cmp(Size::i32Bit, Reg::r29, Reg::r28, ExtendedType::SXTX, 2), "cmp w29, x28, sxtx #2");
+  TEST_SINGLE(cmp(Size::i32Bit, Reg::r29, Reg::r28, ExtendedType::SXTX, 3), "cmp w29, x28, sxtx #3");
+  TEST_SINGLE(cmp(Size::i32Bit, Reg::r29, Reg::r28, ExtendedType::SXTX, 4), "cmp w29, x28, sxtx #4");
+
+  TEST_SINGLE(cmp(Size::i64Bit, Reg::r29, Reg::r28, ExtendedType::UXTB, 0), "cmp x29, w28, uxtb");
+  TEST_SINGLE(cmp(Size::i64Bit, Reg::r29, Reg::r28, ExtendedType::UXTB, 1), "cmp x29, w28, uxtb #1");
+  TEST_SINGLE(cmp(Size::i64Bit, Reg::r29, Reg::r28, ExtendedType::UXTB, 2), "cmp x29, w28, uxtb #2");
+  TEST_SINGLE(cmp(Size::i64Bit, Reg::r29, Reg::r28, ExtendedType::UXTB, 3), "cmp x29, w28, uxtb #3");
+  TEST_SINGLE(cmp(Size::i64Bit, Reg::r29, Reg::r28, ExtendedType::UXTB, 4), "cmp x29, w28, uxtb #4");
+
+  TEST_SINGLE(cmp(Size::i64Bit, Reg::r29, Reg::r28, ExtendedType::UXTH, 0), "cmp x29, w28, uxth");
+  TEST_SINGLE(cmp(Size::i64Bit, Reg::r29, Reg::r28, ExtendedType::UXTH, 1), "cmp x29, w28, uxth #1");
+  TEST_SINGLE(cmp(Size::i64Bit, Reg::r29, Reg::r28, ExtendedType::UXTH, 2), "cmp x29, w28, uxth #2");
+  TEST_SINGLE(cmp(Size::i64Bit, Reg::r29, Reg::r28, ExtendedType::UXTH, 3), "cmp x29, w28, uxth #3");
+  TEST_SINGLE(cmp(Size::i64Bit, Reg::r29, Reg::r28, ExtendedType::UXTH, 4), "cmp x29, w28, uxth #4");
+
+  TEST_SINGLE(cmp(Size::i64Bit, Reg::r29, Reg::r28, ExtendedType::UXTW, 0), "cmp x29, w28, uxtw");
+  TEST_SINGLE(cmp(Size::i64Bit, Reg::r29, Reg::r28, ExtendedType::UXTW, 1), "cmp x29, w28, uxtw #1");
+  TEST_SINGLE(cmp(Size::i64Bit, Reg::r29, Reg::r28, ExtendedType::UXTW, 2), "cmp x29, w28, uxtw #2");
+  TEST_SINGLE(cmp(Size::i64Bit, Reg::r29, Reg::r28, ExtendedType::UXTW, 3), "cmp x29, w28, uxtw #3");
+  TEST_SINGLE(cmp(Size::i64Bit, Reg::r29, Reg::r28, ExtendedType::UXTW, 4), "cmp x29, w28, uxtw #4");
+
+  TEST_SINGLE(cmp(Size::i64Bit, Reg::r29, Reg::r28, ExtendedType::LSL_64, 0), "cmp x29, x28");
+  TEST_SINGLE(cmp(Size::i64Bit, Reg::r29, Reg::r28, ExtendedType::LSL_64, 1), "cmp x29, x28, lsl #1");
+  TEST_SINGLE(cmp(Size::i64Bit, Reg::r29, Reg::r28, ExtendedType::LSL_64, 2), "cmp x29, x28, lsl #2");
+  TEST_SINGLE(cmp(Size::i64Bit, Reg::r29, Reg::r28, ExtendedType::LSL_64, 3), "cmp x29, x28, lsl #3");
+  TEST_SINGLE(cmp(Size::i64Bit, Reg::r29, Reg::r28, ExtendedType::LSL_64, 4), "cmp x29, x28, lsl #4");
+
+  TEST_SINGLE(cmp(Size::i64Bit, Reg::r29, Reg::r28, ExtendedType::SXTB, 0), "cmp x29, w28, sxtb");
+  TEST_SINGLE(cmp(Size::i64Bit, Reg::r29, Reg::r28, ExtendedType::SXTB, 1), "cmp x29, w28, sxtb #1");
+  TEST_SINGLE(cmp(Size::i64Bit, Reg::r29, Reg::r28, ExtendedType::SXTB, 2), "cmp x29, w28, sxtb #2");
+  TEST_SINGLE(cmp(Size::i64Bit, Reg::r29, Reg::r28, ExtendedType::SXTB, 3), "cmp x29, w28, sxtb #3");
+  TEST_SINGLE(cmp(Size::i64Bit, Reg::r29, Reg::r28, ExtendedType::SXTB, 4), "cmp x29, w28, sxtb #4");
+
+  TEST_SINGLE(cmp(Size::i64Bit, Reg::r29, Reg::r28, ExtendedType::SXTH, 0), "cmp x29, w28, sxth");
+  TEST_SINGLE(cmp(Size::i64Bit, Reg::r29, Reg::r28, ExtendedType::SXTH, 1), "cmp x29, w28, sxth #1");
+  TEST_SINGLE(cmp(Size::i64Bit, Reg::r29, Reg::r28, ExtendedType::SXTH, 2), "cmp x29, w28, sxth #2");
+  TEST_SINGLE(cmp(Size::i64Bit, Reg::r29, Reg::r28, ExtendedType::SXTH, 3), "cmp x29, w28, sxth #3");
+  TEST_SINGLE(cmp(Size::i64Bit, Reg::r29, Reg::r28, ExtendedType::SXTH, 4), "cmp x29, w28, sxth #4");
+
+  TEST_SINGLE(cmp(Size::i64Bit, Reg::r29, Reg::r28, ExtendedType::SXTW, 0), "cmp x29, w28, sxtw");
+  TEST_SINGLE(cmp(Size::i64Bit, Reg::r29, Reg::r28, ExtendedType::SXTW, 1), "cmp x29, w28, sxtw #1");
+  TEST_SINGLE(cmp(Size::i64Bit, Reg::r29, Reg::r28, ExtendedType::SXTW, 2), "cmp x29, w28, sxtw #2");
+  TEST_SINGLE(cmp(Size::i64Bit, Reg::r29, Reg::r28, ExtendedType::SXTW, 3), "cmp x29, w28, sxtw #3");
+  TEST_SINGLE(cmp(Size::i64Bit, Reg::r29, Reg::r28, ExtendedType::SXTW, 4), "cmp x29, w28, sxtw #4");
+
+  TEST_SINGLE(cmp(Size::i64Bit, Reg::r29, Reg::r28, ExtendedType::SXTX, 0), "cmp x29, x28, sxtx");
+  TEST_SINGLE(cmp(Size::i64Bit, Reg::r29, Reg::r28, ExtendedType::SXTX, 1), "cmp x29, x28, sxtx #1");
+  TEST_SINGLE(cmp(Size::i64Bit, Reg::r29, Reg::r28, ExtendedType::SXTX, 2), "cmp x29, x28, sxtx #2");
+  TEST_SINGLE(cmp(Size::i64Bit, Reg::r29, Reg::r28, ExtendedType::SXTX, 3), "cmp x29, x28, sxtx #3");
+  TEST_SINGLE(cmp(Size::i64Bit, Reg::r29, Reg::r28, ExtendedType::SXTX, 4), "cmp x29, x28, sxtx #4");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: ALU: AddSub - with carry") {
+  TEST_SINGLE(adc(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27), "adc w29, w28, w27");
+  TEST_SINGLE(adc(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27), "adc x29, x28, x27");
+
+  TEST_SINGLE(adcs(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27), "adcs w29, w28, w27");
+  TEST_SINGLE(adcs(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27), "adcs x29, x28, x27");
+
+  TEST_SINGLE(sbc(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27), "sbc w29, w28, w27");
+  TEST_SINGLE(sbc(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27), "sbc x29, x28, x27");
+
+  TEST_SINGLE(sbcs(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27), "sbcs w29, w28, w27");
+  TEST_SINGLE(sbcs(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27), "sbcs x29, x28, x27");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: ALU: Rotate right into flags") {
+  // TODO: Add support to emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: ALU: Evaluate into flags") {
+  // TODO: Add support to emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: ALU: Conditional compare - register") {
+  TEST_SINGLE(ccmn(Size::i32Bit, Reg::r29, Reg::r28, StatusFlags::None, Condition::CC_AL), "ccmn w29, w28, #nzcv, al");
+  TEST_SINGLE(ccmn(Size::i32Bit, Reg::r29, Reg::r28, StatusFlags::Flag_N, Condition::CC_AL), "ccmn w29, w28, #Nzcv, al");
+  TEST_SINGLE(ccmn(Size::i32Bit, Reg::r29, Reg::r28, StatusFlags::Flag_Z, Condition::CC_AL), "ccmn w29, w28, #nZcv, al");
+  TEST_SINGLE(ccmn(Size::i32Bit, Reg::r29, Reg::r28, StatusFlags::Flag_C, Condition::CC_AL), "ccmn w29, w28, #nzCv, al");
+  TEST_SINGLE(ccmn(Size::i32Bit, Reg::r29, Reg::r28, StatusFlags::Flag_V, Condition::CC_AL), "ccmn w29, w28, #nzcV, al");
+  TEST_SINGLE(ccmn(Size::i32Bit, Reg::r29, Reg::r28, StatusFlags::Flag_NZCV, Condition::CC_AL), "ccmn w29, w28, #NZCV, al");
+
+  TEST_SINGLE(ccmn(Size::i32Bit, Reg::r29, Reg::r28, StatusFlags::None, Condition::CC_EQ), "ccmn w29, w28, #nzcv, eq");
+  TEST_SINGLE(ccmn(Size::i32Bit, Reg::r29, Reg::r28, StatusFlags::Flag_N, Condition::CC_EQ), "ccmn w29, w28, #Nzcv, eq");
+  TEST_SINGLE(ccmn(Size::i32Bit, Reg::r29, Reg::r28, StatusFlags::Flag_Z, Condition::CC_EQ), "ccmn w29, w28, #nZcv, eq");
+  TEST_SINGLE(ccmn(Size::i32Bit, Reg::r29, Reg::r28, StatusFlags::Flag_C, Condition::CC_EQ), "ccmn w29, w28, #nzCv, eq");
+  TEST_SINGLE(ccmn(Size::i32Bit, Reg::r29, Reg::r28, StatusFlags::Flag_V, Condition::CC_EQ), "ccmn w29, w28, #nzcV, eq");
+  TEST_SINGLE(ccmn(Size::i32Bit, Reg::r29, Reg::r28, StatusFlags::Flag_NZCV, Condition::CC_EQ), "ccmn w29, w28, #NZCV, eq");
+
+  TEST_SINGLE(ccmn(Size::i64Bit, Reg::r29, Reg::r28, StatusFlags::None, Condition::CC_AL), "ccmn x29, x28, #nzcv, al");
+  TEST_SINGLE(ccmn(Size::i64Bit, Reg::r29, Reg::r28, StatusFlags::Flag_N, Condition::CC_AL), "ccmn x29, x28, #Nzcv, al");
+  TEST_SINGLE(ccmn(Size::i64Bit, Reg::r29, Reg::r28, StatusFlags::Flag_Z, Condition::CC_AL), "ccmn x29, x28, #nZcv, al");
+  TEST_SINGLE(ccmn(Size::i64Bit, Reg::r29, Reg::r28, StatusFlags::Flag_C, Condition::CC_AL), "ccmn x29, x28, #nzCv, al");
+  TEST_SINGLE(ccmn(Size::i64Bit, Reg::r29, Reg::r28, StatusFlags::Flag_V, Condition::CC_AL), "ccmn x29, x28, #nzcV, al");
+  TEST_SINGLE(ccmn(Size::i64Bit, Reg::r29, Reg::r28, StatusFlags::Flag_NZCV, Condition::CC_AL), "ccmn x29, x28, #NZCV, al");
+
+  TEST_SINGLE(ccmn(Size::i64Bit, Reg::r29, Reg::r28, StatusFlags::None, Condition::CC_EQ), "ccmn x29, x28, #nzcv, eq");
+  TEST_SINGLE(ccmn(Size::i64Bit, Reg::r29, Reg::r28, StatusFlags::Flag_N, Condition::CC_EQ), "ccmn x29, x28, #Nzcv, eq");
+  TEST_SINGLE(ccmn(Size::i64Bit, Reg::r29, Reg::r28, StatusFlags::Flag_Z, Condition::CC_EQ), "ccmn x29, x28, #nZcv, eq");
+  TEST_SINGLE(ccmn(Size::i64Bit, Reg::r29, Reg::r28, StatusFlags::Flag_C, Condition::CC_EQ), "ccmn x29, x28, #nzCv, eq");
+  TEST_SINGLE(ccmn(Size::i64Bit, Reg::r29, Reg::r28, StatusFlags::Flag_V, Condition::CC_EQ), "ccmn x29, x28, #nzcV, eq");
+  TEST_SINGLE(ccmn(Size::i64Bit, Reg::r29, Reg::r28, StatusFlags::Flag_NZCV, Condition::CC_EQ), "ccmn x29, x28, #NZCV, eq");
+
+  TEST_SINGLE(ccmp(Size::i32Bit, Reg::r29, Reg::r28, StatusFlags::None, Condition::CC_AL), "ccmp w29, w28, #nzcv, al");
+  TEST_SINGLE(ccmp(Size::i32Bit, Reg::r29, Reg::r28, StatusFlags::Flag_N, Condition::CC_AL), "ccmp w29, w28, #Nzcv, al");
+  TEST_SINGLE(ccmp(Size::i32Bit, Reg::r29, Reg::r28, StatusFlags::Flag_Z, Condition::CC_AL), "ccmp w29, w28, #nZcv, al");
+  TEST_SINGLE(ccmp(Size::i32Bit, Reg::r29, Reg::r28, StatusFlags::Flag_C, Condition::CC_AL), "ccmp w29, w28, #nzCv, al");
+  TEST_SINGLE(ccmp(Size::i32Bit, Reg::r29, Reg::r28, StatusFlags::Flag_V, Condition::CC_AL), "ccmp w29, w28, #nzcV, al");
+  TEST_SINGLE(ccmp(Size::i32Bit, Reg::r29, Reg::r28, StatusFlags::Flag_NZCV, Condition::CC_AL), "ccmp w29, w28, #NZCV, al");
+
+  TEST_SINGLE(ccmp(Size::i32Bit, Reg::r29, Reg::r28, StatusFlags::None, Condition::CC_EQ), "ccmp w29, w28, #nzcv, eq");
+  TEST_SINGLE(ccmp(Size::i32Bit, Reg::r29, Reg::r28, StatusFlags::Flag_N, Condition::CC_EQ), "ccmp w29, w28, #Nzcv, eq");
+  TEST_SINGLE(ccmp(Size::i32Bit, Reg::r29, Reg::r28, StatusFlags::Flag_Z, Condition::CC_EQ), "ccmp w29, w28, #nZcv, eq");
+  TEST_SINGLE(ccmp(Size::i32Bit, Reg::r29, Reg::r28, StatusFlags::Flag_C, Condition::CC_EQ), "ccmp w29, w28, #nzCv, eq");
+  TEST_SINGLE(ccmp(Size::i32Bit, Reg::r29, Reg::r28, StatusFlags::Flag_V, Condition::CC_EQ), "ccmp w29, w28, #nzcV, eq");
+  TEST_SINGLE(ccmp(Size::i32Bit, Reg::r29, Reg::r28, StatusFlags::Flag_NZCV, Condition::CC_EQ), "ccmp w29, w28, #NZCV, eq");
+
+  TEST_SINGLE(ccmp(Size::i64Bit, Reg::r29, Reg::r28, StatusFlags::None, Condition::CC_AL), "ccmp x29, x28, #nzcv, al");
+  TEST_SINGLE(ccmp(Size::i64Bit, Reg::r29, Reg::r28, StatusFlags::Flag_N, Condition::CC_AL), "ccmp x29, x28, #Nzcv, al");
+  TEST_SINGLE(ccmp(Size::i64Bit, Reg::r29, Reg::r28, StatusFlags::Flag_Z, Condition::CC_AL), "ccmp x29, x28, #nZcv, al");
+  TEST_SINGLE(ccmp(Size::i64Bit, Reg::r29, Reg::r28, StatusFlags::Flag_C, Condition::CC_AL), "ccmp x29, x28, #nzCv, al");
+  TEST_SINGLE(ccmp(Size::i64Bit, Reg::r29, Reg::r28, StatusFlags::Flag_V, Condition::CC_AL), "ccmp x29, x28, #nzcV, al");
+  TEST_SINGLE(ccmp(Size::i64Bit, Reg::r29, Reg::r28, StatusFlags::Flag_NZCV, Condition::CC_AL), "ccmp x29, x28, #NZCV, al");
+
+  TEST_SINGLE(ccmp(Size::i64Bit, Reg::r29, Reg::r28, StatusFlags::None, Condition::CC_EQ), "ccmp x29, x28, #nzcv, eq");
+  TEST_SINGLE(ccmp(Size::i64Bit, Reg::r29, Reg::r28, StatusFlags::Flag_N, Condition::CC_EQ), "ccmp x29, x28, #Nzcv, eq");
+  TEST_SINGLE(ccmp(Size::i64Bit, Reg::r29, Reg::r28, StatusFlags::Flag_Z, Condition::CC_EQ), "ccmp x29, x28, #nZcv, eq");
+  TEST_SINGLE(ccmp(Size::i64Bit, Reg::r29, Reg::r28, StatusFlags::Flag_C, Condition::CC_EQ), "ccmp x29, x28, #nzCv, eq");
+  TEST_SINGLE(ccmp(Size::i64Bit, Reg::r29, Reg::r28, StatusFlags::Flag_V, Condition::CC_EQ), "ccmp x29, x28, #nzcV, eq");
+  TEST_SINGLE(ccmp(Size::i64Bit, Reg::r29, Reg::r28, StatusFlags::Flag_NZCV, Condition::CC_EQ), "ccmp x29, x28, #NZCV, eq");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: ALU: Conditional compare - immediate") {
+  TEST_SINGLE(ccmn(Size::i32Bit, Reg::r29, 0, StatusFlags::None, Condition::CC_AL), "ccmn w29, #0, #nzcv, al");
+  TEST_SINGLE(ccmn(Size::i32Bit, Reg::r29, 0, StatusFlags::Flag_N, Condition::CC_AL), "ccmn w29, #0, #Nzcv, al");
+  TEST_SINGLE(ccmn(Size::i32Bit, Reg::r29, 0, StatusFlags::Flag_Z, Condition::CC_AL), "ccmn w29, #0, #nZcv, al");
+  TEST_SINGLE(ccmn(Size::i32Bit, Reg::r29, 0, StatusFlags::Flag_C, Condition::CC_AL), "ccmn w29, #0, #nzCv, al");
+  TEST_SINGLE(ccmn(Size::i32Bit, Reg::r29, 0, StatusFlags::Flag_V, Condition::CC_AL), "ccmn w29, #0, #nzcV, al");
+  TEST_SINGLE(ccmn(Size::i32Bit, Reg::r29, 0, StatusFlags::Flag_NZCV, Condition::CC_AL), "ccmn w29, #0, #NZCV, al");
+
+  TEST_SINGLE(ccmn(Size::i32Bit, Reg::r29, 0, StatusFlags::None, Condition::CC_EQ), "ccmn w29, #0, #nzcv, eq");
+  TEST_SINGLE(ccmn(Size::i32Bit, Reg::r29, 0, StatusFlags::Flag_N, Condition::CC_EQ), "ccmn w29, #0, #Nzcv, eq");
+  TEST_SINGLE(ccmn(Size::i32Bit, Reg::r29, 0, StatusFlags::Flag_Z, Condition::CC_EQ), "ccmn w29, #0, #nZcv, eq");
+  TEST_SINGLE(ccmn(Size::i32Bit, Reg::r29, 0, StatusFlags::Flag_C, Condition::CC_EQ), "ccmn w29, #0, #nzCv, eq");
+  TEST_SINGLE(ccmn(Size::i32Bit, Reg::r29, 0, StatusFlags::Flag_V, Condition::CC_EQ), "ccmn w29, #0, #nzcV, eq");
+  TEST_SINGLE(ccmn(Size::i32Bit, Reg::r29, 0, StatusFlags::Flag_NZCV, Condition::CC_EQ), "ccmn w29, #0, #NZCV, eq");
+
+  TEST_SINGLE(ccmn(Size::i64Bit, Reg::r29, 0, StatusFlags::None, Condition::CC_AL), "ccmn x29, #0, #nzcv, al");
+  TEST_SINGLE(ccmn(Size::i64Bit, Reg::r29, 0, StatusFlags::Flag_N, Condition::CC_AL), "ccmn x29, #0, #Nzcv, al");
+  TEST_SINGLE(ccmn(Size::i64Bit, Reg::r29, 0, StatusFlags::Flag_Z, Condition::CC_AL), "ccmn x29, #0, #nZcv, al");
+  TEST_SINGLE(ccmn(Size::i64Bit, Reg::r29, 0, StatusFlags::Flag_C, Condition::CC_AL), "ccmn x29, #0, #nzCv, al");
+  TEST_SINGLE(ccmn(Size::i64Bit, Reg::r29, 0, StatusFlags::Flag_V, Condition::CC_AL), "ccmn x29, #0, #nzcV, al");
+  TEST_SINGLE(ccmn(Size::i64Bit, Reg::r29, 0, StatusFlags::Flag_NZCV, Condition::CC_AL), "ccmn x29, #0, #NZCV, al");
+
+  TEST_SINGLE(ccmn(Size::i64Bit, Reg::r29, 0, StatusFlags::None, Condition::CC_EQ), "ccmn x29, #0, #nzcv, eq");
+  TEST_SINGLE(ccmn(Size::i64Bit, Reg::r29, 0, StatusFlags::Flag_N, Condition::CC_EQ), "ccmn x29, #0, #Nzcv, eq");
+  TEST_SINGLE(ccmn(Size::i64Bit, Reg::r29, 0, StatusFlags::Flag_Z, Condition::CC_EQ), "ccmn x29, #0, #nZcv, eq");
+  TEST_SINGLE(ccmn(Size::i64Bit, Reg::r29, 0, StatusFlags::Flag_C, Condition::CC_EQ), "ccmn x29, #0, #nzCv, eq");
+  TEST_SINGLE(ccmn(Size::i64Bit, Reg::r29, 0, StatusFlags::Flag_V, Condition::CC_EQ), "ccmn x29, #0, #nzcV, eq");
+  TEST_SINGLE(ccmn(Size::i64Bit, Reg::r29, 0, StatusFlags::Flag_NZCV, Condition::CC_EQ), "ccmn x29, #0, #NZCV, eq");
+
+  TEST_SINGLE(ccmn(Size::i32Bit, Reg::r29, 31, StatusFlags::None, Condition::CC_AL), "ccmn w29, #31, #nzcv, al");
+  TEST_SINGLE(ccmn(Size::i32Bit, Reg::r29, 31, StatusFlags::Flag_N, Condition::CC_AL), "ccmn w29, #31, #Nzcv, al");
+  TEST_SINGLE(ccmn(Size::i32Bit, Reg::r29, 31, StatusFlags::Flag_Z, Condition::CC_AL), "ccmn w29, #31, #nZcv, al");
+  TEST_SINGLE(ccmn(Size::i32Bit, Reg::r29, 31, StatusFlags::Flag_C, Condition::CC_AL), "ccmn w29, #31, #nzCv, al");
+  TEST_SINGLE(ccmn(Size::i32Bit, Reg::r29, 31, StatusFlags::Flag_V, Condition::CC_AL), "ccmn w29, #31, #nzcV, al");
+  TEST_SINGLE(ccmn(Size::i32Bit, Reg::r29, 31, StatusFlags::Flag_NZCV, Condition::CC_AL), "ccmn w29, #31, #NZCV, al");
+
+  TEST_SINGLE(ccmn(Size::i32Bit, Reg::r29, 31, StatusFlags::None, Condition::CC_EQ), "ccmn w29, #31, #nzcv, eq");
+  TEST_SINGLE(ccmn(Size::i32Bit, Reg::r29, 31, StatusFlags::Flag_N, Condition::CC_EQ), "ccmn w29, #31, #Nzcv, eq");
+  TEST_SINGLE(ccmn(Size::i32Bit, Reg::r29, 31, StatusFlags::Flag_Z, Condition::CC_EQ), "ccmn w29, #31, #nZcv, eq");
+  TEST_SINGLE(ccmn(Size::i32Bit, Reg::r29, 31, StatusFlags::Flag_C, Condition::CC_EQ), "ccmn w29, #31, #nzCv, eq");
+  TEST_SINGLE(ccmn(Size::i32Bit, Reg::r29, 31, StatusFlags::Flag_V, Condition::CC_EQ), "ccmn w29, #31, #nzcV, eq");
+  TEST_SINGLE(ccmn(Size::i32Bit, Reg::r29, 31, StatusFlags::Flag_NZCV, Condition::CC_EQ), "ccmn w29, #31, #NZCV, eq");
+
+  TEST_SINGLE(ccmn(Size::i64Bit, Reg::r29, 31, StatusFlags::None, Condition::CC_AL), "ccmn x29, #31, #nzcv, al");
+  TEST_SINGLE(ccmn(Size::i64Bit, Reg::r29, 31, StatusFlags::Flag_N, Condition::CC_AL), "ccmn x29, #31, #Nzcv, al");
+  TEST_SINGLE(ccmn(Size::i64Bit, Reg::r29, 31, StatusFlags::Flag_Z, Condition::CC_AL), "ccmn x29, #31, #nZcv, al");
+  TEST_SINGLE(ccmn(Size::i64Bit, Reg::r29, 31, StatusFlags::Flag_C, Condition::CC_AL), "ccmn x29, #31, #nzCv, al");
+  TEST_SINGLE(ccmn(Size::i64Bit, Reg::r29, 31, StatusFlags::Flag_V, Condition::CC_AL), "ccmn x29, #31, #nzcV, al");
+  TEST_SINGLE(ccmn(Size::i64Bit, Reg::r29, 31, StatusFlags::Flag_NZCV, Condition::CC_AL), "ccmn x29, #31, #NZCV, al");
+
+  TEST_SINGLE(ccmn(Size::i64Bit, Reg::r29, 31, StatusFlags::None, Condition::CC_EQ), "ccmn x29, #31, #nzcv, eq");
+  TEST_SINGLE(ccmn(Size::i64Bit, Reg::r29, 31, StatusFlags::Flag_N, Condition::CC_EQ), "ccmn x29, #31, #Nzcv, eq");
+  TEST_SINGLE(ccmn(Size::i64Bit, Reg::r29, 31, StatusFlags::Flag_Z, Condition::CC_EQ), "ccmn x29, #31, #nZcv, eq");
+  TEST_SINGLE(ccmn(Size::i64Bit, Reg::r29, 31, StatusFlags::Flag_C, Condition::CC_EQ), "ccmn x29, #31, #nzCv, eq");
+  TEST_SINGLE(ccmn(Size::i64Bit, Reg::r29, 31, StatusFlags::Flag_V, Condition::CC_EQ), "ccmn x29, #31, #nzcV, eq");
+  TEST_SINGLE(ccmn(Size::i64Bit, Reg::r29, 31, StatusFlags::Flag_NZCV, Condition::CC_EQ), "ccmn x29, #31, #NZCV, eq");
+
+  TEST_SINGLE(ccmp(Size::i32Bit, Reg::r29, 0, StatusFlags::None, Condition::CC_AL), "ccmp w29, #0, #nzcv, al");
+  TEST_SINGLE(ccmp(Size::i32Bit, Reg::r29, 0, StatusFlags::Flag_N, Condition::CC_AL), "ccmp w29, #0, #Nzcv, al");
+  TEST_SINGLE(ccmp(Size::i32Bit, Reg::r29, 0, StatusFlags::Flag_Z, Condition::CC_AL), "ccmp w29, #0, #nZcv, al");
+  TEST_SINGLE(ccmp(Size::i32Bit, Reg::r29, 0, StatusFlags::Flag_C, Condition::CC_AL), "ccmp w29, #0, #nzCv, al");
+  TEST_SINGLE(ccmp(Size::i32Bit, Reg::r29, 0, StatusFlags::Flag_V, Condition::CC_AL), "ccmp w29, #0, #nzcV, al");
+  TEST_SINGLE(ccmp(Size::i32Bit, Reg::r29, 0, StatusFlags::Flag_NZCV, Condition::CC_AL), "ccmp w29, #0, #NZCV, al");
+
+  TEST_SINGLE(ccmp(Size::i32Bit, Reg::r29, 0, StatusFlags::None, Condition::CC_EQ), "ccmp w29, #0, #nzcv, eq");
+  TEST_SINGLE(ccmp(Size::i32Bit, Reg::r29, 0, StatusFlags::Flag_N, Condition::CC_EQ), "ccmp w29, #0, #Nzcv, eq");
+  TEST_SINGLE(ccmp(Size::i32Bit, Reg::r29, 0, StatusFlags::Flag_Z, Condition::CC_EQ), "ccmp w29, #0, #nZcv, eq");
+  TEST_SINGLE(ccmp(Size::i32Bit, Reg::r29, 0, StatusFlags::Flag_C, Condition::CC_EQ), "ccmp w29, #0, #nzCv, eq");
+  TEST_SINGLE(ccmp(Size::i32Bit, Reg::r29, 0, StatusFlags::Flag_V, Condition::CC_EQ), "ccmp w29, #0, #nzcV, eq");
+  TEST_SINGLE(ccmp(Size::i32Bit, Reg::r29, 0, StatusFlags::Flag_NZCV, Condition::CC_EQ), "ccmp w29, #0, #NZCV, eq");
+
+  TEST_SINGLE(ccmp(Size::i64Bit, Reg::r29, 0, StatusFlags::None, Condition::CC_AL), "ccmp x29, #0, #nzcv, al");
+  TEST_SINGLE(ccmp(Size::i64Bit, Reg::r29, 0, StatusFlags::Flag_N, Condition::CC_AL), "ccmp x29, #0, #Nzcv, al");
+  TEST_SINGLE(ccmp(Size::i64Bit, Reg::r29, 0, StatusFlags::Flag_Z, Condition::CC_AL), "ccmp x29, #0, #nZcv, al");
+  TEST_SINGLE(ccmp(Size::i64Bit, Reg::r29, 0, StatusFlags::Flag_C, Condition::CC_AL), "ccmp x29, #0, #nzCv, al");
+  TEST_SINGLE(ccmp(Size::i64Bit, Reg::r29, 0, StatusFlags::Flag_V, Condition::CC_AL), "ccmp x29, #0, #nzcV, al");
+  TEST_SINGLE(ccmp(Size::i64Bit, Reg::r29, 0, StatusFlags::Flag_NZCV, Condition::CC_AL), "ccmp x29, #0, #NZCV, al");
+
+  TEST_SINGLE(ccmp(Size::i64Bit, Reg::r29, 0, StatusFlags::None, Condition::CC_EQ), "ccmp x29, #0, #nzcv, eq");
+  TEST_SINGLE(ccmp(Size::i64Bit, Reg::r29, 0, StatusFlags::Flag_N, Condition::CC_EQ), "ccmp x29, #0, #Nzcv, eq");
+  TEST_SINGLE(ccmp(Size::i64Bit, Reg::r29, 0, StatusFlags::Flag_Z, Condition::CC_EQ), "ccmp x29, #0, #nZcv, eq");
+  TEST_SINGLE(ccmp(Size::i64Bit, Reg::r29, 0, StatusFlags::Flag_C, Condition::CC_EQ), "ccmp x29, #0, #nzCv, eq");
+  TEST_SINGLE(ccmp(Size::i64Bit, Reg::r29, 0, StatusFlags::Flag_V, Condition::CC_EQ), "ccmp x29, #0, #nzcV, eq");
+  TEST_SINGLE(ccmp(Size::i64Bit, Reg::r29, 0, StatusFlags::Flag_NZCV, Condition::CC_EQ), "ccmp x29, #0, #NZCV, eq");
+
+  TEST_SINGLE(ccmp(Size::i32Bit, Reg::r29, 31, StatusFlags::None, Condition::CC_AL), "ccmp w29, #31, #nzcv, al");
+  TEST_SINGLE(ccmp(Size::i32Bit, Reg::r29, 31, StatusFlags::Flag_N, Condition::CC_AL), "ccmp w29, #31, #Nzcv, al");
+  TEST_SINGLE(ccmp(Size::i32Bit, Reg::r29, 31, StatusFlags::Flag_Z, Condition::CC_AL), "ccmp w29, #31, #nZcv, al");
+  TEST_SINGLE(ccmp(Size::i32Bit, Reg::r29, 31, StatusFlags::Flag_C, Condition::CC_AL), "ccmp w29, #31, #nzCv, al");
+  TEST_SINGLE(ccmp(Size::i32Bit, Reg::r29, 31, StatusFlags::Flag_V, Condition::CC_AL), "ccmp w29, #31, #nzcV, al");
+  TEST_SINGLE(ccmp(Size::i32Bit, Reg::r29, 31, StatusFlags::Flag_NZCV, Condition::CC_AL), "ccmp w29, #31, #NZCV, al");
+
+  TEST_SINGLE(ccmp(Size::i32Bit, Reg::r29, 31, StatusFlags::None, Condition::CC_EQ), "ccmp w29, #31, #nzcv, eq");
+  TEST_SINGLE(ccmp(Size::i32Bit, Reg::r29, 31, StatusFlags::Flag_N, Condition::CC_EQ), "ccmp w29, #31, #Nzcv, eq");
+  TEST_SINGLE(ccmp(Size::i32Bit, Reg::r29, 31, StatusFlags::Flag_Z, Condition::CC_EQ), "ccmp w29, #31, #nZcv, eq");
+  TEST_SINGLE(ccmp(Size::i32Bit, Reg::r29, 31, StatusFlags::Flag_C, Condition::CC_EQ), "ccmp w29, #31, #nzCv, eq");
+  TEST_SINGLE(ccmp(Size::i32Bit, Reg::r29, 31, StatusFlags::Flag_V, Condition::CC_EQ), "ccmp w29, #31, #nzcV, eq");
+  TEST_SINGLE(ccmp(Size::i32Bit, Reg::r29, 31, StatusFlags::Flag_NZCV, Condition::CC_EQ), "ccmp w29, #31, #NZCV, eq");
+
+  TEST_SINGLE(ccmp(Size::i64Bit, Reg::r29, 31, StatusFlags::None, Condition::CC_AL), "ccmp x29, #31, #nzcv, al");
+  TEST_SINGLE(ccmp(Size::i64Bit, Reg::r29, 31, StatusFlags::Flag_N, Condition::CC_AL), "ccmp x29, #31, #Nzcv, al");
+  TEST_SINGLE(ccmp(Size::i64Bit, Reg::r29, 31, StatusFlags::Flag_Z, Condition::CC_AL), "ccmp x29, #31, #nZcv, al");
+  TEST_SINGLE(ccmp(Size::i64Bit, Reg::r29, 31, StatusFlags::Flag_C, Condition::CC_AL), "ccmp x29, #31, #nzCv, al");
+  TEST_SINGLE(ccmp(Size::i64Bit, Reg::r29, 31, StatusFlags::Flag_V, Condition::CC_AL), "ccmp x29, #31, #nzcV, al");
+  TEST_SINGLE(ccmp(Size::i64Bit, Reg::r29, 31, StatusFlags::Flag_NZCV, Condition::CC_AL), "ccmp x29, #31, #NZCV, al");
+
+  TEST_SINGLE(ccmp(Size::i64Bit, Reg::r29, 31, StatusFlags::None, Condition::CC_EQ), "ccmp x29, #31, #nzcv, eq");
+  TEST_SINGLE(ccmp(Size::i64Bit, Reg::r29, 31, StatusFlags::Flag_N, Condition::CC_EQ), "ccmp x29, #31, #Nzcv, eq");
+  TEST_SINGLE(ccmp(Size::i64Bit, Reg::r29, 31, StatusFlags::Flag_Z, Condition::CC_EQ), "ccmp x29, #31, #nZcv, eq");
+  TEST_SINGLE(ccmp(Size::i64Bit, Reg::r29, 31, StatusFlags::Flag_C, Condition::CC_EQ), "ccmp x29, #31, #nzCv, eq");
+  TEST_SINGLE(ccmp(Size::i64Bit, Reg::r29, 31, StatusFlags::Flag_V, Condition::CC_EQ), "ccmp x29, #31, #nzcV, eq");
+  TEST_SINGLE(ccmp(Size::i64Bit, Reg::r29, 31, StatusFlags::Flag_NZCV, Condition::CC_EQ), "ccmp x29, #31, #NZCV, eq");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: ALU: Conditional select") {
+  TEST_SINGLE(csel(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, Condition::CC_EQ), "csel w29, w28, w27, eq");
+  TEST_SINGLE(csel(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, Condition::CC_EQ), "csel x29, x28, x27, eq");
+  TEST_SINGLE(cset(Size::i32Bit, Reg::r29, Condition::CC_EQ), "cset w29, eq");
+  TEST_SINGLE(cset(Size::i64Bit, Reg::r29, Condition::CC_EQ), "cset x29, eq");
+  TEST_SINGLE(csinc(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, Condition::CC_EQ), "csinc w29, w28, w27, eq");
+  TEST_SINGLE(csinc(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, Condition::CC_EQ), "csinc x29, x28, x27, eq");
+  TEST_SINGLE(csinv(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, Condition::CC_EQ), "csinv w29, w28, w27, eq");
+  TEST_SINGLE(csinv(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, Condition::CC_EQ), "csinv x29, x28, x27, eq");
+  TEST_SINGLE(csneg(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, Condition::CC_EQ), "csneg w29, w28, w27, eq");
+  TEST_SINGLE(csneg(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, Condition::CC_EQ), "csneg x29, x28, x27, eq");
+
+  TEST_SINGLE(csel(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, Condition::CC_AL), "csel w29, w28, w27, al");
+  TEST_SINGLE(csel(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, Condition::CC_AL), "csel x29, x28, x27, al");
+  TEST_SINGLE(cset(Size::i32Bit, Reg::r29, Condition::CC_AL), "csinc w29, wzr, wzr, nv");
+  TEST_SINGLE(cset(Size::i64Bit, Reg::r29, Condition::CC_AL), "csinc x29, xzr, xzr, nv");
+  TEST_SINGLE(csinc(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, Condition::CC_AL), "csinc w29, w28, w27, al");
+  TEST_SINGLE(csinc(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, Condition::CC_AL), "csinc x29, x28, x27, al");
+  TEST_SINGLE(csinv(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, Condition::CC_AL), "csinv w29, w28, w27, al");
+  TEST_SINGLE(csinv(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, Condition::CC_AL), "csinv x29, x28, x27, al");
+  TEST_SINGLE(csneg(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, Condition::CC_AL), "csneg w29, w28, w27, al");
+  TEST_SINGLE(csneg(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, Condition::CC_AL), "csneg x29, x28, x27, al");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: ALU: Data processing - 3 source") {
+  TEST_SINGLE(madd(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, Reg::r26), "madd w29, w28, w27, w26");
+  TEST_SINGLE(madd(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, Reg::r26), "madd x29, x28, x27, x26");
+  TEST_SINGLE(mul(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27), "mul w29, w28, w27");
+  TEST_SINGLE(mul(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27), "mul x29, x28, x27");
+  TEST_SINGLE(msub(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, Reg::r26), "msub w29, w28, w27, w26");
+  TEST_SINGLE(msub(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, Reg::r26), "msub x29, x28, x27, x26");
+  TEST_SINGLE(mneg(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27), "mneg w29, w28, w27");
+  TEST_SINGLE(mneg(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27), "mneg x29, x28, x27");
+
+  TEST_SINGLE(smaddl(XReg::x29, WReg::w28, WReg::w27, XReg::x26), "smaddl x29, w28, w27, x26");
+  TEST_SINGLE(smull(XReg::x29, WReg::w28, WReg::w27), "smull x29, w28, w27");
+  TEST_SINGLE(smsubl(XReg::x29, WReg::w28, WReg::w27, XReg::x26), "smsubl x29, w28, w27, x26");
+  TEST_SINGLE(smnegl(XReg::x29, WReg::w28, WReg::w27), "smnegl x29, w28, w27");
+  TEST_SINGLE(smulh(XReg::x29, XReg::x28, XReg::x27), "smulh x29, x28, x27");
+
+  TEST_SINGLE(umaddl(XReg::x29, WReg::w28, WReg::w27, XReg::x26), "umaddl x29, w28, w27, x26");
+  TEST_SINGLE(umull(XReg::x29, WReg::w28, WReg::w27), "umull x29, w28, w27");
+  TEST_SINGLE(umsubl(XReg::x29, WReg::w28, WReg::w27, XReg::x26), "umsubl x29, w28, w27, x26");
+  TEST_SINGLE(umnegl(XReg::x29, WReg::w28, WReg::w27), "umnegl x29, w28, w27");
+  TEST_SINGLE(umulh(XReg::x29, XReg::x28, XReg::x27), "umulh x29, x28, x27");
+}

--- a/External/FEXCore/unittests/Emitter/ASIMD_Tests.cpp
+++ b/External/FEXCore/unittests/Emitter/ASIMD_Tests.cpp
@@ -1,0 +1,2747 @@
+#include "TestDisassembler.h"
+
+#include <catch2/catch.hpp>
+#include <fcntl.h>
+
+using namespace FEXCore::ARMEmitter;
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Cryptographic AES") {
+  if (false) {
+    // vixl doesn't support these instructions.
+    TEST_SINGLE(aese(VReg::v30, VReg::v29), "aese v30, v29");
+    TEST_SINGLE(aesd(VReg::v30, VReg::v29), "aesd v30, v29");
+    TEST_SINGLE(aesmc(VReg::v30, VReg::v29), "aesmc v30, v29");
+    TEST_SINGLE(aesimc(VReg::v30, VReg::v29), "aesimc v30, v29");
+  }
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Cryptographic three-register SHA") {
+  if (false) {
+    // vixl doesn't support these instructions.
+    TEST_SINGLE(sha1c(VReg::v30, SReg::s29, VReg::v28), "sha1c v30, s29, v28");
+    TEST_SINGLE(sha1p(VReg::v30, SReg::s29, VReg::v28), "sha1p v30, s29, v28");
+    TEST_SINGLE(sha1m(VReg::v30, SReg::s29, VReg::v28), "sha1m v30, s29, v28");
+    TEST_SINGLE(sha1su0(VReg::v30, VReg::v29, VReg::v28), "sha1su0 v30, v29, v28");
+    TEST_SINGLE(sha256h(VReg::v30, VReg::v29, VReg::v28), "sha256h v30, v29, v28");
+    TEST_SINGLE(sha256h2(VReg::v30, VReg::v29, VReg::v28), "sha256h2 v30, v29, v28");
+    TEST_SINGLE(sha256su1(VReg::v30, VReg::v29, VReg::v28), "sha256su1 v30, v29, v28");
+  }
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Cryptographic two-register SHA") {
+  if (false) {
+    // vixl doesn't support these instructions.
+    TEST_SINGLE(sha1h(SReg::s30, SReg::s29), "sha1h s30, s29");
+    TEST_SINGLE(sha1su1(VReg::v30, VReg::v29), "sha1su1 v30, v29");
+    TEST_SINGLE(sha256su0(VReg::v30, VReg::v29), "sha256su0 v30, v29");
+  }
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD table lookup") {
+  TEST_SINGLE(tbl(QReg::q30, QReg::q26, QReg::q25), "tbl v30.16b, {v26.16b}, v25.16b");
+  TEST_SINGLE(tbl(DReg::d30, QReg::q26, DReg::d25), "tbl v30.8b, {v26.16b}, v25.8b");
+  TEST_SINGLE(tbx(QReg::q30, QReg::q26, QReg::q25), "tbx v30.16b, {v26.16b}, v25.16b");
+  TEST_SINGLE(tbx(DReg::d30, QReg::q26, DReg::d25), "tbx v30.8b, {v26.16b}, v25.8b");
+
+  TEST_SINGLE(tbl(QReg::q30, QReg::q26, QReg::q27, QReg::q25), "tbl v30.16b, {v26.16b, v27.16b}, v25.16b");
+  TEST_SINGLE(tbl(DReg::d30, QReg::q26, QReg::q27, DReg::d25), "tbl v30.8b, {v26.16b, v27.16b}, v25.8b");
+  TEST_SINGLE(tbx(QReg::q30, QReg::q26, QReg::q27, QReg::q25), "tbx v30.16b, {v26.16b, v27.16b}, v25.16b");
+  TEST_SINGLE(tbx(DReg::d30, QReg::q26, QReg::q27, DReg::d25), "tbx v30.8b, {v26.16b, v27.16b}, v25.8b");
+
+  TEST_SINGLE(tbl(QReg::q30, QReg::q26, QReg::q27, QReg::q28, QReg::q25), "tbl v30.16b, {v26.16b, v27.16b, v28.16b}, v25.16b");
+  TEST_SINGLE(tbl(DReg::d30, QReg::q26, QReg::q27, QReg::q28, DReg::d25), "tbl v30.8b, {v26.16b, v27.16b, v28.16b}, v25.8b");
+  TEST_SINGLE(tbx(QReg::q30, QReg::q26, QReg::q27, QReg::q28, QReg::q25), "tbx v30.16b, {v26.16b, v27.16b, v28.16b}, v25.16b");
+  TEST_SINGLE(tbx(DReg::d30, QReg::q26, QReg::q27, QReg::q28, DReg::d25), "tbx v30.8b, {v26.16b, v27.16b, v28.16b}, v25.8b");
+
+  TEST_SINGLE(tbl(QReg::q30, QReg::q26, QReg::q27, QReg::q28, QReg::q29, QReg::q25), "tbl v30.16b, {v26.16b, v27.16b, v28.16b, v29.16b}, v25.16b");
+  TEST_SINGLE(tbl(DReg::d30, QReg::q26, QReg::q27, QReg::q28, QReg::q29, DReg::d25), "tbl v30.8b, {v26.16b, v27.16b, v28.16b, v29.16b}, v25.8b");
+  TEST_SINGLE(tbx(QReg::q30, QReg::q26, QReg::q27, QReg::q28, QReg::q29, QReg::q25), "tbx v30.16b, {v26.16b, v27.16b, v28.16b, v29.16b}, v25.16b");
+  TEST_SINGLE(tbx(DReg::d30, QReg::q26, QReg::q27, QReg::q28, QReg::q29, DReg::d25), "tbx v30.8b, {v26.16b, v27.16b, v28.16b, v29.16b}, v25.8b");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD permute") {
+  // Commented out lines showcase unallocated encodings.
+  TEST_SINGLE(uzp1<SubRegSize::i8Bit>(QReg::q30, QReg::q29, QReg::q28), "uzp1 v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(uzp1<SubRegSize::i16Bit>(QReg::q30, QReg::q29, QReg::q28), "uzp1 v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(uzp1<SubRegSize::i32Bit>(QReg::q30, QReg::q29, QReg::q28), "uzp1 v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(uzp1<SubRegSize::i64Bit>(QReg::q30, QReg::q29, QReg::q28), "uzp1 v30.2d, v29.2d, v28.2d");
+  TEST_SINGLE(uzp1(SubRegSize::i8Bit, QReg::q30, QReg::q29, QReg::q28), "uzp1 v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(uzp1(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "uzp1 v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(uzp1(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "uzp1 v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(uzp1(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "uzp1 v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(uzp1<SubRegSize::i8Bit>(DReg::d30, DReg::d29, DReg::d28), "uzp1 v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(uzp1<SubRegSize::i16Bit>(DReg::d30, DReg::d29, DReg::d28), "uzp1 v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(uzp1<SubRegSize::i32Bit>(DReg::d30, DReg::d29, DReg::d28), "uzp1 v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(uzp1<SubRegSize::i64Bit>(DReg::d30, DReg::d29, DReg::d28), "uzp1 v30.1d, v29.1d, v28.1d");
+  TEST_SINGLE(uzp1(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "uzp1 v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(uzp1(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "uzp1 v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(uzp1(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "uzp1 v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(uzp1(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "uzp1 v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(trn1<SubRegSize::i8Bit>(QReg::q30, QReg::q29, QReg::q28), "trn1 v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(trn1<SubRegSize::i16Bit>(QReg::q30, QReg::q29, QReg::q28), "trn1 v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(trn1<SubRegSize::i32Bit>(QReg::q30, QReg::q29, QReg::q28), "trn1 v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(trn1<SubRegSize::i64Bit>(QReg::q30, QReg::q29, QReg::q28), "trn1 v30.2d, v29.2d, v28.2d");
+  TEST_SINGLE(trn1(SubRegSize::i8Bit, QReg::q30, QReg::q29, QReg::q28), "trn1 v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(trn1(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "trn1 v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(trn1(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "trn1 v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(trn1(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "trn1 v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(trn1<SubRegSize::i8Bit>(DReg::d30, DReg::d29, DReg::d28), "trn1 v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(trn1<SubRegSize::i16Bit>(DReg::d30, DReg::d29, DReg::d28), "trn1 v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(trn1<SubRegSize::i32Bit>(DReg::d30, DReg::d29, DReg::d28), "trn1 v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(trn1<SubRegSize::i64Bit>(DReg::d30, DReg::d29, DReg::d28), "trn1 v30.1d, v29.1d, v28.1d");
+  TEST_SINGLE(trn1(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "trn1 v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(trn1(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "trn1 v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(trn1(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "trn1 v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(trn1(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "trn1 v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(zip1<SubRegSize::i8Bit>(QReg::q30, QReg::q29, QReg::q28), "zip1 v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(zip1<SubRegSize::i16Bit>(QReg::q30, QReg::q29, QReg::q28), "zip1 v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(zip1<SubRegSize::i32Bit>(QReg::q30, QReg::q29, QReg::q28), "zip1 v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(zip1<SubRegSize::i64Bit>(QReg::q30, QReg::q29, QReg::q28), "zip1 v30.2d, v29.2d, v28.2d");
+  TEST_SINGLE(zip1(SubRegSize::i8Bit, QReg::q30, QReg::q29, QReg::q28), "zip1 v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(zip1(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "zip1 v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(zip1(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "zip1 v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(zip1(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "zip1 v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(zip1<SubRegSize::i8Bit>(DReg::d30, DReg::d29, DReg::d28), "zip1 v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(zip1<SubRegSize::i16Bit>(DReg::d30, DReg::d29, DReg::d28), "zip1 v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(zip1<SubRegSize::i32Bit>(DReg::d30, DReg::d29, DReg::d28), "zip1 v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(zip1<SubRegSize::i64Bit>(DReg::d30, DReg::d29, DReg::d28), "zip1 v30.1d, v29.1d, v28.1d");
+  TEST_SINGLE(zip1(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "zip1 v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(zip1(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "zip1 v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(zip1(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "zip1 v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(zip1(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "zip1 v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(uzp2<SubRegSize::i8Bit>(QReg::q30, QReg::q29, QReg::q28), "uzp2 v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(uzp2<SubRegSize::i16Bit>(QReg::q30, QReg::q29, QReg::q28), "uzp2 v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(uzp2<SubRegSize::i32Bit>(QReg::q30, QReg::q29, QReg::q28), "uzp2 v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(uzp2<SubRegSize::i64Bit>(QReg::q30, QReg::q29, QReg::q28), "uzp2 v30.2d, v29.2d, v28.2d");
+  TEST_SINGLE(uzp2(SubRegSize::i8Bit, QReg::q30, QReg::q29, QReg::q28), "uzp2 v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(uzp2(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "uzp2 v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(uzp2(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "uzp2 v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(uzp2(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "uzp2 v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(uzp2<SubRegSize::i8Bit>(DReg::d30, DReg::d29, DReg::d28), "uzp2 v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(uzp2<SubRegSize::i16Bit>(DReg::d30, DReg::d29, DReg::d28), "uzp2 v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(uzp2<SubRegSize::i32Bit>(DReg::d30, DReg::d29, DReg::d28), "uzp2 v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(uzp2<SubRegSize::i64Bit>(DReg::d30, DReg::d29, DReg::d28), "uzp2 v30.1d, v29.1d, v28.1d");
+  TEST_SINGLE(uzp2(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "uzp2 v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(uzp2(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "uzp2 v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(uzp2(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "uzp2 v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(uzp2(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "uzp2 v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(trn2<SubRegSize::i8Bit>(QReg::q30, QReg::q29, QReg::q28), "trn2 v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(trn2<SubRegSize::i16Bit>(QReg::q30, QReg::q29, QReg::q28), "trn2 v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(trn2<SubRegSize::i32Bit>(QReg::q30, QReg::q29, QReg::q28), "trn2 v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(trn2<SubRegSize::i64Bit>(QReg::q30, QReg::q29, QReg::q28), "trn2 v30.2d, v29.2d, v28.2d");
+  TEST_SINGLE(trn2(SubRegSize::i8Bit, QReg::q30, QReg::q29, QReg::q28), "trn2 v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(trn2(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "trn2 v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(trn2(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "trn2 v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(trn2(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "trn2 v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(trn2<SubRegSize::i8Bit>(DReg::d30, DReg::d29, DReg::d28), "trn2 v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(trn2<SubRegSize::i16Bit>(DReg::d30, DReg::d29, DReg::d28), "trn2 v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(trn2<SubRegSize::i32Bit>(DReg::d30, DReg::d29, DReg::d28), "trn2 v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(trn2<SubRegSize::i64Bit>(DReg::d30, DReg::d29, DReg::d28), "trn2 v30.1d, v29.1d, v28.1d");
+  TEST_SINGLE(trn2(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "trn2 v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(trn2(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "trn2 v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(trn2(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "trn2 v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(trn2(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "trn2 v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(zip2<SubRegSize::i8Bit>(QReg::q30, QReg::q29, QReg::q28), "zip2 v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(zip2<SubRegSize::i16Bit>(QReg::q30, QReg::q29, QReg::q28), "zip2 v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(zip2<SubRegSize::i32Bit>(QReg::q30, QReg::q29, QReg::q28), "zip2 v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(zip2<SubRegSize::i64Bit>(QReg::q30, QReg::q29, QReg::q28), "zip2 v30.2d, v29.2d, v28.2d");
+  TEST_SINGLE(zip2(SubRegSize::i8Bit, QReg::q30, QReg::q29, QReg::q28), "zip2 v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(zip2(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "zip2 v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(zip2(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "zip2 v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(zip2(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "zip2 v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(zip2<SubRegSize::i8Bit>(DReg::d30, DReg::d29, DReg::d28), "zip2 v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(zip2<SubRegSize::i16Bit>(DReg::d30, DReg::d29, DReg::d28), "zip2 v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(zip2<SubRegSize::i32Bit>(DReg::d30, DReg::d29, DReg::d28), "zip2 v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(zip2<SubRegSize::i64Bit>(DReg::d30, DReg::d29, DReg::d28), "zip2 v30.1d, v29.1d, v28.1d");
+  TEST_SINGLE(zip2(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "zip2 v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(zip2(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "zip2 v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(zip2(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "zip2 v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(zip2(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "zip2 v30.1d, v29.1d, v28.1d");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD extract") {
+  TEST_SINGLE(ext(QReg::q30, QReg::q29, QReg::q28, 0), "ext v30.16b, v29.16b, v28.16b, #0");
+  TEST_SINGLE(ext(QReg::q30, QReg::q29, QReg::q28, 15), "ext v30.16b, v29.16b, v28.16b, #15");
+  TEST_SINGLE(ext(DReg::d30, DReg::d29, DReg::d28, 0), "ext v30.8b, v29.8b, v28.8b, #0");
+  TEST_SINGLE(ext(DReg::d30, DReg::d29, DReg::d28, 7), "ext v30.8b, v29.8b, v28.8b, #7");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD copy") {
+  // Commented out lines showcase unallocated encodings.
+  TEST_SINGLE(dup(SubRegSize::i8Bit, QReg::q30, QReg::q29, 0), "dup v30.16b, v29.b[0]");
+  TEST_SINGLE(dup(SubRegSize::i16Bit, QReg::q30, QReg::q29, 0), "dup v30.8h, v29.h[0]");
+  TEST_SINGLE(dup(SubRegSize::i32Bit, QReg::q30, QReg::q29, 0), "dup v30.4s, v29.s[0]");
+  TEST_SINGLE(dup(SubRegSize::i64Bit, QReg::q30, QReg::q29, 0), "dup v30.2d, v29.d[0]");
+  TEST_SINGLE(dup(SubRegSize::i8Bit, QReg::q30, QReg::q29, 15), "dup v30.16b, v29.b[15]");
+  TEST_SINGLE(dup(SubRegSize::i16Bit, QReg::q30, QReg::q29, 7), "dup v30.8h, v29.h[7]");
+  TEST_SINGLE(dup(SubRegSize::i32Bit, QReg::q30, QReg::q29, 3), "dup v30.4s, v29.s[3]");
+  TEST_SINGLE(dup(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1), "dup v30.2d, v29.d[1]");
+
+  TEST_SINGLE(dup(SubRegSize::i8Bit, DReg::d30, DReg::d29, 0), "dup v30.8b, v29.b[0]");
+  TEST_SINGLE(dup(SubRegSize::i16Bit, DReg::d30, DReg::d29, 0), "dup v30.4h, v29.h[0]");
+  TEST_SINGLE(dup(SubRegSize::i32Bit, DReg::d30, DReg::d29, 0), "dup v30.2s, v29.s[0]");
+  //TEST_SINGLE(dup(SubRegSize::i64Bit, DReg::d30, DReg::d29, 0), "dup v30.1d, v29.d[0]");
+  TEST_SINGLE(dup(SubRegSize::i8Bit, DReg::d30, DReg::d29, 15), "dup v30.8b, v29.b[15]");
+  TEST_SINGLE(dup(SubRegSize::i16Bit, DReg::d30, DReg::d29, 7), "dup v30.4h, v29.h[7]");
+  TEST_SINGLE(dup(SubRegSize::i32Bit, DReg::d30, DReg::d29, 3), "dup v30.2s, v29.s[3]");
+  //TEST_SINGLE(dup(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1), "dup v30.1d, v29.d[1]");
+
+  TEST_SINGLE(dup(SubRegSize::i8Bit, QReg::q30, Reg::r29), "dup v30.16b, w29");
+  TEST_SINGLE(dup(SubRegSize::i16Bit, QReg::q30, Reg::r29), "dup v30.8h, w29");
+  TEST_SINGLE(dup(SubRegSize::i32Bit, QReg::q30, Reg::r29), "dup v30.4s, w29");
+  TEST_SINGLE(dup(SubRegSize::i64Bit, QReg::q30, Reg::r29), "dup v30.2d, x29");
+
+  TEST_SINGLE(dup(SubRegSize::i8Bit, DReg::d30, Reg::r29), "dup v30.8b, w29");
+  TEST_SINGLE(dup(SubRegSize::i16Bit, DReg::d30, Reg::r29), "dup v30.4h, w29");
+  TEST_SINGLE(dup(SubRegSize::i32Bit, DReg::d30, Reg::r29), "dup v30.2s, w29");
+  //TEST_SINGLE(dup(SubRegSize::i64Bit, DReg::d30, Reg::r29), "dup v30.1d, x29");
+  TEST_SINGLE(smov<SubRegSize::i8Bit>(XReg::x29, VReg::v30, 0), "smov x29, v30.b[0]");
+  TEST_SINGLE(smov<SubRegSize::i8Bit>(XReg::x29, VReg::v30, 15), "smov x29, v30.b[15]");
+  TEST_SINGLE(smov<SubRegSize::i16Bit>(XReg::x29, VReg::v30, 0), "smov x29, v30.h[0]");
+  TEST_SINGLE(smov<SubRegSize::i16Bit>(XReg::x29, VReg::v30, 7), "smov x29, v30.h[7]");
+  TEST_SINGLE(smov<SubRegSize::i32Bit>(XReg::x29, VReg::v30, 0), "smov x29, v30.s[0]");
+  TEST_SINGLE(smov<SubRegSize::i32Bit>(XReg::x29, VReg::v30, 3), "smov x29, v30.s[3]");
+
+  TEST_SINGLE(smov<SubRegSize::i8Bit>(WReg::w29, VReg::v30, 0), "smov w29, v30.b[0]");
+  TEST_SINGLE(smov<SubRegSize::i8Bit>(WReg::w29, VReg::v30, 15), "smov w29, v30.b[15]");
+  TEST_SINGLE(smov<SubRegSize::i16Bit>(WReg::w29, VReg::v30, 0), "smov w29, v30.h[0]");
+  TEST_SINGLE(smov<SubRegSize::i16Bit>(WReg::w29, VReg::v30, 7), "smov w29, v30.h[7]");
+
+  TEST_SINGLE(umov<SubRegSize::i8Bit>(Reg::r29, VReg::v30, 0), "umov w29, v30.b[0]");
+  TEST_SINGLE(umov<SubRegSize::i8Bit>(Reg::r29, VReg::v30, 15), "umov w29, v30.b[15]");
+  TEST_SINGLE(umov<SubRegSize::i16Bit>(Reg::r29, VReg::v30, 0), "umov w29, v30.h[0]");
+  TEST_SINGLE(umov<SubRegSize::i16Bit>(Reg::r29, VReg::v30, 7), "umov w29, v30.h[7]");
+  TEST_SINGLE(umov<SubRegSize::i32Bit>(Reg::r29, VReg::v30, 0), "mov w29, v30.s[0]");
+  TEST_SINGLE(umov<SubRegSize::i32Bit>(Reg::r29, VReg::v30, 3), "mov w29, v30.s[3]");
+  TEST_SINGLE(umov<SubRegSize::i64Bit>(Reg::r29, VReg::v30, 0), "mov x29, v30.d[0]");
+  TEST_SINGLE(umov<SubRegSize::i64Bit>(Reg::r29, VReg::v30, 1), "mov x29, v30.d[1]");
+
+  TEST_SINGLE(ins<SubRegSize::i8Bit>(VReg::v30, 0, Reg::r29),  "mov v30.b[0], w29");
+  TEST_SINGLE(ins<SubRegSize::i16Bit>(VReg::v30, 0, Reg::r29), "mov v30.h[0], w29");
+  TEST_SINGLE(ins<SubRegSize::i32Bit>(VReg::v30, 0, Reg::r29), "mov v30.s[0], w29");
+  TEST_SINGLE(ins<SubRegSize::i64Bit>(VReg::v30, 0, Reg::r29), "mov v30.d[0], x29");
+  TEST_SINGLE(ins<SubRegSize::i8Bit>(VReg::v30, 15, Reg::r29), "mov v30.b[15], w29");
+  TEST_SINGLE(ins<SubRegSize::i16Bit>(VReg::v30, 7, Reg::r29), "mov v30.h[7], w29");
+  TEST_SINGLE(ins<SubRegSize::i32Bit>(VReg::v30, 3, Reg::r29), "mov v30.s[3], w29");
+  TEST_SINGLE(ins<SubRegSize::i64Bit>(VReg::v30, 1, Reg::r29), "mov v30.d[1], x29");
+
+  TEST_SINGLE(ins(SubRegSize::i8Bit, VReg::v30, 0, Reg::r29),  "mov v30.b[0], w29");
+  TEST_SINGLE(ins(SubRegSize::i16Bit, VReg::v30, 0, Reg::r29), "mov v30.h[0], w29");
+  TEST_SINGLE(ins(SubRegSize::i32Bit, VReg::v30, 0, Reg::r29), "mov v30.s[0], w29");
+  TEST_SINGLE(ins(SubRegSize::i64Bit, VReg::v30, 0, Reg::r29), "mov v30.d[0], x29");
+  TEST_SINGLE(ins(SubRegSize::i8Bit, VReg::v30, 15, Reg::r29), "mov v30.b[15], w29");
+  TEST_SINGLE(ins(SubRegSize::i16Bit, VReg::v30, 7, Reg::r29), "mov v30.h[7], w29");
+  TEST_SINGLE(ins(SubRegSize::i32Bit, VReg::v30, 3, Reg::r29), "mov v30.s[3], w29");
+  TEST_SINGLE(ins(SubRegSize::i64Bit, VReg::v30, 1, Reg::r29), "mov v30.d[1], x29");
+
+  TEST_SINGLE(ins(SubRegSize::i8Bit, VReg::v30, 0, VReg::v29, 15),  "mov v30.b[0], v29.b[15]");
+  TEST_SINGLE(ins(SubRegSize::i16Bit, VReg::v30, 0, VReg::v29, 7), "mov v30.h[0], v29.h[7]");
+  TEST_SINGLE(ins(SubRegSize::i32Bit, VReg::v30, 0, VReg::v29, 3), "mov v30.s[0], v29.s[3]");
+  TEST_SINGLE(ins(SubRegSize::i64Bit, VReg::v30, 0, VReg::v29, 1), "mov v30.d[0], v29.d[1]");
+  TEST_SINGLE(ins(SubRegSize::i8Bit, VReg::v30, 15, VReg::v29, 0), "mov v30.b[15], v29.b[0]");
+  TEST_SINGLE(ins(SubRegSize::i16Bit, VReg::v30, 7, VReg::v29, 0), "mov v30.h[7], v29.h[0]");
+  TEST_SINGLE(ins(SubRegSize::i32Bit, VReg::v30, 3, VReg::v29, 0), "mov v30.s[3], v29.s[0]");
+  TEST_SINGLE(ins(SubRegSize::i64Bit, VReg::v30, 1, VReg::v29, 0), "mov v30.d[1], v29.d[0]");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD three same (FP16)") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD two-register miscellaneous (FP16)") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD three-register extension") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD two-register miscellaneous") {
+  // Commented out lines showcase unallocated encodings.
+  TEST_SINGLE(rev64(SubRegSize::i8Bit, QReg::q30, QReg::q29), "rev64 v30.16b, v29.16b");
+  TEST_SINGLE(rev64(SubRegSize::i16Bit, QReg::q30, QReg::q29), "rev64 v30.8h, v29.8h");
+  TEST_SINGLE(rev64(SubRegSize::i32Bit, QReg::q30, QReg::q29), "rev64 v30.4s, v29.4s");
+  //TEST_SINGLE(rev64(SubRegSize::i64Bit, QReg::q30, QReg::q29), "rev64 v30.2d, v29.2d");
+
+  TEST_SINGLE(rev64(SubRegSize::i8Bit, DReg::d30, DReg::d29), "rev64 v30.8b, v29.8b");
+  TEST_SINGLE(rev64(SubRegSize::i16Bit, DReg::d30, DReg::d29), "rev64 v30.4h, v29.4h");
+  TEST_SINGLE(rev64(SubRegSize::i32Bit, DReg::d30, DReg::d29), "rev64 v30.2s, v29.2s");
+  //TEST_SINGLE(rev64(SubRegSize::i64Bit, DReg::d30, DReg::d29), "rev64 v30.1d, v29.1d");
+
+  TEST_SINGLE(rev16(SubRegSize::i8Bit, QReg::q30, QReg::q29), "rev16 v30.16b, v29.16b");
+  //TEST_SINGLE(rev16(SubRegSize::i16Bit, QReg::q30, QReg::q29), "rev16 v30.8h, v29.8h");
+  //TEST_SINGLE(rev16(SubRegSize::i32Bit, QReg::q30, QReg::q29), "rev16 v30.4s, v29.4s");
+  //TEST_SINGLE(rev16(SubRegSize::i64Bit, QReg::q30, QReg::q29), "rev16 v30.2d, v29.2d");
+
+  TEST_SINGLE(rev16(SubRegSize::i8Bit, DReg::d30, DReg::d29), "rev16 v30.8b, v29.8b");
+  //TEST_SINGLE(rev16(SubRegSize::i16Bit, DReg::d30, DReg::d29), "rev16 v30.4h, v29.4h");
+  //TEST_SINGLE(rev16(SubRegSize::i32Bit, DReg::d30, DReg::d29), "rev16 v30.2s, v29.2s");
+  //TEST_SINGLE(rev16(SubRegSize::i64Bit, DReg::d30, DReg::d29), "rev16 v30.1d, v29.1d");
+
+  //TEST_SINGLE(saddlp(SubRegSize::i8Bit, QReg::q30, QReg::q29), "saddlp v30.16b, v29.16b");
+  TEST_SINGLE(saddlp(SubRegSize::i16Bit, QReg::q30, QReg::q29), "saddlp v30.8h, v29.16b");
+  TEST_SINGLE(saddlp(SubRegSize::i32Bit, QReg::q30, QReg::q29), "saddlp v30.4s, v29.8h");
+  TEST_SINGLE(saddlp(SubRegSize::i64Bit, QReg::q30, QReg::q29), "saddlp v30.2d, v29.4s");
+
+  //TEST_SINGLE(saddlp(SubRegSize::i8Bit, DReg::d30, DReg::d29), "saddlp v30.8b, v29.8b");
+  TEST_SINGLE(saddlp(SubRegSize::i16Bit, DReg::d30, DReg::d29), "saddlp v30.4h, v29.8b");
+  TEST_SINGLE(saddlp(SubRegSize::i32Bit, DReg::d30, DReg::d29), "saddlp v30.2s, v29.4h");
+  TEST_SINGLE(saddlp(SubRegSize::i64Bit, DReg::d30, DReg::d29), "saddlp v30.1d, v29.2s");
+
+  TEST_SINGLE(suqadd(SubRegSize::i8Bit, QReg::q30, QReg::q29), "suqadd v30.16b, v29.16b");
+  TEST_SINGLE(suqadd(SubRegSize::i16Bit, QReg::q30, QReg::q29), "suqadd v30.8h, v29.8h");
+  TEST_SINGLE(suqadd(SubRegSize::i32Bit, QReg::q30, QReg::q29), "suqadd v30.4s, v29.4s");
+  TEST_SINGLE(suqadd(SubRegSize::i64Bit, QReg::q30, QReg::q29), "suqadd v30.2d, v29.2d");
+
+  TEST_SINGLE(suqadd(SubRegSize::i8Bit, DReg::d30, DReg::d29), "suqadd v30.8b, v29.8b");
+  TEST_SINGLE(suqadd(SubRegSize::i16Bit, DReg::d30, DReg::d29), "suqadd v30.4h, v29.4h");
+  TEST_SINGLE(suqadd(SubRegSize::i32Bit, DReg::d30, DReg::d29), "suqadd v30.2s, v29.2s");
+  //TEST_SINGLE(suqadd(SubRegSize::i64Bit, DReg::d30, DReg::d29), "suqadd v30.1d, v29.1d");
+
+  TEST_SINGLE(cls(SubRegSize::i8Bit, QReg::q30, QReg::q29), "cls v30.16b, v29.16b");
+  TEST_SINGLE(cls(SubRegSize::i16Bit, QReg::q30, QReg::q29), "cls v30.8h, v29.8h");
+  TEST_SINGLE(cls(SubRegSize::i32Bit, QReg::q30, QReg::q29), "cls v30.4s, v29.4s");
+  //TEST_SINGLE(cls(SubRegSize::i64Bit, QReg::q30, QReg::q29), "cls v30.2d, v29.2d");
+
+  TEST_SINGLE(cls(SubRegSize::i8Bit, DReg::d30, DReg::d29), "cls v30.8b, v29.8b");
+  TEST_SINGLE(cls(SubRegSize::i16Bit, DReg::d30, DReg::d29), "cls v30.4h, v29.4h");
+  TEST_SINGLE(cls(SubRegSize::i32Bit, DReg::d30, DReg::d29), "cls v30.2s, v29.2s");
+  //TEST_SINGLE(cls(SubRegSize::i64Bit, DReg::d30, DReg::d29), "cls v30.1d, v29.1d");
+
+  TEST_SINGLE(cnt(SubRegSize::i8Bit, QReg::q30, QReg::q29), "cnt v30.16b, v29.16b");
+  //TEST_SINGLE(cnt(SubRegSize::i16Bit, QReg::q30, QReg::q29), "cnt v30.8h, v29.8h");
+  //TEST_SINGLE(cnt(SubRegSize::i32Bit, QReg::q30, QReg::q29), "cnt v30.4s, v29.4s");
+  //TEST_SINGLE(cnt(SubRegSize::i64Bit, QReg::q30, QReg::q29), "cnt v30.2d, v29.2d");
+
+  TEST_SINGLE(cnt(SubRegSize::i8Bit, DReg::d30, DReg::d29), "cnt v30.8b, v29.8b");
+  //TEST_SINGLE(cnt(SubRegSize::i16Bit, DReg::d30, DReg::d29), "cnt v30.4h, v29.4h");
+  //TEST_SINGLE(cnt(SubRegSize::i32Bit, DReg::d30, DReg::d29), "cnt v30.2s, v29.2s");
+  //TEST_SINGLE(cnt(SubRegSize::i64Bit, DReg::d30, DReg::d29), "cnt v30.1d, v29.1d");
+
+  //TEST_SINGLE(sadalp(SubRegSize::i8Bit, QReg::q30, QReg::q29), "sadalp v30.16b, v29.16b");
+  TEST_SINGLE(sadalp(SubRegSize::i16Bit, QReg::q30, QReg::q29), "sadalp v30.8h, v29.16b");
+  TEST_SINGLE(sadalp(SubRegSize::i32Bit, QReg::q30, QReg::q29), "sadalp v30.4s, v29.8h");
+  TEST_SINGLE(sadalp(SubRegSize::i64Bit, QReg::q30, QReg::q29), "sadalp v30.2d, v29.4s");
+
+  //TEST_SINGLE(sadalp(SubRegSize::i8Bit, DReg::d30, DReg::d29), "sadalp v30.8b, v29.8b");
+  TEST_SINGLE(sadalp(SubRegSize::i16Bit, DReg::d30, DReg::d29), "sadalp v30.4h, v29.8b");
+  TEST_SINGLE(sadalp(SubRegSize::i32Bit, DReg::d30, DReg::d29), "sadalp v30.2s, v29.4h");
+  TEST_SINGLE(sadalp(SubRegSize::i64Bit, DReg::d30, DReg::d29), "sadalp v30.1d, v29.2s");
+
+  TEST_SINGLE(sqabs(SubRegSize::i8Bit, QReg::q30, QReg::q29), "sqabs v30.16b, v29.16b");
+  TEST_SINGLE(sqabs(SubRegSize::i16Bit, QReg::q30, QReg::q29), "sqabs v30.8h, v29.8h");
+  TEST_SINGLE(sqabs(SubRegSize::i32Bit, QReg::q30, QReg::q29), "sqabs v30.4s, v29.4s");
+  TEST_SINGLE(sqabs(SubRegSize::i64Bit, QReg::q30, QReg::q29), "sqabs v30.2d, v29.2d");
+
+  TEST_SINGLE(sqabs(SubRegSize::i8Bit, DReg::d30, DReg::d29), "sqabs v30.8b, v29.8b");
+  TEST_SINGLE(sqabs(SubRegSize::i16Bit, DReg::d30, DReg::d29), "sqabs v30.4h, v29.4h");
+  TEST_SINGLE(sqabs(SubRegSize::i32Bit, DReg::d30, DReg::d29), "sqabs v30.2s, v29.2s");
+  //TEST_SINGLE(sqabs(SubRegSize::i64Bit, DReg::d30, DReg::d29), "sqabs v30.1d, v29.1d");
+
+  TEST_SINGLE(cmgt(SubRegSize::i8Bit, QReg::q30, QReg::q29), "cmgt v30.16b, v29.16b, #0");
+  TEST_SINGLE(cmgt(SubRegSize::i16Bit, QReg::q30, QReg::q29), "cmgt v30.8h, v29.8h, #0");
+  TEST_SINGLE(cmgt(SubRegSize::i32Bit, QReg::q30, QReg::q29), "cmgt v30.4s, v29.4s, #0");
+  TEST_SINGLE(cmgt(SubRegSize::i64Bit, QReg::q30, QReg::q29), "cmgt v30.2d, v29.2d, #0");
+
+  TEST_SINGLE(cmgt(SubRegSize::i8Bit, DReg::d30, DReg::d29), "cmgt v30.8b, v29.8b, #0");
+  TEST_SINGLE(cmgt(SubRegSize::i16Bit, DReg::d30, DReg::d29), "cmgt v30.4h, v29.4h, #0");
+  TEST_SINGLE(cmgt(SubRegSize::i32Bit, DReg::d30, DReg::d29), "cmgt v30.2s, v29.2s, #0");
+  //TEST_SINGLE(cmgt(SubRegSize::i64Bit, DReg::d30, DReg::d29), "cmgt v30.1d, v29.1d, #0");
+
+  TEST_SINGLE(cmeq(SubRegSize::i8Bit, QReg::q30, QReg::q29), "cmeq v30.16b, v29.16b, #0");
+  TEST_SINGLE(cmeq(SubRegSize::i16Bit, QReg::q30, QReg::q29), "cmeq v30.8h, v29.8h, #0");
+  TEST_SINGLE(cmeq(SubRegSize::i32Bit, QReg::q30, QReg::q29), "cmeq v30.4s, v29.4s, #0");
+  TEST_SINGLE(cmeq(SubRegSize::i64Bit, QReg::q30, QReg::q29), "cmeq v30.2d, v29.2d, #0");
+
+  TEST_SINGLE(cmeq(SubRegSize::i8Bit, DReg::d30, DReg::d29), "cmeq v30.8b, v29.8b, #0");
+  TEST_SINGLE(cmeq(SubRegSize::i16Bit, DReg::d30, DReg::d29), "cmeq v30.4h, v29.4h, #0");
+  TEST_SINGLE(cmeq(SubRegSize::i32Bit, DReg::d30, DReg::d29), "cmeq v30.2s, v29.2s, #0");
+  //TEST_SINGLE(cmeq(SubRegSize::i64Bit, DReg::d30, DReg::d29), "cmeq v30.1d, v29.1d, #0");
+
+  TEST_SINGLE(cmlt(SubRegSize::i8Bit, QReg::q30, QReg::q29), "cmlt v30.16b, v29.16b, #0");
+  TEST_SINGLE(cmlt(SubRegSize::i16Bit, QReg::q30, QReg::q29), "cmlt v30.8h, v29.8h, #0");
+  TEST_SINGLE(cmlt(SubRegSize::i32Bit, QReg::q30, QReg::q29), "cmlt v30.4s, v29.4s, #0");
+  TEST_SINGLE(cmlt(SubRegSize::i64Bit, QReg::q30, QReg::q29), "cmlt v30.2d, v29.2d, #0");
+
+  TEST_SINGLE(cmlt(SubRegSize::i8Bit, DReg::d30, DReg::d29), "cmlt v30.8b, v29.8b, #0");
+  TEST_SINGLE(cmlt(SubRegSize::i16Bit, DReg::d30, DReg::d29), "cmlt v30.4h, v29.4h, #0");
+  TEST_SINGLE(cmlt(SubRegSize::i32Bit, DReg::d30, DReg::d29), "cmlt v30.2s, v29.2s, #0");
+  //TEST_SINGLE(cmlt(SubRegSize::i64Bit, DReg::d30, DReg::d29), "cmlt v30.1d, v29.1d, #0");
+
+  TEST_SINGLE(abs(SubRegSize::i8Bit, QReg::q30, QReg::q29), "abs v30.16b, v29.16b");
+  TEST_SINGLE(abs(SubRegSize::i16Bit, QReg::q30, QReg::q29), "abs v30.8h, v29.8h");
+  TEST_SINGLE(abs(SubRegSize::i32Bit, QReg::q30, QReg::q29), "abs v30.4s, v29.4s");
+  TEST_SINGLE(abs(SubRegSize::i64Bit, QReg::q30, QReg::q29), "abs v30.2d, v29.2d");
+
+  TEST_SINGLE(abs(SubRegSize::i8Bit, DReg::d30, DReg::d29), "abs v30.8b, v29.8b");
+  TEST_SINGLE(abs(SubRegSize::i16Bit, DReg::d30, DReg::d29), "abs v30.4h, v29.4h");
+  TEST_SINGLE(abs(SubRegSize::i32Bit, DReg::d30, DReg::d29), "abs v30.2s, v29.2s");
+  // TEST_SINGLE(abs(SubRegSize::i64Bit, DReg::d30, DReg::d29), "abs v30.1d, v29.1d");
+
+  TEST_SINGLE(xtn(SubRegSize::i8Bit, QReg::q30, QReg::q29), "xtn v30.8b, v29.8h");
+  TEST_SINGLE(xtn(SubRegSize::i16Bit, QReg::q30, QReg::q29), "xtn v30.4h, v29.4s");
+  TEST_SINGLE(xtn(SubRegSize::i32Bit, QReg::q30, QReg::q29), "xtn v30.2s, v29.2d");
+  //TEST_SINGLE(xtn(SubRegSize::i64Bit, QReg::q30, QReg::q29), "xtn v30.2d, v29.1d");
+
+  TEST_SINGLE(xtn(SubRegSize::i8Bit, DReg::d30, DReg::d29), "xtn v30.8b, v29.8h");
+  TEST_SINGLE(xtn(SubRegSize::i16Bit, DReg::d30, DReg::d29), "xtn v30.4h, v29.4s");
+  TEST_SINGLE(xtn(SubRegSize::i32Bit, DReg::d30, DReg::d29), "xtn v30.2s, v29.2d");
+  //TEST_SINGLE(xtn(SubRegSize::i64Bit, DReg::d30, DReg::d29), "xtn v30.1d, v29.1d");
+
+  TEST_SINGLE(xtn2(SubRegSize::i8Bit, QReg::q30, QReg::q29), "xtn2 v30.16b, v29.8h");
+  TEST_SINGLE(xtn2(SubRegSize::i16Bit, QReg::q30, QReg::q29), "xtn2 v30.8h, v29.4s");
+  TEST_SINGLE(xtn2(SubRegSize::i32Bit, QReg::q30, QReg::q29), "xtn2 v30.4s, v29.2d");
+  //TEST_SINGLE(xtn2(SubRegSize::i64Bit, QReg::q30, QReg::q29), "xtn2 v30.2d, v29.1d");
+
+  TEST_SINGLE(xtn2(SubRegSize::i8Bit, DReg::d30, DReg::d29), "xtn2 v30.16b, v29.8h");
+  TEST_SINGLE(xtn2(SubRegSize::i16Bit, DReg::d30, DReg::d29), "xtn2 v30.8h, v29.4s");
+  TEST_SINGLE(xtn2(SubRegSize::i32Bit, DReg::d30, DReg::d29), "xtn2 v30.4s, v29.2d");
+  //TEST_SINGLE(xtn2(SubRegSize::i64Bit, DReg::d30, DReg::d29), "xtn2 v30.2d, v29.1d");
+
+  TEST_SINGLE(sqxtn(SubRegSize::i8Bit, QReg::q30, QReg::q29), "sqxtn v30.8b, v29.8h");
+  TEST_SINGLE(sqxtn(SubRegSize::i16Bit, QReg::q30, QReg::q29), "sqxtn v30.4h, v29.4s");
+  TEST_SINGLE(sqxtn(SubRegSize::i32Bit, QReg::q30, QReg::q29), "sqxtn v30.2s, v29.2d");
+  //TEST_SINGLE(sqxtn(SubRegSize::i64Bit, QReg::q30, QReg::q29), "sqxtn v30.2d, v29.1d");
+
+  TEST_SINGLE(sqxtn(SubRegSize::i8Bit, DReg::d30, DReg::d29), "sqxtn v30.8b, v29.8h");
+  TEST_SINGLE(sqxtn(SubRegSize::i16Bit, DReg::d30, DReg::d29), "sqxtn v30.4h, v29.4s");
+  TEST_SINGLE(sqxtn(SubRegSize::i32Bit, DReg::d30, DReg::d29), "sqxtn v30.2s, v29.2d");
+  //TEST_SINGLE(sqxtn(SubRegSize::i64Bit, DReg::d30, DReg::d29), "sqxtn v30.1d, v29.1d");
+
+  TEST_SINGLE(sqxtn2(SubRegSize::i8Bit, QReg::q30, QReg::q29), "sqxtn2 v30.16b, v29.8h");
+  TEST_SINGLE(sqxtn2(SubRegSize::i16Bit, QReg::q30, QReg::q29), "sqxtn2 v30.8h, v29.4s");
+  TEST_SINGLE(sqxtn2(SubRegSize::i32Bit, QReg::q30, QReg::q29), "sqxtn2 v30.4s, v29.2d");
+  //TEST_SINGLE(sqxtn2(SubRegSize::i64Bit, QReg::q30, QReg::q29), "sqxtn2 v30.2d, v29.1d");
+
+  TEST_SINGLE(sqxtn2(SubRegSize::i8Bit, DReg::d30, DReg::d29), "sqxtn2 v30.16b, v29.8h");
+  TEST_SINGLE(sqxtn2(SubRegSize::i16Bit, DReg::d30, DReg::d29), "sqxtn2 v30.8h, v29.4s");
+  TEST_SINGLE(sqxtn2(SubRegSize::i32Bit, DReg::d30, DReg::d29), "sqxtn2 v30.4s, v29.2d");
+  //TEST_SINGLE(sqxtn2(SubRegSize::i64Bit, DReg::d30, DReg::d29), "sqxtn2 v30.2d, v29.1d");
+
+  //TEST_SINGLE(fcvtn(SubRegSize::i8Bit, QReg::q30, QReg::q29), "fcvtn v30.8b, v29.8h");
+  TEST_SINGLE(fcvtn(SubRegSize::i16Bit, QReg::q30, QReg::q29), "fcvtn v30.4h, v29.4s");
+  TEST_SINGLE(fcvtn(SubRegSize::i32Bit, QReg::q30, QReg::q29), "fcvtn v30.2s, v29.2d");
+  //TEST_SINGLE(fcvtn(SubRegSize::i64Bit, QReg::q30, QReg::q29), "fcvtn v30.2d, v29.1d");
+
+  //TEST_SINGLE(fcvtn(SubRegSize::i8Bit, DReg::d30, DReg::d29), "fcvtn v30.8b, v29.8h");
+  TEST_SINGLE(fcvtn(SubRegSize::i16Bit, DReg::d30, DReg::d29), "fcvtn v30.4h, v29.4s");
+  TEST_SINGLE(fcvtn(SubRegSize::i32Bit, DReg::d30, DReg::d29), "fcvtn v30.2s, v29.2d");
+  //TEST_SINGLE(fcvtn(SubRegSize::i64Bit, DReg::d30, DReg::d29), "fcvtn v30.1d, v29.1d");
+
+  //TEST_SINGLE(fcvtn2(SubRegSize::i8Bit, QReg::q30, QReg::q29), "fcvtn2 v30.16b, v29.8h");
+  TEST_SINGLE(fcvtn2(SubRegSize::i16Bit, QReg::q30, QReg::q29), "fcvtn2 v30.8h, v29.4s");
+  TEST_SINGLE(fcvtn2(SubRegSize::i32Bit, QReg::q30, QReg::q29), "fcvtn2 v30.4s, v29.2d");
+  //TEST_SINGLE(fcvtn2(SubRegSize::i64Bit, QReg::q30, QReg::q29), "fcvtn2 v30.2d, v29.1d");
+
+  //TEST_SINGLE(fcvtn2(SubRegSize::i8Bit, DReg::d30, DReg::d29), "fcvtn2 v30.16b, v29.8h");
+  TEST_SINGLE(fcvtn2(SubRegSize::i16Bit, DReg::d30, DReg::d29), "fcvtn2 v30.8h, v29.4s");
+  TEST_SINGLE(fcvtn2(SubRegSize::i32Bit, DReg::d30, DReg::d29), "fcvtn2 v30.4s, v29.2d");
+  //TEST_SINGLE(fcvtn2(SubRegSize::i64Bit, DReg::d30, DReg::d29), "fcvtn2 v30.2d, v29.1d");
+
+  //TEST_SINGLE(fcvtl(SubRegSize::i8Bit, QReg::q30, QReg::q29), "fcvtl v30.8b, v29.8h");
+  //TEST_SINGLE(fcvtl(SubRegSize::i16Bit, QReg::q30, QReg::q29), "fcvtl v30.4h, v29.4s");
+  TEST_SINGLE(fcvtl(SubRegSize::i32Bit, QReg::q30, QReg::q29), "fcvtl v30.4s, v29.4h");
+  TEST_SINGLE(fcvtl(SubRegSize::i64Bit, QReg::q30, QReg::q29), "fcvtl v30.2d, v29.2s");
+
+  //TEST_SINGLE(fcvtl(SubRegSize::i8Bit, DReg::d30, DReg::d29), "fcvtl v30.8b, v29.8h");
+  //TEST_SINGLE(fcvtl(SubRegSize::i16Bit, DReg::d30, DReg::d29), "fcvtl v30.4h, v29.4s");
+  TEST_SINGLE(fcvtl(SubRegSize::i32Bit, DReg::d30, DReg::d29), "fcvtl v30.4s, v29.4h");
+  TEST_SINGLE(fcvtl(SubRegSize::i64Bit, DReg::d30, DReg::d29), "fcvtl v30.2d, v29.2s");
+
+  //TEST_SINGLE(fcvtl2(SubRegSize::i8Bit, QReg::q30, QReg::q29), "fcvtl2 v30.16b, v29.8h");
+  //TEST_SINGLE(fcvtl2(SubRegSize::i16Bit, QReg::q30, QReg::q29), "fcvtl2 v30.8h, v29.4s");
+  TEST_SINGLE(fcvtl2(SubRegSize::i32Bit, QReg::q30, QReg::q29), "fcvtl2 v30.4s, v29.8h");
+  TEST_SINGLE(fcvtl2(SubRegSize::i64Bit, QReg::q30, QReg::q29), "fcvtl2 v30.2d, v29.4s");
+
+  //TEST_SINGLE(fcvtl2(SubRegSize::i8Bit, DReg::d30, DReg::d29), "fcvtl2 v30.16b, v29.8h");
+  //TEST_SINGLE(fcvtl2(SubRegSize::i16Bit, DReg::d30, DReg::d29), "fcvtl2 v30.8h, v29.4s");
+  TEST_SINGLE(fcvtl2(SubRegSize::i32Bit, DReg::d30, DReg::d29), "fcvtl2 v30.4s, v29.8h");
+  TEST_SINGLE(fcvtl2(SubRegSize::i64Bit, DReg::d30, DReg::d29), "fcvtl2 v30.2d, v29.4s");
+
+  TEST_SINGLE(frintn(SubRegSize::i32Bit, QReg::q30, QReg::q29), "frintn v30.4s, v29.4s");
+  TEST_SINGLE(frintn(SubRegSize::i64Bit, QReg::q30, QReg::q29), "frintn v30.2d, v29.2d");
+  TEST_SINGLE(frintn(SubRegSize::i32Bit, DReg::d30, DReg::d29), "frintn v30.2s, v29.2s");
+  //TEST_SINGLE(frintn(SubRegSize::i64Bit, DReg::d30, DReg::d29), "frintn v30.1d, v29.1d");
+
+  TEST_SINGLE(frintm(SubRegSize::i32Bit, QReg::q30, QReg::q29), "frintm v30.4s, v29.4s");
+  TEST_SINGLE(frintm(SubRegSize::i64Bit, QReg::q30, QReg::q29), "frintm v30.2d, v29.2d");
+  TEST_SINGLE(frintm(SubRegSize::i32Bit, DReg::d30, DReg::d29), "frintm v30.2s, v29.2s");
+  //TEST_SINGLE(frintm(SubRegSize::i64Bit, DReg::d30, DReg::d29), "frintm v30.1d, v29.1d");
+
+  TEST_SINGLE(fcvtns(SubRegSize::i32Bit, QReg::q30, QReg::q29), "fcvtns v30.4s, v29.4s");
+  TEST_SINGLE(fcvtns(SubRegSize::i64Bit, QReg::q30, QReg::q29), "fcvtns v30.2d, v29.2d");
+  TEST_SINGLE(fcvtns(SubRegSize::i32Bit, DReg::d30, DReg::d29), "fcvtns v30.2s, v29.2s");
+  //TEST_SINGLE(fcvtns(SubRegSize::i64Bit, DReg::d30, DReg::d29), "fcvtns v30.1d, v29.1d");
+
+  TEST_SINGLE(fcvtms(SubRegSize::i32Bit, QReg::q30, QReg::q29), "fcvtms v30.4s, v29.4s");
+  TEST_SINGLE(fcvtms(SubRegSize::i64Bit, QReg::q30, QReg::q29), "fcvtms v30.2d, v29.2d");
+  TEST_SINGLE(fcvtms(SubRegSize::i32Bit, DReg::d30, DReg::d29), "fcvtms v30.2s, v29.2s");
+  //TEST_SINGLE(fcvtms(SubRegSize::i64Bit, DReg::d30, DReg::d29), "fcvtms v30.1d, v29.1d");
+
+  TEST_SINGLE(fcvtas(SubRegSize::i32Bit, QReg::q30, QReg::q29), "fcvtas v30.4s, v29.4s");
+  TEST_SINGLE(fcvtas(SubRegSize::i64Bit, QReg::q30, QReg::q29), "fcvtas v30.2d, v29.2d");
+  TEST_SINGLE(fcvtas(SubRegSize::i32Bit, DReg::d30, DReg::d29), "fcvtas v30.2s, v29.2s");
+  //TEST_SINGLE(fcvtas(SubRegSize::i64Bit, DReg::d30, DReg::d29), "fcvtas v30.1d, v29.1d");
+
+  TEST_SINGLE(scvtf(SubRegSize::i32Bit, QReg::q30, QReg::q29), "scvtf v30.4s, v29.4s");
+  TEST_SINGLE(scvtf(SubRegSize::i64Bit, QReg::q30, QReg::q29), "scvtf v30.2d, v29.2d");
+  TEST_SINGLE(scvtf(SubRegSize::i32Bit, DReg::d30, DReg::d29), "scvtf v30.2s, v29.2s");
+  //TEST_SINGLE(scvtf(SubRegSize::i64Bit, DReg::d30, DReg::d29), "scvtf v30.1d, v29.1d");
+
+  TEST_SINGLE(frint32z(SubRegSize::i32Bit, QReg::q30, QReg::q29), "frint32z v30.4s, v29.4s");
+  TEST_SINGLE(frint32z(SubRegSize::i64Bit, QReg::q30, QReg::q29), "frint32z v30.2d, v29.2d");
+  TEST_SINGLE(frint32z(SubRegSize::i32Bit, DReg::d30, DReg::d29), "frint32z v30.2s, v29.2s");
+  //TEST_SINGLE(frint32z(SubRegSize::i64Bit, DReg::d30, DReg::d29), "frint32z v30.1d, v29.1d");
+
+  TEST_SINGLE(frint64z(SubRegSize::i32Bit, QReg::q30, QReg::q29), "frint64z v30.4s, v29.4s");
+  TEST_SINGLE(frint64z(SubRegSize::i64Bit, QReg::q30, QReg::q29), "frint64z v30.2d, v29.2d");
+  TEST_SINGLE(frint64z(SubRegSize::i32Bit, DReg::d30, DReg::d29), "frint64z v30.2s, v29.2s");
+  //TEST_SINGLE(frint64z(SubRegSize::i64Bit, DReg::d30, DReg::d29), "frint64z v30.1d, v29.1d");
+
+  TEST_SINGLE(fcmgt(SubRegSize::i32Bit, QReg::q30, QReg::q29), "fcmgt v30.4s, v29.4s, #0.0");
+  TEST_SINGLE(fcmgt(SubRegSize::i64Bit, QReg::q30, QReg::q29), "fcmgt v30.2d, v29.2d, #0.0");
+  TEST_SINGLE(fcmgt(SubRegSize::i32Bit, DReg::d30, DReg::d29), "fcmgt v30.2s, v29.2s, #0.0");
+  //TEST_SINGLE(fcmgt(SubRegSize::i64Bit, DReg::d30, DReg::d29), "fcmgt v30.1d, v29.1d, #0.0");
+
+  TEST_SINGLE(fcmeq(SubRegSize::i32Bit, QReg::q30, QReg::q29), "fcmeq v30.4s, v29.4s, #0.0");
+  TEST_SINGLE(fcmeq(SubRegSize::i64Bit, QReg::q30, QReg::q29), "fcmeq v30.2d, v29.2d, #0.0");
+  TEST_SINGLE(fcmeq(SubRegSize::i32Bit, DReg::d30, DReg::d29), "fcmeq v30.2s, v29.2s, #0.0");
+  //TEST_SINGLE(fcmeq(SubRegSize::i64Bit, DReg::d30, DReg::d29), "fcmeq v30.1d, v29.1d, #0.0");
+
+  TEST_SINGLE(fcmlt(SubRegSize::i32Bit, QReg::q30, QReg::q29), "fcmlt v30.4s, v29.4s, #0.0");
+  TEST_SINGLE(fcmlt(SubRegSize::i64Bit, QReg::q30, QReg::q29), "fcmlt v30.2d, v29.2d, #0.0");
+  TEST_SINGLE(fcmlt(SubRegSize::i32Bit, DReg::d30, DReg::d29), "fcmlt v30.2s, v29.2s, #0.0");
+  //TEST_SINGLE(fcmlt(SubRegSize::i64Bit, DReg::d30, DReg::d29), "fcmlt v30.1d, v29.1d, #0.0");
+
+  TEST_SINGLE(fabs(SubRegSize::i32Bit, QReg::q30, QReg::q29), "fabs v30.4s, v29.4s");
+  TEST_SINGLE(fabs(SubRegSize::i64Bit, QReg::q30, QReg::q29), "fabs v30.2d, v29.2d");
+  TEST_SINGLE(fabs(SubRegSize::i32Bit, DReg::d30, DReg::d29), "fabs v30.2s, v29.2s");
+  //TEST_SINGLE(fabs(SubRegSize::i64Bit, DReg::d30, DReg::d29), "fabs v30.1d, v29.1d");
+
+  TEST_SINGLE(frintp(SubRegSize::i32Bit, QReg::q30, QReg::q29), "frintp v30.4s, v29.4s");
+  TEST_SINGLE(frintp(SubRegSize::i64Bit, QReg::q30, QReg::q29), "frintp v30.2d, v29.2d");
+  TEST_SINGLE(frintp(SubRegSize::i32Bit, DReg::d30, DReg::d29), "frintp v30.2s, v29.2s");
+  //TEST_SINGLE(frintp(SubRegSize::i64Bit, DReg::d30, DReg::d29), "frintp v30.1d, v29.1d");
+
+  TEST_SINGLE(frintz(SubRegSize::i32Bit, QReg::q30, QReg::q29), "frintz v30.4s, v29.4s");
+  TEST_SINGLE(frintz(SubRegSize::i64Bit, QReg::q30, QReg::q29), "frintz v30.2d, v29.2d");
+  TEST_SINGLE(frintz(SubRegSize::i32Bit, DReg::d30, DReg::d29), "frintz v30.2s, v29.2s");
+  //TEST_SINGLE(frintz(SubRegSize::i64Bit, DReg::d30, DReg::d29), "frintz v30.1d, v29.1d");
+
+  TEST_SINGLE(fcvtps(SubRegSize::i32Bit, QReg::q30, QReg::q29), "fcvtps v30.4s, v29.4s");
+  TEST_SINGLE(fcvtps(SubRegSize::i64Bit, QReg::q30, QReg::q29), "fcvtps v30.2d, v29.2d");
+  TEST_SINGLE(fcvtps(SubRegSize::i32Bit, DReg::d30, DReg::d29), "fcvtps v30.2s, v29.2s");
+  //TEST_SINGLE(fcvtps(SubRegSize::i64Bit, DReg::d30, DReg::d29), "fcvtps v30.1d, v29.1d");
+
+  TEST_SINGLE(fcvtzs(SubRegSize::i32Bit, QReg::q30, QReg::q29), "fcvtzs v30.4s, v29.4s");
+  TEST_SINGLE(fcvtzs(SubRegSize::i64Bit, QReg::q30, QReg::q29), "fcvtzs v30.2d, v29.2d");
+  TEST_SINGLE(fcvtzs(SubRegSize::i32Bit, DReg::d30, DReg::d29), "fcvtzs v30.2s, v29.2s");
+  //TEST_SINGLE(fcvtzs(SubRegSize::i64Bit, DReg::d30, DReg::d29), "fcvtzs v30.1d, v29.1d");
+
+  TEST_SINGLE(urecpe(SubRegSize::i32Bit, QReg::q30, QReg::q29), "urecpe v30.4s, v29.4s");
+  //TEST_SINGLE(urecpe(SubRegSize::i64Bit, QReg::q30, QReg::q29), "urecpe v30.2d, v29.2d");
+  TEST_SINGLE(urecpe(SubRegSize::i32Bit, DReg::d30, DReg::d29), "urecpe v30.2s, v29.2s");
+  //TEST_SINGLE(urecpe(SubRegSize::i64Bit, DReg::d30, DReg::d29), "urecpe v30.1d, v29.1d");
+
+  TEST_SINGLE(frecpe(SubRegSize::i32Bit, QReg::q30, QReg::q29), "frecpe v30.4s, v29.4s");
+  TEST_SINGLE(frecpe(SubRegSize::i64Bit, QReg::q30, QReg::q29), "frecpe v30.2d, v29.2d");
+  TEST_SINGLE(frecpe(SubRegSize::i32Bit, DReg::d30, DReg::d29), "frecpe v30.2s, v29.2s");
+  //TEST_SINGLE(frecpe(SubRegSize::i64Bit, DReg::d30, DReg::d29), "frecpe v30.1d, v29.1d");
+
+  TEST_SINGLE(rev32(SubRegSize::i8Bit, QReg::q30, QReg::q29), "rev32 v30.16b, v29.16b");
+  TEST_SINGLE(rev32(SubRegSize::i16Bit, QReg::q30, QReg::q29), "rev32 v30.8h, v29.8h");
+  //TEST_SINGLE(rev32(SubRegSize::i32Bit, QReg::q30, QReg::q29), "rev32 v30.4s, v29.4s");
+  //TEST_SINGLE(rev32(SubRegSize::i64Bit, QReg::q30, QReg::q29), "rev32 v30.2d, v29.2d");
+
+  TEST_SINGLE(rev32(SubRegSize::i8Bit, DReg::d30, DReg::d29), "rev32 v30.8b, v29.8b");
+  TEST_SINGLE(rev32(SubRegSize::i16Bit, DReg::d30, DReg::d29), "rev32 v30.4h, v29.4h");
+  //TEST_SINGLE(rev32(SubRegSize::i32Bit, DReg::d30, DReg::d29), "rev32 v30.2s, v29.2s");
+  //TEST_SINGLE(rev32(SubRegSize::i64Bit, DReg::d30, DReg::d29), "rev32 v30.1d, v29.1d");
+
+  //TEST_SINGLE(uaddlp(SubRegSize::i8Bit, QReg::q30, QReg::q29), "uaddlp v30.16b, v29.16b");
+  TEST_SINGLE(uaddlp(SubRegSize::i16Bit, QReg::q30, QReg::q29), "uaddlp v30.8h, v29.16b");
+  TEST_SINGLE(uaddlp(SubRegSize::i32Bit, QReg::q30, QReg::q29), "uaddlp v30.4s, v29.8h");
+  TEST_SINGLE(uaddlp(SubRegSize::i64Bit, QReg::q30, QReg::q29), "uaddlp v30.2d, v29.4s");
+
+  //TEST_SINGLE(uaddlp(SubRegSize::i8Bit, DReg::d30, DReg::d29), "uaddlp v30.8b, v29.8b");
+  TEST_SINGLE(uaddlp(SubRegSize::i16Bit, DReg::d30, DReg::d29), "uaddlp v30.4h, v29.8b");
+  TEST_SINGLE(uaddlp(SubRegSize::i32Bit, DReg::d30, DReg::d29), "uaddlp v30.2s, v29.4h");
+  TEST_SINGLE(uaddlp(SubRegSize::i64Bit, DReg::d30, DReg::d29), "uaddlp v30.1d, v29.2s");
+
+  TEST_SINGLE(usqadd(SubRegSize::i8Bit, QReg::q30, QReg::q29), "usqadd v30.16b, v29.16b");
+  TEST_SINGLE(usqadd(SubRegSize::i16Bit, QReg::q30, QReg::q29), "usqadd v30.8h, v29.8h");
+  TEST_SINGLE(usqadd(SubRegSize::i32Bit, QReg::q30, QReg::q29), "usqadd v30.4s, v29.4s");
+  TEST_SINGLE(usqadd(SubRegSize::i64Bit, QReg::q30, QReg::q29), "usqadd v30.2d, v29.2d");
+
+  TEST_SINGLE(usqadd(SubRegSize::i8Bit, DReg::d30, DReg::d29), "usqadd v30.8b, v29.8b");
+  TEST_SINGLE(usqadd(SubRegSize::i16Bit, DReg::d30, DReg::d29), "usqadd v30.4h, v29.4h");
+  TEST_SINGLE(usqadd(SubRegSize::i32Bit, DReg::d30, DReg::d29), "usqadd v30.2s, v29.2s");
+  //TEST_SINGLE(usqadd(SubRegSize::i64Bit, DReg::d30, DReg::d29), "usqadd v30.1d, v29.1d");
+
+  TEST_SINGLE(clz(SubRegSize::i8Bit, QReg::q30, QReg::q29), "clz v30.16b, v29.16b");
+  TEST_SINGLE(clz(SubRegSize::i16Bit, QReg::q30, QReg::q29), "clz v30.8h, v29.8h");
+  TEST_SINGLE(clz(SubRegSize::i32Bit, QReg::q30, QReg::q29), "clz v30.4s, v29.4s");
+  //TEST_SINGLE(clz(SubRegSize::i64Bit, QReg::q30, QReg::q29), "clz v30.2d, v29.2d");
+
+  TEST_SINGLE(clz(SubRegSize::i8Bit, DReg::d30, DReg::d29), "clz v30.8b, v29.8b");
+  TEST_SINGLE(clz(SubRegSize::i16Bit, DReg::d30, DReg::d29), "clz v30.4h, v29.4h");
+  TEST_SINGLE(clz(SubRegSize::i32Bit, DReg::d30, DReg::d29), "clz v30.2s, v29.2s");
+  //TEST_SINGLE(clz(SubRegSize::i64Bit, DReg::d30, DReg::d29), "clz v30.1d, v29.1d");
+
+  //TEST_SINGLE(uadalp(SubRegSize::i8Bit, QReg::q30, QReg::q29), "uadalp v30.16b, v29.16b");
+  TEST_SINGLE(uadalp(SubRegSize::i16Bit, QReg::q30, QReg::q29), "uadalp v30.8h, v29.16b");
+  TEST_SINGLE(uadalp(SubRegSize::i32Bit, QReg::q30, QReg::q29), "uadalp v30.4s, v29.8h");
+  TEST_SINGLE(uadalp(SubRegSize::i64Bit, QReg::q30, QReg::q29), "uadalp v30.2d, v29.4s");
+
+  //TEST_SINGLE(uadalp(SubRegSize::i8Bit, DReg::d30, DReg::d29), "uadalp v30.8b, v29.8b");
+  TEST_SINGLE(uadalp(SubRegSize::i16Bit, DReg::d30, DReg::d29), "uadalp v30.4h, v29.8b");
+  TEST_SINGLE(uadalp(SubRegSize::i32Bit, DReg::d30, DReg::d29), "uadalp v30.2s, v29.4h");
+  TEST_SINGLE(uadalp(SubRegSize::i64Bit, DReg::d30, DReg::d29), "uadalp v30.1d, v29.2s");
+
+  TEST_SINGLE(sqneg(SubRegSize::i8Bit, QReg::q30, QReg::q29), "sqneg v30.16b, v29.16b");
+  TEST_SINGLE(sqneg(SubRegSize::i16Bit, QReg::q30, QReg::q29), "sqneg v30.8h, v29.8h");
+  TEST_SINGLE(sqneg(SubRegSize::i32Bit, QReg::q30, QReg::q29), "sqneg v30.4s, v29.4s");
+  TEST_SINGLE(sqneg(SubRegSize::i64Bit, QReg::q30, QReg::q29), "sqneg v30.2d, v29.2d");
+
+  TEST_SINGLE(sqneg(SubRegSize::i8Bit, DReg::d30, DReg::d29), "sqneg v30.8b, v29.8b");
+  TEST_SINGLE(sqneg(SubRegSize::i16Bit, DReg::d30, DReg::d29), "sqneg v30.4h, v29.4h");
+  TEST_SINGLE(sqneg(SubRegSize::i32Bit, DReg::d30, DReg::d29), "sqneg v30.2s, v29.2s");
+  //TEST_SINGLE(sqneg(SubRegSize::i64Bit, DReg::d30, DReg::d29), "sqneg v30.1d, v29.1d");
+
+  TEST_SINGLE(cmge(SubRegSize::i8Bit, QReg::q30, QReg::q29), "cmge v30.16b, v29.16b, #0");
+  TEST_SINGLE(cmge(SubRegSize::i16Bit, QReg::q30, QReg::q29), "cmge v30.8h, v29.8h, #0");
+  TEST_SINGLE(cmge(SubRegSize::i32Bit, QReg::q30, QReg::q29), "cmge v30.4s, v29.4s, #0");
+  TEST_SINGLE(cmge(SubRegSize::i64Bit, QReg::q30, QReg::q29), "cmge v30.2d, v29.2d, #0");
+
+  TEST_SINGLE(cmge(SubRegSize::i8Bit, DReg::d30, DReg::d29), "cmge v30.8b, v29.8b, #0");
+  TEST_SINGLE(cmge(SubRegSize::i16Bit, DReg::d30, DReg::d29), "cmge v30.4h, v29.4h, #0");
+  TEST_SINGLE(cmge(SubRegSize::i32Bit, DReg::d30, DReg::d29), "cmge v30.2s, v29.2s, #0");
+  //TEST_SINGLE(cmge(SubRegSize::i64Bit, DReg::d30, DReg::d29), "cmge v30.1d, v29.1d, #0");
+  //
+  TEST_SINGLE(cmle(SubRegSize::i8Bit, QReg::q30, QReg::q29), "cmle v30.16b, v29.16b, #0");
+  TEST_SINGLE(cmle(SubRegSize::i16Bit, QReg::q30, QReg::q29), "cmle v30.8h, v29.8h, #0");
+  TEST_SINGLE(cmle(SubRegSize::i32Bit, QReg::q30, QReg::q29), "cmle v30.4s, v29.4s, #0");
+  TEST_SINGLE(cmle(SubRegSize::i64Bit, QReg::q30, QReg::q29), "cmle v30.2d, v29.2d, #0");
+
+  TEST_SINGLE(cmle(SubRegSize::i8Bit, DReg::d30, DReg::d29), "cmle v30.8b, v29.8b, #0");
+  TEST_SINGLE(cmle(SubRegSize::i16Bit, DReg::d30, DReg::d29), "cmle v30.4h, v29.4h, #0");
+  TEST_SINGLE(cmle(SubRegSize::i32Bit, DReg::d30, DReg::d29), "cmle v30.2s, v29.2s, #0");
+  //TEST_SINGLE(cmle(SubRegSize::i64Bit, DReg::d30, DReg::d29), "cmle v30.1d, v29.1d, #0");
+
+  TEST_SINGLE(neg(SubRegSize::i8Bit, QReg::q30, QReg::q29), "neg v30.16b, v29.16b");
+  TEST_SINGLE(neg(SubRegSize::i16Bit, QReg::q30, QReg::q29), "neg v30.8h, v29.8h");
+  TEST_SINGLE(neg(SubRegSize::i32Bit, QReg::q30, QReg::q29), "neg v30.4s, v29.4s");
+  TEST_SINGLE(neg(SubRegSize::i64Bit, QReg::q30, QReg::q29), "neg v30.2d, v29.2d");
+
+  TEST_SINGLE(neg(SubRegSize::i8Bit, DReg::d30, DReg::d29), "neg v30.8b, v29.8b");
+  TEST_SINGLE(neg(SubRegSize::i16Bit, DReg::d30, DReg::d29), "neg v30.4h, v29.4h");
+  TEST_SINGLE(neg(SubRegSize::i32Bit, DReg::d30, DReg::d29), "neg v30.2s, v29.2s");
+  //TEST_SINGLE(neg(SubRegSize::i64Bit, DReg::d30, DReg::d29), "neg v30.1d, v29.1d");
+
+  TEST_SINGLE(sqxtun(SubRegSize::i8Bit, QReg::q30, QReg::q29), "sqxtun v30.8b, v29.8h");
+  TEST_SINGLE(sqxtun(SubRegSize::i16Bit, QReg::q30, QReg::q29), "sqxtun v30.4h, v29.4s");
+  TEST_SINGLE(sqxtun(SubRegSize::i32Bit, QReg::q30, QReg::q29), "sqxtun v30.2s, v29.2d");
+  //TEST_SINGLE(sqxtun(SubRegSize::i64Bit, QReg::q30, QReg::q29), "sqxtun v30.2d, v29.1d");
+
+  TEST_SINGLE(sqxtun(SubRegSize::i8Bit, DReg::d30, DReg::d29), "sqxtun v30.8b, v29.8h");
+  TEST_SINGLE(sqxtun(SubRegSize::i16Bit, DReg::d30, DReg::d29), "sqxtun v30.4h, v29.4s");
+  TEST_SINGLE(sqxtun(SubRegSize::i32Bit, DReg::d30, DReg::d29), "sqxtun v30.2s, v29.2d");
+  //TEST_SINGLE(sqxtun(SubRegSize::i64Bit, DReg::d30, DReg::d29), "sqxtun v30.1d, v29.1d");
+
+  TEST_SINGLE(sqxtun2(SubRegSize::i8Bit, QReg::q30, QReg::q29), "sqxtun2 v30.16b, v29.8h");
+  TEST_SINGLE(sqxtun2(SubRegSize::i16Bit, QReg::q30, QReg::q29), "sqxtun2 v30.8h, v29.4s");
+  TEST_SINGLE(sqxtun2(SubRegSize::i32Bit, QReg::q30, QReg::q29), "sqxtun2 v30.4s, v29.2d");
+  //TEST_SINGLE(sqxtun2(SubRegSize::i64Bit, QReg::q30, QReg::q29), "sqxtun2 v30.2d, v29.1d");
+
+  TEST_SINGLE(sqxtun2(SubRegSize::i8Bit, DReg::d30, DReg::d29), "sqxtun2 v30.16b, v29.8h");
+  TEST_SINGLE(sqxtun2(SubRegSize::i16Bit, DReg::d30, DReg::d29), "sqxtun2 v30.8h, v29.4s");
+  TEST_SINGLE(sqxtun2(SubRegSize::i32Bit, DReg::d30, DReg::d29), "sqxtun2 v30.4s, v29.2d");
+  //TEST_SINGLE(sqxtun2(SubRegSize::i64Bit, DReg::d30, DReg::d29), "sqxtun2 v30.2d, v29.1d");
+
+  //TEST_SINGLE(shll(SubRegSize::i8Bit, QReg::q30, QReg::q29), "shll v30.16b, v29.16b, #0");
+  TEST_SINGLE(shll(SubRegSize::i16Bit, QReg::q30, QReg::q29), "shll v30.8h, v29.8b, #8");
+  TEST_SINGLE(shll(SubRegSize::i32Bit, QReg::q30, QReg::q29), "shll v30.4s, v29.4h, #16");
+  TEST_SINGLE(shll(SubRegSize::i64Bit, QReg::q30, QReg::q29), "shll v30.2d, v29.2s, #32");
+
+  //TEST_SINGLE(shll(SubRegSize::i8Bit, DReg::d30, DReg::d29), "shll v30.8b, v29.8b, #0");
+  TEST_SINGLE(shll(SubRegSize::i16Bit, DReg::d30, DReg::d29), "shll v30.8h, v29.8b, #8");
+  TEST_SINGLE(shll(SubRegSize::i32Bit, DReg::d30, DReg::d29), "shll v30.4s, v29.4h, #16");
+  TEST_SINGLE(shll(SubRegSize::i64Bit, DReg::d30, DReg::d29), "shll v30.2d, v29.2s, #32");
+
+  //TEST_SINGLE(shll2(SubRegSize::i8Bit, QReg::q30, QReg::q29), "shll2 v30.16b, v29.16b, #0");
+  TEST_SINGLE(shll2(SubRegSize::i16Bit, QReg::q30, QReg::q29), "shll2 v30.8h, v29.16b, #8");
+  TEST_SINGLE(shll2(SubRegSize::i32Bit, QReg::q30, QReg::q29), "shll2 v30.4s, v29.8h, #16");
+  TEST_SINGLE(shll2(SubRegSize::i64Bit, QReg::q30, QReg::q29), "shll2 v30.2d, v29.4s, #32");
+
+  //TEST_SINGLE(shll2(SubRegSize::i8Bit, DReg::d30, DReg::d29), "shll2 v30.8b, v29.8b, #0");
+  TEST_SINGLE(shll2(SubRegSize::i16Bit, DReg::d30, DReg::d29), "shll2 v30.8h, v29.16b, #8");
+  TEST_SINGLE(shll2(SubRegSize::i32Bit, DReg::d30, DReg::d29), "shll2 v30.4s, v29.8h, #16");
+  TEST_SINGLE(shll2(SubRegSize::i64Bit, DReg::d30, DReg::d29), "shll2 v30.2d, v29.4s, #32");
+
+  TEST_SINGLE(uqxtn(SubRegSize::i8Bit, QReg::q30, QReg::q29), "uqxtn v30.8b, v29.8h");
+  TEST_SINGLE(uqxtn(SubRegSize::i16Bit, QReg::q30, QReg::q29), "uqxtn v30.4h, v29.4s");
+  TEST_SINGLE(uqxtn(SubRegSize::i32Bit, QReg::q30, QReg::q29), "uqxtn v30.2s, v29.2d");
+  //TEST_SINGLE(uqxtn(SubRegSize::i64Bit, QReg::q30, QReg::q29), "uqxtn v30.2d, v29.1d");
+
+  TEST_SINGLE(uqxtn(SubRegSize::i8Bit, DReg::d30, DReg::d29), "uqxtn v30.8b, v29.8h");
+  TEST_SINGLE(uqxtn(SubRegSize::i16Bit, DReg::d30, DReg::d29), "uqxtn v30.4h, v29.4s");
+  TEST_SINGLE(uqxtn(SubRegSize::i32Bit, DReg::d30, DReg::d29), "uqxtn v30.2s, v29.2d");
+  //TEST_SINGLE(uqxtn(SubRegSize::i64Bit, DReg::d30, DReg::d29), "uqxtn v30.1d, v29.1d");
+
+  TEST_SINGLE(uqxtn2(SubRegSize::i8Bit, QReg::q30, QReg::q29), "uqxtn2 v30.16b, v29.8h");
+  TEST_SINGLE(uqxtn2(SubRegSize::i16Bit, QReg::q30, QReg::q29), "uqxtn2 v30.8h, v29.4s");
+  TEST_SINGLE(uqxtn2(SubRegSize::i32Bit, QReg::q30, QReg::q29), "uqxtn2 v30.4s, v29.2d");
+  //TEST_SINGLE(uqxtn2(SubRegSize::i64Bit, QReg::q30, QReg::q29), "uqxtn2 v30.2d, v29.1d");
+
+  TEST_SINGLE(uqxtn2(SubRegSize::i8Bit, DReg::d30, DReg::d29), "uqxtn2 v30.16b, v29.8h");
+  TEST_SINGLE(uqxtn2(SubRegSize::i16Bit, DReg::d30, DReg::d29), "uqxtn2 v30.8h, v29.4s");
+  TEST_SINGLE(uqxtn2(SubRegSize::i32Bit, DReg::d30, DReg::d29), "uqxtn2 v30.4s, v29.2d");
+  //TEST_SINGLE(uqxtn2(SubRegSize::i64Bit, DReg::d30, DReg::d29), "uqxtn2 v30.2d, v29.1d");
+  //
+  //TEST_SINGLE(fcvtxn(SubRegSize::i8Bit, QReg::q30, QReg::q29), "fcvtxn v30.8b, v29.8h");
+  //TEST_SINGLE(fcvtxn(SubRegSize::i16Bit, QReg::q30, QReg::q29), "fcvtxn v30.4h, v29.4s");
+  TEST_SINGLE(fcvtxn(SubRegSize::i32Bit, QReg::q30, QReg::q29), "fcvtxn v30.2s, v29.2d");
+  //TEST_SINGLE(fcvtxn(SubRegSize::i64Bit, QReg::q30, QReg::q29), "fcvtxn v30.2d, v29.1d");
+
+  //TEST_SINGLE(fcvtxn(SubRegSize::i8Bit, DReg::d30, DReg::d29), "fcvtxn v30.8b, v29.8h");
+  //TEST_SINGLE(fcvtxn(SubRegSize::i16Bit, DReg::d30, DReg::d29), "fcvtxn v30.4h, v29.4s");
+  TEST_SINGLE(fcvtxn(SubRegSize::i32Bit, DReg::d30, DReg::d29), "fcvtxn v30.2s, v29.2d");
+  //TEST_SINGLE(fcvtxn(SubRegSize::i64Bit, DReg::d30, DReg::d29), "fcvtxn v30.1d, v29.1d");
+
+  //TEST_SINGLE(fcvtxn2(SubRegSize::i8Bit, QReg::q30, QReg::q29), "fcvtxn2 v30.16b, v29.8h");
+  //TEST_SINGLE(fcvtxn2(SubRegSize::i16Bit, QReg::q30, QReg::q29), "fcvtxn2 v30.8h, v29.4s");
+  TEST_SINGLE(fcvtxn2(SubRegSize::i32Bit, QReg::q30, QReg::q29), "fcvtxn2 v30.4s, v29.2d");
+  //TEST_SINGLE(fcvtxn2(SubRegSize::i64Bit, QReg::q30, QReg::q29), "fcvtxn2 v30.2d, v29.1d");
+
+  //TEST_SINGLE(fcvtxn2(SubRegSize::i8Bit, DReg::d30, DReg::d29), "fcvtxn2 v30.16b, v29.8h");
+  //TEST_SINGLE(fcvtxn2(SubRegSize::i16Bit, DReg::d30, DReg::d29), "fcvtxn2 v30.8h, v29.4s");
+  TEST_SINGLE(fcvtxn2(SubRegSize::i32Bit, DReg::d30, DReg::d29), "fcvtxn2 v30.4s, v29.2d");
+  //TEST_SINGLE(fcvtxn2(SubRegSize::i64Bit, DReg::d30, DReg::d29), "fcvtxn2 v30.2d, v29.1d");
+
+
+  TEST_SINGLE(frinta(SubRegSize::i32Bit, QReg::q30, QReg::q29), "frinta v30.4s, v29.4s");
+  TEST_SINGLE(frinta(SubRegSize::i64Bit, QReg::q30, QReg::q29), "frinta v30.2d, v29.2d");
+  TEST_SINGLE(frinta(SubRegSize::i32Bit, DReg::d30, DReg::d29), "frinta v30.2s, v29.2s");
+  //TEST_SINGLE(frinta(SubRegSize::i64Bit, DReg::d30, DReg::d29), "frinta v30.1d, v29.1d");
+
+  TEST_SINGLE(frintx(SubRegSize::i32Bit, QReg::q30, QReg::q29), "frintx v30.4s, v29.4s");
+  TEST_SINGLE(frintx(SubRegSize::i64Bit, QReg::q30, QReg::q29), "frintx v30.2d, v29.2d");
+  TEST_SINGLE(frintx(SubRegSize::i32Bit, DReg::d30, DReg::d29), "frintx v30.2s, v29.2s");
+  //TEST_SINGLE(frintx(SubRegSize::i64Bit, DReg::d30, DReg::d29), "frintx v30.1d, v29.1d");
+
+  TEST_SINGLE(fcvtnu(SubRegSize::i32Bit, QReg::q30, QReg::q29), "fcvtnu v30.4s, v29.4s");
+  TEST_SINGLE(fcvtnu(SubRegSize::i64Bit, QReg::q30, QReg::q29), "fcvtnu v30.2d, v29.2d");
+  TEST_SINGLE(fcvtnu(SubRegSize::i32Bit, DReg::d30, DReg::d29), "fcvtnu v30.2s, v29.2s");
+  //TEST_SINGLE(fcvtnu(SubRegSize::i64Bit, DReg::d30, DReg::d29), "fcvtnu v30.1d, v29.1d");
+
+  TEST_SINGLE(fcvtmu(SubRegSize::i32Bit, QReg::q30, QReg::q29), "fcvtmu v30.4s, v29.4s");
+  TEST_SINGLE(fcvtmu(SubRegSize::i64Bit, QReg::q30, QReg::q29), "fcvtmu v30.2d, v29.2d");
+  TEST_SINGLE(fcvtmu(SubRegSize::i32Bit, DReg::d30, DReg::d29), "fcvtmu v30.2s, v29.2s");
+  //TEST_SINGLE(fcvtmu(SubRegSize::i64Bit, DReg::d30, DReg::d29), "fcvtmu v30.1d, v29.1d");
+
+  TEST_SINGLE(fcvtau(SubRegSize::i32Bit, QReg::q30, QReg::q29), "fcvtau v30.4s, v29.4s");
+  TEST_SINGLE(fcvtau(SubRegSize::i64Bit, QReg::q30, QReg::q29), "fcvtau v30.2d, v29.2d");
+  TEST_SINGLE(fcvtau(SubRegSize::i32Bit, DReg::d30, DReg::d29), "fcvtau v30.2s, v29.2s");
+  //TEST_SINGLE(fcvtau(SubRegSize::i64Bit, DReg::d30, DReg::d29), "fcvtau v30.1d, v29.1d");
+
+  TEST_SINGLE(ucvtf(SubRegSize::i32Bit, QReg::q30, QReg::q29), "ucvtf v30.4s, v29.4s");
+  TEST_SINGLE(ucvtf(SubRegSize::i64Bit, QReg::q30, QReg::q29), "ucvtf v30.2d, v29.2d");
+  TEST_SINGLE(ucvtf(SubRegSize::i32Bit, DReg::d30, DReg::d29), "ucvtf v30.2s, v29.2s");
+  //TEST_SINGLE(ucvtf(SubRegSize::i64Bit, DReg::d30, DReg::d29), "ucvtf v30.1d, v29.1d");
+
+  TEST_SINGLE(frint32x(SubRegSize::i32Bit, QReg::q30, QReg::q29), "frint32x v30.4s, v29.4s");
+  TEST_SINGLE(frint32x(SubRegSize::i64Bit, QReg::q30, QReg::q29), "frint32x v30.2d, v29.2d");
+  TEST_SINGLE(frint32x(SubRegSize::i32Bit, DReg::d30, DReg::d29), "frint32x v30.2s, v29.2s");
+  //TEST_SINGLE(frint32x(SubRegSize::i64Bit, DReg::d30, DReg::d29), "frint32x v30.1d, v29.1d");
+
+  TEST_SINGLE(frint64x(SubRegSize::i32Bit, QReg::q30, QReg::q29), "frint64x v30.4s, v29.4s");
+  TEST_SINGLE(frint64x(SubRegSize::i64Bit, QReg::q30, QReg::q29), "frint64x v30.2d, v29.2d");
+  TEST_SINGLE(frint64x(SubRegSize::i32Bit, DReg::d30, DReg::d29), "frint64x v30.2s, v29.2s");
+  //TEST_SINGLE(frint64x(SubRegSize::i64Bit, DReg::d30, DReg::d29), "frint64x v30.1d, v29.1d");
+
+  TEST_SINGLE(not_(SubRegSize::i8Bit, QReg::q30, QReg::q29), "mvn v30.16b, v29.16b");
+  //TEST_SINGLE(not_(SubRegSize::i16Bit, QReg::q30, QReg::q29), "not v30.8h, v29.8h");
+  //TEST_SINGLE(not_(SubRegSize::i32Bit, QReg::q30, QReg::q29), "not v30.4s, v29.4s");
+  //TEST_SINGLE(not_(SubRegSize::i64Bit, QReg::q30, QReg::q29), "not v30.2d, v29.2d");
+
+  TEST_SINGLE(not_(SubRegSize::i8Bit, DReg::d30, DReg::d29), "mvn v30.8b, v29.8b");
+  //TEST_SINGLE(not_(SubRegSize::i16Bit, DReg::d30, DReg::d29), "not v30.4h, v29.4h");
+  //TEST_SINGLE(not_(SubRegSize::i32Bit, DReg::d30, DReg::d29), "not v30.2s, v29.2s");
+  //TEST_SINGLE(not_(SubRegSize::i64Bit, DReg::d30, DReg::d29), "not v30.1d, v29.1d");
+
+  TEST_SINGLE(mvn(SubRegSize::i8Bit, QReg::q30, QReg::q29), "mvn v30.16b, v29.16b");
+  //TEST_SINGLE(mvn(SubRegSize::i16Bit, QReg::q30, QReg::q29), "mvn v30.8h, v29.8h");
+  //TEST_SINGLE(mvn(SubRegSize::i32Bit, QReg::q30, QReg::q29), "mvn v30.4s, v29.4s");
+  //TEST_SINGLE(mvn(SubRegSize::i64Bit, QReg::q30, QReg::q29), "mvn v30.2d, v29.2d");
+
+  TEST_SINGLE(mvn(SubRegSize::i8Bit, DReg::d30, DReg::d29), "mvn v30.8b, v29.8b");
+  //TEST_SINGLE(mvn(SubRegSize::i16Bit, DReg::d30, DReg::d29), "mvn v30.4h, v29.4h");
+  //TEST_SINGLE(mvn(SubRegSize::i32Bit, DReg::d30, DReg::d29), "mvn v30.2s, v29.2s");
+  //TEST_SINGLE(mvn(SubRegSize::i64Bit, DReg::d30, DReg::d29), "mvn v30.1d, v29.1d");
+
+  TEST_SINGLE(rbit(SubRegSize::i8Bit, QReg::q30, QReg::q29), "rbit v30.16b, v29.16b");
+  //TEST_SINGLE(rbit(SubRegSize::i16Bit, QReg::q30, QReg::q29), "rbit v30.8h, v29.8h");
+  //TEST_SINGLE(rbit(SubRegSize::i32Bit, QReg::q30, QReg::q29), "rbit v30.4s, v29.4s");
+  //TEST_SINGLE(rbit(SubRegSize::i64Bit, QReg::q30, QReg::q29), "rbit v30.2d, v29.2d");
+
+  TEST_SINGLE(rbit(SubRegSize::i8Bit, DReg::d30, DReg::d29), "rbit v30.8b, v29.8b");
+  //TEST_SINGLE(rbit(SubRegSize::i16Bit, DReg::d30, DReg::d29), "rbit v30.4h, v29.4h");
+  //TEST_SINGLE(rbit(SubRegSize::i32Bit, DReg::d30, DReg::d29), "rbit v30.2s, v29.2s");
+  //TEST_SINGLE(rbit(SubRegSize::i64Bit, DReg::d30, DReg::d29), "rbit v30.1d, v29.1d");
+
+  TEST_SINGLE(fcmge(SubRegSize::i32Bit, QReg::q30, QReg::q29), "fcmge v30.4s, v29.4s, #0.0");
+  TEST_SINGLE(fcmge(SubRegSize::i64Bit, QReg::q30, QReg::q29), "fcmge v30.2d, v29.2d, #0.0");
+  TEST_SINGLE(fcmge(SubRegSize::i32Bit, DReg::d30, DReg::d29), "fcmge v30.2s, v29.2s, #0.0");
+  //TEST_SINGLE(fcmge(SubRegSize::i64Bit, DReg::d30, DReg::d29), "fcmge v30.1d, v29.1d, #0.0");
+
+  TEST_SINGLE(fcmle(SubRegSize::i32Bit, QReg::q30, QReg::q29), "fcmle v30.4s, v29.4s, #0.0");
+  TEST_SINGLE(fcmle(SubRegSize::i64Bit, QReg::q30, QReg::q29), "fcmle v30.2d, v29.2d, #0.0");
+  TEST_SINGLE(fcmle(SubRegSize::i32Bit, DReg::d30, DReg::d29), "fcmle v30.2s, v29.2s, #0.0");
+  //TEST_SINGLE(fcmle(SubRegSize::i64Bit, DReg::d30, DReg::d29), "fcmle v30.1d, v29.1d, #0.0");
+
+  TEST_SINGLE(fneg(SubRegSize::i32Bit, QReg::q30, QReg::q29), "fneg v30.4s, v29.4s");
+  TEST_SINGLE(fneg(SubRegSize::i64Bit, QReg::q30, QReg::q29), "fneg v30.2d, v29.2d");
+  TEST_SINGLE(fneg(SubRegSize::i32Bit, DReg::d30, DReg::d29), "fneg v30.2s, v29.2s");
+  //TEST_SINGLE(fneg(SubRegSize::i64Bit, DReg::d30, DReg::d29), "fneg v30.1d, v29.1d");
+
+  TEST_SINGLE(frinti(SubRegSize::i32Bit, QReg::q30, QReg::q29), "frinti v30.4s, v29.4s");
+  TEST_SINGLE(frinti(SubRegSize::i64Bit, QReg::q30, QReg::q29), "frinti v30.2d, v29.2d");
+  TEST_SINGLE(frinti(SubRegSize::i32Bit, DReg::d30, DReg::d29), "frinti v30.2s, v29.2s");
+  //TEST_SINGLE(frinti(SubRegSize::i64Bit, DReg::d30, DReg::d29), "frinti v30.1d, v29.1d");
+
+  TEST_SINGLE(fcvtpu(SubRegSize::i32Bit, QReg::q30, QReg::q29), "fcvtpu v30.4s, v29.4s");
+  TEST_SINGLE(fcvtpu(SubRegSize::i64Bit, QReg::q30, QReg::q29), "fcvtpu v30.2d, v29.2d");
+  TEST_SINGLE(fcvtpu(SubRegSize::i32Bit, DReg::d30, DReg::d29), "fcvtpu v30.2s, v29.2s");
+  //TEST_SINGLE(fcvtpu(SubRegSize::i64Bit, DReg::d30, DReg::d29), "fcvtpu v30.1d, v29.1d");
+
+  TEST_SINGLE(fcvtzu(SubRegSize::i32Bit, QReg::q30, QReg::q29), "fcvtzu v30.4s, v29.4s");
+  TEST_SINGLE(fcvtzu(SubRegSize::i64Bit, QReg::q30, QReg::q29), "fcvtzu v30.2d, v29.2d");
+  TEST_SINGLE(fcvtzu(SubRegSize::i32Bit, DReg::d30, DReg::d29), "fcvtzu v30.2s, v29.2s");
+  //TEST_SINGLE(fcvtzu(SubRegSize::i64Bit, DReg::d30, DReg::d29), "fcvtzu v30.1d, v29.1d");
+
+  TEST_SINGLE(ursqrte(SubRegSize::i32Bit, QReg::q30, QReg::q29), "ursqrte v30.4s, v29.4s");
+  //TEST_SINGLE(ursqrte(SubRegSize::i64Bit, QReg::q30, QReg::q29), "ursqrte v30.2d, v29.2d");
+  TEST_SINGLE(ursqrte(SubRegSize::i32Bit, DReg::d30, DReg::d29), "ursqrte v30.2s, v29.2s");
+  //TEST_SINGLE(ursqrte(SubRegSize::i64Bit, DReg::d30, DReg::d29), "ursqrte v30.1d, v29.1d");
+
+  TEST_SINGLE(frsqrte(SubRegSize::i32Bit, QReg::q30, QReg::q29), "frsqrte v30.4s, v29.4s");
+  TEST_SINGLE(frsqrte(SubRegSize::i64Bit, QReg::q30, QReg::q29), "frsqrte v30.2d, v29.2d");
+  TEST_SINGLE(frsqrte(SubRegSize::i32Bit, DReg::d30, DReg::d29), "frsqrte v30.2s, v29.2s");
+  //TEST_SINGLE(frsqrte(SubRegSize::i64Bit, DReg::d30, DReg::d29), "frsqrte v30.1d, v29.1d");
+
+  TEST_SINGLE(fsqrt(SubRegSize::i32Bit, QReg::q30, QReg::q29), "fsqrt v30.4s, v29.4s");
+  TEST_SINGLE(fsqrt(SubRegSize::i64Bit, QReg::q30, QReg::q29), "fsqrt v30.2d, v29.2d");
+  TEST_SINGLE(fsqrt(SubRegSize::i32Bit, DReg::d30, DReg::d29), "fsqrt v30.2s, v29.2s");
+  //TEST_SINGLE(fsqrt(SubRegSize::i64Bit, DReg::d30, DReg::d29), "fsqrt v30.1d, v29.1d");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD across lanes") {
+  //TEST_SINGLE(saddlv(SubRegSize::i8Bit, QReg::q30, QReg::q29), "saddlv v30.16b, v29.16b");
+  TEST_SINGLE(saddlv(SubRegSize::i16Bit, QReg::q30, QReg::q29), "saddlv h30, v29.16b");
+  TEST_SINGLE(saddlv(SubRegSize::i32Bit, QReg::q30, QReg::q29), "saddlv s30, v29.8h");
+  TEST_SINGLE(saddlv(SubRegSize::i64Bit, QReg::q30, QReg::q29), "saddlv d30, v29.4s");
+
+  //TEST_SINGLE(saddlv(SubRegSize::i8Bit, DReg::d30, DReg::d29), "saddlv v30.8b, v29.8b");
+  TEST_SINGLE(saddlv(SubRegSize::i16Bit, DReg::d30, DReg::d29), "saddlv h30, v29.8b");
+  TEST_SINGLE(saddlv(SubRegSize::i32Bit, DReg::d30, DReg::d29), "saddlv s30, v29.4h");
+  //TEST_SINGLE(saddlv(SubRegSize::i64Bit, DReg::d30, DReg::d29), "saddlv d30, v29.1d");
+
+  TEST_SINGLE(smaxv(SubRegSize::i8Bit, QReg::q30, QReg::q29), "smaxv b30, v29.16b");
+  TEST_SINGLE(smaxv(SubRegSize::i16Bit, QReg::q30, QReg::q29), "smaxv h30, v29.8h");
+  TEST_SINGLE(smaxv(SubRegSize::i32Bit, QReg::q30, QReg::q29), "smaxv s30, v29.4s");
+  //TEST_SINGLE(smaxv(SubRegSize::i64Bit, QReg::q30, QReg::q29), "smaxv d30, v29.4s");
+
+  TEST_SINGLE(smaxv(SubRegSize::i8Bit, DReg::d30, DReg::d29), "smaxv b30, v29.8b");
+  TEST_SINGLE(smaxv(SubRegSize::i16Bit, DReg::d30, DReg::d29), "smaxv h30, v29.4h");
+  //TEST_SINGLE(smaxv(SubRegSize::i32Bit, DReg::d30, DReg::d29), "smaxv s30, v29.2s");
+  //TEST_SINGLE(smaxv(SubRegSize::i64Bit, DReg::d30, DReg::d29), "smaxv d30, v29.1d");
+
+  TEST_SINGLE(sminv(SubRegSize::i8Bit, QReg::q30, QReg::q29), "sminv b30, v29.16b");
+  TEST_SINGLE(sminv(SubRegSize::i16Bit, QReg::q30, QReg::q29), "sminv h30, v29.8h");
+  TEST_SINGLE(sminv(SubRegSize::i32Bit, QReg::q30, QReg::q29), "sminv s30, v29.4s");
+  //TEST_SINGLE(sminv(SubRegSize::i64Bit, QReg::q30, QReg::q29), "sminv d30, v29.4s");
+
+  TEST_SINGLE(sminv(SubRegSize::i8Bit, DReg::d30, DReg::d29), "sminv b30, v29.8b");
+  TEST_SINGLE(sminv(SubRegSize::i16Bit, DReg::d30, DReg::d29), "sminv h30, v29.4h");
+  //TEST_SINGLE(sminv(SubRegSize::i32Bit, DReg::d30, DReg::d29), "sminv s30, v29.2s");
+  //TEST_SINGLE(sminv(SubRegSize::i64Bit, DReg::d30, DReg::d29), "sminv d30, v29.1d");
+
+  TEST_SINGLE(addv(SubRegSize::i8Bit, QReg::q30, QReg::q29), "addv b30, v29.16b");
+  TEST_SINGLE(addv(SubRegSize::i16Bit, QReg::q30, QReg::q29), "addv h30, v29.8h");
+  TEST_SINGLE(addv(SubRegSize::i32Bit, QReg::q30, QReg::q29), "addv s30, v29.4s");
+  //TEST_SINGLE(addv(SubRegSize::i64Bit, QReg::q30, QReg::q29), "addv d30, v29.4s");
+
+  TEST_SINGLE(addv(SubRegSize::i8Bit, DReg::d30, DReg::d29), "addv b30, v29.8b");
+  TEST_SINGLE(addv(SubRegSize::i16Bit, DReg::d30, DReg::d29), "addv h30, v29.4h");
+  //TEST_SINGLE(addv(SubRegSize::i32Bit, DReg::d30, DReg::d29), "addv s30, v29.2s");
+  //TEST_SINGLE(addv(SubRegSize::i64Bit, DReg::d30, DReg::d29), "addv d30, v29.1d");
+
+  //TEST_SINGLE(uaddlv(SubRegSize::i8Bit, QReg::q30, QReg::q29), "uaddlv v30.16b, v29.16b");
+  TEST_SINGLE(uaddlv(SubRegSize::i16Bit, QReg::q30, QReg::q29), "uaddlv h30, v29.16b");
+  TEST_SINGLE(uaddlv(SubRegSize::i32Bit, QReg::q30, QReg::q29), "uaddlv s30, v29.8h");
+  TEST_SINGLE(uaddlv(SubRegSize::i64Bit, QReg::q30, QReg::q29), "uaddlv d30, v29.4s");
+
+  //TEST_SINGLE(uaddlv(SubRegSize::i8Bit, DReg::d30, DReg::d29), "uaddlv v30.8b, v29.8b");
+  TEST_SINGLE(uaddlv(SubRegSize::i16Bit, DReg::d30, DReg::d29), "uaddlv h30, v29.8b");
+  TEST_SINGLE(uaddlv(SubRegSize::i32Bit, DReg::d30, DReg::d29), "uaddlv s30, v29.4h");
+  //TEST_SINGLE(uaddlv(SubRegSize::i64Bit, DReg::d30, DReg::d29), "uaddlv d30, v29.1d");
+
+  TEST_SINGLE(umaxv(SubRegSize::i8Bit, QReg::q30, QReg::q29), "umaxv b30, v29.16b");
+  TEST_SINGLE(umaxv(SubRegSize::i16Bit, QReg::q30, QReg::q29), "umaxv h30, v29.8h");
+  TEST_SINGLE(umaxv(SubRegSize::i32Bit, QReg::q30, QReg::q29), "umaxv s30, v29.4s");
+  //TEST_SINGLE(umaxv(SubRegSize::i64Bit, QReg::q30, QReg::q29), "umaxv d30, v29.4s");
+
+  TEST_SINGLE(umaxv(SubRegSize::i8Bit, DReg::d30, DReg::d29), "umaxv b30, v29.8b");
+  TEST_SINGLE(umaxv(SubRegSize::i16Bit, DReg::d30, DReg::d29), "umaxv h30, v29.4h");
+  //TEST_SINGLE(umaxv(SubRegSize::i32Bit, DReg::d30, DReg::d29), "umaxv s30, v29.2s");
+  //TEST_SINGLE(umaxv(SubRegSize::i64Bit, DReg::d30, DReg::d29), "umaxv d30, v29.1d");
+
+  TEST_SINGLE(uminv(SubRegSize::i8Bit, QReg::q30, QReg::q29), "uminv b30, v29.16b");
+  TEST_SINGLE(uminv(SubRegSize::i16Bit, QReg::q30, QReg::q29), "uminv h30, v29.8h");
+  TEST_SINGLE(uminv(SubRegSize::i32Bit, QReg::q30, QReg::q29), "uminv s30, v29.4s");
+  //TEST_SINGLE(uminv(SubRegSize::i64Bit, QReg::q30, QReg::q29), "uminv d30, v29.4s");
+
+  TEST_SINGLE(uminv(SubRegSize::i8Bit, DReg::d30, DReg::d29), "uminv b30, v29.8b");
+  TEST_SINGLE(uminv(SubRegSize::i16Bit, DReg::d30, DReg::d29), "uminv h30, v29.4h");
+  //TEST_SINGLE(uminv(SubRegSize::i32Bit, DReg::d30, DReg::d29), "uminv s30, v29.2s");
+  //TEST_SINGLE(uminv(SubRegSize::i64Bit, DReg::d30, DReg::d29), "uminv d30, v29.1d");
+
+  //TEST_SINGLE(fmaxnmv(SubRegSize::i8Bit, QReg::q30, QReg::q29), "fmaxnmv b30, v29.16b");
+  TEST_SINGLE(fmaxnmv(SubRegSize::i16Bit, QReg::q30, QReg::q29), "fmaxnmv h30, v29.8h");
+  TEST_SINGLE(fmaxnmv(SubRegSize::i32Bit, QReg::q30, QReg::q29), "fmaxnmv s30, v29.4s");
+  //TEST_SINGLE(fmaxnmv(SubRegSize::i64Bit, QReg::q30, QReg::q29), "fmaxnmv d30, v29.4s");
+
+  //TEST_SINGLE(fmaxnmv(SubRegSize::i8Bit, DReg::d30, DReg::d29), "fmaxnmv b30, v29.8b");
+  TEST_SINGLE(fmaxnmv(SubRegSize::i16Bit, DReg::d30, DReg::d29), "fmaxnmv h30, v29.4h");
+  //TEST_SINGLE(fmaxnmv(SubRegSize::i32Bit, DReg::d30, DReg::d29), "fmaxnmv s30, v29.2s");
+  //TEST_SINGLE(fmaxnmv(SubRegSize::i64Bit, DReg::d30, DReg::d29), "fmaxnmv d30, v29.1d");
+
+  //TEST_SINGLE(fmaxv(SubRegSize::i8Bit, QReg::q30, QReg::q29), "fmaxv b30, v29.16b");
+  TEST_SINGLE(fmaxv(SubRegSize::i16Bit, QReg::q30, QReg::q29), "fmaxv h30, v29.8h");
+  TEST_SINGLE(fmaxv(SubRegSize::i32Bit, QReg::q30, QReg::q29), "fmaxv s30, v29.4s");
+  //TEST_SINGLE(fmaxv(SubRegSize::i64Bit, QReg::q30, QReg::q29), "fmaxv d30, v29.4s");
+
+  //TEST_SINGLE(fmaxv(SubRegSize::i8Bit, DReg::d30, DReg::d29), "fmaxv b30, v29.8b");
+  TEST_SINGLE(fmaxv(SubRegSize::i16Bit, DReg::d30, DReg::d29), "fmaxv h30, v29.4h");
+  //TEST_SINGLE(fmaxv(SubRegSize::i32Bit, DReg::d30, DReg::d29), "fmaxv s30, v29.2s");
+  //TEST_SINGLE(fmaxv(SubRegSize::i64Bit, DReg::d30, DReg::d29), "fmaxv d30, v29.1d");
+
+  //TEST_SINGLE(fminnmv(SubRegSize::i8Bit, QReg::q30, QReg::q29), "fminnmv b30, v29.16b");
+  TEST_SINGLE(fminnmv(SubRegSize::i16Bit, QReg::q30, QReg::q29), "fminnmv h30, v29.8h");
+  TEST_SINGLE(fminnmv(SubRegSize::i32Bit, QReg::q30, QReg::q29), "fminnmv s30, v29.4s");
+  //TEST_SINGLE(fminnmv(SubRegSize::i64Bit, QReg::q30, QReg::q29), "fminnmv d30, v29.4s");
+
+  //TEST_SINGLE(fminnmv(SubRegSize::i8Bit, DReg::d30, DReg::d29), "fminnmv b30, v29.8b");
+  TEST_SINGLE(fminnmv(SubRegSize::i16Bit, DReg::d30, DReg::d29), "fminnmv h30, v29.4h");
+  //TEST_SINGLE(fminnmv(SubRegSize::i32Bit, DReg::d30, DReg::d29), "fminnmv s30, v29.2s");
+  //TEST_SINGLE(fminnmv(SubRegSize::i64Bit, DReg::d30, DReg::d29), "fminnmv d30, v29.1d");
+
+  //TEST_SINGLE(fminv(SubRegSize::i8Bit, QReg::q30, QReg::q29), "fminv b30, v29.16b");
+  TEST_SINGLE(fminv(SubRegSize::i16Bit, QReg::q30, QReg::q29), "fminv h30, v29.8h");
+  TEST_SINGLE(fminv(SubRegSize::i32Bit, QReg::q30, QReg::q29), "fminv s30, v29.4s");
+  //TEST_SINGLE(fminv(SubRegSize::i64Bit, QReg::q30, QReg::q29), "fminv d30, v29.4s");
+
+  //TEST_SINGLE(fminv(SubRegSize::i8Bit, DReg::d30, DReg::d29), "fminv b30, v29.8b");
+  TEST_SINGLE(fminv(SubRegSize::i16Bit, DReg::d30, DReg::d29), "fminv h30, v29.4h");
+  //TEST_SINGLE(fminv(SubRegSize::i32Bit, DReg::d30, DReg::d29), "fminv s30, v29.2s");
+  //TEST_SINGLE(fminv(SubRegSize::i64Bit, DReg::d30, DReg::d29), "fminv d30, v29.1d");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD three different") {
+  //TEST_SINGLE(saddl(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "saddl v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(saddl(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "saddl v30.8h, v29.8b, v28.8b");
+  TEST_SINGLE(saddl(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "saddl v30.4s, v29.4h, v28.4h");
+  TEST_SINGLE(saddl(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "saddl v30.2d, v29.2s, v28.2s");
+
+  //TEST_SINGLE(saddl2(SubRegSize::i8Bit, QReg::q30, QReg::q29, QReg::q28), "saddl2 v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(saddl2(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "saddl2 v30.8h, v29.16b, v28.16b");
+  TEST_SINGLE(saddl2(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "saddl2 v30.4s, v29.8h, v28.8h");
+  TEST_SINGLE(saddl2(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "saddl2 v30.2d, v29.4s, v28.4s");
+
+  //TEST_SINGLE(saddw(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "saddw v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(saddw(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "saddw v30.8h, v29.8h, v28.8b");
+  TEST_SINGLE(saddw(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "saddw v30.4s, v29.4s, v28.4h");
+  TEST_SINGLE(saddw(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "saddw v30.2d, v29.2d, v28.2s");
+
+  //TEST_SINGLE(saddw2(SubRegSize::i8Bit, QReg::q30, QReg::q29, QReg::q28), "saddw2 v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(saddw2(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "saddw2 v30.8h, v29.8h, v28.16b");
+  TEST_SINGLE(saddw2(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "saddw2 v30.4s, v29.4s, v28.8h");
+  TEST_SINGLE(saddw2(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "saddw2 v30.2d, v29.2d, v28.4s");
+
+  //TEST_SINGLE(ssubl(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "ssubl v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(ssubl(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "ssubl v30.8h, v29.8b, v28.8b");
+  TEST_SINGLE(ssubl(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "ssubl v30.4s, v29.4h, v28.4h");
+  TEST_SINGLE(ssubl(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "ssubl v30.2d, v29.2s, v28.2s");
+
+  //TEST_SINGLE(ssubl2(SubRegSize::i8Bit, QReg::q30, QReg::q29, QReg::q28), "ssubl2 v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(ssubl2(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "ssubl2 v30.8h, v29.16b, v28.16b");
+  TEST_SINGLE(ssubl2(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "ssubl2 v30.4s, v29.8h, v28.8h");
+  TEST_SINGLE(ssubl2(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "ssubl2 v30.2d, v29.4s, v28.4s");
+
+  //TEST_SINGLE(ssubw(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "ssubw v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(ssubw(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "ssubw v30.8h, v29.8h, v28.8b");
+  TEST_SINGLE(ssubw(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "ssubw v30.4s, v29.4s, v28.4h");
+  TEST_SINGLE(ssubw(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "ssubw v30.2d, v29.2d, v28.2s");
+
+  //TEST_SINGLE(ssubw2(SubRegSize::i8Bit, QReg::q30, QReg::q29, QReg::q28), "ssubw2 v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(ssubw2(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "ssubw2 v30.8h, v29.8h, v28.16b");
+  TEST_SINGLE(ssubw2(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "ssubw2 v30.4s, v29.4s, v28.8h");
+  TEST_SINGLE(ssubw2(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "ssubw2 v30.2d, v29.2d, v28.4s");
+
+  TEST_SINGLE(addhn(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "addhn v30.8b, v29.8h, v28.8h");
+  TEST_SINGLE(addhn(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "addhn v30.4h, v29.4s, v28.4s");
+  TEST_SINGLE(addhn(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "addhn v30.2s, v29.2d, v28.2d");
+  //TEST_SINGLE(addhn(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "addhn v30.2d, v29.2d, v28.2s");
+
+  TEST_SINGLE(addhn2(SubRegSize::i8Bit, QReg::q30, QReg::q29, QReg::q28), "addhn2 v30.16b, v29.8h, v28.8h");
+  TEST_SINGLE(addhn2(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "addhn2 v30.8h, v29.4s, v28.4s");
+  TEST_SINGLE(addhn2(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "addhn2 v30.4s, v29.2d, v28.2d");
+  //TEST_SINGLE(addhn2(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "addhn2 v30.2d, v29.2d, v28.4s");
+
+  //TEST_SINGLE(sabal(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "sabal v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(sabal(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "sabal v30.8h, v29.8b, v28.8b");
+  TEST_SINGLE(sabal(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "sabal v30.4s, v29.4h, v28.4h");
+  TEST_SINGLE(sabal(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "sabal v30.2d, v29.2s, v28.2s");
+
+  //TEST_SINGLE(sabal2(SubRegSize::i8Bit, QReg::q30, QReg::q29, QReg::q28), "sabal2 v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(sabal2(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "sabal2 v30.8h, v29.16b, v28.16b");
+  TEST_SINGLE(sabal2(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "sabal2 v30.4s, v29.8h, v28.8h");
+  TEST_SINGLE(sabal2(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "sabal2 v30.2d, v29.4s, v28.4s");
+
+  TEST_SINGLE(subhn(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "subhn v30.8b, v29.8h, v28.8h");
+  TEST_SINGLE(subhn(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "subhn v30.4h, v29.4s, v28.4s");
+  TEST_SINGLE(subhn(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "subhn v30.2s, v29.2d, v28.2d");
+  //TEST_SINGLE(subhn(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "subhn v30.2d, v29.2d, v28.2s");
+
+  TEST_SINGLE(subhn2(SubRegSize::i8Bit, QReg::q30, QReg::q29, QReg::q28), "subhn2 v30.16b, v29.8h, v28.8h");
+  TEST_SINGLE(subhn2(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "subhn2 v30.8h, v29.4s, v28.4s");
+  TEST_SINGLE(subhn2(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "subhn2 v30.4s, v29.2d, v28.2d");
+  //TEST_SINGLE(subhn2(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "subhn2 v30.2d, v29.2d, v28.4s");
+
+  //TEST_SINGLE(sabdl(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "sabdl v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(sabdl(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "sabdl v30.8h, v29.8b, v28.8b");
+  TEST_SINGLE(sabdl(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "sabdl v30.4s, v29.4h, v28.4h");
+  TEST_SINGLE(sabdl(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "sabdl v30.2d, v29.2s, v28.2s");
+
+  //TEST_SINGLE(sabdl2(SubRegSize::i8Bit, QReg::q30, QReg::q29, QReg::q28), "sabdl2 v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(sabdl2(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "sabdl2 v30.8h, v29.16b, v28.16b");
+  TEST_SINGLE(sabdl2(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "sabdl2 v30.4s, v29.8h, v28.8h");
+  TEST_SINGLE(sabdl2(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "sabdl2 v30.2d, v29.4s, v28.4s");
+
+  //TEST_SINGLE(smlal(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "smlal v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(smlal(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "smlal v30.8h, v29.8b, v28.8b");
+  TEST_SINGLE(smlal(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "smlal v30.4s, v29.4h, v28.4h");
+  TEST_SINGLE(smlal(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "smlal v30.2d, v29.2s, v28.2s");
+
+  //TEST_SINGLE(smlal2(SubRegSize::i8Bit, QReg::q30, QReg::q29, QReg::q28), "smlal2 v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(smlal2(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "smlal2 v30.8h, v29.16b, v28.16b");
+  TEST_SINGLE(smlal2(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "smlal2 v30.4s, v29.8h, v28.8h");
+  TEST_SINGLE(smlal2(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "smlal2 v30.2d, v29.4s, v28.4s");
+
+  //TEST_SINGLE(sqdmlal(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "sqdmlal v30.8b, v29.8b, v28.8b");
+  //TEST_SINGLE(sqdmlal(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "sqdmlal v30.8h, v29.8b, v28.8b");
+  TEST_SINGLE(sqdmlal(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "sqdmlal v30.4s, v29.4h, v28.4h");
+  TEST_SINGLE(sqdmlal(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "sqdmlal v30.2d, v29.2s, v28.2s");
+
+  //TEST_SINGLE(sqdmlal2(SubRegSize::i8Bit, QReg::q30, QReg::q29, QReg::q28), "sqdmlal2 v30.8b, v29.8b, v28.8b");
+  //TEST_SINGLE(sqdmlal2(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "sqdmlal2 v30.8h, v29.16b, v28.16b");
+  TEST_SINGLE(sqdmlal2(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "sqdmlal2 v30.4s, v29.8h, v28.8h");
+  TEST_SINGLE(sqdmlal2(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "sqdmlal2 v30.2d, v29.4s, v28.4s");
+
+  //TEST_SINGLE(smlsl(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "smlsl v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(smlsl(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "smlsl v30.8h, v29.8b, v28.8b");
+  TEST_SINGLE(smlsl(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "smlsl v30.4s, v29.4h, v28.4h");
+  TEST_SINGLE(smlsl(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "smlsl v30.2d, v29.2s, v28.2s");
+
+  //TEST_SINGLE(smlsl2(SubRegSize::i8Bit, QReg::q30, QReg::q29, QReg::q28), "smlsl2 v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(smlsl2(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "smlsl2 v30.8h, v29.16b, v28.16b");
+  TEST_SINGLE(smlsl2(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "smlsl2 v30.4s, v29.8h, v28.8h");
+  TEST_SINGLE(smlsl2(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "smlsl2 v30.2d, v29.4s, v28.4s");
+
+  //TEST_SINGLE(sqdmlsl(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "sqdmlsl v30.8b, v29.8b, v28.8b");
+  //TEST_SINGLE(sqdmlsl(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "sqdmlsl v30.8h, v29.8b, v28.8b");
+  TEST_SINGLE(sqdmlsl(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "sqdmlsl v30.4s, v29.4h, v28.4h");
+  TEST_SINGLE(sqdmlsl(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "sqdmlsl v30.2d, v29.2s, v28.2s");
+
+  //TEST_SINGLE(sqdmlsl2(SubRegSize::i8Bit, QReg::q30, QReg::q29, QReg::q28), "sqdmlsl2 v30.8b, v29.8b, v28.8b");
+  //TEST_SINGLE(sqdmlsl2(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "sqdmlsl2 v30.8h, v29.16b, v28.16b");
+  TEST_SINGLE(sqdmlsl2(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "sqdmlsl2 v30.4s, v29.8h, v28.8h");
+  TEST_SINGLE(sqdmlsl2(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "sqdmlsl2 v30.2d, v29.4s, v28.4s");
+
+  //TEST_SINGLE(smull(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "smull v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(smull(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "smull v30.8h, v29.8b, v28.8b");
+  TEST_SINGLE(smull(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "smull v30.4s, v29.4h, v28.4h");
+  TEST_SINGLE(smull(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "smull v30.2d, v29.2s, v28.2s");
+
+  //TEST_SINGLE(smull2(SubRegSize::i8Bit, QReg::q30, QReg::q29, QReg::q28), "smull2 v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(smull2(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "smull2 v30.8h, v29.16b, v28.16b");
+  TEST_SINGLE(smull2(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "smull2 v30.4s, v29.8h, v28.8h");
+  TEST_SINGLE(smull2(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "smull2 v30.2d, v29.4s, v28.4s");
+
+  //TEST_SINGLE(sqdmull(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "sqdmull v30.8b, v29.8b, v28.8b");
+  //TEST_SINGLE(sqdmull(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "sqdmull v30.8h, v29.8b, v28.8b");
+  TEST_SINGLE(sqdmull(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "sqdmull v30.4s, v29.4h, v28.4h");
+  TEST_SINGLE(sqdmull(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "sqdmull v30.2d, v29.2s, v28.2s");
+
+  //TEST_SINGLE(sqdmull2(SubRegSize::i8Bit, QReg::q30, QReg::q29, QReg::q28), "sqdmull2 v30.8b, v29.8b, v28.8b");
+  //TEST_SINGLE(sqdmull2(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "sqdmull2 v30.8h, v29.16b, v28.16b");
+  TEST_SINGLE(sqdmull2(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "sqdmull2 v30.4s, v29.8h, v28.8h");
+  TEST_SINGLE(sqdmull2(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "sqdmull2 v30.2d, v29.4s, v28.4s");
+
+  //TEST_SINGLE(pmull(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "pmull v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(pmull(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "pmull v30.8h, v29.8b, v28.8b");
+  //TEST_SINGLE(pmull(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "pmull v30.4s, v29.4h, v28.4h");
+  //TEST_SINGLE(pmull(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "pmull v30.2d, v29.2s, v28.2s");
+  if (false) {
+    // Vixl doesn't support this
+    TEST_SINGLE(pmull(SubRegSize::i128Bit, DReg::d30, DReg::d29, DReg::d28), "pmull v30.1q, v29.1d, v28.1d");
+  }
+
+  //TEST_SINGLE(pmull2(SubRegSize::i8Bit, QReg::q30, QReg::q29, QReg::q28), "pmull2 v30.8b, v29.8b, v28.8b");
+  //TEST_SINGLE(pmull2(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "pmull2 v30.8h, v29.16b, v28.16b");
+  //TEST_SINGLE(pmull2(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "pmull2 v30.4s, v29.8h, v28.8h");
+  //TEST_SINGLE(pmull2(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "pmull2 v30.2d, v29.4s, v28.4s");
+  if (false) {
+    // Vixl doesn't support this
+    TEST_SINGLE(pmull2(SubRegSize::i128Bit, QReg::q30, QReg::q29, QReg::q28), "pmull2 v30.1q, v29.2d, v28.2d");
+  }
+
+  //TEST_SINGLE(uaddl(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "uaddl v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(uaddl(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "uaddl v30.8h, v29.8b, v28.8b");
+  TEST_SINGLE(uaddl(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "uaddl v30.4s, v29.4h, v28.4h");
+  TEST_SINGLE(uaddl(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "uaddl v30.2d, v29.2s, v28.2s");
+
+  //TEST_SINGLE(uaddl2(SubRegSize::i8Bit, QReg::q30, QReg::q29, QReg::q28), "uaddl2 v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(uaddl2(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "uaddl2 v30.8h, v29.16b, v28.16b");
+  TEST_SINGLE(uaddl2(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "uaddl2 v30.4s, v29.8h, v28.8h");
+  TEST_SINGLE(uaddl2(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "uaddl2 v30.2d, v29.4s, v28.4s");
+
+  //TEST_SINGLE(uaddw(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "uaddw v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(uaddw(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "uaddw v30.8h, v29.8h, v28.8b");
+  TEST_SINGLE(uaddw(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "uaddw v30.4s, v29.4s, v28.4h");
+  TEST_SINGLE(uaddw(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "uaddw v30.2d, v29.2d, v28.2s");
+
+  //TEST_SINGLE(uaddw2(SubRegSize::i8Bit, QReg::q30, QReg::q29, QReg::q28), "uaddw2 v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(uaddw2(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "uaddw2 v30.8h, v29.8h, v28.16b");
+  TEST_SINGLE(uaddw2(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "uaddw2 v30.4s, v29.4s, v28.8h");
+  TEST_SINGLE(uaddw2(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "uaddw2 v30.2d, v29.2d, v28.4s");
+
+  //TEST_SINGLE(usubl(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "usubl v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(usubl(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "usubl v30.8h, v29.8b, v28.8b");
+  TEST_SINGLE(usubl(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "usubl v30.4s, v29.4h, v28.4h");
+  TEST_SINGLE(usubl(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "usubl v30.2d, v29.2s, v28.2s");
+
+  //TEST_SINGLE(usubl2(SubRegSize::i8Bit, QReg::q30, QReg::q29, QReg::q28), "usubl2 v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(usubl2(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "usubl2 v30.8h, v29.16b, v28.16b");
+  TEST_SINGLE(usubl2(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "usubl2 v30.4s, v29.8h, v28.8h");
+  TEST_SINGLE(usubl2(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "usubl2 v30.2d, v29.4s, v28.4s");
+
+  //TEST_SINGLE(usubw(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "usubw v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(usubw(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "usubw v30.8h, v29.8h, v28.8b");
+  TEST_SINGLE(usubw(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "usubw v30.4s, v29.4s, v28.4h");
+  TEST_SINGLE(usubw(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "usubw v30.2d, v29.2d, v28.2s");
+
+  //TEST_SINGLE(usubw2(SubRegSize::i8Bit, QReg::q30, QReg::q29, QReg::q28), "usubw2 v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(usubw2(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "usubw2 v30.8h, v29.8h, v28.16b");
+  TEST_SINGLE(usubw2(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "usubw2 v30.4s, v29.4s, v28.8h");
+  TEST_SINGLE(usubw2(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "usubw2 v30.2d, v29.2d, v28.4s");
+
+  //// XXX: RADDHN/2
+  //TEST_SINGLE(uabal(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "uabal v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(uabal(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "uabal v30.8h, v29.8b, v28.8b");
+  TEST_SINGLE(uabal(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "uabal v30.4s, v29.4h, v28.4h");
+  TEST_SINGLE(uabal(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "uabal v30.2d, v29.2s, v28.2s");
+
+  //TEST_SINGLE(uabal2(SubRegSize::i8Bit, QReg::q30, QReg::q29, QReg::q28), "uabal2 v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(uabal2(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "uabal2 v30.8h, v29.16b, v28.16b");
+  TEST_SINGLE(uabal2(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "uabal2 v30.4s, v29.8h, v28.8h");
+  TEST_SINGLE(uabal2(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "uabal2 v30.2d, v29.4s, v28.4s");
+
+  //// XXX: RSUBHN/2
+  //TEST_SINGLE(uabdl(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "uabdl v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(uabdl(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "uabdl v30.8h, v29.8b, v28.8b");
+  TEST_SINGLE(uabdl(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "uabdl v30.4s, v29.4h, v28.4h");
+  TEST_SINGLE(uabdl(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "uabdl v30.2d, v29.2s, v28.2s");
+
+  //TEST_SINGLE(uabdl2(SubRegSize::i8Bit, QReg::q30, QReg::q29, QReg::q28), "uabdl2 v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(uabdl2(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "uabdl2 v30.8h, v29.16b, v28.16b");
+  TEST_SINGLE(uabdl2(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "uabdl2 v30.4s, v29.8h, v28.8h");
+  TEST_SINGLE(uabdl2(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "uabdl2 v30.2d, v29.4s, v28.4s");
+
+
+  //TEST_SINGLE(umlal(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "umlal v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(umlal(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "umlal v30.8h, v29.8b, v28.8b");
+  TEST_SINGLE(umlal(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "umlal v30.4s, v29.4h, v28.4h");
+  TEST_SINGLE(umlal(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "umlal v30.2d, v29.2s, v28.2s");
+
+  //TEST_SINGLE(umlal2(SubRegSize::i8Bit, QReg::q30, QReg::q29, QReg::q28), "umlal2 v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(umlal2(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "umlal2 v30.8h, v29.16b, v28.16b");
+  TEST_SINGLE(umlal2(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "umlal2 v30.4s, v29.8h, v28.8h");
+  TEST_SINGLE(umlal2(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "umlal2 v30.2d, v29.4s, v28.4s");
+
+  //TEST_SINGLE(umlsl(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "umlsl v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(umlsl(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "umlsl v30.8h, v29.8b, v28.8b");
+  TEST_SINGLE(umlsl(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "umlsl v30.4s, v29.4h, v28.4h");
+  TEST_SINGLE(umlsl(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "umlsl v30.2d, v29.2s, v28.2s");
+
+  //TEST_SINGLE(umlsl2(SubRegSize::i8Bit, QReg::q30, QReg::q29, QReg::q28), "umlsl2 v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(umlsl2(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "umlsl2 v30.8h, v29.16b, v28.16b");
+  TEST_SINGLE(umlsl2(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "umlsl2 v30.4s, v29.8h, v28.8h");
+  TEST_SINGLE(umlsl2(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "umlsl2 v30.2d, v29.4s, v28.4s");
+
+
+  //TEST_SINGLE(umull(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "umull v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(umull(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "umull v30.8h, v29.8b, v28.8b");
+  TEST_SINGLE(umull(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "umull v30.4s, v29.4h, v28.4h");
+  TEST_SINGLE(umull(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "umull v30.2d, v29.2s, v28.2s");
+
+  //TEST_SINGLE(umull2(SubRegSize::i8Bit, QReg::q30, QReg::q29, QReg::q28), "umull2 v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(umull2(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "umull2 v30.8h, v29.16b, v28.16b");
+  TEST_SINGLE(umull2(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "umull2 v30.4s, v29.8h, v28.8h");
+  TEST_SINGLE(umull2(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "umull2 v30.2d, v29.4s, v28.4s");
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD three same") {
+  TEST_SINGLE(shadd(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "shadd v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(shadd(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "shadd v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(shadd(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "shadd v30.4s, v29.4s, v28.4s");
+  //TEST_SINGLE(shadd(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "shadd v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(shadd(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "shadd v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(shadd(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "shadd v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(shadd(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "shadd v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(shadd(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "shadd v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(sqadd(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "sqadd v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(sqadd(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "sqadd v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(sqadd(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "sqadd v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(sqadd(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "sqadd v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(sqadd(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "sqadd v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(sqadd(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "sqadd v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(sqadd(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "sqadd v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(sqadd(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "sqadd v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(srhadd(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "srhadd v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(srhadd(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "srhadd v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(srhadd(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "srhadd v30.4s, v29.4s, v28.4s");
+  //TEST_SINGLE(srhadd(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "srhadd v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(srhadd(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "srhadd v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(srhadd(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "srhadd v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(srhadd(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "srhadd v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(srhadd(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "srhadd v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(shsub(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "shsub v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(shsub(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "shsub v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(shsub(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "shsub v30.4s, v29.4s, v28.4s");
+  //TEST_SINGLE(shsub(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "shsub v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(shsub(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "shsub v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(shsub(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "shsub v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(shsub(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "shsub v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(shsub(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "shsub v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(sqsub(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "sqsub v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(sqsub(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "sqsub v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(sqsub(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "sqsub v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(sqsub(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "sqsub v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(sqsub(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "sqsub v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(sqsub(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "sqsub v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(sqsub(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "sqsub v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(sqsub(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "sqsub v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(cmgt(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "cmgt v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(cmgt(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "cmgt v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(cmgt(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "cmgt v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(cmgt(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "cmgt v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(cmgt(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "cmgt v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(cmgt(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "cmgt v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(cmgt(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "cmgt v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(cmgt(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "cmgt v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(cmge(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "cmge v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(cmge(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "cmge v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(cmge(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "cmge v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(cmge(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "cmge v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(cmge(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "cmge v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(cmge(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "cmge v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(cmge(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "cmge v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(cmge(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "cmge v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(sshl(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "sshl v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(sshl(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "sshl v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(sshl(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "sshl v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(sshl(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "sshl v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(sshl(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "sshl v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(sshl(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "sshl v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(sshl(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "sshl v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(sshl(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "sshl v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(sqshl(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "sqshl v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(sqshl(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "sqshl v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(sqshl(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "sqshl v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(sqshl(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "sqshl v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(sqshl(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "sqshl v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(sqshl(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "sqshl v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(sqshl(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "sqshl v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(sqshl(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "sqshl v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(srshl(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "srshl v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(srshl(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "srshl v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(srshl(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "srshl v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(srshl(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "srshl v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(srshl(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "srshl v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(srshl(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "srshl v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(srshl(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "srshl v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(srshl(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "srshl v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(sqrshl(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "sqrshl v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(sqrshl(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "sqrshl v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(sqrshl(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "sqrshl v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(sqrshl(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "sqrshl v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(sqrshl(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "sqrshl v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(sqrshl(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "sqrshl v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(sqrshl(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "sqrshl v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(sqrshl(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "sqrshl v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(smax(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "smax v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(smax(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "smax v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(smax(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "smax v30.4s, v29.4s, v28.4s");
+  //TEST_SINGLE(smax(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "smax v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(smax(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "smax v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(smax(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "smax v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(smax(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "smax v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(smax(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "smax v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(smin(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "smin v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(smin(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "smin v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(smin(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "smin v30.4s, v29.4s, v28.4s");
+  //TEST_SINGLE(smin(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "smin v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(smin(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "smin v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(smin(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "smin v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(smin(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "smin v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(smin(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "smin v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(sabd(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "sabd v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(sabd(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "sabd v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(sabd(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "sabd v30.4s, v29.4s, v28.4s");
+  //TEST_SINGLE(sabd(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "sabd v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(sabd(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "sabd v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(sabd(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "sabd v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(sabd(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "sabd v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(sabd(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "sabd v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(saba(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "saba v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(saba(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "saba v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(saba(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "saba v30.4s, v29.4s, v28.4s");
+  //TEST_SINGLE(saba(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "saba v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(saba(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "saba v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(saba(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "saba v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(saba(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "saba v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(saba(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "saba v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(add(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "add v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(add(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "add v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(add(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "add v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(add(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "add v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(add(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "add v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(add(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "add v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(add(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "add v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(add(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "add v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(cmtst(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "cmtst v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(cmtst(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "cmtst v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(cmtst(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "cmtst v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(cmtst(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "cmtst v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(cmtst(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "cmtst v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(cmtst(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "cmtst v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(cmtst(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "cmtst v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(cmtst(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "cmtst v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(mla(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "mla v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(mla(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "mla v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(mla(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "mla v30.4s, v29.4s, v28.4s");
+  //TEST_SINGLE(mla(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "mla v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(mla(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "mla v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(mla(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "mla v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(mla(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "mla v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(mla(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "mla v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(mul(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "mul v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(mul(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "mul v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(mul(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "mul v30.4s, v29.4s, v28.4s");
+  //TEST_SINGLE(mul(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "mul v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(mul(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "mul v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(mul(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "mul v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(mul(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "mul v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(mul(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "mul v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(smaxp(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "smaxp v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(smaxp(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "smaxp v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(smaxp(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "smaxp v30.4s, v29.4s, v28.4s");
+  //TEST_SINGLE(smaxp(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "smaxp v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(smaxp(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "smaxp v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(smaxp(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "smaxp v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(smaxp(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "smaxp v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(smaxp(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "smaxp v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(sminp(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "sminp v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(sminp(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "sminp v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(sminp(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "sminp v30.4s, v29.4s, v28.4s");
+  //TEST_SINGLE(sminp(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "sminp v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(sminp(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "sminp v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(sminp(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "sminp v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(sminp(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "sminp v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(sminp(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "sminp v30.1d, v29.1d, v28.1d");
+
+  //TEST_SINGLE(sqdmulh(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "sqdmulh v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(sqdmulh(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "sqdmulh v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(sqdmulh(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "sqdmulh v30.4s, v29.4s, v28.4s");
+  //TEST_SINGLE(sqdmulh(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "sqdmulh v30.2d, v29.2d, v28.2d");
+
+  //TEST_SINGLE(sqdmulh(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "sqdmulh v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(sqdmulh(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "sqdmulh v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(sqdmulh(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "sqdmulh v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(sqdmulh(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "sqdmulh v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(addp(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "addp v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(addp(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "addp v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(addp(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "addp v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(addp(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "addp v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(addp(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "addp v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(addp(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "addp v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(addp(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "addp v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(addp(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "addp v30.1d, v29.1d, v28.1d");
+
+  //TEST_SINGLE(fmaxnm(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "fmaxnm v30.16b, v29.16b, v28.16b");
+  //TEST_SINGLE(fmaxnm(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "fmaxnm v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(fmaxnm(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "fmaxnm v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(fmaxnm(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "fmaxnm v30.2d, v29.2d, v28.2d");
+
+  //TEST_SINGLE(fmaxnm(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "fmaxnm v30.8b, v29.8b, v28.8b");
+  //TEST_SINGLE(fmaxnm(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "fmaxnm v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(fmaxnm(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "fmaxnm v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(fmaxnm(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "fmaxnm v30.1d, v29.1d, v28.1d");
+
+  //TEST_SINGLE(fmla(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "fmla v30.16b, v29.16b, v28.16b");
+  //TEST_SINGLE(fmla(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "fmla v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(fmla(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "fmla v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(fmla(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "fmla v30.2d, v29.2d, v28.2d");
+
+  //TEST_SINGLE(fmla(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "fmla v30.8b, v29.8b, v28.8b");
+  //TEST_SINGLE(fmla(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "fmla v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(fmla(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "fmla v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(fmla(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "fmla v30.1d, v29.1d, v28.1d");
+
+  //TEST_SINGLE(fadd(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "fadd v30.16b, v29.16b, v28.16b");
+  //TEST_SINGLE(fadd(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "fadd v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(fadd(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "fadd v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(fadd(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "fadd v30.2d, v29.2d, v28.2d");
+
+  //TEST_SINGLE(fadd(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "fadd v30.8b, v29.8b, v28.8b");
+  //TEST_SINGLE(fadd(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "fadd v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(fadd(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "fadd v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(fadd(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "fadd v30.1d, v29.1d, v28.1d");
+
+  //TEST_SINGLE(fmulx(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "fmulx v30.16b, v29.16b, v28.16b");
+  //TEST_SINGLE(fmulx(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "fmulx v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(fmulx(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "fmulx v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(fmulx(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "fmulx v30.2d, v29.2d, v28.2d");
+
+  //TEST_SINGLE(fmulx(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "fmulx v30.8b, v29.8b, v28.8b");
+  //TEST_SINGLE(fmulx(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "fmulx v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(fmulx(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "fmulx v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(fmulx(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "fmulx v30.1d, v29.1d, v28.1d");
+
+  //TEST_SINGLE(fcmeq(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "fcmeq v30.16b, v29.16b, v28.16b");
+  //TEST_SINGLE(fcmeq(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "fcmeq v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(fcmeq(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "fcmeq v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(fcmeq(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "fcmeq v30.2d, v29.2d, v28.2d");
+
+  //TEST_SINGLE(fcmeq(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "fcmeq v30.8b, v29.8b, v28.8b");
+  //TEST_SINGLE(fcmeq(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "fcmeq v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(fcmeq(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "fcmeq v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(fcmeq(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "fcmeq v30.1d, v29.1d, v28.1d");
+
+  //TEST_SINGLE(fmax(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "fmax v30.16b, v29.16b, v28.16b");
+  //TEST_SINGLE(fmax(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "fmax v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(fmax(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "fmax v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(fmax(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "fmax v30.2d, v29.2d, v28.2d");
+
+  //TEST_SINGLE(fmax(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "fmax v30.8b, v29.8b, v28.8b");
+  //TEST_SINGLE(fmax(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "fmax v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(fmax(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "fmax v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(fmax(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "fmax v30.1d, v29.1d, v28.1d");
+
+  //TEST_SINGLE(frecps(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "frecps v30.16b, v29.16b, v28.16b");
+  //TEST_SINGLE(frecps(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "frecps v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(frecps(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "frecps v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(frecps(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "frecps v30.2d, v29.2d, v28.2d");
+
+  //TEST_SINGLE(frecps(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "frecps v30.8b, v29.8b, v28.8b");
+  //TEST_SINGLE(frecps(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "frecps v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(frecps(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "frecps v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(frecps(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "frecps v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(and_(QReg::q30, QReg::q29, QReg::q28), "and v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(and_(DReg::d30, DReg::d29, DReg::d28), "and v30.8b, v29.8b, v28.8b");
+
+  TEST_SINGLE(fmlal(QReg::q30, QReg::q29, QReg::q28), "fmlal v30.4s, v29.4h, v28.4h");
+  TEST_SINGLE(fmlal(DReg::d30, DReg::d29, DReg::d28), "fmlal v30.2s, v29.2h, v28.2h");
+
+  TEST_SINGLE(fmlal2(QReg::q30, QReg::q29, QReg::q28), "fmlal2 v30.4s, v29.4h, v28.4h");
+  TEST_SINGLE(fmlal2(DReg::d30, DReg::d29, DReg::d28), "fmlal2 v30.2s, v29.2h, v28.2h");
+
+  TEST_SINGLE(bic(QReg::q30, QReg::q29, QReg::q28), "bic v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(bic(DReg::d30, DReg::d29, DReg::d28), "bic v30.8b, v29.8b, v28.8b");
+
+  //TEST_SINGLE(fminnm(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "fminnm v30.16b, v29.16b, v28.16b");
+  //TEST_SINGLE(fminnm(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "fminnm v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(fminnm(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "fminnm v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(fminnm(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "fminnm v30.2d, v29.2d, v28.2d");
+
+  //TEST_SINGLE(fminnm(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "fminnm v30.8b, v29.8b, v28.8b");
+  //TEST_SINGLE(fminnm(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "fminnm v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(fminnm(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "fminnm v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(fminnm(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "fminnm v30.1d, v29.1d, v28.1d");
+
+  //TEST_SINGLE(fmls(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "fmls v30.16b, v29.16b, v28.16b");
+  //TEST_SINGLE(fmls(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "fmls v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(fmls(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "fmls v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(fmls(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "fmls v30.2d, v29.2d, v28.2d");
+
+  //TEST_SINGLE(fmls(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "fmls v30.8b, v29.8b, v28.8b");
+  //TEST_SINGLE(fmls(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "fmls v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(fmls(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "fmls v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(fmls(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "fmls v30.1d, v29.1d, v28.1d");
+
+  //TEST_SINGLE(fsub(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "fsub v30.16b, v29.16b, v28.16b");
+  //TEST_SINGLE(fsub(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "fsub v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(fsub(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "fsub v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(fsub(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "fsub v30.2d, v29.2d, v28.2d");
+
+  //TEST_SINGLE(fsub(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "fsub v30.8b, v29.8b, v28.8b");
+  //TEST_SINGLE(fsub(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "fsub v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(fsub(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "fsub v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(fsub(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "fsub v30.1d, v29.1d, v28.1d");
+
+  //TEST_SINGLE(fmin(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "fmin v30.16b, v29.16b, v28.16b");
+  //TEST_SINGLE(fmin(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "fmin v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(fmin(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "fmin v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(fmin(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "fmin v30.2d, v29.2d, v28.2d");
+
+  //TEST_SINGLE(fmin(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "fmin v30.8b, v29.8b, v28.8b");
+  //TEST_SINGLE(fmin(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "fmin v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(fmin(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "fmin v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(fmin(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "fmin v30.1d, v29.1d, v28.1d");
+
+  //TEST_SINGLE(frsqrts(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "frsqrts v30.16b, v29.16b, v28.16b");
+  //TEST_SINGLE(frsqrts(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "frsqrts v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(frsqrts(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "frsqrts v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(frsqrts(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "frsqrts v30.2d, v29.2d, v28.2d");
+
+  //TEST_SINGLE(frsqrts(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "frsqrts v30.8b, v29.8b, v28.8b");
+  //TEST_SINGLE(frsqrts(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "frsqrts v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(frsqrts(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "frsqrts v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(frsqrts(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "frsqrts v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(orr(QReg::q30, QReg::q29, QReg::q28), "orr v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(orr(DReg::d30, DReg::d29, DReg::d28), "orr v30.8b, v29.8b, v28.8b");
+
+  TEST_SINGLE(mov(QReg::q30, QReg::q29), "mov v30.16b, v29.16b");
+  TEST_SINGLE(mov(DReg::d30, DReg::d29), "mov v30.8b, v29.8b");
+
+  TEST_SINGLE(fmlsl(QReg::q30, QReg::q29, QReg::q28), "fmlsl v30.4s, v29.4h, v28.4h");
+  TEST_SINGLE(fmlsl(DReg::d30, DReg::d29, DReg::d28), "fmlsl v30.2s, v29.2h, v28.2h");
+
+  TEST_SINGLE(fmlsl2(QReg::q30, QReg::q29, QReg::q28), "fmlsl2 v30.4s, v29.4h, v28.4h");
+  TEST_SINGLE(fmlsl2(DReg::d30, DReg::d29, DReg::d28), "fmlsl2 v30.2s, v29.2h, v28.2h");
+
+  TEST_SINGLE(orn(QReg::q30, QReg::q29, QReg::q28), "orn v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(orn(DReg::d30, DReg::d29, DReg::d28), "orn v30.8b, v29.8b, v28.8b");
+
+  TEST_SINGLE(uhadd(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "uhadd v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(uhadd(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "uhadd v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(uhadd(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "uhadd v30.4s, v29.4s, v28.4s");
+  //TEST_SINGLE(uhadd(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "uhadd v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(uhadd(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "uhadd v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(uhadd(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "uhadd v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(uhadd(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "uhadd v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(uhadd(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "uhadd v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(uqadd(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "uqadd v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(uqadd(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "uqadd v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(uqadd(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "uqadd v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(uqadd(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "uqadd v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(uqadd(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "uqadd v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(uqadd(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "uqadd v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(uqadd(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "uqadd v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(uqadd(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "uqadd v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(urhadd(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "urhadd v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(urhadd(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "urhadd v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(urhadd(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "urhadd v30.4s, v29.4s, v28.4s");
+  //TEST_SINGLE(urhadd(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "urhadd v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(urhadd(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "urhadd v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(urhadd(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "urhadd v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(urhadd(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "urhadd v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(urhadd(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "urhadd v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(uhsub(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "uhsub v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(uhsub(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "uhsub v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(uhsub(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "uhsub v30.4s, v29.4s, v28.4s");
+  //TEST_SINGLE(uhsub(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "uhsub v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(uhsub(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "uhsub v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(uhsub(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "uhsub v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(uhsub(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "uhsub v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(uhsub(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "uhsub v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(uqsub(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "uqsub v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(uqsub(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "uqsub v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(uqsub(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "uqsub v30.4s, v29.4s, v28.4s");
+  //TEST_SINGLE(uqsub(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "uqsub v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(uqsub(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "uqsub v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(uqsub(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "uqsub v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(uqsub(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "uqsub v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(uqsub(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "uqsub v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(cmhi(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "cmhi v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(cmhi(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "cmhi v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(cmhi(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "cmhi v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(cmhi(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "cmhi v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(cmhi(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "cmhi v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(cmhi(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "cmhi v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(cmhi(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "cmhi v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(cmhi(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "cmhi v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(cmhs(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "cmhs v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(cmhs(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "cmhs v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(cmhs(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "cmhs v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(cmhs(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "cmhs v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(cmhs(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "cmhs v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(cmhs(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "cmhs v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(cmhs(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "cmhs v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(cmhs(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "cmhs v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(ushl(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "ushl v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(ushl(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "ushl v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(ushl(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "ushl v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(ushl(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "ushl v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(ushl(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "ushl v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(ushl(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "ushl v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(ushl(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "ushl v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(ushl(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "ushl v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(uqshl(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "uqshl v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(uqshl(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "uqshl v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(uqshl(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "uqshl v30.4s, v29.4s, v28.4s");
+  //TEST_SINGLE(uqshl(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "uqshl v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(uqshl(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "uqshl v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(uqshl(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "uqshl v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(uqshl(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "uqshl v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(uqshl(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "uqshl v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(urshl(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "urshl v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(urshl(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "urshl v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(urshl(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "urshl v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(urshl(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "urshl v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(urshl(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "urshl v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(urshl(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "urshl v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(urshl(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "urshl v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(urshl(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "urshl v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(uqrshl(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "uqrshl v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(uqrshl(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "uqrshl v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(uqrshl(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "uqrshl v30.4s, v29.4s, v28.4s");
+  //TEST_SINGLE(uqrshl(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "uqrshl v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(uqrshl(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "uqrshl v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(uqrshl(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "uqrshl v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(uqrshl(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "uqrshl v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(uqrshl(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "uqrshl v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(umax(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "umax v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(umax(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "umax v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(umax(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "umax v30.4s, v29.4s, v28.4s");
+  //TEST_SINGLE(umax(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "umax v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(umax(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "umax v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(umax(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "umax v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(umax(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "umax v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(umax(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "umax v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(umin(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "umin v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(umin(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "umin v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(umin(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "umin v30.4s, v29.4s, v28.4s");
+  //TEST_SINGLE(umin(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "umin v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(umin(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "umin v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(umin(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "umin v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(umin(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "umin v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(umin(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "umin v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(uabd(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "uabd v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(uabd(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "uabd v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(uabd(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "uabd v30.4s, v29.4s, v28.4s");
+  //TEST_SINGLE(uabd(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "uabd v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(uabd(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "uabd v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(uabd(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "uabd v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(uabd(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "uabd v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(uabd(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "uabd v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(uaba(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "uaba v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(uaba(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "uaba v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(uaba(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "uaba v30.4s, v29.4s, v28.4s");
+  //TEST_SINGLE(uaba(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "uaba v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(uaba(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "uaba v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(uaba(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "uaba v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(uaba(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "uaba v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(uaba(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "uaba v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(sub(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "sub v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(sub(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "sub v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(sub(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "sub v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(sub(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "sub v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(sub(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "sub v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(sub(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "sub v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(sub(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "sub v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(sub(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "sub v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(cmeq(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "cmeq v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(cmeq(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "cmeq v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(cmeq(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "cmeq v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(cmeq(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "cmeq v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(cmeq(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "cmeq v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(cmeq(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "cmeq v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(cmeq(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "cmeq v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(cmeq(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "cmeq v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(mls(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "mls v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(mls(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "mls v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(mls(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "mls v30.4s, v29.4s, v28.4s");
+  //TEST_SINGLE(mls(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "mls v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(mls(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "mls v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(mls(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "mls v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(mls(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "mls v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(mls(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "mls v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(pmul(QReg::q30, QReg::q29, QReg::q28), "pmul v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(pmul(DReg::d30, DReg::d29, DReg::d28), "pmul v30.8b, v29.8b, v28.8b");
+
+  TEST_SINGLE(umaxp(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "umaxp v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(umaxp(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "umaxp v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(umaxp(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "umaxp v30.4s, v29.4s, v28.4s");
+  //TEST_SINGLE(umaxp(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "umaxp v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(umaxp(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "umaxp v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(umaxp(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "umaxp v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(umaxp(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "umaxp v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(umaxp(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "umaxp v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(uminp(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "uminp v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(uminp(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "uminp v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(uminp(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "uminp v30.4s, v29.4s, v28.4s");
+  //TEST_SINGLE(uminp(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "uminp v30.2d, v29.2d, v28.2d");
+
+  TEST_SINGLE(uminp(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "uminp v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(uminp(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "uminp v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(uminp(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "uminp v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(uminp(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "uminp v30.1d, v29.1d, v28.1d");
+
+  //TEST_SINGLE(sqrdmulh(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "sqrdmulh v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(sqrdmulh(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "sqrdmulh v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(sqrdmulh(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "sqrdmulh v30.4s, v29.4s, v28.4s");
+  //TEST_SINGLE(sqrdmulh(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "sqrdmulh v30.2d, v29.2d, v28.2d");
+
+  //TEST_SINGLE(sqrdmulh(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "sqrdmulh v30.8b, v29.8b, v28.8b");
+  TEST_SINGLE(sqrdmulh(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "sqrdmulh v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(sqrdmulh(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "sqrdmulh v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(sqrdmulh(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "sqrdmulh v30.1d, v29.1d, v28.1d");
+
+  //TEST_SINGLE(fmaxnmp(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "fmaxnmp v30.16b, v29.16b, v28.16b");
+  //TEST_SINGLE(fmaxnmp(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "fmaxnmp v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(fmaxnmp(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "fmaxnmp v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(fmaxnmp(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "fmaxnmp v30.2d, v29.2d, v28.2d");
+
+  //TEST_SINGLE(fmaxnmp(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "fmaxnmp v30.8b, v29.8b, v28.8b");
+  //TEST_SINGLE(fmaxnmp(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "fmaxnmp v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(fmaxnmp(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "fmaxnmp v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(fmaxnmp(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "fmaxnmp v30.1d, v29.1d, v28.1d");
+
+  //TEST_SINGLE(faddp(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "faddp v30.16b, v29.16b, v28.16b");
+  //TEST_SINGLE(faddp(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "faddp v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(faddp(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "faddp v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(faddp(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "faddp v30.2d, v29.2d, v28.2d");
+
+  //TEST_SINGLE(faddp(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "faddp v30.8b, v29.8b, v28.8b");
+  //TEST_SINGLE(faddp(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "faddp v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(faddp(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "faddp v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(faddp(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "faddp v30.1d, v29.1d, v28.1d");
+
+  //TEST_SINGLE(fmul(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "fmul v30.16b, v29.16b, v28.16b");
+  //TEST_SINGLE(fmul(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "fmul v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(fmul(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "fmul v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(fmul(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "fmul v30.2d, v29.2d, v28.2d");
+
+  //TEST_SINGLE(fmul(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "fmul v30.8b, v29.8b, v28.8b");
+  //TEST_SINGLE(fmul(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "fmul v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(fmul(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "fmul v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(fmul(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "fmul v30.1d, v29.1d, v28.1d");
+
+  //TEST_SINGLE(fcmge(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "fcmge v30.16b, v29.16b, v28.16b");
+  //TEST_SINGLE(fcmge(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "fcmge v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(fcmge(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "fcmge v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(fcmge(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "fcmge v30.2d, v29.2d, v28.2d");
+
+  //TEST_SINGLE(fcmge(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "fcmge v30.8b, v29.8b, v28.8b");
+  //TEST_SINGLE(fcmge(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "fcmge v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(fcmge(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "fcmge v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(fcmge(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "fcmge v30.1d, v29.1d, v28.1d");
+
+  //TEST_SINGLE(facge(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "facge v30.16b, v29.16b, v28.16b");
+  //TEST_SINGLE(facge(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "facge v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(facge(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "facge v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(facge(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "facge v30.2d, v29.2d, v28.2d");
+
+  //TEST_SINGLE(facge(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "facge v30.8b, v29.8b, v28.8b");
+  //TEST_SINGLE(facge(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "facge v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(facge(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "facge v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(facge(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "facge v30.1d, v29.1d, v28.1d");
+
+  //TEST_SINGLE(fmaxp(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "fmaxp v30.16b, v29.16b, v28.16b");
+  //TEST_SINGLE(fmaxp(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "fmaxp v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(fmaxp(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "fmaxp v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(fmaxp(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "fmaxp v30.2d, v29.2d, v28.2d");
+
+  //TEST_SINGLE(fmaxp(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "fmaxp v30.8b, v29.8b, v28.8b");
+  //TEST_SINGLE(fmaxp(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "fmaxp v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(fmaxp(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "fmaxp v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(fmaxp(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "fmaxp v30.1d, v29.1d, v28.1d");
+
+  //TEST_SINGLE(fdiv(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "fdiv v30.16b, v29.16b, v28.16b");
+  //TEST_SINGLE(fdiv(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "fdiv v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(fdiv(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "fdiv v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(fdiv(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "fdiv v30.2d, v29.2d, v28.2d");
+
+  //TEST_SINGLE(fdiv(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "fdiv v30.8b, v29.8b, v28.8b");
+  //TEST_SINGLE(fdiv(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "fdiv v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(fdiv(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "fdiv v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(fdiv(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "fdiv v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(eor(QReg::q30, QReg::q29, QReg::q28), "eor v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(eor(DReg::d30, DReg::d29, DReg::d28), "eor v30.8b, v29.8b, v28.8b");
+
+  TEST_SINGLE(bsl(QReg::q30, QReg::q29, QReg::q28), "bsl v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(bsl(DReg::d30, DReg::d29, DReg::d28), "bsl v30.8b, v29.8b, v28.8b");
+
+  //TEST_SINGLE(fminnmp(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "fminnmp v30.16b, v29.16b, v28.16b");
+  //TEST_SINGLE(fminnmp(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "fminnmp v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(fminnmp(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "fminnmp v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(fminnmp(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "fminnmp v30.2d, v29.2d, v28.2d");
+
+  //TEST_SINGLE(fminnmp(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "fminnmp v30.8b, v29.8b, v28.8b");
+  //TEST_SINGLE(fminnmp(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "fminnmp v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(fminnmp(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "fminnmp v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(fminnmp(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "fminnmp v30.1d, v29.1d, v28.1d");
+
+  //TEST_SINGLE(fabd(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "fabd v30.16b, v29.16b, v28.16b");
+  //TEST_SINGLE(fabd(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "fabd v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(fabd(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "fabd v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(fabd(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "fabd v30.2d, v29.2d, v28.2d");
+
+  //TEST_SINGLE(fabd(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "fabd v30.8b, v29.8b, v28.8b");
+  //TEST_SINGLE(fabd(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "fabd v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(fabd(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "fabd v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(fabd(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "fabd v30.1d, v29.1d, v28.1d");
+
+  //TEST_SINGLE(fcmgt(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "fcmgt v30.16b, v29.16b, v28.16b");
+  //TEST_SINGLE(fcmgt(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "fcmgt v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(fcmgt(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "fcmgt v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(fcmgt(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "fcmgt v30.2d, v29.2d, v28.2d");
+
+  //TEST_SINGLE(fcmgt(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "fcmgt v30.8b, v29.8b, v28.8b");
+  //TEST_SINGLE(fcmgt(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "fcmgt v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(fcmgt(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "fcmgt v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(fcmgt(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "fcmgt v30.1d, v29.1d, v28.1d");
+
+  //TEST_SINGLE(facgt(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "facgt v30.16b, v29.16b, v28.16b");
+  //TEST_SINGLE(facgt(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "facgt v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(facgt(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "facgt v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(facgt(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "facgt v30.2d, v29.2d, v28.2d");
+
+  //TEST_SINGLE(facgt(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "facgt v30.8b, v29.8b, v28.8b");
+  //TEST_SINGLE(facgt(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "facgt v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(facgt(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "facgt v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(facgt(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "facgt v30.1d, v29.1d, v28.1d");
+
+  //TEST_SINGLE(fminp(SubRegSize::i8Bit,  QReg::q30, QReg::q29, QReg::q28), "fminp v30.16b, v29.16b, v28.16b");
+  //TEST_SINGLE(fminp(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "fminp v30.8h, v29.8h, v28.8h");
+  TEST_SINGLE(fminp(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "fminp v30.4s, v29.4s, v28.4s");
+  TEST_SINGLE(fminp(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "fminp v30.2d, v29.2d, v28.2d");
+
+  //TEST_SINGLE(fminp(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "fminp v30.8b, v29.8b, v28.8b");
+  //TEST_SINGLE(fminp(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "fminp v30.4h, v29.4h, v28.4h");
+  TEST_SINGLE(fminp(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "fminp v30.2s, v29.2s, v28.2s");
+  //TEST_SINGLE(fminp(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "fminp v30.1d, v29.1d, v28.1d");
+
+  TEST_SINGLE(bit(QReg::q30, QReg::q29, QReg::q28), "bit v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(bit(DReg::d30, DReg::d29, DReg::d28), "bit v30.8b, v29.8b, v28.8b");
+
+  TEST_SINGLE(bif(QReg::q30, QReg::q29, QReg::q28), "bif v30.16b, v29.16b, v28.16b");
+  TEST_SINGLE(bif(DReg::d30, DReg::d29, DReg::d28), "bif v30.8b, v29.8b, v28.8b");
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD modified immediate") {
+  // XXX: ORR - 32-bit/16-bit
+  // XXX: MOVI - Shifting ones
+  TEST_SINGLE(fmov(SubRegSize::i16Bit, QReg::q30, 1.0), "fmov v30.8h, #0x70 (1.0000)");
+  TEST_SINGLE(fmov(SubRegSize::i32Bit, QReg::q30, 1.0), "fmov v30.4s, #0x70 (1.0000)");
+  TEST_SINGLE(fmov(SubRegSize::i64Bit, QReg::q30, 1.0), "fmov v30.2d, #0x70 (1.0000)");
+
+  TEST_SINGLE(fmov(SubRegSize::i16Bit, DReg::d30, 1.0), "fmov v30.4h, #0x70 (1.0000)");
+  TEST_SINGLE(fmov(SubRegSize::i32Bit, DReg::d30, 1.0), "fmov v30.2s, #0x70 (1.0000)");
+  //TEST_SINGLE(fmov(SubRegSize::i64Bit, DReg::d30, 1.0), "fmov v30.1d, #0x70 (1.0000)");
+
+  // XXX: MVNI - Shifted immediate
+  // XXX: BIC
+  TEST_SINGLE(movi(SubRegSize::i8Bit, QReg::q30, 0xFE), "movi v30.16b, #0xfe");
+  TEST_SINGLE(movi(SubRegSize::i16Bit, QReg::q30, 0xFE, 0), "movi v30.8h, #0xfe, lsl #0");
+  TEST_SINGLE(movi(SubRegSize::i16Bit, QReg::q30, 0xFE, 8), "movi v30.8h, #0xfe, lsl #8");
+  TEST_SINGLE(movi(SubRegSize::i32Bit, QReg::q30, 0xFE, 0), "movi v30.4s, #0xfe, lsl #0");
+  TEST_SINGLE(movi(SubRegSize::i32Bit, QReg::q30, 0xFE, 8), "movi v30.4s, #0xfe, lsl #8");
+  TEST_SINGLE(movi(SubRegSize::i32Bit, QReg::q30, 0xFE, 16), "movi v30.4s, #0xfe, lsl #16");
+  TEST_SINGLE(movi(SubRegSize::i32Bit, QReg::q30, 0xFE, 24), "movi v30.4s, #0xfe, lsl #24");
+  TEST_SINGLE(movi(SubRegSize::i64Bit, QReg::q30, 0xFF00FF), "movi v30.2d, #0xff00ff");
+
+  TEST_SINGLE(movi(SubRegSize::i8Bit, DReg::d30, 0xFE), "movi v30.8b, #0xfe");
+  TEST_SINGLE(movi(SubRegSize::i16Bit, DReg::d30, 0xFE, 0), "movi v30.4h, #0xfe, lsl #0");
+  TEST_SINGLE(movi(SubRegSize::i16Bit, DReg::d30, 0xFE, 8), "movi v30.4h, #0xfe, lsl #8");
+  TEST_SINGLE(movi(SubRegSize::i32Bit, DReg::d30, 0xFE, 0), "movi v30.2s, #0xfe, lsl #0");
+  TEST_SINGLE(movi(SubRegSize::i32Bit, DReg::d30, 0xFE, 8), "movi v30.2s, #0xfe, lsl #8");
+  TEST_SINGLE(movi(SubRegSize::i32Bit, DReg::d30, 0xFE, 16), "movi v30.2s, #0xfe, lsl #16");
+  TEST_SINGLE(movi(SubRegSize::i32Bit, DReg::d30, 0xFE, 24), "movi v30.2s, #0xfe, lsl #24");
+  TEST_SINGLE(movi(SubRegSize::i64Bit, DReg::d30, 0xFF00000000000000ULL), "movi d30, #0xff00000000000000");
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD shift by immediate") {
+  TEST_SINGLE(sshr(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "sshr v30.16b, v29.16b, #1");
+  TEST_SINGLE(sshr(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "sshr v30.16b, v29.16b, #7");
+  TEST_SINGLE(sshr(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "sshr v30.8h, v29.8h, #1");
+  TEST_SINGLE(sshr(SubRegSize::i16Bit, QReg::q30, QReg::q29, 15), "sshr v30.8h, v29.8h, #15");
+  TEST_SINGLE(sshr(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "sshr v30.4s, v29.4s, #1");
+  TEST_SINGLE(sshr(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "sshr v30.4s, v29.4s, #31");
+  TEST_SINGLE(sshr(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "sshr v30.2d, v29.2d, #1");
+  TEST_SINGLE(sshr(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "sshr v30.2d, v29.2d, #63");
+
+  TEST_SINGLE(sshr(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "sshr v30.8b, v29.8b, #1");
+  TEST_SINGLE(sshr(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "sshr v30.8b, v29.8b, #7");
+  TEST_SINGLE(sshr(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "sshr v30.4h, v29.4h, #1");
+  TEST_SINGLE(sshr(SubRegSize::i16Bit, DReg::d30, DReg::d29, 15), "sshr v30.4h, v29.4h, #15");
+  TEST_SINGLE(sshr(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "sshr v30.2s, v29.2s, #1");
+  TEST_SINGLE(sshr(SubRegSize::i32Bit, DReg::d30, DReg::d29, 31), "sshr v30.2s, v29.2s, #31");
+  //TEST_SINGLE(sshr(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "sshr v30.1d, v29.1d, #1");
+  //TEST_SINGLE(sshr(SubRegSize::i64Bit, DReg::d30, DReg::d29, 63), "sshr v30.1d, v29.1d, #63");
+
+  TEST_SINGLE(ssra(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "ssra v30.16b, v29.16b, #1");
+  TEST_SINGLE(ssra(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "ssra v30.16b, v29.16b, #7");
+  TEST_SINGLE(ssra(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "ssra v30.8h, v29.8h, #1");
+  TEST_SINGLE(ssra(SubRegSize::i16Bit, QReg::q30, QReg::q29, 15), "ssra v30.8h, v29.8h, #15");
+  TEST_SINGLE(ssra(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "ssra v30.4s, v29.4s, #1");
+  TEST_SINGLE(ssra(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "ssra v30.4s, v29.4s, #31");
+  TEST_SINGLE(ssra(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "ssra v30.2d, v29.2d, #1");
+  TEST_SINGLE(ssra(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "ssra v30.2d, v29.2d, #63");
+
+  TEST_SINGLE(ssra(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "ssra v30.8b, v29.8b, #1");
+  TEST_SINGLE(ssra(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "ssra v30.8b, v29.8b, #7");
+  TEST_SINGLE(ssra(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "ssra v30.4h, v29.4h, #1");
+  TEST_SINGLE(ssra(SubRegSize::i16Bit, DReg::d30, DReg::d29, 15), "ssra v30.4h, v29.4h, #15");
+  TEST_SINGLE(ssra(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "ssra v30.2s, v29.2s, #1");
+  TEST_SINGLE(ssra(SubRegSize::i32Bit, DReg::d30, DReg::d29, 31), "ssra v30.2s, v29.2s, #31");
+  //TEST_SINGLE(ssra(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "ssra v30.1d, v29.1d, #1");
+  //TEST_SINGLE(ssra(SubRegSize::i64Bit, DReg::d30, DReg::d29, 63), "ssra v30.1d, v29.1d, #63");
+
+  TEST_SINGLE(srshr(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "srshr v30.16b, v29.16b, #1");
+  TEST_SINGLE(srshr(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "srshr v30.16b, v29.16b, #7");
+  TEST_SINGLE(srshr(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "srshr v30.8h, v29.8h, #1");
+  TEST_SINGLE(srshr(SubRegSize::i16Bit, QReg::q30, QReg::q29, 15), "srshr v30.8h, v29.8h, #15");
+  TEST_SINGLE(srshr(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "srshr v30.4s, v29.4s, #1");
+  TEST_SINGLE(srshr(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "srshr v30.4s, v29.4s, #31");
+  TEST_SINGLE(srshr(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "srshr v30.2d, v29.2d, #1");
+  TEST_SINGLE(srshr(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "srshr v30.2d, v29.2d, #63");
+
+  TEST_SINGLE(srshr(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "srshr v30.8b, v29.8b, #1");
+  TEST_SINGLE(srshr(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "srshr v30.8b, v29.8b, #7");
+  TEST_SINGLE(srshr(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "srshr v30.4h, v29.4h, #1");
+  TEST_SINGLE(srshr(SubRegSize::i16Bit, DReg::d30, DReg::d29, 15), "srshr v30.4h, v29.4h, #15");
+  TEST_SINGLE(srshr(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "srshr v30.2s, v29.2s, #1");
+  TEST_SINGLE(srshr(SubRegSize::i32Bit, DReg::d30, DReg::d29, 31), "srshr v30.2s, v29.2s, #31");
+  //TEST_SINGLE(srshr(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "srshr v30.1d, v29.1d, #1");
+  //TEST_SINGLE(srshr(SubRegSize::i64Bit, DReg::d30, DReg::d29, 63), "srshr v30.1d, v29.1d, #63");
+
+  TEST_SINGLE(srsra(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "srsra v30.16b, v29.16b, #1");
+  TEST_SINGLE(srsra(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "srsra v30.16b, v29.16b, #7");
+  TEST_SINGLE(srsra(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "srsra v30.8h, v29.8h, #1");
+  TEST_SINGLE(srsra(SubRegSize::i16Bit, QReg::q30, QReg::q29, 15), "srsra v30.8h, v29.8h, #15");
+  TEST_SINGLE(srsra(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "srsra v30.4s, v29.4s, #1");
+  TEST_SINGLE(srsra(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "srsra v30.4s, v29.4s, #31");
+  TEST_SINGLE(srsra(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "srsra v30.2d, v29.2d, #1");
+  TEST_SINGLE(srsra(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "srsra v30.2d, v29.2d, #63");
+
+  TEST_SINGLE(srsra(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "srsra v30.8b, v29.8b, #1");
+  TEST_SINGLE(srsra(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "srsra v30.8b, v29.8b, #7");
+  TEST_SINGLE(srsra(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "srsra v30.4h, v29.4h, #1");
+  TEST_SINGLE(srsra(SubRegSize::i16Bit, DReg::d30, DReg::d29, 15), "srsra v30.4h, v29.4h, #15");
+  TEST_SINGLE(srsra(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "srsra v30.2s, v29.2s, #1");
+  TEST_SINGLE(srsra(SubRegSize::i32Bit, DReg::d30, DReg::d29, 31), "srsra v30.2s, v29.2s, #31");
+  //TEST_SINGLE(srsra(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "srsra v30.1d, v29.1d, #1");
+  //TEST_SINGLE(srsra(SubRegSize::i64Bit, DReg::d30, DReg::d29, 63), "srsra v30.1d, v29.1d, #63");
+
+  TEST_SINGLE(shl(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "shl v30.16b, v29.16b, #1");
+  TEST_SINGLE(shl(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "shl v30.16b, v29.16b, #7");
+  TEST_SINGLE(shl(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "shl v30.8h, v29.8h, #1");
+  TEST_SINGLE(shl(SubRegSize::i16Bit, QReg::q30, QReg::q29, 15), "shl v30.8h, v29.8h, #15");
+  TEST_SINGLE(shl(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "shl v30.4s, v29.4s, #1");
+  TEST_SINGLE(shl(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "shl v30.4s, v29.4s, #31");
+  TEST_SINGLE(shl(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "shl v30.2d, v29.2d, #1");
+  TEST_SINGLE(shl(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "shl v30.2d, v29.2d, #63");
+
+  TEST_SINGLE(shl(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "shl v30.8b, v29.8b, #1");
+  TEST_SINGLE(shl(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "shl v30.8b, v29.8b, #7");
+  TEST_SINGLE(shl(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "shl v30.4h, v29.4h, #1");
+  TEST_SINGLE(shl(SubRegSize::i16Bit, DReg::d30, DReg::d29, 15), "shl v30.4h, v29.4h, #15");
+  TEST_SINGLE(shl(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "shl v30.2s, v29.2s, #1");
+  TEST_SINGLE(shl(SubRegSize::i32Bit, DReg::d30, DReg::d29, 31), "shl v30.2s, v29.2s, #31");
+  //TEST_SINGLE(shl(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "shl v30.1d, v29.1d, #1");
+  //TEST_SINGLE(shl(SubRegSize::i64Bit, DReg::d30, DReg::d29, 63), "shl v30.1d, v29.1d, #63");
+
+  TEST_SINGLE(sqshl(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "sqshl v30.16b, v29.16b, #1");
+  TEST_SINGLE(sqshl(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "sqshl v30.16b, v29.16b, #7");
+  TEST_SINGLE(sqshl(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "sqshl v30.8h, v29.8h, #1");
+  TEST_SINGLE(sqshl(SubRegSize::i16Bit, QReg::q30, QReg::q29, 15), "sqshl v30.8h, v29.8h, #15");
+  TEST_SINGLE(sqshl(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "sqshl v30.4s, v29.4s, #1");
+  TEST_SINGLE(sqshl(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "sqshl v30.4s, v29.4s, #31");
+  TEST_SINGLE(sqshl(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "sqshl v30.2d, v29.2d, #1");
+  TEST_SINGLE(sqshl(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "sqshl v30.2d, v29.2d, #63");
+
+  TEST_SINGLE(sqshl(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "sqshl v30.8b, v29.8b, #1");
+  TEST_SINGLE(sqshl(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "sqshl v30.8b, v29.8b, #7");
+  TEST_SINGLE(sqshl(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "sqshl v30.4h, v29.4h, #1");
+  TEST_SINGLE(sqshl(SubRegSize::i16Bit, DReg::d30, DReg::d29, 15), "sqshl v30.4h, v29.4h, #15");
+  TEST_SINGLE(sqshl(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "sqshl v30.2s, v29.2s, #1");
+  TEST_SINGLE(sqshl(SubRegSize::i32Bit, DReg::d30, DReg::d29, 31), "sqshl v30.2s, v29.2s, #31");
+  //TEST_SINGLE(sqshl(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "sqshl v30.1d, v29.1d, #1");
+  //TEST_SINGLE(sqshl(SubRegSize::i64Bit, DReg::d30, DReg::d29, 63), "sqshl v30.1d, v29.1d, #63");
+
+  TEST_SINGLE(shrn(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "shrn v30.8b, v29.8h, #1");
+  TEST_SINGLE(shrn(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "shrn v30.8b, v29.8h, #7");
+  TEST_SINGLE(shrn(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "shrn v30.4h, v29.4s, #1");
+  TEST_SINGLE(shrn(SubRegSize::i16Bit, QReg::q30, QReg::q29, 15), "shrn v30.4h, v29.4s, #15");
+  TEST_SINGLE(shrn(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "shrn v30.2s, v29.2d, #1");
+  TEST_SINGLE(shrn(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "shrn v30.2s, v29.2d, #31");
+  //TEST_SINGLE(shrn(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "shrn v30.2d, v29.2d, #1");
+  //TEST_SINGLE(shrn(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "shrn v30.2d, v29.2d, #63");
+
+  TEST_SINGLE(shrn(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "shrn v30.8b, v29.8h, #1");
+  TEST_SINGLE(shrn(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "shrn v30.8b, v29.8h, #7");
+  TEST_SINGLE(shrn(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "shrn v30.4h, v29.4s, #1");
+  TEST_SINGLE(shrn(SubRegSize::i16Bit, DReg::d30, DReg::d29, 15), "shrn v30.4h, v29.4s, #15");
+  TEST_SINGLE(shrn(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "shrn v30.2s, v29.2d, #1");
+  TEST_SINGLE(shrn(SubRegSize::i32Bit, DReg::d30, DReg::d29, 31), "shrn v30.2s, v29.2d, #31");
+  //TEST_SINGLE(shrn(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "shrn v30.1d, v29.1d, #1");
+  //TEST_SINGLE(shrn(SubRegSize::i64Bit, DReg::d30, DReg::d29, 63), "shrn v30.1d, v29.1d, #63");
+
+  TEST_SINGLE(shrn2(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "shrn2 v30.16b, v29.8h, #1");
+  TEST_SINGLE(shrn2(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "shrn2 v30.16b, v29.8h, #7");
+  TEST_SINGLE(shrn2(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "shrn2 v30.8h, v29.4s, #1");
+  TEST_SINGLE(shrn2(SubRegSize::i16Bit, QReg::q30, QReg::q29, 15), "shrn2 v30.8h, v29.4s, #15");
+  TEST_SINGLE(shrn2(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "shrn2 v30.4s, v29.2d, #1");
+  TEST_SINGLE(shrn2(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "shrn2 v30.4s, v29.2d, #31");
+  //TEST_SINGLE(shrn2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "shrn2 v30.2d, v29.2d, #1");
+  //TEST_SINGLE(shrn2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "shrn2 v30.2d, v29.2d, #63");
+
+  TEST_SINGLE(shrn2(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "shrn2 v30.16b, v29.8h, #1");
+  TEST_SINGLE(shrn2(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "shrn2 v30.16b, v29.8h, #7");
+  TEST_SINGLE(shrn2(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "shrn2 v30.8h, v29.4s, #1");
+  TEST_SINGLE(shrn2(SubRegSize::i16Bit, DReg::d30, DReg::d29, 15), "shrn2 v30.8h, v29.4s, #15");
+  TEST_SINGLE(shrn2(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "shrn2 v30.4s, v29.2d, #1");
+  TEST_SINGLE(shrn2(SubRegSize::i32Bit, DReg::d30, DReg::d29, 31), "shrn2 v30.4s, v29.2d, #31");
+  //TEST_SINGLE(shrn2(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "shrn2 v30.1d, v29.1d, #1");
+  //TEST_SINGLE(shrn2(SubRegSize::i64Bit, DReg::d30, DReg::d29, 63), "shrn2 v30.1d, v29.1d, #63");
+
+  TEST_SINGLE(rshrn(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "rshrn v30.8b, v29.8h, #1");
+  TEST_SINGLE(rshrn(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "rshrn v30.8b, v29.8h, #7");
+  TEST_SINGLE(rshrn(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "rshrn v30.4h, v29.4s, #1");
+  TEST_SINGLE(rshrn(SubRegSize::i16Bit, QReg::q30, QReg::q29, 15), "rshrn v30.4h, v29.4s, #15");
+  TEST_SINGLE(rshrn(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "rshrn v30.2s, v29.2d, #1");
+  TEST_SINGLE(rshrn(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "rshrn v30.2s, v29.2d, #31");
+  //TEST_SINGLE(rshrn(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "rshrn v30.2d, v29.2d, #1");
+  //TEST_SINGLE(rshrn(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "rshrn v30.2d, v29.2d, #63");
+
+  TEST_SINGLE(rshrn(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "rshrn v30.8b, v29.8h, #1");
+  TEST_SINGLE(rshrn(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "rshrn v30.8b, v29.8h, #7");
+  TEST_SINGLE(rshrn(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "rshrn v30.4h, v29.4s, #1");
+  TEST_SINGLE(rshrn(SubRegSize::i16Bit, DReg::d30, DReg::d29, 15), "rshrn v30.4h, v29.4s, #15");
+  TEST_SINGLE(rshrn(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "rshrn v30.2s, v29.2d, #1");
+  TEST_SINGLE(rshrn(SubRegSize::i32Bit, DReg::d30, DReg::d29, 31), "rshrn v30.2s, v29.2d, #31");
+  //TEST_SINGLE(rshrn(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "rshrn v30.1d, v29.1d, #1");
+  //TEST_SINGLE(rshrn(SubRegSize::i64Bit, DReg::d30, DReg::d29, 63), "rshrn v30.1d, v29.1d, #63");
+
+  TEST_SINGLE(rshrn2(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "rshrn2 v30.16b, v29.8h, #1");
+  TEST_SINGLE(rshrn2(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "rshrn2 v30.16b, v29.8h, #7");
+  TEST_SINGLE(rshrn2(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "rshrn2 v30.8h, v29.4s, #1");
+  TEST_SINGLE(rshrn2(SubRegSize::i16Bit, QReg::q30, QReg::q29, 15), "rshrn2 v30.8h, v29.4s, #15");
+  TEST_SINGLE(rshrn2(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "rshrn2 v30.4s, v29.2d, #1");
+  TEST_SINGLE(rshrn2(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "rshrn2 v30.4s, v29.2d, #31");
+  //TEST_SINGLE(rshrn2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "rshrn2 v30.2d, v29.2d, #1");
+  //TEST_SINGLE(rshrn2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "rshrn2 v30.2d, v29.2d, #63");
+
+  TEST_SINGLE(rshrn2(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "rshrn2 v30.16b, v29.8h, #1");
+  TEST_SINGLE(rshrn2(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "rshrn2 v30.16b, v29.8h, #7");
+  TEST_SINGLE(rshrn2(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "rshrn2 v30.8h, v29.4s, #1");
+  TEST_SINGLE(rshrn2(SubRegSize::i16Bit, DReg::d30, DReg::d29, 15), "rshrn2 v30.8h, v29.4s, #15");
+  TEST_SINGLE(rshrn2(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "rshrn2 v30.4s, v29.2d, #1");
+  TEST_SINGLE(rshrn2(SubRegSize::i32Bit, DReg::d30, DReg::d29, 31), "rshrn2 v30.4s, v29.2d, #31");
+  //TEST_SINGLE(rshrn2(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "rshrn2 v30.1d, v29.1d, #1");
+  //TEST_SINGLE(rshrn2(SubRegSize::i64Bit, DReg::d30, DReg::d29, 63), "rshrn2 v30.1d, v29.1d, #63");
+
+  TEST_SINGLE(sqshrn(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "sqshrn v30.8b, v29.8h, #1");
+  TEST_SINGLE(sqshrn(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "sqshrn v30.8b, v29.8h, #7");
+  TEST_SINGLE(sqshrn(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "sqshrn v30.4h, v29.4s, #1");
+  TEST_SINGLE(sqshrn(SubRegSize::i16Bit, QReg::q30, QReg::q29, 15), "sqshrn v30.4h, v29.4s, #15");
+  TEST_SINGLE(sqshrn(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "sqshrn v30.2s, v29.2d, #1");
+  TEST_SINGLE(sqshrn(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "sqshrn v30.2s, v29.2d, #31");
+  //TEST_SINGLE(sqshrn(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "sqshrn v30.2d, v29.2d, #1");
+  //TEST_SINGLE(sqshrn(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "sqshrn v30.2d, v29.2d, #63");
+
+  TEST_SINGLE(sqshrn(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "sqshrn v30.8b, v29.8h, #1");
+  TEST_SINGLE(sqshrn(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "sqshrn v30.8b, v29.8h, #7");
+  TEST_SINGLE(sqshrn(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "sqshrn v30.4h, v29.4s, #1");
+  TEST_SINGLE(sqshrn(SubRegSize::i16Bit, DReg::d30, DReg::d29, 15), "sqshrn v30.4h, v29.4s, #15");
+  TEST_SINGLE(sqshrn(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "sqshrn v30.2s, v29.2d, #1");
+  TEST_SINGLE(sqshrn(SubRegSize::i32Bit, DReg::d30, DReg::d29, 31), "sqshrn v30.2s, v29.2d, #31");
+  //TEST_SINGLE(sqshrn(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "sqshrn v30.1d, v29.1d, #1");
+  //TEST_SINGLE(sqshrn(SubRegSize::i64Bit, DReg::d30, DReg::d29, 63), "sqshrn v30.1d, v29.1d, #63");
+
+  TEST_SINGLE(sqshrn2(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "sqshrn2 v30.16b, v29.8h, #1");
+  TEST_SINGLE(sqshrn2(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "sqshrn2 v30.16b, v29.8h, #7");
+  TEST_SINGLE(sqshrn2(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "sqshrn2 v30.8h, v29.4s, #1");
+  TEST_SINGLE(sqshrn2(SubRegSize::i16Bit, QReg::q30, QReg::q29, 15), "sqshrn2 v30.8h, v29.4s, #15");
+  TEST_SINGLE(sqshrn2(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "sqshrn2 v30.4s, v29.2d, #1");
+  TEST_SINGLE(sqshrn2(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "sqshrn2 v30.4s, v29.2d, #31");
+  //TEST_SINGLE(sqshrn2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "sqshrn2 v30.2d, v29.2d, #1");
+  //TEST_SINGLE(sqshrn2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "sqshrn2 v30.2d, v29.2d, #63");
+
+  TEST_SINGLE(sqshrn2(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "sqshrn2 v30.16b, v29.8h, #1");
+  TEST_SINGLE(sqshrn2(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "sqshrn2 v30.16b, v29.8h, #7");
+  TEST_SINGLE(sqshrn2(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "sqshrn2 v30.8h, v29.4s, #1");
+  TEST_SINGLE(sqshrn2(SubRegSize::i16Bit, DReg::d30, DReg::d29, 15), "sqshrn2 v30.8h, v29.4s, #15");
+  TEST_SINGLE(sqshrn2(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "sqshrn2 v30.4s, v29.2d, #1");
+  TEST_SINGLE(sqshrn2(SubRegSize::i32Bit, DReg::d30, DReg::d29, 31), "sqshrn2 v30.4s, v29.2d, #31");
+  //TEST_SINGLE(sqshrn2(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "sqshrn2 v30.1d, v29.1d, #1");
+  //TEST_SINGLE(sqshrn2(SubRegSize::i64Bit, DReg::d30, DReg::d29, 63), "sqshrn2 v30.1d, v29.1d, #63");
+
+  TEST_SINGLE(sqrshrn(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "sqrshrn v30.8b, v29.8h, #1");
+  TEST_SINGLE(sqrshrn(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "sqrshrn v30.8b, v29.8h, #7");
+  TEST_SINGLE(sqrshrn(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "sqrshrn v30.4h, v29.4s, #1");
+  TEST_SINGLE(sqrshrn(SubRegSize::i16Bit, QReg::q30, QReg::q29, 15), "sqrshrn v30.4h, v29.4s, #15");
+  TEST_SINGLE(sqrshrn(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "sqrshrn v30.2s, v29.2d, #1");
+  TEST_SINGLE(sqrshrn(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "sqrshrn v30.2s, v29.2d, #31");
+  //TEST_SINGLE(sqrshrn(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "sqrshrn v30.2d, v29.2d, #1");
+  //TEST_SINGLE(sqrshrn(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "sqrshrn v30.2d, v29.2d, #63");
+
+  TEST_SINGLE(sqrshrn(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "sqrshrn v30.8b, v29.8h, #1");
+  TEST_SINGLE(sqrshrn(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "sqrshrn v30.8b, v29.8h, #7");
+  TEST_SINGLE(sqrshrn(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "sqrshrn v30.4h, v29.4s, #1");
+  TEST_SINGLE(sqrshrn(SubRegSize::i16Bit, DReg::d30, DReg::d29, 15), "sqrshrn v30.4h, v29.4s, #15");
+  TEST_SINGLE(sqrshrn(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "sqrshrn v30.2s, v29.2d, #1");
+  TEST_SINGLE(sqrshrn(SubRegSize::i32Bit, DReg::d30, DReg::d29, 31), "sqrshrn v30.2s, v29.2d, #31");
+  //TEST_SINGLE(sqrshrn(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "sqrshrn v30.1d, v29.1d, #1");
+  //TEST_SINGLE(sqrshrn(SubRegSize::i64Bit, DReg::d30, DReg::d29, 63), "sqrshrn v30.1d, v29.1d, #63");
+
+  TEST_SINGLE(sqrshrn2(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "sqrshrn2 v30.16b, v29.8h, #1");
+  TEST_SINGLE(sqrshrn2(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "sqrshrn2 v30.16b, v29.8h, #7");
+  TEST_SINGLE(sqrshrn2(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "sqrshrn2 v30.8h, v29.4s, #1");
+  TEST_SINGLE(sqrshrn2(SubRegSize::i16Bit, QReg::q30, QReg::q29, 15), "sqrshrn2 v30.8h, v29.4s, #15");
+  TEST_SINGLE(sqrshrn2(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "sqrshrn2 v30.4s, v29.2d, #1");
+  TEST_SINGLE(sqrshrn2(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "sqrshrn2 v30.4s, v29.2d, #31");
+  //TEST_SINGLE(sqrshrn2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "sqrshrn2 v30.2d, v29.2d, #1");
+  //TEST_SINGLE(sqrshrn2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "sqrshrn2 v30.2d, v29.2d, #63");
+
+  TEST_SINGLE(sqrshrn2(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "sqrshrn2 v30.16b, v29.8h, #1");
+  TEST_SINGLE(sqrshrn2(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "sqrshrn2 v30.16b, v29.8h, #7");
+  TEST_SINGLE(sqrshrn2(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "sqrshrn2 v30.8h, v29.4s, #1");
+  TEST_SINGLE(sqrshrn2(SubRegSize::i16Bit, DReg::d30, DReg::d29, 15), "sqrshrn2 v30.8h, v29.4s, #15");
+  TEST_SINGLE(sqrshrn2(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "sqrshrn2 v30.4s, v29.2d, #1");
+  TEST_SINGLE(sqrshrn2(SubRegSize::i32Bit, DReg::d30, DReg::d29, 31), "sqrshrn2 v30.4s, v29.2d, #31");
+  //TEST_SINGLE(sqrshrn2(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "sqrshrn2 v30.1d, v29.1d, #1");
+  //TEST_SINGLE(sqrshrn2(SubRegSize::i64Bit, DReg::d30, DReg::d29, 63), "sqrshrn2 v30.1d, v29.1d, #63");
+
+  //TEST_SINGLE(sshll(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "sshll v30.8b, v29.8h, #1");
+  //TEST_SINGLE(sshll(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "sshll v30.8b, v29.8h, #7");
+  TEST_SINGLE(sshll(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "sshll v30.8h, v29.8b, #1");
+  TEST_SINGLE(sshll(SubRegSize::i16Bit, QReg::q30, QReg::q29, 7), "sshll v30.8h, v29.8b, #7");
+  TEST_SINGLE(sshll(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "sshll v30.4s, v29.4h, #1");
+  TEST_SINGLE(sshll(SubRegSize::i32Bit, QReg::q30, QReg::q29, 15), "sshll v30.4s, v29.4h, #15");
+  TEST_SINGLE(sshll(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "sshll v30.2d, v29.2s, #1");
+  TEST_SINGLE(sshll(SubRegSize::i64Bit, QReg::q30, QReg::q29, 31), "sshll v30.2d, v29.2s, #31");
+
+  //TEST_SINGLE(sshll(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "sshll v30.8b, v29.8h, #1");
+  //TEST_SINGLE(sshll(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "sshll v30.8b, v29.8h, #7");
+  TEST_SINGLE(sshll(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "sshll v30.8h, v29.8b, #1");
+  TEST_SINGLE(sshll(SubRegSize::i16Bit, DReg::d30, DReg::d29, 7), "sshll v30.8h, v29.8b, #7");
+  TEST_SINGLE(sshll(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "sshll v30.4s, v29.4h, #1");
+  TEST_SINGLE(sshll(SubRegSize::i32Bit, DReg::d30, DReg::d29, 15), "sshll v30.4s, v29.4h, #15");
+  TEST_SINGLE(sshll(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "sshll v30.2d, v29.2s, #1");
+  TEST_SINGLE(sshll(SubRegSize::i64Bit, DReg::d30, DReg::d29, 31), "sshll v30.2d, v29.2s, #31");
+
+  //TEST_SINGLE(sshll2(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "sshll2 v30.16b, v29.8h, #1");
+  //TEST_SINGLE(sshll2(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "sshll2 v30.16b, v29.8h, #7");
+  TEST_SINGLE(sshll2(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "sshll2 v30.8h, v29.16b, #1");
+  TEST_SINGLE(sshll2(SubRegSize::i16Bit, QReg::q30, QReg::q29, 7), "sshll2 v30.8h, v29.16b, #7");
+  TEST_SINGLE(sshll2(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "sshll2 v30.4s, v29.8h, #1");
+  TEST_SINGLE(sshll2(SubRegSize::i32Bit, QReg::q30, QReg::q29, 15), "sshll2 v30.4s, v29.8h, #15");
+  TEST_SINGLE(sshll2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "sshll2 v30.2d, v29.4s, #1");
+  TEST_SINGLE(sshll2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 31), "sshll2 v30.2d, v29.4s, #31");
+
+  //TEST_SINGLE(sshll2(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "sshll2 v30.16b, v29.8h, #1");
+  //TEST_SINGLE(sshll2(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "sshll2 v30.16b, v29.8h, #7");
+  TEST_SINGLE(sshll2(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "sshll2 v30.8h, v29.16b, #1");
+  TEST_SINGLE(sshll2(SubRegSize::i16Bit, DReg::d30, DReg::d29, 7), "sshll2 v30.8h, v29.16b, #7");
+  TEST_SINGLE(sshll2(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "sshll2 v30.4s, v29.8h, #1");
+  TEST_SINGLE(sshll2(SubRegSize::i32Bit, DReg::d30, DReg::d29, 15), "sshll2 v30.4s, v29.8h, #15");
+  TEST_SINGLE(sshll2(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "sshll2 v30.2d, v29.4s, #1");
+  TEST_SINGLE(sshll2(SubRegSize::i64Bit, DReg::d30, DReg::d29, 31), "sshll2 v30.2d, v29.4s, #31");
+
+  //TEST_SINGLE(sxtl(SubRegSize::i8Bit, QReg::q30, QReg::q29),   "sxtl v30.8b, v29.8h");
+  TEST_SINGLE(sxtl(SubRegSize::i16Bit, QReg::q30, QReg::q29),  "sxtl v30.8h, v29.8b");
+  TEST_SINGLE(sxtl(SubRegSize::i32Bit, QReg::q30, QReg::q29),  "sxtl v30.4s, v29.4h");
+  TEST_SINGLE(sxtl(SubRegSize::i64Bit, QReg::q30, QReg::q29),  "sxtl v30.2d, v29.2s");
+
+  //TEST_SINGLE(sxtl(SubRegSize::i8Bit, DReg::d30, DReg::d29),   "sxtl v30.8b, v29.8h");
+  TEST_SINGLE(sxtl(SubRegSize::i16Bit, DReg::d30, DReg::d29),  "sxtl v30.8h, v29.8b");
+  TEST_SINGLE(sxtl(SubRegSize::i32Bit, DReg::d30, DReg::d29),  "sxtl v30.4s, v29.4h");
+  TEST_SINGLE(sxtl(SubRegSize::i64Bit, DReg::d30, DReg::d29),  "sxtl v30.2d, v29.2s");
+
+  //TEST_SINGLE(sxtl2(SubRegSize::i8Bit, QReg::q30, QReg::q29),   "sxtl2 v30.16b, v29.8h");
+  TEST_SINGLE(sxtl2(SubRegSize::i16Bit, QReg::q30, QReg::q29),  "sxtl2 v30.8h, v29.16b");
+  TEST_SINGLE(sxtl2(SubRegSize::i32Bit, QReg::q30, QReg::q29),  "sxtl2 v30.4s, v29.8h");
+  TEST_SINGLE(sxtl2(SubRegSize::i64Bit, QReg::q30, QReg::q29),  "sxtl2 v30.2d, v29.4s");
+
+  //TEST_SINGLE(sxtl2(SubRegSize::i8Bit, DReg::d30, DReg::d29),   "sxtl2 v30.16b, v29.8h");
+  TEST_SINGLE(sxtl2(SubRegSize::i16Bit, DReg::d30, DReg::d29),  "sxtl2 v30.8h, v29.16b");
+  TEST_SINGLE(sxtl2(SubRegSize::i32Bit, DReg::d30, DReg::d29),  "sxtl2 v30.4s, v29.8h");
+  TEST_SINGLE(sxtl2(SubRegSize::i64Bit, DReg::d30, DReg::d29),  "sxtl2 v30.2d, v29.4s");
+
+  //// TODO: SCVTF, FCVTZS
+
+  TEST_SINGLE(ushr(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "ushr v30.16b, v29.16b, #1");
+  TEST_SINGLE(ushr(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "ushr v30.16b, v29.16b, #7");
+  TEST_SINGLE(ushr(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "ushr v30.8h, v29.8h, #1");
+  TEST_SINGLE(ushr(SubRegSize::i16Bit, QReg::q30, QReg::q29, 15), "ushr v30.8h, v29.8h, #15");
+  TEST_SINGLE(ushr(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "ushr v30.4s, v29.4s, #1");
+  TEST_SINGLE(ushr(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "ushr v30.4s, v29.4s, #31");
+  TEST_SINGLE(ushr(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "ushr v30.2d, v29.2d, #1");
+  TEST_SINGLE(ushr(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "ushr v30.2d, v29.2d, #63");
+
+  TEST_SINGLE(ushr(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "ushr v30.8b, v29.8b, #1");
+  TEST_SINGLE(ushr(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "ushr v30.8b, v29.8b, #7");
+  TEST_SINGLE(ushr(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "ushr v30.4h, v29.4h, #1");
+  TEST_SINGLE(ushr(SubRegSize::i16Bit, DReg::d30, DReg::d29, 15), "ushr v30.4h, v29.4h, #15");
+  TEST_SINGLE(ushr(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "ushr v30.2s, v29.2s, #1");
+  TEST_SINGLE(ushr(SubRegSize::i32Bit, DReg::d30, DReg::d29, 31), "ushr v30.2s, v29.2s, #31");
+  //TEST_SINGLE(ushr(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "ushr v30.1d, v29.1d, #1");
+  //TEST_SINGLE(ushr(SubRegSize::i64Bit, DReg::d30, DReg::d29, 63), "ushr v30.1d, v29.1d, #63");
+
+  TEST_SINGLE(usra(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "usra v30.16b, v29.16b, #1");
+  TEST_SINGLE(usra(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "usra v30.16b, v29.16b, #7");
+  TEST_SINGLE(usra(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "usra v30.8h, v29.8h, #1");
+  TEST_SINGLE(usra(SubRegSize::i16Bit, QReg::q30, QReg::q29, 15), "usra v30.8h, v29.8h, #15");
+  TEST_SINGLE(usra(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "usra v30.4s, v29.4s, #1");
+  TEST_SINGLE(usra(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "usra v30.4s, v29.4s, #31");
+  TEST_SINGLE(usra(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "usra v30.2d, v29.2d, #1");
+  TEST_SINGLE(usra(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "usra v30.2d, v29.2d, #63");
+
+  TEST_SINGLE(usra(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "usra v30.8b, v29.8b, #1");
+  TEST_SINGLE(usra(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "usra v30.8b, v29.8b, #7");
+  TEST_SINGLE(usra(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "usra v30.4h, v29.4h, #1");
+  TEST_SINGLE(usra(SubRegSize::i16Bit, DReg::d30, DReg::d29, 15), "usra v30.4h, v29.4h, #15");
+  TEST_SINGLE(usra(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "usra v30.2s, v29.2s, #1");
+  TEST_SINGLE(usra(SubRegSize::i32Bit, DReg::d30, DReg::d29, 31), "usra v30.2s, v29.2s, #31");
+  //TEST_SINGLE(usra(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "usra v30.1d, v29.1d, #1");
+  //TEST_SINGLE(usra(SubRegSize::i64Bit, DReg::d30, DReg::d29, 63), "usra v30.1d, v29.1d, #63");
+
+  TEST_SINGLE(urshr(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "urshr v30.16b, v29.16b, #1");
+  TEST_SINGLE(urshr(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "urshr v30.16b, v29.16b, #7");
+  TEST_SINGLE(urshr(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "urshr v30.8h, v29.8h, #1");
+  TEST_SINGLE(urshr(SubRegSize::i16Bit, QReg::q30, QReg::q29, 15), "urshr v30.8h, v29.8h, #15");
+  TEST_SINGLE(urshr(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "urshr v30.4s, v29.4s, #1");
+  TEST_SINGLE(urshr(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "urshr v30.4s, v29.4s, #31");
+  TEST_SINGLE(urshr(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "urshr v30.2d, v29.2d, #1");
+  TEST_SINGLE(urshr(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "urshr v30.2d, v29.2d, #63");
+
+  TEST_SINGLE(urshr(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "urshr v30.8b, v29.8b, #1");
+  TEST_SINGLE(urshr(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "urshr v30.8b, v29.8b, #7");
+  TEST_SINGLE(urshr(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "urshr v30.4h, v29.4h, #1");
+  TEST_SINGLE(urshr(SubRegSize::i16Bit, DReg::d30, DReg::d29, 15), "urshr v30.4h, v29.4h, #15");
+  TEST_SINGLE(urshr(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "urshr v30.2s, v29.2s, #1");
+  TEST_SINGLE(urshr(SubRegSize::i32Bit, DReg::d30, DReg::d29, 31), "urshr v30.2s, v29.2s, #31");
+  //TEST_SINGLE(urshr(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "urshr v30.1d, v29.1d, #1");
+  //TEST_SINGLE(urshr(SubRegSize::i64Bit, DReg::d30, DReg::d29, 63), "urshr v30.1d, v29.1d, #63");
+
+  TEST_SINGLE(ursra(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "ursra v30.16b, v29.16b, #1");
+  TEST_SINGLE(ursra(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "ursra v30.16b, v29.16b, #7");
+  TEST_SINGLE(ursra(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "ursra v30.8h, v29.8h, #1");
+  TEST_SINGLE(ursra(SubRegSize::i16Bit, QReg::q30, QReg::q29, 15), "ursra v30.8h, v29.8h, #15");
+  TEST_SINGLE(ursra(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "ursra v30.4s, v29.4s, #1");
+  TEST_SINGLE(ursra(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "ursra v30.4s, v29.4s, #31");
+  TEST_SINGLE(ursra(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "ursra v30.2d, v29.2d, #1");
+  TEST_SINGLE(ursra(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "ursra v30.2d, v29.2d, #63");
+
+  TEST_SINGLE(ursra(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "ursra v30.8b, v29.8b, #1");
+  TEST_SINGLE(ursra(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "ursra v30.8b, v29.8b, #7");
+  TEST_SINGLE(ursra(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "ursra v30.4h, v29.4h, #1");
+  TEST_SINGLE(ursra(SubRegSize::i16Bit, DReg::d30, DReg::d29, 15), "ursra v30.4h, v29.4h, #15");
+  TEST_SINGLE(ursra(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "ursra v30.2s, v29.2s, #1");
+  TEST_SINGLE(ursra(SubRegSize::i32Bit, DReg::d30, DReg::d29, 31), "ursra v30.2s, v29.2s, #31");
+  //TEST_SINGLE(ursra(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "ursra v30.1d, v29.1d, #1");
+  //TEST_SINGLE(ursra(SubRegSize::i64Bit, DReg::d30, DReg::d29, 63), "ursra v30.1d, v29.1d, #63");
+
+  TEST_SINGLE(sri(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "sri v30.16b, v29.16b, #1");
+  TEST_SINGLE(sri(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "sri v30.16b, v29.16b, #7");
+  TEST_SINGLE(sri(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "sri v30.8h, v29.8h, #1");
+  TEST_SINGLE(sri(SubRegSize::i16Bit, QReg::q30, QReg::q29, 15), "sri v30.8h, v29.8h, #15");
+  TEST_SINGLE(sri(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "sri v30.4s, v29.4s, #1");
+  TEST_SINGLE(sri(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "sri v30.4s, v29.4s, #31");
+  TEST_SINGLE(sri(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "sri v30.2d, v29.2d, #1");
+  TEST_SINGLE(sri(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "sri v30.2d, v29.2d, #63");
+
+  TEST_SINGLE(sri(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "sri v30.8b, v29.8b, #1");
+  TEST_SINGLE(sri(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "sri v30.8b, v29.8b, #7");
+  TEST_SINGLE(sri(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "sri v30.4h, v29.4h, #1");
+  TEST_SINGLE(sri(SubRegSize::i16Bit, DReg::d30, DReg::d29, 15), "sri v30.4h, v29.4h, #15");
+  TEST_SINGLE(sri(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "sri v30.2s, v29.2s, #1");
+  TEST_SINGLE(sri(SubRegSize::i32Bit, DReg::d30, DReg::d29, 31), "sri v30.2s, v29.2s, #31");
+  //TEST_SINGLE(sri(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "sri v30.1d, v29.1d, #1");
+  //TEST_SINGLE(sri(SubRegSize::i64Bit, DReg::d30, DReg::d29, 63), "sri v30.1d, v29.1d, #63");
+
+  TEST_SINGLE(sli(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "sli v30.16b, v29.16b, #1");
+  TEST_SINGLE(sli(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "sli v30.16b, v29.16b, #7");
+  TEST_SINGLE(sli(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "sli v30.8h, v29.8h, #1");
+  TEST_SINGLE(sli(SubRegSize::i16Bit, QReg::q30, QReg::q29, 15), "sli v30.8h, v29.8h, #15");
+  TEST_SINGLE(sli(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "sli v30.4s, v29.4s, #1");
+  TEST_SINGLE(sli(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "sli v30.4s, v29.4s, #31");
+  TEST_SINGLE(sli(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "sli v30.2d, v29.2d, #1");
+  TEST_SINGLE(sli(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "sli v30.2d, v29.2d, #63");
+
+  TEST_SINGLE(sli(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "sli v30.8b, v29.8b, #1");
+  TEST_SINGLE(sli(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "sli v30.8b, v29.8b, #7");
+  TEST_SINGLE(sli(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "sli v30.4h, v29.4h, #1");
+  TEST_SINGLE(sli(SubRegSize::i16Bit, DReg::d30, DReg::d29, 15), "sli v30.4h, v29.4h, #15");
+  TEST_SINGLE(sli(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "sli v30.2s, v29.2s, #1");
+  TEST_SINGLE(sli(SubRegSize::i32Bit, DReg::d30, DReg::d29, 31), "sli v30.2s, v29.2s, #31");
+  //TEST_SINGLE(sli(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "sli v30.1d, v29.1d, #1");
+  //TEST_SINGLE(sli(SubRegSize::i64Bit, DReg::d30, DReg::d29, 63), "sli v30.1d, v29.1d, #63");
+
+  TEST_SINGLE(sqshlu(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "sqshlu v30.16b, v29.16b, #1");
+  TEST_SINGLE(sqshlu(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "sqshlu v30.16b, v29.16b, #7");
+  TEST_SINGLE(sqshlu(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "sqshlu v30.8h, v29.8h, #1");
+  TEST_SINGLE(sqshlu(SubRegSize::i16Bit, QReg::q30, QReg::q29, 15), "sqshlu v30.8h, v29.8h, #15");
+  TEST_SINGLE(sqshlu(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "sqshlu v30.4s, v29.4s, #1");
+  TEST_SINGLE(sqshlu(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "sqshlu v30.4s, v29.4s, #31");
+  TEST_SINGLE(sqshlu(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "sqshlu v30.2d, v29.2d, #1");
+  TEST_SINGLE(sqshlu(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "sqshlu v30.2d, v29.2d, #63");
+
+  TEST_SINGLE(sqshlu(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "sqshlu v30.8b, v29.8b, #1");
+  TEST_SINGLE(sqshlu(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "sqshlu v30.8b, v29.8b, #7");
+  TEST_SINGLE(sqshlu(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "sqshlu v30.4h, v29.4h, #1");
+  TEST_SINGLE(sqshlu(SubRegSize::i16Bit, DReg::d30, DReg::d29, 15), "sqshlu v30.4h, v29.4h, #15");
+  TEST_SINGLE(sqshlu(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "sqshlu v30.2s, v29.2s, #1");
+  TEST_SINGLE(sqshlu(SubRegSize::i32Bit, DReg::d30, DReg::d29, 31), "sqshlu v30.2s, v29.2s, #31");
+  //TEST_SINGLE(sqshlu(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "sqshlu v30.1d, v29.1d, #1");
+  //TEST_SINGLE(sqshlu(SubRegSize::i64Bit, DReg::d30, DReg::d29, 63), "sqshlu v30.1d, v29.1d, #63");
+
+  TEST_SINGLE(uqshl(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "uqshl v30.16b, v29.16b, #1");
+  TEST_SINGLE(uqshl(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "uqshl v30.16b, v29.16b, #7");
+  TEST_SINGLE(uqshl(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "uqshl v30.8h, v29.8h, #1");
+  TEST_SINGLE(uqshl(SubRegSize::i16Bit, QReg::q30, QReg::q29, 15), "uqshl v30.8h, v29.8h, #15");
+  TEST_SINGLE(uqshl(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "uqshl v30.4s, v29.4s, #1");
+  TEST_SINGLE(uqshl(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "uqshl v30.4s, v29.4s, #31");
+  TEST_SINGLE(uqshl(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "uqshl v30.2d, v29.2d, #1");
+  TEST_SINGLE(uqshl(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "uqshl v30.2d, v29.2d, #63");
+
+  TEST_SINGLE(uqshl(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "uqshl v30.8b, v29.8b, #1");
+  TEST_SINGLE(uqshl(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "uqshl v30.8b, v29.8b, #7");
+  TEST_SINGLE(uqshl(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "uqshl v30.4h, v29.4h, #1");
+  TEST_SINGLE(uqshl(SubRegSize::i16Bit, DReg::d30, DReg::d29, 15), "uqshl v30.4h, v29.4h, #15");
+  TEST_SINGLE(uqshl(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "uqshl v30.2s, v29.2s, #1");
+  TEST_SINGLE(uqshl(SubRegSize::i32Bit, DReg::d30, DReg::d29, 31), "uqshl v30.2s, v29.2s, #31");
+  //TEST_SINGLE(uqshl(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "uqshl v30.1d, v29.1d, #1");
+  //TEST_SINGLE(uqshl(SubRegSize::i64Bit, DReg::d30, DReg::d29, 63), "uqshl v30.1d, v29.1d, #63");
+
+  TEST_SINGLE(sqshrun(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "sqshrun v30.8b, v29.8h, #1");
+  TEST_SINGLE(sqshrun(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "sqshrun v30.8b, v29.8h, #7");
+  TEST_SINGLE(sqshrun(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "sqshrun v30.4h, v29.4s, #1");
+  TEST_SINGLE(sqshrun(SubRegSize::i16Bit, QReg::q30, QReg::q29, 15), "sqshrun v30.4h, v29.4s, #15");
+  TEST_SINGLE(sqshrun(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "sqshrun v30.2s, v29.2d, #1");
+  TEST_SINGLE(sqshrun(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "sqshrun v30.2s, v29.2d, #31");
+  //TEST_SINGLE(sqshrun(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "sqshrun v30.2d, v29.2d, #1");
+  //TEST_SINGLE(sqshrun(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "sqshrun v30.2d, v29.2d, #63");
+
+  TEST_SINGLE(sqshrun(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "sqshrun v30.8b, v29.8h, #1");
+  TEST_SINGLE(sqshrun(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "sqshrun v30.8b, v29.8h, #7");
+  TEST_SINGLE(sqshrun(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "sqshrun v30.4h, v29.4s, #1");
+  TEST_SINGLE(sqshrun(SubRegSize::i16Bit, DReg::d30, DReg::d29, 15), "sqshrun v30.4h, v29.4s, #15");
+  TEST_SINGLE(sqshrun(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "sqshrun v30.2s, v29.2d, #1");
+  TEST_SINGLE(sqshrun(SubRegSize::i32Bit, DReg::d30, DReg::d29, 31), "sqshrun v30.2s, v29.2d, #31");
+  //TEST_SINGLE(sqshrun(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "sqshrun v30.1d, v29.1d, #1");
+  //TEST_SINGLE(sqshrun(SubRegSize::i64Bit, DReg::d30, DReg::d29, 63), "sqshrun v30.1d, v29.1d, #63");
+
+  TEST_SINGLE(sqshrun2(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "sqshrun2 v30.16b, v29.8h, #1");
+  TEST_SINGLE(sqshrun2(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "sqshrun2 v30.16b, v29.8h, #7");
+  TEST_SINGLE(sqshrun2(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "sqshrun2 v30.8h, v29.4s, #1");
+  TEST_SINGLE(sqshrun2(SubRegSize::i16Bit, QReg::q30, QReg::q29, 15), "sqshrun2 v30.8h, v29.4s, #15");
+  TEST_SINGLE(sqshrun2(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "sqshrun2 v30.4s, v29.2d, #1");
+  TEST_SINGLE(sqshrun2(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "sqshrun2 v30.4s, v29.2d, #31");
+  //TEST_SINGLE(sqshrun2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "sqshrun2 v30.2d, v29.2d, #1");
+  //TEST_SINGLE(sqshrun2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "sqshrun2 v30.2d, v29.2d, #63");
+
+  TEST_SINGLE(sqshrun2(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "sqshrun2 v30.16b, v29.8h, #1");
+  TEST_SINGLE(sqshrun2(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "sqshrun2 v30.16b, v29.8h, #7");
+  TEST_SINGLE(sqshrun2(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "sqshrun2 v30.8h, v29.4s, #1");
+  TEST_SINGLE(sqshrun2(SubRegSize::i16Bit, DReg::d30, DReg::d29, 15), "sqshrun2 v30.8h, v29.4s, #15");
+  TEST_SINGLE(sqshrun2(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "sqshrun2 v30.4s, v29.2d, #1");
+  TEST_SINGLE(sqshrun2(SubRegSize::i32Bit, DReg::d30, DReg::d29, 31), "sqshrun2 v30.4s, v29.2d, #31");
+  //TEST_SINGLE(sqshrun2(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "sqshrun2 v30.1d, v29.1d, #1");
+  //TEST_SINGLE(sqshrun2(SubRegSize::i64Bit, DReg::d30, DReg::d29, 63), "sqshrun2 v30.1d, v29.1d, #63");
+
+  TEST_SINGLE(sqrshrun(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "sqrshrun v30.8b, v29.8h, #1");
+  TEST_SINGLE(sqrshrun(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "sqrshrun v30.8b, v29.8h, #7");
+  TEST_SINGLE(sqrshrun(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "sqrshrun v30.4h, v29.4s, #1");
+  TEST_SINGLE(sqrshrun(SubRegSize::i16Bit, QReg::q30, QReg::q29, 15), "sqrshrun v30.4h, v29.4s, #15");
+  TEST_SINGLE(sqrshrun(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "sqrshrun v30.2s, v29.2d, #1");
+  TEST_SINGLE(sqrshrun(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "sqrshrun v30.2s, v29.2d, #31");
+  //TEST_SINGLE(sqrshrun(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "sqrshrun v30.2d, v29.2d, #1");
+  //TEST_SINGLE(sqrshrun(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "sqrshrun v30.2d, v29.2d, #63");
+
+  TEST_SINGLE(sqrshrun(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "sqrshrun v30.8b, v29.8h, #1");
+  TEST_SINGLE(sqrshrun(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "sqrshrun v30.8b, v29.8h, #7");
+  TEST_SINGLE(sqrshrun(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "sqrshrun v30.4h, v29.4s, #1");
+  TEST_SINGLE(sqrshrun(SubRegSize::i16Bit, DReg::d30, DReg::d29, 15), "sqrshrun v30.4h, v29.4s, #15");
+  TEST_SINGLE(sqrshrun(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "sqrshrun v30.2s, v29.2d, #1");
+  TEST_SINGLE(sqrshrun(SubRegSize::i32Bit, DReg::d30, DReg::d29, 31), "sqrshrun v30.2s, v29.2d, #31");
+  //TEST_SINGLE(sqrshrun(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "sqrshrun v30.1d, v29.1d, #1");
+  //TEST_SINGLE(sqrshrun(SubRegSize::i64Bit, DReg::d30, DReg::d29, 63), "sqrshrun v30.1d, v29.1d, #63");
+
+  TEST_SINGLE(sqrshrun2(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "sqrshrun2 v30.16b, v29.8h, #1");
+  TEST_SINGLE(sqrshrun2(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "sqrshrun2 v30.16b, v29.8h, #7");
+  TEST_SINGLE(sqrshrun2(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "sqrshrun2 v30.8h, v29.4s, #1");
+  TEST_SINGLE(sqrshrun2(SubRegSize::i16Bit, QReg::q30, QReg::q29, 15), "sqrshrun2 v30.8h, v29.4s, #15");
+  TEST_SINGLE(sqrshrun2(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "sqrshrun2 v30.4s, v29.2d, #1");
+  TEST_SINGLE(sqrshrun2(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "sqrshrun2 v30.4s, v29.2d, #31");
+  //TEST_SINGLE(sqrshrun2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "sqrshrun2 v30.2d, v29.2d, #1");
+  //TEST_SINGLE(sqrshrun2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "sqrshrun2 v30.2d, v29.2d, #63");
+
+  TEST_SINGLE(sqrshrun2(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "sqrshrun2 v30.16b, v29.8h, #1");
+  TEST_SINGLE(sqrshrun2(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "sqrshrun2 v30.16b, v29.8h, #7");
+  TEST_SINGLE(sqrshrun2(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "sqrshrun2 v30.8h, v29.4s, #1");
+  TEST_SINGLE(sqrshrun2(SubRegSize::i16Bit, DReg::d30, DReg::d29, 15), "sqrshrun2 v30.8h, v29.4s, #15");
+  TEST_SINGLE(sqrshrun2(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "sqrshrun2 v30.4s, v29.2d, #1");
+  TEST_SINGLE(sqrshrun2(SubRegSize::i32Bit, DReg::d30, DReg::d29, 31), "sqrshrun2 v30.4s, v29.2d, #31");
+  //TEST_SINGLE(sqrshrun2(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "sqrshrun2 v30.1d, v29.1d, #1");
+  //TEST_SINGLE(sqrshrun2(SubRegSize::i64Bit, DReg::d30, DReg::d29, 63), "sqrshrun2 v30.1d, v29.1d, #63");
+
+  TEST_SINGLE(uqshrn(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "uqshrn v30.8b, v29.8h, #1");
+  TEST_SINGLE(uqshrn(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "uqshrn v30.8b, v29.8h, #7");
+  TEST_SINGLE(uqshrn(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "uqshrn v30.4h, v29.4s, #1");
+  TEST_SINGLE(uqshrn(SubRegSize::i16Bit, QReg::q30, QReg::q29, 15), "uqshrn v30.4h, v29.4s, #15");
+  TEST_SINGLE(uqshrn(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "uqshrn v30.2s, v29.2d, #1");
+  TEST_SINGLE(uqshrn(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "uqshrn v30.2s, v29.2d, #31");
+  //TEST_SINGLE(uqshrn(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "uqshrn v30.2d, v29.2d, #1");
+  //TEST_SINGLE(uqshrn(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "uqshrn v30.2d, v29.2d, #63");
+
+  TEST_SINGLE(uqshrn(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "uqshrn v30.8b, v29.8h, #1");
+  TEST_SINGLE(uqshrn(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "uqshrn v30.8b, v29.8h, #7");
+  TEST_SINGLE(uqshrn(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "uqshrn v30.4h, v29.4s, #1");
+  TEST_SINGLE(uqshrn(SubRegSize::i16Bit, DReg::d30, DReg::d29, 15), "uqshrn v30.4h, v29.4s, #15");
+  TEST_SINGLE(uqshrn(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "uqshrn v30.2s, v29.2d, #1");
+  TEST_SINGLE(uqshrn(SubRegSize::i32Bit, DReg::d30, DReg::d29, 31), "uqshrn v30.2s, v29.2d, #31");
+  //TEST_SINGLE(uqshrn(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "uqshrn v30.1d, v29.1d, #1");
+  //TEST_SINGLE(uqshrn(SubRegSize::i64Bit, DReg::d30, DReg::d29, 63), "uqshrn v30.1d, v29.1d, #63");
+
+  TEST_SINGLE(uqshrn2(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "uqshrn2 v30.16b, v29.8h, #1");
+  TEST_SINGLE(uqshrn2(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "uqshrn2 v30.16b, v29.8h, #7");
+  TEST_SINGLE(uqshrn2(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "uqshrn2 v30.8h, v29.4s, #1");
+  TEST_SINGLE(uqshrn2(SubRegSize::i16Bit, QReg::q30, QReg::q29, 15), "uqshrn2 v30.8h, v29.4s, #15");
+  TEST_SINGLE(uqshrn2(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "uqshrn2 v30.4s, v29.2d, #1");
+  TEST_SINGLE(uqshrn2(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "uqshrn2 v30.4s, v29.2d, #31");
+  //TEST_SINGLE(uqshrn2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "uqshrn2 v30.2d, v29.2d, #1");
+  //TEST_SINGLE(uqshrn2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "uqshrn2 v30.2d, v29.2d, #63");
+
+  TEST_SINGLE(uqshrn2(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "uqshrn2 v30.16b, v29.8h, #1");
+  TEST_SINGLE(uqshrn2(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "uqshrn2 v30.16b, v29.8h, #7");
+  TEST_SINGLE(uqshrn2(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "uqshrn2 v30.8h, v29.4s, #1");
+  TEST_SINGLE(uqshrn2(SubRegSize::i16Bit, DReg::d30, DReg::d29, 15), "uqshrn2 v30.8h, v29.4s, #15");
+  TEST_SINGLE(uqshrn2(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "uqshrn2 v30.4s, v29.2d, #1");
+  TEST_SINGLE(uqshrn2(SubRegSize::i32Bit, DReg::d30, DReg::d29, 31), "uqshrn2 v30.4s, v29.2d, #31");
+  //TEST_SINGLE(uqshrn2(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "uqshrn2 v30.1d, v29.1d, #1");
+  //TEST_SINGLE(uqshrn2(SubRegSize::i64Bit, DReg::d30, DReg::d29, 63), "uqshrn2 v30.1d, v29.1d, #63");
+
+  TEST_SINGLE(uqrshrn(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "uqrshrn v30.8b, v29.8h, #1");
+  TEST_SINGLE(uqrshrn(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "uqrshrn v30.8b, v29.8h, #7");
+  TEST_SINGLE(uqrshrn(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "uqrshrn v30.4h, v29.4s, #1");
+  TEST_SINGLE(uqrshrn(SubRegSize::i16Bit, QReg::q30, QReg::q29, 15), "uqrshrn v30.4h, v29.4s, #15");
+  TEST_SINGLE(uqrshrn(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "uqrshrn v30.2s, v29.2d, #1");
+  TEST_SINGLE(uqrshrn(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "uqrshrn v30.2s, v29.2d, #31");
+  //TEST_SINGLE(uqrshrn(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "uqrshrn v30.2d, v29.2d, #1");
+  //TEST_SINGLE(uqrshrn(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "uqrshrn v30.2d, v29.2d, #63");
+
+  TEST_SINGLE(uqrshrn(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "uqrshrn v30.8b, v29.8h, #1");
+  TEST_SINGLE(uqrshrn(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "uqrshrn v30.8b, v29.8h, #7");
+  TEST_SINGLE(uqrshrn(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "uqrshrn v30.4h, v29.4s, #1");
+  TEST_SINGLE(uqrshrn(SubRegSize::i16Bit, DReg::d30, DReg::d29, 15), "uqrshrn v30.4h, v29.4s, #15");
+  TEST_SINGLE(uqrshrn(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "uqrshrn v30.2s, v29.2d, #1");
+  TEST_SINGLE(uqrshrn(SubRegSize::i32Bit, DReg::d30, DReg::d29, 31), "uqrshrn v30.2s, v29.2d, #31");
+  //TEST_SINGLE(uqrshrn(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "uqrshrn v30.1d, v29.1d, #1");
+  //TEST_SINGLE(uqrshrn(SubRegSize::i64Bit, DReg::d30, DReg::d29, 63), "uqrshrn v30.1d, v29.1d, #63");
+
+  TEST_SINGLE(uqrshrn2(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "uqrshrn2 v30.16b, v29.8h, #1");
+  TEST_SINGLE(uqrshrn2(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "uqrshrn2 v30.16b, v29.8h, #7");
+  TEST_SINGLE(uqrshrn2(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "uqrshrn2 v30.8h, v29.4s, #1");
+  TEST_SINGLE(uqrshrn2(SubRegSize::i16Bit, QReg::q30, QReg::q29, 15), "uqrshrn2 v30.8h, v29.4s, #15");
+  TEST_SINGLE(uqrshrn2(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "uqrshrn2 v30.4s, v29.2d, #1");
+  TEST_SINGLE(uqrshrn2(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "uqrshrn2 v30.4s, v29.2d, #31");
+  //TEST_SINGLE(uqrshrn2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "uqrshrn2 v30.2d, v29.2d, #1");
+  //TEST_SINGLE(uqrshrn2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "uqrshrn2 v30.2d, v29.2d, #63");
+
+  TEST_SINGLE(uqrshrn2(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "uqrshrn2 v30.16b, v29.8h, #1");
+  TEST_SINGLE(uqrshrn2(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "uqrshrn2 v30.16b, v29.8h, #7");
+  TEST_SINGLE(uqrshrn2(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "uqrshrn2 v30.8h, v29.4s, #1");
+  TEST_SINGLE(uqrshrn2(SubRegSize::i16Bit, DReg::d30, DReg::d29, 15), "uqrshrn2 v30.8h, v29.4s, #15");
+  TEST_SINGLE(uqrshrn2(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "uqrshrn2 v30.4s, v29.2d, #1");
+  TEST_SINGLE(uqrshrn2(SubRegSize::i32Bit, DReg::d30, DReg::d29, 31), "uqrshrn2 v30.4s, v29.2d, #31");
+  //TEST_SINGLE(uqrshrn2(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "uqrshrn2 v30.1d, v29.1d, #1");
+  //TEST_SINGLE(uqrshrn2(SubRegSize::i64Bit, DReg::d30, DReg::d29, 63), "uqrshrn2 v30.1d, v29.1d, #63");
+
+  //TEST_SINGLE(ushll(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "ushll v30.8b, v29.8h, #1");
+  //TEST_SINGLE(ushll(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "ushll v30.8b, v29.8h, #7");
+  TEST_SINGLE(ushll(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "ushll v30.8h, v29.8b, #1");
+  TEST_SINGLE(ushll(SubRegSize::i16Bit, QReg::q30, QReg::q29, 7), "ushll v30.8h, v29.8b, #7");
+  TEST_SINGLE(ushll(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "ushll v30.4s, v29.4h, #1");
+  TEST_SINGLE(ushll(SubRegSize::i32Bit, QReg::q30, QReg::q29, 15), "ushll v30.4s, v29.4h, #15");
+  TEST_SINGLE(ushll(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "ushll v30.2d, v29.2s, #1");
+  TEST_SINGLE(ushll(SubRegSize::i64Bit, QReg::q30, QReg::q29, 31), "ushll v30.2d, v29.2s, #31");
+
+  //TEST_SINGLE(ushll(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "ushll v30.8b, v29.8h, #1");
+  //TEST_SINGLE(ushll(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "ushll v30.8b, v29.8h, #7");
+  TEST_SINGLE(ushll(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "ushll v30.8h, v29.8b, #1");
+  TEST_SINGLE(ushll(SubRegSize::i16Bit, DReg::d30, DReg::d29, 7), "ushll v30.8h, v29.8b, #7");
+  TEST_SINGLE(ushll(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "ushll v30.4s, v29.4h, #1");
+  TEST_SINGLE(ushll(SubRegSize::i32Bit, DReg::d30, DReg::d29, 15), "ushll v30.4s, v29.4h, #15");
+  TEST_SINGLE(ushll(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "ushll v30.2d, v29.2s, #1");
+  TEST_SINGLE(ushll(SubRegSize::i64Bit, DReg::d30, DReg::d29, 31), "ushll v30.2d, v29.2s, #31");
+
+  //TEST_SINGLE(ushll2(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "ushll2 v30.16b, v29.8h, #1");
+  //TEST_SINGLE(ushll2(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "ushll2 v30.16b, v29.8h, #7");
+  TEST_SINGLE(ushll2(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "ushll2 v30.8h, v29.16b, #1");
+  TEST_SINGLE(ushll2(SubRegSize::i16Bit, QReg::q30, QReg::q29, 7), "ushll2 v30.8h, v29.16b, #7");
+  TEST_SINGLE(ushll2(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "ushll2 v30.4s, v29.8h, #1");
+  TEST_SINGLE(ushll2(SubRegSize::i32Bit, QReg::q30, QReg::q29, 15), "ushll2 v30.4s, v29.8h, #15");
+  TEST_SINGLE(ushll2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "ushll2 v30.2d, v29.4s, #1");
+  TEST_SINGLE(ushll2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 31), "ushll2 v30.2d, v29.4s, #31");
+
+  //TEST_SINGLE(ushll2(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "ushll2 v30.16b, v29.8h, #1");
+  //TEST_SINGLE(ushll2(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "ushll2 v30.16b, v29.8h, #7");
+  TEST_SINGLE(ushll2(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "ushll2 v30.8h, v29.16b, #1");
+  TEST_SINGLE(ushll2(SubRegSize::i16Bit, DReg::d30, DReg::d29, 7), "ushll2 v30.8h, v29.16b, #7");
+  TEST_SINGLE(ushll2(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "ushll2 v30.4s, v29.8h, #1");
+  TEST_SINGLE(ushll2(SubRegSize::i32Bit, DReg::d30, DReg::d29, 15), "ushll2 v30.4s, v29.8h, #15");
+  TEST_SINGLE(ushll2(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "ushll2 v30.2d, v29.4s, #1");
+  TEST_SINGLE(ushll2(SubRegSize::i64Bit, DReg::d30, DReg::d29, 31), "ushll2 v30.2d, v29.4s, #31");
+
+  //TEST_SINGLE(uxtl(SubRegSize::i8Bit, QReg::q30, QReg::q29),   "uxtl v30.8b, v29.8h");
+  TEST_SINGLE(uxtl(SubRegSize::i16Bit, QReg::q30, QReg::q29),  "uxtl v30.8h, v29.8b");
+  TEST_SINGLE(uxtl(SubRegSize::i32Bit, QReg::q30, QReg::q29),  "uxtl v30.4s, v29.4h");
+  TEST_SINGLE(uxtl(SubRegSize::i64Bit, QReg::q30, QReg::q29),  "uxtl v30.2d, v29.2s");
+
+  //TEST_SINGLE(uxtl(SubRegSize::i8Bit, DReg::d30, DReg::d29),   "uxtl v30.8b, v29.8h");
+  TEST_SINGLE(uxtl(SubRegSize::i16Bit, DReg::d30, DReg::d29),  "uxtl v30.8h, v29.8b");
+  TEST_SINGLE(uxtl(SubRegSize::i32Bit, DReg::d30, DReg::d29),  "uxtl v30.4s, v29.4h");
+  TEST_SINGLE(uxtl(SubRegSize::i64Bit, DReg::d30, DReg::d29),  "uxtl v30.2d, v29.2s");
+
+  //TEST_SINGLE(uxtl2(SubRegSize::i8Bit, QReg::q30, QReg::q29),   "uxtl2 v30.16b, v29.8h");
+  TEST_SINGLE(uxtl2(SubRegSize::i16Bit, QReg::q30, QReg::q29),  "uxtl2 v30.8h, v29.16b");
+  TEST_SINGLE(uxtl2(SubRegSize::i32Bit, QReg::q30, QReg::q29),  "uxtl2 v30.4s, v29.8h");
+  TEST_SINGLE(uxtl2(SubRegSize::i64Bit, QReg::q30, QReg::q29),  "uxtl2 v30.2d, v29.4s");
+
+  //TEST_SINGLE(uxtl2(SubRegSize::i8Bit, DReg::d30, DReg::d29),   "uxtl2 v30.16b, v29.8h");
+  TEST_SINGLE(uxtl2(SubRegSize::i16Bit, DReg::d30, DReg::d29),  "uxtl2 v30.8h, v29.16b");
+  TEST_SINGLE(uxtl2(SubRegSize::i32Bit, DReg::d30, DReg::d29),  "uxtl2 v30.4s, v29.8h");
+  TEST_SINGLE(uxtl2(SubRegSize::i64Bit, DReg::d30, DReg::d29),  "uxtl2 v30.2d, v29.4s");
+
+  //// XXX: UCVTF/FCVTZU
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD vector x indexed element") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Cryptographic three-register, imm2") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Cryptographic three-register SHA 512") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Cryptographic four-register") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Cryptographic two-register SHA 512") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Conversion between floating-point and fixed-point") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Conversion between floating-point and integer") {
+  TEST_SINGLE(fcvtns(Size::i32Bit, Reg::r29, HReg::h30), "fcvtns w29, h30");
+  TEST_SINGLE(fcvtns(Size::i64Bit, Reg::r29, HReg::h30), "fcvtns x29, h30");
+  TEST_SINGLE(fcvtns(Size::i32Bit, Reg::r29, SReg::s30), "fcvtns w29, s30");
+  TEST_SINGLE(fcvtns(Size::i64Bit, Reg::r29, SReg::s30), "fcvtns x29, s30");
+  TEST_SINGLE(fcvtns(Size::i32Bit, Reg::r29, DReg::d30), "fcvtns w29, d30");
+  TEST_SINGLE(fcvtns(Size::i64Bit, Reg::r29, DReg::d30), "fcvtns x29, d30");
+
+  TEST_SINGLE(fcvtnu(Size::i32Bit, Reg::r29, HReg::h30), "fcvtnu w29, h30");
+  TEST_SINGLE(fcvtnu(Size::i64Bit, Reg::r29, HReg::h30), "fcvtnu x29, h30");
+  TEST_SINGLE(fcvtnu(Size::i32Bit, Reg::r29, SReg::s30), "fcvtnu w29, s30");
+  TEST_SINGLE(fcvtnu(Size::i64Bit, Reg::r29, SReg::s30), "fcvtnu x29, s30");
+  TEST_SINGLE(fcvtnu(Size::i32Bit, Reg::r29, DReg::d30), "fcvtnu w29, d30");
+  TEST_SINGLE(fcvtnu(Size::i64Bit, Reg::r29, DReg::d30), "fcvtnu x29, d30");
+
+  TEST_SINGLE(scvtf(Size::i32Bit, HReg::h30, Reg::r29), "scvtf h30, w29");
+  TEST_SINGLE(scvtf(Size::i64Bit, HReg::h30, Reg::r29), "scvtf h30, x29");
+  TEST_SINGLE(scvtf(Size::i32Bit, SReg::s30, Reg::r29), "scvtf s30, w29");
+  TEST_SINGLE(scvtf(Size::i64Bit, SReg::s30, Reg::r29), "scvtf s30, x29");
+  TEST_SINGLE(scvtf(Size::i32Bit, DReg::d30, Reg::r29), "scvtf d30, w29");
+  TEST_SINGLE(scvtf(Size::i64Bit, DReg::d30, Reg::r29), "scvtf d30, x29");
+
+  TEST_SINGLE(ucvtf(Size::i32Bit, HReg::h30, Reg::r29), "ucvtf h30, w29");
+  TEST_SINGLE(ucvtf(Size::i64Bit, HReg::h30, Reg::r29), "ucvtf h30, x29");
+  TEST_SINGLE(ucvtf(Size::i32Bit, SReg::s30, Reg::r29), "ucvtf s30, w29");
+  TEST_SINGLE(ucvtf(Size::i64Bit, SReg::s30, Reg::r29), "ucvtf s30, x29");
+  TEST_SINGLE(ucvtf(Size::i32Bit, DReg::d30, Reg::r29), "ucvtf d30, w29");
+  TEST_SINGLE(ucvtf(Size::i64Bit, DReg::d30, Reg::r29), "ucvtf d30, x29");
+
+  TEST_SINGLE(fcvtas(Size::i32Bit, Reg::r29, HReg::h30), "fcvtas w29, h30");
+  TEST_SINGLE(fcvtas(Size::i64Bit, Reg::r29, HReg::h30), "fcvtas x29, h30");
+  TEST_SINGLE(fcvtas(Size::i32Bit, Reg::r29, SReg::s30), "fcvtas w29, s30");
+  TEST_SINGLE(fcvtas(Size::i64Bit, Reg::r29, SReg::s30), "fcvtas x29, s30");
+  TEST_SINGLE(fcvtas(Size::i32Bit, Reg::r29, DReg::d30), "fcvtas w29, d30");
+  TEST_SINGLE(fcvtas(Size::i64Bit, Reg::r29, DReg::d30), "fcvtas x29, d30");
+
+  TEST_SINGLE(fcvtau(Size::i32Bit, Reg::r29, HReg::h30), "fcvtau w29, h30");
+  TEST_SINGLE(fcvtau(Size::i64Bit, Reg::r29, HReg::h30), "fcvtau x29, h30");
+  TEST_SINGLE(fcvtau(Size::i32Bit, Reg::r29, SReg::s30), "fcvtau w29, s30");
+  TEST_SINGLE(fcvtau(Size::i64Bit, Reg::r29, SReg::s30), "fcvtau x29, s30");
+  TEST_SINGLE(fcvtau(Size::i32Bit, Reg::r29, DReg::d30), "fcvtau w29, d30");
+  TEST_SINGLE(fcvtau(Size::i64Bit, Reg::r29, DReg::d30), "fcvtau x29, d30");
+
+  TEST_SINGLE(fmov(Size::i32Bit, Reg::r29, HReg::h30), "fmov w29, h30");
+  TEST_SINGLE(fmov(Size::i64Bit, Reg::r29, HReg::h30), "fmov x29, h30");
+  TEST_SINGLE(fmov(Size::i32Bit, Reg::r29, SReg::s30), "fmov w29, s30");
+  //TEST_SINGLE(fmov(Size::i64Bit, Reg::r29, SReg::s30), "fmov x29, s30");
+  //TEST_SINGLE(fmov(Size::i32Bit, Reg::r29, DReg::d30), "fmov w29, d30");
+  TEST_SINGLE(fmov(Size::i64Bit, Reg::r29, DReg::d30), "fmov x29, d30");
+
+  //TEST_SINGLE(fmov(Size::i32Bit, Reg::r29, VReg::v30, false), "fmov w29, s30");
+  TEST_SINGLE(fmov(Size::i64Bit, Reg::r29, VReg::v30, false), "fmov x29, d30");
+
+  //TEST_SINGLE(fmov(Size::i32Bit, Reg::r29, VReg::v30, true), "fmov w29, s30");
+  TEST_SINGLE(fmov(Size::i64Bit, Reg::r29, VReg::v30, true), "fmov x29, v30.D[1]");
+
+  TEST_SINGLE(fmov(Size::i32Bit, HReg::h30, Reg::r29), "fmov h30, w29");
+  TEST_SINGLE(fmov(Size::i64Bit, HReg::h30, Reg::r29), "fmov h30, x29");
+  TEST_SINGLE(fmov(Size::i32Bit, SReg::s30, Reg::r29), "fmov s30, w29");
+  //TEST_SINGLE(fmov(Size::i64Bit, SReg::s30, Reg::r29), "fmov s30, x29");
+  //TEST_SINGLE(fmov(Size::i32Bit, DReg::d30, Reg::r29), "fmov d30, w29");
+  TEST_SINGLE(fmov(Size::i64Bit, DReg::d30, Reg::r29), "fmov d30, x29");
+
+  //TEST_SINGLE(fmov(Size::i32Bit, VReg::v30, Reg::r29, false), "fmov s30, w29");
+  TEST_SINGLE(fmov(Size::i64Bit, VReg::v30, Reg::r29, false), "fmov d30, x29");
+
+  //TEST_SINGLE(fmov(Size::i32Bit, VReg::v30, Reg::r29, true), "fmov d30, x29");
+  TEST_SINGLE(fmov(Size::i64Bit, VReg::v30, Reg::r29, true), "fmov v30.D[1], x29");
+
+  TEST_SINGLE(fcvtps(Size::i32Bit, Reg::r29, HReg::h30), "fcvtps w29, h30");
+  TEST_SINGLE(fcvtps(Size::i64Bit, Reg::r29, HReg::h30), "fcvtps x29, h30");
+  TEST_SINGLE(fcvtps(Size::i32Bit, Reg::r29, SReg::s30), "fcvtps w29, s30");
+  TEST_SINGLE(fcvtps(Size::i64Bit, Reg::r29, SReg::s30), "fcvtps x29, s30");
+  TEST_SINGLE(fcvtps(Size::i32Bit, Reg::r29, DReg::d30), "fcvtps w29, d30");
+  TEST_SINGLE(fcvtps(Size::i64Bit, Reg::r29, DReg::d30), "fcvtps x29, d30");
+
+  TEST_SINGLE(fcvtpu(Size::i32Bit, Reg::r29, HReg::h30), "fcvtpu w29, h30");
+  TEST_SINGLE(fcvtpu(Size::i64Bit, Reg::r29, HReg::h30), "fcvtpu x29, h30");
+  TEST_SINGLE(fcvtpu(Size::i32Bit, Reg::r29, SReg::s30), "fcvtpu w29, s30");
+  TEST_SINGLE(fcvtpu(Size::i64Bit, Reg::r29, SReg::s30), "fcvtpu x29, s30");
+  TEST_SINGLE(fcvtpu(Size::i32Bit, Reg::r29, DReg::d30), "fcvtpu w29, d30");
+  TEST_SINGLE(fcvtpu(Size::i64Bit, Reg::r29, DReg::d30), "fcvtpu x29, d30");
+
+  TEST_SINGLE(fcvtms(Size::i32Bit, Reg::r29, HReg::h30), "fcvtms w29, h30");
+  TEST_SINGLE(fcvtms(Size::i64Bit, Reg::r29, HReg::h30), "fcvtms x29, h30");
+  TEST_SINGLE(fcvtms(Size::i32Bit, Reg::r29, SReg::s30), "fcvtms w29, s30");
+  TEST_SINGLE(fcvtms(Size::i64Bit, Reg::r29, SReg::s30), "fcvtms x29, s30");
+  TEST_SINGLE(fcvtms(Size::i32Bit, Reg::r29, DReg::d30), "fcvtms w29, d30");
+  TEST_SINGLE(fcvtms(Size::i64Bit, Reg::r29, DReg::d30), "fcvtms x29, d30");
+
+  TEST_SINGLE(fcvtmu(Size::i32Bit, Reg::r29, HReg::h30), "fcvtmu w29, h30");
+  TEST_SINGLE(fcvtmu(Size::i64Bit, Reg::r29, HReg::h30), "fcvtmu x29, h30");
+  TEST_SINGLE(fcvtmu(Size::i32Bit, Reg::r29, SReg::s30), "fcvtmu w29, s30");
+  TEST_SINGLE(fcvtmu(Size::i64Bit, Reg::r29, SReg::s30), "fcvtmu x29, s30");
+  TEST_SINGLE(fcvtmu(Size::i32Bit, Reg::r29, DReg::d30), "fcvtmu w29, d30");
+  TEST_SINGLE(fcvtmu(Size::i64Bit, Reg::r29, DReg::d30), "fcvtmu x29, d30");
+
+  TEST_SINGLE(fcvtzs(Size::i32Bit, Reg::r29, HReg::h30), "fcvtzs w29, h30");
+  TEST_SINGLE(fcvtzs(Size::i64Bit, Reg::r29, HReg::h30), "fcvtzs x29, h30");
+  TEST_SINGLE(fcvtzs(Size::i32Bit, Reg::r29, SReg::s30), "fcvtzs w29, s30");
+  TEST_SINGLE(fcvtzs(Size::i64Bit, Reg::r29, SReg::s30), "fcvtzs x29, s30");
+  TEST_SINGLE(fcvtzs(Size::i32Bit, Reg::r29, DReg::d30), "fcvtzs w29, d30");
+  TEST_SINGLE(fcvtzs(Size::i64Bit, Reg::r29, DReg::d30), "fcvtzs x29, d30");
+
+  TEST_SINGLE(fcvtzu(Size::i32Bit, Reg::r29, HReg::h30), "fcvtzu w29, h30");
+  TEST_SINGLE(fcvtzu(Size::i64Bit, Reg::r29, HReg::h30), "fcvtzu x29, h30");
+  TEST_SINGLE(fcvtzu(Size::i32Bit, Reg::r29, SReg::s30), "fcvtzu w29, s30");
+  TEST_SINGLE(fcvtzu(Size::i64Bit, Reg::r29, SReg::s30), "fcvtzu x29, s30");
+  TEST_SINGLE(fcvtzu(Size::i32Bit, Reg::r29, DReg::d30), "fcvtzu w29, d30");
+  TEST_SINGLE(fcvtzu(Size::i64Bit, Reg::r29, DReg::d30), "fcvtzu x29, d30");
+}
+
+

--- a/External/FEXCore/unittests/Emitter/Branch_Tests.cpp
+++ b/External/FEXCore/unittests/Emitter/Branch_Tests.cpp
@@ -1,0 +1,450 @@
+#include "TestDisassembler.h"
+
+#include <catch2/catch.hpp>
+#include <fcntl.h>
+
+using namespace FEXCore::ARMEmitter;
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Branch: Conditional branch immediate") {
+  {
+    BackwardLabel Label;
+    Bind(&Label);
+    dc32(0);
+    b(Condition::CC_PL, &Label);
+
+    CHECK(DisassembleEncoding(1) == 0x54ffffe5);
+  }
+
+  {
+    ForwardLabel Label;
+    b(Condition::CC_PL, &Label);
+    Bind(&Label);
+    dc32(0);
+
+    CHECK(DisassembleEncoding(0) == 0x54000025);
+  }
+
+  {
+    BiDirectionalLabel Label;
+    Bind(&Label);
+    dc32(0);
+    b(Condition::CC_PL, &Label);
+
+    CHECK(DisassembleEncoding(1) == 0x54ffffe5);
+  }
+
+  {
+    BiDirectionalLabel Label;
+    b(Condition::CC_PL, &Label);
+    Bind(&Label);
+    dc32(0);
+
+    CHECK(DisassembleEncoding(0) == 0x54000025);
+  }
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Branch: Branch consistent conditional") {
+  {
+    BackwardLabel Label;
+    Bind(&Label);
+    dc32(0);
+    bc(Condition::CC_PL, &Label);
+
+    CHECK(DisassembleEncoding(1) == 0x54fffff5);
+  }
+
+  {
+    ForwardLabel Label;
+    bc(Condition::CC_PL, &Label);
+    Bind(&Label);
+    dc32(0);
+
+    CHECK(DisassembleEncoding(0) == 0x54000035);
+  }
+
+  {
+    BiDirectionalLabel Label;
+    Bind(&Label);
+    dc32(0);
+    bc(Condition::CC_PL, &Label);
+
+    CHECK(DisassembleEncoding(1) == 0x54fffff5);
+  }
+
+  {
+    BiDirectionalLabel Label;
+    bc(Condition::CC_PL, &Label);
+    Bind(&Label);
+    dc32(0);
+
+    CHECK(DisassembleEncoding(0) == 0x54000035);
+  }
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Branch: Unconditional branch register") {
+  TEST_SINGLE(br(Reg::r29), "br x29");
+  TEST_SINGLE(blr(Reg::r29), "blr x29");
+  TEST_SINGLE(ret(), "ret");
+  TEST_SINGLE(ret(Reg::r29), "ret x29");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Branch: Unconditional branch immediate") {
+  {
+    BackwardLabel Label;
+    Bind(&Label);
+    dc32(0);
+    b(&Label);
+
+    CHECK(DisassembleEncoding(1) == 0x17ffffff);
+  }
+
+  {
+    ForwardLabel Label;
+    b(&Label);
+    Bind(&Label);
+    dc32(0);
+
+    CHECK(DisassembleEncoding(0) == 0x14000001);
+  }
+
+  {
+    BiDirectionalLabel Label;
+    Bind(&Label);
+    dc32(0);
+    b(&Label);
+
+    CHECK(DisassembleEncoding(1) == 0x17ffffff);
+  }
+
+  {
+    BiDirectionalLabel Label;
+    b(&Label);
+    Bind(&Label);
+    dc32(0);
+
+    CHECK(DisassembleEncoding(0) == 0x14000001);
+  }
+
+  {
+    BackwardLabel Label;
+    Bind(&Label);
+    dc32(0);
+    bl(&Label);
+
+    CHECK(DisassembleEncoding(1) == 0x97ffffff);
+  }
+
+  {
+    ForwardLabel Label;
+    bl(&Label);
+    Bind(&Label);
+    dc32(0);
+
+    CHECK(DisassembleEncoding(0) == 0x94000001);
+  }
+
+  {
+    BiDirectionalLabel Label;
+    Bind(&Label);
+    dc32(0);
+    bl(&Label);
+
+    CHECK(DisassembleEncoding(1) == 0x97ffffff);
+  }
+
+  {
+    BiDirectionalLabel Label;
+    bl(&Label);
+    Bind(&Label);
+    dc32(0);
+
+    CHECK(DisassembleEncoding(0) == 0x94000001);
+  }
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Branch: Compare and branch") {
+  {
+    BackwardLabel Label;
+    Bind(&Label);
+    dc32(0);
+    cbz(Size::i32Bit, Reg::r29, &Label);
+
+    CHECK(DisassembleEncoding(1) == 0x34fffffd);
+  }
+
+  {
+    ForwardLabel Label;
+    cbz(Size::i32Bit, Reg::r29, &Label);
+    Bind(&Label);
+    dc32(0);
+
+    CHECK(DisassembleEncoding(0) == 0x3400003d);
+  }
+
+  {
+    BiDirectionalLabel Label;
+    Bind(&Label);
+    dc32(0);
+    cbz(Size::i32Bit, Reg::r29, &Label);
+
+    CHECK(DisassembleEncoding(1) == 0x34fffffd);
+  }
+
+  {
+    BiDirectionalLabel Label;
+    cbz(Size::i32Bit, Reg::r29, &Label);
+    Bind(&Label);
+    dc32(0);
+
+    CHECK(DisassembleEncoding(0) == 0x3400003d);
+  }
+
+  {
+    BackwardLabel Label;
+    Bind(&Label);
+    dc32(0);
+    cbz(Size::i64Bit, Reg::r29, &Label);
+
+    CHECK(DisassembleEncoding(1) == 0xb4fffffd);
+  }
+
+  {
+    ForwardLabel Label;
+    cbz(Size::i64Bit, Reg::r29, &Label);
+    Bind(&Label);
+    dc32(0);
+
+    CHECK(DisassembleEncoding(0) == 0xb400003d);
+  }
+
+  {
+    BiDirectionalLabel Label;
+    Bind(&Label);
+    dc32(0);
+    cbz(Size::i64Bit, Reg::r29, &Label);
+
+    CHECK(DisassembleEncoding(1) == 0xb4fffffd);
+  }
+
+  {
+    BiDirectionalLabel Label;
+    cbz(Size::i64Bit, Reg::r29, &Label);
+    Bind(&Label);
+    dc32(0);
+
+    CHECK(DisassembleEncoding(0) == 0xb400003d);
+  }
+
+  {
+    BackwardLabel Label;
+    Bind(&Label);
+    dc32(0);
+    cbnz(Size::i32Bit, Reg::r29, &Label);
+
+    CHECK(DisassembleEncoding(1) == 0x35fffffd);
+  }
+
+  {
+    ForwardLabel Label;
+    cbnz(Size::i32Bit, Reg::r29, &Label);
+    Bind(&Label);
+    dc32(0);
+
+    CHECK(DisassembleEncoding(0) == 0x3500003d);
+  }
+
+  {
+    BiDirectionalLabel Label;
+    Bind(&Label);
+    dc32(0);
+    cbnz(Size::i32Bit, Reg::r29, &Label);
+
+    CHECK(DisassembleEncoding(1) == 0x35fffffd);
+  }
+
+  {
+    BiDirectionalLabel Label;
+    cbnz(Size::i32Bit, Reg::r29, &Label);
+    Bind(&Label);
+    dc32(0);
+
+    CHECK(DisassembleEncoding(0) == 0x3500003d);
+  }
+
+  {
+    BackwardLabel Label;
+    Bind(&Label);
+    dc32(0);
+    cbnz(Size::i64Bit, Reg::r29, &Label);
+
+    CHECK(DisassembleEncoding(1) == 0xb5fffffd);
+  }
+
+  {
+    ForwardLabel Label;
+    cbnz(Size::i64Bit, Reg::r29, &Label);
+    Bind(&Label);
+    dc32(0);
+
+    CHECK(DisassembleEncoding(0) == 0xb500003d);
+  }
+
+  {
+    BiDirectionalLabel Label;
+    Bind(&Label);
+    dc32(0);
+    cbnz(Size::i64Bit, Reg::r29, &Label);
+
+    CHECK(DisassembleEncoding(1) == 0xb5fffffd);
+  }
+
+  {
+    BiDirectionalLabel Label;
+    cbnz(Size::i64Bit, Reg::r29, &Label);
+    Bind(&Label);
+    dc32(0);
+
+    CHECK(DisassembleEncoding(0) == 0xb500003d);
+  }
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Branch: Test and branch immediate") {
+  {
+    BackwardLabel Label;
+    Bind(&Label);
+    dc32(0);
+    tbz(Reg::r29, 0, &Label);
+
+    CHECK(DisassembleEncoding(1) == 0x3607fffd);
+  }
+
+  {
+    ForwardLabel Label;
+    tbz(Reg::r29, 0, &Label);
+    Bind(&Label);
+    dc32(0);
+
+    CHECK(DisassembleEncoding(0) == 0x3600003d);
+  }
+
+  {
+    BiDirectionalLabel Label;
+    Bind(&Label);
+    dc32(0);
+    tbz(Reg::r29, 0, &Label);
+
+    CHECK(DisassembleEncoding(1) == 0x3607fffd);
+  }
+
+  {
+    BiDirectionalLabel Label;
+    tbz(Reg::r29, 0, &Label);
+    Bind(&Label);
+    dc32(0);
+
+    CHECK(DisassembleEncoding(0) == 0x3600003d);
+  }
+
+  {
+    BackwardLabel Label;
+    Bind(&Label);
+    dc32(0);
+    tbz(Reg::r29, 63, &Label);
+
+    CHECK(DisassembleEncoding(1) == 0xb6fffffd);
+  }
+
+  {
+    ForwardLabel Label;
+    tbz(Reg::r29, 63, &Label);
+    Bind(&Label);
+    dc32(0);
+
+    CHECK(DisassembleEncoding(0) == 0xb6f8003d);
+  }
+
+  {
+    BiDirectionalLabel Label;
+    Bind(&Label);
+    dc32(0);
+    tbz(Reg::r29, 63, &Label);
+
+    CHECK(DisassembleEncoding(1) == 0xb6fffffd);
+  }
+
+  {
+    BiDirectionalLabel Label;
+    tbz(Reg::r29, 63, &Label);
+    Bind(&Label);
+    dc32(0);
+
+    CHECK(DisassembleEncoding(0) == 0xb6f8003d);
+  }
+
+  {
+    BackwardLabel Label;
+    Bind(&Label);
+    dc32(0);
+    tbnz(Reg::r29, 0, &Label);
+
+    CHECK(DisassembleEncoding(1) == 0x3707fffd);
+  }
+
+  {
+    ForwardLabel Label;
+    tbnz(Reg::r29, 0, &Label);
+    Bind(&Label);
+    dc32(0);
+
+    CHECK(DisassembleEncoding(0) == 0x3700003d);
+  }
+
+  {
+    BiDirectionalLabel Label;
+    Bind(&Label);
+    dc32(0);
+    tbnz(Reg::r29, 0, &Label);
+
+    CHECK(DisassembleEncoding(1) == 0x3707fffd);
+  }
+
+  {
+    BiDirectionalLabel Label;
+    tbnz(Reg::r29, 0, &Label);
+    Bind(&Label);
+    dc32(0);
+
+    CHECK(DisassembleEncoding(0) == 0x3700003d);
+  }
+
+  {
+    BackwardLabel Label;
+    Bind(&Label);
+    dc32(0);
+    tbnz(Reg::r29, 63, &Label);
+
+    CHECK(DisassembleEncoding(1) == 0xb7fffffd);
+  }
+
+  {
+    ForwardLabel Label;
+    tbnz(Reg::r29, 63, &Label);
+    Bind(&Label);
+    dc32(0);
+
+    CHECK(DisassembleEncoding(0) == 0xb7f8003d);
+  }
+
+  {
+    BiDirectionalLabel Label;
+    Bind(&Label);
+    dc32(0);
+    tbnz(Reg::r29, 63, &Label);
+
+    CHECK(DisassembleEncoding(1) == 0xb7fffffd);
+  }
+
+  {
+    BiDirectionalLabel Label;
+    tbnz(Reg::r29, 63, &Label);
+    Bind(&Label);
+    dc32(0);
+
+    CHECK(DisassembleEncoding(0) == 0xb7f8003d);
+  }
+}

--- a/External/FEXCore/unittests/Emitter/CMakeLists.txt
+++ b/External/FEXCore/unittests/Emitter/CMakeLists.txt
@@ -1,0 +1,24 @@
+if (ENABLE_VIXL_DISASSEMBLER)
+  file(GLOB_RECURSE TESTS CONFIGURE_DEPENDS *.cpp)
+
+  set (LIBS fmt::fmt vixl Catch2::Catch2WithMain FEXCore_Base)
+  foreach(TEST ${TESTS})
+    get_filename_component(TEST_NAME ${TEST} NAME_WLE)
+    add_executable(Emitter_${TEST_NAME} ${TEST})
+    target_link_libraries(Emitter_${TEST_NAME} PRIVATE ${LIBS})
+    target_include_directories(Emitter_${TEST_NAME} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../../Source/")
+    set_target_properties(Emitter_${TEST_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/EmitterTests")
+    catch_discover_tests(Emitter_${TEST_NAME} TEST_SUFFIX ".${TEST_NAME}.Emitter")
+  endforeach()
+
+  execute_process(COMMAND "nproc" OUTPUT_VARIABLE CORES)
+  string(STRIP ${CORES} CORES)
+
+  add_custom_target(
+    emitter_tests
+    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/"
+    USES_TERMINAL
+    COMMAND "ctest" "--timeout" "302" "-j${CORES}" "-R" "\.*.Emitter$$")
+else()
+  message(AUTHOR_WARNING "Tests are enabled but vixl disassembler is not. Emitter tests won't be built.")
+endif()

--- a/External/FEXCore/unittests/Emitter/Loadstore_Tests.cpp
+++ b/External/FEXCore/unittests/Emitter/Loadstore_Tests.cpp
@@ -1,0 +1,2060 @@
+#include "TestDisassembler.h"
+
+#include <catch2/catch.hpp>
+#include <fcntl.h>
+
+using namespace FEXCore::ARMEmitter;
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Compare and swap pair") {
+  TEST_SINGLE(casp(Size::i32Bit, Reg::r28, Reg::r29, Reg::r26, Reg::r27, Reg::r30), "casp w28, w29, w26, w27, [x30]");
+  TEST_SINGLE(casp(Size::i64Bit, Reg::r28, Reg::r29, Reg::r26, Reg::r27, Reg::r30), "casp x28, x29, x26, x27, [x30]");
+
+  TEST_SINGLE(caspa(Size::i32Bit, Reg::r28, Reg::r29, Reg::r26, Reg::r27, Reg::r30), "caspa w28, w29, w26, w27, [x30]");
+  TEST_SINGLE(caspa(Size::i64Bit, Reg::r28, Reg::r29, Reg::r26, Reg::r27, Reg::r30), "caspa x28, x29, x26, x27, [x30]");
+
+  TEST_SINGLE(caspl(Size::i32Bit, Reg::r28, Reg::r29, Reg::r26, Reg::r27, Reg::r30), "caspl w28, w29, w26, w27, [x30]");
+  TEST_SINGLE(caspl(Size::i64Bit, Reg::r28, Reg::r29, Reg::r26, Reg::r27, Reg::r30), "caspl x28, x29, x26, x27, [x30]");
+
+  TEST_SINGLE(caspal(Size::i32Bit, Reg::r28, Reg::r29, Reg::r26, Reg::r27, Reg::r30), "caspal w28, w29, w26, w27, [x30]");
+  TEST_SINGLE(caspal(Size::i64Bit, Reg::r28, Reg::r29, Reg::r26, Reg::r27, Reg::r30), "caspal x28, x29, x26, x27, [x30]");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Advanced SIMD load/store multiple structures") {
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(QReg::q26, Reg::r30), "ld1 {v26.16b}, [x30]");
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(DReg::d26, Reg::r30), "ld1 {v26.8b}, [x30]");
+
+  TEST_SINGLE(ld1<SubRegSize::i16Bit>(QReg::q26, Reg::r30), "ld1 {v26.8h}, [x30]");
+  TEST_SINGLE(ld1<SubRegSize::i16Bit>(DReg::d26, Reg::r30), "ld1 {v26.4h}, [x30]");
+
+  TEST_SINGLE(ld1<SubRegSize::i32Bit>(QReg::q26, Reg::r30), "ld1 {v26.4s}, [x30]");
+  TEST_SINGLE(ld1<SubRegSize::i32Bit>(DReg::d26, Reg::r30), "ld1 {v26.2s}, [x30]");
+
+  TEST_SINGLE(ld1<SubRegSize::i64Bit>(QReg::q26, Reg::r30), "ld1 {v26.2d}, [x30]");
+  TEST_SINGLE(ld1<SubRegSize::i64Bit>(DReg::d26, Reg::r30), "ld1 {v26.1d}, [x30]");
+
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(QReg::q26, QReg::q27, Reg::r30), "ld1 {v26.16b, v27.16b}, [x30]");
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(DReg::d26, DReg::d27, Reg::r30), "ld1 {v26.8b, v27.8b}, [x30]");
+
+  TEST_SINGLE(ld1<SubRegSize::i16Bit>(QReg::q26, QReg::q27, Reg::r30), "ld1 {v26.8h, v27.8h}, [x30]");
+  TEST_SINGLE(ld1<SubRegSize::i16Bit>(DReg::d26, DReg::d27, Reg::r30), "ld1 {v26.4h, v27.4h}, [x30]");
+
+  TEST_SINGLE(ld1<SubRegSize::i32Bit>(QReg::q26, QReg::q27, Reg::r30), "ld1 {v26.4s, v27.4s}, [x30]");
+  TEST_SINGLE(ld1<SubRegSize::i32Bit>(DReg::d26, DReg::d27, Reg::r30), "ld1 {v26.2s, v27.2s}, [x30]");
+
+  TEST_SINGLE(ld1<SubRegSize::i64Bit>(QReg::q26, QReg::q27, Reg::r30), "ld1 {v26.2d, v27.2d}, [x30]");
+  TEST_SINGLE(ld1<SubRegSize::i64Bit>(DReg::d26, DReg::d27, Reg::r30), "ld1 {v26.1d, v27.1d}, [x30]");
+
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30), "ld1 {v26.16b, v27.16b, v28.16b}, [x30]");
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30), "ld1 {v26.8b, v27.8b, v28.8b}, [x30]");
+
+  TEST_SINGLE(ld1<SubRegSize::i16Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30), "ld1 {v26.8h, v27.8h, v28.8h}, [x30]");
+  TEST_SINGLE(ld1<SubRegSize::i16Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30), "ld1 {v26.4h, v27.4h, v28.4h}, [x30]");
+
+  TEST_SINGLE(ld1<SubRegSize::i32Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30), "ld1 {v26.4s, v27.4s, v28.4s}, [x30]");
+  TEST_SINGLE(ld1<SubRegSize::i32Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30), "ld1 {v26.2s, v27.2s, v28.2s}, [x30]");
+
+  TEST_SINGLE(ld1<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30), "ld1 {v26.2d, v27.2d, v28.2d}, [x30]");
+  TEST_SINGLE(ld1<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30), "ld1 {v26.1d, v27.1d, v28.1d}, [x30]");
+
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30), "ld1 {v26.16b, v27.16b, v28.16b, v29.16b}, [x30]");
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30), "ld1 {v26.8b, v27.8b, v28.8b, v29.8b}, [x30]");
+
+  TEST_SINGLE(ld1<SubRegSize::i16Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30), "ld1 {v26.8h, v27.8h, v28.8h, v29.8h}, [x30]");
+  TEST_SINGLE(ld1<SubRegSize::i16Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30), "ld1 {v26.4h, v27.4h, v28.4h, v29.4h}, [x30]");
+
+  TEST_SINGLE(ld1<SubRegSize::i32Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30), "ld1 {v26.4s, v27.4s, v28.4s, v29.4s}, [x30]");
+  TEST_SINGLE(ld1<SubRegSize::i32Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30), "ld1 {v26.2s, v27.2s, v28.2s, v29.2s}, [x30]");
+
+  TEST_SINGLE(ld1<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30), "ld1 {v26.2d, v27.2d, v28.2d, v29.2d}, [x30]");
+  TEST_SINGLE(ld1<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30), "ld1 {v26.1d, v27.1d, v28.1d, v29.1d}, [x30]");
+
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(QReg::q26, Reg::r30), "st1 {v26.16b}, [x30]");
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(DReg::d26, Reg::r30), "st1 {v26.8b}, [x30]");
+
+  TEST_SINGLE(st1<SubRegSize::i16Bit>(QReg::q26, Reg::r30), "st1 {v26.8h}, [x30]");
+  TEST_SINGLE(st1<SubRegSize::i16Bit>(DReg::d26, Reg::r30), "st1 {v26.4h}, [x30]");
+
+  TEST_SINGLE(st1<SubRegSize::i32Bit>(QReg::q26, Reg::r30), "st1 {v26.4s}, [x30]");
+  TEST_SINGLE(st1<SubRegSize::i32Bit>(DReg::d26, Reg::r30), "st1 {v26.2s}, [x30]");
+
+  TEST_SINGLE(st1<SubRegSize::i64Bit>(QReg::q26, Reg::r30), "st1 {v26.2d}, [x30]");
+  TEST_SINGLE(st1<SubRegSize::i64Bit>(DReg::d26, Reg::r30), "st1 {v26.1d}, [x30]");
+
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(QReg::q26, QReg::q27, Reg::r30), "st1 {v26.16b, v27.16b}, [x30]");
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(DReg::d26, DReg::d27, Reg::r30), "st1 {v26.8b, v27.8b}, [x30]");
+
+  TEST_SINGLE(st1<SubRegSize::i16Bit>(QReg::q26, QReg::q27, Reg::r30), "st1 {v26.8h, v27.8h}, [x30]");
+  TEST_SINGLE(st1<SubRegSize::i16Bit>(DReg::d26, DReg::d27, Reg::r30), "st1 {v26.4h, v27.4h}, [x30]");
+
+  TEST_SINGLE(st1<SubRegSize::i32Bit>(QReg::q26, QReg::q27, Reg::r30), "st1 {v26.4s, v27.4s}, [x30]");
+  TEST_SINGLE(st1<SubRegSize::i32Bit>(DReg::d26, DReg::d27, Reg::r30), "st1 {v26.2s, v27.2s}, [x30]");
+
+  TEST_SINGLE(st1<SubRegSize::i64Bit>(QReg::q26, QReg::q27, Reg::r30), "st1 {v26.2d, v27.2d}, [x30]");
+  TEST_SINGLE(st1<SubRegSize::i64Bit>(DReg::d26, DReg::d27, Reg::r30), "st1 {v26.1d, v27.1d}, [x30]");
+
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30), "st1 {v26.16b, v27.16b, v28.16b}, [x30]");
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30), "st1 {v26.8b, v27.8b, v28.8b}, [x30]");
+
+  TEST_SINGLE(st1<SubRegSize::i16Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30), "st1 {v26.8h, v27.8h, v28.8h}, [x30]");
+  TEST_SINGLE(st1<SubRegSize::i16Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30), "st1 {v26.4h, v27.4h, v28.4h}, [x30]");
+
+  TEST_SINGLE(st1<SubRegSize::i32Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30), "st1 {v26.4s, v27.4s, v28.4s}, [x30]");
+  TEST_SINGLE(st1<SubRegSize::i32Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30), "st1 {v26.2s, v27.2s, v28.2s}, [x30]");
+
+  TEST_SINGLE(st1<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30), "st1 {v26.2d, v27.2d, v28.2d}, [x30]");
+  TEST_SINGLE(st1<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30), "st1 {v26.1d, v27.1d, v28.1d}, [x30]");
+
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30), "st1 {v26.16b, v27.16b, v28.16b, v29.16b}, [x30]");
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30), "st1 {v26.8b, v27.8b, v28.8b, v29.8b}, [x30]");
+
+  TEST_SINGLE(st1<SubRegSize::i16Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30), "st1 {v26.8h, v27.8h, v28.8h, v29.8h}, [x30]");
+  TEST_SINGLE(st1<SubRegSize::i16Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30), "st1 {v26.4h, v27.4h, v28.4h, v29.4h}, [x30]");
+
+  TEST_SINGLE(st1<SubRegSize::i32Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30), "st1 {v26.4s, v27.4s, v28.4s, v29.4s}, [x30]");
+  TEST_SINGLE(st1<SubRegSize::i32Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30), "st1 {v26.2s, v27.2s, v28.2s, v29.2s}, [x30]");
+
+  TEST_SINGLE(st1<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30), "st1 {v26.2d, v27.2d, v28.2d, v29.2d}, [x30]");
+  TEST_SINGLE(st1<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30), "st1 {v26.1d, v27.1d, v28.1d, v29.1d}, [x30]");
+
+  TEST_SINGLE(ld2<SubRegSize::i8Bit>(QReg::q26, QReg::q27, Reg::r30), "ld2 {v26.16b, v27.16b}, [x30]");
+  TEST_SINGLE(ld2<SubRegSize::i8Bit>(DReg::d26, DReg::d27, Reg::r30), "ld2 {v26.8b, v27.8b}, [x30]");
+
+  TEST_SINGLE(ld2<SubRegSize::i16Bit>(QReg::q26, QReg::q27, Reg::r30), "ld2 {v26.8h, v27.8h}, [x30]");
+  TEST_SINGLE(ld2<SubRegSize::i16Bit>(DReg::d26, DReg::d27, Reg::r30), "ld2 {v26.4h, v27.4h}, [x30]");
+
+  TEST_SINGLE(ld2<SubRegSize::i32Bit>(QReg::q26, QReg::q27, Reg::r30), "ld2 {v26.4s, v27.4s}, [x30]");
+  TEST_SINGLE(ld2<SubRegSize::i32Bit>(DReg::d26, DReg::d27, Reg::r30), "ld2 {v26.2s, v27.2s}, [x30]");
+
+  TEST_SINGLE(ld2<SubRegSize::i64Bit>(QReg::q26, QReg::q27, Reg::r30), "ld2 {v26.2d, v27.2d}, [x30]");
+  TEST_SINGLE(ld2<SubRegSize::i64Bit>(DReg::d26, DReg::d27, Reg::r30), "unallocated (NEONLoadStoreMultiStruct)");
+
+  TEST_SINGLE(st2<SubRegSize::i8Bit>(QReg::q26, QReg::q27, Reg::r30), "st2 {v26.16b, v27.16b}, [x30]");
+  TEST_SINGLE(st2<SubRegSize::i8Bit>(DReg::d26, DReg::d27, Reg::r30), "st2 {v26.8b, v27.8b}, [x30]");
+
+  TEST_SINGLE(st2<SubRegSize::i16Bit>(QReg::q26, QReg::q27, Reg::r30), "st2 {v26.8h, v27.8h}, [x30]");
+  TEST_SINGLE(st2<SubRegSize::i16Bit>(DReg::d26, DReg::d27, Reg::r30), "st2 {v26.4h, v27.4h}, [x30]");
+
+  TEST_SINGLE(st2<SubRegSize::i32Bit>(QReg::q26, QReg::q27, Reg::r30), "st2 {v26.4s, v27.4s}, [x30]");
+  TEST_SINGLE(st2<SubRegSize::i32Bit>(DReg::d26, DReg::d27, Reg::r30), "st2 {v26.2s, v27.2s}, [x30]");
+
+  TEST_SINGLE(st2<SubRegSize::i64Bit>(QReg::q26, QReg::q27, Reg::r30), "st2 {v26.2d, v27.2d}, [x30]");
+  TEST_SINGLE(st2<SubRegSize::i64Bit>(DReg::d26, DReg::d27, Reg::r30), "unallocated (NEONLoadStoreMultiStruct)");
+
+  TEST_SINGLE(ld3<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30), "ld3 {v26.16b, v27.16b, v28.16b}, [x30]");
+  TEST_SINGLE(ld3<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30), "ld3 {v26.8b, v27.8b, v28.8b}, [x30]");
+
+  TEST_SINGLE(ld3<SubRegSize::i16Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30), "ld3 {v26.8h, v27.8h, v28.8h}, [x30]");
+  TEST_SINGLE(ld3<SubRegSize::i16Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30), "ld3 {v26.4h, v27.4h, v28.4h}, [x30]");
+
+  TEST_SINGLE(ld3<SubRegSize::i32Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30), "ld3 {v26.4s, v27.4s, v28.4s}, [x30]");
+  TEST_SINGLE(ld3<SubRegSize::i32Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30), "ld3 {v26.2s, v27.2s, v28.2s}, [x30]");
+
+  TEST_SINGLE(ld3<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30), "ld3 {v26.2d, v27.2d, v28.2d}, [x30]");
+  TEST_SINGLE(ld3<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30), "unallocated (NEONLoadStoreMultiStruct)");
+
+  TEST_SINGLE(st3<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30), "st3 {v26.16b, v27.16b, v28.16b}, [x30]");
+  TEST_SINGLE(st3<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30), "st3 {v26.8b, v27.8b, v28.8b}, [x30]");
+
+  TEST_SINGLE(st3<SubRegSize::i16Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30), "st3 {v26.8h, v27.8h, v28.8h}, [x30]");
+  TEST_SINGLE(st3<SubRegSize::i16Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30), "st3 {v26.4h, v27.4h, v28.4h}, [x30]");
+
+  TEST_SINGLE(st3<SubRegSize::i32Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30), "st3 {v26.4s, v27.4s, v28.4s}, [x30]");
+  TEST_SINGLE(st3<SubRegSize::i32Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30), "st3 {v26.2s, v27.2s, v28.2s}, [x30]");
+
+  TEST_SINGLE(st3<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30), "st3 {v26.2d, v27.2d, v28.2d}, [x30]");
+  TEST_SINGLE(st3<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30), "unallocated (NEONLoadStoreMultiStruct)");
+
+  TEST_SINGLE(ld4<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30), "ld4 {v26.16b, v27.16b, v28.16b, v29.16b}, [x30]");
+  TEST_SINGLE(ld4<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30), "ld4 {v26.8b, v27.8b, v28.8b, v29.8b}, [x30]");
+
+  TEST_SINGLE(ld4<SubRegSize::i16Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30), "ld4 {v26.8h, v27.8h, v28.8h, v29.8h}, [x30]");
+  TEST_SINGLE(ld4<SubRegSize::i16Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30), "ld4 {v26.4h, v27.4h, v28.4h, v29.4h}, [x30]");
+
+  TEST_SINGLE(ld4<SubRegSize::i32Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30), "ld4 {v26.4s, v27.4s, v28.4s, v29.4s}, [x30]");
+  TEST_SINGLE(ld4<SubRegSize::i32Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30), "ld4 {v26.2s, v27.2s, v28.2s, v29.2s}, [x30]");
+
+  TEST_SINGLE(ld4<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30), "ld4 {v26.2d, v27.2d, v28.2d, v29.2d}, [x30]");
+  TEST_SINGLE(ld4<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30), "unallocated (NEONLoadStoreMultiStruct)");
+
+  TEST_SINGLE(st4<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30), "st4 {v26.16b, v27.16b, v28.16b, v29.16b}, [x30]");
+  TEST_SINGLE(st4<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30), "st4 {v26.8b, v27.8b, v28.8b, v29.8b}, [x30]");
+
+  TEST_SINGLE(st4<SubRegSize::i16Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30), "st4 {v26.8h, v27.8h, v28.8h, v29.8h}, [x30]");
+  TEST_SINGLE(st4<SubRegSize::i16Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30), "st4 {v26.4h, v27.4h, v28.4h, v29.4h}, [x30]");
+
+  TEST_SINGLE(st4<SubRegSize::i32Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30), "st4 {v26.4s, v27.4s, v28.4s, v29.4s}, [x30]");
+  TEST_SINGLE(st4<SubRegSize::i32Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30), "st4 {v26.2s, v27.2s, v28.2s, v29.2s}, [x30]");
+
+  TEST_SINGLE(st4<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30), "st4 {v26.2d, v27.2d, v28.2d, v29.2d}, [x30]");
+  TEST_SINGLE(st4<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30), "unallocated (NEONLoadStoreMultiStruct)");
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Advanced SIMD load/store multiple structures (post-indexed)") {
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(QReg::q26, Reg::r30, Reg::r29), "ld1 {v26.16b}, [x30], x29");
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(DReg::d26, Reg::r30, Reg::r29), "ld1 {v26.8b}, [x30], x29");
+
+  TEST_SINGLE(ld1<SubRegSize::i16Bit>(QReg::q26, Reg::r30, Reg::r29), "ld1 {v26.8h}, [x30], x29");
+  TEST_SINGLE(ld1<SubRegSize::i16Bit>(DReg::d26, Reg::r30, Reg::r29), "ld1 {v26.4h}, [x30], x29");
+
+  TEST_SINGLE(ld1<SubRegSize::i32Bit>(QReg::q26, Reg::r30, Reg::r29), "ld1 {v26.4s}, [x30], x29");
+  TEST_SINGLE(ld1<SubRegSize::i32Bit>(DReg::d26, Reg::r30, Reg::r29), "ld1 {v26.2s}, [x30], x29");
+
+  TEST_SINGLE(ld1<SubRegSize::i64Bit>(QReg::q26, Reg::r30, Reg::r29), "ld1 {v26.2d}, [x30], x29");
+  TEST_SINGLE(ld1<SubRegSize::i64Bit>(DReg::d26, Reg::r30, Reg::r29), "ld1 {v26.1d}, [x30], x29");
+
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(QReg::q26, Reg::r30, 16), "ld1 {v26.16b}, [x30], #16");
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(DReg::d26, Reg::r30, 8), "ld1 {v26.8b}, [x30], #8");
+
+  TEST_SINGLE(ld1<SubRegSize::i16Bit>(QReg::q26, Reg::r30, 16), "ld1 {v26.8h}, [x30], #16");
+  TEST_SINGLE(ld1<SubRegSize::i16Bit>(DReg::d26, Reg::r30, 8), "ld1 {v26.4h}, [x30], #8");
+
+  TEST_SINGLE(ld1<SubRegSize::i32Bit>(QReg::q26, Reg::r30, 16), "ld1 {v26.4s}, [x30], #16");
+  TEST_SINGLE(ld1<SubRegSize::i32Bit>(DReg::d26, Reg::r30, 8), "ld1 {v26.2s}, [x30], #8");
+
+  TEST_SINGLE(ld1<SubRegSize::i64Bit>(QReg::q26, Reg::r30, 16), "ld1 {v26.2d}, [x30], #16");
+  TEST_SINGLE(ld1<SubRegSize::i64Bit>(DReg::d26, Reg::r30, 8), "ld1 {v26.1d}, [x30], #8");
+
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(QReg::q26, QReg::q27, Reg::r30, Reg::r29), "ld1 {v26.16b, v27.16b}, [x30], x29");
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(DReg::d26, DReg::d27, Reg::r30, Reg::r29), "ld1 {v26.8b, v27.8b}, [x30], x29");
+
+  TEST_SINGLE(ld1<SubRegSize::i16Bit>(QReg::q26, QReg::q27, Reg::r30, Reg::r29), "ld1 {v26.8h, v27.8h}, [x30], x29");
+  TEST_SINGLE(ld1<SubRegSize::i16Bit>(DReg::d26, DReg::d27, Reg::r30, Reg::r29), "ld1 {v26.4h, v27.4h}, [x30], x29");
+
+  TEST_SINGLE(ld1<SubRegSize::i32Bit>(QReg::q26, QReg::q27, Reg::r30, Reg::r29), "ld1 {v26.4s, v27.4s}, [x30], x29");
+  TEST_SINGLE(ld1<SubRegSize::i32Bit>(DReg::d26, DReg::d27, Reg::r30, Reg::r29), "ld1 {v26.2s, v27.2s}, [x30], x29");
+
+  TEST_SINGLE(ld1<SubRegSize::i64Bit>(QReg::q26, QReg::q27, Reg::r30, Reg::r29), "ld1 {v26.2d, v27.2d}, [x30], x29");
+  TEST_SINGLE(ld1<SubRegSize::i64Bit>(DReg::d26, DReg::d27, Reg::r30, Reg::r29), "ld1 {v26.1d, v27.1d}, [x30], x29");
+
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(QReg::q26, QReg::q27, Reg::r30, 32), "ld1 {v26.16b, v27.16b}, [x30], #32");
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(DReg::d26, DReg::d27, Reg::r30, 16), "ld1 {v26.8b, v27.8b}, [x30], #16");
+
+  TEST_SINGLE(ld1<SubRegSize::i16Bit>(QReg::q26, QReg::q27, Reg::r30, 32), "ld1 {v26.8h, v27.8h}, [x30], #32");
+  TEST_SINGLE(ld1<SubRegSize::i16Bit>(DReg::d26, DReg::d27, Reg::r30, 16), "ld1 {v26.4h, v27.4h}, [x30], #16");
+
+  TEST_SINGLE(ld1<SubRegSize::i32Bit>(QReg::q26, QReg::q27, Reg::r30, 32), "ld1 {v26.4s, v27.4s}, [x30], #32");
+  TEST_SINGLE(ld1<SubRegSize::i32Bit>(DReg::d26, DReg::d27, Reg::r30, 16), "ld1 {v26.2s, v27.2s}, [x30], #16");
+
+  TEST_SINGLE(ld1<SubRegSize::i64Bit>(QReg::q26, QReg::q27, Reg::r30, 32), "ld1 {v26.2d, v27.2d}, [x30], #32");
+  TEST_SINGLE(ld1<SubRegSize::i64Bit>(DReg::d26, DReg::d27, Reg::r30, 16), "ld1 {v26.1d, v27.1d}, [x30], #16");
+
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, Reg::r29), "ld1 {v26.16b, v27.16b, v28.16b}, [x30], x29");
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, Reg::r29), "ld1 {v26.8b, v27.8b, v28.8b}, [x30], x29");
+
+  TEST_SINGLE(ld1<SubRegSize::i16Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, Reg::r29), "ld1 {v26.8h, v27.8h, v28.8h}, [x30], x29");
+  TEST_SINGLE(ld1<SubRegSize::i16Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, Reg::r29), "ld1 {v26.4h, v27.4h, v28.4h}, [x30], x29");
+
+  TEST_SINGLE(ld1<SubRegSize::i32Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, Reg::r29), "ld1 {v26.4s, v27.4s, v28.4s}, [x30], x29");
+  TEST_SINGLE(ld1<SubRegSize::i32Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, Reg::r29), "ld1 {v26.2s, v27.2s, v28.2s}, [x30], x29");
+
+  TEST_SINGLE(ld1<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, Reg::r29), "ld1 {v26.2d, v27.2d, v28.2d}, [x30], x29");
+  TEST_SINGLE(ld1<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, Reg::r29), "ld1 {v26.1d, v27.1d, v28.1d}, [x30], x29");
+
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, 48), "ld1 {v26.16b, v27.16b, v28.16b}, [x30], #48");
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, 24), "ld1 {v26.8b, v27.8b, v28.8b}, [x30], #24");
+
+  TEST_SINGLE(ld1<SubRegSize::i16Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, 48), "ld1 {v26.8h, v27.8h, v28.8h}, [x30], #48");
+  TEST_SINGLE(ld1<SubRegSize::i16Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, 24), "ld1 {v26.4h, v27.4h, v28.4h}, [x30], #24");
+
+  TEST_SINGLE(ld1<SubRegSize::i32Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, 48), "ld1 {v26.4s, v27.4s, v28.4s}, [x30], #48");
+  TEST_SINGLE(ld1<SubRegSize::i32Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, 24), "ld1 {v26.2s, v27.2s, v28.2s}, [x30], #24");
+
+  TEST_SINGLE(ld1<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, 48), "ld1 {v26.2d, v27.2d, v28.2d}, [x30], #48");
+  TEST_SINGLE(ld1<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, 24), "ld1 {v26.1d, v27.1d, v28.1d}, [x30], #24");
+
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, Reg::r29), "ld1 {v26.16b, v27.16b, v28.16b, v29.16b}, [x30], x29");
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, Reg::r29), "ld1 {v26.8b, v27.8b, v28.8b, v29.8b}, [x30], x29");
+
+  TEST_SINGLE(ld1<SubRegSize::i16Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, Reg::r29), "ld1 {v26.8h, v27.8h, v28.8h, v29.8h}, [x30], x29");
+  TEST_SINGLE(ld1<SubRegSize::i16Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, Reg::r29), "ld1 {v26.4h, v27.4h, v28.4h, v29.4h}, [x30], x29");
+
+  TEST_SINGLE(ld1<SubRegSize::i32Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, Reg::r29), "ld1 {v26.4s, v27.4s, v28.4s, v29.4s}, [x30], x29");
+  TEST_SINGLE(ld1<SubRegSize::i32Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, Reg::r29), "ld1 {v26.2s, v27.2s, v28.2s, v29.2s}, [x30], x29");
+
+  TEST_SINGLE(ld1<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, Reg::r29), "ld1 {v26.2d, v27.2d, v28.2d, v29.2d}, [x30], x29");
+  TEST_SINGLE(ld1<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, Reg::r29), "ld1 {v26.1d, v27.1d, v28.1d, v29.1d}, [x30], x29");
+
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, 64), "ld1 {v26.16b, v27.16b, v28.16b, v29.16b}, [x30], #64");
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, 32), "ld1 {v26.8b, v27.8b, v28.8b, v29.8b}, [x30], #32");
+
+  TEST_SINGLE(ld1<SubRegSize::i16Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, 64), "ld1 {v26.8h, v27.8h, v28.8h, v29.8h}, [x30], #64");
+  TEST_SINGLE(ld1<SubRegSize::i16Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, 32), "ld1 {v26.4h, v27.4h, v28.4h, v29.4h}, [x30], #32");
+
+  TEST_SINGLE(ld1<SubRegSize::i32Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, 64), "ld1 {v26.4s, v27.4s, v28.4s, v29.4s}, [x30], #64");
+  TEST_SINGLE(ld1<SubRegSize::i32Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, 32), "ld1 {v26.2s, v27.2s, v28.2s, v29.2s}, [x30], #32");
+
+  TEST_SINGLE(ld1<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, 64), "ld1 {v26.2d, v27.2d, v28.2d, v29.2d}, [x30], #64");
+  TEST_SINGLE(ld1<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, 32), "ld1 {v26.1d, v27.1d, v28.1d, v29.1d}, [x30], #32");
+
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(QReg::q26, Reg::r30, Reg::r29), "st1 {v26.16b}, [x30], x29");
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(DReg::d26, Reg::r30, Reg::r29), "st1 {v26.8b}, [x30], x29");
+
+  TEST_SINGLE(st1<SubRegSize::i16Bit>(QReg::q26, Reg::r30, Reg::r29), "st1 {v26.8h}, [x30], x29");
+  TEST_SINGLE(st1<SubRegSize::i16Bit>(DReg::d26, Reg::r30, Reg::r29), "st1 {v26.4h}, [x30], x29");
+
+  TEST_SINGLE(st1<SubRegSize::i32Bit>(QReg::q26, Reg::r30, Reg::r29), "st1 {v26.4s}, [x30], x29");
+  TEST_SINGLE(st1<SubRegSize::i32Bit>(DReg::d26, Reg::r30, Reg::r29), "st1 {v26.2s}, [x30], x29");
+
+  TEST_SINGLE(st1<SubRegSize::i64Bit>(QReg::q26, Reg::r30, Reg::r29), "st1 {v26.2d}, [x30], x29");
+  TEST_SINGLE(st1<SubRegSize::i64Bit>(DReg::d26, Reg::r30, Reg::r29), "st1 {v26.1d}, [x30], x29");
+
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(QReg::q26, Reg::r30, 16), "st1 {v26.16b}, [x30], #16");
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(DReg::d26, Reg::r30, 8), "st1 {v26.8b}, [x30], #8");
+
+  TEST_SINGLE(st1<SubRegSize::i16Bit>(QReg::q26, Reg::r30, 16), "st1 {v26.8h}, [x30], #16");
+  TEST_SINGLE(st1<SubRegSize::i16Bit>(DReg::d26, Reg::r30, 8), "st1 {v26.4h}, [x30], #8");
+
+  TEST_SINGLE(st1<SubRegSize::i32Bit>(QReg::q26, Reg::r30, 16), "st1 {v26.4s}, [x30], #16");
+  TEST_SINGLE(st1<SubRegSize::i32Bit>(DReg::d26, Reg::r30, 8), "st1 {v26.2s}, [x30], #8");
+
+  TEST_SINGLE(st1<SubRegSize::i64Bit>(QReg::q26, Reg::r30, 16), "st1 {v26.2d}, [x30], #16");
+  TEST_SINGLE(st1<SubRegSize::i64Bit>(DReg::d26, Reg::r30, 8), "st1 {v26.1d}, [x30], #8");
+
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(QReg::q26, QReg::q27, Reg::r30, Reg::r29), "st1 {v26.16b, v27.16b}, [x30], x29");
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(DReg::d26, DReg::d27, Reg::r30, Reg::r29), "st1 {v26.8b, v27.8b}, [x30], x29");
+
+  TEST_SINGLE(st1<SubRegSize::i16Bit>(QReg::q26, QReg::q27, Reg::r30, Reg::r29), "st1 {v26.8h, v27.8h}, [x30], x29");
+  TEST_SINGLE(st1<SubRegSize::i16Bit>(DReg::d26, DReg::d27, Reg::r30, Reg::r29), "st1 {v26.4h, v27.4h}, [x30], x29");
+
+  TEST_SINGLE(st1<SubRegSize::i32Bit>(QReg::q26, QReg::q27, Reg::r30, Reg::r29), "st1 {v26.4s, v27.4s}, [x30], x29");
+  TEST_SINGLE(st1<SubRegSize::i32Bit>(DReg::d26, DReg::d27, Reg::r30, Reg::r29), "st1 {v26.2s, v27.2s}, [x30], x29");
+
+  TEST_SINGLE(st1<SubRegSize::i64Bit>(QReg::q26, QReg::q27, Reg::r30, Reg::r29), "st1 {v26.2d, v27.2d}, [x30], x29");
+  TEST_SINGLE(st1<SubRegSize::i64Bit>(DReg::d26, DReg::d27, Reg::r30, Reg::r29), "st1 {v26.1d, v27.1d}, [x30], x29");
+
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(QReg::q26, QReg::q27, Reg::r30, 32), "st1 {v26.16b, v27.16b}, [x30], #32");
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(DReg::d26, DReg::d27, Reg::r30, 16), "st1 {v26.8b, v27.8b}, [x30], #16");
+
+  TEST_SINGLE(st1<SubRegSize::i16Bit>(QReg::q26, QReg::q27, Reg::r30, 32), "st1 {v26.8h, v27.8h}, [x30], #32");
+  TEST_SINGLE(st1<SubRegSize::i16Bit>(DReg::d26, DReg::d27, Reg::r30, 16), "st1 {v26.4h, v27.4h}, [x30], #16");
+
+  TEST_SINGLE(st1<SubRegSize::i32Bit>(QReg::q26, QReg::q27, Reg::r30, 32), "st1 {v26.4s, v27.4s}, [x30], #32");
+  TEST_SINGLE(st1<SubRegSize::i32Bit>(DReg::d26, DReg::d27, Reg::r30, 16), "st1 {v26.2s, v27.2s}, [x30], #16");
+
+  TEST_SINGLE(st1<SubRegSize::i64Bit>(QReg::q26, QReg::q27, Reg::r30, 32), "st1 {v26.2d, v27.2d}, [x30], #32");
+  TEST_SINGLE(st1<SubRegSize::i64Bit>(DReg::d26, DReg::d27, Reg::r30, 16), "st1 {v26.1d, v27.1d}, [x30], #16");
+
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, Reg::r29), "st1 {v26.16b, v27.16b, v28.16b}, [x30], x29");
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, Reg::r29), "st1 {v26.8b, v27.8b, v28.8b}, [x30], x29");
+
+  TEST_SINGLE(st1<SubRegSize::i16Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, Reg::r29), "st1 {v26.8h, v27.8h, v28.8h}, [x30], x29");
+  TEST_SINGLE(st1<SubRegSize::i16Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, Reg::r29), "st1 {v26.4h, v27.4h, v28.4h}, [x30], x29");
+
+  TEST_SINGLE(st1<SubRegSize::i32Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, Reg::r29), "st1 {v26.4s, v27.4s, v28.4s}, [x30], x29");
+  TEST_SINGLE(st1<SubRegSize::i32Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, Reg::r29), "st1 {v26.2s, v27.2s, v28.2s}, [x30], x29");
+
+  TEST_SINGLE(st1<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, Reg::r29), "st1 {v26.2d, v27.2d, v28.2d}, [x30], x29");
+  TEST_SINGLE(st1<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, Reg::r29), "st1 {v26.1d, v27.1d, v28.1d}, [x30], x29");
+
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, 48), "st1 {v26.16b, v27.16b, v28.16b}, [x30], #48");
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, 24), "st1 {v26.8b, v27.8b, v28.8b}, [x30], #24");
+
+  TEST_SINGLE(st1<SubRegSize::i16Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, 48), "st1 {v26.8h, v27.8h, v28.8h}, [x30], #48");
+  TEST_SINGLE(st1<SubRegSize::i16Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, 24), "st1 {v26.4h, v27.4h, v28.4h}, [x30], #24");
+
+  TEST_SINGLE(st1<SubRegSize::i32Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, 48), "st1 {v26.4s, v27.4s, v28.4s}, [x30], #48");
+  TEST_SINGLE(st1<SubRegSize::i32Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, 24), "st1 {v26.2s, v27.2s, v28.2s}, [x30], #24");
+
+  TEST_SINGLE(st1<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, 48), "st1 {v26.2d, v27.2d, v28.2d}, [x30], #48");
+  TEST_SINGLE(st1<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, 24), "st1 {v26.1d, v27.1d, v28.1d}, [x30], #24");
+
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, Reg::r29), "st1 {v26.16b, v27.16b, v28.16b, v29.16b}, [x30], x29");
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, Reg::r29), "st1 {v26.8b, v27.8b, v28.8b, v29.8b}, [x30], x29");
+
+  TEST_SINGLE(st1<SubRegSize::i16Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, Reg::r29), "st1 {v26.8h, v27.8h, v28.8h, v29.8h}, [x30], x29");
+  TEST_SINGLE(st1<SubRegSize::i16Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, Reg::r29), "st1 {v26.4h, v27.4h, v28.4h, v29.4h}, [x30], x29");
+
+  TEST_SINGLE(st1<SubRegSize::i32Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, Reg::r29), "st1 {v26.4s, v27.4s, v28.4s, v29.4s}, [x30], x29");
+  TEST_SINGLE(st1<SubRegSize::i32Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, Reg::r29), "st1 {v26.2s, v27.2s, v28.2s, v29.2s}, [x30], x29");
+
+  TEST_SINGLE(st1<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, Reg::r29), "st1 {v26.2d, v27.2d, v28.2d, v29.2d}, [x30], x29");
+  TEST_SINGLE(st1<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, Reg::r29), "st1 {v26.1d, v27.1d, v28.1d, v29.1d}, [x30], x29");
+
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, 64), "st1 {v26.16b, v27.16b, v28.16b, v29.16b}, [x30], #64");
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, 32), "st1 {v26.8b, v27.8b, v28.8b, v29.8b}, [x30], #32");
+
+  TEST_SINGLE(st1<SubRegSize::i16Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, 64), "st1 {v26.8h, v27.8h, v28.8h, v29.8h}, [x30], #64");
+  TEST_SINGLE(st1<SubRegSize::i16Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, 32), "st1 {v26.4h, v27.4h, v28.4h, v29.4h}, [x30], #32");
+
+  TEST_SINGLE(st1<SubRegSize::i32Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, 64), "st1 {v26.4s, v27.4s, v28.4s, v29.4s}, [x30], #64");
+  TEST_SINGLE(st1<SubRegSize::i32Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, 32), "st1 {v26.2s, v27.2s, v28.2s, v29.2s}, [x30], #32");
+
+  TEST_SINGLE(st1<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, 64), "st1 {v26.2d, v27.2d, v28.2d, v29.2d}, [x30], #64");
+  TEST_SINGLE(st1<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, 32), "st1 {v26.1d, v27.1d, v28.1d, v29.1d}, [x30], #32");
+
+  TEST_SINGLE(ld2<SubRegSize::i8Bit>(QReg::q26, QReg::q27, Reg::r30, Reg::r29), "ld2 {v26.16b, v27.16b}, [x30], x29");
+  TEST_SINGLE(ld2<SubRegSize::i8Bit>(DReg::d26, DReg::d27, Reg::r30, Reg::r29), "ld2 {v26.8b, v27.8b}, [x30], x29");
+
+  TEST_SINGLE(ld2<SubRegSize::i16Bit>(QReg::q26, QReg::q27, Reg::r30, Reg::r29), "ld2 {v26.8h, v27.8h}, [x30], x29");
+  TEST_SINGLE(ld2<SubRegSize::i16Bit>(DReg::d26, DReg::d27, Reg::r30, Reg::r29), "ld2 {v26.4h, v27.4h}, [x30], x29");
+
+  TEST_SINGLE(ld2<SubRegSize::i32Bit>(QReg::q26, QReg::q27, Reg::r30, Reg::r29), "ld2 {v26.4s, v27.4s}, [x30], x29");
+  TEST_SINGLE(ld2<SubRegSize::i32Bit>(DReg::d26, DReg::d27, Reg::r30, Reg::r29), "ld2 {v26.2s, v27.2s}, [x30], x29");
+
+  TEST_SINGLE(ld2<SubRegSize::i64Bit>(QReg::q26, QReg::q27, Reg::r30, Reg::r29), "ld2 {v26.2d, v27.2d}, [x30], x29");
+  TEST_SINGLE(ld2<SubRegSize::i64Bit>(DReg::d26, DReg::d27, Reg::r30, Reg::r29), "unallocated (NEONLoadStoreMultiStructPostIndex)");
+
+  TEST_SINGLE(ld2<SubRegSize::i8Bit>(QReg::q26, QReg::q27, Reg::r30, 32), "ld2 {v26.16b, v27.16b}, [x30], #32");
+  TEST_SINGLE(ld2<SubRegSize::i8Bit>(DReg::d26, DReg::d27, Reg::r30, 16), "ld2 {v26.8b, v27.8b}, [x30], #16");
+
+  TEST_SINGLE(ld2<SubRegSize::i16Bit>(QReg::q26, QReg::q27, Reg::r30, 32), "ld2 {v26.8h, v27.8h}, [x30], #32");
+  TEST_SINGLE(ld2<SubRegSize::i16Bit>(DReg::d26, DReg::d27, Reg::r30, 16), "ld2 {v26.4h, v27.4h}, [x30], #16");
+
+  TEST_SINGLE(ld2<SubRegSize::i32Bit>(QReg::q26, QReg::q27, Reg::r30, 32), "ld2 {v26.4s, v27.4s}, [x30], #32");
+  TEST_SINGLE(ld2<SubRegSize::i32Bit>(DReg::d26, DReg::d27, Reg::r30, 16), "ld2 {v26.2s, v27.2s}, [x30], #16");
+
+  TEST_SINGLE(ld2<SubRegSize::i64Bit>(QReg::q26, QReg::q27, Reg::r30, 32), "ld2 {v26.2d, v27.2d}, [x30], #32");
+  TEST_SINGLE(ld2<SubRegSize::i64Bit>(DReg::d26, DReg::d27, Reg::r30, 16), "unallocated (NEONLoadStoreMultiStructPostIndex)");
+
+  TEST_SINGLE(st2<SubRegSize::i8Bit>(QReg::q26, QReg::q27, Reg::r30, Reg::r29), "st2 {v26.16b, v27.16b}, [x30], x29");
+  TEST_SINGLE(st2<SubRegSize::i8Bit>(DReg::d26, DReg::d27, Reg::r30, Reg::r29), "st2 {v26.8b, v27.8b}, [x30], x29");
+
+  TEST_SINGLE(st2<SubRegSize::i16Bit>(QReg::q26, QReg::q27, Reg::r30, Reg::r29), "st2 {v26.8h, v27.8h}, [x30], x29");
+  TEST_SINGLE(st2<SubRegSize::i16Bit>(DReg::d26, DReg::d27, Reg::r30, Reg::r29), "st2 {v26.4h, v27.4h}, [x30], x29");
+
+  TEST_SINGLE(st2<SubRegSize::i32Bit>(QReg::q26, QReg::q27, Reg::r30, Reg::r29), "st2 {v26.4s, v27.4s}, [x30], x29");
+  TEST_SINGLE(st2<SubRegSize::i32Bit>(DReg::d26, DReg::d27, Reg::r30, Reg::r29), "st2 {v26.2s, v27.2s}, [x30], x29");
+
+  TEST_SINGLE(st2<SubRegSize::i64Bit>(QReg::q26, QReg::q27, Reg::r30, Reg::r29), "st2 {v26.2d, v27.2d}, [x30], x29");
+  TEST_SINGLE(st2<SubRegSize::i64Bit>(DReg::d26, DReg::d27, Reg::r30, Reg::r29), "unallocated (NEONLoadStoreMultiStructPostIndex)");
+
+  TEST_SINGLE(st2<SubRegSize::i8Bit>(QReg::q26, QReg::q27, Reg::r30, 32), "st2 {v26.16b, v27.16b}, [x30], #32");
+  TEST_SINGLE(st2<SubRegSize::i8Bit>(DReg::d26, DReg::d27, Reg::r30, 16), "st2 {v26.8b, v27.8b}, [x30], #16");
+
+  TEST_SINGLE(st2<SubRegSize::i16Bit>(QReg::q26, QReg::q27, Reg::r30, 32), "st2 {v26.8h, v27.8h}, [x30], #32");
+  TEST_SINGLE(st2<SubRegSize::i16Bit>(DReg::d26, DReg::d27, Reg::r30, 16), "st2 {v26.4h, v27.4h}, [x30], #16");
+
+  TEST_SINGLE(st2<SubRegSize::i32Bit>(QReg::q26, QReg::q27, Reg::r30, 32), "st2 {v26.4s, v27.4s}, [x30], #32");
+  TEST_SINGLE(st2<SubRegSize::i32Bit>(DReg::d26, DReg::d27, Reg::r30, 16), "st2 {v26.2s, v27.2s}, [x30], #16");
+
+  TEST_SINGLE(st2<SubRegSize::i64Bit>(QReg::q26, QReg::q27, Reg::r30, 32), "st2 {v26.2d, v27.2d}, [x30], #32");
+  TEST_SINGLE(st2<SubRegSize::i64Bit>(DReg::d26, DReg::d27, Reg::r30, 16), "unallocated (NEONLoadStoreMultiStructPostIndex)");
+
+  TEST_SINGLE(ld3<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, Reg::r29), "ld3 {v26.16b, v27.16b, v28.16b}, [x30], x29");
+  TEST_SINGLE(ld3<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, Reg::r29), "ld3 {v26.8b, v27.8b, v28.8b}, [x30], x29");
+
+  TEST_SINGLE(ld3<SubRegSize::i16Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, Reg::r29), "ld3 {v26.8h, v27.8h, v28.8h}, [x30], x29");
+  TEST_SINGLE(ld3<SubRegSize::i16Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, Reg::r29), "ld3 {v26.4h, v27.4h, v28.4h}, [x30], x29");
+
+  TEST_SINGLE(ld3<SubRegSize::i32Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, Reg::r29), "ld3 {v26.4s, v27.4s, v28.4s}, [x30], x29");
+  TEST_SINGLE(ld3<SubRegSize::i32Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, Reg::r29), "ld3 {v26.2s, v27.2s, v28.2s}, [x30], x29");
+
+  TEST_SINGLE(ld3<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, Reg::r29), "ld3 {v26.2d, v27.2d, v28.2d}, [x30], x29");
+  TEST_SINGLE(ld3<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, Reg::r29), "unallocated (NEONLoadStoreMultiStructPostIndex)");
+
+  TEST_SINGLE(ld3<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, 48), "ld3 {v26.16b, v27.16b, v28.16b}, [x30], #48");
+  TEST_SINGLE(ld3<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, 24), "ld3 {v26.8b, v27.8b, v28.8b}, [x30], #24");
+
+  TEST_SINGLE(ld3<SubRegSize::i16Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, 48), "ld3 {v26.8h, v27.8h, v28.8h}, [x30], #48");
+  TEST_SINGLE(ld3<SubRegSize::i16Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, 24), "ld3 {v26.4h, v27.4h, v28.4h}, [x30], #24");
+
+  TEST_SINGLE(ld3<SubRegSize::i32Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, 48), "ld3 {v26.4s, v27.4s, v28.4s}, [x30], #48");
+  TEST_SINGLE(ld3<SubRegSize::i32Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, 24), "ld3 {v26.2s, v27.2s, v28.2s}, [x30], #24");
+
+  TEST_SINGLE(ld3<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, 48), "ld3 {v26.2d, v27.2d, v28.2d}, [x30], #48");
+  TEST_SINGLE(ld3<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, 24), "unallocated (NEONLoadStoreMultiStructPostIndex)");
+
+  TEST_SINGLE(st3<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, Reg::r29), "st3 {v26.16b, v27.16b, v28.16b}, [x30], x29");
+  TEST_SINGLE(st3<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, Reg::r29), "st3 {v26.8b, v27.8b, v28.8b}, [x30], x29");
+
+  TEST_SINGLE(st3<SubRegSize::i16Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, Reg::r29), "st3 {v26.8h, v27.8h, v28.8h}, [x30], x29");
+  TEST_SINGLE(st3<SubRegSize::i16Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, Reg::r29), "st3 {v26.4h, v27.4h, v28.4h}, [x30], x29");
+
+  TEST_SINGLE(st3<SubRegSize::i32Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, Reg::r29), "st3 {v26.4s, v27.4s, v28.4s}, [x30], x29");
+  TEST_SINGLE(st3<SubRegSize::i32Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, Reg::r29), "st3 {v26.2s, v27.2s, v28.2s}, [x30], x29");
+
+  TEST_SINGLE(st3<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, Reg::r29), "st3 {v26.2d, v27.2d, v28.2d}, [x30], x29");
+  TEST_SINGLE(st3<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, Reg::r29), "unallocated (NEONLoadStoreMultiStructPostIndex)");
+
+  TEST_SINGLE(st3<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, 48), "st3 {v26.16b, v27.16b, v28.16b}, [x30], #48");
+  TEST_SINGLE(st3<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, 24), "st3 {v26.8b, v27.8b, v28.8b}, [x30], #24");
+
+  TEST_SINGLE(st3<SubRegSize::i16Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, 48), "st3 {v26.8h, v27.8h, v28.8h}, [x30], #48");
+  TEST_SINGLE(st3<SubRegSize::i16Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, 24), "st3 {v26.4h, v27.4h, v28.4h}, [x30], #24");
+
+  TEST_SINGLE(st3<SubRegSize::i32Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, 48), "st3 {v26.4s, v27.4s, v28.4s}, [x30], #48");
+  TEST_SINGLE(st3<SubRegSize::i32Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, 24), "st3 {v26.2s, v27.2s, v28.2s}, [x30], #24");
+
+  TEST_SINGLE(st3<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, 48), "st3 {v26.2d, v27.2d, v28.2d}, [x30], #48");
+  TEST_SINGLE(st3<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, 24), "unallocated (NEONLoadStoreMultiStructPostIndex)");
+
+  TEST_SINGLE(ld4<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, Reg::r29), "ld4 {v26.16b, v27.16b, v28.16b, v29.16b}, [x30], x29");
+  TEST_SINGLE(ld4<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, Reg::r29), "ld4 {v26.8b, v27.8b, v28.8b, v29.8b}, [x30], x29");
+
+  TEST_SINGLE(ld4<SubRegSize::i16Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, Reg::r29), "ld4 {v26.8h, v27.8h, v28.8h, v29.8h}, [x30], x29");
+  TEST_SINGLE(ld4<SubRegSize::i16Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, Reg::r29), "ld4 {v26.4h, v27.4h, v28.4h, v29.4h}, [x30], x29");
+
+  TEST_SINGLE(ld4<SubRegSize::i32Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, Reg::r29), "ld4 {v26.4s, v27.4s, v28.4s, v29.4s}, [x30], x29");
+  TEST_SINGLE(ld4<SubRegSize::i32Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, Reg::r29), "ld4 {v26.2s, v27.2s, v28.2s, v29.2s}, [x30], x29");
+
+  TEST_SINGLE(ld4<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, Reg::r29), "ld4 {v26.2d, v27.2d, v28.2d, v29.2d}, [x30], x29");
+  TEST_SINGLE(ld4<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, Reg::r29), "unallocated (NEONLoadStoreMultiStructPostIndex)");
+
+  TEST_SINGLE(ld4<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, 64), "ld4 {v26.16b, v27.16b, v28.16b, v29.16b}, [x30], #64");
+  TEST_SINGLE(ld4<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, 32), "ld4 {v26.8b, v27.8b, v28.8b, v29.8b}, [x30], #32");
+
+  TEST_SINGLE(ld4<SubRegSize::i16Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, 64), "ld4 {v26.8h, v27.8h, v28.8h, v29.8h}, [x30], #64");
+  TEST_SINGLE(ld4<SubRegSize::i16Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, 32), "ld4 {v26.4h, v27.4h, v28.4h, v29.4h}, [x30], #32");
+
+  TEST_SINGLE(ld4<SubRegSize::i32Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, 64), "ld4 {v26.4s, v27.4s, v28.4s, v29.4s}, [x30], #64");
+  TEST_SINGLE(ld4<SubRegSize::i32Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, 32), "ld4 {v26.2s, v27.2s, v28.2s, v29.2s}, [x30], #32");
+
+  TEST_SINGLE(ld4<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, 64), "ld4 {v26.2d, v27.2d, v28.2d, v29.2d}, [x30], #64");
+  TEST_SINGLE(ld4<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, 32), "unallocated (NEONLoadStoreMultiStructPostIndex)");
+
+  TEST_SINGLE(st4<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, Reg::r29), "st4 {v26.16b, v27.16b, v28.16b, v29.16b}, [x30], x29");
+  TEST_SINGLE(st4<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, Reg::r29), "st4 {v26.8b, v27.8b, v28.8b, v29.8b}, [x30], x29");
+
+  TEST_SINGLE(st4<SubRegSize::i16Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, Reg::r29), "st4 {v26.8h, v27.8h, v28.8h, v29.8h}, [x30], x29");
+  TEST_SINGLE(st4<SubRegSize::i16Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, Reg::r29), "st4 {v26.4h, v27.4h, v28.4h, v29.4h}, [x30], x29");
+
+  TEST_SINGLE(st4<SubRegSize::i32Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, Reg::r29), "st4 {v26.4s, v27.4s, v28.4s, v29.4s}, [x30], x29");
+  TEST_SINGLE(st4<SubRegSize::i32Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, Reg::r29), "st4 {v26.2s, v27.2s, v28.2s, v29.2s}, [x30], x29");
+
+  TEST_SINGLE(st4<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, Reg::r29), "st4 {v26.2d, v27.2d, v28.2d, v29.2d}, [x30], x29");
+  TEST_SINGLE(st4<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, Reg::r29), "unallocated (NEONLoadStoreMultiStructPostIndex)");
+
+  TEST_SINGLE(st4<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, 64), "st4 {v26.16b, v27.16b, v28.16b, v29.16b}, [x30], #64");
+  TEST_SINGLE(st4<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, 32), "st4 {v26.8b, v27.8b, v28.8b, v29.8b}, [x30], #32");
+
+  TEST_SINGLE(st4<SubRegSize::i16Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, 64), "st4 {v26.8h, v27.8h, v28.8h, v29.8h}, [x30], #64");
+  TEST_SINGLE(st4<SubRegSize::i16Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, 32), "st4 {v26.4h, v27.4h, v28.4h, v29.4h}, [x30], #32");
+
+  TEST_SINGLE(st4<SubRegSize::i32Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, 64), "st4 {v26.4s, v27.4s, v28.4s, v29.4s}, [x30], #64");
+  TEST_SINGLE(st4<SubRegSize::i32Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, 32), "st4 {v26.2s, v27.2s, v28.2s, v29.2s}, [x30], #32");
+
+  TEST_SINGLE(st4<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, 64), "st4 {v26.2d, v27.2d, v28.2d, v29.2d}, [x30], #64");
+  TEST_SINGLE(st4<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, 32), "unallocated (NEONLoadStoreMultiStructPostIndex)");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: ASIMD loadstore single") {
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(VReg::v26, 0, Reg::r30),  "ld1 {v26.b}[0], [x30]");
+  TEST_SINGLE(ld1<SubRegSize::i16Bit>(VReg::v26, 0, Reg::r30), "ld1 {v26.h}[0], [x30]");
+  TEST_SINGLE(ld1<SubRegSize::i32Bit>(VReg::v26, 0, Reg::r30), "ld1 {v26.s}[0], [x30]");
+  TEST_SINGLE(ld1<SubRegSize::i64Bit>(VReg::v26, 0, Reg::r30), "ld1 {v26.d}[0], [x30]");
+
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(VReg::v26, 15, Reg::r30),  "ld1 {v26.b}[15], [x30]");
+  TEST_SINGLE(ld1<SubRegSize::i16Bit>(VReg::v26, 7, Reg::r30), "ld1 {v26.h}[7], [x30]");
+  TEST_SINGLE(ld1<SubRegSize::i32Bit>(VReg::v26, 3, Reg::r30), "ld1 {v26.s}[3], [x30]");
+  TEST_SINGLE(ld1<SubRegSize::i64Bit>(VReg::v26, 1, Reg::r30), "ld1 {v26.d}[1], [x30]");
+
+  TEST_SINGLE(ld1r<SubRegSize::i8Bit>(DReg::d26, Reg::r30),  "ld1r {v26.8b}, [x30]");
+  TEST_SINGLE(ld1r<SubRegSize::i16Bit>(DReg::d26, Reg::r30), "ld1r {v26.4h}, [x30]");
+  TEST_SINGLE(ld1r<SubRegSize::i32Bit>(DReg::d26, Reg::r30), "ld1r {v26.2s}, [x30]");
+  TEST_SINGLE(ld1r<SubRegSize::i64Bit>(DReg::d26, Reg::r30), "ld1r {v26.1d}, [x30]");
+
+  TEST_SINGLE(ld1r<SubRegSize::i8Bit>(QReg::q26, Reg::r30),  "ld1r {v26.16b}, [x30]");
+  TEST_SINGLE(ld1r<SubRegSize::i16Bit>(QReg::q26, Reg::r30), "ld1r {v26.8h}, [x30]");
+  TEST_SINGLE(ld1r<SubRegSize::i32Bit>(QReg::q26, Reg::r30), "ld1r {v26.4s}, [x30]");
+  TEST_SINGLE(ld1r<SubRegSize::i64Bit>(QReg::q26, Reg::r30), "ld1r {v26.2d}, [x30]");
+
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(VReg::v26, 0, Reg::r30),  "st1 {v26.b}[0], [x30]");
+  TEST_SINGLE(st1<SubRegSize::i16Bit>(VReg::v26, 0, Reg::r30), "st1 {v26.h}[0], [x30]");
+  TEST_SINGLE(st1<SubRegSize::i32Bit>(VReg::v26, 0, Reg::r30), "st1 {v26.s}[0], [x30]");
+  TEST_SINGLE(st1<SubRegSize::i64Bit>(VReg::v26, 0, Reg::r30), "st1 {v26.d}[0], [x30]");
+
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(VReg::v26, 15, Reg::r30),  "st1 {v26.b}[15], [x30]");
+  TEST_SINGLE(st1<SubRegSize::i16Bit>(VReg::v26, 7, Reg::r30), "st1 {v26.h}[7], [x30]");
+  TEST_SINGLE(st1<SubRegSize::i32Bit>(VReg::v26, 3, Reg::r30), "st1 {v26.s}[3], [x30]");
+  TEST_SINGLE(st1<SubRegSize::i64Bit>(VReg::v26, 1, Reg::r30), "st1 {v26.d}[1], [x30]");
+
+  TEST_SINGLE(ld2<SubRegSize::i8Bit>(VReg::v26, VReg::v27, 0, Reg::r30),  "ld2 {v26.b, v27.b}[0], [x30]");
+  TEST_SINGLE(ld2<SubRegSize::i16Bit>(VReg::v26, VReg::v27, 0, Reg::r30), "ld2 {v26.h, v27.h}[0], [x30]");
+  TEST_SINGLE(ld2<SubRegSize::i32Bit>(VReg::v26, VReg::v27, 0, Reg::r30), "ld2 {v26.s, v27.s}[0], [x30]");
+  TEST_SINGLE(ld2<SubRegSize::i64Bit>(VReg::v26, VReg::v27, 0, Reg::r30), "ld2 {v26.d, v27.d}[0], [x30]");
+
+  TEST_SINGLE(ld2<SubRegSize::i8Bit>(VReg::v26, VReg::v27, 15, Reg::r30),  "ld2 {v26.b, v27.b}[15], [x30]");
+  TEST_SINGLE(ld2<SubRegSize::i16Bit>(VReg::v26, VReg::v27, 7, Reg::r30), "ld2 {v26.h, v27.h}[7], [x30]");
+  TEST_SINGLE(ld2<SubRegSize::i32Bit>(VReg::v26, VReg::v27, 3, Reg::r30), "ld2 {v26.s, v27.s}[3], [x30]");
+  TEST_SINGLE(ld2<SubRegSize::i64Bit>(VReg::v26, VReg::v27, 1, Reg::r30), "ld2 {v26.d, v27.d}[1], [x30]");
+
+  TEST_SINGLE(ld2r<SubRegSize::i8Bit>(DReg::d26, DReg::d27, Reg::r30),  "ld2r {v26.8b, v27.8b}, [x30]");
+  TEST_SINGLE(ld2r<SubRegSize::i16Bit>(DReg::d26, DReg::d27, Reg::r30), "ld2r {v26.4h, v27.4h}, [x30]");
+  TEST_SINGLE(ld2r<SubRegSize::i32Bit>(DReg::d26, DReg::d27, Reg::r30), "ld2r {v26.2s, v27.2s}, [x30]");
+  TEST_SINGLE(ld2r<SubRegSize::i64Bit>(DReg::d26, DReg::d27, Reg::r30), "ld2r {v26.1d, v27.1d}, [x30]");
+
+  TEST_SINGLE(ld2r<SubRegSize::i8Bit>(QReg::q26, QReg::q27, Reg::r30),  "ld2r {v26.16b, v27.16b}, [x30]");
+  TEST_SINGLE(ld2r<SubRegSize::i16Bit>(QReg::q26, QReg::q27, Reg::r30), "ld2r {v26.8h, v27.8h}, [x30]");
+  TEST_SINGLE(ld2r<SubRegSize::i32Bit>(QReg::q26, QReg::q27, Reg::r30), "ld2r {v26.4s, v27.4s}, [x30]");
+  TEST_SINGLE(ld2r<SubRegSize::i64Bit>(QReg::q26, QReg::q27, Reg::r30), "ld2r {v26.2d, v27.2d}, [x30]");
+
+  TEST_SINGLE(st2<SubRegSize::i8Bit>(VReg::v26, VReg::v27, 0, Reg::r30),  "st2 {v26.b, v27.b}[0], [x30]");
+  TEST_SINGLE(st2<SubRegSize::i16Bit>(VReg::v26, VReg::v27, 0, Reg::r30), "st2 {v26.h, v27.h}[0], [x30]");
+  TEST_SINGLE(st2<SubRegSize::i32Bit>(VReg::v26, VReg::v27, 0, Reg::r30), "st2 {v26.s, v27.s}[0], [x30]");
+  TEST_SINGLE(st2<SubRegSize::i64Bit>(VReg::v26, VReg::v27, 0, Reg::r30), "st2 {v26.d, v27.d}[0], [x30]");
+
+  TEST_SINGLE(st2<SubRegSize::i8Bit>(VReg::v26, VReg::v27, 15, Reg::r30),  "st2 {v26.b, v27.b}[15], [x30]");
+  TEST_SINGLE(st2<SubRegSize::i16Bit>(VReg::v26, VReg::v27, 7, Reg::r30), "st2 {v26.h, v27.h}[7], [x30]");
+  TEST_SINGLE(st2<SubRegSize::i32Bit>(VReg::v26, VReg::v27, 3, Reg::r30), "st2 {v26.s, v27.s}[3], [x30]");
+  TEST_SINGLE(st2<SubRegSize::i64Bit>(VReg::v26, VReg::v27, 1, Reg::r30), "st2 {v26.d, v27.d}[1], [x30]");
+
+  TEST_SINGLE(ld3<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30),  "ld3 {v26.b, v27.b, v28.b}[0], [x30]");
+  TEST_SINGLE(ld3<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30), "ld3 {v26.h, v27.h, v28.h}[0], [x30]");
+  TEST_SINGLE(ld3<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30), "ld3 {v26.s, v27.s, v28.s}[0], [x30]");
+  TEST_SINGLE(ld3<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30), "ld3 {v26.d, v27.d, v28.d}[0], [x30]");
+
+  TEST_SINGLE(ld3<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, 15, Reg::r30),  "ld3 {v26.b, v27.b, v28.b}[15], [x30]");
+  TEST_SINGLE(ld3<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, 7, Reg::r30), "ld3 {v26.h, v27.h, v28.h}[7], [x30]");
+  TEST_SINGLE(ld3<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, 3, Reg::r30), "ld3 {v26.s, v27.s, v28.s}[3], [x30]");
+  TEST_SINGLE(ld3<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, 1, Reg::r30), "ld3 {v26.d, v27.d, v28.d}[1], [x30]");
+
+  TEST_SINGLE(ld3r<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30),  "ld3r {v26.8b, v27.8b, v28.8b}, [x30]");
+  TEST_SINGLE(ld3r<SubRegSize::i16Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30), "ld3r {v26.4h, v27.4h, v28.4h}, [x30]");
+  TEST_SINGLE(ld3r<SubRegSize::i32Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30), "ld3r {v26.2s, v27.2s, v28.2s}, [x30]");
+  TEST_SINGLE(ld3r<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30), "ld3r {v26.1d, v27.1d, v28.1d}, [x30]");
+
+  TEST_SINGLE(ld3r<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30),  "ld3r {v26.16b, v27.16b, v28.16b}, [x30]");
+  TEST_SINGLE(ld3r<SubRegSize::i16Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30), "ld3r {v26.8h, v27.8h, v28.8h}, [x30]");
+  TEST_SINGLE(ld3r<SubRegSize::i32Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30), "ld3r {v26.4s, v27.4s, v28.4s}, [x30]");
+  TEST_SINGLE(ld3r<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30), "ld3r {v26.2d, v27.2d, v28.2d}, [x30]");
+
+  TEST_SINGLE(st3<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30),  "st3 {v26.b, v27.b, v28.b}[0], [x30]");
+  TEST_SINGLE(st3<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30), "st3 {v26.h, v27.h, v28.h}[0], [x30]");
+  TEST_SINGLE(st3<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30), "st3 {v26.s, v27.s, v28.s}[0], [x30]");
+  TEST_SINGLE(st3<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30), "st3 {v26.d, v27.d, v28.d}[0], [x30]");
+
+  TEST_SINGLE(st3<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, 15, Reg::r30),  "st3 {v26.b, v27.b, v28.b}[15], [x30]");
+  TEST_SINGLE(st3<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, 7, Reg::r30), "st3 {v26.h, v27.h, v28.h}[7], [x30]");
+  TEST_SINGLE(st3<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, 3, Reg::r30), "st3 {v26.s, v27.s, v28.s}[3], [x30]");
+  TEST_SINGLE(st3<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, 1, Reg::r30), "st3 {v26.d, v27.d, v28.d}[1], [x30]");
+
+  TEST_SINGLE(ld4<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30),  "ld4 {v26.b, v27.b, v28.b, v29.b}[0], [x30]");
+  TEST_SINGLE(ld4<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30), "ld4 {v26.h, v27.h, v28.h, v29.h}[0], [x30]");
+  TEST_SINGLE(ld4<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30), "ld4 {v26.s, v27.s, v28.s, v29.s}[0], [x30]");
+  TEST_SINGLE(ld4<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30), "ld4 {v26.d, v27.d, v28.d, v29.d}[0], [x30]");
+
+  TEST_SINGLE(ld4<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 15, Reg::r30),  "ld4 {v26.b, v27.b, v28.b, v29.b}[15], [x30]");
+  TEST_SINGLE(ld4<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 7, Reg::r30), "ld4 {v26.h, v27.h, v28.h, v29.h}[7], [x30]");
+  TEST_SINGLE(ld4<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 3, Reg::r30), "ld4 {v26.s, v27.s, v28.s, v29.s}[3], [x30]");
+  TEST_SINGLE(ld4<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 1, Reg::r30), "ld4 {v26.d, v27.d, v28.d, v29.d}[1], [x30]");
+
+  TEST_SINGLE(ld4r<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30),  "ld4r {v26.8b, v27.8b, v28.8b, v29.8b}, [x30]");
+  TEST_SINGLE(ld4r<SubRegSize::i16Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30), "ld4r {v26.4h, v27.4h, v28.4h, v29.4h}, [x30]");
+  TEST_SINGLE(ld4r<SubRegSize::i32Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30), "ld4r {v26.2s, v27.2s, v28.2s, v29.2s}, [x30]");
+  TEST_SINGLE(ld4r<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30), "ld4r {v26.1d, v27.1d, v28.1d, v29.1d}, [x30]");
+
+  TEST_SINGLE(ld4r<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30),  "ld4r {v26.16b, v27.16b, v28.16b, v29.16b}, [x30]");
+  TEST_SINGLE(ld4r<SubRegSize::i16Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30), "ld4r {v26.8h, v27.8h, v28.8h, v29.8h}, [x30]");
+  TEST_SINGLE(ld4r<SubRegSize::i32Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30), "ld4r {v26.4s, v27.4s, v28.4s, v29.4s}, [x30]");
+  TEST_SINGLE(ld4r<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30), "ld4r {v26.2d, v27.2d, v28.2d, v29.2d}, [x30]");
+
+  TEST_SINGLE(st4<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30),  "st4 {v26.b, v27.b, v28.b, v29.b}[0], [x30]");
+  TEST_SINGLE(st4<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30), "st4 {v26.h, v27.h, v28.h, v29.h}[0], [x30]");
+  TEST_SINGLE(st4<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30), "st4 {v26.s, v27.s, v28.s, v29.s}[0], [x30]");
+  TEST_SINGLE(st4<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30), "st4 {v26.d, v27.d, v28.d, v29.d}[0], [x30]");
+
+  TEST_SINGLE(st4<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 15, Reg::r30),  "st4 {v26.b, v27.b, v28.b, v29.b}[15], [x30]");
+  TEST_SINGLE(st4<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 7, Reg::r30), "st4 {v26.h, v27.h, v28.h, v29.h}[7], [x30]");
+  TEST_SINGLE(st4<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 3, Reg::r30), "st4 {v26.s, v27.s, v28.s, v29.s}[3], [x30]");
+  TEST_SINGLE(st4<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 1, Reg::r30), "st4 {v26.d, v27.d, v28.d, v29.d}[1], [x30]");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Advanced SIMD load/store single structure (post-indexed)") {
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(VReg::v26, 0, Reg::r30, 1),  "ld1 {v26.b}[0], [x30], #1");
+  TEST_SINGLE(ld1<SubRegSize::i16Bit>(VReg::v26, 0, Reg::r30, 2), "ld1 {v26.h}[0], [x30], #2");
+  TEST_SINGLE(ld1<SubRegSize::i32Bit>(VReg::v26, 0, Reg::r30, 4), "ld1 {v26.s}[0], [x30], #4");
+  TEST_SINGLE(ld1<SubRegSize::i64Bit>(VReg::v26, 0, Reg::r30, 8), "ld1 {v26.d}[0], [x30], #8");
+
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(VReg::v26, 15, Reg::r30, 1),  "ld1 {v26.b}[15], [x30], #1");
+  TEST_SINGLE(ld1<SubRegSize::i16Bit>(VReg::v26, 7, Reg::r30, 2), "ld1 {v26.h}[7], [x30], #2");
+  TEST_SINGLE(ld1<SubRegSize::i32Bit>(VReg::v26, 3, Reg::r30, 4), "ld1 {v26.s}[3], [x30], #4");
+  TEST_SINGLE(ld1<SubRegSize::i64Bit>(VReg::v26, 1, Reg::r30, 8), "ld1 {v26.d}[1], [x30], #8");
+
+  TEST_SINGLE(ld1r<SubRegSize::i8Bit>(DReg::d26, Reg::r30, 1),  "ld1r {v26.8b}, [x30], #1");
+  TEST_SINGLE(ld1r<SubRegSize::i16Bit>(DReg::d26, Reg::r30, 2), "ld1r {v26.4h}, [x30], #2");
+  TEST_SINGLE(ld1r<SubRegSize::i32Bit>(DReg::d26, Reg::r30, 4), "ld1r {v26.2s}, [x30], #4");
+  TEST_SINGLE(ld1r<SubRegSize::i64Bit>(DReg::d26, Reg::r30, 8), "ld1r {v26.1d}, [x30], #8");
+
+  TEST_SINGLE(ld1r<SubRegSize::i8Bit>(QReg::q26, Reg::r30, 1),  "ld1r {v26.16b}, [x30], #1");
+  TEST_SINGLE(ld1r<SubRegSize::i16Bit>(QReg::q26, Reg::r30, 2), "ld1r {v26.8h}, [x30], #2");
+  TEST_SINGLE(ld1r<SubRegSize::i32Bit>(QReg::q26, Reg::r30, 4), "ld1r {v26.4s}, [x30], #4");
+  TEST_SINGLE(ld1r<SubRegSize::i64Bit>(QReg::q26, Reg::r30, 8), "ld1r {v26.2d}, [x30], #8");
+
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(VReg::v26, 0, Reg::r30, 1),  "st1 {v26.b}[0], [x30], #1");
+  TEST_SINGLE(st1<SubRegSize::i16Bit>(VReg::v26, 0, Reg::r30, 2), "st1 {v26.h}[0], [x30], #2");
+  TEST_SINGLE(st1<SubRegSize::i32Bit>(VReg::v26, 0, Reg::r30, 4), "st1 {v26.s}[0], [x30], #4");
+  TEST_SINGLE(st1<SubRegSize::i64Bit>(VReg::v26, 0, Reg::r30, 8), "st1 {v26.d}[0], [x30], #8");
+
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(VReg::v26, 15, Reg::r30, 1),  "st1 {v26.b}[15], [x30], #1");
+  TEST_SINGLE(st1<SubRegSize::i16Bit>(VReg::v26, 7, Reg::r30, 2), "st1 {v26.h}[7], [x30], #2");
+  TEST_SINGLE(st1<SubRegSize::i32Bit>(VReg::v26, 3, Reg::r30, 4), "st1 {v26.s}[3], [x30], #4");
+  TEST_SINGLE(st1<SubRegSize::i64Bit>(VReg::v26, 1, Reg::r30, 8), "st1 {v26.d}[1], [x30], #8");
+
+  TEST_SINGLE(ld2<SubRegSize::i8Bit>(VReg::v26, VReg::v27, 0, Reg::r30, 2),  "ld2 {v26.b, v27.b}[0], [x30], #2");
+  TEST_SINGLE(ld2<SubRegSize::i16Bit>(VReg::v26, VReg::v27, 0, Reg::r30, 4), "ld2 {v26.h, v27.h}[0], [x30], #4");
+  TEST_SINGLE(ld2<SubRegSize::i32Bit>(VReg::v26, VReg::v27, 0, Reg::r30, 8), "ld2 {v26.s, v27.s}[0], [x30], #8");
+  TEST_SINGLE(ld2<SubRegSize::i64Bit>(VReg::v26, VReg::v27, 0, Reg::r30, 16), "ld2 {v26.d, v27.d}[0], [x30], #16");
+
+  TEST_SINGLE(ld2<SubRegSize::i8Bit>(VReg::v26, VReg::v27, 15, Reg::r30, 2),  "ld2 {v26.b, v27.b}[15], [x30], #2");
+  TEST_SINGLE(ld2<SubRegSize::i16Bit>(VReg::v26, VReg::v27, 7, Reg::r30, 4), "ld2 {v26.h, v27.h}[7], [x30], #4");
+  TEST_SINGLE(ld2<SubRegSize::i32Bit>(VReg::v26, VReg::v27, 3, Reg::r30, 8), "ld2 {v26.s, v27.s}[3], [x30], #8");
+  TEST_SINGLE(ld2<SubRegSize::i64Bit>(VReg::v26, VReg::v27, 1, Reg::r30, 16), "ld2 {v26.d, v27.d}[1], [x30], #16");
+
+  TEST_SINGLE(ld2r<SubRegSize::i8Bit>(DReg::d26, DReg::d27, Reg::r30, 2),  "ld2r {v26.8b, v27.8b}, [x30], #2");
+  TEST_SINGLE(ld2r<SubRegSize::i16Bit>(DReg::d26, DReg::d27, Reg::r30, 4), "ld2r {v26.4h, v27.4h}, [x30], #4");
+  TEST_SINGLE(ld2r<SubRegSize::i32Bit>(DReg::d26, DReg::d27, Reg::r30, 8), "ld2r {v26.2s, v27.2s}, [x30], #8");
+  TEST_SINGLE(ld2r<SubRegSize::i64Bit>(DReg::d26, DReg::d27, Reg::r30, 16), "ld2r {v26.1d, v27.1d}, [x30], #16");
+
+  TEST_SINGLE(ld2r<SubRegSize::i8Bit>(QReg::q26, QReg::q27, Reg::r30, 2),  "ld2r {v26.16b, v27.16b}, [x30], #2");
+  TEST_SINGLE(ld2r<SubRegSize::i16Bit>(QReg::q26, QReg::q27, Reg::r30, 4), "ld2r {v26.8h, v27.8h}, [x30], #4");
+  TEST_SINGLE(ld2r<SubRegSize::i32Bit>(QReg::q26, QReg::q27, Reg::r30, 8), "ld2r {v26.4s, v27.4s}, [x30], #8");
+  TEST_SINGLE(ld2r<SubRegSize::i64Bit>(QReg::q26, QReg::q27, Reg::r30, 16), "ld2r {v26.2d, v27.2d}, [x30], #16");
+
+  TEST_SINGLE(st2<SubRegSize::i8Bit>(VReg::v26, VReg::v27, 0, Reg::r30, 2),  "st2 {v26.b, v27.b}[0], [x30], #2");
+  TEST_SINGLE(st2<SubRegSize::i16Bit>(VReg::v26, VReg::v27, 0, Reg::r30, 4), "st2 {v26.h, v27.h}[0], [x30], #4");
+  TEST_SINGLE(st2<SubRegSize::i32Bit>(VReg::v26, VReg::v27, 0, Reg::r30, 8), "st2 {v26.s, v27.s}[0], [x30], #8");
+  TEST_SINGLE(st2<SubRegSize::i64Bit>(VReg::v26, VReg::v27, 0, Reg::r30, 16), "st2 {v26.d, v27.d}[0], [x30], #16");
+
+  TEST_SINGLE(st2<SubRegSize::i8Bit>(VReg::v26, VReg::v27, 15, Reg::r30, 2),  "st2 {v26.b, v27.b}[15], [x30], #2");
+  TEST_SINGLE(st2<SubRegSize::i16Bit>(VReg::v26, VReg::v27, 7, Reg::r30, 4), "st2 {v26.h, v27.h}[7], [x30], #4");
+  TEST_SINGLE(st2<SubRegSize::i32Bit>(VReg::v26, VReg::v27, 3, Reg::r30, 8), "st2 {v26.s, v27.s}[3], [x30], #8");
+  TEST_SINGLE(st2<SubRegSize::i64Bit>(VReg::v26, VReg::v27, 1, Reg::r30, 16), "st2 {v26.d, v27.d}[1], [x30], #16");
+
+  TEST_SINGLE(ld3<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30, 3),  "ld3 {v26.b, v27.b, v28.b}[0], [x30], #3");
+  TEST_SINGLE(ld3<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30, 6), "ld3 {v26.h, v27.h, v28.h}[0], [x30], #6");
+  TEST_SINGLE(ld3<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30, 12), "ld3 {v26.s, v27.s, v28.s}[0], [x30], #12");
+  TEST_SINGLE(ld3<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30, 24), "ld3 {v26.d, v27.d, v28.d}[0], [x30], #24");
+
+  TEST_SINGLE(ld3<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, 15, Reg::r30, 1),  "ld3 {v26.b, v27.b, v28.b}[15], [x30], #3");
+  TEST_SINGLE(ld3<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, 7, Reg::r30, 2), "ld3 {v26.h, v27.h, v28.h}[7], [x30], #6");
+  TEST_SINGLE(ld3<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, 3, Reg::r30, 4), "ld3 {v26.s, v27.s, v28.s}[3], [x30], #12");
+  TEST_SINGLE(ld3<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, 1, Reg::r30, 8), "ld3 {v26.d, v27.d, v28.d}[1], [x30], #24");
+
+  TEST_SINGLE(ld3r<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, 3),  "ld3r {v26.8b, v27.8b, v28.8b}, [x30], #3");
+  TEST_SINGLE(ld3r<SubRegSize::i16Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, 6), "ld3r {v26.4h, v27.4h, v28.4h}, [x30], #6");
+  TEST_SINGLE(ld3r<SubRegSize::i32Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, 12), "ld3r {v26.2s, v27.2s, v28.2s}, [x30], #12");
+  TEST_SINGLE(ld3r<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, 24), "ld3r {v26.1d, v27.1d, v28.1d}, [x30], #24");
+
+  TEST_SINGLE(ld3r<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, 3),  "ld3r {v26.16b, v27.16b, v28.16b}, [x30], #3");
+  TEST_SINGLE(ld3r<SubRegSize::i16Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, 6), "ld3r {v26.8h, v27.8h, v28.8h}, [x30], #6");
+  TEST_SINGLE(ld3r<SubRegSize::i32Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, 12), "ld3r {v26.4s, v27.4s, v28.4s}, [x30], #12");
+  TEST_SINGLE(ld3r<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, 24), "ld3r {v26.2d, v27.2d, v28.2d}, [x30], #24");
+
+  TEST_SINGLE(st3<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30, 3),  "st3 {v26.b, v27.b, v28.b}[0], [x30], #3");
+  TEST_SINGLE(st3<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30, 6), "st3 {v26.h, v27.h, v28.h}[0], [x30], #6");
+  TEST_SINGLE(st3<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30, 12), "st3 {v26.s, v27.s, v28.s}[0], [x30], #12");
+  TEST_SINGLE(st3<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30, 24), "st3 {v26.d, v27.d, v28.d}[0], [x30], #24");
+
+  TEST_SINGLE(st3<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, 15, Reg::r30, 3),  "st3 {v26.b, v27.b, v28.b}[15], [x30], #3");
+  TEST_SINGLE(st3<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, 7, Reg::r30, 6), "st3 {v26.h, v27.h, v28.h}[7], [x30], #6");
+  TEST_SINGLE(st3<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, 3, Reg::r30, 12), "st3 {v26.s, v27.s, v28.s}[3], [x30], #12");
+  TEST_SINGLE(st3<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, 1, Reg::r30, 24), "st3 {v26.d, v27.d, v28.d}[1], [x30], #24");
+
+  TEST_SINGLE(ld4<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30, 4),  "ld4 {v26.b, v27.b, v28.b, v29.b}[0], [x30], #4");
+  TEST_SINGLE(ld4<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30, 8), "ld4 {v26.h, v27.h, v28.h, v29.h}[0], [x30], #8");
+  TEST_SINGLE(ld4<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30, 16), "ld4 {v26.s, v27.s, v28.s, v29.s}[0], [x30], #16");
+  TEST_SINGLE(ld4<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30, 32), "ld4 {v26.d, v27.d, v28.d, v29.d}[0], [x30], #32");
+
+  TEST_SINGLE(ld4<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 15, Reg::r30, 4),  "ld4 {v26.b, v27.b, v28.b, v29.b}[15], [x30], #4");
+  TEST_SINGLE(ld4<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 7, Reg::r30, 8), "ld4 {v26.h, v27.h, v28.h, v29.h}[7], [x30], #8");
+  TEST_SINGLE(ld4<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 3, Reg::r30, 16), "ld4 {v26.s, v27.s, v28.s, v29.s}[3], [x30], #16");
+  TEST_SINGLE(ld4<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 1, Reg::r30, 32), "ld4 {v26.d, v27.d, v28.d, v29.d}[1], [x30], #32");
+
+  TEST_SINGLE(ld4r<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, 4),  "ld4r {v26.8b, v27.8b, v28.8b, v29.8b}, [x30], #4");
+  TEST_SINGLE(ld4r<SubRegSize::i16Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, 8), "ld4r {v26.4h, v27.4h, v28.4h, v29.4h}, [x30], #8");
+  TEST_SINGLE(ld4r<SubRegSize::i32Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, 16), "ld4r {v26.2s, v27.2s, v28.2s, v29.2s}, [x30], #16");
+  TEST_SINGLE(ld4r<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, 32), "ld4r {v26.1d, v27.1d, v28.1d, v29.1d}, [x30], #32");
+
+  TEST_SINGLE(ld4r<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, 4),  "ld4r {v26.16b, v27.16b, v28.16b, v29.16b}, [x30], #4");
+  TEST_SINGLE(ld4r<SubRegSize::i16Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, 8), "ld4r {v26.8h, v27.8h, v28.8h, v29.8h}, [x30], #8");
+  TEST_SINGLE(ld4r<SubRegSize::i32Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, 16), "ld4r {v26.4s, v27.4s, v28.4s, v29.4s}, [x30], #16");
+  TEST_SINGLE(ld4r<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, 32), "ld4r {v26.2d, v27.2d, v28.2d, v29.2d}, [x30], #32");
+
+  TEST_SINGLE(st4<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30, 4),  "st4 {v26.b, v27.b, v28.b, v29.b}[0], [x30], #4");
+  TEST_SINGLE(st4<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30, 8), "st4 {v26.h, v27.h, v28.h, v29.h}[0], [x30], #8");
+  TEST_SINGLE(st4<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30, 16), "st4 {v26.s, v27.s, v28.s, v29.s}[0], [x30], #16");
+  TEST_SINGLE(st4<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30, 32), "st4 {v26.d, v27.d, v28.d, v29.d}[0], [x30], #32");
+
+  TEST_SINGLE(st4<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 15, Reg::r30, 4),  "st4 {v26.b, v27.b, v28.b, v29.b}[15], [x30], #4");
+  TEST_SINGLE(st4<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 7, Reg::r30, 8), "st4 {v26.h, v27.h, v28.h, v29.h}[7], [x30], #8");
+  TEST_SINGLE(st4<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 3, Reg::r30, 16), "st4 {v26.s, v27.s, v28.s, v29.s}[3], [x30], #16");
+  TEST_SINGLE(st4<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 1, Reg::r30, 32), "st4 {v26.d, v27.d, v28.d, v29.d}[1], [x30], #32");
+
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(VReg::v26, 0, Reg::r30, Reg::r29),  "ld1 {v26.b}[0], [x30], x29");
+  TEST_SINGLE(ld1<SubRegSize::i16Bit>(VReg::v26, 0, Reg::r30, Reg::r29), "ld1 {v26.h}[0], [x30], x29");
+  TEST_SINGLE(ld1<SubRegSize::i32Bit>(VReg::v26, 0, Reg::r30, Reg::r29), "ld1 {v26.s}[0], [x30], x29");
+  TEST_SINGLE(ld1<SubRegSize::i64Bit>(VReg::v26, 0, Reg::r30, Reg::r29), "ld1 {v26.d}[0], [x30], x29");
+
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(VReg::v26, 15, Reg::r30, Reg::r29),  "ld1 {v26.b}[15], [x30], x29");
+  TEST_SINGLE(ld1<SubRegSize::i16Bit>(VReg::v26, 7, Reg::r30, Reg::r29), "ld1 {v26.h}[7], [x30], x29");
+  TEST_SINGLE(ld1<SubRegSize::i32Bit>(VReg::v26, 3, Reg::r30, Reg::r29), "ld1 {v26.s}[3], [x30], x29");
+  TEST_SINGLE(ld1<SubRegSize::i64Bit>(VReg::v26, 1, Reg::r30, Reg::r29), "ld1 {v26.d}[1], [x30], x29");
+
+  TEST_SINGLE(ld1r<SubRegSize::i8Bit>(DReg::d26, Reg::r30, Reg::r29),  "ld1r {v26.8b}, [x30], x29");
+  TEST_SINGLE(ld1r<SubRegSize::i16Bit>(DReg::d26, Reg::r30, Reg::r29), "ld1r {v26.4h}, [x30], x29");
+  TEST_SINGLE(ld1r<SubRegSize::i32Bit>(DReg::d26, Reg::r30, Reg::r29), "ld1r {v26.2s}, [x30], x29");
+  TEST_SINGLE(ld1r<SubRegSize::i64Bit>(DReg::d26, Reg::r30, Reg::r29), "ld1r {v26.1d}, [x30], x29");
+
+  TEST_SINGLE(ld1r<SubRegSize::i8Bit>(QReg::q26, Reg::r30, Reg::r29),  "ld1r {v26.16b}, [x30], x29");
+  TEST_SINGLE(ld1r<SubRegSize::i16Bit>(QReg::q26, Reg::r30, Reg::r29), "ld1r {v26.8h}, [x30], x29");
+  TEST_SINGLE(ld1r<SubRegSize::i32Bit>(QReg::q26, Reg::r30, Reg::r29), "ld1r {v26.4s}, [x30], x29");
+  TEST_SINGLE(ld1r<SubRegSize::i64Bit>(QReg::q26, Reg::r30, Reg::r29), "ld1r {v26.2d}, [x30], x29");
+
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(VReg::v26, 0, Reg::r30, Reg::r29),  "st1 {v26.b}[0], [x30], x29");
+  TEST_SINGLE(st1<SubRegSize::i16Bit>(VReg::v26, 0, Reg::r30, Reg::r29), "st1 {v26.h}[0], [x30], x29");
+  TEST_SINGLE(st1<SubRegSize::i32Bit>(VReg::v26, 0, Reg::r30, Reg::r29), "st1 {v26.s}[0], [x30], x29");
+  TEST_SINGLE(st1<SubRegSize::i64Bit>(VReg::v26, 0, Reg::r30, Reg::r29), "st1 {v26.d}[0], [x30], x29");
+
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(VReg::v26, 15, Reg::r30, Reg::r29),  "st1 {v26.b}[15], [x30], x29");
+  TEST_SINGLE(st1<SubRegSize::i16Bit>(VReg::v26, 7, Reg::r30, Reg::r29), "st1 {v26.h}[7], [x30], x29");
+  TEST_SINGLE(st1<SubRegSize::i32Bit>(VReg::v26, 3, Reg::r30, Reg::r29), "st1 {v26.s}[3], [x30], x29");
+  TEST_SINGLE(st1<SubRegSize::i64Bit>(VReg::v26, 1, Reg::r30, Reg::r29), "st1 {v26.d}[1], [x30], x29");
+
+  TEST_SINGLE(ld2<SubRegSize::i8Bit>(VReg::v26, VReg::v27, 0, Reg::r30, Reg::r29),  "ld2 {v26.b, v27.b}[0], [x30], x29");
+  TEST_SINGLE(ld2<SubRegSize::i16Bit>(VReg::v26, VReg::v27, 0, Reg::r30, Reg::r29), "ld2 {v26.h, v27.h}[0], [x30], x29");
+  TEST_SINGLE(ld2<SubRegSize::i32Bit>(VReg::v26, VReg::v27, 0, Reg::r30, Reg::r29), "ld2 {v26.s, v27.s}[0], [x30], x29");
+  TEST_SINGLE(ld2<SubRegSize::i64Bit>(VReg::v26, VReg::v27, 0, Reg::r30, Reg::r29), "ld2 {v26.d, v27.d}[0], [x30], x29");
+
+  TEST_SINGLE(ld2<SubRegSize::i8Bit>(VReg::v26, VReg::v27, 15, Reg::r30, Reg::r29),  "ld2 {v26.b, v27.b}[15], [x30], x29");
+  TEST_SINGLE(ld2<SubRegSize::i16Bit>(VReg::v26, VReg::v27, 7, Reg::r30, Reg::r29), "ld2 {v26.h, v27.h}[7], [x30], x29");
+  TEST_SINGLE(ld2<SubRegSize::i32Bit>(VReg::v26, VReg::v27, 3, Reg::r30, Reg::r29), "ld2 {v26.s, v27.s}[3], [x30], x29");
+  TEST_SINGLE(ld2<SubRegSize::i64Bit>(VReg::v26, VReg::v27, 1, Reg::r30, Reg::r29), "ld2 {v26.d, v27.d}[1], [x30], x29");
+
+  TEST_SINGLE(ld2r<SubRegSize::i8Bit>(DReg::d26, DReg::d27, Reg::r30, Reg::r29),  "ld2r {v26.8b, v27.8b}, [x30], x29");
+  TEST_SINGLE(ld2r<SubRegSize::i16Bit>(DReg::d26, DReg::d27, Reg::r30, Reg::r29), "ld2r {v26.4h, v27.4h}, [x30], x29");
+  TEST_SINGLE(ld2r<SubRegSize::i32Bit>(DReg::d26, DReg::d27, Reg::r30, Reg::r29), "ld2r {v26.2s, v27.2s}, [x30], x29");
+  TEST_SINGLE(ld2r<SubRegSize::i64Bit>(DReg::d26, DReg::d27, Reg::r30, Reg::r29), "ld2r {v26.1d, v27.1d}, [x30], x29");
+
+  TEST_SINGLE(ld2r<SubRegSize::i8Bit>(QReg::q26, QReg::q27, Reg::r30, Reg::r29),  "ld2r {v26.16b, v27.16b}, [x30], x29");
+  TEST_SINGLE(ld2r<SubRegSize::i16Bit>(QReg::q26, QReg::q27, Reg::r30, Reg::r29), "ld2r {v26.8h, v27.8h}, [x30], x29");
+  TEST_SINGLE(ld2r<SubRegSize::i32Bit>(QReg::q26, QReg::q27, Reg::r30, Reg::r29), "ld2r {v26.4s, v27.4s}, [x30], x29");
+  TEST_SINGLE(ld2r<SubRegSize::i64Bit>(QReg::q26, QReg::q27, Reg::r30, Reg::r29), "ld2r {v26.2d, v27.2d}, [x30], x29");
+
+  TEST_SINGLE(st2<SubRegSize::i8Bit>(VReg::v26, VReg::v27, 0, Reg::r30, Reg::r29),  "st2 {v26.b, v27.b}[0], [x30], x29");
+  TEST_SINGLE(st2<SubRegSize::i16Bit>(VReg::v26, VReg::v27, 0, Reg::r30, Reg::r29), "st2 {v26.h, v27.h}[0], [x30], x29");
+  TEST_SINGLE(st2<SubRegSize::i32Bit>(VReg::v26, VReg::v27, 0, Reg::r30, Reg::r29), "st2 {v26.s, v27.s}[0], [x30], x29");
+  TEST_SINGLE(st2<SubRegSize::i64Bit>(VReg::v26, VReg::v27, 0, Reg::r30, Reg::r29), "st2 {v26.d, v27.d}[0], [x30], x29");
+
+  TEST_SINGLE(st2<SubRegSize::i8Bit>(VReg::v26, VReg::v27, 15, Reg::r30, Reg::r29),  "st2 {v26.b, v27.b}[15], [x30], x29");
+  TEST_SINGLE(st2<SubRegSize::i16Bit>(VReg::v26, VReg::v27, 7, Reg::r30, Reg::r29), "st2 {v26.h, v27.h}[7], [x30], x29");
+  TEST_SINGLE(st2<SubRegSize::i32Bit>(VReg::v26, VReg::v27, 3, Reg::r30, Reg::r29), "st2 {v26.s, v27.s}[3], [x30], x29");
+  TEST_SINGLE(st2<SubRegSize::i64Bit>(VReg::v26, VReg::v27, 1, Reg::r30, Reg::r29), "st2 {v26.d, v27.d}[1], [x30], x29");
+
+  TEST_SINGLE(ld3<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30, Reg::r29),  "ld3 {v26.b, v27.b, v28.b}[0], [x30], x29");
+  TEST_SINGLE(ld3<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30, Reg::r29), "ld3 {v26.h, v27.h, v28.h}[0], [x30], x29");
+  TEST_SINGLE(ld3<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30, Reg::r29), "ld3 {v26.s, v27.s, v28.s}[0], [x30], x29");
+  TEST_SINGLE(ld3<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30, Reg::r29), "ld3 {v26.d, v27.d, v28.d}[0], [x30], x29");
+
+  TEST_SINGLE(ld3<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, 15, Reg::r30, Reg::r29),  "ld3 {v26.b, v27.b, v28.b}[15], [x30], x29");
+  TEST_SINGLE(ld3<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, 7, Reg::r30, Reg::r29), "ld3 {v26.h, v27.h, v28.h}[7], [x30], x29");
+  TEST_SINGLE(ld3<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, 3, Reg::r30, Reg::r29), "ld3 {v26.s, v27.s, v28.s}[3], [x30], x29");
+  TEST_SINGLE(ld3<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, 1, Reg::r30, Reg::r29), "ld3 {v26.d, v27.d, v28.d}[1], [x30], x29");
+
+  TEST_SINGLE(ld3r<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, Reg::r29),  "ld3r {v26.8b, v27.8b, v28.8b}, [x30], x29");
+  TEST_SINGLE(ld3r<SubRegSize::i16Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, Reg::r29), "ld3r {v26.4h, v27.4h, v28.4h}, [x30], x29");
+  TEST_SINGLE(ld3r<SubRegSize::i32Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, Reg::r29), "ld3r {v26.2s, v27.2s, v28.2s}, [x30], x29");
+  TEST_SINGLE(ld3r<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, Reg::r29), "ld3r {v26.1d, v27.1d, v28.1d}, [x30], x29");
+
+  TEST_SINGLE(ld3r<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, Reg::r29),  "ld3r {v26.16b, v27.16b, v28.16b}, [x30], x29");
+  TEST_SINGLE(ld3r<SubRegSize::i16Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, Reg::r29), "ld3r {v26.8h, v27.8h, v28.8h}, [x30], x29");
+  TEST_SINGLE(ld3r<SubRegSize::i32Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, Reg::r29), "ld3r {v26.4s, v27.4s, v28.4s}, [x30], x29");
+  TEST_SINGLE(ld3r<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, Reg::r29), "ld3r {v26.2d, v27.2d, v28.2d}, [x30], x29");
+
+  TEST_SINGLE(st3<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30, Reg::r29),  "st3 {v26.b, v27.b, v28.b}[0], [x30], x29");
+  TEST_SINGLE(st3<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30, Reg::r29), "st3 {v26.h, v27.h, v28.h}[0], [x30], x29");
+  TEST_SINGLE(st3<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30, Reg::r29), "st3 {v26.s, v27.s, v28.s}[0], [x30], x29");
+  TEST_SINGLE(st3<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30, Reg::r29), "st3 {v26.d, v27.d, v28.d}[0], [x30], x29");
+
+  TEST_SINGLE(st3<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, 15, Reg::r30, Reg::r29),  "st3 {v26.b, v27.b, v28.b}[15], [x30], x29");
+  TEST_SINGLE(st3<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, 7, Reg::r30, Reg::r29), "st3 {v26.h, v27.h, v28.h}[7], [x30], x29");
+  TEST_SINGLE(st3<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, 3, Reg::r30, Reg::r29), "st3 {v26.s, v27.s, v28.s}[3], [x30], x29");
+  TEST_SINGLE(st3<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, 1, Reg::r30, Reg::r29), "st3 {v26.d, v27.d, v28.d}[1], [x30], x29");
+
+  TEST_SINGLE(ld4<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30, Reg::r29),  "ld4 {v26.b, v27.b, v28.b, v29.b}[0], [x30], x29");
+  TEST_SINGLE(ld4<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30, Reg::r29), "ld4 {v26.h, v27.h, v28.h, v29.h}[0], [x30], x29");
+  TEST_SINGLE(ld4<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30, Reg::r29), "ld4 {v26.s, v27.s, v28.s, v29.s}[0], [x30], x29");
+  TEST_SINGLE(ld4<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30, Reg::r29), "ld4 {v26.d, v27.d, v28.d, v29.d}[0], [x30], x29");
+
+  TEST_SINGLE(ld4<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 15, Reg::r30, Reg::r29),  "ld4 {v26.b, v27.b, v28.b, v29.b}[15], [x30], x29");
+  TEST_SINGLE(ld4<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 7, Reg::r30, Reg::r29), "ld4 {v26.h, v27.h, v28.h, v29.h}[7], [x30], x29");
+  TEST_SINGLE(ld4<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 3, Reg::r30, Reg::r29), "ld4 {v26.s, v27.s, v28.s, v29.s}[3], [x30], x29");
+  TEST_SINGLE(ld4<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 1, Reg::r30, Reg::r29), "ld4 {v26.d, v27.d, v28.d, v29.d}[1], [x30], x29");
+
+  TEST_SINGLE(ld4r<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, Reg::r29),  "ld4r {v26.8b, v27.8b, v28.8b, v29.8b}, [x30], x29");
+  TEST_SINGLE(ld4r<SubRegSize::i16Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, Reg::r29), "ld4r {v26.4h, v27.4h, v28.4h, v29.4h}, [x30], x29");
+  TEST_SINGLE(ld4r<SubRegSize::i32Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, Reg::r29), "ld4r {v26.2s, v27.2s, v28.2s, v29.2s}, [x30], x29");
+  TEST_SINGLE(ld4r<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, Reg::r29), "ld4r {v26.1d, v27.1d, v28.1d, v29.1d}, [x30], x29");
+
+  TEST_SINGLE(ld4r<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, Reg::r29),  "ld4r {v26.16b, v27.16b, v28.16b, v29.16b}, [x30], x29");
+  TEST_SINGLE(ld4r<SubRegSize::i16Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, Reg::r29), "ld4r {v26.8h, v27.8h, v28.8h, v29.8h}, [x30], x29");
+  TEST_SINGLE(ld4r<SubRegSize::i32Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, Reg::r29), "ld4r {v26.4s, v27.4s, v28.4s, v29.4s}, [x30], x29");
+  TEST_SINGLE(ld4r<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, Reg::r29), "ld4r {v26.2d, v27.2d, v28.2d, v29.2d}, [x30], x29");
+
+  TEST_SINGLE(st4<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30, Reg::r29),  "st4 {v26.b, v27.b, v28.b, v29.b}[0], [x30], x29");
+  TEST_SINGLE(st4<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30, Reg::r29), "st4 {v26.h, v27.h, v28.h, v29.h}[0], [x30], x29");
+  TEST_SINGLE(st4<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30, Reg::r29), "st4 {v26.s, v27.s, v28.s, v29.s}[0], [x30], x29");
+  TEST_SINGLE(st4<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30, Reg::r29), "st4 {v26.d, v27.d, v28.d, v29.d}[0], [x30], x29");
+
+  TEST_SINGLE(st4<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 15, Reg::r30, Reg::r29),  "st4 {v26.b, v27.b, v28.b, v29.b}[15], [x30], x29");
+  TEST_SINGLE(st4<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 7, Reg::r30, Reg::r29), "st4 {v26.h, v27.h, v28.h, v29.h}[7], [x30], x29");
+  TEST_SINGLE(st4<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 3, Reg::r30, Reg::r29), "st4 {v26.s, v27.s, v28.s, v29.s}[3], [x30], x29");
+  TEST_SINGLE(st4<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 1, Reg::r30, Reg::r29), "st4 {v26.d, v27.d, v28.d, v29.d}[1], [x30], x29");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Loadstore exclusive pair") {
+  TEST_SINGLE(stxp(Size::i32Bit, Reg::r28, Reg::r29, Reg::r30, Reg::r28), "stxp w28, w29, w30, [x28]");
+  TEST_SINGLE(stxp(Size::i64Bit, Reg::r28, Reg::r29, Reg::r30, Reg::r28), "stxp w28, x29, x30, [x28]");
+
+  TEST_SINGLE(stlxp(Size::i32Bit, Reg::r28, Reg::r29, Reg::r30, Reg::r28), "stlxp w28, w29, w30, [x28]");
+  TEST_SINGLE(stlxp(Size::i64Bit, Reg::r28, Reg::r29, Reg::r30, Reg::r28), "stlxp w28, x29, x30, [x28]");
+
+  TEST_SINGLE(ldxp(Size::i32Bit, Reg::r29, Reg::r30, Reg::r28), "ldxp w29, w30, [x28]");
+  TEST_SINGLE(ldxp(Size::i64Bit, Reg::r29, Reg::r30, Reg::r28), "ldxp x29, x30, [x28]");
+
+  TEST_SINGLE(ldaxp(Size::i32Bit, Reg::r29, Reg::r30, Reg::r28), "ldaxp w29, w30, [x28]");
+  TEST_SINGLE(ldaxp(Size::i64Bit, Reg::r29, Reg::r30, Reg::r28), "ldaxp x29, x30, [x28]");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Loadstore exclusive register") {
+  TEST_SINGLE(stxrb(Reg::r30, Reg::r29, Reg::r28), "stxrb w30, w29, [x28]");
+  TEST_SINGLE(stlxrb(Reg::r30, Reg::r29, Reg::r28), "stlxrb w30, w29, [x28]");
+
+  TEST_SINGLE(ldxrb(Reg::r30, Reg::r29), "ldxrb w30, [x29]");
+  TEST_SINGLE(ldaxrb(Reg::r30, Reg::r29), "ldaxrb w30, [x29]");
+
+  TEST_SINGLE(stxrh(Reg::r30, Reg::r29, Reg::r28), "stxrh w30, w29, [x28]");
+  TEST_SINGLE(stlxrh(Reg::r30, Reg::r29, Reg::r28), "stlxrh w30, w29, [x28]");
+
+  TEST_SINGLE(ldxrh(Reg::r30, Reg::r29), "ldxrh w30, [x29]");
+  TEST_SINGLE(ldaxrh(Reg::r30, Reg::r29), "ldaxrh w30, [x29]");
+
+  TEST_SINGLE(stxr(WReg::w30, WReg::w29, Reg::r28), "stxr w30, w29, [x28]");
+  TEST_SINGLE(stlxr(WReg::w30, WReg::w29, Reg::r28), "stlxr w30, w29, [x28]");
+
+  TEST_SINGLE(ldxr(WReg::w30, Reg::r29), "ldxr w30, [x29]");
+  TEST_SINGLE(ldaxr(WReg::w30, Reg::r29), "ldaxr w30, [x29]");
+
+  TEST_SINGLE(stxr(XReg::x30, XReg::x29, Reg::r28), "stxr w30, x29, [x28]");
+  TEST_SINGLE(stlxr(XReg::x30, XReg::x29, Reg::r28), "stlxr w30, x29, [x28]");
+
+  TEST_SINGLE(ldxr(XReg::x30, Reg::r29), "ldxr x30, [x29]");
+  TEST_SINGLE(ldaxr(XReg::x30, Reg::r29), "ldaxr x30, [x29]");
+
+  TEST_SINGLE(stxr(SubRegSize::i8Bit, Reg::r30, Reg::r29, Reg::r28), "stxrb w30, w29, [x28]");
+  TEST_SINGLE(stlxr(SubRegSize::i8Bit, Reg::r30, Reg::r29, Reg::r28), "stlxrb w30, w29, [x28]");
+  TEST_SINGLE(stxr(SubRegSize::i16Bit, Reg::r30, Reg::r29, Reg::r28), "stxrh w30, w29, [x28]");
+  TEST_SINGLE(stlxr(SubRegSize::i16Bit, Reg::r30, Reg::r29, Reg::r28), "stlxrh w30, w29, [x28]");
+  TEST_SINGLE(stxr(SubRegSize::i32Bit, Reg::r30, Reg::r29, Reg::r28), "stxr w30, w29, [x28]");
+  TEST_SINGLE(stlxr(SubRegSize::i32Bit, Reg::r30, Reg::r29, Reg::r28), "stlxr w30, w29, [x28]");
+  TEST_SINGLE(stxr(SubRegSize::i64Bit, Reg::r30, Reg::r29, Reg::r28), "stxr w30, x29, [x28]");
+  TEST_SINGLE(stlxr(SubRegSize::i64Bit, Reg::r30, Reg::r29, Reg::r28), "stlxr w30, x29, [x28]");
+
+  TEST_SINGLE(ldxr(SubRegSize::i8Bit, Reg::r30, Reg::r29), "ldxrb w30, [x29]");
+  TEST_SINGLE(ldaxr(SubRegSize::i8Bit, Reg::r30, Reg::r29), "ldaxrb w30, [x29]");
+  TEST_SINGLE(ldxr(SubRegSize::i16Bit, Reg::r30, Reg::r29), "ldxrh w30, [x29]");
+  TEST_SINGLE(ldaxr(SubRegSize::i16Bit, Reg::r30, Reg::r29), "ldaxrh w30, [x29]");
+  TEST_SINGLE(ldxr(SubRegSize::i32Bit, Reg::r30, Reg::r29), "ldxr w30, [x29]");
+  TEST_SINGLE(ldaxr(SubRegSize::i32Bit, Reg::r30, Reg::r29), "ldaxr w30, [x29]");
+  TEST_SINGLE(ldxr(SubRegSize::i64Bit, Reg::r30, Reg::r29), "ldxr x30, [x29]");
+  TEST_SINGLE(ldaxr(SubRegSize::i64Bit, Reg::r30, Reg::r29), "ldaxr x30, [x29]");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Load/store ordered") {
+  TEST_SINGLE(stllrb(Reg::r30, Reg::r29), "stllrb w30, [x29]");
+  TEST_SINGLE(stlrb(Reg::r30, Reg::r29), "stlrb w30, [x29]");
+  TEST_SINGLE(ldlarb(Reg::r30, Reg::r29), "ldlarb w30, [x29]");
+  TEST_SINGLE(ldarb(Reg::r30, Reg::r29), "ldarb w30, [x29]");
+
+  TEST_SINGLE(stllrh(Reg::r30, Reg::r29), "stllrh w30, [x29]");
+  TEST_SINGLE(stlrh(Reg::r30, Reg::r29), "stlrh w30, [x29]");
+  TEST_SINGLE(ldlarh(Reg::r30, Reg::r29), "ldlarh w30, [x29]");
+  TEST_SINGLE(ldarh(Reg::r30, Reg::r29), "ldarh w30, [x29]");
+
+  TEST_SINGLE(stllr(WReg::w30, Reg::r29), "stllr w30, [x29]");
+  TEST_SINGLE(stlr(WReg::w30, Reg::r29), "stlr w30, [x29]");
+  TEST_SINGLE(ldlar(WReg::w30, Reg::r29), "ldlar w30, [x29]");
+  TEST_SINGLE(ldar(WReg::w30, Reg::r29), "ldar w30, [x29]");
+
+  TEST_SINGLE(stllr(XReg::x30, Reg::r29), "stllr x30, [x29]");
+  TEST_SINGLE(stlr(XReg::x30, Reg::r29), "stlr x30, [x29]");
+  TEST_SINGLE(ldlar(XReg::x30, Reg::r29), "ldlar x30, [x29]");
+  TEST_SINGLE(ldar(XReg::x30, Reg::r29), "ldar x30, [x29]");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Compare and swap") {
+  TEST_SINGLE(casb(Reg::r30, Reg::r29, Reg::r28), "casb w30, w29, [x28]");
+  TEST_SINGLE(caslb(Reg::r30, Reg::r29, Reg::r28), "caslb w30, w29, [x28]");
+  TEST_SINGLE(casab(Reg::r30, Reg::r29, Reg::r28), "casab w30, w29, [x28]");
+  TEST_SINGLE(casalb(Reg::r30, Reg::r29, Reg::r28), "casalb w30, w29, [x28]");
+
+  TEST_SINGLE(cash(Reg::r30, Reg::r29, Reg::r28), "cash w30, w29, [x28]");
+  TEST_SINGLE(caslh(Reg::r30, Reg::r29, Reg::r28), "caslh w30, w29, [x28]");
+  TEST_SINGLE(casah(Reg::r30, Reg::r29, Reg::r28), "casah w30, w29, [x28]");
+  TEST_SINGLE(casalh(Reg::r30, Reg::r29, Reg::r28), "casalh w30, w29, [x28]");
+
+  TEST_SINGLE(cas(WReg::w30, WReg::w29, Reg::r28), "cas w30, w29, [x28]");
+  TEST_SINGLE(casl(WReg::w30, WReg::w29, Reg::r28), "casl w30, w29, [x28]");
+  TEST_SINGLE(casa(WReg::w30, WReg::w29, Reg::r28), "casa w30, w29, [x28]");
+  TEST_SINGLE(casal(WReg::w30, WReg::w29, Reg::r28), "casal w30, w29, [x28]");
+
+  TEST_SINGLE(cas(XReg::x30, XReg::x29, Reg::r28), "cas x30, x29, [x28]");
+  TEST_SINGLE(casl(XReg::x30, XReg::x29, Reg::r28), "casl x30, x29, [x28]");
+  TEST_SINGLE(casa(XReg::x30, XReg::x29, Reg::r28), "casa x30, x29, [x28]");
+  TEST_SINGLE(casal(XReg::x30, XReg::x29, Reg::r28), "casal x30, x29, [x28]");
+
+  TEST_SINGLE(cas(SubRegSize::i8Bit, Reg::r30, Reg::r29, Reg::r28), "casb w30, w29, [x28]");
+  TEST_SINGLE(cas(SubRegSize::i16Bit, Reg::r30, Reg::r29, Reg::r28), "cash w30, w29, [x28]");
+  TEST_SINGLE(cas(SubRegSize::i32Bit, Reg::r30, Reg::r29, Reg::r28), "cas w30, w29, [x28]");
+  TEST_SINGLE(cas(SubRegSize::i64Bit, Reg::r30, Reg::r29, Reg::r28), "cas x30, x29, [x28]");
+
+  TEST_SINGLE(casl(SubRegSize::i8Bit, Reg::r30, Reg::r29, Reg::r28), "caslb w30, w29, [x28]");
+  TEST_SINGLE(casl(SubRegSize::i16Bit, Reg::r30, Reg::r29, Reg::r28), "caslh w30, w29, [x28]");
+  TEST_SINGLE(casl(SubRegSize::i32Bit, Reg::r30, Reg::r29, Reg::r28), "casl w30, w29, [x28]");
+  TEST_SINGLE(casl(SubRegSize::i64Bit, Reg::r30, Reg::r29, Reg::r28), "casl x30, x29, [x28]");
+
+  TEST_SINGLE(casa(SubRegSize::i8Bit, Reg::r30, Reg::r29, Reg::r28), "casab w30, w29, [x28]");
+  TEST_SINGLE(casa(SubRegSize::i16Bit, Reg::r30, Reg::r29, Reg::r28), "casah w30, w29, [x28]");
+  TEST_SINGLE(casa(SubRegSize::i32Bit, Reg::r30, Reg::r29, Reg::r28), "casa w30, w29, [x28]");
+  TEST_SINGLE(casa(SubRegSize::i64Bit, Reg::r30, Reg::r29, Reg::r28), "casa x30, x29, [x28]");
+
+  TEST_SINGLE(casal(SubRegSize::i8Bit, Reg::r30, Reg::r29, Reg::r28), "casalb w30, w29, [x28]");
+  TEST_SINGLE(casal(SubRegSize::i16Bit, Reg::r30, Reg::r29, Reg::r28), "casalh w30, w29, [x28]");
+  TEST_SINGLE(casal(SubRegSize::i32Bit, Reg::r30, Reg::r29, Reg::r28), "casal w30, w29, [x28]");
+  TEST_SINGLE(casal(SubRegSize::i64Bit, Reg::r30, Reg::r29, Reg::r28), "casal x30, x29, [x28]");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: LDAPR/STLR unscaled immediate") {
+  TEST_SINGLE(stlurb(Reg::r30, Reg::r29, -256), "stlurb w30, [x29, #-256]");
+  TEST_SINGLE(stlurb(Reg::r30, Reg::r29, 255),  "stlurb w30, [x29, #255]");
+
+  TEST_SINGLE(ldapurb(Reg::r30, Reg::r29, -256), "ldapurb w30, [x29, #-256]");
+  TEST_SINGLE(ldapurb(Reg::r30, Reg::r29, 255),  "ldapurb w30, [x29, #255]");
+
+  TEST_SINGLE(ldapursb(WReg::w30, Reg::r29, -256), "ldapursb w30, [x29, #-256]");
+  TEST_SINGLE(ldapursb(WReg::w30, Reg::r29, 255),  "ldapursb w30, [x29, #255]");
+  TEST_SINGLE(ldapursb(XReg::x30, Reg::r29, -256), "ldapursb x30, [x29, #-256]");
+  TEST_SINGLE(ldapursb(XReg::x30, Reg::r29, 255),  "ldapursb x30, [x29, #255]");
+
+  TEST_SINGLE(stlurh(Reg::r30, Reg::r29, -256), "stlurh w30, [x29, #-256]");
+  TEST_SINGLE(stlurh(Reg::r30, Reg::r29, 255),  "stlurh w30, [x29, #255]");
+
+  TEST_SINGLE(ldapurh(Reg::r30, Reg::r29, -256), "ldapurh w30, [x29, #-256]");
+  TEST_SINGLE(ldapurh(Reg::r30, Reg::r29, 255),  "ldapurh w30, [x29, #255]");
+
+  TEST_SINGLE(ldapursh(WReg::w30, Reg::r29, -256), "ldapursh w30, [x29, #-256]");
+  TEST_SINGLE(ldapursh(WReg::w30, Reg::r29, 255),  "ldapursh w30, [x29, #255]");
+  TEST_SINGLE(ldapursh(XReg::x30, Reg::r29, -256), "ldapursh x30, [x29, #-256]");
+  TEST_SINGLE(ldapursh(XReg::x30, Reg::r29, 255),  "ldapursh x30, [x29, #255]");
+
+  TEST_SINGLE(stlur(WReg::w30, Reg::r29, -256), "stlur w30, [x29, #-256]");
+  TEST_SINGLE(stlur(WReg::w30, Reg::r29, 255),  "stlur w30, [x29, #255]");
+
+  TEST_SINGLE(ldapur(WReg::w30, Reg::r29, -256), "ldapur w30, [x29, #-256]");
+  TEST_SINGLE(ldapur(WReg::w30, Reg::r29, 255),  "ldapur w30, [x29, #255]");
+
+  TEST_SINGLE(ldapursw(XReg::x30, Reg::r29, -256), "ldapursw x30, [x29, #-256]");
+  TEST_SINGLE(ldapursw(XReg::x30, Reg::r29, 255),  "ldapursw x30, [x29, #255]");
+
+  TEST_SINGLE(stlur(XReg::x30, Reg::r29, -256), "stlur x30, [x29, #-256]");
+  TEST_SINGLE(stlur(XReg::x30, Reg::r29, 255),  "stlur x30, [x29, #255]");
+
+  TEST_SINGLE(ldapur(XReg::x30, Reg::r29, -256), "ldapur x30, [x29, #-256]");
+  TEST_SINGLE(ldapur(XReg::x30, Reg::r29, 255),  "ldapur x30, [x29, #255]");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Load register literal") {
+  {
+    BackwardLabel Label;
+    Bind(&Label);
+    dc32(0);
+    ldr(WReg::w30, &Label);
+
+    CHECK(DisassembleEncoding(1) == 0x18fffffe);
+  }
+
+  {
+    BackwardLabel Label;
+    Bind(&Label);
+    dc32(0);
+    ldr(SReg::s30, &Label);
+
+    CHECK(DisassembleEncoding(1) == 0x1cfffffe);
+  }
+
+  {
+    BackwardLabel Label;
+    Bind(&Label);
+    dc32(0);
+    ldr(XReg::x30, &Label);
+
+    CHECK(DisassembleEncoding(1) == 0x58fffffe);
+  }
+
+  {
+    BackwardLabel Label;
+    Bind(&Label);
+    dc32(0);
+    ldr(DReg::d30, &Label);
+
+    CHECK(DisassembleEncoding(1) == 0x5cfffffe);
+  }
+
+  {
+    BackwardLabel Label;
+    Bind(&Label);
+    dc32(0);
+    ldrsw(XReg::x30, &Label);
+
+    CHECK(DisassembleEncoding(1) == 0x98fffffe);
+  }
+
+  {
+    BackwardLabel Label;
+    Bind(&Label);
+    dc32(0);
+    ldr(QReg::q30, &Label);
+
+    CHECK(DisassembleEncoding(1) == 0x9cfffffe);
+  }
+
+  {
+    BackwardLabel Label;
+    Bind(&Label);
+    dc32(0);
+    prfm(Prefetch::PLDL1KEEP, &Label);
+
+    CHECK(DisassembleEncoding(1) == 0xd8ffffe0);
+  }
+
+  {
+    ForwardLabel Label;
+    ldr(WReg::w30, &Label);
+    Bind(&Label);
+    dc32(0);
+
+    CHECK(DisassembleEncoding(0) == 0x1800003e);
+  }
+
+  {
+    ForwardLabel Label;
+    ldr(SReg::s30, &Label);
+    Bind(&Label);
+    dc32(0);
+
+    CHECK(DisassembleEncoding(0) == 0x1c00003e);
+  }
+
+  {
+    ForwardLabel Label;
+    ldr(XReg::x30, &Label);
+    Bind(&Label);
+    dc32(0);
+
+    CHECK(DisassembleEncoding(0) == 0x5800003e);
+  }
+
+  {
+    ForwardLabel Label;
+    ldr(DReg::d30, &Label);
+    Bind(&Label);
+    dc32(0);
+
+    CHECK(DisassembleEncoding(0) == 0x5c00003e);
+  }
+
+  {
+    ForwardLabel Label;
+    ldrsw(XReg::x30, &Label);
+    Bind(&Label);
+    dc32(0);
+
+    CHECK(DisassembleEncoding(0) == 0x9800003e);
+  }
+
+  {
+    ForwardLabel Label;
+    ldr(QReg::q30, &Label);
+    Bind(&Label);
+    dc32(0);
+
+    CHECK(DisassembleEncoding(0) == 0x9c00003e);
+  }
+
+  {
+    ForwardLabel Label;
+    prfm(Prefetch::PLDL1KEEP, &Label);
+    Bind(&Label);
+    dc32(0);
+
+    CHECK(DisassembleEncoding(0) == 0xd8000020);
+  }
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Memory copy/set") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Loadstore no-allocate pair") {
+  TEST_SINGLE(stnp(WReg::w30, WReg::w28, Reg::r29, -256), "stnp w30, w28, [x29, #-256]");
+  TEST_SINGLE(stnp(WReg::w30, WReg::w28, Reg::r29, 252),  "stnp w30, w28, [x29, #252]");
+
+  TEST_SINGLE(ldnp(WReg::w30, WReg::w28, Reg::r29, -256), "ldnp w30, w28, [x29, #-256]");
+  TEST_SINGLE(ldnp(WReg::w30, WReg::w28, Reg::r29, 252),  "ldnp w30, w28, [x29, #252]");
+
+  TEST_SINGLE(stnp(SReg::s30, SReg::s28, Reg::r29, -256), "stnp s30, s28, [x29, #-256]");
+  TEST_SINGLE(stnp(SReg::s30, SReg::s28, Reg::r29, 252),  "stnp s30, s28, [x29, #252]");
+
+  TEST_SINGLE(ldnp(SReg::s30, SReg::s28, Reg::r29, -256), "ldnp s30, s28, [x29, #-256]");
+  TEST_SINGLE(ldnp(SReg::s30, SReg::s28, Reg::r29, 252),  "ldnp s30, s28, [x29, #252]");
+
+  TEST_SINGLE(stnp(XReg::x30, XReg::x28, Reg::r29, -512), "stnp x30, x28, [x29, #-512]");
+  TEST_SINGLE(stnp(XReg::x30, XReg::x28, Reg::r29, 504),  "stnp x30, x28, [x29, #504]");
+
+  TEST_SINGLE(ldnp(XReg::x30, XReg::x28, Reg::r29, -512), "ldnp x30, x28, [x29, #-512]");
+  TEST_SINGLE(ldnp(XReg::x30, XReg::x28, Reg::r29, 504),  "ldnp x30, x28, [x29, #504]");
+
+  TEST_SINGLE(stnp(DReg::d30, DReg::d28, Reg::r29, -512), "stnp d30, d28, [x29, #-512]");
+  TEST_SINGLE(stnp(DReg::d30, DReg::d28, Reg::r29, 504),  "stnp d30, d28, [x29, #504]");
+
+  TEST_SINGLE(ldnp(DReg::d30, DReg::d28, Reg::r29, -512), "ldnp d30, d28, [x29, #-512]");
+  TEST_SINGLE(ldnp(DReg::d30, DReg::d28, Reg::r29, 504),  "ldnp d30, d28, [x29, #504]");
+
+  TEST_SINGLE(stnp(QReg::q30, QReg::q28, Reg::r29, -1024), "stnp q30, q28, [x29, #-1024]");
+  TEST_SINGLE(stnp(QReg::q30, QReg::q28, Reg::r29, 1008),  "stnp q30, q28, [x29, #1008]");
+
+  TEST_SINGLE(ldnp(QReg::q30, QReg::q28, Reg::r29, -1024), "ldnp q30, q28, [x29, #-1024]");
+  TEST_SINGLE(ldnp(QReg::q30, QReg::q28, Reg::r29, 1008),  "ldnp q30, q28, [x29, #1008]");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Loadstore register pair post-indexed") {
+  TEST_SINGLE(stp<IndexType::POST>(WReg::w30, WReg::w28, Reg::r29, -256), "stp w30, w28, [x29], #-256");
+  TEST_SINGLE(stp<IndexType::POST>(WReg::w30, WReg::w28, Reg::r29, 252), "stp w30, w28, [x29], #252");
+
+  TEST_SINGLE(ldp<IndexType::POST>(WReg::w30, WReg::w28, Reg::r29, -256), "ldp w30, w28, [x29], #-256");
+  TEST_SINGLE(ldp<IndexType::POST>(WReg::w30, WReg::w28, Reg::r29, 252), "ldp w30, w28, [x29], #252");
+
+  TEST_SINGLE(ldpsw<IndexType::POST>(XReg::x30, WReg::w28, Reg::r29, -256), "ldpsw x30, x28, [x29], #-256");
+  TEST_SINGLE(ldpsw<IndexType::POST>(XReg::x30, WReg::w28, Reg::r29, 252), "ldpsw x30, x28, [x29], #252");
+
+  TEST_SINGLE(stp<IndexType::POST>(XReg::x30, XReg::x28, Reg::r29, -512), "stp x30, x28, [x29], #-512");
+  TEST_SINGLE(stp<IndexType::POST>(XReg::x30, XReg::x28, Reg::r29, 504), "stp x30, x28, [x29], #504");
+
+  TEST_SINGLE(ldp<IndexType::POST>(XReg::x30, XReg::x28, Reg::r29, -512), "ldp x30, x28, [x29], #-512");
+  TEST_SINGLE(ldp<IndexType::POST>(XReg::x30, XReg::x28, Reg::r29, 504), "ldp x30, x28, [x29], #504");
+
+  TEST_SINGLE(stp<IndexType::POST>(SReg::s30, SReg::s28, Reg::r29, -256), "stp s30, s28, [x29], #-256");
+  TEST_SINGLE(stp<IndexType::POST>(SReg::s30, SReg::s28, Reg::r29, 252), "stp s30, s28, [x29], #252");
+
+  TEST_SINGLE(ldp<IndexType::POST>(SReg::s30, SReg::s28, Reg::r29, -256), "ldp s30, s28, [x29], #-256");
+  TEST_SINGLE(ldp<IndexType::POST>(SReg::s30, SReg::s28, Reg::r29, 252), "ldp s30, s28, [x29], #252");
+
+  TEST_SINGLE(stp<IndexType::POST>(DReg::d30, DReg::d28, Reg::r29, -512), "stp d30, d28, [x29], #-512");
+  TEST_SINGLE(stp<IndexType::POST>(DReg::d30, DReg::d28, Reg::r29, 504), "stp d30, d28, [x29], #504");
+
+  TEST_SINGLE(ldp<IndexType::POST>(DReg::d30, DReg::d28, Reg::r29, -512), "ldp d30, d28, [x29], #-512");
+  TEST_SINGLE(ldp<IndexType::POST>(DReg::d30, DReg::d28, Reg::r29, 504), "ldp d30, d28, [x29], #504");
+
+  TEST_SINGLE(stp<IndexType::POST>(QReg::q30, QReg::q28, Reg::r29, -1024), "stp q30, q28, [x29], #-1024");
+  TEST_SINGLE(stp<IndexType::POST>(QReg::q30, QReg::q28, Reg::r29, 1008), "stp q30, q28, [x29], #1008");
+
+  TEST_SINGLE(ldp<IndexType::POST>(QReg::q30, QReg::q28, Reg::r29, -1024), "ldp q30, q28, [x29], #-1024");
+  TEST_SINGLE(ldp<IndexType::POST>(QReg::q30, QReg::q28, Reg::r29, 1008), "ldp q30, q28, [x29], #1008");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Loadstore register pair offset") {
+  TEST_SINGLE(stp<IndexType::OFFSET>(WReg::w30, WReg::w28, Reg::r29, -256), "stp w30, w28, [x29, #-256]");
+  TEST_SINGLE(stp<IndexType::OFFSET>(WReg::w30, WReg::w28, Reg::r29, 252), "stp w30, w28, [x29, #252]");
+
+  TEST_SINGLE(ldp<IndexType::OFFSET>(WReg::w30, WReg::w28, Reg::r29, -256), "ldp w30, w28, [x29, #-256]");
+  TEST_SINGLE(ldp<IndexType::OFFSET>(WReg::w30, WReg::w28, Reg::r29, 252), "ldp w30, w28, [x29, #252]");
+
+  TEST_SINGLE(ldpsw<IndexType::OFFSET>(XReg::x30, WReg::w28, Reg::r29, -256), "ldpsw x30, x28, [x29, #-256]");
+  TEST_SINGLE(ldpsw<IndexType::OFFSET>(XReg::x30, WReg::w28, Reg::r29, 252), "ldpsw x30, x28, [x29, #252]");
+
+  TEST_SINGLE(stp<IndexType::OFFSET>(XReg::x30, XReg::x28, Reg::r29, -512), "stp x30, x28, [x29, #-512]");
+  TEST_SINGLE(stp<IndexType::OFFSET>(XReg::x30, XReg::x28, Reg::r29, 504), "stp x30, x28, [x29, #504]");
+
+  TEST_SINGLE(ldp<IndexType::OFFSET>(XReg::x30, XReg::x28, Reg::r29, -512), "ldp x30, x28, [x29, #-512]");
+  TEST_SINGLE(ldp<IndexType::OFFSET>(XReg::x30, XReg::x28, Reg::r29, 504), "ldp x30, x28, [x29, #504]");
+
+  TEST_SINGLE(stp<IndexType::OFFSET>(SReg::s30, SReg::s28, Reg::r29, -256), "stp s30, s28, [x29, #-256]");
+  TEST_SINGLE(stp<IndexType::OFFSET>(SReg::s30, SReg::s28, Reg::r29, 252), "stp s30, s28, [x29, #252]");
+
+  TEST_SINGLE(ldp<IndexType::OFFSET>(SReg::s30, SReg::s28, Reg::r29, -256), "ldp s30, s28, [x29, #-256]");
+  TEST_SINGLE(ldp<IndexType::OFFSET>(SReg::s30, SReg::s28, Reg::r29, 252), "ldp s30, s28, [x29, #252]");
+
+  TEST_SINGLE(stp<IndexType::OFFSET>(DReg::d30, DReg::d28, Reg::r29, -512), "stp d30, d28, [x29, #-512]");
+  TEST_SINGLE(stp<IndexType::OFFSET>(DReg::d30, DReg::d28, Reg::r29, 504), "stp d30, d28, [x29, #504]");
+
+  TEST_SINGLE(ldp<IndexType::OFFSET>(DReg::d30, DReg::d28, Reg::r29, -512), "ldp d30, d28, [x29, #-512]");
+  TEST_SINGLE(ldp<IndexType::OFFSET>(DReg::d30, DReg::d28, Reg::r29, 504), "ldp d30, d28, [x29, #504]");
+
+  TEST_SINGLE(stp<IndexType::OFFSET>(QReg::q30, QReg::q28, Reg::r29, -1024), "stp q30, q28, [x29, #-1024]");
+  TEST_SINGLE(stp<IndexType::OFFSET>(QReg::q30, QReg::q28, Reg::r29, 1008), "stp q30, q28, [x29, #1008]");
+
+  TEST_SINGLE(ldp<IndexType::OFFSET>(QReg::q30, QReg::q28, Reg::r29, -1024), "ldp q30, q28, [x29, #-1024]");
+  TEST_SINGLE(ldp<IndexType::OFFSET>(QReg::q30, QReg::q28, Reg::r29, 1008), "ldp q30, q28, [x29, #1008]");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Loadstore register pair pre-indexed") {
+  TEST_SINGLE(stp<IndexType::PRE>(WReg::w30, WReg::w28, Reg::r29, -256), "stp w30, w28, [x29, #-256]!");
+  TEST_SINGLE(stp<IndexType::PRE>(WReg::w30, WReg::w28, Reg::r29, 252), "stp w30, w28, [x29, #252]!");
+
+  TEST_SINGLE(ldp<IndexType::PRE>(WReg::w30, WReg::w28, Reg::r29, -256), "ldp w30, w28, [x29, #-256]!");
+  TEST_SINGLE(ldp<IndexType::PRE>(WReg::w30, WReg::w28, Reg::r29, 252), "ldp w30, w28, [x29, #252]!");
+
+  TEST_SINGLE(ldpsw<IndexType::PRE>(XReg::x30, WReg::w28, Reg::r29, -256), "ldpsw x30, x28, [x29, #-256]!");
+  TEST_SINGLE(ldpsw<IndexType::PRE>(XReg::x30, WReg::w28, Reg::r29, 252), "ldpsw x30, x28, [x29, #252]!");
+
+  TEST_SINGLE(stp<IndexType::PRE>(XReg::x30, XReg::x28, Reg::r29, -512), "stp x30, x28, [x29, #-512]!");
+  TEST_SINGLE(stp<IndexType::PRE>(XReg::x30, XReg::x28, Reg::r29, 504), "stp x30, x28, [x29, #504]!");
+
+  TEST_SINGLE(ldp<IndexType::PRE>(XReg::x30, XReg::x28, Reg::r29, -512), "ldp x30, x28, [x29, #-512]!");
+  TEST_SINGLE(ldp<IndexType::PRE>(XReg::x30, XReg::x28, Reg::r29, 504), "ldp x30, x28, [x29, #504]!");
+
+  TEST_SINGLE(stp<IndexType::PRE>(SReg::s30, SReg::s28, Reg::r29, -256), "stp s30, s28, [x29, #-256]!");
+  TEST_SINGLE(stp<IndexType::PRE>(SReg::s30, SReg::s28, Reg::r29, 252), "stp s30, s28, [x29, #252]!");
+
+  TEST_SINGLE(ldp<IndexType::PRE>(SReg::s30, SReg::s28, Reg::r29, -256), "ldp s30, s28, [x29, #-256]!");
+  TEST_SINGLE(ldp<IndexType::PRE>(SReg::s30, SReg::s28, Reg::r29, 252), "ldp s30, s28, [x29, #252]!");
+
+  TEST_SINGLE(stp<IndexType::PRE>(DReg::d30, DReg::d28, Reg::r29, -512), "stp d30, d28, [x29, #-512]!");
+  TEST_SINGLE(stp<IndexType::PRE>(DReg::d30, DReg::d28, Reg::r29, 504), "stp d30, d28, [x29, #504]!");
+
+  TEST_SINGLE(ldp<IndexType::PRE>(DReg::d30, DReg::d28, Reg::r29, -512), "ldp d30, d28, [x29, #-512]!");
+  TEST_SINGLE(ldp<IndexType::PRE>(DReg::d30, DReg::d28, Reg::r29, 504), "ldp d30, d28, [x29, #504]!");
+
+  TEST_SINGLE(stp<IndexType::PRE>(QReg::q30, QReg::q28, Reg::r29, -1024), "stp q30, q28, [x29, #-1024]!");
+  TEST_SINGLE(stp<IndexType::PRE>(QReg::q30, QReg::q28, Reg::r29, 1008), "stp q30, q28, [x29, #1008]!");
+
+  TEST_SINGLE(ldp<IndexType::PRE>(QReg::q30, QReg::q28, Reg::r29, -1024), "ldp q30, q28, [x29, #-1024]!");
+  TEST_SINGLE(ldp<IndexType::PRE>(QReg::q30, QReg::q28, Reg::r29, 1008), "ldp q30, q28, [x29, #1008]!");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Loadstore register immediate post-indexed") {
+  TEST_SINGLE(strb<IndexType::POST>(Reg::r30, Reg::r29, -256), "strb w30, [x29], #-256");
+  TEST_SINGLE(strb<IndexType::POST>(Reg::r30, Reg::r29, 255), "strb w30, [x29], #255");
+  TEST_SINGLE(ldrb<IndexType::POST>(Reg::r30, Reg::r29, -256), "ldrb w30, [x29], #-256");
+  TEST_SINGLE(ldrb<IndexType::POST>(Reg::r30, Reg::r29, 255), "ldrb w30, [x29], #255");
+
+  TEST_SINGLE(strb<IndexType::POST>(VReg::v30, Reg::r29, -256), "str b30, [x29], #-256");
+  TEST_SINGLE(strb<IndexType::POST>(VReg::v30, Reg::r29, 255), "str b30, [x29], #255");
+  TEST_SINGLE(ldrb<IndexType::POST>(VReg::v30, Reg::r29, -256), "ldr b30, [x29], #-256");
+  TEST_SINGLE(ldrb<IndexType::POST>(VReg::v30, Reg::r29, 255), "ldr b30, [x29], #255");
+
+  TEST_SINGLE(ldrsb<IndexType::POST>(WReg::w30, Reg::r29, -256), "ldrsb w30, [x29], #-256");
+  TEST_SINGLE(ldrsb<IndexType::POST>(WReg::w30, Reg::r29, 255), "ldrsb w30, [x29], #255");
+  TEST_SINGLE(ldrsb<IndexType::POST>(XReg::x30, Reg::r29, -256), "ldrsb x30, [x29], #-256");
+  TEST_SINGLE(ldrsb<IndexType::POST>(XReg::x30, Reg::r29, 255), "ldrsb x30, [x29], #255");
+
+  TEST_SINGLE(strh<IndexType::POST>(Reg::r30, Reg::r29, -256), "strh w30, [x29], #-256");
+  TEST_SINGLE(strh<IndexType::POST>(Reg::r30, Reg::r29, 255), "strh w30, [x29], #255");
+  TEST_SINGLE(ldrh<IndexType::POST>(Reg::r30, Reg::r29, -256), "ldrh w30, [x29], #-256");
+  TEST_SINGLE(ldrh<IndexType::POST>(Reg::r30, Reg::r29, 255), "ldrh w30, [x29], #255");
+
+  TEST_SINGLE(strh<IndexType::POST>(VReg::v30, Reg::r29, -256), "str h30, [x29], #-256");
+  TEST_SINGLE(strh<IndexType::POST>(VReg::v30, Reg::r29, 255), "str h30, [x29], #255");
+  TEST_SINGLE(ldrh<IndexType::POST>(VReg::v30, Reg::r29, -256), "ldr h30, [x29], #-256");
+  TEST_SINGLE(ldrh<IndexType::POST>(VReg::v30, Reg::r29, 255), "ldr h30, [x29], #255");
+
+  TEST_SINGLE(ldrsh<IndexType::POST>(WReg::w30, Reg::r29, -256), "ldrsh w30, [x29], #-256");
+  TEST_SINGLE(ldrsh<IndexType::POST>(WReg::w30, Reg::r29, 255), "ldrsh w30, [x29], #255");
+  TEST_SINGLE(ldrsh<IndexType::POST>(XReg::x30, Reg::r29, -256), "ldrsh x30, [x29], #-256");
+  TEST_SINGLE(ldrsh<IndexType::POST>(XReg::x30, Reg::r29, 255), "ldrsh x30, [x29], #255");
+
+  TEST_SINGLE(str<IndexType::POST>(WReg::w30, Reg::r29, -256), "str w30, [x29], #-256");
+  TEST_SINGLE(str<IndexType::POST>(WReg::w30, Reg::r29, 255), "str w30, [x29], #255");
+  TEST_SINGLE(ldr<IndexType::POST>(WReg::w30, Reg::r29, -256), "ldr w30, [x29], #-256");
+  TEST_SINGLE(ldr<IndexType::POST>(WReg::w30, Reg::r29, 255), "ldr w30, [x29], #255");
+
+  TEST_SINGLE(str<IndexType::POST>(SReg::s30, Reg::r29, -256), "str s30, [x29], #-256");
+  TEST_SINGLE(str<IndexType::POST>(SReg::s30, Reg::r29, 255), "str s30, [x29], #255");
+  TEST_SINGLE(ldr<IndexType::POST>(SReg::s30, Reg::r29, -256), "ldr s30, [x29], #-256");
+  TEST_SINGLE(ldr<IndexType::POST>(SReg::s30, Reg::r29, 255), "ldr s30, [x29], #255");
+
+  TEST_SINGLE(ldrsw<IndexType::POST>(XReg::x30, Reg::r29, -256), "ldrsw x30, [x29], #-256");
+  TEST_SINGLE(ldrsw<IndexType::POST>(XReg::x30, Reg::r29, 255), "ldrsw x30, [x29], #255");
+
+  TEST_SINGLE(str<IndexType::POST>(XReg::x30, Reg::r29, -256), "str x30, [x29], #-256");
+  TEST_SINGLE(str<IndexType::POST>(XReg::x30, Reg::r29, 255), "str x30, [x29], #255");
+  TEST_SINGLE(ldr<IndexType::POST>(XReg::x30, Reg::r29, -256), "ldr x30, [x29], #-256");
+  TEST_SINGLE(ldr<IndexType::POST>(XReg::x30, Reg::r29, 255), "ldr x30, [x29], #255");
+
+  TEST_SINGLE(str<IndexType::POST>(DReg::d30, Reg::r29, -256), "str d30, [x29], #-256");
+  TEST_SINGLE(str<IndexType::POST>(DReg::d30, Reg::r29, 255), "str d30, [x29], #255");
+  TEST_SINGLE(ldr<IndexType::POST>(DReg::d30, Reg::r29, -256), "ldr d30, [x29], #-256");
+  TEST_SINGLE(ldr<IndexType::POST>(DReg::d30, Reg::r29, 255), "ldr d30, [x29], #255");
+
+  TEST_SINGLE(str<IndexType::POST>(QReg::q30, Reg::r29, -256), "str q30, [x29], #-256");
+  TEST_SINGLE(str<IndexType::POST>(QReg::q30, Reg::r29, 255), "str q30, [x29], #255");
+  TEST_SINGLE(ldr<IndexType::POST>(QReg::q30, Reg::r29, -256), "ldr q30, [x29], #-256");
+  TEST_SINGLE(ldr<IndexType::POST>(QReg::q30, Reg::r29, 255), "ldr q30, [x29], #255");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Loadstore register immediate pre-indexed") {
+  TEST_SINGLE(strb<IndexType::PRE>(Reg::r30, Reg::r29, -256), "strb w30, [x29, #-256]!");
+  TEST_SINGLE(strb<IndexType::PRE>(Reg::r30, Reg::r29, 255), "strb w30, [x29, #255]!");
+  TEST_SINGLE(ldrb<IndexType::PRE>(Reg::r30, Reg::r29, -256), "ldrb w30, [x29, #-256]!");
+  TEST_SINGLE(ldrb<IndexType::PRE>(Reg::r30, Reg::r29, 255), "ldrb w30, [x29, #255]!");
+
+  TEST_SINGLE(strb<IndexType::PRE>(VReg::v30, Reg::r29, -256), "str b30, [x29, #-256]!");
+  TEST_SINGLE(strb<IndexType::PRE>(VReg::v30, Reg::r29, 255), "str b30, [x29, #255]!");
+  TEST_SINGLE(ldrb<IndexType::PRE>(VReg::v30, Reg::r29, -256), "ldr b30, [x29, #-256]!");
+  TEST_SINGLE(ldrb<IndexType::PRE>(VReg::v30, Reg::r29, 255), "ldr b30, [x29, #255]!");
+
+  TEST_SINGLE(ldrsb<IndexType::PRE>(WReg::w30, Reg::r29, -256), "ldrsb w30, [x29, #-256]!");
+  TEST_SINGLE(ldrsb<IndexType::PRE>(WReg::w30, Reg::r29, 255), "ldrsb w30, [x29, #255]!");
+  TEST_SINGLE(ldrsb<IndexType::PRE>(XReg::x30, Reg::r29, -256), "ldrsb x30, [x29, #-256]!");
+  TEST_SINGLE(ldrsb<IndexType::PRE>(XReg::x30, Reg::r29, 255), "ldrsb x30, [x29, #255]!");
+
+  TEST_SINGLE(strh<IndexType::PRE>(Reg::r30, Reg::r29, -256), "strh w30, [x29, #-256]!");
+  TEST_SINGLE(strh<IndexType::PRE>(Reg::r30, Reg::r29, 255), "strh w30, [x29, #255]!");
+  TEST_SINGLE(ldrh<IndexType::PRE>(Reg::r30, Reg::r29, -256), "ldrh w30, [x29, #-256]!");
+  TEST_SINGLE(ldrh<IndexType::PRE>(Reg::r30, Reg::r29, 255), "ldrh w30, [x29, #255]!");
+
+  TEST_SINGLE(strh<IndexType::PRE>(VReg::v30, Reg::r29, -256), "str h30, [x29, #-256]!");
+  TEST_SINGLE(strh<IndexType::PRE>(VReg::v30, Reg::r29, 255), "str h30, [x29, #255]!");
+  TEST_SINGLE(ldrh<IndexType::PRE>(VReg::v30, Reg::r29, -256), "ldr h30, [x29, #-256]!");
+  TEST_SINGLE(ldrh<IndexType::PRE>(VReg::v30, Reg::r29, 255), "ldr h30, [x29, #255]!");
+
+  TEST_SINGLE(ldrsh<IndexType::PRE>(WReg::w30, Reg::r29, -256), "ldrsh w30, [x29, #-256]!");
+  TEST_SINGLE(ldrsh<IndexType::PRE>(WReg::w30, Reg::r29, 255), "ldrsh w30, [x29, #255]!");
+  TEST_SINGLE(ldrsh<IndexType::PRE>(XReg::x30, Reg::r29, -256), "ldrsh x30, [x29, #-256]!");
+  TEST_SINGLE(ldrsh<IndexType::PRE>(XReg::x30, Reg::r29, 255), "ldrsh x30, [x29, #255]!");
+
+  TEST_SINGLE(str<IndexType::PRE>(WReg::w30, Reg::r29, -256), "str w30, [x29, #-256]!");
+  TEST_SINGLE(str<IndexType::PRE>(WReg::w30, Reg::r29, 255), "str w30, [x29, #255]!");
+  TEST_SINGLE(ldr<IndexType::PRE>(WReg::w30, Reg::r29, -256), "ldr w30, [x29, #-256]!");
+  TEST_SINGLE(ldr<IndexType::PRE>(WReg::w30, Reg::r29, 255), "ldr w30, [x29, #255]!");
+
+  TEST_SINGLE(str<IndexType::PRE>(SReg::s30, Reg::r29, -256), "str s30, [x29, #-256]!");
+  TEST_SINGLE(str<IndexType::PRE>(SReg::s30, Reg::r29, 255), "str s30, [x29, #255]!");
+  TEST_SINGLE(ldr<IndexType::PRE>(SReg::s30, Reg::r29, -256), "ldr s30, [x29, #-256]!");
+  TEST_SINGLE(ldr<IndexType::PRE>(SReg::s30, Reg::r29, 255), "ldr s30, [x29, #255]!");
+
+  TEST_SINGLE(ldrsw<IndexType::PRE>(XReg::x30, Reg::r29, -256), "ldrsw x30, [x29, #-256]!");
+  TEST_SINGLE(ldrsw<IndexType::PRE>(XReg::x30, Reg::r29, 255), "ldrsw x30, [x29, #255]!");
+
+  TEST_SINGLE(str<IndexType::PRE>(XReg::x30, Reg::r29, -256), "str x30, [x29, #-256]!");
+  TEST_SINGLE(str<IndexType::PRE>(XReg::x30, Reg::r29, 255), "str x30, [x29, #255]!");
+  TEST_SINGLE(ldr<IndexType::PRE>(XReg::x30, Reg::r29, -256), "ldr x30, [x29, #-256]!");
+  TEST_SINGLE(ldr<IndexType::PRE>(XReg::x30, Reg::r29, 255), "ldr x30, [x29, #255]!");
+
+  TEST_SINGLE(str<IndexType::PRE>(DReg::d30, Reg::r29, -256), "str d30, [x29, #-256]!");
+  TEST_SINGLE(str<IndexType::PRE>(DReg::d30, Reg::r29, 255), "str d30, [x29, #255]!");
+  TEST_SINGLE(ldr<IndexType::PRE>(DReg::d30, Reg::r29, -256), "ldr d30, [x29, #-256]!");
+  TEST_SINGLE(ldr<IndexType::PRE>(DReg::d30, Reg::r29, 255), "ldr d30, [x29, #255]!");
+
+  TEST_SINGLE(str<IndexType::PRE>(QReg::q30, Reg::r29, -256), "str q30, [x29, #-256]!");
+  TEST_SINGLE(str<IndexType::PRE>(QReg::q30, Reg::r29, 255), "str q30, [x29, #255]!");
+  TEST_SINGLE(ldr<IndexType::PRE>(QReg::q30, Reg::r29, -256), "ldr q30, [x29, #-256]!");
+  TEST_SINGLE(ldr<IndexType::PRE>(QReg::q30, Reg::r29, 255), "ldr q30, [x29, #255]!");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Loadstore register unprivileged") {
+  if (false) {
+    // vixl can't disassemble this class of instructions.
+    TEST_SINGLE(sttrb(Reg::r30, Reg::r29, -256), "sttrb w30, [x29, #-256]");
+    TEST_SINGLE(sttrb(Reg::r30, Reg::r29, 255), "sttrb w30, [x29, #255]");
+
+    TEST_SINGLE(ldtrb(Reg::r30, Reg::r29, -256), "ldtrb w30, [x29, #-256]");
+    TEST_SINGLE(ldtrb(Reg::r30, Reg::r29, 255), "ldtrb w30, [x29, #255]");
+
+    TEST_SINGLE(ldtrsb(WReg::w30, Reg::r29, -256), "ldtrsb w30, [x29, #-256]");
+    TEST_SINGLE(ldtrsb(WReg::w30, Reg::r29, 255), "ldtrsb w30, [x29, #255]");
+    TEST_SINGLE(ldtrsb(XReg::x30, Reg::r29, -256), "ldtrsb x30, [x29, #-256]");
+    TEST_SINGLE(ldtrsb(XReg::x30, Reg::r29, 255), "ldtrsb x30, [x29, #255]");
+
+    TEST_SINGLE(sttrh(Reg::r30, Reg::r29, -256), "sttrh w30, [x29, #-256]");
+    TEST_SINGLE(sttrh(Reg::r30, Reg::r29, 255), "sttrh w30, [x29, #255]");
+
+    TEST_SINGLE(ldtrh(Reg::r30, Reg::r29, -256), "ldtrh w30, [x29, #-256]");
+    TEST_SINGLE(ldtrh(Reg::r30, Reg::r29, 255), "ldtrh w30, [x29, #255]");
+
+    TEST_SINGLE(ldtrsh(WReg::w30, Reg::r29, -256), "ldtrsh w30, [x29, #-256]");
+    TEST_SINGLE(ldtrsh(WReg::w30, Reg::r29, 255), "ldtrsh w30, [x29, #255]");
+    TEST_SINGLE(ldtrsh(XReg::x30, Reg::r29, -256), "ldtrsh x30, [x29, #-256]");
+    TEST_SINGLE(ldtrsh(XReg::x30, Reg::r29, 255), "ldtrsh x30, [x29, #255]");
+
+    TEST_SINGLE(sttr(WReg::w30, Reg::r29, -256), "sttr w30, [x29, #-256]");
+    TEST_SINGLE(sttr(WReg::w30, Reg::r29, 255), "sttr w30, [x29, #255]");
+
+    TEST_SINGLE(ldtr(WReg::w30, Reg::r29, -256), "ldtr w30, [x29, #-256]");
+    TEST_SINGLE(ldtr(WReg::w30, Reg::r29, 255), "ldtr w30, [x29, #255]");
+
+    TEST_SINGLE(ldtrsw(XReg::x30, Reg::r29, -256), "ldtrsw x30, [x29, #-256]");
+    TEST_SINGLE(ldtrsw(XReg::x30, Reg::r29, 255), "ldtrsw x30, [x29, #255]");
+
+    TEST_SINGLE(sttr(XReg::x30, Reg::r29, -256), "sttr x30, [x29, #-256]");
+    TEST_SINGLE(sttr(XReg::x30, Reg::r29, 255), "sttr x30, [x29, #255]");
+
+    TEST_SINGLE(ldtr(XReg::x30, Reg::r29, -256), "ldtr x30, [x29, #-256]");
+    TEST_SINGLE(ldtr(XReg::x30, Reg::r29, 255), "ldtr x30, [x29, #255]");
+  }
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Atomic memory operations") {
+  TEST_SINGLE(stadd(SubRegSize::i8Bit, Reg::r30, Reg::r29), "staddb w30, [x29]");
+  TEST_SINGLE(stadd(SubRegSize::i16Bit, Reg::r30, Reg::r29), "staddh w30, [x29]");
+  TEST_SINGLE(stadd(SubRegSize::i32Bit, Reg::r30, Reg::r29), "stadd w30, [x29]");
+  TEST_SINGLE(stadd(SubRegSize::i64Bit, Reg::r30, Reg::r29), "stadd x30, [x29]");
+
+  TEST_SINGLE(staddl(SubRegSize::i8Bit, Reg::r30, Reg::r29), "staddlb w30, [x29]");
+  TEST_SINGLE(staddl(SubRegSize::i16Bit, Reg::r30, Reg::r29), "staddlh w30, [x29]");
+  TEST_SINGLE(staddl(SubRegSize::i32Bit, Reg::r30, Reg::r29), "staddl w30, [x29]");
+  TEST_SINGLE(staddl(SubRegSize::i64Bit, Reg::r30, Reg::r29), "staddl x30, [x29]");
+
+  TEST_SINGLE(stclr(SubRegSize::i8Bit, Reg::r30, Reg::r29), "stclrb w30, [x29]");
+  TEST_SINGLE(stclr(SubRegSize::i16Bit, Reg::r30, Reg::r29), "stclrh w30, [x29]");
+  TEST_SINGLE(stclr(SubRegSize::i32Bit, Reg::r30, Reg::r29), "stclr w30, [x29]");
+  TEST_SINGLE(stclr(SubRegSize::i64Bit, Reg::r30, Reg::r29), "stclr x30, [x29]");
+
+  TEST_SINGLE(stclrl(SubRegSize::i8Bit, Reg::r30, Reg::r29), "stclrlb w30, [x29]");
+  TEST_SINGLE(stclrl(SubRegSize::i16Bit, Reg::r30, Reg::r29), "stclrlh w30, [x29]");
+  TEST_SINGLE(stclrl(SubRegSize::i32Bit, Reg::r30, Reg::r29), "stclrl w30, [x29]");
+  TEST_SINGLE(stclrl(SubRegSize::i64Bit, Reg::r30, Reg::r29), "stclrl x30, [x29]");
+
+  TEST_SINGLE(stset(SubRegSize::i8Bit, Reg::r30, Reg::r29), "stsetb w30, [x29]");
+  TEST_SINGLE(stset(SubRegSize::i16Bit, Reg::r30, Reg::r29), "stseth w30, [x29]");
+  TEST_SINGLE(stset(SubRegSize::i32Bit, Reg::r30, Reg::r29), "stset w30, [x29]");
+  TEST_SINGLE(stset(SubRegSize::i64Bit, Reg::r30, Reg::r29), "stset x30, [x29]");
+
+  TEST_SINGLE(stsetl(SubRegSize::i8Bit, Reg::r30, Reg::r29), "stsetlb w30, [x29]");
+  TEST_SINGLE(stsetl(SubRegSize::i16Bit, Reg::r30, Reg::r29), "stsetlh w30, [x29]");
+  TEST_SINGLE(stsetl(SubRegSize::i32Bit, Reg::r30, Reg::r29), "stsetl w30, [x29]");
+  TEST_SINGLE(stsetl(SubRegSize::i64Bit, Reg::r30, Reg::r29), "stsetl x30, [x29]");
+
+  TEST_SINGLE(steor(SubRegSize::i8Bit, Reg::r30, Reg::r29), "steorb w30, [x29]");
+  TEST_SINGLE(steor(SubRegSize::i16Bit, Reg::r30, Reg::r29), "steorh w30, [x29]");
+  TEST_SINGLE(steor(SubRegSize::i32Bit, Reg::r30, Reg::r29), "steor w30, [x29]");
+  TEST_SINGLE(steor(SubRegSize::i64Bit, Reg::r30, Reg::r29), "steor x30, [x29]");
+
+  TEST_SINGLE(steorl(SubRegSize::i8Bit, Reg::r30, Reg::r29), "steorlb w30, [x29]");
+  TEST_SINGLE(steorl(SubRegSize::i16Bit, Reg::r30, Reg::r29), "steorlh w30, [x29]");
+  TEST_SINGLE(steorl(SubRegSize::i32Bit, Reg::r30, Reg::r29), "steorl w30, [x29]");
+  TEST_SINGLE(steorl(SubRegSize::i64Bit, Reg::r30, Reg::r29), "steorl x30, [x29]");
+
+  TEST_SINGLE(ldswp(SubRegSize::i8Bit, Reg::r30, Reg::r28, Reg::r29), "swpb w30, w28, [x29]");
+  TEST_SINGLE(ldswp(SubRegSize::i16Bit, Reg::r30, Reg::r28, Reg::r29), "swph w30, w28, [x29]");
+  TEST_SINGLE(ldswp(SubRegSize::i32Bit, Reg::r30, Reg::r28, Reg::r29), "swp w30, w28, [x29]");
+  TEST_SINGLE(ldswp(SubRegSize::i64Bit, Reg::r30, Reg::r28, Reg::r29), "swp x30, x28, [x29]");
+
+  TEST_SINGLE(ldswpl(SubRegSize::i8Bit, Reg::r30, Reg::r28, Reg::r29), "swplb w30, w28, [x29]");
+  TEST_SINGLE(ldswpl(SubRegSize::i16Bit, Reg::r30, Reg::r28, Reg::r29), "swplh w30, w28, [x29]");
+  TEST_SINGLE(ldswpl(SubRegSize::i32Bit, Reg::r30, Reg::r28, Reg::r29), "swpl w30, w28, [x29]");
+  TEST_SINGLE(ldswpl(SubRegSize::i64Bit, Reg::r30, Reg::r28, Reg::r29), "swpl x30, x28, [x29]");
+
+  TEST_SINGLE(ldswpa(SubRegSize::i8Bit, Reg::r30, Reg::r28, Reg::r29), "swpab w30, w28, [x29]");
+  TEST_SINGLE(ldswpa(SubRegSize::i16Bit, Reg::r30, Reg::r28, Reg::r29), "swpah w30, w28, [x29]");
+  TEST_SINGLE(ldswpa(SubRegSize::i32Bit, Reg::r30, Reg::r28, Reg::r29), "swpa w30, w28, [x29]");
+  TEST_SINGLE(ldswpa(SubRegSize::i64Bit, Reg::r30, Reg::r28, Reg::r29), "swpa x30, x28, [x29]");
+
+  TEST_SINGLE(ldswpal(SubRegSize::i8Bit, Reg::r30, Reg::r28, Reg::r29), "swpalb w30, w28, [x29]");
+  TEST_SINGLE(ldswpal(SubRegSize::i16Bit, Reg::r30, Reg::r28, Reg::r29), "swpalh w30, w28, [x29]");
+  TEST_SINGLE(ldswpal(SubRegSize::i32Bit, Reg::r30, Reg::r28, Reg::r29), "swpal w30, w28, [x29]");
+  TEST_SINGLE(ldswpal(SubRegSize::i64Bit, Reg::r30, Reg::r28, Reg::r29), "swpal x30, x28, [x29]");
+
+  TEST_SINGLE(ldadd(SubRegSize::i8Bit, Reg::r30, Reg::r28, Reg::r29), "ldaddb w30, w28, [x29]");
+  TEST_SINGLE(ldadd(SubRegSize::i16Bit, Reg::r30, Reg::r28, Reg::r29), "ldaddh w30, w28, [x29]");
+  TEST_SINGLE(ldadd(SubRegSize::i32Bit, Reg::r30, Reg::r28, Reg::r29), "ldadd w30, w28, [x29]");
+  TEST_SINGLE(ldadd(SubRegSize::i64Bit, Reg::r30, Reg::r28, Reg::r29), "ldadd x30, x28, [x29]");
+
+  TEST_SINGLE(ldaddl(SubRegSize::i8Bit, Reg::r30, Reg::r28, Reg::r29), "ldaddlb w30, w28, [x29]");
+  TEST_SINGLE(ldaddl(SubRegSize::i16Bit, Reg::r30, Reg::r28, Reg::r29), "ldaddlh w30, w28, [x29]");
+  TEST_SINGLE(ldaddl(SubRegSize::i32Bit, Reg::r30, Reg::r28, Reg::r29), "ldaddl w30, w28, [x29]");
+  TEST_SINGLE(ldaddl(SubRegSize::i64Bit, Reg::r30, Reg::r28, Reg::r29), "ldaddl x30, x28, [x29]");
+
+  TEST_SINGLE(ldadda(SubRegSize::i8Bit, Reg::r30, Reg::r28, Reg::r29), "ldaddab w30, w28, [x29]");
+  TEST_SINGLE(ldadda(SubRegSize::i16Bit, Reg::r30, Reg::r28, Reg::r29), "ldaddah w30, w28, [x29]");
+  TEST_SINGLE(ldadda(SubRegSize::i32Bit, Reg::r30, Reg::r28, Reg::r29), "ldadda w30, w28, [x29]");
+  TEST_SINGLE(ldadda(SubRegSize::i64Bit, Reg::r30, Reg::r28, Reg::r29), "ldadda x30, x28, [x29]");
+
+  TEST_SINGLE(ldaddal(SubRegSize::i8Bit, Reg::r30, Reg::r28, Reg::r29), "ldaddalb w30, w28, [x29]");
+  TEST_SINGLE(ldaddal(SubRegSize::i16Bit, Reg::r30, Reg::r28, Reg::r29), "ldaddalh w30, w28, [x29]");
+  TEST_SINGLE(ldaddal(SubRegSize::i32Bit, Reg::r30, Reg::r28, Reg::r29), "ldaddal w30, w28, [x29]");
+  TEST_SINGLE(ldaddal(SubRegSize::i64Bit, Reg::r30, Reg::r28, Reg::r29), "ldaddal x30, x28, [x29]");
+
+  TEST_SINGLE(ldclr(SubRegSize::i8Bit, Reg::r30, Reg::r28, Reg::r29), "ldclrb w30, w28, [x29]");
+  TEST_SINGLE(ldclr(SubRegSize::i16Bit, Reg::r30, Reg::r28, Reg::r29), "ldclrh w30, w28, [x29]");
+  TEST_SINGLE(ldclr(SubRegSize::i32Bit, Reg::r30, Reg::r28, Reg::r29), "ldclr w30, w28, [x29]");
+  TEST_SINGLE(ldclr(SubRegSize::i64Bit, Reg::r30, Reg::r28, Reg::r29), "ldclr x30, x28, [x29]");
+
+  TEST_SINGLE(ldclrl(SubRegSize::i8Bit, Reg::r30, Reg::r28, Reg::r29), "ldclrlb w30, w28, [x29]");
+  TEST_SINGLE(ldclrl(SubRegSize::i16Bit, Reg::r30, Reg::r28, Reg::r29), "ldclrlh w30, w28, [x29]");
+  TEST_SINGLE(ldclrl(SubRegSize::i32Bit, Reg::r30, Reg::r28, Reg::r29), "ldclrl w30, w28, [x29]");
+  TEST_SINGLE(ldclrl(SubRegSize::i64Bit, Reg::r30, Reg::r28, Reg::r29), "ldclrl x30, x28, [x29]");
+
+  TEST_SINGLE(ldclra(SubRegSize::i8Bit, Reg::r30, Reg::r28, Reg::r29), "ldclrab w30, w28, [x29]");
+  TEST_SINGLE(ldclra(SubRegSize::i16Bit, Reg::r30, Reg::r28, Reg::r29), "ldclrah w30, w28, [x29]");
+  TEST_SINGLE(ldclra(SubRegSize::i32Bit, Reg::r30, Reg::r28, Reg::r29), "ldclra w30, w28, [x29]");
+  TEST_SINGLE(ldclra(SubRegSize::i64Bit, Reg::r30, Reg::r28, Reg::r29), "ldclra x30, x28, [x29]");
+
+  TEST_SINGLE(ldclral(SubRegSize::i8Bit, Reg::r30, Reg::r28, Reg::r29), "ldclralb w30, w28, [x29]");
+  TEST_SINGLE(ldclral(SubRegSize::i16Bit, Reg::r30, Reg::r28, Reg::r29), "ldclralh w30, w28, [x29]");
+  TEST_SINGLE(ldclral(SubRegSize::i32Bit, Reg::r30, Reg::r28, Reg::r29), "ldclral w30, w28, [x29]");
+  TEST_SINGLE(ldclral(SubRegSize::i64Bit, Reg::r30, Reg::r28, Reg::r29), "ldclral x30, x28, [x29]");
+
+  TEST_SINGLE(ldset(SubRegSize::i8Bit, Reg::r30, Reg::r28, Reg::r29), "ldsetb w30, w28, [x29]");
+  TEST_SINGLE(ldset(SubRegSize::i16Bit, Reg::r30, Reg::r28, Reg::r29), "ldseth w30, w28, [x29]");
+  TEST_SINGLE(ldset(SubRegSize::i32Bit, Reg::r30, Reg::r28, Reg::r29), "ldset w30, w28, [x29]");
+  TEST_SINGLE(ldset(SubRegSize::i64Bit, Reg::r30, Reg::r28, Reg::r29), "ldset x30, x28, [x29]");
+
+  TEST_SINGLE(ldsetl(SubRegSize::i8Bit, Reg::r30, Reg::r28, Reg::r29), "ldsetlb w30, w28, [x29]");
+  TEST_SINGLE(ldsetl(SubRegSize::i16Bit, Reg::r30, Reg::r28, Reg::r29), "ldsetlh w30, w28, [x29]");
+  TEST_SINGLE(ldsetl(SubRegSize::i32Bit, Reg::r30, Reg::r28, Reg::r29), "ldsetl w30, w28, [x29]");
+  TEST_SINGLE(ldsetl(SubRegSize::i64Bit, Reg::r30, Reg::r28, Reg::r29), "ldsetl x30, x28, [x29]");
+
+  TEST_SINGLE(ldseta(SubRegSize::i8Bit, Reg::r30, Reg::r28, Reg::r29), "ldsetab w30, w28, [x29]");
+  TEST_SINGLE(ldseta(SubRegSize::i16Bit, Reg::r30, Reg::r28, Reg::r29), "ldsetah w30, w28, [x29]");
+  TEST_SINGLE(ldseta(SubRegSize::i32Bit, Reg::r30, Reg::r28, Reg::r29), "ldseta w30, w28, [x29]");
+  TEST_SINGLE(ldseta(SubRegSize::i64Bit, Reg::r30, Reg::r28, Reg::r29), "ldseta x30, x28, [x29]");
+
+  TEST_SINGLE(ldsetal(SubRegSize::i8Bit, Reg::r30, Reg::r28, Reg::r29), "ldsetalb w30, w28, [x29]");
+  TEST_SINGLE(ldsetal(SubRegSize::i16Bit, Reg::r30, Reg::r28, Reg::r29), "ldsetalh w30, w28, [x29]");
+  TEST_SINGLE(ldsetal(SubRegSize::i32Bit, Reg::r30, Reg::r28, Reg::r29), "ldsetal w30, w28, [x29]");
+  TEST_SINGLE(ldsetal(SubRegSize::i64Bit, Reg::r30, Reg::r28, Reg::r29), "ldsetal x30, x28, [x29]");
+
+  TEST_SINGLE(ldeor(SubRegSize::i8Bit, Reg::r30, Reg::r28, Reg::r29), "ldeorb w30, w28, [x29]");
+  TEST_SINGLE(ldeor(SubRegSize::i16Bit, Reg::r30, Reg::r28, Reg::r29), "ldeorh w30, w28, [x29]");
+  TEST_SINGLE(ldeor(SubRegSize::i32Bit, Reg::r30, Reg::r28, Reg::r29), "ldeor w30, w28, [x29]");
+  TEST_SINGLE(ldeor(SubRegSize::i64Bit, Reg::r30, Reg::r28, Reg::r29), "ldeor x30, x28, [x29]");
+
+  TEST_SINGLE(ldeorl(SubRegSize::i8Bit, Reg::r30, Reg::r28, Reg::r29), "ldeorlb w30, w28, [x29]");
+  TEST_SINGLE(ldeorl(SubRegSize::i16Bit, Reg::r30, Reg::r28, Reg::r29), "ldeorlh w30, w28, [x29]");
+  TEST_SINGLE(ldeorl(SubRegSize::i32Bit, Reg::r30, Reg::r28, Reg::r29), "ldeorl w30, w28, [x29]");
+  TEST_SINGLE(ldeorl(SubRegSize::i64Bit, Reg::r30, Reg::r28, Reg::r29), "ldeorl x30, x28, [x29]");
+
+  TEST_SINGLE(ldeora(SubRegSize::i8Bit, Reg::r30, Reg::r28, Reg::r29), "ldeorab w30, w28, [x29]");
+  TEST_SINGLE(ldeora(SubRegSize::i16Bit, Reg::r30, Reg::r28, Reg::r29), "ldeorah w30, w28, [x29]");
+  TEST_SINGLE(ldeora(SubRegSize::i32Bit, Reg::r30, Reg::r28, Reg::r29), "ldeora w30, w28, [x29]");
+  TEST_SINGLE(ldeora(SubRegSize::i64Bit, Reg::r30, Reg::r28, Reg::r29), "ldeora x30, x28, [x29]");
+
+  TEST_SINGLE(ldeoral(SubRegSize::i8Bit, Reg::r30, Reg::r28, Reg::r29), "ldeoralb w30, w28, [x29]");
+  TEST_SINGLE(ldeoral(SubRegSize::i16Bit, Reg::r30, Reg::r28, Reg::r29), "ldeoralh w30, w28, [x29]");
+  TEST_SINGLE(ldeoral(SubRegSize::i32Bit, Reg::r30, Reg::r28, Reg::r29), "ldeoral w30, w28, [x29]");
+  TEST_SINGLE(ldeoral(SubRegSize::i64Bit, Reg::r30, Reg::r28, Reg::r29), "ldeoral x30, x28, [x29]");
+
+  TEST_SINGLE(ldaddb(Reg::r30, Reg::r28, Reg::r29), "ldaddb w30, w28, [x29]");
+  TEST_SINGLE(ldclrb(Reg::r30, Reg::r28, Reg::r29), "ldclrb w30, w28, [x29]");
+  TEST_SINGLE(ldeorb(Reg::r30, Reg::r28, Reg::r29), "ldeorb w30, w28, [x29]");
+  TEST_SINGLE(ldsetb(Reg::r30, Reg::r28, Reg::r29), "ldsetb w30, w28, [x29]");
+  TEST_SINGLE(ldsmaxb(Reg::r30, Reg::r28, Reg::r29), "ldsmaxb w30, w28, [x29]");
+  TEST_SINGLE(ldsminb(Reg::r30, Reg::r28, Reg::r29), "ldsminb w30, w28, [x29]");
+  TEST_SINGLE(ldumaxb(Reg::r30, Reg::r28, Reg::r29), "ldumaxb w30, w28, [x29]");
+  TEST_SINGLE(lduminb(Reg::r30, Reg::r28, Reg::r29), "lduminb w30, w28, [x29]");
+  TEST_SINGLE(ldswpb(Reg::r30, Reg::r28, Reg::r29), "swpb w30, w28, [x29]");
+  TEST_SINGLE(ldaddlb(Reg::r30, Reg::r28, Reg::r29), "ldaddlb w30, w28, [x29]");
+  TEST_SINGLE(ldclrlb(Reg::r30, Reg::r28, Reg::r29), "ldclrlb w30, w28, [x29]");
+  TEST_SINGLE(ldeorlb(Reg::r30, Reg::r28, Reg::r29), "ldeorlb w30, w28, [x29]");
+  TEST_SINGLE(ldsetlb(Reg::r30, Reg::r28, Reg::r29), "ldsetlb w30, w28, [x29]");
+  TEST_SINGLE(ldsmaxlb(Reg::r30, Reg::r28, Reg::r29), "ldsmaxlb w30, w28, [x29]");
+  TEST_SINGLE(ldsminlb(Reg::r30, Reg::r28, Reg::r29), "ldsminlb w30, w28, [x29]");
+  TEST_SINGLE(ldumaxlb(Reg::r30, Reg::r28, Reg::r29), "ldumaxlb w30, w28, [x29]");
+  TEST_SINGLE(lduminlb(Reg::r30, Reg::r28, Reg::r29), "lduminlb w30, w28, [x29]");
+  TEST_SINGLE(ldswplb(Reg::r30, Reg::r28, Reg::r29), "swplb w30, w28, [x29]");
+  TEST_SINGLE(ldaddab(Reg::r30, Reg::r28, Reg::r29), "ldaddab w30, w28, [x29]");
+  TEST_SINGLE(ldclrab(Reg::r30, Reg::r28, Reg::r29), "ldclrab w30, w28, [x29]");
+  TEST_SINGLE(ldeorab(Reg::r30, Reg::r28, Reg::r29), "ldeorab w30, w28, [x29]");
+  TEST_SINGLE(ldsetab(Reg::r30, Reg::r28, Reg::r29), "ldsetab w30, w28, [x29]");
+  TEST_SINGLE(ldsmaxab(Reg::r30, Reg::r28, Reg::r29), "ldsmaxab w30, w28, [x29]");
+  TEST_SINGLE(ldsminab(Reg::r30, Reg::r28, Reg::r29), "ldsminab w30, w28, [x29]");
+  TEST_SINGLE(ldumaxab(Reg::r30, Reg::r28, Reg::r29), "ldumaxab w30, w28, [x29]");
+  TEST_SINGLE(lduminab(Reg::r30, Reg::r28, Reg::r29), "lduminab w30, w28, [x29]");
+  TEST_SINGLE(ldswpab(Reg::r30, Reg::r28, Reg::r29), "swpab w30, w28, [x29]");
+  TEST_SINGLE(ldaddalb(Reg::r30, Reg::r28, Reg::r29), "ldaddalb w30, w28, [x29]");
+  TEST_SINGLE(ldclralb(Reg::r30, Reg::r28, Reg::r29), "ldclralb w30, w28, [x29]");
+  TEST_SINGLE(ldeoralb(Reg::r30, Reg::r28, Reg::r29), "ldeoralb w30, w28, [x29]");
+  TEST_SINGLE(ldsetalb(Reg::r30, Reg::r28, Reg::r29), "ldsetalb w30, w28, [x29]");
+  TEST_SINGLE(ldsmaxalb(Reg::r30, Reg::r28, Reg::r29), "ldsmaxalb w30, w28, [x29]");
+  TEST_SINGLE(ldsminalb(Reg::r30, Reg::r28, Reg::r29), "ldsminalb w30, w28, [x29]");
+  TEST_SINGLE(ldumaxalb(Reg::r30, Reg::r28, Reg::r29), "ldumaxalb w30, w28, [x29]");
+  TEST_SINGLE(lduminalb(Reg::r30, Reg::r28, Reg::r29), "lduminalb w30, w28, [x29]");
+  TEST_SINGLE(ldswpalb(Reg::r30, Reg::r28, Reg::r29), "swpalb w30, w28, [x29]");
+
+  TEST_SINGLE(ldaddh(Reg::r30, Reg::r28, Reg::r29), "ldaddh w30, w28, [x29]");
+  TEST_SINGLE(ldclrh(Reg::r30, Reg::r28, Reg::r29), "ldclrh w30, w28, [x29]");
+  TEST_SINGLE(ldeorh(Reg::r30, Reg::r28, Reg::r29), "ldeorh w30, w28, [x29]");
+  TEST_SINGLE(ldseth(Reg::r30, Reg::r28, Reg::r29), "ldseth w30, w28, [x29]");
+  TEST_SINGLE(ldsmaxh(Reg::r30, Reg::r28, Reg::r29), "ldsmaxh w30, w28, [x29]");
+  TEST_SINGLE(ldsminh(Reg::r30, Reg::r28, Reg::r29), "ldsminh w30, w28, [x29]");
+  TEST_SINGLE(ldumaxh(Reg::r30, Reg::r28, Reg::r29), "ldumaxh w30, w28, [x29]");
+  TEST_SINGLE(lduminh(Reg::r30, Reg::r28, Reg::r29), "lduminh w30, w28, [x29]");
+  TEST_SINGLE(ldswph(Reg::r30, Reg::r28, Reg::r29), "swph w30, w28, [x29]");
+  TEST_SINGLE(ldaddlh(Reg::r30, Reg::r28, Reg::r29), "ldaddlh w30, w28, [x29]");
+  TEST_SINGLE(ldclrlh(Reg::r30, Reg::r28, Reg::r29), "ldclrlh w30, w28, [x29]");
+  TEST_SINGLE(ldeorlh(Reg::r30, Reg::r28, Reg::r29), "ldeorlh w30, w28, [x29]");
+  TEST_SINGLE(ldsetlh(Reg::r30, Reg::r28, Reg::r29), "ldsetlh w30, w28, [x29]");
+  TEST_SINGLE(ldsmaxlh(Reg::r30, Reg::r28, Reg::r29), "ldsmaxlh w30, w28, [x29]");
+  TEST_SINGLE(ldsminlh(Reg::r30, Reg::r28, Reg::r29), "ldsminlh w30, w28, [x29]");
+  TEST_SINGLE(ldumaxlh(Reg::r30, Reg::r28, Reg::r29), "ldumaxlh w30, w28, [x29]");
+  TEST_SINGLE(lduminlh(Reg::r30, Reg::r28, Reg::r29), "lduminlh w30, w28, [x29]");
+  TEST_SINGLE(ldswplh(Reg::r30, Reg::r28, Reg::r29), "swplh w30, w28, [x29]");
+  TEST_SINGLE(ldaddah(Reg::r30, Reg::r28, Reg::r29), "ldaddah w30, w28, [x29]");
+  TEST_SINGLE(ldclrah(Reg::r30, Reg::r28, Reg::r29), "ldclrah w30, w28, [x29]");
+  TEST_SINGLE(ldeorah(Reg::r30, Reg::r28, Reg::r29), "ldeorah w30, w28, [x29]");
+  TEST_SINGLE(ldsetah(Reg::r30, Reg::r28, Reg::r29), "ldsetah w30, w28, [x29]");
+  TEST_SINGLE(ldsmaxah(Reg::r30, Reg::r28, Reg::r29), "ldsmaxah w30, w28, [x29]");
+  TEST_SINGLE(ldsminah(Reg::r30, Reg::r28, Reg::r29), "ldsminah w30, w28, [x29]");
+  TEST_SINGLE(ldumaxah(Reg::r30, Reg::r28, Reg::r29), "ldumaxah w30, w28, [x29]");
+  TEST_SINGLE(lduminah(Reg::r30, Reg::r28, Reg::r29), "lduminah w30, w28, [x29]");
+  TEST_SINGLE(ldswpah(Reg::r30, Reg::r28, Reg::r29), "swpah w30, w28, [x29]");
+  TEST_SINGLE(ldaddalh(Reg::r30, Reg::r28, Reg::r29), "ldaddalh w30, w28, [x29]");
+  TEST_SINGLE(ldclralh(Reg::r30, Reg::r28, Reg::r29), "ldclralh w30, w28, [x29]");
+  TEST_SINGLE(ldeoralh(Reg::r30, Reg::r28, Reg::r29), "ldeoralh w30, w28, [x29]");
+  TEST_SINGLE(ldsetalh(Reg::r30, Reg::r28, Reg::r29), "ldsetalh w30, w28, [x29]");
+  TEST_SINGLE(ldsmaxalh(Reg::r30, Reg::r28, Reg::r29), "ldsmaxalh w30, w28, [x29]");
+  TEST_SINGLE(ldsminalh(Reg::r30, Reg::r28, Reg::r29), "ldsminalh w30, w28, [x29]");
+  TEST_SINGLE(ldumaxalh(Reg::r30, Reg::r28, Reg::r29), "ldumaxalh w30, w28, [x29]");
+  TEST_SINGLE(lduminalh(Reg::r30, Reg::r28, Reg::r29), "lduminalh w30, w28, [x29]");
+  TEST_SINGLE(ldswpalh(Reg::r30, Reg::r28, Reg::r29), "swpalh w30, w28, [x29]");
+
+  TEST_SINGLE(ldadd(WReg::w30, WReg::w28, Reg::r29), "ldadd w30, w28, [x29]");
+  TEST_SINGLE(ldclr(WReg::w30, WReg::w28, Reg::r29), "ldclr w30, w28, [x29]");
+  TEST_SINGLE(ldeor(WReg::w30, WReg::w28, Reg::r29), "ldeor w30, w28, [x29]");
+  TEST_SINGLE(ldset(WReg::w30, WReg::w28, Reg::r29), "ldset w30, w28, [x29]");
+  TEST_SINGLE(ldsmax(WReg::w30, WReg::w28, Reg::r29), "ldsmax w30, w28, [x29]");
+  TEST_SINGLE(ldsmin(WReg::w30, WReg::w28, Reg::r29), "ldsmin w30, w28, [x29]");
+  TEST_SINGLE(ldumax(WReg::w30, WReg::w28, Reg::r29), "ldumax w30, w28, [x29]");
+  TEST_SINGLE(ldumin(WReg::w30, WReg::w28, Reg::r29), "ldumin w30, w28, [x29]");
+  TEST_SINGLE(ldswp(WReg::w30, WReg::w28, Reg::r29), "swp w30, w28, [x29]");
+  TEST_SINGLE(ldaddl(WReg::w30, WReg::w28, Reg::r29), "ldaddl w30, w28, [x29]");
+  TEST_SINGLE(ldclrl(WReg::w30, WReg::w28, Reg::r29), "ldclrl w30, w28, [x29]");
+  TEST_SINGLE(ldeorl(WReg::w30, WReg::w28, Reg::r29), "ldeorl w30, w28, [x29]");
+  TEST_SINGLE(ldsetl(WReg::w30, WReg::w28, Reg::r29), "ldsetl w30, w28, [x29]");
+  TEST_SINGLE(ldsmaxl(WReg::w30, WReg::w28, Reg::r29), "ldsmaxl w30, w28, [x29]");
+  TEST_SINGLE(ldsminl(WReg::w30, WReg::w28, Reg::r29), "ldsminl w30, w28, [x29]");
+  TEST_SINGLE(ldumaxl(WReg::w30, WReg::w28, Reg::r29), "ldumaxl w30, w28, [x29]");
+  TEST_SINGLE(lduminl(WReg::w30, WReg::w28, Reg::r29), "lduminl w30, w28, [x29]");
+  TEST_SINGLE(ldswpl(WReg::w30, WReg::w28, Reg::r29), "swpl w30, w28, [x29]");
+  TEST_SINGLE(ldadda(WReg::w30, WReg::w28, Reg::r29), "ldadda w30, w28, [x29]");
+  TEST_SINGLE(ldclra(WReg::w30, WReg::w28, Reg::r29), "ldclra w30, w28, [x29]");
+  TEST_SINGLE(ldeora(WReg::w30, WReg::w28, Reg::r29), "ldeora w30, w28, [x29]");
+  TEST_SINGLE(ldseta(WReg::w30, WReg::w28, Reg::r29), "ldseta w30, w28, [x29]");
+  TEST_SINGLE(ldsmaxa(WReg::w30, WReg::w28, Reg::r29), "ldsmaxa w30, w28, [x29]");
+  TEST_SINGLE(ldsmina(WReg::w30, WReg::w28, Reg::r29), "ldsmina w30, w28, [x29]");
+  TEST_SINGLE(ldumaxa(WReg::w30, WReg::w28, Reg::r29), "ldumaxa w30, w28, [x29]");
+  TEST_SINGLE(ldumina(WReg::w30, WReg::w28, Reg::r29), "ldumina w30, w28, [x29]");
+  TEST_SINGLE(ldswpa(WReg::w30, WReg::w28, Reg::r29), "swpa w30, w28, [x29]");
+  TEST_SINGLE(ldaddal(WReg::w30, WReg::w28, Reg::r29), "ldaddal w30, w28, [x29]");
+  TEST_SINGLE(ldclral(WReg::w30, WReg::w28, Reg::r29), "ldclral w30, w28, [x29]");
+  TEST_SINGLE(ldeoral(WReg::w30, WReg::w28, Reg::r29), "ldeoral w30, w28, [x29]");
+  TEST_SINGLE(ldsetal(WReg::w30, WReg::w28, Reg::r29), "ldsetal w30, w28, [x29]");
+  TEST_SINGLE(ldsmaxal(WReg::w30, WReg::w28, Reg::r29), "ldsmaxal w30, w28, [x29]");
+  TEST_SINGLE(ldsminal(WReg::w30, WReg::w28, Reg::r29), "ldsminal w30, w28, [x29]");
+  TEST_SINGLE(ldumaxal(WReg::w30, WReg::w28, Reg::r29), "ldumaxal w30, w28, [x29]");
+  TEST_SINGLE(lduminal(WReg::w30, WReg::w28, Reg::r29), "lduminal w30, w28, [x29]");
+  TEST_SINGLE(ldswpal(WReg::w30, WReg::w28, Reg::r29), "swpal w30, w28, [x29]");
+
+  TEST_SINGLE(ldadd(XReg::x30, XReg::x28, Reg::r29), "ldadd x30, x28, [x29]");
+  TEST_SINGLE(ldclr(XReg::x30, XReg::x28, Reg::r29), "ldclr x30, x28, [x29]");
+  TEST_SINGLE(ldeor(XReg::x30, XReg::x28, Reg::r29), "ldeor x30, x28, [x29]");
+  TEST_SINGLE(ldset(XReg::x30, XReg::x28, Reg::r29), "ldset x30, x28, [x29]");
+  TEST_SINGLE(ldsmax(XReg::x30, XReg::x28, Reg::r29), "ldsmax x30, x28, [x29]");
+  TEST_SINGLE(ldsmin(XReg::x30, XReg::x28, Reg::r29), "ldsmin x30, x28, [x29]");
+  TEST_SINGLE(ldumax(XReg::x30, XReg::x28, Reg::r29), "ldumax x30, x28, [x29]");
+  TEST_SINGLE(ldumin(XReg::x30, XReg::x28, Reg::r29), "ldumin x30, x28, [x29]");
+  TEST_SINGLE(ldswp(XReg::x30, XReg::x28, Reg::r29), "swp x30, x28, [x29]");
+  TEST_SINGLE(ldaddl(XReg::x30, XReg::x28, Reg::r29), "ldaddl x30, x28, [x29]");
+  TEST_SINGLE(ldclrl(XReg::x30, XReg::x28, Reg::r29), "ldclrl x30, x28, [x29]");
+  TEST_SINGLE(ldeorl(XReg::x30, XReg::x28, Reg::r29), "ldeorl x30, x28, [x29]");
+  TEST_SINGLE(ldsetl(XReg::x30, XReg::x28, Reg::r29), "ldsetl x30, x28, [x29]");
+  TEST_SINGLE(ldsmaxl(XReg::x30, XReg::x28, Reg::r29), "ldsmaxl x30, x28, [x29]");
+  TEST_SINGLE(ldsminl(XReg::x30, XReg::x28, Reg::r29), "ldsminl x30, x28, [x29]");
+  TEST_SINGLE(ldumaxl(XReg::x30, XReg::x28, Reg::r29), "ldumaxl x30, x28, [x29]");
+  TEST_SINGLE(lduminl(XReg::x30, XReg::x28, Reg::r29), "lduminl x30, x28, [x29]");
+  TEST_SINGLE(ldswpl(XReg::x30, XReg::x28, Reg::r29), "swpl x30, x28, [x29]");
+  TEST_SINGLE(ldadda(XReg::x30, XReg::x28, Reg::r29), "ldadda x30, x28, [x29]");
+  TEST_SINGLE(ldclra(XReg::x30, XReg::x28, Reg::r29), "ldclra x30, x28, [x29]");
+  TEST_SINGLE(ldeora(XReg::x30, XReg::x28, Reg::r29), "ldeora x30, x28, [x29]");
+  TEST_SINGLE(ldseta(XReg::x30, XReg::x28, Reg::r29), "ldseta x30, x28, [x29]");
+  TEST_SINGLE(ldsmaxa(XReg::x30, XReg::x28, Reg::r29), "ldsmaxa x30, x28, [x29]");
+  TEST_SINGLE(ldsmina(XReg::x30, XReg::x28, Reg::r29), "ldsmina x30, x28, [x29]");
+  TEST_SINGLE(ldumaxa(XReg::x30, XReg::x28, Reg::r29), "ldumaxa x30, x28, [x29]");
+  TEST_SINGLE(ldumina(XReg::x30, XReg::x28, Reg::r29), "ldumina x30, x28, [x29]");
+  TEST_SINGLE(ldswpa(XReg::x30, XReg::x28, Reg::r29), "swpa x30, x28, [x29]");
+  TEST_SINGLE(ldaddal(XReg::x30, XReg::x28, Reg::r29), "ldaddal x30, x28, [x29]");
+  TEST_SINGLE(ldclral(XReg::x30, XReg::x28, Reg::r29), "ldclral x30, x28, [x29]");
+  TEST_SINGLE(ldeoral(XReg::x30, XReg::x28, Reg::r29), "ldeoral x30, x28, [x29]");
+  TEST_SINGLE(ldsetal(XReg::x30, XReg::x28, Reg::r29), "ldsetal x30, x28, [x29]");
+  TEST_SINGLE(ldsmaxal(XReg::x30, XReg::x28, Reg::r29), "ldsmaxal x30, x28, [x29]");
+  TEST_SINGLE(ldsminal(XReg::x30, XReg::x28, Reg::r29), "ldsminal x30, x28, [x29]");
+  TEST_SINGLE(ldumaxal(XReg::x30, XReg::x28, Reg::r29), "ldumaxal x30, x28, [x29]");
+  TEST_SINGLE(lduminal(XReg::x30, XReg::x28, Reg::r29), "lduminal x30, x28, [x29]");
+  TEST_SINGLE(ldswpal(XReg::x30, XReg::x28, Reg::r29), "swpal x30, x28, [x29]");
+
+  TEST_SINGLE(ldaprb(WReg::w30, Reg::r29), "ldaprb w30, [x29]");
+  TEST_SINGLE(ldaprh(WReg::w30, Reg::r29), "ldaprh w30, [x29]");
+  TEST_SINGLE(ldapr(WReg::w30, Reg::r29), "ldapr w30, [x29]");
+  TEST_SINGLE(ldapr(XReg::x30, Reg::r29), "ldapr x30, [x29]");
+
+  if (false) {
+    // vixl can't disassemble this class of instructions.
+    TEST_SINGLE(st64bv0(XReg::x30, XReg::x28, Reg::r29), "st64bv0 x30, x28, [x29]");
+    TEST_SINGLE(st64bv(XReg::x30, XReg::x28, Reg::r29), "st64bv x30, x28, [x29]");
+    TEST_SINGLE(st64b(XReg::x30, Reg::r29), "st64bv x30, [x29]");
+    TEST_SINGLE(ld64b(XReg::x30, Reg::r29), "ld64b x30, [x29]");
+  }
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Loadstore register-register offset") {
+  TEST_SINGLE(strb(Reg::r30, Reg::r28, Reg::r29, ExtendedType::LSL_64, false), "strb w30, [x28, x29]");
+  TEST_SINGLE(strb(Reg::r30, Reg::r28, Reg::r29, ExtendedType::LSL_64, true), "strb w30, [x28, x29, lsl #0]");
+  TEST_SINGLE(strb(Reg::r30, Reg::r28, Reg::r29, ExtendedType::UXTW, false), "strb w30, [x28, w29, uxtw]");
+  TEST_SINGLE(strb(Reg::r30, Reg::r28, Reg::r29, ExtendedType::UXTW, true), "strb w30, [x28, w29, uxtw #0]");
+  TEST_SINGLE(strb(Reg::r30, Reg::r28, Reg::r29, ExtendedType::SXTW, false), "strb w30, [x28, w29, sxtw]");
+  TEST_SINGLE(strb(Reg::r30, Reg::r28, Reg::r29, ExtendedType::SXTW, true), "strb w30, [x28, w29, sxtw #0]");
+  TEST_SINGLE(strb(Reg::r30, Reg::r28, Reg::r29, ExtendedType::SXTX, false), "strb w30, [x28, x29, sxtx]");
+  TEST_SINGLE(strb(Reg::r30, Reg::r28, Reg::r29, ExtendedType::SXTX, true), "strb w30, [x28, x29, sxtx #0]");
+
+  TEST_SINGLE(ldrb(Reg::r30, Reg::r28, Reg::r29, ExtendedType::LSL_64, false), "ldrb w30, [x28, x29]");
+  TEST_SINGLE(ldrb(Reg::r30, Reg::r28, Reg::r29, ExtendedType::LSL_64, true), "ldrb w30, [x28, x29, lsl #0]");
+  TEST_SINGLE(ldrb(Reg::r30, Reg::r28, Reg::r29, ExtendedType::UXTW, false), "ldrb w30, [x28, w29, uxtw]");
+  TEST_SINGLE(ldrb(Reg::r30, Reg::r28, Reg::r29, ExtendedType::UXTW, true), "ldrb w30, [x28, w29, uxtw #0]");
+  TEST_SINGLE(ldrb(Reg::r30, Reg::r28, Reg::r29, ExtendedType::SXTW, false), "ldrb w30, [x28, w29, sxtw]");
+  TEST_SINGLE(ldrb(Reg::r30, Reg::r28, Reg::r29, ExtendedType::SXTW, true), "ldrb w30, [x28, w29, sxtw #0]");
+  TEST_SINGLE(ldrb(Reg::r30, Reg::r28, Reg::r29, ExtendedType::SXTX, false), "ldrb w30, [x28, x29, sxtx]");
+  TEST_SINGLE(ldrb(Reg::r30, Reg::r28, Reg::r29, ExtendedType::SXTX, true), "ldrb w30, [x28, x29, sxtx #0]");
+
+  TEST_SINGLE(ldrsb(WReg::w30, Reg::r28, Reg::r29, ExtendedType::LSL_64, false), "ldrsb w30, [x28, x29]");
+  TEST_SINGLE(ldrsb(WReg::w30, Reg::r28, Reg::r29, ExtendedType::LSL_64, true), "ldrsb w30, [x28, x29, lsl #0]");
+  TEST_SINGLE(ldrsb(WReg::w30, Reg::r28, Reg::r29, ExtendedType::UXTW, false), "ldrsb w30, [x28, w29, uxtw]");
+  TEST_SINGLE(ldrsb(WReg::w30, Reg::r28, Reg::r29, ExtendedType::UXTW, true), "ldrsb w30, [x28, w29, uxtw #0]");
+  TEST_SINGLE(ldrsb(WReg::w30, Reg::r28, Reg::r29, ExtendedType::SXTW, false), "ldrsb w30, [x28, w29, sxtw]");
+  TEST_SINGLE(ldrsb(WReg::w30, Reg::r28, Reg::r29, ExtendedType::SXTW, true), "ldrsb w30, [x28, w29, sxtw #0]");
+  TEST_SINGLE(ldrsb(WReg::w30, Reg::r28, Reg::r29, ExtendedType::SXTX, false), "ldrsb w30, [x28, x29, sxtx]");
+  TEST_SINGLE(ldrsb(WReg::w30, Reg::r28, Reg::r29, ExtendedType::SXTX, true), "ldrsb w30, [x28, x29, sxtx #0]");
+
+  TEST_SINGLE(ldrsb(XReg::x30, Reg::r28, Reg::r29, ExtendedType::LSL_64, false), "ldrsb x30, [x28, x29]");
+  TEST_SINGLE(ldrsb(XReg::x30, Reg::r28, Reg::r29, ExtendedType::LSL_64, true), "ldrsb x30, [x28, x29, lsl #0]");
+  TEST_SINGLE(ldrsb(XReg::x30, Reg::r28, Reg::r29, ExtendedType::UXTW, false), "ldrsb x30, [x28, w29, uxtw]");
+  TEST_SINGLE(ldrsb(XReg::x30, Reg::r28, Reg::r29, ExtendedType::UXTW, true), "ldrsb x30, [x28, w29, uxtw #0]");
+  TEST_SINGLE(ldrsb(XReg::x30, Reg::r28, Reg::r29, ExtendedType::SXTW, false), "ldrsb x30, [x28, w29, sxtw]");
+  TEST_SINGLE(ldrsb(XReg::x30, Reg::r28, Reg::r29, ExtendedType::SXTW, true), "ldrsb x30, [x28, w29, sxtw #0]");
+  TEST_SINGLE(ldrsb(XReg::x30, Reg::r28, Reg::r29, ExtendedType::SXTX, false), "ldrsb x30, [x28, x29, sxtx]");
+  TEST_SINGLE(ldrsb(XReg::x30, Reg::r28, Reg::r29, ExtendedType::SXTX, true), "ldrsb x30, [x28, x29, sxtx #0]");
+
+  TEST_SINGLE(strh(Reg::r30, Reg::r28, Reg::r29, ExtendedType::LSL_64, 0), "strh w30, [x28, x29]");
+  TEST_SINGLE(strh(Reg::r30, Reg::r28, Reg::r29, ExtendedType::LSL_64, 1), "strh w30, [x28, x29, lsl #1]");
+  TEST_SINGLE(strh(Reg::r30, Reg::r28, Reg::r29, ExtendedType::UXTW, 0), "strh w30, [x28, w29, uxtw]");
+  TEST_SINGLE(strh(Reg::r30, Reg::r28, Reg::r29, ExtendedType::UXTW, 1), "strh w30, [x28, w29, uxtw #1]");
+  TEST_SINGLE(strh(Reg::r30, Reg::r28, Reg::r29, ExtendedType::SXTW, 0), "strh w30, [x28, w29, sxtw]");
+  TEST_SINGLE(strh(Reg::r30, Reg::r28, Reg::r29, ExtendedType::SXTW, 1), "strh w30, [x28, w29, sxtw #1]");
+  TEST_SINGLE(strh(Reg::r30, Reg::r28, Reg::r29, ExtendedType::SXTX, 0), "strh w30, [x28, x29, sxtx]");
+  TEST_SINGLE(strh(Reg::r30, Reg::r28, Reg::r29, ExtendedType::SXTX, 1), "strh w30, [x28, x29, sxtx #1]");
+
+  TEST_SINGLE(ldrh(Reg::r30, Reg::r28, Reg::r29, ExtendedType::LSL_64, 0), "ldrh w30, [x28, x29]");
+  TEST_SINGLE(ldrh(Reg::r30, Reg::r28, Reg::r29, ExtendedType::LSL_64, 1), "ldrh w30, [x28, x29, lsl #1]");
+  TEST_SINGLE(ldrh(Reg::r30, Reg::r28, Reg::r29, ExtendedType::UXTW, 0), "ldrh w30, [x28, w29, uxtw]");
+  TEST_SINGLE(ldrh(Reg::r30, Reg::r28, Reg::r29, ExtendedType::UXTW, 1), "ldrh w30, [x28, w29, uxtw #1]");
+  TEST_SINGLE(ldrh(Reg::r30, Reg::r28, Reg::r29, ExtendedType::SXTW, 0), "ldrh w30, [x28, w29, sxtw]");
+  TEST_SINGLE(ldrh(Reg::r30, Reg::r28, Reg::r29, ExtendedType::SXTW, 1), "ldrh w30, [x28, w29, sxtw #1]");
+  TEST_SINGLE(ldrh(Reg::r30, Reg::r28, Reg::r29, ExtendedType::SXTX, 0), "ldrh w30, [x28, x29, sxtx]");
+  TEST_SINGLE(ldrh(Reg::r30, Reg::r28, Reg::r29, ExtendedType::SXTX, 1), "ldrh w30, [x28, x29, sxtx #1]");
+
+  TEST_SINGLE(ldrsh(WReg::w30, Reg::r28, Reg::r29, ExtendedType::LSL_64, 0), "ldrsh w30, [x28, x29]");
+  TEST_SINGLE(ldrsh(WReg::w30, Reg::r28, Reg::r29, ExtendedType::LSL_64, 1), "ldrsh w30, [x28, x29, lsl #1]");
+  TEST_SINGLE(ldrsh(WReg::w30, Reg::r28, Reg::r29, ExtendedType::UXTW, 0), "ldrsh w30, [x28, w29, uxtw]");
+  TEST_SINGLE(ldrsh(WReg::w30, Reg::r28, Reg::r29, ExtendedType::UXTW, 1), "ldrsh w30, [x28, w29, uxtw #1]");
+  TEST_SINGLE(ldrsh(WReg::w30, Reg::r28, Reg::r29, ExtendedType::SXTW, 0), "ldrsh w30, [x28, w29, sxtw]");
+  TEST_SINGLE(ldrsh(WReg::w30, Reg::r28, Reg::r29, ExtendedType::SXTW, 1), "ldrsh w30, [x28, w29, sxtw #1]");
+  TEST_SINGLE(ldrsh(WReg::w30, Reg::r28, Reg::r29, ExtendedType::SXTX, 0), "ldrsh w30, [x28, x29, sxtx]");
+  TEST_SINGLE(ldrsh(WReg::w30, Reg::r28, Reg::r29, ExtendedType::SXTX, 1), "ldrsh w30, [x28, x29, sxtx #1]");
+
+  TEST_SINGLE(ldrsh(XReg::x30, Reg::r28, Reg::r29, ExtendedType::LSL_64, 0), "ldrsh x30, [x28, x29]");
+  TEST_SINGLE(ldrsh(XReg::x30, Reg::r28, Reg::r29, ExtendedType::LSL_64, 1), "ldrsh x30, [x28, x29, lsl #1]");
+  TEST_SINGLE(ldrsh(XReg::x30, Reg::r28, Reg::r29, ExtendedType::UXTW, 0), "ldrsh x30, [x28, w29, uxtw]");
+  TEST_SINGLE(ldrsh(XReg::x30, Reg::r28, Reg::r29, ExtendedType::UXTW, 1), "ldrsh x30, [x28, w29, uxtw #1]");
+  TEST_SINGLE(ldrsh(XReg::x30, Reg::r28, Reg::r29, ExtendedType::SXTW, 0), "ldrsh x30, [x28, w29, sxtw]");
+  TEST_SINGLE(ldrsh(XReg::x30, Reg::r28, Reg::r29, ExtendedType::SXTW, 1), "ldrsh x30, [x28, w29, sxtw #1]");
+  TEST_SINGLE(ldrsh(XReg::x30, Reg::r28, Reg::r29, ExtendedType::SXTX, 0), "ldrsh x30, [x28, x29, sxtx]");
+  TEST_SINGLE(ldrsh(XReg::x30, Reg::r28, Reg::r29, ExtendedType::SXTX, 1), "ldrsh x30, [x28, x29, sxtx #1]");
+
+  TEST_SINGLE(str(WReg::w30, Reg::r28, Reg::r29, ExtendedType::LSL_64, 0), "str w30, [x28, x29]");
+  TEST_SINGLE(str(WReg::w30, Reg::r28, Reg::r29, ExtendedType::LSL_64, 2), "str w30, [x28, x29, lsl #2]");
+  TEST_SINGLE(str(WReg::w30, Reg::r28, Reg::r29, ExtendedType::UXTW, 0), "str w30, [x28, w29, uxtw]");
+  TEST_SINGLE(str(WReg::w30, Reg::r28, Reg::r29, ExtendedType::UXTW, 2), "str w30, [x28, w29, uxtw #2]");
+  TEST_SINGLE(str(WReg::w30, Reg::r28, Reg::r29, ExtendedType::SXTW, 0), "str w30, [x28, w29, sxtw]");
+  TEST_SINGLE(str(WReg::w30, Reg::r28, Reg::r29, ExtendedType::SXTW, 2), "str w30, [x28, w29, sxtw #2]");
+  TEST_SINGLE(str(WReg::w30, Reg::r28, Reg::r29, ExtendedType::SXTX, 0), "str w30, [x28, x29, sxtx]");
+  TEST_SINGLE(str(WReg::w30, Reg::r28, Reg::r29, ExtendedType::SXTX, 2), "str w30, [x28, x29, sxtx #2]");
+
+  TEST_SINGLE(ldr(WReg::w30, Reg::r28, Reg::r29, ExtendedType::LSL_64, 0), "ldr w30, [x28, x29]");
+  TEST_SINGLE(ldr(WReg::w30, Reg::r28, Reg::r29, ExtendedType::LSL_64, 2), "ldr w30, [x28, x29, lsl #2]");
+  TEST_SINGLE(ldr(WReg::w30, Reg::r28, Reg::r29, ExtendedType::UXTW, 0), "ldr w30, [x28, w29, uxtw]");
+  TEST_SINGLE(ldr(WReg::w30, Reg::r28, Reg::r29, ExtendedType::UXTW, 2), "ldr w30, [x28, w29, uxtw #2]");
+  TEST_SINGLE(ldr(WReg::w30, Reg::r28, Reg::r29, ExtendedType::SXTW, 0), "ldr w30, [x28, w29, sxtw]");
+  TEST_SINGLE(ldr(WReg::w30, Reg::r28, Reg::r29, ExtendedType::SXTW, 2), "ldr w30, [x28, w29, sxtw #2]");
+  TEST_SINGLE(ldr(WReg::w30, Reg::r28, Reg::r29, ExtendedType::SXTX, 0), "ldr w30, [x28, x29, sxtx]");
+  TEST_SINGLE(ldr(WReg::w30, Reg::r28, Reg::r29, ExtendedType::SXTX, 2), "ldr w30, [x28, x29, sxtx #2]");
+
+  TEST_SINGLE(ldrsw(XReg::x30, Reg::r28, Reg::r29, ExtendedType::LSL_64, 0), "ldrsw x30, [x28, x29]");
+  TEST_SINGLE(ldrsw(XReg::x30, Reg::r28, Reg::r29, ExtendedType::LSL_64, 2), "ldrsw x30, [x28, x29, lsl #2]");
+  TEST_SINGLE(ldrsw(XReg::x30, Reg::r28, Reg::r29, ExtendedType::UXTW, 0), "ldrsw x30, [x28, w29, uxtw]");
+  TEST_SINGLE(ldrsw(XReg::x30, Reg::r28, Reg::r29, ExtendedType::UXTW, 2), "ldrsw x30, [x28, w29, uxtw #2]");
+  TEST_SINGLE(ldrsw(XReg::x30, Reg::r28, Reg::r29, ExtendedType::SXTW, 0), "ldrsw x30, [x28, w29, sxtw]");
+  TEST_SINGLE(ldrsw(XReg::x30, Reg::r28, Reg::r29, ExtendedType::SXTW, 2), "ldrsw x30, [x28, w29, sxtw #2]");
+  TEST_SINGLE(ldrsw(XReg::x30, Reg::r28, Reg::r29, ExtendedType::SXTX, 0), "ldrsw x30, [x28, x29, sxtx]");
+  TEST_SINGLE(ldrsw(XReg::x30, Reg::r28, Reg::r29, ExtendedType::SXTX, 2), "ldrsw x30, [x28, x29, sxtx #2]");
+
+  TEST_SINGLE(str(XReg::x30, Reg::r28, Reg::r29, ExtendedType::LSL_64, 0), "str x30, [x28, x29]");
+  TEST_SINGLE(str(XReg::x30, Reg::r28, Reg::r29, ExtendedType::LSL_64, 3), "str x30, [x28, x29, lsl #3]");
+  TEST_SINGLE(str(XReg::x30, Reg::r28, Reg::r29, ExtendedType::UXTW, 0), "str x30, [x28, w29, uxtw]");
+  TEST_SINGLE(str(XReg::x30, Reg::r28, Reg::r29, ExtendedType::UXTW, 3), "str x30, [x28, w29, uxtw #3]");
+  TEST_SINGLE(str(XReg::x30, Reg::r28, Reg::r29, ExtendedType::SXTW, 0), "str x30, [x28, w29, sxtw]");
+  TEST_SINGLE(str(XReg::x30, Reg::r28, Reg::r29, ExtendedType::SXTW, 3), "str x30, [x28, w29, sxtw #3]");
+  TEST_SINGLE(str(XReg::x30, Reg::r28, Reg::r29, ExtendedType::SXTX, 0), "str x30, [x28, x29, sxtx]");
+  TEST_SINGLE(str(XReg::x30, Reg::r28, Reg::r29, ExtendedType::SXTX, 3), "str x30, [x28, x29, sxtx #3]");
+
+  TEST_SINGLE(ldr(XReg::x30, Reg::r28, Reg::r29, ExtendedType::LSL_64, 0), "ldr x30, [x28, x29]");
+  TEST_SINGLE(ldr(XReg::x30, Reg::r28, Reg::r29, ExtendedType::LSL_64, 3), "ldr x30, [x28, x29, lsl #3]");
+  TEST_SINGLE(ldr(XReg::x30, Reg::r28, Reg::r29, ExtendedType::UXTW, 0), "ldr x30, [x28, w29, uxtw]");
+  TEST_SINGLE(ldr(XReg::x30, Reg::r28, Reg::r29, ExtendedType::UXTW, 3), "ldr x30, [x28, w29, uxtw #3]");
+  TEST_SINGLE(ldr(XReg::x30, Reg::r28, Reg::r29, ExtendedType::SXTW, 0), "ldr x30, [x28, w29, sxtw]");
+  TEST_SINGLE(ldr(XReg::x30, Reg::r28, Reg::r29, ExtendedType::SXTW, 3), "ldr x30, [x28, w29, sxtw #3]");
+  TEST_SINGLE(ldr(XReg::x30, Reg::r28, Reg::r29, ExtendedType::SXTX, 0), "ldr x30, [x28, x29, sxtx]");
+  TEST_SINGLE(ldr(XReg::x30, Reg::r28, Reg::r29, ExtendedType::SXTX, 3), "ldr x30, [x28, x29, sxtx #3]");
+
+  TEST_SINGLE(prfm(Prefetch::PLDL1KEEP, Reg::r28, Reg::r29, ExtendedType::LSL_64, 0), "prfm pldl1keep, [x28, x29]");
+  TEST_SINGLE(prfm(Prefetch::PLDL1KEEP, Reg::r28, Reg::r29, ExtendedType::LSL_64, 3), "prfm pldl1keep, [x28, x29, lsl #3]");
+  TEST_SINGLE(prfm(Prefetch::PLDL1KEEP, Reg::r28, Reg::r29, ExtendedType::UXTW, 0), "prfm pldl1keep, [x28, w29, uxtw]");
+  TEST_SINGLE(prfm(Prefetch::PLDL1KEEP, Reg::r28, Reg::r29, ExtendedType::UXTW, 3), "prfm pldl1keep, [x28, w29, uxtw #3]");
+  TEST_SINGLE(prfm(Prefetch::PLDL1KEEP, Reg::r28, Reg::r29, ExtendedType::SXTW, 0), "prfm pldl1keep, [x28, w29, sxtw]");
+  TEST_SINGLE(prfm(Prefetch::PLDL1KEEP, Reg::r28, Reg::r29, ExtendedType::SXTW, 3), "prfm pldl1keep, [x28, w29, sxtw #3]");
+  TEST_SINGLE(prfm(Prefetch::PLDL1KEEP, Reg::r28, Reg::r29, ExtendedType::SXTX, 0), "prfm pldl1keep, [x28, x29, sxtx]");
+  TEST_SINGLE(prfm(Prefetch::PLDL1KEEP, Reg::r28, Reg::r29, ExtendedType::SXTX, 3), "prfm pldl1keep, [x28, x29, sxtx #3]");
+
+  TEST_SINGLE(strb(VReg::v30, Reg::r28, Reg::r29, ExtendedType::LSL_64), "str b30, [x28, x29]");
+  TEST_SINGLE(strb(VReg::v30, Reg::r28, Reg::r29, ExtendedType::UXTW), "str b30, [x28, w29, uxtw]");
+  TEST_SINGLE(strb(VReg::v30, Reg::r28, Reg::r29, ExtendedType::SXTW), "str b30, [x28, w29, sxtw]");
+  TEST_SINGLE(strb(VReg::v30, Reg::r28, Reg::r29, ExtendedType::SXTX), "str b30, [x28, x29, sxtx]");
+
+  TEST_SINGLE(ldrb(VReg::v30, Reg::r28, Reg::r29, ExtendedType::LSL_64), "ldr b30, [x28, x29]");
+  TEST_SINGLE(ldrb(VReg::v30, Reg::r28, Reg::r29, ExtendedType::UXTW), "ldr b30, [x28, w29, uxtw]");
+  TEST_SINGLE(ldrb(VReg::v30, Reg::r28, Reg::r29, ExtendedType::SXTW), "ldr b30, [x28, w29, sxtw]");
+  TEST_SINGLE(ldrb(VReg::v30, Reg::r28, Reg::r29, ExtendedType::SXTX), "ldr b30, [x28, x29, sxtx]");
+
+  TEST_SINGLE(strh(VReg::v30, Reg::r28, Reg::r29, ExtendedType::LSL_64, 0), "str h30, [x28, x29]");
+  TEST_SINGLE(strh(VReg::v30, Reg::r28, Reg::r29, ExtendedType::LSL_64, 1), "str h30, [x28, x29, lsl #1]");
+  TEST_SINGLE(strh(VReg::v30, Reg::r28, Reg::r29, ExtendedType::UXTW, 0), "str h30, [x28, w29, uxtw]");
+  TEST_SINGLE(strh(VReg::v30, Reg::r28, Reg::r29, ExtendedType::UXTW, 1), "str h30, [x28, w29, uxtw #1]");
+  TEST_SINGLE(strh(VReg::v30, Reg::r28, Reg::r29, ExtendedType::SXTW, 0), "str h30, [x28, w29, sxtw]");
+  TEST_SINGLE(strh(VReg::v30, Reg::r28, Reg::r29, ExtendedType::SXTW, 1), "str h30, [x28, w29, sxtw #1]");
+  TEST_SINGLE(strh(VReg::v30, Reg::r28, Reg::r29, ExtendedType::SXTX, 0), "str h30, [x28, x29, sxtx]");
+  TEST_SINGLE(strh(VReg::v30, Reg::r28, Reg::r29, ExtendedType::SXTX, 1), "str h30, [x28, x29, sxtx #1]");
+
+  TEST_SINGLE(ldrh(VReg::v30, Reg::r28, Reg::r29, ExtendedType::LSL_64, 0), "ldr h30, [x28, x29]");
+  TEST_SINGLE(ldrh(VReg::v30, Reg::r28, Reg::r29, ExtendedType::LSL_64, 1), "ldr h30, [x28, x29, lsl #1]");
+  TEST_SINGLE(ldrh(VReg::v30, Reg::r28, Reg::r29, ExtendedType::UXTW, 0), "ldr h30, [x28, w29, uxtw]");
+  TEST_SINGLE(ldrh(VReg::v30, Reg::r28, Reg::r29, ExtendedType::UXTW, 1), "ldr h30, [x28, w29, uxtw #1]");
+  TEST_SINGLE(ldrh(VReg::v30, Reg::r28, Reg::r29, ExtendedType::SXTW, 0), "ldr h30, [x28, w29, sxtw]");
+  TEST_SINGLE(ldrh(VReg::v30, Reg::r28, Reg::r29, ExtendedType::SXTW, 1), "ldr h30, [x28, w29, sxtw #1]");
+  TEST_SINGLE(ldrh(VReg::v30, Reg::r28, Reg::r29, ExtendedType::SXTX, 0), "ldr h30, [x28, x29, sxtx]");
+  TEST_SINGLE(ldrh(VReg::v30, Reg::r28, Reg::r29, ExtendedType::SXTX, 1), "ldr h30, [x28, x29, sxtx #1]");
+
+  TEST_SINGLE(str(SReg::s30, Reg::r28, Reg::r29, ExtendedType::LSL_64, 0), "str s30, [x28, x29]");
+  TEST_SINGLE(str(SReg::s30, Reg::r28, Reg::r29, ExtendedType::LSL_64, 2), "str s30, [x28, x29, lsl #2]");
+  TEST_SINGLE(str(SReg::s30, Reg::r28, Reg::r29, ExtendedType::UXTW, 0), "str s30, [x28, w29, uxtw]");
+  TEST_SINGLE(str(SReg::s30, Reg::r28, Reg::r29, ExtendedType::UXTW, 2), "str s30, [x28, w29, uxtw #2]");
+  TEST_SINGLE(str(SReg::s30, Reg::r28, Reg::r29, ExtendedType::SXTW, 0), "str s30, [x28, w29, sxtw]");
+  TEST_SINGLE(str(SReg::s30, Reg::r28, Reg::r29, ExtendedType::SXTW, 2), "str s30, [x28, w29, sxtw #2]");
+  TEST_SINGLE(str(SReg::s30, Reg::r28, Reg::r29, ExtendedType::SXTX, 0), "str s30, [x28, x29, sxtx]");
+  TEST_SINGLE(str(SReg::s30, Reg::r28, Reg::r29, ExtendedType::SXTX, 2), "str s30, [x28, x29, sxtx #2]");
+
+  TEST_SINGLE(ldr(SReg::s30, Reg::r28, Reg::r29, ExtendedType::LSL_64, 0), "ldr s30, [x28, x29]");
+  TEST_SINGLE(ldr(SReg::s30, Reg::r28, Reg::r29, ExtendedType::LSL_64, 2), "ldr s30, [x28, x29, lsl #2]");
+  TEST_SINGLE(ldr(SReg::s30, Reg::r28, Reg::r29, ExtendedType::UXTW, 0), "ldr s30, [x28, w29, uxtw]");
+  TEST_SINGLE(ldr(SReg::s30, Reg::r28, Reg::r29, ExtendedType::UXTW, 2), "ldr s30, [x28, w29, uxtw #2]");
+  TEST_SINGLE(ldr(SReg::s30, Reg::r28, Reg::r29, ExtendedType::SXTW, 0), "ldr s30, [x28, w29, sxtw]");
+  TEST_SINGLE(ldr(SReg::s30, Reg::r28, Reg::r29, ExtendedType::SXTW, 2), "ldr s30, [x28, w29, sxtw #2]");
+  TEST_SINGLE(ldr(SReg::s30, Reg::r28, Reg::r29, ExtendedType::SXTX, 0), "ldr s30, [x28, x29, sxtx]");
+  TEST_SINGLE(ldr(SReg::s30, Reg::r28, Reg::r29, ExtendedType::SXTX, 2), "ldr s30, [x28, x29, sxtx #2]");
+
+  TEST_SINGLE(str(DReg::d30, Reg::r28, Reg::r29, ExtendedType::LSL_64, 0), "str d30, [x28, x29]");
+  TEST_SINGLE(str(DReg::d30, Reg::r28, Reg::r29, ExtendedType::LSL_64, 3), "str d30, [x28, x29, lsl #3]");
+  TEST_SINGLE(str(DReg::d30, Reg::r28, Reg::r29, ExtendedType::UXTW, 0), "str d30, [x28, w29, uxtw]");
+  TEST_SINGLE(str(DReg::d30, Reg::r28, Reg::r29, ExtendedType::UXTW, 3), "str d30, [x28, w29, uxtw #3]");
+  TEST_SINGLE(str(DReg::d30, Reg::r28, Reg::r29, ExtendedType::SXTW, 0), "str d30, [x28, w29, sxtw]");
+  TEST_SINGLE(str(DReg::d30, Reg::r28, Reg::r29, ExtendedType::SXTW, 3), "str d30, [x28, w29, sxtw #3]");
+  TEST_SINGLE(str(DReg::d30, Reg::r28, Reg::r29, ExtendedType::SXTX, 0), "str d30, [x28, x29, sxtx]");
+  TEST_SINGLE(str(DReg::d30, Reg::r28, Reg::r29, ExtendedType::SXTX, 3), "str d30, [x28, x29, sxtx #3]");
+
+  TEST_SINGLE(ldr(DReg::d30, Reg::r28, Reg::r29, ExtendedType::LSL_64, 0), "ldr d30, [x28, x29]");
+  TEST_SINGLE(ldr(DReg::d30, Reg::r28, Reg::r29, ExtendedType::LSL_64, 3), "ldr d30, [x28, x29, lsl #3]");
+  TEST_SINGLE(ldr(DReg::d30, Reg::r28, Reg::r29, ExtendedType::UXTW, 0), "ldr d30, [x28, w29, uxtw]");
+  TEST_SINGLE(ldr(DReg::d30, Reg::r28, Reg::r29, ExtendedType::UXTW, 3), "ldr d30, [x28, w29, uxtw #3]");
+  TEST_SINGLE(ldr(DReg::d30, Reg::r28, Reg::r29, ExtendedType::SXTW, 0), "ldr d30, [x28, w29, sxtw]");
+  TEST_SINGLE(ldr(DReg::d30, Reg::r28, Reg::r29, ExtendedType::SXTW, 3), "ldr d30, [x28, w29, sxtw #3]");
+  TEST_SINGLE(ldr(DReg::d30, Reg::r28, Reg::r29, ExtendedType::SXTX, 0), "ldr d30, [x28, x29, sxtx]");
+  TEST_SINGLE(ldr(DReg::d30, Reg::r28, Reg::r29, ExtendedType::SXTX, 3), "ldr d30, [x28, x29, sxtx #3]");
+
+  TEST_SINGLE(str(QReg::q30, Reg::r28, Reg::r29, ExtendedType::LSL_64, 0), "str q30, [x28, x29]");
+  TEST_SINGLE(str(QReg::q30, Reg::r28, Reg::r29, ExtendedType::LSL_64, 4), "str q30, [x28, x29, lsl #4]");
+  TEST_SINGLE(str(QReg::q30, Reg::r28, Reg::r29, ExtendedType::UXTW, 0), "str q30, [x28, w29, uxtw]");
+  TEST_SINGLE(str(QReg::q30, Reg::r28, Reg::r29, ExtendedType::UXTW, 4), "str q30, [x28, w29, uxtw #4]");
+  TEST_SINGLE(str(QReg::q30, Reg::r28, Reg::r29, ExtendedType::SXTW, 0), "str q30, [x28, w29, sxtw]");
+  TEST_SINGLE(str(QReg::q30, Reg::r28, Reg::r29, ExtendedType::SXTW, 4), "str q30, [x28, w29, sxtw #4]");
+  TEST_SINGLE(str(QReg::q30, Reg::r28, Reg::r29, ExtendedType::SXTX, 0), "str q30, [x28, x29, sxtx]");
+  TEST_SINGLE(str(QReg::q30, Reg::r28, Reg::r29, ExtendedType::SXTX, 4), "str q30, [x28, x29, sxtx #4]");
+
+  TEST_SINGLE(ldr(QReg::q30, Reg::r28, Reg::r29, ExtendedType::LSL_64, 0), "ldr q30, [x28, x29]");
+  TEST_SINGLE(ldr(QReg::q30, Reg::r28, Reg::r29, ExtendedType::LSL_64, 4), "ldr q30, [x28, x29, lsl #4]");
+  TEST_SINGLE(ldr(QReg::q30, Reg::r28, Reg::r29, ExtendedType::UXTW, 0), "ldr q30, [x28, w29, uxtw]");
+  TEST_SINGLE(ldr(QReg::q30, Reg::r28, Reg::r29, ExtendedType::UXTW, 4), "ldr q30, [x28, w29, uxtw #4]");
+  TEST_SINGLE(ldr(QReg::q30, Reg::r28, Reg::r29, ExtendedType::SXTW, 0), "ldr q30, [x28, w29, sxtw]");
+  TEST_SINGLE(ldr(QReg::q30, Reg::r28, Reg::r29, ExtendedType::SXTW, 4), "ldr q30, [x28, w29, sxtw #4]");
+  TEST_SINGLE(ldr(QReg::q30, Reg::r28, Reg::r29, ExtendedType::SXTX, 0), "ldr q30, [x28, x29, sxtx]");
+  TEST_SINGLE(ldr(QReg::q30, Reg::r28, Reg::r29, ExtendedType::SXTX, 4), "ldr q30, [x28, x29, sxtx #4]");
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Loadstore PAC") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Loadstore unsigned immediate") {
+  TEST_SINGLE(strb(Reg::r30, Reg::r29, 0), "strb w30, [x29]");
+  TEST_SINGLE(strb(Reg::r30, Reg::r29, 4095), "strb w30, [x29, #4095]");
+  TEST_SINGLE(ldrb(Reg::r30, Reg::r29, 0), "ldrb w30, [x29]");
+  TEST_SINGLE(ldrb(Reg::r30, Reg::r29, 4095), "ldrb w30, [x29, #4095]");
+  TEST_SINGLE(ldrsb(WReg::w30, Reg::r29, 0), "ldrsb w30, [x29]");
+  TEST_SINGLE(ldrsb(WReg::w30, Reg::r29, 4095), "ldrsb w30, [x29, #4095]");
+  TEST_SINGLE(ldrsb(XReg::x30, Reg::r29, 0), "ldrsb x30, [x29]");
+  TEST_SINGLE(ldrsb(XReg::x30, Reg::r29, 4095), "ldrsb x30, [x29, #4095]");
+  TEST_SINGLE(ldrb(VReg::v30, Reg::r29, 0), "ldr b30, [x29]");
+  TEST_SINGLE(ldrb(VReg::v30, Reg::r29, 4095), "ldr b30, [x29, #4095]");
+  TEST_SINGLE(strb(VReg::v30, Reg::r29, 0), "str b30, [x29]");
+  TEST_SINGLE(strb(VReg::v30, Reg::r29, 4095), "str b30, [x29, #4095]");
+
+  TEST_SINGLE(strh(Reg::r30, Reg::r29, 0), "strh w30, [x29]");
+  TEST_SINGLE(strh(Reg::r30, Reg::r29, 8190), "strh w30, [x29, #8190]");
+  TEST_SINGLE(ldrh(Reg::r30, Reg::r29, 0), "ldrh w30, [x29]");
+  TEST_SINGLE(ldrh(Reg::r30, Reg::r29, 8190), "ldrh w30, [x29, #8190]");
+  TEST_SINGLE(ldrsh(WReg::w30, Reg::r29, 0), "ldrsh w30, [x29]");
+  TEST_SINGLE(ldrsh(WReg::w30, Reg::r29, 8190), "ldrsh w30, [x29, #8190]");
+  TEST_SINGLE(ldrsh(XReg::x30, Reg::r29, 0), "ldrsh x30, [x29]");
+  TEST_SINGLE(ldrsh(XReg::x30, Reg::r29, 8190), "ldrsh x30, [x29, #8190]");
+
+  TEST_SINGLE(ldrh(VReg::v30, Reg::r29, 0), "ldr h30, [x29]");
+  TEST_SINGLE(ldrh(VReg::v30, Reg::r29, 8190), "ldr h30, [x29, #8190]");
+  TEST_SINGLE(strh(VReg::v30, Reg::r29, 0), "str h30, [x29]");
+  TEST_SINGLE(strh(VReg::v30, Reg::r29, 8190), "str h30, [x29, #8190]");
+
+  TEST_SINGLE(str(WReg::w30, Reg::r29, 0), "str w30, [x29]");
+  TEST_SINGLE(str(WReg::w30, Reg::r29, 16380), "str w30, [x29, #16380]");
+  TEST_SINGLE(ldr(WReg::w30, Reg::r29, 0), "ldr w30, [x29]");
+  TEST_SINGLE(ldr(WReg::w30, Reg::r29, 16380), "ldr w30, [x29, #16380]");
+
+  TEST_SINGLE(ldrsw(XReg::x30, Reg::r29, 0), "ldrsw x30, [x29]");
+  TEST_SINGLE(ldrsw(XReg::x30, Reg::r29, 16380), "ldrsw x30, [x29, #16380]");
+
+  TEST_SINGLE(ldr(SReg::s30, Reg::r29, 0), "ldr s30, [x29]");
+  TEST_SINGLE(ldr(SReg::s30, Reg::r29, 16380), "ldr s30, [x29, #16380]");
+  TEST_SINGLE(str(SReg::s30, Reg::r29, 0), "str s30, [x29]");
+  TEST_SINGLE(str(SReg::s30, Reg::r29, 16380), "str s30, [x29, #16380]");
+
+  TEST_SINGLE(str(XReg::x30, Reg::r29, 0), "str x30, [x29]");
+  TEST_SINGLE(str(XReg::x30, Reg::r29, 32760), "str x30, [x29, #32760]");
+  TEST_SINGLE(ldr(XReg::x30, Reg::r29, 0), "ldr x30, [x29]");
+  TEST_SINGLE(ldr(XReg::x30, Reg::r29, 32760), "ldr x30, [x29, #32760]");
+
+  TEST_SINGLE(ldr(SubRegSize::i8Bit, Reg::r30, Reg::r29, 0), "ldrb w30, [x29]");
+  TEST_SINGLE(ldr(SubRegSize::i8Bit, Reg::r30, Reg::r29, 4095), "ldrb w30, [x29, #4095]");
+  TEST_SINGLE(ldr(SubRegSize::i16Bit, Reg::r30, Reg::r29, 0), "ldrh w30, [x29]");
+  TEST_SINGLE(ldr(SubRegSize::i16Bit, Reg::r30, Reg::r29, 8190), "ldrh w30, [x29, #8190]");
+  TEST_SINGLE(ldr(SubRegSize::i32Bit, Reg::r30, Reg::r29, 0), "ldr w30, [x29]");
+  TEST_SINGLE(ldr(SubRegSize::i32Bit, Reg::r30, Reg::r29, 16380), "ldr w30, [x29, #16380]");
+  TEST_SINGLE(ldr(SubRegSize::i64Bit, Reg::r30, Reg::r29, 0), "ldr x30, [x29]");
+  TEST_SINGLE(ldr(SubRegSize::i64Bit, Reg::r30, Reg::r29, 32760), "ldr x30, [x29, #32760]");
+
+  TEST_SINGLE(str(SubRegSize::i8Bit, Reg::r30, Reg::r29, 0), "strb w30, [x29]");
+  TEST_SINGLE(str(SubRegSize::i8Bit, Reg::r30, Reg::r29, 4095), "strb w30, [x29, #4095]");
+  TEST_SINGLE(str(SubRegSize::i16Bit, Reg::r30, Reg::r29, 0), "strh w30, [x29]");
+  TEST_SINGLE(str(SubRegSize::i16Bit, Reg::r30, Reg::r29, 8190), "strh w30, [x29, #8190]");
+  TEST_SINGLE(str(SubRegSize::i32Bit, Reg::r30, Reg::r29, 0), "str w30, [x29]");
+  TEST_SINGLE(str(SubRegSize::i32Bit, Reg::r30, Reg::r29, 16380), "str w30, [x29, #16380]");
+  TEST_SINGLE(str(SubRegSize::i64Bit, Reg::r30, Reg::r29, 0), "str x30, [x29]");
+  TEST_SINGLE(str(SubRegSize::i64Bit, Reg::r30, Reg::r29, 32760), "str x30, [x29, #32760]");
+
+  TEST_SINGLE(prfm(Prefetch::PLDL1KEEP, Reg::r29, 0), "prfm pldl1keep, [x29]");
+  TEST_SINGLE(prfm(Prefetch::PLDL1KEEP, Reg::r29, 32760), "prfm pldl1keep, [x29, #32760]");
+
+  TEST_SINGLE(ldr(DReg::d30, Reg::r29, 0), "ldr d30, [x29]");
+  TEST_SINGLE(ldr(DReg::d30, Reg::r29, 32760), "ldr d30, [x29, #32760]");
+  TEST_SINGLE(str(DReg::d30, Reg::r29, 0), "str d30, [x29]");
+  TEST_SINGLE(str(DReg::d30, Reg::r29, 32760), "str d30, [x29, #32760]");
+
+  TEST_SINGLE(ldr(QReg::q30, Reg::r29, 0), "ldr q30, [x29]");
+  TEST_SINGLE(ldr(QReg::q30, Reg::r29, 65520), "ldr q30, [x29, #65520]");
+  TEST_SINGLE(str(QReg::q30, Reg::r29, 0), "str q30, [x29]");
+  TEST_SINGLE(str(QReg::q30, Reg::r29, 65520), "str q30, [x29, #65520]");
+}

--- a/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
+++ b/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
@@ -1,0 +1,2159 @@
+#include "TestDisassembler.h"
+
+#include <catch2/catch.hpp>
+#include <fcntl.h>
+
+using namespace FEXCore::ARMEmitter;
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: Base Encodings") {
+  TEST_SINGLE(dup(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, 0), "mov z30.b, b29");
+  TEST_SINGLE(dup(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, 1), "mov z30.b, z29.b[1]");
+  TEST_SINGLE(dup(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, 63), "mov z30.b, z29.b[63]");
+
+  TEST_SINGLE(dup(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, 0), "mov z30.h, h29");
+  TEST_SINGLE(dup(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, 1), "mov z30.h, z29.h[1]");
+  TEST_SINGLE(dup(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, 31), "mov z30.h, z29.h[31]");
+
+  TEST_SINGLE(dup(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, 0), "mov z30.s, s29");
+  TEST_SINGLE(dup(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, 1), "mov z30.s, z29.s[1]");
+  TEST_SINGLE(dup(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, 15), "mov z30.s, z29.s[15]");
+
+  TEST_SINGLE(dup(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, 0), "mov z30.d, d29");
+  TEST_SINGLE(dup(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, 1), "mov z30.d, z29.d[1]");
+  TEST_SINGLE(dup(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, 7), "mov z30.d, z29.d[7]");
+
+  TEST_SINGLE(dup(SubRegSize::i128Bit, ZReg::z30, ZReg::z29, 0), "mov z30.q, q29");
+  TEST_SINGLE(dup(SubRegSize::i128Bit, ZReg::z30, ZReg::z29, 1), "mov z30.q, z29.q[1]");
+  TEST_SINGLE(dup(SubRegSize::i128Bit, ZReg::z30, ZReg::z29, 3), "mov z30.q, z29.q[3]");
+
+  // TODO: TBL
+
+  TEST_SINGLE(sel(SubRegSize::i8Bit, ZReg::z30, PReg::p6, ZReg::z29, ZReg::z28),   "sel z30.b, p6, z29.b, z28.b");
+  TEST_SINGLE(sel(SubRegSize::i16Bit, ZReg::z30, PReg::p6, ZReg::z29, ZReg::z28),  "sel z30.h, p6, z29.h, z28.h");
+  TEST_SINGLE(sel(SubRegSize::i32Bit, ZReg::z30, PReg::p6, ZReg::z29, ZReg::z28),  "sel z30.s, p6, z29.s, z28.s");
+  TEST_SINGLE(sel(SubRegSize::i64Bit, ZReg::z30, PReg::p6, ZReg::z29, ZReg::z28),  "sel z30.d, p6, z29.d, z28.d");
+  //TEST_SINGLE(sel(SubRegSize::i128Bit, ZReg::z30, PReg::p6, ZReg::z29, ZReg::z28), "sel z30.q, p6, z29.q, z28.q");
+
+  TEST_SINGLE(mov(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),   "mov z30.b, p6/m, z29.b");
+  TEST_SINGLE(mov(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "mov z30.h, p6/m, z29.h");
+  TEST_SINGLE(mov(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "mov z30.s, p6/m, z29.s");
+  TEST_SINGLE(mov(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "mov z30.d, p6/m, z29.d");
+  //TEST_SINGLE(mov(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "mov z30.q, p6/m, z29.q");
+
+  // TODO: HISTCNT
+  // TODO: FCMLA
+  // TODO: FCADD
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE integer add/subtract vectors (unpredicated)") {
+  TEST_SINGLE(add(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28),   "add z30.b, z29.b, z28.b");
+  TEST_SINGLE(add(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "add z30.h, z29.h, z28.h");
+  TEST_SINGLE(add(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "add z30.s, z29.s, z28.s");
+  TEST_SINGLE(add(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "add z30.d, z29.d, z28.d");
+  //TEST_SINGLE(add(SubRegSize::i128Bit, ZReg::z30, ZReg::z29, ZReg::z28), "add z30.q, z29.q, z28.q");
+
+  TEST_SINGLE(sub(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28),   "sub z30.b, z29.b, z28.b");
+  TEST_SINGLE(sub(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "sub z30.h, z29.h, z28.h");
+  TEST_SINGLE(sub(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "sub z30.s, z29.s, z28.s");
+  TEST_SINGLE(sub(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "sub z30.d, z29.d, z28.d");
+  //TEST_SINGLE(sub(SubRegSize::i128Bit, ZReg::z30, ZReg::z29, ZReg::z28), "sub z30.q, z29.q, z28.q");
+
+  TEST_SINGLE(sqadd(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28),   "sqadd z30.b, z29.b, z28.b");
+  TEST_SINGLE(sqadd(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "sqadd z30.h, z29.h, z28.h");
+  TEST_SINGLE(sqadd(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "sqadd z30.s, z29.s, z28.s");
+  TEST_SINGLE(sqadd(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "sqadd z30.d, z29.d, z28.d");
+  //TEST_SINGLE(sqadd(SubRegSize::i128Bit, ZReg::z30, ZReg::z29, ZReg::z28), "sqadd z30.q, z29.q, z28.q");
+
+  TEST_SINGLE(uqadd(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28),   "uqadd z30.b, z29.b, z28.b");
+  TEST_SINGLE(uqadd(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "uqadd z30.h, z29.h, z28.h");
+  TEST_SINGLE(uqadd(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "uqadd z30.s, z29.s, z28.s");
+  TEST_SINGLE(uqadd(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "uqadd z30.d, z29.d, z28.d");
+  //TEST_SINGLE(uqadd(SubRegSize::i128Bit, ZReg::z30, ZReg::z29, ZReg::z28), "uqadd z30.q, z29.q, z28.q");
+
+  TEST_SINGLE(sqsub(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28),   "sqsub z30.b, z29.b, z28.b");
+  TEST_SINGLE(sqsub(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "sqsub z30.h, z29.h, z28.h");
+  TEST_SINGLE(sqsub(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "sqsub z30.s, z29.s, z28.s");
+  TEST_SINGLE(sqsub(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "sqsub z30.d, z29.d, z28.d");
+  //TEST_SINGLE(sqsub(SubRegSize::i128Bit, ZReg::z30, ZReg::z29, ZReg::z28), "sqsub z30.q, z29.q, z28.q");
+
+  TEST_SINGLE(uqsub(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28),   "uqsub z30.b, z29.b, z28.b");
+  TEST_SINGLE(uqsub(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "uqsub z30.h, z29.h, z28.h");
+  TEST_SINGLE(uqsub(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "uqsub z30.s, z29.s, z28.s");
+  TEST_SINGLE(uqsub(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "uqsub z30.d, z29.d, z28.d");
+  //TEST_SINGLE(uqsub(SubRegSize::i128Bit, ZReg::z30, ZReg::z29, ZReg::z28), "uqsub z30.q, z29.q, z28.q");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE address generation") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE table lookup (three sources)") {
+  TEST_SINGLE(tbl(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28),   "tbl z30.b, {z29.b}, z28.b");
+  TEST_SINGLE(tbl(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "tbl z30.h, {z29.h}, z28.h");
+  TEST_SINGLE(tbl(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "tbl z30.s, {z29.s}, z28.s");
+  TEST_SINGLE(tbl(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "tbl z30.d, {z29.d}, z28.d");
+  //TEST_SINGLE(tbl(SubRegSize::i128Bit, ZReg::z30, ZReg::z29, ZReg::z28), "tbl z30.q, {z29.q}, z28.q");
+
+  TEST_SINGLE(tbx(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28),   "tbx z30.b, z29.b, z28.b");
+  TEST_SINGLE(tbx(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "tbx z30.h, z29.h, z28.h");
+  TEST_SINGLE(tbx(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "tbx z30.s, z29.s, z28.s");
+  TEST_SINGLE(tbx(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "tbx z30.d, z29.d, z28.d");
+  //TEST_SINGLE(tbx(SubRegSize::i128Bit, ZReg::z30, ZReg::z29, ZReg::z28), "tbx z30.q, z29.q, z28.q");
+
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE permute vector elements") {
+  TEST_SINGLE(zip1(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "zip1 z30.b, z29.b, z28.b");
+  TEST_SINGLE(zip1(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28), "zip1 z30.h, z29.h, z28.h");
+  TEST_SINGLE(zip1(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "zip1 z30.s, z29.s, z28.s");
+  TEST_SINGLE(zip1(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28), "zip1 z30.d, z29.d, z28.d");
+
+  TEST_SINGLE(zip2(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "zip2 z30.b, z29.b, z28.b");
+  TEST_SINGLE(zip2(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28), "zip2 z30.h, z29.h, z28.h");
+  TEST_SINGLE(zip2(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "zip2 z30.s, z29.s, z28.s");
+  TEST_SINGLE(zip2(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28), "zip2 z30.d, z29.d, z28.d");
+
+  TEST_SINGLE(uzp1(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "uzp1 z30.b, z29.b, z28.b");
+  TEST_SINGLE(uzp1(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28), "uzp1 z30.h, z29.h, z28.h");
+  TEST_SINGLE(uzp1(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "uzp1 z30.s, z29.s, z28.s");
+  TEST_SINGLE(uzp1(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28), "uzp1 z30.d, z29.d, z28.d");
+
+  TEST_SINGLE(uzp2(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "uzp2 z30.b, z29.b, z28.b");
+  TEST_SINGLE(uzp2(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28), "uzp2 z30.h, z29.h, z28.h");
+  TEST_SINGLE(uzp2(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "uzp2 z30.s, z29.s, z28.s");
+  TEST_SINGLE(uzp2(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28), "uzp2 z30.d, z29.d, z28.d");
+
+  TEST_SINGLE(trn1(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "trn1 z30.b, z29.b, z28.b");
+  TEST_SINGLE(trn1(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28), "trn1 z30.h, z29.h, z28.h");
+  TEST_SINGLE(trn1(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "trn1 z30.s, z29.s, z28.s");
+  TEST_SINGLE(trn1(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28), "trn1 z30.d, z29.d, z28.d");
+
+  TEST_SINGLE(trn2(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "trn2 z30.b, z29.b, z28.b");
+  TEST_SINGLE(trn2(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28), "trn2 z30.h, z29.h, z28.h");
+  TEST_SINGLE(trn2(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "trn2 z30.s, z29.s, z28.s");
+  TEST_SINGLE(trn2(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28), "trn2 z30.d, z29.d, z28.d");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE integer compare with unsigned immediate") {
+  TEST_SINGLE(cmphi(SubRegSize::i8Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 0),  "cmphi p6.b, p5/z, z30.b, #0");
+  TEST_SINGLE(cmphi(SubRegSize::i16Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 0), "cmphi p6.h, p5/z, z30.h, #0");
+  TEST_SINGLE(cmphi(SubRegSize::i32Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 0), "cmphi p6.s, p5/z, z30.s, #0");
+  TEST_SINGLE(cmphi(SubRegSize::i64Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 0), "cmphi p6.d, p5/z, z30.d, #0");
+  TEST_SINGLE(cmphi(SubRegSize::i8Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 127),  "cmphi p6.b, p5/z, z30.b, #127");
+  TEST_SINGLE(cmphi(SubRegSize::i16Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 127), "cmphi p6.h, p5/z, z30.h, #127");
+  TEST_SINGLE(cmphi(SubRegSize::i32Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 127), "cmphi p6.s, p5/z, z30.s, #127");
+  TEST_SINGLE(cmphi(SubRegSize::i64Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 127), "cmphi p6.d, p5/z, z30.d, #127");
+
+  TEST_SINGLE(cmphs(SubRegSize::i8Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 0),  "cmphs p6.b, p5/z, z30.b, #0");
+  TEST_SINGLE(cmphs(SubRegSize::i16Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 0), "cmphs p6.h, p5/z, z30.h, #0");
+  TEST_SINGLE(cmphs(SubRegSize::i32Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 0), "cmphs p6.s, p5/z, z30.s, #0");
+  TEST_SINGLE(cmphs(SubRegSize::i64Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 0), "cmphs p6.d, p5/z, z30.d, #0");
+  TEST_SINGLE(cmphs(SubRegSize::i8Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 127),  "cmphs p6.b, p5/z, z30.b, #127");
+  TEST_SINGLE(cmphs(SubRegSize::i16Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 127), "cmphs p6.h, p5/z, z30.h, #127");
+  TEST_SINGLE(cmphs(SubRegSize::i32Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 127), "cmphs p6.s, p5/z, z30.s, #127");
+  TEST_SINGLE(cmphs(SubRegSize::i64Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 127), "cmphs p6.d, p5/z, z30.d, #127");
+
+  TEST_SINGLE(cmplo(SubRegSize::i8Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 0),  "cmplo p6.b, p5/z, z30.b, #0");
+  TEST_SINGLE(cmplo(SubRegSize::i16Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 0), "cmplo p6.h, p5/z, z30.h, #0");
+  TEST_SINGLE(cmplo(SubRegSize::i32Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 0), "cmplo p6.s, p5/z, z30.s, #0");
+  TEST_SINGLE(cmplo(SubRegSize::i64Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 0), "cmplo p6.d, p5/z, z30.d, #0");
+  TEST_SINGLE(cmplo(SubRegSize::i8Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 127),  "cmplo p6.b, p5/z, z30.b, #127");
+  TEST_SINGLE(cmplo(SubRegSize::i16Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 127), "cmplo p6.h, p5/z, z30.h, #127");
+  TEST_SINGLE(cmplo(SubRegSize::i32Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 127), "cmplo p6.s, p5/z, z30.s, #127");
+  TEST_SINGLE(cmplo(SubRegSize::i64Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 127), "cmplo p6.d, p5/z, z30.d, #127");
+
+  TEST_SINGLE(cmpls(SubRegSize::i8Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 0),  "cmpls p6.b, p5/z, z30.b, #0");
+  TEST_SINGLE(cmpls(SubRegSize::i16Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 0), "cmpls p6.h, p5/z, z30.h, #0");
+  TEST_SINGLE(cmpls(SubRegSize::i32Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 0), "cmpls p6.s, p5/z, z30.s, #0");
+  TEST_SINGLE(cmpls(SubRegSize::i64Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 0), "cmpls p6.d, p5/z, z30.d, #0");
+  TEST_SINGLE(cmpls(SubRegSize::i8Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 127),  "cmpls p6.b, p5/z, z30.b, #127");
+  TEST_SINGLE(cmpls(SubRegSize::i16Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 127), "cmpls p6.h, p5/z, z30.h, #127");
+  TEST_SINGLE(cmpls(SubRegSize::i32Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 127), "cmpls p6.s, p5/z, z30.s, #127");
+  TEST_SINGLE(cmpls(SubRegSize::i64Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 127), "cmpls p6.d, p5/z, z30.d, #127");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE integer compare with signed immediate") {
+  TEST_SINGLE(cmpeq(SubRegSize::i8Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, -16),  "cmpeq p6.b, p5/z, z30.b, #-16");
+  TEST_SINGLE(cmpeq(SubRegSize::i16Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, -16), "cmpeq p6.h, p5/z, z30.h, #-16");
+  TEST_SINGLE(cmpeq(SubRegSize::i32Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, -16), "cmpeq p6.s, p5/z, z30.s, #-16");
+  TEST_SINGLE(cmpeq(SubRegSize::i64Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, -16), "cmpeq p6.d, p5/z, z30.d, #-16");
+  TEST_SINGLE(cmpeq(SubRegSize::i8Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 15),   "cmpeq p6.b, p5/z, z30.b, #15");
+  TEST_SINGLE(cmpeq(SubRegSize::i16Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 15),  "cmpeq p6.h, p5/z, z30.h, #15");
+  TEST_SINGLE(cmpeq(SubRegSize::i32Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 15),  "cmpeq p6.s, p5/z, z30.s, #15");
+  TEST_SINGLE(cmpeq(SubRegSize::i64Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 15),  "cmpeq p6.d, p5/z, z30.d, #15");
+
+  TEST_SINGLE(cmpgt(SubRegSize::i8Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, -16),  "cmpgt p6.b, p5/z, z30.b, #-16");
+  TEST_SINGLE(cmpgt(SubRegSize::i16Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, -16), "cmpgt p6.h, p5/z, z30.h, #-16");
+  TEST_SINGLE(cmpgt(SubRegSize::i32Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, -16), "cmpgt p6.s, p5/z, z30.s, #-16");
+  TEST_SINGLE(cmpgt(SubRegSize::i64Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, -16), "cmpgt p6.d, p5/z, z30.d, #-16");
+  TEST_SINGLE(cmpgt(SubRegSize::i8Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 15),   "cmpgt p6.b, p5/z, z30.b, #15");
+  TEST_SINGLE(cmpgt(SubRegSize::i16Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 15),  "cmpgt p6.h, p5/z, z30.h, #15");
+  TEST_SINGLE(cmpgt(SubRegSize::i32Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 15),  "cmpgt p6.s, p5/z, z30.s, #15");
+  TEST_SINGLE(cmpgt(SubRegSize::i64Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 15),  "cmpgt p6.d, p5/z, z30.d, #15");
+
+  TEST_SINGLE(cmpge(SubRegSize::i8Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, -16),  "cmpge p6.b, p5/z, z30.b, #-16");
+  TEST_SINGLE(cmpge(SubRegSize::i16Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, -16), "cmpge p6.h, p5/z, z30.h, #-16");
+  TEST_SINGLE(cmpge(SubRegSize::i32Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, -16), "cmpge p6.s, p5/z, z30.s, #-16");
+  TEST_SINGLE(cmpge(SubRegSize::i64Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, -16), "cmpge p6.d, p5/z, z30.d, #-16");
+  TEST_SINGLE(cmpge(SubRegSize::i8Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 15),   "cmpge p6.b, p5/z, z30.b, #15");
+  TEST_SINGLE(cmpge(SubRegSize::i16Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 15),  "cmpge p6.h, p5/z, z30.h, #15");
+  TEST_SINGLE(cmpge(SubRegSize::i32Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 15),  "cmpge p6.s, p5/z, z30.s, #15");
+  TEST_SINGLE(cmpge(SubRegSize::i64Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 15),  "cmpge p6.d, p5/z, z30.d, #15");
+
+  TEST_SINGLE(cmplt(SubRegSize::i8Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, -16),  "cmplt p6.b, p5/z, z30.b, #-16");
+  TEST_SINGLE(cmplt(SubRegSize::i16Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, -16), "cmplt p6.h, p5/z, z30.h, #-16");
+  TEST_SINGLE(cmplt(SubRegSize::i32Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, -16), "cmplt p6.s, p5/z, z30.s, #-16");
+  TEST_SINGLE(cmplt(SubRegSize::i64Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, -16), "cmplt p6.d, p5/z, z30.d, #-16");
+  TEST_SINGLE(cmplt(SubRegSize::i8Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 15),   "cmplt p6.b, p5/z, z30.b, #15");
+  TEST_SINGLE(cmplt(SubRegSize::i16Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 15),  "cmplt p6.h, p5/z, z30.h, #15");
+  TEST_SINGLE(cmplt(SubRegSize::i32Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 15),  "cmplt p6.s, p5/z, z30.s, #15");
+  TEST_SINGLE(cmplt(SubRegSize::i64Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 15),  "cmplt p6.d, p5/z, z30.d, #15");
+
+  TEST_SINGLE(cmple(SubRegSize::i8Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, -16),  "cmple p6.b, p5/z, z30.b, #-16");
+  TEST_SINGLE(cmple(SubRegSize::i16Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, -16), "cmple p6.h, p5/z, z30.h, #-16");
+  TEST_SINGLE(cmple(SubRegSize::i32Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, -16), "cmple p6.s, p5/z, z30.s, #-16");
+  TEST_SINGLE(cmple(SubRegSize::i64Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, -16), "cmple p6.d, p5/z, z30.d, #-16");
+  TEST_SINGLE(cmple(SubRegSize::i8Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 15),   "cmple p6.b, p5/z, z30.b, #15");
+  TEST_SINGLE(cmple(SubRegSize::i16Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 15),  "cmple p6.h, p5/z, z30.h, #15");
+  TEST_SINGLE(cmple(SubRegSize::i32Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 15),  "cmple p6.s, p5/z, z30.s, #15");
+  TEST_SINGLE(cmple(SubRegSize::i64Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, 15),  "cmple p6.d, p5/z, z30.d, #15");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE predicate logical operations") {
+  TEST_SINGLE(and_(PReg::p6, PReg::p5.Zeroing(), PReg::p4, PReg::p3), "and p6.b, p5/z, p4.b, p3.b");
+  TEST_SINGLE(ands(PReg::p6, PReg::p5.Zeroing(), PReg::p4, PReg::p3), "ands p6.b, p5/z, p4.b, p3.b");
+  TEST_SINGLE(mov(PReg::p6, PReg::p5.Merging(), PReg::p4), "mov p6.b, p5/m, p4.b");
+  TEST_SINGLE(mov(PReg::p6, PReg::p5.Zeroing(), PReg::p4), "mov p6.b, p5/z, p4.b");
+  TEST_SINGLE(movs(PReg::p6, PReg::p5.Zeroing(), PReg::p4), "movs p6.b, p5/z, p4.b");
+
+  TEST_SINGLE(bic(PReg::p6, PReg::p5.Zeroing(), PReg::p4, PReg::p3), "bic p6.b, p5/z, p4.b, p3.b");
+  TEST_SINGLE(bics(PReg::p6, PReg::p5.Zeroing(), PReg::p4, PReg::p3), "bics p6.b, p5/z, p4.b, p3.b");
+  TEST_SINGLE(eor(PReg::p6, PReg::p5.Zeroing(), PReg::p4, PReg::p3), "eor p6.b, p5/z, p4.b, p3.b");
+  TEST_SINGLE(eors(PReg::p6, PReg::p5.Zeroing(), PReg::p4, PReg::p3), "eors p6.b, p5/z, p4.b, p3.b");
+  TEST_SINGLE(not_(PReg::p6, PReg::p5.Zeroing(), PReg::p4), "not p6.b, p5/z, p4.b");
+
+  TEST_SINGLE(sel(PReg::p6, PReg::p5, PReg::p4, PReg::p3), "sel p6.b, p5, p4.b, p3.b");
+  TEST_SINGLE(orr(PReg::p6, PReg::p5.Zeroing(), PReg::p4, PReg::p3), "orr p6.b, p5/z, p4.b, p3.b");
+  TEST_SINGLE(mov(PReg::p6, PReg::p5), "mov p6.b, p5.b");
+  TEST_SINGLE(orn(PReg::p6, PReg::p5.Zeroing(), PReg::p4, PReg::p3), "orn p6.b, p5/z, p4.b, p3.b");
+  TEST_SINGLE(nor(PReg::p6, PReg::p5.Zeroing(), PReg::p4, PReg::p3), "nor p6.b, p5/z, p4.b, p3.b");
+  TEST_SINGLE(nand(PReg::p6, PReg::p5.Zeroing(), PReg::p4, PReg::p3), "nand p6.b, p5/z, p4.b, p3.b");
+  TEST_SINGLE(orrs(PReg::p6, PReg::p5.Zeroing(), PReg::p4, PReg::p3), "orrs p6.b, p5/z, p4.b, p3.b");
+  TEST_SINGLE(movs(PReg::p6, PReg::p5), "movs p6.b, p5.b");
+
+  TEST_SINGLE(orns(PReg::p6, PReg::p5.Zeroing(), PReg::p4, PReg::p3), "orns p6.b, p5/z, p4.b, p3.b");
+  TEST_SINGLE(nors(PReg::p6, PReg::p5.Zeroing(), PReg::p4, PReg::p3), "nors p6.b, p5/z, p4.b, p3.b");
+  TEST_SINGLE(nands(PReg::p6, PReg::p5.Zeroing(), PReg::p4, PReg::p3), "nands p6.b, p5/z, p4.b, p3.b");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE broadcast predicate element") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE integer clamp") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 character match") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE floating-point convert precision odd elements") {
+  TEST_SINGLE(fcvtxnt(ZReg::z30, PReg::p6.Merging(), ZReg::z29), "fcvtxnt z30.s, p6/m, z29.d");
+  TEST_SINGLE(fcvtnt(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "fcvtnt z30.h, p6/m, z29.s");
+  TEST_SINGLE(fcvtnt(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "fcvtnt z30.s, p6/m, z29.d");
+  //TEST_SINGLE(fcvtnt(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "fcvtnt z30.d, p6/m, z29.d");
+
+  //TEST_SINGLE(fcvtlt(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "fcvtlt z30.h, p6/m, z29.b");
+  TEST_SINGLE(fcvtlt(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "fcvtlt z30.s, p6/m, z29.h");
+  TEST_SINGLE(fcvtlt(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "fcvtlt z30.d, p6/m, z29.s");
+
+
+  //void fcvtxnt(FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::ZRegister zn) {
+  /////< Size is destination size
+  //void fcvtnt(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::ZRegister zn) {
+  /////< Size is destination size
+  //void fcvtlt(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::ZRegister zn) {
+
+  // XXX: BFCVTNT
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 floating-point pairwise operations") {
+  //TEST_SINGLE(faddp(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),   "faddp z30.b, p6/m, z30.b, z28.b");
+  TEST_SINGLE(faddp(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "faddp z30.h, p6/m, z30.h, z28.h");
+  TEST_SINGLE(faddp(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "faddp z30.s, p6/m, z30.s, z28.s");
+  TEST_SINGLE(faddp(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "faddp z30.d, p6/m, z30.d, z28.d");
+  //TEST_SINGLE(faddp(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28), "faddp z30.q, p6/m, z30.q, z28.q");
+
+  //TEST_SINGLE(fmaxnmp(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),   "fmaxnmp z30.b, p6/m, z30.b, z28.b");
+  TEST_SINGLE(fmaxnmp(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fmaxnmp z30.h, p6/m, z30.h, z28.h");
+  TEST_SINGLE(fmaxnmp(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fmaxnmp z30.s, p6/m, z30.s, z28.s");
+  TEST_SINGLE(fmaxnmp(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fmaxnmp z30.d, p6/m, z30.d, z28.d");
+  //TEST_SINGLE(fmaxnmp(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28), "fmaxnmp z30.q, p6/m, z30.q, z28.q");
+
+  //TEST_SINGLE(fminnmp(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),   "fminnmp z30.b, p6/m, z30.b, z28.b");
+  TEST_SINGLE(fminnmp(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fminnmp z30.h, p6/m, z30.h, z28.h");
+  TEST_SINGLE(fminnmp(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fminnmp z30.s, p6/m, z30.s, z28.s");
+  TEST_SINGLE(fminnmp(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fminnmp z30.d, p6/m, z30.d, z28.d");
+  //TEST_SINGLE(fminnmp(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28), "fminnmp z30.q, p6/m, z30.q, z28.q");
+
+  //TEST_SINGLE(fmax(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),   "fmax z30.b, p6/m, z30.b, z28.b");
+  TEST_SINGLE(fmax(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fmax z30.h, p6/m, z30.h, z28.h");
+  TEST_SINGLE(fmax(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fmax z30.s, p6/m, z30.s, z28.s");
+  TEST_SINGLE(fmax(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fmax z30.d, p6/m, z30.d, z28.d");
+  //TEST_SINGLE(fmax(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28), "fmax z30.q, p6/m, z30.q, z28.q");
+
+  //TEST_SINGLE(fmin(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),   "fmin z30.b, p6/m, z30.b, z28.b");
+  TEST_SINGLE(fmin(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fmin z30.h, p6/m, z30.h, z28.h");
+  TEST_SINGLE(fmin(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fmin z30.s, p6/m, z30.s, z28.s");
+  TEST_SINGLE(fmin(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fmin z30.d, p6/m, z30.d, z28.d");
+  //TEST_SINGLE(fmin(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28), "fmin z30.q, p6/m, z30.q, z28.q");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE floating-point multiply-add (indexed)") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE floating-point complex multiply-add (indexed)") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE floating-point multiply (indexed)") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE floating point matrix multiply accumulate") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE floating-point compare vectors") {
+  TEST_SINGLE(fcmeq(SubRegSize::i16Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, ZReg::z29), "fcmeq p6.h, p5/z, z30.h, z29.h");
+  TEST_SINGLE(fcmeq(SubRegSize::i32Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, ZReg::z29), "fcmeq p6.s, p5/z, z30.s, z29.s");
+  TEST_SINGLE(fcmeq(SubRegSize::i64Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, ZReg::z29), "fcmeq p6.d, p5/z, z30.d, z29.d");
+
+  TEST_SINGLE(fcmgt(SubRegSize::i16Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, ZReg::z29), "fcmgt p6.h, p5/z, z30.h, z29.h");
+  TEST_SINGLE(fcmgt(SubRegSize::i32Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, ZReg::z29), "fcmgt p6.s, p5/z, z30.s, z29.s");
+  TEST_SINGLE(fcmgt(SubRegSize::i64Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, ZReg::z29), "fcmgt p6.d, p5/z, z30.d, z29.d");
+
+  TEST_SINGLE(fcmge(SubRegSize::i16Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, ZReg::z29), "fcmge p6.h, p5/z, z30.h, z29.h");
+  TEST_SINGLE(fcmge(SubRegSize::i32Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, ZReg::z29), "fcmge p6.s, p5/z, z30.s, z29.s");
+  TEST_SINGLE(fcmge(SubRegSize::i64Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, ZReg::z29), "fcmge p6.d, p5/z, z30.d, z29.d");
+
+  TEST_SINGLE(fcmne(SubRegSize::i16Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, ZReg::z29), "fcmne p6.h, p5/z, z30.h, z29.h");
+  TEST_SINGLE(fcmne(SubRegSize::i32Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, ZReg::z29), "fcmne p6.s, p5/z, z30.s, z29.s");
+  TEST_SINGLE(fcmne(SubRegSize::i64Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, ZReg::z29), "fcmne p6.d, p5/z, z30.d, z29.d");
+
+  TEST_SINGLE(fcmuo(SubRegSize::i16Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, ZReg::z29), "fcmuo p6.h, p5/z, z30.h, z29.h");
+  TEST_SINGLE(fcmuo(SubRegSize::i32Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, ZReg::z29), "fcmuo p6.s, p5/z, z30.s, z29.s");
+  TEST_SINGLE(fcmuo(SubRegSize::i64Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, ZReg::z29), "fcmuo p6.d, p5/z, z30.d, z29.d");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE floating-point arithmetic (unpredicated)") {
+  //TEST_SINGLE(fadd(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28),   "fadd z30.b, z29.b, z28.b");
+  TEST_SINGLE(fadd(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "fadd z30.h, z29.h, z28.h");
+  TEST_SINGLE(fadd(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "fadd z30.s, z29.s, z28.s");
+  TEST_SINGLE(fadd(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "fadd z30.d, z29.d, z28.d");
+  //TEST_SINGLE(fadd(SubRegSize::i128Bit, ZReg::z30, ZReg::z29, ZReg::z28), "fadd z30.q, z29.q, z28.q");
+
+  //TEST_SINGLE(fsub(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28),   "fsub z30.b, z29.b, z28.b");
+  TEST_SINGLE(fsub(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "fsub z30.h, z29.h, z28.h");
+  TEST_SINGLE(fsub(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "fsub z30.s, z29.s, z28.s");
+  TEST_SINGLE(fsub(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "fsub z30.d, z29.d, z28.d");
+  //TEST_SINGLE(fsub(SubRegSize::i128Bit, ZReg::z30, ZReg::z29, ZReg::z28), "fsub z30.q, z29.q, z28.q");
+
+  //TEST_SINGLE(fmul(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28),   "fmul z30.b, z29.b, z28.b");
+  TEST_SINGLE(fmul(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "fmul z30.h, z29.h, z28.h");
+  TEST_SINGLE(fmul(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "fmul z30.s, z29.s, z28.s");
+  TEST_SINGLE(fmul(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "fmul z30.d, z29.d, z28.d");
+  //TEST_SINGLE(fmul(SubRegSize::i128Bit, ZReg::z30, ZReg::z29, ZReg::z28), "fmul z30.q, z29.q, z28.q");
+
+  //TEST_SINGLE(ftsmul(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28),   "ftsmul z30.b, z29.b, z28.b");
+  TEST_SINGLE(ftsmul(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "ftsmul z30.h, z29.h, z28.h");
+  TEST_SINGLE(ftsmul(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "ftsmul z30.s, z29.s, z28.s");
+  TEST_SINGLE(ftsmul(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "ftsmul z30.d, z29.d, z28.d");
+  //TEST_SINGLE(ftsmul(SubRegSize::i128Bit, ZReg::z30, ZReg::z29, ZReg::z28), "ftsmul z30.q, z29.q, z28.q");
+
+  //TEST_SINGLE(frecps(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28),   "frecps z30.b, z29.b, z28.b");
+  TEST_SINGLE(frecps(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "frecps z30.h, z29.h, z28.h");
+  TEST_SINGLE(frecps(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "frecps z30.s, z29.s, z28.s");
+  TEST_SINGLE(frecps(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "frecps z30.d, z29.d, z28.d");
+  //TEST_SINGLE(frecps(SubRegSize::i128Bit, ZReg::z30, ZReg::z29, ZReg::z28), "frecps z30.q, z29.q, z28.q");
+
+  //TEST_SINGLE(frsqrts(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28),   "frsqrts z30.b, z29.b, z28.b");
+  TEST_SINGLE(frsqrts(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "frsqrts z30.h, z29.h, z28.h");
+  TEST_SINGLE(frsqrts(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "frsqrts z30.s, z29.s, z28.s");
+  TEST_SINGLE(frsqrts(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28),  "frsqrts z30.d, z29.d, z28.d");
+  //TEST_SINGLE(frsqrts(SubRegSize::i128Bit, ZReg::z30, ZReg::z29, ZReg::z28), "frsqrts z30.q, z29.q, z28.q");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE floating-point recursive reduction") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE integer multiply-accumulate writing addend (predicated)") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE integer multiply-add writing multiplicand (predicated)") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE integer add/subtract vectors (predicated)") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE integer min/max/difference (predicated)") {
+  TEST_SINGLE(smax(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "smax z30.b, p6/m, z30.b, z29.b");
+  TEST_SINGLE(smax(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "smax z30.h, p6/m, z30.h, z29.h");
+  TEST_SINGLE(smax(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "smax z30.s, p6/m, z30.s, z29.s");
+  TEST_SINGLE(smax(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "smax z30.d, p6/m, z30.d, z29.d");
+
+  TEST_SINGLE(umax(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "umax z30.b, p6/m, z30.b, z29.b");
+  TEST_SINGLE(umax(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "umax z30.h, p6/m, z30.h, z29.h");
+  TEST_SINGLE(umax(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "umax z30.s, p6/m, z30.s, z29.s");
+  TEST_SINGLE(umax(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "umax z30.d, p6/m, z30.d, z29.d");
+
+  TEST_SINGLE(smin(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "smin z30.b, p6/m, z30.b, z29.b");
+  TEST_SINGLE(smin(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "smin z30.h, p6/m, z30.h, z29.h");
+  TEST_SINGLE(smin(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "smin z30.s, p6/m, z30.s, z29.s");
+  TEST_SINGLE(smin(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "smin z30.d, p6/m, z30.d, z29.d");
+
+  TEST_SINGLE(umin(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "umin z30.b, p6/m, z30.b, z29.b");
+  TEST_SINGLE(umin(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "umin z30.h, p6/m, z30.h, z29.h");
+  TEST_SINGLE(umin(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "umin z30.s, p6/m, z30.s, z29.s");
+  TEST_SINGLE(umin(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "umin z30.d, p6/m, z30.d, z29.d");
+
+  TEST_SINGLE(sabd(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "sabd z30.b, p6/m, z30.b, z29.b");
+  TEST_SINGLE(sabd(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "sabd z30.h, p6/m, z30.h, z29.h");
+  TEST_SINGLE(sabd(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "sabd z30.s, p6/m, z30.s, z29.s");
+  TEST_SINGLE(sabd(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "sabd z30.d, p6/m, z30.d, z29.d");
+
+  TEST_SINGLE(uabd(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "uabd z30.b, p6/m, z30.b, z29.b");
+  TEST_SINGLE(uabd(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "uabd z30.h, p6/m, z30.h, z29.h");
+  TEST_SINGLE(uabd(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "uabd z30.s, p6/m, z30.s, z29.s");
+  TEST_SINGLE(uabd(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "uabd z30.d, p6/m, z30.d, z29.d");
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE integer multiply vectors (predicated)") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE integer divide vectors (predicated)") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE bitwise logical operations (predicated)") {
+  TEST_SINGLE(orr(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29),   "orr z30.b, p6/m, z30.b, z29.b");
+  TEST_SINGLE(orr(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29),  "orr z30.h, p6/m, z30.h, z29.h");
+  TEST_SINGLE(orr(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29),  "orr z30.s, p6/m, z30.s, z29.s");
+  TEST_SINGLE(orr(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29),  "orr z30.d, p6/m, z30.d, z29.d");
+  //TEST_SINGLE(orr(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "orr z30.q, p6/m, z30.q, z29.q");
+
+  TEST_SINGLE(eor(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29),   "eor z30.b, p6/m, z30.b, z29.b");
+  TEST_SINGLE(eor(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29),  "eor z30.h, p6/m, z30.h, z29.h");
+  TEST_SINGLE(eor(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29),  "eor z30.s, p6/m, z30.s, z29.s");
+  TEST_SINGLE(eor(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29),  "eor z30.d, p6/m, z30.d, z29.d");
+  //TEST_SINGLE(eor(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "eor z30.q, p6/m, z30.q, z29.q");
+
+  TEST_SINGLE(and_(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29),   "and z30.b, p6/m, z30.b, z29.b");
+  TEST_SINGLE(and_(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29),  "and z30.h, p6/m, z30.h, z29.h");
+  TEST_SINGLE(and_(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29),  "and z30.s, p6/m, z30.s, z29.s");
+  TEST_SINGLE(and_(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29),  "and z30.d, p6/m, z30.d, z29.d");
+  //TEST_SINGLE(and_(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "and z30.q, p6/m, z30.q, z29.q");
+
+  TEST_SINGLE(bic(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29),   "bic z30.b, p6/m, z30.b, z29.b");
+  TEST_SINGLE(bic(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29),  "bic z30.h, p6/m, z30.h, z29.h");
+  TEST_SINGLE(bic(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29),  "bic z30.s, p6/m, z30.s, z29.s");
+  TEST_SINGLE(bic(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29),  "bic z30.d, p6/m, z30.d, z29.d");
+  //TEST_SINGLE(bic(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "bic z30.q, p6/m, z30.q, z29.q");
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE integer add reduction (predicated)") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE integer min/max reduction (predicated)") {
+  TEST_SINGLE(smaxv(SubRegSize::i8Bit, ZReg::z30, PReg::p6, ZReg::z29),   "smaxv b30, p6, z29.b");
+  TEST_SINGLE(smaxv(SubRegSize::i16Bit, ZReg::z30, PReg::p6, ZReg::z29),  "smaxv h30, p6, z29.h");
+  TEST_SINGLE(smaxv(SubRegSize::i32Bit, ZReg::z30, PReg::p6, ZReg::z29),  "smaxv s30, p6, z29.s");
+  //TEST_SINGLE(smaxv(SubRegSize::i64Bit, ZReg::z30, PReg::p6, ZReg::z29),  "smaxv d30, p6, z29.d");
+  //TEST_SINGLE(smaxv(SubRegSize::i128Bit, ZReg::z30, PReg::p6, ZReg::z29), "smaxv q30, p6, z29.q");
+
+  TEST_SINGLE(umaxv(SubRegSize::i8Bit, ZReg::z30, PReg::p6, ZReg::z29),   "umaxv b30, p6, z29.b");
+  TEST_SINGLE(umaxv(SubRegSize::i16Bit, ZReg::z30, PReg::p6, ZReg::z29),  "umaxv h30, p6, z29.h");
+  TEST_SINGLE(umaxv(SubRegSize::i32Bit, ZReg::z30, PReg::p6, ZReg::z29),  "umaxv s30, p6, z29.s");
+  //TEST_SINGLE(umaxv(SubRegSize::i64Bit, ZReg::z30, PReg::p6, ZReg::z29),  "umaxv d30, p6, z29.d");
+  //TEST_SINGLE(umaxv(SubRegSize::i128Bit, ZReg::z30, PReg::p6, ZReg::z29), "umaxv q30, p6, z29.q");
+
+  TEST_SINGLE(sminv(SubRegSize::i8Bit, ZReg::z30, PReg::p6, ZReg::z29),   "sminv b30, p6, z29.b");
+  TEST_SINGLE(sminv(SubRegSize::i16Bit, ZReg::z30, PReg::p6, ZReg::z29),  "sminv h30, p6, z29.h");
+  TEST_SINGLE(sminv(SubRegSize::i32Bit, ZReg::z30, PReg::p6, ZReg::z29),  "sminv s30, p6, z29.s");
+  //TEST_SINGLE(sminv(SubRegSize::i64Bit, ZReg::z30, PReg::p6, ZReg::z29),  "sminv d30, p6, z29.d");
+  //TEST_SINGLE(sminv(SubRegSize::i128Bit, ZReg::z30, PReg::p6, ZReg::z29), "sminv q30, p6, z29.q");
+
+  TEST_SINGLE(uminv(SubRegSize::i8Bit, ZReg::z30, PReg::p6, ZReg::z29),   "uminv b30, p6, z29.b");
+  TEST_SINGLE(uminv(SubRegSize::i16Bit, ZReg::z30, PReg::p6, ZReg::z29),  "uminv h30, p6, z29.h");
+  TEST_SINGLE(uminv(SubRegSize::i32Bit, ZReg::z30, PReg::p6, ZReg::z29),  "uminv s30, p6, z29.s");
+  //TEST_SINGLE(uminv(SubRegSize::i64Bit, ZReg::z30, PReg::p6, ZReg::z29),  "uminv d30, p6, z29.d");
+  //TEST_SINGLE(uminv(SubRegSize::i128Bit, ZReg::z30, PReg::p6, ZReg::z29), "uminv q30, p6, z29.q");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE constructive prefix (predicated)") {
+  TEST_SINGLE(movprfx(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),   "movprfx z30.b, p6/m, z29.b");
+  TEST_SINGLE(movprfx(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "movprfx z30.h, p6/m, z29.h");
+  TEST_SINGLE(movprfx(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "movprfx z30.s, p6/m, z29.s");
+  TEST_SINGLE(movprfx(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "movprfx z30.d, p6/m, z29.d");
+  //TEST_SINGLE(movprfx(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "movprfx z30.q, p6/m, z29.q");
+  TEST_SINGLE(movprfx(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Zeroing(), ZReg::z29),   "movprfx z30.b, p6/z, z29.b");
+  TEST_SINGLE(movprfx(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Zeroing(), ZReg::z29),  "movprfx z30.h, p6/z, z29.h");
+  TEST_SINGLE(movprfx(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Zeroing(), ZReg::z29),  "movprfx z30.s, p6/z, z29.s");
+  TEST_SINGLE(movprfx(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Zeroing(), ZReg::z29),  "movprfx z30.d, p6/z, z29.d");
+  //TEST_SINGLE(movprfx(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Zeroing(), ZReg::z29), "movprfx z30.q, p6/z, z29.q");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE bitwise logical reduction (predicated)") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE bitwise shift by immediate (predicated)") {
+  TEST_SINGLE(asr(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 1), "asr z30.b, p6/m, z30.b, #1");
+  TEST_SINGLE(asr(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 8), "asr z30.b, p6/m, z30.b, #8");
+  TEST_SINGLE(asr(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 1), "asr z30.h, p6/m, z30.h, #1");
+  TEST_SINGLE(asr(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 16), "asr z30.h, p6/m, z30.h, #16");
+  TEST_SINGLE(asr(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 1), "asr z30.s, p6/m, z30.s, #1");
+  TEST_SINGLE(asr(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 32), "asr z30.s, p6/m, z30.s, #32");
+  TEST_SINGLE(asr(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 1), "asr z30.d, p6/m, z30.d, #1");
+  TEST_SINGLE(asr(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 64), "asr z30.d, p6/m, z30.d, #64");
+
+  TEST_SINGLE(lsr(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 1), "lsr z30.b, p6/m, z30.b, #1");
+  TEST_SINGLE(lsr(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 8), "lsr z30.b, p6/m, z30.b, #8");
+  TEST_SINGLE(lsr(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 1), "lsr z30.h, p6/m, z30.h, #1");
+  TEST_SINGLE(lsr(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 16), "lsr z30.h, p6/m, z30.h, #16");
+  TEST_SINGLE(lsr(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 1), "lsr z30.s, p6/m, z30.s, #1");
+  TEST_SINGLE(lsr(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 32), "lsr z30.s, p6/m, z30.s, #32");
+  TEST_SINGLE(lsr(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 1), "lsr z30.d, p6/m, z30.d, #1");
+  TEST_SINGLE(lsr(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 64), "lsr z30.d, p6/m, z30.d, #64");
+
+  TEST_SINGLE(lsl(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 0), "lsl z30.b, p6/m, z30.b, #0");
+  TEST_SINGLE(lsl(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 7), "lsl z30.b, p6/m, z30.b, #7");
+  TEST_SINGLE(lsl(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 0), "lsl z30.h, p6/m, z30.h, #0");
+  TEST_SINGLE(lsl(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 15), "lsl z30.h, p6/m, z30.h, #15");
+  TEST_SINGLE(lsl(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 0), "lsl z30.s, p6/m, z30.s, #0");
+  TEST_SINGLE(lsl(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 31), "lsl z30.s, p6/m, z30.s, #31");
+  TEST_SINGLE(lsl(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 0), "lsl z30.d, p6/m, z30.d, #0");
+  TEST_SINGLE(lsl(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 63), "lsl z30.d, p6/m, z30.d, #63");
+
+  TEST_SINGLE(asrd(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 1), "asrd z30.b, p6/m, z30.b, #1");
+  TEST_SINGLE(asrd(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 8), "asrd z30.b, p6/m, z30.b, #8");
+  TEST_SINGLE(asrd(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 1), "asrd z30.h, p6/m, z30.h, #1");
+  TEST_SINGLE(asrd(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 16), "asrd z30.h, p6/m, z30.h, #16");
+  TEST_SINGLE(asrd(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 1), "asrd z30.s, p6/m, z30.s, #1");
+  TEST_SINGLE(asrd(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 32), "asrd z30.s, p6/m, z30.s, #32");
+  TEST_SINGLE(asrd(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 1), "asrd z30.d, p6/m, z30.d, #1");
+  TEST_SINGLE(asrd(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 64), "asrd z30.d, p6/m, z30.d, #64");
+
+  TEST_SINGLE(sqshl(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 0), "sqshl z30.b, p6/m, z30.b, #0");
+  TEST_SINGLE(sqshl(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 7), "sqshl z30.b, p6/m, z30.b, #7");
+  TEST_SINGLE(sqshl(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 0), "sqshl z30.h, p6/m, z30.h, #0");
+  TEST_SINGLE(sqshl(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 15), "sqshl z30.h, p6/m, z30.h, #15");
+  TEST_SINGLE(sqshl(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 0), "sqshl z30.s, p6/m, z30.s, #0");
+  TEST_SINGLE(sqshl(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 31), "sqshl z30.s, p6/m, z30.s, #31");
+  TEST_SINGLE(sqshl(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 0), "sqshl z30.d, p6/m, z30.d, #0");
+  TEST_SINGLE(sqshl(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 63), "sqshl z30.d, p6/m, z30.d, #63");
+
+  TEST_SINGLE(uqshl(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 0), "uqshl z30.b, p6/m, z30.b, #0");
+  TEST_SINGLE(uqshl(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 7), "uqshl z30.b, p6/m, z30.b, #7");
+  TEST_SINGLE(uqshl(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 0), "uqshl z30.h, p6/m, z30.h, #0");
+  TEST_SINGLE(uqshl(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 15), "uqshl z30.h, p6/m, z30.h, #15");
+  TEST_SINGLE(uqshl(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 0), "uqshl z30.s, p6/m, z30.s, #0");
+  TEST_SINGLE(uqshl(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 31), "uqshl z30.s, p6/m, z30.s, #31");
+  TEST_SINGLE(uqshl(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 0), "uqshl z30.d, p6/m, z30.d, #0");
+  TEST_SINGLE(uqshl(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 63), "uqshl z30.d, p6/m, z30.d, #63");
+
+  TEST_SINGLE(srshr(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 1), "srshr z30.b, p6/m, z30.b, #1");
+  TEST_SINGLE(srshr(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 8), "srshr z30.b, p6/m, z30.b, #8");
+  TEST_SINGLE(srshr(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 1), "srshr z30.h, p6/m, z30.h, #1");
+  TEST_SINGLE(srshr(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 16), "srshr z30.h, p6/m, z30.h, #16");
+  TEST_SINGLE(srshr(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 1), "srshr z30.s, p6/m, z30.s, #1");
+  TEST_SINGLE(srshr(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 32), "srshr z30.s, p6/m, z30.s, #32");
+  TEST_SINGLE(srshr(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 1), "srshr z30.d, p6/m, z30.d, #1");
+  TEST_SINGLE(srshr(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 64), "srshr z30.d, p6/m, z30.d, #64");
+
+  TEST_SINGLE(urshr(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 1), "urshr z30.b, p6/m, z30.b, #1");
+  TEST_SINGLE(urshr(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 8), "urshr z30.b, p6/m, z30.b, #8");
+  TEST_SINGLE(urshr(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 1), "urshr z30.h, p6/m, z30.h, #1");
+  TEST_SINGLE(urshr(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 16), "urshr z30.h, p6/m, z30.h, #16");
+  TEST_SINGLE(urshr(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 1), "urshr z30.s, p6/m, z30.s, #1");
+  TEST_SINGLE(urshr(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 32), "urshr z30.s, p6/m, z30.s, #32");
+  TEST_SINGLE(urshr(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 1), "urshr z30.d, p6/m, z30.d, #1");
+  TEST_SINGLE(urshr(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 64), "urshr z30.d, p6/m, z30.d, #64");
+
+  TEST_SINGLE(sqshlu(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 0), "sqshlu z30.b, p6/m, z30.b, #0");
+  TEST_SINGLE(sqshlu(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 7), "sqshlu z30.b, p6/m, z30.b, #7");
+  TEST_SINGLE(sqshlu(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 0), "sqshlu z30.h, p6/m, z30.h, #0");
+  TEST_SINGLE(sqshlu(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 15), "sqshlu z30.h, p6/m, z30.h, #15");
+  TEST_SINGLE(sqshlu(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 0), "sqshlu z30.s, p6/m, z30.s, #0");
+  TEST_SINGLE(sqshlu(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 31), "sqshlu z30.s, p6/m, z30.s, #31");
+  TEST_SINGLE(sqshlu(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 0), "sqshlu z30.d, p6/m, z30.d, #0");
+  TEST_SINGLE(sqshlu(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, 63), "sqshlu z30.d, p6/m, z30.d, #63");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE bitwise shift by vector (predicated)") {
+  TEST_SINGLE(asr(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29),  "asr z30.b, p6/m, z30.b, z29.b");
+  TEST_SINGLE(asr(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "asr z30.h, p6/m, z30.h, z29.h");
+  TEST_SINGLE(asr(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "asr z30.s, p6/m, z30.s, z29.s");
+  TEST_SINGLE(asr(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "asr z30.d, p6/m, z30.d, z29.d");
+
+  TEST_SINGLE(lsr(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29),  "lsr z30.b, p6/m, z30.b, z29.b");
+  TEST_SINGLE(lsr(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "lsr z30.h, p6/m, z30.h, z29.h");
+  TEST_SINGLE(lsr(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "lsr z30.s, p6/m, z30.s, z29.s");
+  TEST_SINGLE(lsr(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "lsr z30.d, p6/m, z30.d, z29.d");
+
+  TEST_SINGLE(lsl(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29),  "lsl z30.b, p6/m, z30.b, z29.b");
+  TEST_SINGLE(lsl(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "lsl z30.h, p6/m, z30.h, z29.h");
+  TEST_SINGLE(lsl(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "lsl z30.s, p6/m, z30.s, z29.s");
+  TEST_SINGLE(lsl(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "lsl z30.d, p6/m, z30.d, z29.d");
+
+  TEST_SINGLE(asrr(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29),  "asrr z30.b, p6/m, z30.b, z29.b");
+  TEST_SINGLE(asrr(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "asrr z30.h, p6/m, z30.h, z29.h");
+  TEST_SINGLE(asrr(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "asrr z30.s, p6/m, z30.s, z29.s");
+  TEST_SINGLE(asrr(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "asrr z30.d, p6/m, z30.d, z29.d");
+
+  TEST_SINGLE(lsrr(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29),  "lsrr z30.b, p6/m, z30.b, z29.b");
+  TEST_SINGLE(lsrr(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "lsrr z30.h, p6/m, z30.h, z29.h");
+  TEST_SINGLE(lsrr(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "lsrr z30.s, p6/m, z30.s, z29.s");
+  TEST_SINGLE(lsrr(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "lsrr z30.d, p6/m, z30.d, z29.d");
+
+  TEST_SINGLE(lslr(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29),  "lslr z30.b, p6/m, z30.b, z29.b");
+  TEST_SINGLE(lslr(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "lslr z30.h, p6/m, z30.h, z29.h");
+  TEST_SINGLE(lslr(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "lslr z30.s, p6/m, z30.s, z29.s");
+  TEST_SINGLE(lslr(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z29), "lslr z30.d, p6/m, z30.d, z29.d");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE bitwise shift by wide elements (predicated)") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE integer unary operations (predicated)") {
+  //TEST_SINGLE(sxtb(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),   "sxtb z30.b, p6/m, z29.b");
+  TEST_SINGLE(sxtb(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "sxtb z30.h, p6/m, z29.h");
+  TEST_SINGLE(sxtb(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "sxtb z30.s, p6/m, z29.s");
+  TEST_SINGLE(sxtb(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "sxtb z30.d, p6/m, z29.d");
+  //TEST_SINGLE(sxtb(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "sxtb z30.q, p6/m, z29.q");
+
+  //TEST_SINGLE(uxtb(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),   "uxtb z30.b, p6/m, z29.b");
+  TEST_SINGLE(uxtb(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "uxtb z30.h, p6/m, z29.h");
+  TEST_SINGLE(uxtb(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "uxtb z30.s, p6/m, z29.s");
+  TEST_SINGLE(uxtb(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "uxtb z30.d, p6/m, z29.d");
+  //TEST_SINGLE(uxtb(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "uxtb z30.q, p6/m, z29.q");
+
+  //TEST_SINGLE(sxth(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),   "sxth z30.b, p6/m, z29.b");
+  //TEST_SINGLE(sxth(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "sxth z30.h, p6/m, z29.h");
+  TEST_SINGLE(sxth(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "sxth z30.s, p6/m, z29.s");
+  TEST_SINGLE(sxth(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "sxth z30.d, p6/m, z29.d");
+  //TEST_SINGLE(sxth(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "sxth z30.q, p6/m, z29.q");
+
+  //TEST_SINGLE(uxth(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),   "uxth z30.b, p6/m, z29.b");
+  //TEST_SINGLE(uxth(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "uxth z30.h, p6/m, z29.h");
+  TEST_SINGLE(uxth(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "uxth z30.s, p6/m, z29.s");
+  TEST_SINGLE(uxth(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "uxth z30.d, p6/m, z29.d");
+  //TEST_SINGLE(uxth(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "uxth z30.q, p6/m, z29.q");
+
+  //TEST_SINGLE(sxtw(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),   "sxtw z30.b, p6/m, z29.b");
+  //TEST_SINGLE(sxtw(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "sxtw z30.h, p6/m, z29.h");
+  //TEST_SINGLE(sxtw(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "sxtw z30.s, p6/m, z29.s");
+  TEST_SINGLE(sxtw(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "sxtw z30.d, p6/m, z29.d");
+  //TEST_SINGLE(sxtw(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "sxtw z30.q, p6/m, z29.q");
+
+  //TEST_SINGLE(uxtw(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),   "uxtw z30.b, p6/m, z29.b");
+  //TEST_SINGLE(uxtw(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "uxtw z30.h, p6/m, z29.h");
+  //TEST_SINGLE(uxtw(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "uxtw z30.s, p6/m, z29.s");
+  TEST_SINGLE(uxtw(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "uxtw z30.d, p6/m, z29.d");
+  //TEST_SINGLE(uxtw(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "uxtw z30.q, p6/m, z29.q");
+
+  TEST_SINGLE(abs(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),   "abs z30.b, p6/m, z29.b");
+  TEST_SINGLE(abs(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "abs z30.h, p6/m, z29.h");
+  TEST_SINGLE(abs(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "abs z30.s, p6/m, z29.s");
+  TEST_SINGLE(abs(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "abs z30.d, p6/m, z29.d");
+  //TEST_SINGLE(abs(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "abs z30.q, p6/m, z29.q");
+
+  TEST_SINGLE(neg(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),   "neg z30.b, p6/m, z29.b");
+  TEST_SINGLE(neg(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "neg z30.h, p6/m, z29.h");
+  TEST_SINGLE(neg(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "neg z30.s, p6/m, z29.s");
+  TEST_SINGLE(neg(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "neg z30.d, p6/m, z29.d");
+  //TEST_SINGLE(neg(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "neg z30.q, p6/m, z29.q");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE bitwise unary operations (predicated)") {
+  TEST_SINGLE(cls(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),   "cls z30.b, p6/m, z29.b");
+  TEST_SINGLE(cls(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "cls z30.h, p6/m, z29.h");
+  TEST_SINGLE(cls(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "cls z30.s, p6/m, z29.s");
+  TEST_SINGLE(cls(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "cls z30.d, p6/m, z29.d");
+  //TEST_SINGLE(cls(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "cls z30.q, p6/m, z29.q");
+
+  TEST_SINGLE(clz(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),   "clz z30.b, p6/m, z29.b");
+  TEST_SINGLE(clz(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "clz z30.h, p6/m, z29.h");
+  TEST_SINGLE(clz(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "clz z30.s, p6/m, z29.s");
+  TEST_SINGLE(clz(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "clz z30.d, p6/m, z29.d");
+  //TEST_SINGLE(clz(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "clz z30.q, p6/m, z29.q");
+
+  TEST_SINGLE(cnt(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),   "cnt z30.b, p6/m, z29.b");
+  TEST_SINGLE(cnt(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "cnt z30.h, p6/m, z29.h");
+  TEST_SINGLE(cnt(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "cnt z30.s, p6/m, z29.s");
+  TEST_SINGLE(cnt(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "cnt z30.d, p6/m, z29.d");
+  //TEST_SINGLE(cnt(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "cnt z30.q, p6/m, z29.q");
+
+  TEST_SINGLE(cnot(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),   "cnot z30.b, p6/m, z29.b");
+  TEST_SINGLE(cnot(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "cnot z30.h, p6/m, z29.h");
+  TEST_SINGLE(cnot(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "cnot z30.s, p6/m, z29.s");
+  TEST_SINGLE(cnot(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "cnot z30.d, p6/m, z29.d");
+  //TEST_SINGLE(cnot(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "cnot z30.q, p6/m, z29.q");
+
+  //TEST_SINGLE(fabs(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),   "fabs z30.b, p6/m, z29.b");
+  TEST_SINGLE(fabs(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "fabs z30.h, p6/m, z29.h");
+  TEST_SINGLE(fabs(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "fabs z30.s, p6/m, z29.s");
+  TEST_SINGLE(fabs(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "fabs z30.d, p6/m, z29.d");
+  //TEST_SINGLE(fabs(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "fabs z30.q, p6/m, z29.q");
+
+  //TEST_SINGLE(fneg(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),   "fneg z30.b, p6/m, z29.b");
+  TEST_SINGLE(fneg(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "fneg z30.h, p6/m, z29.h");
+  TEST_SINGLE(fneg(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "fneg z30.s, p6/m, z29.s");
+  TEST_SINGLE(fneg(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "fneg z30.d, p6/m, z29.d");
+  //TEST_SINGLE(fneg(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "fneg z30.q, p6/m, z29.q");
+
+  TEST_SINGLE(not_(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),   "not z30.b, p6/m, z29.b");
+  TEST_SINGLE(not_(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "not z30.h, p6/m, z29.h");
+  TEST_SINGLE(not_(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "not z30.s, p6/m, z29.s");
+  TEST_SINGLE(not_(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "not z30.d, p6/m, z29.d");
+  //TEST_SINGLE(not_(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "not z30.q, p6/m, z29.q");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE bitwise logical operations (unpredicated)") {
+  TEST_SINGLE(and_(ZReg::z30, ZReg::z29, ZReg::z28), "and z30.d, z29.d, z28.d");
+  TEST_SINGLE(orr(ZReg::z30, ZReg::z29, ZReg::z28), "orr z30.d, z29.d, z28.d");
+  TEST_SINGLE(mov(ZReg::z30, ZReg::z29), "mov z30.d, z29.d");
+  TEST_SINGLE(eor(ZReg::z30, ZReg::z29, ZReg::z28), "eor z30.d, z29.d, z28.d");
+  TEST_SINGLE(bic(ZReg::z30, ZReg::z29, ZReg::z28), "bic z30.d, z29.d, z28.d");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 bitwise ternary operations") {
+  TEST_SINGLE(eor3(ZReg::z30, ZReg::z30, ZReg::z28, ZReg::z29), "eor3 z30.d, z30.d, z28.d, z29.d");
+  TEST_SINGLE(bsl(ZReg::z30, ZReg::z30, ZReg::z28, ZReg::z29), "bsl z30.d, z30.d, z28.d, z29.d");
+  TEST_SINGLE(bcax(ZReg::z30, ZReg::z30, ZReg::z28, ZReg::z29), "bcax z30.d, z30.d, z28.d, z29.d");
+  TEST_SINGLE(bsl1n(ZReg::z30, ZReg::z30, ZReg::z28, ZReg::z29), "bsl1n z30.d, z30.d, z28.d, z29.d");
+  TEST_SINGLE(bsl2n(ZReg::z30, ZReg::z30, ZReg::z28, ZReg::z29), "bsl2n z30.d, z30.d, z28.d, z29.d");
+  TEST_SINGLE(nbsl(ZReg::z30, ZReg::z30, ZReg::z28, ZReg::z29), "nbsl z30.d, z30.d, z28.d, z29.d");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE Index Generation") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE stack frame adjustment") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: Streaming SVE stack frame adjustment") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE stack frame size") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: Streaming SVE stack frame size") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 integer multiply vectors (unpredicated)") {
+  TEST_SINGLE(mul(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28), "mul z30.b, z29.b, z28.b");
+  TEST_SINGLE(mul(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28), "mul z30.h, z29.h, z28.h");
+  TEST_SINGLE(mul(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "mul z30.s, z29.s, z28.s");
+  TEST_SINGLE(mul(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28), "mul z30.d, z29.d, z28.d");
+
+  TEST_SINGLE(smulh(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28), "smulh z30.b, z29.b, z28.b");
+  TEST_SINGLE(smulh(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28), "smulh z30.h, z29.h, z28.h");
+  TEST_SINGLE(smulh(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "smulh z30.s, z29.s, z28.s");
+  TEST_SINGLE(smulh(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28), "smulh z30.d, z29.d, z28.d");
+
+  TEST_SINGLE(umulh(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28), "umulh z30.b, z29.b, z28.b");
+  TEST_SINGLE(umulh(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28), "umulh z30.h, z29.h, z28.h");
+  TEST_SINGLE(umulh(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "umulh z30.s, z29.s, z28.s");
+  TEST_SINGLE(umulh(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28), "umulh z30.d, z29.d, z28.d");
+
+  TEST_SINGLE(pmul(ZReg::z30, ZReg::z29, ZReg::z28), "pmul z30.b, z29.b, z28.b");
+ }
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 signed saturating doubling multiply high (unpredicated)") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE bitwise shift by wide elements (unpredicated)") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE bitwise shift by immediate (unpredicated)") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE floating-point trig select coefficient") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE floating-point exponential accelerator") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE constructive prefix (unpredicated)") {
+  TEST_SINGLE(movprfx(ZReg::z30, ZReg::z29), "movprfx z30, z29");
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE saturating inc/dec vector by element count") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE element count") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE inc/dec vector by element count") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE inc/dec register by element count") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE saturating inc/dec register by element count") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE Bitwise Immediate") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE bitwise logical with immediate (unpredicated)") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE Integer Wide Immediate - Predicated") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE copy integer immediate (predicated)") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE Permute Vector - Unpredicated") {
+  TEST_SINGLE(dup(SubRegSize::i8Bit, ZReg::z30, Reg::r29),   "mov z30.b, w29");
+  TEST_SINGLE(dup(SubRegSize::i16Bit, ZReg::z30, Reg::r29),  "mov z30.h, w29");
+  TEST_SINGLE(dup(SubRegSize::i32Bit, ZReg::z30, Reg::r29),  "mov z30.s, w29");
+  TEST_SINGLE(dup(SubRegSize::i64Bit, ZReg::z30, Reg::r29),  "mov z30.d, x29");
+  //TEST_SINGLE(dup(SubRegSize::i128Bit, ZReg::z30, Reg::r29), "mov z30.q, x29");
+  TEST_SINGLE(mov(SubRegSize::i8Bit, ZReg::z30, Reg::r29),   "mov z30.b, w29");
+  TEST_SINGLE(mov(SubRegSize::i16Bit, ZReg::z30, Reg::r29),  "mov z30.h, w29");
+  TEST_SINGLE(mov(SubRegSize::i32Bit, ZReg::z30, Reg::r29),  "mov z30.s, w29");
+  TEST_SINGLE(mov(SubRegSize::i64Bit, ZReg::z30, Reg::r29),  "mov z30.d, x29");
+  //TEST_SINGLE(mov(SubRegSize::i128Bit, ZReg::z30, Reg::r29), "mov z30.q, x29");
+  // XXX: INSR
+  // XXX: INSR SIMD
+  // XXX: REV
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE unpack vector elements") {
+  //TEST_SINGLE(sunpklo(SubRegSize::i8Bit, ZReg::z30, ZReg::z29),   "sunpklo z30.b, z29.b");
+  TEST_SINGLE(sunpklo(SubRegSize::i16Bit, ZReg::z30, ZReg::z29),  "sunpklo z30.h, z29.b");
+  TEST_SINGLE(sunpklo(SubRegSize::i32Bit, ZReg::z30, ZReg::z29),  "sunpklo z30.s, z29.h");
+  TEST_SINGLE(sunpklo(SubRegSize::i64Bit, ZReg::z30, ZReg::z29),  "sunpklo z30.d, z29.s");
+  //TEST_SINGLE(sunpklo(SubRegSize::i128Bit, ZReg::z30, ZReg::z29), "sunpklo z30.q, z29.q");
+
+  //TEST_SINGLE(sunpkhi(SubRegSize::i8Bit, ZReg::z30, ZReg::z29),   "sunpkhi z30.b, z29.b");
+  TEST_SINGLE(sunpkhi(SubRegSize::i16Bit, ZReg::z30, ZReg::z29),  "sunpkhi z30.h, z29.b");
+  TEST_SINGLE(sunpkhi(SubRegSize::i32Bit, ZReg::z30, ZReg::z29),  "sunpkhi z30.s, z29.h");
+  TEST_SINGLE(sunpkhi(SubRegSize::i64Bit, ZReg::z30, ZReg::z29),  "sunpkhi z30.d, z29.s");
+  //TEST_SINGLE(sunpkhi(SubRegSize::i128Bit, ZReg::z30, ZReg::z29), "sunpkhi z30.q, z29.q");
+
+  //TEST_SINGLE(uunpklo(SubRegSize::i8Bit, ZReg::z30, ZReg::z29),   "uunpklo z30.b, z29.b");
+  TEST_SINGLE(uunpklo(SubRegSize::i16Bit, ZReg::z30, ZReg::z29),  "uunpklo z30.h, z29.b");
+  TEST_SINGLE(uunpklo(SubRegSize::i32Bit, ZReg::z30, ZReg::z29),  "uunpklo z30.s, z29.h");
+  TEST_SINGLE(uunpklo(SubRegSize::i64Bit, ZReg::z30, ZReg::z29),  "uunpklo z30.d, z29.s");
+  //TEST_SINGLE(uunpklo(SubRegSize::i128Bit, ZReg::z30, ZReg::z29), "uunpklo z30.q, z29.q");
+
+  //TEST_SINGLE(uunpkhi(SubRegSize::i8Bit, ZReg::z30, ZReg::z29),   "uunpkhi z30.b, z29.b");
+  TEST_SINGLE(uunpkhi(SubRegSize::i16Bit, ZReg::z30, ZReg::z29),  "uunpkhi z30.h, z29.b");
+  TEST_SINGLE(uunpkhi(SubRegSize::i32Bit, ZReg::z30, ZReg::z29),  "uunpkhi z30.s, z29.h");
+  TEST_SINGLE(uunpkhi(SubRegSize::i64Bit, ZReg::z30, ZReg::z29),  "uunpkhi z30.d, z29.s");
+  //TEST_SINGLE(uunpkhi(SubRegSize::i128Bit, ZReg::z30, ZReg::z29), "uunpkhi z30.q, z29.q");
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE Permute Predicate - Base") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE Permute Predicate") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE permute predicate elements") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE Permute Vector - Predicated - Base") {
+  // XXX: CPY (SIMD&FP scalar)
+  //TEST_SINGLE(compact(SubRegSize::i8Bit, ZReg::z30, PReg::p6, ZReg::z29),   "compact z30.b, p6, z29.b");
+  //TEST_SINGLE(compact(SubRegSize::i16Bit, ZReg::z30, PReg::p6, ZReg::z29),  "compact z30.h, p6, z29.h");
+  TEST_SINGLE(compact(SubRegSize::i32Bit, ZReg::z30, PReg::p6, ZReg::z29),  "compact z30.s, p6, z29.s");
+  TEST_SINGLE(compact(SubRegSize::i64Bit, ZReg::z30, PReg::p6, ZReg::z29),  "compact z30.d, p6, z29.d");
+  //TEST_SINGLE(compact(SubRegSize::i128Bit, ZReg::z30, PReg::p6, ZReg::z29), "compact z30.q, p6, z29.q");
+  // XXX: CPY (scalar)
+
+  TEST_SINGLE(splice<OpType::Constructive>(SubRegSize::i8Bit, ZReg::z30, PReg::p6, ZReg::z28, ZReg::z29),   "splice z30.b, p6, {z28.b, z29.b}");
+  TEST_SINGLE(splice<OpType::Constructive>(SubRegSize::i16Bit, ZReg::z30, PReg::p6, ZReg::z28, ZReg::z29),  "splice z30.h, p6, {z28.h, z29.h}");
+  TEST_SINGLE(splice<OpType::Constructive>(SubRegSize::i32Bit, ZReg::z30, PReg::p6, ZReg::z28, ZReg::z29),  "splice z30.s, p6, {z28.s, z29.s}");
+  TEST_SINGLE(splice<OpType::Constructive>(SubRegSize::i64Bit, ZReg::z30, PReg::p6, ZReg::z28, ZReg::z29),  "splice z30.d, p6, {z28.d, z29.d}");
+  //TEST_SINGLE(splice<OpType::Constructive>(SubRegSize::i128Bit, ZReg::z30, PReg::p6, ZReg::z28, ZReg::z29), "splice z30.q, p6, {z28.q, z29.q}");
+
+  TEST_SINGLE(splice<OpType::Destructive>(SubRegSize::i8Bit, ZReg::z30, PReg::p6, ZReg::z30, ZReg::z28),   "splice z30.b, p6, z30.b, z28.b");
+  TEST_SINGLE(splice<OpType::Destructive>(SubRegSize::i16Bit, ZReg::z30, PReg::p6, ZReg::z30, ZReg::z28),  "splice z30.h, p6, z30.h, z28.h");
+  TEST_SINGLE(splice<OpType::Destructive>(SubRegSize::i32Bit, ZReg::z30, PReg::p6, ZReg::z30, ZReg::z28),  "splice z30.s, p6, z30.s, z28.s");
+  TEST_SINGLE(splice<OpType::Destructive>(SubRegSize::i64Bit, ZReg::z30, PReg::p6, ZReg::z30, ZReg::z28),  "splice z30.d, p6, z30.d, z28.d");
+  //TEST_SINGLE(splice<OpType::Destructive>(SubRegSize::i128Bit, ZReg::z30, PReg::p6, ZReg::z30, ZReg::z28), "splice z30.q, p6, z30.q, z28.q");
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE Permute Vector - Predicated") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE extract element to SIMD&FP scalar register") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE reverse within elements") {
+  //TEST_SINGLE(revb(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "revb z30.b, p6/m, z29.b");
+  TEST_SINGLE(revb(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "revb z30.h, p6/m, z29.h");
+  TEST_SINGLE(revb(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "revb z30.s, p6/m, z29.s");
+  TEST_SINGLE(revb(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "revb z30.d, p6/m, z29.d");
+
+  //TEST_SINGLE(revh(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "revh z30.b, p6/m, z29.b");
+  //TEST_SINGLE(revh(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "revh z30.h, p6/m, z29.h");
+  TEST_SINGLE(revh(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "revh z30.s, p6/m, z29.s");
+  TEST_SINGLE(revh(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "revh z30.d, p6/m, z29.d");
+
+  //TEST_SINGLE(revw(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "revw z30.b, p6/m, z29.b");
+  //TEST_SINGLE(revw(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "revw z30.h, p6/m, z29.h");
+  //TEST_SINGLE(revw(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "revw z30.s, p6/m, z29.s");
+  TEST_SINGLE(revw(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "revw z30.d, p6/m, z29.d");
+
+  TEST_SINGLE(rbit(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "rbit z30.b, p6/m, z29.b");
+  TEST_SINGLE(rbit(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "rbit z30.h, p6/m, z29.h");
+  TEST_SINGLE(rbit(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "rbit z30.s, p6/m, z29.s");
+  TEST_SINGLE(rbit(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "rbit z30.d, p6/m, z29.d");
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE conditionally broadcast element to vector") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE conditionally extract element to SIMD&FP scalar") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE reverse doublewords") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE conditionally extract element to general register") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE Permute Vector - Extract") {
+  TEST_SINGLE(ext<FEXCore::ARMEmitter::OpType::Destructive>(ZReg::z30, ZReg::z30, ZReg::z29, 0), "ext z30.b, z30.b, z29.b, #0");
+  TEST_SINGLE(ext<FEXCore::ARMEmitter::OpType::Destructive>(ZReg::z30, ZReg::z30, ZReg::z29, 255), "ext z30.b, z30.b, z29.b, #255");
+
+  TEST_SINGLE(ext<FEXCore::ARMEmitter::OpType::Constructive>(ZReg::z30, ZReg::z28, ZReg::z29, 0), "ext z30.b, {z28.b, z29.b}, #0");
+  TEST_SINGLE(ext<FEXCore::ARMEmitter::OpType::Constructive>(ZReg::z30, ZReg::z28, ZReg::z29, 255), "ext z30.b, {z28.b, z29.b}, #255");
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE permute vector segments") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE integer compare vectors") {
+  TEST_SINGLE(cmpeq(SubRegSize::i8Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, ZReg::z29),  "cmpeq p6.b, p5/z, z30.b, z29.b");
+  TEST_SINGLE(cmpeq(SubRegSize::i16Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, ZReg::z29), "cmpeq p6.h, p5/z, z30.h, z29.h");
+  TEST_SINGLE(cmpeq(SubRegSize::i32Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, ZReg::z29), "cmpeq p6.s, p5/z, z30.s, z29.s");
+  TEST_SINGLE(cmpeq(SubRegSize::i64Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, ZReg::z29), "cmpeq p6.d, p5/z, z30.d, z29.d");
+
+  TEST_SINGLE(cmpge(SubRegSize::i8Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, ZReg::z29),  "cmpge p6.b, p5/z, z30.b, z29.b");
+  TEST_SINGLE(cmpge(SubRegSize::i16Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, ZReg::z29), "cmpge p6.h, p5/z, z30.h, z29.h");
+  TEST_SINGLE(cmpge(SubRegSize::i32Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, ZReg::z29), "cmpge p6.s, p5/z, z30.s, z29.s");
+  TEST_SINGLE(cmpge(SubRegSize::i64Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, ZReg::z29), "cmpge p6.d, p5/z, z30.d, z29.d");
+
+  TEST_SINGLE(cmpgt(SubRegSize::i8Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, ZReg::z29),  "cmpgt p6.b, p5/z, z30.b, z29.b");
+  TEST_SINGLE(cmpgt(SubRegSize::i16Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, ZReg::z29), "cmpgt p6.h, p5/z, z30.h, z29.h");
+  TEST_SINGLE(cmpgt(SubRegSize::i32Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, ZReg::z29), "cmpgt p6.s, p5/z, z30.s, z29.s");
+  TEST_SINGLE(cmpgt(SubRegSize::i64Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, ZReg::z29), "cmpgt p6.d, p5/z, z30.d, z29.d");
+
+  TEST_SINGLE(cmphi(SubRegSize::i8Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, ZReg::z29),  "cmphi p6.b, p5/z, z30.b, z29.b");
+  TEST_SINGLE(cmphi(SubRegSize::i16Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, ZReg::z29), "cmphi p6.h, p5/z, z30.h, z29.h");
+  TEST_SINGLE(cmphi(SubRegSize::i32Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, ZReg::z29), "cmphi p6.s, p5/z, z30.s, z29.s");
+  TEST_SINGLE(cmphi(SubRegSize::i64Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, ZReg::z29), "cmphi p6.d, p5/z, z30.d, z29.d");
+
+  TEST_SINGLE(cmphs(SubRegSize::i8Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, ZReg::z29),  "cmphs p6.b, p5/z, z30.b, z29.b");
+  TEST_SINGLE(cmphs(SubRegSize::i16Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, ZReg::z29), "cmphs p6.h, p5/z, z30.h, z29.h");
+  TEST_SINGLE(cmphs(SubRegSize::i32Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, ZReg::z29), "cmphs p6.s, p5/z, z30.s, z29.s");
+  TEST_SINGLE(cmphs(SubRegSize::i64Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, ZReg::z29), "cmphs p6.d, p5/z, z30.d, z29.d");
+
+  TEST_SINGLE(cmpne(SubRegSize::i8Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, ZReg::z29),  "cmpne p6.b, p5/z, z30.b, z29.b");
+  TEST_SINGLE(cmpne(SubRegSize::i16Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, ZReg::z29), "cmpne p6.h, p5/z, z30.h, z29.h");
+  TEST_SINGLE(cmpne(SubRegSize::i32Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, ZReg::z29), "cmpne p6.s, p5/z, z30.s, z29.s");
+  TEST_SINGLE(cmpne(SubRegSize::i64Bit, PReg::p6, PReg::p5.Zeroing(), ZReg::z30, ZReg::z29), "cmpne p6.d, p5/z, z30.d, z29.d");
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE integer compare with wide elements") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE propagate break from previous partition") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE Predicate Misc") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE predicate test") {
+  TEST_SINGLE(ptest(PReg::p6, PReg::p5), "ptest p6, p5.b");
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE predicate first active") {
+  TEST_SINGLE(pfirst(PReg::p6, PReg::p5, PReg::p6), "pfirst p6.b, p5, p6.b");
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE predicate zero") {
+  TEST_SINGLE(pfalse(PReg::p6), "pfalse p6.b");
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE predicate read from FFR (predicated)") {
+  TEST_SINGLE(rdffr(PReg::p6, PReg::p5), "rdffr p6.b, p5/z");
+  TEST_SINGLE(rdffrs(PReg::p6, PReg::p5), "rdffrs p6.b, p5/z");
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE predicate read from FFR (unpredicated)") {
+  TEST_SINGLE(rdffr(PReg::p6), "rdffr p6.b");
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE predicate initialize") {
+  TEST_SINGLE(ptrue<SubRegSize::i8Bit>(PReg::p6, PredicatePattern::SVE_POW2), "ptrue p6.b, pow2");
+  TEST_SINGLE(ptrue<SubRegSize::i16Bit>(PReg::p6, PredicatePattern::SVE_POW2), "ptrue p6.h, pow2");
+  TEST_SINGLE(ptrue<SubRegSize::i32Bit>(PReg::p6, PredicatePattern::SVE_POW2), "ptrue p6.s, pow2");
+  TEST_SINGLE(ptrue<SubRegSize::i64Bit>(PReg::p6, PredicatePattern::SVE_POW2), "ptrue p6.d, pow2");
+
+  TEST_SINGLE(ptrues<SubRegSize::i8Bit>(PReg::p6, PredicatePattern::SVE_POW2), "ptrues p6.b, pow2");
+  TEST_SINGLE(ptrues<SubRegSize::i16Bit>(PReg::p6, PredicatePattern::SVE_POW2), "ptrues p6.h, pow2");
+  TEST_SINGLE(ptrues<SubRegSize::i32Bit>(PReg::p6, PredicatePattern::SVE_POW2), "ptrues p6.s, pow2");
+  TEST_SINGLE(ptrues<SubRegSize::i64Bit>(PReg::p6, PredicatePattern::SVE_POW2), "ptrues p6.d, pow2");
+
+  TEST_SINGLE(ptrue<SubRegSize::i8Bit>(PReg::p6, PredicatePattern::SVE_VL1), "ptrue p6.b, vl1");
+  TEST_SINGLE(ptrue<SubRegSize::i16Bit>(PReg::p6, PredicatePattern::SVE_VL1), "ptrue p6.h, vl1");
+  TEST_SINGLE(ptrue<SubRegSize::i32Bit>(PReg::p6, PredicatePattern::SVE_VL1), "ptrue p6.s, vl1");
+  TEST_SINGLE(ptrue<SubRegSize::i64Bit>(PReg::p6, PredicatePattern::SVE_VL1), "ptrue p6.d, vl1");
+
+  TEST_SINGLE(ptrues<SubRegSize::i8Bit>(PReg::p6, PredicatePattern::SVE_VL1), "ptrues p6.b, vl1");
+  TEST_SINGLE(ptrues<SubRegSize::i16Bit>(PReg::p6, PredicatePattern::SVE_VL1), "ptrues p6.h, vl1");
+  TEST_SINGLE(ptrues<SubRegSize::i32Bit>(PReg::p6, PredicatePattern::SVE_VL1), "ptrues p6.s, vl1");
+  TEST_SINGLE(ptrues<SubRegSize::i64Bit>(PReg::p6, PredicatePattern::SVE_VL1), "ptrues p6.d, vl1");
+
+  TEST_SINGLE(ptrue<SubRegSize::i8Bit>(PReg::p6, PredicatePattern::SVE_VL2), "ptrue p6.b, vl2");
+  TEST_SINGLE(ptrue<SubRegSize::i16Bit>(PReg::p6, PredicatePattern::SVE_VL2), "ptrue p6.h, vl2");
+  TEST_SINGLE(ptrue<SubRegSize::i32Bit>(PReg::p6, PredicatePattern::SVE_VL2), "ptrue p6.s, vl2");
+  TEST_SINGLE(ptrue<SubRegSize::i64Bit>(PReg::p6, PredicatePattern::SVE_VL2), "ptrue p6.d, vl2");
+
+  TEST_SINGLE(ptrues<SubRegSize::i8Bit>(PReg::p6, PredicatePattern::SVE_VL2), "ptrues p6.b, vl2");
+  TEST_SINGLE(ptrues<SubRegSize::i16Bit>(PReg::p6, PredicatePattern::SVE_VL2), "ptrues p6.h, vl2");
+  TEST_SINGLE(ptrues<SubRegSize::i32Bit>(PReg::p6, PredicatePattern::SVE_VL2), "ptrues p6.s, vl2");
+  TEST_SINGLE(ptrues<SubRegSize::i64Bit>(PReg::p6, PredicatePattern::SVE_VL2), "ptrues p6.d, vl2");
+
+  TEST_SINGLE(ptrue<SubRegSize::i8Bit>(PReg::p6, PredicatePattern::SVE_VL3), "ptrue p6.b, vl3");
+  TEST_SINGLE(ptrue<SubRegSize::i16Bit>(PReg::p6, PredicatePattern::SVE_VL3), "ptrue p6.h, vl3");
+  TEST_SINGLE(ptrue<SubRegSize::i32Bit>(PReg::p6, PredicatePattern::SVE_VL3), "ptrue p6.s, vl3");
+  TEST_SINGLE(ptrue<SubRegSize::i64Bit>(PReg::p6, PredicatePattern::SVE_VL3), "ptrue p6.d, vl3");
+
+  TEST_SINGLE(ptrues<SubRegSize::i8Bit>(PReg::p6, PredicatePattern::SVE_VL3), "ptrues p6.b, vl3");
+  TEST_SINGLE(ptrues<SubRegSize::i16Bit>(PReg::p6, PredicatePattern::SVE_VL3), "ptrues p6.h, vl3");
+  TEST_SINGLE(ptrues<SubRegSize::i32Bit>(PReg::p6, PredicatePattern::SVE_VL3), "ptrues p6.s, vl3");
+  TEST_SINGLE(ptrues<SubRegSize::i64Bit>(PReg::p6, PredicatePattern::SVE_VL3), "ptrues p6.d, vl3");
+
+  TEST_SINGLE(ptrue<SubRegSize::i8Bit>(PReg::p6, PredicatePattern::SVE_VL4), "ptrue p6.b, vl4");
+  TEST_SINGLE(ptrue<SubRegSize::i16Bit>(PReg::p6, PredicatePattern::SVE_VL4), "ptrue p6.h, vl4");
+  TEST_SINGLE(ptrue<SubRegSize::i32Bit>(PReg::p6, PredicatePattern::SVE_VL4), "ptrue p6.s, vl4");
+  TEST_SINGLE(ptrue<SubRegSize::i64Bit>(PReg::p6, PredicatePattern::SVE_VL4), "ptrue p6.d, vl4");
+
+  TEST_SINGLE(ptrues<SubRegSize::i8Bit>(PReg::p6, PredicatePattern::SVE_VL4), "ptrues p6.b, vl4");
+  TEST_SINGLE(ptrues<SubRegSize::i16Bit>(PReg::p6, PredicatePattern::SVE_VL4), "ptrues p6.h, vl4");
+  TEST_SINGLE(ptrues<SubRegSize::i32Bit>(PReg::p6, PredicatePattern::SVE_VL4), "ptrues p6.s, vl4");
+  TEST_SINGLE(ptrues<SubRegSize::i64Bit>(PReg::p6, PredicatePattern::SVE_VL4), "ptrues p6.d, vl4");
+
+  TEST_SINGLE(ptrue<SubRegSize::i8Bit>(PReg::p6, PredicatePattern::SVE_VL5), "ptrue p6.b, vl5");
+  TEST_SINGLE(ptrue<SubRegSize::i16Bit>(PReg::p6, PredicatePattern::SVE_VL5), "ptrue p6.h, vl5");
+  TEST_SINGLE(ptrue<SubRegSize::i32Bit>(PReg::p6, PredicatePattern::SVE_VL5), "ptrue p6.s, vl5");
+  TEST_SINGLE(ptrue<SubRegSize::i64Bit>(PReg::p6, PredicatePattern::SVE_VL5), "ptrue p6.d, vl5");
+
+  TEST_SINGLE(ptrues<SubRegSize::i8Bit>(PReg::p6, PredicatePattern::SVE_VL5), "ptrues p6.b, vl5");
+  TEST_SINGLE(ptrues<SubRegSize::i16Bit>(PReg::p6, PredicatePattern::SVE_VL5), "ptrues p6.h, vl5");
+  TEST_SINGLE(ptrues<SubRegSize::i32Bit>(PReg::p6, PredicatePattern::SVE_VL5), "ptrues p6.s, vl5");
+  TEST_SINGLE(ptrues<SubRegSize::i64Bit>(PReg::p6, PredicatePattern::SVE_VL5), "ptrues p6.d, vl5");
+
+  TEST_SINGLE(ptrue<SubRegSize::i8Bit>(PReg::p6, PredicatePattern::SVE_VL6), "ptrue p6.b, vl6");
+  TEST_SINGLE(ptrue<SubRegSize::i16Bit>(PReg::p6, PredicatePattern::SVE_VL6), "ptrue p6.h, vl6");
+  TEST_SINGLE(ptrue<SubRegSize::i32Bit>(PReg::p6, PredicatePattern::SVE_VL6), "ptrue p6.s, vl6");
+  TEST_SINGLE(ptrue<SubRegSize::i64Bit>(PReg::p6, PredicatePattern::SVE_VL6), "ptrue p6.d, vl6");
+
+  TEST_SINGLE(ptrues<SubRegSize::i8Bit>(PReg::p6, PredicatePattern::SVE_VL6), "ptrues p6.b, vl6");
+  TEST_SINGLE(ptrues<SubRegSize::i16Bit>(PReg::p6, PredicatePattern::SVE_VL6), "ptrues p6.h, vl6");
+  TEST_SINGLE(ptrues<SubRegSize::i32Bit>(PReg::p6, PredicatePattern::SVE_VL6), "ptrues p6.s, vl6");
+  TEST_SINGLE(ptrues<SubRegSize::i64Bit>(PReg::p6, PredicatePattern::SVE_VL6), "ptrues p6.d, vl6");
+
+  TEST_SINGLE(ptrue<SubRegSize::i8Bit>(PReg::p6, PredicatePattern::SVE_VL7), "ptrue p6.b, vl7");
+  TEST_SINGLE(ptrue<SubRegSize::i16Bit>(PReg::p6, PredicatePattern::SVE_VL7), "ptrue p6.h, vl7");
+  TEST_SINGLE(ptrue<SubRegSize::i32Bit>(PReg::p6, PredicatePattern::SVE_VL7), "ptrue p6.s, vl7");
+  TEST_SINGLE(ptrue<SubRegSize::i64Bit>(PReg::p6, PredicatePattern::SVE_VL7), "ptrue p6.d, vl7");
+
+  TEST_SINGLE(ptrues<SubRegSize::i8Bit>(PReg::p6, PredicatePattern::SVE_VL7), "ptrues p6.b, vl7");
+  TEST_SINGLE(ptrues<SubRegSize::i16Bit>(PReg::p6, PredicatePattern::SVE_VL7), "ptrues p6.h, vl7");
+  TEST_SINGLE(ptrues<SubRegSize::i32Bit>(PReg::p6, PredicatePattern::SVE_VL7), "ptrues p6.s, vl7");
+  TEST_SINGLE(ptrues<SubRegSize::i64Bit>(PReg::p6, PredicatePattern::SVE_VL7), "ptrues p6.d, vl7");
+
+  TEST_SINGLE(ptrue<SubRegSize::i8Bit>(PReg::p6, PredicatePattern::SVE_VL8), "ptrue p6.b, vl8");
+  TEST_SINGLE(ptrue<SubRegSize::i16Bit>(PReg::p6, PredicatePattern::SVE_VL8), "ptrue p6.h, vl8");
+  TEST_SINGLE(ptrue<SubRegSize::i32Bit>(PReg::p6, PredicatePattern::SVE_VL8), "ptrue p6.s, vl8");
+  TEST_SINGLE(ptrue<SubRegSize::i64Bit>(PReg::p6, PredicatePattern::SVE_VL8), "ptrue p6.d, vl8");
+
+  TEST_SINGLE(ptrues<SubRegSize::i8Bit>(PReg::p6, PredicatePattern::SVE_VL8), "ptrues p6.b, vl8");
+  TEST_SINGLE(ptrues<SubRegSize::i16Bit>(PReg::p6, PredicatePattern::SVE_VL8), "ptrues p6.h, vl8");
+  TEST_SINGLE(ptrues<SubRegSize::i32Bit>(PReg::p6, PredicatePattern::SVE_VL8), "ptrues p6.s, vl8");
+  TEST_SINGLE(ptrues<SubRegSize::i64Bit>(PReg::p6, PredicatePattern::SVE_VL8), "ptrues p6.d, vl8");
+
+  TEST_SINGLE(ptrue<SubRegSize::i8Bit>(PReg::p6, PredicatePattern::SVE_VL16), "ptrue p6.b, vl16");
+  TEST_SINGLE(ptrue<SubRegSize::i16Bit>(PReg::p6, PredicatePattern::SVE_VL16), "ptrue p6.h, vl16");
+  TEST_SINGLE(ptrue<SubRegSize::i32Bit>(PReg::p6, PredicatePattern::SVE_VL16), "ptrue p6.s, vl16");
+  TEST_SINGLE(ptrue<SubRegSize::i64Bit>(PReg::p6, PredicatePattern::SVE_VL16), "ptrue p6.d, vl16");
+
+  TEST_SINGLE(ptrues<SubRegSize::i8Bit>(PReg::p6, PredicatePattern::SVE_VL16), "ptrues p6.b, vl16");
+  TEST_SINGLE(ptrues<SubRegSize::i16Bit>(PReg::p6, PredicatePattern::SVE_VL16), "ptrues p6.h, vl16");
+  TEST_SINGLE(ptrues<SubRegSize::i32Bit>(PReg::p6, PredicatePattern::SVE_VL16), "ptrues p6.s, vl16");
+  TEST_SINGLE(ptrues<SubRegSize::i64Bit>(PReg::p6, PredicatePattern::SVE_VL16), "ptrues p6.d, vl16");
+
+  TEST_SINGLE(ptrue<SubRegSize::i8Bit>(PReg::p6, PredicatePattern::SVE_VL32), "ptrue p6.b, vl32");
+  TEST_SINGLE(ptrue<SubRegSize::i16Bit>(PReg::p6, PredicatePattern::SVE_VL32), "ptrue p6.h, vl32");
+  TEST_SINGLE(ptrue<SubRegSize::i32Bit>(PReg::p6, PredicatePattern::SVE_VL32), "ptrue p6.s, vl32");
+  TEST_SINGLE(ptrue<SubRegSize::i64Bit>(PReg::p6, PredicatePattern::SVE_VL32), "ptrue p6.d, vl32");
+
+  TEST_SINGLE(ptrues<SubRegSize::i8Bit>(PReg::p6, PredicatePattern::SVE_VL32), "ptrues p6.b, vl32");
+  TEST_SINGLE(ptrues<SubRegSize::i16Bit>(PReg::p6, PredicatePattern::SVE_VL32), "ptrues p6.h, vl32");
+  TEST_SINGLE(ptrues<SubRegSize::i32Bit>(PReg::p6, PredicatePattern::SVE_VL32), "ptrues p6.s, vl32");
+  TEST_SINGLE(ptrues<SubRegSize::i64Bit>(PReg::p6, PredicatePattern::SVE_VL32), "ptrues p6.d, vl32");
+
+  TEST_SINGLE(ptrue<SubRegSize::i8Bit>(PReg::p6, PredicatePattern::SVE_VL64), "ptrue p6.b, vl64");
+  TEST_SINGLE(ptrue<SubRegSize::i16Bit>(PReg::p6, PredicatePattern::SVE_VL64), "ptrue p6.h, vl64");
+  TEST_SINGLE(ptrue<SubRegSize::i32Bit>(PReg::p6, PredicatePattern::SVE_VL64), "ptrue p6.s, vl64");
+  TEST_SINGLE(ptrue<SubRegSize::i64Bit>(PReg::p6, PredicatePattern::SVE_VL64), "ptrue p6.d, vl64");
+
+  TEST_SINGLE(ptrues<SubRegSize::i8Bit>(PReg::p6, PredicatePattern::SVE_VL64), "ptrues p6.b, vl64");
+  TEST_SINGLE(ptrues<SubRegSize::i16Bit>(PReg::p6, PredicatePattern::SVE_VL64), "ptrues p6.h, vl64");
+  TEST_SINGLE(ptrues<SubRegSize::i32Bit>(PReg::p6, PredicatePattern::SVE_VL64), "ptrues p6.s, vl64");
+  TEST_SINGLE(ptrues<SubRegSize::i64Bit>(PReg::p6, PredicatePattern::SVE_VL64), "ptrues p6.d, vl64");
+
+  TEST_SINGLE(ptrue<SubRegSize::i8Bit>(PReg::p6, PredicatePattern::SVE_VL128), "ptrue p6.b, vl128");
+  TEST_SINGLE(ptrue<SubRegSize::i16Bit>(PReg::p6, PredicatePattern::SVE_VL128), "ptrue p6.h, vl128");
+  TEST_SINGLE(ptrue<SubRegSize::i32Bit>(PReg::p6, PredicatePattern::SVE_VL128), "ptrue p6.s, vl128");
+  TEST_SINGLE(ptrue<SubRegSize::i64Bit>(PReg::p6, PredicatePattern::SVE_VL128), "ptrue p6.d, vl128");
+
+  TEST_SINGLE(ptrues<SubRegSize::i8Bit>(PReg::p6, PredicatePattern::SVE_VL128), "ptrues p6.b, vl128");
+  TEST_SINGLE(ptrues<SubRegSize::i16Bit>(PReg::p6, PredicatePattern::SVE_VL128), "ptrues p6.h, vl128");
+  TEST_SINGLE(ptrues<SubRegSize::i32Bit>(PReg::p6, PredicatePattern::SVE_VL128), "ptrues p6.s, vl128");
+  TEST_SINGLE(ptrues<SubRegSize::i64Bit>(PReg::p6, PredicatePattern::SVE_VL128), "ptrues p6.d, vl128");
+
+  TEST_SINGLE(ptrue<SubRegSize::i8Bit>(PReg::p6, PredicatePattern::SVE_VL256), "ptrue p6.b, vl256");
+  TEST_SINGLE(ptrue<SubRegSize::i16Bit>(PReg::p6, PredicatePattern::SVE_VL256), "ptrue p6.h, vl256");
+  TEST_SINGLE(ptrue<SubRegSize::i32Bit>(PReg::p6, PredicatePattern::SVE_VL256), "ptrue p6.s, vl256");
+  TEST_SINGLE(ptrue<SubRegSize::i64Bit>(PReg::p6, PredicatePattern::SVE_VL256), "ptrue p6.d, vl256");
+
+  TEST_SINGLE(ptrues<SubRegSize::i8Bit>(PReg::p6, PredicatePattern::SVE_VL256), "ptrues p6.b, vl256");
+  TEST_SINGLE(ptrues<SubRegSize::i16Bit>(PReg::p6, PredicatePattern::SVE_VL256), "ptrues p6.h, vl256");
+  TEST_SINGLE(ptrues<SubRegSize::i32Bit>(PReg::p6, PredicatePattern::SVE_VL256), "ptrues p6.s, vl256");
+  TEST_SINGLE(ptrues<SubRegSize::i64Bit>(PReg::p6, PredicatePattern::SVE_VL256), "ptrues p6.d, vl256");
+
+  TEST_SINGLE(ptrue<SubRegSize::i8Bit>(PReg::p6, PredicatePattern::SVE_MUL4), "ptrue p6.b, mul4");
+  TEST_SINGLE(ptrue<SubRegSize::i16Bit>(PReg::p6, PredicatePattern::SVE_MUL4), "ptrue p6.h, mul4");
+  TEST_SINGLE(ptrue<SubRegSize::i32Bit>(PReg::p6, PredicatePattern::SVE_MUL4), "ptrue p6.s, mul4");
+  TEST_SINGLE(ptrue<SubRegSize::i64Bit>(PReg::p6, PredicatePattern::SVE_MUL4), "ptrue p6.d, mul4");
+
+  TEST_SINGLE(ptrues<SubRegSize::i8Bit>(PReg::p6, PredicatePattern::SVE_MUL4), "ptrues p6.b, mul4");
+  TEST_SINGLE(ptrues<SubRegSize::i16Bit>(PReg::p6, PredicatePattern::SVE_MUL4), "ptrues p6.h, mul4");
+  TEST_SINGLE(ptrues<SubRegSize::i32Bit>(PReg::p6, PredicatePattern::SVE_MUL4), "ptrues p6.s, mul4");
+  TEST_SINGLE(ptrues<SubRegSize::i64Bit>(PReg::p6, PredicatePattern::SVE_MUL4), "ptrues p6.d, mul4");
+
+  TEST_SINGLE(ptrue<SubRegSize::i8Bit>(PReg::p6, PredicatePattern::SVE_MUL3), "ptrue p6.b, mul3");
+  TEST_SINGLE(ptrue<SubRegSize::i16Bit>(PReg::p6, PredicatePattern::SVE_MUL3), "ptrue p6.h, mul3");
+  TEST_SINGLE(ptrue<SubRegSize::i32Bit>(PReg::p6, PredicatePattern::SVE_MUL3), "ptrue p6.s, mul3");
+  TEST_SINGLE(ptrue<SubRegSize::i64Bit>(PReg::p6, PredicatePattern::SVE_MUL3), "ptrue p6.d, mul3");
+
+  TEST_SINGLE(ptrues<SubRegSize::i8Bit>(PReg::p6, PredicatePattern::SVE_MUL3), "ptrues p6.b, mul3");
+  TEST_SINGLE(ptrues<SubRegSize::i16Bit>(PReg::p6, PredicatePattern::SVE_MUL3), "ptrues p6.h, mul3");
+  TEST_SINGLE(ptrues<SubRegSize::i32Bit>(PReg::p6, PredicatePattern::SVE_MUL3), "ptrues p6.s, mul3");
+  TEST_SINGLE(ptrues<SubRegSize::i64Bit>(PReg::p6, PredicatePattern::SVE_MUL3), "ptrues p6.d, mul3");
+
+  TEST_SINGLE(ptrue<SubRegSize::i8Bit>(PReg::p6, PredicatePattern::SVE_ALL), "ptrue p6.b");
+  TEST_SINGLE(ptrue<SubRegSize::i16Bit>(PReg::p6, PredicatePattern::SVE_ALL), "ptrue p6.h");
+  TEST_SINGLE(ptrue<SubRegSize::i32Bit>(PReg::p6, PredicatePattern::SVE_ALL), "ptrue p6.s");
+  TEST_SINGLE(ptrue<SubRegSize::i64Bit>(PReg::p6, PredicatePattern::SVE_ALL), "ptrue p6.d");
+
+  TEST_SINGLE(ptrues<SubRegSize::i8Bit>(PReg::p6, PredicatePattern::SVE_ALL), "ptrues p6.b");
+  TEST_SINGLE(ptrues<SubRegSize::i16Bit>(PReg::p6, PredicatePattern::SVE_ALL), "ptrues p6.h");
+  TEST_SINGLE(ptrues<SubRegSize::i32Bit>(PReg::p6, PredicatePattern::SVE_ALL), "ptrues p6.s");
+  TEST_SINGLE(ptrues<SubRegSize::i64Bit>(PReg::p6, PredicatePattern::SVE_ALL), "ptrues p6.d");
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE integer compare scalar count and limit") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE conditionally terminate scalars") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE pointer conflict compare") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE integer add/subtract immediate (unpredicated)") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE integer min/max immediate (unpredicated)") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE integer multiply immediate (unpredicated)") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE broadcast integer immediate (unpredicated)") {
+  TEST_SINGLE(dup_imm(SubRegSize::i8Bit, ZReg::z30, -128, false), "mov z30.b, #-128");
+  TEST_SINGLE(dup_imm(SubRegSize::i16Bit, ZReg::z30, -128, false), "mov z30.h, #-128");
+  TEST_SINGLE(dup_imm(SubRegSize::i32Bit, ZReg::z30, -128, false), "mov z30.s, #-128");
+  TEST_SINGLE(dup_imm(SubRegSize::i64Bit, ZReg::z30, -128, false), "mov z30.d, #-128");
+
+  TEST_SINGLE(dup_imm(SubRegSize::i8Bit, ZReg::z30, 127, false), "mov z30.b, #127");
+  TEST_SINGLE(dup_imm(SubRegSize::i16Bit, ZReg::z30, 127, false), "mov z30.h, #127");
+  TEST_SINGLE(dup_imm(SubRegSize::i32Bit, ZReg::z30, 127, false), "mov z30.s, #127");
+  TEST_SINGLE(dup_imm(SubRegSize::i64Bit, ZReg::z30, 127, false), "mov z30.d, #127");
+
+  //TEST_SINGLE(dup_imm(SubRegSize::i8Bit, ZReg::z30, -128, true), "mov z30.b, #-128");
+  TEST_SINGLE(dup_imm(SubRegSize::i16Bit, ZReg::z30, -128, true), "mov z30.h, #-128, lsl #8");
+  TEST_SINGLE(dup_imm(SubRegSize::i32Bit, ZReg::z30, -128, true), "mov z30.s, #-128, lsl #8");
+  TEST_SINGLE(dup_imm(SubRegSize::i64Bit, ZReg::z30, -128, true), "mov z30.d, #-128, lsl #8");
+
+  //TEST_SINGLE(dup_imm(SubRegSize::i8Bit, ZReg::z30, 127, true), "mov z30.b, #127");
+  TEST_SINGLE(dup_imm(SubRegSize::i16Bit, ZReg::z30, 127, true), "mov z30.h, #127, lsl #8");
+  TEST_SINGLE(dup_imm(SubRegSize::i32Bit, ZReg::z30, 127, true), "mov z30.s, #127, lsl #8");
+  TEST_SINGLE(dup_imm(SubRegSize::i64Bit, ZReg::z30, 127, true), "mov z30.d, #127, lsl #8");
+
+  TEST_SINGLE(mov_imm(SubRegSize::i8Bit, ZReg::z30, -128, false), "mov z30.b, #-128");
+  TEST_SINGLE(mov_imm(SubRegSize::i16Bit, ZReg::z30, -128, false), "mov z30.h, #-128");
+  TEST_SINGLE(mov_imm(SubRegSize::i32Bit, ZReg::z30, -128, false), "mov z30.s, #-128");
+  TEST_SINGLE(mov_imm(SubRegSize::i64Bit, ZReg::z30, -128, false), "mov z30.d, #-128");
+
+  TEST_SINGLE(mov_imm(SubRegSize::i8Bit, ZReg::z30, 127, false), "mov z30.b, #127");
+  TEST_SINGLE(mov_imm(SubRegSize::i16Bit, ZReg::z30, 127, false), "mov z30.h, #127");
+  TEST_SINGLE(mov_imm(SubRegSize::i32Bit, ZReg::z30, 127, false), "mov z30.s, #127");
+  TEST_SINGLE(mov_imm(SubRegSize::i64Bit, ZReg::z30, 127, false), "mov z30.d, #127");
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE broadcast floating-point immediate (unpredicated)") {
+  TEST_SINGLE(fdup(SubRegSize::i16Bit, ZReg::z30, 1.0), "fmov z30.h, #0x70 (1.0000)");
+  TEST_SINGLE(fdup(SubRegSize::i32Bit, ZReg::z30, 1.0), "fmov z30.s, #0x70 (1.0000)");
+  TEST_SINGLE(fdup(SubRegSize::i64Bit, ZReg::z30, 1.0), "fmov z30.d, #0x70 (1.0000)");
+
+  TEST_SINGLE(fmov(SubRegSize::i16Bit, ZReg::z30, 1.0), "fmov z30.h, #0x70 (1.0000)");
+  TEST_SINGLE(fmov(SubRegSize::i32Bit, ZReg::z30, 1.0), "fmov z30.s, #0x70 (1.0000)");
+  TEST_SINGLE(fmov(SubRegSize::i64Bit, ZReg::z30, 1.0), "fmov z30.d, #0x70 (1.0000)");
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE predicate count") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE saturating inc/dec vector by predicate count") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE saturating inc/dec register by predicate count") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE inc/dec vector by predicate count") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE inc/dec register by predicate count") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE FFR write from predicate") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE FFR initialise") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE Integer Multiply-Add - Unpredicated") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE integer dot product (unpredicated)") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 saturating multiply-add interleaved long") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 complex integer multiply-add") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 integer multiply-add long") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 saturating multiply-add long") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 saturating multiply-add high") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE mixed sign dot product") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 integer pairwise add and accumulate long") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 integer unary operations (predicated)") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 saturating/rounding bitwise shift left (predicated)") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 integer halving add/subtract (predicated)") {
+  TEST_SINGLE(shadd(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),   "shadd z30.b, p6/m, z30.b, z28.b");
+  TEST_SINGLE(shadd(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "shadd z30.h, p6/m, z30.h, z28.h");
+  TEST_SINGLE(shadd(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "shadd z30.s, p6/m, z30.s, z28.s");
+  TEST_SINGLE(shadd(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "shadd z30.d, p6/m, z30.d, z28.d");
+  //TEST_SINGLE(shadd(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28), "shadd z30.q, p6/m, z30.q, z28.q");
+
+  TEST_SINGLE(uhadd(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),   "uhadd z30.b, p6/m, z30.b, z28.b");
+  TEST_SINGLE(uhadd(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "uhadd z30.h, p6/m, z30.h, z28.h");
+  TEST_SINGLE(uhadd(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "uhadd z30.s, p6/m, z30.s, z28.s");
+  TEST_SINGLE(uhadd(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "uhadd z30.d, p6/m, z30.d, z28.d");
+  //TEST_SINGLE(uhadd(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28), "uhadd z30.q, p6/m, z30.q, z28.q");
+  TEST_SINGLE(shsub(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),   "shsub z30.b, p6/m, z30.b, z28.b");
+  TEST_SINGLE(shsub(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "shsub z30.h, p6/m, z30.h, z28.h");
+  TEST_SINGLE(shsub(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "shsub z30.s, p6/m, z30.s, z28.s");
+  TEST_SINGLE(shsub(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "shsub z30.d, p6/m, z30.d, z28.d");
+  //TEST_SINGLE(shsub(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28), "shsub z30.q, p6/m, z30.q, z28.q");
+
+  TEST_SINGLE(uhsub(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),   "uhsub z30.b, p6/m, z30.b, z28.b");
+  TEST_SINGLE(uhsub(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "uhsub z30.h, p6/m, z30.h, z28.h");
+  TEST_SINGLE(uhsub(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "uhsub z30.s, p6/m, z30.s, z28.s");
+  TEST_SINGLE(uhsub(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "uhsub z30.d, p6/m, z30.d, z28.d");
+  //TEST_SINGLE(uhsub(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28), "uhsub z30.q, p6/m, z30.q, z28.q");
+
+  TEST_SINGLE(srhadd(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),   "srhadd z30.b, p6/m, z30.b, z28.b");
+  TEST_SINGLE(srhadd(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "srhadd z30.h, p6/m, z30.h, z28.h");
+  TEST_SINGLE(srhadd(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "srhadd z30.s, p6/m, z30.s, z28.s");
+  TEST_SINGLE(srhadd(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "srhadd z30.d, p6/m, z30.d, z28.d");
+  //TEST_SINGLE(srhadd(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28), "srhadd z30.q, p6/m, z30.q, z28.q");
+
+  TEST_SINGLE(urhadd(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),   "urhadd z30.b, p6/m, z30.b, z28.b");
+  TEST_SINGLE(urhadd(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "urhadd z30.h, p6/m, z30.h, z28.h");
+  TEST_SINGLE(urhadd(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "urhadd z30.s, p6/m, z30.s, z28.s");
+  TEST_SINGLE(urhadd(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "urhadd z30.d, p6/m, z30.d, z28.d");
+  //TEST_SINGLE(urhadd(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28), "urhadd z30.q, p6/m, z30.q, z28.q");
+
+  TEST_SINGLE(shsubr(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),   "shsubr z30.b, p6/m, z30.b, z28.b");
+  TEST_SINGLE(shsubr(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "shsubr z30.h, p6/m, z30.h, z28.h");
+  TEST_SINGLE(shsubr(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "shsubr z30.s, p6/m, z30.s, z28.s");
+  TEST_SINGLE(shsubr(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "shsubr z30.d, p6/m, z30.d, z28.d");
+  //TEST_SINGLE(shsubr(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28), "shsubr z30.q, p6/m, z30.q, z28.q");
+
+  TEST_SINGLE(uhsubr(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),   "uhsubr z30.b, p6/m, z30.b, z28.b");
+  TEST_SINGLE(uhsubr(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "uhsubr z30.h, p6/m, z30.h, z28.h");
+  TEST_SINGLE(uhsubr(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "uhsubr z30.s, p6/m, z30.s, z28.s");
+  TEST_SINGLE(uhsubr(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "uhsubr z30.d, p6/m, z30.d, z28.d");
+  //TEST_SINGLE(uhsubr(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28), "uhsubr z30.q, p6/m, z30.q, z28.q");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 integer pairwise arithmetic") {
+  TEST_SINGLE(addp(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),   "addp z30.b, p6/m, z30.b, z28.b");
+  TEST_SINGLE(addp(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "addp z30.h, p6/m, z30.h, z28.h");
+  TEST_SINGLE(addp(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "addp z30.s, p6/m, z30.s, z28.s");
+  TEST_SINGLE(addp(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "addp z30.d, p6/m, z30.d, z28.d");
+  //TEST_SINGLE(addp(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28), "addp z30.q, p6/m, z30.q, z28.q");
+
+  TEST_SINGLE(smaxp(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),   "smaxp z30.b, p6/m, z30.b, z28.b");
+  TEST_SINGLE(smaxp(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "smaxp z30.h, p6/m, z30.h, z28.h");
+  TEST_SINGLE(smaxp(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "smaxp z30.s, p6/m, z30.s, z28.s");
+  TEST_SINGLE(smaxp(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "smaxp z30.d, p6/m, z30.d, z28.d");
+  //TEST_SINGLE(smaxp(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28), "smaxp z30.q, p6/m, z30.q, z28.q");
+
+  TEST_SINGLE(umaxp(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),   "umaxp z30.b, p6/m, z30.b, z28.b");
+  TEST_SINGLE(umaxp(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "umaxp z30.h, p6/m, z30.h, z28.h");
+  TEST_SINGLE(umaxp(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "umaxp z30.s, p6/m, z30.s, z28.s");
+  TEST_SINGLE(umaxp(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "umaxp z30.d, p6/m, z30.d, z28.d");
+  //TEST_SINGLE(umaxp(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28), "umaxp z30.q, p6/m, z30.q, z28.q");
+
+
+  TEST_SINGLE(sminp(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),   "sminp z30.b, p6/m, z30.b, z28.b");
+  TEST_SINGLE(sminp(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "sminp z30.h, p6/m, z30.h, z28.h");
+  TEST_SINGLE(sminp(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "sminp z30.s, p6/m, z30.s, z28.s");
+  TEST_SINGLE(sminp(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "sminp z30.d, p6/m, z30.d, z28.d");
+  //TEST_SINGLE(sminp(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28), "sminp z30.q, p6/m, z30.q, z28.q");
+
+
+  TEST_SINGLE(uminp(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),   "uminp z30.b, p6/m, z30.b, z28.b");
+  TEST_SINGLE(uminp(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "uminp z30.h, p6/m, z30.h, z28.h");
+  TEST_SINGLE(uminp(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "uminp z30.s, p6/m, z30.s, z28.s");
+  TEST_SINGLE(uminp(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "uminp z30.d, p6/m, z30.d, z28.d");
+  //TEST_SINGLE(uminp(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28), "uminp z30.q, p6/m, z30.q, z28.q");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 saturating add/subtract") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 integer add/subtract long") {
+  //TEST_SINGLE(saddlb(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28), "saddlb z30.b, z29.b, z28.b");
+  TEST_SINGLE(saddlb(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28), "saddlb z30.h, z29.b, z28.b");
+  TEST_SINGLE(saddlb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "saddlb z30.s, z29.h, z28.h");
+  TEST_SINGLE(saddlb(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28), "saddlb z30.d, z29.s, z28.s");
+
+  //TEST_SINGLE(saddlt(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28), "saddlt z30.b, z29.b, z28.b");
+  TEST_SINGLE(saddlt(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28), "saddlt z30.h, z29.b, z28.b");
+  TEST_SINGLE(saddlt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "saddlt z30.s, z29.h, z28.h");
+  TEST_SINGLE(saddlt(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28), "saddlt z30.d, z29.s, z28.s");
+
+  //TEST_SINGLE(uaddlb(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28), "uaddlb z30.b, z29.b, z28.b");
+  TEST_SINGLE(uaddlb(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28), "uaddlb z30.h, z29.b, z28.b");
+  TEST_SINGLE(uaddlb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "uaddlb z30.s, z29.h, z28.h");
+  TEST_SINGLE(uaddlb(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28), "uaddlb z30.d, z29.s, z28.s");
+
+  //TEST_SINGLE(uaddlt(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28), "uaddlt z30.b, z29.b, z28.b");
+  TEST_SINGLE(uaddlt(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28), "uaddlt z30.h, z29.b, z28.b");
+  TEST_SINGLE(uaddlt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "uaddlt z30.s, z29.h, z28.h");
+  TEST_SINGLE(uaddlt(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28), "uaddlt z30.d, z29.s, z28.s");
+
+  //TEST_SINGLE(ssublb(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28), "ssublb z30.b, z29.b, z28.b");
+  TEST_SINGLE(ssublb(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28), "ssublb z30.h, z29.b, z28.b");
+  TEST_SINGLE(ssublb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "ssublb z30.s, z29.h, z28.h");
+  TEST_SINGLE(ssublb(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28), "ssublb z30.d, z29.s, z28.s");
+
+  //TEST_SINGLE(ssublt(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28), "ssublt z30.b, z29.b, z28.b");
+  TEST_SINGLE(ssublt(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28), "ssublt z30.h, z29.b, z28.b");
+  TEST_SINGLE(ssublt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "ssublt z30.s, z29.h, z28.h");
+  TEST_SINGLE(ssublt(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28), "ssublt z30.d, z29.s, z28.s");
+
+  //TEST_SINGLE(usublb(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28), "usublb z30.b, z29.b, z28.b");
+  TEST_SINGLE(usublb(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28), "usublb z30.h, z29.b, z28.b");
+  TEST_SINGLE(usublb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "usublb z30.s, z29.h, z28.h");
+  TEST_SINGLE(usublb(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28), "usublb z30.d, z29.s, z28.s");
+
+  //TEST_SINGLE(usublt(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28), "usublt z30.b, z29.b, z28.b");
+  TEST_SINGLE(usublt(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28), "usublt z30.h, z29.b, z28.b");
+  TEST_SINGLE(usublt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "usublt z30.s, z29.h, z28.h");
+  TEST_SINGLE(usublt(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28), "usublt z30.d, z29.s, z28.s");
+
+  //TEST_SINGLE(sabdlb(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28), "sabdlb z30.b, z29.b, z28.b");
+  TEST_SINGLE(sabdlb(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28), "sabdlb z30.h, z29.b, z28.b");
+  TEST_SINGLE(sabdlb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "sabdlb z30.s, z29.h, z28.h");
+  TEST_SINGLE(sabdlb(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28), "sabdlb z30.d, z29.s, z28.s");
+
+  //TEST_SINGLE(sabdlt(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28), "sabdlt z30.b, z29.b, z28.b");
+  TEST_SINGLE(sabdlt(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28), "sabdlt z30.h, z29.b, z28.b");
+  TEST_SINGLE(sabdlt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "sabdlt z30.s, z29.h, z28.h");
+  TEST_SINGLE(sabdlt(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28), "sabdlt z30.d, z29.s, z28.s");
+
+  //TEST_SINGLE(uabdlb(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28), "uabdlb z30.b, z29.b, z28.b");
+  TEST_SINGLE(uabdlb(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28), "uabdlb z30.h, z29.b, z28.b");
+  TEST_SINGLE(uabdlb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "uabdlb z30.s, z29.h, z28.h");
+  TEST_SINGLE(uabdlb(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28), "uabdlb z30.d, z29.s, z28.s");
+
+  //TEST_SINGLE(uabdlt(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28), "uabdlt z30.b, z29.b, z28.b");
+  TEST_SINGLE(uabdlt(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28), "uabdlt z30.h, z29.b, z28.b");
+  TEST_SINGLE(uabdlt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "uabdlt z30.s, z29.h, z28.h");
+  TEST_SINGLE(uabdlt(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28), "uabdlt z30.d, z29.s, z28.s");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 integer add/subtract wide") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 integer multiply long") {
+  //TEST_SINGLE(sqdmullb(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28), "sqdmullb z30.b, z29.b, z28.b");
+  TEST_SINGLE(sqdmullb(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28), "sqdmullb z30.h, z29.b, z28.b");
+  TEST_SINGLE(sqdmullb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "sqdmullb z30.s, z29.h, z28.h");
+  TEST_SINGLE(sqdmullb(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28), "sqdmullb z30.d, z29.s, z28.s");
+
+  //TEST_SINGLE(sqdmullt(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28), "sqdmullt z30.b, z29.b, z28.b");
+  TEST_SINGLE(sqdmullt(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28), "sqdmullt z30.h, z29.b, z28.b");
+  TEST_SINGLE(sqdmullt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "sqdmullt z30.s, z29.h, z28.h");
+  TEST_SINGLE(sqdmullt(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28), "sqdmullt z30.d, z29.s, z28.s");
+
+  //TEST_SINGLE(pmullb(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28), "pmullb z30.b, z29.b, z28.b");
+  TEST_SINGLE(pmullb(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28), "pmullb z30.h, z29.b, z28.b");
+  TEST_SINGLE(pmullb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "pmullb z30.s, z29.h, z28.h");
+  TEST_SINGLE(pmullb(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28), "pmullb z30.d, z29.s, z28.s");
+
+  //TEST_SINGLE(pmullt(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28), "pmullt z30.b, z29.b, z28.b");
+  TEST_SINGLE(pmullt(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28), "pmullt z30.h, z29.b, z28.b");
+  TEST_SINGLE(pmullt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "pmullt z30.s, z29.h, z28.h");
+  TEST_SINGLE(pmullt(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28), "pmullt z30.d, z29.s, z28.s");
+
+  //TEST_SINGLE(smullb(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28), "smullb z30.b, z29.b, z28.b");
+  TEST_SINGLE(smullb(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28), "smullb z30.h, z29.b, z28.b");
+  TEST_SINGLE(smullb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "smullb z30.s, z29.h, z28.h");
+  TEST_SINGLE(smullb(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28), "smullb z30.d, z29.s, z28.s");
+
+  //TEST_SINGLE(smullt(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28), "smullt z30.b, z29.b, z28.b");
+  TEST_SINGLE(smullt(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28), "smullt z30.h, z29.b, z28.b");
+  TEST_SINGLE(smullt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "smullt z30.s, z29.h, z28.h");
+  TEST_SINGLE(smullt(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28), "smullt z30.d, z29.s, z28.s");
+
+  //TEST_SINGLE(umullb(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28), "umullb z30.b, z29.b, z28.b");
+  TEST_SINGLE(umullb(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28), "umullb z30.h, z29.b, z28.b");
+  TEST_SINGLE(umullb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "umullb z30.s, z29.h, z28.h");
+  TEST_SINGLE(umullb(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28), "umullb z30.d, z29.s, z28.s");
+
+  //TEST_SINGLE(umullt(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28), "umullt z30.b, z29.b, z28.b");
+  TEST_SINGLE(umullt(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28), "umullt z30.h, z29.b, z28.b");
+  TEST_SINGLE(umullt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "umullt z30.s, z29.h, z28.h");
+  TEST_SINGLE(umullt(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28), "umullt z30.d, z29.s, z28.s");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 bitwise shift left long") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 integer add/subtract interleaved long") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 bitwise exclusive-or interleaved") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE integer matrix multiply accumulate") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 bitwise permute") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 complex integer add") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 integer absolute difference and accumulate long") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 integer add/subtract long with carry") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 bitwise shift right and accumulate") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 bitwise shift and insert") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 integer absolute difference and accumulate") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 saturating extract narrow") {
+  TEST_SINGLE(sqxtnb(SubRegSize::i8Bit, ZReg::z30, ZReg::z29), "sqxtnb z30.b, z29.h");
+  TEST_SINGLE(sqxtnb(SubRegSize::i16Bit, ZReg::z30, ZReg::z29), "sqxtnb z30.h, z29.s");
+  TEST_SINGLE(sqxtnb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29), "sqxtnb z30.s, z29.d");
+  //TEST_SINGLE(sqxtnb(SubRegSize::i64Bit, ZReg::z30, ZReg::z29), "sqxtnb z30.d, z29.q");
+
+  TEST_SINGLE(sqxtnt(SubRegSize::i8Bit, ZReg::z30, ZReg::z29), "sqxtnt z30.b, z29.h");
+  TEST_SINGLE(sqxtnt(SubRegSize::i16Bit, ZReg::z30, ZReg::z29), "sqxtnt z30.h, z29.s");
+  TEST_SINGLE(sqxtnt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29), "sqxtnt z30.s, z29.d");
+  //TEST_SINGLE(sqxtnt(SubRegSize::i64Bit, ZReg::z30, ZReg::z29), "sqxtnt z30.d, z29.q");
+
+  TEST_SINGLE(uqxtnb(SubRegSize::i8Bit, ZReg::z30, ZReg::z29), "uqxtnb z30.b, z29.h");
+  TEST_SINGLE(uqxtnb(SubRegSize::i16Bit, ZReg::z30, ZReg::z29), "uqxtnb z30.h, z29.s");
+  TEST_SINGLE(uqxtnb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29), "uqxtnb z30.s, z29.d");
+  //TEST_SINGLE(uqxtnb(SubRegSize::i64Bit, ZReg::z30, ZReg::z29), "uqxtnb z30.d, z29.q");
+
+  TEST_SINGLE(uqxtnt(SubRegSize::i8Bit, ZReg::z30, ZReg::z29), "uqxtnt z30.b, z29.h");
+  TEST_SINGLE(uqxtnt(SubRegSize::i16Bit, ZReg::z30, ZReg::z29), "uqxtnt z30.h, z29.s");
+  TEST_SINGLE(uqxtnt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29), "uqxtnt z30.s, z29.d");
+  //TEST_SINGLE(uqxtnt(SubRegSize::i64Bit, ZReg::z30, ZReg::z29), "uqxtnt z30.d, z29.q");
+
+  TEST_SINGLE(sqxtunb(SubRegSize::i8Bit, ZReg::z30, ZReg::z29), "sqxtunb z30.b, z29.h");
+  TEST_SINGLE(sqxtunb(SubRegSize::i16Bit, ZReg::z30, ZReg::z29), "sqxtunb z30.h, z29.s");
+  TEST_SINGLE(sqxtunb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29), "sqxtunb z30.s, z29.d");
+  //TEST_SINGLE(sqxtunb(SubRegSize::i64Bit, ZReg::z30, ZReg::z29), "sqxtunb z30.d, z29.q");
+
+  TEST_SINGLE(sqxtunt(SubRegSize::i8Bit, ZReg::z30, ZReg::z29), "sqxtunt z30.b, z29.h");
+  TEST_SINGLE(sqxtunt(SubRegSize::i16Bit, ZReg::z30, ZReg::z29), "sqxtunt z30.h, z29.s");
+  TEST_SINGLE(sqxtunt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29), "sqxtunt z30.s, z29.d");
+  //TEST_SINGLE(sqxtunt(SubRegSize::i64Bit, ZReg::z30, ZReg::z29), "sqxtunt z30.d, z29.q");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 bitwise shift right narrow") {
+  TEST_SINGLE(sqshrunb(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, 1), "sqshrunb z30.b, z29.h, #1");
+  TEST_SINGLE(sqshrunb(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, 8), "sqshrunb z30.b, z29.h, #8");
+  TEST_SINGLE(sqshrunb(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, 1), "sqshrunb z30.h, z29.s, #1");
+  TEST_SINGLE(sqshrunb(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, 16), "sqshrunb z30.h, z29.s, #16");
+  TEST_SINGLE(sqshrunb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, 1), "sqshrunb z30.s, z29.d, #1");
+  TEST_SINGLE(sqshrunb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, 32), "sqshrunb z30.s, z29.d, #32");
+
+  TEST_SINGLE(sqshrunt(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, 1), "sqshrunt z30.b, z29.h, #1");
+  TEST_SINGLE(sqshrunt(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, 8), "sqshrunt z30.b, z29.h, #8");
+  TEST_SINGLE(sqshrunt(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, 1), "sqshrunt z30.h, z29.s, #1");
+  TEST_SINGLE(sqshrunt(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, 16), "sqshrunt z30.h, z29.s, #16");
+  TEST_SINGLE(sqshrunt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, 1), "sqshrunt z30.s, z29.d, #1");
+  TEST_SINGLE(sqshrunt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, 32), "sqshrunt z30.s, z29.d, #32");
+
+  TEST_SINGLE(sqrshrunb(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, 1), "sqrshrunb z30.b, z29.h, #1");
+  TEST_SINGLE(sqrshrunb(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, 8), "sqrshrunb z30.b, z29.h, #8");
+  TEST_SINGLE(sqrshrunb(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, 1), "sqrshrunb z30.h, z29.s, #1");
+  TEST_SINGLE(sqrshrunb(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, 16), "sqrshrunb z30.h, z29.s, #16");
+  TEST_SINGLE(sqrshrunb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, 1), "sqrshrunb z30.s, z29.d, #1");
+  TEST_SINGLE(sqrshrunb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, 32), "sqrshrunb z30.s, z29.d, #32");
+
+  TEST_SINGLE(sqrshrunt(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, 1), "sqrshrunt z30.b, z29.h, #1");
+  TEST_SINGLE(sqrshrunt(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, 8), "sqrshrunt z30.b, z29.h, #8");
+  TEST_SINGLE(sqrshrunt(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, 1), "sqrshrunt z30.h, z29.s, #1");
+  TEST_SINGLE(sqrshrunt(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, 16), "sqrshrunt z30.h, z29.s, #16");
+  TEST_SINGLE(sqrshrunt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, 1), "sqrshrunt z30.s, z29.d, #1");
+  TEST_SINGLE(sqrshrunt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, 32), "sqrshrunt z30.s, z29.d, #32");
+
+  TEST_SINGLE(shrnb(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, 1), "shrnb z30.b, z29.h, #1");
+  TEST_SINGLE(shrnb(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, 8), "shrnb z30.b, z29.h, #8");
+  TEST_SINGLE(shrnb(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, 1), "shrnb z30.h, z29.s, #1");
+  TEST_SINGLE(shrnb(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, 16), "shrnb z30.h, z29.s, #16");
+  TEST_SINGLE(shrnb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, 1), "shrnb z30.s, z29.d, #1");
+  TEST_SINGLE(shrnb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, 32), "shrnb z30.s, z29.d, #32");
+
+  TEST_SINGLE(shrnt(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, 1), "shrnt z30.b, z29.h, #1");
+  TEST_SINGLE(shrnt(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, 8), "shrnt z30.b, z29.h, #8");
+  TEST_SINGLE(shrnt(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, 1), "shrnt z30.h, z29.s, #1");
+  TEST_SINGLE(shrnt(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, 16), "shrnt z30.h, z29.s, #16");
+  TEST_SINGLE(shrnt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, 1), "shrnt z30.s, z29.d, #1");
+  TEST_SINGLE(shrnt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, 32), "shrnt z30.s, z29.d, #32");
+
+  TEST_SINGLE(rshrnb(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, 1), "rshrnb z30.b, z29.h, #1");
+  TEST_SINGLE(rshrnb(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, 8), "rshrnb z30.b, z29.h, #8");
+  TEST_SINGLE(rshrnb(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, 1), "rshrnb z30.h, z29.s, #1");
+  TEST_SINGLE(rshrnb(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, 16), "rshrnb z30.h, z29.s, #16");
+  TEST_SINGLE(rshrnb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, 1), "rshrnb z30.s, z29.d, #1");
+  TEST_SINGLE(rshrnb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, 32), "rshrnb z30.s, z29.d, #32");
+
+  TEST_SINGLE(rshrnt(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, 1), "rshrnt z30.b, z29.h, #1");
+  TEST_SINGLE(rshrnt(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, 8), "rshrnt z30.b, z29.h, #8");
+  TEST_SINGLE(rshrnt(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, 1), "rshrnt z30.h, z29.s, #1");
+  TEST_SINGLE(rshrnt(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, 16), "rshrnt z30.h, z29.s, #16");
+  TEST_SINGLE(rshrnt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, 1), "rshrnt z30.s, z29.d, #1");
+  TEST_SINGLE(rshrnt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, 32), "rshrnt z30.s, z29.d, #32");
+
+  TEST_SINGLE(sqshrnb(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, 1), "sqshrnb z30.b, z29.h, #1");
+  TEST_SINGLE(sqshrnb(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, 8), "sqshrnb z30.b, z29.h, #8");
+  TEST_SINGLE(sqshrnb(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, 1), "sqshrnb z30.h, z29.s, #1");
+  TEST_SINGLE(sqshrnb(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, 16), "sqshrnb z30.h, z29.s, #16");
+  TEST_SINGLE(sqshrnb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, 1), "sqshrnb z30.s, z29.d, #1");
+  TEST_SINGLE(sqshrnb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, 32), "sqshrnb z30.s, z29.d, #32");
+
+  TEST_SINGLE(sqshrnt(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, 1), "sqshrnt z30.b, z29.h, #1");
+  TEST_SINGLE(sqshrnt(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, 8), "sqshrnt z30.b, z29.h, #8");
+  TEST_SINGLE(sqshrnt(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, 1), "sqshrnt z30.h, z29.s, #1");
+  TEST_SINGLE(sqshrnt(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, 16), "sqshrnt z30.h, z29.s, #16");
+  TEST_SINGLE(sqshrnt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, 1), "sqshrnt z30.s, z29.d, #1");
+  TEST_SINGLE(sqshrnt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, 32), "sqshrnt z30.s, z29.d, #32");
+
+  TEST_SINGLE(sqrshrnb(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, 1), "sqrshrnb z30.b, z29.h, #1");
+  TEST_SINGLE(sqrshrnb(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, 8), "sqrshrnb z30.b, z29.h, #8");
+  TEST_SINGLE(sqrshrnb(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, 1), "sqrshrnb z30.h, z29.s, #1");
+  TEST_SINGLE(sqrshrnb(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, 16), "sqrshrnb z30.h, z29.s, #16");
+  TEST_SINGLE(sqrshrnb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, 1), "sqrshrnb z30.s, z29.d, #1");
+  TEST_SINGLE(sqrshrnb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, 32), "sqrshrnb z30.s, z29.d, #32");
+
+  TEST_SINGLE(sqrshrnt(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, 1), "sqrshrnt z30.b, z29.h, #1");
+  TEST_SINGLE(sqrshrnt(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, 8), "sqrshrnt z30.b, z29.h, #8");
+  TEST_SINGLE(sqrshrnt(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, 1), "sqrshrnt z30.h, z29.s, #1");
+  TEST_SINGLE(sqrshrnt(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, 16), "sqrshrnt z30.h, z29.s, #16");
+  TEST_SINGLE(sqrshrnt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, 1), "sqrshrnt z30.s, z29.d, #1");
+  TEST_SINGLE(sqrshrnt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, 32), "sqrshrnt z30.s, z29.d, #32");
+
+  TEST_SINGLE(uqshrnb(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, 1), "uqshrnb z30.b, z29.h, #1");
+  TEST_SINGLE(uqshrnb(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, 8), "uqshrnb z30.b, z29.h, #8");
+  TEST_SINGLE(uqshrnb(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, 1), "uqshrnb z30.h, z29.s, #1");
+  TEST_SINGLE(uqshrnb(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, 16), "uqshrnb z30.h, z29.s, #16");
+  TEST_SINGLE(uqshrnb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, 1), "uqshrnb z30.s, z29.d, #1");
+  TEST_SINGLE(uqshrnb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, 32), "uqshrnb z30.s, z29.d, #32");
+
+  TEST_SINGLE(uqshrnt(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, 1), "uqshrnt z30.b, z29.h, #1");
+  TEST_SINGLE(uqshrnt(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, 8), "uqshrnt z30.b, z29.h, #8");
+  TEST_SINGLE(uqshrnt(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, 1), "uqshrnt z30.h, z29.s, #1");
+  TEST_SINGLE(uqshrnt(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, 16), "uqshrnt z30.h, z29.s, #16");
+  TEST_SINGLE(uqshrnt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, 1), "uqshrnt z30.s, z29.d, #1");
+  TEST_SINGLE(uqshrnt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, 32), "uqshrnt z30.s, z29.d, #32");
+
+  TEST_SINGLE(uqrshrnb(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, 1), "uqrshrnb z30.b, z29.h, #1");
+  TEST_SINGLE(uqrshrnb(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, 8), "uqrshrnb z30.b, z29.h, #8");
+  TEST_SINGLE(uqrshrnb(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, 1), "uqrshrnb z30.h, z29.s, #1");
+  TEST_SINGLE(uqrshrnb(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, 16), "uqrshrnb z30.h, z29.s, #16");
+  TEST_SINGLE(uqrshrnb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, 1), "uqrshrnb z30.s, z29.d, #1");
+  TEST_SINGLE(uqrshrnb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, 32), "uqrshrnb z30.s, z29.d, #32");
+
+  TEST_SINGLE(uqrshrnt(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, 1), "uqrshrnt z30.b, z29.h, #1");
+  TEST_SINGLE(uqrshrnt(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, 8), "uqrshrnt z30.b, z29.h, #8");
+  TEST_SINGLE(uqrshrnt(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, 1), "uqrshrnt z30.h, z29.s, #1");
+  TEST_SINGLE(uqrshrnt(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, 16), "uqrshrnt z30.h, z29.s, #16");
+  TEST_SINGLE(uqrshrnt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, 1), "uqrshrnt z30.s, z29.d, #1");
+  TEST_SINGLE(uqrshrnt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, 32), "uqrshrnt z30.s, z29.d, #32");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 integer add/subtract narrow high part") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 Histogram Computation - Segment") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 crypto unary operations") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 crypto destructive binary operations") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 crypto constructive binary operations") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE BFloat16 floating-point dot product (indexed)") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE floating-point multiply-add long (indexed)") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE BFloat16 floating-point dot product") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE floating-point multiply-add long") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE floating-point arithmetic (predicated)") {
+  //TEST_SINGLE(fadd(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),   "fadd z30.b, p6/m, z30.b, z28.b");
+  TEST_SINGLE(fadd(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fadd z30.h, p6/m, z30.h, z28.h");
+  TEST_SINGLE(fadd(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fadd z30.s, p6/m, z30.s, z28.s");
+  TEST_SINGLE(fadd(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fadd z30.d, p6/m, z30.d, z28.d");
+  //TEST_SINGLE(fadd(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28), "fadd z30.q, p6/m, z30.q, z28.q");
+
+  //TEST_SINGLE(fsub(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),   "fsub z30.b, p6/m, z30.b, z28.b");
+  TEST_SINGLE(fsub(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fsub z30.h, p6/m, z30.h, z28.h");
+  TEST_SINGLE(fsub(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fsub z30.s, p6/m, z30.s, z28.s");
+  TEST_SINGLE(fsub(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fsub z30.d, p6/m, z30.d, z28.d");
+  //TEST_SINGLE(fsub(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28), "fsub z30.q, p6/m, z30.q, z28.q");
+
+  //TEST_SINGLE(fmul(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),   "fmul z30.b, p6/m, z30.b, z28.b");
+  TEST_SINGLE(fmul(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fmul z30.h, p6/m, z30.h, z28.h");
+  TEST_SINGLE(fmul(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fmul z30.s, p6/m, z30.s, z28.s");
+  TEST_SINGLE(fmul(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fmul z30.d, p6/m, z30.d, z28.d");
+  //TEST_SINGLE(fmul(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28), "fmul z30.q, p6/m, z30.q, z28.q");
+
+  //TEST_SINGLE(fsubr(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),   "fsubr z30.b, p6/m, z30.b, z28.b");
+  TEST_SINGLE(fsubr(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fsubr z30.h, p6/m, z30.h, z28.h");
+  TEST_SINGLE(fsubr(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fsubr z30.s, p6/m, z30.s, z28.s");
+  TEST_SINGLE(fsubr(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fsubr z30.d, p6/m, z30.d, z28.d");
+  //TEST_SINGLE(fsubr(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28), "fsubr z30.q, p6/m, z30.q, z28.q");
+
+  //TEST_SINGLE(fmaxnm(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),   "fmaxnm z30.b, p6/m, z30.b, z28.b");
+  TEST_SINGLE(fmaxnm(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fmaxnm z30.h, p6/m, z30.h, z28.h");
+  TEST_SINGLE(fmaxnm(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fmaxnm z30.s, p6/m, z30.s, z28.s");
+  TEST_SINGLE(fmaxnm(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fmaxnm z30.d, p6/m, z30.d, z28.d");
+  //TEST_SINGLE(fmaxnm(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28), "fmaxnm z30.q, p6/m, z30.q, z28.q");
+
+  //TEST_SINGLE(fminnm(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),   "fminnm z30.b, p6/m, z30.b, z28.b");
+  TEST_SINGLE(fminnm(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fminnm z30.h, p6/m, z30.h, z28.h");
+  TEST_SINGLE(fminnm(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fminnm z30.s, p6/m, z30.s, z28.s");
+  TEST_SINGLE(fminnm(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fminnm z30.d, p6/m, z30.d, z28.d");
+  //TEST_SINGLE(fminnm(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28), "fminnm z30.q, p6/m, z30.q, z28.q");
+
+  //TEST_SINGLE(fmax(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),   "fmax z30.b, p6/m, z30.b, z28.b");
+  TEST_SINGLE(fmax(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fmax z30.h, p6/m, z30.h, z28.h");
+  TEST_SINGLE(fmax(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fmax z30.s, p6/m, z30.s, z28.s");
+  TEST_SINGLE(fmax(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fmax z30.d, p6/m, z30.d, z28.d");
+  //TEST_SINGLE(fmax(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28), "fmax z30.q, p6/m, z30.q, z28.q");
+
+  //TEST_SINGLE(fmin(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),   "fmin z30.b, p6/m, z30.b, z28.b");
+  TEST_SINGLE(fmin(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fmin z30.h, p6/m, z30.h, z28.h");
+  TEST_SINGLE(fmin(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fmin z30.s, p6/m, z30.s, z28.s");
+  TEST_SINGLE(fmin(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fmin z30.d, p6/m, z30.d, z28.d");
+  //TEST_SINGLE(fmin(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28), "fmin z30.q, p6/m, z30.q, z28.q");
+
+  //TEST_SINGLE(fabd(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),   "fabd z30.b, p6/m, z30.b, z28.b");
+  TEST_SINGLE(fabd(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fabd z30.h, p6/m, z30.h, z28.h");
+  TEST_SINGLE(fabd(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fabd z30.s, p6/m, z30.s, z28.s");
+  TEST_SINGLE(fabd(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fabd z30.d, p6/m, z30.d, z28.d");
+  //TEST_SINGLE(fabd(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28), "fabd z30.q, p6/m, z30.q, z28.q");
+
+  //TEST_SINGLE(fscale(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),   "fscale z30.b, p6/m, z30.b, z28.b");
+  TEST_SINGLE(fscale(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fscale z30.h, p6/m, z30.h, z28.h");
+  TEST_SINGLE(fscale(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fscale z30.s, p6/m, z30.s, z28.s");
+  TEST_SINGLE(fscale(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fscale z30.d, p6/m, z30.d, z28.d");
+  //TEST_SINGLE(fscale(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28), "fscale z30.q, p6/m, z30.q, z28.q");
+
+  //TEST_SINGLE(fmulx(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),   "fmulx z30.b, p6/m, z30.b, z28.b");
+  TEST_SINGLE(fmulx(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fmulx z30.h, p6/m, z30.h, z28.h");
+  TEST_SINGLE(fmulx(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fmulx z30.s, p6/m, z30.s, z28.s");
+  TEST_SINGLE(fmulx(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fmulx z30.d, p6/m, z30.d, z28.d");
+  //TEST_SINGLE(fmulx(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28), "fmulx z30.q, p6/m, z30.q, z28.q");
+
+  //TEST_SINGLE(fdiv(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),   "fdiv z30.b, p6/m, z30.b, z28.b");
+  TEST_SINGLE(fdiv(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fdiv z30.h, p6/m, z30.h, z28.h");
+  TEST_SINGLE(fdiv(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fdiv z30.s, p6/m, z30.s, z28.s");
+  TEST_SINGLE(fdiv(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fdiv z30.d, p6/m, z30.d, z28.d");
+  //TEST_SINGLE(fdiv(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28), "fdiv z30.q, p6/m, z30.q, z28.q");
+
+  //TEST_SINGLE(fdivr(SubRegSize::i8Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),   "fdivr z30.b, p6/m, z30.b, z28.b");
+  TEST_SINGLE(fdivr(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fdivr z30.h, p6/m, z30.h, z28.h");
+  TEST_SINGLE(fdivr(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fdivr z30.s, p6/m, z30.s, z28.s");
+  TEST_SINGLE(fdivr(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fdivr z30.d, p6/m, z30.d, z28.d");
+  //TEST_SINGLE(fdivr(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28), "fdivr z30.q, p6/m, z30.q, z28.q");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE floating-point arithmetic with immediate (predicated)") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE Memory - 32-bit Gather and Unsized Contiguous") {
+  TEST_SINGLE(ldr(PReg::p6, Reg::r29, 0), "ldr p6, [x29]");
+  TEST_SINGLE(ldr(PReg::p6, Reg::r29, -256), "ldr p6, [x29, #-256, mul vl]");
+  TEST_SINGLE(ldr(PReg::p6, Reg::r29, 255), "ldr p6, [x29, #255, mul vl]");
+  // XXX: LDR (vector)
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE load multiple structures (scalar plus immediate)") {
+  TEST_SINGLE(ld2b(ZReg::z26, ZReg::z27, PReg::p6.Zeroing(), Reg::r29, 0), "ld2b {z26.b, z27.b}, p6/z, [x29]");
+  TEST_SINGLE(ld2b(ZReg::z26, ZReg::z27, PReg::p6.Zeroing(), Reg::r29, -16), "ld2b {z26.b, z27.b}, p6/z, [x29, #-16, mul vl]");
+  TEST_SINGLE(ld2b(ZReg::z26, ZReg::z27, PReg::p6.Zeroing(), Reg::r29, 14), "ld2b {z26.b, z27.b}, p6/z, [x29, #14, mul vl]");
+
+  TEST_SINGLE(ld2h(ZReg::z26, ZReg::z27, PReg::p6.Zeroing(), Reg::r29, 0), "ld2h {z26.h, z27.h}, p6/z, [x29]");
+  TEST_SINGLE(ld2h(ZReg::z26, ZReg::z27, PReg::p6.Zeroing(), Reg::r29, -16), "ld2h {z26.h, z27.h}, p6/z, [x29, #-16, mul vl]");
+  TEST_SINGLE(ld2h(ZReg::z26, ZReg::z27, PReg::p6.Zeroing(), Reg::r29, 14), "ld2h {z26.h, z27.h}, p6/z, [x29, #14, mul vl]");
+
+  TEST_SINGLE(ld2w(ZReg::z26, ZReg::z27, PReg::p6.Zeroing(), Reg::r29, 0), "ld2w {z26.s, z27.s}, p6/z, [x29]");
+  TEST_SINGLE(ld2w(ZReg::z26, ZReg::z27, PReg::p6.Zeroing(), Reg::r29, -16), "ld2w {z26.s, z27.s}, p6/z, [x29, #-16, mul vl]");
+  TEST_SINGLE(ld2w(ZReg::z26, ZReg::z27, PReg::p6.Zeroing(), Reg::r29, 14), "ld2w {z26.s, z27.s}, p6/z, [x29, #14, mul vl]");
+
+  TEST_SINGLE(ld2d(ZReg::z26, ZReg::z27, PReg::p6.Zeroing(), Reg::r29, 0), "ld2d {z26.d, z27.d}, p6/z, [x29]");
+  TEST_SINGLE(ld2d(ZReg::z26, ZReg::z27, PReg::p6.Zeroing(), Reg::r29, -16), "ld2d {z26.d, z27.d}, p6/z, [x29, #-16, mul vl]");
+  TEST_SINGLE(ld2d(ZReg::z26, ZReg::z27, PReg::p6.Zeroing(), Reg::r29, 14), "ld2d {z26.d, z27.d}, p6/z, [x29, #14, mul vl]");
+
+  TEST_SINGLE(ld3b(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6.Zeroing(), Reg::r29, 0), "ld3b {z26.b, z27.b, z28.b}, p6/z, [x29]");
+  TEST_SINGLE(ld3b(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6.Zeroing(), Reg::r29, -24), "ld3b {z26.b, z27.b, z28.b}, p6/z, [x29, #-24, mul vl]");
+  TEST_SINGLE(ld3b(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6.Zeroing(), Reg::r29, 21), "ld3b {z26.b, z27.b, z28.b}, p6/z, [x29, #21, mul vl]");
+
+  TEST_SINGLE(ld3h(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6.Zeroing(), Reg::r29, 0), "ld3h {z26.h, z27.h, z28.h}, p6/z, [x29]");
+  TEST_SINGLE(ld3h(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6.Zeroing(), Reg::r29, -24), "ld3h {z26.h, z27.h, z28.h}, p6/z, [x29, #-24, mul vl]");
+  TEST_SINGLE(ld3h(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6.Zeroing(), Reg::r29, 21), "ld3h {z26.h, z27.h, z28.h}, p6/z, [x29, #21, mul vl]");
+
+  TEST_SINGLE(ld3w(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6.Zeroing(), Reg::r29, 0), "ld3w {z26.s, z27.s, z28.s}, p6/z, [x29]");
+  TEST_SINGLE(ld3w(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6.Zeroing(), Reg::r29, -24), "ld3w {z26.s, z27.s, z28.s}, p6/z, [x29, #-24, mul vl]");
+  TEST_SINGLE(ld3w(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6.Zeroing(), Reg::r29, 21), "ld3w {z26.s, z27.s, z28.s}, p6/z, [x29, #21, mul vl]");
+
+  TEST_SINGLE(ld3d(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6.Zeroing(), Reg::r29, 0), "ld3d {z26.d, z27.d, z28.d}, p6/z, [x29]");
+  TEST_SINGLE(ld3d(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6.Zeroing(), Reg::r29, -24), "ld3d {z26.d, z27.d, z28.d}, p6/z, [x29, #-24, mul vl]");
+  TEST_SINGLE(ld3d(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6.Zeroing(), Reg::r29, 21), "ld3d {z26.d, z27.d, z28.d}, p6/z, [x29, #21, mul vl]");
+
+  TEST_SINGLE(ld4b(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6.Zeroing(), Reg::r29, 0), "ld4b {z26.b, z27.b, z28.b, z29.b}, p6/z, [x29]");
+  TEST_SINGLE(ld4b(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6.Zeroing(), Reg::r29, -32), "ld4b {z26.b, z27.b, z28.b, z29.b}, p6/z, [x29, #-32, mul vl]");
+  TEST_SINGLE(ld4b(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6.Zeroing(), Reg::r29, 28), "ld4b {z26.b, z27.b, z28.b, z29.b}, p6/z, [x29, #28, mul vl]");
+
+  TEST_SINGLE(ld4h(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6.Zeroing(), Reg::r29, 0), "ld4h {z26.h, z27.h, z28.h, z29.h}, p6/z, [x29]");
+  TEST_SINGLE(ld4h(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6.Zeroing(), Reg::r29, -32), "ld4h {z26.h, z27.h, z28.h, z29.h}, p6/z, [x29, #-32, mul vl]");
+  TEST_SINGLE(ld4h(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6.Zeroing(), Reg::r29, 28), "ld4h {z26.h, z27.h, z28.h, z29.h}, p6/z, [x29, #28, mul vl]");
+
+  TEST_SINGLE(ld4w(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6.Zeroing(), Reg::r29, 0), "ld4w {z26.s, z27.s, z28.s, z29.s}, p6/z, [x29]");
+  TEST_SINGLE(ld4w(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6.Zeroing(), Reg::r29, -32), "ld4w {z26.s, z27.s, z28.s, z29.s}, p6/z, [x29, #-32, mul vl]");
+  TEST_SINGLE(ld4w(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6.Zeroing(), Reg::r29, 28), "ld4w {z26.s, z27.s, z28.s, z29.s}, p6/z, [x29, #28, mul vl]");
+
+  TEST_SINGLE(ld4d(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6.Zeroing(), Reg::r29, 0), "ld4d {z26.d, z27.d, z28.d, z29.d}, p6/z, [x29]");
+  TEST_SINGLE(ld4d(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6.Zeroing(), Reg::r29, -32), "ld4d {z26.d, z27.d, z28.d, z29.d}, p6/z, [x29, #-32, mul vl]");
+  TEST_SINGLE(ld4d(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6.Zeroing(), Reg::r29, 28), "ld4d {z26.d, z27.d, z28.d, z29.d}, p6/z, [x29, #28, mul vl]");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE contiguous load (scalar plus immediate)") {
+  TEST_SINGLE(ld1b<SubRegSize::i8Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, 0), "ld1b {z26.b}, p6/z, [x29]");
+  TEST_SINGLE(ld1b<SubRegSize::i16Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, 0), "ld1b {z26.h}, p6/z, [x29]");
+  TEST_SINGLE(ld1b<SubRegSize::i32Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, 0), "ld1b {z26.s}, p6/z, [x29]");
+  TEST_SINGLE(ld1b<SubRegSize::i64Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, 0), "ld1b {z26.d}, p6/z, [x29]");
+
+  TEST_SINGLE(ld1b<SubRegSize::i8Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, -8), "ld1b {z26.b}, p6/z, [x29, #-8, mul vl]");
+  TEST_SINGLE(ld1b<SubRegSize::i16Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, -8), "ld1b {z26.h}, p6/z, [x29, #-8, mul vl]");
+  TEST_SINGLE(ld1b<SubRegSize::i32Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, -8), "ld1b {z26.s}, p6/z, [x29, #-8, mul vl]");
+  TEST_SINGLE(ld1b<SubRegSize::i64Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, -8), "ld1b {z26.d}, p6/z, [x29, #-8, mul vl]");
+
+  TEST_SINGLE(ld1b<SubRegSize::i8Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, 7), "ld1b {z26.b}, p6/z, [x29, #7, mul vl]");
+  TEST_SINGLE(ld1b<SubRegSize::i16Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, 7), "ld1b {z26.h}, p6/z, [x29, #7, mul vl]");
+  TEST_SINGLE(ld1b<SubRegSize::i32Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, 7), "ld1b {z26.s}, p6/z, [x29, #7, mul vl]");
+  TEST_SINGLE(ld1b<SubRegSize::i64Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, 7), "ld1b {z26.d}, p6/z, [x29, #7, mul vl]");
+
+  TEST_SINGLE(ld1sw(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, 0), "ld1sw {z26.d}, p6/z, [x29]");
+  TEST_SINGLE(ld1sw(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, -8), "ld1sw {z26.d}, p6/z, [x29, #-8, mul vl]");
+  TEST_SINGLE(ld1sw(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, 7), "ld1sw {z26.d}, p6/z, [x29, #7, mul vl]");
+
+  //TEST_SINGLE(ld1h<SubRegSize::i8Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, 0), "ld1h {z26.b}, p6/z, [x29]");
+  TEST_SINGLE(ld1h<SubRegSize::i16Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, 0), "ld1h {z26.h}, p6/z, [x29]");
+  TEST_SINGLE(ld1h<SubRegSize::i32Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, 0), "ld1h {z26.s}, p6/z, [x29]");
+  TEST_SINGLE(ld1h<SubRegSize::i64Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, 0), "ld1h {z26.d}, p6/z, [x29]");
+
+  //TEST_SINGLE(ld1h<SubRegSize::i8Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, -8), "ld1h {z26.b}, p6/z, [x29, #-8, mul vl]");
+  TEST_SINGLE(ld1h<SubRegSize::i16Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, -8), "ld1h {z26.h}, p6/z, [x29, #-8, mul vl]");
+  TEST_SINGLE(ld1h<SubRegSize::i32Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, -8), "ld1h {z26.s}, p6/z, [x29, #-8, mul vl]");
+  TEST_SINGLE(ld1h<SubRegSize::i64Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, -8), "ld1h {z26.d}, p6/z, [x29, #-8, mul vl]");
+
+  //TEST_SINGLE(ld1h<SubRegSize::i8Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, 7), "ld1h {z26.b}, p6/z, [x29, #7, mul vl]");
+  TEST_SINGLE(ld1h<SubRegSize::i16Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, 7), "ld1h {z26.h}, p6/z, [x29, #7, mul vl]");
+  TEST_SINGLE(ld1h<SubRegSize::i32Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, 7), "ld1h {z26.s}, p6/z, [x29, #7, mul vl]");
+  TEST_SINGLE(ld1h<SubRegSize::i64Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, 7), "ld1h {z26.d}, p6/z, [x29, #7, mul vl]");
+
+  //TEST_SINGLE(ld1sh<SubRegSize::i8Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, 0), "ld1sh {z26.b}, p6/z, [x29]");
+  //TEST_SINGLE(ld1sh<SubRegSize::i16Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, 0), "ld1sh {z26.h}, p6/z, [x29]");
+  TEST_SINGLE(ld1sh<SubRegSize::i32Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, 0), "ld1sh {z26.s}, p6/z, [x29]");
+  TEST_SINGLE(ld1sh<SubRegSize::i64Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, 0), "ld1sh {z26.d}, p6/z, [x29]");
+
+  //TEST_SINGLE(ld1sh<SubRegSize::i8Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, -8), "ld1sh {z26.b}, p6/z, [x29, #-8, mul vl]");
+  //TEST_SINGLE(ld1sh<SubRegSize::i16Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, -8), "ld1sh {z26.h}, p6/z, [x29, #-8, mul vl]");
+  TEST_SINGLE(ld1sh<SubRegSize::i32Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, -8), "ld1sh {z26.s}, p6/z, [x29, #-8, mul vl]");
+  TEST_SINGLE(ld1sh<SubRegSize::i64Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, -8), "ld1sh {z26.d}, p6/z, [x29, #-8, mul vl]");
+
+  //TEST_SINGLE(ld1sh<SubRegSize::i8Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, 7), "ld1sh {z26.b}, p6/z, [x29, #7, mul vl]");
+  //TEST_SINGLE(ld1sh<SubRegSize::i16Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, 7), "ld1sh {z26.h}, p6/z, [x29, #7, mul vl]");
+  TEST_SINGLE(ld1sh<SubRegSize::i32Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, 7), "ld1sh {z26.s}, p6/z, [x29, #7, mul vl]");
+  TEST_SINGLE(ld1sh<SubRegSize::i64Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, 7), "ld1sh {z26.d}, p6/z, [x29, #7, mul vl]");
+
+  TEST_SINGLE(ld1sw(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, 0), "ld1sw {z26.d}, p6/z, [x29]");
+  TEST_SINGLE(ld1sw(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, -8), "ld1sw {z26.d}, p6/z, [x29, #-8, mul vl]");
+  TEST_SINGLE(ld1sw(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, 7), "ld1sw {z26.d}, p6/z, [x29, #7, mul vl]");
+
+  //TEST_SINGLE(ld1sb<SubRegSize::i8Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, 0), "ld1sb {z26.b}, p6/z, [x29]");
+  TEST_SINGLE(ld1sb<SubRegSize::i16Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, 0), "ld1sb {z26.h}, p6/z, [x29]");
+  TEST_SINGLE(ld1sb<SubRegSize::i32Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, 0), "ld1sb {z26.s}, p6/z, [x29]");
+  TEST_SINGLE(ld1sb<SubRegSize::i64Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, 0), "ld1sb {z26.d}, p6/z, [x29]");
+
+  //TEST_SINGLE(ld1sb<SubRegSize::i8Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, -8), "ld1sb {z26.b}, p6/z, [x29, #-8, mul vl]");
+  TEST_SINGLE(ld1sb<SubRegSize::i16Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, -8), "ld1sb {z26.h}, p6/z, [x29, #-8, mul vl]");
+  TEST_SINGLE(ld1sb<SubRegSize::i32Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, -8), "ld1sb {z26.s}, p6/z, [x29, #-8, mul vl]");
+  TEST_SINGLE(ld1sb<SubRegSize::i64Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, -8), "ld1sb {z26.d}, p6/z, [x29, #-8, mul vl]");
+
+  //TEST_SINGLE(ld1sb<SubRegSize::i8Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, 7), "ld1sb {z26.b}, p6/z, [x29, #7, mul vl]");
+  TEST_SINGLE(ld1sb<SubRegSize::i16Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, 7), "ld1sb {z26.h}, p6/z, [x29, #7, mul vl]");
+  TEST_SINGLE(ld1sb<SubRegSize::i32Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, 7), "ld1sb {z26.s}, p6/z, [x29, #7, mul vl]");
+  TEST_SINGLE(ld1sb<SubRegSize::i64Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, 7), "ld1sb {z26.d}, p6/z, [x29, #7, mul vl]");
+
+  TEST_SINGLE(ld1d(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, 0), "ld1d {z26.d}, p6/z, [x29]");
+  TEST_SINGLE(ld1d(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, -8), "ld1d {z26.d}, p6/z, [x29, #-8, mul vl]");
+  TEST_SINGLE(ld1d(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, 7), "ld1d {z26.d}, p6/z, [x29, #7, mul vl]");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE contiguous store (scalar plus scalar)") {
+  TEST_SINGLE(st1b<SubRegSize::i8Bit>(ZReg::z26, PReg::p6, Reg::r29, Reg::r28), "st1b {z26.b}, p6, [x29, x28]");
+  TEST_SINGLE(st1b<SubRegSize::i16Bit>(ZReg::z26, PReg::p6, Reg::r29, Reg::r28), "st1b {z26.h}, p6, [x29, x28]");
+  TEST_SINGLE(st1b<SubRegSize::i32Bit>(ZReg::z26, PReg::p6, Reg::r29, Reg::r28), "st1b {z26.s}, p6, [x29, x28]");
+  TEST_SINGLE(st1b<SubRegSize::i64Bit>(ZReg::z26, PReg::p6, Reg::r29, Reg::r28), "st1b {z26.d}, p6, [x29, x28]");
+
+  //TEST_SINGLE(st1h<SubRegSize::i8Bit>(ZReg::z26, PReg::p6, Reg::r29, Reg::r28), "st1h {z26.b}, p6, [x29, x28, lsl #1]");
+  TEST_SINGLE(st1h<SubRegSize::i16Bit>(ZReg::z26, PReg::p6, Reg::r29, Reg::r28), "st1h {z26.h}, p6, [x29, x28, lsl #1]");
+  TEST_SINGLE(st1h<SubRegSize::i32Bit>(ZReg::z26, PReg::p6, Reg::r29, Reg::r28), "st1h {z26.s}, p6, [x29, x28, lsl #1]");
+  TEST_SINGLE(st1h<SubRegSize::i64Bit>(ZReg::z26, PReg::p6, Reg::r29, Reg::r28), "st1h {z26.d}, p6, [x29, x28, lsl #1]");
+
+  //TEST_SINGLE(st1w<SubRegSize::i8Bit>(ZReg::z26, PReg::p6, Reg::r29, Reg::r28), "st1w {z26.b}, p6, [x29, x28, lsl #2]");
+  //TEST_SINGLE(st1w<SubRegSize::i16Bit>(ZReg::z26, PReg::p6, Reg::r29, Reg::r28), "st1w {z26.h}, p6, [x29, x28, lsl #2]");
+  TEST_SINGLE(st1w<SubRegSize::i32Bit>(ZReg::z26, PReg::p6, Reg::r29, Reg::r28), "st1w {z26.s}, p6, [x29, x28, lsl #2]");
+  TEST_SINGLE(st1w<SubRegSize::i64Bit>(ZReg::z26, PReg::p6, Reg::r29, Reg::r28), "st1w {z26.d}, p6, [x29, x28, lsl #2]");
+
+  TEST_SINGLE(st1d(ZReg::z26, PReg::p6, Reg::r29, Reg::r28), "st1d {z26.d}, p6, [x29, x28, lsl #3]");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE contiguous load (scalar plus scalar)") {
+  TEST_SINGLE(ld1b<SubRegSize::i8Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, Reg::r30), "ld1b {z26.b}, p6/z, [x29, x30]");
+  TEST_SINGLE(ld1b<SubRegSize::i16Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, Reg::r30), "ld1b {z26.h}, p6/z, [x29, x30]");
+  TEST_SINGLE(ld1b<SubRegSize::i32Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, Reg::r30), "ld1b {z26.s}, p6/z, [x29, x30]");
+  TEST_SINGLE(ld1b<SubRegSize::i64Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, Reg::r30), "ld1b {z26.d}, p6/z, [x29, x30]");
+
+  TEST_SINGLE(ld1sw(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, Reg::r30), "ld1sw {z26.d}, p6/z, [x29, x30, lsl #2]");
+
+  //TEST_SINGLE(ld1h<SubRegSize::i8Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, Reg::r30), "ld1h {z26.b}, p6/z, [x29, x30, lsl #1]");
+  TEST_SINGLE(ld1h<SubRegSize::i16Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, Reg::r30), "ld1h {z26.h}, p6/z, [x29, x30, lsl #1]");
+  TEST_SINGLE(ld1h<SubRegSize::i32Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, Reg::r30), "ld1h {z26.s}, p6/z, [x29, x30, lsl #1]");
+  TEST_SINGLE(ld1h<SubRegSize::i64Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, Reg::r30), "ld1h {z26.d}, p6/z, [x29, x30, lsl #1]");
+
+  //TEST_SINGLE(ld1sh<SubRegSize::i8Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, Reg::r30), "ld1sh {z26.b}, p6/z, [x29, x30, lsl #1]");
+  //TEST_SINGLE(ld1sh<SubRegSize::i16Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, Reg::r30), "ld1sh {z26.h}, p6/z, [x29, x30, lsl #1]");
+  TEST_SINGLE(ld1sh<SubRegSize::i32Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, Reg::r30), "ld1sh {z26.s}, p6/z, [x29, x30, lsl #1]");
+  TEST_SINGLE(ld1sh<SubRegSize::i64Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, Reg::r30), "ld1sh {z26.d}, p6/z, [x29, x30, lsl #1]");
+
+  TEST_SINGLE(ld1sw(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, Reg::r30), "ld1sw {z26.d}, p6/z, [x29, x30, lsl #2]");
+
+  //TEST_SINGLE(ld1sb<SubRegSize::i8Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, Reg::r30), "ld1sb {z26.b}, p6/z, [x29, x30]");
+  TEST_SINGLE(ld1sb<SubRegSize::i16Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, Reg::r30), "ld1sb {z26.h}, p6/z, [x29, x30]");
+  TEST_SINGLE(ld1sb<SubRegSize::i32Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, Reg::r30), "ld1sb {z26.s}, p6/z, [x29, x30]");
+  TEST_SINGLE(ld1sb<SubRegSize::i64Bit>(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, Reg::r30), "ld1sb {z26.d}, p6/z, [x29, x30]");
+
+  TEST_SINGLE(ld1d(ZReg::z26, PReg::p6.Zeroing(), Reg::r29, Reg::r30), "ld1d {z26.d}, p6/z, [x29, x30, lsl #3]");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE floating-point round to integral value") {
+  TEST_SINGLE(frinti(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "frinti z30.h, p6/m, z29.h");
+  TEST_SINGLE(frinti(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "frinti z30.s, p6/m, z29.s");
+  TEST_SINGLE(frinti(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "frinti z30.d, p6/m, z29.d");
+  TEST_SINGLE(frintx(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "frintx z30.h, p6/m, z29.h");
+  TEST_SINGLE(frintx(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "frintx z30.s, p6/m, z29.s");
+  TEST_SINGLE(frintx(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "frintx z30.d, p6/m, z29.d");
+  TEST_SINGLE(frinta(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "frinta z30.h, p6/m, z29.h");
+  TEST_SINGLE(frinta(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "frinta z30.s, p6/m, z29.s");
+  TEST_SINGLE(frinta(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "frinta z30.d, p6/m, z29.d");
+  TEST_SINGLE(frintn(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "frintn z30.h, p6/m, z29.h");
+  TEST_SINGLE(frintn(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "frintn z30.s, p6/m, z29.s");
+  TEST_SINGLE(frintn(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "frintn z30.d, p6/m, z29.d");
+  TEST_SINGLE(frintz(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "frintz z30.h, p6/m, z29.h");
+  TEST_SINGLE(frintz(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "frintz z30.s, p6/m, z29.s");
+  TEST_SINGLE(frintz(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "frintz z30.d, p6/m, z29.d");
+  TEST_SINGLE(frintm(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "frintm z30.h, p6/m, z29.h");
+  TEST_SINGLE(frintm(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "frintm z30.s, p6/m, z29.s");
+  TEST_SINGLE(frintm(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "frintm z30.d, p6/m, z29.d");
+  TEST_SINGLE(frintp(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "frintp z30.h, p6/m, z29.h");
+  TEST_SINGLE(frintp(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "frintp z30.s, p6/m, z29.s");
+  TEST_SINGLE(frintp(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "frintp z30.d, p6/m, z29.d");
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE floating-point convert precision") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE floating-point unary operations") {
+  TEST_SINGLE(frecpx(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "frecpx z30.h, p6/m, z29.h");
+  TEST_SINGLE(frecpx(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "frecpx z30.s, p6/m, z29.s");
+  TEST_SINGLE(frecpx(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "frecpx z30.d, p6/m, z29.d");
+
+  TEST_SINGLE(fsqrt(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "fsqrt z30.h, p6/m, z29.h");
+  TEST_SINGLE(fsqrt(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "fsqrt z30.s, p6/m, z29.s");
+  TEST_SINGLE(fsqrt(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "fsqrt z30.d, p6/m, z29.d");
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE integer convert to floating-point") {
+  // TODO: Implement in emitter.
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE floating-point convert to integer") {
+  TEST_SINGLE(flogb(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "flogb z30.h, p6/m, z29.h");
+  TEST_SINGLE(flogb(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "flogb z30.s, p6/m, z29.s");
+  TEST_SINGLE(flogb(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "flogb z30.d, p6/m, z29.d");
+
+  TEST_SINGLE(scvtf(ZReg::z30, SubRegSize::i16Bit, PReg::p6.Merging(), ZReg::z29, SubRegSize::i16Bit), "scvtf z30.h, p6/m, z29.h");
+  TEST_SINGLE(scvtf(ZReg::z30, SubRegSize::i16Bit, PReg::p6.Merging(), ZReg::z29, SubRegSize::i32Bit), "scvtf z30.h, p6/m, z29.s");
+  TEST_SINGLE(scvtf(ZReg::z30, SubRegSize::i16Bit, PReg::p6.Merging(), ZReg::z29, SubRegSize::i64Bit), "scvtf z30.h, p6/m, z29.d");
+
+  //TEST_SINGLE(scvtf(ZReg::z30, SubRegSize::i32Bit, PReg::p6.Merging(), ZReg::z29, SubRegSize::i16Bit), "scvtf z30.s, p6/m, z29.h");
+  TEST_SINGLE(scvtf(ZReg::z30, SubRegSize::i32Bit, PReg::p6.Merging(), ZReg::z29, SubRegSize::i32Bit), "scvtf z30.s, p6/m, z29.s");
+  TEST_SINGLE(scvtf(ZReg::z30, SubRegSize::i32Bit, PReg::p6.Merging(), ZReg::z29, SubRegSize::i64Bit), "scvtf z30.s, p6/m, z29.d");
+
+  //TEST_SINGLE(scvtf(ZReg::z30, SubRegSize::i64Bit, PReg::p6.Merging(), ZReg::z29, SubRegSize::i16Bit), "scvtf z30.d, p6/m, z29.h");
+  TEST_SINGLE(scvtf(ZReg::z30, SubRegSize::i64Bit, PReg::p6.Merging(), ZReg::z29, SubRegSize::i32Bit), "scvtf z30.d, p6/m, z29.s");
+  TEST_SINGLE(scvtf(ZReg::z30, SubRegSize::i64Bit, PReg::p6.Merging(), ZReg::z29, SubRegSize::i64Bit), "scvtf z30.d, p6/m, z29.d");
+
+  TEST_SINGLE(ucvtf(ZReg::z30, SubRegSize::i16Bit, PReg::p6.Merging(), ZReg::z29, SubRegSize::i16Bit), "ucvtf z30.h, p6/m, z29.h");
+  TEST_SINGLE(ucvtf(ZReg::z30, SubRegSize::i16Bit, PReg::p6.Merging(), ZReg::z29, SubRegSize::i32Bit), "ucvtf z30.h, p6/m, z29.s");
+  TEST_SINGLE(ucvtf(ZReg::z30, SubRegSize::i16Bit, PReg::p6.Merging(), ZReg::z29, SubRegSize::i64Bit), "ucvtf z30.h, p6/m, z29.d");
+
+  //TEST_SINGLE(ucvtf(ZReg::z30, SubRegSize::i32Bit, PReg::p6.Merging(), ZReg::z29, SubRegSize::i16Bit), "ucvtf z30.s, p6/m, z29.h");
+  TEST_SINGLE(ucvtf(ZReg::z30, SubRegSize::i32Bit, PReg::p6.Merging(), ZReg::z29, SubRegSize::i32Bit), "ucvtf z30.s, p6/m, z29.s");
+  TEST_SINGLE(ucvtf(ZReg::z30, SubRegSize::i32Bit, PReg::p6.Merging(), ZReg::z29, SubRegSize::i64Bit), "ucvtf z30.s, p6/m, z29.d");
+
+  //TEST_SINGLE(ucvtf(ZReg::z30, SubRegSize::i64Bit, PReg::p6.Merging(), ZReg::z29, SubRegSize::i16Bit), "ucvtf z30.d, p6/m, z29.h");
+  TEST_SINGLE(ucvtf(ZReg::z30, SubRegSize::i64Bit, PReg::p6.Merging(), ZReg::z29, SubRegSize::i32Bit), "ucvtf z30.d, p6/m, z29.s");
+  TEST_SINGLE(ucvtf(ZReg::z30, SubRegSize::i64Bit, PReg::p6.Merging(), ZReg::z29, SubRegSize::i64Bit), "ucvtf z30.d, p6/m, z29.d");
+
+  TEST_SINGLE(fcvtzs(ZReg::z30, SubRegSize::i16Bit, PReg::p6.Merging(), ZReg::z29, SubRegSize::i16Bit), "fcvtzs z30.h, p6/m, z29.h");
+  //TEST_SINGLE(fcvtzs(ZReg::z30, SubRegSize::i16Bit, PReg::p6.Merging(), ZReg::z29, SubRegSize::i32Bit), "fcvtzs z30.h, p6/m, z29.s");
+  //TEST_SINGLE(fcvtzs(ZReg::z30, SubRegSize::i16Bit, PReg::p6.Merging(), ZReg::z29, SubRegSize::i64Bit), "fcvtzs z30.h, p6/m, z29.d");
+
+  TEST_SINGLE(fcvtzs(ZReg::z30, SubRegSize::i32Bit, PReg::p6.Merging(), ZReg::z29, SubRegSize::i16Bit), "fcvtzs z30.s, p6/m, z29.h");
+  TEST_SINGLE(fcvtzs(ZReg::z30, SubRegSize::i32Bit, PReg::p6.Merging(), ZReg::z29, SubRegSize::i32Bit), "fcvtzs z30.s, p6/m, z29.s");
+  TEST_SINGLE(fcvtzs(ZReg::z30, SubRegSize::i32Bit, PReg::p6.Merging(), ZReg::z29, SubRegSize::i64Bit), "fcvtzs z30.s, p6/m, z29.d");
+
+  TEST_SINGLE(fcvtzs(ZReg::z30, SubRegSize::i64Bit, PReg::p6.Merging(), ZReg::z29, SubRegSize::i16Bit), "fcvtzs z30.d, p6/m, z29.h");
+  TEST_SINGLE(fcvtzs(ZReg::z30, SubRegSize::i64Bit, PReg::p6.Merging(), ZReg::z29, SubRegSize::i32Bit), "fcvtzs z30.d, p6/m, z29.s");
+  TEST_SINGLE(fcvtzs(ZReg::z30, SubRegSize::i64Bit, PReg::p6.Merging(), ZReg::z29, SubRegSize::i64Bit), "fcvtzs z30.d, p6/m, z29.d");
+
+  TEST_SINGLE(fcvtzu(ZReg::z30, SubRegSize::i16Bit, PReg::p6.Merging(), ZReg::z29, SubRegSize::i16Bit), "fcvtzu z30.h, p6/m, z29.h");
+  //TEST_SINGLE(fcvtzu(ZReg::z30, SubRegSize::i16Bit, PReg::p6.Merging(), ZReg::z29, SubRegSize::i32Bit), "fcvtzu z30.h, p6/m, z29.s");
+  //TEST_SINGLE(fcvtzu(ZReg::z30, SubRegSize::i16Bit, PReg::p6.Merging(), ZReg::z29, SubRegSize::i64Bit), "fcvtzu z30.h, p6/m, z29.d");
+
+  TEST_SINGLE(fcvtzu(ZReg::z30, SubRegSize::i32Bit, PReg::p6.Merging(), ZReg::z29, SubRegSize::i16Bit), "fcvtzu z30.s, p6/m, z29.h");
+  TEST_SINGLE(fcvtzu(ZReg::z30, SubRegSize::i32Bit, PReg::p6.Merging(), ZReg::z29, SubRegSize::i32Bit), "fcvtzu z30.s, p6/m, z29.s");
+  TEST_SINGLE(fcvtzu(ZReg::z30, SubRegSize::i32Bit, PReg::p6.Merging(), ZReg::z29, SubRegSize::i64Bit), "fcvtzu z30.s, p6/m, z29.d");
+
+  TEST_SINGLE(fcvtzu(ZReg::z30, SubRegSize::i64Bit, PReg::p6.Merging(), ZReg::z29, SubRegSize::i16Bit), "fcvtzu z30.d, p6/m, z29.h");
+  TEST_SINGLE(fcvtzu(ZReg::z30, SubRegSize::i64Bit, PReg::p6.Merging(), ZReg::z29, SubRegSize::i32Bit), "fcvtzu z30.d, p6/m, z29.s");
+  TEST_SINGLE(fcvtzu(ZReg::z30, SubRegSize::i64Bit, PReg::p6.Merging(), ZReg::z29, SubRegSize::i64Bit), "fcvtzu z30.d, p6/m, z29.d");
+}
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE store multiple structures (scalar plus immediate)") {
+  TEST_SINGLE(st2b(ZReg::z26, ZReg::z27, PReg::p6, Reg::r29, 0), "st2b {z26.b, z27.b}, p6, [x29]");
+  TEST_SINGLE(st2b(ZReg::z26, ZReg::z27, PReg::p6, Reg::r29, -16), "st2b {z26.b, z27.b}, p6, [x29, #-16, mul vl]");
+  TEST_SINGLE(st2b(ZReg::z26, ZReg::z27, PReg::p6, Reg::r29, 14), "st2b {z26.b, z27.b}, p6, [x29, #14, mul vl]");
+
+  TEST_SINGLE(st2h(ZReg::z26, ZReg::z27, PReg::p6, Reg::r29, 0), "st2h {z26.h, z27.h}, p6, [x29]");
+  TEST_SINGLE(st2h(ZReg::z26, ZReg::z27, PReg::p6, Reg::r29, -16), "st2h {z26.h, z27.h}, p6, [x29, #-16, mul vl]");
+  TEST_SINGLE(st2h(ZReg::z26, ZReg::z27, PReg::p6, Reg::r29, 14), "st2h {z26.h, z27.h}, p6, [x29, #14, mul vl]");
+
+  TEST_SINGLE(st2w(ZReg::z26, ZReg::z27, PReg::p6, Reg::r29, 0), "st2w {z26.s, z27.s}, p6, [x29]");
+  TEST_SINGLE(st2w(ZReg::z26, ZReg::z27, PReg::p6, Reg::r29, -16), "st2w {z26.s, z27.s}, p6, [x29, #-16, mul vl]");
+  TEST_SINGLE(st2w(ZReg::z26, ZReg::z27, PReg::p6, Reg::r29, 14), "st2w {z26.s, z27.s}, p6, [x29, #14, mul vl]");
+
+  TEST_SINGLE(st2d(ZReg::z26, ZReg::z27, PReg::p6, Reg::r29, 0), "st2d {z26.d, z27.d}, p6, [x29]");
+  TEST_SINGLE(st2d(ZReg::z26, ZReg::z27, PReg::p6, Reg::r29, -16), "st2d {z26.d, z27.d}, p6, [x29, #-16, mul vl]");
+  TEST_SINGLE(st2d(ZReg::z26, ZReg::z27, PReg::p6, Reg::r29, 14), "st2d {z26.d, z27.d}, p6, [x29, #14, mul vl]");
+
+  TEST_SINGLE(st3b(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6, Reg::r29, 0), "st3b {z26.b, z27.b, z28.b}, p6, [x29]");
+  TEST_SINGLE(st3b(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6, Reg::r29, -24), "st3b {z26.b, z27.b, z28.b}, p6, [x29, #-24, mul vl]");
+  TEST_SINGLE(st3b(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6, Reg::r29, 21), "st3b {z26.b, z27.b, z28.b}, p6, [x29, #21, mul vl]");
+
+  TEST_SINGLE(st3h(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6, Reg::r29, 0), "st3h {z26.h, z27.h, z28.h}, p6, [x29]");
+  TEST_SINGLE(st3h(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6, Reg::r29, -24), "st3h {z26.h, z27.h, z28.h}, p6, [x29, #-24, mul vl]");
+  TEST_SINGLE(st3h(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6, Reg::r29, 21), "st3h {z26.h, z27.h, z28.h}, p6, [x29, #21, mul vl]");
+
+  TEST_SINGLE(st3w(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6, Reg::r29, 0), "st3w {z26.s, z27.s, z28.s}, p6, [x29]");
+  TEST_SINGLE(st3w(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6, Reg::r29, -24), "st3w {z26.s, z27.s, z28.s}, p6, [x29, #-24, mul vl]");
+  TEST_SINGLE(st3w(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6, Reg::r29, 21), "st3w {z26.s, z27.s, z28.s}, p6, [x29, #21, mul vl]");
+
+  TEST_SINGLE(st3d(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6, Reg::r29, 0), "st3d {z26.d, z27.d, z28.d}, p6, [x29]");
+  TEST_SINGLE(st3d(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6, Reg::r29, -24), "st3d {z26.d, z27.d, z28.d}, p6, [x29, #-24, mul vl]");
+  TEST_SINGLE(st3d(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6, Reg::r29, 21), "st3d {z26.d, z27.d, z28.d}, p6, [x29, #21, mul vl]");
+
+  TEST_SINGLE(st4b(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6, Reg::r29, 0), "st4b {z26.b, z27.b, z28.b, z29.b}, p6, [x29]");
+  TEST_SINGLE(st4b(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6, Reg::r29, -32), "st4b {z26.b, z27.b, z28.b, z29.b}, p6, [x29, #-32, mul vl]");
+  TEST_SINGLE(st4b(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6, Reg::r29, 28), "st4b {z26.b, z27.b, z28.b, z29.b}, p6, [x29, #28, mul vl]");
+
+  TEST_SINGLE(st4h(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6, Reg::r29, 0), "st4h {z26.h, z27.h, z28.h, z29.h}, p6, [x29]");
+  TEST_SINGLE(st4h(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6, Reg::r29, -32), "st4h {z26.h, z27.h, z28.h, z29.h}, p6, [x29, #-32, mul vl]");
+  TEST_SINGLE(st4h(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6, Reg::r29, 28), "st4h {z26.h, z27.h, z28.h, z29.h}, p6, [x29, #28, mul vl]");
+
+  TEST_SINGLE(st4w(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6, Reg::r29, 0), "st4w {z26.s, z27.s, z28.s, z29.s}, p6, [x29]");
+  TEST_SINGLE(st4w(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6, Reg::r29, -32), "st4w {z26.s, z27.s, z28.s, z29.s}, p6, [x29, #-32, mul vl]");
+  TEST_SINGLE(st4w(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6, Reg::r29, 28), "st4w {z26.s, z27.s, z28.s, z29.s}, p6, [x29, #28, mul vl]");
+
+  TEST_SINGLE(st4d(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6, Reg::r29, 0), "st4d {z26.d, z27.d, z28.d, z29.d}, p6, [x29]");
+  TEST_SINGLE(st4d(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6, Reg::r29, -32), "st4d {z26.d, z27.d, z28.d, z29.d}, p6, [x29, #-32, mul vl]");
+  TEST_SINGLE(st4d(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6, Reg::r29, 28), "st4d {z26.d, z27.d, z28.d, z29.d}, p6, [x29, #28, mul vl]");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE contiguous store (scalar plus immediate)") {
+  TEST_SINGLE(st1b<SubRegSize::i8Bit>(ZReg::z26, PReg::p6, Reg::r29, 0), "st1b {z26.b}, p6, [x29]");
+  TEST_SINGLE(st1b<SubRegSize::i16Bit>(ZReg::z26, PReg::p6, Reg::r29, 0), "st1b {z26.h}, p6, [x29]");
+  TEST_SINGLE(st1b<SubRegSize::i32Bit>(ZReg::z26, PReg::p6, Reg::r29, 0), "st1b {z26.s}, p6, [x29]");
+  TEST_SINGLE(st1b<SubRegSize::i64Bit>(ZReg::z26, PReg::p6, Reg::r29, 0), "st1b {z26.d}, p6, [x29]");
+
+  TEST_SINGLE(st1b<SubRegSize::i8Bit>(ZReg::z26, PReg::p6, Reg::r29, -8), "st1b {z26.b}, p6, [x29, #-8, mul vl]");
+  TEST_SINGLE(st1b<SubRegSize::i16Bit>(ZReg::z26, PReg::p6, Reg::r29, -8), "st1b {z26.h}, p6, [x29, #-8, mul vl]");
+  TEST_SINGLE(st1b<SubRegSize::i32Bit>(ZReg::z26, PReg::p6, Reg::r29, -8), "st1b {z26.s}, p6, [x29, #-8, mul vl]");
+  TEST_SINGLE(st1b<SubRegSize::i64Bit>(ZReg::z26, PReg::p6, Reg::r29, -8), "st1b {z26.d}, p6, [x29, #-8, mul vl]");
+
+  TEST_SINGLE(st1b<SubRegSize::i8Bit>(ZReg::z26, PReg::p6, Reg::r29, 7), "st1b {z26.b}, p6, [x29, #7, mul vl]");
+  TEST_SINGLE(st1b<SubRegSize::i16Bit>(ZReg::z26, PReg::p6, Reg::r29, 7), "st1b {z26.h}, p6, [x29, #7, mul vl]");
+  TEST_SINGLE(st1b<SubRegSize::i32Bit>(ZReg::z26, PReg::p6, Reg::r29, 7), "st1b {z26.s}, p6, [x29, #7, mul vl]");
+  TEST_SINGLE(st1b<SubRegSize::i64Bit>(ZReg::z26, PReg::p6, Reg::r29, 7), "st1b {z26.d}, p6, [x29, #7, mul vl]");
+
+  //TEST_SINGLE(st1h<SubRegSize::i8Bit>(ZReg::z26, PReg::p6, Reg::r29, 0), "st1h {z26.b}, p6, [x29]");
+  TEST_SINGLE(st1h<SubRegSize::i16Bit>(ZReg::z26, PReg::p6, Reg::r29, 0), "st1h {z26.h}, p6, [x29]");
+  TEST_SINGLE(st1h<SubRegSize::i32Bit>(ZReg::z26, PReg::p6, Reg::r29, 0), "st1h {z26.s}, p6, [x29]");
+  TEST_SINGLE(st1h<SubRegSize::i64Bit>(ZReg::z26, PReg::p6, Reg::r29, 0), "st1h {z26.d}, p6, [x29]");
+
+  //TEST_SINGLE(st1h<SubRegSize::i8Bit>(ZReg::z26, PReg::p6, Reg::r29, -8), "st1h {z26.b}, p6, [x29, #-8, mul vl]");
+  TEST_SINGLE(st1h<SubRegSize::i16Bit>(ZReg::z26, PReg::p6, Reg::r29, -8), "st1h {z26.h}, p6, [x29, #-8, mul vl]");
+  TEST_SINGLE(st1h<SubRegSize::i32Bit>(ZReg::z26, PReg::p6, Reg::r29, -8), "st1h {z26.s}, p6, [x29, #-8, mul vl]");
+  TEST_SINGLE(st1h<SubRegSize::i64Bit>(ZReg::z26, PReg::p6, Reg::r29, -8), "st1h {z26.d}, p6, [x29, #-8, mul vl]");
+
+  //TEST_SINGLE(st1h<SubRegSize::i8Bit>(ZReg::z26, PReg::p6, Reg::r29, 7), "st1h {z26.b}, p6, [x29, #7, mul vl]");
+  TEST_SINGLE(st1h<SubRegSize::i16Bit>(ZReg::z26, PReg::p6, Reg::r29, 7), "st1h {z26.h}, p6, [x29, #7, mul vl]");
+  TEST_SINGLE(st1h<SubRegSize::i32Bit>(ZReg::z26, PReg::p6, Reg::r29, 7), "st1h {z26.s}, p6, [x29, #7, mul vl]");
+  TEST_SINGLE(st1h<SubRegSize::i64Bit>(ZReg::z26, PReg::p6, Reg::r29, 7), "st1h {z26.d}, p6, [x29, #7, mul vl]");
+
+  //TEST_SINGLE(st1w<SubRegSize::i8Bit>(ZReg::z26, PReg::p6, Reg::r29, 0), "st1w {z26.b}, p6, [x29]");
+  //TEST_SINGLE(st1w<SubRegSize::i16Bit>(ZReg::z26, PReg::p6, Reg::r29, 0), "st1w {z26.h}, p6, [x29]");
+  TEST_SINGLE(st1w<SubRegSize::i32Bit>(ZReg::z26, PReg::p6, Reg::r29, 0), "st1w {z26.s}, p6, [x29]");
+  TEST_SINGLE(st1w<SubRegSize::i64Bit>(ZReg::z26, PReg::p6, Reg::r29, 0), "st1w {z26.d}, p6, [x29]");
+
+  //TEST_SINGLE(st1w<SubRegSize::i8Bit>(ZReg::z26, PReg::p6, Reg::r29, -8), "st1w {z26.b}, p6, [x29, #-8, mul vl]");
+  //TEST_SINGLE(st1w<SubRegSize::i16Bit>(ZReg::z26, PReg::p6, Reg::r29, -8), "st1w {z26.h}, p6, [x29, #-8, mul vl]");
+  TEST_SINGLE(st1w<SubRegSize::i32Bit>(ZReg::z26, PReg::p6, Reg::r29, -8), "st1w {z26.s}, p6, [x29, #-8, mul vl]");
+  TEST_SINGLE(st1w<SubRegSize::i64Bit>(ZReg::z26, PReg::p6, Reg::r29, -8), "st1w {z26.d}, p6, [x29, #-8, mul vl]");
+
+  //TEST_SINGLE(st1w<SubRegSize::i8Bit>(ZReg::z26, PReg::p6, Reg::r29, 7), "st1w {z26.b}, p6, [x29, #7, mul vl]");
+  //TEST_SINGLE(st1w<SubRegSize::i16Bit>(ZReg::z26, PReg::p6, Reg::r29, 7), "st1w {z26.h}, p6, [x29, #7, mul vl]");
+  TEST_SINGLE(st1w<SubRegSize::i32Bit>(ZReg::z26, PReg::p6, Reg::r29, 7), "st1w {z26.s}, p6, [x29, #7, mul vl]");
+  TEST_SINGLE(st1w<SubRegSize::i64Bit>(ZReg::z26, PReg::p6, Reg::r29, 7), "st1w {z26.d}, p6, [x29, #7, mul vl]");
+
+  TEST_SINGLE(st1d(ZReg::z26, PReg::p6, Reg::r29, 0), "st1d {z26.d}, p6, [x29]");
+  TEST_SINGLE(st1d(ZReg::z26, PReg::p6, Reg::r29, -8), "st1d {z26.d}, p6, [x29, #-8, mul vl]");
+  TEST_SINGLE(st1d(ZReg::z26, PReg::p6, Reg::r29, 7), "st1d {z26.d}, p6, [x29, #7, mul vl]");
+}

--- a/External/FEXCore/unittests/Emitter/Scalar_Tests.cpp
+++ b/External/FEXCore/unittests/Emitter/Scalar_Tests.cpp
@@ -1,0 +1,852 @@
+#include "TestDisassembler.h"
+
+#include <catch2/catch.hpp>
+#include <fcntl.h>
+
+using namespace FEXCore::ARMEmitter;
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Scalar: Advanced SIMD scalar copy") {
+  TEST_SINGLE(dup(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, 0), "mov b30, v29.b[0]");
+  TEST_SINGLE(dup(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, 15), "mov b30, v29.b[15]");
+  TEST_SINGLE(mov(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, 0), "mov b30, v29.b[0]");
+  TEST_SINGLE(mov(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, 15), "mov b30, v29.b[15]");
+
+  TEST_SINGLE(dup(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, 0), "mov h30, v29.h[0]");
+  TEST_SINGLE(dup(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, 7), "mov h30, v29.h[7]");
+  TEST_SINGLE(mov(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, 0), "mov h30, v29.h[0]");
+  TEST_SINGLE(mov(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, 7), "mov h30, v29.h[7]");
+
+  TEST_SINGLE(dup(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, 0), "mov s30, v29.s[0]");
+  TEST_SINGLE(dup(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, 3), "mov s30, v29.s[3]");
+  TEST_SINGLE(mov(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, 0), "mov s30, v29.s[0]");
+  TEST_SINGLE(mov(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, 3), "mov s30, v29.s[3]");
+
+  TEST_SINGLE(dup(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, 0), "mov d30, v29.d[0]");
+  TEST_SINGLE(dup(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, 1), "mov d30, v29.d[1]");
+  TEST_SINGLE(mov(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, 0), "mov d30, v29.d[0]");
+  TEST_SINGLE(mov(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, 1), "mov d30, v29.d[1]");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Scalar: Advanced SIMD scalar three same FP16") {
+  TEST_SINGLE(fmulx(HReg::h30, HReg::h29, HReg::h28), "fmulx h30, h29, h28");
+  TEST_SINGLE(fcmeq(HReg::h30, HReg::h29, HReg::h28), "fcmeq h30, h29, h28");
+  TEST_SINGLE(frecps(HReg::h30, HReg::h29, HReg::h28), "frecps h30, h29, h28");
+  TEST_SINGLE(frsqrts(HReg::h30, HReg::h29, HReg::h28), "frsqrts h30, h29, h28");
+  TEST_SINGLE(fcmge(HReg::h30, HReg::h29, HReg::h28), "fcmge h30, h29, h28");
+  TEST_SINGLE(facge(HReg::h30, HReg::h29, HReg::h28), "facge h30, h29, h28");
+  TEST_SINGLE(fabd(HReg::h30, HReg::h29, HReg::h28), "fabd h30, h29, h28");
+  TEST_SINGLE(fcmgt(HReg::h30, HReg::h29, HReg::h28), "fcmgt h30, h29, h28");
+  TEST_SINGLE(facgt(HReg::h30, HReg::h29, HReg::h28), "facgt h30, h29, h28");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Scalar: Advanced SIMD scalar two-register miscellaneous FP16") {
+  TEST_SINGLE(fcvtns(HReg::h30, HReg::h29), "fcvtns h30, h29");
+  TEST_SINGLE(fcvtms(HReg::h30, HReg::h29), "fcvtms h30, h29");
+  TEST_SINGLE(fcvtas(HReg::h30, HReg::h29), "fcvtas h30, h29");
+  TEST_SINGLE(scvtf(HReg::h30, HReg::h29), "scvtf h30, h29");
+  TEST_SINGLE(fcmgt(HReg::h30, HReg::h29), "fcmgt h30, h29, #0.0");
+  TEST_SINGLE(fcmeq(HReg::h30, HReg::h29), "fcmeq h30, h29, #0.0");
+  TEST_SINGLE(fcmlt(HReg::h30, HReg::h29), "fcmlt h30, h29, #0.0");
+  TEST_SINGLE(fcvtps(HReg::h30, HReg::h29), "fcvtps h30, h29");
+  TEST_SINGLE(fcvtzs(HReg::h30, HReg::h29), "fcvtzs h30, h29");
+  TEST_SINGLE(frecpe(HReg::h30, HReg::h29), "frecpe h30, h29");
+  TEST_SINGLE(frecpx(HReg::h30, HReg::h29), "frecpx h30, h29");
+  TEST_SINGLE(fcvtnu(HReg::h30, HReg::h29), "fcvtnu h30, h29");
+  TEST_SINGLE(fcvtmu(HReg::h30, HReg::h29), "fcvtmu h30, h29");
+  TEST_SINGLE(fcvtau(HReg::h30, HReg::h29), "fcvtau h30, h29");
+  TEST_SINGLE(ucvtf(HReg::h30, HReg::h29), "ucvtf h30, h29");
+  TEST_SINGLE(fcmge(HReg::h30, HReg::h29), "fcmge h30, h29, #0.0");
+  TEST_SINGLE(fcmle(HReg::h30, HReg::h29), "fcmle h30, h29, #0.0");
+  TEST_SINGLE(fcvtpu(HReg::h30, HReg::h29), "fcvtpu h30, h29");
+  TEST_SINGLE(fcvtzu(HReg::h30, HReg::h29), "fcvtzu h30, h29");
+  TEST_SINGLE(frsqrte(HReg::h30, HReg::h29), "frsqrte h30, h29");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Scalar: Advanced SIMD scalar three same extra") {
+  // TODO: Implement in emitter
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Scalar: Advanced SIMD scalar two-register miscellaneous") {
+  // Commented out lines showcase unallocated encodings.
+  TEST_SINGLE(suqadd(ScalarRegSize::i8Bit, VReg::v30, VReg::v29),  "suqadd b30, b29");
+  TEST_SINGLE(suqadd(ScalarRegSize::i16Bit, VReg::v30, VReg::v29), "suqadd h30, h29");
+  TEST_SINGLE(suqadd(ScalarRegSize::i32Bit, VReg::v30, VReg::v29), "suqadd s30, s29");
+  TEST_SINGLE(suqadd(ScalarRegSize::i64Bit, VReg::v30, VReg::v29), "suqadd d30, d29");
+
+  TEST_SINGLE(sqabs(ScalarRegSize::i8Bit, VReg::v30, VReg::v29),  "sqabs b30, b29");
+  TEST_SINGLE(sqabs(ScalarRegSize::i16Bit, VReg::v30, VReg::v29), "sqabs h30, h29");
+  TEST_SINGLE(sqabs(ScalarRegSize::i32Bit, VReg::v30, VReg::v29), "sqabs s30, s29");
+  TEST_SINGLE(sqabs(ScalarRegSize::i64Bit, VReg::v30, VReg::v29), "sqabs d30, d29");
+
+  //TEST_SINGLE(cmgt(ScalarRegSize::i8Bit, VReg::v30, VReg::v29),  "cmgt b30, b29, #0");
+  //TEST_SINGLE(cmgt(ScalarRegSize::i16Bit, VReg::v30, VReg::v29), "cmgt h30, h29, #0");
+  //TEST_SINGLE(cmgt(ScalarRegSize::i32Bit, VReg::v30, VReg::v29), "cmgt s30, s29, #0");
+  TEST_SINGLE(cmgt(ScalarRegSize::i64Bit, VReg::v30, VReg::v29), "cmgt d30, d29, #0");
+
+  //TEST_SINGLE(cmeq(ScalarRegSize::i8Bit, VReg::v30, VReg::v29),  "cmeq b30, b29, #0");
+  //TEST_SINGLE(cmeq(ScalarRegSize::i16Bit, VReg::v30, VReg::v29), "cmeq h30, h29, #0");
+  //TEST_SINGLE(cmeq(ScalarRegSize::i32Bit, VReg::v30, VReg::v29), "cmeq s30, s29, #0");
+  TEST_SINGLE(cmeq(ScalarRegSize::i64Bit, VReg::v30, VReg::v29), "cmeq d30, d29, #0");
+
+  //TEST_SINGLE(cmlt(ScalarRegSize::i8Bit, VReg::v30, VReg::v29),  "cmlt b30, b29, #0");
+  //TEST_SINGLE(cmlt(ScalarRegSize::i16Bit, VReg::v30, VReg::v29), "cmlt h30, h29, #0");
+  //TEST_SINGLE(cmlt(ScalarRegSize::i32Bit, VReg::v30, VReg::v29), "cmlt s30, s29, #0");
+  TEST_SINGLE(cmlt(ScalarRegSize::i64Bit, VReg::v30, VReg::v29), "cmlt d30, d29, #0");
+
+  //TEST_SINGLE(abs(ScalarRegSize::i8Bit, VReg::v30, VReg::v29),  "abs b30, b29");
+  //TEST_SINGLE(abs(ScalarRegSize::i16Bit, VReg::v30, VReg::v29), "abs h30, h29");
+  //TEST_SINGLE(abs(ScalarRegSize::i32Bit, VReg::v30, VReg::v29), "abs s30, s29");
+  TEST_SINGLE(abs(ScalarRegSize::i64Bit, VReg::v30, VReg::v29), "abs d30, d29");
+
+  TEST_SINGLE(sqxtn(ScalarRegSize::i8Bit, VReg::v30, VReg::v29),  "sqxtn b30, h29");
+  TEST_SINGLE(sqxtn(ScalarRegSize::i16Bit, VReg::v30, VReg::v29), "sqxtn h30, s29");
+  TEST_SINGLE(sqxtn(ScalarRegSize::i32Bit, VReg::v30, VReg::v29), "sqxtn s30, d29");
+  //TEST_SINGLE(sqxtn(ScalarRegSize::i64Bit, VReg::v30, VReg::v29), "sqxtn d30, d29");
+
+  //TEST_SINGLE(fcvtns(ScalarRegSize::i8Bit, VReg::v30, VReg::v29),  "fcvtns b30, b29");
+  //TEST_SINGLE(fcvtns(ScalarRegSize::i16Bit, VReg::v30, VReg::v29), "fcvtns h30, h29");
+  TEST_SINGLE(fcvtns(ScalarRegSize::i32Bit, VReg::v30, VReg::v29), "fcvtns s30, s29");
+  TEST_SINGLE(fcvtns(ScalarRegSize::i64Bit, VReg::v30, VReg::v29), "fcvtns d30, d29");
+
+  //TEST_SINGLE(fcvtms(ScalarRegSize::i8Bit, VReg::v30, VReg::v29),  "fcvtms b30, b29");
+  //TEST_SINGLE(fcvtms(ScalarRegSize::i16Bit, VReg::v30, VReg::v29), "fcvtms h30, h29");
+  TEST_SINGLE(fcvtms(ScalarRegSize::i32Bit, VReg::v30, VReg::v29), "fcvtms s30, s29");
+  TEST_SINGLE(fcvtms(ScalarRegSize::i64Bit, VReg::v30, VReg::v29), "fcvtms d30, d29");
+
+  //TEST_SINGLE(fcvtas(ScalarRegSize::i8Bit, VReg::v30, VReg::v29),  "fcvtas b30, b29");
+  //TEST_SINGLE(fcvtas(ScalarRegSize::i16Bit, VReg::v30, VReg::v29), "fcvtas h30, h29");
+  TEST_SINGLE(fcvtas(ScalarRegSize::i32Bit, VReg::v30, VReg::v29), "fcvtas s30, s29");
+  TEST_SINGLE(fcvtas(ScalarRegSize::i64Bit, VReg::v30, VReg::v29), "fcvtas d30, d29");
+
+  //TEST_SINGLE(scvtf(ScalarRegSize::i8Bit, VReg::v30, VReg::v29),  "scvtf b30, b29");
+  //TEST_SINGLE(scvtf(ScalarRegSize::i16Bit, VReg::v30, VReg::v29), "scvtf h30, h29");
+  TEST_SINGLE(scvtf(ScalarRegSize::i32Bit, VReg::v30, VReg::v29), "scvtf s30, s29");
+  TEST_SINGLE(scvtf(ScalarRegSize::i64Bit, VReg::v30, VReg::v29), "scvtf d30, d29");
+
+  //TEST_SINGLE(fcmeq(ScalarRegSize::i8Bit, VReg::v30, VReg::v29),  "fcmeq b30, b29");
+  //TEST_SINGLE(fcmeq(ScalarRegSize::i16Bit, VReg::v30, VReg::v29), "fcmeq h30, h29");
+  TEST_SINGLE(fcmeq(ScalarRegSize::i32Bit, VReg::v30, VReg::v29), "fcmeq s30, s29, #0.0");
+  TEST_SINGLE(fcmeq(ScalarRegSize::i64Bit, VReg::v30, VReg::v29), "fcmeq d30, d29, #0.0");
+
+  //TEST_SINGLE(fcmlt(ScalarRegSize::i8Bit, VReg::v30, VReg::v29),  "fcmlt b30, b29");
+  //TEST_SINGLE(fcmlt(ScalarRegSize::i16Bit, VReg::v30, VReg::v29), "fcmlt h30, h29");
+  TEST_SINGLE(fcmlt(ScalarRegSize::i32Bit, VReg::v30, VReg::v29), "fcmlt s30, s29, #0.0");
+  TEST_SINGLE(fcmlt(ScalarRegSize::i64Bit, VReg::v30, VReg::v29), "fcmlt d30, d29, #0.0");
+
+  //TEST_SINGLE(fcvtps(ScalarRegSize::i8Bit, VReg::v30, VReg::v29),  "fcvtps b30, b29");
+  //TEST_SINGLE(fcvtps(ScalarRegSize::i16Bit, VReg::v30, VReg::v29), "fcvtps h30, h29");
+  TEST_SINGLE(fcvtps(ScalarRegSize::i32Bit, VReg::v30, VReg::v29), "fcvtps s30, s29");
+  TEST_SINGLE(fcvtps(ScalarRegSize::i64Bit, VReg::v30, VReg::v29), "fcvtps d30, d29");
+
+  //TEST_SINGLE(fcvtzs(ScalarRegSize::i8Bit, VReg::v30, VReg::v29),  "fcvtzs b30, b29");
+  //TEST_SINGLE(fcvtzs(ScalarRegSize::i16Bit, VReg::v30, VReg::v29), "fcvtzs h30, h29");
+  TEST_SINGLE(fcvtzs(ScalarRegSize::i32Bit, VReg::v30, VReg::v29), "fcvtzs s30, s29");
+  TEST_SINGLE(fcvtzs(ScalarRegSize::i64Bit, VReg::v30, VReg::v29), "fcvtzs d30, d29");
+
+  //TEST_SINGLE(frecpe(ScalarRegSize::i8Bit, VReg::v30, VReg::v29),  "frecpe b30, b29");
+  //TEST_SINGLE(frecpe(ScalarRegSize::i16Bit, VReg::v30, VReg::v29), "frecpe h30, h29");
+  TEST_SINGLE(frecpe(ScalarRegSize::i32Bit, VReg::v30, VReg::v29), "frecpe s30, s29");
+  TEST_SINGLE(frecpe(ScalarRegSize::i64Bit, VReg::v30, VReg::v29), "frecpe d30, d29");
+
+  //TEST_SINGLE(frecpx(ScalarRegSize::i8Bit, VReg::v30, VReg::v29),  "frecpx b30, b29");
+  //TEST_SINGLE(frecpx(ScalarRegSize::i16Bit, VReg::v30, VReg::v29), "frecpx h30, h29");
+  TEST_SINGLE(frecpx(ScalarRegSize::i32Bit, VReg::v30, VReg::v29), "frecpx s30, s29");
+  TEST_SINGLE(frecpx(ScalarRegSize::i64Bit, VReg::v30, VReg::v29), "frecpx d30, d29");
+
+  TEST_SINGLE(usqadd(ScalarRegSize::i8Bit, VReg::v30, VReg::v29),  "usqadd b30, b29");
+  TEST_SINGLE(usqadd(ScalarRegSize::i16Bit, VReg::v30, VReg::v29), "usqadd h30, h29");
+  TEST_SINGLE(usqadd(ScalarRegSize::i32Bit, VReg::v30, VReg::v29), "usqadd s30, s29");
+  TEST_SINGLE(usqadd(ScalarRegSize::i64Bit, VReg::v30, VReg::v29), "usqadd d30, d29");
+
+  TEST_SINGLE(sqneg(ScalarRegSize::i8Bit, VReg::v30, VReg::v29),  "sqneg b30, b29");
+  TEST_SINGLE(sqneg(ScalarRegSize::i16Bit, VReg::v30, VReg::v29), "sqneg h30, h29");
+  TEST_SINGLE(sqneg(ScalarRegSize::i32Bit, VReg::v30, VReg::v29), "sqneg s30, s29");
+  TEST_SINGLE(sqneg(ScalarRegSize::i64Bit, VReg::v30, VReg::v29), "sqneg d30, d29");
+
+  //TEST_SINGLE(cmge(ScalarRegSize::i8Bit, VReg::v30, VReg::v29),  "cmge b30, b29");
+  //TEST_SINGLE(cmge(ScalarRegSize::i16Bit, VReg::v30, VReg::v29), "cmge h30, h29");
+  //TEST_SINGLE(cmge(ScalarRegSize::i32Bit, VReg::v30, VReg::v29), "cmge s30, s29");
+  TEST_SINGLE(cmge(ScalarRegSize::i64Bit, VReg::v30, VReg::v29), "cmge d30, d29, #0");
+
+  //TEST_SINGLE(cmle(ScalarRegSize::i8Bit, VReg::v30, VReg::v29),  "cmle b30, b29");
+  //TEST_SINGLE(cmle(ScalarRegSize::i16Bit, VReg::v30, VReg::v29), "cmle h30, h29");
+  //TEST_SINGLE(cmle(ScalarRegSize::i32Bit, VReg::v30, VReg::v29), "cmle s30, s29");
+  TEST_SINGLE(cmle(ScalarRegSize::i64Bit, VReg::v30, VReg::v29), "cmle d30, d29, #0");
+
+  //TEST_SINGLE(neg(ScalarRegSize::i8Bit, VReg::v30, VReg::v29),  "neg b30, b29");
+  //TEST_SINGLE(neg(ScalarRegSize::i16Bit, VReg::v30, VReg::v29), "neg h30, h29");
+  //TEST_SINGLE(neg(ScalarRegSize::i32Bit, VReg::v30, VReg::v29), "neg s30, s29");
+  TEST_SINGLE(neg(ScalarRegSize::i64Bit, VReg::v30, VReg::v29), "neg d30, d29");
+
+  TEST_SINGLE(sqxtun(ScalarRegSize::i8Bit, VReg::v30, VReg::v29),  "sqxtun b30, h29");
+  TEST_SINGLE(sqxtun(ScalarRegSize::i16Bit, VReg::v30, VReg::v29), "sqxtun h30, s29");
+  TEST_SINGLE(sqxtun(ScalarRegSize::i32Bit, VReg::v30, VReg::v29), "sqxtun s30, d29");
+  //TEST_SINGLE(sqxtun(ScalarRegSize::i64Bit, VReg::v30, VReg::v29), "sqxtun d30, d29");
+
+  TEST_SINGLE(uqxtn(ScalarRegSize::i8Bit, VReg::v30, VReg::v29),  "uqxtn b30, h29");
+  TEST_SINGLE(uqxtn(ScalarRegSize::i16Bit, VReg::v30, VReg::v29), "uqxtn h30, s29");
+  TEST_SINGLE(uqxtn(ScalarRegSize::i32Bit, VReg::v30, VReg::v29), "uqxtn s30, d29");
+  //TEST_SINGLE(uqxtn(ScalarRegSize::i64Bit, VReg::v30, VReg::v29), "uqxtn d30, d29");
+
+  //TEST_SINGLE(fcvtxn(ScalarRegSize::i8Bit, VReg::v30, VReg::v29),  "fcvtxn b30, b29");
+  //TEST_SINGLE(fcvtxn(ScalarRegSize::i16Bit, VReg::v30, VReg::v29), "fcvtxn h30, h29");
+  TEST_SINGLE(fcvtxn(ScalarRegSize::i32Bit, VReg::v30, VReg::v29), "fcvtxn s30, d29");
+  //TEST_SINGLE(fcvtxn(ScalarRegSize::i64Bit, VReg::v30, VReg::v29), "fcvtxn d30, d29");
+
+  //TEST_SINGLE(fcvtnu(ScalarRegSize::i8Bit, VReg::v30, VReg::v29),  "fcvtnu b30, b29");
+  //TEST_SINGLE(fcvtnu(ScalarRegSize::i16Bit, VReg::v30, VReg::v29), "fcvtnu h30, h29");
+  TEST_SINGLE(fcvtnu(ScalarRegSize::i32Bit, VReg::v30, VReg::v29), "fcvtnu s30, s29");
+  TEST_SINGLE(fcvtnu(ScalarRegSize::i64Bit, VReg::v30, VReg::v29), "fcvtnu d30, d29");
+
+  //TEST_SINGLE(fcvtmu(ScalarRegSize::i8Bit, VReg::v30, VReg::v29),  "fcvtmu b30, b29");
+  //TEST_SINGLE(fcvtmu(ScalarRegSize::i16Bit, VReg::v30, VReg::v29), "fcvtmu h30, h29");
+  TEST_SINGLE(fcvtmu(ScalarRegSize::i32Bit, VReg::v30, VReg::v29), "fcvtmu s30, s29");
+  TEST_SINGLE(fcvtmu(ScalarRegSize::i64Bit, VReg::v30, VReg::v29), "fcvtmu d30, d29");
+
+  //TEST_SINGLE(fcvtau(ScalarRegSize::i8Bit, VReg::v30, VReg::v29),  "fcvtau b30, b29");
+  //TEST_SINGLE(fcvtau(ScalarRegSize::i16Bit, VReg::v30, VReg::v29), "fcvtau h30, h29");
+  TEST_SINGLE(fcvtau(ScalarRegSize::i32Bit, VReg::v30, VReg::v29), "fcvtau s30, s29");
+  TEST_SINGLE(fcvtau(ScalarRegSize::i64Bit, VReg::v30, VReg::v29), "fcvtau d30, d29");
+
+  //TEST_SINGLE(ucvtf(ScalarRegSize::i8Bit, VReg::v30, VReg::v29),  "ucvtf b30, b29");
+  //TEST_SINGLE(ucvtf(ScalarRegSize::i16Bit, VReg::v30, VReg::v29), "ucvtf h30, h29");
+  TEST_SINGLE(ucvtf(ScalarRegSize::i32Bit, VReg::v30, VReg::v29), "ucvtf s30, s29");
+  TEST_SINGLE(ucvtf(ScalarRegSize::i64Bit, VReg::v30, VReg::v29), "ucvtf d30, d29");
+
+  //TEST_SINGLE(fcmge(ScalarRegSize::i8Bit, VReg::v30, VReg::v29),  "fcmge b30, b29");
+  //TEST_SINGLE(fcmge(ScalarRegSize::i16Bit, VReg::v30, VReg::v29), "fcmge h30, h29");
+  TEST_SINGLE(fcmge(ScalarRegSize::i32Bit, VReg::v30, VReg::v29), "fcmge s30, s29, #0.0");
+  TEST_SINGLE(fcmge(ScalarRegSize::i64Bit, VReg::v30, VReg::v29), "fcmge d30, d29, #0.0");
+
+  //TEST_SINGLE(fcmle(ScalarRegSize::i8Bit, VReg::v30, VReg::v29),  "fcmle b30, b29");
+  //TEST_SINGLE(fcmle(ScalarRegSize::i16Bit, VReg::v30, VReg::v29), "fcmle h30, h29");
+  TEST_SINGLE(fcmle(ScalarRegSize::i32Bit, VReg::v30, VReg::v29), "fcmle s30, s29, #0.0");
+  TEST_SINGLE(fcmle(ScalarRegSize::i64Bit, VReg::v30, VReg::v29), "fcmle d30, d29, #0.0");
+
+  //TEST_SINGLE(fcvtpu(ScalarRegSize::i8Bit, VReg::v30, VReg::v29),  "fcvtpu b30, b29");
+  //TEST_SINGLE(fcvtpu(ScalarRegSize::i16Bit, VReg::v30, VReg::v29), "fcvtpu h30, h29");
+  TEST_SINGLE(fcvtpu(ScalarRegSize::i32Bit, VReg::v30, VReg::v29), "fcvtpu s30, s29");
+  TEST_SINGLE(fcvtpu(ScalarRegSize::i64Bit, VReg::v30, VReg::v29), "fcvtpu d30, d29");
+
+  //TEST_SINGLE(fcvtzu(ScalarRegSize::i8Bit, VReg::v30, VReg::v29),  "fcvtzu b30, b29");
+  //TEST_SINGLE(fcvtzu(ScalarRegSize::i16Bit, VReg::v30, VReg::v29), "fcvtzu h30, h29");
+  TEST_SINGLE(fcvtzu(ScalarRegSize::i32Bit, VReg::v30, VReg::v29), "fcvtzu s30, s29");
+  TEST_SINGLE(fcvtzu(ScalarRegSize::i64Bit, VReg::v30, VReg::v29), "fcvtzu d30, d29");
+
+  //TEST_SINGLE(frsqrte(ScalarRegSize::i8Bit, VReg::v30, VReg::v29),  "frsqrte b30, b29");
+  //TEST_SINGLE(frsqrte(ScalarRegSize::i16Bit, VReg::v30, VReg::v29), "frsqrte h30, h29");
+  TEST_SINGLE(frsqrte(ScalarRegSize::i32Bit, VReg::v30, VReg::v29), "frsqrte s30, s29");
+  TEST_SINGLE(frsqrte(ScalarRegSize::i64Bit, VReg::v30, VReg::v29), "frsqrte d30, d29");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Scalar: Advanced SIMD scalar pairwise") {
+  // Commented out lines showcase unallocated encodings.
+  //TEST_SINGLE(addp(ScalarRegSize::i8Bit, VReg::v30, VReg::v29),  "addp b30, b29");
+  //TEST_SINGLE(addp(ScalarRegSize::i16Bit, VReg::v30, VReg::v29), "addp h30, h29");
+  //TEST_SINGLE(addp(ScalarRegSize::i32Bit, VReg::v30, VReg::v29), "addp s30, s29");
+  TEST_SINGLE(addp(ScalarRegSize::i64Bit, VReg::v30, VReg::v29), "addp d30, v29.2d");
+
+  TEST_SINGLE(fmaxnmp(HReg::h30, HReg::h29),  "fmaxnmp h30, v29.2h");
+  //TEST_SINGLE(fmaxnmp(ScalarRegSize::i8Bit, VReg::v30, VReg::v29),  "fmaxnmp b30, b29");
+  //TEST_SINGLE(fmaxnmp(ScalarRegSize::i16Bit, VReg::v30, VReg::v29), "fmaxnmp h30, h29");
+  TEST_SINGLE(fmaxnmp(ScalarRegSize::i32Bit, VReg::v30, VReg::v29), "fmaxnmp s30, v29.2s");
+  TEST_SINGLE(fmaxnmp(ScalarRegSize::i64Bit, VReg::v30, VReg::v29), "fmaxnmp d30, v29.2d");
+
+  TEST_SINGLE(faddp(HReg::h30, HReg::h29),  "faddp h30, v29.2h");
+  //TEST_SINGLE(faddp(ScalarRegSize::i8Bit, VReg::v30, VReg::v29),  "faddp b30, b29");
+  //TEST_SINGLE(faddp(ScalarRegSize::i16Bit, VReg::v30, VReg::v29), "faddp h30, h29");
+  TEST_SINGLE(faddp(ScalarRegSize::i32Bit, VReg::v30, VReg::v29), "faddp s30, v29.2s");
+  TEST_SINGLE(faddp(ScalarRegSize::i64Bit, VReg::v30, VReg::v29), "faddp d30, v29.2d");
+
+  TEST_SINGLE(fmaxp(HReg::h30, HReg::h29),  "fmaxp h30, v29.2h");
+  //TEST_SINGLE(fmaxp(ScalarRegSize::i8Bit, VReg::v30, VReg::v29),  "fmaxp b30, b29");
+  //TEST_SINGLE(fmaxp(ScalarRegSize::i16Bit, VReg::v30, VReg::v29), "fmaxp h30, h29");
+  TEST_SINGLE(fmaxp(ScalarRegSize::i32Bit, VReg::v30, VReg::v29), "fmaxp s30, v29.2s");
+  TEST_SINGLE(fmaxp(ScalarRegSize::i64Bit, VReg::v30, VReg::v29), "fmaxp d30, v29.2d");
+
+  TEST_SINGLE(fminnmp(HReg::h30, HReg::h29),  "fminnmp h30, v29.2h");
+  //TEST_SINGLE(fminnmp(ScalarRegSize::i8Bit, VReg::v30, VReg::v29),  "fminnmp b30, b29");
+  //TEST_SINGLE(fminnmp(ScalarRegSize::i16Bit, VReg::v30, VReg::v29), "fminnmp h30, h29");
+  TEST_SINGLE(fminnmp(ScalarRegSize::i32Bit, VReg::v30, VReg::v29), "fminnmp s30, v29.2s");
+  TEST_SINGLE(fminnmp(ScalarRegSize::i64Bit, VReg::v30, VReg::v29), "fminnmp d30, v29.2d");
+
+  TEST_SINGLE(fminp(HReg::h30, HReg::h29),  "fminp h30, v29.2h");
+  //TEST_SINGLE(fminp(ScalarRegSize::i8Bit, VReg::v30, VReg::v29),  "fminp b30, b29");
+  //TEST_SINGLE(fminp(ScalarRegSize::i16Bit, VReg::v30, VReg::v29), "fminp h30, h29");
+  TEST_SINGLE(fminp(ScalarRegSize::i32Bit, VReg::v30, VReg::v29), "fminp s30, v29.2s");
+  TEST_SINGLE(fminp(ScalarRegSize::i64Bit, VReg::v30, VReg::v29), "fminp d30, v29.2d");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Scalar: Advanced SIMD scalar three different") {
+  // Commented out lines showcase unallocated encodings.
+  //TEST_SINGLE(sqdmlal(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, VReg::v28),  "sqdmlal v30.16b, v29.16b, v28.v16b");
+  //TEST_SINGLE(sqdmlal(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v28), "sqdmlal v30.16b, v29.16b, v28.v16b");
+  TEST_SINGLE(sqdmlal(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28), "sqdmlal s30, h29, h28");
+  TEST_SINGLE(sqdmlal(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28), "sqdmlal d30, s29, s28");
+
+  //TEST_SINGLE(sqdmlsl(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, VReg::v28),  "sqdmlsl v30.16b, v29.16b, v28.v16b");
+  //TEST_SINGLE(sqdmlsl(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v28), "sqdmlsl v30.16b, v29.16b, v28.v16b");
+  TEST_SINGLE(sqdmlsl(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28), "sqdmlsl s30, h29, h28");
+  TEST_SINGLE(sqdmlsl(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28), "sqdmlsl d30, s29, s28");
+
+  //TEST_SINGLE(sqdmull(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, VReg::v28),  "sqdmull v30.16b, v29.16b, v28.v16b");
+  //TEST_SINGLE(sqdmull(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v28), "sqdmull v30.16b, v29.16b, v28.v16b");
+  TEST_SINGLE(sqdmull(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28), "sqdmull s30, h29, h28");
+  TEST_SINGLE(sqdmull(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28), "sqdmull d30, s29, s28");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Scalar: Advanced SIMD scalar three same") {
+  TEST_SINGLE(sqadd(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, VReg::v28), "sqadd b30, b29, b28");
+  TEST_SINGLE(sqadd(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v28), "sqadd h30, h29, h28");
+  TEST_SINGLE(sqadd(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28), "sqadd s30, s29, s28");
+  TEST_SINGLE(sqadd(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28), "sqadd d30, d29, d28");
+
+  TEST_SINGLE(sqsub(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, VReg::v28), "sqsub b30, b29, b28");
+  TEST_SINGLE(sqsub(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v28), "sqsub h30, h29, h28");
+  TEST_SINGLE(sqsub(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28), "sqsub s30, s29, s28");
+  TEST_SINGLE(sqsub(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28), "sqsub d30, d29, d28");
+
+  //TEST_SINGLE(cmgt(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, VReg::v28), "cmgt b30, b29, b28");
+  //TEST_SINGLE(cmgt(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v28), "cmgt h30, h29, h28");
+  //TEST_SINGLE(cmgt(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28), "cmgt s30, s29, s28");
+  TEST_SINGLE(cmgt(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28), "cmgt d30, d29, d28");
+
+  //TEST_SINGLE(cmge(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, VReg::v28), "cmge b30, b29, b28");
+  //TEST_SINGLE(cmge(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v28), "cmge h30, h29, h28");
+  //TEST_SINGLE(cmge(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28), "cmge s30, s29, s28");
+  TEST_SINGLE(cmge(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28), "cmge d30, d29, d28");
+
+  //TEST_SINGLE(sshl(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, VReg::v28), "sshl b30, b29, b28");
+  //TEST_SINGLE(sshl(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v28), "sshl h30, h29, h28");
+  //TEST_SINGLE(sshl(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28), "sshl s30, s29, s28");
+  TEST_SINGLE(sshl(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28), "sshl d30, d29, d28");
+
+  TEST_SINGLE(sqshl(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, VReg::v28), "sqshl b30, b29, b28");
+  TEST_SINGLE(sqshl(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v28), "sqshl h30, h29, h28");
+  TEST_SINGLE(sqshl(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28), "sqshl s30, s29, s28");
+  TEST_SINGLE(sqshl(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28), "sqshl d30, d29, d28");
+
+  //TEST_SINGLE(srshl(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, VReg::v28), "srshl b30, b29, b28");
+  //TEST_SINGLE(srshl(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v28), "srshl h30, h29, h28");
+  //TEST_SINGLE(srshl(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28), "srshl s30, s29, s28");
+  TEST_SINGLE(srshl(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28), "srshl d30, d29, d28");
+
+  TEST_SINGLE(sqrshl(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, VReg::v28), "sqrshl b30, b29, b28");
+  TEST_SINGLE(sqrshl(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v28), "sqrshl h30, h29, h28");
+  TEST_SINGLE(sqrshl(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28), "sqrshl s30, s29, s28");
+  TEST_SINGLE(sqrshl(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28), "sqrshl d30, d29, d28");
+
+  //TEST_SINGLE(add(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, VReg::v28), "add b30, b29, b28");
+  //TEST_SINGLE(add(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v28), "add h30, h29, h28");
+  //TEST_SINGLE(add(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28), "add s30, s29, s28");
+  TEST_SINGLE(add(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28), "add d30, d29, d28");
+
+  //TEST_SINGLE(cmtst(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, VReg::v28), "cmtst b30, b29, b28");
+  //TEST_SINGLE(cmtst(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v28), "cmtst h30, h29, h28");
+  //TEST_SINGLE(cmtst(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28), "cmtst s30, s29, s28");
+  TEST_SINGLE(cmtst(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28), "cmtst d30, d29, d28");
+
+  //TEST_SINGLE(sqdmulh(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, VReg::v28), "sqdmulh b30, b29, b28");
+  TEST_SINGLE(sqdmulh(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v28), "sqdmulh h30, h29, h28");
+  TEST_SINGLE(sqdmulh(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28), "sqdmulh s30, s29, s28");
+  //TEST_SINGLE(sqdmulh(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28), "sqdmulh d30, d29, d28");
+
+  //TEST_SINGLE(fmulx(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, VReg::v28), "fmulx b30, b29, b28");
+  //TEST_SINGLE(fmulx(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v28), "fmulx h30, h29, h28");
+  TEST_SINGLE(fmulx(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28), "fmulx s30, s29, s28");
+  TEST_SINGLE(fmulx(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28), "fmulx d30, d29, d28");
+
+  //TEST_SINGLE(fcmeq(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, VReg::v28), "fcmeq b30, b29, b28");
+  //TEST_SINGLE(fcmeq(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v28), "fcmeq h30, h29, h28");
+  TEST_SINGLE(fcmeq(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28), "fcmeq s30, s29, s28");
+  TEST_SINGLE(fcmeq(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28), "fcmeq d30, d29, d28");
+
+  //TEST_SINGLE(frecps(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, VReg::v28), "frecps b30, b29, b28");
+  //TEST_SINGLE(frecps(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v28), "frecps h30, h29, h28");
+  TEST_SINGLE(frecps(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28), "frecps s30, s29, s28");
+  TEST_SINGLE(frecps(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28), "frecps d30, d29, d28");
+
+  //TEST_SINGLE(frsqrts(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, VReg::v28), "frsqrts b30, b29, b28");
+  //TEST_SINGLE(frsqrts(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v28), "frsqrts h30, h29, h28");
+  TEST_SINGLE(frsqrts(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28), "frsqrts s30, s29, s28");
+  TEST_SINGLE(frsqrts(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28), "frsqrts d30, d29, d28");
+
+  TEST_SINGLE(uqadd(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, VReg::v28), "uqadd b30, b29, b28");
+  TEST_SINGLE(uqadd(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v28), "uqadd h30, h29, h28");
+  TEST_SINGLE(uqadd(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28), "uqadd s30, s29, s28");
+  TEST_SINGLE(uqadd(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28), "uqadd d30, d29, d28");
+
+  TEST_SINGLE(uqsub(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, VReg::v28), "uqsub b30, b29, b28");
+  TEST_SINGLE(uqsub(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v28), "uqsub h30, h29, h28");
+  TEST_SINGLE(uqsub(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28), "uqsub s30, s29, s28");
+  TEST_SINGLE(uqsub(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28), "uqsub d30, d29, d28");
+
+  //TEST_SINGLE(cmhi(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, VReg::v28), "cmhi b30, b29, b28");
+  //TEST_SINGLE(cmhi(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v28), "cmhi h30, h29, h28");
+  //TEST_SINGLE(cmhi(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28), "cmhi s30, s29, s28");
+  TEST_SINGLE(cmhi(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28), "cmhi d30, d29, d28");
+
+  //TEST_SINGLE(cmhs(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, VReg::v28), "cmhs b30, b29, b28");
+  //TEST_SINGLE(cmhs(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v28), "cmhs h30, h29, h28");
+  //TEST_SINGLE(cmhs(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28), "cmhs s30, s29, s28");
+  TEST_SINGLE(cmhs(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28), "cmhs d30, d29, d28");
+
+  //TEST_SINGLE(ushl(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, VReg::v28), "ushl b30, b29, b28");
+  //TEST_SINGLE(ushl(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v28), "ushl h30, h29, h28");
+  //TEST_SINGLE(ushl(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28), "ushl s30, s29, s28");
+  TEST_SINGLE(ushl(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28), "ushl d30, d29, d28");
+
+  TEST_SINGLE(uqshl(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, VReg::v28), "uqshl b30, b29, b28");
+  TEST_SINGLE(uqshl(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v28), "uqshl h30, h29, h28");
+  TEST_SINGLE(uqshl(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28), "uqshl s30, s29, s28");
+  TEST_SINGLE(uqshl(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28), "uqshl d30, d29, d28");
+
+  //TEST_SINGLE(urshl(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, VReg::v28), "urshl b30, b29, b28");
+  //TEST_SINGLE(urshl(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v28), "urshl h30, h29, h28");
+  //TEST_SINGLE(urshl(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28), "urshl s30, s29, s28");
+  TEST_SINGLE(urshl(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28), "urshl d30, d29, d28");
+
+  TEST_SINGLE(uqrshl(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, VReg::v28), "uqrshl b30, b29, b28");
+  TEST_SINGLE(uqrshl(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v28), "uqrshl h30, h29, h28");
+  TEST_SINGLE(uqrshl(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28), "uqrshl s30, s29, s28");
+  TEST_SINGLE(uqrshl(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28), "uqrshl d30, d29, d28");
+
+  //TEST_SINGLE(sub(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, VReg::v28), "sub b30, b29, b28");
+  //TEST_SINGLE(sub(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v28), "sub h30, h29, h28");
+  //TEST_SINGLE(sub(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28), "sub s30, s29, s28");
+  TEST_SINGLE(sub(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28), "sub d30, d29, d28");
+
+  //TEST_SINGLE(cmeq(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, VReg::v28), "cmeq b30, b29, b28");
+  //TEST_SINGLE(cmeq(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v28), "cmeq h30, h29, h28");
+  //TEST_SINGLE(cmeq(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28), "cmeq s30, s29, s28");
+  TEST_SINGLE(cmeq(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28), "cmeq d30, d29, d28");
+
+  //TEST_SINGLE(sqrdmulh(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, VReg::v28), "sqrdmulh b30, b29, b28");
+  TEST_SINGLE(sqrdmulh(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v28), "sqrdmulh h30, h29, h28");
+  TEST_SINGLE(sqrdmulh(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28), "sqrdmulh s30, s29, s28");
+  //TEST_SINGLE(sqrdmulh(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28), "sqrdmulh d30, d29, d28");
+
+  //TEST_SINGLE(fcmge(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, VReg::v28), "fcmge b30, b29, b28");
+  //TEST_SINGLE(fcmge(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v28), "fcmge h30, h29, h28");
+  TEST_SINGLE(fcmge(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28), "fcmge s30, s29, s28");
+  TEST_SINGLE(fcmge(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28), "fcmge d30, d29, d28");
+
+  //TEST_SINGLE(facge(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, VReg::v28), "facge b30, b29, b28");
+  //TEST_SINGLE(facge(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v28), "facge h30, h29, h28");
+  TEST_SINGLE(facge(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28), "facge s30, s29, s28");
+  TEST_SINGLE(facge(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28), "facge d30, d29, d28");
+
+  //TEST_SINGLE(fabd(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, VReg::v28), "fabd b30, b29, b28");
+  //TEST_SINGLE(fabd(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v28), "fabd h30, h29, h28");
+  TEST_SINGLE(fabd(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28), "fabd s30, s29, s28");
+  TEST_SINGLE(fabd(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28), "fabd d30, d29, d28");
+
+  //TEST_SINGLE(fcmgt(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, VReg::v28), "fcmgt b30, b29, b28");
+  //TEST_SINGLE(fcmgt(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v28), "fcmgt h30, h29, h28");
+  TEST_SINGLE(fcmgt(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28), "fcmgt s30, s29, s28");
+  TEST_SINGLE(fcmgt(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28), "fcmgt d30, d29, d28");
+
+  //TEST_SINGLE(facgt(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, VReg::v28), "facgt b30, b29, b28");
+  //TEST_SINGLE(facgt(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v28), "facgt h30, h29, h28");
+  TEST_SINGLE(facgt(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28), "facgt s30, s29, s28");
+  TEST_SINGLE(facgt(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28), "facgt d30, d29, d28");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Scalar: Advanced SIMD scalar shift by immediate") {
+  // TODO: Implement `UCVTF, FCVTZU' in emitter
+  // TEST_SINGLE(sshr(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, 1),   "sshr b30, b29, #1");
+  // TEST_SINGLE(sshr(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, 7),   "sshr b30, b29, #7");
+  // TEST_SINGLE(sshr(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, 1),  "sshr h30, h29, #1");
+  // TEST_SINGLE(sshr(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, 15), "sshr h30, h29, #15");
+  // TEST_SINGLE(sshr(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, 1),  "sshr s30, s29, #1");
+  // TEST_SINGLE(sshr(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, 31), "sshr s30, s29, #31");
+  TEST_SINGLE(sshr(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, 1),  "sshr d30, d29, #1");
+  TEST_SINGLE(sshr(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, 63), "sshr d30, d29, #63");
+
+  //TEST_SINGLE(ssra(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, 1),   "ssra b30, b29, #1");
+  //TEST_SINGLE(ssra(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, 7),   "ssra b30, b29, #7");
+  //TEST_SINGLE(ssra(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, 1),  "ssra h30, h29, #1");
+  //TEST_SINGLE(ssra(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, 15), "ssra h30, h29, #15");
+  //TEST_SINGLE(ssra(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, 1),  "ssra s30, s29, #1");
+  //TEST_SINGLE(ssra(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, 31), "ssra s30, s29, #31");
+  TEST_SINGLE(ssra(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, 1),  "ssra d30, d29, #1");
+  TEST_SINGLE(ssra(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, 63), "ssra d30, d29, #63");
+
+  //TEST_SINGLE(srshr(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, 1),   "srshr b30, b29, #1");
+  //TEST_SINGLE(srshr(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, 7),   "srshr b30, b29, #7");
+  //TEST_SINGLE(srshr(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, 1),  "srshr h30, h29, #1");
+  //TEST_SINGLE(srshr(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, 15), "srshr h30, h29, #15");
+  //TEST_SINGLE(srshr(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, 1),  "srshr s30, s29, #1");
+  //TEST_SINGLE(srshr(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, 31), "srshr s30, s29, #31");
+  TEST_SINGLE(srshr(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, 1),  "srshr d30, d29, #1");
+  TEST_SINGLE(srshr(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, 63), "srshr d30, d29, #63");
+
+  //TEST_SINGLE(srsra(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, 1),   "srsra b30, b29, #1");
+  //TEST_SINGLE(srsra(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, 7),   "srsra b30, b29, #7");
+  //TEST_SINGLE(srsra(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, 1),  "srsra h30, h29, #1");
+  //TEST_SINGLE(srsra(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, 15), "srsra h30, h29, #15");
+  //TEST_SINGLE(srsra(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, 1),  "srsra s30, s29, #1");
+  //TEST_SINGLE(srsra(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, 31), "srsra s30, s29, #31");
+  TEST_SINGLE(srsra(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, 1),  "srsra d30, d29, #1");
+  TEST_SINGLE(srsra(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, 63), "srsra d30, d29, #63");
+
+  //TEST_SINGLE(shl(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, 1),   "shl b30, b29, #1");
+  //TEST_SINGLE(shl(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, 7),   "shl b30, b29, #7");
+  //TEST_SINGLE(shl(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, 1),  "shl h30, h29, #1");
+  //TEST_SINGLE(shl(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, 15), "shl h30, h29, #15");
+  //TEST_SINGLE(shl(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, 1),  "shl s30, s29, #1");
+  //TEST_SINGLE(shl(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, 31), "shl s30, s29, #31");
+  TEST_SINGLE(shl(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, 1),  "shl d30, d29, #1");
+  TEST_SINGLE(shl(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, 63), "shl d30, d29, #63");
+
+  TEST_SINGLE(sqshl(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, 1),   "sqshl b30, b29, #1");
+  TEST_SINGLE(sqshl(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, 7),   "sqshl b30, b29, #7");
+  TEST_SINGLE(sqshl(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, 1),  "sqshl h30, h29, #1");
+  TEST_SINGLE(sqshl(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, 15), "sqshl h30, h29, #15");
+  TEST_SINGLE(sqshl(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, 1),  "sqshl s30, s29, #1");
+  TEST_SINGLE(sqshl(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, 31), "sqshl s30, s29, #31");
+  TEST_SINGLE(sqshl(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, 1),  "sqshl d30, d29, #1");
+  TEST_SINGLE(sqshl(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, 63), "sqshl d30, d29, #63");
+
+  TEST_SINGLE(sqshrn(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, 1),   "sqshrn b30, h29, #1");
+  TEST_SINGLE(sqshrn(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, 7),   "sqshrn b30, h29, #7");
+  TEST_SINGLE(sqshrn(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, 1),  "sqshrn h30, s29, #1");
+  TEST_SINGLE(sqshrn(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, 15), "sqshrn h30, s29, #15");
+  TEST_SINGLE(sqshrn(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, 1),  "sqshrn s30, d29, #1");
+  TEST_SINGLE(sqshrn(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, 31), "sqshrn s30, d29, #31");
+  //TEST_SINGLE(sqshrn(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, 1),  "sqshrn d30, d29, #1");
+  //TEST_SINGLE(sqshrn(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, 63), "sqshrn d30, d29, #63");
+
+  TEST_SINGLE(sqrshrn(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, 1),   "sqrshrn b30, h29, #1");
+  TEST_SINGLE(sqrshrn(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, 7),   "sqrshrn b30, h29, #7");
+  TEST_SINGLE(sqrshrn(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, 1),  "sqrshrn h30, s29, #1");
+  TEST_SINGLE(sqrshrn(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, 15), "sqrshrn h30, s29, #15");
+  TEST_SINGLE(sqrshrn(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, 1),  "sqrshrn s30, d29, #1");
+  TEST_SINGLE(sqrshrn(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, 31), "sqrshrn s30, d29, #31");
+  //TEST_SINGLE(sqrshrn(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, 1),  "sqrshrn d30, d29, #1");
+  //TEST_SINGLE(sqrshrn(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, 63), "sqrshrn d30, d29, #63");
+
+  // TODO: Implement `SCVTF, FCVTZS` in emitter
+  //TEST_SINGLE(ushr(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, 1),   "ushr b30, b29, #1");
+  //TEST_SINGLE(ushr(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, 7),   "ushr b30, b29, #7");
+  //TEST_SINGLE(ushr(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, 1),  "ushr h30, h29, #1");
+  //TEST_SINGLE(ushr(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, 15), "ushr h30, h29, #15");
+  //TEST_SINGLE(ushr(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, 1),  "ushr s30, s29, #1");
+  //TEST_SINGLE(ushr(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, 31), "ushr s30, s29, #31");
+  TEST_SINGLE(ushr(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, 1),  "ushr d30, d29, #1");
+  TEST_SINGLE(ushr(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, 63), "ushr d30, d29, #63");
+
+  //TEST_SINGLE(usra(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, 1),   "usra b30, b29, #1");
+  //TEST_SINGLE(usra(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, 7),   "usra b30, b29, #7");
+  //TEST_SINGLE(usra(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, 1),  "usra h30, h29, #1");
+  //TEST_SINGLE(usra(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, 15), "usra h30, h29, #15");
+  //TEST_SINGLE(usra(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, 1),  "usra s30, s29, #1");
+  //TEST_SINGLE(usra(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, 31), "usra s30, s29, #31");
+  TEST_SINGLE(usra(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, 1),  "usra d30, d29, #1");
+  TEST_SINGLE(usra(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, 63), "usra d30, d29, #63");
+
+  //TEST_SINGLE(urshr(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, 1),   "urshr b30, b29, #1");
+  //TEST_SINGLE(urshr(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, 7),   "urshr b30, b29, #7");
+  //TEST_SINGLE(urshr(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, 1),  "urshr h30, h29, #1");
+  //TEST_SINGLE(urshr(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, 15), "urshr h30, h29, #15");
+  //TEST_SINGLE(urshr(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, 1),  "urshr s30, s29, #1");
+  //TEST_SINGLE(urshr(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, 31), "urshr s30, s29, #31");
+  TEST_SINGLE(urshr(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, 1),  "urshr d30, d29, #1");
+  TEST_SINGLE(urshr(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, 63), "urshr d30, d29, #63");
+
+  //TEST_SINGLE(ursra(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, 1),   "ursra b30, b29, #1");
+  //TEST_SINGLE(ursra(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, 7),   "ursra b30, b29, #7");
+  //TEST_SINGLE(ursra(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, 1),  "ursra h30, h29, #1");
+  //TEST_SINGLE(ursra(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, 15), "ursra h30, h29, #15");
+  //TEST_SINGLE(ursra(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, 1),  "ursra s30, s29, #1");
+  //TEST_SINGLE(ursra(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, 31), "ursra s30, s29, #31");
+  TEST_SINGLE(ursra(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, 1),  "ursra d30, d29, #1");
+  TEST_SINGLE(ursra(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, 63), "ursra d30, d29, #63");
+
+  //TEST_SINGLE(sri(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, 1),   "sri b30, b29, #1");
+  //TEST_SINGLE(sri(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, 7),   "sri b30, b29, #7");
+  //TEST_SINGLE(sri(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, 1),  "sri h30, h29, #1");
+  //TEST_SINGLE(sri(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, 15), "sri h30, h29, #15");
+  //TEST_SINGLE(sri(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, 1),  "sri s30, s29, #1");
+  //TEST_SINGLE(sri(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, 31), "sri s30, s29, #31");
+  TEST_SINGLE(sri(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, 1),  "sri d30, d29, #1");
+  TEST_SINGLE(sri(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, 63), "sri d30, d29, #63");
+
+  //TEST_SINGLE(sli(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, 1),   "sli b30, b29, #1");
+  //TEST_SINGLE(sli(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, 7),   "sli b30, b29, #7");
+  //TEST_SINGLE(sli(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, 1),  "sli h30, h29, #1");
+  //TEST_SINGLE(sli(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, 15), "sli h30, h29, #15");
+  //TEST_SINGLE(sli(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, 1),  "sli s30, s29, #1");
+  //TEST_SINGLE(sli(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, 31), "sli s30, s29, #31");
+  TEST_SINGLE(sli(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, 1),  "sli d30, d29, #1");
+  TEST_SINGLE(sli(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, 63), "sli d30, d29, #63");
+
+  TEST_SINGLE(sqshlu(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, 1),   "sqshlu b30, b29, #1");
+  TEST_SINGLE(sqshlu(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, 7),   "sqshlu b30, b29, #7");
+  TEST_SINGLE(sqshlu(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, 1),  "sqshlu h30, h29, #1");
+  TEST_SINGLE(sqshlu(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, 15), "sqshlu h30, h29, #15");
+  TEST_SINGLE(sqshlu(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, 1),  "sqshlu s30, s29, #1");
+  TEST_SINGLE(sqshlu(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, 31), "sqshlu s30, s29, #31");
+  TEST_SINGLE(sqshlu(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, 1),  "sqshlu d30, d29, #1");
+  TEST_SINGLE(sqshlu(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, 63), "sqshlu d30, d29, #63");
+
+  TEST_SINGLE(uqshl(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, 1),   "uqshl b30, b29, #1");
+  TEST_SINGLE(uqshl(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, 7),   "uqshl b30, b29, #7");
+  TEST_SINGLE(uqshl(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, 1),  "uqshl h30, h29, #1");
+  TEST_SINGLE(uqshl(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, 15), "uqshl h30, h29, #15");
+  TEST_SINGLE(uqshl(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, 1),  "uqshl s30, s29, #1");
+  TEST_SINGLE(uqshl(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, 31), "uqshl s30, s29, #31");
+  TEST_SINGLE(uqshl(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, 1),  "uqshl d30, d29, #1");
+  TEST_SINGLE(uqshl(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, 63), "uqshl d30, d29, #63");
+
+  TEST_SINGLE(sqshrun(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, 1),   "sqshrun b30, h29, #1");
+  TEST_SINGLE(sqshrun(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, 7),   "sqshrun b30, h29, #7");
+  TEST_SINGLE(sqshrun(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, 1),  "sqshrun h30, s29, #1");
+  TEST_SINGLE(sqshrun(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, 15), "sqshrun h30, s29, #15");
+  TEST_SINGLE(sqshrun(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, 1),  "sqshrun s30, d29, #1");
+  TEST_SINGLE(sqshrun(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, 31), "sqshrun s30, d29, #31");
+  //TEST_SINGLE(sqshrun(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, 1),  "sqshrun d30, d29, #1");
+  //TEST_SINGLE(sqshrun(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, 63), "sqshrun d30, d29, #63");
+
+  TEST_SINGLE(sqrshrun(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, 1),   "sqrshrun b30, h29, #1");
+  TEST_SINGLE(sqrshrun(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, 7),   "sqrshrun b30, h29, #7");
+  TEST_SINGLE(sqrshrun(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, 1),  "sqrshrun h30, s29, #1");
+  TEST_SINGLE(sqrshrun(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, 15), "sqrshrun h30, s29, #15");
+  TEST_SINGLE(sqrshrun(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, 1),  "sqrshrun s30, d29, #1");
+  TEST_SINGLE(sqrshrun(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, 31), "sqrshrun s30, d29, #31");
+  //TEST_SINGLE(sqrshrun(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, 1),  "sqrshrun d30, d29, #1");
+  //TEST_SINGLE(sqrshrun(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, 63), "sqrshrun d30, d29, #63");
+
+  TEST_SINGLE(uqshrn(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, 1),   "uqshrn b30, h29, #1");
+  TEST_SINGLE(uqshrn(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, 7),   "uqshrn b30, h29, #7");
+  TEST_SINGLE(uqshrn(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, 1),  "uqshrn h30, s29, #1");
+  TEST_SINGLE(uqshrn(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, 15), "uqshrn h30, s29, #15");
+  TEST_SINGLE(uqshrn(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, 1),  "uqshrn s30, d29, #1");
+  TEST_SINGLE(uqshrn(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, 31), "uqshrn s30, d29, #31");
+  //TEST_SINGLE(uqshrn(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, 1),  "uqshrn d30, d29, #1");
+  //TEST_SINGLE(uqshrn(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, 63), "uqshrn d30, d29, #63");
+
+  TEST_SINGLE(uqrshrn(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, 1),   "uqrshrn b30, h29, #1");
+  TEST_SINGLE(uqrshrn(ScalarRegSize::i8Bit, VReg::v30, VReg::v29, 7),   "uqrshrn b30, h29, #7");
+  TEST_SINGLE(uqrshrn(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, 1),  "uqrshrn h30, s29, #1");
+  TEST_SINGLE(uqrshrn(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, 15), "uqrshrn h30, s29, #15");
+  TEST_SINGLE(uqrshrn(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, 1),  "uqrshrn s30, d29, #1");
+  TEST_SINGLE(uqrshrn(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, 31), "uqrshrn s30, d29, #31");
+  //TEST_SINGLE(uqrshrn(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, 1),  "uqrshrn d30, d29, #1");
+  //TEST_SINGLE(uqrshrn(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, 63), "uqrshrn d30, d29, #63");
+
+  // TODO: Implement `UCVTF, FCVTZU' in emitter
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Scalar: Advanced SIMD scalar x indexed element") {
+  // TODO: Implement in emitter
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Scalar: Floating-point data-processing (1 source)") {
+  TEST_SINGLE(fmov(SReg::s30, SReg::s29), "fmov s30, s29");
+  TEST_SINGLE(fabs(SReg::s30, SReg::s29), "fabs s30, s29");
+  TEST_SINGLE(fneg(SReg::s30, SReg::s29), "fneg s30, s29");
+  TEST_SINGLE(fsqrt(SReg::s30, SReg::s29), "fsqrt s30, s29");
+  TEST_SINGLE(fcvt(DReg::d30, SReg::s29), "fcvt d30, s29");
+  TEST_SINGLE(fcvt(HReg::h30, SReg::s29), "fcvt h30, s29");
+  TEST_SINGLE(frintn(SReg::s30, SReg::s29), "frintn s30, s29");
+  TEST_SINGLE(frintp(SReg::s30, SReg::s29), "frintp s30, s29");
+  TEST_SINGLE(frintm(SReg::s30, SReg::s29), "frintm s30, s29");
+  TEST_SINGLE(frintz(SReg::s30, SReg::s29), "frintz s30, s29");
+  TEST_SINGLE(frinta(SReg::s30, SReg::s29), "frinta s30, s29");
+  TEST_SINGLE(frintx(SReg::s30, SReg::s29), "frintx s30, s29");
+  TEST_SINGLE(frinti(SReg::s30, SReg::s29), "frinti s30, s29");
+  TEST_SINGLE(frint32z(SReg::s30, SReg::s29), "frint32z s30, s29");
+  TEST_SINGLE(frint32x(SReg::s30, SReg::s29), "frint32x s30, s29");
+  TEST_SINGLE(frint64z(SReg::s30, SReg::s29), "frint64z s30, s29");
+  TEST_SINGLE(frint64x(SReg::s30, SReg::s29), "frint64x s30, s29");
+
+  TEST_SINGLE(fmov(DReg::d30, DReg::d29), "fmov d30, d29");
+  TEST_SINGLE(fabs(DReg::d30, DReg::d29), "fabs d30, d29");
+  TEST_SINGLE(fneg(DReg::d30, DReg::d29), "fneg d30, d29");
+  TEST_SINGLE(fsqrt(DReg::d30, DReg::d29), "fsqrt d30, d29");
+  TEST_SINGLE(fcvt(SReg::s30, DReg::d29), "fcvt s30, d29");
+  if (false) {
+    // vixl doesn't support this instruction.
+    TEST_SINGLE(bfcvt(HReg::h30, DReg::d29), "bfcvt h30, d29");
+  }
+  TEST_SINGLE(fcvt(HReg::h30, DReg::d29), "fcvt h30, d29");
+  TEST_SINGLE(frintn(DReg::d30, DReg::d29), "frintn d30, d29");
+  TEST_SINGLE(frintp(DReg::d30, DReg::d29), "frintp d30, d29");
+  TEST_SINGLE(frintm(DReg::d30, DReg::d29), "frintm d30, d29");
+  TEST_SINGLE(frintz(DReg::d30, DReg::d29), "frintz d30, d29");
+  TEST_SINGLE(frinta(DReg::d30, DReg::d29), "frinta d30, d29");
+  TEST_SINGLE(frintx(DReg::d30, DReg::d29), "frintx d30, d29");
+  TEST_SINGLE(frinti(DReg::d30, DReg::d29), "frinti d30, d29");
+  TEST_SINGLE(frint32z(DReg::d30, DReg::d29), "frint32z d30, d29");
+  TEST_SINGLE(frint32x(DReg::d30, DReg::d29), "frint32x d30, d29");
+  TEST_SINGLE(frint64z(DReg::d30, DReg::d29), "frint64z d30, d29");
+  TEST_SINGLE(frint64x(DReg::d30, DReg::d29), "frint64x d30, d29");
+
+  TEST_SINGLE(fmov(HReg::h30, HReg::h29), "fmov h30, h29");
+  TEST_SINGLE(fabs(HReg::h30, HReg::h29), "fabs h30, h29");
+  TEST_SINGLE(fneg(HReg::h30, HReg::h29), "fneg h30, h29");
+  TEST_SINGLE(fsqrt(HReg::h30, HReg::h29), "fsqrt h30, h29");
+  TEST_SINGLE(fcvt(SReg::s30, HReg::h29), "fcvt s30, h29");
+  TEST_SINGLE(fcvt(DReg::d30, HReg::h29), "fcvt d30, h29");
+  TEST_SINGLE(frintn(HReg::h30, HReg::h29), "frintn h30, h29");
+  TEST_SINGLE(frintp(HReg::h30, HReg::h29), "frintp h30, h29");
+  TEST_SINGLE(frintm(HReg::h30, HReg::h29), "frintm h30, h29");
+  TEST_SINGLE(frintz(HReg::h30, HReg::h29), "frintz h30, h29");
+  TEST_SINGLE(frinta(HReg::h30, HReg::h29), "frinta h30, h29");
+  TEST_SINGLE(frintx(HReg::h30, HReg::h29), "frintx h30, h29");
+  TEST_SINGLE(frinti(HReg::h30, HReg::h29), "frinti h30, h29");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Scalar: Floating-point compare") {
+  // Commented out lines showcase unallocated encodings.
+  //TEST_SINGLE(fcmp(ScalarRegSize::i8Bit, VReg::v30, VReg::v29), "fcmp b30, b29");
+  TEST_SINGLE(fcmp(ScalarRegSize::i16Bit, VReg::v30, VReg::v29), "fcmp h30, h29");
+  TEST_SINGLE(fcmp(ScalarRegSize::i32Bit, VReg::v30, VReg::v29), "fcmp s30, s29");
+  TEST_SINGLE(fcmp(ScalarRegSize::i64Bit, VReg::v30, VReg::v29), "fcmp d30, d29");
+
+  TEST_SINGLE(fcmp(SReg::s30, SReg::s29), "fcmp s30, s29");
+  TEST_SINGLE(fcmp(SReg::s30), "fcmp s30, #0.0");
+  TEST_SINGLE(fcmpe(SReg::s30, SReg::s29), "fcmpe s30, s29");
+  TEST_SINGLE(fcmpe(SReg::s30), "fcmpe s30, #0.0");
+
+  TEST_SINGLE(fcmp(DReg::d30, DReg::d29), "fcmp d30, d29");
+  TEST_SINGLE(fcmp(DReg::d30), "fcmp d30, #0.0");
+  TEST_SINGLE(fcmpe(DReg::d30, DReg::d29), "fcmpe d30, d29");
+  TEST_SINGLE(fcmpe(DReg::d30), "fcmpe d30, #0.0");
+
+  TEST_SINGLE(fcmp(HReg::h30, HReg::h29), "fcmp h30, h29");
+  TEST_SINGLE(fcmp(HReg::h30), "fcmp h30, #0.0");
+  TEST_SINGLE(fcmpe(HReg::h30, HReg::h29), "fcmpe h30, h29");
+  TEST_SINGLE(fcmpe(HReg::h30), "fcmpe h30, #0.0");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Scalar: Floating-point immediate") {
+  TEST_SINGLE(fmov(ScalarRegSize::i16Bit, VReg::v30, 1.0), "fmov h30, #0x70 (1.0000)");
+  TEST_SINGLE(fmov(ScalarRegSize::i32Bit, VReg::v30, 1.0), "fmov s30, #0x70 (1.0000)");
+  TEST_SINGLE(fmov(ScalarRegSize::i64Bit, VReg::v30, 1.0), "fmov d30, #0x70 (1.0000)");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Scalar: Floating-point conditional compare") {
+  TEST_SINGLE(fccmp(SReg::s30, SReg::s29, StatusFlags::None, Condition::CC_AL), "fccmp s30, s29, #nzcv, al");
+  TEST_SINGLE(fccmp(SReg::s30, SReg::s29, StatusFlags::Flag_N, Condition::CC_AL), "fccmp s30, s29, #Nzcv, al");
+  TEST_SINGLE(fccmp(SReg::s30, SReg::s29, StatusFlags::Flag_Z, Condition::CC_AL), "fccmp s30, s29, #nZcv, al");
+  TEST_SINGLE(fccmp(SReg::s30, SReg::s29, StatusFlags::Flag_C, Condition::CC_AL), "fccmp s30, s29, #nzCv, al");
+  TEST_SINGLE(fccmp(SReg::s30, SReg::s29, StatusFlags::Flag_V, Condition::CC_AL), "fccmp s30, s29, #nzcV, al");
+  TEST_SINGLE(fccmp(SReg::s30, SReg::s29, StatusFlags::Flag_NZCV, Condition::CC_AL), "fccmp s30, s29, #NZCV, al");
+  TEST_SINGLE(fccmp(SReg::s30, SReg::s29, StatusFlags::None, Condition::CC_EQ), "fccmp s30, s29, #nzcv, eq");
+  TEST_SINGLE(fccmp(SReg::s30, SReg::s29, StatusFlags::Flag_N, Condition::CC_EQ), "fccmp s30, s29, #Nzcv, eq");
+  TEST_SINGLE(fccmp(SReg::s30, SReg::s29, StatusFlags::Flag_Z, Condition::CC_EQ), "fccmp s30, s29, #nZcv, eq");
+  TEST_SINGLE(fccmp(SReg::s30, SReg::s29, StatusFlags::Flag_C, Condition::CC_EQ), "fccmp s30, s29, #nzCv, eq");
+  TEST_SINGLE(fccmp(SReg::s30, SReg::s29, StatusFlags::Flag_V, Condition::CC_EQ), "fccmp s30, s29, #nzcV, eq");
+  TEST_SINGLE(fccmp(SReg::s30, SReg::s29, StatusFlags::Flag_NZCV, Condition::CC_EQ), "fccmp s30, s29, #NZCV, eq");
+
+  TEST_SINGLE(fccmpe(SReg::s30, SReg::s29, StatusFlags::None, Condition::CC_AL), "fccmpe s30, s29, #nzcv, al");
+  TEST_SINGLE(fccmpe(SReg::s30, SReg::s29, StatusFlags::Flag_N, Condition::CC_AL), "fccmpe s30, s29, #Nzcv, al");
+  TEST_SINGLE(fccmpe(SReg::s30, SReg::s29, StatusFlags::Flag_Z, Condition::CC_AL), "fccmpe s30, s29, #nZcv, al");
+  TEST_SINGLE(fccmpe(SReg::s30, SReg::s29, StatusFlags::Flag_C, Condition::CC_AL), "fccmpe s30, s29, #nzCv, al");
+  TEST_SINGLE(fccmpe(SReg::s30, SReg::s29, StatusFlags::Flag_V, Condition::CC_AL), "fccmpe s30, s29, #nzcV, al");
+  TEST_SINGLE(fccmpe(SReg::s30, SReg::s29, StatusFlags::Flag_NZCV, Condition::CC_AL), "fccmpe s30, s29, #NZCV, al");
+  TEST_SINGLE(fccmpe(SReg::s30, SReg::s29, StatusFlags::None, Condition::CC_EQ), "fccmpe s30, s29, #nzcv, eq");
+  TEST_SINGLE(fccmpe(SReg::s30, SReg::s29, StatusFlags::Flag_N, Condition::CC_EQ), "fccmpe s30, s29, #Nzcv, eq");
+  TEST_SINGLE(fccmpe(SReg::s30, SReg::s29, StatusFlags::Flag_Z, Condition::CC_EQ), "fccmpe s30, s29, #nZcv, eq");
+  TEST_SINGLE(fccmpe(SReg::s30, SReg::s29, StatusFlags::Flag_C, Condition::CC_EQ), "fccmpe s30, s29, #nzCv, eq");
+  TEST_SINGLE(fccmpe(SReg::s30, SReg::s29, StatusFlags::Flag_V, Condition::CC_EQ), "fccmpe s30, s29, #nzcV, eq");
+  TEST_SINGLE(fccmpe(SReg::s30, SReg::s29, StatusFlags::Flag_NZCV, Condition::CC_EQ), "fccmpe s30, s29, #NZCV, eq");
+
+  TEST_SINGLE(fccmp(DReg::d30, DReg::d29, StatusFlags::None, Condition::CC_AL), "fccmp d30, d29, #nzcv, al");
+  TEST_SINGLE(fccmp(DReg::d30, DReg::d29, StatusFlags::Flag_N, Condition::CC_AL), "fccmp d30, d29, #Nzcv, al");
+  TEST_SINGLE(fccmp(DReg::d30, DReg::d29, StatusFlags::Flag_Z, Condition::CC_AL), "fccmp d30, d29, #nZcv, al");
+  TEST_SINGLE(fccmp(DReg::d30, DReg::d29, StatusFlags::Flag_C, Condition::CC_AL), "fccmp d30, d29, #nzCv, al");
+  TEST_SINGLE(fccmp(DReg::d30, DReg::d29, StatusFlags::Flag_V, Condition::CC_AL), "fccmp d30, d29, #nzcV, al");
+  TEST_SINGLE(fccmp(DReg::d30, DReg::d29, StatusFlags::Flag_NZCV, Condition::CC_AL), "fccmp d30, d29, #NZCV, al");
+  TEST_SINGLE(fccmp(DReg::d30, DReg::d29, StatusFlags::None, Condition::CC_EQ), "fccmp d30, d29, #nzcv, eq");
+  TEST_SINGLE(fccmp(DReg::d30, DReg::d29, StatusFlags::Flag_N, Condition::CC_EQ), "fccmp d30, d29, #Nzcv, eq");
+  TEST_SINGLE(fccmp(DReg::d30, DReg::d29, StatusFlags::Flag_Z, Condition::CC_EQ), "fccmp d30, d29, #nZcv, eq");
+  TEST_SINGLE(fccmp(DReg::d30, DReg::d29, StatusFlags::Flag_C, Condition::CC_EQ), "fccmp d30, d29, #nzCv, eq");
+  TEST_SINGLE(fccmp(DReg::d30, DReg::d29, StatusFlags::Flag_V, Condition::CC_EQ), "fccmp d30, d29, #nzcV, eq");
+  TEST_SINGLE(fccmp(DReg::d30, DReg::d29, StatusFlags::Flag_NZCV, Condition::CC_EQ), "fccmp d30, d29, #NZCV, eq");
+
+  TEST_SINGLE(fccmpe(DReg::d30, DReg::d29, StatusFlags::None, Condition::CC_AL), "fccmpe d30, d29, #nzcv, al");
+  TEST_SINGLE(fccmpe(DReg::d30, DReg::d29, StatusFlags::Flag_N, Condition::CC_AL), "fccmpe d30, d29, #Nzcv, al");
+  TEST_SINGLE(fccmpe(DReg::d30, DReg::d29, StatusFlags::Flag_Z, Condition::CC_AL), "fccmpe d30, d29, #nZcv, al");
+  TEST_SINGLE(fccmpe(DReg::d30, DReg::d29, StatusFlags::Flag_C, Condition::CC_AL), "fccmpe d30, d29, #nzCv, al");
+  TEST_SINGLE(fccmpe(DReg::d30, DReg::d29, StatusFlags::Flag_V, Condition::CC_AL), "fccmpe d30, d29, #nzcV, al");
+  TEST_SINGLE(fccmpe(DReg::d30, DReg::d29, StatusFlags::Flag_NZCV, Condition::CC_AL), "fccmpe d30, d29, #NZCV, al");
+  TEST_SINGLE(fccmpe(DReg::d30, DReg::d29, StatusFlags::None, Condition::CC_EQ), "fccmpe d30, d29, #nzcv, eq");
+  TEST_SINGLE(fccmpe(DReg::d30, DReg::d29, StatusFlags::Flag_N, Condition::CC_EQ), "fccmpe d30, d29, #Nzcv, eq");
+  TEST_SINGLE(fccmpe(DReg::d30, DReg::d29, StatusFlags::Flag_Z, Condition::CC_EQ), "fccmpe d30, d29, #nZcv, eq");
+  TEST_SINGLE(fccmpe(DReg::d30, DReg::d29, StatusFlags::Flag_C, Condition::CC_EQ), "fccmpe d30, d29, #nzCv, eq");
+  TEST_SINGLE(fccmpe(DReg::d30, DReg::d29, StatusFlags::Flag_V, Condition::CC_EQ), "fccmpe d30, d29, #nzcV, eq");
+  TEST_SINGLE(fccmpe(DReg::d30, DReg::d29, StatusFlags::Flag_NZCV, Condition::CC_EQ), "fccmpe d30, d29, #NZCV, eq");
+
+  TEST_SINGLE(fccmp(HReg::h30, HReg::h29, StatusFlags::None, Condition::CC_AL), "fccmp h30, h29, #nzcv, al");
+  TEST_SINGLE(fccmp(HReg::h30, HReg::h29, StatusFlags::Flag_N, Condition::CC_AL), "fccmp h30, h29, #Nzcv, al");
+  TEST_SINGLE(fccmp(HReg::h30, HReg::h29, StatusFlags::Flag_Z, Condition::CC_AL), "fccmp h30, h29, #nZcv, al");
+  TEST_SINGLE(fccmp(HReg::h30, HReg::h29, StatusFlags::Flag_C, Condition::CC_AL), "fccmp h30, h29, #nzCv, al");
+  TEST_SINGLE(fccmp(HReg::h30, HReg::h29, StatusFlags::Flag_V, Condition::CC_AL), "fccmp h30, h29, #nzcV, al");
+  TEST_SINGLE(fccmp(HReg::h30, HReg::h29, StatusFlags::Flag_NZCV, Condition::CC_AL), "fccmp h30, h29, #NZCV, al");
+  TEST_SINGLE(fccmp(HReg::h30, HReg::h29, StatusFlags::None, Condition::CC_EQ), "fccmp h30, h29, #nzcv, eq");
+  TEST_SINGLE(fccmp(HReg::h30, HReg::h29, StatusFlags::Flag_N, Condition::CC_EQ), "fccmp h30, h29, #Nzcv, eq");
+  TEST_SINGLE(fccmp(HReg::h30, HReg::h29, StatusFlags::Flag_Z, Condition::CC_EQ), "fccmp h30, h29, #nZcv, eq");
+  TEST_SINGLE(fccmp(HReg::h30, HReg::h29, StatusFlags::Flag_C, Condition::CC_EQ), "fccmp h30, h29, #nzCv, eq");
+  TEST_SINGLE(fccmp(HReg::h30, HReg::h29, StatusFlags::Flag_V, Condition::CC_EQ), "fccmp h30, h29, #nzcV, eq");
+  TEST_SINGLE(fccmp(HReg::h30, HReg::h29, StatusFlags::Flag_NZCV, Condition::CC_EQ), "fccmp h30, h29, #NZCV, eq");
+
+  TEST_SINGLE(fccmpe(HReg::h30, HReg::h29, StatusFlags::None, Condition::CC_AL), "fccmpe h30, h29, #nzcv, al");
+  TEST_SINGLE(fccmpe(HReg::h30, HReg::h29, StatusFlags::Flag_N, Condition::CC_AL), "fccmpe h30, h29, #Nzcv, al");
+  TEST_SINGLE(fccmpe(HReg::h30, HReg::h29, StatusFlags::Flag_Z, Condition::CC_AL), "fccmpe h30, h29, #nZcv, al");
+  TEST_SINGLE(fccmpe(HReg::h30, HReg::h29, StatusFlags::Flag_C, Condition::CC_AL), "fccmpe h30, h29, #nzCv, al");
+  TEST_SINGLE(fccmpe(HReg::h30, HReg::h29, StatusFlags::Flag_V, Condition::CC_AL), "fccmpe h30, h29, #nzcV, al");
+  TEST_SINGLE(fccmpe(HReg::h30, HReg::h29, StatusFlags::Flag_NZCV, Condition::CC_AL), "fccmpe h30, h29, #NZCV, al");
+  TEST_SINGLE(fccmpe(HReg::h30, HReg::h29, StatusFlags::None, Condition::CC_EQ), "fccmpe h30, h29, #nzcv, eq");
+  TEST_SINGLE(fccmpe(HReg::h30, HReg::h29, StatusFlags::Flag_N, Condition::CC_EQ), "fccmpe h30, h29, #Nzcv, eq");
+  TEST_SINGLE(fccmpe(HReg::h30, HReg::h29, StatusFlags::Flag_Z, Condition::CC_EQ), "fccmpe h30, h29, #nZcv, eq");
+  TEST_SINGLE(fccmpe(HReg::h30, HReg::h29, StatusFlags::Flag_C, Condition::CC_EQ), "fccmpe h30, h29, #nzCv, eq");
+  TEST_SINGLE(fccmpe(HReg::h30, HReg::h29, StatusFlags::Flag_V, Condition::CC_EQ), "fccmpe h30, h29, #nzcV, eq");
+  TEST_SINGLE(fccmpe(HReg::h30, HReg::h29, StatusFlags::Flag_NZCV, Condition::CC_EQ), "fccmpe h30, h29, #NZCV, eq");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Scalar: Floating-point data-processing (2 source)") {
+  TEST_SINGLE(fmul(SReg::s30, SReg::s29, SReg::s28), "fmul s30, s29, s28");
+  TEST_SINGLE(fdiv(SReg::s30, SReg::s29, SReg::s28), "fdiv s30, s29, s28");
+  TEST_SINGLE(fadd(SReg::s30, SReg::s29, SReg::s28), "fadd s30, s29, s28");
+  TEST_SINGLE(fsub(SReg::s30, SReg::s29, SReg::s28), "fsub s30, s29, s28");
+  TEST_SINGLE(fmax(SReg::s30, SReg::s29, SReg::s28), "fmax s30, s29, s28");
+  TEST_SINGLE(fmin(SReg::s30, SReg::s29, SReg::s28), "fmin s30, s29, s28");
+  TEST_SINGLE(fmaxnm(SReg::s30, SReg::s29, SReg::s28), "fmaxnm s30, s29, s28");
+  TEST_SINGLE(fminnm(SReg::s30, SReg::s29, SReg::s28), "fminnm s30, s29, s28");
+  TEST_SINGLE(fnmul(SReg::s30, SReg::s29, SReg::s28), "fnmul s30, s29, s28");
+
+  TEST_SINGLE(fmul(DReg::d30, DReg::d29, DReg::d28), "fmul d30, d29, d28");
+  TEST_SINGLE(fdiv(DReg::d30, DReg::d29, DReg::d28), "fdiv d30, d29, d28");
+  TEST_SINGLE(fadd(DReg::d30, DReg::d29, DReg::d28), "fadd d30, d29, d28");
+  TEST_SINGLE(fsub(DReg::d30, DReg::d29, DReg::d28), "fsub d30, d29, d28");
+  TEST_SINGLE(fmax(DReg::d30, DReg::d29, DReg::d28), "fmax d30, d29, d28");
+  TEST_SINGLE(fmin(DReg::d30, DReg::d29, DReg::d28), "fmin d30, d29, d28");
+  TEST_SINGLE(fmaxnm(DReg::d30, DReg::d29, DReg::d28), "fmaxnm d30, d29, d28");
+  TEST_SINGLE(fminnm(DReg::d30, DReg::d29, DReg::d28), "fminnm d30, d29, d28");
+  TEST_SINGLE(fnmul(DReg::d30, DReg::d29, DReg::d28), "fnmul d30, d29, d28");
+
+  TEST_SINGLE(fmul(HReg::h30, HReg::h29, HReg::h28), "fmul h30, h29, h28");
+  TEST_SINGLE(fdiv(HReg::h30, HReg::h29, HReg::h28), "fdiv h30, h29, h28");
+  TEST_SINGLE(fadd(HReg::h30, HReg::h29, HReg::h28), "fadd h30, h29, h28");
+  TEST_SINGLE(fsub(HReg::h30, HReg::h29, HReg::h28), "fsub h30, h29, h28");
+  TEST_SINGLE(fmax(HReg::h30, HReg::h29, HReg::h28), "fmax h30, h29, h28");
+  TEST_SINGLE(fmin(HReg::h30, HReg::h29, HReg::h28), "fmin h30, h29, h28");
+  TEST_SINGLE(fmaxnm(HReg::h30, HReg::h29, HReg::h28), "fmaxnm h30, h29, h28");
+  TEST_SINGLE(fminnm(HReg::h30, HReg::h29, HReg::h28), "fminnm h30, h29, h28");
+  TEST_SINGLE(fnmul(HReg::h30, HReg::h29, HReg::h28), "fnmul h30, h29, h28");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Scalar: Floating-point conditional select") {
+  TEST_SINGLE(fcsel(SReg::s30, SReg::s29, SReg::s28, Condition::CC_AL), "fcsel s30, s29, s28, al");
+  TEST_SINGLE(fcsel(SReg::s30, SReg::s29, SReg::s28, Condition::CC_EQ), "fcsel s30, s29, s28, eq");
+
+  TEST_SINGLE(fcsel(DReg::d30, DReg::d29, DReg::d28, Condition::CC_AL), "fcsel d30, d29, d28, al");
+  TEST_SINGLE(fcsel(DReg::d30, DReg::d29, DReg::d28, Condition::CC_EQ), "fcsel d30, d29, d28, eq");
+
+  TEST_SINGLE(fcsel(HReg::h30, HReg::h29, HReg::h28, Condition::CC_AL), "fcsel h30, h29, h28, al");
+  TEST_SINGLE(fcsel(HReg::h30, HReg::h29, HReg::h28, Condition::CC_EQ), "fcsel h30, h29, h28, eq");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Scalar: Floating-point data-processing (3 source)") {
+  TEST_SINGLE(fmadd(SReg::s30, SReg::s29, SReg::s28, SReg::s27), "fmadd s30, s29, s28, s27");
+  TEST_SINGLE(fmsub(SReg::s30, SReg::s29, SReg::s28, SReg::s27), "fmsub s30, s29, s28, s27");
+  TEST_SINGLE(fnmadd(SReg::s30, SReg::s29, SReg::s28, SReg::s27), "fnmadd s30, s29, s28, s27");
+  TEST_SINGLE(fnmsub(SReg::s30, SReg::s29, SReg::s28, SReg::s27), "fnmsub s30, s29, s28, s27");
+
+  TEST_SINGLE(fmadd(DReg::d30, DReg::d29, DReg::d28, DReg::d27), "fmadd d30, d29, d28, d27");
+  TEST_SINGLE(fmsub(DReg::d30, DReg::d29, DReg::d28, DReg::d27), "fmsub d30, d29, d28, d27");
+  TEST_SINGLE(fnmadd(DReg::d30, DReg::d29, DReg::d28, DReg::d27), "fnmadd d30, d29, d28, d27");
+  TEST_SINGLE(fnmsub(DReg::d30, DReg::d29, DReg::d28, DReg::d27), "fnmsub d30, d29, d28, d27");
+
+  TEST_SINGLE(fmadd(HReg::h30, HReg::h29, HReg::h28, HReg::h27), "fmadd h30, h29, h28, h27");
+  TEST_SINGLE(fmsub(HReg::h30, HReg::h29, HReg::h28, HReg::h27), "fmsub h30, h29, h28, h27");
+  TEST_SINGLE(fnmadd(HReg::h30, HReg::h29, HReg::h28, HReg::h27), "fnmadd h30, h29, h28, h27");
+  TEST_SINGLE(fnmsub(HReg::h30, HReg::h29, HReg::h28, HReg::h27), "fnmsub h30, h29, h28, h27");
+}

--- a/External/FEXCore/unittests/Emitter/System_Tests.cpp
+++ b/External/FEXCore/unittests/Emitter/System_Tests.cpp
@@ -1,0 +1,139 @@
+#include "TestDisassembler.h"
+
+#include <catch2/catch.hpp>
+#include <fcntl.h>
+
+using namespace FEXCore::ARMEmitter;
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: System: System with result") {
+  // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: System: System Instruction") {
+  // TODO: AT
+  // TODO: CFP
+  // TODO: CPP
+  // vixl doesn't understand a bunch of data cache operation names.
+  TEST_SINGLE(dc(DataCacheOperation::IVAC, Reg::r30), "sys #0, C7, C6, #1, x30");
+  TEST_SINGLE(dc(DataCacheOperation::ISW, Reg::r30), "sys #0, C7, C6, #2, x30");
+  TEST_SINGLE(dc(DataCacheOperation::CSW, Reg::r30), "sys #0, C7, C10, #2, x30");
+  TEST_SINGLE(dc(DataCacheOperation::CISW, Reg::r30), "sys #0, C7, C14, #2, x30");
+  TEST_SINGLE(dc(DataCacheOperation::ZVA, Reg::r30), "dc zva, x30");
+  TEST_SINGLE(dc(DataCacheOperation::CVAC, Reg::r30), "dc cvac, x30");
+  TEST_SINGLE(dc(DataCacheOperation::CVAU, Reg::r30), "dc cvau, x30");
+  TEST_SINGLE(dc(DataCacheOperation::CIVAC, Reg::r30), "dc civac, x30");
+
+  TEST_SINGLE(dc(DataCacheOperation::IGVAC, Reg::r30), "sys #0, C7, C6, #3, x30");
+  TEST_SINGLE(dc(DataCacheOperation::IGSW, Reg::r30), "sys #0, C7, C6, #4, x30");
+  TEST_SINGLE(dc(DataCacheOperation::IGDVAC, Reg::r30), "sys #0, C7, C6, #5, x30");
+  TEST_SINGLE(dc(DataCacheOperation::IGDSW, Reg::r30), "sys #0, C7, C6, #6, x30");
+  TEST_SINGLE(dc(DataCacheOperation::CGSW, Reg::r30), "sys #0, C7, C10, #4, x30");
+  TEST_SINGLE(dc(DataCacheOperation::CGDSW, Reg::r30), "sys #0, C7, C10, #6, x30");
+  TEST_SINGLE(dc(DataCacheOperation::CIGSW, Reg::r30), "sys #0, C7, C14, #4, x30");
+  TEST_SINGLE(dc(DataCacheOperation::CIGDSW, Reg::r30), "sys #0, C7, C14, #6, x30");
+
+  TEST_SINGLE(dc(DataCacheOperation::GVA, Reg::r30), "sys #3, C7, C4, #3, x30");
+  TEST_SINGLE(dc(DataCacheOperation::GZVA, Reg::r30), "sys #3, C7, C4, #4, x30");
+  TEST_SINGLE(dc(DataCacheOperation::CGVAC, Reg::r30), "sys #3, C7, C10, #3, x30");
+  TEST_SINGLE(dc(DataCacheOperation::CGDVAC, Reg::r30), "sys #3, C7, C10, #5, x30");
+  TEST_SINGLE(dc(DataCacheOperation::CGVAP, Reg::r30), "sys #3, C7, C12, #3, x30");
+  TEST_SINGLE(dc(DataCacheOperation::CGDVAP, Reg::r30), "sys #3, C7, C12, #5, x30");
+  TEST_SINGLE(dc(DataCacheOperation::CGVADP, Reg::r30), "sys #3, C7, C13, #3, x30");
+  TEST_SINGLE(dc(DataCacheOperation::CGDVADP, Reg::r30), "sys #3, C7, C13, #5, x30");
+  TEST_SINGLE(dc(DataCacheOperation::CIGVAC, Reg::r30), "sys #3, C7, C14, #3, x30");
+  TEST_SINGLE(dc(DataCacheOperation::CIGDVAC, Reg::r30), "sys #3, C7, C14, #5, x30");
+
+  TEST_SINGLE(dc(DataCacheOperation::CVAP, Reg::r30), "dc cvap, x30");
+
+  TEST_SINGLE(dc(DataCacheOperation::CVADP, Reg::r30), "dc cvadp, x30");
+
+  // TODO: DVP
+  // TODO: IC
+  // TODO: TLBI
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: System: Exception generation") {
+  TEST_SINGLE(svc(65535), "svc #0xffff");
+  TEST_SINGLE(hvc(65535), "hvc #0xffff");
+  TEST_SINGLE(smc(65535), "smc #0xffff");
+  TEST_SINGLE(brk(65535), "brk #0xffff");
+  TEST_SINGLE(hlt(65535), "hlt #0xffff");
+  TEST_SINGLE(tcancel(65535), "unimplemented (Unimplemented)");
+  TEST_SINGLE(dcps1(65535), "dcps1 {#0xffff}");
+  TEST_SINGLE(dcps2(65535), "dcps2 {#0xffff}");
+  TEST_SINGLE(dcps3(65535), "dcps3 {#0xffff}");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: System: System instructions with register argument") {
+  if (false) {
+    // Unsupported in vixl.
+    TEST_SINGLE(wfet(Reg::r30), "wfet x30");
+    TEST_SINGLE(wfit(Reg::r30), "wfit x30");
+  }
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: System: Hints") {
+  TEST_SINGLE(nop(), "nop");
+  TEST_SINGLE(yield(), "yield");
+  TEST_SINGLE(wfe(), "wfe");
+  TEST_SINGLE(wfi(), "wfi");
+  TEST_SINGLE(sev(), "sev");
+  TEST_SINGLE(sevl(), "sevl");
+  TEST_SINGLE(dgh(), "dgh");
+  TEST_SINGLE(csdb(), "csdb");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: System: Barriers") {
+  TEST_SINGLE(clrex(0), "clrex #0x0");
+  TEST_SINGLE(clrex(15), "clrex");
+
+  TEST_SINGLE(dsb(BarrierScope::OSHLD), "dsb oshld");
+  TEST_SINGLE(dsb(BarrierScope::OSHST), "dsb oshst");
+  TEST_SINGLE(dsb(BarrierScope::OSH), "dsb osh");
+  TEST_SINGLE(dsb(BarrierScope::NSHLD), "dsb nshld");
+  TEST_SINGLE(dsb(BarrierScope::NSHST), "dsb nshst");
+  TEST_SINGLE(dsb(BarrierScope::NSH), "dsb nsh");
+  TEST_SINGLE(dsb(BarrierScope::ISHLD), "dsb ishld");
+  TEST_SINGLE(dsb(BarrierScope::ISHST), "dsb ishst");
+  TEST_SINGLE(dsb(BarrierScope::ISH), "dsb ish");
+  TEST_SINGLE(dsb(BarrierScope::LD), "dsb ld");
+  TEST_SINGLE(dsb(BarrierScope::ST), "dsb st");
+  TEST_SINGLE(dsb(BarrierScope::SY), "dsb sy");
+
+  TEST_SINGLE(dmb(BarrierScope::OSHLD), "dmb oshld");
+  TEST_SINGLE(dmb(BarrierScope::OSHST), "dmb oshst");
+  TEST_SINGLE(dmb(BarrierScope::OSH), "dmb osh");
+  TEST_SINGLE(dmb(BarrierScope::NSHLD), "dmb nshld");
+  TEST_SINGLE(dmb(BarrierScope::NSHST), "dmb nshst");
+  TEST_SINGLE(dmb(BarrierScope::NSH), "dmb nsh");
+  TEST_SINGLE(dmb(BarrierScope::ISHLD), "dmb ishld");
+  TEST_SINGLE(dmb(BarrierScope::ISHST), "dmb ishst");
+  TEST_SINGLE(dmb(BarrierScope::ISH), "dmb ish");
+  TEST_SINGLE(dmb(BarrierScope::LD), "dmb ld");
+  TEST_SINGLE(dmb(BarrierScope::ST), "dmb st");
+  TEST_SINGLE(dmb(BarrierScope::SY), "dmb sy");
+
+  TEST_SINGLE(isb(), "isb");
+
+  // vixl has a decoding bug claiming these are system level instructions.
+  TEST_SINGLE(sb(), "sb (System)");
+  TEST_SINGLE(tcommit(), "tcommit (System)");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: System: System register move") {
+  // vixl doesn't have decoding for a bunch of these.
+  // Also most of these aren't writeable from el0, just testing the encoding.
+  TEST_SINGLE(msr(SystemRegister::CTR_EL0, Reg::r30), "msr S3_3_c0_c0_1, x30");
+  TEST_SINGLE(msr(SystemRegister::DCZID_EL0, Reg::r30), "msr S3_3_c0_c0_7, x30");
+  TEST_SINGLE(msr(SystemRegister::TPIDR_EL0, Reg::r30), "msr S3_3_c13_c0_2, x30");
+  TEST_SINGLE(msr(SystemRegister::RNDR, Reg::r30), "msr rndr, x30");
+  TEST_SINGLE(msr(SystemRegister::RNDRRS, Reg::r30), "msr rndrrs, x30");
+  TEST_SINGLE(msr(SystemRegister::NZCV, Reg::r30), "msr nzcv, x30");
+  TEST_SINGLE(msr(SystemRegister::FPCR, Reg::r30), "msr fpcr, x30");
+  TEST_SINGLE(msr(SystemRegister::CNTFRQ_EL0, Reg::r30), "msr S3_3_c14_c0_0, x30");
+  TEST_SINGLE(msr(SystemRegister::CNTVCT_EL0, Reg::r30), "msr S3_3_c14_c0_2, x30");
+
+  TEST_SINGLE(mrs(Reg::r30, SystemRegister::CTR_EL0), "mrs x30, S3_3_c0_c0_1");
+  TEST_SINGLE(mrs(Reg::r30, SystemRegister::DCZID_EL0), "mrs x30, S3_3_c0_c0_7");
+  TEST_SINGLE(mrs(Reg::r30, SystemRegister::TPIDR_EL0), "mrs x30, S3_3_c13_c0_2");
+  TEST_SINGLE(mrs(Reg::r30, SystemRegister::RNDR), "mrs x30, rndr");
+  TEST_SINGLE(mrs(Reg::r30, SystemRegister::RNDRRS), "mrs x30, rndrrs");
+  TEST_SINGLE(mrs(Reg::r30, SystemRegister::NZCV), "mrs x30, nzcv");
+  TEST_SINGLE(mrs(Reg::r30, SystemRegister::FPCR), "mrs x30, fpcr");
+  TEST_SINGLE(mrs(Reg::r30, SystemRegister::CNTFRQ_EL0), "mrs x30, S3_3_c14_c0_0");
+  TEST_SINGLE(mrs(Reg::r30, SystemRegister::CNTVCT_EL0), "mrs x30, S3_3_c14_c0_2");
+}

--- a/External/FEXCore/unittests/Emitter/TestDisassembler.h
+++ b/External/FEXCore/unittests/Emitter/TestDisassembler.h
@@ -1,0 +1,75 @@
+#pragma once
+#include "Interface/Core/ArchHelpers/CodeEmitter/Emitter.h"
+
+#include <aarch64/cpu-aarch64.h>
+#include <aarch64/instructions-aarch64.h>
+#include <aarch64/disasm-aarch64.h>
+
+#include <sys/mman.h>
+
+class TestDisassembler : public FEXCore::ARMEmitter::Emitter  {
+public:
+  TestDisassembler() {
+    fp = tmpfile();
+    Disasm = std::make_unique<vixl::aarch64::PrintDisassembler>(fp);
+    SetBuffer(reinterpret_cast<uint8_t*>(mmap(nullptr, 4096, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0)), 4096);
+    BufferBegin = GetCursorAddress<const vixl::aarch64::Instruction*>();
+  }
+  ~TestDisassembler() {
+    fclose(fp);
+  }
+
+  std::string DisassembleSingle() {
+    HandleDisasm();
+    char Tmp[512];
+    uint64_t Addr;
+    uint32_t Encoding;
+    int Num = fscanf(fp, "0x%lx %x %[^\n]\n", &Addr, &Encoding, Tmp);
+    if (Num != 3) {
+      return "<Invalid>";
+    }
+    ResetFP();
+
+    return Tmp;
+  }
+
+  uint32_t DisassembleEncoding(size_t Offset = 0) {
+    const uint32_t *Values = reinterpret_cast<const uint32_t*>(GetBufferBase());
+    SetCursorOffset(0);
+    ResetFP();
+    return Values[Offset];
+  }
+
+  std::string DisassembleString() {
+    HandleDisasm();
+    std::string Decoded{};
+    char Tmp[512];
+    uint64_t Addr;
+    uint32_t Encoding;
+    while (fscanf(fp, "0x%lx %x %[^\n]\n", &Addr, &Encoding, Tmp) == 3) {
+      Decoded += std::string_view(Tmp);
+      Decoded += "\n";
+    }
+
+    ResetFP();
+    return Decoded;
+  }
+private:
+  void HandleDisasm() {
+    const auto BufferEnd = GetCursorAddress<const vixl::aarch64::Instruction*>();
+    Disasm->DisassembleBuffer(BufferBegin, BufferEnd);
+    SetCursorOffset(0);
+    fseek(fp, 0, SEEK_SET);
+  }
+  void ResetFP() {
+    fseek(fp, 0, SEEK_SET);
+  }
+  FILE *fp;
+  const vixl::aarch64::Instruction* BufferBegin;
+  std::unique_ptr<vixl::aarch64::PrintDisassembler> Disasm;
+};
+
+#define TEST_SINGLE(emit, expected) \
+{ \
+  CHECK((emit, DisassembleSingle()) == expected); \
+}


### PR DESCRIPTION
While profiling the runtime code, vixl has been showing up as a reasonable amount of time in the JIT code due to how bloated the code emission is. Primarily it has a ton of conveniences in both the MacroAssembler and Assembler which makes the programmer's life easier. Most of this ends up in runtime code rather than compile time code which means it gets quite branchy and a just needs a lot of code to be run.

So let's switch over to our own custom ARM Emitter that is tailored towards FEX's performance needs. This emitter is written around the idea that we know the operation sizes at runtime and can use ternary operations to do the minor instruction modifications. This removes a lot of vixl's developer conveniences for the sake of SPEED. To the point that for some of the more complex IR ops and dispatcher we are now generating 128-bit loadstore operations when the code is being emitted. Compared to vixl almost always branching out and doing a single instruction at a time.

Some /very/ preliminary testing shows that this is removing ~27% CPU time from the code emission step of the ARM64 JIT. This is a better improvement than the original suspected 25% time consumed from vixl. Showing that vixl was poisoning cache, BTB, etc due to its large code footprint. Still need to dive in for some more detailed testing about how much of an improvement this is.

Remaining work:
ARMEmitter:
- [X] Implement remaining SVE operations - **Remainder to be done post-merge**
- [X] Implement remaining vector operations - **Remainder to be done post-merge**
- [X] Implement remaining scalar operations - **Remainder to be done post-merge**
- [X] Implement remaining misc operations - **Remainder to be done post-merge**
- [X] Fix ARMv8.0 atomics.
- [X] Clean up
- [X] Documentation
- [X] Basic level of testing

Testing:
- [X] Need to ensure all FEX tests pass.
- [X] Need to ensure Steam still runs
- [X] Need to test a bunch of games
- [X] Figure out why Steam is crashing early in startup.

This is going to be a nightmare to review I know.