### PR TITLE
Context: Pull out some long std::function declarations into aliases

### DIFF
--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -168,13 +168,13 @@ namespace FEXCore::Context {
       void UnloadAOTIRCacheEntry(FEXCore::IR::AOTIRCacheEntry *Entry) override;
 
       void SetAOTIRLoader(AOTIRLoaderCBFn CacheReader) override {
-        IRCaptureCache.SetAOTIRLoader(CacheReader);
+        IRCaptureCache.SetAOTIRLoader(std::move(CacheReader));
       }
       void SetAOTIRWriter(AOTIRWriterCBFn CacheWriter) override {
-        IRCaptureCache.SetAOTIRWriter(CacheWriter);
+        IRCaptureCache.SetAOTIRWriter(std::move(CacheWriter));
       }
       void SetAOTIRRenamer(AOTIRRenamerCBFn CacheRenamer) override {
-        IRCaptureCache.SetAOTIRRenamer(CacheRenamer);
+        IRCaptureCache.SetAOTIRRenamer(std::move(CacheRenamer));
       }
 
       void FinalizeAOTIRCache() override {

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -167,20 +167,20 @@ namespace FEXCore::Context {
       FEXCore::IR::AOTIRCacheEntry *LoadAOTIRCacheEntry(const fextl::string& Name) override;
       void UnloadAOTIRCacheEntry(FEXCore::IR::AOTIRCacheEntry *Entry) override;
 
-      void SetAOTIRLoader(std::function<int(const fextl::string&)> CacheReader) override {
+      void SetAOTIRLoader(AOTIRLoaderCBFn CacheReader) override {
         IRCaptureCache.SetAOTIRLoader(CacheReader);
       }
-      void SetAOTIRWriter(std::function<fextl::unique_ptr<AOTIRWriter>(const fextl::string&)> CacheWriter) override {
+      void SetAOTIRWriter(AOTIRWriterCBFn CacheWriter) override {
         IRCaptureCache.SetAOTIRWriter(CacheWriter);
       }
-      void SetAOTIRRenamer(std::function<void(const fextl::string&)> CacheRenamer) override {
+      void SetAOTIRRenamer(AOTIRRenamerCBFn CacheRenamer) override {
         IRCaptureCache.SetAOTIRRenamer(CacheRenamer);
       }
 
       void FinalizeAOTIRCache() override {
         IRCaptureCache.FinalizeAOTIRCache();
       }
-      void WriteFilesWithCode(std::function<void(const fextl::string& fileid, const fextl::string& filename)> Writer) override {
+      void WriteFilesWithCode(AOTIRCodeFileWriterFn Writer) override {
         IRCaptureCache.WriteFilesWithCode(Writer);
       }
       void InvalidateGuestCodeRange(FEXCore::Core::InternalThreadState *Thread, uint64_t Start, uint64_t Length) override;

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -184,7 +184,7 @@ namespace FEXCore::Context {
         IRCaptureCache.WriteFilesWithCode(Writer);
       }
       void InvalidateGuestCodeRange(FEXCore::Core::InternalThreadState *Thread, uint64_t Start, uint64_t Length) override;
-      void InvalidateGuestCodeRange(FEXCore::Core::InternalThreadState *Thread, uint64_t Start, uint64_t Length, std::function<void(uint64_t start, uint64_t Length)> callback) override;
+      void InvalidateGuestCodeRange(FEXCore::Core::InternalThreadState *Thread, uint64_t Start, uint64_t Length, CodeRangeInvalidationFn callback) override;
       void MarkMemoryShared() override;
 
       void ConfigureAOTGen(FEXCore::Core::InternalThreadState *Thread, fextl::set<uint64_t> *ExternalBranches, uint64_t SectionMaxAddress) override;

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -189,7 +189,7 @@ namespace FEXCore::Context {
 
       void ConfigureAOTGen(FEXCore::Core::InternalThreadState *Thread, fextl::set<uint64_t> *ExternalBranches, uint64_t SectionMaxAddress) override;
       // returns false if a handler was already registered
-      CustomIRResult AddCustomIREntrypoint(uintptr_t Entrypoint, std::function<void(uintptr_t Entrypoint, FEXCore::IR::IREmitter *)> Handler, void *Creator = nullptr, void *Data = nullptr) override;
+      CustomIRResult AddCustomIREntrypoint(uintptr_t Entrypoint, CustomIREntrypointHandler Handler, void *Creator = nullptr, void *Data = nullptr) override;
 
       void AppendThunkDefinitions(fextl::vector<FEXCore::IR::ThunkDefinition> const& Definitions) override;
 
@@ -435,7 +435,7 @@ namespace FEXCore::Context {
     FEX_CONFIG_OPT(AppFilename, APP_FILENAME);
 
     std::shared_mutex CustomIRMutex;
-    fextl::unordered_map<uint64_t, std::tuple<std::function<void(uintptr_t Entrypoint, FEXCore::IR::IREmitter *)>, void *, void *>> CustomIRHandlers;
+    fextl::unordered_map<uint64_t, std::tuple<CustomIREntrypointHandler, void *, void *>> CustomIRHandlers;
     FEXCore::CPU::CPUBackendFeatures BackendFeatures;
     FEXCore::CPU::DispatcherConfig DispatcherConfig;
   };

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -1243,7 +1243,7 @@ namespace FEXCore::Context {
     InvalidateGuestCodeRangeInternal(this, Start, Length);
   }
 
-  void ContextImpl::InvalidateGuestCodeRange(FEXCore::Core::InternalThreadState *Thread, uint64_t Start, uint64_t Length, std::function<void(uint64_t start, uint64_t Length)> CallAfter) {
+  void ContextImpl::InvalidateGuestCodeRange(FEXCore::Core::InternalThreadState *Thread, uint64_t Start, uint64_t Length, CodeRangeInvalidationFn CallAfter) {
     // Potential deferred since Thread might not be valid.
     // Thread object isn't valid very early in frontend's initialization.
     // To be more optimal the frontend should provide this code with a valid Thread object earlier.

--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -1289,7 +1289,7 @@ namespace FEXCore::Context {
     Thread->LookupCache->Erase(GuestRIP);
   }
 
-  CustomIRResult ContextImpl::AddCustomIREntrypoint(uintptr_t Entrypoint, std::function<void(uintptr_t Entrypoint, FEXCore::IR::IREmitter *)> Handler, void *Creator, void *Data) {
+  CustomIRResult ContextImpl::AddCustomIREntrypoint(uintptr_t Entrypoint, CustomIREntrypointHandler Handler, void *Creator, void *Data) {
     LOGMAN_THROW_A_FMT(Config.Is64BitMode || !(Entrypoint >> 32), "64-bit Entrypoint in 32-bit mode {:x}", Entrypoint);
 
     std::unique_lock lk(CustomIRMutex);

--- a/External/FEXCore/Source/Interface/IR/AOTIR.cpp
+++ b/External/FEXCore/Source/Interface/IR/AOTIR.cpp
@@ -242,7 +242,7 @@ namespace FEXCore::IR {
     }
   }
 
-  void AOTIRCaptureCache::WriteFilesWithCode(Context::AOTIRCodeFileWriterFn Writer) {
+  void AOTIRCaptureCache::WriteFilesWithCode(const Context::AOTIRCodeFileWriterFn &Writer) {
     std::shared_lock lk(AOTIRCacheLock);
     for( const auto &Entry: AOTIRCache) {
       if (Entry.second.ContainsCode) {

--- a/External/FEXCore/Source/Interface/IR/AOTIR.cpp
+++ b/External/FEXCore/Source/Interface/IR/AOTIR.cpp
@@ -206,7 +206,7 @@ namespace FEXCore::IR {
       FEXCore::Allocator::YesIKnowImNotSupposedToUseTheGlibcAllocator glibc;
 
       AOTIRCaptureCacheWriteoutLock.lock();
-      std::function<void()> fn = std::move(AOTIRCaptureCacheWriteoutQueue.front());
+      WriteOutFn fn = std::move(AOTIRCaptureCacheWriteoutQueue.front());
       bool MaybeEmpty = false;
       AOTIRCaptureCacheWriteoutQueue.pop();
       MaybeEmpty = AOTIRCaptureCacheWriteoutQueue.size() == 0;
@@ -225,7 +225,7 @@ namespace FEXCore::IR {
     LOGMAN_MSG_A_FMT("Must never get here");
   }
 
-  void AOTIRCaptureCache::AOTIRCaptureCacheWriteoutQueue_Append(const std::function<void()> &fn) {
+  void AOTIRCaptureCache::AOTIRCaptureCacheWriteoutQueue_Append(const WriteOutFn &fn) {
     bool Flush = false;
 
     {
@@ -242,7 +242,7 @@ namespace FEXCore::IR {
     }
   }
 
-  void AOTIRCaptureCache::WriteFilesWithCode(std::function<void(const fextl::string& fileid, const fextl::string& filename)> Writer) {
+  void AOTIRCaptureCache::WriteFilesWithCode(Context::AOTIRCodeFileWriterFn Writer) {
     std::shared_lock lk(AOTIRCacheLock);
     for( const auto &Entry: AOTIRCache) {
       if (Entry.second.ContainsCode) {

--- a/External/FEXCore/Source/Interface/IR/AOTIR.h
+++ b/External/FEXCore/Source/Interface/IR/AOTIR.h
@@ -89,13 +89,14 @@ namespace FEXCore::IR {
 
   class AOTIRCaptureCache final {
     public:
+      using WriteOutFn = std::function<void()>;
 
       AOTIRCaptureCache(FEXCore::Context::ContextImpl *ctx) : CTX {ctx} {}
 
       void FinalizeAOTIRCache();
       void AOTIRCaptureCacheWriteoutQueue_Flush();
-      void AOTIRCaptureCacheWriteoutQueue_Append(const std::function<void()> &fn);
-      void WriteFilesWithCode(std::function<void(const fextl::string& fileid, const fextl::string& filename)> Writer);
+      void AOTIRCaptureCacheWriteoutQueue_Append(const WriteOutFn &fn);
+      void WriteFilesWithCode(Context::AOTIRCodeFileWriterFn Writer);
 
       struct PreGenerateIRFetchResult {
         FEXCore::IR::IRListView *IRList {};
@@ -121,15 +122,15 @@ namespace FEXCore::IR {
       void UnloadAOTIRCacheEntry(AOTIRCacheEntry *Entry);
 
       // Callbacks
-      void SetAOTIRLoader(std::function<int(const fextl::string&)> CacheReader) {
+      void SetAOTIRLoader(Context::AOTIRLoaderCBFn CacheReader) {
         AOTIRLoader = CacheReader;
       }
 
-      void SetAOTIRWriter(std::function<fextl::unique_ptr<FEXCore::Context::AOTIRWriter>(const fextl::string&)> CacheWriter) {
+      void SetAOTIRWriter(Context::AOTIRWriterCBFn CacheWriter) {
         AOTIRWriter = CacheWriter;
       }
 
-      void SetAOTIRRenamer(std::function<void(const fextl::string&)> CacheRenamer) {
+      void SetAOTIRRenamer(Context::AOTIRRenamerCBFn CacheRenamer) {
         AOTIRRenamer = CacheRenamer;
       }
 
@@ -140,13 +141,13 @@ namespace FEXCore::IR {
       std::shared_mutex AOTIRCaptureCacheWriteoutLock;
       std::atomic<bool> AOTIRCaptureCacheWriteoutFlusing;
 
-      fextl::queue<std::function<void()>> AOTIRCaptureCacheWriteoutQueue;
+      fextl::queue<WriteOutFn> AOTIRCaptureCacheWriteoutQueue;
 
       FEXCore::IR::AOTCacheType AOTIRCache;
 
-      std::function<int(const fextl::string&)> AOTIRLoader;
-      std::function<fextl::unique_ptr<FEXCore::Context::AOTIRWriter>(const fextl::string&)> AOTIRWriter;
-      std::function<void(const fextl::string&)> AOTIRRenamer;
+      Context::AOTIRLoaderCBFn AOTIRLoader;
+      Context::AOTIRWriterCBFn AOTIRWriter;
+      Context::AOTIRRenamerCBFn AOTIRRenamer;
       fextl::unordered_map<fextl::string, FEXCore::IR::AOTIRCaptureCacheEntry> AOTIRCaptureCacheMap;
   };
 }

--- a/External/FEXCore/Source/Interface/IR/AOTIR.h
+++ b/External/FEXCore/Source/Interface/IR/AOTIR.h
@@ -96,7 +96,7 @@ namespace FEXCore::IR {
       void FinalizeAOTIRCache();
       void AOTIRCaptureCacheWriteoutQueue_Flush();
       void AOTIRCaptureCacheWriteoutQueue_Append(const WriteOutFn &fn);
-      void WriteFilesWithCode(Context::AOTIRCodeFileWriterFn Writer);
+      void WriteFilesWithCode(const Context::AOTIRCodeFileWriterFn &Writer);
 
       struct PreGenerateIRFetchResult {
         FEXCore::IR::IRListView *IRList {};
@@ -123,15 +123,15 @@ namespace FEXCore::IR {
 
       // Callbacks
       void SetAOTIRLoader(Context::AOTIRLoaderCBFn CacheReader) {
-        AOTIRLoader = CacheReader;
+        AOTIRLoader = std::move(CacheReader);
       }
 
       void SetAOTIRWriter(Context::AOTIRWriterCBFn CacheWriter) {
-        AOTIRWriter = CacheWriter;
+        AOTIRWriter = std::move(CacheWriter);
       }
 
       void SetAOTIRRenamer(Context::AOTIRRenamerCBFn CacheRenamer) {
-        AOTIRRenamer = CacheRenamer;
+        AOTIRRenamer = std::move(CacheRenamer);
       }
 
     private:

--- a/External/FEXCore/include/FEXCore/Core/Context.h
+++ b/External/FEXCore/include/FEXCore/Core/Context.h
@@ -87,8 +87,12 @@ namespace FEXCore::Context {
   };
 
   using CustomCPUFactoryType = std::function<fextl::unique_ptr<FEXCore::CPU::CPUBackend> (FEXCore::Context::Context*, FEXCore::Core::InternalThreadState *Thread)>;
-
   using ExitHandler = std::function<void(uint64_t ThreadId, FEXCore::Context::ExitReason)>;
+
+  using AOTIRCodeFileWriterFn = std::function<void(const fextl::string& fileid, const fextl::string& filename)>;
+  using AOTIRLoaderCBFn = std::function<int(const fextl::string&)>;
+  using AOTIRRenamerCBFn = std::function<void(const fextl::string&)>;
+  using AOTIRWriterCBFn = std::function<fextl::unique_ptr<AOTIRWriter>(const fextl::string&)>;
 
   class Context {
     public:
@@ -257,12 +261,12 @@ namespace FEXCore::Context {
       FEX_DEFAULT_VISIBILITY virtual FEXCore::IR::AOTIRCacheEntry *LoadAOTIRCacheEntry(const fextl::string& Name) = 0;
       FEX_DEFAULT_VISIBILITY virtual void UnloadAOTIRCacheEntry(FEXCore::IR::AOTIRCacheEntry *Entry) = 0;
 
-      FEX_DEFAULT_VISIBILITY virtual void SetAOTIRLoader(std::function<int(const fextl::string&)> CacheReader) = 0;
-      FEX_DEFAULT_VISIBILITY virtual void SetAOTIRWriter(std::function<fextl::unique_ptr<AOTIRWriter>(const fextl::string&)> CacheWriter) = 0;
-      FEX_DEFAULT_VISIBILITY virtual void SetAOTIRRenamer(std::function<void(const fextl::string&)> CacheRenamer) = 0;
+      FEX_DEFAULT_VISIBILITY virtual void SetAOTIRLoader(AOTIRLoaderCBFn CacheReader) = 0;
+      FEX_DEFAULT_VISIBILITY virtual void SetAOTIRWriter(AOTIRWriterCBFn CacheWriter) = 0;
+      FEX_DEFAULT_VISIBILITY virtual void SetAOTIRRenamer(AOTIRRenamerCBFn CacheRenamer) = 0;
 
       FEX_DEFAULT_VISIBILITY virtual void FinalizeAOTIRCache() = 0;
-      FEX_DEFAULT_VISIBILITY virtual void WriteFilesWithCode(std::function<void(const fextl::string& fileid, const fextl::string& filename)> Writer) = 0;
+      FEX_DEFAULT_VISIBILITY virtual void WriteFilesWithCode(AOTIRCodeFileWriterFn Writer) = 0;
       FEX_DEFAULT_VISIBILITY virtual void InvalidateGuestCodeRange(FEXCore::Core::InternalThreadState *Thread, uint64_t Start, uint64_t Length) = 0;
       FEX_DEFAULT_VISIBILITY virtual void InvalidateGuestCodeRange(FEXCore::Core::InternalThreadState *Thread, uint64_t Start, uint64_t Length, std::function<void(uint64_t start, uint64_t Length)> callback) = 0;
       FEX_DEFAULT_VISIBILITY virtual void MarkMemoryShared() = 0;

--- a/External/FEXCore/include/FEXCore/Core/Context.h
+++ b/External/FEXCore/include/FEXCore/Core/Context.h
@@ -86,6 +86,8 @@ namespace FEXCore::Context {
     void *VDSO_kernel_rt_sigreturn;
   };
 
+  using CodeRangeInvalidationFn = std::function<void(uint64_t start, uint64_t Length)>;
+
   using CustomCPUFactoryType = std::function<fextl::unique_ptr<CPU::CPUBackend>(Context*, Core::InternalThreadState *Thread)>;
   using CustomIREntrypointHandler = std::function<void(uintptr_t Entrypoint, IR::IREmitter *)>;
 
@@ -270,7 +272,7 @@ namespace FEXCore::Context {
       FEX_DEFAULT_VISIBILITY virtual void FinalizeAOTIRCache() = 0;
       FEX_DEFAULT_VISIBILITY virtual void WriteFilesWithCode(AOTIRCodeFileWriterFn Writer) = 0;
       FEX_DEFAULT_VISIBILITY virtual void InvalidateGuestCodeRange(FEXCore::Core::InternalThreadState *Thread, uint64_t Start, uint64_t Length) = 0;
-      FEX_DEFAULT_VISIBILITY virtual void InvalidateGuestCodeRange(FEXCore::Core::InternalThreadState *Thread, uint64_t Start, uint64_t Length, std::function<void(uint64_t start, uint64_t Length)> callback) = 0;
+      FEX_DEFAULT_VISIBILITY virtual void InvalidateGuestCodeRange(FEXCore::Core::InternalThreadState *Thread, uint64_t Start, uint64_t Length, CodeRangeInvalidationFn callback) = 0;
       FEX_DEFAULT_VISIBILITY virtual void MarkMemoryShared() = 0;
 
       FEX_DEFAULT_VISIBILITY virtual void ConfigureAOTGen(FEXCore::Core::InternalThreadState *Thread, fextl::set<uint64_t> *ExternalBranches, uint64_t SectionMaxAddress) = 0;

--- a/External/FEXCore/include/FEXCore/Core/Context.h
+++ b/External/FEXCore/include/FEXCore/Core/Context.h
@@ -86,8 +86,10 @@ namespace FEXCore::Context {
     void *VDSO_kernel_rt_sigreturn;
   };
 
-  using CustomCPUFactoryType = std::function<fextl::unique_ptr<FEXCore::CPU::CPUBackend> (FEXCore::Context::Context*, FEXCore::Core::InternalThreadState *Thread)>;
-  using ExitHandler = std::function<void(uint64_t ThreadId, FEXCore::Context::ExitReason)>;
+  using CustomCPUFactoryType = std::function<fextl::unique_ptr<CPU::CPUBackend>(Context*, Core::InternalThreadState *Thread)>;
+  using CustomIREntrypointHandler = std::function<void(uintptr_t Entrypoint, IR::IREmitter *)>;
+
+  using ExitHandler = std::function<void(uint64_t ThreadId, ExitReason)>;
 
   using AOTIRCodeFileWriterFn = std::function<void(const fextl::string& fileid, const fextl::string& filename)>;
   using AOTIRLoaderCBFn = std::function<int(const fextl::string&)>;
@@ -272,7 +274,7 @@ namespace FEXCore::Context {
       FEX_DEFAULT_VISIBILITY virtual void MarkMemoryShared() = 0;
 
       FEX_DEFAULT_VISIBILITY virtual void ConfigureAOTGen(FEXCore::Core::InternalThreadState *Thread, fextl::set<uint64_t> *ExternalBranches, uint64_t SectionMaxAddress) = 0;
-      FEX_DEFAULT_VISIBILITY virtual CustomIRResult AddCustomIREntrypoint(uintptr_t Entrypoint, std::function<void(uintptr_t Entrypoint, FEXCore::IR::IREmitter *)> Handler, void *Creator = nullptr, void *Data = nullptr) = 0;
+      FEX_DEFAULT_VISIBILITY virtual CustomIRResult AddCustomIREntrypoint(uintptr_t Entrypoint, CustomIREntrypointHandler Handler, void *Creator = nullptr, void *Data = nullptr) = 0;
 
       /**
        * @brief Allows the frontend to register its own thunk handlers independent of what is controlled in the backend.


### PR DESCRIPTION
Makes these a little nicer. Since some of these are part of the interface, this also makes them easier to refactor, since just the declaration would need to change, rather than every implementing class.