### PR TITLE
CMake: Stop installing fmt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,6 +267,8 @@ if (BUILD_TESTS)
   include(Catch)
 endif()
 
+# Disable fmt install
+set(FMT_INSTALL OFF)
 add_subdirectory(External/fmt/)
 
 add_subdirectory(External/imgui/)


### PR DESCRIPTION
Fixes #2751

Luckily fmt provides an option to disable this.