### PR TITLE
Dispatcher: Removes signal frame stack

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
@@ -155,7 +155,6 @@ protected:
   };
 
   void RestoreThreadState(FEXCore::Core::InternalThreadState *Thread, void *ucontext, RestoreType Type);
-  std::stack<uint64_t, std::vector<uint64_t>> SignalFrames;
 
   virtual void SpillSRA(FEXCore::Core::InternalThreadState *Thread, void *ucontext, uint32_t IgnoreMask) {}
 


### PR DESCRIPTION
This wasn't used anymore. Removed.