### PR TITLE
OpcodeDispatcher: Remove some extraneous MOVs from VMOVSD/VMOVSS

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -318,6 +318,7 @@ public:
   void MOVLPOp(OpcodeArgs);
   void MOVHPDOp(OpcodeArgs);
   void MOVSDOp(OpcodeArgs);
+  void MOVSSOp(OpcodeArgs);
   template<FEXCore::IR::IROps IROp, size_t ElementSize>
   void VectorALUOp(OpcodeArgs);
   template<FEXCore::IR::IROps IROp, size_t ElementSize>
@@ -376,7 +377,6 @@ public:
   void MOVBetweenGPR_FPR(OpcodeArgs);
   void TZCNT(OpcodeArgs);
   void LZCNT(OpcodeArgs);
-  void MOVSSOp(OpcodeArgs);
   template<size_t ElementSize, bool Scalar>
   void VFCMPOp(OpcodeArgs);
   template<size_t ElementSize>
@@ -973,6 +973,7 @@ private:
                       const X86Tables::DecodedOperand& MaskOp,
                       const X86Tables::DecodedOperand& DataOp);
 
+  void MOVScalarOpImpl(OpcodeArgs, size_t ElementSize);
   void VMOVScalarOpImpl(OpcodeArgs, size_t ElementSize);
 
   OrderedNode* VFCMPOpImpl(OpcodeArgs, size_t ElementSize, bool Scalar,

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -220,7 +220,7 @@ void OpDispatchBuilder::VMOVScalarOpImpl(OpcodeArgs, size_t ElementSize) {
     StoreResult(FPRClass, Op, Src, -1);
   } else {
     // VMOVSS/SD mem32/mem64, xmm1
-    OrderedNode *Src = LoadSource_WithOpSize(FPRClass, Op, Op->Src[1], ElementSize, Op->Flags, -1);
+    OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags, -1);
     StoreResult_WithOpSize(FPRClass, Op, Op->Dest, Src, ElementSize, -1);
   }
 }

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -165,46 +165,33 @@ void OpDispatchBuilder::VMOVSLDUPOp(OpcodeArgs) {
   StoreResult(FPRClass, Op, Result, -1);
 }
 
-void OpDispatchBuilder::MOVSSOp(OpcodeArgs) {
+void OpDispatchBuilder::MOVScalarOpImpl(OpcodeArgs, size_t ElementSize) {
   if (Op->Dest.IsGPR() && Op->Src[0].IsGPR()) {
-    // MOVSS xmm1, xmm2
+    // MOVSS/SD xmm1, xmm2
     OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
     OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-    auto Result = _VInsElement(16, 4, 0, 0, Dest, Src);
+    auto Result = _VInsElement(16, ElementSize, 0, 0, Dest, Src);
     StoreResult(FPRClass, Op, Result, -1);
   }
   else if (Op->Dest.IsGPR()) {
-    // MOVSS xmm1, mem32
-    // xmm1[127:0] <- zext(mem32)
-    OrderedNode *Src = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], 4, Op->Flags, -1);
+    // MOVSS/SD xmm1, mem32/mem64
+    // xmm1[127:0] <- zext(mem32/mem64)
+    OrderedNode *Src = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], ElementSize, Op->Flags, -1);
     StoreResult(FPRClass, Op, Src, -1);
   }
   else {
-    // MOVSS mem32, xmm1
+    // MOVSS/SD mem32/mem64, xmm1
     OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-    StoreResult_WithOpSize(FPRClass, Op, Op->Dest, Src, 4, -1);
+    StoreResult_WithOpSize(FPRClass, Op, Op->Dest, Src, ElementSize, -1);
   }
 }
 
