### PR TITLE
SignalDelegator: Calculate siginfo layout

### DIFF
--- a/Source/Tools/FEXLoader/LinuxSyscalls/UContext.h
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/UContext.h
@@ -221,6 +221,16 @@ namespace FEXCore {
       int si_code;
       union {
         uint32_t pad[29];
+        /* tgkill siginfo_t */
+        struct {
+          int32_t pid;
+          int32_t uid;
+        } _kill;
+        /* SIGPOLL */
+        struct {
+          int32_t band;
+          int32_t fd;
+        } _poll;
         /* SIGILL, SIGFPE, SIGSEGV, SIBUS */
         struct {
           uint32_t addr;
@@ -233,12 +243,27 @@ namespace FEXCore {
           int32_t utime;
           int32_t stime;
         } _sigchld;
+        /* RT signals */
+        struct {
+          int32_t pid;
+          int32_t uid;
+          union {
+            int32_t sival_int;
+            uint32_t sival_ptr; // compat_ptr
+          } sigval;
+        } _rt;
         /* SIGALRM, SIGVTALRM */
         struct {
           int tid;
           int overrun;
           FEXCore::x86::sigval_t sigval;
         } _timer;
+        /* SIGSYS */
+        struct {
+          uint32_t call_addr; // compat_ptr
+          int32_t syscall;
+          uint32_t arch;
+        } _sigsys;
       } _sifields;
 
       union HostSigInfo_t {


### PR DESCRIPTION
There are a handful of siginfo layout types. To determine which layout to use we need to check a combination of si_code and signal number because each one in isolation doesn't explain the layout type.

Once the layout is calculated then calculate the siginfo using that layout type. Adds a couple of different layout types to our guest siginfo_t to handle the previously missing types.