### PR TITLE
Dispatcher: Extract 64-bit signal frame save and restore

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
@@ -90,6 +90,16 @@ protected:
     , config {Config}
     {}
 
+  void RestoreFrame_x64(ArchHelpers::Context::ContextBackup* Context, FEXCore::Core::CpuStateFrame *Frame, void *ucontext);
+
+  const bool incomplete_guest_restorer_support = false;
+
+  ///< Setup the signal frame for x64.
+  uint64_t SetupFrame_x64(FEXCore::Core::InternalThreadState *Thread, ArchHelpers::Context::ContextBackup* ContextBackup, FEXCore::Core::CpuStateFrame *Frame,
+    int Signal, siginfo_t *HostSigInfo, void *ucontext,
+    GuestSigAction *GuestAction, stack_t *GuestStack,
+    uint64_t NewGuestSP, const uint32_t eflags);
+
   ArchHelpers::Context::ContextBackup* StoreThreadState(FEXCore::Core::InternalThreadState *Thread, int Signal, void *ucontext);
   void RestoreThreadState(FEXCore::Core::InternalThreadState *Thread, void *ucontext);
   std::stack<uint64_t, std::vector<uint64_t>> SignalFrames;


### PR DESCRIPTION
Stripped from #2344 at request to ensure 64-bit code hasn't changed in a meaningful way. So that PR can focus on 32-bit.