### PR TITLE
OpcodeDispatcher: Pass full register size through VExtractToGPR

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -847,7 +847,7 @@ void OpDispatchBuilder::MOVMSKOp(OpcodeArgs) {
 
   for (unsigned i = 0; i < NumElements; ++i) {
     // Extract the top bit of the element
-    OrderedNode *Tmp = _VExtractToGPR(16, ElementSize, Src, i);
+    OrderedNode *Tmp = _VExtractToGPR(Size, ElementSize, Src, i);
     Tmp = _Bfe(1, ElementSize * 8 - 1, Tmp);
 
     // Shift it to the correct location


### PR DESCRIPTION
While the register size parameter of VExtractToGPR is currently unused, it's correct to differentiate between 128-bit and 256-bit registers here, since this is used for both the SSE and AVX implementation.

No change in behavior, just making the operation less confusing.