### PR TITLE
GIthub: Only enable InstCountCI on an ARM platform

### DIFF
--- a/.github/workflows/instcountci.yml
+++ b/.github/workflows/instcountci.yml
@@ -1,4 +1,4 @@
-name: Vixl Simulator run
+name: Instruction Count CI run
 
 on:
   push:
@@ -20,8 +20,7 @@ jobs:
     runs-on: ${{ matrix.arch }}
     strategy:
       matrix:
-        # Only the x86-64 runner is fast enough to run this
-        arch: [[self-hosted, x64], [self-hosted, ARMv8.4]]
+        arch: [[self-hosted, ARM64]]
       fail-fast: false
 
     steps:
@@ -65,52 +64,25 @@ jobs:
       # Note the current convention is to use the -S and -B options here to specify source
       # and build directories, but this is only available with CMake 3.13 and higher.
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -G Ninja -DENABLE_VIXL_SIMULATOR=True -DENABLE_VIXL_DISASSEMBLER=True -DENABLE_LTO=False -DENABLE_ASSERTIONS=True -DENABLE_X86_HOST_DEBUG=True
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -G Ninja -DENABLE_VIXL_SIMULATOR=False -DENABLE_VIXL_DISASSEMBLER=True -DENABLE_LTO=False -DENABLE_ASSERTIONS=True
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
       shell: bash
       # Execute the build.  You can specify a specific target with "--target <NAME>"
-      run: cmake --build . --config $BUILD_TYPE
+      run: cmake --build . --config $BUILD_TYPE --target CodeSizeValidation instcountci_test_files
 
-    - name: ASM Tests
+    - name: Instruction Count Tests
       working-directory: ${{runner.workspace}}/build
       shell: bash
       # Execute the unit tests
-      run: cmake --build . --config $BUILD_TYPE --target asm_tests
+      run: cmake --build . --config $BUILD_TYPE --target instcountci_tests
 
-    - name: ASM Test Results move
+    - name: Instruction Count Test Results move
       if: ${{ always() }}
       shell: bash
       working-directory: ${{runner.workspace}}/build
-      run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_ASM.log || true
-
-    - name: ASM Tests 128-bit
-      working-directory: ${{runner.workspace}}/build
-      shell: bash
-      env:
-        FEX_HOSTFEATURES: "disableavx"
-        FEX_FORCESVEWIDTH: "128"
-      # Execute the unit tests
-      run: cmake --build . --config $BUILD_TYPE --target asm_tests
-
-    - name: ASM Test 128-bit Results move
-      if: ${{ always() }}
-      shell: bash
-      working-directory: ${{runner.workspace}}/build
-      run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_ASM128bit.log || true
-
-    - name: IR Tests
-      working-directory: ${{runner.workspace}}/build
-      shell: bash
-      # Execute the unit tests
-      run: cmake --build . --config $BUILD_TYPE --target ir_tests
-
-    - name: IR Test Results move
-      if: ${{ always() }}
-      shell: bash
-      working-directory: ${{runner.workspace}}/build
-      run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_IR.log || true
+      run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_InstCountCI.log || true
 
     - name: Truncate test results
       if: ${{ always() }}

--- a/External/FEXCore/Source/Interface/Config/Config.json.in
+++ b/External/FEXCore/Source/Interface/Config/Config.json.in
@@ -72,7 +72,9 @@
           "ENABLERNG": "enablerng",
           "DISABLERNG": "disablerng",
           "ENABLECLZERO": "enableclzero",
-          "DISABLECLZERO": "disableclzero"
+          "DISABLECLZERO": "disableclzero",
+          "ENABLEATOMICS": "enableatomics",
+          "DISABLEATOMICS": "disableatomics"
         },
         "Desc": [
           "Allows controlling of the CPU features in the JIT.",
@@ -85,7 +87,8 @@
           "\t{enable,disable}cssc: Will force enable or disable cssc even if the host doesn't support it",
           "\t{enable,disable}pmull128: Will force enable or disable pmull128 even if the host doesn't support it",
           "\t{enable,disable}rng: Will force enable or disable rng even if the host doesn't support it",
-          "\t{enable,disable}clzero: Will force enable or disable clzero even if the host doesn't support it"
+          "\t{enable,disable}clzero: Will force enable or disable clzero even if the host doesn't support it",
+          "\t{enable,disable}atomics: Will force enable or disable ARMv8.1 LSE atomics even if the host doesn't support it"
         ]
       }
     },

--- a/External/FEXCore/Source/Interface/Core/HostFeatures.cpp
+++ b/External/FEXCore/Source/Interface/Core/HostFeatures.cpp
@@ -92,6 +92,10 @@ static void OverrideFeatures(HostFeatures *Features) {
   const bool EnableCLZERO = HostFeatures() & FEXCore::Config::HostFeatures::ENABLECLZERO;
   LogMan::Throw::AFmt(!(DisableCLZERO && EnableCLZERO), "Disabling and Enabling CPU features are mutually exclusive");
 
+  const bool DisableAtomics = HostFeatures() & FEXCore::Config::HostFeatures::DISABLEATOMICS;
+  const bool EnableAtomics = HostFeatures() & FEXCore::Config::HostFeatures::ENABLEATOMICS;
+  LogMan::Throw::AFmt(!(DisableAtomics && EnableAtomics), "Disabling and Enabling CPU features are mutually exclusive");
+
   if (EnableAVX) {
     Features->SupportsAVX = true;
   }
@@ -145,6 +149,12 @@ static void OverrideFeatures(HostFeatures *Features) {
   }
   else if (DisableCLZERO) {
     Features->SupportsCLZERO = false;
+  }
+  if (EnableAtomics) {
+    Features->SupportsAtomics = true;
+  }
+  else if (DisableAtomics) {
+    Features->SupportsAtomics = false;
   }
 }
 

--- a/Source/Tools/CodeSizeValidation/Main.cpp
+++ b/Source/Tools/CodeSizeValidation/Main.cpp
@@ -405,6 +405,9 @@ int main(int argc, char **argv, char **const envp) {
     HostFeatureControl |= static_cast<uint64_t>(FEXCore::Config::HostFeatures::ENABLECLZERO);
   }
 
+  // Always enable ARMv8.1 LSE atomics.
+  HostFeatureControl |= static_cast<uint64_t>(FEXCore::Config::HostFeatures::ENABLEATOMICS);
+
   if (TestHeaderData->DisabledHostFeatures & FEATURE_SVE128) {
     HostFeatureControl |= static_cast<uint64_t>(FEXCore::Config::HostFeatures::DISABLESVE);
   }

--- a/unittests/InstructionCountCI/CMakeLists.txt
+++ b/unittests/InstructionCountCI/CMakeLists.txt
@@ -55,6 +55,7 @@ add_custom_target(
   instcountci_tests
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   USES_TERMINAL
+  DEPENDS instcountci_test_files
   COMMAND "ctest" "--timeout" "302" "-j${CORES}" "-R" "InstCountCI/\.*.instcountci$$")
 
 add_custom_target(


### PR DESCRIPTION
simulator generates some instruction count differences that we don't care about. Just run this on ARM platforms only instead.