### PR TITLE
FEXConfig: Fixes misalignment when advanced option is changed. 

### DIFF
--- a/Source/Tools/FEXConfig/Main.cpp
+++ b/Source/Tools/FEXConfig/Main.cpp
@@ -698,6 +698,7 @@ namespace {
 
               }
               ConfigChanged = true;
+              UpdateAdvancedOptionsVector();
             }
 
             ImGui::SameLine();


### PR DESCRIPTION
When the textual field is changed, that order changes and there would be
a partial resort where the labels would misalign compared to the text
entries.
Fixes that.