### PR TITLE
FEXRootFSFetcher: Update link to rootfs links file

### DIFF
--- a/Source/Tools/FEXRootFSFetcher/Main.cpp
+++ b/Source/Tools/FEXRootFSFetcher/Main.cpp
@@ -456,7 +456,7 @@ namespace WebFileFetcher {
     FileType Type;
   };
 
-  const static std::string DownloadURL = "https://rootfs.fex-emu.com/file/fex-rootfs/RootFS_links.json";
+  const static std::string DownloadURL = "https://rootfs.fex-emu.gg/RootFS_links.json";
 
   std::string DownloadToString(const std::string &URL) {
     std::string BigArgs =


### PR DESCRIPTION
Switches to the new CDN which is significantly faster and has other benefits.

In order to make sure we don't break old clients, switch to the new link for a few months while leaving the old one operational.

The links file in the old CDN still points to the new rootfs links so they get the performance improvement on old clients still.