### PR TITLE
FEXServerClient: Insert missing padding in message packet

### DIFF
--- a/Source/Common/FEXServerClient.h
+++ b/Source/Common/FEXServerClient.h
@@ -126,6 +126,7 @@ namespace FEXServerClient {
       PacketHeader Header{};
       size_t MessageLength;
       uint32_t Level{};
+      uint32_t Pad{};
     };
 
     static_assert(sizeof(PacketHeader) == 24, "Wrong size");


### PR DESCRIPTION
This was sending uninitialized data across the wire.