### PR TITLE
Pack NZCV flags

### DIFF
--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -381,6 +381,8 @@ namespace FEXCore::Context {
 
     bool ExitOnHLTEnabled() const { return ExitOnHLT; }
 
+    FEXCore::CPU::CPUBackendFeatures BackendFeatures;
+
   protected:
     void ClearCodeCache(FEXCore::Core::InternalThreadState *Thread);
 
@@ -436,7 +438,6 @@ namespace FEXCore::Context {
 
     std::shared_mutex CustomIRMutex;
     fextl::unordered_map<uint64_t, std::tuple<CustomIREntrypointHandler, void *, void *>> CustomIRHandlers;
-    FEXCore::CPU::CPUBackendFeatures BackendFeatures;
     FEXCore::CPU::DispatcherConfig DispatcherConfig;
   };
 

--- a/External/FEXCore/Source/Interface/Core/Interpreter/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/MemoryOps.cpp
@@ -190,19 +190,31 @@ DEF_OP(LoadFlag) {
   uintptr_t ContextPtr = reinterpret_cast<uintptr_t>(Data->State->CurrentFrame);
   ContextPtr += offsetof(FEXCore::Core::CPUState, flags[0]);
   ContextPtr += Op->Flag;
-  uint8_t const *MemData = reinterpret_cast<uint8_t const*>(ContextPtr);
-  GD = *MemData;
+
+  if (Op->Flag == 24 /* NZCV */) {
+    uint32_t const *MemData = reinterpret_cast<uint32_t const*>(ContextPtr);
+    GD = *MemData;
+  } else {
+    uint8_t const *MemData = reinterpret_cast<uint8_t const*>(ContextPtr);
+    GD = *MemData;
+  }
 }
 
 DEF_OP(StoreFlag) {
   auto Op = IROp->C<IR::IROp_StoreFlag>();
-  uint8_t Arg = *GetSrc<uint8_t*>(Data->SSAData, Op->Value);
+  uint32_t Arg = *GetSrc<uint32_t*>(Data->SSAData, Op->Value);
 
   uintptr_t ContextPtr = reinterpret_cast<uintptr_t>(Data->State->CurrentFrame);
   ContextPtr += offsetof(FEXCore::Core::CPUState, flags[0]);
   ContextPtr += Op->Flag;
-  uint8_t *MemData = reinterpret_cast<uint8_t*>(ContextPtr);
-  *MemData = Arg;
+
+  if (Op->Flag == 24 /* NZCV */) {
+    uint32_t *MemData = reinterpret_cast<uint32_t*>(ContextPtr);
+    *MemData = Arg;
+  } else {
+    uint8_t *MemData = reinterpret_cast<uint8_t*>(ContextPtr);
+    *MemData = Arg;
+  }
 }
 
 DEF_OP(LoadMem) {

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -331,6 +331,23 @@ DEF_OP(Or) {
   }
 }
 
+DEF_OP(Orlshl) {
+  auto Op = IROp->C<IR::IROp_Orlshl>();
+  const uint8_t OpSize = IROp->Size;
+  const auto EmitSize = OpSize == 8 ? ARMEmitter::Size::i64Bit : ARMEmitter::Size::i32Bit;
+
+  const auto Dst = GetReg(Node);
+  const auto Src1 = GetReg(Op->Src1.ID());
+
+  uint64_t Const;
+  if (IsInlineConstant(Op->Src2, &Const)) {
+    orr(EmitSize, Dst, Src1, Const << Op->BitShift);
+  } else {
+    const auto Src2 = GetReg(Op->Src2.ID());
+    orr(EmitSize, Dst, Src1, Src2, ARMEmitter::ShiftType::LSL, Op->BitShift);
+  }
+}
+
 DEF_OP(And) {
   auto Op = IROp->C<IR::IROp_And>();
   const uint8_t OpSize = IROp->Size;

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -348,6 +348,23 @@ DEF_OP(Orlshl) {
   }
 }
 
+DEF_OP(Orlshr) {
+  auto Op = IROp->C<IR::IROp_Orlshr>();
+  const uint8_t OpSize = IROp->Size;
+  const auto EmitSize = OpSize == 8 ? ARMEmitter::Size::i64Bit : ARMEmitter::Size::i32Bit;
+
+  const auto Dst = GetReg(Node);
+  const auto Src1 = GetReg(Op->Src1.ID());
+
+  uint64_t Const;
+  if (IsInlineConstant(Op->Src2, &Const)) {
+    orr(EmitSize, Dst, Src1, Const >> Op->BitShift);
+  } else {
+    const auto Src2 = GetReg(Op->Src2.ID());
+    orr(EmitSize, Dst, Src1, Src2, ARMEmitter::ShiftType::LSR, Op->BitShift);
+  }
+}
+
 DEF_OP(And) {
   auto Op = IROp->C<IR::IROp_And>();
   const uint8_t OpSize = IROp->Size;

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -84,6 +84,21 @@ DEF_OP(Add) {
   }
 }
 
+DEF_OP(TestNZ) {
+  auto Op = IROp->C<IR::IROp_TestNZ>();
+  const uint8_t OpSize = Op->Size;
+
+  LOGMAN_THROW_AA_FMT(OpSize == 4 || OpSize == 8, "Unsupported {} size: {}", __func__, OpSize);
+  const auto EmitSize = OpSize == 8 ? ARMEmitter::Size::i64Bit : ARMEmitter::Size::i32Bit;
+
+  const auto Dst = GetReg(Node);
+  const auto ZeroReg = ARMEmitter::Reg::zr;
+  cmn(EmitSize, GetReg(Op->Src1.ID()), ZeroReg);
+
+  // TODO: Optimize this out
+  mrs(Dst, ARMEmitter::SystemRegister::NZCV);
+}
+
 DEF_OP(Sub) {
   auto Op = IROp->C<IR::IROp_Sub>();
   const uint8_t OpSize = IROp->Size;

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -858,6 +858,7 @@ CPUBackend::CompiledCode Arm64JITCore::CompileCode(uint64_t Entry,
         REGISTER_OP(UMULH,             UMulH);
         REGISTER_OP(OR,                Or);
         REGISTER_OP(ORLSHL,            Orlshl);
+        REGISTER_OP(ORLSHR,            Orlshr);
         REGISTER_OP(AND,               And);
         REGISTER_OP(ANDN,              Andn);
         REGISTER_OP(XOR,               Xor);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -857,6 +857,7 @@ CPUBackend::CompiledCode Arm64JITCore::CompileCode(uint64_t Entry,
         REGISTER_OP(MULH,              MulH);
         REGISTER_OP(UMULH,             UMulH);
         REGISTER_OP(OR,                Or);
+        REGISTER_OP(ORLSHL,            Orlshl);
         REGISTER_OP(AND,               And);
         REGISTER_OP(ANDN,              Andn);
         REGISTER_OP(XOR,               Xor);
@@ -1181,7 +1182,8 @@ fextl::unique_ptr<CPUBackend> CreateArm64JITCore(FEXCore::Context::ContextImpl *
 
 CPUBackendFeatures GetArm64JITBackendFeatures() {
   return CPUBackendFeatures {
-    .SupportsStaticRegisterAllocation = true
+    .SupportsStaticRegisterAllocation = true,
+    .SupportsShiftedBitwise = true,
   };
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -845,6 +845,7 @@ CPUBackend::CompiledCode Arm64JITCore::CompileCode(uint64_t Entry,
         REGISTER_OP(INLINEENTRYPOINTOFFSET,  InlineEntrypointOffset);
         REGISTER_OP(CYCLECOUNTER,      CycleCounter);
         REGISTER_OP(ADD,               Add);
+        REGISTER_OP(TESTNZ,            TestNZ);
         REGISTER_OP(SUB,               Sub);
         REGISTER_OP(NEG,               Neg);
         REGISTER_OP(ABS,               Abs);
@@ -1185,6 +1186,7 @@ CPUBackendFeatures GetArm64JITBackendFeatures() {
   return CPUBackendFeatures {
     .SupportsStaticRegisterAllocation = true,
     .SupportsShiftedBitwise = true,
+    .SupportsFlags = true,
   };
 }
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -248,6 +248,7 @@ private:
   DEF_OP(MulH);
   DEF_OP(UMulH);
   DEF_OP(Or);
+  DEF_OP(Orlshl);
   DEF_OP(And);
   DEF_OP(Andn);
   DEF_OP(Xor);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -236,6 +236,7 @@ private:
   DEF_OP(InlineEntrypointOffset);
   DEF_OP(CycleCounter);
   DEF_OP(Add);
+  DEF_OP(TestNZ);
   DEF_OP(Sub);
   DEF_OP(Neg);
   DEF_OP(Abs);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -249,6 +249,7 @@ private:
   DEF_OP(UMulH);
   DEF_OP(Or);
   DEF_OP(Orlshl);
+  DEF_OP(Orlshr);
   DEF_OP(And);
   DEF_OP(Andn);
   DEF_OP(Xor);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -1051,12 +1051,20 @@ DEF_OP(FillRegister) {
 DEF_OP(LoadFlag) {
   auto Op = IROp->C<IR::IROp_LoadFlag>();
   auto Dst = GetReg(Node);
-  ldrb(Dst, STATE, offsetof(FEXCore::Core::CPUState, flags[0]) + Op->Flag);
+
+  if (Op->Flag == 24 /* NZCV */)
+    ldr(Dst.W(), STATE, offsetof(FEXCore::Core::CPUState, flags[0]) + Op->Flag);
+  else
+    ldrb(Dst, STATE, offsetof(FEXCore::Core::CPUState, flags[0]) + Op->Flag);
 }
 
 DEF_OP(StoreFlag) {
   auto Op = IROp->C<IR::IROp_StoreFlag>();
-  strb(GetReg(Op->Value.ID()), STATE, offsetof(FEXCore::Core::CPUState, flags[0]) + Op->Flag);
+
+  if (Op->Flag == 24 /* NZCV */)
+    str(GetReg(Op->Value.ID()).W(), STATE, offsetof(FEXCore::Core::CPUState, flags[0]) + Op->Flag);
+  else
+    strb(GetReg(Op->Value.ID()), STATE, offsetof(FEXCore::Core::CPUState, flags[0]) + Op->Flag);
 }
 
 FEXCore::ARMEmitter::ExtendedMemOperand Arm64JITCore::GenerateMemOperand(uint8_t AccessSize,

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/MemoryOps.cpp
@@ -601,14 +601,22 @@ DEF_OP(LoadFlag) {
   auto Op = IROp->C<IR::IROp_LoadFlag>();
 
   auto Dst = GetDst<RA_64>(Node);
-  movzx(Dst, byte [STATE + (offsetof(FEXCore::Core::CPUState, flags[0]) + Op->Flag)]);
+
+  if (Op->Flag == 24 /* NZCV */)
+    mov(Dst.cvt32(), dword [STATE + (offsetof(FEXCore::Core::CPUState, flags[0]) + Op->Flag)]);
+  else
+    movzx(Dst, byte [STATE + (offsetof(FEXCore::Core::CPUState, flags[0]) + Op->Flag)]);
 }
 
 DEF_OP(StoreFlag) {
   auto Op = IROp->C<IR::IROp_StoreFlag>();
 
   mov (rax, GetSrc<RA_64>(Op->Value.ID()));
-  mov(byte [STATE + (offsetof(FEXCore::Core::CPUState, flags[0]) + Op->Flag)], al);
+
+  if (Op->Flag == 24 /* NZCV */)
+    mov(dword [STATE + (offsetof(FEXCore::Core::CPUState, flags[0]) + Op->Flag)], eax);
+  else
+    mov(byte [STATE + (offsetof(FEXCore::Core::CPUState, flags[0]) + Op->Flag)], al);
 }
 
 Xbyak::RegExp X86JITCore::GenerateModRM(Xbyak::Reg Base, IR::OrderedNodeWrapper Offset, IR::MemOffsetType OffsetType, uint8_t OffsetScale) const {

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -1159,10 +1159,14 @@ private:
   }
 
   OrderedNode *GetRFLAG(unsigned BitOffset) {
-    if (IsNZCV(BitOffset))
-      return _Bfe(1, 1, IndexNZCV(BitOffset), GetNZCV());
-    else
+    if (IsNZCV(BitOffset)) {
+      if (!CachedNZCV || (PossiblySetNZCVBits & (1u << IndexNZCV(BitOffset))))
+        return _Bfe(1, 1, IndexNZCV(BitOffset), GetNZCV());
+      else
+        return _Constant(0);
+    } else {
       return _LoadFlag(BitOffset);
+    }
   }
 
   OrderedNode *SelectCC(uint8_t OP, OrderedNode *TrueValue, OrderedNode *FalseValue);

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -1081,6 +1081,10 @@ private:
     CachedNZCV = Value;
   }
 
+  void ZeroNZCV() {
+    CachedNZCV = _Constant(0);
+  }
+
   void SetN_ZeroZCV(unsigned SrcSize, OrderedNode *Res) {
     static_assert(IndexNZCV(FEXCore::X86State::RFLAG_SF_LOC) == 31);
 

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -1043,8 +1043,7 @@ private:
 
   template<unsigned BitOffset>
   void SetRFLAG(OrderedNode *Value) {
-    flagsOp = SelectionFlag::Nothing;
-    _StoreFlag(Value, BitOffset);
+    SetRFLAG(Value, BitOffset);
   }
 
   void SetRFLAG(OrderedNode *Value, unsigned BitOffset) {

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
@@ -74,7 +74,7 @@ OrderedNode *OpDispatchBuilder::GetPackedRFLAG(uint32_t FlagsMask) {
     // the byte is allowed to be garbage.
     OrderedNode *Flag = FlagOffset == FEXCore::X86State::RFLAG_PF_LOC ?
                         LoadPF() :
-                        _LoadFlag(FlagOffset);
+                        GetRFLAG(FlagOffset);
 
     Original = _Bfi(4, 1, FlagOffset, Original, Flag);
   }

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
@@ -76,7 +76,10 @@ OrderedNode *OpDispatchBuilder::GetPackedRFLAG(uint32_t FlagsMask) {
                         LoadPF() :
                         GetRFLAG(FlagOffset);
 
-    Original = _Bfi(4, 1, FlagOffset, Original, Flag);
+    if (CTX->BackendFeatures.SupportsShiftedBitwise)
+      Original = _Orlshl(Original, Flag, FlagOffset);
+    else
+      Original = _Bfi(4, 1, FlagOffset, Original, Flag);
   }
   return Original;
 }

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
@@ -702,8 +702,6 @@ void OpDispatchBuilder::CalculateFlags_ShiftLeftImmediate(uint8_t SrcSize, Order
 
   auto Zero = _Constant(0);
 
-  // Stash OF before overwriting it
-  auto OldOF = Shift != 1 ? GetRFLAG(FEXCore::X86State::RFLAG_OF_LOC) : NULL;
   SetNZ_ZeroCV(SrcSize, Res);
 
   // CF
@@ -732,7 +730,7 @@ void OpDispatchBuilder::CalculateFlags_ShiftLeftImmediate(uint8_t SrcSize, Order
     auto OF = _Bfe(1, SrcSize * 8 - 1, Xor);
     SetRFLAG<FEXCore::X86State::RFLAG_OF_LOC>(OF);
   } else {
-    SetRFLAG<FEXCore::X86State::RFLAG_OF_LOC>(OldOF);
+    // Undefined, we choose to zero as part of SetNZ_ZeroCV
   }
 }
 
@@ -742,8 +740,6 @@ void OpDispatchBuilder::CalculateFlags_SignShiftRightImmediate(uint8_t SrcSize, 
 
   auto Zero = _Constant(0);
 
-  // Stash OF before overwriting it
-  auto OldOF = Shift != 1 ? GetRFLAG(FEXCore::X86State::RFLAG_OF_LOC) : NULL;
   SetNZ_ZeroCV(SrcSize, Res);
 
   // CF
@@ -762,14 +758,9 @@ void OpDispatchBuilder::CalculateFlags_SignShiftRightImmediate(uint8_t SrcSize, 
   }
 
   // OF
-  // Only defined when Shift is 1 else undefined
-  // Only is set if the top bit was set to 1 when shifted
-  // So it is set to same value as SF
-  if (Shift == 1) {
-    /* Already zeroed */
-  } else {
-    SetRFLAG<FEXCore::X86State::RFLAG_OF_LOC>(OldOF);
-  }
+  // Only defined when Shift is 1 else undefined. Only is set if the top bit was set to 1 when
+  // shifted So it is set to zero.  In the undefined case we choose to zero as well. Since it was
+  // already zeroed there's nothing to do here.
 }
 
 void OpDispatchBuilder::CalculateFlags_ShiftRightImmediateCommon(uint8_t SrcSize, OrderedNode *Res, OrderedNode *Src1, uint64_t Shift) {

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
@@ -138,6 +138,10 @@ void OpDispatchBuilder::CalculatePF(OrderedNode *Res, OrderedNode *condition) {
 void OpDispatchBuilder::CalculateDeferredFlags(uint32_t FlagsToCalculateMask) {
   if (CurrentDeferredFlags.Type == FlagsGenerationType::TYPE_NONE) {
     // Nothing to do
+    if (CachedNZCV)
+      _StoreFlag(CachedNZCV, FEXCore::X86State::RFLAG_NZCV_LOC);
+
+    CachedNZCV = nullptr;
     return;
   }
 
@@ -320,6 +324,11 @@ void OpDispatchBuilder::CalculateDeferredFlags(uint32_t FlagsToCalculateMask) {
 
   // Done calculating
   CurrentDeferredFlags.Type = FlagsGenerationType::TYPE_NONE;
+
+  if (CachedNZCV)
+    _StoreFlag(CachedNZCV, FEXCore::X86State::RFLAG_NZCV_LOC);
+
+  CachedNZCV = nullptr;
 }
 
 void OpDispatchBuilder::CalculateFlags_ADC(uint8_t SrcSize, OrderedNode *Res, OrderedNode *Src1, OrderedNode *Src2, OrderedNode *CF) {

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
@@ -589,11 +589,7 @@ void OpDispatchBuilder::CalculateFlags_ShiftLeft(uint8_t SrcSize, OrderedNode *R
   CalculatePF(Res, Src2);
 
   // AF
-  {
-    // Undefined
-    // Set to zero anyway
-    COND_FLAG_SET(Src2, RFLAG_AF_LOC, Zero);
-  }
+  // Undefined
 
   // OF
   {

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -782,6 +782,10 @@
         "Desc": ["Integer binary or"
                 ]
       },
+      "GPR = Orlshl GPR:$Src1, GPR:$Src2, u8:$BitShift": {
+        "Desc": ["Integer binary or with logical shift left"
+                ]
+      },
       "GPR = Xor GPR:$Src1, GPR:$Src2": {
         "Desc": ["Integer binary exclusive or"
                 ]

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -786,6 +786,10 @@
         "Desc": ["Integer binary or with logical shift left"
                 ]
       },
+      "GPR = Orlshr GPR:$Src1, GPR:$Src2, u8:$BitShift": {
+        "Desc": ["Integer binary or with logical shift right"
+                ]
+      },
       "GPR = Xor GPR:$Src1, GPR:$Src2": {
         "Desc": ["Integer binary exclusive or"
                 ]

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -802,6 +802,10 @@
         "Desc": ["Integer binary AND NOT. Performs the equivalent of Src1 & ~Src2"],
         "DestSize": "std::max<uint8_t>(4, GetOpSize(_Src1))"
       },
+      "GPR = TestNZ u8:$Size, GPR:$Src1": {
+        "Desc": ["Return NZCV for a GPR, setting N and Z accordingly and zeroing C and V"],
+        "DestSize": "4"
+      },
       "GPR = Lshl u8:#Size, GPR:$Src1, GPR:$Src2": {
         "Desc": ["Integer logical shift left"
                 ],

--- a/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -707,6 +707,19 @@ bool ConstProp::ConstantPropagation(IREmitter *IREmit, const IRListView& Current
       }
     break;
     }
+    case OP_ORLSHL: {
+      auto Op = IROp->CW<IR::IROp_Orlshl>();
+      uint64_t Constant1{};
+      uint64_t Constant2{};
+
+      if (IREmit->IsValueConstant(Op->Header.Args[0], &Constant1) &&
+          IREmit->IsValueConstant(Op->Header.Args[1], &Constant2)) {
+        uint64_t NewConstant = Constant1 | (Constant2 << Op->BitShift);
+        IREmit->ReplaceWithConstant(CodeNode, NewConstant);
+        Changed = true;
+      }
+    break;
+    }
     case OP_XOR: {
       auto Op = IROp->C<IR::IROp_Xor>();
       uint64_t Constant1{};

--- a/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -690,6 +690,20 @@ bool ConstProp::ConstantPropagation(IREmitter *IREmit, const IRListView& Current
       }
     break;
     }
+    case OP_TESTNZ: {
+      auto Op = IROp->CW<IR::IROp_TestNZ>();
+      uint64_t Constant1{};
+
+      if (IREmit->IsValueConstant(Op->Header.Args[0], &Constant1)) {
+        bool N = Constant1 & (1ull << ((Op->Size * 8) - 1));
+        bool Z = Constant1 == 0;
+        uint32_t NZVC = (N ? (1u << 31) : 0) | (Z ? (1u << 30) : 0);
+
+        IREmit->ReplaceWithConstant(CodeNode, NZVC);
+        Changed = true;
+      }
+    break;
+    }
     case OP_OR: {
       auto Op = IROp->CW<IR::IROp_Or>();
       uint64_t Constant1{};

--- a/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -720,6 +720,19 @@ bool ConstProp::ConstantPropagation(IREmitter *IREmit, const IRListView& Current
       }
     break;
     }
+    case OP_ORLSHR: {
+      auto Op = IROp->CW<IR::IROp_Orlshr>();
+      uint64_t Constant1{};
+      uint64_t Constant2{};
+
+      if (IREmit->IsValueConstant(Op->Header.Args[0], &Constant1) &&
+          IREmit->IsValueConstant(Op->Header.Args[1], &Constant2)) {
+        uint64_t NewConstant = Constant1 | (Constant2 >> Op->BitShift);
+        IREmit->ReplaceWithConstant(CodeNode, NewConstant);
+        Changed = true;
+      }
+    break;
+    }
     case OP_XOR: {
       auto Op = IROp->C<IR::IROp_Xor>();
       uint64_t Constant1{};

--- a/External/FEXCore/include/FEXCore/Core/CPUBackend.h
+++ b/External/FEXCore/include/FEXCore/Core/CPUBackend.h
@@ -36,6 +36,7 @@ namespace CPU {
   struct CPUBackendFeatures {
     bool SupportsStaticRegisterAllocation = false;
     bool SupportsShiftedBitwise = false;
+    bool SupportsFlags = false;
   };
 
   class CPUBackend {

--- a/External/FEXCore/include/FEXCore/Core/CPUBackend.h
+++ b/External/FEXCore/include/FEXCore/Core/CPUBackend.h
@@ -35,6 +35,7 @@ namespace CodeSerialize {
 namespace CPU {
   struct CPUBackendFeatures {
     bool SupportsStaticRegisterAllocation = false;
+    bool SupportsShiftedBitwise = false;
   };
 
   class CPUBackend {

--- a/External/FEXCore/include/FEXCore/Core/X86Enums.h
+++ b/External/FEXCore/include/FEXCore/Core/X86Enums.h
@@ -74,6 +74,13 @@ enum X86RegLocation : uint32_t {
   RFLAG_VIP_LOC   = 20,
   RFLAG_ID_LOC    = 21,
 
+  // So we can implement arm64-like flag manipulaton on the interpreter/x86 jit..
+  // SF/ZF/CF/OF packed into a 32-bit word, matching arm64's NZCV structure (not semantics).
+  RFLAG_NZCV_LOC   = 24,
+  RFLAG_NZCV_1_LOC = 25,
+  RFLAG_NZCV_2_LOC = 26,
+  RFLAG_NZCV_3_LOC = 27,
+
 // So we can share flag handling logic, we put x87 flags after RFLAGS
   X87FLAG_BASE    = 32,
   X87FLAG_IE_LOC  = 32,


### PR DESCRIPTION
This is the first piece of the NZCV flags puzzle. Instead of having 4 distinct bytes for the four SF/ZF/CF/OF flags, we have a single packed 32-bit word, with SF in bit 31, ZF in bit 30, CF in bit 29, and OF in bit 28. This layout matches the structure of arm64's native NZCV register (semantics diverge with the inverted carry flag, though). That means we can calculate the packed flags with the help of arm64 flag setting registers. In other cases we can calculate this packed format in software, but still end up ahead (compared to 4 `strb`s) with clever use of bitwise operations. In particular, arm's shift-then-OR instructions are invaluable for this.

This is showing instruction count improvements on some synthetic unit tests I'm looking at. I haven't benchmarked it. The really fruitful gains will come later when we teach RA about the host flags, reducing the load/store traffic still incurred here. This PR is a step in that direction: it gets the code in place to calculate flags, the later work will just be about how those calculated values get stored.

There's also a lot of room to calculate flag values more efficiently, especially when FlagM is present, by using instructions like `adds` and `cfinv` but that's for later work.