### PR TITLE
JIT: Use TST instead of CMN

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -92,8 +92,8 @@ DEF_OP(TestNZ) {
   const auto EmitSize = OpSize == 8 ? ARMEmitter::Size::i64Bit : ARMEmitter::Size::i32Bit;
 
   const auto Dst = GetReg(Node);
-  const auto ZeroReg = ARMEmitter::Reg::zr;
-  cmn(EmitSize, GetReg(Op->Src1.ID()), ZeroReg);
+  const auto Src = GetReg(Op->Src1.ID());
+  tst(EmitSize, Src, Src);
 
   // TODO: Optimize this out
   mrs(Dst, ARMEmitter::SystemRegister::NZCV);


### PR DESCRIPTION
This is more obvious. llvm-mca says TST is half the cycle count of CMN for whatever it's defaulting to. dougallj's reference shows both as the same performance.