### PR TITLE
FEXCore: Removes unused TLS variable

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -81,8 +81,6 @@ struct ThreadLocalData {
   FEXCore::Core::InternalThreadState* Thread;
 };
 
-thread_local ThreadLocalData ThreadData{};
-
 constexpr std::array<std::string_view const, 22> FlagNames = {
   "CF",
   "",
@@ -1153,7 +1151,6 @@ namespace FEXCore::Context {
   }
 
   void ContextImpl::ExecutionThread(FEXCore::Core::InternalThreadState *Thread) {
-    Core::ThreadData.Thread = Thread;
     Thread->ExitReason = FEXCore::Context::ExitReason::EXIT_WAITING;
 
     InitializeThreadTLSData(Thread);


### PR DESCRIPTION
Not sure why this still existed.