### PR TITLE
IR: Removes implicit sized add

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Crypto.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Crypto.cpp
@@ -26,7 +26,7 @@ void OpDispatchBuilder::SHA1NEXTEOp(OpcodeArgs) {
   OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
 
   auto Tmp = _Ror(OpSize::i32Bit, _VExtractToGPR(16, 4, Dest, 3), _Constant(32, 2));
-  auto Top = _Add(_VExtractToGPR(16, 4, Src, 3), Tmp);
+  auto Top = _Add(OpSize::i32Bit, _VExtractToGPR(16, 4, Src, 3), Tmp);
   auto Result = _VInsGPR(16, 4, 3, Src, Top);
 
   StoreResult(FPRClass, Op, Result, -1);
@@ -117,7 +117,7 @@ void OpDispatchBuilder::SHA1RNDS4Op(OpcodeArgs) {
     auto C = _VExtractToGPR(16, 4, Dest, 1);
     auto D = _VExtractToGPR(16, 4, Dest, 0);
 
-    auto A1 = _Add(_Add(_Add(Fn(*this, B, C, D), _Ror(OpSize::i32Bit, A, _Constant(32, 27))), W0E), K);
+    auto A1 = _Add(OpSize::i32Bit, _Add(OpSize::i32Bit, _Add(OpSize::i32Bit, Fn(*this, B, C, D), _Ror(OpSize::i32Bit, A, _Constant(32, 27))), W0E), K);
     auto B1 = A;
     auto C1 = _Ror(OpSize::i32Bit, B, _Constant(32, 2));
     auto D1 = C;
@@ -127,7 +127,7 @@ void OpDispatchBuilder::SHA1RNDS4Op(OpcodeArgs) {
   };
   const auto Round1To3 = [&](OrderedNode *A, OrderedNode *B, OrderedNode *C,
                              OrderedNode *D, OrderedNode *E, OrderedNode *W) -> RoundResult {
-    auto ANext = _Add(_Add(_Add(_Add(Fn(*this, B, C, D), _Ror(OpSize::i32Bit, A, _Constant(32, 27))), W), E), K);
+    auto ANext = _Add(OpSize::i32Bit, _Add(OpSize::i32Bit, _Add(OpSize::i32Bit, _Add(OpSize::i32Bit, Fn(*this, B, C, D), _Ror(OpSize::i32Bit, A, _Constant(32, 27))), W), E), K);
     auto BNext = A;
     auto CNext = _Ror(OpSize::i32Bit, B, _Constant(32, 2));
     auto DNext = C;
@@ -163,10 +163,10 @@ void OpDispatchBuilder::SHA256MSG1Op(OpcodeArgs) {
   auto W1 = _VExtractToGPR(16, 4, Dest, 1);
   auto W0 = _VExtractToGPR(16, 4, Dest, 0);
 
-  auto Sig3 = _Add(W3, Sigma0(W4));
-  auto Sig2 = _Add(W2, Sigma0(W3));
-  auto Sig1 = _Add(W1, Sigma0(W2));
-  auto Sig0 = _Add(W0, Sigma0(W1));
+  auto Sig3 = _Add(OpSize::i32Bit, W3, Sigma0(W4));
+  auto Sig2 = _Add(OpSize::i32Bit, W2, Sigma0(W3));
+  auto Sig1 = _Add(OpSize::i32Bit, W1, Sigma0(W2));
+  auto Sig0 = _Add(OpSize::i32Bit, W0, Sigma0(W1));
 
   auto D3 = _VInsGPR(16, 4, 3, Dest, Sig3);
   auto D2 = _VInsGPR(16, 4, 2, D3, Sig2);
@@ -186,10 +186,10 @@ void OpDispatchBuilder::SHA256MSG2Op(OpcodeArgs) {
 
   auto W14 = _VExtractToGPR(16, 4, Src, 2);
   auto W15 = _VExtractToGPR(16, 4, Src, 3);
-  auto W16 = _Add(_VExtractToGPR(16, 4, Dest, 0), Sigma1(W14));
-  auto W17 = _Add(_VExtractToGPR(16, 4, Dest, 1), Sigma1(W15));
-  auto W18 = _Add(_VExtractToGPR(16, 4, Dest, 2), Sigma1(W16));
-  auto W19 = _Add(_VExtractToGPR(16, 4, Dest, 3), Sigma1(W17));
+  auto W16 = _Add(OpSize::i32Bit, _VExtractToGPR(16, 4, Dest, 0), Sigma1(W14));
+  auto W17 = _Add(OpSize::i32Bit, _VExtractToGPR(16, 4, Dest, 1), Sigma1(W15));
+  auto W18 = _Add(OpSize::i32Bit, _VExtractToGPR(16, 4, Dest, 2), Sigma1(W16));
+  auto W19 = _Add(OpSize::i32Bit, _VExtractToGPR(16, 4, Dest, 3), Sigma1(W17));
 
   auto D3 = _VInsGPR(16, 4, 3, Dest, W19);
   auto D2 = _VInsGPR(16, 4, 2, D3, W18);
@@ -234,11 +234,11 @@ void OpDispatchBuilder::SHA256RNDS2Op(OpcodeArgs) {
   const auto Round = [&](OrderedNode *A, OrderedNode *B, OrderedNode *C, OrderedNode *D,
                          OrderedNode *E, OrderedNode *F, OrderedNode *G, OrderedNode *H,
                          OrderedNode* WK) -> RoundResult {
-    auto ANext = _Add(_Add(_Add(_Add(_Add(Ch(E, F, G), Sigma1(E)), WK), H), Major(A, B, C)), Sigma0(A));
+    auto ANext = _Add(OpSize::i32Bit, _Add(OpSize::i32Bit, _Add(OpSize::i32Bit, _Add(OpSize::i32Bit, _Add(OpSize::i32Bit, Ch(E, F, G), Sigma1(E)), WK), H), Major(A, B, C)), Sigma0(A));
     auto BNext = A;
     auto CNext = B;
     auto DNext = C;
-    auto ENext = _Add(_Add(_Add(_Add(Ch(E, F, G), Sigma1(E)), WK), H), D);
+    auto ENext = _Add(OpSize::i32Bit, _Add(OpSize::i32Bit, _Add(OpSize::i32Bit, _Add(OpSize::i32Bit, Ch(E, F, G), Sigma1(E)), WK), H), D);
     auto FNext = E;
     auto GNext = F;
     auto HNext = G;

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
@@ -108,7 +108,7 @@ void OpDispatchBuilder::FLD(OpcodeArgs) {
   else {
     // Implicit arg
     auto offset = _Constant(Op->OP & 7);
-    data = _And(OpSize::i64Bit, _Add(orig_top, offset), mask);
+    data = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, orig_top, offset), mask);
     data = _LoadContextIndexed(data, 16, MMBaseOffset(), 16, FPRClass);
   }
   OrderedNode *converted = data;
@@ -157,7 +157,7 @@ void OpDispatchBuilder::FBSTP(OpcodeArgs) {
 
   // if we are popping then we must first mark this location as empty
   SetX87TopTag(orig_top, X87Tag::Empty);
-  auto top = _And(OpSize::i64Bit, _Add(orig_top, _Constant(1)), _Constant(7));
+  auto top = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, orig_top, _Constant(1)), _Constant(7));
   SetX87Top(top);
 }
 
@@ -248,7 +248,7 @@ void OpDispatchBuilder::FST(OpcodeArgs) {
     // if we are popping then we must first mark this location as empty
     SetX87TopTag(orig_top, X87Tag::Empty);
     // Set the new top now
-    auto top = _And(OpSize::i64Bit, _Add(orig_top, _Constant(1)), _Constant(7));
+    auto top = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, orig_top, _Constant(1)), _Constant(7));
     SetX87Top(top);
   }
 }
@@ -274,7 +274,7 @@ void OpDispatchBuilder::FIST(OpcodeArgs) {
     // if we are popping then we must first mark this location as empty
     SetX87TopTag(orig_top, X87Tag::Empty);
     // Set the new top now
-    auto top = _And(OpSize::i64Bit, _Add(orig_top, _Constant(1)), _Constant(7));
+    auto top = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, orig_top, _Constant(1)), _Constant(7));
     SetX87Top(top);
   }
 }
