### PR TITLE
Arm64/ConversionOps: Remove redundant moves in AdvSIMD VInsGPR

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/Arm64/ConversionOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/ConversionOps.cpp
@@ -79,7 +79,10 @@ DEF_OP(VInsGPR) {
       splice<ARMEmitter::OpType::Destructive>(ARMEmitter::SubRegSize::i64Bit, Dst.Z(), PRED_TMP_16B, Dst.Z(), DestVector.Z());
     }
   } else {
-    mov(Dst.Q(), DestVector.Q());
+    // No need to move if Dst and DestVector alias one another.
+    if (Dst != DestVector) {
+      mov(Dst.Q(), DestVector.Q());
+    }
     ins(SubEmitSize, Dst, DestIdx, Src);
   }
 }

--- a/unittests/InstructionCountCI/H0F38.json
+++ b/unittests/InstructionCountCI/H0F38.json
@@ -693,7 +693,7 @@
       ]
     },
     "sha1msg2 xmm0, xmm1": {
-      "ExpectedInstructionCount": 23,
+      "ExpectedInstructionCount": 21,
       "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x38 0xca"
@@ -716,16 +716,14 @@
         "ror w23, w23, #31",
         "mov v4.16b, v16.16b",
         "mov v4.s[3], w20",
-        "mov v4.16b, v4.16b",
         "mov v4.s[2], w21",
-        "mov v4.16b, v4.16b",
         "mov v4.s[1], w22",
         "mov v16.16b, v4.16b",
         "mov v16.s[0], w23"
       ]
     },
     "sha256rnds2 xmm0, xmm1": {
-      "ExpectedInstructionCount": 109,
+      "ExpectedInstructionCount": 106,
       "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x38 0xcb"
@@ -831,11 +829,8 @@
         "add w21, w21, w23",
         "ldr w23, [sp, #128]",
         "add w21, w21, w23",
-        "mov v4.16b, v4.16b",
         "mov v4.s[3], w20",
-        "mov v4.16b, v4.16b",
         "mov v4.s[2], w24",
-        "mov v4.16b, v4.16b",
         "mov v4.s[1], w21",
         "mov v16.16b, v4.16b",
         "mov v16.s[0], w22",
@@ -843,7 +838,7 @@
       ]
     },
     "sha256msg1 xmm0, xmm1": {
-      "ExpectedInstructionCount": 37,
+      "ExpectedInstructionCount": 35,
       "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x38 0xcc"
@@ -880,16 +875,14 @@
         "add w23, w24, w23",
         "mov v4.16b, v16.16b",
         "mov v4.s[3], w20",
-        "mov v4.16b, v4.16b",
         "mov v4.s[2], w21",
-        "mov v4.16b, v4.16b",
         "mov v4.s[1], w22",
         "mov v16.16b, v4.16b",
         "mov v16.s[0], w23"
       ]
     },
     "sha256msg2 xmm0, xmm1": {
-      "ExpectedInstructionCount": 38,
+      "ExpectedInstructionCount": 36,
       "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x38 0xcd"
@@ -927,9 +920,7 @@
         "add w23, w23, w24",
         "mov v4.16b, v16.16b",
         "mov v4.s[3], w23",
-        "mov v4.16b, v4.16b",
         "mov v4.s[2], w22",
-        "mov v4.16b, v4.16b",
         "mov v4.s[1], w21",
         "mov v16.16b, v4.16b",
         "mov v16.s[0], w20"

--- a/unittests/InstructionCountCI/H0F3A.json
+++ b/unittests/InstructionCountCI/H0F3A.json
@@ -724,38 +724,35 @@
       ]
     },
     "pinsrb xmm0, eax, 0000b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x3a 0x20"
       ],
       "ExpectedArm64ASM": [
         "uxth x20, w4",
-        "mov v16.16b, v16.16b",
         "mov v16.b[0], w20"
       ]
     },
     "pinsrb xmm0, eax, 0001b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x3a 0x20"
       ],
       "ExpectedArm64ASM": [
         "uxth x20, w4",
-        "mov v16.16b, v16.16b",
         "mov v16.b[1], w20"
       ]
     },
     "pinsrb xmm0, eax, 1111b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x3a 0x20"
       ],
       "ExpectedArm64ASM": [
         "uxth x20, w4",
-        "mov v16.16b, v16.16b",
         "mov v16.b[15], w20"
       ]
     },
