### PR TITLE
Linux: Fixes hangs due to mutexes locked while fork happens.

### DIFF
--- a/External/FEXCore/Source/Utils/Allocator.cpp
+++ b/External/FEXCore/Source/Utils/Allocator.cpp
@@ -340,5 +340,17 @@ namespace FEXCore::Allocator {
       ::munmap(Region.Ptr, Region.Size);
     }
   }
+
+  void LockBeforeFork(FEXCore::Core::InternalThreadState *Thread) {
+    if (Alloc64) {
+      Alloc64->LockBeforeFork(Thread);
+    }
+  }
+
+  void UnlockAfterFork(FEXCore::Core::InternalThreadState *Thread, bool Child) {
+    if (Alloc64) {
+      Alloc64->UnlockAfterFork(Thread, Child);
+    }
+  }
 }
 #endif

--- a/External/FEXCore/Source/Utils/Allocator.h
+++ b/External/FEXCore/Source/Utils/Allocator.h
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace FEXCore::Core {
+struct InternalThreadState;
+}
+
+namespace FEXCore::Allocator {
+  void LockBeforeFork(FEXCore::Core::InternalThreadState *Thread);
+  void UnlockAfterFork(FEXCore::Core::InternalThreadState *Thread, bool Child);
+}

--- a/External/FEXCore/Source/Utils/Allocator/HostAllocator.h
+++ b/External/FEXCore/Source/Utils/Allocator/HostAllocator.h
@@ -22,6 +22,9 @@ namespace Alloc {
 
       virtual void *Mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset) { return nullptr; }
       virtual int Munmap(void *addr, size_t length) { return -1; }
