### PR TITLE
Arm64/ConversionOps: Add scalar support to Vector_FToI 

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/Arm64/ConversionOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/ConversionOps.cpp
@@ -410,7 +410,7 @@ DEF_OP(Vector_FToI) {
     } else {
       switch (Op->Round) {
         case FEXCore::IR::Round_Nearest.Val:
-          frinti(SubEmitSize, Dst.Q(), Vector.Q());
+          frintn(SubEmitSize, Dst.Q(), Vector.Q());
           break;
         case FEXCore::IR::Round_Negative_Infinity.Val:
           frintm(SubEmitSize, Dst.Q(), Vector.Q());

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -999,7 +999,7 @@ private:
   void VectorUnaryDuplicateOpImpl(OpcodeArgs, IROps IROp, size_t ElementSize);
 
   OrderedNode* VectorRoundImpl(OpcodeArgs, size_t ElementSize,
-                               OrderedNode *Src, uint64_t Mode);
+                               OrderedNode *Src, uint64_t Mode, bool IsScalar);
 
   OrderedNode* Scalar_CVT_Float_To_FloatImpl(OpcodeArgs, size_t DstElementSize, size_t SrcElementSize,
                                              const X86Tables::DecodedOperand& Src1Op,

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -3797,7 +3797,6 @@ void OpDispatchBuilder::AVXVectorRound(OpcodeArgs) {
   const auto SrcIdx = Scalar ? 1 : 0;
   const auto SrcSize = Scalar && Op->Src[SrcIdx].IsGPR() ? 16U : GetSrcSize(Op);
   const auto DstSize = GetDstSize(Op);
-  const auto Is128Bit = DstSize == Core::CPUState::XMM_SSE_REG_SIZE;
 
   OrderedNode *Src = LoadSource_WithOpSize(FPRClass, Op, Op->Src[SrcIdx], SrcSize, Op->Flags, -1);
   OrderedNode *Result = VectorRoundImpl(Op, ElementSize, Src, GetMode(), Scalar);
@@ -3806,9 +3805,6 @@ void OpDispatchBuilder::AVXVectorRound(OpcodeArgs) {
     // Insert the lower bits
     OrderedNode *Dest = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], DstSize, Op->Flags, -1);
     Result = _VInsElement(DstSize, ElementSize, 0, 0, Dest, Result);
-  }
-  if (Is128Bit) {
-    Result = _VMov(16, Result);
   }
 
   StoreResult(FPRClass, Op, Result, -1);

--- a/unittests/InstructionCountCI/H0F3A.json
+++ b/unittests/InstructionCountCI/H0F3A.json
@@ -57,7 +57,7 @@
         "0x66 0x0f 0x3a 0x08"
       ],
       "ExpectedArm64ASM": [
-        "frinti v16.4s, v17.4s"
+        "frintn v16.4s, v17.4s"
       ]
     },
     "roundps xmm0, xmm1, 00000001b": {
@@ -112,7 +112,7 @@
         "0x66 0x0f 0x3a 0x09"
       ],
       "ExpectedArm64ASM": [
-        "frinti v16.2d, v17.2d"
+        "frintn v16.2d, v17.2d"
       ]
     },
     "roundpd xmm0, xmm1, 00000001b": {
@@ -164,12 +164,10 @@
       "Optimal": "No",
       "Comment": [
         "Nearest rounding",
-        "FPConvert instruction using vector conversion instead of scalar.",
-        "This lowers throughput from 1 IPC to 1/2IPC",
         "0x66 0x0f 0x3a 0x0a"
       ],
       "ExpectedArm64ASM": [
-        "frinti v4.4s, v17.4s",
+        "frintn s4, s17",
         "mov v16.s[0], v4.s[0]"
       ]
     },
@@ -178,12 +176,10 @@
       "Optimal": "No",
       "Comment": [
         "-inf rounding",
-        "FPConvert instruction using vector conversion instead of scalar.",
-        "This lowers throughput from 1 IPC to 1/2IPC",
         "0x66 0x0f 0x3a 0x0a"
       ],
       "ExpectedArm64ASM": [
-        "frintm v4.4s, v17.4s",
+        "frintm s4, s17",
         "mov v16.s[0], v4.s[0]"
       ]
     },
