### PR TITLE
IR: Remove HasDest member

### DIFF
--- a/External/FEXCore/Scripts/json_ir_generator.py
+++ b/External/FEXCore/Scripts/json_ir_generator.py
@@ -282,8 +282,7 @@ def print_ir_structs(defines):
     output_file.write("\tIROps Op;\n\n")
     output_file.write("\tuint8_t Size;\n")
     output_file.write("\tuint8_t NumArgs;\n")
-    output_file.write("\tuint8_t ElementSize : 7;\n")
-    output_file.write("\tbool HasDest : 1;\n")
+    output_file.write("\tuint8_t ElementSize;\n")
 
     output_file.write("\ttemplate<typename T>\n")
     output_file.write("\tT const* C() const { return reinterpret_cast<T const*>(Data); }\n")
@@ -360,6 +359,7 @@ def print_ir_sizes():
     output_file.write("[[nodiscard, gnu::const, gnu::visibility(\"default\")]] uint8_t GetArgs(IROps Op);\n")
     output_file.write("[[nodiscard, gnu::const, gnu::visibility(\"default\")]] FEXCore::IR::RegisterClassType GetRegClass(IROps Op);\n\n")
     output_file.write("[[nodiscard, gnu::const, gnu::visibility(\"default\")]] bool HasSideEffects(IROps Op);\n")
+    output_file.write("[[nodiscard, gnu::const, gnu::visibility(\"default\")]] bool GetHasDest(IROps Op);\n")
 
     output_file.write("#undef IROP_SIZES\n")
     output_file.write("#endif\n\n")
@@ -451,6 +451,25 @@ def print_ir_hassideeffects():
     output_file.write("}\n")
 
     output_file.write("#undef IROP_HASSIDEEFFECTS_IMPL\n")
+    output_file.write("#endif\n\n")
+
+def print_ir_gethasdest():
+    output_file.write("#ifdef IROP_GETHASDEST_IMPL\n")
+
+    output_file.write("constexpr std::array<bool, OP_LAST + 1> IRDest = {\n")
+    for op in IROps:
+        if op.HasDest:
+            output_file.write("\ttrue,\n")
+        else:
+            output_file.write("\tfalse,\n")
+
+    output_file.write("};\n\n")
+
+    output_file.write("bool GetHasDest(IROps Op) {\n")
+    output_file.write("  return IRDest[Op];\n")
+    output_file.write("}\n")
+
+    output_file.write("#undef IROP_GETHASDEST_IMPL\n")
     output_file.write("#endif\n\n")
 
 # Print out IR argument printing
@@ -547,13 +566,13 @@ def print_ir_allocator_helpers():
 
     output_file.write("\tuint8_t GetOpElements(const OrderedNode *Op) const {\n")
     output_file.write("\t\tauto HeaderOp = Op->Header.Value.GetNode(DualListData.DataBegin());\n")
-    output_file.write("\t\tLOGMAN_THROW_A_FMT(HeaderOp->HasDest, \"Op {} has no dest\\n\", GetName(HeaderOp->Op));\n")
+    output_file.write("\t\tLOGMAN_THROW_A_FMT(OpHasDest(Op), \"Op {} has no dest\\n\", GetName(HeaderOp->Op));\n")
     output_file.write("\t\treturn HeaderOp->Size / HeaderOp->ElementSize;\n")
     output_file.write("\t}\n\n")
 
     output_file.write("\tbool OpHasDest(const OrderedNode *Op) const {\n")
     output_file.write("\t\tauto HeaderOp = Op->Header.Value.GetNode(DualListData.DataBegin());\n")
-    output_file.write("\t\treturn HeaderOp->HasDest;\n")
+    output_file.write("\t\treturn GetHasDest(HeaderOp->Op);\n")
     output_file.write("\t}\n\n")
 
     output_file.write("\tIROps GetOpType(const OrderedNode *Op) const {\n")
@@ -643,9 +662,6 @@ def print_ir_allocator_helpers():
             else:
                 output_file.write("\t\tOp.first->Header.ElementSize = Op.first->Header.Size / ({});\n".format(op.NumElements))
 
-            if (op.HasDest):
-                output_file.write("\t\tOp.first->Header.HasDest = true;\n")
-
             # Insert validation here
             if op.EmitValidation != None:
                 output_file.write("\t\t#if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED\n")
@@ -733,6 +749,7 @@ print_ir_reg_classes()
 print_ir_getname()
 print_ir_getraargs()
 print_ir_hassideeffects()
+print_ir_gethasdest()
 print_ir_arg_printer()
 print_ir_allocator_helpers()
 print_ir_parser_switch_helper()

