### PR TITLE
OpcodeDispatcher: Improve VMOVDDUP output

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -1933,12 +1933,11 @@ void OpDispatchBuilder::VMOVDDUPOp(OpcodeArgs) {
   OrderedNode *Src = IsSrcGPR ? LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], SrcSize, Op->Flags, -1)
                               : LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], MemSize, Op->Flags, -1);
 
-  OrderedNode *Res = _VInsElement(SrcSize, 8, 1, 0, Src, Src);
+  OrderedNode *Res{};
   if (Is256Bit) {
-    Res = _VInsElement(SrcSize, 8, 3, 2, Res, Src);
+    Res = _VTrn(SrcSize, 8, Src, Src);
   } else {
-    // Clear the upper lane
-    Res = _VMov(16, Res);
+    Res = _VDupElement(SrcSize, 8, Src, 0);
   }
 
   StoreResult(FPRClass, Op, Res, -1);

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -283,41 +283,27 @@
       ]
     },
     "vmovddup xmm0, [rax]": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x12 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr d4, [x4]",
-        "mov v4.d[1], v4.d[0]",
-        "mov v4.16b, v4.16b",
+        "dup v4.2d, v4.d[0]",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vmovddup ymm0, [rax]": {
-      "ExpectedInstructionCount": 16,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x12 256-bit"
       ],
       "ExpectedArm64ASM": [
         "ld1b {z4.b}, p7/z, [x4]",
-        "adr x0, #+0x18",
-        "ldr p0, [x0]",
-        "mov z1.d, d4",
-        "mov z5.d, z4.d",
-        "mov z5.d, p0/m, z1.d",
-        "b #+0x8",
-        "udf #0x100",
-        "adr x0, #+0x18",
-        "ldr p0, [x0]",
-        "mov z1.d, z4.d[2]",
-        "mov z4.d, z5.d",
-        "mov z4.d, p0/m, z1.d",
-        "b #+0x8",
-        "unallocated (Unallocated)",
+        "trn1 z4.d, z4.d, z4.d",
         "mov z16.d, p7/m, z4.d"
       ]
     },


### PR DESCRIPTION
We can make use of TRN1 here to collapse a bunch of these moves.