### PR TITLE
Defer AF extract

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -1589,6 +1589,10 @@ void OpDispatchBuilder::FLAGControlOp(OpcodeArgs) {
   break;
   }
 
+  // AF would need special handling here. It doesn't matter.
+  LOGMAN_THROW_AA_FMT(Flag != FEXCore::X86State::RFLAG_AF_LOC,
+                      "No AF complement instruction in x86");
+
   // Calculate flags early.
   CalculateDeferredFlags();
 
@@ -3415,7 +3419,7 @@ void OpDispatchBuilder::PopcountOp(OpcodeArgs) {
 void OpDispatchBuilder::DAAOp(OpcodeArgs) {
   CalculateDeferredFlags();
   auto CF = GetRFLAG(FEXCore::X86State::RFLAG_CF_LOC);
-  auto AF = GetRFLAG(FEXCore::X86State::RFLAG_AF_LOC);
+  auto AF = LoadAF();
   auto AL = LoadGPRRegister(X86State::REG_RAX, 1);
 
   SetRFLAG<FEXCore::X86State::RFLAG_CF_LOC>(_Constant(0));
@@ -3489,7 +3493,7 @@ void OpDispatchBuilder::DAAOp(OpcodeArgs) {
 void OpDispatchBuilder::DASOp(OpcodeArgs) {
   CalculateDeferredFlags();
   auto CF = GetRFLAG(FEXCore::X86State::RFLAG_CF_LOC);
-  auto AF = GetRFLAG(FEXCore::X86State::RFLAG_AF_LOC);
+  auto AF = LoadAF();
   auto AL = LoadGPRRegister(X86State::REG_RAX, 1);
 
   SetRFLAG<FEXCore::X86State::RFLAG_CF_LOC>(_Constant(0));
@@ -3561,7 +3565,7 @@ void OpDispatchBuilder::DASOp(OpcodeArgs) {
 void OpDispatchBuilder::AAAOp(OpcodeArgs) {
   InvalidateDeferredFlags();
 
-  auto AF = GetRFLAG(FEXCore::X86State::RFLAG_AF_LOC);
+  auto AF = LoadAF();
   auto AL = LoadGPRRegister(X86State::REG_RAX, 1);
   auto AX = LoadGPRRegister(X86State::REG_RAX, 2);
   auto Cond = _Or(OpSize::i64Bit, AF, _Select(FEXCore::IR::COND_UGT, _And(OpSize::i64Bit, AL, _Constant(0xF)), _Constant(9), _Constant(1), _Constant(0)));
@@ -3600,7 +3604,7 @@ void OpDispatchBuilder::AAAOp(OpcodeArgs) {
 void OpDispatchBuilder::AASOp(OpcodeArgs) {
   InvalidateDeferredFlags();
 
-  auto AF = GetRFLAG(FEXCore::X86State::RFLAG_AF_LOC);
+  auto AF = LoadAF();
   auto AL = LoadGPRRegister(X86State::REG_RAX, 1);
   auto AX = LoadGPRRegister(X86State::REG_RAX, 2);
   auto Cond = _Or(OpSize::i64Bit, AF, _Select(FEXCore::IR::COND_UGT, _And(OpSize::i64Bit, AL, _Constant(0xF)), _Constant(9), _Constant(1), _Constant(0)));

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -3435,7 +3435,7 @@ void OpDispatchBuilder::DAAOp(OpcodeArgs) {
   SetCurrentCodeBlock(FalseBlock);
   StartNewBlock();
   {
-    SetRFLAG<FEXCore::X86State::RFLAG_AF_LOC>(_Constant(0));
+    SetAF(0);
     _Jump(EndBlock);
   }
   SetCurrentCodeBlock(TrueBlock);
@@ -3450,7 +3450,7 @@ void OpDispatchBuilder::DAAOp(OpcodeArgs) {
     // The `NewCF` will be _Constant(0) stored aboved.
     // So Or(CF, _Constant(0)) ill mean CF gets updated to the old value in the true case?
     SetRFLAG<FEXCore::X86State::RFLAG_CF_LOC>(_Or(OpSize::i64Bit, CF, NewCF));
-    SetRFLAG<FEXCore::X86State::RFLAG_AF_LOC>(_Constant(1));
+    SetAF(1);
     CalculateDeferredFlags();
     _Jump(EndBlock);
   }
@@ -3509,7 +3509,7 @@ void OpDispatchBuilder::DASOp(OpcodeArgs) {
   SetCurrentCodeBlock(FalseBlock);
   StartNewBlock();
   {
-    SetRFLAG<FEXCore::X86State::RFLAG_AF_LOC>(_Constant(0));
+    SetAF(0);
     _Jump(EndBlock);
   }
   SetCurrentCodeBlock(TrueBlock);
@@ -3524,7 +3524,7 @@ void OpDispatchBuilder::DASOp(OpcodeArgs) {
     // The `NewCF` will be _Constant(0) stored aboved.
     // So Or(CF, _Constant(0)) ill mean CF gets updated to the old value in the true case?
     SetRFLAG<FEXCore::X86State::RFLAG_CF_LOC>(_Or(OpSize::i64Bit, CF, NewCF));
-    SetRFLAG<FEXCore::X86State::RFLAG_AF_LOC>(_Constant(1));
+    SetAF(1);
     CalculateDeferredFlags();
     _Jump(EndBlock);
   }
@@ -3581,7 +3581,7 @@ void OpDispatchBuilder::AAAOp(OpcodeArgs) {
     auto NewAX = _And(OpSize::i64Bit, AX, _Constant(0xFF0F));
     StoreGPRRegister(X86State::REG_RAX, NewAX, 2);
     SetRFLAG<FEXCore::X86State::RFLAG_CF_LOC>(_Constant(0));
-    SetRFLAG<FEXCore::X86State::RFLAG_AF_LOC>(_Constant(0));
+    SetAF(0);
     CalculateDeferredFlags();
     _Jump(EndBlock);
   }
@@ -3593,7 +3593,7 @@ void OpDispatchBuilder::AAAOp(OpcodeArgs) {
     auto Result = _And(OpSize::i64Bit, NewAX, _Constant(0xFF0F));
     StoreGPRRegister(X86State::REG_RAX, Result, 2);
     SetRFLAG<FEXCore::X86State::RFLAG_CF_LOC>(_Constant(1));
-    SetRFLAG<FEXCore::X86State::RFLAG_AF_LOC>(_Constant(1));
+    SetAF(1);
     CalculateDeferredFlags();
     _Jump(EndBlock);
   }
@@ -3620,7 +3620,7 @@ void OpDispatchBuilder::AASOp(OpcodeArgs) {
     auto NewAX = _And(OpSize::i64Bit, AX, _Constant(0xFF0F));
     StoreGPRRegister(X86State::REG_RAX, NewAX, 2);
     SetRFLAG<FEXCore::X86State::RFLAG_CF_LOC>(_Constant(0));
-    SetRFLAG<FEXCore::X86State::RFLAG_AF_LOC>(_Constant(0));
+    SetAF(0);
     CalculateDeferredFlags();
     _Jump(EndBlock);
   }
@@ -3632,7 +3632,7 @@ void OpDispatchBuilder::AASOp(OpcodeArgs) {
     auto Result = _And(OpSize::i64Bit, NewAX, _Constant(0xFF0F));
     StoreGPRRegister(X86State::REG_RAX, Result, 2);
     SetRFLAG<FEXCore::X86State::RFLAG_CF_LOC>(_Constant(1));
-    SetRFLAG<FEXCore::X86State::RFLAG_AF_LOC>(_Constant(1));
+    SetAF(1);
     CalculateDeferredFlags();
     _Jump(EndBlock);
   }

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -1376,6 +1376,7 @@ private:
   OrderedNode *LoadAF();
   void CalculatePFUncheckedABI(OrderedNode *Res, OrderedNode *condition = nullptr);
   void CalculatePF(OrderedNode *Res, OrderedNode *condition = nullptr);
+  void CalculateAF(OpSize OpSize, OrderedNode *Res, OrderedNode *Src1, OrderedNode *Src2);
 
   void CalculateOF_Add(uint8_t SrcSize, OrderedNode *Res, OrderedNode *Src1, OrderedNode *Src2);
   void CalculateFlags_ADC(uint8_t SrcSize, OrderedNode *Res, OrderedNode *Src1, OrderedNode *Src2, OrderedNode *CF);

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -1200,6 +1200,10 @@ private:
       _StoreFlag(Value, BitOffset);
   }
 
+  void SetAF(unsigned Constant) {
+    SetRFLAG<FEXCore::X86State::RFLAG_AF_LOC>(_Constant(Constant));
+  }
+
   void ZeroMultipleFlags(uint32_t BitMask);
 
   OrderedNode *GetRFLAG(unsigned BitOffset) {
@@ -1369,6 +1373,7 @@ private:
    * @name These functions are used by the deferred flag handling while it is calculating and storing flags in to RFLAGs.
    * @{ */
   OrderedNode *LoadPF();
+  OrderedNode *LoadAF();
   void CalculatePFUncheckedABI(OrderedNode *Res, OrderedNode *condition = nullptr);
   void CalculatePF(OrderedNode *Res, OrderedNode *condition = nullptr);
 

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -1201,7 +1201,11 @@ private:
   }
 
   void SetAF(unsigned Constant) {
-    SetRFLAG<FEXCore::X86State::RFLAG_AF_LOC>(_Constant(Constant));
+    // AF is stored in bit 4 of the AF flag byte, with garbage in the other
+    // bits. This allows us to defer the extract in the usual case. When it is
+    // read, bit 4 is extracted.  In order to write a constant value of AF, that
+    // means we need to left-shift here to compensate.
+    SetRFLAG<FEXCore::X86State::RFLAG_AF_LOC>(_Constant(Constant << 4));
   }
 
   void ZeroMultipleFlags(uint32_t BitMask);

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
@@ -230,6 +230,12 @@ void OpDispatchBuilder::CalculatePF(OrderedNode *Res, OrderedNode *condition) {
   }
 }
 
+void OpDispatchBuilder::CalculateAF(OpSize OpSize, OrderedNode *Res, OrderedNode *Src1, OrderedNode *Src2) {
+  OrderedNode *AFRes = _Xor(OpSize, _Xor(OpSize, Src1, Src2), Res);
+  AFRes = _Bfe(OpSize, 1, 4, AFRes);
+  SetRFLAG<FEXCore::X86State::RFLAG_AF_LOC>(AFRes);
+}
+
 void OpDispatchBuilder::CalculateDeferredFlags(uint32_t FlagsToCalculateMask) {
   if (CurrentDeferredFlags.Type == FlagsGenerationType::TYPE_NONE) {
     // Nothing to do
@@ -429,14 +435,9 @@ void OpDispatchBuilder::CalculateDeferredFlags(uint32_t FlagsToCalculateMask) {
 void OpDispatchBuilder::CalculateFlags_ADC(uint8_t SrcSize, OrderedNode *Res, OrderedNode *Src1, OrderedNode *Src2, OrderedNode *CF) {
   auto Zero = _Constant(0);
   auto One = _Constant(1);
-  // AF
-  {
-    auto OpSize = SrcSize == 8 ? OpSize::i64Bit : OpSize::i32Bit;
-    OrderedNode *AFRes = _Xor(OpSize, _Xor(OpSize, Src1, Src2), Res);
-    AFRes = _Bfe(OpSize, 1, 4, AFRes);
-    SetRFLAG<FEXCore::X86State::RFLAG_AF_LOC>(AFRes);
-  }
+  auto OpSize = SrcSize == 8 ? OpSize::i64Bit : OpSize::i32Bit;
 
+  CalculateAF(OpSize, Res, Src1, Src2);
   CalculatePF(Res);
 
   // SF/ZF
@@ -460,13 +461,7 @@ void OpDispatchBuilder::CalculateFlags_SBB(uint8_t SrcSize, OrderedNode *Res, Or
   auto One = _Constant(1);
   auto OpSize = SrcSize == 8 ? OpSize::i64Bit : OpSize::i32Bit;
 
-  // AF
-  {
-    OrderedNode *AFRes = _Xor(OpSize, _Xor(OpSize, Src1, Src2), Res);
-    AFRes = _Bfe(OpSize, 1, 4, AFRes);
-    SetRFLAG<FEXCore::X86State::RFLAG_AF_LOC>(AFRes);
-  }
-
+  CalculateAF(OpSize, Res, Src1, Src2);
   CalculatePF(Res);
 
   // SF/ZF
@@ -497,13 +492,7 @@ void OpDispatchBuilder::CalculateFlags_SUB(uint8_t SrcSize, OrderedNode *Res, Or
   auto One = _Constant(1);
   auto OpSize = SrcSize == 8 ? OpSize::i64Bit : OpSize::i32Bit;
 
-  // AF
-  {
-    OrderedNode *AFRes = _Xor(OpSize, _Xor(OpSize, Src1, Src2), Res);
-    AFRes = _Bfe(OpSize, 1, 4, AFRes);
-    SetRFLAG<FEXCore::X86State::RFLAG_AF_LOC>(AFRes);
-  }
-
+  CalculateAF(OpSize, Res, Src1, Src2);
   CalculatePF(Res);
 
   // Stash CF before stomping over it
@@ -546,13 +535,7 @@ void OpDispatchBuilder::CalculateFlags_ADD(uint8_t SrcSize, OrderedNode *Res, Or
   auto One = _Constant(1);
   auto OpSize = SrcSize == 8 ? OpSize::i64Bit : OpSize::i32Bit;
 
-  // AF
-  {
-    OrderedNode *AFRes = _Xor(OpSize, _Xor(OpSize, Src1, Src2), Res);
-    AFRes = _Bfe(OpSize, 1, 4, AFRes);
-    SetRFLAG<FEXCore::X86State::RFLAG_AF_LOC>(AFRes);
-  }
-
+  CalculateAF(OpSize, Res, Src1, Src2);
   CalculatePF(Res);
 
   // Stash CF before stomping over it

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
@@ -193,6 +193,13 @@ OrderedNode *OpDispatchBuilder::LoadPF() {
   return _And(OpSize::i64Bit, _Constant(1), Parity);
 }
 
+OrderedNode *OpDispatchBuilder::LoadAF() {
+  // Read the stored byte.
+  auto AFByte = GetRFLAG(FEXCore::X86State::RFLAG_AF_LOC);
+
+  return AFByte;
+}
+
 void OpDispatchBuilder::CalculatePFUncheckedABI(OrderedNode *Res, OrderedNode *condition) {
   // We will use the bottom bit of the popcount, set if an odd number of bits are set.
   // But the x86 parity flag is supposed to be set for an even number of bits.

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
@@ -587,7 +587,7 @@ void OpDispatchBuilder::CalculateFlags_MUL(uint8_t SrcSize, OrderedNode *Res, Or
   // Undefined
   {
     SetRFLAG<FEXCore::X86State::RFLAG_PF_LOC>(Zero);
-    SetRFLAG<FEXCore::X86State::RFLAG_AF_LOC>(Zero);
+    SetAF(0);
   }
 
   // CF/OF
@@ -611,7 +611,7 @@ void OpDispatchBuilder::CalculateFlags_UMUL(OrderedNode *High) {
   // AF/SF/PF/ZF
   // Undefined
   {
-    SetRFLAG<FEXCore::X86State::RFLAG_AF_LOC>(Zero);
+    SetAF(0);
     SetRFLAG<FEXCore::X86State::RFLAG_PF_LOC>(Zero);
   }
 
@@ -628,12 +628,11 @@ void OpDispatchBuilder::CalculateFlags_UMUL(OrderedNode *High) {
 }
 
 void OpDispatchBuilder::CalculateFlags_Logical(uint8_t SrcSize, OrderedNode *Res, OrderedNode *Src1, OrderedNode *Src2) {
-  auto Zero = _Constant(0);
   // AF
   {
     // Undefined
     // Set to zero anyway
-    SetRFLAG<FEXCore::X86State::RFLAG_AF_LOC>(Zero);
+    SetAF(0);
   }
 
   CalculatePF(Res);
@@ -749,7 +748,6 @@ void OpDispatchBuilder::CalculateFlags_ShiftLeftImmediate(uint8_t SrcSize, Order
   // No flags changed if shift is zero
   if (Shift == 0) return;
 
-  auto Zero = _Constant(0);
   auto OpSize = SrcSize == 8 ? OpSize::i64Bit : OpSize::i32Bit;
 
   SetNZ_ZeroCV(SrcSize, Res);
@@ -770,7 +768,7 @@ void OpDispatchBuilder::CalculateFlags_ShiftLeftImmediate(uint8_t SrcSize, Order
   {
     // Undefined
     // Set to zero anyway
-    SetRFLAG<FEXCore::X86State::RFLAG_AF_LOC>(Zero);
+    SetAF(0);
   }
 
   // OF
@@ -788,8 +786,6 @@ void OpDispatchBuilder::CalculateFlags_SignShiftRightImmediate(uint8_t SrcSize, 
   // No flags changed if shift is zero
   if (Shift == 0) return;
 
-  auto Zero = _Constant(0);
-
   SetNZ_ZeroCV(SrcSize, Res);
 
   // CF
@@ -804,7 +800,7 @@ void OpDispatchBuilder::CalculateFlags_SignShiftRightImmediate(uint8_t SrcSize, 
   {
     // Undefined
     // Set to zero anyway
-    SetRFLAG<FEXCore::X86State::RFLAG_AF_LOC>(Zero);
+    SetAF(0);
   }
 
   // OF
@@ -815,7 +811,6 @@ void OpDispatchBuilder::CalculateFlags_SignShiftRightImmediate(uint8_t SrcSize, 
 
 void OpDispatchBuilder::CalculateFlags_ShiftRightImmediateCommon(uint8_t SrcSize, OrderedNode *Res, OrderedNode *Src1, uint64_t Shift) {
   const auto OpSize = SrcSize == 8 ? OpSize::i64Bit : OpSize::i32Bit;
-  auto Zero = _Constant(0);
 
   // Stash OF before overwriting it
   auto OldOF = Shift != 1 ? GetRFLAG(FEXCore::X86State::RFLAG_OF_LOC) : NULL;
@@ -833,7 +828,7 @@ void OpDispatchBuilder::CalculateFlags_ShiftRightImmediateCommon(uint8_t SrcSize
   {
     // Undefined
     // Set to zero anyway
-    SetRFLAG<FEXCore::X86State::RFLAG_AF_LOC>(Zero);
+    SetAF(0);
   }
 
   // Preserve OF if it won't be written

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -3992,7 +3992,7 @@ void OpDispatchBuilder::PTestOp(OpcodeArgs) {
   SetRFLAG<FEXCore::X86State::RFLAG_ZF_LOC>(Test1);
   SetRFLAG<FEXCore::X86State::RFLAG_CF_LOC>(Test2);
 
-  SetRFLAG<FEXCore::X86State::RFLAG_AF_LOC>(ZeroConst);
+  SetAF(0);
   SetRFLAG<FEXCore::X86State::RFLAG_SF_LOC>(ZeroConst);
   SetRFLAG<FEXCore::X86State::RFLAG_OF_LOC>(ZeroConst);
   SetRFLAG<FEXCore::X86State::RFLAG_PF_LOC>(ZeroConst);
@@ -4036,7 +4036,7 @@ void OpDispatchBuilder::VTESTOpImpl(OpcodeArgs, size_t ElementSize) {
   SetRFLAG<X86State::RFLAG_ZF_LOC>(ZFResult);
   SetRFLAG<X86State::RFLAG_CF_LOC>(CFResult);
 
-  SetRFLAG<X86State::RFLAG_AF_LOC>(ZeroConst);
+  SetAF(0);
   SetRFLAG<X86State::RFLAG_SF_LOC>(ZeroConst);
   SetRFLAG<X86State::RFLAG_OF_LOC>(ZeroConst);
   SetRFLAG<X86State::RFLAG_PF_LOC>(ZeroConst);
@@ -4759,7 +4759,7 @@ void OpDispatchBuilder::PCMPXSTRXOpImpl(OpcodeArgs, bool IsExplicit, bool IsMask
   SetRFLAG<X86State::RFLAG_CF_LOC>(GetFlagBit(18));
   SetRFLAG<X86State::RFLAG_OF_LOC>(GetFlagBit(19));
 
-  SetRFLAG<X86State::RFLAG_AF_LOC>(ZeroConst);
+  SetAF(0);
   SetRFLAG<X86State::RFLAG_PF_LOC>(ZeroConst);
 }
 

--- a/unittests/InstructionCountCI/Primary.json
+++ b/unittests/InstructionCountCI/Primary.json
@@ -9,7 +9,7 @@
   },
   "Instructions": {
     "add bl, cl": {
-      "ExpectedInstructionCount": "25",
+      "ExpectedInstructionCount": 24,
       "Optimal": "No",
       "Comment": "0x00",
       "ExpectedArm64ASM": [
@@ -20,7 +20,6 @@
         "uxtb w22, w22",
         "eor w23, w21, w20",
         "eor w23, w23, w22",
-        "ubfx w23, w23, #4, #1",
         "strb w23, [x28, #708]",
         "eor x23, x22, #0x1",
         "strb w23, [x28, #706]",
@@ -41,7 +40,7 @@
       ]
     },
     "add bx, cx": {
-      "ExpectedInstructionCount": "25",
+      "ExpectedInstructionCount": 24,
       "Optimal": "No",
       "Comment": "0x01",
       "ExpectedArm64ASM": [
@@ -52,7 +51,6 @@
         "uxth w22, w22",
         "eor w23, w21, w20",
         "eor w23, w23, w22",
-        "ubfx w23, w23, #4, #1",
         "strb w23, [x28, #708]",
         "eor x23, x22, #0x1",
         "strb w23, [x28, #706]",
@@ -73,7 +71,7 @@
       ]
     },
     "add ebx, ecx": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 11,
       "Optimal": "No",
       "Comment": "0x01",
       "ExpectedArm64ASM": [
@@ -82,7 +80,6 @@
         "add w7, w21, w20",
         "eor w22, w21, w20",
         "eor w22, w22, w7",
-        "ubfx w22, w22, #4, #1",
         "strb w22, [x28, #708]",
         "eor x22, x7, #0x1",
         "strb w22, [x28, #706]",
@@ -92,7 +89,7 @@
       ]
     },
     "add rbx, rcx": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Optimal": "No",
       "Comment": "0x01",
       "ExpectedArm64ASM": [
@@ -100,7 +97,6 @@
         "add x7, x20, x5",
         "eor x21, x20, x5",
         "eor x21, x21, x7",
-        "ubfx x21, x21, #4, #1",
         "strb w21, [x28, #708]",
         "eor x21, x7, #0x1",
         "strb w21, [x28, #706]",
@@ -110,7 +106,7 @@
       ]
     },
     "db 0x02, 0xcb": {
-      "ExpectedInstructionCount": "25",
+      "ExpectedInstructionCount": 24,
       "Optimal": "No",
       "Comment": [
         "0x02",
@@ -124,7 +120,6 @@
         "uxtb w22, w22",
         "eor w23, w21, w20",
         "eor w23, w23, w22",
-        "ubfx w23, w23, #4, #1",
         "strb w23, [x28, #708]",
         "eor x23, x22, #0x1",
         "strb w23, [x28, #706]",
@@ -145,7 +140,7 @@
       ]
     },
     "db 0x66, 0x03, 0xcb": {
-      "ExpectedInstructionCount": "25",
+      "ExpectedInstructionCount": 24,
       "Optimal": "No",
       "Comment": [
         "0x03",
@@ -159,7 +154,6 @@
         "uxth w22, w22",
         "eor w23, w21, w20",
         "eor w23, w23, w22",
-        "ubfx w23, w23, #4, #1",
         "strb w23, [x28, #708]",
         "eor x23, x22, #0x1",
         "strb w23, [x28, #706]",
@@ -180,7 +174,7 @@
       ]
     },
     "db 0x03, 0xcb": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 11,
       "Optimal": "No",
       "Comment": [
         "0x03",
@@ -192,7 +186,6 @@
         "add w5, w21, w20",
         "eor w22, w21, w20",
         "eor w22, w22, w5",
-        "ubfx w22, w22, #4, #1",
         "strb w22, [x28, #708]",
         "eor x22, x5, #0x1",
         "strb w22, [x28, #706]",
@@ -202,7 +195,7 @@
       ]
     },
     "db 0x48, 0x03, 0xcb": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Optimal": "No",
       "Comment": [
         "0x03",
@@ -213,7 +206,6 @@
         "add x5, x20, x7",
         "eor x21, x20, x7",
         "eor x21, x21, x5",
-        "ubfx x21, x21, #4, #1",
         "strb w21, [x28, #708]",
         "eor x21, x5, #0x1",
         "strb w21, [x28, #706]",
@@ -223,7 +215,7 @@
       ]
     },
     "add al, 1": {
-      "ExpectedInstructionCount": "24",
+      "ExpectedInstructionCount": 23,
       "Optimal": "No",
       "Comment": "0x04",
       "ExpectedArm64ASM": [
@@ -233,7 +225,6 @@
         "uxtb w21, w21",
         "eor w22, w20, #0x1",
         "eor w22, w22, w21",
-        "ubfx w22, w22, #4, #1",
         "strb w22, [x28, #708]",
         "eor x22, x21, #0x1",
         "strb w22, [x28, #706]",
@@ -254,7 +245,7 @@
       ]
     },
     "add ax, 1": {
-      "ExpectedInstructionCount": "24",
+      "ExpectedInstructionCount": 23,
       "Optimal": "No",
       "Comment": "0x05",
       "ExpectedArm64ASM": [
@@ -264,7 +255,6 @@
         "uxth w21, w21",
         "eor w22, w20, #0x1",
         "eor w22, w22, w21",
-        "ubfx w22, w22, #4, #1",
         "strb w22, [x28, #708]",
         "eor x22, x21, #0x1",
         "strb w22, [x28, #706]",
@@ -285,7 +275,7 @@
       ]
     },
     "add eax, 1": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Optimal": "No",
       "Comment": "0x05",
       "ExpectedArm64ASM": [
@@ -293,7 +283,6 @@
         "add w4, w20, #0x1 (1)",
         "eor w21, w20, #0x1",
         "eor w21, w21, w4",
-        "ubfx w21, w21, #4, #1",
         "strb w21, [x28, #708]",
         "eor x21, x4, #0x1",
         "strb w21, [x28, #706]",
@@ -303,7 +292,7 @@
       ]
     },
     "add rax, 1": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Optimal": "No",
       "Comment": "0x05",
       "ExpectedArm64ASM": [
@@ -311,7 +300,6 @@
         "add x4, x20, #0x1 (1)",
         "eor x21, x20, #0x1",
         "eor x21, x21, x4",
-        "ubfx x21, x21, #4, #1",
         "strb w21, [x28, #708]",
         "eor x21, x4, #0x1",
         "strb w21, [x28, #706]",
@@ -552,7 +540,7 @@
       ]
     },
     "adc bl, cl": {
-      "ExpectedInstructionCount": "32",
+      "ExpectedInstructionCount": 31,
       "Optimal": "No",
       "Comment": "0x10",
       "ExpectedArm64ASM": [
@@ -566,7 +554,6 @@
         "uxtb w22, w22",
         "eor w24, w23, w20",
         "eor w24, w24, w22",
-        "ubfx w24, w24, #4, #1",
         "strb w24, [x28, #708]",
         "eor x24, x22, #0x1",
         "strb w24, [x28, #706]",
@@ -591,7 +578,7 @@
       ]
     },
     "adc bx, cx": {
-      "ExpectedInstructionCount": "32",
+      "ExpectedInstructionCount": 31,
       "Optimal": "No",
       "Comment": "0x11",
       "ExpectedArm64ASM": [
@@ -605,7 +592,6 @@
         "uxth w22, w22",
         "eor w24, w23, w20",
         "eor w24, w24, w22",
-        "ubfx w24, w24, #4, #1",
         "strb w24, [x28, #708]",
         "eor x24, x22, #0x1",
         "strb w24, [x28, #706]",
@@ -630,7 +616,7 @@
       ]
     },
     "adc ebx, ecx": {
-      "ExpectedInstructionCount": "27",
+      "ExpectedInstructionCount": 26,
       "Optimal": "No",
       "Comment": "0x11",
       "ExpectedArm64ASM": [
@@ -642,7 +628,6 @@
         "add w7, w23, w22",
         "eor w22, w23, w20",
         "eor w22, w22, w7",
-        "ubfx w22, w22, #4, #1",
         "strb w22, [x28, #708]",
         "eor x22, x7, #0x1",
         "strb w22, [x28, #706]",
@@ -664,7 +649,7 @@
       ]
     },
     "adc rbx, rcx": {
-      "ExpectedInstructionCount": "26",
+      "ExpectedInstructionCount": 25,
       "Optimal": "No",
       "Comment": "0x11",
       "ExpectedArm64ASM": [
@@ -675,7 +660,6 @@
         "add x7, x22, x21",
         "eor x21, x22, x5",
         "eor x21, x21, x7",
-        "ubfx x21, x21, #4, #1",
         "strb w21, [x28, #708]",
         "eor x21, x7, #0x1",
         "strb w21, [x28, #706]",
@@ -697,7 +681,7 @@
       ]
     },
     "db 0x12, 0xcb": {
-      "ExpectedInstructionCount": "32",
+      "ExpectedInstructionCount": 31,
       "Optimal": "No",
       "Comment": [
         "0x12",
@@ -714,7 +698,6 @@
         "uxtb w22, w22",
         "eor w24, w23, w20",
         "eor w24, w24, w22",
-        "ubfx w24, w24, #4, #1",
         "strb w24, [x28, #708]",
         "eor x24, x22, #0x1",
         "strb w24, [x28, #706]",
@@ -739,7 +722,7 @@
       ]
     },
     "db 0x66, 0x13, 0xcb": {
-      "ExpectedInstructionCount": "32",
+      "ExpectedInstructionCount": 31,
       "Optimal": "No",
       "Comment": [
         "0x13",
@@ -756,7 +739,6 @@
         "uxth w22, w22",
         "eor w24, w23, w20",
         "eor w24, w24, w22",
-        "ubfx w24, w24, #4, #1",
         "strb w24, [x28, #708]",
         "eor x24, x22, #0x1",
         "strb w24, [x28, #706]",
@@ -781,7 +763,7 @@
       ]
     },
     "db 0x13, 0xcb": {
-      "ExpectedInstructionCount": "27",
+      "ExpectedInstructionCount": 26,
       "Optimal": "No",
       "Comment": [
         "0x13",
@@ -796,7 +778,6 @@
         "add w5, w23, w22",
         "eor w22, w23, w20",
         "eor w22, w22, w5",
-        "ubfx w22, w22, #4, #1",
         "strb w22, [x28, #708]",
         "eor x22, x5, #0x1",
         "strb w22, [x28, #706]",
@@ -818,7 +799,7 @@
       ]
     },
     "db 0x48, 0x13, 0xcb": {
-      "ExpectedInstructionCount": "26",
+      "ExpectedInstructionCount": 25,
       "Optimal": "No",
       "Comment": [
         "0x13",
@@ -832,7 +813,6 @@
         "add x5, x22, x21",
         "eor x21, x22, x7",
         "eor x21, x21, x5",
-        "ubfx x21, x21, #4, #1",
         "strb w21, [x28, #708]",
         "eor x21, x5, #0x1",
         "strb w21, [x28, #706]",
@@ -854,7 +834,7 @@
       ]
     },
     "adc al, 1": {
-      "ExpectedInstructionCount": "32",
+      "ExpectedInstructionCount": 31,
       "Optimal": "No",
       "Comment": "0x14",
       "ExpectedArm64ASM": [
@@ -868,7 +848,6 @@
         "uxtb w20, w20",
         "eor w23, w22, #0x1",
         "eor w23, w23, w20",
-        "ubfx w23, w23, #4, #1",
         "strb w23, [x28, #708]",
         "eor x23, x20, #0x1",
         "strb w23, [x28, #706]",
@@ -893,7 +872,7 @@
       ]
     },
     "adc ax, 1": {
-      "ExpectedInstructionCount": "32",
+      "ExpectedInstructionCount": 31,
       "Optimal": "No",
       "Comment": "0x15",
       "ExpectedArm64ASM": [
@@ -907,7 +886,6 @@
         "uxth w20, w20",
         "eor w23, w22, #0x1",
         "eor w23, w23, w20",
-        "ubfx w23, w23, #4, #1",
         "strb w23, [x28, #708]",
         "eor x23, x20, #0x1",
         "strb w23, [x28, #706]",
@@ -932,7 +910,7 @@
       ]
     },
     "adc eax, 1": {
-      "ExpectedInstructionCount": "27",
+      "ExpectedInstructionCount": 26,
       "Optimal": "No",
       "Comment": "0x15",
       "ExpectedArm64ASM": [
@@ -944,7 +922,6 @@
         "add w4, w22, w20",
         "eor w20, w22, #0x1",
         "eor w20, w20, w4",
-        "ubfx w20, w20, #4, #1",
         "strb w20, [x28, #708]",
         "eor x20, x4, #0x1",
         "strb w20, [x28, #706]",
@@ -966,7 +943,7 @@
       ]
     },
     "adc rax, 1": {
-      "ExpectedInstructionCount": "27",
+      "ExpectedInstructionCount": 26,
       "Optimal": "No",
       "Comment": "0x15",
       "ExpectedArm64ASM": [
@@ -978,7 +955,6 @@
         "add x4, x22, x20",
         "eor x20, x22, #0x1",
         "eor x20, x20, x4",
-        "ubfx x20, x20, #4, #1",
         "strb w20, [x28, #708]",
         "eor x20, x4, #0x1",
         "strb w20, [x28, #706]",
@@ -1000,7 +976,7 @@
       ]
     },
     "sbb bl, cl": {
-      "ExpectedInstructionCount": "32",
+      "ExpectedInstructionCount": 31,
       "Optimal": "No",
       "Comment": "0x18",
       "ExpectedArm64ASM": [
@@ -1014,7 +990,6 @@
         "uxtb w22, w22",
         "eor w24, w23, w20",
         "eor w24, w24, w22",
-        "ubfx w24, w24, #4, #1",
         "strb w24, [x28, #708]",
         "eor x24, x22, #0x1",
         "strb w24, [x28, #706]",
@@ -1039,7 +1014,7 @@
       ]
     },
     "sbb bx, cx": {
-      "ExpectedInstructionCount": "32",
+      "ExpectedInstructionCount": 31,
       "Optimal": "No",
       "Comment": "0x19",
       "ExpectedArm64ASM": [
@@ -1053,7 +1028,6 @@
         "uxth w22, w22",
         "eor w24, w23, w20",
         "eor w24, w24, w22",
-        "ubfx w24, w24, #4, #1",
         "strb w24, [x28, #708]",
         "eor x24, x22, #0x1",
         "strb w24, [x28, #706]",
@@ -1078,7 +1052,7 @@
       ]
     },
     "sbb ebx, ecx": {
-      "ExpectedInstructionCount": "27",
+      "ExpectedInstructionCount": 26,
       "Optimal": "No",
       "Comment": "0x19",
       "ExpectedArm64ASM": [
@@ -1090,7 +1064,6 @@
         "sub w7, w23, w22",
         "eor w22, w23, w20",
         "eor w22, w22, w7",
-        "ubfx w22, w22, #4, #1",
         "strb w22, [x28, #708]",
         "eor x22, x7, #0x1",
         "strb w22, [x28, #706]",
@@ -1112,7 +1085,7 @@
       ]
     },
     "sbb rbx, rcx": {
-      "ExpectedInstructionCount": "26",
+      "ExpectedInstructionCount": 25,
       "Optimal": "No",
       "Comment": "0x19",
       "ExpectedArm64ASM": [
@@ -1123,7 +1096,6 @@
         "sub x7, x22, x21",
         "eor x21, x22, x5",
         "eor x21, x21, x7",
-        "ubfx x21, x21, #4, #1",
         "strb w21, [x28, #708]",
         "eor x21, x7, #0x1",
         "strb w21, [x28, #706]",
@@ -1145,7 +1117,7 @@
       ]
     },
     "db 0x1A, 0xcb": {
-      "ExpectedInstructionCount": "32",
+      "ExpectedInstructionCount": 31,
       "Optimal": "No",
       "Comment": [
         "0x1A",
@@ -1162,7 +1134,6 @@
         "uxtb w22, w22",
         "eor w24, w23, w20",
         "eor w24, w24, w22",
-        "ubfx w24, w24, #4, #1",
         "strb w24, [x28, #708]",
         "eor x24, x22, #0x1",
         "strb w24, [x28, #706]",
@@ -1187,7 +1158,7 @@
       ]
     },
     "db 0x66, 0x1B, 0xcb": {
-      "ExpectedInstructionCount": "32",
+      "ExpectedInstructionCount": 31,
       "Optimal": "No",
       "Comment": [
         "0x1B",
@@ -1204,7 +1175,6 @@
         "uxth w22, w22",
         "eor w24, w23, w20",
         "eor w24, w24, w22",
-        "ubfx w24, w24, #4, #1",
         "strb w24, [x28, #708]",
         "eor x24, x22, #0x1",
         "strb w24, [x28, #706]",
@@ -1229,7 +1199,7 @@
       ]
     },
     "db 0x1B, 0xcb": {
-      "ExpectedInstructionCount": "27",
+      "ExpectedInstructionCount": 26,
       "Optimal": "No",
       "Comment": [
         "0x1B",
@@ -1244,7 +1214,6 @@
         "sub w5, w23, w22",
         "eor w22, w23, w20",
         "eor w22, w22, w5",
-        "ubfx w22, w22, #4, #1",
         "strb w22, [x28, #708]",
         "eor x22, x5, #0x1",
         "strb w22, [x28, #706]",
@@ -1266,7 +1235,7 @@
       ]
     },
     "db 0x48, 0x1B, 0xcb": {
-      "ExpectedInstructionCount": "26",
+      "ExpectedInstructionCount": 25,
       "Optimal": "No",
       "Comment": [
         "0x1B",
@@ -1280,7 +1249,6 @@
         "sub x5, x22, x21",
         "eor x21, x22, x7",
         "eor x21, x21, x5",
-        "ubfx x21, x21, #4, #1",
         "strb w21, [x28, #708]",
         "eor x21, x5, #0x1",
         "strb w21, [x28, #706]",
@@ -1302,7 +1270,7 @@
       ]
     },
     "sbb al, 1": {
-      "ExpectedInstructionCount": "32",
+      "ExpectedInstructionCount": 31,
       "Optimal": "No",
       "Comment": "0x1C",
       "ExpectedArm64ASM": [
@@ -1316,7 +1284,6 @@
         "uxtb w20, w20",
         "eor w23, w22, #0x1",
         "eor w23, w23, w20",
-        "ubfx w23, w23, #4, #1",
         "strb w23, [x28, #708]",
         "eor x23, x20, #0x1",
         "strb w23, [x28, #706]",
@@ -1341,7 +1308,7 @@
       ]
     },
     "sbb ax, 1": {
-      "ExpectedInstructionCount": "32",
+      "ExpectedInstructionCount": 31,
       "Optimal": "No",
       "Comment": "0x1D",
       "ExpectedArm64ASM": [
@@ -1355,7 +1322,6 @@
         "uxth w20, w20",
         "eor w23, w22, #0x1",
         "eor w23, w23, w20",
-        "ubfx w23, w23, #4, #1",
         "strb w23, [x28, #708]",
         "eor x23, x20, #0x1",
         "strb w23, [x28, #706]",
@@ -1380,7 +1346,7 @@
       ]
     },
     "sbb eax, 1": {
-      "ExpectedInstructionCount": "27",
+      "ExpectedInstructionCount": 26,
       "Optimal": "No",
       "Comment": "0x1D",
       "ExpectedArm64ASM": [
@@ -1392,7 +1358,6 @@
         "sub w4, w22, w20",
         "eor w20, w22, #0x1",
         "eor w20, w20, w4",
-        "ubfx w20, w20, #4, #1",
         "strb w20, [x28, #708]",
         "eor x20, x4, #0x1",
         "strb w20, [x28, #706]",
@@ -1414,7 +1379,7 @@
       ]
     },
     "sbb rax, 1": {
-      "ExpectedInstructionCount": "27",
+      "ExpectedInstructionCount": 26,
       "Optimal": "No",
       "Comment": "0x1D",
       "ExpectedArm64ASM": [
@@ -1426,7 +1391,6 @@
         "sub x4, x22, x20",
         "eor x20, x22, #0x1",
         "eor x20, x20, x4",
-        "ubfx x20, x20, #4, #1",
         "strb w20, [x28, #708]",
         "eor x20, x4, #0x1",
         "strb w20, [x28, #706]",
@@ -1679,7 +1643,7 @@
       ]
     },
     "sub bl, cl": {
-      "ExpectedInstructionCount": "25",
+      "ExpectedInstructionCount": 24,
       "Optimal": "No",
       "Comment": "0x28",
       "ExpectedArm64ASM": [
@@ -1690,7 +1654,6 @@
         "uxtb w22, w22",
         "eor w23, w21, w20",
         "eor w23, w23, w22",
-        "ubfx w23, w23, #4, #1",
         "strb w23, [x28, #708]",
         "eor x23, x22, #0x1",
         "strb w23, [x28, #706]",
@@ -1711,7 +1674,7 @@
       ]
     },
     "sub bx, cx": {
-      "ExpectedInstructionCount": "25",
+      "ExpectedInstructionCount": 24,
       "Optimal": "No",
       "Comment": "0x29",
       "ExpectedArm64ASM": [
@@ -1722,7 +1685,6 @@
         "uxth w22, w22",
         "eor w23, w21, w20",
         "eor w23, w23, w22",
-        "ubfx w23, w23, #4, #1",
         "strb w23, [x28, #708]",
         "eor x23, x22, #0x1",
         "strb w23, [x28, #706]",
@@ -1743,7 +1705,7 @@
       ]
     },
     "sub ebx, ecx": {
-      "ExpectedInstructionCount": 13,
+      "ExpectedInstructionCount": 12,
       "Optimal": "No",
       "Comment": "0x29",
       "ExpectedArm64ASM": [
@@ -1752,7 +1714,6 @@
         "sub w7, w21, w20",
         "eor w22, w21, w20",
         "eor w22, w22, w7",
-        "ubfx w22, w22, #4, #1",
         "strb w22, [x28, #708]",
         "eor x22, x7, #0x1",
         "strb w22, [x28, #706]",
@@ -1763,7 +1724,7 @@
       ]
     },
     "sub rbx, rcx": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 11,
       "Optimal": "No",
       "Comment": "0x29",
       "ExpectedArm64ASM": [
@@ -1771,7 +1732,6 @@
         "sub x7, x20, x5",
         "eor x21, x20, x5",
         "eor x21, x21, x7",
-        "ubfx x21, x21, #4, #1",
         "strb w21, [x28, #708]",
         "eor x21, x7, #0x1",
         "strb w21, [x28, #706]",
@@ -1782,7 +1742,7 @@
       ]
     },
     "db 0x2A, 0xcb": {
-      "ExpectedInstructionCount": "25",
+      "ExpectedInstructionCount": 24,
       "Optimal": "No",
       "Comment": [
         "0x2A",
@@ -1796,7 +1756,6 @@
         "uxtb w22, w22",
         "eor w23, w21, w20",
         "eor w23, w23, w22",
-        "ubfx w23, w23, #4, #1",
         "strb w23, [x28, #708]",
         "eor x23, x22, #0x1",
         "strb w23, [x28, #706]",
@@ -1817,7 +1776,7 @@
       ]
     },
     "db 0x66, 0x2B, 0xcb": {
-      "ExpectedInstructionCount": "25",
+      "ExpectedInstructionCount": 24,
       "Optimal": "No",
       "Comment": [
         "0x2B",
@@ -1831,7 +1790,6 @@
         "uxth w22, w22",
         "eor w23, w21, w20",
         "eor w23, w23, w22",
-        "ubfx w23, w23, #4, #1",
         "strb w23, [x28, #708]",
         "eor x23, x22, #0x1",
         "strb w23, [x28, #706]",
@@ -1852,7 +1810,7 @@
       ]
     },
     "db 0x2B, 0xcb": {
-      "ExpectedInstructionCount": 13,
+      "ExpectedInstructionCount": 12,
       "Optimal": "No",
       "Comment": [
         "0x2B",
@@ -1864,7 +1822,6 @@
         "sub w5, w21, w20",
         "eor w22, w21, w20",
         "eor w22, w22, w5",
-        "ubfx w22, w22, #4, #1",
         "strb w22, [x28, #708]",
         "eor x22, x5, #0x1",
         "strb w22, [x28, #706]",
@@ -1875,7 +1832,7 @@
       ]
     },
     "db 0x48, 0x2B, 0xcb": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 11,
       "Optimal": "No",
       "Comment": [
         "0x2B",
@@ -1886,7 +1843,6 @@
         "sub x5, x20, x7",
         "eor x21, x20, x7",
         "eor x21, x21, x5",
-        "ubfx x21, x21, #4, #1",
         "strb w21, [x28, #708]",
         "eor x21, x5, #0x1",
         "strb w21, [x28, #706]",
@@ -1897,7 +1853,7 @@
       ]
     },
     "sub al, 1": {
-      "ExpectedInstructionCount": "24",
+      "ExpectedInstructionCount": 23,
       "Optimal": "No",
       "Comment": "0x2C",
       "ExpectedArm64ASM": [
@@ -1907,7 +1863,6 @@
         "uxtb w21, w21",
         "eor w22, w20, #0x1",
         "eor w22, w22, w21",
-        "ubfx w22, w22, #4, #1",
         "strb w22, [x28, #708]",
         "eor x22, x21, #0x1",
         "strb w22, [x28, #706]",
@@ -1928,7 +1883,7 @@
       ]
     },
     "sub ax, 1": {
-      "ExpectedInstructionCount": "24",
+      "ExpectedInstructionCount": 23,
       "Optimal": "No",
       "Comment": "0x2D",
       "ExpectedArm64ASM": [
@@ -1938,7 +1893,6 @@
         "uxth w21, w21",
         "eor w22, w20, #0x1",
         "eor w22, w22, w21",
-        "ubfx w22, w22, #4, #1",
         "strb w22, [x28, #708]",
         "eor x22, x21, #0x1",
         "strb w22, [x28, #706]",
@@ -1959,7 +1913,7 @@
       ]
     },
     "sub eax, 1": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 11,
       "Optimal": "No",
       "Comment": "0x2D",
       "ExpectedArm64ASM": [
@@ -1967,7 +1921,6 @@
         "sub w4, w20, #0x1 (1)",
         "eor w21, w20, #0x1",
         "eor w21, w21, w4",
-        "ubfx w21, w21, #4, #1",
         "strb w21, [x28, #708]",
         "eor x21, x4, #0x1",
         "strb w21, [x28, #706]",
@@ -1978,7 +1931,7 @@
       ]
     },
     "sub rax, 1": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 11,
       "Optimal": "No",
       "Comment": "0x2D",
       "ExpectedArm64ASM": [
@@ -1986,7 +1939,6 @@
         "sub x4, x20, #0x1 (1)",
         "eor x21, x20, #0x1",
         "eor x21, x21, x4",
-        "ubfx x21, x21, #4, #1",
         "strb w21, [x28, #708]",
         "eor x21, x4, #0x1",
         "strb w21, [x28, #706]",
@@ -2228,7 +2180,7 @@
       ]
     },
     "cmp bl, cl": {
-      "ExpectedInstructionCount": 24,
+      "ExpectedInstructionCount": 23,
       "Optimal": "No",
       "Comment": "0x38",
       "ExpectedArm64ASM": [
@@ -2238,7 +2190,6 @@
         "uxtb w22, w22",
         "eor w23, w21, w20",
         "eor w23, w23, w22",
-        "ubfx w23, w23, #4, #1",
         "strb w23, [x28, #708]",
         "eor x23, x22, #0x1",
         "strb w23, [x28, #706]",
@@ -2259,7 +2210,7 @@
       ]
     },
     "cmp bx, cx": {
-      "ExpectedInstructionCount": 24,
+      "ExpectedInstructionCount": 23,
       "Optimal": "No",
       "Comment": "0x39",
       "ExpectedArm64ASM": [
@@ -2269,7 +2220,6 @@
         "uxth w22, w22",
         "eor w23, w21, w20",
         "eor w23, w23, w22",
-        "ubfx w23, w23, #4, #1",
         "strb w23, [x28, #708]",
         "eor x23, x22, #0x1",
         "strb w23, [x28, #706]",
@@ -2290,7 +2240,7 @@
       ]
     },
     "cmp ebx, ecx": {
-      "ExpectedInstructionCount": 13,
+      "ExpectedInstructionCount": 12,
       "Optimal": "No",
       "Comment": "0x39",
       "ExpectedArm64ASM": [
@@ -2299,7 +2249,6 @@
         "sub w22, w21, w20",
         "eor w23, w21, w20",
         "eor w23, w23, w22",
-        "ubfx w23, w23, #4, #1",
         "strb w23, [x28, #708]",
         "eor x22, x22, #0x1",
         "strb w22, [x28, #706]",
@@ -2310,14 +2259,13 @@
       ]
     },
     "cmp rbx, rcx": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Optimal": "Yes",
       "Comment": "0x39",
       "ExpectedArm64ASM": [
         "sub x20, x7, x5",
         "eor x21, x7, x5",
         "eor x21, x21, x20",
-        "ubfx x21, x21, #4, #1",
         "strb w21, [x28, #708]",
         "eor x20, x20, #0x1",
         "strb w20, [x28, #706]",
@@ -2328,7 +2276,7 @@
       ]
     },
     "db 0x3A, 0xcb": {
-      "ExpectedInstructionCount": 24,
+      "ExpectedInstructionCount": 23,
       "Optimal": "No",
       "Comment": [
         "0x3A",
@@ -2341,7 +2289,6 @@
         "uxtb w22, w22",
         "eor w23, w21, w20",
         "eor w23, w23, w22",
-        "ubfx w23, w23, #4, #1",
         "strb w23, [x28, #708]",
         "eor x23, x22, #0x1",
         "strb w23, [x28, #706]",
@@ -2362,7 +2309,7 @@
       ]
     },
     "db 0x66, 0x3B, 0xcb": {
-      "ExpectedInstructionCount": 24,
+      "ExpectedInstructionCount": 23,
       "Optimal": "No",
       "Comment": [
         "0x3B",
@@ -2375,7 +2322,6 @@
         "uxth w22, w22",
         "eor w23, w21, w20",
         "eor w23, w23, w22",
-        "ubfx w23, w23, #4, #1",
         "strb w23, [x28, #708]",
         "eor x23, x22, #0x1",
         "strb w23, [x28, #706]",
@@ -2396,7 +2342,7 @@
       ]
     },
     "db 0x3B, 0xcb": {
-      "ExpectedInstructionCount": 13,
+      "ExpectedInstructionCount": 12,
       "Optimal": "No",
       "Comment": [
         "0x3B",
@@ -2408,7 +2354,6 @@
         "sub w22, w21, w20",
         "eor w23, w21, w20",
         "eor w23, w23, w22",
-        "ubfx w23, w23, #4, #1",
         "strb w23, [x28, #708]",
         "eor x22, x22, #0x1",
         "strb w22, [x28, #706]",
@@ -2419,7 +2364,7 @@
       ]
     },
     "db 0x48, 0x3B, 0xcb": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Optimal": "Yes",
       "Comment": [
         "0x3B",
@@ -2429,7 +2374,6 @@
         "sub x20, x5, x7",
         "eor x21, x5, x7",
         "eor x21, x21, x20",
-        "ubfx x21, x21, #4, #1",
         "strb w21, [x28, #708]",
         "eor x20, x20, #0x1",
         "strb w20, [x28, #706]",
@@ -2440,7 +2384,7 @@
       ]
     },
     "cmp al, 1": {
-      "ExpectedInstructionCount": 23,
+      "ExpectedInstructionCount": 22,
       "Optimal": "No",
       "Comment": "0x3C",
       "ExpectedArm64ASM": [
@@ -2449,7 +2393,6 @@
         "uxtb w21, w21",
         "eor w22, w20, #0x1",
         "eor w22, w22, w21",
-        "ubfx w22, w22, #4, #1",
         "strb w22, [x28, #708]",
         "eor x22, x21, #0x1",
         "strb w22, [x28, #706]",
@@ -2470,7 +2413,7 @@
       ]
     },
     "cmp ax, 1": {
-      "ExpectedInstructionCount": 23,
+      "ExpectedInstructionCount": 22,
       "Optimal": "No",
       "Comment": "0x3D",
       "ExpectedArm64ASM": [
@@ -2479,7 +2422,6 @@
         "uxth w21, w21",
         "eor w22, w20, #0x1",
         "eor w22, w22, w21",
-        "ubfx w22, w22, #4, #1",
         "strb w22, [x28, #708]",
         "eor x22, x21, #0x1",
         "strb w22, [x28, #706]",
@@ -2500,7 +2442,7 @@
       ]
     },
     "cmp eax, 1": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 11,
       "Optimal": "No",
       "Comment": "0x3D",
       "ExpectedArm64ASM": [
@@ -2508,7 +2450,6 @@
         "sub w21, w20, #0x1 (1)",
         "eor w22, w20, #0x1",
         "eor w22, w22, w21",
-        "ubfx w22, w22, #4, #1",
         "strb w22, [x28, #708]",
         "eor x21, x21, #0x1",
         "strb w21, [x28, #706]",
@@ -2519,14 +2460,13 @@
       ]
     },
     "cmp rax, 1": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Optimal": "Yes",
       "Comment": "0x3D",
       "ExpectedArm64ASM": [
         "sub x20, x4, #0x1 (1)",
         "eor x21, x4, #0x1",
         "eor x21, x21, x20",
-        "ubfx x21, x21, #4, #1",
         "strb w21, [x28, #708]",
         "eor x20, x20, #0x1",
         "strb w20, [x28, #706]",
@@ -3412,7 +3352,7 @@
       "ExpectedArm64ASM": []
     },
     "pushf": {
-      "ExpectedInstructionCount": 40,
+      "ExpectedInstructionCount": 41,
       "Optimal": "No",
       "Comment": "0x9c",
       "ExpectedArm64ASM": [
@@ -3426,7 +3366,8 @@
         "and x22, x23, x22",
         "orr x21, x21, x22, lsl #2",
         "ldrb w22, [x28, #708]",
-        "orr x21, x21, x22, lsl #4",
+        "and w22, w22, #0x10",
+        "orr w21, w21, w22",
         "ldrb w22, [x28, #712]",
         "orr x21, x21, x22, lsl #8",
         "ldrb w22, [x28, #713]",
@@ -3459,7 +3400,7 @@
       ]
     },
     "pushfq": {
-      "ExpectedInstructionCount": 40,
+      "ExpectedInstructionCount": 41,
       "Optimal": "No",
       "Comment": "0x9c",
       "ExpectedArm64ASM": [
@@ -3473,7 +3414,8 @@
         "and x22, x23, x22",
         "orr x21, x21, x22, lsl #2",
         "ldrb w22, [x28, #708]",
-        "orr x21, x21, x22, lsl #4",
+        "and w22, w22, #0x10",
+        "orr w21, w21, w22",
         "ldrb w22, [x28, #712]",
         "orr x21, x21, x22, lsl #8",
         "ldrb w22, [x28, #713]",
@@ -3506,7 +3448,7 @@
       ]
     },
     "popf": {
-      "ExpectedInstructionCount": 42,
+      "ExpectedInstructionCount": 41,
       "Optimal": "No",
       "Comment": "0x9d",
       "ExpectedArm64ASM": [
@@ -3521,8 +3463,7 @@
         "mov w21, w0",
         "ubfx w22, w20, #2, #1",
         "strb w22, [x28, #706]",
-        "ubfx w22, w20, #4, #1",
-        "strb w22, [x28, #708]",
+        "strb w20, [x28, #708]",
         "ubfx w22, w20, #6, #1",
         "bfi w21, w22, #30, #1",
         "ubfx w22, w20, #7, #1",
@@ -3555,7 +3496,7 @@
       ]
     },
     "sahf": {
-      "ExpectedInstructionCount": 20,
+      "ExpectedInstructionCount": 19,
       "Optimal": "No",
       "Comment": "0x9e",
       "ExpectedArm64ASM": [
@@ -3570,8 +3511,7 @@
         "mov w21, w0",
         "ubfx w22, w20, #2, #1",
         "strb w22, [x28, #706]",
-        "ubfx w22, w20, #4, #1",
-        "strb w22, [x28, #708]",
+        "strb w20, [x28, #708]",
         "ubfx w22, w20, #6, #1",
         "bfi w21, w22, #30, #1",
         "ubfx w20, w20, #7, #1",
@@ -3582,7 +3522,7 @@
       ]
     },
     "lahf": {
-      "ExpectedInstructionCount": 16,
+      "ExpectedInstructionCount": 17,
       "Optimal": "Yes",
       "Comment": "0x9f",
       "ExpectedArm64ASM": [
@@ -3596,7 +3536,8 @@
         "and x22, x23, x22",
         "orr x21, x21, x22, lsl #2",
         "ldrb w22, [x28, #708]",
-        "orr x21, x21, x22, lsl #4",
+        "and w22, w22, #0x10",
+        "orr w21, w21, w22",
         "and x22, x20, #0xc0000000",
         "orr x21, x21, x22, lsr #24",
         "orr x21, x21, #0x2",
@@ -3882,7 +3823,7 @@
       ]
     },
     "cmpsb": {
-      "ExpectedInstructionCount": 31,
+      "ExpectedInstructionCount": 30,
       "Optimal": "No",
       "Comment": [
         "Direction flag increment/decrement location can be made with a single sbfx",
@@ -3902,7 +3843,6 @@
         "add x10, x10, x23",
         "eor w23, w21, w20",
         "eor w23, w23, w22",
-        "ubfx w23, w23, #4, #1",
         "strb w23, [x28, #708]",
         "eor x23, x22, #0x1",
         "strb w23, [x28, #706]",
@@ -3923,7 +3863,7 @@
       ]
     },
     "cmpsw": {
-      "ExpectedInstructionCount": 31,
+      "ExpectedInstructionCount": 30,
       "Optimal": "No",
       "Comment": [
         "Direction flag increment/decrement location can be made with a tst+mov+csel triple",
@@ -3943,7 +3883,6 @@
         "add x10, x10, x23",
         "eor w23, w21, w20",
         "eor w23, w23, w22",
-        "ubfx w23, w23, #4, #1",
         "strb w23, [x28, #708]",
         "eor x23, x22, #0x1",
         "strb w23, [x28, #706]",
@@ -3964,7 +3903,7 @@
       ]
     },
     "cmpsd": {
-      "ExpectedInstructionCount": 20,
+      "ExpectedInstructionCount": 19,
       "Optimal": "No",
       "Comment": [
         "Direction flag increment/decrement location can be made with a tst+mov+csel triple",
@@ -3983,7 +3922,6 @@
         "add x10, x10, x23",
         "eor w23, w21, w20",
         "eor w23, w23, w22",
-        "ubfx w23, w23, #4, #1",
         "strb w23, [x28, #708]",
         "eor x22, x22, #0x1",
         "strb w22, [x28, #706]",
@@ -3994,7 +3932,7 @@
       ]
     },
     "cmpsq": {
-      "ExpectedInstructionCount": 20,
+      "ExpectedInstructionCount": 19,
       "Optimal": "No",
       "Comment": [
         "Direction flag increment/decrement location can be made with a tst+mov+csel triple",
@@ -4013,7 +3951,6 @@
         "add x10, x10, x23",
         "eor x23, x21, x20",
         "eor x23, x23, x22",
-        "ubfx x23, x23, #4, #1",
         "strb w23, [x28, #708]",
         "eor x22, x22, #0x1",
         "strb w22, [x28, #706]",
@@ -4024,7 +3961,7 @@
       ]
     },
     "repz cmpsb": {
-      "ExpectedInstructionCount": 35,
+      "ExpectedInstructionCount": 34,
       "Optimal": "No",
       "Comment": "0xa6",
       "ExpectedArm64ASM": [
@@ -4033,14 +3970,13 @@
         "mov x22, #0xffffffffffffffff",
         "cmp x20, #0x0 (0)",
         "csel x20, x21, x22, eq",
-        "cbz x5, #+0x78",
+        "cbz x5, #+0x74",
         "ldrb w21, [x11]",
         "ldrb w22, [x10]",
         "sub w23, w22, w21",
         "uxtb w23, w23",
         "eor w24, w22, w21",
         "eor w24, w24, w23",
-        "ubfx w24, w24, #4, #1",
         "strb w24, [x28, #708]",
         "eor x24, x23, #0x1",
         "strb w24, [x28, #706]",
@@ -4062,11 +3998,11 @@
         "add x10, x10, x20",
         "ubfx w22, w21, #30, #1",
         "str w21, [x28, #728]",
-        "cbnz w22, #-0x74"
+        "cbnz w22, #-0x70"
       ]
     },
     "repz cmpsw": {
-      "ExpectedInstructionCount": 35,
+      "ExpectedInstructionCount": 34,
       "Optimal": "No",
       "Comment": "0xa7",
       "ExpectedArm64ASM": [
@@ -4075,14 +4011,13 @@
         "mov x22, #0xfffffffffffffffe",
         "cmp x20, #0x0 (0)",
         "csel x20, x21, x22, eq",
-        "cbz x5, #+0x78",
+        "cbz x5, #+0x74",
         "ldrh w21, [x11]",
         "ldrh w22, [x10]",
         "sub w23, w22, w21",
         "uxth w23, w23",
         "eor w24, w22, w21",
         "eor w24, w24, w23",
-        "ubfx w24, w24, #4, #1",
         "strb w24, [x28, #708]",
         "eor x24, x23, #0x1",
         "strb w24, [x28, #706]",
@@ -4104,11 +4039,11 @@
         "add x10, x10, x20",
         "ubfx w22, w21, #30, #1",
         "str w21, [x28, #728]",
-        "cbnz w22, #-0x74"
+        "cbnz w22, #-0x70"
       ]
     },
     "repz cmpsd": {
-      "ExpectedInstructionCount": 24,
+      "ExpectedInstructionCount": 23,
       "Optimal": "No",
       "Comment": "0xa7",
       "ExpectedArm64ASM": [
@@ -4117,13 +4052,12 @@
         "mov x22, #0xfffffffffffffffc",
         "cmp x20, #0x0 (0)",
         "csel x20, x21, x22, eq",
-        "cbz x5, #+0x4c",
+        "cbz x5, #+0x48",
         "ldr w21, [x11]",
         "ldr w22, [x10]",
         "sub w23, w22, w21",
         "eor w24, w22, w21",
         "eor w24, w24, w23",
-        "ubfx w24, w24, #4, #1",
         "strb w24, [x28, #708]",
         "eor x23, x23, #0x1",
         "strb w23, [x28, #706]",
@@ -4135,11 +4069,11 @@
         "add x10, x10, x20",
         "ubfx w22, w21, #30, #1",
         "str w21, [x28, #728]",
-        "cbnz w22, #-0x48"
+        "cbnz w22, #-0x44"
       ]
     },
     "repz cmpsq": {
-      "ExpectedInstructionCount": 24,
+      "ExpectedInstructionCount": 23,
       "Optimal": "No",
       "Comment": "0xa7",
       "ExpectedArm64ASM": [
@@ -4148,13 +4082,12 @@
         "mov x22, #0xfffffffffffffff8",
         "cmp x20, #0x0 (0)",
         "csel x20, x21, x22, eq",
-        "cbz x5, #+0x4c",
+        "cbz x5, #+0x48",
         "ldr x21, [x11]",
         "ldr x22, [x10]",
         "sub x23, x22, x21",
         "eor x24, x22, x21",
         "eor x24, x24, x23",
-        "ubfx x24, x24, #4, #1",
         "strb w24, [x28, #708]",
         "eor x23, x23, #0x1",
         "strb w23, [x28, #706]",
@@ -4166,11 +4099,11 @@
         "add x10, x10, x20",
         "ubfx w22, w21, #30, #1",
         "str w21, [x28, #728]",
-        "cbnz w22, #-0x48"
+        "cbnz w22, #-0x44"
       ]
     },
     "repnz cmpsb": {
-      "ExpectedInstructionCount": 35,
+      "ExpectedInstructionCount": 34,
       "Optimal": "No",
       "Comment": "0xa6",
       "ExpectedArm64ASM": [
@@ -4179,14 +4112,13 @@
         "mov x22, #0xffffffffffffffff",
         "cmp x20, #0x0 (0)",
         "csel x20, x21, x22, eq",
-        "cbz x5, #+0x78",
+        "cbz x5, #+0x74",
         "ldrb w21, [x11]",
         "ldrb w22, [x10]",
         "sub w23, w22, w21",
         "uxtb w23, w23",
         "eor w24, w22, w21",
         "eor w24, w24, w23",
-        "ubfx w24, w24, #4, #1",
         "strb w24, [x28, #708]",
         "eor x24, x23, #0x1",
         "strb w24, [x28, #706]",
@@ -4208,11 +4140,11 @@
         "add x10, x10, x20",
         "ubfx w22, w21, #30, #1",
         "str w21, [x28, #728]",
-        "cbz w22, #-0x74"
+        "cbz w22, #-0x70"
       ]
     },
     "repnz cmpsw": {
-      "ExpectedInstructionCount": 35,
+      "ExpectedInstructionCount": 34,
       "Optimal": "No",
       "Comment": "0xa7",
       "ExpectedArm64ASM": [
@@ -4221,14 +4153,13 @@
         "mov x22, #0xfffffffffffffffe",
         "cmp x20, #0x0 (0)",
         "csel x20, x21, x22, eq",
-        "cbz x5, #+0x78",
+        "cbz x5, #+0x74",
         "ldrh w21, [x11]",
         "ldrh w22, [x10]",
         "sub w23, w22, w21",
         "uxth w23, w23",
         "eor w24, w22, w21",
         "eor w24, w24, w23",
-        "ubfx w24, w24, #4, #1",
         "strb w24, [x28, #708]",
         "eor x24, x23, #0x1",
         "strb w24, [x28, #706]",
@@ -4250,11 +4181,11 @@
         "add x10, x10, x20",
         "ubfx w22, w21, #30, #1",
         "str w21, [x28, #728]",
-        "cbz w22, #-0x74"
+        "cbz w22, #-0x70"
       ]
     },
     "repnz cmpsd": {
-      "ExpectedInstructionCount": 24,
+      "ExpectedInstructionCount": 23,
       "Optimal": "No",
       "Comment": "0xa7",
       "ExpectedArm64ASM": [
@@ -4263,13 +4194,12 @@
         "mov x22, #0xfffffffffffffffc",
         "cmp x20, #0x0 (0)",
         "csel x20, x21, x22, eq",
-        "cbz x5, #+0x4c",
+        "cbz x5, #+0x48",
         "ldr w21, [x11]",
         "ldr w22, [x10]",
         "sub w23, w22, w21",
         "eor w24, w22, w21",
         "eor w24, w24, w23",
-        "ubfx w24, w24, #4, #1",
         "strb w24, [x28, #708]",
         "eor x23, x23, #0x1",
         "strb w23, [x28, #706]",
@@ -4281,11 +4211,11 @@
         "add x10, x10, x20",
         "ubfx w22, w21, #30, #1",
         "str w21, [x28, #728]",
-        "cbz w22, #-0x48"
+        "cbz w22, #-0x44"
       ]
     },
     "repnz cmpsq": {
-      "ExpectedInstructionCount": 24,
+      "ExpectedInstructionCount": 23,
       "Optimal": "No",
       "Comment": "0xa7",
       "ExpectedArm64ASM": [
@@ -4294,13 +4224,12 @@
         "mov x22, #0xfffffffffffffff8",
         "cmp x20, #0x0 (0)",
         "csel x20, x21, x22, eq",
-        "cbz x5, #+0x4c",
+        "cbz x5, #+0x48",
         "ldr x21, [x11]",
         "ldr x22, [x10]",
         "sub x23, x22, x21",
         "eor x24, x22, x21",
         "eor x24, x24, x23",
-        "ubfx x24, x24, #4, #1",
         "strb w24, [x28, #708]",
         "eor x23, x23, #0x1",
         "strb w23, [x28, #706]",
@@ -4312,7 +4241,7 @@
         "add x10, x10, x20",
         "ubfx w22, w21, #30, #1",
         "str w21, [x28, #728]",
-        "cbz w22, #-0x48"
+        "cbz w22, #-0x44"
       ]
     },
     "test al, 1": {
@@ -4671,7 +4600,7 @@
       ]
     },
     "scasb": {
-      "ExpectedInstructionCount": 30,
+      "ExpectedInstructionCount": 29,
       "Optimal": "No",
       "Comment": "0xae",
       "ExpectedArm64ASM": [
@@ -4687,7 +4616,6 @@
         "add x11, x11, x23",
         "eor w23, w20, w21",
         "eor w23, w23, w22",
-        "ubfx w23, w23, #4, #1",
         "strb w23, [x28, #708]",
         "eor x23, x22, #0x1",
         "strb w23, [x28, #706]",
@@ -4708,7 +4636,7 @@
       ]
     },
     "scasw": {
-      "ExpectedInstructionCount": 30,
+      "ExpectedInstructionCount": 29,
       "Optimal": "No",
       "Comment": "0xaf",
       "ExpectedArm64ASM": [
@@ -4724,7 +4652,6 @@
         "add x11, x11, x23",
         "eor w23, w20, w21",
         "eor w23, w23, w22",
-        "ubfx w23, w23, #4, #1",
         "strb w23, [x28, #708]",
         "eor x23, x22, #0x1",
         "strb w23, [x28, #706]",
@@ -4745,7 +4672,7 @@
       ]
     },
     "scasd": {
-      "ExpectedInstructionCount": 19,
+      "ExpectedInstructionCount": 18,
       "Optimal": "No",
       "Comment": "0xaf",
       "ExpectedArm64ASM": [
@@ -4760,7 +4687,6 @@
         "add x11, x11, x23",
         "eor w23, w20, w21",
         "eor w23, w23, w22",
-        "ubfx w23, w23, #4, #1",
         "strb w23, [x28, #708]",
         "eor x22, x22, #0x1",
         "strb w22, [x28, #706]",
@@ -4771,7 +4697,7 @@
       ]
     },
     "scasq": {
-      "ExpectedInstructionCount": 18,
+      "ExpectedInstructionCount": 17,
       "Optimal": "No",
       "Comment": "0xaf",
       "ExpectedArm64ASM": [
@@ -4785,7 +4711,6 @@
         "add x11, x11, x22",
         "eor x22, x4, x20",
         "eor x22, x22, x21",
-        "ubfx x22, x22, #4, #1",
         "strb w22, [x28, #708]",
         "eor x21, x21, #0x1",
         "strb w21, [x28, #706]",
@@ -4796,7 +4721,7 @@
       ]
     },
     "repz scasb": {
-      "ExpectedInstructionCount": 34,
+      "ExpectedInstructionCount": 33,
       "Optimal": "No",
       "Comment": "0xae",
       "ExpectedArm64ASM": [
@@ -4805,14 +4730,13 @@
         "ldrb w22, [x28, #714]",
         "cmp x22, #0x0 (0)",
         "csel x20, x20, x21, eq",
-        "cbz x5, #+0x74",
+        "cbz x5, #+0x70",
         "uxtb w21, w4",
         "ldrb w22, [x11]",
         "sub w23, w21, w22",
         "uxtb w23, w23",
         "eor w24, w21, w22",
         "eor w24, w24, w23",
-        "ubfx w24, w24, #4, #1",
         "strb w24, [x28, #708]",
         "eor x24, x23, #0x1",
         "strb w24, [x28, #706]",
@@ -4833,11 +4757,11 @@
         "add x11, x11, x20",
         "ubfx w22, w21, #30, #1",
         "str w21, [x28, #728]",
-        "cbnz w22, #-0x70"
+        "cbnz w22, #-0x6c"
       ]
     },
     "repz scasw": {
-      "ExpectedInstructionCount": 34,
+      "ExpectedInstructionCount": 33,
       "Optimal": "No",
       "Comment": "0xaf",
       "ExpectedArm64ASM": [
@@ -4846,14 +4770,13 @@
         "ldrb w22, [x28, #714]",
         "cmp x22, #0x0 (0)",
         "csel x20, x20, x21, eq",
-        "cbz x5, #+0x74",
+        "cbz x5, #+0x70",
         "uxth w21, w4",
         "ldrh w22, [x11]",
         "sub w23, w21, w22",
         "uxth w23, w23",
         "eor w24, w21, w22",
         "eor w24, w24, w23",
-        "ubfx w24, w24, #4, #1",
         "strb w24, [x28, #708]",
         "eor x24, x23, #0x1",
         "strb w24, [x28, #706]",
@@ -4874,11 +4797,11 @@
         "add x11, x11, x20",
         "ubfx w22, w21, #30, #1",
         "str w21, [x28, #728]",
-        "cbnz w22, #-0x70"
+        "cbnz w22, #-0x6c"
       ]
     },
     "repz scasd": {
-      "ExpectedInstructionCount": 23,
+      "ExpectedInstructionCount": 22,
       "Optimal": "No",
       "Comment": "0xaf",
       "ExpectedArm64ASM": [
@@ -4887,46 +4810,16 @@
         "ldrb w22, [x28, #714]",
         "cmp x22, #0x0 (0)",
         "csel x20, x20, x21, eq",
-        "cbz x5, #+0x48",
+        "cbz x5, #+0x44",
         "lsr w21, w4, #0",
         "ldr w22, [x11]",
         "sub w23, w21, w22",
         "eor w24, w21, w22",
         "eor w24, w24, w23",
-        "ubfx w24, w24, #4, #1",
         "strb w24, [x28, #708]",
         "eor x23, x23, #0x1",
         "strb w23, [x28, #706]",
         "cmp w21, w22",
-        "mrs x21, nzcv",
-        "eor w21, w21, #0x20000000",
-        "sub x5, x5, #0x1 (1)",
-        "add x11, x11, x20",
-        "ubfx w22, w21, #30, #1",
-        "str w21, [x28, #728]",
-        "cbnz w22, #-0x44"
-      ]
-    },
-    "repz scasq": {
-      "ExpectedInstructionCount": 22,
-      "Optimal": "No",
-      "Comment": "0xaf",
-      "ExpectedArm64ASM": [
-        "mov w20, #0x8",
-        "mov x21, #0xfffffffffffffff8",
-        "ldrb w22, [x28, #714]",
-        "cmp x22, #0x0 (0)",
-        "csel x20, x20, x21, eq",
-        "cbz x5, #+0x44",
-        "ldr x21, [x11]",
-        "sub x22, x4, x21",
-        "eor x23, x4, x21",
-        "eor x23, x23, x22",
-        "ubfx x23, x23, #4, #1",
-        "strb w23, [x28, #708]",
-        "eor x22, x22, #0x1",
-        "strb w22, [x28, #706]",
-        "cmp x4, x21",
         "mrs x21, nzcv",
         "eor w21, w21, #0x20000000",
         "sub x5, x5, #0x1 (1)",
@@ -4936,8 +4829,36 @@
         "cbnz w22, #-0x40"
       ]
     },
+    "repz scasq": {
+      "ExpectedInstructionCount": 21,
+      "Optimal": "No",
+      "Comment": "0xaf",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x8",
+        "mov x21, #0xfffffffffffffff8",
+        "ldrb w22, [x28, #714]",
+        "cmp x22, #0x0 (0)",
+        "csel x20, x20, x21, eq",
+        "cbz x5, #+0x40",
+        "ldr x21, [x11]",
+        "sub x22, x4, x21",
+        "eor x23, x4, x21",
+        "eor x23, x23, x22",
+        "strb w23, [x28, #708]",
+        "eor x22, x22, #0x1",
+        "strb w22, [x28, #706]",
+        "cmp x4, x21",
+        "mrs x21, nzcv",
+        "eor w21, w21, #0x20000000",
+        "sub x5, x5, #0x1 (1)",
+        "add x11, x11, x20",
+        "ubfx w22, w21, #30, #1",
+        "str w21, [x28, #728]",
+        "cbnz w22, #-0x3c"
+      ]
+    },
     "repnz scasb": {
-      "ExpectedInstructionCount": 34,
+      "ExpectedInstructionCount": 33,
       "Optimal": "No",
       "Comment": "0xae",
       "ExpectedArm64ASM": [
@@ -4946,14 +4867,13 @@
         "ldrb w22, [x28, #714]",
         "cmp x22, #0x0 (0)",
         "csel x20, x20, x21, eq",
-        "cbz x5, #+0x74",
+        "cbz x5, #+0x70",
         "uxtb w21, w4",
         "ldrb w22, [x11]",
         "sub w23, w21, w22",
         "uxtb w23, w23",
         "eor w24, w21, w22",
         "eor w24, w24, w23",
-        "ubfx w24, w24, #4, #1",
         "strb w24, [x28, #708]",
         "eor x24, x23, #0x1",
         "strb w24, [x28, #706]",
@@ -4974,11 +4894,11 @@
         "add x11, x11, x20",
         "ubfx w22, w21, #30, #1",
         "str w21, [x28, #728]",
-        "cbz w22, #-0x70"
+        "cbz w22, #-0x6c"
       ]
     },
     "repnz scasw": {
-      "ExpectedInstructionCount": 34,
+      "ExpectedInstructionCount": 33,
       "Optimal": "No",
       "Comment": "0xaf",
       "ExpectedArm64ASM": [
@@ -4987,14 +4907,13 @@
         "ldrb w22, [x28, #714]",
         "cmp x22, #0x0 (0)",
         "csel x20, x20, x21, eq",
-        "cbz x5, #+0x74",
+        "cbz x5, #+0x70",
         "uxth w21, w4",
         "ldrh w22, [x11]",
         "sub w23, w21, w22",
         "uxth w23, w23",
         "eor w24, w21, w22",
         "eor w24, w24, w23",
-        "ubfx w24, w24, #4, #1",
         "strb w24, [x28, #708]",
         "eor x24, x23, #0x1",
         "strb w24, [x28, #706]",
@@ -5015,11 +4934,11 @@
         "add x11, x11, x20",
         "ubfx w22, w21, #30, #1",
         "str w21, [x28, #728]",
-        "cbz w22, #-0x70"
+        "cbz w22, #-0x6c"
       ]
     },
     "repnz scasd": {
-      "ExpectedInstructionCount": 23,
+      "ExpectedInstructionCount": 22,
       "Optimal": "No",
       "Comment": "0xaf",
       "ExpectedArm64ASM": [
@@ -5028,13 +4947,12 @@
         "ldrb w22, [x28, #714]",
         "cmp x22, #0x0 (0)",
         "csel x20, x20, x21, eq",
-        "cbz x5, #+0x48",
+        "cbz x5, #+0x44",
         "lsr w21, w4, #0",
         "ldr w22, [x11]",
         "sub w23, w21, w22",
         "eor w24, w21, w22",
         "eor w24, w24, w23",
-        "ubfx w24, w24, #4, #1",
         "strb w24, [x28, #708]",
         "eor x23, x23, #0x1",
         "strb w23, [x28, #706]",
@@ -5045,11 +4963,11 @@
         "add x11, x11, x20",
         "ubfx w22, w21, #30, #1",
         "str w21, [x28, #728]",
-        "cbz w22, #-0x44"
+        "cbz w22, #-0x40"
       ]
     },
     "repnz scasq": {
-      "ExpectedInstructionCount": 22,
+      "ExpectedInstructionCount": 21,
       "Optimal": "No",
       "Comment": "0xaf",
       "ExpectedArm64ASM": [
@@ -5058,12 +4976,11 @@
         "ldrb w22, [x28, #714]",
         "cmp x22, #0x0 (0)",
         "csel x20, x20, x21, eq",
-        "cbz x5, #+0x44",
+        "cbz x5, #+0x40",
         "ldr x21, [x11]",
         "sub x22, x4, x21",
         "eor x23, x4, x21",
         "eor x23, x23, x22",
-        "ubfx x23, x23, #4, #1",
         "strb w23, [x28, #708]",
         "eor x22, x22, #0x1",
         "strb w22, [x28, #706]",
@@ -5074,7 +4991,7 @@
         "add x11, x11, x20",
         "ubfx w22, w21, #30, #1",
         "str w21, [x28, #728]",
-        "cbz w22, #-0x40"
+        "cbz w22, #-0x3c"
       ]
     },
     "mov al, 0xff": {

--- a/unittests/InstructionCountCI/PrimaryGroup.json
+++ b/unittests/InstructionCountCI/PrimaryGroup.json
@@ -13,7 +13,7 @@
   ],
   "Instructions": {
     "add al, 1": {
-      "ExpectedInstructionCount": 24,
+      "ExpectedInstructionCount": 23,
       "Optimal": "No",
       "Comment": "GROUP1 0x80 /0",
       "ExpectedArm64ASM": [
@@ -23,7 +23,6 @@
         "uxtb w21, w21",
         "eor w22, w20, #0x1",
         "eor w22, w22, w21",
-        "ubfx w22, w22, #4, #1",
         "strb w22, [x28, #708]",
         "eor x22, x21, #0x1",
         "strb w22, [x28, #706]",
@@ -64,7 +63,7 @@
       ]
     },
     "adc al, 1": {
-      "ExpectedInstructionCount": 32,
+      "ExpectedInstructionCount": 31,
       "Optimal": "No",
       "Comment": "GROUP1 0x80 /2",
       "ExpectedArm64ASM": [
@@ -78,7 +77,6 @@
         "uxtb w20, w20",
         "eor w23, w22, #0x1",
         "eor w23, w23, w20",
-        "ubfx w23, w23, #4, #1",
         "strb w23, [x28, #708]",
         "eor x23, x20, #0x1",
         "strb w23, [x28, #706]",
@@ -103,7 +101,7 @@
       ]
     },
     "sbb al, 1": {
-      "ExpectedInstructionCount": 32,
+      "ExpectedInstructionCount": 31,
       "Optimal": "No",
       "Comment": "GROUP1 0x80 /3",
       "ExpectedArm64ASM": [
@@ -117,7 +115,6 @@
         "uxtb w20, w20",
         "eor w23, w22, #0x1",
         "eor w23, w23, w20",
-        "ubfx w23, w23, #4, #1",
         "strb w23, [x28, #708]",
         "eor x23, x20, #0x1",
         "strb w23, [x28, #706]",
@@ -162,7 +159,7 @@
       ]
     },
     "sub al, 1": {
-      "ExpectedInstructionCount": 24,
+      "ExpectedInstructionCount": 23,
       "Optimal": "No",
       "Comment": "GROUP1 0x80 /5",
       "ExpectedArm64ASM": [
@@ -172,7 +169,6 @@
         "uxtb w21, w21",
         "eor w22, w20, #0x1",
         "eor w22, w22, w21",
-        "ubfx w22, w22, #4, #1",
         "strb w22, [x28, #708]",
         "eor x22, x21, #0x1",
         "strb w22, [x28, #706]",
@@ -213,7 +209,7 @@
       ]
     },
     "cmp al, 1": {
-      "ExpectedInstructionCount": 23,
+      "ExpectedInstructionCount": 22,
       "Optimal": "No",
       "Comment": "GROUP1 0x80 /7",
       "ExpectedArm64ASM": [
@@ -222,7 +218,6 @@
         "uxtb w21, w21",
         "eor w22, w20, #0x1",
         "eor w22, w22, w21",
-        "ubfx w22, w22, #4, #1",
         "strb w22, [x28, #708]",
         "eor x22, x21, #0x1",
         "strb w22, [x28, #706]",
@@ -243,7 +238,7 @@
       ]
     },
     "add ax, 256": {
-      "ExpectedInstructionCount": 24,
+      "ExpectedInstructionCount": 23,
       "Optimal": "No",
       "Comment": "GROUP1 0x81 /0",
       "ExpectedArm64ASM": [
@@ -253,7 +248,6 @@
         "uxth w21, w21",
         "eor w22, w20, #0x100",
         "eor w22, w22, w21",
-        "ubfx w22, w22, #4, #1",
         "strb w22, [x28, #708]",
         "eor x22, x21, #0x1",
         "strb w22, [x28, #706]",
@@ -274,7 +268,7 @@
       ]
     },
     "add eax, 256": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Optimal": "No",
       "Comment": "GROUP1 0x81 /0",
       "ExpectedArm64ASM": [
@@ -282,7 +276,6 @@
         "add w4, w20, #0x100 (256)",
         "eor w21, w20, #0x100",
         "eor w21, w21, w4",
-        "ubfx w21, w21, #4, #1",
         "strb w21, [x28, #708]",
         "eor x21, x4, #0x1",
         "strb w21, [x28, #706]",
@@ -292,7 +285,7 @@
       ]
     },
     "add rax, 256": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Optimal": "Yes",
       "Comment": "GROUP1 0x81 /0",
       "ExpectedArm64ASM": [
@@ -300,7 +293,6 @@
         "add x4, x20, #0x100 (256)",
         "eor x21, x20, #0x100",
         "eor x21, x21, x4",
-        "ubfx x21, x21, #4, #1",
         "strb w21, [x28, #708]",
         "eor x21, x4, #0x1",
         "strb w21, [x28, #706]",
@@ -341,7 +333,7 @@
       ]
     },
     "adc eax, 256": {
-      "ExpectedInstructionCount": 27,
+      "ExpectedInstructionCount": 26,
       "Optimal": "No",
       "Comment": "GROUP1 0x81 /2",
       "ExpectedArm64ASM": [
@@ -353,7 +345,6 @@
         "add w4, w22, w20",
         "eor w20, w22, #0x100",
         "eor w20, w20, w4",
-        "ubfx w20, w20, #4, #1",
         "strb w20, [x28, #708]",
         "eor x20, x4, #0x1",
         "strb w20, [x28, #706]",
@@ -375,7 +366,7 @@
       ]
     },
     "adc rax, 256": {
-      "ExpectedInstructionCount": 27,
+      "ExpectedInstructionCount": 26,
       "Optimal": "No",
       "Comment": "GROUP1 0x81 /2",
       "ExpectedArm64ASM": [
@@ -387,7 +378,6 @@
         "add x4, x22, x20",
         "eor x20, x22, #0x100",
         "eor x20, x20, x4",
-        "ubfx x20, x20, #4, #1",
         "strb w20, [x28, #708]",
         "eor x20, x4, #0x1",
         "strb w20, [x28, #706]",
@@ -409,7 +399,7 @@
       ]
     },
     "sbb eax, 256": {
-      "ExpectedInstructionCount": 27,
+      "ExpectedInstructionCount": 26,
       "Optimal": "No",
       "Comment": "GROUP1 0x81 /3",
       "ExpectedArm64ASM": [
@@ -421,7 +411,6 @@
         "sub w4, w22, w20",
         "eor w20, w22, #0x100",
         "eor w20, w20, w4",
-        "ubfx w20, w20, #4, #1",
         "strb w20, [x28, #708]",
         "eor x20, x4, #0x1",
         "strb w20, [x28, #706]",
@@ -443,7 +432,7 @@
       ]
     },
     "sbb rax, 256": {
-      "ExpectedInstructionCount": 27,
+      "ExpectedInstructionCount": 26,
       "Optimal": "No",
       "Comment": "GROUP1 0x81 /3",
       "ExpectedArm64ASM": [
@@ -455,7 +444,6 @@
         "sub x4, x22, x20",
         "eor x20, x22, #0x100",
         "eor x20, x20, x4",
-        "ubfx x20, x20, #4, #1",
         "strb w20, [x28, #708]",
         "eor x20, x4, #0x1",
         "strb w20, [x28, #706]",
@@ -508,7 +496,7 @@
       ]
     },
     "sub eax, 256": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 11,
       "Optimal": "No",
       "Comment": "GROUP1 0x81 /5",
       "ExpectedArm64ASM": [
@@ -516,7 +504,6 @@
         "sub w4, w20, #0x100 (256)",
         "eor w21, w20, #0x100",
         "eor w21, w21, w4",
-        "ubfx w21, w21, #4, #1",
         "strb w21, [x28, #708]",
         "eor x21, x4, #0x1",
         "strb w21, [x28, #706]",
@@ -527,7 +514,7 @@
       ]
     },
     "sub rax, 256": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 11,
       "Optimal": "Yes",
       "Comment": "GROUP1 0x81 /5",
       "ExpectedArm64ASM": [
@@ -535,7 +522,6 @@
         "sub x4, x20, #0x100 (256)",
         "eor x21, x20, #0x100",
         "eor x21, x21, x4",
-        "ubfx x21, x21, #4, #1",
         "strb w21, [x28, #708]",
         "eor x21, x4, #0x1",
         "strb w21, [x28, #706]",
@@ -577,7 +563,7 @@
       ]
     },
     "cmp eax, 256": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 11,
       "Optimal": "No",
       "Comment": "GROUP1 0x81 /7",
       "ExpectedArm64ASM": [
@@ -585,7 +571,6 @@
         "sub w21, w20, #0x100 (256)",
         "eor w22, w20, #0x100",
         "eor w22, w22, w21",
-        "ubfx w22, w22, #4, #1",
         "strb w22, [x28, #708]",
         "eor x21, x21, #0x1",
         "strb w21, [x28, #706]",
@@ -596,14 +581,13 @@
       ]
     },
     "cmp rax, 256": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Optimal": "Yes",
       "Comment": "GROUP1 0x81 /7",
       "ExpectedArm64ASM": [
         "sub x20, x4, #0x100 (256)",
         "eor x21, x4, #0x100",
         "eor x21, x21, x20",
-        "ubfx x21, x21, #4, #1",
         "strb w21, [x28, #708]",
         "eor x20, x20, #0x1",
         "strb w20, [x28, #706]",
@@ -614,7 +598,7 @@
       ]
     },
     "add ax, 1": {
-      "ExpectedInstructionCount": 24,
+      "ExpectedInstructionCount": 23,
       "Optimal": "No",
       "Comment": "GROUP1 0x83 /0",
       "ExpectedArm64ASM": [
@@ -624,7 +608,6 @@
         "uxth w21, w21",
         "eor w22, w20, #0x1",
         "eor w22, w22, w21",
-        "ubfx w22, w22, #4, #1",
         "strb w22, [x28, #708]",
         "eor x22, x21, #0x1",
         "strb w22, [x28, #706]",
@@ -645,7 +628,7 @@
       ]
     },
     "add eax, 1": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Optimal": "No",
       "Comment": "GROUP1 0x83 /0",
       "ExpectedArm64ASM": [
@@ -653,7 +636,6 @@
         "add w4, w20, #0x1 (1)",
         "eor w21, w20, #0x1",
         "eor w21, w21, w4",
-        "ubfx w21, w21, #4, #1",
         "strb w21, [x28, #708]",
         "eor x21, x4, #0x1",
         "strb w21, [x28, #706]",
@@ -663,7 +645,7 @@
       ]
     },
     "add rax, 1": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Optimal": "Yes",
       "Comment": "GROUP1 0x83 /0",
       "ExpectedArm64ASM": [
@@ -671,7 +653,6 @@
         "add x4, x20, #0x1 (1)",
         "eor x21, x20, #0x1",
         "eor x21, x21, x4",
-        "ubfx x21, x21, #4, #1",
         "strb w21, [x28, #708]",
         "eor x21, x4, #0x1",
         "strb w21, [x28, #706]",
@@ -712,7 +693,7 @@
       ]
     },
     "adc eax, 1": {
-      "ExpectedInstructionCount": 27,
+      "ExpectedInstructionCount": 26,
       "Optimal": "No",
       "Comment": "GROUP1 0x83 /2",
       "ExpectedArm64ASM": [
@@ -724,7 +705,6 @@
         "add w4, w22, w20",
         "eor w20, w22, #0x1",
         "eor w20, w20, w4",
-        "ubfx w20, w20, #4, #1",
         "strb w20, [x28, #708]",
         "eor x20, x4, #0x1",
         "strb w20, [x28, #706]",
@@ -746,7 +726,7 @@
       ]
     },
     "adc rax, 1": {
-      "ExpectedInstructionCount": 27,
+      "ExpectedInstructionCount": 26,
       "Optimal": "No",
       "Comment": "GROUP1 0x83 /2",
       "ExpectedArm64ASM": [
@@ -758,7 +738,6 @@
         "add x4, x22, x20",
         "eor x20, x22, #0x1",
         "eor x20, x20, x4",
-        "ubfx x20, x20, #4, #1",
         "strb w20, [x28, #708]",
         "eor x20, x4, #0x1",
         "strb w20, [x28, #706]",
@@ -780,7 +759,7 @@
       ]
     },
     "sbb eax, 1": {
-      "ExpectedInstructionCount": 27,
+      "ExpectedInstructionCount": 26,
       "Optimal": "No",
       "Comment": "GROUP1 0x83 /3",
       "ExpectedArm64ASM": [
@@ -792,7 +771,6 @@
         "sub w4, w22, w20",
         "eor w20, w22, #0x1",
         "eor w20, w20, w4",
-        "ubfx w20, w20, #4, #1",
         "strb w20, [x28, #708]",
         "eor x20, x4, #0x1",
         "strb w20, [x28, #706]",
@@ -814,7 +792,7 @@
       ]
     },
     "sbb rax, 1": {
-      "ExpectedInstructionCount": 27,
+      "ExpectedInstructionCount": 26,
       "Optimal": "No",
       "Comment": "GROUP1 0x83 /3",
       "ExpectedArm64ASM": [
@@ -826,7 +804,6 @@
         "sub x4, x22, x20",
         "eor x20, x22, #0x1",
         "eor x20, x20, x4",
-        "ubfx x20, x20, #4, #1",
         "strb w20, [x28, #708]",
         "eor x20, x4, #0x1",
         "strb w20, [x28, #706]",
@@ -879,7 +856,7 @@
       ]
     },
     "sub eax, 1": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 11,
       "Optimal": "No",
       "Comment": "GROUP1 0x83 /5",
       "ExpectedArm64ASM": [
@@ -887,7 +864,6 @@
         "sub w4, w20, #0x1 (1)",
         "eor w21, w20, #0x1",
         "eor w21, w21, w4",
-        "ubfx w21, w21, #4, #1",
         "strb w21, [x28, #708]",
         "eor x21, x4, #0x1",
         "strb w21, [x28, #706]",
@@ -898,7 +874,7 @@
       ]
     },
     "sub rax, 1": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 11,
       "Optimal": "No",
       "Comment": "GROUP1 0x83 /5",
       "ExpectedArm64ASM": [
@@ -906,7 +882,6 @@
         "sub x4, x20, #0x1 (1)",
         "eor x21, x20, #0x1",
         "eor x21, x21, x4",
-        "ubfx x21, x21, #4, #1",
         "strb w21, [x28, #708]",
         "eor x21, x4, #0x1",
         "strb w21, [x28, #706]",
@@ -948,7 +923,7 @@
       ]
     },
     "cmp eax, 1": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 11,
       "Optimal": "No",
       "Comment": "GROUP1 0x83 /7",
       "ExpectedArm64ASM": [
@@ -956,7 +931,6 @@
         "sub w21, w20, #0x1 (1)",
         "eor w22, w20, #0x1",
         "eor w22, w22, w21",
-        "ubfx w22, w22, #4, #1",
         "strb w22, [x28, #708]",
         "eor x21, x21, #0x1",
         "strb w21, [x28, #706]",
@@ -967,14 +941,13 @@
       ]
     },
     "cmp rax, 1": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Optimal": "No",
       "Comment": "GROUP1 0x83 /7",
       "ExpectedArm64ASM": [
         "sub x20, x4, #0x1 (1)",
         "eor x21, x4, #0x1",
         "eor x21, x21, x20",
-        "ubfx x21, x21, #4, #1",
         "strb w21, [x28, #708]",
         "eor x20, x20, #0x1",
         "strb w20, [x28, #706]",
@@ -1093,17 +1066,17 @@
         "lsl w21, w20, #2",
         "bfxil x4, x21, #0, #8",
         "uxtb w21, w21",
-        "mov w22, #0x0",
-        "lsl w23, w21, #24",
-        "and w23, w23, #0x80000000",
+        "lsl w22, w21, #24",
+        "and w22, w22, #0x80000000",
+        "mov w23, #0x0",
         "cmp x21, #0x0 (0)",
         "cset x24, eq",
-        "orr w23, w23, w24, lsl #30",
+        "orr w22, w22, w24, lsl #30",
         "ubfx w20, w20, #6, #1",
-        "orr w20, w23, w20, lsl #29",
+        "orr w20, w22, w20, lsl #29",
         "eor x21, x21, #0x1",
         "strb w21, [x28, #706]",
-        "strb w22, [x28, #708]",
+        "strb w23, [x28, #708]",
         "str w20, [x28, #728]"
       ]
     },
@@ -1115,20 +1088,20 @@
         "uxtb w20, w4",
         "lsr w21, w20, #2",
         "bfxil x4, x21, #0, #8",
-        "mov w22, #0x0",
-        "ldr w23, [x28, #728]",
-        "ubfx w23, w23, #28, #1",
-        "lsl w24, w21, #24",
-        "and w24, w24, #0x80000000",
+        "ldr w22, [x28, #728]",
+        "ubfx w22, w22, #28, #1",
+        "lsl w23, w21, #24",
+        "and w23, w23, #0x80000000",
+        "mov w24, #0x0",
         "cmp x21, #0x0 (0)",
         "cset x25, eq",
-        "orr w24, w24, w25, lsl #30",
+        "orr w23, w23, w25, lsl #30",
         "ubfx w20, w20, #1, #1",
-        "orr w20, w24, w20, lsl #29",
+        "orr w20, w23, w20, lsl #29",
         "eor x21, x21, #0x1",
         "strb w21, [x28, #706]",
-        "strb w22, [x28, #708]",
-        "orr w20, w20, w23, lsl #28",
+        "strb w24, [x28, #708]",
+        "orr w20, w20, w22, lsl #28",
         "str w20, [x28, #728]"
       ]
     },
@@ -1141,17 +1114,17 @@
         "sxtb x20, w20",
         "asr x21, x20, #2",
         "bfxil x4, x21, #0, #8",
-        "mov w22, #0x0",
-        "lsl w23, w21, #24",
-        "and w23, w23, #0x80000000",
+        "lsl w22, w21, #24",
+        "and w22, w22, #0x80000000",
+        "mov w23, #0x0",
         "cmp x21, #0x0 (0)",
         "cset x24, eq",
-        "orr w23, w23, w24, lsl #30",
+        "orr w22, w22, w24, lsl #30",
         "ubfx x20, x20, #1, #1",
-        "orr w20, w23, w20, lsl #29",
+        "orr w20, w22, w20, lsl #29",
         "eor x21, x21, #0x1",
         "strb w21, [x28, #706]",
-        "strb w22, [x28, #708]",
+        "strb w23, [x28, #708]",
         "str w20, [x28, #728]"
       ]
     },
