### PR TITLE
Thunks: Remove weak symbol definitions

### DIFF
--- a/ThunkLibs/include/common/Host.h
+++ b/ThunkLibs/include/common/Host.h
@@ -16,23 +16,17 @@ $end_info$
 //
 // Note these are statically linked into the FEX executable. The linker hence
 // doesn't know about them when linking thunk libraries. This issue is avoided
-// by declaring the functions as weak symbols. Their implementation in this
-// file serves as a panicking fallback if matching symbols are not found.
+// by declaring the functions as weak symbols.
 namespace FEXCore {
   struct HostToGuestTrampolinePtr;
 
   __attribute__((weak))
   HostToGuestTrampolinePtr*
-  MakeHostTrampolineForGuestFunction(void* HostPacker, uintptr_t GuestTarget, uintptr_t GuestUnpacker) {
-    fprintf(stderr, "Failed to load %s from FEX executable\n", __FUNCTION__);
-    std::abort();
-  }
+  MakeHostTrampolineForGuestFunction(void* HostPacker, uintptr_t GuestTarget, uintptr_t GuestUnpacker);
+
   __attribute__((weak))
   HostToGuestTrampolinePtr*
-  FinalizeHostTrampolineForGuestFunction(HostToGuestTrampolinePtr*, void* HostPacker) {
-    fprintf(stderr, "Failed to load %s from FEX executable\n", __FUNCTION__);
-    std::abort();
-  }
+  FinalizeHostTrampolineForGuestFunction(HostToGuestTrampolinePtr*, void* HostPacker);
 }
 
 template<typename Fn>


### PR DESCRIPTION
Fixes #2754

These panicking fallbacks are at times not ending up in as plt calls for some reason that I haven't been able to reproduce locally.

So far the only way I can reproduce is building with Canonical's PPA build system, since rebuilding locally didn't resolve the issue.

This will change the failure mode from these panicking asserts happening at call time, to dlopen failing during relocation when loading the thunk. Which LD_DEBUG=all can be used for debugging relocation failure in that case.