### PR TITLE
Thunks: Mostly reverts #2672

### DIFF
--- a/External/FEXCore/Source/Interface/HLE/Thunks/Thunks.cpp
+++ b/External/FEXCore/Source/Interface/HLE/Thunks/Thunks.cpp
@@ -53,9 +53,13 @@ static __attribute__((aligned(16), naked, section("HostToGuestTrampolineTemplate
   );
 #elif defined(_M_ARM_64)
   asm(
+    // x11 is part of the custom ABI and needs to point to the TrampolineInstanceInfo.
     "ldr x16, 0f \n"
+    "adr x11, 0f \n"
     "br x16 \n"
-    // 8-byte aligned quad.
+    // Manually align to the next 8-byte boundary
+    // NOTE: GCC over-aligns to a full page when using .align directives on ARM (last tested on GCC 11.2)
+    "nop \n"
     "0: \n"
     ".quad 0, 0, 0, 0 \n" // TrampolineInstanceInfo
   );


### PR DESCRIPTION
I forgot that x11 was part of the custom ABI of thunks. #2672 had broken thunks on ARM64. I thought I had tested a game with them enabled but apparently I tested the wrong game.

Not a full revert since we can still ldr with a literal, but we also still need to adr x11 and nop pad. At least removes the data dependency on x11 from the ldr.