### PR TITLE
Arm64: Implement first SVE-128bit optimization 

### DIFF
--- a/External/FEXCore/Scripts/config_generator.py
+++ b/External/FEXCore/Scripts/config_generator.py
@@ -402,7 +402,7 @@ def print_parse_argloader_options(options):
 
             if (value_type == "strenum"):
                 output_argloader.write("\tfextl::string UserValue = Options[\"{0}\"];\n".format(op_key))
-                output_argloader.write("\tSet(FEXCore::Config::ConfigOption::CONFIG_{}, FEXCore::Config::EnumParser(FEXCore::Config::{}_EnumPairs, UserValue));\n".format(op_key.upper(), op_key, op_key))
+                output_argloader.write("\tSet(FEXCore::Config::ConfigOption::CONFIG_{}, FEXCore::Config::EnumParser<FEXCore::Config::{}ConfigPair>(FEXCore::Config::{}_EnumPairs, UserValue));\n".format(op_key.upper(), op_key, op_key, op_key))
             elif (value_type == "strarray"):
                 # these need a bit more help
                 output_argloader.write("\tauto Array = Options.all(\"{0}\");\n".format(op_key))
@@ -431,7 +431,7 @@ def print_parse_envloader_options(options):
             value_type = op_vals["Type"]
             if (value_type == "strenum"):
                 output_argloader.write("else if (Key == \"FEX_{0}\") {{\n".format(op_key.upper()))
-                output_argloader.write("Value = FEXCore::Config::EnumParser(FEXCore::Config::{}_EnumPairs, Value);\n".format(op_key, op_key))
+                output_argloader.write("Value = FEXCore::Config::EnumParser<FEXCore::Config::{}ConfigPair>(FEXCore::Config::{}_EnumPairs, Value);\n".format(op_key, op_key, op_key))
                 output_argloader.write("}\n")
 
             if ("ArgumentHandler" in op_vals):
@@ -447,7 +447,7 @@ def print_parse_enum_options(options):
     for op_group, group_vals in options.items():
         for op_key, op_vals in group_vals.items():
             if (op_vals["Type"] == "strenum"):
-                output_argloader.write("enum {} : uint64_t {{\n".format(op_key))
+                output_argloader.write("enum class {} : uint64_t {{\n".format(op_key))
                 Enums = op_vals["Enums"]
                 i = 0
                 # Always have an OFF.
@@ -457,6 +457,8 @@ def print_parse_enum_options(options):
                     i += 1
 
                 output_argloader.write("};\n")
+                output_argloader.write("FEX_DEF_NUM_OPS({})\n".format(op_key))
+
 
     for op_group, group_vals in options.items():
         for op_key, op_vals in group_vals.items():

--- a/External/FEXCore/Source/Interface/Config/Config.json.in
+++ b/External/FEXCore/Source/Interface/Config/Config.json.in
@@ -51,11 +51,38 @@
           "Allows JIT code to be shared between applications"
         ]
       },
