### PR TITLE
OpcodeDispatcher: Remove redundant moves from remaining AVX ops

### DIFF
--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -888,7 +888,7 @@
       ]
     },
     "vandnps xmm0, xmm1": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x55 128-bit"
@@ -897,7 +897,6 @@
         "mov z4.d, p7/m, z16.d",
         "mov z5.d, p7/m, z17.d",
         "bic v4.16b, v5.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -916,7 +915,7 @@
       ]
     },
     "vandnpd xmm0, xmm1": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x55 128-bit"
@@ -925,7 +924,6 @@
         "mov z4.d, p7/m, z16.d",
         "mov z5.d, p7/m, z17.d",
         "bic v4.16b, v5.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -4867,7 +4865,7 @@
       ]
     },
     "vhaddpd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x7c 128-bit"
@@ -4876,7 +4874,6 @@
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
         "faddp v4.2d, v4.2d, v5.2d",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -4909,7 +4906,7 @@
       ]
     },
     "vhaddps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x7c 128-bit"
@@ -4918,7 +4915,6 @@
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
         "faddp v4.4s, v4.4s, v5.4s",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -5104,7 +5100,7 @@
       ]
     },
     "vaddsubpd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 9,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xd0 128-bit"
@@ -5117,7 +5113,6 @@
         "uzp1 v4.2d, v4.2d, v4.2d",
         "uzp2 v5.2d, v6.2d, v6.2d",
         "zip1 v4.2d, v4.2d, v5.2d",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -5140,7 +5135,7 @@
       ]
     },
     "vaddsubps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 9,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0xd0 128-bit"
@@ -5153,7 +5148,6 @@
         "uzp1 v4.4s, v4.4s, v4.4s",
         "uzp2 v5.4s, v6.4s, v6.4s",
         "zip1 v4.4s, v4.4s, v5.4s",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -5572,7 +5566,7 @@
       ]
     },
     "vpandn xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xdf 128-bit"
@@ -5581,7 +5575,6 @@
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
         "bic v4.16b, v5.16b, v4.16b",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -5716,7 +5709,7 @@
       ]
     },
     "vpmulhuw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xe4 128-bit"
@@ -5730,7 +5723,6 @@
         "mov v0.16b, v5.16b",
         "shrn2 v0.8h, v4.4s, #16",
         "mov v4.16b, v0.16b",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -5760,7 +5752,7 @@
       ]
     },
     "vpmulhw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xe5 128-bit"
@@ -5774,7 +5766,6 @@
         "mov v0.16b, v5.16b",
         "shrn2 v0.8h, v4.4s, #16",
         "mov v4.16b, v0.16b",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -6245,7 +6236,7 @@
       ]
     },
     "vpmuludq xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xf4 128-bit"
@@ -6256,7 +6247,6 @@
         "uzp1 v4.4s, v4.4s, v4.4s",
         "uzp1 v5.4s, v5.4s, v5.4s",
         "umull v4.2d, v4.2s, v5.2s",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]

--- a/unittests/InstructionCountCI/VEX_map2.json
+++ b/unittests/InstructionCountCI/VEX_map2.json
@@ -46,7 +46,7 @@
       ]
     },
     "vphaddw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x01 128-bit"
@@ -55,7 +55,6 @@
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
         "addp v4.8h, v4.8h, v5.8h",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -88,7 +87,7 @@
       ]
     },
     "vphaddd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x02 128-bit"
@@ -97,7 +96,6 @@
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
         "addp v4.4s, v4.4s, v5.4s",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -214,7 +212,7 @@
       ]
     },
     "vphsubw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x05 128-bit"
@@ -225,7 +223,6 @@
         "uzp1 v6.8h, v4.8h, v5.8h",
         "uzp2 v4.8h, v4.8h, v5.8h",
         "sub v4.8h, v6.8h, v4.8h",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -256,7 +253,7 @@
       ]
     },
     "vphsubd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x06 128-bit"
@@ -267,7 +264,6 @@
         "uzp1 v6.4s, v4.4s, v5.4s",
         "uzp2 v4.4s, v4.4s, v5.4s",
         "sub v4.4s, v6.4s, v4.4s",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -438,7 +434,7 @@
       ]
     },
     "vpmulhrsw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 16,
+      "ExpectedInstructionCount": 15,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x0b 128-bit"
@@ -457,7 +453,6 @@
         "mov v0.16b, v5.16b",
         "shrn2 v0.8h, v4.4s, #1",
         "mov v4.16b, v0.16b",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -1169,7 +1164,7 @@
       ]
     },
     "vpmuldq xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x28 128-bit"
@@ -1180,7 +1175,6 @@
         "uzp1 v4.4s, v4.4s, v4.4s",
         "uzp1 v5.4s, v5.4s, v5.4s",
         "smull v4.2d, v4.2s, v5.2s",
-        "mov v4.16b, v4.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]


### PR DESCRIPTION
Zero-extension will occur automatically if necessary upon storing.