### PR TITLE
Arm64: Adds stats to the disassembly

### DIFF
--- a/External/FEXCore/Source/Interface/Config/Config.json.in
+++ b/External/FEXCore/Source/Interface/Config/Config.json.in
@@ -257,13 +257,15 @@
         "Default": "FEXCore::Config::Disassemble::OFF",
         "Enums": {
           "DISPATCHER": "dispatcher",
-          "BLOCKS": "blocks"
+          "BLOCKS": "blocks",
+          "STATS": "stats"
         },
         "Desc": [
           "Allows controlling of the vixl disassembler.",
           "\toff: No disassembly will be output",
           "\tdispatcher: Will enable disassembly of the JIT dispatcher loop",
-          "\tblocks: Will enable disassembly of the translated instruction code blocks"
+          "\tblocks: Will enable disassembly of the translated instruction code blocks",
+          "\tstats: Will print stats when disassembling the code"
         ]
       }
     },

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -1152,6 +1152,13 @@ CPUBackend::CompiledCode Arm64JITCore::CompileCode(uint64_t Entry,
   ClearICache(CodeData.BlockBegin, CodeOnlySize);
 
 #ifdef VIXL_DISASSEMBLER
+  if (Disassemble() & FEXCore::Config::Disassemble::STATS) {
+    LogMan::Msg::IFmt("RIP: 0x{:x}", Entry);
+    LogMan::Msg::IFmt("Guest Code instructions: {}", HeaderOp->NumHostInstructions);
+    LogMan::Msg::IFmt("Host Code instructions: {}", CodeOnlySize >> 2);
+    LogMan::Msg::IFmt("Blow-up Amt: {}x", double(CodeOnlySize >> 2) / double(HeaderOp->NumHostInstructions));
+  }
+
   if (Disassemble() & FEXCore::Config::Disassemble::BLOCKS) {
     const auto DisasmEnd = reinterpret_cast<const vixl::aarch64::Instruction*>(JITBlockTailLocation);
     Disasm.DisassembleBuffer(DisasmBegin, DisasmEnd);


### PR DESCRIPTION
I use this locally when looking for optimization opportunities in the JIT.
The instruction count CI in the future will use this as well. Just get it upstreamed right away.