### PR TITLE
FEXServer: Remove POLLREMOVE usage

### DIFF
--- a/Source/Tools/FEXServer/ProcessPipe.cpp
+++ b/Source/Tools/FEXServer/ProcessPipe.cpp
@@ -474,7 +474,7 @@ namespace ProcessPipe {
                 // Add the new client to the temporary array
                 NewPollFDs.emplace_back(pollfd {
                   .fd = NewFD,
-                  .events = POLLIN | POLLPRI | POLLRDHUP | POLLREMOVE,
+                  .events = POLLIN | POLLPRI | POLLRDHUP,
                   .revents = 0,
                 });
               }


### PR DESCRIPTION
Fixes this file compiling on musl at least.

POLLREMOVE usage here is technically incorrect as it shouldn't be OR'd with other flags.
But it is also additionally wrong here because the Linux kernel doesn't even support this flag anymore, so it doesn't change behaviour.