@@ -309,7 +309,7 @@ void OpDispatchBuilder::FADD(OpcodeArgs) {
   } else {
     // Implicit arg
     auto offset = _Constant(Op->OP & 7);
-    arg = _And(OpSize::i64Bit, _Add(top, offset), mask);
+    arg = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, top, offset), mask);
     if constexpr (ResInST0 == OpResult::RES_STI) {
       StackLocation = arg;
     }
@@ -323,7 +323,7 @@ void OpDispatchBuilder::FADD(OpcodeArgs) {
     // if we are popping then we must first mark this location as empty
     SetX87TopTag(top, X87Tag::Empty);
     // Set the new top now
-    top = _And(OpSize::i64Bit, _Add(top, _Constant(1)), mask);
+    top = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, top, _Constant(1)), mask);
     SetX87Top(top);
   }
 
@@ -370,7 +370,7 @@ void OpDispatchBuilder::FMUL(OpcodeArgs) {
   } else {
     // Implicit arg
     auto offset = _Constant(Op->OP & 7);
-    arg = _And(OpSize::i64Bit, _Add(top, offset), mask);
+    arg = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, top, offset), mask);
     if constexpr (ResInST0 == OpResult::RES_STI) {
       StackLocation = arg;
     }
@@ -386,7 +386,7 @@ void OpDispatchBuilder::FMUL(OpcodeArgs) {
     // if we are popping then we must first mark this location as empty
     SetX87TopTag(top, X87Tag::Empty);
     // Set the new top now
-    top = _And(OpSize::i64Bit, _Add(top, _Constant(1)), mask);
+    top = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, top, _Constant(1)), mask);
     SetX87Top(top);
   }
 
@@ -433,7 +433,7 @@ void OpDispatchBuilder::FDIV(OpcodeArgs) {
   } else {
     // Implicit arg
     auto offset = _Constant(Op->OP & 7);
-    arg = _And(OpSize::i64Bit, _Add(top, offset), mask);
+    arg = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, top, offset), mask);
     if constexpr (ResInST0 == OpResult::RES_STI) {
       StackLocation = arg;
     }
@@ -455,7 +455,7 @@ void OpDispatchBuilder::FDIV(OpcodeArgs) {
     // if we are popping then we must first mark this location as empty
     SetX87TopTag(top, X87Tag::Empty);
     // Set the new top now
-    top = _And(OpSize::i64Bit, _Add(top, _Constant(1)), mask);
+    top = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, top, _Constant(1)), mask);
     SetX87Top(top);
   }
 
@@ -518,7 +518,7 @@ void OpDispatchBuilder::FSUB(OpcodeArgs) {
   } else {
     // Implicit arg
     auto offset = _Constant(Op->OP & 7);
-    arg = _And(OpSize::i64Bit, _Add(top, offset), mask);
+    arg = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, top, offset), mask);
     if constexpr (ResInST0 == OpResult::RES_STI) {
       StackLocation = arg;
     }
