### PR TITLE
OpcodeDispatcher: Remove unnecessary moves in {AVX}VectorScalarALUOp 

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -601,10 +601,14 @@ template
 void OpDispatchBuilder::VectorScalarALUOp<IR::OP_VFMAX, 8>(OpcodeArgs);
 
 void OpDispatchBuilder::AVXVectorScalarALUOpImpl(OpcodeArgs, IROps IROp, size_t ElementSize) {
+  // We load the full vector width when dealing with a source vector,
+  // so that we don't do any unnecessary zero extension to the scalar
+  // element that we're going to operate on.
+  const auto SrcSize = Op->Src[1].IsGPR() ? 16U : GetSrcSize(Op);
   const auto DstSize = GetDstSize(Op);
 
   OrderedNode *Src1 = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], DstSize, Op->Flags, -1);
-  OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags, -1);
+  OrderedNode *Src2 = LoadSource_WithOpSize(FPRClass, Op, Op->Src[1], SrcSize, Op->Flags, -1);
 
   // If OpSize == ElementSize then it only does the lower scalar op
   auto ALUOp = _VAdd(ElementSize, ElementSize, Src1, Src2);

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -546,10 +546,14 @@ template
 void OpDispatchBuilder::VectorALUROp<IR::OP_VFSUB, 8>(OpcodeArgs);
 
 void OpDispatchBuilder::VectorScalarALUOpImpl(OpcodeArgs, IROps IROp, size_t ElementSize) {
+  // We load the full vector width when dealing with a source vector,
+  // so that we don't do any unnecessary zero extension to the scalar
+  // element that we're going to operate on.
+  const auto SrcSize = Op->Src[0].IsGPR() ? 16U : GetSrcSize(Op);
   const auto DstSize = GetDstSize(Op);
 
   OrderedNode *Dest = LoadSource_WithOpSize(FPRClass, Op, Op->Dest, DstSize, Op->Flags, -1);
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Src = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], SrcSize, Op->Flags, -1);
 
   // If OpSize == ElementSize then it only does the lower scalar op
   auto ALUOp = _VAdd(ElementSize, ElementSize, Dest, Src);

--- a/unittests/InstructionCountCI/Secondary_REP.json
+++ b/unittests/InstructionCountCI/Secondary_REP.json
@@ -317,18 +317,15 @@
       ]
     },
     "minss xmm0, xmm1": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "With AFP mode FEX can remove an insert after the operation.",
         "0xf3 0x0f 0x5d"
       ],
       "ExpectedArm64ASM": [
-        "movi v0.2d, #0x0",
-        "mov v0.s[0], v17.s[0]",
-        "mov v4.16b, v0.16b",
-        "fcmp s16, s4",
-        "fcsel s4, s16, s4, mi",
+        "fcmp s16, s17",
+        "fcsel s4, s16, s17, mi",
         "mov v16.s[0], v4.s[0]"
       ]
     },
@@ -345,18 +342,15 @@
       ]
     },
     "maxss xmm0, xmm1": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "With AFP mode FEX can remove an insert after the operation.",
         "0xf3 0x0f 0x5f"
       ],
       "ExpectedArm64ASM": [
-        "movi v0.2d, #0x0",
-        "mov v0.s[0], v17.s[0]",
-        "mov v4.16b, v0.16b",
-        "fcmp s16, s4",
-        "fcsel s4, s4, s16, mi",
+        "fcmp s16, s17",
+        "fcsel s4, s17, s16, mi",
         "mov v16.s[0], v4.s[0]"
       ]
     },

--- a/unittests/InstructionCountCI/Secondary_REPNE.json
+++ b/unittests/InstructionCountCI/Secondary_REPNE.json
@@ -262,16 +262,15 @@
       ]
     },
     "minsd xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "With AFP mode FEX can remove an insert after the operation.",
         "0xf2 0x0f 0x5d"
       ],
       "ExpectedArm64ASM": [
-        "mov v4.8b, v17.8b",
-        "fcmp d16, d4",
-        "fcsel d4, d16, d4, mi",
+        "fcmp d16, d17",
+        "fcsel d4, d16, d17, mi",
         "mov v16.d[0], v4.d[0]"
       ]
     },
@@ -288,16 +287,15 @@
       ]
     },
     "maxsd xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "With AFP mode FEX can remove an insert after the operation.",
         "0xf2 0x0f 0x5f"
       ],
       "ExpectedArm64ASM": [
-        "mov v4.8b, v17.8b",
-        "fcmp d16, d4",
-        "fcsel d4, d4, d16, mi",
+        "fcmp d16, d17",
+        "fcsel d4, d17, d16, mi",
         "mov v16.d[0], v4.d[0]"
       ]
     },

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -4897,7 +4897,7 @@
       ]
     },
     "vminss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 8,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0x5d 128-bit"
@@ -4905,9 +4905,6 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "movi v0.2d, #0x0",
-        "mov v0.s[0], v5.s[0]",
-        "mov v5.16b, v0.16b",
         "fcmp s4, s5",
         "fcsel s5, s4, s5, mi",
         "mov v4.s[0], v5.s[0]",
@@ -4917,7 +4914,7 @@
       ]
     },
     "vminsd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x5d 128-bit"
@@ -4925,7 +4922,6 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "mov v5.8b, v5.8b",
         "fcmp d4, d5",
         "fcsel d5, d4, d5, mi",
         "mov v4.d[0], v5.d[0]",
@@ -5095,7 +5091,7 @@
       ]
     },
     "vmaxss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 8,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0x5f 128-bit"
@@ -5103,9 +5099,6 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "movi v0.2d, #0x0",
-        "mov v0.s[0], v5.s[0]",
-        "mov v5.16b, v0.16b",
         "fcmp s4, s5",
         "fcsel s5, s5, s4, mi",
         "mov v4.s[0], v5.s[0]",
@@ -5115,7 +5108,7 @@
       ]
     },
     "vmaxsd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x5f 128-bit"
@@ -5123,7 +5116,6 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "mov v5.8b, v5.8b",
         "fcmp d4, d5",
         "fcsel d5, d5, d4, mi",
         "mov v4.d[0], v5.d[0]",


### PR DESCRIPTION
Removes a few unnecessary moves in the vector source operand case by not zero-extending the scalar value, since it's only going to be inserted into another vector after the operation is complete.