### PR TITLE
ARMEmitter: Migrate off vixl float utils

### DIFF
--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ASIMDOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ASIMDOps.inl
@@ -3033,22 +3033,19 @@ public:
     uint32_t o2;
     uint32_t Imm;
     if (size == SubRegSize::i16Bit) {
-      LOGMAN_THROW_A_FMT(vixl::aarch64::Assembler::IsImmFP16(vixl::Float16(Value)), "Invalid float");
       op = 0;
       o2 = 1;
-      Imm = vixl::VFP::FP16ToImm8(vixl::Float16(Value));
+      Imm = FP16ToImm8(vixl::Float16(Value));
     }
     else if (size == SubRegSize::i32Bit) {
-      LOGMAN_THROW_A_FMT(vixl::VFP::IsImmFP32(Value), "Invalid float");
       op = 0;
       o2 = 0;
-      Imm = vixl::VFP::FP32ToImm8(Value);
+      Imm = FP32ToImm8(Value);
     }
     else if (size == SubRegSize::i64Bit) {
-      LOGMAN_THROW_A_FMT(vixl::VFP::IsImmFP64(Value), "Invalid float");
       op = 1;
       o2 = 0;
-      Imm = vixl::VFP::FP64ToImm8(Value);
+      Imm = FP64ToImm8(Value);
     }
     else {
       LOGMAN_MSG_A_FMT("Invalid subregsize");

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
@@ -4896,8 +4896,8 @@ private:
   // Alias that returns the equivalently sized unsigned type for a floating-point type T.
   template <typename T>
   requires(std::is_same_v<T, float> || std::is_same_v<T, double> || std::is_same_v<T, vixl::Float16>)
-  using FloatToEquivalentUInt = std::conditional_t<sizeof(T) == 2, uint16_t,
-                                                   std::conditional_t<sizeof(T) == 4, uint32_t, uint64_t>>;
+  using FloatToEquivalentUInt = std::conditional_t<std::is_same_v<T, vixl::Float16>, uint16_t,
+                                                   std::conditional_t<std::is_same_v<T, float>, uint32_t, uint64_t>>;
 
   // Determines if a floating-point value is capable of being converted
   // into an 8-bit immediate. See pseudocode definition of VFPExpandImm

--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ScalarOps.inl
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ScalarOps.inl
@@ -1013,18 +1013,15 @@ public:
     uint32_t imm5 = 0b0'0000;
     if (size == FEXCore::ARMEmitter::ScalarRegSize::i16Bit) {
       ptype = 0b11;
-      LOGMAN_THROW_A_FMT(vixl::aarch64::Assembler::IsImmFP16(vixl::Float16(Value)), "Invalid float");
-      imm8 = vixl::VFP::FP16ToImm8(vixl::Float16(Value));
+      imm8 = FP16ToImm8(vixl::Float16(Value));
     }
     else if (size == FEXCore::ARMEmitter::ScalarRegSize::i32Bit) {
       ptype = 0b00;
-      LOGMAN_THROW_A_FMT(vixl::VFP::IsImmFP32(Value), "Invalid float");
-      imm8 = vixl::VFP::FP32ToImm8(Value);
+      imm8 = FP32ToImm8(Value);
     }
     else if (size == FEXCore::ARMEmitter::ScalarRegSize::i64Bit) {
       ptype = 0b01;
-      LOGMAN_THROW_A_FMT(vixl::VFP::IsImmFP64(Value), "Invalid float");
-      imm8 = vixl::VFP::FP64ToImm8(Value);
+      imm8 = FP64ToImm8(Value);
     }
     else {
       FEX_UNREACHABLE;


### PR DESCRIPTION
Since we have our own now, we can lessen our dependence on vixl by shifting over to our own equivalents