@@ -540,7 +540,7 @@ void OpDispatchBuilder::FSUB(OpcodeArgs) {
     SetX87TopTag(top, X87Tag::Empty);
     // Set the new top now
 
-    top = _And(OpSize::i64Bit, _Add(top, _Constant(1)), mask);
+    top = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, top, _Constant(1)), mask);
     SetX87Top(top);
   }
 
@@ -700,7 +700,7 @@ void OpDispatchBuilder::FCOMI(OpcodeArgs) {
   } else {
     // Implicit arg
     auto offset = _Constant(Op->OP & 7);
-    arg = _And(OpSize::i64Bit, _Add(top, offset), mask);
+    arg = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, top, offset), mask);
     b = _LoadContextIndexed(arg, 16, MMBaseOffset(), 16, FPRClass);
   }
 
@@ -736,17 +736,17 @@ void OpDispatchBuilder::FCOMI(OpcodeArgs) {
   if constexpr (poptwice) {
     // if we are popping then we must first mark this location as empty
     SetX87TopTag(top, X87Tag::Empty);
-    top = _And(OpSize::i64Bit, _Add(top, _Constant(1)), mask);
+    top = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, top, _Constant(1)), mask);
     SetX87TopTag(top, X87Tag::Empty);
     // Set the new top now
-    top = _And(OpSize::i64Bit, _Add(top, _Constant(1)), mask);
+    top = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, top, _Constant(1)), mask);
     SetX87Top(top);
   }
   else if ((Op->TableInfo->Flags & X86Tables::InstFlags::FLAGS_POP) != 0) {
     // if we are popping then we must first mark this location as empty
     SetX87TopTag(top, X87Tag::Empty);
     // Set the new top now
-    top = _And(OpSize::i64Bit, _Add(top, _Constant(1)), mask);
+    top = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, top, _Constant(1)), mask);
     SetX87Top(top);
   }
 }
@@ -779,7 +779,7 @@ void OpDispatchBuilder::FXCH(OpcodeArgs) {
 
   // Implicit arg
   auto offset = _Constant(Op->OP & 7);
-  arg = _And(OpSize::i64Bit, _Add(top, offset), mask);
+  arg = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, top, offset), mask);
 
   auto a = _LoadContextIndexed(top, 16, MMBaseOffset(), 16, FPRClass);
   auto b = _LoadContextIndexed(arg, 16, MMBaseOffset(), 16, FPRClass);
@@ -797,7 +797,7 @@ void OpDispatchBuilder::FST(OpcodeArgs) {
 
   // Implicit arg
   auto offset = _Constant(Op->OP & 7);
-  arg = _And(OpSize::i64Bit, _Add(top, offset), mask);
+  arg = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, top, offset), mask);
 
   auto a = _LoadContextIndexed(top, 16, MMBaseOffset(), 16, FPRClass);
 
@@ -807,7 +807,7 @@ void OpDispatchBuilder::FST(OpcodeArgs) {
   if ((Op->TableInfo->Flags & X86Tables::InstFlags::FLAGS_POP) != 0) {
     // if we are popping then we must first mark this location as empty
     SetX87TopTag(top, X87Tag::Empty);
-    top = _And(OpSize::i64Bit, _Add(top, _Constant(1)), _Constant(7));
+    top = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, top, _Constant(1)), _Constant(7));
     SetX87Top(top);
   }
 }
@@ -845,7 +845,7 @@ void OpDispatchBuilder::X87BinaryOp(OpcodeArgs) {
   auto top = GetX87Top();
 
   auto mask = _Constant(7);
-  OrderedNode *st1 = _And(OpSize::i64Bit, _Add(top, _Constant(1)), mask);
+  OrderedNode *st1 = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, top, _Constant(1)), mask);
 
   auto a = _LoadContextIndexed(top, 16, MMBaseOffset(), 16, FPRClass);
   st1 = _LoadContextIndexed(st1, 16, MMBaseOffset(), 16, FPRClass);
@@ -875,7 +875,7 @@ template<bool Inc>
 void OpDispatchBuilder::X87ModifySTP(OpcodeArgs) {
   auto orig_top = GetX87Top();
   if (Inc) {
-    auto top = _And(OpSize::i64Bit, _Add(orig_top, _Constant(1)), _Constant(7));
+    auto top = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, orig_top, _Constant(1)), _Constant(7));
     SetX87Top(top);
   }
   else {
@@ -914,7 +914,7 @@ void OpDispatchBuilder::X87FYL2X(OpcodeArgs) {
   auto orig_top = GetX87Top();
   // if we are popping then we must first mark this location as empty
   SetX87TopTag(orig_top, X87Tag::Empty);
-  auto top = _And(OpSize::i64Bit, _Add(orig_top, _Constant(1)), _Constant(7));
+  auto top = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, orig_top, _Constant(1)), _Constant(7));
   SetX87Top(top);
 
   OrderedNode *st0 = _LoadContextIndexed(orig_top, 16, MMBaseOffset(), 16, FPRClass);
@@ -961,7 +961,7 @@ void OpDispatchBuilder::X87ATAN(OpcodeArgs) {
   auto orig_top = GetX87Top();
   // if we are popping then we must first mark this location as empty
   SetX87TopTag(orig_top, X87Tag::Empty);
-  auto top = _And(OpSize::i64Bit, _Add(orig_top, _Constant(1)), _Constant(7));
+  auto top = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, orig_top, _Constant(1)), _Constant(7));
   SetX87Top(top);
 
   auto a = _LoadContextIndexed(orig_top, 16, MMBaseOffset(), 16, FPRClass);
