### PR TITLE
FEXCore: Adds fexctl container alias objects

### DIFF
--- a/External/FEXCore/include/FEXCore/fextl/allocator.h
+++ b/External/FEXCore/include/FEXCore/fextl/allocator.h
@@ -1,0 +1,27 @@
+#pragma once
+#include <FEXCore/Utils/Allocator.h>
+
+namespace fextl {
+  /**
+   * @brief C++ allocator class interface in to FEXCore::Allocator for memory allocations.
+   */
+  template <typename T>
+  class FEXAlloc : public std::allocator<T> {
+    public:
+      using value_type = T;
+      using propagate_on_container_move_assignment = std::true_type;
+
+      FEXAlloc() noexcept {}
+      template <class U> FEXAlloc(FEXAlloc<U> const&) noexcept {}
+
+      inline value_type *allocate(std::size_t n) {
+        return reinterpret_cast<value_type*>(::FEXCore::Allocator::aligned_alloc(std::alignment_of_v<value_type>, n * sizeof(value_type)));
+      }
+
+      inline void deallocate(value_type* p, size_t) noexcept {
+        ::FEXCore::Allocator::free(p);
+      }
+
+      inline bool operator==(const FEXAlloc&) const { return true; }
+  };
+}

--- a/External/FEXCore/include/FEXCore/fextl/deque.h
+++ b/External/FEXCore/include/FEXCore/fextl/deque.h
@@ -1,0 +1,9 @@
+#pragma once
+#include <fextl/allocator.h>
+
+#include <deque>
+
+namespace fextl {
+  template<class T, class Allocator = fextl::FEXAlloc<T>>
+  using deque = std::deque<T, Allocator>;
+}

--- a/External/FEXCore/include/FEXCore/fextl/forward_list.h
+++ b/External/FEXCore/include/FEXCore/fextl/forward_list.h
@@ -1,0 +1,9 @@
+#pragma once
+#include <fextl/allocator.h>
+
+#include <forward_list>
+
+namespace fextl {
+  template<class T, class Allocator = fextl::FEXAlloc<T>>
+  using forward_list = std::forward_list<T, Allocator>;
+}

--- a/External/FEXCore/include/FEXCore/fextl/list.h
+++ b/External/FEXCore/include/FEXCore/fextl/list.h
@@ -1,0 +1,9 @@
+#pragma once
+#include <fextl/allocator.h>
+
+#include <list>
+
+namespace fextl {
+  template<class T, class Allocator = fextl::FEXAlloc<T>>
+  using list = std::list<T, Allocator>;
+}

--- a/External/FEXCore/include/FEXCore/fextl/map.h
+++ b/External/FEXCore/include/FEXCore/fextl/map.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <fextl/allocator.h>
+
+#include <map>
+
+namespace fextl {
+  template<class Key, class T, class Compare = std::less<Key>, class Allocator = fextl::FEXAlloc<std::pair<const Key, T>>>
+  using map = std::map<Key, T, Compare, Allocator>;
+
+  template<class Key, class T, class Compare = std::less<Key>, class Allocator = fextl::FEXAlloc<std::pair<const Key, T>>>
+  using multimap = std::multimap<Key, T, Compare, Allocator>;
+}

--- a/External/FEXCore/include/FEXCore/fextl/set.h
+++ b/External/FEXCore/include/FEXCore/fextl/set.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <fextl/allocator.h>
+
+#include <set>
+
+namespace fextl {
+  template<class Key, class Compare = std::less<Key>, class Allocator = fextl::FEXAlloc<Key>>
+  using set = std::set<Key, Compare, Allocator>;
+
+  template<class Key, class Compare = std::less<Key>, class Allocator = fextl::FEXAlloc<Key>>
+  using multiset = std::multiset<Key, Compare, Allocator>;
+}

--- a/External/FEXCore/include/FEXCore/fextl/string.h
+++ b/External/FEXCore/include/FEXCore/fextl/string.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <fextl/allocator.h>
+
+#include <string>
+
+namespace fextl {
+  template<class CharT, class Traits = std::char_traits<CharT>, class Allocator = fextl::FEXAlloc<CharT>>
+  using basic_string = std::basic_string<CharT, Traits, Allocator>;
+
+  using string = fextl::basic_string<char>;
+}

--- a/External/FEXCore/include/FEXCore/fextl/unordered_map.h
+++ b/External/FEXCore/include/FEXCore/fextl/unordered_map.h
@@ -1,0 +1,9 @@
+#pragma once
+#include <fextl/allocator.h>
+
+#include <unordered_map>
+
+namespace fextl {
+  template<class Key, class T, class Hash = std::hash<Key>, class KeyEqual = std::equal_to<Key>, class Allocator = fextl::FEXAlloc<std::pair<const Key, T>>>
+  using unordered_map = std::unordered_map<Key, T, Hash, KeyEqual, Allocator>;
+}

--- a/External/FEXCore/include/FEXCore/fextl/unordered_set.h
+++ b/External/FEXCore/include/FEXCore/fextl/unordered_set.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <fextl/allocator.h>
+
+#include <unordered_set>
+
+namespace fextl {
+  template<class Key, class Hash = std::hash<Key>, class KeyEqual = std::equal_to<Key>, class Allocator = fextl::FEXAlloc<Key>>
+  using unordered_set = std::unordered_set<Key, Hash, KeyEqual, Allocator>;
+
+  template<class Key, class Hash = std::hash<Key>, class KeyEqual = std::equal_to<Key>, class Allocator = fextl::FEXAlloc<Key>>
+  using unordered_multiset = std::unordered_multiset<Key, Hash, KeyEqual, Allocator>;
+}

--- a/External/FEXCore/include/FEXCore/fextl/vector.h
+++ b/External/FEXCore/include/FEXCore/fextl/vector.h
@@ -1,0 +1,9 @@
+#pragma once
+#include <fextl/allocator.h>
+
+#include <vector>
+
+namespace fextl {
+  template<class T, class Allocator = fextl::FEXAlloc<T>>
+  using vector = std::vector<T, Allocator>;
+}


### PR DESCRIPTION
Completely unused right now, this will very quickly spread throughout the entire codebase.

Currently only containers with FEX's global allocator usage. Any STL class that is allocation free and has been vetted to fit within the guidelines of not allocating memory will get an alias inside of `fextl`.

This means that any std:: namespace usage going forward will need to be scrutinized heavily. As aliasing it will mean it is vetted, otherwise it needs to be checked with FEX CI (once in place) to ensure it doesn't allocate memory behind our back.

Aliases everything we allow from std:: reduces mental burden from needing to check if it is okay to use or not. Additionally it will allow us to quickly pivot to the EASTL if we find as some point during this transition that this will in-fact not work.

Once this is committed, we are going to be moving very quickly to piecemeal convert /everything/ in the codebase over to fextl:: namespace from std::.

I am sorry for the hellscape that will follow.