### PR TITLE
Arm64/EncryptionOps: Use MOVI reg, #0 to zero vectors

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/Arm64/EncryptionOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/EncryptionOps.cpp
@@ -27,7 +27,7 @@ DEF_OP(AESEnc) {
   LOGMAN_THROW_AA_FMT(OpSize == Core::CPUState::XMM_SSE_REG_SIZE,
                       "Currently only supports 128-bit operations.");
 
-  eor(VTMP2.Q(), VTMP2.Q(), VTMP2.Q());
+  movi(ARMEmitter::SubRegSize::i64Bit, VTMP2.Q(), 0);
   mov(VTMP1.Q(), State.Q());
   aese(VTMP1, VTMP2);
   aesmc(VTMP1, VTMP1);
@@ -45,7 +45,7 @@ DEF_OP(AESEncLast) {
   LOGMAN_THROW_AA_FMT(OpSize == Core::CPUState::XMM_SSE_REG_SIZE,
                       "Currently only supports 128-bit operations.");
 
-  eor(VTMP2.Q(), VTMP2.Q(), VTMP2.Q());
+  movi(ARMEmitter::SubRegSize::i64Bit, VTMP2.Q(), 0);
   mov(VTMP1.Q(), State.Q());
   aese(VTMP1, VTMP2);
   eor(Dst.Q(), VTMP1.Q(), Key.Q());
@@ -62,7 +62,7 @@ DEF_OP(AESDec) {
   LOGMAN_THROW_AA_FMT(OpSize == Core::CPUState::XMM_SSE_REG_SIZE,
                       "Currently only supports 128-bit operations.");
 
-  eor(VTMP2.Q(), VTMP2.Q(), VTMP2.Q());
+  movi(ARMEmitter::SubRegSize::i64Bit, VTMP2.Q(), 0);
   mov(VTMP1.Q(), State.Q());
   aesd(VTMP1, VTMP2);
   aesimc(VTMP1, VTMP1);
@@ -80,7 +80,7 @@ DEF_OP(AESDecLast) {
   LOGMAN_THROW_AA_FMT(OpSize == Core::CPUState::XMM_SSE_REG_SIZE,
                       "Currently only supports 128-bit operations.");
 
-  eor(VTMP2.Q(), VTMP2.Q(), VTMP2.Q());
+  movi(ARMEmitter::SubRegSize::i64Bit, VTMP2.Q(), 0);
   mov(VTMP1.Q(), State.Q());
   aesd(VTMP1, VTMP2);
   eor(Dst.Q(), VTMP1.Q(), Key.Q());
@@ -93,7 +93,7 @@ DEF_OP(AESKeyGenAssist) {
   ARMEmitter::ForwardLabel PastConstant;
 
   // Do a "regular" AESE step
-  eor(VTMP2.Q(), VTMP2.Q(), VTMP2.Q());
+  movi(ARMEmitter::SubRegSize::i64Bit, VTMP2.Q(), 0);
   mov(VTMP1.Q(), GetVReg(Op->Src.ID()).Q());
   aese(VTMP1, VTMP2);
 

--- a/unittests/InstructionCountCI/H0F38.json
+++ b/unittests/InstructionCountCI/H0F38.json
@@ -1057,7 +1057,7 @@
         "0x66 0x0f 0x38 0xdc"
       ],
       "ExpectedArm64ASM": [
-        "eor v1.16b, v1.16b, v1.16b",
+        "movi v1.2d, #0x0",
         "mov v0.16b, v16.16b",
         "unimplemented (Unimplemented)",
         "unimplemented (Unimplemented)",
@@ -1071,7 +1071,7 @@
         "0x66 0x0f 0x38 0xdd"
       ],
       "ExpectedArm64ASM": [
-        "eor v1.16b, v1.16b, v1.16b",
+        "movi v1.2d, #0x0",
         "mov v0.16b, v16.16b",
         "unimplemented (Unimplemented)",
         "eor v16.16b, v0.16b, v17.16b"
@@ -1084,7 +1084,7 @@
         "0x66 0x0f 0x38 0xde"
       ],
       "ExpectedArm64ASM": [
-        "eor v1.16b, v1.16b, v1.16b",
+        "movi v1.2d, #0x0",
         "mov v0.16b, v16.16b",
         "unimplemented (Unimplemented)",
         "unimplemented (Unimplemented)",
@@ -1098,7 +1098,7 @@
         "0x66 0x0f 0x38 0xdf"
       ],
       "ExpectedArm64ASM": [
-        "eor v1.16b, v1.16b, v1.16b",
+        "movi v1.2d, #0x0",
         "mov v0.16b, v16.16b",
         "unimplemented (Unimplemented)",
         "eor v16.16b, v0.16b, v17.16b"

--- a/unittests/InstructionCountCI/H0F3A.json
+++ b/unittests/InstructionCountCI/H0F3A.json
@@ -1520,7 +1520,7 @@
         "0x66 0x0f 0x3a 0xdf"
       ],
       "ExpectedArm64ASM": [
-        "eor v1.16b, v1.16b, v1.16b",
+        "movi v1.2d, #0x0",
         "mov v0.16b, v17.16b",
         "unimplemented (Unimplemented)",
         "ldr q2, pc+12",
@@ -1539,7 +1539,7 @@
         "0x66 0x0f 0x3a 0xdf"
       ],
       "ExpectedArm64ASM": [
-        "eor v1.16b, v1.16b, v1.16b",
+        "movi v1.2d, #0x0",
         "mov v0.16b, v17.16b",
         "unimplemented (Unimplemented)",
         "ldr q2, pc+24",

--- a/unittests/InstructionCountCI/VEX_map2.json
+++ b/unittests/InstructionCountCI/VEX_map2.json
@@ -3952,7 +3952,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "eor v1.16b, v1.16b, v1.16b",
+        "movi v1.2d, #0x0",
         "mov v0.16b, v4.16b",
         "unimplemented (Unimplemented)",
         "unimplemented (Unimplemented)",
@@ -3979,7 +3979,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "eor v1.16b, v1.16b, v1.16b",
+        "movi v1.2d, #0x0",
         "mov v0.16b, v4.16b",
         "unimplemented (Unimplemented)",
         "eor v4.16b, v0.16b, v5.16b",
@@ -4005,7 +4005,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "eor v1.16b, v1.16b, v1.16b",
+        "movi v1.2d, #0x0",
         "mov v0.16b, v4.16b",
         "unimplemented (Unimplemented)",
         "unimplemented (Unimplemented)",
@@ -4032,7 +4032,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "eor v1.16b, v1.16b, v1.16b",
+        "movi v1.2d, #0x0",
         "mov v0.16b, v4.16b",
         "unimplemented (Unimplemented)",
         "eor v4.16b, v0.16b, v5.16b",

--- a/unittests/InstructionCountCI/VEX_map3.json
+++ b/unittests/InstructionCountCI/VEX_map3.json
@@ -6124,7 +6124,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "eor v1.16b, v1.16b, v1.16b",
+        "movi v1.2d, #0x0",
         "mov v0.16b, v4.16b",
         "unimplemented (Unimplemented)",
         "ldr q2, pc+12",
@@ -6147,7 +6147,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "eor v1.16b, v1.16b, v1.16b",
+        "movi v1.2d, #0x0",
         "mov v0.16b, v4.16b",
         "unimplemented (Unimplemented)",
         "ldr q2, pc+24",


### PR DESCRIPTION
This is a little more optimal than XORing the vector by itself.