### PR TITLE
Thunks: Fixes host symbol overrides

### DIFF
--- a/ThunkLibs/include/common/Host.h
+++ b/ThunkLibs/include/common/Host.h
@@ -8,6 +8,7 @@ $end_info$
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
+#include <dlfcn.h>
 
 #include "PackedArguments.h"
 
@@ -191,4 +192,15 @@ void FinalizeHostTrampolineForGuestFunction(F* PreallocatedTrampolineForGuestFun
   FEXCore::FinalizeHostTrampolineForGuestFunction(
       (FEXCore::HostToGuestTrampolinePtr*)PreallocatedTrampolineForGuestFunction,
       (void*)&CallbackUnpack<F>::CallGuestPtr);
+}
+
+// In the case of the thunk host_loader being the default, FEX need to use dlsym with RTLD_DEFAULT.
+// If FEX queried the symbol object directly then it wouldn't follow symbol overriding rules.
+//
+// Common usecase is LD_PRELOAD with a library that defines some symbols.
+// And then programs and libraries will pick up the preloaded symbols.
+// ex: MangoHud overrides GLX and EGL symbols.
+inline
+void *dlsym_default(void* handle, const char* symbol) {
+  return dlsym(RTLD_DEFAULT, symbol);
 }

--- a/unittests/ThunkLibs/generator.cpp
+++ b/unittests/ThunkLibs/generator.cpp
@@ -332,7 +332,8 @@ SourceWithAST Fixture::run_thunkgen_host(std::string_view prelude, std::string_v
         "};\n"
         "template<typename F>\n"
         "void FinalizeHostTrampolineForGuestFunction(F*);\n"
-        "struct ExportEntry { uint8_t* sha256; void(*fn)(void *); };\n";
+        "struct ExportEntry { uint8_t* sha256; void(*fn)(void *); };\n"
+        "void *dlsym_default(void* handle, const char* symbol);\n";
 
     auto& filename = output_filenames.host;
     {


### PR DESCRIPTION
1) The host library needs to be loaded in the global namespace.

2) We need to use `RTLD_DEFAULT` instead of querying the object
   directly.

We need to load the host library in the global namespace so the symbols
end up in the global symbol table. This follows how all these symbols
/usually/ get loaded. Either by linking directly to the library or how
loaders will end up loading these.

We need to use RTLD_DEFAULT to follow symbol overriding rules that tend
to occur. For example, MangoHUD will LD_PRELOAD a library that provides
GLX and EGL symbols. Which FEX's thunk libraries need to pick up this
override.
If we are querying the host library directly then we fail to pickup
these overrides, thus breaking MangoHUD and other overlays.