### PR TITLE
CMake: Get past configuration when mingw is used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,13 @@ set (X86_32_TOOLCHAIN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/toolchain_x86_32.cmake" 
 set (X86_64_TOOLCHAIN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/toolchain_x86_64.cmake" CACHE FILEPATH "Toolchain file for the (cross-)compiler targeting x86_64")
 set (DATA_DIRECTORY "${CMAKE_INSTALL_PREFIX}/share/fex-emu" CACHE PATH "global data directory")
 
+string(FIND ${CMAKE_BASE_NAME} mingw CONTAINS_MINGW)
+if (NOT CONTAINS_MINGW EQUAL -1)
+  message (STATUS "Mingw build")
+  set (MINGW_BUILD TRUE)
+  set (ENABLE_JEMALLOC FALSE)
+endif()
+
 if (ENABLE_FEXCORE_PROFILER)
   add_definitions(-DENABLE_FEXCORE_PROFILER=1)
   string(TOUPPER "${FEXCORE_PROFILER_BACKEND}" FEXCORE_PROFILER_BACKEND)

--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -393,10 +393,12 @@ AddObject(${PROJECT_NAME}_object OBJECT)
 AddLibrary(${PROJECT_NAME} STATIC)
 AddLibrary(${PROJECT_NAME}_shared SHARED)
 
-install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_shared
-  LIBRARY
-    DESTINATION lib
-    COMPONENT Libraries
-  ARCHIVE
-    DESTINATION lib
-    COMPONENT Libraries)
+if (NOT MINGW_BUILD)
+  install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_shared
+    LIBRARY
+      DESTINATION lib
+      COMPONENT Libraries
+    ARCHIVE
+      DESTINATION lib
+      COMPONENT Libraries)
+endif()

--- a/Source/Tests/CMakeLists.txt
+++ b/Source/Tests/CMakeLists.txt
@@ -39,11 +39,13 @@ function(GenerateInterpreter NAME AsInterpreter)
     )
   endif()
 
-  install(TARGETS ${NAME}
-    RUNTIME
-      DESTINATION bin
-      COMPONENT runtime
-  )
+  if (NOT MINGW_BUILD)
+    install(TARGETS ${NAME}
+      RUNTIME
+        DESTINATION bin
+        COMPONENT runtime
+    )
+  endif()
 endfunction()
 
 GenerateInterpreter(FEXLoader 0)

--- a/Source/Tools/CMakeLists.txt
+++ b/Source/Tools/CMakeLists.txt
@@ -2,21 +2,24 @@ if (ENABLE_VISUAL_DEBUGGER)
   add_subdirectory(Debugger/)
 endif()
 
-if (NOT TERMUX_BUILD)
-  # Termux builds can't rely on X11 packages
-  # SDL2 isn't even compiled with GL support so our GUIs wouldn't even work
-  add_subdirectory(FEXConfig/)
+if (NOT MINGW_BUILD)
+  if (NOT TERMUX_BUILD)
+    # Termux builds can't rely on X11 packages
+    # SDL2 isn't even compiled with GL support so our GUIs wouldn't even work
+    add_subdirectory(FEXConfig/)
 
-  # Disable FEXRootFSFetcher on Termux, it doesn't even work there
-  add_subdirectory(FEXRootFSFetcher/)
-endif()
+    # Disable FEXRootFSFetcher on Termux, it doesn't even work there
+    add_subdirectory(FEXRootFSFetcher/)
+  endif()
 
-if (ENABLE_GDB_SYMBOLS)
-  add_subdirectory(FEXGDBReader/)
+  if (ENABLE_GDB_SYMBOLS)
+    add_subdirectory(FEXGDBReader/)
+  endif()
+
+  add_subdirectory(FEXGetConfig/)
+  add_subdirectory(FEXServer/)
+  add_subdirectory(FEXBash/)
 endif()
-add_subdirectory(FEXGetConfig/)
-add_subdirectory(FEXServer/)
-add_subdirectory(FEXBash/)
 
 set(NAME Opt)
 set(SRCS Opt.cpp)


### PR DESCRIPTION
Right now cmake doesn't even get past the configuration stage when mingw is used.
If mingw is detected, setup cmake so it can at least configure itself. Will be necessary for cleaning up the rest of the codebase.