### PR TITLE
OpcodeDispatcher: Optimize addsubp{s,d} using fcadd 

### DIFF
--- a/FEXCore/Source/Interface/Config/Config.json.in
+++ b/FEXCore/Source/Interface/Config/Config.json.in
@@ -74,7 +74,9 @@
           "ENABLECLZERO": "enableclzero",
           "DISABLECLZERO": "disableclzero",
           "ENABLEATOMICS": "enableatomics",
-          "DISABLEATOMICS": "disableatomics"
+          "DISABLEATOMICS": "disableatomics",
+          "ENABLEFCMA": "enablefcma",
+          "DISABLEFCMA": "disablefcma"
         },
         "Desc": [
           "Allows controlling of the CPU features in the JIT.",
@@ -88,7 +90,8 @@
           "\t{enable,disable}pmull128: Will force enable or disable pmull128 even if the host doesn't support it",
           "\t{enable,disable}rng: Will force enable or disable rng even if the host doesn't support it",
           "\t{enable,disable}clzero: Will force enable or disable clzero even if the host doesn't support it",
-          "\t{enable,disable}atomics: Will force enable or disable ARMv8.1 LSE atomics even if the host doesn't support it"
+          "\t{enable,disable}atomics: Will force enable or disable ARMv8.1 LSE atomics even if the host doesn't support it",
+          "\t{enable,disable}fcma: Will force enable or disable fcma even if the host doesn't support it"
         ]
       }
     },

