### PR TITLE
CPUID: Optimize initialization

### DIFF
--- a/External/FEXCore/Source/Utils/FileLoading.cpp
+++ b/External/FEXCore/Source/Utils/FileLoading.cpp
@@ -2,6 +2,9 @@
 #include <vector>
 #include <filesystem>
 #include <fstream>
+#include <fcntl.h>
+#include <unistd.h>
+#include <span>
 
 namespace FEXCore::FileLoading {
 bool LoadFile(std::vector<char> &Data, const std::string &Filepath, size_t FixedSize) {
@@ -47,5 +50,16 @@ bool LoadFile(std::vector<char> &Data, const std::string &Filepath, size_t Fixed
   return true;
 }
 
+ssize_t LoadFileToBuffer(const std::string &Filepath, std::span<char> Buffer) {
+  int FD = open(Filepath.c_str(), O_RDONLY);
+
+  if (FD == -1) {
+    return -1;
+  }
+
+  ssize_t Read = pread(FD, Buffer.data(), Buffer.size(), 0);
+  close(FD);
+  return Read;
+}
 
 }

--- a/External/FEXCore/Source/Utils/FileLoading.h
+++ b/External/FEXCore/Source/Utils/FileLoading.h
@@ -3,6 +3,7 @@
 #include <vector>
 #include <filesystem>
 #include <fstream>
+#include <span>
 
 namespace FEXCore::FileLoading {
   /**
@@ -14,5 +15,15 @@ namespace FEXCore::FileLoading {
    * @return true on file loaded, false on failure
    */
   bool LoadFile(std::vector<char> &Data, const std::string &Filepath, size_t FixedSize = 0);
+
+  /**
+   * @brief Loads a filepath in to a buffer of data with a fixed size
+   *
+   * @param Filepath The filepath to load
+   * @param Buffer The buffer to load the data in to. Attempting to read the full size of the span
+   *
+   * @return The amount of data read or -1 on error.
+   */
+  ssize_t LoadFileToBuffer(const std::string &Filepath, std::span<char> Buffer);
 }
 


### PR DESCRIPTION
Map lookup was quite expensive, switched over to three small vectors
that are constexpr instead.

Some file querying and parsing was fairly slow as well. Optimized to
make that CPU time to go away.

This improves initialization time of CPUIDEmu by 33%