@@ -192,12 +188,10 @@
       "Optimal": "No",
       "Comment": [
         "+inf rounding",
-        "FPConvert instruction using vector conversion instead of scalar.",
-        "This lowers throughput from 1 IPC to 1/2IPC",
         "0x66 0x0f 0x3a 0x0a"
       ],
       "ExpectedArm64ASM": [
-        "frintp v4.4s, v17.4s",
+        "frintp s4, s17",
         "mov v16.s[0], v4.s[0]"
       ]
     },
@@ -206,12 +200,10 @@
       "Optimal": "No",
       "Comment": [
         "truncate rounding",
-        "FPConvert instruction using vector conversion instead of scalar.",
-        "This lowers throughput from 1 IPC to 1/2IPC",
         "0x66 0x0f 0x3a 0x0a"
       ],
       "ExpectedArm64ASM": [
-        "frintz v4.4s, v17.4s",
+        "frintz s4, s17",
         "mov v16.s[0], v4.s[0]"
       ]
     },
@@ -220,12 +212,10 @@
       "Optimal": "No",
       "Comment": [
         "host rounding mode rounding",
-        "FPConvert instruction using vector conversion instead of scalar.",
-        "This lowers throughput from 1 IPC to 1/2IPC",
         "0x66 0x0f 0x3a 0x0a"
       ],
       "ExpectedArm64ASM": [
-        "frinti v4.4s, v17.4s",
+        "frinti s4, s17",
         "mov v16.s[0], v4.s[0]"
       ]
     },
@@ -234,12 +224,10 @@
       "Optimal": "No",
       "Comment": [
         "Nearest rounding",
-        "FPConvert instruction using vector conversion instead of scalar.",
-        "This lowers throughput from 1 IPC to 1/2IPC",
         "0x66 0x0f 0x3a 0x0b"
       ],
       "ExpectedArm64ASM": [
-        "frinti v4.2d, v17.2d",
+        "frintn d4, d17",
         "mov v16.d[0], v4.d[0]"
       ]
     },
@@ -248,12 +236,10 @@
       "Optimal": "No",
       "Comment": [
         "-inf rounding",
-        "FPConvert instruction using vector conversion instead of scalar.",
-        "This lowers throughput from 1 IPC to 1/2IPC",
         "0x66 0x0f 0x3a 0x0b"
       ],
       "ExpectedArm64ASM": [
-        "frintm v4.2d, v17.2d",
+        "frintm d4, d17",
         "mov v16.d[0], v4.d[0]"
       ]
     },
@@ -262,12 +248,10 @@
       "Optimal": "No",
       "Comment": [
         "+inf rounding",
-        "FPConvert instruction using vector conversion instead of scalar.",
-        "This lowers throughput from 1 IPC to 1/2IPC",
         "0x66 0x0f 0x3a 0x0b"
       ],
       "ExpectedArm64ASM": [
-        "frintp v4.2d, v17.2d",
+        "frintp d4, d17",
         "mov v16.d[0], v4.d[0]"
       ]
     },
@@ -276,12 +260,10 @@
       "Optimal": "No",
       "Comment": [
         "truncate rounding",
-        "FPConvert instruction using vector conversion instead of scalar.",
-        "This lowers throughput from 1 IPC to 1/2IPC",
         "0x66 0x0f 0x3a 0x0b"
       ],
       "ExpectedArm64ASM": [
-        "frintz v4.2d, v17.2d",
+        "frintz d4, d17",
         "mov v16.d[0], v4.d[0]"
       ]
     },
@@ -290,12 +272,10 @@
       "Optimal": "No",
       "Comment": [
         "host rounding mode rounding",
-        "FPConvert instruction using vector conversion instead of scalar.",
-        "This lowers throughput from 1 IPC to 1/2IPC",
         "0x66 0x0f 0x3a 0x0b"
       ],
       "ExpectedArm64ASM": [
-        "frinti v4.2d, v17.2d",
+        "frinti d4, d17",
         "mov v16.d[0], v4.d[0]"
       ]
     },

--- a/unittests/InstructionCountCI/VEX_map3.json
+++ b/unittests/InstructionCountCI/VEX_map3.json
@@ -1625,7 +1625,7 @@
       ]
     },
     "vroundps xmm0, xmm1, 00000000b": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "nearest rounding",
