### PR TITLE
CPUID: Adds an config option to hide hypervisor bit

### DIFF
--- a/Data/AppConfig/client.json
+++ b/Data/AppConfig/client.json
@@ -1,0 +1,5 @@
+{
+  "Config": {
+    "HideHypervisorBit": "1"
+  }
+}

--- a/External/FEXCore/Source/Interface/Config/Config.json.in
+++ b/External/FEXCore/Source/Interface/Config/Config.json.in
@@ -342,6 +342,14 @@
           "Forces a process to stall out on initialization",
           "Useful for a process that keeps restarting and doesn't work"
         ]
+      },
+      "HideHypervisorBit": {
+        "Type": "bool",
+        "Default": "false",
+        "Desc": [
+          "Hides the hypervisor CPUID bit when set.",
+          "Should only be used for applications that have issues with this set."
+        ]
       }
     },
     "Misc": {

--- a/External/FEXCore/Source/Interface/Core/CPUID.cpp
+++ b/External/FEXCore/Source/Interface/Core/CPUID.cpp
@@ -410,6 +410,9 @@ FEXCore::CPUID::FunctionResults CPUIDEmu::Function_01h(uint32_t Leaf) {
   // XXX: Enable once the rest of the SSE4.2 instructions are emulated
   uint32_t SupportsSSE42 = CTX->HostFeatures.SupportsCRC && false ? 1 : 0;
 
+  // Hypervisor bit is normally set but some applications have issues with it.
+  uint32_t Hypervisor = HideHypervisorBit() ? 0 : 1;
+
   Res.eax = FAMILY_IDENTIFIER;
 
   Res.ebx = 0 | // Brand index
@@ -449,7 +452,7 @@ FEXCore::CPUID::FunctionResults CPUIDEmu::Function_01h(uint32_t Leaf) {
     (SUPPORTS_AVX << 28) | // AVX
     (0 << 29) | // F16C
     (CTX->HostFeatures.SupportsRAND << 30) | // RDRAND
-    (1 << 31);  // Hypervisor always returns one
+    (Hypervisor << 31);
 
   Res.edx =
     (1 <<  0) | // FPU

--- a/External/FEXCore/Source/Interface/Core/CPUID.h
+++ b/External/FEXCore/Source/Interface/Core/CPUID.h
@@ -67,6 +67,7 @@ private:
   FEXCore::Context::ContextImpl *CTX;
   bool Hybrid{};
   FEX_CONFIG_OPT(Cores, THREADS);
+  FEX_CONFIG_OPT(HideHypervisorBit, HIDEHYPERVISORBIT);
 
   using FunctionHandler = FEXCore::CPUID::FunctionResults (CPUIDEmu::*)(uint32_t Leaf);
   struct CPUData {


### PR DESCRIPTION
This is known to cause issues in some cases. We hit the first game that checks for this bit and early exits if it is found.

Lets the MMORPG Tibia run in non-VM situations.
Looks like they have more checks for VMs other than hypervisor bit, so running under Parallels still won't work. Running on bare Linux is fine.