### PR TITLE
ARMEmitter: Finish off remaining SVE Integer Wide Immediate - Unpredicated categories

### DIFF
--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
@@ -1473,7 +1473,9 @@ public:
   }
 
   // SVE integer multiply immediate (unpredicated)
-  // XXX:
+  void mul(SubRegSize size, ZRegister zd, ZRegister zn, int32_t imm) {
+    SVEMultiplyImmediateUnpred(0b000, size, zd, zn, imm);
+  }
 
   // SVE broadcast integer immediate (unpredicated)
   void dup_imm(FEXCore::ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::ZRegister zd, int32_t Value, bool LSL8 = false) {
@@ -3209,6 +3211,22 @@ private:
     const auto imm8 = static_cast<uint32_t>(imm) & 0xFF;
 
     uint32_t Instr = 0b0010'0101'0010'1000'1100'0000'0000'0000;
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= opc << 16;
+    Instr |= imm8 << 5;
+    Instr |= zd.Idx();
+    dc32(Instr);
+  }
+
+  void SVEMultiplyImmediateUnpred(uint32_t opc, SubRegSize size, ZRegister zd, ZRegister zn, int32_t imm) {
+    LOGMAN_THROW_AA_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit element size");
+    LOGMAN_THROW_A_FMT(zd == zn, "zd needs to equal zn");
+    LOGMAN_THROW_AA_FMT(imm >= -128 && imm <= 127,
+                        "Invalid immediate ({}). Must be within [-127, 128]", imm);
+
+    const auto imm8 = static_cast<uint32_t>(imm) & 0xFF;
+
+    uint32_t Instr = 0b0010'0101'0011'0000'1100'0000'0000'0000;
     Instr |= FEXCore::ToUnderlying(size) << 22;
     Instr |= opc << 16;
     Instr |= imm8 << 5;

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
@@ -1436,7 +1436,28 @@ public:
 
   // SVE Integer Wide Immediate - Unpredicated
   // SVE integer add/subtract immediate (unpredicated)
-  // XXX:
+  void add(SubRegSize size, ZRegister zd, ZRegister zn, uint32_t imm) {
+    SVEAddSubImmediateUnpred(0b000, size, zd, zn, imm);
+  }
+  void sub(SubRegSize size, ZRegister zd, ZRegister zn, uint32_t imm) {
+    SVEAddSubImmediateUnpred(0b001, size, zd, zn, imm);
+  }
+  void subr(SubRegSize size, ZRegister zd, ZRegister zn, uint32_t imm) {
+    SVEAddSubImmediateUnpred(0b011, size, zd, zn, imm);
+  }
+  void sqadd(SubRegSize size, ZRegister zd, ZRegister zn, uint32_t imm) {
+    SVEAddSubImmediateUnpred(0b100, size, zd, zn, imm);
+  }
+  void uqadd(SubRegSize size, ZRegister zd, ZRegister zn, uint32_t imm) {
+    SVEAddSubImmediateUnpred(0b101, size, zd, zn, imm);
+  }
+  void sqsub(SubRegSize size, ZRegister zd, ZRegister zn, uint32_t imm) {
+    SVEAddSubImmediateUnpred(0b110, size, zd, zn, imm);
+  }
+  void uqsub(SubRegSize size, ZRegister zd, ZRegister zn, uint32_t imm) {
+    SVEAddSubImmediateUnpred(0b111, size, zd, zn, imm);
+  }
+
   // SVE integer min/max immediate (unpredicated)
   // XXX:
   // SVE integer multiply immediate (unpredicated)
@@ -3128,6 +3149,35 @@ private:
     Instr |= tsz << 16;
     Instr |= Encode_rn(zn);
     Instr |= Encode_rd(zd);
+    dc32(Instr);
+  }
+
+  void SVEAddSubImmediateUnpred(uint32_t opc, SubRegSize size, ZRegister zd, ZRegister zn, uint32_t imm) {
+    LOGMAN_THROW_AA_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit element size");
+    LOGMAN_THROW_A_FMT(zd == zn, "zd needs to equal zn");
+
+    const bool is_uint8_imm = (imm >> 8) == 0;
+    if (size == SubRegSize::i8Bit) {
+      LOGMAN_THROW_AA_FMT(is_uint8_imm, "Can't perform LSL #8 shift on 8-bit elements.");
+    }
+
+    uint32_t shift = 0;
+    if (!is_uint8_imm) {
+      const bool is_uint16_imm = (imm >> 16) == 0;
+
+      LOGMAN_THROW_AA_FMT(is_uint16_imm, "Immediate ({}) must be a 16-bit value within [256, 65280]", imm);
+      LOGMAN_THROW_AA_FMT((imm % 256) == 0, "Immediate ({}) must be a multiple of 256", imm);
+
+      imm /= 256;
+      shift = 1;
+    }
+
+    uint32_t Instr = 0b0010'0101'0010'0000'1100'0000'0000'0000;
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= opc << 16;
+    Instr |= shift << 13;
+    Instr |= imm << 5;
+    Instr |= zd.Idx();
     dc32(Instr);
   }
 

