### PR TITLE
Arm64: Optimize VFMin/VFMax

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -869,10 +869,22 @@ DEF_OP(VFMin) {
           break;
       }
     } else {
-      fcmgt(SubRegSize, VTMP1.Q(), Vector2.Q(), Vector1.Q());
-      mov(VTMP2.Q(), Vector1.Q());
-      bif(VTMP2.Q(), Vector2.Q(), VTMP1.Q());
-      mov(Dst.Q(), VTMP2.Q());
+      if (Dst == Vector1) {
+        // Destination is already Vector1, need to insert Vector2 on false.
+        fcmgt(SubRegSize, VTMP1.Q(), Vector2.Q(), Vector1.Q());
+        bif(Dst.Q(), Vector2.Q(), VTMP1.Q());
+      }
+      else if (Dst == Vector2) {
+        // Destination is already Vector2, Invert arguments and insert Vector1 on false.
+        fcmgt(SubRegSize, VTMP1.Q(), Vector1.Q(), Vector2.Q());
+        bif(Dst.Q(), Vector1.Q(), VTMP1.Q());
+      }
+      else {
+        // Dst is not either source, need a move.
+        fcmgt(SubRegSize, VTMP1.Q(), Vector2.Q(), Vector1.Q());
+        mov(Dst.Q(), Vector1.Q());
+        bif(Dst.Q(), Vector2.Q(), VTMP1.Q());
+      }
     }
   }
 }
@@ -930,10 +942,22 @@ DEF_OP(VFMax) {
           break;
       }
     } else {
-      fcmgt(SubRegSize, VTMP1.Q(), Vector2.Q(), Vector1.Q());
-      mov(VTMP2.Q(), Vector1.Q());
-      bit(VTMP2.Q(), Vector2.Q(), VTMP1.Q());
-      mov(Dst.Q(), VTMP2.Q());
+      if (Dst == Vector1) {
+        // Destination is already Vector1, need to insert Vector2 on true.
+        fcmgt(SubRegSize, VTMP1.Q(), Vector2.Q(), Vector1.Q());
+        bit(Dst.Q(), Vector2.Q(), VTMP1.Q());
+      }
+      else if (Dst == Vector2) {
+        // Destination is already Vector2, Invert arguments and insert Vector1 on true.
+        fcmgt(SubRegSize, VTMP1.Q(), Vector1.Q(), Vector2.Q());
+        bit(Dst.Q(), Vector1.Q(), VTMP1.Q());
+      }
+      else {
+        // Dst is not either source, need a move.
+        fcmgt(SubRegSize, VTMP1.Q(), Vector2.Q(), Vector1.Q());
+        mov(Dst.Q(), Vector1.Q());
+        bit(Dst.Q(), Vector2.Q(), VTMP1.Q());
+      }
     }
   }
 }

--- a/unittests/InstructionCountCI/DDD.json
+++ b/unittests/InstructionCountCI/DDD.json
@@ -143,16 +143,14 @@
       ]
     },
     "pfmin mm0, mm1": {
-      "ExpectedInstructionCount": 7,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 5,
+      "Optimal": "Yes",
       "Comment": "0x0f 0x0f 0x94",
       "ExpectedArm64ASM": [
         "ldr d4, [x28, #768]",
         "ldr d5, [x28, #752]",
-        "fcmgt v0.4s, v4.4s, v5.4s",
-        "mov v1.16b, v5.16b",
-        "bif v1.16b, v4.16b, v0.16b",
-        "mov v4.16b, v1.16b",
+        "fcmgt v0.4s, v5.4s, v4.4s",
+        "bif v4.16b, v5.16b, v0.16b",
         "str d4, [x28, #752]"
       ]
     },
@@ -221,16 +219,14 @@
       ]
     },
     "pfmax mm0, mm1": {
-      "ExpectedInstructionCount": 7,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 5,
+      "Optimal": "Yes",
       "Comment": "0x0f 0x0f 0xa4",
       "ExpectedArm64ASM": [
         "ldr d4, [x28, #768]",
         "ldr d5, [x28, #752]",
-        "fcmgt v0.4s, v4.4s, v5.4s",
-        "mov v1.16b, v5.16b",
-        "bit v1.16b, v4.16b, v0.16b",
-        "mov v4.16b, v1.16b",
+        "fcmgt v0.4s, v5.4s, v4.4s",
+        "bit v4.16b, v5.16b, v0.16b",
         "str d4, [x28, #752]"
       ]
     },

