### PR TITLE
Arm64/VectorOps: Remove redundant moves from SVE V{S,U}Min/V{S,U}Max when possible

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -1262,10 +1262,15 @@ DEF_OP(VSMin) {
   if (HostSupportsSVE256 && Is256Bit) {
     const auto Pred = PRED_TMP_32B.Merging();
 
-    // SVE SMIN is a destructive operation, so we need a temporary.
-    movprfx(VTMP1.Z(), Vector1.Z());
-    smin(SubRegSize, VTMP1.Z(), Pred, VTMP1.Z(), Vector2.Z());
-    mov(Dst.Z(), VTMP1.Z());
+    if (Dst == Vector1) {
+      // Trivial case where we can perform the operation in place.
+      smin(SubRegSize, Dst.Z(), Pred, Dst.Z(), Vector2.Z());
+    } else {
+      // SVE SMIN is a destructive operation, so we need a temporary.
+      movprfx(VTMP1.Z(), Vector1.Z());
+      smin(SubRegSize, VTMP1.Z(), Pred, VTMP1.Z(), Vector2.Z());
+      mov(Dst.Z(), VTMP1.Z());
+    }
   } else {
     switch (ElementSize) {
       case 1:

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -1314,10 +1314,15 @@ DEF_OP(VUMax) {
   if (HostSupportsSVE256 && Is256Bit) {
     const auto Pred = PRED_TMP_32B.Merging();
 
-    // SVE UMAX is a destructive operation, so we need a temporary.
-    movprfx(VTMP1.Z(), Vector1.Z());
-    umax(SubRegSize, VTMP1.Z(), Pred, VTMP1.Z(), Vector2.Z());
-    mov(Dst.Z(), VTMP1.Z());
+    if (Dst == Vector1) {
+      // Trivial case where we can perform the operation in place.
+      umax(SubRegSize, Dst.Z(), Pred, Dst.Z(), Vector2.Z());
+    } else {
+      // SVE UMAX is a destructive operation, so we need a temporary.
+      movprfx(VTMP1.Z(), Vector1.Z());
+      umax(SubRegSize, VTMP1.Z(), Pred, VTMP1.Z(), Vector2.Z());
+      mov(Dst.Z(), VTMP1.Z());
+    }
   } else {
     switch (ElementSize) {
       case 1:

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -1366,10 +1366,15 @@ DEF_OP(VSMax) {
   if (HostSupportsSVE256 && Is256Bit) {
     const auto Pred = PRED_TMP_32B.Merging();
 
-    // SVE SMAX is a destructive operation, so we need a temporary.
-    movprfx(VTMP1.Z(), Vector1.Z());
-    smax(SubRegSize, VTMP1.Z(), Pred, VTMP1.Z(), Vector2.Z());
-    mov(Dst.Z(), VTMP1.Z());
+    if (Dst == Vector1) {
+      // Trivial case where we can perform the operation in place.
+      smax(SubRegSize, Dst.Z(), Pred, Dst.Z(), Vector2.Z());
+    } else {
+      // SVE SMAX is a destructive operation, so we need a temporary.
+      movprfx(VTMP1.Z(), Vector1.Z());
+      smax(SubRegSize, VTMP1.Z(), Pred, VTMP1.Z(), Vector2.Z());
+      mov(Dst.Z(), VTMP1.Z());
+    }
   } else {
     switch (ElementSize) {
       case 1:

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -1210,10 +1210,15 @@ DEF_OP(VUMin) {
   if (HostSupportsSVE256 && Is256Bit) {
     const auto Pred = PRED_TMP_32B.Merging();
 
-    // SVE UMIN is a destructive operation so we need a temporary.
-    movprfx(VTMP1.Z(), Vector1.Z());
-    umin(SubRegSize, VTMP1.Z(), Pred, VTMP1.Z(), Vector2.Z());
-    mov(Dst.Z(), VTMP1.Z());
+    if (Dst == Vector1) {
+      // Trivial case where we can perform the operation in place.
+      umin(SubRegSize, Dst.Z(), Pred, Dst.Z(), Vector2.Z());
+    } else {
+      // SVE UMIN is a destructive operation so we need a temporary.
+      movprfx(VTMP1.Z(), Vector1.Z());
+      umin(SubRegSize, VTMP1.Z(), Pred, VTMP1.Z(), Vector2.Z());
+      mov(Dst.Z(), VTMP1.Z());
+    }
   } else {
     switch (ElementSize) {
       case 1:

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -5959,7 +5959,7 @@
       ]
     },
     "vpminsw ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xea 256-bit"
@@ -5967,9 +5967,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "movprfx z0, z4",
-        "smin z0.h, p7/m, z0.h, z5.h",
-        "mov z4.d, z0.d",
+        "smin z4.h, p7/m, z4.h, z5.h",
         "mov z16.d, p7/m, z4.d"
       ]
     },

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -5431,7 +5431,7 @@
       ]
     },
     "vpminub ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xda 256-bit"
@@ -5439,9 +5439,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "movprfx z0, z4",
-        "umin z0.b, p7/m, z0.b, z5.b",
-        "mov z4.d, z0.d",
+        "umin z4.b, p7/m, z4.b, z5.b",
         "mov z16.d, p7/m, z4.d"
       ]
     },

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -6065,7 +6065,7 @@
       ]
     },
     "vpmaxsw ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xee 256-bit"
@@ -6073,9 +6073,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "movprfx z0, z4",
-        "smax z0.h, p7/m, z0.h, z5.h",
-        "mov z4.d, z0.d",
+        "smax z4.h, p7/m, z4.h, z5.h",
         "mov z16.d, p7/m, z4.d"
       ]
     },

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -5539,7 +5539,7 @@
       ]
     },
     "vpmaxub ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xde 256-bit"
