### PR TITLE
FEXLoader: Don't build with mingw

### DIFF
--- a/Source/Tools/CMakeLists.txt
+++ b/Source/Tools/CMakeLists.txt
@@ -19,9 +19,8 @@ if (NOT MINGW_BUILD)
   add_subdirectory(FEXGetConfig/)
   add_subdirectory(FEXServer/)
   add_subdirectory(FEXBash/)
+  add_subdirectory(FEXLoader/)
 endif()
-
-add_subdirectory(FEXLoader/)
 
 set(NAME Opt)
 set(SRCS Opt.cpp)


### PR DESCRIPTION
FEXLoader won't ever work in this configuration. This was a mistake to enable.