### PR TITLE
IRDumper: Fixes ssa number in arguments.

### DIFF
--- a/External/FEXCore/Source/Interface/IR/IRDumper.cpp
+++ b/External/FEXCore/Source/Interface/IR/IRDumper.cpp
@@ -103,7 +103,7 @@ static void PrintArg(fextl::stringstream *out, IRListView const* IR, OrderedNode
   if (ArgID.IsInvalid()) {
     *out << "%Invalid";
   } else {
-    *out << "%ssa" << ArgID;
+    *out << "%ssa" << std::dec << ArgID;
     if (RAData) {
       auto PhyReg = RAData->GetNodeRegister(ArgID);
 


### PR DESCRIPTION
This can spuriously end up as a hex number which makes it hard to reason why DCE wasn't deleting IR operations. Ensure it is always a decimal.