### PR TITLE
CPUInfo: Switch away from using get_nprocs_conf

### DIFF
--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -3,6 +3,7 @@ set (MAN_DIR ${CMAKE_INSTALL_PREFIX}/share/man CACHE PATH "MAN_DIR")
 set (FEXCORE_BASE_SRCS
   Common/Paths.cpp
   Interface/Config/Config.cpp
+  Utils/CPUInfo.cpp
   Utils/FileLoading.cpp
   Utils/ForcedAssert.cpp
   Utils/LogManager.cpp

--- a/External/FEXCore/Source/Interface/Config/Config.cpp
+++ b/External/FEXCore/Source/Interface/Config/Config.cpp
@@ -4,6 +4,7 @@
 #include "Utils/FileLoading.h"
 
 #include <FEXCore/Config/Config.h>
+#include <FEXCore/Utils/CPUInfo.h>
 #include <FEXCore/Utils/LogManager.h>
 
 #include <array>
@@ -20,7 +21,6 @@
 #include <stdint.h>
 #include <string>
 #include <string_view>
-#include <sys/sysinfo.h>
 #include <system_error>
 #include <type_traits>
 #include <unordered_map>
@@ -424,7 +424,7 @@ namespace JSON {
       FEX_CONFIG_OPT(Cores, THREADS);
       if (Cores == 0) {
         // When the number of emulated CPU cores is zero then auto detect
-        FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_THREADS, std::to_string(get_nprocs_conf()));
+        FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_THREADS, std::to_string(FEXCore::CPUInfo::CalculateNumberOfCPUs()));
       }
     }
 

--- a/External/FEXCore/Source/Interface/Core/CPUID.cpp
+++ b/External/FEXCore/Source/Interface/Core/CPUID.cpp
@@ -13,6 +13,7 @@ $end_info$
 #include <FEXCore/Config/Config.h>
 #include <FEXCore/Core/CPUID.h>
 #include <FEXCore/Core/HostFeatures.h>
+#include <FEXCore/Utils/CPUInfo.h>
 #include <FEXHeaderUtils/Syscalls.h>
 
 #include "git_version.h"
@@ -74,16 +75,6 @@ static uint32_t GetCPUID() {
   return CPU;
 }
 
-static uint32_t CalculateNumberOfCPUs() {
-  size_t CPUs = 1;
-
-  while(std::filesystem::exists("/sys/devices/system/cpu/cpu" + std::to_string(CPUs))) {
-    CPUs++;
-  }
-
-  return CPUs;
-}
-
 // TODO: Replace usages with CTX->HostFeatures.EnableAVX
 //       when AVX implementations are further along.
 constexpr uint32_t SUPPORTS_AVX = 0;
@@ -115,7 +106,7 @@ static uint32_t GetCycleCounterFrequency() {
 }
 
 void CPUIDEmu::SetupHostHybridFlag() {
-  size_t CPUs = CalculateNumberOfCPUs();
+  size_t CPUs = FEXCore::CPUInfo::CalculateNumberOfCPUs();
   PerCPUData.resize(CPUs);
 
   uint64_t MIDR{};
@@ -375,7 +366,7 @@ void CPUIDEmu::SetupHostHybridFlag() {
     Hybrid = (edx & (1U << 15)) != 0;
   }
 
-  size_t CPUs = CalculateNumberOfCPUs();
+  size_t CPUs = FEXCore::CPUInfo::CalculateNumberOfCPUs();
   PerCPUData.resize(CPUs);
   for (size_t i = 0; i < CPUs; ++i) {
     PerCPUData[i].IsBig = true;

--- a/External/FEXCore/Source/Utils/CPUInfo.cpp
+++ b/External/FEXCore/Source/Utils/CPUInfo.cpp
@@ -1,0 +1,24 @@
+#include <FEXHeaderUtils/Filesystem.h>
+
+#include <fmt/format.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <linux/limits.h>
+
+namespace FEXCore::CPUInfo {
+  uint32_t CalculateNumberOfCPUs() {
+    char Tmp[PATH_MAX];
+    size_t CPUs = 1;
+
+    for (;; ++CPUs) {
+      auto Size = fmt::format_to_n(Tmp, sizeof(Tmp), "/sys/devices/system/cpu/cpu{}", CPUs);
+      Tmp[Size.size] = 0;
+      if (!FHU::Filesystem::Exists(Tmp)) {
+        break;
+      }
+    }
+
+    return CPUs;
+  }
+}

--- a/External/FEXCore/include/FEXCore/Utils/CPUInfo.h
+++ b/External/FEXCore/include/FEXCore/Utils/CPUInfo.h
@@ -1,0 +1,13 @@
+#pragma once
+#include <FEXCore/Utils/CompilerDefs.h>
+
+#include <cstdint>
+
+namespace FEXCore::CPUInfo {
+  /**
+   * @brief Calculate the number of CPUs in the system regardless of affinity mask.
+   *
+   * @return The number of CPUs in the system.
+   */
+  FEX_DEFAULT_VISIBILITY uint32_t CalculateNumberOfCPUs();
+}

--- a/FEXHeaderUtils/FEXHeaderUtils/Filesystem.h
+++ b/FEXHeaderUtils/FEXHeaderUtils/Filesystem.h
@@ -1,0 +1,17 @@
+#pragma once
+#include <fcntl.h>
+#include <string>
+#include <unistd.h>
+
+namespace FHU::Filesystem {
+  /**
+   * @brief Check if a filepath exists.
+   *
+   * @param Path The path to check for.
+   *
+   * @return True if the file exists, False if it doesn't.
+   */
+  inline bool Exists(const char *Path) {
+    return access(Path, F_OK) == 0;
+  }
+}


### PR DESCRIPTION
Allocates memory behind our backs. Needed to make CI glibc allocator clean.