### PR TITLE
fix spelling errors

### DIFF
--- a/External/FEXCore/docs/OptimizationPasses.md
+++ b/External/FEXCore/docs/OptimizationPasses.md
@@ -30,7 +30,7 @@ Large amount of x86-64 instructions load or store registers in order from the co
 We can merge these in to loadstore pair ops to improve perf
 ### Function level heuristic pass
 Once we know that a function is a true full recompile we can do some additional optimizations.
-Remove any final flag stores. We know that a compiler won't pass flags past a function call boundry(It doesn't exist in the ABI)
+Remove any final flag stores. We know that a compiler won't pass flags past a function call boundary(It doesn't exist in the ABI)
 Remove any loadstores to the context mid function, only do a final store at the end of the function and do loads at the start. Which means ops just map registers directly throughout the entire function.
 ### SIMD coalescing pass?
 When operating on older MMX ops(64bit SIMD) and they may end up up generating some independent ops that can be coalesced in to a 128bit op

--- a/docs/DeferredSignals.md
+++ b/docs/DeferredSignals.md
@@ -133,7 +133,7 @@ refcounter will be the original value loaded. So even though it is a tear, it's 
 This edge is far less problematic to understand compared to the incrementing edge. Signals will get deferred entirely until the store instruction (If
 storing zero), so FEX will always return to the code region and finish the decrement.
 
-If FEX receives a signal after the decrement store has completed but /before/ the page faulting store has occured, then FEX will start processing the
+If FEX receives a signal after the decrement store has completed but /before/ the page faulting store has occurred, then FEX will start processing the
 signal immediately. At which point the fault page will have either RW or NONE permission. FEX will then likely hit another "uninterruptible" code
 section which will complete the store to the fault page.
  - RW permission if it hadn't received another signal in the uninterruptible section

--- a/docs/ReleaseProcess.md
+++ b/docs/ReleaseProcess.md
@@ -92,7 +92,7 @@ Follow the steps in: https://github.com/FEX-Emu/FEX-ppa/blob/main/README.md
 * Use FEXRootFSFetcher <image.sqsh> to generate the xxhash for the image
 * Update `https://rootfs.fex-emu.com/file/fex-rootfs/RootFS_links.json` with the new rootfs image and hash
   * This currently lives in a private FEX-Emu backblaze bucket with cloudflare servicing it.
-  * Never publically give the direct backblaze link to the file. Will cause BW costs to skyrocket
+  * Never publicly give the direct backblaze link to the file. Will cause BW costs to skyrocket
   * Always pass through cloudflare
 
 * Upload new image to Backblaze using the b2 upload tool


### PR DESCRIPTION
Fixing some minor spelling errors which should not affect functionality but improve the overall quality of documentation.