### PR TITLE
IR: Removes NumArgs member from IR ops

### DIFF
--- a/External/FEXCore/Scripts/json_ir_generator.py
+++ b/External/FEXCore/Scripts/json_ir_generator.py
@@ -281,7 +281,6 @@ def print_ir_structs(defines):
     output_file.write("\tvoid* Data[0];\n")
     output_file.write("\tIROps Op;\n\n")
     output_file.write("\tuint8_t Size;\n")
-    output_file.write("\tuint8_t NumArgs;\n")
     output_file.write("\tuint8_t ElementSize;\n")
 
     output_file.write("\ttemplate<typename T>\n")
@@ -357,6 +356,7 @@ def print_ir_sizes():
 
     output_file.write("[[nodiscard, gnu::const, gnu::visibility(\"default\")]] std::string_view const& GetName(IROps Op);\n")
     output_file.write("[[nodiscard, gnu::const, gnu::visibility(\"default\")]] uint8_t GetArgs(IROps Op);\n")
+    output_file.write("[[nodiscard, gnu::const, gnu::visibility(\"default\")]] uint8_t GetRAArgs(IROps Op);\n")
     output_file.write("[[nodiscard, gnu::const, gnu::visibility(\"default\")]] FEXCore::IR::RegisterClassType GetRegClass(IROps Op);\n\n")
     output_file.write("[[nodiscard, gnu::const, gnu::visibility(\"default\")]] bool HasSideEffects(IROps Op);\n")
     output_file.write("[[nodiscard, gnu::const, gnu::visibility(\"default\")]] bool GetHasDest(IROps Op);\n")
@@ -417,7 +417,7 @@ def print_ir_getname():
 def print_ir_getraargs():
     output_file.write("#ifdef IROP_GETRAARGS_IMPL\n")
 
-    output_file.write("constexpr std::array<uint8_t, OP_LAST + 1> IRArgs = {\n")
+    output_file.write("constexpr std::array<uint8_t, OP_LAST + 1> IRRAArgs = {\n")
     for op in IROps:
         SSAArgs = op.SSAArgNum
 
@@ -429,6 +429,18 @@ def print_ir_getraargs():
         output_file.write("\t{},\n".format(SSAArgs))
 
     output_file.write("};\n\n")
+
+
+    output_file.write("constexpr std::array<uint8_t, OP_LAST + 1> IRArgs = {\n")
+    for op in IROps:
+        SSAArgs = op.SSAArgNum
+        output_file.write("\t{},\n".format(SSAArgs))
+
+    output_file.write("};\n\n")
+
+    output_file.write("uint8_t GetRAArgs(IROps Op) {\n")
+    output_file.write("  return IRRAArgs[Op];\n")
+    output_file.write("}\n")
 
     output_file.write("uint8_t GetArgs(IROps Op) {\n")
     output_file.write("  return IRArgs[Op];\n")
@@ -649,8 +661,6 @@ def print_ir_allocator_helpers():
                                 output_file.write("\t\tInferSize = std::max(InferSize, Size{});\n".format(arg.Name))
 
                     output_file.write("\t\tOp.first->Header.Size = InferSize;\n")
