### PR TITLE
OpcodeDispatcher: Minor optimization to FILD

### DIFF
--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ALUOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ALUOps.inl
@@ -761,6 +761,9 @@ public:
     constexpr uint32_t Op = 0b0001'1010'100 << 21;
     ConditionalCompare(Op, 1, 0b01, s, rd, rn, rm, Cond);
   }
+  void cneg(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Condition Cond) {
+    csneg(s, rd, rn, rn, static_cast<FEXCore::ARMEmitter::Condition>(FEXCore::ToUnderlying(Cond) ^ FEXCore::ToUnderlying(FEXCore::ARMEmitter::Condition::CC_NE)));
+  }
 
   // Data processing - 3 source
   void madd(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Register rm, FEXCore::ARMEmitter::Register ra) {

--- a/External/FEXCore/Source/Interface/Core/HostFeatures.cpp
+++ b/External/FEXCore/Source/Interface/Core/HostFeatures.cpp
@@ -71,6 +71,7 @@ HostFeatures::HostFeatures() {
   SupportsRCPC = Features.Has(vixl::CPUFeatures::Feature::kRCpc);
   SupportsTSOImm9 = Features.Has(vixl::CPUFeatures::Feature::kRCpcImm);
   SupportsPMULL_128Bit = Features.Has(vixl::CPUFeatures::Feature::kPmull1Q);
+  SupportsCSSC = Features.Has(vixl::CPUFeatures::Feature::kCSSC);
 
   Supports3DNow = true;
   SupportsSSE4A = true;

--- a/External/FEXCore/Source/Interface/Core/Interpreter/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/ALUOps.cpp
@@ -113,6 +113,22 @@ DEF_OP(Neg) {
   }
 }
 
+DEF_OP(Abs) {
+  auto Op = IROp->C<IR::IROp_Abs>();
+  const uint8_t OpSize = IROp->Size;
+
+  const int64_t Src = *GetSrc<int64_t*>(Data->SSAData, Op->Src);
+  switch (OpSize) {
+    case 4:
+      GD = std::abs(static_cast<int32_t>(Src));
+      break;
+    case 8:
+      GD = std::abs(static_cast<int64_t>(Src));
+      break;
+    default: LOGMAN_MSG_A_FMT("Unknown Abs Size: {}\n", OpSize); break;
+  }
+}
+
 DEF_OP(Mul) {
   auto Op = IROp->C<IR::IROp_Mul>();
   const uint8_t OpSize = IROp->Size;

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -52,6 +52,7 @@ constexpr OpHandlerArray InterpreterOpHandlers = [] {
   REGISTER_OP(ADD,                    Add);
   REGISTER_OP(SUB,                    Sub);
   REGISTER_OP(NEG,                    Neg);
+  REGISTER_OP(ABS,                    Abs);
   REGISTER_OP(MUL,                    Mul);
   REGISTER_OP(UMUL,                   UMul);
   REGISTER_OP(DIV,                    Div);

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
@@ -85,6 +85,7 @@ namespace FEXCore::CPU {
   DEF_OP(Add);
   DEF_OP(Sub);
   DEF_OP(Neg);
+  DEF_OP(Abs);
   DEF_OP(Mul);
   DEF_OP(UMul);
   DEF_OP(Div);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -847,6 +847,7 @@ CPUBackend::CompiledCode Arm64JITCore::CompileCode(uint64_t Entry,
         REGISTER_OP(ADD,               Add);
         REGISTER_OP(SUB,               Sub);
         REGISTER_OP(NEG,               Neg);
+        REGISTER_OP(ABS,               Abs);
         REGISTER_OP(MUL,               Mul);
         REGISTER_OP(UMUL,              UMul);
         REGISTER_OP(DIV,               Div);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -238,6 +238,7 @@ private:
   DEF_OP(Add);
   DEF_OP(Sub);
   DEF_OP(Neg);
+  DEF_OP(Abs);
   DEF_OP(Mul);
   DEF_OP(UMul);
   DEF_OP(Div);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/ALUOps.cpp
@@ -161,6 +161,30 @@ DEF_OP(Neg) {
   neg(Dst);
 }
 
+DEF_OP(Abs) {
+  auto Op = IROp->C<IR::IROp_Abs>();
+  const uint8_t OpSize = IROp->Size;
+
+  Xbyak::Reg Src;
+  Xbyak::Reg Dst;
+  switch (OpSize) {
+  case 4:
+    Src = GetSrc<RA_32>(Op->Src.ID());
+    Dst = GetDst<RA_32>(Node);
+    break;
+  case 8:
+    Src = GetSrc<RA_64>(Op->Src.ID());
+    Dst = GetDst<RA_64>(Node);
+    break;
+  default:  LOGMAN_MSG_A_FMT("Unhandled Abs size: {}", OpSize);
+    break;
+  }
+  mov(Dst, Src);
+  mov(TMP1, Src);
+  neg(Dst);
+  cmovs(Dst, TMP1);
+}
+
 DEF_OP(Mul) {
   auto Op = IROp->C<IR::IROp_Mul>();
   const uint8_t OpSize = IROp->Size;
@@ -1298,6 +1322,7 @@ void X86JITCore::RegisterALUHandlers() {
   REGISTER_OP(ADD,               Add);
   REGISTER_OP(SUB,               Sub);
   REGISTER_OP(NEG,               Neg);
+  REGISTER_OP(ABS,               Abs);
   REGISTER_OP(MUL,               Mul);
   REGISTER_OP(UMUL,              UMul);
   REGISTER_OP(DIV,               Div);

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -245,6 +245,7 @@ private:
   DEF_OP(Add);
   DEF_OP(Sub);
   DEF_OP(Neg);
+  DEF_OP(Abs);
   DEF_OP(Mul);
   DEF_OP(UMul);
   DEF_OP(Div);

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
@@ -171,12 +171,14 @@ void OpDispatchBuilder::FILD(OpcodeArgs) {
   auto zero = _Constant(0);
 
   // Sign extend to 64bits
-  if (read_width != 8)
+  if (read_width != 8) {
     data = _Sext(read_width * 8, data);
+  }
 
   // Extract sign and make interger absolute
   auto sign = _Select(COND_SLT, data, zero, _Constant(0x8000), zero);
-  auto absolute =  _Select(COND_SLT, data, zero, _Sub(zero, data), data);
+
+  auto absolute = _Abs(data);
 
   // left justify the absolute interger
   auto shift = _Sub(_Constant(63), _FindMSB(absolute));

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -717,6 +717,13 @@
                 ],
         "DestSize": "std::max<uint8_t>(4, GetOpSize(_Src))"
       },
+      "GPR = Abs GPR:$Src": {
+        "Desc": ["Integer 2's complement absolute value",
+                 "Dest = std::abs(Src)",
+                 "Will truncate to 64 or 32bits"
+                ],
+        "DestSize": "std::max<uint8_t>(4, GetOpSize(_Src))"
+      },
       "GPR = Not GPR:$Src": {
         "Desc": ["Integer binary not",
                  "op:",

--- a/External/FEXCore/include/FEXCore/Core/HostFeatures.h
+++ b/External/FEXCore/include/FEXCore/Core/HostFeatures.h
@@ -29,6 +29,7 @@ class HostFeatures final {
     bool SupportsBMI2{};
     bool SupportsCLWB{};
     bool SupportsPMULL_128Bit{};
+    bool SupportsCSSC{};
 
     // Float exception behaviour
     bool SupportsFlushInputsToZero{};

--- a/External/FEXCore/unittests/Emitter/ALU_Tests.cpp
+++ b/External/FEXCore/unittests/Emitter/ALU_Tests.cpp
@@ -1690,6 +1690,8 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: ALU: Conditional select") {
   TEST_SINGLE(csinv(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, Condition::CC_EQ), "csinv x29, x28, x27, eq");
   TEST_SINGLE(csneg(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, Condition::CC_EQ), "csneg w29, w28, w27, eq");
   TEST_SINGLE(csneg(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, Condition::CC_EQ), "csneg x29, x28, x27, eq");
+  TEST_SINGLE(cneg(Size::i32Bit, Reg::r29, Reg::r28, Condition::CC_EQ), "cneg w29, w28, eq");
+  TEST_SINGLE(cneg(Size::i64Bit, Reg::r29, Reg::r28, Condition::CC_EQ), "cneg x29, x28, eq");
 
   TEST_SINGLE(csel(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, Condition::CC_AL), "csel w29, w28, w27, al");
   TEST_SINGLE(csel(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, Condition::CC_AL), "csel x29, x28, x27, al");
@@ -1701,6 +1703,8 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: ALU: Conditional select") {
   TEST_SINGLE(csinv(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, Condition::CC_AL), "csinv x29, x28, x27, al");
   TEST_SINGLE(csneg(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, Condition::CC_AL), "csneg w29, w28, w27, al");
   TEST_SINGLE(csneg(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, Condition::CC_AL), "csneg x29, x28, x27, al");
+  TEST_SINGLE(cneg(Size::i32Bit, Reg::r29, Reg::r28, Condition::CC_AL), "csneg w29, w28, w28, nv");
+  TEST_SINGLE(cneg(Size::i64Bit, Reg::r29, Reg::r28, Condition::CC_AL), "csneg x29, x28, x28, nv");
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: ALU: Data processing - 3 source") {
   TEST_SINGLE(madd(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, Reg::r26), "madd w29, w28, w27, w26");


### PR DESCRIPTION
Removes one instruction from FILD, or two instructions if the CPU
supports the CSSC extension.

Going from 47 instructions to 46/45.