@@ -1444,17 +1417,17 @@
         "lsl w21, w20, #2",
         "bfxil x4, x21, #0, #16",
         "uxth w21, w21",
-        "mov w22, #0x0",
-        "lsl w23, w21, #16",
-        "and w23, w23, #0x80000000",
+        "lsl w22, w21, #16",
+        "and w22, w22, #0x80000000",
+        "mov w23, #0x0",
         "cmp x21, #0x0 (0)",
         "cset x24, eq",
-        "orr w23, w23, w24, lsl #30",
+        "orr w22, w22, w24, lsl #30",
         "ubfx w20, w20, #14, #1",
-        "orr w20, w23, w20, lsl #29",
+        "orr w20, w22, w20, lsl #29",
         "eor x21, x21, #0x1",
         "strb w21, [x28, #706]",
-        "strb w22, [x28, #708]",
+        "strb w23, [x28, #708]",
         "str w20, [x28, #728]"
       ]
     },
@@ -1465,13 +1438,13 @@
       "ExpectedArm64ASM": [
         "lsr w20, w4, #0",
         "lsl w4, w20, #2",
-        "mov w21, #0x0",
         "tst w4, w4",
-        "mrs x22, nzcv",
+        "mrs x21, nzcv",
         "ubfx w20, w20, #30, #1",
-        "orr w20, w22, w20, lsl #29",
-        "eor x22, x4, #0x1",
-        "strb w22, [x28, #706]",
+        "orr w20, w21, w20, lsl #29",
+        "eor x21, x4, #0x1",
+        "strb w21, [x28, #706]",
+        "mov w21, #0x0",
         "strb w21, [x28, #708]",
         "str w20, [x28, #728]"
       ]
