### PR TITLE
ARMEmitter: Remove most implicit conversion operators for vector register types

### DIFF
--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
@@ -217,7 +217,7 @@ void Arm64Emitter::SpillStaticRegs(bool FPRs, uint32_t GPRSpillMask, uint32_t FP
 
         if (((1U << Reg.Idx()) & FPRSpillMask) != 0) {
           mov(ARMEmitter::Size::i64Bit, TMP4.R(), offsetof(Core::CpuStateFrame, State.xmm.avx.data[i][0]));
-          st1b<ARMEmitter::SubRegSize::i8Bit>(Reg, PRED_TMP_32B, STATE.R(), TMP4.R());
+          st1b<ARMEmitter::SubRegSize::i8Bit>(Reg.Z(), PRED_TMP_32B, STATE.R(), TMP4.R());
         }
       }
     } else {
@@ -274,7 +274,7 @@ void Arm64Emitter::FillStaticRegs(bool FPRs, uint32_t GPRFillMask, uint32_t FPRF
         const auto Reg = SRAFPR[i];
         if (((1U << Reg.Idx()) & FPRFillMask) != 0) {
           mov(ARMEmitter::Size::i64Bit, TMP4.R(), offsetof(Core::CpuStateFrame, State.xmm.avx.data[i][0]));
-          ld1b<ARMEmitter::SubRegSize::i8Bit>(Reg, PRED_TMP_32B, STATE.R(), TMP4.R());
+          ld1b<ARMEmitter::SubRegSize::i8Bit>(Reg.Z(), PRED_TMP_32B, STATE.R(), TMP4.R());
         }
       }
     } else {
@@ -348,7 +348,7 @@ void Arm64Emitter::PushDynamicRegsAndLR(FEXCore::ARMEmitter::Register TmpReg) {
       const auto Reg2 = RAFPR[i + 1];
       const auto Reg3 = RAFPR[i + 2];
       const auto Reg4 = RAFPR[i + 3];
-      st4b(Reg1, Reg2, Reg3, Reg4, PRED_TMP_32B, TmpReg, 0);
+      st4b(Reg1.Z(), Reg2.Z(), Reg3.Z(), Reg4.Z(), PRED_TMP_32B, TmpReg, 0);
       add(ARMEmitter::Size::i64Bit, TmpReg, TmpReg, 32 * 4);
     }
   } else {
@@ -374,7 +374,7 @@ void Arm64Emitter::PopDynamicRegsAndLR() {
       const auto Reg2 = RAFPR[i + 1];
       const auto Reg3 = RAFPR[i + 2];
       const auto Reg4 = RAFPR[i + 3];
-      ld4b(Reg1, Reg2, Reg3, Reg4, PRED_TMP_32B, ARMEmitter::Reg::rsp);
+      ld4b(Reg1.Z(), Reg2.Z(), Reg3.Z(), Reg4.Z(), PRED_TMP_32B, ARMEmitter::Reg::rsp);
       add(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::rsp, ARMEmitter::Reg::rsp, 32 * 4);
     }
   } else {

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ASIMDOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ASIMDOps.inl
@@ -3598,11 +3598,11 @@ public:
   }
   ///< size is destination size
   void sxtl(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    sshll(size, rd, rn, 0);
+    sshll(size, rd.D(), rn.D(), 0);
   }
   ///< size is destination size
   void sxtl2(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    sshll2(size, rd, rn, 0);
+    sshll2(size, rd.Q(), rn.Q(), 0);
   }
 
   template<typename T>

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/Registers.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/Registers.h
@@ -426,12 +426,9 @@ namespace FEXCore::ARMEmitter {
         return Index;
       }
 
-      operator VRegister() const;
-      operator BRegister() const;
-      operator HRegister() const;
-      operator SRegister() const;
-      operator QRegister() const;
-      operator ZRegister() const;
+      operator VRegister() const {
+        return VRegister(Index);
+      }
 
       DRegister V() const;
       BRegister B() const;
