### PR TITLE
ARMEmitter: Add missing atomic aliases

### DIFF
--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/LoadstoreOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/LoadstoreOps.inl
@@ -4164,8 +4164,8 @@ private:
   }
 
   // Atomic memory operations
-  template<typename T>
-  void LoadStoreAtomicLSE(SubRegSize s, uint32_t A, uint32_t R, uint32_t o3, uint32_t opc, T rs, T rt, Register rn) {
+  void LoadStoreAtomicLSE(SubRegSize s, uint32_t A, uint32_t R, uint32_t o3, uint32_t opc,
+                          Register rs, Register rt, Register rn) {
     uint32_t Instr = 0b0011'1000'0010'0000'0000'0000'0000'0000;
     Instr |= FEXCore::ToUnderlying(s) << 30;
     Instr |= A << 23;

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/LoadstoreOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/LoadstoreOps.inl
@@ -2593,733 +2593,553 @@ public:
     ldXr<IndexType::UNPRIVILEGED>(rt, rn, Imm);
   }
   // Atomic memory operations
-  void stadd(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, size, 0, 0, 0, 0b000, rs, FEXCore::ARMEmitter::Reg::zr, rn);
+  void stadd(SubRegSize size, Register rs, Register rn) {
+    LoadStoreAtomicLSE(size, 0, 0, 0, 0b000, rs, Reg::zr, rn);
   }
-  void staddl(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, size, 0, 1, 0, 0b000, rs, FEXCore::ARMEmitter::Reg::zr, rn);
+  void staddl(SubRegSize size, Register rs, Register rn) {
+    LoadStoreAtomicLSE(size, 0, 1, 0, 0b000, rs, Reg::zr, rn);
   }
-  void stclr(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, size, 0, 0, 0, 0b001, rs, FEXCore::ARMEmitter::Reg::zr, rn);
+  void stclr(SubRegSize size, Register rs, Register rn) {
+    LoadStoreAtomicLSE(size, 0, 0, 0, 0b001, rs, Reg::zr, rn);
   }
-  void stclrl(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, size, 0, 1, 0, 0b001, rs, FEXCore::ARMEmitter::Reg::zr, rn);
+  void stclrl(SubRegSize size, Register rs, Register rn) {
+    LoadStoreAtomicLSE(size, 0, 1, 0, 0b001, rs, Reg::zr, rn);
   }
-  void stset(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, size, 0, 0, 0, 0b011, rs, FEXCore::ARMEmitter::Reg::zr, rn);
+  void stset(SubRegSize size, Register rs, Register rn) {
+    LoadStoreAtomicLSE(size, 0, 0, 0, 0b011, rs, Reg::zr, rn);
   }
-  void stsetl(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, size, 0, 1, 0, 0b011, rs, FEXCore::ARMEmitter::Reg::zr, rn);
+  void stsetl(SubRegSize size, Register rs, Register rn) {
+    LoadStoreAtomicLSE(size, 0, 1, 0, 0b011, rs, Reg::zr, rn);
   }
-  void steor(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, size, 0, 0, 0, 0b010, rs, FEXCore::ARMEmitter::Reg::zr, rn);
+  void steor(SubRegSize size, Register rs, Register rn) {
+    LoadStoreAtomicLSE(size, 0, 0, 0, 0b010, rs, Reg::zr, rn);
   }
-  void steorl(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, size, 0, 1, 0, 0b010, rs, FEXCore::ARMEmitter::Reg::zr, rn);
+  void steorl(SubRegSize size, Register rs, Register rn) {
+    LoadStoreAtomicLSE(size, 0, 1, 0, 0b010, rs, Reg::zr, rn);
   }
-  void ldswp(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, size, 0, 0, 1, 0b000, rs, rt, rn);
+  void ldswp(SubRegSize size, Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(size, 0, 0, 1, 0b000, rs, rt, rn);
   }
-  void ldswpl(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, size, 0, 1, 1, 0b000, rs, rt, rn);
+  void ldswpl(SubRegSize size, Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(size, 0, 1, 1, 0b000, rs, rt, rn);
   }
-  void ldswpa(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, size, 1, 0, 1, 0b000, rs, rt, rn);
+  void ldswpa(SubRegSize size, Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(size, 1, 0, 1, 0b000, rs, rt, rn);
   }
-  void ldswpal(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, size, 1, 1, 1, 0b000, rs, rt, rn);
+  void ldswpal(SubRegSize size, Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(size, 1, 1, 1, 0b000, rs, rt, rn);
   }
 
-  void ldadd(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, size, 0, 0, 0, 0b000, rs, rt, rn);
+  void ldadd(SubRegSize size, Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(size, 0, 0, 0, 0b000, rs, rt, rn);
   }
-  void ldadda(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, size, 1, 0, 0, 0b000, rs, rt, rn);
+  void ldadda(SubRegSize size, Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(size, 1, 0, 0, 0b000, rs, rt, rn);
   }
-  void ldaddl(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, size, 0, 1, 0, 0b000, rs, rt, rn);
+  void ldaddl(SubRegSize size, Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(size, 0, 1, 0, 0b000, rs, rt, rn);
   }
-  void ldaddal(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, size, 1, 1, 0, 0b000, rs, rt, rn);
+  void ldaddal(SubRegSize size, Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(size, 1, 1, 0, 0b000, rs, rt, rn);
   }
-  void ldclr(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, size, 0, 0, 0, 0b001, rs, rt, rn);
+  void ldclr(SubRegSize size, Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(size, 0, 0, 0, 0b001, rs, rt, rn);
   }
-  void ldclra(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, size, 1, 0, 0, 0b001, rs, rt, rn);
+  void ldclra(SubRegSize size, Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(size, 1, 0, 0, 0b001, rs, rt, rn);
   }
-  void ldclrl(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, size, 0, 1, 0, 0b001, rs, rt, rn);
+  void ldclrl(SubRegSize size, Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(size, 0, 1, 0, 0b001, rs, rt, rn);
   }
-  void ldclral(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, size, 1, 1, 0, 0b001, rs, rt, rn);
+  void ldclral(SubRegSize size, Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(size, 1, 1, 0, 0b001, rs, rt, rn);
   }
 
-  void ldset(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, size, 0, 0, 0, 0b011, rs, rt, rn);
+  void ldset(SubRegSize size, Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(size, 0, 0, 0, 0b011, rs, rt, rn);
   }
-  void ldseta(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, size, 1, 0, 0, 0b011, rs, rt, rn);
+  void ldseta(SubRegSize size, Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(size, 1, 0, 0, 0b011, rs, rt, rn);
   }
-  void ldsetl(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, size, 0, 1, 0, 0b011, rs, rt, rn);
+  void ldsetl(SubRegSize size, Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(size, 0, 1, 0, 0b011, rs, rt, rn);
   }
-  void ldsetal(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, size, 1, 1, 0, 0b011, rs, rt, rn);
+  void ldsetal(SubRegSize size, Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(size, 1, 1, 0, 0b011, rs, rt, rn);
   }
-  void ldeor(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, size, 0, 0, 0, 0b010, rs, rt, rn);
+  void ldeor(SubRegSize size, Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(size, 0, 0, 0, 0b010, rs, rt, rn);
   }
-  void ldeora(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, size, 1, 0, 0, 0b010, rs, rt, rn);
+  void ldeora(SubRegSize size, Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(size, 1, 0, 0, 0b010, rs, rt, rn);
   }
-  void ldeorl(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, size, 0, 1, 0, 0b010, rs, rt, rn);
+  void ldeorl(SubRegSize size, Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(size, 0, 1, 0, 0b010, rs, rt, rn);
   }
-  void ldeoral(ARMEmitter::SubRegSize size, FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, size, 1, 1, 0, 0b010, rs, rt, rn);
+  void ldeoral(SubRegSize size, Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(size, 1, 1, 0, 0b010, rs, rt, rn);
   }
 
 
   // 8-bit
-  void ldaddb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 0, 0, 0, 0b000, rs, rt, rn);
+  void ldaddb(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i8Bit, 0, 0, 0, 0b000, rs, rt, rn);
   }
-  void ldclrb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 0, 0, 0, 0b001, rs, rt, rn);
+  void ldclrb(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i8Bit, 0, 0, 0, 0b001, rs, rt, rn);
   }
-  void ldeorb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 0, 0, 0, 0b010, rs, rt, rn);
+  void ldeorb(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i8Bit, 0, 0, 0, 0b010, rs, rt, rn);
   }
