### PR TITLE
Arm64: Optimize {Load,Store}ContextIndexed address generation

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -172,6 +172,17 @@ jobs:
       working-directory: ${{runner.workspace}}/build
       run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_APITests.log || true
 
+    - name: FEXCore APITest tests
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      run: cmake --build . --config $BUILD_TYPE --target fexcore_apitests
+
+    - name: FEXCore APITest Test Results move
+      if: ${{ always() }}
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_FEXCoreAPITests.log || true
+
     - name: ARMEmitter tests
       working-directory: ${{runner.workspace}}/build
       shell: bash

--- a/.github/workflows/glibc_fault.yml
+++ b/.github/workflows/glibc_fault.yml
@@ -157,6 +157,17 @@ jobs:
       working-directory: ${{runner.workspace}}/build
       run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_APITests.log || true
 
+    - name: FEXCore APITest tests
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      run: cmake --build . --config $BUILD_TYPE --target fexcore_apitests
+
+    - name: FEXCore APITest Test Results move
+      if: ${{ always() }}
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_FEXCoreAPITests.log || true
+
     - name: FEXLinuxTests
       working-directory: ${{runner.workspace}}/build
       shell: bash

--- a/External/FEXCore/include/FEXCore/Utils/MathUtils.h
+++ b/External/FEXCore/include/FEXCore/Utils/MathUtils.h
@@ -1,6 +1,10 @@
 #pragma once
 
+#include <FEXCore/Utils/LogManager.h>
+
+#include <bit>
 #include <cstdint>
+#include <type_traits>
 
 namespace FEXCore {
 [[nodiscard]] constexpr uint64_t AlignUp(uint64_t value, uint64_t size) {
@@ -10,4 +14,14 @@ namespace FEXCore {
 [[nodiscard]] constexpr uint64_t AlignDown(uint64_t value, uint64_t size) {
   return value - value % size;
 }
+
+// Returns the ilog2 of a power-of-2 integer.
+// Asserts in the case that the passed in integer is not a power-of-2.
+template<typename T>
+requires(std::is_unsigned_v<T>)
+[[nodiscard]] constexpr T ilog2(T Value) {
+  LOGMAN_THROW_A_FMT(std::has_single_bit(Value), "ilog2 requires popcount to be one");
+  return std::countr_zero(Value);
+}
+
 } // namespace FEXCore

--- a/External/FEXCore/unittests/APITests/CMakeLists.txt
+++ b/External/FEXCore/unittests/APITests/CMakeLists.txt
@@ -1,0 +1,21 @@
+file(GLOB_RECURSE TESTS CONFIGURE_DEPENDS *.cpp)
+
+set (LIBS fmt::fmt vixl Catch2::Catch2WithMain FEXCore_Base)
+foreach(TEST ${TESTS})
+  get_filename_component(TEST_NAME ${TEST} NAME_WLE)
+  add_executable(FEXCore_Tests_${TEST_NAME} ${TEST})
+  target_link_libraries(FEXCore_Tests_${TEST_NAME} PRIVATE ${LIBS})
+  target_include_directories(FEXCore_Tests_${TEST_NAME} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../../Source/")
+  set_target_properties(FEXCore_Tests_${TEST_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/FEXCore_Tests")
+  catch_discover_tests(FEXCore_Tests_${TEST_NAME} TEST_SUFFIX ".${TEST_NAME}.FEXCore_Tests")
+endforeach()
+
+execute_process(COMMAND "nproc" OUTPUT_VARIABLE CORES)
+string(STRIP ${CORES} CORES)
+
+add_custom_target(
+  fexcore_apitests
+  WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/"
+  USES_TERMINAL
+  COMMAND "ctest" "--timeout" "302" "-j${CORES}" "-R" "\.*.FEXCore_Tests$$")
+

--- a/External/FEXCore/unittests/APITests/ILog2.cpp
+++ b/External/FEXCore/unittests/APITests/ILog2.cpp
@@ -1,0 +1,7 @@
+#include <FEXCore/Utils/MathUtils.h>
+#include <catch2/catch.hpp>
+
+TEST_CASE("ILog2") {
+  auto i = GENERATE(range(0, 64));
+  REQUIRE(FEXCore::ilog2(1ull << i) == i);
+}

--- a/External/FEXCore/unittests/CMakeLists.txt
+++ b/External/FEXCore/unittests/CMakeLists.txt
@@ -1,3 +1,5 @@
 if (NOT MINGW_BUILD)
   add_subdirectory(Emitter/)
 endif()
+
+add_subdirectory(APITests/)


### PR DESCRIPTION
All of these IR operations were being fairly inefficient in their address calculation. All of these are known using power of 2 stride indexing. So all of these can be converted from three instructions to one.

These are always used for x87 stack accesses so each one gets an improvement.

Before:
```asm
0x0000ffff6a800248  d2800200    mov x0, #0x10
0x0000ffff6a80024c  9b007e80    mul x0, x20, x0
0x0000ffff6a800250  8b000380    add x0, x28, x0
0x0000ffff6a800254  fd417805    ldr d5, [x0, #752]
```

After:
```asm
0x0000ffff91e80240  8b141380    add x0, x28, x20, lsl #4
0x0000ffff91e80244  fd417805    ldr d5, [x0, #752]
```