### PR TITLE
Linux: Handle xattr syscalls with emulated paths.

### DIFF
--- a/Source/Tools/FEXLoader/LinuxSyscalls/FileManagement.cpp
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/FileManagement.cpp
@@ -31,6 +31,7 @@ $end_info$
 #include <stdio.h>
 #include <sys/stat.h>
 #include <sys/statfs.h>
+#include <sys/xattr.h>
 #include <syscall.h>
 #include <system_error>
 #include <unistd.h>
@@ -840,6 +841,126 @@ uint64_t FileManager::NewFSStatAt64(int dirfd, const char *pathname, struct stat
     }
   }
   return ::fstatat64(dirfd, SelfPath, buf, flag);
+}
+
+uint64_t FileManager::Setxattr(const char *path, const char *name, const void *value, size_t size, int flags) {
+  auto NewPath = GetSelf(path);
+  const char *SelfPath = NewPath ? NewPath->c_str() : nullptr;
+
+  auto Path = GetEmulatedPath(SelfPath, true);
+  if (!Path.empty()) {
+    uint64_t Result = ::setxattr(Path.c_str(), name, value, size, flags);
+    if (Result != -1 || errno != ENOENT) {
+      return Result;
+    }
+  }
+
+  return ::setxattr(SelfPath, name, value, size, flags);
+}
+
+uint64_t FileManager::LSetxattr(const char *path, const char *name, const void *value, size_t size, int flags) {
+  auto NewPath = GetSelf(path);
+  const char *SelfPath = NewPath ? NewPath->c_str() : nullptr;
+
+  auto Path = GetEmulatedPath(SelfPath, false);
+  if (!Path.empty()) {
+    uint64_t Result = ::lsetxattr(Path.c_str(), name, value, size, flags);
+    if (Result != -1 || errno != ENOENT) {
+      return Result;
+    }
+  }
+
+  return ::lsetxattr(SelfPath, name, value, size, flags);
+}
+
+uint64_t FileManager::Getxattr(const char *path, const char *name, void *value, size_t size) {
+  auto NewPath = GetSelf(path);
+  const char *SelfPath = NewPath ? NewPath->c_str() : nullptr;
+
+  auto Path = GetEmulatedPath(SelfPath, true);
+  if (!Path.empty()) {
+    uint64_t Result = ::getxattr(Path.c_str(), name, value, size);
+    if (Result != -1 || errno != ENOENT) {
+      return Result;
+    }
+  }
+
+  return ::getxattr(SelfPath, name, value, size);
+}
+
+uint64_t FileManager::LGetxattr(const char *path, const char *name, void *value, size_t size) {
+  auto NewPath = GetSelf(path);
+  const char *SelfPath = NewPath ? NewPath->c_str() : nullptr;
+
+  auto Path = GetEmulatedPath(SelfPath, false);
+  if (!Path.empty()) {
+    uint64_t Result = ::lgetxattr(Path.c_str(), name, value, size);
+    if (Result != -1 || errno != ENOENT) {
+      return Result;
+    }
+  }
+
+  return ::lgetxattr(SelfPath, name, value, size);
+}
+
+uint64_t FileManager::Listxattr(const char *path, char *list, size_t size) {
+  auto NewPath = GetSelf(path);
+  const char *SelfPath = NewPath ? NewPath->c_str() : nullptr;
+
+  auto Path = GetEmulatedPath(SelfPath, true);
+  if (!Path.empty()) {
+    uint64_t Result = ::listxattr(Path.c_str(), list, size);
+    if (Result != -1 || errno != ENOENT) {
+      return Result;
+    }
+  }
+
+  return ::listxattr(SelfPath, list, size);
+}
+
+uint64_t FileManager::LListxattr(const char *path, char *list, size_t size) {
+  auto NewPath = GetSelf(path);
+  const char *SelfPath = NewPath ? NewPath->c_str() : nullptr;
+
+  auto Path = GetEmulatedPath(SelfPath, false);
+  if (!Path.empty()) {
+    uint64_t Result = ::llistxattr(Path.c_str(), list, size);
+    if (Result != -1 || errno != ENOENT) {
+      return Result;
+    }
+  }
+
+  return ::llistxattr(SelfPath, list, size);
+}
+
+uint64_t FileManager::Removexattr(const char *path, const char *name) {
+  auto NewPath = GetSelf(path);
+  const char *SelfPath = NewPath ? NewPath->c_str() : nullptr;
+
+  auto Path = GetEmulatedPath(SelfPath, true);
+  if (!Path.empty()) {
+    uint64_t Result = ::removexattr(Path.c_str(), name);
+    if (Result != -1 || errno != ENOENT) {
+      return Result;
+    }
+  }
+
+  return ::removexattr(SelfPath, name);
+}
+
+uint64_t FileManager::LRemovexattr(const char *path, const char *name) {
+  auto NewPath = GetSelf(path);
+  const char *SelfPath = NewPath ? NewPath->c_str() : nullptr;
+
+  auto Path = GetEmulatedPath(SelfPath, false);
+  if (!Path.empty()) {
+    uint64_t Result = ::lremovexattr(Path.c_str(), name);
+    if (Result != -1 || errno != ENOENT) {
+      return Result;
+    }
+  }
+
+  return ::lremovexattr(SelfPath, name);
 }
 
 }

--- a/Source/Tools/FEXLoader/LinuxSyscalls/FileManagement.h
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/FileManagement.h
@@ -66,7 +66,14 @@ public:
   uint64_t Mknod(const char *pathname, mode_t mode, dev_t dev);
   uint64_t NewFSStatAt(int dirfd, const char *pathname, struct stat *buf, int flag);
   uint64_t NewFSStatAt64(int dirfd, const char *pathname, struct stat64 *buf, int flag);
