### PR TITLE
Allocator: Disable glibc sbrk allocations

### DIFF
--- a/External/FEXCore/Source/Utils/Allocator.cpp
+++ b/External/FEXCore/Source/Utils/Allocator.cpp
@@ -2,6 +2,7 @@
 #include <FEXCore/Utils/Allocator.h>
 #include <FEXCore/Utils/CompilerDefs.h>
 #include <FEXCore/Utils/LogManager.h>
+#include <FEXCore/fextl/fmt.h>
 #include <FEXCore/fextl/memory_resource.h>
 #include <FEXHeaderUtils/Syscalls.h>
 #include <FEXHeaderUtils/TypeDefines.h>
@@ -89,6 +90,52 @@ namespace FEXCore::Allocator {
       return -1;
     }
     return Result;
+  }
+
+  // This function disables glibc's ability to allocate memory through the `sbrk` interface.
+  // This is run early in the lifecycle of FEX in order to make sure no 64-bit pointers can make it to the guest 32-bit application.
+  //
+  // How this works is that this allocates a single page at the current sbrk pointer (aligned upward to page size). This makes it
+  // so that when the sbrk syscall is used to allocate more memory, it fails with an ENOMEM since it runs in to the allocated guard page.
+  //
+  // glibc notices the sbrk failure and falls back to regular mmap based allocations when this occurs. Ensuring that memory can still be allocated.
+  void *DisableSBRKAllocations() {
+    void* INVALID_PTR = reinterpret_cast<void*>(~0ULL);
+    // Get the starting sbrk pointer.
+    void *StartingSBRK = sbrk(0);
+    if (StartingSBRK == INVALID_PTR) {
+      // If sbrk is already returning invalid pointers then nothing to do here.
+      return INVALID_PTR;
+    }
+
+    // Now allocate the next page after the sbrk address to ensure it can't grow.
+    // In most cases at the start of `main` this will already be page aligned, which means subsequent `sbrk`
+    // calls won't allocate any memory through that.
+    void* AlignedBRK = reinterpret_cast<void*>(FEXCore::AlignUp(reinterpret_cast<uintptr_t>(StartingSBRK), FHU::FEX_PAGE_SIZE));
+    void *AfterBRK = mmap(AlignedBRK, FHU::FEX_PAGE_SIZE, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED_NOREPLACE | MAP_NORESERVE, -1, 0);
+    if (AfterBRK == INVALID_PTR) {
+      // Couldn't allocate the page after the aligned brk? This should never happen.
+      // FEXCore::LogMan isn't configured yet so we just need to print the message.
+      fextl::fmt::print("Couldn't allocate page after SBRK.\n");
+      FEX_TRAP_EXECUTION;
+      return INVALID_PTR;
+    }
+
+    // Now that the page after sbrk is allocated, FEX needs to consume the remaining sbrk space.
+    // This will be anywhere from [0, 4096) bytes.
+    // Start allocating from 1024 byte increments just to make any steps a bit faster.
+    intptr_t IncrementAmount = 1024;
+    for (; IncrementAmount != 0; IncrementAmount >>= 1) {
+      while (sbrk(IncrementAmount) != INVALID_PTR);
+    }
+    return AlignedBRK;
+  }
+
+  void ReenableSBRKAllocations(void* Ptr) {
+    const void* INVALID_PTR = reinterpret_cast<void*>(~0ULL);
+    if (Ptr != INVALID_PTR) {
+      munmap(Ptr, FHU::FEX_PAGE_SIZE);
+    }
   }
 
 #pragma GCC diagnostic push

--- a/External/FEXCore/include/FEXCore/Utils/Allocator.h
+++ b/External/FEXCore/include/FEXCore/Utils/Allocator.h
@@ -59,6 +59,13 @@ namespace FEXCore::Allocator {
   };
 #endif
 
+  // Disable allocations through glibc's sbrk allocation method.
+  // Returns a pointer at the end of the sbrk region.
+  FEX_DEFAULT_VISIBILITY void *DisableSBRKAllocations();
+
+  // Allow sbrk again. Pass in the pointer returned by `DisableSBRKAllocations`
+  FEX_DEFAULT_VISIBILITY void ReenableSBRKAllocations(void* Ptr);
+
   struct MemoryRegion {
     void *Ptr;
     size_t Size;

--- a/Source/Tests/FEXLoader.cpp
+++ b/Source/Tests/FEXLoader.cpp
@@ -199,6 +199,7 @@ bool IsInterpreterInstalled() {
 }
 
 int main(int argc, char **argv, char **const envp) {
+  auto SBRKPointer = FEXCore::Allocator::DisableSBRKAllocations();
   FEXCore::Allocator::GLIBCScopedFault GLIBFaultScope;
   const bool IsInterpreter = RanAsInterpreter(argv[0]);
 
@@ -530,6 +531,8 @@ int main(int argc, char **argv, char **const envp) {
   // Allocator is now original system allocator
   FEXCore::Telemetry::Shutdown(Program.ProgramName);
   FEXCore::Profiler::Shutdown();
+
+  FEXCore::Allocator::ReenableSBRKAllocations(SBRKPointer);
 
   if (ShutdownReason == FEXCore::Context::ExitReason::EXIT_SHUTDOWN) {
     return ProgramStatus;

--- a/Source/Tests/TestHarnessRunner.cpp
+++ b/Source/Tests/TestHarnessRunner.cpp
@@ -115,6 +115,7 @@ private:
 }
 
 int main(int argc, char **argv, char **const envp) {
+  auto SBRKPointer = FEXCore::Allocator::DisableSBRKAllocations();
   FEXCore::Allocator::GLIBCScopedFault GLIBFaultScope;
   LogMan::Throw::InstallHandler(AssertHandler);
   LogMan::Msg::InstallHandler(MsgHandler);
@@ -260,6 +261,9 @@ int main(int argc, char **argv, char **const envp) {
   LogMan::Msg::UnInstallHandlers();
 
   FEXCore::Allocator::ClearHooks();
+
+  FEXCore::Allocator::ReenableSBRKAllocations(SBRKPointer);
+
   return Passed ? 0 : -1;
 }
 


### PR DESCRIPTION
This is done by consuming a single page at the end of the current sbrk memory region. Then consuming any remaining bytes that could have potentially ended up in it.

This ensures that glibc won't be able to return 64-bit pointers to 32-bit thunks once the remaining work is in place.

This can be merged independently of the other pull requests.