### PR TITLE
OpcodeDispatcher: Handle VSIB byte

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Frontend.cpp
+++ b/External/FEXCore/Source/Interface/Core/Frontend.cpp
@@ -242,6 +242,9 @@ void Decoder::DecodeModRM_64(X86Tables::DecodedOperand *Operand, X86Tables::ModR
     {
       // If we have a VSIB byte (as opposed to SIB), then the index register is a vector.
       const bool IsIndexVector = (DecodeInst->TableInfo->Flags & InstFlags::FLAGS_VEX_VSIB) != 0;
+      if (IsIndexVector) {
+        DecodeInst->Flags |= X86Tables::DecodeFlags::FLAG_VSIB_BYTE;
+      }
 
       const uint8_t IndexREX = (DecodeInst->Flags & DecodeFlags::FLAG_REX_XGPR_X) != 0 ? 1 : 0;
       const uint8_t BaseREX = (DecodeInst->Flags & DecodeFlags::FLAG_REX_XGPR_B) != 0 ? 1 : 0;

--- a/External/FEXCore/Source/Interface/Core/X86Tables/X86Tables.h
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/X86Tables.h
@@ -25,7 +25,7 @@ constexpr uint32_t FLAG_ADDRESS_SIZE  = (1 << 1);
 constexpr uint32_t FLAG_LOCK          = (1 << 2);
 constexpr uint32_t FLAG_LEGACY_PREFIX = (1 << 3);
 constexpr uint32_t FLAG_REX_PREFIX    = (1 << 4);
-// Hole where 1 << 5 is
+constexpr uint32_t FLAG_VSIB_BYTE     = (1 << 5);
 // Hole where 1 << 6 is
 constexpr uint32_t FLAG_REX_WIDENING  = (1 << 7);
 constexpr uint32_t FLAG_REX_XGPR_B    = (1 << 8);


### PR DESCRIPTION
Ensures that we handle the AVX2 VSIB byte in a decent way.

As is, we can't compute the [index * scale] variant portion of the entire address operand, since the scale needs to act on every element of the vector after sign extension.

What we can do though, is compute the base address and add the displacement to it ahead of time though.