### PR TITLE
IR: Move VPCMPESTRX REX handling to OpcodeDispatcher 

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
@@ -2280,15 +2280,12 @@ DEF_OP(VRev64) {
 
 DEF_OP(VPCMPESTRX) {
   const auto Op = IROp->C<IR::IROp_VPCMPESTRX>();
-  const auto Is64Bit = Op->GPRSize == 8;
+  const auto Control = Op->Control;
 
   const auto RAX = *GetSrc<uint64_t*>(Data->SSAData, Op->RAX);
   const auto RDX = *GetSrc<uint64_t*>(Data->SSAData, Op->RDX);
   const auto LHS = *GetSrc<__uint128_t*>(Data->SSAData, Op->LHS);
   const auto RHS = *GetSrc<__uint128_t*>(Data->SSAData, Op->RHS);
-
-  // We can be cheeky and encode the size at bit 8 to save a parameter
-  const auto Control = Op->Control | (uint16_t(Is64Bit) << 8);
 
   const auto Result = OpHandlers<IR::OP_VPCMPESTRX>::handle(RAX, RDX, LHS, RHS, Control);
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -450,15 +450,12 @@ void Arm64JITCore::Op_Unhandled(IR::IROp_Header const *IROp, IR::NodeID Node) {
         PushDynamicRegsAndLR(TMP1);
 
         const auto Op = IROp->C<IR::IROp_VPCMPESTRX>();
-        const auto Is64Bit = Op->GPRSize == 8;
+        const auto Control = Op->Control;
 
         const auto Src1 = GetVReg(Op->LHS.ID());
         const auto Src2 = GetVReg(Op->RHS.ID());
         const auto SrcRAX = GetReg(Op->RAX.ID());
         const auto SrcRDX = GetReg(Op->RDX.ID());
-
-        // We can be cheeky and encode the size at bit 8 to save a parameter
-        const auto Control = Op->Control | (uint16_t(Is64Bit) << 8);
 
         mov(ARMEmitter::XReg::x0, SrcRAX.X());
         mov(ARMEmitter::XReg::x1, SrcRDX.X());

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -308,15 +308,12 @@ void X86JITCore::Op_Unhandled(IR::IROp_Header *IROp, IR::NodeID Node) {
         PushRegs();
 
         const auto Op = IROp->C<IR::IROp_VPCMPESTRX>();
-        const auto Is64Bit = Op->GPRSize == 8;
+        const auto Control = Op->Control;
 
         const auto LHS = GetSrc(Op->LHS.ID());
         const auto RHS = GetSrc(Op->RHS.ID());
         const auto SrcRAX = GetSrc<RA_64>(Op->RAX.ID());
         const auto SrcRDX = GetSrc<RA_64>(Op->RDX.ID());
-
-        // Encode the size check into the 8th bit to save a parameter
-        const auto Control = Op->Control | (uint16_t(Is64Bit) << 8);
 
         mov(rdi, SrcRAX);
         mov(rsi, SrcRDX);

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -1405,7 +1405,7 @@
         "DestSize": "RegisterSize"
       },
 
-      "GPR = VPCMPESTRX u8:$GPRSize, FPR:$LHS, FPR:$RHS, GPR:$RAX, GPR:$RDX, u8:$Control": {
+      "GPR = VPCMPESTRX FPR:$LHS, FPR:$RHS, GPR:$RAX, GPR:$RDX, u16:$Control": {
         "Desc": ["Performs intermediate behavior analogous to the x86 PCMPESTRI/PCMPESTRM instruction",
                  "This will return the intermediate result of a PCMPESTR-type operation, but NOT the final",
                  "result. This must be derived from the intermediate result",

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -1414,7 +1414,6 @@
                  "flags into the upper 16-bits of the 32-bit result, as these can also be derived over the",
                  "course of creating the intermediate result"
                 ],
-        "HasSideEffects": true,
         "DestSize": "4"
       },
       "GPR = VPCMPISTRX FPR:$LHS, FPR:$RHS, u8:$Control": {
@@ -1426,7 +1425,6 @@
                  "flags into the upper 16-bits of the 32-bit result, as these can also be derived over the",
                  "course of creating the intermediate result"
                 ],
-        "HasSideEffects": true,
         "DestSize": "4"
       }
     },


### PR DESCRIPTION
We can handle this in the dispatcher itself, so that we don't need to pass along the register size as a member of the opcode. This gets rid of some unnecessary duplication of functionality in the backends and makes it so potential backends don't need to deal with this.

We can also remove the HasSideEffects JSON boolean from the IR description as well, since we don't actually perform any side-effects, since we only operate directly on the data given to the IR op and that's it.