-
-            output_file.write("\t\tOp.first->Header.NumArgs = {};\n".format(op.SSAArgNum))
 
             # Some ops without a destination still need an operating size
             # Effectively reusing the destination size value for operation size

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -329,7 +329,6 @@ void InterpreterOps::InterpretIR(FEXCore::Core::CpuStateFrame *Frame, FEXCore::I
 
   const uintptr_t ListSize = CurrentIR->GetSSACount();
 
-  static_assert(sizeof(FEXCore::IR::IROp_Header) == 4);
   static_assert(sizeof(FEXCore::IR::OrderedNode) == 16);
 
   auto BlockEnd = CurrentIR->GetBlocks().end();

--- a/External/FEXCore/Source/Interface/IR/IREmitter.cpp
+++ b/External/FEXCore/Source/Interface/IR/IREmitter.cpp
@@ -112,7 +112,7 @@ void IREmitter::ReplaceAllUsesWithRange(OrderedNode *Node, OrderedNode *NewNode,
   while (Begin != End) {
     auto [RealNode, IROp] = Begin();
 
-    uint8_t NumArgs = IR::GetArgs(IROp->Op);
+    const uint8_t NumArgs = IR::GetArgs(IROp->Op);
     for (uint8_t i = 0; i < NumArgs; ++i) {
       if (IROp->Args[i].ID() == NodeId) {
         Node->RemoveUse();
@@ -148,7 +148,7 @@ void IREmitter::RemoveArgUses(OrderedNode *Node) {
 
   FEXCore::IR::IROp_Header *IROp = Node->Op(DataBegin);
 
-  uint8_t NumArgs = IR::GetArgs(IROp->Op);
+  const uint8_t NumArgs = IR::GetArgs(IROp->Op);
   for (uint8_t i = 0; i < NumArgs; ++i) {
     auto ArgNode = IROp->Args[i].GetNode(ListBegin);
     ArgNode->RemoveUse();
@@ -201,7 +201,6 @@ void IREmitter::ReplaceWithConstant(OrderedNode *Node, uint64_t Value) {
 
       // Overwrite data with the new constant op
       Header->Op = OP_CONSTANT;
-      Header->NumArgs = 0;
       auto Const = Header->CW<IROp_Constant>();
       Const->Constant = Value;
     } else {

--- a/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -245,7 +245,7 @@ void ConstProp::CodeMotionAroundSelects(IREmitter *IREmit, const IRListView& Cur
   for (auto [BlockNode, BlockIROp] : CurrentIR.GetBlocks()) {
     auto BlockOp = BlockIROp->CW<FEXCore::IR::IROp_CodeBlock>();
     for (auto [UnaryOpNode, UnaryOpHdr] : CurrentIR.GetCode(BlockNode)) {
-      if (UnaryOpHdr->NumArgs == 1 && !HasSideEffects(UnaryOpHdr->Op)) {
+      if (IR::GetArgs(UnaryOpHdr->Op) == 1 && !HasSideEffects(UnaryOpHdr->Op)) {
         // could be moved
         auto SelectOpNode = IREmit->UnwrapNode(UnaryOpHdr->Args[0]);
         auto SelectOpHdr = IREmit->GetOpHeader(UnaryOpHdr->Args[0]);
@@ -267,7 +267,7 @@ void ConstProp::CodeMotionAroundSelects(IREmitter *IREmit, const IRListView& Cur
           // Copy over the op
           memcpy(NewUnaryOp1.first, UnaryOpHdr, OpSize);
 
-          for (int i = 0; i < NewUnaryOp1.first->NumArgs; i++) {
+          for (int i = 0; i < IR::GetArgs(NewUnaryOp1.first->Op); i++) {
             NewUnaryOp1.first->Args[i] = IREmit->WrapNode(IREmit->Invalid());
           }
           // Set New Op to operate on the constant
@@ -281,7 +281,7 @@ void ConstProp::CodeMotionAroundSelects(IREmitter *IREmit, const IRListView& Cur
           // Copy over the op
           memcpy(NewUnaryOp2.first, UnaryOpHdr, OpSize);
 
-          for (int i = 0; i < NewUnaryOp2.first->NumArgs; i++) {
+          for (int i = 0; i < IR::GetArgs(NewUnaryOp2.first->Op); i++) {
             NewUnaryOp2.first->Args[i] = IREmit->WrapNode(IREmit->Invalid());
           }
           // Set New Op to operate on the constant
@@ -378,7 +378,7 @@ bool ConstProp::ZextAndMaskingElimination(IREmitter *IREmit, const IRListView& C
     case OP_ASHR:
     case OP_LSHL:
     case OP_ROR: {
-      for (int i = 0; i < IROp->NumArgs; i++) {
+      for (int i = 0; i < IR::GetArgs(IROp->Op); i++) {
         auto newArg = RemoveUselessMasking(IREmit, IROp->Args[i], getMask(IROp));
         if (newArg.ID() != IROp->Args[i].ID()) {
           IREmit->ReplaceNodeArgument(CodeNode, i, IREmit->UnwrapNode(newArg));
@@ -390,7 +390,7 @@ bool ConstProp::ZextAndMaskingElimination(IREmitter *IREmit, const IRListView& C
 
     case OP_AND: {
       // if AND's arguments are imms, they are masking
-      for (int i = 0; i < IROp->NumArgs; i++) {
+      for (int i = 0; i < IR::GetArgs(IROp->Op); i++) {
         auto mask = getMask(IROp);
         uint64_t imm = 0;
         if (IREmit->IsValueConstant(IROp->Args[i^1], &imm))
@@ -469,7 +469,7 @@ bool ConstProp::ZextAndMaskingElimination(IREmitter *IREmit, const IRListView& C
     case OP_VFDIV:
     case OP_FCMP: {
       auto flopSize = IROp->Size;
-      for (int i = 0; i < IROp->NumArgs; i++) {
+      for (int i = 0; i < IR::GetArgs(IROp->Op); i++) {
         auto argHeader = IREmit->GetOpHeader(IROp->Args[i]);
 
         if (argHeader->Op == OP_VMOV) {

--- a/External/FEXCore/Source/Interface/IR/Passes/IRCompaction.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/IRCompaction.cpp
@@ -174,9 +174,9 @@ bool IRCompaction::Run(IREmitter *IREmit) {
       for (auto [LocalNode, LocalIROp] : LocalIR.GetCode(Block.NewNode)) {
 
         // Now that we have the op copied over, we need to modify SSA values to point to the new correct locations
-        // This doesn't use IR::GetArgs(Op) because we need to remap all SSA nodes
+        // This doesn't use IR::GetRAArgs(Op) because we need to remap all SSA nodes
         // Including ones that we don't RA
-        const uint8_t NumArgs = LocalIROp->NumArgs;
+        const uint8_t NumArgs = IR::GetArgs(LocalIROp->Op);
         for (uint8_t i = 0; i < NumArgs; ++i) {
           const auto OldArg = LocalIROp->Args[i].ID();
           const auto NewArg = OldToNewRemap[OldArg.Value].NodeID;

--- a/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
@@ -120,23 +120,8 @@ bool IRValidation::Run(IREmitter *IREmit) {
         }
       }
 
-      uint8_t NumArgs = IR::GetArgs(IROp->Op);
+      uint8_t NumArgs = IR::GetRAArgs(IROp->Op);
 
-      if (NumArgs != IROp->NumArgs) {
-        switch (IROp->Op) {
-          case OP_BEGINBLOCK:
-          case OP_ENDBLOCK:
-          case OP_PHI:
-          case OP_PHIVALUE:
-          case OP_CONDJUMP:
-          case OP_JUMP:
-            // These override the number of args for RA, so ignore them.
-            break;
-          default:
-            HadError |= true;
-            Errors << "%ssa" << ID << ": Has wrong number of Args" << std::endl;
-        }
-      }
       for (uint32_t i = 0; i < NumArgs; ++i) {
         OrderedNodeWrapper Arg = IROp->Args[i];
         const auto ArgID = Arg.ID();

--- a/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -475,7 +475,7 @@ namespace {
           continue;
         }
 
-        const uint8_t NumArgs = IR::GetArgs(IROp->Op);
+        const uint8_t NumArgs = IR::GetRAArgs(IROp->Op);
         for (uint8_t i = 0; i < NumArgs; ++i) {
           const auto& Arg = IROp->Args[i];
 
@@ -679,7 +679,7 @@ namespace {
         auto& NodeLiveRange = LiveRanges[Node.Value];
 
         // Check for read-after-write and demote if it happens
-        const uint8_t NumArgs = IR::GetArgs(IROp->Op);
+        const uint8_t NumArgs = IR::GetRAArgs(IROp->Op);
         for (uint8_t i = 0; i < NumArgs; ++i) {
           const auto& Arg = IROp->Args[i];
 
@@ -1037,7 +1037,7 @@ namespace {
     while(1) {
       auto [RealNode, IROp] = Begin();
 
-      const uint8_t NumArgs = FEXCore::IR::GetArgs(IROp->Op);
+      const uint8_t NumArgs = FEXCore::IR::GetRAArgs(IROp->Op);
       for (uint8_t i = 0; i < NumArgs; ++i) {
         const auto ArgNode = IROp->Args[i].ID();
         if (ArgNode == SearchID) {
@@ -1069,7 +1069,7 @@ namespace {
         return End;
       }
 
-      const uint8_t NumArgs = FEXCore::IR::GetArgs(IROp->Op);
+      const uint8_t NumArgs = FEXCore::IR::GetRAArgs(IROp->Op);
       for (uint8_t i = 0; i < NumArgs; ++i) {
         const auto ArgNode = IROp->Args[i].ID();
         if (ArgNode == SearchID) {
@@ -1297,7 +1297,7 @@ namespace {
 
           CurrentNodes.insert(NodeOpBegin.ID());
 
-          for (int i = 0; i < IROp->NumArgs; i++) {
+          for (int i = 0; i < IR::GetRAArgs(IROp->Op); i++) {
             CurrentNodes.insert(IROp->Args[i].ID());
           }
       }

--- a/External/FEXCore/Source/Interface/IR/Passes/ValueDominanceValidation.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ValueDominanceValidation.cpp
@@ -94,7 +94,7 @@ bool ValueDominanceValidation::Run(IREmitter *IREmit) {
     for (auto [CodeNode, IROp] : CurrentIR.GetCode(BlockNode)) {
       const auto CodeID = CurrentIR.GetID(CodeNode);
 
-      const uint8_t NumArgs = IR::GetArgs(IROp->Op);
+      const uint8_t NumArgs = IR::GetRAArgs(IROp->Op);
       for (uint32_t i = 0; i < NumArgs; ++i) {
         if (IROp->Args[i].IsInvalid()) continue;
         if (CurrentIR.GetOp<IROp_Header>(IROp->Args[i])->Op == OP_IRHEADER) continue;

--- a/External/FEXCore/include/FEXCore/IR/IREmitter.h
+++ b/External/FEXCore/include/FEXCore/IR/IREmitter.h
@@ -58,7 +58,6 @@ friend class FEXCore::IR::PassManager;
     Op.first->Constant = (Constant & Mask);
     Op.first->Header.Size = Size / 8;
     Op.first->Header.ElementSize = Size / 8;
-    Op.first->Header.NumArgs = 0;
     return Op;
   }
   IRPair<IROp_Bfe> _Bfe(uint8_t Width, uint8_t lsb, OrderedNode *ssa0) {


### PR DESCRIPTION
Split off from #2243 to remove each member individually.

Shaves 8-bits off of each IR op.
No need to cart around this data when it is constant for each operation. Especially since most optimization passes don't need the data anyway.

Needed to add a new `GetRAArgs` to get the number of SSA arguments that get RA versus `GetArgs` which returns all SSA arguments the IR operation owns. This is what was causing #2243 to fail CI since it needs to know the difference in some places.