### PR TITLE
Arm64: Emitter: Handle LD1{*}/LDFF1{*} Vector + Immediate encodings

### DIFF
--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/Emitter.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/Emitter.h
@@ -249,6 +249,14 @@ namespace FEXCore::ARMEmitter {
             .scale = scale,
           }
         } {}
+      SVEMemOperand(ZRegister zn, uint32_t imm)
+        : rn{Register{zn.Idx()}}
+        , MemType{Type::VectorPlusImm}
+        , MetaType {
+          .VectorImmType{
+            .Imm = imm,
+          }
+        } {}
 
       [[nodiscard]] bool IsScalarPlusScalar() const {
         return MemType == Type::ScalarPlusScalar;
@@ -280,7 +288,7 @@ namespace FEXCore::ARMEmitter {
 
         struct {
           // rn will be a ZRegister
-          int32_t Imm;
+          uint32_t Imm;
         } VectorImmType;
       };
 

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
@@ -2758,7 +2758,7 @@ public:
       SVEGatherLoadScalarPlusVector(size, SubRegSize::i8Bit, zt, pg, Src, true, false);
     }
     else if (Src.IsVectorPlusImm()) {
-      LOGMAN_THROW_A_FMT(false, "Not yet implemented");
+      SVEGatherLoadVectorPlusImm(size, SubRegSize::i8Bit, zt, pg, Src, true, false);
     }
     else {
       FEX_UNREACHABLE;
@@ -2777,7 +2777,7 @@ public:
       SVEGatherLoadScalarPlusVector(size, SubRegSize::i8Bit, zt, pg, Src, true, true);
     }
     else if (Src.IsVectorPlusImm()) {
-      LOGMAN_THROW_A_FMT(false, "ldff1b vector plus immediate not yet implemented");
+      SVEGatherLoadVectorPlusImm(size, SubRegSize::i8Bit, zt, pg, Src, true, true);
     }
     else {
       FEX_UNREACHABLE;
@@ -2795,7 +2795,7 @@ public:
       SVEGatherLoadScalarPlusVector(SubRegSize::i64Bit, SubRegSize::i32Bit, zt, pg, Src, false, false);
     }
     else if (Src.IsVectorPlusImm()) {
-      LOGMAN_THROW_A_FMT(false, "Not yet implemented");
+      SVEGatherLoadVectorPlusImm(SubRegSize::i64Bit, SubRegSize::i32Bit, zt, pg, Src, false, false);
     }
     else {
       FEX_UNREACHABLE;
@@ -2814,7 +2814,7 @@ public:
       SVEGatherLoadScalarPlusVector(size, SubRegSize::i16Bit, zt, pg, Src, true, false);
     }
     else if (Src.IsVectorPlusImm()) {
-      LOGMAN_THROW_A_FMT(false, "Not yet implemented");
+      SVEGatherLoadVectorPlusImm(size, SubRegSize::i16Bit, zt, pg, Src, true, false);
     }
     else {
       FEX_UNREACHABLE;
@@ -2833,7 +2833,7 @@ public:
       SVEGatherLoadScalarPlusVector(size, SubRegSize::i16Bit, zt, pg, Src, false, false);
     }
     else if (Src.IsVectorPlusImm()) {
-      LOGMAN_THROW_A_FMT(false, "Not yet implemented");
+      SVEGatherLoadVectorPlusImm(size, SubRegSize::i16Bit, zt, pg, Src, false, false);
     }
     else {
       FEX_UNREACHABLE;
@@ -2852,7 +2852,7 @@ public:
       SVEGatherLoadScalarPlusVector(size, SubRegSize::i16Bit, zt, pg, Src, true, true);
     }
     else if (Src.IsVectorPlusImm()) {
-      LOGMAN_THROW_A_FMT(false, "ldff1h vector plus immediate not yet implemented");
+      SVEGatherLoadVectorPlusImm(size, SubRegSize::i16Bit, zt, pg, Src, true, true);
     }
     else {
       FEX_UNREACHABLE;
@@ -2871,7 +2871,7 @@ public:
       SVEGatherLoadScalarPlusVector(size, SubRegSize::i16Bit, zt, pg, Src, false, true);
     }
     else if (Src.IsVectorPlusImm()) {
-      LOGMAN_THROW_A_FMT(false, "ldff1sh vector plus immediate not yet implemented");
+      SVEGatherLoadVectorPlusImm(size, SubRegSize::i16Bit, zt, pg, Src, false, true);
     }
     else {
       FEX_UNREACHABLE;
@@ -2890,7 +2890,7 @@ public:
       SVEGatherLoadScalarPlusVector(size, SubRegSize::i32Bit, zt, pg, Src, true, false);
     }
     else if (Src.IsVectorPlusImm()) {
-      LOGMAN_THROW_A_FMT(false, "Not yet implemented");
+      SVEGatherLoadVectorPlusImm(size, SubRegSize::i32Bit, zt, pg, Src, true, false);
     }
     else {
       FEX_UNREACHABLE;
@@ -2909,7 +2909,7 @@ public:
       SVEGatherLoadScalarPlusVector(size, SubRegSize::i32Bit, zt, pg, Src, true, true);
     }
     else if (Src.IsVectorPlusImm()) {
-      LOGMAN_THROW_A_FMT(false, "ldff1w vector plus immediate not yet implemented");
+      SVEGatherLoadVectorPlusImm(size, SubRegSize::i32Bit, zt, pg, Src, true, true);
     }
     else {
       FEX_UNREACHABLE;
@@ -2927,7 +2927,7 @@ public:
       SVEGatherLoadScalarPlusVector(SubRegSize::i64Bit, SubRegSize::i32Bit, zt, pg, Src, false, true);
     }
     else if (Src.IsVectorPlusImm()) {
-      LOGMAN_THROW_A_FMT(false, "ldff1sw vector plus immediate not yet implemented");
+      SVEGatherLoadVectorPlusImm(SubRegSize::i64Bit, SubRegSize::i32Bit, zt, pg, Src, false, true);
     }
     else {
       FEX_UNREACHABLE;
@@ -2946,7 +2946,7 @@ public:
       SVEGatherLoadScalarPlusVector(size, SubRegSize::i8Bit, zt, pg, Src, false, false);
     }
     else if (Src.IsVectorPlusImm()) {
-      LOGMAN_THROW_A_FMT(false, "Not yet implemented");
+      SVEGatherLoadVectorPlusImm(size, SubRegSize::i8Bit, zt, pg, Src, false, false);
     }
     else {
       FEX_UNREACHABLE;
@@ -2965,7 +2965,7 @@ public:
       SVEGatherLoadScalarPlusVector(size, SubRegSize::i8Bit, zt, pg, Src, false, true);
     }
     else if (Src.IsVectorPlusImm()) {
-      LOGMAN_THROW_A_FMT(false, "ldff1sb vector plus immediate not yet implemented");
+      SVEGatherLoadVectorPlusImm(size, SubRegSize::i8Bit, zt, pg, Src, false, true);
     }
     else {
       FEX_UNREACHABLE;
@@ -2983,7 +2983,7 @@ public:
       SVEGatherLoadScalarPlusVector(SubRegSize::i64Bit, SubRegSize::i64Bit, zt, pg, Src, true, false);
     }
     else if (Src.IsVectorPlusImm()) {
-      LOGMAN_THROW_A_FMT(false, "Not yet implemented");
+      SVEGatherLoadVectorPlusImm(SubRegSize::i64Bit, SubRegSize::i64Bit, zt, pg, Src, true, false);
     }
     else {
       FEX_UNREACHABLE;
@@ -3001,7 +3001,7 @@ public:
       SVEGatherLoadScalarPlusVector(SubRegSize::i64Bit, SubRegSize::i64Bit, zt, pg, Src, true, true);
     }
     else if (Src.IsVectorPlusImm()) {
-      LOGMAN_THROW_A_FMT(false, "ldff1d vector plus immediate not yet implemented");
+      SVEGatherLoadVectorPlusImm(SubRegSize::i64Bit, SubRegSize::i64Bit, zt, pg, Src, true, true);
     }
     else {
       FEX_UNREACHABLE;
@@ -4120,6 +4120,40 @@ private:
     Instr |= static_cast<uint32_t>(mod_value) << 22;
     Instr |= static_cast<uint32_t>(is_scaled) << 21;
     Instr |= op_data.zm.Idx() << 16;
+    Instr |= static_cast<uint32_t>(is_unsigned) << 14;
+    Instr |= static_cast<uint32_t>(is_fault_first) << 13;
+    Instr |= pg.Idx() << 10;
+    Instr |= mem_op.rn.Idx() << 5;
+    Instr |= zt.Idx();
+
+    dc32(Instr);
+  }
+
+  void SVEGatherLoadVectorPlusImm(SubRegSize esize, SubRegSize msize, ZRegister zt, PRegisterZero pg, SVEMemOperand mem_op,
+                                  bool is_unsigned, bool is_fault_first) {
+    LOGMAN_THROW_A_FMT(esize == SubRegSize::i32Bit || esize == SubRegSize::i64Bit,
+                       "Gather load element size must be 32-bit or 64-bit");
+    LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
+
+    const auto msize_value = FEXCore::ToUnderlying(msize);
+    const auto msize_bytes = 1U << msize_value;
+
+    const auto imm_limit = (32U << msize_value) - msize_bytes;
+    const auto imm = mem_op.MetaType.VectorImmType.Imm;
+    const auto imm_to_encode = imm >> msize_value;
+
+    LOGMAN_THROW_A_FMT(imm <= imm_limit, "immediate must be within [0, {}]", imm_limit);
+    LOGMAN_THROW_A_FMT(imm == 0 || (imm % msize_bytes) == 0,
+                       "Immediate must be cleanly divisible by {}", msize_bytes);
+
+    uint32_t Instr = 0b1000'0100'0010'0000'1000'0000'0000'0000;
+
+    if (esize == SubRegSize::i64Bit) {
+      Instr |= 1U << 30;
+    }
+
+    Instr |= FEXCore::ToUnderlying(msize) << 23;
+    Instr |= imm_to_encode << 16;
     Instr |= static_cast<uint32_t>(is_unsigned) << 14;
     Instr |= static_cast<uint32_t>(is_fault_first) << 13;
     Instr |= pg.Idx() << 10;

--- a/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
+++ b/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
@@ -3103,6 +3103,15 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE Memory - 32-bit Gather and
                                        SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_NONE, 0)),
                                        "ld1b {z30.d}, p6/z, [x30, z31.d]");
 
