### PR TITLE
FEXCore: Support Wine syscalls

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
@@ -216,8 +216,11 @@ DEF_OP(Syscall) {
 
     PopDynamicRegsAndLR();
 
-    // Move result to its destination register
-    mov(ARMEmitter::Size::i64Bit, GetReg(Node), ARMEmitter::Reg::r0);
+    if ((Flags & FEXCore::IR::SyscallFlags::NORETURNEDRESULT) != FEXCore::IR::SyscallFlags::NORETURNEDRESULT) {
+      // Move result to its destination register.
+      // Only if `NORETURNEDRESULT` wasn't set, otherwise we might overwrite the CPUState refilled with `FillStaticRegs`
+      mov(ARMEmitter::Size::i64Bit, GetReg(Node), ARMEmitter::Reg::r0);
+    }
   }
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
@@ -146,6 +146,7 @@ DEF_OP(Syscall) {
   auto Op = IROp->C<IR::IROp_Syscall>();
   // XXX: This is very terrible, but I don't care for right now
 
+  FEXCore::IR::SyscallFlags Flags = Op->Flags;
   auto NumPush = RA64.size();
 
   for (auto &Reg : RA64)
@@ -186,7 +187,11 @@ DEF_OP(Syscall) {
   for (uint32_t i = RA64.size(); i > 0; --i)
     pop(RA64[i - 1]);
 
-  mov (GetDst<RA_64>(Node), rax);
+  if ((Flags & FEXCore::IR::SyscallFlags::NORETURNEDRESULT) != FEXCore::IR::SyscallFlags::NORETURNEDRESULT) {
+    // Move result to its destination register.
+    // Only if `NORETURNEDRESULT` wasn't set, otherwise we might overwrite the CPUState refilled with `FillStaticRegs`
+    mov (GetDst<RA_64>(Node), rax);
+  }
 }
 
 DEF_OP(Thunk) {

--- a/External/FEXCore/Source/Interface/Core/X86Tables/BaseTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/BaseTables.cpp
@@ -169,7 +169,7 @@ void InitializeBaseTables(Context::OperatingMode Mode) {
     {0xC9, 1, X86InstInfo{"LEAVE",  TYPE_INST, GenFlagsSameSize(SIZE_64BITDEF) | FLAGS_DEBUG_MEM_ACCESS ,                                                0, nullptr}},
     {0xCA, 2, X86InstInfo{"RETF",   TYPE_PRIV, GenFlagsSameSize(SIZE_64BITDEF) | FLAGS_SETS_RIP | FLAGS_BLOCK_END,                                                              0, nullptr}},
     {0xCC, 1, X86InstInfo{"INT3",   TYPE_INST, FLAGS_DEBUG,                                                                                      0, nullptr}},
-    {0xCD, 1, X86InstInfo{"INT",    TYPE_INST, FLAGS_DEBUG ,                                                                  1, nullptr}},
+    {0xCD, 1, X86InstInfo{"INT",    TYPE_INST, DEFAULT_SYSCALL_FLAGS,                                                                  1, nullptr}},
     {0xCF, 1, X86InstInfo{"IRET",   TYPE_INST, FLAGS_SETS_RIP | FLAGS_BLOCK_END,                                                                                    0, nullptr}},
 
     {0xD7, 1, X86InstInfo{"XLAT",   TYPE_INST, FLAGS_DEBUG_MEM_ACCESS,                                                                           0, nullptr}},

--- a/External/FEXCore/Source/Interface/Core/X86Tables/SecondaryTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/SecondaryTables.cpp
@@ -22,7 +22,7 @@ void InitializeSecondaryTables(Context::OperatingMode Mode) {
     {0x02, 1, X86InstInfo{"LAR",        TYPE_UNDEC, FLAGS_NO_OVERLAY,                                                                                   0, nullptr}},
     {0x03, 1, X86InstInfo{"LSL",        TYPE_UNDEC, FLAGS_NO_OVERLAY,                                                                                   0, nullptr}},
     {0x04, 1, X86InstInfo{"",           TYPE_INVALID, FLAGS_NO_OVERLAY,                                                                                 0, nullptr}},
-    {0x05, 1, X86InstInfo{"SYSCALL",    TYPE_INST, FLAGS_NO_OVERLAY,                                                                                    0, nullptr}},
+    {0x05, 1, X86InstInfo{"SYSCALL",    TYPE_INST, DEFAULT_SYSCALL_FLAGS,                                                                               0, nullptr}},
     {0x06, 1, X86InstInfo{"CLTS",       TYPE_PRIV, FLAGS_NO_OVERLAY,                                                                                    0, nullptr}},
     {0x07, 1, X86InstInfo{"SYSRET",     TYPE_PRIV, FLAGS_NO_OVERLAY,                                                                                    0, nullptr}},
     {0x08, 1, X86InstInfo{"INVD",       TYPE_PRIV, FLAGS_NO_OVERLAY,                                                                                    0, nullptr}},

--- a/External/FEXCore/Source/Interface/Core/X86Tables/X86Tables.h
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/X86Tables.h
@@ -361,6 +361,13 @@ constexpr InstFlagType SIZE_128BIT   = 0b101;
 constexpr InstFlagType SIZE_256BIT   = 0b110;
 constexpr InstFlagType SIZE_64BITDEF = 0b111; // Default mode is 64bit instead of typical 32bit
 
+#ifndef _WIN32
+  constexpr uint32_t DEFAULT_SYSCALL_FLAGS = FLAGS_NO_OVERLAY;
+#else
+  // Syscall ends a block on WIN32 because the instruction can update the CPU's RIP.
+  constexpr uint32_t DEFAULT_SYSCALL_FLAGS = FLAGS_NO_OVERLAY | FLAGS_BLOCK_END;
+#endif
+
 constexpr InstFlagType GetSizeDstFlags(InstFlagType Flags) { return (Flags >> FLAGS_SIZE_DST_OFF) & SIZE_MASK; }
 constexpr InstFlagType GetSizeSrcFlags(InstFlagType Flags) { return (Flags >> FLAGS_SIZE_SRC_OFF) & SIZE_MASK; }
 

--- a/External/FEXCore/include/FEXCore/IR/IR.h
+++ b/External/FEXCore/include/FEXCore/IR/IR.h
@@ -491,10 +491,20 @@ protected:
 
 enum class SyscallFlags : uint8_t {
   DEFAULT            = 0,
+  // Syscalldoesn't care about CPUState being serialized up to the syscall instruction.
+  // Means DeadCodeElimination can optimize through a syscall operation.
   OPTIMIZETHROUGH    = 1 << 0,
+  // Syscall only reads the passed in arguments. Doesn't read CPUState.
   NOSYNCSTATEONENTRY = 1 << 1,
+  // Syscall doesn't return. Code generation after syscall return can be removed.
   NORETURN           = 1 << 2,
-  NOSIDEEFFECTS      = 1 << 3
+  // Syscall doesn't have any side-effects, so if the result isn't used then it can be removed.
+  NOSIDEEFFECTS      = 1 << 3,
+  // Syscall doesn't return a result.
+  // Means the resulting register shouldn't be written (Usually RAX).
+  // Usually used with !NOSYNCSTATEONENTRY, so the syscall can modify CPU state entirely.
+  // Then on return FEXCore picks up the new state.
+  NORETURNEDRESULT   = 1 << 4,
 };
 
 FEX_DEF_NUM_OPS(SyscallFlags)


### PR DESCRIPTION
Wine syscalls need to end the code block at the point of the syscall. This is because syscalls may update RIP which means the JIT loop needs to immediately restart.

Additionally since they can update CPU state, make wine syscalls not return a result and instead refill the register state from the CPU state. This will mean the syscall handler will need to update their result register (RAX?) before returning.

Depends on #2666 for this code to be active but can be merged independently.