### PR TITLE
JIT: Implement support for per-instruction RIP reconstruction

### DIFF
--- a/External/FEXCore/Source/Interface/Core/X86Tables/BaseTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/BaseTables.cpp
@@ -146,10 +146,10 @@ void InitializeBaseTables(Context::OperatingMode Mode) {
     {0x9E, 1, X86InstInfo{"SAHF",   TYPE_INST, FLAGS_NONE,                              0, nullptr}},
     {0x9F, 1, X86InstInfo{"LAHF",   TYPE_INST, FLAGS_NONE,                              0, nullptr}},
 
-    {0xA4, 1, X86InstInfo{"MOVSB",  TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_SUPPORTS_REP,                                            0, nullptr}},
-    {0xA5, 1, X86InstInfo{"MOVS",   TYPE_INST, FLAGS_SUPPORTS_REP,                                                            0, nullptr}},
-    {0xA6, 1, X86InstInfo{"CMPSB",  TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_SUPPORTS_REP,                                            0, nullptr}},
-    {0xA7, 1, X86InstInfo{"CMPS",   TYPE_INST, FLAGS_SUPPORTS_REP,                                                            0, nullptr}},
+    {0xA4, 1, X86InstInfo{"MOVSB",  TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_DEBUG_MEM_ACCESS  | FLAGS_SUPPORTS_REP,                                            0, nullptr}},
+    {0xA5, 1, X86InstInfo{"MOVS",   TYPE_INST, FLAGS_DEBUG_MEM_ACCESS | FLAGS_SUPPORTS_REP,                                                            0, nullptr}},
+    {0xA6, 1, X86InstInfo{"CMPSB",  TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_DEBUG_MEM_ACCESS  | FLAGS_SUPPORTS_REP,                                            0, nullptr}},
+    {0xA7, 1, X86InstInfo{"CMPS",   TYPE_INST, FLAGS_DEBUG_MEM_ACCESS | FLAGS_SUPPORTS_REP,                                                            0, nullptr}},
 
     {0xA8, 1, X86InstInfo{"TEST",   TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_SF_DST_RAX ,                                             1, nullptr}},
     {0xA9, 1, X86InstInfo{"TEST",   TYPE_INST, FLAGS_SF_DST_RAX | FLAGS_SRC_SEXT | FLAGS_DISPLACE_SIZE_DIV_2,                4, nullptr}},

--- a/External/FEXCore/include/FEXCore/Core/CPUBackend.h
+++ b/External/FEXCore/include/FEXCore/Core/CPUBackend.h
@@ -89,6 +89,28 @@ namespace CPU {
       size_t Size;
       // RIP that the block's entry comes from.
       uint64_t RIP;
+
+      // Number of RIP entries for this JIT Code section.
+      uint32_t NumberOfRIPEntries;
+
+      // Offset after this block to the start of the RIP entries.
+      uint32_t OffsetToRIPEntries;
+    };
+
+    // Entries that live after the JITCodeTail.
+    // These entries correlate JIT code regions with guest RIP regions.
+    // Using these entries FEX is able to reconstruct the guest RIP accurately when an instruction cause a signal fault.
+    // Packed using 16-bit entries to ensure the size isn't too large.
+    // These smaller sizes means that each entry is relative to each other instead of absolute offset from the start of the JIT block.
+    // When reconstructing the RIP, each entry must be walked linearly and accumulated with the previous entries.
+    // This is a trade-off between compression inside the JIT code space and execution time when reconstruction the RIP.
+    // RIP reconstruction when faulting is less likely so we are requiring the accumulation.
+    struct JITRIPReconstructEntries {
+      // The Host PC offset from the previous entry.
+      uint16_t HostPCOffset;
+
+      // How much to offset the RIP from the previous entry.
+      uint16_t GuestRIPOffset;
     };
 
     /**


### PR DESCRIPTION
FEX's current implementation of RIP reconstruction is limited to the
entrypoint that a single block has. This will cause the RIP to be
incorrect past the first instruction in that block.

While this is fine for a decent number of games, especially since fault
handling isn't super common. This doesn't work for all situations.

When testing Ultimate Chicken Horse, we found out that changing the
block size to 1 worked around an early crash in the game's startup.
This game is likely relying on Mono/Unity's AOT compilation step, which
does some more robust faulting that the runtime JIT. Needing the RIP to
be correct since they do some sort of checking for what the code came
from.

This fixes Ultimate Chicken Horse specifically, but will likely fix
other games that are built the same way.
Fixes #2721