### PR TITLE
Linux: Stop using faccessat2 for faccessat emulation

### DIFF
--- a/Source/Tools/FEXLoader/LinuxSyscalls/FileManagement.cpp
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/FileManagement.cpp
@@ -592,7 +592,7 @@ uint64_t FileManager::FAccessat(int dirfd, const char *pathname, int mode) {
   FDPathTmpData TmpFilename;
   auto Path = GetEmulatedFDPath(dirfd, SelfPath, true, TmpFilename);
   if (Path.first != -1) {
-    uint64_t Result = ::syscall(SYSCALL_DEF(faccessat2), Path.first, Path.second, mode, 0);
+    uint64_t Result = ::syscall(SYSCALL_DEF(faccessat), Path.first, Path.second, mode);
     if (Result != -1)
       return Result;
   }


### PR DESCRIPTION
This can can issues when running on devices with kernel older than 5.8.