### PR TITLE
ARM64Emitter: Ensure platform register is saved on win32

### DIFF
--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
@@ -133,7 +133,11 @@ void Arm64Emitter::LoadConstant(ARMEmitter::Size s, ARMEmitter::Register Reg, ui
 void Arm64Emitter::PushCalleeSavedRegisters() {
   // We need to save pairs of registers
   // We save r19-r30
-  const std::array<std::pair<ARMEmitter::XRegister, ARMEmitter::XRegister>, 6> CalleeSaved = {{
+  const fextl::vector<std::pair<ARMEmitter::XRegister, ARMEmitter::XRegister>> CalleeSaved = {{
+#ifdef _WIN32
+    // Platform register, Just save it twice to make logic easy.
+    {ARMEmitter::XReg::x18, ARMEmitter::XReg::x18},
+#endif
     {ARMEmitter::XReg::x19, ARMEmitter::XReg::x20},
     {ARMEmitter::XReg::x21, ARMEmitter::XReg::x22},
     {ARMEmitter::XReg::x23, ARMEmitter::XReg::x24},
@@ -197,13 +201,17 @@ void Arm64Emitter::PopCalleeSavedRegisters() {
         32);
   }
 
-  const std::array<std::pair<ARMEmitter::XRegister, ARMEmitter::XRegister>, 6> CalleeSaved = {{
+  const fextl::vector<std::pair<ARMEmitter::XRegister, ARMEmitter::XRegister>> CalleeSaved = {{
     {ARMEmitter::XReg::x29, ARMEmitter::XReg::x30},
     {ARMEmitter::XReg::x27, ARMEmitter::XReg::x28},
     {ARMEmitter::XReg::x25, ARMEmitter::XReg::x26},
     {ARMEmitter::XReg::x23, ARMEmitter::XReg::x24},
     {ARMEmitter::XReg::x21, ARMEmitter::XReg::x22},
     {ARMEmitter::XReg::x19, ARMEmitter::XReg::x20},
+#ifdef _WIN32
+    // Platform register.
+    {ARMEmitter::XReg::x18, ARMEmitter::XReg::zr},
+#endif
   }};
 
   for (auto &RegPair : CalleeSaved) {


### PR DESCRIPTION
Platform register stores the TEB region on win32 and needs to be preserved if we're going to overwrite it.

Ensure we do so.