### PR TITLE
Arm64/Emitter: Handle ST1{*} scatter store variants

### DIFF
--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
@@ -3008,8 +3008,8 @@ public:
     }
   }
 
-  template<FEXCore::ARMEmitter::SubRegSize size>
-  void st1b(FEXCore::ARMEmitter::ZRegister zt, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::SVEMemOperand Src) {
+  template<SubRegSize size>
+  void st1b(ZRegister zt, PRegister pg, SVEMemOperand Src) {
     if (Src.IsScalarPlusScalar()) {
       st1b<size>(zt, pg, Src.rn, Src.MetaType.ScalarScalarType.rm);
     }
@@ -3017,7 +3017,7 @@ public:
       st1b<size>(zt, pg, Src.rn, Src.MetaType.ScalarImmType.Imm);
     }
     else if (Src.IsScalarPlusVector()) {
-      LOGMAN_THROW_A_FMT(false, "Not yet implemented");
+      SVEScatterStoreScalarPlusVector(size, SubRegSize::i8Bit, zt, pg, Src);
     }
     else if (Src.IsVectorPlusImm()) {
       LOGMAN_THROW_A_FMT(false, "Not yet implemented");
@@ -3027,8 +3027,8 @@ public:
     }
   }
 
-  template<FEXCore::ARMEmitter::SubRegSize size>
-  void st1h(FEXCore::ARMEmitter::ZRegister zt, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::SVEMemOperand Src) {
+  template<SubRegSize size>
+  void st1h(ZRegister zt, PRegister pg, SVEMemOperand Src) {
     if (Src.IsScalarPlusScalar()) {
       st1h<size>(zt, pg, Src.rn, Src.MetaType.ScalarScalarType.rm);
     }
@@ -3036,7 +3036,7 @@ public:
       st1h<size>(zt, pg, Src.rn, Src.MetaType.ScalarImmType.Imm);
     }
     else if (Src.IsScalarPlusVector()) {
-      LOGMAN_THROW_A_FMT(false, "Not yet implemented");
+      SVEScatterStoreScalarPlusVector(size, SubRegSize::i16Bit, zt, pg, Src);
     }
     else if (Src.IsVectorPlusImm()) {
       LOGMAN_THROW_A_FMT(false, "Not yet implemented");
@@ -3046,8 +3046,8 @@ public:
     }
   }
 
-  template<FEXCore::ARMEmitter::SubRegSize size>
-  void st1w(FEXCore::ARMEmitter::ZRegister zt, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::SVEMemOperand Src) {
+  template<SubRegSize size>
+  void st1w(ZRegister zt, PRegister pg, SVEMemOperand Src) {
     if (Src.IsScalarPlusScalar()) {
       st1w<size>(zt, pg, Src.rn, Src.MetaType.ScalarScalarType.rm);
     }
@@ -3055,7 +3055,7 @@ public:
       st1w<size>(zt, pg, Src.rn, Src.MetaType.ScalarImmType.Imm);
     }
     else if (Src.IsScalarPlusVector()) {
-      LOGMAN_THROW_A_FMT(false, "Not yet implemented");
+      SVEScatterStoreScalarPlusVector(size, SubRegSize::i32Bit, zt, pg, Src);
     }
     else if (Src.IsVectorPlusImm()) {
       LOGMAN_THROW_A_FMT(false, "Not yet implemented");
@@ -3065,7 +3065,7 @@ public:
     }
   }
 
