### PR TITLE
X86Tables: Adds spaceship operator to couple op types

### DIFF
--- a/External/FEXCore/Source/Interface/Core/X86Tables/X86Tables.h
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/X86Tables.h
@@ -138,9 +138,10 @@ struct DecodedOperand {
   }
 
   union TypeUnion {
-    struct {
+    struct GPRType {
       bool HighBits;
       uint8_t GPR;
+      auto operator<=>(const GPRType&) const = default;
     } GPR;
 
     struct {
@@ -155,9 +156,10 @@ struct DecodedOperand {
       } Value;
     } RIPLiteral;
 
-    struct {
+    struct LiteralType {
       uint64_t Value;
       uint8_t Size;
+      auto operator<=>(const LiteralType&) const = default;
     } Literal;
 
     struct {


### PR DESCRIPTION
For #2804 so it can compare if GPRs match more easily.

Only adding to GPR and Literal types, since its ambiguous what this would mean for the memory accessing types. Going to leave those other ones alone for now.