-      "EnableAVX": {
-        "Type": "bool",
-        "Default": "false",
+      "HostFeatures": {
+        "Type": "strenum",
+        "Default": "FEXCore::Config::HostFeatures::OFF",
+        "Enums": {
+          "ENABLESVE": "enablesve",
+          "DISABLESVE": "disasblesve",
+          "ENABLEAVX": "enableavx",
+          "DISABLEAVX": "disasbleavx",
+          "ENABLEAFP": "enableafp",
+          "DISABLEAFP": "disableafp",
+          "ENABLELRCPC": "enablelrcpc",
+          "DISABLELRCPC": "disablelrcpc",
+          "ENABLELRCPC2": "enablelrcpc2",
+          "DISABLELRCPC2": "disablelrcpc2",
+          "ENABLECSSC": "enablecssc",
+          "DISABLECSSC": "disablecssc",
+          "ENABLEPMULL128": "enablepmull128",
+          "DISABLEPMULL128": "disablepmull128",
+          "ENABLERNG": "enablerng",
+          "DISABLERNG": "disablerng"
+        },
         "Desc": [
-          "Determines whether or not we use the expanded register file for AVX or not"
+          "Allows controlling of the CPU features in the JIT.",
+          "\toff: Default CPU features queried from CPU features",
+          "\t{enable,disable}sve: Will force enable or disable sve even if the host doesn't support it",
+          "\t{enable,disable}avx: Will force enable or disable avx even if the host doesn't support it",
+          "\t{enable,disable}afp: Will force enable or disable afp even if the host doesn't support it",
+          "\t{enable,disable}lrcpc: Will force enable or disable lrcpc even if the host doesn't support it",
+          "\t{enable,disable}lrcpc2: Will force enable or disable lrcpc2 even if the host doesn't support it",
+          "\t{enable,disable}cssc: Will force enable or disable cssc even if the host doesn't support it",
+          "\t{enable,disable}pmull128: Will force enable or disable pmull128 even if the host doesn't support it",
+          "\t{enable,disable}rng: Will force enable or disable rng even if the host doesn't support it"
         ]
       }
     },

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -1260,7 +1260,7 @@ DEF_OP(VExtractToGPR) {
     // when acting on larger register sizes.
     PerformMove(Vector, Op->Index);
   } else {
-    LOGMAN_THROW_AA_FMT(HostSupportsSVE,
+    LOGMAN_THROW_AA_FMT(HostSupportsSVE256,
                         "Host doesn't support SVE. Cannot perform 256-bit operation.");
     LOGMAN_THROW_AA_FMT(Is256Bit,
                         "Can't perform 256-bit extraction with op side: {}", OpSize);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/ConversionOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/ConversionOps.cpp
@@ -28,7 +28,7 @@ DEF_OP(VInsGPR) {
   const auto DestVector = GetVReg(Op->DestVector.ID());
   const auto Src = GetReg(Op->Src.ID());
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     const auto ElementSizeBits = ElementSize * 8;
     const auto Offset = ElementSizeBits * DestIdx;
 
@@ -127,7 +127,7 @@ DEF_OP(VDupFromGPR) {
     ElementSize == 2 ? ARMEmitter::SubRegSize::i16Bit :
     ElementSize == 1 ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     dup(SubEmitSize, Dst.Z(), Src);
   } else {
     dup(SubEmitSize, Dst.Q(), Src);
@@ -201,7 +201,7 @@ DEF_OP(Vector_SToF) {
 
   const auto Dst = GetVReg(Node);
   const auto Vector = GetVReg(Op->Vector.ID());
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     const auto Mask = PRED_TMP_32B;
     scvtf(Dst.Z(), SubEmitSize, Mask.Merging(), Vector.Z(), SubEmitSize);
   } else {
@@ -223,7 +223,7 @@ DEF_OP(Vector_FToZS) {
 
   const auto Dst = GetVReg(Node);
   const auto Vector = GetVReg(Op->Vector.ID());
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     const auto Mask = PRED_TMP_32B;
     fcvtzs(Dst.Z(), SubEmitSize, Mask.Merging(), Vector.Z(), SubEmitSize);
   } else {
@@ -246,7 +246,7 @@ DEF_OP(Vector_FToS) {
   const auto Dst = GetVReg(Node);
   const auto Vector = GetVReg(Op->Vector.ID());
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     const auto Mask = PRED_TMP_32B;
     frinti(SubEmitSize, Dst.Z(), Mask.Merging(), Vector.Z());
     fcvtzs(Dst.Z(), SubEmitSize, Mask.Merging(), Dst.Z(), SubEmitSize);
@@ -274,7 +274,7 @@ DEF_OP(Vector_FToF) {
   const auto Dst = GetVReg(Node);
   const auto Vector = GetVReg(Op->Vector.ID());
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     // Curiously, FCVTLT and FCVTNT have no bottom variants,
     // and also interesting is that FCVTLT will iterate the
     // source vector by accessing each odd element and storing
@@ -349,7 +349,7 @@ DEF_OP(Vector_FToI) {
   const auto Dst = GetVReg(Node);
   const auto Vector = GetVReg(Op->Vector.ID());
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     const auto Mask = PRED_TMP_32B.Merging();
 
     switch (Op->Round) {

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -577,7 +577,8 @@ void Arm64JITCore::Op_NoOp(IR::IROp_Header const *IROp, IR::NodeID Node) {
 Arm64JITCore::Arm64JITCore(FEXCore::Context::ContextImpl *ctx, FEXCore::Core::InternalThreadState *Thread)
   : CPUBackend(Thread, INITIAL_CODE_SIZE, MAX_CODE_SIZE)
   , Arm64Emitter(ctx, 0)
-  , HostSupportsSVE{ctx->HostFeatures.SupportsAVX}
+  , HostSupportsSVE128{ctx->HostFeatures.SupportsSVE}
+  , HostSupportsSVE256{ctx->HostFeatures.SupportsAVX}
   , CTX {ctx} {
 
   RAPass = Thread->PassManager->GetPass<IR::RegisterAllocationPass>("RA");

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -54,7 +54,9 @@ public:
 
 private:
   FEX_CONFIG_OPT(ParanoidTSO, PARANOIDTSO);
-  const bool HostSupportsSVE{};
+
+  const bool HostSupportsSVE128{};
+  const bool HostSupportsSVE256{};
 
   ARMEmitter::BiDirectionalLabel *PendingTargetLabel;
   FEXCore::Context::ContextImpl *CTX;

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -162,11 +162,11 @@ DEF_OP(LoadRegister) {
     }
   }
   else if (Op->Class == IR::FPRClass) {
-    const auto regSize = HostSupportsSVE ? Core::CPUState::XMM_AVX_REG_SIZE
-                                         : Core::CPUState::XMM_SSE_REG_SIZE;
+    const auto regSize = HostSupportsSVE256 ? Core::CPUState::XMM_AVX_REG_SIZE
+                                            : Core::CPUState::XMM_SSE_REG_SIZE;
     [[maybe_unused]] const auto regId = (Op->Offset - offsetof(Core::CpuStateFrame, State.xmm.avx.data[0][0])) / regSize;
 
-    LOGMAN_THROW_A_FMT(HostSupportsSVE, "Unsupported code path!");
+    LOGMAN_THROW_A_FMT(HostSupportsSVE256, "Unsupported code path!");
     LOGMAN_THROW_A_FMT(regId < StaticFPRegisters.size(), "out of range regId");
 
     const auto host = GetVReg(Node);
@@ -244,11 +244,11 @@ DEF_OP(StoreRegister) {
         break;
     }
   } else if (Op->Class == IR::FPRClass) {
-    const auto regSize = HostSupportsSVE ? Core::CPUState::XMM_AVX_REG_SIZE
-                                         : Core::CPUState::XMM_SSE_REG_SIZE;
+    const auto regSize = HostSupportsSVE256 ? Core::CPUState::XMM_AVX_REG_SIZE
+                                            : Core::CPUState::XMM_SSE_REG_SIZE;
     [[maybe_unused]] const auto regId = (Op->Offset - offsetof(Core::CpuStateFrame, State.xmm.avx.data[0][0])) / regSize;
 
-    LOGMAN_THROW_A_FMT(HostSupportsSVE, "Unsupported code path!");
+    LOGMAN_THROW_A_FMT(HostSupportsSVE256, "Unsupported code path!");
     LOGMAN_THROW_A_FMT(regId < StaticFPRegisters.size(), "regId out of range");
 
     const auto host = GetVReg(Op->Value.ID());
@@ -331,8 +331,8 @@ DEF_OP(LoadRegisterSRA) {
     }
   }
   else if (Op->Class == IR::FPRClass) {
-    const auto regSize = HostSupportsSVE ? Core::CPUState::XMM_AVX_REG_SIZE
-                                         : Core::CPUState::XMM_SSE_REG_SIZE;
+    const auto regSize = HostSupportsSVE256 ? Core::CPUState::XMM_AVX_REG_SIZE
+                                            : Core::CPUState::XMM_SSE_REG_SIZE;
     const auto regId = (Op->Offset - offsetof(Core::CpuStateFrame, State.xmm.avx.data[0][0])) / regSize;
 
     LOGMAN_THROW_A_FMT(regId < StaticFPRegisters.size(), "out of range regId");
@@ -340,7 +340,7 @@ DEF_OP(LoadRegisterSRA) {
     const auto guest = StaticFPRegisters[regId];
     const auto host = GetVReg(Node);
 
-    if (HostSupportsSVE) {
+    if (HostSupportsSVE256) {
       const auto regOffs = Op->Offset & 31;
 
       ARMEmitter::ForwardLabel DataLocation;
@@ -517,8 +517,8 @@ DEF_OP(StoreRegisterSRA) {
         break;
     }
   } else if (Op->Class == IR::FPRClass) {
-    const auto regSize = HostSupportsSVE ? Core::CPUState::XMM_AVX_REG_SIZE
-                                         : Core::CPUState::XMM_SSE_REG_SIZE;
+    const auto regSize = HostSupportsSVE256 ? Core::CPUState::XMM_AVX_REG_SIZE
+                                            : Core::CPUState::XMM_SSE_REG_SIZE;
     const auto regId = (Op->Offset - offsetof(Core::CpuStateFrame, State.xmm.avx.data[0][0])) / regSize;
 
     LOGMAN_THROW_A_FMT(regId < StaticFPRegisters.size(), "regId out of range");
@@ -526,7 +526,7 @@ DEF_OP(StoreRegisterSRA) {
     const auto guest = StaticFPRegisters[regId];
     const auto host = GetVReg(Op->Value.ID());
 
-    if (HostSupportsSVE) {
+    if (HostSupportsSVE256) {
       // 256-bit capable hardware allows us to expand the allowed
       // offsets used, however we cannot use Adv. SIMD's INS instruction
       // at all, since it will zero out the upper lanes of the 256-bit SVE
@@ -1341,7 +1341,7 @@ DEF_OP(LoadMemTSO) {
 }
 
 DEF_OP(VLoadVectorMasked) {
-  LOGMAN_THROW_A_FMT(HostSupportsSVE, "Need SVE support in order to use VLoadVectorMasked");
+  LOGMAN_THROW_A_FMT(HostSupportsSVE256, "Need SVE support in order to use VLoadVectorMasked");
 
   const auto Op = IROp->C<IR::IROp_VLoadVectorMasked>();
   const auto OpSize = IROp->Size;
@@ -1391,7 +1391,7 @@ DEF_OP(VLoadVectorMasked) {
 }
 
 DEF_OP(VStoreVectorMasked) {
-  LOGMAN_THROW_A_FMT(HostSupportsSVE, "Need SVE support in order to use VStoreVectorMasked");
+  LOGMAN_THROW_A_FMT(HostSupportsSVE256, "Need SVE support in order to use VStoreVectorMasked");
 
   const auto Op = IROp->C<IR::IROp_VStoreVectorMasked>();
   const auto OpSize = IROp->Size;

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -2662,7 +2662,8 @@ DEF_OP(VSXTL) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE256 && Is256Bit) {
+  if ((HostSupportsSVE128 && !Is256Bit && !HostSupportsSVE256) ||
+      (HostSupportsSVE256 && Is256Bit)) {
     sunpklo(SubRegSize, Dst.Z(), Vector.Z());
   } else {
     sxtl(SubRegSize, Dst.D(), Vector.D());
@@ -2685,7 +2686,8 @@ DEF_OP(VSXTL2) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE256 && Is256Bit) {
+  if ((HostSupportsSVE128 && !Is256Bit && !HostSupportsSVE256) ||
+      (HostSupportsSVE256 && Is256Bit)) {
     sunpkhi(SubRegSize, Dst.Z(), Vector.Z());
   } else {
     sxtl2(SubRegSize, Dst.Q(), Vector.Q());
@@ -2708,7 +2710,8 @@ DEF_OP(VUXTL) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE256 && Is256Bit) {
+  if ((HostSupportsSVE128 && !Is256Bit && !HostSupportsSVE256) ||
+      (HostSupportsSVE256 && Is256Bit)) {
     uunpklo(SubRegSize, Dst.Z(), Vector.Z());
   } else {
     uxtl(SubRegSize, Dst.D(), Vector.D());
@@ -2717,7 +2720,6 @@ DEF_OP(VUXTL) {
 
 DEF_OP(VUXTL2) {
   const auto Op = IROp->C<IR::IROp_VUXTL2>();
-
   const auto OpSize = IROp->Size;
 
   const auto ElementSize = Op->Header.ElementSize;
@@ -2732,7 +2734,8 @@ DEF_OP(VUXTL2) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE256 && Is256Bit) {
+  if ((HostSupportsSVE128 && !Is256Bit && !HostSupportsSVE256) ||
+      (HostSupportsSVE256 && Is256Bit)) {
     uunpkhi(SubRegSize, Dst.Z(), Vector.Z());
   } else {
     uxtl2(SubRegSize, Dst.Q(), Vector.Q());

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -18,7 +18,7 @@ DEF_OP(VectorZero) {
 
   const auto Dst = GetVReg(Node);
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     mov_imm(ARMEmitter::SubRegSize::i64Bit, Dst.Z(), 0);
   } else {
     switch (OpSize) {
@@ -53,7 +53,7 @@ DEF_OP(VectorImm) {
 
   const auto Dst = GetVReg(Node);
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     if (ElementSize > 1 && (Op->Immediate & 0x80)) {
       // SVE dup uses sign extension where VectorImm wants zext
       LoadConstant(ARMEmitter::Size::i64Bit, TMP1, Op->Immediate);
@@ -105,7 +105,7 @@ DEF_OP(VMov) {
       break;
     }
     case 16: {
-      if (HostSupportsSVE || Dst.Idx() != Source.Idx()) {
+      if (HostSupportsSVE256 || Dst.Idx() != Source.Idx()) {
         mov(Dst.Q(), Source.Q());
       }
       break;
@@ -135,7 +135,7 @@ DEF_OP(VAnd) {
   const auto Vector1 = GetVReg(Op->Vector1.ID());
   const auto Vector2 = GetVReg(Op->Vector2.ID());
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     and_(Dst.Z(), Vector1.Z(), Vector2.Z());
   } else {
     and_(Dst.Q(), Vector1.Q(), Vector2.Q());
@@ -151,7 +151,7 @@ DEF_OP(VBic) {
   const auto Vector1 = GetVReg(Op->Vector1.ID());
   const auto Vector2 = GetVReg(Op->Vector2.ID());
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     bic(Dst.Z(), Vector1.Z(), Vector2.Z());
   } else {
     bic(Dst.Q(), Vector1.Q(), Vector2.Q());
@@ -167,7 +167,7 @@ DEF_OP(VOr) {
   const auto Vector1 = GetVReg(Op->Vector1.ID());
   const auto Vector2 = GetVReg(Op->Vector2.ID());
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     orr(Dst.Z(), Vector1.Z(), Vector2.Z());
   } else {
     orr(Dst.Q(), Vector1.Q(), Vector2.Q());
@@ -183,7 +183,7 @@ DEF_OP(VXor) {
   const auto Vector1 = GetVReg(Op->Vector1.ID());
   const auto Vector2 = GetVReg(Op->Vector2.ID());
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     eor(Dst.Z(), Vector1.Z(), Vector2.Z());
   } else {
     eor(Dst.Q(), Vector1.Q(), Vector2.Q());
@@ -208,7 +208,7 @@ DEF_OP(VAdd) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     add(SubRegSize, Dst.Z(), Vector1.Z(), Vector2.Z());
   } else {
     add(SubRegSize, Dst.Q(), Vector1.Q(), Vector2.Q());
@@ -233,7 +233,7 @@ DEF_OP(VSub) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     sub(SubRegSize, Dst.Z(), Vector1.Z(), Vector2.Z());
   } else {
     sub(SubRegSize, Dst.Q(), Vector1.Q(), Vector2.Q());
@@ -258,7 +258,7 @@ DEF_OP(VUQAdd) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     uqadd(SubRegSize, Dst.Z(), Vector1.Z(), Vector2.Z());
   } else {
     uqadd(SubRegSize, Dst.Q(), Vector1.Q(), Vector2.Q());
@@ -283,7 +283,7 @@ DEF_OP(VUQSub) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     uqsub(SubRegSize, Dst.Z(), Vector1.Z(), Vector2.Z());
   } else {
     uqsub(SubRegSize, Dst.Q(), Vector1.Q(), Vector2.Q());
@@ -308,7 +308,7 @@ DEF_OP(VSQAdd) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     sqadd(SubRegSize, Dst.Z(), Vector1.Z(), Vector2.Z());
   } else {
     sqadd(SubRegSize, Dst.Q(), Vector1.Q(), Vector2.Q());
@@ -333,7 +333,7 @@ DEF_OP(VSQSub) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     sqsub(SubRegSize, Dst.Z(), Vector1.Z(), Vector2.Z());
   } else {
     sqsub(SubRegSize, Dst.Q(), Vector1.Q(), Vector2.Q());
@@ -359,7 +359,7 @@ DEF_OP(VAddP) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     const auto Pred = PRED_TMP_32B.Merging();
 
     // SVE ADDP is a destructive operation, so we need a temporary
@@ -401,7 +401,7 @@ DEF_OP(VAddV) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit);
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     // SVE doesn't have an equivalent ADDV instruction, so we make do
     // by performing two Adv. SIMD ADDV operations on the high and low
     // 128-bit lanes and then sum them up.
@@ -443,7 +443,7 @@ DEF_OP(VUMinV) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     const auto Pred = PRED_TMP_32B;
     uminv(SubRegSize, Dst, Pred, Vector.Z());
   } else {
@@ -470,7 +470,7 @@ DEF_OP(VURAvg) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     const auto Mask = PRED_TMP_32B.Merging();
 
     // SVE URHADD is a destructive operation, so we need
@@ -500,7 +500,7 @@ DEF_OP(VAbs) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     abs(SubRegSize, Dst.Z(), PRED_TMP_32B.Merging(), Src.Z());
   } else {
     if (ElementSize == OpSize) {
@@ -532,7 +532,7 @@ DEF_OP(VPopcount) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     const auto Pred = PRED_TMP_32B.Merging();
     cnt(SubRegSize, Dst.Z(), Pred, Src.Z());
   } else {
@@ -562,7 +562,7 @@ DEF_OP(VFAdd) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     fadd(SubRegSize, Dst.Z(), Vector1.Z(), Vector2.Z());
   } else {
     if (IsScalar) {
@@ -606,7 +606,7 @@ DEF_OP(VFAddP) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     const auto Pred = PRED_TMP_32B.Merging();
 
     // SVE FADDP is a destructive operation, so we need a temporary
@@ -645,7 +645,7 @@ DEF_OP(VFSub) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     fsub(SubRegSize, Dst.Z(), Vector1.Z(), Vector2.Z());
   } else {
     if (IsScalar) {
@@ -690,7 +690,7 @@ DEF_OP(VFMul) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     fmul(SubRegSize, Dst.Z(), Vector1.Z(), Vector2.Z());
   } else {
     if (IsScalar) {
@@ -735,7 +735,7 @@ DEF_OP(VFDiv) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     const auto Mask = PRED_TMP_32B.Merging();
 
     // SVE VDIV is a destructive operation, so we need a temporary.
@@ -793,7 +793,7 @@ DEF_OP(VFMin) {
   //
   // * - Not exactly (differs slightly with SNaNs), but close enough for the explanation
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     const auto Mask = PRED_TMP_32B;
     const auto ComparePred = ARMEmitter::PReg::p0;
 
@@ -863,7 +863,7 @@ DEF_OP(VFMax) {
   // NOTE: See VFMin implementation for reasons why we
   //       don't just use FMAX/FMIN for these implementations.
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     const auto Mask = PRED_TMP_32B;
     const auto ComparePred = ARMEmitter::PReg::p0;
 
@@ -920,7 +920,7 @@ DEF_OP(VFRecp) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i128Bit);
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     const auto Pred = PRED_TMP_32B.Merging();
 
     fmov(SubRegSize.Vector, VTMP1.Z(), 1.0);
@@ -970,7 +970,7 @@ DEF_OP(VFSqrt) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     const auto Pred = PRED_TMP_32B.Merging();
 
     fsqrt(SubRegSize, Dst.Z(), Pred, Vector.Z());
@@ -1016,7 +1016,7 @@ DEF_OP(VFRSqrt) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i128Bit);
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     const auto Pred = PRED_TMP_32B.Merging();
     fmov(SubRegSize.Vector, VTMP1.Z(), 1.0);
     fsqrt(SubRegSize.Vector, VTMP2.Z(), Pred, Vector.Z());
@@ -1070,7 +1070,7 @@ DEF_OP(VNeg) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     const auto Pred = PRED_TMP_32B.Merging();
     neg(SubRegSize, Dst.Z(), Pred, Vector.Z());
   } else {
@@ -1094,7 +1094,7 @@ DEF_OP(VFNeg) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     const auto Pred = PRED_TMP_32B.Merging();
 
     fneg(SubRegSize, Dst.Z(), Pred, Vector.Z());
@@ -1111,7 +1111,7 @@ DEF_OP(VNot) {
   const auto Dst = GetVReg(Node);
   const auto Vector = GetVReg(Op->Vector.ID());
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     not_(ARMEmitter::SubRegSize::i8Bit, Dst.Z(), PRED_TMP_32B.Merging(), Vector.Z());
   } else {
     mvn(ARMEmitter::SubRegSize::i8Bit, Dst.Q(), Vector.Q());
@@ -1136,7 +1136,7 @@ DEF_OP(VUMin) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i128Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     const auto Pred = PRED_TMP_32B.Merging();
 
     // SVE UMIN is a destructive operation so we need a temporary.
@@ -1183,7 +1183,7 @@ DEF_OP(VSMin) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i128Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     const auto Pred = PRED_TMP_32B.Merging();
 
     // SVE SMIN is a destructive operation, so we need a temporary.
@@ -1230,7 +1230,7 @@ DEF_OP(VUMax) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i128Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     const auto Pred = PRED_TMP_32B.Merging();
 
     // SVE UMAX is a destructive operation, so we need a temporary.
@@ -1277,7 +1277,7 @@ DEF_OP(VSMax) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i128Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     const auto Pred = PRED_TMP_32B.Merging();
 
     // SVE SMAX is a destructive operation, so we need a temporary.
@@ -1324,7 +1324,7 @@ DEF_OP(VZip) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     zip1(SubRegSize, Dst.Z(), VectorLower.Z(), VectorUpper.Z());
   } else {
     if (OpSize == 8) {
@@ -1353,7 +1353,7 @@ DEF_OP(VZip2) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     zip2(SubRegSize, Dst.Z(), VectorLower.Z(), VectorUpper.Z());
   } else {
     if (OpSize == 8) {
@@ -1382,7 +1382,7 @@ DEF_OP(VUnZip) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     uzp1(SubRegSize, Dst.Z(), VectorLower.Z(), VectorUpper.Z());
   } else {
     if (OpSize == 8) {
@@ -1411,7 +1411,7 @@ DEF_OP(VUnZip2) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     uzp2(SubRegSize, Dst.Z(), VectorLower.Z(), VectorUpper.Z());
   } else {
     if (OpSize == 8) {
@@ -1440,7 +1440,7 @@ DEF_OP(VTrn) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     trn1(SubRegSize, Dst.Z(), VectorLower.Z(), VectorUpper.Z());
   } else {
     if (OpSize == 8) {
@@ -1469,7 +1469,7 @@ DEF_OP(VTrn2) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     trn2(SubRegSize, Dst.Z(), VectorLower.Z(), VectorUpper.Z());
   } else {
     if (OpSize == 8) {
@@ -1490,7 +1490,7 @@ DEF_OP(VBSL) {
   const auto VectorTrue = GetVReg(Op->VectorTrue.ID());
   const auto VectorMask = GetVReg(Op->VectorMask.ID());
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     // NOTE: Slight parameter difference from ASIMD
     //       ASIMD -> BSL Mask, True, False
     //       SVE   -> BSL True, True, False, Mask
@@ -1529,7 +1529,7 @@ DEF_OP(VCMPEQ) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i128Bit);
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     const auto Mask = PRED_TMP_32B.Zeroing();
     const auto ComparePred = ARMEmitter::PReg::p0;
 
@@ -1567,7 +1567,7 @@ DEF_OP(VCMPEQZ) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i128Bit);
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     const auto Mask = PRED_TMP_32B.Zeroing();
     const auto ComparePred = ARMEmitter::PReg::p0;
 
@@ -1609,7 +1609,7 @@ DEF_OP(VCMPGT) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i128Bit);
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     const auto Mask = PRED_TMP_32B.Zeroing();
     const auto ComparePred = ARMEmitter::PReg::p0;
 
@@ -1647,7 +1647,7 @@ DEF_OP(VCMPGTZ) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i128Bit);
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     const auto Mask = PRED_TMP_32B.Zeroing();
     const auto ComparePred = ARMEmitter::PReg::p0;
 
@@ -1685,7 +1685,7 @@ DEF_OP(VCMPLTZ) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i128Bit);
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     const auto Mask = PRED_TMP_32B.Zeroing();
     const auto ComparePred = ARMEmitter::PReg::p0;
 
@@ -1723,7 +1723,7 @@ DEF_OP(VFCMPEQ) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit);
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     const auto Mask = PRED_TMP_32B.Zeroing();
     const auto ComparePred = ARMEmitter::PReg::p0;
 
@@ -1770,7 +1770,7 @@ DEF_OP(VFCMPNEQ) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit);
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     const auto Mask = PRED_TMP_32B.Zeroing();
     const auto ComparePred = ARMEmitter::PReg::p0;
 
@@ -1819,7 +1819,7 @@ DEF_OP(VFCMPLT) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit);
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     const auto Mask = PRED_TMP_32B.Zeroing();
     const auto ComparePred = ARMEmitter::PReg::p0;
 
@@ -1866,7 +1866,7 @@ DEF_OP(VFCMPGT) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit);
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     const auto Mask = PRED_TMP_32B.Zeroing();
     const auto ComparePred = ARMEmitter::PReg::p0;
 
@@ -1913,7 +1913,7 @@ DEF_OP(VFCMPLE) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit);
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     const auto Mask = PRED_TMP_32B.Zeroing();
     const auto ComparePred = ARMEmitter::PReg::p0;
 
@@ -1961,7 +1961,7 @@ DEF_OP(VFCMPORD) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit);
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     const auto Mask = PRED_TMP_32B.Zeroing();
     const auto ComparePred = ARMEmitter::PReg::p0;
 
@@ -2019,7 +2019,7 @@ DEF_OP(VFCMPUNO) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit);
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     const auto Mask = PRED_TMP_32B.Zeroing();
     const auto ComparePred = ARMEmitter::PReg::p0;
 
@@ -2076,7 +2076,7 @@ DEF_OP(VUShl) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     const auto Mask = PRED_TMP_32B.Merging();
 
     dup_imm(SubRegSize, VTMP2.Z(), MaxShift);
@@ -2120,7 +2120,7 @@ DEF_OP(VUShr) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     const auto Mask = PRED_TMP_32B.Merging();
 
     dup_imm(SubRegSize, VTMP2.Z(), MaxShift);
@@ -2167,7 +2167,7 @@ DEF_OP(VSShr) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     const auto Mask = PRED_TMP_32B.Merging();
 
     dup_imm(SubRegSize, VTMP1.Z(), MaxShift);
@@ -2213,7 +2213,7 @@ DEF_OP(VUShlS) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i128Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     const auto Mask = PRED_TMP_32B.Merging();
 
     // NOTE: SVE LSL is a destructive operation.
@@ -2244,7 +2244,7 @@ DEF_OP(VUShrS) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i128Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     const auto Mask = PRED_TMP_32B.Merging();
 
     // NOTE: SVE LSR is a destructive operation.
@@ -2276,7 +2276,7 @@ DEF_OP(VSShrS) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i128Bit;
 
-   if (HostSupportsSVE && Is256Bit) {
+   if (HostSupportsSVE256 && Is256Bit) {
     const auto Mask = PRED_TMP_32B.Merging();
 
     // NOTE: SVE ASR is a destructive operation.
@@ -2304,7 +2304,7 @@ DEF_OP(VInsElement) {
   const auto SrcVector = GetVReg(Op->SrcVector.ID());
   auto Reg = GetVReg(Op->DestVector.ID());
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     LOGMAN_THROW_AA_FMT(ElementSize == 1 || ElementSize == 2 || ElementSize == 4 || ElementSize == 8 || ElementSize == 16, "Invalid size");
     const auto SubRegSize =
       ElementSize == 1 ? ARMEmitter::SubRegSize::i8Bit :
@@ -2405,7 +2405,7 @@ DEF_OP(VDupElement) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i128Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     dup(SubRegSize, Dst.Z(), Vector.Z(), Index);
   } else {
     dup(SubRegSize, Dst.Q(), Vector.Q(), Index);
@@ -2437,7 +2437,7 @@ DEF_OP(VExtr) {
 
   const auto CopyFromByte = Index * ElementSize;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     movprfx(VTMP2.Z(), LowerBits.Z());
     ext<FEXCore::ARMEmitter::OpType::Destructive>(VTMP2.Z(), VTMP2.Z(), UpperBits.Z(), CopyFromByte);
     mov(Dst.Z(), VTMP2.Z());
@@ -2471,7 +2471,7 @@ DEF_OP(VUShrI) {
   if (BitShift >= (ElementSize * 8)) {
     movi(ARMEmitter::SubRegSize::i64Bit, Dst.Q(), 0);
   } else {
-    if (HostSupportsSVE && Is256Bit) {
+    if (HostSupportsSVE256 && Is256Bit) {
       const auto Mask = PRED_TMP_32B.Merging();
 
       if (BitShift == 0) {
@@ -2515,7 +2515,7 @@ DEF_OP(VSShrI) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     const auto Mask = PRED_TMP_32B.Merging();
 
     if (Shift == 0) {
@@ -2562,7 +2562,7 @@ DEF_OP(VShlI) {
   if (BitShift >= (ElementSize * 8)) {
     movi(ARMEmitter::SubRegSize::i64Bit, Dst.Q(), 0);
   } else {
-    if (HostSupportsSVE && Is256Bit) {
+    if (HostSupportsSVE256 && Is256Bit) {
       const auto Mask = PRED_TMP_32B.Merging();
 
       if (BitShift == 0) {
@@ -2605,7 +2605,7 @@ DEF_OP(VUShrNI) {
     ElementSize == 2 ? ARMEmitter::SubRegSize::i16Bit :
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     shrnb(SubRegSize, Dst.Z(), Vector.Z(), BitShift);
     uzp1(SubRegSize, Dst.Z(), Dst.Z(), Dst.Z());
   } else {
@@ -2631,7 +2631,7 @@ DEF_OP(VUShrNI2) {
     ElementSize == 2 ? ARMEmitter::SubRegSize::i16Bit :
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     const auto Mask = PRED_TMP_16B;
 
     shrnb(SubRegSize, VTMP2.Z(), VectorUpper.Z(), BitShift);
@@ -2662,7 +2662,7 @@ DEF_OP(VSXTL) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     sunpklo(SubRegSize, Dst.Z(), Vector.Z());
   } else {
     sxtl(SubRegSize, Dst.D(), Vector.D());
@@ -2685,7 +2685,7 @@ DEF_OP(VSXTL2) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     sunpkhi(SubRegSize, Dst.Z(), Vector.Z());
   } else {
     sxtl2(SubRegSize, Dst.Q(), Vector.Q());
@@ -2708,7 +2708,7 @@ DEF_OP(VUXTL) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     uunpklo(SubRegSize, Dst.Z(), Vector.Z());
   } else {
     uxtl(SubRegSize, Dst.D(), Vector.D());
@@ -2732,7 +2732,7 @@ DEF_OP(VUXTL2) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     uunpkhi(SubRegSize, Dst.Z(), Vector.Z());
   } else {
     uxtl2(SubRegSize, Dst.Q(), Vector.Q());
@@ -2755,7 +2755,7 @@ DEF_OP(VSQXTN) {
     ElementSize == 2 ? ARMEmitter::SubRegSize::i16Bit :
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     // Note that SVE SQXTNB and SQXTNT are a tad different
     // in behavior compared to most other [name]B and [name]T
     // instructions.
@@ -2813,7 +2813,7 @@ DEF_OP(VSQXTN2) {
     ElementSize == 2 ? ARMEmitter::SubRegSize::i16Bit :
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     // We use the 16 byte mask due to how SPLICE works. We only
     // want to get at the first 16 bytes in the lower vector, so
     // that SPLICE will then begin copying the first 16 bytes
@@ -2859,7 +2859,7 @@ DEF_OP(VSQXTUN) {
     ElementSize == 2 ? ARMEmitter::SubRegSize::i16Bit :
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     sqxtunb(SubRegSize, Dst.Z(), Vector.Z());
     uzp1(SubRegSize, Dst.Z(), Dst.Z(), Dst.Z());
   } else {
@@ -2884,7 +2884,7 @@ DEF_OP(VSQXTUN2) {
     ElementSize == 2 ? ARMEmitter::SubRegSize::i16Bit :
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     // NOTE: See VSQXTN2 implementation for an in-depth explanation
     //       of everything going on here.
 
@@ -2926,7 +2926,7 @@ DEF_OP(VMul) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     mul(SubRegSize, Dst.Z(), Vector1.Z(), Vector2.Z());
   } else {
     mul(SubRegSize, Dst.Q(), Vector1.Q(), Vector2.Q());
@@ -2950,7 +2950,7 @@ DEF_OP(VUMull) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     umullb(SubRegSize, VTMP1.Z(), Vector1.Z(), Vector2.Z());
     umullt(SubRegSize, VTMP2.Z(), Vector1.Z(), Vector2.Z());
     zip1(SubRegSize, Dst.Z(), VTMP1.Z(), VTMP2.Z());
@@ -2976,7 +2976,7 @@ DEF_OP(VSMull) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     smullb(SubRegSize, VTMP1.Z(), Vector1.Z(), Vector2.Z());
     smullt(SubRegSize, VTMP2.Z(), Vector1.Z(), Vector2.Z());
     zip1(SubRegSize, Dst.Z(), VTMP1.Z(), VTMP2.Z());
@@ -3002,7 +3002,7 @@ DEF_OP(VUMull2) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     umullb(SubRegSize, VTMP1.Z(), Vector1.Z(), Vector2.Z());
     umullt(SubRegSize, VTMP2.Z(), Vector1.Z(), Vector2.Z());
     zip2(SubRegSize, Dst.Z(), VTMP1.Z(), VTMP2.Z());
@@ -3028,7 +3028,7 @@ DEF_OP(VSMull2) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     smullb(SubRegSize, VTMP1.Z(), Vector1.Z(), Vector2.Z());
     smullt(SubRegSize, VTMP2.Z(), Vector1.Z(), Vector2.Z());
     zip2(SubRegSize, Dst.Z(), VTMP1.Z(), VTMP2.Z());
@@ -3054,7 +3054,7 @@ DEF_OP(VUABDL) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     // To mimic the behavior of AdvSIMD UABDL, we need to get the
     // absolute difference of the even elements (UADBLB), get the
     // absolute difference of the odd elemenets (UABDLT), then
@@ -3085,7 +3085,7 @@ DEF_OP(VUABDL2) {
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit :
     ElementSize == 8 ? ARMEmitter::SubRegSize::i64Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     // To mimic the behavior of AdvSIMD UABDL, we need to get the
     // absolute difference of the even elements (UADBLB), get the
     // absolute difference of the odd elemenets (UABDLT), then
@@ -3117,7 +3117,7 @@ DEF_OP(VTBL1) {
       break;
     }
     case 32: {
-      LOGMAN_THROW_AA_FMT(HostSupportsSVE,
+      LOGMAN_THROW_AA_FMT(HostSupportsSVE256,
                           "Host does not support SVE. Cannot perform 256-bit table lookup");
 
       tbl(ARMEmitter::SubRegSize::i8Bit, Dst.Z(), VectorTable.Z(), VectorIndices.Z());
@@ -3145,7 +3145,7 @@ DEF_OP(VRev64) {
     ElementSize == 2 ? ARMEmitter::SubRegSize::i16Bit :
     ElementSize == 4 ? ARMEmitter::SubRegSize::i32Bit : ARMEmitter::SubRegSize::i8Bit;
 
-  if (HostSupportsSVE && Is256Bit) {
+  if (HostSupportsSVE256 && Is256Bit) {
     const auto Mask = PRED_TMP_32B.Merging();
 
     switch (ElementSize) {

--- a/External/FEXCore/include/FEXCore/Config/Config.h
+++ b/External/FEXCore/include/FEXCore/Config/Config.h
@@ -90,8 +90,8 @@ namespace Handler {
     LAYER_TOP,
   };
 
-  template<typename PairTypes>
-  static inline fextl::string EnumParser(PairTypes const &EnumPairs, std::string_view const View) {
+  template<typename PairTypes, typename ArrayPairType>
+  static inline fextl::string EnumParser(ArrayPairType const &EnumPairs, std::string_view const View) {
     uint64_t EnumMask{};
     auto Results = std::from_chars(View.data(), View.data() + View.size(), EnumMask);
     if (Results.ec == std::errc()) {
@@ -104,7 +104,7 @@ namespace Handler {
     std::string_view Option = View.substr(Begin, End);
     while (Option.size() != 0) {
       auto EnumValue = std::find_if(EnumPairs.begin(), EnumPairs.end(),
-        [Option](const DisassembleConfigPair &Value) -> bool {
+        [Option](const PairTypes &Value) -> bool {
           return Value.first == Option;
         });
 

--- a/External/FEXCore/include/FEXCore/Core/HostFeatures.h
+++ b/External/FEXCore/include/FEXCore/Core/HostFeatures.h
@@ -24,6 +24,7 @@ class HostFeatures final {
     bool Supports3DNow{};
     bool SupportsSSE4A{};
     bool SupportsAVX{};
+    bool SupportsSVE{};
     bool SupportsSHA{};
     bool SupportsBMI1{};
     bool SupportsBMI2{};

--- a/External/FEXCore/include/FEXCore/Utils/EnumOperators.h
+++ b/External/FEXCore/include/FEXCore/Utils/EnumOperators.h
@@ -7,6 +7,12 @@ static constexpr Enum operator Op(Enum lhs, Enum rhs) { \
     Type _lhs = static_cast<Type>(lhs); \
     Type _rhs = static_cast<Type>(rhs); \
     return static_cast<Enum>(_lhs Op _rhs); \
+} \
+[[maybe_unused]] \
+static constexpr uint64_t operator Op(uint64_t lhs, Enum rhs) { \
+    using Type = std::underlying_type_t<Enum>; \
+    Type _rhs = static_cast<Type>(rhs); \
+    return lhs Op _rhs; \
 }
 
 #define FEX_DEF_ENUM_CLASS_UNARY_OP(Enum, Op) \


### PR DESCRIPTION
This is a /very/ simple optimization purely because of a choice that ARM
made with SVE in latest Cortex.

Cortex-A715:
   - sxtl/sxtl2/uxtl/uxtl2 can execute 1 instruction per cycle.
   - sunpklo/sunpkhi/uunpklo/uunpkhi can execute 2 instructions per cycle.

Cortex-X3:
   - sxtl/sxtl2/uxtl/uxtl2 can execute 2 instruction per cycle.
   - sunpklo/sunpkhi/uunpklo/uunpkhi can execute 4 instructions per cycle.

This is fairly quirky since this optimization only works on SVE systems
with 128-bit Vector length. Which since it is all of the current
consumer platforms, it will work.

Requires #2864 to be merged first.