### PR TITLE
ARMEmitter: Remove implicit conversions from Register/XRegister/WRegister

### DIFF
--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ALUOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ALUOps.inl
@@ -710,28 +710,28 @@ public:
     DataProcessing_3Source(Op, 0, s, rd, rn, rm, ra);
   }
   void mul(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
-    madd(s, rd, rn, rm, FEXCore::ARMEmitter::Reg::zr);
+    madd(s, rd, rn, rm, XReg::zr);
   }
   void msub(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::Register ra) {
     constexpr uint32_t Op = 0b001'1011'000U << 21;
     DataProcessing_3Source(Op, 1, s, rd, rn, rm, ra);
   }
   void mneg(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm) {
-    msub(s, rd, rn, rm, FEXCore::ARMEmitter::Reg::zr);
+    msub(s, rd, rn, rm, XReg::zr);
   }
   void smaddl(FEXCore::ARMEmitter::XRegister rd, FEXCore::ARMEmitter::WRegister rn, FEXCore::ARMEmitter::WRegister rm, FEXCore::ARMEmitter::XRegister ra) {
     constexpr uint32_t Op = 0b001'1011'001U << 21;
     DataProcessing_3Source(Op, 0, FEXCore::ARMEmitter::Size::i64Bit, rd, rn, rm, ra);
   }
   void smull(FEXCore::ARMEmitter::XRegister rd, FEXCore::ARMEmitter::WRegister rn, FEXCore::ARMEmitter::WRegister rm) {
-    smaddl(rd, rn, rm, FEXCore::ARMEmitter::Reg::zr);
+    smaddl(rd, rn, rm, XReg::zr);
   }
   void smsubl(FEXCore::ARMEmitter::XRegister rd, FEXCore::ARMEmitter::WRegister rn, FEXCore::ARMEmitter::WRegister rm, FEXCore::ARMEmitter::XRegister ra) {
     constexpr uint32_t Op = 0b001'1011'001U << 21;
     DataProcessing_3Source(Op, 1, FEXCore::ARMEmitter::Size::i64Bit, rd, rn, rm, ra);
   }
   void smnegl(FEXCore::ARMEmitter::XRegister rd, FEXCore::ARMEmitter::WRegister rn, FEXCore::ARMEmitter::WRegister rm) {
-    smsubl(rd, rn, rm, FEXCore::ARMEmitter::Reg::zr);
+    smsubl(rd, rn, rm, XReg::zr);
   }
   void smulh(FEXCore::ARMEmitter::XRegister rd, FEXCore::ARMEmitter::XRegister rn, FEXCore::ARMEmitter::XRegister rm) {
     constexpr uint32_t Op = 0b001'1011'010U << 21;
@@ -742,14 +742,14 @@ public:
     DataProcessing_3Source(Op, 0, FEXCore::ARMEmitter::Size::i64Bit, rd, rn, rm, ra);
   }
   void umull(FEXCore::ARMEmitter::XRegister rd, FEXCore::ARMEmitter::WRegister rn, FEXCore::ARMEmitter::WRegister rm) {
-    umaddl(rd, rn, rm, FEXCore::ARMEmitter::Reg::zr);
+    umaddl(rd, rn, rm, XReg::zr);
   }
   void umsubl(FEXCore::ARMEmitter::XRegister rd, FEXCore::ARMEmitter::WRegister rn, FEXCore::ARMEmitter::WRegister rm, FEXCore::ARMEmitter::XRegister ra) {
     constexpr uint32_t Op = 0b001'1011'101U << 21;
     DataProcessing_3Source(Op, 1, FEXCore::ARMEmitter::Size::i64Bit, rd, rn, rm, ra);
   }
   void umnegl(FEXCore::ARMEmitter::XRegister rd, FEXCore::ARMEmitter::WRegister rn, FEXCore::ARMEmitter::WRegister rm) {
-    umsubl(rd, rn, rm, FEXCore::ARMEmitter::Reg::zr);
+    umsubl(rd, rn, rm, XReg::zr);
   }
   void umulh(FEXCore::ARMEmitter::XRegister rd, FEXCore::ARMEmitter::XRegister rn, FEXCore::ARMEmitter::XRegister rm) {
     constexpr uint32_t Op = 0b001'1011'110U << 21;

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/Registers.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/Registers.h
@@ -24,9 +24,6 @@ namespace FEXCore::ARMEmitter {
         return Index;
       }
 
-      operator WRegister() const;
-      operator XRegister() const;
-
       WRegister W() const;
       XRegister X() const;
 
@@ -56,10 +53,7 @@ namespace FEXCore::ARMEmitter {
         return Register(Index);
       }
 
-      operator XRegister() const;
-
       XRegister X() const;
-
       Register R() const;
 
     private:
@@ -88,10 +82,7 @@ namespace FEXCore::ARMEmitter {
         return Register(Index);
       }
 
-      operator WRegister() const;
-
       WRegister W() const;
-
       Register R() const;
 
     private:
@@ -102,43 +93,27 @@ namespace FEXCore::ARMEmitter {
   static_assert(std::is_standard_layout_v<Register>, "Needs to be standard");
 
   inline WRegister Register::W() const {
-    return *this;
+    return WRegister{Index};
   }
 
   inline XRegister Register::X() const {
-    return *this;
-  }
-
-  inline Register::operator WRegister () const {
-    return WRegister(Index);
-  }
-
-  inline Register::operator XRegister () const {
-    return XRegister(Index);
+    return XRegister{Index};
   }
 
   inline XRegister WRegister::X() const {
-    return *this;
+    return XRegister{Index};
   }
 
   inline Register WRegister::R() const {
     return *this;
   }
 
-  inline WRegister::operator XRegister () const {
-    return XRegister(Index);
-  }
-
   inline WRegister XRegister::W() const {
-    return *this;
+    return WRegister{Index};
   }
 
   inline Register XRegister::R() const {
     return *this;
-  }
-
-  inline XRegister::operator WRegister () const {
-    return WRegister(Index);
   }
 
   // Namespace containing all unsized GPR register objects.

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
@@ -970,15 +970,15 @@ public:
     LOGMAN_THROW_A_FMT(increment >= -16 && increment <= 15, "increment value must be within -16-15. increment: {}", increment);
     SVEIndexGeneration(0b00, size, zd, initial, increment);
   }
-  void index(SubRegSize size, ZRegister zd, XRegister initial, int32_t increment) {
+  void index(SubRegSize size, ZRegister zd, Register initial, int32_t increment) {
     LOGMAN_THROW_A_FMT(increment >= -16 && increment <= 15, "increment value must be within -16-15. increment: {}", increment);
     SVEIndexGeneration(0b01, size, zd, static_cast<int32_t>(initial.Idx()), increment);
   }
-  void index(SubRegSize size, ZRegister zd, int32_t initial, XRegister increment) {
+  void index(SubRegSize size, ZRegister zd, int32_t initial, Register increment) {
     LOGMAN_THROW_A_FMT(initial >= -16 && initial <= 15, "initial value must be within -16-15. initial: {}", initial);
     SVEIndexGeneration(0b10, size, zd, initial, static_cast<int32_t>(increment.Idx()));
   }
-  void index(SubRegSize size, ZRegister zd, XRegister initial, XRegister increment) {
+  void index(SubRegSize size, ZRegister zd, Register initial, Register increment) {
     SVEIndexGeneration(0b11, size, zd, static_cast<int32_t>(initial.Idx()), static_cast<int32_t>(increment.Idx()));
   }
 
@@ -1165,7 +1165,7 @@ public:
   }
 
   // CPY (scalar)
-  void cpy(SubRegSize size, ZRegister zd, PRegisterMerge pg, WRegister rn) {
+  void cpy(SubRegSize size, ZRegister zd, PRegisterMerge pg, Register rn) {
     SVEPermuteVectorPredicated(0b01000, 0b1, size, zd, pg, ZRegister{rn.Idx()});
   }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -262,13 +262,13 @@ DEF_OP(MulH) {
   const auto Src2 = GetReg(Op->Src2.ID());
 
   if (OpSize == 4) {
-    sxtw(TMP1, Src1);
-    sxtw(TMP2, Src2);
+    sxtw(TMP1, Src1.X());
+    sxtw(TMP2, Src2.X());
     mul(ARMEmitter::Size::i32Bit, Dst, TMP1, TMP2);
     ubfx(ARMEmitter::Size::i32Bit, Dst, Dst, 32, 32);
   }
   else {
-    smulh(Dst, Src1, Src2);
+    smulh(Dst.X(), Src1.X(), Src2.X());
   }
 }
 
@@ -289,7 +289,7 @@ DEF_OP(UMulH) {
     ubfx(ARMEmitter::Size::i64Bit, Dst, Dst, 32, 32);
   }
   else {
-    umulh(Dst, Src1, Src2);
+    umulh(Dst.X(), Src1.X(), Src2.X());
   }
 }
 
@@ -610,7 +610,7 @@ DEF_OP(LDiv) {
     case 4: {
       mov(EmitSize, TMP1, Lower);
       bfi(EmitSize, TMP1, Upper, 32, 32);
-      sxtw(TMP2, Divisor);
+      sxtw(TMP2, Divisor.X());
       sdiv(EmitSize, Dst, TMP1, TMP2);
     break;
     }
@@ -744,7 +744,7 @@ DEF_OP(LRem) {
     case 4: {
       mov(EmitSize, TMP1, Lower);
       bfi(EmitSize, TMP1, Upper, 32, 32);
-      sxtw(TMP3, Divisor);
+      sxtw(TMP3, Divisor.X());
       sdiv(EmitSize, TMP2, TMP1, TMP3);
       msub(EmitSize, Dst, TMP2, TMP3, TMP1);
     break;

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/EncryptionOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/EncryptionOps.cpp
@@ -137,7 +137,7 @@ DEF_OP(CRC32) {
       crc32cw(Dst.W(), Src1.W(), Src2.W());
       break;
     case 8:
-      crc32cx(Dst, Src1, Src2);
+      crc32cx(Dst.X(), Src1.X(), Src2.X());
       break;
     default: LOGMAN_MSG_A_FMT("Unknown CRC32 size: {}", Op->SrcSize);
   }

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -911,20 +911,20 @@ FEXCore::ARMEmitter::ExtendedMemOperand Arm64JITCore::GenerateMemOperand(uint8_t
                                             IR::MemOffsetType OffsetType,
                                             uint8_t OffsetScale) {
   if (Offset.IsInvalid()) {
-    return FEXCore::ARMEmitter::ExtendedMemOperand(Base, ARMEmitter::IndexType::OFFSET, 0);
+    return ARMEmitter::ExtendedMemOperand(Base.X(), ARMEmitter::IndexType::OFFSET, 0);
   } else {
     if (OffsetScale != 1 && OffsetScale != AccessSize) {
       LOGMAN_MSG_A_FMT("Unhandled GenerateMemOperand OffsetScale: {}", OffsetScale);
     }
     uint64_t Const;
     if (IsInlineConstant(Offset, &Const)) {
-      return FEXCore::ARMEmitter::ExtendedMemOperand(Base, ARMEmitter::IndexType::OFFSET, Const);
+      return ARMEmitter::ExtendedMemOperand(Base.X(), ARMEmitter::IndexType::OFFSET, Const);
     } else {
       auto RegOffset = GetReg(Offset.ID());
       switch(OffsetType.Val) {
-        case IR::MEM_OFFSET_SXTX.Val: return FEXCore::ARMEmitter::ExtendedMemOperand(Base, RegOffset, FEXCore::ARMEmitter::ExtendedType::SXTX, (int)std::log2(OffsetScale) );
-        case IR::MEM_OFFSET_UXTW.Val: return FEXCore::ARMEmitter::ExtendedMemOperand(Base, RegOffset, FEXCore::ARMEmitter::ExtendedType::UXTW, (int)std::log2(OffsetScale) );
-        case IR::MEM_OFFSET_SXTW.Val: return FEXCore::ARMEmitter::ExtendedMemOperand(Base, RegOffset, FEXCore::ARMEmitter::ExtendedType::SXTW, (int)std::log2(OffsetScale) );
+        case IR::MEM_OFFSET_SXTX.Val: return ARMEmitter::ExtendedMemOperand(Base.X(), RegOffset.X(), ARMEmitter::ExtendedType::SXTX, (int)std::log2(OffsetScale) );
+        case IR::MEM_OFFSET_UXTW.Val: return ARMEmitter::ExtendedMemOperand(Base.X(), RegOffset.X(), ARMEmitter::ExtendedType::UXTW, (int)std::log2(OffsetScale) );
+        case IR::MEM_OFFSET_SXTW.Val: return ARMEmitter::ExtendedMemOperand(Base.X(), RegOffset.X(), ARMEmitter::ExtendedType::SXTW, (int)std::log2(OffsetScale) );
         default: LOGMAN_MSG_A_FMT("Unhandled GenerateMemOperand OffsetType: {}", OffsetType.Val); break;
       }
     }
@@ -1101,14 +1101,14 @@ DEF_OP(LoadMemTSO) {
     const auto Dst = GetReg(Node);
     if (OpSize == 1) {
       // 8bit load is always aligned to natural alignment
-      ldaprb(Dst, MemReg);
+      ldaprb(Dst.W(), MemReg);
     }
     else {
       // Aligned
       nop();
       switch (OpSize) {
         case 2:
-          ldaprh(Dst, MemReg);
+          ldaprh(Dst.W(), MemReg);
           break;
         case 4:
           ldapr(Dst.W(), MemReg);

--- a/External/FEXCore/unittests/Emitter/ALU_Tests.cpp
+++ b/External/FEXCore/unittests/Emitter/ALU_Tests.cpp
@@ -1504,8 +1504,8 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: ALU: Rotate right into flags") {
   TEST_SINGLE(rmif(XReg::x30, 63, 0b1111), "rmif x30, #63, #NZCV");
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: ALU: Evaluate into flags") {
-  TEST_SINGLE(setf8(XReg::x30),  "setf8 w30");
-  TEST_SINGLE(setf16(XReg::x30), "setf16 w30");
+  TEST_SINGLE(setf8(WReg::w30),  "setf8 w30");
+  TEST_SINGLE(setf16(WReg::w30), "setf16 w30");
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: ALU: Conditional compare - register") {
   TEST_SINGLE(ccmn(Size::i32Bit, Reg::r29, Reg::r28, StatusFlags::None, Condition::CC_AL), "ccmn w29, w28, #nzcv, al");

--- a/External/FEXCore/unittests/Emitter/Loadstore_Tests.cpp
+++ b/External/FEXCore/unittests/Emitter/Loadstore_Tests.cpp
@@ -1028,7 +1028,7 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Loadstore exclusive regi
   TEST_SINGLE(ldaxr(WReg::w30, Reg::r29), "ldaxr w30, [x29]");
 
   TEST_SINGLE(stxr(XReg::x30, XReg::x29, Reg::r28), "stxr w30, x29, [x28]");
-  TEST_SINGLE(stlxr(XReg::x30, XReg::x29, Reg::r28), "stlxr w30, x29, [x28]");
+  TEST_SINGLE(stlxr(WReg::w30, XReg::x29, Reg::r28), "stlxr w30, x29, [x28]");
 
   TEST_SINGLE(ldxr(XReg::x30, Reg::r29), "ldxr x30, [x29]");
   TEST_SINGLE(ldaxr(XReg::x30, Reg::r29), "ldaxr x30, [x29]");
@@ -1319,8 +1319,8 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Loadstore register pair 
   TEST_SINGLE(ldp<IndexType::POST>(WReg::w30, WReg::w28, Reg::r29, -256), "ldp w30, w28, [x29], #-256");
   TEST_SINGLE(ldp<IndexType::POST>(WReg::w30, WReg::w28, Reg::r29, 252), "ldp w30, w28, [x29], #252");
 
-  TEST_SINGLE(ldpsw<IndexType::POST>(XReg::x30, WReg::w28, Reg::r29, -256), "ldpsw x30, x28, [x29], #-256");
-  TEST_SINGLE(ldpsw<IndexType::POST>(XReg::x30, WReg::w28, Reg::r29, 252), "ldpsw x30, x28, [x29], #252");
+  TEST_SINGLE(ldpsw<IndexType::POST>(XReg::x30, XReg::x28, Reg::r29, -256), "ldpsw x30, x28, [x29], #-256");
+  TEST_SINGLE(ldpsw<IndexType::POST>(XReg::x30, XReg::x28, Reg::r29, 252), "ldpsw x30, x28, [x29], #252");
 
   TEST_SINGLE(stp<IndexType::POST>(XReg::x30, XReg::x28, Reg::r29, -512), "stp x30, x28, [x29], #-512");
   TEST_SINGLE(stp<IndexType::POST>(XReg::x30, XReg::x28, Reg::r29, 504), "stp x30, x28, [x29], #504");
@@ -1353,8 +1353,8 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Loadstore register pair 
   TEST_SINGLE(ldp<IndexType::OFFSET>(WReg::w30, WReg::w28, Reg::r29, -256), "ldp w30, w28, [x29, #-256]");
   TEST_SINGLE(ldp<IndexType::OFFSET>(WReg::w30, WReg::w28, Reg::r29, 252), "ldp w30, w28, [x29, #252]");
 
-  TEST_SINGLE(ldpsw<IndexType::OFFSET>(XReg::x30, WReg::w28, Reg::r29, -256), "ldpsw x30, x28, [x29, #-256]");
-  TEST_SINGLE(ldpsw<IndexType::OFFSET>(XReg::x30, WReg::w28, Reg::r29, 252), "ldpsw x30, x28, [x29, #252]");
+  TEST_SINGLE(ldpsw<IndexType::OFFSET>(XReg::x30, XReg::x28, Reg::r29, -256), "ldpsw x30, x28, [x29, #-256]");
+  TEST_SINGLE(ldpsw<IndexType::OFFSET>(XReg::x30, XReg::x28, Reg::r29, 252), "ldpsw x30, x28, [x29, #252]");
 
   TEST_SINGLE(stp<IndexType::OFFSET>(XReg::x30, XReg::x28, Reg::r29, -512), "stp x30, x28, [x29, #-512]");
   TEST_SINGLE(stp<IndexType::OFFSET>(XReg::x30, XReg::x28, Reg::r29, 504), "stp x30, x28, [x29, #504]");
@@ -1387,8 +1387,8 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Loadstore register pair 
   TEST_SINGLE(ldp<IndexType::PRE>(WReg::w30, WReg::w28, Reg::r29, -256), "ldp w30, w28, [x29, #-256]!");
   TEST_SINGLE(ldp<IndexType::PRE>(WReg::w30, WReg::w28, Reg::r29, 252), "ldp w30, w28, [x29, #252]!");
 
-  TEST_SINGLE(ldpsw<IndexType::PRE>(XReg::x30, WReg::w28, Reg::r29, -256), "ldpsw x30, x28, [x29, #-256]!");
-  TEST_SINGLE(ldpsw<IndexType::PRE>(XReg::x30, WReg::w28, Reg::r29, 252), "ldpsw x30, x28, [x29, #252]!");
+  TEST_SINGLE(ldpsw<IndexType::PRE>(XReg::x30, XReg::x28, Reg::r29, -256), "ldpsw x30, x28, [x29, #-256]!");
+  TEST_SINGLE(ldpsw<IndexType::PRE>(XReg::x30, XReg::x28, Reg::r29, 252), "ldpsw x30, x28, [x29, #252]!");
 
   TEST_SINGLE(stp<IndexType::PRE>(XReg::x30, XReg::x28, Reg::r29, -512), "stp x30, x28, [x29, #-512]!");
   TEST_SINGLE(stp<IndexType::PRE>(XReg::x30, XReg::x28, Reg::r29, 504), "stp x30, x28, [x29, #504]!");


### PR DESCRIPTION
Ensures that we're always explicit about the size of a register when using APIs that enforce it.

The only implicit conversions we keep are conversions that convert down to Register, but not anything that converts up the hierarchy or across it.