### PR TITLE
Fix 16-bit popa insertion behaviour

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -674,7 +674,6 @@ void OpDispatchBuilder::POPOp(OpcodeArgs) {
 void OpDispatchBuilder::POPAOp(OpcodeArgs) {
   // 32bit only
   const uint8_t Size = GetSrcSize(Op);
-  const uint8_t GPRSize = 4;
 
   auto Constant = _Constant(Size);
   auto OldSP = LoadGPRRegister(X86State::REG_RSP);
@@ -692,32 +691,32 @@ void OpDispatchBuilder::POPAOp(OpcodeArgs) {
   OrderedNode *Src{};
   OrderedNode *NewSP = OldSP;
   Src = _LoadMem(GPRClass, Size, NewSP, Size);
-  StoreGPRRegister(X86State::REG_RDI, Src, GPRSize);
+  StoreGPRRegister(X86State::REG_RDI, Src, Size);
   NewSP = _Add(NewSP, Constant);
 
   Src = _LoadMem(GPRClass, Size, NewSP, Size);
-  StoreGPRRegister(X86State::REG_RSI, Src, GPRSize);
+  StoreGPRRegister(X86State::REG_RSI, Src, Size);
   NewSP = _Add(NewSP, Constant);
 
   Src = _LoadMem(GPRClass, Size, NewSP, Size);
-  StoreGPRRegister(X86State::REG_RBP, Src, GPRSize);
+  StoreGPRRegister(X86State::REG_RBP, Src, Size);
   NewSP = _Add(NewSP, _Constant(Size * 2));
 
   // Skip SP loading
   Src = _LoadMem(GPRClass, Size, NewSP, Size);
-  StoreGPRRegister(X86State::REG_RBX, Src, GPRSize);
+  StoreGPRRegister(X86State::REG_RBX, Src, Size);
   NewSP = _Add(NewSP, Constant);
 
   Src = _LoadMem(GPRClass, Size, NewSP, Size);
-  StoreGPRRegister(X86State::REG_RDX, Src, GPRSize);
+  StoreGPRRegister(X86State::REG_RDX, Src, Size);
   NewSP = _Add(NewSP, Constant);
 
   Src = _LoadMem(GPRClass, Size, NewSP, Size);
-  StoreGPRRegister(X86State::REG_RCX, Src, GPRSize);
+  StoreGPRRegister(X86State::REG_RCX, Src, Size);
   NewSP = _Add(NewSP, Constant);
 
   Src = _LoadMem(GPRClass, Size, NewSP, Size);
-  StoreGPRRegister(X86State::REG_RAX, Src, GPRSize);
+  StoreGPRRegister(X86State::REG_RAX, Src, Size);
   NewSP = _Add(NewSP, Constant);
 
   // Store the new stack pointer

--- a/unittests/32Bit_ASM/Primary/Primary_61_2.asm
+++ b/unittests/32Bit_ASM/Primary/Primary_61_2.asm
@@ -1,7 +1,7 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "RAX": "0x6",
+    "RAX": "0xFF0006",
     "RCX": "0x5",
     "RDX": "0x4",
     "RSP": "0xE0000020",
@@ -16,7 +16,7 @@
 
 mov esp, 0xe0000020
 
-mov eax, 0xFF
+mov eax, 0xFF0000
 mov ecx, 0xFF
 mov edx, 0xFF
 mov ebx, 0xFF


### PR DESCRIPTION
Caught this when debugging Stalker, OpenAL does this amazing little hack https://github.com/OpenXRay/xray-15/blob/1390dfb08ed20997d7e8c95147ea8e8cb71f5e86/cs/3rd%20party/OpenAL/OpenAL-Windows/Router/alc.cpp#L1862 that was broken by the FEX behaviour 