@@ -1483,13 +1456,13 @@
       "ExpectedArm64ASM": [
         "mov x20, x4",
         "lsl x4, x20, #2",
-        "mov w21, #0x0",
         "tst x4, x4",
-        "mrs x22, nzcv",
+        "mrs x21, nzcv",
         "ubfx x20, x20, #62, #1",
-        "orr w20, w22, w20, lsl #29",
-        "eor x22, x4, #0x1",
-        "strb w22, [x28, #706]",
+        "orr w20, w21, w20, lsl #29",
+        "eor x21, x4, #0x1",
+        "strb w21, [x28, #706]",
+        "mov w21, #0x0",
         "strb w21, [x28, #708]",
         "str w20, [x28, #728]"
       ]
@@ -1502,20 +1475,20 @@
         "uxth w20, w4",
         "lsr w21, w20, #2",
         "bfxil x4, x21, #0, #16",
-        "mov w22, #0x0",
-        "ldr w23, [x28, #728]",
-        "ubfx w23, w23, #28, #1",
-        "lsl w24, w21, #16",
-        "and w24, w24, #0x80000000",
+        "ldr w22, [x28, #728]",
+        "ubfx w22, w22, #28, #1",
+        "lsl w23, w21, #16",
+        "and w23, w23, #0x80000000",
+        "mov w24, #0x0",
         "cmp x21, #0x0 (0)",
         "cset x25, eq",
