### PR TITLE
IR: Adds Option to run the IRDumper with more configurations

### DIFF
--- a/External/FEXCore/Source/CMakeLists.txt
+++ b/External/FEXCore/Source/CMakeLists.txt
@@ -133,6 +133,7 @@ set (SRCS
   Interface/IR/Passes/DeadCodeElimination.cpp
   Interface/IR/Passes/DeadContextStoreElimination.cpp
   Interface/IR/Passes/IRCompaction.cpp
+  Interface/IR/Passes/IRDumperPass.cpp
   Interface/IR/Passes/IRValidation.cpp
   Interface/IR/Passes/RAValidation.cpp
   Interface/IR/Passes/LongDivideRemovalPass.cpp

--- a/External/FEXCore/Source/Interface/Config/Config.json.in
+++ b/External/FEXCore/Source/Interface/Config/Config.json.in
@@ -198,6 +198,24 @@
           "[no, stdout, stderr, <Folder>]"
         ]
       },
+      "PassManagerDumpIR": {
+        "Type": "strenum",
+        "Default": "FEXCore::Config::PassManagerDumpIR::OFF",
+        "Enums": {
+          "BEFOREOPT": "beforeopt",
+          "AFTEROPT": "afteropt",
+          "BEFORE": "beforepass",
+          "AFTER": "afterpass"
+        },
+        "Desc": [
+          "Allows controlling when FEX dumps its IR.",
+          "\toff: IR dumping will be disabled",
+          "\tbeforeopt: Dump IR before any optimizations",
+          "\tafteropt: Dump IR after all optimizations",
+          "\tbeforepass: Dump IR before every optimization pass",
+          "\tafterpass: Dump IR after every optimization pass"
+        ]
+      },
       "DumpGPRs": {
         "Type": "bool",
         "Default": "false",

--- a/External/FEXCore/Source/Interface/Context/Context.h
+++ b/External/FEXCore/Source/Interface/Context/Context.h
@@ -230,7 +230,6 @@ namespace FEXCore::Context {
       FEX_CONFIG_OPT(ThunkHostLibsPath, THUNKHOSTLIBS);
       FEX_CONFIG_OPT(ThunkHostLibsPath32, THUNKHOSTLIBS32);
       FEX_CONFIG_OPT(ThunkConfigFile, THUNKCONFIG);
-      FEX_CONFIG_OPT(DumpIR, DUMPIR);
       FEX_CONFIG_OPT(StaticRegisterAllocation, SRA);
       FEX_CONFIG_OPT(GlobalJITNaming, GLOBALJITNAMING);
       FEX_CONFIG_OPT(LibraryJITNaming, LIBRARYJITNAMING);

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -4734,7 +4734,7 @@ void OpDispatchBuilder::CreateJumpBlocks(fextl::vector<FEXCore::Frontend::Decode
 
 void OpDispatchBuilder::BeginFunction(uint64_t RIP, fextl::vector<FEXCore::Frontend::Decoder::DecodedBlocks> const *Blocks) {
   Entry = RIP;
-  auto IRHeader = _IRHeader(InvalidNode, 0);
+  auto IRHeader = _IRHeader(InvalidNode, RIP, 0);
   CreateJumpBlocks(Blocks);
 
   auto Block = GetNewJumpBlock(RIP);

--- a/External/FEXCore/Source/Interface/HLE/Thunks/Thunks.cpp
+++ b/External/FEXCore/Source/Interface/HLE/Thunks/Thunks.cpp
@@ -208,7 +208,7 @@ namespace FEXCore {
             auto Result = Thread->CTX->AddCustomIREntrypoint(
                     args->original_callee,
                     [CTX, GuestThunkEntrypoint = args->target_addr](uintptr_t Entrypoint, FEXCore::IR::IREmitter *emit) {
-                        auto IRHeader = emit->_IRHeader(emit->Invalid(), 0);
+                        auto IRHeader = emit->_IRHeader(emit->Invalid(), Entrypoint, 0);
                         auto Block = emit->CreateCodeNode();
                         IRHeader.first->Blocks = emit->WrapNode(Block);
                         emit->SetCurrentCodeBlock(Block);

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -160,7 +160,7 @@
         "HasSideEffects": true,
         "SwitchGen": false
       },
-      "IRHeader SSA:$Blocks, u32:$BlockCount": {
+      "IRHeader SSA:$Blocks, u64:$OriginalRIP, u32:$BlockCount": {
         "SwitchGen": false
       },
       "CodeBlock SSA:$Begin, SSA:$Last": {

--- a/External/FEXCore/Source/Interface/IR/IRParser.cpp
+++ b/External/FEXCore/Source/Interface/IR/IRParser.cpp
@@ -533,11 +533,15 @@ class IRParser: public FEXCore::IR::IREmitter {
         return false;
       }
 
+      auto OriginalRIP = DecodeValue<uint64_t>(Def.Args[1]);
+
+      if (!CheckPrintError(Def, OriginalRIP.first)) return false;
+
       auto CodeBlockCount = DecodeValue<uint64_t>(Def.Args[1]);
 
       if (!CheckPrintError(Def, CodeBlockCount.first)) return false;
 
-      IRHeader = _IRHeader(InvalidNode, CodeBlockCount.second);
+      IRHeader = _IRHeader(InvalidNode, OriginalRIP.second, CodeBlockCount.second);
     }
 
     SetWriteCursor(nullptr); // isolate the header from everything following

--- a/External/FEXCore/Source/Interface/IR/Passes.h
+++ b/External/FEXCore/Source/Interface/IR/Passes.h
@@ -29,5 +29,9 @@ fextl::unique_ptr<FEXCore::IR::Pass> CreateRAValidation();
 fextl::unique_ptr<FEXCore::IR::Pass> CreatePhiValidation();
 fextl::unique_ptr<FEXCore::IR::Pass> CreateValueDominanceValidation();
 }
+
+namespace Debug {
+fextl::unique_ptr<FEXCore::IR::Pass> CreateIRDumper();
+}
 }
 

--- a/External/FEXCore/Source/Interface/IR/Passes/IRCompaction.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/IRCompaction.cpp
@@ -98,7 +98,8 @@ bool IRCompaction::Run(IREmitter *IREmit) {
 
   // Zero is always zero(invalid)
   OldToNewRemap[0].NodeID.Invalidate();
-  auto LocalHeaderOp = LocalBuilder._IRHeader(OrderedNodeWrapper::WrapOffset(0).GetNode(ListBegin), HeaderOp->BlockCount);
+  auto LocalHeaderOp = LocalBuilder._IRHeader(OrderedNodeWrapper::WrapOffset(0).GetNode(ListBegin), HeaderOp->OriginalRIP, HeaderOp->BlockCount);
+
   OldToNewRemap[CurrentIR.GetID(HeaderNode).Value].NodeID = LocalIR.GetID(LocalHeaderOp.Node);
 
   {

--- a/External/FEXCore/Source/Interface/IR/Passes/IRDumperPass.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/IRDumperPass.cpp
@@ -1,0 +1,84 @@
+/*
+$info$
+tags: ir|debug
+desc: Prints IR
+$end_info$
+*/
+
+#include "Interface/IR/PassManager.h"
+#include "Interface/IR/Passes/RegisterAllocationPass.h"
+#include "Interface/Core/OpcodeDispatcher.h"
+
+#include <FEXCore/IR/IR.h>
+
+namespace FEXCore::IR::Debug {
+class IRDumper final : public FEXCore::IR::Pass {
+public:
+  IRDumper();
+  bool Run(IREmitter *IREmit) override;
+
+private:
+  FEX_CONFIG_OPT(DumpIR, DUMPIR);
+  bool DumpToFile{};
+  bool DumpToLog{};
+};
+
+IRDumper::IRDumper() {
+  const auto DumpIRStr = DumpIR();
+  if (DumpIRStr == "stderr" || DumpIRStr == "stdout" || DumpIRStr == "no") {
+    // Intentionally do nothing
+  }
+  else if (DumpIRStr == "server") {
+    DumpToLog = true;
+  }
+  else {
+    DumpToFile = true;
+  }
+}
+
+bool IRDumper::Run(IREmitter *IREmit) {
+  auto RAPass = Manager->GetPass<IR::RegisterAllocationPass>("RA");
+  IR::RegisterAllocationData* RA{};
+  if (RAPass) {
+    RA = RAPass->GetAllocationData();
+  }
+
+  FEXCore::File::File FD{};
+  if (DumpIR() == "stderr") {
+    FD = FEXCore::File::File::GetStdERR();
+  }
+  else if (DumpIR() == "stdout") {
+    FD = FEXCore::File::File::GetStdOUT();
+  }
+
+  auto IR = IREmit->ViewIR();
+  auto HeaderOp = IR.GetHeader();
+  LOGMAN_THROW_AA_FMT(HeaderOp->Header.Op == OP_IRHEADER, "First op wasn't IRHeader");
+
+  // DumpIRStr might be no if not dumping but ShouldDump is set in OpDisp
+  if (DumpToFile) {
+    const auto fileName = fextl::fmt::format("{}/{:x}{}", DumpIR(), HeaderOp->OriginalRIP, RA ? "-post.ir" : "-pre.ir");
+    FD = FEXCore::File::File(fileName.c_str(),
+      FEXCore::File::FileModes::WRITE |
+      FEXCore::File::FileModes::CREATE |
+      FEXCore::File::FileModes::TRUNCATE);
+  }
+
+  if (FD.IsValid() || DumpToLog) {
+    fextl::stringstream out;
+    FEXCore::IR::Dump(&out, &IR, RA);
+    if (FD.IsValid()) {
+      fextl::fmt::print(FD, "IR-{} 0x{:x}:\n{}\n@@@@@\n", RA ? "post" : "pre", HeaderOp->OriginalRIP, out.str());
+    }
+    else {
+      LogMan::Msg::IFmt("IR-{} 0x{:x}:\n{}\n@@@@@\n", RA ? "post" : "pre", HeaderOp->OriginalRIP, out.str());
+    }
+  }
+
+  return false;
+}
+
+fextl::unique_ptr<FEXCore::IR::Pass> CreateIRDumper() {
+  return fextl::make_unique<IRDumper>();
+}
+}


### PR DESCRIPTION
This is incredibly useful and I find myself hacking this feature in
every time I am optimizing IR. Adds a new configuration option which
allows dumping IR at various times.

Before any optimization passes has happened
After all optimizations passes have happened
Before and After each IRPass to see what is breaking something.