+  TEST_SINGLE(ld1b<SubRegSize::i32Bit>(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 0)),
+                                       "ld1b {z30.s}, p6/z, [z31.s]");
+  TEST_SINGLE(ld1b<SubRegSize::i32Bit>(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 31)),
+                                       "ld1b {z30.s}, p6/z, [z31.s, #31]");
+  TEST_SINGLE(ld1b<SubRegSize::i64Bit>(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 0)),
+                                       "ld1b {z30.d}, p6/z, [z31.d]");
+  TEST_SINGLE(ld1b<SubRegSize::i64Bit>(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 31)),
+                                       "ld1b {z30.d}, p6/z, [z31.d, #31]");
+
   TEST_SINGLE(ld1sb<SubRegSize::i32Bit>(ZReg::z30, PReg::p6.Zeroing(),
                                         SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_UXTW, 0)),
                                         "ld1sb {z30.s}, p6/z, [x30, z31.s, uxtw]");
@@ -3118,6 +3127,15 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE Memory - 32-bit Gather and
   TEST_SINGLE(ld1sb<SubRegSize::i64Bit>(ZReg::z30, PReg::p6.Zeroing(),
                                         SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_NONE, 0)),
                                         "ld1sb {z30.d}, p6/z, [x30, z31.d]");
+
+  TEST_SINGLE(ld1sb<SubRegSize::i32Bit>(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 0)),
+                                        "ld1sb {z30.s}, p6/z, [z31.s]");
+  TEST_SINGLE(ld1sb<SubRegSize::i32Bit>(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 31)),
+                                        "ld1sb {z30.s}, p6/z, [z31.s, #31]");
+  TEST_SINGLE(ld1sb<SubRegSize::i64Bit>(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 0)),
+                                        "ld1sb {z30.d}, p6/z, [z31.d]");
+  TEST_SINGLE(ld1sb<SubRegSize::i64Bit>(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 31)),
+                                        "ld1sb {z30.d}, p6/z, [z31.d, #31]");
 
   TEST_SINGLE(ld1d(ZReg::z30, PReg::p6.Zeroing(),
                    SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_UXTW, 0)),
