### PR TITLE
CMake: Fix pkg version extraction for xcb

### DIFF
--- a/CMakeFiles/version_to_variables.cmake
+++ b/CMakeFiles/version_to_variables.cmake
@@ -1,0 +1,30 @@
+# Extracts a version from the passed in version string in the form of "<Major>.<Minor>.<Patch>".
+# If a part of the version is missing then it gets set as zero.
+# Version variables returned in:
+# ${Package}_VERSION_MAJOR
+# ${Package}_VERSION_MINOR
+# ${Package}_VERSION_PATCH
+function(version_to_variables VERSION _Package)
+  string(REPLACE "." ";" VERSION_LIST "${VERSION}")
+  list (LENGTH VERSION_LIST VERSION_LEN)
+  if (${VERSION_LEN} GREATER 0)
+    list(GET VERSION_LIST 0 VERSION_MAJOR)
+    set(${_Package}_VERSION_MAJOR ${VERSION_MAJOR} PARENT_SCOPE)
+  else()
+    set(${_Package}_VERSION_MAJOR 0 PARENT_SCOPE)
+  endif()
+
+  if (${VERSION_LEN} GREATER 1)
+    list(GET VERSION_LIST 1 VERSION_MINOR)
+    set(${_Package}_VERSION_MINOR ${VERSION_MINOR} PARENT_SCOPE)
+  else()
+    set(${_Package}_VERSION_MINOR 0 PARENT_SCOPE)
+  endif()
+
+  if (${VERSION_LEN} GREATER 2)
+    list(GET VERSION_LIST 2 VERSION_PATCH)
+    set(${_Package}_VERSION_PATCH ${VERSION_PATCH} PARENT_SCOPE)
+  else()
+    set(${_Package}_VERSION_PATCH 0 PARENT_SCOPE)
+  endif()
+endfunction()

--- a/ThunkLibs/GuestLibs/CMakeLists.txt
+++ b/ThunkLibs/GuestLibs/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.14)
 project(guest-thunks)
+include(${FEX_PROJECT_SOURCE_DIR}/CMakeFiles/version_to_variables.cmake)
 
 option(ENABLE_CLANG_THUNKS "Enable building thunks with clang" FALSE)
 
@@ -189,11 +190,7 @@ if (BITNESS EQUAL 64)
 
   find_package(PkgConfig)
   pkg_search_module(X11 REQUIRED x11)
-
-  string(REGEX MATCH "([0-9]*)\.([0-9]*)\.([0-9]*)" _ "${X11_VERSION}")
-  set(X11_VERSION_MAJOR ${CMAKE_MATCH_1})
-  set(X11_VERSION_MINOR ${CMAKE_MATCH_2})
-  set(X11_VERSION_PATCH ${CMAKE_MATCH_3})
+  version_to_variables(${X11_VERSION} X11)
 
   generate(libX11 ${CMAKE_CURRENT_SOURCE_DIR}/../libX11/libX11_interface.cpp)
   add_guest_lib(X11 "libX11.so.6")
@@ -219,8 +216,16 @@ if (BITNESS EQUAL 64)
   target_include_directories(libvulkan-guest-deps INTERFACE ${FEX_PROJECT_SOURCE_DIR}/External/Vulkan-Headers/include/)
   add_guest_lib(vulkan "libvulkan.so.1")
 
+  find_package(PkgConfig)
+  pkg_search_module(XCB REQUIRED xcb)
+  version_to_variables(${XCB_VERSION} XCB)
+
   generate(libxcb ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb/libxcb_interface.cpp)
   add_guest_lib(xcb "libxcb.so.1")
+
+  target_compile_definitions(libxcb-guest-deps INTERFACE -DXCB_VERSION_MAJOR=${XCB_VERSION_MAJOR})
+  target_compile_definitions(libxcb-guest-deps INTERFACE -DXCB_VERSION_MINOR=${XCB_VERSION_MINOR})
+  target_compile_definitions(libxcb-guest-deps INTERFACE -DXCB_VERSION_PATCH=${XCB_VERSION_PATCH})
 
   generate(libwayland-client ${CMAKE_CURRENT_SOURCE_DIR}/../libwayland-client/libwayland-client_interface.cpp)
   add_guest_lib(wayland-client "libwayland-client.so.0.20.0")

