### PR TITLE
Dispatcher: Support reconstructing RIP from block entry

### DIFF
--- a/Data/AppConfig/VC_redist.x64.exe.json
+++ b/Data/AppConfig/VC_redist.x64.exe.json
@@ -1,5 +1,0 @@
-{
-  "Config": {
-    "x86dec_SynchronizeRIPOnAllBlocks": "1"
-  }
-}

--- a/Data/AppConfig/VC_redist.x86.exe.json
+++ b/Data/AppConfig/VC_redist.x86.exe.json
@@ -1,5 +1,0 @@
-{
-  "Config": {
-    "x86dec_SynchronizeRIPOnAllBlocks": "1"
-  }
-}

--- a/Data/AppConfig/vcredist_x64.exe.json
+++ b/Data/AppConfig/vcredist_x64.exe.json
@@ -1,5 +1,0 @@
-{
-  "Config": {
-    "x86dec_SynchronizeRIPOnAllBlocks": "1"
-  }
-}

--- a/Data/AppConfig/vcredist_x86.exe.json
+++ b/Data/AppConfig/vcredist_x86.exe.json
@@ -1,5 +1,0 @@
-{
-  "Config": {
-    "x86dec_SynchronizeRIPOnAllBlocks": "1"
-  }
-}

--- a/External/FEXCore/Source/Interface/Config/Config.json.in
+++ b/External/FEXCore/Source/Interface/Config/Config.json.in
@@ -342,16 +342,6 @@
           "Forces a process to stall out on initialization",
           "Useful for a process that keeps restarting and doesn't work"
         ]
