### PR TITLE
Arm64/VectorOps: Use movprfx with VBSL

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -1425,7 +1425,7 @@ DEF_OP(VBSL) {
     // NOTE: Slight parameter difference from ASIMD
     //       ASIMD -> BSL Mask, True, False
     //       SVE   -> BSL True, True, False, Mask
-    mov(VTMP1.Z(), VectorTrue.Z());
+    movprfx(VTMP1.Z(), VectorTrue.Z());
     bsl(VTMP1.Z(), VTMP1.Z(), VectorFalse.Z(), VectorMask.Z());
     mov(Dst.Z(), VTMP1.Z());
   } else {


### PR DESCRIPTION
We can use movprfx here to allow compressing the move and bsl operation together on cpus that can handle it.

Noticed after #2386 was merged