+
+      virtual void LockBeforeFork(FEXCore::Core::InternalThreadState *Thread) {}
+      virtual void UnlockAfterFork(FEXCore::Core::InternalThreadState *Thread, bool Child) {}
   };
 
   class GlobalAllocator {

--- a/External/FEXCore/include/FEXCore/Core/Context.h
+++ b/External/FEXCore/include/FEXCore/Core/Context.h
@@ -243,7 +243,8 @@ namespace FEXCore::Context {
       FEX_DEFAULT_VISIBILITY virtual void RunThread(FEXCore::Core::InternalThreadState *Thread) = 0;
       FEX_DEFAULT_VISIBILITY virtual void StopThread(FEXCore::Core::InternalThreadState *Thread) = 0;
       FEX_DEFAULT_VISIBILITY virtual void DestroyThread(FEXCore::Core::InternalThreadState *Thread) = 0;
-      FEX_DEFAULT_VISIBILITY virtual void CleanupAfterFork(FEXCore::Core::InternalThreadState *Thread) = 0;
+      FEX_DEFAULT_VISIBILITY virtual void LockBeforeFork(FEXCore::Core::InternalThreadState *Thread) {}
+      FEX_DEFAULT_VISIBILITY virtual void UnlockAfterFork(FEXCore::Core::InternalThreadState *Thread, bool Child) {}
       FEX_DEFAULT_VISIBILITY virtual void SetSignalDelegator(FEXCore::SignalDelegator *SignalDelegation) = 0;
       FEX_DEFAULT_VISIBILITY virtual void SetSyscallHandler(FEXCore::HLE::SyscallHandler *Handler) = 0;
 

--- a/FEXHeaderUtils/FEXHeaderUtils/ScopedSignalMask.h
+++ b/FEXHeaderUtils/FEXHeaderUtils/ScopedSignalMask.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <FEXCore/Utils/CompilerDefs.h>
+#include <FEXCore/Utils/DeferredSignalMutex.h>
 
 #include <atomic>
 #include <cstdint>
@@ -106,4 +106,17 @@ namespace FHU {
   using ScopedSignalMaskWithMutex = ScopedSignalMaskWithMutexBase<std::mutex, &std::mutex::lock, &std::mutex::unlock>;
   using ScopedSignalMaskWithSharedLock = ScopedSignalMaskWithMutexBase<std::shared_mutex, &std::shared_mutex::lock_shared, &std::shared_mutex::unlock_shared>;
   using ScopedSignalMaskWithUniqueLock = ScopedSignalMaskWithMutexBase<std::shared_mutex, &std::shared_mutex::lock, &std::shared_mutex::unlock>;
+
+  using ScopedSignalMaskWithForkableMutex = ScopedSignalMaskWithMutexBase<
+    FEXCore::ForkableUniqueMutex,
+    &FEXCore::ForkableUniqueMutex::lock,
+    &FEXCore::ForkableUniqueMutex::unlock>;
+  using ScopedSignalMaskWithForkableSharedLock = ScopedSignalMaskWithMutexBase<
+    FEXCore::ForkableSharedMutex,
+    &FEXCore::ForkableSharedMutex::lock_shared,
+    &FEXCore::ForkableSharedMutex::unlock_shared>;
+  using ScopedSignalMaskWithForkableUniqueLock = ScopedSignalMaskWithMutexBase<
+    FEXCore::ForkableSharedMutex,
+    &FEXCore::ForkableSharedMutex::lock,
+    &FEXCore::ForkableSharedMutex::unlock>;
 }

--- a/Source/Tools/FEXLoader/LinuxSyscalls/Syscalls.h
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/Syscalls.h
@@ -15,6 +15,7 @@ $end_info$
 #include <FEXCore/HLE/SourcecodeResolver.h>
 #include <FEXCore/IR/IR.h>
 #include <FEXCore/Utils/CompilerDefs.h>
+#include <FEXCore/Utils/DeferredSignalMutex.h>
 #include <FEXCore/fextl/fmt.h>
 #include <FEXCore/fextl/map.h>
 #include <FEXCore/fextl/memory.h>
@@ -220,7 +221,7 @@ public:
 
   ///// FORK tracking /////
   void LockBeforeFork();
-  void UnlockAfterFork();
+  void UnlockAfterFork(bool Child);
 
   SourcecodeResolver *GetSourcecodeResolver() override { return this; }
 
@@ -327,7 +328,7 @@ private:
   struct VMATracking {
     using VMAEntry = SyscallHandler::VMAEntry;
     // Held while reading/writing this struct
-    std::shared_mutex Mutex;
+    FEXCore::ForkableSharedMutex Mutex;
 
     // Memory ranges indexed by page aligned starting address
     fextl::map<uint64_t, VMAEntry> VMAs;
@@ -430,6 +431,7 @@ enum TypeOfClone {
 
 struct clone3_args {
   TypeOfClone Type;
+  uint64_t SignalMask;
   kernel_clone3_args args;
 };
 


### PR DESCRIPTION
When a fork occurs FEX needs to be incredibly careful as any thread
(that isn't forking) that holds a lock will vanish when the fork occurs.

At this point if the newly forked process tries to use these mutexes
then the process hangs indefinitely.

The three major mutexes that need to be held during a fork:
- Code Invalidation mutex
  - This is the highest priority and causes us to hang frequently.
  - This is highly likely to occur when one thread is loading shared
    libraries and another thread is forking.
     - Happens frequently with Wine and steam.
- VMA tracking mutex
  - This one happens when one thread is allocating memory while a fork
    occurs.
  - This closely relates to the code invalidation mutex, just happens at
    the syscall layer instead of the FEXCore layer.
  - Happens as frequently as the code invalidation mutex.
- Allocation mutex
  - This mutex is used for FEX's 64-bit Allocator, this happens when FEX
    is allocating memory on one thread and a fork occurs.
  - Fairly infrequent because jemalloc doesn't allocate VMA regions that
    often.

While this likely doesn't hit all of the FEX mutexes, this hits the ones
that are burning fires and are happening frequently.

Fixes #2664