### PR TITLE
Arm64: Fixes LR corruption in 128-bit divides

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -654,7 +654,10 @@ DEF_OP(LDiv) {
         mov(EmitSize, ARMEmitter::Reg::r2, Divisor);
 
         ldr(ARMEmitter::XReg::x3, STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.AArch64.LDIVHandler));
+
+        str<ARMEmitter::IndexType::PRE>(ARMEmitter::XReg::lr, ARMEmitter::Reg::rsp, -16);
         blr(ARMEmitter::Reg::r3);
+        ldr<ARMEmitter::IndexType::POST>(ARMEmitter::XReg::lr, ARMEmitter::Reg::rsp, 16);
 
         // Move result to its destination register
         mov(EmitSize, Dst, ARMEmitter::Reg::r0);
@@ -718,7 +721,11 @@ DEF_OP(LUDiv) {
         mov(EmitSize, ARMEmitter::Reg::r2, Divisor);
 
         ldr(ARMEmitter::XReg::x3, STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.AArch64.LUDIVHandler));
+
+        str<ARMEmitter::IndexType::PRE>(ARMEmitter::XReg::lr, ARMEmitter::Reg::rsp, -16);
         blr(ARMEmitter::Reg::r3);
+        ldr<ARMEmitter::IndexType::POST>(ARMEmitter::XReg::lr, ARMEmitter::Reg::rsp, 16);
+
         // Move result to its destination register
         mov(EmitSize, Dst, ARMEmitter::Reg::r0);
 
@@ -789,7 +796,11 @@ DEF_OP(LRem) {
         mov(EmitSize, ARMEmitter::Reg::r2, Divisor);
 
         ldr(ARMEmitter::XReg::x3, STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.AArch64.LREMHandler));
+
+        str<ARMEmitter::IndexType::PRE>(ARMEmitter::XReg::lr, ARMEmitter::Reg::rsp, -16);
         blr(ARMEmitter::Reg::r3);
+        ldr<ARMEmitter::IndexType::POST>(ARMEmitter::XReg::lr, ARMEmitter::Reg::rsp, 16);
+
         // Move result to its destination register
         mov(EmitSize, Dst, ARMEmitter::Reg::r0);
 
@@ -854,7 +865,11 @@ DEF_OP(LURem) {
         mov(EmitSize, ARMEmitter::Reg::r2, Divisor);
 
         ldr(ARMEmitter::XReg::x3, STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.AArch64.LUREMHandler));
+
+        str<ARMEmitter::IndexType::PRE>(ARMEmitter::XReg::lr, ARMEmitter::Reg::rsp, -16);
         blr(ARMEmitter::Reg::r3);
+        ldr<ARMEmitter::IndexType::POST>(ARMEmitter::XReg::lr, ARMEmitter::Reg::rsp, 16);
+
         // Move result to its destination register
         mov(EmitSize, Dst, ARMEmitter::Reg::r0);
 


### PR DESCRIPTION
Need to save and restore LR before branching out to the helpers. Confirmed that the rest of the JIT handles this correctly.