### PR TITLE
Dispatcher: Fixes crash with misalign stack returning from signal

### DIFF
--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/MContext.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/MContext.h
@@ -237,8 +237,10 @@ static inline void BackupContext(void* ucontext, T *Backup) {
 template <typename T>
 static inline void RestoreContext(void* ucontext, T *Backup) {
   if constexpr (std::is_same<T, ArmContextBackup>::value) {
+    LOGMAN_THROW_A_FMT(Backup->StackCookie == STACK_COOKIE_MAGIC, "Stack cookie didn't match! 0x{:x}", Backup->StackCookie);
+
     auto _ucontext = GetUContext(ucontext);
-   auto _mcontext = GetMContext(ucontext);
+    auto _mcontext = GetMContext(ucontext);
 
     HostFPRState *HostState = reinterpret_cast<HostFPRState*>(&_mcontext->__reserved[0]);
     LOGMAN_THROW_AA_FMT(HostState->Head.Magic == FPR_MAGIC, "Wrong FPR Magic: 0x{:08x}", HostState->Head.Magic);
@@ -254,8 +256,6 @@ static inline void RestoreContext(void* ucontext, T *Backup) {
 
     // Restore the signal mask now
     memcpy(&_ucontext->uc_sigmask, &Backup->sa_mask, sizeof(uint64_t));
-
-    LOGMAN_THROW_A_FMT(Backup->StackCookie == STACK_COOKIE_MAGIC, "Stack cookie didn't match! 0x{:x}", Backup->StackCookie);
   } else {
     // This must be a runtime error
     ERROR_AND_DIE_FMT("Wrong context type");
@@ -334,6 +334,8 @@ static inline void BackupContext(void* ucontext, T *Backup) {
 template <typename T>
 static inline void RestoreContext(void* ucontext, T *Backup) {
   if constexpr (std::is_same<T, X86ContextBackup>::value) {
+    LOGMAN_THROW_A_FMT(Backup->StackCookie == STACK_COOKIE_MAGIC, "Stack cookie didn't match! 0x{:x}", Backup->StackCookie);
+
     auto _ucontext = GetUContext(ucontext);
     auto _mcontext = GetMContext(ucontext);
 
@@ -344,8 +346,6 @@ static inline void RestoreContext(void* ucontext, T *Backup) {
 
     // Restore the signal mask now
     memcpy(&_ucontext->uc_sigmask, &Backup->sa_mask, sizeof(uint64_t));
-
-    LOGMAN_THROW_A_FMT(Backup->StackCookie == STACK_COOKIE_MAGIC, "Stack cookie didn't match! 0x{:x}", Backup->StackCookie);
   } else {
     // This must be a runtime error
     ERROR_AND_DIE_FMT("Wrong context type");

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
@@ -440,6 +440,8 @@ uint64_t Dispatcher::SetupFrame_ia32(
   const uint64_t SignalReturn = reinterpret_cast<uint64_t>(CTX->VDSOPointers.VDSO_kernel_sigreturn);
 
   NewGuestSP -= sizeof(uint64_t);
+  NewGuestSP = AlignDown(NewGuestSP, alignof(uint64_t));
+
   uint64_t HostStackLocation = NewGuestSP;
 
   if (IsAVXEnabled) {
@@ -580,6 +582,8 @@ uint64_t Dispatcher::SetupRTFrame_ia32(
   const uint64_t SignalReturn = reinterpret_cast<uint64_t>(CTX->VDSOPointers.VDSO_kernel_rt_sigreturn);
 
   NewGuestSP -= sizeof(uint64_t);
+  NewGuestSP = AlignDown(NewGuestSP, alignof(uint64_t));
+
   uint64_t HostStackLocation = NewGuestSP;
 
   if (IsAVXEnabled) {
@@ -860,6 +864,7 @@ uint64_t Dispatcher::SetupFrame_x64(
   // FP state
   // Host stack location
   NewGuestSP -= sizeof(uint64_t);
+  NewGuestSP = AlignDown(NewGuestSP, alignof(uint64_t));
 
   uint64_t HostStackLocation = NewGuestSP;
 


### PR DESCRIPTION
When we were taking a signal that had a misaligned stack, we would store the host stack at a weird offset.

After that point when we were trying to sigreturn we wouldn't know the alignment of the stack coming back and we would try loading the host stack from the wrong offset. Easy fix is to just align the host stack location.

Fixes Ender Lilies, which was consistently crashing from a SIGCHLD due to having a misaligned stack.

Side-change: Move the cookie check to the start of the restore. Doesn't make sense to check the cookie after restoring state since it could be quite wrong.