### PR TITLE
Scripts: Disable using catchsegv if it doesn't exist

### DIFF
--- a/Scripts/Threaded_Lockstep_Runner.py
+++ b/Scripts/Threaded_Lockstep_Runner.py
@@ -9,6 +9,7 @@ from threading import Thread
 import subprocess
 import time
 import multiprocessing
+from shutil import which
 
 if sys.version_info[0] < 3:
         raise Exception("Python 3 or a more recent version is required.")
@@ -40,6 +41,10 @@ def Threaded_Runner(Args, ID, Client):
 def Threaded_Manager(Runner, ID, File):
     ServerArgs = ["catchsegv", Runner, "-c", "vm", "-n", "1", "-I", "R" + str(ID), File]
     ClientArgs = ["catchsegv", Runner, "-c", "vm", "-n", "1", "-I", "R" + str(ID), "-C"]
+
+    if which("catchsegv") is None:
+        ServerArgs.pop(0)
+        ClientArgs.pop(0)
 
     ServerThread = Thread(target = Threaded_Runner, args = (ServerArgs, ID, 0))
     ClientThread = Thread(target = Threaded_Runner, args = (ClientArgs, ID, 1))

--- a/Scripts/testharness_runner.py
+++ b/Scripts/testharness_runner.py
@@ -3,6 +3,7 @@ import sys
 import subprocess
 import os.path
 from os import path
+from shutil import which
 
 # Args: <Known Failures file> <Known Failures Type File> <DisabledTestsFile> <DisabledTestsTypeFile> <DisabledTestsRunnerFile> <TestName> <Test Harness Executable> <Args>...
 
@@ -46,6 +47,9 @@ if path.exists(disabled_tests_runner_file):
             disabled_tests[line.strip()] = 1
 
 RunnerArgs = ["catchsegv", runner]
+
+if which("catchsegv") is None:
+    RunnerArgs.pop(0)
 # Add the rest of the arguments
 for i in range(len(sys.argv) - args_start_index):
     RunnerArgs.append(sys.argv[args_start_index + i])


### PR DESCRIPTION
Fixes #2724

If catchsegv doesn't exist then just remove it from the execution environment.

While nice to have, this shouldn't be mandatory especially with Debian no longer shipping it.