### PR TITLE
Allocator: Remove pointer indirection overhead

### DIFF
--- a/External/FEXCore/Source/Utils/Allocator.cpp
+++ b/External/FEXCore/Source/Utils/Allocator.cpp
@@ -44,27 +44,6 @@ namespace fextl::pmr {
 namespace FEXCore::Allocator {
   MMAP_Hook mmap {::mmap};
   MUNMAP_Hook munmap {::munmap};
-#ifdef ENABLE_JEMALLOC
-  MALLOC_Hook malloc {::je_malloc};
-  CALLOC_Hook calloc {::je_calloc};
-  MEMALIGN_Hook memalign {::je_memalign};
-  VALLOC_Hook valloc {::je_valloc};
-  POSIX_MEMALIGN_Hook posix_memalign {::je_posix_memalign};
-  REALLOC_Hook realloc {::je_realloc};
-  FREE_Hook free {::je_free};
-  MALLOC_USABLE_SIZE_Hook malloc_usable_size {::je_malloc_usable_size};
-  ALIGNED_ALLOC_Hook aligned_alloc {::je_aligned_alloc};
-#else
-  MALLOC_Hook malloc {::malloc};
-  CALLOC_Hook calloc {::calloc};
-  MEMALIGN_Hook memalign {::memalign};
-  VALLOC_Hook valloc {::valloc};
-  POSIX_MEMALIGN_Hook posix_memalign {::posix_memalign};
-  REALLOC_Hook realloc {::realloc};
-  FREE_Hook free {::free};
-  MALLOC_USABLE_SIZE_Hook malloc_usable_size {::malloc_usable_size};
-  ALIGNED_ALLOC_Hook aligned_alloc {::aligned_alloc};
-#endif
 
   uint64_t HostVASize{};
 

--- a/External/FEXCore/Source/Utils/AllocatorOverride.cpp
+++ b/External/FEXCore/Source/Utils/AllocatorOverride.cpp
@@ -53,15 +53,15 @@ namespace FEXCore::Allocator {
   static thread_local uint64_t SkipEvalForThread{};
 
   // Internal memory allocation hooks to allow non-faulting allocations through.
-  CALLOC_Hook calloc_ptr = __libc_calloc;
-  FREE_Hook free_ptr = __libc_free;
-  MALLOC_Hook malloc_ptr = __libc_malloc;
-  MEMALIGN_Hook memalign_ptr = __libc_memalign;
-  REALLOC_Hook realloc_ptr = __libc_realloc;
-  VALLOC_Hook valloc_ptr = __libc_valloc;
-  POSIX_MEMALIGN_Hook posix_memalign_ptr = ::posix_memalign;
-  MALLOC_USABLE_SIZE_Hook malloc_usable_size_ptr  = ::malloc_usable_size;
-  ALIGNED_ALLOC_Hook aligned_alloc_ptr = __libc_memalign;
+  auto calloc_ptr = __libc_calloc;
+  auto free_ptr = __libc_free;
+  auto malloc_ptr = __libc_malloc;
+  auto memalign_ptr = __libc_memalign;
+  auto realloc_ptr = __libc_realloc;
+  auto valloc_ptr = __libc_valloc;
+  auto posix_memalign_ptr = ::posix_memalign;
+  auto malloc_usable_size_ptr  = ::malloc_usable_size;
+  auto aligned_alloc_ptr = __libc_memalign;
 
   // Constructor for per-thread allocation faulting check.
   YesIKnowImNotSupposedToUseTheGlibcAllocator::YesIKnowImNotSupposedToUseTheGlibcAllocator() {

--- a/External/FEXCore/include/FEXCore/Utils/AllocatorHooks.h
+++ b/External/FEXCore/include/FEXCore/Utils/AllocatorHooks.h
@@ -1,35 +1,62 @@
 #pragma once
 #include <FEXCore/Utils/CompilerDefs.h>
 
+#ifndef ENABLE_JEMALLOC
+#include <stdlib.h>
+#include <malloc.h>
+#endif
+
 #include <cstddef>
 #include <cstdint>
 #include <sys/types.h>
+
+extern "C" {
+// jemalloc defines nothrow on its internal C function signatures.
+#ifdef ENABLE_JEMALLOC
+#define JEMALLOC_NOTHROW __attribute__((nothrow))
+  // Forward declare jemalloc functions so we don't need to pull in the jemalloc header in to the public API.
+  FEX_DEFAULT_VISIBILITY JEMALLOC_NOTHROW extern void *je_malloc(size_t size);
+  FEX_DEFAULT_VISIBILITY JEMALLOC_NOTHROW extern void *je_calloc(size_t n, size_t size);
+  FEX_DEFAULT_VISIBILITY JEMALLOC_NOTHROW extern void *je_memalign(size_t align, size_t s);
+  FEX_DEFAULT_VISIBILITY JEMALLOC_NOTHROW extern void *je_valloc(size_t size);
+  FEX_DEFAULT_VISIBILITY JEMALLOC_NOTHROW extern int je_posix_memalign(void** r, size_t a, size_t s);
+  FEX_DEFAULT_VISIBILITY JEMALLOC_NOTHROW extern void *je_realloc(void* ptr, size_t size);
+  FEX_DEFAULT_VISIBILITY JEMALLOC_NOTHROW extern void je_free(void* ptr);
+  FEX_DEFAULT_VISIBILITY JEMALLOC_NOTHROW extern size_t je_malloc_usable_size(void *ptr);
+  FEX_DEFAULT_VISIBILITY JEMALLOC_NOTHROW extern void *je_aligned_alloc(size_t a, size_t s);
+#undef JEMALLOC_NOTHROW
+#endif
+}
 
 namespace FEXCore::Allocator {
   using MMAP_Hook = void*(*)(void*, size_t, int, int, int, off_t);
   using MUNMAP_Hook = int(*)(void*, size_t);
 
-  using MALLOC_Hook = void *(*)(size_t);
-  using CALLOC_Hook = void *(*)(size_t, size_t);
-  using MEMALIGN_Hook = void *(*)(size_t, size_t);
-  using VALLOC_Hook = void *(*)(size_t);
-  using POSIX_MEMALIGN_Hook = int (*)(void**, size_t, size_t);
-  using REALLOC_Hook = void *(*)(void*, size_t);
-  using FREE_Hook = void(*)(void*);
-  using MALLOC_USABLE_SIZE_Hook = size_t (*)(void*);
-  using ALIGNED_ALLOC_Hook = void *(*)(size_t, size_t);
-
   FEX_DEFAULT_VISIBILITY extern MMAP_Hook mmap;
   FEX_DEFAULT_VISIBILITY extern MUNMAP_Hook munmap;
-  FEX_DEFAULT_VISIBILITY extern MALLOC_Hook malloc;
-  FEX_DEFAULT_VISIBILITY extern CALLOC_Hook calloc;
-  FEX_DEFAULT_VISIBILITY extern MEMALIGN_Hook memalign;
-  FEX_DEFAULT_VISIBILITY extern VALLOC_Hook valloc;
-  FEX_DEFAULT_VISIBILITY extern POSIX_MEMALIGN_Hook posix_memalign;
-  FEX_DEFAULT_VISIBILITY extern REALLOC_Hook realloc;
-  FEX_DEFAULT_VISIBILITY extern FREE_Hook free;
-  FEX_DEFAULT_VISIBILITY extern MALLOC_USABLE_SIZE_Hook malloc_usable_size;
-  FEX_DEFAULT_VISIBILITY extern ALIGNED_ALLOC_Hook aligned_alloc;
+
+  // Memory allocation routines aliased to jemalloc functions.
+#ifdef ENABLE_JEMALLOC
+  inline void *malloc(size_t size) { return ::je_malloc(size); }
+  inline void *calloc(size_t n, size_t size) { return ::je_calloc(n, size); }
+  inline void *memalign(size_t align, size_t s) { return ::je_memalign(align, s); }
+  inline void *valloc(size_t size) { return ::je_valloc(size); }
+  inline int posix_memalign(void** r, size_t a, size_t s) { return ::je_posix_memalign(r, a, s); }
+  inline void *realloc(void* ptr, size_t size) { return ::je_realloc(ptr, size); }
+  inline void free(void* ptr) { return ::je_free(ptr); }
+  inline size_t malloc_usable_size(void *ptr) { return ::je_malloc_usable_size(ptr); }
+  inline void *aligned_alloc(size_t a, size_t s) { return ::je_aligned_alloc(a, s); }
+#else
+  inline void *malloc(size_t size) { return ::malloc(size); }
+  inline void *calloc(size_t n, size_t size) { return ::calloc(n, size); }
+  inline void *memalign(size_t align, size_t s) { return ::memalign(align, s); }
+  inline void *valloc(size_t size) { return ::valloc(size); }
+  inline int posix_memalign(void** r, size_t a, size_t s) { return ::posix_memalign(r, a, s); }
+  inline void *realloc(void* ptr, size_t size) { return ::realloc(ptr, size); }
+  inline void free(void* ptr) { return ::free(ptr); }
+  inline size_t malloc_usable_size(void *ptr) { return ::malloc_usable_size(ptr); }
+  inline void *aligned_alloc(size_t a, size_t s) { return ::aligned_alloc(a, s); }
+#endif
 
   struct FEXAllocOperators {
     FEXAllocOperators() = default;


### PR DESCRIPTION
Every time we are calling a function in `FEXCore::Allocator::` this is a
pointer indirection. Which means on x86 it is always a `call [rdi]` and
on AArch64 it is a `ldr x17, [x0]; blr x17;`.

Instead of doing this, use inline functions in the header that call the
correct allocation function directly. This function gets inlined and is
no longer an indirect call.

When compiling with jemalloc, we forward declare the jemalloc function
definitions so we don't have to pull in the entire jemalloc interface in
to the public header definitions.