### PR TITLE
Arm64/VectorOps: Remove redundant move in VFRSqrt SVE path

### DIFF
--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -1018,10 +1018,9 @@ DEF_OP(VFRSqrt) {
 
   if (HostSupportsSVE256 && Is256Bit) {
     const auto Pred = PRED_TMP_32B.Merging();
-    fmov(SubRegSize.Vector, VTMP1.Z(), 1.0);
-    fsqrt(SubRegSize.Vector, VTMP2.Z(), Pred, Vector.Z());
-    fdiv(SubRegSize.Vector, VTMP1.Z(), Pred, VTMP1.Z(), VTMP2.Z());
-    mov(Dst.Z(), VTMP1.Z());
+    fsqrt(SubRegSize.Vector, VTMP1.Z(), Pred, Vector.Z());
+    fmov(SubRegSize.Vector, Dst.Z(), 1.0);
+    fdiv(SubRegSize.Vector, Dst.Z(), Pred, Dst.Z(), VTMP1.Z());
   } else {
     if (IsScalar) {
       fmov(SubRegSize.Scalar, VTMP1.Q(), 1.0);

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -374,7 +374,7 @@
       ]
     },
     "vrsqrtps ymm0, ymm1": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "FEAT_FPRES could make this more optimal",


### PR DESCRIPTION
We can perform the SQRT first and then broadcast 1.0 into the destination since all the intermediary work is done, meaning we don't have to worry about Dst and Vector aliasing one another