### PR TITLE
Fix FPREM flags calculation in F64

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87F64.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87F64.cpp
@@ -822,8 +822,8 @@ void OpDispatchBuilder::X87BinaryOpF64(OpcodeArgs) {
   // Overwrite the op
   result.first->Header.Op = IROp;
 
-  if constexpr (IROp == IR::OP_F80FPREM ||
-    IROp == IR::OP_F80FPREM1) {
+  if constexpr (IROp == IR::OP_F64FPREM ||
+    IROp == IR::OP_F64FPREM1) {
     //TODO: Set C0 to Q2, C3 to Q1, C1 to Q0
     SetRFLAG<FEXCore::X86State::X87FLAG_C2_LOC>(_Constant(0));
   }

--- a/unittests/ASM/X87/FPREM1_Flags.asm
+++ b/unittests/ASM/X87/FPREM1_Flags.asm
@@ -1,0 +1,34 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0"
+  }
+}
+%endif
+
+mov rbx, 0xe0000000
+o32 fstenv [rbx]
+mov dword [rbx+4], 0xFFFFFFFF ; set status word to all one
+o32 fldenv [rbx]
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+lea rdx, [rel data2]
+fld tword [rdx + 8 * 0]
+
+fprem1
+
+xor rax, rax
+fstsw ax
+and rax, 0x400 ; C2 should be set to zero
+
+hlt
+
+align 8
+data:
+  dt 3.0
+  dq 0
+data2:
+  dt 5.1
+  dq 0

--- a/unittests/ASM/X87/FPREM_Flags.asm
+++ b/unittests/ASM/X87/FPREM_Flags.asm
@@ -1,0 +1,34 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0"
+  }
+}
+%endif
+
+mov rbx, 0xe0000000
+o32 fstenv [rbx]
+mov dword [rbx+4], 0xFFFFFFFF ; set status word to all one
+o32 fldenv [rbx]
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+lea rdx, [rel data2]
+fld tword [rdx + 8 * 0]
+
+fprem
+
+xor rax, rax
+fstsw ax
+and rax, 0x400 ; C2 should be set to zero
+
+hlt
+
+align 8
+data:
+  dt 3.0
+  dq 0
+data2:
+  dt 5.1
+  dq 0

--- a/unittests/ASM/X87_F64/FPREM1_Flags_F64.asm
+++ b/unittests/ASM/X87_F64/FPREM1_Flags_F64.asm
@@ -1,0 +1,35 @@
+%ifdef CONFIG
+{
+  "Env": { "FEX_X87REDUCEDPRECISION" : "1" },
+  "RegData": {
+    "RAX": "0"
+  }
+}
+%endif
+
+mov rbx, 0xe0000000
+o32 fstenv [rbx]
+mov dword [rbx+4], 0xFFFFFFFF ; set status word to all one
+o32 fldenv [rbx]
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+lea rdx, [rel data2]
+fld tword [rdx + 8 * 0]
+
+fprem1
+
+xor rax, rax
+fstsw ax
+and rax, 0x400 ; C2 should be set to zero
+
+hlt
+
+align 8
+data:
+  dt 3.0
+  dq 0
+data2:
+  dt 5.1
+  dq 0

--- a/unittests/ASM/X87_F64/FPREM_Flags_F64.asm
+++ b/unittests/ASM/X87_F64/FPREM_Flags_F64.asm
@@ -1,0 +1,35 @@
+%ifdef CONFIG
+{
+  "Env": { "FEX_X87REDUCEDPRECISION" : "1" },
+  "RegData": {
+    "RAX": "0"
+  }
+}
+%endif
+
+mov rbx, 0xe0000000
+o32 fstenv [rbx]
+mov dword [rbx+4], 0xFFFFFFFF ; set status word to all one
+o32 fldenv [rbx]
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+lea rdx, [rel data2]
+fld tword [rdx + 8 * 0]
+
+fprem
+
+xor rax, rax
+fstsw ax
+and rax, 0x400 ; C2 should be set to zero
+
+hlt
+
+align 8
+data:
+  dt 3.0
+  dq 0
+data2:
+  dt 5.1
+  dq 0


### PR DESCRIPTION
Copy+paste error meant C2 flag was not getting cleared for FPREM/1 in F64 mode.

Also adds tests to verify C2 flag clear on both F80 and F64