### PR TITLE
OpcodeDispatcher: Optimize MOVLP{S,D} loads 

### DIFF
--- a/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -154,6 +154,7 @@ constexpr OpHandlerArray InterpreterOpHandlers = [] {
   REGISTER_OP(STOREMEMTSO,            StoreMem);
   REGISTER_OP(VLOADVECTORMASKED,      VLoadVectorMasked);
   REGISTER_OP(VSTOREVECTORMASKED,     VStoreVectorMasked);
+  REGISTER_OP(VLOADVECTORELEMENT,     VLoadVectorElement);
   REGISTER_OP(VBROADCASTFROMMEM,      VBroadcastFromMem);
   REGISTER_OP(PUSH,                   Push);
   REGISTER_OP(MEMSET,                 MemSet);

--- a/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
+++ b/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
@@ -190,6 +190,7 @@ namespace FEXCore::CPU {
   DEF_OP(StoreMem);
   DEF_OP(VLoadVectorMasked);
   DEF_OP(VStoreVectorMasked);
+  DEF_OP(VLoadVectorElement);
   DEF_OP(VBroadcastFromMem);
   DEF_OP(Push);
   DEF_OP(MemSet);

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -972,6 +972,7 @@ CPUBackend::CompiledCode Arm64JITCore::CompileCode(uint64_t Entry,
         REGISTER_OP_RT(STOREMEMTSO,      StoreMemTSO);
         REGISTER_OP(VLOADVECTORMASKED,   VLoadVectorMasked);
         REGISTER_OP(VSTOREVECTORMASKED,  VStoreVectorMasked);
+        REGISTER_OP(VLOADVECTORELEMENT,  VLoadVectorElement);
         REGISTER_OP(VBROADCASTFROMMEM,   VBroadcastFromMem);
         REGISTER_OP(PUSH,                Push);
         REGISTER_OP(MEMSET,              MemSet);

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -343,6 +343,7 @@ private:
   DEF_OP(StoreMemTSO);
   DEF_OP(VLoadVectorMasked);
   DEF_OP(VStoreVectorMasked);
+  DEF_OP(VLoadVectorElement);
   DEF_OP(VBroadcastFromMem);
   DEF_OP(Push);
   DEF_OP(MemSet);

--- a/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -349,6 +349,7 @@ private:
   DEF_OP(StoreMem);
   DEF_OP(VLoadVectorMasked);
   DEF_OP(VStoreVectorMasked);
+  DEF_OP(VLoadVectorElement);
   DEF_OP(VBroadcastFromMem);
   DEF_OP(Push);
   DEF_OP(MemSet);

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -115,22 +115,24 @@ void OpDispatchBuilder::VMOVHPOp(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::MOVLPOp(OpcodeArgs) {
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, 8);
   if (Op->Dest.IsGPR()) {
     // xmm, xmm is movhlps special case
     if (Op->Src[0].IsGPR()) {
+      OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, 8);
       OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, 8, 16);
       auto Result = _VInsElement(16, 8, 0, 1, Dest, Src);
       StoreResult_WithOpSize(FPRClass, Op, Op->Dest, Result, 16, 16);
     }
     else {
       auto DstSize = GetDstSize(Op);
+      OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, 8, false);
       OrderedNode *Dest = LoadSource_WithOpSize(FPRClass, Op, Op->Dest, DstSize, Op->Flags, -1);
-      auto Result = _VInsElement(16, 8, 0, 0, Dest, Src);
+      auto Result = _VLoadVectorElement(16, 8, Dest, 0, Src);
       StoreResult(FPRClass, Op, Result, -1);
     }
   }
   else {
+    OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, 8);
     StoreResult_WithOpSize(FPRClass, Op, Op->Dest, Src, 8, 8);
   }
 }

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -491,7 +491,6 @@
         "DestSize": "RegisterSize",
         "NumElements": "RegisterSize / ElementSize"
       },
-
       "VStoreVectorMasked u8:#RegisterSize, u8:#ElementSize, FPR:$Mask, FPR:$Data, GPR:$Addr, GPR:$Offset, MemOffsetType:$OffsetType, u8:$OffsetScale": {
         "Desc": ["Does a masked store similar to VPMASKMOV/VMASKMOV where the upper bit of each element",
                  "determines whether or not that element will be stored to memory"],
@@ -499,7 +498,13 @@
         "DestSize": "RegisterSize",
         "NumElements": "RegisterSize / ElementSize"
       },
-
+      "FPR = VLoadVectorElement u8:#RegisterSize, u8:#ElementSize, FPR:$DstSrc, u8:$Index, GPR:$Addr": {
+        "Desc": ["Does a memory load to a single element of a vector.",
+                 "Leaves the rest of the vector's data intact.",
+                 "Matches arm64 ld1 semantics"],
+        "DestSize": "RegisterSize",
+        "NumElements": "RegisterSize / ElementSize"
+      },
       "FPR = VBroadcastFromMem u8:#RegisterSize, u8:#ElementSize, GPR:$Address": {
         "Desc": ["Broadcasts an ElementSize value from memory into each element of a vector."],
         "DestSize": "RegisterSize",

--- a/unittests/InstructionCountCI/Secondary.json
+++ b/unittests/InstructionCountCI/Secondary.json
@@ -40,12 +40,11 @@
       ]
     },
     "movlps xmm0, [rax]": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": "0x0f 0x12",
       "ExpectedArm64ASM": [
-        "ldr q4, [x4]",
-        "mov v16.d[0], v4.d[0]"
+        "ld1 {v16.d}[0], [x4]"
       ]
     },
     "movlps [rax], xmm0": {
@@ -54,6 +53,14 @@
       "Comment": "0x0f 0x13",
       "ExpectedArm64ASM": [
         "str d16, [x4]"
+      ]
+    },
+    "movhlps xmm0, xmm1": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": "0x0f 0x12",
+      "ExpectedArm64ASM": [
+        "mov v16.d[0], v17.d[1]"
       ]
     },
     "unpcklps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_OpSize.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize.json
@@ -33,12 +33,11 @@
       ]
     },
     "movlpd xmm0, [rax]": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x12",
       "ExpectedArm64ASM": [
-        "ldr d4, [x4]",
-        "mov v16.d[0], v4.d[0]"
+        "ld1 {v16.d}[0], [x4]"
       ]
     },
     "movlpd [rax], xmm0": {


### PR DESCRIPTION
This now uses the new load element IR operation and makes these
instructions optimal.

LRPCPC3 will introduce instructions in the future for TSO emulation to
help these operations, but that doesn't exist today.