### PR TITLE
InstCountCI: Disables tests with unsupported configurations

### DIFF
--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -19,4 +19,7 @@ endif()
 
 add_subdirectory(ASM/)
 add_subdirectory(32Bit_ASM/)
-add_subdirectory(InstructionCountCI/)
+if (ENABLE_VIXL_DISASSEMBLER AND (ENABLE_JIT_ARM64 OR CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch64|^arm64|^armv8\.*") AND NOT ENABLE_JIT_X86_64)
+  # Tests are only valid to run if the vixl disassembler is enabled and the active JIT is the ARM64 JIT.
+  add_subdirectory(InstructionCountCI/)
+endif()


### PR DESCRIPTION
Need to have the vixl disassembler enabled for instcountci.

Also need to make sure the host platform is using the ARM64 JIT.