### PR TITLE
Config: Minor changes

### DIFF
--- a/External/FEXCore/Source/Interface/Config/Config.cpp
+++ b/External/FEXCore/Source/Interface/Config/Config.cpp
@@ -407,7 +407,7 @@ namespace DefaultValues {
     }
     if (FEXCore::Config::Exists(FEXCore::Config::CONFIG_OUTPUTLOG)) {
       FEX_CONFIG_OPT(PathName, OUTPUTLOG);
-      if (PathName() != "stdout" && PathName() != "stderr") {
+      if (PathName() != "stdout" && PathName() != "stderr" && PathName() != "server") {
         ExpandPathIfExists(FEXCore::Config::CONFIG_OUTPUTLOG, PathName());
       }
     }

--- a/External/FEXCore/Source/Interface/Config/Config.cpp
+++ b/External/FEXCore/Source/Interface/Config/Config.cpp
@@ -412,6 +412,15 @@ namespace DefaultValues {
       }
     }
 
+    if (FEXCore::Config::Exists(FEXCore::Config::CONFIG_DUMPIR) &&
+        !FEXCore::Config::Exists(FEXCore::Config::CONFIG_PASSMANAGERDUMPIR)) {
+      // If DumpIR is set but no PassManagerDumpIR configuration is set, then default to `afteropt`
+      FEX_CONFIG_OPT(PathName, DUMPIR);
+      if (PathName() != "no") {
+        EraseSet(FEXCore::Config::ConfigOption::CONFIG_PASSMANAGERDUMPIR, fextl::fmt::format("{}", static_cast<uint64_t>(FEXCore::Config::PassManagerDumpIR::AFTEROPT)));
+      }
+    }
+
     if (FEXCore::Config::Exists(FEXCore::Config::CONFIG_SINGLESTEP)) {
       // Single stepping also enforces single instruction size blocks
       Set(FEXCore::Config::ConfigOption::CONFIG_MAXINST, "1");

--- a/External/FEXCore/Source/Interface/Config/Config.json.in
+++ b/External/FEXCore/Source/Interface/Config/Config.json.in
@@ -207,8 +207,8 @@
         "Enums": {
           "BEFOREOPT": "beforeopt",
           "AFTEROPT": "afteropt",
-          "BEFORE": "beforepass",
-          "AFTER": "afterpass"
+          "BEFOREPASS": "beforepass",
+          "AFTERPASS": "afterpass"
         },
         "Desc": [
           "Allows controlling when FEX dumps its IR.",

--- a/External/FEXCore/Source/Interface/Config/Config.json.in
+++ b/External/FEXCore/Source/Interface/Config/Config.json.in
@@ -198,7 +198,7 @@
         "Default": "no",
         "Desc": [
           "Folder to dump the IR in to.",
-          "[no, stdout, stderr, <Folder>]"
+          "[no, stdout, stderr, server, <Folder>]"
         ]
       },
       "PassManagerDumpIR": {

--- a/External/FEXCore/Source/Interface/IR/PassManager.cpp
+++ b/External/FEXCore/Source/Interface/IR/PassManager.cpp
@@ -25,18 +25,18 @@ void PassManager::Finalize() {
 
   auto it = Passes.begin();
   // Walk the passes and add them where asked.
-  if (PassManagerDumpIR() & FEXCore::Config::PassManagerDumpIR::BEFORE) {
+  if (PassManagerDumpIR() & FEXCore::Config::PassManagerDumpIR::BEFOREOPT) {
     // Insert at the start.
     it = InsertAt(it, Debug::CreateIRDumper());
     ++it; // Skip what we inserted.
   }
 
-  if ((PassManagerDumpIR() & FEXCore::Config::PassManagerDumpIR::BEFOREOPT) ||
-      (PassManagerDumpIR() & FEXCore::Config::PassManagerDumpIR::AFTEROPT)) {
+  if ((PassManagerDumpIR() & FEXCore::Config::PassManagerDumpIR::BEFOREPASS) ||
+      (PassManagerDumpIR() & FEXCore::Config::PassManagerDumpIR::AFTERPASS)) {
 
-    bool SkipFirstBefore = PassManagerDumpIR() & FEXCore::Config::PassManagerDumpIR::BEFORE;
+    bool SkipFirstBefore = PassManagerDumpIR() & FEXCore::Config::PassManagerDumpIR::BEFOREOPT;
     for (; it != Passes.end();) {
-      if (PassManagerDumpIR() & FEXCore::Config::PassManagerDumpIR::BEFOREOPT) {
+      if (PassManagerDumpIR() & FEXCore::Config::PassManagerDumpIR::BEFOREPASS) {
         if (SkipFirstBefore) {
           // If we need to skip the first one, then continue.
           SkipFirstBefore = false;
@@ -50,15 +50,15 @@ void PassManager::Finalize() {
       }
 
       ++it; // Skip current pass.
-      if (PassManagerDumpIR() & FEXCore::Config::PassManagerDumpIR::AFTEROPT) {
+      if (PassManagerDumpIR() & FEXCore::Config::PassManagerDumpIR::AFTERPASS) {
         // Insert after
         it = InsertAt(it, Debug::CreateIRDumper());
         ++it; // Skip what we inserted.
       }
     }
   }
-  if (PassManagerDumpIR() & FEXCore::Config::PassManagerDumpIR::AFTER) {
-    if (!(PassManagerDumpIR() & FEXCore::Config::PassManagerDumpIR::AFTEROPT)) {
+  if (PassManagerDumpIR() & FEXCore::Config::PassManagerDumpIR::AFTEROPT) {
+    if (!(PassManagerDumpIR() & FEXCore::Config::PassManagerDumpIR::AFTERPASS)) {
       // Insert final IRDumper.
       it = InsertAt(it, Debug::CreateIRDumper());
     }

--- a/Source/Tools/FEXLoader/TestHarnessRunner.cpp
+++ b/Source/Tools/FEXLoader/TestHarnessRunner.cpp
@@ -211,6 +211,8 @@ int main(int argc, char **argv, char **const envp) {
   FEXCore::Allocator::GLIBCScopedFault GLIBFaultScope;
   LogMan::Throw::InstallHandler(AssertHandler);
   LogMan::Msg::InstallHandler(MsgHandler);
+
+  FEX::Config::InitializeConfigs();
   FEXCore::Config::Initialize();
   FEXCore::Config::AddLayer(fextl::make_unique<FEX::ArgLoader::ArgLoader>(argc, argv));
   FEXCore::Config::AddLayer(FEX::Config::CreateEnvironmentLayer(envp));


### PR DESCRIPTION
Main change here is fixing a logic bug in the IRDumper, using the wrong config option for dumping around each optimization pass versus before and after all passes.
And then automatically enabling one of the dump options if DumpIR has been set.