-        "orr w24, w24, w25, lsl #30",
+        "orr w23, w23, w25, lsl #30",
         "ubfx w20, w20, #1, #1",
-        "orr w20, w24, w20, lsl #29",
+        "orr w20, w23, w20, lsl #29",
         "eor x21, x21, #0x1",
         "strb w21, [x28, #706]",
-        "strb w22, [x28, #708]",
-        "orr w20, w20, w23, lsl #28",
+        "strb w24, [x28, #708]",
+        "orr w20, w20, w22, lsl #28",
         "str w20, [x28, #728]"
       ]
     },
@@ -1526,17 +1499,17 @@
       "ExpectedArm64ASM": [
         "lsr w20, w4, #0",
         "lsr w4, w20, #2",
-        "mov w21, #0x0",
-        "ldr w22, [x28, #728]",
-        "ubfx w22, w22, #28, #1",
+        "ldr w21, [x28, #728]",
+        "ubfx w21, w21, #28, #1",
         "tst w4, w4",
-        "mrs x23, nzcv",
+        "mrs x22, nzcv",
         "ubfx w20, w20, #1, #1",
-        "orr w20, w23, w20, lsl #29",
-        "eor x23, x4, #0x1",
-        "strb w23, [x28, #706]",
-        "strb w21, [x28, #708]",
-        "orr w20, w20, w22, lsl #28",
+        "orr w20, w22, w20, lsl #29",
+        "eor x22, x4, #0x1",
+        "strb w22, [x28, #706]",
+        "mov w22, #0x0",
+        "strb w22, [x28, #708]",
+        "orr w20, w20, w21, lsl #28",
         "str w20, [x28, #728]"
       ]
     },