-  void ldsetb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 0, 0, 0, 0b011, rs, rt, rn);
+  void ldsetb(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i8Bit, 0, 0, 0, 0b011, rs, rt, rn);
   }
-  void ldsmaxb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 0, 0, 0, 0b100, rs, rt, rn);
+  void ldsmaxb(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i8Bit, 0, 0, 0, 0b100, rs, rt, rn);
   }
-  void ldsminb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 0, 0, 0, 0b101, rs, rt, rn);
+  void ldsminb(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i8Bit, 0, 0, 0, 0b101, rs, rt, rn);
   }
-  void ldumaxb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 0, 0, 0, 0b110, rs, rt, rn);
+  void ldumaxb(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i8Bit, 0, 0, 0, 0b110, rs, rt, rn);
   }
-  void lduminb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 0, 0, 0, 0b111, rs, rt, rn);
+  void lduminb(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i8Bit, 0, 0, 0, 0b111, rs, rt, rn);
   }
-  void ldswpb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 0, 0, 1, 0b000, rs, rt, rn);
+  void ldswpb(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i8Bit, 0, 0, 1, 0b000, rs, rt, rn);
   }
-  void ldaddlb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 0, 1, 0, 0b000, rs, rt, rn);
+  void ldaddlb(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i8Bit, 0, 1, 0, 0b000, rs, rt, rn);
   }
-  void ldclrlb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 0, 1, 0, 0b001, rs, rt, rn);
+  void ldclrlb(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i8Bit, 0, 1, 0, 0b001, rs, rt, rn);
   }
-  void ldeorlb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 0, 1, 0, 0b010, rs, rt, rn);
+  void ldeorlb(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i8Bit, 0, 1, 0, 0b010, rs, rt, rn);
   }
-  void ldsetlb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 0, 1, 0, 0b011, rs, rt, rn);
+  void ldsetlb(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i8Bit, 0, 1, 0, 0b011, rs, rt, rn);
   }
-  void ldsmaxlb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 0, 1, 0, 0b100, rs, rt, rn);
+  void ldsmaxlb(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i8Bit, 0, 1, 0, 0b100, rs, rt, rn);
   }
-  void ldsminlb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 0, 1, 0, 0b101, rs, rt, rn);
+  void ldsminlb(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i8Bit, 0, 1, 0, 0b101, rs, rt, rn);
   }
-  void ldumaxlb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 0, 1, 0, 0b110, rs, rt, rn);
+  void ldumaxlb(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i8Bit, 0, 1, 0, 0b110, rs, rt, rn);
   }
-  void lduminlb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 0, 1, 0, 0b111, rs, rt, rn);
+  void lduminlb(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i8Bit, 0, 1, 0, 0b111, rs, rt, rn);
   }
-  void ldswplb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 0, 1, 1, 0b000, rs, rt, rn);
+  void ldswplb(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i8Bit, 0, 1, 1, 0b000, rs, rt, rn);
   }
-  void ldaddab(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 1, 0, 0, 0b000, rs, rt, rn);
+  void ldaddab(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i8Bit, 1, 0, 0, 0b000, rs, rt, rn);
   }
-  void ldclrab(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 1, 0, 0, 0b001, rs, rt, rn);
+  void ldclrab(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i8Bit, 1, 0, 0, 0b001, rs, rt, rn);
   }
-  void ldeorab(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 1, 0, 0, 0b010, rs, rt, rn);
+  void ldeorab(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i8Bit, 1, 0, 0, 0b010, rs, rt, rn);
   }
-  void ldsetab(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 1, 0, 0, 0b011, rs, rt, rn);
+  void ldsetab(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i8Bit, 1, 0, 0, 0b011, rs, rt, rn);
   }
-  void ldsmaxab(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 1, 0, 0, 0b100, rs, rt, rn);
+  void ldsmaxab(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i8Bit, 1, 0, 0, 0b100, rs, rt, rn);
   }
-  void ldsminab(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 1, 0, 0, 0b101, rs, rt, rn);
+  void ldsminab(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i8Bit, 1, 0, 0, 0b101, rs, rt, rn);
   }
-  void ldumaxab(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 1, 0, 0, 0b110, rs, rt, rn);
+  void ldumaxab(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i8Bit, 1, 0, 0, 0b110, rs, rt, rn);
   }
-  void lduminab(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 1, 0, 0, 0b111, rs, rt, rn);
+  void lduminab(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i8Bit, 1, 0, 0, 0b111, rs, rt, rn);
   }
-  void ldswpab(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 1, 0, 1, 0b000, rs, rt, rn);
+  void ldswpab(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i8Bit, 1, 0, 1, 0b000, rs, rt, rn);
   }
-  void ldaddalb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 1, 1, 0, 0b000, rs, rt, rn);
+  void ldaddalb(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i8Bit, 1, 1, 0, 0b000, rs, rt, rn);
   }
-  void ldclralb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 1, 1, 0, 0b001, rs, rt, rn);
+  void ldclralb(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i8Bit, 1, 1, 0, 0b001, rs, rt, rn);
   }
-  void ldeoralb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 1, 1, 0, 0b010, rs, rt, rn);
+  void ldeoralb(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i8Bit, 1, 1, 0, 0b010, rs, rt, rn);
   }
-  void ldsetalb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 1, 1, 0, 0b011, rs, rt, rn);
+  void ldsetalb(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i8Bit, 1, 1, 0, 0b011, rs, rt, rn);
   }
-  void ldsmaxalb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 1, 1, 0, 0b100, rs, rt, rn);
+  void ldsmaxalb(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i8Bit, 1, 1, 0, 0b100, rs, rt, rn);
   }
-  void ldsminalb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 1, 1, 0, 0b101, rs, rt, rn);
+  void ldsminalb(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i8Bit, 1, 1, 0, 0b101, rs, rt, rn);
   }
-  void ldumaxalb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 1, 1, 0, 0b110, rs, rt, rn);
+  void ldumaxalb(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i8Bit, 1, 1, 0, 0b110, rs, rt, rn);
   }
-  void lduminalb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 1, 1, 0, 0b111, rs, rt, rn);
+  void lduminalb(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i8Bit, 1, 1, 0, 0b111, rs, rt, rn);
   }
-  void ldswpalb(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 1, 1, 1, 0b000, rs, rt, rn);
+  void ldswpalb(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i8Bit, 1, 1, 1, 0b000, rs, rt, rn);
   }
   // 16-bit
-  void ldaddh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 0, 0, 0, 0b000, rs, rt, rn);
+  void ldaddh(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i16Bit, 0, 0, 0, 0b000, rs, rt, rn);
   }
-  void ldclrh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 0, 0, 0, 0b001, rs, rt, rn);
+  void ldclrh(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i16Bit, 0, 0, 0, 0b001, rs, rt, rn);
   }
-  void ldeorh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 0, 0, 0, 0b010, rs, rt, rn);
+  void ldeorh(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i16Bit, 0, 0, 0, 0b010, rs, rt, rn);
   }
-  void ldseth(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 0, 0, 0, 0b011, rs, rt, rn);
+  void ldseth(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i16Bit, 0, 0, 0, 0b011, rs, rt, rn);
   }
-  void ldsmaxh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 0, 0, 0, 0b100, rs, rt, rn);
+  void ldsmaxh(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i16Bit, 0, 0, 0, 0b100, rs, rt, rn);
   }
-  void ldsminh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 0, 0, 0, 0b101, rs, rt, rn);
+  void ldsminh(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i16Bit, 0, 0, 0, 0b101, rs, rt, rn);
   }
-  void ldumaxh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 0, 0, 0, 0b110, rs, rt, rn);
+  void ldumaxh(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i16Bit, 0, 0, 0, 0b110, rs, rt, rn);
   }
-  void lduminh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 0, 0, 0, 0b111, rs, rt, rn);
+  void lduminh(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i16Bit, 0, 0, 0, 0b111, rs, rt, rn);
   }
-  void ldswph(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 0, 0, 1, 0b000, rs, rt, rn);
+  void ldswph(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i16Bit, 0, 0, 1, 0b000, rs, rt, rn);
   }
-  void ldaddlh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 0, 1, 0, 0b000, rs, rt, rn);
+  void ldaddlh(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i16Bit, 0, 1, 0, 0b000, rs, rt, rn);
   }
-  void ldclrlh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 0, 1, 0, 0b001, rs, rt, rn);
+  void ldclrlh(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i16Bit, 0, 1, 0, 0b001, rs, rt, rn);
   }
