### PR TITLE
FEXLoader: Adds support for execveat with AT_EMPTY_PATH 

### DIFF
--- a/FEXHeaderUtils/FEXHeaderUtils/SymlinkChecks.h
+++ b/FEXHeaderUtils/FEXHeaderUtils/SymlinkChecks.h
@@ -1,0 +1,28 @@
+#pragma once
+#include <fcntl.h>
+#include <string>
+#include <sys/stat.h>
+#include <span>
+#include <unistd.h>
+
+namespace FHU::Symlinks {
+// Checks to see if a filepath is a symlink.
+inline bool IsSymlink(const std::string &Filename) {
+  struct stat Buffer{};
+  int Result = lstat(Filename.c_str(), &Buffer);
+  return Result == 0 && S_ISLNK(Buffer.st_mode);
+}
+
+// Resolves a symlink path.
+// Doesn't handle recursive symlinks.
+// Doesn't append null terminator character.
+// Returns a string_view of the resolved path, or an empty view on error.
+inline std::string_view ResolveSymlink(const std::string &Filename, std::span<char> ResultBuffer) {
+  ssize_t Result = readlink(Filename.c_str(), ResultBuffer.data(), ResultBuffer.size());
+  if (Result == -1) {
+    return {};
+  }
+
+  return std::string_view(ResultBuffer.data(), Result);
+}
+}

--- a/Source/Common/Config.cpp
+++ b/Source/Common/Config.cpp
@@ -2,11 +2,13 @@
 #include "Common/Config.h"
 
 #include <FEXCore/Config/Config.h>
+#include <FEXHeaderUtils/SymlinkChecks.h>
 
 #include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <map>
+#include <linux/limits.h>
 #include <list>
 #include <unordered_map>
 #include <utility>
@@ -40,12 +42,68 @@ namespace FEX::Config {
     }
   }
 
-  std::pair<std::string, std::string> LoadConfig(
+  std::string RecoverGuestProgramFilename(std::string Program, bool ExecFDInterp, const std::string_view ProgramFDFromEnv) {
+    // If executed with a FEX FD then the Program argument might be empty.
+    // In this case we need to scan the FD node to recover the application binary that exists on disk.
+    // Only do this if the Program argument is empty, since we would prefer the application's expectation
+    // of application name.
+    if (!ProgramFDFromEnv.empty() && Program.empty()) {
+      // Get the `dev` node of the execveat fd string.
+      Program = "/dev/fd/";
+      Program += ProgramFDFromEnv;
+    }
+
+    // If FEX was invoked through an FD path (either binfmt_misc or execveat) then we need to check the
+    // Program to see if it is a symlink to find the real path.
+    //
+    // binfmt_misc: Arg[0] is actually the full application path or `/dev/fd/<FD>` path
+    //   - Full application path with execve (See Side Note)
+    //   - FD path with execveat and FD doesn't have an existing file on the disk
+    //
+    // ProgramFDFromEnv: Arg[0] is Application provided data or `/dev/fd/<FD>` from above fix-up.
+    //   - execveat was either passed no arguments (argv=NULL) or the first argument is an empty string (argv[0]="").
+    //   - FD path with execveat and FD doesn't have an existing file on the disk
+    //
+    // Side Note:
+    //  The `execve` syscall doesn't take an FD but binfmt_misc will give FEX an FD to execute still.
+    //  Arg[0] will always contain a pathname to an application in this case and it won't be a symlink.
+    //  Kernel resolves the symlink before passing the application to the interpreter.
+    //
+    // Examples:
+    //  - Regular execve. Application must exist on disk.
+    //    execve binfmt_misc args layout:   `FEXInterpreter <Full path> <user provided argv[0]> <user provided argv[n]>...`
+    //  - Regular execveat with FD. FD is backed by application on disk.
+    //    execveat binfmt_misc args layout: `FEXInterpreter <Full path> <user provided argv[0]> <user provided argv[n]>...`
+    //  - Regular execveat with FD. FD points to file on disk that has been deleted.
+    //    execveat binfmt_misc args layout: `FEXInterpreter /dev/fd/<FD> <user provided argv[0]> <user provided argv[n]>...`
+    if (ExecFDInterp || !ProgramFDFromEnv.empty()) {
+      // Only in the case that FEX is executing an FD will the program argument potentially be a symlink.
+      // This symlink will be in the style of `/dev/fd/<FD>`.
+      //
+      // If the argument /is/ a symlink then resolve its path to get the original application name.
+      if (FHU::Symlinks::IsSymlink(Program)) {
+        char Filename[PATH_MAX];
+        auto SymlinkPath = FHU::Symlinks::ResolveSymlink(Program, Filename);
+        if (SymlinkPath.starts_with('/')) {
+          // This file was executed through an FD.
+          // Remove the ` (deleted)` text if the file was deleted after the fact.
+          // Otherwise just get the symlink without the deleted text.
+          return std::string{SymlinkPath.substr(0, SymlinkPath.rfind(" (deleted)"))};
+        }
+      }
+    }
+
+    return Program;
+  }
+
+  ApplicationNames LoadConfig(
     bool NoFEXArguments,
     bool LoadProgramConfig,
     int argc,
     char **argv,
-    char **const envp) {
+    char **const envp,
+    bool ExecFDInterp,
+    const std::string_view ProgramFDFromEnv) {
     FEXCore::Config::Initialize();
     FEXCore::Config::AddLayer(FEXCore::Config::CreateGlobalMainLayer());
     FEXCore::Config::AddLayer(FEXCore::Config::CreateMainLayer());
@@ -68,7 +126,8 @@ namespace FEX::Config {
         return {};
       }
 
-      std::string Program = Args[0];
+      Args[0] = RecoverGuestProgramFilename(std::move(Args[0]), ExecFDInterp, ProgramFDFromEnv);
+      std::string& Program = Args[0];
 
       bool Wine = false;
       std::filesystem::path ProgramName;
@@ -121,7 +180,7 @@ namespace FEX::Config {
         FEXCore::Config::AddLayer(FEXCore::Config::CreateAppLayer(SteamAppName, FEXCore::Config::LayerType::LAYER_LOCAL_STEAM_APP));
       }
 
-      return std::make_pair(Program, ProgramName);
+      return ApplicationNames{std::move(Program), std::move(ProgramName)};
     }
     return {};
   }

