### PR TITLE
Telemetry: Save on signal terminate

### DIFF
--- a/External/FEXCore/Source/Utils/Telemetry.cpp
+++ b/External/FEXCore/Source/Utils/Telemetry.cpp
@@ -23,6 +23,7 @@ namespace FEXCore::Telemetry {
     "32bit CAS Tear",
     "64bit CAS Tear",
     "128bit CAS Tear",
+    "Crash mask",
   };
   void Initialize() {
     auto DataDirectory = Config::GetDataDirectory();

--- a/External/FEXCore/include/FEXCore/Utils/Telemetry.h
+++ b/External/FEXCore/include/FEXCore/Utils/Telemetry.h
@@ -37,6 +37,7 @@ namespace FEXCore::Telemetry {
     TYPE_CAS_32BIT_TEAR,
     TYPE_CAS_64BIT_TEAR,
     TYPE_CAS_128BIT_TEAR,
+    TYPE_CRASH_MASK,
     TYPE_LAST,
   };
 

--- a/Source/Tools/FEXLoader/FEXLoader.cpp
+++ b/Source/Tools/FEXLoader/FEXLoader.cpp
@@ -472,7 +472,7 @@ int main(int argc, char **argv, char **const envp) {
   // Setup TSO hardware emulation immediately after initializing the context.
   FEX::TSO::SetupTSOEmulation(CTX.get());
 
-  auto SignalDelegation = FEX::HLE::CreateSignalDelegator(CTX.get());
+  auto SignalDelegation = FEX::HLE::CreateSignalDelegator(CTX.get(), Program.ProgramName);
 
   auto SyscallHandler = Loader.Is64BitMode() ? FEX::HLE::x64::CreateHandler(CTX.get(), SignalDelegation.get())
                                              : FEX::HLE::x32::CreateHandler(CTX.get(), SignalDelegation.get(), std::move(Allocator));

--- a/Source/Tools/FEXLoader/IRLoader.cpp
+++ b/Source/Tools/FEXLoader/IRLoader.cpp
@@ -187,7 +187,7 @@ int main(int argc, char **argv, char **const envp)
   auto CTX = FEXCore::Context::Context::CreateNewContext();
   CTX->InitializeContext();
 
-  auto SignalDelegation = FEX::HLE::CreateSignalDelegator(CTX.get());
+  auto SignalDelegation = FEX::HLE::CreateSignalDelegator(CTX.get(), {});
 
   CTX->SetSignalDelegator(SignalDelegation.get());
   CTX->SetSyscallHandler(new DummySyscallHandler());

--- a/Source/Tools/FEXLoader/LinuxSyscalls/SignalDelegator.h
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/SignalDelegator.h
@@ -22,6 +22,7 @@ $end_info$
 #include <mutex>
 
 #include <FEXCore/Core/SignalDelegator.h>
+#include <FEXCore/Utils/Telemetry.h>
 
 namespace FEXCore {
 namespace Context {
@@ -40,7 +41,7 @@ namespace FEX::HLE {
   public:
     // Returns true if the host handled the signal
     // Arguments are the same as sigaction handler
-    SignalDelegator(FEXCore::Context::Context *_CTX);
+    SignalDelegator(FEXCore::Context::Context *_CTX, const std::string_view ApplicationName);
     ~SignalDelegator() override;
 
     /**
@@ -118,6 +119,8 @@ namespace FEX::HLE {
   private:
     FEX_CONFIG_OPT(Is64BitMode, IS64BIT_MODE);
     FEX_CONFIG_OPT(Core, CORE);
+    fextl::string const ApplicationName;
+    FEXCORE_TELEMETRY_INIT(CrashMask, TYPE_CRASH_MASK);
 
     enum DefaultBehaviour {
       DEFAULT_TERM,
@@ -231,5 +234,5 @@ namespace FEX::HLE {
     std::mutex GuestDelegatorMutex;
   };
 
-  fextl::unique_ptr<FEX::HLE::SignalDelegator> CreateSignalDelegator(FEXCore::Context::Context *CTX);
+  fextl::unique_ptr<FEX::HLE::SignalDelegator> CreateSignalDelegator(FEXCore::Context::Context *CTX, const std::string_view ApplicationName);
 }

--- a/Source/Tools/FEXLoader/TestHarnessRunner.cpp
+++ b/Source/Tools/FEXLoader/TestHarnessRunner.cpp
@@ -256,7 +256,7 @@ int main(int argc, char **argv, char **const envp) {
   CTX->InitializeContext();
 
 #ifndef _WIN32
-  auto SignalDelegation = FEX::HLE::CreateSignalDelegator(CTX.get());
+  auto SignalDelegation = FEX::HLE::CreateSignalDelegator(CTX.get(), {});
 #else
   // Enable exit on HLT while Wine's longjump is broken.
   //


### PR DESCRIPTION
When a signal handler is not installed and is a terminal failure, make sure to save telemetry before faulting.

We know when an application is going down in this case so we can make sure to have the telemetry data saved.

Adds a telemetry signal mask data point as well to know which signal took it down.