### PR TITLE
EmulatedFiles: Optimize openat handler

### DIFF
--- a/Source/Common/FDUtils.h
+++ b/Source/Common/FDUtils.h
@@ -23,4 +23,10 @@ std::optional<std::string> get_fdpath(int fd) {
   return std::nullopt;
 }
 
+inline
+int get_fdpath(int fd, char *SymlinkPath) {
+  auto Path = fmt::format("/proc/self/fd/{}", fd);
+  return readlinkat(AT_FDCWD, Path.c_str(), SymlinkPath, PATH_MAX);
+}
+
 }

--- a/Source/Tests/LinuxSyscalls/FileManagement.h
+++ b/Source/Tests/LinuxSyscalls/FileManagement.h
@@ -81,7 +81,7 @@ public:
 
   std::string GetEmulatedPath(const char *pathname, bool FollowSymlink = false);
   using FDPathTmpData = std::array<char[PATH_MAX], 2>;
-  std::optional<std::pair<int, const char*>> GetEmulatedFDPath(const char *pathname, bool FollowSymlink, FDPathTmpData &TmpFilename);
+  std::pair<int, const char*> GetEmulatedFDPath(const char *pathname, bool FollowSymlink, FDPathTmpData &TmpFilename);
 
   std::mutex *GetFDLock() { return &FDLock; }
 


### PR DESCRIPTION
Fixes #2443
I found out with some profiling that this we were spending a decent amount of time with the `openat` syscall in heavily utilized situations. While not super common in active gameplay situations, it matters significantly in loading screens that this is fairly optimal.

The bulk of the time is spent in the emulated files handler to ensure that whatever path we are given, we can capture file paths that we need to emulate. The largest contributor being the std::filesystem::canonical function call.

A couple of optimizations in place here.
1) Do a quick hashmap check right at the start to see if we exactly fit
2) Change from `std::fs::canonical` to `realpath`
3) Switch `GetEmulatedFDPath` to not use optional so it stops building
   on the stack

I'm still not super happy with the performance of `realpath` and also not happy that we still need to use `lexically_normal` in one code path. But short of writing a super hand-optimized `realpath` that fits our constraints, I don't think we can do better.

Micro benchmark needs to test four different situations due to this optimization.
1) Non-EmuFD path
2) Non-EmuFD path with dirfs
3) EmuFD path
4) EmuFD path with dirfs

And the performance improvement for each situation respectively
1) 12% performance improvement
   - 213413 openat syscalls/s -> 238999 syscalls/s
2) 17% performance improvement
   - 202085 openat syscalls/s -> 237309 syscalls/s
3) 17% performance improvement (/proc/cpuinfo)
   - 56616 openat syscalls/s -> 66231 syscalls/s
   - Includes overhead of generating temp FD and close syscall
4) 5% performance improvement (/proc/cpuinfo)
   - 51080 openat syscalls/s -> 53956 syscalls/s
   - Includes overhead of generating temp FD and close syscall

And for sake of comparison to the non-emulated system; My test system can hit around 1-1.1 million openat syscalls per second in the same microbench.

Nice little performance uplift.