### PR TITLE
Frontend/OpDispatcher: Convert vector to fextl

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Frontend.h
+++ b/External/FEXCore/Source/Interface/Core/Frontend.h
@@ -3,12 +3,12 @@
 #include <FEXCore/Debug/X86Tables.h>
 #include <FEXCore/HLE/SyscallHandler.h>
 #include <FEXCore/Utils/Telemetry.h>
+#include <FEXCore/fextl/vector.h>
 
 #include <array>
 #include <cstdint>
 #include <set>
 #include <stddef.h>
-#include <vector>
 
 namespace FEXCore::Context {
 class ContextImpl;
@@ -29,7 +29,7 @@ public:
   ~Decoder();
   void DecodeInstructionsAtEntry(uint8_t const* InstStream, uint64_t PC, std::function<void(uint64_t BlockEntry, uint64_t Start, uint64_t Length)> AddContainedCodePage);
 
-  std::vector<DecodedBlocks> const *GetDecodedBlocks() const {
+  fextl::vector<DecodedBlocks> const *GetDecodedBlocks() const {
     return &Blocks;
   }
 
@@ -89,7 +89,7 @@ private:
   uint64_t SymbolMinAddress {~0ULL};
   uint64_t SectionMaxAddress {~0ULL};
 
-  std::vector<DecodedBlocks> Blocks;
+  fextl::vector<DecodedBlocks> Blocks;
   std::set<uint64_t> BlocksToDecode;
   std::set<uint64_t> HasBlocks;
   std::set<uint64_t> *ExternalBranches {nullptr};

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -4644,7 +4644,7 @@ void OpDispatchBuilder::CMPXCHGPairOp(OpcodeArgs) {
   SetCurrentCodeBlock(NextJumpTarget);
 }
 
-void OpDispatchBuilder::CreateJumpBlocks(std::vector<FEXCore::Frontend::Decoder::DecodedBlocks> const *Blocks) {
+void OpDispatchBuilder::CreateJumpBlocks(fextl::vector<FEXCore::Frontend::Decoder::DecodedBlocks> const *Blocks) {
   OrderedNode *PrevCodeBlock{};
   for (auto &Target : *Blocks) {
     auto CodeNode = CreateCodeNode();
@@ -4659,7 +4659,7 @@ void OpDispatchBuilder::CreateJumpBlocks(std::vector<FEXCore::Frontend::Decoder:
   }
 }
 
-void OpDispatchBuilder::BeginFunction(uint64_t RIP, std::vector<FEXCore::Frontend::Decoder::DecodedBlocks> const *Blocks) {
+void OpDispatchBuilder::BeginFunction(uint64_t RIP, fextl::vector<FEXCore::Frontend::Decoder::DecodedBlocks> const *Blocks) {
   Entry = RIP;
   auto IRHeader = _IRHeader(InvalidNode, 0);
   Current_Header = IRHeader.first;

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -12,13 +12,13 @@
 #include <FEXCore/IR/IREmitter.h>
 
 #include <FEXCore/Utils/LogManager.h>
+#include <FEXCore/fextl/vector.h>
 
 #include <cstdint>
 #include <fmt/format.h>
 #include <map>
 #include <stddef.h>
 #include <utility>
-#include <vector>
 
 namespace FEXCore::IR {
 class Pass;
@@ -157,7 +157,7 @@ public:
   bool HadDecodeFailure() const { return DecodeFailure; }
   bool NeedsBlockEnder() const { return NeedsBlockEnd; }
 
-  void BeginFunction(uint64_t RIP, std::vector<FEXCore::Frontend::Decoder::DecodedBlocks> const *Blocks);
+  void BeginFunction(uint64_t RIP, fextl::vector<FEXCore::Frontend::Decoder::DecodedBlocks> const *Blocks);
   void Finalize();
 
   // Dispatch builder functions
@@ -1507,7 +1507,7 @@ private:
     return !Op->Dest.IsGPR();
   }
 
-  void CreateJumpBlocks(std::vector<FEXCore::Frontend::Decoder::DecodedBlocks> const *Blocks);
+  void CreateJumpBlocks(fextl::vector<FEXCore::Frontend::Decoder::DecodedBlocks> const *Blocks);
   bool BlockSetRIP {false};
 
   bool Multiblock{};


### PR DESCRIPTION
These two are intrinsicly linked. Need to cover both at the same time.