### PR TITLE
VEXTables: Adds a missing class of AVX instructions

### DIFF
--- a/External/FEXCore/Source/Interface/Core/X86Tables/VEXTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/VEXTables.cpp
@@ -146,6 +146,11 @@ void InitializeVEXTables() {
     {OPD(1, 0b10, 0x59), 1, X86InstInfo{"VMULSS",   TYPE_INST, GenFlagsSizes(SIZE_128BIT, SIZE_32BIT) | FLAGS_MODRM | FLAGS_VEX_1ST_SRC | FLAGS_XMM_FLAGS, 0, nullptr}},
     {OPD(1, 0b11, 0x59), 1, X86InstInfo{"VMULSD",   TYPE_INST, GenFlagsSizes(SIZE_128BIT, SIZE_64BIT) | FLAGS_MODRM | FLAGS_VEX_1ST_SRC | FLAGS_XMM_FLAGS, 0, nullptr}},
 
+    {OPD(1, 0b00, 0x5A), 1, X86InstInfo{"VCVTPS2PD",   TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
+    {OPD(1, 0b01, 0x5A), 1, X86InstInfo{"VCVTPD2PS",   TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
+    {OPD(1, 0b10, 0x5A), 1, X86InstInfo{"VCVTSS2SD",   TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
+    {OPD(1, 0b11, 0x5A), 1, X86InstInfo{"VCVTSD2SS",   TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
+
     {OPD(1, 0b00, 0x5B), 1, X86InstInfo{"VCVTDQ2PS",   TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS, 0, nullptr}},
     {OPD(1, 0b01, 0x5B), 1, X86InstInfo{"VCVTPS2DQ",   TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS, 0, nullptr}},
     {OPD(1, 0b10, 0x5B), 1, X86InstInfo{"VCVTTPS2DQ",  TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS, 0, nullptr}},


### PR DESCRIPTION
These are all AVX1, not sure how I missed this.
Sorry @lioncash, four more instructions.

Uncharted legacy of thieves uses `VCVTSD2SS` specifically.
Sackboy also uses `VCVTSD2SS`
The Last of Us also uses `VCVTSD2SS`
Death Stranding also uses `VCVTSD2SS`
Returnal uses `VCVTSS2SD`