### PR TITLE
OpcodeDispatcher: Remove redundant moves from {V}CVTSD2SI/{V}CVTSS2SI

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -1979,7 +1979,11 @@ void OpDispatchBuilder::AVXCVTGPR_To_FPR<8>(OpcodeArgs);
 
 template<size_t SrcElementSize, bool HostRoundingMode>
 void OpDispatchBuilder::CVTFPR_To_GPR(OpcodeArgs) {
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  // If loading a vector, use the full size, so we don't
+  // unnecessarily zero extend the vector. Otherwise, if
+  // memory, then we want to load the element size exactly.
+  const auto SrcSize = Op->Src[0].IsGPR() ? 16U : GetSrcSize(Op);
+  OrderedNode *Src = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], SrcSize, Op->Flags, -1);
 
   // GPR size is determined by REX.W
   // Source Element size is determined by instruction

--- a/unittests/InstructionCountCI/Secondary_REP.json
+++ b/unittests/InstructionCountCI/Secondary_REP.json
@@ -126,14 +126,11 @@
       ]
     },
     "cvttss2si eax, xmm0": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": "0xf3 0x0f 0x2c",
       "ExpectedArm64ASM": [
-        "movi v0.2d, #0x0",
-        "mov v0.s[0], v16.s[0]",
-        "mov v4.16b, v0.16b",
-        "fcvtzs w4, s4"
+        "fcvtzs w4, s16"
       ]
     },
     "cvttss2si eax, dword [rbx]": {
@@ -146,12 +143,11 @@
       ]
     },
     "cvttss2si rax, xmm0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": "0xf3 0x0f 0x2c",
       "ExpectedArm64ASM": [
-        "mov v4.8b, v16.8b",
-        "fcvtzs x4, s4"
+        "fcvtzs x4, s16"
       ]
     },
     "cvttss2si rax, dword [rbx]": {
@@ -164,14 +160,11 @@
       ]
     },
     "cvtss2si eax, xmm0": {
-      "ExpectedInstructionCount": 5,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": "0xf3 0x0f 0x2d",
       "ExpectedArm64ASM": [
-        "movi v0.2d, #0x0",
-        "mov v0.s[0], v16.s[0]",
-        "mov v4.16b, v0.16b",
-        "frinti s0, s4",
+        "frinti s0, s16",
         "fcvtzs w4, s0"
       ]
     },
@@ -186,12 +179,11 @@
       ]
     },
     "cvtss2si rax, xmm0": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": "0xf3 0x0f 0x2d",
       "ExpectedArm64ASM": [
-        "mov v4.8b, v16.8b",
-        "frinti s0, s4",
+        "frinti s0, s16",
         "fcvtzs x4, s0"
       ]
     },

--- a/unittests/InstructionCountCI/Secondary_REPNE.json
+++ b/unittests/InstructionCountCI/Secondary_REPNE.json
@@ -111,17 +111,16 @@
       ]
     },
     "cvttsd2si eax, xmm0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": "0xf2 0x0f 0x2c",
       "ExpectedArm64ASM": [
-        "mov v4.8b, v16.8b",
-        "fcvtzs w4, d4"
+        "fcvtzs w4, d16"
       ]
     },
     "cvttsd2si eax, qword [rbx]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "Optimal": "Yes",
       "Comment": "0xf2 0x0f 0x2c",
       "ExpectedArm64ASM": [
         "ldr d4, [x7]",
@@ -129,12 +128,11 @@
       ]
     },
     "cvttsd2si rax, xmm0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": "0xf2 0x0f 0x2c",
       "ExpectedArm64ASM": [
-        "mov v4.8b, v16.8b",
-        "fcvtzs x4, d4"
+        "fcvtzs x4, d16"
       ]
     },
     "cvttsd2si rax, qword [rbx]": {
@@ -147,12 +145,11 @@
       ]
     },
     "cvtsd2si eax, xmm0": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": "0xf2 0x0f 0x2d",
       "ExpectedArm64ASM": [
-        "mov v4.8b, v16.8b",
-        "frinti d0, d4",
+        "frinti d0, d16",
         "fcvtzs x4, d0"
       ]
     },
@@ -167,12 +164,11 @@
       ]
     },
     "cvtsd2si rax, xmm0": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": "0xf2 0x0f 0x2d",
       "ExpectedArm64ASM": [
-        "mov v4.8b, v16.8b",
-        "frinti d0, d4",
+        "frinti d0, d16",
         "fcvtzs x4, d0"
       ]
     },

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -4180,105 +4180,93 @@
       ]
     },
     "vcvttss2si eax, xmm0": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0x2c 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z16.d",
-        "movi v0.2d, #0x0",
-        "mov v0.s[0], v4.s[0]",
-        "mov v4.16b, v0.16b",
         "fcvtzs w4, s4"
       ]
     },
     "vcvttss2si rax, xmm0": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0x2c 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z16.d",
-        "mov v4.8b, v4.8b",
         "fcvtzs x4, s4"
       ]
     },
     "vcvttsd2si eax, xmm0": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x2c 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z16.d",
-        "mov v4.8b, v4.8b",
         "fcvtzs w4, d4"
       ]
     },
     "vcvttsd2si rax, xmm0": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x2c 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z16.d",
-        "mov v4.8b, v4.8b",
         "fcvtzs x4, d4"
       ]
     },
     "vcvtss2si eax, xmm0": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0x2d 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z16.d",
-        "movi v0.2d, #0x0",
-        "mov v0.s[0], v4.s[0]",
-        "mov v4.16b, v0.16b",
         "frinti s0, s4",
         "fcvtzs w4, s0"
       ]
     },
     "vcvtss2si rax, xmm0": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0x2d 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z16.d",
-        "mov v4.8b, v4.8b",
         "frinti s0, s4",
         "fcvtzs x4, s0"
       ]
     },
     "vcvtsd2si eax, xmm0": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x2d 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z16.d",
-        "mov v4.8b, v4.8b",
         "frinti d0, d4",
         "fcvtzs x4, d0"
       ]
     },
     "vcvtsd2si rax, xmm0": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x2d 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z16.d",
-        "mov v4.8b, v4.8b",
         "frinti d0, d4",
         "fcvtzs x4, d0"
       ]


### PR DESCRIPTION
We can specify the full vector length when dealing with a source vector to avoid zero-extending the vector unnecessarily. When dealing with a memory operand, however, we only want to load the exact source size.