### PR TITLE
Config: Adds support for overriding host features

### DIFF
--- a/External/FEXCore/Scripts/config_generator.py
+++ b/External/FEXCore/Scripts/config_generator.py
@@ -402,7 +402,7 @@ def print_parse_argloader_options(options):
 
             if (value_type == "strenum"):
                 output_argloader.write("\tfextl::string UserValue = Options[\"{0}\"];\n".format(op_key))
-                output_argloader.write("\tSet(FEXCore::Config::ConfigOption::CONFIG_{}, FEXCore::Config::EnumParser(FEXCore::Config::{}_EnumPairs, UserValue));\n".format(op_key.upper(), op_key, op_key))
+                output_argloader.write("\tSet(FEXCore::Config::ConfigOption::CONFIG_{}, FEXCore::Config::EnumParser<FEXCore::Config::{}ConfigPair>(FEXCore::Config::{}_EnumPairs, UserValue));\n".format(op_key.upper(), op_key, op_key, op_key))
             elif (value_type == "strarray"):
                 # these need a bit more help
                 output_argloader.write("\tauto Array = Options.all(\"{0}\");\n".format(op_key))
@@ -431,7 +431,7 @@ def print_parse_envloader_options(options):
             value_type = op_vals["Type"]
             if (value_type == "strenum"):
                 output_argloader.write("else if (Key == \"FEX_{0}\") {{\n".format(op_key.upper()))
-                output_argloader.write("Value = FEXCore::Config::EnumParser(FEXCore::Config::{}_EnumPairs, Value);\n".format(op_key, op_key))
+                output_argloader.write("Value = FEXCore::Config::EnumParser<FEXCore::Config::{}ConfigPair>(FEXCore::Config::{}_EnumPairs, Value);\n".format(op_key, op_key, op_key))
                 output_argloader.write("}\n")
 
             if ("ArgumentHandler" in op_vals):
@@ -447,7 +447,7 @@ def print_parse_enum_options(options):
     for op_group, group_vals in options.items():
         for op_key, op_vals in group_vals.items():
             if (op_vals["Type"] == "strenum"):
-                output_argloader.write("enum {} : uint64_t {{\n".format(op_key))
+                output_argloader.write("enum class {} : uint64_t {{\n".format(op_key))
                 Enums = op_vals["Enums"]
                 i = 0
                 # Always have an OFF.
@@ -457,6 +457,8 @@ def print_parse_enum_options(options):
                     i += 1
 
                 output_argloader.write("};\n")
+                output_argloader.write("FEX_DEF_NUM_OPS({})\n".format(op_key))
+
 
     for op_group, group_vals in options.items():
         for op_key, op_vals in group_vals.items():

--- a/External/FEXCore/Source/Interface/Config/Config.json.in
+++ b/External/FEXCore/Source/Interface/Config/Config.json.in
@@ -51,11 +51,38 @@
           "Allows JIT code to be shared between applications"
         ]
       },
