### PR TITLE
Support user supplied signal restorer. 

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -72,6 +72,11 @@ jobs:
       # Execute the build.  You can specify a specific target with "--target <NAME>"
       run: cmake --build . --config $BUILD_TYPE
 
+    - name: Install
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      run: cmake --build . --config $BUILD_TYPE --target install
+
     - name: ASM Tests
       working-directory: ${{runner.workspace}}/build
       shell: bash
@@ -198,12 +203,6 @@ jobs:
       shell: bash
       working-directory: ${{runner.workspace}}/build
       run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_ThunkgenTests.log || true
-
-    - name: Install
-      if: matrix.arch[1] == 'x64'
-      working-directory: ${{runner.workspace}}/build
-      shell: bash
-      run: cmake --build . --config $BUILD_TYPE --target install
 
     - name: Test GL No-Thunks
       if: matrix.arch[1] == 'x64'

--- a/External/FEXCore/Source/Interface/Context/Context.cpp
+++ b/External/FEXCore/Source/Interface/Context/Context.cpp
@@ -207,6 +207,9 @@ namespace FEXCore::Context {
   void AppendThunkDefinitions(FEXCore::Context::Context *CTX, std::vector<FEXCore::IR::ThunkDefinition> const& Definitions) {
     CTX->AppendThunkDefinitions(Definitions);
   }
+  void SetVDSOSigReturn(FEXCore::Context::Context *CTX, const VDSOSigReturn &Pointers) {
+    CTX->SetVDSOSigReturn(Pointers);
+  }
 
 namespace Debug {
   void CompileRIP(FEXCore::Context::Context *CTX, uint64_t RIP) {

--- a/External/FEXCore/Source/Interface/Context/Context.cpp
+++ b/External/FEXCore/Source/Interface/Context/Context.cpp
@@ -117,7 +117,9 @@ namespace FEXCore::Context {
   void HandleCallback(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread, uint64_t RIP) {
     CTX->HandleCallback(Thread, RIP);
   }
-
+  void HandleSignalHandlerReturn(FEXCore::Context::Context *CTX, bool RT) {
+    CTX->HandleSignalHandlerReturn(RT);
+  }
   void RegisterHostSignalHandler(FEXCore::Context::Context *CTX, int Signal, HostSignalDelegatorFunction Func, bool Required) {
       CTX->RegisterHostSignalHandler(Signal, std::move(Func), Required);
   }

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -173,6 +173,7 @@ namespace FEXCore::Context {
     void StartGdbServer();
     void StopGdbServer();
     void HandleCallback(FEXCore::Core::InternalThreadState *Thread, uint64_t RIP);
+    [[noreturn]] void HandleSignalHandlerReturn(bool RT);
     void RegisterHostSignalHandler(int Signal, HostSignalDelegatorFunction Func, bool Required);
     void RegisterFrontendHostSignalHandler(int Signal, HostSignalDelegatorFunction Func, bool Required);
 

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -152,6 +152,7 @@ namespace FEXCore::Context {
 
     SignalDelegator *SignalDelegation{};
     X86GeneratedCode X86CodeGen;
+    VDSOSigReturn VDSOPointers{};
 
     Context();
     ~Context();
@@ -326,6 +327,10 @@ namespace FEXCore::Context {
     }
 
     void AppendThunkDefinitions(std::vector<FEXCore::IR::ThunkDefinition> const& Definitions);
+
+    void SetVDSOSigReturn(const VDSOSigReturn &Pointers) {
+      VDSOPointers = Pointers;
+    }
 
     FEXCore::Utils::PooledAllocatorMMap OpDispatcherAllocator;
     FEXCore::Utils::PooledAllocatorMMap FrontendAllocator;

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -330,6 +330,13 @@ namespace FEXCore::Context {
 
     void SetVDSOSigReturn(const VDSOSigReturn &Pointers) {
       VDSOPointers = Pointers;
+      if (VDSOPointers.VDSO_kernel_sigreturn == nullptr) {
+        VDSOPointers.VDSO_kernel_sigreturn = reinterpret_cast<void*>(X86CodeGen.sigreturn_32);
+      }
+
+      if (VDSOPointers.VDSO_kernel_rt_sigreturn == nullptr) {
+        VDSOPointers.VDSO_kernel_rt_sigreturn = reinterpret_cast<void*>(X86CodeGen.rt_sigreturn_32);
+      }
     }
 
     FEXCore::Utils::PooledAllocatorMMap OpDispatcherAllocator;

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/MContext.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/MContext.h
@@ -15,7 +15,6 @@ namespace FEXCore::ArchHelpers::Context {
 
 enum ContextFlags : uint32_t {
   CONTEXT_FLAG_INJIT = (1U << 0),
-  CONTEXT_FLAG_32BIT = (1U << 1),
 };
 
 #if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -310,6 +310,21 @@ namespace FEXCore::Context {
     Thread->CTX->Dispatcher->ExecuteJITCallback(Thread->CurrentFrame, RIP);
   }
 
+  void Context::HandleSignalHandlerReturn(bool RT) {
+    using SignalHandlerReturnFunc = void(*)();
+
+    SignalHandlerReturnFunc SignalHandlerReturn{};
+    if (RT) {
+      SignalHandlerReturn = reinterpret_cast<SignalHandlerReturnFunc>(Dispatcher->SignalHandlerReturnAddressRT);
+    }
+    else {
+      SignalHandlerReturn = reinterpret_cast<SignalHandlerReturnFunc>(Dispatcher->SignalHandlerReturnAddress);
+    }
+
+    SignalHandlerReturn();
+    FEX_UNREACHABLE;
+  }
+
   void Context::RegisterHostSignalHandler(int Signal, HostSignalDelegatorFunction Func, bool Required) {
       SignalDelegation->RegisterHostSignalHandler(Signal, Func, Required);
   }

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
@@ -95,8 +95,6 @@ protected:
   void RestoreFrame_ia32(ArchHelpers::Context::ContextBackup* Context, FEXCore::Core::CpuStateFrame *Frame, void *ucontext);
   void RestoreRTFrame_ia32(ArchHelpers::Context::ContextBackup* Context, FEXCore::Core::CpuStateFrame *Frame, void *ucontext);
 
-  const bool incomplete_guest_restorer_support = false;
-
   ///< Setup the signal frame for x64.
   uint64_t SetupFrame_x64(FEXCore::Core::InternalThreadState *Thread, ArchHelpers::Context::ContextBackup* ContextBackup, FEXCore::Core::CpuStateFrame *Frame,
     int Signal, siginfo_t *HostSigInfo, void *ucontext,

--- a/External/FEXCore/Source/Interface/Core/Interpreter/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/BranchOps.cpp
@@ -17,21 +17,7 @@ $end_info$
 #include <unistd.h>
 
 namespace FEXCore::CPU {
-[[noreturn]]
-static void SignalReturn(FEXCore::Core::InternalThreadState *Thread, bool RT) {
-  Thread->CTX->SignalThread(Thread, RT ? FEXCore::Core::SignalEvent::ReturnRT : FEXCore::Core::SignalEvent::Return);
-
-  LOGMAN_MSG_A_FMT("unreachable");
-  FEX_UNREACHABLE;
-}
-
 #define DEF_OP(x) void InterpreterOps::Op_##x(IR::IROp_Header *IROp, IROpData *Data, IR::NodeID Node)
-
-DEF_OP(SignalReturn) {
-  auto Op = IROp->C<IR::IROp_SignalReturn>();
-
-  SignalReturn(Data->State, Op->IsRT);
-}
 
 DEF_OP(CallbackReturn) {
   Data->State->CurrentFrame->Pointers.Interpreter.CallbackReturn(Data->State, Data->StackEntry);

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -50,6 +50,9 @@ InterpreterCore::InterpreterCore(Dispatcher *Dispatcher, FEXCore::Core::Internal
 }
 
 void InterpreterCore::InitializeSignalHandlers(FEXCore::Context::Context *CTX) {
+  CTX->SignalDelegation->RegisterHostSignalHandler(SIGILL, [](FEXCore::Core::InternalThreadState *Thread, int Signal, void *info, void *ucontext) -> bool {
+    return Thread->CTX->Dispatcher->HandleSIGILL(Thread, Signal, info, ucontext);
+  }, true);
 
 #ifdef _M_ARM_64
   CTX->SignalDelegation->RegisterHostSignalHandler(SIGBUS, [](FEXCore::Core::InternalThreadState *Thread, int Signal, void *info, void *ucontext) -> bool {

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -113,7 +113,6 @@ constexpr OpHandlerArray InterpreterOpHandlers = [] {
   REGISTER_OP(ATOMICFETCHNEG,         AtomicFetchNeg);
 
   // Branch ops
-  REGISTER_OP(SIGNALRETURN,           SignalReturn);
   REGISTER_OP(CALLBACKRETURN,         CallbackReturn);
   REGISTER_OP(EXITFUNCTION,           ExitFunction);
   REGISTER_OP(JUMP,                   Jump);

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
@@ -142,7 +142,6 @@ namespace FEXCore::CPU {
   DEF_OP(AtomicFetchNeg);
 
   ///< Branch ops
-  DEF_OP(SignalReturn);
   DEF_OP(CallbackReturn);
   DEF_OP(ExitFunction);
   DEF_OP(Jump);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
@@ -20,23 +20,6 @@ $end_info$
 namespace FEXCore::CPU {
 #define DEF_OP(x) void Arm64JITCore::Op_##x(IR::IROp_Header const *IROp, IR::NodeID Node)
 
-DEF_OP(SignalReturn) {
-  auto Op = IROp->C<IR::IROp_SignalReturn>();
-
-  // First we must reset the stack
-  ResetStack();
-
-  // Now branch to our signal return helper
-  // This can't be a direct branch since the code needs to live at a constant location
-  if (Op->IsRT) {
-    ldr(ARMEmitter::XReg::x0, STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.SignalReturnHandlerRT));
-  }
-  else {
-    ldr(ARMEmitter::XReg::x0, STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.SignalReturnHandler));
-  }
-  br(ARMEmitter::Reg::r0);
-}
-
 DEF_OP(CallbackReturn) {
   // spill back to CTX
   SpillStaticRegs();

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -822,7 +822,6 @@ void *Arm64JITCore::CompileCode(uint64_t Entry,
         REGISTER_OP(ATOMICFETCHNEG, AtomicFetchNeg);
 
         // Branch ops
-        REGISTER_OP(SIGNALRETURN,      SignalReturn);
         REGISTER_OP(CALLBACKRETURN,    CallbackReturn);
         REGISTER_OP(EXITFUNCTION,      ExitFunction);
         REGISTER_OP(JUMP,              Jump);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -312,7 +312,6 @@ private:
   DEF_OP(AtomicFetchNeg);
 
   ///< Branch ops
-  DEF_OP(SignalReturn);
   DEF_OP(CallbackReturn);
   DEF_OP(ExitFunction);
   DEF_OP(Jump);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
@@ -30,22 +30,6 @@ $end_info$
 namespace FEXCore::CPU {
 #define DEF_OP(x) void X86JITCore::Op_##x(IR::IROp_Header *IROp, IR::NodeID Node)
 
-DEF_OP(SignalReturn) {
-  auto Op = IROp->C<IR::IROp_SignalReturn>();
-
-  // Adjust the stack first for a regular return
-  if (SpillSlots) {
-    add(rsp, SpillSlots * MaxSpillSlotSize); // + 8 to consume return address
-  }
-
-  if (Op->IsRT) {
-    jmp(qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.SignalReturnHandlerRT)]);
-  }
-  else {
-    jmp(qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.SignalReturnHandler)]);
-  }
-}
-
 DEF_OP(CallbackReturn) {
   // Adjust the stack first for a regular return
   if (SpillSlots) {
@@ -321,7 +305,6 @@ DEF_OP(CPUID) {
 #undef DEF_OP
 void X86JITCore::RegisterBranchHandlers() {
 #define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &X86JITCore::Op_##x
-  REGISTER_OP(SIGNALRETURN,      SignalReturn);
   REGISTER_OP(CALLBACKRETURN,    CallbackReturn);
   REGISTER_OP(EXITFUNCTION,      ExitFunction);
   REGISTER_OP(JUMP,              Jump);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -308,7 +308,6 @@ private:
   DEF_OP(AtomicFetchNeg);
 
   ///< Branch ops
-  DEF_OP(SignalReturn);
   DEF_OP(CallbackReturn);
   DEF_OP(ExitFunction);
   DEF_OP(Jump);

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -277,18 +277,6 @@ void OpDispatchBuilder::IRETOp(OpcodeArgs) {
   BlockSetRIP = true;
 }
 
-void OpDispatchBuilder::SIGRETOp(OpcodeArgs) {
-  uint8_t Literal = Op->Src[0].Data.Literal.Value;
-  const uint8_t GPRSize = CTX->GetGPRSize();
-  // Store the new RIP
-  bool IsRT = CTX->Config.Is64BitMode() || Literal;
-  _SignalReturn(IsRT);
-  auto NewRIP = _LoadContext(GPRSize, GPRClass, offsetof(FEXCore::Core::CPUState, rip));
-  // This ExitFunction won't actually get hit but needs to exist
-  _ExitFunction(NewRIP);
-  BlockSetRIP = true;
-}
-
 void OpDispatchBuilder::CallbackReturnOp(OpcodeArgs) {
   const uint8_t GPRSize = CTX->GetGPRSize();
   // Store the new RIP
@@ -6419,7 +6407,6 @@ void InstallOpcodeHandlers(Context::OperatingMode Mode) {
     {0xFE, 1, &OpDispatchBuilder::VectorALUOp<IR::OP_VADD, 4>},
 
     // FEX reserved instructions
-    {0x36, 1, &OpDispatchBuilder::SIGRETOp},
     {0x37, 1, &OpDispatchBuilder::CallbackReturnOp},
   };
 

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -176,7 +176,6 @@ public:
   void NOPOp(OpcodeArgs);
   void RETOp(OpcodeArgs);
   void IRETOp(OpcodeArgs);
-  void SIGRETOp(OpcodeArgs);
   void CallbackReturnOp(OpcodeArgs);
   void SecondaryALUOp(OpcodeArgs);
   template<uint32_t SrcIndex>

--- a/External/FEXCore/Source/Interface/Core/X86HelperGen.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86HelperGen.cpp
@@ -23,19 +23,9 @@ X86GeneratedCode::X86GeneratedCode() {
   // Allocate a page for our emulated guest
   CodePtr = AllocateGuestCodeSpace(CODE_SIZE);
 
-  SignalReturn = reinterpret_cast<uint64_t>(CodePtr);
-  SignalReturnRT = reinterpret_cast<uint64_t>(CodePtr) + 7;
-  CallbackReturn = reinterpret_cast<uint64_t>(CodePtr) + 14;
+  CallbackReturn = reinterpret_cast<uint64_t>(CodePtr);
 
   const std::vector<uint8_t> SignalReturnCode = {
-    // sigreturn
-    0xb8, 0x77, 0x00, 0x00, 0x00, // mov eax, SYS_sigreturn
-    0xcd, 0x80, // int 0x80
-
-    // rt_sigreturn
-    0xb8, 0xad, 0x00, 0x00, 0x00, // mov eax, SYS_rt_sigreturn
-    0xcd, 0x80, // int 0x80
-
     0x0F, 0x37, // CALLBACKRET FEX Instruction
   };
 

--- a/External/FEXCore/Source/Interface/Core/X86HelperGen.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86HelperGen.cpp
@@ -24,12 +24,18 @@ X86GeneratedCode::X86GeneratedCode() {
   CodePtr = AllocateGuestCodeSpace(CODE_SIZE);
 
   SignalReturn = reinterpret_cast<uint64_t>(CodePtr);
-  SignalReturnRT = reinterpret_cast<uint64_t>(CodePtr) + 3;
-  CallbackReturn = reinterpret_cast<uint64_t>(CodePtr) + 6;
+  SignalReturnRT = reinterpret_cast<uint64_t>(CodePtr) + 7;
+  CallbackReturn = reinterpret_cast<uint64_t>(CodePtr) + 14;
 
   const std::vector<uint8_t> SignalReturnCode = {
-    0x0F, 0x36, 0x0, // SIGRET FEX instruction (Non-RT)
-    0x0F, 0x36, 0x1, // SIGRET FEX instruction (RT)
+    // sigreturn
+    0xb8, 0x77, 0x00, 0x00, 0x00, // mov eax, SYS_sigreturn
+    0xcd, 0x80, // int 0x80
+
+    // rt_sigreturn
+    0xb8, 0xad, 0x00, 0x00, 0x00, // mov eax, SYS_rt_sigreturn
+    0xcd, 0x80, // int 0x80
+
     0x0F, 0x37, // CALLBACKRET FEX Instruction
   };
 

--- a/External/FEXCore/Source/Interface/Core/X86HelperGen.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86HelperGen.cpp
@@ -23,13 +23,38 @@ X86GeneratedCode::X86GeneratedCode() {
   // Allocate a page for our emulated guest
   CodePtr = AllocateGuestCodeSpace(CODE_SIZE);
 
-  CallbackReturn = reinterpret_cast<uint64_t>(CodePtr);
-
-  const std::vector<uint8_t> SignalReturnCode = {
+  constexpr std::array<uint8_t, 2> SignalReturnCode = {
     0x0F, 0x37, // CALLBACKRET FEX Instruction
   };
 
-  memcpy(CodePtr, &SignalReturnCode.at(0), SignalReturnCode.size());
+  // Signal return handlers need to be bit-exact to what the Linux kernel provides in VDSO.
+  // GDB and unwinding libraries key off of these instructions to understand if the stack frame is a signal frame or not.
+  // This two code sections match exactly what libSegFault expects.
+  //
+  // Typically this handlers are provided by the 32-bit VDSO thunk library, but that isn't available in all cases.
+  // Falling back to this generated code segment still allows a backtrace to work, just might not show
+  // the symbol as VDSO since there is no ELF to parse.
+  constexpr std::array<uint8_t, 9> sigreturn_32_code = {
+    0x58, // pop eax
+    0xb8, 0x77, 0x00, 0x00, 0x00, // mov eax, 0x77
+    0xcd, 0x80, // int 0x80
+    0x90, // nop
+  };
+
+  constexpr std::array<uint8_t, 7> rt_sigreturn_32_code = {
+    0xb8, 0xad, 0x00, 0x00, 0x00, // mov eax, 0xad
+    0xcd, 0x80, // int 0x80
+  };
+
+  CallbackReturn = reinterpret_cast<uint64_t>(CodePtr);
+  sigreturn_32 = CallbackReturn + SignalReturnCode.size();
+  rt_sigreturn_32 = sigreturn_32 + sigreturn_32_code.size();
+
+  memcpy(reinterpret_cast<void*>(CallbackReturn), &SignalReturnCode.at(0), SignalReturnCode.size());
+  memcpy(reinterpret_cast<void*>(sigreturn_32), &sigreturn_32_code.at(0), sigreturn_32_code.size());
+  memcpy(reinterpret_cast<void*>(rt_sigreturn_32), &rt_sigreturn_32_code.at(0), rt_sigreturn_32_code.size());
+
+  mprotect(CodePtr, CODE_SIZE, PROT_READ);
 }
 
 X86GeneratedCode::~X86GeneratedCode() {

--- a/External/FEXCore/Source/Interface/Core/X86HelperGen.h
+++ b/External/FEXCore/Source/Interface/Core/X86HelperGen.h
@@ -15,8 +15,6 @@ public:
   X86GeneratedCode();
   ~X86GeneratedCode();
 
-  uint64_t SignalReturn{};
-  uint64_t SignalReturnRT{};
   uint64_t CallbackReturn{};
 
 private:

--- a/External/FEXCore/Source/Interface/Core/X86HelperGen.h
+++ b/External/FEXCore/Source/Interface/Core/X86HelperGen.h
@@ -16,6 +16,8 @@ public:
   ~X86GeneratedCode();
 
   uint64_t CallbackReturn{};
+  uint64_t sigreturn_32{};
+  uint64_t rt_sigreturn_32{};
 
 private:
   void *CodePtr{};

--- a/External/FEXCore/Source/Interface/Core/X86Tables/SecondaryTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/SecondaryTables.cpp
@@ -64,6 +64,7 @@ void InitializeSecondaryTables(Context::OperatingMode Mode) {
     {0x33, 1, X86InstInfo{"RDPMC",      TYPE_PRIV, FLAGS_NO_OVERLAY,                                                                             0, nullptr}},
     {0x34, 1, X86InstInfo{"SYSENTER",   TYPE_PRIV, FLAGS_NO_OVERLAY,                                                                             0, nullptr}},
     {0x35, 1, X86InstInfo{"SYSEXIT",    TYPE_PRIV, FLAGS_NO_OVERLAY,                                                                             0, nullptr}},
+    {0x36, 1, X86InstInfo{"",           TYPE_INVALID, FLAGS_NO_OVERLAY,                                                                          0, nullptr}},
     {0x38, 1, X86InstInfo{"",           TYPE_0F38_TABLE, FLAGS_NO_OVERLAY,                                                                       0, nullptr}},
     {0x39, 1, X86InstInfo{"",           TYPE_INVALID, FLAGS_NO_OVERLAY,                                                                          0, nullptr}},
     {0x3A, 1, X86InstInfo{"",           TYPE_0F3A_TABLE, FLAGS_NO_OVERLAY,                                                                       0, nullptr}},
@@ -257,8 +258,6 @@ void InitializeSecondaryTables(Context::OperatingMode Mode) {
 
     // FEX reserved instructions
     // Unused x86 encoding instruction.
-    // Used by FEX to know when to do a signal return
-    {0x36, 1, X86InstInfo{"SIGRET",       TYPE_INST, FLAGS_BLOCK_END | FLAGS_NO_OVERLAY | FLAGS_SETS_RIP,                                                            1, nullptr}},
 
     {0x37, 1, X86InstInfo{"CALLBACKRET",  TYPE_INST, FLAGS_BLOCK_END | FLAGS_NO_OVERLAY | FLAGS_SETS_RIP,                                                                          0, nullptr}},
 

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -22,7 +22,7 @@
     "",
     "Eg:",
     "IR op with no result and no arguments",
-    "  SignalReturn",
+    "  CallbackReturn",
     "",
     "IR op with result and no arguments",
     "  GPR = ProcessorID",
@@ -262,9 +262,6 @@
         "DestSize": "GetOpSize(_NewRIP)"
       },
       "Break BreakDefinition:$Reason": {
-        "HasSideEffects": true
-      },
-      "SignalReturn i8:$IsRT": {
         "HasSideEffects": true
       },
       "CallbackReturn": {

--- a/External/FEXCore/include/FEXCore/Core/Context.h
+++ b/External/FEXCore/include/FEXCore/Core/Context.h
@@ -252,6 +252,7 @@ namespace FEXCore::Context {
   FEX_DEFAULT_VISIBILITY void HandleCallback(FEXCore::Context::Context *CTX, FEXCore::Core::InternalThreadState *Thread, uint64_t RIP);
 
   FEX_DEFAULT_VISIBILITY void RegisterHostSignalHandler(FEXCore::Context::Context *CTX, int Signal, HostSignalDelegatorFunction Func, bool Required);
+  [[noreturn]] FEX_DEFAULT_VISIBILITY void HandleSignalHandlerReturn(FEXCore::Context::Context *CTX, bool RT);
   FEX_DEFAULT_VISIBILITY void RegisterFrontendHostSignalHandler(FEXCore::Context::Context *CTX, int Signal, HostSignalDelegatorFunction Func, bool Required);
 
   FEX_DEFAULT_VISIBILITY FEXCore::Core::InternalThreadState* CreateThread(FEXCore::Context::Context *CTX, FEXCore::Core::CPUState *NewThreadState, uint64_t ParentTID);

--- a/External/FEXCore/include/FEXCore/Core/Context.h
+++ b/External/FEXCore/include/FEXCore/Core/Context.h
@@ -69,6 +69,11 @@ namespace FEXCore::Context {
       std::unique_lock<std::shared_mutex> lock;
   };
 
+  struct VDSOSigReturn {
+    void *VDSO_kernel_sigreturn;
+    void *VDSO_kernel_rt_sigreturn;
+  };
+
   using CustomCPUFactoryType = std::function<std::unique_ptr<FEXCore::CPU::CPUBackend> (FEXCore::Context::Context*, FEXCore::Core::InternalThreadState *Thread)>;
 
   using ExitHandler = std::function<void(uint64_t ThreadId, FEXCore::Context::ExitReason)>;
@@ -290,4 +295,7 @@ namespace FEXCore::Context {
    * @param Definitions A vector of thunk definitions that the frontend controls
    */
   FEX_DEFAULT_VISIBILITY void AppendThunkDefinitions(FEXCore::Context::Context *CTX, std::vector<FEXCore::IR::ThunkDefinition> const& Definitions);
+
+  FEX_DEFAULT_VISIBILITY void SetVDSOSigReturn(FEXCore::Context::Context *CTX, const VDSOSigReturn &Pointers);
+
 }

--- a/Source/Tests/FEXLoader.cpp
+++ b/Source/Tests/FEXLoader.cpp
@@ -429,6 +429,7 @@ int main(int argc, char **argv, char **const envp) {
 
   // Pass in our VDSO thunks
   FEXCore::Context::AppendThunkDefinitions(CTX, FEX::VDSO::GetVDSOThunkDefinitions());
+  FEXCore::Context::SetVDSOSigReturn(CTX, FEX::VDSO::GetVDSOSymbols());
 
   FEXCore::Context::ExitReason ShutdownReason = FEXCore::Context::ExitReason::EXIT_SHUTDOWN;
 

--- a/Source/Tests/LinuxSyscalls/Syscalls/Stubs.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Stubs.cpp
@@ -23,10 +23,6 @@ namespace FEXCore::Core {
 namespace FEX::HLE {
   void RegisterStubs(FEX::HLE::SyscallHandler *Handler) {
 
-    REGISTER_SYSCALL_IMPL(rt_sigreturn, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t {
-      SYSCALL_STUB(rt_sigreturn);
-    });
-
     REGISTER_SYSCALL_IMPL(ptrace, [](FEXCore::Core::CpuStateFrame *Frame, int /*enum __ptrace_request*/ request, pid_t pid, void *addr, void *data) -> uint64_t {
       // We don't support this
       return -EPERM;

--- a/Source/Tests/LinuxSyscalls/Syscalls/Thread.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls/Thread.cpp
@@ -263,6 +263,11 @@ namespace FEX::HLE {
   void RegisterThread(FEX::HLE::SyscallHandler *Handler) {
     using namespace FEXCore::IR;
 
+    REGISTER_SYSCALL_IMPL(rt_sigreturn, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t {
+      FEXCore::Context::HandleSignalHandlerReturn(Frame->Thread->CTX, true);
+      FEX_UNREACHABLE;
+    });
+
     REGISTER_SYSCALL_IMPL_PASS_FLAGS(getpid, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
       [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t {
       uint64_t Result = ::getpid();

--- a/Source/Tests/LinuxSyscalls/x32/Stubs.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Stubs.cpp
@@ -21,10 +21,6 @@ namespace FEXCore::Core {
 
 namespace FEX::HLE::x32 {
   void RegisterStubs(FEX::HLE::SyscallHandler *Handler) {
-    REGISTER_SYSCALL_IMPL_X32(sigreturn, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t {
-      SYSCALL_STUB(sigreturn);
-    });
-
     REGISTER_SYSCALL_IMPL_X32(readdir, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t {
       SYSCALL_STUB(readdir);
     });

--- a/Source/Tests/LinuxSyscalls/x32/Thread.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/Thread.cpp
@@ -99,6 +99,11 @@ namespace FEX::HLE::x32 {
   }
 
   void RegisterThread(FEX::HLE::SyscallHandler *Handler) {
+    REGISTER_SYSCALL_IMPL_X32(sigreturn, [](FEXCore::Core::CpuStateFrame *Frame) -> uint64_t {
+      FEXCore::Context::HandleSignalHandlerReturn(Frame->Thread->CTX, false);
+      FEX_UNREACHABLE;
+    });
+
     REGISTER_SYSCALL_IMPL_X32(clone, ([](FEXCore::Core::CpuStateFrame *Frame, uint32_t flags, void *stack, pid_t *parent_tid, void *tls, pid_t *child_tid) -> uint64_t {
       FEX::HLE::clone3_args args {
         .Type = TypeOfClone::TYPE_CLONE2,

--- a/Source/Tests/VDSO_Emulation.h
+++ b/Source/Tests/VDSO_Emulation.h
@@ -1,6 +1,10 @@
 #pragma once
 #include <FEXCore/IR/IR.h>
 
+namespace FEXCore::Context {
+struct VDSOSigReturn;
+}
+
 namespace FEX::VDSO {
   using MapperFn = std::function<void *(void *addr, size_t length, int prot, int flags, int fd, off_t offset)>;
   void* LoadVDSOThunks(bool Is64Bit, MapperFn Mapper);
@@ -8,4 +12,5 @@ namespace FEX::VDSO {
   uint64_t GetVSyscallEntry(const void* VDSOBase);
 
   std::vector<FEXCore::IR::ThunkDefinition> const& GetVDSOThunkDefinitions();
+  FEXCore::Context::VDSOSigReturn const& GetVDSOSymbols();
 }

--- a/ThunkLibs/libVDSO/libVDSO_Guest.cpp
+++ b/ThunkLibs/libVDSO/libVDSO_Guest.cpp
@@ -38,5 +38,29 @@ int __kernel_vsyscall() {
   )"
   ::: "memory");
 }
+
+__attribute__((naked))
+void __kernel_sigreturn() {
+  asm volatile(R"(
+  .intel_syntax noprefix
+  pop eax;
+  mov eax, 0x77;
+  int 0x80;
+  nop;
+  .att_syntax prefix
+  )"
+  ::: "memory");
+}
+__attribute__((naked))
+void __kernel_rt_sigreturn() {
+  asm volatile(R"(
+  .intel_syntax noprefix
+  mov eax, 0xad;
+  int 0x80;
+  .att_syntax prefix
+  )"
+  ::: "memory");
+}
+
 #endif
 }

--- a/ThunkLibs/libVDSO/libVDSO_Guest_32.lds
+++ b/ThunkLibs/libVDSO/libVDSO_Guest_32.lds
@@ -54,6 +54,8 @@ VERSION {
   LINUX_2.5 {
   global:
     __kernel_vsyscall;
+    __kernel_sigreturn;
+    __kernel_rt_sigreturn;
   local: *;
   };
 }


### PR DESCRIPTION
This depends on #2327 and #2344 being commited first

With this in-place, we now support libSegFault's backtrace capabilities.

eg 64-bit:
```
Backtrace:
/mnt/Work/Work/Unicorn_Tests/ELFLoader/Tests/sigsegv_test(+0x1130)[0x56454f0e5130]
/lib/x86_64-linux-gnu/libc.so.6(+0x29d90)[0x7fffd9c29d90]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x80)[0x7fffd9c29e40]
/mnt/Work/Work/Unicorn_Tests/ELFLoader/Tests/sigsegv_test(+0x1065)[0x56454f0e5065]
```

eg 32-bit:
```
Backtrace:
/mnt/Work/Work/Unicorn_Tests/ELFLoader/Tests/sigsegv_test_32(+0x1190)[0xaab7b190]
/mnt/Work/Work/Unicorn_Tests/ELFLoader/Tests/sigsegv_test_32(+0x11bc)[0xaab7b1bc]
/lib/i386-linux-gnu/libc.so.6(+0x21519)[0xf7821519]
/lib/i386-linux-gnu/libc.so.6(__libc_start_main+0x93)[0xf78215f3]
/mnt/Work/Work/Unicorn_Tests/ELFLoader/Tests/sigsegv_test_32(+0x108b)[0xaab7b08b]
```