### PR TITLE
ARMEmitter: Add a few missing instructions

### DIFF
--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
@@ -392,12 +392,16 @@ public:
     SVEPredicateLogical(Op, 1, 1, 1, 1, pm, pg, pn, pd);
   }
 
+  // XXX:
   // SVE broadcast predicate element
   // XXX:
   // SVE integer clamp
-  // XXX:
-  // SVE2 character match
-  // XXX:
+
+  void match(SubRegSize size, PRegister pd, PRegisterZero pg, ZRegister zn, ZRegister zm) {
+    constexpr uint32_t Op = 0b0100'0101'0010'0000'1000'0000'0000'0000;
+    SVECharacterMatch(Op, 0, size, pd, pg, zn, zm);
+  }
+
   // SVE floating-point convert precision odd elements
   void fcvtxnt(FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegisterMerge pg, FEXCore::ARMEmitter::ZRegister zn) {
     constexpr uint32_t Op = 0b0110'0100'0000'1000'101 << 13;
@@ -3902,6 +3906,21 @@ private:
     Instr |= pg.Idx() << 10;
     Instr |= zm.Idx() << 5;
     Instr |= zd.Idx();
+    dc32(Instr);
+  }
+
+  void SVECharacterMatch(uint32_t op, uint32_t opc, SubRegSize size, PRegister pd, PRegisterZero pg, ZRegister zn, ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit,
+                        "match/nmatch can only use 8-bit or 16-bit element sizes");
+    LOGMAN_THROW_AA_FMT(pg <= PReg::p7, "match/nmatch can only use p0-p7 as a governing predicate");
+
+    uint32_t Instr = op;
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= opc << 4;
+    Instr |= zm.Idx() << 16;
+    Instr |= pg.Idx() << 10;
+    Instr |= zn.Idx() << 5;
+    Instr |= pd.Idx();
     dc32(Instr);
   }
 

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
@@ -88,7 +88,26 @@ public:
   }
 
   // TODO: FCMLA
-  // TODO: FCADD
+  
+  void fcadd(SubRegSize size, ZRegister zd, PRegisterMerge pv, ZRegister zn, ZRegister zm, Rotation rot) {
+    LOGMAN_THROW_AA_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
+                        "SubRegSize must be 16-bit, 32-bit, or 64-bit");
+    LOGMAN_THROW_AA_FMT(pv <= PReg::p7, "fcadd can only use p0 to p7");
+    LOGMAN_THROW_AA_FMT(rot == Rotation::ROTATE_90 || rot == Rotation::ROTATE_270,
+                        "fcadd rotation may only be 90 or 270 degrees");
+    LOGMAN_THROW_AA_FMT(zd.Idx() == zn.Idx(), "fcadd zd and zn must be the same register");
+
+    const uint32_t ConvertedRotation = rot == Rotation::ROTATE_90 ? 0 : 1;
+
+    uint32_t Op = 0b0110'0100'0000'0000'1000'0000'0000'0000;
+    Op |= FEXCore::ToUnderlying(size) << 22;
+    Op |= ConvertedRotation << 16;
+    Op |= pv.Idx() << 10;
+    Op |= zm.Idx() << 5;
+    Op |= zd.Idx();
+
+    dc32(Op);
+  }
 
   // SVE integer add/subtract vectors (unpredicated)
   void add(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zm) {

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
@@ -397,9 +397,14 @@ public:
   // XXX:
   // SVE integer clamp
 
+  // SVE2 character match
   void match(SubRegSize size, PRegister pd, PRegisterZero pg, ZRegister zn, ZRegister zm) {
     constexpr uint32_t Op = 0b0100'0101'0010'0000'1000'0000'0000'0000;
     SVECharacterMatch(Op, 0, size, pd, pg, zn, zm);
+  }
+  void nmatch(SubRegSize size, PRegister pd, PRegisterZero pg, ZRegister zn, ZRegister zm) {
+    constexpr uint32_t Op = 0b0100'0101'0010'0000'1000'0000'0000'0000;
+    SVECharacterMatch(Op, 1, size, pd, pg, zn, zm);
   }
 
   // SVE floating-point convert precision odd elements

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
@@ -79,6 +79,14 @@ public:
     dc32(Op);
   }
 
