### PR TITLE
Thunks/X11: Fixes variadic packing and callbacks.

### DIFF
--- a/ThunkLibs/libX11/X11Common.h
+++ b/ThunkLibs/libX11/X11Common.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <array>
+#include <string>
+extern "C" {
+#include <X11/Xlib.h>
+}
+
+namespace X11 {
+  constexpr static std::array<std::string_view, 13> CallbackKeys = {{
+    XNGeometryCallback,
+    XNDestroyCallback,
+    XNPreeditStartCallback,
+    XNPreeditDoneCallback,
+    XNPreeditDrawCallback,
+    XNPreeditCaretCallback,
+    XNPreeditStateNotifyCallback,
+    XNStatusStartCallback,
+    XNStatusDoneCallback,
+    XNStatusDrawCallback,
+    XNR6PreeditCallback,
+    XNStringConversionCallback,
+  }};
+
+}

--- a/ThunkLibs/libX11/libX11_Guest.cpp
+++ b/ThunkLibs/libX11/libX11_Guest.cpp
@@ -20,134 +20,214 @@ extern "C" {
 #undef max
 }
 
+#include <algorithm>
+#include <array>
+#include <cassert>
 #include <cstdint>
 #include <stdio.h>
 #include <cstring>
 #include <map>
+#include <list>
 #include <string>
+#include <unistd.h>
 
 #include "common/Guest.h"
 #include <stdarg.h>
 
 #include "thunkgen_guest_libX11.inl"
+#include "X11Common.h"
 
 // Custom implementations //
 
 #include <vector>
 
