### PR TITLE
OpcodeDispatcher: Optimize PMULH{U,}W using new IR operations

### DIFF
--- a/FEXCore/Source/Interface/Core/Interpreter/InterpreterDefines.h
+++ b/FEXCore/Source/Interface/Core/Interpreter/InterpreterDefines.h
@@ -43,6 +43,17 @@
   }                                                        \
   break;                                                   \
   }
+#define DO_VECTOR_OP_WIDE(size, type, type2, func)         \
+  case size: {                                             \
+  auto *Dst_d  = reinterpret_cast<type*>(std::data(Tmp));  \
+  auto *Src1_d = reinterpret_cast<type*>(Src1);            \
+  auto *Src2_d = reinterpret_cast<type*>(Src2);            \
+  for (uint8_t i = 0; i < Elements; ++i) {                 \
+    Dst_d[i] = func((type2)Src1_d[i], (type2)Src2_d[i]);   \
+  }                                                        \
+  break;                                                   \
+  }
+
 #define DO_VECTOR_PAIR_OP(size, type, func)                 \
   case size: {                                              \
   auto *Dst_d  = reinterpret_cast<type*>(std::data(Tmp));   \

--- a/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -277,6 +277,8 @@ constexpr OpHandlerArray InterpreterOpHandlers = [] {
   REGISTER_OP(VSMULL,                 VSMull);
   REGISTER_OP(VUMULL2,                VUMull2);
   REGISTER_OP(VSMULL2,                VSMull2);
+  REGISTER_OP(VUMULH,                 VUMulH);
+  REGISTER_OP(VSMULH,                 VSMulH);
   REGISTER_OP(VUABDL,                 VUABDL);
   REGISTER_OP(VUABDL2,                VUABDL2);
   REGISTER_OP(VTBL1,                  VTBL1);

--- a/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
+++ b/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
@@ -305,6 +305,8 @@ namespace FEXCore::CPU {
   DEF_OP(VSMull);
   DEF_OP(VUMull2);
   DEF_OP(VSMull2);
+  DEF_OP(VUMulH);
+  DEF_OP(VSMulH);
   DEF_OP(VUABDL);
   DEF_OP(VUABDL2);
   DEF_OP(VTBL1);

--- a/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
@@ -2352,6 +2352,54 @@ DEF_OP(VSMull2) {
   memcpy(GDP, Tmp.data(), Op->Header.Size);
 }
 
+DEF_OP(VUMulH) {
+  const auto Op = IROp->C<IR::IROp_VUMul>();
+  const uint8_t OpSize = IROp->Size;
+
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector1);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Vector2);
+  TempVectorDataArray Tmp;
+
+  const uint8_t ElementSize = Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / ElementSize;
+  const auto Func = [](auto a, auto b) { return (a * b) >> (sizeof(a) * 8  / 2); };
+
+  switch (ElementSize) {
+    DO_VECTOR_OP_WIDE(1, uint8_t,  uint16_t, Func)
+    DO_VECTOR_OP_WIDE(2, uint16_t, uint32_t, Func)
+    DO_VECTOR_OP_WIDE(4, uint32_t, uint64_t, Func)
+    DO_VECTOR_OP_WIDE(8, uint64_t, __uint128_t, Func)
+    default:
+      LOGMAN_MSG_A_FMT("Unknown Element Size: {}", ElementSize);
+      break;
+  }
+  memcpy(GDP, Tmp.data(), OpSize);
+}
+
+DEF_OP(VSMulH) {
+  const auto Op = IROp->C<IR::IROp_VSMul>();
+  const uint8_t OpSize = IROp->Size;
+
+  void *Src1 = GetSrc<void*>(Data->SSAData, Op->Vector1);
+  void *Src2 = GetSrc<void*>(Data->SSAData, Op->Vector2);
+  TempVectorDataArray Tmp;
+
+  const uint8_t ElementSize = Op->Header.ElementSize;
+  const uint8_t Elements = OpSize / ElementSize;
+  const auto Func = [](auto a, auto b) { return (a * b) >> (sizeof(a) * 8  / 2); };
+
+  switch (ElementSize) {
+    DO_VECTOR_OP_WIDE(1, int8_t,  int16_t, Func)
+    DO_VECTOR_OP_WIDE(2, int16_t, int32_t, Func)
+    DO_VECTOR_OP_WIDE(4, int32_t, int64_t, Func)
+    DO_VECTOR_OP_WIDE(8, int64_t, __int128_t, Func)
+    default:
+      LOGMAN_MSG_A_FMT("Unknown Element Size: {}", ElementSize);
+      break;
+  }
+  memcpy(GDP, Tmp.data(), OpSize);
+}
+
 DEF_OP(VUABDL) {
   const auto Op = IROp->C<IR::IROp_VUABDL>();
   const uint8_t OpSize = IROp->Size;

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -1097,6 +1097,8 @@ CPUBackend::CompiledCode Arm64JITCore::CompileCode(uint64_t Entry,
         REGISTER_OP(VSMULL,            VSMull);
         REGISTER_OP(VUMULL2,           VUMull2);
         REGISTER_OP(VSMULL2,           VSMull2);
+        REGISTER_OP(VUMULH,            VUMulH);
+        REGISTER_OP(VSMULH,            VSMulH);
         REGISTER_OP(VUABDL,            VUABDL);
         REGISTER_OP(VUABDL2,           VUABDL2);
         REGISTER_OP(VTBL1,             VTBL1);

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -463,6 +463,8 @@ private:
   DEF_OP(VSMull);
   DEF_OP(VUMull2);
   DEF_OP(VSMull2);
+  DEF_OP(VUMulH);
+  DEF_OP(VSMulH);
   DEF_OP(VUABDL);
   DEF_OP(VUABDL2);
   DEF_OP(VTBL1);

--- a/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -462,6 +462,8 @@ private:
   DEF_OP(VSMull);
   DEF_OP(VUMull2);
   DEF_OP(VSMull2);
+  DEF_OP(VUMulH);
+  DEF_OP(VSMulH);
   DEF_OP(VUABDL);
   DEF_OP(VUABDL2);
   DEF_OP(VTBL1);

--- a/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
@@ -4627,6 +4627,58 @@ DEF_OP(VUABDL2) {
   }
 }
 
+DEF_OP(VUMulH) {
+  const auto Op = IROp->C<IR::IROp_VUMulH>();
+  const auto OpSize = IROp->Size;
+
+  const auto ElementSize = Op->Header.ElementSize;
+  const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
+
+  const auto Dst = GetDst(Node);
+  const auto Vector1 = GetSrc(Op->Vector1.ID());
+  const auto Vector2 = GetSrc(Op->Vector2.ID());
+
+  switch (ElementSize) {
+    case 2: {
+      if (Is256Bit) {
+        vpmulhuw(ToYMM(Dst), ToYMM(Vector1), ToYMM(Vector2));
+      }
+      else {
+        vpmulhuw(Dst, Vector1, Vector2);
+      }
+      break;
+    }
+    default:
+      LOGMAN_MSG_A_FMT("Unknown Element Size: {}", ElementSize);
+      break;
+  }
+}
+DEF_OP(VSMulH) {
+  const auto Op = IROp->C<IR::IROp_VSMulH>();
+  const auto OpSize = IROp->Size;
+
+  const auto ElementSize = Op->Header.ElementSize;
+  const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
+
+  const auto Dst = GetDst(Node);
+  const auto Vector1 = GetSrc(Op->Vector1.ID());
+  const auto Vector2 = GetSrc(Op->Vector2.ID());
+
+  switch (ElementSize) {
+    case 2: {
+      if (Is256Bit) {
+        vpmulhw(ToYMM(Dst), ToYMM(Vector1), ToYMM(Vector2));
+      }
+      else {
+        vpmulhw(Dst, Vector1, Vector2);
+      }
+      break;
+    }
+    default:
+      LOGMAN_MSG_A_FMT("Unknown Element Size: {}", ElementSize);
+      break;
+  }
+}
 
 DEF_OP(VTBL1) {
   const auto Op = IROp->C<IR::IROp_VTBL1>();
@@ -4938,6 +4990,8 @@ void X86JITCore::RegisterVectorHandlers() {
   REGISTER_OP(VSMULL,            VSMull);
   REGISTER_OP(VUMULL2,           VUMull2);
   REGISTER_OP(VSMULL2,           VSMull2);
+  REGISTER_OP(VUMULH,            VUMulH);
+  REGISTER_OP(VSMULH,            VSMulH);
   REGISTER_OP(VUABDL,            VUABDL);
   REGISTER_OP(VUABDL2,           VUABDL2);
   REGISTER_OP(VTBL1,             VTBL1);

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -3230,32 +3230,11 @@ void OpDispatchBuilder::VPMADDUBSWOp(OpcodeArgs) {
 OrderedNode* OpDispatchBuilder::PMULHWOpImpl(OpcodeArgs, bool Signed,
                                              OrderedNode *Src1, OrderedNode *Src2) {
   const auto Size = GetSrcSize(Op);
-  OrderedNode *Res{};
-
-  if (Size == 8) {
-    // Implementation is more efficient for 8byte registers
-    if (Signed) {
-      Res = _VSMull(Size * 2, 2, Src1, Src2);
-    } else {
-      Res = _VUMull(Size * 2, 2, Src1, Src2);
-    }
-
-    return _VUShrNI(Size * 2, 4, Res, 16);
-  } else {
-    // 128-bit and 256-bit is less efficient
-    OrderedNode *ResultLow;
-    OrderedNode *ResultHigh;
-    if (Signed) {
-      ResultLow = _VSMull(Size, 2, Src1, Src2);
-      ResultHigh = _VSMull2(Size, 2, Src1, Src2);
-    } else {
-      ResultLow = _VUMull(Size, 2, Src1, Src2);
-      ResultHigh = _VUMull2(Size, 2, Src1, Src2);
-    }
-
-    // Combine the results
-    Res = _VUShrNI(Size, 4, ResultLow, 16);
-    return _VUShrNI2(Size, 4, Res, ResultHigh, 16);
+  if (Signed) {
+    return _VSMulH(Size, 2, Src1, Src2);
+  }
+  else {
+    return _VUMulH(Size, 2, Src1, Src2);
   }
 }
 

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -1398,6 +1398,17 @@
         "DestSize": "RegisterSize",
         "NumElements": "RegisterSize / (ElementSize << 1)"
       },
+      "FPR = VUMulH u8:#RegisterSize, u8:#ElementSize, FPR:$Vector1, FPR:$Vector2": {
+        "Desc": "Wide unsigned multiply returning the high results",
+        "DestSize": "RegisterSize",
+        "NumElements": "RegisterSize / ElementSize"
+      },
+      "FPR = VSMulH u8:#RegisterSize, u8:#ElementSize, FPR:$Vector1, FPR:$Vector2": {
+        "Desc": "Wide signed multiply returning the high results",
+
+        "DestSize": "RegisterSize",
+        "NumElements": "RegisterSize / ElementSize"
+      },
       "FPR = VUABDL u8:#RegisterSize, u8:#ElementSize, FPR:$Vector1, FPR:$Vector2": {
         "Desc": ["Unsigned Absolute Difference Long"
                 ],

--- a/unittests/InstructionCountCI/Secondary_OpSize.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize.json
@@ -909,29 +909,23 @@
       ]
     },
     "pmulhuw xmm0, xmm1": {
-      "ExpectedInstructionCount": 6,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 3,
+      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xe4",
       "ExpectedArm64ASM": [
-        "umull v4.4s, v16.4h, v17.4h",
-        "umull2 v5.4s, v16.8h, v17.8h",
-        "shrn v4.4h, v4.4s, #16",
-        "mov v0.16b, v4.16b",
-        "shrn2 v0.8h, v5.4s, #16",
-        "mov v16.16b, v0.16b"
+        "umull2 v0.4s, v16.8h, v17.8h",
+        "umull v16.4s, v16.4h, v17.4h",
+        "uzp2 v16.8h, v16.8h, v0.8h"
       ]
     },
     "pmulhw xmm0, xmm1": {
-      "ExpectedInstructionCount": 6,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 3,
+      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xe5",
       "ExpectedArm64ASM": [
-        "smull v4.4s, v16.4h, v17.4h",
-        "smull2 v5.4s, v16.8h, v17.8h",
-        "shrn v4.4h, v4.4s, #16",
-        "mov v0.16b, v4.16b",
-        "shrn2 v0.8h, v5.4s, #16",
-        "mov v16.16b, v0.16b"
+        "smull2 v0.4s, v16.8h, v17.8h",
+        "smull v16.4s, v16.4h, v17.4h",
+        "uzp2 v16.8h, v16.8h, v0.8h"
       ]
     },
     "cvttpd2dq xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_OpSize_SVE128.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize_SVE128.json
@@ -52,6 +52,22 @@
         "asr z16.s, p6/m, z16.s, z0.d"
       ]
     },
+    "pmulhuw xmm0, xmm1": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": "0x66 0x0f 0xe4",
+      "ExpectedArm64ASM": [
+        "umulh z16.h, z16.h, z17.h"
+      ]
+    },
+    "pmulhw xmm0, xmm1": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": "0x66 0x0f 0xe5",
+      "ExpectedArm64ASM": [
+        "smulh z16.h, z16.h, z17.h"
+      ]
+    },
     "psllw xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
       "Optimal": "No",

