### PR TITLE
FEXServerClient: Ensure server socket is created with SOCK_CLOEXEC

### DIFF
--- a/Source/Common/FEXServerClient.cpp
+++ b/Source/Common/FEXServerClient.cpp
@@ -153,7 +153,7 @@ namespace FEXServerClient {
     auto ServerSocketName = GetServerSocketName();
 
     // Create the initial unix socket
-    int SocketFD = socket(AF_UNIX, SOCK_STREAM, 0);
+    int SocketFD = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
     if (SocketFD == -1) {
       LogMan::Msg::EFmt("Couldn't open AF_UNIX socket {} {}", errno, strerror(errno));
       return -1;


### PR DESCRIPTION
To make sure we don't have dangling FDs when an application calls execve, enable this flag.