### PR TITLE
Scripts: Update fit_native script for X1C/A78C

### DIFF
--- a/Scripts/aarch64_fit_native.py
+++ b/Scripts/aarch64_fit_native.py
@@ -15,7 +15,16 @@ BigCoreIDs = {
         tuple([0x41, 0xd0b]): "cortex-a76",
         tuple([0x41, 0xd0d]): "cortex-a77",
         tuple([0x41, 0xd41]): "cortex-a78",
+        tuple([0x41, 0xd41]):
+            [ ["cortex-a78", "0.0"],
+              ["cortex-x1c", "14.0"],    # Claim to be x1c as an alternative if available.
+              ["cortex-a78c", "9999.0"], # Doesn't exist in clang as of version 15.0
+            ],
         tuple([0x41, 0xd44]): "cortex-x1",
+        tuple([0x41, 0xd4c]):
+            [ ["cortex-x1", "0.0"],
+              ["cortex-x1c", "14.0"],
+            ],
         tuple([0x41, 0xd47]):
             [ ["cortex-a78", "0.0"],
               ["cortex-a710", "14.0"],


### PR DESCRIPTION
Cortex-X1C and A78C are relatively minor changes to their non-C counterparts. Support classifying them in case clang understands them.

Fixes a minor perf regression noticed on the Lenovo X13s while testing.