@@ -1547,17 +1520,17 @@
       "ExpectedArm64ASM": [
         "mov x20, x4",
         "lsr x4, x20, #2",
-        "mov w21, #0x0",
-        "ldr w22, [x28, #728]",
-        "ubfx w22, w22, #28, #1",
+        "ldr w21, [x28, #728]",
+        "ubfx w21, w21, #28, #1",
         "tst x4, x4",
-        "mrs x23, nzcv",
+        "mrs x22, nzcv",
         "ubfx x20, x20, #1, #1",
-        "orr w20, w23, w20, lsl #29",
-        "eor x23, x4, #0x1",
-        "strb w23, [x28, #706]",
-        "strb w21, [x28, #708]",
-        "orr w20, w20, w22, lsl #28",
+        "orr w20, w22, w20, lsl #29",
+        "eor x22, x4, #0x1",
+        "strb w22, [x28, #706]",
+        "mov w22, #0x0",
+        "strb w22, [x28, #708]",
+        "orr w20, w20, w21, lsl #28",
         "str w20, [x28, #728]"
       ]
     },
@@ -1570,17 +1543,17 @@
         "sxth x20, w20",
         "asr x21, x20, #2",
         "bfxil x4, x21, #0, #16",
-        "mov w22, #0x0",
-        "lsl w23, w21, #16",
-        "and w23, w23, #0x80000000",
+        "lsl w22, w21, #16",
+        "and w22, w22, #0x80000000",
+        "mov w23, #0x0",
         "cmp x21, #0x0 (0)",
         "cset x24, eq",
