### PR TITLE
ARMEmitter: Add cinc/cinv/csetm aliases

### DIFF
--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ALUOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ALUOps.inl
@@ -809,7 +809,16 @@ public:
     ConditionalCompare(Op, 1, 0b01, s, rd, rn, rm, Cond);
   }
   void cneg(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, FEXCore::ARMEmitter::Condition Cond) {
-    csneg(s, rd, rn, rn, static_cast<FEXCore::ARMEmitter::Condition>(FEXCore::ToUnderlying(Cond) ^ FEXCore::ToUnderlying(FEXCore::ARMEmitter::Condition::CC_NE)));
+    csneg(s, rd, rn, rn, InvertCondition(Cond));
+  }
+  void cinc(ARMEmitter::Size s, Register rd, Register rn, Condition cond) {
+    csinc(s, rd, rn, rn, InvertCondition(cond));
+  }
+  void cinv(ARMEmitter::Size s, Register rd, Register rn, Condition cond) {
+    csinv(s, rd, rn, rn, InvertCondition(cond));
+  }
+  void csetm(ARMEmitter::Size s, Register rd, Condition cond) {
+    csinv(s, rd, Reg::zr, Reg::zr, InvertCondition(cond));
   }
 
   // Data processing - 3 source
@@ -865,6 +874,13 @@ public:
   }
 
 private:
+  static constexpr Condition InvertCondition(Condition cond) {
+    // These behave as always, so it makes no sense to allow inverting these.
+    LOGMAN_THROW_AA_FMT(cond != Condition::CC_AL && cond != Condition::CC_NV,
+                        "Cannot invert CC_AL or CC_NV");
+    return static_cast<Condition>(FEXCore::ToUnderlying(cond) ^ 1);
+  }
+
   void and_(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rd, FEXCore::ARMEmitter::Register rn, uint32_t n, uint32_t immr, uint32_t imms) {
     constexpr uint32_t Op = 0b001'0010'00 << 22;
     DataProcessing_Logical_Imm(Op, s, rd, rn, n, immr, imms);

--- a/External/FEXCore/unittests/Emitter/ALU_Tests.cpp
+++ b/External/FEXCore/unittests/Emitter/ALU_Tests.cpp
@@ -1893,6 +1893,13 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: ALU: Conditional select") {
   TEST_SINGLE(cneg(Size::i32Bit, Reg::r29, Reg::r28, Condition::CC_EQ), "cneg w29, w28, eq");
   TEST_SINGLE(cneg(Size::i64Bit, Reg::r29, Reg::r28, Condition::CC_EQ), "cneg x29, x28, eq");
 
+  TEST_SINGLE(cinc(Size::i32Bit, Reg::r29, Reg::r28, Condition::CC_EQ), "cinc w29, w28, eq");
+  TEST_SINGLE(cinc(Size::i64Bit, Reg::r29, Reg::r28, Condition::CC_EQ), "cinc x29, x28, eq");
+  TEST_SINGLE(cinv(Size::i32Bit, Reg::r29, Reg::r28, Condition::CC_EQ), "cinv w29, w28, eq");
+  TEST_SINGLE(cinv(Size::i64Bit, Reg::r29, Reg::r28, Condition::CC_EQ), "cinv x29, x28, eq");
+  TEST_SINGLE(csetm(Size::i32Bit, Reg::r29, Condition::CC_EQ), "csetm w29, eq");
+  TEST_SINGLE(csetm(Size::i64Bit, Reg::r29, Condition::CC_EQ), "csetm x29, eq");
+
   TEST_SINGLE(csel(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, Condition::CC_AL), "csel w29, w28, w27, al");
   TEST_SINGLE(csel(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, Condition::CC_AL), "csel x29, x28, x27, al");
   TEST_SINGLE(cset(Size::i32Bit, Reg::r29, Condition::CC_AL), "csinc w29, wzr, wzr, nv");
@@ -1903,8 +1910,6 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: ALU: Conditional select") {
   TEST_SINGLE(csinv(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, Condition::CC_AL), "csinv x29, x28, x27, al");
   TEST_SINGLE(csneg(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, Condition::CC_AL), "csneg w29, w28, w27, al");
   TEST_SINGLE(csneg(Size::i64Bit, Reg::r29, Reg::r28, Reg::r27, Condition::CC_AL), "csneg x29, x28, x27, al");
-  TEST_SINGLE(cneg(Size::i32Bit, Reg::r29, Reg::r28, Condition::CC_AL), "csneg w29, w28, w28, nv");
-  TEST_SINGLE(cneg(Size::i64Bit, Reg::r29, Reg::r28, Condition::CC_AL), "csneg x29, x28, x28, nv");
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: ALU: Data processing - 3 source") {
   TEST_SINGLE(madd(Size::i32Bit, Reg::r29, Reg::r28, Reg::r27, Reg::r26), "madd w29, w28, w27, w26");


### PR DESCRIPTION
Also corrects a cneg test using CC_AL. The ARM ARM says this shouldn't be using both AL and NV

Crosses three more aliases off #2836 