### PR TITLE
OpcodeDispatcher: Optimizes movq

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -750,13 +750,14 @@ template
 void OpDispatchBuilder::VectorUnaryDuplicateOp<IR::OP_VFRECP, 4>(OpcodeArgs);
 
 void OpDispatchBuilder::MOVQOp(OpcodeArgs) {
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  const auto SrcSize = Op->Src[0].IsGPR() ? 16U : GetSrcSize(Op);
+  OrderedNode *Src = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], SrcSize, Op->Flags, -1);
   // This instruction is a bit special that if the destination is a register then it'll ZEXT the 64bit source to 128bit
   if (Op->Dest.IsGPR()) {
     const auto gpr = Op->Dest.Data.GPR.GPR;
     const auto gprIndex = gpr - X86State::REG_XMM_0;
 
-    auto Reg = _VMov(16, Src);
+    auto Reg = _VMov(8, Src);
     StoreXMMRegister(gprIndex, Reg);
   }
   else {

--- a/unittests/InstructionCountCI/Secondary_REP.json
+++ b/unittests/InstructionCountCI/Secondary_REP.json
@@ -396,12 +396,11 @@
       ]
     },
     "movq xmm0, xmm1": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": "0xf3 0x0f 0x7e",
       "ExpectedArm64ASM": [
-        "mov v4.8b, v17.8b",
-        "mov v16.16b, v4.16b"
+        "mov v16.8b, v17.8b"
       ]
     },
     "movq xmm0, [rax]": {

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -5015,14 +5015,13 @@
       ]
     },
     "vmovq qword [rax], xmm0": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x7e 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z16.d",
-        "mov v4.8b, v4.8b",
         "str d4, [x4]"
       ]
     },
@@ -5278,14 +5277,13 @@
       ]
     },
     "vmovq [rax], xmm0": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xd6 256-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z16.d",
-        "mov v4.8b, v4.8b",
         "str d4, [x4]"
       ]
     },


### PR DESCRIPTION
Removes a redundant move between registers and makes it optimal.
Also removes a couple redundant moves on the avx version.