### PR TITLE
 CodeEmitter: Convert vector to fextl 

### DIFF
--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -3,6 +3,8 @@ set (MAN_DIR ${CMAKE_INSTALL_PREFIX}/share/man CACHE PATH "MAN_DIR")
 set (FEXCORE_BASE_SRCS
   Common/Paths.cpp
   Interface/Config/Config.cpp
+  Utils/Allocator.cpp
+  Utils/Allocator/64BitAllocator.cpp
   Utils/CPUInfo.cpp
   Utils/FileLoading.cpp
   Utils/ForcedAssert.cpp
@@ -138,8 +140,6 @@ set (SRCS
   Interface/IR/Passes/DeadStoreElimination.cpp
   Interface/IR/Passes/RegisterAllocationPass.cpp
   Interface/IR/Passes/SyscallOptimization.cpp
-  Utils/Allocator.cpp
-  Utils/Allocator/64BitAllocator.cpp
   Utils/NetStream.cpp
   Utils/Telemetry.cpp
   Utils/Threads.cpp

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/Emitter.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/Emitter.h
@@ -6,6 +6,7 @@
 #include <FEXCore/Utils/CompilerDefs.h>
 #include <FEXCore/Utils/EnumUtils.h>
 #include <FEXCore/Utils/LogManager.h>
+#include <FEXCore/fextl/vector.h>
 
 #include <aarch64/assembler-aarch64.h>
 
@@ -503,7 +504,7 @@ namespace FEXCore::ARMEmitter {
       uint8_t *Location{};
       InstType Type;
     };
-    std::vector<Instructions> Insts{};
+    fextl::vector<Instructions> Insts{};
   };
 
   /* This `BiDirectionalLabel` struct used for retaining a location for PC-Relative instructions.


### PR DESCRIPTION
Needs https://github.com/FEX-Emu/FEX/pull/2506 merged first. First commit is cherry-picked from it.