### PR TITLE
OpcodeDispatcher: Remove unnecessary moves in AVXVFCMPOp

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -2349,7 +2349,6 @@ void OpDispatchBuilder::AVXVFCMPOp(OpcodeArgs) {
   // all we need is an insert at the end of the operation.
   const auto SrcSize = Scalar && Op->Src[1].IsGPR() ? 16U : GetSrcSize(Op);
   const auto DstSize = GetDstSize(Op);
-  const auto Is128Bit = DstSize == Core::CPUState::XMM_SSE_REG_SIZE;
 
   LOGMAN_THROW_A_FMT(Op->Src[2].IsLiteral(), "Src[2] needs to be literal");
   const uint8_t CompType = Op->Src[2].Data.Literal.Value;
@@ -2358,9 +2357,6 @@ void OpDispatchBuilder::AVXVFCMPOp(OpcodeArgs) {
   OrderedNode *Src2 = LoadSource_WithOpSize(FPRClass, Op, Op->Src[1], SrcSize, Op->Flags, -1);
   OrderedNode *Result = VFCMPOpImpl(Op, ElementSize, Scalar, Src1, Src2, CompType);
 
-  if (Is128Bit) {
-    Result = _VMov(16, Result);
-  }
   StoreResult(FPRClass, Op, Result, -1);
 }
 

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -2288,7 +2288,7 @@
       ]
     },
     "vcmpps xmm0, xmm1, xmm2, 0x00": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC2 128-bit"
@@ -2297,7 +2297,6 @@
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
         "fcmeq v4.4s, v4.4s, v5.4s",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -2319,7 +2318,7 @@
       ]
     },
     "vcmpps xmm0, xmm1, xmm2, 0x01": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC2 128-bit"
@@ -2328,7 +2327,6 @@
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
         "fcmgt v4.4s, v5.4s, v4.4s",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -2350,7 +2348,7 @@
       ]
     },
     "vcmpps xmm0, xmm1, xmm2, 0x02": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC2 128-bit"
@@ -2359,7 +2357,6 @@
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
         "fcmge v4.4s, v5.4s, v4.4s",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -2381,7 +2378,7 @@
       ]
     },
     "vcmpps xmm0, xmm1, xmm2, 0x03": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC2 128-bit"
@@ -2393,7 +2390,6 @@
         "fcmgt v1.4s, v5.4s, v4.4s",
         "orr v4.16b, v0.16b, v1.16b",
         "mvn v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -2415,7 +2411,7 @@
       ]
     },
     "vcmpps xmm0, xmm1, xmm2, 0x04": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC2 128-bit"
@@ -2425,7 +2421,6 @@
         "mov z5.d, p7/m, z18.d",
         "fcmeq v4.4s, v4.4s, v5.4s",
         "mvn v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -2447,7 +2442,7 @@
       ]
     },
     "vcmpps xmm0, xmm1, xmm2, 0x05": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC2 128-bit"
@@ -2457,7 +2452,6 @@
         "mov z5.d, p7/m, z18.d",
         "fcmgt v4.4s, v5.4s, v4.4s",
         "mvn v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -2480,7 +2474,7 @@
       ]
     },
     "vcmpps xmm0, xmm1, xmm2, 0x06": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC2 128-bit"
@@ -2490,7 +2484,6 @@
         "mov z5.d, p7/m, z18.d",
         "fcmge v4.4s, v5.4s, v4.4s",
         "mvn v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -2513,7 +2506,7 @@
       ]
     },
     "vcmpps xmm0, xmm1, xmm2, 0x07": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC2 128-bit"
@@ -2524,7 +2517,6 @@
         "fcmge v0.4s, v4.4s, v5.4s",
         "fcmgt v1.4s, v5.4s, v4.4s",
         "orr v4.16b, v0.16b, v1.16b",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -2547,7 +2539,7 @@
       ]
     },
     "vcmppd xmm0, xmm1, xmm2, 0x00": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC2 128-bit"
@@ -2556,7 +2548,6 @@
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
         "fcmeq v4.2d, v4.2d, v5.2d",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -2578,7 +2569,7 @@
       ]
     },
     "vcmppd xmm0, xmm1, xmm2, 0x01": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC2 128-bit"
@@ -2587,7 +2578,6 @@
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
         "fcmgt v4.2d, v5.2d, v4.2d",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -2609,7 +2599,7 @@
       ]
     },
     "vcmppd xmm0, xmm1, xmm2, 0x02": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC2 128-bit"
@@ -2618,7 +2608,6 @@
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
         "fcmge v4.2d, v5.2d, v4.2d",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -2640,7 +2629,7 @@
       ]
     },
     "vcmppd xmm0, xmm1, xmm2, 0x03": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC2 128-bit"
