### PR TITLE
Config: Convert vector to fextl

### DIFF
--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -3,6 +3,8 @@ set (MAN_DIR ${CMAKE_INSTALL_PREFIX}/share/man CACHE PATH "MAN_DIR")
 set (FEXCORE_BASE_SRCS
   Common/Paths.cpp
   Interface/Config/Config.cpp
+  Utils/Allocator.cpp
+  Utils/Allocator/64BitAllocator.cpp
   Utils/CPUInfo.cpp
   Utils/FileLoading.cpp
   Utils/ForcedAssert.cpp
@@ -138,8 +140,6 @@ set (SRCS
   Interface/IR/Passes/DeadStoreElimination.cpp
   Interface/IR/Passes/RegisterAllocationPass.cpp
   Interface/IR/Passes/SyscallOptimization.cpp
-  Utils/Allocator.cpp
-  Utils/Allocator/64BitAllocator.cpp
   Utils/NetStream.cpp
   Utils/Telemetry.cpp
   Utils/Threads.cpp

--- a/External/FEXCore/Source/Interface/Config/Config.cpp
+++ b/External/FEXCore/Source/Interface/Config/Config.cpp
@@ -6,6 +6,7 @@
 #include <FEXCore/Config/Config.h>
 #include <FEXCore/Utils/CPUInfo.h>
 #include <FEXCore/Utils/LogManager.h>
+#include <FEXCore/fextl/vector.h>
 
 #include <array>
 #include <assert.h>
@@ -61,7 +62,7 @@ namespace JSON {
   }
 
   static void LoadJSonConfig(const std::string &Config, std::function<void(const char *Name, const char *ConfigSring)> Func) {
-    std::vector<char> Data;
+    fextl::vector<char> Data;
     if (!FEXCore::FileLoading::LoadFile(Data, Config)) {
       return;
     }
@@ -384,7 +385,7 @@ namespace JSON {
     // We only support pressure-vessel at the moment
     const static std::string ContainerManager = "/run/host/container-manager";
     if (std::filesystem::exists(ContainerManager)) {
-      std::vector<char> Manager{};
+      fextl::vector<char> Manager{};
       if (FEXCore::FileLoading::LoadFile(Manager, ContainerManager)) {
         // Trim the whitespace, may contain a newline
         std::string ManagerStr = Manager.data();
@@ -399,7 +400,7 @@ namespace JSON {
     // We only support pressure-vessel at the moment
     const static std::string ContainerManager = "/run/host/container-manager";
     if (std::filesystem::exists(ContainerManager)) {
-      std::vector<char> Manager{};
+      fextl::vector<char> Manager{};
       if (FEXCore::FileLoading::LoadFile(Manager, ContainerManager)) {
         // Trim the whitespace, may contain a newline
         std::string ManagerStr = Manager.data();
@@ -651,7 +652,7 @@ namespace JSON {
 #define OPT_BASE(type, group, enum, json, default) {#json, FEXCore::Config::ConfigOption::CONFIG_##enum},
 #include <FEXCore/Config/ConfigValues.inl>
   }};
-  static const std::vector<std::pair<const char*, FEXCore::Config::ConfigOption>> EnvConfigLookup = {{
+  static const fextl::vector<std::pair<const char*, FEXCore::Config::ConfigOption>> EnvConfigLookup = {{
 #define OPT_BASE(type, group, enum, json, default) {"FEX_" #enum, FEXCore::Config::ConfigOption::CONFIG_##enum},
 #include <FEXCore/Config/ConfigValues.inl>
   }};

--- a/External/FEXCore/Source/Utils/FileLoading.cpp
+++ b/External/FEXCore/Source/Utils/FileLoading.cpp
@@ -1,3 +1,5 @@
+#include <FEXCore/fextl/vector.h>
+
 #include <string>
 #include <vector>
 #include <fcntl.h>
@@ -7,7 +9,38 @@
 #include <unistd.h>
 
 namespace FEXCore::FileLoading {
+// TODO: Delete once all uses of std::vector LoadFile is removed.
 bool LoadFile(std::vector<char> &Data, const std::string &Filepath, size_t FixedSize) {
+  int FD = open(Filepath.c_str(), O_RDONLY);
+
+  if (FD == -1) {
+    return false;
+  }
+
+  size_t FileSize{};
+  if (FixedSize == 0) {
+    struct stat buf;
+    if (fstat(FD, &buf) != 0) {
+      close(FD);
+      return false;
+    }
+
+    FileSize = buf.st_size;
+  }
+  else {
+    FileSize = FixedSize;
+  }
+
+  ssize_t Read = -1;
+  if (FileSize > 0) {
+    Data.resize(FileSize);
+    Read = pread(FD, &Data.at(0), FileSize, 0);
+  }
+  close(FD);
+  return Read == FileSize;
+}
+
+bool LoadFile(fextl::vector<char> &Data, const std::string &Filepath, size_t FixedSize) {
   int FD = open(Filepath.c_str(), O_RDONLY);
 
   if (FD == -1) {

--- a/External/FEXCore/Source/Utils/FileLoading.h
+++ b/External/FEXCore/Source/Utils/FileLoading.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <FEXCore/fextl/vector.h>
+
 #include <string>
 #include <vector>
 #include <filesystem>
@@ -14,7 +16,9 @@ namespace FEXCore::FileLoading {
    *
    * @return true on file loaded, false on failure
    */
+  // TODO: Delete once all uses of std::vector LoadFile is removed.
   bool LoadFile(std::vector<char> &Data, const std::string &Filepath, size_t FixedSize = 0);
+  bool LoadFile(fextl::vector<char> &Data, const std::string &Filepath, size_t FixedSize = 0);
 
   /**
    * @brief Loads a filepath in to a buffer of data with a fixed size


### PR DESCRIPTION
Plus two commits.
1) Moving Allocator.cpp so symbols are available in that TU
2) Temporarily duplicate LoadFile while code churn happens. This will only live for a few days at most.