### PR TITLE
FEXCore: Fixup 32-bit signal handling 

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
@@ -321,6 +321,14 @@ void Arm64Dispatcher::EmitDispatcher() {
   }
 
   {
+    SignalHandlerReturnAddressRT = GetCursorAddress<uint64_t>();
+
+    // Now to get back to our old location we need to do a fault dance
+    // We can't use SIGTRAP here since gdb catches it and never gives it to the application!
+    hlt(0);
+  }
+
+  {
     // Guest SIGILL handler
     // Needs to be distinct from the SignalHandlerReturnAddress
     GuestSignal_SIGILL = GetCursorAddress<uint64_t>();
@@ -654,6 +662,7 @@ void Arm64Dispatcher::InitThreadPointers(FEXCore::Core::InternalThreadState *Thr
     Common.GuestSignal_SIGTRAP = GuestSignal_SIGTRAP;
     Common.GuestSignal_SIGSEGV = GuestSignal_SIGSEGV;
     Common.SignalReturnHandler = SignalHandlerReturnAddress;
+    Common.SignalReturnHandlerRT = SignalHandlerReturnAddressRT;
 
     auto &AArch64 = Thread->CurrentFrame->Pointers.AArch64;
     AArch64.LUDIVHandler = LUDIVHandlerAddress;

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/X86Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/X86Dispatcher.cpp
@@ -345,6 +345,12 @@ X86Dispatcher::X86Dispatcher(FEXCore::Context::Context *ctx, const DispatcherCon
   }
 
   {
+    // RT Signal return handler
+    SignalHandlerReturnAddressRT = getCurr<uint64_t>();
+    ud2();
+  }
+
+  {
     // Guest SIGILL handler
     // Needs to be distinct from the SignalHandlerReturnAddress
     GuestSignal_SIGILL = getCurr<uint64_t>();
@@ -486,6 +492,7 @@ void X86Dispatcher::InitThreadPointers(FEXCore::Core::InternalThreadState *Threa
     Common.GuestSignal_SIGTRAP = GuestSignal_SIGTRAP;
     Common.GuestSignal_SIGSEGV = GuestSignal_SIGSEGV;
     Common.SignalReturnHandler = SignalHandlerReturnAddress;
+    Common.SignalReturnHandlerRT = SignalHandlerReturnAddressRT;
 
     auto &Interpreter = Thread->CurrentFrame->Pointers.Interpreter;
     (uintptr_t&)Interpreter.CallbackReturn = IntCallbackReturnAddress;

--- a/External/FEXCore/Source/Interface/Core/Interpreter/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/BranchOps.cpp
@@ -18,8 +18,8 @@ $end_info$
 
 namespace FEXCore::CPU {
 [[noreturn]]
-static void SignalReturn(FEXCore::Core::InternalThreadState *Thread) {
-  Thread->CTX->SignalThread(Thread, FEXCore::Core::SignalEvent::Return);
+static void SignalReturn(FEXCore::Core::InternalThreadState *Thread, bool RT) {
+  Thread->CTX->SignalThread(Thread, RT ? FEXCore::Core::SignalEvent::ReturnRT : FEXCore::Core::SignalEvent::Return);
 
   LOGMAN_MSG_A_FMT("unreachable");
   FEX_UNREACHABLE;
@@ -28,7 +28,9 @@ static void SignalReturn(FEXCore::Core::InternalThreadState *Thread) {
 #define DEF_OP(x) void InterpreterOps::Op_##x(IR::IROp_Header *IROp, IROpData *Data, IR::NodeID Node)
 
 DEF_OP(SignalReturn) {
-  SignalReturn(Data->State);
+  auto Op = IROp->C<IR::IROp_SignalReturn>();
+
+  SignalReturn(Data->State, Op->IsRT);
 }
 
 DEF_OP(CallbackReturn) {

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
@@ -21,12 +21,19 @@ namespace FEXCore::CPU {
 #define DEF_OP(x) void Arm64JITCore::Op_##x(IR::IROp_Header const *IROp, IR::NodeID Node)
 
 DEF_OP(SignalReturn) {
+  auto Op = IROp->C<IR::IROp_SignalReturn>();
+
   // First we must reset the stack
   ResetStack();
 
   // Now branch to our signal return helper
   // This can't be a direct branch since the code needs to live at a constant location
-  ldr(ARMEmitter::XReg::x0, STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.SignalReturnHandler));
+  if (Op->IsRT) {
+    ldr(ARMEmitter::XReg::x0, STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.SignalReturnHandlerRT));
+  }
+  else {
+    ldr(ARMEmitter::XReg::x0, STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.SignalReturnHandler));
+  }
   br(ARMEmitter::Reg::r0);
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
@@ -31,12 +31,19 @@ namespace FEXCore::CPU {
 #define DEF_OP(x) void X86JITCore::Op_##x(IR::IROp_Header *IROp, IR::NodeID Node)
 
 DEF_OP(SignalReturn) {
+  auto Op = IROp->C<IR::IROp_SignalReturn>();
+
   // Adjust the stack first for a regular return
   if (SpillSlots) {
     add(rsp, SpillSlots * MaxSpillSlotSize); // + 8 to consume return address
   }
 
-  jmp(qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.SignalReturnHandler)]);
+  if (Op->IsRT) {
+    jmp(qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.SignalReturnHandlerRT)]);
+  }
+  else {
+    jmp(qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.SignalReturnHandler)]);
+  }
 }
 
 DEF_OP(CallbackReturn) {

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -278,9 +278,11 @@ void OpDispatchBuilder::IRETOp(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::SIGRETOp(OpcodeArgs) {
+  uint8_t Literal = Op->Src[0].Data.Literal.Value;
   const uint8_t GPRSize = CTX->GetGPRSize();
   // Store the new RIP
-  _SignalReturn();
+  bool IsRT = CTX->Config.Is64BitMode() || Literal;
+  _SignalReturn(IsRT);
   auto NewRIP = _LoadContext(GPRSize, GPRClass, offsetof(FEXCore::Core::CPUState, rip));
   // This ExitFunction won't actually get hit but needs to exist
   _ExitFunction(NewRIP);

--- a/External/FEXCore/Source/Interface/Core/X86HelperGen.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86HelperGen.cpp
@@ -24,10 +24,12 @@ X86GeneratedCode::X86GeneratedCode() {
   CodePtr = AllocateGuestCodeSpace(CODE_SIZE);
 
   SignalReturn = reinterpret_cast<uint64_t>(CodePtr);
-  CallbackReturn = reinterpret_cast<uint64_t>(CodePtr) + 2;
+  SignalReturnRT = reinterpret_cast<uint64_t>(CodePtr) + 3;
+  CallbackReturn = reinterpret_cast<uint64_t>(CodePtr) + 6;
 
   const std::vector<uint8_t> SignalReturnCode = {
-    0x0F, 0x36, // SIGRET FEX instruction
+    0x0F, 0x36, 0x0, // SIGRET FEX instruction (Non-RT)
+    0x0F, 0x36, 0x1, // SIGRET FEX instruction (RT)
     0x0F, 0x37, // CALLBACKRET FEX Instruction
   };
 

--- a/External/FEXCore/Source/Interface/Core/X86HelperGen.h
+++ b/External/FEXCore/Source/Interface/Core/X86HelperGen.h
@@ -16,6 +16,7 @@ public:
   ~X86GeneratedCode();
 
   uint64_t SignalReturn{};
+  uint64_t SignalReturnRT{};
   uint64_t CallbackReturn{};
 
 private:

--- a/External/FEXCore/Source/Interface/Core/X86Tables/SecondaryTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/SecondaryTables.cpp
@@ -258,7 +258,7 @@ void InitializeSecondaryTables(Context::OperatingMode Mode) {
     // FEX reserved instructions
     // Unused x86 encoding instruction.
     // Used by FEX to know when to do a signal return
-    {0x36, 1, X86InstInfo{"SIGRET",       TYPE_INST, FLAGS_BLOCK_END | FLAGS_NO_OVERLAY | FLAGS_SETS_RIP,                                                            0, nullptr}},
+    {0x36, 1, X86InstInfo{"SIGRET",       TYPE_INST, FLAGS_BLOCK_END | FLAGS_NO_OVERLAY | FLAGS_SETS_RIP,                                                            1, nullptr}},
 
     {0x37, 1, X86InstInfo{"CALLBACKRET",  TYPE_INST, FLAGS_BLOCK_END | FLAGS_NO_OVERLAY | FLAGS_SETS_RIP,                                                                          0, nullptr}},
 

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -264,7 +264,7 @@
       "Break BreakDefinition:$Reason": {
         "HasSideEffects": true
       },
-      "SignalReturn": {
+      "SignalReturn i8:$IsRT": {
         "HasSideEffects": true
       },
       "CallbackReturn": {

--- a/External/FEXCore/include/FEXCore/Core/CoreState.h
+++ b/External/FEXCore/include/FEXCore/Core/CoreState.h
@@ -159,6 +159,7 @@ namespace FEXCore::Core {
       uint64_t GuestSignal_SIGTRAP{};
       uint64_t GuestSignal_SIGSEGV{};
       uint64_t SignalReturnHandler{};
+      uint64_t SignalReturnHandlerRT{};
       uint64_t L1Pointer{};
       uint64_t L2Pointer{};
       /**  @} */

--- a/External/FEXCore/include/FEXCore/Core/UContext.h
+++ b/External/FEXCore/include/FEXCore/Core/UContext.h
@@ -372,5 +372,33 @@ namespace FEXCore {
     };
     static_assert(sizeof(FEXCore::x86::ucontext_t) == 236, "This needs to be the right size");
 
+    ///< Non-rt signal context.
+    //
+    // Needs to match the format expected from signal handlers without SA_SIGINFO set.
+    struct sigcontext {
+      uint32_t gs;
+      uint32_t fs;
+      uint32_t es;
+      uint32_t ds;
+      uint32_t di;
+      uint32_t si;
+      uint32_t bp;
+      uint32_t sp;
+      uint32_t bx;
+      uint32_t dx;
+      uint32_t cx;
+      uint32_t ax;
+      uint32_t trapno;
+      uint32_t err;
+      uint32_t ip;
+      uint32_t cs;
+      uint32_t flags;
+      uint32_t sp_at_signal;
+      uint32_t ss;
+
+      uint32_t fpstate;
+      uint32_t oldmask;
+      uint32_t cr2;
+    };
   }
 }

--- a/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
+++ b/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
@@ -68,6 +68,7 @@ namespace FEXCore::Core {
     Pause,
     Stop,
     Return,
+    ReturnRT,
   };
 
   struct LocalIREntry {

--- a/unittests/FEXLinuxTests/tests/signal/invalid_util.h
+++ b/unittests/FEXLinuxTests/tests/signal/invalid_util.h
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include <signal.h>
 #include <optional>
 
@@ -24,3 +25,193 @@ static void CapturingHandler(int signal, siginfo_t *siginfo, void* context) {
   _context->uc_mcontext.gregs[FEX_IP_REG] += capturing_handler_skip;
 #undef FEX_IP_REG
 }
+
+#if __SIZEOF_POINTER__ == 4
+struct sigcontext_32 {
+  uint16_t gs, gsh;
+  uint16_t fs, fsh;
+  uint16_t es, esh;
+  uint16_t ds, dsh;
+  uint32_t di;
+  uint32_t si;
+  uint32_t bp;
+  uint32_t sp;
+  uint32_t bx;
+  uint32_t dx;
+  uint32_t cx;
+  uint32_t ax;
+  uint32_t trapno;
+  uint32_t err;
+  uint32_t ip;
+  uint16_t cs, csh;
+  uint32_t flags;
+  uint32_t sp_at_signal;
+  uint16_t ss, ssh;
+
+  uint32_t fpstate;
+  uint32_t oldmask;
+  uint32_t cr2;
+};
+struct sigframe_ia32 {
+  uint32_t pretcode;
+  int signal;
+  sigcontext_32 sc;
+  // <...>
+  // Some extra state
+};
+
+struct rt_sigframe_ia32 {
+  uint32_t pretcode;
+  int signal;
+  uint32_t pinfo;
+  uint32_t puc;
+  siginfo_t info;
+  ucontext_t uc;
+  // <...>
+  // Some extra state
+};
+
+struct CapturedHandlerState_32 {
+  sigcontext_32 mctx;
+  int signal;
+  int si_code;
+};
+
+struct CapturedHandlerState_regparm_32 {
+  int signal;
+  siginfo_t *siginfo;
+  void* context;
+};
+
+// This capturing handler is for non-realtime signals pulling arguments from the stack.
+std::optional<CapturedHandlerState_32> from_handler_32;
+// This capturing handler is for non-realtime signals pulling arguments from regparm ABI.
+std::optional<CapturedHandlerState_regparm_32> from_handler_regparm_32;
+
+/*
+ * This signal handler is for testing 32-bit non-realtime signal support.
+ * This handler gives a signal, and a sigcontext_32 object.
+ *
+ * The arguments are passed on the stack for this function.
+ */
+static void CapturingHandler_non_realtime(int signal, ...) {
+  // Getting the context frame is really hard, so hardwire some magic.
+  // Getting the frame address returns
+  // struct frame {
+  //  uint32_t ????;
+  //  uint32_t pret;
+  //  uint32_t signal;
+  //  sigcontext_32 sc;
+  sigframe_ia32 *frame = (sigframe_ia32 *)((size_t)__builtin_frame_address(0) + 4);
+  sigcontext_32 *context = &frame->sc;
+
+  from_handler_32 = { *context, signal, 0 };
+#ifdef REG_RIP
+#define FEX_IP_REG REG_RIP
+#else
+#define FEX_IP_REG REG_EIP
+#endif
+  context->ip += capturing_handler_skip;
+#undef FEX_IP_REG
+}
+
+/*
+ * This signal handler is for testing 32-bit realtime signal support.
+ * This handler gives a signal, a siginfo_t, and mcontext_t object.
+ *
+ * The arguments are passed on the stack for this function.
+ */
+[[gnu::regparm(3)]]
+static void CapturingHandler_realtime_regparm(int signal, siginfo_t *siginfo, void* context) {
+  ucontext_t* _context = (ucontext_t*)context;
+
+  from_handler = { _context->uc_mcontext, signal, siginfo->si_code };
+#ifdef REG_RIP
+#define FEX_IP_REG REG_RIP
+#else
+#define FEX_IP_REG REG_EIP
+#endif
+  _context->uc_mcontext.gregs[FEX_IP_REG] += capturing_handler_skip;
+#undef FEX_IP_REG
+}
+
+/*
+ * This signal handler is for testing 32-bit non-realtime signal support.
+ * This handler gives a signal, and that's it
+ *
+ * siginfo and context objects should always be nullptr in this case.
+ *
+ * The arguments are passed on in registers for this function.
+ */
+[[gnu::regparm(3)]]
+static void CapturingHandler_non_realtime_regparm(int signal, siginfo_t *siginfo, void* context) {
+  // Getting the context frame is really hard, so hardwire some magic.
+  // Getting the frame address returns
+  // struct frame {
+  //  uint32_t ????;
+  //  uint32_t pret;
+  //  uint32_t signal;
+  //  sigcontext_32 sc;
+  // If volatile isn't used then the compiler optimizes this out.
+  volatile sigframe_ia32 *frame = (volatile sigframe_ia32 *)((size_t)__builtin_frame_address(0) + 4);
+  volatile sigcontext_32 *context_stack = &frame->sc;
+
+  // siginfo and context should be nullptr.
+  from_handler_regparm_32 = { signal, siginfo, context };
+#ifdef REG_RIP
+#define FEX_IP_REG REG_RIP
+#else
+#define FEX_IP_REG REG_EIP
+#endif
+  context_stack->ip += capturing_handler_skip;
+#undef FEX_IP_REG
+}
+
+/*
+ * This signal handler is for testing 32-bit realtime signal support.
+ * This handler gives a signal, a siginfo_t, and mcontext_t object.
+ *
+ * The arguments are passed on the stack for this function.
+ */
+static void CapturingHandler_realtime() {
+  // Getting the context frame is really hard, so hardwire some magic.
+  // Getting the frame address returns
+  // struct frame {
+  //  uint32_t ????;
+  //  rt_sigframe_ia32 frame;
+  rt_sigframe_ia32 *frame = (rt_sigframe_ia32 *)((size_t)__builtin_frame_address(0) + 4);
+  int signal = frame->signal;
+  siginfo_t *siginfo = &frame->info;
+  ucontext_t* _context = &frame->uc;
+
+  from_handler = { _context->uc_mcontext, signal, siginfo->si_code };
+#ifdef REG_RIP
+#define FEX_IP_REG REG_RIP
+#else
+#define FEX_IP_REG REG_EIP
+#endif
+  _context->uc_mcontext.gregs[FEX_IP_REG] += capturing_handler_skip;
+#undef FEX_IP_REG
+}
+
+/*
+ * This signal handler is for testing 32-bit realtime signal support.
+ * This handler gives a signal, a siginfo_t, and mcontext_t object.
+ *
+ * The arguments are passed on in registers for this function.
+ * This one is specifically is for testing if the glibc handler is working correctly.
+ * It matches `CapturingHandler_realtime_regparm` but without the `regparm` ABI.
+ */
+static void CapturingHandler_realtime_glibc_helper(int signal, siginfo_t *siginfo, void* context) {
+  ucontext_t* _context = (ucontext_t*)context;
+
+  from_handler = { _context->uc_mcontext, signal, siginfo->si_code };
+#ifdef REG_RIP
+#define FEX_IP_REG REG_RIP
+#else
+#define FEX_IP_REG REG_EIP
+#endif
+  _context->uc_mcontext.gregs[FEX_IP_REG] += capturing_handler_skip;
+#undef FEX_IP_REG
+}
+#endif

--- a/unittests/FEXLinuxTests/tests/signal/sigtest_siginfo.32.cpp
+++ b/unittests/FEXLinuxTests/tests/signal/sigtest_siginfo.32.cpp
@@ -1,0 +1,192 @@
+#include "invalid_util.h"
+
+#include <catch2/catch.hpp>
+
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <cstdint>
+#include <syscall.h>
+
+extern "C" {
+extern void IntInstruction();
+}
+__attribute__((naked))
+static void CauseInt() {
+  __asm volatile(R"(
+  IntInstruction:
+  int $1;
+  ret; # For RIP modification
+  )");
+}
+
+static uint32_t EXPECTED_RIP = reinterpret_cast<uint32_t>(&IntInstruction);
+constexpr int EXPECTED_TRAPNO = 13;
+constexpr int EXPECTED_ERR = 10;
+constexpr int EXPECTED_SI_CODE = 128;
+constexpr int EXPECTED_SIGNAL = SIGSEGV;
+
+struct ActionHandler {
+  void* handler;
+  uint32_t sa_mask;
+  uint32_t sa_flags;
+  void* restorer;
+};
+
+struct rt_ActionHandler {
+  void* handler;
+
+  uint32_t sa_flags;
+  void* restorer;
+  uint64_t sa_mask;
+};
+
+TEST_CASE("sigaction: no siginfo") {
+  // On 32-bit, non-realtime sigaction still receives a context on the stack.
+  // This is an implementation detail of Linux and not enforced by POSIX.
+  // This can be modified by the userspace application as it is part of the uapi.
+  // This is how Linux allows an application to modify its context on signal return.
+  // This unit test is testing this by incrementing EIP by 2.
+  capturing_handler_skip = 2;
+  ActionHandler act{};
+  act.handler = (void*)CapturingHandler_non_realtime;
+  act.sa_flags = 0;
+  syscall(SYS_sigaction, SIGSEGV, &act, nullptr);
+
+  CauseInt();
+
+  REQUIRE(from_handler_32.has_value());
+  CHECK(from_handler_32->mctx.ip == EXPECTED_RIP);
+  CHECK(from_handler_32->mctx.trapno == EXPECTED_TRAPNO);
+  CHECK(from_handler_32->mctx.err == EXPECTED_ERR);
+  CHECK(from_handler_32->signal == EXPECTED_SIGNAL);
+}
+
+TEST_CASE("sigaction: siginfo - regparm") {
+  // On 32-bit, siginfo sigaction supports receiving siginfo and context in regparm.
+  // This can be modified by the userspace application as it is part of the uapi.
+  // This unit test is testing this by incrementing EIP by 2.
+  capturing_handler_skip = 2;
+  ActionHandler act{};
+  act.handler = (void*)CapturingHandler_realtime_regparm;
+  act.sa_flags = SA_SIGINFO;
+  syscall(SYS_sigaction, SIGSEGV, &act, nullptr);
+
+  CauseInt();
+
+  REQUIRE(from_handler.has_value());
+  CHECK((uint32_t)from_handler->mctx.gregs[REG_EIP] == EXPECTED_RIP);
+  CHECK(from_handler->mctx.gregs[REG_TRAPNO] == EXPECTED_TRAPNO);
+  CHECK(from_handler->mctx.gregs[REG_ERR] == EXPECTED_ERR);
+  CHECK(from_handler->signal == EXPECTED_SIGNAL);
+}
+
+TEST_CASE("sigaction: no siginfo - regparm") {
+  // On 32-bit, siginfo sigaction supports receiving siginfo and context in regparm.
+  // This can be modified by the userspace application as it is part of the uapi.
+  // This unit test is testing this by incrementing EIP by 2.
+  capturing_handler_skip = 2;
+  ActionHandler act{};
+  act.handler = (void*)CapturingHandler_non_realtime_regparm;
+  act.sa_flags = 0;
+  syscall(SYS_sigaction, SIGSEGV, &act, nullptr);
+
+  CauseInt();
+
+  REQUIRE(from_handler_regparm_32.has_value());
+  CHECK(from_handler_regparm_32->signal == EXPECTED_SIGNAL);
+  CHECK(from_handler_regparm_32->siginfo == nullptr);
+  CHECK(from_handler_regparm_32->context == nullptr);
+}
+
+TEST_CASE("sigaction: siginfo - stack") {
+  // On 32-bit, siginfo sigaction put the frame on the stack.
+  // This can be modified by the userspace application as it is part of the uapi.
+  // This unit test is testing this by incrementing EIP by 2.
+  capturing_handler_skip = 2;
+  ActionHandler act{};
+  act.handler = (void*)CapturingHandler_realtime;
+  act.sa_flags = SA_SIGINFO;
+  syscall(SYS_sigaction, SIGSEGV, &act, nullptr);
+
+  CauseInt();
+
+  REQUIRE(from_handler.has_value());
+  CHECK(from_handler->mctx.gregs[REG_EIP] == EXPECTED_RIP);
+  CHECK(from_handler->mctx.gregs[REG_TRAPNO] == EXPECTED_TRAPNO);
+  CHECK(from_handler->mctx.gregs[REG_ERR] == EXPECTED_ERR);
+  CHECK(from_handler->signal == EXPECTED_SIGNAL);
+}
+
+TEST_CASE("rt_sigaction: no siginfo") {
+  // On 32-bit, classic rt_sigaction still receives a context on the stack.
+  // This can be modified by the userspace application as it is part of the uapi.
+  // This is how to modify the context on sigreturn.
+  capturing_handler_skip = 2;
+  rt_ActionHandler act{};
+  act.handler = (void*)CapturingHandler_non_realtime;
+  act.sa_flags = 0;
+  syscall(SYS_rt_sigaction, SIGSEGV, &act, nullptr, 8);
+
+  CauseInt();
+
+  REQUIRE(from_handler_32.has_value());
+  CHECK(from_handler_32->mctx.ip == EXPECTED_RIP);
+  CHECK(from_handler_32->mctx.trapno == EXPECTED_TRAPNO);
+  CHECK(from_handler_32->mctx.err == EXPECTED_ERR);
+  CHECK(from_handler_32->signal == EXPECTED_SIGNAL);
+}
+
+TEST_CASE("rt_sigaction: siginfo - regparm") {
+  // On 32-bit, a realtime sigaction supports arguments being received on the stack AND regparm.
+  // This unit test ensures that the regparm implementation is working correctly.
+  capturing_handler_skip = 2;
+  rt_ActionHandler act{};
+  act.handler = (void*)CapturingHandler_realtime_regparm;
+  act.sa_flags = SA_SIGINFO;
+  syscall(SYS_rt_sigaction, SIGSEGV, &act, nullptr, 8);
+
+  CauseInt();
+
+  REQUIRE(from_handler.has_value());
+  CHECK(from_handler->mctx.gregs[REG_EIP] == EXPECTED_RIP);
+  CHECK(from_handler->mctx.gregs[REG_TRAPNO] == EXPECTED_TRAPNO);
+  CHECK(from_handler->mctx.gregs[REG_ERR] == EXPECTED_ERR);
+  CHECK(from_handler->signal == EXPECTED_SIGNAL);
+}
+
+TEST_CASE("rt_sigaction: siginfo - stack") {
+  // On 32-bit, a realtime sigaction supports arguments being received on the stack AND regparm.
+  // This unit test ensures that the stack implementation is working correctly.
+  capturing_handler_skip = 2;
+  rt_ActionHandler act{};
+  act.handler = (void*)CapturingHandler_realtime;
+  act.sa_flags = SA_SIGINFO;
+  syscall(SYS_rt_sigaction, SIGSEGV, &act, nullptr, 8);
+
+  CauseInt();
+
+  REQUIRE(from_handler.has_value());
+  CHECK(from_handler->mctx.gregs[REG_EIP] == EXPECTED_RIP);
+  CHECK(from_handler->mctx.gregs[REG_TRAPNO] == EXPECTED_TRAPNO);
+  CHECK(from_handler->mctx.gregs[REG_ERR] == EXPECTED_ERR);
+  CHECK(from_handler->signal == EXPECTED_SIGNAL);
+}
+
+TEST_CASE("sigaction: siginfo - glibc") {
+  // Test to ensure that regular glibc sigaction works.
+  capturing_handler_skip = 2;
+  struct sigaction act{};
+  act.sa_sigaction = CapturingHandler_realtime_glibc_helper;
+  act.sa_flags = SA_SIGINFO;
+  sigaction(SIGSEGV, &act, nullptr);
+
+  CauseInt();
+
+  REQUIRE(from_handler.has_value());
+  CHECK(from_handler->mctx.gregs[REG_EIP] == EXPECTED_RIP);
+  CHECK(from_handler->mctx.gregs[REG_TRAPNO] == EXPECTED_TRAPNO);
+  CHECK(from_handler->mctx.gregs[REG_ERR] == EXPECTED_ERR);
+  CHECK(from_handler->signal == EXPECTED_SIGNAL);
+}


### PR DESCRIPTION
Follow-up to https://github.com/FEX-Emu/FEX/pull/2327.
~~First four commits are from #2327 and those should be merged first.~~

Split off from https://github.com/FEX-Emu/FEX/pull/2176 and improved.

32-bit signals are a bit more complex than 64-bit due to behaviour
changing depending on if `rt_sigaction` and `sigaction` syscall is used
and if `SA_SIGINFO` is passed in to the flags.

With `SA_SIGINFO` used, both turn in to an `RT` frame, which is encoded
differently than without `SA_SIGINFO`.
Additionally 32-bit signals support both regular Linux stack ABI and
`regparm(3)` ABI.

Without `SA_SIGINFO` then `siginfo_t` is removed from the signal handler
arguments, but most of the rest still remains.
Also two of the arguments to the signal handler are forced to be nullptr
with `regparm(3)`.