### PR TITLE
Linux: Remove warning that isn't necessary anymore

### DIFF
--- a/Source/Tools/FEXLoader/LinuxSyscalls/Syscalls.cpp
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/Syscalls.cpp
@@ -606,12 +606,6 @@ uint64_t CloneHandler(FEXCore::Core::CpuStateFrame *Frame, FEX::HLE::clone3_args
   }
 
   if (!(flags & CLONE_THREAD)) {
-    if (flags & CLONE_VFORK) {
-      PrintFlags(flags);
-      flags &= ~CLONE_VM;
-      LogMan::Msg::DFmt("clone: WARNING: CLONE_VFORK w/o CLONE_THREAD");
-    }
-
     // CLONE_PARENT is ignored (Implied by CLONE_THREAD)
     return FEX::HLE::ForkGuest(Thread, Frame, flags,
       reinterpret_cast<void*>(args->args.stack),


### PR DESCRIPTION
This message is complaining each time VFORK was using with clone, but we are handling VFORK here now.
This is just causing debug messages for no reason. Remove the message and remove the flag removal option.