### PR TITLE
OpcodeDispatcher: Optimize MOVHP{S,D}

### DIFF
--- a/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -155,6 +155,7 @@ constexpr OpHandlerArray InterpreterOpHandlers = [] {
   REGISTER_OP(VLOADVECTORMASKED,      VLoadVectorMasked);
   REGISTER_OP(VSTOREVECTORMASKED,     VStoreVectorMasked);
   REGISTER_OP(VLOADVECTORELEMENT,     VLoadVectorElement);
+  REGISTER_OP(VSTOREVECTORELEMENT,    VStoreVectorElement);
   REGISTER_OP(VBROADCASTFROMMEM,      VBroadcastFromMem);
   REGISTER_OP(PUSH,                   Push);
   REGISTER_OP(MEMSET,                 MemSet);

--- a/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
+++ b/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
@@ -191,6 +191,7 @@ namespace FEXCore::CPU {
   DEF_OP(VLoadVectorMasked);
   DEF_OP(VStoreVectorMasked);
   DEF_OP(VLoadVectorElement);
+  DEF_OP(VStoreVectorElement);
   DEF_OP(VBroadcastFromMem);
   DEF_OP(Push);
   DEF_OP(MemSet);

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -973,6 +973,7 @@ CPUBackend::CompiledCode Arm64JITCore::CompileCode(uint64_t Entry,
         REGISTER_OP(VLOADVECTORMASKED,   VLoadVectorMasked);
         REGISTER_OP(VSTOREVECTORMASKED,  VStoreVectorMasked);
         REGISTER_OP(VLOADVECTORELEMENT,  VLoadVectorElement);
+        REGISTER_OP(VSTOREVECTORELEMENT, VStoreVectorElement);
         REGISTER_OP(VBROADCASTFROMMEM,   VBroadcastFromMem);
         REGISTER_OP(PUSH,                Push);
         REGISTER_OP(MEMSET,              MemSet);

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -344,6 +344,7 @@ private:
   DEF_OP(VLoadVectorMasked);
   DEF_OP(VStoreVectorMasked);
   DEF_OP(VLoadVectorElement);
+  DEF_OP(VStoreVectorElement);
   DEF_OP(VBroadcastFromMem);
   DEF_OP(Push);
   DEF_OP(MemSet);

--- a/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -350,6 +350,7 @@ private:
   DEF_OP(VLoadVectorMasked);
   DEF_OP(VStoreVectorMasked);
   DEF_OP(VLoadVectorElement);
+  DEF_OP(VStoreVectorElement);
   DEF_OP(VBroadcastFromMem);
   DEF_OP(Push);
   DEF_OP(MemSet);

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -505,6 +505,13 @@
         "DestSize": "RegisterSize",
         "NumElements": "RegisterSize / ElementSize"
       },
+      "VStoreVectorElement u8:#RegisterSize, u8:#ElementSize, FPR:$Value, u8:$Index, GPR:$Addr": {
+        "Desc": ["Does a memory store of a single element of a vector.",
+                 "Matches arm64 st1 semantics"],
+        "HasSideEffects": true,
+        "DestSize": "RegisterSize",
+        "NumElements": "RegisterSize / ElementSize"
+      },
       "FPR = VBroadcastFromMem u8:#RegisterSize, u8:#ElementSize, GPR:$Address": {
         "Desc": ["Broadcasts an ElementSize value from memory into each element of a vector."],
         "DestSize": "RegisterSize",

--- a/unittests/InstructionCountCI/Secondary.json
+++ b/unittests/InstructionCountCI/Secondary.json
@@ -80,12 +80,11 @@
       ]
     },
     "movhps xmm0, [rax]": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": "0x0f 0x16",
       "ExpectedArm64ASM": [
-        "ldr q4, [x4]",
-        "mov v16.d[1], v4.d[0]"
+        "ld1 {v16.d}[1], [x4]"
       ]
     },
     "movlhps xmm0, xmm1": {
@@ -97,12 +96,11 @@
       ]
     },
     "movhps [rax], xmm0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": "0x0f 0x17",
       "ExpectedArm64ASM": [
-        "mov x20, v16.d[1]",
-        "str x20, [x4]"
+        "st1 {v16.d}[1], [x4]"
       ]
     },
     "nop": {

--- a/unittests/InstructionCountCI/Secondary_OpSize.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize.json
@@ -65,21 +65,19 @@
       ]
     },
     "movhpd xmm0, [rax]": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x16",
       "ExpectedArm64ASM": [
-        "ldr d4, [x4]",
-        "mov v16.d[1], v4.d[0]"
+        "ld1 {v16.d}[1], [x4]"
       ]
     },
     "movhpd [rax], xmm0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x17",
       "ExpectedArm64ASM": [
-        "mov x20, v16.d[1]",
-        "str x20, [x4]"
+        "st1 {v16.d}[1], [x4]"
       ]
     },
     "movapd xmm0, xmm1": {


### PR DESCRIPTION
Loads can turn in to element Loads.
Stores can turn in to element stores.

These four instruction variants are now optimal.

~~Requires #2963 to be merged first.~~