### PR TITLE
ARMEmitter: Handle sequential registers in lists nicer

### DIFF
--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ASIMDOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ASIMDOps.inl
@@ -93,77 +93,65 @@ public:
     ASIMDTable(Op, 0, 0b00, 0b00, 0b1, rd.V(), rn.V(), rm.V());
   }
 
-  void tbl(FEXCore::ARMEmitter::QRegister rd, FEXCore::ARMEmitter::QRegister rn, FEXCore::ARMEmitter::QRegister rn2, FEXCore::ARMEmitter::QRegister rm) {
-    LOGMAN_THROW_A_FMT((rn.Idx() + 1) == rn2.Idx(), "These must be sequential");
+  void tbl(QRegister rd, QRegister rn, QRegister rn2, QRegister rm) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rn, rn2), "rn and rn2 must be sequential");
     constexpr uint32_t Op = 0b0000'1110'000 << 21;
     ASIMDTable(Op, 1, 0b00, 0b01, 0b0, rd.V(), rn.V(), rm.V());
   }
-  void tbl(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::QRegister rn, FEXCore::ARMEmitter::QRegister rn2, FEXCore::ARMEmitter::DRegister rm) {
-    LOGMAN_THROW_A_FMT((rn.Idx() + 1) == rn2.Idx(), "These must be sequential");
+  void tbl(DRegister rd, QRegister rn, QRegister rn2, DRegister rm) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rn, rn2), "rn and rn2 must be sequential");
     constexpr uint32_t Op = 0b0000'1110'000 << 21;
     ASIMDTable(Op, 0, 0b00, 0b01, 0b0, rd.V(), rn.V(), rm.V());
   }
-  void tbx(FEXCore::ARMEmitter::QRegister rd, FEXCore::ARMEmitter::QRegister rn, FEXCore::ARMEmitter::QRegister rn2, FEXCore::ARMEmitter::QRegister rm) {
-    LOGMAN_THROW_A_FMT((rn.Idx() + 1) == rn2.Idx(), "These must be sequential");
+  void tbx(QRegister rd, QRegister rn, QRegister rn2, QRegister rm) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rn, rn2), "rn and rn2 must be sequential");
     constexpr uint32_t Op = 0b0000'1110'000 << 21;
     ASIMDTable(Op, 1, 0b00, 0b01, 0b1, rd.V(), rn.V(), rm.V());
   }
-  void tbx(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::QRegister rn, FEXCore::ARMEmitter::QRegister rn2, FEXCore::ARMEmitter::DRegister rm) {
-    LOGMAN_THROW_A_FMT((rn.Idx() + 1) == rn2.Idx(), "These must be sequential");
+  void tbx(DRegister rd, QRegister rn, QRegister rn2, DRegister rm) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rn, rn2), "rn and rn2 must be sequential");
     constexpr uint32_t Op = 0b0000'1110'000 << 21;
     ASIMDTable(Op, 0, 0b00, 0b01, 0b1, rd.V(), rn.V(), rm.V());
   }
 
-  void tbl(FEXCore::ARMEmitter::QRegister rd, FEXCore::ARMEmitter::QRegister rn, FEXCore::ARMEmitter::QRegister rn2, FEXCore::ARMEmitter::QRegister rn3, FEXCore::ARMEmitter::QRegister rm) {
-    LOGMAN_THROW_A_FMT((rn.Idx() + 1) == rn2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rn2.Idx() + 1) == rn3.Idx(), "These must be sequential");
+  void tbl(QRegister rd, QRegister rn, QRegister rn2, QRegister rn3, QRegister rm) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rn, rn2, rn3), "rn, rn2, and rn3 must be sequential");
     constexpr uint32_t Op = 0b0000'1110'000 << 21;
     ASIMDTable(Op, 1, 0b00, 0b10, 0b0, rd.V(), rn.V(), rm.V());
   }
-  void tbl(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::QRegister rn, FEXCore::ARMEmitter::QRegister rn2, FEXCore::ARMEmitter::QRegister rn3, FEXCore::ARMEmitter::DRegister rm) {
-    LOGMAN_THROW_A_FMT((rn.Idx() + 1) == rn2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rn2.Idx() + 1) == rn3.Idx(), "These must be sequential");
+  void tbl(DRegister rd, QRegister rn, QRegister rn2, QRegister rn3, DRegister rm) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rn, rn2, rn3), "rn, rn2, and rn3 must be sequential");
     constexpr uint32_t Op = 0b0000'1110'000 << 21;
     ASIMDTable(Op, 0, 0b00, 0b10, 0b0, rd.V(), rn.V(), rm.V());
   }
-  void tbx(FEXCore::ARMEmitter::QRegister rd, FEXCore::ARMEmitter::QRegister rn, FEXCore::ARMEmitter::QRegister rn2, FEXCore::ARMEmitter::QRegister rn3, FEXCore::ARMEmitter::QRegister rm) {
-    LOGMAN_THROW_A_FMT((rn.Idx() + 1) == rn2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rn2.Idx() + 1) == rn3.Idx(), "These must be sequential");
+  void tbx(QRegister rd, QRegister rn, QRegister rn2, QRegister rn3, QRegister rm) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rn, rn2, rn3), "rn, rn2, and rn3 must be sequential");
     constexpr uint32_t Op = 0b0000'1110'000 << 21;
     ASIMDTable(Op, 1, 0b00, 0b10, 0b1, rd.V(), rn.V(), rm.V());
   }
-  void tbx(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::QRegister rn, FEXCore::ARMEmitter::QRegister rn2, FEXCore::ARMEmitter::QRegister rn3, FEXCore::ARMEmitter::DRegister rm) {
-    LOGMAN_THROW_A_FMT((rn.Idx() + 1) == rn2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rn2.Idx() + 1) == rn3.Idx(), "These must be sequential");
+  void tbx(DRegister rd, QRegister rn, QRegister rn2, QRegister rn3, DRegister rm) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rn, rn2, rn3), "rn, rn2, and rn3 must be sequential");
     constexpr uint32_t Op = 0b0000'1110'000 << 21;
     ASIMDTable(Op, 0, 0b00, 0b10, 0b1, rd.V(), rn.V(), rm.V());
   }
 
-  void tbl(FEXCore::ARMEmitter::QRegister rd, FEXCore::ARMEmitter::QRegister rn, FEXCore::ARMEmitter::QRegister rn2, FEXCore::ARMEmitter::QRegister rn3, FEXCore::ARMEmitter::QRegister rn4, FEXCore::ARMEmitter::QRegister rm) {
-    LOGMAN_THROW_A_FMT((rn.Idx() + 1) == rn2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rn2.Idx() + 1) == rn3.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rn3.Idx() + 1) == rn4.Idx(), "These must be sequential");
+  void tbl(QRegister rd, QRegister rn, QRegister rn2, QRegister rn3, QRegister rn4, QRegister rm) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rn, rn2, rn3, rn4), "rn, rn2, rn3, and rn4 must be sequential");
     constexpr uint32_t Op = 0b0000'1110'000 << 21;
     ASIMDTable(Op, 1, 0b00, 0b11, 0b0, rd.V(), rn.V(), rm.V());
   }
-  void tbl(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::QRegister rn, FEXCore::ARMEmitter::QRegister rn2, FEXCore::ARMEmitter::QRegister rn3, FEXCore::ARMEmitter::QRegister rn4, FEXCore::ARMEmitter::DRegister rm) {
-    LOGMAN_THROW_A_FMT((rn.Idx() + 1) == rn2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rn2.Idx() + 1) == rn3.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rn3.Idx() + 1) == rn4.Idx(), "These must be sequential");
+  void tbl(DRegister rd, QRegister rn, QRegister rn2, QRegister rn3, QRegister rn4, DRegister rm) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rn, rn2, rn3, rn4), "rn, rn2, rn3, and rn4 must be sequential");
     constexpr uint32_t Op = 0b0000'1110'000 << 21;
     ASIMDTable(Op, 0, 0b00, 0b11, 0b0, rd.V(), rn.V(), rm.V());
   }
-  void tbx(FEXCore::ARMEmitter::QRegister rd, FEXCore::ARMEmitter::QRegister rn, FEXCore::ARMEmitter::QRegister rn2, FEXCore::ARMEmitter::QRegister rn3, FEXCore::ARMEmitter::QRegister rn4, FEXCore::ARMEmitter::QRegister rm) {
-    LOGMAN_THROW_A_FMT((rn.Idx() + 1) == rn2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rn2.Idx() + 1) == rn3.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rn3.Idx() + 1) == rn4.Idx(), "These must be sequential");
+  void tbx(QRegister rd, QRegister rn, QRegister rn2, QRegister rn3, QRegister rn4, QRegister rm) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rn, rn2, rn3, rn4), "rn, rn2, rn3, and rn4 must be sequential");
     constexpr uint32_t Op = 0b0000'1110'000 << 21;
     ASIMDTable(Op, 1, 0b00, 0b11, 0b1, rd.V(), rn.V(), rm.V());
   }
-  void tbx(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::QRegister rn, FEXCore::ARMEmitter::QRegister rn2, FEXCore::ARMEmitter::QRegister rn3, FEXCore::ARMEmitter::QRegister rn4, FEXCore::ARMEmitter::DRegister rm) {
-    LOGMAN_THROW_A_FMT((rn.Idx() + 1) == rn2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rn2.Idx() + 1) == rn3.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rn3.Idx() + 1) == rn4.Idx(), "These must be sequential");
+  void tbx(DRegister rd, QRegister rn, QRegister rn2, QRegister rn3, QRegister rn4, DRegister rm) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rn, rn2, rn3, rn4), "rn, rn2, rn3, and rn4 must be sequential");
     constexpr uint32_t Op = 0b0000'1110'000 << 21;
     ASIMDTable(Op, 0, 0b00, 0b11, 0b1, rd.V(), rn.V(), rm.V());
   }

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/Emitter.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/Emitter.h
@@ -549,6 +549,31 @@ namespace FEXCore::ARMEmitter {
   template <typename T>
   concept IsXOrWRegister = std::is_same_v<T, XRegister> || std::is_same_v<T, WRegister>;
 
+  // Whether or not a given set of vector registers are sequential
+  // in increasing order as far as the register file is concerned (modulo its size)
+  //
+  // For example, a set of registers like:
+  //
+  // v1,  v2, v3 and
+  // v31, v0, v1
+  //
+  // would both be considered sequential sequences, and some instructions in particular
+  // limit register lists to these kind of sequences.
+  //
+  template <typename T, typename... Args>
+  constexpr bool AreVectorsSequential(T first, const Args&... args) {
+    // Ensure we always have a pair of registers to compare against.
+    static_assert(sizeof...(args) >= 1, "Number of arguments must be greater than 1");
+
+    const auto fn = [](auto& lhs, const auto& rhs) {
+      const auto result = ((lhs.Idx() + 1) % 32) == rhs.Idx();
+      lhs = rhs;
+      return result;
+    };
+
+    return (fn(first, args) && ...);
+  }
+
   // This is an emitter that is designed around the smallest code bloat as possible.
   // Eschewing most developer convenience in order to keep code as small as possible.
 

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/LoadstoreOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/LoadstoreOps.inl
@@ -37,380 +37,344 @@ public:
   }
 
   // Advanced SIMD load/store multiple structures
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  void ld1(T rt, FEXCore::ARMEmitter::Register rn) {
+  template<SubRegSize size, typename T>
+  void ld1(T rt, Register rn) {
     constexpr uint32_t Op = 0b0000'1100'000 << 21;
     constexpr uint32_t Opcode = 0b0111 << 12;
-    ASIMDLoadStoreMultipleStructure<size, true>(Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r0);
+    ASIMDLoadStoreMultipleStructure<size, true>(Op, Opcode, rt, rn, Reg::r0);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  void ld1(T rt, T rt2, FEXCore::ARMEmitter::Register rn) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+  template<SubRegSize size, typename T>
+  void ld1(T rt, T rt2, Register rn) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2), "rt and rt2 must be sequential");
     constexpr uint32_t Op = 0b0000'1100'000 << 21;
     constexpr uint32_t Opcode = 0b1010 << 12;
-    ASIMDLoadStoreMultipleStructure<size, true>(Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r0);
+    ASIMDLoadStoreMultipleStructure<size, true>(Op, Opcode, rt, rn, Reg::r0);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  void ld1(T rt, T rt2, T rt3, FEXCore::ARMEmitter::Register rn) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+  template<SubRegSize size, typename T>
+  void ld1(T rt, T rt2, T rt3, Register rn) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3), "rt, rt2, and rt3 must be sequential");
     constexpr uint32_t Op = 0b0000'1100'000 << 21;
     constexpr uint32_t Opcode = 0b0110 << 12;
-    ASIMDLoadStoreMultipleStructure<size, true>(Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r0);
+    ASIMDLoadStoreMultipleStructure<size, true>(Op, Opcode, rt, rn, Reg::r0);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  void ld1(T rt, T rt2, T rt3, T rt4, FEXCore::ARMEmitter::Register rn) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+  template<SubRegSize size, typename T>
+  void ld1(T rt, T rt2, T rt3, T rt4, Register rn) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3, rt4), "rt, rt2, rt3, and rt4 must be sequential");
     constexpr uint32_t Op = 0b0000'1100'000 << 21;
     constexpr uint32_t Opcode = 0b0010 << 12;
-    ASIMDLoadStoreMultipleStructure<size, true>(Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r0);
+    ASIMDLoadStoreMultipleStructure<size, true>(Op, Opcode, rt, rn, Reg::r0);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  void st1(T rt, FEXCore::ARMEmitter::Register rn) {
+  template<SubRegSize size, typename T>
+  void st1(T rt, Register rn) {
     constexpr uint32_t Op = 0b0000'1100'000 << 21;
     constexpr uint32_t Opcode = 0b0111 << 12;
-    ASIMDLoadStoreMultipleStructure<size, false>(Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r0);
+    ASIMDLoadStoreMultipleStructure<size, false>(Op, Opcode, rt, rn, Reg::r0);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  void st1(T rt, T rt2, FEXCore::ARMEmitter::Register rn) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+  template<SubRegSize size, typename T>
+  void st1(T rt, T rt2, Register rn) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2), "rt and rt2 must be sequential");
     constexpr uint32_t Op = 0b0000'1100'000 << 21;
     constexpr uint32_t Opcode = 0b1010 << 12;
-    ASIMDLoadStoreMultipleStructure<size, false>(Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r0);
+    ASIMDLoadStoreMultipleStructure<size, false>(Op, Opcode, rt, rn, Reg::r0);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  void st1(T rt, T rt2, T rt3, FEXCore::ARMEmitter::Register rn) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+  template<SubRegSize size, typename T>
+  void st1(T rt, T rt2, T rt3, Register rn) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3), "rt, rt2, and rt3 must be sequential");
     constexpr uint32_t Op = 0b0000'1100'000 << 21;
     constexpr uint32_t Opcode = 0b0110 << 12;
-    ASIMDLoadStoreMultipleStructure<size, false>(Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r0);
+    ASIMDLoadStoreMultipleStructure<size, false>(Op, Opcode, rt, rn, Reg::r0);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  void st1(T rt, T rt2, T rt3, T rt4, FEXCore::ARMEmitter::Register rn) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+  template<SubRegSize size, typename T>
+  void st1(T rt, T rt2, T rt3, T rt4, Register rn) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3, rt4), "rt, rt2, rt3, and rt4 must be sequential");
     constexpr uint32_t Op = 0b0000'1100'000 << 21;
     constexpr uint32_t Opcode = 0b0010 << 12;
-    ASIMDLoadStoreMultipleStructure<size, false>(Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r0);
+    ASIMDLoadStoreMultipleStructure<size, false>(Op, Opcode, rt, rn, Reg::r0);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  void ld2(T rt, T rt2, FEXCore::ARMEmitter::Register rn) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+  template<SubRegSize size, typename T>
+  void ld2(T rt, T rt2, Register rn) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2), "rt and rt2 must be sequential");
     constexpr uint32_t Op = 0b0000'1100'000 << 21;
     constexpr uint32_t Opcode = 0b1000 << 12;
-    ASIMDLoadStoreMultipleStructure<size, true>(Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r0);
+    ASIMDLoadStoreMultipleStructure<size, true>(Op, Opcode, rt, rn, Reg::r0);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  void st2(T rt, T rt2, FEXCore::ARMEmitter::Register rn) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+  template<SubRegSize size, typename T>
+  void st2(T rt, T rt2, Register rn) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2), "rt and rt2 must be sequential");
     constexpr uint32_t Op = 0b0000'1100'000 << 21;
     constexpr uint32_t Opcode = 0b1000 << 12;
-    ASIMDLoadStoreMultipleStructure<size, false>(Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r0);
+    ASIMDLoadStoreMultipleStructure<size, false>(Op, Opcode, rt, rn, Reg::r0);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  void ld3(T rt, T rt2, T rt3, FEXCore::ARMEmitter::Register rn) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+  template<SubRegSize size, typename T>
+  void ld3(T rt, T rt2, T rt3, Register rn) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3), "rt, rt2, and rt3 must be sequential");
     constexpr uint32_t Op = 0b0000'1100'000 << 21;
     constexpr uint32_t Opcode = 0b0100 << 12;
-    ASIMDLoadStoreMultipleStructure<size, true>(Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r0);
+    ASIMDLoadStoreMultipleStructure<size, true>(Op, Opcode, rt, rn, Reg::r0);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  void st3(T rt, T rt2, T rt3, FEXCore::ARMEmitter::Register rn) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+  template<SubRegSize size, typename T>
+  void st3(T rt, T rt2, T rt3, Register rn) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3), "rt, rt2, and rt3 must be sequential");
     constexpr uint32_t Op = 0b0000'1100'000 << 21;
     constexpr uint32_t Opcode = 0b0100 << 12;
-    ASIMDLoadStoreMultipleStructure<size, false>(Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r0);
+    ASIMDLoadStoreMultipleStructure<size, false>(Op, Opcode, rt, rn, Reg::r0);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  void ld4(T rt, T rt2, T rt3, T rt4, FEXCore::ARMEmitter::Register rn) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+  template<SubRegSize size, typename T>
+  void ld4(T rt, T rt2, T rt3, T rt4, Register rn) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3, rt4), "rt, rt2, rt3, and rt4 must be sequential");
     constexpr uint32_t Op = 0b0000'1100'000 << 21;
     constexpr uint32_t Opcode = 0b0000 << 12;
-    ASIMDLoadStoreMultipleStructure<size, true>(Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r0);
+    ASIMDLoadStoreMultipleStructure<size, true>(Op, Opcode, rt, rn, Reg::r0);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  void st4(T rt, T rt2, T rt3, T rt4, FEXCore::ARMEmitter::Register rn) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+  template<SubRegSize size, typename T>
+  void st4(T rt, T rt2, T rt3, T rt4, Register rn) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3, rt4), "rt, rt2, rt3, and rt4 must be sequential");
     constexpr uint32_t Op = 0b0000'1100'000 << 21;
     constexpr uint32_t Opcode = 0b0000 << 12;
-    ASIMDLoadStoreMultipleStructure<size, false>(Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r0);
+    ASIMDLoadStoreMultipleStructure<size, false>(Op, Opcode, rt, rn, Reg::r0);
   }
   // Advanced SIMD load/store multiple structures (post-indexed)
   static constexpr uint32_t ASIMDLoadstoreMultiplePost_Op = 0b0000'1100'100 << 21;
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  void ld1(T rt, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+  template<SubRegSize size, typename T>
+  void ld1(T rt, Register rn, Register rm) {
     constexpr uint32_t Opcode = 0b0111 << 12;
     ASIMDLoadStoreMultipleStructure<size, true>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, rm);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  void ld1(T rt, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+  template<SubRegSize size, typename T>
+  void ld1(T rt, Register rn, uint32_t PostOffset) {
     LOGMAN_THROW_A_FMT(
-      (std::is_same_v<FEXCore::ARMEmitter::QRegister, T> && (PostOffset == 16)) ||
-      (std::is_same_v<FEXCore::ARMEmitter::DRegister, T> && (PostOffset == 8)),
+      (std::is_same_v<QRegister, T> && (PostOffset == 16)) ||
+      (std::is_same_v<DRegister, T> && (PostOffset == 8)),
       "Post-index offset needs to match number of elements times their size");
 
     constexpr uint32_t Opcode = 0b0111 << 12;
-    ASIMDLoadStoreMultipleStructure<size, true>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r31);
+    ASIMDLoadStoreMultipleStructure<size, true>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, Reg::r31);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  void ld1(T rt, T rt2, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+  template<SubRegSize size, typename T>
+  void ld1(T rt, T rt2, Register rn, Register rm) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2), "rt and rt2 must be sequential");
     constexpr uint32_t Opcode = 0b1010 << 12;
     ASIMDLoadStoreMultipleStructure<size, true>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, rm);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  void ld1(T rt, T rt2, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+  template<SubRegSize size, typename T>
+  void ld1(T rt, T rt2, Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2), "rt and rt2 must be sequential");
     LOGMAN_THROW_A_FMT(
-      (std::is_same_v<FEXCore::ARMEmitter::QRegister, T> && (PostOffset == 32)) ||
-      (std::is_same_v<FEXCore::ARMEmitter::DRegister, T> && (PostOffset == 16)),
+      (std::is_same_v<QRegister, T> && (PostOffset == 32)) ||
+      (std::is_same_v<DRegister, T> && (PostOffset == 16)),
       "Post-index offset needs to match number of elements times their size");
 
     constexpr uint32_t Opcode = 0b1010 << 12;
-    ASIMDLoadStoreMultipleStructure<size, true>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r31);
+    ASIMDLoadStoreMultipleStructure<size, true>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, Reg::r31);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  void ld1(T rt, T rt2, T rt3, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+  template<SubRegSize size, typename T>
+  void ld1(T rt, T rt2, T rt3, Register rn, Register rm) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3), "rt, rt2, and rt3 must be sequential");
     constexpr uint32_t Opcode = 0b0110 << 12;
     ASIMDLoadStoreMultipleStructure<size, true>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, rm);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  void ld1(T rt, T rt2, T rt3, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+  template<SubRegSize size, typename T>
+  void ld1(T rt, T rt2, T rt3, Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3), "rt, rt2, and rt3 must be sequential");
     LOGMAN_THROW_A_FMT(
-      (std::is_same_v<FEXCore::ARMEmitter::QRegister, T> && (PostOffset == 48)) ||
-      (std::is_same_v<FEXCore::ARMEmitter::DRegister, T> && (PostOffset == 24)),
+      (std::is_same_v<QRegister, T> && (PostOffset == 48)) ||
+      (std::is_same_v<DRegister, T> && (PostOffset == 24)),
       "Post-index offset needs to match number of elements times their size");
 
     constexpr uint32_t Opcode = 0b0110 << 12;
-    ASIMDLoadStoreMultipleStructure<size, true>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r31);
+    ASIMDLoadStoreMultipleStructure<size, true>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, Reg::r31);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  void ld1(T rt, T rt2, T rt3, T rt4, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+  template<SubRegSize size, typename T>
+  void ld1(T rt, T rt2, T rt3, T rt4, Register rn, Register rm) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3, rt4), "rt, rt2, rt3, and rt4 must be sequential");
     constexpr uint32_t Opcode = 0b0010 << 12;
     ASIMDLoadStoreMultipleStructure<size, true>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, rm);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  void ld1(T rt, T rt2, T rt3, T rt4, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+  template<SubRegSize size, typename T>
+  void ld1(T rt, T rt2, T rt3, T rt4, Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3, rt4), "rt, rt2, rt3, and rt4 must be sequential");
     LOGMAN_THROW_A_FMT(
-      (std::is_same_v<FEXCore::ARMEmitter::QRegister, T> && (PostOffset == 64)) ||
-      (std::is_same_v<FEXCore::ARMEmitter::DRegister, T> && (PostOffset == 32)),
+      (std::is_same_v<QRegister, T> && (PostOffset == 64)) ||
+      (std::is_same_v<DRegister, T> && (PostOffset == 32)),
       "Post-index offset needs to match number of elements times their size");
 
     constexpr uint32_t Opcode = 0b0010 << 12;
-    ASIMDLoadStoreMultipleStructure<size, true>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r31);
+    ASIMDLoadStoreMultipleStructure<size, true>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, Reg::r31);
   }
 
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  void st1(T rt, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+  template<SubRegSize size, typename T>
+  void st1(T rt, Register rn, Register rm) {
     constexpr uint32_t Opcode = 0b0111 << 12;
     ASIMDLoadStoreMultipleStructure<size, false>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, rm);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  void st1(T rt, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+  template<SubRegSize size, typename T>
+  void st1(T rt, Register rn, uint32_t PostOffset) {
     LOGMAN_THROW_A_FMT(
-      (std::is_same_v<FEXCore::ARMEmitter::QRegister, T> && (PostOffset == 16)) ||
-      (std::is_same_v<FEXCore::ARMEmitter::DRegister, T> && (PostOffset == 8)),
+      (std::is_same_v<QRegister, T> && (PostOffset == 16)) ||
+      (std::is_same_v<DRegister, T> && (PostOffset == 8)),
       "Post-index offset needs to match number of elements times their size");
 
     constexpr uint32_t Opcode = 0b0111 << 12;
-    ASIMDLoadStoreMultipleStructure<size, false>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r31);
+    ASIMDLoadStoreMultipleStructure<size, false>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, Reg::r31);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  void st1(T rt, T rt2, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+  template<SubRegSize size, typename T>
+  void st1(T rt, T rt2, Register rn, Register rm) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2), "rt and rt2 must be sequential");
     constexpr uint32_t Opcode = 0b1010 << 12;
     ASIMDLoadStoreMultipleStructure<size, false>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, rm);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  void st1(T rt, T rt2, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+  template<SubRegSize size, typename T>
+  void st1(T rt, T rt2, Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2), "rt and rt2 must be sequential");
     LOGMAN_THROW_A_FMT(
-      (std::is_same_v<FEXCore::ARMEmitter::QRegister, T> && (PostOffset == 32)) ||
-      (std::is_same_v<FEXCore::ARMEmitter::DRegister, T> && (PostOffset == 16)),
+      (std::is_same_v<QRegister, T> && (PostOffset == 32)) ||
+      (std::is_same_v<DRegister, T> && (PostOffset == 16)),
       "Post-index offset needs to match number of elements times their size");
 
     constexpr uint32_t Opcode = 0b1010 << 12;