--- a/unittests/InstructionCountCI/Secondary_OpSize_SVE256.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize_SVE256.json
@@ -1,0 +1,42 @@
+{
+  "Features": {
+    "Bitness": 64,
+    "EnabledHostFeatures": [
+      "SVE128",
+      "SVE256"
+    ],
+    "DisabledHostFeatures": []
+  },
+  "Instructions": {
+    "pmulhuw xmm0, xmm1": {
+      "ExpectedInstructionCount": 5,
+      "Optimal": "No",
+      "Comment": [
+        "SVE-256bit changes behaviour slightly",
+        "0x66 0x0f 0xe4"
+      ],
+      "ExpectedArm64ASM": [
+        "mov z4.d, p7/m, z16.d",
+        "mov z5.d, p7/m, z17.d",
+        "umulh z4.h, p6/m, z4.h, z5.h",
+        "mov v4.16b, v4.16b",
+        "mov z16.d, p7/m, z4.d"
+      ]
+    },
+    "pmulhw xmm0, xmm1": {
+      "ExpectedInstructionCount": 5,
+      "Optimal": "No",
+      "Comment": [
+        "SVE-256bit changes behaviour slightly",
+        "0x66 0x0f 0xe5"
+      ],
+      "ExpectedArm64ASM": [
+        "mov z4.d, p7/m, z16.d",
+        "mov z5.d, p7/m, z17.d",
+        "smulh z4.h, p6/m, z4.h, z5.h",
+        "mov v4.16b, v4.16b",
+        "mov z16.d, p7/m, z4.d"
+      ]
+    }
+  }
+}

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -5671,7 +5671,7 @@
       ]
     },
     "vpmulhuw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xe4 128-bit"
