### PR TITLE
ArmEmitter: Adds two more classes of ASIMD instructions

### DIFF
--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ASIMDOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ASIMDOps.inl
@@ -3573,7 +3573,919 @@ public:
   }
 
   // Advanced SIMD vector x indexed element
-  // TODO
+  ///< size is destination size
+  void smlal(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm, uint32_t Index) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
+
+    if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
+    }
+    const auto EncodedSubRegSize = FEXCore::ARMEmitter::SubRegSize(FEXCore::ToUnderlying(size) - 1);
+    LOGMAN_THROW_A_FMT(Index < SubRegSizeInBits(EncodedSubRegSize), "Index must be less than the source register size");
+
+    uint32_t H, L, M;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      // Index encoded in H:L:M
+      H = (Index >> 2) & 1;
+      L = (Index >> 1) & 1;
+      M = (Index >> 0) & 1;
+    }
+    else {
+      // Index encoded in H:L
+      // M overlaps rm register.
+      H = (Index >> 1) & 1;
+      L = (Index >> 0) & 1;
+      M = 0;
+    }
+    ASIMDVectorXIndexedElement(0b0, L, M, 0b0010, H, EncodedSubRegSize, rm.D(), rn.D(), rd.D());
+  }
+  ///< size is destination size
+  void smlal2(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm, uint32_t Index) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
+
+    if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
+    }
+    const auto EncodedSubRegSize = FEXCore::ARMEmitter::SubRegSize(FEXCore::ToUnderlying(size) - 1);
+    LOGMAN_THROW_A_FMT(Index < SubRegSizeInBits(EncodedSubRegSize), "Index must be less than the source register size");
+
+    uint32_t H, L, M;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      // Index encoded in H:L:M
+      H = (Index >> 2) & 1;
+      L = (Index >> 1) & 1;
+      M = (Index >> 0) & 1;
+    }
+    else {
+      // Index encoded in H:L
+      // M overlaps rm register.
+      H = (Index >> 1) & 1;
+      L = (Index >> 0) & 1;
+      M = 0;
+    }
+    ASIMDVectorXIndexedElement(0b0, L, M, 0b0010, H, EncodedSubRegSize, rm.Q(), rn.Q(), rd.Q());
+  }
+  ///< size is destination size
+  void sqdmlal(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm, uint32_t Index) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
+
+    if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
+    }
+    const auto EncodedSubRegSize = FEXCore::ARMEmitter::SubRegSize(FEXCore::ToUnderlying(size) - 1);
+    LOGMAN_THROW_A_FMT(Index < SubRegSizeInBits(EncodedSubRegSize), "Index must be less than the source register size");
+
+    uint32_t H, L, M;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      // Index encoded in H:L:M
+      H = (Index >> 2) & 1;
+      L = (Index >> 1) & 1;
+      M = (Index >> 0) & 1;
+    }
+    else {
+      // Index encoded in H:L
+      // M overlaps rm register.
+      H = (Index >> 1) & 1;
+      L = (Index >> 0) & 1;
+      M = 0;
+    }
+    ASIMDVectorXIndexedElement(0b0, L, M, 0b0011, H, EncodedSubRegSize, rm.D(), rn.D(), rd.D());
+  }
+  ///< size is destination size
+  void sqdmlal2(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm, uint32_t Index) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
+
+    if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
+    }
+    const auto EncodedSubRegSize = FEXCore::ARMEmitter::SubRegSize(FEXCore::ToUnderlying(size) - 1);
+    LOGMAN_THROW_A_FMT(Index < SubRegSizeInBits(EncodedSubRegSize), "Index must be less than the source register size");
+
+    uint32_t H, L, M;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      // Index encoded in H:L:M
+      H = (Index >> 2) & 1;
+      L = (Index >> 1) & 1;
+      M = (Index >> 0) & 1;
+    }
+    else {
+      // Index encoded in H:L
+      // M overlaps rm register.
+      H = (Index >> 1) & 1;
+      L = (Index >> 0) & 1;
+      M = 0;
+    }
+    ASIMDVectorXIndexedElement(0b0, L, M, 0b0011, H, EncodedSubRegSize, rm.Q(), rn.Q(), rd.Q());
+  }
+  ///< size is destination size
+  void smlsl(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm, uint32_t Index) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
+
+    if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
+    }
+    const auto EncodedSubRegSize = FEXCore::ARMEmitter::SubRegSize(FEXCore::ToUnderlying(size) - 1);
+    LOGMAN_THROW_A_FMT(Index < SubRegSizeInBits(EncodedSubRegSize), "Index must be less than the source register size");
+
+    uint32_t H, L, M;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      // Index encoded in H:L:M
+      H = (Index >> 2) & 1;
+      L = (Index >> 1) & 1;
+      M = (Index >> 0) & 1;
+    }
+    else {
+      // Index encoded in H:L
+      // M overlaps rm register.
+      H = (Index >> 1) & 1;
+      L = (Index >> 0) & 1;
+      M = 0;
+    }
+    ASIMDVectorXIndexedElement(0b0, L, M, 0b0110, H, EncodedSubRegSize, rm.D(), rn.D(), rd.D());
+  }
+  ///< size is destination size
+  void smlsl2(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm, uint32_t Index) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
+
+    if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
+    }
+    const auto EncodedSubRegSize = FEXCore::ARMEmitter::SubRegSize(FEXCore::ToUnderlying(size) - 1);
+    LOGMAN_THROW_A_FMT(Index < SubRegSizeInBits(EncodedSubRegSize), "Index must be less than the source register size");
+
+    uint32_t H, L, M;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      // Index encoded in H:L:M
+      H = (Index >> 2) & 1;
+      L = (Index >> 1) & 1;
+      M = (Index >> 0) & 1;
+    }
+    else {
+      // Index encoded in H:L
+      // M overlaps rm register.
+      H = (Index >> 1) & 1;
+      L = (Index >> 0) & 1;
+      M = 0;
+    }
+    ASIMDVectorXIndexedElement(0b0, L, M, 0b0110, H, EncodedSubRegSize, rm.Q(), rn.Q(), rd.Q());
+  }
+  ///< size is destination size
+  void sqdmlsl(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm, uint32_t Index) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
+
+    if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
+    }
+    const auto EncodedSubRegSize = FEXCore::ARMEmitter::SubRegSize(FEXCore::ToUnderlying(size) - 1);
+    LOGMAN_THROW_A_FMT(Index < SubRegSizeInBits(EncodedSubRegSize), "Index must be less than the source register size");
+
+    uint32_t H, L, M;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      // Index encoded in H:L:M
+      H = (Index >> 2) & 1;
+      L = (Index >> 1) & 1;
+      M = (Index >> 0) & 1;
+    }
+    else {
+      // Index encoded in H:L
+      // M overlaps rm register.
+      H = (Index >> 1) & 1;
+      L = (Index >> 0) & 1;
+      M = 0;
+    }
+    ASIMDVectorXIndexedElement(0b0, L, M, 0b0111, H, EncodedSubRegSize, rm.D(), rn.D(), rd.D());
+  }
+  ///< size is destination size
+  void sqdmlsl2(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm, uint32_t Index) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
+
+    if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
+    }
+    const auto EncodedSubRegSize = FEXCore::ARMEmitter::SubRegSize(FEXCore::ToUnderlying(size) - 1);
+    LOGMAN_THROW_A_FMT(Index < SubRegSizeInBits(EncodedSubRegSize), "Index must be less than the source register size");
+
+    uint32_t H, L, M;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      // Index encoded in H:L:M
+      H = (Index >> 2) & 1;
+      L = (Index >> 1) & 1;
+      M = (Index >> 0) & 1;
+    }
+    else {
+      // Index encoded in H:L
+      // M overlaps rm register.
+      H = (Index >> 1) & 1;
+      L = (Index >> 0) & 1;
+      M = 0;
+    }
+    ASIMDVectorXIndexedElement(0b0, L, M, 0b0111, H, EncodedSubRegSize, rm.Q(), rn.Q(), rd.Q());
+  }
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void mul(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm, uint32_t Index) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i16Bit || size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Invalid destination size");
+
+    if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
+    }
+    LOGMAN_THROW_A_FMT(Index < SubRegSizeInBits(size), "Index must be less than the source register size");
+
+    uint32_t H, L, M;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      // Index encoded in H:L:M
+      H = (Index >> 2) & 1;
+      L = (Index >> 1) & 1;
+      M = (Index >> 0) & 1;
+    }
+    else {
+      // Index encoded in H:L
+      // M overlaps rm register.
+      H = (Index >> 1) & 1;
+      L = (Index >> 0) & 1;
+      M = 0;
+    }
+    ASIMDVectorXIndexedElement(0b0, L, M, 0b1000, H, size, rm, rn, rd);
+  }
+  ///< size is destination size
+  void smull(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm, uint32_t Index) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
+
+    if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
+    }
+    const auto EncodedSubRegSize = FEXCore::ARMEmitter::SubRegSize(FEXCore::ToUnderlying(size) - 1);
+    LOGMAN_THROW_A_FMT(Index < SubRegSizeInBits(EncodedSubRegSize), "Index must be less than the source register size");
+
+    uint32_t H, L, M;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      // Index encoded in H:L:M
+      H = (Index >> 2) & 1;
+      L = (Index >> 1) & 1;
+      M = (Index >> 0) & 1;
+    }
+    else {
+      // Index encoded in H:L
+      // M overlaps rm register.
+      H = (Index >> 1) & 1;
+      L = (Index >> 0) & 1;
+      M = 0;
+    }
+    ASIMDVectorXIndexedElement(0b0, L, M, 0b1010, H, EncodedSubRegSize, rm.D(), rn.D(), rd.D());
+  }
+  ///< size is destination size
+  void smull2(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm, uint32_t Index) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
+
+    if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
+    }
+    const auto EncodedSubRegSize = FEXCore::ARMEmitter::SubRegSize(FEXCore::ToUnderlying(size) - 1);
+    LOGMAN_THROW_A_FMT(Index < SubRegSizeInBits(EncodedSubRegSize), "Index must be less than the source register size");
+
+    uint32_t H, L, M;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      // Index encoded in H:L:M
+      H = (Index >> 2) & 1;
+      L = (Index >> 1) & 1;
+      M = (Index >> 0) & 1;
+    }
+    else {
+      // Index encoded in H:L
+      // M overlaps rm register.
+      H = (Index >> 1) & 1;
+      L = (Index >> 0) & 1;
+      M = 0;
+    }
+    ASIMDVectorXIndexedElement(0b0, L, M, 0b1010, H, EncodedSubRegSize, rm.Q(), rn.Q(), rd.Q());
+  }
+  ///< size is destination size
+  void sqdmull(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm, uint32_t Index) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
+
+    if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
+    }
+    const auto EncodedSubRegSize = FEXCore::ARMEmitter::SubRegSize(FEXCore::ToUnderlying(size) - 1);
+    LOGMAN_THROW_A_FMT(Index < SubRegSizeInBits(EncodedSubRegSize), "Index must be less than the source register size");
+
+    uint32_t H, L, M;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      // Index encoded in H:L:M
+      H = (Index >> 2) & 1;
+      L = (Index >> 1) & 1;
+      M = (Index >> 0) & 1;
+    }
+    else {
+      // Index encoded in H:L
+      // M overlaps rm register.
+      H = (Index >> 1) & 1;
+      L = (Index >> 0) & 1;
+      M = 0;
+    }
+    ASIMDVectorXIndexedElement(0b0, L, M, 0b1011, H, EncodedSubRegSize, rm.D(), rn.D(), rd.D());
+  }
+  ///< size is destination size
+  void sqdmull2(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm, uint32_t Index) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
+
+    if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
+    }
+    const auto EncodedSubRegSize = FEXCore::ARMEmitter::SubRegSize(FEXCore::ToUnderlying(size) - 1);
+    LOGMAN_THROW_A_FMT(Index < SubRegSizeInBits(EncodedSubRegSize), "Index must be less than the source register size");
+
+    uint32_t H, L, M;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      // Index encoded in H:L:M
+      H = (Index >> 2) & 1;
+      L = (Index >> 1) & 1;
+      M = (Index >> 0) & 1;
+    }
+    else {
+      // Index encoded in H:L
+      // M overlaps rm register.
+      H = (Index >> 1) & 1;
+      L = (Index >> 0) & 1;
+      M = 0;
+    }
+    ASIMDVectorXIndexedElement(0b0, L, M, 0b1011, H, EncodedSubRegSize, rm.Q(), rn.Q(), rd.Q());
+  }
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void sqdmulh(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm, uint32_t Index) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i16Bit || size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Invalid destination size");
+
+    if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
+    }
+    LOGMAN_THROW_A_FMT(Index < SubRegSizeInBits(size), "Index must be less than the source register size");
+
+    uint32_t H, L, M;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      // Index encoded in H:L:M
+      H = (Index >> 2) & 1;
+      L = (Index >> 1) & 1;
+      M = (Index >> 0) & 1;
+    }
+    else {
+      // Index encoded in H:L
+      // M overlaps rm register.
+      H = (Index >> 1) & 1;
+      L = (Index >> 0) & 1;
+      M = 0;
+    }
+    ASIMDVectorXIndexedElement(0b0, L, M, 0b1100, H, size, rm, rn, rd);
+  }
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void sqrdmulh(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm, uint32_t Index) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i16Bit || size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Invalid destination size");
+
+    if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
+    }
+    LOGMAN_THROW_A_FMT(Index < SubRegSizeInBits(size), "Index must be less than the source register size");
+
+    uint32_t H, L, M;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      // Index encoded in H:L:M
+      H = (Index >> 2) & 1;
+      L = (Index >> 1) & 1;
+      M = (Index >> 0) & 1;
+    }
+    else {
+      // Index encoded in H:L
+      // M overlaps rm register.
+      H = (Index >> 1) & 1;
+      L = (Index >> 0) & 1;
+      M = 0;
+    }
+    ASIMDVectorXIndexedElement(0b0, L, M, 0b1101, H, size, rm, rn, rd);
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void sdot(T rd, T rn, T rm, uint32_t Index) {
+    LOGMAN_THROW_A_FMT(Index < 4, "Index must be less than the source register size");
+
+    uint32_t H, L, M;
+    // Index encoded in H:L
+    // M overlaps rm register.
+    H = (Index >> 1) & 1;
+    L = (Index >> 0) & 1;
+    M = 0;
+    ASIMDVectorXIndexedElement(0b0, L, M, 0b1110, H, FEXCore::ARMEmitter::SubRegSize::i32Bit, rm, rn, rd);
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void sudot(T rd, T rn, T rm, uint32_t Index) {
+    LOGMAN_THROW_A_FMT(Index < 4, "Index must be less than the source register size");
+
+    uint32_t H, L, M;
+    // Index encoded in H:L
+    // M overlaps rm register.
+    H = (Index >> 1) & 1;
+    L = (Index >> 0) & 1;
+    M = 0;
+    ASIMDVectorXIndexedElement(0b0, L, M, 0b1111, H, FEXCore::ARMEmitter::SubRegSize::i8Bit, rm, rn, rd);
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void bfdot(T rd, T rn, T rm, uint32_t Index) {
+    LOGMAN_THROW_A_FMT(Index < 4, "Index must be less than the source register size");
+
+    uint32_t H, L, M;
+    // Index encoded in H:L
+    // M overlaps rm register.
+    H = (Index >> 1) & 1;
+    L = (Index >> 0) & 1;
+    M = 0;
+    ASIMDVectorXIndexedElement(0b0, L, M, 0b1111, H, FEXCore::ARMEmitter::SubRegSize::i16Bit, rm, rn, rd);
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void fmla(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm, uint32_t Index) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i16Bit ||
+                        size == FEXCore::ARMEmitter::SubRegSize::i32Bit ||
+                        size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
+    LOGMAN_THROW_A_FMT(Index < SubRegSizeInBits(size), "Index must be less than the source register size");
+
+    uint32_t H, L, M;
+    auto EncodedSubRegSize = size;
+
+    if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      // Index encoded in H:L:M
+      H = (Index >> 2) & 1;
+      L = (Index >> 1) & 1;
+      M = (Index >> 0) & 1;
+      // ARM in their infinite wisdom decided to encode 16-bit as an 8-bit operation even though 16-bit was unallocated.
+      EncodedSubRegSize = FEXCore::ARMEmitter::SubRegSize::i8Bit;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      // Index encoded in H:L
+      H = (Index >> 1) & 1;
+      L = (Index >> 0) & 1;
+      M = 0;
+    }
+    else {
+      LOGMAN_THROW_A_FMT(std::is_same_v<FEXCore::ARMEmitter::QRegister, T>, "Can't encode DRegister with i64Bit");
+      // Index encoded in H
+      H = Index;
+      L = 0;
+      M = 0;
+    }
+    ASIMDVectorXIndexedElement(0b0, L, M, 0b0001, H, EncodedSubRegSize, rm, rn, rd);
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void fmls(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm, uint32_t Index) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i16Bit ||
+                        size == FEXCore::ARMEmitter::SubRegSize::i32Bit ||
+                        size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
+    LOGMAN_THROW_A_FMT(Index < SubRegSizeInBits(size), "Index must be less than the source register size");
+
+    uint32_t H, L, M;
+    auto EncodedSubRegSize = size;
+
+    if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      // Index encoded in H:L:M
+      H = (Index >> 2) & 1;
+      L = (Index >> 1) & 1;
+      M = (Index >> 0) & 1;
+      // ARM in their infinite wisdom decided to encode 16-bit as an 8-bit operation even though 16-bit was unallocated.
+      EncodedSubRegSize = FEXCore::ARMEmitter::SubRegSize::i8Bit;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      // Index encoded in H:L
+      H = (Index >> 1) & 1;
+      L = (Index >> 0) & 1;
+      M = 0;
+    }
+    else {
+      LOGMAN_THROW_A_FMT(std::is_same_v<FEXCore::ARMEmitter::QRegister, T>, "Can't encode DRegister with i64Bit");
+      // Index encoded in H
+      H = Index;
+      L = 0;
+      M = 0;
+    }
+    ASIMDVectorXIndexedElement(0b0, L, M, 0b0101, H, EncodedSubRegSize, rm, rn, rd);
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void fmul(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm, uint32_t Index) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i16Bit ||
+                        size == FEXCore::ARMEmitter::SubRegSize::i32Bit ||
+                        size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
+    LOGMAN_THROW_A_FMT(Index < SubRegSizeInBits(size), "Index must be less than the source register size");
+
+    uint32_t H, L, M;
+    auto EncodedSubRegSize = size;
+
+    if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      // Index encoded in H:L:M
+      H = (Index >> 2) & 1;
+      L = (Index >> 1) & 1;
+      M = (Index >> 0) & 1;
+      // ARM in their infinite wisdom decided to encode 16-bit as an 8-bit operation even though 16-bit was unallocated.
+      EncodedSubRegSize = FEXCore::ARMEmitter::SubRegSize::i8Bit;
+    }
+    else if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      // Index encoded in H:L
+      H = (Index >> 1) & 1;
+      L = (Index >> 0) & 1;
+      M = 0;
+    }
+    else {
+      LOGMAN_THROW_A_FMT(std::is_same_v<FEXCore::ARMEmitter::QRegister, T>, "Can't encode DRegister with i64Bit");
+      // Index encoded in H
+      H = Index;
+      L = 0;
+      M = 0;
+    }
+    ASIMDVectorXIndexedElement(0b0, L, M, 0b1001, H, EncodedSubRegSize, rm, rn, rd);
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void fmlal(T rd, T rn, T rm, uint32_t Index) {
+    LOGMAN_THROW_A_FMT(Index < 8, "Index must be less than the source register size");
+
+    uint32_t H, L, M;
+    // Index encoded in H:L
+    // M overlaps rm register.
+    H = (Index >> 2) & 1;
+    L = (Index >> 1) & 1;
+    M = (Index >> 0) & 1;
+    ASIMDVectorXIndexedElement(0b0, L, M, 0b0000, H, FEXCore::ARMEmitter::SubRegSize::i32Bit, rm, rn, rd);
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void fmlal2(T rd, T rn, T rm, uint32_t Index) {
+    LOGMAN_THROW_A_FMT(Index < 8, "Index must be less than the source register size");
+
+    uint32_t H, L, M;
+    // Index encoded in H:L
+    // M overlaps rm register.
+    H = (Index >> 2) & 1;
+    L = (Index >> 1) & 1;
+    M = (Index >> 0) & 1;
+    ASIMDVectorXIndexedElement(0b1, L, M, 0b1000, H, FEXCore::ARMEmitter::SubRegSize::i32Bit, rm, rn, rd);
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void fmlsl(T rd, T rn, T rm, uint32_t Index) {
+    LOGMAN_THROW_A_FMT(Index < 8, "Index must be less than the source register size");
+
+    uint32_t H, L, M;
+    // Index encoded in H:L
+    // M overlaps rm register.
+    H = (Index >> 2) & 1;
+    L = (Index >> 1) & 1;
+    M = (Index >> 0) & 1;
+    ASIMDVectorXIndexedElement(0b0, L, M, 0b0100, H, FEXCore::ARMEmitter::SubRegSize::i32Bit, rm, rn, rd);
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void fmlsl2(T rd, T rn, T rm, uint32_t Index) {
+    LOGMAN_THROW_A_FMT(Index < 8, "Index must be less than the source register size");
+
+    uint32_t H, L, M;
+    // Index encoded in H:L
+    // M overlaps rm register.
+    H = (Index >> 2) & 1;
+    L = (Index >> 1) & 1;
+    M = (Index >> 0) & 1;
+    ASIMDVectorXIndexedElement(0b1, L, M, 0b1100, H, FEXCore::ARMEmitter::SubRegSize::i32Bit, rm, rn, rd);
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void usdot(T rd, T rn, T rm, uint32_t Index) {
+    LOGMAN_THROW_A_FMT(Index < 4, "Index must be less than the source register size");
+
+    uint32_t H, L, M;
+    // Index encoded in H:L
+    // M overlaps rm register.
+    H = (Index >> 1) & 1;
+    L = (Index >> 0) & 1;
+    M = 0;
+    ASIMDVectorXIndexedElement(0b0, L, M, 0b1111, H, FEXCore::ARMEmitter::SubRegSize::i32Bit, rm, rn, rd);
+  }
+
+  void bfmlalb(FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm, uint32_t Index) {
+    LOGMAN_THROW_AA_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
+    LOGMAN_THROW_A_FMT(Index < 8, "Index must be less than the source register size");
+
+    uint32_t H, L, M;
+    // Index encoded in H:L
+    // M overlaps rm register.
+    H = (Index >> 2) & 1;
+    L = (Index >> 1) & 1;
+    M = (Index >> 0) & 1;
+    ASIMDVectorXIndexedElement(0b0, L, M, 0b1111, H, FEXCore::ARMEmitter::SubRegSize::i64Bit, rm.D(), rn.D(), rd.D());
+  }
+  void bfmlalt(FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm, uint32_t Index) {
+    LOGMAN_THROW_AA_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
+    LOGMAN_THROW_A_FMT(Index < 8, "Index must be less than the source register size");
+
+    uint32_t H, L, M;
+    // Index encoded in H:L
+    // M overlaps rm register.
+    H = (Index >> 2) & 1;
+    L = (Index >> 1) & 1;
+    M = (Index >> 0) & 1;
+    ASIMDVectorXIndexedElement(0b0, L, M, 0b1111, H, FEXCore::ARMEmitter::SubRegSize::i64Bit, rm.Q(), rn.Q(), rd.Q());
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void mla(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm, uint32_t Index) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i16Bit || size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Invalid destination size");
+
+    if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
+    }
+    LOGMAN_THROW_A_FMT(Index < SubRegSizeInBits(size), "Index must be less than the source register size");
+
+    uint32_t H, L, M;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      // Index encoded in H:L:M
+      H = (Index >> 2) & 1;
+      L = (Index >> 1) & 1;
+      M = (Index >> 0) & 1;
+    }
+    else {
+      // Index encoded in H:L
+      // M overlaps rm register.
+      H = (Index >> 1) & 1;
+      L = (Index >> 0) & 1;
+      M = 0;
+    }
+    ASIMDVectorXIndexedElement(0b1, L, M, 0b0000, H, size, rm, rn, rd);
+  }
+
+  ///< size is destination size
+  void umlal(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm, uint32_t Index) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
+
+    if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
+    }
+    const auto EncodedSubRegSize = FEXCore::ARMEmitter::SubRegSize(FEXCore::ToUnderlying(size) - 1);
+    LOGMAN_THROW_A_FMT(Index < SubRegSizeInBits(EncodedSubRegSize), "Index must be less than the source register size");
+
+    uint32_t H, L, M;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      // Index encoded in H:L:M
+      H = (Index >> 2) & 1;
+      L = (Index >> 1) & 1;
+      M = (Index >> 0) & 1;
+    }
+    else {
+      // Index encoded in H:L
+      // M overlaps rm register.
+      H = (Index >> 1) & 1;
+      L = (Index >> 0) & 1;
+      M = 0;
+    }
+    ASIMDVectorXIndexedElement(0b1, L, M, 0b0010, H, EncodedSubRegSize, rm.D(), rn.D(), rd.D());
+  }
+  ///< size is destination size
+  void umlal2(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm, uint32_t Index) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
+
+    if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
+    }
+    const auto EncodedSubRegSize = FEXCore::ARMEmitter::SubRegSize(FEXCore::ToUnderlying(size) - 1);
+    LOGMAN_THROW_A_FMT(Index < SubRegSizeInBits(EncodedSubRegSize), "Index must be less than the source register size");
+
+    uint32_t H, L, M;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      // Index encoded in H:L:M
+      H = (Index >> 2) & 1;
+      L = (Index >> 1) & 1;
+      M = (Index >> 0) & 1;
+    }
+    else {
+      // Index encoded in H:L
+      // M overlaps rm register.
+      H = (Index >> 1) & 1;
+      L = (Index >> 0) & 1;
+      M = 0;
+    }
+    ASIMDVectorXIndexedElement(0b1, L, M, 0b0010, H, EncodedSubRegSize, rm.Q(), rn.Q(), rd.Q());
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void mls(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm, uint32_t Index) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i16Bit || size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Invalid destination size");
+
+    if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
+    }
+    LOGMAN_THROW_A_FMT(Index < SubRegSizeInBits(size), "Index must be less than the source register size");
+
+    uint32_t H, L, M;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      // Index encoded in H:L:M
+      H = (Index >> 2) & 1;
+      L = (Index >> 1) & 1;
+      M = (Index >> 0) & 1;
+    }
+    else {
+      // Index encoded in H:L
+      // M overlaps rm register.
+      H = (Index >> 1) & 1;
+      L = (Index >> 0) & 1;
+      M = 0;
+    }
+    ASIMDVectorXIndexedElement(0b1, L, M, 0b0100, H, size, rm, rn, rd);
+  }
+
+  ///< size is destination size
+  void umlsl(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm, uint32_t Index) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
+
+    if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
+    }
+    const auto EncodedSubRegSize = FEXCore::ARMEmitter::SubRegSize(FEXCore::ToUnderlying(size) - 1);
+    LOGMAN_THROW_A_FMT(Index < SubRegSizeInBits(EncodedSubRegSize), "Index must be less than the source register size");
+
+    uint32_t H, L, M;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      // Index encoded in H:L:M
+      H = (Index >> 2) & 1;
+      L = (Index >> 1) & 1;
+      M = (Index >> 0) & 1;
+    }
+    else {
+      // Index encoded in H:L
+      // M overlaps rm register.
+      H = (Index >> 1) & 1;
+      L = (Index >> 0) & 1;
+      M = 0;
+    }
+    ASIMDVectorXIndexedElement(0b1, L, M, 0b0110, H, EncodedSubRegSize, rm.D(), rn.D(), rd.D());
+  }
+  ///< size is destination size
+  void umlsl2(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm, uint32_t Index) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
+
+    if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
+    }
+    const auto EncodedSubRegSize = FEXCore::ARMEmitter::SubRegSize(FEXCore::ToUnderlying(size) - 1);
+    LOGMAN_THROW_A_FMT(Index < SubRegSizeInBits(EncodedSubRegSize), "Index must be less than the source register size");
+
+    uint32_t H, L, M;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      // Index encoded in H:L:M
+      H = (Index >> 2) & 1;
+      L = (Index >> 1) & 1;
+      M = (Index >> 0) & 1;
+    }
+    else {
+      // Index encoded in H:L
+      // M overlaps rm register.
+      H = (Index >> 1) & 1;
+      L = (Index >> 0) & 1;
+      M = 0;
+    }
+    ASIMDVectorXIndexedElement(0b1, L, M, 0b0110, H, EncodedSubRegSize, rm.Q(), rn.Q(), rd.Q());
+  }
+
+  ///< size is destination size
+  void umull(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm, uint32_t Index) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
+
+    if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
+    }
+    const auto EncodedSubRegSize = FEXCore::ARMEmitter::SubRegSize(FEXCore::ToUnderlying(size) - 1);
+    LOGMAN_THROW_A_FMT(Index < SubRegSizeInBits(EncodedSubRegSize), "Index must be less than the source register size");
+
+    uint32_t H, L, M;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      // Index encoded in H:L:M
+      H = (Index >> 2) & 1;
+      L = (Index >> 1) & 1;
+      M = (Index >> 0) & 1;
+    }
+    else {
+      // Index encoded in H:L
+      // M overlaps rm register.
+      H = (Index >> 1) & 1;
+      L = (Index >> 0) & 1;
+      M = 0;
+    }
+    ASIMDVectorXIndexedElement(0b1, L, M, 0b1010, H, EncodedSubRegSize, rm.D(), rn.D(), rd.D());
+  }
+  ///< size is destination size
+  void umull2(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm, uint32_t Index) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i32Bit || size == FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
+
+    if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      LOGMAN_THROW_AA_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
+    }
+    const auto EncodedSubRegSize = FEXCore::ARMEmitter::SubRegSize(FEXCore::ToUnderlying(size) - 1);
+    LOGMAN_THROW_A_FMT(Index < SubRegSizeInBits(EncodedSubRegSize), "Index must be less than the source register size");
+
+    uint32_t H, L, M;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i32Bit) {
+      // Index encoded in H:L:M
+      H = (Index >> 2) & 1;
+      L = (Index >> 1) & 1;
+      M = (Index >> 0) & 1;
+    }
+    else {
+      // Index encoded in H:L
+      // M overlaps rm register.
+      H = (Index >> 1) & 1;
+      L = (Index >> 0) & 1;
+      M = 0;
+    }
+    ASIMDVectorXIndexedElement(0b1, L, M, 0b1010, H, EncodedSubRegSize, rm.Q(), rn.Q(), rd.Q());
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void sqrdmlah(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm, uint32_t Index) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i16Bit || size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Invalid destination size");
+
+    if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
+    }
+    LOGMAN_THROW_A_FMT(Index < SubRegSizeInBits(size), "Index must be less than the source register size");
+
+    uint32_t H, L, M;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      // Index encoded in H:L:M
+      H = (Index >> 2) & 1;
+      L = (Index >> 1) & 1;
+      M = (Index >> 0) & 1;
+    }
+    else {
+      // Index encoded in H:L
+      // M overlaps rm register.
+      H = (Index >> 1) & 1;
+      L = (Index >> 0) & 1;
+      M = 0;
+    }
+    ASIMDVectorXIndexedElement(0b1, L, M, 0b1101, H, size, rm, rn, rd);
+  }
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void udot(T rd, T rn, T rm, uint32_t Index) {
+    LOGMAN_THROW_A_FMT(Index < 4, "Index must be less than the source register size");
+
+    uint32_t H, L, M;
+    // Index encoded in H:L
+    // M overlaps rm register.
+    H = (Index >> 1) & 1;
+    L = (Index >> 0) & 1;
+    M = 0;
+    ASIMDVectorXIndexedElement(0b1, L, M, 0b1110, H, FEXCore::ARMEmitter::SubRegSize::i32Bit, rm, rn, rd);
+  }
+
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void sqrdmlsh(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, T rm, uint32_t Index) {
+    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i16Bit || size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Invalid destination size");
+
+    if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      LOGMAN_THROW_AA_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
+    }
+    LOGMAN_THROW_A_FMT(Index < SubRegSizeInBits(size), "Index must be less than the source register size");
+
+    uint32_t H, L, M;
+    if (size == FEXCore::ARMEmitter::SubRegSize::i16Bit) {
+      // Index encoded in H:L:M
+      H = (Index >> 2) & 1;
+      L = (Index >> 1) & 1;
+      M = (Index >> 0) & 1;
+    }
+    else {
+      // Index encoded in H:L
+      // M overlaps rm register.
+      H = (Index >> 1) & 1;
+      L = (Index >> 0) & 1;
+      M = 0;
+    }
+    ASIMDVectorXIndexedElement(0b1, L, M, 0b1111, H, size, rm, rn, rd);
+  }
+
   // Cryptographic three-register, imm2
   // TODO
   // Cryptographic three-register SHA 512
