### PR TITLE
InstCountCI: Test rorx at max mask size

### DIFF
--- a/unittests/InstructionCountCI/VEX_map3.json
+++ b/unittests/InstructionCountCI/VEX_map3.json
@@ -5118,6 +5118,17 @@
         "ror w4, w20, #31"
       ]
     },
+    "rorx eax, ebx, 32": {
+      "ExpectedInstructionCount": 2,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b11 0xf0 32-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "ubfx x20, x7, #0, #32",
+        "ror w4, w20, #0"
+      ]
+    },
     "rorx rax, rbx, 0": {
       "ExpectedInstructionCount": 1,
       "Optimal": "Yes",
@@ -5136,6 +5147,16 @@
       ],
       "ExpectedArm64ASM": [
         "ror x4, x7, #63"
+      ]
+    },
+    "rorx rax, rbx, 64": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b11 0xf0 64-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "ror x4, x7, #0"
       ]
     }
   }


### PR DESCRIPTION
Just to ensure we capture the nop nature of passing in the rotate amount of the operating size.