-    ASIMDLoadStoreMultipleStructure<size, false>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r31);
+    ASIMDLoadStoreMultipleStructure<size, false>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, Reg::r31);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  void st1(T rt, T rt2, T rt3, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+  template<SubRegSize size, typename T>
+  void st1(T rt, T rt2, T rt3, Register rn, Register rm) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3), "rt, rt2, and rt3 must be sequential");
     constexpr uint32_t Opcode = 0b0110 << 12;
     ASIMDLoadStoreMultipleStructure<size, false>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, rm);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  void st1(T rt, T rt2, T rt3, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+  template<SubRegSize size, typename T>
+  void st1(T rt, T rt2, T rt3, Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3), "rt, rt2, and rt3 must be sequential");
     LOGMAN_THROW_A_FMT(
-      (std::is_same_v<FEXCore::ARMEmitter::QRegister, T> && (PostOffset == 48)) ||
-      (std::is_same_v<FEXCore::ARMEmitter::DRegister, T> && (PostOffset == 24)),
+      (std::is_same_v<QRegister, T> && (PostOffset == 48)) ||
+      (std::is_same_v<DRegister, T> && (PostOffset == 24)),
       "Post-index offset needs to match number of elements times their size");
 
     constexpr uint32_t Opcode = 0b0110 << 12;
-    ASIMDLoadStoreMultipleStructure<size, false>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r31);
+    ASIMDLoadStoreMultipleStructure<size, false>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, Reg::r31);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  void st1(T rt, T rt2, T rt3, T rt4, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+  template<SubRegSize size, typename T>
+  void st1(T rt, T rt2, T rt3, T rt4, Register rn, Register rm) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3, rt4), "rt, rt2, rt3, and rt4 must be sequential");
     constexpr uint32_t Opcode = 0b0010 << 12;
     ASIMDLoadStoreMultipleStructure<size, false>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, rm);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  void st1(T rt, T rt2, T rt3, T rt4, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+  template<SubRegSize size, typename T>
+  void st1(T rt, T rt2, T rt3, T rt4, Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3, rt4), "rt, rt2, rt3, and rt4 must be sequential");
     LOGMAN_THROW_A_FMT(
-      (std::is_same_v<FEXCore::ARMEmitter::QRegister, T> && (PostOffset == 64)) ||
-      (std::is_same_v<FEXCore::ARMEmitter::DRegister, T> && (PostOffset == 32)),
+      (std::is_same_v<QRegister, T> && (PostOffset == 64)) ||
+      (std::is_same_v<DRegister, T> && (PostOffset == 32)),
       "Post-index offset needs to match number of elements times their size");
 
     constexpr uint32_t Opcode = 0b0010 << 12;
-    ASIMDLoadStoreMultipleStructure<size, false>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r31);
+    ASIMDLoadStoreMultipleStructure<size, false>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, Reg::r31);
   }
 
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  void ld2(T rt, T rt2, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+  template<SubRegSize size, typename T>
+  void ld2(T rt, T rt2, Register rn, Register rm) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2), "rt and rt2 must be sequential");
     constexpr uint32_t Opcode = 0b1000 << 12;
     ASIMDLoadStoreMultipleStructure<size, true>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, rm);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  void ld2(T rt, T rt2, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+  template<SubRegSize size, typename T>
+  void ld2(T rt, T rt2, Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2), "rt and rt2 must be sequential");
     LOGMAN_THROW_A_FMT(
-      (std::is_same_v<FEXCore::ARMEmitter::QRegister, T> && (PostOffset == 32)) ||
-      (std::is_same_v<FEXCore::ARMEmitter::DRegister, T> && (PostOffset == 16)),
+      (std::is_same_v<QRegister, T> && (PostOffset == 32)) ||
+      (std::is_same_v<DRegister, T> && (PostOffset == 16)),
       "Post-index offset needs to match number of elements times their size");
 
     constexpr uint32_t Opcode = 0b1000 << 12;
-    ASIMDLoadStoreMultipleStructure<size, true>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r31);
+    ASIMDLoadStoreMultipleStructure<size, true>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, Reg::r31);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  void st2(T rt, T rt2, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+  template<SubRegSize size, typename T>
+  void st2(T rt, T rt2, Register rn, Register rm) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2), "rt and rt2 must be sequential");
     constexpr uint32_t Opcode = 0b1000 << 12;
     ASIMDLoadStoreMultipleStructure<size, false>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, rm);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  void st2(T rt, T rt2, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+  template<SubRegSize size, typename T>
+  void st2(T rt, T rt2, Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2), "rt and rt2 must be sequential");
     LOGMAN_THROW_A_FMT(
-      (std::is_same_v<FEXCore::ARMEmitter::QRegister, T> && (PostOffset == 32)) ||
-      (std::is_same_v<FEXCore::ARMEmitter::DRegister, T> && (PostOffset == 16)),
+      (std::is_same_v<QRegister, T> && (PostOffset == 32)) ||
+      (std::is_same_v<DRegister, T> && (PostOffset == 16)),
       "Post-index offset needs to match number of elements times their size");
 
     constexpr uint32_t Opcode = 0b1000 << 12;
-    ASIMDLoadStoreMultipleStructure<size, false>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r31);
+    ASIMDLoadStoreMultipleStructure<size, false>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, Reg::r31);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  void ld3(T rt, T rt2, T rt3, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+  template<SubRegSize size, typename T>
+  void ld3(T rt, T rt2, T rt3, Register rn, Register rm) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3), "rt, rt2, and rt3 must be sequential");
     constexpr uint32_t Opcode = 0b0100 << 12;
     ASIMDLoadStoreMultipleStructure<size, true>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, rm);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  void ld3(T rt, T rt2, T rt3, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+  template<SubRegSize size, typename T>
+  void ld3(T rt, T rt2, T rt3, Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3), "rt, rt2, and rt3 must be sequential");
     LOGMAN_THROW_A_FMT(
-      (std::is_same_v<FEXCore::ARMEmitter::QRegister, T> && (PostOffset == 48)) ||
-      (std::is_same_v<FEXCore::ARMEmitter::DRegister, T> && (PostOffset == 24)),
+      (std::is_same_v<QRegister, T> && (PostOffset == 48)) ||
+      (std::is_same_v<DRegister, T> && (PostOffset == 24)),
       "Post-index offset needs to match number of elements times their size");
 
     constexpr uint32_t Opcode = 0b0100 << 12;
-    ASIMDLoadStoreMultipleStructure<size, true>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r31);
+    ASIMDLoadStoreMultipleStructure<size, true>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, Reg::r31);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  void st3(T rt, T rt2, T rt3, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+  template<SubRegSize size, typename T>
+  void st3(T rt, T rt2, T rt3, Register rn, Register rm) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3), "rt, rt2, and rt3 must be sequential");
     constexpr uint32_t Opcode = 0b0100 << 12;
     ASIMDLoadStoreMultipleStructure<size, false>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, rm);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  void st3(T rt, T rt2, T rt3, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+  template<SubRegSize size, typename T>
+  void st3(T rt, T rt2, T rt3, Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3), "rt, rt2, and rt3 must be sequential");
     LOGMAN_THROW_A_FMT(
-      (std::is_same_v<FEXCore::ARMEmitter::QRegister, T> && (PostOffset == 48)) ||
-      (std::is_same_v<FEXCore::ARMEmitter::DRegister, T> && (PostOffset == 24)),
+      (std::is_same_v<QRegister, T> && (PostOffset == 48)) ||
+      (std::is_same_v<DRegister, T> && (PostOffset == 24)),
       "Post-index offset needs to match number of elements times their size");
 
     constexpr uint32_t Opcode = 0b0100 << 12;
-    ASIMDLoadStoreMultipleStructure<size, false>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r31);
+    ASIMDLoadStoreMultipleStructure<size, false>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, Reg::r31);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  void ld4(T rt, T rt2, T rt3, T rt4, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+  template<SubRegSize size, typename T>
+  void ld4(T rt, T rt2, T rt3, T rt4, Register rn, Register rm) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3, rt4), "rt, rt2, rt3, and rt4 must be sequential");
     constexpr uint32_t Opcode = 0b0000 << 12;
     ASIMDLoadStoreMultipleStructure<size, true>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, rm);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  void ld4(T rt, T rt2, T rt3, T rt4, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+  template<SubRegSize size, typename T>
+  void ld4(T rt, T rt2, T rt3, T rt4, Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3, rt4), "rt, rt2, rt3, and rt4 must be sequential");
     LOGMAN_THROW_A_FMT(
-      (std::is_same_v<FEXCore::ARMEmitter::QRegister, T> && (PostOffset == 64)) ||
-      (std::is_same_v<FEXCore::ARMEmitter::DRegister, T> && (PostOffset == 32)),
+      (std::is_same_v<QRegister, T> && (PostOffset == 64)) ||
+      (std::is_same_v<DRegister, T> && (PostOffset == 32)),
       "Post-index offset needs to match number of elements times their size");
 
     constexpr uint32_t Opcode = 0b0000 << 12;
-    ASIMDLoadStoreMultipleStructure<size, true>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r31);
+    ASIMDLoadStoreMultipleStructure<size, true>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, Reg::r31);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  void st4(T rt, T rt2, T rt3, T rt4, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+  template<SubRegSize size, typename T>
+  void st4(T rt, T rt2, T rt3, T rt4, Register rn, Register rm) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3, rt4), "rt, rt2, rt3, and rt4 must be sequential");
     constexpr uint32_t Opcode = 0b0000 << 12;
     ASIMDLoadStoreMultipleStructure<size, false>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, rm);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  void st4(T rt, T rt2, T rt3, T rt4, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+  template<SubRegSize size, typename T>
+  void st4(T rt, T rt2, T rt3, T rt4, Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3, rt4), "rt, rt2, rt3, and rt4 must be sequential");
     LOGMAN_THROW_A_FMT(
-      (std::is_same_v<FEXCore::ARMEmitter::QRegister, T> && (PostOffset == 64)) ||
-      (std::is_same_v<FEXCore::ARMEmitter::DRegister, T> && (PostOffset == 32)),
+      (std::is_same_v<QRegister, T> && (PostOffset == 64)) ||
+      (std::is_same_v<DRegister, T> && (PostOffset == 32)),
       "Post-index offset needs to match number of elements times their size");
 
     constexpr uint32_t Opcode = 0b0000 << 12;
-    ASIMDLoadStoreMultipleStructure<size, false>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r31);
+    ASIMDLoadStoreMultipleStructure<size, false>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, Reg::r31);
   }
 
   // ASIMD loadstore single
-  template<FEXCore::ARMEmitter::SubRegSize size>
-  void st1(FEXCore::ARMEmitter::VRegister rt, uint32_t Index, FEXCore::ARMEmitter::Register rn) {
+  template<SubRegSize size>
+  void st1(VRegister rt, uint32_t Index, Register rn) {
     constexpr uint32_t Op = 0b0000'1101'000 << 21;
     constexpr uint32_t Opcode =
         size == SubRegSize::i8Bit  ? 0b000 : // Scale = 0
@@ -418,11 +382,11 @@ public:
         size == SubRegSize::i32Bit ? 0b100 : // Scale = 2
         size == SubRegSize::i64Bit ? 0b100 : // Scale = 2 (Uses size to determine difference between 32-bit).
         0;
-    ASIMDSTLD<size, false, 1>(Op, Opcode, rt, Index, rn, FEXCore::ARMEmitter::Reg::r0);
+    ASIMDSTLD<size, false, 1>(Op, Opcode, rt, Index, rn, Reg::r0);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size>
-  void st2(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::VRegister rt2, uint32_t Index, FEXCore::ARMEmitter::Register rn) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+  template<SubRegSize size>
+  void st2(VRegister rt, VRegister rt2, uint32_t Index, Register rn) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2), "rt and rt2 must be sequential");
     constexpr uint32_t Op = 0b0000'1101'000 << 21;
     constexpr uint32_t Opcode =
         size == SubRegSize::i8Bit  ? 0b000 : // Scale = 0
@@ -430,12 +394,11 @@ public:
         size == SubRegSize::i32Bit ? 0b100 : // Scale = 2
         size == SubRegSize::i64Bit ? 0b100 : // Scale = 2 (Uses size to determine difference between 32-bit).
         0;
-    ASIMDSTLD<size, false, 2>(Op, Opcode, rt, Index, rn, FEXCore::ARMEmitter::Reg::r0);
+    ASIMDSTLD<size, false, 2>(Op, Opcode, rt, Index, rn, Reg::r0);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size>
-  void st3(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::VRegister rt2, FEXCore::ARMEmitter::VRegister rt3, uint32_t Index, FEXCore::ARMEmitter::Register rn) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+  template<SubRegSize size>
+  void st3(VRegister rt, VRegister rt2, VRegister rt3, uint32_t Index, Register rn) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3), "rt, rt2, and rt3 must be sequential");
     constexpr uint32_t Op = 0b0000'1101'000 << 21;
     constexpr uint32_t Opcode =
         size == SubRegSize::i8Bit  ? 0b000 : // Scale = 0
@@ -443,13 +406,11 @@ public:
         size == SubRegSize::i32Bit ? 0b100 : // Scale = 2
         size == SubRegSize::i64Bit ? 0b100 : // Scale = 2 (Uses size to determine difference between 32-bit).
         0;
-    ASIMDSTLD<size, false, 3>(Op, Opcode, rt, Index, rn, FEXCore::ARMEmitter::Reg::r0);
+    ASIMDSTLD<size, false, 3>(Op, Opcode, rt, Index, rn, Reg::r0);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size>
-  void st4(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::VRegister rt2, FEXCore::ARMEmitter::VRegister rt3, FEXCore::ARMEmitter::VRegister rt4, uint32_t Index, FEXCore::ARMEmitter::Register rn) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+  template<SubRegSize size>
+  void st4(VRegister rt, VRegister rt2, VRegister rt3, VRegister rt4, uint32_t Index, Register rn) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3, rt4), "rt, rt2, rt3, and rt4 must be sequential");
     constexpr uint32_t Op = 0b0000'1101'000 << 21;
     constexpr uint32_t Opcode =
         size == SubRegSize::i8Bit  ? 0b000 : // Scale = 0
@@ -457,10 +418,10 @@ public:
         size == SubRegSize::i32Bit ? 0b100 : // Scale = 2
         size == SubRegSize::i64Bit ? 0b100 : // Scale = 2 (Uses size to determine difference between 32-bit).
         0;
-    ASIMDSTLD<size, false, 4>(Op, Opcode, rt, Index, rn, FEXCore::ARMEmitter::Reg::r0);
+    ASIMDSTLD<size, false, 4>(Op, Opcode, rt, Index, rn, Reg::r0);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size>
-  void ld1(FEXCore::ARMEmitter::VRegister rt, uint32_t Index, FEXCore::ARMEmitter::Register rn) {
+  template<SubRegSize size>
+  void ld1(VRegister rt, uint32_t Index, Register rn) {
     constexpr uint32_t Op = 0b0000'1101'000 << 21;
     constexpr uint32_t Opcode =
         size == SubRegSize::i8Bit  ? 0b000 : // Scale = 0
@@ -468,18 +429,18 @@ public:
         size == SubRegSize::i32Bit ? 0b100 : // Scale = 2
         size == SubRegSize::i64Bit ? 0b100 : // Scale = 2 (Uses size to determine difference between 32-bit).
         0;
-    ASIMDSTLD<size, true, 1>(Op, Opcode, rt, Index, rn, FEXCore::ARMEmitter::Reg::r0);
+    ASIMDSTLD<size, true, 1>(Op, Opcode, rt, Index, rn, Reg::r0);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
-  void ld1r(T rt, FEXCore::ARMEmitter::Register rn) {
+  template<SubRegSize size, typename T>
+  requires(std::is_same_v<QRegister, T> || std::is_same_v<DRegister, T>)
+  void ld1r(T rt, Register rn) {
     constexpr uint32_t Op = 0b0000'1101'000 << 21;
     constexpr uint32_t Opcode = 0b110;
-    ASIMDSTLD<size, true, 1>(Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r0);
+    ASIMDSTLD<size, true, 1>(Op, Opcode, rt, rn, Reg::r0);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size>
-  void ld2(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::VRegister rt2, uint32_t Index, FEXCore::ARMEmitter::Register rn) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+  template<SubRegSize size>
+  void ld2(VRegister rt, VRegister rt2, uint32_t Index, Register rn) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2), "rt and rt2 must be sequential");
     constexpr uint32_t Op = 0b0000'1101'000 << 21;
     constexpr uint32_t Opcode =
         size == SubRegSize::i8Bit  ? 0b000 : // Scale = 0
@@ -487,20 +448,19 @@ public:
         size == SubRegSize::i32Bit ? 0b100 : // Scale = 2
         size == SubRegSize::i64Bit ? 0b100 : // Scale = 2 (Uses size to determine difference between 32-bit).
         0;
-    ASIMDSTLD<size, true, 2>(Op, Opcode, rt, Index, rn, FEXCore::ARMEmitter::Reg::r0);
+    ASIMDSTLD<size, true, 2>(Op, Opcode, rt, Index, rn, Reg::r0);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
-  void ld2r(T rt, T rt2, FEXCore::ARMEmitter::Register rn) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+  template<SubRegSize size, typename T>
+  requires(std::is_same_v<QRegister, T> || std::is_same_v<DRegister, T>)
+  void ld2r(T rt, T rt2, Register rn) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2), "rt and rt2 must be sequential");
     constexpr uint32_t Op = 0b0000'1101'000 << 21;
     constexpr uint32_t Opcode = 0b110;
-    ASIMDSTLD<size, true, 2>(Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r0);
+    ASIMDSTLD<size, true, 2>(Op, Opcode, rt, rn, Reg::r0);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size>
-  void ld3(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::VRegister rt2, FEXCore::ARMEmitter::VRegister rt3, uint32_t Index, FEXCore::ARMEmitter::Register rn) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+  template<SubRegSize size>
+  void ld3(VRegister rt, VRegister rt2, VRegister rt3, uint32_t Index, Register rn) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3), "rt, rt2, and rt3 must be sequential");
     constexpr uint32_t Op = 0b0000'1101'000 << 21;
     constexpr uint32_t Opcode =
         size == SubRegSize::i8Bit  ? 0b000 : // Scale = 0
@@ -508,22 +468,19 @@ public:
         size == SubRegSize::i32Bit ? 0b100 : // Scale = 2
         size == SubRegSize::i64Bit ? 0b100 : // Scale = 2 (Uses size to determine difference between 32-bit).
         0;
-    ASIMDSTLD<size, true, 3>(Op, Opcode, rt, Index, rn, FEXCore::ARMEmitter::Reg::r0);
+    ASIMDSTLD<size, true, 3>(Op, Opcode, rt, Index, rn, Reg::r0);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
-  void ld3r(T rt, T rt2, T rt3, FEXCore::ARMEmitter::Register rn) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+  template<SubRegSize size, typename T>
+  requires(std::is_same_v<QRegister, T> || std::is_same_v<DRegister, T>)
+  void ld3r(T rt, T rt2, T rt3, Register rn) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3), "rt, rt2, and rt3 must be sequential");
     constexpr uint32_t Op = 0b0000'1101'000 << 21;
     constexpr uint32_t Opcode = 0b110;
-    ASIMDSTLD<size, true, 3>(Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r0);
+    ASIMDSTLD<size, true, 3>(Op, Opcode, rt, rn, Reg::r0);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size>
-  void ld4(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::VRegister rt2, FEXCore::ARMEmitter::VRegister rt3, FEXCore::ARMEmitter::VRegister rt4, uint32_t Index, FEXCore::ARMEmitter::Register rn) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+  template<SubRegSize size>
+  void ld4(VRegister rt, VRegister rt2, VRegister rt3, VRegister rt4, uint32_t Index, Register rn) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3, rt4), "rt, rt2, rt3, and rt4 must be sequential");
     constexpr uint32_t Op = 0b0000'1101'000 << 21;
     constexpr uint32_t Opcode =
         size == SubRegSize::i8Bit  ? 0b000 : // Scale = 0
@@ -531,22 +488,20 @@ public:
         size == SubRegSize::i32Bit ? 0b100 : // Scale = 2
         size == SubRegSize::i64Bit ? 0b100 : // Scale = 2 (Uses size to determine difference between 32-bit).
         0;
-    ASIMDSTLD<size, true, 4>(Op, Opcode, rt, Index, rn, FEXCore::ARMEmitter::Reg::r0);
+    ASIMDSTLD<size, true, 4>(Op, Opcode, rt, Index, rn, Reg::r0);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size, typename T>
-  requires(std::is_same_v<FEXCore::ARMEmitter::QRegister, T> || std::is_same_v<FEXCore::ARMEmitter::DRegister, T>)
-  void ld4r(T rt, T rt2, T rt3, T rt4, FEXCore::ARMEmitter::Register rn) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+  template<SubRegSize size, typename T>
+  requires(std::is_same_v<QRegister, T> || std::is_same_v<DRegister, T>)
+  void ld4r(T rt, T rt2, T rt3, T rt4, Register rn) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3, rt4), "rt, rt2, rt3, and rt4 must be sequential");
     constexpr uint32_t Op = 0b0000'1101'000 << 21;
     constexpr uint32_t Opcode = 0b110;
-    ASIMDSTLD<size, true, 4>(Op, Opcode, rt, rn, FEXCore::ARMEmitter::Reg::r0);
+    ASIMDSTLD<size, true, 4>(Op, Opcode, rt, rn, Reg::r0);
   }
 
   // ASIMD loadstore single post-indexed
