### PR TITLE
OpcodeDispatcher: Fixes bug with pcmpestri

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -4881,7 +4881,12 @@ void OpDispatchBuilder::PCMPXSTRXOpImpl(OpcodeArgs, bool IsExplicit, bool IsMask
     OrderedNode *Result = _Select(IR::COND_EQ, ResultNoFlags, ZeroConst,
                                   IfZero, IfNotZero);
 
-    StoreGPRRegister(X86State::REG_RCX, Result, 4);
+    const uint8_t GPRSize = CTX->GetGPRSize();
+    if (GPRSize == 8) {
+      // If being stored to an 8-byte register, zero extend the 4-byte result.
+      Result = _Bfe(8, 32, 0, Result);
+    }
+    StoreGPRRegister(X86State::REG_RCX, Result);
   }
 
   // Set all of the necessary flags.

--- a/unittests/ASM/FEX_bugs/pcmpestri_garbage_rcx.asm
+++ b/unittests/ASM/FEX_bugs/pcmpestri_garbage_rcx.asm
@@ -1,0 +1,36 @@
+%ifdef CONFIG
+{
+  "RegData": {
+      "RAX": ["15"],
+      "RCX": ["5"],
+      "RDX": ["16"]
+  }
+}
+%endif
+
+; Tests a bug that FEX had with pcmpestri where the returned index would leave data in the upper 32-bits of rcx.
+; This instruction writes a 32-bit result to rcx with zero extend to 64-bit.
+; Test this by writing data in to rcx before the instruction and ensuring it is erased after the fact.
+
+movaps xmm2, [rel .data]
+movaps xmm3, [rel .data + 32]
+
+; Unsigned byte character check (lsb, positive polarity)
+mov rax, 15 ; Exclude 'l'
+mov rdx, 16
+mov rcx, 0x4142434445464748
+
+pcmpestri xmm2, xmm3, 0b00000000
+hlt
+
+align 32
+.data:
+dq 0x6463626144434241 ; "ABCDabcd"
+dq 0x6C6B6A694C4B4A49 ; "IJKLijkl"
+dq 0xFFFFFFFFFFFFFFFF
+dq 0xEEEEEEEEEEEEEEEE
+
+dq 0x4120492065726548 ; "Here I A"
+dq 0x6C4C612759202C6D ; "m, Y'aLl"
+dq 0xDDDDDDDDDDDDDDDD
+dq 0xCCCCCCCCCCCCCCCC


### PR DESCRIPTION
When this instruction returns the index in to the ecx register, this is defined as a 32-bit result. This means it actually gets zero-extended to the full 64-bit GPR size on 64-bit processes.
Previously FEX was doing a 32-bit insert which leaves garbage data in the upper 32-bits of the RCX register.

Adds a unit test to ensure the result is zero extended. Fixes running Java games under FEX now that SSE4.2 is exposed.