### PR TITLE
SignalDelegator: Moves last TLS variable to the frontend

### DIFF
--- a/External/FEXCore/Source/Interface/Core/SignalDelegator.cpp
+++ b/External/FEXCore/Source/Interface/Core/SignalDelegator.cpp
@@ -6,26 +6,6 @@
 #include <signal.h>
 
 namespace FEXCore {
-  struct ThreadState {
-    FEXCore::Core::InternalThreadState *Thread{};
-  };
-
-  thread_local ThreadState ThreadData{};
-
-  FEXCore::Core::InternalThreadState *SignalDelegator::GetTLSThread() {
-    return ThreadData.Thread;
-  }
-
-  void SignalDelegator::RegisterTLSState(FEXCore::Core::InternalThreadState *Thread) {
-    ThreadData.Thread = Thread;
-    RegisterFrontendTLSState(Thread);
-  }
-
-  void SignalDelegator::UninstallTLSState(FEXCore::Core::InternalThreadState *Thread) {
-    UninstallFrontendTLSState(Thread);
-    ThreadData.Thread = nullptr;
-  }
-
   void SignalDelegator::RegisterHostSignalHandler(int Signal, HostSignalDelegatorFunction Func, bool Required) {
     SetHostSignalHandler(Signal, Func, Required);
     FrontendRegisterHostSignalHandler(Signal, Func, Required);

--- a/External/FEXCore/include/FEXCore/Core/SignalDelegator.h
+++ b/External/FEXCore/include/FEXCore/Core/SignalDelegator.h
@@ -45,8 +45,8 @@ namespace Core {
      *
      * Required to know which thread has received the signal when it occurs
      */
-    void RegisterTLSState(FEXCore::Core::InternalThreadState *Thread);
-    void UninstallTLSState(FEXCore::Core::InternalThreadState *Thread);
+    virtual void RegisterTLSState(FEXCore::Core::InternalThreadState *Thread) = 0;
+    virtual void UninstallTLSState(FEXCore::Core::InternalThreadState *Thread) = 0;
 
     /**
      * @brief Registers a signal handler for the host to handle a signal
@@ -120,16 +120,8 @@ namespace Core {
   protected:
     SignalDelegatorConfig Config;
 
-    FEXCore::Core::InternalThreadState *GetTLSThread();
+    virtual FEXCore::Core::InternalThreadState *GetTLSThread() = 0;
     virtual void HandleGuestSignal(FEXCore::Core::InternalThreadState *Thread, int Signal, void *info, void *ucontext) = 0;
-
-    /**
-     * @brief Registers an emulated thread's object to a TLS object
-     *
-     * Required to know which thread has received the signal when it occurs
-     */
-    virtual void RegisterFrontendTLSState(FEXCore::Core::InternalThreadState *Thread) = 0;
-    virtual void UninstallFrontendTLSState(FEXCore::Core::InternalThreadState *Thread) = 0;
 
     /**
      * @brief Registers a signal handler for the host to handle a signal

--- a/Source/Tools/FEXLoader/LinuxSyscalls/SignalDelegator.h
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/SignalDelegator.h
@@ -44,6 +44,9 @@ namespace FEX::HLE {
     SignalDelegator(FEXCore::Context::Context *_CTX, const std::string_view ApplicationName);
     ~SignalDelegator() override;
 
+    void RegisterTLSState(FEXCore::Core::InternalThreadState *Thread) override;
+    void UninstallTLSState(FEXCore::Core::InternalThreadState *Thread) override;
+
     /**
      * @brief Registers a signal handler for the host to handle a signal specifically for guest handling
      *
@@ -105,8 +108,7 @@ namespace FEX::HLE {
     // Called from the thunk handler to handle the signal
     void HandleGuestSignal(FEXCore::Core::InternalThreadState *Thread, int Signal, void *Info, void *UContext) override;
 
-    void RegisterFrontendTLSState(FEXCore::Core::InternalThreadState *Thread) override;
-    void UninstallFrontendTLSState(FEXCore::Core::InternalThreadState *Thread) override;
+    FEXCore::Core::InternalThreadState *GetTLSThread() override;
 
     /**
      * @brief Registers a signal handler for the host to handle a signal


### PR DESCRIPTION
There was one holdout variable that was in a TLS object in FEXCore. Move it to the frontend with the rest of the TLS variables.

Allows us to remove "Frontend" TLS management to be the only TLS management.