### PR TITLE
FEXCore: Adds support for hardware x86-TSO prctl

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -162,6 +162,9 @@ namespace FEXCore::Context {
       // Only initialize symbols file if enabled. Ensures we don't pollute /tmp with empty files.
       Symbols.InitFile();
     }
+
+    // Track atomic TSO emulation configuration.
+    UpdateAtomicTSOEmulationConfig();
   }
 
   ContextImpl::~ContextImpl() {
@@ -1237,6 +1240,7 @@ namespace FEXCore::Context {
   void ContextImpl::MarkMemoryShared() {
     if (!IsMemoryShared) {
       IsMemoryShared = true;
+      UpdateAtomicTSOEmulationConfig();
 
       if (Config.TSOAutoMigration) {
         std::lock_guard<std::mutex> lkThreads(ThreadCreationMutex);

--- a/External/FEXCore/Source/Interface/Core/ObjectCache/CodeObjectSerializationConfig.h
+++ b/External/FEXCore/Source/Interface/Core/ObjectCache/CodeObjectSerializationConfig.h
@@ -22,6 +22,9 @@ namespace FEXCore::CodeSerialize {
     // Multiblock enabled
     unsigned MultiBlock : 1;
 
+    // Hardware TSO enabled
+    unsigned HardwareTSOEnabled : 1;
+
     // TSO enabled
     unsigned TSOEnabled : 1;
 
@@ -48,13 +51,14 @@ namespace FEXCore::CodeSerialize {
 
     // Padding to remove uninitialized data warning from asan
     // Shows remaining amount of bits available for config
-    unsigned _Pad : 18;
+    unsigned _Pad : 17;
 
     bool operator==(CodeObjectSerializationConfig const &other) const {
       return Cookie == other.Cookie &&
         MaxInstPerBlock == other.MaxInstPerBlock &&
         Arch == other.Arch &&
         MultiBlock == other.MultiBlock &&
+        HardwareTSOEnabled == other.HardwareTSOEnabled &&
         TSOEnabled == other.TSOEnabled &&
         ABILocalFlags == other.ABILocalFlags &&
         ABINoPF == other.ABINoPF &&
@@ -71,6 +75,7 @@ namespace FEXCore::CodeSerialize {
       Hash <<= 32; Hash |= other.MaxInstPerBlock;
       Hash <<= 1;  Hash |= other.Arch;
       Hash <<= 1;  Hash |= other.MultiBlock;
+      Hash <<= 1;  Hash |= other.HardwareTSOEnabled;
       Hash <<= 1;  Hash |= other.TSOEnabled;
       Hash <<= 1;  Hash |= other.ABILocalFlags;
       Hash <<= 1;  Hash |= other.ABINoPF;

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -3807,7 +3807,7 @@ void OpDispatchBuilder::STOSOp(OpcodeArgs) {
     OrderedNode *Counter = LoadGPRRegister(X86State::REG_RCX);
     auto DF = GetRFLAG(FEXCore::X86State::RFLAG_DF_LOC);
 
-    auto Result = _MemSet(CTX->IsTSOEnabled(), Size, Segment ?: InvalidNode, Dest, Src, Counter, DF);
+    auto Result = _MemSet(CTX->IsAtomicTSOEnabled(), Size, Segment ?: InvalidNode, Dest, Src, Counter, DF);
     StoreGPRRegister(X86State::REG_RCX, _Constant(0));
     StoreGPRRegister(X86State::REG_RDI, Result);
   }
@@ -3834,7 +3834,7 @@ void OpDispatchBuilder::MOVSOp(OpcodeArgs) {
     auto DstSegment = GetSegment(0, FEXCore::X86Tables::DecodeFlags::FLAG_ES_PREFIX, true);
     auto SrcSegment = GetSegment(Op->Flags, FEXCore::X86Tables::DecodeFlags::FLAG_DS_PREFIX);
 
-    auto Result = _MemCpy(CTX->IsTSOEnabled(), Size,
+    auto Result = _MemCpy(CTX->IsAtomicTSOEnabled(), Size,
         DstSegment ?: InvalidNode,
         SrcSegment ?: InvalidNode,
         DstAddr, SrcAddr, Counter, DF);

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -1555,14 +1555,14 @@ private:
   uint64_t Entry;
 
   OrderedNode* _StoreMemAutoTSO(FEXCore::IR::RegisterClassType Class, uint8_t Size, OrderedNode *Addr, OrderedNode *Value, uint8_t Align = 1) {
-    if (CTX->IsTSOEnabled())
+    if (CTX->IsAtomicTSOEnabled())
       return _StoreMemTSO(Class, Size, Value, Addr, Invalid(), Align, MEM_OFFSET_SXTX, 1);
     else
       return _StoreMem(Class, Size, Value, Addr, Invalid(), Align, MEM_OFFSET_SXTX, 1);
   }
 
   OrderedNode* _LoadMemAutoTSO(FEXCore::IR::RegisterClassType Class, uint8_t Size, OrderedNode *ssa0, uint8_t Align = 1) {
-    if (CTX->IsTSOEnabled())
+    if (CTX->IsAtomicTSOEnabled())
       return _LoadMemTSO(Class, Size, ssa0, Invalid(), Align, MEM_OFFSET_SXTX, 1);
     else
       return _LoadMem(Class, Size, ssa0, Invalid(), Align, MEM_OFFSET_SXTX, 1);

--- a/External/FEXCore/include/FEXCore/Core/Context.h
+++ b/External/FEXCore/include/FEXCore/Core/Context.h
@@ -288,6 +288,14 @@ namespace FEXCore::Context {
       FEX_DEFAULT_VISIBILITY virtual void GetVDSOSigReturn(VDSOSigReturn *VDSOPointers) = 0;
 
       FEX_DEFAULT_VISIBILITY virtual void IncrementIdleRefCount() = 0;
+
+      /**
+       * @brief Informs the context if hardware TSO is supported.
+       * Once hardware TSO is enabled, then TSO emulation through atomics is disabled and relies on the hardware.
+       *
+       * @param HardwareTSOSupported If the hardware supports the TSO memory model or not.
+       */
+      FEX_DEFAULT_VISIBILITY virtual void SetHardwareTSOSupport(bool HardwareTSOSupported) = 0;
     private:
   };
 


### PR DESCRIPTION
From https://github.com/AsahiLinux/linux/commits/bits/220-tso

This fails gracefully in the case the upstream kernel doesn't support this feature, so can go in early.

This feature allows FEX to use hardware's TSO emulation capability to reduce emulation overhead from our atomic/lrcpc implementation. In the case that the TSO emulation feature is enabled in FEX, we will check if the hardware supports this feature and then enable it.

If the hardware feature is supported it will then use regular memory accesses with the expectation that these are x86-TSO in strength.

The only hardware that anyone cares about that supports this is Apple's M class SoCs. Theoretically NVIDIA Denver/Carmel supports sequentially consistent, which isn't quite the same thing. I haven't cared to check if multithreaded SC has as strong of guarantees. But also since Carmel/Denver hardware is fairly rare, it's hard to care about for our use case.