### PR TITLE
Arm64/VectorOps: Handle 64-bit elements in VSShr

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -2163,7 +2163,7 @@ DEF_OP(VUShr) {
       bif(VTMP1.Q(), ShiftVector.Q(), VTMP2.Q());
     }
 
-    // Need to invert shift values to perform a right shift with SSHL
+    // Need to invert shift values to perform a right shift with USHL
     // (USHR only has an immediate variant).
     neg(SubRegSize, VTMP1.Q(), VTMP1.Q());
     ushl(SubRegSize, Dst.Q(), Vector.Q(), VTMP1.Q());


### PR DESCRIPTION
Makes it consistent with all of the other variable shift IR ops.

Now this won't explode if we ever implement VPSRAVQ from AVX-512