### PR TITLE
Github: Adds a CI runner for 128-bit SVE testing 

### DIFF
--- a/.github/workflows/vixl_simulator.yml
+++ b/.github/workflows/vixl_simulator.yml
@@ -85,6 +85,21 @@ jobs:
       working-directory: ${{runner.workspace}}/build
       run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_ASM.log || true
 
+    - name: ASM Tests 128-bit
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      env:
+        FEX_HOSTFEATURES: "disableavx"
+        FEX_FORCESVEWIDTH: "128"
+      # Execute the unit tests
+      run: cmake --build . --config $BUILD_TYPE --target asm_tests
+
+    - name: ASM Test 128-bit Results move
+      if: ${{ always() }}
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_ASM128bit.log || true
+
     - name: IR Tests
       working-directory: ${{runner.workspace}}/build
       shell: bash

--- a/External/FEXCore/Scripts/config_generator.py
+++ b/External/FEXCore/Scripts/config_generator.py
@@ -431,13 +431,13 @@ def print_parse_envloader_options(options):
             value_type = op_vals["Type"]
             if (value_type == "strenum"):
                 output_argloader.write("else if (Key == \"FEX_{0}\") {{\n".format(op_key.upper()))
-                output_argloader.write("Value = FEXCore::Config::EnumParser<FEXCore::Config::{}ConfigPair>(FEXCore::Config::{}_EnumPairs, Value);\n".format(op_key, op_key, op_key))
+                output_argloader.write("Value = FEXCore::Config::EnumParser<FEXCore::Config::{}ConfigPair>(FEXCore::Config::{}_EnumPairs, Value_View);\n".format(op_key, op_key, op_key))
                 output_argloader.write("}\n")
 
             if ("ArgumentHandler" in op_vals):
                 conversion_func = "FEXCore::Config::Handler::{0}".format(op_vals["ArgumentHandler"])
                 output_argloader.write("else if (Key == \"FEX_{0}\") {{\n".format(op_key.upper()))
-                output_argloader.write("Value = {0}(Value);\n".format(conversion_func))
+                output_argloader.write("Value = {0}(Value_View);\n".format(conversion_func))
                 output_argloader.write("}\n")
     output_argloader.write("#endif\n")
 

--- a/External/FEXCore/Source/Interface/Config/Config.json.in
+++ b/External/FEXCore/Source/Interface/Config/Config.json.in
@@ -56,9 +56,9 @@
         "Default": "FEXCore::Config::HostFeatures::OFF",
         "Enums": {
           "ENABLESVE": "enablesve",
-          "DISABLESVE": "disasblesve",
+          "DISABLESVE": "disablesve",
           "ENABLEAVX": "enableavx",
-          "DISABLEAVX": "disasbleavx",
+          "DISABLEAVX": "disableavx",
           "ENABLEAFP": "enableafp",
           "DISABLEAFP": "disableafp",
           "ENABLELRCPC": "enablelrcpc",

--- a/External/FEXCore/Source/Interface/Config/Config.json.in
+++ b/External/FEXCore/Source/Interface/Config/Config.json.in
@@ -312,6 +312,14 @@
           "\tblocks: Will enable disassembly of the translated instruction code blocks",
           "\tstats: Will print stats when disassembling the code"
         ]
