### PR TITLE
OpcodeDispatcher: Implement support for push IR operation

### DIFF
--- a/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -154,6 +154,7 @@ constexpr OpHandlerArray InterpreterOpHandlers = [] {
   REGISTER_OP(VLOADVECTORMASKED,      VLoadVectorMasked);
   REGISTER_OP(VSTOREVECTORMASKED,     VStoreVectorMasked);
   REGISTER_OP(VBROADCASTFROMMEM,      VBroadcastFromMem);
+  REGISTER_OP(PUSH,                   Push);
   REGISTER_OP(MEMSET,                 MemSet);
   REGISTER_OP(MEMCPY,                 MemCpy);
   REGISTER_OP(CACHELINECLEAR,         CacheLineClear);

--- a/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
+++ b/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
@@ -188,6 +188,7 @@ namespace FEXCore::CPU {
   DEF_OP(VLoadVectorMasked);
   DEF_OP(VStoreVectorMasked);
   DEF_OP(VBroadcastFromMem);
+  DEF_OP(Push);
   DEF_OP(MemSet);
   DEF_OP(MemCpy);
   DEF_OP(CacheLineClear);

--- a/FEXCore/Source/Interface/Core/Interpreter/MemoryOps.cpp
+++ b/FEXCore/Source/Interface/Core/Interpreter/MemoryOps.cpp
@@ -457,6 +457,37 @@ DEF_OP(VBroadcastFromMem) {
   }
 }
 
+DEF_OP(Push) {
+  const auto Op = IROp->C<IR::IROp_Push>();
+  const auto ValueSize = Op->ValueSize;
+
+  uint64_t MemData = *GetSrc<uint64_t*>(Data->SSAData, Op->Addr);
+
+  switch (ValueSize) {
+    case 1: {
+      *reinterpret_cast<uint8_t*>(MemData - ValueSize) = *GetSrc<uint8_t*>(Data->SSAData, Op->Value);
+      break;
+    }
+    case 2: {
+      *reinterpret_cast<uint16_t*>(MemData - ValueSize) = *GetSrc<uint16_t*>(Data->SSAData, Op->Value);
+      break;
+    }
+    case 4: {
+      *reinterpret_cast<uint32_t*>(MemData - ValueSize) = *GetSrc<uint32_t*>(Data->SSAData, Op->Value);
+      break;
+    }
+    case 8: {
+      *reinterpret_cast<uint64_t*>(MemData - ValueSize) = *GetSrc<uint64_t*>(Data->SSAData, Op->Value);
+      break;
+    }
+    default:
+      LOGMAN_MSG_A_FMT("Unhandled {} size: {}", __func__, ValueSize);
+      break;
+  }
+
+  GD = MemData - ValueSize;
+}
+
 DEF_OP(MemSet) {
   const auto Op = IROp->C<IR::IROp_MemSet>();
   const int32_t Size = Op->Size;

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -965,6 +965,7 @@ CPUBackend::CompiledCode Arm64JITCore::CompileCode(uint64_t Entry,
         REGISTER_OP(VLOADVECTORMASKED,   VLoadVectorMasked);
         REGISTER_OP(VSTOREVECTORMASKED,  VStoreVectorMasked);
         REGISTER_OP(VBROADCASTFROMMEM,   VBroadcastFromMem);
+        REGISTER_OP(PUSH,                Push);
         REGISTER_OP(MEMSET,              MemSet);
         REGISTER_OP(MEMCPY,              MemCpy);
         REGISTER_OP(CACHELINECLEAR,      CacheLineClear);

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -343,6 +343,7 @@ private:
   DEF_OP(VLoadVectorMasked);
   DEF_OP(VStoreVectorMasked);
   DEF_OP(VBroadcastFromMem);
+  DEF_OP(Push);
   DEF_OP(MemSet);
   DEF_OP(MemCpy);
   DEF_OP(ParanoidLoadMemTSO);

--- a/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -349,6 +349,7 @@ private:
   DEF_OP(VLoadVectorMasked);
   DEF_OP(VStoreVectorMasked);
   DEF_OP(VBroadcastFromMem);
+  DEF_OP(Push);
   DEF_OP(MemSet);
   DEF_OP(MemCpy);
   DEF_OP(CacheLineClear);

--- a/FEXCore/Source/Interface/Core/JIT/x86_64/MemoryOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/x86_64/MemoryOps.cpp
@@ -902,6 +902,35 @@ DEF_OP(VBroadcastFromMem) {
   }
 }
 
+DEF_OP(Push) {
+  const auto Op = IROp->C<IR::IROp_Push>();
+  const auto ValueSize = Op->ValueSize;
+
+  const Xbyak::Reg Value = GetSrc<RA_64>(Op->Value.ID());
+  const Xbyak::Reg AddrSrc = GetSrc<RA_64>(Op->Addr.ID());
+  const auto Dst = GetSrc<RA_64>(Node);
+
+  switch (ValueSize) {
+  case 1:
+    mov(byte [AddrSrc - ValueSize], Value.cvt8());
+    break;
+  case 2:
+    mov(word [AddrSrc - ValueSize], Value.cvt16());
+    break;
+  case 4:
+    mov(dword [AddrSrc - ValueSize], Value.cvt32());
+    break;
+  case 8:
+    mov(qword [AddrSrc - ValueSize], Value);
+    break;
+  default:
+    LOGMAN_MSG_A_FMT("Unhandled {} size: {}", __func__, ValueSize);
+    break;
+  }
+
+  lea(Dst, qword [AddrSrc - ValueSize]);
+}
+
 DEF_OP(MemSet) {
   const auto Op = IROp->C<IR::IROp_MemSet>();
 
@@ -1184,6 +1213,7 @@ void X86JITCore::RegisterMemoryHandlers() {
   REGISTER_OP(VLOADVECTORMASKED,   VLoadVectorMasked);
   REGISTER_OP(VSTOREVECTORMASKED,  VStoreVectorMasked);
   REGISTER_OP(VBROADCASTFROMMEM,   VBroadcastFromMem);
+  REGISTER_OP(PUSH,                Push);
   REGISTER_OP(MEMSET,              MemSet);
   REGISTER_OP(MEMCPY,              MemCpy);
   REGISTER_OP(CACHELINECLEAR,      CacheLineClear);

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -504,7 +504,15 @@
         "DestSize": "RegisterSize",
         "NumElements": "RegisterSize / ElementSize"
       },
-
+      "GPR = Push u8:#Size, u8:$ValueSize, GPR:$Value, GPR:$Addr": {
+        "Desc": [
+          "Pushes a value to the address, returning the new pointer after incrementing.",
+          "The address is decremented by the value size while.",
+          "The return value size is the size of the current operating mode"
+        ],
+        "HasSideEffects": true,
+        "DestSize": "Size"
+      },
       "GPR = MemSet i1:$IsAtomic, u8:$Size, GPR:$Prefix, GPR:$Addr, GPR:$Value, GPR:$Length, GPR:$Direction": {
         "Desc": ["Duplicates behaviour of x86 STOS repeat",
                  "Returns the final address that gets generated without the prefix appended."

--- a/unittests/InstructionCountCI/Primary.json
+++ b/unittests/InstructionCountCI/Primary.json
@@ -2669,22 +2669,20 @@
       ]
     },
     "push ax": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
-      "Comment": "0x50",
-      "ExpectedArm64ASM": [
-        "uxth x20, w4",
-        "sub x8, x8, #0x2 (2)",
-        "strh w20, [x8]"
-      ]
-    },
-    "push rax": {
       "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": "0x50",
       "ExpectedArm64ASM": [
-        "sub x8, x8, #0x8 (8)",
-        "str x4, [x8]"
+        "uxth x20, w4",
+        "strh w20, [x8, #-2]!"
+      ]
+    },
+    "push rax": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": "0x50",
+      "ExpectedArm64ASM": [
+        "str x4, [x8, #-8]!"
       ]
     },
     "pop ax": {
@@ -2716,23 +2714,21 @@
       ]
     },
     "push word 1": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": "0x68",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
