### PR TITLE
Arm64: Fixes GPR pair allocation to get one pair back

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.h
@@ -31,22 +31,22 @@ class Arm64Dispatcher final : public Dispatcher, public Arm64Emitter {
   void EmitDispatcher();
 
   uint16_t GetSRAGPRCount() const override {
-    return SRA64.size();
+    return StaticRegisters.size();
   }
 
   uint16_t GetSRAFPRCount() const override {
-    return SRAFPR.size();
+    return StaticFPRegisters.size();
   }
 
   void GetSRAGPRMapping(uint8_t Mapping[16]) const override {
-    for (size_t i = 0; i < SRA64.size(); ++i) {
-      Mapping[i] = SRA64[i].Idx();
+    for (size_t i = 0; i < StaticRegisters.size(); ++i) {
+      Mapping[i] = StaticRegisters[i].Idx();
     }
   }
 
   void GetSRAFPRMapping(uint8_t Mapping[16]) const override {
-    for (size_t i = 0; i < SRAFPR.size(); ++i) {
-      Mapping[i] = SRAFPR[i].Idx();
+    for (size_t i = 0; i < StaticFPRegisters.size(); ++i) {
+      Mapping[i] = StaticFPRegisters[i].Idx();
     }
   }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -477,9 +477,9 @@ DEF_OP(PDep) {
   const auto IndexReg      = TMP4.R();
   const auto ZeroReg       = ARMEmitter::Reg::zr;
 
-  const auto InputReg = SRA64[0];
-  const auto MaskReg  = SRA64[1];
-  const auto DestReg  = SRA64[2];
+  const auto InputReg = StaticRegisters[0];
+  const auto MaskReg  = StaticRegisters[1];
+  const auto DestReg  = StaticRegisters[2];
 
   const auto SpillCode = 1U << InputReg.Idx() |
                          1U << MaskReg.Idx() |

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -587,17 +587,16 @@ Arm64JITCore::Arm64JITCore(FEXCore::Context::ContextImpl *ctx, FEXCore::Core::In
 
   RAPass->AllocateRegisterSet(RegisterClasses);
 
-  RAPass->AddRegisters(FEXCore::IR::GPRClass, ConfiguredGPRs);
-  RAPass->AddRegisters(FEXCore::IR::GPRFixedClass, ConfiguredSRAGPRs);
-  RAPass->AddRegisters(FEXCore::IR::FPRClass, ConfiguredFPRs);
-  RAPass->AddRegisters(FEXCore::IR::FPRFixedClass, ConfiguredSRAFPRs);
-  RAPass->AddRegisters(FEXCore::IR::GPRPairClass, ConfiguredGPRPairs);
+  RAPass->AddRegisters(FEXCore::IR::GPRClass, GeneralRegisters.size());
+  RAPass->AddRegisters(FEXCore::IR::GPRFixedClass, StaticRegisters.size());
+  RAPass->AddRegisters(FEXCore::IR::FPRClass, GeneralFPRegisters.size());
+  RAPass->AddRegisters(FEXCore::IR::FPRFixedClass, StaticFPRegisters.size());
+  RAPass->AddRegisters(FEXCore::IR::GPRPairClass, GeneralPairRegisters.size());
   RAPass->AddRegisters(FEXCore::IR::ComplexClass, 1);
 
-  for (uint32_t i = 0; i < ConfiguredGPRPairs; ++i) {
-    const auto Intersect = RA64Pair_Intersections[i];
-    RAPass->AddRegisterConflict(FEXCore::IR::GPRClass, Intersect.first,  FEXCore::IR::GPRPairClass, i);
-    RAPass->AddRegisterConflict(FEXCore::IR::GPRClass, Intersect.second, FEXCore::IR::GPRPairClass, i);
+  for (uint32_t i = 0; i < GeneralPairRegisters.size(); ++i) {
+    RAPass->AddRegisterConflict(FEXCore::IR::GPRClass, i * 2,     FEXCore::IR::GPRPairClass, i);
+    RAPass->AddRegisterConflict(FEXCore::IR::GPRClass, i * 2 + 1, FEXCore::IR::GPRPairClass, i);
   }
 
   {

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -70,9 +70,9 @@ private:
     LOGMAN_THROW_AA_FMT(Reg.Class == IR::GPRFixedClass.Val || Reg.Class == IR::GPRClass.Val, "Unexpected Class: {}", Reg.Class);
 
     if (Reg.Class == IR::GPRFixedClass.Val) {
-      return SRA64[Reg.Reg];
+      return StaticRegisters[Reg.Reg];
     } else if (Reg.Class == IR::GPRClass.Val) {
-      return RA64[Reg.Reg];
+      return GeneralRegisters[Reg.Reg];
     }
 
     FEX_UNREACHABLE;
@@ -84,9 +84,9 @@ private:
     LOGMAN_THROW_AA_FMT(Reg.Class == IR::FPRFixedClass.Val || Reg.Class == IR::FPRClass.Val, "Unexpected Class: {}", Reg.Class);
 
     if (Reg.Class == IR::FPRFixedClass.Val) {
-      return SRAFPR[Reg.Reg];
+      return StaticFPRegisters[Reg.Reg];
     } else if (Reg.Class == IR::FPRClass.Val) {
-      return RAFPR[Reg.Reg];
+      return GeneralFPRegisters[Reg.Reg];
     }
 
     FEX_UNREACHABLE;
@@ -97,7 +97,7 @@ private:
 
     LOGMAN_THROW_AA_FMT(Reg.Class == IR::GPRPairClass.Val, "Unexpected Class: {}", Reg.Class);
 
-    return RA64Pair[Reg.Reg];
+    return GeneralPairRegisters[Reg.Reg];
   }
 
   [[nodiscard]] FEXCore::IR::RegisterClassType GetRegClass(IR::NodeID Node) const;

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -132,7 +132,7 @@ DEF_OP(LoadRegister) {
     [[maybe_unused]] const auto regId = (Op->Offset / Core::CPUState::GPR_REG_SIZE) - 1;
     const auto regOffs = Op->Offset & 7;
 
-    LOGMAN_THROW_A_FMT(regId < SRA64.size(), "out of range regId");
+    LOGMAN_THROW_A_FMT(regId < StaticFPRegisters.size(), "out of range regId");
 
     switch (OpSize) {
       case 1:
@@ -166,7 +166,7 @@ DEF_OP(LoadRegister) {
     [[maybe_unused]] const auto regId = (Op->Offset - offsetof(Core::CpuStateFrame, State.xmm.avx.data[0][0])) / regSize;
 
     LOGMAN_THROW_A_FMT(HostSupportsSVE, "Unsupported code path!");
-    LOGMAN_THROW_A_FMT(regId < SRAFPR.size(), "out of range regId");
+    LOGMAN_THROW_A_FMT(regId < StaticFPRegisters.size(), "out of range regId");
 
     const auto host = GetVReg(Node);
 
@@ -214,7 +214,7 @@ DEF_OP(StoreRegister) {
     [[maybe_unused]] const auto regId = (Op->Offset / Core::CPUState::GPR_REG_SIZE) - 1;
     const auto regOffs = Op->Offset & 7;
 
-    LOGMAN_THROW_A_FMT(regId < SRA64.size(), "out of range regId");
+    LOGMAN_THROW_A_FMT(regId < StaticFPRegisters.size(), "out of range regId");
 
     const auto Src = GetReg(Op->Value.ID());
 
@@ -248,7 +248,7 @@ DEF_OP(StoreRegister) {
     [[maybe_unused]] const auto regId = (Op->Offset - offsetof(Core::CpuStateFrame, State.xmm.avx.data[0][0])) / regSize;
 
     LOGMAN_THROW_A_FMT(HostSupportsSVE, "Unsupported code path!");
-    LOGMAN_THROW_A_FMT(regId < SRAFPR.size(), "regId out of range");
+    LOGMAN_THROW_A_FMT(regId < StaticFPRegisters.size(), "regId out of range");
 
     const auto host = GetVReg(Op->Value.ID());
 
@@ -296,9 +296,9 @@ DEF_OP(LoadRegisterSRA) {
     const auto regId = (Op->Offset - offsetof(Core::CpuStateFrame, State.gregs[0])) / Core::CPUState::GPR_REG_SIZE;
     const auto regOffs = Op->Offset & 7;
 
-    LOGMAN_THROW_A_FMT(regId < SRA64.size(), "out of range regId");
+    LOGMAN_THROW_A_FMT(regId < StaticFPRegisters.size(), "out of range regId");
 
-    const auto reg = SRA64[regId];
+    const auto reg = StaticRegisters[regId];
 
     switch (OpSize) {
       case 1:
@@ -334,9 +334,9 @@ DEF_OP(LoadRegisterSRA) {
                                          : Core::CPUState::XMM_SSE_REG_SIZE;
     const auto regId = (Op->Offset - offsetof(Core::CpuStateFrame, State.xmm.avx.data[0][0])) / regSize;
 
-    LOGMAN_THROW_A_FMT(regId < SRAFPR.size(), "out of range regId");
+    LOGMAN_THROW_A_FMT(regId < StaticFPRegisters.size(), "out of range regId");
 
-    const auto guest = SRAFPR[regId];
+    const auto guest = StaticFPRegisters[regId];
     const auto host = GetVReg(Node);
 
     if (HostSupportsSVE) {
@@ -484,9 +484,9 @@ DEF_OP(StoreRegisterSRA) {
     const auto regId = (Op->Offset / Core::CPUState::GPR_REG_SIZE) - 1;
     const auto regOffs = Op->Offset & 7;
 
-    LOGMAN_THROW_A_FMT(regId < SRA64.size(), "out of range regId");
+    LOGMAN_THROW_A_FMT(regId < StaticFPRegisters.size(), "out of range regId");
 
-    const auto reg = SRA64[regId];
+    const auto reg = StaticRegisters[regId];
     const auto Src = GetReg(Op->Value.ID());
 
     switch (OpSize) {
@@ -520,9 +520,9 @@ DEF_OP(StoreRegisterSRA) {
                                          : Core::CPUState::XMM_SSE_REG_SIZE;
     const auto regId = (Op->Offset - offsetof(Core::CpuStateFrame, State.xmm.avx.data[0][0])) / regSize;
 
-    LOGMAN_THROW_A_FMT(regId < SRAFPR.size(), "regId out of range");
+    LOGMAN_THROW_A_FMT(regId < StaticFPRegisters.size(), "regId out of range");
 
-    const auto guest = SRAFPR[regId];
+    const auto guest = StaticFPRegisters[regId];
     const auto host = GetVReg(Op->Value.ID());
 
     if (HostSupportsSVE) {


### PR DESCRIPTION
When executing a 32-bit application we were failing to allocate a single GPR pair. This meant we only have 7 pairs when we could have had 8.

This was because r30 was ending up in the middle of the allocation arrays so we couldn't safely create a sequential pair of registers.

Organize the register allocation arrays to be unique for each bitness being executed and then access them through spans instead.

Also works around bug where the RA validation doesn't understand when pair indexes don't correlate directly to GPR indexes. So while the previous PR fixed the RA pass, it didn't fix the RA validation pass.

Noticed this when pr57018 32-bit gcc test was run with the #2700 PR which improved the RA allocation a bit.