-  template<FEXCore::ARMEmitter::SubRegSize size>
-  void st1(FEXCore::ARMEmitter::VRegister rt, uint32_t Index, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+  template<SubRegSize size>
+  void st1(VRegister rt, uint32_t Index, Register rn, Register rm) {
     constexpr uint32_t Op = 0b0000'1101'100 << 21;
     constexpr uint32_t Opcode =
         size == SubRegSize::i8Bit  ? 0b000 : // Scale = 0
@@ -556,8 +511,8 @@ public:
         0;
     ASIMDSTLD<size, false, 1>(Op, Opcode, rt, Index, rn, rm);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size>
-  void st1(FEXCore::ARMEmitter::VRegister rt, uint32_t Index, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+  template<SubRegSize size>
+  void st1(VRegister rt, uint32_t Index, Register rn, uint32_t PostOffset) {
     LOGMAN_THROW_A_FMT(
       (size == SubRegSize::i8Bit && (PostOffset == 1)) ||
       (size == SubRegSize::i16Bit && (PostOffset == 2)) ||
@@ -571,11 +526,11 @@ public:
         size == SubRegSize::i32Bit ? 0b100 : // Scale = 2
         size == SubRegSize::i64Bit ? 0b100 : // Scale = 2 (Uses size to determine difference between 32-bit).
         0;
-    ASIMDSTLD<size, false, 1>(Op, Opcode, rt, Index, rn, FEXCore::ARMEmitter::Reg::r31);
+    ASIMDSTLD<size, false, 1>(Op, Opcode, rt, Index, rn, Reg::r31);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size>
-  void st2(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::VRegister rt2, uint32_t Index, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+  template<SubRegSize size>
+  void st2(VRegister rt, VRegister rt2, uint32_t Index, Register rn, Register rm) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2), "rt and rt2 must be sequential");
     constexpr uint32_t Op = 0b0000'1101'100 << 21;
     constexpr uint32_t Opcode =
         size == SubRegSize::i8Bit  ? 0b000 : // Scale = 0
@@ -585,8 +540,8 @@ public:
         0;
     ASIMDSTLD<size, false, 2>(Op, Opcode, rt, Index, rn, rm);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size>
-  void st2(FEXCore::ARMEmitter::VRegister rt, uint32_t Index, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+  template<SubRegSize size>
+  void st2(VRegister rt, uint32_t Index, Register rn, uint32_t PostOffset) {
     LOGMAN_THROW_A_FMT(
       (size == SubRegSize::i8Bit && (PostOffset == 2)) ||
       (size == SubRegSize::i16Bit && (PostOffset == 4)) ||
@@ -600,12 +555,11 @@ public:
         size == SubRegSize::i32Bit ? 0b100 : // Scale = 2
         size == SubRegSize::i64Bit ? 0b100 : // Scale = 2 (Uses size to determine difference between 32-bit).
         0;
-    ASIMDSTLD<size, false, 2>(Op, Opcode, rt, Index, rn, FEXCore::ARMEmitter::Reg::r31);
+    ASIMDSTLD<size, false, 2>(Op, Opcode, rt, Index, rn, Reg::r31);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size>
-  void st3(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::VRegister rt2, FEXCore::ARMEmitter::VRegister rt3, uint32_t Index, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+  template<SubRegSize size>
+  void st3(VRegister rt, VRegister rt2, VRegister rt3, uint32_t Index, Register rn, Register rm) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3), "rt, rt2, and rt3 must be sequential");
     constexpr uint32_t Op = 0b0000'1101'100 << 21;
     constexpr uint32_t Opcode =
         size == SubRegSize::i8Bit  ? 0b000 : // Scale = 0
@@ -615,8 +569,8 @@ public:
         0;
     ASIMDSTLD<size, false, 3>(Op, Opcode, rt, Index, rn, rm);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size>
-  void st3(FEXCore::ARMEmitter::VRegister rt, uint32_t Index, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+  template<SubRegSize size>
+  void st3(VRegister rt, uint32_t Index, Register rn, uint32_t PostOffset) {
     LOGMAN_THROW_A_FMT(
       (size == SubRegSize::i8Bit && (PostOffset == 3)) ||
       (size == SubRegSize::i16Bit && (PostOffset == 6)) ||
@@ -630,13 +584,11 @@ public:
         size == SubRegSize::i32Bit ? 0b100 : // Scale = 2
         size == SubRegSize::i64Bit ? 0b100 : // Scale = 2 (Uses size to determine difference between 32-bit).
         0;
-    ASIMDSTLD<size, false, 3>(Op, Opcode, rt, Index, rn, FEXCore::ARMEmitter::Reg::r31);
+    ASIMDSTLD<size, false, 3>(Op, Opcode, rt, Index, rn, Reg::r31);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size>
-  void st4(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::VRegister rt2, FEXCore::ARMEmitter::VRegister rt3, FEXCore::ARMEmitter::VRegister rt4, uint32_t Index, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+  template<SubRegSize size>
+  void st4(VRegister rt, VRegister rt2, VRegister rt3, VRegister rt4, uint32_t Index, Register rn, Register rm) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3, rt4), "rt, rt2, rt3, and rt4 must be sequential");
     constexpr uint32_t Op = 0b0000'1101'100 << 21;
     constexpr uint32_t Opcode =
         size == SubRegSize::i8Bit  ? 0b000 : // Scale = 0
@@ -646,8 +598,8 @@ public:
         0;
     ASIMDSTLD<size, false, 4>(Op, Opcode, rt, Index, rn, rm);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size>
-  void st4(FEXCore::ARMEmitter::VRegister rt, uint32_t Index, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+  template<SubRegSize size>
+  void st4(VRegister rt, uint32_t Index, Register rn, uint32_t PostOffset) {
     LOGMAN_THROW_A_FMT(
       (size == SubRegSize::i8Bit && (PostOffset == 4)) ||
       (size == SubRegSize::i16Bit && (PostOffset == 8)) ||
@@ -661,10 +613,10 @@ public:
         size == SubRegSize::i32Bit ? 0b100 : // Scale = 2
         size == SubRegSize::i64Bit ? 0b100 : // Scale = 2 (Uses size to determine difference between 32-bit).
         0;
-    ASIMDSTLD<size, false, 4>(Op, Opcode, rt, Index, rn, FEXCore::ARMEmitter::Reg::r31);
+    ASIMDSTLD<size, false, 4>(Op, Opcode, rt, Index, rn, Reg::r31);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size>
-  void ld1(FEXCore::ARMEmitter::VRegister rt, uint32_t Index, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+  template<SubRegSize size>
+  void ld1(VRegister rt, uint32_t Index, Register rn, Register rm) {
     constexpr uint32_t Op = 0b0000'1101'100 << 21;
     constexpr uint32_t Opcode =
         size == SubRegSize::i8Bit  ? 0b000 : // Scale = 0
@@ -674,8 +626,8 @@ public:
         0;
     ASIMDSTLD<size, true, 1>(Op, Opcode, rt, Index, rn, rm);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size>
-  void ld1(FEXCore::ARMEmitter::VRegister rt, uint32_t Index, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+  template<SubRegSize size>
+  void ld1(VRegister rt, uint32_t Index, Register rn, uint32_t PostOffset) {
     LOGMAN_THROW_A_FMT(
       (size == SubRegSize::i8Bit && (PostOffset == 1)) ||
       (size == SubRegSize::i16Bit && (PostOffset == 2)) ||
@@ -688,16 +640,16 @@ public:
         size == SubRegSize::i32Bit ? 0b100 : // Scale = 2
         size == SubRegSize::i64Bit ? 0b100 : // Scale = 2 (Uses size to determine difference between 32-bit).
         0;
-    ASIMDSTLD<size, true, 1>(Op, Opcode, rt, Index, rn, FEXCore::ARMEmitter::Reg::r31);
+    ASIMDSTLD<size, true, 1>(Op, Opcode, rt, Index, rn, Reg::r31);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size>
-  void ld1r(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+  template<SubRegSize size>
+  void ld1r(VRegister rt, Register rn, Register rm) {
     constexpr uint32_t Op = 0b0000'1101'100 << 21;
     constexpr uint32_t Opcode = 0b110;
     ASIMDSTLD<size, true, 1>(Op, Opcode, rt, 0, rn, rm);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size>
-  void ld1r(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+  template<SubRegSize size>
+  void ld1r(VRegister rt, Register rn, uint32_t PostOffset) {
     LOGMAN_THROW_A_FMT(
       (size == SubRegSize::i8Bit && (PostOffset == 1)) ||
       (size == SubRegSize::i16Bit && (PostOffset == 2)) ||
@@ -705,11 +657,11 @@ public:
       (size == SubRegSize::i64Bit && (PostOffset == 8)), "Post-index offset needs to match number of elements times their size");
     constexpr uint32_t Op = 0b0000'1101'100 << 21;
     constexpr uint32_t Opcode = 0b110;
-    ASIMDSTLD<size, true, 1>(Op, Opcode, rt, 0, rn, FEXCore::ARMEmitter::Reg::r31);
+    ASIMDSTLD<size, true, 1>(Op, Opcode, rt, 0, rn, Reg::r31);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size>
-  void ld2(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::VRegister rt2, uint32_t Index, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+  template<SubRegSize size>
+  void ld2(VRegister rt, VRegister rt2, uint32_t Index, Register rn, Register rm) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2), "rt and rt2 must be sequential");
     constexpr uint32_t Op = 0b0000'1101'100 << 21;
     constexpr uint32_t Opcode =
         size == SubRegSize::i8Bit  ? 0b000 : // Scale = 0
@@ -719,8 +671,8 @@ public:
         0;
     ASIMDSTLD<size, true, 2>(Op, Opcode, rt, Index, rn, rm);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size>
-  void ld2(FEXCore::ARMEmitter::VRegister rt, uint32_t Index, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+  template<SubRegSize size>
+  void ld2(VRegister rt, uint32_t Index, Register rn, uint32_t PostOffset) {
     LOGMAN_THROW_A_FMT(
       (size == SubRegSize::i8Bit && (PostOffset == 2)) ||
       (size == SubRegSize::i16Bit && (PostOffset == 4)) ||
@@ -733,18 +685,18 @@ public:
         size == SubRegSize::i32Bit ? 0b100 : // Scale = 2
         size == SubRegSize::i64Bit ? 0b100 : // Scale = 2 (Uses size to determine difference between 32-bit).
         0;
-    ASIMDSTLD<size, true, 2>(Op, Opcode, rt, Index, rn, FEXCore::ARMEmitter::Reg::r31);
+    ASIMDSTLD<size, true, 2>(Op, Opcode, rt, Index, rn, Reg::r31);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size>
-  void ld2r(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::VRegister rt2, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+  template<SubRegSize size>
+  void ld2r(VRegister rt, VRegister rt2, Register rn, Register rm) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2), "rt and rt2 must be sequential");
     constexpr uint32_t Op = 0b0000'1101'100 << 21;
     constexpr uint32_t Opcode = 0b110;
     ASIMDSTLD<size, true, 2>(Op, Opcode, rt, 0, rn, rm);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size>
-  void ld2r(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::VRegister rt2, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+  template<SubRegSize size>
+  void ld2r(VRegister rt, VRegister rt2, Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2), "rt and rt2 must be sequential");
     LOGMAN_THROW_A_FMT(
       (size == SubRegSize::i8Bit && (PostOffset == 2)) ||
       (size == SubRegSize::i16Bit && (PostOffset == 4)) ||
@@ -752,12 +704,11 @@ public:
       (size == SubRegSize::i64Bit && (PostOffset == 16)), "Post-index offset needs to match number of elements times their size");
     constexpr uint32_t Op = 0b0000'1101'100 << 21;
     constexpr uint32_t Opcode = 0b110;
-    ASIMDSTLD<size, true, 2>(Op, Opcode, rt, 0, rn, FEXCore::ARMEmitter::Reg::r31);
+    ASIMDSTLD<size, true, 2>(Op, Opcode, rt, 0, rn, Reg::r31);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size>
-  void ld3(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::VRegister rt2, FEXCore::ARMEmitter::VRegister rt3, uint32_t Index, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+  template<SubRegSize size>
+  void ld3(VRegister rt, VRegister rt2, VRegister rt3, uint32_t Index, Register rn, Register rm) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3), "rt, rt2, and rt3 must be sequential");
     constexpr uint32_t Op = 0b0000'1101'100 << 21;
     constexpr uint32_t Opcode =
         size == SubRegSize::i8Bit  ? 0b000 : // Scale = 0
@@ -767,8 +718,8 @@ public:
         0;
     ASIMDSTLD<size, true, 3>(Op, Opcode, rt, Index, rn, rm);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size>
-  void ld3(FEXCore::ARMEmitter::VRegister rt, uint32_t Index, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+  template<SubRegSize size>
+  void ld3(VRegister rt, uint32_t Index, Register rn, uint32_t PostOffset) {
     LOGMAN_THROW_A_FMT(
       (size == SubRegSize::i8Bit && (PostOffset == 3)) ||
       (size == SubRegSize::i16Bit && (PostOffset == 6)) ||
@@ -781,20 +732,18 @@ public:
         size == SubRegSize::i32Bit ? 0b100 : // Scale = 2
         size == SubRegSize::i64Bit ? 0b100 : // Scale = 2 (Uses size to determine difference between 32-bit).
         0;
-    ASIMDSTLD<size, true, 3>(Op, Opcode, rt, Index, rn, FEXCore::ARMEmitter::Reg::r31);
+    ASIMDSTLD<size, true, 3>(Op, Opcode, rt, Index, rn, Reg::r31);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size>
-  void ld3r(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::VRegister rt2, FEXCore::ARMEmitter::VRegister rt3, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+  template<SubRegSize size>
+  void ld3r(VRegister rt, VRegister rt2, VRegister rt3, Register rn, Register rm) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3), "rt, rt2, and rt3 must be sequential");
     constexpr uint32_t Op = 0b0000'1101'100 << 21;
     constexpr uint32_t Opcode = 0b110;
     ASIMDSTLD<size, true, 3>(Op, Opcode, rt, 0, rn, rm);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size>
-  void ld3r(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::VRegister rt2, FEXCore::ARMEmitter::VRegister rt3, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+  template<SubRegSize size>
+  void ld3r(VRegister rt, VRegister rt2, VRegister rt3, Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3), "rt, rt2, and rt3 must be sequential");
     LOGMAN_THROW_A_FMT(
       (size == SubRegSize::i8Bit && (PostOffset == 3)) ||
       (size == SubRegSize::i16Bit && (PostOffset == 6)) ||
@@ -802,13 +751,11 @@ public:
       (size == SubRegSize::i64Bit && (PostOffset == 16)), "Post-index offset needs to match number of elements times their size");
     constexpr uint32_t Op = 0b0000'1101'100 << 21;
     constexpr uint32_t Opcode = 0b110;
-    ASIMDSTLD<size, true, 3>(Op, Opcode, rt, 0, rn, FEXCore::ARMEmitter::Reg::r31);
+    ASIMDSTLD<size, true, 3>(Op, Opcode, rt, 0, rn, Reg::r31);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size>
-  void ld4(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::VRegister rt2, FEXCore::ARMEmitter::VRegister rt3, FEXCore::ARMEmitter::VRegister rt4, uint32_t Index, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+  template<SubRegSize size>
+  void ld4(VRegister rt, VRegister rt2, VRegister rt3, VRegister rt4, uint32_t Index, Register rn, Register rm) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3, rt4), "rt, rt2, rt3, and rt4 must be sequential");
     constexpr uint32_t Op = 0b0000'1101'100 << 21;
     constexpr uint32_t Opcode =
         size == SubRegSize::i8Bit  ? 0b000 : // Scale = 0
@@ -818,8 +765,8 @@ public:
         0;
     ASIMDSTLD<size, true, 4>(Op, Opcode, rt, Index, rn, rm);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size>
-  void ld4(FEXCore::ARMEmitter::VRegister rt, uint32_t Index, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+  template<SubRegSize size>
+  void ld4(VRegister rt, uint32_t Index, Register rn, uint32_t PostOffset) {
     LOGMAN_THROW_A_FMT(
       (size == SubRegSize::i8Bit && (PostOffset == 4)) ||
       (size == SubRegSize::i16Bit && (PostOffset == 8)) ||
@@ -832,22 +779,18 @@ public:
         size == SubRegSize::i32Bit ? 0b100 : // Scale = 2
         size == SubRegSize::i64Bit ? 0b100 : // Scale = 2 (Uses size to determine difference between 32-bit).
         0;
-    ASIMDSTLD<size, true, 4>(Op, Opcode, rt, Index, rn, FEXCore::ARMEmitter::Reg::r31);
+    ASIMDSTLD<size, true, 4>(Op, Opcode, rt, Index, rn, Reg::r31);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size>
-  void ld4r(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::VRegister rt2, FEXCore::ARMEmitter::VRegister rt3, FEXCore::ARMEmitter::VRegister rt4, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+  template<SubRegSize size>
+  void ld4r(VRegister rt, VRegister rt2, VRegister rt3, VRegister rt4, Register rn, Register rm) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3, rt4), "rt, rt2, rt3, and rt4 must be sequential");
     constexpr uint32_t Op = 0b0000'1101'100 << 21;
     constexpr uint32_t Opcode = 0b110;
     ASIMDSTLD<size, true, 4>(Op, Opcode, rt, 0, rn, rm);
   }
-  template<FEXCore::ARMEmitter::SubRegSize size>
-  void ld4r(FEXCore::ARMEmitter::VRegister rt, FEXCore::ARMEmitter::VRegister rt2, FEXCore::ARMEmitter::VRegister rt3, FEXCore::ARMEmitter::VRegister rt4, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+  template<SubRegSize size>
+  void ld4r(VRegister rt, VRegister rt2, VRegister rt3, VRegister rt4, Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3, rt4), "rt, rt2, rt3, and rt4 must be sequential");
     LOGMAN_THROW_A_FMT(
       (size == SubRegSize::i8Bit && (PostOffset == 4)) ||
       (size == SubRegSize::i16Bit && (PostOffset == 8)) ||
@@ -855,7 +798,7 @@ public:
       (size == SubRegSize::i64Bit && (PostOffset == 32)), "Post-index offset needs to match number of elements times their size");
     constexpr uint32_t Op = 0b0000'1101'100 << 21;
     constexpr uint32_t Opcode = 0b110;
-    ASIMDSTLD<size, true, 4>(Op, Opcode, rt, 0, rn, FEXCore::ARMEmitter::Reg::r31);
+    ASIMDSTLD<size, true, 4>(Op, Opcode, rt, 0, rn, Reg::r31);
   }
 
   // Advanced SIMD load/store single structure (post-indexed)
@@ -960,50 +903,47 @@ public:
   }
 
   template<typename T>
-  void ld2r(FEXCore::ARMEmitter::SubRegSize size, T rt, T rt2, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+  void ld2r(SubRegSize size, T rt, T rt2, Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2), "rt and rt2 must be sequential");
     LOGMAN_THROW_AA_FMT(PostOffset == 2 || PostOffset == 4 || PostOffset == 8 || PostOffset == 16, "Index too large");
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
-    constexpr uint32_t Q = std::is_same_v<FEXCore::ARMEmitter::QRegister, T> ? 1 : 0;
+    constexpr uint32_t Q = std::is_same_v<QRegister, T> ? 1 : 0;
     uint32_t R = 1;
     uint32_t opcode = 0b110;
     uint32_t S = 0;
     uint32_t Size = FEXCore::ToUnderlying(size);
-    ASIMDLoadStoreSinglePost<T>(Op, Q, 1, R, opcode, S, Size, FEXCore::ARMEmitter::Reg::r31, rn, rt);
+    ASIMDLoadStoreSinglePost<T>(Op, Q, 1, R, opcode, S, Size, Reg::r31, rn, rt);
   }
 
   template<typename T>
-  void ld3r(FEXCore::ARMEmitter::SubRegSize size, T rt, T rt2, T rt3, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+  void ld3r(SubRegSize size, T rt, T rt2, T rt3, Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3), "rt, rt2, and rt3 must be sequential");
     LOGMAN_THROW_AA_FMT(PostOffset == 3 || PostOffset == 6 || PostOffset == 12 || PostOffset == 24, "Index too large");
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
-    constexpr uint32_t Q = std::is_same_v<FEXCore::ARMEmitter::QRegister, T> ? 1 : 0;
+    constexpr uint32_t Q = std::is_same_v<QRegister, T> ? 1 : 0;
     uint32_t R = 0;
     uint32_t opcode = 0b111;
     uint32_t S = 0;
     uint32_t Size = FEXCore::ToUnderlying(size);
-    ASIMDLoadStoreSinglePost<T>(Op, Q, 1, R, opcode, S, Size, FEXCore::ARMEmitter::Reg::r31, rn, rt);
+    ASIMDLoadStoreSinglePost<T>(Op, Q, 1, R, opcode, S, Size, Reg::r31, rn, rt);
   }
   template<typename T>
-  void ld4r(FEXCore::ARMEmitter::SubRegSize size, T rt, T rt2, T rt3, T rt4, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+  void ld4r(SubRegSize size, T rt, T rt2, T rt3, T rt4, Register rn, uint32_t PostOffset) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3, rt4), "rt, rt2, rt3, and rt4 must be sequential");
     LOGMAN_THROW_AA_FMT(PostOffset == 4 || PostOffset == 8 || PostOffset == 16 || PostOffset == 32, "Index too large");
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
-    constexpr uint32_t Q = std::is_same_v<FEXCore::ARMEmitter::QRegister, T> ? 1 : 0;
+    constexpr uint32_t Q = std::is_same_v<QRegister, T> ? 1 : 0;
     uint32_t R = 1;
     uint32_t opcode = 0b111;
     uint32_t S = 0;
     uint32_t Size = FEXCore::ToUnderlying(size);
-    ASIMDLoadStoreSinglePost<T>(Op, Q, 1, R, opcode, S, Size, FEXCore::ARMEmitter::Reg::r31, rn, rt);
+    ASIMDLoadStoreSinglePost<T>(Op, Q, 1, R, opcode, S, Size, Reg::r31, rn, rt);
   }
 
   template<typename T>
-  void st2(FEXCore::ARMEmitter::SubRegSize size, T rt, T rt2, uint32_t Index, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+  void st2(SubRegSize size, T rt, T rt2, uint32_t Index, Register rn, uint32_t PostOffset) {
     LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2), "rt and rt2 must be sequential");
 
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
     uint32_t Q;
@@ -1044,12 +984,12 @@ public:
       FEX_UNREACHABLE;
     }
 
-    ASIMDLoadStoreSinglePost(Op, Q, 0, R, opcode, S, Size, FEXCore::ARMEmitter::Reg::r31, rn, rt.Q());
+    ASIMDLoadStoreSinglePost(Op, Q, 0, R, opcode, S, Size, Reg::r31, rn, rt.Q());
   }
   template<typename T>
-  void ld2(FEXCore::ARMEmitter::SubRegSize size, T rt, T rt2, uint32_t Index, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+  void ld2(SubRegSize size, T rt, T rt2, uint32_t Index, Register rn, uint32_t PostOffset) {
     LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2), "rt and rt2 must be sequential");
 
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
     uint32_t Q;
@@ -1090,13 +1030,12 @@ public:
       FEX_UNREACHABLE;
     }
 
-    ASIMDLoadStoreSinglePost(Op, Q, 1, R, opcode, S, Size, FEXCore::ARMEmitter::Reg::r31, rn, rt.Q());
+    ASIMDLoadStoreSinglePost(Op, Q, 1, R, opcode, S, Size, Reg::r31, rn, rt.Q());
   }
   template<typename T>
-  void st3(FEXCore::ARMEmitter::SubRegSize size, T rt, T rt2, T rt3, uint32_t Index, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+  void st3(SubRegSize size, T rt, T rt2, T rt3, uint32_t Index, Register rn, uint32_t PostOffset) {
     LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3), "rt, rt2, and rt3 must be sequential");
 
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
     uint32_t Q;
@@ -1137,13 +1076,12 @@ public:
       FEX_UNREACHABLE;
     }
 
-    ASIMDLoadStoreSinglePost(Op, Q, 0, R, opcode, S, Size, FEXCore::ARMEmitter::Reg::r31, rn, rt.Q());
+    ASIMDLoadStoreSinglePost(Op, Q, 0, R, opcode, S, Size, Reg::r31, rn, rt.Q());
   }
   template<typename T>
-  void ld3(FEXCore::ARMEmitter::SubRegSize size, T rt, T rt2, T rt3, uint32_t Index, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+  void ld3(SubRegSize size, T rt, T rt2, T rt3, uint32_t Index, Register rn, uint32_t PostOffset) {
     LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3), "rt, rt2, and rt3 must be sequential");
 
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
     uint32_t Q;
@@ -1184,14 +1122,12 @@ public:
       FEX_UNREACHABLE;
     }
 
-    ASIMDLoadStoreSinglePost(Op, Q, 1, R, opcode, S, Size, FEXCore::ARMEmitter::Reg::r31, rn, rt.Q());
+    ASIMDLoadStoreSinglePost(Op, Q, 1, R, opcode, S, Size, Reg::r31, rn, rt.Q());
   }
   template<typename T>
-  void st4(FEXCore::ARMEmitter::SubRegSize size, T rt, T rt2, T rt3, T rt4, uint32_t Index, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+  void st4(SubRegSize size, T rt, T rt2, T rt3, T rt4, uint32_t Index, Register rn, uint32_t PostOffset) {
     LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3, rt4), "rt, rt2, rt3, and rt4 must be sequential");
 
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
     uint32_t Q;
@@ -1232,14 +1168,12 @@ public:
       FEX_UNREACHABLE;
     }
 
-    ASIMDLoadStoreSinglePost(Op, Q, 0, R, opcode, S, Size, FEXCore::ARMEmitter::Reg::r31, rn, rt.Q());
+    ASIMDLoadStoreSinglePost(Op, Q, 0, R, opcode, S, Size, Reg::r31, rn, rt.Q());
   }
   template<typename T>
-  void ld4(FEXCore::ARMEmitter::SubRegSize size, T rt, T rt2, T rt3, T rt4, uint32_t Index, FEXCore::ARMEmitter::Register rn, uint32_t PostOffset) {
+  void ld4(SubRegSize size, T rt, T rt2, T rt3, T rt4, uint32_t Index, Register rn, uint32_t PostOffset) {
     LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3, rt4), "rt, rt2, rt3, and rt4 must be sequential");
 
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
     uint32_t Q;
@@ -1280,7 +1214,7 @@ public:
       FEX_UNREACHABLE;
     }
 
-    ASIMDLoadStoreSinglePost(Op, Q, 1, R, opcode, S, Size, FEXCore::ARMEmitter::Reg::r31, rn, rt.Q());
+    ASIMDLoadStoreSinglePost(Op, Q, 1, R, opcode, S, Size, Reg::r31, rn, rt.Q());
   }
 
   template<typename T>
@@ -1372,9 +1306,9 @@ public:
     ASIMDLoadStoreSinglePost(Op, Q, 1, R, opcode, S, Size, rm, rn, rt.Q());
   }
   template<typename T>
-  void ld1r(FEXCore::ARMEmitter::SubRegSize size, T rt, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+  void ld1r(SubRegSize size, T rt, Register rn, Register rm) {
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
-    constexpr uint32_t Q = std::is_same_v<FEXCore::ARMEmitter::QRegister, T> ? 1 : 0;
+    constexpr uint32_t Q = std::is_same_v<QRegister, T> ? 1 : 0;
     uint32_t R = 0;
     uint32_t opcode = 0b110;
     uint32_t S = 0;
@@ -1383,10 +1317,10 @@ public:
   }
 
   template<typename T>
-  void ld2r(FEXCore::ARMEmitter::SubRegSize size, T rt, T rt2, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+  void ld2r(SubRegSize size, T rt, T rt2, Register rn, Register rm) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2), "rt and rt2 must be sequential");
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
-    constexpr uint32_t Q = std::is_same_v<FEXCore::ARMEmitter::QRegister, T> ? 1 : 0;
+    constexpr uint32_t Q = std::is_same_v<QRegister, T> ? 1 : 0;
     uint32_t R = 1;
     uint32_t opcode = 0b110;
     uint32_t S = 0;
@@ -1395,11 +1329,10 @@ public:
   }
 
   template<typename T>
-  void ld3r(FEXCore::ARMEmitter::SubRegSize size, T rt, T rt2, T rt3, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+  void ld3r(SubRegSize size, T rt, T rt2, T rt3, Register rn, Register rm) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3), "rt, rt2, and rt3 must be sequential");
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
-    constexpr uint32_t Q = std::is_same_v<FEXCore::ARMEmitter::QRegister, T> ? 1 : 0;
+    constexpr uint32_t Q = std::is_same_v<QRegister, T> ? 1 : 0;
     uint32_t R = 0;
     uint32_t opcode = 0b111;
     uint32_t S = 0;
@@ -1407,12 +1340,10 @@ public:
     ASIMDLoadStoreSinglePost<T>(Op, Q, 1, R, opcode, S, Size, rm, rn, rt);
   }
   template<typename T>
-  void ld4r(FEXCore::ARMEmitter::SubRegSize size, T rt, T rt2, T rt3, T rt4, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+  void ld4r(SubRegSize size, T rt, T rt2, T rt3, T rt4, Register rn, Register rm) {
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3, rt4), "rt, rt2, rt3, and rt4 must be sequential");
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
-    constexpr uint32_t Q = std::is_same_v<FEXCore::ARMEmitter::QRegister, T> ? 1 : 0;
+    constexpr uint32_t Q = std::is_same_v<QRegister, T> ? 1 : 0;
     uint32_t R = 1;
     uint32_t opcode = 0b111;
     uint32_t S = 0;
@@ -1421,9 +1352,9 @@ public:
   }
 
   template<typename T>
-  void st2(FEXCore::ARMEmitter::SubRegSize size, T rt, T rt2, uint32_t Index, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+  void st2(SubRegSize size, T rt, T rt2, uint32_t Index, Register rn, Register rm) {
     LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2), "rt and rt2 must be sequential");
 
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
     uint32_t Q;
@@ -1467,9 +1398,9 @@ public:
     ASIMDLoadStoreSinglePost(Op, Q, 0, R, opcode, S, Size, rm, rn, rt.Q());
   }
   template<typename T>
-  void ld2(FEXCore::ARMEmitter::SubRegSize size, T rt, T rt2, uint32_t Index, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+  void ld2(SubRegSize size, T rt, T rt2, uint32_t Index, Register rn, Register rm) {
     LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2), "rt and rt2 must be sequential");
 
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
     uint32_t Q;
@@ -1513,10 +1444,9 @@ public:
     ASIMDLoadStoreSinglePost(Op, Q, 1, R, opcode, S, Size, rm, rn, rt.Q());
   }
   template<typename T>
-  void st3(FEXCore::ARMEmitter::SubRegSize size, T rt, T rt2, T rt3, uint32_t Index, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+  void st3(SubRegSize size, T rt, T rt2, T rt3, uint32_t Index, Register rn, Register rm) {
     LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3), "rt, rt2, and rt3 must be sequential");
 
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
     uint32_t Q;
@@ -1560,10 +1490,9 @@ public:
     ASIMDLoadStoreSinglePost(Op, Q, 0, R, opcode, S, Size, rm, rn, rt.Q());
   }
   template<typename T>
-  void ld3(FEXCore::ARMEmitter::SubRegSize size, T rt, T rt2, T rt3, uint32_t Index, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+  void ld3(SubRegSize size, T rt, T rt2, T rt3, uint32_t Index, Register rn, Register rm) {
     LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3), "rt, rt2, and rt3 must be sequential");
 
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
     uint32_t Q;
@@ -1607,11 +1536,9 @@ public:
     ASIMDLoadStoreSinglePost(Op, Q, 1, R, opcode, S, Size, rm, rn, rt.Q());
   }
   template<typename T>
-  void st4(FEXCore::ARMEmitter::SubRegSize size, T rt, T rt2, T rt3, T rt4, uint32_t Index, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+  void st4(SubRegSize size, T rt, T rt2, T rt3, T rt4, uint32_t Index, Register rn, Register rm) {
     LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3, rt4), "rt, rt2, rt3, and rt4 must be sequential");
 
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
     uint32_t Q;