-        "sub x8, x8, #0x2 (2)",
-        "strh w20, [x8]"
+        "strh w20, [x8, #-2]!"
       ]
     },
     "push qword 1": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": "0x68",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
-        "sub x8, x8, #0x8 (8)",
-        "str x20, [x8]"
+        "str x20, [x8, #-8]!"
       ]
     },
     "imul ax, bx, 257": {
@@ -2796,33 +2792,30 @@
       ]
     },
     "push word -1": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": "0x6a",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
-        "sub x8, x8, #0x2 (2)",
-        "strh w20, [x8]"
+        "strh w20, [x8, #-2]!"
       ]
     },
     "push dword -1": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": "0x6a",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
-        "sub x8, x8, #0x8 (8)",
-        "str x20, [x8]"
+        "str x20, [x8, #-8]!"
       ]
     },
     "push qword -1": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": "0x6a",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
-        "sub x8, x8, #0x8 (8)",
-        "str x20, [x8]"
+        "str x20, [x8, #-8]!"
       ]
     },
     "imul ax, bx, 3": {
@@ -3553,7 +3546,7 @@
       "ExpectedArm64ASM": []
     },
     "pushf": {
-      "ExpectedInstructionCount": 41,
+      "ExpectedInstructionCount": 40,
       "Optimal": "No",
       "Comment": "0x9c",
       "ExpectedArm64ASM": [
@@ -3595,13 +3588,12 @@
         "and x22, x20, #0xc0000000",
         "orr x21, x21, x22, lsr #24",
         "orr x21, x21, #0x2",
-        "sub x8, x8, #0x8 (8)",
-        "str x21, [x8]",
+        "str x21, [x8, #-8]!",
         "str w20, [x28, #728]"
       ]
     },
     "pushfq": {
-      "ExpectedInstructionCount": 41,
+      "ExpectedInstructionCount": 40,
       "Optimal": "No",
       "Comment": "0x9c",
       "ExpectedArm64ASM": [
@@ -3643,8 +3635,7 @@
         "and x22, x20, #0xc0000000",
         "orr x21, x21, x22, lsr #24",
         "orr x21, x21, #0x2",
-        "sub x8, x8, #0x8 (8)",
-        "str x21, [x8]",
+        "str x21, [x8, #-8]!",
         "str w20, [x28, #728]"
       ]
     },

