### PR TITLE
OpcodeDispatcher: Handle PCMPESTRI/VPCMPESTRI

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/F80Ops.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/F80Ops.cpp
@@ -417,6 +417,23 @@ DEF_OP(F64SCALE) {
   memcpy(GDP, &Tmp, sizeof(double));
 }
 
+DEF_OP(VPCMPESTRX) {
+  const auto Op = IROp->C<IR::IROp_VPCMPESTRX>();
+  const auto Is64Bit = Op->GPRSize == 8;
+
+  const auto RAX = *GetSrc<uint64_t*>(Data->SSAData, Op->RAX);
+  const auto RDX = *GetSrc<uint64_t*>(Data->SSAData, Op->RDX);;
+  const auto LHS = *GetSrc<__uint128_t*>(Data->SSAData, Op->LHS);
+  const auto RHS = *GetSrc<__uint128_t*>(Data->SSAData, Op->RHS);
+
+  // We can be cheeky and encode the size at bit 8 to save a parameter
+  const auto Control = Op->Control | (uint16_t(Is64Bit) << 8);
+
+  const auto Result = OpHandlers<IR::OP_VPCMPESTRX>::handle(RAX, RDX, LHS, RHS, Control);
+
+  memset(GDP, 0, sizeof(uint64_t));
+  memcpy(GDP, &Result, sizeof(Result));
+}
 
 #undef DEF_OP
 

--- a/External/FEXCore/Source/Interface/Core/Interpreter/F80Ops.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/F80Ops.h
@@ -395,5 +395,348 @@ struct OpHandlers<IR::OP_F80LOADFCW> {
   }
 };
 
+template<>
+struct OpHandlers<IR::OP_VPCMPESTRX> {
+  enum class AggregationOp {
+    EqualAny     = 0b00,
+    Ranges       = 0b01,
+    EqualEach    = 0b10,
+    EqualOrdered = 0b11,
+  };
+
+  enum class SourceData {
+    U8,
+    U16,
+    S8,
+    S16,
+  };
+
+  enum class Polarity {
+    Positive,
+    Negative,
+    PositiveMasked,
+    NegativeMasked,
+  };
+
+  static uint32_t handle(uint64_t RAX, uint64_t RDX, __uint128_t lhs, __uint128_t rhs, uint16_t control) {
+    // Subtract by 1 in order to make validity limits 0-based
+    const auto valid_lhs = GetExplicitLength(RAX, control) - 1;
+    const auto valid_rhs = GetExplicitLength(RDX, control) - 1;
+
+    return MainBody(lhs, valid_lhs, rhs, valid_rhs, control);
+  }
+
+  // Main PCMPXSTRX algorithm body. Allows for reuse with both implicit and explicit length variants.
+  static uint32_t MainBody(const __uint128_t& lhs, int valid_lhs, const __uint128_t& rhs, int valid_rhs, uint16_t control) {
+    const uint32_t aggregation = PerformAggregation(lhs, valid_lhs, rhs, valid_rhs, control);
+    const uint32_t upper_limit = (16U >> (control & 1)) - 1;
+
+    // Bits are arranged as:
+    // Bit #:   3    2    1    0
+    //         [OF | CF | SF | ZF]
+    uint32_t flags = 0;
+    flags |= (valid_rhs < upper_limit) ? 0b01 : 0b00;
+    flags |= (valid_lhs < upper_limit) ? 0b10 : 0b00;
+
+    const uint32_t result = HandlePolarity(aggregation, control, upper_limit, valid_rhs);
+    if (result != 0) {
+      flags |= 0b0100;
+    }
+    if ((result & 1) != 0) {
+      flags |= 0b1000;
+    }
+
+    // We tack the flags on top of the result to avoid needing to handle
+    // multiple return values in the JITs.
+    return result | (flags << 16);
+  }
+
+  static int32_t GetExplicitLength(uint64_t reg, uint16_t control) {
+    // Bit 8 controls whether or not the reg value is 64-bit or 32-bit.
+    int64_t value = 0;
+    if (((control >> 8) & 1) != 0) {
+      value = static_cast<int64_t>(reg);
+    } else {
+      // We need a sign extend in this case.
+      value = static_cast<int32_t>(reg);
+    }
+
+    // If control[0] is set, then we're dealing with words instead of bytes
+    const int64_t limit = (control & 1) != 0 ? 8 : 16;
+
+    // Length needs to saturate to 16 (if bytes) or 8 (if words)
+    // when the length value is greater than 16 (if bytes)/8 (if words)
+    // or if the length value is less than -16 (if bytes)/-8 (if words).
+    if (value < -limit || value > limit) {
+      return limit;
+    }
+
+    return std::abs(static_cast<int>(value));
+  }
+
+  static int32_t GetElement(const __uint128_t& vec, int32_t index, uint16_t control) {
+    const auto* vec_ptr = reinterpret_cast<const uint8_t*>(&vec);
+
+    // Control bits [1:0] define the data type being dealt with.
+    switch (static_cast<SourceData>(control & 0b11)) {
+    case SourceData::U8:
+      return static_cast<int32_t>(vec_ptr[index]);
+    case SourceData::U16: {
+      uint16_t value{};
+      std::memcpy(&value, vec_ptr + (sizeof(uint16_t) * static_cast<size_t>(index)), sizeof(value));
+      return value;
+    }
+    case SourceData::S8:
+      return static_cast<int8_t>(vec_ptr[index]);
+    case SourceData::S16:
+    default: {
+      int16_t value{};
+      std::memcpy(&value, vec_ptr + (sizeof(int16_t) * static_cast<size_t>(index)), sizeof(value));
+      return value;
+    }
+    }
+  }
+
+  static uint32_t PerformAggregation(const __uint128_t& lhs, int32_t valid_lhs,
+                                     const __uint128_t& rhs, int32_t valid_rhs,
+                                     uint16_t control) {
+    switch (static_cast<AggregationOp>((control >> 2) & 0b11)) {
+    case AggregationOp::EqualAny:
+      return HandleEqualAny(lhs, valid_lhs, rhs, valid_rhs, control);
+    case AggregationOp::Ranges:
+      return HandleRanges(lhs, valid_lhs, rhs, valid_rhs, control);
+    case AggregationOp::EqualEach:
+      return HandleEqualEach(lhs, valid_lhs, rhs, valid_rhs, control);
+    case AggregationOp::EqualOrdered:
+    default:
+      return HandleEqualOrdered(lhs, valid_lhs, rhs, valid_rhs, control);
+    }
+  }
+
+  static uint32_t HandlePolarity(uint32_t value, uint16_t control, int upper_limit, int valid_rhs) {
+    switch (static_cast<Polarity>((control >> 4) & 0b11)) {
+      case Polarity::Negative:
+        return value ^ ((2U << upper_limit) - 1);
+      case Polarity::NegativeMasked:
+        return value ^ ((1U << (valid_rhs + 1)) - 1);
+      case Polarity::Positive:
+      case Polarity::PositiveMasked:
+      default:
+        // Both positive masking and positive polarity are documented
+        // as both being equivalent to "IntRes2 = IntRes1", where IntRes1
+        // is our 'value' parameter, so we don't need to do anything in
+        // these cases except return the same value.
+        return value;
+    }
+  }
+
+  // Finds characters from an overall character set.
+  //
+  // Scans through RHS trying to find any characters contained in LHS.
+  // Think of this as a sort of vectorized version of strspn (kind of).
+  //
+  // e.g. Assume operating on two character vectors as unsigned words
+  //
+  //         0  1  2  3  4  5  6  7
+  // LHS -> [a, b, c, d, e, f, g, n]
+  // RHS -> [z, k, v, c, d, o, p, n]
+  //
+  // With both explicit lengths for each string being 8 (the max length for words),
+  // this would result in an intermediate result like:
+  //
+  //            0b1001'1000
+  //              │  │ │
+  // 'n' match ───┘  │ │
+  //                 │ │
+  // 'd' match ──────┘ │
+  //                   │
+  // 'c' match ────────┘
+  //
+  static uint32_t HandleEqualAny(const __uint128_t& lhs, int32_t valid_lhs,
+                                 const __uint128_t& rhs, int32_t valid_rhs,
+                                 uint16_t control) {
+    uint32_t result = 0;
+
+    for (int j = valid_rhs; j >= 0; j--) {
+      result <<= 1;
+
+      const int rhs_value = GetElement(rhs, j, control);
+      for (int i = valid_lhs; i >= 0; i--) {
+        const int lhs_value = GetElement(lhs, i, control);
+        result |= static_cast<uint32_t>(rhs_value == lhs_value);
+      }
+    }
+
+    return result;
+  }
+
+  // Determines if a character falls within a limited range
+  //
+  // Scans through rhs using a range denoted by two elements
+  // in lhs and determines if the respective character in rhs
+  // falls within its range.
+  //
+  // i.e.
+  //      lhs_upper_bound >= rhs_value && lhs_lower_bound <= rhs_value
+  //
+  // e.g. Assume operating on two character vectors as unsigned words
+  //
+  //         0  1  2  3  4  5  6  7
+  // LHS -> [a, z, A, Z, 0, 0, 0, 0]
+  // RHS -> [z, k, ., C, M, ;, \, ']
+  //
+  // With LHS's length being 4 and RHS's lenth being 8,
+  // this would result in an intermediate result like:
+  //
+  //                          0b0001'1011
+  //                               │ │ ││
+  // 'z' >= 'M' && 'a' <= 'M' ─────┘ │ ││
+  //                                 │ ││
+  // 'z' >= 'C' && 'a' <= 'C' ───────┘ ││
+  //                                   ││
+  // 'Z' >= 'k' && 'A' <= 'k' ─────────┘│
+  //                                    │
+  // 'Z' >= 'z' && 'A' <= 'z' ──────────┘
+  //
+  static uint32_t HandleRanges(const __uint128_t& lhs, int32_t valid_lhs,
+                               const __uint128_t& rhs, int32_t valid_rhs,
+                               uint16_t control) {
+    uint32_t result = 0;
+
+    for (int j = valid_rhs; j >= 0; j--) {
+      result <<= 1;
+
+      const int element = GetElement(rhs, j, control);
+      for (int i = (valid_lhs - 1) | 1; i >= 0; i -= 2) {
+        const int upper_bound = GetElement(lhs, i - 0, control);
+        const int lower_bound = GetElement(lhs, i - 1, control);
+
+        const bool ge = upper_bound >= element;
+        const bool le = lower_bound <= element;
+
+        result |= static_cast<uint32_t>(ge && le);
+      }
+    }
+
+    return result;
+  }
+
+  // Determines if each character is equal to one another (string compare)
+  //
+  // Essentially the PCMPXSTRX variant of memcmp/strcmp. Sets the bit of the
+  // resulting mask if both elements are equal to one another. Otherwise
+  // sets it to false.
+  //
+  // e.g. Assume operating on two character vectors as unsigned words
+  //
+  //         0  1  2  3  4  5  6  7
+  // LHS -> [a, b, c, d, e, f, g, n]
+  // RHS -> [a, b, c, d, e, f, e, x]
+  //
+  // With both explicit lengths for each string being 8 (the max length for words),
+  // this would result in an intermediate result like:
+  //
+  //            0b0011'1111
+  //                ││ ││││
+  // 'f' == 'f' ────┘│ ││││
+  //                 │ ││││
+  // 'e' == 'e' ─────┘ ││││
+  //                   ││││
+  // 'd' == 'd' ───────┘│││
+  //                    │││
+  // 'c' == 'c' ────────┘││
+  //                     ││
+  // 'b' == 'b' ─────────┘│
+  //                      │
+  // 'a' == 'a' ──────────┘
+  //
+  static uint32_t HandleEqualEach(const __uint128_t& lhs, int32_t valid_lhs,
+                                  const __uint128_t& rhs, int32_t valid_rhs,
+                                  uint16_t control) {
+    const auto upper_limit = (16 >> (control & 1)) - 1;
+    const auto max_valid = std::max(valid_lhs, valid_rhs);
+    const auto min_valid = std::min(valid_lhs, valid_rhs);
+
+    // All values past the end of string must be forced to true.
+    // (See 4.1.6 Valid/Invalid Override of Comparisons in the Intel Software Development Manual)
+    // So we can calculate this part of the mask ahead of time and set all those to-be bits to true
+    // and then progressively shift them into place over the course of execution.
+    uint32_t result = (1U << (upper_limit - max_valid)) - 1;
+    result <<= (max_valid - min_valid);
+
+    for (int i = min_valid; i >= 0; i--) {
+      const int lhs_element = GetElement(lhs, i, control);
+      const int rhs_element = GetElement(rhs, i, control);
+
+      result <<= 1;
+      result |= static_cast<uint32_t>(lhs_element == rhs_element);
+    }
+
+    return result;
+  }
+
+  // Determines if a substring exists within an overall string
+  //
+  // Somewhat equivalent to the behavior of strstr.
+  //
+  // Sets the corresponding index in the result where a substring is found.
+  //
+  // e.g. Assume operating on two character vectors as unsigned words
+  //
+  //         0  1  2  3  4  5  6  7
+  // LHS -> [b, a, x, z, y, v, o, m]
+  // RHS -> [b, a, d, b, a, n, k, s]
+  //
+  // With the length of LHS being 2 and the length of RHS being 8, we have a composition like:
+  //
+  //      Substring to look for
+  //       ┌──┴──┐
+  // LHS -> [b, a, x, z, y, v, o, m]
+  // RHS -> [b, a, d, b, a, n, k, s]
+  //       └───────────┬────────────┘
+  //         Entire string to search
+  //
+  // And we end up with a result like:
+  //
+  //            0b0000'1001
+  //                   │  │
+  // At index 3 ───────┘  │
+  //                      │
+  // At index 0 ──────────┘
+  //
+  static uint32_t HandleEqualOrdered(const __uint128_t& lhs, int32_t valid_lhs,
+                                     const __uint128_t& rhs, int32_t valid_rhs,
+                                     uint16_t control) {
+    const auto upper_limit = (16 >> (control & 1)) - 1;
+
+    // Edge case!
+    // If we have *no* valid characters in our inner string, then
+    // we need to return the intermediate result as
+    // 0xFF (if operating on words) or 0xFFFF (if operating on bytes)
+    if (valid_lhs == -1) {
+      return (2U << upper_limit) - 1;
+    }
+
+    uint32_t result = 0;
+    const int initial = valid_rhs == upper_limit ? valid_rhs
+                                                 : valid_rhs - valid_lhs;
+    for (int j = initial; j >= 0; j--) {
+      result <<= 1;
+
+      uint32_t value = 1;
+      const int start = std::min(valid_rhs - j, valid_lhs);
+      for (int i = start; i >= 0; i--) {
+        const int lhs_value = GetElement(lhs, i + 0, control);
+        const int rhs_value = GetElement(rhs, i + j, control);
+
+        value &= static_cast<uint32_t>(lhs_value == rhs_value);
+      }
+
+      result |= value;
+    }
+
+    return result;
+  }
+};
 
 }

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterFallbacks.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterFallbacks.cpp
@@ -87,6 +87,11 @@ FallbackInfo GetFallbackInfo(X80SoftFloat(*fn)(X80SoftFloat, X80SoftFloat), FEXC
   return {FABI_F80_F80_F80, (void*)fn, HandlerIndex};
 }
 