-  void ldeorlh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 0, 1, 0, 0b010, rs, rt, rn);
+  void ldeorlh(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i16Bit, 0, 1, 0, 0b010, rs, rt, rn);
   }
-  void ldsetlh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 0, 1, 0, 0b011, rs, rt, rn);
+  void ldsetlh(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i16Bit, 0, 1, 0, 0b011, rs, rt, rn);
   }
-  void ldsmaxlh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 0, 1, 0, 0b100, rs, rt, rn);
+  void ldsmaxlh(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i16Bit, 0, 1, 0, 0b100, rs, rt, rn);
   }
-  void ldsminlh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 0, 1, 0, 0b101, rs, rt, rn);
+  void ldsminlh(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i16Bit, 0, 1, 0, 0b101, rs, rt, rn);
   }
-  void ldumaxlh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 0, 1, 0, 0b110, rs, rt, rn);
+  void ldumaxlh(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i16Bit, 0, 1, 0, 0b110, rs, rt, rn);
   }
-  void lduminlh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 0, 1, 0, 0b111, rs, rt, rn);
+  void lduminlh(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i16Bit, 0, 1, 0, 0b111, rs, rt, rn);
   }
-  void ldswplh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 0, 1, 1, 0b000, rs, rt, rn);
+  void ldswplh(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i16Bit, 0, 1, 1, 0b000, rs, rt, rn);
   }
-  void ldaddah(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 1, 0, 0, 0b000, rs, rt, rn);
+  void ldaddah(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i16Bit, 1, 0, 0, 0b000, rs, rt, rn);
   }
-  void ldclrah(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 1, 0, 0, 0b001, rs, rt, rn);
+  void ldclrah(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i16Bit, 1, 0, 0, 0b001, rs, rt, rn);
   }
-  void ldeorah(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 1, 0, 0, 0b010, rs, rt, rn);
+  void ldeorah(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i16Bit, 1, 0, 0, 0b010, rs, rt, rn);
   }
-  void ldsetah(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 1, 0, 0, 0b011, rs, rt, rn);
+  void ldsetah(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i16Bit, 1, 0, 0, 0b011, rs, rt, rn);
   }
-  void ldsmaxah(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 1, 0, 0, 0b100, rs, rt, rn);
+  void ldsmaxah(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i16Bit, 1, 0, 0, 0b100, rs, rt, rn);
   }
-  void ldsminah(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 1, 0, 0, 0b101, rs, rt, rn);
+  void ldsminah(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i16Bit, 1, 0, 0, 0b101, rs, rt, rn);
   }
-  void ldumaxah(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 1, 0, 0, 0b110, rs, rt, rn);
+  void ldumaxah(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i16Bit, 1, 0, 0, 0b110, rs, rt, rn);
   }
-  void lduminah(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 1, 0, 0, 0b111, rs, rt, rn);
+  void lduminah(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i16Bit, 1, 0, 0, 0b111, rs, rt, rn);
   }
-  void ldswpah(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 1, 0, 1, 0b000, rs, rt, rn);
+  void ldswpah(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i16Bit, 1, 0, 1, 0b000, rs, rt, rn);
   }
-  void ldaddalh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 1, 1, 0, 0b000, rs, rt, rn);
+  void ldaddalh(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i16Bit, 1, 1, 0, 0b000, rs, rt, rn);
   }
-  void ldclralh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 1, 1, 0, 0b001, rs, rt, rn);
+  void ldclralh(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i16Bit, 1, 1, 0, 0b001, rs, rt, rn);
   }
-  void ldeoralh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 1, 1, 0, 0b010, rs, rt, rn);
+  void ldeoralh(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i16Bit, 1, 1, 0, 0b010, rs, rt, rn);
   }
-  void ldsetalh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 1, 1, 0, 0b011, rs, rt, rn);
+  void ldsetalh(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i16Bit, 1, 1, 0, 0b011, rs, rt, rn);
   }
-  void ldsmaxalh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 1, 1, 0, 0b100, rs, rt, rn);
+  void ldsmaxalh(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i16Bit, 1, 1, 0, 0b100, rs, rt, rn);
   }
-  void ldsminalh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 1, 1, 0, 0b101, rs, rt, rn);
+  void ldsminalh(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i16Bit, 1, 1, 0, 0b101, rs, rt, rn);
   }
-  void ldumaxalh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 1, 1, 0, 0b110, rs, rt, rn);
+  void ldumaxalh(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i16Bit, 1, 1, 0, 0b110, rs, rt, rn);
   }
-  void lduminalh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 1, 1, 0, 0b111, rs, rt, rn);
+  void lduminalh(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i16Bit, 1, 1, 0, 0b111, rs, rt, rn);
   }
-  void ldswpalh(FEXCore::ARMEmitter::Register rs, FEXCore::ARMEmitter::Register rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 1, 1, 1, 0b000, rs, rt, rn);
+  void ldswpalh(Register rs, Register rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i16Bit, 1, 1, 1, 0b000, rs, rt, rn);
   }
   // 32-bit
-  void ldadd(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 0, 0, 0, 0b000, rs, rt, rn);
+  void ldadd(WRegister rs, WRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i32Bit, 0, 0, 0, 0b000, rs, rt, rn);
   }
-  void ldclr(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 0, 0, 0, 0b001, rs, rt, rn);
+  void ldclr(WRegister rs, WRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i32Bit, 0, 0, 0, 0b001, rs, rt, rn);
   }
-  void ldeor(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 0, 0, 0, 0b010, rs, rt, rn);
+  void ldeor(WRegister rs, WRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i32Bit, 0, 0, 0, 0b010, rs, rt, rn);
   }
-  void ldset(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 0, 0, 0, 0b011, rs, rt, rn);
+  void ldset(WRegister rs, WRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i32Bit, 0, 0, 0, 0b011, rs, rt, rn);
   }
-  void ldsmax(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 0, 0, 0, 0b100, rs, rt, rn);
+  void ldsmax(WRegister rs, WRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i32Bit, 0, 0, 0, 0b100, rs, rt, rn);
   }
-  void ldsmin(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 0, 0, 0, 0b101, rs, rt, rn);
+  void ldsmin(WRegister rs, WRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i32Bit, 0, 0, 0, 0b101, rs, rt, rn);
   }
-  void ldumax(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 0, 0, 0, 0b110, rs, rt, rn);
+  void ldumax(WRegister rs, WRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i32Bit, 0, 0, 0, 0b110, rs, rt, rn);
   }
-  void ldumin(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 0, 0, 0, 0b111, rs, rt, rn);
+  void ldumin(WRegister rs, WRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i32Bit, 0, 0, 0, 0b111, rs, rt, rn);
   }
-  void ldswp(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 0, 0, 1, 0b000, rs, rt, rn);
+  void ldswp(WRegister rs, WRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i32Bit, 0, 0, 1, 0b000, rs, rt, rn);
   }
-  void ldaddl(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 0, 1, 0, 0b000, rs, rt, rn);
+  void ldaddl(WRegister rs, WRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i32Bit, 0, 1, 0, 0b000, rs, rt, rn);
   }
-  void ldclrl(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 0, 1, 0, 0b001, rs, rt, rn);
+  void ldclrl(WRegister rs, WRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i32Bit, 0, 1, 0, 0b001, rs, rt, rn);
   }
-  void ldeorl(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 0, 1, 0, 0b010, rs, rt, rn);
+  void ldeorl(WRegister rs, WRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i32Bit, 0, 1, 0, 0b010, rs, rt, rn);
   }
-  void ldsetl(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 0, 1, 0, 0b011, rs, rt, rn);
+  void ldsetl(WRegister rs, WRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i32Bit, 0, 1, 0, 0b011, rs, rt, rn);
   }
-  void ldsmaxl(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 0, 1, 0, 0b100, rs, rt, rn);
+  void ldsmaxl(WRegister rs, WRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i32Bit, 0, 1, 0, 0b100, rs, rt, rn);
   }
-  void ldsminl(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 0, 1, 0, 0b101, rs, rt, rn);
+  void ldsminl(WRegister rs, WRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i32Bit, 0, 1, 0, 0b101, rs, rt, rn);
   }
-  void ldumaxl(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 0, 1, 0, 0b110, rs, rt, rn);
+  void ldumaxl(WRegister rs, WRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i32Bit, 0, 1, 0, 0b110, rs, rt, rn);
   }
