### PR TITLE
OpcodeDispatcher: Optimize ALUOp handler

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -168,6 +168,7 @@ public:
   void MOVGPRNTOp(OpcodeArgs);
   void MOVVectorOp(OpcodeArgs);
   void MOVVectorNTOp(OpcodeArgs);
+  template<FEXCore::IR::IROps ALUIROp, FEXCore::IR::IROps AtomicFetchOp, bool RequiresMask>
   void ALUOp(OpcodeArgs);
   void INTOp(OpcodeArgs);
   void SyscallOp(OpcodeArgs);
@@ -772,6 +773,8 @@ private:
   bool NeedsBlockEnd{false};
   FEXCore::IR::IROp_IRHeader *Current_Header{};
   OrderedNode *Current_HeaderNode{};
+
+  void ALUOpImpl(OpcodeArgs, FEXCore::IR::IROps ALUIROp, FEXCore::IR::IROps AtomicFetchOp, bool RequiresMask);
 
   // Opcode helpers for generalizing behavior across VEX and non-VEX variants.
 


### PR DESCRIPTION
Take a leaf from the Vector ops and have the jump entry choose the IR op.
Also generate one atomic op and modify the IR type in the locked memory type just like the non locked memory path.

This class of instructions in the number one instruction type percentage wise, so making this more optimal will be a win.

It's a fairly minor optimization so it should be a small impact.