+template<>
+FallbackInfo GetFallbackInfo(uint32_t(*fn)(uint64_t, uint64_t, __uint128_t, __uint128_t, uint16_t), FEXCore::Core::FallbackHandlerIndex HandlerIndex) {
+  return {FABI_I32_I64_I64_I128_I128_I16, (void*)fn, HandlerIndex};
+}
+
 void InterpreterOps::FillFallbackIndexPointers(uint64_t *Info) {
   Info[Core::OPINDEX_F80LOADFCW] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80LOADFCW>::handle, Core::OPINDEX_F80LOADFCW).fn);
   Info[Core::OPINDEX_F80CVTTO_4] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80CVTTO>::handle4, Core::OPINDEX_F80CVTTO_4).fn);
@@ -144,6 +149,8 @@ void InterpreterOps::FillFallbackIndexPointers(uint64_t *Info) {
   Info[Core::OPINDEX_F64FPREM1] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F64FPREM1>::handle, Core::OPINDEX_F64FPREM1).fn);
   Info[Core::OPINDEX_F64SCALE] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F64SCALE>::handle, Core::OPINDEX_F64SCALE).fn);
 
+  // SSE4.2 string instructions
+  Info[Core::OPINDEX_VPCMPESTRX] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_VPCMPESTRX>::handle, Core::OPINDEX_VPCMPESTRX).fn);
 }
 
 bool InterpreterOps::GetFallbackHandler(IR::IROp_Header const *IROp, FallbackInfo *Info) {
@@ -301,6 +308,11 @@ bool InterpreterOps::GetFallbackHandler(IR::IROp_Header const *IROp, FallbackInf
     COMMON_F64_OP(FPREM1)
     COMMON_F64_OP(FPREM)
     COMMON_F64_OP(SCALE)
+
+    // SSE4.2 Fallbacks
+    case IR::OP_VPCMPESTRX:
+      *Info = GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_VPCMPESTRX>::handle, Core::OPINDEX_VPCMPESTRX);
+      return true;
 
     default:
       break;

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -272,6 +272,7 @@ constexpr OpHandlerArray InterpreterOpHandlers = [] {
   REGISTER_OP(VUABDL,                 VUABDL);
   REGISTER_OP(VTBL1,                  VTBL1);
   REGISTER_OP(VREV64,                 VRev64);
+  REGISTER_OP(VPCMPESTRX,             VPCMPESTRX);
 
   // Encryption ops
   REGISTER_OP(VAESIMC,                AESImc);

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
@@ -36,6 +36,7 @@ namespace FEXCore::CPU {
     FABI_I64_F80_F80,
     FABI_F80_F80,
     FABI_F80_F80_F80,
+    FABI_I32_I64_I64_I128_I128_I16,
   };
 
   struct FallbackInfo {
@@ -291,6 +292,7 @@ namespace FEXCore::CPU {
   DEF_OP(VUABDL);
   DEF_OP(VTBL1);
   DEF_OP(VRev64);
+  DEF_OP(VPCMPESTRX);
 
   ///< Encryption ops
   DEF_OP(AESImc);

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -5978,6 +5978,8 @@ void OpDispatchBuilder::InstallHostSpecificOpcodeHandlers() {
     {OPD(3, 0b01, 0x4B), 1, &OpDispatchBuilder::AVXVectorVariableBlend<8>},
     {OPD(3, 0b01, 0x4C), 1, &OpDispatchBuilder::AVXVectorVariableBlend<1>},
 
+    {OPD(3, 0b01, 0x61), 1, &OpDispatchBuilder::VPCMPESTRIOp},
+
     {OPD(3, 0b01, 0xDF), 1, &OpDispatchBuilder::VAESKeyGenAssistOp},
   };
 #undef OPD
@@ -7265,6 +7267,8 @@ constexpr uint16_t PF_F2 = 3;
     {OPD(0, PF_3A_66,   0x40), 1, &OpDispatchBuilder::DPPOp<4>},
     {OPD(0, PF_3A_66,   0x41), 1, &OpDispatchBuilder::DPPOp<8>},
     {OPD(0, PF_3A_66,   0x42), 1, &OpDispatchBuilder::MPSADBWOp},
+
+    {OPD(0, PF_3A_66,   0x61), 1, &OpDispatchBuilder::VPCMPESTRIOp},
 
     {OPD(0, PF_3A_NONE, 0xCC), 1, &OpDispatchBuilder::SHA1RNDS4Op},
   };

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -487,6 +487,8 @@ public:
 
   void VPALIGNROp(OpcodeArgs);
 
+  void VPCMPESTRIOp(OpcodeArgs);
+
   void VPERM2Op(OpcodeArgs);
   void VPERMDOp(OpcodeArgs);
   void VPERMQOp(OpcodeArgs);
@@ -852,6 +854,11 @@ private:
   OrderedNode* PALIGNROpImpl(OpcodeArgs, const X86Tables::DecodedOperand& Src1,
                              const X86Tables::DecodedOperand& Src2,
                              const X86Tables::DecodedOperand& Imm);
+
+  OrderedNode* PCMPESTRXOpImpl(OpcodeArgs,
+                               const X86Tables::DecodedOperand& Src1,
+                               const X86Tables::DecodedOperand& Src2,
+                               const X86Tables::DecodedOperand& Imm);
 
   OrderedNode* PHADDSOpImpl(OpcodeArgs, const X86Tables::DecodedOperand& Src1,
                             const X86Tables::DecodedOperand& Src2);

--- a/External/FEXCore/Source/Interface/Core/X86Tables/H0F3ATables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/H0F3ATables.cpp
@@ -45,9 +45,9 @@ void InitializeH0F3ATables(Context::OperatingMode Mode) {
     {OPD(0, PF_3A_66,   0x44), 1, X86InstInfo{"PCLMULQDQ",       TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS, 1, nullptr}},
 
     {OPD(0, PF_3A_66,   0x60), 1, X86InstInfo{"PCMPESTRM",       TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
-    {OPD(0, PF_3A_66,   0x61), 1, X86InstInfo{"PCMPESTRI",       TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
+    {OPD(0, PF_3A_66,   0x61), 1, X86InstInfo{"PCMPESTRI",       TYPE_INST, GenFlagsSizes(SIZE_128BIT, SIZE_32BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS, 1, nullptr}},
     {OPD(0, PF_3A_66,   0x62), 1, X86InstInfo{"PCMPISTRM",       TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
-    {OPD(0, PF_3A_66,   0x63), 1, X86InstInfo{"PCMPISTRI",       TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS, 1, nullptr}},
+    {OPD(0, PF_3A_66,   0x63), 1, X86InstInfo{"PCMPISTRI",       TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
 
     {OPD(0, PF_3A_NONE, 0xCC), 1, X86InstInfo{"SHA1RNDS4",       TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS, 1, nullptr}},
 

--- a/External/FEXCore/Source/Interface/Core/X86Tables/VEXTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/VEXTables.cpp
@@ -453,9 +453,9 @@ void InitializeVEXTables() {
     {OPD(3, 0b01, 0x5F), 1, X86InstInfo{"VFMSUBADDPD", TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
 
     {OPD(3, 0b01, 0x60), 1, X86InstInfo{"VPCMPESTRM", TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
-    {OPD(3, 0b01, 0x61), 1, X86InstInfo{"VPCMPESTRI", TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
+    {OPD(3, 0b01, 0x61), 1, X86InstInfo{"VPCMPESTRI", TYPE_INST, GenFlagsSizes(SIZE_128BIT, SIZE_32BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS, 1, nullptr}},
     {OPD(3, 0b01, 0x62), 1, X86InstInfo{"VPCMPISTRM", TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
-    {OPD(3, 0b01, 0x63), 1, X86InstInfo{"VPCMPISTRI", TYPE_INST, FLAGS_MODRM | FLAGS_XMM_FLAGS, 1, nullptr}},
+    {OPD(3, 0b01, 0x63), 1, X86InstInfo{"VPCMPISTRI", TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
 
     {OPD(3, 0b01, 0x68), 1, X86InstInfo{"VFMADDPS", TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
     {OPD(3, 0b01, 0x69), 1, X86InstInfo{"VFMADDPD", TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -1395,6 +1395,19 @@
                  "If the bit in the field is 0 then the corresponding bit is pulled from VectorFalse"
                 ],
         "DestSize": "RegisterSize"
+      },
+
+      "GPR = VPCMPESTRX u8:$GPRSize, FPR:$LHS, FPR:$RHS, GPR:$RAX, GPR:$RDX, u8:$Control": {
+        "Desc": ["Performs intermediate behavior analogous to the x86 PCMPESTRI/PCMPESTRM instruction",
+                 "This will return the intermediate result of a PCMPESTR-type operation, but NOT the final",
+                 "result. This must be derived from the intermediate result",
+
+                 "NOTE: On top of returning the intermediate result, the returned value also combines the status",
+                 "flags into the upper 16-bits of the 32-bit result, as these can also be derived over the",
+                 "course of creating the intermediate result"
+                ],
+        "HasSideEffects": true,
+        "DestSize": "4"
       }
     },
     "Conv": {

--- a/External/FEXCore/include/FEXCore/Core/CoreState.h
+++ b/External/FEXCore/include/FEXCore/Core/CoreState.h
@@ -125,6 +125,10 @@ namespace FEXCore::Core {
     OPINDEX_F64FPREM,
     OPINDEX_F64FPREM1,
     OPINDEX_F64SCALE,
+
+    // SSE4.2 string instructions
+    OPINDEX_VPCMPESTRX,
+
     // Maximum
     OPINDEX_MAX,
   };

--- a/unittests/ASM/H0F3A/pcmpestri_equal_any.asm
+++ b/unittests/ASM/H0F3A/pcmpestri_equal_any.asm
@@ -1,0 +1,153 @@
+%ifdef CONFIG
+{
+  "RegData": {
+      "RAX": ["15"],
+      "RDX": ["16"],
+      "XMM0": ["0x04070F000F000E05", "0x0000000000040404"],
+      "XMM1": ["0x0121313131311111", "0x0000000000010101"],
+      "XMM2": ["0x306F8A9E672C65E5", "0x000030443057697D"],
+      "XMM3": ["0x306F8A9E672C65E5", "0x00003044305796E3"]
+  }
+}
+%endif
+
+; Adjusts the result from LAHF and SETO so that we have a set of flags organized
+; like [OF, SF, ZF, AF, PF, CF] for storing into the .flags region
+; of memory.
+;
+; The first parameter is the byte offset to store the flag result
+; at in the .flags region of memory.
+;
+%macro ArrangeAndStoreFLAGS 1
+  lahf
+  seto bl
+  movzx bx, bl
+
+  shr ax, 8
+  shl bx, 5
+
+  mov di, ax
+  mov si, ax
+
+  ; Mask and shift
+  and di, 0b0000_0000_0000_0100 ; PF
+  and si, 0b0000_0000_0001_0000 ; AF
+  shr di, 1
+  shr si, 2
+
+  ; OR all of them together
+  or bx, di
+  or bx, si
+
+  ; Reclaim DI for getting ZF/SF and shift into place
+  mov di, ax
+  and di, 0b0000_0000_1100_0000 ; ZF and SF
+  shr di, 3
+
+  ; Finally mask and OR all of the bits together
+  and ax, 0b0000_0000_0000_0001 ; CF
+  or bx, ax
+  or bx, di
+
+  ; Store result to .flags memory
+  mov [rel .flags + %1], bl
+%endmacro
+
+; Performs the string comparison and moves the result from RCX to
+; a region of memory in the .indices section specified by a byte
+; offset.
+;
+; The first parameter is the byte offset to store the RCX result to.
+; The second parameter is the control values to pass to pcmpestri
+;
+%macro CompareAndStore 2
+  pcmpestri xmm2, xmm3, %2
+  mov [rel .indices + %1], cl
+
+  mov r15, rax
+  ArrangeAndStoreFLAGS %1
+  mov rax, r15
+%endmacro
+
+movaps xmm2, [rel .data]
+movaps xmm3, [rel .data + 32]
+
+; Unsigned byte character check (lsb, positive polarity)
+mov rax, 15 ; Exclude 'l'
+mov rdx, 16
+CompareAndStore 0, 0b00000000
+
+; Unsigned byte character check (msb, positive polarity)
+CompareAndStore 1, 0b01000000
+
+; Unsigned byte character check (lsb, negative polarity)
+CompareAndStore 2, 0b00010000
+
+; Unsigned byte character check (msb, negative polarity)
+CompareAndStore 3, 0b01010000
+
+; Unsigned byte character check (lsb, negative masked)
+CompareAndStore 4, 0b00110000
+
+; Unsigned byte character check (msb, negative masked)
+CompareAndStore 5, 0b01110000
+
+; --- 16-bit unsigned word tests ---
+movaps xmm2, [rel .data16]
+movaps xmm3, [rel .data16 + 32]
+
+; Unsigned word character check (msb, positive polarity)
+CompareAndStore 6, 0b01000001
+
+; Unsigned word character check (lsb, negative polarity)
+CompareAndStore 7, 0b00010001
+
+; Unsigned word character check (msb, negative polarity)
+CompareAndStore 8, 0b01010001
+
+; Unsigned word character check (lsb, negative masked)
+CompareAndStore 9, 0b00110001
+
+; Unsigned word character check (msb, negative masked)
+CompareAndStore 10, 0b01110001
+
+; Load all our stored indices and flags for result comparing
+movaps xmm0, [rel .indices]
+movaps xmm1, [rel .flags]
+
+hlt
+
+align 32
+.data:
+dq 0x6463626144434241 ; "ABCDabcd"
+dq 0x6C6B6A694C4B4A49 ; "IJKLijkl"
+dq 0xFFFFFFFFFFFFFFFF
+dq 0xEEEEEEEEEEEEEEEE
+
+dq 0x4120492065726548 ; "Here I A"
+dq 0x6C4C612759202C6D ; "m, Y'aLl"
+dq 0xDDDDDDDDDDDDDDDD
+dq 0xCCCCCCCCCCCCCCCC
+
+.data16:
+dq 0x306F8A9E672C65E5 ; "日本語は"
+dq 0x000030443057697D ; "楽しい\0" (Japanese is fun)
+dq 0xAAAAAAAAAAAAAAAA
+dq 0xBBBBBBBBBBBBBBBB
+
+dq 0x306F8A9E672C65E5 ; "日本語は"
+dq 0x00003044305796E3 ; "難しい\0" (Japanese is hard)
+dq 0x8888888888888888
+dq 0x9999999999999999
+
+.indices:
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+
+.flags:
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000

--- a/unittests/ASM/H0F3A/pcmpestri_equal_each.asm
+++ b/unittests/ASM/H0F3A/pcmpestri_equal_each.asm
@@ -1,0 +1,203 @@
+%ifdef CONFIG
+{
+  "RegData": {
+      "RAX": ["4"],
+      "RDX": ["3"],
+      "XMM0": ["0x0F000B060B060F00", "0x040407000F060706"],
+      "XMM1": ["0x3939010101012121", "0x0101212119191919"],
+      "XMM2": ["0x306F8A9E672C65E5", "0x000030443057697D"],
+      "XMM3": ["0x306F8A9E672C65E5", "0x00003044305796E3"],
+      "XMM4": ["0x0704030307000404", "0x0000000000000000"],
+      "XMM5": ["0x1919191939390101", "0x0000000000000000"]
+  }
+}
+%endif
+
+; Adjusts the result from LAHF and SETO so that we have a set of flags organized
+; like [OF, SF, ZF, AF, PF, CF] for storing into the .flags region
+; of memory.
+;
+; The first parameter is the byte offset to store the flag result
+; at in the .flags region of memory.
+;
+%macro ArrangeAndStoreFLAGS 1
+  lahf
+  seto bl
+  movzx bx, bl
+
+  shr ax, 8
+  shl bx, 5
+
+  mov di, ax
+  mov si, ax
+
+  ; Mask and shift
+  and di, 0b0000_0000_0000_0100 ; PF
+  and si, 0b0000_0000_0001_0000 ; AF
+  shr di, 1
+  shr si, 2
+
+  ; OR all of them together
+  or bx, di
+  or bx, si
+
+  ; Reclaim DI for getting ZF/SF and shift into place
+  mov di, ax
+  and di, 0b0000_0000_1100_0000 ; ZF and SF
+  shr di, 3
+
+  ; Finally mask and OR all of the bits together
+  and ax, 0b0000_0000_0000_0001 ; CF
+  or bx, ax
+  or bx, di
+
+  ; Store result to .flags memory
+  mov [rel .flags + %1], bl
+%endmacro
+
+; Performs the string comparison and moves the result from RCX to
+; a region of memory in the .indices section specified by a byte
+; offset.
+;
+; The first parameter is the byte offset to store the RCX result to.
+; The second parameter is the control values to pass to pcmpestri
+;
+%macro CompareAndStore 2
+  pcmpestri xmm2, xmm3, %2
+  mov [rel .indices + %1], cl
+
+  mov r15, rax
+  ArrangeAndStoreFLAGS %1
+  mov rax, r15
+%endmacro
+
+movaps xmm2, [rel .data]
+movaps xmm3, [rel .data + 32]
+
+; Full length unsigned byte string check (lsb, positive polarity)
+mov rax, 16
+mov rdx, 16
+CompareAndStore 0, 0b00001000
+
+; Full length unsigned byte string check (msb, positive polarity)
+CompareAndStore 1, 0b01001000
+
+; Full length unsigned byte string check (lsb, negative polarity)
+CompareAndStore 2, 0b00011000
+
+; Full length unsigned byte string check (msb, negative polarity)
+CompareAndStore 3, 0b01011000
+
+; Full length unsigned byte string check (lsb, negative masked)
+CompareAndStore 4, 0b00111000
+
+; Full length unsigned byte string check (msb, negative masked)
+CompareAndStore 5, 0b01111000
+
+; Non-full length unsigned byte string check (lsb, positive polarity)
+mov rax, 8
+mov rdx, 7
+CompareAndStore 6, 0b00001000
+
+; Non-full length unsigned byte string check (msb, positive polarity)
+CompareAndStore 7, 0b01001000
+
+; Non-full length unsigned byte string check (lsb, negative polarity)
+CompareAndStore 8, 0b00011000
+
+; Non-full length unsigned byte string check (msb, negative polarity)
+CompareAndStore 9, 0b01011000
+
+; Non-full length unsigned byte string check (lsb, negative masked)
+CompareAndStore 10, 0b00111000
+
+; Non-full length unsigned byte string check (msb, negative masked)
+CompareAndStore 11, 0b01111000
+
+; --- 16-bit unsigned word tests ---
+
+movaps xmm2, [rel .data16]
+movaps xmm3, [rel .data16 + 32]
+
+; Full length unsigned word string check (lsb, positive polarity)
+mov rax, 8
+mov rdx, 8
+CompareAndStore 12, 0b00001001
+
+; Full length unsigned word string check (msb, positive polarity)
+CompareAndStore 13, 0b01001001
+
+; Full length unsigned word string check (lsb, negative polarity)
+CompareAndStore 14, 0b00011001
+
+; Full length unsigned word string check (msb, negative polarity)
+CompareAndStore 15, 0b01011001
+
+; Full length unsigned word string check (lsb, negative masked)
+CompareAndStore 16, 0b00111001
+
+; Full length unsigned word string check (msb, negative masked)
+CompareAndStore 17, 0b01111001
+
+; Non-full length unsigned word string check (lsb, positive polarity)
+mov rax, 4
+mov rdx, 3
+CompareAndStore 18, 0b00001001
+
+; Non-full length unsigned word string check (msb, positive polarity)
+CompareAndStore 19, 0b01001001
+
+; Non-full length unsigned word string check (lsb, negative polarity)
+CompareAndStore 20, 0b00011001
+
+; Non-full length unsigned word string check (msb, negative polarity)
+CompareAndStore 21, 0b01011001
+
+; Non-full length unsigned word string check (lsb, negative masked)
+CompareAndStore 22, 0b00111001
+
+; Non-full length unsigned word string check (msb, negative masked)
+CompareAndStore 23, 0b01111001
+
+; Load all our stored indices and flags for result comparing
+movaps xmm0, [rel .indices]
+movaps xmm4, [rel .indices + 16]
+movaps xmm1, [rel .flags]
+movaps xmm5, [rel .flags + 16]
+
+hlt
+
+align 32
+.data:
+dq 0x6550206F6C6C6548 ; "Hello Pe"
+dq 0x21212121656C706F ; "ople!!!!"
+dq 0xFFFFFFFFFFFFFFFF
+dq 0xEEEEEEEEEEEEEEEE
+
+dq 0x2759206F6C6C6548 ; "Hello Y'"
+dq 0x21212121216C6C61 ; "all!!!!!"
+dq 0xDDDDDDDDDDDDDDDD
+dq 0xCCCCCCCCCCCCCCCC
+
+.data16:
+dq 0x306F8A9E672C65E5 ; "日本語は"
+dq 0x000030443057697D ; "楽しい\0" (Japanese is fun)
+dq 0xAAAAAAAAAAAAAAAA
+dq 0xBBBBBBBBBBBBBBBB
+
+dq 0x306F8A9E672C65E5 ; "日本語は"
+dq 0x00003044305796E3 ; "難しい\0" (Japanese is hard)
+dq 0x8888888888888888
+dq 0x9999999999999999
+
+.indices:
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+
+.flags:
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000

--- a/unittests/ASM/H0F3A/pcmpestri_equal_ordered.asm
+++ b/unittests/ASM/H0F3A/pcmpestri_equal_ordered.asm
@@ -1,0 +1,156 @@
+%ifdef CONFIG
+{
+  "RegData": {
+      "RAX": ["2"],
+      "RDX": ["16"],
+      "XMM0": ["0x05050F000F000902", "0x0000000007000700"],
+      "XMM1": ["0x1111313131311111", "0x0000000031313131"],
+      "XMM2": ["0x306F8A9E30443057", "0x000030443057697D"],
+      "XMM3": ["0x306F8A9E672C65E5", "0x00003044305796E3"]
+  }
+}
+%endif
+
+; Adjusts the result from LAHF and SETO so that we have a set of flags organized
+; like [OF, SF, ZF, AF, PF, CF] for storing into the .flags region
+; of memory.
+;
+; The first parameter is the byte offset to store the flag result
+; at in the .flags region of memory.
+;
+%macro ArrangeAndStoreFLAGS 1
+  lahf
+  seto bl
+  movzx bx, bl
+
+  shr ax, 8
+  shl bx, 5
+
+  mov di, ax
+  mov si, ax
+
+  ; Mask and shift
+  and di, 0b0000_0000_0000_0100 ; PF
+  and si, 0b0000_0000_0001_0000 ; AF
+  shr di, 1
+  shr si, 2
+
+  ; OR all of them together
+  or bx, di
+  or bx, si
+
+  ; Reclaim DI for getting ZF/SF and shift into place
+  mov di, ax
+  and di, 0b0000_0000_1100_0000 ; ZF and SF
+  shr di, 3
+
+  ; Finally mask and OR all of the bits together
+  and ax, 0b0000_0000_0000_0001 ; CF
+  or bx, ax
+  or bx, di
+
+  ; Store result to .flags memory
+  mov [rel .flags + %1], bl
+%endmacro
+
+; Performs the string comparison and moves the result from RCX to
+; a region of memory in the .indices section specified by a byte
+; offset.
+;
+; The first parameter is the byte offset to store the RCX result to.
+; The second parameter is the control values to pass to pcmpestri
+;
+%macro CompareAndStore 2
+  pcmpestri xmm2, xmm3, %2
+  mov [rel .indices + %1], cl
+
+  mov r15, rax
+  ArrangeAndStoreFLAGS %1
+  mov rax, r15
+%endmacro
+
+movaps xmm2, [rel .data]
+movaps xmm3, [rel .data + 32]
+
+; Unsigned byte string check (lsb, positive polarity)
+mov rax, 2
+mov rdx, 16
+CompareAndStore 0, 0b00001100
+
+; Unsigned byte string check (msb, positive polarity)
+CompareAndStore 1, 0b01001100
+
+; Unsigned byte string check (lsb, negative polarity)
+CompareAndStore 2, 0b00011100
+
+; Unsigned byte string check (msb, negative polarity)
+CompareAndStore 3, 0b01011100
+
+; Unsigned byte string check (lsb, negative masked)
+CompareAndStore 4, 0b00111100
+
+; Unsigned byte string check (msb, negative masked)
+CompareAndStore 5, 0b01111100
+
+; --- 16-bit unsigned word tests ---
+; Intentionally don't reset RDX to 8 here to test upper bounds clamping.
+movaps xmm2, [rel .data16]
+movaps xmm3, [rel .data16 + 32]
+
+CompareAndStore 6, 0b00001101
+
+; Unsigned word string check (msb, positive polarity)
+CompareAndStore 7, 0b01001101
+
+; Unsigned word string check (lsb, negative polarity)
+CompareAndStore 8, 0b00011101
+
+; Unsigned word string check (msb, negative polarity)
+CompareAndStore 9, 0b01011101
+
+; Unsigned word string check (lsb, negative masked)
+CompareAndStore 10, 0b00111101
+
+; Unsigned word string check (msb, negative masked)
+CompareAndStore 11, 0b01111101
+
+; Load all our stored indices and flags for result comparing
+movaps xmm0, [rel .indices]
+movaps xmm1, [rel .flags]
+
+hlt
+
+align 32
+.data:
+dq 0x6550206F6FFF6C6C ; "ll" with junk following it
+dq 0x21212121656C706F
+dq 0xFFFFFFFFFFFFFFFF
+dq 0xEEEEEEEEEEEEEEEE
+
+dq 0x2759206F6C6C6548 ; "Hello Y'"
+dq 0x21212121216C6C61 ; "all!!!!!"
+dq 0xDDDDDDDDDDDDDDDD
+dq 0xCCCCCCCCCCCCCCCC
+
+.data16:
+dq 0x306F8A9E30443057 ; "しい" followed by junk
+dq 0x000030443057697D
+dq 0xAAAAAAAAAAAAAAAA
+dq 0xBBBBBBBBBBBBBBBB
+
+dq 0x306F8A9E672C65E5 ; "日本語は"
+dq 0x00003044305796E3 ; "難しい\0" (Japanese is hard)
+dq 0x8888888888888888
+dq 0x9999999999999999
+
+.indices:
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+
+.flags:
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000

--- a/unittests/ASM/H0F3A/pcmpestri_ranges.asm
+++ b/unittests/ASM/H0F3A/pcmpestri_ranges.asm
@@ -1,0 +1,154 @@
+%ifdef CONFIG
+{
+  "RegData": {
+      "RAX": ["4"],
+      "RDX": ["16"],
+      "XMM0": ["0x00060F000F000D01", "0x0000000000070007"],
+      "XMM1": ["0x3111313131311111", "0x0000000000313131"],
+      "XMM2": ["0x005A0041007A0061", "0x55AACCBBFF223344"],
+      "XMM3": ["0x006500200027003F", "0x00210065004F0065"]
+  }
+}
+%endif
+
+; Adjusts the result from LAHF and SETO so that we have a set of flags organized
+; like [OF, SF, ZF, AF, PF, CF] for storing into the .flags region
+; of memory.
+;
+; The first parameter is the byte offset to store the flag result
+; at in the .flags region of memory.
+;
+%macro ArrangeAndStoreFLAGS 1
+  lahf
+  seto bl
+  movzx bx, bl
+
+  shr ax, 8
+  shl bx, 5
+
+  mov di, ax
+  mov si, ax
+
+  ; Mask and shift
+  and di, 0b0000_0000_0000_0100 ; PF
+  and si, 0b0000_0000_0001_0000 ; AF
+  shr di, 1
+  shr si, 2
+
+  ; OR all of them together
+  or bx, di
+  or bx, si
+
+  ; Reclaim DI for getting ZF/SF and shift into place
+  mov di, ax
+  and di, 0b0000_0000_1100_0000 ; ZF and SF
+  shr di, 3
+
+  ; Finally mask and OR all of the bits together
+  and ax, 0b0000_0000_0000_0001 ; CF
+  or bx, ax
+  or bx, di
+
+  ; Store result to .flags memory
+  mov [rel .flags + %1], bl
+%endmacro
+
+; Performs the string comparison and moves the result from RCX to
+; a region of memory in the .indices section specified by a byte
+; offset.
+;
+; The first parameter is the byte offset to store the RCX result to.
+; The second parameter is the control values to pass to pcmpestri
+;
+%macro CompareAndStore 2
+  pcmpestri xmm2, xmm3, %2
+  mov [rel .indices + %1], cl
+
+  mov r15, rax
+  ArrangeAndStoreFLAGS %1
+  mov rax, r15
+%endmacro
+
+movaps xmm2, [rel .data]
+movaps xmm3, [rel .data + 32]
+
+; Range unsigned byte check (lsb, positive polarity)
+mov rax, 4
+mov rdx, 16
+CompareAndStore 0, 0b00000100
+
+; Range unsigned byte check (msb, positive polarity)
+CompareAndStore 1, 0b01000100
+
+; Range unsigned byte check (lsb, negative polarity)
+CompareAndStore 2, 0b00010100
+
+; Range unsigned byte check (msb, negative polarity)
+CompareAndStore 3, 0b01010100
+
+; Range unsigned byte check (lsb, negative masked)
+CompareAndStore 4, 0b00110100
+
+; Range unsigned byte check (msb, negative masked)
+CompareAndStore 5, 0b01110100
+
+; --- 16-bit unsigned word tests ---
+; Intentionally don't reset RDX to 8 here to test upper bounds clamping.
+movaps xmm2, [rel .data16]
+movaps xmm3, [rel .data16 + 32]
+
+; Range unsigned word check (msb, positive polarity)
+CompareAndStore 6, 0b01000101
+
+; Range unsigned word check (lsb, negative polarity)
+CompareAndStore 7, 0b00010101
+
+; Range unsigned word check (msb, negative polarity)
+CompareAndStore 8, 0b01010101
+
+; Range unsigned word check (lsb, negative masked)
+CompareAndStore 9, 0b00110101
+
+; Range unsigned word check (msb, negative masked)
+CompareAndStore 10, 0b01110101
+
+; Load all our stored indices and flags for result comparing
+movaps xmm0, [rel .indices]
+movaps xmm1, [rel .flags]
+
+hlt
+
+align 32
+.data:
+dq 0x998877665A417A61 ; "azAZ" (followed by junk)
+dq 0x55AACCBBFF223344
+dq 0xFFFFFFFFFFFFFFFF
+dq 0xEEEEEEEEEEEEEEEE
+
+dq 0x726548206D27493F ; "?I'm Her"
+dq 0x21216E65704F2065 ; "e Open!!"
+dq 0xFFFFFFFFFFFFFFFF
+dq 0xEEEEEEEEEEEEEEEE
+
+.data16:
+dq 0x005A0041007A0061 ; "azAZ"
+dq 0x55AACCBBFF223344
+dq 0xAAAAAAAAAAAAAAAA
+dq 0xBBBBBBBBBBBBBBBB
+
+dq 0x006500200027003F ; "?' e"
+dq 0x00210065004F0065 ; "eOen!"
+dq 0x8888888888888888
+dq 0x9999999999999999
+
+.indices:
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+
+.flags:
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000

--- a/unittests/ASM/VEX/vpcmpestri_equal_any.asm
+++ b/unittests/ASM/VEX/vpcmpestri_equal_any.asm
@@ -1,0 +1,154 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+      "RAX": ["15"],
+      "RDX": ["16"],
+      "XMM0": ["0x04070F000F000E05", "0x0000000000040404", "0x0000000000000000", "0x0000000000000000"],
+      "XMM1": ["0x0121313131311111", "0x0000000000010101", "0x0000000000000000", "0x0000000000000000"],
+      "XMM2": ["0x306F8A9E672C65E5", "0x000030443057697D", "0xAAAAAAAAAAAAAAAA", "0xBBBBBBBBBBBBBBBB"],
+      "XMM3": ["0x306F8A9E672C65E5", "0x00003044305796E3", "0x8888888888888888", "0x9999999999999999"]
+  }
+}
+%endif
+
+; Adjusts the result from LAHF and SETO so that we have a set of flags organized
+; like [OF, SF, ZF, AF, PF, CF] for storing into the .flags region
+; of memory.
+;
+; The first parameter is the byte offset to store the flag result
+; at in the .flags region of memory.
+;
+%macro ArrangeAndStoreFLAGS 1
+  lahf
+  seto bl
+  movzx bx, bl
+
+  shr ax, 8
+  shl bx, 5
+
+  mov di, ax
+  mov si, ax
+
+  ; Mask and shift
+  and di, 0b0000_0000_0000_0100 ; PF
+  and si, 0b0000_0000_0001_0000 ; AF
+  shr di, 1
+  shr si, 2
+
+  ; OR all of them together
+  or bx, di
+  or bx, si
+
+  ; Reclaim DI for getting ZF/SF and shift into place
+  mov di, ax
+  and di, 0b0000_0000_1100_0000 ; ZF and SF
+  shr di, 3
+
+  ; Finally mask and OR all of the bits together
+  and ax, 0b0000_0000_0000_0001 ; CF
+  or bx, ax
+  or bx, di
+
+  ; Store result to .flags memory
+  mov [rel .flags + %1], bl
+%endmacro
+
+; Performs the string comparison and moves the result from RCX to
+; a region of memory in the .indices section specified by a byte
+; offset.
+;
+; The first parameter is the byte offset to store the RCX result to.
+; The second parameter is the control values to pass to vpcmpestri
+;
+%macro CompareAndStore 2
+  vpcmpestri xmm2, xmm3, %2
+  mov [rel .indices + %1], cl
+
+  mov r15, rax
+  ArrangeAndStoreFLAGS %1
+  mov rax, r15
+%endmacro
+
+vmovaps ymm2, [rel .data]
+vmovaps ymm3, [rel .data + 32]
+
+; Unsigned byte character check (lsb, positive polarity)
+mov rax, 15 ; Exclude 'l'
+mov rdx, 16
+CompareAndStore 0, 0b00000000
+
+; Unsigned byte character check (msb, positive polarity)
+CompareAndStore 1, 0b01000000
+
+; Unsigned byte character check (lsb, negative polarity)
+CompareAndStore 2, 0b00010000
+
+; Unsigned byte character check (msb, negative polarity)
+CompareAndStore 3, 0b01010000
+
+; Unsigned byte character check (lsb, negative masked)
+CompareAndStore 4, 0b00110000
+
+; Unsigned byte character check (msb, negative masked)
+CompareAndStore 5, 0b01110000
+
+; --- 16-bit unsigned word tests ---
+vmovaps ymm2, [rel .data16]
+vmovaps ymm3, [rel .data16 + 32]
+
+; Unsigned word character check (msb, positive polarity)
+CompareAndStore 6, 0b01000001
+
+; Unsigned word character check (lsb, negative polarity)
+CompareAndStore 7, 0b00010001
+
+; Unsigned word character check (msb, negative polarity)
+CompareAndStore 8, 0b01010001
+
+; Unsigned word character check (lsb, negative masked)
+CompareAndStore 9, 0b00110001
+
+; Unsigned word character check (msb, negative masked)
+CompareAndStore 10, 0b01110001
+
+; Load all our stored indices and flags for result comparing
+vmovaps ymm0, [rel .indices]
+vmovaps ymm1, [rel .flags]
+
+hlt
+
+align 32
+.data:
+dq 0x6463626144434241 ; "ABCDabcd"
+dq 0x6C6B6A694C4B4A49 ; "IJKLijkl"
+dq 0xFFFFFFFFFFFFFFFF
+dq 0xEEEEEEEEEEEEEEEE
+
+dq 0x4120492065726548 ; "Here I A"
+dq 0x6C4C612759202C6D ; "m, Y'aLl"
+dq 0xDDDDDDDDDDDDDDDD
+dq 0xCCCCCCCCCCCCCCCC
+
+.data16:
+dq 0x306F8A9E672C65E5 ; "日本語は"
+dq 0x000030443057697D ; "楽しい\0" (Japanese is fun)
+dq 0xAAAAAAAAAAAAAAAA
+dq 0xBBBBBBBBBBBBBBBB
+
+dq 0x306F8A9E672C65E5 ; "日本語は"
+dq 0x00003044305796E3 ; "難しい\0" (Japanese is hard)
+dq 0x8888888888888888
+dq 0x9999999999999999
+
+.indices:
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+
+.flags:
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000

--- a/unittests/ASM/VEX/vpcmpestri_equal_each.asm
+++ b/unittests/ASM/VEX/vpcmpestri_equal_each.asm
@@ -1,0 +1,200 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+      "RAX": ["4"],
+      "RDX": ["3"],
+      "XMM0": ["0x0F000B060B060F00", "0x040407000F060706", "0x0704030307000404", "0x0000000000000000"],
+      "XMM1": ["0x3939010101012121", "0x0101212119191919", "0x1919191939390101", "0x0000000000000000"],
+      "XMM2": ["0x306F8A9E672C65E5", "0x000030443057697D", "0xAAAAAAAAAAAAAAAA", "0xBBBBBBBBBBBBBBBB"],
+      "XMM3": ["0x306F8A9E672C65E5", "0x00003044305796E3", "0x8888888888888888", "0x9999999999999999"]
+  }
+}
+%endif
+
+; Adjusts the result from LAHF and SETO so that we have a set of flags organized
+; like [OF, SF, ZF, AF, PF, CF] for storing into the .flags region
+; of memory.
+;
+; The first parameter is the byte offset to store the flag result
+; at in the .flags region of memory.
+;
+%macro ArrangeAndStoreFLAGS 1
+  lahf
+  seto bl
+  movzx bx, bl
+
+  shr ax, 8
+  shl bx, 5
+
+  mov di, ax
+  mov si, ax
+
+  ; Mask and shift
+  and di, 0b0000_0000_0000_0100 ; PF
+  and si, 0b0000_0000_0001_0000 ; AF
+  shr di, 1
+  shr si, 2
+
+  ; OR all of them together
+  or bx, di
+  or bx, si
+
+  ; Reclaim DI for getting ZF/SF and shift into place
+  mov di, ax
+  and di, 0b0000_0000_1100_0000 ; ZF and SF
+  shr di, 3
+
+  ; Finally mask and OR all of the bits together
+  and ax, 0b0000_0000_0000_0001 ; CF
+  or bx, ax
+  or bx, di
+
+  ; Store result to .flags memory
+  mov [rel .flags + %1], bl
+%endmacro
+
+; Performs the string comparison and moves the result from RCX to
+; a region of memory in the .indices section specified by a byte
+; offset.
+;
+; The first parameter is the byte offset to store the RCX result to.
+; The second parameter is the control values to pass to vpcmpestri
+;
+%macro CompareAndStore 2
+  vpcmpestri xmm2, xmm3, %2
+  mov [rel .indices + %1], cl
+
+  mov r15, rax
+  ArrangeAndStoreFLAGS %1
+  mov rax, r15
+%endmacro
+
+vmovaps ymm2, [rel .data]
+vmovaps ymm3, [rel .data + 32]
+
+; Full length unsigned byte string check (lsb, positive polarity)
+mov rax, 16
+mov rdx, 16
+CompareAndStore 0, 0b00001000
+
+; Full length unsigned byte string check (msb, positive polarity)
+CompareAndStore 1, 0b01001000
+
+; Full length unsigned byte string check (lsb, negative polarity)
+CompareAndStore 2, 0b00011000
+
+; Full length unsigned byte string check (msb, negative polarity)
+CompareAndStore 3, 0b01011000
+
+; Full length unsigned byte string check (lsb, negative masked)
+CompareAndStore 4, 0b00111000
+
+; Full length unsigned byte string check (msb, negative masked)
+CompareAndStore 5, 0b01111000
+
+; Non-full length unsigned byte string check (lsb, positive polarity)
+mov rax, 8
+mov rdx, 7
+CompareAndStore 6, 0b00001000
+
+; Non-full length unsigned byte string check (msb, positive polarity)
+CompareAndStore 7, 0b01001000
+
+; Non-full length unsigned byte string check (lsb, negative polarity)
+CompareAndStore 8, 0b00011000
+
+; Non-full length unsigned byte string check (msb, negative polarity)
+CompareAndStore 9, 0b01011000
+
+; Non-full length unsigned byte string check (lsb, negative masked)
+CompareAndStore 10, 0b00111000
+
+; Non-full length unsigned byte string check (msb, negative masked)
+CompareAndStore 11, 0b01111000
+
+; --- 16-bit unsigned word tests ---
+
+vmovaps ymm2, [rel .data16]
+vmovaps ymm3, [rel .data16 + 32]
+
+; Full length unsigned word string check (lsb, positive polarity)
+mov rax, 8
+mov rdx, 8
+CompareAndStore 12, 0b00001001
+
+; Full length unsigned word string check (msb, positive polarity)
+CompareAndStore 13, 0b01001001
+
+; Full length unsigned word string check (lsb, negative polarity)
+CompareAndStore 14, 0b00011001
+
+; Full length unsigned word string check (msb, negative polarity)
+CompareAndStore 15, 0b01011001
+
+; Full length unsigned word string check (lsb, negative masked)
+CompareAndStore 16, 0b00111001
+
+; Full length unsigned word string check (msb, negative masked)
+CompareAndStore 17, 0b01111001
+
+; Non-full length unsigned word string check (lsb, positive polarity)
+mov rax, 4
+mov rdx, 3
+CompareAndStore 18, 0b00001001
+
+; Non-full length unsigned word string check (msb, positive polarity)
+CompareAndStore 19, 0b01001001
+
+; Non-full length unsigned word string check (lsb, negative polarity)
+CompareAndStore 20, 0b00011001
+
+; Non-full length unsigned word string check (msb, negative polarity)
+CompareAndStore 21, 0b01011001
+
+; Non-full length unsigned word string check (lsb, negative masked)
+CompareAndStore 22, 0b00111001
+
+; Non-full length unsigned word string check (msb, negative masked)
+CompareAndStore 23, 0b01111001
+
+; Load all our stored indices and flags for result comparing
+vmovaps ymm0, [rel .indices]
+vmovaps ymm1, [rel .flags]
+
+hlt
+
+align 32
+.data:
+dq 0x6550206F6C6C6548 ; "Hello Pe"
+dq 0x21212121656C706F ; "ople!!!!"
+dq 0xFFFFFFFFFFFFFFFF
+dq 0xEEEEEEEEEEEEEEEE
+
+dq 0x2759206F6C6C6548 ; "Hello Y'"
+dq 0x21212121216C6C61 ; "all!!!!!"
+dq 0xDDDDDDDDDDDDDDDD
+dq 0xCCCCCCCCCCCCCCCC
+
+.data16:
+dq 0x306F8A9E672C65E5 ; "日本語は"
+dq 0x000030443057697D ; "楽しい\0" (Japanese is fun)
+dq 0xAAAAAAAAAAAAAAAA
+dq 0xBBBBBBBBBBBBBBBB
+
+dq 0x306F8A9E672C65E5 ; "日本語は"
+dq 0x00003044305796E3 ; "難しい\0" (Japanese is hard)
+dq 0x8888888888888888
+dq 0x9999999999999999
+
+.indices:
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+
+.flags:
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000

--- a/unittests/ASM/VEX/vpcmpestri_equal_ordered.asm
+++ b/unittests/ASM/VEX/vpcmpestri_equal_ordered.asm
@@ -1,0 +1,157 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+      "RAX": ["2"],
+      "RDX": ["16"],
+      "XMM0": ["0x05050F000F000902", "0x0000000007000700", "0x0000000000000000", "0x0000000000000000"],
+      "XMM1": ["0x1111313131311111", "0x0000000031313131", "0x0000000000000000", "0x0000000000000000"],
+      "XMM2": ["0x306F8A9E30443057", "0x000030443057697D", "0xAAAAAAAAAAAAAAAA", "0xBBBBBBBBBBBBBBBB"],
+      "XMM3": ["0x306F8A9E672C65E5", "0x00003044305796E3", "0x8888888888888888", "0x9999999999999999"]
+  }
+}
+%endif
+
+; Adjusts the result from LAHF and SETO so that we have a set of flags organized
+; like [OF, SF, ZF, AF, PF, CF] for storing into the .flags region
+; of memory.
+;
+; The first parameter is the byte offset to store the flag result
+; at in the .flags region of memory.
+;
+%macro ArrangeAndStoreFLAGS 1
+  lahf
+  seto bl
+  movzx bx, bl
+
+  shr ax, 8
+  shl bx, 5
+
+  mov di, ax
+  mov si, ax
+
+  ; Mask and shift
+  and di, 0b0000_0000_0000_0100 ; PF
+  and si, 0b0000_0000_0001_0000 ; AF
+  shr di, 1
+  shr si, 2
+
+  ; OR all of them together
+  or bx, di
+  or bx, si
+
+  ; Reclaim DI for getting ZF/SF and shift into place
+  mov di, ax
+  and di, 0b0000_0000_1100_0000 ; ZF and SF
+  shr di, 3
+
+  ; Finally mask and OR all of the bits together
+  and ax, 0b0000_0000_0000_0001 ; CF
+  or bx, ax
+  or bx, di
+
+  ; Store result to .flags memory
+  mov [rel .flags + %1], bl
+%endmacro
+
+; Performs the string comparison and moves the result from RCX to
+; a region of memory in the .indices section specified by a byte
+; offset.
+;
+; The first parameter is the byte offset to store the RCX result to.
+; The second parameter is the control values to pass to vpcmpestri
+;
+%macro CompareAndStore 2
+  vpcmpestri xmm2, xmm3, %2
+  mov [rel .indices + %1], cl
+
+  mov r15, rax
+  ArrangeAndStoreFLAGS %1
+  mov rax, r15
+%endmacro
+
+vmovaps ymm2, [rel .data]
+vmovaps ymm3, [rel .data + 32]
+
+; Unsigned byte string check (lsb, positive polarity)
+mov rax, 2
+mov rdx, 16
+CompareAndStore 0, 0b00001100
+
+; Unsigned byte string check (msb, positive polarity)
+CompareAndStore 1, 0b01001100
+
+; Unsigned byte string check (lsb, negative polarity)
+CompareAndStore 2, 0b00011100
+
+; Unsigned byte string check (msb, negative polarity)
+CompareAndStore 3, 0b01011100
+
+; Unsigned byte string check (lsb, negative masked)
+CompareAndStore 4, 0b00111100
+
+; Unsigned byte string check (msb, negative masked)
+CompareAndStore 5, 0b01111100
+
+; --- 16-bit unsigned word tests ---
+; Intentionally don't reset RDX to 8 here to test upper bounds clamping.
+vmovaps ymm2, [rel .data16]
+vmovaps ymm3, [rel .data16 + 32]
+
+CompareAndStore 6, 0b00001101
+
+; Unsigned word string check (msb, positive polarity)
+CompareAndStore 7, 0b01001101
+
+; Unsigned word string check (lsb, negative polarity)
+CompareAndStore 8, 0b00011101
+
+; Unsigned word string check (msb, negative polarity)
+CompareAndStore 9, 0b01011101
+
+; Unsigned word string check (lsb, negative masked)
+CompareAndStore 10, 0b00111101
+
+; Unsigned word string check (msb, negative masked)
+CompareAndStore 11, 0b01111101
+
+; Load all our stored indices and flags for result comparing
+vmovaps ymm0, [rel .indices]
+vmovaps ymm1, [rel .flags]
+
+hlt
+
+align 32
+.data:
+dq 0x6550206F6FFF6C6C ; "ll" with junk following it
+dq 0x21212121656C706F
+dq 0xFFFFFFFFFFFFFFFF
+dq 0xEEEEEEEEEEEEEEEE
+
+dq 0x2759206F6C6C6548 ; "Hello Y'"
+dq 0x21212121216C6C61 ; "all!!!!!"
+dq 0xDDDDDDDDDDDDDDDD
+dq 0xCCCCCCCCCCCCCCCC
+
+.data16:
+dq 0x306F8A9E30443057 ; "しい" followed by junk
+dq 0x000030443057697D
+dq 0xAAAAAAAAAAAAAAAA
+dq 0xBBBBBBBBBBBBBBBB
+
+dq 0x306F8A9E672C65E5 ; "日本語は"
+dq 0x00003044305796E3 ; "難しい\0" (Japanese is hard)
+dq 0x8888888888888888
+dq 0x9999999999999999
+
+.indices:
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+
+.flags:
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000

--- a/unittests/ASM/VEX/vpcmpestri_ranges.asm
+++ b/unittests/ASM/VEX/vpcmpestri_ranges.asm
@@ -1,0 +1,155 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+      "RAX": ["4"],
+      "RDX": ["16"],
+      "XMM0": ["0x00060F000F000D01", "0x0000000000070007", "0x0000000000000000", "0x0000000000000000"],
+      "XMM1": ["0x3111313131311111", "0x0000000000313131", "0x0000000000000000", "0x0000000000000000"],
+      "XMM2": ["0x005A0041007A0061", "0x55AACCBBFF223344", "0xAAAAAAAAAAAAAAAA", "0xBBBBBBBBBBBBBBBB"],
+      "XMM3": ["0x006500200027003F", "0x00210065004F0065", "0x8888888888888888", "0x9999999999999999"]
+  }
+}
+%endif
+
+; Adjusts the result from LAHF and SETO so that we have a set of flags organized
+; like [OF, SF, ZF, AF, PF, CF] for storing into the .flags region
+; of memory.
+;
+; The first parameter is the byte offset to store the flag result
+; at in the .flags region of memory.
+;
+%macro ArrangeAndStoreFLAGS 1
+  lahf
+  seto bl
+  movzx bx, bl
+
+  shr ax, 8
+  shl bx, 5
+
+  mov di, ax
+  mov si, ax
+
+  ; Mask and shift
+  and di, 0b0000_0000_0000_0100 ; PF
+  and si, 0b0000_0000_0001_0000 ; AF
+  shr di, 1
+  shr si, 2
+
+  ; OR all of them together
+  or bx, di
+  or bx, si
+
+  ; Reclaim DI for getting ZF/SF and shift into place
+  mov di, ax
+  and di, 0b0000_0000_1100_0000 ; ZF and SF
+  shr di, 3
+
+  ; Finally mask and OR all of the bits together
+  and ax, 0b0000_0000_0000_0001 ; CF
+  or bx, ax
+  or bx, di
+
+  ; Store result to .flags memory
+  mov [rel .flags + %1], bl
+%endmacro
+
+; Performs the string comparison and moves the result from RCX to
+; a region of memory in the .indices section specified by a byte
+; offset.
+;
+; The first parameter is the byte offset to store the RCX result to.
+; The second parameter is the control values to pass to vpcmpestri
+;
+%macro CompareAndStore 2
+  vpcmpestri xmm2, xmm3, %2
+  mov [rel .indices + %1], cl
+
+  mov r15, rax
+  ArrangeAndStoreFLAGS %1
+  mov rax, r15
+%endmacro
+
+vmovaps ymm2, [rel .data]
+vmovaps ymm3, [rel .data + 32]
+
+; Range unsigned byte check (lsb, positive polarity)
+mov rax, 4
+mov rdx, 16
+CompareAndStore 0, 0b00000100
+
+; Range unsigned byte check (msb, positive polarity)
+CompareAndStore 1, 0b01000100
+
+; Range unsigned byte check (lsb, negative polarity)
+CompareAndStore 2, 0b00010100
+
+; Range unsigned byte check (msb, negative polarity)
+CompareAndStore 3, 0b01010100
+
+; Range unsigned byte check (lsb, negative masked)
+CompareAndStore 4, 0b00110100
+
+; Range unsigned byte check (msb, negative masked)
+CompareAndStore 5, 0b01110100
+
+; --- 16-bit unsigned word tests ---
+; Intentionally don't reset RDX to 8 here to test upper bounds clamping.
+vmovaps ymm2, [rel .data16]
+vmovaps ymm3, [rel .data16 + 32]
+
+; Range unsigned word check (msb, positive polarity)
+CompareAndStore 6, 0b01000101
+
+; Range unsigned word check (lsb, negative polarity)
+CompareAndStore 7, 0b00010101
+
+; Range unsigned word check (msb, negative polarity)
+CompareAndStore 8, 0b01010101
+
+; Range unsigned word check (lsb, negative masked)
+CompareAndStore 9, 0b00110101
+
+; Range unsigned word check (msb, negative masked)
+CompareAndStore 10, 0b01110101
+
+; Load all our stored indices and flags for result comparing
+vmovaps ymm0, [rel .indices]
+vmovaps ymm1, [rel .flags]
+
+hlt
+
+align 32
+.data:
+dq 0x998877665A417A61 ; "azAZ" (followed by junk)
+dq 0x55AACCBBFF223344
+dq 0xFFFFFFFFFFFFFFFF
+dq 0xEEEEEEEEEEEEEEEE
+
+dq 0x726548206D27493F ; "?I'm Her"
+dq 0x21216E65704F2065 ; "e Open!!"
+dq 0xFFFFFFFFFFFFFFFF
+dq 0xEEEEEEEEEEEEEEEE
+
+.data16:
+dq 0x005A0041007A0061 ; "azAZ"
+dq 0x55AACCBBFF223344
+dq 0xAAAAAAAAAAAAAAAA
+dq 0xBBBBBBBBBBBBBBBB
+
+dq 0x006500200027003F ; "?' e"
+dq 0x00210065004F0065 ; "eOen!"
+dq 0x8888888888888888
+dq 0x9999999999999999
+
+.indices:
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+
+.flags:
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000


### PR DESCRIPTION
Handles the rather behavior-abundant PCMPESTRI instruction variants.

We only implement this instruction in this PR, since the fallback itself on top of the tests are quite large. This allows the base implementation to get reviews, making it much nicer to review following instructions that will add handling for implicit lengths and mask handling