-      "EnableAVX": {
-        "Type": "bool",
-        "Default": "false",
+      "HostFeatures": {
+        "Type": "strenum",
+        "Default": "FEXCore::Config::HostFeatures::OFF",
+        "Enums": {
+          "ENABLESVE": "enablesve",
+          "DISABLESVE": "disasblesve",
+          "ENABLEAVX": "enableavx",
+          "DISABLEAVX": "disasbleavx",
+          "ENABLEAFP": "enableafp",
+          "DISABLEAFP": "disableafp",
+          "ENABLELRCPC": "enablelrcpc",
+          "DISABLELRCPC": "disablelrcpc",
+          "ENABLELRCPC2": "enablelrcpc2",
+          "DISABLELRCPC2": "disablelrcpc2",
+          "ENABLECSSC": "enablecssc",
+          "DISABLECSSC": "disablecssc",
+          "ENABLEPMULL128": "enablepmull128",
+          "DISABLEPMULL128": "disablepmull128",
+          "ENABLERNG": "enablerng",
+          "DISABLERNG": "disablerng"
+        },
         "Desc": [
-          "Determines whether or not we use the expanded register file for AVX or not"
+          "Allows controlling of the CPU features in the JIT.",
+          "\toff: Default CPU features queried from CPU features",
+          "\t{enable,disable}sve: Will force enable or disable sve even if the host doesn't support it",
+          "\t{enable,disable}avx: Will force enable or disable avx even if the host doesn't support it",
+          "\t{enable,disable}afp: Will force enable or disable afp even if the host doesn't support it",
+          "\t{enable,disable}lrcpc: Will force enable or disable lrcpc even if the host doesn't support it",
+          "\t{enable,disable}lrcpc2: Will force enable or disable lrcpc2 even if the host doesn't support it",
+          "\t{enable,disable}cssc: Will force enable or disable cssc even if the host doesn't support it",
+          "\t{enable,disable}pmull128: Will force enable or disable pmull128 even if the host doesn't support it",
+          "\t{enable,disable}rng: Will force enable or disable rng even if the host doesn't support it"
         ]
       }
     },

--- a/External/FEXCore/include/FEXCore/Config/Config.h
+++ b/External/FEXCore/include/FEXCore/Config/Config.h
@@ -90,8 +90,8 @@ namespace Handler {
     LAYER_TOP,
   };
 
-  template<typename PairTypes>
-  static inline fextl::string EnumParser(PairTypes const &EnumPairs, std::string_view const View) {
+  template<typename PairTypes, typename ArrayPairType>
+  static inline fextl::string EnumParser(ArrayPairType const &EnumPairs, std::string_view const View) {
     uint64_t EnumMask{};
     auto Results = std::from_chars(View.data(), View.data() + View.size(), EnumMask);
     if (Results.ec == std::errc()) {
@@ -104,7 +104,7 @@ namespace Handler {
     std::string_view Option = View.substr(Begin, End);
     while (Option.size() != 0) {
       auto EnumValue = std::find_if(EnumPairs.begin(), EnumPairs.end(),
-        [Option](const DisassembleConfigPair &Value) -> bool {
+        [Option](const PairTypes &Value) -> bool {
           return Value.first == Option;
         });
 

--- a/External/FEXCore/include/FEXCore/Core/HostFeatures.h
+++ b/External/FEXCore/include/FEXCore/Core/HostFeatures.h
@@ -24,6 +24,7 @@ class HostFeatures final {
     bool Supports3DNow{};
     bool SupportsSSE4A{};
     bool SupportsAVX{};
+    bool SupportsSVE{};
     bool SupportsSHA{};
     bool SupportsBMI1{};
     bool SupportsBMI2{};

--- a/External/FEXCore/include/FEXCore/Utils/EnumOperators.h
+++ b/External/FEXCore/include/FEXCore/Utils/EnumOperators.h
@@ -7,6 +7,12 @@ static constexpr Enum operator Op(Enum lhs, Enum rhs) { \
     Type _lhs = static_cast<Type>(lhs); \
     Type _rhs = static_cast<Type>(rhs); \
     return static_cast<Enum>(_lhs Op _rhs); \
+} \
+[[maybe_unused]] \
+static constexpr uint64_t operator Op(uint64_t lhs, Enum rhs) { \
+    using Type = std::underlying_type_t<Enum>; \
+    Type _rhs = static_cast<Type>(rhs); \
+    return lhs Op _rhs; \
 }
 
 #define FEX_DEF_ENUM_CLASS_UNARY_OP(Enum, Op) \


### PR DESCRIPTION
This allows use to both enable and disable regardless of what the host supports. This replaces the old `EnableAVX` option.

Unlike the old EnableAVX option which was a binary option which could only disable, each of these options are technically trinary states. Not setting an option gives you the default detection, while explicitly enabling or disabling will toggle the option regardless of what the host supports.

This will be used by the instruction count CI in the future.