@@ -982,13 +982,13 @@ void OpDispatchBuilder::X87LDENV(OpcodeArgs) {
   _F80LoadFCW(NewFCW);
   _StoreContext(2, GPRClass, NewFCW, offsetof(FEXCore::Core::CPUState, FCW));
 
-  OrderedNode *MemLocation = _Add(Mem, _Constant(Size * 1));
+  OrderedNode *MemLocation = _Add(OpSize::i64Bit, Mem, _Constant(Size * 1));
   auto NewFSW = _LoadMem(GPRClass, Size, MemLocation, Size);
   ReconstructX87StateFromFSW(NewFSW);
 
   {
     // FTW
-    OrderedNode *MemLocation = _Add(Mem, _Constant(Size * 2));
+    OrderedNode *MemLocation = _Add(OpSize::i64Bit, Mem, _Constant(Size * 2));
     auto NewFTW = _LoadMem(GPRClass, Size, MemLocation, Size);
     _StoreContext(2, GPRClass, NewFTW, offsetof(FEXCore::Core::CPUState, FTW));
   }
@@ -1024,7 +1024,7 @@ void OpDispatchBuilder::X87FNSTENV(OpcodeArgs) {
   }
 
   {
-    OrderedNode *MemLocation = _Add(Mem, _Constant(Size * 1));
+    OrderedNode *MemLocation = _Add(OpSize::i64Bit, Mem, _Constant(Size * 1));
     _StoreMem(GPRClass, Size, MemLocation, ReconstructFSW(), Size);
   }
 
@@ -1032,32 +1032,32 @@ void OpDispatchBuilder::X87FNSTENV(OpcodeArgs) {
 
   {
     // FTW
-    OrderedNode *MemLocation = _Add(Mem, _Constant(Size * 2));
+    OrderedNode *MemLocation = _Add(OpSize::i64Bit, Mem, _Constant(Size * 2));
     auto FTW = _LoadContext(2, GPRClass, offsetof(FEXCore::Core::CPUState, FTW));
     _StoreMem(GPRClass, Size, MemLocation, FTW, Size);
   }
 
   {
     // Instruction Offset
-    OrderedNode *MemLocation = _Add(Mem, _Constant(Size * 3));
+    OrderedNode *MemLocation = _Add(OpSize::i64Bit, Mem, _Constant(Size * 3));
     _StoreMem(GPRClass, Size, MemLocation, ZeroConst, Size);
   }
 
   {
     // Instruction CS selector (+ Opcode)
-    OrderedNode *MemLocation = _Add(Mem, _Constant(Size * 4));
+    OrderedNode *MemLocation = _Add(OpSize::i64Bit, Mem, _Constant(Size * 4));
     _StoreMem(GPRClass, Size, MemLocation, ZeroConst, Size);
   }
 
   {
     // Data pointer offset
-    OrderedNode *MemLocation = _Add(Mem, _Constant(Size * 5));
+    OrderedNode *MemLocation = _Add(OpSize::i64Bit, Mem, _Constant(Size * 5));
     _StoreMem(GPRClass, Size, MemLocation, ZeroConst, Size);
   }
 
   {
     // Data pointer selector
-    OrderedNode *MemLocation = _Add(Mem, _Constant(Size * 6));
+    OrderedNode *MemLocation = _Add(OpSize::i64Bit, Mem, _Constant(Size * 6));
     _StoreMem(GPRClass, Size, MemLocation, ZeroConst, Size);
   }
 }
@@ -1114,7 +1114,7 @@ void OpDispatchBuilder::X87FNSAVE(OpcodeArgs) {
   }
 
   {
-    OrderedNode *MemLocation = _Add(Mem, _Constant(Size * 1));
+    OrderedNode *MemLocation = _Add(OpSize::i64Bit, Mem, _Constant(Size * 1));
     _StoreMem(GPRClass, Size, MemLocation, ReconstructFSW(), Size);
   }
 
@@ -1122,36 +1122,36 @@ void OpDispatchBuilder::X87FNSAVE(OpcodeArgs) {
 
   {
     // FTW
-    OrderedNode *MemLocation = _Add(Mem, _Constant(Size * 2));
+    OrderedNode *MemLocation = _Add(OpSize::i64Bit, Mem, _Constant(Size * 2));
     auto FTW = _LoadContext(2, GPRClass, offsetof(FEXCore::Core::CPUState, FTW));
     _StoreMem(GPRClass, Size, MemLocation, FTW, Size);
   }
 
   {
     // Instruction Offset
-    OrderedNode *MemLocation = _Add(Mem, _Constant(Size * 3));
+    OrderedNode *MemLocation = _Add(OpSize::i64Bit, Mem, _Constant(Size * 3));
     _StoreMem(GPRClass, Size, MemLocation, ZeroConst, Size);
   }
 
   {
     // Instruction CS selector (+ Opcode)
-    OrderedNode *MemLocation = _Add(Mem, _Constant(Size * 4));
+    OrderedNode *MemLocation = _Add(OpSize::i64Bit, Mem, _Constant(Size * 4));
     _StoreMem(GPRClass, Size, MemLocation, ZeroConst, Size);
   }
 
   {
     // Data pointer offset
-    OrderedNode *MemLocation = _Add(Mem, _Constant(Size * 5));
+    OrderedNode *MemLocation = _Add(OpSize::i64Bit, Mem, _Constant(Size * 5));
     _StoreMem(GPRClass, Size, MemLocation, ZeroConst, Size);
   }
 
   {
     // Data pointer selector
-    OrderedNode *MemLocation = _Add(Mem, _Constant(Size * 6));
+    OrderedNode *MemLocation = _Add(OpSize::i64Bit, Mem, _Constant(Size * 6));
     _StoreMem(GPRClass, Size, MemLocation, ZeroConst, Size);
   }
 
-  OrderedNode *ST0Location = _Add(Mem, _Constant(Size * 7));
+  OrderedNode *ST0Location = _Add(OpSize::i64Bit, Mem, _Constant(Size * 7));
 
   auto OneConst = _Constant(1);
   auto SevenConst = _Constant(7);
@@ -1159,8 +1159,8 @@ void OpDispatchBuilder::X87FNSAVE(OpcodeArgs) {
   for (int i = 0; i < 7; ++i) {
     auto data = _LoadContextIndexed(Top, 16, MMBaseOffset(), 16, FPRClass);
     _StoreMem(FPRClass, 16, ST0Location, data, 1);
-    ST0Location = _Add(ST0Location, TenConst);
-    Top = _And(OpSize::i64Bit, _Add(Top, OneConst), SevenConst);
+    ST0Location = _Add(OpSize::i64Bit, ST0Location, TenConst);
+    Top = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, Top, OneConst), SevenConst);
   }
 
   // The final st(7) needs a bit of special handling here
@@ -1169,7 +1169,7 @@ void OpDispatchBuilder::X87FNSAVE(OpcodeArgs) {
   // Lower 64bits [63:0]
   // upper 16 bits [79:64]
   _StoreMem(FPRClass, 8, ST0Location, data, 1);
-  ST0Location = _Add(ST0Location, _Constant(8));
+  ST0Location = _Add(OpSize::i64Bit, ST0Location, _Constant(8));
   auto topBytes = _VDupElement(16, 2, data, 4);
   _StoreMem(FPRClass, 2, ST0Location, topBytes, 1);
 
@@ -1186,17 +1186,17 @@ void OpDispatchBuilder::X87FRSTOR(OpcodeArgs) {
   _F80LoadFCW(NewFCW);
   _StoreContext(2, GPRClass, NewFCW, offsetof(FEXCore::Core::CPUState, FCW));
 
-  OrderedNode *MemLocation = _Add(Mem, _Constant(Size * 1));
+  OrderedNode *MemLocation = _Add(OpSize::i64Bit, Mem, _Constant(Size * 1));
   auto NewFSW = _LoadMem(GPRClass, Size, MemLocation, Size);
   auto Top = ReconstructX87StateFromFSW(NewFSW);
   {
     // FTW
-    OrderedNode *MemLocation = _Add(Mem, _Constant(Size * 2));
+    OrderedNode *MemLocation = _Add(OpSize::i64Bit, Mem, _Constant(Size * 2));
     auto NewFTW = _LoadMem(GPRClass, Size, MemLocation, Size);
     _StoreContext(2, GPRClass, NewFTW, offsetof(FEXCore::Core::CPUState, FTW));
   }
 
-  OrderedNode *ST0Location = _Add(Mem, _Constant(Size * 7));
+  OrderedNode *ST0Location = _Add(OpSize::i64Bit, Mem, _Constant(Size * 7));
 
   auto OneConst = _Constant(1);
   auto SevenConst = _Constant(7);
@@ -1214,8 +1214,8 @@ void OpDispatchBuilder::X87FRSTOR(OpcodeArgs) {
 
     _StoreContextIndexed(Reg, Top, 16, MMBaseOffset(), 16, FPRClass);
 
-    ST0Location = _Add(ST0Location, TenConst);
-    Top = _And(OpSize::i64Bit, _Add(Top, OneConst), SevenConst);
+    ST0Location = _Add(OpSize::i64Bit, ST0Location, TenConst);
+    Top = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, Top, OneConst), SevenConst);
   }
 
   // The final st(7) needs a bit of special handling here
@@ -1224,7 +1224,7 @@ void OpDispatchBuilder::X87FRSTOR(OpcodeArgs) {
   // upper 16 bits [79:64]
 
   OrderedNode *Reg = _LoadMem(FPRClass, 8, ST0Location, 1);
-  ST0Location = _Add(ST0Location, _Constant(8));
+  ST0Location = _Add(OpSize::i64Bit, ST0Location, _Constant(8));
   OrderedNode *RegHigh = _LoadMem(FPRClass, 2, ST0Location, 1);
   Reg = _VInsElement(16, 2, 4, 0, Reg, RegHigh);
   _StoreContextIndexed(Reg, Top, 16, MMBaseOffset(), 16, FPRClass);
@@ -1338,7 +1338,7 @@ void OpDispatchBuilder::X87FCMOV(OpcodeArgs) {
 
   // Implicit arg
   auto offset = _Constant(Op->OP & 7);
-  arg = _And(OpSize::i64Bit, _Add(top, offset), mask);
+  arg = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, top, offset), mask);
 
   auto a = _LoadContextIndexed(top, 16, MMBaseOffset(), 16, FPRClass);
   auto b = _LoadContextIndexed(arg, 16, MMBaseOffset(), 16, FPRClass);
@@ -1359,7 +1359,7 @@ void OpDispatchBuilder::X87FFREE(OpcodeArgs) {
 
   // Implicit arg
   auto offset = _Constant(Op->OP & 7);
-  top = _And(OpSize::i64Bit, _Add(top, offset), _Constant(7));
+  top = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, top, offset), _Constant(7));
 
   // Set this argument's tag as empty now
   SetX87TopTag(top, X87Tag::Empty);

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87F64.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87F64.cpp
@@ -79,13 +79,13 @@ void OpDispatchBuilder::X87LDENVF64(OpcodeArgs) {
 
   _StoreContext(2, GPRClass, NewFCW, offsetof(FEXCore::Core::CPUState, FCW));
 
-  OrderedNode *MemLocation = _Add(Mem, _Constant(Size * 1));
+  OrderedNode *MemLocation = _Add(OpSize::i64Bit, Mem, _Constant(Size * 1));
   auto NewFSW = _LoadMem(GPRClass, Size, MemLocation, Size);
   ReconstructX87StateFromFSW(NewFSW);
 
   {
     // FTW
-    OrderedNode *MemLocation = _Add(Mem, _Constant(Size * 2));
+    OrderedNode *MemLocation = _Add(OpSize::i64Bit, Mem, _Constant(Size * 2));
     auto NewFTW = _LoadMem(GPRClass, Size, MemLocation, Size);
     _StoreContext(2, GPRClass, NewFTW, offsetof(FEXCore::Core::CPUState, FTW));
   }
@@ -134,7 +134,7 @@ void OpDispatchBuilder::FLDF64(OpcodeArgs) {
   else {
     // Implicit arg (does this need to change with width?)
     auto offset = _Constant(Op->OP & 7);
-    data = _And(OpSize::i64Bit, _Add(orig_top, offset), mask);
+    data = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, orig_top, offset), mask);
     data = _LoadContextIndexed(data, 8, MMBaseOffset(), 16, FPRClass);
     converted = data;
   }