-  void lduminl(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 0, 1, 0, 0b111, rs, rt, rn);
+  void lduminl(WRegister rs, WRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i32Bit, 0, 1, 0, 0b111, rs, rt, rn);
   }
-  void ldswpl(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 0, 1, 1, 0b000, rs, rt, rn);
+  void ldswpl(WRegister rs, WRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i32Bit, 0, 1, 1, 0b000, rs, rt, rn);
   }
-  void ldadda(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 1, 0, 0, 0b000, rs, rt, rn);
+  void ldadda(WRegister rs, WRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i32Bit, 1, 0, 0, 0b000, rs, rt, rn);
   }
-  void ldclra(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 1, 0, 0, 0b001, rs, rt, rn);
+  void ldclra(WRegister rs, WRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i32Bit, 1, 0, 0, 0b001, rs, rt, rn);
   }
-  void ldeora(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 1, 0, 0, 0b010, rs, rt, rn);
+  void ldeora(WRegister rs, WRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i32Bit, 1, 0, 0, 0b010, rs, rt, rn);
   }
-  void ldseta(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 1, 0, 0, 0b011, rs, rt, rn);
+  void ldseta(WRegister rs, WRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i32Bit, 1, 0, 0, 0b011, rs, rt, rn);
   }
-  void ldsmaxa(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 1, 0, 0, 0b100, rs, rt, rn);
+  void ldsmaxa(WRegister rs, WRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i32Bit, 1, 0, 0, 0b100, rs, rt, rn);
   }
-  void ldsmina(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 1, 0, 0, 0b101, rs, rt, rn);
+  void ldsmina(WRegister rs, WRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i32Bit, 1, 0, 0, 0b101, rs, rt, rn);
   }
-  void ldumaxa(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 1, 0, 0, 0b110, rs, rt, rn);
+  void ldumaxa(WRegister rs, WRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i32Bit, 1, 0, 0, 0b110, rs, rt, rn);
   }
-  void ldumina(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 1, 0, 0, 0b111, rs, rt, rn);
+  void ldumina(WRegister rs, WRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i32Bit, 1, 0, 0, 0b111, rs, rt, rn);
   }
-  void ldswpa(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 1, 0, 1, 0b000, rs, rt, rn);
+  void ldswpa(WRegister rs, WRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i32Bit, 1, 0, 1, 0b000, rs, rt, rn);
   }
-  void ldaddal(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 1, 1, 0, 0b000, rs, rt, rn);
+  void ldaddal(WRegister rs, WRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i32Bit, 1, 1, 0, 0b000, rs, rt, rn);
   }
-  void ldclral(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 1, 1, 0, 0b001, rs, rt, rn);
+  void ldclral(WRegister rs, WRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i32Bit, 1, 1, 0, 0b001, rs, rt, rn);
   }
-  void ldeoral(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 1, 1, 0, 0b010, rs, rt, rn);
+  void ldeoral(WRegister rs, WRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i32Bit, 1, 1, 0, 0b010, rs, rt, rn);
   }
-  void ldsetal(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 1, 1, 0, 0b011, rs, rt, rn);
+  void ldsetal(WRegister rs, WRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i32Bit, 1, 1, 0, 0b011, rs, rt, rn);
   }
-  void ldsmaxal(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 1, 1, 0, 0b100, rs, rt, rn);
+  void ldsmaxal(WRegister rs, WRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i32Bit, 1, 1, 0, 0b100, rs, rt, rn);
   }
-  void ldsminal(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 1, 1, 0, 0b101, rs, rt, rn);
+  void ldsminal(WRegister rs, WRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i32Bit, 1, 1, 0, 0b101, rs, rt, rn);
   }
-  void ldumaxal(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 1, 1, 0, 0b110, rs, rt, rn);
+  void ldumaxal(WRegister rs, WRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i32Bit, 1, 1, 0, 0b110, rs, rt, rn);
   }
-  void lduminal(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 1, 1, 0, 0b111, rs, rt, rn);
+  void lduminal(WRegister rs, WRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i32Bit, 1, 1, 0, 0b111, rs, rt, rn);
   }
-  void ldswpal(FEXCore::ARMEmitter::WRegister rs, FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 1, 1, 1, 0b000, rs, rt, rn);
+  void ldswpal(WRegister rs, WRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i32Bit, 1, 1, 1, 0b000, rs, rt, rn);
   }
   // 64-bit
-  void ldadd(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 0, 0, 0, 0b000, rs, rt, rn);
+  void ldadd(XRegister rs, XRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i64Bit, 0, 0, 0, 0b000, rs, rt, rn);
   }
-  void ldclr(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 0, 0, 0, 0b001, rs, rt, rn);
+  void ldclr(XRegister rs, XRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i64Bit, 0, 0, 0, 0b001, rs, rt, rn);
   }
-  void ldeor(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 0, 0, 0, 0b010, rs, rt, rn);
+  void ldeor(XRegister rs, XRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i64Bit, 0, 0, 0, 0b010, rs, rt, rn);
   }
-  void ldset(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 0, 0, 0, 0b011, rs, rt, rn);
+  void ldset(XRegister rs, XRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i64Bit, 0, 0, 0, 0b011, rs, rt, rn);
   }
-  void ldsmax(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 0, 0, 0, 0b100, rs, rt, rn);
+  void ldsmax(XRegister rs, XRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i64Bit, 0, 0, 0, 0b100, rs, rt, rn);
   }
-  void ldsmin(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 0, 0, 0, 0b101, rs, rt, rn);
+  void ldsmin(XRegister rs, XRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i64Bit, 0, 0, 0, 0b101, rs, rt, rn);
   }
-  void ldumax(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 0, 0, 0, 0b110, rs, rt, rn);
+  void ldumax(XRegister rs, XRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i64Bit, 0, 0, 0, 0b110, rs, rt, rn);
   }
-  void ldumin(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 0, 0, 0, 0b111, rs, rt, rn);
+  void ldumin(XRegister rs, XRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i64Bit, 0, 0, 0, 0b111, rs, rt, rn);
   }
-  void ldswp(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 0, 0, 1, 0b000, rs, rt, rn);
+  void ldswp(XRegister rs, XRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i64Bit, 0, 0, 1, 0b000, rs, rt, rn);
   }
-  void ldaddl(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 0, 1, 0, 0b000, rs, rt, rn);
+  void ldaddl(XRegister rs, XRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i64Bit, 0, 1, 0, 0b000, rs, rt, rn);
   }
-  void ldclrl(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 0, 1, 0, 0b001, rs, rt, rn);
+  void ldclrl(XRegister rs, XRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i64Bit, 0, 1, 0, 0b001, rs, rt, rn);
   }
-  void ldeorl(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 0, 1, 0, 0b010, rs, rt, rn);
+  void ldeorl(XRegister rs, XRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i64Bit, 0, 1, 0, 0b010, rs, rt, rn);
   }
-  void ldsetl(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 0, 1, 0, 0b011, rs, rt, rn);
+  void ldsetl(XRegister rs, XRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i64Bit, 0, 1, 0, 0b011, rs, rt, rn);
   }
-  void ldsmaxl(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 0, 1, 0, 0b100, rs, rt, rn);
+  void ldsmaxl(XRegister rs, XRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i64Bit, 0, 1, 0, 0b100, rs, rt, rn);
   }
-  void ldsminl(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 0, 1, 0, 0b101, rs, rt, rn);
+  void ldsminl(XRegister rs, XRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i64Bit, 0, 1, 0, 0b101, rs, rt, rn);
   }
-  void ldumaxl(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 0, 1, 0, 0b110, rs, rt, rn);
+  void ldumaxl(XRegister rs, XRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i64Bit, 0, 1, 0, 0b110, rs, rt, rn);
   }
-  void lduminl(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 0, 1, 0, 0b111, rs, rt, rn);
+  void lduminl(XRegister rs, XRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i64Bit, 0, 1, 0, 0b111, rs, rt, rn);
   }
-  void ldswpl(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 0, 1, 1, 0b000, rs, rt, rn);
+  void ldswpl(XRegister rs, XRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i64Bit, 0, 1, 1, 0b000, rs, rt, rn);
   }
-  void ldadda(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 1, 0, 0, 0b000, rs, rt, rn);
+  void ldadda(XRegister rs, XRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i64Bit, 1, 0, 0, 0b000, rs, rt, rn);
   }
