### PR TITLE
X86Tables: Optimize MOVLPD stores 

### DIFF
--- a/FEXCore/Source/Interface/Core/X86Tables/SecondaryTables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables/SecondaryTables.cpp
@@ -439,7 +439,7 @@ void InitializeSecondaryTables(Context::OperatingMode Mode) {
     {0x10, 1, X86InstInfo{"MOVUPD",     TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS,                         0, nullptr}},
     {0x11, 1, X86InstInfo{"MOVUPD",     TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_XMM_FLAGS,                         0, nullptr}},
     {0x12, 1, X86InstInfo{"MOVLPD",     TYPE_INST, GenFlagsSizes(SIZE_128BIT, SIZE_64BIT) | FLAGS_MODRM | FLAGS_SF_MOD_MEM_ONLY | FLAGS_XMM_FLAGS,      0, nullptr}},
-    {0x13, 1, X86InstInfo{"MOVLPD",     TYPE_INST, GenFlagsSizes(SIZE_64BIT, SIZE_64BIT) | FLAGS_MODRM | FLAGS_SF_MOD_MEM_ONLY | FLAGS_SF_MOD_DST | FLAGS_XMM_FLAGS,      0, nullptr}},
+    {0x13, 1, X86InstInfo{"MOVLPD",     TYPE_INST, GenFlagsSizes(SIZE_64BIT, SIZE_128BIT) | FLAGS_MODRM | FLAGS_SF_MOD_MEM_ONLY | FLAGS_SF_MOD_DST | FLAGS_XMM_FLAGS,      0, nullptr}},
     {0x14, 1, X86InstInfo{"UNPCKLPD",   TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS,                         0, nullptr}},
     {0x15, 1, X86InstInfo{"UNPCKHPD",   TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS,                         0, nullptr}},
     {0x16, 1, X86InstInfo{"MOVHPD",     TYPE_INST, GenFlagsSizes(SIZE_128BIT, SIZE_64BIT) | FLAGS_MODRM | FLAGS_SF_MOD_MEM_ONLY | FLAGS_XMM_FLAGS,      0, nullptr}},

--- a/unittests/InstructionCountCI/Secondary_OpSize.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize.json
@@ -42,12 +42,11 @@
       ]
     },
     "movlpd [rax], xmm0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x13",
       "ExpectedArm64ASM": [
-        "mov v4.8b, v16.8b",
-        "str d4, [x4]"
+        "str d16, [x4]"
       ]
     },
     "unpcklpd xmm0, xmm1": {


### PR DESCRIPTION
Just use the full register size and store the lower bits.