### PR TITLE
unittests: Adds negative integer x87 tests

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -163,7 +163,7 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header const *IROp, IR::NodeID Node) {
 
         const auto Src1 = GetReg(IROp->Args[0].ID());
         if (Info.ABI == FABI_F80_I16) {
-          uxth(ARMEmitter::Size::i32Bit, ARMEmitter::Reg::r0, Src1);
+          sxth(ARMEmitter::Size::i32Bit, ARMEmitter::Reg::r0, Src1);
         }
         else {
           mov(ARMEmitter::Size::i32Bit, ARMEmitter::Reg::r0, Src1);
@@ -310,7 +310,7 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header const *IROp, IR::NodeID Node) {
         FillStaticRegs();
 
         const auto Dst = GetReg(Node);
-        uxth(ARMEmitter::Size::i64Bit, Dst, ARMEmitter::Reg::r0);
+        sxth(ARMEmitter::Size::i64Bit, Dst, ARMEmitter::Reg::r0);
       }
       break;
       case FABI_I32_F80:{

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -147,7 +147,12 @@ void X86JITCore::Op_Unhandled(IR::IROp_Header *IROp, IR::NodeID Node) {
       case FABI_F80_I32: {
         PushRegs();
 
-        mov(edi, GetSrc<RA_32>(IROp->Args[0].ID()));
+        if (Info.ABI == FABI_F80_I16) {
+          movsx(rdi, GetSrc<RA_32>(IROp->Args[0].ID()).cvt16());
+        }
+        else {
+          mov(edi, GetSrc<RA_32>(IROp->Args[0].ID()));
+        }
         call(qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.FallbackHandlerPointers[Info.HandlerIndex])]);
 
         PopRegs();
@@ -223,7 +228,7 @@ void X86JITCore::Op_Unhandled(IR::IROp_Header *IROp, IR::NodeID Node) {
 
         PopRegs();
 
-        movzx(GetDst<RA_64>(Node), ax);
+        movsx(GetDst<RA_64>(Node), ax);
       }
       break;
       case FABI_I32_F80:{

--- a/unittests/32Bit_ASM/X87/DA_00.asm
+++ b/unittests/32Bit_ASM/X87/DA_00.asm
@@ -1,7 +1,8 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "MM7":  ["0xc000000000000000", "0x4000"]
+    "XMM0":  ["0xc000000000000000", "0x4000"],
+    "XMM1":  ["0x8000000000000000", "0xbfff"]
   },
   "Mode": "32BIT"
 }
@@ -11,8 +12,31 @@ lea edx, [.data]
 
 fld qword [edx + 8 * 0]
 fiadd dword [edx + 8 * 1]
+
+fstp tword [rel data2]
+
+movups xmm0, [rel data2]
+
+; Test negative
+lea edx, [.data_neg]
+
+fld qword [edx + 8 * 0]
+fiadd dword [edx + 8 * 1]
+
+fstp tword [rel data2]
+
+movups xmm1, [rel data2]
+
 hlt
 
 .data:
 dq 0x3ff0000000000000
 dq 2
+
+.data_neg:
+dq 0x3ff0000000000000
+dq -2
+
+data2:
+dq 0
+dq 0

--- a/unittests/32Bit_ASM/X87/DA_01.asm
+++ b/unittests/32Bit_ASM/X87/DA_01.asm
@@ -1,7 +1,8 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "MM7":  ["0x8000000000000000", "0x4000"]
+    "XMM0":  ["0x8000000000000000", "0x4000"],
+    "XMM1":  ["0x8000000000000000", "0xC000"]
   },
   "Mode": "32BIT"
 }
@@ -11,8 +12,27 @@ lea edx, [.data]
 
 fld qword [edx + 8 * 0]
 fimul dword [edx + 8 * 1]
+fstp tword [rel data2]
+movups xmm0, [rel data2]
+
+; Test negative
+lea edx, [.data_neg]
+
+fld qword [edx + 8 * 0]
+fimul dword [edx + 8 * 1]
+fstp tword [rel data2]
+movups xmm1, [rel data2]
+
 hlt
 
 .data:
 dq 0x3ff0000000000000
 dq 2
+
+.data_neg:
+dq 0x3ff0000000000000
+dq -2
+
+data2:
+dq 0
+dq 0

--- a/unittests/32Bit_ASM/X87/DA_04.asm
+++ b/unittests/32Bit_ASM/X87/DA_04.asm
@@ -1,7 +1,8 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "MM7":  ["0x8000000000000000", "0xBFFF"]
+    "XMM0":  ["0x8000000000000000", "0xBFFF"],
+    "XMM1":  ["0xC000000000000000", "0x4000"]
   },
   "Mode": "32BIT"
 }