@@ -2652,7 +2641,6 @@
         "fcmgt v1.2d, v5.2d, v4.2d",
         "orr v4.16b, v0.16b, v1.16b",
         "mvn v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -2674,7 +2662,7 @@
       ]
     },
     "vcmppd xmm0, xmm1, xmm2, 0x04": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC2 128-bit"
@@ -2684,7 +2672,6 @@
         "mov z5.d, p7/m, z18.d",
         "fcmeq v4.2d, v4.2d, v5.2d",
         "mvn v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -2706,7 +2693,7 @@
       ]
     },
     "vcmppd xmm0, xmm1, xmm2, 0x05": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC2 128-bit"
@@ -2716,7 +2703,6 @@
         "mov z5.d, p7/m, z18.d",
         "fcmgt v4.2d, v5.2d, v4.2d",
         "mvn v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -2739,7 +2725,7 @@
       ]
     },
     "vcmppd xmm0, xmm1, xmm2, 0x06": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC2 128-bit"
@@ -2749,7 +2735,6 @@
         "mov z5.d, p7/m, z18.d",
         "fcmge v4.2d, v5.2d, v4.2d",
         "mvn v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -2772,7 +2757,7 @@
       ]
     },
     "vcmppd xmm0, xmm1, xmm2, 0x07": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC2 128-bit"
@@ -2783,7 +2768,6 @@
         "fcmge v0.2d, v4.2d, v5.2d",
         "fcmgt v1.2d, v5.2d, v4.2d",
         "orr v4.16b, v0.16b, v1.16b",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -2806,7 +2790,7 @@
       ]
     },
     "vcmpss xmm0, xmm1, xmm2, 0x00": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0xC2 128-bit"
@@ -2816,13 +2800,12 @@
         "mov z5.d, p7/m, z18.d",
         "fcmeq s5, s4, s5",
         "mov v4.s[0], v5.s[0]",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vcmpss xmm0, xmm1, xmm2, 0x01": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0xC2 128-bit"
@@ -2833,12 +2816,11 @@
         "fcmgt s5, s5, s4",
         "mov v4.s[0], v5.s[0]",
         "mov v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vcmpss xmm0, xmm1, xmm2, 0x02": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0xC2 128-bit"
@@ -2849,12 +2831,11 @@
         "fcmge s5, s5, s4",
         "mov v4.s[0], v5.s[0]",
         "mov v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vcmpss xmm0, xmm1, xmm2, 0x03": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 9,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0xC2 128-bit"
@@ -2868,12 +2849,11 @@
         "mvn v5.8b, v5.8b",
         "mov v4.s[0], v5.s[0]",
         "mov v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vcmpss xmm0, xmm1, xmm2, 0x04": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0xC2 128-bit"
@@ -2885,12 +2865,11 @@
         "mvn v5.8b, v5.8b",
         "mov v4.s[0], v5.s[0]",
         "mov v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vcmpss xmm0, xmm1, xmm2, 0x05": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0xC2 128-bit"
@@ -2902,12 +2881,11 @@
         "mvn v5.16b, v5.16b",
         "mov v4.s[0], v5.s[0]",
         "mov v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vcmpss xmm0, xmm1, xmm2, 0x06": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0xC2 128-bit"
@@ -2919,12 +2897,11 @@
         "mvn v5.16b, v5.16b",
         "mov v4.s[0], v5.s[0]",
         "mov v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vcmpss xmm0, xmm1, xmm2, 0x07": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0xC2 128-bit"
@@ -2937,12 +2914,11 @@
         "orr v5.8b, v0.8b, v1.8b",
         "mov v4.s[0], v5.s[0]",
         "mov v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vcmpsd xmm0, xmm1, xmm2, 0x00": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0xC2 128-bit"
@@ -2952,13 +2928,12 @@
         "mov z5.d, p7/m, z18.d",
         "fcmeq d5, d4, d5",
         "mov v4.d[0], v5.d[0]",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vcmpsd xmm0, xmm1, xmm2, 0x01": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0xC2 128-bit"
@@ -2968,13 +2943,12 @@
         "mov z5.d, p7/m, z18.d",
         "fcmgt d5, d5, d4",
         "mov v4.d[0], v5.d[0]",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vcmpsd xmm0, xmm1, xmm2, 0x02": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0xC2 128-bit"
@@ -2984,82 +2958,11 @@
         "mov z5.d, p7/m, z18.d",
         "fcmge d5, d5, d4",
         "mov v4.d[0], v5.d[0]",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vcmpsd xmm0, xmm1, xmm2, 0x03": {
