### PR TITLE
Context: Removes dead `AddVirtualMemoryMapping` function

### DIFF
--- a/External/FEXCore/Source/Interface/Context/Context.cpp
+++ b/External/FEXCore/Source/Interface/Context/Context.cpp
@@ -66,10 +66,6 @@ namespace FEXCore::Context {
     CustomCPUFactory = std::move(Factory);
   }
 
-  bool FEXCore::Context::ContextImpl::AddVirtualMemoryMapping([[maybe_unused]] uint64_t VirtualAddress, [[maybe_unused]] uint64_t PhysicalAddress, [[maybe_unused]] uint64_t Size) {
-    return false;
-  }
-
   HostFeatures FEXCore::Context::ContextImpl::GetHostFeatures() const {
     return HostFeatures;
   }

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -100,8 +100,6 @@ namespace FEXCore::Context {
 
       void SetCustomCPUBackendFactory(CustomCPUFactoryType Factory) override;
 
-      bool AddVirtualMemoryMapping(uint64_t VirtualAddress, uint64_t PhysicalAddress, uint64_t Size) override;
-
       HostFeatures GetHostFeatures() const override;
 
       void HandleCallback(FEXCore::Core::InternalThreadState *Thread, uint64_t RIP) override;

--- a/External/FEXCore/include/FEXCore/Core/Context.h
+++ b/External/FEXCore/include/FEXCore/Core/Context.h
@@ -226,17 +226,6 @@ namespace FEXCore::Context {
       FEX_DEFAULT_VISIBILITY virtual void SetCustomCPUBackendFactory(CustomCPUFactoryType Factory) = 0;
 
       /**
-       * @brief Sets up memory regions on the guest for mirroring within the guest's VM space
-       *
-       * @param VirtualAddress The address we want to set to mirror a physical memory region
-       * @param PhysicalAddress The physical memory region we are mapping
-       * @param Size Size of the region to mirror
-       *
-       * @return true when successfully mapped. false if there was an error adding
-       */
-      FEX_DEFAULT_VISIBILITY virtual bool AddVirtualMemoryMapping(uint64_t VirtualAddress, uint64_t PhysicalAddress, uint64_t Size) = 0;
-
-      /**
        * @brief Retrieves a feature struct indicating certain supported aspects from
        *        the hose.
        *


### PR DESCRIPTION
This has been around since the initial commit. Bad idea that wasn't ever thought through. Something about remapping guest virtual and host virtual memory which will never be a thing.