### PR TITLE
Linux: Fixes shebang file execution

### DIFF
--- a/Source/Tests/LinuxSyscalls/Syscalls.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls.cpp
@@ -176,8 +176,9 @@ static bool IsShebangFile(std::span<char> Data) {
   // Handle shebang files.
   if (Data[0] == '#' &&
       Data[1] == '!') {
-    std::string_view InterpreterView { Data.data(), Data.size() };
-    std::string InterpreterLine { Data.data(), InterpreterView.find('\n') };
+    // Make sure to strip off the shebang prefix.
+    std::string_view InterpreterView { Data.data() + 2, Data.size() - 2};
+    std::string InterpreterLine { InterpreterView.data(), InterpreterView.find('\n') };
     std::vector<std::string> ShebangArguments{};
 
     // Shebang line can have a single argument


### PR DESCRIPTION
Somewhere during the refactoring/review process, failed to strip the shebang prefix off of the arguments.
Causing shebang files to always fail as if the file never existed.

Fixes steam execution.