@@ -11,8 +12,27 @@ lea edx, [.data]
 
 fld qword [edx + 8 * 0]
 fisub dword [edx + 8 * 1]
+fstp tword [rel data2]
+movups xmm0, [rel data2]
+
+; Test negative
+lea edx, [.data_neg]
+
+fld qword [edx + 8 * 0]
+fisub dword [edx + 8 * 1]
+fstp tword [rel data2]
+movups xmm1, [rel data2]
+
 hlt
 
 .data:
 dq 0x3ff0000000000000
 dq 2
+
+.data_neg:
+dq 0x3ff0000000000000
+dq -2
+
+data2:
+dq 0
+dq 0

--- a/unittests/32Bit_ASM/X87/DA_05.asm
+++ b/unittests/32Bit_ASM/X87/DA_05.asm
@@ -1,7 +1,8 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "MM7":  ["0x8000000000000000", "0x3FFF"]
+    "XMM0":  ["0x8000000000000000", "0x3FFF"],
+    "XMM1":  ["0xC000000000000000", "0xC000"]
   },
   "Mode": "32BIT"
 }
@@ -11,8 +12,27 @@ lea edx, [.data]
 
 fld qword [edx + 8 * 0]
 fisubr dword [edx + 8 * 1]
+fstp tword [rel data2]
+movups xmm0, [rel data2]
+
+; Test negative
+lea edx, [.data_neg]
+
+fld qword [edx + 8 * 0]
+fisubr dword [edx + 8 * 1]
+fstp tword [rel data2]
+movups xmm1, [rel data2]
+
 hlt
 
 .data:
 dq 0x3ff0000000000000
 dq 2
+
+.data_neg:
+dq 0x3ff0000000000000
+dq -2
+
+data2:
+dq 0
+dq 0

--- a/unittests/32Bit_ASM/X87/DA_06.asm
+++ b/unittests/32Bit_ASM/X87/DA_06.asm
@@ -1,7 +1,8 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "MM7":  ["0x8000000000000000", "0x3FFE"]
+    "XMM0":  ["0x8000000000000000", "0x3FFE"],
+    "XMM1":  ["0x8000000000000000", "0xBFFE"]
   },
   "Mode": "32BIT"
 }
@@ -11,8 +12,27 @@ lea edx, [.data]
 
 fld qword [edx + 8 * 0]
 fidiv dword [edx + 8 * 1]
+fstp tword [rel data2]
+movups xmm0, [rel data2]
+
+; Test negative
+lea edx, [.data_neg]
+
+fld qword [edx + 8 * 0]
+fidiv dword [edx + 8 * 1]
+fstp tword [rel data2]
+movups xmm1, [rel data2]
+
 hlt
 
 .data:
 dq 0x3ff0000000000000
 dq 2
+
+.data_neg:
+dq 0x3ff0000000000000
+dq -2
+
+data2:
+dq 0
+dq 0

--- a/unittests/32Bit_ASM/X87/DA_07.asm
+++ b/unittests/32Bit_ASM/X87/DA_07.asm
@@ -1,7 +1,8 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "MM7":  ["0x8000000000000000", "0x4000"]
+    "XMM0":  ["0x8000000000000000", "0x4000"],
+    "XMM1":  ["0x8000000000000000", "0xC000"]
   },
   "Mode": "32BIT"
 }
@@ -11,8 +12,29 @@ lea edx, [.data]
 
 fld qword [edx + 8 * 0]
 fidivr dword [edx + 8 * 1]
+
+fstp tword [rel data2]
+movups xmm0, [rel data2]
+
+; Test negative
+lea edx, [.data_neg]
+
+fld qword [edx + 8 * 0]
+fidivr dword [edx + 8 * 1]
+
+fstp tword [rel data2]
+movups xmm1, [rel data2]
+
 hlt
 
 .data:
 dq 0x3ff0000000000000
 dq 2
+
+.data_neg:
+dq 0x3ff0000000000000
+dq -2
+
+data2:
+dq 0
+dq 0

--- a/unittests/32Bit_ASM/X87/DE_00.asm
+++ b/unittests/32Bit_ASM/X87/DE_00.asm
@@ -1,7 +1,8 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "MM7":  ["0xc000000000000000", "0x4000"]
+    "XMM0":  ["0xc000000000000000", "0x4000"],
+    "XMM1":  ["0x8000000000000000", "0xbfff"]
   },
   "Mode": "32BIT"
 }
@@ -11,8 +12,29 @@ lea edx, [.data]
 
 fld qword [edx + 8 * 0]
 fiadd word [edx + 8 * 1]
