### PR TITLE
OpcodeDispatcher: Optimize EFLAG unpacking

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -1544,7 +1544,7 @@ void OpDispatchBuilder::SAHFOp(OpcodeArgs) {
   OrderedNode *Src = LoadGPRRegister(X86State::REG_RAX, 1, 8);
 
   // Clear bits that aren't supposed to be set
-  Src = _And(Src, _Constant(~0b101000));
+  Src = _Andn(Src, _Constant(0b101000));
 
   // Set the bit that is always set here
   Src = _Or(Src, _Constant(0b10));

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
@@ -52,10 +52,9 @@ void OpDispatchBuilder::SetPackedRFLAG(bool Lower8, OrderedNode *Src) {
     InvalidateDeferredFlags();
   }
 
-  auto OneConst = _Constant(1);
   for (size_t i = 0; i < NumFlags; ++i) {
     const auto FlagOffset = FlagOffsets[i];
-    auto Tmp = _And(_Lshr(Src, _Constant(FlagOffset)), OneConst);
+    auto Tmp = _Bfe(4, 1, FlagOffset, Src);
     SetRFLAG(Tmp, FlagOffset);
   }
 }


### PR DESCRIPTION
Noticed this was slightly unoptimal. Resulting in a 18% code reduction in the case of of a simple four instruction test ASM case.