### PR TITLE
ARMEmitter: Make VRegister constructor explicit

### DIFF
--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/Registers.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/Registers.h
@@ -291,7 +291,7 @@ namespace FEXCore::ARMEmitter {
   class VRegister {
     public:
       VRegister() = delete;
-      constexpr VRegister(uint32_t Idx)
+      constexpr explicit VRegister(uint32_t Idx)
         : Index {Idx} {}
 
       uint32_t Idx() const {


### PR DESCRIPTION
All other parameter taking constructors for the other register types are explicit, so this just makes behavior more consistent.