+namespace {
+  // The various X11 variadic functions take a flattened sequence of key:value pairs as arguments.
+  // The key element is a pointer to a string.
+  // The value element is a pointer to the data of that key type.
+  //
+  // Some keys describe function callbacks for various events that the server interface can call.
+  // FEX needs to walk these keys and ensure any callback function has a trampoline so the native
+  // X11 library can call it.
+  template<typename CallbackType>
+  static std::list<CallbackType> ConvertCallbackArguments(std::vector<void*> &IncomingArguments) {
+    assert(IncomingArguments.size() % 2 == 0 && "Incoming arguments needs to be in pairs");
+
+    std::list<CallbackType> Callbacks;
+    // Walk the arguments and convert any callbacks.
+    const size_t ArgumentPairs = IncomingArguments.size() / 2;
+    for (size_t i = 0; i < ArgumentPairs; ++i) {
+      const char *Key = static_cast<const char*>(IncomingArguments[i * 2]);
+      void** Data = &IncomingArguments[i * 2 + 1];
+      if (!*Data) {
+        continue;
+      }
+
+      // Check if the key is a callback and needs to be modified.
+      auto KeyIt = std::find(X11::CallbackKeys.begin(), X11::CallbackKeys.end(), Key);
+      if (KeyIt == X11::CallbackKeys.end()) {
+        continue;
+      }
+
+      // Key matches a callback, we need to wrap this.
+      CallbackType *IncomingCallback = reinterpret_cast<CallbackType*>(*Data);
+      CallbackType *ConvertedCallback = &Callbacks.emplace_back(CallbackType {
+        // Client data stays the same.
+        .client_data = IncomingCallback->client_data,
+
+        // Callback needs a trampoline.
+        .callback = AllocateHostTrampolineForGuestFunction(IncomingCallback->callback),
+      });
+
+      // Add this converted back in.
+      *Data = ConvertedCallback;
+    }
+
+    return Callbacks;
+  }
+}
+
 extern "C" {
     char* XGetICValues(XIC ic, ...) {
-        fprintf(stderr, "XGetICValues\n");
-        va_list ap;
-        std::vector<unsigned long> args;
-        va_start(ap, ic);
-        for (;;) {
-            auto arg = va_arg(ap, unsigned long);
-            if (arg == 0)
-                break;
-            args.push_back(arg);
-            fprintf(stderr, "%016lX\n", arg);
-        }
+      fprintf(stderr, "XGetICValues\n");
+      va_list ap;
+      std::vector<void*> args;
+      va_start(ap, ic);
+      for (;;) {
+        auto arg = va_arg(ap, void*);
+        if (arg == 0)
+          break;
+        args.push_back(arg);
+        fprintf(stderr, "%p\n", arg);
+      }
 
-        va_end(ap);
-        auto rv = fexfn_pack_XGetICValues_internal(ic, args.size(), &args[0]);
-        fprintf(stderr, "RV: %p\n", rv);
-        return rv;
+      va_end(ap);
+
+      auto rv = fexfn_pack_XGetICValues_internal(ic, args.size(), &args[0]);
+      fprintf(stderr, "RV: %p\n", rv);
+      return rv;
     }
 
     char* XSetICValues(XIC ic, ...) {
-        fprintf(stderr, "XSetICValues\n");
-        va_list ap;
-        std::vector<unsigned long> args;
-        va_start(ap, ic);
-        for (;;) {
-            auto arg = va_arg(ap, unsigned long);
-            if (arg == 0)
-                break;
-            args.push_back(arg);
-            fprintf(stderr, "%016lX\n", arg);
-        }
+      fprintf(stderr, "XSetICValues\n");
+      va_list ap;
+      std::vector<void*> IncomingArguments;
+      va_start(ap, ic);
+      for (;;) {
+        auto Key = va_arg(ap, void*);
+        if (Key == 0)
+          break;
 
-        va_end(ap);
-        auto rv = fexfn_pack_XSetICValues_internal(ic, args.size(), &args[0]);
-        fprintf(stderr, "RV: %p\n", rv);
-        return rv;
+        auto Value = va_arg(ap, void*);
+        IncomingArguments.emplace_back(Key);
+        IncomingArguments.emplace_back(Value);
+      }
+
+      va_end(ap);
+
+      // Callback memory needs to live beyond internal function call.
+      std::list<XICCallback> Callbacks = ConvertCallbackArguments<XICCallback>(IncomingArguments);
+
+      auto rv = fexfn_pack_XSetICValues_internal(ic, IncomingArguments.size(), &IncomingArguments[0]);
+      fprintf(stderr, "RV: %p\n", rv);
+      return rv;
     }
 
     char* XGetIMValues(XIM ic, ...) {
-        fprintf(stderr, "XGetIMValues\n");
-        va_list ap;
-        std::vector<void*> args;
-        va_start(ap, ic);
-        for (;;) {
-            auto arg = va_arg(ap, void*);
-            if (arg == 0)
-                break;
-            args.push_back(arg);
-            fprintf(stderr, "%p\n", arg);
-        }
+      fprintf(stderr, "XGetIMValues\n");
+      va_list ap;
+      std::vector<void*> args;
+      va_start(ap, ic);
+      for (;;) {
+        auto arg = va_arg(ap, void*);
+        if (arg == 0)
+          break;
+        args.push_back(arg);
+        fprintf(stderr, "%p\n", arg);
+      }
 
-        va_end(ap);
-        auto rv = fexfn_pack_XGetIMValues_internal(ic, args.size(), &args[0]);
-        fprintf(stderr, "RV: %p\n", rv);
-        return rv;
+      va_end(ap);
+      auto rv = fexfn_pack_XGetIMValues_internal(ic, args.size(), &args[0]);
+      fprintf(stderr, "RV: %p\n", rv);
+      return rv;
     }
 
     char* XSetIMValues(XIM ic, ...) {
-        fprintf(stderr, "XSetIMValues\n");
-        va_list ap;
-        std::vector<void*> args;
-        va_start(ap, ic);
-        for (;;) {
-            auto arg = va_arg(ap, void*);
-            if (arg == 0)
-                break;
-            args.push_back(arg);
-            fprintf(stderr, "%p\n", arg);
-        }
+      fprintf(stderr, "XSetIMValues\n");
+      va_list ap;
+      std::vector<void*> IncomingArguments;
+      va_start(ap, ic);
+      for (;;) {
+        auto Key = va_arg(ap, void*);
+        if (Key == 0)
+          break;
 
-        va_end(ap);
-        auto rv = fexfn_pack_XSetIMValues_internal(ic, args.size(), &args[0]);
-        fprintf(stderr, "RV: %p\n", rv);
-        return rv;
+        auto Value = va_arg(ap, void*);
+        IncomingArguments.emplace_back(Key);
+        IncomingArguments.emplace_back(Value);
+        fprintf(stderr, "%s\n", (char*)Key);
+      }
+
+      va_end(ap);
+
+      // Callback memory needs to live beyond internal function call.
+      std::list<XIMCallback> Callbacks = ConvertCallbackArguments<XIMCallback>(IncomingArguments);
+
+      // Send a count (not including nullptr);
+      auto rv = fexfn_pack_XSetIMValues_internal(ic, IncomingArguments.size(), &IncomingArguments[0]);
+      fprintf(stderr, "RV: %p\n", rv);
+      return rv;
     }
 
     _XIC* XCreateIC(XIM im, ...) {
-        fprintf(stderr, "XCreateIC\n");
-        va_list ap;
-        std::vector<unsigned long> args;
-        va_start(ap, im);
-        for (;;) {
-            auto arg = va_arg(ap, unsigned long);
-            if (arg == 0)
-                break;
-            args.push_back(arg);
-            fprintf(stderr, "%016lX\n", arg);
-        }
+      fprintf(stderr, "XCreateIC\n");
+      va_list ap;
+      std::vector<void*> IncomingArguments;
 
-        va_end(ap);
-        auto rv = fexfn_pack_XCreateIC_internal(im, args.size(), &args[0]);
-        fprintf(stderr, "RV: %p\n", rv);
-        return rv;
+      va_start(ap, im);
+      for (;;) {
+        auto Key = va_arg(ap, void*);
+        if (Key == 0)
+          break;
+
+        auto Value = va_arg(ap, void*);
+        IncomingArguments.emplace_back(Key);
+        IncomingArguments.emplace_back(Value);
+      }
+
+      va_end(ap);
+
+      // Callback memory needs to live beyond internal function call.
+      std::list<XICCallback> Callbacks = ConvertCallbackArguments<XICCallback>(IncomingArguments);
+
+      auto rv = fexfn_pack_XCreateIC_internal(im, IncomingArguments.size(), &IncomingArguments[0]);
+      return rv;
     }
 
     XVaNestedList XVaCreateNestedList(int unused_arg, ...) {
-        fprintf(stderr, "XVaCreateNestedList\n");
-        va_list ap;
-        std::vector<void*> args;
-        va_start(ap, unused_arg);
-        for (;;) {
-            auto arg = va_arg(ap, void*);
-            if (arg == 0)
-                break;
-            args.push_back(arg);
-            fprintf(stderr, "%p\n", arg);
-        }
+      fprintf(stderr, "XVaCreateNestedList\n");
+      va_list ap;
+      std::vector<void*> IncomingArguments;
 
-        va_end(ap);
-        auto rv = fexfn_pack_XVaCreateNestedList_internal(unused_arg, args.size(), &args[0]);
-        fprintf(stderr, "RV: %p\n", rv);
-        return rv;
+      va_start(ap, unused_arg);
+      for (;;) {
+        auto Key = va_arg(ap, void*);
+        if (Key == 0)
+          break;
+
+        auto Value = va_arg(ap, void*);
+        IncomingArguments.emplace_back(Key);
+        IncomingArguments.emplace_back(Value);
+      }
+
+      va_end(ap);
+
+      // Callback memory needs to live beyond internal function call.
+      std::list<XICCallback> Callbacks = ConvertCallbackArguments<XICCallback>(IncomingArguments);
+
+      auto rv = fexfn_pack_XVaCreateNestedList_internal(unused_arg, IncomingArguments.size(), &IncomingArguments[0]);
+      fprintf(stderr, "RV: %p\n", rv);
+      return rv;
     }
 
     static void LockMutexFunction(LockInfoPtr) {
@@ -263,6 +343,27 @@ extern "C" {
     auto ret = fexfn_pack_XInitImage(image);
     FixupImageFuncPtrs(image);
     return ret;
+  }
+
+  Bool XRegisterIMInstantiateCallback(Display* dpy,
+    struct _XrmHashBucketRec* rdb,
+    char* res_name,
+    char* res_class,
+    XIDProc callback,
+    XPointer client_data
+  ) {
+    return fexfn_pack_XRegisterIMInstantiateCallback(dpy, rdb, res_name, res_class, AllocateHostTrampolineForGuestFunction(callback), client_data);
+  }
+
+  Bool XUnregisterIMInstantiateCallback(
+    Display* dpy,
+    struct _XrmHashBucketRec* rdb,
+    char* res_name,
+    char* res_class,
+    XIDProc callback,
+    XPointer client_data
+  ) {
+    return fexfn_pack_XUnregisterIMInstantiateCallback(dpy, rdb, res_name, res_class, AllocateHostTrampolineForGuestFunction(callback), client_data);
   }
 
   void (*_XLockMutex_fn)(LockInfoPtr) = LockMutexFunction;

--- a/ThunkLibs/libX11/libX11_Host.cpp
+++ b/ThunkLibs/libX11/libX11_Host.cpp
@@ -35,164 +35,6 @@ extern "C" {
 #include "thunkgen_host_libX11.inl"
 #include "X11Common.h"
 
-#ifdef _M_ARM_64
-// This Variadic asm only works for one signature
-// ({uint32_t,uint64_t} a_0, size_t count, uint64_t *list)
-//
-// Variadic ABI for AArch64 (flat uint64_t):
-// Arguments 0-7 is in registers
-// 8+ stored on to stack
-//
-// The X11 functions we are calling need an additional nullptr passed in.
-// nullptr will be at the end of the list of generated stack items when called through this.
-// We will always generate a variadic frame of `count` objects + 1 for nullptr.
-//
-// Incoming:
-// x0 = XIM
-// x1 = count (excluding final nullptr)
-// x2 = array of 64-bit values (excluding final nullptr)
-// x3 = Function to call
-//
-// Outgoing:
-// x0: Ptr
-
-__attribute__((naked))
-void *libX11_Variadic_u64(uint64_t a_0, size_t count, void **list, void *Func) {
-  asm volatile(R"(
-    # Move our function to x8, which will be unused
-    mov x8, x3
-
-    # Move our list to x9, which will be unused
-    mov x9, x2
-
-    # >6 means use stack callback
-    cmp x1, 6
-    b.gt .stack%=
-
-    # Setup a jump table
-    adr x10, .zero%=
-    adr x11, .jump_table%=
-    ldrb w11, [x11, x1]
-    add x10, x10, x11, lsl 2
-    br x10
-
-    .zero%=:
-      mov x1, 0
-      br x8
-
-    .one%=:
-      ldr x1, [x9, 0]
-      mov x2, #0
-      br x8
-
-    .two%=:
-      ldp x1, x2, [x9, 0]
-      mov x3, 0
-      br x8
-
-    .three%=:
-      ldp x1, x2, [x9, 0]
-      ldr x3, [x9, 16]
-      mov x4, 0
-      br x8
-
-    .four%=:
-      ldp x1, x2, [x9, 0]
-      ldp x3, x4, [x9, 16]
-      mov x5, 0
-      br x8
-
-    .five%=:
-      ldp x1, x2, [x9, 0]
-      ldp x3, x4, [x9, 16]
-      ldr x5, [x9, 32]
-      mov x6, 0
-      br x8
-
-    .six%=:
-      ldp x1, x2, [x9, 0]
-      ldp x3, x4, [x9, 16]
-      ldp x5, x6, [x9, 32]
-      mov x7, 0
-      br x8
-
-    .stack%=:
-      # Store LR and x28
-      stp x28, x30, [sp, -16]!
-
-      # x8 = <arg ptr>
-      # x0 = <arg im>
-      # x1 = <count>
-      # x9 = <list ptr>
-
-      # The number of arguments on the stack will always be (Count - 7) + 1
-
-      # Subtract 6 count objects
-      # Gives us the total number of objects that need to be stored on to the stack.
-      # If exactly 7 objects then only nullptr ends up on the stack.
-      sub x1, x1, 6
-
-      # Round up to the nearest pair
-      and x10, x1, 1
-      add x10, x10, x1
-
-      # Multiply by eight to get the size of stack we need to create
-      lsl x10, x10, 3
-
-      # Allocate stack space
-      sub sp, sp, x10
-
-      # Store how much data we added to the stack in our callee saved register we stole
-      mov x28, x10
-
-      # x11 - stack offset - for stack Arguments
-      mov x11, sp
-
-      # x12 - load offset into input array (skipping the first 7 arguments)
-      add x12, x9, (7 * 8)
-
-      # Compute the number of elements excluding the terminating nullptr
-      subs x10, x1, 1
-
-      .single%=:
-      ldr x1, [x12], 8
-      str x1, [x11], 8
-      sub x10, x10, 1
-      cmp x10, 1
-      b.ge .single%=
-
-      # Need to store nullptr
-      str xzr, [x11]
-
-      .top_reg_args%=:
-      ldp x1, x2, [x9, 0]
-      ldp x3, x4, [x9, 16]
-      ldp x5, x6, [x9, 32]
-      ldr x7, [x9, 48]
-
-      # Stack is setup going in to this
-      blr x8
-
-      # Move stack back
-      add sp, sp, x28
-      ldp x28, x30, [sp], 16
-      ret
-
-      .jump_table%=:
-      .byte (.zero%=  - .zero%=) >> 2
-      .byte (.one%=   - .zero%=) >> 2
-      .byte (.two%=   - .zero%=) >> 2
-      .byte (.three%= - .zero%=) >> 2
-      .byte (.four%=  - .zero%=) >> 2
-      .byte (.five%=  - .zero%=) >> 2
-      .byte (.six%=   - .zero%=) >> 2
-  )"
-  ::: "memory"
-  );
-}
-
-#endif
-
 // Walks the array of key:value pairs provided from the guest code side.
 // Finalizing any callback functions that the guest side prepared for us.
 template<typename CallbackType>
@@ -220,43 +62,707 @@ _XIC *fexfn_impl_libX11_XCreateIC_internal(XIM a_0, size_t count, void **list) {
   FinalizeIncomingCallbacks<XICCallback>(count, list);
 
   switch(count) {
-    case 0: return fexldr_ptr_libX11_XCreateIC(a_0, nullptr); break;
-    case 1: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], nullptr); break;
-    case 2: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], nullptr); break;
-    case 3: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], nullptr); break;
-    case 4: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], nullptr); break;
-    case 5: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], nullptr); break;
-    case 6: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], nullptr); break;
-    case 7: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], nullptr); break;
-    case 8: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7], nullptr); break;
+    case 0: return fexldr_ptr_libX11_XCreateIC(a_0, nullptr);
+      break;
+    case 1: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], nullptr);
+      break;
+    case 2: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], nullptr);
+      break;
+    case 3: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], nullptr);
+      break;
+    case 4: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], nullptr);
+      break;
+    case 5: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], nullptr);
+      break;
+    case 6: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], nullptr);
+      break;
+    case 7: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], nullptr);
+      break;
+    case 8: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7], nullptr);
+      break;
+    case 9: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], nullptr);
+      break;
+    case 10: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], nullptr);
+      break;
+    case 11: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], nullptr);
+      break;
+    case 12: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], nullptr);
+      break;
+    case 13: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], nullptr);
+      break;
+    case 14: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], nullptr);
+      break;
+    case 15: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], nullptr);
+      break;
+    case 16: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15], nullptr);
+      break;
+    case 17: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], nullptr);
+      break;
+    case 18: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], nullptr);
+      break;
+    case 19: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], nullptr);
+      break;
+    case 20: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], nullptr);
+      break;
+    case 21: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], nullptr);
+      break;
+    case 22: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], nullptr);
+      break;
+    case 23: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], nullptr);
+      break;
+    case 24: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23], nullptr);
+      break;
+    case 25: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], nullptr);
+      break;
+    case 26: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], nullptr);
+      break;
+    case 27: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], nullptr);
+      break;
+    case 28: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], nullptr);
+      break;
+    case 29: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], nullptr);
+      break;
+    case 30: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], nullptr);
+      break;
+    case 31: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], nullptr);
+      break;
+    case 32: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31], nullptr);
+      break;
+    case 33: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], nullptr);
+      break;
+    case 34: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], nullptr);
+      break;
+    case 35: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], nullptr);
+      break;
+    case 36: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], nullptr);
+      break;
+    case 37: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], nullptr);
+      break;
+    case 38: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], nullptr);
+      break;
+    case 39: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], nullptr);
+      break;
+    case 40: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39], nullptr);
+      break;
+    case 41: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], nullptr);
+      break;
+    case 42: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], nullptr);
+      break;
+    case 43: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], nullptr);
+      break;
+    case 44: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], nullptr);
+      break;
+    case 45: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], nullptr);
+      break;
+    case 46: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], nullptr);
+      break;
+    case 47: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], nullptr);
+      break;
+    case 48: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47], nullptr);
+      break;
+    case 49: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], nullptr);
+      break;
+    case 50: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], nullptr);
+      break;
+    case 51: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], nullptr);
+      break;
+    case 52: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], nullptr);
+      break;
+    case 53: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], nullptr);
+      break;
+    case 54: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], nullptr);
+      break;
+    case 55: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], nullptr);
+      break;
+    case 56: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55], nullptr);
+      break;
+    case 57: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55],
+      list[56], nullptr);
+      break;
+    case 58: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55],
+      list[56], list[57], nullptr);
+      break;
+    case 59: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55],
+      list[56], list[57], list[58], nullptr);
+      break;
+    case 60: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55],
+      list[56], list[57], list[58], list[59], nullptr);
+      break;
+    case 61: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55],
+      list[56], list[57], list[58], list[59], list[60], nullptr);
+      break;
+    case 62: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55],
+      list[56], list[57], list[58], list[59], list[60], list[61], nullptr);
+      break;
+    case 63: return fexldr_ptr_libX11_XCreateIC(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55],
+      list[56], list[57], list[58], list[59], list[60], list[61], list[62], nullptr);
+      break;
     default:
-#ifdef _M_ARM_64
-      return reinterpret_cast<_XIC*>(libX11_Variadic_u64(reinterpret_cast<uint64_t>(a_0), count, list, reinterpret_cast<void*>(fexldr_ptr_libX11_XCreateIC)));
-#else
       fprintf(stderr, "XCreateIC_internal FAILURE\n");
       return nullptr;
-#endif
   }
 }
 
 char* fexfn_impl_libX11_XGetICValues_internal(XIC a_0, size_t count, void **list) {
   switch(count) {
-    case 0: return fexldr_ptr_libX11_XGetICValues(a_0, nullptr); break;
-    case 1: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], nullptr); break;
-    case 2: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], nullptr); break;
-    case 3: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], nullptr); break;
-    case 4: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], nullptr); break;
-    case 5: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], nullptr); break;
-    case 6: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], nullptr); break;
-    case 7: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], nullptr); break;
-    case 8: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7], nullptr); break;
+    case 0: return fexldr_ptr_libX11_XGetICValues(a_0, nullptr);
+      break;
+    case 1: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], nullptr);
+      break;
+    case 2: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], nullptr);
+      break;
+    case 3: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], nullptr);
+      break;
+    case 4: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], nullptr);
+      break;
+    case 5: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], nullptr);
+      break;
+    case 6: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], nullptr);
+      break;
+    case 7: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], nullptr);
+      break;
+    case 8: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7], nullptr);
+      break;
+    case 9: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], nullptr);
+      break;
+    case 10: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], nullptr);
+      break;
+    case 11: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], nullptr);
+      break;
+    case 12: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], nullptr);
+      break;
+    case 13: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], nullptr);
+      break;
+    case 14: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], nullptr);
+      break;
+    case 15: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], nullptr);
+      break;
+    case 16: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15], nullptr);
+      break;
+    case 17: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], nullptr);
+      break;
+    case 18: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], nullptr);
+      break;
+    case 19: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], nullptr);
+      break;
+    case 20: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], nullptr);
+      break;
+    case 21: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], nullptr);
+      break;
+    case 22: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], nullptr);
+      break;
+    case 23: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], nullptr);
+      break;
+    case 24: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23], nullptr);
+      break;
+    case 25: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], nullptr);
+      break;
+    case 26: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], nullptr);
+      break;
+    case 27: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], nullptr);
+      break;
+    case 28: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], nullptr);
+      break;
+    case 29: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], nullptr);
+      break;
+    case 30: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], nullptr);
+      break;
+    case 31: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], nullptr);
+      break;
+    case 32: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31], nullptr);
+      break;
+    case 33: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], nullptr);
+      break;
+    case 34: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], nullptr);
+      break;
+    case 35: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], nullptr);
+      break;
+    case 36: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], nullptr);
+      break;
+    case 37: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], nullptr);
+      break;
+    case 38: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], nullptr);
+      break;
+    case 39: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], nullptr);
+      break;
+    case 40: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39], nullptr);
+      break;
+    case 41: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], nullptr);
+      break;
+    case 42: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], nullptr);
+      break;
+    case 43: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], nullptr);
+      break;
+    case 44: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], nullptr);
+      break;
+    case 45: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], nullptr);
+      break;
+    case 46: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], nullptr);
+      break;
+    case 47: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], nullptr);
+      break;
+    case 48: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47], nullptr);
+      break;
+    case 49: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], nullptr);
+      break;
+    case 50: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], nullptr);
+      break;
+    case 51: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], nullptr);
+      break;
+    case 52: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], nullptr);
+      break;
+    case 53: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], nullptr);
+      break;
+    case 54: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], nullptr);
+      break;
+    case 55: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], nullptr);
+      break;
+    case 56: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55], nullptr);
+      break;
+    case 57: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55],
+      list[56], nullptr);
+      break;
+    case 58: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55],
+      list[56], list[57], nullptr);
+      break;
+    case 59: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55],
+      list[56], list[57], list[58], nullptr);
+      break;
+    case 60: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55],
+      list[56], list[57], list[58], list[59], nullptr);
+      break;
+    case 61: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55],
+      list[56], list[57], list[58], list[59], list[60], nullptr);
+      break;
+    case 62: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55],
+      list[56], list[57], list[58], list[59], list[60], list[61], nullptr);
+      break;
+    case 63: return fexldr_ptr_libX11_XGetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55],
+      list[56], list[57], list[58], list[59], list[60], list[61], list[62], nullptr);
+      break;
     default:
-#ifdef _M_ARM_64
-      return reinterpret_cast<char*>(libX11_Variadic_u64(reinterpret_cast<uint64_t>(a_0), count, list, reinterpret_cast<void*>(fexldr_ptr_libX11_XGetICValues)));
-#else
       fprintf(stderr, "XGetICValues_internal FAILURE\n");
       abort();
-#endif
   }
 }
 
@@ -264,43 +770,707 @@ char* fexfn_impl_libX11_XSetICValues_internal(XIC a_0, size_t count, void **list
   FinalizeIncomingCallbacks<XICCallback>(count, list);
 
   switch(count) {
-    case 0: return fexldr_ptr_libX11_XSetICValues(a_0, nullptr); break;
-    case 1: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], nullptr); break;
-    case 2: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], nullptr); break;
-    case 3: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], nullptr); break;
-    case 4: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], nullptr); break;
-    case 5: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], nullptr); break;
-    case 6: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], nullptr); break;
-    case 7: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], nullptr); break;
-    case 8: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7], nullptr); break;
+    case 0: return fexldr_ptr_libX11_XSetICValues(a_0, nullptr);
+      break;
+    case 1: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], nullptr);
+      break;
+    case 2: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], nullptr);
+      break;
+    case 3: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], nullptr);
+      break;
+    case 4: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], nullptr);
+      break;
+    case 5: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], nullptr);
+      break;
+    case 6: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], nullptr);
+      break;
+    case 7: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], nullptr);
+      break;
+    case 8: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7], nullptr);
+      break;
+    case 9: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], nullptr);
+      break;
+    case 10: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], nullptr);
+      break;
+    case 11: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], nullptr);
+      break;
+    case 12: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], nullptr);
+      break;
+    case 13: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], nullptr);
+      break;
+    case 14: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], nullptr);
+      break;
+    case 15: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], nullptr);
+      break;
+    case 16: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15], nullptr);
+      break;
+    case 17: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], nullptr);
+      break;
+    case 18: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], nullptr);
+      break;
+    case 19: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], nullptr);
+      break;
+    case 20: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], nullptr);
+      break;
+    case 21: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], nullptr);
+      break;
+    case 22: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], nullptr);
+      break;
+    case 23: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], nullptr);
+      break;
+    case 24: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23], nullptr);
+      break;
+    case 25: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], nullptr);
+      break;
+    case 26: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], nullptr);
+      break;
+    case 27: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], nullptr);
+      break;
+    case 28: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], nullptr);
+      break;
+    case 29: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], nullptr);
+      break;
+    case 30: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], nullptr);
+      break;
+    case 31: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], nullptr);
+      break;
+    case 32: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31], nullptr);
+      break;
+    case 33: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], nullptr);
+      break;
+    case 34: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], nullptr);
+      break;
+    case 35: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], nullptr);
+      break;
+    case 36: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], nullptr);
+      break;
+    case 37: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], nullptr);
+      break;
+    case 38: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], nullptr);
+      break;
+    case 39: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], nullptr);
+      break;
+    case 40: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39], nullptr);
+      break;
+    case 41: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], nullptr);
+      break;
+    case 42: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], nullptr);
+      break;
+    case 43: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], nullptr);
+      break;
+    case 44: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], nullptr);
+      break;
+    case 45: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], nullptr);
+      break;
+    case 46: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], nullptr);
+      break;
+    case 47: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], nullptr);
+      break;
+    case 48: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47], nullptr);
+      break;
+    case 49: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], nullptr);
+      break;
+    case 50: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], nullptr);
+      break;
+    case 51: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], nullptr);
+      break;
+    case 52: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], nullptr);
+      break;
+    case 53: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], nullptr);
+      break;
+    case 54: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], nullptr);
+      break;
+    case 55: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], nullptr);
+      break;
+    case 56: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55], nullptr);
+      break;
+    case 57: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55],
+      list[56], nullptr);
+      break;
+    case 58: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55],
+      list[56], list[57], nullptr);
+      break;
+    case 59: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55],
+      list[56], list[57], list[58], nullptr);
+      break;
+    case 60: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55],
+      list[56], list[57], list[58], list[59], nullptr);
+      break;
+    case 61: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55],
+      list[56], list[57], list[58], list[59], list[60], nullptr);
+      break;
+    case 62: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55],
+      list[56], list[57], list[58], list[59], list[60], list[61], nullptr);
+      break;
+    case 63: return fexldr_ptr_libX11_XSetICValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55],
+      list[56], list[57], list[58], list[59], list[60], list[61], list[62], nullptr);
+      break;
     default:
