### PR TITLE
Arm64: Fixes a race condition on syscall spilling SRA

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
@@ -1009,14 +1009,7 @@ bool Dispatcher::HandleGuestSignal(FEXCore::Core::InternalThreadState *Thread, i
         // We need to spill SRA but only some of it, since some values have already been spilled
         // Lower 16 bits tells us which registers are already spilled to the context
         // So we ignore spilling those ones
-        uint16_t NumRegisters = std::popcount(Frame->InSyscallInfo & 0xFFFF);
-        if (NumRegisters >= 4) {
-          // Unhandled case
-          IgnoreMask = 0;
-        }
-        else {
-          IgnoreMask = Frame->InSyscallInfo & 0xFFFF;
-        }
+        IgnoreMask = Frame->InSyscallInfo & 0xFFFF;
       }
       else {
         // We must spill everything


### PR DESCRIPTION
When executing a non-inlined syscall, we spill all static registers. We weren't storing in to the thread context that we have done this. If a signal occured between FEX returning from the syscall (after the blr) and before the `FillStaticRegs` then the signal handler would get the incorrect register state.

This typically manifested as Steam getting a SIGCHLD, trying to recover the guest stack pointer, and it that pointer would be zero or some other corrupt value. Thus crashing inside of the signal handler.

Surprising that we hadn't hit this way more before this point, must have needed hardware that tickled the race condition *just* right.