### PR TITLE
FEXCore: Allow for interrupting the JIT on block entry

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -791,6 +791,13 @@ CPUBackend::CompiledCode Arm64JITCore::CompileCode(uint64_t Entry,
   adr(TMP1, &JITCodeHeaderLabel);
   str(TMP1, STATE, offsetof(FEXCore::Core::CPUState, InlineJITBlockHeader));
 
+#ifdef _WIN32
+  // Trigger a fault if there are any pending interrupts
+  // Used only for suspend on WIN32 at the moment
+  strb(ARMEmitter::XReg::zr, STATE, offsetof(FEXCore::Core::InternalThreadState, InterruptFaultPage) -
+                                    offsetof(FEXCore::Core::InternalThreadState, BaseFrameState));
+#endif
+
   if (GDBEnabled) {
     auto GDBSize = CTX->Dispatcher->GenerateGDBPauseCheck(CodeData.BlockEntry, Entry);
     CursorIncrement(GDBSize);

--- a/FEXCore/include/FEXCore/Utils/AllocatorHooks.h
+++ b/FEXCore/include/FEXCore/Utils/AllocatorHooks.h
@@ -12,6 +12,7 @@
 #include <sys/mman.h>
 #endif
 
+#include <new>
 #include <cstddef>
 #include <cstdint>
 #include <sys/types.h>
@@ -135,8 +136,16 @@ namespace FEXCore::Allocator {
       return FEXCore::Allocator::malloc(size);
     }
 
+    void *operator new(size_t size, std::align_val_t align) {
+      return FEXCore::Allocator::aligned_alloc(static_cast<size_t>(align), size);
+    }
+
     void operator delete(void *ptr) {
       return FEXCore::Allocator::free(ptr);
+    }
+
+    void operator delete(void *ptr, std::align_val_t align) {
+      return FEXCore::Allocator::aligned_free(ptr);
     }
   };
 }


### PR DESCRIPTION
This takes a similar approach to deferred signal handling and allows any given thread to be interrupted while running JIT code by protecting the appropriate page as RO. Then, when the thread then enters a new block, it will try to access that page and segfault. This can then be caught by the frontend where it can recover/edit the context as required.