### PR TITLE
InstCountCI: Adds RNG support

### DIFF
--- a/Scripts/InstructionCountParser.py
+++ b/Scripts/InstructionCountParser.py
@@ -45,12 +45,13 @@ class HostFeatures(Flag) :
     FEATURE_SVE128 = (1 << 0)
     FEATURE_SVE256 = (1 << 1)
     FEATURE_CLZERO = (1 << 2)
-
+    FEATURE_RNG    = (1 << 3)
 
 HostFeaturesLookup = {
     "SVE128"  : HostFeatures.FEATURE_SVE128,
     "SVE256"  : HostFeatures.FEATURE_SVE256,
     "CLZERO"  : HostFeatures.FEATURE_CLZERO,
+    "RNG"     : HostFeatures.FEATURE_RNG,
 }
 
 def GetHostFeatures(data):

--- a/Source/Tools/CodeSizeValidation/Main.cpp
+++ b/Source/Tools/CodeSizeValidation/Main.cpp
@@ -389,6 +389,7 @@ int main(int argc, char **argv, char **const envp) {
     FEATURE_SVE128 = (1U << 0),
     FEATURE_SVE256 = (1U << 1),
     FEATURE_CLZERO = (1U << 2),
+    FEATURE_RNG    = (1U << 3),
   };
 
   uint64_t SVEWidth = 0;
@@ -404,6 +405,9 @@ int main(int argc, char **argv, char **const envp) {
   if (TestHeaderData->EnabledHostFeatures & FEATURE_CLZERO) {
     HostFeatureControl |= static_cast<uint64_t>(FEXCore::Config::HostFeatures::ENABLECLZERO);
   }
+  if (TestHeaderData->EnabledHostFeatures & FEATURE_RNG) {
+    HostFeatureControl |= static_cast<uint64_t>(FEXCore::Config::HostFeatures::ENABLERNG);
+  }
 
   if (TestHeaderData->DisabledHostFeatures & FEATURE_SVE128) {
     HostFeatureControl |= static_cast<uint64_t>(FEXCore::Config::HostFeatures::DISABLESVE);
@@ -413,6 +417,9 @@ int main(int argc, char **argv, char **const envp) {
   }
   if (TestHeaderData->DisabledHostFeatures & FEATURE_CLZERO) {
     HostFeatureControl |= static_cast<uint64_t>(FEXCore::Config::HostFeatures::DISABLECLZERO);
+  }
+  if (TestHeaderData->DisabledHostFeatures & FEATURE_RNG) {
+    HostFeatureControl |= static_cast<uint64_t>(FEXCore::Config::HostFeatures::DISABLERNG);
   }
   FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_HOSTFEATURES, fextl::fmt::format("{}", HostFeatureControl));
   FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_FORCESVEWIDTH, fextl::fmt::format("{}", SVEWidth));

--- a/unittests/InstructionCountCI/SecondaryGroup.json
+++ b/unittests/InstructionCountCI/SecondaryGroup.json
@@ -1,7 +1,9 @@
 {
   "Features": {
     "Bitness": 64,
-    "EnabledHostFeatures": [],
+    "EnabledHostFeatures": [
+      "RNG"
+    ],
     "DisabledHostFeatures": [
       "SVE128",
       "SVE256"


### PR DESCRIPTION
Some instructions in the SecondaryGroup need RNG support for testing.