@@ -3137,6 +3155,11 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE Memory - 32-bit Gather and
   TEST_SINGLE(ld1d(ZReg::z30, PReg::p6.Zeroing(),
                    SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_NONE, 0)),
                    "ld1d {z30.d}, p6/z, [x30, z31.d]");
+
+  TEST_SINGLE(ld1d(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 0)),
+                   "ld1d {z30.d}, p6/z, [z31.d]");
+  TEST_SINGLE(ld1d(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 248)),
+                   "ld1d {z30.d}, p6/z, [z31.d, #248]");
 
   TEST_SINGLE(ld1h<SubRegSize::i32Bit>(ZReg::z30, PReg::p6.Zeroing(),
                                        SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_UXTW, 1)),
@@ -3170,6 +3193,15 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE Memory - 32-bit Gather and
                                        SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_SXTW, 0)),
                                        "ld1h {z30.d}, p6/z, [x30, z31.d, sxtw]");
 
+  TEST_SINGLE(ld1h<SubRegSize::i32Bit>(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 0)),
+                                       "ld1h {z30.s}, p6/z, [z31.s]");
+  TEST_SINGLE(ld1h<SubRegSize::i32Bit>(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 62)),
+                                       "ld1h {z30.s}, p6/z, [z31.s, #62]");
+  TEST_SINGLE(ld1h<SubRegSize::i64Bit>(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 0)),
+                                       "ld1h {z30.d}, p6/z, [z31.d]");
+  TEST_SINGLE(ld1h<SubRegSize::i64Bit>(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 62)),
+                                       "ld1h {z30.d}, p6/z, [z31.d, #62]");
+
   TEST_SINGLE(ld1sh<SubRegSize::i32Bit>(ZReg::z30, PReg::p6.Zeroing(),
                                         SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_UXTW, 1)),
                                         "ld1sh {z30.s}, p6/z, [x30, z31.s, uxtw #1]");
