### PR TITLE
Core: Add a new log message for unsupported instruction

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -862,6 +862,9 @@ namespace FEXCore::Context {
             }
           }
           else {
+            if (TableInfo) {
+              LogMan::Msg::EFmt("Invalid or Unknown instruction: {} 0x{:x}", TableInfo->Name ?: "UND", Block.Entry - GuestRIP);
+            }
             // Invalid instruction
             Thread->OpDispatcher->InvalidOp(DecodedInfo);
             Thread->OpDispatcher->_ExitFunction(Thread->OpDispatcher->_EntrypointOffset(Block.Entry - GuestRIP, GPRSize));


### PR DESCRIPTION
The previous log in the frontend is super useful when an instruction decoding wasn't supported.
Now that most of AVX is covered, a game will crash on SIGILL (and usually catch it) and close without any indication.

Now if the instruction is decoded but it is invalid for the configuration, still output a message as a good indicator that the game is using instructions that the host doesn't support.

Will let us still pick up on games crashing due to lack of SVE very easily.