@@ -1635,12 +1635,11 @@
         "mov z4.d, p7/m, z17.d",
         "frintn v4.4s, v4.4s",
         "mov v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vroundps xmm0, xmm1, 00000001b": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "-inf rounding",
@@ -1650,12 +1649,11 @@
         "mov z4.d, p7/m, z17.d",
         "frintm v4.4s, v4.4s",
         "mov v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vroundps xmm0, xmm1, 00000010b": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "+inf rounding",
@@ -1665,12 +1663,11 @@
         "mov z4.d, p7/m, z17.d",
         "frintp v4.4s, v4.4s",
         "mov v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vroundps xmm0, xmm1, 00000011b": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "truncate rounding",
@@ -1680,12 +1677,11 @@
         "mov z4.d, p7/m, z17.d",
         "frintz v4.4s, v4.4s",
         "mov v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vroundps xmm0, xmm1, 00000100b": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "host mode rounding",
@@ -1694,7 +1690,6 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "frinti v4.4s, v4.4s",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -1765,7 +1760,7 @@
       ]
     },
     "vroundpd xmm0, xmm1, 00000000b": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "nearest rounding",
@@ -1775,12 +1770,11 @@
         "mov z4.d, p7/m, z17.d",
         "frintn v4.2d, v4.2d",
         "mov v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vroundpd xmm0, xmm1, 00000001b": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "-inf rounding",
@@ -1790,12 +1784,11 @@
         "mov z4.d, p7/m, z17.d",
         "frintm v4.2d, v4.2d",
         "mov v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vroundpd xmm0, xmm1, 00000010b": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "+inf rounding",
@@ -1805,12 +1798,11 @@
         "mov z4.d, p7/m, z17.d",
         "frintp v4.2d, v4.2d",
         "mov v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vroundpd xmm0, xmm1, 00000011b": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "truncate rounding",
@@ -1820,12 +1812,11 @@
         "mov z4.d, p7/m, z17.d",
         "frintz v4.2d, v4.2d",
         "mov v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vroundpd xmm0, xmm1, 00000100b": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "host mode rounding",