@@ -1655,11 +1582,9 @@ public:
     ASIMDLoadStoreSinglePost(Op, Q, 0, R, opcode, S, Size, rm, rn, rt.Q());
   }
   template<typename T>
-  void ld4(FEXCore::ARMEmitter::SubRegSize size, T rt, T rt2, T rt3, T rt4, uint32_t Index, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
+  void ld4(SubRegSize size, T rt, T rt2, T rt3, T rt4, uint32_t Index, Register rn, Register rm) {
     LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
-    LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt2.Idx() + 1) == rt3.Idx(), "These must be sequential");
-    LOGMAN_THROW_A_FMT((rt3.Idx() + 1) == rt4.Idx(), "These must be sequential");
+    LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3, rt4), "rt, rt2, rt3, and rt4 must be sequential");
 
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
     uint32_t Q;

--- a/External/FEXCore/unittests/Emitter/ASIMD_Tests.cpp
+++ b/External/FEXCore/unittests/Emitter/ASIMD_Tests.cpp
@@ -40,18 +40,33 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD table lookup")
   TEST_SINGLE(tbx(QReg::q30, QReg::q26, QReg::q25), "tbx v30.16b, {v26.16b}, v25.16b");
   TEST_SINGLE(tbx(DReg::d30, QReg::q26, DReg::d25), "tbx v30.8b, {v26.16b}, v25.8b");
 
+  TEST_SINGLE(tbl(QReg::q30, QReg::q31, QReg::q0,  QReg::q25), "tbl v30.16b, {v31.16b, v0.16b}, v25.16b");
+  TEST_SINGLE(tbl(DReg::d30, QReg::q31, QReg::q0,  DReg::d25), "tbl v30.8b, {v31.16b, v0.16b}, v25.8b");
   TEST_SINGLE(tbl(QReg::q30, QReg::q26, QReg::q27, QReg::q25), "tbl v30.16b, {v26.16b, v27.16b}, v25.16b");
   TEST_SINGLE(tbl(DReg::d30, QReg::q26, QReg::q27, DReg::d25), "tbl v30.8b, {v26.16b, v27.16b}, v25.8b");
+
+  TEST_SINGLE(tbx(QReg::q30, QReg::q31, QReg::q0,  QReg::q25), "tbx v30.16b, {v31.16b, v0.16b}, v25.16b");
+  TEST_SINGLE(tbx(DReg::d30, QReg::q31, QReg::q0,  DReg::d25), "tbx v30.8b, {v31.16b, v0.16b}, v25.8b");
   TEST_SINGLE(tbx(QReg::q30, QReg::q26, QReg::q27, QReg::q25), "tbx v30.16b, {v26.16b, v27.16b}, v25.16b");
   TEST_SINGLE(tbx(DReg::d30, QReg::q26, QReg::q27, DReg::d25), "tbx v30.8b, {v26.16b, v27.16b}, v25.8b");
 
+  TEST_SINGLE(tbl(QReg::q30, QReg::q31, QReg::q0,  QReg::q1,  QReg::q25), "tbl v30.16b, {v31.16b, v0.16b, v1.16b}, v25.16b");
+  TEST_SINGLE(tbl(DReg::d30, QReg::q31, QReg::q0,  QReg::q1,  DReg::d25), "tbl v30.8b, {v31.16b, v0.16b, v1.16b}, v25.8b");
   TEST_SINGLE(tbl(QReg::q30, QReg::q26, QReg::q27, QReg::q28, QReg::q25), "tbl v30.16b, {v26.16b, v27.16b, v28.16b}, v25.16b");
   TEST_SINGLE(tbl(DReg::d30, QReg::q26, QReg::q27, QReg::q28, DReg::d25), "tbl v30.8b, {v26.16b, v27.16b, v28.16b}, v25.8b");
+
+  TEST_SINGLE(tbx(QReg::q30, QReg::q31, QReg::q0,  QReg::q1,  QReg::q25), "tbx v30.16b, {v31.16b, v0.16b, v1.16b}, v25.16b");
+  TEST_SINGLE(tbx(DReg::d30, QReg::q31, QReg::q0,  QReg::q1,  DReg::d25), "tbx v30.8b, {v31.16b, v0.16b, v1.16b}, v25.8b");
   TEST_SINGLE(tbx(QReg::q30, QReg::q26, QReg::q27, QReg::q28, QReg::q25), "tbx v30.16b, {v26.16b, v27.16b, v28.16b}, v25.16b");
   TEST_SINGLE(tbx(DReg::d30, QReg::q26, QReg::q27, QReg::q28, DReg::d25), "tbx v30.8b, {v26.16b, v27.16b, v28.16b}, v25.8b");
 
+  TEST_SINGLE(tbl(QReg::q30, QReg::q31, QReg::q0,  QReg::q1,  QReg::q2,  QReg::q25), "tbl v30.16b, {v31.16b, v0.16b, v1.16b, v2.16b}, v25.16b");
+  TEST_SINGLE(tbl(DReg::d30, QReg::q31, QReg::q0,  QReg::q1,  QReg::q2,  DReg::d25), "tbl v30.8b, {v31.16b, v0.16b, v1.16b, v2.16b}, v25.8b");
   TEST_SINGLE(tbl(QReg::q30, QReg::q26, QReg::q27, QReg::q28, QReg::q29, QReg::q25), "tbl v30.16b, {v26.16b, v27.16b, v28.16b, v29.16b}, v25.16b");
   TEST_SINGLE(tbl(DReg::d30, QReg::q26, QReg::q27, QReg::q28, QReg::q29, DReg::d25), "tbl v30.8b, {v26.16b, v27.16b, v28.16b, v29.16b}, v25.8b");
+
+  TEST_SINGLE(tbx(QReg::q30, QReg::q31, QReg::q0,  QReg::q1,  QReg::q2,  QReg::q25), "tbx v30.16b, {v31.16b, v0.16b, v1.16b, v2.16b}, v25.16b");
+  TEST_SINGLE(tbx(DReg::d30, QReg::q31, QReg::q0,  QReg::q1,  QReg::q2,  DReg::d25), "tbx v30.8b, {v31.16b, v0.16b, v1.16b, v2.16b}, v25.8b");
   TEST_SINGLE(tbx(QReg::q30, QReg::q26, QReg::q27, QReg::q28, QReg::q29, QReg::q25), "tbx v30.16b, {v26.16b, v27.16b, v28.16b, v29.16b}, v25.16b");
   TEST_SINGLE(tbx(DReg::d30, QReg::q26, QReg::q27, QReg::q28, QReg::q29, DReg::d25), "tbx v30.8b, {v26.16b, v27.16b, v28.16b, v29.16b}, v25.8b");
 }

--- a/External/FEXCore/unittests/Emitter/Loadstore_Tests.cpp
+++ b/External/FEXCore/unittests/Emitter/Loadstore_Tests.cpp
@@ -31,6 +31,8 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Advanced SIMD load/store
   TEST_SINGLE(ld1<SubRegSize::i64Bit>(QReg::q26, Reg::r30), "ld1 {v26.2d}, [x30]");
   TEST_SINGLE(ld1<SubRegSize::i64Bit>(DReg::d26, Reg::r30), "ld1 {v26.1d}, [x30]");
 
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(QReg::q31, QReg::q0,  Reg::r30), "ld1 {v31.16b, v0.16b}, [x30]");
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(DReg::d31, DReg::d0,  Reg::r30), "ld1 {v31.8b, v0.8b}, [x30]");
   TEST_SINGLE(ld1<SubRegSize::i8Bit>(QReg::q26, QReg::q27, Reg::r30), "ld1 {v26.16b, v27.16b}, [x30]");
   TEST_SINGLE(ld1<SubRegSize::i8Bit>(DReg::d26, DReg::d27, Reg::r30), "ld1 {v26.8b, v27.8b}, [x30]");
 
@@ -43,6 +45,8 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Advanced SIMD load/store
   TEST_SINGLE(ld1<SubRegSize::i64Bit>(QReg::q26, QReg::q27, Reg::r30), "ld1 {v26.2d, v27.2d}, [x30]");
   TEST_SINGLE(ld1<SubRegSize::i64Bit>(DReg::d26, DReg::d27, Reg::r30), "ld1 {v26.1d, v27.1d}, [x30]");
 
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(QReg::q31, QReg::q0,  QReg::q1,  Reg::r30), "ld1 {v31.16b, v0.16b, v1.16b}, [x30]");
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(DReg::d31, DReg::d0,  DReg::d1,  Reg::r30), "ld1 {v31.8b, v0.8b, v1.8b}, [x30]");
   TEST_SINGLE(ld1<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30), "ld1 {v26.16b, v27.16b, v28.16b}, [x30]");
   TEST_SINGLE(ld1<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30), "ld1 {v26.8b, v27.8b, v28.8b}, [x30]");
 
@@ -55,6 +59,8 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Advanced SIMD load/store
   TEST_SINGLE(ld1<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30), "ld1 {v26.2d, v27.2d, v28.2d}, [x30]");
   TEST_SINGLE(ld1<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30), "ld1 {v26.1d, v27.1d, v28.1d}, [x30]");
 
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(QReg::q31, QReg::q0,  QReg::q1,  QReg::q2,  Reg::r30), "ld1 {v31.16b, v0.16b, v1.16b, v2.16b}, [x30]");
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(DReg::d31, DReg::d0,  DReg::d1,  DReg::d2,  Reg::r30), "ld1 {v31.8b, v0.8b, v1.8b, v2.8b}, [x30]");
   TEST_SINGLE(ld1<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30), "ld1 {v26.16b, v27.16b, v28.16b, v29.16b}, [x30]");
   TEST_SINGLE(ld1<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30), "ld1 {v26.8b, v27.8b, v28.8b, v29.8b}, [x30]");
 
@@ -79,6 +85,8 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Advanced SIMD load/store
   TEST_SINGLE(st1<SubRegSize::i64Bit>(QReg::q26, Reg::r30), "st1 {v26.2d}, [x30]");
   TEST_SINGLE(st1<SubRegSize::i64Bit>(DReg::d26, Reg::r30), "st1 {v26.1d}, [x30]");
 
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(QReg::q31, QReg::q0,  Reg::r30), "st1 {v31.16b, v0.16b}, [x30]");
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(DReg::d31, DReg::d0,  Reg::r30), "st1 {v31.8b, v0.8b}, [x30]");
   TEST_SINGLE(st1<SubRegSize::i8Bit>(QReg::q26, QReg::q27, Reg::r30), "st1 {v26.16b, v27.16b}, [x30]");
   TEST_SINGLE(st1<SubRegSize::i8Bit>(DReg::d26, DReg::d27, Reg::r30), "st1 {v26.8b, v27.8b}, [x30]");
 
@@ -91,6 +99,8 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Advanced SIMD load/store
   TEST_SINGLE(st1<SubRegSize::i64Bit>(QReg::q26, QReg::q27, Reg::r30), "st1 {v26.2d, v27.2d}, [x30]");
   TEST_SINGLE(st1<SubRegSize::i64Bit>(DReg::d26, DReg::d27, Reg::r30), "st1 {v26.1d, v27.1d}, [x30]");
 
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(QReg::q31, QReg::q0,  QReg::q1,  Reg::r30), "st1 {v31.16b, v0.16b, v1.16b}, [x30]");
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(DReg::d31, DReg::d0,  DReg::d1,  Reg::r30), "st1 {v31.8b, v0.8b, v1.8b}, [x30]");
   TEST_SINGLE(st1<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30), "st1 {v26.16b, v27.16b, v28.16b}, [x30]");
   TEST_SINGLE(st1<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30), "st1 {v26.8b, v27.8b, v28.8b}, [x30]");
 
@@ -103,6 +113,8 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Advanced SIMD load/store
   TEST_SINGLE(st1<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30), "st1 {v26.2d, v27.2d, v28.2d}, [x30]");
   TEST_SINGLE(st1<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30), "st1 {v26.1d, v27.1d, v28.1d}, [x30]");
 
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(QReg::q31, QReg::q0,  QReg::q1,  QReg::q2,  Reg::r30), "st1 {v31.16b, v0.16b, v1.16b, v2.16b}, [x30]");
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(DReg::d31, DReg::d0,  DReg::d1,  DReg::d2,  Reg::r30), "st1 {v31.8b, v0.8b, v1.8b, v2.8b}, [x30]");
   TEST_SINGLE(st1<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30), "st1 {v26.16b, v27.16b, v28.16b, v29.16b}, [x30]");
   TEST_SINGLE(st1<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30), "st1 {v26.8b, v27.8b, v28.8b, v29.8b}, [x30]");
 
@@ -115,6 +127,8 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Advanced SIMD load/store
   TEST_SINGLE(st1<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30), "st1 {v26.2d, v27.2d, v28.2d, v29.2d}, [x30]");
   TEST_SINGLE(st1<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30), "st1 {v26.1d, v27.1d, v28.1d, v29.1d}, [x30]");
 
+  TEST_SINGLE(ld2<SubRegSize::i8Bit>(QReg::q31, QReg::q0,  Reg::r30), "ld2 {v31.16b, v0.16b}, [x30]");
+  TEST_SINGLE(ld2<SubRegSize::i8Bit>(DReg::d31, DReg::d0,  Reg::r30), "ld2 {v31.8b, v0.8b}, [x30]");
   TEST_SINGLE(ld2<SubRegSize::i8Bit>(QReg::q26, QReg::q27, Reg::r30), "ld2 {v26.16b, v27.16b}, [x30]");
   TEST_SINGLE(ld2<SubRegSize::i8Bit>(DReg::d26, DReg::d27, Reg::r30), "ld2 {v26.8b, v27.8b}, [x30]");
 
@@ -127,6 +141,8 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Advanced SIMD load/store
   TEST_SINGLE(ld2<SubRegSize::i64Bit>(QReg::q26, QReg::q27, Reg::r30), "ld2 {v26.2d, v27.2d}, [x30]");
   TEST_SINGLE(ld2<SubRegSize::i64Bit>(DReg::d26, DReg::d27, Reg::r30), "unallocated (NEONLoadStoreMultiStruct)");
 
+  TEST_SINGLE(st2<SubRegSize::i8Bit>(QReg::q31, QReg::q0,  Reg::r30), "st2 {v31.16b, v0.16b}, [x30]");
+  TEST_SINGLE(st2<SubRegSize::i8Bit>(DReg::d31, DReg::d0,  Reg::r30), "st2 {v31.8b, v0.8b}, [x30]");
   TEST_SINGLE(st2<SubRegSize::i8Bit>(QReg::q26, QReg::q27, Reg::r30), "st2 {v26.16b, v27.16b}, [x30]");
   TEST_SINGLE(st2<SubRegSize::i8Bit>(DReg::d26, DReg::d27, Reg::r30), "st2 {v26.8b, v27.8b}, [x30]");
 
@@ -139,6 +155,8 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Advanced SIMD load/store
   TEST_SINGLE(st2<SubRegSize::i64Bit>(QReg::q26, QReg::q27, Reg::r30), "st2 {v26.2d, v27.2d}, [x30]");
   TEST_SINGLE(st2<SubRegSize::i64Bit>(DReg::d26, DReg::d27, Reg::r30), "unallocated (NEONLoadStoreMultiStruct)");
 
+  TEST_SINGLE(ld3<SubRegSize::i8Bit>(QReg::q31, QReg::q0,  QReg::q1,  Reg::r30), "ld3 {v31.16b, v0.16b, v1.16b}, [x30]");
+  TEST_SINGLE(ld3<SubRegSize::i8Bit>(DReg::d31, DReg::d0,  DReg::d1,  Reg::r30), "ld3 {v31.8b, v0.8b, v1.8b}, [x30]");
   TEST_SINGLE(ld3<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30), "ld3 {v26.16b, v27.16b, v28.16b}, [x30]");
   TEST_SINGLE(ld3<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30), "ld3 {v26.8b, v27.8b, v28.8b}, [x30]");
 
@@ -151,6 +169,8 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Advanced SIMD load/store
   TEST_SINGLE(ld3<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30), "ld3 {v26.2d, v27.2d, v28.2d}, [x30]");
   TEST_SINGLE(ld3<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30), "unallocated (NEONLoadStoreMultiStruct)");
 
+  TEST_SINGLE(st3<SubRegSize::i8Bit>(QReg::q31, QReg::q0,  QReg::q1,  Reg::r30), "st3 {v31.16b, v0.16b, v1.16b}, [x30]");
+  TEST_SINGLE(st3<SubRegSize::i8Bit>(DReg::d31, DReg::d0,  DReg::d1,  Reg::r30), "st3 {v31.8b, v0.8b, v1.8b}, [x30]");
   TEST_SINGLE(st3<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30), "st3 {v26.16b, v27.16b, v28.16b}, [x30]");
   TEST_SINGLE(st3<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30), "st3 {v26.8b, v27.8b, v28.8b}, [x30]");
 
@@ -163,6 +183,8 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Advanced SIMD load/store
   TEST_SINGLE(st3<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30), "st3 {v26.2d, v27.2d, v28.2d}, [x30]");
   TEST_SINGLE(st3<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30), "unallocated (NEONLoadStoreMultiStruct)");
 
+  TEST_SINGLE(ld4<SubRegSize::i8Bit>(QReg::q31, QReg::q0,  QReg::q1,  QReg::q2,  Reg::r30), "ld4 {v31.16b, v0.16b, v1.16b, v2.16b}, [x30]");
+  TEST_SINGLE(ld4<SubRegSize::i8Bit>(DReg::d31, DReg::d0,  DReg::d1,  DReg::d2,  Reg::r30), "ld4 {v31.8b, v0.8b, v1.8b, v2.8b}, [x30]");
   TEST_SINGLE(ld4<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30), "ld4 {v26.16b, v27.16b, v28.16b, v29.16b}, [x30]");
   TEST_SINGLE(ld4<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30), "ld4 {v26.8b, v27.8b, v28.8b, v29.8b}, [x30]");
 
@@ -175,6 +197,8 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Advanced SIMD load/store
   TEST_SINGLE(ld4<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30), "ld4 {v26.2d, v27.2d, v28.2d, v29.2d}, [x30]");
   TEST_SINGLE(ld4<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30), "unallocated (NEONLoadStoreMultiStruct)");
 
+  TEST_SINGLE(st4<SubRegSize::i8Bit>(QReg::q31, QReg::q0,  QReg::q1,  QReg::q2,  Reg::r30), "st4 {v31.16b, v0.16b, v1.16b, v2.16b}, [x30]");
+  TEST_SINGLE(st4<SubRegSize::i8Bit>(DReg::d31, DReg::d0,  DReg::d1,  DReg::d2,  Reg::r30), "st4 {v31.8b, v0.8b, v1.8b, v2.8b}, [x30]");
   TEST_SINGLE(st4<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30), "st4 {v26.16b, v27.16b, v28.16b, v29.16b}, [x30]");
   TEST_SINGLE(st4<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30), "st4 {v26.8b, v27.8b, v28.8b, v29.8b}, [x30]");
 
@@ -213,6 +237,8 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Advanced SIMD load/store
   TEST_SINGLE(ld1<SubRegSize::i64Bit>(QReg::q26, Reg::r30, 16), "ld1 {v26.2d}, [x30], #16");
   TEST_SINGLE(ld1<SubRegSize::i64Bit>(DReg::d26, Reg::r30, 8), "ld1 {v26.1d}, [x30], #8");
 
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(QReg::q31, QReg::q0,  Reg::r30, Reg::r29), "ld1 {v31.16b, v0.16b}, [x30], x29");
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(DReg::d31, DReg::d0,  Reg::r30, Reg::r29), "ld1 {v31.8b, v0.8b}, [x30], x29");
   TEST_SINGLE(ld1<SubRegSize::i8Bit>(QReg::q26, QReg::q27, Reg::r30, Reg::r29), "ld1 {v26.16b, v27.16b}, [x30], x29");
   TEST_SINGLE(ld1<SubRegSize::i8Bit>(DReg::d26, DReg::d27, Reg::r30, Reg::r29), "ld1 {v26.8b, v27.8b}, [x30], x29");
 
@@ -225,6 +251,8 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Advanced SIMD load/store
   TEST_SINGLE(ld1<SubRegSize::i64Bit>(QReg::q26, QReg::q27, Reg::r30, Reg::r29), "ld1 {v26.2d, v27.2d}, [x30], x29");
   TEST_SINGLE(ld1<SubRegSize::i64Bit>(DReg::d26, DReg::d27, Reg::r30, Reg::r29), "ld1 {v26.1d, v27.1d}, [x30], x29");
 
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(QReg::q31, QReg::q0,  Reg::r30, 32), "ld1 {v31.16b, v0.16b}, [x30], #32");
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(DReg::d31, DReg::d0,  Reg::r30, 16), "ld1 {v31.8b, v0.8b}, [x30], #16");
   TEST_SINGLE(ld1<SubRegSize::i8Bit>(QReg::q26, QReg::q27, Reg::r30, 32), "ld1 {v26.16b, v27.16b}, [x30], #32");
   TEST_SINGLE(ld1<SubRegSize::i8Bit>(DReg::d26, DReg::d27, Reg::r30, 16), "ld1 {v26.8b, v27.8b}, [x30], #16");
 
@@ -237,6 +265,8 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Advanced SIMD load/store
   TEST_SINGLE(ld1<SubRegSize::i64Bit>(QReg::q26, QReg::q27, Reg::r30, 32), "ld1 {v26.2d, v27.2d}, [x30], #32");
   TEST_SINGLE(ld1<SubRegSize::i64Bit>(DReg::d26, DReg::d27, Reg::r30, 16), "ld1 {v26.1d, v27.1d}, [x30], #16");
 
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(QReg::q31, QReg::q0,  QReg::q1,  Reg::r30, Reg::r29), "ld1 {v31.16b, v0.16b, v1.16b}, [x30], x29");
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(DReg::d31, DReg::d0,  DReg::d1,  Reg::r30, Reg::r29), "ld1 {v31.8b, v0.8b, v1.8b}, [x30], x29");
   TEST_SINGLE(ld1<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, Reg::r29), "ld1 {v26.16b, v27.16b, v28.16b}, [x30], x29");
   TEST_SINGLE(ld1<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, Reg::r29), "ld1 {v26.8b, v27.8b, v28.8b}, [x30], x29");
 
@@ -249,6 +279,8 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Advanced SIMD load/store
   TEST_SINGLE(ld1<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, Reg::r29), "ld1 {v26.2d, v27.2d, v28.2d}, [x30], x29");
   TEST_SINGLE(ld1<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, Reg::r29), "ld1 {v26.1d, v27.1d, v28.1d}, [x30], x29");
 
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(QReg::q31, QReg::q0,  QReg::q1,  Reg::r30, 48), "ld1 {v31.16b, v0.16b, v1.16b}, [x30], #48");
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(DReg::d31, DReg::d0,  DReg::d1,  Reg::r30, 24), "ld1 {v31.8b, v0.8b, v1.8b}, [x30], #24");
   TEST_SINGLE(ld1<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, 48), "ld1 {v26.16b, v27.16b, v28.16b}, [x30], #48");
   TEST_SINGLE(ld1<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, 24), "ld1 {v26.8b, v27.8b, v28.8b}, [x30], #24");
 
@@ -261,6 +293,8 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Advanced SIMD load/store
   TEST_SINGLE(ld1<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, 48), "ld1 {v26.2d, v27.2d, v28.2d}, [x30], #48");
   TEST_SINGLE(ld1<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, 24), "ld1 {v26.1d, v27.1d, v28.1d}, [x30], #24");
 
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(QReg::q31, QReg::q0,  QReg::q1,  QReg::q2,  Reg::r30, Reg::r29), "ld1 {v31.16b, v0.16b, v1.16b, v2.16b}, [x30], x29");
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(DReg::d31, DReg::d0,  DReg::d1,  DReg::d2,  Reg::r30, Reg::r29), "ld1 {v31.8b, v0.8b, v1.8b, v2.8b}, [x30], x29");
   TEST_SINGLE(ld1<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, Reg::r29), "ld1 {v26.16b, v27.16b, v28.16b, v29.16b}, [x30], x29");
   TEST_SINGLE(ld1<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, Reg::r29), "ld1 {v26.8b, v27.8b, v28.8b, v29.8b}, [x30], x29");
 
@@ -273,6 +307,8 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Advanced SIMD load/store
   TEST_SINGLE(ld1<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, Reg::r29), "ld1 {v26.2d, v27.2d, v28.2d, v29.2d}, [x30], x29");
   TEST_SINGLE(ld1<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, Reg::r29), "ld1 {v26.1d, v27.1d, v28.1d, v29.1d}, [x30], x29");
 
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(QReg::q31, QReg::q0,  QReg::q1,  QReg::q2,  Reg::r30, 64), "ld1 {v31.16b, v0.16b, v1.16b, v2.16b}, [x30], #64");
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(DReg::d31, DReg::d0,  DReg::d1,  DReg::d2,  Reg::r30, 32), "ld1 {v31.8b, v0.8b, v1.8b, v2.8b}, [x30], #32");
   TEST_SINGLE(ld1<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, 64), "ld1 {v26.16b, v27.16b, v28.16b, v29.16b}, [x30], #64");
   TEST_SINGLE(ld1<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, 32), "ld1 {v26.8b, v27.8b, v28.8b, v29.8b}, [x30], #32");
 
@@ -309,6 +345,8 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Advanced SIMD load/store
   TEST_SINGLE(st1<SubRegSize::i64Bit>(QReg::q26, Reg::r30, 16), "st1 {v26.2d}, [x30], #16");
   TEST_SINGLE(st1<SubRegSize::i64Bit>(DReg::d26, Reg::r30, 8), "st1 {v26.1d}, [x30], #8");
 
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(QReg::q31, QReg::q0,  Reg::r30, Reg::r29), "st1 {v31.16b, v0.16b}, [x30], x29");
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(DReg::d31, DReg::d0,  Reg::r30, Reg::r29), "st1 {v31.8b, v0.8b}, [x30], x29");
   TEST_SINGLE(st1<SubRegSize::i8Bit>(QReg::q26, QReg::q27, Reg::r30, Reg::r29), "st1 {v26.16b, v27.16b}, [x30], x29");
   TEST_SINGLE(st1<SubRegSize::i8Bit>(DReg::d26, DReg::d27, Reg::r30, Reg::r29), "st1 {v26.8b, v27.8b}, [x30], x29");
 
