### PR TITLE
ARMEmitter: Handle SVE FP multiply-add long groups

### DIFF
--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
@@ -2137,13 +2137,37 @@ public:
   // XXX:
   // SVE2 crypto constructive binary operations
   // XXX:
-  //
+
   // SVE Floating Point Widening Multiply-Add - Indexed
   // SVE BFloat16 floating-point dot product (indexed)
   // XXX:
+
   // SVE floating-point multiply-add long (indexed)
-  // XXX:
-  //
+  void fmlalb(SubRegSize dstsize, ZRegister zda, ZRegister zn, ZRegister zm, uint32_t index) {
+    SVEFPMultiplyAddLongIndexed(0, 0, 0, dstsize, zda, zn, zm, index);
+  }
+  void fmlalt(SubRegSize dstsize, ZRegister zda, ZRegister zn, ZRegister zm, uint32_t index) {
+    SVEFPMultiplyAddLongIndexed(0, 0, 1, dstsize, zda, zn, zm, index);
+  }
+  void fmlslb(SubRegSize dstsize, ZRegister zda, ZRegister zn, ZRegister zm, uint32_t index) {
+    SVEFPMultiplyAddLongIndexed(0, 1, 0, dstsize, zda, zn, zm, index);
+  }
+  void fmlslt(SubRegSize dstsize, ZRegister zda, ZRegister zn, ZRegister zm, uint32_t index) {
+    SVEFPMultiplyAddLongIndexed(0, 1, 1, dstsize, zda, zn, zm, index);
+  }
+  void bfmlalb(SubRegSize dstsize, ZRegister zda, ZRegister zn, ZRegister zm, uint32_t index) {
+    SVEFPMultiplyAddLongIndexed(1, 0, 0, dstsize, zda, zn, zm, index);
+  }
+  void bfmlalt(SubRegSize dstsize, ZRegister zda, ZRegister zn, ZRegister zm, uint32_t index) {
+    SVEFPMultiplyAddLongIndexed(1, 0, 1, dstsize, zda, zn, zm, index);
+  }
+  void bfmlslb(SubRegSize dstsize, ZRegister zda, ZRegister zn, ZRegister zm, uint32_t index) {
+    SVEFPMultiplyAddLongIndexed(1, 1, 0, dstsize, zda, zn, zm, index);
+  }
+  void bfmlslt(SubRegSize dstsize, ZRegister zda, ZRegister zn, ZRegister zm, uint32_t index) {
+    SVEFPMultiplyAddLongIndexed(1, 1, 1, dstsize, zda, zn, zm, index);
+  }
+
   // SVE Floating Point Widening Multiply-Add
   // SVE BFloat16 floating-point dot product
   // XXX:
@@ -4545,6 +4569,24 @@ private:
     Instr |= zn.Idx() << 5;
     Instr |= zda.Idx();
     dc32(Instr);
