### PR TITLE
Dispathcer: Fixes crash in 32-bit non-rt context generation

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
@@ -641,7 +641,6 @@ bool Dispatcher::HandleGuestSignal(FEXCore::Core::InternalThreadState *Thread, i
     }
     else {
       guest_uctx->uc_mcontext.gregs[FEXCore::x86::FEX_REG_TRAPNO] = ConvertSignalToTrapNo(Signal, HostSigInfo);
-      guest_siginfo->si_code = HostSigInfo->si_code;
       guest_uctx->uc_mcontext.gregs[FEXCore::x86::FEX_REG_ERR] = ConvertSignalToError(ucontext, Signal, HostSigInfo);
     }
 


### PR DESCRIPTION
This line was moved lower and this was accidentally leftover while rebasing.
Fixes a crash in 32-bit applications that aren't using SA_SIGINFO.

Unnecessary if #2344 gets merged first.