@@ -321,6 +359,8 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Advanced SIMD load/store
   TEST_SINGLE(st1<SubRegSize::i64Bit>(QReg::q26, QReg::q27, Reg::r30, Reg::r29), "st1 {v26.2d, v27.2d}, [x30], x29");
   TEST_SINGLE(st1<SubRegSize::i64Bit>(DReg::d26, DReg::d27, Reg::r30, Reg::r29), "st1 {v26.1d, v27.1d}, [x30], x29");
 
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(QReg::q31, QReg::q0,  Reg::r30, 32), "st1 {v31.16b, v0.16b}, [x30], #32");
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(DReg::d31, DReg::d0,  Reg::r30, 16), "st1 {v31.8b, v0.8b}, [x30], #16");
   TEST_SINGLE(st1<SubRegSize::i8Bit>(QReg::q26, QReg::q27, Reg::r30, 32), "st1 {v26.16b, v27.16b}, [x30], #32");
   TEST_SINGLE(st1<SubRegSize::i8Bit>(DReg::d26, DReg::d27, Reg::r30, 16), "st1 {v26.8b, v27.8b}, [x30], #16");
 
@@ -333,6 +373,8 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Advanced SIMD load/store
   TEST_SINGLE(st1<SubRegSize::i64Bit>(QReg::q26, QReg::q27, Reg::r30, 32), "st1 {v26.2d, v27.2d}, [x30], #32");
   TEST_SINGLE(st1<SubRegSize::i64Bit>(DReg::d26, DReg::d27, Reg::r30, 16), "st1 {v26.1d, v27.1d}, [x30], #16");
 
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(QReg::q31, QReg::q0,  QReg::q1,  Reg::r30, Reg::r29), "st1 {v31.16b, v0.16b, v1.16b}, [x30], x29");
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(DReg::d31, DReg::d0,  DReg::d1,  Reg::r30, Reg::r29), "st1 {v31.8b, v0.8b, v1.8b}, [x30], x29");
   TEST_SINGLE(st1<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, Reg::r29), "st1 {v26.16b, v27.16b, v28.16b}, [x30], x29");
   TEST_SINGLE(st1<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, Reg::r29), "st1 {v26.8b, v27.8b, v28.8b}, [x30], x29");
 
@@ -345,6 +387,8 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Advanced SIMD load/store
   TEST_SINGLE(st1<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, Reg::r29), "st1 {v26.2d, v27.2d, v28.2d}, [x30], x29");
   TEST_SINGLE(st1<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, Reg::r29), "st1 {v26.1d, v27.1d, v28.1d}, [x30], x29");
 
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(QReg::q31, QReg::q0,  QReg::q1,  Reg::r30, 48), "st1 {v31.16b, v0.16b, v1.16b}, [x30], #48");
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(DReg::d31, DReg::d0,  DReg::d1,  Reg::r30, 24), "st1 {v31.8b, v0.8b, v1.8b}, [x30], #24");
   TEST_SINGLE(st1<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, 48), "st1 {v26.16b, v27.16b, v28.16b}, [x30], #48");
   TEST_SINGLE(st1<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, 24), "st1 {v26.8b, v27.8b, v28.8b}, [x30], #24");
 
@@ -357,6 +401,8 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Advanced SIMD load/store
   TEST_SINGLE(st1<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, 48), "st1 {v26.2d, v27.2d, v28.2d}, [x30], #48");
   TEST_SINGLE(st1<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, 24), "st1 {v26.1d, v27.1d, v28.1d}, [x30], #24");
 
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(QReg::q31, QReg::q0,  QReg::q1,  QReg::q2,  Reg::r30, Reg::r29), "st1 {v31.16b, v0.16b, v1.16b, v2.16b}, [x30], x29");
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(DReg::d31, DReg::d0,  DReg::d1,  DReg::d2,  Reg::r30, Reg::r29), "st1 {v31.8b, v0.8b, v1.8b, v2.8b}, [x30], x29");
   TEST_SINGLE(st1<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, Reg::r29), "st1 {v26.16b, v27.16b, v28.16b, v29.16b}, [x30], x29");
   TEST_SINGLE(st1<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, Reg::r29), "st1 {v26.8b, v27.8b, v28.8b, v29.8b}, [x30], x29");
 
@@ -369,6 +415,8 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Advanced SIMD load/store
   TEST_SINGLE(st1<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, Reg::r29), "st1 {v26.2d, v27.2d, v28.2d, v29.2d}, [x30], x29");
   TEST_SINGLE(st1<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, Reg::r29), "st1 {v26.1d, v27.1d, v28.1d, v29.1d}, [x30], x29");
 
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(QReg::q31, QReg::q0,  QReg::q1,  QReg::q2,  Reg::r30, 64), "st1 {v31.16b, v0.16b, v1.16b, v2.16b}, [x30], #64");
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(DReg::d31, DReg::d0,  DReg::d1,  DReg::d2,  Reg::r30, 32), "st1 {v31.8b, v0.8b, v1.8b, v2.8b}, [x30], #32");
   TEST_SINGLE(st1<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, 64), "st1 {v26.16b, v27.16b, v28.16b, v29.16b}, [x30], #64");
   TEST_SINGLE(st1<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, 32), "st1 {v26.8b, v27.8b, v28.8b, v29.8b}, [x30], #32");
 
@@ -381,6 +429,8 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Advanced SIMD load/store
   TEST_SINGLE(st1<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, 64), "st1 {v26.2d, v27.2d, v28.2d, v29.2d}, [x30], #64");
   TEST_SINGLE(st1<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, 32), "st1 {v26.1d, v27.1d, v28.1d, v29.1d}, [x30], #32");
 
+  TEST_SINGLE(ld2<SubRegSize::i8Bit>(QReg::q31, QReg::q0,  Reg::r30, Reg::r29), "ld2 {v31.16b, v0.16b}, [x30], x29");
+  TEST_SINGLE(ld2<SubRegSize::i8Bit>(DReg::d31, DReg::d0,  Reg::r30, Reg::r29), "ld2 {v31.8b, v0.8b}, [x30], x29");
   TEST_SINGLE(ld2<SubRegSize::i8Bit>(QReg::q26, QReg::q27, Reg::r30, Reg::r29), "ld2 {v26.16b, v27.16b}, [x30], x29");
   TEST_SINGLE(ld2<SubRegSize::i8Bit>(DReg::d26, DReg::d27, Reg::r30, Reg::r29), "ld2 {v26.8b, v27.8b}, [x30], x29");
 
@@ -393,6 +443,8 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Advanced SIMD load/store
   TEST_SINGLE(ld2<SubRegSize::i64Bit>(QReg::q26, QReg::q27, Reg::r30, Reg::r29), "ld2 {v26.2d, v27.2d}, [x30], x29");
   TEST_SINGLE(ld2<SubRegSize::i64Bit>(DReg::d26, DReg::d27, Reg::r30, Reg::r29), "unallocated (NEONLoadStoreMultiStructPostIndex)");
 
+  TEST_SINGLE(ld2<SubRegSize::i8Bit>(QReg::q31, QReg::q0,  Reg::r30, 32), "ld2 {v31.16b, v0.16b}, [x30], #32");
+  TEST_SINGLE(ld2<SubRegSize::i8Bit>(DReg::d31, DReg::d0,  Reg::r30, 16), "ld2 {v31.8b, v0.8b}, [x30], #16");
   TEST_SINGLE(ld2<SubRegSize::i8Bit>(QReg::q26, QReg::q27, Reg::r30, 32), "ld2 {v26.16b, v27.16b}, [x30], #32");
   TEST_SINGLE(ld2<SubRegSize::i8Bit>(DReg::d26, DReg::d27, Reg::r30, 16), "ld2 {v26.8b, v27.8b}, [x30], #16");
 
@@ -405,6 +457,8 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Advanced SIMD load/store
   TEST_SINGLE(ld2<SubRegSize::i64Bit>(QReg::q26, QReg::q27, Reg::r30, 32), "ld2 {v26.2d, v27.2d}, [x30], #32");
   TEST_SINGLE(ld2<SubRegSize::i64Bit>(DReg::d26, DReg::d27, Reg::r30, 16), "unallocated (NEONLoadStoreMultiStructPostIndex)");
 
+  TEST_SINGLE(st2<SubRegSize::i8Bit>(QReg::q31, QReg::q0,  Reg::r30, Reg::r29), "st2 {v31.16b, v0.16b}, [x30], x29");
+  TEST_SINGLE(st2<SubRegSize::i8Bit>(DReg::d31, DReg::d0,  Reg::r30, Reg::r29), "st2 {v31.8b, v0.8b}, [x30], x29");
   TEST_SINGLE(st2<SubRegSize::i8Bit>(QReg::q26, QReg::q27, Reg::r30, Reg::r29), "st2 {v26.16b, v27.16b}, [x30], x29");
   TEST_SINGLE(st2<SubRegSize::i8Bit>(DReg::d26, DReg::d27, Reg::r30, Reg::r29), "st2 {v26.8b, v27.8b}, [x30], x29");
 
@@ -417,6 +471,8 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Advanced SIMD load/store
   TEST_SINGLE(st2<SubRegSize::i64Bit>(QReg::q26, QReg::q27, Reg::r30, Reg::r29), "st2 {v26.2d, v27.2d}, [x30], x29");
   TEST_SINGLE(st2<SubRegSize::i64Bit>(DReg::d26, DReg::d27, Reg::r30, Reg::r29), "unallocated (NEONLoadStoreMultiStructPostIndex)");
 
+  TEST_SINGLE(st2<SubRegSize::i8Bit>(QReg::q31, QReg::q0,  Reg::r30, 32), "st2 {v31.16b, v0.16b}, [x30], #32");
+  TEST_SINGLE(st2<SubRegSize::i8Bit>(DReg::d31, DReg::d0,  Reg::r30, 16), "st2 {v31.8b, v0.8b}, [x30], #16");
   TEST_SINGLE(st2<SubRegSize::i8Bit>(QReg::q26, QReg::q27, Reg::r30, 32), "st2 {v26.16b, v27.16b}, [x30], #32");
   TEST_SINGLE(st2<SubRegSize::i8Bit>(DReg::d26, DReg::d27, Reg::r30, 16), "st2 {v26.8b, v27.8b}, [x30], #16");
 
@@ -429,6 +485,8 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Advanced SIMD load/store
   TEST_SINGLE(st2<SubRegSize::i64Bit>(QReg::q26, QReg::q27, Reg::r30, 32), "st2 {v26.2d, v27.2d}, [x30], #32");
   TEST_SINGLE(st2<SubRegSize::i64Bit>(DReg::d26, DReg::d27, Reg::r30, 16), "unallocated (NEONLoadStoreMultiStructPostIndex)");
 
+  TEST_SINGLE(ld3<SubRegSize::i8Bit>(QReg::q31, QReg::q0,  QReg::q1,  Reg::r30, Reg::r29), "ld3 {v31.16b, v0.16b, v1.16b}, [x30], x29");
+  TEST_SINGLE(ld3<SubRegSize::i8Bit>(DReg::d31, DReg::d0,  DReg::d1,  Reg::r30, Reg::r29), "ld3 {v31.8b, v0.8b, v1.8b}, [x30], x29");
   TEST_SINGLE(ld3<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, Reg::r29), "ld3 {v26.16b, v27.16b, v28.16b}, [x30], x29");
   TEST_SINGLE(ld3<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, Reg::r29), "ld3 {v26.8b, v27.8b, v28.8b}, [x30], x29");
 
@@ -441,6 +499,8 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Advanced SIMD load/store
   TEST_SINGLE(ld3<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, Reg::r29), "ld3 {v26.2d, v27.2d, v28.2d}, [x30], x29");
   TEST_SINGLE(ld3<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, Reg::r29), "unallocated (NEONLoadStoreMultiStructPostIndex)");
 
+  TEST_SINGLE(ld3<SubRegSize::i8Bit>(QReg::q31, QReg::q0,  QReg::q1,  Reg::r30, 48), "ld3 {v31.16b, v0.16b, v1.16b}, [x30], #48");
+  TEST_SINGLE(ld3<SubRegSize::i8Bit>(DReg::d31, DReg::d0,  DReg::d1,  Reg::r30, 24), "ld3 {v31.8b, v0.8b, v1.8b}, [x30], #24");
   TEST_SINGLE(ld3<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, 48), "ld3 {v26.16b, v27.16b, v28.16b}, [x30], #48");
   TEST_SINGLE(ld3<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, 24), "ld3 {v26.8b, v27.8b, v28.8b}, [x30], #24");
 
@@ -453,6 +513,8 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Advanced SIMD load/store
   TEST_SINGLE(ld3<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, 48), "ld3 {v26.2d, v27.2d, v28.2d}, [x30], #48");
   TEST_SINGLE(ld3<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, 24), "unallocated (NEONLoadStoreMultiStructPostIndex)");
 
+  TEST_SINGLE(st3<SubRegSize::i8Bit>(QReg::q31, QReg::q0,  QReg::q1,  Reg::r30, Reg::r29), "st3 {v31.16b, v0.16b, v1.16b}, [x30], x29");
+  TEST_SINGLE(st3<SubRegSize::i8Bit>(DReg::d31, DReg::d0,  DReg::d1,  Reg::r30, Reg::r29), "st3 {v31.8b, v0.8b, v1.8b}, [x30], x29");
   TEST_SINGLE(st3<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, Reg::r29), "st3 {v26.16b, v27.16b, v28.16b}, [x30], x29");
   TEST_SINGLE(st3<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, Reg::r29), "st3 {v26.8b, v27.8b, v28.8b}, [x30], x29");
 
@@ -465,6 +527,8 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Advanced SIMD load/store
   TEST_SINGLE(st3<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, Reg::r29), "st3 {v26.2d, v27.2d, v28.2d}, [x30], x29");
   TEST_SINGLE(st3<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, Reg::r29), "unallocated (NEONLoadStoreMultiStructPostIndex)");
 
+  TEST_SINGLE(st3<SubRegSize::i8Bit>(QReg::q31, QReg::q0,  QReg::q1,  Reg::r30, 48), "st3 {v31.16b, v0.16b, v1.16b}, [x30], #48");
+  TEST_SINGLE(st3<SubRegSize::i8Bit>(DReg::d31, DReg::d0,  DReg::d1,  Reg::r30, 24), "st3 {v31.8b, v0.8b, v1.8b}, [x30], #24");
   TEST_SINGLE(st3<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, 48), "st3 {v26.16b, v27.16b, v28.16b}, [x30], #48");
   TEST_SINGLE(st3<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, 24), "st3 {v26.8b, v27.8b, v28.8b}, [x30], #24");
 
@@ -477,6 +541,8 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Advanced SIMD load/store
   TEST_SINGLE(st3<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, 48), "st3 {v26.2d, v27.2d, v28.2d}, [x30], #48");
   TEST_SINGLE(st3<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, 24), "unallocated (NEONLoadStoreMultiStructPostIndex)");
 
+  TEST_SINGLE(ld4<SubRegSize::i8Bit>(QReg::q31, QReg::q0,  QReg::q1,  QReg::q2,  Reg::r30, Reg::r29), "ld4 {v31.16b, v0.16b, v1.16b, v2.16b}, [x30], x29");
+  TEST_SINGLE(ld4<SubRegSize::i8Bit>(DReg::d31, DReg::d0,  DReg::d1,  DReg::d2,  Reg::r30, Reg::r29), "ld4 {v31.8b, v0.8b, v1.8b, v2.8b}, [x30], x29");
   TEST_SINGLE(ld4<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, Reg::r29), "ld4 {v26.16b, v27.16b, v28.16b, v29.16b}, [x30], x29");
   TEST_SINGLE(ld4<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, Reg::r29), "ld4 {v26.8b, v27.8b, v28.8b, v29.8b}, [x30], x29");
 
@@ -489,6 +555,8 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Advanced SIMD load/store
   TEST_SINGLE(ld4<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, Reg::r29), "ld4 {v26.2d, v27.2d, v28.2d, v29.2d}, [x30], x29");
   TEST_SINGLE(ld4<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, Reg::r29), "unallocated (NEONLoadStoreMultiStructPostIndex)");
 
+  TEST_SINGLE(ld4<SubRegSize::i8Bit>(QReg::q31, QReg::q0,  QReg::q1,  QReg::q2,  Reg::r30, 64), "ld4 {v31.16b, v0.16b, v1.16b, v2.16b}, [x30], #64");
+  TEST_SINGLE(ld4<SubRegSize::i8Bit>(DReg::d31, DReg::d0,  DReg::d1,  DReg::d2,  Reg::r30, 32), "ld4 {v31.8b, v0.8b, v1.8b, v2.8b}, [x30], #32");
   TEST_SINGLE(ld4<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, 64), "ld4 {v26.16b, v27.16b, v28.16b, v29.16b}, [x30], #64");
   TEST_SINGLE(ld4<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, 32), "ld4 {v26.8b, v27.8b, v28.8b, v29.8b}, [x30], #32");
 
@@ -501,6 +569,8 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Advanced SIMD load/store
   TEST_SINGLE(ld4<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, 64), "ld4 {v26.2d, v27.2d, v28.2d, v29.2d}, [x30], #64");
   TEST_SINGLE(ld4<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, 32), "unallocated (NEONLoadStoreMultiStructPostIndex)");
 
+  TEST_SINGLE(st4<SubRegSize::i8Bit>(QReg::q31, QReg::q0,  QReg::q1,  QReg::q2,  Reg::r30, Reg::r29), "st4 {v31.16b, v0.16b, v1.16b, v2.16b}, [x30], x29");
+  TEST_SINGLE(st4<SubRegSize::i8Bit>(DReg::d31, DReg::d0,  DReg::d1,  DReg::d2,  Reg::r30, Reg::r29), "st4 {v31.8b, v0.8b, v1.8b, v2.8b}, [x30], x29");
   TEST_SINGLE(st4<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, Reg::r29), "st4 {v26.16b, v27.16b, v28.16b, v29.16b}, [x30], x29");
   TEST_SINGLE(st4<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, Reg::r29), "st4 {v26.8b, v27.8b, v28.8b, v29.8b}, [x30], x29");
 
@@ -513,6 +583,8 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Advanced SIMD load/store
   TEST_SINGLE(st4<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, Reg::r29), "st4 {v26.2d, v27.2d, v28.2d, v29.2d}, [x30], x29");
   TEST_SINGLE(st4<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, Reg::r29), "unallocated (NEONLoadStoreMultiStructPostIndex)");
 
+  TEST_SINGLE(st4<SubRegSize::i8Bit>(QReg::q31, QReg::q0,  QReg::q1,  QReg::q2,  Reg::r30, 64), "st4 {v31.16b, v0.16b, v1.16b, v2.16b}, [x30], #64");
+  TEST_SINGLE(st4<SubRegSize::i8Bit>(DReg::d31, DReg::d0,  DReg::d1,  DReg::d2,  Reg::r30, 32), "st4 {v31.8b, v0.8b, v1.8b, v2.8b}, [x30], #32");
   TEST_SINGLE(st4<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, 64), "st4 {v26.16b, v27.16b, v28.16b, v29.16b}, [x30], #64");
   TEST_SINGLE(st4<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, 32), "st4 {v26.8b, v27.8b, v28.8b, v29.8b}, [x30], #32");
 
@@ -531,7 +603,7 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: ASIMD loadstore single")
   TEST_SINGLE(ld1<SubRegSize::i32Bit>(VReg::v26, 0, Reg::r30), "ld1 {v26.s}[0], [x30]");
   TEST_SINGLE(ld1<SubRegSize::i64Bit>(VReg::v26, 0, Reg::r30), "ld1 {v26.d}[0], [x30]");
 
-  TEST_SINGLE(ld1<SubRegSize::i8Bit>(VReg::v26, 15, Reg::r30),  "ld1 {v26.b}[15], [x30]");
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(VReg::v26, 15, Reg::r30), "ld1 {v26.b}[15], [x30]");
   TEST_SINGLE(ld1<SubRegSize::i16Bit>(VReg::v26, 7, Reg::r30), "ld1 {v26.h}[7], [x30]");
   TEST_SINGLE(ld1<SubRegSize::i32Bit>(VReg::v26, 3, Reg::r30), "ld1 {v26.s}[3], [x30]");
   TEST_SINGLE(ld1<SubRegSize::i64Bit>(VReg::v26, 1, Reg::r30), "ld1 {v26.d}[1], [x30]");
@@ -551,71 +623,80 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: ASIMD loadstore single")
   TEST_SINGLE(st1<SubRegSize::i32Bit>(VReg::v26, 0, Reg::r30), "st1 {v26.s}[0], [x30]");
   TEST_SINGLE(st1<SubRegSize::i64Bit>(VReg::v26, 0, Reg::r30), "st1 {v26.d}[0], [x30]");
 
-  TEST_SINGLE(st1<SubRegSize::i8Bit>(VReg::v26, 15, Reg::r30),  "st1 {v26.b}[15], [x30]");
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(VReg::v26, 15, Reg::r30), "st1 {v26.b}[15], [x30]");
   TEST_SINGLE(st1<SubRegSize::i16Bit>(VReg::v26, 7, Reg::r30), "st1 {v26.h}[7], [x30]");
   TEST_SINGLE(st1<SubRegSize::i32Bit>(VReg::v26, 3, Reg::r30), "st1 {v26.s}[3], [x30]");
   TEST_SINGLE(st1<SubRegSize::i64Bit>(VReg::v26, 1, Reg::r30), "st1 {v26.d}[1], [x30]");
 
+  TEST_SINGLE(ld2<SubRegSize::i8Bit>(VReg::v31, VReg::v0,  0, Reg::r30),  "ld2 {v31.b, v0.b}[0], [x30]");
   TEST_SINGLE(ld2<SubRegSize::i8Bit>(VReg::v26, VReg::v27, 0, Reg::r30),  "ld2 {v26.b, v27.b}[0], [x30]");
   TEST_SINGLE(ld2<SubRegSize::i16Bit>(VReg::v26, VReg::v27, 0, Reg::r30), "ld2 {v26.h, v27.h}[0], [x30]");
   TEST_SINGLE(ld2<SubRegSize::i32Bit>(VReg::v26, VReg::v27, 0, Reg::r30), "ld2 {v26.s, v27.s}[0], [x30]");
   TEST_SINGLE(ld2<SubRegSize::i64Bit>(VReg::v26, VReg::v27, 0, Reg::r30), "ld2 {v26.d, v27.d}[0], [x30]");
 
-  TEST_SINGLE(ld2<SubRegSize::i8Bit>(VReg::v26, VReg::v27, 15, Reg::r30),  "ld2 {v26.b, v27.b}[15], [x30]");
+  TEST_SINGLE(ld2<SubRegSize::i8Bit>(VReg::v26, VReg::v27, 15, Reg::r30), "ld2 {v26.b, v27.b}[15], [x30]");
   TEST_SINGLE(ld2<SubRegSize::i16Bit>(VReg::v26, VReg::v27, 7, Reg::r30), "ld2 {v26.h, v27.h}[7], [x30]");
   TEST_SINGLE(ld2<SubRegSize::i32Bit>(VReg::v26, VReg::v27, 3, Reg::r30), "ld2 {v26.s, v27.s}[3], [x30]");
   TEST_SINGLE(ld2<SubRegSize::i64Bit>(VReg::v26, VReg::v27, 1, Reg::r30), "ld2 {v26.d, v27.d}[1], [x30]");
 
+  TEST_SINGLE(ld2r<SubRegSize::i8Bit>(DReg::d31, DReg::d0,  Reg::r30),  "ld2r {v31.8b, v0.8b}, [x30]");
   TEST_SINGLE(ld2r<SubRegSize::i8Bit>(DReg::d26, DReg::d27, Reg::r30),  "ld2r {v26.8b, v27.8b}, [x30]");
   TEST_SINGLE(ld2r<SubRegSize::i16Bit>(DReg::d26, DReg::d27, Reg::r30), "ld2r {v26.4h, v27.4h}, [x30]");
   TEST_SINGLE(ld2r<SubRegSize::i32Bit>(DReg::d26, DReg::d27, Reg::r30), "ld2r {v26.2s, v27.2s}, [x30]");
   TEST_SINGLE(ld2r<SubRegSize::i64Bit>(DReg::d26, DReg::d27, Reg::r30), "ld2r {v26.1d, v27.1d}, [x30]");
 
+  TEST_SINGLE(ld2r<SubRegSize::i8Bit>(QReg::q31, QReg::q0,  Reg::r30),  "ld2r {v31.16b, v0.16b}, [x30]");
   TEST_SINGLE(ld2r<SubRegSize::i8Bit>(QReg::q26, QReg::q27, Reg::r30),  "ld2r {v26.16b, v27.16b}, [x30]");
   TEST_SINGLE(ld2r<SubRegSize::i16Bit>(QReg::q26, QReg::q27, Reg::r30), "ld2r {v26.8h, v27.8h}, [x30]");
   TEST_SINGLE(ld2r<SubRegSize::i32Bit>(QReg::q26, QReg::q27, Reg::r30), "ld2r {v26.4s, v27.4s}, [x30]");
   TEST_SINGLE(ld2r<SubRegSize::i64Bit>(QReg::q26, QReg::q27, Reg::r30), "ld2r {v26.2d, v27.2d}, [x30]");
 
+  TEST_SINGLE(st2<SubRegSize::i8Bit>(VReg::v31, VReg::v0,  0, Reg::r30),  "st2 {v31.b, v0.b}[0], [x30]");
   TEST_SINGLE(st2<SubRegSize::i8Bit>(VReg::v26, VReg::v27, 0, Reg::r30),  "st2 {v26.b, v27.b}[0], [x30]");
   TEST_SINGLE(st2<SubRegSize::i16Bit>(VReg::v26, VReg::v27, 0, Reg::r30), "st2 {v26.h, v27.h}[0], [x30]");
   TEST_SINGLE(st2<SubRegSize::i32Bit>(VReg::v26, VReg::v27, 0, Reg::r30), "st2 {v26.s, v27.s}[0], [x30]");
   TEST_SINGLE(st2<SubRegSize::i64Bit>(VReg::v26, VReg::v27, 0, Reg::r30), "st2 {v26.d, v27.d}[0], [x30]");
 
-  TEST_SINGLE(st2<SubRegSize::i8Bit>(VReg::v26, VReg::v27, 15, Reg::r30),  "st2 {v26.b, v27.b}[15], [x30]");
+  TEST_SINGLE(st2<SubRegSize::i8Bit>(VReg::v26, VReg::v27, 15, Reg::r30), "st2 {v26.b, v27.b}[15], [x30]");
   TEST_SINGLE(st2<SubRegSize::i16Bit>(VReg::v26, VReg::v27, 7, Reg::r30), "st2 {v26.h, v27.h}[7], [x30]");
   TEST_SINGLE(st2<SubRegSize::i32Bit>(VReg::v26, VReg::v27, 3, Reg::r30), "st2 {v26.s, v27.s}[3], [x30]");
   TEST_SINGLE(st2<SubRegSize::i64Bit>(VReg::v26, VReg::v27, 1, Reg::r30), "st2 {v26.d, v27.d}[1], [x30]");
 
