### PR TITLE
Arm64/Emitter: Handle SVE XAR

### DIFF
--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
@@ -857,6 +857,20 @@ public:
     SVEBitwiseLogicalUnpredicated(0b11, zm, zn, zd);
   }
 
+  void xar(SubRegSize size, ZRegister zd, ZRegister zm, uint32_t rotate) {
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i128Bit, "Element size cannot be 128-bit.");
+
+    const auto [tszh, tszl, imm3] = EncodeSVEShiftImmediate(size, rotate);
+
+    uint32_t Inst = 0b0000'0100'0010'0000'0011'0100'0000'0000;
+    Inst |= tszh << 22;
+    Inst |= tszl << 19;
+    Inst |= imm3 << 16;
+    Inst |= zm.Idx() << 5;
+    Inst |= zd.Idx();
+    dc32(Inst);
+  }
+
   // SVE2 bitwise ternary operations
   void eor3(FEXCore::ARMEmitter::ZRegister zd, FEXCore::ARMEmitter::ZRegister zdn, FEXCore::ARMEmitter::ZRegister zm, FEXCore::ARMEmitter::ZRegister zk) {
     LOGMAN_THROW_A_FMT(zd == zdn, "Dest needs to equal zdn");

--- a/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
+++ b/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
@@ -911,6 +911,15 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE bitwise logical operations
   TEST_SINGLE(mov(ZReg::z30, ZReg::z29), "mov z30.d, z29.d");
   TEST_SINGLE(eor(ZReg::z30, ZReg::z29, ZReg::z28), "eor z30.d, z29.d, z28.d");
   TEST_SINGLE(bic(ZReg::z30, ZReg::z29, ZReg::z28), "bic z30.d, z29.d, z28.d");
+
+  TEST_SINGLE(xar(SubRegSize::i8Bit,  ZReg::z30, ZReg::z29, 1),  "xar z30.b, z30.b, z29.b, #1");
+  TEST_SINGLE(xar(SubRegSize::i8Bit,  ZReg::z30, ZReg::z29, 8),  "xar z30.b, z30.b, z29.b, #8");
+  TEST_SINGLE(xar(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, 1),  "xar z30.h, z30.h, z29.h, #1");
+  TEST_SINGLE(xar(SubRegSize::i16Bit, ZReg::z30, ZReg::z29, 16), "xar z30.h, z30.h, z29.h, #16");
+  TEST_SINGLE(xar(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, 1),  "xar z30.s, z30.s, z29.s, #1");
+  TEST_SINGLE(xar(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, 32), "xar z30.s, z30.s, z29.s, #32");
+  TEST_SINGLE(xar(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, 1),  "xar z30.d, z30.d, z29.d, #1");
+  TEST_SINGLE(xar(SubRegSize::i64Bit, ZReg::z30, ZReg::z29, 64), "xar z30.d, z30.d, z29.d, #64");
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 bitwise ternary operations") {
   TEST_SINGLE(eor3(ZReg::z30, ZReg::z30, ZReg::z28, ZReg::z29), "eor3 z30.d, z30.d, z28.d, z29.d");


### PR DESCRIPTION
Now that we have the helper for encoding immediate shifts, we can trivially implement the remaining missing instruction in the bitwise logical unpredicated group.