### PR TITLE
StringUtils: Stop allocating TrimTokens

### DIFF
--- a/External/FEXCore/Source/Common/StringUtils.h
+++ b/External/FEXCore/Source/Common/StringUtils.h
@@ -3,7 +3,7 @@
 
 namespace FEXCore::StringUtils {
   // Trim the left side of the string of whitespace and new lines
-  [[maybe_unused]] static fextl::string LeftTrim(fextl::string String, fextl::string TrimTokens = " \t\n\r") {
+  [[maybe_unused]] static fextl::string LeftTrim(fextl::string String, std::string_view TrimTokens = " \t\n\r") {
     size_t pos = fextl::string::npos;
     if ((pos = String.find_first_not_of(TrimTokens)) != fextl::string::npos) {
       String.erase(0, pos);
@@ -13,7 +13,7 @@ namespace FEXCore::StringUtils {
   }
 
   // Trim the right side of the string of whitespace and new lines
-  [[maybe_unused]] static fextl::string RightTrim(fextl::string String, fextl::string TrimTokens = " \t\n\r") {
+  [[maybe_unused]] static fextl::string RightTrim(fextl::string String, std::string_view TrimTokens = " \t\n\r") {
     size_t pos = fextl::string::npos;
     if ((pos = String.find_last_not_of(TrimTokens)) != fextl::string::npos) {
       String.erase(String.begin() + pos + 1, String.end());
@@ -23,8 +23,8 @@ namespace FEXCore::StringUtils {
   }
 
   // Trim both the left and right of the string of whitespace and new lines
-  [[maybe_unused]] static fextl::string Trim(fextl::string String, fextl::string TrimTokens = " \t\n\r") {
-    return RightTrim(LeftTrim(String, TrimTokens), TrimTokens);
+  [[maybe_unused]] static fextl::string Trim(fextl::string String, std::string_view TrimTokens = " \t\n\r") {
+    return RightTrim(LeftTrim(std::move(String), TrimTokens), TrimTokens);
   }
 
 }


### PR DESCRIPTION
Use a string_view instead of a fextl::string so this stops allocating memory (stack in the cases I have seen).

Fixes #2562