### PR TITLE
ARMEmitter: Make second sxtw parameter a WRegister

### DIFF
--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ALUOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ALUOps.inl
@@ -257,8 +257,8 @@ public:
   void sxth(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn) {
     sbfm(s, rd, rn, 0, 15);
   }
-  void sxtw(FEXCore::ARMEmitter::XRegister rd, FEXCore::ARMEmitter::XRegister rn) {
-    sbfm(ARMEmitter::Size::i64Bit, rd, rn, 0, 31);
+  void sxtw(FEXCore::ARMEmitter::XRegister rd, FEXCore::ARMEmitter::WRegister rn) {
+    sbfm(ARMEmitter::Size::i64Bit, rd, rn.X(), 0, 31);
   }
   void sbfx(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, uint32_t lsb, uint32_t width) {
     LOGMAN_THROW_A_FMT(width > 0, "sbfx needs width > 0");

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -262,8 +262,8 @@ DEF_OP(MulH) {
   const auto Src2 = GetReg(Op->Src2.ID());
 
   if (OpSize == 4) {
-    sxtw(TMP1, Src1.X());
-    sxtw(TMP2, Src2.X());
+    sxtw(TMP1, Src1.W());
+    sxtw(TMP2, Src2.W());
     mul(ARMEmitter::Size::i32Bit, Dst, TMP1, TMP2);
     ubfx(ARMEmitter::Size::i32Bit, Dst, Dst, 32, 32);
   }
@@ -610,7 +610,7 @@ DEF_OP(LDiv) {
     case 4: {
       mov(EmitSize, TMP1, Lower);
       bfi(EmitSize, TMP1, Upper, 32, 32);
-      sxtw(TMP2, Divisor.X());
+      sxtw(TMP2, Divisor.W());
       sdiv(EmitSize, Dst, TMP1, TMP2);
     break;
     }
@@ -744,7 +744,7 @@ DEF_OP(LRem) {
     case 4: {
       mov(EmitSize, TMP1, Lower);
       bfi(EmitSize, TMP1, Upper, 32, 32);
-      sxtw(TMP3, Divisor.X());
+      sxtw(TMP3, Divisor.W());
       sdiv(EmitSize, TMP2, TMP1, TMP3);
       msub(EmitSize, Dst, TMP2, TMP3, TMP1);
     break;

--- a/External/FEXCore/unittests/Emitter/ALU_Tests.cpp
+++ b/External/FEXCore/unittests/Emitter/ALU_Tests.cpp
@@ -390,7 +390,7 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: ALU: Bitfield") {
   TEST_SINGLE(sxth(Size::i32Bit, Reg::r29, Reg::r28), "sxth w29, w28");
   TEST_SINGLE(sxth(Size::i64Bit, Reg::r29, Reg::r28), "sxth x29, w28");
 
-  TEST_SINGLE(sxtw(XReg::x29, XReg::x28), "sxtw x29, w28");
+  TEST_SINGLE(sxtw(XReg::x29, WReg::w28), "sxtw x29, w28");
 
   TEST_SINGLE(sbfx(Size::i32Bit, Reg::r29, Reg::r28, 4, 16), "sbfx w29, w28, #4, #16");
   TEST_SINGLE(sbfx(Size::i64Bit, Reg::r29, Reg::r28, 4, 16), "sbfx x29, x28, #4, #16");


### PR DESCRIPTION
Matches the assembly use of it more closely.