### PR TITLE
ARMEmitter: Add ngc/ngcs aliases

### DIFF
--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ALUOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ALUOps.inl
@@ -735,6 +735,12 @@ public:
     constexpr uint32_t Op = 0b0111'1010'000U << 21;
     DataProcessing_Extended_Reg(Op, s, rd, rn, rm, FEXCore::ARMEmitter::ExtendedType::UXTB, 0);
   }
+  void ngc(ARMEmitter::Size s, Register rd, Register rm) {
+    sbc(s, rd, Reg::zr, rm);
+  }
+  void ngcs(ARMEmitter::Size s, Register rd, Register rm) {
+    sbcs(s, rd, Reg::zr, rm);
+  }
 
   // Rotate right into flags
   void rmif(XRegister rn, uint32_t shift, uint32_t mask) {

--- a/External/FEXCore/unittests/Emitter/ALU_Tests.cpp
+++ b/External/FEXCore/unittests/Emitter/ALU_Tests.cpp
@@ -1690,6 +1690,12 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: ALU: AddSub - with carry") {
 
   TEST_SINGLE(sbcs(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27), "sbcs w29, w28, w27");
   TEST_SINGLE(sbcs(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27), "sbcs x29, x28, x27");
+
+  TEST_SINGLE(ngc(Size::i32Bit, Reg::r29, Reg::r27),  "ngc w29, w27");
+  TEST_SINGLE(ngc(Size::i64Bit, Reg::r29, Reg::r27),  "ngc x29, x27");
+
+  TEST_SINGLE(ngcs(Size::i32Bit, Reg::r29, Reg::r27), "ngcs w29, w27");
+  TEST_SINGLE(ngcs(Size::i64Bit, Reg::r29, Reg::r27), "ngcs x29, x27");
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: ALU: Rotate right into flags") {
   TEST_SINGLE(rmif(XReg::x30, 63, 0b0000), "rmif x30, #63, #nzcv");


### PR DESCRIPTION
Adds the Nintendo GameCube aliases for sbc/sbcs.

Crosses two more off #2836 