@@ -790,60 +787,55 @@
       ]
     },
     "pinsrd xmm0, eax, 00b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x3a 0x22"
       ],
       "ExpectedArm64ASM": [
         "ubfx x20, x4, #0, #32",
-        "mov v16.16b, v16.16b",
         "mov v16.s[0], w20"
       ]
     },
     "pinsrd xmm0, eax, 01b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x3a 0x22"
       ],
       "ExpectedArm64ASM": [
         "ubfx x20, x4, #0, #32",
-        "mov v16.16b, v16.16b",
         "mov v16.s[1], w20"
       ]
     },
     "pinsrd xmm0, eax, 11b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x3a 0x22"
       ],
       "ExpectedArm64ASM": [
         "ubfx x20, x4, #0, #32",
-        "mov v16.16b, v16.16b",
         "mov v16.s[3], w20"
       ]
     },
     "pinsrq xmm0, rax, 0b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "0x66 REX.W 0x0f 0x3a 0x22"
       ],
       "ExpectedArm64ASM": [
-        "mov v16.16b, v16.16b",
         "mov v16.d[0], x4"
       ]
     },
     "pinsrq xmm0, rax, 1b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "0x66 REX.W 0x0f 0x3a 0x22"
       ],
       "ExpectedArm64ASM": [
-        "mov v16.16b, v16.16b",
         "mov v16.d[1], x4"
       ]
     },
