### PR TITLE
OpDispatcher: Implements REP MOVS as Memcpy IR op 

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -155,6 +155,7 @@ constexpr OpHandlerArray InterpreterOpHandlers = [] {
   REGISTER_OP(LOADMEMTSO,             LoadMem);
   REGISTER_OP(STOREMEMTSO,            StoreMem);
   REGISTER_OP(MEMSET,                 MemSet);
+  REGISTER_OP(MEMCPY,                 MemCpy);
   REGISTER_OP(CACHELINECLEAR,         CacheLineClear);
   REGISTER_OP(CACHELINECLEAN,         CacheLineClean);
   REGISTER_OP(CACHELINEZERO,          CacheLineZero);

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
@@ -182,6 +182,7 @@ namespace FEXCore::CPU {
   DEF_OP(LoadMem);
   DEF_OP(StoreMem);
   DEF_OP(MemSet);
+  DEF_OP(MemCpy);
   DEF_OP(CacheLineClear);
   DEF_OP(CacheLineClean);
   DEF_OP(CacheLineZero);

--- a/External/FEXCore/Source/Interface/Core/Interpreter/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/MemoryOps.cpp
@@ -293,6 +293,11 @@ DEF_OP(MemSet) {
   const int32_t Size = Op->Size;
 
   char *MemData = *GetSrc<char **>(Data->SSAData, Op->Addr);
+  uint64_t MemPrefix{};
+  if (!Op->Prefix.IsInvalid()) {
+    MemPrefix = *GetSrc<uint64_t*>(Data->SSAData, Op->Prefix);
+  }
+
   const auto Value = *GetSrc<uint64_t*>(Data->SSAData, Op->Value);
   const auto Length = *GetSrc<uint64_t*>(Data->SSAData, Op->Length);
   const auto Direction = *GetSrc<uint8_t*>(Data->SSAData, Op->Direction);
@@ -313,16 +318,16 @@ DEF_OP(MemSet) {
     if (Op->IsAtomic) {
       switch (Size) {
         case 1:
-          MemSetElements(reinterpret_cast<std::atomic<uint8_t>*>(MemData), Value, Length);
+          MemSetElements(reinterpret_cast<std::atomic<uint8_t>*>(MemData + MemPrefix), Value, Length);
           break;
         case 2:
-          MemSetElements(reinterpret_cast<std::atomic<uint16_t>*>(MemData), Value, Length);
+          MemSetElements(reinterpret_cast<std::atomic<uint16_t>*>(MemData + MemPrefix), Value, Length);
           break;
         case 4:
-          MemSetElements(reinterpret_cast<std::atomic<uint32_t>*>(MemData), Value, Length);
+          MemSetElements(reinterpret_cast<std::atomic<uint32_t>*>(MemData + MemPrefix), Value, Length);
           break;
         case 8:
-          MemSetElements(reinterpret_cast<std::atomic<uint64_t>*>(MemData), Value, Length);
+          MemSetElements(reinterpret_cast<std::atomic<uint64_t>*>(MemData + MemPrefix), Value, Length);
           break;
         default:
           LOGMAN_MSG_A_FMT("Unhandled {} size: {}", __func__, Size);
@@ -332,16 +337,16 @@ DEF_OP(MemSet) {
     else {
       switch (Size) {
         case 1:
-          MemSetElements(reinterpret_cast<uint8_t*>(MemData), Value, Length);
+          MemSetElements(reinterpret_cast<uint8_t*>(MemData + MemPrefix), Value, Length);
           break;
         case 2:
-          MemSetElements(reinterpret_cast<uint16_t*>(MemData), Value, Length);
+          MemSetElements(reinterpret_cast<uint16_t*>(MemData + MemPrefix), Value, Length);
           break;
         case 4:
-          MemSetElements(reinterpret_cast<uint32_t*>(MemData), Value, Length);
+          MemSetElements(reinterpret_cast<uint32_t*>(MemData + MemPrefix), Value, Length);
           break;
         case 8:
-          MemSetElements(reinterpret_cast<uint64_t*>(MemData), Value, Length);
+          MemSetElements(reinterpret_cast<uint64_t*>(MemData + MemPrefix), Value, Length);
           break;
         default:
           LOGMAN_MSG_A_FMT("Unhandled {} size: {}", __func__, Size);
@@ -354,16 +359,16 @@ DEF_OP(MemSet) {
     if (Op->IsAtomic) {
       switch (Size) {
         case 1:
-          MemSetElementsInverse(reinterpret_cast<std::atomic<uint8_t>*>(MemData), Value, Length);
+          MemSetElementsInverse(reinterpret_cast<std::atomic<uint8_t>*>(MemData + MemPrefix), Value, Length);
           break;
         case 2:
-          MemSetElementsInverse(reinterpret_cast<std::atomic<uint16_t>*>(MemData), Value, Length);
+          MemSetElementsInverse(reinterpret_cast<std::atomic<uint16_t>*>(MemData + MemPrefix), Value, Length);
           break;
         case 4:
-          MemSetElementsInverse(reinterpret_cast<std::atomic<uint32_t>*>(MemData), Value, Length);
+          MemSetElementsInverse(reinterpret_cast<std::atomic<uint32_t>*>(MemData + MemPrefix), Value, Length);
           break;
         case 8:
-          MemSetElementsInverse(reinterpret_cast<std::atomic<uint64_t>*>(MemData), Value, Length);
+          MemSetElementsInverse(reinterpret_cast<std::atomic<uint64_t>*>(MemData + MemPrefix), Value, Length);
           break;
         default:
           LOGMAN_MSG_A_FMT("Unhandled {} size: {}", __func__, Size);
@@ -373,16 +378,16 @@ DEF_OP(MemSet) {
     else {
       switch (Size) {
         case 1:
-          MemSetElementsInverse(reinterpret_cast<uint8_t*>(MemData), Value, Length);
+          MemSetElementsInverse(reinterpret_cast<uint8_t*>(MemData + MemPrefix), Value, Length);
           break;
         case 2:
-          MemSetElementsInverse(reinterpret_cast<uint16_t*>(MemData), Value, Length);
+          MemSetElementsInverse(reinterpret_cast<uint16_t*>(MemData + MemPrefix), Value, Length);
           break;
         case 4:
-          MemSetElementsInverse(reinterpret_cast<uint32_t*>(MemData), Value, Length);
+          MemSetElementsInverse(reinterpret_cast<uint32_t*>(MemData + MemPrefix), Value, Length);
           break;
         case 8:
-          MemSetElementsInverse(reinterpret_cast<uint64_t*>(MemData), Value, Length);
+          MemSetElementsInverse(reinterpret_cast<uint64_t*>(MemData + MemPrefix), Value, Length);
           break;
         default:
           LOGMAN_MSG_A_FMT("Unhandled {} size: {}", __func__, Size);

--- a/External/FEXCore/Source/Interface/Core/Interpreter/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/MemoryOps.cpp
@@ -398,6 +398,138 @@ DEF_OP(MemSet) {
   }
 }
 
+DEF_OP(MemCpy) {
+  const auto Op = IROp->C<IR::IROp_MemCpy>();
+  const int32_t Size = Op->Size;
+
+  uint64_t *DstPtr = GetDest<uint64_t*>(Data->SSAData, Node);
+
+  char *MemDataDest = *GetSrc<char **>(Data->SSAData, Op->AddrDest);
+  char *MemDataSrc = *GetSrc<char **>(Data->SSAData, Op->AddrSrc);
+
+  uint64_t DestPrefix{};
+  uint64_t SrcPrefix{};
+  if (!Op->PrefixDest.IsInvalid()) {
+    DestPrefix = *GetSrc<uint64_t*>(Data->SSAData, Op->PrefixDest);
+
+  }
+  if (!Op->PrefixSrc.IsInvalid()) {
+    SrcPrefix = *GetSrc<uint64_t*>(Data->SSAData, Op->PrefixSrc);
+  }
+
+  const auto Length = *GetSrc<uint64_t*>(Data->SSAData, Op->Length);
+  const auto Direction = *GetSrc<uint8_t*>(Data->SSAData, Op->Direction);
+
+  auto MemSetElementsAtomic = [](auto* MemDst, auto* MemSrc, size_t Length) {
+    for (size_t i = 0; i < Length; ++i) {
+      MemDst[i].store(MemSrc[i].load());
+    }
+  };
+
+  auto MemSetElementsAtomicInverse = [](auto* MemDst, auto* MemSrc, size_t Length) {
+    for (size_t i = 0; i < Length; ++i) {
+      MemDst[-i].store(MemSrc[-i].load());
+    }
+  };
+
+  auto MemSetElements = [](auto* MemDst, auto* MemSrc, size_t Length) {
+    for (size_t i = 0; i < Length; ++i) {
+      MemDst[i] = MemSrc[i];
+    }
+  };
+
+  auto MemSetElementsInverse = [](auto* MemDst, auto* MemSrc, size_t Length) {
+    for (size_t i = 0; i < Length; ++i) {
+      MemDst[-i] = MemSrc[-i];
+    }
+  };
+
+  if (Direction == 0) { // Forward
+    if (Op->IsAtomic) {
+      switch (Size) {
+        case 1:
+          MemSetElementsAtomic(reinterpret_cast<std::atomic<uint8_t>*>(MemDataDest + DestPrefix), reinterpret_cast<std::atomic<uint8_t>*>(MemDataSrc + SrcPrefix), Length);
+          break;
+        case 2:
+          MemSetElementsAtomic(reinterpret_cast<std::atomic<uint16_t>*>(MemDataDest + DestPrefix), reinterpret_cast<std::atomic<uint16_t>*>(MemDataSrc + SrcPrefix), Length);
+          break;
+        case 4:
+          MemSetElementsAtomic(reinterpret_cast<std::atomic<uint32_t>*>(MemDataDest + DestPrefix), reinterpret_cast<std::atomic<uint32_t>*>(MemDataSrc + SrcPrefix), Length);
+          break;
+        case 8:
+          MemSetElementsAtomic(reinterpret_cast<std::atomic<uint64_t>*>(MemDataDest + DestPrefix), reinterpret_cast<std::atomic<uint64_t>*>(MemDataSrc + SrcPrefix), Length);
+          break;
+        default:
+          LOGMAN_MSG_A_FMT("Unhandled {} size: {}", __func__, Size);
+          break;
+      }
+    }
+    else {
+      switch (Size) {
+        case 1:
+          MemSetElements(reinterpret_cast<uint8_t*>(MemDataDest + DestPrefix), reinterpret_cast<uint8_t*>(MemDataSrc + SrcPrefix), Length);
+          break;
+        case 2:
+          MemSetElements(reinterpret_cast<uint16_t*>(MemDataDest + DestPrefix), reinterpret_cast<uint16_t*>(MemDataSrc + SrcPrefix), Length);
+          break;
+        case 4:
+          MemSetElements(reinterpret_cast<uint32_t*>(MemDataDest + DestPrefix), reinterpret_cast<uint32_t*>(MemDataSrc + SrcPrefix), Length);
+          break;
+        case 8:
+          MemSetElements(reinterpret_cast<uint64_t*>(MemDataDest + DestPrefix), reinterpret_cast<uint64_t*>(MemDataSrc + SrcPrefix), Length);
+          break;
+        default:
+          LOGMAN_MSG_A_FMT("Unhandled {} size: {}", __func__, Size);
+          break;
+      }
+    }
+    DstPtr[0] = reinterpret_cast<uint64_t>(MemDataDest + (Length * Size));
+    DstPtr[1] = reinterpret_cast<uint64_t>(MemDataSrc + (Length * Size));
+  }
+  else { // Backward
+    if (Op->IsAtomic) {
+      switch (Size) {
+        case 1:
+          MemSetElementsAtomicInverse(reinterpret_cast<std::atomic<uint8_t>*>(MemDataDest + DestPrefix), reinterpret_cast<std::atomic<uint8_t>*>(MemDataSrc + SrcPrefix), Length);
+          break;
+        case 2:
+          MemSetElementsAtomicInverse(reinterpret_cast<std::atomic<uint16_t>*>(MemDataDest + DestPrefix), reinterpret_cast<std::atomic<uint16_t>*>(MemDataSrc + SrcPrefix), Length);
+          break;
+        case 4:
+          MemSetElementsAtomicInverse(reinterpret_cast<std::atomic<uint32_t>*>(MemDataDest + DestPrefix), reinterpret_cast<std::atomic<uint32_t>*>(MemDataSrc + SrcPrefix), Length);
+          break;
+        case 8:
+          MemSetElementsAtomicInverse(reinterpret_cast<std::atomic<uint64_t>*>(MemDataDest + DestPrefix), reinterpret_cast<std::atomic<uint64_t>*>(MemDataSrc + SrcPrefix), Length);
+          break;
+        default:
+          LOGMAN_MSG_A_FMT("Unhandled {} size: {}", __func__, Size);
+          break;
+      }
+    }
+    else {
+      switch (Size) {
+        case 1:
+          MemSetElementsInverse(reinterpret_cast<uint8_t*>(MemDataDest + DestPrefix), reinterpret_cast<uint8_t*>(MemDataSrc + SrcPrefix), Length);
+          break;
+        case 2:
+          MemSetElementsInverse(reinterpret_cast<uint16_t*>(MemDataDest + DestPrefix), reinterpret_cast<uint16_t*>(MemDataSrc + SrcPrefix), Length);
+          break;
+        case 4:
+          MemSetElementsInverse(reinterpret_cast<uint32_t*>(MemDataDest + DestPrefix), reinterpret_cast<uint32_t*>(MemDataSrc + SrcPrefix), Length);
+          break;
+        case 8:
+          MemSetElementsInverse(reinterpret_cast<uint64_t*>(MemDataDest + DestPrefix), reinterpret_cast<uint64_t*>(MemDataSrc + SrcPrefix), Length);
+          break;
+        default:
+          LOGMAN_MSG_A_FMT("Unhandled {} size: {}", __func__, Size);
+          break;
+      }
+    }
+    DstPtr[0] = reinterpret_cast<uint64_t>(MemDataDest - (Length * Size));
+    DstPtr[1] = reinterpret_cast<uint64_t>(MemDataSrc - (Length * Size));
+  }
+}
+
 DEF_OP(CacheLineClear) {
   auto Op = IROp->C<IR::IROp_CacheLineClear>();
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -901,6 +901,7 @@ CPUBackend::CompiledCode Arm64JITCore::CompileCode(uint64_t Entry,
           break;
 
         REGISTER_OP(MEMSET,              MemSet);
+        REGISTER_OP(MEMCPY,              MemCpy);
         REGISTER_OP(CACHELINECLEAR,      CacheLineClear);
         REGISTER_OP(CACHELINECLEAN,      CacheLineClean);
         REGISTER_OP(CACHELINEZERO,       CacheLineZero);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -350,6 +350,7 @@ private:
   DEF_OP(LoadMemTSO);
   DEF_OP(StoreMemTSO);
   DEF_OP(MemSet);
+  DEF_OP(MemCpy);
   DEF_OP(ParanoidLoadMemTSO);
   DEF_OP(ParanoidStoreMemTSO);
   DEF_OP(CacheLineClear);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -345,6 +345,7 @@ private:
   DEF_OP(LoadMem);
   DEF_OP(StoreMem);
   DEF_OP(MemSet);
+  DEF_OP(MemCpy);
   DEF_OP(CacheLineClear);
   DEF_OP(CacheLineClean);
   DEF_OP(CacheLineZero);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/MemoryOps.cpp
@@ -791,6 +791,10 @@ DEF_OP(MemSet) {
   mov(rcx, Length);
   mov(rdi, MemReg);
 
+  if (!Op->Prefix.IsInvalid()) {
+    add(rdi, GetSrc<RA_64>(Op->Prefix.ID()));
+  }
+
   {
     mov(TMP3, Length);
     auto CalculateDest = [&]() {

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/MemoryOps.cpp
@@ -858,6 +858,139 @@ DEF_OP(MemSet) {
   cld();
 }
 
+DEF_OP(MemCpy) {
+  const auto Op = IROp->C<IR::IROp_MemCpy>();
+
+  const int32_t Size = Op->Size;
+  const auto MemRegDest = GetSrc<RA_64>(Op->AddrDest.ID());
+  const auto MemRegSrc = GetSrc<RA_64>(Op->AddrSrc.ID());
+
+  const auto Length = GetSrc<RA_64>(Op->Length.ID());
+  const auto Direction = GetSrc<RA_64>(Op->Direction.ID());
+
+  // If Direction == 0 then:
+  //   MemRegDest is incremented (by size)
+  //   MemRegSrc is incremented (by size)
+  // else:
+  //   MemRegDest is decremented (by size)
+  //   MemRegSrc is decremented (by size)
+  //
+  // Counter is decremented regardless.
+
+  // TMP1 = Length
+  // TMP2 = Dest
+  // TMP3 = Src
+  // TMP4 = Temp value
+  mov(TMP1, Length);
+  mov(TMP2, MemRegDest);
+  mov(TMP3, MemRegSrc);
+  if (!Op->PrefixDest.IsInvalid()) {
+    add(TMP2, GetSrc<RA_64>(Op->PrefixDest.ID()));
+  }
+  if (!Op->PrefixSrc.IsInvalid()) {
+    add(TMP3, GetSrc<RA_64>(Op->PrefixSrc.ID()));
+  }
+
+  auto Dst = GetSrcPair<RA_64>(Node);
+  Label Done;
+  Label BackwardImpl;
+  cmp(Direction, 0);
+  jne(BackwardImpl);
+
+  // Emit forward direction memcpy then backward direction memcpy.
+  for (int32_t Direction :  { 1, -1 }) {
+    Label DoneInternal;
+    Label AgainInternal;
+
+    L(AgainInternal);
+    cmp(TMP1, 0);
+    je(DoneInternal);
+
+    {
+      switch (Size) {
+        case 1:
+          movzx(TMP4, byte [TMP3]);
+          mov(byte [TMP2], TMP4.cvt8());
+          break;
+        case 2:
+          movzx(TMP4, word [TMP3]);
+          mov(word [TMP2], TMP4.cvt16());
+          break;
+        case 4:
+          mov(TMP4.cvt32(), dword [TMP3]);
+          mov(dword [TMP2], TMP4.cvt32());
+          break;
+        case 8:
+          mov(TMP4, qword [TMP3]);
+          mov(qword [TMP2], TMP4);
+          break;
+        default:
+          LOGMAN_MSG_A_FMT("Unhandled {} size: {}", __func__, Size);
+          break;
+      }
+    }
+
+    if (Direction == 1) {
+      // Incrementing pointers
+      add(TMP2, Size);
+      add(TMP3, Size);
+    }
+    else {
+      // Decrementing pointers
+      sub(TMP2, Size);
+      sub(TMP3, Size);
+    }
+
+    // Decrement counter by one
+    sub(TMP1, 1);
+
+    jmp(AgainInternal);
+    L(DoneInternal);
+
+    // Pointer math using source pointers and length.
+    mov(TMP3, Length);
+    switch (Size) {
+      case 1:
+        break;
+      case 2:
+        shl(TMP3, 1);
+        break;
+      case 4:
+        shl(TMP3, 2);
+        break;
+      case 8:
+        shl(TMP3, 3);
+        break;
+      default:
+        LOGMAN_MSG_A_FMT("Unhandled {} size: {}", __func__, Size);
+        break;
+    }
+
+    // Needs to use temporaries just in case of overwrite
+    mov(TMP1, MemRegDest);
+    mov(TMP2, MemRegSrc);
+
+    mov(Dst.first, TMP1);
+    mov(Dst.second, TMP2);
+
+    if (Direction == 1) {
+      // Incrementing pointers
+      add(Dst.first, TMP3);
+      add(Dst.second, TMP3);
+
+      jmp(Done);
+      L(BackwardImpl);
+    }
+    else {
+      // Decrementing pointers
+      sub(Dst.first, TMP3);
+      sub(Dst.second, TMP3);
+    }
+  }
+
+  L(Done);
+}
+
 DEF_OP(CacheLineClear) {
   auto Op = IROp->C<IR::IROp_CacheLineClear>();
 
@@ -913,6 +1046,7 @@ void X86JITCore::RegisterMemoryHandlers() {
   REGISTER_OP(LOADMEMTSO,          LoadMem);
   REGISTER_OP(STOREMEMTSO,         StoreMem);
   REGISTER_OP(MEMSET,              MemSet);
+  REGISTER_OP(MEMCPY,              MemCpy);
   REGISTER_OP(CACHELINECLEAR,      CacheLineClear);
   REGISTER_OP(CACHELINECLEAN,      CacheLineClean);
   REGISTER_OP(CACHELINEZERO,       CacheLineZero);

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -483,7 +483,14 @@
         "HasSideEffects": true,
         "DestSize": "8"
       },
-
+      "GPRPair = MemCpy i1:$IsAtomic, u8:$Size, GPR:$PrefixDest, GPR:$PrefixSrc, GPR:$AddrDest, GPR:$AddrSrc, GPR:$Length, GPR:$Direction": {
+        "Desc": ["Duplicates behaviour of x86 MOVS repeat",
+                 "Returns the final addresses of destination and src addresses after they have been incremented or decremented"
+                ],
+        "HasSideEffects": true,
+        "DestSize": "16",
+        "NumElements": "2"
+      },
       "CacheLineClear GPR:$Addr, i1:$Serialize": {
         "Desc": ["Does a 64 byte cacheline clear at the address specified",
                  "Only clears the data cachelines. Doesn't do any zeroing",


### PR DESCRIPTION
Just like the `REP STOS` instruction, this removes a fairly nasty bit of
code generation from our dispatcher. This instruction behaves like a
memcpy/memmove when not dealing with the faulting behaviour around the
instruction.

With a microbench things improves this instruction's throughput by 3.5%
to 26.5% depending on operating size.

There is a TODO for implementing this instruction with ARM's future MOPS
instructions which will accelerate this implementation further.

![Image_2023-03-06_16-46-43](https://user-images.githubusercontent.com/1018829/223290095-79775a23-7e93-4799-af82-5699411b2bae.png)
