### PR TITLE
Arm64: Fixes register pair conflict.

### DIFF
--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
@@ -73,6 +73,24 @@ constexpr std::array<std::pair<FEXCore::ARMEmitter::Register, FEXCore::ARMEmitte
   {FEXCore::ARMEmitter::Reg::r16, FEXCore::ARMEmitter::Reg::r17}
 }};
 
+/**
+ * @brief These are the intersection indexes for RA64Pair to RA64.
+ *
+ * Since RA64 sticks a register right in the middle of the allocation, this intersection offsets by one half way through.
+ * Keep these intersection indexes nearby the definitions so they can follow the previous definitions.
+ */
+constexpr std::array<std::pair<uint8_t, uint8_t>, RA64Pair.size()> RA64Pair_Intersections = {{
+  {0, 1},
+  {2, 3},
+  {4, 5},
+  {6, 7},
+
+  // Registers only available on 32-bit
+  {9, 10},
+  {11, 12},
+  {13, 14}
+}};
+
 // All are caller saved
 constexpr std::array<FEXCore::ARMEmitter::VRegister, 16> SRAFPR = {
   FEXCore::ARMEmitter::VReg::v16, FEXCore::ARMEmitter::VReg::v17,

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -595,8 +595,9 @@ Arm64JITCore::Arm64JITCore(FEXCore::Context::ContextImpl *ctx, FEXCore::Core::In
   RAPass->AddRegisters(FEXCore::IR::ComplexClass, 1);
 
   for (uint32_t i = 0; i < ConfiguredGPRPairs; ++i) {
-    RAPass->AddRegisterConflict(FEXCore::IR::GPRClass, i * 2,     FEXCore::IR::GPRPairClass, i);
-    RAPass->AddRegisterConflict(FEXCore::IR::GPRClass, i * 2 + 1, FEXCore::IR::GPRPairClass, i);
+    const auto Intersect = RA64Pair_Intersections[i];
+    RAPass->AddRegisterConflict(FEXCore::IR::GPRClass, Intersect.first,  FEXCore::IR::GPRPairClass, i);
+    RAPass->AddRegisterConflict(FEXCore::IR::GPRClass, Intersect.second, FEXCore::IR::GPRPairClass, i);
   }
 
   {


### PR DESCRIPTION
When FEX was updated to reclaim 64-bit registers in #2494, I had mistakenly messed up pair register class conflicts.

The problem is that FEX has r30 stuck in the middle of the RA which causes the paired registers to need to offset their index half way.

This meant that the conflict index being incorrect was always broken on 32-bit applications ever since that PR.

Keep the intersection indexes in their own array so to can be correctly indexed at runtime.

Thanks to @asahilina finding out that Osmos started crashing a few months ago and I finally just got around to bisecting what the problem was.
This now fixes Osmos from crashing, although the motes are still invisible on the 32-bit application. Not sure what other havok this has been causing.