### PR TITLE
Syscalls: Renamed fstatat64 to fstatat_64

### DIFF
--- a/Scripts/GenerateSyscallNumbers.py
+++ b/Scripts/GenerateSyscallNumbers.py
@@ -66,6 +66,9 @@ DefinitionRenameDict = {
     "shmctl": "_shmctl",
     "shmat": "_shmat",
     "shmdt": "_shmdt",
+    # musl/Alpine Linux defines `fstatat64` as a define that points to `fstatat`.
+    # Rename it to avoid global define conflicts.
+    "fstatat64": "fstatat_64",
 }
 
 Definitions_x64 = []

--- a/Source/Tests/LinuxSyscalls/Arm64/SyscallsEnum.h
+++ b/Source/Tests/LinuxSyscalls/Arm64/SyscallsEnum.h
@@ -454,7 +454,7 @@ enum Syscalls_Arm64 {
   SYSCALL_Arm64_vserver = ~0,
   SYSCALL_Arm64_inotify_init = ~0,
   SYSCALL_Arm64_futimesat = ~0,
-  SYSCALL_Arm64_fstatat64 = ~0,
+  SYSCALL_Arm64_fstatat_64 = ~0,
   SYSCALL_Arm64_signalfd = ~0,
   SYSCALL_Arm64_eventfd = ~0,
   SYSCALL_Arm64_arch_prctl = ~0,

--- a/Source/Tests/LinuxSyscalls/x32/FD.cpp
+++ b/Source/Tests/LinuxSyscalls/x32/FD.cpp
@@ -571,7 +571,7 @@ namespace FEX::HLE::x32 {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_X32(fstatat64, [](FEXCore::Core::CpuStateFrame *Frame, int dirfd, const char *pathname, stat64_32 *buf, int flag) -> uint64_t {
+    REGISTER_SYSCALL_IMPL_X32(fstatat_64, [](FEXCore::Core::CpuStateFrame *Frame, int dirfd, const char *pathname, stat64_32 *buf, int flag) -> uint64_t {
       struct stat64 host_stat;
       uint64_t Result = FEX::HLE::_SyscallHandler->FM.NewFSStatAt64(dirfd, pathname, &host_stat, flag);
       if (Result != -1) {

--- a/Source/Tests/LinuxSyscalls/x32/SyscallsEnum.h
+++ b/Source/Tests/LinuxSyscalls/x32/SyscallsEnum.h
@@ -321,7 +321,7 @@ enum Syscalls_x86 {
   SYSCALL_x86_mknodat = 297,
   SYSCALL_x86_fchownat = 298,
   SYSCALL_x86_futimesat = 299,
-  SYSCALL_x86_fstatat64 = 300,
+  SYSCALL_x86_fstatat_64 = 300,
   SYSCALL_x86_unlinkat = 301,
   SYSCALL_x86_renameat = 302,
   SYSCALL_x86_linkat = 303,

--- a/Source/Tests/LinuxSyscalls/x64/SyscallsEnum.h
+++ b/Source/Tests/LinuxSyscalls/x64/SyscallsEnum.h
@@ -453,7 +453,7 @@ enum Syscalls_x64 {
   SYSCALL_x64_statfs64 = ~0,
   SYSCALL_x64_fstatfs64 = ~0,
   SYSCALL_x64_fadvise64_64 = ~0,
-  SYSCALL_x64_fstatat64 = ~0,
+  SYSCALL_x64_fstatat_64 = ~0,
   SYSCALL_x64_clock_gettime64 = ~0,
   SYSCALL_x64_clock_settime64 = ~0,
   SYSCALL_x64_clock_adjtime64 = ~0,


### PR DESCRIPTION
Similar to our other syscall conflicts, musl/Alpine Linux has a global define that is conflicting with our name here