### PR TITLE
OpcodeDispatcher: Optimize cvtps2pd 

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -2053,8 +2053,9 @@ void OpDispatchBuilder::Vector_CVT_Float_To_FloatImpl(OpcodeArgs, size_t DstElem
   const auto SrcSize = GetSrcSize(Op);
   const auto StoreSize = IsFloatSrc ? SrcSize
                                     : 16;
-  const auto LoadSize = IsFloatSrc ? SrcSize / 2
-                                   : SrcSize;
+  const auto LoadSize = IsFloatSrc && !Op->Src[0].IsGPR() ?
+    SrcSize / 2 :
+    SrcSize;
 
   OrderedNode *Src = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], LoadSize, Op->Flags, -1);
 

--- a/unittests/InstructionCountCI/Secondary.json
+++ b/unittests/InstructionCountCI/Secondary.json
@@ -1130,11 +1130,19 @@
       ]
     },
     "cvtps2pd xmm0, xmm1": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": "0x0f 0x5a",
       "ExpectedArm64ASM": [
-        "mov v4.8b, v17.8b",
+        "fcvtl v16.2d, v17.2s"
+      ]
+    },
+    "cvtps2pd xmm0, [rax]": {
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
+      "Comment": "0x0f 0x5a",
+      "ExpectedArm64ASM": [
+        "ldr d4, [x4]",
         "fcvtl v16.2d, v4.2s"
       ]
     },

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -4094,14 +4094,13 @@
       ]
     },
     "vcvtps2pd xmm0, xmm1": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x5a 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "mov v4.8b, v4.8b",
         "fcvtl v4.2d, v4.2s",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"


### PR DESCRIPTION
SSE version is now optimal and AVX version gets rid of a redundant move.
