### PR TITLE
IR: Optimize vector TSO loadstore address calculation

### DIFF
--- a/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -561,6 +561,44 @@ bool ConstProp::ConstantPropagation(IREmitter *IREmit, const IRListView& Current
     }
 */
 
+    case OP_LOADMEMTSO: {
+      auto Op = IROp->CW<IR::IROp_LoadMemTSO>();
+      auto AddressHeader = IREmit->GetOpHeader(Op->Addr);
+
+      if (Op->Class == FEXCore::IR::FPRClass && AddressHeader->Op == OP_ADD && AddressHeader->Size == 8) {
+        // TODO: LRCPC3 supports a vector unscaled offset like LRCPC2.
+        // Support once hardware is available to use this.
+        auto [OffsetType, OffsetScale, Arg0, Arg1] = MemExtendedAddressing(IREmit, IROp->Size, AddressHeader);
+
+        Op->OffsetType = OffsetType;
+        Op->OffsetScale = OffsetScale;
+        IREmit->ReplaceNodeArgument(CodeNode, Op->Addr_Index, Arg0); // Addr
+        IREmit->ReplaceNodeArgument(CodeNode, Op->Offset_Index, Arg1); // Offset
+
+        Changed = true;
+      }
+      break;
+    }
+
+    case OP_STOREMEMTSO: {
+      auto Op = IROp->CW<IR::IROp_StoreMemTSO>();
+      auto AddressHeader = IREmit->GetOpHeader(Op->Addr);
+
+      if (Op->Class == FEXCore::IR::FPRClass && AddressHeader->Op == OP_ADD && AddressHeader->Size == 8) {
+        // TODO: LRCPC3 supports a vector unscaled offset like LRCPC2.
+        // Support once hardware is available to use this.
+        auto [OffsetType, OffsetScale, Arg0, Arg1] = MemExtendedAddressing(IREmit, IROp->Size, AddressHeader);
+
+        Op->OffsetType = OffsetType;
+        Op->OffsetScale = OffsetScale;
+        IREmit->ReplaceNodeArgument(CodeNode, Op->Addr_Index, Arg0); // Addr
+        IREmit->ReplaceNodeArgument(CodeNode, Op->Offset_Index, Arg1); // Offset
+
+        Changed = true;
+      }
+      break;
+    }
+
     case OP_LOADMEM: {
       auto Op = IROp->CW<IR::IROp_LoadMem>();
       auto AddressHeader = IREmit->GetOpHeader(Op->Addr);


### PR DESCRIPTION
These address calculations were failing to understand that they can be optimized. When TSO emulation is disabled these were fine, but with TSO we were eating one more instruction.

Before:
```
add x20, x12, #0x4 (4)
dmb ish
ldr s16, [x20]
dmb ish
```

After:
```
dmb ish
ldr s16, [x12, #4]
dmb ish
```

Also left a note that once LRCPC3 is supported in hardware that we can do a similar optimization there.

Found through inspection.