### PR TITLE
ARMEmitter/ScalarOps: Move base opcodes into helper functions

### DIFF
--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ScalarOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ScalarOps.inl
@@ -37,41 +37,32 @@ public:
   }
 
 // Advanced SIMD scalar three same FP16
-  void fmulx(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm) {
-    constexpr uint32_t Op = 0b0101'1110'0100'0000'0000'01 << 10;
-    ASIMDScalarThreeSameFP16(Op, 0, 0, 0b011, rm, rn, rd);
+  void fmulx(HRegister rd, HRegister rn, HRegister rm) {
+    ASIMDScalarThreeSameFP16(0, 0, 0b011, rm, rn, rd);
   }
-  void fcmeq(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm) {
-    constexpr uint32_t Op = 0b0101'1110'0100'0000'0000'01 << 10;
-    ASIMDScalarThreeSameFP16(Op, 0, 0, 0b100, rm, rn, rd);
+  void fcmeq(HRegister rd, HRegister rn, HRegister rm) {
+    ASIMDScalarThreeSameFP16(0, 0, 0b100, rm, rn, rd);
   }
-  void frecps(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm) {
-    constexpr uint32_t Op = 0b0101'1110'0100'0000'0000'01 << 10;
-    ASIMDScalarThreeSameFP16(Op, 0, 0, 0b111, rm, rn, rd);
+  void frecps(HRegister rd, HRegister rn, HRegister rm) {
+    ASIMDScalarThreeSameFP16(0, 0, 0b111, rm, rn, rd);
   }
-  void frsqrts(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm) {
-    constexpr uint32_t Op = 0b0101'1110'0100'0000'0000'01 << 10;
-    ASIMDScalarThreeSameFP16(Op, 0, 1, 0b111, rm, rn, rd);
+  void frsqrts(HRegister rd, HRegister rn, HRegister rm) {
+    ASIMDScalarThreeSameFP16(0, 1, 0b111, rm, rn, rd);
   }
-  void fcmge(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm) {
-    constexpr uint32_t Op = 0b0101'1110'0100'0000'0000'01 << 10;
-    ASIMDScalarThreeSameFP16(Op, 1, 0, 0b100, rm, rn, rd);
+  void fcmge(HRegister rd, HRegister rn, HRegister rm) {
+    ASIMDScalarThreeSameFP16(1, 0, 0b100, rm, rn, rd);
   }
-  void facge(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm) {
-    constexpr uint32_t Op = 0b0101'1110'0100'0000'0000'01 << 10;
-    ASIMDScalarThreeSameFP16(Op, 1, 0, 0b101, rm, rn, rd);
+  void facge(HRegister rd, HRegister rn, HRegister rm) {
+    ASIMDScalarThreeSameFP16(1, 0, 0b101, rm, rn, rd);
   }
-  void fabd(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm) {
-    constexpr uint32_t Op = 0b0101'1110'0100'0000'0000'01 << 10;
-    ASIMDScalarThreeSameFP16(Op, 1, 1, 0b010, rm, rn, rd);
+  void fabd(HRegister rd, HRegister rn, HRegister rm) {
+    ASIMDScalarThreeSameFP16(1, 1, 0b010, rm, rn, rd);
   }
-  void fcmgt(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm) {
-    constexpr uint32_t Op = 0b0101'1110'0100'0000'0000'01 << 10;
-    ASIMDScalarThreeSameFP16(Op, 1, 1, 0b100, rm, rn, rd);
+  void fcmgt(HRegister rd, HRegister rn, HRegister rm) {
+    ASIMDScalarThreeSameFP16(1, 1, 0b100, rm, rn, rd);
   }
-  void facgt(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm) {
-    constexpr uint32_t Op = 0b0101'1110'0100'0000'0000'01 << 10;
-    ASIMDScalarThreeSameFP16(Op, 1, 1, 0b101, rm, rn, rd);
+  void facgt(HRegister rd, HRegister rn, HRegister rm) {
+    ASIMDScalarThreeSameFP16(1, 1, 0b101, rm, rn, rd);
   }
 
 // Advanced SIMD scalar two-register miscellaneous FP16
@@ -1574,8 +1565,8 @@ private:
   }
 
 // Advanced SIMD scalar three same FP16
-  void ASIMDScalarThreeSameFP16(uint32_t Op, uint32_t U, uint32_t a, uint32_t opcode, FEXCore::ARMEmitter::HRegister rm, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rd) {
-    uint32_t Instr = Op;
+  void ASIMDScalarThreeSameFP16(uint32_t U, uint32_t a, uint32_t opcode, HRegister rm, HRegister rn, HRegister rd) {
+    uint32_t Instr = 0b0101'1110'0100'0000'0000'0100'0000'0000;
 
     Instr |= U << 29;
     Instr |= a << 23;

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ScalarOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ScalarOps.inl
@@ -1067,142 +1067,88 @@ public:
   }
 
 // Floating-point data-processing (2 source)
-  void fmul(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn, FEXCore::ARMEmitter::SRegister rm) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b10 << 10;
-    Float2Source(Op, 0, 0, 0b00, 0b0000, rd.V(), rn.V(), rm.V());
+  void fmul(SRegister rd, SRegister rn, SRegister rm) {
+    Float2Source(0, 0, 0b00, 0b0000, rd.V(), rn.V(), rm.V());
   }
-  void fdiv(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn, FEXCore::ARMEmitter::SRegister rm) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b10 << 10;
-    Float2Source(Op, 0, 0, 0b00, 0b0001, rd.V(), rn.V(), rm.V());
+  void fdiv(SRegister rd, SRegister rn, SRegister rm) {
+    Float2Source(0, 0, 0b00, 0b0001, rd.V(), rn.V(), rm.V());
   }
-  void fadd(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn, FEXCore::ARMEmitter::SRegister rm) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b10 << 10;
-    Float2Source(Op, 0, 0, 0b00, 0b0010, rd.V(), rn.V(), rm.V());
+  void fadd(SRegister rd, SRegister rn, SRegister rm) {
+    Float2Source(0, 0, 0b00, 0b0010, rd.V(), rn.V(), rm.V());
   }
-  void fsub(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn, FEXCore::ARMEmitter::SRegister rm) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b10 << 10;
-    Float2Source(Op, 0, 0, 0b00, 0b0011, rd.V(), rn.V(), rm.V());
+  void fsub(SRegister rd, SRegister rn, SRegister rm) {
+    Float2Source(0, 0, 0b00, 0b0011, rd.V(), rn.V(), rm.V());
   }
-  void fmax(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn, FEXCore::ARMEmitter::SRegister rm) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b10 << 10;
-    Float2Source(Op, 0, 0, 0b00, 0b0100, rd.V(), rn.V(), rm.V());
+  void fmax(SRegister rd, SRegister rn, SRegister rm) {
+    Float2Source(0, 0, 0b00, 0b0100, rd.V(), rn.V(), rm.V());
   }
-  void fmin(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn, FEXCore::ARMEmitter::SRegister rm) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b10 << 10;
-    Float2Source(Op, 0, 0, 0b00, 0b0101, rd.V(), rn.V(), rm.V());
+  void fmin(SRegister rd, SRegister rn, SRegister rm) {
+    Float2Source(0, 0, 0b00, 0b0101, rd.V(), rn.V(), rm.V());
   }
-  void fmaxnm(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn, FEXCore::ARMEmitter::SRegister rm) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b10 << 10;
-    Float2Source(Op, 0, 0, 0b00, 0b0110, rd.V(), rn.V(), rm.V());
+  void fmaxnm(SRegister rd, SRegister rn, SRegister rm) {
+    Float2Source(0, 0, 0b00, 0b0110, rd.V(), rn.V(), rm.V());
   }
-  void fminnm(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn, FEXCore::ARMEmitter::SRegister rm) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b10 << 10;
-    Float2Source(Op, 0, 0, 0b00, 0b0111, rd.V(), rn.V(), rm.V());
+  void fminnm(SRegister rd, SRegister rn, SRegister rm) {
+    Float2Source(0, 0, 0b00, 0b0111, rd.V(), rn.V(), rm.V());
   }
-  void fnmul(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn, FEXCore::ARMEmitter::SRegister rm) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b10 << 10;
-    Float2Source(Op, 0, 0, 0b00, 0b1000, rd.V(), rn.V(), rm.V());
+  void fnmul(SRegister rd, SRegister rn, SRegister rm) {
+    Float2Source(0, 0, 0b00, 0b1000, rd.V(), rn.V(), rm.V());
   }
 
-  void fmul(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b10 << 10;
-    Float2Source(Op, 0, 0, 0b01, 0b0000, rd.V(), rn.V(), rm.V());
+  void fmul(DRegister rd, DRegister rn, DRegister rm) {
+    Float2Source(0, 0, 0b01, 0b0000, rd.V(), rn.V(), rm.V());
   }
-  void fdiv(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b10 << 10;
-    Float2Source(Op, 0, 0, 0b01, 0b0001, rd.V(), rn.V(), rm.V());
+  void fdiv(DRegister rd, DRegister rn, DRegister rm) {
+    Float2Source(0, 0, 0b01, 0b0001, rd.V(), rn.V(), rm.V());
   }
-  void fadd(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b10 << 10;
-    Float2Source(Op, 0, 0, 0b01, 0b0010, rd.V(), rn.V(), rm.V());
+  void fadd(DRegister rd, DRegister rn, DRegister rm) {
+    Float2Source(0, 0, 0b01, 0b0010, rd.V(), rn.V(), rm.V());
   }
-  void fsub(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b10 << 10;
-    Float2Source(Op, 0, 0, 0b01, 0b0011, rd.V(), rn.V(), rm.V());
+  void fsub(DRegister rd, DRegister rn, DRegister rm) {
+    Float2Source(0, 0, 0b01, 0b0011, rd.V(), rn.V(), rm.V());
   }
-  void fmax(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b10 << 10;
-    Float2Source(Op, 0, 0, 0b01, 0b0100, rd.V(), rn.V(), rm.V());
+  void fmax(DRegister rd, DRegister rn, DRegister rm) {
+    Float2Source(0, 0, 0b01, 0b0100, rd.V(), rn.V(), rm.V());
   }
-  void fmin(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b10 << 10;
-    Float2Source(Op, 0, 0, 0b01, 0b0101, rd.V(), rn.V(), rm.V());
+  void fmin(DRegister rd, DRegister rn, DRegister rm) {
+    Float2Source(0, 0, 0b01, 0b0101, rd.V(), rn.V(), rm.V());
   }
-  void fmaxnm(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b10 << 10;
-    Float2Source(Op, 0, 0, 0b01, 0b0110, rd.V(), rn.V(), rm.V());
+  void fmaxnm(DRegister rd, DRegister rn, DRegister rm) {
+    Float2Source(0, 0, 0b01, 0b0110, rd.V(), rn.V(), rm.V());
   }
-  void fminnm(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b10 << 10;
-    Float2Source(Op, 0, 0, 0b01, 0b0111, rd.V(), rn.V(), rm.V());
+  void fminnm(DRegister rd, DRegister rn, DRegister rm) {
+    Float2Source(0, 0, 0b01, 0b0111, rd.V(), rn.V(), rm.V());
   }
-  void fnmul(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b10 << 10;
-    Float2Source(Op, 0, 0, 0b01, 0b1000, rd.V(), rn.V(), rm.V());
+  void fnmul(DRegister rd, DRegister rn, DRegister rm) {
+    Float2Source(0, 0, 0b01, 0b1000, rd.V(), rn.V(), rm.V());
   }
 
-  void fmul(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b10 << 10;
-    Float2Source(Op, 0, 0, 0b11, 0b0000, rd.V(), rn.V(), rm.V());
+  void fmul(HRegister rd, HRegister rn, HRegister rm) {
+    Float2Source(0, 0, 0b11, 0b0000, rd.V(), rn.V(), rm.V());
   }
-  void fdiv(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b10 << 10;
-    Float2Source(Op, 0, 0, 0b11, 0b0001, rd.V(), rn.V(), rm.V());
+  void fdiv(HRegister rd, HRegister rn, HRegister rm) {
+    Float2Source(0, 0, 0b11, 0b0001, rd.V(), rn.V(), rm.V());
   }
-  void fadd(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b10 << 10;
-    Float2Source(Op, 0, 0, 0b11, 0b0010, rd.V(), rn.V(), rm.V());
+  void fadd(HRegister rd, HRegister rn, HRegister rm) {
+    Float2Source(0, 0, 0b11, 0b0010, rd.V(), rn.V(), rm.V());
   }
-  void fsub(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b10 << 10;
-    Float2Source(Op, 0, 0, 0b11, 0b0011, rd.V(), rn.V(), rm.V());
+  void fsub(HRegister rd, HRegister rn, HRegister rm) {
+    Float2Source(0, 0, 0b11, 0b0011, rd.V(), rn.V(), rm.V());
   }
-  void fmax(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b10 << 10;
-    Float2Source(Op, 0, 0, 0b11, 0b0100, rd.V(), rn.V(), rm.V());
+  void fmax(HRegister rd, HRegister rn, HRegister rm) {
+    Float2Source(0, 0, 0b11, 0b0100, rd.V(), rn.V(), rm.V());
   }
-  void fmin(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b10 << 10;
-    Float2Source(Op, 0, 0, 0b11, 0b0101, rd.V(), rn.V(), rm.V());
+  void fmin(HRegister rd, HRegister rn, HRegister rm) {
+    Float2Source(0, 0, 0b11, 0b0101, rd.V(), rn.V(), rm.V());
   }
-  void fmaxnm(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b10 << 10;
-    Float2Source(Op, 0, 0, 0b11, 0b0110, rd.V(), rn.V(), rm.V());
+  void fmaxnm(HRegister rd, HRegister rn, HRegister rm) {
+    Float2Source(0, 0, 0b11, 0b0110, rd.V(), rn.V(), rm.V());
   }
-  void fminnm(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b10 << 10;
-    Float2Source(Op, 0, 0, 0b11, 0b0111, rd.V(), rn.V(), rm.V());
+  void fminnm(HRegister rd, HRegister rn, HRegister rm) {
+    Float2Source(0, 0, 0b11, 0b0111, rd.V(), rn.V(), rm.V());
   }
-  void fnmul(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b10 << 10;
-    Float2Source(Op, 0, 0, 0b11, 0b1000, rd.V(), rn.V(), rm.V());
+  void fnmul(HRegister rd, HRegister rn, HRegister rm) {
+    Float2Source(0, 0, 0b11, 0b1000, rd.V(), rn.V(), rm.V());
   }
 
   // Floating-point conditional select
@@ -1417,8 +1363,8 @@ private:
     dc32(Instr);
   }
 // Floating-point data-processing (2 source)
-  void Float2Source(uint32_t Op, uint32_t M, uint32_t S, uint32_t ptype, uint32_t opcode, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
-    uint32_t Instr = Op;
+  void Float2Source(uint32_t M, uint32_t S, uint32_t ptype, uint32_t opcode, VRegister rd, VRegister rn, VRegister rm) {
+    uint32_t Instr = 0b0001'1110'0010'0000'0000'1000'0000'0000;
 
     Instr |= M << 31;
     Instr |= S << 29;

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ScalarOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ScalarOps.inl
@@ -1347,41 +1347,23 @@ public:
   }
 
 // Floating-point conditional compare
-  void fccmp(FEXCore::ARMEmitter::SRegister rn, FEXCore::ARMEmitter::SRegister rm, FEXCore::ARMEmitter::StatusFlags flags, FEXCore::ARMEmitter::Condition Cond) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b01 << 10;
-
-    FloatConditionalCompare(Op, 0, 0, 0b00, 0b0, rn.V(), rm.V(), flags, Cond);
+  void fccmp(SRegister rn, SRegister rm, StatusFlags flags, Condition Cond) {
+    FloatConditionalCompare(0, 0, 0b00, 0b0, rn.V(), rm.V(), flags, Cond);
   }
-  void fccmpe(FEXCore::ARMEmitter::SRegister rn, FEXCore::ARMEmitter::SRegister rm, FEXCore::ARMEmitter::StatusFlags flags, FEXCore::ARMEmitter::Condition Cond) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b01 << 10;
-
-    FloatConditionalCompare(Op, 0, 0, 0b00, 0b1, rn.V(), rm.V(), flags, Cond);
+  void fccmpe(SRegister rn, SRegister rm, StatusFlags flags, Condition Cond) {
+    FloatConditionalCompare(0, 0, 0b00, 0b1, rn.V(), rm.V(), flags, Cond);
   }
-  void fccmp(FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm, FEXCore::ARMEmitter::StatusFlags flags, FEXCore::ARMEmitter::Condition Cond) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b01 << 10;
-
-    FloatConditionalCompare(Op, 0, 0, 0b01, 0b0, rn.V(), rm.V(), flags, Cond);
+  void fccmp(DRegister rn, DRegister rm, StatusFlags flags, Condition Cond) {
+    FloatConditionalCompare(0, 0, 0b01, 0b0, rn.V(), rm.V(), flags, Cond);
   }
-  void fccmpe(FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm, FEXCore::ARMEmitter::StatusFlags flags, FEXCore::ARMEmitter::Condition Cond) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b01 << 10;
-
-    FloatConditionalCompare(Op, 0, 0, 0b01, 0b1, rn.V(), rm.V(), flags, Cond);
+  void fccmpe(DRegister rn, DRegister rm, StatusFlags flags, Condition Cond) {
+    FloatConditionalCompare(0, 0, 0b01, 0b1, rn.V(), rm.V(), flags, Cond);
   }
-  void fccmp(FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm, FEXCore::ARMEmitter::StatusFlags flags, FEXCore::ARMEmitter::Condition Cond) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b01 << 10;
-
-    FloatConditionalCompare(Op, 0, 0, 0b11, 0b0, rn.V(), rm.V(), flags, Cond);
+  void fccmp(HRegister rn, HRegister rm, StatusFlags flags, Condition Cond) {
+    FloatConditionalCompare(0, 0, 0b11, 0b0, rn.V(), rm.V(), flags, Cond);
   }
-  void fccmpe(FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm, FEXCore::ARMEmitter::StatusFlags flags, FEXCore::ARMEmitter::Condition Cond) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b01 << 10;
-
-    FloatConditionalCompare(Op, 0, 0, 0b11, 0b1, rn.V(), rm.V(), flags, Cond);
+  void fccmpe(HRegister rn, HRegister rm, StatusFlags flags, Condition Cond) {
+    FloatConditionalCompare(0, 0, 0b11, 0b1, rn.V(), rm.V(), flags, Cond);
   }
 
 // Floating-point data-processing (2 source)
@@ -1725,8 +1707,8 @@ private:
 // Floating-point immediate
 // XXX:
 // Floating-point conditional compare
-  void FloatConditionalCompare(uint32_t Op, uint32_t M, uint32_t S, uint32_t ptype, uint32_t op, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm, FEXCore::ARMEmitter::StatusFlags flags, FEXCore::ARMEmitter::Condition Cond) {
-    uint32_t Instr = Op;
+  void FloatConditionalCompare(uint32_t M, uint32_t S, uint32_t ptype, uint32_t op, VRegister rn, VRegister rm, StatusFlags flags, Condition Cond) {
+    uint32_t Instr = 0b0001'1110'0010'0000'0000'0100'0000'0000;
 
     Instr |= M << 31;
     Instr |= S << 29;

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ScalarOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ScalarOps.inl
@@ -1206,20 +1206,14 @@ public:
   }
 
   // Floating-point conditional select
-  void fcsel(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn, FEXCore::ARMEmitter::SRegister rm, FEXCore::ARMEmitter::Condition Cond) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b11 << 10;
-    Float2Source(Op, 0, 0, 0b00, FEXCore::ToUnderlying(Cond), rd.V(), rn.V(), rm.V());
+  void fcsel(SRegister rd, SRegister rn, SRegister rm, Condition Cond) {
+    FloatConditionalSelect(0, 0, 0b00, rd.V(), rn.V(), rm.V(), Cond);
   }
-  void fcsel(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm, FEXCore::ARMEmitter::Condition Cond) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b11 << 10;
-    Float2Source(Op, 0, 0, 0b01, FEXCore::ToUnderlying(Cond), rd.V(), rn.V(), rm.V());
+  void fcsel(DRegister rd, DRegister rn, DRegister rm, Condition Cond) {
+    FloatConditionalSelect(0, 0, 0b01, rd.V(), rn.V(), rm.V(), Cond);
   }
-  void fcsel(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm, FEXCore::ARMEmitter::Condition Cond) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b11 << 10;
-    Float2Source(Op, 0, 0, 0b11, FEXCore::ToUnderlying(Cond), rd.V(), rn.V(), rm.V());
+  void fcsel(HRegister rd, HRegister rn, HRegister rm, Condition Cond) {
+    FloatConditionalSelect(0, 0, 0b11, rd.V(), rn.V(), rm.V(), Cond);
   }
 
 // Floating-point data-processing (3 source)
@@ -1438,8 +1432,8 @@ private:
   }
 
 // Floating-point conditional select
-  void FloatConditionalSelect(uint32_t Op, uint32_t M, uint32_t S, uint32_t ptype, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm, FEXCore::ARMEmitter::Condition Cond) {
-    uint32_t Instr = Op;
+  void FloatConditionalSelect(uint32_t M, uint32_t S, uint32_t ptype, VRegister rd, VRegister rn, VRegister rm, Condition Cond) {
+    uint32_t Instr = 0b0001'1110'0010'0000'0000'1100'0000'0000;
 
     Instr |= M << 31;
     Instr |= S << 29;

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ScalarOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ScalarOps.inl
@@ -404,35 +404,32 @@ public:
   }
 // Advanced SIMD scalar three different
   ///< size is destination.
-  void sqdmlal(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'00 << 10;
-    const FEXCore::ARMEmitter::ScalarRegSize ConvertedSize =
-      size == ARMEmitter::ScalarRegSize::i64Bit ?
-        ARMEmitter::ScalarRegSize::i32Bit :
-        ARMEmitter::ScalarRegSize::i16Bit;
-    ASIMD3RegDifferent(Op, 0, ConvertedSize, 0b1001, rd, rn, rm);
+  void sqdmlal(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    const ScalarRegSize ConvertedSize =
+      size == ScalarRegSize::i64Bit ?
+        ScalarRegSize::i32Bit :
+        ScalarRegSize::i16Bit;
+    ASIMD3RegDifferent(0, ConvertedSize, 0b1001, rd, rn, rm);
   }
   ///< size is destination.
-  void sqdmlsl(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'00 << 10;
-    const FEXCore::ARMEmitter::ScalarRegSize ConvertedSize =
-      size == ARMEmitter::ScalarRegSize::i64Bit ?
-        ARMEmitter::ScalarRegSize::i32Bit :
-        ARMEmitter::ScalarRegSize::i16Bit;
-    ASIMD3RegDifferent(Op, 0, ConvertedSize, 0b1011, rd, rn, rm);
+  void sqdmlsl(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    const ScalarRegSize ConvertedSize =
+      size == ScalarRegSize::i64Bit ?
+        ScalarRegSize::i32Bit :
+        ScalarRegSize::i16Bit;
+    ASIMD3RegDifferent(0, ConvertedSize, 0b1011, rd, rn, rm);
   }
 
   ///< size is destination.
-  void sqdmull(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'00 << 10;
-    const FEXCore::ARMEmitter::ScalarRegSize ConvertedSize =
-      size == ARMEmitter::ScalarRegSize::i64Bit ?
-        ARMEmitter::ScalarRegSize::i32Bit :
-        ARMEmitter::ScalarRegSize::i16Bit;
-    ASIMD3RegDifferent(Op, 0, ConvertedSize, 0b1101, rd, rn, rm);
+  void sqdmull(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    const ScalarRegSize ConvertedSize =
+      size == ScalarRegSize::i64Bit ?
+        ScalarRegSize::i32Bit :
+        ScalarRegSize::i16Bit;
+    ASIMD3RegDifferent(0, ConvertedSize, 0b1101, rd, rn, rm);
   }
 // Advanced SIMD scalar three same
   void sqadd(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
@@ -1534,8 +1531,8 @@ private:
 // Advanced SIMD scalar pairwise
 // XXX:
 // Advanced SIMD scalar three different
-  void ASIMD3RegDifferent(uint32_t Op, uint32_t U, FEXCore::ARMEmitter::ScalarRegSize size, uint32_t opcode, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
-    uint32_t Instr = Op;
+  void ASIMD3RegDifferent(uint32_t U, ScalarRegSize size, uint32_t opcode, VRegister rd, VRegister rn, VRegister rm) {
+    uint32_t Instr = 0b0101'1110'0010'0000'0000'0000'0000'0000;
 
     Instr |= U << 29;
     Instr |= FEXCore::ToUnderlying(size) << 22;

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ScalarOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ScalarOps.inl
@@ -66,85 +66,65 @@ public:
   }
 
 // Advanced SIMD scalar two-register miscellaneous FP16
-  void fcvtns(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0101'1110'0111'1000'0000'10 << 10;
-    ASIMDScalarTwoRegMiscFP16(Op, 0, 0, 0b11010, rn, rd);
+  void fcvtns(HRegister rd, HRegister rn) {
+    ASIMDScalarTwoRegMiscFP16(0, 0, 0b11010, rn, rd);
   }
-  void fcvtms(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0101'1110'0111'1000'0000'10 << 10;
-    ASIMDScalarTwoRegMiscFP16(Op, 0, 0, 0b11011, rn, rd);
+  void fcvtms(HRegister rd, HRegister rn) {
+    ASIMDScalarTwoRegMiscFP16(0, 0, 0b11011, rn, rd);
   }
-  void fcvtas(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0101'1110'0111'1000'0000'10 << 10;
-    ASIMDScalarTwoRegMiscFP16(Op, 0, 0, 0b11100, rn, rd);
+  void fcvtas(HRegister rd, HRegister rn) {
+    ASIMDScalarTwoRegMiscFP16(0, 0, 0b11100, rn, rd);
   }
-  void scvtf(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0101'1110'0111'1000'0000'10 << 10;
-    ASIMDScalarTwoRegMiscFP16(Op, 0, 0, 0b11101, rn, rd);
+  void scvtf(HRegister rd, HRegister rn) {
+    ASIMDScalarTwoRegMiscFP16(0, 0, 0b11101, rn, rd);
   }
-  void fcmgt(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0101'1110'0111'1000'0000'10 << 10;
-    ASIMDScalarTwoRegMiscFP16(Op, 0, 1, 0b01100, rn, rd);
+  void fcmgt(HRegister rd, HRegister rn) {
+    ASIMDScalarTwoRegMiscFP16(0, 1, 0b01100, rn, rd);
   }
-  void fcmeq(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0101'1110'0111'1000'0000'10 << 10;
-    ASIMDScalarTwoRegMiscFP16(Op, 0, 1, 0b01101, rn, rd);
+  void fcmeq(HRegister rd, HRegister rn) {
+    ASIMDScalarTwoRegMiscFP16(0, 1, 0b01101, rn, rd);
   }
-  void fcmlt(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0101'1110'0111'1000'0000'10 << 10;
-    ASIMDScalarTwoRegMiscFP16(Op, 0, 1, 0b01110, rn, rd);
+  void fcmlt(HRegister rd, HRegister rn) {
+    ASIMDScalarTwoRegMiscFP16(0, 1, 0b01110, rn, rd);
   }
-  void fcvtps(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0101'1110'0111'1000'0000'10 << 10;
-    ASIMDScalarTwoRegMiscFP16(Op, 0, 1, 0b11010, rn, rd);
+  void fcvtps(HRegister rd, HRegister rn) {
+    ASIMDScalarTwoRegMiscFP16(0, 1, 0b11010, rn, rd);
   }
-  void fcvtzs(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0101'1110'0111'1000'0000'10 << 10;
-    ASIMDScalarTwoRegMiscFP16(Op, 0, 1, 0b11011, rn, rd);
+  void fcvtzs(HRegister rd, HRegister rn) {
+    ASIMDScalarTwoRegMiscFP16(0, 1, 0b11011, rn, rd);
   }
-  void frecpe(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0101'1110'0111'1000'0000'10 << 10;
-    ASIMDScalarTwoRegMiscFP16(Op, 0, 1, 0b11101, rn, rd);
+  void frecpe(HRegister rd, HRegister rn) {
+    ASIMDScalarTwoRegMiscFP16(0, 1, 0b11101, rn, rd);
   }
-  void frecpx(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0101'1110'0111'1000'0000'10 << 10;
-    ASIMDScalarTwoRegMiscFP16(Op, 0, 1, 0b11111, rn, rd);
+  void frecpx(HRegister rd, HRegister rn) {
+    ASIMDScalarTwoRegMiscFP16(0, 1, 0b11111, rn, rd);
   }
-  void fcvtnu(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0101'1110'0111'1000'0000'10 << 10;
-    ASIMDScalarTwoRegMiscFP16(Op, 1, 0, 0b11010, rn, rd);
+  void fcvtnu(HRegister rd, HRegister rn) {
+    ASIMDScalarTwoRegMiscFP16(1, 0, 0b11010, rn, rd);
   }
-  void fcvtmu(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0101'1110'0111'1000'0000'10 << 10;
-    ASIMDScalarTwoRegMiscFP16(Op, 1, 0, 0b11011, rn, rd);
+  void fcvtmu(HRegister rd, HRegister rn) {
+    ASIMDScalarTwoRegMiscFP16(1, 0, 0b11011, rn, rd);
   }
-  void fcvtau(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0101'1110'0111'1000'0000'10 << 10;
-    ASIMDScalarTwoRegMiscFP16(Op, 1, 0, 0b11100, rn, rd);
+  void fcvtau(HRegister rd, HRegister rn) {
+    ASIMDScalarTwoRegMiscFP16(1, 0, 0b11100, rn, rd);
   }
-  void ucvtf(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0101'1110'0111'1000'0000'10 << 10;
-    ASIMDScalarTwoRegMiscFP16(Op, 1, 0, 0b11101, rn, rd);
+  void ucvtf(HRegister rd, HRegister rn) {
+    ASIMDScalarTwoRegMiscFP16(1, 0, 0b11101, rn, rd);
   }
-  void fcmge(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0101'1110'0111'1000'0000'10 << 10;
-    ASIMDScalarTwoRegMiscFP16(Op, 1, 1, 0b01100, rn, rd);
+  void fcmge(HRegister rd, HRegister rn) {
+    ASIMDScalarTwoRegMiscFP16(1, 1, 0b01100, rn, rd);
   }
-  void fcmle(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0101'1110'0111'1000'0000'10 << 10;
-    ASIMDScalarTwoRegMiscFP16(Op, 1, 1, 0b01101, rn, rd);
+  void fcmle(HRegister rd, HRegister rn) {
+    ASIMDScalarTwoRegMiscFP16(1, 1, 0b01101, rn, rd);
   }
-  void fcvtpu(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0101'1110'0111'1000'0000'10 << 10;
-    ASIMDScalarTwoRegMiscFP16(Op, 1, 1, 0b11010, rn, rd);
+  void fcvtpu(HRegister rd, HRegister rn) {
+    ASIMDScalarTwoRegMiscFP16(1, 1, 0b11010, rn, rd);
   }
-  void fcvtzu(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0101'1110'0111'1000'0000'10 << 10;
-    ASIMDScalarTwoRegMiscFP16(Op, 1, 1, 0b11011, rn, rd);
+  void fcvtzu(HRegister rd, HRegister rn) {
+    ASIMDScalarTwoRegMiscFP16(1, 1, 0b11011, rn, rd);
   }
-  void frsqrte(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0101'1110'0111'1000'0000'10 << 10;
-    ASIMDScalarTwoRegMiscFP16(Op, 1, 1, 0b11101, rn, rd);
+  void frsqrte(HRegister rd, HRegister rn) {
+    ASIMDScalarTwoRegMiscFP16(1, 1, 0b11101, rn, rd);
   }
 
 // Advanced SIMD scalar three same extra
@@ -1577,8 +1557,8 @@ private:
     dc32(Instr);
   }
 // Advanced SIMD scalar two-register miscellaneous FP16
-  void ASIMDScalarTwoRegMiscFP16(uint32_t Op, uint32_t U, uint32_t a, uint32_t opcode, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rd) {
-    uint32_t Instr = Op;
+  void ASIMDScalarTwoRegMiscFP16(uint32_t U, uint32_t a, uint32_t opcode, HRegister rn, HRegister rd) {
+    uint32_t Instr = 0b0101'1110'0111'1000'0000'1000'0000'0000;
 
     Instr |= U << 29;
     Instr |= a << 23;

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ScalarOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ScalarOps.inl
@@ -432,177 +432,151 @@ public:
     ASIMD3RegDifferent(0, ConvertedSize, 0b1101, rd, rn, rm);
   }
 // Advanced SIMD scalar three same
-  void sqadd(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
-    ASIMD3RegSame(Op, 0, size, 0b00001, rd, rn, rm);
+  void sqadd(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
+    ASIMD3RegSame(0, size, 0b00001, rd, rn, rm);
   }
-  void sqsub(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
-    ASIMD3RegSame(Op, 0, size, 0b00101, rd, rn, rm);
+  void sqsub(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
+    ASIMD3RegSame(0, size, 0b00101, rd, rn, rm);
   }
-  void cmgt(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::ScalarRegSize::i64Bit, "Only supports 64-bit");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
-    ASIMD3RegSame(Op, 0, size, 0b00110, rd, rn, rm);
+  void cmgt(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
+    ASIMD3RegSame(0, size, 0b00110, rd, rn, rm);
   }
-  void cmge(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::ScalarRegSize::i64Bit, "Only supports 64-bit");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
-    ASIMD3RegSame(Op, 0, size, 0b00111, rd, rn, rm);
+  void cmge(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
+    ASIMD3RegSame(0, size, 0b00111, rd, rn, rm);
   }
-  void sshl(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::ScalarRegSize::i64Bit, "Only supports 64-bit");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
-    ASIMD3RegSame(Op, 0, size, 0b01000, rd, rn, rm);
+  void sshl(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
+    ASIMD3RegSame(0, size, 0b01000, rd, rn, rm);
   }
-  void sqshl(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
-    ASIMD3RegSame(Op, 0, size, 0b01001, rd, rn, rm);
+  void sqshl(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
+    ASIMD3RegSame(0, size, 0b01001, rd, rn, rm);
   }
-  void srshl(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::ScalarRegSize::i64Bit, "Only supports 64-bit");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
-    ASIMD3RegSame(Op, 0, size, 0b01010, rd, rn, rm);
+  void srshl(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
+    ASIMD3RegSame(0, size, 0b01010, rd, rn, rm);
   }
-  void sqrshl(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
-    ASIMD3RegSame(Op, 0, size, 0b01011, rd, rn, rm);
+  void sqrshl(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
+    ASIMD3RegSame(0, size, 0b01011, rd, rn, rm);
   }
-  void add(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::ScalarRegSize::i64Bit, "Only supports 64-bit");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
-    ASIMD3RegSame(Op, 0, size, 0b10000, rd, rn, rm);
+  void add(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
+    ASIMD3RegSame(0, size, 0b10000, rd, rn, rm);
   }
-  void cmtst(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::ScalarRegSize::i64Bit, "Only supports 64-bit");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
-    ASIMD3RegSame(Op, 0, size, 0b10001, rd, rn, rm);
+  void cmtst(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
+    ASIMD3RegSame(0, size, 0b10001, rd, rn, rm);
   }
-  void sqdmulh(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i32Bit || size == ARMEmitter::ScalarRegSize::i16Bit, "Invalid size");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
-    ASIMD3RegSame(Op, 0, size, 0b10110, rd, rn, rm);
+  void sqdmulh(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i32Bit || size == ScalarRegSize::i16Bit, "Invalid size");
+    ASIMD3RegSame(0, size, 0b10110, rd, rn, rm);
   }
-  void fmulx(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
-    const FEXCore::ARMEmitter::ScalarRegSize ConvertedSize =
-      size == ARMEmitter::ScalarRegSize::i64Bit ?
-        ARMEmitter::ScalarRegSize::i16Bit :
-        ARMEmitter::ScalarRegSize::i8Bit;
+  void fmulx(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
 
-    ASIMD3RegSame(Op, 0, ConvertedSize, 0b11011, rd, rn, rm);
-  }
-  void fcmeq(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
-    const FEXCore::ARMEmitter::ScalarRegSize ConvertedSize =
-      size == ARMEmitter::ScalarRegSize::i64Bit ?
-        ARMEmitter::ScalarRegSize::i16Bit :
-        ARMEmitter::ScalarRegSize::i8Bit;
+    const ScalarRegSize ConvertedSize =
+      size == ScalarRegSize::i64Bit ?
+        ScalarRegSize::i16Bit :
+        ScalarRegSize::i8Bit;
 
-    ASIMD3RegSame(Op, 0, ConvertedSize, 0b11100, rd, rn, rm);
+    ASIMD3RegSame(0, ConvertedSize, 0b11011, rd, rn, rm);
   }
-  void frecps(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
-    const FEXCore::ARMEmitter::ScalarRegSize ConvertedSize =
-      size == ARMEmitter::ScalarRegSize::i64Bit ?
-        ARMEmitter::ScalarRegSize::i16Bit :
-        ARMEmitter::ScalarRegSize::i8Bit;
+  void fcmeq(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
 
-    ASIMD3RegSame(Op, 0, ConvertedSize, 0b11111, rd, rn, rm);
-  }
-  void frsqrts(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
-    ASIMD3RegSame(Op, 0, size, 0b11111, rd, rn, rm);
-  }
-  void uqadd(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
-    ASIMD3RegSame(Op, 1, size, 0b00001, rd, rn, rm);
-  }
-  void uqsub(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
-    ASIMD3RegSame(Op, 1, size, 0b00101, rd, rn, rm);
-  }
-  void cmhi(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::ScalarRegSize::i64Bit, "Only supports 64-bit");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
-    ASIMD3RegSame(Op, 1, size, 0b00110, rd, rn, rm);
-  }
-  void cmhs(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::ScalarRegSize::i64Bit, "Only supports 64-bit");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
-    ASIMD3RegSame(Op, 1, size, 0b00111, rd, rn, rm);
-  }
-  void ushl(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::ScalarRegSize::i64Bit, "Only supports 64-bit");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
-    ASIMD3RegSame(Op, 1, size, 0b01000, rd, rn, rm);
-  }
-  void uqshl(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
-    ASIMD3RegSame(Op, 1, size, 0b01001, rd, rn, rm);
-  }
-  void urshl(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::ScalarRegSize::i64Bit, "Only supports 64-bit");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
-    ASIMD3RegSame(Op, 1, size, 0b01010, rd, rn, rm);
-  }
-  void uqrshl(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
-    ASIMD3RegSame(Op, 1, size, 0b01011, rd, rn, rm);
-  }
-  void sub(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::ScalarRegSize::i64Bit, "Only supports 64-bit");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
-    ASIMD3RegSame(Op, 1, size, 0b10000, rd, rn, rm);
-  }
-  void cmeq(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::ScalarRegSize::i64Bit, "Only supports 64-bit");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
-    ASIMD3RegSame(Op, 1, size, 0b10001, rd, rn, rm);
-  }
-  void sqrdmulh(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i32Bit || size == ARMEmitter::ScalarRegSize::i16Bit, "Invalid size");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
-    ASIMD3RegSame(Op, 1, size, 0b10110, rd, rn, rm);
-  }
-  void fcmge(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
-    const FEXCore::ARMEmitter::ScalarRegSize ConvertedSize =
-      size == ARMEmitter::ScalarRegSize::i64Bit ?
-        ARMEmitter::ScalarRegSize::i16Bit :
-        ARMEmitter::ScalarRegSize::i8Bit;
+    const ScalarRegSize ConvertedSize =
+      size == ScalarRegSize::i64Bit ?
+        ScalarRegSize::i16Bit :
+        ScalarRegSize::i8Bit;
 
-    ASIMD3RegSame(Op, 1, ConvertedSize, 0b11100, rd, rn, rm);
+    ASIMD3RegSame(0, ConvertedSize, 0b11100, rd, rn, rm);
   }
-  void facge(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
-    const FEXCore::ARMEmitter::ScalarRegSize ConvertedSize =
-      size == ARMEmitter::ScalarRegSize::i64Bit ?
-        ARMEmitter::ScalarRegSize::i16Bit :
-        ARMEmitter::ScalarRegSize::i8Bit;
+  void frecps(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
 
-    ASIMD3RegSame(Op, 1, ConvertedSize, 0b11101, rd, rn, rm);
+    const ScalarRegSize ConvertedSize =
+      size == ScalarRegSize::i64Bit ?
+        ScalarRegSize::i16Bit :
+        ScalarRegSize::i8Bit;
+
+    ASIMD3RegSame(0, ConvertedSize, 0b11111, rd, rn, rm);
   }
-  void fabd(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
-    ASIMD3RegSame(Op, 1, size, 0b11010, rd, rn, rm);
+  void frsqrts(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    ASIMD3RegSame(0, size, 0b11111, rd, rn, rm);
   }
-  void fcmgt(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
-    ASIMD3RegSame(Op, 1, size, 0b11100, rd, rn, rm);
+  void uqadd(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
+    ASIMD3RegSame(1, size, 0b00001, rd, rn, rm);
   }
-  void facgt(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'01 << 10;
-    ASIMD3RegSame(Op, 1, size, 0b11101, rd, rn, rm);
+  void uqsub(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
+    ASIMD3RegSame(1, size, 0b00101, rd, rn, rm);
+  }
+  void cmhi(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
+    ASIMD3RegSame(1, size, 0b00110, rd, rn, rm);
+  }
+  void cmhs(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
+    ASIMD3RegSame(1, size, 0b00111, rd, rn, rm);
+  }
+  void ushl(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
+    ASIMD3RegSame(1, size, 0b01000, rd, rn, rm);
+  }
+  void uqshl(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
+    ASIMD3RegSame(1, size, 0b01001, rd, rn, rm);
+  }
+  void urshl(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
+    ASIMD3RegSame(1, size, 0b01010, rd, rn, rm);
+  }
+  void uqrshl(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
+    ASIMD3RegSame(1, size, 0b01011, rd, rn, rm);
+  }
+  void sub(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
+    ASIMD3RegSame(1, size, 0b10000, rd, rn, rm);
+  }
+  void cmeq(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
+    ASIMD3RegSame(1, size, 0b10001, rd, rn, rm);
+  }
+  void sqrdmulh(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i32Bit || size == ScalarRegSize::i16Bit, "Invalid size");
+    ASIMD3RegSame(1, size, 0b10110, rd, rn, rm);
+  }
+  void fcmge(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+
+    const ScalarRegSize ConvertedSize =
+      size == ScalarRegSize::i64Bit ?
+        ScalarRegSize::i16Bit :
+        ScalarRegSize::i8Bit;
+
+    ASIMD3RegSame(1, ConvertedSize, 0b11100, rd, rn, rm);
+  }
+  void facge(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+
+    const ScalarRegSize ConvertedSize =
+      size == ScalarRegSize::i64Bit ?
+        ScalarRegSize::i16Bit :
+        ScalarRegSize::i8Bit;
+
+    ASIMD3RegSame(1, ConvertedSize, 0b11101, rd, rn, rm);
+  }
+  void fabd(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    ASIMD3RegSame(1, size, 0b11010, rd, rn, rm);
+  }
+  void fcmgt(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    ASIMD3RegSame(1, size, 0b11100, rd, rn, rm);
+  }
+  void facgt(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
+    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    ASIMD3RegSame(1, size, 0b11101, rd, rn, rm);
   }
 // Advanced SIMD scalar shift by immediate
   void sshr(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Shift) {
@@ -1543,8 +1517,8 @@ private:
     dc32(Instr);
   }
 // Advanced SIMD scalar three same
-  void ASIMD3RegSame(uint32_t Op, uint32_t U, FEXCore::ARMEmitter::ScalarRegSize size, uint32_t opcode, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
-    uint32_t Instr = Op;
+  void ASIMD3RegSame(uint32_t U, ScalarRegSize size, uint32_t opcode, VRegister rd, VRegister rn, VRegister rm) {
+    uint32_t Instr = 0b0101'1110'0010'0000'0000'0100'0000'0000;
 
     Instr |= U << 29;
     Instr |= FEXCore::ToUnderlying(size) << 22;

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ScalarOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ScalarOps.inl
@@ -1163,67 +1163,43 @@ public:
   }
 
 // Floating-point data-processing (3 source)
-  void fmadd(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn, FEXCore::ARMEmitter::SRegister rm, FEXCore::ARMEmitter::SRegister ra) {
-    constexpr uint32_t Op = 0b0001'1111'000 << 21;
-
-    Float3Source(Op, 0, 0, 0b00, 0, 0, rd.V(), rn.V(), rm.V(), ra.V());
+  void fmadd(SRegister rd, SRegister rn, SRegister rm, SRegister ra) {
+    Float3Source(0, 0, 0b00, 0, 0, rd.V(), rn.V(), rm.V(), ra.V());
   }
-  void fmsub(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn, FEXCore::ARMEmitter::SRegister rm, FEXCore::ARMEmitter::SRegister ra) {
-    constexpr uint32_t Op = 0b0001'1111'000 << 21;
-
-    Float3Source(Op, 0, 0, 0b00, 0, 1, rd.V(), rn.V(), rm.V(), ra.V());
+  void fmsub(SRegister rd, SRegister rn, SRegister rm, SRegister ra) {
+    Float3Source(0, 0, 0b00, 0, 1, rd.V(), rn.V(), rm.V(), ra.V());
   }
-  void fnmadd(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn, FEXCore::ARMEmitter::SRegister rm, FEXCore::ARMEmitter::SRegister ra) {
-    constexpr uint32_t Op = 0b0001'1111'000 << 21;
-
-    Float3Source(Op, 0, 0, 0b00, 1, 0, rd.V(), rn.V(), rm.V(), ra.V());
+  void fnmadd(SRegister rd, SRegister rn, SRegister rm, SRegister ra) {
+    Float3Source(0, 0, 0b00, 1, 0, rd.V(), rn.V(), rm.V(), ra.V());
   }
-  void fnmsub(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn, FEXCore::ARMEmitter::SRegister rm, FEXCore::ARMEmitter::SRegister ra) {
-    constexpr uint32_t Op = 0b0001'1111'000 << 21;
-
-    Float3Source(Op, 0, 0, 0b00, 1, 1, rd.V(), rn.V(), rm.V(), ra.V());
+  void fnmsub(SRegister rd, SRegister rn, SRegister rm, SRegister ra) {
+    Float3Source(0, 0, 0b00, 1, 1, rd.V(), rn.V(), rm.V(), ra.V());
   }
 
-  void fmadd(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm, FEXCore::ARMEmitter::DRegister ra) {
-    constexpr uint32_t Op = 0b0001'1111'000 << 21;
-
-    Float3Source(Op, 0, 0, 0b01, 0, 0, rd.V(), rn.V(), rm.V(), ra.V());
+  void fmadd(DRegister rd, DRegister rn, DRegister rm, DRegister ra) {
+    Float3Source(0, 0, 0b01, 0, 0, rd.V(), rn.V(), rm.V(), ra.V());
   }
-  void fmsub(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm, FEXCore::ARMEmitter::DRegister ra) {
-    constexpr uint32_t Op = 0b0001'1111'000 << 21;
-
-    Float3Source(Op, 0, 0, 0b01, 0, 1, rd.V(), rn.V(), rm.V(), ra.V());
+  void fmsub(DRegister rd, DRegister rn, DRegister rm, DRegister ra) {
+    Float3Source(0, 0, 0b01, 0, 1, rd.V(), rn.V(), rm.V(), ra.V());
   }
-  void fnmadd(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm, FEXCore::ARMEmitter::DRegister ra) {
-    constexpr uint32_t Op = 0b0001'1111'000 << 21;
-
-    Float3Source(Op, 0, 0, 0b01, 1, 0, rd.V(), rn.V(), rm.V(), ra.V());
+  void fnmadd(DRegister rd, DRegister rn, DRegister rm, DRegister ra) {
+    Float3Source(0, 0, 0b01, 1, 0, rd.V(), rn.V(), rm.V(), ra.V());
   }
-  void fnmsub(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm, FEXCore::ARMEmitter::DRegister ra) {
-    constexpr uint32_t Op = 0b0001'1111'000 << 21;
-
-    Float3Source(Op, 0, 0, 0b01, 1, 1, rd.V(), rn.V(), rm.V(), ra.V());
+  void fnmsub(DRegister rd, DRegister rn, DRegister rm, DRegister ra) {
+    Float3Source(0, 0, 0b01, 1, 1, rd.V(), rn.V(), rm.V(), ra.V());
   }
 
-  void fmadd(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm, FEXCore::ARMEmitter::HRegister ra) {
-    constexpr uint32_t Op = 0b0001'1111'000 << 21;
-
-    Float3Source(Op, 0, 0, 0b11, 0, 0, rd.V(), rn.V(), rm.V(), ra.V());
+  void fmadd(HRegister rd, HRegister rn, HRegister rm, HRegister ra) {
+    Float3Source(0, 0, 0b11, 0, 0, rd.V(), rn.V(), rm.V(), ra.V());
   }
-  void fmsub(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm, FEXCore::ARMEmitter::HRegister ra) {
-    constexpr uint32_t Op = 0b0001'1111'000 << 21;
-
-    Float3Source(Op, 0, 0, 0b11, 0, 1, rd.V(), rn.V(), rm.V(), ra.V());
+  void fmsub(HRegister rd, HRegister rn, HRegister rm, HRegister ra) {
+    Float3Source(0, 0, 0b11, 0, 1, rd.V(), rn.V(), rm.V(), ra.V());
   }
-  void fnmadd(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm, FEXCore::ARMEmitter::HRegister ra) {
-    constexpr uint32_t Op = 0b0001'1111'000 << 21;
-
-    Float3Source(Op, 0, 0, 0b11, 1, 0, rd.V(), rn.V(), rm.V(), ra.V());
+  void fnmadd(HRegister rd, HRegister rn, HRegister rm, HRegister ra) {
+    Float3Source(0, 0, 0b11, 1, 0, rd.V(), rn.V(), rm.V(), ra.V());
   }
-  void fnmsub(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm, FEXCore::ARMEmitter::HRegister ra) {
-    constexpr uint32_t Op = 0b0001'1111'000 << 21;
-
-    Float3Source(Op, 0, 0, 0b11, 1, 1, rd.V(), rn.V(), rm.V(), ra.V());
+  void fnmsub(HRegister rd, HRegister rn, HRegister rm, HRegister ra) {
+    Float3Source(0, 0, 0b11, 1, 1, rd.V(), rn.V(), rm.V(), ra.V());
   }
 
 private:
@@ -1392,8 +1368,8 @@ private:
   }
 
 // Floating-point data-processing (3 source)
-  void Float3Source(uint32_t Op, uint32_t M, uint32_t S, uint32_t ptype, uint32_t o1, uint32_t o0, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm, FEXCore::ARMEmitter::VRegister ra) {
-    uint32_t Instr = Op;
+  void Float3Source(uint32_t M, uint32_t S, uint32_t ptype, uint32_t o1, uint32_t o0, VRegister rd, VRegister rn, VRegister rm, VRegister ra) {
+    uint32_t Instr = 0b0001'1111'0000'0000'0000'0000'0000'0000;
 
     Instr |= M << 31;
     Instr |= S << 29;

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ScalarOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ScalarOps.inl
@@ -130,329 +130,277 @@ public:
 // Advanced SIMD scalar three same extra
 // XXX:
 // Advanced SIMD scalar two-register miscellaneous
-  void suqadd(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
-
-    ASIMDScalar2RegMisc(Op, 0, size, 0b00011, rd, rn);
+  void suqadd(ScalarRegSize size, VRegister rd, VRegister rn) {
+    ASIMDScalar2RegMisc(0, 0, size, 0b00011, rd, rn);
   }
-  void sqabs(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
-
-    ASIMDScalar2RegMisc(Op, 0, size, 0b00111, rd, rn);
+  void sqabs(ScalarRegSize size, VRegister rd, VRegister rn) {
+    ASIMDScalar2RegMisc(0, 0, size, 0b00111, rd, rn);
   }
 
   ///< Comparison against 0.0
-  void cmgt(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::ScalarRegSize::i64Bit, "Only supports 64-bit");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
-
-    ASIMDScalar2RegMisc(Op, 0, size, 0b01000, rd, rn);
+  void cmgt(ScalarRegSize size, VRegister rd, VRegister rn) {
+    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
+    ASIMDScalar2RegMisc(0, 0, size, 0b01000, rd, rn);
   }
   ///< Comparison against 0.0
-  void cmeq(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::ScalarRegSize::i64Bit, "Only supports 64-bit");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
-
-    ASIMDScalar2RegMisc(Op, 0, size, 0b01001, rd, rn);
+  void cmeq(ScalarRegSize size, VRegister rd, VRegister rn) {
+    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
+    ASIMDScalar2RegMisc(0, 0, size, 0b01001, rd, rn);
   }
 
   ///< Comparison against 0.0
-  void cmlt(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::ScalarRegSize::i64Bit, "Only supports 64-bit");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
-
-    ASIMDScalar2RegMisc(Op, 0, size, 0b01010, rd, rn);
+  void cmlt(ScalarRegSize size, VRegister rd, VRegister rn) {
+    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
+    ASIMDScalar2RegMisc(0, 0, size, 0b01010, rd, rn);
   }
-  void abs(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::ScalarRegSize::i64Bit, "Only supports 64-bit");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
-
-    ASIMDScalar2RegMisc(Op, 0, size, 0b01011, rd, rn);
+  void abs(ScalarRegSize size, VRegister rd, VRegister rn) {
+    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
+    ASIMDScalar2RegMisc(0, 0, size, 0b01011, rd, rn);
   }
   ///< size is destination size.
-  void sqxtn(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::ScalarRegSize::i64Bit, "64-bit destination not supported");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
-
-    ASIMDScalar2RegMisc(Op, 0, size, 0b10100, rd, rn);
+  void sqxtn(ScalarRegSize size, VRegister rd, VRegister rn) {
+    LOGMAN_THROW_AA_FMT(size != ScalarRegSize::i64Bit, "64-bit destination not supported");
+    ASIMDScalar2RegMisc(0, 0, size, 0b10100, rd, rn);
   }
 
-  void fcvtns(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
-    const FEXCore::ARMEmitter::ScalarRegSize ConvertedSize =
-      size == ARMEmitter::ScalarRegSize::i64Bit ?
-        ARMEmitter::ScalarRegSize::i16Bit :
-        ARMEmitter::ScalarRegSize::i8Bit;
+  void fcvtns(ScalarRegSize size, VRegister rd, VRegister rn) {
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
 
-    ASIMDScalar2RegMisc(Op, 0, ConvertedSize, 0b11010, rd, rn);
+    const ScalarRegSize ConvertedSize =
+      size == ScalarRegSize::i64Bit ?
+        ScalarRegSize::i16Bit :
+        ScalarRegSize::i8Bit;
+
+    ASIMDScalar2RegMisc(0, 0, ConvertedSize, 0b11010, rd, rn);
   }
-  void fcvtms(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
-    const FEXCore::ARMEmitter::ScalarRegSize ConvertedSize =
-      size == ARMEmitter::ScalarRegSize::i64Bit ?
-        ARMEmitter::ScalarRegSize::i16Bit :
-        ARMEmitter::ScalarRegSize::i8Bit;
+  void fcvtms(ScalarRegSize size, VRegister rd, VRegister rn) {
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
 
-    ASIMDScalar2RegMisc(Op, 0, ConvertedSize, 0b11011, rd, rn);
+    const ScalarRegSize ConvertedSize =
+      size == ScalarRegSize::i64Bit ?
+        ScalarRegSize::i16Bit :
+        ScalarRegSize::i8Bit;
+
+    ASIMDScalar2RegMisc(0, 0, ConvertedSize, 0b11011, rd, rn);
   }
-  void fcvtas(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
-    const FEXCore::ARMEmitter::ScalarRegSize ConvertedSize =
-      size == ARMEmitter::ScalarRegSize::i64Bit ?
-        ARMEmitter::ScalarRegSize::i16Bit :
-        ARMEmitter::ScalarRegSize::i8Bit;
+  void fcvtas(ScalarRegSize size, VRegister rd, VRegister rn) {
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
 
-    ASIMDScalar2RegMisc(Op, 0, ConvertedSize, 0b11100, rd, rn);
+    const ScalarRegSize ConvertedSize =
+      size == ScalarRegSize::i64Bit ?
+        ScalarRegSize::i16Bit :
+        ScalarRegSize::i8Bit;
+
+    ASIMDScalar2RegMisc(0, 0, ConvertedSize, 0b11100, rd, rn);
   }
-  void scvtf(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
-    const FEXCore::ARMEmitter::ScalarRegSize ConvertedSize =
-      size == ARMEmitter::ScalarRegSize::i64Bit ?
-        ARMEmitter::ScalarRegSize::i16Bit :
-        ARMEmitter::ScalarRegSize::i8Bit;
+  void scvtf(ScalarRegSize size, VRegister rd, VRegister rn) {
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
 
-    ASIMDScalar2RegMisc(Op, 0, ConvertedSize, 0b11101, rd, rn);
+    const ScalarRegSize ConvertedSize =
+      size == ScalarRegSize::i64Bit ?
+        ScalarRegSize::i16Bit :
+        ScalarRegSize::i8Bit;
+
+    ASIMDScalar2RegMisc(0, 0, ConvertedSize, 0b11101, rd, rn);
   }
 
   ///< Comparison against 0.0
-  void fcmgt(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float compare");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
-
-    ASIMDScalar2RegMisc(Op, 0, size, 0b01100, rd, rn);
+  void fcmgt(ScalarRegSize size, VRegister rd, VRegister rn) {
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float compare");
+    ASIMDScalar2RegMisc(0, 0, size, 0b01100, rd, rn);
   }
   ///< Comparison against 0.0
-  void fcmeq(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float compare");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
-
-    ASIMDScalar2RegMisc(Op, 0, size, 0b01101, rd, rn);
+  void fcmeq(ScalarRegSize size, VRegister rd, VRegister rn) {
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float compare");
+    ASIMDScalar2RegMisc(0, 0, size, 0b01101, rd, rn);
   }
   ///< Comparison against 0.0
-  void fcmlt(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float compare");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
+  void fcmlt(ScalarRegSize size, VRegister rd, VRegister rn) {
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float compare");
 
-    ASIMDScalar2RegMisc(Op, 0, size, 0b01110, rd, rn);
+    ASIMDScalar2RegMisc(0, 0, size, 0b01110, rd, rn);
   }
-  void fcvtps(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
+  void fcvtps(ScalarRegSize size, VRegister rd, VRegister rn) {
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
 
-    ASIMDScalar2RegMisc(Op, 0, size, 0b11010, rd, rn);
+    ASIMDScalar2RegMisc(0, 0, size, 0b11010, rd, rn);
   }
-  void fcvtzs(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
+  void fcvtzs(ScalarRegSize size, VRegister rd, VRegister rn) {
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
 
-    ASIMDScalar2RegMisc(Op, 0, size, 0b11011, rd, rn);
+    ASIMDScalar2RegMisc(0, 0, size, 0b11011, rd, rn);
   }
-  void frecpe(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
+  void frecpe(ScalarRegSize size, VRegister rd, VRegister rn) {
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
 
-    ASIMDScalar2RegMisc(Op, 0, size, 0b11101, rd, rn);
+    ASIMDScalar2RegMisc(0, 0, size, 0b11101, rd, rn);
   }
-  void frecpx(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
+  void frecpx(ScalarRegSize size, VRegister rd, VRegister rn) {
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
 
-    ASIMDScalar2RegMisc(Op, 0, size, 0b11111, rd, rn);
+    ASIMDScalar2RegMisc(0, 0, size, 0b11111, rd, rn);
   }
-  void usqadd(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
-
-    ASIMDScalar2RegMisc(Op, 1, size, 0b00011, rd, rn);
+  void usqadd(ScalarRegSize size, VRegister rd, VRegister rn) {
+    ASIMDScalar2RegMisc(0, 1, size, 0b00011, rd, rn);
   }
-  void sqneg(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
-
-    ASIMDScalar2RegMisc(Op, 1, size, 0b00111, rd, rn);
+  void sqneg(ScalarRegSize size, VRegister rd, VRegister rn) {
+    ASIMDScalar2RegMisc(0, 1, size, 0b00111, rd, rn);
   }
   ///< Comparison against 0.0
-  void cmge(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::ScalarRegSize::i64Bit, "Only supports 64-bit");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
-
-    ASIMDScalar2RegMisc(Op, 1, size, 0b01000, rd, rn);
+  void cmge(ScalarRegSize size, VRegister rd, VRegister rn) {
+    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
+    ASIMDScalar2RegMisc(0, 1, size, 0b01000, rd, rn);
   }
   ///< Comparison against 0.0
-  void cmle(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::ScalarRegSize::i64Bit, "Only supports 64-bit");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
-
-    ASIMDScalar2RegMisc(Op, 1, size, 0b01001, rd, rn);
+  void cmle(ScalarRegSize size, VRegister rd, VRegister rn) {
+    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
+    ASIMDScalar2RegMisc(0, 1, size, 0b01001, rd, rn);
   }
-  void neg(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_AA_FMT(size == FEXCore::ARMEmitter::ScalarRegSize::i64Bit, "Only supports 64-bit");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
-
-    ASIMDScalar2RegMisc(Op, 1, size, 0b01011, rd, rn);
+  void neg(ScalarRegSize size, VRegister rd, VRegister rn) {
+    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
+    ASIMDScalar2RegMisc(0, 1, size, 0b01011, rd, rn);
   }
   ///< size is destination.
-  void sqxtun(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::ScalarRegSize::i64Bit, "64-bit destination not supported");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
-
-    ASIMDScalar2RegMisc(Op, 1, size, 0b10010, rd, rn);
+  void sqxtun(ScalarRegSize size, VRegister rd, VRegister rn) {
+    LOGMAN_THROW_AA_FMT(size != ScalarRegSize::i64Bit, "64-bit destination not supported");
+    ASIMDScalar2RegMisc(0, 1, size, 0b10010, rd, rn);
   }
   ///< size is destination.
-  void uqxtn(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_AA_FMT(size != FEXCore::ARMEmitter::ScalarRegSize::i64Bit, "64-bit destination not supported");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
-
-    ASIMDScalar2RegMisc(Op, 1, size, 0b10100, rd, rn);
+  void uqxtn(ScalarRegSize size, VRegister rd, VRegister rn) {
+    LOGMAN_THROW_AA_FMT(size != ScalarRegSize::i64Bit, "64-bit destination not supported");
+    ASIMDScalar2RegMisc(0, 1, size, 0b10100, rd, rn);
   }
   ///< size is destination.
-  void fcvtxn(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
-    ASIMDScalar2RegMisc(Op, 1, ARMEmitter::ScalarRegSize::i16Bit, 0b10110, rd, rn);
+  void fcvtxn(ScalarRegSize size, VRegister rd, VRegister rn) {
+    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    ASIMDScalar2RegMisc(0, 1, ScalarRegSize::i16Bit, 0b10110, rd, rn);
   }
-  void fcvtnu(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
-    const FEXCore::ARMEmitter::ScalarRegSize ConvertedSize =
-      size == ARMEmitter::ScalarRegSize::i64Bit ?
-        ARMEmitter::ScalarRegSize::i16Bit :
-        ARMEmitter::ScalarRegSize::i8Bit;
+  void fcvtnu(ScalarRegSize size, VRegister rd, VRegister rn) {
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
 
-    ASIMDScalar2RegMisc(Op, 1, ConvertedSize, 0b11010, rd, rn);
+    const ScalarRegSize ConvertedSize =
+      size == ScalarRegSize::i64Bit ?
+        ScalarRegSize::i16Bit :
+        ScalarRegSize::i8Bit;
+
+    ASIMDScalar2RegMisc(0, 1, ConvertedSize, 0b11010, rd, rn);
   }
-  void fcvtmu(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
-    const FEXCore::ARMEmitter::ScalarRegSize ConvertedSize =
-      size == ARMEmitter::ScalarRegSize::i64Bit ?
-        ARMEmitter::ScalarRegSize::i16Bit :
-        ARMEmitter::ScalarRegSize::i8Bit;
+  void fcvtmu(ScalarRegSize size, VRegister rd, VRegister rn) {
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
 
-    ASIMDScalar2RegMisc(Op, 1, ConvertedSize, 0b11011, rd, rn);
+    const ScalarRegSize ConvertedSize =
+      size == ScalarRegSize::i64Bit ?
+        ScalarRegSize::i16Bit :
+        ScalarRegSize::i8Bit;
+
+    ASIMDScalar2RegMisc(0, 1, ConvertedSize, 0b11011, rd, rn);
   }
-  void fcvtau(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
-    const FEXCore::ARMEmitter::ScalarRegSize ConvertedSize =
-      size == ARMEmitter::ScalarRegSize::i64Bit ?
-        ARMEmitter::ScalarRegSize::i16Bit :
-        ARMEmitter::ScalarRegSize::i8Bit;
+  void fcvtau(ScalarRegSize size, VRegister rd, VRegister rn) {
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
 
-    ASIMDScalar2RegMisc(Op, 1, ConvertedSize, 0b11100, rd, rn);
+    const ScalarRegSize ConvertedSize =
+      size == ScalarRegSize::i64Bit ?
+        ScalarRegSize::i16Bit :
+        ScalarRegSize::i8Bit;
+
+    ASIMDScalar2RegMisc(0, 1, ConvertedSize, 0b11100, rd, rn);
   }
-  void ucvtf(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
-    const FEXCore::ARMEmitter::ScalarRegSize ConvertedSize =
-      size == ARMEmitter::ScalarRegSize::i64Bit ?
-        ARMEmitter::ScalarRegSize::i16Bit :
-        ARMEmitter::ScalarRegSize::i8Bit;
+  void ucvtf(ScalarRegSize size, VRegister rd, VRegister rn) {
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
 
-    ASIMDScalar2RegMisc(Op, 1, ConvertedSize, 0b11101, rd, rn);
-  }
-  ///< Comparison against 0.0
-  void fcmge(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
+    const ScalarRegSize ConvertedSize =
+      size == ScalarRegSize::i64Bit ?
+        ScalarRegSize::i16Bit :
+        ScalarRegSize::i8Bit;
 
-    ASIMDScalar2RegMisc(Op, 1, size, 0b01100, rd, rn);
+    ASIMDScalar2RegMisc(0, 1, ConvertedSize, 0b11101, rd, rn);
   }
   ///< Comparison against 0.0
-  void fcmle(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
+  void fcmge(ScalarRegSize size, VRegister rd, VRegister rn) {
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
 
-    ASIMDScalar2RegMisc(Op, 1, size, 0b01101, rd, rn);
+    ASIMDScalar2RegMisc(0, 1, size, 0b01100, rd, rn);
   }
-  void fcvtpu(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
+  ///< Comparison against 0.0
+  void fcmle(ScalarRegSize size, VRegister rd, VRegister rn) {
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
 
-    ASIMDScalar2RegMisc(Op, 1, size, 0b11010, rd, rn);
+    ASIMDScalar2RegMisc(0, 1, size, 0b01101, rd, rn);
   }
-  void fcvtzu(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
+  void fcvtpu(ScalarRegSize size, VRegister rd, VRegister rn) {
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
 
-    ASIMDScalar2RegMisc(Op, 1, size, 0b11011, rd, rn);
+    ASIMDScalar2RegMisc(0, 1, size, 0b11010, rd, rn);
   }
-  void frsqrte(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
-    constexpr uint32_t Op = 0b0101'1110'0010'0000'0000'10 << 10;
+  void fcvtzu(ScalarRegSize size, VRegister rd, VRegister rn) {
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
 
-    ASIMDScalar2RegMisc(Op, 1, size, 0b11101, rd, rn);
+    ASIMDScalar2RegMisc(0, 1, size, 0b11011, rd, rn);
+  }
+  void frsqrte(ScalarRegSize size, VRegister rd, VRegister rn) {
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+
+    ASIMDScalar2RegMisc(0, 1, size, 0b11101, rd, rn);
   }
   // Advanced SIMD scalar pairwise
-  void addp(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for addp");
-    constexpr uint32_t Op = 0b0101'1110'0011'0000'0000'10 << 10;
-
-    ASIMDScalar2RegMisc(Op, 0, size, 0b11011, rd, rn);
+  void addp(ScalarRegSize size, VRegister rd, VRegister rn) {
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit, "Invalid size selected for addp");
+    ASIMDScalar2RegMisc(1, 0, size, 0b11011, rd, rn);
   }
 
-  void fmaxnmp(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0101'1110'0011'0000'0000'10 << 10;
-    ASIMDScalar2RegMisc(Op, 0, ARMEmitter::ScalarRegSize::i8Bit, 0b01100, rd.V(), rn.V());
+  void fmaxnmp(HRegister rd, HRegister rn) {
+    ASIMDScalar2RegMisc(1, 0, ScalarRegSize::i8Bit, 0b01100, rd.V(), rn.V());
   }
-  void faddp(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0101'1110'0011'0000'0000'10 << 10;
-    ASIMDScalar2RegMisc(Op, 0, ARMEmitter::ScalarRegSize::i8Bit, 0b01101, rd.V(), rn.V());
+  void faddp(HRegister rd, HRegister rn) {
+    ASIMDScalar2RegMisc(1, 0, ScalarRegSize::i8Bit, 0b01101, rd.V(), rn.V());
   }
-  void fmaxp(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0101'1110'0011'0000'0000'10 << 10;
-    ASIMDScalar2RegMisc(Op, 0, ARMEmitter::ScalarRegSize::i8Bit, 0b01111, rd.V(), rn.V());
+  void fmaxp(HRegister rd, HRegister rn) {
+    ASIMDScalar2RegMisc(1, 0, ScalarRegSize::i8Bit, 0b01111, rd.V(), rn.V());
   }
-  void fminnmp(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0101'1110'0011'0000'0000'10 << 10;
-    ASIMDScalar2RegMisc(Op, 0, ARMEmitter::ScalarRegSize::i32Bit, 0b01100, rd.V(), rn.V());
+  void fminnmp(HRegister rd, HRegister rn) {
+    ASIMDScalar2RegMisc(1, 0, ScalarRegSize::i32Bit, 0b01100, rd.V(), rn.V());
   }
-  void fminp(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0101'1110'0011'0000'0000'10 << 10;
-    ASIMDScalar2RegMisc(Op, 0, ARMEmitter::ScalarRegSize::i32Bit, 0b01111, rd.V(), rn.V());
+  void fminp(HRegister rd, HRegister rn) {
+    ASIMDScalar2RegMisc(1, 0, ScalarRegSize::i32Bit, 0b01111, rd.V(), rn.V());
   }
 
-  void fmaxnmp(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
-    constexpr uint32_t Op = 0b0101'1110'0011'0000'0000'10 << 10;
-    const FEXCore::ARMEmitter::ScalarRegSize ConvertedSize =
-      size == ARMEmitter::ScalarRegSize::i64Bit ?
-        ARMEmitter::ScalarRegSize::i16Bit :
-        ARMEmitter::ScalarRegSize::i8Bit;
+  void fmaxnmp(ScalarRegSize size, VRegister rd, VRegister rn) {
+    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
 
-    ASIMDScalar2RegMisc(Op, 1, ConvertedSize, 0b01100, rd, rn);
-  }
-  void faddp(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
-    constexpr uint32_t Op = 0b0101'1110'0011'0000'0000'10 << 10;
-    const FEXCore::ARMEmitter::ScalarRegSize ConvertedSize =
-      size == ARMEmitter::ScalarRegSize::i64Bit ?
-        ARMEmitter::ScalarRegSize::i16Bit :
-        ARMEmitter::ScalarRegSize::i8Bit;
+    const ScalarRegSize ConvertedSize =
+      size == ScalarRegSize::i64Bit ?
+        ScalarRegSize::i16Bit :
+        ScalarRegSize::i8Bit;
 
-    ASIMDScalar2RegMisc(Op, 1, ConvertedSize, 0b01101, rd, rn);
+    ASIMDScalar2RegMisc(1, 1, ConvertedSize, 0b01100, rd, rn);
   }
-  void fmaxp(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
-    constexpr uint32_t Op = 0b0101'1110'0011'0000'0000'10 << 10;
-    const FEXCore::ARMEmitter::ScalarRegSize ConvertedSize =
-      size == ARMEmitter::ScalarRegSize::i64Bit ?
-        ARMEmitter::ScalarRegSize::i16Bit :
-        ARMEmitter::ScalarRegSize::i8Bit;
+  void faddp(ScalarRegSize size, VRegister rd, VRegister rn) {
+    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
 
-    ASIMDScalar2RegMisc(Op, 1, ConvertedSize, 0b01111, rd, rn);
+    const ScalarRegSize ConvertedSize =
+      size == ScalarRegSize::i64Bit ?
+        ScalarRegSize::i16Bit :
+        ScalarRegSize::i8Bit;
+
+    ASIMDScalar2RegMisc(1, 1, ConvertedSize, 0b01101, rd, rn);
   }
-  void fminnmp(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
-    constexpr uint32_t Op = 0b0101'1110'0011'0000'0000'10 << 10;
-    ASIMDScalar2RegMisc(Op, 1, size, 0b01100, rd, rn);
+  void fmaxp(ScalarRegSize size, VRegister rd, VRegister rn) {
+    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+
+    const ScalarRegSize ConvertedSize =
+      size == ScalarRegSize::i64Bit ?
+        ScalarRegSize::i16Bit :
+        ScalarRegSize::i8Bit;
+
+    ASIMDScalar2RegMisc(1, 1, ConvertedSize, 0b01111, rd, rn);
   }
-  void fminp(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit || size == ARMEmitter::ScalarRegSize::i32Bit, "Invalid size selected for float convert");
-    constexpr uint32_t Op = 0b0101'1110'0011'0000'0000'10 << 10;
-    ASIMDScalar2RegMisc(Op, 1, size, 0b01111, rd, rn);
+  void fminnmp(ScalarRegSize size, VRegister rd, VRegister rn) {
+    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    ASIMDScalar2RegMisc(1, 1, size, 0b01100, rd, rn);
+  }
+  void fminp(ScalarRegSize size, VRegister rd, VRegister rn) {
+    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    ASIMDScalar2RegMisc(1, 1, size, 0b01111, rd, rn);
   }
 // Advanced SIMD scalar three different
   ///< size is destination.
@@ -1571,11 +1519,12 @@ private:
 // Advanced SIMD scalar three same extra
 // XXX:
 // Advanced SIMD scalar two-register miscellaneous
-  void ASIMDScalar2RegMisc(uint32_t Op, uint32_t U, FEXCore::ARMEmitter::ScalarRegSize size, uint32_t opcode, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    uint32_t Instr = Op;
+  void ASIMDScalar2RegMisc(uint32_t b20, uint32_t U, ScalarRegSize size, uint32_t opcode, VRegister rd, VRegister rn) {
+    uint32_t Instr = 0b0101'1110'0010'0000'0000'1000'0000'0000;
 
     Instr |= U << 29;
     Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= b20 << 20;
     Instr |= opcode << 12;
     Instr |= rn.Idx() << 5;
     Instr |= rd.Idx();

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ScalarOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ScalarOps.inl
@@ -579,238 +579,218 @@ public:
     ASIMD3RegSame(1, size, 0b11101, rd, rn, rm);
   }
 // Advanced SIMD scalar shift by immediate
-  void sshr(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Shift) {
+  void sshr(ScalarRegSize size, VRegister rd, VRegister rn, uint32_t Shift) {
     LOGMAN_THROW_AA_FMT(Shift > 0 && Shift < 64, "Invalid shift for sshr");
     LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sshr");
-    constexpr uint32_t Op = 0b0101'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = ScalarRegSizeInBits(size);
     // Shift encoded in immh:immb, but inverted with 128-bit source
     // shift = (esize * 2) - immh:immb
     const uint32_t InvertedShift = (SubregSizeInBits * 2) - Shift;
     const uint32_t immh = InvertedShift >> 3;
     const uint32_t immb = InvertedShift & 0b111;
-    ASIMDScalarShiftByImm(Op, 0, immh, immb, 0b00000, rd, rn);
+    ASIMDScalarShiftByImm(0, immh, immb, 0b00000, rd, rn);
   }
-  void ssra(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Shift) {
+  void ssra(ScalarRegSize size, VRegister rd, VRegister rn, uint32_t Shift) {
     LOGMAN_THROW_AA_FMT(Shift > 0 && Shift < 64, "Invalid shift for sshr");
     LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sshr");
-    constexpr uint32_t Op = 0b0101'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = ScalarRegSizeInBits(size);
     // Shift encoded in immh:immb, but inverted with 128-bit source
     // shift = (esize * 2) - immh:immb
     const uint32_t InvertedShift = (SubregSizeInBits * 2) - Shift;
     const uint32_t immh = InvertedShift >> 3;
     const uint32_t immb = InvertedShift & 0b111;
-    ASIMDScalarShiftByImm(Op, 0, immh, immb, 0b00010, rd, rn);
+    ASIMDScalarShiftByImm(0, immh, immb, 0b00010, rd, rn);
   }
-  void srshr(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Shift) {
+  void srshr(ScalarRegSize size, VRegister rd, VRegister rn, uint32_t Shift) {
     LOGMAN_THROW_AA_FMT(Shift > 0 && Shift < 64, "Invalid shift for sshr");
     LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sshr");
-    constexpr uint32_t Op = 0b0101'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = ScalarRegSizeInBits(size);
     // Shift encoded in immh:immb, but inverted with 128-bit source
     // shift = (esize * 2) - immh:immb
     const uint32_t InvertedShift = (SubregSizeInBits * 2) - Shift;
     const uint32_t immh = InvertedShift >> 3;
     const uint32_t immb = InvertedShift & 0b111;
-    ASIMDScalarShiftByImm(Op, 0, immh, immb, 0b00100, rd, rn);
+    ASIMDScalarShiftByImm(0, immh, immb, 0b00100, rd, rn);
   }
-  void srsra(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Shift) {
+  void srsra(ScalarRegSize size, VRegister rd, VRegister rn, uint32_t Shift) {
     LOGMAN_THROW_AA_FMT(Shift > 0 && Shift < 64, "Invalid shift for sshr");
     LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sshr");
-    constexpr uint32_t Op = 0b0101'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = ScalarRegSizeInBits(size);
     // Shift encoded in immh:immb, but inverted with 128-bit source
     // shift = (esize * 2) - immh:immb
     const uint32_t InvertedShift = (SubregSizeInBits * 2) - Shift;
     const uint32_t immh = InvertedShift >> 3;
     const uint32_t immb = InvertedShift & 0b111;
-    ASIMDScalarShiftByImm(Op, 0, immh, immb, 0b00110, rd, rn);
+    ASIMDScalarShiftByImm(0, immh, immb, 0b00110, rd, rn);
   }
-  void shl(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Shift) {
+  void shl(ScalarRegSize size, VRegister rd, VRegister rn, uint32_t Shift) {
     LOGMAN_THROW_AA_FMT(Shift > 0 && Shift < 64, "Invalid shift for sshr");
     LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sshr");
-    constexpr uint32_t Op = 0b0101'1111'0000'0000'0000'01 << 10;
     // Shift encoded a bit weirdly.
     // shift = immh:immb - elementsize but immh is /also/ used for element size.
     const uint32_t immh = 1 << FEXCore::ToUnderlying(size) | (Shift >> 3);
     const uint32_t immb = Shift & 0b111;
-    ASIMDScalarShiftByImm(Op, 0, immh, immb, 0b01010, rd, rn);
+    ASIMDScalarShiftByImm(0, immh, immb, 0b01010, rd, rn);
   }
-  void sqshl(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Shift) {
+  void sqshl(ScalarRegSize size, VRegister rd, VRegister rn, uint32_t Shift) {
     LOGMAN_THROW_A_FMT(Shift > 0 && Shift < ScalarRegSizeInBits(size), "Invalid shift for sshr");
-    constexpr uint32_t Op = 0b0101'1111'0000'0000'0000'01 << 10;
     // Shift encoded a bit weirdly.
     // shift = immh:immb - elementsize but immh is /also/ used for element size.
     const uint32_t immh = 1 << FEXCore::ToUnderlying(size) | (Shift >> 3);
     const uint32_t immb = Shift & 0b111;
-    ASIMDScalarShiftByImm(Op, 0, immh, immb, 0b01110, rd, rn);
+    ASIMDScalarShiftByImm(0, immh, immb, 0b01110, rd, rn);
   }
   ///< size is destination
-  void sqshrn(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Shift) {
+  void sqshrn(ScalarRegSize size, VRegister rd, VRegister rn, uint32_t Shift) {
     LOGMAN_THROW_A_FMT(Shift > 0 && Shift < ScalarRegSizeInBits(size), "Invalid shift for sshr");
     LOGMAN_THROW_AA_FMT(size != ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sqshrn");
-    constexpr uint32_t Op = 0b0101'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = ScalarRegSizeInBits(size);
     // Shift encoded in immh:immb, but inverted with 128-bit source
     // shift = (esize * 2) - immh:immb
     const uint32_t InvertedShift = (SubregSizeInBits * 2) - Shift;
     const uint32_t immh = InvertedShift >> 3;
     const uint32_t immb = InvertedShift & 0b111;
-    ASIMDScalarShiftByImm(Op, 0, immh, immb, 0b10010, rd, rn);
+    ASIMDScalarShiftByImm(0, immh, immb, 0b10010, rd, rn);
   }
-  void sqrshrn(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Shift) {
+  void sqrshrn(ScalarRegSize size, VRegister rd, VRegister rn, uint32_t Shift) {
     LOGMAN_THROW_A_FMT(Shift > 0 && Shift < ScalarRegSizeInBits(size), "Invalid shift for sshr");
     LOGMAN_THROW_AA_FMT(size != ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sqshrn");
-    constexpr uint32_t Op = 0b0101'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = ScalarRegSizeInBits(size);
     // Shift encoded in immh:immb, but inverted with 128-bit source
     // shift = (esize * 2) - immh:immb
     const uint32_t InvertedShift = (SubregSizeInBits * 2) - Shift;
     const uint32_t immh = InvertedShift >> 3;
     const uint32_t immb = InvertedShift & 0b111;
-    ASIMDScalarShiftByImm(Op, 0, immh, immb, 0b10011, rd, rn);
+    ASIMDScalarShiftByImm(0, immh, immb, 0b10011, rd, rn);
   }
   // TODO: SCVTF, FCVTZS
-  void ushr(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Shift) {
+  void ushr(ScalarRegSize size, VRegister rd, VRegister rn, uint32_t Shift) {
     LOGMAN_THROW_AA_FMT(Shift > 0 && Shift < 64, "Invalid shift for sshr");
     LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sshr");
-    constexpr uint32_t Op = 0b0101'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = ScalarRegSizeInBits(size);
     // Shift encoded in immh:immb, but inverted with 128-bit source
     // shift = (esize * 2) - immh:immb
     const uint32_t InvertedShift = (SubregSizeInBits * 2) - Shift;
     const uint32_t immh = InvertedShift >> 3;
     const uint32_t immb = InvertedShift & 0b111;
-    ASIMDScalarShiftByImm(Op, 1, immh, immb, 0b00000, rd, rn);
+    ASIMDScalarShiftByImm(1, immh, immb, 0b00000, rd, rn);
   }
-  void usra(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Shift) {
+  void usra(ScalarRegSize size, VRegister rd, VRegister rn, uint32_t Shift) {
     LOGMAN_THROW_AA_FMT(Shift > 0 && Shift < 64, "Invalid shift for sshr");
     LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sshr");
-    constexpr uint32_t Op = 0b0101'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = ScalarRegSizeInBits(size);
     // Shift encoded in immh:immb, but inverted with 128-bit source
     // shift = (esize * 2) - immh:immb
     const uint32_t InvertedShift = (SubregSizeInBits * 2) - Shift;
     const uint32_t immh = InvertedShift >> 3;
     const uint32_t immb = InvertedShift & 0b111;
-    ASIMDScalarShiftByImm(Op, 1, immh, immb, 0b00010, rd, rn);
+    ASIMDScalarShiftByImm(1, immh, immb, 0b00010, rd, rn);
   }
-  void urshr(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Shift) {
+  void urshr(ScalarRegSize size, VRegister rd, VRegister rn, uint32_t Shift) {
     LOGMAN_THROW_AA_FMT(Shift > 0 && Shift < 64, "Invalid shift for sshr");
     LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sshr");
-    constexpr uint32_t Op = 0b0101'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = ScalarRegSizeInBits(size);
     // Shift encoded in immh:immb, but inverted with 128-bit source
     // shift = (esize * 2) - immh:immb
     const uint32_t InvertedShift = (SubregSizeInBits * 2) - Shift;
     const uint32_t immh = InvertedShift >> 3;
     const uint32_t immb = InvertedShift & 0b111;
-    ASIMDScalarShiftByImm(Op, 1, immh, immb, 0b00100, rd, rn);
+    ASIMDScalarShiftByImm(1, immh, immb, 0b00100, rd, rn);
   }
-  void ursra(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Shift) {
+  void ursra(ScalarRegSize size, VRegister rd, VRegister rn, uint32_t Shift) {
     LOGMAN_THROW_AA_FMT(Shift > 0 && Shift < 64, "Invalid shift for sshr");
     LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sshr");
-    constexpr uint32_t Op = 0b0101'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = ScalarRegSizeInBits(size);
     // Shift encoded in immh:immb, but inverted with 128-bit source
     // shift = (esize * 2) - immh:immb
     const uint32_t InvertedShift = (SubregSizeInBits * 2) - Shift;
     const uint32_t immh = InvertedShift >> 3;
     const uint32_t immb = InvertedShift & 0b111;
-    ASIMDScalarShiftByImm(Op, 1, immh, immb, 0b00110, rd, rn);
+    ASIMDScalarShiftByImm(1, immh, immb, 0b00110, rd, rn);
   }
-  void sri(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Shift) {
+  void sri(ScalarRegSize size, VRegister rd, VRegister rn, uint32_t Shift) {
     LOGMAN_THROW_AA_FMT(Shift > 0 && Shift < 64, "Invalid shift for sshr");
     LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sshr");
-    constexpr uint32_t Op = 0b0101'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = ScalarRegSizeInBits(size);
     // Shift encoded in immh:immb, but inverted with 128-bit source
     // shift = (esize * 2) - immh:immb
     const uint32_t InvertedShift = (SubregSizeInBits * 2) - Shift;
     const uint32_t immh = InvertedShift >> 3;
     const uint32_t immb = InvertedShift & 0b111;
-    ASIMDScalarShiftByImm(Op, 1, immh, immb, 0b01000, rd, rn);
+    ASIMDScalarShiftByImm(1, immh, immb, 0b01000, rd, rn);
   }
-  void sli(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Shift) {
+  void sli(ScalarRegSize size, VRegister rd, VRegister rn, uint32_t Shift) {
     LOGMAN_THROW_AA_FMT(Shift > 0 && Shift < 64, "Invalid shift for sshr");
     LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sshr");
-    constexpr uint32_t Op = 0b0101'1111'0000'0000'0000'01 << 10;
     // Shift encoded a bit weirdly.
     // shift = immh:immb - elementsize but immh is /also/ used for element size.
     const uint32_t immh = 1 << FEXCore::ToUnderlying(size) | (Shift >> 3);
     const uint32_t immb = Shift & 0b111;
-    ASIMDScalarShiftByImm(Op, 1, immh, immb, 0b01010, rd, rn);
+    ASIMDScalarShiftByImm(1, immh, immb, 0b01010, rd, rn);
   }
-  void sqshlu(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Shift) {
+  void sqshlu(ScalarRegSize size, VRegister rd, VRegister rn, uint32_t Shift) {
     LOGMAN_THROW_A_FMT(Shift > 0 && Shift < ScalarRegSizeInBits(size), "Invalid shift for sshr");
-    constexpr uint32_t Op = 0b0101'1111'0000'0000'0000'01 << 10;
     // Shift encoded a bit weirdly.
     // shift = immh:immb - elementsize but immh is /also/ used for element size.
     const uint32_t immh = 1 << FEXCore::ToUnderlying(size) | (Shift >> 3);
     const uint32_t immb = Shift & 0b111;
-    ASIMDScalarShiftByImm(Op, 1, immh, immb, 0b01100, rd, rn);
+    ASIMDScalarShiftByImm(1, immh, immb, 0b01100, rd, rn);
   }
-  void uqshl(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Shift) {
+  void uqshl(ScalarRegSize size, VRegister rd, VRegister rn, uint32_t Shift) {
     LOGMAN_THROW_A_FMT(Shift > 0 && Shift < ScalarRegSizeInBits(size), "Invalid shift for sshr");
-    constexpr uint32_t Op = 0b0101'1111'0000'0000'0000'01 << 10;
     // Shift encoded a bit weirdly.
     // shift = immh:immb - elementsize but immh is /also/ used for element size.
     const uint32_t immh = 1 << FEXCore::ToUnderlying(size) | (Shift >> 3);
     const uint32_t immb = Shift & 0b111;
-    ASIMDScalarShiftByImm(Op, 1, immh, immb, 0b01110, rd, rn);
+    ASIMDScalarShiftByImm(1, immh, immb, 0b01110, rd, rn);
   }
   ///< size is destination.
-  void sqshrun(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Shift) {
+  void sqshrun(ScalarRegSize size, VRegister rd, VRegister rn, uint32_t Shift) {
     LOGMAN_THROW_A_FMT(Shift > 0 && Shift < ScalarRegSizeInBits(size), "Invalid shift for sshr");
     LOGMAN_THROW_AA_FMT(size != ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sqshrun");
-    constexpr uint32_t Op = 0b0101'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = ScalarRegSizeInBits(size);
     // Shift encoded in immh:immb, but inverted with 128-bit source
     // shift = (esize * 2) - immh:immb
     const uint32_t InvertedShift = (SubregSizeInBits * 2) - Shift;
     const uint32_t immh = InvertedShift >> 3;
     const uint32_t immb = InvertedShift & 0b111;
-    ASIMDScalarShiftByImm(Op, 1, immh, immb, 0b10000, rd, rn);
+    ASIMDScalarShiftByImm(1, immh, immb, 0b10000, rd, rn);
   }
   ///< size is destination.
-  void sqrshrun(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Shift) {
+  void sqrshrun(ScalarRegSize size, VRegister rd, VRegister rn, uint32_t Shift) {
     LOGMAN_THROW_A_FMT(Shift > 0 && Shift < ScalarRegSizeInBits(size), "Invalid shift for sshr");
     LOGMAN_THROW_AA_FMT(size != ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sqrshrun");
-    constexpr uint32_t Op = 0b0101'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = ScalarRegSizeInBits(size);
     // Shift encoded in immh:immb, but inverted with 128-bit source
     // shift = (esize * 2) - immh:immb
     const uint32_t InvertedShift = (SubregSizeInBits * 2) - Shift;
     const uint32_t immh = InvertedShift >> 3;
     const uint32_t immb = InvertedShift & 0b111;
-    ASIMDScalarShiftByImm(Op, 1, immh, immb, 0b10001, rd, rn);
+    ASIMDScalarShiftByImm(1, immh, immb, 0b10001, rd, rn);
   }
   ///< size is destination.
-  void uqshrn(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Shift) {
+  void uqshrn(ScalarRegSize size, VRegister rd, VRegister rn, uint32_t Shift) {
     LOGMAN_THROW_A_FMT(Shift > 0 && Shift < ScalarRegSizeInBits(size), "Invalid shift for sshr");
     LOGMAN_THROW_AA_FMT(size != ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sqrshrun");
-    constexpr uint32_t Op = 0b0101'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = ScalarRegSizeInBits(size);
     // Shift encoded in immh:immb, but inverted with 128-bit source
     // shift = (esize * 2) - immh:immb
     const uint32_t InvertedShift = (SubregSizeInBits * 2) - Shift;
     const uint32_t immh = InvertedShift >> 3;
     const uint32_t immb = InvertedShift & 0b111;
-    ASIMDScalarShiftByImm(Op, 1, immh, immb, 0b10010, rd, rn);
+    ASIMDScalarShiftByImm(1, immh, immb, 0b10010, rd, rn);
   }
   ///< size is destination.
-  void uqrshrn(FEXCore::ARMEmitter::ScalarRegSize size, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, uint32_t Shift) {
+  void uqrshrn(ScalarRegSize size, VRegister rd, VRegister rn, uint32_t Shift) {
     LOGMAN_THROW_A_FMT(Shift > 0 && Shift < ScalarRegSizeInBits(size), "Invalid shift for sshr");
     LOGMAN_THROW_AA_FMT(size != ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sqrshrun");
-    constexpr uint32_t Op = 0b0101'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = ScalarRegSizeInBits(size);
     // Shift encoded in immh:immb, but inverted with 128-bit source
     // shift = (esize * 2) - immh:immb
     const uint32_t InvertedShift = (SubregSizeInBits * 2) - Shift;
     const uint32_t immh = InvertedShift >> 3;
     const uint32_t immb = InvertedShift & 0b111;
-    ASIMDScalarShiftByImm(Op, 1, immh, immb, 0b10011, rd, rn);
+    ASIMDScalarShiftByImm(1, immh, immb, 0b10011, rd, rn);
   }
   // TODO: UCVTF, FCVTZU
 // Advanced SIMD scalar x indexed element
@@ -1529,8 +1509,8 @@ private:
     dc32(Instr);
   }
 // Advanced SIMD scalar shift by immediate
-  void ASIMDScalarShiftByImm(uint32_t Op, uint32_t U, uint32_t immh, uint32_t immb, uint32_t opcode, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    uint32_t Instr = Op;
+  void ASIMDScalarShiftByImm(uint32_t U, uint32_t immh, uint32_t immb, uint32_t opcode, VRegister rd, VRegister rn) {
+    uint32_t Instr = 0b0101'1111'0000'0000'0000'0100'0000'0000;
 
     Instr |= U << 29;
     Instr |= immh << 19;

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ScalarOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ScalarOps.inl
@@ -1219,89 +1219,63 @@ public:
   }
 
 // Floating-point compare
-  void fcmp(FEXCore::ARMEmitter::ScalarRegSize Size, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
-    LOGMAN_THROW_AA_FMT(Size != FEXCore::ARMEmitter::ScalarRegSize::i8Bit, "8-bit destination not supported");
+  void fcmp(ScalarRegSize Size, VRegister rn, VRegister rm) {
+    LOGMAN_THROW_AA_FMT(Size != ScalarRegSize::i8Bit, "8-bit destination not supported");
 
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b1000 << 10;
     const auto ConvertedSize =
       Size == ARMEmitter::ScalarRegSize::i64Bit ? 0b01 :
       Size == ARMEmitter::ScalarRegSize::i32Bit ? 0b00 :
       Size == ARMEmitter::ScalarRegSize::i16Bit ? 0b11 : 0;
 
-    FloatCompare(Op, 0, 0, ConvertedSize, 0b00, 0b00000, rn, rm);
+    FloatCompare(0, 0, ConvertedSize, 0b00, 0b00000, rn, rm);
   }
 
-  void fcmp(FEXCore::ARMEmitter::SRegister rn, FEXCore::ARMEmitter::SRegister rm) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b1000 << 10;
-    FloatCompare(Op, 0, 0, 0b00, 0b00, 0b00000, rn.V(), rm.V());
+  void fcmp(SRegister rn, SRegister rm) {
+    FloatCompare(0, 0, 0b00, 0b00, 0b00000, rn.V(), rm.V());
   }
   ///< Compare to #0.0
-  void fcmp(FEXCore::ARMEmitter::SRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b1000 << 10;
-    FloatCompare(Op, 0, 0, 0b00, 0b00, 0b01000, rn.V(), FEXCore::ARMEmitter::VReg::v0);
+  void fcmp(SRegister rn) {
+    FloatCompare(0, 0, 0b00, 0b00, 0b01000, rn.V(), VReg::v0);
   }
-  void fcmpe(FEXCore::ARMEmitter::SRegister rn, FEXCore::ARMEmitter::SRegister rm) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b1000 << 10;
-    FloatCompare(Op, 0, 0, 0b00, 0b00, 0b10000, rn.V(), rm.V());
+  void fcmpe(SRegister rn, SRegister rm) {
+    FloatCompare(0, 0, 0b00, 0b00, 0b10000, rn.V(), rm.V());
   }
 
   ///< Compare to #0.0
-  void fcmpe(FEXCore::ARMEmitter::SRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b1000 << 10;
-    FloatCompare(Op, 0, 0, 0b00, 0b00, 0b11000, rn.V(), FEXCore::ARMEmitter::VReg::v0);
+  void fcmpe(SRegister rn) {
+    FloatCompare(0, 0, 0b00, 0b00, 0b11000, rn.V(), VReg::v0);
   }
-  void fcmp(FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b1000 << 10;
-    FloatCompare(Op, 0, 0, 0b01, 0b00, 0b00000, rn.V(), rm.V());
+  void fcmp(DRegister rn, DRegister rm) {
+    FloatCompare(0, 0, 0b01, 0b00, 0b00000, rn.V(), rm.V());
   }
 
   ///< Compare to #0.0
-  void fcmp(FEXCore::ARMEmitter::DRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b1000 << 10;
-    FloatCompare(Op, 0, 0, 0b01, 0b00, 0b01000, rn.V(), FEXCore::ARMEmitter::VReg::v0);
+  void fcmp(DRegister rn) {
+    FloatCompare(0, 0, 0b01, 0b00, 0b01000, rn.V(), VReg::v0);
   }
-  void fcmpe(FEXCore::ARMEmitter::DRegister rn, FEXCore::ARMEmitter::DRegister rm) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b1000 << 10;
-    FloatCompare(Op, 0, 0, 0b01, 0b00, 0b10000, rn.V(), rm.V());
+  void fcmpe(DRegister rn, DRegister rm) {
+    FloatCompare(0, 0, 0b01, 0b00, 0b10000, rn.V(), rm.V());
   }
 
   ///< Compare to #0.0
-  void fcmpe(FEXCore::ARMEmitter::DRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b1000 << 10;
-    FloatCompare(Op, 0, 0, 0b01, 0b00, 0b11000, rn.V(), FEXCore::ARMEmitter::VReg::v0);
+  void fcmpe(DRegister rn) {
+    FloatCompare(0, 0, 0b01, 0b00, 0b11000, rn.V(), VReg::v0);
   }
-  void fcmp(FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b1000 << 10;
-    FloatCompare(Op, 0, 0, 0b11, 0b00, 0b00000, rn.V(), rm.V());
+  void fcmp(HRegister rn, HRegister rm) {
+    FloatCompare(0, 0, 0b11, 0b00, 0b00000, rn.V(), rm.V());
   }
 
   ///< Compare to #0.0
-  void fcmp(FEXCore::ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b1000 << 10;
-    FloatCompare(Op, 0, 0, 0b11, 0b00, 0b01000, rn.V(), FEXCore::ARMEmitter::VReg::v0);
+  void fcmp(HRegister rn) {
+    FloatCompare(0, 0, 0b11, 0b00, 0b01000, rn.V(), VReg::v0);
   }
-  void fcmpe(FEXCore::ARMEmitter::HRegister rn, FEXCore::ARMEmitter::HRegister rm) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b1000 << 10;
-    FloatCompare(Op, 0, 0, 0b11, 0b00, 0b10000, rn.V(), rm.V());
+  void fcmpe(HRegister rn, HRegister rm) {
+    FloatCompare(0, 0, 0b11, 0b00, 0b10000, rn.V(), rm.V());
   }
 
   ///< Compare to #0.0
-  void fcmpe(FEXCore::ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b1000 << 10;
-    FloatCompare(Op, 0, 0, 0b11, 0b00, 0b11000, rn.V(), FEXCore::ARMEmitter::VReg::v0);
+  void fcmpe(HRegister rn) {
+    FloatCompare(0, 0, 0b11, 0b00, 0b11000, rn.V(), VReg::v0);
   }
 
 // Floating-point immediate
@@ -1691,8 +1665,8 @@ private:
     dc32(Instr);
   }
 // Floating-point compare
-  void FloatCompare(uint32_t Op, uint32_t M, uint32_t S, uint32_t ftype, uint32_t op, uint32_t opcode2, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
-    uint32_t Instr = Op;
+  void FloatCompare(uint32_t M, uint32_t S, uint32_t ftype, uint32_t op, uint32_t opcode2, VRegister rn, VRegister rm) {
+    uint32_t Instr = 0b0001'1110'0010'0000'0010'0000'0000'0000;
 
     Instr |= M << 31;
     Instr |= S << 29;

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ScalarOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ScalarOps.inl
@@ -797,295 +797,151 @@ public:
 // XXX:
 //
 // Floating-point data-processing (1 source)
-  void fmov(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b00, 0b000000, rd.V(), rn.V());
+  void fmov(SRegister rd, SRegister rn) {
+    Float1Source(0, 0, 0b00, 0b000000, rd.V(), rn.V());
   }
-  void fabs(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b00, 0b000001, rd.V(), rn.V());
+  void fabs(SRegister rd, SRegister rn) {
+    Float1Source(0, 0, 0b00, 0b000001, rd.V(), rn.V());
   }
-  void fneg(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b00, 0b000010, rd.V(), rn.V());
+  void fneg(SRegister rd, SRegister rn) {
+    Float1Source(0, 0, 0b00, 0b000010, rd.V(), rn.V());
   }
-  void fsqrt(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b00, 0b000011, rd.V(), rn.V());
+  void fsqrt(SRegister rd, SRegister rn) {
+    Float1Source(0, 0, 0b00, 0b000011, rd.V(), rn.V());
   }
-  void fcvt(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::SRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b00, 0b000101, rd.V(), rn.V());
+  void fcvt(DRegister rd, SRegister rn) {
+    Float1Source(0, 0, 0b00, 0b000101, rd.V(), rn.V());
   }
-  void fcvt(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::SRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b00, 0b000111, rd.V(), rn.V());
+  void fcvt(HRegister rd, SRegister rn) {
+    Float1Source(0, 0, 0b00, 0b000111, rd.V(), rn.V());
   }
-  void frintn(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b00, 0b001000, rd.V(), rn.V());
+  void frintn(SRegister rd, SRegister rn) {
+    Float1Source(0, 0, 0b00, 0b001000, rd.V(), rn.V());
   }
-  void frintp(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b00, 0b001001, rd.V(), rn.V());
+  void frintp(SRegister rd, SRegister rn) {
+    Float1Source(0, 0, 0b00, 0b001001, rd.V(), rn.V());
   }
-  void frintm(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b00, 0b001010, rd.V(), rn.V());
+  void frintm(SRegister rd, SRegister rn) {
+    Float1Source(0, 0, 0b00, 0b001010, rd.V(), rn.V());
   }
-  void frintz(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b00, 0b001011, rd.V(), rn.V());
+  void frintz(SRegister rd, SRegister rn) {
+    Float1Source(0, 0, 0b00, 0b001011, rd.V(), rn.V());
   }
-  void frinta(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b00, 0b001100, rd.V(), rn.V());
+  void frinta(SRegister rd, SRegister rn) {
+    Float1Source(0, 0, 0b00, 0b001100, rd.V(), rn.V());
   }
-  void frintx(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b00, 0b001110, rd.V(), rn.V());
+  void frintx(SRegister rd, SRegister rn) {
+    Float1Source(0, 0, 0b00, 0b001110, rd.V(), rn.V());
   }
-  void frinti(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b00, 0b001111, rd.V(), rn.V());
+  void frinti(SRegister rd, SRegister rn) {
+    Float1Source(0, 0, 0b00, 0b001111, rd.V(), rn.V());
   }
-  void frint32z(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b00, 0b010000, rd.V(), rn.V());
+  void frint32z(SRegister rd, SRegister rn) {
+    Float1Source(0, 0, 0b00, 0b010000, rd.V(), rn.V());
   }
-  void frint32x(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b00, 0b010001, rd.V(), rn.V());
+  void frint32x(SRegister rd, SRegister rn) {
+    Float1Source(0, 0, 0b00, 0b010001, rd.V(), rn.V());
   }
-  void frint64z(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b00, 0b010010, rd.V(), rn.V());
+  void frint64z(SRegister rd, SRegister rn) {
+    Float1Source(0, 0, 0b00, 0b010010, rd.V(), rn.V());
   }
-  void frint64x(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::SRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b00, 0b010011, rd.V(), rn.V());
+  void frint64x(SRegister rd, SRegister rn) {
+    Float1Source(0, 0, 0b00, 0b010011, rd.V(), rn.V());
   }
 
-  void fmov(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b01, 0b000000, rd.V(), rn.V());
+  void fmov(DRegister rd, DRegister rn) {
+    Float1Source(0, 0, 0b01, 0b000000, rd.V(), rn.V());
   }
-  void fabs(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b01, 0b000001, rd.V(), rn.V());
+  void fabs(DRegister rd, DRegister rn) {
+    Float1Source(0, 0, 0b01, 0b000001, rd.V(), rn.V());
   }
-  void fneg(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b01, 0b000010, rd.V(), rn.V());
+  void fneg(DRegister rd, DRegister rn) {
+    Float1Source(0, 0, 0b01, 0b000010, rd.V(), rn.V());
   }
-  void fsqrt(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b01, 0b000011, rd.V(), rn.V());
+  void fsqrt(DRegister rd, DRegister rn) {
+    Float1Source(0, 0, 0b01, 0b000011, rd.V(), rn.V());
   }
-  void fcvt(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::DRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b01, 0b000100, rd.V(), rn.V());
+  void fcvt(SRegister rd, DRegister rn) {
+    Float1Source(0, 0, 0b01, 0b000100, rd.V(), rn.V());
   }
-  void bfcvt(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::SRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b01, 0b000110, rd.V(), rn.V());
+  void bfcvt(HRegister rd, SRegister rn) {
+    Float1Source(0, 0, 0b01, 0b000110, rd.V(), rn.V());
   }
-  void fcvt(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::DRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b01, 0b000111, rd.V(), rn.V());
+  void fcvt(HRegister rd, DRegister rn) {
+    Float1Source(0, 0, 0b01, 0b000111, rd.V(), rn.V());
   }
-  void frintn(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b01, 0b001000, rd.V(), rn.V());
+  void frintn(DRegister rd, DRegister rn) {
+    Float1Source(0, 0, 0b01, 0b001000, rd.V(), rn.V());
   }
-  void frintp(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b01, 0b001001, rd.V(), rn.V());
+  void frintp(DRegister rd, DRegister rn) {
+    Float1Source(0, 0, 0b01, 0b001001, rd.V(), rn.V());
   }
-  void frintm(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b01, 0b001010, rd.V(), rn.V());
+  void frintm(DRegister rd, DRegister rn) {
+    Float1Source(0, 0, 0b01, 0b001010, rd.V(), rn.V());
   }
-  void frintz(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b01, 0b001011, rd.V(), rn.V());
+  void frintz(DRegister rd, DRegister rn) {
+    Float1Source(0, 0, 0b01, 0b001011, rd.V(), rn.V());
   }
-  void frinta(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b01, 0b001100, rd.V(), rn.V());
+  void frinta(DRegister rd, DRegister rn) {
+    Float1Source(0, 0, 0b01, 0b001100, rd.V(), rn.V());
   }
-  void frintx(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b01, 0b001110, rd.V(), rn.V());
+  void frintx(DRegister rd, DRegister rn) {
+    Float1Source(0, 0, 0b01, 0b001110, rd.V(), rn.V());
   }
-  void frinti(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b01, 0b001111, rd.V(), rn.V());
+  void frinti(DRegister rd, DRegister rn) {
+    Float1Source(0, 0, 0b01, 0b001111, rd.V(), rn.V());
   }
-  void frint32z(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b01, 0b010000, rd.V(), rn.V());
+  void frint32z(DRegister rd, DRegister rn) {
+    Float1Source(0, 0, 0b01, 0b010000, rd.V(), rn.V());
   }
-  void frint32x(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b01, 0b010001, rd.V(), rn.V());
+  void frint32x(DRegister rd, DRegister rn) {
+    Float1Source(0, 0, 0b01, 0b010001, rd.V(), rn.V());
   }
-  void frint64z(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b01, 0b010010, rd.V(), rn.V());
+  void frint64z(DRegister rd, DRegister rn) {
+    Float1Source(0, 0, 0b01, 0b010010, rd.V(), rn.V());
   }
-  void frint64x(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::DRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b01, 0b010011, rd.V(), rn.V());
+  void frint64x(DRegister rd, DRegister rn) {
+    Float1Source(0, 0, 0b01, 0b010011, rd.V(), rn.V());
   }
 
-  void fmov(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b11, 0b000000, rd.V(), rn.V());
+  void fmov(HRegister rd, HRegister rn) {
+    Float1Source(0, 0, 0b11, 0b000000, rd.V(), rn.V());
   }
-  void fabs(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b11, 0b000001, rd.V(), rn.V());
+  void fabs(HRegister rd, HRegister rn) {
+    Float1Source(0, 0, 0b11, 0b000001, rd.V(), rn.V());
   }
-  void fneg(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b11, 0b000010, rd.V(), rn.V());
+  void fneg(HRegister rd, HRegister rn) {
+    Float1Source(0, 0, 0b11, 0b000010, rd.V(), rn.V());
   }
-  void fsqrt(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b11, 0b000011, rd.V(), rn.V());
+  void fsqrt(HRegister rd, HRegister rn) {
+    Float1Source(0, 0, 0b11, 0b000011, rd.V(), rn.V());
   }
-  void fcvt(FEXCore::ARMEmitter::SRegister rd, FEXCore::ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b11, 0b000100, rd.V(), rn.V());
+  void fcvt(SRegister rd, HRegister rn) {
+    Float1Source(0, 0, 0b11, 0b000100, rd.V(), rn.V());
   }
-  void fcvt(FEXCore::ARMEmitter::DRegister rd, FEXCore::ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b11, 0b000101, rd.V(), rn.V());
+  void fcvt(DRegister rd, HRegister rn) {
+    Float1Source(0, 0, 0b11, 0b000101, rd.V(), rn.V());
   }
-  void frintn(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b11, 0b001000, rd.V(), rn.V());
+  void frintn(HRegister rd, HRegister rn) {
+    Float1Source(0, 0, 0b11, 0b001000, rd.V(), rn.V());
   }
-  void frintp(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b11, 0b001001, rd.V(), rn.V());
+  void frintp(HRegister rd, HRegister rn) {
+    Float1Source(0, 0, 0b11, 0b001001, rd.V(), rn.V());
   }
-  void frintm(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b11, 0b001010, rd.V(), rn.V());
+  void frintm(HRegister rd, HRegister rn) {
+    Float1Source(0, 0, 0b11, 0b001010, rd.V(), rn.V());
   }
-  void frintz(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b11, 0b001011, rd.V(), rn.V());
+  void frintz(HRegister rd, HRegister rn) {
+    Float1Source(0, 0, 0b11, 0b001011, rd.V(), rn.V());
   }
-  void frinta(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b11, 0b001100, rd.V(), rn.V());
+  void frinta(HRegister rd, HRegister rn) {
+    Float1Source(0, 0, 0b11, 0b001100, rd.V(), rn.V());
   }
-  void frintx(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b11, 0b001110, rd.V(), rn.V());
+  void frintx(HRegister rd, HRegister rn) {
+    Float1Source(0, 0, 0b11, 0b001110, rd.V(), rn.V());
   }
-  void frinti(FEXCore::ARMEmitter::HRegister rd, FEXCore::ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21 |
-                            0b100'00 << 10;
-
-    Float1Source(Op, 0, 0, 0b11, 0b001111, rd.V(), rn.V());
+  void frinti(HRegister rd, HRegister rn) {
+    Float1Source(0, 0, 0b11, 0b001111, rd.V(), rn.V());
   }
 
 // Floating-point compare
@@ -1523,8 +1379,8 @@ private:
 // Advanced SIMD scalar x indexed element
 // XXX:
 // Floating-point data-processing (1 source)
-  void Float1Source(uint32_t Op, uint32_t M, uint32_t S, uint32_t ptype, uint32_t opcode, FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn) {
-    uint32_t Instr = Op;
+  void Float1Source(uint32_t M, uint32_t S, uint32_t ptype, uint32_t opcode, VRegister rd, VRegister rn) {
+    uint32_t Instr = 0b0001'1110'0010'0000'0100'0000'0000'0000;
 
     Instr |= M << 31;
     Instr |= S << 29;


### PR DESCRIPTION
Moving the base opcode into the implementation functions for the instructions lets us deduplicate a lot of cases where the same opcode is redeclared over and over.