### PR TITLE
Core: Support Data in JIT buffer header

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -1002,7 +1002,10 @@ namespace FEXCore::Context {
     }
     // Attempt to get the CPU backend to compile this code
     return {
-      .CompiledCode = Thread->CPUBackend->CompileCode(GuestRIP, IRList, DebugData, RAData.get(), GetGdbServerStatus()),
+      // FEX currently throws away the CPUBackend::CompiledCode object other than the entrypoint
+      // In the future with code caching getting wired up, we will pass the rest of the data forward.
+      // TODO: Pass the data forward when code caching is wired up to this.
+      .CompiledCode = Thread->CPUBackend->CompileCode(GuestRIP, IRList, DebugData, RAData.get(), GetGdbServerStatus()).BlockEntry,
       .IRData = IRList,
       .DebugData = DebugData,
       .RAData = std::move(RAData),

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterClass.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterClass.h
@@ -26,7 +26,7 @@ public:
 
   [[nodiscard]] std::string GetName() override { return "Interpreter"; }
 
-  [[nodiscard]] void *CompileCode(uint64_t Entry,
+  [[nodiscard]] CPUBackend::CompiledCode CompileCode(uint64_t Entry,
                                   FEXCore::IR::IRListView const *IR,
                                   FEXCore::Core::DebugData *DebugData,
                                   FEXCore::IR::RegisterAllocationData *RAData, bool GDBEnabled) override;

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/Arm64Relocations.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/Arm64Relocations.cpp
@@ -27,7 +27,7 @@ void Arm64JITCore::InsertNamedThunkRelocation(ARMEmitter::Register Reg, const IR
   MoveABI.NamedThunkMove.Header.Type = FEXCore::CPU::RelocationTypes::RELOC_NAMED_THUNK_MOVE;
   // Offset is the offset from the entrypoint of the block
   auto CurrentCursor = GetCursorAddress<uint8_t *>();
-  MoveABI.NamedThunkMove.Offset = CurrentCursor - GuestEntry;
+  MoveABI.NamedThunkMove.Offset = CurrentCursor - CodeData.BlockBegin;
   MoveABI.NamedThunkMove.Symbol = Sum;
   MoveABI.NamedThunkMove.RegisterIndex = Reg.Idx();
 
@@ -58,7 +58,7 @@ Arm64JITCore::NamedSymbolLiteralPair Arm64JITCore::InsertNamedSymbolLiteral(FEXC
 void Arm64JITCore::PlaceNamedSymbolLiteral(NamedSymbolLiteralPair &Lit) {
   // Offset is the offset from the entrypoint of the block
   auto CurrentCursor = GetCursorAddress<uint8_t *>();
-  Lit.MoveABI.NamedSymbolLiteral.Offset = CurrentCursor - GuestEntry;
+  Lit.MoveABI.NamedSymbolLiteral.Offset = CurrentCursor - CodeData.BlockBegin;
 
   Bind(&Lit.Loc);
   dc64(Lit.Lit);
@@ -70,7 +70,7 @@ void Arm64JITCore::InsertGuestRIPMove(ARMEmitter::Register Reg, uint64_t Constan
   MoveABI.GuestRIPMove.Header.Type = FEXCore::CPU::RelocationTypes::RELOC_GUEST_RIP_MOVE;
   // Offset is the offset from the entrypoint of the block
   auto CurrentCursor = GetCursorAddress<uint8_t *>();
-  MoveABI.GuestRIPMove.Offset = CurrentCursor - GuestEntry;
+  MoveABI.GuestRIPMove.Offset = CurrentCursor - CodeData.BlockBegin;
   MoveABI.GuestRIPMove.GuestRIP = Constant;
   MoveABI.GuestRIPMove.RegisterIndex = Reg.Idx();
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -37,7 +37,7 @@ public:
 
   [[nodiscard]] std::string GetName() override { return "JIT"; }
 
-  [[nodiscard]] void *CompileCode(uint64_t Entry,
+  [[nodiscard]] CPUBackend::CompiledCode CompileCode(uint64_t Entry,
                                   FEXCore::IR::IRListView const *IR,
                                   FEXCore::Core::DebugData *DebugData,
                                   FEXCore::IR::RegisterAllocationData *RAData, bool GDBEnabled) override;
@@ -60,6 +60,7 @@ private:
   FEXCore::Context::Context *CTX;
   FEXCore::IR::IRListView const *IR;
   uint64_t Entry;
+  CPUBackend::CompiledCode CodeData{};
 
   std::map<IR::NodeID, ARMEmitter::BiDirectionalLabel> JumpTargets;
 
@@ -230,11 +231,6 @@ private:
   /**  @} */
 
   uint32_t SpillSlots{};
-  /**
-  * @brief Current guest RIP entrypoint
-  */
-  uint8_t *GuestEntry{};
-
 #define DEF_OP(x) void Op_##x(IR::IROp_Header const *IROp, IR::NodeID Node)
 
   ///< Unhandled handler

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
@@ -15,7 +15,7 @@ namespace FEXCore::CPU {
 DEF_OP(GuestOpcode) {
   auto Op = IROp->C<IR::IROp_GuestOpcode>();
   // metadata
-  DebugData->GuestOpcodes.push_back({Op->GuestEntryOffset, GetCursorAddress<uint8_t*>() - GuestEntry});
+  DebugData->GuestOpcodes.push_back({Op->GuestEntryOffset, GetCursorAddress<uint8_t*>() - CodeData.BlockBegin});
 }
 
 DEF_OP(Fence) {

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -57,7 +57,7 @@ public:
 
   [[nodiscard]] std::string GetName() override { return "JIT"; }
 
-  [[nodiscard]] void *CompileCode(uint64_t Entry,
+  [[nodiscard]] CPUBackend::CompiledCode CompileCode(uint64_t Entry,
                                   FEXCore::IR::IRListView const *IR,
                                   FEXCore::Core::DebugData *DebugData,
                                   FEXCore::IR::RegisterAllocationData *RAData, bool GDBEnabled) override;
@@ -138,6 +138,7 @@ private:
   FEXCore::Context::Context *CTX;
   FEXCore::IR::IRListView const *IR;
   uint64_t Entry;
+  CPUBackend::CompiledCode CodeData{};
 
   std::unordered_map<IR::NodeID, Label> JumpTargets;
   Xbyak::util::Cpu Features{};
@@ -205,10 +206,6 @@ private:
   void EmitDetectionString();
 
   uint32_t SpillSlots{};
-  /**
-  * @brief Current guest RIP entrypoint
-  */
-  uint8_t *GuestEntry{};
 
   using SetCC = void (X86JITCore::*)(const Operand& op);
   using CMovCC = void (X86JITCore::*)(const Reg& reg, const Operand& op);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/MiscOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/MiscOps.cpp
@@ -24,7 +24,7 @@ namespace FEXCore::CPU {
 DEF_OP(GuestOpcode) {
   auto Op = IROp->C<IR::IROp_GuestOpcode>();
   // metadata
-  DebugData->GuestOpcodes.push_back({Op->GuestEntryOffset, getCurr<uint8_t*>() - GuestEntry});
+  DebugData->GuestOpcodes.push_back({Op->GuestEntryOffset, getCurr<uint8_t*>() - CodeData.BlockBegin});
 }
 
 DEF_OP(Fence) {

--- a/External/FEXCore/include/FEXCore/Core/CPUBackend.h
+++ b/External/FEXCore/include/FEXCore/Core/CPUBackend.h
@@ -36,7 +36,7 @@ namespace CPU {
   struct CPUBackendFeatures {
     bool SupportsStaticRegisterAllocation = false;
   };
-  
+
   class CPUBackend {
   public:
     struct CodeBuffer {
@@ -55,6 +55,23 @@ namespace CPU {
      * @return The name of this backend
      */
     [[nodiscard]] virtual std::string GetName() = 0;
+
+    struct CompiledCode {
+      // Where this code block begins.
+      uint8_t* BlockBegin;
+      /**
+       * The function entrypoint to this codeblock.
+       *
+       * This may or may not equal `BlockBegin` above. Depending on the CPU backend, it may stick data
+       * prior to the BlockEntry.
+       *
+       * Is actually a function pointer of type `void (FEXCore::Core::ThreadState *Thread)`
+       */
+      uint8_t* BlockEntry;
+      // The total size of the codeblock from [BlockBegin, BlockBegin+Size).
+      size_t Size;
+    };
+
     /**
      * @brief Tells this CPUBackend to compile code for the provided IR and DebugData
      *
@@ -69,10 +86,9 @@ namespace CPU {
      * @param IR -  IR that maps to the IR for this RIP
      * @param DebugData - Debug data that is available for this IR indirectly
      *
-     * @return An executable function pointer that is theoretically compiled from this point.
-     * Is actually a function pointer of type `void (FEXCore::Core::ThreadState *Thread)
+     * @return Information about the compiled code block.
      */
-    [[nodiscard]] virtual void *CompileCode(uint64_t Entry,
+    [[nodiscard]] virtual CompiledCode CompileCode(uint64_t Entry,
                                             FEXCore::IR::IRListView const *IR,
                                             FEXCore::Core::DebugData *DebugData,
                                             FEXCore::IR::RegisterAllocationData *RAData, bool GDBEnabled) = 0;


### PR DESCRIPTION
Currently unused (The full data gets thrown away after CompileCode is called), but allows us to separate code and data in what `CompileCode` returns.

This will allow us put a header on JIT blocks which will fix a long outstanding bug where RIP isn't always synchronized on block entry, but since it only needs to synchronize on signal we can rebuild in the handler. This future task will remove the `86dec_SynchronizeRIPOnAllBlocks` config option, but the data will also end up being used for more things in the future.