### PR TITLE
VectorOps: Only use VBSL 256-bit path if SVE is present

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
@@ -964,7 +964,9 @@ DEF_OP(VUnZip) {
 }
 
 DEF_OP(VBSL) {
-  auto Op = IROp->C<IR::IROp_VBSL>();
+  const auto Op = IROp->C<IR::IROp_VBSL>();
+  const auto OpSize = IROp->Size;
+
   const auto Src1 = *GetSrc<InterpVector256*>(Data->SSAData, Op->VectorMask);
   const auto Src2 = *GetSrc<InterpVector256*>(Data->SSAData, Op->VectorTrue);
   const auto Src3 = *GetSrc<InterpVector256*>(Data->SSAData, Op->VectorFalse);
@@ -974,7 +976,8 @@ DEF_OP(VBSL) {
     .Upper = (Src2.Upper & Src1.Upper) | (Src3.Upper & ~Src1.Upper),
   };
 
-  memcpy(GDP, &Tmp, sizeof(Tmp));
+  memset(GDP, 0, sizeof(InterpVector256));
+  memcpy(GDP, &Tmp, OpSize);
 }
 
 DEF_OP(VCMPEQ) {

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -1414,13 +1414,14 @@ DEF_OP(VUnZip2) {
 DEF_OP(VBSL) {
   const auto Op = IROp->C<IR::IROp_VBSL>();
   const auto OpSize = IROp->Size;
+  const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
   const auto Dst = GetVReg(Node);
   const auto VectorFalse = GetVReg(Op->VectorFalse.ID());
   const auto VectorTrue = GetVReg(Op->VectorTrue.ID());
   const auto VectorMask = GetVReg(Op->VectorMask.ID());
 
-  if (HostSupportsSVE) {
+  if (HostSupportsSVE && Is256Bit) {
     // NOTE: Slight parameter difference from ASIMD
     //       ASIMD -> BSL Mask, True, False
     //       SVE   -> BSL True, True, False, Mask

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -3447,8 +3447,6 @@ void OpDispatchBuilder::VectorVariableBlend<8>(OpcodeArgs);
 template <size_t ElementSize>
 void OpDispatchBuilder::AVXVectorVariableBlend(OpcodeArgs) {
   const auto SrcSize = GetSrcSize(Op);
-  const auto Is128Bit = SrcSize == Core::CPUState::XMM_SSE_REG_SIZE;
-
   constexpr auto ElementSizeBits = ElementSize * 8;
 
   OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
@@ -3462,9 +3460,6 @@ void OpDispatchBuilder::AVXVectorVariableBlend(OpcodeArgs) {
 
   OrderedNode *Shifted = _VSShrI(SrcSize, ElementSize, Mask, ElementSizeBits - 1);
   OrderedNode *Result = _VBSL(SrcSize, Shifted, Src2, Src1);
-  if (Is128Bit) {
-    Result = _VMov(16, Result);
-  }
   StoreResult(FPRClass, Op, Result, -1);
 }
 template


### PR DESCRIPTION
With this in place, a _VMov isn't necessary for variable blends anymore, since the vector upper lanes are guaranteed to be zeroed out in the 128-bit case.