### PR TITLE
FEXCore: Implements support for xgetbv

### DIFF
--- a/External/FEXCore/Source/Interface/Context/Context.cpp
+++ b/External/FEXCore/Source/Interface/Context/Context.cpp
@@ -87,6 +87,10 @@ namespace FEXCore::Context {
     return CPUID.RunFunction(Function, Leaf);
   }
 
+  FEXCore::CPUID::XCRResults FEXCore::Context::ContextImpl::RunXCRFunction(uint32_t Function) {
+    return CPUID.RunXCRFunction(Function);
+  }
+
   FEXCore::CPUID::FunctionResults FEXCore::Context::ContextImpl::RunCPUIDFunctionName(uint32_t Function, uint32_t Leaf, uint32_t CPU) {
     return CPUID.RunFunctionName(Function, Leaf, CPU);
   }

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -159,6 +159,7 @@ namespace FEXCore::Context {
       void SetSyscallHandler(FEXCore::HLE::SyscallHandler *Handler) override;
 
       FEXCore::CPUID::FunctionResults RunCPUIDFunction(uint32_t Function, uint32_t Leaf) override;
+      FEXCore::CPUID::XCRResults RunXCRFunction(uint32_t Function) override;
       FEXCore::CPUID::FunctionResults RunCPUIDFunctionName(uint32_t Function, uint32_t Leaf, uint32_t CPU) override;
 
       FEXCore::IR::AOTIRCacheEntry *LoadAOTIRCacheEntry(const fextl::string& Name) override;

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
@@ -219,7 +219,7 @@ void Arm64Emitter::PopCalleeSavedRegisters() {
   }
 }
 
