### PR TITLE
Arm64: Remove erroneous LoadConstant

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -763,10 +763,6 @@ CPUBackend::CompiledCode Arm64JITCore::CompileCode(uint64_t Entry,
   const auto DisasmBegin = GetCursorAddress<const vixl::aarch64::Instruction*>();
 #endif
 
-#ifndef NDEBUG
-  LoadConstant(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r0, Entry);
-#endif
-
   // AAPCS64
   // r30      = LR
   // r29      = FP


### PR DESCRIPTION
This was a debug LoadConstant that would load the entry in to a temprary register to make it easier to see what RIP a block was in.

This was implemented when FEX stopped storing the RIP in the CPU state for every block. This is now no longer necessary since FEX stores the in the tail data of the block.

This was affecting instructioncountci when in a debug build.