--- a/unittests/InstructionCountCI/PrimaryGroup.json
+++ b/unittests/InstructionCountCI/PrimaryGroup.json
@@ -3930,22 +3930,20 @@
       ]
     },
     "push ax": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
-      "Comment": "GROUP4 0xff /6",
-      "ExpectedArm64ASM": [
-        "uxth x20, w4",
-        "sub x8, x8, #0x2 (2)",
-        "strh w20, [x8]"
-      ]
-    },
-    "push rax": {
       "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": "GROUP4 0xff /6",
       "ExpectedArm64ASM": [
-        "sub x8, x8, #0x8 (8)",
-        "str x4, [x8]"
+        "uxth x20, w4",
+        "strh w20, [x8, #-2]!"
+      ]
+    },
+    "push rax": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": "GROUP4 0xff /6",
+      "ExpectedArm64ASM": [
+        "str x4, [x8, #-8]!"
       ]
     },
     "mov byte [rax], 0": {

--- a/unittests/InstructionCountCI/Primary_32Bit.json
+++ b/unittests/InstructionCountCI/Primary_32Bit.json
@@ -9,15 +9,14 @@
   },
   "Instructions": {
     "push es": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": "0x06",
       "ExpectedArm64ASM": [
         "mov w20, w8",
-        "sub x20, x20, #0x4 (4)",
-        "bfxil x8, x20, #0, #32",
         "ldrh w21, [x28, #136]",
-        "str w21, [x20]"
+        "str w21, [x20, #-4]!",
+        "bfxil x8, x20, #0, #32"
       ]
     },
     "pop es": {
@@ -37,27 +36,25 @@
       ]
     },
     "push cs": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": "0x0e",
       "ExpectedArm64ASM": [
         "mov w20, w8",
-        "sub x20, x20, #0x4 (4)",
-        "bfxil x8, x20, #0, #32",
         "ldrh w21, [x28, #138]",
-        "str w21, [x20]"
+        "str w21, [x20, #-4]!",
+        "bfxil x8, x20, #0, #32"
       ]
     },
     "push ss": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": "0x16",
       "ExpectedArm64ASM": [
         "mov w20, w8",
-        "sub x20, x20, #0x4 (4)",
-        "bfxil x8, x20, #0, #32",
         "ldrh w21, [x28, #140]",
-        "str w21, [x20]"
+        "str w21, [x20, #-4]!",
+        "bfxil x8, x20, #0, #32"
       ]
     },
     "pop ss": {
@@ -77,15 +74,14 @@
       ]
     },
     "push ds": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": "0x1e",
       "ExpectedArm64ASM": [
         "mov w20, w8",
-        "sub x20, x20, #0x4 (4)",
-        "bfxil x8, x20, #0, #32",
         "ldrh w21, [x28, #142]",
-        "str w21, [x20]"
+        "str w21, [x20, #-4]!",
+        "bfxil x8, x20, #0, #32"
       ]
     },
     "pop ds": {
@@ -468,66 +464,54 @@
       ]
     },
     "pusha": {
-      "ExpectedInstructionCount": "25",
+      "ExpectedInstructionCount": 19,
       "Optimal": "No",
       "Comment": "0x60",
       "ExpectedArm64ASM": [
         "mov w20, w8",
-        "sub x21, x20, #0x4 (4)",
-        "mov w22, w4",
-        "str w22, [x21]",
-        "sub x21, x21, #0x4 (4)",
+        "mov w21, w4",
+        "stur w21, [x20, #-4]",
+        "sub w21, w20, #0x4 (4)",
         "mov w22, w5",
-        "str w22, [x21]",
-        "sub x21, x21, #0x4 (4)",
+        "str w22, [x21, #-4]!",
         "mov w22, w6",
-        "str w22, [x21]",
-        "sub x21, x21, #0x4 (4)",
+        "str w22, [x21, #-4]!",
         "mov w22, w7",
-        "str w22, [x21]",
-        "sub x21, x21, #0x4 (4)",
-        "str w20, [x21]",
-        "sub x20, x21, #0x4 (4)",
+        "str w22, [x21, #-4]!",
+        "stur w20, [x21, #-4]",
+        "sub w20, w21, #0x4 (4)",
         "mov w21, w9",
-        "str w21, [x20]",
-        "sub x20, x20, #0x4 (4)",
+        "str w21, [x20, #-4]!",
         "mov w21, w10",
-        "str w21, [x20]",
-        "sub x20, x20, #0x4 (4)",
+        "str w21, [x20, #-4]!",
         "mov w21, w11",
-        "str w21, [x20]",
+        "str w21, [x20, #-4]!",
         "bfxil x8, x20, #0, #32"
       ]
     },
     "pushad": {
-      "ExpectedInstructionCount": "25",
+      "ExpectedInstructionCount": 19,
       "Optimal": "No",
       "Comment": "0x60",
       "ExpectedArm64ASM": [
         "mov w20, w8",
-        "sub x21, x20, #0x4 (4)",
-        "mov w22, w4",
-        "str w22, [x21]",
-        "sub x21, x21, #0x4 (4)",
+        "mov w21, w4",
+        "stur w21, [x20, #-4]",
+        "sub w21, w20, #0x4 (4)",
         "mov w22, w5",
-        "str w22, [x21]",
-        "sub x21, x21, #0x4 (4)",
+        "str w22, [x21, #-4]!",
         "mov w22, w6",
-        "str w22, [x21]",
-        "sub x21, x21, #0x4 (4)",
+        "str w22, [x21, #-4]!",
         "mov w22, w7",
-        "str w22, [x21]",
-        "sub x21, x21, #0x4 (4)",
-        "str w20, [x21]",
-        "sub x20, x21, #0x4 (4)",
+        "str w22, [x21, #-4]!",
+        "stur w20, [x21, #-4]",
+        "sub w20, w21, #0x4 (4)",
         "mov w21, w9",
-        "str w21, [x20]",
-        "sub x20, x20, #0x4 (4)",
+        "str w21, [x20, #-4]!",
         "mov w21, w10",
-        "str w21, [x20]",
-        "sub x20, x20, #0x4 (4)",
+        "str w21, [x20, #-4]!",
         "mov w21, w11",
-        "str w21, [x20]",
+        "str w21, [x20, #-4]!",
         "bfxil x8, x20, #0, #32"
       ]
     },

