### PR TITLE
X87_F64: Fixes FICOM

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -163,7 +163,7 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header const *IROp, IR::NodeID Node) {
 
         const auto Src1 = GetReg(IROp->Args[0].ID());
         if (Info.ABI == FABI_F80_I16) {
-          uxth(ARMEmitter::Size::i32Bit, ARMEmitter::Reg::r0, Src1);
+          sxth(ARMEmitter::Size::i32Bit, ARMEmitter::Reg::r0, Src1);
         }
         else {
           mov(ARMEmitter::Size::i32Bit, ARMEmitter::Reg::r0, Src1);
@@ -310,7 +310,7 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header const *IROp, IR::NodeID Node) {
         FillStaticRegs();
 
         const auto Dst = GetReg(Node);
-        uxth(ARMEmitter::Size::i64Bit, Dst, ARMEmitter::Reg::r0);
+        sxth(ARMEmitter::Size::i64Bit, Dst, ARMEmitter::Reg::r0);
       }
       break;
       case FABI_I32_F80:{

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -147,7 +147,12 @@ void X86JITCore::Op_Unhandled(IR::IROp_Header *IROp, IR::NodeID Node) {
       case FABI_F80_I32: {
         PushRegs();
 
-        mov(edi, GetSrc<RA_32>(IROp->Args[0].ID()));
+        if (Info.ABI == FABI_F80_I16) {
+          movsx(rdi, GetSrc<RA_32>(IROp->Args[0].ID()).cvt16());
+        }
+        else {
+          mov(edi, GetSrc<RA_32>(IROp->Args[0].ID()));
+        }
         call(qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.FallbackHandlerPointers[Info.HandlerIndex])]);
 
         PopRegs();
@@ -223,7 +228,7 @@ void X86JITCore::Op_Unhandled(IR::IROp_Header *IROp, IR::NodeID Node) {
 
         PopRegs();
 
-        movzx(GetDst<RA_64>(Node), ax);
+        movsx(GetDst<RA_64>(Node), ax);
       }
       break;
       case FABI_I32_F80:{

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87F64.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87F64.cpp
@@ -39,7 +39,7 @@ class OrderedNode;
 //FST(register to register)
 
 // State loading duplicated from X87.cpp, setting host rounding mode
-// See issue 
+// See issue
 void OpDispatchBuilder::FNINITF64(OpcodeArgs) {
   // Init FCW to 0x037F
   auto NewFCW = _Constant(16, 0x037F);
@@ -76,7 +76,7 @@ void OpDispatchBuilder::X87LDENVF64(OpcodeArgs) {
   roundingMode = _And(roundingMode, roundMask);
   _SetRoundingMode(roundingMode);
   _F80LoadFCW(NewFCW);
-  
+
   _StoreContext(2, GPRClass, NewFCW, offsetof(FEXCore::Core::CPUState, FCW));
 
   OrderedNode *MemLocation = _Add(Mem, _Constant(Size * 1));
@@ -184,7 +184,7 @@ void OpDispatchBuilder::FBLDF64(OpcodeArgs) {
 void OpDispatchBuilder::FBSTPF64(OpcodeArgs) {
   auto orig_top = GetX87Top();
   auto data = _LoadContextIndexed(orig_top, 8, MMBaseOffset(), 16, FPRClass);
-  
+
   OrderedNode *converted = _F80CVTTo(data, 8);
   converted = _F80BCDStore(converted);
 
@@ -256,7 +256,7 @@ void OpDispatchBuilder::FSTF64(OpcodeArgs) {
     //Convert to 80-bit float
     auto result = _F80CVTTo(data, 8);
     StoreResult_WithOpSize(FPRClass, Op, Op->Dest, result, 10, 1);
-  } 
+  }
 
   if ((Op->TableInfo->Flags & X86Tables::InstFlags::FLAGS_POP) != 0) {
     // if we are popping then we must first mark this location as empty
@@ -688,7 +688,10 @@ void OpDispatchBuilder::FCOMIF64(OpcodeArgs) {
     // Memory arg
     if constexpr (Integer) {
       arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
-      b = _Float_FromGPR_S(8, 8, arg);
+      if(width == 16) {
+        arg = _Sext(16, arg);
+      }
+      b = _Float_FromGPR_S(8, width == 64 ? 8 : 4, arg);
     } else if constexpr (width == 32) {
       arg = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
       b = _Float_FToF(8, 4, arg);
@@ -712,7 +715,7 @@ void OpDispatchBuilder::FCOMIF64(OpcodeArgs) {
   OrderedNode *HostFlag_CF = _GetHostFlag(Res, FCMP_FLAG_LT);
   OrderedNode *HostFlag_ZF = _GetHostFlag(Res, FCMP_FLAG_EQ);
   OrderedNode *HostFlag_Unordered  = _GetHostFlag(Res, FCMP_FLAG_UNORDERED);
-  
+
   HostFlag_CF = _Or(HostFlag_CF, HostFlag_Unordered);
   HostFlag_ZF = _Or(HostFlag_ZF, HostFlag_Unordered);
 

--- a/unittests/ASM/X87/DA_02.asm
+++ b/unittests/ASM/X87/DA_02.asm
@@ -1,0 +1,84 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RSI":  ["0x18"]
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+mov rsi, 0
+
+; Matching positive-positive
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov eax, 1
+mov [rdx + 8 * 1], eax
+
+fld qword [rdx + 8 * 0]
+ficomp dword [rdx + 8 * 1]
+
+; Get the status word
+mov rax, 0
+fstsw ax
+; Extract C3 to see if it was equal
+shr ax, 14
+and ax, 1
+or rsi, rax
+shl rsi, 1
+
+; Matching negative-negative
+mov rax, 0xbff0000000000000 ; -1.0
+mov [rdx + 8 * 0], rax
+mov eax, -1
+mov [rdx + 8 * 1], eax
+
+fld qword [rdx + 8 * 0]
+ficomp dword [rdx + 8 * 1]
+
+; Get the status word
+mov rax, 0
+fstsw ax
+; Extract C3 to see if it was equal
+shr ax, 14
+and ax, 1
+or rsi, rax
+shl rsi, 1
+
+; Nonmatching negative-positive
+mov rax, 0xbff0000000000000 ; -1.0
+mov [rdx + 8 * 0], rax
+mov eax, 1
+mov [rdx + 8 * 1], eax
+
+fld qword [rdx + 8 * 0]
+ficomp dword [rdx + 8 * 1]
+
+; Get the status word
+mov rax, 0
+fstsw ax
+; Extract C3 to see if it was equal
+shr ax, 14
+and ax, 1
+or rsi, rax
+shl rsi, 1
+
+; Nonmatching positive-negative
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov eax, -1
+mov [rdx + 8 * 1], eax
+
+fld qword [rdx + 8 * 0]
+ficomp dword [rdx + 8 * 1]
+
+; Get the status word
+mov rax, 0
+fstsw ax
+; Extract C3 to see if it was equal
+shr ax, 14
+and ax, 1
+or rsi, rax
+shl rsi, 1
+
+hlt

--- a/unittests/ASM/X87/DE_02.asm
+++ b/unittests/ASM/X87/DE_02.asm
@@ -1,0 +1,84 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RSI":  ["0x18"]
+  }
+}
+%endif
+
+mov rdx, 0xe0000000
+mov rsi, 0
+
+; Matching positive-positive
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov ax, 1
+mov [rdx + 8 * 1], eax
+
+fld qword [rdx + 8 * 0]
+ficomp word [rdx + 8 * 1]
+
+; Get the status word
+mov rax, 0
+fstsw ax
+; Extract C3 to see if it was equal
+shr ax, 14
+and ax, 1
+or rsi, rax
+shl rsi, 1
+
+; Matching negative-negative
+mov rax, 0xbff0000000000000 ; -1.0
+mov [rdx + 8 * 0], rax
+mov ax, -1
+mov [rdx + 8 * 1], eax
+
+fld qword [rdx + 8 * 0]
+ficomp word [rdx + 8 * 1]
+
+; Get the status word
+mov rax, 0
+fstsw ax
+; Extract C3 to see if it was equal
+shr ax, 14
+and ax, 1
+or rsi, rax
+shl rsi, 1
+
+; Nonmatching negative-positive
+mov rax, 0xbff0000000000000 ; -1.0
+mov [rdx + 8 * 0], rax
+mov ax, 1
+mov [rdx + 8 * 1], eax
+
+fld qword [rdx + 8 * 0]
+ficomp word [rdx + 8 * 1]
+
+; Get the status word
+mov rax, 0
+fstsw ax
+; Extract C3 to see if it was equal
+shr ax, 14
+and ax, 1
+or rsi, rax
+shl rsi, 1
+
+; Nonmatching positive-negative
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov ax, -1
+mov [rdx + 8 * 1], eax
+
+fld qword [rdx + 8 * 0]
+ficomp word [rdx + 8 * 1]
+
+; Get the status word
+mov rax, 0
+fstsw ax
+; Extract C3 to see if it was equal
+shr ax, 14
+and ax, 1
+or rsi, rax
+shl rsi, 1
+
+hlt

--- a/unittests/ASM/X87_F64/DA_02_F64.asm
+++ b/unittests/ASM/X87_F64/DA_02_F64.asm
@@ -1,0 +1,85 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RSI":  ["0x18"]
+  },
+  "Env": { "FEX_X87REDUCEDPRECISION" : "1" }
+}
+%endif
+
+mov rdx, 0xe0000000
+mov rsi, 0
+
+; Matching positive-positive
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov eax, 1
+mov [rdx + 8 * 1], eax
+
+fld qword [rdx + 8 * 0]
+ficomp dword [rdx + 8 * 1]
+
+; Get the status word
+mov rax, 0
+fstsw ax
+; Extract C3 to see if it was equal
+shr ax, 14
+and ax, 1
+or rsi, rax
+shl rsi, 1
+
+; Matching negative-negative
+mov rax, 0xbff0000000000000 ; -1.0
+mov [rdx + 8 * 0], rax
+mov eax, -1
+mov [rdx + 8 * 1], eax
+
+fld qword [rdx + 8 * 0]
+ficomp dword [rdx + 8 * 1]
+
+; Get the status word
+mov rax, 0
+fstsw ax
+; Extract C3 to see if it was equal
+shr ax, 14
+and ax, 1
+or rsi, rax
+shl rsi, 1
+
+; Nonmatching negative-positive
+mov rax, 0xbff0000000000000 ; -1.0
+mov [rdx + 8 * 0], rax
+mov eax, 1
+mov [rdx + 8 * 1], eax
+
+fld qword [rdx + 8 * 0]
+ficomp dword [rdx + 8 * 1]
+
+; Get the status word
+mov rax, 0
+fstsw ax
+; Extract C3 to see if it was equal
+shr ax, 14
+and ax, 1
+or rsi, rax
+shl rsi, 1
+
+; Nonmatching positive-negative
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov eax, -1
+mov [rdx + 8 * 1], eax
+
+fld qword [rdx + 8 * 0]
+ficomp dword [rdx + 8 * 1]
+
+; Get the status word
+mov rax, 0
+fstsw ax
+; Extract C3 to see if it was equal
+shr ax, 14
+and ax, 1
+or rsi, rax
+shl rsi, 1
+
+hlt

--- a/unittests/ASM/X87_F64/DE_02_F64.asm
+++ b/unittests/ASM/X87_F64/DE_02_F64.asm
@@ -1,0 +1,85 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RSI":  ["0x18"]
+  },
+  "Env": { "FEX_X87REDUCEDPRECISION" : "1" }
+}
+%endif
+
+mov rdx, 0xe0000000
+mov rsi, 0
+
+; Matching positive-positive
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov ax, 1
+mov [rdx + 8 * 1], eax
+
+fld qword [rdx + 8 * 0]
+ficomp word [rdx + 8 * 1]
+
+; Get the status word
+mov rax, 0
+fstsw ax
+; Extract C3 to see if it was equal
+shr ax, 14
+and ax, 1
+or rsi, rax
+shl rsi, 1
+
+; Matching negative-negative
+mov rax, 0xbff0000000000000 ; -1.0
+mov [rdx + 8 * 0], rax
+mov ax, -1
+mov [rdx + 8 * 1], eax
+
+fld qword [rdx + 8 * 0]
+ficomp word [rdx + 8 * 1]
+
+; Get the status word
+mov rax, 0
+fstsw ax
+; Extract C3 to see if it was equal
+shr ax, 14
+and ax, 1
+or rsi, rax
+shl rsi, 1
+
+; Nonmatching negative-positive
+mov rax, 0xbff0000000000000 ; -1.0
+mov [rdx + 8 * 0], rax
+mov ax, 1
+mov [rdx + 8 * 1], eax
+
+fld qword [rdx + 8 * 0]
+ficomp word [rdx + 8 * 1]
+
+; Get the status word
+mov rax, 0
+fstsw ax
+; Extract C3 to see if it was equal
+shr ax, 14
+and ax, 1
+or rsi, rax
+shl rsi, 1
+
+; Nonmatching positive-negative
+mov rax, 0x3ff0000000000000 ; 1.0
+mov [rdx + 8 * 0], rax
+mov ax, -1
+mov [rdx + 8 * 1], eax
+
+fld qword [rdx + 8 * 0]
+ficomp word [rdx + 8 * 1]
+
+; Get the status word
+mov rax, 0
+fstsw ax
+; Extract C3 to see if it was equal
+shr ax, 14
+and ax, 1
+or rsi, rax
+shl rsi, 1
+
+hlt


### PR DESCRIPTION
This was not correctly converting both 32-bit and 16-bit integers over
to 64-bit double.