### PR TITLE
gvisor: Disable timerfd test

### DIFF
--- a/unittests/gvisor-tests/Disabled_Tests
+++ b/unittests/gvisor-tests/Disabled_Tests
@@ -194,3 +194,8 @@ semaphore_test
 # Since we are running these tests on a fully loaded system, we tend to context switch,
 # causing the chance of a hang to occur quite frequently.
 pselect_test
+
+# Somewhere between kernel versions 5.15 and 6.0, timerfd lseek behaviour has changed.
+# On older kernels it would return -ESPIPE, on new kernels it returns 0.
+# This test expects -ESPIPE behaviour.
+timerfd_test

--- a/unittests/gvisor-tests/Known_Failures
+++ b/unittests/gvisor-tests/Known_Failures
@@ -220,3 +220,8 @@ semaphore_test
 # Since we are running these tests on a fully loaded system, we tend to context switch,
 # causing the chance of a hang to occur quite frequently.
 pselect_test
+
+# Somewhere between kernel versions 5.15 and 6.0, timerfd lseek behaviour has changed.
+# On older kernels it would return -ESPIPE, on new kernels it returns 0.
+# This test expects -ESPIPE behaviour.
+timerfd_test


### PR DESCRIPTION
Somewhere between kernel 5.15 and 6.0 this syscall's behaviour has changed.
The unit test expects -ESPIPE result but new kernels will return 0 (noop_llseek in the source).

The new solidrun board is our first CI machine to be running kernel 6.1 so this needs to be merged before that CI machine can be enabled.