--- a/FEXCore/Source/Interface/Core/HostFeatures.cpp
+++ b/FEXCore/Source/Interface/Core/HostFeatures.cpp
@@ -96,6 +96,10 @@ static void OverrideFeatures(HostFeatures *Features) {
   const bool EnableAtomics = HostFeatures() & FEXCore::Config::HostFeatures::ENABLEATOMICS;
   LogMan::Throw::AFmt(!(DisableAtomics && EnableAtomics), "Disabling and Enabling CPU features are mutually exclusive");
 
+  const bool DisableFCMA = HostFeatures() & FEXCore::Config::HostFeatures::DISABLEFCMA;
+  const bool EnableFCMA = HostFeatures() & FEXCore::Config::HostFeatures::ENABLEFCMA;
+  LogMan::Throw::AFmt(!(DisableFCMA && EnableFCMA), "Disabling and Enabling CPU features are mutually exclusive");
+
   if (EnableAVX) {
     Features->SupportsAVX = true;
   }
@@ -156,6 +160,12 @@ static void OverrideFeatures(HostFeatures *Features) {
   else if (DisableAtomics) {
     Features->SupportsAtomics = false;
   }
+  if (EnableFCMA) {
+    Features->SupportsFCMA = true;
+  }
+  else if (DisableFCMA) {
+    Features->SupportsFCMA = false;
+  }
 }
 
 HostFeatures::HostFeatures() {
@@ -181,6 +191,7 @@ HostFeatures::HostFeatures() {
   SupportsTSOImm9 = Features.Has(vixl::CPUFeatures::Feature::kRCpcImm);
   SupportsPMULL_128Bit = Features.Has(vixl::CPUFeatures::Feature::kPmull1Q);
   SupportsCSSC = Features.Has(vixl::CPUFeatures::Feature::kCSSC);
+  SupportsFCMA = Features.Has(vixl::CPUFeatures::Feature::kFcma);
 
   Supports3DNow = true;
   SupportsSSE4A = true;

--- a/FEXCore/Source/Interface/Core/Interpreter/InterpreterDefines.h
+++ b/FEXCore/Source/Interface/Core/Interpreter/InterpreterDefines.h
@@ -65,6 +65,17 @@
   }                                                         \
   break;                                                    \
   }
+#define DO_VECTOR_FCADD_PAIR_OP(size, type, func)           \
+  case size: {                                              \
+  auto *Dst_d  = reinterpret_cast<type*>(std::data(Tmp));   \
+  auto *Src1_d = reinterpret_cast<const type*>(Src1);             \
+  auto *Src2_d = reinterpret_cast<const type*>(Src2);             \
+  for (uint8_t i = 0; i < Elements; i += 2) {               \
+    func(&Dst_d[i], &Src1_d[i], &Src2_d[i]);                \
+  }                                                         \
+  break;                                                    \
+  }
+
 #define DO_VECTOR_SCALAR_OP(size, type, func)              \
   case size: {                                             \
   auto *Dst_d  = reinterpret_cast<type*>(std::data(Tmp));  \

--- a/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -286,6 +286,7 @@ constexpr OpHandlerArray InterpreterOpHandlers = [] {
   REGISTER_OP(VREV64,                 VRev64);
   REGISTER_OP(VPCMPESTRX,             VPCMPESTRX);
   REGISTER_OP(VPCMPISTRX,             VPCMPISTRX);
+  REGISTER_OP(VFCADD,                 VFCADD);
 
   // Encryption ops
   REGISTER_OP(VAESIMC,                AESImc);

--- a/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
+++ b/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
@@ -314,6 +314,7 @@ namespace FEXCore::CPU {
   DEF_OP(VRev64);
   DEF_OP(VPCMPESTRX);
   DEF_OP(VPCMPISTRX);
+  DEF_OP(VFCADD);
 
   ///< Encryption ops
   DEF_OP(AESImc);

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -1104,6 +1104,7 @@ CPUBackend::CompiledCode Arm64JITCore::CompileCode(uint64_t Entry,
         REGISTER_OP(VTBL1,             VTBL1);
         REGISTER_OP(VREV32,            VRev32);
         REGISTER_OP(VREV64,            VRev64);
+        REGISTER_OP(VFCADD,            VFCADD);
 #undef REGISTER_OP
 
         default:

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -470,6 +470,7 @@ private:
   DEF_OP(VTBL1);
   DEF_OP(VRev32);
   DEF_OP(VRev64);
+  DEF_OP(VFCADD);
 
   ///< Encryption ops
   DEF_OP(AESImc);

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -1558,6 +1558,10 @@
                  "course of creating the intermediate result"
                 ],
         "DestSize": "4"
+      },
+      "FPR = VFCADD u8:#RegisterSize, u8:#ElementSize, FPR:$Vector1, FPR:$Vector2, u16:$Rotate": {
+        "DestSize": "RegisterSize",
+        "NumElements": "RegisterSize / ElementSize"
       }
     },
     "Conv": {

--- a/FEXCore/include/FEXCore/Core/HostFeatures.h
+++ b/FEXCore/include/FEXCore/Core/HostFeatures.h
@@ -31,6 +31,7 @@ class HostFeatures final {
     bool SupportsCLWB{};
     bool SupportsPMULL_128Bit{};
     bool SupportsCSSC{};
+    bool SupportsFCMA{};
 
     // Float exception behaviour
     bool SupportsFlushInputsToZero{};

--- a/Scripts/InstructionCountParser.py
+++ b/Scripts/InstructionCountParser.py
@@ -46,12 +46,14 @@ class HostFeatures(Flag) :
     FEATURE_SVE256 = (1 << 1)
     FEATURE_CLZERO = (1 << 2)
     FEATURE_RNG    = (1 << 3)
+    FEATURE_FCMA   = (1 << 4)
 
 HostFeaturesLookup = {
     "SVE128"  : HostFeatures.FEATURE_SVE128,
     "SVE256"  : HostFeatures.FEATURE_SVE256,
     "CLZERO"  : HostFeatures.FEATURE_CLZERO,
     "RNG"     : HostFeatures.FEATURE_RNG,
+    "FCMA"    : HostFeatures.FEATURE_FCMA,
 }
 
 def GetHostFeatures(data):

--- a/Source/Tools/CodeSizeValidation/Main.cpp
+++ b/Source/Tools/CodeSizeValidation/Main.cpp
@@ -384,6 +384,7 @@ int main(int argc, char **argv, char **const envp) {
     FEATURE_SVE256 = (1U << 1),
     FEATURE_CLZERO = (1U << 2),
     FEATURE_RNG    = (1U << 3),
+    FEATURE_FCMA   = (1U << 4),
   };
 
   uint64_t SVEWidth = 0;
@@ -402,6 +403,9 @@ int main(int argc, char **argv, char **const envp) {
   if (TestHeaderData->EnabledHostFeatures & FEATURE_RNG) {
     HostFeatureControl |= static_cast<uint64_t>(FEXCore::Config::HostFeatures::ENABLERNG);
   }
+  if (TestHeaderData->EnabledHostFeatures & FEATURE_FCMA) {
+    HostFeatureControl |= static_cast<uint64_t>(FEXCore::Config::HostFeatures::ENABLEFCMA);
+  }
 
   // Always enable ARMv8.1 LSE atomics.
   HostFeatureControl |= static_cast<uint64_t>(FEXCore::Config::HostFeatures::ENABLEATOMICS);
@@ -417,6 +421,9 @@ int main(int argc, char **argv, char **const envp) {
   }
   if (TestHeaderData->DisabledHostFeatures & FEATURE_RNG) {
     HostFeatureControl |= static_cast<uint64_t>(FEXCore::Config::HostFeatures::DISABLERNG);
+  }
+  if (TestHeaderData->DisabledHostFeatures & FEATURE_FCMA) {
+    HostFeatureControl |= static_cast<uint64_t>(FEXCore::Config::HostFeatures::DISABLEFCMA);
   }
   FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_HOSTFEATURES, fextl::fmt::format("{}", HostFeatureControl));
   FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_FORCESVEWIDTH, fextl::fmt::format("{}", SVEWidth));

--- a/unittests/InstructionCountCI/Secondary_OpSize.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize.json
@@ -4,7 +4,8 @@
     "EnabledHostFeatures": [],
     "DisabledHostFeatures": [
       "SVE128",
-      "SVE256"
+      "SVE256",
+      "FCMA"
     ]
   },
   "Instructions": {

--- a/unittests/InstructionCountCI/Secondary_OpSize_FCMA.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize_FCMA.json
@@ -1,0 +1,23 @@
+{
+  "Features": {
+    "Bitness": 64,
+    "EnabledHostFeatures": [
+      "FCMA"
+    ],
+    "DisabledHostFeatures": [
+      "SVE128",
+      "SVE256"
+    ]
+  },
+  "Instructions": {
+    "addsubpd xmm0, xmm1": {
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
+      "Comment": "0x66 0x0f 0xd0",
+      "ExpectedArm64ASM": [
+        "ext v4.16b, v17.16b, v17.16b, #8",
+        "fcadd v16.2d, v16.2d, v4.2d, #90"
+      ]
+    }
+  }
+}

--- a/unittests/InstructionCountCI/Secondary_REPNE.json
+++ b/unittests/InstructionCountCI/Secondary_REPNE.json
@@ -4,7 +4,8 @@
     "EnabledHostFeatures": [],
     "DisabledHostFeatures": [
       "SVE128",
-      "SVE256"
+      "SVE256",
+      "FCMA"
     ]
   },
   "Instructions": {

--- a/unittests/InstructionCountCI/Secondary_REPNE_FCMA.json
+++ b/unittests/InstructionCountCI/Secondary_REPNE_FCMA.json
@@ -1,0 +1,23 @@
+{
+  "Features": {
+    "Bitness": 64,
+    "EnabledHostFeatures": [
+      "FCMA"
+    ],
+    "DisabledHostFeatures": [
+      "SVE128",
+      "SVE256"
+    ]
+  },
+  "Instructions": {
+    "addsubps xmm0, xmm1": {
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
+      "Comment": "0xf2 0x0f 0xd0",
+      "ExpectedArm64ASM": [
+        "rev64 v4.4s, v17.4s",
+        "fcadd v16.4s, v16.4s, v4.4s, #90"
+      ]
+    }
+  }
+}

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -5,7 +5,9 @@
       "SVE128",
       "SVE256"
     ],
-    "DisabledHostFeatures": []
+    "DisabledHostFeatures": [
+      "FCMA"
+    ]
   },
   "Instructions": {
     "vmovups xmm0, [rax]": {

--- a/unittests/InstructionCountCI/VEX_map1_FCMA.json
+++ b/unittests/InstructionCountCI/VEX_map1_FCMA.json
@@ -1,0 +1,71 @@
+{
+  "Features": {
+    "Bitness": 64,
+    "EnabledHostFeatures": [
+      "SVE128",
+      "SVE256",
+      "FCMA"
+    ],
+    "DisabledHostFeatures": []
+  },
+  "Instructions": {
+    "vaddsubpd xmm0, xmm1, xmm2": {
+      "ExpectedInstructionCount": 6,
+      "Optimal": "No",
+      "Comment": [
+        "Map 1 0b01 0xd0 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "mov z4.d, p7/m, z17.d",
+        "mov z5.d, p7/m, z18.d",
+        "ext v5.16b, v5.16b, v5.16b, #8",
+        "fcadd v4.2d, v4.2d, v5.2d, #90",
+        "mov v4.16b, v4.16b",
+        "mov z16.d, p7/m, z4.d"
+      ]
+    },
+    "vaddsubpd ymm0, ymm1, ymm2": {
+      "ExpectedInstructionCount": 5,
+      "Optimal": "No",
+      "Comment": [
+        "Map 1 0b01 0xd0 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "mov z4.d, p7/m, z17.d",
+        "mov z5.d, p7/m, z18.d",
+        "ext z5.b, z5.b, z5.b, #8",
+        "fcadd z4.d, p7/m, z4.d, z5.d, #90",
+        "mov z16.d, p7/m, z4.d"
+      ]
+    },
+    "vaddsubps xmm0, xmm1, xmm2": {
+      "ExpectedInstructionCount": 6,
+      "Optimal": "No",
+      "Comment": [
+        "Map 1 0b11 0xd0 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "mov z4.d, p7/m, z17.d",
+        "mov z5.d, p7/m, z18.d",
+        "rev64 v5.4s, v5.4s",
+        "fcadd v4.4s, v4.4s, v5.4s, #90",
+        "mov v4.16b, v4.16b",
+        "mov z16.d, p7/m, z4.d"
+      ]
+    },
+    "vaddsubps ymm0, ymm1, ymm2": {
+      "ExpectedInstructionCount": 5,
+      "Optimal": "No",
+      "Comment": [
+        "Map 1 0b11 0xd0 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "mov z4.d, p7/m, z17.d",
+        "mov z5.d, p7/m, z18.d",
+        "revw z5.d, p7/m, z5.d",
+        "fcadd z4.s, p7/m, z4.s, z5.s, #90",
+        "mov z16.d, p7/m, z4.d"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This extension was added with seemingly Cortex-A710 and turns this
instruction in to two instructions which is quite good.

~~Needs https://github.com/FEX-Emu/FEX/pull/2994 merged first.~~

 Huge thanks to @dougallj for the optimization idea!