### PR TITLE
FEXCore: Fixes Arm64 stats disassembly

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Core.cpp
+++ b/External/FEXCore/Source/Interface/Core/Core.cpp
@@ -793,9 +793,10 @@ namespace FEXCore::Context {
         }
       });
 
-      auto CodeBlocks = Thread->FrontendDecoder->GetDecodedBlocks();
+      auto BlockInfo = Thread->FrontendDecoder->GetDecodedBlockInfo();
+      auto CodeBlocks = &BlockInfo->Blocks;
 
-      Thread->OpDispatcher->BeginFunction(GuestRIP, CodeBlocks);
+      Thread->OpDispatcher->BeginFunction(GuestRIP, CodeBlocks, BlockInfo->TotalInstructionCount);
 
       const uint8_t GPRSize = GetGPRSize();
 

--- a/External/FEXCore/Source/Interface/Core/Frontend.h
+++ b/External/FEXCore/Source/Interface/Core/Frontend.h
@@ -26,12 +26,17 @@ public:
     bool HasInvalidInstruction{};
   };
 
+  struct DecodedBlockInformation final {
+    uint64_t TotalInstructionCount;
+    fextl::vector<DecodedBlocks> Blocks;
+  };
+
   Decoder(FEXCore::Context::ContextImpl *ctx);
   ~Decoder();
   void DecodeInstructionsAtEntry(uint8_t const* InstStream, uint64_t PC, std::function<void(uint64_t BlockEntry, uint64_t Start, uint64_t Length)> AddContainedCodePage);
 
