### PR TITLE
Frontend: Remove redundant lookups in BranchTargetInMultiblockRange()

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Frontend.cpp
+++ b/External/FEXCore/Source/Interface/Core/Frontend.cpp
@@ -1026,15 +1026,13 @@ void Decoder::BranchTargetInMultiblockRange() {
 
       // If we are conditional then a target can be the instruction past the conditional instruction
       uint64_t FallthroughRIP = DecodeInst->PC + DecodeInst->InstSize;
-      if (HasBlocks.find(FallthroughRIP) == HasBlocks.end() &&
-          BlocksToDecode.find(FallthroughRIP) == BlocksToDecode.end()) {
-        BlocksToDecode.emplace(FallthroughRIP);
+      if (!HasBlocks.contains(FallthroughRIP)) {
+        BlocksToDecode.insert(FallthroughRIP);
       }
     }
 
-    if (HasBlocks.find(TargetRIP) == HasBlocks.end() &&
-        BlocksToDecode.find(TargetRIP) == BlocksToDecode.end()) {
-      BlocksToDecode.emplace(TargetRIP);
+    if (!HasBlocks.contains(TargetRIP)) {
+      BlocksToDecode.insert(TargetRIP);
     }
   } else {
     if (ExternalBranches) {


### PR DESCRIPTION
insert() will only ever perform an insertion if the relevant element doesn't exist within the set, so we were doing an unnecessary lookup in two spots.

We don't use emplace() here because it will need to construct the key for the element inside the allocated node (since the key may be non-copyable/non-movable), causing an allocation even if an insert doesn't actually occur.

Conversely, insert() will not need to allocate and construct a node ahead of time if an element already exists in the set.