### PR TITLE
OpcodeDispatcher: Eliminate unnecessary moves in AVXVectorUnaryOpImpl

### DIFF
--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -760,10 +760,11 @@ void OpDispatchBuilder::AVXVectorUnaryOpImpl(OpcodeArgs, IROps IROp, size_t Elem
     // Insert the lower bits
     Result = _VInsElement(DstSize, ElementSize, 0, 0, Dest, Result);
   }
-  if (Is128Bit) {
-    // Clear the upper lane.
-    Result = _VMov(16, Result);
-  }
+
+  // NOTE: We don't need to clear the upper lanes here, since the
+  //       IR ops make use of 128-bit AdvSimd for 128-bit cases,
+  //       which, on hardware with SVE, zero-extends as part of
+  //       storing into the destination.
 
   StoreResult(FPRClass, Op, Result, -1);
 }

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -322,7 +322,7 @@
       ]
     },
     "vsqrtps xmm0, xmm1": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x51 128-bit"
@@ -336,7 +336,7 @@
       ]
     },
     "vsqrtpd xmm0, xmm1": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x51 128-bit"
@@ -350,7 +350,7 @@
       ]
     },
     "vsqrtss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 11,
       "Optimal": "No",
       "Comment": [
         "Insert in to first element could be more optimal, which is the common case.",
@@ -358,7 +358,7 @@
       ]
     },
     "vsqrtsd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 9,
       "Optimal": "No",
       "Comment": [
         "Insert in to first element could be more optimal, which is the common case.",
@@ -366,7 +366,7 @@
       ]
     },
     "vrsqrtps xmm0, xmm1": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "FEAT_FPRES could make this more optimal",
@@ -382,7 +382,7 @@
       ]
     },
     "vrsqrtss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 14,
+      "ExpectedInstructionCount": 13,
       "Optimal": "No",
       "Comment": [
         "FEAT_FPRES could make this more optimal",
@@ -390,7 +390,7 @@
       ]
     },
     "vrcpps xmm0, xmm1": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "FEAT_FPRES could make this more optimal",
@@ -406,7 +406,7 @@
       ]
     },
     "vrcpss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 13,
+      "ExpectedInstructionCount": 12,
       "Optimal": "No",
       "Comment": [
         "FEAT_FPRES could make this more optimal",

--- a/unittests/InstructionCountCI/VEX_map2.json
+++ b/unittests/InstructionCountCI/VEX_map2.json
@@ -297,7 +297,7 @@
       ]
     },
     "vpabsb xmm0, xmm1": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x1c 128-bit"
@@ -311,7 +311,7 @@
       ]
     },
     "vpabsw xmm0, xmm1": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x1d 128-bit"
@@ -325,7 +325,7 @@
       ]
     },
     "vpabsd xmm0, xmm1": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x1e 128-bit"


### PR DESCRIPTION
We no longer need to do any manual zero-extending here, since this will occur automatically on hardware with SVE when AdvSIMD is used