@@ -1834,7 +1825,6 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "frinti v4.2d, v4.2d",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -1905,7 +1895,7 @@
       ]
     },
     "vroundss xmm0, xmm1, 00000000b": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Optimal": "No",
       "Comment": [
         "nearest rounding",
@@ -1919,12 +1909,11 @@
         "mov v0.s[0], v4.s[0]",
         "mov v4.16b, v0.16b",
         "mov v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vroundss xmm0, xmm1, 00000001b": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Optimal": "No",
       "Comment": [
         "-inf rounding",
@@ -1938,12 +1927,11 @@
         "mov v0.s[0], v4.s[0]",
         "mov v4.16b, v0.16b",
         "mov v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vroundss xmm0, xmm1, 00000010b": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Optimal": "No",
       "Comment": [
         "+inf rounding",
@@ -1957,12 +1945,11 @@
         "mov v0.s[0], v4.s[0]",
         "mov v4.16b, v0.16b",
         "mov v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vroundss xmm0, xmm1, 00000011b": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Optimal": "No",
       "Comment": [
         "truncate rounding",
@@ -1976,12 +1963,11 @@
         "mov v0.s[0], v4.s[0]",
         "mov v4.16b, v0.16b",
         "mov v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vroundss xmm0, xmm1, 00000100b": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Optimal": "No",
       "Comment": [
         "host mode rounding",
@@ -1995,12 +1981,11 @@
         "mov v0.s[0], v4.s[0]",
         "mov v4.16b, v0.16b",
         "mov v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vroundsd xmm0, xmm1, 00000000b": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Optimal": "No",
       "Comment": [
         "nearest rounding",
@@ -2014,12 +1999,11 @@
         "mov v0.d[0], v4.d[0]",
         "mov v4.16b, v0.16b",
         "mov v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vroundsd xmm0, xmm1, 00000001b": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Optimal": "No",
       "Comment": [
         "-inf rounding",
@@ -2033,12 +2017,11 @@
         "mov v0.d[0], v4.d[0]",
         "mov v4.16b, v0.16b",
         "mov v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vroundsd xmm0, xmm1, 00000010b": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Optimal": "No",
       "Comment": [
         "+inf rounding",
@@ -2052,12 +2035,11 @@
         "mov v0.d[0], v4.d[0]",
         "mov v4.16b, v0.16b",
         "mov v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vroundsd xmm0, xmm1, 00000011b": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Optimal": "No",
       "Comment": [
         "truncate rounding",
@@ -2071,12 +2053,11 @@
         "mov v0.d[0], v4.d[0]",
         "mov v4.16b, v0.16b",
         "mov v4.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vroundsd xmm0, xmm1, 00000100b": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Optimal": "No",
       "Comment": [
         "host mode rounding",
@@ -2089,7 +2070,6 @@
         "mov v0.16b, v5.16b",
         "mov v0.d[0], v4.d[0]",
         "mov v4.16b, v0.16b",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]

--- a/unittests/InstructionCountCI/VEX_map3.json
+++ b/unittests/InstructionCountCI/VEX_map3.json
@@ -1633,7 +1633,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "frinti v4.4s, v4.4s",
+        "frintn v4.4s, v4.4s",
         "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
@@ -1773,7 +1773,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "frinti v4.2d, v4.2d",
+        "frintn v4.2d, v4.2d",
         "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
@@ -1913,7 +1913,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "frinti v4.4s, v4.4s",
+        "frintn s4, s4",
         "mov z5.d, p7/m, z16.d",
         "mov v0.16b, v5.16b",
         "mov v0.s[0], v4.s[0]",
@@ -1932,7 +1932,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "frintm v4.4s, v4.4s",
+        "frintm s4, s4",
         "mov z5.d, p7/m, z16.d",
         "mov v0.16b, v5.16b",
         "mov v0.s[0], v4.s[0]",
@@ -1951,7 +1951,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "frintp v4.4s, v4.4s",
+        "frintp s4, s4",
         "mov z5.d, p7/m, z16.d",
         "mov v0.16b, v5.16b",
         "mov v0.s[0], v4.s[0]",
@@ -1970,7 +1970,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "frintz v4.4s, v4.4s",
+        "frintz s4, s4",
         "mov z5.d, p7/m, z16.d",
         "mov v0.16b, v5.16b",
         "mov v0.s[0], v4.s[0]",
@@ -1989,7 +1989,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "frinti v4.4s, v4.4s",
+        "frinti s4, s4",
         "mov z5.d, p7/m, z16.d",
         "mov v0.16b, v5.16b",
         "mov v0.s[0], v4.s[0]",
@@ -2008,7 +2008,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "frinti v4.2d, v4.2d",
+        "frintn d4, d4",
         "mov z5.d, p7/m, z16.d",
         "mov v0.16b, v5.16b",
         "mov v0.d[0], v4.d[0]",
@@ -2027,7 +2027,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "frintm v4.2d, v4.2d",
+        "frintm d4, d4",
         "mov z5.d, p7/m, z16.d",
         "mov v0.16b, v5.16b",
         "mov v0.d[0], v4.d[0]",
@@ -2046,7 +2046,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "frintp v4.2d, v4.2d",
+        "frintp d4, d4",
         "mov z5.d, p7/m, z16.d",
         "mov v0.16b, v5.16b",
         "mov v0.d[0], v4.d[0]",
@@ -2065,7 +2065,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "frintz v4.2d, v4.2d",
+        "frintz d4, d4",
         "mov z5.d, p7/m, z16.d",
         "mov v0.16b, v5.16b",
         "mov v0.d[0], v4.d[0]",
@@ -2084,7 +2084,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "frinti v4.2d, v4.2d",
+        "frinti d4, d4",
         "mov z5.d, p7/m, z16.d",
         "mov v0.16b, v5.16b",
         "mov v0.d[0], v4.d[0]",


### PR DESCRIPTION
This can be used for the scalar conversions instead of always using the vector variants. Also corrects an oversight on the AdvSIMD side of things where rounding nearest would be using `frinti` (host rounding mode) instead of `frintn`.

While we're in the area, we can also remove unnecessary moves on the AVX side of things, where we were doing a manual zero-extension when we didn't need to.