### PR TITLE
Arm64/Emitter: Collapse encoding cases for indexed dup 

### DIFF
--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/Emitter.h
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/Emitter.h
@@ -6,6 +6,7 @@
 #include <FEXCore/Utils/CompilerDefs.h>
 #include <FEXCore/Utils/EnumUtils.h>
 #include <FEXCore/Utils/LogManager.h>
+#include <FEXCore/Utils/MathUtils.h>
 #include <FEXCore/fextl/vector.h>
 
 #include <aarch64/assembler-aarch64.h>


### PR DESCRIPTION
Lets us hoist out the asserts and also collapse all the branching into one series of operations.