### PR TITLE
SignalDelegator: Allow getting the internal configuration

### DIFF
--- a/FEXCore/include/FEXCore/Core/SignalDelegator.h
+++ b/FEXCore/include/FEXCore/Core/SignalDelegator.h
@@ -109,6 +109,10 @@ namespace Core {
       Config = _Config;
     }
 
+    const SignalDelegatorConfig &GetConfig() const {
+      return Config;
+    }
+
     /**
      * @brief Signals a thread with a specific core event.
      *


### PR DESCRIPTION
Not used by FEX today but will be used by the WINE integration.