--- a/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
+++ b/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
@@ -1983,7 +1983,180 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE pointer conflict compare")
 }
 
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE integer add/subtract immediate (unpredicated)") {
-  // TODO: Implement in emitter.
+  TEST_SINGLE(add(SubRegSize::i8Bit,  ZReg::z30, ZReg::z30, 0),     "add z30.b, z30.b, #0");
+  TEST_SINGLE(add(SubRegSize::i8Bit,  ZReg::z30, ZReg::z30, 127),   "add z30.b, z30.b, #127");
+  TEST_SINGLE(add(SubRegSize::i8Bit,  ZReg::z30, ZReg::z30, 255),   "add z30.b, z30.b, #255");
+
+  TEST_SINGLE(add(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 0),     "add z30.h, z30.h, #0");
+  TEST_SINGLE(add(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 127),   "add z30.h, z30.h, #127");
+  TEST_SINGLE(add(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 255),   "add z30.h, z30.h, #255");
+  TEST_SINGLE(add(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 256),   "add z30.h, z30.h, #1, lsl #8");
+  TEST_SINGLE(add(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 32512), "add z30.h, z30.h, #127, lsl #8");
+  TEST_SINGLE(add(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 65280), "add z30.h, z30.h, #255, lsl #8");
+
+  TEST_SINGLE(add(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 0),     "add z30.s, z30.s, #0");
+  TEST_SINGLE(add(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 127),   "add z30.s, z30.s, #127");
+  TEST_SINGLE(add(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 255),   "add z30.s, z30.s, #255");
+  TEST_SINGLE(add(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 256),   "add z30.s, z30.s, #1, lsl #8");
+  TEST_SINGLE(add(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 32512), "add z30.s, z30.s, #127, lsl #8");
+  TEST_SINGLE(add(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 65280), "add z30.s, z30.s, #255, lsl #8");
+
+  TEST_SINGLE(add(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 0),     "add z30.d, z30.d, #0");
+  TEST_SINGLE(add(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 127),   "add z30.d, z30.d, #127");
+  TEST_SINGLE(add(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 255),   "add z30.d, z30.d, #255");
+  TEST_SINGLE(add(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 256),   "add z30.d, z30.d, #1, lsl #8");
+  TEST_SINGLE(add(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 32512), "add z30.d, z30.d, #127, lsl #8");
+  TEST_SINGLE(add(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 65280), "add z30.d, z30.d, #255, lsl #8");
+
+  TEST_SINGLE(sub(SubRegSize::i8Bit,  ZReg::z30, ZReg::z30, 0),     "sub z30.b, z30.b, #0");
+  TEST_SINGLE(sub(SubRegSize::i8Bit,  ZReg::z30, ZReg::z30, 127),   "sub z30.b, z30.b, #127");
+  TEST_SINGLE(sub(SubRegSize::i8Bit,  ZReg::z30, ZReg::z30, 255),   "sub z30.b, z30.b, #255");
+
+  TEST_SINGLE(sub(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 0),     "sub z30.h, z30.h, #0");
+  TEST_SINGLE(sub(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 127),   "sub z30.h, z30.h, #127");
+  TEST_SINGLE(sub(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 255),   "sub z30.h, z30.h, #255");
+  TEST_SINGLE(sub(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 256),   "sub z30.h, z30.h, #1, lsl #8");
+  TEST_SINGLE(sub(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 32512), "sub z30.h, z30.h, #127, lsl #8");
+  TEST_SINGLE(sub(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 65280), "sub z30.h, z30.h, #255, lsl #8");
+
+  TEST_SINGLE(sub(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 0),     "sub z30.s, z30.s, #0");
+  TEST_SINGLE(sub(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 127),   "sub z30.s, z30.s, #127");
+  TEST_SINGLE(sub(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 255),   "sub z30.s, z30.s, #255");
+  TEST_SINGLE(sub(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 256),   "sub z30.s, z30.s, #1, lsl #8");
+  TEST_SINGLE(sub(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 32512), "sub z30.s, z30.s, #127, lsl #8");
+  TEST_SINGLE(sub(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 65280), "sub z30.s, z30.s, #255, lsl #8");
+
+  TEST_SINGLE(sub(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 0),     "sub z30.d, z30.d, #0");
+  TEST_SINGLE(sub(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 127),   "sub z30.d, z30.d, #127");
+  TEST_SINGLE(sub(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 255),   "sub z30.d, z30.d, #255");
+  TEST_SINGLE(sub(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 256),   "sub z30.d, z30.d, #1, lsl #8");
+  TEST_SINGLE(sub(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 32512), "sub z30.d, z30.d, #127, lsl #8");
+  TEST_SINGLE(sub(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 65280), "sub z30.d, z30.d, #255, lsl #8");
+
+  TEST_SINGLE(subr(SubRegSize::i8Bit,  ZReg::z30, ZReg::z30, 0),     "subr z30.b, z30.b, #0");
+  TEST_SINGLE(subr(SubRegSize::i8Bit,  ZReg::z30, ZReg::z30, 127),   "subr z30.b, z30.b, #127");
+  TEST_SINGLE(subr(SubRegSize::i8Bit,  ZReg::z30, ZReg::z30, 255),   "subr z30.b, z30.b, #255");
+
+  TEST_SINGLE(subr(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 0),     "subr z30.h, z30.h, #0");
+  TEST_SINGLE(subr(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 127),   "subr z30.h, z30.h, #127");
+  TEST_SINGLE(subr(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 255),   "subr z30.h, z30.h, #255");
+  TEST_SINGLE(subr(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 256),   "subr z30.h, z30.h, #1, lsl #8");
+  TEST_SINGLE(subr(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 32512), "subr z30.h, z30.h, #127, lsl #8");
+  TEST_SINGLE(subr(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 65280), "subr z30.h, z30.h, #255, lsl #8");
+
+  TEST_SINGLE(subr(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 0),     "subr z30.s, z30.s, #0");
+  TEST_SINGLE(subr(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 127),   "subr z30.s, z30.s, #127");
+  TEST_SINGLE(subr(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 255),   "subr z30.s, z30.s, #255");
+  TEST_SINGLE(subr(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 256),   "subr z30.s, z30.s, #1, lsl #8");
+  TEST_SINGLE(subr(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 32512), "subr z30.s, z30.s, #127, lsl #8");
+  TEST_SINGLE(subr(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 65280), "subr z30.s, z30.s, #255, lsl #8");
+
+  TEST_SINGLE(subr(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 0),     "subr z30.d, z30.d, #0");
+  TEST_SINGLE(subr(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 127),   "subr z30.d, z30.d, #127");
+  TEST_SINGLE(subr(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 255),   "subr z30.d, z30.d, #255");
+  TEST_SINGLE(subr(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 256),   "subr z30.d, z30.d, #1, lsl #8");
+  TEST_SINGLE(subr(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 32512), "subr z30.d, z30.d, #127, lsl #8");
+  TEST_SINGLE(subr(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 65280), "subr z30.d, z30.d, #255, lsl #8");
+
+  TEST_SINGLE(sqadd(SubRegSize::i8Bit,  ZReg::z30, ZReg::z30, 0),     "sqadd z30.b, z30.b, #0");
+  TEST_SINGLE(sqadd(SubRegSize::i8Bit,  ZReg::z30, ZReg::z30, 127),   "sqadd z30.b, z30.b, #127");
+  TEST_SINGLE(sqadd(SubRegSize::i8Bit,  ZReg::z30, ZReg::z30, 255),   "sqadd z30.b, z30.b, #255");
+
+  TEST_SINGLE(sqadd(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 0),     "sqadd z30.h, z30.h, #0");
+  TEST_SINGLE(sqadd(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 127),   "sqadd z30.h, z30.h, #127");
+  TEST_SINGLE(sqadd(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 255),   "sqadd z30.h, z30.h, #255");
+  TEST_SINGLE(sqadd(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 256),   "sqadd z30.h, z30.h, #1, lsl #8");
+  TEST_SINGLE(sqadd(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 32512), "sqadd z30.h, z30.h, #127, lsl #8");
+  TEST_SINGLE(sqadd(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 65280), "sqadd z30.h, z30.h, #255, lsl #8");
+
+  TEST_SINGLE(sqadd(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 0),     "sqadd z30.s, z30.s, #0");
+  TEST_SINGLE(sqadd(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 127),   "sqadd z30.s, z30.s, #127");
+  TEST_SINGLE(sqadd(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 255),   "sqadd z30.s, z30.s, #255");
+  TEST_SINGLE(sqadd(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 256),   "sqadd z30.s, z30.s, #1, lsl #8");
+  TEST_SINGLE(sqadd(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 32512), "sqadd z30.s, z30.s, #127, lsl #8");
+  TEST_SINGLE(sqadd(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 65280), "sqadd z30.s, z30.s, #255, lsl #8");
+
+  TEST_SINGLE(sqadd(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 0),     "sqadd z30.d, z30.d, #0");
+  TEST_SINGLE(sqadd(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 127),   "sqadd z30.d, z30.d, #127");
+  TEST_SINGLE(sqadd(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 255),   "sqadd z30.d, z30.d, #255");
+  TEST_SINGLE(sqadd(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 256),   "sqadd z30.d, z30.d, #1, lsl #8");
+  TEST_SINGLE(sqadd(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 32512), "sqadd z30.d, z30.d, #127, lsl #8");
+  TEST_SINGLE(sqadd(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 65280), "sqadd z30.d, z30.d, #255, lsl #8");
+
+  TEST_SINGLE(uqadd(SubRegSize::i8Bit,  ZReg::z30, ZReg::z30, 0),     "uqadd z30.b, z30.b, #0");
+  TEST_SINGLE(uqadd(SubRegSize::i8Bit,  ZReg::z30, ZReg::z30, 127),   "uqadd z30.b, z30.b, #127");
+  TEST_SINGLE(uqadd(SubRegSize::i8Bit,  ZReg::z30, ZReg::z30, 255),   "uqadd z30.b, z30.b, #255");
+
+  TEST_SINGLE(uqadd(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 0),     "uqadd z30.h, z30.h, #0");
+  TEST_SINGLE(uqadd(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 127),   "uqadd z30.h, z30.h, #127");
+  TEST_SINGLE(uqadd(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 255),   "uqadd z30.h, z30.h, #255");
+  TEST_SINGLE(uqadd(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 256),   "uqadd z30.h, z30.h, #1, lsl #8");
+  TEST_SINGLE(uqadd(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 32512), "uqadd z30.h, z30.h, #127, lsl #8");
+  TEST_SINGLE(uqadd(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 65280), "uqadd z30.h, z30.h, #255, lsl #8");
+
+  TEST_SINGLE(uqadd(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 0),     "uqadd z30.s, z30.s, #0");
+  TEST_SINGLE(uqadd(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 127),   "uqadd z30.s, z30.s, #127");
+  TEST_SINGLE(uqadd(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 255),   "uqadd z30.s, z30.s, #255");
+  TEST_SINGLE(uqadd(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 256),   "uqadd z30.s, z30.s, #1, lsl #8");
+  TEST_SINGLE(uqadd(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 32512), "uqadd z30.s, z30.s, #127, lsl #8");
+  TEST_SINGLE(uqadd(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 65280), "uqadd z30.s, z30.s, #255, lsl #8");
+
+  TEST_SINGLE(uqadd(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 0),     "uqadd z30.d, z30.d, #0");
+  TEST_SINGLE(uqadd(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 127),   "uqadd z30.d, z30.d, #127");
+  TEST_SINGLE(uqadd(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 255),   "uqadd z30.d, z30.d, #255");
+  TEST_SINGLE(uqadd(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 256),   "uqadd z30.d, z30.d, #1, lsl #8");
+  TEST_SINGLE(uqadd(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 32512), "uqadd z30.d, z30.d, #127, lsl #8");
+  TEST_SINGLE(uqadd(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 65280), "uqadd z30.d, z30.d, #255, lsl #8");
+
+  TEST_SINGLE(sqsub(SubRegSize::i8Bit,  ZReg::z30, ZReg::z30, 0),     "sqsub z30.b, z30.b, #0");
+  TEST_SINGLE(sqsub(SubRegSize::i8Bit,  ZReg::z30, ZReg::z30, 127),   "sqsub z30.b, z30.b, #127");
+  TEST_SINGLE(sqsub(SubRegSize::i8Bit,  ZReg::z30, ZReg::z30, 255),   "sqsub z30.b, z30.b, #255");
+
+  TEST_SINGLE(sqsub(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 0),     "sqsub z30.h, z30.h, #0");
+  TEST_SINGLE(sqsub(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 127),   "sqsub z30.h, z30.h, #127");
+  TEST_SINGLE(sqsub(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 255),   "sqsub z30.h, z30.h, #255");
+  TEST_SINGLE(sqsub(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 256),   "sqsub z30.h, z30.h, #1, lsl #8");
+  TEST_SINGLE(sqsub(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 32512), "sqsub z30.h, z30.h, #127, lsl #8");
+  TEST_SINGLE(sqsub(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 65280), "sqsub z30.h, z30.h, #255, lsl #8");
+
+  TEST_SINGLE(sqsub(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 0),     "sqsub z30.s, z30.s, #0");
+  TEST_SINGLE(sqsub(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 127),   "sqsub z30.s, z30.s, #127");
+  TEST_SINGLE(sqsub(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 255),   "sqsub z30.s, z30.s, #255");
+  TEST_SINGLE(sqsub(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 256),   "sqsub z30.s, z30.s, #1, lsl #8");
+  TEST_SINGLE(sqsub(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 32512), "sqsub z30.s, z30.s, #127, lsl #8");
+  TEST_SINGLE(sqsub(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 65280), "sqsub z30.s, z30.s, #255, lsl #8");
+
+  TEST_SINGLE(sqsub(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 0),     "sqsub z30.d, z30.d, #0");
+  TEST_SINGLE(sqsub(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 127),   "sqsub z30.d, z30.d, #127");
+  TEST_SINGLE(sqsub(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 255),   "sqsub z30.d, z30.d, #255");
+  TEST_SINGLE(sqsub(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 256),   "sqsub z30.d, z30.d, #1, lsl #8");
+  TEST_SINGLE(sqsub(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 32512), "sqsub z30.d, z30.d, #127, lsl #8");
+  TEST_SINGLE(sqsub(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 65280), "sqsub z30.d, z30.d, #255, lsl #8");
+
+  TEST_SINGLE(uqsub(SubRegSize::i8Bit,  ZReg::z30, ZReg::z30, 0),     "uqsub z30.b, z30.b, #0");
+  TEST_SINGLE(uqsub(SubRegSize::i8Bit,  ZReg::z30, ZReg::z30, 127),   "uqsub z30.b, z30.b, #127");
+  TEST_SINGLE(uqsub(SubRegSize::i8Bit,  ZReg::z30, ZReg::z30, 255),   "uqsub z30.b, z30.b, #255");
+
+  TEST_SINGLE(uqsub(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 0),     "uqsub z30.h, z30.h, #0");
+  TEST_SINGLE(uqsub(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 127),   "uqsub z30.h, z30.h, #127");
+  TEST_SINGLE(uqsub(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 255),   "uqsub z30.h, z30.h, #255");
+  TEST_SINGLE(uqsub(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 256),   "uqsub z30.h, z30.h, #1, lsl #8");
+  TEST_SINGLE(uqsub(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 32512), "uqsub z30.h, z30.h, #127, lsl #8");
+  TEST_SINGLE(uqsub(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 65280), "uqsub z30.h, z30.h, #255, lsl #8");
+
+  TEST_SINGLE(uqsub(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 0),     "uqsub z30.s, z30.s, #0");
+  TEST_SINGLE(uqsub(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 127),   "uqsub z30.s, z30.s, #127");
+  TEST_SINGLE(uqsub(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 255),   "uqsub z30.s, z30.s, #255");
+  TEST_SINGLE(uqsub(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 256),   "uqsub z30.s, z30.s, #1, lsl #8");
+  TEST_SINGLE(uqsub(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 32512), "uqsub z30.s, z30.s, #127, lsl #8");
+  TEST_SINGLE(uqsub(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 65280), "uqsub z30.s, z30.s, #255, lsl #8");
+
+  TEST_SINGLE(uqsub(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 0),     "uqsub z30.d, z30.d, #0");
+  TEST_SINGLE(uqsub(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 127),   "uqsub z30.d, z30.d, #127");
+  TEST_SINGLE(uqsub(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 255),   "uqsub z30.d, z30.d, #255");
+  TEST_SINGLE(uqsub(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 256),   "uqsub z30.d, z30.d, #1, lsl #8");
+  TEST_SINGLE(uqsub(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 32512), "uqsub z30.d, z30.d, #127, lsl #8");
+  TEST_SINGLE(uqsub(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 65280), "uqsub z30.d, z30.d, #255, lsl #8");
 }
 
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE integer min/max immediate (unpredicated)") {

