### PR TITLE
IR: Convert all Move+Atomic+ALU ops from implicit to explicit size

### DIFF
--- a/FEXCore/Source/Interface/Core/Interpreter/ALUOps.cpp
+++ b/FEXCore/Source/Interface/Core/Interpreter/ALUOps.cpp
@@ -773,8 +773,8 @@ DEF_OP(FindMSB) {
   }
 }
 
-DEF_OP(FindTrailingZeros) {
-  auto Op = IROp->C<IR::IROp_FindTrailingZeros>();
+DEF_OP(FindTrailingZeroes) {
+  auto Op = IROp->C<IR::IROp_FindTrailingZeroes>();
   const uint8_t OpSize = IROp->Size;
 
   switch (OpSize) {

--- a/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -80,7 +80,7 @@ constexpr OpHandlerArray InterpreterOpHandlers = [] {
   REGISTER_OP(POPCOUNT,               Popcount);
   REGISTER_OP(FINDLSB,                FindLSB);
   REGISTER_OP(FINDMSB,                FindMSB);
-  REGISTER_OP(FINDTRAILINGZEROS,      FindTrailingZeros);
+  REGISTER_OP(FINDTRAILINGZEROES,     FindTrailingZeroes);
   REGISTER_OP(COUNTLEADINGZEROES,     CountLeadingZeroes);
   REGISTER_OP(REV,                    Rev);
   REGISTER_OP(BFI,                    Bfi);

--- a/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
+++ b/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
@@ -117,7 +117,7 @@ namespace FEXCore::CPU {
   DEF_OP(Popcount);
   DEF_OP(FindLSB);
   DEF_OP(FindMSB);
-  DEF_OP(FindTrailingZeros);
+  DEF_OP(FindTrailingZeroes);
   DEF_OP(CountLeadingZeroes);
   DEF_OP(Rev);
   DEF_OP(Bfi);

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -1040,8 +1040,8 @@ DEF_OP(FindMSB) {
   sub(ARMEmitter::Size::i64Bit, Dst, TMP1, Dst);
 }
 
-DEF_OP(FindTrailingZeros) {
-  auto Op = IROp->C<IR::IROp_FindTrailingZeros>();
+DEF_OP(FindTrailingZeroes) {
+  auto Op = IROp->C<IR::IROp_FindTrailingZeroes>();
   const uint8_t OpSize = IROp->Size;
 
   LOGMAN_THROW_AA_FMT(OpSize == 2 || OpSize == 4 || OpSize == 8, "Unsupported {} size: {}", __func__, OpSize);

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -888,7 +888,7 @@ CPUBackend::CompiledCode Arm64JITCore::CompileCode(uint64_t Entry,
         REGISTER_OP(POPCOUNT,          Popcount);
         REGISTER_OP(FINDLSB,           FindLSB);
         REGISTER_OP(FINDMSB,           FindMSB);
-        REGISTER_OP(FINDTRAILINGZEROS, FindTrailingZeros);
+        REGISTER_OP(FINDTRAILINGZEROES, FindTrailingZeroes);
         REGISTER_OP(COUNTLEADINGZEROES, CountLeadingZeroes);
         REGISTER_OP(REV,               Rev);
         REGISTER_OP(BFI,               Bfi);

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -266,7 +266,7 @@ private:
   DEF_OP(Popcount);
   DEF_OP(FindLSB);
   DEF_OP(FindMSB);
-  DEF_OP(FindTrailingZeros);
+  DEF_OP(FindTrailingZeroes);
   DEF_OP(CountLeadingZeroes);
   DEF_OP(Rev);
   DEF_OP(Bfi);

--- a/FEXCore/Source/Interface/Core/JIT/x86_64/ALUOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/x86_64/ALUOps.cpp
@@ -920,8 +920,8 @@ DEF_OP(FindMSB) {
   }
 }
 
-DEF_OP(FindTrailingZeros) {
-  auto Op = IROp->C<IR::IROp_FindTrailingZeros>();
+DEF_OP(FindTrailingZeroes) {
+  auto Op = IROp->C<IR::IROp_FindTrailingZeroes>();
   const uint8_t OpSize = IROp->Size;
 
   switch (OpSize) {
@@ -940,7 +940,7 @@ DEF_OP(FindTrailingZeros) {
       mov(rax, 0x40);
       cmovz(GetDst<RA_64>(Node), rax);
       break;
-    default: LOGMAN_MSG_A_FMT("Unknown FindTrailingZeros size: {}", OpSize); break;
+    default: LOGMAN_MSG_A_FMT("Unknown FindTrailingZeroes size: {}", OpSize); break;
   }
 }
 
@@ -963,7 +963,7 @@ DEF_OP(CountLeadingZeroes) {
         lzcnt(GetDst<RA_64>(Node), GetSrc<RA_64>(Op->Src.ID()));
         break;
       }
-      default: LOGMAN_MSG_A_FMT("Unknown CountLeadingZeros size: {}", OpSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown CountLeadingZeroes size: {}", OpSize); break;
     }
   }
   else {
@@ -1002,7 +1002,7 @@ DEF_OP(CountLeadingZeroes) {
         mov(GetDst<RA_64>(Node), rax);
         break;
       }
-      default: LOGMAN_MSG_A_FMT("Unknown CountLeadingZeros size: {}", OpSize); break;
+      default: LOGMAN_MSG_A_FMT("Unknown CountLeadingZeroes size: {}", OpSize); break;
     }
   }
 }
@@ -1371,7 +1371,7 @@ void X86JITCore::RegisterALUHandlers() {
   REGISTER_OP(POPCOUNT,          Popcount);
   REGISTER_OP(FINDLSB,           FindLSB);
   REGISTER_OP(FINDMSB,           FindMSB);
-  REGISTER_OP(FINDTRAILINGZEROS, FindTrailingZeros);
+  REGISTER_OP(FINDTRAILINGZEROES, FindTrailingZeroes);
   REGISTER_OP(COUNTLEADINGZEROES, CountLeadingZeroes);
   REGISTER_OP(REV,               Rev);
   REGISTER_OP(BFI,               Bfi);

--- a/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -276,7 +276,7 @@ private:
   DEF_OP(Popcount);
   DEF_OP(FindLSB);
   DEF_OP(FindMSB);
-  DEF_OP(FindTrailingZeros);
+  DEF_OP(FindTrailingZeroes);
   DEF_OP(CountLeadingZeroes);
   DEF_OP(Rev);
   DEF_OP(Bfi);

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -5582,7 +5582,7 @@ void OpDispatchBuilder::INTOp(OpcodeArgs) {
 void OpDispatchBuilder::TZCNT(OpcodeArgs) {
   OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
 
-  Src = _FindTrailingZeros(Src);
+  Src = _FindTrailingZeroes(Src);
   StoreResult(GPRClass, Op, Src, -1);
 
   GenerateFlags_TZCNT(Op, Src);

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -141,6 +141,7 @@
     "u16": "uint16_t",
     "u32": "uint32_t",
     "u64": "uint64_t",
+    "OpSize": "FEXCore::IR::OpSize",
     "SSA": "OrderedNode*",
     "GPR": "OrderedNode*",
     "GPRPair": "OrderedNode*",
@@ -309,18 +310,24 @@
       }
     },
     "Moves": {
-      "GPR = ExtractElementPair GPRPair:$Pair, u8:$Element": {
+      "GPR = ExtractElementPair OpSize:#Size, GPRPair:$Pair, u8:$Element": {
         "Desc": ["Extracts a register for the register pair"],
-        "DestSize": "GetOpSize(_Pair) >> 1"
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
 
-      "GPRPair = CreateElementPair GPR:$Lower, GPR:$Upper": {
+      "GPRPair = CreateElementPair OpSize:#Size, GPR:$Lower, GPR:$Upper": {
         "Desc": ["Inserts a register for the register pair",
                  "ssa0 is the lower incoming register",
                  "ssa1 is the upper incoming register"
                 ],
-        "DestSize": "GetOpSize(_Lower) * 2",
-        "NumElements": "2"
+        "DestSize": "Size",
+        "NumElements": "2",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i64Bit || Size == FEXCore::IR::OpSize::i128Bit"
+        ]
       },
       "SSA = Phi SSA:$PhiBegin, SSA:$PhiEnd, RegisterClass:$Class": {
         "DestSize": "~0",
@@ -575,7 +582,7 @@
       }
     },
     "Atomic": {
-      "GPR = CAS GPR:$Expected, GPR:$Desired, GPR:$Addr": {
+      "GPR = CAS OpSize:#Size, GPR:$Expected, GPR:$Desired, GPR:$Addr": {
         "HasSideEffects": true,
         "Desc": ["Does a compare and swap of values to a memory location",
                  "This mostly matches the C++ atomic_compare_exchange_strong function",
@@ -586,9 +593,12 @@
                  "if (deref(%Addr) != %Expected) Dest = deref(%Addr)"
                 ],
 
-        "DestSize": "GetOpSize(_Expected)"
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i8Bit || Size == FEXCore::IR::OpSize::i16Bit || Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-      "GPRPair = CASPair GPRPair:$Expected, GPRPair:$Desired, GPR:$Addr": {
+      "GPRPair = CASPair OpSize:#Size, GPRPair:$Expected, GPRPair:$Desired, GPR:$Addr": {
         "HasSideEffects": true,
         "Desc": ["Does a compare and exchange with two GPRPair values",
                  "ssa0 is the comparison value",
@@ -597,96 +607,130 @@
                  "Returns a pair containing the value in memory"
                 ],
         "HasDest": true,
-        "DestSize": "GetOpSize(_Expected)",
+        "DestSize": "Size",
         "NumElements": "2",
         "EmitValidation": [
-          "(GetOpElementSize(_Expected) == 4 && GetOpSize(_Expected) == 8) || GetOpElementSize(_Expected) == 8",
-          "(GetOpElementSize(_Expected) == 8 && GetOpSize(_Expected) == 16) || GetOpElementSize(_Expected) == 4"
+          "Size == FEXCore::IR::OpSize::i64Bit || Size == FEXCore::IR::OpSize::i128Bit"
         ]
       },
-      "GPR = AtomicAdd u8:#Size, GPR:$Value, GPR:$Addr": {
+      "AtomicAdd OpSize:#Size, GPR:$Value, GPR:$Addr": {
         "HasSideEffects": true,
         "Desc": ["Atomic integer add"
                 ],
-        "DestSize": "Size"
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i8Bit || Size == FEXCore::IR::OpSize::i16Bit || Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-
-      "AtomicSub u8:#Size, GPR:$Value, GPR:$Addr": {
+      "AtomicSub OpSize:#Size, GPR:$Value, GPR:$Addr": {
         "HasSideEffects": true,
         "Desc": ["Atomic integer sub"
                 ],
-        "DestSize": "Size"
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i8Bit || Size == FEXCore::IR::OpSize::i16Bit || Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-      "AtomicAnd u8:#Size, GPR:$Value, GPR:$Addr": {
+      "AtomicAnd OpSize:#Size, GPR:$Value, GPR:$Addr": {
         "HasSideEffects": true,
         "Desc": ["Atomic integer and"
                 ],
-        "DestSize": "Size"
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i8Bit || Size == FEXCore::IR::OpSize::i16Bit || Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-      "AtomicOr u8:#Size, GPR:$Value, GPR:$Addr": {
+      "AtomicOr OpSize:#Size, GPR:$Value, GPR:$Addr": {
         "HasSideEffects": true,
         "Desc": ["Atomic integer or"
                 ],
-        "DestSize": "Size"
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i8Bit || Size == FEXCore::IR::OpSize::i16Bit || Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-      "AtomicXor u8:#Size, GPR:$Value, GPR:$Addr": {
+      "AtomicXor OpSize:#Size, GPR:$Value, GPR:$Addr": {
         "HasSideEffects": true,
         "Desc": ["Atomic integer xor"
                 ],
-        "DestSize": "Size"
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i8Bit || Size == FEXCore::IR::OpSize::i16Bit || Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-      "GPR = AtomicSwap u8:#Size, GPR:$Value, GPR:$Addr": {
+      "GPR = AtomicSwap OpSize:#Size, GPR:$Value, GPR:$Addr": {
         "HasSideEffects": true,
         "Desc": ["Atomic integer swap"
                 ],
-        "DestSize": "Size"
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i8Bit || Size == FEXCore::IR::OpSize::i16Bit || Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-      "GPR = AtomicFetchAdd u8:#Size, GPR:$Value, GPR:$Addr": {
+      "GPR = AtomicFetchAdd OpSize:#Size, GPR:$Value, GPR:$Addr": {
         "HasSideEffects": true,
         "Desc": ["Atomic integer fetch and add",
                  "Atomically fetches %Addr and adds %value to the memory location",
                  "Dest is the value prior to operating on the value in memory"
                 ],
-        "DestSize": "Size"
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i8Bit || Size == FEXCore::IR::OpSize::i16Bit || Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-      "GPR = AtomicFetchSub u8:#Size, GPR:$Value, GPR:$Addr": {
+      "GPR = AtomicFetchSub OpSize:#Size, GPR:$Value, GPR:$Addr": {
         "HasSideEffects": true,
         "Desc": ["Atomic integer fetch and sub",
                  "Atomically fetches %Addr and subtracts %value to the memory location",
                  "Dest is the value prior to operating on the value in memory"
                 ],
-        "DestSize": "Size"
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i8Bit || Size == FEXCore::IR::OpSize::i16Bit || Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-      "GPR = AtomicFetchAnd u8:#Size, GPR:$Value, GPR:$Addr": {
+      "GPR = AtomicFetchAnd OpSize:#Size, GPR:$Value, GPR:$Addr": {
         "HasSideEffects": true,
         "Desc": ["Atomic integer fetch and binary and",
                  "Atomically fetches %Addr and binary ands %value to the memory location",
                  "Dest is the value prior to operating on the value in memory"
                 ],
-        "DestSize": "Size"
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i8Bit || Size == FEXCore::IR::OpSize::i16Bit || Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-      "GPR = AtomicFetchOr u8:#Size, GPR:$Value, GPR:$Addr": {
+      "GPR = AtomicFetchOr OpSize:#Size, GPR:$Value, GPR:$Addr": {
         "HasSideEffects": true,
         "Desc": ["Atomic integer fetch and binary or",
                  "Atomically fetches %Addr and binary ors %value to the memory location",
                  "Dest is the value prior to operating on the value in memory"
                 ],
-        "DestSize": "Size"
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i8Bit || Size == FEXCore::IR::OpSize::i16Bit || Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-      "GPR = AtomicFetchXor u8:#Size, GPR:$Value, GPR:$Addr": {
+      "GPR = AtomicFetchXor OpSize:#Size, GPR:$Value, GPR:$Addr": {
         "HasSideEffects": true,
         "Desc": ["Atomic integer fetch and binary exclusive or",
                  "Atomically fetches %Addr and binary exclusive ors %value to the memory location",
                  "Dest is the value prior to operating on the value in memory"
                 ],
-        "DestSize": "Size"
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i8Bit || Size == FEXCore::IR::OpSize::i16Bit || Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-      "GPR = AtomicFetchNeg u8:#Size, GPR:$Addr": {
+      "GPR = AtomicFetchNeg OpSize:#Size, GPR:$Addr": {
         "HasSideEffects": true,
         "Desc": ["Atomic integer fetch and two's complement negate",
                  "Dest is the value prior to operating on the value in memory"
                 ],
-        "DestSize": "Size"
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i8Bit || Size == FEXCore::IR::OpSize::i16Bit || Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
       "TelemetrySetValue GPR:$Value, u8:$TelemetryValueIndex": {
         "HasSideEffects": true,
@@ -697,20 +741,26 @@
       }
     },
     "ALU": {
-      "GPR = EntrypointOffset i64:$Offset, u8:#RegisterSize": {
+      "GPR = EntrypointOffset OpSize:#Size, i64:$Offset": {
         "Desc": ["Returns the <entrypoint> + Offset address",
                  "When the size is 4 bytes then 32-bit overflow and underflow needs to work"
                 ],
-        "DestSize": "RegisterSize"
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
 
-      "InlineEntrypointOffset i64:$Offset, u8:#RegisterSize": {
+      "InlineEntrypointOffset OpSize:#Size, i64:$Offset": {
         "Desc": ["Returns the <entrypoint> + Offset address",
                  "When the size is 4 bytes then 32-bit overflow and underflow needs to work"
                 ],
         "HasSideEffects": true,
         "RAOverride": "0",
-        "DestSize": "RegisterSize"
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
 
       "GPR = Constant i64:$Constant": {
@@ -728,7 +778,10 @@
       },
 
       "GPRPair = TruncElementPair GPRPair:$Pair, u8:#ByteSize": {
-        "Desc": "Truncates each element of a pair to the destination size",
+        "Desc": [
+          "Truncates each element of a pair to the destination size",
+          "TODO: This IR op should get removed"
+        ],
         "DestSize": "ByteSize * 2",
         "NumElements": "2"
       },
@@ -745,248 +798,391 @@
         "DestSize": "8"
       },
 
-      "GPR = Neg GPR:$Src": {
+      "GPR = Neg OpSize:#Size, GPR:$Src": {
         "Desc": ["Integer negation",
                  "Dest = -Src",
                  "Will truncate to 64 or 32bits"
                 ],
-        "DestSize": "std::max<uint8_t>(4, GetOpSize(_Src))"
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-      "GPR = Abs GPR:$Src": {
+      "GPR = Abs OpSize:#Size, GPR:$Src": {
         "Desc": ["Integer 2's complement absolute value",
                  "Dest = std::abs(Src)",
                  "Will truncate to 64 or 32bits"
                 ],
-        "DestSize": "std::max<uint8_t>(4, GetOpSize(_Src))"
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-      "GPR = Not GPR:$Src": {
+      "GPR = Not OpSize:#Size, GPR:$Src": {
         "Desc": ["Integer binary not",
                  "op:",
                  "Dest = ~Src"
                 ],
-        "DestSize": "std::max<uint8_t>(4, GetOpSize(_Src))"
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-      "GPR = Popcount GPR:$Src": {
+      "GPR = Popcount OpSize:#Size, GPR:$Src": {
         "Desc": ["Population count of source register",
                  "Returns the number of bits set"
-                ]
+                ],
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i8Bit || Size == FEXCore::IR::OpSize::i16Bit || Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-      "GPR = FindLSB GPR:$Src": {
+      "GPR = FindLSB OpSize:#Size, GPR:$Src": {
         "Desc": ["Find least-significant-bit set",
                  "Returns the index of the least significant bit set",
                  "In the case of zero returns ~0U"
-                ]
+                ],
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i8Bit || Size == FEXCore::IR::OpSize::i16Bit || Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-      "GPR = FindMSB GPR:$Src": {
+      "GPR = FindMSB OpSize:#Size, GPR:$Src": {
         "Desc": ["Find most-significant-bit set",
                  "Returns the index of the most significant bit set",
                  "In the case of zero returns ~0U"
-                ]
+                ],
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i16Bit || Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-      "GPR = FindTrailingZeros GPR:$Src": {
+      "GPR = FindTrailingZeroes OpSize:#Size, GPR:$Src": {
         "Desc": ["Counts the number of trailing zero bits in a GPR",
                  "Returns the number of bits that are zero trailing",
                  "In the case of zero returns the size in bits of the input"
-                ]
+                ],
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i16Bit || Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-      "GPR = CountLeadingZeroes GPR:$Src": {
+      "GPR = CountLeadingZeroes OpSize:#Size, GPR:$Src": {
         "Desc": ["Counts the number of leading zero bits in a GPR",
                  "Returns the number of bits that are zero leading",
                  "In the case of zero returns the size in bits of the input"
-                ]
+                ],
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i16Bit || Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-      "GPR = Rev GPR:$Src": {
+      "GPR = Rev OpSize:#Size, GPR:$Src": {
         "Desc": ["Reverses the byte order of the register",
                  "Specifically 8bit byte swap size. (Not 16bit or 32bit word swapping)"
-                ]
+                ],
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i16Bit || Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-
-      "GPR = Add GPR:$Src1, GPR:$Src2": {
+      "GPR = Add OpSize:#Size, GPR:$Src1, GPR:$Src2": {
         "Desc": [ "Integer Add",
                   "Will truncate to 64 or 32bits"
                 ],
-        "DestSize": "std::max<uint8_t>(4, std::max(GetOpSize(_Src1), GetOpSize(_Src2)))"
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-      "GPR = Sub GPR:$Src1, GPR:$Src2": {
+      "GPR = Sub OpSize:#Size, GPR:$Src1, GPR:$Src2": {
         "Desc": [ "Integer Sub",
                   "Will truncate to 64 or 32bits"
                 ],
-        "DestSize": "std::max<uint8_t>(4, std::max(GetOpSize(_Src1), GetOpSize(_Src2)))"
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-      "GPR = Or GPR:$Src1, GPR:$Src2": {
+      "GPR = Or OpSize:#Size, GPR:$Src1, GPR:$Src2": {
         "Desc": ["Integer binary or"
-                ]
+                ],
+        "Comment": [
+          "TODO: There is an assumption that Or of operating size < 32-bit makes sense"
+        ],
+        "DestSize": "Size",
+        "EmitValidation": [
+          "true || Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-      "GPR = Orlshl GPR:$Src1, GPR:$Src2, u8:$BitShift": {
+      "GPR = Orlshl OpSize:#Size, GPR:$Src1, GPR:$Src2, u8:$BitShift": {
         "Desc": ["Integer binary or with logical shift left"
-                ]
+                ],
+        "Comment": [
+          "TODO: There is an assumption that Orlshl of operating size < 32-bit makes sense"
+        ],
+        "DestSize": "Size",
+        "EmitValidation": [
+          "true || Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-      "GPR = Orlshr GPR:$Src1, GPR:$Src2, u8:$BitShift": {
+      "GPR = Orlshr OpSize:#Size, GPR:$Src1, GPR:$Src2, u8:$BitShift": {
         "Desc": ["Integer binary or with logical shift right"
-                ]
+                ],
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-      "GPR = Xor GPR:$Src1, GPR:$Src2": {
+      "GPR = Xor OpSize:#Size, GPR:$Src1, GPR:$Src2": {
         "Desc": ["Integer binary exclusive or"
-                ]
+                ],
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-      "GPR = And GPR:$Src1, GPR:$Src2": {
+      "GPR = And OpSize:#Size, GPR:$Src1, GPR:$Src2": {
         "Desc": ["Integer binary and"
-                ]
+                ],
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-      "GPR = Andn GPR:$Src1, GPR:$Src2": {
+      "GPR = Andn OpSize:#Size, GPR:$Src1, GPR:$Src2": {
         "Desc": ["Integer binary AND NOT. Performs the equivalent of Src1 & ~Src2"],
-        "DestSize": "std::max<uint8_t>(4, GetOpSize(_Src1))"
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
       "GPR = TestNZ u8:$Size, GPR:$Src1": {
         "Desc": ["Return NZCV for a GPR, setting N and Z accordingly and zeroing C and V"],
         "DestSize": "4"
       },
-      "GPR = Lshl u8:#Size, GPR:$Src1, GPR:$Src2": {
+      "GPR = Lshl OpSize:#Size, GPR:$Src1, GPR:$Src2": {
         "Desc": ["Integer logical shift left"
                 ],
+        "DestSize": "Size",
         "EmitValidation": [
-          "Size >= 4"
-        ],
-        "DestSize": "Size"
+          "Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-      "GPR = Lshr u8:#Size, GPR:$Src1, GPR:$Src2": {
+      "GPR = Lshr OpSize:#Size, GPR:$Src1, GPR:$Src2": {
         "Desc": ["Integer logical shift right"
                 ],
+        "DestSize": "Size",
         "EmitValidation": [
-          "Size >= 4"
-        ],
-        "DestSize": "Size"
+          "Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-      "GPR = Ashr u8:#Size, GPR:$Src1, GPR:$Src2": {
+      "GPR = Ashr OpSize:#Size, GPR:$Src1, GPR:$Src2": {
         "Desc": ["Integer arithmetic shift right"
                 ],
+        "DestSize": "Size",
         "EmitValidation": [
-          "Size >= 4"
-        ],
-        "DestSize": "Size"
+          "Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-      "GPR = Ror GPR:$Src1, GPR:$Src2": {
+      "GPR = Ror OpSize:#Size, GPR:$Src1, GPR:$Src2": {
         "Desc": ["Integer rotate right"
                 ],
-        "DestSize": "std::max<uint8_t>(4, GetOpSize(_Src1))"
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-      "GPR = Mul GPR:$Src1, GPR:$Src2": {
+      "GPR = Mul OpSize:#Size, GPR:$Src1, GPR:$Src2": {
         "Desc": ["Integer signed multiplication"
                 ],
-        "DestSize": "std::max<uint8_t>(4, std::max(GetOpSize(_Src1), GetOpSize(_Src2)))"
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-      "GPR = UMul GPR:$Src1, GPR:$Src2": {
+      "GPR = UMul OpSize:#Size, GPR:$Src1, GPR:$Src2": {
         "Desc": ["Integer unsigned multiplication"
                 ],
-        "DestSize": "std::max<uint8_t>(4, std::max(GetOpSize(_Src1), GetOpSize(_Src2)))"
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-
-      "GPR = Div GPR:$Src1, GPR:$Src2": {
+      "GPR = Div OpSize:#Size, GPR:$Src1, GPR:$Src2": {
         "Desc": ["Integer signed division"
-                ]
+                ],
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i8Bit || Size == FEXCore::IR::OpSize::i16Bit || Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-      "GPR = UDiv GPR:$Src1, GPR:$Src2": {
+      "GPR = UDiv OpSize:#Size, GPR:$Src1, GPR:$Src2": {
         "Desc": ["Integer unsigned division"
-                ]
+                ],
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i8Bit || Size == FEXCore::IR::OpSize::i16Bit || Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-      "GPR = Rem GPR:$Src1, GPR:$Src2": {
+      "GPR = Rem OpSize:#Size, GPR:$Src1, GPR:$Src2": {
         "Desc": ["Integer signed remainder"
-                ]
+                ],
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i8Bit || Size == FEXCore::IR::OpSize::i16Bit || Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-      "GPR = URem GPR:$Src1, GPR:$Src2": {
+      "GPR = URem OpSize:#Size, GPR:$Src1, GPR:$Src2": {
         "Desc": ["Integer unsigned remainder"
-                ]
+                ],
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i8Bit || Size == FEXCore::IR::OpSize::i16Bit || Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-      "GPR = MulH GPR:$Src1, GPR:$Src2": {
+      "GPR = MulH OpSize:#Size, GPR:$Src1, GPR:$Src2": {
         "Desc": ["Integer signed multiply returning high results",
                  "op:",
                  "Tmp <size * 2> = Src1 * Src2;",
                  "Dest = Tmp >> (size * 8);"
-                ]
+                ],
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-      "GPR = UMulH GPR:$Src1, GPR:$Src2": {
+      "GPR = UMulH OpSize:#Size, GPR:$Src1, GPR:$Src2": {
         "Desc": ["Integer unsigned multiply returning high results",
                  "op:",
                  "Tmp <size * 2> = Src1 * Src2;",
                  "Dest = Tmp >> (size * 8);"
-                ]
+                ],
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-      "GPR = Bfi u8:#DestSize, u8:$Width, u8:$lsb, GPR:$Dest, GPR:$Src": {
+      "GPR = Bfi OpSize:#Size, u8:$Width, u8:$lsb, GPR:$Dest, GPR:$Src": {
         "Desc": ["Copies a bitfield from one GPR to another",
                  "The source bitfield is from Src[Width:0]",
                  "The bitfield is copied in to Dest[(Width + lsb):lsb]"
                 ],
-        "DestSize": "DestSize"
+        "Comment": [
+          "TODO: There is an assumption that BFI of operating size < 32-bit makes sense"
+        ],
+        "DestSize": "Size",
+        "EmitValidation": [
+          "true || Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-      "GPR = Bfe u8:#DestSize, u8:$Width, u8:$lsb, GPR:$Src": {
+      "GPR = Bfe OpSize:#Size, u8:$Width, u8:$lsb, GPR:$Src": {
         "Desc": ["Extracts a bitfield from one GPR with zext",
                  "The source bitfield is from Src[Width:0]",
                  "The bitfield is then zero extended"
                 ],
-        "DestSize": "DestSize != 0 ? DestSize : GetOpSize(_Src)"
+        "Comment": [
+          "TODO: There is an assumption that BFE of operating size < 32-bit makes sense"
+        ],
+        "DestSize": "Size",
+        "EmitValidation": [
+          "true || Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-      "GPR = Sbfe u8:$Width, u8:$lsb, GPR:$Src": {
+      "GPR = Sbfe OpSize:#Size, u8:$Width, u8:$lsb, GPR:$Src": {
         "Desc": ["Extracts a bitfield from one GPR with sext",
                  "The source bitfield is from Src[Width:0]",
                  "The bitfield is then sign extended"
                 ],
-        "DestSize": "8"
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
       "GPR = Select CondClass:$Cond, SSA:$Cmp1, SSA:$Cmp2, GPR:$TrueVal, GPR:$FalseVal, u8:$CompareSize": {
         "Desc": ["Ternary selection of GPRs",
                  "op:",
-                 "Dest = Cmp1 <Cond> Cmp2 ? TrueVal : FalseVal"
+                 "Dest = Cmp1 <Cond> Cmp2 ? TrueVal : FalseVal",
+                 "TODO: Make this less opaque about how it operates"
                 ],
         "DestSize": "std::max<uint8_t>(4, std::max<uint8_t>(GetOpSize(_TrueVal), GetOpSize(_FalseVal)))",
         "EmitValidation": [
           "WalkFindRegClass($Cmp1) == WalkFindRegClass($Cmp2)"
         ]
       },
-      "GPR = Extr GPR:$Upper, GPR:$Lower, u8:$LSB": {
+      "GPR = Extr OpSize:#Size, GPR:$Upper, GPR:$Lower, u8:$LSB": {
         "Desc": ["Concats the two GPRs to create a value that is the size of the full two GPRs",
                  "It then extracts a bitfield width that size of a GPR from the LSB",
                  "Valid LSB range is 0-31 for 32bit and 0-63 for 64bit",
                  "<Size * 2> ConcatValue = $Upper:$Lower",
                  "Result = ConcatValue<LSB+Size - 1: LSB>"
-                ]
+                ],
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-      "GPR = PDep GPR:$Input, GPR:$Mask": {
+      "GPR = PDep OpSize:#Size, GPR:$Input, GPR:$Mask": {
         "Desc": ["Performs a parallel bit deposit.",
                  "Takes the contiguous low-order bits and deposits them into",
                  "the destination at the locations specified by the Mask."
-                ]
+                ],
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
 
-      "GPR = PExt GPR:$Input, GPR:$Mask": {
+      "GPR = PExt OpSize:#Size, GPR:$Input, GPR:$Mask": {
         "Desc": ["Performs a parallel bit extract.",
                  "Each bit set in the mask will select the corresponding bit in the Input",
                  "and transfers them to the lower contiguous bits in the destination."
-                ]
+                ],
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
 
-      "GPR = LDiv GPR:$Lower, GPR:$Upper, GPR:$Divisor": {
+      "GPR = LDiv OpSize:#Size, GPR:$Lower, GPR:$Upper, GPR:$Divisor": {
         "Desc": ["Integer long unsigned division returning lower bits",
                  "The Lower and Upper registers will be concated together to generate a dividend twice the size",
                  "Then the divisor divides the temporary dividend and returns the results in the original sized register"
-                ]
+                ],
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i16Bit || Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-      "GPR = LUDiv GPR:$Lower, GPR:$Upper, GPR:$Divisor": {
+      "GPR = LUDiv OpSize:#Size, GPR:$Lower, GPR:$Upper, GPR:$Divisor": {
         "Desc": ["Integer long unsigned division returning lower bits",
                  "The Lower and Upper registers will be concated together to generate a dividend twice the size",
                  "Then the divisor divides the temporary dividend and returns the results in the original sized register"
-                ]
+                ],
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i16Bit || Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-      "GPR = LRem GPR:$Lower, GPR:$Upper, GPR:$Divisor": {
+      "GPR = LRem OpSize:#Size, GPR:$Lower, GPR:$Upper, GPR:$Divisor": {
         "Desc": ["Integer long signed remainder returning lower bits",
                  "The Lower and Upper registers will be concated together to generate a dividend twice the size",
                  "Then the divisor divides the temporary dividend and returns the remainder results in the original sized register"
-                ]
+                ],
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i16Bit || Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
-      "GPR = LURem GPR:$Lower, GPR:$Upper, GPR:$Divisor": {
+      "GPR = LURem OpSize:#Size, GPR:$Lower, GPR:$Upper, GPR:$Divisor": {
         "Desc": ["Integer long unsigned remainder returning lower bits",
                  "The Lower and Upper registers will be concated together to generate a dividend twice the size",
                  "Then the divisor divides the temporary dividend and returns the remainder results in the original sized register"
-                ]
+                ],
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i16Bit || Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
       },
 
       "Float to GPR": {"Ignore": 1},

--- a/FEXCore/Source/Interface/IR/IRParser.cpp
+++ b/FEXCore/Source/Interface/IR/IRParser.cpp
@@ -43,7 +43,7 @@ enum class DecodeFailure {
   DECODE_INVALID_MEMOFFSETTYPE,
   DECODE_INVALID_FENCETYPE,
   DECODE_INVALID_BREAKTYPE,
-
+  DECODE_INVALID_OPSIZE,
 };
 
 fextl::string DecodeErrorToString(DecodeFailure Failure) {
@@ -59,6 +59,7 @@ fextl::string DecodeErrorToString(DecodeFailure Failure) {
     case DecodeFailure::DECODE_INVALID_MEMOFFSETTYPE: return "Invalid Memory Offset Type";
     case DecodeFailure::DECODE_INVALID_FENCETYPE: return "Invalid Fence Type";
     case DecodeFailure::DECODE_INVALID_BREAKTYPE: return "Invalid Break Reason Type";
+    case DecodeFailure::DECODE_INVALID_OPSIZE: return "Invalid Operation size name";
   }
   return "Unknown Error";
 }
@@ -289,6 +290,25 @@ class IRParser: public FEXCore::IR::IREmitter {
     else {
       return {DecodeFailure::DECODE_OKAY, Reason};
     }
+  }
+
+  template<>
+  std::pair<DecodeFailure, FEXCore::IR::OpSize> DecodeValue(const fextl::string &Arg) {
+    static constexpr std::array<std::pair<std::string_view, FEXCore::IR::OpSize>, 6> Names = {{
+      { "i8", OpSize::i8Bit },
+      { "i16", OpSize::i16Bit },
+      { "i32", OpSize::i32Bit },
+      { "i64", OpSize::i64Bit },
+      { "i128", OpSize::i128Bit },
+      { "i256", OpSize::i256Bit },
+    }};
+
+    for (size_t i = 0; i < Names.size(); ++i) {
+      if (Names[i].first == Arg) {
+        return {DecodeFailure::DECODE_OKAY, Names[i].second};
+      }
+    }
+    return {DecodeFailure::DECODE_INVALID_OPSIZE, {}};
   }
 
   template<>

--- a/FEXCore/include/FEXCore/IR/IR.h
+++ b/FEXCore/include/FEXCore/IR/IR.h
@@ -536,6 +536,17 @@ enum IndexNamedVectorConstant : uint8_t {
   INDEXED_NAMED_VECTOR_MAX,
 };
 
+// This must directly match bytes to the named opsize.
+// Implicit sized IR operations does math to get between sizes.
+enum OpSize : uint8_t {
+  i8Bit = 1,
+  i16Bit = 2,
+  i32Bit = 4,
+  i64Bit = 8,
+  i128Bit = 16,
+  i256Bit = 32,
+};
+
 #define IROP_ENUM
 #define IROP_STRUCTS
 #define IROP_SIZES

--- a/FEXCore/include/FEXCore/IR/IREmitter.h
+++ b/FEXCore/include/FEXCore/IR/IREmitter.h
@@ -60,9 +60,6 @@ friend class FEXCore::IR::PassManager;
     Op.first->Header.ElementSize = Size / 8;
     return Op;
   }
-  IRPair<IROp_Bfe> _Bfe(uint8_t Width, uint8_t lsb, OrderedNode *ssa0) {
-    return _Bfe(0, Width, lsb, ssa0);
-  }
   IRPair<IROp_Sbfe> _Sext(uint8_t SrcSize, OrderedNode *ssa0) {
     return _Sbfe(SrcSize, 0, ssa0);
   }
@@ -105,6 +102,186 @@ friend class FEXCore::IR::PassManager;
   OrderedNode *Invalid() {
     return InvalidNode;
   }
+
+  // Temporary naughty implicit IR operation handlers
+  ///< Moves
+  IRPair<IROp_ExtractElementPair> _ExtractElementPair(OrderedNode *_Pair, uint8_t _Element) {
+    return _ExtractElementPair(static_cast<OpSize>(GetOpSize(_Pair) >> 1), _Pair, _Element);
+  }
+  IRPair<IROp_CreateElementPair> _CreateElementPair(OrderedNode *_Lower, OrderedNode *_Upper) {
+    return _CreateElementPair(static_cast<OpSize>(GetOpSize(_Lower) * 2), _Lower, _Upper);
+  }
+  ///< Atomics
+  IRPair<IROp_CAS> _CAS(OrderedNode *_Expected, OrderedNode *_Desired, OrderedNode *_Addr) {
+    return _CAS(static_cast<OpSize>(GetOpSize(_Expected)), _Expected, _Desired, _Addr);
+  }
+  IRPair<IROp_CASPair> _CASPair(OrderedNode *_Expected, OrderedNode *_Desired, OrderedNode *_Addr) {
+    return _CASPair(static_cast<OpSize>(GetOpSize(_Expected)), _Expected, _Desired, _Addr);
+  }
+  IRPair<IROp_AtomicAdd> _AtomicAdd(uint8_t Size, OrderedNode *_Value, OrderedNode *_Addr) {
+    return _AtomicAdd(static_cast<OpSize>(Size), _Value, _Addr);
+  }
+  IRPair<IROp_AtomicSub> _AtomicSub(uint8_t Size, OrderedNode *_Value, OrderedNode *_Addr) {
+    return _AtomicSub(static_cast<OpSize>(Size), _Value, _Addr);
+  }
+  IRPair<IROp_AtomicAnd> _AtomicAnd(uint8_t Size, OrderedNode *_Value, OrderedNode *_Addr) {
+    return _AtomicAnd(static_cast<OpSize>(Size), _Value, _Addr);
+  }
+  IRPair<IROp_AtomicOr> _AtomicOr(uint8_t Size, OrderedNode *_Value, OrderedNode *_Addr) {
+    return _AtomicOr(static_cast<OpSize>(Size), _Value, _Addr);
+  }
+  IRPair<IROp_AtomicXor> _AtomicXor(uint8_t Size, OrderedNode *_Value, OrderedNode *_Addr) {
+    return _AtomicXor(static_cast<OpSize>(Size), _Value, _Addr);
+  }
+  IRPair<IROp_AtomicSwap> _AtomicSwap(uint8_t Size, OrderedNode *_Value, OrderedNode *_Addr) {
+    return _AtomicSwap(static_cast<OpSize>(Size), _Value, _Addr);
+  }
+  IRPair<IROp_AtomicFetchAdd> _AtomicFetchAdd(uint8_t Size, OrderedNode *_Value, OrderedNode *_Addr) {
+    return _AtomicFetchAdd(static_cast<OpSize>(Size), _Value, _Addr);
+  }
+  IRPair<IROp_AtomicFetchSub> _AtomicFetchSub(uint8_t Size, OrderedNode *_Value, OrderedNode *_Addr) {
+    return _AtomicFetchSub(static_cast<OpSize>(Size), _Value, _Addr);
+  }
+  IRPair<IROp_AtomicFetchAnd> _AtomicFetchAnd(uint8_t Size, OrderedNode *_Value, OrderedNode *_Addr) {
+    return _AtomicFetchAnd(static_cast<OpSize>(Size), _Value, _Addr);
+  }
+  IRPair<IROp_AtomicFetchOr> _AtomicFetchOr(uint8_t Size, OrderedNode *_Value, OrderedNode *_Addr) {
+    return _AtomicFetchOr(static_cast<OpSize>(Size), _Value, _Addr);
+  }
+  IRPair<IROp_AtomicFetchXor> _AtomicFetchXor(uint8_t Size, OrderedNode *_Value, OrderedNode *_Addr) {
+    return _AtomicFetchXor(static_cast<OpSize>(Size), _Value, _Addr);
+  }
+  IRPair<IROp_AtomicFetchNeg> _AtomicFetchNeg(uint8_t Size, OrderedNode *_Addr) {
+    return _AtomicFetchNeg(static_cast<OpSize>(Size), _Addr);
+  }
+  ///< ALU
+  IRPair<IROp_EntrypointOffset> _EntrypointOffset(int64_t _Offset, uint8_t RegisterSize) {
+    return _EntrypointOffset(static_cast<OpSize>(RegisterSize), _Offset);
+  }
+  IRPair<IROp_InlineEntrypointOffset> _InlineEntrypointOffset(int64_t _Offset, uint8_t RegisterSize) {
+    return _InlineEntrypointOffset(static_cast<OpSize>(RegisterSize), _Offset);
+  }
+  IRPair<IROp_Neg> _Neg(OrderedNode *_Src) {
+    return _Neg(static_cast<OpSize>(std::max<uint8_t>(4, GetOpSize(_Src))), _Src);
+  }
+  IRPair<IROp_Abs> _Abs(OrderedNode *_Src) {
+    return _Abs(static_cast<OpSize>(std::max<uint8_t>(4, GetOpSize(_Src))), _Src);
+  }
+  IRPair<IROp_Not> _Not(OrderedNode *_Src) {
+    return _Not(static_cast<OpSize>(std::max<uint8_t>(4, GetOpSize(_Src))), _Src);
+  }
+  IRPair<IROp_Popcount> _Popcount(OrderedNode *_Src) {
+    return _Popcount(static_cast<OpSize>(GetOpSize(_Src)), _Src);
+  }
+  IRPair<IROp_FindLSB> _FindLSB(OrderedNode *_Src) {
+    return _FindLSB(static_cast<OpSize>(GetOpSize(_Src)), _Src);
+  }
+  IRPair<IROp_FindMSB> _FindMSB(OrderedNode *_Src) {
+    return _FindMSB(static_cast<OpSize>(GetOpSize(_Src)), _Src);
+  }
+  IRPair<IROp_FindTrailingZeroes> _FindTrailingZeroes(OrderedNode *_Src) {
+    return _FindTrailingZeroes(static_cast<OpSize>(GetOpSize(_Src)), _Src);
+  }
+  IRPair<IROp_CountLeadingZeroes> _CountLeadingZeroes(OrderedNode *_Src) {
+    return _CountLeadingZeroes(static_cast<OpSize>(GetOpSize(_Src)), _Src);
+  }
+  IRPair<IROp_Rev> _Rev(OrderedNode *_Src) {
+    return _Rev(static_cast<OpSize>(GetOpSize(_Src)), _Src);
+  }
+  IRPair<IROp_Add> _Add(OrderedNode *_Src1, OrderedNode *_Src2) {
+    return _Add(static_cast<OpSize>(std::max<uint8_t>(4, std::max(GetOpSize(_Src1), GetOpSize(_Src2)))), _Src1, _Src2);
+  }
+  IRPair<IROp_Sub> _Sub(OrderedNode *_Src1, OrderedNode *_Src2) {
+    return _Sub(static_cast<OpSize>(std::max<uint8_t>(4, std::max(GetOpSize(_Src1), GetOpSize(_Src2)))), _Src1, _Src2);
+  }
+  IRPair<IROp_Or> _Or(OrderedNode *_Src1, OrderedNode *_Src2) {
+    return _Or(static_cast<OpSize>(std::max(GetOpSize(_Src1), GetOpSize(_Src2))), _Src1, _Src2);
+  }
+  IRPair<IROp_Orlshl> _Orlshl(OrderedNode *_Src1, OrderedNode *_Src2, uint8_t _BitShift) {
+    return _Orlshl(static_cast<OpSize>(std::max(GetOpSize(_Src1), GetOpSize(_Src2))), _Src1, _Src2, _BitShift);
+  }
+  IRPair<IROp_Orlshr> _Orlshr(OrderedNode *_Src1, OrderedNode *_Src2, uint8_t _BitShift) {
+    return _Orlshr(static_cast<OpSize>(std::max(GetOpSize(_Src1), GetOpSize(_Src2))), _Src1, _Src2, _BitShift);
+  }
+  IRPair<IROp_Xor> _Xor(OrderedNode *_Src1, OrderedNode *_Src2) {
+    return _Xor(static_cast<OpSize>(std::max<uint8_t>(4, std::max(GetOpSize(_Src1), GetOpSize(_Src2)))), _Src1, _Src2);
+  }
+  IRPair<IROp_And> _And(OrderedNode *_Src1, OrderedNode *_Src2) {
+    return _And(static_cast<OpSize>(std::max<uint8_t>(4, std::max(GetOpSize(_Src1), GetOpSize(_Src2)))), _Src1, _Src2);
+  }
+  IRPair<IROp_Andn> _Andn(OrderedNode *_Src1, OrderedNode *_Src2) {
+    return _Andn(static_cast<OpSize>(std::max<uint8_t>(4, std::max(GetOpSize(_Src1), GetOpSize(_Src2)))), _Src1, _Src2);
+  }
+  IRPair<IROp_Lshl> _Lshl(uint8_t Size, OrderedNode *_Src1, OrderedNode *_Src2) {
+    return _Lshl(static_cast<OpSize>(Size), _Src1, _Src2);
+  }
+  IRPair<IROp_Lshr> _Lshr(uint8_t Size, OrderedNode *_Src1, OrderedNode *_Src2) {
+    return _Lshr(static_cast<OpSize>(Size), _Src1, _Src2);
+  }
+  IRPair<IROp_Ashr> _Ashr(uint8_t Size, OrderedNode *_Src1, OrderedNode *_Src2) {
+    return _Ashr(static_cast<OpSize>(Size), _Src1, _Src2);
+  }
+  IRPair<IROp_Ror> _Ror(OrderedNode *_Src1, OrderedNode *_Src2) {
+    return _Ror(static_cast<OpSize>(std::max<uint8_t>(4, GetOpSize(_Src1))), _Src1, _Src2);
+  }
+  IRPair<IROp_Mul> _Mul(OrderedNode *_Src1, OrderedNode *_Src2) {
+    return _Mul(static_cast<OpSize>(std::max<uint8_t>(4, std::max(GetOpSize(_Src1), GetOpSize(_Src2)))), _Src1, _Src2);
+  }
+  IRPair<IROp_UMul> _UMul(OrderedNode *_Src1, OrderedNode *_Src2) {
+    return _UMul(static_cast<OpSize>(std::max<uint8_t>(4, std::max(GetOpSize(_Src1), GetOpSize(_Src2)))), _Src1, _Src2);
+  }
+  IRPair<IROp_Div> _Div(OrderedNode *_Src1, OrderedNode *_Src2) {
+    return _Div(static_cast<OpSize>(std::max(GetOpSize(_Src1), GetOpSize(_Src2))), _Src1, _Src2);
+  }
+  IRPair<IROp_UDiv> _UDiv(OrderedNode *_Src1, OrderedNode *_Src2) {
+    return _UDiv(static_cast<OpSize>(std::max(GetOpSize(_Src1), GetOpSize(_Src2))), _Src1, _Src2);
+  }
+  IRPair<IROp_Rem> _Rem(OrderedNode *_Src1, OrderedNode *_Src2) {
+    return _Rem(static_cast<OpSize>(std::max(GetOpSize(_Src1), GetOpSize(_Src2))), _Src1, _Src2);
+  }
+  IRPair<IROp_URem> _URem(OrderedNode *_Src1, OrderedNode *_Src2) {
+    return _URem(static_cast<OpSize>(std::max(GetOpSize(_Src1), GetOpSize(_Src2))), _Src1, _Src2);
+  }
+  IRPair<IROp_MulH> _MulH(OrderedNode *_Src1, OrderedNode *_Src2) {
+    return _MulH(static_cast<OpSize>(std::max<uint8_t>(4, std::max(GetOpSize(_Src1), GetOpSize(_Src2)))), _Src1, _Src2);
+  }
+  IRPair<IROp_UMulH> _UMulH(OrderedNode *_Src1, OrderedNode *_Src2) {
+    return _UMulH(static_cast<OpSize>(std::max<uint8_t>(4, std::max(GetOpSize(_Src1), GetOpSize(_Src2)))), _Src1, _Src2);
+  }
+  IRPair<IROp_Bfi> _Bfi(uint8_t DestSize, uint8_t _Width, uint8_t _lsb, OrderedNode *_Dest, OrderedNode *_Src) {
+    return _Bfi(static_cast<OpSize>(DestSize), _Width, _lsb, _Dest, _Src);
+  }
+  IRPair<IROp_Bfe> _Bfe(uint8_t DestSize, uint8_t _Width, uint8_t _lsb, OrderedNode *_Src) {
+    return _Bfe(static_cast<OpSize>(DestSize != 0 ? DestSize : GetOpSize(_Src)), _Width, _lsb, _Src);
+  }
+  IRPair<IROp_Bfe> _Bfe(uint8_t Width, uint8_t lsb, OrderedNode *ssa0) {
+    return _Bfe(0, Width, lsb, ssa0);
+  }
+  IRPair<IROp_Sbfe> _Sbfe(uint8_t _Width, uint8_t _lsb, OrderedNode *_Src) {
+    return _Sbfe(OpSize::i64Bit, _Width, _lsb, _Src);
+  }
+  IRPair<IROp_Extr> _Extr(OrderedNode *_Upper, OrderedNode *_Lower, uint8_t _LSB) {
+    return _Extr(static_cast<OpSize>(std::max(GetOpSize(_Upper), GetOpSize(_Lower))), _Upper, _Lower, _LSB);
+  }
+  IRPair<IROp_PDep> _PDep(OrderedNode *_Input, OrderedNode *_Mask) {
+    return _PDep(static_cast<OpSize>(std::max(GetOpSize(_Input), GetOpSize(_Mask))), _Input, _Mask);
+  }
+  IRPair<IROp_PExt> _PExt(OrderedNode *_Input, OrderedNode *_Mask) {
+    return _PExt(static_cast<OpSize>(std::max(GetOpSize(_Input), GetOpSize(_Mask))), _Input, _Mask);
+  }
+  IRPair<IROp_LDiv> _LDiv(OrderedNode *_Lower, OrderedNode *_Upper, OrderedNode *_Divisor) {
+    return _LDiv(static_cast<OpSize>(std::max(GetOpSize(_Divisor), std::max(GetOpSize(_Upper), GetOpSize(_Lower)))), _Lower, _Upper, _Divisor);
+  }
+  IRPair<IROp_LUDiv> _LUDiv(OrderedNode *_Lower, OrderedNode *_Upper, OrderedNode *_Divisor) {
+    return _LUDiv(static_cast<OpSize>(std::max(GetOpSize(_Divisor), std::max(GetOpSize(_Upper), GetOpSize(_Lower)))), _Lower, _Upper, _Divisor);
+  }
+  IRPair<IROp_LRem> _LRem(OrderedNode *_Lower, OrderedNode *_Upper, OrderedNode *_Divisor) {
+    return _LRem(static_cast<OpSize>(std::max(GetOpSize(_Divisor), std::max(GetOpSize(_Upper), GetOpSize(_Lower)))), _Lower, _Upper, _Divisor);
+  }
+  IRPair<IROp_LURem> _LURem(OrderedNode *_Lower, OrderedNode *_Upper, OrderedNode *_Divisor) {
+    return _LURem(static_cast<OpSize>(std::max(GetOpSize(_Divisor), std::max(GetOpSize(_Upper), GetOpSize(_Lower)))), _Lower, _Upper, _Divisor);
+  }
+  // End of Temporary naughty implicit IR operation handlers
 
   void AddPhiValue(IR::IROp_Phi *Phi, OrderedNode *Value) {
     // Got to do some bookkeeping first

--- a/unittests/IR/Basic/Sbfe.ir
+++ b/unittests/IR/Basic/Sbfe.ir
@@ -23,20 +23,20 @@
     %Addr1 i64 = Constant #0x1000000
     %Val i64 = LoadMem GPR, #8, %Addr1 i64, %Invalid, #8, SXTX, #1
 ; Test aligned special cases
-    %Res1 i64 = Sbfe #0x8, #0x0, %Val
+    %Res1 i64 = Sbfe i64, #0x8, #0x0, %Val
     (%Store1 i64) StoreRegister %Res1 i64, #0, #8, GPR, GPRFixed, #8
-    %Res2 i64 = Sbfe #0x10, #0x0, %Val
+    %Res2 i64 = Sbfe i64, #0x10, #0x0, %Val
     (%Store2 i64) StoreRegister %Res2 i64, #0, #0x20, GPR, GPRFixed, #8
-    %Res3 i64 = Sbfe #0x20, #0x0, %Val
+    %Res3 i64 = Sbfe i64, #0x20, #0x0, %Val
     (%Store3 i64) StoreRegister %Res3 i64, #0, #0x10, GPR, GPRFixed, #8
     %Addr2 i64 = Constant #0x1000008
 ; Test non special width
     %Val2 i64 = LoadMem GPR, #8, %Addr2 i64, %Invalid, #8, SXTX, #1
 
-    %Res4 i64 = Sbfe #0x6, #0x0, %Val2
+    %Res4 i64 = Sbfe i64, #0x6, #0x0, %Val2
     (%Store4 i64) StoreRegister %Res4 i64, #0, #0x18, GPR, GPRFixed, #8
 ; Test with + shift
-    %Res5 i64 = Sbfe #0x4, #0x2, %Val2
+    %Res5 i64 = Sbfe i64, #0x4, #0x2, %Val2
     (%Store5 i64) StoreRegister %Res5 i64, #0, #0x38, GPR, GPRFixed, #8
     (%brk i0) Break {0.11.0.128}
     (%end i0) EndBlock %2

--- a/unittests/IR/Correctness/AddTruncate.ir
+++ b/unittests/IR/Correctness/AddTruncate.ir
@@ -23,16 +23,16 @@
     %MemValueA i64 = LoadMem GPR, #8, %AddrA i64, %Invalid, #8, SXTX, #1
     %AddrB i64 = Constant #0x1000010
     %MemValueB i64 = LoadMem GPR, #8, %AddrB i64, %Invalid, #8, SXTX, #1
-    %ResultA i32 = Add %MemValueA, %MemValueB
-    %ResultB i64 = Add %MemValueA, %MemValueB
+    %ResultA i32 = Add i32, %MemValueA, %MemValueB
+    %ResultB i64 = Add i64, %MemValueA, %MemValueB
 
     (%Store i64) StoreRegister %ResultA i64, #0, #0x8, GPR, GPRFixed, #8
     (%Store i64) StoreRegister %ResultB i64, #0, #0x20, GPR, GPRFixed, #8
 ;  Constant optimisable version
     %ValueC i64 = Constant #0xaaaaaaaaaaaaaaa8
     %ValueD i64 = Constant #0x5555555555555551
-    %ResultC i32 = Add %ValueC, %ValueD
-    %ResultD i64 = Add %ValueC, %ValueD
+    %ResultC i32 = Add i32, %ValueC, %ValueD
+    %ResultD i64 = Add i64, %ValueC, %ValueD
     (%Store i64) StoreRegister %ResultC i64, #0, #0x10, GPR, GPRFixed, #8
     (%Store i64) StoreRegister %ResultD i64, #0, #0x18, GPR, GPRFixed, #8
     (%7 i0) Break {0.11.0.128}

--- a/unittests/IR/Correctness/LeftShiftTruncate.ir
+++ b/unittests/IR/Correctness/LeftShiftTruncate.ir
@@ -22,14 +22,14 @@
     %AddrA i64 = Constant #0x1000000
     %MemValueA i32 = LoadMem GPR, #4, %AddrA i64, %Invalid, #4, SXTX, #1
     %Shift i64 = Constant #0x1
-    %ResultA i32 = Lshl #4, %MemValueA, %Shift
-    %ResultB i64 = Lshl #8, %MemValueA, %Shift
+    %ResultA i32 = Lshl i32, %MemValueA, %Shift
+    %ResultB i64 = Lshl i64, %MemValueA, %Shift
     (%Store i64) StoreRegister %ResultA i64, #0, #0x8, GPR, GPRFixed, #8
     (%Store i64) StoreRegister %ResultB i64, #0, #0x20, GPR, GPRFixed, #8
 ;  Constant optimisable version
     %ValueB i64 = Constant #0x87654321
-    %ResultC i32 = Lshl #4, %ValueB, %Shift
-    %ResultD i64 = Lshl #8, %ValueB, %Shift
+    %ResultC i32 = Lshl i32, %ValueB, %Shift
+    %ResultD i64 = Lshl i64, %ValueB, %Shift
     (%Store i64) StoreRegister %ResultC i64, #0, #0x10, GPR, GPRFixed, #8
     (%Store i64) StoreRegister %ResultD i64, #0, #0x18, GPR, GPRFixed, #8
     (%7 i0) Break {0.11.0.128}

--- a/unittests/IR/Correctness/SubTruncate.ir
+++ b/unittests/IR/Correctness/SubTruncate.ir
@@ -23,15 +23,15 @@
     %MemValueA i64 = LoadMem GPR, #8, %AddrA i64, %Invalid, #8, SXTX, #1
     %AddrB i64 = Constant #0x1000010
     %MemValueB i64 = LoadMem GPR, #8, %AddrB i64, %Invalid, #8, SXTX, #1
-    %ResultA i32 = Sub %MemValueA, %MemValueB
-    %ResultB i64 = Sub %MemValueA, %MemValueB
+    %ResultA i32 = Sub i32, %MemValueA, %MemValueB
+    %ResultB i64 = Sub i64, %MemValueA, %MemValueB
     (%Store i64) StoreRegister %ResultA i64, #0, #0x8, GPR, GPRFixed, #8
     (%Store i64) StoreRegister %ResultB i64, #0, #0x20, GPR, GPRFixed, #8
 ;  Constant optimisable version
     %ValueC i64 = Constant #0xaaaaaaaaaaaaaaa8
     %ValueD i64 = Constant #0x5555555555555551
-    %ResultC i32 = Sub %ValueC, %ValueD
-    %ResultD i64 = Sub %ValueC, %ValueD
+    %ResultC i32 = Sub i32, %ValueC, %ValueD
+    %ResultD i64 = Sub i64, %ValueC, %ValueD
     (%Store i64) StoreRegister %ResultC i64, #0, #0x10, GPR, GPRFixed, #8
     (%Store i64) StoreRegister %ResultD i64, #0, #0x18, GPR, GPRFixed, #8
     (%7 i0) Break {0.11.0.128}


### PR DESCRIPTION
The number of times the implicit size calculation in GPR operations has bit us is immeasurable and was a mistake from the start of the project. The vector based operations never had this problem since they were explicitly sized for a long time now.

This converts the base IR operations to be explicitly sized, but adds implicit sized helpers for the moment while we work on removing implicit usage from the OpcodeDispatcher.

Should be NFC at this moment but it is a big enough change that I want it in before the "real" work starts.