-  void st1d(FEXCore::ARMEmitter::ZRegister zt, FEXCore::ARMEmitter::PRegister pg, FEXCore::ARMEmitter::SVEMemOperand Src) {
+  void st1d(ZRegister zt, PRegister pg, SVEMemOperand Src) {
     if (Src.IsScalarPlusScalar()) {
       st1d(zt, pg, Src.rn, Src.MetaType.ScalarScalarType.rm);
     }
@@ -3073,7 +3073,7 @@ public:
       st1d(zt, pg, Src.rn, Src.MetaType.ScalarImmType.Imm);
     }
     else if (Src.IsScalarPlusVector()) {
-      LOGMAN_THROW_A_FMT(false, "Not yet implemented");
+      SVEScatterStoreScalarPlusVector(SubRegSize::i64Bit, SubRegSize::i64Bit, zt, pg, Src);
     }
     else if (Src.IsVectorPlusImm()) {
       LOGMAN_THROW_A_FMT(false, "Not yet implemented");
@@ -3276,21 +3276,7 @@ public:
   // SVE store multiple structures (scalar plus scalar)
   // XXX:
 
-  // SVE Memory - Scatter with Optional Sign Extend
-  // SVE 64-bit scatter store (scalar plus unpacked 32-bit unscaled offsets)
-  // XXX:
-  // SVE 64-bit scatter store (scalar plus unpacked 32-bit scaled offsets)
-  // XXX:
-  // SVE 32-bit scatter store (scalar plus 32-bit unscaled offsets)
-  // XXX:
-  // SVE 32-bit scatter store (scalar plus 32-bit scaled offsets)
-  // XXX:
-
   // SVE Memory - Scatter
-  // SVE 64-bit scatter store (scalar plus 64-bit unscaled offsets)
-  // XXX:
-  // SVE 64-bit scatter store (scalar plus 64-bit scaled offsets)
-  // XXX:
   // SVE 64-bit scatter store (vector plus immediate)
   // XXX:
   // SVE 32-bit scatter store (vector plus immediate)
@@ -4122,6 +4108,75 @@ private:
     Instr |= op_data.zm.Idx() << 16;
     Instr |= static_cast<uint32_t>(is_unsigned) << 14;
     Instr |= static_cast<uint32_t>(is_fault_first) << 13;
+    Instr |= pg.Idx() << 10;
+    Instr |= mem_op.rn.Idx() << 5;
+    Instr |= zt.Idx();
+
+    dc32(Instr);
+  }
+
+  void SVEScatterStoreScalarPlusVector(SubRegSize esize, SubRegSize msize, ZRegister zt, PRegister pg, SVEMemOperand mem_op) {
+    LOGMAN_THROW_A_FMT(esize == SubRegSize::i32Bit || esize == SubRegSize::i64Bit,
+                       "Gather load element size must be 32-bit or 64-bit");
+    LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
+
+    const auto& op_data = mem_op.MetaType.ScalarVectorType;
+    const bool is_scaled = op_data.scale != 0;
+
+    const auto msize_value = FEXCore::ToUnderlying(msize);
+    uint32_t mod_value = FEXCore::ToUnderlying(op_data.mod);
+
+    LOGMAN_THROW_A_FMT(op_data.scale == 0 || op_data.scale == msize_value,
+                       "scale may only be 0 or {}", msize_value);
+
+    uint32_t Instr = 0b1110'0100'0000'0000'1000'0000'0000'0000;
+
+    if (esize == SubRegSize::i64Bit) {
+      const auto mod = op_data.mod;
+      const bool is_lsl = mod == SVEMemOperand::ModType::MOD_LSL;
+      const bool is_none = mod == SVEMemOperand::ModType::MOD_NONE;
+
+      if (is_lsl || is_none) {
+        if (is_lsl) {
+          LOGMAN_THROW_A_FMT(op_data.scale == msize_value,
+                             "mod type of LSL must have a scale of {}", msize_value);
+        } else {
+          LOGMAN_THROW_A_FMT(op_data.scale == 0,
+                             "mod type of none must have a scale of 0");
+        }
+        if (is_lsl || is_scaled) {
+          LOGMAN_THROW_A_FMT(msize != SubRegSize::i8Bit,
+                           "Cannot use 8-bit store elements with unpacked 32-bit scaled offset and "
+                           "64-bit scaled offset variants. Instructions not allocated.");
+        }
+
+        // 64-bit scaled/unscaled scatters need to set bit 13
+        Instr |= 1U << 13;
+        mod_value = 0;
+      }
+    } else {
+      if (is_scaled) {
+        LOGMAN_THROW_A_FMT(msize != SubRegSize::i8Bit && msize != SubRegSize::i64Bit,
+                           "Cannot use 8-bit or 64-bit store elements with 32-bit scaled offset variant. "
+                           "Instructions not allocated");
+      } else {
+        LOGMAN_THROW_A_FMT(msize != SubRegSize::i64Bit,
+                           "Cannot use 64-bit store elements with 32-bit unscaled offset variant. "
+                           "Instruction not allocated.");
+      }
+
+      LOGMAN_THROW_A_FMT(op_data.mod == SVEMemOperand::ModType::MOD_UXTW ||
+                         op_data.mod == SVEMemOperand::ModType::MOD_SXTW,
+                         "mod type for 32-bit lane size may only be UXTW or SXTW");
+
+      // 32-bit scatters need to set bit 22.
+      Instr |= 1U << 22;
+    }
+
+    Instr |= msize_value << 23;
+    Instr |= static_cast<uint32_t>(is_scaled) << 21;
+    Instr |= op_data.zm.Idx() << 16;
+    Instr |= static_cast<uint32_t>(mod_value) << 14;
     Instr |= pg.Idx() << 10;
     Instr |= mem_op.rn.Idx() << 5;
     Instr |= zt.Idx();

--- a/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
+++ b/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
@@ -4006,3 +4006,105 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE contiguous store (scalar p
   TEST_SINGLE(st1d(ZReg::z26, PReg::p6, Reg::r29, -8), "st1d {z26.d}, p6, [x29, #-8, mul vl]");
   TEST_SINGLE(st1d(ZReg::z26, PReg::p6, Reg::r29, 7), "st1d {z26.d}, p6, [x29, #7, mul vl]");
 }
+
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE Scatters") {
+  TEST_SINGLE(st1b<SubRegSize::i32Bit>(ZReg::z30, PReg::p6,
+                                       SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_UXTW, 0)),
+                                       "st1b {z30.s}, p6, [x30, z31.s, uxtw]");
+  TEST_SINGLE(st1b<SubRegSize::i32Bit>(ZReg::z30, PReg::p6,
+                                       SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_SXTW, 0)),
+                                       "st1b {z30.s}, p6, [x30, z31.s, sxtw]");
+  TEST_SINGLE(st1b<SubRegSize::i64Bit>(ZReg::z30, PReg::p6,
+                                       SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_UXTW, 0)),
+                                       "st1b {z30.d}, p6, [x30, z31.d, uxtw]");
+  TEST_SINGLE(st1b<SubRegSize::i64Bit>(ZReg::z30, PReg::p6,
+                                       SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_SXTW, 0)),
+                                       "st1b {z30.d}, p6, [x30, z31.d, sxtw]");
+  TEST_SINGLE(st1b<SubRegSize::i64Bit>(ZReg::z30, PReg::p6,
+                                       SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_NONE, 0)),
+                                       "st1b {z30.d}, p6, [x30, z31.d]");
+
+  TEST_SINGLE(st1h<SubRegSize::i32Bit>(ZReg::z30, PReg::p6,
+                                       SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_UXTW, 1)),
+                                       "st1h {z30.s}, p6, [x30, z31.s, uxtw #1]");
+  TEST_SINGLE(st1h<SubRegSize::i32Bit>(ZReg::z30, PReg::p6,
+                                       SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_SXTW, 1)),
+                                       "st1h {z30.s}, p6, [x30, z31.s, sxtw #1]");
+  TEST_SINGLE(st1h<SubRegSize::i64Bit>(ZReg::z30, PReg::p6,
+                                       SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_UXTW, 1)),
+                                       "st1h {z30.d}, p6, [x30, z31.d, uxtw #1]");
+  TEST_SINGLE(st1h<SubRegSize::i64Bit>(ZReg::z30, PReg::p6,
+                                       SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_SXTW, 1)),
+                                       "st1h {z30.d}, p6, [x30, z31.d, sxtw #1]");
+  TEST_SINGLE(st1h<SubRegSize::i64Bit>(ZReg::z30, PReg::p6,
+                                       SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_LSL, 1)),
+                                       "st1h {z30.d}, p6, [x30, z31.d, lsl #1]");
+
+  TEST_SINGLE(st1h<SubRegSize::i32Bit>(ZReg::z30, PReg::p6,
+                                       SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_UXTW, 0)),
+                                       "st1h {z30.s}, p6, [x30, z31.s, uxtw]");
+  TEST_SINGLE(st1h<SubRegSize::i32Bit>(ZReg::z30, PReg::p6,
+                                       SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_SXTW, 0)),
+                                       "st1h {z30.s}, p6, [x30, z31.s, sxtw]");
+  TEST_SINGLE(st1h<SubRegSize::i64Bit>(ZReg::z30, PReg::p6,
+                                       SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_UXTW, 0)),
+                                       "st1h {z30.d}, p6, [x30, z31.d, uxtw]");
+  TEST_SINGLE(st1h<SubRegSize::i64Bit>(ZReg::z30, PReg::p6,
+                                       SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_SXTW, 0)),
+                                       "st1h {z30.d}, p6, [x30, z31.d, sxtw]");
+  TEST_SINGLE(st1h<SubRegSize::i64Bit>(ZReg::z30, PReg::p6,
+                                       SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_NONE, 0)),
+                                       "st1h {z30.d}, p6, [x30, z31.d]");
+
+  TEST_SINGLE(st1w<SubRegSize::i32Bit>(ZReg::z30, PReg::p6,
+                                       SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_UXTW, 2)),
+                                       "st1w {z30.s}, p6, [x30, z31.s, uxtw #2]");
+  TEST_SINGLE(st1w<SubRegSize::i32Bit>(ZReg::z30, PReg::p6,
+                                       SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_SXTW, 2)),
+                                       "st1w {z30.s}, p6, [x30, z31.s, sxtw #2]");
+  TEST_SINGLE(st1w<SubRegSize::i64Bit>(ZReg::z30, PReg::p6,
+                                       SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_UXTW, 2)),
+                                       "st1w {z30.d}, p6, [x30, z31.d, uxtw #2]");
+  TEST_SINGLE(st1w<SubRegSize::i64Bit>(ZReg::z30, PReg::p6,
+                                       SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_SXTW, 2)),
+                                       "st1w {z30.d}, p6, [x30, z31.d, sxtw #2]");
+  TEST_SINGLE(st1w<SubRegSize::i64Bit>(ZReg::z30, PReg::p6,
+                                       SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_LSL, 2)),
+                                       "st1w {z30.d}, p6, [x30, z31.d, lsl #2]");
+
+  TEST_SINGLE(st1w<SubRegSize::i32Bit>(ZReg::z30, PReg::p6,
+                                       SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_UXTW, 0)),
+                                       "st1w {z30.s}, p6, [x30, z31.s, uxtw]");
+  TEST_SINGLE(st1w<SubRegSize::i32Bit>(ZReg::z30, PReg::p6,
+                                       SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_SXTW, 0)),
+                                       "st1w {z30.s}, p6, [x30, z31.s, sxtw]");
+  TEST_SINGLE(st1w<SubRegSize::i64Bit>(ZReg::z30, PReg::p6,
+                                       SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_UXTW, 0)),
+                                       "st1w {z30.d}, p6, [x30, z31.d, uxtw]");
+  TEST_SINGLE(st1w<SubRegSize::i64Bit>(ZReg::z30, PReg::p6,
+                                       SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_SXTW, 0)),
+                                       "st1w {z30.d}, p6, [x30, z31.d, sxtw]");
+  TEST_SINGLE(st1w<SubRegSize::i64Bit>(ZReg::z30, PReg::p6,
+                                       SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_NONE, 0)),
+                                       "st1w {z30.d}, p6, [x30, z31.d]");
+
+  TEST_SINGLE(st1d(ZReg::z30, PReg::p6,
+                   SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_UXTW, 3)),
+                   "st1d {z30.d}, p6, [x30, z31.d, uxtw #3]");
+  TEST_SINGLE(st1d(ZReg::z30, PReg::p6,
+                   SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_SXTW, 3)),
+                   "st1d {z30.d}, p6, [x30, z31.d, sxtw #3]");
+  TEST_SINGLE(st1d(ZReg::z30, PReg::p6,
+                   SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_LSL, 3)),
+                   "st1d {z30.d}, p6, [x30, z31.d, lsl #3]");
+
+  TEST_SINGLE(st1d(ZReg::z30, PReg::p6,
+                   SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_UXTW, 0)),
+                   "st1d {z30.d}, p6, [x30, z31.d, uxtw]");
+  TEST_SINGLE(st1d(ZReg::z30, PReg::p6,
+                   SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_SXTW, 0)),
+                   "st1d {z30.d}, p6, [x30, z31.d, sxtw]");
+  TEST_SINGLE(st1d(ZReg::z30, PReg::p6,
+                   SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_NONE, 0)),
+                   "st1d {z30.d}, p6, [x30, z31.d]");
+}

