### PR TITLE
SignalDelegator: Make sure to save and restore `InSyscallInfo`

### DIFF
--- a/Source/Tools/FEXLoader/LinuxSyscalls/ArchHelpers/MContext.h
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/ArchHelpers/MContext.h
@@ -38,6 +38,7 @@ struct X86ContextBackup {
   uint64_t GPRs[23];
   FEXCore::x86_64::_libc_fpstate FPRState;
   uint64_t sa_mask;
+  uint16_t InSyscallInfo;
   bool FaultToTopAndGeneratedException;
 
   // Guest state
@@ -64,6 +65,7 @@ struct ArmContextBackup {
   uint32_t FPCR;
   __uint128_t FPRs[32];
   uint64_t sa_mask;
+  uint16_t InSyscallInfo;
   bool FaultToTopAndGeneratedException;
 
   // Guest state


### PR DESCRIPTION
Fixes #2560

This was a forgotten member of the context that needs to be saved and restored when jumping around the signal state.
When FEX was receiving signals back to back, there was a chance that the signals would ride the edge of having set `InSyscallInfo` in the JIT, which meant the SRA state would get saved once, then another signal would occur with the previous SRA data, saving SRA again. Then when unwinding the frames it would corrupt the SRA registers. This would result in trying to load SRA state that was no longer valid, looking like a crash in the JIT that was hard to see what happens.

Should also make Mono games a little less crash happy.

Cleans up CPUState memcpy as well, since it was a little weird looking.