@@ -3583,7 +4495,54 @@ public:
   // Cryptographic two-register SHA 512
   // TODO
   // Conversion between floating-point and fixed-point
-  // TODO
+  void scvtf(FEXCore::ARMEmitter::ScalarRegSize ScalarSize, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::Size GPRSize, FEXCore::ARMEmitter::Register rn, uint32_t FractionalBits) {
+    LOGMAN_THROW_AA_FMT(FractionalBits >= 1 && FractionalBits <= FEXCore::ARMEmitter::RegSizeInBits(GPRSize), "Fractional bits out of range");
+
+    uint32_t Scale = 64 - FractionalBits;
+    const auto ConvertedSize =
+      ScalarSize == ARMEmitter::ScalarRegSize::i64Bit ? 0b01 :
+      ScalarSize == ARMEmitter::ScalarRegSize::i32Bit ? 0b00 :
+      ScalarSize == ARMEmitter::ScalarRegSize::i16Bit ? 0b11 : 0;
+
+    ScalarConvertBetweenFPAndFixed(0, 0b00, 0b010, Scale, GPRSize, ConvertedSize, rn, rd);
+  }
+
+  void ucvtf(FEXCore::ARMEmitter::ScalarRegSize ScalarSize, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::Size GPRSize, FEXCore::ARMEmitter::Register rn, uint32_t FractionalBits) {
+    LOGMAN_THROW_AA_FMT(FractionalBits >= 1 && FractionalBits <= FEXCore::ARMEmitter::RegSizeInBits(GPRSize), "Fractional bits out of range");
+
+    uint32_t Scale = 64 - FractionalBits;
+    const auto ConvertedSize =
+      ScalarSize == ARMEmitter::ScalarRegSize::i64Bit ? 0b01 :
+      ScalarSize == ARMEmitter::ScalarRegSize::i32Bit ? 0b00 :
+      ScalarSize == ARMEmitter::ScalarRegSize::i16Bit ? 0b11 : 0;
+
+    ScalarConvertBetweenFPAndFixed(0, 0b00, 0b011, Scale, GPRSize, ConvertedSize, rn, rd);
+  }
+
+  void fcvtzs(FEXCore::ARMEmitter::Size GPRSize, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::ScalarRegSize ScalarSize, FEXCore::ARMEmitter::VRegister rn, uint32_t FractionalBits) {
+    LOGMAN_THROW_AA_FMT(FractionalBits >= 1 && FractionalBits <= FEXCore::ARMEmitter::RegSizeInBits(GPRSize), "Fractional bits out of range");
+
+    uint32_t Scale = 64 - FractionalBits;
+    const auto ConvertedSize =
+      ScalarSize == ARMEmitter::ScalarRegSize::i64Bit ? 0b01 :
+      ScalarSize == ARMEmitter::ScalarRegSize::i32Bit ? 0b00 :
+      ScalarSize == ARMEmitter::ScalarRegSize::i16Bit ? 0b11 : 0;
+
+    ScalarConvertBetweenFPAndFixed(0, 0b11, 0b000, Scale, GPRSize, ConvertedSize, rn, rd);
+  }
+
+  void fcvtzu(FEXCore::ARMEmitter::Size GPRSize, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::ScalarRegSize ScalarSize, FEXCore::ARMEmitter::VRegister rn, uint32_t FractionalBits) {
+    LOGMAN_THROW_AA_FMT(FractionalBits >= 1 && FractionalBits <= FEXCore::ARMEmitter::RegSizeInBits(GPRSize), "Fractional bits out of range");
+
+    uint32_t Scale = 64 - FractionalBits;
+    const auto ConvertedSize =
+      ScalarSize == ARMEmitter::ScalarRegSize::i64Bit ? 0b01 :
+      ScalarSize == ARMEmitter::ScalarRegSize::i32Bit ? 0b00 :
+      ScalarSize == ARMEmitter::ScalarRegSize::i16Bit ? 0b11 : 0;
+
+    ScalarConvertBetweenFPAndFixed(0, 0b11, 0b001, Scale, GPRSize, ConvertedSize, rn, rd);
+  }
+
   // Conversion between floating-point and integer
   void fcvtns(FEXCore::ARMEmitter::Size size, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::HRegister rn) {
     constexpr uint32_t Op = 0b0001'1110'001 << 21;
@@ -3954,6 +4913,50 @@ private:
     Instr |= opcode << 11;
     Instr |= Encode_rn(rn);
     Instr |= Encode_rd(rd);
+    dc32(Instr);
+  }
+
+  // Advanced SIMD vector x indexed element
+  template<typename T>
+  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
+  void ASIMDVectorXIndexedElement(uint32_t U, uint32_t L, uint32_t M, uint32_t opcode, uint32_t H, FEXCore::ARMEmitter::SubRegSize size, T rm, T rn, T rd) {
+    constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'00 << 10;
+    constexpr uint32_t Q = std::is_same_v<FEXCore::ARMEmitter::QRegister, T> ? 1U << 30 : 0;
+
+    uint32_t Instr = Op;
+
+    Instr |= Q;
+    Instr |= U << 29;
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= L << 21;
+
+    // M and Rm might overlap. It's up to the instruction emitter itself to ensure there is no conflict.
+    Instr |= M << 20;
+    Instr |= rm.Idx() << 16;
+    Instr |= opcode << 12;
+    Instr |= H << 11;
+    Instr |= rn.Idx() << 5;
+    Instr |= rd.Idx();
+    dc32(Instr);
+  }
+
+  // Conversion between floating-point and fixed-point
+  template<typename T, typename T2>
+  void ScalarConvertBetweenFPAndFixed(uint32_t S, uint32_t rmode, uint32_t opcode, uint32_t scale,
+                                      FEXCore::ARMEmitter::Size GPRSize, uint32_t ScalarSize,
+                                      T rn, T2 rd) {
+    constexpr uint32_t Op = 0b0001'1110'000 << 21;
+    const uint32_t SF = GPRSize == FEXCore::ARMEmitter::Size::i64Bit ? (1U << 31) : 0;
+
+    uint32_t Instr = Op;
+    Instr |= SF;
+    Instr |= S << 29;
+    Instr |= ScalarSize << 22;
+    Instr |= rmode << 19;
+    Instr |= opcode << 16;
+    Instr |= scale << 10;
+    Instr |= rn.Idx() << 5;
+    Instr |= rd.Idx();
     dc32(Instr);
   }
 

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ASIMDOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ASIMDOps.inl
@@ -3220,7 +3220,46 @@ public:
     sshll2(size, rd, rn, 0);
   }
 