+  void histseg(ZRegister zd, ZRegister zn, ZRegister zm) {
+    uint32_t Op = 0b0100'0101'0010'0000'1010'0000'0000'0000;
+    Op |= zm.Idx() << 16;
+    Op |= zn.Idx() << 5;
+    Op |= zd.Idx();
+    dc32(Op);
+  }
+
   // TODO: FCMLA
   // TODO: FCADD
 

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
@@ -66,7 +66,19 @@ public:
     SVESel(Op, size, zd, pv, zn, zd);
   }
 
-  // TODO: HISTCNT
+  void histcnt(SubRegSize size, ZRegister zd, PRegisterZero pv, ZRegister zn, ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "SubRegSize must be 32-bit or 64-bit");
+    LOGMAN_THROW_AA_FMT(pv <= PReg::p7, "histcnt can only use p0 to p7");
+
+    uint32_t Op = 0b0100'0101'0010'0000'1100'0000'0000'0000;
+    Op |= FEXCore::ToUnderlying(size) << 22;
+    Op |= zm.Idx() << 16;
+    Op |= pv.Idx() << 10;
+    Op |= zn.Idx() << 5;
+    Op |= zd.Idx();
+    dc32(Op);
+  }
+
   // TODO: FCMLA
   // TODO: FCADD
 

--- a/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
+++ b/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
@@ -245,6 +245,11 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 character match") {
               "match p8.b, p6/z, z30.b, z29.b");
   TEST_SINGLE(match(SubRegSize::i16Bit, PReg::p8, PReg::p6.Zeroing(), ZReg::z30, ZReg::z29),
               "match p8.h, p6/z, z30.h, z29.h");
+
+  TEST_SINGLE(nmatch(SubRegSize::i8Bit, PReg::p8, PReg::p6.Zeroing(), ZReg::z30, ZReg::z29),
+              "nmatch p8.b, p6/z, z30.b, z29.b");
+  TEST_SINGLE(nmatch(SubRegSize::i16Bit, PReg::p8, PReg::p6.Zeroing(), ZReg::z30, ZReg::z29),
+              "nmatch p8.h, p6/z, z30.h, z29.h");
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE floating-point convert precision odd elements") {
   TEST_SINGLE(fcvtxnt(ZReg::z30, PReg::p6.Merging(), ZReg::z29), "fcvtxnt z30.s, p6/m, z29.d");

--- a/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
+++ b/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
@@ -41,7 +41,6 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: Base Encodings") {
   //TEST_SINGLE(mov(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "mov z30.q, p6/m, z29.q");
 
   // TODO: FCMLA
-  // TODO: FCADD
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE integer add/subtract vectors (unpredicated)") {
   TEST_SINGLE(add(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28),   "add z30.b, z29.b, z28.b");
