### PR TITLE
OpcodeDispatcher: Simplify PCMPXSTRIOpImpl

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -862,11 +862,7 @@ private:
                              const X86Tables::DecodedOperand& Src2,
                              const X86Tables::DecodedOperand& Imm);
 
-  OrderedNode* PCMPXSTRIOpImpl(OpcodeArgs,
-                               const X86Tables::DecodedOperand& Src1,
-                               const X86Tables::DecodedOperand& Src2,
-                               const X86Tables::DecodedOperand& Imm,
-                               bool IsExplicit);
+  void PCMPXSTRXOpImpl(OpcodeArgs, bool IsExplicit);
 
   OrderedNode* PHADDSOpImpl(OpcodeArgs, const X86Tables::DecodedOperand& Src1,
                             const X86Tables::DecodedOperand& Src2);


### PR DESCRIPTION
All variants of the PCMPXSTRX instructions will take their arguments in the same manner, so we don't need to specify them for each handler.

We can also rename the function to PCMPXSTRXOpImpl, since this will be extended to handle the masking variants of the string instructions.