@@ -5547,9 +5547,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "movprfx z0, z4",
-        "umax z0.b, p7/m, z0.b, z5.b",
-        "mov z4.d, z0.d",
+        "umax z4.b, p7/m, z4.b, z5.b",
         "mov z16.d, p7/m, z4.d"
       ]
     },

--- a/unittests/InstructionCountCI/VEX_map2.json
+++ b/unittests/InstructionCountCI/VEX_map2.json
@@ -1625,7 +1625,7 @@
       ]
     },
     "vpminsb ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x38 256-bit"
@@ -1633,9 +1633,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "movprfx z0, z4",
-        "smin z0.b, p7/m, z0.b, z5.b",
-        "mov z4.d, z0.d",
+        "smin z4.b, p7/m, z4.b, z5.b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
@@ -1654,7 +1652,7 @@
       ]
     },
     "vpminsd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x39 256-bit"
@@ -1662,9 +1660,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "movprfx z0, z4",
-        "smin z0.s, p7/m, z0.s, z5.s",
-        "mov z4.d, z0.d",
+        "smin z4.s, p7/m, z4.s, z5.s",
         "mov z16.d, p7/m, z4.d"
       ]
     },

--- a/unittests/InstructionCountCI/VEX_map2.json
+++ b/unittests/InstructionCountCI/VEX_map2.json
@@ -1683,7 +1683,7 @@
       ]
     },
     "vpminuw ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x3a 256-bit"
@@ -1691,9 +1691,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "movprfx z0, z4",
-        "umin z0.h, p7/m, z0.h, z5.h",
-        "mov z4.d, z0.d",
+        "umin z4.h, p7/m, z4.h, z5.h",
         "mov z16.d, p7/m, z4.d"
       ]
     },
@@ -1712,7 +1710,7 @@
       ]
     },
     "vpminud ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x3b 256-bit"
@@ -1720,9 +1718,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "movprfx z0, z4",
-        "umin z0.s, p7/m, z0.s, z5.s",
-        "mov z4.d, z0.d",
+        "umin z4.s, p7/m, z4.s, z5.s",
         "mov z16.d, p7/m, z4.d"
       ]
     },

--- a/unittests/InstructionCountCI/VEX_map2.json
+++ b/unittests/InstructionCountCI/VEX_map2.json
@@ -1791,7 +1791,7 @@
       ]
     },
     "vpmaxuw ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x3e 256-bit"
@@ -1799,9 +1799,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "movprfx z0, z4",
-        "umax z0.h, p7/m, z0.h, z5.h",
-        "mov z4.d, z0.d",
+        "umax z4.h, p7/m, z4.h, z5.h",
         "mov z16.d, p7/m, z4.d"
       ]
     },
@@ -1820,7 +1818,7 @@
       ]
     },
     "vpmaxud ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x3f 256-bit"
@@ -1828,9 +1826,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "movprfx z0, z4",
-        "umax z0.s, p7/m, z0.s, z5.s",
-        "mov z4.d, z0.d",
+        "umax z4.s, p7/m, z4.s, z5.s",
         "mov z16.d, p7/m, z4.d"
       ]
     },

--- a/unittests/InstructionCountCI/VEX_map2.json
+++ b/unittests/InstructionCountCI/VEX_map2.json
@@ -1733,7 +1733,7 @@
       ]
     },
     "vpmaxsb ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x3c 256-bit"
@@ -1741,9 +1741,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "movprfx z0, z4",
-        "smax z0.b, p7/m, z0.b, z5.b",
-        "mov z4.d, z0.d",
+        "smax z4.b, p7/m, z4.b, z5.b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
@@ -1762,7 +1760,7 @@
       ]
     },
     "vpmaxsd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x3d 256-bit"
@@ -1770,9 +1768,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "movprfx z0, z4",
-        "smax z0.s, p7/m, z0.s, z5.s",
-        "mov z4.d, z0.d",
+        "smax z4.s, p7/m, z4.s, z5.s",
         "mov z16.d, p7/m, z4.d"
       ]
     },


### PR DESCRIPTION
When the destination and first source alias, we can perform the operation in place without needing to move any data around.