+fstp tword [rel data2]
+movups xmm0, [rel data2]
+
+; Test negative
+lea edx, [.data_neg]
+
+fld qword [edx + 8 * 0]
+fiadd word [edx + 8 * 1]
+
+fstp tword [rel data2]
+
+movups xmm1, [rel data2]
+
 hlt
 
 .data:
 dq 0x3ff0000000000000
 dq 2
+
+.data_neg:
+dq 0x3ff0000000000000
+dq -2
+
+data2:
+dq 0
+dq 0

--- a/unittests/32Bit_ASM/X87/DE_01.asm
+++ b/unittests/32Bit_ASM/X87/DE_01.asm
@@ -1,7 +1,8 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "MM7":  ["0x8000000000000000", "0x4000"]
+    "XMM0":  ["0x8000000000000000", "0x4000"],
+    "XMM1":  ["0x8000000000000000", "0xC000"]
   },
   "Mode": "32BIT"
 }
@@ -11,8 +12,27 @@ lea edx, [.data]
 
 fld qword [edx + 8 * 0]
 fimul word [edx + 8 * 1]
+fstp tword [rel data2]
+movups xmm0, [rel data2]
+
+; Test negative
+lea edx, [.data_neg]
+
+fld qword [edx + 8 * 0]
+fimul word [edx + 8 * 1]
+fstp tword [rel data2]
+movups xmm1, [rel data2]
+
 hlt
 
 .data:
 dq 0x3ff0000000000000
 dq 2
+
+.data_neg:
+dq 0x3ff0000000000000
+dq -2
+
+data2:
+dq 0
+dq 0

--- a/unittests/32Bit_ASM/X87/DE_04.asm
+++ b/unittests/32Bit_ASM/X87/DE_04.asm
@@ -1,7 +1,8 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "MM7":  ["0x8000000000000000", "0xBFFF"]
+    "XMM0":  ["0x8000000000000000", "0xBFFF"],
+    "XMM1":  ["0xc000000000000000", "0x4000"]
   },
   "Mode": "32BIT"
 }
@@ -11,8 +12,27 @@ lea edx, [.data]
 
 fld qword [edx + 8 * 0]
 fisub word [edx + 8 * 1]
+fstp tword [rel data2]
+movups xmm0, [rel data2]
+
+; Test negative
+lea edx, [.data_neg]
+
+fld qword [edx + 8 * 0]
+fisub word [edx + 8 * 1]
+fstp tword [rel data2]
+movups xmm1, [rel data2]
+
 hlt
 
 .data:
 dq 0x3ff0000000000000
 dq 2
+
+.data_neg:
+dq 0x3ff0000000000000
+dq -2
+
+data2:
+dq 0
+dq 0

--- a/unittests/32Bit_ASM/X87/DE_05.asm
+++ b/unittests/32Bit_ASM/X87/DE_05.asm
@@ -1,7 +1,8 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "MM7":  ["0x8000000000000000", "0x3FFF"]
+    "XMM0":  ["0x8000000000000000", "0x3FFF"],
+    "XMM1":  ["0xC000000000000000", "0xC000"]
   },
   "Mode": "32BIT"
 }
@@ -11,8 +12,27 @@ lea edx, [.data]
 
 fld qword [edx + 8 * 0]
 fisubr word [edx + 8 * 1]
+fstp tword [rel data2]
+movups xmm0, [rel data2]
+
+; Test negative
+lea edx, [.data_neg]
+
+fld qword [edx + 8 * 0]
+fisubr word [edx + 8 * 1]
+fstp tword [rel data2]
+movups xmm1, [rel data2]
+
 hlt
 
 .data:
 dq 0x3ff0000000000000
 dq 2
+
+.data_neg:
+dq 0x3ff0000000000000
+dq -2
+
+data2:
+dq 0
+dq 0

--- a/unittests/32Bit_ASM/X87/DE_06.asm
+++ b/unittests/32Bit_ASM/X87/DE_06.asm
@@ -1,7 +1,8 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "MM7":  ["0x8000000000000000", "0x3FFE"]
+    "XMM0":  ["0x8000000000000000", "0x3FFE"],
+    "XMM1":  ["0x8000000000000000", "0xBFFE"]
   },
   "Mode": "32BIT"
 }
@@ -11,8 +12,27 @@ lea edx, [.data]
 
 fld qword [edx + 8 * 0]
 fidiv word [edx + 8 * 1]
+fstp tword [rel data2]
+movups xmm0, [rel data2]
+
+; Test negative
+lea edx, [.data_neg]
+
+fld qword [edx + 8 * 0]
+fidiv word [edx + 8 * 1]
+fstp tword [rel data2]
+movups xmm1, [rel data2]
+
 hlt
 
 .data:
 dq 0x3ff0000000000000
 dq 2
+
+.data_neg:
+dq 0x3ff0000000000000
+dq -2
+
+data2:
+dq 0
+dq 0