@@ -3201,6 +3233,15 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE Memory - 32-bit Gather and
   TEST_SINGLE(ld1sh<SubRegSize::i64Bit>(ZReg::z30, PReg::p6.Zeroing(),
                                         SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_SXTW, 0)),
                                         "ld1sh {z30.d}, p6/z, [x30, z31.d, sxtw]");
+
+  TEST_SINGLE(ld1sh<SubRegSize::i32Bit>(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 0)),
+                                        "ld1sh {z30.s}, p6/z, [z31.s]");
+  TEST_SINGLE(ld1sh<SubRegSize::i32Bit>(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 62)),
+                                        "ld1sh {z30.s}, p6/z, [z31.s, #62]");
+  TEST_SINGLE(ld1sh<SubRegSize::i64Bit>(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 0)),
+                                        "ld1sh {z30.d}, p6/z, [z31.d]");
+  TEST_SINGLE(ld1sh<SubRegSize::i64Bit>(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 62)),
+                                        "ld1sh {z30.d}, p6/z, [z31.d, #62]");
 
   TEST_SINGLE(ld1w<SubRegSize::i32Bit>(ZReg::z30, PReg::p6.Zeroing(),
                                        SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_UXTW, 2)),
@@ -3234,6 +3275,15 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE Memory - 32-bit Gather and
                                        SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_NONE, 0)),
                                        "ld1w {z30.d}, p6/z, [x30, z31.d]");
 
+  TEST_SINGLE(ld1w<SubRegSize::i32Bit>(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 0)),
+                                       "ld1w {z30.s}, p6/z, [z31.s]");
+  TEST_SINGLE(ld1w<SubRegSize::i32Bit>(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 124)),
+                                       "ld1w {z30.s}, p6/z, [z31.s, #124]");
+  TEST_SINGLE(ld1w<SubRegSize::i64Bit>(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 0)),
+                                       "ld1w {z30.d}, p6/z, [z31.d]");
+  TEST_SINGLE(ld1w<SubRegSize::i64Bit>(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 124)),
+                                       "ld1w {z30.d}, p6/z, [z31.d, #124]");
+
   TEST_SINGLE(ld1sw(ZReg::z30, PReg::p6.Zeroing(),
                     SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_UXTW, 0)),
                     "ld1sw {z30.d}, p6/z, [x30, z31.d, uxtw]");
