### PR TITLE
OpcodeDispatcher: Handle PCMPISTRI/VPCMPISTRI

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/Fallbacks/InterpreterFallbacks.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/Fallbacks/InterpreterFallbacks.cpp
@@ -94,6 +94,11 @@ FallbackInfo GetFallbackInfo(uint32_t(*fn)(uint64_t, uint64_t, __uint128_t, __ui
   return {FABI_I32_I64_I64_I128_I128_I16, (void*)fn, HandlerIndex};
 }
 
+template<>
+FallbackInfo GetFallbackInfo(uint32_t(*fn)(__uint128_t, __uint128_t, uint16_t), FEXCore::Core::FallbackHandlerIndex HandlerIndex) {
+  return {FABI_I32_I128_I128_I16, (void*)fn, HandlerIndex};
+}
+
 void InterpreterOps::FillFallbackIndexPointers(uint64_t *Info) {
   Info[Core::OPINDEX_F80LOADFCW] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80LOADFCW>::handle, Core::OPINDEX_F80LOADFCW).fn);
   Info[Core::OPINDEX_F80CVTTO_4] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_F80CVTTO>::handle4, Core::OPINDEX_F80CVTTO_4).fn);
@@ -153,6 +158,7 @@ void InterpreterOps::FillFallbackIndexPointers(uint64_t *Info) {
 
   // SSE4.2 string instructions
   Info[Core::OPINDEX_VPCMPESTRX] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_VPCMPESTRX>::handle, Core::OPINDEX_VPCMPESTRX).fn);
+  Info[Core::OPINDEX_VPCMPISTRX] = reinterpret_cast<uint64_t>(GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_VPCMPISTRX>::handle, Core::OPINDEX_VPCMPISTRX).fn);
 }
 
 bool InterpreterOps::GetFallbackHandler(IR::IROp_Header const *IROp, FallbackInfo *Info) {
@@ -314,6 +320,9 @@ bool InterpreterOps::GetFallbackHandler(IR::IROp_Header const *IROp, FallbackInf
     // SSE4.2 Fallbacks
     case IR::OP_VPCMPESTRX:
       *Info = GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_VPCMPESTRX>::handle, Core::OPINDEX_VPCMPESTRX);
+      return true;
+    case IR::OP_VPCMPISTRX:
+      *Info = GetFallbackInfo(&FEXCore::CPU::OpHandlers<IR::OP_VPCMPISTRX>::handle, Core::OPINDEX_VPCMPISTRX);
       return true;
 
     default:

--- a/External/FEXCore/Source/Interface/Core/Interpreter/Fallbacks/VectorFallbacks.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/Fallbacks/VectorFallbacks.h
@@ -356,4 +356,53 @@ struct OpHandlers<IR::OP_VPCMPESTRX> {
   }
 };
 
+template<>
+struct OpHandlers<IR::OP_VPCMPISTRX> {
+  // Essentially the same in terms of behavior with VPCMPESTRX instructions,
+  // with the only difference being that the length of the string is encoded
+  // as part of the data vectors passed in.
+  //
+  // i.e. Length is determined by the presence of a NUL (all-zero) character
+  //      within the data.
+  //
+  //      If no NUL character exists, then the length of the strings are assumed
+  //      to be the max length possible for the given character size specified
+  //      in the control flags (16 characters for 8-bit, and 8 characters for 16-bit).
+  //
+  static uint32_t handle(__uint128_t lhs, __uint128_t rhs, uint16_t control) {
+    // Subtract by 1 in order to make validity limits 0-based
+    const auto valid_lhs = GetImplicitLength(lhs, control) - 1;
+    const auto valid_rhs = GetImplicitLength(rhs, control) - 1;
+
+    return OpHandlers<IR::OP_VPCMPESTRX>::MainBody(lhs, valid_lhs, rhs, valid_rhs, control);
+  }
+
+  static int32_t GetImplicitLength(const __uint128_t& data, uint16_t control) {
+    const auto* data_u8 = reinterpret_cast<const uint8_t*>(&data);
+    const auto is_using_words = (control & 1) != 0;
+
+    int32_t length = 0;
+
+    if (is_using_words) {
+      const auto get_word = [data_u8](int32_t index) {
+        const auto* src = data_u8 + (index * sizeof(uint16_t));
+
+        uint16_t element{};
+        std::memcpy(&element, src, sizeof(uint16_t));
+        return element;
+      };
+
+      while (length < 8 && get_word(length) != 0) {
+        length++;
+      }
+    } else {
+      while (length < 16 && data_u8[length] != 0) {
+        length++;
+      }
+    }
+
+    return length;
+  }
+};
+
 } // namespace FEXCore::CPU

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -268,6 +268,7 @@ constexpr OpHandlerArray InterpreterOpHandlers = [] {
   REGISTER_OP(VTBL1,                  VTBL1);
   REGISTER_OP(VREV64,                 VRev64);
   REGISTER_OP(VPCMPESTRX,             VPCMPESTRX);
+  REGISTER_OP(VPCMPISTRX,             VPCMPISTRX);
 
   // Encryption ops
   REGISTER_OP(VAESIMC,                AESImc);

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
@@ -37,6 +37,7 @@ namespace FEXCore::CPU {
     FABI_F80_F80,
     FABI_F80_F80_F80,
     FABI_I32_I64_I64_I128_I128_I16,
+    FABI_I32_I128_I128_I16,
   };
 
   struct FallbackInfo {
@@ -293,6 +294,7 @@ namespace FEXCore::CPU {
   DEF_OP(VTBL1);
   DEF_OP(VRev64);
   DEF_OP(VPCMPESTRX);
+  DEF_OP(VPCMPISTRX);
 
   ///< Encryption ops
   DEF_OP(AESImc);

--- a/External/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
@@ -2283,7 +2283,7 @@ DEF_OP(VPCMPESTRX) {
   const auto Is64Bit = Op->GPRSize == 8;
 
   const auto RAX = *GetSrc<uint64_t*>(Data->SSAData, Op->RAX);
-  const auto RDX = *GetSrc<uint64_t*>(Data->SSAData, Op->RDX);;
+  const auto RDX = *GetSrc<uint64_t*>(Data->SSAData, Op->RDX);
   const auto LHS = *GetSrc<__uint128_t*>(Data->SSAData, Op->LHS);
   const auto RHS = *GetSrc<__uint128_t*>(Data->SSAData, Op->RHS);
 
@@ -2291,6 +2291,19 @@ DEF_OP(VPCMPESTRX) {
   const auto Control = Op->Control | (uint16_t(Is64Bit) << 8);
 
   const auto Result = OpHandlers<IR::OP_VPCMPESTRX>::handle(RAX, RDX, LHS, RHS, Control);
+
+  memset(GDP, 0, sizeof(uint64_t));
+  memcpy(GDP, &Result, sizeof(Result));
+}
+
+DEF_OP(VPCMPISTRX) {
+  const auto Op = IROp->C<IR::IROp_VPCMPISTRX>();
+
+  const auto LHS = *GetSrc<__uint128_t*>(Data->SSAData, Op->LHS);
+  const auto RHS = *GetSrc<__uint128_t*>(Data->SSAData, Op->RHS);
+  const auto Control = Op->Control;
+
+  const auto Result = OpHandlers<IR::OP_VPCMPISTRX>::handle(LHS, RHS, Control);
 
   memset(GDP, 0, sizeof(uint64_t));
   memcpy(GDP, &Result, sizeof(Result));

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -339,6 +339,31 @@ void X86JITCore::Op_Unhandled(IR::IROp_Header *IROp, IR::NodeID Node) {
         break;
       }
 
+      case FABI_I32_I128_I128_I16: {
+        PushRegs();
+
+        const auto Op = IROp->C<IR::IROp_VPCMPISTRX>();
+
+        const auto LHS = GetSrc(Op->LHS.ID());
+        const auto RHS = GetSrc(Op->RHS.ID());
+        const auto Control = Op->Control;
+
+        movq(rdi, LHS);
+        pextrq(rsi, LHS, 1);
+
+        movq(rdx, RHS);
+        pextrq(rcx, RHS, 1);
+
+        mov(r8, Control);
+
+        call(qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.FallbackHandlerPointers[Info.HandlerIndex])]);
+
+        PopRegs();
+
+        mov(GetDst<RA_32>(Node), rax);
+        break;
+      }
+
       case FABI_UNKNOWN:
       default:
 #if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -5993,6 +5993,7 @@ void OpDispatchBuilder::InstallHostSpecificOpcodeHandlers() {
     {OPD(3, 0b01, 0x4C), 1, &OpDispatchBuilder::AVXVectorVariableBlend<1>},
 
     {OPD(3, 0b01, 0x61), 1, &OpDispatchBuilder::VPCMPESTRIOp},
+    {OPD(3, 0b01, 0x63), 1, &OpDispatchBuilder::VPCMPISTRIOp},
 
     {OPD(3, 0b01, 0xDF), 1, &OpDispatchBuilder::VAESKeyGenAssistOp},
   };
@@ -7283,6 +7284,7 @@ constexpr uint16_t PF_F2 = 3;
     {OPD(0, PF_3A_66,   0x42), 1, &OpDispatchBuilder::MPSADBWOp},
 
     {OPD(0, PF_3A_66,   0x61), 1, &OpDispatchBuilder::VPCMPESTRIOp},
+    {OPD(0, PF_3A_66,   0x63), 1, &OpDispatchBuilder::VPCMPISTRIOp},
 
     {OPD(0, PF_3A_NONE, 0xCC), 1, &OpDispatchBuilder::SHA1RNDS4Op},
   };

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -491,6 +491,7 @@ public:
   void VPALIGNROp(OpcodeArgs);
 
   void VPCMPESTRIOp(OpcodeArgs);
+  void VPCMPISTRIOp(OpcodeArgs);
 
   void VPERM2Op(OpcodeArgs);
   void VPERMDOp(OpcodeArgs);
@@ -861,10 +862,11 @@ private:
                              const X86Tables::DecodedOperand& Src2,
                              const X86Tables::DecodedOperand& Imm);
 
