### PR TITLE
OpcodeDispatcher: Remove unused member variables and reorganize

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -920,7 +920,7 @@ namespace FEXCore::Context {
 
     IR::IREmitter *IREmitter = Thread->OpDispatcher.get();
 
-    auto ShouldDump = static_cast<ContextImpl*>(Thread->CTX)->Config.DumpIR() != "no" || Thread->OpDispatcher->ShouldDump;
+    auto ShouldDump = static_cast<ContextImpl*>(Thread->CTX)->Config.DumpIR() != "no" || Thread->OpDispatcher->ShouldDumpIR();
     // Debug
     {
       if (ShouldDump) {

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -863,14 +863,14 @@ namespace FEXCore::Context {
 
           if (TableInfo && TableInfo->OpcodeDispatcher) {
             auto Fn = TableInfo->OpcodeDispatcher;
-            Thread->OpDispatcher->HandledLock = false;
+            Thread->OpDispatcher->ResetHandledLock();
             Thread->OpDispatcher->ResetDecodeFailure();
             std::invoke(Fn, Thread->OpDispatcher, DecodedInfo);
             if (Thread->OpDispatcher->HadDecodeFailure()) {
               HadDispatchError = true;
             }
             else {
-              if (Thread->OpDispatcher->HandledLock != IsLocked) {
+              if (Thread->OpDispatcher->HasHandledLock() != IsLocked) {
                 HadDispatchError = true;
                 LogMan::Msg::EFmt("Missing LOCK HANDLER at 0x{:x}{{'{}'}}", Block.Entry + BlockInstructionsLength, TableInfo->Name ?: "UND");
               }

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -4672,8 +4672,6 @@ void OpDispatchBuilder::CreateJumpBlocks(fextl::vector<FEXCore::Frontend::Decode
 void OpDispatchBuilder::BeginFunction(uint64_t RIP, fextl::vector<FEXCore::Frontend::Decoder::DecodedBlocks> const *Blocks) {
   Entry = RIP;
   auto IRHeader = _IRHeader(InvalidNode, 0);
-  Current_Header = IRHeader.first;
-  Current_HeaderNode = IRHeader;
   CreateJumpBlocks(Blocks);
 
   auto Block = GetNewJumpBlock(RIP);

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -61,9 +61,6 @@ public:
     TYPE_RDRAND,
   };
 
-  // Used during new op bringup
-  bool ShouldDump {false};
-
   OrderedNode* GetNewJumpBlock(uint64_t RIP) {
     auto it = JumpTargets.find(RIP);
     LOGMAN_THROW_A_FMT(it != JumpTargets.end(), "Couldn't find block generated for 0x{:x}", RIP);
@@ -161,6 +158,9 @@ public:
 
   void ResetHandledLock() { HandledLock = false; }
   bool HasHandledLock() const { return HandledLock; }
+
+  void SetDumpIR(bool DumpIR) { ShouldDump = DumpIR; }
+  bool ShouldDumpIR() const { return ShouldDump; }
 
   void BeginFunction(uint64_t RIP, fextl::vector<FEXCore::Frontend::Decoder::DecodedBlocks> const *Blocks);
   void Finalize();
@@ -837,6 +837,8 @@ private:
   bool HandledLock{false};
   bool DecodeFailure{false};
   bool NeedsBlockEnd{false};
+  // Used during new op bringup
+  bool ShouldDump{false};
 
   void ALUOpImpl(OpcodeArgs, FEXCore::IR::IROps ALUIROp, FEXCore::IR::IROps AtomicFetchOp, bool RequiresMask);
 

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -80,13 +80,6 @@ public:
   // Used during new op bringup
   bool ShouldDump {false};
 
-  struct JumpTargetInfo {
-    OrderedNode* BlockEntry;
-    bool HaveEmitted;
-  };
-
-  fextl::map<uint64_t, JumpTargetInfo> JumpTargets;
-
   OrderedNode* GetNewJumpBlock(uint64_t RIP) {
     auto it = JumpTargets.find(RIP);
     LOGMAN_THROW_A_FMT(it != JumpTargets.end(), "Couldn't find block generated for 0x{:x}", RIP);
@@ -835,6 +828,12 @@ public:
   void SetMultiblock(bool _Multiblock) { Multiblock = _Multiblock; }
 
 private:
+  struct JumpTargetInfo {
+    OrderedNode* BlockEntry;
+    bool HaveEmitted;
+  };
+
+  fextl::map<uint64_t, JumpTargetInfo> JumpTargets;
   bool HandledLock{false};
   bool DecodeFailure{false};
   bool NeedsBlockEnd{false};

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -61,8 +61,6 @@ public:
     TYPE_RDRAND,
   };
 
-  FEXCore::Context::ContextImpl *CTX{};
-
   // Used during new op bringup
   bool ShouldDump {false};
 
@@ -825,6 +823,8 @@ private:
     OrderedNode* BlockEntry;
     bool HaveEmitted;
   };
+
+  FEXCore::Context::ContextImpl *CTX{};
 
   SelectionFlag flagsOp{};
   uint8_t flagsOpSize{};

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -182,6 +182,9 @@ public:
   bool HadDecodeFailure() const { return DecodeFailure; }
   bool NeedsBlockEnder() const { return NeedsBlockEnd; }
 
+  void ResetHandledLock() { HandledLock = false; }
+  bool HasHandledLock() const { return HandledLock; }
+
   void BeginFunction(uint64_t RIP, fextl::vector<FEXCore::Frontend::Decoder::DecodedBlocks> const *Blocks);
   void Finalize();
 
@@ -831,8 +834,8 @@ public:
 
   void SetMultiblock(bool _Multiblock) { Multiblock = _Multiblock; }
 
-  bool HandledLock = false;
 private:
+  bool HandledLock{false};
   bool DecodeFailure{false};
   bool NeedsBlockEnd{false};
 

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -28,13 +28,6 @@ class OpDispatchBuilder final : public IREmitter {
 friend class FEXCore::IR::Pass;
 friend class FEXCore::IR::PassManager;
 
-enum class SelectionFlag {
-  Nothing,  // must rely on x86 flags
-  CMP,      // flags were set by a CMP between flagsOpDest/flagsOpDestSigned and flagsOpSrc/flagsOpSrcSigned with flagsOpSize size
-  AND,      // flags were set by an AND/TEST, flagsOpDest contains the resulting value of flagsOpSize size
-  FCMP,     // flags were set by a ucomis* / comis*
-};
-
 public:
   enum class FlagsGenerationType : uint8_t {
     TYPE_NONE,
@@ -67,13 +60,6 @@ public:
     TYPE_BITSELECT,
     TYPE_RDRAND,
   };
-
-  SelectionFlag flagsOp{};
-  uint8_t flagsOpSize{};
-  OrderedNode* flagsOpDest{};
-  OrderedNode* flagsOpSrc{};
-  OrderedNode* flagsOpDestSigned{};
-  OrderedNode* flagsOpSrcSigned{};
 
   FEXCore::Context::ContextImpl *CTX{};
 
@@ -828,10 +814,24 @@ public:
   void SetMultiblock(bool _Multiblock) { Multiblock = _Multiblock; }
 
 private:
+  enum class SelectionFlag {
+    Nothing,  // must rely on x86 flags
+    CMP,      // flags were set by a CMP between flagsOpDest/flagsOpDestSigned and flagsOpSrc/flagsOpSrcSigned with flagsOpSize size
+    AND,      // flags were set by an AND/TEST, flagsOpDest contains the resulting value of flagsOpSize size
+    FCMP,     // flags were set by a ucomis* / comis*
+  };
+
   struct JumpTargetInfo {
     OrderedNode* BlockEntry;
     bool HaveEmitted;
   };
+
+  SelectionFlag flagsOp{};
+  uint8_t flagsOpSize{};
+  OrderedNode* flagsOpDest{};
+  OrderedNode* flagsOpSrc{};
+  OrderedNode* flagsOpDestSigned{};
+  OrderedNode* flagsOpSrcSigned{};
 
   fextl::map<uint64_t, JumpTargetInfo> JumpTargets;
   bool HandledLock{false};

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -835,8 +835,6 @@ public:
 private:
   bool DecodeFailure{false};
   bool NeedsBlockEnd{false};
-  FEXCore::IR::IROp_IRHeader *Current_Header{};
-  OrderedNode *Current_HeaderNode{};
 
   void ALUOpImpl(OpcodeArgs, FEXCore::IR::IROps ALUIROp, FEXCore::IR::IROps AtomicFetchOp, bool RequiresMask);
 


### PR DESCRIPTION
Removes two member variables that were only assigned to, but never actually used, and moves all members into the private class section. Almost all of the members were only used internally anyway, and for the few accesses outside of the class, we can just add querying accessors for those.

Has the nice effect of putting most of the members in one place.