### PR TITLE
Arm64/ConversionOps: Add missing half-precision conversions to scalar functions

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/Arm64/ConversionOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/ConversionOps.cpp
@@ -144,6 +144,14 @@ DEF_OP(Float_FromGPR_S) {
   auto Src = GetReg(Op->Src.ID());
 
   switch (Conv) {
+    case 0x0204: { // Half <- int32_t
+      scvtf(ARMEmitter::Size::i32Bit, Dst.H(), Src);
+      break;
+    }
+    case 0x0208: { // Half <- int64_t
+      scvtf(ARMEmitter::Size::i64Bit, Dst.H(), Src);
+      break;
+    }
     case 0x0404: { // Float <- int32_t
       scvtf(ARMEmitter::Size::i32Bit, Dst.S(), Src);
       break;

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/ConversionOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/ConversionOps.cpp
@@ -175,6 +175,22 @@ DEF_OP(Float_FToF) {
   auto Src = GetVReg(Op->Scalar.ID());
 
   switch (Conv) {
+    case 0x0204: { // Half <- Float
+      fcvt(Dst.H(), Src.S());
+      break;
+    }
+    case 0x0208: { // Half <- Double
+      fcvt(Dst.H(), Src.D());
+      break;
+    }
+    case 0x0402: { // Float <- Half
+      fcvt(Dst.S(), Src.H());
+      break;
+    }
+    case 0x0802: { // Double <- Half
+      fcvt(Dst.D(), Src.H());
+      break;
+    }
     case 0x0804: { // Double <- Float
       fcvt(Dst.D(), Src.S());
       break;


### PR DESCRIPTION
Makes them equal feature-wise to the vector variants