### PR TITLE
CPUID: Only enable BMI1 and BMI2 if AVX is supported

### DIFF
--- a/External/FEXCore/Source/Interface/Core/CPUID.cpp
+++ b/External/FEXCore/Source/Interface/Core/CPUID.cpp
@@ -626,12 +626,12 @@ FEXCore::CPUID::FunctionResults CPUIDEmu::Function_07h(uint32_t Leaf) {
       (1 <<  0) | // FS/GS support
       (0 <<  1) | // TSC adjust MSR
       (0 <<  2) | // SGX
-      (1 <<  3) | // BMI1
+      (SupportsAVX() << 3) | // BMI1
       (0 <<  4) | // Intel Hardware Lock Elison
       (0 <<  5) | // AVX2 support
       (1 <<  6) | // FPU data pointer updated only on exception
       (1 <<  7) | // SMEP support
-      (1 <<  8) | // BMI2
+      (SupportsAVX() << 8) | // BMI2
       (0 <<  9) | // Enhanced REP MOVSB/STOSB
       (1 << 10) | // INVPCID for system software control of process-context
       (0 << 11) | // Restricted transactional memory


### PR DESCRIPTION
These two extensions rely on AVX being supported to be used. Primarily because they are VEX encoded.

GTA5 is using these flags to determine if it should enable its AVX support.