-void Arm64Emitter::SpillStaticRegs(bool FPRs, uint32_t GPRSpillMask, uint32_t FPRSpillMask) {
+void Arm64Emitter::SpillStaticRegs(FEXCore::ARMEmitter::Register TmpReg, bool FPRs, uint32_t GPRSpillMask, uint32_t FPRSpillMask) {
   if (!StaticRegisterAllocation()) {
     return;
   }
@@ -252,8 +252,6 @@ void Arm64Emitter::SpillStaticRegs(bool FPRs, uint32_t GPRSpillMask, uint32_t FP
     } else {
       if (GPRSpillMask && FPRSpillMask == ~0U) {
         // Optimize the common case where we can spill four registers per instruction
-        auto TmpReg = SRA64[FindFirstSetBit(GPRSpillMask)];
-
         // Load the sse offset in to the temporary register
         add(ARMEmitter::Size::i64Bit, TmpReg, STATE.R(), offsetof(FEXCore::Core::CpuStateFrame, State.xmm.sse.data[0][0]));
         for (size_t i = 0; i < ConfiguredSRAFPRs; i += 4) {

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
@@ -183,7 +183,7 @@ protected:
   // NOTE: These functions WILL clobber the register TMP4 if AVX support is enabled
   //       and FPRs are being spilled or filled. If only GPRs are spilled/filled, then
   //       TMP4 is left alone.
-  void SpillStaticRegs(bool FPRs = true, uint32_t GPRSpillMask = ~0U, uint32_t FPRSpillMask = ~0U);
+  void SpillStaticRegs(FEXCore::ARMEmitter::Register TmpReg, bool FPRs = true, uint32_t GPRSpillMask = ~0U, uint32_t FPRSpillMask = ~0U);
   void FillStaticRegs(bool FPRs = true, uint32_t GPRFillMask = ~0U, uint32_t FPRFillMask = ~0U);
 
   // Register 0-18 + 29 + 30 are caller saved

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
@@ -183,7 +183,7 @@ void Arm64Dispatcher::EmitDispatcher() {
   {
     ThreadStopHandlerAddressSpillSRA = GetCursorAddress<uint64_t>();
     if (config.StaticRegisterAllocation)
-      SpillStaticRegs();
+      SpillStaticRegs(TMP1);
 
     ThreadStopHandlerAddress = GetCursorAddress<uint64_t>();
 
@@ -197,7 +197,7 @@ void Arm64Dispatcher::EmitDispatcher() {
   {
     ExitFunctionLinkerAddress = GetCursorAddress<uint64_t>();
     if (config.StaticRegisterAllocation)
-      SpillStaticRegs();
+      SpillStaticRegs(TMP1);
 
 #ifndef _WIN32
     if (SignalSafeCompile) {
@@ -260,7 +260,7 @@ void Arm64Dispatcher::EmitDispatcher() {
     Bind(&NoBlock);
 
     if (config.StaticRegisterAllocation)
-      SpillStaticRegs();
+      SpillStaticRegs(TMP1);
 
 #ifndef _WIN32
     if (SignalSafeCompile) {
@@ -341,7 +341,7 @@ void Arm64Dispatcher::EmitDispatcher() {
     GuestSignal_SIGILL = GetCursorAddress<uint64_t>();
 
     if (config.StaticRegisterAllocation)
-      SpillStaticRegs();
+      SpillStaticRegs(TMP1);
 
     hlt(0);
   }
@@ -352,7 +352,7 @@ void Arm64Dispatcher::EmitDispatcher() {
     GuestSignal_SIGTRAP  = GetCursorAddress<uint64_t>();
 
     if (config.StaticRegisterAllocation)
-      SpillStaticRegs();
+      SpillStaticRegs(TMP1);
 
     brk(0);
   }
@@ -363,7 +363,7 @@ void Arm64Dispatcher::EmitDispatcher() {
     GuestSignal_SIGSEGV = GetCursorAddress<uint64_t>();
 
     if (config.StaticRegisterAllocation)
-      SpillStaticRegs();
+      SpillStaticRegs(TMP1);
 
     // hlt/udf = SIGILL
     // brk = SIGTRAP
@@ -384,7 +384,7 @@ void Arm64Dispatcher::EmitDispatcher() {
   {
     ThreadPauseHandlerAddressSpillSRA = GetCursorAddress<uint64_t>();
     if (config.StaticRegisterAllocation)
-      SpillStaticRegs();
+      SpillStaticRegs(TMP1);
 
     ThreadPauseHandlerAddress = GetCursorAddress<uint64_t>();
     // We are pausing, this means the frontend should be waiting for this thread to idle
@@ -461,7 +461,7 @@ void Arm64Dispatcher::EmitDispatcher() {
     LUDIVHandlerAddress = GetCursorAddress<uint64_t>();
 
     PushDynamicRegsAndLR(ARMEmitter::Reg::r3);
-    SpillStaticRegs();
+    SpillStaticRegs(ARMEmitter::Reg::r3);
 
     ldr(ARMEmitter::XReg::x3, STATE_PTR(CpuStateFrame, Pointers.AArch64.LUDIV));
 #ifdef VIXL_SIMULATOR
@@ -483,7 +483,7 @@ void Arm64Dispatcher::EmitDispatcher() {
     LDIVHandlerAddress = GetCursorAddress<uint64_t>();
 
     PushDynamicRegsAndLR(ARMEmitter::Reg::r3);
-    SpillStaticRegs();
+    SpillStaticRegs(ARMEmitter::Reg::r3);
 
     ldr(ARMEmitter::XReg::x3, STATE_PTR(CpuStateFrame, Pointers.AArch64.LDIV));
 #ifdef VIXL_SIMULATOR
@@ -505,7 +505,7 @@ void Arm64Dispatcher::EmitDispatcher() {
     LUREMHandlerAddress = GetCursorAddress<uint64_t>();
 
     PushDynamicRegsAndLR(ARMEmitter::Reg::r3);
-    SpillStaticRegs();
+    SpillStaticRegs(ARMEmitter::Reg::r3);
 
     ldr(ARMEmitter::XReg::x3, STATE_PTR(CpuStateFrame, Pointers.AArch64.LUREM));
 #ifdef VIXL_SIMULATOR
@@ -527,7 +527,7 @@ void Arm64Dispatcher::EmitDispatcher() {
     LREMHandlerAddress = GetCursorAddress<uint64_t>();
 
     PushDynamicRegsAndLR(ARMEmitter::Reg::r3);
-    SpillStaticRegs();
+    SpillStaticRegs(ARMEmitter::Reg::r3);
 
     ldr(ARMEmitter::XReg::x3, STATE_PTR(CpuStateFrame, Pointers.AArch64.LREM));
 

--- a/External/FEXCore/Source/Interface/Core/Interpreter/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/BranchOps.cpp
@@ -143,6 +143,15 @@ DEF_OP(CPUID) {
   memcpy(DstPtr, &Results, sizeof(uint32_t) * 4);
 }
 
+DEF_OP(XGETBV) {
+  auto Op = IROp->C<IR::IROp_XGetBV>();
+  uint32_t *DstPtr = GetDest<uint32_t*>(Data->SSAData, Node);
+  const uint32_t Function = *GetSrc<uint32_t*>(Data->SSAData, Op->Function);
+
+  auto Results = Data->State->CTX->RunXCRFunction(Function);
+  memcpy(DstPtr, &Results, sizeof(uint32_t) * 2);
+}
+
 #undef DEF_OP
 
 } // namespace FEXCore::CPU

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -118,6 +118,7 @@ constexpr OpHandlerArray InterpreterOpHandlers = [] {
   REGISTER_OP(VALIDATECODE,           ValidateCode);
   REGISTER_OP(THREADREMOVECODEENTRY,        ThreadRemoveCodeEntry);
   REGISTER_OP(CPUID,                  CPUID);
+  REGISTER_OP(XGETBV,                 XGETBV);
 
   // Conversion ops
   REGISTER_OP(VINSGPR,                VInsGPR);

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
@@ -154,6 +154,7 @@ namespace FEXCore::CPU {
   DEF_OP(ValidateCode);
   DEF_OP(ThreadRemoveCodeEntry);
   DEF_OP(CPUID);
+  DEF_OP(XGETBV);
 
   ///< Conversion ops
   DEF_OP(VInsGPR);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -494,7 +494,7 @@ DEF_OP(PDep) {
   // We sadly need to spill regs for this for the time being
   // TODO: Remove when scratch registers can be allocated
   //       explicitly.
-  SpillStaticRegs(false, SpillCode);
+  SpillStaticRegs(TMP1, false, SpillCode);
 
 
   mov(EmitSize, InputReg, Input);
@@ -558,7 +558,7 @@ DEF_OP(PExt) {
   // We sadly need to spill a reg for this for the time being
   // TODO: Remove when scratch registers can be allocated
   //       explicitly.
-  SpillStaticRegs(false, 1U << Mask.Idx());
+  SpillStaticRegs(TMP2, false, 1U << Mask.Idx());
   mov(EmitSize, Mask, ZeroReg);
 
   // Main loop

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
@@ -22,7 +22,7 @@ namespace FEXCore::CPU {
 
 DEF_OP(CallbackReturn) {
   // spill back to CTX
-  SpillStaticRegs();
+  SpillStaticRegs(TMP1);
 
   // First we must reset the stack
   ResetStack();
@@ -175,7 +175,7 @@ DEF_OP(Syscall) {
     FPRSpillMask = CALLER_FPR_MASK;
   }
 
-  SpillStaticRegs(true, GPRSpillMask, FPRSpillMask);
+  SpillStaticRegs(TMP1, true, GPRSpillMask, FPRSpillMask);
 
   // Now that we are spilled, store in the state that we are in a syscall
   // Still without overwriting registers that matter
@@ -260,7 +260,7 @@ DEF_OP(InlineSyscall) {
   // Ordering is incredibly important here
   // We must spill any overlapping registers first THEN claim we are in a syscall without invalidating state at all
   // Only spill the registers that intersect with our usage
-  SpillStaticRegs(false, SpillMask);
+  SpillStaticRegs(TMP1, false, SpillMask);
 
   // Now that we are spilled, store in the state that we are in a syscall
   // Still without overwriting registers that matter
@@ -328,7 +328,7 @@ DEF_OP(Thunk) {
   // X0: CTX
   // X1: Args (from guest stack)
 
-  SpillStaticRegs(); // spill to ctx before ra64 spill
+  SpillStaticRegs(TMP1); // spill to ctx before ra64 spill
 
   PushDynamicRegsAndLR(TMP1);
 
@@ -403,12 +403,12 @@ DEF_OP(ThreadRemoveCodeEntry) {
   // X1: RIP
 
   PushDynamicRegsAndLR(TMP1);
+  SpillStaticRegs(TMP1);
 
   mov(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r0, STATE.R());
   LoadConstant(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r1, Entry);
 
   ldr(ARMEmitter::XReg::x2, STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.ThreadRemoveCodeEntryFromJIT));
-  SpillStaticRegs();
 #ifdef VIXL_SIMULATOR
   GenerateIndirectRuntimeCall<void, void*, void*>(ARMEmitter::Reg::r2);
 #else
@@ -424,7 +424,7 @@ DEF_OP(CPUID) {
   auto Op = IROp->C<IR::IROp_CPUID>();
 
   PushDynamicRegsAndLR(TMP1);
-  SpillStaticRegs();
+  SpillStaticRegs(TMP1);
 
   // x0 = CPUID Handler
   // x1 = CPUID Function
@@ -454,7 +454,7 @@ DEF_OP(XGETBV) {
   auto Op = IROp->C<IR::IROp_XGetBV>();
 
   PushDynamicRegsAndLR(TMP1);
-  SpillStaticRegs();
+  SpillStaticRegs(TMP1);
 
   // x0 = CPUID Handler
   // x1 = XCR Function
@@ -475,7 +475,7 @@ DEF_OP(XGETBV) {
   // Results want to be in a i32v2 vector
   auto Dst = GetRegPair(Node);
   mov(ARMEmitter::Size::i32Bit, Dst.first,  ARMEmitter::Reg::r0);
-  ubfx(ARMEmitter::Size::i64Bit, Dst.second, ARMEmitter::Reg::r0, 32, 32);
+  lsr(ARMEmitter::Size::i64Bit, Dst.second, ARMEmitter::Reg::r0, 32);
 }
 
 #undef DEF_OP

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -615,6 +615,11 @@ Arm64JITCore::Arm64JITCore(FEXCore::Context::ContextImpl *ctx, FEXCore::Core::In
       Common.CPUIDFunction = PMF.GetConvertedPointer();
     }
 
+    {
+      FEXCore::Utils::MemberFunctionToPointerCast PMF(&FEXCore::CPUIDEmu::RunXCRFunction);
+      Common.XCRFunction = PMF.GetConvertedPointer();
+    }
+
     Common.SyscallHandlerObj = reinterpret_cast<uint64_t>(CTX->SyscallHandler);
     Common.SyscallHandlerFunc = reinterpret_cast<uint64_t>(FEXCore::Context::HandleSyscall);
     Common.ExitFunctionLink = reinterpret_cast<uintptr_t>(&Context::ContextImpl::ThreadExitFunctionLink<Arm64JITCore_ExitFunctionLink>);
@@ -911,6 +916,7 @@ CPUBackend::CompiledCode Arm64JITCore::CompileCode(uint64_t Entry,
         REGISTER_OP(VALIDATECODE,      ValidateCode);
         REGISTER_OP(THREADREMOVECODEENTRY,   ThreadRemoveCodeEntry);
         REGISTER_OP(CPUID,             CPUID);
+        REGISTER_OP(XGETBV,            XGETBV);
 
         // Conversion ops
         REGISTER_OP(VINSGPR,         VInsGPR);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -83,7 +83,7 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header const *IROp, IR::NodeID Node) {
   } else {
     switch(Info.ABI) {
       case FABI_VOID_U16:{
-        SpillStaticRegs();
+        SpillStaticRegs(TMP1);
 
         PushDynamicRegsAndLR(TMP1);
 
@@ -103,7 +103,7 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header const *IROp, IR::NodeID Node) {
       break;
 
       case FABI_F80_F32:{
-        SpillStaticRegs();
+        SpillStaticRegs(TMP1);
 
         PushDynamicRegsAndLR(TMP1);
         const auto Src1 = GetVReg(IROp->Args[0].ID());
@@ -127,7 +127,7 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header const *IROp, IR::NodeID Node) {
       break;
 
       case FABI_F80_F64:{
-        SpillStaticRegs();
+        SpillStaticRegs(TMP1);
 
         PushDynamicRegsAndLR(TMP1);
 
@@ -153,7 +153,7 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header const *IROp, IR::NodeID Node) {
 
       case FABI_F80_I16:
       case FABI_F80_I32: {
-        SpillStaticRegs();
+        SpillStaticRegs(TMP1);
 
         PushDynamicRegsAndLR(TMP1);
 
@@ -183,7 +183,7 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header const *IROp, IR::NodeID Node) {
       break;
 
       case FABI_F32_F80:{
-        SpillStaticRegs();
+        SpillStaticRegs(TMP1);
 
         PushDynamicRegsAndLR(TMP1);
 
@@ -209,7 +209,7 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header const *IROp, IR::NodeID Node) {
       break;
 
       case FABI_F64_F80:{
-        SpillStaticRegs();
+        SpillStaticRegs(TMP1);
 
         PushDynamicRegsAndLR(TMP1);
 
@@ -235,7 +235,7 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header const *IROp, IR::NodeID Node) {
       break;
 
       case FABI_F64_F64: {
-        SpillStaticRegs();
+        SpillStaticRegs(TMP1);
 
         PushDynamicRegsAndLR(TMP1);
 
@@ -259,7 +259,7 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header const *IROp, IR::NodeID Node) {
       break;
 
       case FABI_F64_F64_F64: {
-        SpillStaticRegs();
+        SpillStaticRegs(TMP1);
 
         PushDynamicRegsAndLR(TMP1);
 
@@ -285,7 +285,7 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header const *IROp, IR::NodeID Node) {
       break;
 
       case FABI_I16_F80:{
-        SpillStaticRegs();
+        SpillStaticRegs(TMP1);
 
         PushDynamicRegsAndLR(TMP1);
 
@@ -310,7 +310,7 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header const *IROp, IR::NodeID Node) {
       }
       break;
       case FABI_I32_F80:{
-        SpillStaticRegs();
+        SpillStaticRegs(TMP1);
 
         PushDynamicRegsAndLR(TMP1);
 
@@ -335,7 +335,7 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header const *IROp, IR::NodeID Node) {
       }
       break;
       case FABI_I64_F80:{
-        SpillStaticRegs();
+        SpillStaticRegs(TMP1);
 
         PushDynamicRegsAndLR(TMP1);
 
@@ -360,7 +360,7 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header const *IROp, IR::NodeID Node) {
       }
       break;
       case FABI_I64_F80_F80:{
-        SpillStaticRegs();
+        SpillStaticRegs(TMP1);
 
         PushDynamicRegsAndLR(TMP1);
 
@@ -388,7 +388,7 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header const *IROp, IR::NodeID Node) {
       }
       break;
       case FABI_F80_F80:{
-        SpillStaticRegs();
+        SpillStaticRegs(TMP1);
 
         PushDynamicRegsAndLR(TMP1);
 
@@ -415,7 +415,7 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header const *IROp, IR::NodeID Node) {
       }
       break;
       case FABI_F80_F80_F80:{
-        SpillStaticRegs();
+        SpillStaticRegs(TMP1);
 
         PushDynamicRegsAndLR(TMP1);
 
@@ -446,7 +446,7 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header const *IROp, IR::NodeID Node) {
       }
       break;
       case FABI_I32_I64_I64_I128_I128_I16: {
-        SpillStaticRegs();
+        SpillStaticRegs(TMP1);
         PushDynamicRegsAndLR(TMP1);
 
         const auto Op = IROp->C<IR::IROp_VPCMPESTRX>();
@@ -486,7 +486,7 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header const *IROp, IR::NodeID Node) {
         break;
       }
       case FABI_I32_I128_I128_I16: {
-        SpillStaticRegs();
+        SpillStaticRegs(TMP1);
         PushDynamicRegsAndLR(TMP1);
 
         const auto Op = IROp->C<IR::IROp_VPCMPISTRX>();

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -307,6 +307,7 @@ private:
   DEF_OP(ValidateCode);
   DEF_OP(ThreadRemoveCodeEntry);
   DEF_OP(CPUID);
+  DEF_OP(XGETBV);
 
   ///< Conversion ops
   DEF_OP(VInsGPR);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
@@ -144,7 +144,7 @@ DEF_OP(Print) {
   auto Op = IROp->C<IR::IROp_Print>();
 
   PushDynamicRegsAndLR(TMP1);
-  SpillStaticRegs();
+  SpillStaticRegs(TMP1);
 
   if (IsGPR(Op->Value.ID())) {
     mov(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r0, GetReg(Op->Value.ID()));
@@ -170,7 +170,7 @@ DEF_OP(ProcessorID) {
   // Ordering is incredibly important here
   // We must spill any overlapping registers first THEN claim we are in a syscall without invalidating state at all
   // Only spill the registers that intersect with our usage
-  SpillStaticRegs(false, SpillMask);
+  SpillStaticRegs(TMP1, false, SpillMask);
 
   // Now that we are spilled, store in the state that we are in a syscall
   // Still without overwriting registers that matter

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -444,6 +444,11 @@ X86JITCore::X86JITCore(FEXCore::Context::ContextImpl *ctx, FEXCore::Core::Intern
       Common.CPUIDFunction = PMF.GetConvertedPointer();
     }
 
+    {
+      FEXCore::Utils::MemberFunctionToPointerCast PMF(&FEXCore::CPUIDEmu::RunXCRFunction);
+      Common.XCRFunction = PMF.GetConvertedPointer();
+    }
+
     Common.SyscallHandlerObj = reinterpret_cast<uint64_t>(CTX->SyscallHandler);
     Common.SyscallHandlerFunc = reinterpret_cast<uint64_t>(FEXCore::Context::HandleSyscall);
     Common.ExitFunctionLink = reinterpret_cast<uintptr_t>(&Context::ContextImpl::ThreadExitFunctionLink<X86JITCore_ExitFunctionLink>);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -313,6 +313,7 @@ private:
   DEF_OP(ValidateCode);
   DEF_OP(ThreadRemoveCodeEntry);
   DEF_OP(CPUID);
+  DEF_OP(XGETBV);
 
   ///< Conversion ops
   DEF_OP(VInsGPR);

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -1779,6 +1779,18 @@ void OpDispatchBuilder::CPUIDOp(OpcodeArgs) {
   StoreGPRRegister(X86State::REG_RCX, _Bfe(32, 0,  Result_Upper));
 }
 
+void OpDispatchBuilder::XGetBVOp(OpcodeArgs) {
+  OrderedNode *Function = LoadGPRRegister(X86State::REG_RCX);
+
+  auto Res = _XGetBV(Function);
+
+  OrderedNode *Result_Lower = _ExtractElementPair(Res, 0);
+  OrderedNode *Result_Upper = _ExtractElementPair(Res, 1);
+
+  StoreGPRRegister(X86State::REG_RAX, Result_Lower);
+  StoreGPRRegister(X86State::REG_RDX, Result_Upper);
+}
+
 template<bool SHL1Bit>
 void OpDispatchBuilder::SHLOp(OpcodeArgs) {
   OrderedNode *Src{};
@@ -6736,7 +6748,7 @@ constexpr uint16_t PF_F2 = 3;
 
   constexpr std::tuple<uint8_t, uint8_t, FEXCore::X86Tables::OpDispatchPtr> SecondaryModRMExtensionOpTable[] = {
     // REG /2
-    {((1 << 3) | 0), 1, &OpDispatchBuilder::UnimplementedOp},
+    {((1 << 3) | 0), 1, &OpDispatchBuilder::XGetBVOp},
 
     // REG /7
     {((3 << 3) | 1), 1, &OpDispatchBuilder::RDTSCPOp},

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -219,6 +219,7 @@ public:
   void MOVOffsetOp(OpcodeArgs);
   void CMOVOp(OpcodeArgs);
   void CPUIDOp(OpcodeArgs);
+  void XGetBVOp(OpcodeArgs);
   template<bool SHL1Bit>
   void SHLOp(OpcodeArgs);
   void SHLImmediateOp(OpcodeArgs);

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -297,6 +297,13 @@
                 ],
         "DestSize": "16",
         "NumElements": "2"
+      },
+      "GPRPair = XGetBV GPR:$Function": {
+        "Desc": ["Calls in to the XCR handler function to return emulated XCR",
+                 "Returns a 64bit GPR pair that fits emulated EAX, EDX respectively"
+                ],
+        "DestSize": "8",
+        "NumElements": "2"
       }
     },
     "Moves": {

--- a/External/FEXCore/include/FEXCore/Core/CPUID.h
+++ b/External/FEXCore/include/FEXCore/Core/CPUID.h
@@ -5,5 +5,9 @@ namespace FEXCore::CPUID {
   struct FunctionResults {
     uint32_t eax, ebx, ecx, edx;
   };
+
+  struct XCRResults {
+    uint32_t eax, edx;
+  };
 }
 

--- a/External/FEXCore/include/FEXCore/Core/Context.h
+++ b/External/FEXCore/include/FEXCore/Core/Context.h
@@ -259,6 +259,7 @@ namespace FEXCore::Context {
       FEX_DEFAULT_VISIBILITY virtual void SetSyscallHandler(FEXCore::HLE::SyscallHandler *Handler) = 0;
 
       FEX_DEFAULT_VISIBILITY virtual FEXCore::CPUID::FunctionResults RunCPUIDFunction(uint32_t Function, uint32_t Leaf) = 0;
+      FEX_DEFAULT_VISIBILITY virtual FEXCore::CPUID::XCRResults RunXCRFunction(uint32_t Function) = 0;
       FEX_DEFAULT_VISIBILITY virtual FEXCore::CPUID::FunctionResults RunCPUIDFunctionName(uint32_t Function, uint32_t Leaf, uint32_t CPU) = 0;
 
       FEX_DEFAULT_VISIBILITY virtual FEXCore::IR::AOTIRCacheEntry *LoadAOTIRCacheEntry(const fextl::string& Name) = 0;

--- a/External/FEXCore/include/FEXCore/Core/CoreState.h
+++ b/External/FEXCore/include/FEXCore/Core/CoreState.h
@@ -144,6 +144,7 @@ namespace FEXCore::Core {
       uint64_t ThreadRemoveCodeEntryFromJIT{};
       uint64_t CPUIDObj{};
       uint64_t CPUIDFunction{};
+      uint64_t XCRFunction{};
       uint64_t SyscallHandlerObj{};
       uint64_t SyscallHandlerFunc{};
       uint64_t ExitFunctionLink{};

--- a/unittests/ASM/SecondaryModRM/Reg_2_0.asm
+++ b/unittests/ASM/SecondaryModRM/Reg_2_0.asm
@@ -1,0 +1,18 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x3",
+    "RDX": "0x0"
+  }
+}
+%endif
+
+mov ecx, 0
+xgetbv
+
+; Mask only the lower two bits to get host and FEX runners to match.
+; This way we can test that we're getting data back.
+; Bit 0 and 1 refer to X87 and SSE respectively.
+and eax, 0x3
+
+hlt


### PR DESCRIPTION
This returns the `XFEATURE_ENABLED_MASK` register which reports what features are enabled on the CPU.
This behaves similarly to CPUID where it uses an index register in ecx.

This is a prerequisite to enabling XSAVE/XRSTOR and AVX since applications will expect this to exist.

xsetbv is a privileged instruction and doesn't need to be implemented.