### PR TITLE
OpcodeDispatcher: Improve SHA1MSG1 output

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
@@ -3191,13 +3191,13 @@ DEF_OP(VExtr) {
 
   const auto Index = Op->Index;
   const auto ElementSize = Op->Header.ElementSize;
+  const auto ByteIndex = uint32_t{Index} * ElementSize;
 
   const auto Dst = GetDst(Node);
   const auto VectorLower = GetSrc(Op->VectorLower.ID());
   const auto VectorUpper = GetSrc(Op->VectorUpper.ID());
 
   if (Is256Bit) {
-    const auto ByteIndex = Index * ElementSize;
     const auto IsUpperVectorZero = ByteIndex >= OpSize;
     const auto SanitizedByteIndex = IsUpperVectorZero ? ByteIndex - OpSize
                                                       : ByteIndex;
@@ -3227,9 +3227,9 @@ DEF_OP(VExtr) {
     vpxor(xmm14, xmm14, xmm14);
     movq(xmm15, VectorUpper);
     vshufpd(xmm15, xmm15, VectorLower, 0b00);
-    vpalignr(Dst, xmm14, xmm15, Index);
+    vpalignr(Dst, xmm14, xmm15, ByteIndex);
   } else {
-    vpalignr(Dst, VectorLower, VectorUpper, Index);
+    vpalignr(Dst, VectorLower, VectorUpper, ByteIndex);
   }
 }
 

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Crypto.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Crypto.cpp
@@ -36,11 +36,7 @@ void OpDispatchBuilder::SHA1MSG1Op(OpcodeArgs) {
   OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
   OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
 
-  OrderedNode *NewVec{};
-  NewVec = _VInsElement(16, 4, 3, 1, Dest, Dest);
-  NewVec = _VInsElement(16, 4, 2, 0, NewVec, Dest);
-  NewVec = _VInsElement(16, 4, 1, 3, NewVec, Src);
-  NewVec = _VInsElement(16, 4, 0, 2, NewVec, Src);
+  OrderedNode *NewVec = _VExtr(16, 8, Dest, Src, 1);
 
   // [W0, W1, W2, W3] ^ [W2, W3, W4, W5]
   OrderedNode *Result = _VXor(16, 1, Dest, NewVec);

--- a/unittests/InstructionCountCI/H0F38.json
+++ b/unittests/InstructionCountCI/H0F38.json
@@ -782,18 +782,13 @@
       ]
     },
     "sha1msg1 xmm0, xmm1": {
-      "ExpectedInstructionCount": 7,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0xc9"
       ],
       "ExpectedArm64ASM": [
-        "mov v0.16b, v16.16b",
-        "mov v0.s[3], v16.s[1]",
-        "mov v4.16b, v0.16b",
-        "mov v4.s[2], v16.s[0]",
-        "mov v4.s[1], v17.s[3]",
-        "mov v4.s[0], v17.s[2]",
+        "ext v4.16b, v17.16b, v16.16b, #8",
         "eor v16.16b, v16.16b, v4.16b"
       ]
     },


### PR DESCRIPTION
We can simplify these inserts down to only two inserts.