### PR TITLE
Arm64/VectorOps: Remove redundant moves from SVE variable/immediate/vector shifts when possible

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -2217,7 +2217,10 @@ DEF_OP(VUShl) {
     dup_imm(SubRegSize, VTMP2.Z(), MaxShift);
     umin(SubRegSize, VTMP2.Z(), Mask, VTMP2.Z(), ShiftVector.Z());
 
-    movprfx(Dst.Z(), Vector.Z());
+    // If Dst aliases Vector, then we can skip the move.
+    if (Dst != Vector) {
+      movprfx(Dst.Z(), Vector.Z());
+    }
     lsl(SubRegSize, Dst.Z(), Mask, Dst.Z(), VTMP2.Z());
   } else {
     if (ElementSize < 8) {
@@ -2261,7 +2264,10 @@ DEF_OP(VUShr) {
     dup_imm(SubRegSize, VTMP2.Z(), MaxShift);
     umin(SubRegSize, VTMP2.Z(), Mask, VTMP2.Z(), ShiftVector.Z());
 
-    movprfx(Dst.Z(), Vector.Z());
+    // If Dst aliases Vector, then we can skip the move.
+    if (Dst != Vector) {
+      movprfx(Dst.Z(), Vector.Z());
+    }
     lsr(SubRegSize, Dst.Z(), Mask, Dst.Z(), VTMP2.Z());
   } else {
     if (ElementSize < 8) {
@@ -2308,7 +2314,10 @@ DEF_OP(VSShr) {
     dup_imm(SubRegSize, VTMP1.Z(), MaxShift);
     umin(SubRegSize, VTMP1.Z(), Mask, VTMP1.Z(), ShiftVector.Z());
 
-    movprfx(Dst.Z(), Vector.Z());
+    // If Dst aliases Vector, then we can skip the move.
+    if (Dst != Vector) {
+      movprfx(Dst.Z(), Vector.Z());
+    }
     asr(SubRegSize, Dst.Z(), Mask, Dst.Z(), VTMP1.Z());
   } else {
     if (ElementSize < 8) {

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -2949,7 +2949,9 @@ DEF_OP(VUShrNI2) {
     shrnb(SubRegSize, VTMP2.Z(), VectorUpper.Z(), BitShift);
     uzp1(SubRegSize, VTMP2.Z(), VTMP2.Z(), VTMP2.Z());
 
-    movprfx(Dst.Z(), VectorLower.Z());
+    if (Dst != VectorLower) {
+      movprfx(Dst.Z(), VectorLower.Z());
+    }
     splice<ARMEmitter::OpType::Destructive>(SubRegSize, Dst.Z(), Mask, Dst.Z(), VTMP2.Z());
   } else {
     mov(VTMP1.Q(), VectorLower.Q());

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -2784,22 +2784,23 @@ DEF_OP(VUShrI) {
       const auto Mask = PRED_TMP_32B.Merging();
 
       if (BitShift == 0) {
-        if (Dst.Idx() != Vector.Idx()) {
+        if (Dst != Vector) {
           mov(Dst.Z(), Vector.Z());
         }
-      }
-      else {
-        // SVE LSR is destructive, so lets set up the destination.
-        movprfx(Dst.Z(), Vector.Z());
+      } else {
+        // SVE LSR is destructive, so lets set up the destination if
+        // Vector doesn't already alias it.
+        if (Dst != Vector) {
+          movprfx(Dst.Z(), Vector.Z());
+        }
         lsr(SubRegSize, Dst.Z(), Mask, Dst.Z(), BitShift);
       }
     } else {
       if (BitShift == 0) {
-        if (Dst.Idx() != Vector.Idx()) {
+        if (Dst != Vector) {
           mov(Dst.Q(), Vector.Q());
         }
-      }
-      else {
+      } else {
         ushr(SubRegSize, Dst.Q(), Vector.Q(), BitShift);
       }
     }
@@ -2828,22 +2829,23 @@ DEF_OP(VSShrI) {
     const auto Mask = PRED_TMP_32B.Merging();
 
     if (Shift == 0) {
-      if (Dst.Idx() != Vector.Idx()) {
+      if (Dst != Vector) {
         mov(Dst.Z(), Vector.Z());
       }
-    }
-    else {
-      // SVE ASR is destructive, so lets set up the destination.
-      movprfx(Dst.Z(), Vector.Z());
+    } else {
+      // SVE ASR is destructive, so lets set up the destination if
+      // Vector doesn't already alias it.
+      if (Dst != Vector) {
+        movprfx(Dst.Z(), Vector.Z());
+      }
       asr(SubRegSize, Dst.Z(), Mask, Dst.Z(), Shift);
     }
   } else {
     if (Shift == 0) {
-      if (Dst.Idx() != Vector.Idx()) {
+      if (Dst != Vector) {
         mov(Dst.Q(), Vector.Q());
       }
-    }
-    else {
+    } else {
       sshr(SubRegSize, Dst.Q(), Vector.Q(), Shift);
     }
   }
@@ -2875,22 +2877,23 @@ DEF_OP(VShlI) {
       const auto Mask = PRED_TMP_32B.Merging();
 
       if (BitShift == 0) {
-        if (Dst.Idx() != Vector.Idx()) {
+        if (Dst != Vector) {
           mov(Dst.Z(), Vector.Z());
         }
-      }
-      else {
-        // SVE LSL is destructive, so lets set up the destination.
-        movprfx(Dst.Z(), Vector.Z());
+      } else {
+        // SVE LSL is destructive, so lets set up the destination if
+        // Vector doesn't already alias it.
+        if (Dst != Vector) {
+          movprfx(Dst.Z(), Vector.Z());
+        }
         lsl(SubRegSize, Dst.Z(), Mask, Dst.Z(), BitShift);
       }
     } else {
       if (BitShift == 0) {
-        if (Dst.Idx() != Vector.Idx()) {
+        if (Dst != Vector) {
           mov(Dst.Q(), Vector.Q());
         }
-      }
-      else {
+      } else {
         shl(SubRegSize, Dst.Q(), Vector.Q(), BitShift);
       }
     }

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -2360,9 +2360,13 @@ DEF_OP(VUShlS) {
   if (HostSupportsSVE256 && Is256Bit) {
     const auto Mask = PRED_TMP_32B.Merging();
 
-    // NOTE: SVE LSL is a destructive operation.
+    // NOTE: SVE LSL is a destructive operation, so we need to
+    //       move the vector into the destination if they don't
+    //       already alias.
     dup(SubRegSize, VTMP1.Z(), ShiftScalar.Z(), 0);
-    movprfx(Dst.Z(), Vector.Z());
+    if (Dst != Vector) {
+      movprfx(Dst.Z(), Vector.Z());
+    }
     lsl(SubRegSize, Dst.Z(), Mask, Dst.Z(), VTMP1.Z());
   } else {
     dup(SubRegSize, VTMP1.Q(), ShiftScalar.Q(), 0);
@@ -2391,9 +2395,13 @@ DEF_OP(VUShrS) {
   if (HostSupportsSVE256 && Is256Bit) {
     const auto Mask = PRED_TMP_32B.Merging();
 
-    // NOTE: SVE LSR is a destructive operation.
+    // NOTE: SVE LSR is a destructive operation, so we need to
+    //       move the vector into the destination if they don't
+    //       already alias.
     dup(SubRegSize, VTMP1.Z(), ShiftScalar.Z(), 0);
-    movprfx(Dst.Z(), Vector.Z());
+    if (Dst != Vector) {
+      movprfx(Dst.Z(), Vector.Z());
+    }
     lsr(SubRegSize, Dst.Z(), Mask, Dst.Z(), VTMP1.Z());
   } else {
     dup(SubRegSize, VTMP1.Q(), ShiftScalar.Q(), 0);
@@ -2602,9 +2610,13 @@ DEF_OP(VSShrS) {
    if (HostSupportsSVE256 && Is256Bit) {
     const auto Mask = PRED_TMP_32B.Merging();
 
-    // NOTE: SVE ASR is a destructive operation.
+    // NOTE: SVE ASR is a destructive operation, so we need to
+    //       move the vector into the destination if they don't
+    //       already alias.
     dup(SubRegSize, VTMP1.Z(), ShiftScalar.Z(), 0);
-    movprfx(Dst.Z(), Vector.Z());
+    if (Dst != Vector) {
+      movprfx(Dst.Z(), Vector.Z());
+    }
     asr(SubRegSize, Dst.Z(), Mask, Dst.Z(), VTMP1.Z());
   } else {
     dup(SubRegSize, VTMP1.Q(), ShiftScalar.Q(), 0);

--- a/unittests/InstructionCountCI/VEX_map2.json
+++ b/unittests/InstructionCountCI/VEX_map2.json
@@ -458,7 +458,7 @@
       ]
     },
     "vpmulhrsw ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 22,
+      "ExpectedInstructionCount": 21,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x0b 256-bit"
@@ -474,7 +474,6 @@
         "zip2 z4.s, z0.s, z1.s",
         "movprfx z5, z6",
         "asr z5.s, p7/m, z5.s, #14",
-        "movprfx z4, z4",
         "asr z4.s, p7/m, z4.s, #14",
         "mov z6.s, #1",
         "add z5.s, z5.s, z6.s",
@@ -512,7 +511,7 @@
       ]
     },
     "vpermilps ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 20,
+      "ExpectedInstructionCount": 19,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x0c 256-bit"
@@ -524,7 +523,6 @@
         "and z5.d, z5.d, z6.d",
         "trn1 z5.b, z5.b, z5.b",
         "trn1 z5.h, z5.h, z5.h",
-        "movprfx z5, z5",
         "lsl z5.b, p7/m, z5.b, #2",
         "mov w20, #0x100",
         "movk w20, #0x302, lsl #16",
@@ -569,7 +567,7 @@
       ]
     },
     "vpermilpd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 25,
+      "ExpectedInstructionCount": 23,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x0d 256-bit"
@@ -577,14 +575,12 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "movprfx z5, z5",
         "lsr z5.d, p7/m, z5.d, #1",
         "mov z6.d, #1",
         "and z5.d, z5.d, z6.d",
         "trn1 z5.b, z5.b, z5.b",
         "trn1 z5.h, z5.h, z5.h",
         "trn1 z5.s, z5.s, z5.s",
-        "movprfx z5, z5",
         "lsl z5.b, p7/m, z5.b, #3",
         "mov x20, #0x100",
         "movk x20, #0x302, lsl #16",
@@ -787,7 +783,7 @@
       ]
     },
     "vpermps ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 14,
+      "ExpectedInstructionCount": 13,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x16 256-bit"
@@ -799,7 +795,6 @@
         "and z4.d, z4.d, z6.d",
         "trn1 z4.b, z4.b, z4.b",
         "trn1 z4.h, z4.h, z4.h",
-        "movprfx z4, z4",
         "lsl z4.b, p7/m, z4.b, #2",
         "mov w20, #0x100",
         "movk w20, #0x302, lsl #16",
@@ -1558,7 +1553,7 @@
       ]
     },
     "vpermd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 14,
+      "ExpectedInstructionCount": 13,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x36 256-bit"
@@ -1570,7 +1565,6 @@
         "and z4.d, z4.d, z6.d",
         "trn1 z4.b, z4.b, z4.b",
         "trn1 z4.h, z4.h, z4.h",
-        "movprfx z4, z4",
         "lsl z4.b, p7/m, z4.b, #2",
         "mov w20, #0x100",
         "movk w20, #0x302, lsl #16",

--- a/unittests/InstructionCountCI/VEX_map2.json
+++ b/unittests/InstructionCountCI/VEX_map2.json
@@ -1890,7 +1890,7 @@
       ]
     },
     "vpsrlvd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x45 256-bit"
@@ -1900,7 +1900,6 @@
         "mov z5.d, p7/m, z18.d",
         "mov z1.s, #32",
         "umin z1.s, p7/m, z1.s, z5.s",
-        "movprfx z4, z4",
         "lsr z4.s, p7/m, z4.s, z1.s",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -1925,7 +1924,7 @@
       ]
     },
     "vpsrlvq ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x45 256-bit"
@@ -1935,7 +1934,6 @@
         "mov z5.d, p7/m, z18.d",
         "mov z1.d, #64",
         "umin z1.d, p7/m, z1.d, z5.d",
-        "movprfx z4, z4",
         "lsr z4.d, p7/m, z4.d, z1.d",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -1958,7 +1956,7 @@
       ]
     },
     "vpsravd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x46 256-bit"
@@ -1968,7 +1966,6 @@
         "mov z5.d, p7/m, z18.d",
         "mov z0.s, #31",
         "umin z0.s, p7/m, z0.s, z5.s",
-        "movprfx z4, z4",
         "asr z4.s, p7/m, z4.s, z0.s",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -1990,7 +1987,7 @@
       ]
     },
     "vpsllvd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x47 256-bit"
@@ -2000,7 +1997,6 @@
         "mov z5.d, p7/m, z18.d",
         "mov z1.s, #32",
         "umin z1.s, p7/m, z1.s, z5.s",
-        "movprfx z4, z4",
         "lsl z4.s, p7/m, z4.s, z1.s",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -2024,7 +2020,7 @@
       ]
     },
     "vpsllvq ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x47 256-bit"