--- a/unittests/32Bit_ASM/X87/DE_07.asm
+++ b/unittests/32Bit_ASM/X87/DE_07.asm
@@ -1,7 +1,8 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "MM7":  ["0x8000000000000000", "0x4000"]
+    "XMM0":  ["0x8000000000000000", "0x4000"],
+    "XMM1":  ["0x8000000000000000", "0xC000"]
   },
   "Mode": "32BIT"
 }
@@ -11,8 +12,27 @@ lea edx, [.data]
 
 fld qword [edx + 8 * 0]
 fidivr word [edx + 8 * 1]
+fstp tword [rel data2]
+movups xmm0, [rel data2]
+
+; Test negative
+lea edx, [.data_neg]
+
+fld qword [edx + 8 * 0]
+fidivr word [edx + 8 * 1]
+fstp tword [rel data2]
+movups xmm1, [rel data2]
+
 hlt
 
 .data:
 dq 0x3ff0000000000000
 dq 2
+
+.data_neg:
+dq 0x3ff0000000000000
+dq -2
+
+data2:
+dq 0
+dq 0

--- a/unittests/ASM/X87/DA_00.asm
+++ b/unittests/ASM/X87/DA_00.asm
@@ -1,7 +1,8 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "MM7":  ["0xc000000000000000", "0x4000"]
+    "XMM0":  ["0xc000000000000000", "0x4000"],
+    "XMM1":  ["0x8000000000000000", "0xbfff"]
   },
   "MemoryRegions": {
     "0x100000000": "4096"
@@ -18,4 +19,27 @@ mov [rdx + 8 * 1], eax
 
 fld qword [rdx + 8 * 0]
 fiadd dword [rdx + 8 * 1]
+
+fstp tword [rel data]
+
+movups xmm0, [rel data]
+
+; Test negative
+
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov eax, -2
+mov [rdx + 8 * 1], eax
+
+fld qword [rdx + 8 * 0]
+fiadd dword [rdx + 8 * 1]
+
+fstp tword [rel data]
+
+movups xmm1, [rel data]
+
 hlt
+
+data:
+dq 0
+dq 0

--- a/unittests/ASM/X87/DA_01.asm
+++ b/unittests/ASM/X87/DA_01.asm
@@ -1,7 +1,8 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "MM7":  ["0x8000000000000000", "0x4000"]
+    "XMM0":  ["0x8000000000000000", "0x4000"],
+    "XMM1":  ["0x8000000000000000", "0xC000"]
   },
   "MemoryRegions": {
     "0x100000000": "4096"
@@ -18,4 +19,22 @@ mov [rdx + 8 * 1], eax
 
 fld qword [rdx + 8 * 0]
 fimul dword [rdx + 8 * 1]
+fstp tword [rel data2]
+movups xmm0, [rel data2]
+
+; Test negative
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov eax, -2
+mov [rdx + 8 * 1], eax
+
+fld qword [rdx + 8 * 0]
+fimul dword [rdx + 8 * 1]
+fstp tword [rel data2]
+movups xmm1, [rel data2]
+
 hlt
+
+data2:
+dq 0
+dq 0

--- a/unittests/ASM/X87/DA_04.asm
+++ b/unittests/ASM/X87/DA_04.asm
@@ -1,7 +1,8 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "MM7":  ["0x8000000000000000", "0xBFFF"]
+    "XMM0":  ["0x8000000000000000", "0xBFFF"],
+    "XMM1":  ["0xC000000000000000", "0x4000"]
   },
   "MemoryRegions": {
     "0x100000000": "4096"
@@ -18,4 +19,22 @@ mov [rdx + 8 * 1], eax
 
 fld qword [rdx + 8 * 0]
 fisub dword [rdx + 8 * 1]
+fstp tword [rel data]
+movups xmm0, [rel data]
+
+; Test negative
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov eax, -2
+mov [rdx + 8 * 1], eax
+
+fld qword [rdx + 8 * 0]
+fisub dword [rdx + 8 * 1]
+fstp tword [rel data]
+movups xmm1, [rel data]
+
 hlt
+
+data:
+dq 0
+dq 0

--- a/unittests/ASM/X87/DA_05.asm
+++ b/unittests/ASM/X87/DA_05.asm
@@ -1,7 +1,8 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "MM7":  ["0x8000000000000000", "0x3FFF"]
+    "XMM0":  ["0x8000000000000000", "0x3FFF"],
+    "XMM1":  ["0xC000000000000000", "0xC000"]
   },
   "MemoryRegions": {
     "0x100000000": "4096"
@@ -18,4 +19,22 @@ mov [rdx + 8 * 1], eax
 
 fld qword [rdx + 8 * 0]
 fisubr dword [rdx + 8 * 1]
+fstp tword [rel data]
+movups xmm0, [rel data]
+
+; Test negative
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov eax, -2
+mov [rdx + 8 * 1], eax
+
+fld qword [rdx + 8 * 0]
+fisubr dword [rdx + 8 * 1]
+fstp tword [rel data]
+movups xmm1, [rel data]
+
 hlt
+
+data:
+dq 0
+dq 0

--- a/unittests/ASM/X87/DA_06.asm
+++ b/unittests/ASM/X87/DA_06.asm
@@ -1,7 +1,8 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "MM7":  ["0x8000000000000000", "0x3FFE"]
+    "XMM0":  ["0x8000000000000000", "0x3FFE"],
+    "XMM1":  ["0x8000000000000000", "0xBFFE"]
   },
   "MemoryRegions": {
     "0x100000000": "4096"
@@ -18,4 +19,24 @@ mov [rdx + 8 * 1], eax
 
 fld qword [rdx + 8 * 0]
 fidiv dword [rdx + 8 * 1]
+
+fstp tword [rel data]
+movups xmm0, [rel data]
+
+; Test negative
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov eax, -2
+mov [rdx + 8 * 1], eax
+
+fld qword [rdx + 8 * 0]
+fidiv dword [rdx + 8 * 1]
+
+fstp tword [rel data]
+movups xmm1, [rel data]
+
 hlt
+
+data:
+dq 0
+dq 0

--- a/unittests/ASM/X87/DA_07.asm
+++ b/unittests/ASM/X87/DA_07.asm
@@ -1,7 +1,8 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "MM7":  ["0x8000000000000000", "0x4000"]
+    "XMM0":  ["0x8000000000000000", "0x4000"],
+    "XMM1":  ["0x8000000000000000", "0xC000"]
   },
   "MemoryRegions": {
     "0x100000000": "4096"
@@ -18,4 +19,22 @@ mov [rdx + 8 * 1], eax
 
 fld qword [rdx + 8 * 0]
 fidivr dword [rdx + 8 * 1]
+fstp tword [rel data]
+movups xmm0, [rel data]
+
+; Test negative
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov eax, -2
+mov [rdx + 8 * 1], eax
+
+fld qword [rdx + 8 * 0]
+fidivr dword [rdx + 8 * 1]
+fstp tword [rel data]
+movups xmm1, [rel data]
+
 hlt
+
+data:
+dq 0
+dq 0

--- a/unittests/ASM/X87/DE_00.asm
+++ b/unittests/ASM/X87/DE_00.asm
@@ -1,7 +1,8 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "MM7":  ["0xc000000000000000", "0x4000"]
+    "XMM0":  ["0xc000000000000000", "0x4000"],
+    "XMM1":  ["0x8000000000000000", "0xbfff"]
   },
   "MemoryRegions": {
     "0x100000000": "4096"
@@ -18,4 +19,27 @@ mov [rdx + 8 * 1], ax
 
 fld qword [rdx + 8 * 0]
 fiadd word [rdx + 8 * 1]
+
+fstp tword [rel data]
+
+movups xmm0, [rel data]
+
+; Test negative
+
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov ax, -2
+mov [rdx + 8 * 1], ax
+
+fld qword [rdx + 8 * 0]
+fiadd word [rdx + 8 * 1]
+
+fstp tword [rel data]
+
+movups xmm1, [rel data]
+
 hlt
+
+data:
+dq 0
+dq 0

--- a/unittests/ASM/X87/DE_01.asm
+++ b/unittests/ASM/X87/DE_01.asm
@@ -1,7 +1,8 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "MM7":  ["0x8000000000000000", "0x4000"]
+    "XMM0":  ["0x8000000000000000", "0x4000"],
+    "XMM1":  ["0x8000000000000000", "0xC000"]
   },
   "MemoryRegions": {
     "0x100000000": "4096"
@@ -18,4 +19,22 @@ mov [rdx + 8 * 1], ax
 
 fld qword [rdx + 8 * 0]
 fimul word [rdx + 8 * 1]
+fstp tword [rel data2]
+movups xmm0, [rel data2]
+
+; Test negative
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov ax, -2
+mov [rdx + 8 * 1], ax
+
+fld qword [rdx + 8 * 0]
+fimul word [rdx + 8 * 1]
+fstp tword [rel data2]
+movups xmm1, [rel data2]
+
 hlt
+
+data2:
+dq 0
+dq 0

--- a/unittests/ASM/X87/DE_04.asm
+++ b/unittests/ASM/X87/DE_04.asm
@@ -1,7 +1,8 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "MM7":  ["0x8000000000000000", "0xBFFF"]
+    "XMM0":  ["0x8000000000000000", "0xBFFF"],
+    "XMM1":  ["0xC000000000000000", "0x4000"]
   },
   "MemoryRegions": {
     "0x100000000": "4096"
@@ -18,4 +19,22 @@ mov [rdx + 8 * 1], ax
 
 fld qword [rdx + 8 * 0]
 fisub word [rdx + 8 * 1]
+fstp tword [rel data]
+movups xmm0, [rel data]
+
+; Test negative
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov ax, -2
+mov [rdx + 8 * 1], ax
+
+fld qword [rdx + 8 * 0]
+fisub word [rdx + 8 * 1]
+fstp tword [rel data]
+movups xmm1, [rel data]
+
 hlt
+
+data:
+dq 0
+dq 0

--- a/unittests/ASM/X87/DE_05.asm
+++ b/unittests/ASM/X87/DE_05.asm
@@ -1,7 +1,8 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "MM7":  ["0x8000000000000000", "0x3FFF"]
+    "XMM0":  ["0x8000000000000000", "0x3FFF"],
+    "XMM1":  ["0xC000000000000000", "0xC000"]
   },
   "MemoryRegions": {
     "0x100000000": "4096"
@@ -18,4 +19,22 @@ mov [rdx + 8 * 1], ax
 
 fld qword [rdx + 8 * 0]
 fisubr word [rdx + 8 * 1]
+fstp tword [rel data]
+movups xmm0, [rel data]
+
+; Test negative
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov ax, -2
+mov [rdx + 8 * 1], ax
+
+fld qword [rdx + 8 * 0]
+fisubr word [rdx + 8 * 1]
+fstp tword [rel data]
+movups xmm1, [rel data]
+
 hlt
+
+data:
+dq 0
+dq 0

--- a/unittests/ASM/X87/DE_06.asm
+++ b/unittests/ASM/X87/DE_06.asm
@@ -1,7 +1,8 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "MM7":  ["0x8000000000000000", "0x3FFE"]
+    "XMM0":  ["0x8000000000000000", "0x3FFE"],
+    "XMM1":  ["0x8000000000000000", "0xBFFE"]
   },
   "MemoryRegions": {
     "0x100000000": "4096"
@@ -18,4 +19,22 @@ mov [rdx + 8 * 1], ax
 
 fld qword [rdx + 8 * 0]
 fidiv word [rdx + 8 * 1]
+fstp tword [rel data]
+movups xmm0, [rel data]
+
+; Test negative
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov ax, -2
+mov [rdx + 8 * 1], ax
+
+fld qword [rdx + 8 * 0]
+fidiv word [rdx + 8 * 1]
+fstp tword [rel data]
+movups xmm1, [rel data]
+
 hlt
+
+data:
+dq 0
+dq 0

--- a/unittests/ASM/X87/DE_07.asm
+++ b/unittests/ASM/X87/DE_07.asm
@@ -1,7 +1,8 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "MM7":  ["0x8000000000000000", "0x4000"]
+    "XMM0":  ["0x8000000000000000", "0x4000"],
+    "XMM1":  ["0x8000000000000000", "0xC000"]
   },
   "MemoryRegions": {
     "0x100000000": "4096"
@@ -18,4 +19,22 @@ mov [rdx + 8 * 1], ax
 
 fld qword [rdx + 8 * 0]
 fidivr word [rdx + 8 * 1]
+fstp tword [rel data]
+movups xmm0, [rel data]
+
+; Test negative
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov ax, -2
+mov [rdx + 8 * 1], ax
+
+fld qword [rdx + 8 * 0]
+fidivr word [rdx + 8 * 1]
+fstp tword [rel data]
+movups xmm1, [rel data]
+
 hlt
+
+data:
+dq 0
+dq 0

--- a/unittests/ASM/X87_F64/DA_01_F64.asm
+++ b/unittests/ASM/X87_F64/DA_01_F64.asm
@@ -1,7 +1,8 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "RAX":  ["0x4000000000000000"]
+    "RCX":  ["0x4000000000000000"],
+    "RSI":  ["0xC000000000000000"]
   },
   "Env": { "FEX_X87REDUCEDPRECISION" : "1" }
 }
