### PR TITLE
OpcodeDispatcher: Remove unnecessary moves from AVX inserts

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -1285,24 +1285,19 @@ void OpDispatchBuilder::PINSROp<8>(OpcodeArgs);
 
 void OpDispatchBuilder::VPINSRBOp(OpcodeArgs) {
   OrderedNode *Result = PINSROpImpl(Op, 1, Op->Src[0], Op->Src[1], Op->Src[2]);
-  OrderedNode *Final = _VMov(16, Result);
-
-  StoreResult(FPRClass, Op, Final, -1);
+  StoreResult(FPRClass, Op, Result, -1);
 }
 
 void OpDispatchBuilder::VPINSRDQOp(OpcodeArgs) {
   const auto SrcSize = GetSrcSize(Op);
   OrderedNode *Result = PINSROpImpl(Op, SrcSize, Op->Src[0], Op->Src[1], Op->Src[2]);
-  OrderedNode *Final = _VMov(16, Result);
 
-  StoreResult(FPRClass, Op, Final, -1);
+  StoreResult(FPRClass, Op, Result, -1);
 }
 
 void OpDispatchBuilder::VPINSRWOp(OpcodeArgs) {
   OrderedNode *Result = PINSROpImpl(Op, 2, Op->Src[0], Op->Src[1], Op->Src[2]);
-  OrderedNode *Final = _VMov(16, Result);
-
-  StoreResult(FPRClass, Op, Final, -1);
+  StoreResult(FPRClass, Op, Result, -1);
 }
 
 OrderedNode* OpDispatchBuilder::InsertPSOpImpl(OpcodeArgs, const X86Tables::DecodedOperand& Src1,
@@ -1359,9 +1354,7 @@ void OpDispatchBuilder::InsertPSOp(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::VINSERTPSOp(OpcodeArgs) {
-  OrderedNode *Insert = InsertPSOpImpl(Op, Op->Src[0], Op->Src[1], Op->Src[2]);
-  OrderedNode *Result = _VMov(16, Insert);
-
+  OrderedNode *Result = InsertPSOpImpl(Op, Op->Src[0], Op->Src[1], Op->Src[2]);
   StoreResult(FPRClass, Op, Result, -1);
 }
 

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -3078,7 +3078,7 @@
       ]
     },
     "vpinsrw xmm0, xmm1, eax, 000b": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC4 128-bit"
@@ -3089,12 +3089,11 @@
         "mov v4.16b, v4.16b",
         "mov v4.h[0], w20",
         "mov v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vpinsrw xmm0, xmm1, eax, 001b": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC4 128-bit"
@@ -3105,12 +3104,11 @@
         "mov v4.16b, v4.16b",
         "mov v4.h[1], w20",
         "mov v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vpinsrw xmm0, xmm1, eax, 111b": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC4 128-bit"
@@ -3120,7 +3118,6 @@
         "mov z4.d, p7/m, z17.d",
         "mov v4.16b, v4.16b",
         "mov v4.h[7], w20",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]

--- a/unittests/InstructionCountCI/VEX_map3.json
+++ b/unittests/InstructionCountCI/VEX_map3.json
@@ -3262,7 +3262,7 @@
       ]
     },
     "vpinsrb xmm0, xmm1, eax, 0": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "nearest rounding",
@@ -3274,12 +3274,11 @@
         "mov v4.16b, v4.16b",
         "mov v4.b[0], w20",
         "mov v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vpinsrb xmm0, xmm1, eax, 15": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "nearest rounding",
@@ -3291,12 +3290,11 @@
         "mov v4.16b, v4.16b",
         "mov v4.b[15], w20",
         "mov v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vinsertps xmm0, xmm1, xmm2, ((0b00 << 6) | (0b00 << 4) | (0b0000))": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "nearest rounding",
@@ -3307,12 +3305,11 @@
         "mov z5.d, p7/m, z18.d",
         "mov v4.s[0], v5.s[0]",
         "mov v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vinsertps xmm0, xmm1, xmm2, ((0b00 << 6) | (0b00 << 4) | (0b1111))": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "nearest rounding",
@@ -3321,12 +3318,11 @@
       "ExpectedArm64ASM": [
         "movi v4.2d, #0x0",
         "mov v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vinsertps xmm0, xmm1, xmm2, ((0b11 << 6) | (0b11 << 4) | (0b0000))": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "nearest rounding",
@@ -3337,12 +3333,11 @@
         "mov z5.d, p7/m, z18.d",
         "mov v4.s[3], v5.s[3]",
         "mov v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vpinsrd xmm0, xmm1, eax, 0": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "nearest rounding",
@@ -3354,12 +3349,11 @@
         "mov v4.16b, v4.16b",
         "mov v4.s[0], w20",
         "mov v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vpinsrd xmm0, xmm1, eax, 3": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "nearest rounding",
@@ -3371,12 +3365,11 @@
         "mov v4.16b, v4.16b",
         "mov v4.s[3], w20",
         "mov v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vpinsrq xmm0, xmm1, rax, 0": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "nearest rounding",
@@ -3387,12 +3380,11 @@
         "mov v4.16b, v4.16b",
         "mov v4.d[0], x4",
         "mov v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vpinsrq xmm0, xmm1, rax, 1": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "nearest rounding",
@@ -3402,7 +3394,6 @@
         "mov z4.d, p7/m, z17.d",
         "mov v4.16b, v4.16b",
         "mov v4.d[1], x4",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]


### PR DESCRIPTION
We already zero-extend on stores when necessary.