### PR TITLE
ARMEmitter: Fully handle SVE Integer Misc - Unpredicated

### DIFF
--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
@@ -1034,13 +1034,20 @@ public:
 
   // SVE Integer Misc - Unpredicated
   // SVE floating-point trig select coefficient
-  // XXX:
+  void ftssel(SubRegSize size, ZRegister zd, ZRegister zn, ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
+                        "ftssel may only have 16-bit, 32-bit, or 64-bit element sizes");
+    SVEIntegerMiscUnpredicated(0b00, zm.Idx(), FEXCore::ToUnderlying(size), zd, zn);
+  }
   // SVE floating-point exponential accelerator
-  // XXX:
+  void fexpa(SubRegSize size, ZRegister zd, ZRegister zn) {
+    LOGMAN_THROW_AA_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
+                        "fexpa may only have 16-bit, 32-bit, or 64-bit element sizes");
+    SVEIntegerMiscUnpredicated(0b10, 0b00000, FEXCore::ToUnderlying(size), zd, zn);
+  }
   // SVE constructive prefix (unpredicated)
-  void movprfx(FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zn) {
-    const uint32_t Op = 0b0000'0100'0010'0000'1011'11 << 10;
-    SVEConstructivePrefixUnpredicated(Op, 0b00, 0b00000, zn, zd);
+  void movprfx(ZRegister zd, ZRegister zn) {
+    SVEIntegerMiscUnpredicated(0b11, 0b00000, 0b00, zd, zn);
   }
 
   // SVE Element Count
@@ -3163,14 +3170,14 @@ private:
     dc32(Instr);
   }
 
-  // SVE constructive prefix (unpredicated)
-  void SVEConstructivePrefixUnpredicated(uint32_t Op, uint32_t opc, uint32_t opc2, FEXCore::ARMEmitter::ZRegister zn, FEXCore::ARMEmitter::ZRegister zd) {
-    uint32_t Instr = Op;
-
-    Instr |= opc << 22;
-    Instr |= opc2 << 16;
-    Instr |= Encode_rn(zn);
-    Instr |= Encode_rd(zd);
+  // SVE Integer Misc - Unpredicated
+  void SVEIntegerMiscUnpredicated(uint32_t op0, uint32_t opc, uint32_t opc2, ZRegister zd, ZRegister zn) {
+    uint32_t Instr = 0b0000'0100'0010'0000'1011'0000'0000'0000;
+    Instr |= opc2 << 22;
+    Instr |= opc << 16;
+    Instr |= op0 << 10;
+    Instr |= zn.Idx() << 5;
+    Instr |= zd.Idx();
     dc32(Instr);
   }
 

--- a/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
+++ b/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
@@ -1044,10 +1044,14 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE bitwise shift by immediate
 }
 
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE floating-point trig select coefficient") {
-  // TODO: Implement in emitter.
+  TEST_SINGLE(ftssel(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28), "ftssel z30.h, z29.h, z28.h");
+  TEST_SINGLE(ftssel(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "ftssel z30.s, z29.s, z28.s");
+  TEST_SINGLE(ftssel(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28), "ftssel z30.d, z29.d, z28.d");
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE floating-point exponential accelerator") {
-  // TODO: Implement in emitter.
+  TEST_SINGLE(fexpa(SubRegSize::i16Bit, ZReg::z30, ZReg::z29), "fexpa z30.h, z29.h");
+  TEST_SINGLE(fexpa(SubRegSize::i32Bit, ZReg::z30, ZReg::z29), "fexpa z30.s, z29.s");
+  TEST_SINGLE(fexpa(SubRegSize::i64Bit, ZReg::z30, ZReg::z29), "fexpa z30.d, z29.d");
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE constructive prefix (unpredicated)") {
   TEST_SINGLE(movprfx(ZReg::z30, ZReg::z29), "movprfx z30, z29");


### PR DESCRIPTION
Finishes off an integer category that, at present, has more floating point operations in it than anything else.