### PR TITLE
Jit64: Convert unordered_map to fextl

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterClass.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterClass.h
@@ -12,12 +12,7 @@ class Dispatcher;
 class X86DispatchGenerator;
 class Arm64DispatchGenerator;
 
-#define DESTMAP_AS_MAP 0
-#if DESTMAP_AS_MAP
-using DestMapType = std::unordered_map<uint32_t, uint32_t>;
-#else
 using DestMapType = std::vector<uint32_t>;
-#endif
 
 class InterpreterCore final : public CPUBackend {
 public:
@@ -36,7 +31,7 @@ public:
   [[nodiscard]] bool NeedsOpDispatch() override { return true; }
 
   static void InitializeSignalHandlers(FEXCore::Context::ContextImpl *CTX);
-  
+
   void ClearCache() override;
 
 private:

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -21,6 +21,7 @@ using namespace Xbyak;
 #include <FEXCore/IR/IR.h>
 #include <FEXCore/IR/IntrusiveIRList.h>
 #include <FEXCore/Utils/MathUtils.h>
+#include <FEXCore/fextl/unordered_map.h>
 #include "Interface/IR/Passes/RegisterAllocationPass.h"
 
 #include <tuple>
@@ -140,7 +141,7 @@ private:
   uint64_t Entry;
   CPUBackend::CompiledCode CodeData{};
 
-  std::unordered_map<IR::NodeID, Label> JumpTargets;
+  fextl::unordered_map<IR::NodeID, Label> JumpTargets;
   Xbyak::util::Cpu Features{};
 
   bool MemoryDebug = false;


### PR DESCRIPTION
Interpreter just remove the destination as a map. This isn't useful anymore.