### PR TITLE
Various warning fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,7 +236,7 @@ if (BUILD_TESTS)
 endif()
 
 add_subdirectory(External/vixl/)
-include_directories(External/vixl/src/)
+include_directories(SYSTEM External/vixl/src/)
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   # This means we were attempted to get compiled with GCC

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
@@ -3981,7 +3981,7 @@ private:
 
     const auto& op_data = mem_op.MetaType.ScalarVectorType;
     const bool is_scaled = op_data.scale != 0;
-    const auto msize_value = FEXCore::ToUnderlying(msize);
+    [[maybe_unused]] const auto msize_value = FEXCore::ToUnderlying(msize);
 
     LOGMAN_THROW_A_FMT(op_data.scale == 0 || op_data.scale == msize_value,
                        "scale may only be 0 or {}", msize_value);
@@ -4106,7 +4106,7 @@ private:
     const auto msize_value = FEXCore::ToUnderlying(msize);
     const auto msize_bytes = 1U << msize_value;
 
-    const auto imm_limit = (32U << msize_value) - msize_bytes;
+    [[maybe_unused]] const auto imm_limit = (32U << msize_value) - msize_bytes;
     const auto imm = mem_op.MetaType.VectorImmType.Imm;
     const auto imm_to_encode = imm >> msize_value;
 

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -1095,17 +1095,6 @@ FEXCore::ARMEmitter::ExtendedMemOperand Arm64JITCore::GenerateMemOperand(uint8_t
   FEX_UNREACHABLE;
 }
 
-static auto ConvertExtendedType(IR::MemOffsetType OffsetType) -> ARMEmitter::ExtendedType {
-  switch (OffsetType.Val) {
-    case IR::MEM_OFFSET_SXTX.Val: return ARMEmitter::ExtendedType::SXTX;
-    case IR::MEM_OFFSET_UXTW.Val: return ARMEmitter::ExtendedType::UXTW;
-    case IR::MEM_OFFSET_SXTW.Val: return ARMEmitter::ExtendedType::SXTW;
-
-    default: LOGMAN_MSG_A_FMT("Unhandled GenerateMemOperand OffsetType: {}", OffsetType.Val); break;
-  }
-  FEX_UNREACHABLE;
-}
-
 FEXCore::ARMEmitter::SVEMemOperand Arm64JITCore::GenerateSVEMemOperand(uint8_t AccessSize,
                                                   FEXCore::ARMEmitter::Register Base,
                                                   IR::OrderedNodeWrapper Offset,

--- a/Source/Tools/FEXLoader/LinuxSyscalls/Syscalls.cpp
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/Syscalls.cpp
@@ -687,7 +687,7 @@ uint64_t SyscallHandler::HandleBRK(FEXCore::Core::CpuStateFrame *Frame, void *Ad
 
         uint64_t RemainingSize = DataSpaceMaxSize - NewSizeAligned;
         // We have pages we can unmap
-        auto ok = GuestMunmap(Frame->Thread, reinterpret_cast<void*>(DataSpace + NewSizeAligned), RemainingSize);
+        [[maybe_unused]] auto ok = GuestMunmap(Frame->Thread, reinterpret_cast<void*>(DataSpace + NewSizeAligned), RemainingSize);
         LOGMAN_THROW_A_FMT(ok != -1, "Munmap failed");
 
         DataSpaceMaxSize = NewSizeAligned;
@@ -708,7 +708,7 @@ uint64_t SyscallHandler::HandleBRK(FEXCore::Core::CpuStateFrame *Frame, void *Ad
         if (NewBRK != ~0ULL && NewBRK != (DataSpace + DataSpaceMaxSize)) {
           // Couldn't allocate that the region we wanted
           // Can happen if MAP_FIXED_NOREPLACE isn't understood by the kernel
-          int ok = GuestMunmap(Frame->Thread, reinterpret_cast<void*>(NewBRK), AllocateNewSize);
+          [[maybe_unused]] int ok = GuestMunmap(Frame->Thread, reinterpret_cast<void*>(NewBRK), AllocateNewSize);
           LOGMAN_THROW_A_FMT(ok != -1, "Munmap failed");
           NewBRK = ~0ULL;
         }


### PR DESCRIPTION
With these, only three warnings relating to our use of `offsetof` in the dispatchers and one warning in ImGui remain.

@lioncash Could you double-check that the variables in SVEOps.inl are intentionally unused in Release builds?