### PR TITLE
Hardcode SDL2 includes only when no CMake target is not available

### DIFF
--- a/Source/Tools/FEXConfig/CMakeLists.txt
+++ b/Source/Tools/FEXConfig/CMakeLists.txt
@@ -12,14 +12,13 @@ add_executable(${NAME} ${SRCS})
 target_include_directories(${NAME} PRIVATE ${CMAKE_SOURCE_DIR}/Source/)
 target_include_directories(${NAME} PRIVATE ${CMAKE_SOURCE_DIR}/External/imgui/examples/)
 
-# Fix for SDL2 includes under Alpine Linux.
-target_include_directories(${NAME} PRIVATE /usr/include/directfb/)
-
 if (TARGET SDL2::SDL2)
   target_link_libraries(${NAME} PRIVATE SDL2::SDL2)
 else()
   target_include_directories(${NAME} PRIVATE ${SDL2_INCLUDE_DIRS})
   target_link_libraries(${NAME} PRIVATE ${SDL2_LIBRARIES})
+  # Fix for SDL2 includes under Alpine Linux
+  target_include_directories(${NAME} PRIVATE /usr/include/directfb/)
 endif()
 
 target_link_libraries(${NAME} PRIVATE Common pthread epoxy X11 EGL imgui json-maker)


### PR DESCRIPTION
The CMake target should have all dependency information already included.