### PR TITLE
OpcodeDispatcher: Optimize REP STOS to MemSet operation

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -154,6 +154,7 @@ constexpr OpHandlerArray InterpreterOpHandlers = [] {
   REGISTER_OP(STOREMEM,               StoreMem);
   REGISTER_OP(LOADMEMTSO,             LoadMem);
   REGISTER_OP(STOREMEMTSO,            StoreMem);
+  REGISTER_OP(MEMSET,                 MemSet);
   REGISTER_OP(CACHELINECLEAR,         CacheLineClear);
   REGISTER_OP(CACHELINECLEAN,         CacheLineClean);
   REGISTER_OP(CACHELINEZERO,          CacheLineZero);

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
@@ -181,6 +181,7 @@ namespace FEXCore::CPU {
   DEF_OP(StoreFlag);
   DEF_OP(LoadMem);
   DEF_OP(StoreMem);
+  DEF_OP(MemSet);
   DEF_OP(CacheLineClear);
   DEF_OP(CacheLineClean);
   DEF_OP(CacheLineZero);

--- a/External/FEXCore/Source/Interface/Core/Interpreter/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/MemoryOps.cpp
@@ -288,6 +288,111 @@ DEF_OP(StoreMem) {
   }
 }
 
+DEF_OP(MemSet) {
+  const auto Op = IROp->C<IR::IROp_MemSet>();
+  const int32_t Size = Op->Size;
+
+  char *MemData = *GetSrc<char **>(Data->SSAData, Op->Addr);
+  const auto Value = *GetSrc<uint64_t*>(Data->SSAData, Op->Value);
+  const auto Length = *GetSrc<uint64_t*>(Data->SSAData, Op->Length);
+  const auto Direction = *GetSrc<uint8_t*>(Data->SSAData, Op->Direction);
+
+  auto MemSetElements = [](auto* Memory, uint64_t Value, size_t Length) {
+    for (size_t i = 0; i < Length; ++i) {
+      Memory[i] = Value;
+    }
+  };
+
+  auto MemSetElementsInverse = [](auto* Memory, uint64_t Value, size_t Length) {
+    for (size_t i = 0; i < Length; ++i) {
+      Memory[-i] = Value;
+    }
+  };
+
+  if (Direction == 0) { // Forward
+    if (Op->IsAtomic) {
+      switch (Size) {
+        case 1:
+          MemSetElements(reinterpret_cast<std::atomic<uint8_t>*>(MemData), Value, Length);
+          break;
+        case 2:
+          MemSetElements(reinterpret_cast<std::atomic<uint16_t>*>(MemData), Value, Length);
+          break;
+        case 4:
+          MemSetElements(reinterpret_cast<std::atomic<uint32_t>*>(MemData), Value, Length);
+          break;
+        case 8:
+          MemSetElements(reinterpret_cast<std::atomic<uint64_t>*>(MemData), Value, Length);
+          break;
+        default:
+          LOGMAN_MSG_A_FMT("Unhandled {} size: {}", __func__, Size);
+          break;
+      }
+    }
+    else {
+      switch (Size) {
+        case 1:
+          MemSetElements(reinterpret_cast<uint8_t*>(MemData), Value, Length);
+          break;
+        case 2:
+          MemSetElements(reinterpret_cast<uint16_t*>(MemData), Value, Length);
+          break;
+        case 4:
+          MemSetElements(reinterpret_cast<uint32_t*>(MemData), Value, Length);
+          break;
+        case 8:
+          MemSetElements(reinterpret_cast<uint64_t*>(MemData), Value, Length);
+          break;
+        default:
+          LOGMAN_MSG_A_FMT("Unhandled {} size: {}", __func__, Size);
+          break;
+      }
+    }
+    GD = reinterpret_cast<uint64_t>(MemData + (Length * Size));
+  }
+  else { // Backward
+    if (Op->IsAtomic) {
+      switch (Size) {
+        case 1:
+          MemSetElementsInverse(reinterpret_cast<std::atomic<uint8_t>*>(MemData), Value, Length);
+          break;
+        case 2:
+          MemSetElementsInverse(reinterpret_cast<std::atomic<uint16_t>*>(MemData), Value, Length);
+          break;
+        case 4:
+          MemSetElementsInverse(reinterpret_cast<std::atomic<uint32_t>*>(MemData), Value, Length);
+          break;
+        case 8:
+          MemSetElementsInverse(reinterpret_cast<std::atomic<uint64_t>*>(MemData), Value, Length);
+          break;
+        default:
+          LOGMAN_MSG_A_FMT("Unhandled {} size: {}", __func__, Size);
+          break;
+      }
+    }
+    else {
+      switch (Size) {
+        case 1:
+          MemSetElementsInverse(reinterpret_cast<uint8_t*>(MemData), Value, Length);
+          break;
+        case 2:
+          MemSetElementsInverse(reinterpret_cast<uint16_t*>(MemData), Value, Length);
+          break;
+        case 4:
+          MemSetElementsInverse(reinterpret_cast<uint32_t*>(MemData), Value, Length);
+          break;
+        case 8:
+          MemSetElementsInverse(reinterpret_cast<uint64_t*>(MemData), Value, Length);
+          break;
+        default:
+          LOGMAN_MSG_A_FMT("Unhandled {} size: {}", __func__, Size);
+          break;
+      }
+    }
+    GD = reinterpret_cast<uint64_t>(MemData - (Length * Size));
+  }
+}
+
 DEF_OP(CacheLineClear) {
   auto Op = IROp->C<IR::IROp_CacheLineClear>();
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -899,6 +899,8 @@ CPUBackend::CompiledCode Arm64JITCore::CompileCode(uint64_t Entry,
             Op_StoreMemTSO(IROp, ID);
           }
           break;
+
+        REGISTER_OP(MEMSET,              MemSet);
         REGISTER_OP(CACHELINECLEAR,      CacheLineClear);
         REGISTER_OP(CACHELINECLEAN,      CacheLineClean);
         REGISTER_OP(CACHELINEZERO,       CacheLineZero);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -349,6 +349,7 @@ private:
   DEF_OP(StoreMem);
   DEF_OP(LoadMemTSO);
   DEF_OP(StoreMemTSO);
+  DEF_OP(MemSet);
   DEF_OP(ParanoidLoadMemTSO);
   DEF_OP(ParanoidStoreMemTSO);
   DEF_OP(CacheLineClear);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -344,6 +344,7 @@ private:
   DEF_OP(StoreFlag);
   DEF_OP(LoadMem);
   DEF_OP(StoreMem);
+  DEF_OP(MemSet);
   DEF_OP(CacheLineClear);
   DEF_OP(CacheLineClean);
   DEF_OP(CacheLineZero);

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -889,6 +889,8 @@ private:
   #undef OpcodeArgs
 
   OrderedNode *AppendSegmentOffset(OrderedNode *Value, uint32_t Flags, uint32_t DefaultPrefix = 0, bool Override = false);
+  OrderedNode *GetSegment(uint32_t Flags, uint32_t DefaultPrefix = 0, bool Override = false);
+
   void UpdatePrefixFromSegment(OrderedNode *Segment, uint32_t SegmentReg);
 
   enum class MemoryAccessType {

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -476,6 +476,14 @@
         ]
       },
 
+      "GPR = MemSet i1:$IsAtomic, u8:$Size, GPR:$Prefix, GPR:$Addr, GPR:$Value, GPR:$Length, GPR:$Direction": {
+        "Desc": ["Duplicates behaviour of x86 STOS repeat",
+                 "Returns the final address that gets generated without the prefix appended."
+                ],
+        "HasSideEffects": true,
+        "DestSize": "8"
+      },
+
       "CacheLineClear GPR:$Addr, i1:$Serialize": {
         "Desc": ["Does a 64 byte cacheline clear at the address specified",
                  "Only clears the data cachelines. Doesn't do any zeroing",


### PR DESCRIPTION
x86's REP STOS instruction is a memset (with element size!) with the
ability to choose a direction of execution.
Additionally it has a feature where if it faults part-way through the
copy, an application can catch the fault and continue afterwards to know
how many bytes got copied.

RCX is the counter which decrements for each element, and RDI is the
memory pointer. On fault these will reflect the last location that was
attempted to be written. FEX doesn't support this behaviour which makes
our lives easier.

Without supporting that feature, this turns in to a directional memset
by element size. Let's remove all the multiple blocks and just emit a
single IR operation to improve performance of the JIT.
Our generated code here was terrible, the IR was terrible, multiblock is
always slow with RA. Just a general overall improvement.

With profiling pressure-vessel this change deletes the hottest block that
appeared in the trace. This instruction is very commonly used for
memsetting a region to zero so it should be quite fast.

We can also optimize REP MOVS in the future with a Memcpy IR operation
in a similar fashion.

Additionally in the future these can be optimized to use ARM's new MOPS
instructions since the most common case is memset by byte. Which is when
we should expose the "Fast REP STOS" CPUID bit. Both setp/setm/sete and
cpyfp/cpyfm/cpyfe match `REP STOS` and `REP MOVS` respectively.

This shaves a decent amount of time off of pressure-vessel initialization time, but I'll need to spend time doing some microbenching to see the exact impact. Also testing real games to see how much they improve.