### PR TITLE
Arm64/VectorOps: Remove redundant moves from VSQXTN2/VSQXTUN2/VSQSHL/VSRSHR

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -3354,8 +3354,11 @@ DEF_OP(VSRSHR) {
 
   if (HostSupportsSVE256 && Is256Bit) {
     const auto Mask = PRED_TMP_32B.Merging();
-    // SVE SRSHR is destructive, so lets set up the destination.
-    movprfx(Dst.Z(), Vector.Z());
+    // SVE SRSHR is destructive, so lets set up the destination
+    // in the event we Dst and Vector don't alias.
+    if (Dst != Vector) {
+      movprfx(Dst.Z(), Vector.Z());
+    }
     srshr(SubRegSize, Dst.Z(), Mask, Vector.Z(), BitShift);
   } else {
     if (OpSize == 8) {

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -3390,8 +3390,11 @@ DEF_OP(VSQSHL) {
 
   if (HostSupportsSVE256 && Is256Bit) {
     const auto Mask = PRED_TMP_32B.Merging();
-    // SVE SQSHL is destructive, so lets set up the destination.
-    movprfx(Dst.Z(), Vector.Z());
+    // SVE SQSHL is destructive, so lets set up the destination
+    // in the event Dst and Vector don't alias
+    if (Dst != Vector) {
+      movprfx(Dst.Z(), Vector.Z());
+    }
     sqshl(SubRegSize, Dst.Z(), Mask, Vector.Z(), BitShift);
   } else {
     if (OpSize == 8) {

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -3150,7 +3150,9 @@ DEF_OP(VSQXTN2) {
     // the constructive variant requires a register list, and
     // we can't guarantee VectorLower and VectorUpper will always
     // have consecutive indexes with one another.
-    movprfx(Dst.Z(), VectorLower.Z());
+    if (Dst != VectorLower) {
+      movprfx(Dst.Z(), VectorLower.Z());
+    }
     splice<ARMEmitter::OpType::Destructive>(SubRegSize, Dst.Z(), Mask, Dst.Z(), VTMP2.Z());
   } else {
     if (OpSize == 8) {

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -3267,7 +3267,9 @@ DEF_OP(VSQXTUN2) {
     sqxtunb(SubRegSize, VTMP2.Z(), VectorUpper.Z());
     uzp1(SubRegSize, VTMP2.Z(), VTMP2.Z(), VTMP2.Z());
 
-    movprfx(Dst.Z(), VectorLower.Z());
+    if (Dst != VectorLower) {
+      movprfx(Dst.Z(), VectorLower.Z());
+    }
     splice<ARMEmitter::OpType::Destructive>(SubRegSize, Dst.Z(), Mask, Dst.Z(), VTMP2.Z());
   } else {
     if (OpSize == 8) {

--- a/unittests/InstructionCountCI/VEX_map2.json
+++ b/unittests/InstructionCountCI/VEX_map2.json
@@ -351,7 +351,7 @@
       ]
     },
     "vpsignb ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x08 256-bit"
@@ -361,7 +361,6 @@
         "mov z5.d, p7/m, z18.d",
         "movprfx z5, z5",
         "sqshl z5.b, p7/m, z5.b, #7",
-        "movprfx z5, z5",
         "srshr z5.b, p7/m, z5.b, #7",
         "mul z4.b, z4.b, z5.b",
         "mov z16.d, p7/m, z4.d"
@@ -384,7 +383,7 @@
       ]
     },
     "vpsignw ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x09 256-bit"
@@ -394,7 +393,6 @@
         "mov z5.d, p7/m, z18.d",
         "movprfx z5, z5",
         "sqshl z5.h, p7/m, z5.h, #15",
-        "movprfx z5, z5",
         "srshr z5.h, p7/m, z5.h, #15",
         "mul z4.h, z4.h, z5.h",
         "mov z16.d, p7/m, z4.d"
@@ -417,7 +415,7 @@
       ]
     },
     "vpsignd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x0a 256-bit"
@@ -427,7 +425,6 @@
         "mov z5.d, p7/m, z18.d",
         "movprfx z5, z5",
         "sqshl z5.s, p7/m, z5.s, #31",
-        "movprfx z5, z5",
         "srshr z5.s, p7/m, z5.s, #31",
         "mul z4.s, z4.s, z5.s",
         "mov z16.d, p7/m, z4.d"

--- a/unittests/InstructionCountCI/VEX_map2.json
+++ b/unittests/InstructionCountCI/VEX_map2.json
@@ -351,7 +351,7 @@
       ]
     },
     "vpsignb ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x08 256-bit"
@@ -359,7 +359,6 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "movprfx z5, z5",
         "sqshl z5.b, p7/m, z5.b, #7",
         "srshr z5.b, p7/m, z5.b, #7",
         "mul z4.b, z4.b, z5.b",
@@ -383,7 +382,7 @@
       ]
     },
     "vpsignw ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x09 256-bit"
@@ -391,7 +390,6 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "movprfx z5, z5",
         "sqshl z5.h, p7/m, z5.h, #15",
         "srshr z5.h, p7/m, z5.h, #15",
         "mul z4.h, z4.h, z5.h",
@@ -415,7 +413,7 @@
       ]
     },
     "vpsignd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x0a 256-bit"
@@ -423,7 +421,6 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "movprfx z5, z5",
         "sqshl z5.s, p7/m, z5.s, #31",
         "srshr z5.s, p7/m, z5.s, #31",
         "mul z4.s, z4.s, z5.s",


### PR DESCRIPTION
We don't need to perform a move if some vectors alias the destination