--- a/ThunkLibs/HostLibs/CMakeLists.txt
+++ b/ThunkLibs/HostLibs/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.14)
 project(host-thunks)
+include(${FEX_PROJECT_SOURCE_DIR}/CMakeFiles/version_to_variables.cmake)
 
 set(CMAKE_CXX_STANDARD 17)
 set (HOSTLIBS_DATA_DIRECTORY "${CMAKE_INSTALL_PREFIX}/lib/fex-emu" CACHE PATH "global data directory")
@@ -114,11 +115,7 @@ foreach(GUEST_BITNESS IN LISTS BITNESS_LIST)
 
   find_package(PkgConfig)
   pkg_search_module(X11 REQUIRED x11)
-
-  string(REGEX MATCH "([0-9]*)\.([0-9]*)\.([0-9]*)" _ "${X11_VERSION}")
-  set(X11_VERSION_MAJOR ${CMAKE_MATCH_1})
-  set(X11_VERSION_MINOR ${CMAKE_MATCH_2})
-  set(X11_VERSION_PATCH ${CMAKE_MATCH_3})
+  version_to_variables(${X11_VERSION} X11)
 
   generate(libX11 ${CMAKE_CURRENT_SOURCE_DIR}/../libX11/libX11_interface.cpp ${GUEST_BITNESS})
   add_host_lib(X11 ${GUEST_BITNESS})
@@ -144,8 +141,16 @@ foreach(GUEST_BITNESS IN LISTS BITNESS_LIST)
   target_include_directories(libvulkan-${GUEST_BITNESS}-deps INTERFACE ${FEX_PROJECT_SOURCE_DIR}/External/Vulkan-Headers/include/)
   add_host_lib(vulkan ${GUEST_BITNESS})
 
+  find_package(PkgConfig)
+  pkg_search_module(XCB REQUIRED xcb)
+  version_to_variables(${XCB_VERSION} XCB)
+
   generate(libxcb ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb/libxcb_interface.cpp ${GUEST_BITNESS})
   add_host_lib(xcb ${GUEST_BITNESS})
+
+  target_compile_definitions(libxcb-${GUEST_BITNESS}-deps INTERFACE -DXCB_VERSION_MAJOR=${XCB_VERSION_MAJOR})
+  target_compile_definitions(libxcb-${GUEST_BITNESS}-deps INTERFACE -DXCB_VERSION_MINOR=${XCB_VERSION_MINOR})
+  target_compile_definitions(libxcb-${GUEST_BITNESS}-deps INTERFACE -DXCB_VERSION_PATCH=${XCB_VERSION_PATCH})
 
   generate(libwayland-client ${CMAKE_CURRENT_SOURCE_DIR}/../libwayland-client/libwayland-client_interface.cpp ${GUEST_BITNESS})
   add_host_lib(wayland-client ${GUEST_BITNESS})

--- a/ThunkLibs/libxcb/libxcb_interface.cpp
+++ b/ThunkLibs/libxcb/libxcb_interface.cpp
@@ -51,8 +51,11 @@ template<> struct fex_gen_config<xcb_parse_display> : fexgen::custom_guest_entry
 template<> struct fex_gen_config<xcb_connect> : fexgen::custom_guest_entrypoint {};
 template<> struct fex_gen_config<xcb_connect_to_display_with_auth_info> : fexgen::custom_guest_entrypoint {};
 template<> struct fex_gen_config<xcb_generate_id> {};
+
+#if XCB_VERSION_MAJOR >= 1 && XCB_VERSION_MINOR >= 4 && XCB_VERSION_PATCH >= 0
 template<> struct fex_gen_config<xcb_total_read> {};
 template<> struct fex_gen_config<xcb_total_written> {};
+#endif
 
 template<> struct fex_gen_config<xcb_send_request> {};
 template<> struct fex_gen_config<xcb_send_request_with_fds> {};


### PR DESCRIPTION
Our regex would only ever capture a single digit, so versions that had more than one digit per section would lose additional digits.

Fixes and moves the helper to a cmake file to be shared between GuestLibs and HostLibs.

Uses the fix in xcb because Fedora ships an older version that doesn't have some of FEX's newer symbols.