### PR TITLE
AllocatorHooks: Adds some mingw allocator helpers

### DIFF
--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -368,8 +368,8 @@ namespace FEXCore::Context {
       }
     }
 
-    FEXCore::Utils::PooledAllocatorMMap OpDispatcherAllocator;
-    FEXCore::Utils::PooledAllocatorMMap FrontendAllocator;
+    FEXCore::Utils::PooledAllocatorVirtual OpDispatcherAllocator;
+    FEXCore::Utils::PooledAllocatorVirtual FrontendAllocator;
 
     bool IsTSOEnabled() { return (IsMemoryShared || !Config.TSOAutoMigration) && Config.TSOEnabled; }
 

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
@@ -1,4 +1,5 @@
 #include "Interface/Core/ArchHelpers/Arm64Emitter.h"
+#include "FEXCore/Utils/AllocatorHooks.h"
 #include "Interface/Core/ArchHelpers/CodeEmitter/Emitter.h"
 #include "Interface/Core/Dispatcher/Dispatcher.h"
 #include "Interface/Context/Context.h"
@@ -22,7 +23,7 @@ namespace FEXCore::CPU {
 
 // We want vixl to not allocate a default buffer. Jit and dispatcher will manually create one.
 Arm64Emitter::Arm64Emitter(FEXCore::Context::ContextImpl *ctx, size_t size)
-  : Emitter(size ? (uint8_t*)FEXCore::Allocator::mmap(nullptr, size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0) : nullptr, size)
+  : Emitter(size ? (uint8_t*)FEXCore::Allocator::VirtualAlloc(size, true) : nullptr, size)
   , EmitterCTX {ctx} {
   CPU.SetUp();
 
@@ -50,7 +51,7 @@ Arm64Emitter::Arm64Emitter(FEXCore::Context::ContextImpl *ctx, size_t size)
 Arm64Emitter::~Arm64Emitter() {
   auto BufferSize = GetBufferSize();
   if (BufferSize) {
-    FEXCore::Allocator::munmap(GetBufferBase(), BufferSize);
+    FEXCore::Allocator::VirtualFree(GetBufferBase(), BufferSize);
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/CPUBackend.cpp
+++ b/External/FEXCore/Source/Interface/Core/CPUBackend.cpp
@@ -1,3 +1,4 @@
+#include "FEXCore/Utils/AllocatorHooks.h"
 #include "Interface/Context/Context.h"
 #include "Interface/Core/Dispatcher/Dispatcher.h"
 #include <FEXCore/Core/CPUBackend.h>
@@ -57,7 +58,7 @@ auto CPUBackend::AllocateNewCodeBuffer(size_t Size) -> CodeBuffer {
   CodeBuffer Buffer;
   Buffer.Size = Size;
   Buffer.Ptr = static_cast<uint8_t *>(
-      FEXCore::Allocator::mmap(nullptr, Buffer.Size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+      FEXCore::Allocator::VirtualAlloc(Buffer.Size, true));
   LOGMAN_THROW_AA_FMT(!!Buffer.Ptr, "Couldn't allocate code buffer");
 
   if (static_cast<Context::ContextImpl*>(ThreadState->CTX)->Config.GlobalJITNaming()) {
@@ -67,7 +68,7 @@ auto CPUBackend::AllocateNewCodeBuffer(size_t Size) -> CodeBuffer {
 }
 
 void CPUBackend::FreeCodeBuffer(CodeBuffer Buffer) {
-  FEXCore::Allocator::munmap(Buffer.Ptr, Buffer.Size);
+  FEXCore::Allocator::VirtualFree(Buffer.Ptr, Buffer.Size);
 }
 
 bool CPUBackend::IsAddressInCodeBuffer(uintptr_t Address) const {

--- a/External/FEXCore/Source/Utils/Allocator.cpp
+++ b/External/FEXCore/Source/Utils/Allocator.cpp
@@ -8,12 +8,14 @@
 #include <FEXHeaderUtils/TypeDefines.h>
 
 #include <array>
-#include <asm-generic/errno-base.h>
 #include <cctype>
 #include <cstdio>
 #include <fcntl.h>
+#ifndef _WIN32
 #include <sys/mman.h>
 #include <sys/user.h>
+#endif
+
 #ifdef ENABLE_JEMALLOC
 #include <jemalloc/jemalloc.h>
 #endif
@@ -41,6 +43,7 @@ namespace fextl::pmr {
   }
 }
 
+#ifndef _WIN32
 namespace FEXCore::Allocator {
   MMAP_Hook mmap {::mmap};
   MUNMAP_Hook munmap {::munmap};
@@ -338,3 +341,4 @@ namespace FEXCore::Allocator {
     }
   }
 }
+#endif

--- a/External/FEXCore/include/FEXCore/Utils/ThreadPoolAllocator.h
+++ b/External/FEXCore/include/FEXCore/Utils/ThreadPoolAllocator.h
@@ -8,7 +8,6 @@
 #include <chrono>
 #include <cstddef>
 #include <mutex>
-#include <sys/mman.h>
 
 namespace FEXCore::Utils {
   /**
@@ -353,22 +352,21 @@ namespace FEXCore::Utils {
   /**
    * @brief Thread pool allocator that allocates and frees objects that uses mmap
    */
-  class PooledAllocatorMMap final : public IntrusivePooledAllocator {
+  class PooledAllocatorVirtual final : public IntrusivePooledAllocator {
     public:
-      PooledAllocatorMMap() = default;
+      PooledAllocatorVirtual() = default;
 
-      virtual ~PooledAllocatorMMap() {
+      virtual ~PooledAllocatorVirtual() {
         FreeAllBuffers();
       }
 
     private:
       void *Alloc(size_t Size) override {
-        return FEXCore::Allocator::mmap(0, Size,
-          PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        return FEXCore::Allocator::VirtualAlloc(Size);
       }
 
       void Free(void* Ptr, size_t Size) override {
-        FEXCore::Allocator::munmap(Ptr, Size);
+        FEXCore::Allocator::VirtualFree(Ptr, Size);
       }
   };
 


### PR DESCRIPTION
Most cases of direct mmap are just there for virtual memory allocation reasons. We don't usually care about mapping files or other extended behaviour.
Also disables the signal safe compiling with Mingw in the x86Dispatcher as a bonus. 