### PR TITLE
Arm64/VectorOps: Remove redundant moves in SVE VExtr when possible

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -2752,9 +2752,14 @@ DEF_OP(VExtr) {
   const auto CopyFromByte = Index * ElementSize;
 
   if (HostSupportsSVE256 && Is256Bit) {
-    movprfx(VTMP2.Z(), LowerBits.Z());
-    ext<FEXCore::ARMEmitter::OpType::Destructive>(VTMP2.Z(), VTMP2.Z(), UpperBits.Z(), CopyFromByte);
-    mov(Dst.Z(), VTMP2.Z());
+    if (Dst == LowerBits) {
+      // Trivial case where we don't need to do any moves
+      ext<FEXCore::ARMEmitter::OpType::Destructive>(Dst.Z(), Dst.Z(), UpperBits.Z(), CopyFromByte);
+    } else {
+      movprfx(VTMP2.Z(), LowerBits.Z());
+      ext<FEXCore::ARMEmitter::OpType::Destructive>(VTMP2.Z(), VTMP2.Z(), UpperBits.Z(), CopyFromByte);
+      mov(Dst.Z(), VTMP2.Z());
+    }
   } else {
     if (OpSize == 8) {
       ext(Dst.D(), LowerBits.D(), UpperBits.D(), CopyFromByte);

--- a/unittests/InstructionCountCI/VEX_map_group.json
+++ b/unittests/InstructionCountCI/VEX_map_group.json
@@ -568,7 +568,7 @@
       ]
     },
     "vpsrldq ymm0, ymm1, 15": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 9,
       "Optimal": "No",
       "Comment": [
         "Map group 14 0b011 256-bit"
@@ -577,9 +577,7 @@
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, #0",
         "ext v6.16b, v4.16b, v5.16b, #15",
-        "movprfx z1, z4",
-        "ext z1.b, z1.b, z5.b, #31",
-        "mov z4.d, z1.d",
+        "ext z4.b, z4.b, z5.b, #31",
         "mov z1.q, q4",
         "mov z4.d, z6.d",
         "not p0.b, p7/z, p6.b",


### PR DESCRIPTION
We don't need to do any moves here is the destination aliases the lower bits.