--- a/Source/Common/Config.h
+++ b/Source/Common/Config.h
@@ -19,11 +19,33 @@ namespace FEX::Config {
 
   void SaveLayerToJSON(const std::string& Filename, FEXCore::Config::Layer *const Layer);
 
-  std::pair<std::string, std::string> LoadConfig(
+  struct ApplicationNames {
+    // This is the full path to the program (if it exists).
+    std::string ProgramPath;
+    // This is the program executable name (if it exists).
+    std::string ProgramName;
+  };
+
+  /**
+   * @brief Loads the FEX and application configurations for the application that is getting ready to run.
+   *
+   * @param NoFEXArguments Do we want to parse FEXLoader arguments, Or is this FEXInterpreter?
+   * @param LoadProgramConfig Do we want to load application specific configurations?
+   * @param argc The `argc` passed to main(...)
+   * @param argv The `argv` passed to main(...)
+   * @param envp The `envp` passed to main(...)
+   * @param ExecFDInterp If FEX was executed with binfmt_misc FD argument
+   * @param ProgramFDFromEnv The execveat FD argument passed through FEX
+   *
+   * @return The application name and path structure
+   */
+  ApplicationNames LoadConfig(
     bool NoFEXArguments,
     bool LoadProgramConfig,
     int argc,
     char **argv,
-    char **const envp
+    char **const envp,
+    bool ExecFDInterp,
+    const std::string_view ProgramFDFromEnv
   );
 }

--- a/Source/Linux/Utils/ELFContainer.h
+++ b/Source/Linux/Utils/ELFContainer.h
@@ -117,6 +117,7 @@ public:
     TYPE_OTHER_ELF,
   };
   static ELFType GetELFType(std::string const &Filename);
