### PR TITLE
OpcodeDispatcher: Optimize PSAD* to use vuabdl{2,} 

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -267,6 +267,7 @@ constexpr OpHandlerArray InterpreterOpHandlers = [] {
   REGISTER_OP(VUMULL2,                VUMull2);
   REGISTER_OP(VSMULL2,                VSMull2);
   REGISTER_OP(VUABDL,                 VUABDL);
+  REGISTER_OP(VUABDL2,                VUABDL2);
   REGISTER_OP(VTBL1,                  VTBL1);
   REGISTER_OP(VREV64,                 VRev64);
   REGISTER_OP(VPCMPESTRX,             VPCMPESTRX);

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
@@ -293,6 +293,7 @@ namespace FEXCore::CPU {
   DEF_OP(VUMull2);
   DEF_OP(VSMull2);
   DEF_OP(VUABDL);
+  DEF_OP(VUABDL2);
   DEF_OP(VTBL1);
   DEF_OP(VRev64);
   DEF_OP(VPCMPESTRX);

--- a/External/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
@@ -2227,6 +2227,33 @@ DEF_OP(VUABDL) {
   memcpy(GDP, Tmp, OpSize);
 }
 
+DEF_OP(VUABDL2) {
+  const auto Op = IROp->C<IR::IROp_VUABDL2>();
+  const uint8_t OpSize = IROp->Size;
+
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector1);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Vector2);
+
+  uint8_t Tmp[Core::CPUState::XMM_AVX_REG_SIZE];
+
+  const uint8_t ElementSize = Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / ElementSize;
+
+  const auto Func8 = [](auto a, auto b) { return std::abs((int16_t)a - (int16_t)b); };
+  const auto Func16 = [](auto a, auto b) { return std::abs((int32_t)a - (int32_t)b); };
+  const auto Func32 = [](auto a, auto b) { return std::abs((int64_t)a - (int64_t)b); };
+
+  switch (ElementSize) {
+    DO_VECTOR_2SRC_2TYPE_OP_TOP_SRC(2, uint16_t, uint8_t, Func8)
+    DO_VECTOR_2SRC_2TYPE_OP_TOP_SRC(4, uint32_t, uint16_t, Func16)
+    DO_VECTOR_2SRC_2TYPE_OP_TOP_SRC(8, uint64_t, uint32_t, Func32)
+    default:
+      LOGMAN_MSG_A_FMT("Unknown Element Size: {}", ElementSize);
+      break;
+  }
+  memcpy(GDP, Tmp, OpSize);
+}
+
 DEF_OP(VTBL1) {
   const auto Op = IROp->C<IR::IROp_VTBL1>();
   const uint8_t OpSize = IROp->Size;

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -1073,6 +1073,7 @@ CPUBackend::CompiledCode Arm64JITCore::CompileCode(uint64_t Entry,
         REGISTER_OP(VUMULL2,           VUMull2);
         REGISTER_OP(VSMULL2,           VSMull2);
         REGISTER_OP(VUABDL,            VUABDL);
+        REGISTER_OP(VUABDL2,           VUABDL2);
         REGISTER_OP(VTBL1,             VTBL1);
         REGISTER_OP(VREV64,            VRev64);
 #undef REGISTER_OP

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -453,6 +453,7 @@ private:
   DEF_OP(VUMull2);
   DEF_OP(VSMull2);
   DEF_OP(VUABDL);
+  DEF_OP(VUABDL2);
   DEF_OP(VTBL1);
   DEF_OP(VRev64);
 

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -454,6 +454,7 @@ private:
   DEF_OP(VUMull2);
   DEF_OP(VSMull2);
   DEF_OP(VUABDL);
+  DEF_OP(VUABDL2);
   DEF_OP(VTBL1);
   DEF_OP(VRev64);
 

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -3764,28 +3764,14 @@ OrderedNode* OpDispatchBuilder::PSADBWOpImpl(OpcodeArgs,
   OrderedNode *Src2 = LoadSource(FPRClass, Op, Src2Op, Op->Flags, -1);
 
   if (Size == 8) {
-    OrderedNode *Src1_Low = _VUXTL(Size*2, 1, Src1);
-    OrderedNode *Src2_Low = _VUXTL(Size*2, 1, Src2);
-
-    OrderedNode *SubResult = _VSub(Size*2, 2, Src1_Low, Src2_Low);
-    OrderedNode *AbsResult = _VAbs(Size*2, 2, SubResult);
+    auto AbsResult = _VUABDL(Size * 2, 1, Src1, Src2);
 
     // Now vector-wide add the results for each
     return _VAddV(Size * 2, 2, AbsResult);
   }
 
-
-  OrderedNode *Src1_Low = _VUXTL(Size, 1, Src1);
-  OrderedNode *Src1_High = _VUXTL2(Size, 1, Src1);
-
-  OrderedNode *Src2_Low = _VUXTL(Size, 1, Src2);
-  OrderedNode *Src2_High = _VUXTL2(Size, 1, Src2);
-
-  OrderedNode *SubResult_Low = _VSub(Size, 2, Src1_Low, Src2_Low);
-  OrderedNode *SubResult_High = _VSub(Size, 2, Src1_High, Src2_High);
-
-  OrderedNode *AbsResult_Low = _VAbs(Size, 2, SubResult_Low);
-  OrderedNode *AbsResult_High = _VAbs(Size, 2, SubResult_High);
+  auto AbsResult_Low = _VUABDL(Size, 1, Src1, Src2);
+  auto AbsResult_High = _VUABDL2(Size, 1, Src1, Src2);
 
   OrderedNode *Result_Low = _VAddV(16, 2, AbsResult_Low);
   OrderedNode *Result_High = _VAddV(16, 2, AbsResult_High);

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -3775,8 +3775,8 @@ OrderedNode* OpDispatchBuilder::PSADBWOpImpl(OpcodeArgs,
 
   OrderedNode *Result_Low = _VAddV(16, 2, AbsResult_Low);
   OrderedNode *Result_High = _VAddV(16, 2, AbsResult_High);
+  auto Low = _VZip(Size, 8, Result_Low, Result_High);
 
-  OrderedNode *Low = _VInsElement(Size, 8, 1, 0, Result_Low, Result_High);
   if (Is128Bit) {
     return Low;
   }

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -1317,7 +1317,13 @@
         "DestSize": "RegisterSize",
         "NumElements": "RegisterSize / (ElementSize << 1)"
       },
-
+      "FPR = VUABDL2 u8:#RegisterSize, u8:#ElementSize, FPR:$Vector1, FPR:$Vector2": {
+        "Desc": ["Unsigned Absolute Difference Long",
+                 "Using the high elements of the source vectors"
+                ],
+        "DestSize": "RegisterSize",
+        "NumElements": "RegisterSize / (ElementSize << 1)"
+      },
       "FPR = VUShl u8:#RegisterSize, u8:#ElementSize, FPR:$Vector, FPR:$ShiftVector": {
         "DestSize": "RegisterSize",
         "NumElements": "RegisterSize / ElementSize"


### PR DESCRIPTION
Optimizes this instruction from 18 down to 10 instructions.

Fixes #443

Before:
```asm
0x00007fffe2080908  10ffffe0            adr x0, #-0x4 (addr 0x7fffe2080904)
0x00007fffe208090c  f9005f80            str x0, [x28, #184]
0x00007fffe2080910  3dc03cc4            ldr q4, [x6, #240]
0x00007fffe2080914  2f08a705            uxtl v5.8h, v24.8b
0x00007fffe2080918  6f08a706            uxtl2 v6.8h, v24.16b
0x00007fffe208091c  2f08a487            uxtl v7.8h, v4.8b
0x00007fffe2080920  6f08a484            uxtl2 v4.8h, v4.16b
0x00007fffe2080924  6e6784a5            sub v5.8h, v5.8h, v7.8h
0x00007fffe2080928  6e6484c4            sub v4.8h, v6.8h, v4.8h
0x00007fffe208092c  4e60b8a5            abs v5.8h, v5.8h
0x00007fffe2080930  4e60b884            abs v4.8h, v4.8h
0x00007fffe2080934  4e71b8a5            addv h5, v5.8h
0x00007fffe2080938  4e71b884            addv h4, v4.8h
0x00007fffe208093c  4ea51ca0            mov v0.16b, v5.16b
0x00007fffe2080940  6e180480            mov v0.d[1], v4.d[0]
0x00007fffe2080944  4ea01c18            mov v24.16b, v0.16b
0x00007fffe2080948  58000040            ldr x0, pc+8 (addr 0x7fffe2080950)
0x00007fffe208094c  d63f0000            blr x0
```

After:
```asm
0x00007fffe2080808  10ffffe0            adr x0, #-0x4 (addr 0x7fffe2080804)
0x00007fffe208080c  f9005f80            str x0, [x28, #184]
0x00007fffe2080810  3dc03cc4            ldr q4, [x6, #240]
0x00007fffe2080814  2e247305            uabdl v5.8h, v24.8b, v4.8b
0x00007fffe2080818  6e247304            uabdl2 v4.8h, v24.16b, v4.16b
0x00007fffe208081c  4e71b8a5            addv h5, v5.8h
0x00007fffe2080820  4e71b884            addv h4, v4.8h
0x00007fffe2080824  4ec438b8            zip1 v24.2d, v5.2d, v4.2d
0x00007fffe2080828  58000040            ldr x0, pc+8 (addr 0x7fffe2080830)
0x00007fffe208082c  d63f0000            blr x0
```