### PR TITLE
Thunks: Fixes thunks in non-multiarch

### DIFF
--- a/Data/ThunksDB.json
+++ b/Data/ThunksDB.json
@@ -6,10 +6,10 @@
         "X11"
       ],
       "Overlay": [
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libGL.so",
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libGL.so.1",
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libGL.so.1.2.0",
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libGL.so.1.7.0"
+        "@PREFIX_LIB@/libGL.so",
+        "@PREFIX_LIB@/libGL.so.1",
+        "@PREFIX_LIB@/libGL.so.1.2.0",
+        "@PREFIX_LIB@/libGL.so.1.7.0"
       ]
     },
     "GLESv2": {
@@ -18,17 +18,17 @@
         "X11"
       ],
       "Overlay": [
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libGLESv2.so",
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libGLESv2.so.2",
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libGLESv2.so.2.0.0"
+        "@PREFIX_LIB@/libGLESv2.so",
+        "@PREFIX_LIB@/libGLESv2.so.2",
+        "@PREFIX_LIB@/libGLESv2.so.2.0.0"
       ]
     },
     "X11": {
       "Library": "libX11-guest.so",
       "Overlay": [
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libX11.so",
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libX11.so.6",
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libX11.so.6.4.0"
+        "@PREFIX_LIB@/libX11.so",
+        "@PREFIX_LIB@/libX11.so.6",
+        "@PREFIX_LIB@/libX11.so.6.4.0"
       ]
     },
     "Vulkan": {
@@ -37,8 +37,8 @@
         "xcb"
       ],
       "Overlay": [
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libvulkan.so",
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libvulkan.so.1",
+        "@PREFIX_LIB@/libvulkan.so",
+        "@PREFIX_LIB@/libvulkan.so.1",
         "@HOME@/.local/share/Steam/ubuntu12_32/steam-runtime/pinned_libs_64/libvulkan.so.1"
       ],
       "Comment": [
@@ -48,137 +48,137 @@
     "xcb": {
       "Library": "libxcb-guest.so",
       "Overlay": [
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libxcb.so",
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libxcb.so.1",
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libxcb.so.1.1.0"
+        "@PREFIX_LIB@/libxcb.so",
+        "@PREFIX_LIB@/libxcb.so.1",
+        "@PREFIX_LIB@/libxcb.so.1.1.0"
       ]
     },
     "xcb-dri2": {
       "Library": "libxcb-dri2-guest.so",
       "Overlay": [
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libxcb-dri2.so",
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libxcb-dri2.so.0",
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libxcb-dri2.so.0.0.0"
+        "@PREFIX_LIB@/libxcb-dri2.so",
+        "@PREFIX_LIB@/libxcb-dri2.so.0",
+        "@PREFIX_LIB@/libxcb-dri2.so.0.0.0"
       ]
     },
     "xcb-dri3": {
       "Library": "libxcb-dri3-guest.so",
       "Overlay": [
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libxcb-dri3.so",
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libxcb-dri3.so.0",
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libxcb-dri3.so.0.0.0"
+        "@PREFIX_LIB@/libxcb-dri3.so",
+        "@PREFIX_LIB@/libxcb-dri3.so.0",
+        "@PREFIX_LIB@/libxcb-dri3.so.0.0.0"
       ]
     },
     "xcb-xfixes": {
       "Library": "libxcb-xfixes-guest.so",
       "Overlay": [
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libxcb-xfixes.so",
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libxcb-xfixes.so.0",
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libxcb-xfixes.so.0.0.0"
+        "@PREFIX_LIB@/libxcb-xfixes.so",
+        "@PREFIX_LIB@/libxcb-xfixes.so.0",
+        "@PREFIX_LIB@/libxcb-xfixes.so.0.0.0"
       ]
     },
     "xcb-shm": {
       "Library": "libxcb-shm-guest.so",
       "Overlay": [
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libxcb-shm.so",
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libxcb-shm.so.0",
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libxcb-shm.so.0.0.0"
+        "@PREFIX_LIB@/libxcb-shm.so",
+        "@PREFIX_LIB@/libxcb-shm.so.0",
+        "@PREFIX_LIB@/libxcb-shm.so.0.0.0"
       ]
     },
     "xcb-sync": {
       "Library": "libxcb-sync-guest.so",
       "Overlay": [
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libxcb-sync.so",
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libxcb-sync.so.1",
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libxcb-sync.so.1.0.0"
+        "@PREFIX_LIB@/libxcb-sync.so",
+        "@PREFIX_LIB@/libxcb-sync.so.1",
+        "@PREFIX_LIB@/libxcb-sync.so.1.0.0"
       ]
     },
     "xcb-randr": {
       "Library": "libxcb-randr-guest.so",
       "Overlay": [
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libxcb-randr.so",
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libxcb-randr.so.0",
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libxcb-randr.so.0.1.0"
+        "@PREFIX_LIB@/libxcb-randr.so",
+        "@PREFIX_LIB@/libxcb-randr.so.0",
+        "@PREFIX_LIB@/libxcb-randr.so.0.1.0"
       ]
     },
     "xcb-present": {
       "Library": "libxcb-present-guest.so",
       "Overlay": [
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libxcb-present.so",
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libxcb-present.so.0",
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libxcb-present.so.0.0.0"
+        "@PREFIX_LIB@/libxcb-present.so",
+        "@PREFIX_LIB@/libxcb-present.so.0",
+        "@PREFIX_LIB@/libxcb-present.so.0.0.0"
       ]
     },
     "xcb-glx": {
       "Library": "libxcb-glx-guest.so",
       "Overlay": [
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libxcb-glx.so",
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libxcb-glx.so.0",
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libxcb-glx.so.0.0.0"
+        "@PREFIX_LIB@/libxcb-glx.so",
+        "@PREFIX_LIB@/libxcb-glx.so.0",
+        "@PREFIX_LIB@/libxcb-glx.so.0.0.0"
       ]
     },
     "xshmfence": {
       "Library": "libxshmfence-guest.so",
       "Overlay": [
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libxshmfence.so",
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libxshmfence.so.1",
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libxshmfence.so.1.0.0"
+        "@PREFIX_LIB@/libxshmfence.so",
+        "@PREFIX_LIB@/libxshmfence.so.1",
+        "@PREFIX_LIB@/libxshmfence.so.1.0.0"
       ]
     },
     "drm": {
       "Library": "libdrm-guest.so",
       "Overlay": [
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libdrm.so",
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libdrm.so.2",
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libdrm.so.2.4.0"
+        "@PREFIX_LIB@/libdrm.so",
+        "@PREFIX_LIB@/libdrm.so.2",
+        "@PREFIX_LIB@/libdrm.so.2.4.0"
       ]
     },
     "asound": {
       "Library": "libasound-guest.so",
       "Overlay": [
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libasound.so",
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libasound.so.2",
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libasound.so.2.0.0"
+        "@PREFIX_LIB@/libasound.so",
+        "@PREFIX_LIB@/libasound.so.2",
+        "@PREFIX_LIB@/libasound.so.2.0.0"
       ]
     },
     "Xrender": {
       "Library": "libXrender-guest.so",
       "Overlay": [
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libXrender.so",
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libXrender.so.1",
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libXrender.so.1.3.0"
+        "@PREFIX_LIB@/libXrender.so",
+        "@PREFIX_LIB@/libXrender.so.1",
+        "@PREFIX_LIB@/libXrender.so.1.3.0"
       ]
     },
     "Xext": {
       "Library": "libXext-guest.so",
       "Overlay": [
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libXext.so",
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libXext.so.6",
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libXext.so.6.4.0"
+        "@PREFIX_LIB@/libXext.so",
+        "@PREFIX_LIB@/libXext.so.6",
+        "@PREFIX_LIB@/libXext.so.6.4.0"
       ]
     },
     "Xfixes": {
       "Library": "libXfixes-guest.so",
       "Overlay": [
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libXfixes.so",
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libXfixes.so.3",
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libXfixes.so.3.1.0"
+        "@PREFIX_LIB@/libXfixes.so",
+        "@PREFIX_LIB@/libXfixes.so.3",
+        "@PREFIX_LIB@/libXfixes.so.3.1.0"
       ]
     },
     "OpenCL": {
       "Library" : "libOpenCL-guest.so",
       "Overlay": [
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libOpenCL.so",
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libOpenCL.so.1",
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libOpenCL.so.1.0.0"
+        "@PREFIX_LIB@/libOpenCL.so",
+        "@PREFIX_LIB@/libOpenCL.so.1",
+        "@PREFIX_LIB@/libOpenCL.so.1.0.0"
       ]
     },
     "WaylandClient": {
       "Library" : "libwayland-client-guest.so",
       "Overlay": [
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libwayland-client.so",
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libwayland-client.so.0",
-        "@PREFIX_LIB@/@PREFIX_ARCH@-linux-gnu/libwayland-client.so.0.20.0"
+        "@PREFIX_LIB@/libwayland-client.so",
+        "@PREFIX_LIB@/libwayland-client.so.0",
+        "@PREFIX_LIB@/libwayland-client.so.0.20.0"
       ]
     },
     "":{}

--- a/FEXHeaderUtils/FEXHeaderUtils/Filesystem.h
+++ b/FEXHeaderUtils/FEXHeaderUtils/Filesystem.h
@@ -33,6 +33,10 @@ namespace FHU::Filesystem {
     return access(Path.c_str(), F_OK) == 0;
   }
 
+  inline bool ExistsAt(int FD, const fextl::string &Path) {
+    return faccessat(FD, Path.c_str(), F_OK, 0) == 0;
+  }
+
   enum class CreateDirectoryResult {
     CREATED,
     EXISTS,

--- a/Source/Tools/FEXLoader/LinuxSyscalls/FileManagement.h
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/FileManagement.h
@@ -86,6 +86,15 @@ public:
   std::pair<int, const char*> GetEmulatedFDPath(int dirfd, const char *pathname, bool FollowSymlink, FDPathTmpData &TmpFilename);
 
 private:
+  bool RootFSPathExists(const char* Filepath);
+
+  struct ThunkDBObject {
+    fextl::string LibraryName;
+    fextl::unordered_set<fextl::string> Depends;
+    fextl::vector<fextl::string> Overlays;
+    bool Enabled{};
+  };
+  void LoadThunkDatabase(fextl::unordered_map<fextl::string, ThunkDBObject>& ThunkDB, bool Global);
   FEX::EmulatedFile::EmulatedFDManager EmuFD;
 
   fextl::map<fextl::string, fextl::string, std::less<>> ThunkOverlays;


### PR DESCRIPTION
Removes the @PREFIX_ARCH@ replacement  string in the thunks path.

The library prefix paths now get generated upfront and everything gets replaced to handle the differences between multiarch distros.

Fixes Thunks on Arch and Fedora.