@@ -295,6 +294,21 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 floating-point pairwise o
   TEST_SINGLE(fmin(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fmin z30.s, p6/m, z30.s, z28.s");
   TEST_SINGLE(fmin(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28),  "fmin z30.d, p6/m, z30.d, z28.d");
   //TEST_SINGLE(fmin(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28), "fmin z30.q, p6/m, z30.q, z28.q");
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE floating-point complex add") {
+  TEST_SINGLE(fcadd(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28, Rotation::ROTATE_90),
+              "fcadd z30.h, p6/m, z30.h, z28.h, #90");
+  TEST_SINGLE(fcadd(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28, Rotation::ROTATE_90),
+              "fcadd z30.s, p6/m, z30.s, z28.s, #90");
+  TEST_SINGLE(fcadd(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28, Rotation::ROTATE_90),
+              "fcadd z30.d, p6/m, z30.d, z28.d, #90");
+
+  TEST_SINGLE(fcadd(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28, Rotation::ROTATE_270),
+              "fcadd z30.h, p6/m, z30.h, z28.h, #270");
+  TEST_SINGLE(fcadd(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28, Rotation::ROTATE_270),
+              "fcadd z30.s, p6/m, z30.s, z28.s, #270");
+  TEST_SINGLE(fcadd(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28, Rotation::ROTATE_270),
+              "fcadd z30.d, p6/m, z30.d, z28.d, #270");
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE floating-point multiply-add (indexed)") {
   // TODO: Implement in emitter.
@@ -1687,7 +1701,7 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 Histogram Computation") {
   TEST_SINGLE(histcnt(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29, ZReg::z28),  "histcnt z30.d, p6/z, z29.d, z28.d");
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 Histogram Computation - Segment") {
-  // TODO: Implement in emitter.
+  TEST_SINGLE(histseg(ZReg::z30, ZReg::z29, ZReg::z28), "histseg z30.b, z29.b, z28.b");
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 crypto unary operations") {
   // TODO: Implement in emitter.

--- a/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
+++ b/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
@@ -39,8 +39,6 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: Base Encodings") {
   TEST_SINGLE(mov(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "mov z30.s, p6/m, z29.s");
   TEST_SINGLE(mov(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "mov z30.d, p6/m, z29.d");
   //TEST_SINGLE(mov(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "mov z30.q, p6/m, z29.q");
-
-  // TODO: FCMLA
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE integer add/subtract vectors (unpredicated)") {
   TEST_SINGLE(add(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28),   "add z30.b, z29.b, z28.b");
@@ -310,11 +308,57 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE floating-point complex add
   TEST_SINGLE(fcadd(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28, Rotation::ROTATE_270),
               "fcadd z30.d, p6/m, z30.d, z28.d, #270");
 }
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE floating-point multiply-add (vector)") {
+  TEST_SINGLE(fcmla(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z10, ZReg::z28, Rotation::ROTATE_0),
+              "fcmla z30.h, p6/m, z10.h, z28.h, #0");
+  TEST_SINGLE(fcmla(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z10, ZReg::z28, Rotation::ROTATE_0),
+              "fcmla z30.s, p6/m, z10.s, z28.s, #0");
+  TEST_SINGLE(fcmla(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z10, ZReg::z28, Rotation::ROTATE_0),
+              "fcmla z30.d, p6/m, z10.d, z28.d, #0");
+
+  TEST_SINGLE(fcmla(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z10, ZReg::z28, Rotation::ROTATE_90),
+              "fcmla z30.h, p6/m, z10.h, z28.h, #90");
+  TEST_SINGLE(fcmla(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z10, ZReg::z28, Rotation::ROTATE_90),
+              "fcmla z30.s, p6/m, z10.s, z28.s, #90");
+  TEST_SINGLE(fcmla(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z10, ZReg::z28, Rotation::ROTATE_90),
+              "fcmla z30.d, p6/m, z10.d, z28.d, #90");
+
+  TEST_SINGLE(fcmla(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z10, ZReg::z28, Rotation::ROTATE_180),
+              "fcmla z30.h, p6/m, z10.h, z28.h, #180");
+  TEST_SINGLE(fcmla(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z10, ZReg::z28, Rotation::ROTATE_180),
+              "fcmla z30.s, p6/m, z10.s, z28.s, #180");
+  TEST_SINGLE(fcmla(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z10, ZReg::z28, Rotation::ROTATE_180),
+              "fcmla z30.d, p6/m, z10.d, z28.d, #180");
+
+  TEST_SINGLE(fcmla(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z10, ZReg::z28, Rotation::ROTATE_270),
+              "fcmla z30.h, p6/m, z10.h, z28.h, #270");
+  TEST_SINGLE(fcmla(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z10, ZReg::z28, Rotation::ROTATE_270),
+              "fcmla z30.s, p6/m, z10.s, z28.s, #270");
+  TEST_SINGLE(fcmla(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z10, ZReg::z28, Rotation::ROTATE_270),
+              "fcmla z30.d, p6/m, z10.d, z28.d, #270");
+}
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE floating-point multiply-add (indexed)") {
   // TODO: Implement in emitter.
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE floating-point complex multiply-add (indexed)") {
-  // TODO: Implement in emitter.
+  TEST_SINGLE(fcmla(SubRegSize::i16Bit, ZReg::z30, ZReg::z10, ZReg::z7, 0, Rotation::ROTATE_0),
+              "fcmla z30.h, z10.h, z7.h[0], #0");
+  TEST_SINGLE(fcmla(SubRegSize::i32Bit, ZReg::z30, ZReg::z10, ZReg::z15, 0, Rotation::ROTATE_0),
+              "fcmla z30.s, z10.s, z15.s[0], #0");
+
+  TEST_SINGLE(fcmla(SubRegSize::i16Bit, ZReg::z30, ZReg::z10, ZReg::z7, 1, Rotation::ROTATE_90),
+              "fcmla z30.h, z10.h, z7.h[1], #90");
+  TEST_SINGLE(fcmla(SubRegSize::i32Bit, ZReg::z30, ZReg::z10, ZReg::z15, 1, Rotation::ROTATE_90),
+              "fcmla z30.s, z10.s, z15.s[1], #90");
+  TEST_SINGLE(fcmla(SubRegSize::i32Bit, ZReg::z30, ZReg::z10, ZReg::z15, 1, Rotation::ROTATE_180),
+              "fcmla z30.s, z10.s, z15.s[1], #180");
+  TEST_SINGLE(fcmla(SubRegSize::i32Bit, ZReg::z30, ZReg::z10, ZReg::z15, 1, Rotation::ROTATE_270),
+              "fcmla z30.s, z10.s, z15.s[1], #270");
+
+  TEST_SINGLE(fcmla(SubRegSize::i16Bit, ZReg::z30, ZReg::z10, ZReg::z7, 2, Rotation::ROTATE_180),
+              "fcmla z30.h, z10.h, z7.h[2], #180");
+  TEST_SINGLE(fcmla(SubRegSize::i16Bit, ZReg::z30, ZReg::z10, ZReg::z7, 3, Rotation::ROTATE_270),
+              "fcmla z30.h, z10.h, z7.h[3], #270");
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE floating-point multiply (indexed)") {
   // TODO: Implement in emitter.

--- a/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
+++ b/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
@@ -40,7 +40,6 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: Base Encodings") {
   TEST_SINGLE(mov(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29),  "mov z30.d, p6/m, z29.d");
   //TEST_SINGLE(mov(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29), "mov z30.q, p6/m, z29.q");
 
-  // TODO: HISTCNT
   // TODO: FCMLA
   // TODO: FCADD
 }
@@ -1682,6 +1681,10 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 bitwise shift right narro
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 integer add/subtract narrow high part") {
   // TODO: Implement in emitter.
+}
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 Histogram Computation") {
+  TEST_SINGLE(histcnt(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29, ZReg::z28),  "histcnt z30.s, p6/z, z29.s, z28.s");
+  TEST_SINGLE(histcnt(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z29, ZReg::z28),  "histcnt z30.d, p6/z, z29.d, z28.d");
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 Histogram Computation - Segment") {
   // TODO: Implement in emitter.

--- a/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
+++ b/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
@@ -241,7 +241,10 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE integer clamp") {
   // TODO: Implement in emitter.
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 character match") {
-  // TODO: Implement in emitter.
+  TEST_SINGLE(match(SubRegSize::i8Bit, PReg::p8, PReg::p6.Zeroing(), ZReg::z30, ZReg::z29),
+              "match p8.b, p6/z, z30.b, z29.b");
+  TEST_SINGLE(match(SubRegSize::i16Bit, PReg::p8, PReg::p6.Zeroing(), ZReg::z30, ZReg::z29),
+              "match p8.h, p6/z, z30.h, z29.h");
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE floating-point convert precision odd elements") {
   TEST_SINGLE(fcvtxnt(ZReg::z30, PReg::p6.Merging(), ZReg::z29), "fcvtxnt z30.s, p6/m, z29.d");


### PR DESCRIPTION
Adds HISTCNT/HISTSEG FCADD/FCMLA and MATCH/NMATCH

Knocks out a few TODOs