### PR TITLE
Interpreter: Tie SSA data elements to supported vector width

### DIFF
--- a/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -346,8 +346,10 @@ void InterpreterOps::InterpretIR(FEXCore::Core::CpuStateFrame *Frame, FEXCore::I
 
   auto BlockEnd = CurrentIR->GetBlocks().end();
 
-  constexpr size_t ListEntrySizeInBytes = sizeof(InterpVector256);
-  const size_t SSADataSize = ListSize * ListEntrySizeInBytes;
+  // SSA data elements must be able to accommodate data that would
+  // fit inside the largest vector size (otherwise vector operations
+  // go kaboom, and we don't want that).
+  const size_t SSADataSize = ListSize * MaxInterpeterVectorSize;
 
   InterpreterOps::IROpData OpData{
     .State = Frame->Thread,

--- a/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
+++ b/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <cstddef>
 #include <cstdint>
 
 #include <FEXCore/Core/CoreState.h>
@@ -433,13 +434,14 @@ namespace FEXCore::CPU {
     return IROp->Size;
   }
 
+  // The maximum size a vector can be within FEX's interpreter.
+  // NOTE: If we ever support AVX-512, this should be changed
+  //       to 64 bytes in size.
+  static constexpr size_t MaxInterpeterVectorSize = Core::CPUState::XMM_AVX_REG_SIZE;
+
   // Alias for specifying temporary data that is operated on
   // before storing into a destination.
-  //
-  // NOTE: This should be the maximum size a vector can be within
-  //       FEX. e.g. If we ever support AVX-512, this should be changed
-  //       to be 64 bytes in size.
-  using TempVectorDataArray = std::array<uint8_t, Core::CPUState::XMM_AVX_REG_SIZE>;
+  using TempVectorDataArray = std::array<uint8_t, MaxInterpeterVectorSize>;
 
   };
 } // namespace FEXCore::CPU


### PR DESCRIPTION
Now, if we ever increase our vector sizes, the allocated data elements will follow suit without needing to remember to handle this as well.