### PR TITLE
ThunkDB: Clean up database loading

### DIFF
--- a/Source/Tests/LinuxSyscalls/FileManagement.h
+++ b/Source/Tests/LinuxSyscalls/FileManagement.h
@@ -96,14 +96,5 @@ private:
   FEX_CONFIG_OPT(AppConfigName, APP_CONFIG_NAME);
   FEX_CONFIG_OPT(Is64BitMode, IS64BIT_MODE);
   uint32_t CurrentPID{};
-
-  void LoadThunkDatabase(bool Global);
-  struct ThunkDBObject {
-    std::string LibraryName;
-    std::unordered_set<std::string> Depends;
-    std::vector<std::string> Overlays;
-    bool Enabled{};
-  };
-  std::unordered_map<std::string, ThunkDBObject> ThunkDB{};
 };
 }


### PR DESCRIPTION
A number of various cleanups eliminating the bits that confused me while trying to understand this code the first time.

* Reduces floating state carried around in lambdas (and the overall number of lambdas used)
* Replaces thunk DB template handling (such as `%ARCH_PREFIX%`): Instead of iteratively replacing each "prefix" one after the other, all of them are replaced in one go now
* Decouples processing steps that were previously intertwined (such as DB template filling and the actual insertion into the `Overlays` list)

As a side effect, this avoids a few heap allocations from `std::string` and `std::function`.
