### PR TITLE
Filemanagement: Optimize GetSelf using a string_view 

### DIFF
--- a/External/FEXCore/include/FEXCore/Config/Config.h
+++ b/External/FEXCore/include/FEXCore/Config/Config.h
@@ -286,7 +286,13 @@ namespace Type {
     }
 
     operator T() const { return ValueData; }
+
+    template <typename TT = T> requires (!std::is_same_v<TT, fextl::string>)
     T operator()() const { return ValueData; }
+
+    template <typename TT = T> requires (std::is_same_v<TT, fextl::string>)
+    const T& operator()() const { return ValueData; }
+
     Value<T>(T Value) { ValueData = std::move(Value); }
     fextl::list<T> &All() { return AppendList; }
 

--- a/Source/Tools/FEXLoader/LinuxSyscalls/FileManagement.cpp
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/FileManagement.cpp
@@ -469,7 +469,7 @@ std::pair<int, const char*> FileManager::GetEmulatedFDPath(int dirfd, const char
   return std::make_pair(RootFSFD, &SubPath[1]);
 }
 
-std::optional<fextl::string> FileManager::GetSelf(const char *Pathname) {
+std::optional<std::string_view> FileManager::GetSelf(const char *Pathname) {
   if (!Pathname) {
     return std::nullopt;
   }
@@ -507,7 +507,7 @@ static bool ShouldSkipOpenInEmu(int flags) {
 
 uint64_t FileManager::Open(const char *pathname, int flags, uint32_t mode) {
   auto NewPath = GetSelf(pathname);
-  const char *SelfPath = NewPath ? NewPath->c_str() : nullptr;
+  const char *SelfPath = NewPath ? NewPath->data() : nullptr;
   int fd = -1;
 
   if (!ShouldSkipOpenInEmu(flags)) {
@@ -541,7 +541,7 @@ uint64_t FileManager::CloseRange(unsigned int first, unsigned int last, unsigned
 
 uint64_t FileManager::Stat(const char *pathname, void *buf) {
   auto NewPath = GetSelf(pathname);
-  const char *SelfPath = NewPath ? NewPath->c_str() : nullptr;
+  const char *SelfPath = NewPath ? NewPath->data() : nullptr;
 
   // Stat follows symlinks
   FDPathTmpData TmpFilename;
@@ -556,7 +556,7 @@ uint64_t FileManager::Stat(const char *pathname, void *buf) {
 
 uint64_t FileManager::Lstat(const char *pathname, void *buf) {
   auto NewPath = GetSelf(pathname);
-  const char *SelfPath = NewPath ? NewPath->c_str() : nullptr;
+  const char *SelfPath = NewPath ? NewPath->data() : nullptr;
 
   // lstat does not follow symlinks
   FDPathTmpData TmpFilename;
@@ -572,7 +572,7 @@ uint64_t FileManager::Lstat(const char *pathname, void *buf) {
 
 uint64_t FileManager::Access(const char *pathname, [[maybe_unused]] int mode) {
   auto NewPath = GetSelf(pathname);
-  const char *SelfPath = NewPath ? NewPath->c_str() : nullptr;
+  const char *SelfPath = NewPath ? NewPath->data() : nullptr;
 
   // Access follows symlinks
   FDPathTmpData TmpFilename;
@@ -587,7 +587,7 @@ uint64_t FileManager::Access(const char *pathname, [[maybe_unused]] int mode) {
 
 uint64_t FileManager::FAccessat(int dirfd, const char *pathname, int mode) {
   auto NewPath = GetSelf(pathname);
-  const char *SelfPath = NewPath ? NewPath->c_str() : nullptr;
+  const char *SelfPath = NewPath ? NewPath->data() : nullptr;
 
   FDPathTmpData TmpFilename;
   auto Path = GetEmulatedFDPath(dirfd, SelfPath, true, TmpFilename);
@@ -602,7 +602,7 @@ uint64_t FileManager::FAccessat(int dirfd, const char *pathname, int mode) {
 
 uint64_t FileManager::FAccessat2(int dirfd, const char *pathname, int mode, int flags) {
   auto NewPath = GetSelf(pathname);
-  const char *SelfPath = NewPath ? NewPath->c_str() : nullptr;
+  const char *SelfPath = NewPath ? NewPath->data() : nullptr;
 
   FDPathTmpData TmpFilename;
   auto Path = GetEmulatedFDPath(dirfd, SelfPath, (flags & AT_SYMLINK_NOFOLLOW) == 0, TmpFilename);
@@ -649,7 +649,7 @@ uint64_t FileManager::Readlink(const char *pathname, char *buf, size_t bufsiz) {
 
 uint64_t FileManager::Chmod(const char *pathname, mode_t mode) {
   auto NewPath = GetSelf(pathname);
-  const char *SelfPath = NewPath ? NewPath->c_str() : nullptr;
+  const char *SelfPath = NewPath ? NewPath->data() : nullptr;
 
   FDPathTmpData TmpFilename;
   auto Path = GetEmulatedFDPath(AT_FDCWD, SelfPath, false, TmpFilename);
@@ -727,7 +727,7 @@ uint64_t FileManager::Readlinkat(int dirfd, const char *pathname, char *buf, siz
 
 uint64_t FileManager::Openat([[maybe_unused]] int dirfs, const char *pathname, int flags, uint32_t mode) {
   auto NewPath = GetSelf(pathname);
-  const char *SelfPath = NewPath ? NewPath->c_str() : nullptr;
+  const char *SelfPath = NewPath ? NewPath->data() : nullptr;
 
   int32_t fd = -1;
 
@@ -751,7 +751,7 @@ uint64_t FileManager::Openat([[maybe_unused]] int dirfs, const char *pathname, i
 
 uint64_t FileManager::Openat2(int dirfs, const char *pathname, FEX::HLE::open_how *how, size_t usize) {
   auto NewPath = GetSelf(pathname);
-  const char *SelfPath = NewPath ? NewPath->c_str() : nullptr;
+  const char *SelfPath = NewPath ? NewPath->data() : nullptr;
 
   int32_t fd = -1;
 
@@ -776,7 +776,7 @@ uint64_t FileManager::Openat2(int dirfs, const char *pathname, FEX::HLE::open_ho
 
 uint64_t FileManager::Statx(int dirfd, const char *pathname, int flags, uint32_t mask, struct statx *statxbuf) {
   auto NewPath = GetSelf(pathname);
-  const char *SelfPath = NewPath ? NewPath->c_str() : nullptr;
+  const char *SelfPath = NewPath ? NewPath->data() : nullptr;
 
   FDPathTmpData TmpFilename;
   auto Path = GetEmulatedFDPath(dirfd, SelfPath, (flags & AT_SYMLINK_NOFOLLOW) == 0, TmpFilename);
@@ -790,7 +790,7 @@ uint64_t FileManager::Statx(int dirfd, const char *pathname, int flags, uint32_t
 
 uint64_t FileManager::Mknod(const char *pathname, mode_t mode, dev_t dev) {
   auto NewPath = GetSelf(pathname);
-  const char *SelfPath = NewPath ? NewPath->c_str() : nullptr;
+  const char *SelfPath = NewPath ? NewPath->data() : nullptr;
 
   FDPathTmpData TmpFilename;
   auto Path = GetEmulatedFDPath(AT_FDCWD, SelfPath, false, TmpFilename);
@@ -814,7 +814,7 @@ uint64_t FileManager::Statfs(const char *path, void *buf) {
 
 uint64_t FileManager::NewFSStatAt(int dirfd, const char *pathname, struct stat *buf, int flag) {
   auto NewPath = GetSelf(pathname);
-  const char *SelfPath = NewPath ? NewPath->c_str() : nullptr;
+  const char *SelfPath = NewPath ? NewPath->data() : nullptr;
 
   FDPathTmpData TmpFilename;
   auto Path = GetEmulatedFDPath(dirfd, SelfPath, (flag & AT_SYMLINK_NOFOLLOW) == 0, TmpFilename);
@@ -829,7 +829,7 @@ uint64_t FileManager::NewFSStatAt(int dirfd, const char *pathname, struct stat *
 
 uint64_t FileManager::NewFSStatAt64(int dirfd, const char *pathname, struct stat64 *buf, int flag) {
   auto NewPath = GetSelf(pathname);
-  const char *SelfPath = NewPath ? NewPath->c_str() : nullptr;
+  const char *SelfPath = NewPath ? NewPath->data() : nullptr;
 
   FDPathTmpData TmpFilename;
   auto Path = GetEmulatedFDPath(dirfd, SelfPath, (flag & AT_SYMLINK_NOFOLLOW) == 0, TmpFilename);
@@ -844,7 +844,7 @@ uint64_t FileManager::NewFSStatAt64(int dirfd, const char *pathname, struct stat
 
 uint64_t FileManager::Setxattr(const char *path, const char *name, const void *value, size_t size, int flags) {
   auto NewPath = GetSelf(path);
-  const char *SelfPath = NewPath ? NewPath->c_str() : nullptr;
+  const char *SelfPath = NewPath ? NewPath->data() : nullptr;
 
   auto Path = GetEmulatedPath(SelfPath, true);
   if (!Path.empty()) {
@@ -859,7 +859,7 @@ uint64_t FileManager::Setxattr(const char *path, const char *name, const void *v
 
 uint64_t FileManager::LSetxattr(const char *path, const char *name, const void *value, size_t size, int flags) {
   auto NewPath = GetSelf(path);
-  const char *SelfPath = NewPath ? NewPath->c_str() : nullptr;
+  const char *SelfPath = NewPath ? NewPath->data() : nullptr;
 
   auto Path = GetEmulatedPath(SelfPath, false);
   if (!Path.empty()) {
@@ -874,7 +874,7 @@ uint64_t FileManager::LSetxattr(const char *path, const char *name, const void *
 
 uint64_t FileManager::Getxattr(const char *path, const char *name, void *value, size_t size) {
   auto NewPath = GetSelf(path);
-  const char *SelfPath = NewPath ? NewPath->c_str() : nullptr;
+  const char *SelfPath = NewPath ? NewPath->data() : nullptr;
 
   auto Path = GetEmulatedPath(SelfPath, true);
   if (!Path.empty()) {
@@ -889,7 +889,7 @@ uint64_t FileManager::Getxattr(const char *path, const char *name, void *value, 
 
 uint64_t FileManager::LGetxattr(const char *path, const char *name, void *value, size_t size) {
   auto NewPath = GetSelf(path);
-  const char *SelfPath = NewPath ? NewPath->c_str() : nullptr;
+  const char *SelfPath = NewPath ? NewPath->data() : nullptr;
 
   auto Path = GetEmulatedPath(SelfPath, false);
   if (!Path.empty()) {
@@ -904,7 +904,7 @@ uint64_t FileManager::LGetxattr(const char *path, const char *name, void *value,
 
 uint64_t FileManager::Listxattr(const char *path, char *list, size_t size) {
   auto NewPath = GetSelf(path);
-  const char *SelfPath = NewPath ? NewPath->c_str() : nullptr;
+  const char *SelfPath = NewPath ? NewPath->data() : nullptr;
 
   auto Path = GetEmulatedPath(SelfPath, true);
   if (!Path.empty()) {
@@ -919,7 +919,7 @@ uint64_t FileManager::Listxattr(const char *path, char *list, size_t size) {
 
 uint64_t FileManager::LListxattr(const char *path, char *list, size_t size) {
   auto NewPath = GetSelf(path);
-  const char *SelfPath = NewPath ? NewPath->c_str() : nullptr;
+  const char *SelfPath = NewPath ? NewPath->data() : nullptr;
 
   auto Path = GetEmulatedPath(SelfPath, false);
   if (!Path.empty()) {
@@ -934,7 +934,7 @@ uint64_t FileManager::LListxattr(const char *path, char *list, size_t size) {
 
 uint64_t FileManager::Removexattr(const char *path, const char *name) {
   auto NewPath = GetSelf(path);
-  const char *SelfPath = NewPath ? NewPath->c_str() : nullptr;
+  const char *SelfPath = NewPath ? NewPath->data() : nullptr;
 
   auto Path = GetEmulatedPath(SelfPath, true);
   if (!Path.empty()) {
@@ -949,7 +949,7 @@ uint64_t FileManager::Removexattr(const char *path, const char *name) {
 
 uint64_t FileManager::LRemovexattr(const char *path, const char *name) {
   auto NewPath = GetSelf(path);
-  const char *SelfPath = NewPath ? NewPath->c_str() : nullptr;
+  const char *SelfPath = NewPath ? NewPath->data() : nullptr;
 
   auto Path = GetEmulatedPath(SelfPath, false);
   if (!Path.empty()) {

--- a/Source/Tools/FEXLoader/LinuxSyscalls/FileManagement.h
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/FileManagement.h
@@ -77,7 +77,7 @@ public:
   // vfs
   uint64_t Statfs(const char *path, void *buf);
 
-  std::optional<fextl::string> GetSelf(const char *Pathname);
+  std::optional<std::string_view> GetSelf(const char *Pathname);
 
   void UpdatePID(uint32_t PID) { CurrentPID = PID; }
 


### PR DESCRIPTION
Instead of allocating a temporary copy of the string, return a view of
it instead. Should improve the performance of system calls that take
file paths. Since it was allocating a string for every single syscall
that uses them in this case.