### PR TITLE
ELFCodeLoader: Adds an option to inject libSegFault

### DIFF
--- a/External/FEXCore/Source/Interface/Config/Config.json.in
+++ b/External/FEXCore/Source/Interface/Config/Config.json.in
@@ -240,6 +240,17 @@
           "Also needs x86_64-linux-gnu-objdump in PATH.",
           "Can be very slow."
         ]
+      },
+      "InjectLibSegFault": {
+        "Type": "bool",
+        "Default": "false",
+        "Desc": [
+          "Sets the environment variable LD_PRELOAD=libSegFault.so",
+          "This allows the user to very easily enable libSegFault without dealing with environment variables",
+          "Very useful for applications that have launch scripts that set the variable to nothing at launch",
+          "Set this in an application configuration for injecting in to only specific applications.",
+          "\tNote: If x86/x86_64 libSegFault.so isn't installed then this option won't work."
+        ]
       }
     },
     "Logging": {

--- a/Source/Tests/ELFCodeLoader2.h
+++ b/Source/Tests/ELFCodeLoader2.h
@@ -316,6 +316,10 @@ class ELFCodeLoader2 final : public FEXCore::CodeLoader {
       }
     }
 
+    if (InjectLibSegFault()) {
+      EnvironmentVariables.emplace_back("LD_PRELOAD=libSegFault.so");
+    }
+
     // Calculate argument and envp backing sizes
     for (unsigned i = 0; i < Args.size(); ++i) {
       ArgumentBackingSize += Args[i].size() + 1;
@@ -922,4 +926,6 @@ class ELFCodeLoader2 final : public FEXCore::CodeLoader {
   static constexpr size_t platform_string_max_size = std::max(platform_name_x86_64.size(), platform_name_i686.size()) + 1;
 
   FEX_CONFIG_OPT(AdditionalArguments, ADDITIONALARGUMENTS);
+  FEX_CONFIG_OPT(InjectLibSegFault, INJECTLIBSEGFAULT);
+
 };


### PR DESCRIPTION
When used in conjuction with #2345 this is a useful way to enable libSegFault in applications using application profiles.

Very useful for applications and games that use launcher scripts that set LD_PRELOAD to nothing prior to launch.

A user was wanting this.