### PR TITLE
Ioctl: Add default handler for drm

### DIFF
--- a/Source/Tools/FEXLoader/LinuxSyscalls/x32/IoctlEmulation.cpp
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/x32/IoctlEmulation.cpp
@@ -567,6 +567,12 @@ namespace FEX::HLE::x32 {
       return -EPERM;
     }
 
+    uint32_t Default_Handler(int fd, uint32_t cmd, uint32_t args) {
+      // Default handler assumes everything is correct and doesn't need to do any work.
+      uint64_t Result = ::ioctl(fd, cmd, args);
+      SYSCALL_ERRNO();
+    }
+
     void AssignDeviceTypeToFD(int fd, drm_version const &Version) {
       if (Version.name) {
         if (strcmp(Version.name, "amdgpu") == 0) {
@@ -600,7 +606,8 @@ namespace FEX::HLE::x32 {
           FDToHandler.SetFDHandler(fd, Virtio_Handler);
         }
         else {
-          LogMan::Msg::EFmt("Unknown DRM device: '{}'", Version.name);
+          LogMan::Msg::IFmt("Unknown DRM device: '{}'. Using default passthrough", Version.name);
+          FDToHandler.SetFDHandler(fd, Default_Handler);
         }
       }
     }


### PR DESCRIPTION
In the case that an unknown drm device shows up, send it down the default handler. This handler is just a passthrough and assumes that the kernel doesn't have any compat handlers for that device.

This is nicer than crashing or returning EPERM, since then downstream drm drivers like Xe, Asahi, and PVR and still try to run.

We of course still want to run their struct definitions through CI once they go upstream.