@@ -5679,18 +5679,13 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "umull v6.4s, v4.4h, v5.4h",
-        "umull2 v4.4s, v4.8h, v5.8h",
-        "shrn v5.4h, v6.4s, #16",
-        "mov v0.16b, v5.16b",
-        "shrn2 v0.8h, v4.4s, #16",
-        "mov v4.16b, v0.16b",
+        "umulh z4.h, p6/m, z4.h, z5.h",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vpmulhuw ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 15,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xe4 256-bit"
@@ -5698,23 +5693,12 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "umullb z0.s, z4.h, z5.h",
-        "umullt z1.s, z4.h, z5.h",
-        "zip1 z6.s, z0.s, z1.s",
-        "umullb z0.s, z4.h, z5.h",
-        "umullt z1.s, z4.h, z5.h",
-        "zip2 z4.s, z0.s, z1.s",
-        "shrnb z5.h, z6.s, #16",
-        "uzp1 z5.h, z5.h, z5.h",
-        "shrnb z1.h, z4.s, #16",
-        "uzp1 z1.h, z1.h, z1.h",
-        "movprfx z4, z5",
-        "splice z4.h, p6, z4.h, z1.h",
+        "umulh z4.h, z4.h, z5.h",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vpmulhw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xe5 128-bit"
@@ -5722,18 +5706,13 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "smull v6.4s, v4.4h, v5.4h",
-        "smull2 v4.4s, v4.8h, v5.8h",
-        "shrn v5.4h, v6.4s, #16",
-        "mov v0.16b, v5.16b",
-        "shrn2 v0.8h, v4.4s, #16",
-        "mov v4.16b, v0.16b",
+        "smulh z4.h, p6/m, z4.h, z5.h",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
     },
     "vpmulhw ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 15,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xe5 256-bit"
@@ -5741,18 +5720,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "smullb z0.s, z4.h, z5.h",
-        "smullt z1.s, z4.h, z5.h",
-        "zip1 z6.s, z0.s, z1.s",
-        "smullb z0.s, z4.h, z5.h",
-        "smullt z1.s, z4.h, z5.h",
-        "zip2 z4.s, z0.s, z1.s",
-        "shrnb z5.h, z6.s, #16",
-        "uzp1 z5.h, z5.h, z5.h",
-        "shrnb z1.h, z4.s, #16",
-        "uzp1 z1.h, z1.h, z1.h",
-        "movprfx z4, z5",
-        "splice z4.h, p6, z4.h, z1.h",
+        "smulh z4.h, z4.h, z5.h",
         "mov z16.d, p7/m, z4.d"
       ]
     },


### PR DESCRIPTION
SSE implementations are now optimal.
SVE-128bit operation makes it more optimal.

Interestingly when SVE-256bit is supported, the 128-bit operation gets worse.