+  }
+
+  void SVEFPMultiplyAddLongIndexed(uint32_t o2, uint32_t op, uint32_t T, SubRegSize dstsize,
+                                   ZRegister zda, ZRegister zn, ZRegister zm, uint32_t index) {
+    LOGMAN_THROW_AA_FMT(dstsize == SubRegSize::i32Bit, "Destination size must be 32-bit.");
+    LOGMAN_THROW_AA_FMT(index <= 7, "Index ({}) must be within [0, 7]", index);
+    LOGMAN_THROW_A_FMT(zm <= ZReg::z7, "zm (z{}) must be within [z0, z7]", zm.Idx());
+
+    uint32_t Inst = 0b0110'0100'1010'0000'0100'0000'0000'0000;
+    Inst |= o2 << 22;
+    Inst |= (index & 0b110) << 18;
+    Inst |= zm.Idx() << 16;
+    Inst |= op << 13;
+    Inst |= (index & 0b001) << 11;
+    Inst |= T << 10;
+    Inst |= zn.Idx() << 5;
+    Inst |= zda.Idx();
+    dc32(Inst);
   }
 
   void SVEFPMatrixMultiplyAccumulate(SubRegSize size, ZRegister zda, ZRegister zn, ZRegister zm) {

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
@@ -2171,8 +2171,32 @@ public:
   // SVE Floating Point Widening Multiply-Add
   // SVE BFloat16 floating-point dot product
   // XXX:
+
   // SVE floating-point multiply-add long
-  // XXX:
+  void fmlalb(SubRegSize dstsize, ZRegister zda, ZRegister zn, ZRegister zm) {
+    SVEFPMultiplyAddLong(0, 0, 0, dstsize, zda, zn, zm);
+  }
+  void fmlalt(SubRegSize dstsize, ZRegister zda, ZRegister zn, ZRegister zm) {
+    SVEFPMultiplyAddLong(0, 0, 1, dstsize, zda, zn, zm);
+  }
+  void fmlslb(SubRegSize dstsize, ZRegister zda, ZRegister zn, ZRegister zm) {
+    SVEFPMultiplyAddLong(0, 1, 0, dstsize, zda, zn, zm);
+  }
+  void fmlslt(SubRegSize dstsize, ZRegister zda, ZRegister zn, ZRegister zm) {
+    SVEFPMultiplyAddLong(0, 1, 1, dstsize, zda, zn, zm);
+  }
+  void bfmlalb(SubRegSize dstsize, ZRegister zda, ZRegister zn, ZRegister zm) {
+    SVEFPMultiplyAddLong(1, 0, 0, dstsize, zda, zn, zm);
+  }
+  void bfmlalt(SubRegSize dstsize, ZRegister zda, ZRegister zn, ZRegister zm) {
+    SVEFPMultiplyAddLong(1, 0, 1, dstsize, zda, zn, zm);
+  }
+  void bfmlslb(SubRegSize dstsize, ZRegister zda, ZRegister zn, ZRegister zm) {
+    SVEFPMultiplyAddLong(1, 1, 0, dstsize, zda, zn, zm);
+  }
+  void bfmlslt(SubRegSize dstsize, ZRegister zda, ZRegister zn, ZRegister zm) {
+    SVEFPMultiplyAddLong(1, 1, 1, dstsize, zda, zn, zm);
+  }
 
   // SVE Floating Point Arithmetic - Predicated
   void ftmad(SubRegSize size, ZRegister zd, ZRegister zn, ZRegister zm, uint32_t imm) {
@@ -4587,6 +4611,20 @@ private:
     Inst |= zn.Idx() << 5;
     Inst |= zda.Idx();
     dc32(Inst);
+  }
+
+  void SVEFPMultiplyAddLong(uint32_t o2, uint32_t op, uint32_t T, SubRegSize dstsize,
+                            ZRegister zda, ZRegister zn, ZRegister zm) {
+    LOGMAN_THROW_AA_FMT(dstsize == SubRegSize::i32Bit, "Destination size must be 32-bit.");
+
+    uint32_t Instr = 0b0110'0100'1010'0000'1000'0000'0000'0000;
+    Instr |= o2 << 22;
+    Instr |= zm.Idx() << 16;
+    Instr |= op << 13;
+    Instr |= T << 10;
+    Instr |= zn.Idx() << 5;
+    Instr |= zda.Idx();
+    dc32(Instr);
   }
 
   void SVEFPMatrixMultiplyAccumulate(SubRegSize size, ZRegister zda, ZRegister zn, ZRegister zm) {

--- a/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
+++ b/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
@@ -3262,7 +3262,40 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE BFloat16 floating-point do
   // TODO: Implement in emitter.
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE floating-point multiply-add long (indexed)") {
-  // TODO: Implement in emitter.
+  TEST_SINGLE(fmlalb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z7, 0), "fmlalb z30.s, z29.h, z7.h[0]");
+  TEST_SINGLE(fmlalb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z7, 3), "fmlalb z30.s, z29.h, z7.h[3]");
+  TEST_SINGLE(fmlalb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z7, 7), "fmlalb z30.s, z29.h, z7.h[7]");
+
+  TEST_SINGLE(fmlalt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z7, 0), "fmlalt z30.s, z29.h, z7.h[0]");
+  TEST_SINGLE(fmlalt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z7, 3), "fmlalt z30.s, z29.h, z7.h[3]");
+  TEST_SINGLE(fmlalt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z7, 7), "fmlalt z30.s, z29.h, z7.h[7]");
+
+  TEST_SINGLE(fmlslb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z7, 0), "fmlslb z30.s, z29.h, z7.h[0]");
+  TEST_SINGLE(fmlslb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z7, 3), "fmlslb z30.s, z29.h, z7.h[3]");
+  TEST_SINGLE(fmlslb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z7, 7), "fmlslb z30.s, z29.h, z7.h[7]");
+
+  TEST_SINGLE(fmlslt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z7, 0), "fmlslt z30.s, z29.h, z7.h[0]");
+  TEST_SINGLE(fmlslt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z7, 3), "fmlslt z30.s, z29.h, z7.h[3]");
+  TEST_SINGLE(fmlslt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z7, 7), "fmlslt z30.s, z29.h, z7.h[7]");
+
+  // XXX: vixl's diassembler doesn't support these. Re-enable when it does
+  //      or upon switching disassemblers.
+
+  // TEST_SINGLE(bfmlalb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z7, 0), "bfmlalb z30.s, z29.h, z7.h[0]");
+  // TEST_SINGLE(bfmlalb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z7, 3), "bfmlalb z30.s, z29.h, z7.h[3]");
+  // TEST_SINGLE(bfmlalb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z7, 7), "bfmlalb z30.s, z29.h, z7.h[7]");
+
+  // TEST_SINGLE(bfmlalt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z7, 0), "bfmlalt z30.s, z29.h, z7.h[0]");
+  // TEST_SINGLE(bfmlalt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z7, 3), "bfmlalt z30.s, z29.h, z7.h[3]");
+  // TEST_SINGLE(bfmlalt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z7, 7), "bfmlalt z30.s, z29.h, z7.h[7]");
+
+  // TEST_SINGLE(bfmlslb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z7, 0), "bfmlslb z30.s, z29.h, z7.h[0]");
+  // TEST_SINGLE(bfmlslb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z7, 3), "bfmlslb z30.s, z29.h, z7.h[3]");
+  // TEST_SINGLE(bfmlslb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z7, 7), "bfmlslb z30.s, z29.h, z7.h[7]");
+
+  // TEST_SINGLE(bfmlslt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z7, 0), "bfmlslt z30.s, z29.h, z7.h[0]");
+  // TEST_SINGLE(bfmlslt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z7, 3), "bfmlslt z30.s, z29.h, z7.h[3]");
+  // TEST_SINGLE(bfmlslt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z7, 7), "bfmlslt z30.s, z29.h, z7.h[7]");
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE BFloat16 floating-point dot product") {
   // TODO: Implement in emitter.

