### PR TITLE
OpcodeDispatcher: Fixes SHRD by immediate OF flag calculation

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -2081,7 +2081,7 @@ void OpDispatchBuilder::SHRDImmediateOp(OpcodeArgs) {
     }
 
     StoreResult(GPRClass, Op, Res, -1);
-    GenerateFlags_ShiftRightImmediate(Op, Res, Dest, Shift);
+    GenerateFlags_ShiftRightDoubleImmediate(Op, Res, Dest, Shift);
   }
   else if (Shift == 0 && Size == 32) {
     // Ensure Zext still occurs

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -42,6 +42,7 @@ public:
     TYPE_LSHLI,
     TYPE_LSHR,
     TYPE_LSHRI,
+    TYPE_LSHRDI,
     TYPE_ASHR,
     TYPE_ASHRI,
     TYPE_ROR,
@@ -1173,6 +1174,8 @@ private:
   void CalculateFlags_ShiftLeftImmediate(uint8_t SrcSize, OrderedNode *Res, OrderedNode *Src1, uint64_t Shift);
   void CalculateFlags_ShiftRight(uint8_t SrcSize, OrderedNode *Res, OrderedNode *Src1, OrderedNode *Src2);
   void CalculateFlags_ShiftRightImmediate(uint8_t SrcSize, OrderedNode *Res, OrderedNode *Src1, uint64_t Shift);
+  void CalculateFlags_ShiftRightDoubleImmediate(uint8_t SrcSize, OrderedNode *Res, OrderedNode *Src1, uint64_t Shift);
+  void CalculateFlags_ShiftRightImmediateCommon(uint8_t SrcSize, OrderedNode *Res, OrderedNode *Src1, uint64_t Shift);
   void CalculateFlags_SignShiftRight(uint8_t SrcSize, OrderedNode *Res, OrderedNode *Src1, OrderedNode *Src2);
   void CalculateFlags_SignShiftRightImmediate(uint8_t SrcSize, OrderedNode *Res, OrderedNode *Src1, uint64_t Shift);
   void CalculateFlags_RotateRight(uint8_t SrcSize, OrderedNode *Res, OrderedNode *Src1, OrderedNode *Src2);
@@ -1391,6 +1394,23 @@ private:
 
     CurrentDeferredFlags = DeferredFlagData {
       .Type = FlagsGenerationType::TYPE_LSHRI,
+      .SrcSize = GetSrcSize(Op),
+      .Res = Res,
+      .Sources = {
+        .OneSrcImmediate = {
+          .Src1 = Src1,
+          .Imm = Shift,
+        },
+      },
+    };
+  }
+
+  void GenerateFlags_ShiftRightDoubleImmediate(FEXCore::X86Tables::DecodedOp Op, OrderedNode *Res, OrderedNode *Src1, uint64_t Shift) {
+    // No flags changed if shift is zero.
+    if (Shift == 0) return;
+
+    CurrentDeferredFlags = DeferredFlagData {
+      .Type = FlagsGenerationType::TYPE_LSHRDI,
       .SrcSize = GetSrcSize(Op),
       .Res = Res,
       .Sources = {

--- a/unittests/ASM/FEX_bugs/SHRD_OF.asm
+++ b/unittests/ASM/FEX_bugs/SHRD_OF.asm
@@ -1,0 +1,26 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x0000000000008601"
+  }
+}
+%endif
+
+; FEX had a bug where OF for SHRD wasn't getting calculated correctly.
+; OF with SHRD set if the sign bit has changed.
+; FEX /previously/ calculated it like regular SHR, where it contained the original MSB.
+
+mov edi, 0x35b292fc
+mov ebp, 0x37d434ad
+shrd edi, ebp, 1
+
+mov rax, 0
+
+lahf
+; Load OF
+seto al
+
+; Mask out AF, SHRD leaves it undefined
+and rax, 0xEFFF
+
+hlt


### PR DESCRIPTION
We were calculating this like the regular SHR instruction which isn't correct.

With this resolved, Denuvo games get slightly farther.