### PR TITLE
CMake: Add mingw toolchain file

### DIFF
--- a/.github/workflows/mingw_build.yml
+++ b/.github/workflows/mingw_build.yml
@@ -26,17 +26,18 @@ jobs:
     - name: Set runner label
       run: echo "runner_label=${{ matrix.arch[1] }}" >> $GITHUB_ENV
 
+    - name: Add MingGW to PATH
+      run: echo "$HOME/llvm-mingw/build/bin/" >> $GITHUB_PATH
+
     - name: Set CC x86
       if: matrix.arch[1] == 'x64'
       run: |
-        echo "CC=$HOME/llvm-mingw/build/bin/x86_64-w64-mingw32-clang" >> $GITHUB_ENV
-        echo "CXX=$HOME/llvm-mingw/build/bin/x86_64-w64-mingw32-clang++" >> $GITHUB_ENV
+        echo "MINGW_TRIPLE=x86_64-w64-mingw32" >> $GITHUB_ENV
 
     - name: Set CC Arm64
       if: matrix.arch[1] == 'ARM64'
       run: |
-        echo "CC=$HOME/llvm-mingw/build/bin/aarch64-w64-mingw32-clang" >> $GITHUB_ENV
-        echo "CXX=$HOME/llvm-mingw/build/bin/aarch64-w64-mingw32-clang++" >> $GITHUB_ENV
+        echo "MINGW_TRIPLE=aarch64-w64-mingw32" >> $GITHUB_ENV
 
     - name: Set rootfs paths
       run: |
@@ -73,7 +74,7 @@ jobs:
       # Note the current convention is to use the -S and -B options here to specify source
       # and build directories, but this is only available with CMake 3.13 and higher.
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -G Ninja -DENABLE_LTO=False -DENABLE_ASSERTIONS=True -DENABLE_X86_HOST_DEBUG=True -DENABLE_INTERPRETER=False -DBUILD_TESTS=False -DENABLE_JEMALLOC=False -DENABLE_JEMALLOC_GLIBC_ALLOC=False -DCMAKE_INSTALL_PREFIX=${{runner.workspace}}/build/install
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/toolchain_mingw.cmake -DMINGW_TRIPLE=$MINGW_TRIPLE -G Ninja -DENABLE_LTO=False -DENABLE_ASSERTIONS=True -DENABLE_X86_HOST_DEBUG=True -DENABLE_INTERPRETER=False -DBUILD_TESTS=False -DENABLE_JEMALLOC=False -DENABLE_JEMALLOC_GLIBC_ALLOC=False -DCMAKE_INSTALL_PREFIX=${{runner.workspace}}/build/install
 
     - name: Build
       working-directory: ${{runner.workspace}}/build

--- a/toolchain_mingw.cmake
+++ b/toolchain_mingw.cmake
@@ -1,0 +1,15 @@
+set(MINGW_TRIPLE "" CACHE STRING "MinGW compiler target architecture triple")
+
+set(CMAKE_RC_COMPILER ${MINGW_TRIPLE}-windres)
+set(CMAKE_C_COMPILER ${MINGW_TRIPLE}-clang)
+set(CMAKE_CXX_COMPILER ${MINGW_TRIPLE}-clang++)
+set(CMAKE_DLLTOOL ${MINGW_TRIPLE}-dlltool)
+
+# Compile everything as static to avoid requiring the MinGW runtime libraries, force page aligned sections so that
+# debug symbols work correctly, and disable loop alignment to workaround an LLVM bug
+# (https://github.com/llvm/llvm-project/issues/47432)
+set(CMAKE_SHARED_LINKER_FLAGS_INIT "-static -static-libgcc -static-libstdc++ -Wl,--file-alignment=4096,/mllvm:-align-loops=1")
+set(CMAKE_EXE_LINKER_FLAGS_INIT "-static -static-libgcc -static-libstdc++ -Wl,--file-alignment=4096,/mllvm:-align-loops=1")
+
+set(CMAKE_SYSTEM_NAME Windows)
+set(CMAKE_SYSTEM_PROCESSOR ${MINGW_TRIPLE})


### PR DESCRIPTION
This simplifies the setup needed for WIN32-targeted FEX builds and serves as documentation of the workaround for the LLVM linker bug that would otherwise prevent release builds.