### PR TITLE
unittests/gcc: Disable mcount_pic test

### DIFF
--- a/unittests/gcc-target-tests-32/Disabled_Tests
+++ b/unittests/gcc-target-tests-32/Disabled_Tests
@@ -19,3 +19,6 @@ sse4_1-roundf-vec.c.gcc-target-test-32
 # These tests fail on Nvidia Xavier ONLY
 sse4_1-rintf-vec.c.gcc-target-test-32
 sse4_1-round-vec.c.gcc-target-test-32
+
+# This has a race with SIGPROF
+mcount_pic.c.gcc-target-test-32

--- a/unittests/gcc-target-tests-32/Known_Failures
+++ b/unittests/gcc-target-tests-32/Known_Failures
@@ -20,3 +20,6 @@ sse4_1-roundf-vec.c.gcc-target-test-32
 # These tests fail on Nvidia Xavier ONLY
 sse4_1-rintf-vec.c.gcc-target-test-32
 sse4_1-round-vec.c.gcc-target-test-32
+
+# This has a race with SIGPROF
+mcount_pic.c.gcc-target-test-32

--- a/unittests/gcc-target-tests-64/Disabled_Tests
+++ b/unittests/gcc-target-tests-64/Disabled_Tests
@@ -40,3 +40,6 @@ sse4_1-rint-sfix-vec.c.gcc-target-test-64
 sse4_1-rintf-sfix-vec.c.gcc-target-test-64
 sse4_1-round-sfix-vec.c.gcc-target-test-64
 sse4_1-roundf-sfix-vec.c.gcc-target-test-64
+
+# This has a race with SIGPROF
+mcount_pic.c.gcc-target-test-64

--- a/unittests/gcc-target-tests-64/Known_Failures
+++ b/unittests/gcc-target-tests-64/Known_Failures
@@ -40,3 +40,6 @@ sse4_1-rint-sfix-vec.c.gcc-target-test-64
 sse4_1-rintf-sfix-vec.c.gcc-target-test-64
 sse4_1-round-sfix-vec.c.gcc-target-test-64
 sse4_1-roundf-sfix-vec.c.gcc-target-test-64
+
+# This has a race with SIGPROF
+mcount_pic.c.gcc-target-test-64


### PR DESCRIPTION
This has a race condition with SIGPROF which the Tegra Orin hits consistently. Probably due to a faster timer or something?