### PR TITLE
X8764: Ensure frndint uses host rounding mode

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87F64.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87F64.cpp
@@ -649,7 +649,7 @@ void OpDispatchBuilder::FRNDINTF64(OpcodeArgs) {
   auto top = GetX87Top();
   auto a = _LoadContextIndexed(top, 8, MMBaseOffset(), 16, FPRClass);
 
-  auto result = _Vector_FToI(8, 8, a, FEXCore::IR::Round_Nearest);
+  auto result = _Vector_FToI(8, 8, a, FEXCore::IR::Round_Host);
 
   // Write to ST[TOP]
   _StoreContextIndexed(result, top, 8, MMBaseOffset(), 16, FPRClass);


### PR DESCRIPTION
This previously used `Round_Nearest` which had a bug on Arm64 that it actually was always using `Round_Host` aka frinti. Ever since 393cea2e8ba47a15a3ce31d07a6088a2ff91653c[1] this has been fixed so that `Round_Nearest` actually uses frintn for neaest.

This instruction actually wants to use the host rounding mode. Once issue with this is that x87 and SSE have different rounding mode flags and currently we conflate the two in our JIT. This will need to be fixed in the future.

In the meantime this restores behaviour that it actually uses the host rounding mode, which fixes black screen and broken vertices in Grim Fandango Remastered.

[1] e89321dc602e35cbb1382b35ac2b35e7e417ef92 for scalar.