-  OrderedNode* PCMPESTRXOpImpl(OpcodeArgs,
+  OrderedNode* PCMPXSTRIOpImpl(OpcodeArgs,
                                const X86Tables::DecodedOperand& Src1,
                                const X86Tables::DecodedOperand& Src2,
-                               const X86Tables::DecodedOperand& Imm);
+                               const X86Tables::DecodedOperand& Imm,
+                               bool IsExplicit);
 
   OrderedNode* PHADDSOpImpl(OpcodeArgs, const X86Tables::DecodedOperand& Src1,
                             const X86Tables::DecodedOperand& Src2);

--- a/External/FEXCore/Source/Interface/Core/X86Tables/H0F3ATables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/H0F3ATables.cpp
@@ -46,7 +46,7 @@ void InitializeH0F3ATables(Context::OperatingMode Mode) {
     {OPD(0, PF_3A_66,   0x60), 1, X86InstInfo{"PCMPESTRM",       TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
     {OPD(0, PF_3A_66,   0x61), 1, X86InstInfo{"PCMPESTRI",       TYPE_INST, GenFlagsSizes(SIZE_128BIT, SIZE_32BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS, 1, nullptr}},
     {OPD(0, PF_3A_66,   0x62), 1, X86InstInfo{"PCMPISTRM",       TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
-    {OPD(0, PF_3A_66,   0x63), 1, X86InstInfo{"PCMPISTRI",       TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
+    {OPD(0, PF_3A_66,   0x63), 1, X86InstInfo{"PCMPISTRI",       TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS, 1, nullptr}},
 
     {OPD(0, PF_3A_NONE, 0xCC), 1, X86InstInfo{"SHA1RNDS4",       TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS, 1, nullptr}},
 

--- a/External/FEXCore/Source/Interface/Core/X86Tables/VEXTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/VEXTables.cpp
@@ -459,7 +459,7 @@ void InitializeVEXTables() {
     {OPD(3, 0b01, 0x60), 1, X86InstInfo{"VPCMPESTRM", TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
     {OPD(3, 0b01, 0x61), 1, X86InstInfo{"VPCMPESTRI", TYPE_INST, GenFlagsSizes(SIZE_128BIT, SIZE_32BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS, 1, nullptr}},
     {OPD(3, 0b01, 0x62), 1, X86InstInfo{"VPCMPISTRM", TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
-    {OPD(3, 0b01, 0x63), 1, X86InstInfo{"VPCMPISTRI", TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
+    {OPD(3, 0b01, 0x63), 1, X86InstInfo{"VPCMPISTRI", TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS, 1, nullptr}},
 
     {OPD(3, 0b01, 0x68), 1, X86InstInfo{"VFMADDPS", TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
     {OPD(3, 0b01, 0x69), 1, X86InstInfo{"VFMADDPD", TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -1408,6 +1408,18 @@
                 ],
         "HasSideEffects": true,
         "DestSize": "4"
+      },
+      "GPR = VPCMPISTRX FPR:$LHS, FPR:$RHS, u8:$Control": {
+        "Desc": ["Performs intermediate behavior analogous to the x86 PCMPISTRI/PCMPISTRM instruction",
+                 "This will return the intermediate result of a PCMPISTR-type operation, but NOT the final",
+                 "result. This must be derived from the intermediate result",
+
+                 "NOTE: On top of returning the intermediate result, the returned value also combines the status",
+                 "flags into the upper 16-bits of the 32-bit result, as these can also be derived over the",
+                 "course of creating the intermediate result"
+                ],
+        "HasSideEffects": true,
+        "DestSize": "4"
       }
     },
     "Conv": {

--- a/External/FEXCore/include/FEXCore/Core/CoreState.h
+++ b/External/FEXCore/include/FEXCore/Core/CoreState.h
@@ -128,6 +128,7 @@ namespace FEXCore::Core {
 
     // SSE4.2 string instructions
     OPINDEX_VPCMPESTRX,
+    OPINDEX_VPCMPISTRX,
 
     // Maximum
     OPINDEX_MAX,

--- a/unittests/ASM/H0F3A/pcmpistri_equal_any.asm
+++ b/unittests/ASM/H0F3A/pcmpistri_equal_any.asm
@@ -1,0 +1,146 @@
+%ifdef CONFIG
+{
+  "RegData": {
+      "XMM0": ["0x04060F000F000D07", "0x0000000000040407"],
+      "XMM1": ["0x1939313131311111", "0x0000000000191919"],
+      "XMM2": ["0x306F8A9E672C65E5", "0x000030443057697D"],
+      "XMM3": ["0x306F8A9E672C65E5", "0x00003044305796E3"]
+  }
+}
+%endif
+
+; Adjusts the result from LAHF and SETO so that we have a set of flags organized
+; like [OF, SF, ZF, AF, PF, CF] for storing into the .flags region
+; of memory.
+;
+; The first parameter is the byte offset to store the flag result
+; at in the .flags region of memory.
+;
+%macro ArrangeAndStoreFLAGS 1
+  lahf
+  seto bl
+  movzx bx, bl
+
+  shr ax, 8
+  shl bx, 5
+
+  mov di, ax
+  mov si, ax
+
+  ; Mask and shift
+  and di, 0b0000_0000_0000_0100 ; PF
+  and si, 0b0000_0000_0001_0000 ; AF
+  shr di, 1
+  shr si, 2
+
+  ; OR all of them together
+  or bx, di
+  or bx, si
+
+  ; Reclaim DI for getting ZF/SF and shift into place
+  mov di, ax
+  and di, 0b0000_0000_1100_0000 ; ZF and SF
+  shr di, 3
+
+  ; Finally mask and OR all of the bits together
+  and ax, 0b0000_0000_0000_0001 ; CF
+  or bx, ax
+  or bx, di
+
+  ; Store result to .flags memory
+  mov [rel .flags + %1], bl
+%endmacro
+
+; Performs the string comparison and moves the result from RCX to
+; a region of memory in the .indices section specified by a byte
+; offset.
+;
+; The first parameter is the byte offset to store the RCX result to.
+; The second parameter is the control values to pass to pcmpistri
+;
+%macro CompareAndStore 2
+  pcmpistri xmm2, xmm3, %2
+  mov [rel .indices + %1], cl
+  ArrangeAndStoreFLAGS %1
+%endmacro
+
+movaps xmm2, [rel .data]
+movaps xmm3, [rel .data + 32]
+
+; Unsigned byte character check (lsb, positive polarity)
+CompareAndStore 0, 0b00000000
+
+; Unsigned byte character check (msb, positive polarity)
+CompareAndStore 1, 0b01000000
+
+; Unsigned byte character check (lsb, negative polarity)
+CompareAndStore 2, 0b00010000
+
+; Unsigned byte character check (msb, negative polarity)
+CompareAndStore 3, 0b01010000
+
+; Unsigned byte character check (lsb, negative masked)
+CompareAndStore 4, 0b00110000
+
+; Unsigned byte character check (msb, negative masked)
+CompareAndStore 5, 0b01110000
+
+; --- 16-bit unsigned word tests ---
+movaps xmm2, [rel .data16]
+movaps xmm3, [rel .data16 + 32]
+
+; Unsigned word character check (msb, positive polarity)
+CompareAndStore 6, 0b01000001
+
+; Unsigned word character check (lsb, negative polarity)
+CompareAndStore 7, 0b00010001
+
+; Unsigned word character check (msb, negative polarity)
+CompareAndStore 8, 0b01010001
+
+; Unsigned word character check (lsb, negative masked)
+CompareAndStore 9, 0b00110001
+
+; Unsigned word character check (msb, negative masked)
+CompareAndStore 10, 0b01110001
+
+; Load all our stored indices and flags for result comparing
+movaps xmm0, [rel .indices]
+movaps xmm1, [rel .flags]
+
+hlt
+
+align 32
+.data:
+dq 0x6463626144434241 ; "ABCDabcd"
+dq 0x6C6B6A694C4B4A00 ; "\0JKLijkl"
+dq 0xFFFFFFFFFFFFFFFF
+dq 0xEEEEEEEEEEEEEEEE
+
+dq 0x4120492065726548 ; "Here I A"
+dq 0x6C4C612759202C6D ; "m, Y'aLl"
+dq 0xDDDDDDDDDDDDDDDD
+dq 0xCCCCCCCCCCCCCCCC
+
+.data16:
+dq 0x306F8A9E672C65E5 ; "日本語は"
+dq 0x000030443057697D ; "楽しい\0" (Japanese is fun)
+dq 0xAAAAAAAAAAAAAAAA
+dq 0xBBBBBBBBBBBBBBBB
+
+dq 0x306F8A9E672C65E5 ; "日本語は"
+dq 0x00003044305796E3 ; "難しい\0" (Japanese is hard)
+dq 0x8888888888888888
+dq 0x9999999999999999
+
+.indices:
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+
+.flags:
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000

--- a/unittests/ASM/H0F3A/pcmpistri_equal_each.asm
+++ b/unittests/ASM/H0F3A/pcmpistri_equal_each.asm
@@ -1,0 +1,150 @@
+%ifdef CONFIG
+{
+  "RegData": {
+      "XMM0": ["0x07000F060E060F00", "0x0000000007040404"],
+      "XMM1": ["0x3939191919193939", "0x0000000019191919"],
+      "XMM2": ["0x306F8A9E672C65E5", "0x000030443057697D"],
+      "XMM3": ["0x306F8A9E672C65E5", "0x00003044305796E3"]
+  }
+}
+%endif
+
+; Adjusts the result from LAHF and SETO so that we have a set of flags organized
+; like [OF, SF, ZF, AF, PF, CF] for storing into the .flags region
+; of memory.
+;
+; The first parameter is the byte offset to store the flag result
+; at in the .flags region of memory.
+;
+%macro ArrangeAndStoreFLAGS 1
+  lahf
+  seto bl
+  movzx bx, bl
+
+  shr ax, 8
+  shl bx, 5
+
+  mov di, ax
+  mov si, ax
+
+  ; Mask and shift
+  and di, 0b0000_0000_0000_0100 ; PF
+  and si, 0b0000_0000_0001_0000 ; AF
+  shr di, 1
+  shr si, 2
+
+  ; OR all of them together
+  or bx, di
+  or bx, si
+
+  ; Reclaim DI for getting ZF/SF and shift into place
+  mov di, ax
+  and di, 0b0000_0000_1100_0000 ; ZF and SF
+  shr di, 3
+
+  ; Finally mask and OR all of the bits together
+  and ax, 0b0000_0000_0000_0001 ; CF
+  or bx, ax
+  or bx, di
+
+  ; Store result to .flags memory
+  mov [rel .flags + %1], bl
+%endmacro
+
+; Performs the string comparison and moves the result from RCX to
+; a region of memory in the .indices section specified by a byte
+; offset.
+;
+; The first parameter is the byte offset to store the RCX result to.
+; The second parameter is the control values to pass to pcmpistri
+;
+%macro CompareAndStore 2
+  pcmpistri xmm2, xmm3, %2
+  mov [rel .indices + %1], cl
+  ArrangeAndStoreFLAGS %1
+%endmacro
+
+movaps xmm2, [rel .data]
+movaps xmm3, [rel .data + 32]
+
+; Unsigned byte string check (lsb, positive polarity)
+CompareAndStore 0, 0b00001000
+
+; Unsigned byte string check (msb, positive polarity)
+CompareAndStore 1, 0b01001000
+
+; Unsigned byte string check (lsb, negative polarity)
+CompareAndStore 2, 0b00011000
+
+; Unsigned byte string check (msb, negative polarity)
+CompareAndStore 3, 0b01011000
+
+; Unsigned byte string check (lsb, negative masked)
+CompareAndStore 4, 0b00111000
+
+; Unsigned byte string check (msb, negative masked)
+CompareAndStore 5, 0b01111000
+
+; --- 16-bit unsigned word tests ---
+
+movaps xmm2, [rel .data16]
+movaps xmm3, [rel .data16 + 32]
+
+; Unsigned word string check (lsb, positive polarity)
+CompareAndStore 6, 0b00001001
+
+; Unsigned word string check (msb, positive polarity)
+CompareAndStore 7, 0b01001001
+
+; Unsigned word string check (lsb, negative polarity)
+CompareAndStore 8, 0b00011001
+
+; Unsigned word string check (msb, negative polarity)
+CompareAndStore 9, 0b01011001
+
+; Unsigned word string check (lsb, negative masked)
+CompareAndStore 10, 0b00111001
+
+; Unsigned word string check (msb, negative masked)
+CompareAndStore 11, 0b01111001
+
+; Load all our stored indices and flags for result comparing
+movaps xmm0, [rel .indices]
+movaps xmm1, [rel .flags]
+
+hlt
+
+align 32
+.data:
+dq 0x6550206F6C6C6548 ; "Hello Pe"
+dq 0x00002121656C706F ; "ople!!\0\0"
+dq 0xFFFFFFFFFFFFFFFF
+dq 0xEEEEEEEEEEEEEEEE
+
+dq 0x2759206F6C6C6548 ; "Hello Y'"
+dq 0x00212121216C6C61 ; "all!!!!\0"
+dq 0xDDDDDDDDDDDDDDDD
+dq 0xCCCCCCCCCCCCCCCC
+
+.data16:
+dq 0x306F8A9E672C65E5 ; "日本語は"
+dq 0x000030443057697D ; "楽しい\0" (Japanese is fun)
+dq 0xAAAAAAAAAAAAAAAA
+dq 0xBBBBBBBBBBBBBBBB
+
+dq 0x306F8A9E672C65E5 ; "日本語は"
+dq 0x00003044305796E3 ; "難しい\0" (Japanese is hard)
+dq 0x8888888888888888
+dq 0x9999999999999999
+
+.indices:
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+
+.flags:
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000

--- a/unittests/ASM/H0F3A/pcmpistri_equal_ordered.asm
+++ b/unittests/ASM/H0F3A/pcmpistri_equal_ordered.asm
@@ -1,0 +1,148 @@
+%ifdef CONFIG
+{
+  "RegData": {
+      "XMM0": ["0x05050F000F000902", "0x0000000006000700"],
+      "XMM1": ["0x1919313131311111", "0x0000000039393939"],
+      "XMM2": ["0x306F000030443057", "0x000030443057697D"],
+      "XMM3": ["0x306F8A9E672C65E5", "0x00003044305796E3"]
+  }
+}
+%endif
+
+; Adjusts the result from LAHF and SETO so that we have a set of flags organized
+; like [OF, SF, ZF, AF, PF, CF] for storing into the .flags region
+; of memory.
+;
+; The first parameter is the byte offset to store the flag result
+; at in the .flags region of memory.
+;
+%macro ArrangeAndStoreFLAGS 1
+  lahf
+  seto bl
+  movzx bx, bl
+
+  shr ax, 8
+  shl bx, 5
+
+  mov di, ax
+  mov si, ax
+
+  ; Mask and shift
+  and di, 0b0000_0000_0000_0100 ; PF
+  and si, 0b0000_0000_0001_0000 ; AF
+  shr di, 1
+  shr si, 2
+
+  ; OR all of them together
+  or bx, di
+  or bx, si
+
+  ; Reclaim DI for getting ZF/SF and shift into place
+  mov di, ax
+  and di, 0b0000_0000_1100_0000 ; ZF and SF
+  shr di, 3
+
+  ; Finally mask and OR all of the bits together
+  and ax, 0b0000_0000_0000_0001 ; CF
+  or bx, ax
+  or bx, di
+
+  ; Store result to .flags memory
+  mov [rel .flags + %1], bl
+%endmacro
+
+; Performs the string comparison and moves the result from RCX to
+; a region of memory in the .indices section specified by a byte
+; offset.
+;
+; The first parameter is the byte offset to store the RCX result to.
+; The second parameter is the control values to pass to pcmpistri
+;
+%macro CompareAndStore 2
+  pcmpistri xmm2, xmm3, %2
+  mov [rel .indices + %1], cl
+  ArrangeAndStoreFLAGS %1
+%endmacro
+
+movaps xmm2, [rel .data]
+movaps xmm3, [rel .data + 32]
+
+; Unsigned byte string check (lsb, positive polarity)
+CompareAndStore 0, 0b00001100
+
+; Unsigned byte string check (msb, positive polarity)
+CompareAndStore 1, 0b01001100
+
+; Unsigned byte string check (lsb, negative polarity)
+CompareAndStore 2, 0b00011100
+
+; Unsigned byte string check (msb, negative polarity)
+CompareAndStore 3, 0b01011100
+
+; Unsigned byte string check (lsb, negative masked)
+CompareAndStore 4, 0b00111100
+
+; Unsigned byte string check (msb, negative masked)
+CompareAndStore 5, 0b01111100
+
+; --- 16-bit unsigned word tests ---
+movaps xmm2, [rel .data16]
+movaps xmm3, [rel .data16 + 32]
+
+CompareAndStore 6, 0b00001101
+
+; Unsigned word string check (msb, positive polarity)
+CompareAndStore 7, 0b01001101
+
+; Unsigned word string check (lsb, negative polarity)
+CompareAndStore 8, 0b00011101
+
+; Unsigned word string check (msb, negative polarity)
+CompareAndStore 9, 0b01011101
+
+; Unsigned word string check (lsb, negative masked)
+CompareAndStore 10, 0b00111101
+
+; Unsigned word string check (msb, negative masked)
+CompareAndStore 11, 0b01111101
+
+; Load all our stored indices and flags for result comparing
+movaps xmm0, [rel .indices]
+movaps xmm1, [rel .flags]
+
+hlt
+
+align 32
+.data:
+dq 0x6550206F6F006C6C ; "ll" with junk following it
+dq 0x21212121656C706F
+dq 0xFFFFFFFFFFFFFFFF
+dq 0xEEEEEEEEEEEEEEEE
+
+dq 0x2759206F6C6C6548 ; "Hello Y'"
+dq 0x21212121216C6C61 ; "all!!!!!"
+dq 0xDDDDDDDDDDDDDDDD
+dq 0xCCCCCCCCCCCCCCCC
+
+.data16:
+dq 0x306F000030443057 ; "しい" followed by junk
+dq 0x000030443057697D
+dq 0xAAAAAAAAAAAAAAAA
+dq 0xBBBBBBBBBBBBBBBB
+
+dq 0x306F8A9E672C65E5 ; "日本語は"
+dq 0x00003044305796E3 ; "難しい\0" (Japanese is hard)
+dq 0x8888888888888888
+dq 0x9999999999999999
+
+.indices:
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+
+.flags:
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000

--- a/unittests/ASM/H0F3A/pcmpistri_ranges.asm
+++ b/unittests/ASM/H0F3A/pcmpistri_ranges.asm
@@ -1,0 +1,146 @@
+%ifdef CONFIG
+{
+  "RegData": {
+      "XMM0": ["0x00060F000F000D01", "0x0000000000070007"],
+      "XMM1": ["0x3111313131311111", "0x0000000000313131"],
+      "XMM2": ["0x005A0041007A0061", "0x55AACCBBFF220000"],
+      "XMM3": ["0x006500200027003F", "0x00210065004F0065"]
+  }
+}
+%endif
+
+; Adjusts the result from LAHF and SETO so that we have a set of flags organized
+; like [OF, SF, ZF, AF, PF, CF] for storing into the .flags region
+; of memory.
+;
+; The first parameter is the byte offset to store the flag result
+; at in the .flags region of memory.
+;
+%macro ArrangeAndStoreFLAGS 1
+  lahf
+  seto bl
+  movzx bx, bl
+
+  shr ax, 8
+  shl bx, 5
+
+  mov di, ax
+  mov si, ax
+
+  ; Mask and shift
+  and di, 0b0000_0000_0000_0100 ; PF
+  and si, 0b0000_0000_0001_0000 ; AF
+  shr di, 1
+  shr si, 2
+
+  ; OR all of them together
+  or bx, di
+  or bx, si
+
+  ; Reclaim DI for getting ZF/SF and shift into place
+  mov di, ax
+  and di, 0b0000_0000_1100_0000 ; ZF and SF
+  shr di, 3
+
+  ; Finally mask and OR all of the bits together
+  and ax, 0b0000_0000_0000_0001 ; CF
+  or bx, ax
+  or bx, di
+
+  ; Store result to .flags memory
+  mov [rel .flags + %1], bl
+%endmacro
+
+; Performs the string comparison and moves the result from RCX to
+; a region of memory in the .indices section specified by a byte
+; offset.
+;
+; The first parameter is the byte offset to store the RCX result to.
+; The second parameter is the control values to pass to pcmpistri
+;
+%macro CompareAndStore 2
+  pcmpistri xmm2, xmm3, %2
+  mov [rel .indices + %1], cl
+  ArrangeAndStoreFLAGS %1
+%endmacro
+
+movaps xmm2, [rel .data]
+movaps xmm3, [rel .data + 32]
+
+; Range unsigned byte check (lsb, positive polarity)
+CompareAndStore 0, 0b00000100
+
+; Range unsigned byte check (msb, positive polarity)
+CompareAndStore 1, 0b01000100
+
+; Range unsigned byte check (lsb, negative polarity)
+CompareAndStore 2, 0b00010100
+
+; Range unsigned byte check (msb, negative polarity)
+CompareAndStore 3, 0b01010100
+
+; Range unsigned byte check (lsb, negative masked)
+CompareAndStore 4, 0b00110100
+
+; Range unsigned byte check (msb, negative masked)
+CompareAndStore 5, 0b01110100
+
+; --- 16-bit unsigned word tests ---
+movaps xmm2, [rel .data16]
+movaps xmm3, [rel .data16 + 32]
+
+; Range unsigned word check (msb, positive polarity)
+CompareAndStore 6, 0b01000101
+
+; Range unsigned word check (lsb, negative polarity)
+CompareAndStore 7, 0b00010101
+
+; Range unsigned word check (msb, negative polarity)
+CompareAndStore 8, 0b01010101
+
+; Range unsigned word check (lsb, negative masked)
+CompareAndStore 9, 0b00110101
+
+; Range unsigned word check (msb, negative masked)
+CompareAndStore 10, 0b01110101
+
+; Load all our stored indices and flags for result comparing
+movaps xmm0, [rel .indices]
+movaps xmm1, [rel .flags]
+
+hlt
+
+align 32
+.data:
+dq 0x998877005A417A61 ; "azAZ" (followed by junk)
+dq 0x55AACCBBFF223344
+dq 0xFFFFFFFFFFFFFFFF
+dq 0xEEEEEEEEEEEEEEEE
+
+dq 0x726548206D27493F ; "?I'm Her"
+dq 0x21216E65704F2065 ; "e Open!!"
+dq 0xFFFFFFFFFFFFFFFF
+dq 0xEEEEEEEEEEEEEEEE
+
+.data16:
+dq 0x005A0041007A0061 ; "azAZ"
+dq 0x55AACCBBFF220000
+dq 0xAAAAAAAAAAAAAAAA
+dq 0xBBBBBBBBBBBBBBBB
+
+dq 0x006500200027003F ; "?' e"
+dq 0x00210065004F0065 ; "eOen!"
+dq 0x8888888888888888
+dq 0x9999999999999999
+
+.indices:
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+
+.flags:
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000

--- a/unittests/ASM/VEX/vpcmpistri_equal_any.asm
+++ b/unittests/ASM/VEX/vpcmpistri_equal_any.asm
@@ -1,0 +1,147 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+      "XMM0": ["0x04060F000F000D07", "0x0000000000040407", "0x0000000000000000", "0x0000000000000000"],
+      "XMM1": ["0x1939313131311111", "0x0000000000191919", "0x0000000000000000", "0x0000000000000000"],
+      "XMM2": ["0x306F8A9E672C65E5", "0x000030443057697D", "0xAAAAAAAAAAAAAAAA", "0xBBBBBBBBBBBBBBBB"],
+      "XMM3": ["0x306F8A9E672C65E5", "0x00003044305796E3", "0x8888888888888888", "0x9999999999999999"]
+  }
+}
+%endif
+
+; Adjusts the result from LAHF and SETO so that we have a set of flags organized
+; like [OF, SF, ZF, AF, PF, CF] for storing into the .flags region
+; of memory.
+;
+; The first parameter is the byte offset to store the flag result
+; at in the .flags region of memory.
+;
+%macro ArrangeAndStoreFLAGS 1
+  lahf
+  seto bl
+  movzx bx, bl
+
+  shr ax, 8
+  shl bx, 5
+
+  mov di, ax
+  mov si, ax
+
+  ; Mask and shift
+  and di, 0b0000_0000_0000_0100 ; PF
+  and si, 0b0000_0000_0001_0000 ; AF
+  shr di, 1
+  shr si, 2
+
+  ; OR all of them together
+  or bx, di
+  or bx, si
+
+  ; Reclaim DI for getting ZF/SF and shift into place
+  mov di, ax
+  and di, 0b0000_0000_1100_0000 ; ZF and SF
+  shr di, 3
+
+  ; Finally mask and OR all of the bits together
+  and ax, 0b0000_0000_0000_0001 ; CF
+  or bx, ax
+  or bx, di
+
+  ; Store result to .flags memory
+  mov [rel .flags + %1], bl
+%endmacro
+
+; Performs the string comparison and moves the result from RCX to
+; a region of memory in the .indices section specified by a byte
+; offset.
+;
+; The first parameter is the byte offset to store the RCX result to.
+; The second parameter is the control values to pass to vpcmpistri
+;
+%macro CompareAndStore 2
+  vpcmpistri xmm2, xmm3, %2
+  mov [rel .indices + %1], cl
+  ArrangeAndStoreFLAGS %1
+%endmacro
+
+vmovaps ymm2, [rel .data]
+vmovaps ymm3, [rel .data + 32]
+
+; Unsigned byte character check (lsb, positive polarity)
+CompareAndStore 0, 0b00000000
+
+; Unsigned byte character check (msb, positive polarity)
+CompareAndStore 1, 0b01000000
+
+; Unsigned byte character check (lsb, negative polarity)
+CompareAndStore 2, 0b00010000
+
+; Unsigned byte character check (msb, negative polarity)
+CompareAndStore 3, 0b01010000
+
+; Unsigned byte character check (lsb, negative masked)
+CompareAndStore 4, 0b00110000
+
+; Unsigned byte character check (msb, negative masked)
+CompareAndStore 5, 0b01110000
+
+; --- 16-bit unsigned word tests ---
+vmovaps ymm2, [rel .data16]
+vmovaps ymm3, [rel .data16 + 32]
+
+; Unsigned word character check (msb, positive polarity)
+CompareAndStore 6, 0b01000001
+
+; Unsigned word character check (lsb, negative polarity)
+CompareAndStore 7, 0b00010001
+
+; Unsigned word character check (msb, negative polarity)
+CompareAndStore 8, 0b01010001
+
+; Unsigned word character check (lsb, negative masked)
+CompareAndStore 9, 0b00110001
+
+; Unsigned word character check (msb, negative masked)
+CompareAndStore 10, 0b01110001
+
+; Load all our stored indices and flags for result comparing
+vmovaps ymm0, [rel .indices]
+vmovaps ymm1, [rel .flags]
+
+hlt
+
+align 32
+.data:
+dq 0x6463626144434241 ; "ABCDabcd"
+dq 0x6C6B6A694C4B4A00 ; "\0JKLijkl"
+dq 0xFFFFFFFFFFFFFFFF
+dq 0xEEEEEEEEEEEEEEEE
+
+dq 0x4120492065726548 ; "Here I A"
+dq 0x6C4C612759202C6D ; "m, Y'aLl"
+dq 0xDDDDDDDDDDDDDDDD
+dq 0xCCCCCCCCCCCCCCCC
+
+.data16:
+dq 0x306F8A9E672C65E5 ; "日本語は"
+dq 0x000030443057697D ; "楽しい\0" (Japanese is fun)
+dq 0xAAAAAAAAAAAAAAAA
+dq 0xBBBBBBBBBBBBBBBB
+
+dq 0x306F8A9E672C65E5 ; "日本語は"
+dq 0x00003044305796E3 ; "難しい\0" (Japanese is hard)
+dq 0x8888888888888888
+dq 0x9999999999999999
+
+.indices:
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+
+.flags:
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000

--- a/unittests/ASM/VEX/vpcmpistri_equal_each.asm
+++ b/unittests/ASM/VEX/vpcmpistri_equal_each.asm
@@ -1,0 +1,151 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+      "XMM0": ["0x07000F060E060F00", "0x0000000007040404", "0x0000000000000000", "0x0000000000000000"],
+      "XMM1": ["0x3939191919193939", "0x0000000019191919", "0x0000000000000000", "0x0000000000000000"],
+      "XMM2": ["0x306F8A9E672C65E5", "0x000030443057697D", "0xAAAAAAAAAAAAAAAA", "0xBBBBBBBBBBBBBBBB"],
+      "XMM3": ["0x306F8A9E672C65E5", "0x00003044305796E3", "0x8888888888888888", "0x9999999999999999"]
+  }
+}
+%endif
+
+; Adjusts the result from LAHF and SETO so that we have a set of flags organized
+; like [OF, SF, ZF, AF, PF, CF] for storing into the .flags region
+; of memory.
+;
+; The first parameter is the byte offset to store the flag result
+; at in the .flags region of memory.
+;
+%macro ArrangeAndStoreFLAGS 1
+  lahf
+  seto bl
+  movzx bx, bl
+
+  shr ax, 8
+  shl bx, 5
+
+  mov di, ax
+  mov si, ax
+
+  ; Mask and shift
+  and di, 0b0000_0000_0000_0100 ; PF
+  and si, 0b0000_0000_0001_0000 ; AF
+  shr di, 1
+  shr si, 2
+
+  ; OR all of them together
+  or bx, di
+  or bx, si
+
+  ; Reclaim DI for getting ZF/SF and shift into place
+  mov di, ax
+  and di, 0b0000_0000_1100_0000 ; ZF and SF
+  shr di, 3
+
+  ; Finally mask and OR all of the bits together
+  and ax, 0b0000_0000_0000_0001 ; CF
+  or bx, ax
+  or bx, di
+
+  ; Store result to .flags memory
+  mov [rel .flags + %1], bl
+%endmacro
+
+; Performs the string comparison and moves the result from RCX to
+; a region of memory in the .indices section specified by a byte
+; offset.
+;
+; The first parameter is the byte offset to store the RCX result to.
+; The second parameter is the control values to pass to vpcmpistri
+;
+%macro CompareAndStore 2
+  vpcmpistri xmm2, xmm3, %2
+  mov [rel .indices + %1], cl
+  ArrangeAndStoreFLAGS %1
+%endmacro
+
+vmovaps ymm2, [rel .data]
+vmovaps ymm3, [rel .data + 32]
+
+; Unsigned byte string check (lsb, positive polarity)
+CompareAndStore 0, 0b00001000
+
+; Unsigned byte string check (msb, positive polarity)
+CompareAndStore 1, 0b01001000
+
+; Unsigned byte string check (lsb, negative polarity)
+CompareAndStore 2, 0b00011000
+
+; Unsigned byte string check (msb, negative polarity)
+CompareAndStore 3, 0b01011000
+
+; Unsigned byte string check (lsb, negative masked)
+CompareAndStore 4, 0b00111000
+
+; Unsigned byte string check (msb, negative masked)
+CompareAndStore 5, 0b01111000
+
+; --- 16-bit unsigned word tests ---
+
+vmovaps ymm2, [rel .data16]
+vmovaps ymm3, [rel .data16 + 32]
+
+; Unsigned word string check (lsb, positive polarity)
+CompareAndStore 6, 0b00001001
+
+; Unsigned word string check (msb, positive polarity)
+CompareAndStore 7, 0b01001001
+
+; Unsigned word string check (lsb, negative polarity)
+CompareAndStore 8, 0b00011001
+
+; Unsigned word string check (msb, negative polarity)
+CompareAndStore 9, 0b01011001
+
+; Unsigned word string check (lsb, negative masked)
+CompareAndStore 10, 0b00111001
+
+; Unsigned word string check (msb, negative masked)
+CompareAndStore 11, 0b01111001
+
+; Load all our stored indices and flags for result comparing
+vmovaps ymm0, [rel .indices]
+vmovaps ymm1, [rel .flags]
+
+hlt
+
+align 32
+.data:
+dq 0x6550206F6C6C6548 ; "Hello Pe"
+dq 0x00002121656C706F ; "ople!!\0\0"
+dq 0xFFFFFFFFFFFFFFFF
+dq 0xEEEEEEEEEEEEEEEE
+
+dq 0x2759206F6C6C6548 ; "Hello Y'"
+dq 0x00212121216C6C61 ; "all!!!!\0"
+dq 0xDDDDDDDDDDDDDDDD
+dq 0xCCCCCCCCCCCCCCCC
+
+.data16:
+dq 0x306F8A9E672C65E5 ; "日本語は"
+dq 0x000030443057697D ; "楽しい\0" (Japanese is fun)
+dq 0xAAAAAAAAAAAAAAAA
+dq 0xBBBBBBBBBBBBBBBB
+
+dq 0x306F8A9E672C65E5 ; "日本語は"
+dq 0x00003044305796E3 ; "難しい\0" (Japanese is hard)
+dq 0x8888888888888888
+dq 0x9999999999999999
+
+.indices:
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+
+.flags:
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000

--- a/unittests/ASM/VEX/vpcmpistri_equal_ordered.asm
+++ b/unittests/ASM/VEX/vpcmpistri_equal_ordered.asm
@@ -1,0 +1,149 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+      "XMM0": ["0x05050F000F000902", "0x0000000006000700", "0x0000000000000000", "0x0000000000000000"],
+      "XMM1": ["0x1919313131311111", "0x0000000039393939", "0x0000000000000000", "0x0000000000000000"],
+      "XMM2": ["0x306F000030443057", "0x000030443057697D", "0xAAAAAAAAAAAAAAAA", "0xBBBBBBBBBBBBBBBB"],
+      "XMM3": ["0x306F8A9E672C65E5", "0x00003044305796E3", "0x8888888888888888", "0x9999999999999999"]
+  }
+}
+%endif
+
+; Adjusts the result from LAHF and SETO so that we have a set of flags organized
+; like [OF, SF, ZF, AF, PF, CF] for storing into the .flags region
+; of memory.
+;
+; The first parameter is the byte offset to store the flag result
+; at in the .flags region of memory.
+;
+%macro ArrangeAndStoreFLAGS 1
+  lahf
+  seto bl
+  movzx bx, bl
+
+  shr ax, 8
+  shl bx, 5
+
+  mov di, ax
+  mov si, ax
+
+  ; Mask and shift
+  and di, 0b0000_0000_0000_0100 ; PF
+  and si, 0b0000_0000_0001_0000 ; AF
+  shr di, 1
+  shr si, 2
+
+  ; OR all of them together
+  or bx, di
+  or bx, si
+
+  ; Reclaim DI for getting ZF/SF and shift into place
+  mov di, ax
+  and di, 0b0000_0000_1100_0000 ; ZF and SF
+  shr di, 3
+
+  ; Finally mask and OR all of the bits together
+  and ax, 0b0000_0000_0000_0001 ; CF
+  or bx, ax
+  or bx, di
+
+  ; Store result to .flags memory
+  mov [rel .flags + %1], bl
+%endmacro
+
+; Performs the string comparison and moves the result from RCX to
+; a region of memory in the .indices section specified by a byte
+; offset.
+;
+; The first parameter is the byte offset to store the RCX result to.
+; The second parameter is the control values to pass to vpcmpistri
+;
+%macro CompareAndStore 2
+  vpcmpistri xmm2, xmm3, %2
+  mov [rel .indices + %1], cl
+  ArrangeAndStoreFLAGS %1
+%endmacro
+
+vmovaps ymm2, [rel .data]
+vmovaps ymm3, [rel .data + 32]
+
+; Unsigned byte string check (lsb, positive polarity)
+CompareAndStore 0, 0b00001100
+
+; Unsigned byte string check (msb, positive polarity)
+CompareAndStore 1, 0b01001100
+
+; Unsigned byte string check (lsb, negative polarity)
+CompareAndStore 2, 0b00011100
+
+; Unsigned byte string check (msb, negative polarity)
+CompareAndStore 3, 0b01011100
+
+; Unsigned byte string check (lsb, negative masked)
+CompareAndStore 4, 0b00111100
+
+; Unsigned byte string check (msb, negative masked)
+CompareAndStore 5, 0b01111100
+
+; --- 16-bit unsigned word tests ---
+vmovaps ymm2, [rel .data16]
+vmovaps ymm3, [rel .data16 + 32]
+
+CompareAndStore 6, 0b00001101
+
+; Unsigned word string check (msb, positive polarity)
+CompareAndStore 7, 0b01001101
+
+; Unsigned word string check (lsb, negative polarity)
+CompareAndStore 8, 0b00011101
+
+; Unsigned word string check (msb, negative polarity)
+CompareAndStore 9, 0b01011101
+
+; Unsigned word string check (lsb, negative masked)
+CompareAndStore 10, 0b00111101
+
+; Unsigned word string check (msb, negative masked)
+CompareAndStore 11, 0b01111101
+
+; Load all our stored indices and flags for result comparing
+vmovaps ymm0, [rel .indices]
+vmovaps ymm1, [rel .flags]
+
+hlt
+
+align 32
+.data:
+dq 0x6550206F6F006C6C ; "ll" with junk following it
+dq 0x21212121656C706F
+dq 0xFFFFFFFFFFFFFFFF
+dq 0xEEEEEEEEEEEEEEEE
+
+dq 0x2759206F6C6C6548 ; "Hello Y'"
+dq 0x21212121216C6C61 ; "all!!!!!"
+dq 0xDDDDDDDDDDDDDDDD
+dq 0xCCCCCCCCCCCCCCCC
+
+.data16:
+dq 0x306F000030443057 ; "しい" followed by junk
+dq 0x000030443057697D
+dq 0xAAAAAAAAAAAAAAAA
+dq 0xBBBBBBBBBBBBBBBB
+
+dq 0x306F8A9E672C65E5 ; "日本語は"
+dq 0x00003044305796E3 ; "難しい\0" (Japanese is hard)
+dq 0x8888888888888888
+dq 0x9999999999999999
+
+.indices:
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+
+.flags:
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000

--- a/unittests/ASM/VEX/vpcmpistri_ranges.asm
+++ b/unittests/ASM/VEX/vpcmpistri_ranges.asm
@@ -1,0 +1,147 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+      "XMM0": ["0x00060F000F000D01", "0x0000000000070007", "0x0000000000000000", "0x0000000000000000"],
+      "XMM1": ["0x3111313131311111", "0x0000000000313131", "0x0000000000000000", "0x0000000000000000"],
+      "XMM2": ["0x005A0041007A0061", "0x55AACCBBFF220000", "0xAAAAAAAAAAAAAAAA", "0xBBBBBBBBBBBBBBBB"],
+      "XMM3": ["0x006500200027003F", "0x00210065004F0065", "0x8888888888888888", "0x9999999999999999"]
+  }
+}
+%endif
+
+; Adjusts the result from LAHF and SETO so that we have a set of flags organized
+; like [OF, SF, ZF, AF, PF, CF] for storing into the .flags region
+; of memory.
+;
+; The first parameter is the byte offset to store the flag result
+; at in the .flags region of memory.
+;
+%macro ArrangeAndStoreFLAGS 1
+  lahf
+  seto bl
+  movzx bx, bl
+
+  shr ax, 8
+  shl bx, 5
+
+  mov di, ax
+  mov si, ax
+
+  ; Mask and shift
+  and di, 0b0000_0000_0000_0100 ; PF
+  and si, 0b0000_0000_0001_0000 ; AF
+  shr di, 1
+  shr si, 2
+
+  ; OR all of them together
+  or bx, di
+  or bx, si
+
+  ; Reclaim DI for getting ZF/SF and shift into place
+  mov di, ax
+  and di, 0b0000_0000_1100_0000 ; ZF and SF
+  shr di, 3
+
+  ; Finally mask and OR all of the bits together
+  and ax, 0b0000_0000_0000_0001 ; CF
+  or bx, ax
+  or bx, di
+
+  ; Store result to .flags memory
+  mov [rel .flags + %1], bl
+%endmacro
+
+; Performs the string comparison and moves the result from RCX to
+; a region of memory in the .indices section specified by a byte
+; offset.
+;
+; The first parameter is the byte offset to store the RCX result to.
+; The second parameter is the control values to pass to vpcmpistri
+;
+%macro CompareAndStore 2
+  vpcmpistri xmm2, xmm3, %2
+  mov [rel .indices + %1], cl
+  ArrangeAndStoreFLAGS %1
+%endmacro
+
+vmovaps ymm2, [rel .data]
+vmovaps ymm3, [rel .data + 32]
+
+; Range unsigned byte check (lsb, positive polarity)
+CompareAndStore 0, 0b00000100
+
+; Range unsigned byte check (msb, positive polarity)
+CompareAndStore 1, 0b01000100
+
+; Range unsigned byte check (lsb, negative polarity)
+CompareAndStore 2, 0b00010100
+
+; Range unsigned byte check (msb, negative polarity)
+CompareAndStore 3, 0b01010100
+
+; Range unsigned byte check (lsb, negative masked)
+CompareAndStore 4, 0b00110100
+
+; Range unsigned byte check (msb, negative masked)
+CompareAndStore 5, 0b01110100
+
+; --- 16-bit unsigned word tests ---
+vmovaps ymm2, [rel .data16]
+vmovaps ymm3, [rel .data16 + 32]
+
+; Range unsigned word check (msb, positive polarity)
+CompareAndStore 6, 0b01000101
+
+; Range unsigned word check (lsb, negative polarity)
+CompareAndStore 7, 0b00010101
+
+; Range unsigned word check (msb, negative polarity)
+CompareAndStore 8, 0b01010101
+
+; Range unsigned word check (lsb, negative masked)
+CompareAndStore 9, 0b00110101
+
+; Range unsigned word check (msb, negative masked)
+CompareAndStore 10, 0b01110101
+
+; Load all our stored indices and flags for result comparing
+vmovaps ymm0, [rel .indices]
+vmovaps ymm1, [rel .flags]
+
+hlt
+
+align 32
+.data:
+dq 0x998877005A417A61 ; "azAZ" (followed by junk)
+dq 0x55AACCBBFF223344
+dq 0xFFFFFFFFFFFFFFFF
+dq 0xEEEEEEEEEEEEEEEE
+
+dq 0x726548206D27493F ; "?I'm Her"
+dq 0x21216E65704F2065 ; "e Open!!"
+dq 0xFFFFFFFFFFFFFFFF
+dq 0xEEEEEEEEEEEEEEEE
+
+.data16:
+dq 0x005A0041007A0061 ; "azAZ"
+dq 0x55AACCBBFF220000
+dq 0xAAAAAAAAAAAAAAAA
+dq 0xBBBBBBBBBBBBBBBB
+
+dq 0x006500200027003F ; "?' e"
+dq 0x00210065004F0065 ; "eOen!"
+dq 0x8888888888888888
+dq 0x9999999999999999
+
+.indices:
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+
+.flags:
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000


### PR DESCRIPTION
Handles the implicit variant of the string-compare-returning-index instructions. Now all that remains is the masked variants.