### PR TITLE
OpcodeDispatcher: Minor optimization to phminposuw

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -4221,11 +4221,8 @@ OrderedNode* OpDispatchBuilder::PHMINPOSUWOpImpl(OpcodeArgs) {
                   Element, MinGPR, Indexes[i - 1], Pos);
   }
 
-  // Insert the minimum in to bits [15:0]
-  OrderedNode *Result = _VMov(2, Min);
-
   // Insert position in to bits [18:16]
-  return _VInsGPR(16, 2, 1, Result, Pos);
+  return _VInsGPR(16, 2, 1, Min, Pos);
 }
 
 void OpDispatchBuilder::PHMINPOSUWOp(OpcodeArgs) {


### PR DESCRIPTION
This instruction doesn't match ARM semantics very well since it returns the position of the minimum element.

But at the very least the insert in to the final instruction can be a bit more optimal, Converts an 5 inst eor+mov+mov+mov+mov in to 2 inst mov+mov.

This works because `VUMinV` already zero extends the vector so the position only needs to be inserted at the end.