--- a/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
+++ b/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
@@ -4024,6 +4024,15 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE Scatters") {
                                        SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_NONE, 0)),
                                        "st1b {z30.d}, p6, [x30, z31.d]");
 
+  TEST_SINGLE(st1b<SubRegSize::i32Bit>(ZReg::z30, PReg::p6, SVEMemOperand(ZReg::z31, 0)),
+                                       "st1b {z30.s}, p6, [z31.s]");
+  TEST_SINGLE(st1b<SubRegSize::i32Bit>(ZReg::z30, PReg::p6, SVEMemOperand(ZReg::z31, 31)),
+                                       "st1b {z30.s}, p6, [z31.s, #31]");
+  TEST_SINGLE(st1b<SubRegSize::i64Bit>(ZReg::z30, PReg::p6, SVEMemOperand(ZReg::z31, 0)),
+                                       "st1b {z30.d}, p6, [z31.d]");
+  TEST_SINGLE(st1b<SubRegSize::i64Bit>(ZReg::z30, PReg::p6, SVEMemOperand(ZReg::z31, 31)),
+                                       "st1b {z30.d}, p6, [z31.d, #31]");
+
   TEST_SINGLE(st1h<SubRegSize::i32Bit>(ZReg::z30, PReg::p6,
                                        SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_UXTW, 1)),
                                        "st1h {z30.s}, p6, [x30, z31.s, uxtw #1]");
