### PR TITLE
FHU: Fix WIN32 getcpu implementation

### DIFF
--- a/FEXHeaderUtils/FEXHeaderUtils/Syscalls.h
+++ b/FEXHeaderUtils/FEXHeaderUtils/Syscalls.h
@@ -98,8 +98,12 @@ inline int32_t pidfd_open(pid_t pid, unsigned int flags) {
 #else
 
 inline int32_t getcpu(uint32_t *cpu, uint32_t *node) {
-  *cpu = GetCurrentProcessorNumber();
-  *node = 0;
+  if (cpu) {
+    *cpu = GetCurrentProcessorNumber();
+  }
+  if (node) {
+    *node = 0;
+  }
   return 0;
 }
 


### PR DESCRIPTION
Both parameters to getcpu are nullable and FEX relies upon this for CPUID, this fixes an access violation when running Portal under PE FEX.