+  static ELFType GetELFType(int FD);
   static bool IsSupportedELF(std::string const &Filename) {
     ELFType Type = GetELFType(Filename);
     return Type == TYPE_X86_64 || Type == TYPE_X86_32;

--- a/Source/Tests/ELFCodeLoader2.h
+++ b/Source/Tests/ELFCodeLoader2.h
@@ -27,6 +27,7 @@
 #include <FEXCore/Utils/LogManager.h>
 #include <FEXHeaderUtils/Syscalls.h>
 #include <FEXHeaderUtils/TypeDefines.h>
+#include <FEXHeaderUtils/SymlinkChecks.h>
 
 #include <elf.h>
 #include <fcntl.h>
@@ -191,10 +192,10 @@ class ELFCodeLoader2 final : public FEXCore::CodeLoader {
       // Do some special handling if the RootFS's linker is a symlink
       // Ubuntu's rootFS by default provides an absolute location symlink to the linker
       // Resolve this around back to the rootfs
-      auto SymlinkSize = FEX::HLE::GetSymlink(RootFSLink, Filename, PATH_MAX - 1);
-      if (SymlinkSize > 0 && Filename[0] == '/') {
+      auto SymlinkPath = FHU::Symlinks::ResolveSymlink(RootFSLink, Filename);
+      if (SymlinkPath.starts_with('/')) {
         RootFSLink = RootFS;
-        RootFSLink += std::string_view(Filename, SymlinkSize);
+        RootFSLink += SymlinkPath;
       }
       else {
         break;
@@ -215,11 +216,23 @@ class ELFCodeLoader2 final : public FEXCore::CodeLoader {
 
   std::vector<LoadedSection> Sections;
 
-  ELFCodeLoader2(std::string const &Filename, std::string const &RootFS, [[maybe_unused]] std::vector<std::string> const &args, std::vector<std::string> const &ParsedArgs, char **const envp = nullptr, FEXCore::Config::Value<std::string> *AdditionalEnvp = nullptr) :
+  ELFCodeLoader2(std::string const &Filename, const std::string_view FEXFDString, std::string const &RootFS, [[maybe_unused]] std::vector<std::string> const &args, std::vector<std::string> const &ParsedArgs, char **const envp = nullptr, FEXCore::Config::Value<std::string> *AdditionalEnvp = nullptr) :
     Args {args} {
 
     bool LoadedWithFD = false;
     int FD = getauxval(AT_EXECFD);
+
+    if (!FEXFDString.empty()) {
+      // If we passed the execve FD to us then use that.
+      const char *StartPtr = FEXFDString.data();
+      char *EndPtr{};
+      FD = ::strtol(StartPtr, &EndPtr, 10);
+      if (EndPtr == StartPtr) {
+        LogMan::Msg::AFmt("FEXInterpreter passed invalid FD to exececute: {}", FEXFDString);
+        return;
+      }
+      unsetenv("FEX_EXECVEFD");
+    }
 
     // If we are provided an EXECFD then attempt to execute that first
     // This happens in the case of binfmt_misc usage

--- a/Source/Tests/LinuxSyscalls/Syscalls.h
+++ b/Source/Tests/LinuxSyscalls/Syscalls.h
@@ -20,6 +20,7 @@ $end_info$
 #include <shared_mutex>
 
 #include <errno.h>
+#include <fcntl.h>
 #include <stdint.h>
 #include <type_traits>
 #include <vector>
@@ -80,9 +81,15 @@ uint64_t UnimplementedSyscallSafe(FEXCore::Core::CpuStateFrame *Frame, uint64_t 
 struct ExecveAtArgs {
   int dirfd;
   int flags;
+  static ExecveAtArgs Empty() {
+    return ExecveAtArgs {
+      .dirfd = AT_FDCWD,
+      .flags = 0,
+    };
+  }
 };
 
-uint64_t ExecveHandler(const char *pathname, char* const* argv, char* const* envp, ExecveAtArgs *Args);
+uint64_t ExecveHandler(const char *pathname, char* const* argv, char* const* envp, ExecveAtArgs Args);
 
 class SyscallHandler : public FEXCore::HLE::SyscallHandler, FEXCore::HLE::SourcecodeResolver {
 public:

--- a/Source/Tests/LinuxSyscalls/x32/Thread.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Thread.cpp
@@ -330,7 +330,10 @@ namespace FEX::HLE::x32 {
 
       auto* const* ArgsPtr = argv ? const_cast<char* const*>(Args.data()) : nullptr;
       auto* const* EnvpPtr = envp ? const_cast<char* const*>(Envp.data()) : nullptr;
-      return FEX::HLE::ExecveHandler(pathname, ArgsPtr, EnvpPtr, nullptr);
+
+      FEX::HLE::ExecveAtArgs AtArgs = FEX::HLE::ExecveAtArgs::Empty();
+
+      return FEX::HLE::ExecveHandler(pathname, ArgsPtr, EnvpPtr, AtArgs);
     });
 
     REGISTER_SYSCALL_IMPL_X32(execveat, ([](FEXCore::Core::CpuStateFrame *Frame, int dirfd, const char *pathname, uint32_t *argv, uint32_t *envp, int flags) -> uint64_t {
@@ -359,7 +362,7 @@ namespace FEX::HLE::x32 {
 
       auto* const* ArgsPtr = argv ? const_cast<char* const*>(Args.data()) : nullptr;
       auto* const* EnvpPtr = envp ? const_cast<char* const*>(Envp.data()) : nullptr;
-      return FEX::HLE::ExecveHandler(pathname, ArgsPtr, EnvpPtr, &AtArgs);
+      return FEX::HLE::ExecveHandler(pathname, ArgsPtr, EnvpPtr, AtArgs);
     }));
 
     REGISTER_SYSCALL_IMPL_X32(wait4, [](FEXCore::Core::CpuStateFrame *Frame, pid_t pid, int *wstatus, int options, struct rusage_32 *rusage) -> uint64_t {

--- a/Source/Tests/LinuxSyscalls/x64/Thread.cpp
+++ b/Source/Tests/LinuxSyscalls/x64/Thread.cpp
@@ -119,7 +119,10 @@ namespace FEX::HLE::x64 {
 
       auto* const* ArgsPtr = argv ? const_cast<char* const*>(Args.data()) : nullptr;
       auto* const* EnvpPtr = envp ? const_cast<char* const*>(Envp.data()) : nullptr;
-      return FEX::HLE::ExecveHandler(pathname, ArgsPtr, EnvpPtr, nullptr);
+
+      FEX::HLE::ExecveAtArgs AtArgs = FEX::HLE::ExecveAtArgs::Empty();
+
+      return FEX::HLE::ExecveHandler(pathname, ArgsPtr, EnvpPtr, AtArgs);
     });
 
     REGISTER_SYSCALL_IMPL_X64_FLAGS(execveat, SyscallFlags::DEFAULT,
@@ -150,7 +153,7 @@ namespace FEX::HLE::x64 {
 
       auto* const* ArgsPtr = argv ? const_cast<char* const*>(Args.data()) : nullptr;
       auto* const* EnvpPtr = envp ? const_cast<char* const*>(Envp.data()) : nullptr;
-      return FEX::HLE::ExecveHandler(pathname, ArgsPtr, EnvpPtr, &AtArgs);
+      return FEX::HLE::ExecveHandler(pathname, ArgsPtr, EnvpPtr, AtArgs);
     }));
 
     REGISTER_SYSCALL_IMPL_X64_PASS_FLAGS(wait4, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,

--- a/Source/Tools/FEXRootFSFetcher/Main.cpp
+++ b/Source/Tools/FEXRootFSFetcher/Main.cpp
@@ -1080,7 +1080,8 @@ int main(int argc, char **argv, char **const envp) {
   FEX::Config::LoadConfig(
     true,
     false,
-    argc, argv, envp
+    argc, argv, envp,
+    false, {}
   );
 
   // Reload the meta layer

--- a/Source/Tools/FEXServer/Main.cpp
+++ b/Source/Tools/FEXServer/Main.cpp
@@ -146,7 +146,8 @@ int main(int argc, char **argv, char **const envp) {
   FEX::Config::LoadConfig(
     true,
     false,
-    argc, argv, envp
+    argc, argv, envp,
+    false, {}
   );
 
   // Reload the meta layer


### PR DESCRIPTION
Fixes https://github.com/FEX-Emu/FEX/issues/2136

This is a fairly tricky edge case to support with FEX.
If execveat is used with AT_EMPTY_PATH then the application can pass an
FD to execve instead of a filename. This includes FDs that have been
deleted from the disk so the child process can't open it by filename
anymore.

To work around this limitation, we need to pass the FD to the new FEX
process and open it directly, similar to how binfmt_misc works with FDs.
The FD will get passed through environment variables, which the new
process will check for and then remove the variable from the
environment.

Lots of prickly edge cases to support here.

Without binfmt_misc:
- Passes the FD to FEXLoader directly.
  - Requires duplicating the FD if it has O_CLOEXEC on the FD.

With binfmt_misc:
- Shebang file, pass directly to FEXLoader, just like without binfmt.
- x86 ELF Files, rely on the kernel's binfmt_misc support here.
- Unsupported ELF files, let kernel handle it through binfmt_misc

Argument handling:
- The application can pass in no arguments.
  - Means our application configurations were failing to find a config
  - Also various checks in the frontend were failing.
  - If opened through an FD, find the symlink for that FD for the
    application configuration instead.

Side note:
Fixed a performance issue in execve where when we were checking for file
format support. Either ELF or Shebang files, we were reading the /whole/
file upfront. We only need to read a header worth of ELF files, and only
257 bytes if it is potentially a shebang file. Should dramatically
reduce some application's execve times.