### PR TITLE
Support for Config.json loading on WIN32

### DIFF
--- a/FEXCore/Source/Utils/FileLoading.cpp
+++ b/FEXCore/Source/Utils/FileLoading.cpp
@@ -60,6 +60,9 @@ ssize_t LoadFileToBuffer(const fextl::string &Filepath, std::span<char> Buffer) 
 template<typename T>
 static bool LoadFileImpl(T &Data, const fextl::string &Filepath, size_t FixedSize) {
   std::ifstream f(Filepath, std::ios::binary | std::ios::ate);
+  if (f.fail()) {
+    return false;
+  }
   auto Size = f.tellg();
   f.seekg(0, std::ios::beg);
   Data.resize(Size);

--- a/FEXCore/Source/Utils/FileLoading.cpp
+++ b/FEXCore/Source/Utils/FileLoading.cpp
@@ -56,7 +56,6 @@ ssize_t LoadFileToBuffer(const fextl::string &Filepath, std::span<char> Buffer) 
 }
 
 #else
-// TODO: Should be rewritten using WIN32 specific APIs.
 template<typename T>
 static bool LoadFileImpl(T &Data, const fextl::string &Filepath, size_t FixedSize) {
   std::ifstream f(Filepath, std::ios::binary | std::ios::ate);

--- a/FEXHeaderUtils/FEXHeaderUtils/Filesystem.h
+++ b/FEXHeaderUtils/FEXHeaderUtils/Filesystem.h
@@ -73,7 +73,6 @@ namespace FHU::Filesystem {
     return CreateDirectoryResult::ERROR;
   }
 #else
-  // TODO: Should be rewritten using WIN32 specific APIs.
   inline CreateDirectoryResult CreateDirectory(const fextl::string &Path) {
     std::error_code ec;
     if (std::filesystem::exists(Path, ec)) {
@@ -226,7 +225,6 @@ namespace FHU::Filesystem {
     return false;
   }
 #else
-  // TODO: Should be rewritten using WIN32 specific APIs.
   inline bool CopyFile(const fextl::string &From, const fextl::string &To, CopyOptions Options = CopyOptions::NONE) {
     std::filesystem::copy_options options{};
     if (Options == CopyOptions::SKIP_EXISTING) {
@@ -359,7 +357,6 @@ namespace FHU::Filesystem {
     return realpath(Path, Fill);
   }
 #else
-  // TODO: Should be rewritten using WIN32 specific APIs.
   inline char *Absolute(const char *Path, char Fill[PATH_MAX]) {
     std::error_code ec;
     const auto PathAbsolute = std::filesystem::absolute(Path, ec);

--- a/Source/Common/Config.cpp
+++ b/Source/Common/Config.cpp
@@ -465,6 +465,17 @@ namespace JSON {
 
     return HomeDir;
   }
+#else
+  const char *GetHomeDirectory() {
+    const char *HomeObjectPath = getenv("WINEHOMEDIR");
+    if (!HomeObjectPath) {
+      return nullptr;
+    }
+
+    // Skip over the \??\ prefix in the NT path since we want a DOS path
+    return HomeObjectPath + 4;
+  }
+#endif
 
   fextl::string GetDataDirectory() {
     fextl::string DataDir{};
@@ -537,10 +548,4 @@ namespace JSON {
     FEXCore::Config::SetConfigFileLocation(GetConfigFileLocation(false), false);
     FEXCore::Config::SetConfigFileLocation(GetConfigFileLocation(true), true);
   }
-#else
-  void InitializeConfigs() {
-    // TODO: Find out how to set this up on WIN32.
-    LogMan::Msg::EFmt("{} Unsupported on WIN32!", __func__);
-  }
-#endif
 }


### PR DESCRIPTION
This relies on wine's behaviour of passing through linux paths and env vars, so that the config in the user's linux home directory can be accessed when running FEXCore under wine.