--- a/unittests/InstructionCountCI/Secondary.json
+++ b/unittests/InstructionCountCI/Secondary.json
@@ -1157,14 +1157,12 @@
       ]
     },
     "minps xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": "0x0f 0x5d",
       "ExpectedArm64ASM": [
         "fcmgt v0.4s, v17.4s, v16.4s",
-        "mov v1.16b, v16.16b",
-        "bif v1.16b, v17.16b, v0.16b",
-        "mov v16.16b, v1.16b"
+        "bif v16.16b, v17.16b, v0.16b"
       ]
     },
     "divps xmm0, xmm1": {
@@ -1176,14 +1174,12 @@
       ]
     },
     "maxps xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": "0x0f 0x5f",
       "ExpectedArm64ASM": [
         "fcmgt v0.4s, v17.4s, v16.4s",
-        "mov v1.16b, v16.16b",
-        "bit v1.16b, v17.16b, v0.16b",
-        "mov v16.16b, v1.16b"
+        "bit v16.16b, v17.16b, v0.16b"
       ]
     },
     "punpcklbw mm0, mm1": {

--- a/unittests/InstructionCountCI/Secondary_OpSize.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize.json
@@ -286,14 +286,12 @@
       ]
     },
     "minpd xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x5d",
       "ExpectedArm64ASM": [
         "fcmgt v0.2d, v17.2d, v16.2d",
-        "mov v1.16b, v16.16b",
-        "bif v1.16b, v17.16b, v0.16b",
-        "mov v16.16b, v1.16b"
+        "bif v16.16b, v17.16b, v0.16b"
       ]
     },
     "divpd xmm0, xmm1": {
@@ -305,14 +303,12 @@
       ]
     },
     "maxpd xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x5f",
       "ExpectedArm64ASM": [
         "fcmgt v0.2d, v17.2d, v16.2d",
-        "mov v1.16b, v16.16b",
-        "bit v1.16b, v17.16b, v0.16b",
-        "mov v16.16b, v1.16b"
+        "bit v16.16b, v17.16b, v0.16b"
       ]
     },
     "punpcklbw xmm0, xmm1": {

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -4313,7 +4313,7 @@
       ]
     },
     "vminps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x5d 128-bit"
@@ -4322,9 +4322,7 @@
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
         "fcmgt v0.4s, v5.4s, v4.4s",
-        "mov v1.16b, v4.16b",
-        "bif v1.16b, v5.16b, v0.16b",
-        "mov v4.16b, v1.16b",
+        "bif v4.16b, v5.16b, v0.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -4347,7 +4345,7 @@
       ]
     },
     "vminpd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x5d 128-bit"
@@ -4356,9 +4354,7 @@
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
         "fcmgt v0.2d, v5.2d, v4.2d",
-        "mov v1.16b, v4.16b",
-        "bif v1.16b, v5.16b, v0.16b",
-        "mov v4.16b, v1.16b",
+        "bif v4.16b, v5.16b, v0.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -4501,7 +4497,7 @@
       ]
     },
     "vmaxps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x5f 128-bit"
@@ -4510,9 +4506,7 @@
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
         "fcmgt v0.4s, v5.4s, v4.4s",
-        "mov v1.16b, v4.16b",
-        "bit v1.16b, v5.16b, v0.16b",
-        "mov v4.16b, v1.16b",
+        "bit v4.16b, v5.16b, v0.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -4534,7 +4528,7 @@
       ]
     },
     "vmaxpd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x5f 128-bit"
@@ -4543,9 +4537,7 @@
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
         "fcmgt v0.2d, v5.2d, v4.2d",
-        "mov v1.16b, v4.16b",
-        "bit v1.16b, v5.16b, v0.16b",
-        "mov v4.16b, v1.16b",
+        "bit v4.16b, v5.16b, v0.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]


### PR DESCRIPTION
We can be more optimal on the selects. This makes 3DNow! and SSE packed
min/max operations optimal.