@@ -3253,6 +3303,11 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE Memory - 32-bit Gather and
                     SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_NONE, 0)),
                     "ld1sw {z30.d}, p6/z, [x30, z31.d]");
 
+  TEST_SINGLE(ld1sw(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 0)),
+                    "ld1sw {z30.d}, p6/z, [z31.d]");
+  TEST_SINGLE(ld1sw(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 124)),
+                    "ld1sw {z30.d}, p6/z, [z31.d, #124]");
+
   TEST_SINGLE(ldff1b<SubRegSize::i32Bit>(ZReg::z30, PReg::p6.Zeroing(),
                                          SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_UXTW, 0)),
                                          "ldff1b {z30.s}, p6/z, [x30, z31.s, uxtw]");
@@ -3269,6 +3324,15 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE Memory - 32-bit Gather and
                                          SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_NONE, 0)),
                                          "ldff1b {z30.d}, p6/z, [x30, z31.d]");
 
+  TEST_SINGLE(ldff1b<SubRegSize::i32Bit>(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 0)),
+                                         "ldff1b {z30.s}, p6/z, [z31.s]");
+  TEST_SINGLE(ldff1b<SubRegSize::i32Bit>(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 31)),
+                                         "ldff1b {z30.s}, p6/z, [z31.s, #31]");
+  TEST_SINGLE(ldff1b<SubRegSize::i64Bit>(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 0)),
+                                         "ldff1b {z30.d}, p6/z, [z31.d]");
+  TEST_SINGLE(ldff1b<SubRegSize::i64Bit>(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 31)),
+                                         "ldff1b {z30.d}, p6/z, [z31.d, #31]");
+
   TEST_SINGLE(ldff1sb<SubRegSize::i32Bit>(ZReg::z30, PReg::p6.Zeroing(),
                                           SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_UXTW, 0)),
                                           "ldff1sb {z30.s}, p6/z, [x30, z31.s, uxtw]");
@@ -3284,6 +3348,15 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE Memory - 32-bit Gather and
   TEST_SINGLE(ldff1sb<SubRegSize::i64Bit>(ZReg::z30, PReg::p6.Zeroing(),
                                           SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_NONE, 0)),
                                           "ldff1sb {z30.d}, p6/z, [x30, z31.d]");
+
+  TEST_SINGLE(ldff1sb<SubRegSize::i32Bit>(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 0)),
+                                          "ldff1sb {z30.s}, p6/z, [z31.s]");
+  TEST_SINGLE(ldff1sb<SubRegSize::i32Bit>(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 31)),
+                                          "ldff1sb {z30.s}, p6/z, [z31.s, #31]");
+  TEST_SINGLE(ldff1sb<SubRegSize::i64Bit>(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 0)),
+                                          "ldff1sb {z30.d}, p6/z, [z31.d]");
+  TEST_SINGLE(ldff1sb<SubRegSize::i64Bit>(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 31)),
+                                          "ldff1sb {z30.d}, p6/z, [z31.d, #31]");
 
   TEST_SINGLE(ldff1d(ZReg::z30, PReg::p6.Zeroing(),
                      SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_UXTW, 0)),
@@ -3303,6 +3376,11 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE Memory - 32-bit Gather and
   TEST_SINGLE(ldff1d(ZReg::z30, PReg::p6.Zeroing(),
                      SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_NONE, 0)),
                      "ldff1d {z30.d}, p6/z, [x30, z31.d]");
+
+  TEST_SINGLE(ldff1d(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 0)),
+                     "ldff1d {z30.d}, p6/z, [z31.d]");
+  TEST_SINGLE(ldff1d(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 248)),
+                     "ldff1d {z30.d}, p6/z, [z31.d, #248]");
 
   TEST_SINGLE(ldff1h<SubRegSize::i32Bit>(ZReg::z30, PReg::p6.Zeroing(),
                                          SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_UXTW, 1)),
@@ -3336,6 +3414,15 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE Memory - 32-bit Gather and
                                          SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_SXTW, 0)),
                                          "ldff1h {z30.d}, p6/z, [x30, z31.d, sxtw]");
 
