### PR TITLE
fextl::fmt: Remove fwrite usage

### DIFF
--- a/External/FEXCore/include/FEXCore/fextl/fmt.h
+++ b/External/FEXCore/include/FEXCore/fextl/fmt.h
@@ -42,7 +42,7 @@ namespace fextl::fmt {
   FMT_INLINE auto print(::fmt::format_string<T...> fmt, T&&... args)
       -> void {
     auto String = fextl::fmt::vformat(fmt, ::fmt::make_format_args(args...));
-    std::fwrite(String.c_str(), sizeof(typename decltype(String)::value_type), String.size(), stdout);
+    write(STDOUT_FILENO, String.c_str(), String.size());
   }
 
   template <typename... T>
@@ -56,6 +56,6 @@ namespace fextl::fmt {
   FMT_INLINE auto print(std::FILE* f, ::fmt::format_string<T...> fmt, T&&... args)
       -> void {
     auto String = fextl::fmt::vformat(fmt, ::fmt::make_format_args(args...));
-    std::fwrite(String.c_str(), sizeof(typename decltype(String)::value_type), String.size(), f);
+    write(fileno(f), String.c_str(), String.size());
   }
 }


### PR DESCRIPTION
fwrite allocates some backing memory for buffering outputs which FEX can't track.

Switch to using `fileno` to get the fd from the FILE and write directly. This will need to be changed for llvm-mingw support but that will come after this.

This will be added to the documentation that we can't use fwrite.