### PR TITLE
JitSymbols: Fixes file opening and writing

### DIFF
--- a/External/FEXCore/Source/Common/JitSymbols.cpp
+++ b/External/FEXCore/Source/Common/JitSymbols.cpp
@@ -20,7 +20,7 @@ namespace FEXCore {
     // We can't use FILE here since we must be robust against forking processes closing our FD from under us.
     const auto PerfMap = fmt::format("/tmp/perf-{}.map", getpid());
 
-    fd = open(PerfMap.c_str(), O_CREAT | O_EXCL | O_WRONLY | O_DIRECT, 0644);
+    fd = open(PerfMap.c_str(), O_CREAT | O_TRUNC | O_WRONLY | O_APPEND, 0644);
   }
 
   void JITSymbols::Register(const void *HostAddr, uint64_t GuestAddr, uint32_t CodeSize) {


### PR DESCRIPTION
We shouldn't use O_EXCL, since we need to overwrite previous entry PIDs if they happen to exist. The kernel ensures that PIDs don't overlap, but in some kernel configurations PIDs are aggressively reused, resulting in O_EXCL quickly hitting an issue when writing stale files.

Additionally O_DIRECT, this doesn't allow us to write to files, so all write functions were failing.

Additionally use O_APPEND, we are only ever appending, so let the kernel know.

Additionally use O_TRUNC, in the case that a stale perf file exists, this will immediately truncate the file to zero.