### PR TITLE
Arm64Emitter: Stop saving and restoring platform register

### DIFF
--- a/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
+++ b/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
@@ -22,7 +22,7 @@
 namespace FEXCore::CPU {
 // Register x18 is unused in the current configuration.
 // This is due to it being a platform register on wine platforms.
-// TODO: Allow x18 register allocation in the future to gain one more register.
+// TODO: Allow x18 register allocation on Linux in the future to gain one more register.
 
 namespace x64 {
   // All but x19 and x29 are caller saved
@@ -310,10 +310,6 @@ void Arm64Emitter::PushCalleeSavedRegisters() {
   // We need to save pairs of registers
   // We save r19-r30
   const fextl::vector<std::pair<ARMEmitter::XRegister, ARMEmitter::XRegister>> CalleeSaved = {{
-#ifdef _WIN32
-    // Platform register, Just save it twice to make logic easy.
-    {ARMEmitter::XReg::x18, ARMEmitter::XReg::x18},
-#endif
     {ARMEmitter::XReg::x19, ARMEmitter::XReg::x20},
     {ARMEmitter::XReg::x21, ARMEmitter::XReg::x22},
     {ARMEmitter::XReg::x23, ARMEmitter::XReg::x24},
@@ -384,10 +380,6 @@ void Arm64Emitter::PopCalleeSavedRegisters() {
     {ARMEmitter::XReg::x23, ARMEmitter::XReg::x24},
     {ARMEmitter::XReg::x21, ARMEmitter::XReg::x22},
     {ARMEmitter::XReg::x19, ARMEmitter::XReg::x20},
-#ifdef _WIN32
-    // Platform register.
-    {ARMEmitter::XReg::x18, ARMEmitter::XReg::zr},
-#endif
   }};
 
   for (auto &RegPair : CalleeSaved) {


### PR DESCRIPTION
FEX doesn't use the platform register on wine platforms so there is no reason to save  and restore it.

On Linux we can still use it at some point but for now it isn't part of our RA.