### PR TITLE
FEXCore/Config: Adds support for enum mask configuration array

### DIFF
--- a/External/FEXCore/Source/Interface/Config/Config.cpp
+++ b/External/FEXCore/Source/Interface/Config/Config.cpp
@@ -1,5 +1,6 @@
 #include "Common/StringConv.h"
 #include "Common/StringUtils.h"
+#include "FEXCore/Utils/EnumUtils.h"
 
 #include <FEXCore/Config/Config.h>
 #include <FEXCore/Utils/Allocator.h>
@@ -37,6 +38,7 @@ namespace DefaultValues {
 #define OPT_BASE(type, group, enum, json, default) const P(type) P(enum) = P(default);
 #define OPT_STR(group, enum, json, default) const std::string_view P(enum) = P(default);
 #define OPT_STRARRAY(group, enum, json, default) OPT_STR(group, enum, json, default)
+#define OPT_STRENUM(group, enum, json, default) const uint64_t P(enum) = FEXCore::ToUnderlying(P(default));
 #include <FEXCore/Config/ConfigValues.inl>
 }
 

--- a/External/FEXCore/Source/Interface/Config/Config.json.in
+++ b/External/FEXCore/Source/Interface/Config/Config.json.in
@@ -251,6 +251,20 @@
           "Set this in an application configuration for injecting in to only specific applications.",
           "\tNote: If x86/x86_64 libSegFault.so isn't installed then this option won't work."
         ]
+      },
+      "Disassemble": {
+        "Type": "strenum",
+        "Default": "FEXCore::Config::Disassemble::OFF",
+        "Enums": {
+          "DISPATCHER": "dispatcher",
+          "BLOCKS": "blocks"
+        },
+        "Desc": [
+          "Allows controlling of the vixl disassembler.",
+          "\toff: No disassembly will be output",
+          "\tdispatcher: Will enable disassembly of the JIT dispatcher loop",
+          "\tblocks: Will enable disassembly of the translated instruction code blocks"
+        ]
       }
     },
     "Logging": {

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
@@ -175,6 +175,7 @@ protected:
 #endif
 #ifdef VIXL_DISASSEMBLER
   vixl::aarch64::PrintDisassembler Disasm {stderr};
+  FEX_CONFIG_OPT(Disassemble, DISASSEMBLE);
 #endif
   FEX_CONFIG_OPT(StaticRegisterAllocation, SRA);
 };

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
@@ -503,8 +503,10 @@ void Arm64Dispatcher::EmitDispatcher() {
   }
 
 #ifdef VIXL_DISASSEMBLER
-  const auto DisasmEnd = GetCursorAddress<const vixl::aarch64::Instruction*>();
-  Disasm.DisassembleBuffer(DisasmBegin, DisasmEnd);
+  if (Disassemble() & FEXCore::Config::Disassemble::DISPATCHER) {
+    const auto DisasmEnd = GetCursorAddress<const vixl::aarch64::Instruction*>();
+    Disasm.DisassembleBuffer(DisasmBegin, DisasmEnd);
+  }
 #endif
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -1142,8 +1142,10 @@ CPUBackend::CompiledCode Arm64JITCore::CompileCode(uint64_t Entry,
   ClearICache(CodeData.BlockBegin, CodeOnlySize);
 
 #ifdef VIXL_DISASSEMBLER
-  const auto DisasmEnd = reinterpret_cast<const vixl::aarch64::Instruction*>(JITBlockTailLocation);
-  Disasm.DisassembleBuffer(DisasmBegin, DisasmEnd);
+  if (Disassemble() & FEXCore::Config::Disassemble::BLOCKS) {
+    const auto DisasmEnd = reinterpret_cast<const vixl::aarch64::Instruction*>(JITBlockTailLocation);
+    Disasm.DisassembleBuffer(DisasmBegin, DisasmEnd);
+  }
 #endif
 
   if (DebugData) {

--- a/Source/Tools/FEXConfig/Main.cpp
+++ b/Source/Tools/FEXConfig/Main.cpp
@@ -1,6 +1,7 @@
 #include "Common/Config.h"
 #include "Common/FileFormatCheck.h"
 #include "FEXCore/Config/Config.h"
+#include "FEXCore/Utils/EnumUtils.h"
 #include "Tools/CommonGUI/IMGui.h"
 
 #include <FEXCore/Utils/Event.h>
@@ -75,6 +76,8 @@ namespace {
 #define OPT_STR(group, enum, json, default) \
     LoadedConfig->Set(FEXCore::Config::ConfigOption::CONFIG_##enum, default);
 #define OPT_STRARRAY(group, enum, json, default)  // Do nothing
+#define OPT_STRENUM(group, enum, json, default) \
+    LoadedConfig->Set(FEXCore::Config::ConfigOption::CONFIG_##enum, std::to_string(FEXCore::ToUnderlying(default)));
 #include <FEXCore/Config/ConfigValues.inl>
 
     // Erase unnamed options which shouldn't be set
@@ -108,6 +111,8 @@ namespace {
 #define OPT_STR(group, enum, json, default) \
     if (!LoadedConfig->OptionExists(FEXCore::Config::ConfigOption::CONFIG_##enum)) { LoadedConfig->EraseSet(FEXCore::Config::ConfigOption::CONFIG_##enum, default); }
 #define OPT_STRARRAY(group, enum, json, default)  // Do nothing
+#define OPT_STRENUM(group, enum, json, default) \
+    if (!LoadedConfig->OptionExists(FEXCore::Config::ConfigOption::CONFIG_##enum)) { LoadedConfig->EraseSet(FEXCore::Config::ConfigOption::CONFIG_##enum, std::to_string(FEXCore::ToUnderlying(default))); }
 #include <FEXCore/Config/ConfigValues.inl>
 
     // Erase unnamed options which shouldn't be set


### PR DESCRIPTION
Allows us to consume an array of strings and convert it to an mask of enum values. This is a quality of life change that allows us to specify a mask of options.

The first configuration option added to support this is to control the vixl disassembler. Now by default the vixl disassembler doesn't disassemble any blocks and needs to be enabled individually.

eg:
```
FEXLoader --disassemble=blocks <args>
FEXLoader --disassemble=dispatcher <args>
FEXLoader --disassemble=blocks,dispatcher <args>
```

Has the additional convenience option of just passing in numbers as well.

```
FEXLoader --disassemble=2 <args>
FEXLoader --disassemble=1 <args>
FEXLoader --disassemble=3 <args>
```

Also of course all of this works through environment variables.
```
FEX_DISASSEMBLE=blocks FEXInterpreter <args>
FEX_DISASSEMBLE=dispatcher FEXInterpreter <args>
FEX_DISASSEMBLE=blocks,dispatcher FEXInterpreter <args>
```

While only used fairly sparingly now, this is likely to have some additional configurations using this in the future. Since we already have some configs that are basically using enums, but just by doing string comparisons.

This was asked for by a developer, so I figured I would throw it together quick.