### PR TITLE
HostFeatures: Mark DCZID related utilities as [[maybe_unused]]

### DIFF
--- a/External/FEXCore/Source/Interface/Core/HostFeatures.cpp
+++ b/External/FEXCore/Source/Interface/Core/HostFeatures.cpp
@@ -17,12 +17,12 @@ namespace FEXCore {
 // Data Zero Prohibited flag
 // 0b0 = ZVA/GVA/GZVA permitted
 // 0b1 = ZVA/GVA/GZVA prohibited
-constexpr uint32_t DCZID_DZP_MASK = 0b1'0000;
+[[maybe_unused]] constexpr uint32_t DCZID_DZP_MASK = 0b1'0000;
 // Log2 of the blocksize in 32-bit words
-constexpr uint32_t DCZID_BS_MASK = 0b0'1111;
+[[maybe_unused]] constexpr uint32_t DCZID_BS_MASK = 0b0'1111;
 
 #ifdef _M_ARM_64
-static uint32_t GetDCZID() {
+[[maybe_unused]] static uint32_t GetDCZID() {
   uint64_t Result{};
   __asm("mrs %[Res], DCZID_EL0"
       : [Res] "=r" (Result));


### PR DESCRIPTION
When building with the simulator enabled, these aren't used and cause some unused funtion/variable warnings.

We can silence these with [[maybe_unused]], since these are used in non-simulator builds.