-  fextl::vector<DecodedBlocks> const *GetDecodedBlocks() const {
-    return &Blocks;
+  DecodedBlockInformation const *GetDecodedBlockInfo() const {
+    return &BlockInfo;
   }
 
   uint64_t DecodedMinAddress {};
@@ -90,7 +95,7 @@ private:
   uint64_t SymbolMinAddress {~0ULL};
   uint64_t SectionMaxAddress {~0ULL};
 
-  fextl::vector<DecodedBlocks> Blocks;
+  DecodedBlockInformation BlockInfo;
   fextl::set<uint64_t> BlocksToDecode;
   fextl::set<uint64_t> HasBlocks;
   fextl::set<uint64_t> *ExternalBranches {nullptr};

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -1150,6 +1150,9 @@ CPUBackend::CompiledCode Arm64JITCore::CompileCode(uint64_t Entry,
 
 #ifdef VIXL_DISASSEMBLER
   if (Disassemble() & FEXCore::Config::Disassemble::STATS) {
+    auto HeaderOp = IR->GetHeader();
+    LOGMAN_THROW_AA_FMT(HeaderOp->Header.Op == IR::OP_IRHEADER, "First op wasn't IRHeader");
+
     LogMan::Msg::IFmt("RIP: 0x{:x}", Entry);
     LogMan::Msg::IFmt("Guest Code instructions: {}", HeaderOp->NumHostInstructions);
     LogMan::Msg::IFmt("Host Code instructions: {}", CodeOnlySize >> 2);

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -4732,9 +4732,9 @@ void OpDispatchBuilder::CreateJumpBlocks(fextl::vector<FEXCore::Frontend::Decode
   }
 }
 
-void OpDispatchBuilder::BeginFunction(uint64_t RIP, fextl::vector<FEXCore::Frontend::Decoder::DecodedBlocks> const *Blocks) {
+void OpDispatchBuilder::BeginFunction(uint64_t RIP, fextl::vector<FEXCore::Frontend::Decoder::DecodedBlocks> const *Blocks, uint32_t NumInstructions) {
   Entry = RIP;
-  auto IRHeader = _IRHeader(InvalidNode, RIP, 0);
+  auto IRHeader = _IRHeader(InvalidNode, RIP, 0, NumInstructions);
   CreateJumpBlocks(Blocks);
 
   auto Block = GetNewJumpBlock(RIP);

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -167,7 +167,7 @@ public:
   void SetDumpIR(bool DumpIR) { ShouldDump = DumpIR; }
   bool ShouldDumpIR() const { return ShouldDump; }
 
-  void BeginFunction(uint64_t RIP, fextl::vector<FEXCore::Frontend::Decoder::DecodedBlocks> const *Blocks);
+  void BeginFunction(uint64_t RIP, fextl::vector<FEXCore::Frontend::Decoder::DecodedBlocks> const *Blocks, uint32_t NumInstructions);
   void Finalize();
 
   // Dispatch builder functions

--- a/External/FEXCore/Source/Interface/HLE/Thunks/Thunks.cpp
+++ b/External/FEXCore/Source/Interface/HLE/Thunks/Thunks.cpp
@@ -208,7 +208,7 @@ namespace FEXCore {
             auto Result = Thread->CTX->AddCustomIREntrypoint(
                     args->original_callee,
                     [CTX, GuestThunkEntrypoint = args->target_addr](uintptr_t Entrypoint, FEXCore::IR::IREmitter *emit) {
-                        auto IRHeader = emit->_IRHeader(emit->Invalid(), Entrypoint, 0);
+                        auto IRHeader = emit->_IRHeader(emit->Invalid(), Entrypoint, 0, 0);
                         auto Block = emit->CreateCodeNode();
                         IRHeader.first->Blocks = emit->WrapNode(Block);
                         emit->SetCurrentCodeBlock(Block);

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -160,7 +160,7 @@
         "HasSideEffects": true,
         "SwitchGen": false
       },
-      "IRHeader SSA:$Blocks, u64:$OriginalRIP, u32:$BlockCount": {
+      "IRHeader SSA:$Blocks, u64:$OriginalRIP, u32:$BlockCount, u32:$NumHostInstructions": {
         "SwitchGen": false
       },
       "CodeBlock SSA:$Begin, SSA:$Last": {

--- a/External/FEXCore/Source/Interface/IR/IRDumper.cpp
+++ b/External/FEXCore/Source/Interface/IR/IRDumper.cpp
@@ -204,7 +204,9 @@ void Dump(fextl::stringstream *out, IRListView const* IR, IR::RegisterAllocation
   AddIndent();
   *out << "(%0) " << "IRHeader ";
   *out << "%" << HeaderOp->Blocks.ID() << ", ";
-  *out << "#" << std::dec << HeaderOp->BlockCount << std::endl;
+  *out << "#" << std::dec << HeaderOp->OriginalRIP << ", ";
+  *out << "#" << std::dec << HeaderOp->BlockCount << ", ";
+  *out << "#" << std::dec << HeaderOp->NumHostInstructions << std::endl;
 
   for (auto [BlockNode, BlockHeader] : IR->GetBlocks()) {
     {

--- a/External/FEXCore/Source/Interface/IR/IRParser.cpp
+++ b/External/FEXCore/Source/Interface/IR/IRParser.cpp
@@ -537,11 +537,15 @@ class IRParser: public FEXCore::IR::IREmitter {
 
       if (!CheckPrintError(Def, OriginalRIP.first)) return false;
 
-      auto CodeBlockCount = DecodeValue<uint64_t>(Def.Args[1]);
+      auto CodeBlockCount = DecodeValue<uint64_t>(Def.Args[2]);
 
       if (!CheckPrintError(Def, CodeBlockCount.first)) return false;
 
-      IRHeader = _IRHeader(InvalidNode, OriginalRIP.second, CodeBlockCount.second);
+      auto InstructionCount = DecodeValue<uint64_t>(Def.Args[3]);
+
+      if (!CheckPrintError(Def, InstructionCount.first)) return false;
+
+      IRHeader = _IRHeader(InvalidNode, OriginalRIP.second, CodeBlockCount.second, InstructionCount.second);
     }
 
     SetWriteCursor(nullptr); // isolate the header from everything following

--- a/External/FEXCore/Source/Interface/IR/Passes/IRCompaction.cpp
+++ b/External/FEXCore/Source/Interface/IR/Passes/IRCompaction.cpp
@@ -98,7 +98,7 @@ bool IRCompaction::Run(IREmitter *IREmit) {
 
   // Zero is always zero(invalid)
   OldToNewRemap[0].NodeID.Invalidate();
-  auto LocalHeaderOp = LocalBuilder._IRHeader(OrderedNodeWrapper::WrapOffset(0).GetNode(ListBegin), HeaderOp->OriginalRIP, HeaderOp->BlockCount);
+  auto LocalHeaderOp = LocalBuilder._IRHeader(OrderedNodeWrapper::WrapOffset(0).GetNode(ListBegin), HeaderOp->OriginalRIP, HeaderOp->BlockCount, HeaderOp->NumHostInstructions);
 
   OldToNewRemap[CurrentIR.GetID(HeaderNode).Value].NodeID = LocalIR.GetID(LocalHeaderOp.Node);
 

--- a/unittests/IR/Basic/MemoryData.ir
+++ b/unittests/IR/Basic/MemoryData.ir
@@ -12,7 +12,7 @@
 ;}
 ;%endif
 
-(%1) IRHeader %2, #0
+(%1) IRHeader %2, #0, #0, #0
   (%2) CodeBlock %start, %end, %1
     (%start i0) BeginBlock %2
     %Addr i64 = Constant #0x100000

--- a/unittests/IR/Basic/Sbfe.ir
+++ b/unittests/IR/Basic/Sbfe.ir
@@ -17,7 +17,7 @@
 ;}
 ;%endif
 
-(%1) IRHeader %2, #0
+(%1) IRHeader %2, #0, #0, #0
   (%2) CodeBlock %start, %end, %1
     (%start i0) BeginBlock %2
     %Addr1 i64 = Constant #0x1000000

--- a/unittests/IR/Basic/SetGPR.ir
+++ b/unittests/IR/Basic/SetGPR.ir
@@ -6,7 +6,7 @@
 ;}
 ;%endif
 
-(%1) IRHeader %2, #0
+(%1) IRHeader %2, #0, #0, #0
   (%2) CodeBlock %6, %8, %3
     (%6 i0) BeginBlock %2
     %Value i64 = Constant #0x4142434445464748

--- a/unittests/IR/Correctness/AddTruncate.ir
+++ b/unittests/IR/Correctness/AddTruncate.ir
@@ -16,7 +16,7 @@
 ;}
 ;%endif
 
-(%1) IRHeader %2, #0
+(%1) IRHeader %2, #0, #0, #0
   (%2) CodeBlock %6, %12, %1
     (%6 i0) BeginBlock %2
     %AddrA i64 = Constant #0x1000000

--- a/unittests/IR/Correctness/FPRStoreTruncate.ir
+++ b/unittests/IR/Correctness/FPRStoreTruncate.ir
@@ -19,7 +19,7 @@
 
 
 
-(%1) IRHeader %2, #0
+(%1) IRHeader %2, #0, #0, #0
   (%2) CodeBlock %6, %end, %begin
     (%begin i0) BeginBlock %2
 ; Clear registers

--- a/unittests/IR/Correctness/LeftShiftTruncate.ir
+++ b/unittests/IR/Correctness/LeftShiftTruncate.ir
@@ -16,7 +16,7 @@
 ;}
 ;%endif
 
-(%1) IRHeader %2, #0
+(%1) IRHeader %2, #0, #0, #0
   (%2) CodeBlock %6, %12, %1
     (%6 i0) BeginBlock %2
     %AddrA i64 = Constant #0x1000000

--- a/unittests/IR/Correctness/SubTruncate.ir
+++ b/unittests/IR/Correctness/SubTruncate.ir
@@ -16,7 +16,7 @@
 ;}
 ;%endif
 
-(%1) IRHeader %2, #0
+(%1) IRHeader %2, #0, #0, #0
   (%2) CodeBlock %6, %12, %1
     (%Start i0) BeginBlock %2
     %AddrA i64 = Constant #0x1000000


### PR DESCRIPTION
Requires the IR headerop to house the number of host instructions this code is translating for the stats.

Fixes compiling with disassembly enabled, will be used with the instruction count CI.