### PR TITLE
Implement support for deferred asynchronous signals

### DIFF
--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "Common/JitSymbols.h"
-#include "FEXHeaderUtils/ScopedSignalMask.h"
 #include "Interface/Core/CPUID.h"
 #include "Interface/Core/X86HelperGen.h"
 #include "Interface/Core/ObjectCache/ObjectCacheService.h"
@@ -14,6 +13,7 @@
 #include <FEXCore/Core/SignalDelegator.h>
 #include <FEXCore/Debug/InternalThreadState.h>
 #include <FEXCore/Utils/CompilerDefs.h>
+#include <FEXCore/Utils/DeferredSignalMutex.h>
 #include <FEXCore/Utils/Event.h>
 #include <FEXCore/fextl/memory.h>
 #include <FEXCore/fextl/set.h>
@@ -290,7 +290,8 @@ namespace FEXCore::Context {
 
     template<auto Fn>
     static uint64_t ThreadExitFunctionLink(FEXCore::Core::CpuStateFrame *Frame, uint64_t *record) {
-      FHU::ScopedSignalMaskWithSharedLock lk(static_cast<ContextImpl*>(Frame->Thread->CTX)->CodeInvalidationMutex);
+      auto Thread = Frame->Thread;
+      ScopedDeferredSignalWithSharedLock lk(static_cast<ContextImpl*>(Thread->CTX)->CodeInvalidationMutex, Thread);
 
       return Fn(Frame, record);
     }
@@ -302,7 +303,7 @@ namespace FEXCore::Context {
 
       LogMan::Throw::AFmt(Thread->ThreadManager.GetTID() == FHU::Syscalls::gettid(), "Must be called from owning thread {}, not {}", Thread->ThreadManager.GetTID(), FHU::Syscalls::gettid());
 
-      FHU::ScopedSignalMaskWithUniqueLock lk(static_cast<ContextImpl*>(Thread->CTX)->CodeInvalidationMutex);
+      ScopedDeferredSignalWithUniqueLock lk(static_cast<ContextImpl*>(Thread->CTX)->CodeInvalidationMutex, Thread);
 
       ThreadRemoveCodeEntry(Thread, GuestRIP);
     }

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -181,8 +181,8 @@ namespace FEXCore::Context {
       void WriteFilesWithCode(std::function<void(const fextl::string& fileid, const fextl::string& filename)> Writer) override {
         IRCaptureCache.WriteFilesWithCode(Writer);
       }
-      void InvalidateGuestCodeRange(uint64_t Start, uint64_t Length) override;
-      void InvalidateGuestCodeRange(uint64_t Start, uint64_t Length, std::function<void(uint64_t start, uint64_t Length)> callback) override;
+      void InvalidateGuestCodeRange(FEXCore::Core::InternalThreadState *Thread, uint64_t Start, uint64_t Length) override;
+      void InvalidateGuestCodeRange(FEXCore::Core::InternalThreadState *Thread, uint64_t Start, uint64_t Length, std::function<void(uint64_t start, uint64_t Length)> callback) override;
       void MarkMemoryShared() override;
 
       void ConfigureAOTGen(FEXCore::Core::InternalThreadState *Thread, fextl::set<uint64_t> *ExternalBranches, uint64_t SectionMaxAddress) override;

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -803,7 +803,7 @@ namespace FEXCore::Context {
 
       Thread->FrontendDecoder->DecodeInstructionsAtEntry(GuestCode, GuestRIP, [Thread](uint64_t BlockEntry, uint64_t Start, uint64_t Length) {
         if (Thread->LookupCache->AddBlockExecutableRange(BlockEntry, Start, Length)) {
-          static_cast<ContextImpl*>(Thread->CTX)->SyscallHandler->MarkGuestExecutableRange(Start, Length);
+          static_cast<ContextImpl*>(Thread->CTX)->SyscallHandler->MarkGuestExecutableRange(Thread, Start, Length);
         }
       });
 
@@ -982,7 +982,7 @@ namespace FEXCore::Context {
     }
 
     if (SourcecodeResolver && Config.GDBSymbols()) {
-      auto AOTIRCacheEntry = SyscallHandler->LookupAOTIRCacheEntry(GuestRIP);
+      auto AOTIRCacheEntry = SyscallHandler->LookupAOTIRCacheEntry(Thread, GuestRIP);
       if (AOTIRCacheEntry.Entry && !AOTIRCacheEntry.Entry->ContainsCode) {
         AOTIRCacheEntry.Entry->SourcecodeMap =
             SourcecodeResolver->GenerateMap(AOTIRCacheEntry.Entry->Filename, AOTIRCacheEntry.Entry->FileId);
@@ -991,7 +991,7 @@ namespace FEXCore::Context {
 
     // AOT IR bookkeeping and cache
     {
-      auto [IRCopy, RACopy, DebugDataCopy, _StartAddr, _Length, _GeneratedIR] = IRCaptureCache.PreGenerateIRFetch(GuestRIP, IRList);
+      auto [IRCopy, RACopy, DebugDataCopy, _StartAddr, _Length, _GeneratedIR] = IRCaptureCache.PreGenerateIRFetch(Thread, GuestRIP, IRList);
       if (_GeneratedIR) {
         // Setup pointers to internal structures
         IRList = IRCopy;
@@ -1084,7 +1084,7 @@ namespace FEXCore::Context {
       auto FragmentBasePtr = reinterpret_cast<uint8_t *>(CodePtr);
 
       if (DebugData) {
-        auto GuestRIPLookup = SyscallHandler->LookupAOTIRCacheEntry(GuestRIP);
+        auto GuestRIPLookup = SyscallHandler->LookupAOTIRCacheEntry(Thread, GuestRIP);
 
         if (DebugData->Subblocks.size()) {
           for (auto& Subblock: DebugData->Subblocks) {

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -24,6 +24,7 @@ $end_info$
 #include "Interface/IR/Passes/RegisterAllocationPass.h"
 #include "Interface/IR/Passes.h"
 #include "Interface/IR/PassManager.h"
+#include "Utils/Allocator/HostAllocator.h"
 
 #include <FEXCore/Config/Config.h>
 #include <FEXCore/Core/CodeLoader.h>
@@ -1151,6 +1152,7 @@ namespace FEXCore::Context {
     Thread->ExitReason = FEXCore::Context::ExitReason::EXIT_WAITING;
 
     InitializeThreadTLSData(Thread);
+    Alloc::OSAllocator::RegisterTLSData(Thread);
 
     ++IdleWaitRefCount;
 
@@ -1195,6 +1197,7 @@ namespace FEXCore::Context {
     --IdleWaitRefCount;
     IdleWaitCV.notify_all();
 
+    Alloc::OSAllocator::UninstallTLSData(Thread);
     SignalDelegation->UninstallTLSState(Thread);
 
     // If the parent thread is waiting to join, then we can't destroy our thread object

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -192,29 +192,6 @@ namespace FEXCore::Context {
     }
   }
 
-  static FEXCore::Core::CPUState CreateDefaultCPUState() {
-    FEXCore::Core::CPUState NewThreadState{};
-
-    // Initialize default CPU state
-    NewThreadState.rip = ~0ULL;
-    for (auto& greg : NewThreadState.gregs) {
-      greg = 0;
-    }
-
-    for (auto& xmm : NewThreadState.xmm.avx.data) {
-      xmm[0] = 0xDEADBEEFULL;
-      xmm[1] = 0xBAD0DAD1ULL;
-      xmm[2] = 0xDEADCAFEULL;
-      xmm[3] = 0xBAD2CAD3ULL;
-    }
-    memset(NewThreadState.flags, 0, Core::CPUState::NUM_EFLAG_BITS);
-    NewThreadState.flags[1] = 1;
-    NewThreadState.flags[9] = 1;
-    NewThreadState.FCW = 0x37F;
-    NewThreadState.FTW = 0xFFFF;
-    return NewThreadState;
-  }
-
   uint64_t ContextImpl::RestoreRIPFromHostPC(FEXCore::Core::InternalThreadState *Thread, uint64_t HostPC) {
     const auto Frame = Thread->CurrentFrame;
     const uint64_t BlockBegin = Frame->State.InlineJITBlockHeader;
@@ -315,8 +292,7 @@ namespace FEXCore::Context {
 
     using namespace FEXCore::Core;
 
-    FEXCore::Core::CPUState NewThreadState = CreateDefaultCPUState();
-    FEXCore::Core::InternalThreadState *Thread = CreateThread(&NewThreadState, 0);
+    FEXCore::Core::InternalThreadState *Thread = CreateThread(nullptr, 0);
 
     // We are the parent thread
     ParentThread = Thread;
@@ -625,7 +601,9 @@ namespace FEXCore::Context {
     FEXCore::Core::InternalThreadState *Thread = new FEXCore::Core::InternalThreadState{};
 
     // Copy over the new thread state to the new object
-    memcpy(Thread->CurrentFrame, NewThreadState, sizeof(FEXCore::Core::CPUState));
+    if (NewThreadState) {
+      memcpy(Thread->CurrentFrame, NewThreadState, sizeof(FEXCore::Core::CPUState));
+    }
     Thread->CurrentFrame->Thread = Thread;
 
     // Set up the thread manager state
@@ -635,7 +613,7 @@ namespace FEXCore::Context {
     InitializeThreadData(Thread);
 
     Thread->CurrentFrame->State.DeferredSignalRefCount.Store(0);
-    Thread->CurrentFrame->State.DeferredSignalFaultAddress = reinterpret_cast<Core::MoveableNonatomicRefCounter<uint64_t>*>(FEXCore::Allocator::VirtualAlloc(4096));
+    Thread->CurrentFrame->State.DeferredSignalFaultAddress = reinterpret_cast<Core::NonAtomicRefCounter<uint64_t>*>(FEXCore::Allocator::VirtualAlloc(4096));
 
     // Insert after the Thread object has been fully initialized
     {
@@ -1230,6 +1208,8 @@ namespace FEXCore::Context {
 
   void ContextImpl::InvalidateGuestCodeRange(FEXCore::Core::InternalThreadState *Thread, uint64_t Start, uint64_t Length) {
     // Potential deferred since Thread might not be valid.
+    // Thread object isn't valid very early in frontend's initialization.
+    // To be more optimal the frontend should provide this code with a valid Thread object earlier.
     ScopedPotentialDeferredSignalWithUniqueLock CodeInvalidationLock(CodeInvalidationMutex, Thread);
 
     InvalidateGuestCodeRangeInternal(this, Start, Length);
@@ -1237,6 +1217,8 @@ namespace FEXCore::Context {
 
   void ContextImpl::InvalidateGuestCodeRange(FEXCore::Core::InternalThreadState *Thread, uint64_t Start, uint64_t Length, std::function<void(uint64_t start, uint64_t Length)> CallAfter) {
     // Potential deferred since Thread might not be valid.
+    // Thread object isn't valid very early in frontend's initialization.
+    // To be more optimal the frontend should provide this code with a valid Thread object earlier.
     ScopedPotentialDeferredSignalWithUniqueLock CodeInvalidationLock(CodeInvalidationMutex, Thread);
 
     InvalidateGuestCodeRangeInternal(this, Start, Length);

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -633,6 +633,9 @@ namespace FEXCore::Context {
     InitializeCompiler(Thread);
     InitializeThreadData(Thread);
 
+    Thread->CurrentFrame->State.DeferredSignalRefCount.Store(0);
+    Thread->CurrentFrame->State.DeferredSignalFaultAddress = reinterpret_cast<Core::MoveableNonatomicRefCounter<uint64_t>*>(FEXCore::Allocator::VirtualAlloc(4096));
+
     // Insert after the Thread object has been fully initialized
     {
       std::lock_guard lk(ThreadCreationMutex);
@@ -658,6 +661,8 @@ namespace FEXCore::Context {
       // To be able to delete a thread from itself, we need to detached the std::thread object
       Thread->ExecutionThread->detach();
     }
+
+    FEXCore::Allocator::VirtualFree(reinterpret_cast<void*>(Thread->CurrentFrame->State.DeferredSignalFaultAddress), 4096);
     delete Thread;
   }
 

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
@@ -213,6 +213,7 @@ void Arm64Dispatcher::EmitDispatcher() {
     subs(ARMEmitter::Size::i64Bit, ARMEmitter::XReg::x1, ARMEmitter::XReg::x1, 1);
     str(ARMEmitter::XReg::x1, STATE, offsetof(FEXCore::Core::CPUState, DeferredSignalRefCount));
 
+    // Trigger segfault if any deferred signals are pending
     ldr(ARMEmitter::XReg::x1, STATE, offsetof(FEXCore::Core::CPUState, DeferredSignalFaultAddress));
     str(ARMEmitter::XReg::zr, ARMEmitter::XReg::x1, 0);
 
@@ -248,6 +249,7 @@ void Arm64Dispatcher::EmitDispatcher() {
     subs(ARMEmitter::Size::i64Bit, ARMEmitter::XReg::x0, ARMEmitter::XReg::x0, 1);
     str(ARMEmitter::XReg::x0, STATE, offsetof(FEXCore::Core::CPUState, DeferredSignalRefCount));
 
+    // Trigger segfault if any deferred signals are pending
     ldr(TMP1, STATE, offsetof(FEXCore::Core::CPUState, DeferredSignalFaultAddress));
     str(ARMEmitter::XReg::zr, TMP1, 0);
 

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
@@ -129,13 +129,6 @@ void Arm64Dispatcher::EmitDispatcher() {
     and_(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r3, RipReg.R(), ARMEmitter::Reg::r3);
   }
 
-#ifdef VIXL_SIMULATOR
-  // VIXL simulator can't run syscalls.
-  constexpr bool SignalSafeCompile = false;
-#else
-  constexpr bool SignalSafeCompile = true;
-#endif
-
   ARMEmitter::ForwardLabel NoBlock;
 
   {
@@ -199,26 +192,9 @@ void Arm64Dispatcher::EmitDispatcher() {
     if (config.StaticRegisterAllocation)
       SpillStaticRegs(TMP1);
 
-#ifndef _WIN32
-    if (SignalSafeCompile) {
-      // When compiling code, mask all signals to reduce the chance of reentrant allocations
-      // Args:
-      // X0: SETMASK
-      // X1: Pointer to mask value (uint64_t)
-      // X2: Pointer to old mask value (uint64_t)
-      // X3: Size of mask, sizeof(uint64_t)
-      // X8: Syscall
-
-      LoadConstant(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r0, ~0ULL);
-      stp<ARMEmitter::IndexType::PRE>(ARMEmitter::XReg::x0, ARMEmitter::XReg::x0, ARMEmitter::Reg::rsp, -16);
-      LoadConstant(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r0, SIG_SETMASK);
-      add(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r1, ARMEmitter::Reg::rsp, 0);
-      add(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r2, ARMEmitter::Reg::rsp, 0);
-      LoadConstant(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r3, 8);
-      LoadConstant(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r8, SYS_rt_sigprocmask);
-      svc(0);
-    }
-#endif
+    ldr(ARMEmitter::XReg::x0, STATE, offsetof(FEXCore::Core::CPUState, DeferredSignalRefCount));
+    add(ARMEmitter::Size::i64Bit, ARMEmitter::XReg::x0, ARMEmitter::XReg::x0, 1);
+    str(ARMEmitter::XReg::x0, STATE, offsetof(FEXCore::Core::CPUState, DeferredSignalRefCount));
 
     mov(ARMEmitter::XReg::x0, STATE);
     mov(ARMEmitter::XReg::x1, ARMEmitter::XReg::lr);
@@ -230,27 +206,15 @@ void Arm64Dispatcher::EmitDispatcher() {
     blr(ARMEmitter::Reg::r2);
 #endif
 
-#ifndef _WIN32
-    if (SignalSafeCompile) {
-      // Now restore the signal mask
-      // Living in the same location
-
-      mov(ARMEmitter::XReg::x4, ARMEmitter::XReg::x0);
-      LoadConstant(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r0, SIG_SETMASK);
-      add(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r1, ARMEmitter::Reg::rsp, 0);
-      LoadConstant(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r2, 0);
-      LoadConstant(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r3, 8);
-      LoadConstant(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r8, SYS_rt_sigprocmask);
-      svc(0);
-
-      // Bring stack back
-      add(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::rsp, ARMEmitter::Reg::rsp, 16);
-      mov(ARMEmitter::XReg::x0, ARMEmitter::XReg::x4);
-    }
-#endif
-
     if (config.StaticRegisterAllocation)
       FillStaticRegs();
+
+    ldr(ARMEmitter::XReg::x1, STATE, offsetof(FEXCore::Core::CPUState, DeferredSignalRefCount));
+    subs(ARMEmitter::Size::i64Bit, ARMEmitter::XReg::x1, ARMEmitter::XReg::x1, 1);
+    str(ARMEmitter::XReg::x1, STATE, offsetof(FEXCore::Core::CPUState, DeferredSignalRefCount));
+
+    ldr(ARMEmitter::XReg::x1, STATE, offsetof(FEXCore::Core::CPUState, DeferredSignalFaultAddress));
+    str(ARMEmitter::XReg::zr, ARMEmitter::XReg::x1, 0);
 
     br(ARMEmitter::Reg::r0);
   }
@@ -262,29 +226,9 @@ void Arm64Dispatcher::EmitDispatcher() {
     if (config.StaticRegisterAllocation)
       SpillStaticRegs(TMP1);
 
-#ifndef _WIN32
-    if (SignalSafeCompile) {
-      // When compiling code, mask all signals to reduce the chance of reentrant allocations
-      // Args:
-      // X0: SETMASK
-      // X1: Pointer to mask value (uint64_t)
-      // X2: Pointer to old mask value (uint64_t)
-      // X3: Size of mask, sizeof(uint64_t)
-      // X8: Syscall
-
-      LoadConstant(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r0, ~0ULL);
-      stp<ARMEmitter::IndexType::PRE>(ARMEmitter::XReg::x0, ARMEmitter::XReg::x2, ARMEmitter::Reg::rsp, -16);
-      LoadConstant(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r0, SIG_SETMASK);
-      add(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r1, ARMEmitter::Reg::rsp, 0);
-      add(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r2, ARMEmitter::Reg::rsp, 0);
-      LoadConstant(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r3, 8);
-      LoadConstant(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r8, SYS_rt_sigprocmask);
-      svc(0);
-
-      // Reload x2 to bring back RIP
-      ldr(ARMEmitter::XReg::x2, ARMEmitter::Reg::rsp, 8);
-    }
-#endif
+    ldr(ARMEmitter::XReg::x0, STATE, offsetof(FEXCore::Core::CPUState, DeferredSignalRefCount));
+    add(ARMEmitter::Size::i64Bit, ARMEmitter::XReg::x0, ARMEmitter::XReg::x0, 1);
+    str(ARMEmitter::XReg::x0, STATE, offsetof(FEXCore::Core::CPUState, DeferredSignalRefCount));
 
     ldr(ARMEmitter::XReg::x0, &l_CTX);
     mov(ARMEmitter::XReg::x1, STATE);
@@ -297,24 +241,15 @@ void Arm64Dispatcher::EmitDispatcher() {
     blr(ARMEmitter::Reg::r3); // { CTX, Frame, RIP}
 #endif
 
-#ifndef _WIN32
-    if (SignalSafeCompile) {
-      // Now restore the signal mask
-      // Living in the same location
-      LoadConstant(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r0, SIG_SETMASK);
-      add(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r1, ARMEmitter::Reg::rsp, 0);
-      LoadConstant(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r2, 0);
-      LoadConstant(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r3, 8);
-      LoadConstant(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r8, SYS_rt_sigprocmask);
-      svc(0);
-
-      // Bring stack back
-      add(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::rsp, ARMEmitter::Reg::rsp, 16);
-    }
-#endif
-
     if (config.StaticRegisterAllocation)
       FillStaticRegs();
+
+    ldr(ARMEmitter::XReg::x0, STATE, offsetof(FEXCore::Core::CPUState, DeferredSignalRefCount));
+    subs(ARMEmitter::Size::i64Bit, ARMEmitter::XReg::x0, ARMEmitter::XReg::x0, 1);
+    str(ARMEmitter::XReg::x0, STATE, offsetof(FEXCore::Core::CPUState, DeferredSignalRefCount));
+
+    ldr(TMP1, STATE, offsetof(FEXCore::Core::CPUState, DeferredSignalFaultAddress));
+    str(ARMEmitter::XReg::zr, TMP1, 0);
 
     b(&LoopTop);
   }

--- a/External/FEXCore/Source/Interface/IR/AOTIR.cpp
+++ b/External/FEXCore/Source/Interface/IR/AOTIR.cpp
@@ -251,8 +251,8 @@ namespace FEXCore::IR {
     }
   }
 
-  AOTIRCaptureCache::PreGenerateIRFetchResult AOTIRCaptureCache::PreGenerateIRFetch(uint64_t GuestRIP, FEXCore::IR::IRListView *IRList) {
-    auto AOTIRCacheEntry = CTX->SyscallHandler->LookupAOTIRCacheEntry(GuestRIP);
+  AOTIRCaptureCache::PreGenerateIRFetchResult AOTIRCaptureCache::PreGenerateIRFetch(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP, FEXCore::IR::IRListView *IRList) {
+    auto AOTIRCacheEntry = CTX->SyscallHandler->LookupAOTIRCacheEntry(Thread, GuestRIP);
 
     PreGenerateIRFetchResult Result{};
 
@@ -306,7 +306,7 @@ namespace FEXCore::IR {
     // Both generated ir and LibraryJITName need a named region lookup
     if (GeneratedIR || CTX->Config.LibraryJITNaming() || CTX->Config.GDBSymbols()) {
 
-      auto AOTIRCacheEntry = CTX->SyscallHandler->LookupAOTIRCacheEntry(GuestRIP);
+      auto AOTIRCacheEntry = CTX->SyscallHandler->LookupAOTIRCacheEntry(Thread, GuestRIP);
 
       if (AOTIRCacheEntry.Entry) {
         if (DebugData && CTX->Config.LibraryJITNaming()) {

--- a/External/FEXCore/Source/Interface/IR/AOTIR.h
+++ b/External/FEXCore/Source/Interface/IR/AOTIR.h
@@ -105,7 +105,7 @@ namespace FEXCore::IR {
         uint64_t Length {};
         bool GeneratedIR {};
       };
-      [[nodiscard]] PreGenerateIRFetchResult PreGenerateIRFetch(uint64_t GuestRIP, FEXCore::IR::IRListView *IRList);
+      [[nodiscard]] PreGenerateIRFetchResult PreGenerateIRFetch(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP, FEXCore::IR::IRListView *IRList);
 
       bool PostCompileCode(FEXCore::Core::InternalThreadState *Thread,
         void* CodePtr,

--- a/External/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
@@ -314,6 +314,36 @@ namespace {
       FEXCore::IR::InvalidClass,
     });
 
+    // _pad2
+    ContextClassification->emplace_back(ContextMemberInfo {
+      ContextMemberClassification {
+        offsetof(FEXCore::Core::CPUState, _pad2),
+        sizeof(FEXCore::Core::CPUState::_pad2),
+      },
+      ACCESS_NONE,
+      FEXCore::IR::InvalidClass,
+    });
+
+    // DeferredSignalRefCount
+    ContextClassification->emplace_back(ContextMemberInfo {
+      ContextMemberClassification {
+        offsetof(FEXCore::Core::CPUState, DeferredSignalRefCount),
+        sizeof(FEXCore::Core::CPUState::DeferredSignalRefCount),
+      },
+      ACCESS_NONE,
+      FEXCore::IR::InvalidClass,
+    });
+
+    // DeferredSignalFaultAddress
+    ContextClassification->emplace_back(ContextMemberInfo {
+      ContextMemberClassification {
+        offsetof(FEXCore::Core::CPUState, DeferredSignalFaultAddress),
+        sizeof(FEXCore::Core::CPUState::DeferredSignalFaultAddress),
+      },
+      ACCESS_NONE,
+      FEXCore::IR::InvalidClass,
+    });
+
 
     [[maybe_unused]] size_t ClassifiedStructSize{};
     ContextClassificationInfo->Lookup.reserve(sizeof(FEXCore::Core::CPUState));
@@ -393,6 +423,10 @@ namespace {
 
     SetAccess(Offset++, ACCESS_NONE);
     SetAccess(Offset++, ACCESS_NONE);
+
+    SetAccess(Offset++, ACCESS_INVALID);
+    SetAccess(Offset++, ACCESS_INVALID);
+    SetAccess(Offset++, ACCESS_INVALID);
   }
 
   struct BlockInfo {

--- a/External/FEXCore/Source/Utils/Allocator/64BitAllocator.cpp
+++ b/External/FEXCore/Source/Utils/Allocator/64BitAllocator.cpp
@@ -6,7 +6,6 @@
 #include <FEXCore/Utils/MathUtils.h>
 #include <FEXCore/fextl/sstream.h>
 #include <FEXCore/Utils/DeferredSignalMutex.h>
-#include <FEXHeaderUtils/ScopedSignalMask.h>
 #include <FEXHeaderUtils/Syscalls.h>
 #include <FEXHeaderUtils/TypeDefines.h>
 #include <FEXCore/fextl/memory.h>

--- a/External/FEXCore/Source/Utils/Allocator/HostAllocator.h
+++ b/External/FEXCore/Source/Utils/Allocator/HostAllocator.h
@@ -6,6 +6,10 @@
 #include <cstdint>
 #include <sys/types.h>
 
+namespace FEXCore::Core {
+struct InternalThreadState;
+}
+
 namespace Alloc {
   // HostAllocator is just a page pased slab allocator
   // Similar to mmap and munmap only mapping at the page level
@@ -36,5 +40,7 @@ namespace Alloc {
 }
 
 namespace Alloc::OSAllocator {
+void RegisterTLSData(FEXCore::Core::InternalThreadState *Thread);
+void UninstallTLSData(FEXCore::Core::InternalThreadState *Thread);
 fextl::unique_ptr<Alloc::HostAllocator> Create64BitAllocator();
 }

--- a/External/FEXCore/include/FEXCore/Core/Context.h
+++ b/External/FEXCore/include/FEXCore/Core/Context.h
@@ -271,8 +271,8 @@ namespace FEXCore::Context {
 
       FEX_DEFAULT_VISIBILITY virtual void FinalizeAOTIRCache() = 0;
       FEX_DEFAULT_VISIBILITY virtual void WriteFilesWithCode(std::function<void(const fextl::string& fileid, const fextl::string& filename)> Writer) = 0;
-      FEX_DEFAULT_VISIBILITY virtual void InvalidateGuestCodeRange(uint64_t Start, uint64_t Length) = 0;
-      FEX_DEFAULT_VISIBILITY virtual void InvalidateGuestCodeRange(uint64_t Start, uint64_t Length, std::function<void(uint64_t start, uint64_t Length)> callback) = 0;
+      FEX_DEFAULT_VISIBILITY virtual void InvalidateGuestCodeRange(FEXCore::Core::InternalThreadState *Thread, uint64_t Start, uint64_t Length) = 0;
+      FEX_DEFAULT_VISIBILITY virtual void InvalidateGuestCodeRange(FEXCore::Core::InternalThreadState *Thread, uint64_t Start, uint64_t Length, std::function<void(uint64_t start, uint64_t Length)> callback) = 0;
       FEX_DEFAULT_VISIBILITY virtual void MarkMemoryShared() = 0;
 
       FEX_DEFAULT_VISIBILITY virtual void ConfigureAOTGen(FEXCore::Core::InternalThreadState *Thread, fextl::set<uint64_t> *ExternalBranches, uint64_t SectionMaxAddress) = 0;

--- a/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
+++ b/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
@@ -105,10 +105,14 @@ namespace FEXCore::Core {
     bool DestroyedByParent{false};  // Should the parent destroy this thread, or it destory itself
 
     struct DeferredSignalState {
+#ifndef _WIN32
       siginfo_t Info;
+#endif
       int Signal;
     };
 
+    // Queue of thread local signal frames that have been deferred.
+    // Async signals aren't guaranteed to be delivered in any particular order, but FEX treats them as FILO.
     fextl::vector<DeferredSignalState> DeferredSignalFrames;
 
     // BaseFrameState should always be at the end.

--- a/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
+++ b/External/FEXCore/include/FEXCore/Debug/InternalThreadState.h
@@ -104,8 +104,15 @@ namespace FEXCore::Core {
     std::shared_mutex ObjectCacheRefCounter{};
     bool DestroyedByParent{false};  // Should the parent destroy this thread, or it destory itself
 
-    alignas(16) FEXCore::Core::CpuStateFrame BaseFrameState{};
+    struct DeferredSignalState {
+      siginfo_t Info;
+      int Signal;
+    };
 
+    fextl::vector<DeferredSignalState> DeferredSignalFrames;
+
+    // BaseFrameState should always be at the end.
+    alignas(16) FEXCore::Core::CpuStateFrame BaseFrameState{};
   };
   // static_assert(std::is_standard_layout<InternalThreadState>::value, "This needs to be standard layout");
 }

--- a/External/FEXCore/include/FEXCore/HLE/SyscallHandler.h
+++ b/External/FEXCore/include/FEXCore/HLE/SyscallHandler.h
@@ -74,8 +74,8 @@ namespace FEXCore::HLE {
 
     SyscallOSABI GetOSABI() const { return OSABI; }
     virtual FEXCore::CodeLoader *GetCodeLoader() const { return nullptr; }
-    virtual void MarkGuestExecutableRange(uint64_t Start, uint64_t Length) { }
-    virtual AOTIRCacheEntryLookupResult LookupAOTIRCacheEntry(uint64_t GuestAddr) = 0;
+    virtual void MarkGuestExecutableRange(FEXCore::Core::InternalThreadState *Thread, uint64_t Start, uint64_t Length) { }
+    virtual AOTIRCacheEntryLookupResult LookupAOTIRCacheEntry(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestAddr) = 0;
 
     virtual SourcecodeResolver *GetSourcecodeResolver() { return nullptr; }
   protected:

--- a/External/FEXCore/include/FEXCore/Utils/DeferredSignalMutex.h
+++ b/External/FEXCore/include/FEXCore/Utils/DeferredSignalMutex.h
@@ -1,0 +1,134 @@
+#pragma once
+
+#include <FEXCore/Debug/InternalThreadState.h>
+
+#include <atomic>
+#include <cstdint>
+#include <mutex>
+#include <shared_mutex>
+#include <signal.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+namespace FEXCore {
+
+  template<typename MutexType, void (MutexType::*lock_fn)(), void (MutexType::*unlock_fn)()>
+  class ScopedDeferredSignalWithMutexBase final {
+    public:
+
+      ScopedDeferredSignalWithMutexBase(MutexType &_Mutex, FEXCore::Core::InternalThreadState *Thread)
+        : Mutex {&_Mutex}
+        , Thread {Thread} {
+        // Needs to be atomic so that operations can't end up getting reordered around this.
+        Thread->CurrentFrame->State.DeferredSignalRefCount.Increment(1);
+        // Lock the mutex
+        (Mutex->*lock_fn)();
+      }
+
+      // No copy or assignment possible
+      ScopedDeferredSignalWithMutexBase(const ScopedDeferredSignalWithMutexBase&) = delete;
+      ScopedDeferredSignalWithMutexBase& operator=(ScopedDeferredSignalWithMutexBase&) = delete;
+
+      // Only move
+      ScopedDeferredSignalWithMutexBase(ScopedDeferredSignalWithMutexBase &&rhs)
+        : Mutex {rhs.Mutex}
+        , Thread {rhs.Thread} {
+        rhs.Mutex = nullptr;
+      }
+
+      ~ScopedDeferredSignalWithMutexBase() {
+        if (Mutex != nullptr) {
+          // Unlock the mutex
+          (Mutex->*unlock_fn)();
+
+#ifdef _M_X86_64
+          // Needs to be atomic so that operations can't end up getting reordered around this.
+          // Without this, the recount and the signal access could get reordered.
+          auto Result = Thread->CurrentFrame->State.DeferredSignalRefCount.Decrement(1);
+
+          // X86-64 must do an additional check around the store.
+          if ((Result - 1) == 0) {
+            // Must happen after the refcount store
+            Thread->CurrentFrame->State.DeferredSignalFaultAddress->Store(0);
+          }
+#else
+          Thread->CurrentFrame->State.DeferredSignalRefCount.Decrement(1);
+          Thread->CurrentFrame->State.DeferredSignalFaultAddress->Store(0);
+#endif
+        }
+      }
+    private:
+      MutexType *Mutex;
+      FEXCore::Core::InternalThreadState *Thread;
+  };
+
+  using ScopedDeferredSignalWithMutex      = ScopedDeferredSignalWithMutexBase<std::mutex, &std::mutex::lock, &std::mutex::unlock>;
+  using ScopedDeferredSignalWithSharedLock = ScopedDeferredSignalWithMutexBase<std::shared_mutex, &std::shared_mutex::lock_shared, &std::shared_mutex::unlock_shared>;
+  using ScopedDeferredSignalWithUniqueLock = ScopedDeferredSignalWithMutexBase<std::shared_mutex, &std::shared_mutex::lock, &std::shared_mutex::unlock>;
+
+  template<typename MutexType, void (MutexType::*lock_fn)(), void (MutexType::*unlock_fn)()>
+  class ScopedPotentialDeferredSignalWithMutexBase final {
+    public:
+
+      ScopedPotentialDeferredSignalWithMutexBase(MutexType &_Mutex, FEXCore::Core::InternalThreadState *Thread, uint64_t Mask = ~0ULL)
+        : Mutex {&_Mutex}
+        , Thread {Thread} {
+        if (Thread) {
+          Thread->CurrentFrame->State.DeferredSignalRefCount.Increment(1);
+        }
+        else {
+          // Mask all signals, storing the original incoming mask
+          ::syscall(SYS_rt_sigprocmask, SIG_SETMASK, &Mask, &OriginalMask, sizeof(OriginalMask));
+        }
+        // Lock the mutex
+        (Mutex->*lock_fn)();
+      }
+
+      // No copy or assignment possible
+      ScopedPotentialDeferredSignalWithMutexBase(const ScopedPotentialDeferredSignalWithMutexBase&) = delete;
+      ScopedPotentialDeferredSignalWithMutexBase& operator=(ScopedPotentialDeferredSignalWithMutexBase&) = delete;
+
+      // Only move
+      ScopedPotentialDeferredSignalWithMutexBase(ScopedPotentialDeferredSignalWithMutexBase &&rhs)
+        : Mutex {rhs.Mutex}
+        , Thread {rhs.Thread} {
+        rhs.Mutex = nullptr;
+      }
+
+      ~ScopedPotentialDeferredSignalWithMutexBase() {
+        if (Mutex != nullptr) {
+          // Unlock the mutex
+          (Mutex->*unlock_fn)();
+
+          if (Thread) {
+#ifdef _M_X86_64
+          // Needs to be atomic so that operations can't end up getting reordered around this.
+          // Without this, the recount and the signal access could get reordered.
+          auto Result = Thread->CurrentFrame->State.DeferredSignalRefCount.Decrement(1);
+
+          // X86-64 must do an additional check around the store.
+          if ((Result - 1) == 0) {
+            // Must happen after the refcount store
+            Thread->CurrentFrame->State.DeferredSignalFaultAddress->Store(0);
+          }
+#else
+          Thread->CurrentFrame->State.DeferredSignalRefCount.Decrement(1);
+          Thread->CurrentFrame->State.DeferredSignalFaultAddress->Store(0);
+#endif
+          }
+          else {
+            // Unmask back to the original signal mask
+            ::syscall(SYS_rt_sigprocmask, SIG_SETMASK, &OriginalMask, nullptr, sizeof(OriginalMask));
+          }
+        }
+      }
+    private:
+      MutexType *Mutex;
+      uint64_t OriginalMask{};
+      FEXCore::Core::InternalThreadState *Thread;
+  };
+
+  using ScopedPotentialDeferredSignalWithMutex      = ScopedPotentialDeferredSignalWithMutexBase<std::mutex, &std::mutex::lock, &std::mutex::unlock>;
+  using ScopedPotentialDeferredSignalWithSharedLock = ScopedPotentialDeferredSignalWithMutexBase<std::shared_mutex, &std::shared_mutex::lock_shared, &std::shared_mutex::unlock_shared>;
+  using ScopedPotentialDeferredSignalWithUniqueLock = ScopedPotentialDeferredSignalWithMutexBase<std::shared_mutex, &std::shared_mutex::lock, &std::shared_mutex::unlock>;
+}

--- a/External/FEXCore/include/FEXCore/Utils/DeferredSignalMutex.h
+++ b/External/FEXCore/include/FEXCore/Utils/DeferredSignalMutex.h
@@ -103,7 +103,7 @@ namespace FEXCore {
           if (Thread) {
 #ifdef _M_X86_64
           // Needs to be atomic so that operations can't end up getting reordered around this.
-          // Without this, the recount and the signal access could get reordered.
+          // Without this, the refcount and the signal access could get reordered.
           auto Result = Thread->CurrentFrame->State.DeferredSignalRefCount.Decrement(1);
 
           // X86-64 must do an additional check around the store.

--- a/FEXHeaderUtils/FEXHeaderUtils/ScopedSignalMask.h
+++ b/FEXHeaderUtils/FEXHeaderUtils/ScopedSignalMask.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <FEXCore/Utils/CompilerDefs.h>
-#include <FEXCore/Utils/LogManager.h>
 
+#include <atomic>
 #include <cstdint>
 #include <mutex>
 #include <shared_mutex>

--- a/Source/Tools/FEXLoader/IRLoader.cpp
+++ b/Source/Tools/FEXLoader/IRLoader.cpp
@@ -158,7 +158,7 @@ class DummySyscallHandler: public FEXCore::HLE::SyscallHandler, public FEXCore::
   }
 
   // These are no-ops implementations of the SyscallHandler API
-  FEXCore::HLE::AOTIRCacheEntryLookupResult LookupAOTIRCacheEntry(uint64_t GuestAddr) override {
+  FEXCore::HLE::AOTIRCacheEntryLookupResult LookupAOTIRCacheEntry(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestAddr) override {
     return {0, 0};
   }
 };

--- a/Source/Tools/FEXLoader/LinuxSyscalls/FileManagement.cpp
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/FileManagement.cpp
@@ -20,7 +20,6 @@ $end_info$
 #include <FEXCore/fextl/string.h>
 #include <FEXCore/fextl/vector.h>
 #include <FEXHeaderUtils/Filesystem.h>
-#include <FEXHeaderUtils/ScopedSignalMask.h>
 #include <FEXHeaderUtils/Syscalls.h>
 
 #include <algorithm>

--- a/Source/Tools/FEXLoader/LinuxSyscalls/Syscalls.cpp
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/Syscalls.cpp
@@ -729,9 +729,7 @@ SyscallHandler::SyscallHandler(FEXCore::Context::Context *_CTX, FEX::HLE::Signal
   GuestKernelVersion = CalculateGuestKernelVersion();
   Alloc32Handler = FEX::HLE::Create32BitAllocator();
 
-  if (SMCChecks == FEXCore::Config::CONFIG_SMC_MTRACK) {
-    SignalDelegation->RegisterHostSignalHandler(SIGSEGV, HandleSegfault, true);
-  }
+  SignalDelegation->RegisterHostSignalHandler(SIGSEGV, HandleSegfault, true);
 }
 
 SyscallHandler::~SyscallHandler() {

--- a/Source/Tools/FEXLoader/LinuxSyscalls/Syscalls.h
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/Syscalls.h
@@ -198,10 +198,10 @@ public:
   FEX::HLE::MemAllocator *Get32BitAllocator() { return Alloc32Handler.get(); }
 
   // does a mmap as if done via a guest syscall
-  virtual void *GuestMmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset) = 0;
+  virtual void *GuestMmap(FEXCore::Core::InternalThreadState *Thread, void *addr, size_t length, int prot, int flags, int fd, off_t offset) = 0;
 
   // does a guest munmap as if done via a guest syscall
-  virtual int GuestMunmap(void *addr, uint64_t length) = 0;
+  virtual int GuestMunmap(FEXCore::Core::InternalThreadState *Thread, void *addr, uint64_t length) = 0;
 
   ///// Memory Manager tracking /////
   void TrackMmap(FEXCore::Core::InternalThreadState *Thread, uintptr_t Base, uintptr_t Size, int Prot, int Flags, int fd, off_t Offset);
@@ -210,13 +210,13 @@ public:
   void TrackMremap(FEXCore::Core::InternalThreadState *Thread, uintptr_t OldAddress, size_t OldSize, size_t NewSize, int flags, uintptr_t NewAddress);
   void TrackShmat(FEXCore::Core::InternalThreadState *Thread, int shmid, uintptr_t Base, int shmflg);
   void TrackShmdt(FEXCore::Core::InternalThreadState *Thread, uintptr_t Base);
-  void TrackMadvise(uintptr_t Base, uintptr_t Size, int advice);
+  void TrackMadvise(FEXCore::Core::InternalThreadState *Thread, uintptr_t Base, uintptr_t Size, int advice);
 
   ///// VMA (Virtual Memory Area) tracking /////
   static bool HandleSegfault(FEXCore::Core::InternalThreadState *Thread, int Signal, void *info, void *ucontext);
-  void MarkGuestExecutableRange(uint64_t Start, uint64_t Length) override;
+  void MarkGuestExecutableRange(FEXCore::Core::InternalThreadState *Thread, uint64_t Start, uint64_t Length) override;
   // AOTIRCacheEntryLookupResult also includes a shared lock guard, so the pointed AOTIRCacheEntry return can be safely used
-  FEXCore::HLE::AOTIRCacheEntryLookupResult LookupAOTIRCacheEntry(uint64_t GuestAddr) final override;
+  FEXCore::HLE::AOTIRCacheEntryLookupResult LookupAOTIRCacheEntry(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestAddr) final override;
 
   ///// FORK tracking /////
   void LockBeforeFork();

--- a/Source/Tools/FEXLoader/LinuxSyscalls/Syscalls.h
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/Syscalls.h
@@ -204,12 +204,12 @@ public:
   virtual int GuestMunmap(void *addr, uint64_t length) = 0;
 
   ///// Memory Manager tracking /////
-  void TrackMmap(uintptr_t Base, uintptr_t Size, int Prot, int Flags, int fd, off_t Offset);
-  void TrackMunmap(uintptr_t Base, uintptr_t Size);
-  void TrackMprotect(uintptr_t Base, uintptr_t Size, int Prot);
-  void TrackMremap(uintptr_t OldAddress, size_t OldSize, size_t NewSize, int flags, uintptr_t NewAddress);
-  void TrackShmat(int shmid, uintptr_t Base, int shmflg);
-  void TrackShmdt(uintptr_t Base);
+  void TrackMmap(FEXCore::Core::InternalThreadState *Thread, uintptr_t Base, uintptr_t Size, int Prot, int Flags, int fd, off_t Offset);
+  void TrackMunmap(FEXCore::Core::InternalThreadState *Thread, uintptr_t Base, uintptr_t Size);
+  void TrackMprotect(FEXCore::Core::InternalThreadState *Thread, uintptr_t Base, uintptr_t Size, int Prot);
+  void TrackMremap(FEXCore::Core::InternalThreadState *Thread, uintptr_t OldAddress, size_t OldSize, size_t NewSize, int flags, uintptr_t NewAddress);
+  void TrackShmat(FEXCore::Core::InternalThreadState *Thread, int shmid, uintptr_t Base, int shmflg);
+  void TrackShmdt(FEXCore::Core::InternalThreadState *Thread, uintptr_t Base);
   void TrackMadvise(uintptr_t Base, uintptr_t Size, int advice);
 
   ///// VMA (Virtual Memory Area) tracking /////

--- a/Source/Tools/FEXLoader/LinuxSyscalls/Syscalls/Memory.cpp
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/Syscalls/Memory.cpp
@@ -8,6 +8,7 @@ $end_info$
 #include "LinuxSyscalls/x64/Syscalls.h"
 #include "LinuxSyscalls/x32/Syscalls.h"
 
+#include <FEXCore/Debug/InternalThreadState.h>
 #include <FEXCore/IR/IR.h>
 
 #include <stddef.h>
@@ -43,7 +44,7 @@ namespace FEX::HLE {
       uint64_t Result = ::madvise(addr, length, advice);
 
       if (Result != -1) {
-        FEX::HLE::_SyscallHandler->TrackMadvise((uintptr_t)addr, length, advice);
+        FEX::HLE::_SyscallHandler->TrackMadvise(Frame->Thread, (uintptr_t)addr, length, advice);
       }
       SYSCALL_ERRNO();
     });

--- a/Source/Tools/FEXLoader/LinuxSyscalls/SyscallsSMCTracking.cpp
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/SyscallsSMCTracking.cpp
@@ -191,7 +191,9 @@ void SyscallHandler::TrackMmap(FEXCore::Core::InternalThreadState *Thread, uintp
   }
 
   {
-    // Frontend calls this with nullptr Thread.
+    // NOTE: Frontend calls this with a nullptr Thread during initialization, but
+    //       providing this code with a valid Thread object earlier would allow
+    //       us to be more optimal by using ScopedDeferredSignalWithUniqueLock instead
     FEXCore::ScopedPotentialDeferredSignalWithUniqueLock lk(VMATracking.Mutex, Thread);
 
     static uint64_t AnonSharedId = 1;
@@ -239,7 +241,9 @@ void SyscallHandler::TrackMunmap(FEXCore::Core::InternalThreadState *Thread, uin
   Size = FEXCore::AlignUp(Size, FHU::FEX_PAGE_SIZE);
 
   {
-    // Frontend calls this with nullptr Thread.
+    // Frontend calls this with nullptr Thread during initialization.
+    // This is why `ScopedPotentialDeferredSignalWithUniqueLock` is used here.
+    // To be more optimal the frontend should provide this code with a valid Thread object earlier.
     FEXCore::ScopedPotentialDeferredSignalWithUniqueLock lk(VMATracking.Mutex, Thread);
 
     VMATracking.ClearUnsafe(CTX, Base, Size);

--- a/Source/Tools/FEXLoader/LinuxSyscalls/x32/Memory.cpp
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/x32/Memory.cpp
@@ -28,7 +28,7 @@ namespace FEX::HLE::x32 {
     LOGMAN_THROW_AA_FMT((Result >> 32) == 0|| (Result >> 32) == 0xFFFFFFFF, "values must fit to 32 bits");
 
     if (!FEX::HLE::HasSyscallError(Result)) {
-      FEX::HLE::_SyscallHandler->TrackMmap(Result, length, prot, flags, fd, offset);
+      FEX::HLE::_SyscallHandler->TrackMmap(nullptr, Result, length, prot, flags, fd, offset);
       return (void *)Result;
     } else {
       errno = -Result;
@@ -43,7 +43,7 @@ namespace FEX::HLE::x32 {
     auto Result = GetAllocator()->Munmap(addr, length);
 
     if (Result == 0) {
-      FEX::HLE::_SyscallHandler->TrackMunmap((uintptr_t)addr, length);
+      FEX::HLE::_SyscallHandler->TrackMunmap(nullptr, (uintptr_t)addr, length);
       return Result;
     } else {
       errno = -Result;
@@ -84,7 +84,7 @@ namespace FEX::HLE::x32 {
     REGISTER_SYSCALL_IMPL_X32(mprotect, [](FEXCore::Core::CpuStateFrame *Frame, void *addr, uint32_t len, int prot) -> uint64_t {
       uint64_t Result = ::mprotect(addr, len, prot);
       if (Result != -1) {
-        FEX::HLE::_SyscallHandler->TrackMprotect((uintptr_t)addr, len, prot);
+        FEX::HLE::_SyscallHandler->TrackMprotect(Frame->Thread, (uintptr_t)addr, len, prot);
       }
 
       SYSCALL_ERRNO();
@@ -95,7 +95,7 @@ namespace FEX::HLE::x32 {
         Mremap(old_address, old_size, new_size, flags, new_address));
 
       if (!FEX::HLE::HasSyscallError(Result)) {
-        FEX::HLE::_SyscallHandler->TrackMremap((uintptr_t)old_address, old_size, new_size, flags, Result);
+        FEX::HLE::_SyscallHandler->TrackMremap(Frame->Thread, (uintptr_t)old_address, old_size, new_size, flags, Result);
       }
 
       return Result;
@@ -118,7 +118,7 @@ namespace FEX::HLE::x32 {
           Shmat(shmid, reinterpret_cast<const void*>(shmaddr), shmflg, &ResultAddr);
 
       if (!FEX::HLE::HasSyscallError(Result)) {
-        FEX::HLE::_SyscallHandler->TrackShmat(shmid, ResultAddr, shmflg);
+        FEX::HLE::_SyscallHandler->TrackShmat(Frame->Thread, shmid, ResultAddr, shmflg);
         return ResultAddr;
       }
       else {
@@ -132,7 +132,7 @@ namespace FEX::HLE::x32 {
         Shmdt(shmaddr);
 
       if (!FEX::HLE::HasSyscallError(Result)) {
-        FEX::HLE::_SyscallHandler->TrackShmdt((uintptr_t)shmaddr);
+        FEX::HLE::_SyscallHandler->TrackShmdt(Frame->Thread, (uintptr_t)shmaddr);
       }
 
       return Result;

--- a/Source/Tools/FEXLoader/LinuxSyscalls/x32/Semaphore.cpp
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/x32/Semaphore.cpp
@@ -10,6 +10,7 @@ $end_info$
 
 #include "LinuxSyscalls/x64/Syscalls.h"
 
+#include <FEXCore/Debug/InternalThreadState.h>
 #include <FEXCore/Utils/LogManager.h>
 #include <FEXCore/fextl/vector.h>
 #include <FEXHeaderUtils/Syscalls.h>
@@ -283,7 +284,7 @@ namespace FEX::HLE::x32 {
         Result = static_cast<FEX::HLE::x32::x32SyscallHandler*>(FEX::HLE::_SyscallHandler)->GetAllocator()->
           Shmat(first, reinterpret_cast<const void*>(ptr), second, reinterpret_cast<uint32_t*>(third));
         if (!FEX::HLE::HasSyscallError(Result)) {
-          FEX::HLE::_SyscallHandler->TrackShmat(first, *reinterpret_cast<uint32_t*>(third), second);
+          FEX::HLE::_SyscallHandler->TrackShmat(Frame->Thread, first, *reinterpret_cast<uint32_t*>(third), second);
         }
         break;
       }
@@ -292,7 +293,7 @@ namespace FEX::HLE::x32 {
         Result = static_cast<FEX::HLE::x32::x32SyscallHandler*>(FEX::HLE::_SyscallHandler)->GetAllocator()->
           Shmdt(reinterpret_cast<void*>(ptr));
         if (!FEX::HLE::HasSyscallError(Result)) {
-          FEX::HLE::_SyscallHandler->TrackShmdt(ptr);
+          FEX::HLE::_SyscallHandler->TrackShmdt(Frame->Thread, ptr);
         }
         break;
       }

--- a/Source/Tools/FEXLoader/LinuxSyscalls/x32/Syscalls.h
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/x32/Syscalls.h
@@ -37,8 +37,8 @@ public:
   x32SyscallHandler(FEXCore::Context::Context *ctx, FEX::HLE::SignalDelegator *_SignalDelegation, fextl::unique_ptr<MemAllocator> Allocator);
 
   FEX::HLE::MemAllocator *GetAllocator() { return AllocHandler.get(); }
-  void *GuestMmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset) override;
-  int GuestMunmap(void *addr, uint64_t length) override;
+  void *GuestMmap(FEXCore::Core::InternalThreadState *Thread, void *addr, size_t length, int prot, int flags, int fd, off_t offset) override;
+  int GuestMunmap(FEXCore::Core::InternalThreadState *Thread, void *addr, uint64_t length) override;
 
   void RegisterSyscall_32(int SyscallNumber,
     int32_t HostSyscallNumber,

--- a/Source/Tools/FEXLoader/LinuxSyscalls/x64/Memory.cpp
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/x64/Memory.cpp
@@ -37,7 +37,7 @@ namespace FEX::HLE::x64 {
     }
 
     if (Result != -1) {
-      FEX::HLE::_SyscallHandler->TrackMmap((uintptr_t)Result, length, prot, flags, fd, offset);
+      FEX::HLE::_SyscallHandler->TrackMmap(nullptr, (uintptr_t)Result, length, prot, flags, fd, offset);
     }
 
     return reinterpret_cast<void*>(Result);
@@ -57,7 +57,7 @@ namespace FEX::HLE::x64 {
     }
 
     if (Result != -1) {
-      FEX::HLE::_SyscallHandler->TrackMunmap(reinterpret_cast<uintptr_t>(addr), length);
+      FEX::HLE::_SyscallHandler->TrackMunmap(nullptr, reinterpret_cast<uintptr_t>(addr), length);
     }
 
     return Result;
@@ -87,7 +87,7 @@ namespace FEX::HLE::x64 {
       uint64_t Result = reinterpret_cast<uint64_t>(::mremap(old_address, old_size, new_size, flags, new_address));
 
       if (Result != -1) {
-        FEX::HLE::_SyscallHandler->TrackMremap((uintptr_t)old_address, old_size, new_size, flags, Result);
+        FEX::HLE::_SyscallHandler->TrackMremap(Frame->Thread, (uintptr_t)old_address, old_size, new_size, flags, Result);
       }
       SYSCALL_ERRNO();
     });
@@ -97,7 +97,7 @@ namespace FEX::HLE::x64 {
       uint64_t Result = ::mprotect(addr, len, prot);
 
       if (Result != -1) {
-        FEX::HLE::_SyscallHandler->TrackMprotect((uintptr_t)addr, len, prot);
+        FEX::HLE::_SyscallHandler->TrackMprotect(Frame->Thread, (uintptr_t)addr, len, prot);
       }
       SYSCALL_ERRNO();
     });
@@ -119,7 +119,7 @@ namespace FEX::HLE::x64 {
       uint64_t Result = reinterpret_cast<uint64_t>(shmat(shmid, shmaddr, shmflg));
 
       if (Result != -1) {
-        FEX::HLE::_SyscallHandler->TrackShmat(shmid, Result, shmflg);
+        FEX::HLE::_SyscallHandler->TrackShmat(Frame->Thread, shmid, Result, shmflg);
       }
       SYSCALL_ERRNO();
     });
@@ -129,7 +129,7 @@ namespace FEX::HLE::x64 {
       uint64_t Result = ::shmdt(shmaddr);
 
       if (Result != -1) {
-        FEX::HLE::_SyscallHandler->TrackShmdt((uintptr_t)shmaddr);
+        FEX::HLE::_SyscallHandler->TrackShmdt(Frame->Thread, (uintptr_t)shmaddr);
       }
       SYSCALL_ERRNO();
     });

--- a/Source/Tools/FEXLoader/LinuxSyscalls/x64/Syscalls.h
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/x64/Syscalls.h
@@ -35,8 +35,8 @@ class x64SyscallHandler final : public FEX::HLE::SyscallHandler {
   public:
     x64SyscallHandler(FEXCore::Context::Context *ctx, FEX::HLE::SignalDelegator *_SignalDelegation);
 
-    void *GuestMmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset) override;
-    int GuestMunmap(void *addr, uint64_t length) override;
+    void *GuestMmap(FEXCore::Core::InternalThreadState *Thread, void *addr, size_t length, int prot, int flags, int fd, off_t offset) override;
+    int GuestMunmap(FEXCore::Core::InternalThreadState *Thread, void *addr, uint64_t length) override;
 
 
   void RegisterSyscall_64(int SyscallNumber,

--- a/Source/Tools/FEXLoader/VDSO_Emulation.cpp
+++ b/Source/Tools/FEXLoader/VDSO_Emulation.cpp
@@ -544,7 +544,7 @@ namespace FEX::VDSO {
         VDSOSize = FEXCore::AlignUp(VDSOSize, 4096);
 
         // Map the VDSO file to memory
-        VDSOBase = Handler->GuestMmap(nullptr, VDSOSize, PROT_READ, MAP_PRIVATE, VDSOFD, 0);
+        VDSOBase = Handler->GuestMmap(nullptr, nullptr, VDSOSize, PROT_READ, MAP_PRIVATE, VDSOFD, 0);
 
         // Since we found our VDSO thunk library, find our host VDSO function implementations.
         LoadHostVDSO();

--- a/docs/DeferredSignals.md
+++ b/docs/DeferredSignals.md
@@ -1,0 +1,264 @@
+# Deferred signals and why FEX needs them
+
+FEX-Emu has locations in its code which are effectively "uninterruptible". In the sense that if the guest application receives a signal during an
+"uninterruptible" code section, then FEX is likely to hang or crash in spurious and terrible ways.
+
+## Example
+FEX-Emu is in the middle of emitting code. This is a vulnerable state in which FEX can be in the middle of allocating memory or reading guest state.
+If a signal is received in the middle of this, FEX-Emu might need to compile new code in a re-entrant state. Which could involve allocating memory and
+other vulnerable things. In this case a mutex could very easily be held, interrupted, and then try to get held again while being reentrant.
+
+**This will result in a hang.**
+
+## How do we solve this?
+
+### Classical signal masking
+One solution to this problem is to mask **all** signals going in to an uninterruptible section and then unmask when leaving. This is the classical
+approach that is viable if performance isn't a significant concern. A major problem with this approach is that we must do two system calls per
+"uninterruptible" code section, which if the section is fairly small then it might cost more to ensure state integrity than doing the work at all.
+
+### Cooperative signal deferring
+A new solution is to defer asynchronous signals if they are caught inside an uninterruptible section. At the basic level, we increment a reference
+counter going in to the "uninterruptible" section, and then decrement the reference counter once we leave. This way when the signal handler receives a
+signal, it can check that thread's reference counter, store the `siginfo_t` to an array/stack object, and return to the same code segment to be handled
+later.
+
+The trick to how this works is the cost it takes to check if a signal occured, and then handling the signal safely. Ideally no signal has happened in
+the "uninterruptible" code section, so the check needs to be as cheap as possible to ensure no cost in the case that no signal has occured.
+
+The trick is that FEX maintains two memory regions for tracking deferred signals **per thread**.
+
+#### 1st memory region
+
+This region is FEX's InternalThreadState object, which is always resident for each guest thread and usually inside a register inside the JIT.
+Inside this object is where the reference counter for "uninterruptible" code segments lives. It is specifically a reference counter since these
+code segments may nest inside each other and we can only interrupt with a signal if the counter is zero.
+
+This reference counter is thread local and won't be read by any other threads, so it can be a non-atomic increment and decrement.
+Meaning it is usually three instructions (on ARM64) to increment and decrement.
+
+```cpp
+MoveableNonatomicRefCounter<uint64_t> DeferredReferenceCounter;
+MoveableNonatomicRefCounter<uint64_t> *DeferredSignalHandlerPagePtr;
+```
+
+#### 2nd memory region
+
+This memory region is a single page of memory that is allocated per thread. A pointer to this region exists inside the InternalThreadState object just
+after the reference counter. This allows the JIT code to quickly load the pointer to this region after modifying the reference counter.
+
+This is the tricky memory page where we determine if we have any deferred signals to process. I say it's tricky because after FEX leaves an
+"uninterruptible" code section, it will decrement the reference counter, and then try to store in to the first byte of this page. In the case that no
+signal has been deferred, this memory store will progress without issue, consuming only two instructions in the process.
+
+In the case that a signal **HAS** been deferred, then the permissions on this page will be set to `PROT_NONE` and this memory store will cause a
+SIGSEGV. Then FEX's signal handler will check to see if the access was this special page and start the deferred signal mechanisms. This means that a
+deferred signal check is only five instructions in total.
+
+#### Example ARM64 JIT code for uninterruptible region
+```asm
+  ; Increment the reference counter.
+  ldr x0, [x28, #(offsetof(CPUState, DeferredReferenceCounter))]
+  add x0, x0, #1
+  str x0, [x28, #(offsetof(CPUState, DeferredReferenceCounter))]
+
+  ; Do the uninterruptible code section here.
+  <...>
+
+  ; Now decrement the reference counter.
+  ldr x0, [x28, #(offsetof(CPUState, DeferredReferenceCounter))]
+  sub x0, x0, #1
+  str x0, [x28, #(offsetof(CPUState, DeferredReferenceCounter))]
+
+  ; Now the magic memory access to check for any deferred signals.
+  ; Load the page pointer from the CPUState
+  ldr x0, [x28, #(offsetof(CPUState, DeferredSignalHandlerPagePtr))]
+  ; Just store zero. (1 cycle plus no dependencies on a register. Super fast!)
+  ; Will store fine with no deferred signal, or SIGSEGV if there was one!
+  str xzr, [x0]
+```
+
+### Deferred signal handling
+In the case that FEX has received a signal, FEX's signal handler will first check to see if that thread's reference counter is zero or not.
+
+#### Reference counter is zero
+This is the easy case, just handle the signal as normal.
+
+#### Reference counter is not zero
+The signal handler now knows that FEX is in an uninterruptible code section. We check the signal to see if it is a synchronous signal or not.
+- If the signal is synchronous then we need to handle it as normal, because this is a hardware signal that we can't defer.
+- If it is an async signal (from tgkill, sigqueue, or something else) then we will start the deferring process.
+
+The deferring process starts with storing the kernel `siginfo_t` to a thread local array so we can restore it later.
+We then modify the permissions on the thread local `DeferredSignalHandlerPagePtr` to be `PROT_NONE`.
+We then immediately return from the signal handler so that FEX can resume its "uninterruptible" code section without breaking anything.
+Once the "uninterruptible" code section finishes, FEX will intentionally trigger a SIGSEGV by storing to the page.
+
+This will trigger a jump to FEX's SIGSEGV handler, where FEX will process the signal as if it was the previously deferred signal.
+the previous signal that was deferred.
+- Replacing the SIGSEGV signal number with the previous captured signal number
+- Replacing the `siginfo_t` with the previous captured `siginfo_t`
+- mprotect the thread local `DeferredSignalHandlerPagePtr` to be RW.
+   - This is so that future signals get deferred, but we don't block forward code progress.
+- TODO: Overwrite mcontext_t things? I don't think this matters but there will be some private state that might leak SIGSEGV information?
+
+Once we are now handling the guest signal, FEX-Emu is in a vulnerable state where any signals received will be deferred /and/ not handled at the end
+of "uninterruptible" code sections. This is because FEX is now currently in a guest signal frame and we need to handle code compiling and other
+potentially awkward interactions without checking for additional signals.
+
+Once a guest signal handler has finished what it was working on, it will call `rt_sigreturn` or `sigreturn` which triggers FEX's SIGILL signal
+handler.
+   - This SIGILL behaviour is how FEX-Emu emulates sigreturn. In order to safely long-jump on AArch64, it must come from a signal context.
+   - The sigreturn syscall handlers intentionally trigger a SIGILL to do this.
+
+Inside of this SIGILL signal handler FEX will restore the state of FEX /back/ to where the deferred signal handler started (The str xzr, [x0]).
+Inside of this signal handler FEX will check to see if all deferred signals are handled.
+- Checks the reference counter to see if it is zero or not.
+   - If further asynchronous signals have been triggered that need handling, mprotect the fault page to `PROT_NONE`
+      - This trampolining is repeated once per asynchronous signal queued during processing.
+      - This will cause further signal handling immediately once the JIT returns to its original location (Where it'll cause a SIGSEGV again).
+
+Once FEX gets back to the page store, it will trampoline back to the SIGSEGV handler if it has more signals to handle.
+   - This is an edge case where we aren't expecting multiple signals in almost all cases
+   - Slightly more expensive is fine in this case.
+
+## Disadvantages of cooperative signal deferring
+Still thinking about this, come back to me. I'm concerned about signal queueing.
+- How do we handle the guest doing a long-jump out of a signal frame and still receiving signals?
+   - This will block FEX from handling /any/ more deferred signals.
+   -  Do we need to store guest stack as well to see if it has reset its own stack frame?
+   - moon-buggy does this as an example
+   - We currently just leak stack for every guest signal handler that long jumps out of the signal frame.
+      - Long term this would exhaust our stack and then crash.
+      - Test with a second guest thread where our host will only have an 8MB stack instead of the 128MB primary stack.
+      - See issue #2487
+## Expectations and considerations
+### What happens with a race condition with the refcounter?
+There are two edges to this problem. The incrementing edge and the decrementing edge that must be considered.
+
+#### Incrementing edge
+This is the most problematic edge. This takes three instructions (one on x86) to increment the ref counter. If a signal is received between the load
+and store then this theoretically could result in a tear on the refcounter. In actual practice this is a real tear but doesn't cause any problems.
+
+The reasoning for this is that FEX isn't in the "uninterruptible" section until that reference counter has been stored, so FEX will handle the signals
+immediately at that point, return to this code location, and then increment the counter. In particular, once returning to the code location the
+refcounter will be the original value loaded. So even though it is a tear, it's one that doesn't cause issues since it is all thread local.
+
+#### Decrementing edge
+This edge is far less problematic to understand compared to the incrementing edge. Signals will get deferred entirely until the store instruction (If
+storing zero), so FEX will always return to the code region and finish the decrement.
+
+If FEX receives a signal after the decrement store has completed but /before/ the page faulting store has occured, then FEX will start processing the
+signal immediately. At which point the fault page will have either RW or NONE permission. FEX will then likely hit another "uninterruptible" code
+section which will complete the store to the fault page.
+ - RW permission if it hadn't received another signal in the uninterruptible section
+ - NONE permission if it did receive a signal previously
+
+RW permission has no problems, it will continue as normal.
+
+NONE will get captured by the fault handler, the fault handler will determine that there was no deferred signals, and set the fault page back to RW
+permissions and continue execution safely.
+
+## Execution examples
+### No signal
+This is a simple example because nothing happens.
+``` diff
+- <Enter Deferred region - 3 instructions>
+! Compiling JIT Code
++ <Exit deferred region - 5 instructions>
+```
+
+### Signal outside of region
+This is simple because the JIT just handles it.
+``` diff
+! In JIT code
+# Signal received
+# Guest Signal handler called
+# JIT jumps to guest signal handler
+# Hopefully guest calls rt_sigreturn instead of long jumping out.
+```
+
+### Synchronous signal in JIT
+Deferred signals don't affect anything here because only asynchronous signals get affected.
+* State reconstruction problems aren't discussed here.
+``` diff
+! In JIT code
+! JIT code causes a synchronous signal (SIGSEGV or other)
+# Guest Signal Handler called
+# JIT jumps to guest signal handler
+# Hopefully guest calls rt_sigreturn instead of long jumping out.
+```
+
+### Asynchronous signal in code emitter
+This is the first interesting example since deferred signals affects it.
+``` diff
+- <Enter Deferred region - 3 instructions>
+! Compiling JIT Code
+# Asynchronous Signal received
+# - Host signal handler determines the thread is in a deferred signal section.
+# - Signal information is stored in a queue
+# - mprotect signal page to NONE.
+# - Signal handler returns without giving the signal to the guest
+! Compiling JIT Code continues.
++ #1 - <Exit deferred region - 5 instructions>
++ Deferred region section causes SIGSEGV
++ - Host signal handler determines deferred region is done, Still has signal in queue.
++ - Pull signal information off of queue
+# JIT jumps to guest signal handler
+# Hopefully guest calls rt_sigreturn instead of long jumping out.
+# Host PC is back at deferred signal section.
++ Deferred region section causes SIGSEGV #2
++ - Host signal handler determines deferred region is done, No signals in the queue.
+# - mprotect signal page to RW.
+# - Continue execution.
++ #1 <Exit deferred region continues>
+```
+
+### Recursive regions with signal in code emitter.
+This one mostly matches the previous example except the behaviour of deferred signal regions leaving.
+
+In this case, if the thread-local refcount is still >0 on `<Exit deferred region>` then there are two behaviours.
+- On ARM64, it will receive a SIGSEGV but the signal handler will increment PC by one instruction and continue execution
+   - Expectation is that signals are significantly less common than `<Exit deferred region>` so the cost of SIGSEGV+PC increment is faster.
+- On x86-64, the region exit checks the refcount before doing the fault access.
+   - This adds more instructions so is slower on average.
+
+This has the expectation that recursive deferred regions both aren't very deep (usually only nested a couple times), and that signals are rare.
+This way there aren't many SIGSEGV checks generated and the signal is finally only handled when reaching the top-most deferred region exit routine.
+
+``` diff
+- #1 <Enter Deferred region - 3 instructions>
+! Compiling JIT Code
+-    #2 <Enter Deferred region - 3 instructions>
+!    Memory allocation
+#    <Async signal received logic from above>
++    #2 <Exit deferred region - 5 instructions>
++    #2 Exit deferred region causes SIGSEGV
++    - TLS refcount is still 1 (from #1)
++    - PC is incremented by one instruction, signal still unhandled.
++ #1 <Exit deferred region - 5 instructions>
++ #1 Exit deferred region causes SIGSEGV
++ <Regular deferred region handling from above called>
+```
+
+### Multiple signals in deferred region
+This is slightly different from the previous iterations since multiple signals in the stack result in odd behaviour.
+
+``` diff
+- #1 <Enter Deferred region - 3 instructions>
+! Compiling JIT Code
+# #1 Asynchronous Signal received
+#   - Signal queued logic
+# #2 Asynchronous Signal received
+#   - Signal queued logic
++ #1 <Exit deferred region - 5 instructions>
++ Exit deferred region causes SIGSEGV
++ <Regular deferred region handling from above called>
++ Guest calls rt_sigreturn
++ - rt_sigreturn handler checks for number of queued signals
+# - mprotect signal page to NONE because signals is > 0
+# - JIT is back to #1 <Exit deferred region>
+# - Exit deferred region causes SIGSEGV again.
+# - Regular handler loop occurs
+```
+


### PR DESCRIPTION
~~First three commits are cherry-picks from: #2490, #2491, #2492~~

This is partial support, we still use sigprocmask based signal deferring in some cases. This replaces the most egregious abuse of it though.

This is a fairly scary change but I've done a bunch of testing to try and make sure nothing has broken. The whole point of this change is to reduce the use sigprocmask system calls by deferring the signal if the signal is received inside of an "uninterruptible" code section. Read the markdown file for more information as to how that exactly occurs.

Very specifically this changes two things:
1) Entry in to "uninterruptible" code section

Before:
```cpp
LoadConstant(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r0, ~0ULL);
stp<ARMEmitter::IndexType::PRE>(ARMEmitter::XReg::x0, ARMEmitter::XReg::x0, ARMEmitter::Reg::rsp, -16);
LoadConstant(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r0, SIG_SETMASK);
add(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r1, ARMEmitter::Reg::rsp, 0);
add(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r2, ARMEmitter::Reg::rsp, 0);
LoadConstant(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r3, 8);
LoadConstant(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r8, SYS_rt_sigprocmask);
svc(0);
```

After:
```cpp
ldr(ARMEmitter::XReg::x0, STATE, offsetof(FEXCore::Core::CPUState, DeferredSignalRefCount));
add(ARMEmitter::Size::i64Bit, ARMEmitter::XReg::x0, ARMEmitter::XReg::x0, 1);
str(ARMEmitter::XReg::x0, STATE, offsetof(FEXCore::Core::CPUState, DeferredSignalRefCount));
```

As you can see, going in to a "uninterruptible" section goes from 8 instructions (One of which is a system call!) down to three. With a special guarantee to ensure that the three instructions are not atomic.

2) Exit from an "uninterruptible" code section

Before:
```cpp
mov(ARMEmitter::XReg::x4, ARMEmitter::XReg::x0);
LoadConstant(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r0, SIG_SETMASK);
add(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r1, ARMEmitter::Reg::rsp, 0);
LoadConstant(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r2, 0);
LoadConstant(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r3, 8);
LoadConstant(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r8, SYS_rt_sigprocmask);
svc(0);

// Bring stack back
add(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::rsp, ARMEmitter::Reg::rsp, 16);
mov(ARMEmitter::XReg::x0, ARMEmitter::XReg::x4);
```

After:
```cpp
ldr(ARMEmitter::XReg::x1, STATE, offsetof(FEXCore::Core::CPUState, DeferredSignalRefCount));
subs(ARMEmitter::Size::i64Bit, ARMEmitter::XReg::x1, ARMEmitter::XReg::x1, 1);
str(ARMEmitter::XReg::x1, STATE, offsetof(FEXCore::Core::CPUState, DeferredSignalRefCount));

ldr(ARMEmitter::XReg::x1, STATE, offsetof(FEXCore::Core::CPUState, DeferredSignalFaultAddress));
str(ARMEmitter::XReg::zr, ARMEmitter::XReg::x1, 0);
```

As you can see, coming out of an uninterruptible section goes from 9 instructions (Another system call!) down to five. With a guarantee that it's a non-atomic decrement and a non-atomic load+store pairing.

Not only does this make JIT emitting significantly faster, it cleans up our strace log so it has quite a bit less spam of sigprocmask.

After this gets merged I'll go through the remaining signal mask mutex sections and switch them over to deferred signals.