### PR TITLE
FM: Remove unused FD to Name mapping

### DIFF
--- a/Source/Tests/LinuxSyscalls/FileManagement.h
+++ b/Source/Tests/LinuxSyscalls/FileManagement.h
@@ -73,8 +73,6 @@ public:
   // vfs
   uint64_t Statfs(const char *path, void *buf);
 
-  std::string *FindFDName(int fd);
-
   std::optional<std::string> GetSelf(const char *Pathname);
 
   void UpdatePID(uint32_t PID) { CurrentPID = PID; }
@@ -83,13 +81,9 @@ public:
   using FDPathTmpData = std::array<char[PATH_MAX], 2>;
   std::pair<int, const char*> GetEmulatedFDPath(int dirfd, const char *pathname, bool FollowSymlink, FDPathTmpData &TmpFilename);
 
-  std::mutex *GetFDLock() { return &FDLock; }
-
 private:
   FEX::EmulatedFile::EmulatedFDManager EmuFD;
 
-  std::mutex FDLock;
-  std::map<uint32_t, std::string> FDToNameMap;
   std::map<std::string, std::string, std::less<>> ThunkOverlays;
 
   FEX_CONFIG_OPT(Filename, APP_FILENAME);

--- a/Source/Tests/LinuxSyscalls/Syscalls.cpp
+++ b/Source/Tests/LinuxSyscalls/Syscalls.cpp
@@ -847,8 +847,6 @@ uint64_t UnimplementedSyscallSafe(FEXCore::Core::CpuStateFrame *Frame, uint64_t 
 }
 
 void SyscallHandler::LockBeforeFork() {
-  FM.GetFDLock()->lock();
-
   // XXX shared_mutex has issues with locking and forks
   // VMATracking.Mutex.lock();
 
@@ -860,8 +858,6 @@ void SyscallHandler::UnlockAfterFork() {
 
   // XXX shared_mutex has issues with locking and forks
   // VMATracking.Mutex.unlock();
-
-  FM.GetFDLock()->unlock();
 }
 
 static bool isHEX(char c) {


### PR DESCRIPTION
This was completely unused so this just reduces some syscall signal mutex locking around FD operations.