### PR TITLE
IR: Add VBroadcastFromMem opcode 

### DIFF
--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -153,6 +153,7 @@ constexpr OpHandlerArray InterpreterOpHandlers = [] {
   REGISTER_OP(STOREMEMTSO,            StoreMem);
   REGISTER_OP(VLOADVECTORMASKED,      VLoadVectorMasked);
   REGISTER_OP(VSTOREVECTORMASKED,     VStoreVectorMasked);
+  REGISTER_OP(VBROADCASTFROMMEM,      VBroadcastFromMem);
   REGISTER_OP(MEMSET,                 MemSet);
   REGISTER_OP(MEMCPY,                 MemCpy);
   REGISTER_OP(CACHELINECLEAR,         CacheLineClear);

--- a/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
+++ b/External/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
@@ -187,6 +187,7 @@ namespace FEXCore::CPU {
   DEF_OP(StoreMem);
   DEF_OP(VLoadVectorMasked);
   DEF_OP(VStoreVectorMasked);
+  DEF_OP(VBroadcastFromMem);
   DEF_OP(MemSet);
   DEF_OP(MemCpy);
   DEF_OP(CacheLineClear);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -964,7 +964,7 @@ CPUBackend::CompiledCode Arm64JITCore::CompileCode(uint64_t Entry,
         REGISTER_OP_RT(STOREMEMTSO,      StoreMemTSO);
         REGISTER_OP(VLOADVECTORMASKED,   VLoadVectorMasked);
         REGISTER_OP(VSTOREVECTORMASKED,  VStoreVectorMasked);
-
+        REGISTER_OP(VBROADCASTFROMMEM,   VBroadcastFromMem);
         REGISTER_OP(MEMSET,              MemSet);
         REGISTER_OP(MEMCPY,              MemCpy);
         REGISTER_OP(CACHELINECLEAR,      CacheLineClear);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -342,6 +342,7 @@ private:
   DEF_OP(StoreMemTSO);
   DEF_OP(VLoadVectorMasked);
   DEF_OP(VStoreVectorMasked);
+  DEF_OP(VBroadcastFromMem);
   DEF_OP(MemSet);
   DEF_OP(MemCpy);
   DEF_OP(ParanoidLoadMemTSO);

--- a/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/External/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -1489,6 +1489,11 @@ DEF_OP(VBroadcastFromMem) {
       return;
     }
   }
+
+  // Emit a half-barrier if TSO is enabled.
+  if (CTX->IsAtomicTSOEnabled()) {
+    dmb(ARMEmitter::BarrierScope::ISHLD);
+  }
 }
 
 DEF_OP(StoreMem) {

--- a/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/External/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -348,6 +348,7 @@ private:
   DEF_OP(StoreMem);
   DEF_OP(VLoadVectorMasked);
   DEF_OP(VStoreVectorMasked);
+  DEF_OP(VBroadcastFromMem);
   DEF_OP(MemSet);
   DEF_OP(MemCpy);
   DEF_OP(CacheLineClear);

--- a/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/External/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -1257,8 +1257,6 @@ void OpDispatchBuilder::VHADDPOp<IR::OP_VFADDP, 8>(OpcodeArgs);
 template <size_t ElementSize>
 void OpDispatchBuilder::VBROADCASTOp(OpcodeArgs) {
   const auto DstSize = GetDstSize(Op);
-  const auto Is128Bit = DstSize == Core::CPUState::XMM_SSE_REG_SIZE;
-
   OrderedNode *Result{};
 
   if (Op->Src[0].IsGPR()) {
@@ -1278,9 +1276,8 @@ void OpDispatchBuilder::VBROADCASTOp(OpcodeArgs) {
     }
   }
 
-  if (Is128Bit) {
-    Result = _VMov(16, Result);
-  }
+  // No need to zero-extend result, since implementations
+  // use zero extending AdvSIMD or zeroing SVE loads internally.
 
   StoreResult(FPRClass, Op, Result, -1);
 }

--- a/External/FEXCore/Source/Interface/IR/IR.json
+++ b/External/FEXCore/Source/Interface/IR/IR.json
@@ -499,6 +499,12 @@
         "NumElements": "RegisterSize / ElementSize"
       },
 
+      "FPR = VBroadcastFromMem u8:#RegisterSize, u8:#ElementSize, GPR:$Address": {
+        "Desc": ["Broadcasts an ElementSize value from memory into each element of a vector."],
+        "DestSize": "RegisterSize",
+        "NumElements": "RegisterSize / ElementSize"
+      },
+
       "GPR = MemSet i1:$IsAtomic, u8:$Size, GPR:$Prefix, GPR:$Addr, GPR:$Value, GPR:$Length, GPR:$Direction": {
         "Desc": ["Duplicates behaviour of x86 STOS repeat",
                  "Returns the final address that gets generated without the prefix appended."

--- a/unittests/InstructionCountCI/VEX_map2.json
+++ b/unittests/InstructionCountCI/VEX_map2.json
@@ -1063,14 +1063,13 @@
       ]
     },
     "vbroadcastss xmm0, [rax]": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x18 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ld1rw {z4.s}, p6/z, [x4]",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -2340,7 +2339,7 @@
       ]
     },
     "vpbroadcastd xmm0, xmm1": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x58 128-bit"
