### PR TITLE
ARM64: Fixes SRA disabled codepath

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
@@ -90,6 +90,8 @@ public:
   virtual void GetSRAFPRMapping(uint8_t Mapping[16]) const {
   }
 
+  const DispatcherConfig& GetConfig() const { return config; }
+
 protected:
   Dispatcher(FEXCore::Context::ContextImpl *ctx, const DispatcherConfig &Config)
     : CTX {ctx}

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -210,6 +210,16 @@ private:
   /**  @} */
 
   uint32_t SpillSlots{};
+  using OpType = void (Arm64JITCore::*)(IR::IROp_Header const *IROp, IR::NodeID Node);
+
+  // Runtime selection;
+  // Load and store register style.
+  OpType RT_LoadRegister;
+  OpType RT_StoreRegister;
+  // Load and store TSO memory style
+  OpType RT_LoadMemTSO;
+  OpType RT_StoreMemTSO;
+
 #define DEF_OP(x) void Op_##x(IR::IROp_Header const *IROp, IR::NodeID Node)
 
   ///< Unhandled handler
@@ -318,6 +328,8 @@ private:
   DEF_OP(StoreContext);
   DEF_OP(LoadRegister);
   DEF_OP(StoreRegister);
+  DEF_OP(LoadRegisterSRA);
+  DEF_OP(StoreRegisterSRA);
   DEF_OP(LoadContextIndexed);
   DEF_OP(StoreContextIndexed);
   DEF_OP(SpillRegister);


### PR DESCRIPTION
Disabling SRA has been broken a quite a while. Disabling this was instrumental in figuring out the VC redistributable crash.

Ensure it works by reintroducing non-SRA load/store register handlers, and by supporting runtime selectable dispatch pointers for the JIT.

Side-bonus, moves the {LOAD,STORE}MEMTSO ops over to this dispatch as well to make it consistent and probably slightly quicker.