### PR TITLE
unittests: Change alignment directive in 256-bit VPSADBW test to 32

### DIFF
--- a/unittests/ASM/VEX/vpsadbw_256.asm
+++ b/unittests/ASM/VEX/vpsadbw_256.asm
@@ -39,7 +39,7 @@ vpsadbw ymm14, ymm7, [rdx + 32 * 14]
 
 hlt
 
-align 16
+align 32
 
 .reg_data:
 dq 0x4142434445464748


### PR DESCRIPTION
Meant to change this over when writing the test, but forgot.