### PR TITLE
OpcodeDispatcher: Optimize CMPXCHG{8B,16B} final comparison

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/ALUOps.cpp
@@ -885,12 +885,8 @@ DEF_OP(Select) {
   auto Op = IROp->C<IR::IROp_Select>();
   const uint8_t OpSize = IROp->Size;
 
-  const uint64_t Src1 = *GetSrc<uint64_t*>(Data->SSAData, Op->Cmp1);
-  const uint64_t Src2 = *GetSrc<uint64_t*>(Data->SSAData, Op->Cmp2);
-
   uint64_t ArgTrue;
   uint64_t ArgFalse;
-
   if (OpSize == 4) {
     ArgTrue = *GetSrc<uint32_t*>(Data->SSAData, Op->TrueVal);
     ArgFalse = *GetSrc<uint32_t*>(Data->SSAData, Op->FalseVal);
@@ -901,10 +897,25 @@ DEF_OP(Select) {
 
   bool CompResult;
 
-  if (Op->CompareSize == 4)
+  if (Op->CompareSize == 4) {
+    const auto Src1 = *GetSrc<uint32_t*>(Data->SSAData, Op->Cmp1);
+    const auto Src2 = *GetSrc<uint32_t*>(Data->SSAData, Op->Cmp2);
     CompResult = IsConditionTrue<uint32_t, int32_t, float>(Op->Cond.Val, Src1, Src2);
-  else
+  }
+  else if (Op->CompareSize == 8) {
+    const auto Src1 = *GetSrc<uint64_t*>(Data->SSAData, Op->Cmp1);
+    const auto Src2 = *GetSrc<uint64_t*>(Data->SSAData, Op->Cmp2);
     CompResult = IsConditionTrue<uint64_t, int64_t, double>(Op->Cond.Val, Src1, Src2);
+  }
+  else if (Op->CompareSize == 16) {
+    const auto Src1 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Cmp1);
+    const auto Src2 = *GetSrc<__uint128_t*>(Data->SSAData, Op->Cmp2);
+    CompResult = IsConditionTrue<__uint128_t, __int128_t, double>(Op->Cond.Val, Src1, Src2);
+  }
+  else {
+    LOGMAN_MSG_A_FMT("Unknown select size: {}", Op->CompareSize);
+    FEX_UNREACHABLE;
+  }
 
   GD = CompResult ? ArgTrue : ArgFalse;
 }

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
@@ -350,6 +350,15 @@ namespace FEXCore::CPU {
   template<typename unsigned_type, typename signed_type, typename float_type>
   [[nodiscard]] static bool IsConditionTrue(uint8_t Cond, uint64_t Src1, uint64_t Src2) {
     bool CompResult = false;
+    if constexpr (sizeof(unsigned_type) == 16) {
+      LOGMAN_THROW_A_FMT(Cond != FEXCore::IR::COND_FLU &&
+        Cond != FEXCore::IR::COND_FGE &&
+        Cond != FEXCore::IR::COND_FLEU &&
+        Cond != FEXCore::IR::COND_FGT &&
+        Cond != FEXCore::IR::COND_FU &&
+        Cond != FEXCore::IR::COND_FNU, "Unsupported comparison for 128-bit floats");
+    }
+
     switch (Cond) {
       case FEXCore::IR::COND_EQ:
         CompResult = static_cast<unsigned_type>(Src1) == static_cast<unsigned_type>(Src2);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -1129,6 +1129,7 @@ DEF_OP(Select) {
   const auto CompareEmitSize = Op->CompareSize == 8 ? ARMEmitter::Size::i64Bit : ARMEmitter::Size::i32Bit;
 
   uint64_t Const;
+  auto cc = MapSelectCC(Op->Cond);
 
   if (IsGPR(Op->Cmp1.ID())) {
     const auto Src1 = GetReg(Op->Cmp1.ID());
@@ -1139,15 +1140,20 @@ DEF_OP(Select) {
       const auto Src2 = GetReg(Op->Cmp2.ID());
       cmp(CompareEmitSize, Src1, Src2);
     }
-  } else if (IsFPR(Op->Cmp1.ID())) {
+  }
+  else if (IsGPRPair(Op->Cmp1.ID())) {
+    const auto Src1 = GetRegPair(Op->Cmp1.ID());
+    const auto Src2 = GetRegPair(Op->Cmp2.ID());
+    cmp(EmitSize, Src1.first, Src2.first);
+    ccmp(EmitSize, Src1.second, Src2.second, ARMEmitter::StatusFlags::None, cc);
+  }
+  else if (IsFPR(Op->Cmp1.ID())) {
     const auto Src1 = GetVReg(Op->Cmp1.ID());
     const auto Src2 = GetVReg(Op->Cmp2.ID());
     fcmp(Op->CompareSize == 8 ? ARMEmitter::ScalarRegSize::i64Bit : ARMEmitter::ScalarRegSize::i32Bit, Src1, Src2);
   } else {
     LOGMAN_MSG_A_FMT("Select: Expected GPR or FPR");
   }
-
-  auto cc = MapSelectCC(Op->Cond);
 
   uint64_t const_true, const_false;
   bool is_const_true = IsInlineConstant(Op->TrueVal, &const_true);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -724,6 +724,12 @@ bool Arm64JITCore::IsGPR(IR::NodeID Node) const {
   return Class == IR::GPRClass || Class == IR::GPRFixedClass;
 }
 
+bool Arm64JITCore::IsGPRPair(IR::NodeID Node) const {
+  auto Class = GetRegClass(Node);
+
+  return Class == IR::GPRPairClass;
+}
+
 CPUBackend::CompiledCode Arm64JITCore::CompileCode(uint64_t Entry,
                                 FEXCore::IR::IRListView const *IR,
                                 FEXCore::Core::DebugData *DebugData,

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -112,6 +112,7 @@ private:
 
   [[nodiscard]] bool IsFPR(IR::NodeID Node) const;
   [[nodiscard]] bool IsGPR(IR::NodeID Node) const;
+  [[nodiscard]] bool IsGPRPair(IR::NodeID Node) const;
 
   [[nodiscard]] FEXCore::ARMEmitter::ExtendedMemOperand GenerateMemOperand(uint8_t AccessSize,
                                               FEXCore::ARMEmitter::Register Base,

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/ALUOps.cpp
@@ -1140,7 +1140,28 @@ DEF_OP(Select) {
     } else {
       cmp(GRCMP(Op->Cmp1.ID()), GRCMP(Op->Cmp2.ID()));
     }
-  } else if (IsFPR(Op->Cmp1.ID())) {
+  }
+  else if (IsGPRPair(Op->Cmp1.ID())) {
+    if (Op->CompareSize == 4) {
+      const auto Src1 = GetSrcPair<RA_32>(Op->Cmp1.ID());
+      const auto Src2 = GetSrcPair<RA_32>(Op->Cmp2.ID());
+      mov (TMP1.cvt32(), Src1.first);
+      mov (TMP2.cvt32(), Src1.second);
+      xor_(TMP1.cvt32(), Src2.first);
+      xor_(TMP2.cvt32(), Src2.second);
+      or_(TMP1.cvt32(), TMP2.cvt32());
+    }
+    else {
+      const auto Src1 = GetSrcPair<RA_64>(Op->Cmp1.ID());
+      const auto Src2 = GetSrcPair<RA_64>(Op->Cmp2.ID());
+      mov (TMP1, Src1.first);
+      mov (TMP2, Src1.second);
+      xor_(TMP1, Src2.first);
+      xor_(TMP2, Src2.second);
+      or_(TMP1, TMP2);
+    }
+  }
+  else if (IsFPR(Op->Cmp1.ID())) {
     if (Op->CompareSize  == 4)
       ucomiss(GetSrc(Op->Cmp1.ID()), GetSrc(Op->Cmp2.ID()));
     else

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -484,11 +484,15 @@ IR::PhysicalRegister X86JITCore::GetPhys(IR::NodeID Node) const {
 }
 
 bool X86JITCore::IsFPR(IR::NodeID Node) const {
-  return RAData->GetNodeRegister(Node).Class == IR::FPRClass.Val;
+  return RAData->GetNodeRegister(Node).Class == IR::FPRClass;
 }
 
 bool X86JITCore::IsGPR(IR::NodeID Node) const {
-  return RAData->GetNodeRegister(Node).Class == IR::GPRClass.Val;
+  return RAData->GetNodeRegister(Node).Class == IR::GPRClass;
+}
+
+bool X86JITCore::IsGPRPair(IR::NodeID Node) const {
+  return RAData->GetNodeRegister(Node).Class == IR::GPRPairClass;
 }
 
 template<uint8_t RAType>

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -169,6 +169,7 @@ private:
 
   [[nodiscard]] bool IsFPR(IR::NodeID Node) const;
   [[nodiscard]] bool IsGPR(IR::NodeID Node) const;
+  [[nodiscard]] bool IsGPRPair(IR::NodeID Node) const;
 
   template<uint8_t RAType>
   [[nodiscard]] Xbyak::Reg GetSrc(IR::NodeID Node) const;

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -4663,14 +4663,11 @@ void OpDispatchBuilder::CMPXCHGPairOp(OpcodeArgs) {
   OrderedNode *Result_Upper = _ExtractElementPair(CASResult, 1);
 
   // Set ZF if memory result was expected
-  OrderedNode *EOR_Lower = _Xor(Result_Lower, Expected_Lower);
-  OrderedNode *EOR_Upper = _Xor(Result_Upper, Expected_Upper);
-  OrderedNode *Orr_Result = _Or(EOR_Lower, EOR_Upper);
-
   auto OneConst = _Constant(1);
   auto ZeroConst = _Constant(0);
+
   OrderedNode *ZFResult = _Select(FEXCore::IR::COND_EQ,
-    Orr_Result, ZeroConst,
+    CASResult, Expected,
     OneConst, ZeroConst);
 
   // Set ZF

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -885,12 +885,15 @@
                 ],
         "DestSize": "8"
       },
-      "GPR = Select CondClass:$Cond, GPR:$Cmp1, GPR:$Cmp2, GPR:$TrueVal, GPR:$FalseVal, u8:$CompareSize": {
+      "GPR = Select CondClass:$Cond, SSA:$Cmp1, SSA:$Cmp2, GPR:$TrueVal, GPR:$FalseVal, u8:$CompareSize": {
         "Desc": ["Ternary selection of GPRs",
                  "op:",
                  "Dest = Cmp1 <Cond> Cmp2 ? TrueVal : FalseVal"
                 ],
-        "DestSize": "std::max<uint8_t>(4, std::max<uint8_t>(GetOpSize(_TrueVal), GetOpSize(_FalseVal)))"
+        "DestSize": "std::max<uint8_t>(4, std::max<uint8_t>(GetOpSize(_TrueVal), GetOpSize(_FalseVal)))",
+        "EmitValidation": [
+          "WalkFindRegClass($Cmp1) == WalkFindRegClass($Cmp2)"
+        ]
       },
       "GPR = Extr GPR:$Upper, GPR:$Lower, u8:$LSB": {
         "Desc": ["Concats the two GPRs to create a value that is the size of the full two GPRs",

--- a/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -906,6 +906,11 @@ bool ConstProp::ConstantPropagation(IREmitter *IREmit, const IRListView& Current
       // Fold the select into the CondJump if possible. Could handle more complex cases, too.
       if (Op->Cond.Val == COND_NEQ && IREmit->IsValueConstant(Op->Cmp2, &Constant) && Constant == 0 &&  Select->Op == OP_SELECT) {
 
+        const auto SelectCmpClass = IREmit->WalkFindRegClass(Select->Args[0]);
+        if (SelectCmpClass == GPRPairClass) {
+          // If the comparison class is a GPRPair then don't fold the select since it isn't free.
+          break;
+        }
         uint64_t Constant1{};
         uint64_t Constant2{};
 

--- a/External/FEXCore/include/FEXCore/IR/IREmitter.h
+++ b/External/FEXCore/include/FEXCore/IR/IREmitter.h
@@ -171,6 +171,10 @@ friend class FEXCore::IR::PassManager;
   }
 
   /**  @} */
+  FEXCore::IR::RegisterClassType WalkFindRegClass(OrderedNodeWrapper ssa) {
+     OrderedNode *RealNode = ssa.GetNode(DualListData.ListBegin());
+     return WalkFindRegClass(RealNode);
+  }
 
   bool IsValueConstant(OrderedNodeWrapper ssa, uint64_t *Constant = nullptr) {
      OrderedNode *RealNode = ssa.GetNode(DualListData.ListBegin());


### PR DESCRIPTION
Optimizes the instruction blow-up from 36x to 34x.
The issue with this instruction is that AArch64 doesn't do something
like x86 where it sets a flag if the CAS was successful. This means we
need to do additional comparisons after the fact to see if it was
actually successful.

Previously this was implemented as eor+eor+orr+cmp+cset, Now it is
cmp+ccmp+cset, Saving two instructions.
Simple optimization but easy to do. This instruction is still mostly
killed by the overhead of moving registers all over.

Before:
```asm
0x0000ffffe25002ec  10ffffe0            adr x0, #-0x4 (addr 0xffffe25002e8)
0x0000ffffe25002f0  f9005f80            str x0, [x28, #184]
0x0000ffffe25002f4  aa0403f4            mov x20, x4
0x0000ffffe25002f8  aa0603f5            mov x21, x6
0x0000ffffe25002fc  aa0703f6            mov x22, x7
0x0000ffffe2500300  aa0503f7            mov x23, x5
0x0000ffffe2500304  aa1403e2            mov x2, x20
0x0000ffffe2500308  aa1503e3            mov x3, x21
0x0000ffffe250030c  4862ffb6            caspal x2, x3, x22, x23, [x29]
0x0000ffffe2500310  aa0203f4            mov x20, x2
0x0000ffffe2500314  aa0303f5            mov x21, x3
0x0000ffffe2500318  aa1403f6            mov x22, x20
0x0000ffffe250031c  aa1503f4            mov x20, x21
; ZF Flag + branch
0x0000ffffe2500320  ca0402d5            eor x21, x22, x4
0x0000ffffe2500324  ca060297            eor x23, x20, x6
0x0000ffffe2500328  aa1702b5            orr x21, x21, x23
0x0000ffffe250032c  f10002bf            cmp x21, #0x0 (0)
0x0000ffffe2500330  9a9f17f7            cset x23, eq
0x0000ffffe2500334  390b1b97            strb w23, [x28, #710]
0x0000ffffe2500338  b4000075            cbz x21, #+0xc (addr 0xffffe2500344)

0x0000ffffe250033c  aa1603e4            mov x4, x22
0x0000ffffe2500340  aa1403e6            mov x6, x20
0x0000ffffe2500344  58000040            ldr x0, pc+8 (addr 0xffffe250034c)
0x0000ffffe2500348  d63f0000            blr x0
0x0000ffffe250034c  f7fec128            unallocated (Unallocated)
0x0000ffffe2500350  0000ffff            udf #0xffff
0x0000ffffe2500354  00010053            unallocated (Unallocated)
0x0000ffffe2500358  00000000            udf #0x0
[DEBUG] RIP: 0x1004f
[DEBUG] Guest Code instructions: 1
[DEBUG] Host Code instructions: 36
[DEBUG] Blow-up Amt: 36x
```

After:
```asm
0x0000ffffe25002ec  10ffffe0            adr x0, #-0x4 (addr 0xffffe25002e8)
0x0000ffffe25002f0  f9005f80            str x0, [x28, #184]
0x0000ffffe25002f4  aa0403f4            mov x20, x4
0x0000ffffe25002f8  aa0603f5            mov x21, x6
0x0000ffffe25002fc  aa0703f6            mov x22, x7
0x0000ffffe2500300  aa0503f7            mov x23, x5
0x0000ffffe2500304  aa1403e2            mov x2, x20
0x0000ffffe2500308  aa1503e3            mov x3, x21
0x0000ffffe250030c  4862ffb6            caspal x2, x3, x22, x23, [x29]
0x0000ffffe2500310  aa0203f6            mov x22, x2
0x0000ffffe2500314  aa0303f7            mov x23, x3
0x0000ffffe2500318  aa1603f8            mov x24, x22
0x0000ffffe250031c  aa1703f9            mov x25, x23
; ZF Flag + branch
0x0000ffffe2500320  eb1402df            cmp x22, x20
0x0000ffffe2500324  fa5502e0            ccmp x23, x21, #nzcv, eq
0x0000ffffe2500328  9a9f17f4            cset x20, eq
0x0000ffffe250032c  390b1b94            strb w20, [x28, #710]
0x0000ffffe2500330  b5000074            cbnz x20, #+0xc (addr 0xffffe250033c)

0x0000ffffe2500334  aa1803e4            mov x4, x24
0x0000ffffe2500338  aa1903e6            mov x6, x25
0x0000ffffe250033c  58000040            ldr x0, pc+8 (addr 0xffffe2500344)
0x0000ffffe2500340  d63f0000            blr x0
0x0000ffffe2500344  f7fec128            unallocated (Unallocated)
0x0000ffffe2500348  0000ffff            udf #0xffff
0x0000ffffe250034c  00010053            unallocated (Unallocated)
0x0000ffffe2500350  00000000            udf #0x0
[DEBUG] RIP: 0x1004f
[DEBUG] Guest Code instructions: 1
[DEBUG] Host Code instructions: 34
[DEBUG] Blow-up Amt: 34x
```