@@ -179,7 +179,7 @@ void OpDispatchBuilder::FBSTPF64(OpcodeArgs) {
 
   // if we are popping then we must first mark this location as empty
   SetX87TopTag(orig_top, X87Tag::Empty);
-  auto top = _And(OpSize::i64Bit, _Add(orig_top, _Constant(1)), _Constant(7));
+  auto top = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, orig_top, _Constant(1)), _Constant(7));
   SetX87Top(top);
 }
 
@@ -249,7 +249,7 @@ void OpDispatchBuilder::FSTF64(OpcodeArgs) {
     // if we are popping then we must first mark this location as empty
     SetX87TopTag(orig_top, X87Tag::Empty);
     // Set the new top now
-    auto top = _And(OpSize::i64Bit, _Add(orig_top, _Constant(1)), _Constant(7));
+    auto top = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, orig_top, _Constant(1)), _Constant(7));
     SetX87Top(top);
   }
 }
@@ -278,7 +278,7 @@ void OpDispatchBuilder::FISTF64(OpcodeArgs) {
     // if we are popping then we must first mark this location as empty
     SetX87TopTag(orig_top, X87Tag::Empty);
     // Set the new top now
-    auto top = _And(OpSize::i64Bit, _Add(orig_top, _Constant(1)), _Constant(7));
+    auto top = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, orig_top, _Constant(1)), _Constant(7));
     SetX87Top(top);
   }
 }
