### PR TITLE
Core: Adjust virtual memory size for 32-bit

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -159,6 +159,11 @@ namespace FEXCore::Context {
       HostFeatures.SupportsAVX = false;
     }
 
+    if (!Config.Is64BitMode()) {
+      // When operating in 32-bit mode, the virtual memory we care about is only the lower 32-bits.
+      Config.VirtualMemSize = 1ULL << 32;
+    }
+
     if (Config.BlockJITNaming() ||
         Config.GlobalJITNaming() ||
         Config.LibraryJITNaming()) {


### PR DESCRIPTION
We only need a 32-bit virtual memory size when running a 32-bit application.

Just lowers some virtual memory space that we need to allocate.