--- a/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
+++ b/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
@@ -2226,7 +2226,21 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE integer min/max immediate 
 }
 
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE integer multiply immediate (unpredicated)") {
-  // TODO: Implement in emitter.
+  TEST_SINGLE(mul(SubRegSize::i8Bit,  ZReg::z30, ZReg::z30, 0),     "mul z30.b, z30.b, #0");
+  TEST_SINGLE(mul(SubRegSize::i8Bit,  ZReg::z30, ZReg::z30, -128),  "mul z30.b, z30.b, #-128");
+  TEST_SINGLE(mul(SubRegSize::i8Bit,  ZReg::z30, ZReg::z30, 127),   "mul z30.b, z30.b, #127");
+
+  TEST_SINGLE(mul(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 0),     "mul z30.h, z30.h, #0");
+  TEST_SINGLE(mul(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, -128),  "mul z30.h, z30.h, #-128");
+  TEST_SINGLE(mul(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 127),   "mul z30.h, z30.h, #127");
+
+  TEST_SINGLE(mul(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 0),     "mul z30.s, z30.s, #0");
+  TEST_SINGLE(mul(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, -128),  "mul z30.s, z30.s, #-128");
+  TEST_SINGLE(mul(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 127),   "mul z30.s, z30.s, #127");
+
+  TEST_SINGLE(mul(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 0),     "mul z30.d, z30.d, #0");
+  TEST_SINGLE(mul(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, -128),  "mul z30.d, z30.d, #-128");
+  TEST_SINGLE(mul(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 127),   "mul z30.d, z30.d, #127");
 }
 
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE broadcast integer immediate (unpredicated)") {

