### PR TITLE
OpcodeDispatcher: Ensure MXCSR is saved/restored with FXSAVE/FXRSTOR

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -2457,6 +2457,7 @@ void OpDispatchBuilder::FXSaveOp(OpcodeArgs) {
 
   SaveX87State(Op, Mem);
   SaveSSEState(Mem);
+  SaveMXCSRState(Mem);
 }
 
 void OpDispatchBuilder::XSaveOp(OpcodeArgs) {
@@ -2667,6 +2668,10 @@ void OpDispatchBuilder::FXRStoreOp(OpcodeArgs) {
 
   RestoreX87State(Mem);
   RestoreSSEState(Mem);
+
+  OrderedNode *MXCSRLocation = _Add(Mem, _Constant(24));
+  OrderedNode *MXCSR = _LoadMem(GPRClass, 4, MXCSRLocation, 4);
+  RestoreMXCSRState(MXCSR);
 }
 
 void OpDispatchBuilder::XRstorOpImpl(OpcodeArgs) {


### PR DESCRIPTION
Previously, the bits that we support in the MXCSR weren't being saved, which means that some opcode patterns may fail to restore the rounding mode properly.

e.g. FXSAVE, followed by FNINIT, followed by FXRSTOR wouldn't restore the rounding mode properly

This fixes that.