@@ -1190,7 +1182,7 @@
       ]
     },
     "sha1rnds4 xmm0, xmm1, 00b": {
-      "ExpectedInstructionCount": 61,
+      "ExpectedInstructionCount": 59,
       "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x3a 0xcc"
@@ -1250,9 +1242,7 @@
         "ror w21, w21, #2",
         "mov v4.16b, v16.16b",
         "mov v4.s[3], w23",
-        "mov v4.16b, v4.16b",
         "mov v4.s[2], w22",
-        "mov v4.16b, v4.16b",
         "mov v4.s[1], w21",
         "mov v16.16b, v4.16b",
         "mov v16.s[0], w20",
@@ -1260,7 +1250,7 @@
       ]
     },
     "sha1rnds4 xmm0, xmm1, 01b": {
-      "ExpectedInstructionCount": 57,
+      "ExpectedInstructionCount": 55,
       "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x3a 0xcc"
@@ -1316,9 +1306,7 @@
         "ror w21, w21, #2",
         "mov v4.16b, v16.16b",
         "mov v4.s[3], w23",
-        "mov v4.16b, v4.16b",
         "mov v4.s[2], w22",
-        "mov v4.16b, v4.16b",
         "mov v4.s[1], w21",
         "mov v16.16b, v4.16b",
         "mov v16.s[0], w20",
@@ -1326,7 +1314,7 @@
       ]
     },
     "sha1rnds4 xmm0, xmm1, 10b": {
-      "ExpectedInstructionCount": 69,
+      "ExpectedInstructionCount": 67,
       "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x3a 0xcc"
@@ -1394,9 +1382,7 @@
         "ror w21, w21, #2",
         "mov v4.16b, v16.16b",
         "mov v4.s[3], w23",
-        "mov v4.16b, v4.16b",
         "mov v4.s[2], w22",
-        "mov v4.16b, v4.16b",
         "mov v4.s[1], w21",
         "mov v16.16b, v4.16b",
         "mov v16.s[0], w20",
@@ -1404,7 +1390,7 @@
       ]
     },
     "sha1rnds4 xmm0, xmm1, 11b": {
-      "ExpectedInstructionCount": 57,
+      "ExpectedInstructionCount": 55,
       "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x3a 0xcc"
@@ -1460,9 +1446,7 @@
         "ror w21, w21, #2",
         "mov v4.16b, v16.16b",
         "mov v4.s[3], w23",
-        "mov v4.16b, v4.16b",
         "mov v4.s[2], w22",
-        "mov v4.16b, v4.16b",
         "mov v4.s[1], w21",
         "mov v16.16b, v4.16b",
         "mov v16.s[0], w20",

--- a/unittests/InstructionCountCI/Secondary.json
+++ b/unittests/InstructionCountCI/Secondary.json
@@ -3722,121 +3722,111 @@
       ]
     },
     "pinsrw mm0, eax, 0": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": "0x0f 0xc4",
       "ExpectedArm64ASM": [
         "uxth x20, w4",
         "ldr d4, [x28, #752]",
-        "mov v4.16b, v4.16b",
         "mov v4.h[0], w20",
         "str d4, [x28, #752]"
       ]
     },
     "pinsrw mm0, eax, 1": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": "0x0f 0xc4",
       "ExpectedArm64ASM": [
         "uxth x20, w4",
         "ldr d4, [x28, #752]",
-        "mov v4.16b, v4.16b",
         "mov v4.h[1], w20",
         "str d4, [x28, #752]"
       ]
     },
     "pinsrw mm0, eax, 2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": "0x0f 0xc4",
       "ExpectedArm64ASM": [
         "uxth x20, w4",
         "ldr d4, [x28, #752]",
-        "mov v4.16b, v4.16b",
         "mov v4.h[2], w20",
         "str d4, [x28, #752]"
       ]
     },
     "pinsrw mm0, eax, 3": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": "0x0f 0xc4",
       "ExpectedArm64ASM": [
         "uxth x20, w4",
         "ldr d4, [x28, #752]",
-        "mov v4.16b, v4.16b",
         "mov v4.h[3], w20",
         "str d4, [x28, #752]"
       ]
     },
     "pinsrw mm0, eax, 4": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": "0x0f 0xc4",
       "ExpectedArm64ASM": [
         "uxth x20, w4",
         "ldr d4, [x28, #752]",
-        "mov v4.16b, v4.16b",
         "mov v4.h[0], w20",
         "str d4, [x28, #752]"
       ]
     },
     "pinsrw mm0, [rax], 0": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": "0x0f 0xc4",
       "ExpectedArm64ASM": [
         "ldrh w20, [x4]",
         "ldr d4, [x28, #752]",
-        "mov v4.16b, v4.16b",
         "mov v4.h[0], w20",
         "str d4, [x28, #752]"
       ]
     },
     "pinsrw mm0, [rax], 1": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": "0x0f 0xc4",
       "ExpectedArm64ASM": [
         "ldrh w20, [x4]",
         "ldr d4, [x28, #752]",
-        "mov v4.16b, v4.16b",
         "mov v4.h[1], w20",
         "str d4, [x28, #752]"
       ]
     },
     "pinsrw mm0, [rax], 2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": "0x0f 0xc4",
       "ExpectedArm64ASM": [
         "ldrh w20, [x4]",
         "ldr d4, [x28, #752]",
-        "mov v4.16b, v4.16b",
         "mov v4.h[2], w20",
         "str d4, [x28, #752]"
       ]
     },
     "pinsrw mm0, [rax], 3": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": "0x0f 0xc4",
       "ExpectedArm64ASM": [
         "ldrh w20, [x4]",
         "ldr d4, [x28, #752]",
-        "mov v4.16b, v4.16b",
         "mov v4.h[3], w20",
         "str d4, [x28, #752]"
       ]
     },
     "pinsrw mm0, [rax], 4": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": "0x0f 0xc4",
       "ExpectedArm64ASM": [
         "ldrh w20, [x4]",
         "ldr d4, [x28, #752]",
-        "mov v4.16b, v4.16b",
         "mov v4.h[0], w20",
         "str d4, [x28, #752]"
       ]

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -3032,7 +3032,7 @@
       ]
     },
     "vpinsrw xmm0, xmm1, eax, 000b": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC4 128-bit"