@@ -18,6 +19,18 @@ fld qword [rdx + 8 * 0]
 fimul dword [rdx + 8 * 1]
 
 fst qword [rdx]
-mov rax, [rdx]
+mov rcx, [rdx]
+
+; Test negative
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov eax, -2
+mov [rdx + 8 * 1], eax
+
+fld qword [rdx + 8 * 0]
+fimul dword [rdx + 8 * 1]
+
+fst qword [rdx]
+mov rsi, [rdx]
 
 hlt

--- a/unittests/ASM/X87_F64/DA_04_F64.asm
+++ b/unittests/ASM/X87_F64/DA_04_F64.asm
@@ -1,7 +1,8 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "RAX":  ["0xbff0000000000000"]
+    "RCX":  ["0xbff0000000000000"],
+    "RSI":  ["0x4008000000000000"]
   },
   "Env": { "FEX_X87REDUCEDPRECISION" : "1" }
 }
@@ -18,6 +19,18 @@ fld qword [rdx + 8 * 0]
 fisub dword [rdx + 8 * 1]
 
 fst qword [rdx]
-mov rax, [rdx]
+mov rcx, [rdx]
+
+; Test negative
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov eax, -2
+mov [rdx + 8 * 1], eax
+
+fld qword [rdx + 8 * 0]
+fisub dword [rdx + 8 * 1]
+
+fst qword [rdx]
+mov rsi, [rdx]
 
 hlt