--- a/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
+++ b/External/FEXCore/unittests/Emitter/SVE_Tests.cpp
@@ -3301,7 +3301,40 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE BFloat16 floating-point do
   // TODO: Implement in emitter.
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE floating-point multiply-add long") {
-  // TODO: Implement in emitter.
+  TEST_SINGLE(fmlalb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "fmlalb z30.s, z29.h, z28.h");
+  TEST_SINGLE(fmlalb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "fmlalb z30.s, z29.h, z28.h");
+  TEST_SINGLE(fmlalb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "fmlalb z30.s, z29.h, z28.h");
+
+  TEST_SINGLE(fmlalt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "fmlalt z30.s, z29.h, z28.h");
+  TEST_SINGLE(fmlalt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "fmlalt z30.s, z29.h, z28.h");
+  TEST_SINGLE(fmlalt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "fmlalt z30.s, z29.h, z28.h");
+
+  TEST_SINGLE(fmlslb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "fmlslb z30.s, z29.h, z28.h");
+  TEST_SINGLE(fmlslb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "fmlslb z30.s, z29.h, z28.h");
+  TEST_SINGLE(fmlslb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "fmlslb z30.s, z29.h, z28.h");
+
+  TEST_SINGLE(fmlslt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "fmlslt z30.s, z29.h, z28.h");
+  TEST_SINGLE(fmlslt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "fmlslt z30.s, z29.h, z28.h");
+  TEST_SINGLE(fmlslt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "fmlslt z30.s, z29.h, z28.h");
+
+  // XXX: vixl's diassembler doesn't support these. Re-enable when it does
+  //      or upon switching disassemblers.
+
+  // TEST_SINGLE(bfmlalb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "bfmlalb z30.s, z29.h, z28.h");
+  // TEST_SINGLE(bfmlalb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "bfmlalb z30.s, z29.h, z28.h");
+  // TEST_SINGLE(bfmlalb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "bfmlalb z30.s, z29.h, z28.h");
+  
+  // TEST_SINGLE(bfmlalt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "bfmlalt z30.s, z29.h, z28.h");
+  // TEST_SINGLE(bfmlalt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "bfmlalt z30.s, z29.h, z28.h");
+  // TEST_SINGLE(bfmlalt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "bfmlalt z30.s, z29.h, z28.h");
+  
+  // TEST_SINGLE(bfmlalb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "bfmlslb z30.s, z29.h, z28.h");
+  // TEST_SINGLE(bfmlalb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "bfmlslb z30.s, z29.h, z28.h");
+  // TEST_SINGLE(bfmlalb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "bfmlslb z30.s, z29.h, z28.h");
+  
+  // TEST_SINGLE(bfmlslt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "bfmlslt z30.s, z29.h, z28.h");
+  // TEST_SINGLE(bfmlslt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "bfmlslt z30.s, z29.h, z28.h");
+  // TEST_SINGLE(bfmlslt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "bfmlslt z30.s, z29.h, z28.h");
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE floating-point arithmetic (predicated)") {
   TEST_SINGLE(ftmad(SubRegSize::i16Bit, ZReg::z30, ZReg::z30, ZReg::z28, 7), "ftmad z30.h, z30.h, z28.h, #7");


### PR DESCRIPTION
Crosses off the only remaining "normal" FP group that hasn't been implemented. All that remains for FP groups are BFloat and SME-related categories which we don't need to worry about (yet)