@@ -4055,6 +4064,15 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE Scatters") {
   TEST_SINGLE(st1h<SubRegSize::i64Bit>(ZReg::z30, PReg::p6,
                                        SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_NONE, 0)),
                                        "st1h {z30.d}, p6, [x30, z31.d]");
+
+  TEST_SINGLE(st1h<SubRegSize::i32Bit>(ZReg::z30, PReg::p6, SVEMemOperand(ZReg::z31, 0)),
+                                       "st1h {z30.s}, p6, [z31.s]");
+  TEST_SINGLE(st1h<SubRegSize::i32Bit>(ZReg::z30, PReg::p6, SVEMemOperand(ZReg::z31, 62)),
+                                       "st1h {z30.s}, p6, [z31.s, #62]");
+  TEST_SINGLE(st1h<SubRegSize::i64Bit>(ZReg::z30, PReg::p6, SVEMemOperand(ZReg::z31, 0)),
+                                       "st1h {z30.d}, p6, [z31.d]");
+  TEST_SINGLE(st1h<SubRegSize::i64Bit>(ZReg::z30, PReg::p6, SVEMemOperand(ZReg::z31, 62)),
+                                       "st1h {z30.d}, p6, [z31.d, #62]");
 
   TEST_SINGLE(st1w<SubRegSize::i32Bit>(ZReg::z30, PReg::p6,
                                        SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_UXTW, 2)),
