### PR TITLE
OpcodeDispatcher: Remove extraneous moves in {V}CVTSD2SS/{V}CVTSS2SD

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -2123,8 +2123,13 @@ void OpDispatchBuilder::AVXVector_CVT_Float_To_Int<8, true, true>(OpcodeArgs);
 OrderedNode* OpDispatchBuilder::Scalar_CVT_Float_To_FloatImpl(OpcodeArgs, size_t DstElementSize, size_t SrcElementSize,
                                                               const X86Tables::DecodedOperand& Src1Op,
                                                               const X86Tables::DecodedOperand& Src2Op) {
+  // In the case of vectors, we can just specify the full vector length,
+  // so that we don't unnecessarily zero-extend the entire vector.
+  // Otherwise, if it's a memory load, then we only want to load its exact size.
+  const auto Src2Size = Src2Op.IsGPR() ? 16U : SrcElementSize;
+
   OrderedNode *Src1 = LoadSource_WithOpSize(FPRClass, Op, Src1Op, 16, Op->Flags, -1);
-  OrderedNode *Src2 = LoadSource_WithOpSize(FPRClass, Op, Src2Op, SrcElementSize, Op->Flags, -1);
+  OrderedNode *Src2 = LoadSource_WithOpSize(FPRClass, Op, Src2Op, Src2Size, Op->Flags, -1);
 
   OrderedNode *Converted = _Float_FToF(DstElementSize, SrcElementSize, Src2);
 

--- a/unittests/InstructionCountCI/Secondary_REP.json
+++ b/unittests/InstructionCountCI/Secondary_REP.json
@@ -275,14 +275,11 @@
       ]
     },
     "cvtss2sd xmm0, xmm1": {
-      "ExpectedInstructionCount": 5,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": "0xf3 0x0f 0x5a",
       "ExpectedArm64ASM": [
-        "movi v0.2d, #0x0",
-        "mov v0.s[0], v17.s[0]",
-        "mov v4.16b, v0.16b",
-        "fcvt d4, s4",
+        "fcvt d4, s17",
         "mov v16.d[0], v4.d[0]"
       ]
     },

--- a/unittests/InstructionCountCI/Secondary_REPNE.json
+++ b/unittests/InstructionCountCI/Secondary_REPNE.json
@@ -224,15 +224,14 @@
       ]
     },
     "cvtsd2ss xmm0, xmm1": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "With AFP mode FEX can remove an insert after the operation.",
         "0xf2 0x0f 0x5a"
       ],
       "ExpectedArm64ASM": [
-        "mov v4.8b, v17.8b",
-        "fcvt s4, d4",
+        "fcvt s4, d17",
         "mov v16.s[0], v4.s[0]"
       ]
     },

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -4625,7 +4625,7 @@
       ]
     },
     "vcvtss2sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0x5a 128-bit"
@@ -4633,9 +4633,6 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "movi v0.2d, #0x0",
-        "mov v0.s[0], v5.s[0]",
-        "mov v5.16b, v0.16b",
         "fcvt d5, s5",
         "mov v4.d[0], v5.d[0]",
         "mov v4.16b, v4.16b",
@@ -4643,7 +4640,7 @@
       ]
     },
     "vcvtsd2ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x5a 128-bit"
@@ -4651,7 +4648,6 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "mov v5.8b, v5.8b",
         "fcvt s5, d5",
         "mov v4.s[0], v5.s[0]",
         "mov v4.16b, v4.16b",


### PR DESCRIPTION
Since all we're going to be doing is an insert as the final operation, in the cases where our source is a vector, we can specify the size of the vector rather than the size of the element to avoid doing unnecessary zero-extending.