### PR TITLE
FEXServer: Change systemd service environment variable key

### DIFF
--- a/Source/Tools/FEXServer/Main.cpp
+++ b/Source/Tools/FEXServer/Main.cpp
@@ -109,7 +109,7 @@ namespace {
    * @brief Deparents itself by forking and terminating the parent process.
    */
   void DeparentSelf() {
-    auto SystemdEnv = getenv("SYSTEMD_EXEC_PID");
+    auto SystemdEnv = getenv("INVOCATION_ID");
     if (SystemdEnv) {
       // If FEXServer was launched through systemd then don't deparent, otherwise systemd kills the entire server.
       return;


### PR DESCRIPTION
It looks like `SYSTEMD_EXEC_PID` can leak through to the executable environment in regular situations. Instead let's key off of `INVOCATATION_ID` which doesn't leak through.

Fixes an edge case behaviour where FEXServer wouldn't daemonize in some systemd environments.