### PR TITLE
VectorFallbacks: Fix PCMPSTR fallback ZF/SF flag setting 

### DIFF
--- a/External/FEXCore/Source/Interface/Core/CPUID.cpp
+++ b/External/FEXCore/Source/Interface/Core/CPUID.cpp
@@ -395,8 +395,6 @@ FEXCore::CPUID::FunctionResults CPUIDEmu::Function_0h(uint32_t Leaf) {
 FEXCore::CPUID::FunctionResults CPUIDEmu::Function_01h(uint32_t Leaf) {
   FEXCore::CPUID::FunctionResults Res{};
   uint32_t CoreCount = Cores();
-  // XXX: Enable once the rest of the SSE4.2 instructions are emulated
-  uint32_t SupportsSSE42 = CTX->HostFeatures.SupportsCRC && false ? 1 : 0;
 
   // Hypervisor bit is normally set but some applications have issues with it.
   uint32_t Hypervisor = HideHypervisorBit() ? 0 : 1;
@@ -429,7 +427,7 @@ FEXCore::CPUID::FunctionResults CPUIDEmu::Function_01h(uint32_t Leaf) {
     (0 << 17) | // Process-context identifiers
     (0 << 18) | // Prefetching from memory mapped device
     (1 << 19) | // SSE4.1
-    (SupportsSSE42 << 20) | // SSE4.2
+    (CTX->HostFeatures.SupportsCRC << 20) | // SSE4.2
     (0 << 21) | // X2APIC
     (1 << 22) | // MOVBE
     (1 << 23) | // POPCNT

--- a/External/FEXCore/Source/Interface/Core/Interpreter/Fallbacks/VectorFallbacks.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/Fallbacks/VectorFallbacks.h
@@ -46,7 +46,7 @@ struct OpHandlers<IR::OP_VPCMPESTRX> {
   // Main PCMPXSTRX algorithm body. Allows for reuse with both implicit and explicit length variants.
   static uint32_t MainBody(const __uint128_t& lhs, int valid_lhs, const __uint128_t& rhs, int valid_rhs, uint16_t control) {
     const uint32_t aggregation = PerformAggregation(lhs, valid_lhs, rhs, valid_rhs, control);
-    const uint32_t upper_limit = (16U >> (control & 1)) - 1;
+    const int32_t upper_limit = (16 >> (control & 1)) - 1;
 
     // Bits are arranged as:
     // Bit #:   3    2    1    0

--- a/unittests/ASM/H0F3A/pcmpistri_ranges.asm
+++ b/unittests/ASM/H0F3A/pcmpistri_ranges.asm
@@ -1,10 +1,10 @@
 %ifdef CONFIG
 {
   "RegData": {
-      "XMM0": ["0x00060F000F000D01", "0x0000000000070007"],
-      "XMM1": ["0x3111313131311111", "0x0000000000313131"],
+      "XMM0": ["0x00060F000F000D01", "0x0000001010070007"],
+      "XMM1": ["0x3111313131311111", "0x0000001818313131"],
       "XMM2": ["0x005A0041007A0061", "0x55AACCBBFF220000"],
-      "XMM3": ["0x006500200027003F", "0x00210065004F0065"]
+      "XMM3": ["0x0065002000270000", "0x00210065004F0065"]
   }
 }
 %endif
@@ -104,6 +104,16 @@ CompareAndStore 9, 0b00110101
 ; Range unsigned word check (msb, negative masked)
 CompareAndStore 10, 0b01110101
 
+; --- Edge case test (string begins with null character) ---
+movaps xmm2, [rel .data_null]
+movaps xmm3, [rel .data_null + 32]
+
+; Range signed byte check (msb)
+CompareAndStore 11, 0b01000110
+
+; Range signed byte check (lsb)
+CompareAndStore 12, 0b01000110
+
 ; Load all our stored indices and flags for result comparing
 movaps xmm0, [rel .indices]
 movaps xmm1, [rel .flags]
@@ -129,6 +139,17 @@ dq 0xAAAAAAAAAAAAAAAA
 dq 0xBBBBBBBBBBBBBBBB
 
 dq 0x006500200027003F ; "?' e"
+dq 0x00210065004F0065 ; "eOen!"
+dq 0x8888888888888888
+dq 0x9999999999999999
+
+.data_null:
+dq 0x005A0041007A0061 ; "azAZ"
+dq 0x55AACCBBFF220000
+dq 0xAAAAAAAAAAAAAAAA
+dq 0xBBBBBBBBBBBBBBBB
+
+dq 0x0065002000270000 ; "\0' e"
 dq 0x00210065004F0065 ; "eOen!"
 dq 0x8888888888888888
 dq 0x9999999999999999


### PR DESCRIPTION
So, uh, this was a little silly to track down. Having the upper limit as unsigned was a mistake, since this would cause negative valid lengths to convert into an unsigned value (woo sign conversions, gotta love 'em!) within the first two flag comparison cases. A -1 valid length can occur if one of the strings starts with a null character in a vector's first element. (It will be zero and we then subtract it to make the length zero-based).

Fixes this edge-case up and expands a test to check for this in the future