### PR TITLE
X86Tables: Fixes CLZero destination address

### DIFF
--- a/External/FEXCore/Source/Interface/Core/X86Tables/SecondaryModRMTables.cpp
+++ b/External/FEXCore/Source/Interface/Core/X86Tables/SecondaryModRMTables.cpp
@@ -48,7 +48,7 @@ void InitializeSecondaryModRMTables() {
     {((3 << 3) | 1), 1, X86InstInfo{"RDTSCP",   TYPE_INST,    FLAGS_NONE, 0, nullptr}},
     {((3 << 3) | 2), 1, X86InstInfo{"MONITORX", TYPE_PRIV,    FLAGS_NONE, 0, nullptr}},
     {((3 << 3) | 3), 1, X86InstInfo{"MWAITX",   TYPE_PRIV,    FLAGS_NONE, 0, nullptr}},
-    {((3 << 3) | 4), 1, X86InstInfo{"CLZERO",   TYPE_INST,    FLAGS_SF_SRC_RAX, 0, nullptr}},
+    {((3 << 3) | 4), 1, X86InstInfo{"CLZERO",   TYPE_INST,    GenFlagsSameSize(SIZE_64BITDEF) | FLAGS_SF_SRC_RAX | FLAGS_DEBUG_MEM_ACCESS, 0, nullptr}},
     {((3 << 3) | 5), 1, X86InstInfo{"",         TYPE_INVALID, FLAGS_NONE, 0, nullptr}},
     {((3 << 3) | 6), 1, X86InstInfo{"",         TYPE_INVALID, FLAGS_NONE, 0, nullptr}},
     {((3 << 3) | 7), 1, X86InstInfo{"",         TYPE_INVALID, FLAGS_NONE, 0, nullptr}},

--- a/unittests/32Bit_ASM/SecondaryModRM/Reg_7_4_2.asm
+++ b/unittests/32Bit_ASM/SecondaryModRM/Reg_7_4_2.asm
@@ -1,0 +1,93 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RBX": "0x0",
+    "RCX": "0x000000000a121a20",
+    "RDX": "0x000000000b131b20"
+  },
+  "Mode": "32BIT",
+  "HostFeatures": ["CLZERO"]
+}
+%endif
+
+; Starting address to store to
+mov eax, 0xe8000000
+
+; Set up the cachelines with garbage
+
+; Cacheline 0
+mov ebx, 0x41424344
+mov [eax + 8 * 0], ebx
+mov [eax + 8 * 1], ebx
+mov [eax + 8 * 2], ebx
+mov [eax + 8 * 3], ebx
+mov [eax + 8 * 4], ebx
+mov [eax + 8 * 5], ebx
+mov [eax + 8 * 6], ebx
+mov [eax + 8 * 7], ebx
+
+; Cacheline 1
+mov ebx, 0x55565758
+mov [eax + 8 * 8], ebx
+mov [eax + 8 * 9], ebx
+mov [eax + 8 * 10], ebx
+mov [eax + 8 * 11], ebx ; clzero here
+mov [eax + 8 * 12], ebx
+mov [eax + 8 * 13], ebx
+mov [eax + 8 * 14], ebx
+mov [eax + 8 * 15], ebx
+
+; Cacheline 2
+mov ebx, 0x61626364
+mov [eax + 8 * 16], ebx
+mov [eax + 8 * 17], ebx
+mov [eax + 8 * 18], ebx
+mov [eax + 8 * 19], ebx
+mov [eax + 8 * 20], ebx
+mov [eax + 8 * 21], ebx
+mov [eax + 8 * 22], ebx
+mov [eax + 8 * 23], ebx
+
+; Set RAX to the middle of cacheline 1 to ensure alignment
+lea eax, [eax + 8 * 11]
+
+clzero
+
+; Set eax back to the start
+mov eax, 0xe8000000
+
+mov ebx, 0
+mov ecx, 0
+mov edx, 0
+
+; Cacheline 0 should be unmodified
+add ecx, [eax + 8 * 0]
+add ecx, [eax + 8 * 1]
+add ecx, [eax + 8 * 2]
+add ecx, [eax + 8 * 3]
+add ecx, [eax + 8 * 4]
+add ecx, [eax + 8 * 5]
+add ecx, [eax + 8 * 6]
+add ecx, [eax + 8 * 7]
+
+; Cacheline 1 Should be zero
+add ebx, [eax + 8 * 8]
+add ebx, [eax + 8 * 9]
+add ebx, [eax + 8 * 10]
+add ebx, [eax + 8 * 11]
+add ebx, [eax + 8 * 12]
+add ebx, [eax + 8 * 13]
+add ebx, [eax + 8 * 14]
+add ebx, [eax + 8 * 15]
+
+; Cacheline 2 should be unmodified
+add edx, [eax + 8 * 16]
+add edx, [eax + 8 * 17]
+add edx, [eax + 8 * 18]
+add edx, [eax + 8 * 19]
+add edx, [eax + 8 * 20]
+add edx, [eax + 8 * 21]
+add edx, [eax + 8 * 22]
+add edx, [eax + 8 * 23]
+
+hlt


### PR DESCRIPTION
This needs to default to 64-bit addresses, this was previously defaulting to 32-bit which was meaning the destination address was getting truncated. In a 32-bit process the address is still 32-bit.

I'm actually surprised this hasn't caused spurious SIGSEGV before this point.

Adds a 32-bit test to ensure that side is tested as well.