+void OpDispatchBuilder::MOVSSOp(OpcodeArgs) {
+  MOVScalarOpImpl(Op, 4);
+}
+
 void OpDispatchBuilder::MOVSDOp(OpcodeArgs) {
-  if (Op->Dest.IsGPR() && Op->Src[0].IsGPR()) {
-    // xmm1[63:0] <- xmm2[63:0]
-    OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
-    OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-    auto Result = _VInsElement(16, 8, 0, 0, Dest, Src);
-    StoreResult(FPRClass, Op, Result, -1);
-  }
-  else if (Op->Dest.IsGPR()) {
-    // xmm1[127:0] <- zext(mem64)
-    OrderedNode *Src = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], 8, Op->Flags, -1);
-    StoreResult(FPRClass, Op, Src, -1);
-  }
-  else {
-    // In this case memory is the destination and the low bits of the XMM are source
-    // Mem64 = xmm2[63:0]
-    OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-    StoreResult_WithOpSize(FPRClass, Op, Op->Dest, Src, 8, -1);
-  }
+  MOVScalarOpImpl(Op, 8);
 }
 
 void OpDispatchBuilder::VMOVScalarOpImpl(OpcodeArgs, size_t ElementSize) {

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -210,8 +210,8 @@ void OpDispatchBuilder::MOVSDOp(OpcodeArgs) {
 void OpDispatchBuilder::VMOVScalarOpImpl(OpcodeArgs, size_t ElementSize) {
   if (Op->Dest.IsGPR() && Op->Src[0].IsGPR() && Op->Src[1].IsGPR()) {
     // VMOVSS/SD xmm1, xmm2, xmm3
-    OrderedNode *Src1 = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], 16, Op->Flags, -1);
-    OrderedNode *Src2 = LoadSource_WithOpSize(FPRClass, Op, Op->Src[1], ElementSize, Op->Flags, -1);
+    OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+    OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags, -1);
     OrderedNode *Result = _VInsElement(16, ElementSize, 0, 0, Src1, Src2);
     StoreResult(FPRClass, Op, Result, -1);
   } else if (Op->Dest.IsGPR()) {

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -158,16 +158,13 @@
       ]
     },
     "vmovss [rax], xmm0": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0x11 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z16.d",
-        "movi v0.2d, #0x0",
-        "mov v0.s[0], v4.s[0]",
-        "mov v4.16b, v0.16b",
         "str s4, [x4]"
       ]
     },
@@ -189,14 +186,13 @@
       ]
     },
     "vmovsd [rax], xmm0": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x11 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z16.d",
-        "mov v4.8b, v4.8b",
         "str d4, [x4]"
       ]
     },

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -71,7 +71,7 @@
       ]
     },
     "vmovss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Insert in to first element could be more optimal, which is the common case.",
@@ -80,9 +80,6 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "movi v0.2d, #0x0",
-        "mov v0.s[0], v5.s[0]",
-        "mov v5.16b, v0.16b",
         "mov v4.s[0], v5.s[0]",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
@@ -102,7 +99,7 @@
       ]
     },
     "vmovsd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Insert in to first element could be more optimal, which is the common case.",
@@ -111,7 +108,6 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "mov v5.8b, v5.8b",
         "mov v4.d[0], v5.d[0]",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
@@ -176,7 +172,7 @@
       ]
     },
     "db 0xc5, 0xf2, 0x11, 0xc2": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "vmovss xmm2, xmm1, xmm0",
@@ -187,9 +183,6 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z16.d",
-        "movi v0.2d, #0x0",
-        "mov v0.s[0], v5.s[0]",
-        "mov v5.16b, v0.16b",
         "mov v4.s[0], v5.s[0]",
         "mov v4.16b, v4.16b",
         "mov z18.d, p7/m, z4.d"
@@ -208,7 +201,7 @@
       ]
     },
     "db 0xc5, 0xf3, 0x11, 0xc2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "vmovsd xmm2, xmm1, xmm0",
@@ -219,7 +212,6 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z16.d",
-        "mov v5.8b, v5.8b",
         "mov v4.d[0], v5.d[0]",
         "mov v4.16b, v4.16b",
         "mov z18.d, p7/m, z4.d"


### PR DESCRIPTION
In cases where we have a vector source and destination, we can load the vector by its full size. This lets us skip some unnecessary zero-extending behavior, since we're doing an insert rather than operating on the 64-bit value.