### PR TITLE
OpcodeDispatcher: Optimize calls with push

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -789,16 +789,13 @@ void OpDispatchBuilder::CALLOp(OpcodeArgs) {
   OrderedNode *JMPPCOffset = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
 
   OrderedNode *NewRIP = _Add(IR::SizeToOpSize(GPRSize), ConstantPC, JMPPCOffset);
-  auto ConstantPCReturn = GetRelocatedPC(Op);
 
-  auto ConstantSize = _Constant(GPRSize);
+  // Push the return address.
   auto OldSP = LoadGPRRegister(X86State::REG_RSP);
-  auto NewSP = _Sub(OpSize::i64Bit, OldSP, ConstantSize);
+  auto NewSP = _Push(GPRSize, GPRSize, ConstantPC, OldSP);
 
   // Store the new stack pointer
   StoreGPRRegister(X86State::REG_RSP, NewSP);
-
-  _StoreMem(GPRClass, GPRSize, NewSP, ConstantPCReturn, GPRSize);
 
   const uint64_t NextRIP = Op->PC + Op->InstSize;
   LOGMAN_THROW_A_FMT(Op->Src[0].IsLiteral(), "Had wrong operand type");
@@ -825,14 +822,12 @@ void OpDispatchBuilder::CALLAbsoluteOp(OpcodeArgs) {
 
   auto ConstantPCReturn = GetRelocatedPC(Op);
 
-  auto ConstantSize = _Constant(Size);
+  // Push the return address.
   auto OldSP = LoadGPRRegister(X86State::REG_RSP);
-  auto NewSP = _Sub(OpSize::i64Bit, OldSP, ConstantSize);
+  auto NewSP = _Push(Size, Size, ConstantPCReturn, OldSP);
 
   // Store the new stack pointer
   StoreGPRRegister(X86State::REG_RSP, NewSP);
-
-  _StoreMem(GPRClass, Size, NewSP, ConstantPCReturn, Size);
 
   // Store the RIP
   CalculateDeferredFlags();


### PR DESCRIPTION
InstCountCI doesn't cover branch instructions so needs manual inspection.

Branch instruction assembly:
```asm
; Header
adr x0, #-0x4 (addr 0xffffe228005c)
str x0, [x28, #184]
; Calculate return address
mov w20, #0xa
movk w20, #0x1, lsl #16
; Calculate target RIP (Only +1 in this instance)
add x21, x20, #0x1 (1)
; Push ret
str x20, [x8, #-8]!
; Load L1 code cache base
ldr x0, [x28, #1864]
; Calculate offset
and x3, x21, #0xfffff
add x0, x0, x3, lsl #4
; Load 128-bit values from base + offset
ldp x1, x0, [x0]
; Compare if L1 target RIP is current RIP
cmp x0, x21
; b.ne to dispatcher
b.ne #+0x8 (addr 0xffffe2280094)
; Jump to block target
br x1
; Dispatcher path. Load dispatcher PTR
ldr x0, [x28, #1776]
; Store current RIP to CPU state so dispatcher can pick it up
str x21, [x28]
; Branch to dispatcher.
br x0
```