### PR TITLE
Update drm headers to v6.2

### DIFF
--- a/Scripts/StructPackVerifier.py
+++ b/Scripts/StructPackVerifier.py
@@ -400,7 +400,8 @@ def HandleTypeDefDecl(Arch, Cursor, Name):
             Arch = HandleTypeDefDeclCursor(Arch, Child)
         elif (Child.kind == CursorKind.TYPE_REF or
               Child.kind == CursorKind.NAMESPACE_REF or
-              Child.kind == CursorKind.TEMPLATE_REF):
+              Child.kind == CursorKind.TEMPLATE_REF or
+              Child.kind == CursorKind.ALIGNED_ATTR):
             # Safe to pass on
             pass
         else:

--- a/Source/Tools/FEXLoader/LinuxSyscalls/x32/Ioctl/drm.h
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/x32/Ioctl/drm.h
@@ -7,6 +7,9 @@
 
 #include <cstdint>
 extern "C" {
+// drm headers use a `__user` define that has an address_space attribute. This allows their tooling to see unsafe user-space accesses.
+// Define this to nothing so we don't need to modify those headers.
+#define __user
 #include "fex-drm/drm.h"
 #include "fex-drm/drm_mode.h"
 #include "fex-drm/i915_drm.h"


### PR DESCRIPTION
Nothing here that changes anything really. Just need to handle `__user` define and a new Aligned Attribute for clang.
i915 still has some changes that we might not be picking up, but that is a known issue and considering i915 doesn't compile on non-x86 platforms I'm inclined to not care.

No uapi changes otherwise.