-  // TODO: SCVTF, FCVTZS
+  template<typename T>
+  void scvtf(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, uint32_t FractionalBits) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "Invalid size");
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+
+    constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = SubRegSizeInBits(size);
+    LOGMAN_THROW_AA_FMT(FractionalBits < SubregSizeInBits, "FractionalBits must not be larger than incoming element size");
+
+    // fbits encoded a bit weirdly.
+    // fbits = (esize * 2) - immh:immb but immh is /also/ used for element size.
+    const uint32_t InvertedFractionalBits = (SubregSizeInBits * 2) - FractionalBits;
+    const uint32_t immh = InvertedFractionalBits >> 3;
+    const uint32_t immb = InvertedFractionalBits & 0b111;
+
+    ASIMDShiftByImm(Op, 0, immh, immb, 0b11100, rn, rd);
+  }
+
+  template<typename T>
+  void fcvtzs(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, uint32_t FractionalBits) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "Invalid size");
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+
+    constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = SubRegSizeInBits(size);
+    LOGMAN_THROW_AA_FMT(FractionalBits < SubregSizeInBits, "FractionalBits must not be larger than incoming element size");
+
+    // fbits encoded a bit weirdly.
+    // fbits = (esize * 2) - immh:immb but immh is /also/ used for element size.
+    const uint32_t InvertedFractionalBits = (SubregSizeInBits * 2) - FractionalBits;
+    const uint32_t immh = InvertedFractionalBits >> 3;
+    const uint32_t immb = InvertedFractionalBits & 0b111;
+
+    ASIMDShiftByImm(Op, 0, immh, immb, 0b11111, rn, rd);
+  }
+
   template<typename T>
   void ushr(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, uint32_t Shift) {
     if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
@@ -3493,7 +3532,45 @@ public:
   void uxtl2(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::QRegister rd, FEXCore::ARMEmitter::QRegister rn) {
     ushll2(size, rd, rn, 0);
   }
-  // XXX: UCVTF/FCVTZU
+  template<typename T>
+  void ucvtf(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, uint32_t FractionalBits) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "Invalid size");
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+
+    constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = SubRegSizeInBits(size);
+    LOGMAN_THROW_AA_FMT(FractionalBits < SubregSizeInBits, "FractionalBits must not be larger than incoming element size");
+
+    // fbits encoded a bit weirdly.
+    // fbits = (esize * 2) - immh:immb but immh is /also/ used for element size.
+    const uint32_t InvertedFractionalBits = (SubregSizeInBits * 2) - FractionalBits;
+    const uint32_t immh = InvertedFractionalBits >> 3;
+    const uint32_t immb = InvertedFractionalBits & 0b111;
+
+    ASIMDShiftByImm(Op, 1, immh, immb, 0b11100, rn, rd);
+  }
+
+  template<typename T>
+  void fcvtzu(FEXCore::ARMEmitter::SubRegSize size, T rd, T rn, uint32_t FractionalBits) {
+    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i8Bit, "Invalid size");
+    if constexpr (std::is_same_v<FEXCore::ARMEmitter::DRegister, T>) {
+      LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    }
+
+    constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
+    const size_t SubregSizeInBits = SubRegSizeInBits(size);
+    LOGMAN_THROW_AA_FMT(FractionalBits < SubregSizeInBits, "FractionalBits must not be larger than incoming element size");
+
+    // fbits encoded a bit weirdly.
+    // fbits = (esize * 2) - immh:immb but immh is /also/ used for element size.
+    const uint32_t InvertedFractionalBits = (SubregSizeInBits * 2) - FractionalBits;
+    const uint32_t immh = InvertedFractionalBits >> 3;
+    const uint32_t immb = InvertedFractionalBits & 0b111;
+
+    ASIMDShiftByImm(Op, 1, immh, immb, 0b11111, rn, rd);
+  }
 
   // Advanced SIMD vector x indexed element
   // TODO

