### PR TITLE
FEXCore: Compile without exceptions

### DIFF
--- a/External/FEXCore/CMakeLists.txt
+++ b/External/FEXCore/CMakeLists.txt
@@ -77,6 +77,7 @@ configure_file(
 
 include_directories(${CMAKE_BINARY_DIR}/generated)
 
+add_compile_options(-fno-exceptions)
 add_subdirectory(Source/)
 
 install (DIRECTORY include/FEXCore ${CMAKE_BINARY_DIR}/include/FEXCore

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/X86Dispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/X86Dispatcher.h
@@ -15,6 +15,7 @@
 #define XBYAK_STD_UNORDERED_MAP fextl::unordered_map
 #define XBYAK_STD_UNORDERED_MULTIMAP fextl::unordered_multimap
 #define XBYAK_STD_LIST fextl::list
+#define XBYAK_NO_EXCEPTION
 
 #include <xbyak/xbyak.h>
 #include <xbyak/xbyak_util.h>


### PR DESCRIPTION
This disables some unwinding overhead when FEXCore is already guaranteed to not throw.