@@ -2349,19 +2348,17 @@
         "mov z4.d, p7/m, z17.d",
         "dup v4.4s, v4.s[0]",
         "mov v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vpbroadcastd xmm0, [rax]": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x58 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ld1rw {z4.s}, p6/z, [x4]",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -2390,7 +2387,7 @@
       ]
     },
     "vpbroadcastq xmm0, xmm1": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x59 128-bit"
@@ -2399,19 +2396,17 @@
         "mov z4.d, p7/m, z17.d",
         "dup v4.2d, v4.d[0]",
         "mov v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vpbroadcastq xmm0, [rax]": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x59 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ld1rd {z4.d}, p6/z, [x4]",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -2453,7 +2448,7 @@
       ]
     },
     "vpbroadcastb xmm0, xmm1": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x78 128-bit"
@@ -2462,19 +2457,17 @@
         "mov z4.d, p7/m, z17.d",
         "dup v4.16b, v4.b[0]",
         "mov v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vpbroadcastb xmm0, [rax]": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x78 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ld1rb {z4.b}, p6/z, [x4]",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -2504,7 +2497,7 @@
       ]
     },
     "vpbroadcastw xmm0, xmm1": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x79 128-bit"
@@ -2513,19 +2506,17 @@
         "mov z4.d, p7/m, z17.d",
         "dup v4.8h, v4.h[0]",
         "mov v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vpbroadcastw xmm0, [rax]": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x79 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ld1rh {z4.h}, p6/z, [x4]",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]

--- a/unittests/InstructionCountCI/VEX_map2.json
+++ b/unittests/InstructionCountCI/VEX_map2.json
@@ -1063,40 +1063,37 @@
       ]
     },
     "vbroadcastss xmm0, [rax]": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x18 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "ldr s4, [x4]",
-        "dup v4.4s, v4.s[0]",
+        "ld1rw {z4.s}, p6/z, [x4]",
         "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vbroadcastss ymm0, [rax]": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x18 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "ldr s4, [x4]",
-        "mov z4.s, s4",
+        "ld1rw {z4.s}, p7/z, [x4]",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vbroadcastsd ymm0, [rax]": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x19 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "ldr d4, [x4]",
-        "mov z4.d, d4",
+        "ld1rd {z4.d}, p7/z, [x4]",
         "mov z16.d, p7/m, z4.d"
       ]
     },
@@ -2357,14 +2354,13 @@
       ]
     },
     "vpbroadcastd xmm0, [rax]": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x58 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "ldr s4, [x4]",
-        "dup v4.4s, v4.s[0]",
+        "ld1rw {z4.s}, p6/z, [x4]",
         "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
@@ -2383,14 +2379,13 @@
       ]
     },
     "vpbroadcastd ymm0, [rax]": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x58 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "ldr s4, [x4]",
-        "mov z4.s, s4",
+        "ld1rw {z4.s}, p7/z, [x4]",
         "mov z16.d, p7/m, z4.d"
       ]
     },
@@ -2409,14 +2404,13 @@
       ]
     },
     "vpbroadcastq xmm0, [rax]": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x59 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "ldr d4, [x4]",
-        "dup v4.2d, v4.d[0]",
+        "ld1rd {z4.d}, p6/z, [x4]",
         "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
@@ -2440,10 +2434,9 @@
       "Comment": [
         "Map 2 0b01 0x59 256-bit"
       ],
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "ExpectedArm64ASM": [
-        "ldr d4, [x4]",
-        "mov z4.d, d4",
+        "ld1rd {z4.d}, p7/z, [x4]",
         "mov z16.d, p7/m, z4.d"
       ]
     },
@@ -2474,14 +2467,13 @@
       ]
     },
     "vpbroadcastb xmm0, [rax]": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x78 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "ldr b4, [x4]",
-        "dup v4.16b, v4.b[0]",
+        "ld1rb {z4.b}, p6/z, [x4]",
         "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
@@ -2505,10 +2497,9 @@
       "Comment": [
         "Map 2 0b01 0x78 256-bit"
       ],
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "ExpectedArm64ASM": [
-        "ldr b4, [x4]",
-        "mov z4.b, b4",
+        "ld1rb {z4.b}, p7/z, [x4]",
         "mov z16.d, p7/m, z4.d"
       ]
     },
@@ -2527,14 +2518,13 @@
       ]
     },
     "vpbroadcastw xmm0, [rax]": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x79 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "ldr h4, [x4]",
-        "dup v4.8h, v4.h[0]",
+        "ld1rh {z4.h}, p6/z, [x4]",
         "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
@@ -2558,10 +2548,9 @@
       "Comment": [
         "Map 2 0b01 0x79 256-bit"
       ],
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "ExpectedArm64ASM": [
-        "ldr h4, [x4]",
-        "mov z4.h, h4",
+        "ld1rh {z4.h}, p7/z, [x4]",
         "mov z16.d, p7/m, z4.d"
       ]
     },


### PR DESCRIPTION
Allows the implementations of the vbroadcast instructions to perform the load and broadcast in one operation as opposed to doing the load and then broadcast separately.

Notably, the broadcasting loads can also be used on systems that have SVE 128-bit support as well, not only 256-bit. On non-SVE systems, the AdvSIMD equivalent LD1R is used instead.