### PR TITLE
OpcodeDispatcher: Optimize some shifts size masking

### DIFF
--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -787,20 +787,29 @@
         "Desc": ["Integer binary AND NOT. Performs the equivalent of Src1 & ~Src2"],
         "DestSize": "std::max<uint8_t>(4, GetOpSize(_Src1))"
       },
-      "GPR = Lshl GPR:$Src1, GPR:$Src2": {
+      "GPR = Lshl u8:#Size, GPR:$Src1, GPR:$Src2": {
         "Desc": ["Integer logical shift left"
                 ],
-        "DestSize": "std::max<uint8_t>(4, GetOpSize(_Src1))"
+        "EmitValidation": [
+          "Size >= 4"
+        ],
+        "DestSize": "Size"
       },
-      "GPR = Lshr GPR:$Src1, GPR:$Src2": {
+      "GPR = Lshr u8:#Size, GPR:$Src1, GPR:$Src2": {
         "Desc": ["Integer logical shift right"
                 ],
-        "DestSize": "std::max<uint8_t>(4, GetOpSize(_Src1))"
+        "EmitValidation": [
+          "Size >= 4"
+        ],
+        "DestSize": "Size"
       },
-      "GPR = Ashr GPR:$Src1, GPR:$Src2": {
+      "GPR = Ashr u8:#Size, GPR:$Src1, GPR:$Src2": {
         "Desc": ["Integer arithmetic shift right"
                 ],
-        "DestSize": "std::max<uint8_t>(4, GetOpSize(_Src1))"
+        "EmitValidation": [
+          "Size >= 4"
+        ],
+        "DestSize": "Size"
       },
       "GPR = Ror GPR:$Src1, GPR:$Src2": {
         "Desc": ["Integer rotate right"

--- a/External/FEXCore/include/FEXCore/IR/IREmitter.h
+++ b/External/FEXCore/include/FEXCore/IR/IREmitter.h
@@ -93,6 +93,15 @@ friend class FEXCore::IR::PassManager;
   IRPair<IROp_StoreMemTSO> _StoreMemTSO(FEXCore::IR::RegisterClassType Class, uint8_t Size, OrderedNode *Addr, OrderedNode *Value, uint8_t Align = 1) {
     return _StoreMemTSO(Class, Size, Value, Addr, Invalid(), Align, MEM_OFFSET_SXTX, 1);
   }
+  IRPair<IROp_Lshl> _Lshl(OrderedNode *Src1, OrderedNode *Src2) {
+    return _Lshl(std::max<uint8_t>(4, GetOpSize(Src1)), Src1, Src2);
+  }
+  IRPair<IROp_Lshr> _Lshr(OrderedNode *Src1, OrderedNode *Src2) {
+    return _Lshr(std::max<uint8_t>(4, GetOpSize(Src1)), Src1, Src2);
+  }
+  IRPair<IROp_Ashr> _Ashr(OrderedNode *Src1, OrderedNode *Src2) {
+    return _Ashr(std::max<uint8_t>(4, GetOpSize(Src1)), Src1, Src2);
+  }
   OrderedNode *Invalid() {
     return InvalidNode;
   }

--- a/unittests/IR/Correctness/LeftShiftTruncate.ir
+++ b/unittests/IR/Correctness/LeftShiftTruncate.ir
@@ -22,14 +22,14 @@
     %AddrA i64 = Constant #0x1000000
     %MemValueA i32 = LoadMem GPR, #4, %AddrA i64, %Invalid, #4, SXTX, #1
     %Shift i64 = Constant #0x1
-    %ResultA i32 = Lshl %MemValueA, %Shift
-    %ResultB i64 = Lshl %MemValueA, %Shift
+    %ResultA i32 = Lshl #4, %MemValueA, %Shift
+    %ResultB i64 = Lshl #8, %MemValueA, %Shift
     (%Store i64) StoreRegister %ResultA i64, #0, #0x8, GPR, GPRFixed, #8
     (%Store i64) StoreRegister %ResultB i64, #0, #0x20, GPR, GPRFixed, #8
 ;  Constant optimisable version
     %ValueB i64 = Constant #0x87654321
-    %ResultC i32 = Lshl %ValueB, %Shift
-    %ResultD i64 = Lshl %ValueB, %Shift
+    %ResultC i32 = Lshl #4, %ValueB, %Shift
+    %ResultD i64 = Lshl #8, %ValueB, %Shift
     (%Store i64) StoreRegister %ResultC i64, #0, #0x10, GPR, GPRFixed, #8
     (%Store i64) StoreRegister %ResultD i64, #0, #0x18, GPR, GPRFixed, #8
     (%ssa7 i0) Break {0.11.0.128}


### PR DESCRIPTION
Inspired from #2561, these shifts don't need to be masked if we know their operating size up front.

Causes a handful of these to become more optimal.