--- a/External/FEXCore/unittests/Emitter/ASIMD_Tests.cpp
+++ b/External/FEXCore/unittests/Emitter/ASIMD_Tests.cpp
@@ -2683,7 +2683,471 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD shift by immed
 }
 
 TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD vector x indexed element") {
-  // TODO: Implement in emitter.
+  TEST_SINGLE(smlal(SubRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v15, 0), "smlal v30.4s, v29.4h, v15.h[0]");
+  TEST_SINGLE(smlal(SubRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v15, 7), "smlal v30.4s, v29.4h, v15.h[7]");
+
+  // vixl has a disassembler bug where it doesn't decode rm correctly for registers >= 16
+  //TEST_SINGLE(smlal(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28, 0), "smlal v30.2d, v29.2s, v28.s[0]");
+  //TEST_SINGLE(smlal(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28, 3), "smlal v30.2d, v29.2s, v28.s[3]");
+
+  TEST_SINGLE(smlal(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v15, 0), "smlal v30.2d, v29.2s, v15.s[0]");
+  TEST_SINGLE(smlal(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v15, 3), "smlal v30.2d, v29.2s, v15.s[3]");
+
+  TEST_SINGLE(smlal2(SubRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v15, 0), "smlal2 v30.4s, v29.8h, v15.h[0]");
+  TEST_SINGLE(smlal2(SubRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v15, 7), "smlal2 v30.4s, v29.8h, v15.h[7]");
+
+  // vixl has a disassembler bug where it doesn't decode rm correctly for registers >= 16
+  //TEST_SINGLE(smlal2(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28, 0), "smlal2 v30.2d, v29.4s, v28.s[0]");
+  //TEST_SINGLE(smlal2(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28, 3), "smlal2 v30.2d, v29.4s, v28.s[3]");
+
+  TEST_SINGLE(smlal2(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v15, 0), "smlal2 v30.2d, v29.4s, v15.s[0]");
+  TEST_SINGLE(smlal2(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v15, 3), "smlal2 v30.2d, v29.4s, v15.s[3]");
+
+  TEST_SINGLE(sqdmlal(SubRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v15, 0), "sqdmlal v30.4s, v29.4h, v15.h[0]");
+  TEST_SINGLE(sqdmlal(SubRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v15, 7), "sqdmlal v30.4s, v29.4h, v15.h[7]");
+
+  // vixl has a disassembler bug where it doesn't decode rm correctly for registers >= 16
+  //TEST_SINGLE(sqdmlal(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28, 0), "sqdmlal v30.2d, v29.2s, v28.s[0]");
+  //TEST_SINGLE(sqdmlal(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28, 3), "sqdmlal v30.2d, v29.2s, v28.s[3]");
+
+  TEST_SINGLE(sqdmlal(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v15, 0), "sqdmlal v30.2d, v29.2s, v15.s[0]");
+  TEST_SINGLE(sqdmlal(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v15, 3), "sqdmlal v30.2d, v29.2s, v15.s[3]");
+
+  TEST_SINGLE(sqdmlal2(SubRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v15, 0), "sqdmlal2 v30.4s, v29.8h, v15.h[0]");
+  TEST_SINGLE(sqdmlal2(SubRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v15, 7), "sqdmlal2 v30.4s, v29.8h, v15.h[7]");
+
+  // vixl has a disassembler bug where it doesn't decode rm correctly for registers >= 16
+  //TEST_SINGLE(sqdmlal2(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28, 0), "sqdmlal2 v30.2d, v29.4s, v28.s[0]");
+  //TEST_SINGLE(sqdmlal2(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28, 3), "sqdmlal2 v30.2d, v29.4s, v28.s[3]");
+
+  TEST_SINGLE(sqdmlal2(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v15, 0), "sqdmlal2 v30.2d, v29.4s, v15.s[0]");
+  TEST_SINGLE(sqdmlal2(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v15, 3), "sqdmlal2 v30.2d, v29.4s, v15.s[3]");
+
+  TEST_SINGLE(smlsl(SubRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v15, 0), "smlsl v30.4s, v29.4h, v15.h[0]");
+  TEST_SINGLE(smlsl(SubRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v15, 7), "smlsl v30.4s, v29.4h, v15.h[7]");
+
+  // vixl has a disassembler bug where it doesn't decode rm correctly for registers >= 16
+  //TEST_SINGLE(smlsl(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28, 0), "smlsl v30.2d, v29.2s, v28.s[0]");
+  //TEST_SINGLE(smlsl(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28, 3), "smlsl v30.2d, v29.2s, v28.s[3]");
+
+  TEST_SINGLE(smlsl(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v15, 0), "smlsl v30.2d, v29.2s, v15.s[0]");
+  TEST_SINGLE(smlsl(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v15, 3), "smlsl v30.2d, v29.2s, v15.s[3]");
+
+  TEST_SINGLE(smlsl2(SubRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v15, 0), "smlsl2 v30.4s, v29.8h, v15.h[0]");
+  TEST_SINGLE(smlsl2(SubRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v15, 7), "smlsl2 v30.4s, v29.8h, v15.h[7]");
+
+  // vixl has a disassembler bug where it doesn't decode rm correctly for registers >= 16
+  //TEST_SINGLE(smlsl2(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28, 0), "smlsl2 v30.2d, v29.4s, v28.s[0]");
+  //TEST_SINGLE(smlsl2(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28, 3), "smlsl2 v30.2d, v29.4s, v28.s[3]");
+
+  TEST_SINGLE(smlsl2(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v15, 0), "smlsl2 v30.2d, v29.4s, v15.s[0]");
+  TEST_SINGLE(smlsl2(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v15, 3), "smlsl2 v30.2d, v29.4s, v15.s[3]");
+
+  TEST_SINGLE(sqdmlsl(SubRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v15, 0), "sqdmlsl v30.4s, v29.4h, v15.h[0]");
+  TEST_SINGLE(sqdmlsl(SubRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v15, 7), "sqdmlsl v30.4s, v29.4h, v15.h[7]");
+
+  // vixl has a disassembler bug where it doesn't decode rm correctly for registers >= 16
+  //TEST_SINGLE(sqdmlsl(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28, 0), "sqdmlsl v30.2d, v29.2s, v28.s[0]");
+  //TEST_SINGLE(sqdmlsl(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28, 3), "sqdmlsl v30.2d, v29.2s, v28.s[3]");
+
+  TEST_SINGLE(sqdmlsl(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v15, 0), "sqdmlsl v30.2d, v29.2s, v15.s[0]");
+  TEST_SINGLE(sqdmlsl(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v15, 3), "sqdmlsl v30.2d, v29.2s, v15.s[3]");
+
+  TEST_SINGLE(sqdmlsl2(SubRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v15, 0), "sqdmlsl2 v30.4s, v29.8h, v15.h[0]");
+  TEST_SINGLE(sqdmlsl2(SubRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v15, 7), "sqdmlsl2 v30.4s, v29.8h, v15.h[7]");
+
+  // vixl has a disassembler bug where it doesn't decode rm correctly for registers >= 16
+  //TEST_SINGLE(sqdmlsl2(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28, 0), "sqdmlsl2 v30.2d, v29.4s, v28.s[0]");
+  //TEST_SINGLE(sqdmlsl2(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28, 3), "sqdmlsl2 v30.2d, v29.4s, v28.s[3]");
+
+  TEST_SINGLE(sqdmlsl2(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v15, 0), "sqdmlsl2 v30.2d, v29.4s, v15.s[0]");
+  TEST_SINGLE(sqdmlsl2(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v15, 3), "sqdmlsl2 v30.2d, v29.4s, v15.s[3]");
+
+  TEST_SINGLE(mul(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q15, 0), "mul v30.8h, v29.8h, v15.h[0]");
+  TEST_SINGLE(mul(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q15, 7), "mul v30.8h, v29.8h, v15.h[7]");
+
+  // vixl has a disassembler bug where it doesn't decode rm correctly for registers >= 16
+  //TEST_SINGLE(mul(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28, 0), "mul v30.4s, v29.4s, v28.s[0]");
+  //TEST_SINGLE(mul(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28, 3), "mul v30.4s, v29.4s, v28.s[3]");
+
+  TEST_SINGLE(mul(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q15, 0), "mul v30.4s, v29.4s, v15.s[0]");
+  TEST_SINGLE(mul(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q15, 3), "mul v30.4s, v29.4s, v15.s[3]");
+
+  TEST_SINGLE(mul(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d15, 0), "mul v30.4h, v29.4h, v15.h[0]");
+  TEST_SINGLE(mul(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d15, 7), "mul v30.4h, v29.4h, v15.h[7]");
+
+  // vixl has a disassembler bug where it doesn't decode rm correctly for registers >= 16
+  //TEST_SINGLE(mul(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28, 0), "mul v30.2s, v29.2s, v28.s[0]");
+  //TEST_SINGLE(mul(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28, 3), "mul v30.2s, v29.2s, v28.s[3]");
+
+  TEST_SINGLE(mul(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d15, 0), "mul v30.2s, v29.2s, v15.s[0]");
+  TEST_SINGLE(mul(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d15, 3), "mul v30.2s, v29.2s, v15.s[3]");
+
+  TEST_SINGLE(smull(SubRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v15, 0), "smull v30.4s, v29.4h, v15.h[0]");
+  TEST_SINGLE(smull(SubRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v15, 7), "smull v30.4s, v29.4h, v15.h[7]");
+
+  // vixl has a disassembler bug where it doesn't decode rm correctly for registers >= 16
+  //TEST_SINGLE(smull(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28, 0), "smull v30.2d, v29.2s, v28.s[0]");
+  //TEST_SINGLE(smull(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28, 3), "smull v30.2d, v29.2s, v28.s[3]");
+
+  TEST_SINGLE(smull(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v15, 0), "smull v30.2d, v29.2s, v15.s[0]");
+  TEST_SINGLE(smull(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v15, 3), "smull v30.2d, v29.2s, v15.s[3]");
+
+  TEST_SINGLE(smull2(SubRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v15, 0), "smull2 v30.4s, v29.8h, v15.h[0]");
+  TEST_SINGLE(smull2(SubRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v15, 7), "smull2 v30.4s, v29.8h, v15.h[7]");
+
+  // vixl has a disassembler bug where it doesn't decode rm correctly for registers >= 16
+  //TEST_SINGLE(smull2(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28, 0), "smull2 v30.2d, v29.4s, v28.s[0]");
+  //TEST_SINGLE(smull2(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28, 3), "smull2 v30.2d, v29.4s, v28.s[3]");
+
+  TEST_SINGLE(smull2(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v15, 0), "smull2 v30.2d, v29.4s, v15.s[0]");
+  TEST_SINGLE(smull2(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v15, 3), "smull2 v30.2d, v29.4s, v15.s[3]");
+
+  TEST_SINGLE(sqdmull(SubRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v15, 0), "sqdmull v30.4s, v29.4h, v15.h[0]");
+  TEST_SINGLE(sqdmull(SubRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v15, 7), "sqdmull v30.4s, v29.4h, v15.h[7]");
+
+  // vixl has a disassembler bug where it doesn't decode rm correctly for registers >= 16
+  //TEST_SINGLE(sqdmull(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28, 0), "sqdmull v30.2d, v29.2s, v28.s[0]");
+  //TEST_SINGLE(sqdmull(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28, 3), "sqdmull v30.2d, v29.2s, v28.s[3]");
+
+  TEST_SINGLE(sqdmull(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v15, 0), "sqdmull v30.2d, v29.2s, v15.s[0]");
+  TEST_SINGLE(sqdmull(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v15, 3), "sqdmull v30.2d, v29.2s, v15.s[3]");
+
+  TEST_SINGLE(sqdmull2(SubRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v15, 0), "sqdmull2 v30.4s, v29.8h, v15.h[0]");
+  TEST_SINGLE(sqdmull2(SubRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v15, 7), "sqdmull2 v30.4s, v29.8h, v15.h[7]");
+
+  // vixl has a disassembler bug where it doesn't decode rm correctly for registers >= 16
+  //TEST_SINGLE(sqdmull2(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28, 0), "sqdmull2 v30.2d, v29.4s, v28.s[0]");
+  //TEST_SINGLE(sqdmull2(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28, 3), "sqdmull2 v30.2d, v29.4s, v28.s[3]");
+
+  TEST_SINGLE(sqdmull2(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v15, 0), "sqdmull2 v30.2d, v29.4s, v15.s[0]");
+  TEST_SINGLE(sqdmull2(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v15, 3), "sqdmull2 v30.2d, v29.4s, v15.s[3]");
+
+  TEST_SINGLE(sqdmulh(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q15, 0), "sqdmulh v30.8h, v29.8h, v15.h[0]");
+  TEST_SINGLE(sqdmulh(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q15, 7), "sqdmulh v30.8h, v29.8h, v15.h[7]");
+
+  // vixl has a disassembler bug where it doesn't decode rm correctly for registers >= 16
+  //TEST_SINGLE(sqdmulh(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28, 0), "sqdmulh v30.4s, v29.4s, v28.s[0]");
+  //TEST_SINGLE(sqdmulh(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28, 3), "sqdmulh v30.4s, v29.4s, v28.s[3]");
+
+  TEST_SINGLE(sqdmulh(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q15, 0), "sqdmulh v30.4s, v29.4s, v15.s[0]");
+  TEST_SINGLE(sqdmulh(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q15, 3), "sqdmulh v30.4s, v29.4s, v15.s[3]");
+
+  TEST_SINGLE(sqdmulh(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d15, 0), "sqdmulh v30.4h, v29.4h, v15.h[0]");
+  TEST_SINGLE(sqdmulh(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d15, 7), "sqdmulh v30.4h, v29.4h, v15.h[7]");
+
+  // vixl has a disassembler bug where it doesn't decode rm correctly for registers >= 16
+  //TEST_SINGLE(sqdmulh(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28, 0), "sqdmulh v30.2s, v29.2s, v28.s[0]");
+  //TEST_SINGLE(sqdmulh(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28, 3), "sqdmulh v30.2s, v29.2s, v28.s[3]");
+
+  TEST_SINGLE(sqdmulh(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d15, 0), "sqdmulh v30.2s, v29.2s, v15.s[0]");
+  TEST_SINGLE(sqdmulh(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d15, 3), "sqdmulh v30.2s, v29.2s, v15.s[3]");
+
+  TEST_SINGLE(sqrdmulh(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q15, 0), "sqrdmulh v30.8h, v29.8h, v15.h[0]");
+  TEST_SINGLE(sqrdmulh(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q15, 7), "sqrdmulh v30.8h, v29.8h, v15.h[7]");
+
+  // vixl has a disassembler bug where it doesn't decode rm correctly for registers >= 16
+  //TEST_SINGLE(sqrdmulh(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28, 0), "sqrdmulh v30.4s, v29.4s, v28.s[0]");
+  //TEST_SINGLE(sqrdmulh(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28, 3), "sqrdmulh v30.4s, v29.4s, v28.s[3]");
+
+  TEST_SINGLE(sqrdmulh(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q15, 0), "sqrdmulh v30.4s, v29.4s, v15.s[0]");
+  TEST_SINGLE(sqrdmulh(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q15, 3), "sqrdmulh v30.4s, v29.4s, v15.s[3]");
+
+  TEST_SINGLE(sqrdmulh(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d15, 0), "sqrdmulh v30.4h, v29.4h, v15.h[0]");
+  TEST_SINGLE(sqrdmulh(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d15, 7), "sqrdmulh v30.4h, v29.4h, v15.h[7]");
+
+  // vixl has a disassembler bug where it doesn't decode rm correctly for registers >= 16
+  //TEST_SINGLE(sqrdmulh(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28, 0), "sqrdmulh v30.2s, v29.2s, v28.s[0]");
+  //TEST_SINGLE(sqrdmulh(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28, 3), "sqrdmulh v30.2s, v29.2s, v28.s[3]");
+
+  TEST_SINGLE(sqrdmulh(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d15, 0), "sqrdmulh v30.2s, v29.2s, v15.s[0]");
+  TEST_SINGLE(sqrdmulh(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d15, 3), "sqrdmulh v30.2s, v29.2s, v15.s[3]");
+
+  TEST_SINGLE(sdot(QReg::q30, QReg::q29, QReg::q28, 0), "sdot v30.4s, v29.16b, v28.4b[0]");
+  TEST_SINGLE(sdot(QReg::q30, QReg::q29, QReg::q28, 3), "sdot v30.4s, v29.16b, v28.4b[3]");
+
+  TEST_SINGLE(sdot(QReg::q30, QReg::q29, QReg::q15, 0), "sdot v30.4s, v29.16b, v15.4b[0]");
+  TEST_SINGLE(sdot(QReg::q30, QReg::q29, QReg::q15, 3), "sdot v30.4s, v29.16b, v15.4b[3]");
+
+  TEST_SINGLE(sdot(DReg::d30, DReg::d29, DReg::d28, 0), "sdot v30.2s, v29.8b, v28.4b[0]");
+  TEST_SINGLE(sdot(DReg::d30, DReg::d29, DReg::d28, 3), "sdot v30.2s, v29.8b, v28.4b[3]");
+
+  TEST_SINGLE(sdot(DReg::d30, DReg::d29, DReg::d15, 0), "sdot v30.2s, v29.8b, v15.4b[0]");
+  TEST_SINGLE(sdot(DReg::d30, DReg::d29, DReg::d15, 3), "sdot v30.2s, v29.8b, v15.4b[3]");
+
+  TEST_SINGLE(fmla(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q15, 0), "fmla v30.8h, v29.8h, v15.h[0]");
+  TEST_SINGLE(fmla(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q15, 7), "fmla v30.8h, v29.8h, v15.h[7]");
+
+  TEST_SINGLE(fmla(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d15, 0), "fmla v30.4h, v29.4h, v15.h[0]");
+  TEST_SINGLE(fmla(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d15, 7), "fmla v30.4h, v29.4h, v15.h[7]");
+
+  TEST_SINGLE(fmls(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q15, 0), "fmls v30.8h, v29.8h, v15.h[0]");
+  TEST_SINGLE(fmls(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q15, 7), "fmls v30.8h, v29.8h, v15.h[7]");
+
+  TEST_SINGLE(fmls(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d15, 0), "fmls v30.4h, v29.4h, v15.h[0]");
+  TEST_SINGLE(fmls(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d15, 7), "fmls v30.4h, v29.4h, v15.h[7]");
+
+  TEST_SINGLE(fmul(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q15, 0), "fmul v30.8h, v29.8h, v15.h[0]");
+  TEST_SINGLE(fmul(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q15, 7), "fmul v30.8h, v29.8h, v15.h[7]");
+
+  TEST_SINGLE(fmul(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d15, 0), "fmul v30.4h, v29.4h, v15.h[0]");
+  TEST_SINGLE(fmul(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d15, 7), "fmul v30.4h, v29.4h, v15.h[7]");
+
+  TEST_SINGLE(sudot(QReg::q30, QReg::q29, QReg::q28, 0), "sudot v30.4s, v29.16b, v28.4b[0]");
+  TEST_SINGLE(sudot(QReg::q30, QReg::q29, QReg::q28, 3), "sudot v30.4s, v29.16b, v28.4b[3]");
+
+  TEST_SINGLE(sudot(QReg::q30, QReg::q29, QReg::q15, 0), "sudot v30.4s, v29.16b, v15.4b[0]");
+  TEST_SINGLE(sudot(QReg::q30, QReg::q29, QReg::q15, 3), "sudot v30.4s, v29.16b, v15.4b[3]");
+
+  TEST_SINGLE(sudot(DReg::d30, DReg::d29, DReg::d28, 0), "sudot v30.2s, v29.8b, v28.4b[0]");
+  TEST_SINGLE(sudot(DReg::d30, DReg::d29, DReg::d28, 3), "sudot v30.2s, v29.8b, v28.4b[3]");
+
+  TEST_SINGLE(sudot(DReg::d30, DReg::d29, DReg::d15, 0), "sudot v30.2s, v29.8b, v15.4b[0]");
+  TEST_SINGLE(sudot(DReg::d30, DReg::d29, DReg::d15, 3), "sudot v30.2s, v29.8b, v15.4b[3]");
+
+  // Unimplemented in vixl disassembler
+  //TEST_SINGLE(bfdot(QReg::q30, QReg::q29, QReg::q28, 0), "bfdot v30.4s, v29.8h, v28.2h[0]");
+  //TEST_SINGLE(bfdot(QReg::q30, QReg::q29, QReg::q28, 3), "bfdot v30.4s, v29.8h, v28.2h[3]");
+
+  //TEST_SINGLE(bfdot(QReg::q30, QReg::q29, QReg::q15, 0), "bfdot v30.4s, v29.8h, v15.2h[0]");
+  //TEST_SINGLE(bfdot(QReg::q30, QReg::q29, QReg::q15, 3), "bfdot v30.4s, v29.8h, v15.2h[3]");
+
+  //TEST_SINGLE(bfdot(DReg::d30, DReg::d29, DReg::d28, 0), "bfdot v30.2s, v29.4h, v28.2h[0]");
+  //TEST_SINGLE(bfdot(DReg::d30, DReg::d29, DReg::d28, 3), "bfdot v30.2s, v29.4h, v28.2h[3]");
+
+  //TEST_SINGLE(bfdot(DReg::d30, DReg::d29, DReg::d15, 0), "bfdot v30.2s, v29.4h, v15.2h[0]");
+  //TEST_SINGLE(bfdot(DReg::d30, DReg::d29, DReg::d15, 3), "bfdot v30.2s, v29.4h, v15.2h[3]");
+
+  TEST_SINGLE(fmla(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q15, 0), "fmla v30.4s, v29.4s, v15.s[0]");
+  TEST_SINGLE(fmla(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q15, 3), "fmla v30.4s, v29.4s, v15.s[3]");
+
+  TEST_SINGLE(fmla(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d15, 0), "fmla v30.2s, v29.2s, v15.s[0]");
+  TEST_SINGLE(fmla(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d15, 3), "fmla v30.2s, v29.2s, v15.s[3]");
+
+  TEST_SINGLE(fmla(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q15, 0), "fmla v30.2d, v29.2d, v15.d[0]");
+  TEST_SINGLE(fmla(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q15, 1), "fmla v30.2d, v29.2d, v15.d[1]");
+
+  //TEST_SINGLE(fmla(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d15, 0), "fmla v30.1d, v29.1d, v15.d[0]");
+  //TEST_SINGLE(fmla(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d15, 1), "fmla v30.1d, v29.1d, v15.d[1]");
+
+  TEST_SINGLE(fmls(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q15, 0), "fmls v30.4s, v29.4s, v15.s[0]");
+  TEST_SINGLE(fmls(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q15, 3), "fmls v30.4s, v29.4s, v15.s[3]");
+
+  TEST_SINGLE(fmls(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d15, 0), "fmls v30.2s, v29.2s, v15.s[0]");
+  TEST_SINGLE(fmls(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d15, 3), "fmls v30.2s, v29.2s, v15.s[3]");
+
+  TEST_SINGLE(fmls(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q15, 0), "fmls v30.2d, v29.2d, v15.d[0]");
+  TEST_SINGLE(fmls(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q15, 1), "fmls v30.2d, v29.2d, v15.d[1]");
+
+  //TEST_SINGLE(fmls(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d15, 0), "fmls v30.1d, v29.1d, v15.d[0]");
+  //TEST_SINGLE(fmls(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d15, 1), "fmls v30.1d, v29.1d, v15.d[1]");
+
+  TEST_SINGLE(fmul(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q15, 0), "fmul v30.4s, v29.4s, v15.s[0]");
+  TEST_SINGLE(fmul(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q15, 3), "fmul v30.4s, v29.4s, v15.s[3]");
+
+  TEST_SINGLE(fmul(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d15, 0), "fmul v30.2s, v29.2s, v15.s[0]");
+  TEST_SINGLE(fmul(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d15, 3), "fmul v30.2s, v29.2s, v15.s[3]");
+
+  TEST_SINGLE(fmul(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q15, 0), "fmul v30.2d, v29.2d, v15.d[0]");
+  TEST_SINGLE(fmul(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q15, 1), "fmul v30.2d, v29.2d, v15.d[1]");
+
+  //TEST_SINGLE(fmul(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d15, 0), "fmul v30.1d, v29.1d, v15.d[0]");
+  //TEST_SINGLE(fmul(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d15, 1), "fmul v30.1d, v29.1d, v15.d[1]");
+
+  TEST_SINGLE(fmlal(QReg::q30, QReg::q29, QReg::q15, 0), "fmlal v30.4s, v29.4h, v15.h[0]");
+  TEST_SINGLE(fmlal(QReg::q30, QReg::q29, QReg::q15, 7), "fmlal v30.4s, v29.4h, v15.h[7]");
+
+  TEST_SINGLE(fmlal(DReg::d30, DReg::d29, DReg::d15, 0), "fmlal v30.2s, v29.2h, v15.h[0]");
+  TEST_SINGLE(fmlal(DReg::d30, DReg::d29, DReg::d15, 7), "fmlal v30.2s, v29.2h, v15.h[7]");
+
+  TEST_SINGLE(fmlal2(QReg::q30, QReg::q29, QReg::q15, 0), "fmlal2 v30.4s, v29.4h, v15.h[0]");
+  TEST_SINGLE(fmlal2(QReg::q30, QReg::q29, QReg::q15, 7), "fmlal2 v30.4s, v29.4h, v15.h[7]");
+
+  TEST_SINGLE(fmlal2(DReg::d30, DReg::d29, DReg::d15, 0), "fmlal2 v30.2s, v29.2h, v15.h[0]");
+  TEST_SINGLE(fmlal2(DReg::d30, DReg::d29, DReg::d15, 7), "fmlal2 v30.2s, v29.2h, v15.h[7]");
+
+  TEST_SINGLE(fmlsl(QReg::q30, QReg::q29, QReg::q15, 0), "fmlsl v30.4s, v29.4h, v15.h[0]");
+  TEST_SINGLE(fmlsl(QReg::q30, QReg::q29, QReg::q15, 7), "fmlsl v30.4s, v29.4h, v15.h[7]");
+
+  TEST_SINGLE(fmlsl(DReg::d30, DReg::d29, DReg::d15, 0), "fmlsl v30.2s, v29.2h, v15.h[0]");
+  TEST_SINGLE(fmlsl(DReg::d30, DReg::d29, DReg::d15, 7), "fmlsl v30.2s, v29.2h, v15.h[7]");
+
+  TEST_SINGLE(fmlsl2(QReg::q30, QReg::q29, QReg::q15, 0), "fmlsl2 v30.4s, v29.4h, v15.h[0]");
+  TEST_SINGLE(fmlsl2(QReg::q30, QReg::q29, QReg::q15, 7), "fmlsl2 v30.4s, v29.4h, v15.h[7]");
+
+  TEST_SINGLE(fmlsl2(DReg::d30, DReg::d29, DReg::d15, 0), "fmlsl2 v30.2s, v29.2h, v15.h[0]");
+  TEST_SINGLE(fmlsl2(DReg::d30, DReg::d29, DReg::d15, 7), "fmlsl2 v30.2s, v29.2h, v15.h[7]");
+
+  TEST_SINGLE(usdot(QReg::q30, QReg::q29, QReg::q28, 0), "usdot v30.4s, v29.16b, v28.4b[0]");
+  TEST_SINGLE(usdot(QReg::q30, QReg::q29, QReg::q28, 3), "usdot v30.4s, v29.16b, v28.4b[3]");
+
+  TEST_SINGLE(usdot(QReg::q30, QReg::q29, QReg::q15, 0), "usdot v30.4s, v29.16b, v15.4b[0]");
+  TEST_SINGLE(usdot(QReg::q30, QReg::q29, QReg::q15, 3), "usdot v30.4s, v29.16b, v15.4b[3]");
+
+  TEST_SINGLE(usdot(DReg::d30, DReg::d29, DReg::d28, 0), "usdot v30.2s, v29.8b, v28.4b[0]");
+  TEST_SINGLE(usdot(DReg::d30, DReg::d29, DReg::d28, 3), "usdot v30.2s, v29.8b, v28.4b[3]");
+
+  TEST_SINGLE(usdot(DReg::d30, DReg::d29, DReg::d15, 0), "usdot v30.2s, v29.8b, v15.4b[0]");
+  TEST_SINGLE(usdot(DReg::d30, DReg::d29, DReg::d15, 3), "usdot v30.2s, v29.8b, v15.4b[3]");
+
+  // Unimplemented in vixl disassembler
+  //TEST_SINGLE(bfmlalb(VReg::v30, VReg::v29, VReg::v15, 0), "bfmlalb v30.4s, v29.8h, v15.h[0]");
+  //TEST_SINGLE(bfmlalb(VReg::v30, VReg::v29, VReg::v15, 7), "bfmlalb v30.4s, v29.8h, v15.h[7]");
+
+  //TEST_SINGLE(bfmlalt(VReg::v30, VReg::v29, VReg::v15, 0), "bfmlalt v30.4s, v29.8h, v15.h[0]");
+  //TEST_SINGLE(bfmlalt(VReg::v30, VReg::v29, VReg::v15, 7), "bfmlalt v30.4s, v29.8h, v15.h[7]");
+
+  TEST_SINGLE(mla(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q15, 0), "mla v30.8h, v29.8h, v15.h[0]");
+  TEST_SINGLE(mla(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q15, 7), "mla v30.8h, v29.8h, v15.h[7]");
+
+  // vixl has a disassembler bug where it doesn't decode rm correctly for registers >= 16
+  //TEST_SINGLE(mla(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28, 0), "mla v30.4s, v29.4s, v28.s[0]");
+  //TEST_SINGLE(mla(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28, 3), "mla v30.4s, v29.4s, v28.s[3]");
+
+  TEST_SINGLE(mla(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q15, 0), "mla v30.4s, v29.4s, v15.s[0]");
+  TEST_SINGLE(mla(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q15, 3), "mla v30.4s, v29.4s, v15.s[3]");
+
+  TEST_SINGLE(mla(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d15, 0), "mla v30.4h, v29.4h, v15.h[0]");
+  TEST_SINGLE(mla(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d15, 7), "mla v30.4h, v29.4h, v15.h[7]");
+
+  // vixl has a disassembler bug where it doesn't decode rm correctly for registers >= 16
+  //TEST_SINGLE(mla(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28, 0), "mla v30.2s, v29.2s, v28.s[0]");
+  //TEST_SINGLE(mla(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28, 3), "mla v30.2s, v29.2s, v28.s[3]");
+
+  TEST_SINGLE(mla(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d15, 0), "mla v30.2s, v29.2s, v15.s[0]");
+  TEST_SINGLE(mla(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d15, 3), "mla v30.2s, v29.2s, v15.s[3]");
+
+  TEST_SINGLE(umlal(SubRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v15, 0), "umlal v30.4s, v29.4h, v15.h[0]");
+  TEST_SINGLE(umlal(SubRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v15, 7), "umlal v30.4s, v29.4h, v15.h[7]");
+
+  // vixl has a disassembler bug where it doesn't decode rm correctly for registers >= 16
+  //TEST_SINGLE(umlal(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28, 0), "umlal v30.2d, v29.2s, v28.s[0]");
+  //TEST_SINGLE(umlal(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28, 3), "umlal v30.2d, v29.2s, v28.s[3]");
+
+  TEST_SINGLE(umlal(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v15, 0), "umlal v30.2d, v29.2s, v15.s[0]");
+  TEST_SINGLE(umlal(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v15, 3), "umlal v30.2d, v29.2s, v15.s[3]");
+
+  TEST_SINGLE(umlal2(SubRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v15, 0), "umlal2 v30.4s, v29.8h, v15.h[0]");
+  TEST_SINGLE(umlal2(SubRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v15, 7), "umlal2 v30.4s, v29.8h, v15.h[7]");
+
+  // vixl has a disassembler bug where it doesn't decode rm correctly for registers >= 16
+  //TEST_SINGLE(umlal2(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28, 0), "umlal2 v30.2d, v29.4s, v28.s[0]");
+  //TEST_SINGLE(umlal2(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28, 3), "umlal2 v30.2d, v29.4s, v28.s[3]");
+
+  TEST_SINGLE(umlal2(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v15, 0), "umlal2 v30.2d, v29.4s, v15.s[0]");
+  TEST_SINGLE(umlal2(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v15, 3), "umlal2 v30.2d, v29.4s, v15.s[3]");
+
+  TEST_SINGLE(mls(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q15, 0), "mls v30.8h, v29.8h, v15.h[0]");
+  TEST_SINGLE(mls(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q15, 7), "mls v30.8h, v29.8h, v15.h[7]");
+
+  // vixl has a disassembler bug where it doesn't decode rm correctly for registers >= 16
+  //TEST_SINGLE(mls(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28, 0), "mls v30.4s, v29.4s, v28.s[0]");
+  //TEST_SINGLE(mls(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28, 3), "mls v30.4s, v29.4s, v28.s[3]");
+
+  TEST_SINGLE(mls(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q15, 0), "mls v30.4s, v29.4s, v15.s[0]");
+  TEST_SINGLE(mls(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q15, 3), "mls v30.4s, v29.4s, v15.s[3]");
+
+  TEST_SINGLE(mls(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d15, 0), "mls v30.4h, v29.4h, v15.h[0]");
+  TEST_SINGLE(mls(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d15, 7), "mls v30.4h, v29.4h, v15.h[7]");
+
+  // vixl has a disassembler bug where it doesn't decode rm correctly for registers >= 16
+  //TEST_SINGLE(mls(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28, 0), "mls v30.2s, v29.2s, v28.s[0]");
+  //TEST_SINGLE(mls(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28, 3), "mls v30.2s, v29.2s, v28.s[3]");
+
+  TEST_SINGLE(mls(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d15, 0), "mls v30.2s, v29.2s, v15.s[0]");
+  TEST_SINGLE(mls(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d15, 3), "mls v30.2s, v29.2s, v15.s[3]");
+
+  TEST_SINGLE(umlsl(SubRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v15, 0), "umlsl v30.4s, v29.4h, v15.h[0]");
+  TEST_SINGLE(umlsl(SubRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v15, 7), "umlsl v30.4s, v29.4h, v15.h[7]");
+
+  // vixl has a disassembler bug where it doesn't decode rm correctly for registers >= 16
+  //TEST_SINGLE(umlsl(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28, 0), "umlsl v30.2d, v29.2s, v28.s[0]");
+  //TEST_SINGLE(umlsl(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28, 3), "umlsl v30.2d, v29.2s, v28.s[3]");
+
+  TEST_SINGLE(umlsl(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v15, 0), "umlsl v30.2d, v29.2s, v15.s[0]");
+  TEST_SINGLE(umlsl(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v15, 3), "umlsl v30.2d, v29.2s, v15.s[3]");
+
+  TEST_SINGLE(umlsl2(SubRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v15, 0), "umlsl2 v30.4s, v29.8h, v15.h[0]");
+  TEST_SINGLE(umlsl2(SubRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v15, 7), "umlsl2 v30.4s, v29.8h, v15.h[7]");
+
+  // vixl has a disassembler bug where it doesn't decode rm correctly for registers >= 16
+  //TEST_SINGLE(umlsl2(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28, 0), "umlsl2 v30.2d, v29.4s, v28.s[0]");
+  //TEST_SINGLE(umlsl2(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28, 3), "umlsl2 v30.2d, v29.4s, v28.s[3]");
+
+  TEST_SINGLE(umlsl2(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v15, 0), "umlsl2 v30.2d, v29.4s, v15.s[0]");
+  TEST_SINGLE(umlsl2(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v15, 3), "umlsl2 v30.2d, v29.4s, v15.s[3]");
+
+  TEST_SINGLE(umull(SubRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v15, 0), "umull v30.4s, v29.4h, v15.h[0]");
+  TEST_SINGLE(umull(SubRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v15, 7), "umull v30.4s, v29.4h, v15.h[7]");
+
+  // vixl has a disassembler bug where it doesn't decode rm correctly for registers >= 16
+  //TEST_SINGLE(umull(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28, 0), "umull v30.2d, v29.2s, v28.s[0]");
+  //TEST_SINGLE(umull(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28, 3), "umull v30.2d, v29.2s, v28.s[3]");
+
+  TEST_SINGLE(umull(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v15, 0), "umull v30.2d, v29.2s, v15.s[0]");
+  TEST_SINGLE(umull(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v15, 3), "umull v30.2d, v29.2s, v15.s[3]");
+
+  TEST_SINGLE(umull2(SubRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v15, 0), "umull2 v30.4s, v29.8h, v15.h[0]");
+  TEST_SINGLE(umull2(SubRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v15, 7), "umull2 v30.4s, v29.8h, v15.h[7]");
+
+  // vixl has a disassembler bug where it doesn't decode rm correctly for registers >= 16
+  //TEST_SINGLE(umull2(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28, 0), "umull2 v30.2d, v29.4s, v28.s[0]");
+  //TEST_SINGLE(umull2(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28, 3), "umull2 v30.2d, v29.4s, v28.s[3]");
+
+  TEST_SINGLE(umull2(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v15, 0), "umull2 v30.2d, v29.4s, v15.s[0]");
+  TEST_SINGLE(umull2(SubRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v15, 3), "umull2 v30.2d, v29.4s, v15.s[3]");
+
+  TEST_SINGLE(sqrdmlah(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q15, 0), "sqrdmlah v30.8h, v29.8h, v15.h[0]");
+  TEST_SINGLE(sqrdmlah(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q15, 7), "sqrdmlah v30.8h, v29.8h, v15.h[7]");
+
+  // vixl has a disassembler bug where it doesn't decode rm correctly for registers >= 16
+  //TEST_SINGLE(sqrdmlah(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28, 0), "sqrdmlah v30.4s, v29.4s, v28.s[0]");
+  //TEST_SINGLE(sqrdmlah(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28, 3), "sqrdmlah v30.4s, v29.4s, v28.s[3]");
+
+  TEST_SINGLE(sqrdmlah(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q15, 0), "sqrdmlah v30.4s, v29.4s, v15.s[0]");
+  TEST_SINGLE(sqrdmlah(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q15, 3), "sqrdmlah v30.4s, v29.4s, v15.s[3]");
+
+  TEST_SINGLE(sqrdmlah(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d15, 0), "sqrdmlah v30.4h, v29.4h, v15.h[0]");
+  TEST_SINGLE(sqrdmlah(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d15, 7), "sqrdmlah v30.4h, v29.4h, v15.h[7]");
+
+  // vixl has a disassembler bug where it doesn't decode rm correctly for registers >= 16
+  //TEST_SINGLE(sqrdmlah(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28, 0), "sqrdmlah v30.2s, v29.2s, v28.s[0]");
+  //TEST_SINGLE(sqrdmlah(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28, 3), "sqrdmlah v30.2s, v29.2s, v28.s[3]");
+
+  TEST_SINGLE(sqrdmlah(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d15, 0), "sqrdmlah v30.2s, v29.2s, v15.s[0]");
+  TEST_SINGLE(sqrdmlah(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d15, 3), "sqrdmlah v30.2s, v29.2s, v15.s[3]");
+
+  TEST_SINGLE(udot(QReg::q30, QReg::q29, QReg::q28, 0), "udot v30.4s, v29.16b, v28.4b[0]");
+  TEST_SINGLE(udot(QReg::q30, QReg::q29, QReg::q28, 3), "udot v30.4s, v29.16b, v28.4b[3]");
+
+  TEST_SINGLE(udot(QReg::q30, QReg::q29, QReg::q15, 0), "udot v30.4s, v29.16b, v15.4b[0]");
+  TEST_SINGLE(udot(QReg::q30, QReg::q29, QReg::q15, 3), "udot v30.4s, v29.16b, v15.4b[3]");
+
+  TEST_SINGLE(udot(DReg::d30, DReg::d29, DReg::d28, 0), "udot v30.2s, v29.8b, v28.4b[0]");
+  TEST_SINGLE(udot(DReg::d30, DReg::d29, DReg::d28, 3), "udot v30.2s, v29.8b, v28.4b[3]");
+
+  TEST_SINGLE(udot(DReg::d30, DReg::d29, DReg::d15, 0), "udot v30.2s, v29.8b, v15.4b[0]");
+  TEST_SINGLE(udot(DReg::d30, DReg::d29, DReg::d15, 3), "udot v30.2s, v29.8b, v15.4b[3]");
+
+  TEST_SINGLE(sqrdmlsh(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q15, 0), "sqrdmlsh v30.8h, v29.8h, v15.h[0]");
+  TEST_SINGLE(sqrdmlsh(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q15, 7), "sqrdmlsh v30.8h, v29.8h, v15.h[7]");
+
+  // vixl has a disassembler bug where it doesn't decode rm correctly for registers >= 16
+  //TEST_SINGLE(sqrdmlsh(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28, 0), "sqrdmlsh v30.4s, v29.4s, v28.s[0]");
+  //TEST_SINGLE(sqrdmlsh(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28, 3), "sqrdmlsh v30.4s, v29.4s, v28.s[3]");
+
+  TEST_SINGLE(sqrdmlsh(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q15, 0), "sqrdmlsh v30.4s, v29.4s, v15.s[0]");
+  TEST_SINGLE(sqrdmlsh(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q15, 3), "sqrdmlsh v30.4s, v29.4s, v15.s[3]");
+
+  TEST_SINGLE(sqrdmlsh(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d15, 0), "sqrdmlsh v30.4h, v29.4h, v15.h[0]");
+  TEST_SINGLE(sqrdmlsh(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d15, 7), "sqrdmlsh v30.4h, v29.4h, v15.h[7]");
+
+  // vixl has a disassembler bug where it doesn't decode rm correctly for registers >= 16
+  //TEST_SINGLE(sqrdmlsh(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28, 0), "sqrdmlsh v30.2s, v29.2s, v28.s[0]");
+  //TEST_SINGLE(sqrdmlsh(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28, 3), "sqrdmlsh v30.2s, v29.2s, v28.s[3]");
+
+  TEST_SINGLE(sqrdmlsh(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d15, 0), "sqrdmlsh v30.2s, v29.2s, v15.s[0]");
+  TEST_SINGLE(sqrdmlsh(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d15, 3), "sqrdmlsh v30.2s, v29.2s, v15.s[3]");
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Cryptographic three-register, imm2") {
   // TODO: Implement in emitter.