@@ -315,7 +315,7 @@ void OpDispatchBuilder::FADDF64(OpcodeArgs) {
   } else {
     // Implicit arg
     auto offset = _Constant(Op->OP & 7);
-    arg = _And(OpSize::i64Bit, _Add(top, offset), mask);
+    arg = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, top, offset), mask);
     if constexpr (ResInST0 == OpResult::RES_STI) {
       StackLocation = arg;
     }
@@ -328,7 +328,7 @@ void OpDispatchBuilder::FADDF64(OpcodeArgs) {
     // if we are popping then we must first mark this location as empty
     SetX87TopTag(top, X87Tag::Empty);
     // Set the new top now
-    top = _And(OpSize::i64Bit, _Add(top, _Constant(1)), mask);
+    top = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, top, _Constant(1)), mask);
     SetX87Top(top);
   }
 
@@ -376,7 +376,7 @@ void OpDispatchBuilder::FMULF64(OpcodeArgs) {
   } else {
     // Implicit arg
     auto offset = _Constant(Op->OP & 7);
-    arg = _And(OpSize::i64Bit, _Add(top, offset), mask);
+    arg = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, top, offset), mask);
     if constexpr (ResInST0 == OpResult::RES_STI) {
       StackLocation = arg;
     }
@@ -392,7 +392,7 @@ void OpDispatchBuilder::FMULF64(OpcodeArgs) {
     // if we are popping then we must first mark this location as empty
     SetX87TopTag(top, X87Tag::Empty);
     // Set the new top now
-    top = _And(OpSize::i64Bit, _Add(top, _Constant(1)), mask);
+    top = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, top, _Constant(1)), mask);
     SetX87Top(top);
   }
 
@@ -440,7 +440,7 @@ void OpDispatchBuilder::FDIVF64(OpcodeArgs) {
   } else {
     // Implicit arg
     auto offset = _Constant(Op->OP & 7);
-    arg = _And(OpSize::i64Bit, _Add(top, offset), mask);
+    arg = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, top, offset), mask);
     if constexpr (ResInST0 == OpResult::RES_STI) {
       StackLocation = arg;
     }
@@ -462,7 +462,7 @@ void OpDispatchBuilder::FDIVF64(OpcodeArgs) {
     // if we are popping then we must first mark this location as empty
     SetX87TopTag(top, X87Tag::Empty);
     // Set the new top now
-    top = _And(OpSize::i64Bit, _Add(top, _Constant(1)), mask);
+    top = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, top, _Constant(1)), mask);
     SetX87Top(top);
   }
 
@@ -526,7 +526,7 @@ void OpDispatchBuilder::FSUBF64(OpcodeArgs) {
   } else {
     // Implicit arg
     auto offset = _Constant(Op->OP & 7);
-    arg = _And(OpSize::i64Bit, _Add(top, offset), mask);
+    arg = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, top, offset), mask);
     if constexpr (ResInST0 == OpResult::RES_STI) {
       StackLocation = arg;
     }
@@ -549,7 +549,7 @@ void OpDispatchBuilder::FSUBF64(OpcodeArgs) {
     SetX87TopTag(top, X87Tag::Empty);
     // Set the new top now
 
-    top = _And(OpSize::i64Bit, _Add(top, _Constant(1)), mask);
+    top = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, top, _Constant(1)), mask);
     SetX87Top(top);
   }
 