-        "orr w23, w23, w24, lsl #30",
+        "orr w22, w22, w24, lsl #30",
         "ubfx x20, x20, #1, #1",
-        "orr w20, w23, w20, lsl #29",
+        "orr w20, w22, w20, lsl #29",
         "eor x21, x21, #0x1",
         "strb w21, [x28, #706]",
-        "strb w22, [x28, #708]",
+        "strb w23, [x28, #708]",
         "str w20, [x28, #728]"
       ]
     },
@@ -1591,13 +1564,13 @@
       "ExpectedArm64ASM": [
         "lsr w20, w4, #0",
         "asr w4, w20, #2",
-        "mov w21, #0x0",
         "tst w4, w4",
-        "mrs x22, nzcv",
+        "mrs x21, nzcv",
         "ubfx w20, w20, #1, #1",
-        "orr w20, w22, w20, lsl #29",
-        "eor x22, x4, #0x1",
-        "strb w22, [x28, #706]",
+        "orr w20, w21, w20, lsl #29",
+        "eor x21, x4, #0x1",
+        "strb w21, [x28, #706]",
+        "mov w21, #0x0",
         "strb w21, [x28, #708]",
         "str w20, [x28, #728]"
       ]
@@ -1609,13 +1582,13 @@
       "ExpectedArm64ASM": [
         "mov x20, x4",
         "asr x4, x20, #2",
-        "mov w21, #0x0",
         "tst x4, x4",
-        "mrs x22, nzcv",
+        "mrs x21, nzcv",
         "ubfx x20, x20, #1, #1",
-        "orr w20, w22, w20, lsl #29",
-        "eor x22, x4, #0x1",
-        "strb w22, [x28, #706]",
+        "orr w20, w21, w20, lsl #29",
+        "eor x21, x4, #0x1",
+        "strb w21, [x28, #706]",
+        "mov w21, #0x0",
         "strb w21, [x28, #708]",
         "str w20, [x28, #728]"
       ]
@@ -1711,20 +1684,20 @@
         "lsl w21, w20, #1",
         "bfxil x4, x21, #0, #8",
         "uxtb w21, w21",
-        "mov w22, #0x0",
-        "lsl w23, w21, #24",
-        "and w23, w23, #0x80000000",
+        "lsl w22, w21, #24",
+        "and w22, w22, #0x80000000",
+        "mov w23, #0x0",
         "cmp x21, #0x0 (0)",
         "cset x24, eq",
-        "orr w23, w23, w24, lsl #30",
+        "orr w22, w22, w24, lsl #30",
         "ubfx w24, w20, #7, #1",
-        "orr w23, w23, w24, lsl #29",
+        "orr w22, w22, w24, lsl #29",
         "eor x24, x21, #0x1",
         "strb w24, [x28, #706]",
-        "strb w22, [x28, #708]",
+        "strb w23, [x28, #708]",
         "eor w20, w21, w20",
         "ubfx w20, w20, #7, #1",
-        "orr w20, w23, w20, lsl #28",
+        "orr w20, w22, w20, lsl #28",
         "str w20, [x28, #728]"
       ]
     },
@@ -1736,19 +1709,19 @@
         "uxtb w20, w4",
         "lsr w21, w20, #1",
         "bfxil x4, x21, #0, #8",
-        "mov w22, #0x0",
-        "lsl w23, w21, #24",
-        "and w23, w23, #0x80000000",
+        "lsl w22, w21, #24",
+        "and w22, w22, #0x80000000",
+        "mov w23, #0x0",
         "cmp x21, #0x0 (0)",
         "cset x24, eq",
-        "orr w23, w23, w24, lsl #30",
+        "orr w22, w22, w24, lsl #30",
         "ubfx w24, w20, #0, #1",
-        "orr w23, w23, w24, lsl #29",
+        "orr w22, w22, w24, lsl #29",
         "eor x21, x21, #0x1",
         "strb w21, [x28, #706]",
-        "strb w22, [x28, #708]",
+        "strb w23, [x28, #708]",
         "ubfx w20, w20, #7, #1",
-        "orr w20, w23, w20, lsl #28",
+        "orr w20, w22, w20, lsl #28",
         "str w20, [x28, #728]"
       ]
     },
@@ -1761,17 +1734,17 @@
         "sxtb x20, w20",
         "asr w21, w20, #1",
         "bfxil x4, x21, #0, #8",
-        "mov w22, #0x0",
-        "lsl w23, w21, #24",
-        "and w23, w23, #0x80000000",
+        "lsl w22, w21, #24",
+        "and w22, w22, #0x80000000",
+        "mov w23, #0x0",
         "cmp x21, #0x0 (0)",
         "cset x24, eq",
-        "orr w23, w23, w24, lsl #30",
+        "orr w22, w22, w24, lsl #30",
         "ubfx x20, x20, #0, #1",
-        "orr w20, w23, w20, lsl #29",
+        "orr w20, w22, w20, lsl #29",
         "eor x21, x21, #0x1",
         "strb w21, [x28, #706]",
-        "strb w22, [x28, #708]",
+        "strb w23, [x28, #708]",
         "str w20, [x28, #728]"
       ]
     },
@@ -2009,20 +1982,20 @@
         "lsl w21, w20, #1",
         "bfxil x4, x21, #0, #16",
         "uxth w21, w21",
-        "mov w22, #0x0",
-        "lsl w23, w21, #16",
-        "and w23, w23, #0x80000000",
+        "lsl w22, w21, #16",
+        "and w22, w22, #0x80000000",
+        "mov w23, #0x0",
         "cmp x21, #0x0 (0)",
         "cset x24, eq",
-        "orr w23, w23, w24, lsl #30",
+        "orr w22, w22, w24, lsl #30",
         "ubfx w24, w20, #15, #1",
-        "orr w23, w23, w24, lsl #29",
+        "orr w22, w22, w24, lsl #29",
         "eor x24, x21, #0x1",
         "strb w24, [x28, #706]",
-        "strb w22, [x28, #708]",
+        "strb w23, [x28, #708]",
         "eor w20, w21, w20",
         "ubfx w20, w20, #15, #1",
-        "orr w20, w23, w20, lsl #28",
+        "orr w20, w22, w20, lsl #28",
         "str w20, [x28, #728]"
       ]
     },
@@ -2033,17 +2006,17 @@
       "ExpectedArm64ASM": [
         "lsr w20, w4, #0",
         "lsl w4, w20, #1",
-        "mov w21, #0x0",
         "tst w4, w4",
-        "mrs x22, nzcv",
-        "lsr w23, w20, #31",
-        "orr w22, w22, w23, lsl #29",
-        "eor x23, x4, #0x1",
-        "strb w23, [x28, #706]",
-        "strb w21, [x28, #708]",
+        "mrs x21, nzcv",
+        "lsr w22, w20, #31",
+        "orr w21, w21, w22, lsl #29",
+        "eor x22, x4, #0x1",
+        "strb w22, [x28, #706]",
+        "mov w22, #0x0",
+        "strb w22, [x28, #708]",
         "eor w20, w4, w20",
         "lsr w20, w20, #31",
-        "orr w20, w22, w20, lsl #28",
+        "orr w20, w21, w20, lsl #28",
         "str w20, [x28, #728]"
       ]
     },
@@ -2054,17 +2027,17 @@
       "ExpectedArm64ASM": [
         "mov x20, x4",
         "lsl x4, x20, #1",
-        "mov w21, #0x0",
         "tst x4, x4",
-        "mrs x22, nzcv",
-        "lsr x23, x20, #63",
-        "orr w22, w22, w23, lsl #29",
-        "eor x23, x4, #0x1",
-        "strb w23, [x28, #706]",
-        "strb w21, [x28, #708]",
+        "mrs x21, nzcv",
+        "lsr x22, x20, #63",
+        "orr w21, w21, w22, lsl #29",
+        "eor x22, x4, #0x1",
+        "strb w22, [x28, #706]",
+        "mov w22, #0x0",
+        "strb w22, [x28, #708]",
         "eor x20, x4, x20",
         "lsr x20, x20, #63",
-        "orr w20, w22, w20, lsl #28",
+        "orr w20, w21, w20, lsl #28",
         "str w20, [x28, #728]"
       ]
     },
@@ -2076,19 +2049,19 @@
         "uxth w20, w4",
         "lsr w21, w20, #1",
         "bfxil x4, x21, #0, #16",