@@ -2698,7 +3162,61 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Cryptographic two-register S
   // TODO: Implement in emitter.
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Conversion between floating-point and fixed-point") {
-  // TODO: Implement in emitter.
+  TEST_SINGLE(scvtf(ScalarRegSize::i16Bit, VReg::v29, Size::i32Bit, Reg::r30, 1),  "scvtf h29, w30, #1");
+  TEST_SINGLE(scvtf(ScalarRegSize::i16Bit, VReg::v29, Size::i32Bit, Reg::r30, 32), "scvtf h29, w30, #32");
+  TEST_SINGLE(scvtf(ScalarRegSize::i32Bit, VReg::v29, Size::i32Bit, Reg::r30, 1),  "scvtf s29, w30, #1");
+  TEST_SINGLE(scvtf(ScalarRegSize::i32Bit, VReg::v29, Size::i32Bit, Reg::r30, 32), "scvtf s29, w30, #32");
+  TEST_SINGLE(scvtf(ScalarRegSize::i64Bit, VReg::v29, Size::i32Bit, Reg::r30, 1),  "scvtf d29, w30, #1");
+  TEST_SINGLE(scvtf(ScalarRegSize::i64Bit, VReg::v29, Size::i32Bit, Reg::r30, 32), "scvtf d29, w30, #32");
+
+  TEST_SINGLE(scvtf(ScalarRegSize::i16Bit, VReg::v29, Size::i64Bit, Reg::r30, 1),  "scvtf h29, x30, #1");
+  TEST_SINGLE(scvtf(ScalarRegSize::i16Bit, VReg::v29, Size::i64Bit, Reg::r30, 64), "scvtf h29, x30, #64");
+  TEST_SINGLE(scvtf(ScalarRegSize::i32Bit, VReg::v29, Size::i64Bit, Reg::r30, 1),  "scvtf s29, x30, #1");
+  TEST_SINGLE(scvtf(ScalarRegSize::i32Bit, VReg::v29, Size::i64Bit, Reg::r30, 64), "scvtf s29, x30, #64");
+  TEST_SINGLE(scvtf(ScalarRegSize::i64Bit, VReg::v29, Size::i64Bit, Reg::r30, 1),  "scvtf d29, x30, #1");
+  TEST_SINGLE(scvtf(ScalarRegSize::i64Bit, VReg::v29, Size::i64Bit, Reg::r30, 64), "scvtf d29, x30, #64");
+
+  TEST_SINGLE(ucvtf(ScalarRegSize::i16Bit, VReg::v29, Size::i32Bit, Reg::r30, 1),  "ucvtf h29, w30, #1");
+  TEST_SINGLE(ucvtf(ScalarRegSize::i16Bit, VReg::v29, Size::i32Bit, Reg::r30, 32), "ucvtf h29, w30, #32");
+  TEST_SINGLE(ucvtf(ScalarRegSize::i32Bit, VReg::v29, Size::i32Bit, Reg::r30, 1),  "ucvtf s29, w30, #1");
+  TEST_SINGLE(ucvtf(ScalarRegSize::i32Bit, VReg::v29, Size::i32Bit, Reg::r30, 32), "ucvtf s29, w30, #32");
+  TEST_SINGLE(ucvtf(ScalarRegSize::i64Bit, VReg::v29, Size::i32Bit, Reg::r30, 1),  "ucvtf d29, w30, #1");
+  TEST_SINGLE(ucvtf(ScalarRegSize::i64Bit, VReg::v29, Size::i32Bit, Reg::r30, 32), "ucvtf d29, w30, #32");
+
+  TEST_SINGLE(ucvtf(ScalarRegSize::i16Bit, VReg::v29, Size::i64Bit, Reg::r30, 1),  "ucvtf h29, x30, #1");
+  TEST_SINGLE(ucvtf(ScalarRegSize::i16Bit, VReg::v29, Size::i64Bit, Reg::r30, 64), "ucvtf h29, x30, #64");
+  TEST_SINGLE(ucvtf(ScalarRegSize::i32Bit, VReg::v29, Size::i64Bit, Reg::r30, 1),  "ucvtf s29, x30, #1");
+  TEST_SINGLE(ucvtf(ScalarRegSize::i32Bit, VReg::v29, Size::i64Bit, Reg::r30, 64), "ucvtf s29, x30, #64");
+  TEST_SINGLE(ucvtf(ScalarRegSize::i64Bit, VReg::v29, Size::i64Bit, Reg::r30, 1),  "ucvtf d29, x30, #1");
+  TEST_SINGLE(ucvtf(ScalarRegSize::i64Bit, VReg::v29, Size::i64Bit, Reg::r30, 64), "ucvtf d29, x30, #64");
+
+  TEST_SINGLE(fcvtzs(Size::i32Bit, Reg::r30, ScalarRegSize::i16Bit, VReg::v29, 1),  "fcvtzs w30, h29, #1");
+  TEST_SINGLE(fcvtzs(Size::i32Bit, Reg::r30, ScalarRegSize::i16Bit, VReg::v29, 32), "fcvtzs w30, h29, #32");
+  TEST_SINGLE(fcvtzs(Size::i32Bit, Reg::r30, ScalarRegSize::i32Bit, VReg::v29, 1),  "fcvtzs w30, s29, #1");
+  TEST_SINGLE(fcvtzs(Size::i32Bit, Reg::r30, ScalarRegSize::i32Bit, VReg::v29, 32), "fcvtzs w30, s29, #32");
+  TEST_SINGLE(fcvtzs(Size::i32Bit, Reg::r30, ScalarRegSize::i64Bit, VReg::v29, 1),  "fcvtzs w30, d29, #1");
+  TEST_SINGLE(fcvtzs(Size::i32Bit, Reg::r30, ScalarRegSize::i64Bit, VReg::v29, 32), "fcvtzs w30, d29, #32");
+
+  TEST_SINGLE(fcvtzs(Size::i64Bit, Reg::r30, ScalarRegSize::i16Bit, VReg::v29, 1),  "fcvtzs x30, h29, #1");
+  TEST_SINGLE(fcvtzs(Size::i64Bit, Reg::r30, ScalarRegSize::i16Bit, VReg::v29, 64), "fcvtzs x30, h29, #64");
+  TEST_SINGLE(fcvtzs(Size::i64Bit, Reg::r30, ScalarRegSize::i32Bit, VReg::v29, 1),  "fcvtzs x30, s29, #1");
+  TEST_SINGLE(fcvtzs(Size::i64Bit, Reg::r30, ScalarRegSize::i32Bit, VReg::v29, 64), "fcvtzs x30, s29, #64");
+  TEST_SINGLE(fcvtzs(Size::i64Bit, Reg::r30, ScalarRegSize::i64Bit, VReg::v29, 1),  "fcvtzs x30, d29, #1");
+  TEST_SINGLE(fcvtzs(Size::i64Bit, Reg::r30, ScalarRegSize::i64Bit, VReg::v29, 64), "fcvtzs x30, d29, #64");
+
+  TEST_SINGLE(fcvtzu(Size::i32Bit, Reg::r30, ScalarRegSize::i16Bit, VReg::v29, 1),  "fcvtzu w30, h29, #1");
+  TEST_SINGLE(fcvtzu(Size::i32Bit, Reg::r30, ScalarRegSize::i16Bit, VReg::v29, 32), "fcvtzu w30, h29, #32");
+  TEST_SINGLE(fcvtzu(Size::i32Bit, Reg::r30, ScalarRegSize::i32Bit, VReg::v29, 1),  "fcvtzu w30, s29, #1");
+  TEST_SINGLE(fcvtzu(Size::i32Bit, Reg::r30, ScalarRegSize::i32Bit, VReg::v29, 32), "fcvtzu w30, s29, #32");
+  TEST_SINGLE(fcvtzu(Size::i32Bit, Reg::r30, ScalarRegSize::i64Bit, VReg::v29, 1),  "fcvtzu w30, d29, #1");
+  TEST_SINGLE(fcvtzu(Size::i32Bit, Reg::r30, ScalarRegSize::i64Bit, VReg::v29, 32), "fcvtzu w30, d29, #32");
+
+  TEST_SINGLE(fcvtzu(Size::i64Bit, Reg::r30, ScalarRegSize::i16Bit, VReg::v29, 1),  "fcvtzu x30, h29, #1");
+  TEST_SINGLE(fcvtzu(Size::i64Bit, Reg::r30, ScalarRegSize::i16Bit, VReg::v29, 64), "fcvtzu x30, h29, #64");
+  TEST_SINGLE(fcvtzu(Size::i64Bit, Reg::r30, ScalarRegSize::i32Bit, VReg::v29, 1),  "fcvtzu x30, s29, #1");
+  TEST_SINGLE(fcvtzu(Size::i64Bit, Reg::r30, ScalarRegSize::i32Bit, VReg::v29, 64), "fcvtzu x30, s29, #64");
+  TEST_SINGLE(fcvtzu(Size::i64Bit, Reg::r30, ScalarRegSize::i64Bit, VReg::v29, 1),  "fcvtzu x30, d29, #1");
+  TEST_SINGLE(fcvtzu(Size::i64Bit, Reg::r30, ScalarRegSize::i64Bit, VReg::v29, 64), "fcvtzu x30, d29, #64");
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Conversion between floating-point and integer") {
   TEST_SINGLE(fcvtns(Size::i32Bit, Reg::r29, HReg::h30), "fcvtns w29, h30");