@@ -688,7 +688,7 @@ void OpDispatchBuilder::FCOMIF64(OpcodeArgs) {
   } else {
     // Implicit arg
     auto offset = _Constant(Op->OP & 7);
-    arg = _And(OpSize::i64Bit, _Add(top, offset), mask);
+    arg = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, top, offset), mask);
     b = _LoadContextIndexed(arg, 8, MMBaseOffset(), 16, FPRClass);
   }
 
@@ -725,17 +725,17 @@ void OpDispatchBuilder::FCOMIF64(OpcodeArgs) {
   if constexpr (poptwice) {
     // if we are popping then we must first mark this location as empty
     SetX87TopTag(top, X87Tag::Empty);
-    top = _And(OpSize::i64Bit, _Add(top, _Constant(1)), mask);
+    top = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, top, _Constant(1)), mask);
     SetX87TopTag(top, X87Tag::Empty);
     // Set the new top now
-    top = _And(OpSize::i64Bit, _Add(top, _Constant(1)), mask);
+    top = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, top, _Constant(1)), mask);
     SetX87Top(top);
   }
   else if ((Op->TableInfo->Flags & X86Tables::InstFlags::FLAGS_POP) != 0) {
     // if we are popping then we must first mark this location as empty
     SetX87TopTag(top, X87Tag::Empty);
     // Set the new top now
-    top = _And(OpSize::i64Bit, _Add(top, _Constant(1)), mask);
+    top = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, top, _Constant(1)), mask);
     SetX87Top(top);
   }
 }
@@ -803,7 +803,7 @@ void OpDispatchBuilder::X87BinaryOpF64(OpcodeArgs) {
   auto top = GetX87Top();
 
   auto mask = _Constant(7);
-  OrderedNode *st1 = _And(OpSize::i64Bit, _Add(top, _Constant(1)), mask);
+  OrderedNode *st1 = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, top, _Constant(1)), mask);
 
   auto a = _LoadContextIndexed(top, 8, MMBaseOffset(), 16, FPRClass);
   st1 = _LoadContextIndexed(st1, 8, MMBaseOffset(), 16, FPRClass);
@@ -854,7 +854,7 @@ void OpDispatchBuilder::X87FYL2XF64(OpcodeArgs) {
   auto orig_top = GetX87Top();
   // if we are popping then we must first mark this location as empty
   SetX87TopTag(orig_top, X87Tag::Empty);
-  auto top = _And(OpSize::i64Bit, _Add(orig_top, _Constant(1)), _Constant(7));
+  auto top = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, orig_top, _Constant(1)), _Constant(7));
   SetX87Top(top);
 
   OrderedNode *st0 = _LoadContextIndexed(orig_top, 8, MMBaseOffset(), 16, FPRClass);
@@ -895,7 +895,7 @@ void OpDispatchBuilder::X87ATANF64(OpcodeArgs) {
   auto orig_top = GetX87Top();
   // if we are popping then we must first mark this location as empty
   SetX87TopTag(orig_top, X87Tag::Empty);
-  auto top = _And(OpSize::i64Bit, _Add(orig_top, _Constant(1)), _Constant(7));
+  auto top = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, orig_top, _Constant(1)), _Constant(7));
   SetX87Top(top);
 
   auto a = _LoadContextIndexed(orig_top, 8, MMBaseOffset(), 16, FPRClass);
@@ -940,7 +940,7 @@ void OpDispatchBuilder::X87FNSAVEF64(OpcodeArgs) {
   }
 
   {
-    OrderedNode *MemLocation = _Add(Mem, _Constant(Size * 1));
+    OrderedNode *MemLocation = _Add(OpSize::i64Bit, Mem, _Constant(Size * 1));
     _StoreMem(GPRClass, Size, MemLocation, ReconstructFSW(), Size);
   }
 
@@ -948,36 +948,36 @@ void OpDispatchBuilder::X87FNSAVEF64(OpcodeArgs) {
 
   {
     // FTW
-    OrderedNode *MemLocation = _Add(Mem, _Constant(Size * 2));
+    OrderedNode *MemLocation = _Add(OpSize::i64Bit, Mem, _Constant(Size * 2));
     auto FTW = _LoadContext(2, GPRClass, offsetof(FEXCore::Core::CPUState, FTW));
     _StoreMem(GPRClass, Size, MemLocation, FTW, Size);
   }
 
   {
     // Instruction Offset
-    OrderedNode *MemLocation = _Add(Mem, _Constant(Size * 3));
+    OrderedNode *MemLocation = _Add(OpSize::i64Bit, Mem, _Constant(Size * 3));
     _StoreMem(GPRClass, Size, MemLocation, ZeroConst, Size);
   }
 
   {
     // Instruction CS selector (+ Opcode)
-    OrderedNode *MemLocation = _Add(Mem, _Constant(Size * 4));
+    OrderedNode *MemLocation = _Add(OpSize::i64Bit, Mem, _Constant(Size * 4));
     _StoreMem(GPRClass, Size, MemLocation, ZeroConst, Size);
   }
 
   {
     // Data pointer offset
-    OrderedNode *MemLocation = _Add(Mem, _Constant(Size * 5));
+    OrderedNode *MemLocation = _Add(OpSize::i64Bit, Mem, _Constant(Size * 5));
     _StoreMem(GPRClass, Size, MemLocation, ZeroConst, Size);
   }
 
   {
     // Data pointer selector
-    OrderedNode *MemLocation = _Add(Mem, _Constant(Size * 6));
+    OrderedNode *MemLocation = _Add(OpSize::i64Bit, Mem, _Constant(Size * 6));
     _StoreMem(GPRClass, Size, MemLocation, ZeroConst, Size);
   }
 
-  OrderedNode *ST0Location = _Add(Mem, _Constant(Size * 7));
+  OrderedNode *ST0Location = _Add(OpSize::i64Bit, Mem, _Constant(Size * 7));
 
   auto OneConst = _Constant(1);
   auto SevenConst = _Constant(7);
@@ -986,8 +986,8 @@ void OpDispatchBuilder::X87FNSAVEF64(OpcodeArgs) {
     OrderedNode* data = _LoadContextIndexed(Top, 8, MMBaseOffset(), 16, FPRClass);
     data = _F80CVTTo(data, 8);
     _StoreMem(FPRClass, 16, ST0Location, data, 1);
-    ST0Location = _Add(ST0Location, TenConst);
-    Top = _And(OpSize::i64Bit, _Add(Top, OneConst), SevenConst);
+    ST0Location = _Add(OpSize::i64Bit, ST0Location, TenConst);
+    Top = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, Top, OneConst), SevenConst);
   }
 
   // The final st(7) needs a bit of special handling here
