### PR TITLE
CI: Adds glibc faulting testing

### DIFF
--- a/.github/workflows/glibc_fault.yml
+++ b/.github/workflows/glibc_fault.yml
@@ -1,0 +1,190 @@
+name: GLIBC fault test
+# This workflow file is the same as the `Build + Test` with some key differences
+# - Runs on any x86 and ARM64 runner
+# - Disables the glibc jemalloc compile option
+# - Enables the glibc allocator fault option
+# - Disables gvisor tests to reduce stress on CI machines (tmp/shm tests overwhelm them)
+# - Disables thunk tests since they are incompatible with glibc fault allocator
+# - Disables ARMEmitter tests (We don't want to fault test vixl's disassembler)
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+  CC: clang
+  CXX: clang++
+  FEX_FORCE32BITALLOCATOR: 1
+  FEX_ENABLEAVX: 1
+
+jobs:
+  build:
+    runs-on: ${{ matrix.arch }}
+    strategy:
+      matrix:
+        # Run on an x86 device and any ARM runner.
+        arch: [[self-hosted, x64], [self-hosted, ARM64]]
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set runner label
+      run: echo "runner_label=${{ matrix.arch[1] }}" >> $GITHUB_ENV
+
+    - name: Set rootfs paths
+      run: |
+        echo "FEX_ROOTFS_MOUNT=/mnt/AutoNFS/rootfs/" >> $GITHUB_ENV
+        echo "FEX_ROOTFS_PATH=$HOME/Rootfs/" >> $GITHUB_ENV
+        echo "FEX_ROOTFS=$HOME/Rootfs/" >> $GITHUB_ENV
+        echo "ROOTFS=$HOME/Rootfs/" >> $GITHUB_ENV
+
+    - name: Update RootFS cache
+      # Use a bash shell so we can use the same syntax for environment variable
+      # access regardless of the host operating system
+      shell: bash
+      run: $GITHUB_WORKSPACE/Scripts/CI_FetchRootFS.py
+
+    - name : submodule checkout
+      # Need to update submodules
+      run: |
+        git submodule sync --recursive
+        git submodule update --init --depth 1
+
+    - name: Clean Build Environment
+      run: rm -Rf ${{runner.workspace}}/build
+
+    - name: Create Build Environment
+      # Some projects don't allow in-source building, so create a separate build directory
+      # We'll use this as our working directory for all subsequent commands
+      run: cmake -E make_directory ${{runner.workspace}}/build
+
+    - name: Configure CMake
+      # Use a bash shell so we can use the same syntax for environment variable
+      # access regardless of the host operating system
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      # Note the current convention is to use the -S and -B options here to specify source
+      # and build directories, but this is only available with CMake 3.13 and higher.
+      # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -G Ninja -DENABLE_LTO=False -DENABLE_ASSERTIONS=True -DENABLE_X86_HOST_DEBUG=True -DENABLE_INTERPRETER=True -DBUILD_FEX_LINUX_TESTS=True -DENABLE_GLIBC_ALLOCATOR_HOOK_FAULT=True -DENABLE_JEMALLOC_GLIBC_ALLOC=False -DCMAKE_INSTALL_PREFIX=${{runner.workspace}}/build/install
+
+    - name: Build
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      # Execute the build.  You can specify a specific target with "--target <NAME>"
+      run: cmake --build . --config $BUILD_TYPE
+
+    - name: Install
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      run: cmake --build . --config $BUILD_TYPE --target install
+
+    - name: ASM Tests
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      # Execute the unit tests
+      run: cmake --build . --config $BUILD_TYPE --target asm_tests
+
+    - name: ASM Test Results move
+      if: ${{ always() }}
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_ASM.log || true
+
+    - name: IR Tests
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      # Execute the unit tests
+      run: cmake --build . --config $BUILD_TYPE --target ir_tests
+
+    - name: IR Test Results move
+      if: ${{ always() }}
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_IR.log || true
+
+    - name: Posix Tests
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      # Execute the posixtest
+      run: cmake --build . --config $BUILD_TYPE --target posix_tests
+
+    - name: Posix Test Results move
+      if: ${{ always() }}
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_Posix.log || true
+
+    - name: gcc target tests 64
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      # Execute the gvisor tests
+      run: cmake --build . --config $BUILD_TYPE --target gcc_target_tests_64
+
+    - name: GCC64 Test Results move
+      if: ${{ always() }}
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_GCC64.log || true
+
+    - name: gcc target tests 32
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      # Execute the gvisor tests
+      run: cmake --build . --config $BUILD_TYPE --target gcc_target_tests_32
+
+    - name: GCC32 Test Results move
+      if: ${{ always() }}
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_GCC32.log || true
+
+    - name: APITest tests
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      run: cmake --build . --config $BUILD_TYPE --target api_tests
+
+    - name: APITest Test Results move
+      if: ${{ always() }}
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_APITests.log || true
+
+    - name: FEXLinuxTests
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      run: cmake --build . --config $BUILD_TYPE --target fex_linux_tests_all
+
+    - name: FEXLinuxTests Results move
+      if: ${{ always() }}
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_FEXLinuxTests.log || true
+
+    - name: Truncate test results
+      if: ${{ always() }}
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      # Cap out the log files at 20M in case something crash spins and dumps fault text
+      # ASM tests get quite close to 10MB
+      run: truncate --size=<20M ${{runner.workspace}}/build/Testing/Temporary/LastTest_*.log || true
+
+    - name: Set runner name
+      if: ${{ always() }}
+      run: echo "runner_name=$(hostname)" >> $GITHUB_ENV
+
+    - name: Upload results
+      if: ${{ always() }}
+      uses: 'actions/upload-artifact@v2'
+      with:
+        name: Results-${{ env.runner_name }}
+        path: ${{runner.workspace}}/build/Testing/Temporary/LastTest_*.log
+        retention-days: 3
+


### PR DESCRIPTION
This is based on our regular CI runner file with a couple of things stripped out.

- gvisor tests removed because they cause our CI machines pain with tmp/shm mounts
- Thunks disabled since glibc fault testing is incompatible with it
- ARMEmitter tests removed since we don't want to test vixl.

~~First two commits are from #2591 so that needs to be merged first.~~
~~Next commit is from #2592 and needs to be merged first.~~
~~Next commit is from #2593 and needs to be merged first.~~
~~Next commit is from #2595 and needs to be merged first.~~
~~Next commit is from #2596 and needs to be merged first.~~

Fixes #2500