--- a/External/FEXCore/Source/Interface/IR/IRDumper.cpp
+++ b/External/FEXCore/Source/Interface/IR/IRDumper.cpp
@@ -23,6 +23,7 @@ namespace FEXCore::IR {
 #define IROP_REG_CLASSES_IMPL
 #define IROP_HASSIDEEFFECTS_IMPL
 #define IROP_SIZES_IMPL
+#define IROP_GETHASDEST_IMPL
 
 #include <FEXCore/IR/IRDefines.inc>
 
@@ -125,7 +126,7 @@ static void PrintArg(std::stringstream *out, IRListView const* IR, OrderedNodeWr
     }
   }
 
-  if (IROp->HasDest) {
+  if (GetHasDest(IROp->Op)) {
     uint32_t ElementSize = IROp->ElementSize;
     uint32_t NumElements = IROp->Size;
     if (!IROp->ElementSize) {
@@ -231,7 +232,7 @@ void Dump(std::stringstream *out, IRListView const* IR, IR::RegisterAllocationDa
 
       if (!Skip) {
         AddIndent();
-        if (IROp->HasDest) {
+        if (GetHasDest(IROp->Op)) {
 
           uint32_t ElementSize = IROp->ElementSize;
           uint32_t NumElements = IROp->Size;

--- a/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
@@ -79,7 +79,7 @@ bool IRValidation::Run(IREmitter *IREmit) {
       const auto ID = CurrentIR.GetID(CodeNode);
       const uint8_t OpSize = IROp->Size;
 
-      if (IROp->HasDest) {
+      if (GetHasDest(IROp->Op)) {
         HadError |= OpSize == 0;
         // Does the op have a destination of size 0?
         if (OpSize == 0) {

--- a/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -257,7 +257,7 @@ namespace {
   void FindNodeClasses(RegisterGraph *Graph, FEXCore::IR::IRListView *IR) {
     for (auto [CodeNode, IROp] : IR->GetAllCode()) {
       // If the destination hasn't yet been set then set it now
-      if (IROp->HasDest) {
+      if (GetHasDest(IROp->Op)) {
         const auto ID = IR->GetID(CodeNode);
         Graph->AllocData->Map[ID.Value] = PhysicalRegister(GetRegClassFromNode(IR, IROp), INVALID_REG);
       } else {
@@ -455,7 +455,7 @@ namespace {
         auto& NodeLiveRange = LiveRanges[Node.Value];
 
         // If the destination hasn't yet been set then set it now
-        if (IROp->HasDest) {
+        if (GetHasDest(IROp->Op)) {
           LOGMAN_THROW_AA_FMT(NodeLiveRange.Begin.Value == UINT32_MAX,
                              "Node begin already defined?");
           NodeLiveRange.Begin = Node;
@@ -709,7 +709,7 @@ namespace {
         }
 
         // This op defines a span
-        if (IROp->HasDest) {
+        if (GetHasDest(IROp->Op)) {
           // If this is a pre-write, update the StaticMap so we track writes
           if (!NodeLiveRange.PrefferedRegister.IsInvalid()) {
             SRA_DEBUG("ssa{} is a pre-write\n", Node);
@@ -1370,7 +1370,7 @@ namespace {
     auto LastCursor = IREmit->GetWriteCursor();
     auto [CodeNode, IROp] = IR.at(SpillPointId)();
 
-    LOGMAN_THROW_AA_FMT(IROp->HasDest, "Can't spill with no dest");
+    LOGMAN_THROW_AA_FMT(GetHasDest(IROp->Op), "Can't spill with no dest");
 
     const auto Node = IR.GetID(CodeNode);
     RegisterNode *CurrentNode = &Graph->Nodes[Node.Value];

--- a/External/FEXCore/include/FEXCore/IR/IREmitter.h
+++ b/External/FEXCore/include/FEXCore/IR/IREmitter.h
@@ -59,7 +59,6 @@ friend class FEXCore::IR::PassManager;
     Op.first->Header.Size = Size / 8;
     Op.first->Header.ElementSize = Size / 8;
     Op.first->Header.NumArgs = 0;
-    Op.first->Header.HasDest = true;
     return Op;
   }
   IRPair<IROp_Bfe> _Bfe(uint8_t Width, uint8_t lsb, OrderedNode *ssa0) {


### PR DESCRIPTION
Split off from #2243 to remove each member individually.

IR ops are hardcoded by operation to have a destination or not. No need to have each operation have a boolean for determining if the operation has a destination or not.

The number of places things need to know if the operation has destination or not is better served by using a lookup instead.