@@ -997,7 +997,7 @@ void OpDispatchBuilder::X87FNSAVEF64(OpcodeArgs) {
   // Lower 64bits [63:0]
   // upper 16 bits [79:64]
   _StoreMem(FPRClass, 8, ST0Location, data, 1);
-  ST0Location = _Add(ST0Location, _Constant(8));
+  ST0Location = _Add(OpSize::i64Bit, ST0Location, _Constant(8));
   auto topBytes = _VDupElement(16, 2, data, 4);
   _StoreMem(FPRClass, 2, ST0Location, topBytes, 1);
 
@@ -1025,18 +1025,18 @@ void OpDispatchBuilder::X87FRSTORF64(OpcodeArgs) {
   _StoreContext(2, GPRClass, NewFCW, offsetof(FEXCore::Core::CPUState, FCW));
   _StoreContext(2, GPRClass, NewFCW, offsetof(FEXCore::Core::CPUState, FCW));
 
-  OrderedNode *MemLocation = _Add(Mem, _Constant(Size * 1));
+  OrderedNode *MemLocation = _Add(OpSize::i64Bit, Mem, _Constant(Size * 1));
   auto NewFSW = _LoadMem(GPRClass, Size, MemLocation, Size);
   auto Top = ReconstructX87StateFromFSW(NewFSW);
 
   {
     // FTW
-    OrderedNode *MemLocation = _Add(Mem, _Constant(Size * 2));
+    OrderedNode *MemLocation = _Add(OpSize::i64Bit, Mem, _Constant(Size * 2));
     auto NewFTW = _LoadMem(GPRClass, Size, MemLocation, Size);
     _StoreContext(2, GPRClass, NewFTW, offsetof(FEXCore::Core::CPUState, FTW));
   }
 
-  OrderedNode *ST0Location = _Add(Mem, _Constant(Size * 7));
+  OrderedNode *ST0Location = _Add(OpSize::i64Bit, Mem, _Constant(Size * 7));
 
   auto OneConst = _Constant(1);
   auto SevenConst = _Constant(7);
@@ -1055,8 +1055,8 @@ void OpDispatchBuilder::X87FRSTORF64(OpcodeArgs) {
     Reg = _F80CVT(8, Reg);
     _StoreContextIndexed(Reg, Top, 8, MMBaseOffset(), 16, FPRClass);
 
-    ST0Location = _Add(ST0Location, TenConst);
-    Top = _And(OpSize::i64Bit, _Add(Top, OneConst), SevenConst);
+    ST0Location = _Add(OpSize::i64Bit, ST0Location, TenConst);
+    Top = _And(OpSize::i64Bit, _Add(OpSize::i64Bit, Top, OneConst), SevenConst);
   }
 
   // The final st(7) needs a bit of special handling here
@@ -1065,7 +1065,7 @@ void OpDispatchBuilder::X87FRSTORF64(OpcodeArgs) {
   // upper 16 bits [79:64]
 
   OrderedNode *Reg = _LoadMem(FPRClass, 8, ST0Location, 1);
-  ST0Location = _Add(ST0Location, _Constant(8));
+  ST0Location = _Add(OpSize::i64Bit, ST0Location, _Constant(8));
   OrderedNode *RegHigh = _LoadMem(FPRClass, 2, ST0Location, 1);
   Reg = _VInsElement(16, 2, 4, 0, Reg, RegHigh);
   Reg = _F80CVT(8, Reg); //Convert to double precision

--- a/FEXCore/include/FEXCore/IR/IREmitter.h
+++ b/FEXCore/include/FEXCore/IR/IREmitter.h
@@ -91,13 +91,6 @@ friend class FEXCore::IR::PassManager;
     return InvalidNode;
   }
 
-  // Temporary naughty implicit IR operation handlers
-  ///< ALU
-  IRPair<IROp_Add> _Add(OrderedNode *_Src1, OrderedNode *_Src2) {
-    return _Add(static_cast<OpSize>(std::max<uint8_t>(4, std::max(GetOpSize(_Src1), GetOpSize(_Src2)))), _Src1, _Src2);
-  }
-  // End of Temporary naughty implicit IR operation handlers
-
   void AddPhiValue(IR::IROp_Phi *Phi, OrderedNode *Value) {
     // Got to do some bookkeeping first
     Value->AddUse();


### PR DESCRIPTION
Saw a few locations in here that we operate things at 64-bit unconditionally around pointer calculation. Will be coming back for those when running in 32-bit mode.

This is the last of the implicit sized ALU operations! After this I'll be going through the IR more individually to try and remove any stragglers.
Then should be able to start cleaning up and actually optimizing GPR operations.