+      },
+      "ForceSVEWidth": {
+        "Type": "uint32",
+        "Default": "0",
+        "Desc": [
+          "Allows overriding the SVE width in the vixl simulator.",
+          "Useful as a debugging feature."
+        ]
       }
     },
     "Logging": {

--- a/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
@@ -41,8 +41,10 @@ Arm64Dispatcher::Arm64Dispatcher(FEXCore::Context::ContextImpl *ctx, const Dispa
 #endif
 {
 #ifdef VIXL_SIMULATOR
+  FEX_CONFIG_OPT(ForceSVEWidth, FORCESVEWIDTH);
   // Hardcode a 256-bit vector width if we are running in the simulator.
-  Simulator.SetVectorLengthInBits(256);
+  // Allow the user to override this.
+  Simulator.SetVectorLengthInBits(ForceSVEWidth() ? ForceSVEWidth() : 256);
 #endif
 
   EmitDispatcher();

--- a/External/FEXCore/include/FEXCore/Config/Config.h
+++ b/External/FEXCore/include/FEXCore/Config/Config.h
@@ -17,7 +17,7 @@
 
 namespace FEXCore::Config {
 namespace Handler {
-  static inline std::string_view CoreHandler(std::string_view Value) {
+  static inline std::optional<fextl::string> CoreHandler(std::string_view Value) {
     if (Value == "irint")
       return "0";
     else if (Value == "irjit")
@@ -29,7 +29,7 @@ namespace Handler {
     return "1";
   }
 
-  static inline std::string_view SMCCheckHandler(std::string_view Value) {
+  static inline std::optional<fextl::string> SMCCheckHandler(std::string_view Value) {
     if (Value == "none")
       return "0";
     else if (Value == "mtrack")
@@ -40,7 +40,7 @@ namespace Handler {
       return "3";
     return "0";
   }
-  static inline std::string_view CacheObjectCodeHandler(std::string_view Value) {
+  static inline std::optional<fextl::string> CacheObjectCodeHandler(std::string_view Value) {
     if (Value == "none")
       return "0";
     else if (Value == "read")
@@ -91,12 +91,12 @@ namespace Handler {
   };
 
   template<typename PairTypes, typename ArrayPairType>
-  static inline fextl::string EnumParser(ArrayPairType const &EnumPairs, std::string_view const View) {
+  static inline std::optional<fextl::string> EnumParser(ArrayPairType const &EnumPairs, std::string_view const View) {
     uint64_t EnumMask{};
     auto Results = std::from_chars(View.data(), View.data() + View.size(), EnumMask);
     if (Results.ec == std::errc()) {
       // If the data is a valid number, just pass it through.
-      return View.data();
+      return std::nullopt;
     }
 
     auto Begin = 0;
@@ -188,13 +188,27 @@ namespace Type {
       return &it->second.front();
     }
 
+    void Set(ConfigOption Option, const char *Data) {
+      OptionMap[Option].emplace_back(fextl::string(Data));
+    }
+
     void Set(ConfigOption Option, std::string_view Data) {
       OptionMap[Option].emplace_back(fextl::string(Data));
     }
 
+    void Set(ConfigOption Option, fextl::string Data) {
+      OptionMap[Option].emplace_back(std::move(Data));
+    }
+
+    void Set(ConfigOption Option, std::optional<fextl::string> Data) {
+      if (Data) {
+        OptionMap[Option].emplace_back(std::move(*Data));
+      }
+    }
+
     void EraseSet(ConfigOption Option, std::string_view Data) {
       Erase(Option);
-      Set(Option, fextl::string(Data));
+      Set(Option, Data);
     }
 
     void Erase(ConfigOption Option) {

--- a/External/FEXCore/include/FEXCore/Core/CoreState.h
+++ b/External/FEXCore/include/FEXCore/Core/CoreState.h
@@ -85,28 +85,28 @@ namespace FEXCore::Core {
       SSE sse;
     };
 
-    uint64_t rip; ///< Current core's RIP. May not be entirely accurate while JIT is active
-    uint64_t gregs[16];
+    uint64_t rip{}; ///< Current core's RIP. May not be entirely accurate while JIT is active
+    uint64_t gregs[16]{};
     // Raw segment register indexes
-    uint16_t es_idx, cs_idx, ss_idx, ds_idx;
-    uint16_t gs_idx, fs_idx;
+    uint16_t es_idx{}, cs_idx{}, ss_idx{}, ds_idx{};
+    uint16_t gs_idx{}, fs_idx{};
     uint16_t _pad[2];
 
     // Segment registers holding base addresses
-    uint32_t es_cached, cs_cached, ss_cached, ds_cached;
-    uint64_t gs_cached;
-    uint64_t fs_cached;
-    uint64_t InlineJITBlockHeader;
-    XMMRegs xmm;
-    uint8_t flags[48];
-    uint64_t mm[8][2];
+    uint32_t es_cached{}, cs_cached{}, ss_cached{}, ds_cached{};
+    uint64_t gs_cached{};
+    uint64_t fs_cached{};
+    uint64_t InlineJITBlockHeader{};
+    XMMRegs xmm{};
+    uint8_t flags[48]{};
+    uint64_t mm[8][2]{};
 
     // 32bit x86 state
     struct {
       uint32_t base;
-    } gdt[32];
-    uint16_t FCW;
-    uint16_t FTW;
+    } gdt[32]{};
+    uint16_t FCW { 0x37F };
+    uint16_t FTW { 0xFFFF };
 
     uint32_t _pad2[1];
     // Reference counter for FEX's per-thread deferred signals.
@@ -130,21 +130,20 @@ namespace FEXCore::Core {
     static constexpr size_t NUM_XMMS = sizeof(xmm) / XMM_AVX_REG_SIZE;
     static constexpr size_t NUM_MMS = sizeof(mm) / MM_REG_SIZE;
     CPUState() {
+#ifndef NDEBUG
       // Initialize default CPU state
       rip = ~0ULL;
-      memset(gregs, 0, sizeof(gregs));
-
+      // Initialize xmm state with garbage to catch spurious incorrect xmm usage.
       for (auto& xmm : xmm.avx.data) {
         xmm[0] = 0xDEADBEEFULL;
         xmm[1] = 0xBAD0DAD1ULL;
         xmm[2] = 0xDEADCAFEULL;
         xmm[3] = 0xBAD2CAD3ULL;
       }
-      memset(&flags, 0, Core::CPUState::NUM_EFLAG_BITS);
+#endif
+
       flags[1] = 1; ///< Reserved - Always 1.
       flags[9] = 1; ///< Interrupt flag - Always 1.
-      FCW = 0x37F;
-      FTW = 0xFFFF;
     }
   };
   static_assert(std::is_trivially_copyable_v<CPUState>, "Needs to be trivial");

--- a/Source/Common/Config.cpp
+++ b/Source/Common/Config.cpp
@@ -211,7 +211,7 @@ namespace JSON {
   }
 
   void EnvLoader::Load() {
-    using EnvMapType = fextl::unordered_map<std::string_view, std::string_view>;
+    using EnvMapType = fextl::unordered_map<std::string_view, fextl::string>;
     EnvMapType EnvMap;
 
     for(const char *const *pvar=envp; pvar && *pvar; pvar++) {
@@ -221,12 +221,18 @@ namespace JSON {
         continue;
 
       std::string_view Key = Var.substr(0,pos);
-      std::string_view Value {Var.substr(pos+1)};
+      std::string_view Value_View {Var.substr(pos+1)};
+      std::optional<fextl::string> Value;
 
 #define ENVLOADER
 #include <FEXCore/Config/ConfigOptions.inl>
 
-      EnvMap[Key] = Value;
+      if (Value) {
+        EnvMap.insert_or_assign(Key, *Value);
+      }
+      else {
+        EnvMap.insert_or_assign(Key, Value_View);
+      }
     }
 
     auto GetVar = [](EnvMapType &EnvMap, const std::string_view id)  -> std::optional<std::string_view> {

--- a/Source/Tools/FEXLoader/TestHarnessRunner.cpp
+++ b/Source/Tools/FEXLoader/TestHarnessRunner.cpp
@@ -91,15 +91,21 @@ public:
   }
 
   void Load() override {
-    fextl::unordered_map<std::string_view, std::string_view> EnvMap;
+    fextl::unordered_map<std::string_view, std::string> EnvMap;
     for (auto &Option : Env) {
       std::string_view Key = Option.first;
-      std::string_view Value = Option.second;
+      std::string_view Value_View = Option.second;
+      std::optional<fextl::string> Value;
 
 #define ENVLOADER
 #include <FEXCore/Config/ConfigOptions.inl>
 
-      EnvMap.insert_or_assign(Key, Value);
+      if (Value) {
+        EnvMap.insert_or_assign(Key, *Value);
+      }
+      else {
+        EnvMap.insert_or_assign(Key, Value_View);
+      }
     }
 
     auto GetVar = [&](const std::string_view id) -> std::optional<std::string_view> {


### PR DESCRIPTION
We don't currently have a device in CI that can run SVE with 128-bit
width registers. Until we have a device with this, make sure the vixl
simulator is also running the ASM tests in this width.