--- a/unittests/ASM/X87_F64/DA_05_F64.asm
+++ b/unittests/ASM/X87_F64/DA_05_F64.asm
@@ -1,7 +1,8 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "RAX":  ["0x3ff0000000000000"]
+    "RCX":  ["0x3ff0000000000000"],
+    "RSI":  ["0xc008000000000000"]
   },
   "Env": { "FEX_X87REDUCEDPRECISION" : "1" }
 }
@@ -18,6 +19,18 @@ fld qword [rdx + 8 * 0]
 fisubr dword [rdx + 8 * 1]
 
 fst qword [rdx]
-mov rax, [rdx]
+mov rcx, [rdx]
+
+; Test negative
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov eax, -2
+mov [rdx + 8 * 1], eax
+
+fld qword [rdx + 8 * 0]
+fisubr dword [rdx + 8 * 1]
+
+fst qword [rdx]
+mov rsi, [rdx]
 
 hlt

--- a/unittests/ASM/X87_F64/DA_06_F64.asm
+++ b/unittests/ASM/X87_F64/DA_06_F64.asm
@@ -1,7 +1,8 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "RAX":  ["0x3fe0000000000000"]
+    "RCX":  ["0x3fe0000000000000"],
+    "RSI":  ["0xbfe0000000000000"]
   },
   "Env": { "FEX_X87REDUCEDPRECISION" : "1" }
 }