-#ifdef _M_ARM_64
-      return reinterpret_cast<char*>(libX11_Variadic_u64(reinterpret_cast<uint64_t>(a_0), count, list, reinterpret_cast<void*>(fexldr_ptr_libX11_XSetICValues)));
-#else
       fprintf(stderr, "XSetICValues_internal FAILURE\n");
       abort();
-#endif
   }
 }
 
 char* fexfn_impl_libX11_XGetIMValues_internal(XIM a_0, size_t count, void **list) {
   switch(count) {
-    case 0: return fexldr_ptr_libX11_XGetIMValues(a_0, nullptr); break;
-    case 1: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], nullptr); break;
-    case 2: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], nullptr); break;
-    case 3: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], nullptr); break;
-    case 4: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], nullptr); break;
-    case 5: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], nullptr); break;
-    case 6: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], nullptr); break;
-    case 7: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], nullptr); break;
-    case 8: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7], nullptr); break;
+    case 0: return fexldr_ptr_libX11_XGetIMValues(a_0, nullptr);
+      break;
+    case 1: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], nullptr);
+      break;
+    case 2: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], nullptr);
+      break;
+    case 3: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], nullptr);
+      break;
+    case 4: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], nullptr);
+      break;
+    case 5: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], nullptr);
+      break;
+    case 6: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], nullptr);
+      break;
+    case 7: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], nullptr);
+      break;
+    case 8: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7], nullptr);
+      break;
+    case 9: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], nullptr);
+      break;
+    case 10: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], nullptr);
+      break;
+    case 11: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], nullptr);
+      break;
+    case 12: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], nullptr);
+      break;
+    case 13: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], nullptr);
+      break;
+    case 14: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], nullptr);
+      break;
+    case 15: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], nullptr);
+      break;
+    case 16: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15], nullptr);
+      break;
+    case 17: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], nullptr);
+      break;
+    case 18: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], nullptr);
+      break;
+    case 19: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], nullptr);
+      break;
+    case 20: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], nullptr);
+      break;
+    case 21: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], nullptr);
+      break;
+    case 22: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], nullptr);
+      break;
+    case 23: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], nullptr);
+      break;
+    case 24: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23], nullptr);
+      break;
+    case 25: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], nullptr);
+      break;
+    case 26: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], nullptr);
+      break;
+    case 27: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], nullptr);
+      break;
+    case 28: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], nullptr);
+      break;
+    case 29: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], nullptr);
+      break;
+    case 30: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], nullptr);
+      break;
+    case 31: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], nullptr);
+      break;
+    case 32: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31], nullptr);
+      break;
+    case 33: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], nullptr);
+      break;
+    case 34: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], nullptr);
+      break;
+    case 35: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], nullptr);
+      break;
+    case 36: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], nullptr);
+      break;
+    case 37: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], nullptr);
+      break;
+    case 38: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], nullptr);
+      break;
+    case 39: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], nullptr);
+      break;
+    case 40: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39], nullptr);
+      break;
+    case 41: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], nullptr);
+      break;
+    case 42: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], nullptr);
+      break;
+    case 43: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], nullptr);
+      break;
+    case 44: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], nullptr);
+      break;
+    case 45: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], nullptr);
+      break;
+    case 46: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], nullptr);
+      break;
+    case 47: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], nullptr);
+      break;
+    case 48: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47], nullptr);
+      break;
+    case 49: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], nullptr);
+      break;
+    case 50: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], nullptr);
+      break;
+    case 51: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], nullptr);
+      break;
+    case 52: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], nullptr);
+      break;
+    case 53: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], nullptr);
+      break;
+    case 54: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], nullptr);
+      break;
+    case 55: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], nullptr);
+      break;
+    case 56: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55], nullptr);
+      break;
+    case 57: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55],
+      list[56], nullptr);
+      break;
+    case 58: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55],
+      list[56], list[57], nullptr);
+      break;
+    case 59: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55],
+      list[56], list[57], list[58], nullptr);
+      break;
+    case 60: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55],
+      list[56], list[57], list[58], list[59], nullptr);
+      break;
+    case 61: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55],
+      list[56], list[57], list[58], list[59], list[60], nullptr);
+      break;
+    case 62: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55],
+      list[56], list[57], list[58], list[59], list[60], list[61], nullptr);
+      break;
+    case 63: return fexldr_ptr_libX11_XGetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55],
+      list[56], list[57], list[58], list[59], list[60], list[61], list[62], nullptr);
+      break;
     default:
