### PR TITLE
FileManagement: Fixes Proton

### DIFF
--- a/Source/Tests/LinuxSyscalls/FileManagement.cpp
+++ b/Source/Tests/LinuxSyscalls/FileManagement.cpp
@@ -393,12 +393,13 @@ std::string FileManager::GetEmulatedPath(const char *pathname, bool FollowSymlin
   return Path;
 }
 
-std::pair<int, const char*> FileManager::GetEmulatedFDPath(const char *pathname, bool FollowSymlink, FDPathTmpData &TmpFilename) {
+std::pair<int, const char*> FileManager::GetEmulatedFDPath(int dirfd, const char *pathname, bool FollowSymlink, FDPathTmpData &TmpFilename) {
   constexpr auto NoEntry = std::make_pair(-1, nullptr);
 
   if (!pathname || // If no pathname
       pathname[0] != '/' || // If relative
-      pathname[1] == 0) { // If we are getting root
+      pathname[1] == 0 || // If we are getting root
+      dirfd != AT_FDCWD) { // If dirfd isn't special FDCWD
     return NoEntry;
   }
 
@@ -473,16 +474,35 @@ std::optional<std::string> FileManager::GetSelf(const char *Pathname) {
   return Pathname;
 }
 
-uint64_t FileManager::Open(const char *pathname, [[maybe_unused]] int flags, [[maybe_unused]] uint32_t mode) {
+static bool ShouldSkipOpenInEmu(int flags) {
+  if (flags & O_CREAT) {
+    // If trying to create a file then skip checking in emufd
+    return true;
+  }
+
+  if (flags & O_WRONLY) {
+    // If the file is trying to be open with write permissions then skip.
+    return true;
+  }
+
+  if (flags & O_APPEND) {
+    // If the file is trying to be open with append options then skip.
+    return true;
+  }
+
+  return false;
+}
+
+uint64_t FileManager::Open(const char *pathname, int flags, uint32_t mode) {
   auto NewPath = GetSelf(pathname);
   const char *SelfPath = NewPath ? NewPath->c_str() : nullptr;
   int fd = -1;
 
-  if (!((flags & O_CREAT) || (mode & O_WRONLY))) {
+  if (!ShouldSkipOpenInEmu(flags)) {
     fd = EmuFD.OpenAt(AT_FDCWD, SelfPath, flags, mode);
     if (fd == -1) {
       FDPathTmpData TmpFilename;
-      auto Path = GetEmulatedFDPath(SelfPath, true, TmpFilename);
+      auto Path = GetEmulatedFDPath(AT_FDCWD, SelfPath, true, TmpFilename);
       if (Path.first != -1) {
         fd = ::openat(Path.first, Path.second, flags, mode);
       }
@@ -531,7 +551,7 @@ uint64_t FileManager::Stat(const char *pathname, void *buf) {
 
   // Stat follows symlinks
   FDPathTmpData TmpFilename;
-  auto Path = GetEmulatedFDPath(SelfPath, true, TmpFilename);
+  auto Path = GetEmulatedFDPath(AT_FDCWD, SelfPath, true, TmpFilename);
   if (Path.first != -1) {
     uint64_t Result = ::fstatat(Path.first, Path.second, reinterpret_cast<struct stat*>(buf), 0);
     if (Result != -1)
@@ -546,7 +566,7 @@ uint64_t FileManager::Lstat(const char *pathname, void *buf) {
 
   // lstat does not follow symlinks
   FDPathTmpData TmpFilename;
-  auto Path = GetEmulatedFDPath(SelfPath, false, TmpFilename);
+  auto Path = GetEmulatedFDPath(AT_FDCWD, SelfPath, false, TmpFilename);
   if (Path.first != -1) {
     uint64_t Result = ::fstatat(Path.first, Path.second, reinterpret_cast<struct stat*>(buf), AT_SYMLINK_NOFOLLOW);
     if (Result != -1)
@@ -562,13 +582,12 @@ uint64_t FileManager::Access(const char *pathname, [[maybe_unused]] int mode) {
 
   // Access follows symlinks
   FDPathTmpData TmpFilename;
-  auto Path = GetEmulatedFDPath(SelfPath, true, TmpFilename);
+  auto Path = GetEmulatedFDPath(AT_FDCWD, SelfPath, true, TmpFilename);
   if (Path.first != -1) {
     uint64_t Result = ::faccessat(Path.first, Path.second, mode, 0);
     if (Result != -1)
       return Result;
   }
-
   return ::access(SelfPath, mode);
 }
 
@@ -577,7 +596,7 @@ uint64_t FileManager::FAccessat(int dirfd, const char *pathname, int mode) {
   const char *SelfPath = NewPath ? NewPath->c_str() : nullptr;
 
   FDPathTmpData TmpFilename;
-  auto Path = GetEmulatedFDPath(SelfPath, true, TmpFilename);
+  auto Path = GetEmulatedFDPath(dirfd, SelfPath, true, TmpFilename);
   if (Path.first != -1) {
     uint64_t Result = ::syscall(SYSCALL_DEF(faccessat2), Path.first, Path.second, mode, 0);
     if (Result != -1)
@@ -592,7 +611,7 @@ uint64_t FileManager::FAccessat2(int dirfd, const char *pathname, int mode, int 
   const char *SelfPath = NewPath ? NewPath->c_str() : nullptr;
 
   FDPathTmpData TmpFilename;
-  auto Path = GetEmulatedFDPath(SelfPath, (flags & AT_SYMLINK_NOFOLLOW) == 0, TmpFilename);
+  auto Path = GetEmulatedFDPath(dirfd, SelfPath, (flags & AT_SYMLINK_NOFOLLOW) == 0, TmpFilename);
   if (Path.first != -1) {
     uint64_t Result = ::syscall(SYSCALL_DEF(faccessat2), Path.first, Path.second, mode, flags);
     if (Result != -1)
@@ -617,7 +636,7 @@ uint64_t FileManager::Readlink(const char *pathname, char *buf, size_t bufsiz) {
   }
 
   FDPathTmpData TmpFilename;
-  auto Path = GetEmulatedFDPath(pathname, false, TmpFilename);
+  auto Path = GetEmulatedFDPath(AT_FDCWD, pathname, false, TmpFilename);
   if (Path.first != -1) {
     uint64_t Result = ::readlinkat(Path.first, Path.second, buf, bufsiz);
     if (Result != -1)
@@ -639,13 +658,12 @@ uint64_t FileManager::Chmod(const char *pathname, mode_t mode) {
   const char *SelfPath = NewPath ? NewPath->c_str() : nullptr;
 
   FDPathTmpData TmpFilename;
-  auto Path = GetEmulatedFDPath(SelfPath, false, TmpFilename);
+  auto Path = GetEmulatedFDPath(AT_FDCWD, SelfPath, false, TmpFilename);
   if (Path.first != -1) {
     uint64_t Result = ::fchmodat(Path.first, Path.second, mode, 0);
     if (Result != -1)
       return Result;
   }
-
   return ::chmod(SelfPath, mode);
 }
 
@@ -692,7 +710,7 @@ uint64_t FileManager::Readlinkat(int dirfd, const char *pathname, char *buf, siz
   }
 
   FDPathTmpData TmpFilename;
-  auto NewPath = GetEmulatedFDPath(pathname, false, TmpFilename);
+  auto NewPath = GetEmulatedFDPath(dirfd, pathname, false, TmpFilename);
   if (NewPath.first != -1) {
     uint64_t Result = ::readlinkat(NewPath.first, NewPath.second, buf, bufsiz);
     if (Result != -1)
@@ -715,11 +733,11 @@ uint64_t FileManager::Openat([[maybe_unused]] int dirfs, const char *pathname, i
 
   int32_t fd = -1;
 
-  if (!((flags & O_CREAT) || (mode & O_WRONLY))) {
+  if (!ShouldSkipOpenInEmu(flags)) {
     fd = EmuFD.OpenAt(dirfs, SelfPath, flags, mode);
     if (fd == -1) {
       FDPathTmpData TmpFilename;
-      auto Path = GetEmulatedFDPath(SelfPath, true, TmpFilename);
+      auto Path = GetEmulatedFDPath(dirfs, SelfPath, true, TmpFilename);
       if (Path.first != -1) {
         fd = ::syscall(SYSCALL_DEF(openat), Path.first, Path.second, flags, mode);
       }
@@ -744,11 +762,11 @@ uint64_t FileManager::Openat2(int dirfs, const char *pathname, FEX::HLE::open_ho
 
   int32_t fd = -1;
 
-  if (!((how->flags & O_CREAT) || (how->mode & O_WRONLY))) {
+  if (!ShouldSkipOpenInEmu(how->flags)) {
     fd = EmuFD.OpenAt(dirfs, SelfPath, how->flags, how->mode);
     if (fd == -1) {
       FDPathTmpData TmpFilename;
-      auto Path = GetEmulatedFDPath(SelfPath, true, TmpFilename);
+      auto Path = GetEmulatedFDPath(dirfs, SelfPath, true, TmpFilename);
       if (Path.first != -1) {
         fd = ::syscall(SYSCALL_DEF(openat2), Path.first, Path.second, how, usize);
       }
@@ -773,7 +791,7 @@ uint64_t FileManager::Statx(int dirfd, const char *pathname, int flags, uint32_t
   const char *SelfPath = NewPath ? NewPath->c_str() : nullptr;
 
   FDPathTmpData TmpFilename;
-  auto Path = GetEmulatedFDPath(SelfPath, (flags & AT_SYMLINK_NOFOLLOW) == 0, TmpFilename);
+  auto Path = GetEmulatedFDPath(dirfd, SelfPath, (flags & AT_SYMLINK_NOFOLLOW) == 0, TmpFilename);
   if (Path.first != -1) {
     uint64_t Result = FHU::Syscalls::statx(Path.first, Path.second, flags, mask, statxbuf);
     if (Result != -1)
@@ -787,7 +805,7 @@ uint64_t FileManager::Mknod(const char *pathname, mode_t mode, dev_t dev) {
   const char *SelfPath = NewPath ? NewPath->c_str() : nullptr;
 
   FDPathTmpData TmpFilename;
-  auto Path = GetEmulatedFDPath(SelfPath, false, TmpFilename);
+  auto Path = GetEmulatedFDPath(AT_FDCWD, SelfPath, false, TmpFilename);
   if (Path.first != -1) {
     uint64_t Result = ::mknodat(Path.first, Path.second, mode, dev);
     if (Result != -1)
@@ -811,7 +829,7 @@ uint64_t FileManager::NewFSStatAt(int dirfd, const char *pathname, struct stat *
   const char *SelfPath = NewPath ? NewPath->c_str() : nullptr;
 
   FDPathTmpData TmpFilename;
-  auto Path = GetEmulatedFDPath(SelfPath, (flag & AT_SYMLINK_NOFOLLOW) == 0, TmpFilename);
+  auto Path = GetEmulatedFDPath(dirfd, SelfPath, (flag & AT_SYMLINK_NOFOLLOW) == 0, TmpFilename);
   if (Path.first != -1) {
     uint64_t Result = ::fstatat(Path.first, Path.second, buf, flag);
     if (Result != -1) {
@@ -826,7 +844,7 @@ uint64_t FileManager::NewFSStatAt64(int dirfd, const char *pathname, struct stat
   const char *SelfPath = NewPath ? NewPath->c_str() : nullptr;
 
   FDPathTmpData TmpFilename;
-  auto Path = GetEmulatedFDPath(SelfPath, (flag & AT_SYMLINK_NOFOLLOW) == 0, TmpFilename);
+  auto Path = GetEmulatedFDPath(dirfd, SelfPath, (flag & AT_SYMLINK_NOFOLLOW) == 0, TmpFilename);
   if (Path.first != -1) {
     uint64_t Result = ::fstatat64(Path.first, Path.second, buf, flag);
     if (Result != -1) {

--- a/Source/Tests/LinuxSyscalls/FileManagement.h
+++ b/Source/Tests/LinuxSyscalls/FileManagement.h
@@ -81,7 +81,7 @@ public:
 
   std::string GetEmulatedPath(const char *pathname, bool FollowSymlink = false);
   using FDPathTmpData = std::array<char[PATH_MAX], 2>;
-  std::pair<int, const char*> GetEmulatedFDPath(const char *pathname, bool FollowSymlink, FDPathTmpData &TmpFilename);
+  std::pair<int, const char*> GetEmulatedFDPath(int dirfd, const char *pathname, bool FollowSymlink, FDPathTmpData &TmpFilename);
 
   std::mutex *GetFDLock() { return &FDLock; }
 


### PR DESCRIPTION
Need to ensure that dirfd is AT_FDCWD and also need to check flags correctly.

Flags were incorrectly checking mode for O_WRONLY and also we should check for O_APPEND. Split it out to a helper function just so it is easier to see what is going on.

Fixes the issue of proton not finding `/lib64/ld-linux-x86-64.so.2`