--- a/External/FEXCore/unittests/Emitter/ASIMD_Tests.cpp
+++ b/External/FEXCore/unittests/Emitter/ASIMD_Tests.cpp
@@ -2265,7 +2265,41 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD shift by immed
   TEST_SINGLE(sxtl2(SubRegSize::i32Bit, DReg::d30, DReg::d29),  "sxtl2 v30.4s, v29.8h");
   TEST_SINGLE(sxtl2(SubRegSize::i64Bit, DReg::d30, DReg::d29),  "sxtl2 v30.2d, v29.4s");
 
-  //// TODO: SCVTF, FCVTZS
+  //TEST_SINGLE(scvtf(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "scvtf v30.16b, v29.16b, #1");
+  //TEST_SINGLE(scvtf(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "scvtf v30.16b, v29.16b, #7");
+  TEST_SINGLE(scvtf(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "scvtf v30.8h, v29.8h, #1");
+  TEST_SINGLE(scvtf(SubRegSize::i16Bit, QReg::q30, QReg::q29, 15), "scvtf v30.8h, v29.8h, #15");
+  TEST_SINGLE(scvtf(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "scvtf v30.4s, v29.4s, #1");
+  TEST_SINGLE(scvtf(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "scvtf v30.4s, v29.4s, #31");
+  TEST_SINGLE(scvtf(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "scvtf v30.2d, v29.2d, #1");
+  TEST_SINGLE(scvtf(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "scvtf v30.2d, v29.2d, #63");
+
+  //TEST_SINGLE(scvtf(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "scvtf v30.8b, v29.8b, #1");
+  //TEST_SINGLE(scvtf(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "scvtf v30.8b, v29.8b, #7");
+  TEST_SINGLE(scvtf(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "scvtf v30.4h, v29.4h, #1");
+  TEST_SINGLE(scvtf(SubRegSize::i16Bit, DReg::d30, DReg::d29, 15), "scvtf v30.4h, v29.4h, #15");
+  TEST_SINGLE(scvtf(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "scvtf v30.2s, v29.2s, #1");
+  TEST_SINGLE(scvtf(SubRegSize::i32Bit, DReg::d30, DReg::d29, 31), "scvtf v30.2s, v29.2s, #31");
+  //TEST_SINGLE(scvtf(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "scvtf v30.1d, v29.1d, #1");
+  //TEST_SINGLE(scvtf(SubRegSize::i64Bit, DReg::d30, DReg::d29, 63), "scvtf v30.1d, v29.1d, #63");
+
+  //TEST_SINGLE(fcvtzs(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "fcvtzs v30.16b, v29.16b, #1");
+  //TEST_SINGLE(fcvtzs(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "fcvtzs v30.16b, v29.16b, #7");
+  TEST_SINGLE(fcvtzs(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "fcvtzs v30.8h, v29.8h, #1");
+  TEST_SINGLE(fcvtzs(SubRegSize::i16Bit, QReg::q30, QReg::q29, 15), "fcvtzs v30.8h, v29.8h, #15");
+  TEST_SINGLE(fcvtzs(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "fcvtzs v30.4s, v29.4s, #1");
+  TEST_SINGLE(fcvtzs(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "fcvtzs v30.4s, v29.4s, #31");
+  TEST_SINGLE(fcvtzs(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "fcvtzs v30.2d, v29.2d, #1");
+  TEST_SINGLE(fcvtzs(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "fcvtzs v30.2d, v29.2d, #63");
+
+  //TEST_SINGLE(fcvtzs(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "fcvtzs v30.8b, v29.8b, #1");
+  //TEST_SINGLE(fcvtzs(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "fcvtzs v30.8b, v29.8b, #7");
+  TEST_SINGLE(fcvtzs(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "fcvtzs v30.4h, v29.4h, #1");
+  TEST_SINGLE(fcvtzs(SubRegSize::i16Bit, DReg::d30, DReg::d29, 15), "fcvtzs v30.4h, v29.4h, #15");
+  TEST_SINGLE(fcvtzs(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "fcvtzs v30.2s, v29.2s, #1");
+  TEST_SINGLE(fcvtzs(SubRegSize::i32Bit, DReg::d30, DReg::d29, 31), "fcvtzs v30.2s, v29.2s, #31");
+  //TEST_SINGLE(fcvtzs(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "fcvtzs v30.1d, v29.1d, #1");
+  //TEST_SINGLE(fcvtzs(SubRegSize::i64Bit, DReg::d30, DReg::d29, 63), "fcvtzs v30.1d, v29.1d, #63");
 
   TEST_SINGLE(ushr(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "ushr v30.16b, v29.16b, #1");
   TEST_SINGLE(ushr(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "ushr v30.16b, v29.16b, #7");
@@ -2611,7 +2645,41 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD shift by immed
   TEST_SINGLE(uxtl2(SubRegSize::i32Bit, DReg::d30, DReg::d29),  "uxtl2 v30.4s, v29.8h");
   TEST_SINGLE(uxtl2(SubRegSize::i64Bit, DReg::d30, DReg::d29),  "uxtl2 v30.2d, v29.4s");
 
-  //// XXX: UCVTF/FCVTZU
+  //TEST_SINGLE(ucvtf(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "ucvtf v30.16b, v29.16b, #1");
+  //TEST_SINGLE(ucvtf(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "ucvtf v30.16b, v29.16b, #7");
+  TEST_SINGLE(ucvtf(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "ucvtf v30.8h, v29.8h, #1");
+  TEST_SINGLE(ucvtf(SubRegSize::i16Bit, QReg::q30, QReg::q29, 15), "ucvtf v30.8h, v29.8h, #15");
+  TEST_SINGLE(ucvtf(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "ucvtf v30.4s, v29.4s, #1");
+  TEST_SINGLE(ucvtf(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "ucvtf v30.4s, v29.4s, #31");
+  TEST_SINGLE(ucvtf(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "ucvtf v30.2d, v29.2d, #1");
+  TEST_SINGLE(ucvtf(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "ucvtf v30.2d, v29.2d, #63");
+
+  //TEST_SINGLE(ucvtf(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "ucvtf v30.8b, v29.8b, #1");
+  //TEST_SINGLE(ucvtf(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "ucvtf v30.8b, v29.8b, #7");
+  TEST_SINGLE(ucvtf(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "ucvtf v30.4h, v29.4h, #1");
+  TEST_SINGLE(ucvtf(SubRegSize::i16Bit, DReg::d30, DReg::d29, 15), "ucvtf v30.4h, v29.4h, #15");
+  TEST_SINGLE(ucvtf(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "ucvtf v30.2s, v29.2s, #1");
+  TEST_SINGLE(ucvtf(SubRegSize::i32Bit, DReg::d30, DReg::d29, 31), "ucvtf v30.2s, v29.2s, #31");
+  //TEST_SINGLE(ucvtf(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "ucvtf v30.1d, v29.1d, #1");
+  //TEST_SINGLE(ucvtf(SubRegSize::i64Bit, DReg::d30, DReg::d29, 63), "ucvtf v30.1d, v29.1d, #63");
+
+  //TEST_SINGLE(fcvtzu(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "fcvtzu v30.16b, v29.16b, #1");
+  //TEST_SINGLE(fcvtzu(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "fcvtzu v30.16b, v29.16b, #7");
+  TEST_SINGLE(fcvtzu(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "fcvtzu v30.8h, v29.8h, #1");
+  TEST_SINGLE(fcvtzu(SubRegSize::i16Bit, QReg::q30, QReg::q29, 15), "fcvtzu v30.8h, v29.8h, #15");
+  TEST_SINGLE(fcvtzu(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "fcvtzu v30.4s, v29.4s, #1");
+  TEST_SINGLE(fcvtzu(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "fcvtzu v30.4s, v29.4s, #31");
+  TEST_SINGLE(fcvtzu(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "fcvtzu v30.2d, v29.2d, #1");
+  TEST_SINGLE(fcvtzu(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "fcvtzu v30.2d, v29.2d, #63");
+
+  //TEST_SINGLE(fcvtzu(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "fcvtzu v30.8b, v29.8b, #1");
+  //TEST_SINGLE(fcvtzu(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "fcvtzu v30.8b, v29.8b, #7");
+  TEST_SINGLE(fcvtzu(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "fcvtzu v30.4h, v29.4h, #1");
+  TEST_SINGLE(fcvtzu(SubRegSize::i16Bit, DReg::d30, DReg::d29, 15), "fcvtzu v30.4h, v29.4h, #15");
+  TEST_SINGLE(fcvtzu(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "fcvtzu v30.2s, v29.2s, #1");
+  TEST_SINGLE(fcvtzu(SubRegSize::i32Bit, DReg::d30, DReg::d29, 31), "fcvtzu v30.2s, v29.2s, #31");
+  //TEST_SINGLE(fcvtzu(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "fcvtzu v30.1d, v29.1d, #1");
+  //TEST_SINGLE(fcvtzu(SubRegSize::i64Bit, DReg::d30, DReg::d29, 63), "fcvtzu v30.1d, v29.1d, #63");
 }
 
 TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD vector x indexed element") {


### PR DESCRIPTION
Also adds four missing shift by imm instructions.

Only missing four ASIMD instruction classes now.
- 3Reg SM3 crypto
- 3Reg SHA512/SHA3/SM3
- 4Reg SHA3/SM3
- 2Reg SHA512/SM4

Also some misc instructions