-
+  uint64_t Setxattr(const char *path, const char *name, const void *value, size_t size, int flags);
+  uint64_t LSetxattr(const char *path, const char *name, const void *value, size_t size, int flags);
+  uint64_t Getxattr(const char *path, const char *name, void *value, size_t size);
+  uint64_t LGetxattr(const char *path, const char *name, void *value, size_t size);
+  uint64_t Listxattr(const char *path, char *list, size_t size);
+  uint64_t LListxattr(const char *path, char *list, size_t size);
+  uint64_t Removexattr(const char *path, const char *name);
+  uint64_t LRemovexattr(const char *path, const char *name);
   // vfs
   uint64_t Statfs(const char *path, void *buf);
 

--- a/Source/Tools/FEXLoader/LinuxSyscalls/Syscalls/FS.cpp
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/Syscalls/FS.cpp
@@ -181,15 +181,15 @@ namespace FEX::HLE {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_PASS_FLAGS(setxattr, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
+    REGISTER_SYSCALL_IMPL(setxattr,
       [](FEXCore::Core::CpuStateFrame *Frame, const char *path, const char *name, const void *value, size_t size, int flags) -> uint64_t {
-      uint64_t Result = ::setxattr(path, name, value, size, flags);
+      uint64_t Result = FEX::HLE::_SyscallHandler->FM.Setxattr(path, name, value, size, flags);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_PASS_FLAGS(lsetxattr, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
+    REGISTER_SYSCALL_IMPL(lsetxattr,
       [](FEXCore::Core::CpuStateFrame *Frame, const char *path, const char *name, const void *value, size_t size, int flags) -> uint64_t {
-      uint64_t Result = ::lsetxattr(path, name, value, size, flags);
+      uint64_t Result = FEX::HLE::_SyscallHandler->FM.LSetxattr(path, name, value, size, flags);
       SYSCALL_ERRNO();
     });
 
@@ -199,15 +199,15 @@ namespace FEX::HLE {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_PASS_FLAGS(getxattr, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
+    REGISTER_SYSCALL_IMPL(getxattr,
       [](FEXCore::Core::CpuStateFrame *Frame, const char *path, const char *name, void *value, size_t size) -> uint64_t {
-      uint64_t Result = ::getxattr(path, name, value, size);
+      uint64_t Result = FEX::HLE::_SyscallHandler->FM.Getxattr(path, name, value, size);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_PASS_FLAGS(lgetxattr, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
+    REGISTER_SYSCALL_IMPL(lgetxattr,
       [](FEXCore::Core::CpuStateFrame *Frame, const char *path, const char *name, void *value, size_t size) -> uint64_t {
-      uint64_t Result = ::lgetxattr(path, name, value, size);
+      uint64_t Result = FEX::HLE::_SyscallHandler->FM.LGetxattr(path, name, value, size);
       SYSCALL_ERRNO();
     });
 
@@ -217,15 +217,15 @@ namespace FEX::HLE {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_PASS_FLAGS(listxattr, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
+    REGISTER_SYSCALL_IMPL(listxattr,
       [](FEXCore::Core::CpuStateFrame *Frame, const char *path, char *list, size_t size) -> uint64_t {
-      uint64_t Result = ::listxattr(path, list, size);
+      uint64_t Result = FEX::HLE::_SyscallHandler->FM.Listxattr(path, list, size);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_PASS_FLAGS(llistxattr, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
+    REGISTER_SYSCALL_IMPL(llistxattr,
       [](FEXCore::Core::CpuStateFrame *Frame, const char *path, char *list, size_t size) -> uint64_t {
-      uint64_t Result = ::llistxattr(path, list, size);
+      uint64_t Result = FEX::HLE::_SyscallHandler->FM.LListxattr(path, list, size);
       SYSCALL_ERRNO();
     });
 
@@ -235,15 +235,15 @@ namespace FEX::HLE {
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_PASS_FLAGS(removexattr, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
+    REGISTER_SYSCALL_IMPL(removexattr,
       [](FEXCore::Core::CpuStateFrame *Frame, const char *path, const char *name) -> uint64_t {
-      uint64_t Result = ::removexattr(path, name);
+      uint64_t Result = FEX::HLE::_SyscallHandler->FM.Removexattr(path, name);
       SYSCALL_ERRNO();
     });
 
-    REGISTER_SYSCALL_IMPL_PASS_FLAGS(lremovexattr, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
+    REGISTER_SYSCALL_IMPL(lremovexattr,
       [](FEXCore::Core::CpuStateFrame *Frame, const char *path, const char *name) -> uint64_t {
-      uint64_t Result = ::lremovexattr(path, name);
+      uint64_t Result = FEX::HLE::_SyscallHandler->FM.LRemovexattr(path, name);
       SYSCALL_ERRNO();
     });
 


### PR DESCRIPTION
Fixes a spurious `No such file or directory` error when `ls` is trying to query a path's xattributes that come from the emulated rootfs.

These syscalls don't support the *at variants, so it can't use the optimized `GetEmulatedFDPath` implementation. It must also return an error on a found file path, which makes their implementation be slightly different than the other user of of `GetEmulatedPath`. In the case of error, it must only return an error from the emulated path if it is /not/ ENOENT.

Before:
```
$ FEXInterpreter /usr/bin/ls -alth /usr/bin/wine-stable
/usr/bin/ls: /usr/bin/wine-stable: No such file or directory
-rwxr-xr-x 1 ryanh ryanh 1.1K Sep 24  2022 /usr/bin/wine-stable
```

After:
```
$ FEXInterpreter /usr/bin/ls -alth /usr/bin/wine-stable
-rwxr-xr-x 1 ryanh ryanh 1.1K Sep 24  2022 /usr/bin/wine-stable
```