@@ -18,6 +19,18 @@ fld qword [rdx + 8 * 0]
 fidiv dword [rdx + 8 * 1]
 
 fst qword [rdx]
-mov rax, [rdx]
+mov rcx, [rdx]
+
+; Test negative
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov eax, -2
+mov [rdx + 8 * 1], eax
+
+fld qword [rdx + 8 * 0]
+fidiv dword [rdx + 8 * 1]
+
+fst qword [rdx]
+mov rsi, [rdx]
 
 hlt

--- a/unittests/ASM/X87_F64/DA_07_F64.asm
+++ b/unittests/ASM/X87_F64/DA_07_F64.asm
@@ -1,7 +1,8 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "RAX":  ["0x4000000000000000"]
+    "RCX":  ["0x4000000000000000"],
+    "RSI":  ["0xc000000000000000"]
   },
   "Env": { "FEX_X87REDUCEDPRECISION" : "1" }
 }
@@ -18,6 +19,18 @@ fld qword [rdx + 8 * 0]
 fidivr dword [rdx + 8 * 1]
 
 fst qword [rdx]
-mov rax, [rdx]
+mov rcx, [rdx]
+
+; Test negative
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov eax, -2
+mov [rdx + 8 * 1], eax
+
+fld qword [rdx + 8 * 0]
+fidivr dword [rdx + 8 * 1]
+
+fst qword [rdx]
+mov rsi, [rdx]
 
 hlt

--- a/unittests/ASM/X87_F64/DE_00_F64.asm
+++ b/unittests/ASM/X87_F64/DE_00_F64.asm
@@ -1,7 +1,8 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "RAX":  ["0x4008000000000000"]
+    "RCX":  ["0x4008000000000000"],
+    "RSI":  ["0xbff0000000000000"]
   },
   "Env": { "FEX_X87REDUCEDPRECISION" : "1" }
 }
@@ -18,6 +19,19 @@ fld qword [rdx + 8 * 0]
 fiadd word [rdx + 8 * 1]
 
 fst qword [rdx]
-mov rax, [rdx]
+mov rcx, [rdx]
+
+; Test negative
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov ax, -2
+mov [rdx + 8 * 1], ax
+
+fld qword [rdx + 8 * 0]
+fiadd word [rdx + 8 * 1]
+
+fst qword [rdx]
+mov rsi, [rdx]
+
 
 hlt

