### PR TITLE
unittests: Adds missing header

### DIFF
--- a/unittests/Utilities/DeleteOldSHMRegions.cpp
+++ b/unittests/Utilities/DeleteOldSHMRegions.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include <fstream>
 #include <stdio.h>
 #include <sys/shm.h>


### PR DESCRIPTION
Newer libstdc++ moved an internal header include and now this failed to compile.