-#ifdef _M_ARM_64
-      return reinterpret_cast<char*>(libX11_Variadic_u64(reinterpret_cast<uint64_t>(a_0), count, list, reinterpret_cast<void*>(fexldr_ptr_libX11_XGetIMValues)));
-#else
       fprintf(stderr, "XGetIMValues_internal FAILURE\n");
       abort();
-#endif
   }
 }
 
@@ -308,22 +1478,354 @@ char* fexfn_impl_libX11_XSetIMValues_internal(XIM a_0, size_t count, void **list
   FinalizeIncomingCallbacks<XIMCallback>(count, list);
 
   switch(count) {
-    case 0: return fexldr_ptr_libX11_XSetIMValues(a_0, nullptr); break;
-    case 1: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], nullptr); break;
-    case 2: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], nullptr); break;
-    case 3: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], nullptr); break;
-    case 4: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], nullptr); break;
-    case 5: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], nullptr); break;
-    case 6: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], nullptr); break;
-    case 7: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], nullptr); break;
-    case 8: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7], nullptr); break;
+    case 0: return fexldr_ptr_libX11_XSetIMValues(a_0, nullptr);
+      break;
+    case 1: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], nullptr);
+      break;
+    case 2: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], nullptr);
+      break;
+    case 3: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], nullptr);
+      break;
+    case 4: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], nullptr);
+      break;
+    case 5: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], nullptr);
+      break;
+    case 6: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], nullptr);
+      break;
+    case 7: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], nullptr);
+      break;
+    case 8: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7], nullptr);
+      break;
+    case 9: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], nullptr);
+      break;
+    case 10: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], nullptr);
+      break;
+    case 11: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], nullptr);
+      break;
+    case 12: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], nullptr);
+      break;
+    case 13: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], nullptr);
+      break;
+    case 14: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], nullptr);
+      break;
+    case 15: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], nullptr);
+      break;
+    case 16: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15], nullptr);
+      break;
+    case 17: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], nullptr);
+      break;
+    case 18: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], nullptr);
+      break;
+    case 19: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], nullptr);
+      break;
+    case 20: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], nullptr);
+      break;
+    case 21: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], nullptr);
+      break;
+    case 22: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], nullptr);
+      break;
+    case 23: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], nullptr);
+      break;
+    case 24: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23], nullptr);
+      break;
+    case 25: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], nullptr);
+      break;
+    case 26: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], nullptr);
+      break;
+    case 27: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], nullptr);
+      break;
+    case 28: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], nullptr);
+      break;
+    case 29: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], nullptr);
+      break;
+    case 30: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], nullptr);
+      break;
+    case 31: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], nullptr);
+      break;
+    case 32: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31], nullptr);
+      break;
+    case 33: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], nullptr);
+      break;
+    case 34: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], nullptr);
+      break;
+    case 35: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], nullptr);
+      break;
+    case 36: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], nullptr);
+      break;
+    case 37: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], nullptr);
+      break;
+    case 38: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], nullptr);
+      break;
+    case 39: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], nullptr);
+      break;
+    case 40: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39], nullptr);
+      break;
+    case 41: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], nullptr);
+      break;
+    case 42: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], nullptr);
+      break;
+    case 43: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], nullptr);
+      break;
+    case 44: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], nullptr);
+      break;
+    case 45: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], nullptr);
+      break;
+    case 46: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], nullptr);
+      break;
+    case 47: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], nullptr);
+      break;
+    case 48: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47], nullptr);
+      break;
+    case 49: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], nullptr);
+      break;
+    case 50: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], nullptr);
+      break;
+    case 51: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], nullptr);
+      break;
+    case 52: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], nullptr);
+      break;
+    case 53: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], nullptr);
+      break;
+    case 54: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], nullptr);
+      break;
+    case 55: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], nullptr);
+      break;
+    case 56: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55], nullptr);
+      break;
+    case 57: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55],
+      list[56], nullptr);
+      break;
+    case 58: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55],
+      list[56], list[57], nullptr);
+      break;
+    case 59: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55],
+      list[56], list[57], list[58], nullptr);
+      break;
+    case 60: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55],
+      list[56], list[57], list[58], list[59], nullptr);
+      break;
+    case 61: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55],
+      list[56], list[57], list[58], list[59], list[60], nullptr);
+      break;
+    case 62: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55],
+      list[56], list[57], list[58], list[59], list[60], list[61], nullptr);
+      break;
+    case 63: return fexldr_ptr_libX11_XSetIMValues(a_0, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55],
+      list[56], list[57], list[58], list[59], list[60], list[61], list[62], nullptr);
+      break;
     default:
-#ifdef _M_ARM_64
-      return reinterpret_cast<char*>(libX11_Variadic_u64(reinterpret_cast<uint64_t>(a_0), count, list, reinterpret_cast<void*>(fexldr_ptr_libX11_XSetIMValues)));
-#else
       fprintf(stderr, "XSetIMValues_internal FAILURE\n");
       abort();
-#endif
   }
 }
 
@@ -331,22 +1833,354 @@ XVaNestedList fexfn_impl_libX11_XVaCreateNestedList_internal(int unused_arg, siz
   FinalizeIncomingCallbacks<XIMCallback>(count, list);
 
   switch(count) {
-    case 0: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, nullptr); break;
-    case 1: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], nullptr); break;
-    case 2: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], nullptr); break;
-    case 3: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], nullptr); break;
-    case 4: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], nullptr); break;
-    case 5: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], nullptr); break;
-    case 6: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], nullptr); break;
-    case 7: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], nullptr); break;
-    case 8: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7], nullptr); break;
+    case 0: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, nullptr);
+      break;
+    case 1: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], nullptr);
+      break;
+    case 2: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], nullptr);
+      break;
+    case 3: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], nullptr);
+      break;
+    case 4: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], nullptr);
+      break;
+    case 5: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], nullptr);
+      break;
+    case 6: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], nullptr);
+      break;
+    case 7: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], nullptr);
+      break;
+    case 8: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7], nullptr);
+      break;
+    case 9: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], nullptr);
+      break;
+    case 10: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], nullptr);
+      break;
+    case 11: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], nullptr);
+      break;
+    case 12: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], nullptr);
+      break;
+    case 13: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], nullptr);
+      break;
+    case 14: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], nullptr);
+      break;
+    case 15: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], nullptr);
+      break;
+    case 16: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15], nullptr);
+      break;
+    case 17: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], nullptr);
+      break;
+    case 18: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], nullptr);
+      break;
+    case 19: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], nullptr);
+      break;
+    case 20: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], nullptr);
+      break;
+    case 21: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], nullptr);
+      break;
+    case 22: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], nullptr);
+      break;
+    case 23: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], nullptr);
+      break;
+    case 24: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23], nullptr);
+      break;
+    case 25: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], nullptr);
+      break;
+    case 26: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], nullptr);
+      break;
+    case 27: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], nullptr);
+      break;
+    case 28: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], nullptr);
+      break;
+    case 29: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], nullptr);
+      break;
+    case 30: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], nullptr);
+      break;
+    case 31: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], nullptr);
+      break;
+    case 32: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31], nullptr);
+      break;
+    case 33: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], nullptr);
+      break;
+    case 34: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], nullptr);
+      break;
+    case 35: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], nullptr);
+      break;
+    case 36: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], nullptr);
+      break;
+    case 37: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], nullptr);
+      break;
+    case 38: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], nullptr);
+      break;
+    case 39: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], nullptr);
+      break;
+    case 40: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39], nullptr);
+      break;
+    case 41: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], nullptr);
+      break;
+    case 42: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], nullptr);
+      break;
+    case 43: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], nullptr);
+      break;
+    case 44: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], nullptr);
+      break;
+    case 45: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], nullptr);
+      break;
+    case 46: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], nullptr);
+      break;
+    case 47: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], nullptr);
+      break;
+    case 48: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47], nullptr);
+      break;
+    case 49: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], nullptr);
+      break;
+    case 50: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], nullptr);
+      break;
+    case 51: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], nullptr);
+      break;
+    case 52: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], nullptr);
+      break;
+    case 53: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], nullptr);
+      break;
+    case 54: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], nullptr);
+      break;
+    case 55: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], nullptr);
+      break;
+    case 56: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55], nullptr);
+      break;
+    case 57: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55],
+      list[56], nullptr);
+      break;
+    case 58: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55],
+      list[56], list[57], nullptr);
+      break;
+    case 59: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55],
+      list[56], list[57], list[58], nullptr);
+      break;
+    case 60: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55],
+      list[56], list[57], list[58], list[59], nullptr);
+      break;
+    case 61: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55],
+      list[56], list[57], list[58], list[59], list[60], nullptr);
+      break;
+    case 62: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55],
+      list[56], list[57], list[58], list[59], list[60], list[61], nullptr);
+      break;
+    case 63: return fexldr_ptr_libX11_XVaCreateNestedList(unused_arg, list[0], list[1], list[2], list[3], list[4], list[5], list[6], list[7],
+      list[8], list[9], list[10], list[11], list[12], list[13], list[14], list[15],
+      list[16], list[17], list[18], list[19], list[20], list[21], list[22], list[23],
+      list[24], list[25], list[26], list[27], list[28], list[29], list[30], list[31],
+      list[32], list[33], list[34], list[35], list[36], list[37], list[38], list[39],
+      list[40], list[41], list[42], list[43], list[44], list[45], list[46], list[47],
+      list[48], list[49], list[50], list[51], list[52], list[53], list[54], list[55],
+      list[56], list[57], list[58], list[59], list[60], list[61], list[62], nullptr);
+      break;
     default:
-#ifdef _M_ARM_64
-      return reinterpret_cast<XVaNestedList>(libX11_Variadic_u64(unused_arg, count, list, reinterpret_cast<void*>(fexldr_ptr_libX11_XVaCreateNestedList)));
-#else
       fprintf(stderr, "XVaCreateNestedList_internal FAILURE\n");
       abort();
-#endif
   }
 }
 

--- a/ThunkLibs/libX11/libX11_Host.cpp
+++ b/ThunkLibs/libX11/libX11_Host.cpp
@@ -154,29 +154,13 @@ void *libX11_Variadic_u64(uint64_t a_0, size_t count, void **list, void *Func) {
       # Compute the number of elements excluding the terminating nullptr
       subs x10, x1, 1
 
-      b.eq .single%=
-      b.lt .no_single%=
-
-      .load_pair%=:
-      # Copy data from x12 to x11
-      ldp x1, x2, [x12], 16
-      stp x1, x2, [x11], 16
-
-      # Stored two so subtract from the count.
-      sub x10, x10, 2
-      cmp x10, 1
-      b.gt .load_pair%=
-      b.lt .no_single%=
-
       .single%=:
-      # One variable at most
-      # Load the argument from the source.
-      # Then store that and the terminating nullptr.
-      ldr x1, [x12]
-      stp x1, xzr, [x11]
-      b .top_reg_args%=
+      ldr x1, [x12], 8
+      str x1, [x11], 8
+      sub x10, x10, 1
+      cmp x10, 1
+      b.ge .single%=
 
-      .no_single%=:
       # Need to store nullptr
       str xzr, [x11]
 

--- a/ThunkLibs/libX11/libX11_interface.cpp
+++ b/ThunkLibs/libX11/libX11_interface.cpp
@@ -45,6 +45,10 @@ template<> struct fex_gen_type<std::remove_pointer_t<XIOErrorExitHandler>> {}; /
 
 template<> struct fex_gen_type<Bool(Display*, xReply*, char*, int, XPointer)> {}; // XDisplay::async_handlers->handler
 
+template<> struct fex_gen_type<Bool(XIM, XPointer, XPointer)> {}; // XIMProc
+template<> struct fex_gen_type<Bool(XIC, XPointer, XPointer)> {}; // XICProc
+template<> struct fex_gen_type<void(Display*, XPointer, XPointer)> {}; // XIDProc
+
 template<> struct fex_gen_type<int(XImage*)> {};                          // XImage::f.destroy_image
 template<> struct fex_gen_type<unsigned long(XImage*, int, int)> {};      // XImage::f.get_pixel
 template<> struct fex_gen_type<int(XImage*, int, int, unsigned long)> {}; // XImage::f.put_pixel
@@ -653,15 +657,15 @@ template<> struct fex_gen_config<Xutf8DrawImageString> {};
 template<> struct fex_gen_config<XOpenIM> {};
 template<> struct fex_gen_config<XCloseIM> {};
 template<> struct fex_gen_config<XGetIMValues> {
-    using uniform_va_type = void*;
+  using uniform_va_type = void*;
 };
 template<> struct fex_gen_config<XSetIMValues> {
-    using uniform_va_type = void*;
+  using uniform_va_type = void*;
 };
 template<> struct fex_gen_config<XDisplayOfIM> {};
 template<> struct fex_gen_config<XLocaleOfIM> {};
 template<> struct fex_gen_config<XCreateIC> {
-    using uniform_va_type = unsigned long;
+  using uniform_va_type = void*;
 };
 template<> struct fex_gen_config<XDestroyIC> {};
 template<> struct fex_gen_config<XSetICFocus> {};
@@ -670,11 +674,11 @@ template<> struct fex_gen_config<XwcResetIC> {};
 template<> struct fex_gen_config<XmbResetIC> {};
 template<> struct fex_gen_config<Xutf8ResetIC> {};
 template<> struct fex_gen_config<XSetICValues> {
-    using uniform_va_type = unsigned long;
+  using uniform_va_type = void*;
 };
 
 template<> struct fex_gen_config<XGetICValues> {
-    using uniform_va_type = unsigned long;
+  using uniform_va_type = void*;
 };
 
 template<> struct fex_gen_config<XIMOfIC> {};
@@ -683,11 +687,11 @@ template<> struct fex_gen_config<XmbLookupString> {};
 template<> struct fex_gen_config<XwcLookupString> {};
 template<> struct fex_gen_config<Xutf8LookupString> {};
 template<> struct fex_gen_config<XVaCreateNestedList> {
-    using uniform_va_type = void*;
+  using uniform_va_type = void*;
 };
 
-template<> struct fex_gen_config<XRegisterIMInstantiateCallback> {};
-template<> struct fex_gen_config<XUnregisterIMInstantiateCallback> {};
+template<> struct fex_gen_config<XRegisterIMInstantiateCallback> : fexgen::custom_guest_entrypoint {};
+template<> struct fex_gen_config<XUnregisterIMInstantiateCallback>  : fexgen::custom_guest_entrypoint {};
 template<> struct fex_gen_config<XInternalConnectionNumbers> {};
 template<> struct fex_gen_config<XProcessInternalConnection> {};
 template<> struct fex_gen_config<XAddConnectionWatch> {};


### PR DESCRIPTION
Two bugs here that caused thunking X11 thunking in Wine/Proton to not work.

The easier of the two. The various variadic functions that we thunk actually take key:value pairs where the first is a string pointer, and the value can be various things.

We need to handle these as true key:value pairs rather than finding the first nullptr and dropping the remainder.

Additionally, there are 12 keys that specify a callback that FEX needs to catch and convert to host callable. Wine is the first application that I have seen that actually uses this. If these callbacks aren't wired up then it it can miss events.

The harder of the two problems is the `libX11_Variadic_u64` function was subtly incorrect. Nothing had previously truly exercised this and my test program didn't notice anything wrong while writing it.

The first incorrect thing was that it was subtracting the nullptr ender variable before the stack size calculation, causing the value to overwrite the stack if the number of remaining elements was event.

Secondly the assembly that was storing two elements per step was decrementing the counter by 8 instead of two. Didn't pick this up before since I believe the code was only hitting the non-pair path before.

This gets Proton thunking working under FEX now.