+  TEST_SINGLE(ldff1h<SubRegSize::i32Bit>(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 0)),
+                                         "ldff1h {z30.s}, p6/z, [z31.s]");
+  TEST_SINGLE(ldff1h<SubRegSize::i32Bit>(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 62)),
+                                         "ldff1h {z30.s}, p6/z, [z31.s, #62]");
+  TEST_SINGLE(ldff1h<SubRegSize::i64Bit>(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 0)),
+                                         "ldff1h {z30.d}, p6/z, [z31.d]");
+  TEST_SINGLE(ldff1h<SubRegSize::i64Bit>(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 62)),
+                                         "ldff1h {z30.d}, p6/z, [z31.d, #62]");
+
   TEST_SINGLE(ldff1sh<SubRegSize::i32Bit>(ZReg::z30, PReg::p6.Zeroing(),
                                           SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_UXTW, 1)),
                                           "ldff1sh {z30.s}, p6/z, [x30, z31.s, uxtw #1]");
@@ -3367,6 +3454,15 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE Memory - 32-bit Gather and
   TEST_SINGLE(ldff1sh<SubRegSize::i64Bit>(ZReg::z30, PReg::p6.Zeroing(),
                                           SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_SXTW, 0)),
                                           "ldff1sh {z30.d}, p6/z, [x30, z31.d, sxtw]");
+
+  TEST_SINGLE(ldff1sh<SubRegSize::i32Bit>(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 0)),
+                                          "ldff1sh {z30.s}, p6/z, [z31.s]");
+  TEST_SINGLE(ldff1sh<SubRegSize::i32Bit>(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 62)),
+                                          "ldff1sh {z30.s}, p6/z, [z31.s, #62]");
+  TEST_SINGLE(ldff1sh<SubRegSize::i64Bit>(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 0)),
+                                          "ldff1sh {z30.d}, p6/z, [z31.d]");
+  TEST_SINGLE(ldff1sh<SubRegSize::i64Bit>(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 62)),
+                                          "ldff1sh {z30.d}, p6/z, [z31.d, #62]");
 
   TEST_SINGLE(ldff1w<SubRegSize::i32Bit>(ZReg::z30, PReg::p6.Zeroing(),
                                          SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_UXTW, 2)),
@@ -3400,6 +3496,15 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE Memory - 32-bit Gather and
                                          SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_NONE, 0)),
                                          "ldff1w {z30.d}, p6/z, [x30, z31.d]");
 
+  TEST_SINGLE(ldff1w<SubRegSize::i32Bit>(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 0)),
+                                         "ldff1w {z30.s}, p6/z, [z31.s]");
+  TEST_SINGLE(ldff1w<SubRegSize::i32Bit>(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 124)),
+                                         "ldff1w {z30.s}, p6/z, [z31.s, #124]");
+  TEST_SINGLE(ldff1w<SubRegSize::i64Bit>(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 0)),
+                                         "ldff1w {z30.d}, p6/z, [z31.d]");
+  TEST_SINGLE(ldff1w<SubRegSize::i64Bit>(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 124)),
+                                         "ldff1w {z30.d}, p6/z, [z31.d, #124]");
+
   TEST_SINGLE(ldff1sw(ZReg::z30, PReg::p6.Zeroing(),
                       SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_UXTW, 0)),
                       "ldff1sw {z30.d}, p6/z, [x30, z31.d, uxtw]");
@@ -3418,6 +3523,11 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE Memory - 32-bit Gather and
   TEST_SINGLE(ldff1sw(ZReg::z30, PReg::p6.Zeroing(),
                       SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_NONE, 0)),
                       "ldff1sw {z30.d}, p6/z, [x30, z31.d]");
+
+  TEST_SINGLE(ldff1sw(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 0)),
+                      "ldff1sw {z30.d}, p6/z, [z31.d]");
+  TEST_SINGLE(ldff1sw(ZReg::z30, PReg::p6.Zeroing(), SVEMemOperand(ZReg::z31, 124)),
+                      "ldff1sw {z30.d}, p6/z, [z31.d, #124]");
 
   TEST_SINGLE(ldr(PReg::p6, XReg::x29, 0), "ldr p6, [x29]");
   TEST_SINGLE(ldr(PReg::p6, XReg::x29, -256), "ldr p6, [x29, #-256, mul vl]");


### PR DESCRIPTION
While we're in the area implementing the Scalar + Vector variants, we may as well cross off the Vector + Immediate variants and complete all of the load variants for the regular LD1{*} loads