@@ -4088,6 +4106,15 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE Scatters") {
                                        SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_NONE, 0)),
                                        "st1w {z30.d}, p6, [x30, z31.d]");
 
+  TEST_SINGLE(st1w<SubRegSize::i32Bit>(ZReg::z30, PReg::p6, SVEMemOperand(ZReg::z31, 0)),
+                                       "st1w {z30.s}, p6, [z31.s]");
+  TEST_SINGLE(st1w<SubRegSize::i32Bit>(ZReg::z30, PReg::p6, SVEMemOperand(ZReg::z31, 124)),
+                                       "st1w {z30.s}, p6, [z31.s, #124]");
+  TEST_SINGLE(st1w<SubRegSize::i64Bit>(ZReg::z30, PReg::p6, SVEMemOperand(ZReg::z31, 0)),
+                                       "st1w {z30.d}, p6, [z31.d]");
+  TEST_SINGLE(st1w<SubRegSize::i64Bit>(ZReg::z30, PReg::p6, SVEMemOperand(ZReg::z31, 124)),
+                                       "st1w {z30.d}, p6, [z31.d, #124]");
+
   TEST_SINGLE(st1d(ZReg::z30, PReg::p6,
                    SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_UXTW, 3)),
                    "st1d {z30.d}, p6, [x30, z31.d, uxtw #3]");
@@ -4107,4 +4134,9 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE Scatters") {
   TEST_SINGLE(st1d(ZReg::z30, PReg::p6,
                    SVEMemOperand(XReg::x30, ZReg::z31, SVEMemOperand::ModType::MOD_NONE, 0)),
                    "st1d {z30.d}, p6, [x30, z31.d]");
+
+  TEST_SINGLE(st1d(ZReg::z30, PReg::p6, SVEMemOperand(ZReg::z31, 0)),
+                   "st1d {z30.d}, p6, [z31.d]");
+  TEST_SINGLE(st1d(ZReg::z30, PReg::p6, SVEMemOperand(ZReg::z31, 248)),
+                   "st1d {z30.d}, p6, [z31.d, #248]");
 }


### PR DESCRIPTION
Since we implemented the gather variants, we may as well add the scatters as well for symmetry