### PR TITLE
Arm64/VectorOps: Remove moves from SVE VFDiv if possible

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -773,10 +773,17 @@ DEF_OP(VFDiv) {
   if (HostSupportsSVE256 && Is256Bit) {
     const auto Mask = PRED_TMP_32B.Merging();
 
-    // SVE VDIV is a destructive operation, so we need a temporary.
-    movprfx(VTMP1.Z(), Vector1.Z());
-    fdiv(SubRegSize, VTMP1.Z(), Mask, VTMP1.Z(), Vector2.Z());
-    mov(Dst.Z(), VTMP1.Z());
+    if (Dst == Vector1) {
+      // Trivial case where we already have source data to be divided in the
+      // destination register. We can just divide by Vector2 and be done with it.
+      fdiv(SubRegSize, Dst.Z(), Mask, Dst.Z(), Vector2.Z());
+    } else {
+      // SVE FDIV is a destructive operation, so we need a temporary
+      // in the event that Dst and Vector1 don't alias.
+      movprfx(VTMP1.Z(), Vector1.Z());
+      fdiv(SubRegSize, VTMP1.Z(), Mask, VTMP1.Z(), Vector2.Z());
+      mov(Dst.Z(), VTMP1.Z());
+    }
   } else {
     if (IsScalar) {
       switch (ElementSize) {

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -4431,7 +4431,7 @@
       ]
     },
     "vdivps ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x5e 256-bit"
@@ -4439,9 +4439,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "movprfx z0, z4",
-        "fdiv z0.s, p7/m, z0.s, z5.s",
-        "mov z4.d, z0.d",
+        "fdiv z4.s, p7/m, z4.s, z5.s",
         "mov z16.d, p7/m, z4.d"
       ]
     },
@@ -4460,7 +4458,7 @@
       ]
     },
     "vdivpd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x5e 256-bit"
@@ -4468,9 +4466,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "movprfx z0, z4",
-        "fdiv z0.d, p7/m, z0.d, z5.d",
-        "mov z4.d, z0.d",
+        "fdiv z4.d, p7/m, z4.d, z5.d",
         "mov z16.d, p7/m, z4.d"
       ]
     },


### PR DESCRIPTION
Given the operation is:

```
Dst = Vector1 / Vector2
```

If Dst and Vector1 alias one another, then we can just perform the division as is without any moving of data around.