### PR TITLE
Optimize `xor %eax, %eax`

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -914,18 +914,12 @@ OrderedNode *OpDispatchBuilder::SelectCC(uint8_t OP, OrderedNode *TrueValue, Ord
           Flag, ZeroConst, TrueValue, FalseValue);
       break;
     }
-    case 0xA:   // JP - Jump if PF == 1
+    case 0xA: { // JP - Jump if PF == 1
+      SrcCond = _Select(FEXCore::IR::COND_NEQ, LoadPF(), ZeroConst, TrueValue, FalseValue);
+      break;
+    }
     case 0xB: { // JNP - Jump if PF == 0
-      bool invert = OP == (0xB);
-
-      // We must only consider the bottom bit of PF, the rest is garbage.
-      // For JP, mask off the bottom bit. For JNP, mask off the bottom bit
-      // and invert it. In either case, we return true if that is nonzero.
-      auto PFByte = GetRFLAG(FEXCore::X86State::RFLAG_PF_LOC);
-      auto Flag = _And(OneConst, PFByte);
-
-      SrcCond = _Select(invert ? FEXCore::IR::COND_EQ : FEXCore::IR::COND_NEQ,
-                        Flag, ZeroConst, TrueValue, FalseValue);
+      SrcCond = _Select(FEXCore::IR::COND_EQ, LoadPF(), ZeroConst, TrueValue, FalseValue);
       break;
     }
     case 0xC: { // SF <> OF

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -1157,6 +1157,7 @@ private:
   /**
    * @name These functions are used by the deferred flag handling while it is calculating and storing flags in to RFLAGs.
    * @{ */
+  OrderedNode *LoadPF();
   void CalculatePFUncheckedABI(OrderedNode *Res);
   void CalculatePF(OrderedNode *Res);
 

--- a/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -858,7 +858,25 @@ bool ConstProp::ConstantPropagation(IREmitter *IREmit, const IRListView& Current
       }
       break;
     }