+  TEST_SINGLE(ld3<SubRegSize::i8Bit>(VReg::v31, VReg::v0,  VReg::v1,  0, Reg::r30),  "ld3 {v31.b, v0.b, v1.b}[0], [x30]");
   TEST_SINGLE(ld3<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30),  "ld3 {v26.b, v27.b, v28.b}[0], [x30]");
   TEST_SINGLE(ld3<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30), "ld3 {v26.h, v27.h, v28.h}[0], [x30]");
   TEST_SINGLE(ld3<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30), "ld3 {v26.s, v27.s, v28.s}[0], [x30]");
   TEST_SINGLE(ld3<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30), "ld3 {v26.d, v27.d, v28.d}[0], [x30]");
 
-  TEST_SINGLE(ld3<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, 15, Reg::r30),  "ld3 {v26.b, v27.b, v28.b}[15], [x30]");
+  TEST_SINGLE(ld3<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, 15, Reg::r30), "ld3 {v26.b, v27.b, v28.b}[15], [x30]");
   TEST_SINGLE(ld3<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, 7, Reg::r30), "ld3 {v26.h, v27.h, v28.h}[7], [x30]");
   TEST_SINGLE(ld3<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, 3, Reg::r30), "ld3 {v26.s, v27.s, v28.s}[3], [x30]");
   TEST_SINGLE(ld3<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, 1, Reg::r30), "ld3 {v26.d, v27.d, v28.d}[1], [x30]");
 
+  TEST_SINGLE(ld3r<SubRegSize::i8Bit>(DReg::d31, DReg::d0,  DReg::d1,  Reg::r30),  "ld3r {v31.8b, v0.8b, v1.8b}, [x30]");
   TEST_SINGLE(ld3r<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30),  "ld3r {v26.8b, v27.8b, v28.8b}, [x30]");
   TEST_SINGLE(ld3r<SubRegSize::i16Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30), "ld3r {v26.4h, v27.4h, v28.4h}, [x30]");
   TEST_SINGLE(ld3r<SubRegSize::i32Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30), "ld3r {v26.2s, v27.2s, v28.2s}, [x30]");
   TEST_SINGLE(ld3r<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30), "ld3r {v26.1d, v27.1d, v28.1d}, [x30]");
 
+  TEST_SINGLE(ld3r<SubRegSize::i8Bit>(QReg::q31, QReg::q0,  QReg::q1,  Reg::r30),  "ld3r {v31.16b, v0.16b, v1.16b}, [x30]");
   TEST_SINGLE(ld3r<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30),  "ld3r {v26.16b, v27.16b, v28.16b}, [x30]");
   TEST_SINGLE(ld3r<SubRegSize::i16Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30), "ld3r {v26.8h, v27.8h, v28.8h}, [x30]");
   TEST_SINGLE(ld3r<SubRegSize::i32Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30), "ld3r {v26.4s, v27.4s, v28.4s}, [x30]");
   TEST_SINGLE(ld3r<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30), "ld3r {v26.2d, v27.2d, v28.2d}, [x30]");
 
+  TEST_SINGLE(st3<SubRegSize::i8Bit>(VReg::v31, VReg::v0,  VReg::v1,  0, Reg::r30),  "st3 {v31.b, v0.b, v1.b}[0], [x30]");
   TEST_SINGLE(st3<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30),  "st3 {v26.b, v27.b, v28.b}[0], [x30]");
   TEST_SINGLE(st3<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30), "st3 {v26.h, v27.h, v28.h}[0], [x30]");
   TEST_SINGLE(st3<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30), "st3 {v26.s, v27.s, v28.s}[0], [x30]");
   TEST_SINGLE(st3<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30), "st3 {v26.d, v27.d, v28.d}[0], [x30]");
 
-  TEST_SINGLE(st3<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, 15, Reg::r30),  "st3 {v26.b, v27.b, v28.b}[15], [x30]");
+  TEST_SINGLE(st3<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, 15, Reg::r30), "st3 {v26.b, v27.b, v28.b}[15], [x30]");
   TEST_SINGLE(st3<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, 7, Reg::r30), "st3 {v26.h, v27.h, v28.h}[7], [x30]");
   TEST_SINGLE(st3<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, 3, Reg::r30), "st3 {v26.s, v27.s, v28.s}[3], [x30]");
   TEST_SINGLE(st3<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, 1, Reg::r30), "st3 {v26.d, v27.d, v28.d}[1], [x30]");
 
+  TEST_SINGLE(ld4<SubRegSize::i8Bit>(VReg::v31, VReg::v0,  VReg::v1,  VReg::v2,  0, Reg::r30),  "ld4 {v31.b, v0.b, v1.b, v2.b}[0], [x30]");
   TEST_SINGLE(ld4<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30),  "ld4 {v26.b, v27.b, v28.b, v29.b}[0], [x30]");
   TEST_SINGLE(ld4<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30), "ld4 {v26.h, v27.h, v28.h, v29.h}[0], [x30]");
   TEST_SINGLE(ld4<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30), "ld4 {v26.s, v27.s, v28.s, v29.s}[0], [x30]");
@@ -626,22 +707,25 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: ASIMD loadstore single")
   TEST_SINGLE(ld4<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 3, Reg::r30), "ld4 {v26.s, v27.s, v28.s, v29.s}[3], [x30]");
   TEST_SINGLE(ld4<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 1, Reg::r30), "ld4 {v26.d, v27.d, v28.d, v29.d}[1], [x30]");
 
+  TEST_SINGLE(ld4r<SubRegSize::i8Bit>(DReg::d31, DReg::d0,  DReg::d1,  DReg::d2,  Reg::r30),  "ld4r {v31.8b, v0.8b, v1.8b, v2.8b}, [x30]");
   TEST_SINGLE(ld4r<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30),  "ld4r {v26.8b, v27.8b, v28.8b, v29.8b}, [x30]");
   TEST_SINGLE(ld4r<SubRegSize::i16Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30), "ld4r {v26.4h, v27.4h, v28.4h, v29.4h}, [x30]");
   TEST_SINGLE(ld4r<SubRegSize::i32Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30), "ld4r {v26.2s, v27.2s, v28.2s, v29.2s}, [x30]");
   TEST_SINGLE(ld4r<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30), "ld4r {v26.1d, v27.1d, v28.1d, v29.1d}, [x30]");
 
+  TEST_SINGLE(ld4r<SubRegSize::i8Bit>(QReg::q31, QReg::q0,  QReg::q1,  QReg::q2,  Reg::r30),  "ld4r {v31.16b, v0.16b, v1.16b, v2.16b}, [x30]");
   TEST_SINGLE(ld4r<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30),  "ld4r {v26.16b, v27.16b, v28.16b, v29.16b}, [x30]");
   TEST_SINGLE(ld4r<SubRegSize::i16Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30), "ld4r {v26.8h, v27.8h, v28.8h, v29.8h}, [x30]");
   TEST_SINGLE(ld4r<SubRegSize::i32Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30), "ld4r {v26.4s, v27.4s, v28.4s, v29.4s}, [x30]");
   TEST_SINGLE(ld4r<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30), "ld4r {v26.2d, v27.2d, v28.2d, v29.2d}, [x30]");
 
+  TEST_SINGLE(st4<SubRegSize::i8Bit>(VReg::v31, VReg::v0,  VReg::v1,  VReg::v2,  0, Reg::r30),  "st4 {v31.b, v0.b, v1.b, v2.b}[0], [x30]");
   TEST_SINGLE(st4<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30),  "st4 {v26.b, v27.b, v28.b, v29.b}[0], [x30]");
   TEST_SINGLE(st4<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30), "st4 {v26.h, v27.h, v28.h, v29.h}[0], [x30]");
   TEST_SINGLE(st4<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30), "st4 {v26.s, v27.s, v28.s, v29.s}[0], [x30]");
   TEST_SINGLE(st4<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30), "st4 {v26.d, v27.d, v28.d, v29.d}[0], [x30]");
 
-  TEST_SINGLE(st4<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 15, Reg::r30),  "st4 {v26.b, v27.b, v28.b, v29.b}[15], [x30]");
+  TEST_SINGLE(st4<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 15, Reg::r30), "st4 {v26.b, v27.b, v28.b, v29.b}[15], [x30]");
   TEST_SINGLE(st4<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 7, Reg::r30), "st4 {v26.h, v27.h, v28.h, v29.h}[7], [x30]");
   TEST_SINGLE(st4<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 3, Reg::r30), "st4 {v26.s, v27.s, v28.s, v29.s}[3], [x30]");
   TEST_SINGLE(st4<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 1, Reg::r30), "st4 {v26.d, v27.d, v28.d, v29.d}[1], [x30]");
@@ -652,7 +736,7 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Advanced SIMD load/store
   TEST_SINGLE(ld1<SubRegSize::i32Bit>(VReg::v26, 0, Reg::r30, 4), "ld1 {v26.s}[0], [x30], #4");
   TEST_SINGLE(ld1<SubRegSize::i64Bit>(VReg::v26, 0, Reg::r30, 8), "ld1 {v26.d}[0], [x30], #8");
 
-  TEST_SINGLE(ld1<SubRegSize::i8Bit>(VReg::v26, 15, Reg::r30, 1),  "ld1 {v26.b}[15], [x30], #1");
+  TEST_SINGLE(ld1<SubRegSize::i8Bit>(VReg::v26, 15, Reg::r30, 1), "ld1 {v26.b}[15], [x30], #1");
   TEST_SINGLE(ld1<SubRegSize::i16Bit>(VReg::v26, 7, Reg::r30, 2), "ld1 {v26.h}[7], [x30], #2");
   TEST_SINGLE(ld1<SubRegSize::i32Bit>(VReg::v26, 3, Reg::r30, 4), "ld1 {v26.s}[3], [x30], #4");
   TEST_SINGLE(ld1<SubRegSize::i64Bit>(VReg::v26, 1, Reg::r30, 8), "ld1 {v26.d}[1], [x30], #8");
@@ -672,100 +756,112 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Advanced SIMD load/store
   TEST_SINGLE(st1<SubRegSize::i32Bit>(VReg::v26, 0, Reg::r30, 4), "st1 {v26.s}[0], [x30], #4");
   TEST_SINGLE(st1<SubRegSize::i64Bit>(VReg::v26, 0, Reg::r30, 8), "st1 {v26.d}[0], [x30], #8");
 
-  TEST_SINGLE(st1<SubRegSize::i8Bit>(VReg::v26, 15, Reg::r30, 1),  "st1 {v26.b}[15], [x30], #1");
+  TEST_SINGLE(st1<SubRegSize::i8Bit>(VReg::v26, 15, Reg::r30, 1), "st1 {v26.b}[15], [x30], #1");
   TEST_SINGLE(st1<SubRegSize::i16Bit>(VReg::v26, 7, Reg::r30, 2), "st1 {v26.h}[7], [x30], #2");
   TEST_SINGLE(st1<SubRegSize::i32Bit>(VReg::v26, 3, Reg::r30, 4), "st1 {v26.s}[3], [x30], #4");
   TEST_SINGLE(st1<SubRegSize::i64Bit>(VReg::v26, 1, Reg::r30, 8), "st1 {v26.d}[1], [x30], #8");
 
-  TEST_SINGLE(ld2<SubRegSize::i8Bit>(VReg::v26, VReg::v27, 0, Reg::r30, 2),  "ld2 {v26.b, v27.b}[0], [x30], #2");
-  TEST_SINGLE(ld2<SubRegSize::i16Bit>(VReg::v26, VReg::v27, 0, Reg::r30, 4), "ld2 {v26.h, v27.h}[0], [x30], #4");
-  TEST_SINGLE(ld2<SubRegSize::i32Bit>(VReg::v26, VReg::v27, 0, Reg::r30, 8), "ld2 {v26.s, v27.s}[0], [x30], #8");
+  TEST_SINGLE(ld2<SubRegSize::i8Bit>(VReg::v31,  VReg::v0,  0, Reg::r30, 2),  "ld2 {v31.b, v0.b}[0], [x30], #2");
+  TEST_SINGLE(ld2<SubRegSize::i8Bit>(VReg::v26,  VReg::v27, 0, Reg::r30, 2),  "ld2 {v26.b, v27.b}[0], [x30], #2");
+  TEST_SINGLE(ld2<SubRegSize::i16Bit>(VReg::v26, VReg::v27, 0, Reg::r30, 4),  "ld2 {v26.h, v27.h}[0], [x30], #4");
+  TEST_SINGLE(ld2<SubRegSize::i32Bit>(VReg::v26, VReg::v27, 0, Reg::r30, 8),  "ld2 {v26.s, v27.s}[0], [x30], #8");
   TEST_SINGLE(ld2<SubRegSize::i64Bit>(VReg::v26, VReg::v27, 0, Reg::r30, 16), "ld2 {v26.d, v27.d}[0], [x30], #16");
 
   TEST_SINGLE(ld2<SubRegSize::i8Bit>(VReg::v26, VReg::v27, 15, Reg::r30, 2),  "ld2 {v26.b, v27.b}[15], [x30], #2");
-  TEST_SINGLE(ld2<SubRegSize::i16Bit>(VReg::v26, VReg::v27, 7, Reg::r30, 4), "ld2 {v26.h, v27.h}[7], [x30], #4");
-  TEST_SINGLE(ld2<SubRegSize::i32Bit>(VReg::v26, VReg::v27, 3, Reg::r30, 8), "ld2 {v26.s, v27.s}[3], [x30], #8");
+  TEST_SINGLE(ld2<SubRegSize::i16Bit>(VReg::v26, VReg::v27, 7, Reg::r30, 4),  "ld2 {v26.h, v27.h}[7], [x30], #4");
+  TEST_SINGLE(ld2<SubRegSize::i32Bit>(VReg::v26, VReg::v27, 3, Reg::r30, 8),  "ld2 {v26.s, v27.s}[3], [x30], #8");
   TEST_SINGLE(ld2<SubRegSize::i64Bit>(VReg::v26, VReg::v27, 1, Reg::r30, 16), "ld2 {v26.d, v27.d}[1], [x30], #16");
 
-  TEST_SINGLE(ld2r<SubRegSize::i8Bit>(DReg::d26, DReg::d27, Reg::r30, 2),  "ld2r {v26.8b, v27.8b}, [x30], #2");
-  TEST_SINGLE(ld2r<SubRegSize::i16Bit>(DReg::d26, DReg::d27, Reg::r30, 4), "ld2r {v26.4h, v27.4h}, [x30], #4");
-  TEST_SINGLE(ld2r<SubRegSize::i32Bit>(DReg::d26, DReg::d27, Reg::r30, 8), "ld2r {v26.2s, v27.2s}, [x30], #8");
+  TEST_SINGLE(ld2r<SubRegSize::i8Bit>(DReg::d31,  DReg::d0,  Reg::r30, 2),  "ld2r {v31.8b, v0.8b}, [x30], #2");
+  TEST_SINGLE(ld2r<SubRegSize::i8Bit>(DReg::d26,  DReg::d27, Reg::r30, 2),  "ld2r {v26.8b, v27.8b}, [x30], #2");
+  TEST_SINGLE(ld2r<SubRegSize::i16Bit>(DReg::d26, DReg::d27, Reg::r30, 4),  "ld2r {v26.4h, v27.4h}, [x30], #4");
+  TEST_SINGLE(ld2r<SubRegSize::i32Bit>(DReg::d26, DReg::d27, Reg::r30, 8),  "ld2r {v26.2s, v27.2s}, [x30], #8");
   TEST_SINGLE(ld2r<SubRegSize::i64Bit>(DReg::d26, DReg::d27, Reg::r30, 16), "ld2r {v26.1d, v27.1d}, [x30], #16");
 
-  TEST_SINGLE(ld2r<SubRegSize::i8Bit>(QReg::q26, QReg::q27, Reg::r30, 2),  "ld2r {v26.16b, v27.16b}, [x30], #2");
-  TEST_SINGLE(ld2r<SubRegSize::i16Bit>(QReg::q26, QReg::q27, Reg::r30, 4), "ld2r {v26.8h, v27.8h}, [x30], #4");
-  TEST_SINGLE(ld2r<SubRegSize::i32Bit>(QReg::q26, QReg::q27, Reg::r30, 8), "ld2r {v26.4s, v27.4s}, [x30], #8");
+  TEST_SINGLE(ld2r<SubRegSize::i8Bit>(QReg::q31,  QReg::q0,  Reg::r30, 2),  "ld2r {v31.16b, v0.16b}, [x30], #2");
+  TEST_SINGLE(ld2r<SubRegSize::i8Bit>(QReg::q26,  QReg::q27, Reg::r30, 2),  "ld2r {v26.16b, v27.16b}, [x30], #2");
+  TEST_SINGLE(ld2r<SubRegSize::i16Bit>(QReg::q26, QReg::q27, Reg::r30, 4),  "ld2r {v26.8h, v27.8h}, [x30], #4");
+  TEST_SINGLE(ld2r<SubRegSize::i32Bit>(QReg::q26, QReg::q27, Reg::r30, 8),  "ld2r {v26.4s, v27.4s}, [x30], #8");
   TEST_SINGLE(ld2r<SubRegSize::i64Bit>(QReg::q26, QReg::q27, Reg::r30, 16), "ld2r {v26.2d, v27.2d}, [x30], #16");
 
-  TEST_SINGLE(st2<SubRegSize::i8Bit>(VReg::v26, VReg::v27, 0, Reg::r30, 2),  "st2 {v26.b, v27.b}[0], [x30], #2");
-  TEST_SINGLE(st2<SubRegSize::i16Bit>(VReg::v26, VReg::v27, 0, Reg::r30, 4), "st2 {v26.h, v27.h}[0], [x30], #4");
-  TEST_SINGLE(st2<SubRegSize::i32Bit>(VReg::v26, VReg::v27, 0, Reg::r30, 8), "st2 {v26.s, v27.s}[0], [x30], #8");
+  TEST_SINGLE(st2<SubRegSize::i8Bit>(VReg::v31,  VReg::v0,  0, Reg::r30, 2),  "st2 {v31.b, v0.b}[0], [x30], #2");
+  TEST_SINGLE(st2<SubRegSize::i8Bit>(VReg::v26,  VReg::v27, 0, Reg::r30, 2),  "st2 {v26.b, v27.b}[0], [x30], #2");
+  TEST_SINGLE(st2<SubRegSize::i16Bit>(VReg::v26, VReg::v27, 0, Reg::r30, 4),  "st2 {v26.h, v27.h}[0], [x30], #4");
+  TEST_SINGLE(st2<SubRegSize::i32Bit>(VReg::v26, VReg::v27, 0, Reg::r30, 8),  "st2 {v26.s, v27.s}[0], [x30], #8");
   TEST_SINGLE(st2<SubRegSize::i64Bit>(VReg::v26, VReg::v27, 0, Reg::r30, 16), "st2 {v26.d, v27.d}[0], [x30], #16");
 
-  TEST_SINGLE(st2<SubRegSize::i8Bit>(VReg::v26, VReg::v27, 15, Reg::r30, 2),  "st2 {v26.b, v27.b}[15], [x30], #2");
-  TEST_SINGLE(st2<SubRegSize::i16Bit>(VReg::v26, VReg::v27, 7, Reg::r30, 4), "st2 {v26.h, v27.h}[7], [x30], #4");
-  TEST_SINGLE(st2<SubRegSize::i32Bit>(VReg::v26, VReg::v27, 3, Reg::r30, 8), "st2 {v26.s, v27.s}[3], [x30], #8");
-  TEST_SINGLE(st2<SubRegSize::i64Bit>(VReg::v26, VReg::v27, 1, Reg::r30, 16), "st2 {v26.d, v27.d}[1], [x30], #16");
+  TEST_SINGLE(st2<SubRegSize::i8Bit>(VReg::v26,  VReg::v27, 15, Reg::r30, 2),  "st2 {v26.b, v27.b}[15], [x30], #2");
+  TEST_SINGLE(st2<SubRegSize::i16Bit>(VReg::v26, VReg::v27, 7,  Reg::r30, 4),  "st2 {v26.h, v27.h}[7], [x30], #4");
+  TEST_SINGLE(st2<SubRegSize::i32Bit>(VReg::v26, VReg::v27, 3,  Reg::r30, 8),  "st2 {v26.s, v27.s}[3], [x30], #8");
+  TEST_SINGLE(st2<SubRegSize::i64Bit>(VReg::v26, VReg::v27, 1,  Reg::r30, 16), "st2 {v26.d, v27.d}[1], [x30], #16");
 
-  TEST_SINGLE(ld3<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30, 3),  "ld3 {v26.b, v27.b, v28.b}[0], [x30], #3");
-  TEST_SINGLE(ld3<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30, 6), "ld3 {v26.h, v27.h, v28.h}[0], [x30], #6");
+  TEST_SINGLE(ld3<SubRegSize::i8Bit>(VReg::v31,  VReg::v0,  VReg::v1,  0, Reg::r30, 3),  "ld3 {v31.b, v0.b, v1.b}[0], [x30], #3");
+  TEST_SINGLE(ld3<SubRegSize::i8Bit>(VReg::v26,  VReg::v27, VReg::v28, 0, Reg::r30, 3),  "ld3 {v26.b, v27.b, v28.b}[0], [x30], #3");
+  TEST_SINGLE(ld3<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30, 6),  "ld3 {v26.h, v27.h, v28.h}[0], [x30], #6");
   TEST_SINGLE(ld3<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30, 12), "ld3 {v26.s, v27.s, v28.s}[0], [x30], #12");
   TEST_SINGLE(ld3<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30, 24), "ld3 {v26.d, v27.d, v28.d}[0], [x30], #24");
 
-  TEST_SINGLE(ld3<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, 15, Reg::r30, 1),  "ld3 {v26.b, v27.b, v28.b}[15], [x30], #3");
-  TEST_SINGLE(ld3<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, 7, Reg::r30, 2), "ld3 {v26.h, v27.h, v28.h}[7], [x30], #6");
-  TEST_SINGLE(ld3<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, 3, Reg::r30, 4), "ld3 {v26.s, v27.s, v28.s}[3], [x30], #12");
-  TEST_SINGLE(ld3<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, 1, Reg::r30, 8), "ld3 {v26.d, v27.d, v28.d}[1], [x30], #24");
+  TEST_SINGLE(ld3<SubRegSize::i8Bit>(VReg::v26,  VReg::v27, VReg::v28, 15, Reg::r30, 1), "ld3 {v26.b, v27.b, v28.b}[15], [x30], #3");
+  TEST_SINGLE(ld3<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, 7,  Reg::r30, 2), "ld3 {v26.h, v27.h, v28.h}[7], [x30], #6");
+  TEST_SINGLE(ld3<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, 3,  Reg::r30, 4), "ld3 {v26.s, v27.s, v28.s}[3], [x30], #12");
+  TEST_SINGLE(ld3<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, 1,  Reg::r30, 8), "ld3 {v26.d, v27.d, v28.d}[1], [x30], #24");
 
-  TEST_SINGLE(ld3r<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, 3),  "ld3r {v26.8b, v27.8b, v28.8b}, [x30], #3");
-  TEST_SINGLE(ld3r<SubRegSize::i16Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, 6), "ld3r {v26.4h, v27.4h, v28.4h}, [x30], #6");
+  TEST_SINGLE(ld3r<SubRegSize::i8Bit>(DReg::d31,  DReg::d0,  DReg::d1,  Reg::r30, 3),  "ld3r {v31.8b, v0.8b, v1.8b}, [x30], #3");
+  TEST_SINGLE(ld3r<SubRegSize::i8Bit>(DReg::d26,  DReg::d27, DReg::d28, Reg::r30, 3),  "ld3r {v26.8b, v27.8b, v28.8b}, [x30], #3");
+  TEST_SINGLE(ld3r<SubRegSize::i16Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, 6),  "ld3r {v26.4h, v27.4h, v28.4h}, [x30], #6");
   TEST_SINGLE(ld3r<SubRegSize::i32Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, 12), "ld3r {v26.2s, v27.2s, v28.2s}, [x30], #12");
   TEST_SINGLE(ld3r<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, 24), "ld3r {v26.1d, v27.1d, v28.1d}, [x30], #24");
 
-  TEST_SINGLE(ld3r<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, 3),  "ld3r {v26.16b, v27.16b, v28.16b}, [x30], #3");
-  TEST_SINGLE(ld3r<SubRegSize::i16Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, 6), "ld3r {v26.8h, v27.8h, v28.8h}, [x30], #6");
+  TEST_SINGLE(ld3r<SubRegSize::i8Bit>(QReg::q31,  QReg::q0,  QReg::q1,  Reg::r30, 3),  "ld3r {v31.16b, v0.16b, v1.16b}, [x30], #3");
+  TEST_SINGLE(ld3r<SubRegSize::i8Bit>(QReg::q26,  QReg::q27, QReg::q28, Reg::r30, 3),  "ld3r {v26.16b, v27.16b, v28.16b}, [x30], #3");
+  TEST_SINGLE(ld3r<SubRegSize::i16Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, 6),  "ld3r {v26.8h, v27.8h, v28.8h}, [x30], #6");
   TEST_SINGLE(ld3r<SubRegSize::i32Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, 12), "ld3r {v26.4s, v27.4s, v28.4s}, [x30], #12");
   TEST_SINGLE(ld3r<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, 24), "ld3r {v26.2d, v27.2d, v28.2d}, [x30], #24");
 
-  TEST_SINGLE(st3<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30, 3),  "st3 {v26.b, v27.b, v28.b}[0], [x30], #3");
-  TEST_SINGLE(st3<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30, 6), "st3 {v26.h, v27.h, v28.h}[0], [x30], #6");
+  TEST_SINGLE(st3<SubRegSize::i8Bit>(VReg::v31,  VReg::v0,  VReg::v1,  0, Reg::r30, 3),  "st3 {v31.b, v0.b, v1.b}[0], [x30], #3");
+  TEST_SINGLE(st3<SubRegSize::i8Bit>(VReg::v26,  VReg::v27, VReg::v28, 0, Reg::r30, 3),  "st3 {v26.b, v27.b, v28.b}[0], [x30], #3");
+  TEST_SINGLE(st3<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30, 6),  "st3 {v26.h, v27.h, v28.h}[0], [x30], #6");
   TEST_SINGLE(st3<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30, 12), "st3 {v26.s, v27.s, v28.s}[0], [x30], #12");
   TEST_SINGLE(st3<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30, 24), "st3 {v26.d, v27.d, v28.d}[0], [x30], #24");
 
