### PR TITLE
OpcodeDispatcher: Remove unnecessary move from VPHMINPOSUW

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -6103,7 +6103,7 @@ void OpDispatchBuilder::InstallHostSpecificOpcodeHandlers() {
     {OPD(2, 0b01, 0x3F), 1, &OpDispatchBuilder::AVXVectorALUOp<IR::OP_VUMAX, 4>},
 
     {OPD(2, 0b01, 0x40), 1, &OpDispatchBuilder::AVXVectorALUOp<IR::OP_VSMUL, 4>},
-    {OPD(2, 0b01, 0x41), 1, &OpDispatchBuilder::VPHMINPOSUWOp},
+    {OPD(2, 0b01, 0x41), 1, &OpDispatchBuilder::PHMINPOSUWOp},
     {OPD(2, 0b01, 0x45), 1, &OpDispatchBuilder::VPSRLVOp},
     {OPD(2, 0b01, 0x46), 1, &OpDispatchBuilder::VPSRAVDOp},
     {OPD(2, 0b01, 0x47), 1, &OpDispatchBuilder::VPSLLVOp},

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -518,8 +518,6 @@ public:
 
   void VPHADDSWOp(OpcodeArgs);
 
-  void VPHMINPOSUWOp(OpcodeArgs);
-
   template <size_t ElementSize>
   void VPHSUBOp(OpcodeArgs);
   void VPHSUBSWOp(OpcodeArgs);

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -4089,12 +4089,6 @@ void OpDispatchBuilder::PHMINPOSUWOp(OpcodeArgs) {
   StoreResult(FPRClass, Op, Result, -1);
 }
 
-void OpDispatchBuilder::VPHMINPOSUWOp(OpcodeArgs) {
-  OrderedNode *MinPos = PHMINPOSUWOpImpl(Op);
-  OrderedNode *Result = _VMov(16, MinPos);
-  StoreResult(FPRClass, Op, Result, -1);
-}
-
 OrderedNode* OpDispatchBuilder::DPPOpImpl(OpcodeArgs, const X86Tables::DecodedOperand& Src1,
                                           const X86Tables::DecodedOperand& Src2,
                                           const X86Tables::DecodedOperand& Imm, size_t ElementSize) {

--- a/unittests/InstructionCountCI/VEX_map2.json
+++ b/unittests/InstructionCountCI/VEX_map2.json
@@ -1933,7 +1933,7 @@
       ]
     },
     "vphminposuw xmm0, xmm1": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x41 256-bit"
@@ -1947,7 +1947,6 @@
         "umin v4.4s, v6.4s, v4.4s",
         "uminv s4, v4.4s",
         "rev32 v4.8h, v4.8h",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]


### PR DESCRIPTION
We already do a zero-extend if necessary in StoreResult.

This also lets us unify both the SSE and AVX handling code.