### PR TITLE
Arm64: Switch to using half barriers

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -1231,8 +1231,6 @@ DEF_OP(LoadMemTSO) {
       ldapurb(Dst, MemReg, Offset);
     }
     else {
-      // Aligned
-      nop();
       switch (OpSize) {
         case 2:
           ldapurh(Dst, MemReg, Offset);
@@ -1247,6 +1245,7 @@ DEF_OP(LoadMemTSO) {
           LOGMAN_MSG_A_FMT("Unhandled LoadMemTSO size: {}", OpSize);
           break;
       }
+      // Half-barrier once back-patched.
       nop();
     }
   }
@@ -1257,8 +1256,6 @@ DEF_OP(LoadMemTSO) {
       ldaprb(Dst.W(), MemReg);
     }
     else {
-      // Aligned
-      nop();
       switch (OpSize) {
         case 2:
           ldaprh(Dst.W(), MemReg);
@@ -1273,6 +1270,7 @@ DEF_OP(LoadMemTSO) {
           LOGMAN_MSG_A_FMT("Unhandled LoadMemTSO size: {}", OpSize);
           break;
       }
+      // Half-barrier once back-patched.
       nop();
     }
   }
@@ -1283,8 +1281,6 @@ DEF_OP(LoadMemTSO) {
       ldarb(Dst, MemReg);
     }
     else {
-      // Aligned
-      nop();
       switch (OpSize) {
         case 2:
           ldarh(Dst, MemReg);
@@ -1299,11 +1295,11 @@ DEF_OP(LoadMemTSO) {
           LOGMAN_MSG_A_FMT("Unhandled LoadMemTSO size: {}", OpSize);
           break;
       }
+      // Half-barrier once back-patched.
       nop();
     }
   }
   else {
-    dmb(FEXCore::ARMEmitter::BarrierScope::ISH);
     const auto Dst = GetVReg(Node);
     const auto MemSrc = GenerateMemOperand(OpSize, MemReg, Op->Offset, Op->OffsetType, Op->OffsetScale);
     switch (OpSize) {
@@ -1331,7 +1327,8 @@ DEF_OP(LoadMemTSO) {
         LOGMAN_MSG_A_FMT("Unhandled LoadMemTSO size: {}", OpSize);
         break;
     }
-    dmb(FEXCore::ARMEmitter::BarrierScope::ISH);
+    // Half-barrier.
+    dmb(FEXCore::ARMEmitter::BarrierScope::ISHLD);
   }
 }
 
@@ -1516,6 +1513,7 @@ DEF_OP(StoreMemTSO) {
       stlurb(Src, MemReg, Offset);
     }
     else {
+      // Half-barrier once back-patched.
       nop();
       switch (OpSize) {
         case 2:
@@ -1531,7 +1529,6 @@ DEF_OP(StoreMemTSO) {
           LOGMAN_MSG_A_FMT("Unhandled StoreMemTSO size: {}", OpSize);
           break;
       }
-      nop();
     }
   }
   else if (Op->Class == FEXCore::IR::GPRClass) {
@@ -1542,6 +1539,7 @@ DEF_OP(StoreMemTSO) {
       stlrb(Src, MemReg);
     }
     else {
+      // Half-barrier once back-patched.
       nop();
       switch (OpSize) {
         case 2:
@@ -1557,10 +1555,10 @@ DEF_OP(StoreMemTSO) {
           LOGMAN_MSG_A_FMT("Unhandled StoreMemTSO size: {}", OpSize);
           break;
       }
-      nop();
     }
   }
   else {
+    // Half-Barrier.
     dmb(FEXCore::ARMEmitter::BarrierScope::ISH);
     const auto Src = GetVReg(Op->Value.ID());
     const auto MemSrc = GenerateMemOperand(OpSize, MemReg, Op->Offset, Op->OffsetType, Op->OffsetScale);
@@ -1589,7 +1587,6 @@ DEF_OP(StoreMemTSO) {
         LOGMAN_MSG_A_FMT("Unhandled StoreMemTSO size: {}", OpSize);
         break;
     }
-    dmb(FEXCore::ARMEmitter::BarrierScope::ISH);
   }
 }
 

