### PR TITLE
Arm64: Fixes paranoidtso option for CPUs that support LRCPC/2 

### DIFF
--- a/External/FEXCore/Source/Utils/ArchHelpers/Arm64.cpp
+++ b/External/FEXCore/Source/Utils/ArchHelpers/Arm64.cpp
@@ -2043,8 +2043,8 @@ static uint64_t HandleAtomicLoadstoreExclusive(uintptr_t ProgramCounter, uint64_
     uint32_t Size = (Instr & 0xC000'0000) >> 30;
     uint32_t AddrReg = (Instr >> 5) & 0x1F;
     uint32_t DataReg = Instr & 0x1F;
-    if ((Instr & 0x3F'FF'FC'00) == 0x08'DF'FC'00 || // LDAR*
-        (Instr & 0x3F'FF'FC'00) == 0x38'BF'C0'00) { // LDAPR*
+    if ((Instr & LDAXR_MASK) == LDAR_INST || // LDAR*
+        (Instr & LDAXR_MASK) == LDAPR_INST) { // LDAPR*
       if (ParanoidTSO) {
         if (ArchHelpers::Arm64::HandleAtomicLoad(Instr, GPRs, 0)) {
           // Skip this instruction now
@@ -2068,7 +2068,7 @@ static uint64_t HandleAtomicLoadstoreExclusive(uintptr_t ProgramCounter, uint64_
         return std::make_pair(true, -4);
       }
     }
-    else if ( (Instr & 0x3F'FF'FC'00) == 0x08'9F'FC'00) { // STLR*
+    else if ( (Instr & LDAXR_MASK) == STLR_INST) { // STLR*
       if (ParanoidTSO) {
         if (ArchHelpers::Arm64::HandleAtomicStore(Instr, GPRs, 0)) {
           // Skip this instruction now

--- a/External/FEXCore/include/FEXCore/Utils/ArchHelpers/Arm64.h
+++ b/External/FEXCore/include/FEXCore/Utils/ArchHelpers/Arm64.h
@@ -27,6 +27,9 @@ namespace FEXCore::ArchHelpers::Arm64 {
 
   constexpr uint32_t LDAXR_MASK = 0x3F'FF'FC'00;
   constexpr uint32_t LDAXR_INST = 0x08'5F'FC'00;
+  constexpr uint32_t LDAR_INST  = 0x08'DF'FC'00;
+  constexpr uint32_t LDAPR_INST = 0x38'BF'C0'00;
+  constexpr uint32_t STLR_INST  = 0x08'9F'FC'00;
 
   constexpr uint32_t STLXR_MASK = 0x3F'E0'FC'00;
   constexpr uint32_t STLXR_INST = 0x08'00'FC'00;


### PR DESCRIPTION
Regular LoadStoreTSO operations have gained support for LRCPC and LRCPC2
which changes the semantics of the operation by letting it support
immediate offsets.

The paranoid version of these operations didn't support the immediate
offsets yet which was causing incorrect memory loadstores.

Bring over the new semantics from the regular LoadStoreTSO but without
any nop padding.