--- a/unittests/InstructionCountCI/Secondary.json
+++ b/unittests/InstructionCountCI/Secondary.json
@@ -1857,13 +1857,12 @@
       ]
     },
     "push fs": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": "0x0f 0xa0",
       "ExpectedArm64ASM": [
-        "sub x8, x8, #0x8 (8)",
         "ldr x20, [x28, #176]",
-        "str x20, [x8]"
+        "str x20, [x8, #-8]!"
       ]
     },
     "pop fs": {
@@ -2380,13 +2379,12 @@
       ]
     },
     "push gs": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": "0x0f 0xa8",
       "ExpectedArm64ASM": [
-        "sub x8, x8, #0x8 (8)",
         "ldr x20, [x28, #168]",
-        "str x20, [x8]"
+        "str x20, [x8, #-8]!"
       ]
     },
     "pop gs": {

--- a/unittests/InstructionCountCI/Secondary_32Bit.json
+++ b/unittests/InstructionCountCI/Secondary_32Bit.json
@@ -9,15 +9,14 @@
   },
   "Instructions": {
     "push fs": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": "0x0f 0xa0",
       "ExpectedArm64ASM": [
         "mov w20, w8",
-        "sub x20, x20, #0x4 (4)",
-        "bfxil x8, x20, #0, #32",
         "ldrh w21, [x28, #146]",
-        "str w21, [x20]"
+        "str w21, [x20, #-4]!",
+        "bfxil x8, x20, #0, #32"
       ]
     },
     "pop fs": {
@@ -37,15 +36,14 @@
       ]
     },
     "push gs": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": "0x0f 0xa8",
       "ExpectedArm64ASM": [
         "mov w20, w8",
-        "sub x20, x20, #0x4 (4)",
-        "bfxil x8, x20, #0, #32",
         "ldrh w21, [x28, #144]",
-        "str w21, [x20]"
+        "str w21, [x20, #-4]!",
+        "bfxil x8, x20, #0, #32"
       ]
     },
     "pop gs": {


### PR DESCRIPTION
This paves the way to optimizing pushes in to both push operations and
push pair operations to more optimally match Arm64 push support.

While this does the first step for supporting the base push, we'll leave
optimizing push pairs to future work.