### PR TITLE
Arm64: Fixes incorrect operation for CacheLineClear

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -1493,7 +1493,7 @@ DEF_OP(CacheLineClear) {
   // icache doesn't matter here since the guest application shouldn't be calling clflush on JIT code.
   mov(TMP1, MemReg.X());
   for (size_t i = 0; i < std::max(1U, CTX->HostFeatures.DCacheLineSize / 64U); ++i) {
-    dc(ARMEmitter::DataCacheOperation::CVAU, TMP1);
+    dc(ARMEmitter::DataCacheOperation::CIVAC, TMP1);
     add(ARMEmitter::Size::i64Bit, TMP1, TMP1, CTX->HostFeatures.DCacheLineSize);
   }
   dsb(FEXCore::ARMEmitter::BarrierScope::ISH);


### PR DESCRIPTION
CVAU does Clean to `Point Of Unification` CIVAC does Clean+Invalidate to `Point of Coherency`

`Point of Unification` means to L2/L3, so unification of core visibility.

`Point of Coherency` means SLC/RAM, All cores, DNA engines, etc must be coherent.