-      "ExpectedInstructionCount": 10,
-      "Optimal": "No",
-      "Comment": [
-        "Map 1 0b11 0xC2 128-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z4.d, p7/m, z17.d",
-        "mov z5.d, p7/m, z18.d",
-        "fcmge d0, d4, d5",
-        "fcmgt d1, d5, d4",
-        "orr v5.8b, v0.8b, v1.8b",
-        "mvn v5.8b, v5.8b",
-        "mov v4.d[0], v5.d[0]",
-        "mov v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
-        "mov z16.d, p7/m, z4.d"
-      ]
-    },
-    "vcmpsd xmm0, xmm1, xmm2, 0x04": {
-      "ExpectedInstructionCount": 8,
-      "Optimal": "No",
-      "Comment": [
-        "Map 1 0b11 0xC2 128-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z4.d, p7/m, z17.d",
-        "mov z5.d, p7/m, z18.d",
-        "fcmeq d5, d4, d5",
-        "mvn v5.8b, v5.8b",
-        "mov v4.d[0], v5.d[0]",
-        "mov v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
-        "mov z16.d, p7/m, z4.d"
-      ]
-    },
-    "vcmpsd xmm0, xmm1, xmm2, 0x05": {
-      "ExpectedInstructionCount": 8,
-      "Optimal": "No",
-      "Comment": [
-        "Map 1 0b11 0xC2 128-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z4.d, p7/m, z17.d",
-        "mov z5.d, p7/m, z18.d",
-        "fcmgt d5, d5, d4",
-        "mvn v5.16b, v5.16b",
-        "mov v4.d[0], v5.d[0]",
-        "mov v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
-        "mov z16.d, p7/m, z4.d"
-      ]
-    },
-    "vcmpsd xmm0, xmm1, xmm2, 0x06": {
-      "ExpectedInstructionCount": 8,
-      "Optimal": "No",
-      "Comment": [
-        "Map 1 0b11 0xC2 128-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z4.d, p7/m, z17.d",
-        "mov z5.d, p7/m, z18.d",
-        "fcmge d5, d5, d4",
-        "mvn v5.16b, v5.16b",
-        "mov v4.d[0], v5.d[0]",
-        "mov v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
-        "mov z16.d, p7/m, z4.d"
-      ]
-    },
-    "vcmpsd xmm0, xmm1, xmm2, 0x07": {
       "ExpectedInstructionCount": 9,
       "Optimal": "No",
       "Comment": [
@@ -3071,8 +2974,73 @@
         "fcmge d0, d4, d5",
         "fcmgt d1, d5, d4",
         "orr v5.8b, v0.8b, v1.8b",
+        "mvn v5.8b, v5.8b",
         "mov v4.d[0], v5.d[0]",
         "mov v4.16b, v4.16b",
+        "mov z16.d, p7/m, z4.d"
+      ]
+    },
+    "vcmpsd xmm0, xmm1, xmm2, 0x04": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": [
+        "Map 1 0b11 0xC2 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "mov z4.d, p7/m, z17.d",
+        "mov z5.d, p7/m, z18.d",
+        "fcmeq d5, d4, d5",
+        "mvn v5.8b, v5.8b",
+        "mov v4.d[0], v5.d[0]",
+        "mov v4.16b, v4.16b",
+        "mov z16.d, p7/m, z4.d"
+      ]
+    },
+    "vcmpsd xmm0, xmm1, xmm2, 0x05": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": [
+        "Map 1 0b11 0xC2 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "mov z4.d, p7/m, z17.d",
+        "mov z5.d, p7/m, z18.d",
+        "fcmgt d5, d5, d4",
+        "mvn v5.16b, v5.16b",
+        "mov v4.d[0], v5.d[0]",
+        "mov v4.16b, v4.16b",
+        "mov z16.d, p7/m, z4.d"
+      ]
+    },
+    "vcmpsd xmm0, xmm1, xmm2, 0x06": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": [
+        "Map 1 0b11 0xC2 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "mov z4.d, p7/m, z17.d",
+        "mov z5.d, p7/m, z18.d",
+        "fcmge d5, d5, d4",
+        "mvn v5.16b, v5.16b",
+        "mov v4.d[0], v5.d[0]",
+        "mov v4.16b, v4.16b",
+        "mov z16.d, p7/m, z4.d"
+      ]
+    },
+    "vcmpsd xmm0, xmm1, xmm2, 0x07": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": [
+        "Map 1 0b11 0xC2 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "mov z4.d, p7/m, z17.d",
+        "mov z5.d, p7/m, z18.d",
+        "fcmge d0, d4, d5",
+        "fcmgt d1, d5, d4",
+        "orr v5.8b, v0.8b, v1.8b",
+        "mov v4.d[0], v5.d[0]",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]


### PR DESCRIPTION
Zero-extension will already occur if necessary upon storing.