### PR TITLE
IR: Removes bfi from variable size

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -1180,7 +1180,7 @@ private:
     else if (CTX->BackendFeatures.SupportsShiftedBitwise && (SetBits & (1u << Bit)) == 0)
       return _Orlshl(IR::SizeToOpSize(std::max(GetOpSize(NZCV), GetOpSize(Value))), NZCV, Value, Bit);
     else
-      return _Bfi(4, 1, Bit, NZCV, Value);
+      return _Bfi(OpSize::i32Bit, 1, Bit, NZCV, Value);
   }
 
   template<unsigned BitOffset>

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
@@ -150,7 +150,7 @@ OrderedNode *OpDispatchBuilder::GetPackedRFLAG(uint32_t FlagsMask) {
     if (CTX->BackendFeatures.SupportsShiftedBitwise)
       Original = _Orlshl(OpSize::i64Bit, Original, Flag, FlagOffset);
     else
-      Original = _Bfi(4, 1, FlagOffset, Original, Flag);
+      Original = _Bfi(OpSize::i32Bit, 1, FlagOffset, Original, Flag);
   }
 
   // OR in the SF/ZF flags at the end, allowing the lshr to fold with the OR

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -782,7 +782,7 @@ void OpDispatchBuilder::MOVMSKOp(OpcodeArgs) {
     OrderedNode *GPR = _VExtractToGPR(Size, 8, Src, 0);
     // BFI the sign bit in 31 in to 62.
     // Inserting the full lower 32-bits offset 31 so the sign bit ends up at offset 63.
-    GPR = _Bfi(8, 32, 31, GPR, GPR);
+    GPR = _Bfi(OpSize::i64Bit, 32, 31, GPR, GPR);
     // Shift right to only get the two sign bits we care about.
     GPR = _Lshr(OpSize::i64Bit, GPR, _Constant(62));
     StoreResult_WithOpSize(GPRClass, Op, Op->Dest, GPR, CTX->GetGPRSize(), -1);
@@ -2712,7 +2712,7 @@ OrderedNode *OpDispatchBuilder::GetMXCSR() {
   // Default MXCSR Value
   OrderedNode *MXCSR = _Constant(0x1F80);
   OrderedNode *RoundingMode = _GetRoundingMode();
-  return _Bfi(4, 3, 13, MXCSR, RoundingMode);
+  return _Bfi(OpSize::i32Bit, 3, 13, MXCSR, RoundingMode);
 }
 
 void OpDispatchBuilder::FXRStoreOp(OpcodeArgs) {

--- a/FEXCore/include/FEXCore/IR/IREmitter.h
+++ b/FEXCore/include/FEXCore/IR/IREmitter.h
@@ -102,9 +102,6 @@ friend class FEXCore::IR::PassManager;
   IRPair<IROp_And> _And(OrderedNode *_Src1, OrderedNode *_Src2) {
     return _And(static_cast<OpSize>(std::max<uint8_t>(4, std::max(GetOpSize(_Src1), GetOpSize(_Src2)))), _Src1, _Src2);
   }
-  IRPair<IROp_Bfi> _Bfi(uint8_t DestSize, uint8_t _Width, uint8_t _lsb, OrderedNode *_Dest, OrderedNode *_Src) {
-    return _Bfi(static_cast<OpSize>(DestSize), _Width, _lsb, _Dest, _Src);
-  }
   IRPair<IROp_Bfe> _Bfe(uint8_t DestSize, uint8_t _Width, uint8_t _lsb, OrderedNode *_Src) {
     return _Bfe(static_cast<OpSize>(DestSize != 0 ? DestSize : GetOpSize(_Src)), _Width, _lsb, _Src);
   }


### PR DESCRIPTION
This one was already explicit sized. Just convert it over to OpSize.