@@ -2034,7 +2030,6 @@
         "mov z5.d, p7/m, z18.d",
         "mov z1.d, #64",
         "umin z1.d, p7/m, z1.d, z5.d",
-        "movprfx z4, z4",
         "lsl z4.d, p7/m, z4.d, z1.d",
         "mov z16.d, p7/m, z4.d"
       ]

--- a/unittests/InstructionCountCI/VEX_map3.json
+++ b/unittests/InstructionCountCI/VEX_map3.json
@@ -4737,7 +4737,7 @@
       ]
     },
     "vblendvps ymm0, ymm1, ymm2, ymm3": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x4a 256-bit"
@@ -4746,7 +4746,6 @@
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
         "mov z6.d, p7/m, z19.d",
-        "movprfx z6, z6",
         "asr z6.s, p7/m, z6.s, #31",
         "movprfx z0, z5",
         "bsl z0.d, z0.d, z4.d, z6.d",
@@ -4771,7 +4770,7 @@
       ]
     },
     "vblendvpd ymm0, ymm1, ymm2, ymm3": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x4b 256-bit"
@@ -4780,7 +4779,6 @@
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
         "mov z6.d, p7/m, z19.d",
-        "movprfx z6, z6",
         "asr z6.d, p7/m, z6.d, #63",
         "movprfx z0, z5",
         "bsl z0.d, z0.d, z4.d, z6.d",
