### PR TITLE
FEXCore: Remove erroneous asserts in the project

### DIFF
--- a/External/FEXCore/Scripts/json_ir_generator.py
+++ b/External/FEXCore/Scripts/json_ir_generator.py
@@ -675,7 +675,7 @@ def print_ir_allocator_helpers():
                 output_file.write("\t\t#if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED\n")
 
                 for Validation in op.EmitValidation:
-                    output_file.write("\t\tassert({});\n".format(Validation))
+                    output_file.write("\tLOGMAN_THROW_A_FMT({}, \"\");\n".format(Validation))
                 output_file.write("\t\t#endif\n")
 
             output_file.write("\t\treturn Op;\n")

--- a/External/FEXCore/Source/Interface/Config/Config.cpp
+++ b/External/FEXCore/Source/Interface/Config/Config.cpp
@@ -17,7 +17,6 @@
 #include <FEXHeaderUtils/Filesystem.h>
 
 #include <array>
-#include <assert.h>
 #include <cstdlib>
 #include <functional>
 #include <optional>
@@ -453,7 +452,7 @@ namespace DefaultValues {
     auto Value = FEXCore::Config::Get(Option);
 
     if (!FEXCore::StrConv::Conv(**Value, &Result)) {
-      assert(0 && "Attempted to convert invalid value");
+      LOGMAN_MSG_A_FMT("Attempted to convert invalid value");
     }
     return Result;
   }

--- a/External/FEXCore/Source/Interface/Core/Frontend.cpp
+++ b/External/FEXCore/Source/Interface/Core/Frontend.cpp
@@ -10,7 +10,6 @@ $end_info$
 #include "Interface/Core/X86Tables/X86Tables.h"
 
 #include <array>
-#include <assert.h>
 #include <algorithm>
 #include <cstring>
 #include <FEXCore/Config/Config.h>
@@ -965,7 +964,7 @@ bool Decoder::DecodeInstruction(uint64_t PC) {
   }
 
   if (DecodeInst->Dest.IsGPR()) {
-    assert(DecodeInst->Dest.Data.GPR.GPR != FEXCore::X86State::REG_INVALID);
+    LOGMAN_THROW_A_FMT(DecodeInst->Dest.Data.GPR.GPR != FEXCore::X86State::REG_INVALID, "Destination GPR was invalid");
   }
 
   return true;

--- a/External/FEXCore/include/FEXCore/IR/IntrusiveIRList.h
+++ b/External/FEXCore/include/FEXCore/IR/IntrusiveIRList.h
@@ -7,7 +7,6 @@
 #include <FEXCore/Utils/ThreadPoolAllocator.h>
 #include <FEXCore/fextl/vector.h>
 
-#include <cassert>
 #include <cstddef>
 #include <cstring>
 #include <tuple>
@@ -35,7 +34,7 @@ class DualIntrusiveAllocator {
     }
 
     [[nodiscard]] void *DataAllocate(size_t Size) {
-      assert(DataCheckSize(Size) &&
+      LOGMAN_THROW_A_FMT(DataCheckSize(Size),
         "Ran out of space in DualIntrusiveAllocator during allocation");
       size_t NewOffset = DataCurrentOffset + Size;
       uintptr_t NewPointer = Data + DataCurrentOffset;
@@ -44,7 +43,7 @@ class DualIntrusiveAllocator {
     }
 
     [[nodiscard]] void *ListAllocate(size_t Size) {
-      assert(ListCheckSize(Size) &&
+      LOGMAN_THROW_A_FMT(ListCheckSize(Size),
         "Ran out of space in DualIntrusiveAllocator during allocation");
       size_t NewOffset = ListCurrentOffset + Size;
       uintptr_t NewPointer = List + ListCurrentOffset;


### PR DESCRIPTION
Inspired by #2832 by going through the source and removing uses of `assert`.

assert doesn't work for us in debug builds because some games will capture SIGABRT and continue running. So we need to use FEX's built in assert handlers which call `FEX_TRAP_EXECUTION` which will take down the FEX process as expected.

There wasn't too much usage of this in the source, so this is relatively straightforward.