--- a/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
+++ b/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
@@ -2160,7 +2160,69 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE integer add/subtract immed
 }
 
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE integer min/max immediate (unpredicated)") {
-  // TODO: Implement in emitter.
+  TEST_SINGLE(smax(SubRegSize::i8Bit,  ZReg::z30, ZReg::z30, 0),     "smax z30.b, z30.b, #0");
+  TEST_SINGLE(smax(SubRegSize::i8Bit,  ZReg::z30, ZReg::z30, -128),  "smax z30.b, z30.b, #-128");
+  TEST_SINGLE(smax(SubRegSize::i8Bit,  ZReg::z30, ZReg::z30, 127),   "smax z30.b, z30.b, #127");
+
+  TEST_SINGLE(smax(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 0),     "smax z30.h, z30.h, #0");
+  TEST_SINGLE(smax(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, -128),  "smax z30.h, z30.h, #-128");
+  TEST_SINGLE(smax(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 127),   "smax z30.h, z30.h, #127");
+
+  TEST_SINGLE(smax(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 0),     "smax z30.s, z30.s, #0");
+  TEST_SINGLE(smax(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, -128),  "smax z30.s, z30.s, #-128");
+  TEST_SINGLE(smax(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 127),   "smax z30.s, z30.s, #127");
+
+  TEST_SINGLE(smax(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 0),     "smax z30.d, z30.d, #0");
+  TEST_SINGLE(smax(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, -128),  "smax z30.d, z30.d, #-128");
+  TEST_SINGLE(smax(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 127),   "smax z30.d, z30.d, #127");
+
+  TEST_SINGLE(smin(SubRegSize::i8Bit,  ZReg::z30, ZReg::z30, 0),     "smin z30.b, z30.b, #0");
+  TEST_SINGLE(smin(SubRegSize::i8Bit,  ZReg::z30, ZReg::z30, -128),  "smin z30.b, z30.b, #-128");
+  TEST_SINGLE(smin(SubRegSize::i8Bit,  ZReg::z30, ZReg::z30, 127),   "smin z30.b, z30.b, #127");
+
+  TEST_SINGLE(smin(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 0),     "smin z30.h, z30.h, #0");
+  TEST_SINGLE(smin(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, -128),  "smin z30.h, z30.h, #-128");
+  TEST_SINGLE(smin(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 127),   "smin z30.h, z30.h, #127");
+
+  TEST_SINGLE(smin(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 0),     "smin z30.s, z30.s, #0");
+  TEST_SINGLE(smin(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, -128),  "smin z30.s, z30.s, #-128");
+  TEST_SINGLE(smin(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 127),   "smin z30.s, z30.s, #127");
+
+  TEST_SINGLE(smin(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 0),     "smin z30.d, z30.d, #0");
+  TEST_SINGLE(smin(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, -128),  "smin z30.d, z30.d, #-128");
+  TEST_SINGLE(smin(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 127),   "smin z30.d, z30.d, #127");
+
+  TEST_SINGLE(umax(SubRegSize::i8Bit,  ZReg::z30, ZReg::z30, 0),     "umax z30.b, z30.b, #0");
+  TEST_SINGLE(umax(SubRegSize::i8Bit,  ZReg::z30, ZReg::z30, 127),   "umax z30.b, z30.b, #127");
+  TEST_SINGLE(umax(SubRegSize::i8Bit,  ZReg::z30, ZReg::z30, 255),   "umax z30.b, z30.b, #255");
+
+  TEST_SINGLE(umax(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 0),     "umax z30.h, z30.h, #0");
+  TEST_SINGLE(umax(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 127),   "umax z30.h, z30.h, #127");
+  TEST_SINGLE(umax(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 255),   "umax z30.h, z30.h, #255");
+
+  TEST_SINGLE(umax(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 0),     "umax z30.s, z30.s, #0");
+  TEST_SINGLE(umax(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 127),   "umax z30.s, z30.s, #127");
+  TEST_SINGLE(umax(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 255),   "umax z30.s, z30.s, #255");
+
+  TEST_SINGLE(umax(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 0),     "umax z30.d, z30.d, #0");
+  TEST_SINGLE(umax(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 127),   "umax z30.d, z30.d, #127");
+  TEST_SINGLE(umax(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 255),   "umax z30.d, z30.d, #255");
+
+  TEST_SINGLE(umin(SubRegSize::i8Bit,  ZReg::z30, ZReg::z30, 0),     "umin z30.b, z30.b, #0");
+  TEST_SINGLE(umin(SubRegSize::i8Bit,  ZReg::z30, ZReg::z30, 127),   "umin z30.b, z30.b, #127");
+  TEST_SINGLE(umin(SubRegSize::i8Bit,  ZReg::z30, ZReg::z30, 255),   "umin z30.b, z30.b, #255");
+
+  TEST_SINGLE(umin(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 0),     "umin z30.h, z30.h, #0");
+  TEST_SINGLE(umin(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 127),   "umin z30.h, z30.h, #127");
+  TEST_SINGLE(umin(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, 255),   "umin z30.h, z30.h, #255");
+
+  TEST_SINGLE(umin(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 0),     "umin z30.s, z30.s, #0");
+  TEST_SINGLE(umin(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 127),   "umin z30.s, z30.s, #127");
+  TEST_SINGLE(umin(SubRegSize::i32Bit, ZReg::z30, ZReg::z30, 255),   "umin z30.s, z30.s, #255");
+
+  TEST_SINGLE(umin(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 0),     "umin z30.d, z30.d, #0");
+  TEST_SINGLE(umin(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 127),   "umin z30.d, z30.d, #127");
+  TEST_SINGLE(umin(SubRegSize::i64Bit, ZReg::z30, ZReg::z30, 255),   "umin z30.d, z30.d, #255");
 }
 
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE integer multiply immediate (unpredicated)") {


### PR DESCRIPTION
Crosses off the lingering TODOs for this group