@@ -3040,14 +3040,13 @@
       "ExpectedArm64ASM": [
         "uxth x20, w4",
         "mov z4.d, p7/m, z17.d",
-        "mov v4.16b, v4.16b",
         "mov v4.h[0], w20",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vpinsrw xmm0, xmm1, eax, 001b": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC4 128-bit"
@@ -3055,14 +3054,13 @@
       "ExpectedArm64ASM": [
         "uxth x20, w4",
         "mov z4.d, p7/m, z17.d",
-        "mov v4.16b, v4.16b",
         "mov v4.h[1], w20",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vpinsrw xmm0, xmm1, eax, 111b": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC4 128-bit"
@@ -3070,7 +3068,6 @@
       "ExpectedArm64ASM": [
         "uxth x20, w4",
         "mov z4.d, p7/m, z17.d",
-        "mov v4.16b, v4.16b",
         "mov v4.h[7], w20",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"

--- a/unittests/InstructionCountCI/VEX_map3.json
+++ b/unittests/InstructionCountCI/VEX_map3.json
@@ -3234,7 +3234,7 @@
       ]
     },
     "vpinsrb xmm0, xmm1, eax, 0": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "nearest rounding",
@@ -3243,14 +3243,13 @@
       "ExpectedArm64ASM": [
         "ubfx x20, x4, #0, #32",
         "mov z4.d, p7/m, z17.d",
-        "mov v4.16b, v4.16b",
         "mov v4.b[0], w20",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vpinsrb xmm0, xmm1, eax, 15": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "nearest rounding",
@@ -3259,7 +3258,6 @@
       "ExpectedArm64ASM": [
         "ubfx x20, x4, #0, #32",
         "mov z4.d, p7/m, z17.d",
-        "mov v4.16b, v4.16b",
         "mov v4.b[15], w20",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
@@ -3309,7 +3307,7 @@
       ]
     },
     "vpinsrd xmm0, xmm1, eax, 0": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "nearest rounding",
@@ -3318,14 +3316,13 @@
       "ExpectedArm64ASM": [
         "ubfx x20, x4, #0, #32",
         "mov z4.d, p7/m, z17.d",
-        "mov v4.16b, v4.16b",
         "mov v4.s[0], w20",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vpinsrd xmm0, xmm1, eax, 3": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "nearest rounding",
@@ -3334,14 +3331,13 @@
       "ExpectedArm64ASM": [
         "ubfx x20, x4, #0, #32",
         "mov z4.d, p7/m, z17.d",
-        "mov v4.16b, v4.16b",
         "mov v4.s[3], w20",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vpinsrq xmm0, xmm1, rax, 0": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "nearest rounding",
@@ -3349,14 +3345,13 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "mov v4.16b, v4.16b",
         "mov v4.d[0], x4",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vpinsrq xmm0, xmm1, rax, 1": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "nearest rounding",
@@ -3364,7 +3359,6 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "mov v4.16b, v4.16b",
         "mov v4.d[1], x4",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"

--- a/unittests/InstructionCountCI/x87.json
+++ b/unittests/InstructionCountCI/x87.json
@@ -5773,7 +5773,7 @@
       "ExpectedArm64ASM": []
     },
     "fchs": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xe0 /4"
@@ -5785,7 +5785,6 @@
         "mov w21, #0x0",
         "mov w22, #0x8000",
         "fmov d5, x21",
-        "mov v5.16b, v5.16b",
         "mov v5.d[1], x22",
         "eor v4.16b, v4.16b, v5.16b",
         "add x0, x28, x20, lsl #4",
@@ -5793,7 +5792,7 @@
       ]
     },
     "fabs": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xe1 /4"
@@ -5805,7 +5804,6 @@
         "mov x21, #0xffffffffffffffff",
         "mov w22, #0x7fff",
         "fmov d5, x21",
-        "mov v5.16b, v5.16b",
         "mov v5.d[1], x22",
         "and v4.16b, v4.16b, v5.16b",
         "add x0, x28, x20, lsl #4",
