### PR TITLE
LookupCache: Removes unnecessary recursive lock_guard

### DIFF
--- a/External/FEXCore/Source/Interface/Core/LookupCache.h
+++ b/External/FEXCore/Source/Interface/Core/LookupCache.h
@@ -168,8 +168,6 @@ public:
 
 private:
   void CacheBlockMapping(uint64_t Address, uintptr_t HostCode) {
-    std::lock_guard<std::recursive_mutex> lk(WriteLock);
-
     // Do L1
     auto &L1Entry = reinterpret_cast<LookupCacheEntry*>(L1Pointer)[Address & L1_ENTRIES_MASK];
     L1Entry.GuestCode = Address;


### PR DESCRIPTION
All code paths to this are already guaranteed to own the lock.

The rest of the codepaths haven't been vetted to actually need recursive_mutex yet, but seems likely that it will be able to get converted to a regular mutex with some more work.