### PR TITLE
Arm64/VectorOps: Remove redundant moves from SVE VURAvg if possible

### DIFF
--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -5611,7 +5611,7 @@
       ]
     },
     "vpavgb ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xe0 256-bit"
@@ -5619,9 +5619,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "movprfx z0, z4",
-        "urhadd z0.b, p7/m, z0.b, z5.b",
-        "mov z4.d, z0.d",
+        "urhadd z4.b, p7/m, z4.b, z5.b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
@@ -5698,7 +5696,7 @@
       ]
     },
     "vpavgw ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xe3 256-bit"
@@ -5706,9 +5704,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "movprfx z0, z4",
-        "urhadd z0.h, p7/m, z0.h, z5.h",
-        "mov z4.d, z0.d",
+        "urhadd z4.h, p7/m, z4.h, z5.h",
         "mov z16.d, p7/m, z4.d"
       ]
     },


### PR DESCRIPTION
If Dst and Vector1 alias one another, then we can perform the operation without needing to move any data around.