### PR TITLE
FEXServerClient: Fixes instance where FEXServer can create a zombie

### DIFF
--- a/Source/Common/FEXServerClient.cpp
+++ b/Source/Common/FEXServerClient.cpp
@@ -216,6 +216,15 @@ namespace FEXServerClient {
         FEXServerPath = "FEXServer";
       }
 
+      // Set-up our SIGCHLD handler to ignore the signal.
+      // This is early in the initialization stage so no handlers have been installed.
+      //
+      // We want to ignore the signal so that if FEXServer starts in daemon mode, it
+      // doesn't leave a zombie process around waiting for something to get the result.
+      struct sigaction action{};
+      action.sa_handler = SIG_IGN,
+      sigaction(SIGCHLD, &action, &action);
+
       pid_t pid = fork();
       if (pid == 0) {
         // Child
@@ -269,6 +278,9 @@ namespace FEXServerClient {
           LogMan::Msg::EFmt("Couldn't connect to FEXServer socket {} after launching the process", GetServerSocketName());
         }
       }
+
+      // Restore the original SIGCHLD handler if it existed.
+      sigaction(SIGCHLD, &action, nullptr);
     }
     return ServerFD;
   }


### PR DESCRIPTION
When FEXServer is daemonizing through an instance of FEXLoader or FEXInterpreter, it would leave a zombie process which was waiting for us to read the process status.
Since we don't care about the child status and don't want to get blocked by waitpid, just ignore the signal.

This tells the kernel that we don't care about the signal and will kill the zombie process immediately.
Didn't notice this before since FEXServer started failing to daemonize.