### PR TITLE
OpcodeDispatcher: Optimize BLENDV when xmm0 is one of the sources 

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -3894,8 +3894,19 @@ void OpDispatchBuilder::VectorVariableBlend(OpcodeArgs) {
   OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
   OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
 
-  // The mask is hardcoded to be xmm0 in this instruction
-  auto Mask = LoadXMMRegister(0);
+  OrderedNode *Mask{};
+
+  // The mask is hardcoded to be xmm0 in this instruction.
+  // Reuse one of the incoming sources if it happens to be xmm0.
+  if (Op->Dest.Data.GPR.GPR == X86State::REG_XMM_0) {
+    Mask = Dest;
+  }
+  else if (Op->Src[0].IsGPR() && Op->Src[0].Data.GPR.GPR == X86State::REG_XMM_0) {
+    Mask = Src;
+  }
+  else {
+    Mask = LoadXMMRegister(0);
+  }
 
   // Each element is selected by the high bit of that element size
   // Dest[ElementIdx] = Xmm0[ElementIndex][HighBit] ? Src : Dest;

--- a/unittests/InstructionCountCI/H0F38.json
+++ b/unittests/InstructionCountCI/H0F38.json
@@ -350,42 +350,69 @@
       ]
     },
     "pblendvb xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0x10"
       ],
       "ExpectedArm64ASM": [
-        "mov v4.16b, v16.16b",
-        "sshr v5.16b, v16.16b, #7",
-        "mov v16.16b, v5.16b",
-        "bsl v16.16b, v17.16b, v4.16b"
+        "sshr v4.16b, v16.16b, #7",
+        "bit v16.16b, v17.16b, v4.16b"
       ]
     },
     "blendvps xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0x14"
       ],
       "ExpectedArm64ASM": [
-        "mov v4.16b, v16.16b",
-        "sshr v5.4s, v16.4s, #31",
-        "mov v16.16b, v5.16b",
-        "bsl v16.16b, v17.16b, v4.16b"
+        "sshr v4.4s, v16.4s, #31",
+        "bit v16.16b, v17.16b, v4.16b"
       ]
     },
     "blendvpd xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0x15"
       ],
       "ExpectedArm64ASM": [
-        "mov v4.16b, v16.16b",
-        "sshr v5.2d, v16.2d, #63",
-        "mov v16.16b, v5.16b",
-        "bsl v16.16b, v17.16b, v4.16b"
+        "sshr v4.2d, v16.2d, #63",
+        "bit v16.16b, v17.16b, v4.16b"
+      ]
+    },
+    "pblendvb xmm1, xmm2": {
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
+      "Comment": [
+        "0x66 0x0f 0x38 0x10"
+      ],
+      "ExpectedArm64ASM": [
+        "sshr v4.16b, v16.16b, #7",
+        "bit v17.16b, v18.16b, v4.16b"
+      ]
+    },
+    "blendvps xmm1, xmm2": {
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
+      "Comment": [
+        "0x66 0x0f 0x38 0x14"
+      ],
+      "ExpectedArm64ASM": [
+        "sshr v4.4s, v16.4s, #31",
+        "bit v17.16b, v18.16b, v4.16b"
+      ]
+    },
+    "blendvpd xmm1, xmm2": {
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
+      "Comment": [
+        "0x66 0x0f 0x38 0x15"
+      ],
+      "ExpectedArm64ASM": [
+        "sshr v4.2d, v16.2d, #63",
+        "bit v17.16b, v18.16b, v4.16b"
       ]
     },
     "ptest xmm0, xmm1": {


### PR DESCRIPTION
This instruction has xmm0 be one of the implicit sources. We were
loading xmm0 twice. https://github.com/FEX-Emu/FEX/pull/2700 would also fix this but that breaks other
things for some reason.

This was already optimal when one of the two explicit sources wasn't xmm0. So made sure to add those to InstCountCI.