### PR TITLE
FEXCore: Adds telemetry around legacy segment register setting

### DIFF
--- a/.github/workflows/instcountci.yml
+++ b/.github/workflows/instcountci.yml
@@ -64,7 +64,7 @@ jobs:
       # Note the current convention is to use the -S and -B options here to specify source
       # and build directories, but this is only available with CMake 3.13 and higher.
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -G Ninja -DENABLE_VIXL_SIMULATOR=False -DENABLE_VIXL_DISASSEMBLER=True -DENABLE_LTO=False -DENABLE_ASSERTIONS=True
+      run: cmake $GITHUB_WORKSPACE -DENABLE_OFFLINE_TELEMETRY=False -DCMAKE_BUILD_TYPE=$BUILD_TYPE -G Ninja -DENABLE_VIXL_SIMULATOR=False -DENABLE_VIXL_DISASSEMBLER=True -DENABLE_LTO=False -DENABLE_ASSERTIONS=True
 
     - name: Build
       working-directory: ${{runner.workspace}}/build

--- a/FEXCore/Source/Interface/Core/CPUBackend.cpp
+++ b/FEXCore/Source/Interface/Core/CPUBackend.cpp
@@ -7,7 +7,18 @@ namespace FEXCore {
 namespace CPU {
 
 CPUBackend::CPUBackend(FEXCore::Core::InternalThreadState *ThreadState, size_t InitialCodeSize, size_t MaxCodeSize)
-    : ThreadState(ThreadState), InitialCodeSize(InitialCodeSize), MaxCodeSize(MaxCodeSize) {}
+    : ThreadState(ThreadState), InitialCodeSize(InitialCodeSize), MaxCodeSize(MaxCodeSize) {
+
+#ifndef FEX_DISABLE_TELEMETRY
+  auto &Common = ThreadState->CurrentFrame->Pointers.Common;
+
+  // Fill in telemetry values
+  for (size_t i = 0; i < FEXCore::Telemetry::TYPE_LAST; ++i) {
+    auto &Telem = FEXCore::Telemetry::GetTelemetryValue(static_cast<FEXCore::Telemetry::TelemetryType>(i));
+    Common.TelemetryValueAddresses[i] = reinterpret_cast<uint64_t>(Telem.GetAddr());
+  }
+#endif
+}
 
 CPUBackend::~CPUBackend() {
   for (auto CodeBuffer : CodeBuffers) {

--- a/FEXCore/Source/Interface/Core/Interpreter/AtomicOps.cpp
+++ b/FEXCore/Source/Interface/Core/Interpreter/AtomicOps.cpp
@@ -771,6 +771,20 @@ DEF_OP(AtomicFetchNeg) {
     default:  LOGMAN_MSG_A_FMT("Unhandled Atomic size: {}", IROp->Size);
   }
 }
+DEF_OP(TelemetrySetValue) {
+#ifndef FEX_DISABLE_TELEMETRY
+  auto Op = IROp->C<IR::IROp_TelemetrySetValue>();
+  uint64_t Src = *GetSrc<uint64_t*>(Data->SSAData, Op->Value);
+
+  auto TelemetryPtr = reinterpret_cast<std::atomic<uint64_t>*>(Data->State->CurrentFrame->Pointers.Common.TelemetryValueAddresses[Op->TelemetryValueIndex]);
+  uint64_t Set{};
+  if (Src != 0) {
+    Set = 1;
+  }
+
+  *TelemetryPtr |= Set;
+#endif
+}
 
 #undef DEF_OP
 

--- a/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -107,6 +107,7 @@ constexpr OpHandlerArray InterpreterOpHandlers = [] {
   REGISTER_OP(ATOMICFETCHOR,          AtomicFetchOr);
   REGISTER_OP(ATOMICFETCHXOR,         AtomicFetchXor);
   REGISTER_OP(ATOMICFETCHNEG,         AtomicFetchNeg);
+  REGISTER_OP(TELEMETRYSETVALUE,      TelemetrySetValue);
 
   // Branch ops
   REGISTER_OP(CALLBACKRETURN,         CallbackReturn);

--- a/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
+++ b/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
@@ -143,6 +143,7 @@ namespace FEXCore::CPU {
   DEF_OP(AtomicFetchOr);
   DEF_OP(AtomicFetchXor);
   DEF_OP(AtomicFetchNeg);
+  DEF_OP(TelemetrySetValue);
 
   ///< Branch ops
   DEF_OP(CallbackReturn);

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -10,6 +10,7 @@ desc: Main glue logic of the arm64 splatter backend
 $end_info$
 */
 
+#include "FEXCore/Utils/Telemetry.h"
 #include "Interface/Context/Context.h"
 #include "Interface/Core/ArchHelpers/CodeEmitter/Emitter.h"
 #include "Interface/Core/LookupCache.h"
@@ -622,7 +623,6 @@ Arm64JITCore::Arm64JITCore(FEXCore::Context::ContextImpl *ctx, FEXCore::Core::In
     Common.SyscallHandlerFunc = reinterpret_cast<uint64_t>(FEXCore::Context::HandleSyscall);
     Common.ExitFunctionLink = reinterpret_cast<uintptr_t>(&Context::ContextImpl::ThreadExitFunctionLink<Arm64JITCore_ExitFunctionLink>);
 
-
     // Fill in the fallback handlers
     InterpreterOps::FillFallbackIndexPointers(Common.FallbackHandlerPointers);
 
@@ -908,6 +908,7 @@ CPUBackend::CompiledCode Arm64JITCore::CompileCode(uint64_t Entry,
         REGISTER_OP(ATOMICFETCHOR,  AtomicFetchOr);
         REGISTER_OP(ATOMICFETCHXOR, AtomicFetchXor);
         REGISTER_OP(ATOMICFETCHNEG, AtomicFetchNeg);
+        REGISTER_OP(TELEMETRYSETVALUE, TelemetrySetValue);
 
         // Branch ops
         REGISTER_OP(CALLBACKRETURN,    CallbackReturn);

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -294,6 +294,7 @@ private:
   DEF_OP(AtomicFetchOr);
   DEF_OP(AtomicFetchXor);
   DEF_OP(AtomicFetchNeg);
+  DEF_OP(TelemetrySetValue);
 
   ///< Branch ops
   DEF_OP(CallbackReturn);

--- a/FEXCore/Source/Interface/Core/JIT/x86_64/AtomicOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/x86_64/AtomicOps.cpp
@@ -628,23 +628,38 @@ DEF_OP(AtomicFetchNeg) {
   }
 }
 
+DEF_OP(TelemetrySetValue) {
+#ifndef FEX_DISABLE_TELEMETRY
+  auto Op = IROp->C<IR::IROp_TelemetrySetValue>();
+  auto Src = GetSrc<RA_32>(Op->Value.ID());
+
+  xor_(TMP1, TMP1);
+  mov(TMP2, qword [STATE + offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.TelemetryValueAddresses[Op->TelemetryValueIndex])]);
+  test(Src, Src);
+  setne(TMP1.cvt8());
+  lock(); or_(qword [TMP2], TMP1);
+#endif
+}
+
 #undef DEF_OP
 void X86JITCore::RegisterAtomicHandlers() {
 #define REGISTER_OP(op, x) OpHandlers[FEXCore::IR::IROps::OP_##op] = &X86JITCore::Op_##x
-  REGISTER_OP(CASPAIR,        CASPair);
-  REGISTER_OP(CAS,            CAS);
-  REGISTER_OP(ATOMICADD,      AtomicAdd);
-  REGISTER_OP(ATOMICSUB,      AtomicSub);
-  REGISTER_OP(ATOMICAND,      AtomicAnd);
-  REGISTER_OP(ATOMICOR,       AtomicOr);
-  REGISTER_OP(ATOMICXOR,      AtomicXor);
-  REGISTER_OP(ATOMICSWAP,     AtomicSwap);
-  REGISTER_OP(ATOMICFETCHADD, AtomicFetchAdd);
-  REGISTER_OP(ATOMICFETCHSUB, AtomicFetchSub);
-  REGISTER_OP(ATOMICFETCHAND, AtomicFetchAnd);
-  REGISTER_OP(ATOMICFETCHOR,  AtomicFetchOr);
-  REGISTER_OP(ATOMICFETCHXOR, AtomicFetchXor);
-  REGISTER_OP(ATOMICFETCHNEG, AtomicFetchNeg);
+  REGISTER_OP(CASPAIR,           CASPair);
+  REGISTER_OP(CAS,               CAS);
+  REGISTER_OP(ATOMICADD,         AtomicAdd);
+  REGISTER_OP(ATOMICSUB,         AtomicSub);
+  REGISTER_OP(ATOMICAND,         AtomicAnd);
+  REGISTER_OP(ATOMICOR,          AtomicOr);
+  REGISTER_OP(ATOMICXOR,         AtomicXor);
+  REGISTER_OP(ATOMICSWAP,        AtomicSwap);
+  REGISTER_OP(ATOMICFETCHADD,    AtomicFetchAdd);
+  REGISTER_OP(ATOMICFETCHSUB,    AtomicFetchSub);
+  REGISTER_OP(ATOMICFETCHAND,    AtomicFetchAnd);
+  REGISTER_OP(ATOMICFETCHOR,     AtomicFetchOr);
+  REGISTER_OP(ATOMICFETCHXOR,    AtomicFetchXor);
+  REGISTER_OP(ATOMICFETCHNEG,    AtomicFetchNeg);
+  REGISTER_OP(TELEMETRYSETVALUE, TelemetrySetValue);
+
 #undef REGISTER_OP
 }
 }

--- a/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -304,6 +304,7 @@ private:
   DEF_OP(AtomicFetchOr);
   DEF_OP(AtomicFetchXor);
   DEF_OP(AtomicFetchNeg);
+  DEF_OP(TelemetrySetValue);
 
   ///< Branch ops
   DEF_OP(CallbackReturn);

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -87,6 +87,9 @@ public:
     // If we loaded flags but didn't change them, invalidate the cached copy and move on.
     // Changes get stored out by CalculateDeferredFlags.
     CachedNZCV = nullptr;
+
+    // New block needs to reset segment telemetry.
+    SegmentsNeedReadCheck = ~0U;
   }
 
   bool FinishOp(uint64_t NextRIP, bool LastOp) {
@@ -1763,6 +1766,11 @@ private:
   }
 
   void InstallHostSpecificOpcodeHandlers();
+
+  ///< Segment telemetry tracking
+  uint32_t SegmentsNeedReadCheck{~0U};
+  void CheckLegacySegmentWrite(OrderedNode *NewNode, uint32_t SegmentReg);
+  void CheckLegacySegmentRead(OrderedNode *NewNode, uint32_t SegmentReg);
 };
 
 void InstallOpcodeHandlers(Context::OperatingMode Mode);

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -665,6 +665,13 @@
                  "Dest is the value prior to operating on the value in memory"
                 ],
         "DestSize": "Size"
+      },
+      "TelemetrySetValue GPR:$Value, u8:$TelemetryValueIndex": {
+        "HasSideEffects": true,
+        "Desc": ["Set Telemetry value if the passed in 32-bit value isn't zero.",
+                 "Only useful for 32-bit applications."
+                ],
+        "DestSize": "8"
       }
     },
     "ALU": {

--- a/FEXCore/Source/Utils/Telemetry.cpp
+++ b/FEXCore/Source/Utils/Telemetry.cpp
@@ -24,6 +24,14 @@ namespace FEXCore::Telemetry {
     "64bit CAS Tear",
     "128bit CAS Tear",
     "Crash mask",
+    "Write 32-bit Segment ES",
+    "Write 32-bit Segment SS",
+    "Write 32-bit Segment CS",
+    "Write 32-bit Segment DS",
+    "Uses 32-bit Segment ES",
+    "Uses 32-bit Segment SS",
+    "Uses 32-bit Segment CS",
+    "Uses 32-bit Segment DS",
   };
   void Initialize() {
     auto DataDirectory = Config::GetDataDirectory();

--- a/FEXCore/include/FEXCore/Core/CoreState.h
+++ b/FEXCore/include/FEXCore/Core/CoreState.h
@@ -2,6 +2,7 @@
 
 #include <FEXCore/HLE/Linux/ThreadManagement.h>
 #include <FEXCore/Utils/CompilerDefs.h>
+#include <FEXCore/Utils/Telemetry.h>
 #include <FEXCore/Core/CPUBackend.h>
 
 #include <atomic>
@@ -235,6 +236,9 @@ namespace FEXCore::Core {
       uint64_t ExitFunctionLink{};
 
       uint64_t FallbackHandlerPointers[FallbackHandlerIndex::OPINDEX_MAX];
+#ifndef FEX_DISABLE_TELEMETRY
+      uint64_t TelemetryValueAddresses[FEXCore::Telemetry::TYPE_LAST];
+#endif
 
       // Thread Specific
       /**

--- a/FEXCore/include/FEXCore/Utils/Telemetry.h
+++ b/FEXCore/include/FEXCore/Utils/Telemetry.h
@@ -38,6 +38,16 @@ namespace FEXCore::Telemetry {
     TYPE_CAS_64BIT_TEAR,
     TYPE_CAS_128BIT_TEAR,
     TYPE_CRASH_MASK,
+    // If a 32-bit application is writing a non-zero value to segments.
+    TYPE_WRITES_32BIT_SEGMENT_ES,
+    TYPE_WRITES_32BIT_SEGMENT_SS,
+    TYPE_WRITES_32BIT_SEGMENT_CS,
+    TYPE_WRITES_32BIT_SEGMENT_DS,
+    // If a 32-bit application is prefix/using a non-zero segment on memory access.
+    TYPE_USES_32BIT_SEGMENT_ES,
+    TYPE_USES_32BIT_SEGMENT_SS,
+    TYPE_USES_32BIT_SEGMENT_CS,
+    TYPE_USES_32BIT_SEGMENT_DS,
     TYPE_LAST,
   };
 


### PR DESCRIPTION
Due to Intel dropping support for legacy segment registers[1] there is a concern that this will break legacy 32-bit software that is doing some magic segment register handling.

Adds some simple telemetry for 32-bit applications that when they encounter an instruction that sets the segment register or uses a segment register that the JIT will do a /relatively/ quick four instruction check to see if it is not a null segment.

It's not enough to just check if the segment index is 0 or not, 32-bit Linux software starts with non-zero segment register indexes but the LDT for each segment index is a null-descriptor.

Once the segment address is loaded, the IR operation will do a quick check against zero and if it /isn't/ zero then set the telemetry value.

A very minor optimization that segment registers only get checked once per block to ensure overhead stays low.

[1] https://www.intel.com/content/www/us/en/developer/articles/technical/envisioning-future-simplified-architecture.html
   - 3.6 - Restricted Subset of Segmentation
      - `Bases are supported for FS, GS, GDT, IDT, LDT, and TSS registers; the base for CS, DS, ES, and SS is ignored for 32-bit mode, same as 64-bit mode (treated as zero).`
   - 4.2.17 - MOV to Segment Register
      - Will fault if SS is written (Breaking anything that writes to SS).
      - Will not fault if CS, DS, ES are written (Thus it sets the segment but gets ignored due to 3.6).