### PR TITLE
FHU: Workaround libstdc++ version 13+ bug

### DIFF
--- a/FEXHeaderUtils/FEXHeaderUtils/Filesystem.h
+++ b/FEXHeaderUtils/FEXHeaderUtils/Filesystem.h
@@ -265,7 +265,7 @@ namespace FHU::Filesystem {
     size_t DataSize = (sizeof(std::string_view) + sizeof(void*) * 2) * (SeparatorCount + 2);
     void *Data = alloca(DataSize);
     fextl::pmr::fixed_size_monotonic_buffer_resource mbr(Data, DataSize);
-    std::pmr::polymorphic_allocator pa {&mbr};
+    std::pmr::polymorphic_allocator<std::byte>  pa {&mbr};
     std::pmr::list<std::string_view> Parts{pa};
 
     size_t CurrentOffset{};


### PR DESCRIPTION
In libstdc++ version 13, they moved the implementation of `polymorphic_allocator` to `bits/memory_resource.h`. In doing so they forgot to move the template's default argument to that header. This causes the problem that `bits/memory_resource.h` is included first without the template's default argument defined. This breaking the automatic type deducation of `std::byte`.

Still broken in
[upstream](https://github.com/gcc-mirror/gcc/blob/be240fc6acc9714e66afbfbe6dc193844bfcba05/libstdc%2B%2B-v3/include/std/memory_resource#L79-L83) and is unlikely to be fixed and backported. Since this is the only place we use this type, just fix it here.

Shoutout to Rob Clark for noticing this bug and getting hit by it since they are using a distro new enough to ship libstdc++13.