### PR TITLE
OpcodeDispatcher: Remove redundant moves from VPACKUSOP/VPACKSSOp

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -2815,15 +2815,13 @@ void OpDispatchBuilder::PACKUSOp<4>(OpcodeArgs);
 template<size_t ElementSize>
 void OpDispatchBuilder::VPACKUSOp(OpcodeArgs) {
   const auto DstSize = GetDstSize(Op);
-  const auto Is128Bit = DstSize == Core::CPUState::XMM_SSE_REG_SIZE;
+  const auto Is256Bit = DstSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
   OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
   OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags, -1);
   OrderedNode *Result = PACKUSOpImpl(Op, ElementSize, Src1, Src2);
 
-  if (Is128Bit) {
-    Result = _VMov(16, Result);
-  } else {
+  if (Is256Bit) {
     // We do a little cheeky 64-bit swapping to interleave the result.
     OrderedNode* Swapped = _VInsElement(DstSize, 8, 2, 1, Result, Result);
     Result = _VInsElement(DstSize, 8, 1, 2, Swapped, Result);
@@ -2861,15 +2859,13 @@ void OpDispatchBuilder::PACKSSOp<4>(OpcodeArgs);
 template<size_t ElementSize>
 void OpDispatchBuilder::VPACKSSOp(OpcodeArgs) {
   const auto DstSize = GetDstSize(Op);
-  const auto Is128Bit = DstSize == Core::CPUState::XMM_SSE_REG_SIZE;
+  const auto Is256Bit = DstSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
   OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
   OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags, -1);
   OrderedNode *Result = PACKSSOpImpl(Op, ElementSize, Src1, Src2);
 
-  if (Is128Bit) {
-    Result = _VMov(16, Result);
-  } else {
+  if (Is256Bit) {
     // We do a little cheeky 64-bit swapping to interleave the result.
     OrderedNode* Swapped = _VInsElement(DstSize, 8, 2, 1, Result, Result);
     Result = _VInsElement(DstSize, 8, 1, 2, Swapped, Result);

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -1148,7 +1148,7 @@
       ]
     },
     "vpacksswb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x63 128-bit"
@@ -1160,7 +1160,6 @@
         "mov v0.16b, v4.16b",
         "sqxtn2 v0.16b, v5.8h",
         "mov v4.16b, v0.16b",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -1284,7 +1283,7 @@
       ]
     },
     "vpackuswb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x67 128-bit"
@@ -1296,7 +1295,6 @@
         "mov v0.16b, v4.16b",
         "sqxtun2 v0.16b, v5.8h",
         "mov v4.16b, v0.16b",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -4691,7 +4689,7 @@
       ]
     },
     "vpackssdw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x6b 128-bit"
@@ -4703,7 +4701,6 @@
         "mov v0.16b, v4.16b",
         "sqxtn2 v0.8h, v5.4s",
         "mov v4.16b, v0.16b",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]

--- a/unittests/InstructionCountCI/VEX_map2.json
+++ b/unittests/InstructionCountCI/VEX_map2.json
@@ -1255,7 +1255,7 @@
       ]
     },
     "vpackusdw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x2b 128-bit"
@@ -1267,7 +1267,6 @@
         "mov v0.16b, v4.16b",
         "sqxtun2 v0.8h, v5.4s",
         "mov v4.16b, v0.16b",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]


### PR DESCRIPTION
Zero-extension will occur automatically if necessary.