### PR TITLE
ThunksDB: Adds X11 dependency to XCB

### DIFF
--- a/Data/ThunksDB.json
+++ b/Data/ThunksDB.json
@@ -46,6 +46,9 @@
       ]
     },
     "xcb": {
+      "Depends": [
+        "X11"
+      ],
       "Library": "libxcb-guest.so",
       "Overlay": [
         "@PREFIX_LIB@/libxcb.so",


### PR DESCRIPTION
I was hitting an issue where thunking in Wine+Vulkan applications was breaking unless both OpenGL and Vulkan was enabled.

Turns out this was because Vulkan enabled only XCB, which didn't enable X11. So when XCB is thunked but X11 isn't, this causes weird issues where X11 calls in to XCB functions and gets in desync'ed state. Causing hangs to appear in xcb_take_socket.

Now we can enabled just `Vulkan` as a thunk and it'll work fine.

```
(gdb) bt
#0  syscall () at ../sysdeps/unix/sysv/linux/aarch64/syscall.S:38
#1  0x00007fffe21d3d5c in xcb_take_socket_cb(void*) () from target:/usr/lib/fex-emu/HostThunks//libxcb-host.so
#2  0x00007fffe248b734 in ?? () from target:/lib/aarch64-linux-gnu/libxcb.so.1
#3  0x00007fffe2492e28 in xcb_send_request_with_fds64 () from target:/lib/aarch64-linux-gnu/libxcb.so.1
#4  0x00007fffe249338c in xcb_send_request () from target:/lib/aarch64-linux-gnu/libxcb.so.1
#5  0x00007fffe249c36c in xcb_query_extension () from target:/lib/aarch64-linux-gnu/libxcb.so.1
#6  0x00007fffe24929b0 in ?? () from target:/lib/aarch64-linux-gnu/libxcb.so.1
#7  0x00007fffe2492abc in xcb_get_extension_data () from target:/lib/aarch64-linux-gnu/libxcb.so.1
#8  0x00007fffe2492d04 in xcb_send_request_with_fds64 () from target:/lib/aarch64-linux-gnu/libxcb.so.1
#9  0x00007fffe249338c in xcb_send_request () from target:/lib/aarch64-linux-gnu/libxcb.so.1
#10 0x00007fffc7596ae0 in xcb_randr_query_version () from target:/lib/aarch64-linux-gnu/libxcb-randr.so.0
#11 0x00007fffc79b8128 in wsi_display_output_to_root () from target:/usr/lib/aarch64-linux-gnu/libvulkan_freedreno.so
#12 0x00007fffc79b82b4 in wsi_GetRandROutputDisplayEXT () from target:/usr/lib/aarch64-linux-gnu/libvulkan_freedreno.so
#13 0x00007ffd264e61ac in CallbackUnpack<VkResult (VkPhysicalDevice_T*, _XDisplay*, unsigned long, VkDisplayKHR_T**)>::ForIndirectCall(void*) ()
   from target:/usr/lib/fex-emu/HostThunks//libvulkan-host.so
#14 0x00007ffd23a30024 in ?? ()
```