### PR TITLE
StringConv: Convert to conversion functions that don't use std::string

### DIFF
--- a/External/FEXCore/Source/Common/StringConv.h
+++ b/External/FEXCore/Source/Common/StringConv.h
@@ -7,32 +7,32 @@
 
 namespace FEXCore::StrConv {
   [[maybe_unused]] static bool Conv(std::string_view Value, bool *Result) {
-    *Result = std::stoull(Value.data(), nullptr, 0);
+    *Result = std::strtoull(Value.data(), nullptr, 0);
     return true;
   }
 
   [[maybe_unused]] static bool Conv(std::string_view Value, uint8_t *Result) {
-    *Result = std::stoul(Value.data(), nullptr, 0);
+    *Result = std::strtoul(Value.data(), nullptr, 0);
     return true;
   }
 
   [[maybe_unused]] static bool Conv(std::string_view Value, uint16_t *Result) {
-    *Result = std::stoul(Value.data(), nullptr, 0);
+    *Result = std::strtoul(Value.data(), nullptr, 0);
     return true;
   }
 
   [[maybe_unused]] static bool Conv(std::string_view Value, uint32_t *Result) {
-    *Result = std::stoul(Value.data(), nullptr, 0);
+    *Result = std::strtoul(Value.data(), nullptr, 0);
     return true;
   }
 
   [[maybe_unused]] static bool Conv(std::string_view Value, int32_t *Result) {
-    *Result = std::stol(Value.data(), nullptr, 0);
+    *Result = std::strtol(Value.data(), nullptr, 0);
     return true;
   }
 
   [[maybe_unused]] static bool Conv(std::string_view Value, uint64_t *Result) {
-    *Result = std::stoull(Value.data(), nullptr, 0);
+    *Result = std::strtoull(Value.data(), nullptr, 0);
     return true;
   }
   template <typename T,


### PR DESCRIPTION
`std::stoul` and `std::stroull` take a std::string which was converting the string_view to a std::string first. Causing glibc fault testing to catch this since not much uses this.

These will be added to the documentation.