-        "mov w22, #0x0",
-        "lsl w23, w21, #16",
-        "and w23, w23, #0x80000000",
+        "lsl w22, w21, #16",
+        "and w22, w22, #0x80000000",
+        "mov w23, #0x0",
         "cmp x21, #0x0 (0)",
         "cset x24, eq",
-        "orr w23, w23, w24, lsl #30",
+        "orr w22, w22, w24, lsl #30",
         "ubfx w24, w20, #0, #1",
-        "orr w23, w23, w24, lsl #29",
+        "orr w22, w22, w24, lsl #29",
         "eor x21, x21, #0x1",
         "strb w21, [x28, #706]",
-        "strb w22, [x28, #708]",
+        "strb w23, [x28, #708]",
         "ubfx w20, w20, #15, #1",
-        "orr w20, w23, w20, lsl #28",
+        "orr w20, w22, w20, lsl #28",
         "str w20, [x28, #728]"
       ]
     },
@@ -2099,16 +2072,16 @@
       "ExpectedArm64ASM": [
         "lsr w20, w4, #0",
         "lsr w4, w20, #1",
-        "mov w21, #0x0",
         "tst w4, w4",
-        "mrs x22, nzcv",
-        "ubfx w23, w20, #0, #1",
-        "orr w22, w22, w23, lsl #29",
-        "eor x23, x4, #0x1",
-        "strb w23, [x28, #706]",
-        "strb w21, [x28, #708]",
+        "mrs x21, nzcv",
+        "ubfx w22, w20, #0, #1",
+        "orr w21, w21, w22, lsl #29",
+        "eor x22, x4, #0x1",
+        "strb w22, [x28, #706]",
+        "mov w22, #0x0",
+        "strb w22, [x28, #708]",
         "lsr w20, w20, #31",
-        "orr w20, w22, w20, lsl #28",
+        "orr w20, w21, w20, lsl #28",
         "str w20, [x28, #728]"
       ]
     },
@@ -2119,16 +2092,16 @@
       "ExpectedArm64ASM": [
         "mov x20, x4",
         "lsr x4, x20, #1",
-        "mov w21, #0x0",
         "tst x4, x4",
-        "mrs x22, nzcv",
-        "ubfx x23, x20, #0, #1",
-        "orr w22, w22, w23, lsl #29",
-        "eor x23, x4, #0x1",
-        "strb w23, [x28, #706]",
-        "strb w21, [x28, #708]",
+        "mrs x21, nzcv",
+        "ubfx x22, x20, #0, #1",
+        "orr w21, w21, w22, lsl #29",
+        "eor x22, x4, #0x1",
+        "strb w22, [x28, #706]",
+        "mov w22, #0x0",
+        "strb w22, [x28, #708]",
         "lsr x20, x20, #63",
-        "orr w20, w22, w20, lsl #28",
+        "orr w20, w21, w20, lsl #28",
         "str w20, [x28, #728]"
       ]
     },
@@ -2141,17 +2114,17 @@
         "sxth x20, w20",
         "asr w21, w20, #1",
         "bfxil x4, x21, #0, #16",
-        "mov w22, #0x0",
-        "lsl w23, w21, #16",
-        "and w23, w23, #0x80000000",
+        "lsl w22, w21, #16",
+        "and w22, w22, #0x80000000",
+        "mov w23, #0x0",
         "cmp x21, #0x0 (0)",
         "cset x24, eq",
-        "orr w23, w23, w24, lsl #30",
+        "orr w22, w22, w24, lsl #30",
         "ubfx x20, x20, #0, #1",
-        "orr w20, w23, w20, lsl #29",
+        "orr w20, w22, w20, lsl #29",
         "eor x21, x21, #0x1",
         "strb w21, [x28, #706]",
-        "strb w22, [x28, #708]",
+        "strb w23, [x28, #708]",
         "str w20, [x28, #728]"
       ]
     },
@@ -2162,13 +2135,13 @@
       "ExpectedArm64ASM": [
         "lsr w20, w4, #0",
         "asr w4, w20, #1",
-        "mov w21, #0x0",
         "tst w4, w4",
-        "mrs x22, nzcv",
+        "mrs x21, nzcv",
         "ubfx w20, w20, #0, #1",
-        "orr w20, w22, w20, lsl #29",
-        "eor x22, x4, #0x1",
-        "strb w22, [x28, #706]",
+        "orr w20, w21, w20, lsl #29",
+        "eor x21, x4, #0x1",
+        "strb w21, [x28, #706]",
+        "mov w21, #0x0",
         "strb w21, [x28, #708]",
         "str w20, [x28, #728]"
       ]
@@ -2180,13 +2153,13 @@
       "ExpectedArm64ASM": [
         "mov x20, x4",
         "asr x4, x20, #1",
-        "mov w21, #0x0",
         "tst x4, x4",
-        "mrs x22, nzcv",
+        "mrs x21, nzcv",
         "ubfx x20, x20, #0, #1",
-        "orr w20, w22, w20, lsl #29",
-        "eor x22, x4, #0x1",
-        "strb w22, [x28, #706]",
+        "orr w20, w21, w20, lsl #29",
+        "eor x21, x4, #0x1",
+        "strb w21, [x28, #706]",
+        "mov w21, #0x0",
         "strb w21, [x28, #708]",
         "str w20, [x28, #728]"
       ]
@@ -3069,7 +3042,7 @@
       ]
     },
     "neg bl": {
-      "ExpectedInstructionCount": 22,
+      "ExpectedInstructionCount": 21,
       "Optimal": "No",
       "Comment": "GROUP2 0xf6 /3",
       "ExpectedArm64ASM": [
@@ -3079,7 +3052,6 @@
         "bfxil x7, x22, #0, #8",
         "uxtb w22, w22",
         "eor w23, w21, w22",
-        "ubfx w23, w23, #4, #1",
         "strb w23, [x28, #708]",
         "eor x23, x22, #0x1",
         "strb w23, [x28, #706]",
@@ -3255,7 +3227,7 @@
       ]
     },
     "neg bx": {
-      "ExpectedInstructionCount": 22,
+      "ExpectedInstructionCount": 21,
       "Optimal": "No",
       "Comment": "GROUP2 0xf7 /2",
       "ExpectedArm64ASM": [
@@ -3265,7 +3237,6 @@
         "bfxil x7, x22, #0, #16",
         "uxth w22, w22",
         "eor w23, w21, w22",
-        "ubfx w23, w23, #4, #1",
         "strb w23, [x28, #708]",
         "eor x23, x22, #0x1",
         "strb w23, [x28, #706]",
@@ -3284,14 +3255,13 @@
       ]
     },
     "neg ebx": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Optimal": "No",
       "Comment": "GROUP2 0xf7 /2",
       "ExpectedArm64ASM": [
         "lsr w20, w7, #0",
         "neg w7, w20",
         "eor w21, w20, w7",
-        "ubfx w21, w21, #4, #1",
         "strb w21, [x28, #708]",
         "eor x21, x7, #0x1",
         "strb w21, [x28, #706]",
@@ -3302,14 +3272,13 @@
       ]
     },
     "neg rbx": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Optimal": "No",
       "Comment": "GROUP2 0xf7 /2",
       "ExpectedArm64ASM": [
         "mov x20, x7",
         "neg x7, x20",
         "eor x21, x20, x7",
-        "ubfx x21, x21, #4, #1",
         "strb w21, [x28, #708]",
         "eor x21, x7, #0x1",
         "strb w21, [x28, #706]",
@@ -3585,7 +3554,7 @@
       ]
     },
     "inc al": {
-      "ExpectedInstructionCount": 24,
+      "ExpectedInstructionCount": 23,
       "Optimal": "No",
       "Comment": "GROUP3 0xfe /0",
       "ExpectedArm64ASM": [
@@ -3595,7 +3564,6 @@
         "uxtb w21, w21",
         "eor w22, w20, #0x1",
         "eor w22, w22, w21",
-        "ubfx w22, w22, #4, #1",
         "strb w22, [x28, #708]",
         "eor x22, x21, #0x1",
         "strb w22, [x28, #706]",
@@ -3616,7 +3584,7 @@
       ]
     },
     "dec al": {
-      "ExpectedInstructionCount": 24,
+      "ExpectedInstructionCount": 23,
       "Optimal": "No",
       "Comment": "GROUP3 0xfe /1",
       "ExpectedArm64ASM": [
@@ -3626,7 +3594,6 @@
         "uxtb w21, w21",
         "eor w22, w20, #0x1",
         "eor w22, w22, w21",
-        "ubfx w22, w22, #4, #1",
         "strb w22, [x28, #708]",
         "eor x22, x21, #0x1",
         "strb w22, [x28, #706]",
@@ -3647,7 +3614,7 @@
       ]
     },
     "inc ax": {
-      "ExpectedInstructionCount": 24,
+      "ExpectedInstructionCount": 23,
       "Optimal": "No",
       "Comment": "GROUP4 0xfe /0",
       "ExpectedArm64ASM": [
@@ -3657,7 +3624,6 @@
         "uxth w21, w21",
         "eor w22, w20, #0x1",
         "eor w22, w22, w21",
-        "ubfx w22, w22, #4, #1",
         "strb w22, [x28, #708]",
         "eor x22, x21, #0x1",
         "strb w22, [x28, #706]",
@@ -3678,7 +3644,7 @@
       ]
     },
     "inc eax": {
-      "ExpectedInstructionCount": 14,
+      "ExpectedInstructionCount": 13,
       "Optimal": "No",
       "Comment": "GROUP4 0xfe /0",
       "ExpectedArm64ASM": [
@@ -3686,7 +3652,6 @@
         "add w4, w20, #0x1 (1)",
         "eor w21, w20, #0x1",
         "eor w21, w21, w4",
-        "ubfx w21, w21, #4, #1",
         "strb w21, [x28, #708]",
         "eor x21, x4, #0x1",
         "strb w21, [x28, #706]",
@@ -3699,7 +3664,7 @@
       ]
     },
     "inc rax": {
-      "ExpectedInstructionCount": 14,
+      "ExpectedInstructionCount": 13,
       "Optimal": "Yes",
       "Comment": "GROUP4 0xfe /0",
       "ExpectedArm64ASM": [
@@ -3707,7 +3672,6 @@
         "add x4, x20, #0x1 (1)",
         "eor x21, x20, #0x1",
         "eor x21, x21, x4",
-        "ubfx x21, x21, #4, #1",
         "strb w21, [x28, #708]",
         "eor x21, x4, #0x1",
         "strb w21, [x28, #706]",
@@ -3720,7 +3684,7 @@
       ]
     },
     "dec ax": {
-      "ExpectedInstructionCount": 24,
+      "ExpectedInstructionCount": 23,
       "Optimal": "No",
       "Comment": "GROUP4 0xfe /1",
       "ExpectedArm64ASM": [
@@ -3730,7 +3694,6 @@
         "uxth w21, w21",
         "eor w22, w20, #0x1",
         "eor w22, w22, w21",
-        "ubfx w22, w22, #4, #1",
         "strb w22, [x28, #708]",
         "eor x22, x21, #0x1",
         "strb w22, [x28, #706]",
@@ -3751,7 +3714,7 @@
       ]
     },
     "dec eax": {
-      "ExpectedInstructionCount": 15,
+      "ExpectedInstructionCount": 14,
       "Optimal": "No",
       "Comment": "GROUP4 0xfe /1",
       "ExpectedArm64ASM": [
@@ -3759,7 +3722,6 @@
         "sub w4, w20, #0x1 (1)",
         "eor w21, w20, #0x1",
         "eor w21, w21, w4",
-        "ubfx w21, w21, #4, #1",
         "strb w21, [x28, #708]",
         "eor x21, x4, #0x1",
         "strb w21, [x28, #706]",
@@ -3773,7 +3735,7 @@
       ]
     },
     "dec rax": {
-      "ExpectedInstructionCount": 15,
+      "ExpectedInstructionCount": 14,
       "Optimal": "Yes",
       "Comment": "GROUP4 0xfe /1",
       "ExpectedArm64ASM": [
@@ -3781,7 +3743,6 @@
         "sub x4, x20, #0x1 (1)",
         "eor x21, x20, #0x1",
         "eor x21, x21, x4",
-        "ubfx x21, x21, #4, #1",
         "strb w21, [x28, #708]",
         "eor x21, x4, #0x1",
         "strb w21, [x28, #706]",

--- a/unittests/InstructionCountCI/Primary_32Bit.json
+++ b/unittests/InstructionCountCI/Primary_32Bit.json
@@ -94,13 +94,14 @@
       ]
     },
     "daa": {
-      "ExpectedInstructionCount": 54,
+      "ExpectedInstructionCount": 55,
       "Optimal": "No",
       "Comment": "0x27",
       "ExpectedArm64ASM": [
         "ldr w20, [x28, #728]",
         "ubfx w21, w20, #29, #1",
         "ldrb w22, [x28, #708]",
+        "ubfx w22, w22, #4, #1",
         "uxtb w23, w4",
         "and w20, w20, #0xdfffffff",
         "str w20, [x28, #728]",
@@ -119,7 +120,7 @@
         "ubfx w22, w20, #29, #1",
         "orr x22, x21, x22",
         "bfi w20, w22, #29, #1",
-        "mov w22, #0x1",
+        "mov w22, #0x10",
         "strb w22, [x28, #708]",
         "str w20, [x28, #728]",
         "cmp x23, #0x99 (153)",
@@ -155,13 +156,14 @@
       ]
     },
     "das": {
-      "ExpectedInstructionCount": 54,
+      "ExpectedInstructionCount": 55,
       "Optimal": "No",
       "Comment": "0x2f",
       "ExpectedArm64ASM": [
         "ldr w20, [x28, #728]",
         "ubfx w21, w20, #29, #1",
         "ldrb w22, [x28, #708]",
+        "ubfx w22, w22, #4, #1",
         "uxtb w23, w4",
         "and w20, w20, #0xdfffffff",
         "str w20, [x28, #728]",
@@ -180,7 +182,7 @@
         "ubfx w22, w20, #29, #1",
         "orr x22, x21, x22",
         "bfi w20, w22, #29, #1",
-        "mov w22, #0x1",
+        "mov w22, #0x10",
         "strb w22, [x28, #708]",
         "str w20, [x28, #728]",
         "cmp x23, #0x99 (153)",
@@ -216,11 +218,12 @@
       ]
     },
     "aaa": {
-      "ExpectedInstructionCount": 28,
+      "ExpectedInstructionCount": 29,
       "Optimal": "No",
       "Comment": "0x37",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #708]",
+        "ubfx w20, w20, #4, #1",
         "uxtb w21, w4",
         "uxth w22, w4",
         "and x21, x21, #0xf",
@@ -243,19 +246,20 @@
         "and x20, x20, x21",
         "bfxil w4, w20, #0, #16",
         "bfxil x4, x4, #0, #32",
-        "mov w20, #0x1",
-        "ldr w21, [x28, #728]",
-        "orr w21, w21, #0x20000000",
-        "strb w20, [x28, #708]",
-        "str w21, [x28, #728]"
+        "ldr w20, [x28, #728]",
+        "orr w20, w20, #0x20000000",
+        "mov w21, #0x10",
+        "strb w21, [x28, #708]",
+        "str w20, [x28, #728]"
       ]
     },
     "aas": {
-      "ExpectedInstructionCount": 29,
+      "ExpectedInstructionCount": 30,
       "Optimal": "No",
       "Comment": "0x3f",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #708]",
+        "ubfx w20, w20, #4, #1",
         "uxtb w21, w4",
         "uxth w22, w4",
         "and x21, x21, #0xf",
@@ -279,15 +283,15 @@
         "and x20, x20, x21",
         "bfxil w4, w20, #0, #16",
         "bfxil x4, x4, #0, #32",
-        "mov w20, #0x1",
-        "ldr w21, [x28, #728]",
-        "orr w21, w21, #0x20000000",
-        "strb w20, [x28, #708]",
-        "str w21, [x28, #728]"
+        "ldr w20, [x28, #728]",
+        "orr w20, w20, #0x20000000",
+        "mov w21, #0x10",
+        "strb w21, [x28, #708]",
+        "str w20, [x28, #728]"
       ]
     },
     "inc ax": {
-      "ExpectedInstructionCount": 25,
+      "ExpectedInstructionCount": 24,
       "Optimal": "No",
       "Comment": "0x40",
       "ExpectedArm64ASM": [
@@ -298,7 +302,6 @@
         "uxth w21, w21",
         "eor w22, w20, #0x1",
         "eor w22, w22, w21",
-        "ubfx w22, w22, #4, #1",
         "strb w22, [x28, #708]",
         "eor x22, x21, #0x1",
         "strb w22, [x28, #706]",
@@ -319,7 +322,7 @@
       ]
     },
     "inc eax": {
-      "ExpectedInstructionCount": 15,
+      "ExpectedInstructionCount": 14,
       "Optimal": "No",
       "Comment": "0x40",
       "ExpectedArm64ASM": [
@@ -328,7 +331,6 @@
         "bfxil x4, x4, #0, #32",
         "eor w21, w20, #0x1",
         "eor w21, w21, w4",
-        "ubfx w21, w21, #4, #1",
         "strb w21, [x28, #708]",
         "eor x21, x4, #0x1",
         "strb w21, [x28, #706]",
@@ -341,7 +343,7 @@
       ]
     },
     "dec ax": {
-      "ExpectedInstructionCount": 25,
+      "ExpectedInstructionCount": 24,
       "Optimal": "No",
       "Comment": "0x48",
       "ExpectedArm64ASM": [
@@ -352,7 +354,6 @@
         "uxth w21, w21",
         "eor w22, w20, #0x1",
         "eor w22, w22, w21",
-        "ubfx w22, w22, #4, #1",
         "strb w22, [x28, #708]",
         "eor x22, x21, #0x1",
         "strb w22, [x28, #706]",
@@ -373,7 +374,7 @@
       ]
     },
     "dec eax": {
-      "ExpectedInstructionCount": 16,
+      "ExpectedInstructionCount": 15,
       "Optimal": "No",
       "Comment": "0x48",
       "ExpectedArm64ASM": [
@@ -382,7 +383,6 @@
         "bfxil x4, x4, #0, #32",
         "eor w21, w20, #0x1",
         "eor w21, w21, w4",
-        "ubfx w21, w21, #4, #1",
         "strb w21, [x28, #708]",
         "eor x21, x4, #0x1",
         "strb w21, [x28, #706]",

--- a/unittests/InstructionCountCI/Secondary.json
+++ b/unittests/InstructionCountCI/Secondary.json
@@ -1933,20 +1933,20 @@
         "lsr w20, w20, #15",
         "orr x20, x22, x20",
         "bfxil x4, x20, #0, #16",
-        "mov w22, #0x0",
-        "lsl w23, w20, #16",
-        "and w23, w23, #0x80000000",
+        "lsl w22, w20, #16",
+        "and w22, w22, #0x80000000",
+        "mov w23, #0x0",
         "cmp x20, #0x0 (0)",
         "cset x24, eq",
-        "orr w23, w23, w24, lsl #30",
+        "orr w22, w22, w24, lsl #30",
         "ubfx w24, w21, #15, #1",
-        "orr w23, w23, w24, lsl #29",
+        "orr w22, w22, w24, lsl #29",
         "eor x24, x20, #0x1",
         "strb w24, [x28, #706]",
-        "strb w22, [x28, #708]",
+        "strb w23, [x28, #708]",
         "eor w20, w20, w21",
         "ubfx w20, w20, #15, #1",
-        "orr w20, w23, w20, lsl #28",
+        "orr w20, w22, w20, lsl #28",
         "str w20, [x28, #728]"
       ]
     },
