### PR TITLE
OpcodeDispatcher: Remove redundant moves in AVX blend special cases

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -4388,14 +4388,12 @@ void OpDispatchBuilder::VBLENDPDOp(OpcodeArgs) {
   const auto Selector = Op->Src[2].Data.Literal.Value;
 
   if (Selector == 0) {
-    OrderedNode *Result = Is256Bit ? Src1 : _VMov(16, Src1);
-    StoreResult(FPRClass, Op, Result, -1);
+    StoreResult(FPRClass, Op, Src1, -1);
     return;
   }
   // Only the first four bits of the 8-bit immediate are used, so only check them.
   if (((Selector & 0b11) == 0b11 && !Is256Bit) || (Selector & 0b1111) == 0b1111) {
-    OrderedNode *Result = Is256Bit ? Src2 : _VMov(16, Src2);
-    StoreResult(FPRClass, Op, Result, -1);
+    StoreResult(FPRClass, Op, Src2, -1);
     return;
   }
 
@@ -4423,8 +4421,7 @@ void OpDispatchBuilder::VPBLENDDOp(OpcodeArgs) {
   // silly is happening, we have your back.
 
   if (Selector == 0) {
-    OrderedNode *Result = Is256Bit ? Src1 : _VMov(16, Src1);
-    StoreResult(FPRClass, Op, Result, -1);
+    StoreResult(FPRClass, Op, Src1, -1);
     return;
   }
   if (Selector == 0xFF && Is256Bit) {
@@ -4436,7 +4433,7 @@ void OpDispatchBuilder::VPBLENDDOp(OpcodeArgs) {
   // silliness is going on and the upper bits are being set even when they'll
   // be ignored
   if ((Selector & 0xF) == 0xF && !Is256Bit) {
-    StoreResult(FPRClass, Op, _VMov(16, Src2), -1);
+    StoreResult(FPRClass, Op, Src2, -1);
     return;
   }
 
@@ -4446,7 +4443,6 @@ void OpDispatchBuilder::VPBLENDDOp(OpcodeArgs) {
 
 void OpDispatchBuilder::VPBLENDWOp(OpcodeArgs) {
   const auto DstSize = GetDstSize(Op);
-  const auto Is256Bit = DstSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
   OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
   OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags, -1);
@@ -4455,13 +4451,11 @@ void OpDispatchBuilder::VPBLENDWOp(OpcodeArgs) {
   const auto Selector = Op->Src[2].Data.Literal.Value;
 
   if (Selector == 0) {
-    OrderedNode *Result = Is256Bit ? Src1 : _VMov(16, Src1);
-    StoreResult(FPRClass, Op, Result, -1);
+    StoreResult(FPRClass, Op, Src1, -1);
     return;
   }
   if (Selector == 0xFF) {
-    OrderedNode *Result = Is256Bit ? Src2 : _VMov(16, Src2);
-    StoreResult(FPRClass, Op, Result, -1);
+    StoreResult(FPRClass, Op, Src2, -1);
     return;
   }
 

--- a/unittests/InstructionCountCI/VEX_map3.json
+++ b/unittests/InstructionCountCI/VEX_map3.json
@@ -104,14 +104,13 @@
       ]
     },
     "vpblendd xmm0, xmm1, 0000b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z16.d",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -411,14 +410,13 @@
       ]
     },
     "vpblendd xmm0, xmm1, 1111b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -2097,14 +2095,13 @@
       ]
     },
     "vblendps xmm0, xmm1, xmm2, 0000b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x0c 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -2132,14 +2129,13 @@
       ]
     },
     "vblendps xmm0, xmm1, xmm2, 1111b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x0c 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z18.d",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -2213,14 +2209,13 @@
       ]
     },
     "vblendpd xmm0, xmm1, xmm2, 00b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x0d 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -2264,14 +2259,13 @@
       ]
     },
     "vblendpd xmm0, xmm1, xmm2, 11b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x0d 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z18.d",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -2726,14 +2720,13 @@
       ]
     },
     "vpblendw xmm0, xmm1, xmm2, 00000000b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x0e 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -2765,14 +2758,13 @@
       ]
     },
     "vpblendw xmm0, xmm1, xmm2, 11111111b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x0e 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z18.d",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]


### PR DESCRIPTION
Zero-extension will happen if necessary upon storing.