### PR TITLE
Draft: Use the host NZCV register

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -173,6 +173,8 @@ constexpr OpHandlerArray InterpreterOpHandlers = [] {
   REGISTER_OP(PRINT,                  Print);
   REGISTER_OP(GETROUNDINGMODE,        GetRoundingMode);
   REGISTER_OP(SETROUNDINGMODE,        SetRoundingMode);
+  REGISTER_OP(GETNZCV,                GetNZCV);
+  REGISTER_OP(SETNZCV,                SetNZCV);
   REGISTER_OP(INVALIDATEFLAGS,        NoOp);
   REGISTER_OP(PROCESSORID,            ProcessorID);
   REGISTER_OP(RDRAND,                 RDRAND);

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
@@ -202,6 +202,8 @@ namespace FEXCore::CPU {
   DEF_OP(Print);
   DEF_OP(GetRoundingMode);
   DEF_OP(SetRoundingMode);
+  DEF_OP(GetNZCV);
+  DEF_OP(SetNZCV);
   DEF_OP(ProcessorID);
   DEF_OP(RDRAND);
   DEF_OP(Yield);

--- a/External/FEXCore/Source/Interface/Core/Interpreter/MiscOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/MiscOps.cpp
@@ -131,6 +131,12 @@ DEF_OP(SetRoundingMode) {
 #endif
 }
 
+DEF_OP(SetNZCV) {
+}
+
+DEF_OP(GetNZCV) {
+}
+
 DEF_OP(Print) {
   auto Op = IROp->C<IR::IROp_Print>();
   const uint8_t OpSize = IROp->Size;

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -365,6 +365,27 @@ DEF_OP(Andn) {
   }
 }
 
+DEF_OP(Test) {
+  auto Op = IROp->C<IR::IROp_Test>();
+  const uint8_t OpSize = IROp->Size;
+  const auto EmitSize = OpSize == 8 ? ARMEmitter::Size::i64Bit : ARMEmitter::Size::i32Bit;
+
+  const auto Dst = GetReg(Node);
+  const auto ZeroReg = ARMEmitter::Reg::zr;
+  const auto Src1 = GetReg(Op->Src1.ID());
+
+  uint64_t Const;
+  if (IsInlineConstant(Op->Src2, &Const)) {
+    ands(EmitSize, ZeroReg, Src1, Const);
+  } else {
+    const auto Src2 = GetReg(Op->Src2.ID());
+    ands(EmitSize, ZeroReg, Src1, Src2);
+  }
+
+  // TODO: Optimize this out
+  mrs(Dst, ARMEmitter::SystemRegister::NZCV);
+}
+
 DEF_OP(Xor) {
   auto Op = IROp->C<IR::IROp_Xor>();
   const uint8_t OpSize = IROp->Size;

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -859,6 +859,7 @@ CPUBackend::CompiledCode Arm64JITCore::CompileCode(uint64_t Entry,
         REGISTER_OP(OR,                Or);
         REGISTER_OP(AND,               And);
         REGISTER_OP(ANDN,              Andn);
+        REGISTER_OP(TEST,              Test);
         REGISTER_OP(XOR,               Xor);
         REGISTER_OP(LSHL,              Lshl);
         REGISTER_OP(LSHR,              Lshr);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -979,6 +979,8 @@ CPUBackend::CompiledCode Arm64JITCore::CompileCode(uint64_t Entry,
         REGISTER_OP(PRINT,      Print);
         REGISTER_OP(GETROUNDINGMODE, GetRoundingMode);
         REGISTER_OP(SETROUNDINGMODE, SetRoundingMode);
+        REGISTER_OP(GETNZCV, GetNZCV);
+        REGISTER_OP(SETNZCV, SetNZCV);
         REGISTER_OP(INVALIDATEFLAGS,   NoOp);
         REGISTER_OP(PROCESSORID,   ProcessorID);
         REGISTER_OP(RDRAND, RDRAND);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -250,6 +250,7 @@ private:
   DEF_OP(Or);
   DEF_OP(And);
   DEF_OP(Andn);
+  DEF_OP(Test);
   DEF_OP(Xor);
   DEF_OP(Lshl);
   DEF_OP(Lshr);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -361,6 +361,8 @@ private:
   DEF_OP(Print);
   DEF_OP(GetRoundingMode);
   DEF_OP(SetRoundingMode);
+  DEF_OP(GetNZCV);
+  DEF_OP(SetNZCV);
   DEF_OP(ProcessorID);
   DEF_OP(RDRAND);
   DEF_OP(Yield);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
@@ -140,6 +140,25 @@ DEF_OP(SetRoundingMode) {
   msr(ARMEmitter::SystemRegister::FPCR, TMP1);
 }
 
+DEF_OP(GetNZCV) {
+  auto Dst = GetReg(Node);
+  mrs(Dst, ARMEmitter::SystemRegister::NZCV);
+}
+
+DEF_OP(SetNZCV) {
+  auto Op = IROp->C<IR::IROp_SetNZCV>();
+
+  uint64_t Const;
+  if (IsInlineConstant(Op->NZCV, &Const)) {
+    ccmp(ARMEmitter::Size::i32Bit, ARMEmitter::Reg::r0, ARMEmitter::Reg::r0,
+         (FEXCore::ARMEmitter::StatusFlags)((Const >> 28) & 0xf),
+         ARMEmitter::Condition::CC_NE);
+  } else {
+    auto Src = GetReg(Op->NZCV.ID());
+    msr(ARMEmitter::SystemRegister::NZCV, Src);
+  }
+}
+
 DEF_OP(Print) {
   auto Op = IROp->C<IR::IROp_Print>();
 

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -1090,6 +1090,10 @@ private:
     return _Bfi(4, 1, IndexNZCV(BitOffset), NZCV, Value);
   }
 
+  OrderedNode *PreserveNZCV(OrderedNode *NZCV, unsigned BitOffset) {
+    return InsertNZCV(NZCV, BitOffset, GetRFLAG(BitOffset));
+  }
+
   // Test a value with zero, returning an appropriate NZ flag mask.
   OrderedNode *TestNZ(uint8_t SrcSize, OrderedNode *A) {
     uint64_t mask = (SrcSize == 8) ? ~0ull : ((1ull << (SrcSize * 8)) - 1);

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -1227,7 +1227,6 @@ private:
   void CalculatePFUncheckedABI(OrderedNode *Res);
   void CalculatePF(OrderedNode *Res);
 
-  void CalculateOF_Add(uint8_t SrcSize, OrderedNode *Res, OrderedNode *Src1, OrderedNode *Src2);
   void CalculateFlags_ADC(uint8_t SrcSize, OrderedNode *Res, OrderedNode *Src1, OrderedNode *Src2, OrderedNode *CF);
   void CalculateFlags_SBB(uint8_t SrcSize, OrderedNode *Res, OrderedNode *Src1, OrderedNode *Src2, OrderedNode *CF);
   void CalculateFlags_SUB(uint8_t SrcSize, OrderedNode *Res, OrderedNode *Src1, OrderedNode *Src2, bool UpdateCF = true);

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -1080,6 +1080,12 @@ private:
     return _Bfi(4, 1, IndexNZCV(BitOffset), NZCV, Value);
   }
 
+  // Test a value with zero, returning an appropriate NZ flag mask.
+  OrderedNode *TestNZ(uint8_t SrcSize, OrderedNode *A) {
+    uint64_t mask = (SrcSize == 8) ? ~0ull : ((1ull << (SrcSize * 8)) - 1);
+    return _Test(A, _Constant(mask));
+  }
+
   void SetRFLAG(OrderedNode *Value, unsigned BitOffset) {
     flagsOp = SelectionFlag::Nothing;
 

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -1094,6 +1094,17 @@ private:
     return InsertNZCV(NZCV, BitOffset, GetRFLAG(BitOffset));
   }
 
+  // Test a value with zero, returning an appropriate Z flag mask.
+  // TODO: Use TST for this, it is equivalent and faster.
+  OrderedNode *TestZ(OrderedNode *A) {
+    auto One = _Constant(1);
+    auto Zero = _Constant(0);
+
+    // Lsl(Select(1, 0), x) is actually cheaper than Select(1 << x, 0)
+    auto ZSelect = _Select(FEXCore::IR::COND_EQ, A, Zero, One, Zero);
+    return _Lshl(ZSelect, _Constant(FEXCore::X86State::RFLAG_ZF_LOC));
+  }
+
   // Test a value with zero, returning an appropriate NZ flag mask.
   OrderedNode *TestNZ(uint8_t SrcSize, OrderedNode *A) {
     uint64_t mask = (SrcSize == 8) ? ~0ull : ((1ull << (SrcSize * 8)) - 1);

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -1076,6 +1076,16 @@ private:
     CachedNZCV = Value;
   }
 
+  // If A compare B, set overflow and carry flags. Else, clear them. Sign and zero flags are
+  // undefined.
+  void SelectVC(OrderedNode *A, OrderedNode *B, uint8_t Condition) {
+    auto VCFalse = _Constant(0);
+    auto VCTrue = _Constant((1 << IndexNZCV(FEXCore::X86State::RFLAG_OF_LOC)) |
+                            (1 << IndexNZCV(FEXCore::X86State::RFLAG_CF_LOC)));
+
+    SetNZCV(_Select(Condition, A, B, VCTrue, VCFalse));
+  }
+
   OrderedNode *InsertNZCV(OrderedNode *NZCV, unsigned BitOffset, OrderedNode *Value) {
     return _Bfi(4, 1, IndexNZCV(BitOffset), NZCV, Value);
   }

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
@@ -1102,16 +1102,8 @@ void OpDispatchBuilder::CalculateFlags_LZCNT(uint8_t SrcSize, OrderedNode *Src) 
 
 void OpDispatchBuilder::CalculateFlags_BITSELECT(OrderedNode *Src) {
   // OF, SF, AF, PF, CF all undefined
-
-  auto ZeroConst = _Constant(0);
-  auto OneConst = _Constant(1);
-
   // ZF is set to 1 if the source was zero
-  auto ZFSelectOp = _Select(FEXCore::IR::COND_EQ,
-      Src, ZeroConst,
-      OneConst, ZeroConst);
-
-  SetRFLAG<FEXCore::X86State::RFLAG_ZF_LOC>(ZFSelectOp);
+  SetNZCV(TestZ(Src));
 }
 
 void OpDispatchBuilder::CalculateFlags_RDRAND(OrderedNode *Src) {

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
@@ -529,7 +529,6 @@ void OpDispatchBuilder::CalculateFlags_UMUL(OrderedNode *High) {
 
 void OpDispatchBuilder::CalculateFlags_Logical(uint8_t SrcSize, OrderedNode *Res, OrderedNode *Src1, OrderedNode *Src2) {
   auto Zero = _Constant(0);
-  auto One = _Constant(1);
   // AF
   {
     // Undefined
@@ -537,26 +536,11 @@ void OpDispatchBuilder::CalculateFlags_Logical(uint8_t SrcSize, OrderedNode *Res
     SetRFLAG<FEXCore::X86State::RFLAG_AF_LOC>(Zero);
   }
 
-  // SF
-  {
-    auto SignOp = _Bfe(1, SrcSize * 8 - 1, Res);
-    SetRFLAG<FEXCore::X86State::RFLAG_SF_LOC>(SignOp);
-  }
-
   CalculatePF(Res);
 
-  // ZF
-  {
-    auto SelectOp = _Select(FEXCore::IR::COND_EQ,
-        Res, Zero, One, Zero);
-    SetRFLAG<FEXCore::X86State::RFLAG_ZF_LOC>(SelectOp);
-  }
-
-  // CF/OF
-  {
-    SetRFLAG<FEXCore::X86State::RFLAG_CF_LOC>(Zero);
-    SetRFLAG<FEXCore::X86State::RFLAG_OF_LOC>(Zero);
-  }
+  // CF/OF zero.
+  // ZF/SF normal.
+  SetNZCV(TestNZ(SrcSize, Res));
 }
 
 #define COND_FLAG_SET(cond, flag, newflag) \

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
@@ -1081,6 +1081,7 @@ void OpDispatchBuilder::CalculateFlags_TZCNT(OrderedNode *Src) {
       _Constant(1), Zero);
 
   // Set flags
+  SetNZCV(Zero);
   SetRFLAG<FEXCore::X86State::RFLAG_CF_LOC>(ZFResult);
   SetRFLAG<FEXCore::X86State::RFLAG_ZF_LOC>(_Bfe(1, 0, Src));
 }
@@ -1094,6 +1095,7 @@ void OpDispatchBuilder::CalculateFlags_LZCNT(uint8_t SrcSize, OrderedNode *Src) 
       _Constant(1), Zero);
 
   // Set flags
+  SetNZCV(Zero);
   SetRFLAG<FEXCore::X86State::RFLAG_CF_LOC>(ZFResult);
   SetRFLAG<FEXCore::X86State::RFLAG_ZF_LOC>(_Bfe(1, SrcSize * 8 - 1, Src));
 }

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
@@ -74,7 +74,7 @@ OrderedNode *OpDispatchBuilder::GetPackedRFLAG(uint32_t FlagsMask) {
     // the byte is allowed to be garbage.
     OrderedNode *Flag = FlagOffset == FEXCore::X86State::RFLAG_PF_LOC ?
                         LoadPF() :
-                        _LoadFlag(FlagOffset);
+                        GetRFLAG(FlagOffset);
 
     Original = _Bfi(4, 1, FlagOffset, Original, Flag);
   }
@@ -304,6 +304,11 @@ void OpDispatchBuilder::CalculateDeferredFlags(uint32_t FlagsToCalculateMask) {
 
   // Done calculating
   CurrentDeferredFlags.Type = FlagsGenerationType::TYPE_NONE;
+
+  if (CachedNZCV)
+    _SetNZCV(CachedNZCV);
+
+  CachedNZCV = NULL;
 }
 
 void OpDispatchBuilder::CalculateFlags_ADC(uint8_t SrcSize, OrderedNode *Res, OrderedNode *Src1, OrderedNode *Src2, OrderedNode *CF) {

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -217,6 +217,19 @@
                 ],
         "HasSideEffects": true
       },
+
+      "GPR = GetNZCV": {
+        "Desc": ["Gets the current NZCV packed flag register"
+                ],
+        "DestSize": "4"
+      },
+
+      "SetNZCV GPR:$NZCV": {
+        "Desc": ["Sets the current NZCV packed flag register"
+                ],
+        "HasSideEffects": true
+      },
+
       "Print SSA:$Value": {
         "HasSideEffects": true,
         "Desc": ["Debug operation that prints an SSA value to the console",

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -807,6 +807,9 @@
         "Desc": ["Integer binary AND NOT. Performs the equivalent of Src1 & ~Src2"],
         "DestSize": "std::max<uint8_t>(4, GetOpSize(_Src1))"
       },
+      "GPR = Test GPR:$Src1, GPR:$Src2": {
+        "Desc": ["Determine NZ-- flags from the integer binary AND of the two sources"]
+      },
       "GPR = Lshl u8:#Size, GPR:$Src1, GPR:$Src2": {
         "Desc": ["Integer logical shift left"
                 ],

--- a/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -1112,6 +1112,20 @@ bool ConstProp::ConstantInlining(IREmitter *IREmit, const IRListView& CurrentIR)
         }
         break;
       }
+      case OP_SETNZCV:
+      {
+        auto Op = IROp->CW<IR::IROp_SetNZCV>();
+
+        uint64_t Constant{};
+        if (IREmit->IsValueConstant(Op->Header.Args[0], &Constant)) {
+          IREmit->SetWriteCursor(CurrentIR.GetNode(Op->Header.Args[0]));
+
+          IREmit->ReplaceNodeArgument(CodeNode, 0, CreateInlineConstant(IREmit, Constant));
+
+          Changed = true;
+        }
+        break;
+      }
       default:
         break;
     }


### PR DESCRIPTION
This is a very early WIP, not ready for merge at all, but I want to get this on people's radars since it is showing signs of life.

The overall strategy I'm taking is to model the packed 32-bit NZCV register as a SSA value (i.e. pretending it's a GPR). All accesses to SF/ZF/CF/OF become accesses to the packed 32-bit register. As a default path, `OpcodeDispatcher.h` learns to do bitfield insert/extract for these flags. During the block this is treated as a GPR, with msr/mrs to the "real" register only at block boundaries.

That regresses code gen, since now we have piles of extra packing/unpacking emitted. We can get some perf back by rewriting the flag generation code to generate a "synthetic" NZCV register directly, rather than doing 1-bit RMW cycles on the existing values.

The real value comes when we start introducing real arm64 opcodes that operate on NZCV. At this point, I've added support (only) for TST, which perfectly translates the x86 flag behaviour of logical ops. Again this is all modelled as pure SSA. Logically, our IR's "test" opcode returns a 32-bit GPR that happens to match the encoding of the arm64 register -- it could be implemented (less efficiently) with bit operations, e.g. for a risc-v backend.

At this point, `llvm-mca` thinks this is a cycle count win (if not instruction count) for simple logical ops and adds/subs.

The next step is to actually teach the register allocator about these flags, so it can allocate the destination of a TST directly to the NZCV, and then insert an mrs only if it would be get read/clobbered. This will let us delete pointless moves between NZCV<-->GPR. I don't think this PR will get to that, since it's not required to get wins from this and this PR is already big and churny.