### PR TITLE
LogMan: Commonise log level to string conversion

### DIFF
--- a/FEXCore/include/FEXCore/Utils/LogManager.h
+++ b/FEXCore/include/FEXCore/Utils/LogManager.h
@@ -17,6 +17,28 @@ enum DebugLevels {
   STDERR = 6, ///< Meant to go to STDERR
 };
 
+static inline const char *DebugLevelStr(uint32_t Level) {
+  switch (Level) {
+  case NONE:
+    return "NONE";
+  case ASSERT:
+    return "ASSERT";
+  case ERROR:
+    return "ERROR";
+  case DEBUG:
+    return "DEBUG";
+  case INFO:
+    return "INFO";
+  case STDOUT:
+    return "STDOUT";
+  case STDERR:
+    return "STDERR";
+  default:
+    return "???";
+    break;
+  }
+}
+
 constexpr DebugLevels MSG_LEVEL = INFO;
 
 // Note that all logging functions with the Fmt or _FMT suffix on them expect

--- a/Source/Tools/CodeSizeValidation/Main.cpp
+++ b/Source/Tools/CodeSizeValidation/Main.cpp
@@ -202,23 +202,9 @@ namespace CodeSize {
 }
 
 void MsgHandler(LogMan::DebugLevels Level, char const *Message) {
-  const char *CharLevel{nullptr};
+  const char *CharLevel{LogMan::DebugLevelStr(Level)};
 
-  switch (Level) {
-  case LogMan::NONE:
-    CharLevel = "NONE";
-    break;
-  case LogMan::ASSERT:
-    CharLevel = "ASSERT";
-    break;
-  case LogMan::ERROR:
-    CharLevel = "ERROR";
-    break;
-  case LogMan::DEBUG:
-    CharLevel = "DEBUG";
-    break;
-  case LogMan::INFO:
-    CharLevel = "Info";
+  if (Level == LogMan::INFO) {
     // Disassemble information is sent through the Info log level.
     if (!CodeSize::Validation.ParseMessage(Message)) {
       return;
@@ -226,11 +212,8 @@ void MsgHandler(LogMan::DebugLevels Level, char const *Message) {
     if (CodeSize::Validation.InfoPrintingDisabled()) {
       return;
     }
-    break;
-  default:
-    CharLevel = "???";
-    break;
   }
+
   fextl::fmt::print("[{}] {}\n", CharLevel, Message);
 }
 

--- a/Source/Tools/FEXLoader/FEXLoader.cpp
+++ b/Source/Tools/FEXLoader/FEXLoader.cpp
@@ -67,36 +67,7 @@ void MsgHandler(LogMan::DebugLevels Level, char const *Message) {
     return;
   }
 
-  const char *CharLevel{nullptr};
-
-  switch (Level) {
-  case LogMan::NONE:
-    CharLevel = "NONE";
-    break;
-  case LogMan::ASSERT:
-    CharLevel = "ASSERT";
-    break;
-  case LogMan::ERROR:
-    CharLevel = "ERROR";
-    break;
-  case LogMan::DEBUG:
-    CharLevel = "DEBUG";
-    break;
-  case LogMan::INFO:
-    CharLevel = "Info";
-    break;
-  case LogMan::STDOUT:
-    CharLevel = "STDOUT";
-    break;
-  case LogMan::STDERR:
-    CharLevel = "STDERR";
-    break;
-  default:
-    CharLevel = "???";
-    break;
-  }
-
-  const auto Output = fextl::fmt::format("[{}] {}\n", CharLevel, Message);
+  const auto Output = fextl::fmt::format("[{}] {}\n", LogMan::DebugLevelStr(Level), Message);
   write(OutputFD, Output.c_str(), Output.size());
   fsync(OutputFD);
 }

--- a/Source/Tools/FEXLoader/IRLoader.cpp
+++ b/Source/Tools/FEXLoader/IRLoader.cpp
@@ -38,37 +38,7 @@ namespace FEXCore::Context {
 
 void MsgHandler(LogMan::DebugLevels Level, char const *Message)
 {
-  const char *CharLevel{nullptr};
-
-  switch (Level)
-  {
-  case LogMan::NONE:
-    CharLevel = "NONE";
-    break;
-  case LogMan::ASSERT:
-    CharLevel = "ASSERT";
-    break;
-  case LogMan::ERROR:
-    CharLevel = "ERROR";
-    break;
-  case LogMan::DEBUG:
-    CharLevel = "DEBUG";
-    break;
-  case LogMan::INFO:
-    CharLevel = "Info";
-    break;
-  case LogMan::STDOUT:
-    CharLevel = "STDOUT";
-    break;
-  case LogMan::STDERR:
-    CharLevel = "STDERR";
-    break;
-  default:
-    CharLevel = "???";
-    break;
-  }
-
-  fextl::fmt::print("[{}] {}\n", CharLevel, Message);
+  fextl::fmt::print("[{}] {}\n", LogMan::DebugLevelStr(Level), Message);
   fflush(stdout);
 }
 

--- a/Source/Tools/FEXLoader/TestHarnessRunner.cpp
+++ b/Source/Tools/FEXLoader/TestHarnessRunner.cpp
@@ -43,29 +43,7 @@ $end_info$
 #include <utility>
 
 void MsgHandler(LogMan::DebugLevels Level, char const *Message) {
-  const char *CharLevel{nullptr};
-
-  switch (Level) {
-  case LogMan::NONE:
-    CharLevel = "NONE";
-    break;
-  case LogMan::ASSERT:
-    CharLevel = "ASSERT";
-    break;
-  case LogMan::ERROR:
-    CharLevel = "ERROR";
-    break;
-  case LogMan::DEBUG:
-    CharLevel = "DEBUG";
-    break;
-  case LogMan::INFO:
-    CharLevel = "Info";
-    break;
-  default:
-    CharLevel = "???";
-    break;
-  }
-  fextl::fmt::print("[{}] {}\n", CharLevel, Message);
+  fextl::fmt::print("[{}] {}\n", LogMan::DebugLevelStr(Level), Message);
 }
 
 void AssertHandler(char const *Message) {

--- a/Source/Tools/FEXServer/Main.cpp
+++ b/Source/Tools/FEXServer/Main.cpp
@@ -24,36 +24,8 @@
 #include <unistd.h>
 
 namespace Logging {
-  const char *GetCharLevel(uint32_t Level) {
-    switch (Level) {
-    case LogMan::NONE:
-      return "NONE";
-      break;
-    case LogMan::ASSERT:
-      return "ASSERT";
-      break;
-    case LogMan::ERROR:
-      return "ERROR";
-      break;
-    case LogMan::DEBUG:
-      return "DEBUG";
-      break;
-    case LogMan::INFO:
-      return "Info";
-      break;
-    case LogMan::STDOUT:
-      return "STDOUT";
-      break;
-    case LogMan::STDERR:
-      return "STDERR";
-      break;
-    default:
-      return "???";
-      break;
-    }
-  }
   void MsgHandler(LogMan::DebugLevels Level, char const *Message) {
-    const auto Output = fmt::format("[{}] {}\n", GetCharLevel(Level), Message);
+    const auto Output = fmt::format("[{}] {}\n", LogMan::DebugLevelStr(Level), Message);
     write(STDOUT_FILENO, Output.c_str(), Output.size());
   }
 
@@ -63,8 +35,7 @@ namespace Logging {
   }
 
   void ClientMsgHandler(int FD, uint64_t Timestamp, uint32_t PID, uint32_t TID, uint32_t Level, const char* Msg) {
-    auto CharLevel = GetCharLevel(Level);
-    const auto Output = fmt::format("[{}][{}][{}.{}] {}\n", CharLevel, Timestamp, PID, TID, Msg);
+    const auto Output = fmt::format("[{}][{}][{}.{}] {}\n", LogMan::DebugLevelStr(Level), Timestamp, PID, TID, Msg);
     write(STDERR_FILENO, Output.c_str(), Output.size());
   }
 }


### PR DESCRIPTION
Avoids the same logic being duplicated 5 times and should make it easier to add or change log levels in the future.