### PR TITLE
Linux: Call exit_group when application tries

### DIFF
--- a/Source/Tools/FEXLoader/LinuxSyscalls/Syscalls/Thread.cpp
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/Syscalls/Thread.cpp
@@ -572,11 +572,9 @@ namespace FEX::HLE {
       return Thread->ThreadManager.GetTID();
     });
 
-    REGISTER_SYSCALL_IMPL_FLAGS(exit_group, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY | SyscallFlags::NORETURN,
+    REGISTER_SYSCALL_IMPL_PASS_FLAGS(exit_group, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY | SyscallFlags::NORETURN,
       [](FEXCore::Core::CpuStateFrame *Frame, int status) -> uint64_t {
-      auto Thread = Frame->Thread;
-      Thread->StatusCode = status;
-      Thread->CTX->Stop();
+      syscall(SYSCALL_DEF(exit_group), status);
       // This will never be reached
       std::terminate();
     });


### PR DESCRIPTION
When the application calls exit_group we no longer need to care about cleanup because the entire process group is leaving.

Just immediately call exit group and get out. Might revisit this in the future.

Fixes #2752