### PR TITLE
ARMEmitter: Handle ADDVL/ADDPL and RDVL

### DIFF
--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
@@ -1354,11 +1354,17 @@ public:
     SVEStackFrameOperation(0b01, rd, rn, imm);
   }
 
-  // Streaming SVE stack frame adjustment
+  // Streaming SVE stack frame adjustment (SME)
   // XXX:
+
   // SVE stack frame size
-  // XXX:
-  // Streaming SVE stack frame size
+  void rdvl(XRegister rd, int32_t imm) {
+    // Would-be Rn field is just set to all 1's, which is the same
+    // as writing the encoding for the SP into it.
+    SVEStackFrameOperation(0b10, rd, XReg::rsp, imm);
+  }
+
+  // Streaming SVE stack frame size (SME)
   // XXX:
 
   // SVE2 Integer Multiply - Unpredicated

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
@@ -1350,6 +1350,9 @@ public:
   void addvl(XRegister rd, XRegister rn, int32_t imm) {
     SVEStackFrameOperation(0b00, rd, rn, imm);
   }
+  void addpl(XRegister rd, XRegister rn, int32_t imm) {
+    SVEStackFrameOperation(0b01, rd, rn, imm);
+  }
 
   // Streaming SVE stack frame adjustment
   // XXX:

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
@@ -1347,7 +1347,10 @@ public:
 
   // SVE Stack Allocation
   // SVE stack frame adjustment
-  // XXX:
+  void addvl(XRegister rd, XRegister rn, int32_t imm) {
+    SVEStackFrameOperation(0b00, rd, rn, imm);
+  }
+
   // Streaming SVE stack frame adjustment
   // XXX:
   // SVE stack frame size
@@ -4081,6 +4084,18 @@ private:
     Instr |= pg.Idx() << 10;
     Instr |= zn.Idx() << 5;
     Instr |= zd.Idx();
+    dc32(Instr);
+  }
+
+  void SVEStackFrameOperation(uint32_t opc, XRegister rd, XRegister rn, int32_t imm) {
+    LOGMAN_THROW_AA_FMT(imm >= -32 && imm <= 31,
+                        "Stack frame operation immediate must be within -32 to 31");
+
+    uint32_t Instr = 0b0000'0100'0010'0000'0101'0000'0000'0000;
+    Instr |= opc << 22;
+    Instr |= rn.Idx() << 16;
+    Instr |= (static_cast<uint32_t>(imm) & 0b111111) << 5;
+    Instr |= rd.Idx();
     dc32(Instr);
   }
 

--- a/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
+++ b/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
@@ -901,7 +901,9 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: Streaming SVE stack frame adju
   // TODO: Implement in emitter.
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE stack frame size") {
-  // TODO: Implement in emitter.
+  TEST_SINGLE(rdvl(XReg::x30, -32), "rdvl x30, #-32");
+  TEST_SINGLE(rdvl(XReg::x30, 31),  "rdvl x30, #31");
+  TEST_SINGLE(rdvl(XReg::x30, 15),  "rdvl x30, #15");
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: Streaming SVE stack frame size") {
   // TODO: Implement in emitter.

--- a/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
+++ b/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
@@ -889,7 +889,9 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE Index Generation") {
   // TODO: Implement in emitter.
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE stack frame adjustment") {
-  // TODO: Implement in emitter.
+  TEST_SINGLE(addvl(XReg::rsp, XReg::rsp, -32), "addvl sp, sp, #-32");
+  TEST_SINGLE(addvl(XReg::rsp, XReg::rsp, 31), "addvl sp, sp, #31");
+  TEST_SINGLE(addvl(XReg::x30, XReg::x29, 15), "addvl x30, x29, #15");
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: Streaming SVE stack frame adjustment") {
   // TODO: Implement in emitter.

--- a/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
+++ b/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
@@ -890,8 +890,12 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE Index Generation") {
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE stack frame adjustment") {
   TEST_SINGLE(addvl(XReg::rsp, XReg::rsp, -32), "addvl sp, sp, #-32");
-  TEST_SINGLE(addvl(XReg::rsp, XReg::rsp, 31), "addvl sp, sp, #31");
-  TEST_SINGLE(addvl(XReg::x30, XReg::x29, 15), "addvl x30, x29, #15");
+  TEST_SINGLE(addvl(XReg::rsp, XReg::rsp, 31),  "addvl sp, sp, #31");
+  TEST_SINGLE(addvl(XReg::x30, XReg::x29, 15),  "addvl x30, x29, #15");
+
+  TEST_SINGLE(addpl(XReg::rsp, XReg::rsp, -32), "addpl sp, sp, #-32");
+  TEST_SINGLE(addpl(XReg::rsp, XReg::rsp, 31),  "addpl sp, sp, #31");
+  TEST_SINGLE(addpl(XReg::x30, XReg::x29, 15),  "addpl x30, x29, #15");
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: Streaming SVE stack frame adjustment") {
   // TODO: Implement in emitter.


### PR DESCRIPTION
Knocks out the relevant stack management functions. The other variants are SME only