### PR TITLE
Arm64/VectorOps: Remove redundant moves from SVE VFMin/VFMax when possible

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -843,9 +843,16 @@ DEF_OP(VFMin) {
     fcmgt(SubRegSize, ComparePred, Mask.Zeroing(),
           Vector2.Z(), Vector1.Z());
     not_(ComparePred, Mask.Zeroing(), ComparePred);
-    mov(VTMP1.Z(), Vector1.Z());
-    mov(SubRegSize, VTMP1.Z(), ComparePred.Merging(), Vector2.Z());
-    mov(Dst.Z(), VTMP1.Z());
+    
+    if (Dst == Vector1) {
+      // Trivial case where Vector1 is also the destination.
+      // We don't need to move any data around in this case (aside from the merge).
+      mov(SubRegSize, Dst.Z(), ComparePred.Merging(), Vector2.Z());
+    } else {
+      mov(VTMP1.Z(), Vector1.Z());
+      mov(SubRegSize, VTMP1.Z(), ComparePred.Merging(), Vector2.Z());
+      mov(Dst.Z(), VTMP1.Z());
+    }
   } else {
     if (IsScalar) {
       switch (ElementSize) {

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -923,9 +923,16 @@ DEF_OP(VFMax) {
 
     fcmgt(SubRegSize, ComparePred, Mask.Zeroing(),
           Vector2.Z(), Vector1.Z());
-    mov(VTMP1.Z(), Vector1.Z());
-    mov(SubRegSize, VTMP1.Z(), ComparePred.Merging(), Vector2.Z());
-    mov(Dst.Z(), VTMP1.Z());
+
+    if (Dst == Vector1) {
+      // Trivial case where Vector1 is also the destination.
+      // We don't need to move any data around in this case (aside from the merge).
+      mov(SubRegSize, Dst.Z(), ComparePred.Merging(), Vector2.Z());
+    } else {
+      mov(VTMP1.Z(), Vector1.Z());
+      mov(SubRegSize, VTMP1.Z(), ComparePred.Merging(), Vector2.Z());
+      mov(Dst.Z(), VTMP1.Z());
+    }
   } else {
     if (IsScalar) {
       switch (ElementSize) {

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -4336,7 +4336,7 @@
       ]
     },
     "vminps ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x5d 256-bit"
@@ -4346,9 +4346,7 @@
         "mov z5.d, p7/m, z18.d",
         "fcmgt p0.s, p7/z, z5.s, z4.s",
         "not p0.b, p7/z, p0.b",
-        "mov z0.d, z4.d",
-        "mov z0.s, p0/m, z5.s",
-        "mov z4.d, z0.d",
+        "mov z4.s, p0/m, z5.s",
         "mov z16.d, p7/m, z4.d"
       ]
     },
@@ -4368,7 +4366,7 @@
       ]
     },
     "vminpd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x5d 256-bit"
@@ -4378,9 +4376,7 @@
         "mov z5.d, p7/m, z18.d",
         "fcmgt p0.d, p7/z, z5.d, z4.d",
         "not p0.b, p7/z, p0.b",
-        "mov z0.d, z4.d",
-        "mov z0.d, p0/m, z5.d",
-        "mov z4.d, z0.d",
+        "mov z4.d, p0/m, z5.d",
         "mov z16.d, p7/m, z4.d"
       ]
     },

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -4516,7 +4516,7 @@
       ]
     },
     "vmaxps ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x5f 256-bit"
@@ -4525,9 +4525,7 @@
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
         "fcmgt p0.s, p7/z, z5.s, z4.s",
-        "mov z0.d, z4.d",
-        "mov z0.s, p0/m, z5.s",
-        "mov z4.d, z0.d",
+        "mov z4.s, p0/m, z5.s",
         "mov z16.d, p7/m, z4.d"
       ]
     },
@@ -4547,7 +4545,7 @@
       ]
     },
     "vmaxpd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x5f 256-bit"
@@ -4556,9 +4554,7 @@
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
         "fcmgt p0.d, p7/z, z5.d, z4.d",
-        "mov z0.d, z4.d",
-        "mov z0.d, p0/m, z5.d",
-        "mov z4.d, z0.d",
+        "mov z4.d, p0/m, z5.d",
         "mov z16.d, p7/m, z4.d"
       ]
     },


### PR DESCRIPTION
We can perform these operations in place if the destination and first source alias one another.