### PR TITLE
OpcodeDispatcher: Fix and optimize PF calculation

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -3414,10 +3414,7 @@ void OpDispatchBuilder::DAAOp(OpcodeArgs) {
 
   SetRFLAG<FEXCore::X86State::RFLAG_SF_LOC>(_Select(FEXCore::IR::COND_UGE, _And(AL, _Constant(0x80)), _Constant(0), _Constant(1), _Constant(0)));
   SetRFLAG<FEXCore::X86State::RFLAG_ZF_LOC>(_Select(FEXCore::IR::COND_EQ, _And(AL, _Constant(0xFF)), _Constant(0), _Constant(1), _Constant(0)));
-  auto EightBitMask = _Constant(0xFF);
-  auto PopCountOp = _Popcount(_And(AL, EightBitMask));
-  auto XorOp = _Xor(PopCountOp, _Constant(1));
-  SetRFLAG<FEXCore::X86State::RFLAG_PF_LOC>(XorOp);
+  CalculatePFUncheckedABI(AL);
 }
 
 void OpDispatchBuilder::DASOp(OpcodeArgs) {
@@ -3478,10 +3475,7 @@ void OpDispatchBuilder::DASOp(OpcodeArgs) {
   AL = LoadGPRRegister(X86State::REG_RAX, 1);
   SetRFLAG<FEXCore::X86State::RFLAG_SF_LOC>(_Select(FEXCore::IR::COND_UGE, _And(AL, _Constant(0x80)), _Constant(0), _Constant(1), _Constant(0)));
   SetRFLAG<FEXCore::X86State::RFLAG_ZF_LOC>(_Select(FEXCore::IR::COND_EQ, _And(AL, _Constant(0xFF)), _Constant(0), _Constant(1), _Constant(0)));
-  auto EightBitMask = _Constant(0xFF);
-  auto PopCountOp = _Popcount(_And(AL, EightBitMask));
-  auto XorOp = _Xor(PopCountOp, _Constant(1));
-  SetRFLAG<FEXCore::X86State::RFLAG_PF_LOC>(XorOp);
+  CalculatePFUncheckedABI(AL);
 }
 
 void OpDispatchBuilder::AAAOp(OpcodeArgs) {
@@ -3566,10 +3560,7 @@ void OpDispatchBuilder::AAMOp(OpcodeArgs) {
   AL = LoadGPRRegister(X86State::REG_RAX, 1);
   SetRFLAG<FEXCore::X86State::RFLAG_SF_LOC>(_Select(FEXCore::IR::COND_UGE, _And(AL, _Constant(0x80)), _Constant(0), _Constant(1), _Constant(0)));
   SetRFLAG<FEXCore::X86State::RFLAG_ZF_LOC>(_Select(FEXCore::IR::COND_EQ, _And(AL, _Constant(0xFF)), _Constant(0), _Constant(1), _Constant(0)));
-  auto EightBitMask = _Constant(0xFF);
-  auto PopCountOp = _Popcount(_And(AL, EightBitMask));
-  auto XorOp = _Xor(PopCountOp, _Constant(1));
-  SetRFLAG<FEXCore::X86State::RFLAG_PF_LOC>(XorOp);
+  CalculatePFUncheckedABI(AL);
 }
 
 void OpDispatchBuilder::AADOp(OpcodeArgs) {
@@ -3586,10 +3577,7 @@ void OpDispatchBuilder::AADOp(OpcodeArgs) {
   AL = LoadGPRRegister(X86State::REG_RAX, 1);
   SetRFLAG<FEXCore::X86State::RFLAG_SF_LOC>(_Select(FEXCore::IR::COND_UGE, _And(AL, _Constant(0x80)), _Constant(0), _Constant(1), _Constant(0)));
   SetRFLAG<FEXCore::X86State::RFLAG_ZF_LOC>(_Select(FEXCore::IR::COND_EQ, _And(AL, _Constant(0xFF)), _Constant(0), _Constant(1), _Constant(0)));
-  auto EightBitMask = _Constant(0xFF);
-  auto PopCountOp = _Popcount(_And(AL, EightBitMask));
-  auto XorOp = _Xor(PopCountOp, _Constant(1));
-  SetRFLAG<FEXCore::X86State::RFLAG_PF_LOC>(XorOp);
+  CalculatePFUncheckedABI(AL);
 }
 
 void OpDispatchBuilder::XLATOp(OpcodeArgs) {

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -914,16 +914,18 @@ OrderedNode *OpDispatchBuilder::SelectCC(uint8_t OP, OrderedNode *TrueValue, Ord
           Flag, ZeroConst, TrueValue, FalseValue);
       break;
     }
-    case 0xA: { // JP - Jump if PF == 1
-      auto Flag = GetRFLAG(FEXCore::X86State::RFLAG_PF_LOC);
-      SrcCond = _Select(FEXCore::IR::COND_NEQ,
-          Flag, ZeroConst, TrueValue, FalseValue);
-      break;
-    }
+    case 0xA:   // JP - Jump if PF == 1
     case 0xB: { // JNP - Jump if PF == 0
-      auto Flag = GetRFLAG(FEXCore::X86State::RFLAG_PF_LOC);
-      SrcCond = _Select(FEXCore::IR::COND_EQ,
-          Flag, ZeroConst, TrueValue, FalseValue);
+      bool invert = OP == (0xB);
+
+      // We must only consider the bottom bit of PF, the rest is garbage.
+      // For JP, mask off the bottom bit. For JNP, mask off the bottom bit
+      // and invert it. In either case, we return true if that is nonzero.
+      auto PFByte = GetRFLAG(FEXCore::X86State::RFLAG_PF_LOC);
+      auto Flag = _And(OneConst, PFByte);
+
+      SrcCond = _Select(invert ? FEXCore::IR::COND_EQ : FEXCore::IR::COND_NEQ,
+                        Flag, ZeroConst, TrueValue, FalseValue);
       break;
     }
     case 0xC: { // SF <> OF

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -1155,6 +1155,9 @@ private:
   /**
    * @name These functions are used by the deferred flag handling while it is calculating and storing flags in to RFLAGs.
    * @{ */
+  void CalculatePFUncheckedABI(OrderedNode *Res);
+  void CalculatePF(OrderedNode *Res);
+
   void CalculateOF_Add(uint8_t SrcSize, OrderedNode *Res, OrderedNode *Src1, OrderedNode *Src2);
   void CalculateFlags_ADC(uint8_t SrcSize, OrderedNode *Res, OrderedNode *Src1, OrderedNode *Src2, OrderedNode *CF);
   void CalculateFlags_SBB(uint8_t SrcSize, OrderedNode *Res, OrderedNode *Src1, OrderedNode *Src2, OrderedNode *CF);

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
@@ -70,6 +70,8 @@ OrderedNode *OpDispatchBuilder::GetPackedRFLAG(uint32_t FlagsMask) {
       continue;
     }
 
+    // Note that the Bfi only considers the bottom bit of the flag, the rest of
+    // the byte is allowed to be garbage. PF relies on this.
     OrderedNode *Flag = _LoadFlag(FlagOffset);
     Original = _Bfi(4, 1, FlagOffset, Original, Flag);
   }

--- a/unittests/ASM/FEX_bugs/Test_JP.asm
+++ b/unittests/ASM/FEX_bugs/Test_JP.asm
@@ -1,0 +1,42 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x0000000cafecafe"
+  }
+}
+%endif
+
+; This test checks for proper behaviour of the parity flag. Older FEX versions
+; would accidentally turn JP into a zero/nonzero check of the result.
+
+; rax = 0x20, odd parity
+mov rax, 0x10
+mov rbx, 0x10
+add rax, rbx
+jpe fexi_fexi_im_so_broken
+
+; rax = 0x32, odd parity
+mov rax, 0x10
+mov rbx, 0x22
+xor rax, rbx
+jpe fexi_fexi_im_so_broken
+
+; rax = 0x41, even parity
+mov rax, 0x40
+mov rbx, 0x01
+or rax, rbx
+jpo fexi_fexi_im_so_broken
+
+; rax = 0x43, even parity
+mov rax, 0x43
+mov rbx, 0xfe
+and rax, rbx
+jpo fexi_fexi_im_so_broken
+
+; success code
+mov rax, 0xcafecafe
+hlt
+
+; failure, rax != 0xcafecafe
+fexi_fexi_im_so_broken:
+hlt


### PR DESCRIPTION
    We store garbage in the upper bits. That's ok, but it means we need to
    mask on read for correct behaviour.