### PR TITLE
FEXCore: IR_INC dependency on FEXCore_Base

### DIFF
--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -332,7 +332,7 @@ function(AddDefaultOptionsToTarget Name)
   target_include_directories(${Name} PUBLIC "${CMAKE_BINARY_DIR}/include/")
 
   target_compile_definitions(${Name} PRIVATE ${DEFINES})
-  add_dependencies(${Name} CONFIG_INC)
+  add_dependencies(${Name} CONFIG_INC IR_INC)
 
   target_compile_options(${Name}
     PRIVATE
@@ -374,7 +374,6 @@ AddDefaultOptionsToTarget(FEXCore_Base)
 
 function(AddObject Name Type)
   add_library(${Name} ${Type} ${SRCS})
-  add_dependencies(${Name} IR_INC)
 
   target_link_libraries(${Name} FEXCore_Base)
   AddDefaultOptionsToTarget(${Name})


### PR DESCRIPTION
This dependency was on FEXCore only. Add it to the same dependency definitions that CONFIG_INC is in so that FEXCore_Base picks it up.

Might solve a compile error from FEX Common missing the dependency being generated.

Edit:
Confirms to resolve the compile error.