-  TEST_SINGLE(st3<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, 15, Reg::r30, 3),  "st3 {v26.b, v27.b, v28.b}[15], [x30], #3");
-  TEST_SINGLE(st3<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, 7, Reg::r30, 6), "st3 {v26.h, v27.h, v28.h}[7], [x30], #6");
-  TEST_SINGLE(st3<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, 3, Reg::r30, 12), "st3 {v26.s, v27.s, v28.s}[3], [x30], #12");
-  TEST_SINGLE(st3<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, 1, Reg::r30, 24), "st3 {v26.d, v27.d, v28.d}[1], [x30], #24");
+  TEST_SINGLE(st3<SubRegSize::i8Bit>(VReg::v26,  VReg::v27, VReg::v28, 15, Reg::r30, 3),  "st3 {v26.b, v27.b, v28.b}[15], [x30], #3");
+  TEST_SINGLE(st3<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, 7,  Reg::r30, 6),  "st3 {v26.h, v27.h, v28.h}[7], [x30], #6");
+  TEST_SINGLE(st3<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, 3,  Reg::r30, 12), "st3 {v26.s, v27.s, v28.s}[3], [x30], #12");
+  TEST_SINGLE(st3<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, 1,  Reg::r30, 24), "st3 {v26.d, v27.d, v28.d}[1], [x30], #24");
 
-  TEST_SINGLE(ld4<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30, 4),  "ld4 {v26.b, v27.b, v28.b, v29.b}[0], [x30], #4");
-  TEST_SINGLE(ld4<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30, 8), "ld4 {v26.h, v27.h, v28.h, v29.h}[0], [x30], #8");
+  TEST_SINGLE(ld4<SubRegSize::i8Bit>(VReg::v31,  VReg::v0,  VReg::v1,  VReg::v2,  0, Reg::r30, 4),  "ld4 {v31.b, v0.b, v1.b, v2.b}[0], [x30], #4");
+  TEST_SINGLE(ld4<SubRegSize::i8Bit>(VReg::v26,  VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30, 4),  "ld4 {v26.b, v27.b, v28.b, v29.b}[0], [x30], #4");
+  TEST_SINGLE(ld4<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30, 8),  "ld4 {v26.h, v27.h, v28.h, v29.h}[0], [x30], #8");
   TEST_SINGLE(ld4<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30, 16), "ld4 {v26.s, v27.s, v28.s, v29.s}[0], [x30], #16");
   TEST_SINGLE(ld4<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30, 32), "ld4 {v26.d, v27.d, v28.d, v29.d}[0], [x30], #32");
 
-  TEST_SINGLE(ld4<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 15, Reg::r30, 4),  "ld4 {v26.b, v27.b, v28.b, v29.b}[15], [x30], #4");
-  TEST_SINGLE(ld4<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 7, Reg::r30, 8), "ld4 {v26.h, v27.h, v28.h, v29.h}[7], [x30], #8");
-  TEST_SINGLE(ld4<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 3, Reg::r30, 16), "ld4 {v26.s, v27.s, v28.s, v29.s}[3], [x30], #16");
-  TEST_SINGLE(ld4<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 1, Reg::r30, 32), "ld4 {v26.d, v27.d, v28.d, v29.d}[1], [x30], #32");
+  TEST_SINGLE(ld4<SubRegSize::i8Bit>(VReg::v26,  VReg::v27, VReg::v28, VReg::v29, 15, Reg::r30, 4),  "ld4 {v26.b, v27.b, v28.b, v29.b}[15], [x30], #4");
+  TEST_SINGLE(ld4<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 7,  Reg::r30, 8),  "ld4 {v26.h, v27.h, v28.h, v29.h}[7], [x30], #8");
+  TEST_SINGLE(ld4<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 3,  Reg::r30, 16), "ld4 {v26.s, v27.s, v28.s, v29.s}[3], [x30], #16");
+  TEST_SINGLE(ld4<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 1,  Reg::r30, 32), "ld4 {v26.d, v27.d, v28.d, v29.d}[1], [x30], #32");
 
-  TEST_SINGLE(ld4r<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, 4),  "ld4r {v26.8b, v27.8b, v28.8b, v29.8b}, [x30], #4");
-  TEST_SINGLE(ld4r<SubRegSize::i16Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, 8), "ld4r {v26.4h, v27.4h, v28.4h, v29.4h}, [x30], #8");
+  TEST_SINGLE(ld4r<SubRegSize::i8Bit>(DReg::d31,  DReg::d0,  DReg::d1,  DReg::d2,  Reg::r30, 4),  "ld4r {v31.8b, v0.8b, v1.8b, v2.8b}, [x30], #4");
+  TEST_SINGLE(ld4r<SubRegSize::i8Bit>(DReg::d26,  DReg::d27, DReg::d28, DReg::d29, Reg::r30, 4),  "ld4r {v26.8b, v27.8b, v28.8b, v29.8b}, [x30], #4");
+  TEST_SINGLE(ld4r<SubRegSize::i16Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, 8),  "ld4r {v26.4h, v27.4h, v28.4h, v29.4h}, [x30], #8");
   TEST_SINGLE(ld4r<SubRegSize::i32Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, 16), "ld4r {v26.2s, v27.2s, v28.2s, v29.2s}, [x30], #16");
   TEST_SINGLE(ld4r<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, 32), "ld4r {v26.1d, v27.1d, v28.1d, v29.1d}, [x30], #32");
 
-  TEST_SINGLE(ld4r<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, 4),  "ld4r {v26.16b, v27.16b, v28.16b, v29.16b}, [x30], #4");
-  TEST_SINGLE(ld4r<SubRegSize::i16Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, 8), "ld4r {v26.8h, v27.8h, v28.8h, v29.8h}, [x30], #8");
+  TEST_SINGLE(ld4r<SubRegSize::i8Bit>(QReg::q31,  QReg::q0,  QReg::q1,  QReg::q2,  Reg::r30, 4),  "ld4r {v31.16b, v0.16b, v1.16b, v2.16b}, [x30], #4");
+  TEST_SINGLE(ld4r<SubRegSize::i8Bit>(QReg::q26,  QReg::q27, QReg::q28, QReg::q29, Reg::r30, 4),  "ld4r {v26.16b, v27.16b, v28.16b, v29.16b}, [x30], #4");
+  TEST_SINGLE(ld4r<SubRegSize::i16Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, 8),  "ld4r {v26.8h, v27.8h, v28.8h, v29.8h}, [x30], #8");
   TEST_SINGLE(ld4r<SubRegSize::i32Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, 16), "ld4r {v26.4s, v27.4s, v28.4s, v29.4s}, [x30], #16");
   TEST_SINGLE(ld4r<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, 32), "ld4r {v26.2d, v27.2d, v28.2d, v29.2d}, [x30], #32");
 
-  TEST_SINGLE(st4<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30, 4),  "st4 {v26.b, v27.b, v28.b, v29.b}[0], [x30], #4");
-  TEST_SINGLE(st4<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30, 8), "st4 {v26.h, v27.h, v28.h, v29.h}[0], [x30], #8");
+  TEST_SINGLE(st4<SubRegSize::i8Bit>(VReg::v31,  VReg::v0,  VReg::v1,  VReg::v2,  0, Reg::r30, 4),  "st4 {v31.b, v0.b, v1.b, v2.b}[0], [x30], #4");
+  TEST_SINGLE(st4<SubRegSize::i8Bit>(VReg::v26,  VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30, 4),  "st4 {v26.b, v27.b, v28.b, v29.b}[0], [x30], #4");
+  TEST_SINGLE(st4<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30, 8),  "st4 {v26.h, v27.h, v28.h, v29.h}[0], [x30], #8");
   TEST_SINGLE(st4<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30, 16), "st4 {v26.s, v27.s, v28.s, v29.s}[0], [x30], #16");
   TEST_SINGLE(st4<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30, 32), "st4 {v26.d, v27.d, v28.d, v29.d}[0], [x30], #32");
 
-  TEST_SINGLE(st4<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 15, Reg::r30, 4),  "st4 {v26.b, v27.b, v28.b, v29.b}[15], [x30], #4");
-  TEST_SINGLE(st4<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 7, Reg::r30, 8), "st4 {v26.h, v27.h, v28.h, v29.h}[7], [x30], #8");
-  TEST_SINGLE(st4<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 3, Reg::r30, 16), "st4 {v26.s, v27.s, v28.s, v29.s}[3], [x30], #16");
-  TEST_SINGLE(st4<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 1, Reg::r30, 32), "st4 {v26.d, v27.d, v28.d, v29.d}[1], [x30], #32");
+  TEST_SINGLE(st4<SubRegSize::i8Bit>(VReg::v26,  VReg::v27, VReg::v28, VReg::v29, 15, Reg::r30, 4),  "st4 {v26.b, v27.b, v28.b, v29.b}[15], [x30], #4");
+  TEST_SINGLE(st4<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 7,  Reg::r30, 8),  "st4 {v26.h, v27.h, v28.h, v29.h}[7], [x30], #8");
+  TEST_SINGLE(st4<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 3,  Reg::r30, 16), "st4 {v26.s, v27.s, v28.s, v29.s}[3], [x30], #16");
+  TEST_SINGLE(st4<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 1,  Reg::r30, 32), "st4 {v26.d, v27.d, v28.d, v29.d}[1], [x30], #32");
 
   TEST_SINGLE(ld1<SubRegSize::i8Bit>(VReg::v26, 0, Reg::r30, Reg::r29),  "ld1 {v26.b}[0], [x30], x29");
   TEST_SINGLE(ld1<SubRegSize::i16Bit>(VReg::v26, 0, Reg::r30, Reg::r29), "ld1 {v26.h}[0], [x30], x29");
@@ -797,95 +893,107 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Advanced SIMD load/store
   TEST_SINGLE(st1<SubRegSize::i32Bit>(VReg::v26, 3, Reg::r30, Reg::r29), "st1 {v26.s}[3], [x30], x29");
   TEST_SINGLE(st1<SubRegSize::i64Bit>(VReg::v26, 1, Reg::r30, Reg::r29), "st1 {v26.d}[1], [x30], x29");
 
-  TEST_SINGLE(ld2<SubRegSize::i8Bit>(VReg::v26, VReg::v27, 0, Reg::r30, Reg::r29),  "ld2 {v26.b, v27.b}[0], [x30], x29");
+  TEST_SINGLE(ld2<SubRegSize::i8Bit>(VReg::v31,  VReg::v0,  0, Reg::r30, Reg::r29), "ld2 {v31.b, v0.b}[0], [x30], x29");
+  TEST_SINGLE(ld2<SubRegSize::i8Bit>(VReg::v26,  VReg::v27, 0, Reg::r30, Reg::r29), "ld2 {v26.b, v27.b}[0], [x30], x29");
   TEST_SINGLE(ld2<SubRegSize::i16Bit>(VReg::v26, VReg::v27, 0, Reg::r30, Reg::r29), "ld2 {v26.h, v27.h}[0], [x30], x29");
   TEST_SINGLE(ld2<SubRegSize::i32Bit>(VReg::v26, VReg::v27, 0, Reg::r30, Reg::r29), "ld2 {v26.s, v27.s}[0], [x30], x29");
   TEST_SINGLE(ld2<SubRegSize::i64Bit>(VReg::v26, VReg::v27, 0, Reg::r30, Reg::r29), "ld2 {v26.d, v27.d}[0], [x30], x29");
 
-  TEST_SINGLE(ld2<SubRegSize::i8Bit>(VReg::v26, VReg::v27, 15, Reg::r30, Reg::r29),  "ld2 {v26.b, v27.b}[15], [x30], x29");
-  TEST_SINGLE(ld2<SubRegSize::i16Bit>(VReg::v26, VReg::v27, 7, Reg::r30, Reg::r29), "ld2 {v26.h, v27.h}[7], [x30], x29");
-  TEST_SINGLE(ld2<SubRegSize::i32Bit>(VReg::v26, VReg::v27, 3, Reg::r30, Reg::r29), "ld2 {v26.s, v27.s}[3], [x30], x29");
-  TEST_SINGLE(ld2<SubRegSize::i64Bit>(VReg::v26, VReg::v27, 1, Reg::r30, Reg::r29), "ld2 {v26.d, v27.d}[1], [x30], x29");
+  TEST_SINGLE(ld2<SubRegSize::i8Bit>(VReg::v26,  VReg::v27, 15, Reg::r30, Reg::r29),  "ld2 {v26.b, v27.b}[15], [x30], x29");
+  TEST_SINGLE(ld2<SubRegSize::i16Bit>(VReg::v26, VReg::v27, 7,  Reg::r30, Reg::r29),  "ld2 {v26.h, v27.h}[7], [x30], x29");
+  TEST_SINGLE(ld2<SubRegSize::i32Bit>(VReg::v26, VReg::v27, 3,  Reg::r30, Reg::r29),  "ld2 {v26.s, v27.s}[3], [x30], x29");
+  TEST_SINGLE(ld2<SubRegSize::i64Bit>(VReg::v26, VReg::v27, 1,  Reg::r30, Reg::r29),  "ld2 {v26.d, v27.d}[1], [x30], x29");
 
-  TEST_SINGLE(ld2r<SubRegSize::i8Bit>(DReg::d26, DReg::d27, Reg::r30, Reg::r29),  "ld2r {v26.8b, v27.8b}, [x30], x29");
+  TEST_SINGLE(ld2r<SubRegSize::i8Bit>(DReg::d31,  DReg::d0,  Reg::r30, Reg::r29), "ld2r {v31.8b, v0.8b}, [x30], x29");
+  TEST_SINGLE(ld2r<SubRegSize::i8Bit>(DReg::d26,  DReg::d27, Reg::r30, Reg::r29), "ld2r {v26.8b, v27.8b}, [x30], x29");
   TEST_SINGLE(ld2r<SubRegSize::i16Bit>(DReg::d26, DReg::d27, Reg::r30, Reg::r29), "ld2r {v26.4h, v27.4h}, [x30], x29");
   TEST_SINGLE(ld2r<SubRegSize::i32Bit>(DReg::d26, DReg::d27, Reg::r30, Reg::r29), "ld2r {v26.2s, v27.2s}, [x30], x29");
   TEST_SINGLE(ld2r<SubRegSize::i64Bit>(DReg::d26, DReg::d27, Reg::r30, Reg::r29), "ld2r {v26.1d, v27.1d}, [x30], x29");
 
-  TEST_SINGLE(ld2r<SubRegSize::i8Bit>(QReg::q26, QReg::q27, Reg::r30, Reg::r29),  "ld2r {v26.16b, v27.16b}, [x30], x29");
+  TEST_SINGLE(ld2r<SubRegSize::i8Bit>(QReg::q31,  QReg::q0,  Reg::r30, Reg::r29), "ld2r {v31.16b, v0.16b}, [x30], x29");
+  TEST_SINGLE(ld2r<SubRegSize::i8Bit>(QReg::q26,  QReg::q27, Reg::r30, Reg::r29), "ld2r {v26.16b, v27.16b}, [x30], x29");
   TEST_SINGLE(ld2r<SubRegSize::i16Bit>(QReg::q26, QReg::q27, Reg::r30, Reg::r29), "ld2r {v26.8h, v27.8h}, [x30], x29");
   TEST_SINGLE(ld2r<SubRegSize::i32Bit>(QReg::q26, QReg::q27, Reg::r30, Reg::r29), "ld2r {v26.4s, v27.4s}, [x30], x29");
   TEST_SINGLE(ld2r<SubRegSize::i64Bit>(QReg::q26, QReg::q27, Reg::r30, Reg::r29), "ld2r {v26.2d, v27.2d}, [x30], x29");
 
-  TEST_SINGLE(st2<SubRegSize::i8Bit>(VReg::v26, VReg::v27, 0, Reg::r30, Reg::r29),  "st2 {v26.b, v27.b}[0], [x30], x29");
+  TEST_SINGLE(st2<SubRegSize::i8Bit>(VReg::v31,  VReg::v0,  0, Reg::r30, Reg::r29), "st2 {v31.b, v0.b}[0], [x30], x29");
+  TEST_SINGLE(st2<SubRegSize::i8Bit>(VReg::v26,  VReg::v27, 0, Reg::r30, Reg::r29), "st2 {v26.b, v27.b}[0], [x30], x29");
   TEST_SINGLE(st2<SubRegSize::i16Bit>(VReg::v26, VReg::v27, 0, Reg::r30, Reg::r29), "st2 {v26.h, v27.h}[0], [x30], x29");
   TEST_SINGLE(st2<SubRegSize::i32Bit>(VReg::v26, VReg::v27, 0, Reg::r30, Reg::r29), "st2 {v26.s, v27.s}[0], [x30], x29");
   TEST_SINGLE(st2<SubRegSize::i64Bit>(VReg::v26, VReg::v27, 0, Reg::r30, Reg::r29), "st2 {v26.d, v27.d}[0], [x30], x29");
 
-  TEST_SINGLE(st2<SubRegSize::i8Bit>(VReg::v26, VReg::v27, 15, Reg::r30, Reg::r29),  "st2 {v26.b, v27.b}[15], [x30], x29");
-  TEST_SINGLE(st2<SubRegSize::i16Bit>(VReg::v26, VReg::v27, 7, Reg::r30, Reg::r29), "st2 {v26.h, v27.h}[7], [x30], x29");
-  TEST_SINGLE(st2<SubRegSize::i32Bit>(VReg::v26, VReg::v27, 3, Reg::r30, Reg::r29), "st2 {v26.s, v27.s}[3], [x30], x29");
-  TEST_SINGLE(st2<SubRegSize::i64Bit>(VReg::v26, VReg::v27, 1, Reg::r30, Reg::r29), "st2 {v26.d, v27.d}[1], [x30], x29");
+  TEST_SINGLE(st2<SubRegSize::i8Bit>(VReg::v26,  VReg::v27, 15, Reg::r30, Reg::r29), "st2 {v26.b, v27.b}[15], [x30], x29");
+  TEST_SINGLE(st2<SubRegSize::i16Bit>(VReg::v26, VReg::v27, 7,  Reg::r30, Reg::r29), "st2 {v26.h, v27.h}[7], [x30], x29");
+  TEST_SINGLE(st2<SubRegSize::i32Bit>(VReg::v26, VReg::v27, 3,  Reg::r30, Reg::r29), "st2 {v26.s, v27.s}[3], [x30], x29");
+  TEST_SINGLE(st2<SubRegSize::i64Bit>(VReg::v26, VReg::v27, 1,  Reg::r30, Reg::r29), "st2 {v26.d, v27.d}[1], [x30], x29");
 
-  TEST_SINGLE(ld3<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30, Reg::r29),  "ld3 {v26.b, v27.b, v28.b}[0], [x30], x29");
+  TEST_SINGLE(ld3<SubRegSize::i8Bit>(VReg::v31,  VReg::v0,  VReg::v1,  0, Reg::r30, Reg::r29), "ld3 {v31.b, v0.b, v1.b}[0], [x30], x29");
+  TEST_SINGLE(ld3<SubRegSize::i8Bit>(VReg::v26,  VReg::v27, VReg::v28, 0, Reg::r30, Reg::r29), "ld3 {v26.b, v27.b, v28.b}[0], [x30], x29");
   TEST_SINGLE(ld3<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30, Reg::r29), "ld3 {v26.h, v27.h, v28.h}[0], [x30], x29");
   TEST_SINGLE(ld3<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30, Reg::r29), "ld3 {v26.s, v27.s, v28.s}[0], [x30], x29");
   TEST_SINGLE(ld3<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30, Reg::r29), "ld3 {v26.d, v27.d, v28.d}[0], [x30], x29");
 
-  TEST_SINGLE(ld3<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, 15, Reg::r30, Reg::r29),  "ld3 {v26.b, v27.b, v28.b}[15], [x30], x29");
-  TEST_SINGLE(ld3<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, 7, Reg::r30, Reg::r29), "ld3 {v26.h, v27.h, v28.h}[7], [x30], x29");
-  TEST_SINGLE(ld3<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, 3, Reg::r30, Reg::r29), "ld3 {v26.s, v27.s, v28.s}[3], [x30], x29");
-  TEST_SINGLE(ld3<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, 1, Reg::r30, Reg::r29), "ld3 {v26.d, v27.d, v28.d}[1], [x30], x29");
+  TEST_SINGLE(ld3<SubRegSize::i8Bit>(VReg::v26,  VReg::v27, VReg::v28, 15, Reg::r30, Reg::r29), "ld3 {v26.b, v27.b, v28.b}[15], [x30], x29");
+  TEST_SINGLE(ld3<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, 7,  Reg::r30, Reg::r29), "ld3 {v26.h, v27.h, v28.h}[7], [x30], x29");
+  TEST_SINGLE(ld3<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, 3,  Reg::r30, Reg::r29), "ld3 {v26.s, v27.s, v28.s}[3], [x30], x29");
+  TEST_SINGLE(ld3<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, 1,  Reg::r30, Reg::r29), "ld3 {v26.d, v27.d, v28.d}[1], [x30], x29");
 
-  TEST_SINGLE(ld3r<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, Reg::r29),  "ld3r {v26.8b, v27.8b, v28.8b}, [x30], x29");
+  TEST_SINGLE(ld3r<SubRegSize::i8Bit>(DReg::d31,  DReg::d0,  DReg::d1,  Reg::r30, Reg::r29), "ld3r {v31.8b, v0.8b, v1.8b}, [x30], x29");
+  TEST_SINGLE(ld3r<SubRegSize::i8Bit>(DReg::d26,  DReg::d27, DReg::d28, Reg::r30, Reg::r29), "ld3r {v26.8b, v27.8b, v28.8b}, [x30], x29");
   TEST_SINGLE(ld3r<SubRegSize::i16Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, Reg::r29), "ld3r {v26.4h, v27.4h, v28.4h}, [x30], x29");
   TEST_SINGLE(ld3r<SubRegSize::i32Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, Reg::r29), "ld3r {v26.2s, v27.2s, v28.2s}, [x30], x29");
   TEST_SINGLE(ld3r<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, Reg::r30, Reg::r29), "ld3r {v26.1d, v27.1d, v28.1d}, [x30], x29");
 
-  TEST_SINGLE(ld3r<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, Reg::r29),  "ld3r {v26.16b, v27.16b, v28.16b}, [x30], x29");
+  TEST_SINGLE(ld3r<SubRegSize::i8Bit>(QReg::q31,  QReg::q0,  QReg::q1,  Reg::r30, Reg::r29), "ld3r {v31.16b, v0.16b, v1.16b}, [x30], x29");
+  TEST_SINGLE(ld3r<SubRegSize::i8Bit>(QReg::q26,  QReg::q27, QReg::q28, Reg::r30, Reg::r29), "ld3r {v26.16b, v27.16b, v28.16b}, [x30], x29");
   TEST_SINGLE(ld3r<SubRegSize::i16Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, Reg::r29), "ld3r {v26.8h, v27.8h, v28.8h}, [x30], x29");
   TEST_SINGLE(ld3r<SubRegSize::i32Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, Reg::r29), "ld3r {v26.4s, v27.4s, v28.4s}, [x30], x29");
   TEST_SINGLE(ld3r<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, Reg::r30, Reg::r29), "ld3r {v26.2d, v27.2d, v28.2d}, [x30], x29");
 
-  TEST_SINGLE(st3<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30, Reg::r29),  "st3 {v26.b, v27.b, v28.b}[0], [x30], x29");
+  TEST_SINGLE(st3<SubRegSize::i8Bit>(VReg::v31,  VReg::v0,  VReg::v1,  0, Reg::r30, Reg::r29), "st3 {v31.b, v0.b, v1.b}[0], [x30], x29");
+  TEST_SINGLE(st3<SubRegSize::i8Bit>(VReg::v26,  VReg::v27, VReg::v28, 0, Reg::r30, Reg::r29), "st3 {v26.b, v27.b, v28.b}[0], [x30], x29");
   TEST_SINGLE(st3<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30, Reg::r29), "st3 {v26.h, v27.h, v28.h}[0], [x30], x29");
   TEST_SINGLE(st3<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30, Reg::r29), "st3 {v26.s, v27.s, v28.s}[0], [x30], x29");
   TEST_SINGLE(st3<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, 0, Reg::r30, Reg::r29), "st3 {v26.d, v27.d, v28.d}[0], [x30], x29");
 
-  TEST_SINGLE(st3<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, 15, Reg::r30, Reg::r29),  "st3 {v26.b, v27.b, v28.b}[15], [x30], x29");
-  TEST_SINGLE(st3<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, 7, Reg::r30, Reg::r29), "st3 {v26.h, v27.h, v28.h}[7], [x30], x29");
-  TEST_SINGLE(st3<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, 3, Reg::r30, Reg::r29), "st3 {v26.s, v27.s, v28.s}[3], [x30], x29");
-  TEST_SINGLE(st3<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, 1, Reg::r30, Reg::r29), "st3 {v26.d, v27.d, v28.d}[1], [x30], x29");
+  TEST_SINGLE(st3<SubRegSize::i8Bit>(VReg::v26,  VReg::v27, VReg::v28, 15, Reg::r30, Reg::r29), "st3 {v26.b, v27.b, v28.b}[15], [x30], x29");
+  TEST_SINGLE(st3<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, 7,  Reg::r30, Reg::r29), "st3 {v26.h, v27.h, v28.h}[7], [x30], x29");
+  TEST_SINGLE(st3<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, 3,  Reg::r30, Reg::r29), "st3 {v26.s, v27.s, v28.s}[3], [x30], x29");
+  TEST_SINGLE(st3<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, 1,  Reg::r30, Reg::r29), "st3 {v26.d, v27.d, v28.d}[1], [x30], x29");
 
-  TEST_SINGLE(ld4<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30, Reg::r29),  "ld4 {v26.b, v27.b, v28.b, v29.b}[0], [x30], x29");
+  TEST_SINGLE(ld4<SubRegSize::i8Bit>(VReg::v31,  VReg::v0,  VReg::v1,  VReg::v2,  0, Reg::r30, Reg::r29), "ld4 {v31.b, v0.b, v1.b, v2.b}[0], [x30], x29");
+  TEST_SINGLE(ld4<SubRegSize::i8Bit>(VReg::v26,  VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30, Reg::r29), "ld4 {v26.b, v27.b, v28.b, v29.b}[0], [x30], x29");
   TEST_SINGLE(ld4<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30, Reg::r29), "ld4 {v26.h, v27.h, v28.h, v29.h}[0], [x30], x29");
   TEST_SINGLE(ld4<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30, Reg::r29), "ld4 {v26.s, v27.s, v28.s, v29.s}[0], [x30], x29");
   TEST_SINGLE(ld4<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30, Reg::r29), "ld4 {v26.d, v27.d, v28.d, v29.d}[0], [x30], x29");
 