--- a/External/FEXCore/Source/Utils/ArchHelpers/Arm64.cpp
+++ b/External/FEXCore/Source/Utils/ArchHelpers/Arm64.cpp
@@ -2060,12 +2060,11 @@ static uint64_t HandleAtomicLoadstoreExclusive(uintptr_t ProgramCounter, uint64_
         LDR |= Size << 30;
         LDR |= AddrReg << 5;
         LDR |= DataReg;
-        PC[-1] = DMB;
         PC[0] = LDR;
-        PC[1] = DMB;
+        PC[1] = DMB_LD; // Back-patch the half-barrier.
         ClearICache(&PC[-1], 16);
-        // Back up one instruction and have another go
-        return std::make_pair(true, -4);
+        // With the instruction modified, now execute again.
+        return std::make_pair(true, 0);
       }
     }
     else if ( (Instr & LDAXR_MASK) == STLR_INST) { // STLR*
@@ -2084,9 +2083,8 @@ static uint64_t HandleAtomicLoadstoreExclusive(uintptr_t ProgramCounter, uint64_
         STR |= Size << 30;
         STR |= AddrReg << 5;
         STR |= DataReg;
-        PC[-1] = DMB;
+        PC[-1] = DMB; // Back-patch the half-barrier.
         PC[0] = STR;
-        PC[1] = DMB;
         ClearICache(&PC[-1], 16);
         // Back up one instruction and have another go
         return std::make_pair(true, -4);
@@ -2111,12 +2109,11 @@ static uint64_t HandleAtomicLoadstoreExclusive(uintptr_t ProgramCounter, uint64_
         LDUR |= AddrReg << 5;
         LDUR |= DataReg;
         LDUR |= Instr & (0b1'1111'1111 << 9);
-        PC[-1] = DMB;
         PC[0] = LDUR;
-        PC[1] = DMB;
+        PC[1] = DMB_LD; // Back-patch the half-barrier.
         ClearICache(&PC[-1], 16);
-        // Back up one instruction and have another go
-        return std::make_pair(true, -4);
+        // With the instruction modified, now execute again.
+        return std::make_pair(true, 0);
       }
     }
     else if ((Instr & RCPC2_MASK) == STLUR_INST) { // STLUR*
@@ -2138,9 +2135,8 @@ static uint64_t HandleAtomicLoadstoreExclusive(uintptr_t ProgramCounter, uint64_
         STUR |= AddrReg << 5;
         STUR |= DataReg;
         STUR |= Instr & (0b1'1111'1111 << 9);
-        PC[-1] = DMB;
+        PC[-1] = DMB;  // Back-patch the half-barrier.
         PC[0] = STUR;
-        PC[1] = DMB;
         ClearICache(&PC[-1], 16);
         // Back up one instruction and have another go
         return std::make_pair(true, -4);

--- a/External/FEXCore/include/FEXCore/Utils/ArchHelpers/Arm64.h
+++ b/External/FEXCore/include/FEXCore/Utils/ArchHelpers/Arm64.h
@@ -90,6 +90,9 @@ namespace FEXCore::ArchHelpers::Arm64 {
   constexpr uint32_t DMB = 0b1101'0101'0000'0011'0011'0000'1011'1111 |
     0b1011'0000'0000; // Inner shareable all
 
+  constexpr uint32_t DMB_LD = 0b1101'0101'0000'0011'0011'0000'1011'1111 |
+    0b1101'0000'0000; // Inner shareable load
+
   inline uint32_t GetRdReg(uint32_t Instr) {
     return (Instr >> RD_OFFSET) & REGISTER_MASK;
   }


### PR DESCRIPTION
Inspired from: https://github.com/dotnet/runtime/issues/8072

Currently FEX is /very/ heavy handed with our backpatching where we wrap every backpatched loadstore with `dmb ish`.

This can be relaxed slightly according to the linked issue.

For TSO load instructions the instruction sequence changes to:
  ldr <args>;
  dmb ld; <-- Slightly less strict dmb

For TSO store instructions the instruction sequence changes to:
  dmb ish; <-- Still the all encompassing dmb
  str <args>;

For backpatching loadstores this does the same thing where only one side needs the nop and it uses the same instruction sequence when backpatched.

The minor change is that on load backpatching, we are no longer backing up a single instruction, instead just re-executing the instruction we patched directly.

Took a long time to come back to this (Last looked in August 2020). Previously when I was implementing this idea it didn't work, but that was because our CompareExchange operation was broken back then. With the CAS now, it should just work.