### PR TITLE
InstCountCI: Ensure output nasm name doesn't conflict

### DIFF
--- a/Scripts/InstructionCountParser.py
+++ b/Scripts/InstructionCountParser.py
@@ -66,7 +66,7 @@ def GetHostFeatures(data):
         HostFeaturesData |= HostFeaturesLookup[data_key]
     return HostFeaturesData
 
-def parse_json_data(json_data, output_binary_path):
+def parse_json_data(json_filename, json_data, output_binary_path):
     Bitness = 64
     EnabledHostFeatures = HostFeatures.FEATURE_ANY
     DisabledHostFeatures = HostFeatures.FEATURE_ANY
@@ -96,7 +96,7 @@ def parse_json_data(json_data, output_binary_path):
                 if items["Skip"].upper() == "YES":
                     continue
 
-        TestName = base64.b64encode(key.encode("ascii")).decode("ascii")
+        TestName = base64.b64encode("{}.{}".format(json_filename, key).encode("ascii")).decode("ascii")
         tmp_asm = "/tmp/{}.asm".format(TestName)
         tmp_asm_out = "/tmp/{}.asm.o".format(TestName)
         logging.info("'{}' -> '{}' -> '{}'".format(key, tmp_asm, tmp_asm_out))
@@ -192,7 +192,7 @@ def main():
         if not isinstance(json_data, dict):
             raise TypeError('JSON data must be a dict')
 
-        return parse_json_data(json_data, output_binary_path)
+        return parse_json_data(os.path.basename(json_path), json_data, output_binary_path)
 
     except ValueError as ve:
         logging.error(f'JSON error: {ve}')


### PR DESCRIPTION
Pretty sure this is why CI is unhappy. If a test in a different file has the same name then it is highly likely to conflict when nasm is generating files and will overwrite and erase, causing CI to break.

Include the incoming json filename as part of the asm keys so it can't conflict here.