@@ -5907,7 +5905,7 @@
       ]
     },
     "fld1": {
-      "ExpectedInstructionCount": 17,
+      "ExpectedInstructionCount": 16,
       "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xe8 /5"
@@ -5926,14 +5924,13 @@
         "mov x21, #0x8000000000000000",
         "mov w22, #0x3fff",
         "fmov d4, x21",
-        "mov v4.16b, v4.16b",
         "mov v4.d[1], x22",
         "add x0, x28, x20, lsl #4",
         "str q4, [x0, #752]"
       ]
     },
     "fldl2t": {
-      "ExpectedInstructionCount": 20,
+      "ExpectedInstructionCount": 19,
       "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xe9 /5"
@@ -5955,14 +5952,13 @@
         "movk x21, #0xd49a, lsl #48",
         "mov w22, #0x4000",
         "fmov d4, x21",
-        "mov v4.16b, v4.16b",
         "mov v4.d[1], x22",
         "add x0, x28, x20, lsl #4",
         "str q4, [x0, #752]"
       ]
     },
     "fldl2e": {
-      "ExpectedInstructionCount": 20,
+      "ExpectedInstructionCount": 19,
       "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xea /5"
@@ -5984,14 +5980,13 @@
         "movk x21, #0xb8aa, lsl #48",
         "mov w22, #0x3fff",
         "fmov d4, x21",
-        "mov v4.16b, v4.16b",
         "mov v4.d[1], x22",
         "add x0, x28, x20, lsl #4",
         "str q4, [x0, #752]"
       ]
     },
     "fldpi": {
-      "ExpectedInstructionCount": 20,
+      "ExpectedInstructionCount": 19,
       "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xeb /5"
@@ -6013,14 +6008,13 @@
         "movk x21, #0xc90f, lsl #48",
         "mov w22, #0x4000",
         "fmov d4, x21",
-        "mov v4.16b, v4.16b",
         "mov v4.d[1], x22",
         "add x0, x28, x20, lsl #4",
         "str q4, [x0, #752]"
       ]
     },
     "fldlg2": {
-      "ExpectedInstructionCount": 20,
+      "ExpectedInstructionCount": 19,
       "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xec /5"
@@ -6042,14 +6036,13 @@
         "movk x21, #0x9a20, lsl #48",
         "mov w22, #0x3ffd",
         "fmov d4, x21",
-        "mov v4.16b, v4.16b",
         "mov v4.d[1], x22",
         "add x0, x28, x20, lsl #4",
         "str q4, [x0, #752]"
       ]
     },
     "fldln2": {
-      "ExpectedInstructionCount": 20,
+      "ExpectedInstructionCount": 19,
       "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xed /5"
@@ -6071,14 +6064,13 @@
         "movk x21, #0xb172, lsl #48",
         "mov w22, #0x3ffe",
         "fmov d4, x21",
-        "mov v4.16b, v4.16b",
         "mov v4.d[1], x22",
         "add x0, x28, x20, lsl #4",
         "str q4, [x0, #752]"
       ]
     },
     "fldz": {
-      "ExpectedInstructionCount": 16,
+      "ExpectedInstructionCount": 15,
       "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xee /5"
@@ -6096,7 +6088,6 @@
         "strb w20, [x28, #747]",
         "mov w21, #0x0",
         "fmov d4, x21",
-        "mov v4.16b, v4.16b",
         "mov v4.d[1], x21",
         "add x0, x28, x20, lsl #4",
         "str q4, [x0, #752]"
@@ -6232,7 +6223,7 @@
       ]
     },
     "fptan": {
-      "ExpectedInstructionCount": 66,
+      "ExpectedInstructionCount": 65,
       "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xf2 /6"
@@ -6296,7 +6287,6 @@
         "mov x22, #0x8000000000000000",
         "mov w23, #0x3fff",
         "fmov d5, x22",
-        "mov v5.16b, v5.16b",
         "mov v5.d[1], x23",
         "mov w22, #0x0",
         "strb w22, [x28, #746]",
@@ -6646,7 +6636,7 @@
       ]
     },
     "fyl2xp1": {
-      "ExpectedInstructionCount": 113,
+      "ExpectedInstructionCount": 112,
       "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xf9 /7"
@@ -6671,7 +6661,6 @@
         "mov x20, #0x8000000000000000",
         "mov w22, #0x3fff",
         "fmov d6, x20",
-        "mov v6.16b, v6.16b",
         "mov v6.d[1], x22",
         "stp x4, x5, [x28, #8]",
         "stp x6, x7, [x28, #24]",
@@ -15575,7 +15564,7 @@
       ]
     },
     "frstor [rax]": {
-      "ExpectedInstructionCount": 114,
+      "ExpectedInstructionCount": 113,
       "Optimal": "No",
       "Comment": [
         "0xdd !11b /4"
@@ -15639,7 +15628,6 @@
         "mov x22, #0xffffffffffffffff",
         "mov w23, #0xffff",
         "fmov d4, x22",
-        "mov v4.16b, v4.16b",
         "mov v4.d[1], x23",
         "ldur q5, [x4, #28]",
         "and v5.16b, v5.16b, v4.16b",


### PR DESCRIPTION
If Dst and DestVector alias one another, then we don't need to move the vector unnecessarily.