### PR TITLE
FEXCore: Ensure that the man page follows DESTDIR

### DIFF
--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -1,4 +1,4 @@
-set (MAN_DIR ${CMAKE_INSTALL_PREFIX}/share/man CACHE PATH "MAN_DIR")
+set (MAN_DIR share/man CACHE PATH "MAN_DIR")
 
 set (FEXCORE_BASE_SRCS
   Interface/Config/Config.cpp


### PR DESCRIPTION
When cmake's `install` function is invoked with a relative path, then it is interpreted as being relative to the `CMAKE_INSTALL_PREFIX` variable.

This variable follows both `DESTDIR` and `CMAKE_INSTALL_PREFIX` so it is best to use relative addresses in the install path.

Thanks for the report Mike!
Fixes #2849