@@ -610,41 +607,22 @@ namespace FEXCore::ARMEmitter {
 
   // DRegister
   inline DRegister DRegister::V() const {
-    return *this;
+    return DRegister{Index};
   }
   inline BRegister DRegister::B() const {
-    return *this;
+    return BRegister{Index};
   }
   inline HRegister DRegister::H() const {
-    return *this;
+    return HRegister{Index};
   }
   inline SRegister DRegister::S() const {
-    return *this;
+    return SRegister{Index};
   }
   inline QRegister DRegister::Q() const {
-    return *this;
+    return QRegister{Index};
   }
   inline ZRegister DRegister::Z() const {
-    return *this;
-  }
-
-  inline DRegister::operator VRegister () const {
-    return VRegister(Index);
-  }
-  inline DRegister::operator BRegister () const {
-    return BRegister(Index);
-  }
-  inline DRegister::operator HRegister () const {
-    return HRegister(Index);
-  }
-  inline DRegister::operator SRegister () const {
-    return SRegister(Index);
-  }
-  inline DRegister::operator QRegister () const {
-    return QRegister(Index);
-  }
-  inline DRegister::operator ZRegister () const {
-    return ZRegister(Index);
+    return ZRegister{Index};
   }
 
   // QRegister

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/Registers.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/Registers.h
@@ -458,12 +458,9 @@ namespace FEXCore::ARMEmitter {
         return Index;
       }
 
-      operator VRegister() const;
-      operator BRegister() const;
-      operator HRegister() const;
-      operator SRegister() const;
-      operator DRegister() const;
-      operator ZRegister() const;
+      operator VRegister () const {
+        return VRegister(Index);
+      }
 
       QRegister V() const;
       BRegister B() const;
@@ -630,38 +627,19 @@ namespace FEXCore::ARMEmitter {
     return *this;
   }
   inline BRegister QRegister::B() const {
-    return *this;
+    return BRegister{Index};
   }
   inline HRegister QRegister::H() const {
-    return *this;
+    return HRegister{Index};
   }
   inline SRegister QRegister::S() const {
-    return *this;
+    return SRegister{Index};
   }
   inline DRegister QRegister::D() const {
-    return *this;
+    return DRegister{Index};
   }
   inline ZRegister QRegister::Z() const {
-    return *this;
-  }
-
-  inline QRegister::operator VRegister () const {
-    return VRegister(Index);
-  }
-  inline QRegister::operator BRegister () const {
-    return BRegister(Index);
-  }
-  inline QRegister::operator HRegister () const {
-    return HRegister(Index);
-  }
-  inline QRegister::operator SRegister () const {
-    return SRegister(Index);
-  }
-  inline QRegister::operator DRegister () const {
-    return DRegister(Index);
-  }
-  inline QRegister::operator ZRegister () const {
-    return ZRegister(Index);
+    return ZRegister{Index};
   }
 
   // ZRegister

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/Registers.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/Registers.h
@@ -366,12 +366,9 @@ namespace FEXCore::ARMEmitter {
         return Index;
       }
 
-      operator VRegister() const;
-      operator BRegister() const;
-      operator SRegister() const;
-      operator DRegister() const;
-      operator QRegister() const;
-      operator ZRegister() const;
+      operator VRegister() const {
+        return VRegister(Index);
+      }
 
       HRegister V() const;
       BRegister B() const;
@@ -601,38 +598,19 @@ namespace FEXCore::ARMEmitter {
     return *this;
   }
   inline BRegister HRegister::B() const {
-    return *this;
+    return BRegister{Index};
   }
   inline SRegister HRegister::S() const {
-    return *this;
+    return SRegister{Index};
   }
   inline DRegister HRegister::D() const {
-    return *this;
+    return DRegister{Index};
   }
   inline QRegister HRegister::Q() const {
-    return *this;
+    return QRegister{Index};
   }
   inline ZRegister HRegister::Z() const {
-    return *this;
-  }
-
-  inline HRegister::operator VRegister () const {
-    return VRegister(Index);
-  }
-  inline HRegister::operator BRegister () const {
-    return BRegister(Index);
-  }
-  inline HRegister::operator SRegister () const {
-    return SRegister(Index);
-  }
-  inline HRegister::operator DRegister () const {
-    return DRegister(Index);
-  }
-  inline HRegister::operator QRegister () const {
-    return QRegister(Index);
-  }
-  inline HRegister::operator ZRegister () const {
-    return ZRegister(Index);
+    return ZRegister{Index};
   }
 
   // SRegister

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/Registers.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/Registers.h
@@ -298,13 +298,6 @@ namespace FEXCore::ARMEmitter {
         return Index;
       }
 
-      operator BRegister() const;
-      operator HRegister() const;
-      operator SRegister() const;
-      operator DRegister() const;
-      operator QRegister() const;
-      operator ZRegister() const;
-
       BRegister B() const;
       HRegister H() const;
       SRegister S() const;
@@ -505,41 +498,22 @@ namespace FEXCore::ARMEmitter {
 
   // VRegister
   inline BRegister VRegister::B() const {
-    return *this;
+    return BRegister{Index};
   }
   inline HRegister VRegister::H() const {
-    return *this;
+    return HRegister{Index};
   }
   inline SRegister VRegister::S() const {
-    return *this;
+    return SRegister{Index};
   }
   inline DRegister VRegister::D() const {
-    return *this;
+    return DRegister{Index};
   }
   inline QRegister VRegister::Q() const {
-    return *this;
+    return QRegister{Index};
   }
   inline ZRegister VRegister::Z() const {
-    return *this;
-  }
-
-  inline VRegister::operator BRegister () const {
-    return BRegister(Index);
-  }
-  inline VRegister::operator HRegister () const {
-    return HRegister(Index);
-  }
-  inline VRegister::operator SRegister () const {
-    return SRegister(Index);
-  }
-  inline VRegister::operator DRegister () const {
-    return DRegister(Index);
-  }
-  inline VRegister::operator QRegister () const {
-    return QRegister(Index);
-  }
-  inline VRegister::operator ZRegister () const {
-    return ZRegister(Index);
+    return ZRegister{Index};
   }
 
   // BRegister

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/Registers.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/Registers.h
@@ -394,12 +394,9 @@ namespace FEXCore::ARMEmitter {
         return Index;
       }
 
-      operator VRegister() const;
-      operator BRegister() const;
-      operator HRegister() const;
-      operator DRegister() const;
-      operator QRegister() const;
-      operator ZRegister() const;
+      operator VRegister() const {
+        return VRegister(Index);
+      }
 
       SRegister V() const;
       BRegister B() const;
@@ -596,38 +593,19 @@ namespace FEXCore::ARMEmitter {
     return *this;
   }
   inline BRegister SRegister::B() const {
-    return *this;
+    return BRegister{Index};
   }
   inline HRegister SRegister::H() const {
-    return *this;
+    return HRegister{Index};
   }
   inline DRegister SRegister::D() const {
-    return *this;
+    return DRegister{Index};
   }
   inline QRegister SRegister::Q() const {
-    return *this;
+    return QRegister{Index};
   }
   inline ZRegister SRegister::Z() const {
-    return *this;
-  }
-
-  inline SRegister::operator VRegister () const {
-    return VRegister(Index);
-  }
-  inline SRegister::operator BRegister () const {
-    return BRegister(Index);
-  }
-  inline SRegister::operator HRegister () const {
-    return HRegister(Index);
-  }
-  inline SRegister::operator DRegister () const {
-    return DRegister(Index);
-  }
-  inline SRegister::operator QRegister () const {
-    return QRegister(Index);
-  }
-  inline SRegister::operator ZRegister () const {
-    return ZRegister(Index);
+    return ZRegister{Index};
   }
 
   // DRegister

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/Registers.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/Registers.h
@@ -332,12 +332,9 @@ namespace FEXCore::ARMEmitter {
         return Index;
       }
 
-      operator VRegister() const;
-      operator HRegister() const;
-      operator SRegister() const;
-      operator DRegister() const;
-      operator QRegister() const;
-      operator ZRegister() const;
+      operator VRegister () const {
+        return VRegister(Index);
+      }
 
       BRegister V() const;
       HRegister H() const;
@@ -559,38 +556,19 @@ namespace FEXCore::ARMEmitter {
     return *this;
   }
   inline HRegister BRegister::H() const {
-    return *this;
+    return HRegister{Index};
   }
   inline SRegister BRegister::S() const {
-    return *this;
+    return SRegister{Index};
   }
   inline DRegister BRegister::D() const {
-    return *this;
+    return DRegister{Index};
   }
   inline QRegister BRegister::Q() const {
-    return *this;
+    return QRegister{Index};
   }
   inline ZRegister BRegister::Z() const {
-    return *this;
-  }
-
-  inline BRegister::operator VRegister () const {
-    return VRegister(Index);
-  }
-  inline BRegister::operator HRegister () const {
-    return HRegister(Index);
-  }
-  inline BRegister::operator SRegister () const {
-    return SRegister(Index);
-  }
-  inline BRegister::operator DRegister () const {
-    return DRegister(Index);
-  }
-  inline BRegister::operator QRegister () const {
-    return QRegister(Index);
-  }
-  inline BRegister::operator ZRegister () const {
-    return ZRegister(Index);
+    return ZRegister{Index};
   }
 
   // HRegister

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -1174,7 +1174,7 @@ DEF_OP(VExtractToGPR) {
     // all of the top lanes. We can then compact those into a temporary.
     const auto CompactPred = ARMEmitter::PReg::p0;
     not_(CompactPred, PRED_TMP_32B, PRED_TMP_16B);
-    compact(ARMEmitter::SubRegSize::i64Bit, VTMP1, CompactPred, Vector);
+    compact(ARMEmitter::SubRegSize::i64Bit, VTMP1.Z(), CompactPred, Vector.Z());
 
     // Sanitize the zero-based index to work on the now-moved
     // upper half of the vector.

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ConversionOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ConversionOps.cpp
@@ -55,7 +55,7 @@ DEF_OP(VInsGPR) {
       // Move the upper lane down for the insertion.
       const auto CompactPred = ARMEmitter::PReg::p0;
       not_(CompactPred, PRED_TMP_32B.Zeroing(), PRED_TMP_16B);
-      compact(ARMEmitter::SubRegSize::i64Bit, VTMP1.Z(), CompactPred, DestVector);
+      compact(ARMEmitter::SubRegSize::i64Bit, VTMP1.Z(), CompactPred, DestVector.Z());
     }
 
     // Put data in place for destructive SPLICE below.
@@ -225,7 +225,7 @@ DEF_OP(Vector_FToZS) {
   const auto Vector = GetVReg(Op->Vector.ID());
   if (HostSupportsSVE && Is256Bit) {
     const auto Mask = PRED_TMP_32B;
-    fcvtzs(Dst, SubEmitSize, Mask.Merging(), Vector, SubEmitSize);
+    fcvtzs(Dst.Z(), SubEmitSize, Mask.Merging(), Vector.Z(), SubEmitSize);
   } else {
     fcvtzs(SubEmitSize, Dst.Q(), Vector.Q());
   }
@@ -248,8 +248,8 @@ DEF_OP(Vector_FToS) {
 
   if (HostSupportsSVE && Is256Bit) {
     const auto Mask = PRED_TMP_32B;
-    frinti(SubEmitSize, Dst, Mask.Merging(), Vector);
-    fcvtzs(Dst, SubEmitSize, Mask.Merging(), Dst, SubEmitSize);
+    frinti(SubEmitSize, Dst.Z(), Mask.Merging(), Vector.Z());
+    fcvtzs(Dst.Z(), SubEmitSize, Mask.Merging(), Dst.Z(), SubEmitSize);
   } else {
     const auto Dst = GetVReg(Node);
     const auto Vector = GetVReg(Op->Vector.ID());
@@ -302,12 +302,12 @@ DEF_OP(Vector_FToF) {
         break;
       }
       case 0x0204: { // Half <- Float
-        fcvtnt(FEXCore::ARMEmitter::SubRegSize::i16Bit, Dst, Mask, Vector);
+        fcvtnt(FEXCore::ARMEmitter::SubRegSize::i16Bit, Dst.Z(), Mask, Vector.Z());
         uzp2(FEXCore::ARMEmitter::SubRegSize::i16Bit, Dst.Z(), Dst.Z(), Dst.Z());
         break;
       }
       case 0x0408: { // Float <- Double
-        fcvtnt(FEXCore::ARMEmitter::SubRegSize::i32Bit, Dst, Mask, Vector);
+        fcvtnt(FEXCore::ARMEmitter::SubRegSize::i32Bit, Dst.Z(), Mask, Vector.Z());
         uzp2(FEXCore::ARMEmitter::SubRegSize::i32Bit, Dst.Z(), Dst.Z(), Dst.Z());
         break;
       }

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -1473,7 +1473,7 @@ DEF_OP(ParanoidStoreMemTSO) {
       }
       case 32: {
         dmb(FEXCore::ARMEmitter::BarrierScope::ISH);
-        st1b<ARMEmitter::SubRegSize::i8Bit>(Src, PRED_TMP_32B, Addr, 0);
+        st1b<ARMEmitter::SubRegSize::i8Bit>(Src.Z(), PRED_TMP_32B, Addr, 0);
         dmb(FEXCore::ARMEmitter::BarrierScope::ISH);
         break;
       }

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -2629,7 +2629,7 @@ DEF_OP(VUXTL2) {
   if (HostSupportsSVE && Is256Bit) {
     uunpkhi(SubRegSize, Dst.Z(), Vector.Z());
   } else {
-    uxtl2(SubRegSize, Dst.D(), Vector.D());
+    uxtl2(SubRegSize, Dst.Q(), Vector.Q());
   }
 }
 
@@ -2972,7 +2972,7 @@ DEF_OP(VTBL1) {
 
   switch (OpSize) {
     case 8: {
-      tbl(Dst.D(), VectorTable.D(), VectorIndices.D());
+      tbl(Dst.D(), VectorTable.Q(), VectorIndices.Q());
       break;
     }
     case 16: {

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -2972,7 +2972,7 @@ DEF_OP(VTBL1) {
 
   switch (OpSize) {
     case 8: {
-      tbl(Dst.D(), VectorTable.Q(), VectorIndices.Q());
+      tbl(Dst.D(), VectorTable.Q(), VectorIndices.D());
       break;
     }
     case 16: {

--- a/External/FEXCore/unittests/Emitter/ASIMD_Tests.cpp
+++ b/External/FEXCore/unittests/Emitter/ASIMD_Tests.cpp
@@ -815,11 +815,6 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD two-register m
   TEST_SINGLE(sqxtun2(SubRegSize::i32Bit, DReg::d30, DReg::d29), "sqxtun2 v30.4s, v29.2d");
   //TEST_SINGLE(sqxtun2(SubRegSize::i64Bit, DReg::d30, DReg::d29), "sqxtun2 v30.2d, v29.1d");
 
-  //TEST_SINGLE(shll(SubRegSize::i8Bit, QReg::q30, QReg::q29), "shll v30.16b, v29.16b, #0");
-  TEST_SINGLE(shll(SubRegSize::i16Bit, QReg::q30, QReg::q29), "shll v30.8h, v29.8b, #8");
-  TEST_SINGLE(shll(SubRegSize::i32Bit, QReg::q30, QReg::q29), "shll v30.4s, v29.4h, #16");
-  TEST_SINGLE(shll(SubRegSize::i64Bit, QReg::q30, QReg::q29), "shll v30.2d, v29.2s, #32");
-
   //TEST_SINGLE(shll(SubRegSize::i8Bit, DReg::d30, DReg::d29), "shll v30.8b, v29.8b, #0");
   TEST_SINGLE(shll(SubRegSize::i16Bit, DReg::d30, DReg::d29), "shll v30.8h, v29.8b, #8");
   TEST_SINGLE(shll(SubRegSize::i32Bit, DReg::d30, DReg::d29), "shll v30.4s, v29.4h, #16");
@@ -2216,15 +2211,6 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD shift by immed
   //TEST_SINGLE(sqshl(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "sqshl v30.1d, v29.1d, #1");
   //TEST_SINGLE(sqshl(SubRegSize::i64Bit, DReg::d30, DReg::d29, 63), "sqshl v30.1d, v29.1d, #63");
 
-  TEST_SINGLE(shrn(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "shrn v30.8b, v29.8h, #1");
-  TEST_SINGLE(shrn(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "shrn v30.8b, v29.8h, #7");
-  TEST_SINGLE(shrn(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "shrn v30.4h, v29.4s, #1");
-  TEST_SINGLE(shrn(SubRegSize::i16Bit, QReg::q30, QReg::q29, 15), "shrn v30.4h, v29.4s, #15");
-  TEST_SINGLE(shrn(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "shrn v30.2s, v29.2d, #1");
-  TEST_SINGLE(shrn(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "shrn v30.2s, v29.2d, #31");
-  //TEST_SINGLE(shrn(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "shrn v30.2d, v29.2d, #1");
-  //TEST_SINGLE(shrn(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "shrn v30.2d, v29.2d, #63");
-
   TEST_SINGLE(shrn(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "shrn v30.8b, v29.8h, #1");
   TEST_SINGLE(shrn(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "shrn v30.8b, v29.8h, #7");
   TEST_SINGLE(shrn(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "shrn v30.4h, v29.4s, #1");
@@ -2242,15 +2228,6 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD shift by immed
   TEST_SINGLE(shrn2(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "shrn2 v30.4s, v29.2d, #31");
   //TEST_SINGLE(shrn2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "shrn2 v30.2d, v29.2d, #1");
   //TEST_SINGLE(shrn2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "shrn2 v30.2d, v29.2d, #63");
-
-  TEST_SINGLE(rshrn(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "rshrn v30.8b, v29.8h, #1");
-  TEST_SINGLE(rshrn(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "rshrn v30.8b, v29.8h, #7");
-  TEST_SINGLE(rshrn(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "rshrn v30.4h, v29.4s, #1");
-  TEST_SINGLE(rshrn(SubRegSize::i16Bit, QReg::q30, QReg::q29, 15), "rshrn v30.4h, v29.4s, #15");
-  TEST_SINGLE(rshrn(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "rshrn v30.2s, v29.2d, #1");
-  TEST_SINGLE(rshrn(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "rshrn v30.2s, v29.2d, #31");
-  //TEST_SINGLE(rshrn(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "rshrn v30.2d, v29.2d, #1");
-  //TEST_SINGLE(rshrn(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "rshrn v30.2d, v29.2d, #63");
 
   TEST_SINGLE(rshrn(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "rshrn v30.8b, v29.8h, #1");
   TEST_SINGLE(rshrn(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "rshrn v30.8b, v29.8h, #7");
@@ -2270,15 +2247,6 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD shift by immed
   //TEST_SINGLE(rshrn2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "rshrn2 v30.2d, v29.2d, #1");
   //TEST_SINGLE(rshrn2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "rshrn2 v30.2d, v29.2d, #63");
 
-  TEST_SINGLE(sqshrn(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "sqshrn v30.8b, v29.8h, #1");
-  TEST_SINGLE(sqshrn(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "sqshrn v30.8b, v29.8h, #7");
-  TEST_SINGLE(sqshrn(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "sqshrn v30.4h, v29.4s, #1");
-  TEST_SINGLE(sqshrn(SubRegSize::i16Bit, QReg::q30, QReg::q29, 15), "sqshrn v30.4h, v29.4s, #15");
-  TEST_SINGLE(sqshrn(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "sqshrn v30.2s, v29.2d, #1");
-  TEST_SINGLE(sqshrn(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "sqshrn v30.2s, v29.2d, #31");
-  //TEST_SINGLE(sqshrn(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "sqshrn v30.2d, v29.2d, #1");
-  //TEST_SINGLE(sqshrn(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "sqshrn v30.2d, v29.2d, #63");
-
   TEST_SINGLE(sqshrn(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "sqshrn v30.8b, v29.8h, #1");
   TEST_SINGLE(sqshrn(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "sqshrn v30.8b, v29.8h, #7");
   TEST_SINGLE(sqshrn(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "sqshrn v30.4h, v29.4s, #1");
@@ -2297,15 +2265,6 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD shift by immed
   //TEST_SINGLE(sqshrn2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "sqshrn2 v30.2d, v29.2d, #1");
   //TEST_SINGLE(sqshrn2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "sqshrn2 v30.2d, v29.2d, #63");
 
-  TEST_SINGLE(sqrshrn(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "sqrshrn v30.8b, v29.8h, #1");
-  TEST_SINGLE(sqrshrn(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "sqrshrn v30.8b, v29.8h, #7");
-  TEST_SINGLE(sqrshrn(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "sqrshrn v30.4h, v29.4s, #1");
-  TEST_SINGLE(sqrshrn(SubRegSize::i16Bit, QReg::q30, QReg::q29, 15), "sqrshrn v30.4h, v29.4s, #15");
-  TEST_SINGLE(sqrshrn(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "sqrshrn v30.2s, v29.2d, #1");
-  TEST_SINGLE(sqrshrn(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "sqrshrn v30.2s, v29.2d, #31");
-  //TEST_SINGLE(sqrshrn(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "sqrshrn v30.2d, v29.2d, #1");
-  //TEST_SINGLE(sqrshrn(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "sqrshrn v30.2d, v29.2d, #63");
-
   TEST_SINGLE(sqrshrn(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "sqrshrn v30.8b, v29.8h, #1");
   TEST_SINGLE(sqrshrn(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "sqrshrn v30.8b, v29.8h, #7");
   TEST_SINGLE(sqrshrn(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "sqrshrn v30.4h, v29.4s, #1");
@@ -2323,15 +2282,6 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD shift by immed
   TEST_SINGLE(sqrshrn2(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "sqrshrn2 v30.4s, v29.2d, #31");
   //TEST_SINGLE(sqrshrn2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "sqrshrn2 v30.2d, v29.2d, #1");
   //TEST_SINGLE(sqrshrn2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "sqrshrn2 v30.2d, v29.2d, #63");
-
-  //TEST_SINGLE(sshll(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "sshll v30.8b, v29.8h, #1");
-  //TEST_SINGLE(sshll(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "sshll v30.8b, v29.8h, #7");
-  TEST_SINGLE(sshll(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "sshll v30.8h, v29.8b, #1");
-  TEST_SINGLE(sshll(SubRegSize::i16Bit, QReg::q30, QReg::q29, 7), "sshll v30.8h, v29.8b, #7");
-  TEST_SINGLE(sshll(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "sshll v30.4s, v29.4h, #1");
-  TEST_SINGLE(sshll(SubRegSize::i32Bit, QReg::q30, QReg::q29, 15), "sshll v30.4s, v29.4h, #15");
-  TEST_SINGLE(sshll(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "sshll v30.2d, v29.2s, #1");
-  TEST_SINGLE(sshll(SubRegSize::i64Bit, QReg::q30, QReg::q29, 31), "sshll v30.2d, v29.2s, #31");
 
   //TEST_SINGLE(sshll(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "sshll v30.8b, v29.8h, #1");
   //TEST_SINGLE(sshll(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "sshll v30.8b, v29.8h, #7");
@@ -2551,15 +2501,6 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD shift by immed
   //TEST_SINGLE(uqshl(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "uqshl v30.1d, v29.1d, #1");
   //TEST_SINGLE(uqshl(SubRegSize::i64Bit, DReg::d30, DReg::d29, 63), "uqshl v30.1d, v29.1d, #63");
 
-  TEST_SINGLE(sqshrun(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "sqshrun v30.8b, v29.8h, #1");
-  TEST_SINGLE(sqshrun(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "sqshrun v30.8b, v29.8h, #7");
-  TEST_SINGLE(sqshrun(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "sqshrun v30.4h, v29.4s, #1");
-  TEST_SINGLE(sqshrun(SubRegSize::i16Bit, QReg::q30, QReg::q29, 15), "sqshrun v30.4h, v29.4s, #15");
-  TEST_SINGLE(sqshrun(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "sqshrun v30.2s, v29.2d, #1");
-  TEST_SINGLE(sqshrun(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "sqshrun v30.2s, v29.2d, #31");
-  //TEST_SINGLE(sqshrun(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "sqshrun v30.2d, v29.2d, #1");
-  //TEST_SINGLE(sqshrun(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "sqshrun v30.2d, v29.2d, #63");
-
   TEST_SINGLE(sqshrun(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "sqshrun v30.8b, v29.8h, #1");
   TEST_SINGLE(sqshrun(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "sqshrun v30.8b, v29.8h, #7");
   TEST_SINGLE(sqshrun(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "sqshrun v30.4h, v29.4s, #1");
@@ -2577,15 +2518,6 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD shift by immed
   TEST_SINGLE(sqshrun2(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "sqshrun2 v30.4s, v29.2d, #31");
   //TEST_SINGLE(sqshrun2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "sqshrun2 v30.2d, v29.2d, #1");
   //TEST_SINGLE(sqshrun2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "sqshrun2 v30.2d, v29.2d, #63");
-
-  TEST_SINGLE(sqrshrun(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "sqrshrun v30.8b, v29.8h, #1");
-  TEST_SINGLE(sqrshrun(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "sqrshrun v30.8b, v29.8h, #7");
-  TEST_SINGLE(sqrshrun(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "sqrshrun v30.4h, v29.4s, #1");
-  TEST_SINGLE(sqrshrun(SubRegSize::i16Bit, QReg::q30, QReg::q29, 15), "sqrshrun v30.4h, v29.4s, #15");
-  TEST_SINGLE(sqrshrun(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "sqrshrun v30.2s, v29.2d, #1");
-  TEST_SINGLE(sqrshrun(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "sqrshrun v30.2s, v29.2d, #31");
-  //TEST_SINGLE(sqrshrun(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "sqrshrun v30.2d, v29.2d, #1");
-  //TEST_SINGLE(sqrshrun(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "sqrshrun v30.2d, v29.2d, #63");
 
   TEST_SINGLE(sqrshrun(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "sqrshrun v30.8b, v29.8h, #1");
   TEST_SINGLE(sqrshrun(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "sqrshrun v30.8b, v29.8h, #7");
@@ -2605,15 +2537,6 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD shift by immed
   //TEST_SINGLE(sqrshrun2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "sqrshrun2 v30.2d, v29.2d, #1");
   //TEST_SINGLE(sqrshrun2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "sqrshrun2 v30.2d, v29.2d, #63");
 
-  TEST_SINGLE(uqshrn(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "uqshrn v30.8b, v29.8h, #1");
-  TEST_SINGLE(uqshrn(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "uqshrn v30.8b, v29.8h, #7");
-  TEST_SINGLE(uqshrn(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "uqshrn v30.4h, v29.4s, #1");
-  TEST_SINGLE(uqshrn(SubRegSize::i16Bit, QReg::q30, QReg::q29, 15), "uqshrn v30.4h, v29.4s, #15");
-  TEST_SINGLE(uqshrn(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "uqshrn v30.2s, v29.2d, #1");
-  TEST_SINGLE(uqshrn(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "uqshrn v30.2s, v29.2d, #31");
-  //TEST_SINGLE(uqshrn(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "uqshrn v30.2d, v29.2d, #1");
-  //TEST_SINGLE(uqshrn(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "uqshrn v30.2d, v29.2d, #63");
-
   TEST_SINGLE(uqshrn(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "uqshrn v30.8b, v29.8h, #1");
   TEST_SINGLE(uqshrn(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "uqshrn v30.8b, v29.8h, #7");
   TEST_SINGLE(uqshrn(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "uqshrn v30.4h, v29.4s, #1");
@@ -2631,15 +2554,6 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD shift by immed
   TEST_SINGLE(uqshrn2(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "uqshrn2 v30.4s, v29.2d, #31");
   //TEST_SINGLE(uqshrn2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "uqshrn2 v30.2d, v29.2d, #1");
   //TEST_SINGLE(uqshrn2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "uqshrn2 v30.2d, v29.2d, #63");
-
-  TEST_SINGLE(uqrshrn(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "uqrshrn v30.8b, v29.8h, #1");
-  TEST_SINGLE(uqrshrn(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "uqrshrn v30.8b, v29.8h, #7");
-  TEST_SINGLE(uqrshrn(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "uqrshrn v30.4h, v29.4s, #1");
-  TEST_SINGLE(uqrshrn(SubRegSize::i16Bit, QReg::q30, QReg::q29, 15), "uqrshrn v30.4h, v29.4s, #15");
-  TEST_SINGLE(uqrshrn(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "uqrshrn v30.2s, v29.2d, #1");
-  TEST_SINGLE(uqrshrn(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "uqrshrn v30.2s, v29.2d, #31");
-  //TEST_SINGLE(uqrshrn(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "uqrshrn v30.2d, v29.2d, #1");
-  //TEST_SINGLE(uqrshrn(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "uqrshrn v30.2d, v29.2d, #63");
 
   TEST_SINGLE(uqrshrn(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "uqrshrn v30.8b, v29.8h, #1");
   TEST_SINGLE(uqrshrn(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "uqrshrn v30.8b, v29.8h, #7");
@@ -2659,15 +2573,6 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD shift by immed
   //TEST_SINGLE(uqrshrn2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "uqrshrn2 v30.2d, v29.2d, #1");
   //TEST_SINGLE(uqrshrn2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "uqrshrn2 v30.2d, v29.2d, #63");
 
-  //TEST_SINGLE(ushll(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "ushll v30.8b, v29.8h, #1");
-  //TEST_SINGLE(ushll(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "ushll v30.8b, v29.8h, #7");
-  TEST_SINGLE(ushll(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "ushll v30.8h, v29.8b, #1");
-  TEST_SINGLE(ushll(SubRegSize::i16Bit, QReg::q30, QReg::q29, 7), "ushll v30.8h, v29.8b, #7");
-  TEST_SINGLE(ushll(SubRegSize::i32Bit, QReg::q30, QReg::q29, 1),  "ushll v30.4s, v29.4h, #1");
-  TEST_SINGLE(ushll(SubRegSize::i32Bit, QReg::q30, QReg::q29, 15), "ushll v30.4s, v29.4h, #15");
-  TEST_SINGLE(ushll(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "ushll v30.2d, v29.2s, #1");
-  TEST_SINGLE(ushll(SubRegSize::i64Bit, QReg::q30, QReg::q29, 31), "ushll v30.2d, v29.2s, #31");
-
   //TEST_SINGLE(ushll(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "ushll v30.8b, v29.8h, #1");
   //TEST_SINGLE(ushll(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "ushll v30.8b, v29.8h, #7");
   TEST_SINGLE(ushll(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "ushll v30.8h, v29.8b, #1");
@@ -2685,11 +2590,6 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD shift by immed
   TEST_SINGLE(ushll2(SubRegSize::i32Bit, QReg::q30, QReg::q29, 15), "ushll2 v30.4s, v29.8h, #15");
   TEST_SINGLE(ushll2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "ushll2 v30.2d, v29.4s, #1");
   TEST_SINGLE(ushll2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 31), "ushll2 v30.2d, v29.4s, #31");
-
-  //TEST_SINGLE(uxtl(SubRegSize::i8Bit, QReg::q30, QReg::q29),   "uxtl v30.8b, v29.8h");
-  TEST_SINGLE(uxtl(SubRegSize::i16Bit, QReg::q30, QReg::q29),  "uxtl v30.8h, v29.8b");
-  TEST_SINGLE(uxtl(SubRegSize::i32Bit, QReg::q30, QReg::q29),  "uxtl v30.4s, v29.4h");
-  TEST_SINGLE(uxtl(SubRegSize::i64Bit, QReg::q30, QReg::q29),  "uxtl v30.2d, v29.2s");
 
   //TEST_SINGLE(uxtl(SubRegSize::i8Bit, DReg::d30, DReg::d29),   "uxtl v30.8b, v29.8h");
   TEST_SINGLE(uxtl(SubRegSize::i16Bit, DReg::d30, DReg::d29),  "uxtl v30.8h, v29.8b");

--- a/External/FEXCore/unittests/Emitter/ASIMD_Tests.cpp
+++ b/External/FEXCore/unittests/Emitter/ASIMD_Tests.cpp
@@ -830,11 +830,6 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD two-register m
   TEST_SINGLE(shll2(SubRegSize::i32Bit, QReg::q30, QReg::q29), "shll2 v30.4s, v29.8h, #16");
   TEST_SINGLE(shll2(SubRegSize::i64Bit, QReg::q30, QReg::q29), "shll2 v30.2d, v29.4s, #32");
 
-  //TEST_SINGLE(shll2(SubRegSize::i8Bit, DReg::d30, DReg::d29), "shll2 v30.8b, v29.8b, #0");
-  TEST_SINGLE(shll2(SubRegSize::i16Bit, DReg::d30, DReg::d29), "shll2 v30.8h, v29.16b, #8");
-  TEST_SINGLE(shll2(SubRegSize::i32Bit, DReg::d30, DReg::d29), "shll2 v30.4s, v29.8h, #16");
-  TEST_SINGLE(shll2(SubRegSize::i64Bit, DReg::d30, DReg::d29), "shll2 v30.2d, v29.4s, #32");
-
   TEST_SINGLE(uqxtn(SubRegSize::i8Bit, QReg::q30, QReg::q29), "uqxtn v30.8b, v29.8h");
   TEST_SINGLE(uqxtn(SubRegSize::i16Bit, QReg::q30, QReg::q29), "uqxtn v30.4h, v29.4s");
   TEST_SINGLE(uqxtn(SubRegSize::i32Bit, QReg::q30, QReg::q29), "uqxtn v30.2s, v29.2d");
@@ -2248,15 +2243,6 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD shift by immed
   //TEST_SINGLE(shrn2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "shrn2 v30.2d, v29.2d, #1");
   //TEST_SINGLE(shrn2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "shrn2 v30.2d, v29.2d, #63");
 
-  TEST_SINGLE(shrn2(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "shrn2 v30.16b, v29.8h, #1");
-  TEST_SINGLE(shrn2(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "shrn2 v30.16b, v29.8h, #7");
-  TEST_SINGLE(shrn2(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "shrn2 v30.8h, v29.4s, #1");
-  TEST_SINGLE(shrn2(SubRegSize::i16Bit, DReg::d30, DReg::d29, 15), "shrn2 v30.8h, v29.4s, #15");
-  TEST_SINGLE(shrn2(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "shrn2 v30.4s, v29.2d, #1");
-  TEST_SINGLE(shrn2(SubRegSize::i32Bit, DReg::d30, DReg::d29, 31), "shrn2 v30.4s, v29.2d, #31");
-  //TEST_SINGLE(shrn2(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "shrn2 v30.1d, v29.1d, #1");
-  //TEST_SINGLE(shrn2(SubRegSize::i64Bit, DReg::d30, DReg::d29, 63), "shrn2 v30.1d, v29.1d, #63");
-
   TEST_SINGLE(rshrn(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "rshrn v30.8b, v29.8h, #1");
   TEST_SINGLE(rshrn(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "rshrn v30.8b, v29.8h, #7");
   TEST_SINGLE(rshrn(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "rshrn v30.4h, v29.4s, #1");
@@ -2283,15 +2269,6 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD shift by immed
   TEST_SINGLE(rshrn2(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "rshrn2 v30.4s, v29.2d, #31");
   //TEST_SINGLE(rshrn2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "rshrn2 v30.2d, v29.2d, #1");
   //TEST_SINGLE(rshrn2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "rshrn2 v30.2d, v29.2d, #63");
-
-  TEST_SINGLE(rshrn2(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "rshrn2 v30.16b, v29.8h, #1");
-  TEST_SINGLE(rshrn2(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "rshrn2 v30.16b, v29.8h, #7");
-  TEST_SINGLE(rshrn2(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "rshrn2 v30.8h, v29.4s, #1");
-  TEST_SINGLE(rshrn2(SubRegSize::i16Bit, DReg::d30, DReg::d29, 15), "rshrn2 v30.8h, v29.4s, #15");
-  TEST_SINGLE(rshrn2(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "rshrn2 v30.4s, v29.2d, #1");
-  TEST_SINGLE(rshrn2(SubRegSize::i32Bit, DReg::d30, DReg::d29, 31), "rshrn2 v30.4s, v29.2d, #31");
-  //TEST_SINGLE(rshrn2(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "rshrn2 v30.1d, v29.1d, #1");
-  //TEST_SINGLE(rshrn2(SubRegSize::i64Bit, DReg::d30, DReg::d29, 63), "rshrn2 v30.1d, v29.1d, #63");
 
   TEST_SINGLE(sqshrn(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "sqshrn v30.8b, v29.8h, #1");
   TEST_SINGLE(sqshrn(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "sqshrn v30.8b, v29.8h, #7");
@@ -2320,15 +2297,6 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD shift by immed
   //TEST_SINGLE(sqshrn2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "sqshrn2 v30.2d, v29.2d, #1");
   //TEST_SINGLE(sqshrn2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "sqshrn2 v30.2d, v29.2d, #63");
 
-  TEST_SINGLE(sqshrn2(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "sqshrn2 v30.16b, v29.8h, #1");
-  TEST_SINGLE(sqshrn2(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "sqshrn2 v30.16b, v29.8h, #7");
-  TEST_SINGLE(sqshrn2(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "sqshrn2 v30.8h, v29.4s, #1");
-  TEST_SINGLE(sqshrn2(SubRegSize::i16Bit, DReg::d30, DReg::d29, 15), "sqshrn2 v30.8h, v29.4s, #15");
-  TEST_SINGLE(sqshrn2(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "sqshrn2 v30.4s, v29.2d, #1");
-  TEST_SINGLE(sqshrn2(SubRegSize::i32Bit, DReg::d30, DReg::d29, 31), "sqshrn2 v30.4s, v29.2d, #31");
-  //TEST_SINGLE(sqshrn2(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "sqshrn2 v30.1d, v29.1d, #1");
-  //TEST_SINGLE(sqshrn2(SubRegSize::i64Bit, DReg::d30, DReg::d29, 63), "sqshrn2 v30.1d, v29.1d, #63");
-
   TEST_SINGLE(sqrshrn(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "sqrshrn v30.8b, v29.8h, #1");
   TEST_SINGLE(sqrshrn(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "sqrshrn v30.8b, v29.8h, #7");
   TEST_SINGLE(sqrshrn(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "sqrshrn v30.4h, v29.4s, #1");
@@ -2356,15 +2324,6 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD shift by immed
   //TEST_SINGLE(sqrshrn2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "sqrshrn2 v30.2d, v29.2d, #1");
   //TEST_SINGLE(sqrshrn2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "sqrshrn2 v30.2d, v29.2d, #63");
 
-  TEST_SINGLE(sqrshrn2(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "sqrshrn2 v30.16b, v29.8h, #1");
-  TEST_SINGLE(sqrshrn2(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "sqrshrn2 v30.16b, v29.8h, #7");
-  TEST_SINGLE(sqrshrn2(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "sqrshrn2 v30.8h, v29.4s, #1");
-  TEST_SINGLE(sqrshrn2(SubRegSize::i16Bit, DReg::d30, DReg::d29, 15), "sqrshrn2 v30.8h, v29.4s, #15");
-  TEST_SINGLE(sqrshrn2(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "sqrshrn2 v30.4s, v29.2d, #1");
-  TEST_SINGLE(sqrshrn2(SubRegSize::i32Bit, DReg::d30, DReg::d29, 31), "sqrshrn2 v30.4s, v29.2d, #31");
-  //TEST_SINGLE(sqrshrn2(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "sqrshrn2 v30.1d, v29.1d, #1");
-  //TEST_SINGLE(sqrshrn2(SubRegSize::i64Bit, DReg::d30, DReg::d29, 63), "sqrshrn2 v30.1d, v29.1d, #63");
-
   //TEST_SINGLE(sshll(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "sshll v30.8b, v29.8h, #1");
   //TEST_SINGLE(sshll(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "sshll v30.8b, v29.8h, #7");
   TEST_SINGLE(sshll(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "sshll v30.8h, v29.8b, #1");
@@ -2391,15 +2350,6 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD shift by immed
   TEST_SINGLE(sshll2(SubRegSize::i32Bit, QReg::q30, QReg::q29, 15), "sshll2 v30.4s, v29.8h, #15");
   TEST_SINGLE(sshll2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "sshll2 v30.2d, v29.4s, #1");
   TEST_SINGLE(sshll2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 31), "sshll2 v30.2d, v29.4s, #31");
-
-  //TEST_SINGLE(sshll2(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "sshll2 v30.16b, v29.8h, #1");
-  //TEST_SINGLE(sshll2(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "sshll2 v30.16b, v29.8h, #7");
-  TEST_SINGLE(sshll2(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "sshll2 v30.8h, v29.16b, #1");
-  TEST_SINGLE(sshll2(SubRegSize::i16Bit, DReg::d30, DReg::d29, 7), "sshll2 v30.8h, v29.16b, #7");
-  TEST_SINGLE(sshll2(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "sshll2 v30.4s, v29.8h, #1");
-  TEST_SINGLE(sshll2(SubRegSize::i32Bit, DReg::d30, DReg::d29, 15), "sshll2 v30.4s, v29.8h, #15");
-  TEST_SINGLE(sshll2(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "sshll2 v30.2d, v29.4s, #1");
-  TEST_SINGLE(sshll2(SubRegSize::i64Bit, DReg::d30, DReg::d29, 31), "sshll2 v30.2d, v29.4s, #31");
 
   //TEST_SINGLE(sxtl(SubRegSize::i8Bit, QReg::q30, QReg::q29),   "sxtl v30.8b, v29.8h");
   TEST_SINGLE(sxtl(SubRegSize::i16Bit, QReg::q30, QReg::q29),  "sxtl v30.8h, v29.8b");
@@ -2628,15 +2578,6 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD shift by immed
   //TEST_SINGLE(sqshrun2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "sqshrun2 v30.2d, v29.2d, #1");
   //TEST_SINGLE(sqshrun2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "sqshrun2 v30.2d, v29.2d, #63");
 
-  TEST_SINGLE(sqshrun2(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "sqshrun2 v30.16b, v29.8h, #1");
-  TEST_SINGLE(sqshrun2(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "sqshrun2 v30.16b, v29.8h, #7");
-  TEST_SINGLE(sqshrun2(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "sqshrun2 v30.8h, v29.4s, #1");
-  TEST_SINGLE(sqshrun2(SubRegSize::i16Bit, DReg::d30, DReg::d29, 15), "sqshrun2 v30.8h, v29.4s, #15");
-  TEST_SINGLE(sqshrun2(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "sqshrun2 v30.4s, v29.2d, #1");
-  TEST_SINGLE(sqshrun2(SubRegSize::i32Bit, DReg::d30, DReg::d29, 31), "sqshrun2 v30.4s, v29.2d, #31");
-  //TEST_SINGLE(sqshrun2(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "sqshrun2 v30.1d, v29.1d, #1");
-  //TEST_SINGLE(sqshrun2(SubRegSize::i64Bit, DReg::d30, DReg::d29, 63), "sqshrun2 v30.1d, v29.1d, #63");
-
   TEST_SINGLE(sqrshrun(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "sqrshrun v30.8b, v29.8h, #1");
   TEST_SINGLE(sqrshrun(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "sqrshrun v30.8b, v29.8h, #7");
   TEST_SINGLE(sqrshrun(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "sqrshrun v30.4h, v29.4s, #1");
@@ -2663,15 +2604,6 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD shift by immed
   TEST_SINGLE(sqrshrun2(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "sqrshrun2 v30.4s, v29.2d, #31");
   //TEST_SINGLE(sqrshrun2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "sqrshrun2 v30.2d, v29.2d, #1");
   //TEST_SINGLE(sqrshrun2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "sqrshrun2 v30.2d, v29.2d, #63");
-
-  TEST_SINGLE(sqrshrun2(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "sqrshrun2 v30.16b, v29.8h, #1");
-  TEST_SINGLE(sqrshrun2(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "sqrshrun2 v30.16b, v29.8h, #7");
-  TEST_SINGLE(sqrshrun2(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "sqrshrun2 v30.8h, v29.4s, #1");
-  TEST_SINGLE(sqrshrun2(SubRegSize::i16Bit, DReg::d30, DReg::d29, 15), "sqrshrun2 v30.8h, v29.4s, #15");
-  TEST_SINGLE(sqrshrun2(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "sqrshrun2 v30.4s, v29.2d, #1");
-  TEST_SINGLE(sqrshrun2(SubRegSize::i32Bit, DReg::d30, DReg::d29, 31), "sqrshrun2 v30.4s, v29.2d, #31");
-  //TEST_SINGLE(sqrshrun2(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "sqrshrun2 v30.1d, v29.1d, #1");
-  //TEST_SINGLE(sqrshrun2(SubRegSize::i64Bit, DReg::d30, DReg::d29, 63), "sqrshrun2 v30.1d, v29.1d, #63");
 
   TEST_SINGLE(uqshrn(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "uqshrn v30.8b, v29.8h, #1");
   TEST_SINGLE(uqshrn(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "uqshrn v30.8b, v29.8h, #7");
@@ -2700,15 +2632,6 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD shift by immed
   //TEST_SINGLE(uqshrn2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "uqshrn2 v30.2d, v29.2d, #1");
   //TEST_SINGLE(uqshrn2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "uqshrn2 v30.2d, v29.2d, #63");
 
-  TEST_SINGLE(uqshrn2(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "uqshrn2 v30.16b, v29.8h, #1");
-  TEST_SINGLE(uqshrn2(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "uqshrn2 v30.16b, v29.8h, #7");
-  TEST_SINGLE(uqshrn2(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "uqshrn2 v30.8h, v29.4s, #1");
-  TEST_SINGLE(uqshrn2(SubRegSize::i16Bit, DReg::d30, DReg::d29, 15), "uqshrn2 v30.8h, v29.4s, #15");
-  TEST_SINGLE(uqshrn2(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "uqshrn2 v30.4s, v29.2d, #1");
-  TEST_SINGLE(uqshrn2(SubRegSize::i32Bit, DReg::d30, DReg::d29, 31), "uqshrn2 v30.4s, v29.2d, #31");
-  //TEST_SINGLE(uqshrn2(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "uqshrn2 v30.1d, v29.1d, #1");
-  //TEST_SINGLE(uqshrn2(SubRegSize::i64Bit, DReg::d30, DReg::d29, 63), "uqshrn2 v30.1d, v29.1d, #63");
-
   TEST_SINGLE(uqrshrn(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "uqrshrn v30.8b, v29.8h, #1");
   TEST_SINGLE(uqrshrn(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "uqrshrn v30.8b, v29.8h, #7");
   TEST_SINGLE(uqrshrn(SubRegSize::i16Bit, QReg::q30, QReg::q29, 1),  "uqrshrn v30.4h, v29.4s, #1");
@@ -2735,15 +2658,6 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD shift by immed
   TEST_SINGLE(uqrshrn2(SubRegSize::i32Bit, QReg::q30, QReg::q29, 31), "uqrshrn2 v30.4s, v29.2d, #31");
   //TEST_SINGLE(uqrshrn2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "uqrshrn2 v30.2d, v29.2d, #1");
   //TEST_SINGLE(uqrshrn2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 63), "uqrshrn2 v30.2d, v29.2d, #63");
-
-  TEST_SINGLE(uqrshrn2(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "uqrshrn2 v30.16b, v29.8h, #1");
-  TEST_SINGLE(uqrshrn2(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "uqrshrn2 v30.16b, v29.8h, #7");
-  TEST_SINGLE(uqrshrn2(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "uqrshrn2 v30.8h, v29.4s, #1");
-  TEST_SINGLE(uqrshrn2(SubRegSize::i16Bit, DReg::d30, DReg::d29, 15), "uqrshrn2 v30.8h, v29.4s, #15");
-  TEST_SINGLE(uqrshrn2(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "uqrshrn2 v30.4s, v29.2d, #1");
-  TEST_SINGLE(uqrshrn2(SubRegSize::i32Bit, DReg::d30, DReg::d29, 31), "uqrshrn2 v30.4s, v29.2d, #31");
-  //TEST_SINGLE(uqrshrn2(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "uqrshrn2 v30.1d, v29.1d, #1");
-  //TEST_SINGLE(uqrshrn2(SubRegSize::i64Bit, DReg::d30, DReg::d29, 63), "uqrshrn2 v30.1d, v29.1d, #63");
 
   //TEST_SINGLE(ushll(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "ushll v30.8b, v29.8h, #1");
   //TEST_SINGLE(ushll(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "ushll v30.8b, v29.8h, #7");
@@ -2772,15 +2686,6 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD shift by immed
   TEST_SINGLE(ushll2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 1),  "ushll2 v30.2d, v29.4s, #1");
   TEST_SINGLE(ushll2(SubRegSize::i64Bit, QReg::q30, QReg::q29, 31), "ushll2 v30.2d, v29.4s, #31");
 
-  //TEST_SINGLE(ushll2(SubRegSize::i8Bit, DReg::d30, DReg::d29, 1),   "ushll2 v30.16b, v29.8h, #1");
-  //TEST_SINGLE(ushll2(SubRegSize::i8Bit, DReg::d30, DReg::d29, 7),   "ushll2 v30.16b, v29.8h, #7");
-  TEST_SINGLE(ushll2(SubRegSize::i16Bit, DReg::d30, DReg::d29, 1),  "ushll2 v30.8h, v29.16b, #1");
-  TEST_SINGLE(ushll2(SubRegSize::i16Bit, DReg::d30, DReg::d29, 7), "ushll2 v30.8h, v29.16b, #7");
-  TEST_SINGLE(ushll2(SubRegSize::i32Bit, DReg::d30, DReg::d29, 1),  "ushll2 v30.4s, v29.8h, #1");
-  TEST_SINGLE(ushll2(SubRegSize::i32Bit, DReg::d30, DReg::d29, 15), "ushll2 v30.4s, v29.8h, #15");
-  TEST_SINGLE(ushll2(SubRegSize::i64Bit, DReg::d30, DReg::d29, 1),  "ushll2 v30.2d, v29.4s, #1");
-  TEST_SINGLE(ushll2(SubRegSize::i64Bit, DReg::d30, DReg::d29, 31), "ushll2 v30.2d, v29.4s, #31");
-
   //TEST_SINGLE(uxtl(SubRegSize::i8Bit, QReg::q30, QReg::q29),   "uxtl v30.8b, v29.8h");
   TEST_SINGLE(uxtl(SubRegSize::i16Bit, QReg::q30, QReg::q29),  "uxtl v30.8h, v29.8b");
   TEST_SINGLE(uxtl(SubRegSize::i32Bit, QReg::q30, QReg::q29),  "uxtl v30.4s, v29.4h");
@@ -2795,11 +2700,6 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD shift by immed
   TEST_SINGLE(uxtl2(SubRegSize::i16Bit, QReg::q30, QReg::q29),  "uxtl2 v30.8h, v29.16b");
   TEST_SINGLE(uxtl2(SubRegSize::i32Bit, QReg::q30, QReg::q29),  "uxtl2 v30.4s, v29.8h");
   TEST_SINGLE(uxtl2(SubRegSize::i64Bit, QReg::q30, QReg::q29),  "uxtl2 v30.2d, v29.4s");
-
-  //TEST_SINGLE(uxtl2(SubRegSize::i8Bit, DReg::d30, DReg::d29),   "uxtl2 v30.16b, v29.8h");
-  TEST_SINGLE(uxtl2(SubRegSize::i16Bit, DReg::d30, DReg::d29),  "uxtl2 v30.8h, v29.16b");
-  TEST_SINGLE(uxtl2(SubRegSize::i32Bit, DReg::d30, DReg::d29),  "uxtl2 v30.4s, v29.8h");
-  TEST_SINGLE(uxtl2(SubRegSize::i64Bit, DReg::d30, DReg::d29),  "uxtl2 v30.2d, v29.4s");
 
   //TEST_SINGLE(ucvtf(SubRegSize::i8Bit, QReg::q30, QReg::q29, 1),   "ucvtf v30.16b, v29.16b, #1");
   //TEST_SINGLE(ucvtf(SubRegSize::i8Bit, QReg::q30, QReg::q29, 7),   "ucvtf v30.16b, v29.16b, #7");

--- a/External/FEXCore/unittests/Emitter/Scalar_Tests.cpp
+++ b/External/FEXCore/unittests/Emitter/Scalar_Tests.cpp
@@ -658,7 +658,7 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Scalar: Floating-point data-process
   TEST_SINGLE(fcvt(SReg::s30, DReg::d29), "fcvt s30, d29");
   if (false) {
     // vixl doesn't support this instruction.
-    TEST_SINGLE(bfcvt(HReg::h30, DReg::d29), "bfcvt h30, d29");
+    TEST_SINGLE(bfcvt(HReg::h30, SReg::s29), "bfcvt h30, s29");
   }
   TEST_SINGLE(fcvt(HReg::h30, DReg::d29), "fcvt h30, d29");
   TEST_SINGLE(frintn(DReg::d30, DReg::d29), "frintn d30, d29");


### PR DESCRIPTION
These can create conversion ambiguity compiler errors and in the worst case, cause the wrong thing to happen. So we can get rid of all the implicit conversion operators, except for the the one to `VRegister`, since it's supposed to be the catch-all type.

For the other cases, we already have explicit conversion functions that can be used instead to specify behavior.

This also catches a few cases where the wrong conversion functions were being called, but happened to work, since they'd implicitly be converted to the right type.