+    case OP_SELECT: {
+      auto Op = IROp->C<IR::IROp_Select>();
+      uint64_t Constant1{};
+      uint64_t Constant2{};
 
+      if (IREmit->IsValueConstant(Op->Header.Args[0], &Constant1) &&
+          IREmit->IsValueConstant(Op->Header.Args[1], &Constant2) &&
+          Op->Cond == COND_EQ) {
+
+        Constant1 &= getMask(Op);
+        Constant2 &= getMask(Op);
+
+        bool is_true = Constant1 == Constant2;
+
+        IREmit->ReplaceAllUsesWith(CodeNode, CurrentIR.GetNode(Op->Header.Args[is_true ? 2 : 3]));
+        Changed = true;
+      }
+      break;
+    }
     case OP_CONDJUMP: {
       auto Op = IROp->CW<IR::IROp_CondJump>();
 

--- a/External/FEXCore/Source/Interface/IR/Passes/LongDivideRemovalPass.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/LongDivideRemovalPass.cpp
@@ -28,11 +28,7 @@ bool LongDivideEliminationPass::IsZeroOp(IREmitter *IREmit, OrderedNodeWrapper A
   auto IROp = IREmit->GetOpHeader(Arg);
   uint64_t Value;
 
-  // XOR based zero
-  if (IROp->Op == OP_XOR) {
-    return IROp->Args[0] == IROp->Args[1];
-  }
-  else if (IREmit->IsValueConstant(Arg, &Value)) {
+  if (IREmit->IsValueConstant(Arg, &Value)) {
     // Zero constant based zero op
     return Value == 0;
   }
@@ -87,8 +83,7 @@ bool LongDivideEliminationPass::Run(IREmitter *IREmit) {
         else if (IROp->Op == OP_LUDIV ||
                  IROp->Op == OP_LUREM) {
           auto Op = IROp->C<IR::IROp_LUDiv>();
-          // Check upper Op to see if it came from a xor zeroing op
-          // XOR: Result = _Xor(Dest, Src);
+          // Check upper Op to see if it came from a zeroing op
           // If it does then it we only need a 64bit UDIV
           if (IsZeroOp(IREmit, Op->Upper)) {
             IREmit->SetWriteCursor(CodeNode);


### PR DESCRIPTION
Warming up to more serious work, but this unit test

```
xor eax, eax
hlt
```

gets a 40% cycle count reduction according to llvm-mca.

---

before assembly:

```
2995: 0x0000000265a0001c  321003e0		orr w0, wzr, #0x10000
2995: 0x0000000265a00020  10ffffc0		adr x0, #-0x8 (addr 0x265a00018)
2995: 0x0000000265a00024  f9005f80		str x0, [x28, #184]
2995: 0x0000000265a00028  2a0403f4		mov w20, w4
2995: 0x0000000265a0002c  2a0403f5		mov w21, w4
2995: 0x0000000265a00030  4a1402b4		eor w20, w21, w20
2995: 0x0000000265a00034  b3407e84		bfxil x4, x20, #0, #32
2995: 0x0000000265a00038  52800015		mov w21, #0x0
2995: 0x0000000265a0003c  390b1395		strb w21, [x28, #708]
2995: 0x0000000265a00040  d35f7e96		ubfx x22, x20, #31, #1
2995: 0x0000000265a00044  390b1f96		strb w22, [x28, #711]
2995: 0x0000000265a00048  d2400296		eor x22, x20, #0x1
2995: 0x0000000265a0004c  1e2702c4		fmov s4, w22
2995: 0x0000000265a00050  4e205884		cnt v4.16b, v4.16b
2995: 0x0000000265a00054  0e013c96		umov w22, v4.b[0]
2995: 0x0000000265a00058  390b0b96		strb w22, [x28, #706]
2995: 0x0000000265a0005c  f100029f		cmp x20, #0x0 (0)
2995: 0x0000000265a00060  9a9f17f4		cset x20, eq
2995: 0x0000000265a00064  390b1b94		strb w20, [x28, #710]
2995: 0x0000000265a00068  390b0395		strb w21, [x28, #704]
2995: 0x0000000265a0006c  390b2f95		strb w21, [x28, #715]
2995: 0x0000000265a00070  52800054		mov w20, #0x2
2995: 0x0000000265a00074  72a00034		movk w20, #0x1, lsl #16
2995: 0x0000000265a00078  b9000394		str w20, [x28]
2995: 0x0000000265a0007c  52816021		mov w1, #0xb01
2995: 0x0000000265a00080  72b001a1		movk w1, #0x800d, lsl #16
2995: 0x0000000265a00084  f9021381		str x1, [x28, #1056]
2995: 0x0000000265a00088  f9432b80		ldr x0, [x28, #1616]
2995: 0x0000000265a0008c  d61f0000		br x0
```

after assembly:

```
2995: 0x0000000265a0001c  321003e0		orr w0, wzr, #0x10000
2995: 0x0000000265a00020  10ffffc0		adr x0, #-0x8 (addr 0x265a00018)
2995: 0x0000000265a00024  f9005f80		str x0, [x28, #184]
2995: 0x0000000265a00028  52800014		mov w20, #0x0
2995: 0x0000000265a0002c  b3407e84		bfxil x4, x20, #0, #32
2995: 0x0000000265a00030  320003f5		orr w21, wzr, #0x1
2995: 0x0000000265a00034  390b1394		strb w20, [x28, #708]
2995: 0x0000000265a00038  52800016		mov w22, #0x0
2995: 0x0000000265a0003c  390b1f96		strb w22, [x28, #711]
2995: 0x0000000265a00040  320003f6		orr w22, wzr, #0x1
2995: 0x0000000265a00044  390b0b96		strb w22, [x28, #706]
2995: 0x0000000265a00048  390b1b95		strb w21, [x28, #710]
2995: 0x0000000265a0004c  390b0394		strb w20, [x28, #704]
2995: 0x0000000265a00050  390b2f94		strb w20, [x28, #715]
2995: 0x0000000265a00054  52800054		mov w20, #0x2
2995: 0x0000000265a00058  72a00034		movk w20, #0x1, lsl #16
2995: 0x0000000265a0005c  b9000394		str w20, [x28]
2995: 0x0000000265a00060  52816021		mov w1, #0xb01
2995: 0x0000000265a00064  72b001a1		movk w1, #0x800d, lsl #16
2995: 0x0000000265a00068  f9021381		str x1, [x28, #1056]
2995: 0x0000000265a0006c  f9432b80		ldr x0, [x28, #1616]
2995: 0x0000000265a00070  d61f0000		br x0
```

