### PR TITLE
Thunks: Fixes xcb helper thread creation

### DIFF
--- a/ThunkLibs/libxcb/libxcb_Guest.cpp
+++ b/ThunkLibs/libxcb/libxcb_Guest.cpp
@@ -80,6 +80,7 @@ extern "C" {
 
     // Start a guest side thread that allows us to do callbacks from xcb safely
     if (!CBThread.joinable()) {
+      CBDone = false;
       CBThread = std::thread(CallbackThreadFunc);
     }
   }
@@ -125,6 +126,18 @@ extern "C" {
     args.p = Ptr;
     fexthunks_libxcb_FEX_usable_size(&args);
     return args.rv;
+  }
+
+  xcb_connection_t * xcb_connect_to_fd(int a_0, xcb_auth_info_t * a_1) {
+    auto ret = fexfn_pack_xcb_connect_to_fd(a_0, a_1);
+
+    if (xcb_get_file_descriptor(ret) != -1) {
+      // Only create callback on valid xcb connections.
+      // Checking for FD is the easiest way to do this.
+      CreateCallback();
+    }
+    InitializeExtensions(ret);
+    return ret;
   }
 
   xcb_connection_t * xcb_connect(const char * a_0,int * a_1){

--- a/ThunkLibs/libxcb/libxcb_interface.cpp
+++ b/ThunkLibs/libxcb/libxcb_interface.cpp
@@ -42,7 +42,7 @@ template<> struct fex_gen_config<xcb_prefetch_extension_data> {};
 template<> struct fex_gen_config<xcb_get_setup> {};
 template<> struct fex_gen_config<xcb_get_file_descriptor> {};
 template<> struct fex_gen_config<xcb_connection_has_error> {};
-template<> struct fex_gen_config<xcb_connect_to_fd> {};
+template<> struct fex_gen_config<xcb_connect_to_fd> : fexgen::custom_guest_entrypoint {};
 
 template<> struct fex_gen_config<xcb_disconnect> : fexgen::custom_guest_entrypoint {};
 


### PR DESCRIPTION
Forgot to initialize CBDone to false before the helper thread is started.
This fixes an issue where an XCB context is created, then stopped, then another is created but immediately exits because CBDone was still true from the previous run.

Also adds the handler for `xcb_connect_to_fd` so we don't miss that usage.