### PR TITLE
Some small fixes for android building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ CHECK_INCLUDE_FILES ("gdb/jit-reader.h" HAVE_GDB_JIT_READER_H)
 option(BUILD_TESTS "Build unit tests to ensure sanity" TRUE)
 option(BUILD_FEX_LINUX_TESTS "Build FEXLinuxTests, requires x86 compiler" FALSE)
 option(BUILD_THUNKS "Build thunks" FALSE)
+option(BUILD_FEXCONFIG "Build FEXConfig, requires SDL2 and X11" TRUE)
 option(ENABLE_CLANG_THUNKS "Build thunks with clang" FALSE)
 option(ENABLE_CLANG_FORMAT "Run clang format over the source" FALSE)
 option(ENABLE_IWYU "Enables include what you use program" FALSE)
@@ -179,8 +180,13 @@ endif()
 if(DEFINED ENV{TERMUX_VERSION} OR ENABLE_TERMUX_BUILD)
   add_definitions(-DTERMUX_BUILD=1)
   set(TERMUX_BUILD 1)
+
   # Termux doesn't support Jemalloc due to bad interactions between emutls, jemalloc, and scudo
   set(ENABLE_JEMALLOC FALSE)
+
+  # Termux builds can't rely on X11 packages
+  # SDL2 isn't even compiled with GL support so our GUIs wouldn't even work
+  set(BUILD_FEXCONFIG FALSE)
 endif()
 
 if (ENABLE_ASAN)

--- a/External/FEXCore/Source/Common/JitSymbols.cpp
+++ b/External/FEXCore/Source/Common/JitSymbols.cpp
@@ -17,8 +17,12 @@ namespace FEXCore {
 
   void JITSymbols::InitFile() {
     // We can't use FILE here since we must be robust against forking processes closing our FD from under us.
+#ifdef __ANDROID__
+    // Android simpleperf looks in /data/local/tmp instead of /tmp
+    const auto PerfMap = fextl::fmt::format("/data/local/tmp/perf-{}.map", getpid());
+#else
     const auto PerfMap = fextl::fmt::format("/tmp/perf-{}.map", getpid());
-
+#endif
     fd = open(PerfMap.c_str(), O_CREAT | O_TRUNC | O_WRONLY | O_APPEND, 0644);
   }
 

--- a/External/FEXCore/include/FEXCore/Utils/AllocatorHooks.h
+++ b/External/FEXCore/include/FEXCore/Utils/AllocatorHooks.h
@@ -112,7 +112,14 @@ namespace FEXCore::Allocator {
   inline void *malloc(size_t size) { return ::malloc(size); }
   inline void *calloc(size_t n, size_t size) { return ::calloc(n, size); }
   inline void *memalign(size_t align, size_t s) { return ::memalign(align, s); }
-  inline void *valloc(size_t size) { return ::valloc(size); }
+  inline void *valloc(size_t size)
+  {
+#ifdef __ANDROID__
+    return ::aligned_alloc(4096, size);
+#else
+    return ::valloc(size);
+#endif
+  }
   inline int posix_memalign(void** r, size_t a, size_t s) { return ::posix_memalign(r, a, s); }
   inline void *realloc(void* ptr, size_t size) { return ::realloc(ptr, size); }
   inline void free(void* ptr) { return ::free(ptr); }

--- a/Source/Tools/CMakeLists.txt
+++ b/Source/Tools/CMakeLists.txt
@@ -1,9 +1,9 @@
 if (NOT MINGW_BUILD)
-  if (NOT TERMUX_BUILD)
-    # Termux builds can't rely on X11 packages
-    # SDL2 isn't even compiled with GL support so our GUIs wouldn't even work
+  if (BUILD_FEXCONFIG)
     add_subdirectory(FEXConfig/)
+  endif()
 
+  if (NOT TERMUX_BUILD)
     # Disable FEXRootFSFetcher on Termux, it doesn't even work there
     add_subdirectory(FEXRootFSFetcher/)
   endif()


### PR DESCRIPTION
Fixes a few issues I encountered when trying to build for android (non-termux, via NDK).  A successful build does currently require either using a beta NDK or pulling in a local libc++ through CMake though due to FEX's reliance on std::pmr.