### PR TITLE
ARMEmitter: Handle CPY (scalar) and CPY (SIMD&FP, scalar)

### DIFF
--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
@@ -2078,9 +2078,6 @@ public:
   // SVE2 integer add/subtract narrow high part
   // XXX:
   //
-  // SVE2 Histogram Computation - Segment
-  // XXX:
-  //
   // SVE2 Crypto Extensions
   // SVE2 crypto unary operations
   // XXX:

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
@@ -1314,7 +1314,19 @@ public:
     Instr |= zd.Idx();
     dc32(Instr);
   }
-  // XXX: CPY (scalar)
+
+  // CPY (scalar)
+  void cpy(SubRegSize size, ZRegister zd, PRegisterMerge pg, WRegister rn) {
+    LOGMAN_THROW_A_FMT(pg <= PReg::p7, "cpy can only use p0-p7 as a governing predicate");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit element size");
+
+    uint32_t Instr = 0b0000'0101'0010'1000'1010'0000'0000'0000;
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= pg.Idx() << 10;
+    Instr |= rn.Idx() << 5;
+    Instr |= zd.Idx();
+    dc32(Instr);
+  }
 
   template<FEXCore::ARMEmitter::OpType optype>
   requires(optype == FEXCore::ARMEmitter::OpType::Constructive)

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
@@ -1292,7 +1292,19 @@ public:
   // XXX:
 
   // SVE Permute Vector - Predicated - Base
-  // XXX: CPY (SIMD&FP scalar)
+  // CPY (SIMD&FP scalar)
+  void cpy(SubRegSize size, ZRegister zd, PRegisterMerge pg, VRegister vn) {
+    LOGMAN_THROW_A_FMT(pg <= PReg::p7, "cpy can only use p0-p7 as a governing predicate");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit element size");
+
+    uint32_t Instr = 0b0000'0101'0010'0000'1000'0000'0000'0000;
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= pg.Idx() << 10;
+    Instr |= vn.Idx() << 5;
+    Instr |= zd.Idx();
+    dc32(Instr);
+  }
+
   void compact(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::ZRegister zn) {
     LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::SubRegSize::i64Bit ||
       size == FEXCore::ARMEmitter::SubRegSize::i32Bit, "Invalid size");

--- a/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
+++ b/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
@@ -1094,7 +1094,12 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE permute predicate elements
 }
 
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE Permute Vector - Predicated - Base") {
-  // XXX: CPY (SIMD&FP scalar)
+  // CPY (SIMD&FP scalar)
+  TEST_SINGLE(cpy(SubRegSize::i8Bit,  ZReg::z30, PReg::p7.Merging(), VReg::v30), "mov z30.b, p7/m, b30");
+  TEST_SINGLE(cpy(SubRegSize::i16Bit, ZReg::z30, PReg::p7.Merging(), VReg::v30), "mov z30.h, p7/m, h30");
+  TEST_SINGLE(cpy(SubRegSize::i32Bit, ZReg::z30, PReg::p7.Merging(), VReg::v30), "mov z30.s, p7/m, s30");
+  TEST_SINGLE(cpy(SubRegSize::i64Bit, ZReg::z30, PReg::p7.Merging(), VReg::v30), "mov z30.d, p7/m, d30");
+
   //TEST_SINGLE(compact(SubRegSize::i8Bit, ZReg::z30, PReg::p6, ZReg::z29),   "compact z30.b, p6, z29.b");
   //TEST_SINGLE(compact(SubRegSize::i16Bit, ZReg::z30, PReg::p6, ZReg::z29),  "compact z30.h, p6, z29.h");
   TEST_SINGLE(compact(SubRegSize::i32Bit, ZReg::z30, PReg::p6, ZReg::z29),  "compact z30.s, p6, z29.s");

--- a/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
+++ b/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
@@ -1100,7 +1100,12 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE Permute Vector - Predicate
   TEST_SINGLE(compact(SubRegSize::i32Bit, ZReg::z30, PReg::p6, ZReg::z29),  "compact z30.s, p6, z29.s");
   TEST_SINGLE(compact(SubRegSize::i64Bit, ZReg::z30, PReg::p6, ZReg::z29),  "compact z30.d, p6, z29.d");
   //TEST_SINGLE(compact(SubRegSize::i128Bit, ZReg::z30, PReg::p6, ZReg::z29), "compact z30.q, p6, z29.q");
-  // XXX: CPY (scalar)
+
+  // CPY (scalar)
+  TEST_SINGLE(cpy(SubRegSize::i8Bit,  ZReg::z30, PReg::p7.Merging(), WReg::rsp), "mov z30.b, p7/m, wsp");
+  TEST_SINGLE(cpy(SubRegSize::i16Bit, ZReg::z30, PReg::p7.Merging(), WReg::rsp), "mov z30.h, p7/m, wsp");
+  TEST_SINGLE(cpy(SubRegSize::i32Bit, ZReg::z30, PReg::p7.Merging(), WReg::rsp), "mov z30.s, p7/m, wsp");
+  TEST_SINGLE(cpy(SubRegSize::i64Bit, ZReg::z30, PReg::p7.Merging(), XReg::rsp), "mov z30.d, p7/m, sp");
 
   TEST_SINGLE(splice<OpType::Constructive>(SubRegSize::i8Bit, ZReg::z30, PReg::p6, ZReg::z28, ZReg::z29),   "splice z30.b, p6, {z28.b, z29.b}");
   TEST_SINGLE(splice<OpType::Constructive>(SubRegSize::i16Bit, ZReg::z30, PReg::p6, ZReg::z28, ZReg::z29),  "splice z30.h, p6, {z28.h, z29.h}");


### PR DESCRIPTION
Clears out the scalar CPY broadcasting ops