### PR TITLE
IntrusiveIRList: Ensure this is using the FEX allocator

### DIFF
--- a/External/FEXCore/include/FEXCore/IR/IntrusiveIRList.h
+++ b/External/FEXCore/include/FEXCore/IR/IntrusiveIRList.h
@@ -136,7 +136,7 @@ public:
     ListSize = Data->ListSize();
 
     if (_IsCopy) {
-      IRDataInternal = malloc(DataSize + ListSize);
+      IRDataInternal = FEXCore::Allocator::malloc(DataSize + ListSize);
       ListDataInternal = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(IRDataInternal) + DataSize);
       memcpy(IRDataInternal, reinterpret_cast<void*>(Data->DataBegin()), DataSize);
       memcpy(ListDataInternal, reinterpret_cast<void*>(Data->ListBegin()), ListSize);
@@ -153,7 +153,7 @@ public:
     DataSize = Old->DataSize;
     ListSize = Old->ListSize;
     if (_IsCopy) {
-      IRDataInternal = malloc(DataSize + ListSize);
+      IRDataInternal = FEXCore::Allocator::malloc(DataSize + ListSize);
       ListDataInternal = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(IRDataInternal) + DataSize);
       memcpy(IRDataInternal, Old->IRDataInternal, DataSize);
       memcpy(ListDataInternal, Old->ListDataInternal, ListSize);
@@ -165,7 +165,7 @@ public:
 
   ~IRListView() {
     if (IsCopy()) {
-      free (IRDataInternal);
+      FEXCore::Allocator::free (IRDataInternal);
       // ListData is just offset from IRData
     }
   }


### PR DESCRIPTION
Necessary to be glibc allocator clean.