@@ -1961,17 +1961,17 @@
         "lsr w20, w20, #1",
         "orr x20, x22, x20",
         "bfxil x4, x20, #0, #16",
-        "mov w22, #0x0",
-        "lsl w23, w20, #16",
-        "and w23, w23, #0x80000000",
+        "lsl w22, w20, #16",
+        "and w22, w22, #0x80000000",
+        "mov w23, #0x0",
         "cmp x20, #0x0 (0)",
         "cset x24, eq",
-        "orr w23, w23, w24, lsl #30",
+        "orr w22, w22, w24, lsl #30",
         "ubfx w21, w21, #1, #1",
-        "orr w21, w23, w21, lsl #29",
+        "orr w21, w22, w21, lsl #29",
         "eor x20, x20, #0x1",
         "strb w20, [x28, #706]",
-        "strb w22, [x28, #708]",
+        "strb w23, [x28, #708]",
         "str w21, [x28, #728]"
       ]
     },
@@ -2010,17 +2010,17 @@
         "lsr w20, w20, #17",
         "orr x20, x22, x20",
         "bfxil x4, x20, #0, #16",
-        "mov w22, #0x0",
-        "lsl w23, w20, #16",
-        "and w23, w23, #0x80000000",
+        "lsl w22, w20, #16",
+        "and w22, w22, #0x80000000",
+        "mov w23, #0x0",
         "cmp x20, #0x0 (0)",
         "cset x24, eq",
-        "orr w23, w23, w24, lsl #30",
+        "orr w22, w22, w24, lsl #30",
         "ubfx w21, w21, #1, #1",
-        "orr w21, w23, w21, lsl #29",
+        "orr w21, w22, w21, lsl #29",
         "eor x20, x20, #0x1",
         "strb w20, [x28, #706]",
-        "strb w22, [x28, #708]",
+        "strb w23, [x28, #708]",
         "str w21, [x28, #728]"
       ]
     },
@@ -2040,17 +2040,17 @@
         "lsr w20, w7, #0",
         "lsr w21, w4, #0",
         "extr w4, w21, w20, #31",
-        "mov w20, #0x0",
         "tst w4, w4",
-        "mrs x22, nzcv",
-        "lsr w23, w21, #31",
-        "orr w22, w22, w23, lsl #29",
-        "eor x23, x4, #0x1",
-        "strb w23, [x28, #706]",
-        "strb w20, [x28, #708]",
-        "eor w20, w4, w21",
-        "lsr w20, w20, #31",
-        "orr w20, w22, w20, lsl #28",
+        "mrs x20, nzcv",
+        "lsr w22, w21, #31",
+        "orr w20, w20, w22, lsl #29",
+        "eor x22, x4, #0x1",
+        "strb w22, [x28, #706]",
+        "mov w22, #0x0",
+        "strb w22, [x28, #708]",
+        "eor w21, w4, w21",
+        "lsr w21, w21, #31",
+        "orr w20, w20, w21, lsl #28",
         "str w20, [x28, #728]"
       ]
     },
@@ -2062,15 +2062,15 @@
         "lsr w20, w7, #0",
         "lsr w21, w4, #0",
         "extr w4, w21, w20, #17",
-        "mov w20, #0x0",
         "tst w4, w4",
-        "mrs x22, nzcv",
+        "mrs x20, nzcv",
         "ubfx w21, w21, #17, #1",
-        "orr w21, w22, w21, lsl #29",
-        "eor x22, x4, #0x1",
-        "strb w22, [x28, #706]",
-        "strb w20, [x28, #708]",
-        "str w21, [x28, #728]"
+        "orr w20, w20, w21, lsl #29",
+        "eor x21, x4, #0x1",
+        "strb w21, [x28, #706]",
+        "mov w21, #0x0",
+        "strb w21, [x28, #708]",
+        "str w20, [x28, #728]"
       ]
     },
     "shld eax, ebx, 16": {
@@ -2081,15 +2081,15 @@
         "lsr w20, w7, #0",
         "lsr w21, w4, #0",
         "extr w4, w21, w20, #16",
-        "mov w20, #0x0",
         "tst w4, w4",
-        "mrs x22, nzcv",
+        "mrs x20, nzcv",
         "ubfx w21, w21, #16, #1",
-        "orr w21, w22, w21, lsl #29",
-        "eor x22, x4, #0x1",
-        "strb w22, [x28, #706]",
-        "strb w20, [x28, #708]",
-        "str w21, [x28, #728]"
+        "orr w20, w20, w21, lsl #29",
+        "eor x21, x4, #0x1",
+        "strb w21, [x28, #706]",
+        "mov w21, #0x0",
+        "strb w21, [x28, #708]",
+        "str w20, [x28, #728]"
       ]
     },
     "shld eax, ebx, 31": {
@@ -2100,15 +2100,15 @@
         "lsr w20, w7, #0",
         "lsr w21, w4, #0",
         "extr w4, w21, w20, #1",
-        "mov w20, #0x0",
         "tst w4, w4",
-        "mrs x22, nzcv",
+        "mrs x20, nzcv",
         "ubfx w21, w21, #1, #1",
-        "orr w21, w22, w21, lsl #29",
-        "eor x22, x4, #0x1",
-        "strb w22, [x28, #706]",
-        "strb w20, [x28, #708]",
-        "str w21, [x28, #728]"
+        "orr w20, w20, w21, lsl #29",
+        "eor x21, x4, #0x1",
+        "strb w21, [x28, #706]",
+        "mov w21, #0x0",
+        "strb w21, [x28, #708]",
+        "str w20, [x28, #728]"
       ]
     },
     "shld rax, rbx, 0": {
@@ -2124,17 +2124,17 @@
       "ExpectedArm64ASM": [
         "mov x20, x4",
         "extr x4, x20, x7, #63",
-        "mov w21, #0x0",
         "tst x4, x4",
-        "mrs x22, nzcv",
-        "lsr x23, x20, #63",
-        "orr w22, w22, w23, lsl #29",
-        "eor x23, x4, #0x1",
-        "strb w23, [x28, #706]",
-        "strb w21, [x28, #708]",
+        "mrs x21, nzcv",
+        "lsr x22, x20, #63",
+        "orr w21, w21, w22, lsl #29",
+        "eor x22, x4, #0x1",
+        "strb w22, [x28, #706]",
+        "mov w22, #0x0",
+        "strb w22, [x28, #708]",
         "eor x20, x4, x20",
         "lsr x20, x20, #63",
-        "orr w20, w22, w20, lsl #28",
+        "orr w20, w21, w20, lsl #28",
         "str w20, [x28, #728]"
       ]
     },
@@ -2145,13 +2145,13 @@
       "ExpectedArm64ASM": [
         "mov x20, x4",
         "extr x4, x20, x7, #49",
-        "mov w21, #0x0",
         "tst x4, x4",
-        "mrs x22, nzcv",
+        "mrs x21, nzcv",
         "ubfx x20, x20, #49, #1",
-        "orr w20, w22, w20, lsl #29",
-        "eor x22, x4, #0x1",
-        "strb w22, [x28, #706]",
+        "orr w20, w21, w20, lsl #29",
+        "eor x21, x4, #0x1",
+        "strb w21, [x28, #706]",
+        "mov w21, #0x0",
         "strb w21, [x28, #708]",
         "str w20, [x28, #728]"
       ]
@@ -2163,13 +2163,13 @@
       "ExpectedArm64ASM": [
         "mov x20, x4",
         "extr x4, x20, x7, #32",
-        "mov w21, #0x0",
         "tst x4, x4",
-        "mrs x22, nzcv",
+        "mrs x21, nzcv",
         "ubfx x20, x20, #32, #1",
-        "orr w20, w22, w20, lsl #29",
-        "eor x22, x4, #0x1",
-        "strb w22, [x28, #706]",
+        "orr w20, w21, w20, lsl #29",
+        "eor x21, x4, #0x1",
+        "strb w21, [x28, #706]",
+        "mov w21, #0x0",
         "strb w21, [x28, #708]",
         "str w20, [x28, #728]"
       ]
@@ -2181,13 +2181,13 @@
       "ExpectedArm64ASM": [
         "mov x20, x4",
         "extr x4, x20, x7, #1",
-        "mov w21, #0x0",
         "tst x4, x4",
-        "mrs x22, nzcv",
+        "mrs x21, nzcv",
         "ubfx x20, x20, #1, #1",
-        "orr w20, w22, w20, lsl #29",
-        "eor x22, x4, #0x1",
-        "strb w22, [x28, #706]",
+        "orr w20, w21, w20, lsl #29",
+        "eor x21, x4, #0x1",
+        "strb w21, [x28, #706]",
+        "mov w21, #0x0",
         "strb w21, [x28, #708]",
         "str w20, [x28, #728]"
       ]
@@ -2524,7 +2524,7 @@
       ]
     },
     "cmpxchg al, bl": {
-      "ExpectedInstructionCount": 31,
+      "ExpectedInstructionCount": 30,
       "Optimal": "No",
       "Comment": "0x0f 0xb0",
       "ExpectedArm64ASM": [
@@ -2541,7 +2541,6 @@
         "uxtb x20, w20",
         "eor w21, w22, w23",
         "eor w21, w21, w20",
-        "ubfx w21, w21, #4, #1",
         "strb w21, [x28, #708]",
         "eor x21, x20, #0x1",
         "strb w21, [x28, #706]",
@@ -2562,7 +2561,7 @@
       ]
     },
     "cmpxchg [rax], bl": {
-      "ExpectedInstructionCount": 28,
+      "ExpectedInstructionCount": 27,
       "Optimal": "No",
       "Comment": "0x0f 0xb0",
       "ExpectedArm64ASM": [
@@ -2576,7 +2575,6 @@
         "uxtb w22, w22",
         "eor w23, w21, w20",
         "eor w23, w23, w22",
-        "ubfx w23, w23, #4, #1",
         "strb w23, [x28, #708]",
         "eor x23, x22, #0x1",
         "strb w23, [x28, #706]",
@@ -2597,7 +2595,7 @@
       ]
     },
     "cmpxchg ax, bx": {
-      "ExpectedInstructionCount": 31,
+      "ExpectedInstructionCount": 30,
       "Optimal": "No",
       "Comment": "0x0f 0xb1",
       "ExpectedArm64ASM": [
@@ -2614,7 +2612,6 @@
         "uxth x20, w20",
         "eor w21, w22, w23",
         "eor w21, w21, w20",
-        "ubfx w21, w21, #4, #1",
         "strb w21, [x28, #708]",
         "eor x21, x20, #0x1",
         "strb w21, [x28, #706]",
@@ -2635,7 +2632,7 @@
       ]
     },
     "cmpxchg [rax], bx": {
-      "ExpectedInstructionCount": 28,
+      "ExpectedInstructionCount": 27,
       "Optimal": "No",
       "Comment": "0x0f 0xb1",
       "ExpectedArm64ASM": [
@@ -2649,7 +2646,6 @@
         "uxth w22, w22",
         "eor w23, w21, w20",
         "eor w23, w23, w22",
-        "ubfx w23, w23, #4, #1",
         "strb w23, [x28, #708]",
         "eor x23, x22, #0x1",
         "strb w23, [x28, #706]",
@@ -2670,7 +2666,7 @@
       ]
     },
     "cmpxchg eax, ebx": {
-      "ExpectedInstructionCount": 23,
+      "ExpectedInstructionCount": 22,
       "Optimal": "No",
       "Comment": "0x0f 0xb1",
       "ExpectedArm64ASM": [
@@ -2689,7 +2685,6 @@
         "sub x20, x24, x25",
         "eor w21, w24, w25",
         "eor w21, w21, w20",
-        "ubfx w21, w21, #4, #1",
         "strb w21, [x28, #708]",
         "eor x20, x20, #0x1",
         "strb w20, [x28, #706]",
@@ -2700,7 +2695,7 @@
       ]
     },
     "cmpxchg [rax], ebx": {
-      "ExpectedInstructionCount": 19,
+      "ExpectedInstructionCount": 18,
       "Optimal": "No",
       "Comment": "0x0f 0xb1",
       "ExpectedArm64ASM": [
@@ -2715,7 +2710,6 @@
         "sub w21, w22, w20",
         "eor w23, w22, w20",
         "eor w23, w23, w21",
-        "ubfx w23, w23, #4, #1",
         "strb w23, [x28, #708]",
         "eor x21, x21, #0x1",
         "strb w21, [x28, #706]",
@@ -2726,7 +2720,7 @@
       ]
     },
     "cmpxchg rax, rbx": {
-      "ExpectedInstructionCount": 19,
+      "ExpectedInstructionCount": 18,
       "Optimal": "No",
       "Comment": "0x0f 0xb1",
       "ExpectedArm64ASM": [
@@ -2741,7 +2735,6 @@
         "sub x20, x21, x22",
         "eor x23, x21, x22",
         "eor x23, x23, x20",
-        "ubfx x23, x23, #4, #1",
         "strb w23, [x28, #708]",
         "eor x20, x20, #0x1",
         "strb w20, [x28, #706]",
@@ -2752,7 +2745,7 @@
       ]
     },
     "cmpxchg [rax], rbx": {
-      "ExpectedInstructionCount": 15,
+      "ExpectedInstructionCount": 14,
       "Optimal": "No",
       "Comment": "0x0f 0xb1",
       "ExpectedArm64ASM": [
@@ -2763,7 +2756,6 @@
         "sub x21, x20, x4",
         "eor x22, x20, x4",
         "eor x22, x22, x21",
-        "ubfx x22, x22, #4, #1",
         "strb w22, [x28, #708]",
         "eor x21, x21, #0x1",
         "strb w21, [x28, #706]",
@@ -3313,7 +3305,7 @@
       ]
     },
     "xadd al, bl": {
-      "ExpectedInstructionCount": 26,
+      "ExpectedInstructionCount": 25,
       "Optimal": "No",
       "Comment": "0x0f 0xc0",
       "ExpectedArm64ASM": [
@@ -3325,7 +3317,6 @@
         "uxtb w22, w22",
         "eor w23, w20, w21",
         "eor w23, w23, w22",
-        "ubfx w23, w23, #4, #1",
         "strb w23, [x28, #708]",
         "eor x23, x22, #0x1",
         "strb w23, [x28, #706]",
@@ -3346,7 +3337,7 @@
       ]
     },
     "xadd [rax], bl": {
-      "ExpectedInstructionCount": 25,
+      "ExpectedInstructionCount": 24,
       "Optimal": "No",
       "Comment": "0x0f 0xc0",
       "ExpectedArm64ASM": [
@@ -3357,7 +3348,6 @@
         "uxtb w22, w22",
         "eor w23, w21, w20",
         "eor w23, w23, w22",
-        "ubfx w23, w23, #4, #1",
         "strb w23, [x28, #708]",
         "eor x23, x22, #0x1",
         "strb w23, [x28, #706]",
@@ -3378,7 +3368,7 @@
       ]
     },
     "xadd ax, bx": {
-      "ExpectedInstructionCount": 26,
+      "ExpectedInstructionCount": 25,
       "Optimal": "No",
       "Comment": "0x0f 0xc1",
       "ExpectedArm64ASM": [
@@ -3390,7 +3380,6 @@
         "uxth w22, w22",
         "eor w23, w20, w21",
         "eor w23, w23, w22",
-        "ubfx w23, w23, #4, #1",
         "strb w23, [x28, #708]",
         "eor x23, x22, #0x1",
         "strb w23, [x28, #706]",
@@ -3411,7 +3400,7 @@
       ]
     },
     "xadd [rax], bx": {
-      "ExpectedInstructionCount": 25,
+      "ExpectedInstructionCount": 24,
       "Optimal": "No",
       "Comment": "0x0f 0xc1",
       "ExpectedArm64ASM": [
@@ -3422,7 +3411,6 @@
         "uxth w22, w22",
         "eor w23, w21, w20",
         "eor w23, w23, w22",
-        "ubfx w23, w23, #4, #1",
         "strb w23, [x28, #708]",
         "eor x23, x22, #0x1",
         "strb w23, [x28, #706]",
@@ -3443,7 +3431,7 @@
       ]
     },
     "xadd eax, ebx": {
-      "ExpectedInstructionCount": 13,
+      "ExpectedInstructionCount": 12,
       "Optimal": "No",
       "Comment": "0x0f 0xc1",
       "ExpectedArm64ASM": [
@@ -3453,7 +3441,6 @@
         "mov x7, x20",
         "eor w22, w20, w21",
         "eor w22, w22, w4",
-        "ubfx w22, w22, #4, #1",
         "strb w22, [x28, #708]",
         "eor x22, x4, #0x1",
         "strb w22, [x28, #706]",
@@ -3463,7 +3450,7 @@
       ]
     },
     "xadd [rax], ebx": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 11,
       "Optimal": "Yes",
       "Comment": "0x0f 0xc1",
       "ExpectedArm64ASM": [
@@ -3472,7 +3459,6 @@
         "add w21, w7, w20",
         "eor w22, w7, w20",
         "eor w22, w22, w21",
-        "ubfx w22, w22, #4, #1",
         "strb w22, [x28, #708]",
         "eor x21, x21, #0x1",
         "strb w21, [x28, #706]",
@@ -3482,7 +3468,7 @@
       ]
     },
     "xadd rax, rbx": {
-      "ExpectedInstructionCount": 13,
+      "ExpectedInstructionCount": 12,
       "Optimal": "No",
       "Comment": "0x0f 0xc1",
       "ExpectedArm64ASM": [
@@ -3492,7 +3478,6 @@
         "mov x7, x20",
         "eor x22, x20, x21",
         "eor x22, x22, x4",
-        "ubfx x22, x22, #4, #1",
         "strb w22, [x28, #708]",
         "eor x22, x4, #0x1",
         "strb w22, [x28, #706]",
@@ -3502,7 +3487,7 @@
       ]
     },
     "xadd [rax], rbx": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 11,
       "Optimal": "Yes",
       "Comment": "0x0f 0xc1",
       "ExpectedArm64ASM": [
@@ -3511,7 +3496,6 @@
         "add x21, x7, x20",
         "eor x22, x7, x20",
         "eor x22, x22, x21",
-        "ubfx x22, x22, #4, #1",
         "strb w22, [x28, #708]",
         "eor x21, x21, #0x1",
         "strb w21, [x28, #706]",


### PR DESCRIPTION
Save 1 instruction for all add/sub/cmp-like instructions by deferring part of the AF calculation. on top of #3035 