### PR TITLE
IR: Pad IROp_Header to be 32-bit in width

### DIFF
--- a/External/FEXCore/Scripts/json_ir_generator.py
+++ b/External/FEXCore/Scripts/json_ir_generator.py
@@ -282,6 +282,7 @@ def print_ir_structs(defines):
     output_file.write("\tIROps Op;\n\n")
     output_file.write("\tuint8_t Size;\n")
     output_file.write("\tuint8_t ElementSize;\n")
+    output_file.write("\tuint8_t _pad;\n")
 
     output_file.write("\ttemplate<typename T>\n")
     output_file.write("\tT const* C() const { return reinterpret_cast<T const*>(Data); }\n")
@@ -291,6 +292,7 @@ def print_ir_structs(defines):
     output_file.write("\tOrderedNodeWrapper Args[0];\n")
 
     output_file.write("};\n\n");
+    output_file.write("static_assert(sizeof(IROp_Header) == sizeof(uint32_t), \"IROp_Header should be 32-bits in size\");\n\n");
 
     # Now the user defined types
     output_file.write("// User defined IR Op structs\n")


### PR DESCRIPTION
We spent a bit of effort removing 8-bits from this header to get it down to three bytes. This ended up in PRs #2319 and #2320

There was no explicit need to go down to three bytes, the other two arguments we were removing were just better served to be lookups instead of adding IR overhead for each operation.

This now introduced alignment issues that was brought up in #2472. Apparently the Android NDK's clang will pad nested structs like this, maybe to match alignment? Regardless we should just make it be 32-bit.

This fixes Android execution of FEXCore.
This fixes #2472

Pros:
- Initialization now turns in to a single str because it's 32-bit
- We have 8-bits more space that we can abuse in the IR op now
   - If we need more than 64-bit and 128-bit are easy bumps in the future

Cons:
- Each IR operation takes at minimum 25% more space in the intrusive allocators
   - Not really that big of a deal since we are talking 3 bytes versus 4.