### PR TITLE
Arm64: Reclaim SRA registers on 32-bit

### DIFF
--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
@@ -31,32 +31,47 @@ namespace FEXCore::CPU {
 // All but x29 are caller saved
 constexpr std::array<FEXCore::ARMEmitter::Register, 16> SRA64 = {
   FEXCore::ARMEmitter::Reg::r4, FEXCore::ARMEmitter::Reg::r5, FEXCore::ARMEmitter::Reg::r6, FEXCore::ARMEmitter::Reg::r7, FEXCore::ARMEmitter::Reg::r8, FEXCore::ARMEmitter::Reg::r9, FEXCore::ARMEmitter::Reg::r10, FEXCore::ARMEmitter::Reg::r11,
-  FEXCore::ARMEmitter::Reg::r12, FEXCore::ARMEmitter::Reg::r18, FEXCore::ARMEmitter::Reg::r17, FEXCore::ARMEmitter::Reg::r16, FEXCore::ARMEmitter::Reg::r15, FEXCore::ARMEmitter::Reg::r14, FEXCore::ARMEmitter::Reg::r13, FEXCore::ARMEmitter::Reg::r29
+  // Registers that don't exist on 32-bit
+  FEXCore::ARMEmitter::Reg::r12, FEXCore::ARMEmitter::Reg::r13, FEXCore::ARMEmitter::Reg::r14, FEXCore::ARMEmitter::Reg::r15, FEXCore::ARMEmitter::Reg::r16, FEXCore::ARMEmitter::Reg::r17, FEXCore::ARMEmitter::Reg::r18, FEXCore::ARMEmitter::Reg::r29
 };
 
-// All are callee saved
-constexpr std::array<FEXCore::ARMEmitter::Register, 9> RA64 = {
+// All are callee saved (except additional registers from 32-bit)
+constexpr std::array<FEXCore::ARMEmitter::Register, 9 + 8> RA64 = {
   FEXCore::ARMEmitter::Reg::r20, FEXCore::ARMEmitter::Reg::r21, FEXCore::ARMEmitter::Reg::r22, FEXCore::ARMEmitter::Reg::r23, FEXCore::ARMEmitter::Reg::r24, FEXCore::ARMEmitter::Reg::r25, FEXCore::ARMEmitter::Reg::r26, FEXCore::ARMEmitter::Reg::r27,
-  FEXCore::ARMEmitter::Reg::r19
+  FEXCore::ARMEmitter::Reg::r19,
+
+  // Registers only available on 32-bit
+  // All these are caller saved.
+  FEXCore::ARMEmitter::Reg::r12, FEXCore::ARMEmitter::Reg::r13, FEXCore::ARMEmitter::Reg::r14, FEXCore::ARMEmitter::Reg::r15, FEXCore::ARMEmitter::Reg::r16, FEXCore::ARMEmitter::Reg::r17, FEXCore::ARMEmitter::Reg::r18, FEXCore::ARMEmitter::Reg::r29
 };
 
-constexpr std::array<std::pair<FEXCore::ARMEmitter::Register, FEXCore::ARMEmitter::Register>, 4>  RA64Pair = {{
+constexpr std::array<std::pair<FEXCore::ARMEmitter::Register, FEXCore::ARMEmitter::Register>, 4 + 3> RA64Pair = {{
   {FEXCore::ARMEmitter::Reg::r20, FEXCore::ARMEmitter::Reg::r21},
   {FEXCore::ARMEmitter::Reg::r22, FEXCore::ARMEmitter::Reg::r23},
   {FEXCore::ARMEmitter::Reg::r24, FEXCore::ARMEmitter::Reg::r25},
   {FEXCore::ARMEmitter::Reg::r26, FEXCore::ARMEmitter::Reg::r27},
+
+  // Registers only available on 32-bit
+  {FEXCore::ARMEmitter::Reg::r12, FEXCore::ARMEmitter::Reg::r13},
+  {FEXCore::ARMEmitter::Reg::r14, FEXCore::ARMEmitter::Reg::r15},
+  {FEXCore::ARMEmitter::Reg::r16, FEXCore::ARMEmitter::Reg::r17}
 }};
 
 // All are caller saved
 constexpr std::array<FEXCore::ARMEmitter::VRegister, 16> SRAFPR = {
   FEXCore::ARMEmitter::VReg::v16, FEXCore::ARMEmitter::VReg::v17, FEXCore::ARMEmitter::VReg::v18, FEXCore::ARMEmitter::VReg::v19, FEXCore::ARMEmitter::VReg::v20, FEXCore::ARMEmitter::VReg::v21, FEXCore::ARMEmitter::VReg::v22, FEXCore::ARMEmitter::VReg::v23,
+
+  // Registers that don't exist on 32-bit
   FEXCore::ARMEmitter::VReg::v24, FEXCore::ARMEmitter::VReg::v25, FEXCore::ARMEmitter::VReg::v26, FEXCore::ARMEmitter::VReg::v27, FEXCore::ARMEmitter::VReg::v28, FEXCore::ARMEmitter::VReg::v29, FEXCore::ARMEmitter::VReg::v30, FEXCore::ARMEmitter::VReg::v31
 };
 
 //  v8..v15 = (lower 64bits) Callee saved
-constexpr std::array<FEXCore::ARMEmitter::VRegister, 12> RAFPR = {
+constexpr std::array<FEXCore::ARMEmitter::VRegister, 12 + 8> RAFPR = {
 /*FEXCore::ARMEmitter::VReg::v0,  FEXCore::ARMEmitter::VReg::v1,  FEXCore::ARMEmitter::VReg::v2,  FEXCore::ARMEmitter::VReg::v3,*/FEXCore::ARMEmitter::VReg::v4,  FEXCore::ARMEmitter::VReg::v5,  FEXCore::ARMEmitter::VReg::v6,  FEXCore::ARMEmitter::VReg::v7,  // FEXCore::ARMEmitter::VReg::v0 ~ FEXCore::ARMEmitter::VReg::v3 are used as temps
-  FEXCore::ARMEmitter::VReg::v8,  FEXCore::ARMEmitter::VReg::v9,  FEXCore::ARMEmitter::VReg::v10, FEXCore::ARMEmitter::VReg::v11, FEXCore::ARMEmitter::VReg::v12, FEXCore::ARMEmitter::VReg::v13, FEXCore::ARMEmitter::VReg::v14, FEXCore::ARMEmitter::VReg::v15
+  FEXCore::ARMEmitter::VReg::v8,  FEXCore::ARMEmitter::VReg::v9,  FEXCore::ARMEmitter::VReg::v10, FEXCore::ARMEmitter::VReg::v11, FEXCore::ARMEmitter::VReg::v12, FEXCore::ARMEmitter::VReg::v13, FEXCore::ARMEmitter::VReg::v14, FEXCore::ARMEmitter::VReg::v15,
+
+  // Registers only available on 32-bit
+  FEXCore::ARMEmitter::VReg::v24, FEXCore::ARMEmitter::VReg::v25, FEXCore::ARMEmitter::VReg::v26, FEXCore::ARMEmitter::VReg::v27, FEXCore::ARMEmitter::VReg::v28, FEXCore::ARMEmitter::VReg::v29, FEXCore::ARMEmitter::VReg::v30, FEXCore::ARMEmitter::VReg::v31
 };
 
 // Contains the address to the currently available CPU state
@@ -90,6 +105,45 @@ protected:
 
   FEXCore::Context::ContextImpl *EmitterCTX;
   vixl::aarch64::CPU CPU;
+
+  uint32_t ConfiguredGPRs;
+  uint32_t ConfiguredSRAGPRs;
+  uint32_t ConfiguredGPRPairs;
+  uint32_t ConfiguredFPRs;
+  uint32_t ConfiguredSRAFPRs;
+  uint32_t ConfiguredDynamicGPRs;
+  const FEXCore::ARMEmitter::Register *ConfiguredDynamicRegisterBase{};
+
+  /**
+   * @name Register Allocation
+   * @{ */
+  // 64-bit gets removal of additional pairs
+  constexpr static uint32_t NumGPRs64       = RA64.size() - 8;
+  constexpr static uint32_t NumSRAGPRs64    = SRA64.size();
+  constexpr static uint32_t NumFPRs64       = RAFPR.size() - 8;
+  constexpr static uint32_t NumSRAFPRs64    = SRAFPR.size();
+  constexpr static uint32_t NumGPRPairs64   = RA64Pair.size() - 3;
+
+  // 32-bit gets full array of GPR registers
+  // SRA registers remove the additional 8
+  constexpr static uint32_t NumGPRs32       = RA64.size();
+  constexpr static uint32_t NumSRAGPRs32    = SRA64.size() - 8;
+  constexpr static uint32_t NumFPRs32       = RAFPR.size();
+  constexpr static uint32_t NumSRAFPRs32    = SRAFPR.size() - 8;
+  constexpr static uint32_t NumGPRPairs32   = RA64Pair.size();
+
+  constexpr static uint32_t RegisterClasses = 6;
+
+  constexpr static uint64_t GPRBase = (0ULL << 32);
+  constexpr static uint64_t FPRBase = (1ULL << 32);
+  constexpr static uint64_t GPRPairBase = (2ULL << 32);
+
+  /**  @} */
+
+  constexpr static uint8_t RA_32 = 0;
+  constexpr static uint8_t RA_64 = 1;
+  constexpr static uint8_t RA_FPR = 2;
+
   void LoadConstant(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register Reg, uint64_t Constant, bool NOPPad = false);
 
 
@@ -99,7 +153,8 @@ protected:
   void SpillStaticRegs(bool FPRs = true, uint32_t GPRSpillMask = ~0U, uint32_t FPRSpillMask = ~0U);
   void FillStaticRegs(bool FPRs = true, uint32_t GPRFillMask = ~0U, uint32_t FPRFillMask = ~0U);
 
-  static constexpr uint32_t CALLER_GPR_MASK = 0b0011'1111'1111'1111'1111;
+  // Register 0-18 + 29 + 30 are caller saved
+  static constexpr uint32_t CALLER_GPR_MASK = 0b0110'0000'0000'0111'1111'1111'1111'1111U;
 
   // This isn't technically true because the lower 64-bits of v8..v15 are callee saved
   // We can't guarantee only the lower 64bits are used so flush everything

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -517,20 +517,16 @@ Arm64JITCore::Arm64JITCore(FEXCore::Context::ContextImpl *ctx, FEXCore::Core::In
 
   RAPass = Thread->PassManager->GetPass<IR::RegisterAllocationPass>("RA");
 
-  uint32_t NumUsedGPRs = NumGPRs;
-  uint32_t NumUsedGPRPairs = NumGPRPairs;
-  uint32_t UsedRegisterCount = RegisterCount;
+  RAPass->AllocateRegisterSet(RegisterClasses);
 
-  RAPass->AllocateRegisterSet(UsedRegisterCount, RegisterClasses);
-
-  RAPass->AddRegisters(FEXCore::IR::GPRClass, NumUsedGPRs);
-  RAPass->AddRegisters(FEXCore::IR::GPRFixedClass, SRA64.size());
-  RAPass->AddRegisters(FEXCore::IR::FPRClass, NumFPRs);
-  RAPass->AddRegisters(FEXCore::IR::FPRFixedClass, SRAFPR.size()  );
-  RAPass->AddRegisters(FEXCore::IR::GPRPairClass, NumUsedGPRPairs);
+  RAPass->AddRegisters(FEXCore::IR::GPRClass, ConfiguredGPRs);
+  RAPass->AddRegisters(FEXCore::IR::GPRFixedClass, ConfiguredSRAGPRs);
+  RAPass->AddRegisters(FEXCore::IR::FPRClass, ConfiguredFPRs);
+  RAPass->AddRegisters(FEXCore::IR::FPRFixedClass, ConfiguredSRAFPRs);
+  RAPass->AddRegisters(FEXCore::IR::GPRPairClass, ConfiguredGPRPairs);
   RAPass->AddRegisters(FEXCore::IR::ComplexClass, 1);
 
-  for (uint32_t i = 0; i < NumUsedGPRPairs; ++i) {
+  for (uint32_t i = 0; i < ConfiguredGPRPairs; ++i) {
     RAPass->AddRegisterConflict(FEXCore::IR::GPRClass, i * 2,     FEXCore::IR::GPRPairClass, i);
     RAPass->AddRegisterConflict(FEXCore::IR::GPRClass, i * 2 + 1, FEXCore::IR::GPRPairClass, i);
   }

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -64,27 +64,6 @@ private:
 
   std::map<IR::NodeID, ARMEmitter::BiDirectionalLabel> JumpTargets;
 
-  /**
-   * @name Register Allocation
-   * @{ */
-  constexpr static uint32_t NumGPRs = RA64.size();
-  constexpr static uint32_t NumFPRs = RAFPR.size();
-  constexpr static uint32_t NumGPRPairs = RA64Pair.size();
-  constexpr static uint32_t NumCalleeGPRs = 10;
-  constexpr static uint32_t NumCalleeGPRPairs = 5;
-  constexpr static uint32_t RegisterCount = NumGPRs + NumFPRs + NumGPRPairs;
-  constexpr static uint32_t RegisterClasses = 6;
-
-  constexpr static uint64_t GPRBase = (0ULL << 32);
-  constexpr static uint64_t FPRBase = (1ULL << 32);
-  constexpr static uint64_t GPRPairBase = (2ULL << 32);
-
-  /**  @} */
-
-  constexpr static uint8_t RA_32 = 0;
-  constexpr static uint8_t RA_64 = 1;
-  constexpr static uint8_t RA_FPR = 2;
-
   [[nodiscard]] FEXCore::ARMEmitter::Register GetReg(IR::NodeID Node) const {
     const auto Reg = GetPhys(Node);
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -349,7 +349,7 @@ X86JITCore::X86JITCore(FEXCore::Context::ContextImpl *ctx, FEXCore::Core::Intern
 
   RAPass = Thread->PassManager->GetPass<IR::RegisterAllocationPass>("RA");
 
-  RAPass->AllocateRegisterSet(RegisterCount, RegisterClasses);
+  RAPass->AllocateRegisterSet(RegisterClasses);
   RAPass->AddRegisters(FEXCore::IR::GPRClass, NumGPRs);
   RAPass->AddRegisters(FEXCore::IR::FPRClass, NumXMMs);
   RAPass->AddRegisters(FEXCore::IR::GPRPairClass, NumGPRPairs);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -151,7 +151,6 @@ private:
   constexpr static uint32_t NumGPRs = RA64.size(); // 4 is the minimum required for GPR ops
   constexpr static uint32_t NumXMMs = RAXMM.size();
   constexpr static uint32_t NumGPRPairs = RA64Pair.size();
-  constexpr static uint32_t RegisterCount = NumGPRs + NumXMMs + NumGPRPairs;
   constexpr static uint32_t RegisterClasses = 6;
 
   constexpr static uint64_t GPRBase = (0ULL << 32);

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -83,6 +83,7 @@
     "constexpr FEXCore::IR::RegisterClassType ComplexClass {5}",
     "constexpr FEXCore::IR::RegisterClassType InvalidClass {7}",
     "",
+    "// Only up to 30 registers per register class",
     "constexpr uint8_t InvalidReg {31}",
     "",
     "constexpr FEXCore::IR::TypeDefinition i8    {TypeDefinition::Create(1, 0)}",

--- a/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -273,7 +273,7 @@ namespace {
       ~ConstrainedRAPass();
       bool Run(IREmitter *IREmit) override;
 
-      void AllocateRegisterSet(uint32_t RegisterCount, uint32_t ClassCount) override;
+      void AllocateRegisterSet(uint32_t ClassCount) override;
       void AddRegisters(FEXCore::IR::RegisterClassType Class, uint32_t RegisterCount) override;
       void AddRegisterConflict(FEXCore::IR::RegisterClassType ClassConflict, uint32_t RegConflict, FEXCore::IR::RegisterClassType Class, uint32_t Reg) override;
 
@@ -351,8 +351,7 @@ namespace {
     FreeRegisterGraph(Graph);
   }
 
-  void ConstrainedRAPass::AllocateRegisterSet(uint32_t RegisterCount, uint32_t ClassCount) {
-    LOGMAN_THROW_AA_FMT(RegisterCount <= INVALID_REG, "Up to {} regs supported", INVALID_REG);
+  void ConstrainedRAPass::AllocateRegisterSet(uint32_t ClassCount) {
     LOGMAN_THROW_AA_FMT(ClassCount <= INVALID_CLASS, "Up to {} classes supported", INVALID_CLASS);
 
     Graph = AllocateRegisterGraph(ClassCount);

--- a/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.h
+++ b/External/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.h
@@ -19,7 +19,7 @@ class RegisterAllocationPass : public FEXCore::IR::Pass {
   public:
     bool HasFullRA() const { return HadFullRA; }
 
-    virtual void AllocateRegisterSet(uint32_t RegisterCount, uint32_t ClassCount) = 0;
+    virtual void AllocateRegisterSet(uint32_t ClassCount) = 0;
     virtual void AddRegisters(FEXCore::IR::RegisterClassType Class, uint32_t RegisterCount) = 0;
 
     /**

--- a/External/FEXCore/include/FEXCore/IR/RegisterAllocationData.h
+++ b/External/FEXCore/include/FEXCore/IR/RegisterAllocationData.h
@@ -8,7 +8,9 @@ namespace FEXCore::IR {
 union PhysicalRegister {
   uint8_t Raw;
   struct {
+    // 32 maximum physical registers
     uint8_t Reg: 5;
+    // 8 Maximum classes
     uint8_t Class: 3;
   };
 

--- a/Source/Tests/IRLoader.cpp
+++ b/Source/Tests/IRLoader.cpp
@@ -174,6 +174,10 @@ int main(int argc, char **argv, char **const envp)
   FEXCore::Config::AddLayer(std::make_unique<FEX::ArgLoader::ArgLoader>(argc, argv));
   FEXCore::Config::AddLayer(FEXCore::Config::CreateEnvironmentLayer(envp));
   FEXCore::Config::Load();
+  // Ensure the IRLoader runs in 64-bit mode.
+  // This is to ensure that static register allocation in the JIT
+  // is configured correctly for accesses to the top 8 GPRs and 8 XMM registers.
+  FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_IS64BIT_MODE, "1");
 
   auto Args = FEX::ArgLoader::Get();
   auto ParsedArgs = FEX::ArgLoader::GetParsedArgs();


### PR DESCRIPTION
Causes Portal to go from 85FPS to 120FPS on Lenovo X13s.

When running in 32-bit mode we were wasting 8 GPRs and 8 FPRs by still allocating the top 8 registers of each even though 32-bit can't use them.

Reallocate them to be register allocated registers when running 32-bit applications which reduces spills and lowers the cost of spilling/filling SRA registers.

Quite a significant speed boost for a little bit of work.