### PR TITLE
Arm64Emitter: Ensure that 128-bit predicate is generated with SVE

### DIFF
--- a/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
+++ b/External/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
@@ -465,12 +465,15 @@ void Arm64Emitter::FillStaticRegs(bool FPRs, uint32_t GPRFillMask, uint32_t FPRF
   }
 
   if (FPRs) {
-    if (EmitterCTX->HostFeatures.SupportsAVX) {
-      // Set up predicate registers.
-      // We don't bother spilling these in SpillStaticRegs,
-      // since all that matters is we restore them on a fill.
-      // It's not a concern if they get trounced by something else.
+    // Set up predicate registers.
+    // We don't bother spilling these in SpillStaticRegs,
+    // since all that matters is we restore them on a fill.
+    // It's not a concern if they get trounced by something else.
+    if (EmitterCTX->HostFeatures.SupportsSVE) {
       ptrue<ARMEmitter::SubRegSize::i8Bit>(PRED_TMP_16B, ARMEmitter::PredicatePattern::SVE_VL16);
+    }
+
+    if (EmitterCTX->HostFeatures.SupportsAVX) {
       ptrue<ARMEmitter::SubRegSize::i8Bit>(PRED_TMP_32B, ARMEmitter::PredicatePattern::SVE_VL32);
 
       for (size_t i = 0; i < StaticFPRegisters.size(); i++) {


### PR DESCRIPTION
In the case of running on a 128-bit SVE system this predicate wasn't setup. Since we never had any predicate usage before this wasn't an issue. Now that #2914 is using the 128-bit predicate we need to make sure that we are generating it.