### PR TITLE
ARMEmitter: Handle SVE2 integer add/subtract wide category

### DIFF
--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
@@ -2012,7 +2012,30 @@ public:
   }
 
   // SVE2 integer add/subtract wide
-  // XXX:
+  void saddwb(SubRegSize size, ZRegister zd, ZRegister zn, ZRegister zm) {
+    SVE2IntegerAddSubWide(0b000, size, zd, zn, zm);
+  }
+  void saddwt(SubRegSize size, ZRegister zd, ZRegister zn, ZRegister zm) {
+    SVE2IntegerAddSubWide(0b001, size, zd, zn, zm);
+  }
+  void uaddwb(SubRegSize size, ZRegister zd, ZRegister zn, ZRegister zm) {
+    SVE2IntegerAddSubWide(0b010, size, zd, zn, zm);
+  }
+  void uaddwt(SubRegSize size, ZRegister zd, ZRegister zn, ZRegister zm) {
+    SVE2IntegerAddSubWide(0b011, size, zd, zn, zm);
+  }
+  void ssubwb(SubRegSize size, ZRegister zd, ZRegister zn, ZRegister zm) {
+    SVE2IntegerAddSubWide(0b100, size, zd, zn, zm);
+  }
+  void ssubwt(SubRegSize size, ZRegister zd, ZRegister zn, ZRegister zm) {
+    SVE2IntegerAddSubWide(0b101, size, zd, zn, zm);
+  }
+  void usubwb(SubRegSize size, ZRegister zd, ZRegister zn, ZRegister zm) {
+    SVE2IntegerAddSubWide(0b110, size, zd, zn, zm);
+  }
+  void usubwt(SubRegSize size, ZRegister zd, ZRegister zn, ZRegister zm) {
+    SVE2IntegerAddSubWide(0b111, size, zd, zn, zm);
+  }
 
   // SVE2 integer multiply long
   void sqdmullb(SubRegSize size, ZRegister zd, ZRegister zn, ZRegister zm) {
@@ -4591,6 +4614,11 @@ private:
   void SVE2IntegerAddSubLong(uint32_t op, uint32_t SUT, SubRegSize size, ZRegister zd, ZRegister zn, ZRegister zm) {
     LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit && size != SubRegSize::i128Bit, "Can't use 8-bit or 128-bit element size");
     SVE2WideningIntegerArithmetic(op, SUT, size, zd, zn, zm);
+  }
+
+  void SVE2IntegerAddSubWide(uint32_t SUT, SubRegSize size, ZRegister zd, ZRegister zn, ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit && size != SubRegSize::i128Bit, "Can't use 8-bit or 128-bit element size");
+    SVE2WideningIntegerArithmetic(0b10, SUT, size, zd, zn, zm);
   }
 
   void SVE2IntegerMultiplyLong(uint32_t SUT, SubRegSize size, ZRegister zd, ZRegister zn, ZRegister zm) {

--- a/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
+++ b/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
@@ -2522,7 +2522,37 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 integer add/subtract long
   TEST_SINGLE(uabdlt(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28), "uabdlt z30.d, z29.s, z28.s");
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 integer add/subtract wide") {
-  // TODO: Implement in emitter.
+  TEST_SINGLE(saddwb(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28), "saddwb z30.h, z29.h, z28.b");
+  TEST_SINGLE(saddwb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "saddwb z30.s, z29.s, z28.h");
+  TEST_SINGLE(saddwb(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28), "saddwb z30.d, z29.d, z28.s");
+
+  TEST_SINGLE(saddwt(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28), "saddwt z30.h, z29.h, z28.b");
+  TEST_SINGLE(saddwt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "saddwt z30.s, z29.s, z28.h");
+  TEST_SINGLE(saddwt(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28), "saddwt z30.d, z29.d, z28.s");
+
+  TEST_SINGLE(uaddwb(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28), "uaddwb z30.h, z29.h, z28.b");
+  TEST_SINGLE(uaddwb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "uaddwb z30.s, z29.s, z28.h");
+  TEST_SINGLE(uaddwb(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28), "uaddwb z30.d, z29.d, z28.s");
+
+  TEST_SINGLE(uaddwt(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28), "uaddwt z30.h, z29.h, z28.b");
+  TEST_SINGLE(uaddwt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "uaddwt z30.s, z29.s, z28.h");
+  TEST_SINGLE(uaddwt(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28), "uaddwt z30.d, z29.d, z28.s");
+
+  TEST_SINGLE(ssubwb(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28), "ssubwb z30.h, z29.h, z28.b");
+  TEST_SINGLE(ssubwb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "ssubwb z30.s, z29.s, z28.h");
+  TEST_SINGLE(ssubwb(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28), "ssubwb z30.d, z29.d, z28.s");
+
+  TEST_SINGLE(ssubwt(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28), "ssubwt z30.h, z29.h, z28.b");
+  TEST_SINGLE(ssubwt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "ssubwt z30.s, z29.s, z28.h");
+  TEST_SINGLE(ssubwt(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28), "ssubwt z30.d, z29.d, z28.s");
+
+  TEST_SINGLE(usubwb(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28), "usubwb z30.h, z29.h, z28.b");
+  TEST_SINGLE(usubwb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "usubwb z30.s, z29.s, z28.h");
+  TEST_SINGLE(usubwb(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28), "usubwb z30.d, z29.d, z28.s");
+
+  TEST_SINGLE(usubwt(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, ZReg::z28), "usubwt z30.h, z29.h, z28.b");
+  TEST_SINGLE(usubwt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "usubwt z30.s, z29.s, z28.h");
+  TEST_SINGLE(usubwt(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, ZReg::z28), "usubwt z30.d, z29.d, z28.s");
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 integer multiply long") {
   //TEST_SINGLE(sqdmullb(SubRegSize::i8Bit, ZReg::z30, ZReg::z29, ZReg::z28), "sqdmullb z30.b, z29.b, z28.b");


### PR DESCRIPTION
Adds the only missing category under the SVE2 Widening Integer Arithmetic group