@@ -4805,7 +4803,7 @@
       ]
     },
     "vpblendvb ymm0, ymm1, ymm2, ymm3": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x4c 256-bit"
@@ -4814,7 +4812,6 @@
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
         "mov z6.d, p7/m, z19.d",
-        "movprfx z6, z6",
         "asr z6.b, p7/m, z6.b, #7",
         "movprfx z0, z5",
         "bsl z0.d, z0.d, z4.d, z6.d",

--- a/unittests/InstructionCountCI/VEX_map_group.json
+++ b/unittests/InstructionCountCI/VEX_map_group.json
@@ -57,14 +57,13 @@
       ]
     },
     "vpsrlw ymm0, ymm1, 15": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map group 12 0b010 256-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "movprfx z4, z4",
         "lsr z4.h, p7/m, z4.h, #15",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -131,27 +130,25 @@
       ]
     },
     "vpsraw ymm0, ymm1, 15": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map group 12 0b100 256-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "movprfx z4, z4",
         "asr z4.h, p7/m, z4.h, #15",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vpsraw ymm0, ymm1, 16": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map group 12 0b100 256-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "movprfx z4, z4",
         "asr z4.h, p7/m, z4.h, #15",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -206,14 +203,13 @@
       ]
     },
     "vpsllw ymm0, ymm1, 15": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map group 12 0b110 256-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "movprfx z4, z4",
         "lsl z4.h, p7/m, z4.h, #15",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -280,14 +276,13 @@
       ]
     },
     "vpsrld ymm0, ymm1, 31": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map group 13 0b010 256-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "movprfx z4, z4",
         "lsr z4.s, p7/m, z4.s, #31",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -354,27 +349,25 @@
       ]
     },
     "vpsrad ymm0, ymm1, 31": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map group 13 0b100 256-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "movprfx z4, z4",
         "asr z4.s, p7/m, z4.s, #31",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vpsrad ymm0, ymm1, 32": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map group 13 0b100 256-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "movprfx z4, z4",
         "asr z4.s, p7/m, z4.s, #31",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -429,14 +422,13 @@
       ]
     },
     "vpslld ymm0, ymm1, 31": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map group 13 0b110 256-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "movprfx z4, z4",
         "lsl z4.s, p7/m, z4.s, #31",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -503,14 +495,13 @@
       ]
     },
     "vpsrlq ymm0, ymm1, 63": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map group 14 0b010 256-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "movprfx z4, z4",
         "lsr z4.d, p7/m, z4.d, #63",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -657,14 +648,13 @@
       ]
     },
     "vpsllq ymm0, ymm1, 63": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map group 14 0b110 256-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "movprfx z4, z4",
         "lsl z4.d, p7/m, z4.d, #63",
         "mov z16.d, p7/m, z4.d"
       ]


### PR DESCRIPTION
When our destination aliases the vector to be shifted, we don't need to emit a movprfx