-  TEST_SINGLE(ld4<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 15, Reg::r30, Reg::r29),  "ld4 {v26.b, v27.b, v28.b, v29.b}[15], [x30], x29");
-  TEST_SINGLE(ld4<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 7, Reg::r30, Reg::r29), "ld4 {v26.h, v27.h, v28.h, v29.h}[7], [x30], x29");
-  TEST_SINGLE(ld4<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 3, Reg::r30, Reg::r29), "ld4 {v26.s, v27.s, v28.s, v29.s}[3], [x30], x29");
-  TEST_SINGLE(ld4<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 1, Reg::r30, Reg::r29), "ld4 {v26.d, v27.d, v28.d, v29.d}[1], [x30], x29");
+  TEST_SINGLE(ld4<SubRegSize::i8Bit>(VReg::v26,  VReg::v27, VReg::v28, VReg::v29, 15, Reg::r30, Reg::r29), "ld4 {v26.b, v27.b, v28.b, v29.b}[15], [x30], x29");
+  TEST_SINGLE(ld4<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 7,  Reg::r30, Reg::r29), "ld4 {v26.h, v27.h, v28.h, v29.h}[7], [x30], x29");
+  TEST_SINGLE(ld4<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 3,  Reg::r30, Reg::r29), "ld4 {v26.s, v27.s, v28.s, v29.s}[3], [x30], x29");
+  TEST_SINGLE(ld4<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 1,  Reg::r30, Reg::r29), "ld4 {v26.d, v27.d, v28.d, v29.d}[1], [x30], x29");
 
-  TEST_SINGLE(ld4r<SubRegSize::i8Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, Reg::r29),  "ld4r {v26.8b, v27.8b, v28.8b, v29.8b}, [x30], x29");
+  TEST_SINGLE(ld4r<SubRegSize::i8Bit>(DReg::d31,  DReg::d0,  DReg::d1,  DReg::d2,  Reg::r30, Reg::r29), "ld4r {v31.8b, v0.8b, v1.8b, v2.8b}, [x30], x29");
+  TEST_SINGLE(ld4r<SubRegSize::i8Bit>(DReg::d26,  DReg::d27, DReg::d28, DReg::d29, Reg::r30, Reg::r29), "ld4r {v26.8b, v27.8b, v28.8b, v29.8b}, [x30], x29");
   TEST_SINGLE(ld4r<SubRegSize::i16Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, Reg::r29), "ld4r {v26.4h, v27.4h, v28.4h, v29.4h}, [x30], x29");
   TEST_SINGLE(ld4r<SubRegSize::i32Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, Reg::r29), "ld4r {v26.2s, v27.2s, v28.2s, v29.2s}, [x30], x29");
   TEST_SINGLE(ld4r<SubRegSize::i64Bit>(DReg::d26, DReg::d27, DReg::d28, DReg::d29, Reg::r30, Reg::r29), "ld4r {v26.1d, v27.1d, v28.1d, v29.1d}, [x30], x29");
 
-  TEST_SINGLE(ld4r<SubRegSize::i8Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, Reg::r29),  "ld4r {v26.16b, v27.16b, v28.16b, v29.16b}, [x30], x29");
+  TEST_SINGLE(ld4r<SubRegSize::i8Bit>(QReg::q31,  QReg::q0,  QReg::q1,  QReg::q2,  Reg::r30, Reg::r29), "ld4r {v31.16b, v0.16b, v1.16b, v2.16b}, [x30], x29");
+  TEST_SINGLE(ld4r<SubRegSize::i8Bit>(QReg::q26,  QReg::q27, QReg::q28, QReg::q29, Reg::r30, Reg::r29), "ld4r {v26.16b, v27.16b, v28.16b, v29.16b}, [x30], x29");
   TEST_SINGLE(ld4r<SubRegSize::i16Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, Reg::r29), "ld4r {v26.8h, v27.8h, v28.8h, v29.8h}, [x30], x29");
   TEST_SINGLE(ld4r<SubRegSize::i32Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, Reg::r29), "ld4r {v26.4s, v27.4s, v28.4s, v29.4s}, [x30], x29");
   TEST_SINGLE(ld4r<SubRegSize::i64Bit>(QReg::q26, QReg::q27, QReg::q28, QReg::q29, Reg::r30, Reg::r29), "ld4r {v26.2d, v27.2d, v28.2d, v29.2d}, [x30], x29");
 
-  TEST_SINGLE(st4<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30, Reg::r29),  "st4 {v26.b, v27.b, v28.b, v29.b}[0], [x30], x29");
+  TEST_SINGLE(st4<SubRegSize::i8Bit>(VReg::v31,  VReg::v0,  VReg::v1,  VReg::v2,  0, Reg::r30, Reg::r29), "st4 {v31.b, v0.b, v1.b, v2.b}[0], [x30], x29");
+  TEST_SINGLE(st4<SubRegSize::i8Bit>(VReg::v26,  VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30, Reg::r29), "st4 {v26.b, v27.b, v28.b, v29.b}[0], [x30], x29");
   TEST_SINGLE(st4<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30, Reg::r29), "st4 {v26.h, v27.h, v28.h, v29.h}[0], [x30], x29");
   TEST_SINGLE(st4<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30, Reg::r29), "st4 {v26.s, v27.s, v28.s, v29.s}[0], [x30], x29");
   TEST_SINGLE(st4<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 0, Reg::r30, Reg::r29), "st4 {v26.d, v27.d, v28.d, v29.d}[0], [x30], x29");
 
-  TEST_SINGLE(st4<SubRegSize::i8Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 15, Reg::r30, Reg::r29),  "st4 {v26.b, v27.b, v28.b, v29.b}[15], [x30], x29");
-  TEST_SINGLE(st4<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 7, Reg::r30, Reg::r29), "st4 {v26.h, v27.h, v28.h, v29.h}[7], [x30], x29");
-  TEST_SINGLE(st4<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 3, Reg::r30, Reg::r29), "st4 {v26.s, v27.s, v28.s, v29.s}[3], [x30], x29");
-  TEST_SINGLE(st4<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 1, Reg::r30, Reg::r29), "st4 {v26.d, v27.d, v28.d, v29.d}[1], [x30], x29");
+  TEST_SINGLE(st4<SubRegSize::i8Bit>(VReg::v26,  VReg::v27, VReg::v28, VReg::v29, 15, Reg::r30, Reg::r29), "st4 {v26.b, v27.b, v28.b, v29.b}[15], [x30], x29");
+  TEST_SINGLE(st4<SubRegSize::i16Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 7,  Reg::r30, Reg::r29), "st4 {v26.h, v27.h, v28.h, v29.h}[7], [x30], x29");
+  TEST_SINGLE(st4<SubRegSize::i32Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 3,  Reg::r30, Reg::r29), "st4 {v26.s, v27.s, v28.s, v29.s}[3], [x30], x29");
+  TEST_SINGLE(st4<SubRegSize::i64Bit>(VReg::v26, VReg::v27, VReg::v28, VReg::v29, 1,  Reg::r30, Reg::r29), "st4 {v26.d, v27.d, v28.d, v29.d}[1], [x30], x29");
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Loadstore exclusive pair") {
   TEST_SINGLE(stxp(Size::i32Bit, Reg::r28, Reg::r29, Reg::r30, Reg::r28), "stxp w28, w29, w30, [x28]");

--- a/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
+++ b/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
@@ -2538,50 +2538,62 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE Memory - 32-bit Gather and
   // XXX: LDR (vector)
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE load multiple structures (scalar plus immediate)") {
+  TEST_SINGLE(ld2b(ZReg::z31, ZReg::z0,  PReg::p6.Zeroing(), Reg::r29, 0), "ld2b {z31.b, z0.b}, p6/z, [x29]");
   TEST_SINGLE(ld2b(ZReg::z26, ZReg::z27, PReg::p6.Zeroing(), Reg::r29, 0), "ld2b {z26.b, z27.b}, p6/z, [x29]");
   TEST_SINGLE(ld2b(ZReg::z26, ZReg::z27, PReg::p6.Zeroing(), Reg::r29, -16), "ld2b {z26.b, z27.b}, p6/z, [x29, #-16, mul vl]");
   TEST_SINGLE(ld2b(ZReg::z26, ZReg::z27, PReg::p6.Zeroing(), Reg::r29, 14), "ld2b {z26.b, z27.b}, p6/z, [x29, #14, mul vl]");
 
+  TEST_SINGLE(ld2h(ZReg::z31, ZReg::z0,  PReg::p6.Zeroing(), Reg::r29, 0), "ld2h {z31.h, z0.h}, p6/z, [x29]");
   TEST_SINGLE(ld2h(ZReg::z26, ZReg::z27, PReg::p6.Zeroing(), Reg::r29, 0), "ld2h {z26.h, z27.h}, p6/z, [x29]");
   TEST_SINGLE(ld2h(ZReg::z26, ZReg::z27, PReg::p6.Zeroing(), Reg::r29, -16), "ld2h {z26.h, z27.h}, p6/z, [x29, #-16, mul vl]");
   TEST_SINGLE(ld2h(ZReg::z26, ZReg::z27, PReg::p6.Zeroing(), Reg::r29, 14), "ld2h {z26.h, z27.h}, p6/z, [x29, #14, mul vl]");
 
+  TEST_SINGLE(ld2w(ZReg::z31, ZReg::z0,  PReg::p6.Zeroing(), Reg::r29, 0), "ld2w {z31.s, z0.s}, p6/z, [x29]");
   TEST_SINGLE(ld2w(ZReg::z26, ZReg::z27, PReg::p6.Zeroing(), Reg::r29, 0), "ld2w {z26.s, z27.s}, p6/z, [x29]");
   TEST_SINGLE(ld2w(ZReg::z26, ZReg::z27, PReg::p6.Zeroing(), Reg::r29, -16), "ld2w {z26.s, z27.s}, p6/z, [x29, #-16, mul vl]");
   TEST_SINGLE(ld2w(ZReg::z26, ZReg::z27, PReg::p6.Zeroing(), Reg::r29, 14), "ld2w {z26.s, z27.s}, p6/z, [x29, #14, mul vl]");
 
+  TEST_SINGLE(ld2d(ZReg::z31, ZReg::z0,  PReg::p6.Zeroing(), Reg::r29, 0), "ld2d {z31.d, z0.d}, p6/z, [x29]");
   TEST_SINGLE(ld2d(ZReg::z26, ZReg::z27, PReg::p6.Zeroing(), Reg::r29, 0), "ld2d {z26.d, z27.d}, p6/z, [x29]");
   TEST_SINGLE(ld2d(ZReg::z26, ZReg::z27, PReg::p6.Zeroing(), Reg::r29, -16), "ld2d {z26.d, z27.d}, p6/z, [x29, #-16, mul vl]");
   TEST_SINGLE(ld2d(ZReg::z26, ZReg::z27, PReg::p6.Zeroing(), Reg::r29, 14), "ld2d {z26.d, z27.d}, p6/z, [x29, #14, mul vl]");
 
+  TEST_SINGLE(ld3b(ZReg::z31, ZReg::z0,  ZReg::z1,  PReg::p6.Zeroing(), Reg::r29, 0), "ld3b {z31.b, z0.b, z1.b}, p6/z, [x29]");
   TEST_SINGLE(ld3b(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6.Zeroing(), Reg::r29, 0), "ld3b {z26.b, z27.b, z28.b}, p6/z, [x29]");
   TEST_SINGLE(ld3b(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6.Zeroing(), Reg::r29, -24), "ld3b {z26.b, z27.b, z28.b}, p6/z, [x29, #-24, mul vl]");
   TEST_SINGLE(ld3b(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6.Zeroing(), Reg::r29, 21), "ld3b {z26.b, z27.b, z28.b}, p6/z, [x29, #21, mul vl]");
 
+  TEST_SINGLE(ld3h(ZReg::z31, ZReg::z0,  ZReg::z1,  PReg::p6.Zeroing(), Reg::r29, 0), "ld3h {z31.h, z0.h, z1.h}, p6/z, [x29]");
   TEST_SINGLE(ld3h(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6.Zeroing(), Reg::r29, 0), "ld3h {z26.h, z27.h, z28.h}, p6/z, [x29]");
   TEST_SINGLE(ld3h(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6.Zeroing(), Reg::r29, -24), "ld3h {z26.h, z27.h, z28.h}, p6/z, [x29, #-24, mul vl]");
   TEST_SINGLE(ld3h(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6.Zeroing(), Reg::r29, 21), "ld3h {z26.h, z27.h, z28.h}, p6/z, [x29, #21, mul vl]");
 
+  TEST_SINGLE(ld3w(ZReg::z31, ZReg::z0,  ZReg::z1,  PReg::p6.Zeroing(), Reg::r29, 0), "ld3w {z31.s, z0.s, z1.s}, p6/z, [x29]");
   TEST_SINGLE(ld3w(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6.Zeroing(), Reg::r29, 0), "ld3w {z26.s, z27.s, z28.s}, p6/z, [x29]");
   TEST_SINGLE(ld3w(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6.Zeroing(), Reg::r29, -24), "ld3w {z26.s, z27.s, z28.s}, p6/z, [x29, #-24, mul vl]");
   TEST_SINGLE(ld3w(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6.Zeroing(), Reg::r29, 21), "ld3w {z26.s, z27.s, z28.s}, p6/z, [x29, #21, mul vl]");
 
+  TEST_SINGLE(ld3d(ZReg::z31, ZReg::z0,  ZReg::z1,  PReg::p6.Zeroing(), Reg::r29, 0), "ld3d {z31.d, z0.d, z1.d}, p6/z, [x29]");
   TEST_SINGLE(ld3d(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6.Zeroing(), Reg::r29, 0), "ld3d {z26.d, z27.d, z28.d}, p6/z, [x29]");
   TEST_SINGLE(ld3d(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6.Zeroing(), Reg::r29, -24), "ld3d {z26.d, z27.d, z28.d}, p6/z, [x29, #-24, mul vl]");
   TEST_SINGLE(ld3d(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6.Zeroing(), Reg::r29, 21), "ld3d {z26.d, z27.d, z28.d}, p6/z, [x29, #21, mul vl]");
 
+  TEST_SINGLE(ld4b(ZReg::z31, ZReg::z0,  ZReg::z1,  ZReg::z2,  PReg::p6.Zeroing(), Reg::r29, 0), "ld4b {z31.b, z0.b, z1.b, z2.b}, p6/z, [x29]");
   TEST_SINGLE(ld4b(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6.Zeroing(), Reg::r29, 0), "ld4b {z26.b, z27.b, z28.b, z29.b}, p6/z, [x29]");
   TEST_SINGLE(ld4b(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6.Zeroing(), Reg::r29, -32), "ld4b {z26.b, z27.b, z28.b, z29.b}, p6/z, [x29, #-32, mul vl]");
   TEST_SINGLE(ld4b(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6.Zeroing(), Reg::r29, 28), "ld4b {z26.b, z27.b, z28.b, z29.b}, p6/z, [x29, #28, mul vl]");
 
+  TEST_SINGLE(ld4h(ZReg::z31, ZReg::z0,  ZReg::z1,  ZReg::z2,  PReg::p6.Zeroing(), Reg::r29, 0), "ld4h {z31.h, z0.h, z1.h, z2.h}, p6/z, [x29]");
   TEST_SINGLE(ld4h(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6.Zeroing(), Reg::r29, 0), "ld4h {z26.h, z27.h, z28.h, z29.h}, p6/z, [x29]");
   TEST_SINGLE(ld4h(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6.Zeroing(), Reg::r29, -32), "ld4h {z26.h, z27.h, z28.h, z29.h}, p6/z, [x29, #-32, mul vl]");
   TEST_SINGLE(ld4h(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6.Zeroing(), Reg::r29, 28), "ld4h {z26.h, z27.h, z28.h, z29.h}, p6/z, [x29, #28, mul vl]");
 
+  TEST_SINGLE(ld4w(ZReg::z31, ZReg::z0,  ZReg::z1,  ZReg::z2,  PReg::p6.Zeroing(), Reg::r29, 0), "ld4w {z31.s, z0.s, z1.s, z2.s}, p6/z, [x29]");
   TEST_SINGLE(ld4w(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6.Zeroing(), Reg::r29, 0), "ld4w {z26.s, z27.s, z28.s, z29.s}, p6/z, [x29]");
   TEST_SINGLE(ld4w(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6.Zeroing(), Reg::r29, -32), "ld4w {z26.s, z27.s, z28.s, z29.s}, p6/z, [x29, #-32, mul vl]");
   TEST_SINGLE(ld4w(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6.Zeroing(), Reg::r29, 28), "ld4w {z26.s, z27.s, z28.s, z29.s}, p6/z, [x29, #28, mul vl]");
 
+  TEST_SINGLE(ld4d(ZReg::z31, ZReg::z0,  ZReg::z1,  ZReg::z2,  PReg::p6.Zeroing(), Reg::r29, 0), "ld4d {z31.d, z0.d, z1.d, z2.d}, p6/z, [x29]");
   TEST_SINGLE(ld4d(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6.Zeroing(), Reg::r29, 0), "ld4d {z26.d, z27.d, z28.d, z29.d}, p6/z, [x29]");
   TEST_SINGLE(ld4d(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6.Zeroing(), Reg::r29, -32), "ld4d {z26.d, z27.d, z28.d, z29.d}, p6/z, [x29, #-32, mul vl]");
   TEST_SINGLE(ld4d(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6.Zeroing(), Reg::r29, 28), "ld4d {z26.d, z27.d, z28.d, z29.d}, p6/z, [x29, #28, mul vl]");
@@ -2801,50 +2813,62 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE floating-point convert to 
 }
 
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE store multiple structures (scalar plus immediate)") {
+  TEST_SINGLE(st2b(ZReg::z31, ZReg::z0,  PReg::p6, Reg::r29, 0), "st2b {z31.b, z0.b}, p6, [x29]");
   TEST_SINGLE(st2b(ZReg::z26, ZReg::z27, PReg::p6, Reg::r29, 0), "st2b {z26.b, z27.b}, p6, [x29]");
   TEST_SINGLE(st2b(ZReg::z26, ZReg::z27, PReg::p6, Reg::r29, -16), "st2b {z26.b, z27.b}, p6, [x29, #-16, mul vl]");
   TEST_SINGLE(st2b(ZReg::z26, ZReg::z27, PReg::p6, Reg::r29, 14), "st2b {z26.b, z27.b}, p6, [x29, #14, mul vl]");
 
+  TEST_SINGLE(st2h(ZReg::z31, ZReg::z0,  PReg::p6, Reg::r29, 0), "st2h {z31.h, z0.h}, p6, [x29]");
   TEST_SINGLE(st2h(ZReg::z26, ZReg::z27, PReg::p6, Reg::r29, 0), "st2h {z26.h, z27.h}, p6, [x29]");
   TEST_SINGLE(st2h(ZReg::z26, ZReg::z27, PReg::p6, Reg::r29, -16), "st2h {z26.h, z27.h}, p6, [x29, #-16, mul vl]");
   TEST_SINGLE(st2h(ZReg::z26, ZReg::z27, PReg::p6, Reg::r29, 14), "st2h {z26.h, z27.h}, p6, [x29, #14, mul vl]");
 
+  TEST_SINGLE(st2w(ZReg::z31, ZReg::z0,  PReg::p6, Reg::r29, 0), "st2w {z31.s, z0.s}, p6, [x29]");
   TEST_SINGLE(st2w(ZReg::z26, ZReg::z27, PReg::p6, Reg::r29, 0), "st2w {z26.s, z27.s}, p6, [x29]");
   TEST_SINGLE(st2w(ZReg::z26, ZReg::z27, PReg::p6, Reg::r29, -16), "st2w {z26.s, z27.s}, p6, [x29, #-16, mul vl]");
   TEST_SINGLE(st2w(ZReg::z26, ZReg::z27, PReg::p6, Reg::r29, 14), "st2w {z26.s, z27.s}, p6, [x29, #14, mul vl]");
 
+  TEST_SINGLE(st2d(ZReg::z31, ZReg::z0,  PReg::p6, Reg::r29, 0), "st2d {z31.d, z0.d}, p6, [x29]");
   TEST_SINGLE(st2d(ZReg::z26, ZReg::z27, PReg::p6, Reg::r29, 0), "st2d {z26.d, z27.d}, p6, [x29]");
   TEST_SINGLE(st2d(ZReg::z26, ZReg::z27, PReg::p6, Reg::r29, -16), "st2d {z26.d, z27.d}, p6, [x29, #-16, mul vl]");
   TEST_SINGLE(st2d(ZReg::z26, ZReg::z27, PReg::p6, Reg::r29, 14), "st2d {z26.d, z27.d}, p6, [x29, #14, mul vl]");
 
+  TEST_SINGLE(st3b(ZReg::z31, ZReg::z0,  ZReg::z1,  PReg::p6, Reg::r29, 0), "st3b {z31.b, z0.b, z1.b}, p6, [x29]");
   TEST_SINGLE(st3b(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6, Reg::r29, 0), "st3b {z26.b, z27.b, z28.b}, p6, [x29]");
   TEST_SINGLE(st3b(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6, Reg::r29, -24), "st3b {z26.b, z27.b, z28.b}, p6, [x29, #-24, mul vl]");
   TEST_SINGLE(st3b(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6, Reg::r29, 21), "st3b {z26.b, z27.b, z28.b}, p6, [x29, #21, mul vl]");
 
+  TEST_SINGLE(st3h(ZReg::z31, ZReg::z0,  ZReg::z1,  PReg::p6, Reg::r29, 0), "st3h {z31.h, z0.h, z1.h}, p6, [x29]");
   TEST_SINGLE(st3h(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6, Reg::r29, 0), "st3h {z26.h, z27.h, z28.h}, p6, [x29]");
   TEST_SINGLE(st3h(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6, Reg::r29, -24), "st3h {z26.h, z27.h, z28.h}, p6, [x29, #-24, mul vl]");
   TEST_SINGLE(st3h(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6, Reg::r29, 21), "st3h {z26.h, z27.h, z28.h}, p6, [x29, #21, mul vl]");
 
+  TEST_SINGLE(st3w(ZReg::z31, ZReg::z0,  ZReg::z1,  PReg::p6, Reg::r29, 0), "st3w {z31.s, z0.s, z1.s}, p6, [x29]");
   TEST_SINGLE(st3w(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6, Reg::r29, 0), "st3w {z26.s, z27.s, z28.s}, p6, [x29]");
   TEST_SINGLE(st3w(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6, Reg::r29, -24), "st3w {z26.s, z27.s, z28.s}, p6, [x29, #-24, mul vl]");
   TEST_SINGLE(st3w(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6, Reg::r29, 21), "st3w {z26.s, z27.s, z28.s}, p6, [x29, #21, mul vl]");
 
+  TEST_SINGLE(st3d(ZReg::z31, ZReg::z0,  ZReg::z1,  PReg::p6, Reg::r29, 0), "st3d {z31.d, z0.d, z1.d}, p6, [x29]");
   TEST_SINGLE(st3d(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6, Reg::r29, 0), "st3d {z26.d, z27.d, z28.d}, p6, [x29]");
   TEST_SINGLE(st3d(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6, Reg::r29, -24), "st3d {z26.d, z27.d, z28.d}, p6, [x29, #-24, mul vl]");
   TEST_SINGLE(st3d(ZReg::z26, ZReg::z27, ZReg::z28, PReg::p6, Reg::r29, 21), "st3d {z26.d, z27.d, z28.d}, p6, [x29, #21, mul vl]");
 
+  TEST_SINGLE(st4b(ZReg::z31, ZReg::z0,  ZReg::z1,  ZReg::z2,  PReg::p6, Reg::r29, 0), "st4b {z31.b, z0.b, z1.b, z2.b}, p6, [x29]");
   TEST_SINGLE(st4b(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6, Reg::r29, 0), "st4b {z26.b, z27.b, z28.b, z29.b}, p6, [x29]");
   TEST_SINGLE(st4b(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6, Reg::r29, -32), "st4b {z26.b, z27.b, z28.b, z29.b}, p6, [x29, #-32, mul vl]");
   TEST_SINGLE(st4b(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6, Reg::r29, 28), "st4b {z26.b, z27.b, z28.b, z29.b}, p6, [x29, #28, mul vl]");
 
+  TEST_SINGLE(st4h(ZReg::z31, ZReg::z0,  ZReg::z1,  ZReg::z2,  PReg::p6, Reg::r29, 0), "st4h {z31.h, z0.h, z1.h, z2.h}, p6, [x29]");
   TEST_SINGLE(st4h(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6, Reg::r29, 0), "st4h {z26.h, z27.h, z28.h, z29.h}, p6, [x29]");
   TEST_SINGLE(st4h(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6, Reg::r29, -32), "st4h {z26.h, z27.h, z28.h, z29.h}, p6, [x29, #-32, mul vl]");
   TEST_SINGLE(st4h(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6, Reg::r29, 28), "st4h {z26.h, z27.h, z28.h, z29.h}, p6, [x29, #28, mul vl]");
 
+  TEST_SINGLE(st4w(ZReg::z31, ZReg::z0,  ZReg::z1,  ZReg::z2,  PReg::p6, Reg::r29, 0), "st4w {z31.s, z0.s, z1.s, z2.s}, p6, [x29]");
   TEST_SINGLE(st4w(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6, Reg::r29, 0), "st4w {z26.s, z27.s, z28.s, z29.s}, p6, [x29]");
   TEST_SINGLE(st4w(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6, Reg::r29, -32), "st4w {z26.s, z27.s, z28.s, z29.s}, p6, [x29, #-32, mul vl]");
   TEST_SINGLE(st4w(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6, Reg::r29, 28), "st4w {z26.s, z27.s, z28.s, z29.s}, p6, [x29, #28, mul vl]");
 
+  TEST_SINGLE(st4d(ZReg::z31, ZReg::z0,  ZReg::z1,  ZReg::z2,  PReg::p6, Reg::r29, 0), "st4d {z31.d, z0.d, z1.d, z2.d}, p6, [x29]");
   TEST_SINGLE(st4d(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6, Reg::r29, 0), "st4d {z26.d, z27.d, z28.d, z29.d}, p6, [x29]");
   TEST_SINGLE(st4d(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6, Reg::r29, -32), "st4d {z26.d, z27.d, z28.d, z29.d}, p6, [x29, #-32, mul vl]");
   TEST_SINGLE(st4d(ZReg::z26, ZReg::z27, ZReg::z28, ZReg::z29, PReg::p6, Reg::r29, 28), "st4d {z26.d, z27.d, z28.d, z29.d}, p6, [x29, #28, mul vl]");


### PR DESCRIPTION
A few vector instructions that take register lists often require vector registers within the list to be sequential in the form of an increasing list (modulo the register file size).

For example:

```
v1, v2, v3, v4
```
and
```
v31, v0, v1, v2
```

both fit these requirements.

However, in quite a few instructions that permit it, we don't handle the latter one that wraps around at all. This fixes this by introducing a helper to do all the work for us when it comes to these cases.

Also expands the tests to ensure these cases are handled.