### PR TITLE
FEXCore/IR: Fixes bug in IRDumper without specification

### DIFF
--- a/External/FEXCore/Source/Interface/IR/PassManager.cpp
+++ b/External/FEXCore/Source/Interface/IR/PassManager.cpp
@@ -60,7 +60,7 @@ void PassManager::Finalize() {
   if (PassManagerDumpIR() & FEXCore::Config::PassManagerDumpIR::AFTEROPT) {
     if (!(PassManagerDumpIR() & FEXCore::Config::PassManagerDumpIR::AFTERPASS)) {
       // Insert final IRDumper.
-      it = InsertAt(it, Debug::CreateIRDumper());
+      InsertAt(Passes.end(), Debug::CreateIRDumper());
     }
   }
 }


### PR DESCRIPTION
Didn't notice this in the previous PR, When DUMPIR=stderr without and selection of where to place it in PASSMANAGERDUMPIR it was supposed to put the dumper at the end of the passes.

We need to make sure that it it placed at the end of the passes rather than current `it`.