### PR TITLE
OpcodeDispatcher: Implement support for 32-bit SALC instruction

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -433,7 +433,7 @@ void OpDispatchBuilder::ADCOp(OpcodeArgs) {
   GenerateFlags_ADC(Op, Result, Before, Src, CF);
 }
 
-template<uint32_t SrcIndex>
+template<uint32_t SrcIndex, bool SetFlags>
 void OpDispatchBuilder::SBBOp(OpcodeArgs) {
   // Calculate flags early.
   CalculateDeferredFlags();
@@ -459,10 +459,12 @@ void OpDispatchBuilder::SBBOp(OpcodeArgs) {
     StoreResult(GPRClass, Op, Result, -1);
   }
 
-  if (Size < 4) {
-    Result = _Bfe(Size, Size * 8, 0, Result);
+  if (SetFlags) {
+    if (Size < 4) {
+      Result = _Bfe(Size, Size * 8, 0, Result);
+    }
+    GenerateFlags_SBB(Op, Result, Before, Src, CF);
   }
-  GenerateFlags_SBB(Op, Result, Before, Src, CF);
 }
 
 void OpDispatchBuilder::PUSHOp(OpcodeArgs) {
@@ -6051,7 +6053,7 @@ void InstallOpcodeHandlers(Context::OperatingMode Mode) {
 
     {0x10, 6, &OpDispatchBuilder::ADCOp<0>},
 
-    {0x18, 6, &OpDispatchBuilder::SBBOp<0>},
+    {0x18, 6, &OpDispatchBuilder::SBBOp<0, true>},
 
     {0x20, 6, &OpDispatchBuilder::ALUOp<FEXCore::IR::IROps::OP_AND, FEXCore::IR::IROps::OP_ATOMICFETCHAND, false>},
 
@@ -6133,6 +6135,7 @@ void InstallOpcodeHandlers(Context::OperatingMode Mode) {
     {0xCE, 1, &OpDispatchBuilder::INTOp},
     {0xD4, 1, &OpDispatchBuilder::AAMOp},
     {0xD5, 1, &OpDispatchBuilder::AADOp},
+    {0xD6, 1, &OpDispatchBuilder::SBBOp<0, false>},
   };
 
   constexpr std::tuple<uint8_t, uint8_t, X86Tables::OpDispatchPtr> BaseOpTable_64[] = {
@@ -6294,7 +6297,7 @@ void InstallOpcodeHandlers(Context::OperatingMode Mode) {
     {OPD(FEXCore::X86Tables::TYPE_GROUP_1, OpToIndex(0x80), 0), 1, &OpDispatchBuilder::SecondaryALUOp},
     {OPD(FEXCore::X86Tables::TYPE_GROUP_1, OpToIndex(0x80), 1), 1, &OpDispatchBuilder::SecondaryALUOp},
     {OPD(FEXCore::X86Tables::TYPE_GROUP_1, OpToIndex(0x80), 2), 1, &OpDispatchBuilder::ADCOp<1>},
-    {OPD(FEXCore::X86Tables::TYPE_GROUP_1, OpToIndex(0x80), 3), 1, &OpDispatchBuilder::SBBOp<1>},
+    {OPD(FEXCore::X86Tables::TYPE_GROUP_1, OpToIndex(0x80), 3), 1, &OpDispatchBuilder::SBBOp<1, true>},
     {OPD(FEXCore::X86Tables::TYPE_GROUP_1, OpToIndex(0x80), 4), 1, &OpDispatchBuilder::SecondaryALUOp},
     {OPD(FEXCore::X86Tables::TYPE_GROUP_1, OpToIndex(0x80), 5), 1, &OpDispatchBuilder::SecondaryALUOp},
     {OPD(FEXCore::X86Tables::TYPE_GROUP_1, OpToIndex(0x80), 6), 1, &OpDispatchBuilder::SecondaryALUOp},
@@ -6303,7 +6306,7 @@ void InstallOpcodeHandlers(Context::OperatingMode Mode) {
     {OPD(FEXCore::X86Tables::TYPE_GROUP_1, OpToIndex(0x81), 0), 1, &OpDispatchBuilder::SecondaryALUOp},
     {OPD(FEXCore::X86Tables::TYPE_GROUP_1, OpToIndex(0x81), 1), 1, &OpDispatchBuilder::SecondaryALUOp},
     {OPD(FEXCore::X86Tables::TYPE_GROUP_1, OpToIndex(0x81), 2), 1, &OpDispatchBuilder::ADCOp<1>},
-    {OPD(FEXCore::X86Tables::TYPE_GROUP_1, OpToIndex(0x81), 3), 1, &OpDispatchBuilder::SBBOp<1>},
+    {OPD(FEXCore::X86Tables::TYPE_GROUP_1, OpToIndex(0x81), 3), 1, &OpDispatchBuilder::SBBOp<1, true>},
     {OPD(FEXCore::X86Tables::TYPE_GROUP_1, OpToIndex(0x81), 4), 1, &OpDispatchBuilder::SecondaryALUOp},
     {OPD(FEXCore::X86Tables::TYPE_GROUP_1, OpToIndex(0x81), 5), 1, &OpDispatchBuilder::SecondaryALUOp},
     {OPD(FEXCore::X86Tables::TYPE_GROUP_1, OpToIndex(0x81), 6), 1, &OpDispatchBuilder::SecondaryALUOp},
@@ -6312,7 +6315,7 @@ void InstallOpcodeHandlers(Context::OperatingMode Mode) {
     {OPD(FEXCore::X86Tables::TYPE_GROUP_1, OpToIndex(0x83), 0), 1, &OpDispatchBuilder::SecondaryALUOp},
     {OPD(FEXCore::X86Tables::TYPE_GROUP_1, OpToIndex(0x83), 1), 1, &OpDispatchBuilder::SecondaryALUOp},
     {OPD(FEXCore::X86Tables::TYPE_GROUP_1, OpToIndex(0x83), 2), 1, &OpDispatchBuilder::ADCOp<1>},
-    {OPD(FEXCore::X86Tables::TYPE_GROUP_1, OpToIndex(0x83), 3), 1, &OpDispatchBuilder::SBBOp<1>}, // Unit tests find this setting flags incorrectly
+    {OPD(FEXCore::X86Tables::TYPE_GROUP_1, OpToIndex(0x83), 3), 1, &OpDispatchBuilder::SBBOp<1, true>},
     {OPD(FEXCore::X86Tables::TYPE_GROUP_1, OpToIndex(0x83), 4), 1, &OpDispatchBuilder::SecondaryALUOp},
     {OPD(FEXCore::X86Tables::TYPE_GROUP_1, OpToIndex(0x83), 5), 1, &OpDispatchBuilder::SecondaryALUOp},
     {OPD(FEXCore::X86Tables::TYPE_GROUP_1, OpToIndex(0x83), 6), 1, &OpDispatchBuilder::SecondaryALUOp},

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -181,7 +181,7 @@ public:
   void SecondaryALUOp(OpcodeArgs);
   template<uint32_t SrcIndex>
   void ADCOp(OpcodeArgs);
-  template<uint32_t SrcIndex>
+  template<uint32_t SrcIndex, bool SetFlags>
   void SBBOp(OpcodeArgs);
   void PUSHOp(OpcodeArgs);
   void PUSHREGOp(OpcodeArgs);

--- a/External/FEXCore/Source/Interface/Core/X86Tables/BaseTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/BaseTables.cpp
@@ -173,7 +173,6 @@ void InitializeBaseTables(Context::OperatingMode Mode) {
     {0xCD, 1, X86InstInfo{"INT",    TYPE_INST, FLAGS_DEBUG ,                                                                  1, nullptr}},
     {0xCF, 1, X86InstInfo{"IRET",   TYPE_INST, FLAGS_SETS_RIP | FLAGS_BLOCK_END,                                                                                    0, nullptr}},
 
-    {0xD6, 1, X86InstInfo{"[INV]",  TYPE_INVALID, FLAGS_NONE,                                                                                    0, nullptr}},
     {0xD7, 1, X86InstInfo{"XLAT",   TYPE_INST, FLAGS_DEBUG_MEM_ACCESS,                                                                           0, nullptr}},
 
     {0xE0, 1, X86InstInfo{"LOOPNE", TYPE_INST, GenFlagsSameSize(SIZE_64BITDEF) | FLAGS_SETS_RIP | FLAGS_SRC_SEXT | FLAGS_SF_SRC_RCX,                             1, nullptr}},
@@ -255,6 +254,9 @@ void InitializeBaseTables(Context::OperatingMode Mode) {
     {0xA3, 1, X86InstInfo{"MOV",    TYPE_INST, FLAGS_SF_SRC_RAX | FLAGS_MEM_OFFSET, 8, nullptr}},
     {0xCE, 1, X86InstInfo{"[INV]",  TYPE_INVALID, FLAGS_NONE,                                                                                    0, nullptr}},
     {0xD4, 2, X86InstInfo{"[INV]",  TYPE_INVALID, FLAGS_NONE,                                                                                    0, nullptr}},
+    // `L1OM` Larrabee instructions used this as an escape byte.
+    // FEX will never support this.
+    {0xD6, 1, X86InstInfo{"[INV]",  TYPE_INVALID, FLAGS_NONE,                                                                                    0, nullptr}},
     {0xEA, 1, X86InstInfo{"[INV]",  TYPE_INVALID, FLAGS_NONE,                                                                                                      0, nullptr}},
   };
 
@@ -285,6 +287,7 @@ void InitializeBaseTables(Context::OperatingMode Mode) {
     {0xCE, 1, X86InstInfo{"INTO",   TYPE_INST, FLAGS_NONE,                                                        0, nullptr}},
     {0xD4, 1, X86InstInfo{"AAM",    TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_SF_DST_RAX,                    1, nullptr}},
     {0xD5, 1, X86InstInfo{"AAD",    TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_SF_DST_RAX,                    1, nullptr}},
+    {0xD6, 1, X86InstInfo{"SALC",   TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_SF_DST_RAX | FLAGS_SF_SRC_RAX, 0, nullptr}},
     {0xEA, 1, X86InstInfo{"JMPF",   TYPE_INST, FLAGS_NONE,                                                        0, nullptr}},
   };
 

--- a/unittests/32Bit_ASM/Primary/Primary_D6.asm
+++ b/unittests/32Bit_ASM/Primary/Primary_D6.asm
@@ -1,0 +1,36 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x0000000041D7FF00"
+  },
+  "Mode": "32BIT"
+}
+%endif
+
+mov edx, 0xe0000000
+
+mov eax, 0x41424344
+mov [edx + 8 * 0], eax
+mov eax, 0x51525354
+
+; Set resulting al to zero
+clc
+salc
+mov [edx + 8 * 0 + 0], al
+
+; Set resulting al to 0xFF
+stc
+salc
+lahf
+mov [edx + 8 * 0 + 1], al
+
+; Ensure that salc doesn't set flags
+mov eax, -1
+sahf
+salc
+lahf
+mov [edx + 8 * 0 + 2], ah
+
+mov eax, [edx + 8 * 0]
+
+hlt


### PR DESCRIPTION
This is an undocumented but supported instruction. It behaves just like an `sbb al, al` but doesn't set flags and is one byte shorter.

The end result is that al is set to 0xFF or 0 depending on if CF is set or not.