### PR TITLE
Arm64/Emitter: Handle SVE FP arithmetic with immediate (predicated) group

### DIFF
--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/Emitter.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/Emitter.h
@@ -511,6 +511,20 @@ namespace FEXCore::ARMEmitter {
     SVE_ALL   = 0b11111,
   };
 
+  // Used with SVE FP immediate arithmetic instructions
+  enum class SVEFAddSubImm : uint32_t {
+    _0_5,
+    _1_0,
+  };
+  enum class SVEFMulImm : uint32_t {
+    _0_5,
+    _2_0,
+  };
+  enum class SVEFMaxMinImm : uint32_t {
+    _0_0,
+    _1_0,
+  };
+
   /* This `BackwardLabel` struct used for retaining a location for PC-Relative instructions.
    * This is specifically a label for a target that is logically `below` an instruction that uses it.
    * Which means that a branch would jump backwards.

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
@@ -2336,7 +2336,30 @@ public:
   }
 
   // SVE floating-point arithmetic with immediate (predicated)
-  // XXX:
+  void fadd(SubRegSize size, ZRegister zd, PRegisterMerge pg, SVEFAddSubImm imm) {
+    SVEFPArithWithImmediate(0b000, size, zd, pg, FEXCore::ToUnderlying(imm));
+  }
+  void fsub(SubRegSize size, ZRegister zd, PRegisterMerge pg, SVEFAddSubImm imm) {
+    SVEFPArithWithImmediate(0b001, size, zd, pg, FEXCore::ToUnderlying(imm));
+  }
+  void fmul(SubRegSize size, ZRegister zd, PRegisterMerge pg, SVEFMulImm imm) {
+    SVEFPArithWithImmediate(0b010, size, zd, pg, FEXCore::ToUnderlying(imm));
+  }
+  void fsubr(SubRegSize size, ZRegister zd, PRegisterMerge pg, SVEFAddSubImm imm) {
+    SVEFPArithWithImmediate(0b011, size, zd, pg, FEXCore::ToUnderlying(imm));
+  }
+  void fmaxnm(SubRegSize size, ZRegister zd, PRegisterMerge pg, SVEFMaxMinImm imm) {
+    SVEFPArithWithImmediate(0b100, size, zd, pg, FEXCore::ToUnderlying(imm));
+  }
+  void fminnm(SubRegSize size, ZRegister zd, PRegisterMerge pg, SVEFMaxMinImm imm) {
+    SVEFPArithWithImmediate(0b101, size, zd, pg, FEXCore::ToUnderlying(imm));
+  }
+  void fmax(SubRegSize size, ZRegister zd, PRegisterMerge pg, SVEFMaxMinImm imm) {
+    SVEFPArithWithImmediate(0b110, size, zd, pg, FEXCore::ToUnderlying(imm));
+  }
+  void fmin(SubRegSize size, ZRegister zd, PRegisterMerge pg, SVEFMaxMinImm imm) {
+    SVEFPArithWithImmediate(0b111, size, zd, pg, FEXCore::ToUnderlying(imm));
+  }
 
   // SVE Floating Point Unary Operations - Predicated
   // SVE floating-point round to integral value
@@ -3753,6 +3776,20 @@ private:
     Instr |= opc << 10;
     Instr |= zm.Idx() << 16;
     Instr |= zn.Idx() << 5;
+    Instr |= zd.Idx();
+    dc32(Instr);
+  }
+
+  void SVEFPArithWithImmediate(uint32_t opc, SubRegSize size, ZRegister zd, PRegister pg, uint32_t i1) {
+    LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit && size != SubRegSize::i128Bit,
+                       "Can't use 8-bit or 128-bit element size");
+
+    uint32_t Instr = 0b0110'0101'0001'1000'1000'0000'0000'0000;
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= opc << 16;
+    Instr |= pg.Idx() << 10;
+    Instr |= i1 << 5;
     Instr |= zd.Idx();
     dc32(Instr);
   }

--- a/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
+++ b/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
@@ -3093,7 +3093,61 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE floating-point arithmetic 
   //TEST_SINGLE(fdivr(SubRegSize::i128Bit, ZReg::z30, PReg::p6.Merging(), ZReg::z30, ZReg::z28), "fdivr z30.q, p6/m, z30.q, z28.q");
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE floating-point arithmetic with immediate (predicated)") {
-  // TODO: Implement in emitter.
+  TEST_SINGLE(fadd(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), SVEFAddSubImm::_0_5),   "fadd z30.h, p6/m, z30.h, #0.5");
+  TEST_SINGLE(fadd(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), SVEFAddSubImm::_0_5),   "fadd z30.s, p6/m, z30.s, #0.5");
+  TEST_SINGLE(fadd(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), SVEFAddSubImm::_0_5),   "fadd z30.d, p6/m, z30.d, #0.5");
+  TEST_SINGLE(fadd(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), SVEFAddSubImm::_1_0),   "fadd z30.h, p6/m, z30.h, #1.0");
+  TEST_SINGLE(fadd(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), SVEFAddSubImm::_1_0),   "fadd z30.s, p6/m, z30.s, #1.0");
+  TEST_SINGLE(fadd(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), SVEFAddSubImm::_1_0),   "fadd z30.d, p6/m, z30.d, #1.0");
+
+  TEST_SINGLE(fsub(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), SVEFAddSubImm::_0_5),   "fsub z30.h, p6/m, z30.h, #0.5");
+  TEST_SINGLE(fsub(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), SVEFAddSubImm::_0_5),   "fsub z30.s, p6/m, z30.s, #0.5");
+  TEST_SINGLE(fsub(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), SVEFAddSubImm::_0_5),   "fsub z30.d, p6/m, z30.d, #0.5");
+  TEST_SINGLE(fsub(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), SVEFAddSubImm::_1_0),   "fsub z30.h, p6/m, z30.h, #1.0");
+  TEST_SINGLE(fsub(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), SVEFAddSubImm::_1_0),   "fsub z30.s, p6/m, z30.s, #1.0");
+  TEST_SINGLE(fsub(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), SVEFAddSubImm::_1_0),   "fsub z30.d, p6/m, z30.d, #1.0");
+
+  TEST_SINGLE(fsubr(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), SVEFAddSubImm::_0_5),  "fsubr z30.h, p6/m, z30.h, #0.5");
+  TEST_SINGLE(fsubr(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), SVEFAddSubImm::_0_5),  "fsubr z30.s, p6/m, z30.s, #0.5");
+  TEST_SINGLE(fsubr(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), SVEFAddSubImm::_0_5),  "fsubr z30.d, p6/m, z30.d, #0.5");
+  TEST_SINGLE(fsubr(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), SVEFAddSubImm::_1_0),  "fsubr z30.h, p6/m, z30.h, #1.0");
+  TEST_SINGLE(fsubr(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), SVEFAddSubImm::_1_0),  "fsubr z30.s, p6/m, z30.s, #1.0");
+  TEST_SINGLE(fsubr(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), SVEFAddSubImm::_1_0),  "fsubr z30.d, p6/m, z30.d, #1.0");
+
+  TEST_SINGLE(fmul(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), SVEFMulImm::_0_5),      "fmul z30.h, p6/m, z30.h, #0.5");
+  TEST_SINGLE(fmul(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), SVEFMulImm::_0_5),      "fmul z30.s, p6/m, z30.s, #0.5");
+  TEST_SINGLE(fmul(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), SVEFMulImm::_0_5),      "fmul z30.d, p6/m, z30.d, #0.5");
+  TEST_SINGLE(fmul(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), SVEFMulImm::_2_0),      "fmul z30.h, p6/m, z30.h, #2.0");
+  TEST_SINGLE(fmul(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), SVEFMulImm::_2_0),      "fmul z30.s, p6/m, z30.s, #2.0");
+  TEST_SINGLE(fmul(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), SVEFMulImm::_2_0),      "fmul z30.d, p6/m, z30.d, #2.0");
+
+  TEST_SINGLE(fmaxnm(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), SVEFMaxMinImm::_0_0), "fmaxnm z30.h, p6/m, z30.h, #0.0");
+  TEST_SINGLE(fmaxnm(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), SVEFMaxMinImm::_0_0), "fmaxnm z30.s, p6/m, z30.s, #0.0");
+  TEST_SINGLE(fmaxnm(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), SVEFMaxMinImm::_0_0), "fmaxnm z30.d, p6/m, z30.d, #0.0");
+  TEST_SINGLE(fmaxnm(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), SVEFMaxMinImm::_1_0), "fmaxnm z30.h, p6/m, z30.h, #1.0");
+  TEST_SINGLE(fmaxnm(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), SVEFMaxMinImm::_1_0), "fmaxnm z30.s, p6/m, z30.s, #1.0");
+  TEST_SINGLE(fmaxnm(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), SVEFMaxMinImm::_1_0), "fmaxnm z30.d, p6/m, z30.d, #1.0");
+
+  TEST_SINGLE(fminnm(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), SVEFMaxMinImm::_0_0), "fminnm z30.h, p6/m, z30.h, #0.0");
+  TEST_SINGLE(fminnm(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), SVEFMaxMinImm::_0_0), "fminnm z30.s, p6/m, z30.s, #0.0");
+  TEST_SINGLE(fminnm(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), SVEFMaxMinImm::_0_0), "fminnm z30.d, p6/m, z30.d, #0.0");
+  TEST_SINGLE(fminnm(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), SVEFMaxMinImm::_1_0), "fminnm z30.h, p6/m, z30.h, #1.0");
+  TEST_SINGLE(fminnm(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), SVEFMaxMinImm::_1_0), "fminnm z30.s, p6/m, z30.s, #1.0");
+  TEST_SINGLE(fminnm(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), SVEFMaxMinImm::_1_0), "fminnm z30.d, p6/m, z30.d, #1.0");
+
+  TEST_SINGLE(fmax(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), SVEFMaxMinImm::_0_0),   "fmax z30.h, p6/m, z30.h, #0.0");
+  TEST_SINGLE(fmax(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), SVEFMaxMinImm::_0_0),   "fmax z30.s, p6/m, z30.s, #0.0");
+  TEST_SINGLE(fmax(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), SVEFMaxMinImm::_0_0),   "fmax z30.d, p6/m, z30.d, #0.0");
+  TEST_SINGLE(fmax(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), SVEFMaxMinImm::_1_0),   "fmax z30.h, p6/m, z30.h, #1.0");
+  TEST_SINGLE(fmax(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), SVEFMaxMinImm::_1_0),   "fmax z30.s, p6/m, z30.s, #1.0");
+  TEST_SINGLE(fmax(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), SVEFMaxMinImm::_1_0),   "fmax z30.d, p6/m, z30.d, #1.0");
+
+  TEST_SINGLE(fmin(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), SVEFMaxMinImm::_0_0),   "fmin z30.h, p6/m, z30.h, #0.0");
+  TEST_SINGLE(fmin(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), SVEFMaxMinImm::_0_0),   "fmin z30.s, p6/m, z30.s, #0.0");
+  TEST_SINGLE(fmin(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), SVEFMaxMinImm::_0_0),   "fmin z30.d, p6/m, z30.d, #0.0");
+  TEST_SINGLE(fmin(SubRegSize::i16Bit, ZReg::z30, PReg::p6.Merging(), SVEFMaxMinImm::_1_0),   "fmin z30.h, p6/m, z30.h, #1.0");
+  TEST_SINGLE(fmin(SubRegSize::i32Bit, ZReg::z30, PReg::p6.Merging(), SVEFMaxMinImm::_1_0),   "fmin z30.s, p6/m, z30.s, #1.0");
+  TEST_SINGLE(fmin(SubRegSize::i64Bit, ZReg::z30, PReg::p6.Merging(), SVEFMaxMinImm::_1_0),   "fmin z30.d, p6/m, z30.d, #1.0");
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE Memory - 32-bit Gather and Unsized Contiguous") {
   TEST_SINGLE(ld1b<SubRegSize::i32Bit>(ZReg::z30, PReg::p6.Zeroing(),


### PR DESCRIPTION
Pretty straightforward to handle