-  void ldclra(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 1, 0, 0, 0b001, rs, rt, rn);
+  void ldclra(XRegister rs, XRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i64Bit, 1, 0, 0, 0b001, rs, rt, rn);
   }
-  void ldeora(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 1, 0, 0, 0b010, rs, rt, rn);
+  void ldeora(XRegister rs, XRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i64Bit, 1, 0, 0, 0b010, rs, rt, rn);
   }
-  void ldseta(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 1, 0, 0, 0b011, rs, rt, rn);
+  void ldseta(XRegister rs, XRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i64Bit, 1, 0, 0, 0b011, rs, rt, rn);
   }
-  void ldsmaxa(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 1, 0, 0, 0b100, rs, rt, rn);
+  void ldsmaxa(XRegister rs, XRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i64Bit, 1, 0, 0, 0b100, rs, rt, rn);
   }
-  void ldsmina(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 1, 0, 0, 0b101, rs, rt, rn);
+  void ldsmina(XRegister rs, XRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i64Bit, 1, 0, 0, 0b101, rs, rt, rn);
   }
-  void ldumaxa(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 1, 0, 0, 0b110, rs, rt, rn);
+  void ldumaxa(XRegister rs, XRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i64Bit, 1, 0, 0, 0b110, rs, rt, rn);
   }
-  void ldumina(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 1, 0, 0, 0b111, rs, rt, rn);
+  void ldumina(XRegister rs, XRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i64Bit, 1, 0, 0, 0b111, rs, rt, rn);
   }
-  void ldswpa(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 1, 0, 1, 0b000, rs, rt, rn);
+  void ldswpa(XRegister rs, XRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i64Bit, 1, 0, 1, 0b000, rs, rt, rn);
   }
-  void ldaddal(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 1, 1, 0, 0b000, rs, rt, rn);
+  void ldaddal(XRegister rs, XRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i64Bit, 1, 1, 0, 0b000, rs, rt, rn);
   }
-  void ldclral(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 1, 1, 0, 0b001, rs, rt, rn);
+  void ldclral(XRegister rs, XRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i64Bit, 1, 1, 0, 0b001, rs, rt, rn);
   }
-  void ldeoral(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 1, 1, 0, 0b010, rs, rt, rn);
+  void ldeoral(XRegister rs, XRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i64Bit, 1, 1, 0, 0b010, rs, rt, rn);
   }
-  void ldsetal(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 1, 1, 0, 0b011, rs, rt, rn);
+  void ldsetal(XRegister rs, XRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i64Bit, 1, 1, 0, 0b011, rs, rt, rn);
   }
-  void ldsmaxal(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 1, 1, 0, 0b100, rs, rt, rn);
+  void ldsmaxal(XRegister rs, XRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i64Bit, 1, 1, 0, 0b100, rs, rt, rn);
   }
-  void ldsminal(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 1, 1, 0, 0b101, rs, rt, rn);
+  void ldsminal(XRegister rs, XRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i64Bit, 1, 1, 0, 0b101, rs, rt, rn);
   }
-  void ldumaxal(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 1, 1, 0, 0b110, rs, rt, rn);
+  void ldumaxal(XRegister rs, XRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i64Bit, 1, 1, 0, 0b110, rs, rt, rn);
   }
-  void lduminal(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 1, 1, 0, 0b111, rs, rt, rn);
+  void lduminal(XRegister rs, XRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i64Bit, 1, 1, 0, 0b111, rs, rt, rn);
   }
-  void ldswpal(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 1, 1, 1, 0b000, rs, rt, rn);
+  void ldswpal(XRegister rs, XRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i64Bit, 1, 1, 1, 0b000, rs, rt, rn);
   }
-  void ldaprb(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i8Bit, 1, 0, 1, 0b100, FEXCore::ARMEmitter::WReg::w31, rt, rn);
+  void ldaprb(WRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i8Bit, 1, 0, 1, 0b100, WReg::w31, rt, rn);
   }
-  void ldaprh(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i16Bit, 1, 0, 1, 0b100, FEXCore::ARMEmitter::WReg::w31, rt, rn);
+  void ldaprh(WRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i16Bit, 1, 0, 1, 0b100, WReg::w31, rt, rn);
   }
-  void ldapr(FEXCore::ARMEmitter::WRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i32Bit, 1, 0, 1, 0b100, FEXCore::ARMEmitter::WReg::w31, rt, rn);
+  void ldapr(WRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i32Bit, 1, 0, 1, 0b100, WReg::w31, rt, rn);
   }
-  void ldapr(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 1, 0, 1, 0b100, FEXCore::ARMEmitter::XReg::x31, rt, rn);
+  void ldapr(XRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i64Bit, 1, 0, 1, 0b100, XReg::x31, rt, rn);
   }
-  void st64bv0(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 0, 0, 1, 0b010, rs, rt, rn);
+  void st64bv0(XRegister rs, XRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i64Bit, 0, 0, 1, 0b010, rs, rt, rn);
   }
-  void st64bv(FEXCore::ARMEmitter::XRegister rs, FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 0, 0, 1, 0b011, rs, rt, rn);
+  void st64bv(XRegister rs, XRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i64Bit, 0, 0, 1, 0b011, rs, rt, rn);
   }
-  void st64b(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 0, 0, 1, 0b001, FEXCore::ARMEmitter::XReg::x31, rt, rn);
+  void st64b(XRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i64Bit, 0, 0, 1, 0b001, XReg::x31, rt, rn);
   }
