### PR TITLE
OpcodeDispatcher: Generate more optimal code for scalar GPR converts

### DIFF
--- a/FEXCore/Source/Interface/Core/Interpreter/ConversionOps.cpp
+++ b/FEXCore/Source/Interface/Core/Interpreter/ConversionOps.cpp
@@ -133,7 +133,7 @@ DEF_OP(Vector_SToF) {
   TempVectorDataArray Tmp{};
 
   const uint8_t ElementSize = Op->Header.ElementSize;
-  const uint8_t Elements = OpSize / ElementSize;
+  const uint8_t Elements = OpSize == ElementSize ? 1 : OpSize / ElementSize;
 
   const auto Func = [](auto a, auto min, auto max) { return a; };
   switch (ElementSize) {
@@ -154,7 +154,7 @@ DEF_OP(Vector_FToZS) {
   TempVectorDataArray Tmp{};
 
   const uint8_t ElementSize = Op->Header.ElementSize;
-  const uint8_t Elements = OpSize / ElementSize;
+  const uint8_t Elements = OpSize == ElementSize ? 1 : OpSize / ElementSize;
 
   const auto Func = [](auto a, auto min, auto max) { return std::trunc(a); };
   switch (ElementSize) {
@@ -175,7 +175,7 @@ DEF_OP(Vector_FToS) {
   TempVectorDataArray Tmp{};
 
   const uint8_t ElementSize = Op->Header.ElementSize;
-  const uint8_t Elements = OpSize / ElementSize;
+  const uint8_t Elements = OpSize == ElementSize ? 1 : OpSize / ElementSize;
 
   const auto Func = [](auto a, auto min, auto max) { return std::nearbyint(a); };
   switch (ElementSize) {

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/ConversionOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/ConversionOps.cpp
@@ -232,11 +232,24 @@ DEF_OP(Vector_SToF) {
     const auto Mask = PRED_TMP_32B;
     scvtf(Dst.Z(), SubEmitSize, Mask.Merging(), Vector.Z(), SubEmitSize);
   } else {
-    if (OpSize == 8) {
-      scvtf(SubEmitSize, Dst.D(), Vector.D());
+    if (OpSize == ElementSize) {
+      if (ElementSize == 8) {
+        scvtf(ARMEmitter::ScalarRegSize::i64Bit, Dst.D(), Vector.D());
+      }
+      else if (ElementSize == 4) {
+        scvtf(ARMEmitter::ScalarRegSize::i32Bit, Dst.S(), Vector.S());
+      }
+      else {
+        scvtf(ARMEmitter::ScalarRegSize::i16Bit, Dst.H(), Vector.H());
+      }
     }
     else {
-      scvtf(SubEmitSize, Dst.Q(), Vector.Q());
+      if (OpSize == 8) {
+        scvtf(SubEmitSize, Dst.D(), Vector.D());
+      }
+      else {
+        scvtf(SubEmitSize, Dst.Q(), Vector.Q());
+      }
     }
   }
 }
@@ -259,11 +272,24 @@ DEF_OP(Vector_FToZS) {
     const auto Mask = PRED_TMP_32B;
     fcvtzs(Dst.Z(), SubEmitSize, Mask.Merging(), Vector.Z(), SubEmitSize);
   } else {
-    if (OpSize == 8) {
-      fcvtzs(SubEmitSize, Dst.D(), Vector.D());
+    if (OpSize == ElementSize) {
+      if (ElementSize == 8) {
+        fcvtzs(ARMEmitter::ScalarRegSize::i64Bit, Dst.D(), Vector.D());
+      }
+      else if (ElementSize == 4) {
+        fcvtzs(ARMEmitter::ScalarRegSize::i32Bit, Dst.S(), Vector.S());
+      }
+      else {
+        fcvtzs(ARMEmitter::ScalarRegSize::i16Bit, Dst.H(), Vector.H());
+      }
     }
     else {
-      fcvtzs(SubEmitSize, Dst.Q(), Vector.Q());
+      if (OpSize == 8) {
+        fcvtzs(SubEmitSize, Dst.D(), Vector.D());
+      }
+      else {
+        fcvtzs(SubEmitSize, Dst.Q(), Vector.Q());
+      }
     }
   }
 }

--- a/unittests/InstructionCountCI/Secondary_REP.json
+++ b/unittests/InstructionCountCI/Secondary_REP.json
@@ -67,28 +67,27 @@
       ]
     },
     "cvtsi2ss xmm0, eax": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "With AFP mode FEX can remove an insert after the operation.",
         "0xf3 0x0f 0x2a"
       ],
       "ExpectedArm64ASM": [
-        "ubfx x20, x4, #0, #32",
-        "scvtf s4, w20",
+        "scvtf s4, w4",
         "mov v16.s[0], v4.s[0]"
       ]
     },
     "cvtsi2ss xmm0, dword [rax]": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "Optimal": "Yes",
       "Comment": [
         "With AFP mode FEX can remove an insert after the operation.",
         "0xf3 0x0f 0x2a"
       ],
       "ExpectedArm64ASM": [
-        "ldr w20, [x4]",
-        "scvtf s4, w20",
+        "ldr s4, [x4]",
+        "scvtf s4, s4",
         "mov v16.s[0], v4.s[0]"
       ]
     },

--- a/unittests/InstructionCountCI/Secondary_REPNE.json
+++ b/unittests/InstructionCountCI/Secondary_REPNE.json
@@ -52,15 +52,14 @@
       ]
     },
     "cvtsi2sd xmm0, eax": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "With AFP mode FEX can remove an insert after the operation.",
         "0xf2 0x0f 0x2a"
       ],
       "ExpectedArm64ASM": [
-        "ubfx x20, x4, #0, #32",
-        "scvtf d4, w20",
+        "scvtf d4, w4",
         "mov v16.d[0], v4.d[0]"
       ]
     },
@@ -97,8 +96,8 @@
         "0xf2 0x0f 0x2a"
       ],
       "ExpectedArm64ASM": [
-        "ldr x20, [x4]",
-        "scvtf d4, x20",
+        "ldr d4, [x4]",
+        "scvtf d4, d4",
         "mov v16.d[0], v4.d[0]"
       ]
     },

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -3604,15 +3604,14 @@
       ]
     },
     "vcvtsi2ss xmm0, xmm1, eax": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0x2A 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "ubfx x20, x4, #0, #32",
-        "scvtf s5, w20",
+        "scvtf s5, w4",
         "mov v4.s[0], v5.s[0]",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
@@ -3633,15 +3632,14 @@
       ]
     },
     "vcvtsi2sd xmm0, xmm1, eax": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x2A 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "ubfx x20, x4, #0, #32",
-        "scvtf d5, w20",
+        "scvtf d5, w4",
         "mov v4.d[0], v5.d[0]",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"


### PR DESCRIPTION
1) In the case that we are converted a GPR, don't zero extend it first.
2) In the case that the scalar comes from memory, load it first in an
   FPR and converted it in-place.

These are now optimal in the case of AFP is unsupported.