### PR TITLE
FEXLoader: Allow simulated kernel version up to 6.2

### DIFF
--- a/Source/Tools/FEXLoader/LinuxSyscalls/Syscalls.cpp
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/Syscalls.cpp
@@ -790,8 +790,8 @@ uint32_t SyscallHandler::CalculateHostKernelVersion() {
 }
 
 uint32_t SyscallHandler::CalculateGuestKernelVersion() {
-  // We currently only emulate a kernel between the ranges of Kernel 5.0.0 and 5.18.0
-  return std::max(KernelVersion(5, 0), std::min(KernelVersion(5, 18), GetHostKernelVersion()));
+  // We currently only emulate a kernel between the ranges of Kernel 5.0.0 and 6.2.0
+  return std::max(KernelVersion(5, 0), std::min(KernelVersion(6, 2), GetHostKernelVersion()));
 }
 
 uint64_t SyscallHandler::HandleSyscall(FEXCore::Core::CpuStateFrame *Frame, FEXCore::HLE::SyscallArguments *Args) {


### PR DESCRIPTION
Investigation in #2589 shows we can push it to this point. 6.3 adds a new prctl that FEX can't enable yet.