-      },
-      "x86dec_SynchronizeRIPOnAllBlocks": {
-        "Type": "bool",
-        "Default": "false",
-        "Desc": [
-          "An application that uses try-catch or longjump extensively needs the ability to do context aware state flushing",
-          "In the case of FEX's block-linking, it won't always ensure that RIP is synchronized.",
-          "If an exception occurs and RIP isn't synchronized, then FEX's exception stack restore may not long jump as expected",
-          "Can be useful for Wine applications that rely on stack unwinding"
-        ]
       }
     },
     "Misc": {

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -116,7 +116,6 @@ namespace FEXCore::Context {
       FEX_CONFIG_OPT(ParanoidTSO, PARANOIDTSO);
       FEX_CONFIG_OPT(CacheObjectCodeCompilation, CACHEOBJECTCODECOMPILATION);
       FEX_CONFIG_OPT(x87ReducedPrecision, X87REDUCEDPRECISION);
-      FEX_CONFIG_OPT(x86dec_SynchronizeRIPOnAllBlocks, X86DEC_SYNCHRONIZERIPONALLBLOCKS);
       FEX_CONFIG_OPT(EnableAVX, ENABLEAVX);
     } Config;
 

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -810,13 +810,6 @@ namespace FEXCore::Context {
         // Reset any block-specific state
         Thread->OpDispatcher->StartNewBlock();
 
-        if (Config.x86dec_SynchronizeRIPOnAllBlocks) {
-          // Ensure the RIP is synchronized to the context on block entry.
-          // In the case of block linking, the RIP may not have synchronized.
-          auto NewRIP = Thread->OpDispatcher->_EntrypointOffset(Block.Entry - GuestRIP, GPRSize);
-          Thread->OpDispatcher->_StoreContext(GPRSize, IR::GPRClass, NewRIP, offsetof(FEXCore::Core::CPUState, rip));
-        }
-
         uint64_t InstsInBlock = Block.NumInstructions;
 
         for (size_t i = 0; i < InstsInBlock; ++i) {

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
@@ -40,6 +40,27 @@ void Dispatcher::SleepThread(FEXCore::Context::Context *ctx, FEXCore::Core::CpuS
   ctx->IdleWaitCV.notify_all();
 }
 
+uint64_t Dispatcher::ReconstructRIPFromContext(FEXCore::Core::CpuStateFrame *Frame, void *ucontext) const {
+  const uint64_t HostPC = ArchHelpers::Context::GetPc(ucontext);
+  const uint64_t BlockBegin = Frame->State.InlineJITBlockHeader;
+  const CPUBackend::JITCodeHeader *InlineHeader = reinterpret_cast<const CPUBackend::JITCodeHeader *>(BlockBegin);
+
+  if (InlineHeader) {
+    const CPUBackend::JITCodeTail *InlineTail = reinterpret_cast<const CPUBackend::JITCodeTail *>(Frame->State.InlineJITBlockHeader + InlineHeader->OffsetToBlockTail);
+
+    // Check if the host PC is currently within a code block.
+    // If it is then RIP can be reconstructed from the beginning of the code block.
+    // This is currently as close as FEX can get RIP reconstructions.
+    if (HostPC >= reinterpret_cast<uint64_t>(BlockBegin) &&
+        HostPC < reinterpret_cast<uint64_t>(BlockBegin + InlineTail->Size)) {
+      return InlineTail->RIP;
+    }
+  }
+
+  // Fallback to what is stored in the RIP currently.
+  return Frame->State.rip;
+}
+
 ArchHelpers::Context::ContextBackup* Dispatcher::StoreThreadState(FEXCore::Core::InternalThreadState *Thread, int Signal, void *ucontext) {
   // We can end up getting a signal at any point in our host state
   // Jump to a handler that saves all state so we can safely return
@@ -465,7 +486,7 @@ uint64_t Dispatcher::SetupFrame_ia32(
     guest_uctx->sc.err = ConvertSignalToError(ucontext, Signal, HostSigInfo);
   }
 
-  guest_uctx->sc.ip = Frame->State.rip;
+  guest_uctx->sc.ip = ContextBackup->OriginalRIP;
   guest_uctx->sc.flags = eflags;
   guest_uctx->sc.sp_at_signal = 0;
 
@@ -610,7 +631,7 @@ uint64_t Dispatcher::SetupRTFrame_ia32(
     guest_uctx->uc.uc_mcontext.gregs[FEXCore::x86::FEX_REG_ERR] = ConvertSignalToError(ucontext, Signal, HostSigInfo);
   }
 
-  guest_uctx->uc.uc_mcontext.gregs[FEXCore::x86::FEX_REG_EIP] = Frame->State.rip;
+  guest_uctx->uc.uc_mcontext.gregs[FEXCore::x86::FEX_REG_EIP] = ContextBackup->OriginalRIP;
   guest_uctx->uc.uc_mcontext.gregs[FEXCore::x86::FEX_REG_EFL] = eflags;
   guest_uctx->uc.uc_mcontext.gregs[FEXCore::x86::FEX_REG_UESP] = Frame->State.gregs[X86State::REG_RSP];
   guest_uctx->uc.uc_mcontext.cr2 = 0;
@@ -687,7 +708,7 @@ uint64_t Dispatcher::SetupRTFrame_ia32(
     case SIGILL:
       // Macro expansion to get the si_addr
       // Can't really give a real result here. Pull from the context for now
-      guest_uctx->info._sifields._sigfault.addr = Frame->State.rip;
+      guest_uctx->info._sifields._sigfault.addr = ContextBackup->OriginalRIP;
       break;
     case SIGCHLD:
       guest_uctx->info._sifields._sigchld.pid = HostSigInfo->si_pid;
@@ -879,7 +900,7 @@ uint64_t Dispatcher::SetupFrame_x64(
   auto *xstate = reinterpret_cast<x86_64::xstate*>(FPStateLocation);
   SetXStateInfo(xstate, IsAVXEnabled);
 
-  guest_uctx->uc_mcontext.gregs[FEXCore::x86_64::FEX_REG_RIP] = Frame->State.rip;
+  guest_uctx->uc_mcontext.gregs[FEXCore::x86_64::FEX_REG_RIP] = ContextBackup->OriginalRIP;
   guest_uctx->uc_mcontext.gregs[FEXCore::x86_64::FEX_REG_EFL] = eflags;
   guest_uctx->uc_mcontext.gregs[FEXCore::x86_64::FEX_REG_CSGSFS] = 0;
 
@@ -989,11 +1010,6 @@ bool Dispatcher::HandleGuestSignal(FEXCore::Core::InternalThreadState *Thread, i
   ++Thread->CurrentFrame->SignalHandlerRefCounter;
 
   uint64_t OldPC = ArchHelpers::Context::GetPc(ucontext);
-  // Set the new PC
-  ArchHelpers::Context::SetPc(ucontext, AbsoluteLoopTopAddressFillSRA);
-  // Set our state register to point to our guest thread data
-  ArchHelpers::Context::SetState(ucontext, reinterpret_cast<uint64_t>(Frame));
-
   // Pulling from context here
   const bool Is64BitMode = CTX->Config.Is64BitMode;
 
@@ -1067,7 +1083,7 @@ bool Dispatcher::HandleGuestSignal(FEXCore::Core::InternalThreadState *Thread, i
   siginfo_t *HostSigInfo = reinterpret_cast<siginfo_t*>(info);
 
   // Backup where we think the RIP currently is
-  ContextBackup->OriginalRIP = Frame->State.rip;
+  ContextBackup->OriginalRIP = ReconstructRIPFromContext(Frame, ucontext);
   // Calculate eflags upfront.
   uint32_t eflags = 0;
   for (size_t i = 0; i < Core::CPUState::NUM_EFLAG_BITS; ++i) {
@@ -1097,6 +1113,11 @@ bool Dispatcher::HandleGuestSignal(FEXCore::Core::InternalThreadState *Thread, i
   memset(Frame->State.mm, 0, sizeof(Frame->State.mm));
   Frame->State.FCW = 0x37F;
   Frame->State.FTW = 0xFFFF;
+
+  // Set the new PC
+  ArchHelpers::Context::SetPc(ucontext, AbsoluteLoopTopAddressFillSRA);
+  // Set our state register to point to our guest thread data
+  ArchHelpers::Context::SetState(ucontext, reinterpret_cast<uint64_t>(Frame));
 
   return true;
 }

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
@@ -91,6 +91,7 @@ protected:
     , config {Config}
     {}
 
+  uint64_t ReconstructRIPFromContext(FEXCore::Core::CpuStateFrame *Frame, void *ucontext) const;
   void RestoreFrame_x64(ArchHelpers::Context::ContextBackup* Context, FEXCore::Core::CpuStateFrame *Frame, void *ucontext);
   void RestoreFrame_ia32(ArchHelpers::Context::ContextBackup* Context, FEXCore::Core::CpuStateFrame *Frame, void *ucontext);
   void RestoreRTFrame_ia32(ArchHelpers::Context::ContextBackup* Context, FEXCore::Core::CpuStateFrame *Frame, void *ucontext);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -1048,6 +1048,9 @@ CPUBackend::CompiledCode Arm64JITCore::CompileCode(uint64_t Entry,
   CodeHeader->OffsetToBlockTail = JITBlockTailLocation - CodeData.BlockBegin;
 
   CodeData.Size = GetCursorAddress<uint8_t *>() - CodeData.BlockBegin;
+
+  JITBlockTail->Size = CodeData.Size;
+
   ClearICache(CodeData.BlockBegin, CodeData.Size);
 
 #ifdef VIXL_DISASSEMBLER

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -772,7 +772,9 @@ CPUBackend::CompiledCode X86JITCore::CompileCode(uint64_t Entry, [[maybe_unused]
 
   CodeHeader->OffsetToBlockTail = JITBlockTailLocation - CodeData.BlockBegin;
 
-  CodeData.Size = CodeData.BlockBegin - getCurr<uint8_t*>();
+  CodeData.Size = getCurr<uint8_t*>() - CodeData.BlockBegin;
+
+  JITBlockTail->Size = CodeData.Size;
 
   this->IR = nullptr;
 

--- a/External/FEXCore/include/FEXCore/Core/CPUBackend.h
+++ b/External/FEXCore/include/FEXCore/Core/CPUBackend.h
@@ -85,6 +85,8 @@ namespace CPU {
     // Any data that is explicitly tied to the JIT code and needs to be cached with it
     // should end up in this data structure.
     struct JITCodeTail {
+      // The total size of the codeblock from [BlockBegin, BlockBegin+Size).
+      size_t Size;
       // RIP that the block's entry comes from.
       uint64_t RIP;
     };


### PR DESCRIPTION
This allows us to not update RIP on block entry, but still allow
reconstructing the RIP up until that point.

While still not full RIP reconstruction, this lets us update the signal
context's RIP just like the `x86dec_SynchronizeRIPOnAllBlocks` without
eating the cost of writing to RIP on block entry.

This was tested on a few Proton games that were using the VC setup files to ensure it still worked as expected.

- [X] Retest this with Sonic Mania specifically.