--- a/unittests/ASM/X87_F64/DE_01_F64.asm
+++ b/unittests/ASM/X87_F64/DE_01_F64.asm
@@ -1,7 +1,8 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "RAX":  ["0x4000000000000000"]
+    "RCX":  ["0x4000000000000000"],
+    "RSI":  ["0xC000000000000000"]
   },
   "Env": { "FEX_X87REDUCEDPRECISION" : "1" }
 }
@@ -18,6 +19,18 @@ fld qword [rdx + 8 * 0]
 fimul word [rdx + 8 * 1]
 
 fst qword [rdx]
-mov rax, [rdx]
+mov rcx, [rdx]
+
+; Test negative
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov ax, -2
+mov [rdx + 8 * 1], ax
+
+fld qword [rdx + 8 * 0]
+fimul word [rdx + 8 * 1]
+
+fst qword [rdx]
+mov rsi, [rdx]
 
 hlt

--- a/unittests/ASM/X87_F64/DE_04_F64.asm
+++ b/unittests/ASM/X87_F64/DE_04_F64.asm
@@ -1,7 +1,8 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "RAX":  ["0xbff0000000000000"]
+    "RCX":  ["0xbff0000000000000"],
+    "RSI":  ["0x4008000000000000"]
   },
   "Env": { "FEX_X87REDUCEDPRECISION" : "1" }
 }
@@ -18,6 +19,18 @@ fld qword [rdx + 8 * 0]
 fisub word [rdx + 8 * 1]
 
 fst qword [rdx]
-mov rax, [rdx]
+mov rcx, [rdx]
+
+; Test negative
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov ax, -2
+mov [rdx + 8 * 1], ax
+
+fld qword [rdx + 8 * 0]
+fisub word [rdx + 8 * 1]
+
+fst qword [rdx]
+mov rsi, [rdx]
 
 hlt

--- a/unittests/ASM/X87_F64/DE_05_F64.asm
+++ b/unittests/ASM/X87_F64/DE_05_F64.asm
@@ -1,7 +1,8 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "RAX":  ["0x3ff0000000000000"]
+    "RCX":  ["0x3ff0000000000000"],
+    "RSI":  ["0xc008000000000000"]
   },
   "Env": { "FEX_X87REDUCEDPRECISION" : "1" }
 }
@@ -18,6 +19,18 @@ fld qword [rdx + 8 * 0]
 fisubr word [rdx + 8 * 1]
 
 fst qword [rdx]
-mov rax, [rdx]
+mov rcx, [rdx]
+
+; Test negative
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov ax, -2
+mov [rdx + 8 * 1], ax
+
+fld qword [rdx + 8 * 0]
+fisubr word [rdx + 8 * 1]
+
+fst qword [rdx]
+mov rsi, [rdx]
 
 hlt

--- a/unittests/ASM/X87_F64/DE_06_F64.asm
+++ b/unittests/ASM/X87_F64/DE_06_F64.asm
@@ -1,7 +1,8 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "RAX":  ["0x3fe0000000000000"]
+    "RCX":  ["0x3fe0000000000000"],
+    "RSI":  ["0xbfe0000000000000"]
   },
   "Env": { "FEX_X87REDUCEDPRECISION" : "1" }
 }
@@ -18,6 +19,18 @@ fld qword [rdx + 8 * 0]
 fidiv word [rdx + 8 * 1]
 
 fst qword [rdx]
-mov rax, [rdx]
+mov rcx, [rdx]
+
+; Test negative
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov ax, -2
+mov [rdx + 8 * 1], ax
+
+fld qword [rdx + 8 * 0]
+fidiv word [rdx + 8 * 1]
+
+fst qword [rdx]
+mov rsi, [rdx]
 
 hlt

--- a/unittests/ASM/X87_F64/DE_07_F64.asm
+++ b/unittests/ASM/X87_F64/DE_07_F64.asm
@@ -1,7 +1,8 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "RAX":  ["0x4000000000000000"]
+    "RCX":  ["0x4000000000000000"],
+    "RSI":  ["0xc000000000000000"]
   },
   "Env": { "FEX_X87REDUCEDPRECISION" : "1" }
 }
@@ -18,6 +19,18 @@ fld qword [rdx + 8 * 0]
 fidivr word [rdx + 8 * 1]
 
 fst qword [rdx]
-mov rax, [rdx]
+mov rcx, [rdx]
+
+; Test negative
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov ax, -2
+mov [rdx + 8 * 1], ax
+
+fld qword [rdx + 8 * 0]
+fidivr word [rdx + 8 * 1]
+
+fst qword [rdx]
+mov rsi, [rdx]
 
 hlt


### PR DESCRIPTION
All of these operations were only testing positive integers which is why they didn't show 16-bit failures.

Adds a bunch of negative tests to each ones now that #2314 is merged, which would have caught them.