### PR TITLE
ARMEmitter: Support helper for long address generation 

### DIFF
--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/Buffer.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/Buffer.h
@@ -87,6 +87,11 @@ namespace FEXCore::ARMEmitter {
         return Size;
       }
 
+      template<typename T>
+      size_t GetCursorOffsetFromAddress(const T* Address) const {
+        return static_cast<size_t>(reinterpret_cast<const uint8_t*>(Address) - BufferBase);
+      }
+
     protected:
 
       void ResetBuffer() {

--- a/External/FEXCore/unittests/Emitter/TestDisassembler.h
+++ b/External/FEXCore/unittests/Emitter/TestDisassembler.h
@@ -12,7 +12,9 @@ public:
   TestDisassembler() {
     fp = tmpfile();
     Disasm = std::make_unique<vixl::aarch64::PrintDisassembler>(fp);
-    SetBuffer(reinterpret_cast<uint8_t*>(mmap(nullptr, 4096, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0)), 4096);
+    // 2MB code size.
+    const size_t CodeSize = 2 * 1024 * 1024;
+    SetBuffer(reinterpret_cast<uint8_t*>(mmap(nullptr, CodeSize, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0)), CodeSize);
     BufferBegin = GetCursorAddress<const vixl::aarch64::Instruction*>();
   }
   ~TestDisassembler() {


### PR DESCRIPTION
The current separated adr and adrp handlers are difficult to use if you
don't know if the resulting address is going to be within 1MB or 4GB.

Adds a `LongAddressGen` helper that will generate the various pieces of
code that will need to be emitted.

Backward labels:
 - Can generate three different code segments depending on distance to
   label
   - adr if label is within 1MB
   - adrp if label is 4K page aligned and within 4GB
   - adrp+add if label is within 4GB

Forward labels:
- Can generate three different code segments depending on distance to
  label
  - nop+adr if label is within 1MB
  - nop+adrp if label is 4K page aligned and within 4GB
  - adrp+add if label is within 4GB

There is still the limitation that this can't generate addresses to
labels that are >4GB away. Which is fine.