-  void ld64b(FEXCore::ARMEmitter::XRegister rt, FEXCore::ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0011'1000'0010'0000'0000'00 << 10;
-    LoadStoreAtomicLSE(Op, SubRegSize::i64Bit, 0, 0, 1, 0b101, FEXCore::ARMEmitter::XReg::x31, rt, rn);
+  void ld64b(XRegister rt, Register rn) {
+    LoadStoreAtomicLSE(SubRegSize::i64Bit, 0, 0, 1, 0b101, XReg::x31, rt, rn);
   }
 
   // Loadstore register-register offset
@@ -4345,11 +4165,9 @@ private:
 
   // Atomic memory operations
   template<typename T>
-  void LoadStoreAtomicLSE(uint32_t Op, FEXCore::ARMEmitter::SubRegSize s, uint32_t A, uint32_t R, uint32_t o3, uint32_t opc, T rs, T rt, FEXCore::ARMEmitter::Register rn) {
-    const uint32_t sz = FEXCore::ToUnderlying(s) << 30;
-    uint32_t Instr = Op;
-
-    Instr |= sz;
+  void LoadStoreAtomicLSE(SubRegSize s, uint32_t A, uint32_t R, uint32_t o3, uint32_t opc, T rs, T rt, Register rn) {
+    uint32_t Instr = 0b0011'1000'0010'0000'0000'0000'0000'0000;
+    Instr |= FEXCore::ToUnderlying(s) << 30;
     Instr |= A << 23;
     Instr |= R << 22;
     Instr |= Encode_rs(rs);

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/LoadstoreOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/LoadstoreOps.inl
@@ -2599,11 +2599,23 @@ public:
   void staddl(SubRegSize size, Register rs, Register rn) {
     LoadStoreAtomicLSE(size, 0, 1, 0, 0b000, rs, Reg::zr, rn);
   }
+  void stadda(SubRegSize size, Register rs, Register rn) {
+    LoadStoreAtomicLSE(size, 1, 0, 0, 0b000, rs, Reg::zr, rn);
+  }
+  void staddal(SubRegSize size, Register rs, Register rn) {
+    LoadStoreAtomicLSE(size, 1, 1, 0, 0b000, rs, Reg::zr, rn);
+  }
   void stclr(SubRegSize size, Register rs, Register rn) {
     LoadStoreAtomicLSE(size, 0, 0, 0, 0b001, rs, Reg::zr, rn);
   }
   void stclrl(SubRegSize size, Register rs, Register rn) {
     LoadStoreAtomicLSE(size, 0, 1, 0, 0b001, rs, Reg::zr, rn);
+  }
+  void stclra(SubRegSize size, Register rs, Register rn) {
+    LoadStoreAtomicLSE(size, 1, 0, 0, 0b001, rs, Reg::zr, rn);
+  }
+  void stclral(SubRegSize size, Register rs, Register rn) {
+    LoadStoreAtomicLSE(size, 1, 1, 0, 0b001, rs, Reg::zr, rn);
   }
   void stset(SubRegSize size, Register rs, Register rn) {
     LoadStoreAtomicLSE(size, 0, 0, 0, 0b011, rs, Reg::zr, rn);
@@ -2611,11 +2623,71 @@ public:
   void stsetl(SubRegSize size, Register rs, Register rn) {
     LoadStoreAtomicLSE(size, 0, 1, 0, 0b011, rs, Reg::zr, rn);
   }
+  void stseta(SubRegSize size, Register rs, Register rn) {
+    LoadStoreAtomicLSE(size, 1, 0, 0, 0b011, rs, Reg::zr, rn);
+  }
+  void stsetal(SubRegSize size, Register rs, Register rn) {
+    LoadStoreAtomicLSE(size, 1, 1, 0, 0b011, rs, Reg::zr, rn);
+  }
   void steor(SubRegSize size, Register rs, Register rn) {
     LoadStoreAtomicLSE(size, 0, 0, 0, 0b010, rs, Reg::zr, rn);
   }
   void steorl(SubRegSize size, Register rs, Register rn) {
     LoadStoreAtomicLSE(size, 0, 1, 0, 0b010, rs, Reg::zr, rn);
+  }
+  void steora(SubRegSize size, Register rs, Register rn) {
+    LoadStoreAtomicLSE(size, 1, 0, 0, 0b010, rs, Reg::zr, rn);
+  }
+  void steoral(SubRegSize size, Register rs, Register rn) {
+    LoadStoreAtomicLSE(size, 1, 1, 0, 0b010, rs, Reg::zr, rn);
+  }
+  void stsmax(SubRegSize size, Register rs, Register rn) {
+    LoadStoreAtomicLSE(size, 0, 0, 0, 0b100, rs, Reg::zr, rn);
+  }
+  void stsmaxl(SubRegSize size, Register rs, Register rn) {
+    LoadStoreAtomicLSE(size, 0, 1, 0, 0b100, rs, Reg::zr, rn);
+  }
+  void stsmaxa(SubRegSize size, Register rs, Register rn) {
+    LoadStoreAtomicLSE(size, 1, 0, 0, 0b100, rs, Reg::zr, rn);
+  }
+  void stsmaxal(SubRegSize size, Register rs, Register rn) {
+    LoadStoreAtomicLSE(size, 1, 1, 0, 0b100, rs, Reg::zr, rn);
+  }
+  void stsmin(SubRegSize size, Register rs, Register rn) {
+    LoadStoreAtomicLSE(size, 0, 0, 0, 0b101, rs, Reg::zr, rn);
+  }
+  void stsminl(SubRegSize size, Register rs, Register rn) {
+    LoadStoreAtomicLSE(size, 0, 1, 0, 0b101, rs, Reg::zr, rn);
+  }
+  void stsmina(SubRegSize size, Register rs, Register rn) {
+    LoadStoreAtomicLSE(size, 1, 0, 0, 0b101, rs, Reg::zr, rn);
+  }
+  void stsminal(SubRegSize size, Register rs, Register rn) {
+    LoadStoreAtomicLSE(size, 1, 1, 0, 0b101, rs, Reg::zr, rn);
+  }
+  void stumax(SubRegSize size, Register rs, Register rn) {
+    LoadStoreAtomicLSE(size, 0, 0, 0, 0b110, rs, Reg::zr, rn);
+  }
+  void stumaxl(SubRegSize size, Register rs, Register rn) {
+    LoadStoreAtomicLSE(size, 0, 1, 0, 0b110, rs, Reg::zr, rn);
+  }
+  void stumaxa(SubRegSize size, Register rs, Register rn) {
+    LoadStoreAtomicLSE(size, 1, 0, 0, 0b110, rs, Reg::zr, rn);
+  }
+  void stumaxal(SubRegSize size, Register rs, Register rn) {
+    LoadStoreAtomicLSE(size, 1, 1, 0, 0b110, rs, Reg::zr, rn);
+  }
+  void stumin(SubRegSize size, Register rs, Register rn) {
+    LoadStoreAtomicLSE(size, 0, 0, 0, 0b111, rs, Reg::zr, rn);
+  }
+  void stuminl(SubRegSize size, Register rs, Register rn) {
+    LoadStoreAtomicLSE(size, 0, 1, 0, 0b111, rs, Reg::zr, rn);
+  }
+  void stumina(SubRegSize size, Register rs, Register rn) {
+    LoadStoreAtomicLSE(size, 1, 0, 0, 0b111, rs, Reg::zr, rn);
+  }
+  void stuminal(SubRegSize size, Register rs, Register rn) {
+    LoadStoreAtomicLSE(size, 1, 1, 0, 0b111, rs, Reg::zr, rn);
   }
   void ldswp(SubRegSize size, Register rs, Register rt, Register rn) {
     LoadStoreAtomicLSE(size, 0, 0, 1, 0b000, rs, rt, rn);

--- a/External/FEXCore/unittests/Emitter/Loadstore_Tests.cpp
+++ b/External/FEXCore/unittests/Emitter/Loadstore_Tests.cpp
@@ -1574,45 +1574,165 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Loadstore register unpri
   }
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: Loadstore: Atomic memory operations") {
-  TEST_SINGLE(stadd(SubRegSize::i8Bit, Reg::r30, Reg::r29), "staddb w30, [x29]");
+  TEST_SINGLE(stadd(SubRegSize::i8Bit,  Reg::r30, Reg::r29), "staddb w30, [x29]");
   TEST_SINGLE(stadd(SubRegSize::i16Bit, Reg::r30, Reg::r29), "staddh w30, [x29]");
   TEST_SINGLE(stadd(SubRegSize::i32Bit, Reg::r30, Reg::r29), "stadd w30, [x29]");
   TEST_SINGLE(stadd(SubRegSize::i64Bit, Reg::r30, Reg::r29), "stadd x30, [x29]");
 
-  TEST_SINGLE(staddl(SubRegSize::i8Bit, Reg::r30, Reg::r29), "staddlb w30, [x29]");
+  TEST_SINGLE(staddl(SubRegSize::i8Bit,  Reg::r30, Reg::r29), "staddlb w30, [x29]");
   TEST_SINGLE(staddl(SubRegSize::i16Bit, Reg::r30, Reg::r29), "staddlh w30, [x29]");
   TEST_SINGLE(staddl(SubRegSize::i32Bit, Reg::r30, Reg::r29), "staddl w30, [x29]");
   TEST_SINGLE(staddl(SubRegSize::i64Bit, Reg::r30, Reg::r29), "staddl x30, [x29]");
 
-  TEST_SINGLE(stclr(SubRegSize::i8Bit, Reg::r30, Reg::r29), "stclrb w30, [x29]");
+  TEST_SINGLE(stadda(SubRegSize::i8Bit,  Reg::r30, Reg::r29), "staddab w30, [x29]");
+  TEST_SINGLE(stadda(SubRegSize::i16Bit, Reg::r30, Reg::r29), "staddah w30, [x29]");
+  TEST_SINGLE(stadda(SubRegSize::i32Bit, Reg::r30, Reg::r29), "stadda w30, [x29]");
+  TEST_SINGLE(stadda(SubRegSize::i64Bit, Reg::r30, Reg::r29), "stadda x30, [x29]");
+
+  TEST_SINGLE(staddal(SubRegSize::i8Bit,  Reg::r30, Reg::r29), "staddalb w30, [x29]");
+  TEST_SINGLE(staddal(SubRegSize::i16Bit, Reg::r30, Reg::r29), "staddalh w30, [x29]");
+  TEST_SINGLE(staddal(SubRegSize::i32Bit, Reg::r30, Reg::r29), "staddal w30, [x29]");
+  TEST_SINGLE(staddal(SubRegSize::i64Bit, Reg::r30, Reg::r29), "staddal x30, [x29]");
+
+  TEST_SINGLE(stclr(SubRegSize::i8Bit,  Reg::r30, Reg::r29), "stclrb w30, [x29]");
   TEST_SINGLE(stclr(SubRegSize::i16Bit, Reg::r30, Reg::r29), "stclrh w30, [x29]");
   TEST_SINGLE(stclr(SubRegSize::i32Bit, Reg::r30, Reg::r29), "stclr w30, [x29]");
   TEST_SINGLE(stclr(SubRegSize::i64Bit, Reg::r30, Reg::r29), "stclr x30, [x29]");
 
-  TEST_SINGLE(stclrl(SubRegSize::i8Bit, Reg::r30, Reg::r29), "stclrlb w30, [x29]");
+  TEST_SINGLE(stclrl(SubRegSize::i8Bit,  Reg::r30, Reg::r29), "stclrlb w30, [x29]");
   TEST_SINGLE(stclrl(SubRegSize::i16Bit, Reg::r30, Reg::r29), "stclrlh w30, [x29]");
   TEST_SINGLE(stclrl(SubRegSize::i32Bit, Reg::r30, Reg::r29), "stclrl w30, [x29]");
   TEST_SINGLE(stclrl(SubRegSize::i64Bit, Reg::r30, Reg::r29), "stclrl x30, [x29]");
 
-  TEST_SINGLE(stset(SubRegSize::i8Bit, Reg::r30, Reg::r29), "stsetb w30, [x29]");
+  TEST_SINGLE(stclra(SubRegSize::i8Bit,  Reg::r30, Reg::r29), "stclrab w30, [x29]");
+  TEST_SINGLE(stclra(SubRegSize::i16Bit, Reg::r30, Reg::r29), "stclrah w30, [x29]");
+  TEST_SINGLE(stclra(SubRegSize::i32Bit, Reg::r30, Reg::r29), "stclra w30, [x29]");
+  TEST_SINGLE(stclra(SubRegSize::i64Bit, Reg::r30, Reg::r29), "stclra x30, [x29]");
+
+  TEST_SINGLE(stclral(SubRegSize::i8Bit,  Reg::r30, Reg::r29), "stclralb w30, [x29]");
+  TEST_SINGLE(stclral(SubRegSize::i16Bit, Reg::r30, Reg::r29), "stclralh w30, [x29]");
+  TEST_SINGLE(stclral(SubRegSize::i32Bit, Reg::r30, Reg::r29), "stclral w30, [x29]");
+  TEST_SINGLE(stclral(SubRegSize::i64Bit, Reg::r30, Reg::r29), "stclral x30, [x29]");
+
+  TEST_SINGLE(stset(SubRegSize::i8Bit,  Reg::r30, Reg::r29), "stsetb w30, [x29]");
   TEST_SINGLE(stset(SubRegSize::i16Bit, Reg::r30, Reg::r29), "stseth w30, [x29]");
   TEST_SINGLE(stset(SubRegSize::i32Bit, Reg::r30, Reg::r29), "stset w30, [x29]");
   TEST_SINGLE(stset(SubRegSize::i64Bit, Reg::r30, Reg::r29), "stset x30, [x29]");
 
-  TEST_SINGLE(stsetl(SubRegSize::i8Bit, Reg::r30, Reg::r29), "stsetlb w30, [x29]");
+  TEST_SINGLE(stsetl(SubRegSize::i8Bit,  Reg::r30, Reg::r29), "stsetlb w30, [x29]");
   TEST_SINGLE(stsetl(SubRegSize::i16Bit, Reg::r30, Reg::r29), "stsetlh w30, [x29]");
   TEST_SINGLE(stsetl(SubRegSize::i32Bit, Reg::r30, Reg::r29), "stsetl w30, [x29]");
   TEST_SINGLE(stsetl(SubRegSize::i64Bit, Reg::r30, Reg::r29), "stsetl x30, [x29]");
 
-  TEST_SINGLE(steor(SubRegSize::i8Bit, Reg::r30, Reg::r29), "steorb w30, [x29]");
+  TEST_SINGLE(stseta(SubRegSize::i8Bit,  Reg::r30, Reg::r29), "stsetab w30, [x29]");
+  TEST_SINGLE(stseta(SubRegSize::i16Bit, Reg::r30, Reg::r29), "stsetah w30, [x29]");
+  TEST_SINGLE(stseta(SubRegSize::i32Bit, Reg::r30, Reg::r29), "stseta w30, [x29]");
+  TEST_SINGLE(stseta(SubRegSize::i64Bit, Reg::r30, Reg::r29), "stseta x30, [x29]");
+
+  TEST_SINGLE(stsetal(SubRegSize::i8Bit,  Reg::r30, Reg::r29), "stsetalb w30, [x29]");
+  TEST_SINGLE(stsetal(SubRegSize::i16Bit, Reg::r30, Reg::r29), "stsetalh w30, [x29]");
+  TEST_SINGLE(stsetal(SubRegSize::i32Bit, Reg::r30, Reg::r29), "stsetal w30, [x29]");
+  TEST_SINGLE(stsetal(SubRegSize::i64Bit, Reg::r30, Reg::r29), "stsetal x30, [x29]");
+
+  TEST_SINGLE(steor(SubRegSize::i8Bit,  Reg::r30, Reg::r29), "steorb w30, [x29]");
   TEST_SINGLE(steor(SubRegSize::i16Bit, Reg::r30, Reg::r29), "steorh w30, [x29]");
   TEST_SINGLE(steor(SubRegSize::i32Bit, Reg::r30, Reg::r29), "steor w30, [x29]");
   TEST_SINGLE(steor(SubRegSize::i64Bit, Reg::r30, Reg::r29), "steor x30, [x29]");
 
-  TEST_SINGLE(steorl(SubRegSize::i8Bit, Reg::r30, Reg::r29), "steorlb w30, [x29]");
+  TEST_SINGLE(steorl(SubRegSize::i8Bit,  Reg::r30, Reg::r29), "steorlb w30, [x29]");
   TEST_SINGLE(steorl(SubRegSize::i16Bit, Reg::r30, Reg::r29), "steorlh w30, [x29]");
   TEST_SINGLE(steorl(SubRegSize::i32Bit, Reg::r30, Reg::r29), "steorl w30, [x29]");
   TEST_SINGLE(steorl(SubRegSize::i64Bit, Reg::r30, Reg::r29), "steorl x30, [x29]");
+
+  TEST_SINGLE(steora(SubRegSize::i8Bit,  Reg::r30, Reg::r29), "steorab w30, [x29]");
+  TEST_SINGLE(steora(SubRegSize::i16Bit, Reg::r30, Reg::r29), "steorah w30, [x29]");
+  TEST_SINGLE(steora(SubRegSize::i32Bit, Reg::r30, Reg::r29), "steora w30, [x29]");
+  TEST_SINGLE(steora(SubRegSize::i64Bit, Reg::r30, Reg::r29), "steora x30, [x29]");
+
+  TEST_SINGLE(steoral(SubRegSize::i8Bit,  Reg::r30, Reg::r29), "steoralb w30, [x29]");
+  TEST_SINGLE(steoral(SubRegSize::i16Bit, Reg::r30, Reg::r29), "steoralh w30, [x29]");
+  TEST_SINGLE(steoral(SubRegSize::i32Bit, Reg::r30, Reg::r29), "steoral w30, [x29]");
+  TEST_SINGLE(steoral(SubRegSize::i64Bit, Reg::r30, Reg::r29), "steoral x30, [x29]");
+
+  TEST_SINGLE(stsmax(SubRegSize::i8Bit,  Reg::r30, Reg::r29), "stsmaxb w30, [x29]");
+  TEST_SINGLE(stsmax(SubRegSize::i16Bit, Reg::r30, Reg::r29), "stsmaxh w30, [x29]");
+  TEST_SINGLE(stsmax(SubRegSize::i32Bit, Reg::r30, Reg::r29), "stsmax w30, [x29]");
+  TEST_SINGLE(stsmax(SubRegSize::i64Bit, Reg::r30, Reg::r29), "stsmax x30, [x29]");
+
+  TEST_SINGLE(stsmaxl(SubRegSize::i8Bit,  Reg::r30, Reg::r29), "stsmaxlb w30, [x29]");
+  TEST_SINGLE(stsmaxl(SubRegSize::i16Bit, Reg::r30, Reg::r29), "stsmaxlh w30, [x29]");
+  TEST_SINGLE(stsmaxl(SubRegSize::i32Bit, Reg::r30, Reg::r29), "stsmaxl w30, [x29]");
+  TEST_SINGLE(stsmaxl(SubRegSize::i64Bit, Reg::r30, Reg::r29), "stsmaxl x30, [x29]");
+
+  TEST_SINGLE(stsmaxa(SubRegSize::i8Bit,  Reg::r30, Reg::r29), "stsmaxab w30, [x29]");
+  TEST_SINGLE(stsmaxa(SubRegSize::i16Bit, Reg::r30, Reg::r29), "stsmaxah w30, [x29]");
+  TEST_SINGLE(stsmaxa(SubRegSize::i32Bit, Reg::r30, Reg::r29), "stsmaxa w30, [x29]");
+  TEST_SINGLE(stsmaxa(SubRegSize::i64Bit, Reg::r30, Reg::r29), "stsmaxa x30, [x29]");
+
+  TEST_SINGLE(stsmaxal(SubRegSize::i8Bit,  Reg::r30, Reg::r29), "stsmaxalb w30, [x29]");
+  TEST_SINGLE(stsmaxal(SubRegSize::i16Bit, Reg::r30, Reg::r29), "stsmaxalh w30, [x29]");
+  TEST_SINGLE(stsmaxal(SubRegSize::i32Bit, Reg::r30, Reg::r29), "stsmaxal w30, [x29]");
+  TEST_SINGLE(stsmaxal(SubRegSize::i64Bit, Reg::r30, Reg::r29), "stsmaxal x30, [x29]");
+
+  TEST_SINGLE(stsmin(SubRegSize::i8Bit,  Reg::r30, Reg::r29), "stsminb w30, [x29]");
+  TEST_SINGLE(stsmin(SubRegSize::i16Bit, Reg::r30, Reg::r29), "stsminh w30, [x29]");
+  TEST_SINGLE(stsmin(SubRegSize::i32Bit, Reg::r30, Reg::r29), "stsmin w30, [x29]");
+  TEST_SINGLE(stsmin(SubRegSize::i64Bit, Reg::r30, Reg::r29), "stsmin x30, [x29]");
+
+  TEST_SINGLE(stsminl(SubRegSize::i8Bit,  Reg::r30, Reg::r29), "stsminlb w30, [x29]");
+  TEST_SINGLE(stsminl(SubRegSize::i16Bit, Reg::r30, Reg::r29), "stsminlh w30, [x29]");
+  TEST_SINGLE(stsminl(SubRegSize::i32Bit, Reg::r30, Reg::r29), "stsminl w30, [x29]");
+  TEST_SINGLE(stsminl(SubRegSize::i64Bit, Reg::r30, Reg::r29), "stsminl x30, [x29]");
+
+  TEST_SINGLE(stsmina(SubRegSize::i8Bit,  Reg::r30, Reg::r29), "stsminab w30, [x29]");
+  TEST_SINGLE(stsmina(SubRegSize::i16Bit, Reg::r30, Reg::r29), "stsminah w30, [x29]");
+  TEST_SINGLE(stsmina(SubRegSize::i32Bit, Reg::r30, Reg::r29), "stsmina w30, [x29]");
+  TEST_SINGLE(stsmina(SubRegSize::i64Bit, Reg::r30, Reg::r29), "stsmina x30, [x29]");
+
+  TEST_SINGLE(stsminal(SubRegSize::i8Bit,  Reg::r30, Reg::r29), "stsminalb w30, [x29]");
+  TEST_SINGLE(stsminal(SubRegSize::i16Bit, Reg::r30, Reg::r29), "stsminalh w30, [x29]");
+  TEST_SINGLE(stsminal(SubRegSize::i32Bit, Reg::r30, Reg::r29), "stsminal w30, [x29]");
+  TEST_SINGLE(stsminal(SubRegSize::i64Bit, Reg::r30, Reg::r29), "stsminal x30, [x29]");
+
+  TEST_SINGLE(stumax(SubRegSize::i8Bit,  Reg::r30, Reg::r29), "stumaxb w30, [x29]");
+  TEST_SINGLE(stumax(SubRegSize::i16Bit, Reg::r30, Reg::r29), "stumaxh w30, [x29]");
+  TEST_SINGLE(stumax(SubRegSize::i32Bit, Reg::r30, Reg::r29), "stumax w30, [x29]");
+  TEST_SINGLE(stumax(SubRegSize::i64Bit, Reg::r30, Reg::r29), "stumax x30, [x29]");
+
+  TEST_SINGLE(stumaxl(SubRegSize::i8Bit,  Reg::r30, Reg::r29), "stumaxlb w30, [x29]");
+  TEST_SINGLE(stumaxl(SubRegSize::i16Bit, Reg::r30, Reg::r29), "stumaxlh w30, [x29]");
+  TEST_SINGLE(stumaxl(SubRegSize::i32Bit, Reg::r30, Reg::r29), "stumaxl w30, [x29]");
+  TEST_SINGLE(stumaxl(SubRegSize::i64Bit, Reg::r30, Reg::r29), "stumaxl x30, [x29]");
+
+  TEST_SINGLE(stumaxa(SubRegSize::i8Bit,  Reg::r30, Reg::r29), "stumaxab w30, [x29]");
+  TEST_SINGLE(stumaxa(SubRegSize::i16Bit, Reg::r30, Reg::r29), "stumaxah w30, [x29]");
+  TEST_SINGLE(stumaxa(SubRegSize::i32Bit, Reg::r30, Reg::r29), "stumaxa w30, [x29]");
+  TEST_SINGLE(stumaxa(SubRegSize::i64Bit, Reg::r30, Reg::r29), "stumaxa x30, [x29]");
+
+  TEST_SINGLE(stumaxal(SubRegSize::i8Bit,  Reg::r30, Reg::r29), "stumaxalb w30, [x29]");
+  TEST_SINGLE(stumaxal(SubRegSize::i16Bit, Reg::r30, Reg::r29), "stumaxalh w30, [x29]");
+  TEST_SINGLE(stumaxal(SubRegSize::i32Bit, Reg::r30, Reg::r29), "stumaxal w30, [x29]");
+  TEST_SINGLE(stumaxal(SubRegSize::i64Bit, Reg::r30, Reg::r29), "stumaxal x30, [x29]");
+
+  TEST_SINGLE(stumin(SubRegSize::i8Bit,  Reg::r30, Reg::r29), "stuminb w30, [x29]");
+  TEST_SINGLE(stumin(SubRegSize::i16Bit, Reg::r30, Reg::r29), "stuminh w30, [x29]");
+  TEST_SINGLE(stumin(SubRegSize::i32Bit, Reg::r30, Reg::r29), "stumin w30, [x29]");
+  TEST_SINGLE(stumin(SubRegSize::i64Bit, Reg::r30, Reg::r29), "stumin x30, [x29]");
+
+  TEST_SINGLE(stuminl(SubRegSize::i8Bit,  Reg::r30, Reg::r29), "stuminlb w30, [x29]");
+  TEST_SINGLE(stuminl(SubRegSize::i16Bit, Reg::r30, Reg::r29), "stuminlh w30, [x29]");
+  TEST_SINGLE(stuminl(SubRegSize::i32Bit, Reg::r30, Reg::r29), "stuminl w30, [x29]");
+  TEST_SINGLE(stuminl(SubRegSize::i64Bit, Reg::r30, Reg::r29), "stuminl x30, [x29]");
+
+  TEST_SINGLE(stumina(SubRegSize::i8Bit,  Reg::r30, Reg::r29), "stuminab w30, [x29]");
+  TEST_SINGLE(stumina(SubRegSize::i16Bit, Reg::r30, Reg::r29), "stuminah w30, [x29]");
+  TEST_SINGLE(stumina(SubRegSize::i32Bit, Reg::r30, Reg::r29), "stumina w30, [x29]");
+  TEST_SINGLE(stumina(SubRegSize::i64Bit, Reg::r30, Reg::r29), "stumina x30, [x29]");
+
+  TEST_SINGLE(stuminal(SubRegSize::i8Bit,  Reg::r30, Reg::r29), "stuminalb w30, [x29]");
+  TEST_SINGLE(stuminal(SubRegSize::i16Bit, Reg::r30, Reg::r29), "stuminalh w30, [x29]");
+  TEST_SINGLE(stuminal(SubRegSize::i32Bit, Reg::r30, Reg::r29), "stuminal w30, [x29]");
+  TEST_SINGLE(stuminal(SubRegSize::i64Bit, Reg::r30, Reg::r29), "stuminal x30, [x29]");
 
   TEST_SINGLE(ldswp(SubRegSize::i8Bit, Reg::r30, Reg::r28, Reg::r29), "swpb w30, w28, [x29]");
   TEST_SINGLE(ldswp(SubRegSize::i16Bit, Reg::r30, Reg::r28, Reg::r29), "swph w30, w28, [x29]");


### PR DESCRIPTION
Finishes off the missing aliases in #2836 