### PR TITLE
Arm64: Optimize AES operations by caching a zero register 

### DIFF
--- a/FEXCore/Source/Interface/Core/CPUBackend.cpp
+++ b/FEXCore/Source/Interface/Core/CPUBackend.cpp
@@ -7,7 +7,7 @@
 namespace FEXCore {
 namespace CPU {
 
-constexpr static uint64_t NamedVectorConstants[FEXCore::IR::NamedVectorConstant::NAMED_VECTOR_MAX][2] = {
+constexpr static uint64_t NamedVectorConstants[FEXCore::IR::NamedVectorConstant::NAMED_VECTOR_CONST_POOL_MAX][2] = {
   {0x0003'0002'0001'0000ULL, 0x0007'0006'0005'0004ULL}, // NAMED_VECTOR_INCREMENTAL_U16_INDEX
   {0x000B'000A'0009'0008ULL, 0x000F'000E'000D'000CULL}, // NAMED_VECTOR_INCREMENTAL_U16_INDEX_UPPER
   {0x0000'0000'8000'0000ULL, 0x0000'0000'8000'0000ULL}, // NAMED_VECTOR_PADDSUBPS_INVERT
@@ -132,7 +132,7 @@ CPUBackend::CPUBackend(FEXCore::Core::InternalThreadState *ThreadState, size_t I
   auto &Common = ThreadState->CurrentFrame->Pointers.Common;
 
   // Initialize named vector constants.
-  for (size_t i = 0; i < FEXCore::IR::NamedVectorConstant::NAMED_VECTOR_MAX; ++i) {
+  for (size_t i = 0; i < FEXCore::IR::NamedVectorConstant::NAMED_VECTOR_CONST_POOL_MAX; ++i) {
     Common.NamedVectorConstantPointers[i] = reinterpret_cast<uint64_t>(NamedVectorConstants[i]);
   }
 

--- a/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
@@ -50,6 +50,15 @@ DEF_OP(LoadNamedVectorConstant) {
   auto Op = IROp->C<IR::IROp_LoadNamedVectorConstant>();
   uint8_t OpSize = IROp->Size;
 
+  switch (Op->Constant) {
+    case FEXCore::IR::NamedVectorConstant::NAMED_VECTOR_ZERO:
+      memset(GDP, 0, OpSize);
+      return;
+    default:
+      // Intentionally doing nothing.
+      break;
+  }
+
   memcpy(GDP, reinterpret_cast<void*>(Data->State->CurrentFrame->Pointers.Common.NamedVectorConstantPointers[Op->Constant]), OpSize);
 }
 

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -80,6 +80,14 @@ DEF_OP(LoadNamedVectorConstant) {
   const auto OpSize = IROp->Size;
 
   const auto Dst = GetVReg(Node);
+  switch (Op->Constant) {
+    case FEXCore::IR::NamedVectorConstant::NAMED_VECTOR_ZERO:
+      movi(ARMEmitter::SubRegSize::i64Bit, Dst.Q(), 0);
+      return;
+    default:
+      // Intentionally doing nothing.
+      break;
+  }
 
   if (HostSupportsSVE128) {
     switch (Op->Constant) {

--- a/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
@@ -75,10 +75,18 @@ DEF_OP(VectorImm) {
 DEF_OP(LoadNamedVectorConstant) {
   const auto Op = IROp->C<IR::IROp_LoadNamedVectorConstant>();
   const auto OpSize = IROp->Size;
+  const auto Dst = GetDst(Node);
+
+  switch (Op->Constant) {
+    case FEXCore::IR::NamedVectorConstant::NAMED_VECTOR_ZERO:
+      vpxor(Dst, Dst, Dst);
+      return;
+    default:
+      // Intentionally doing nothing.
+      break;
+  }
 
   mov(TMP1, qword STATE_PTR(CpuStateFrame, Pointers.Common.NamedVectorConstantPointers[Op->Constant]));
-
-  const auto Dst = GetDst(Node);
 
   switch (OpSize) {
     case 1:

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -1139,6 +1139,7 @@ void OpDispatchBuilder::CondJUMPOp(OpcodeArgs) {
       auto JumpTarget = CreateNewCodeBlockAtEnd();
       SetTrueJumpTarget(CondJump, JumpTarget);
       SetCurrentCodeBlock(JumpTarget);
+      StartNewBlock();
 
       auto NewRIP = GetRelocatedPC(Op, TargetOffset);
 
@@ -1156,6 +1157,7 @@ void OpDispatchBuilder::CondJUMPOp(OpcodeArgs) {
       auto JumpTarget = CreateNewCodeBlockAfter(CurrentBlock);
       SetFalseJumpTarget(CondJump, JumpTarget);
       SetCurrentCodeBlock(JumpTarget);
+      StartNewBlock();
 
       // Leave block
       auto RIPTargetConst = GetRelocatedPC(Op);
@@ -1202,6 +1204,7 @@ void OpDispatchBuilder::CondJUMPRCXOp(OpcodeArgs) {
       auto JumpTarget = CreateNewCodeBlockAtEnd();
       SetTrueJumpTarget(CondJump, JumpTarget);
       SetCurrentCodeBlock(JumpTarget);
+      StartNewBlock();
 
       auto NewRIP = GetRelocatedPC(Op, Op->Src[0].Data.Literal.Value);
 
@@ -1219,6 +1222,7 @@ void OpDispatchBuilder::CondJUMPRCXOp(OpcodeArgs) {
       auto JumpTarget = CreateNewCodeBlockAfter(CurrentBlock);
       SetFalseJumpTarget(CondJump, JumpTarget);
       SetCurrentCodeBlock(JumpTarget);
+      StartNewBlock();
 
       // Leave block
       auto RIPTargetConst = GetRelocatedPC(Op);
@@ -1282,6 +1286,7 @@ void OpDispatchBuilder::LoopOp(OpcodeArgs) {
       auto JumpTarget = CreateNewCodeBlockAtEnd();
       SetTrueJumpTarget(CondJump, JumpTarget);
       SetCurrentCodeBlock(JumpTarget);
+      StartNewBlock();
 
       auto NewRIP = GetRelocatedPC(Op, Op->Src[1].Data.Literal.Value);
 
@@ -1299,6 +1304,7 @@ void OpDispatchBuilder::LoopOp(OpcodeArgs) {
       auto JumpTarget = CreateNewCodeBlockAfter(GetCurrentBlock());
       SetFalseJumpTarget(CondJump, JumpTarget);
       SetCurrentCodeBlock(JumpTarget);
+      StartNewBlock();
 
       // Leave block
       auto RIPTargetConst = GetRelocatedPC(Op);
@@ -1350,6 +1356,7 @@ void OpDispatchBuilder::JUMPOp(OpcodeArgs) {
       auto JumpTarget = CreateNewCodeBlockAfter(GetCurrentBlock());
       SetJumpTarget(Jump, JumpTarget);
       SetCurrentCodeBlock(JumpTarget);
+      StartNewBlock();
       _ExitFunction(GetRelocatedPC(Op, TargetOffset));
     }
     return;
@@ -1929,6 +1936,7 @@ void OpDispatchBuilder::SHLDOp(OpcodeArgs) {
   auto JumpTarget = CreateNewCodeBlockAfter(CurrentBlock);
   SetFalseJumpTarget(CondJump, JumpTarget);
   SetCurrentCodeBlock(JumpTarget);
+  StartNewBlock();
 
   if (Size != 64) {
     Res = _Bfe(OpSize::i64Bit, Size, 0, Res);
@@ -1943,6 +1951,7 @@ void OpDispatchBuilder::SHLDOp(OpcodeArgs) {
   SetJumpTarget(Jump, NextJumpTarget);
   SetTrueJumpTarget(CondJump, NextJumpTarget);
   SetCurrentCodeBlock(NextJumpTarget);
+  StartNewBlock();
 }
 
 void OpDispatchBuilder::SHLDImmediateOp(OpcodeArgs) {
@@ -2027,6 +2036,7 @@ void OpDispatchBuilder::SHRDOp(OpcodeArgs) {
   auto JumpTarget = CreateNewCodeBlockAfter(GetCurrentBlock());
   SetFalseJumpTarget(CondJump, JumpTarget);
   SetCurrentCodeBlock(JumpTarget);
+  StartNewBlock();
 
   if (Size != 64) {
     Res = _Bfe(OpSize::i64Bit, Size, 0, Res);
@@ -2041,6 +2051,7 @@ void OpDispatchBuilder::SHRDOp(OpcodeArgs) {
   SetJumpTarget(Jump, NextJumpTarget);
   SetTrueJumpTarget(CondJump, NextJumpTarget);
   SetCurrentCodeBlock(NextJumpTarget);
+  StartNewBlock();
 }
 
 void OpDispatchBuilder::SHRDImmediateOp(OpcodeArgs) {
@@ -3424,11 +3435,13 @@ void OpDispatchBuilder::DAAOp(OpcodeArgs) {
   CalculateDeferredFlags();
   _CondJump(Cond, TrueBlock, FalseBlock);
   SetCurrentCodeBlock(FalseBlock);
+  StartNewBlock();
   {
     SetRFLAG<FEXCore::X86State::RFLAG_AF_LOC>(_Constant(0));
     _Jump(EndBlock);
   }
   SetCurrentCodeBlock(TrueBlock);
+  StartNewBlock();
   {
     auto NewAL = _Add(OpSize::i64Bit, AL, _Constant(0x6));
     StoreGPRRegister(X86State::REG_RAX, NewAL, 1);
@@ -3444,6 +3457,7 @@ void OpDispatchBuilder::DAAOp(OpcodeArgs) {
     _Jump(EndBlock);
   }
   SetCurrentCodeBlock(EndBlock);
+  StartNewBlock();
 
   Cond = _Or(OpSize::i64Bit, CF, _Select(FEXCore::IR::COND_UGT, AL, _Constant(0x99), _Constant(1), _Constant(0)));
   FalseBlock = CreateNewCodeBlockAfter(GetCurrentBlock());
@@ -3451,12 +3465,14 @@ void OpDispatchBuilder::DAAOp(OpcodeArgs) {
   EndBlock = CreateNewCodeBlockAfter(TrueBlock);
   _CondJump(Cond, TrueBlock, FalseBlock);
   SetCurrentCodeBlock(FalseBlock);
+  StartNewBlock();
   {
     SetRFLAG<FEXCore::X86State::RFLAG_CF_LOC>(_Constant(0));
     CalculateDeferredFlags();
     _Jump(EndBlock);
   }
   SetCurrentCodeBlock(TrueBlock);
+  StartNewBlock();
   {
     AL = LoadGPRRegister(X86State::REG_RAX, 1);
 
@@ -3467,6 +3483,7 @@ void OpDispatchBuilder::DAAOp(OpcodeArgs) {
     _Jump(EndBlock);
   }
   SetCurrentCodeBlock(EndBlock);
+  StartNewBlock();
   // Update Flags
   AL = LoadGPRRegister(X86State::REG_RAX, 1);
 
@@ -3492,11 +3509,13 @@ void OpDispatchBuilder::DASOp(OpcodeArgs) {
   CalculateDeferredFlags();
   _CondJump(Cond, TrueBlock, FalseBlock);
   SetCurrentCodeBlock(FalseBlock);
+  StartNewBlock();
   {
     SetRFLAG<FEXCore::X86State::RFLAG_AF_LOC>(_Constant(0));
     _Jump(EndBlock);
   }
   SetCurrentCodeBlock(TrueBlock);
+  StartNewBlock();
   {
     auto NewAL = _Sub(OpSize::i64Bit, AL, _Constant(0x6));
     StoreGPRRegister(X86State::REG_RAX, NewAL, 1);
@@ -3512,6 +3531,7 @@ void OpDispatchBuilder::DASOp(OpcodeArgs) {
     _Jump(EndBlock);
   }
   SetCurrentCodeBlock(EndBlock);
+  StartNewBlock();
 
   Cond = _Or(OpSize::i64Bit, CF, _Select(FEXCore::IR::COND_UGT, AL, _Constant(0x99), _Constant(1), _Constant(0)));
   FalseBlock = CreateNewCodeBlockAfter(GetCurrentBlock());
@@ -3519,12 +3539,14 @@ void OpDispatchBuilder::DASOp(OpcodeArgs) {
   EndBlock = CreateNewCodeBlockAfter(TrueBlock);
   _CondJump(Cond, TrueBlock, FalseBlock);
   SetCurrentCodeBlock(FalseBlock);
+  StartNewBlock();
   {
     SetRFLAG<FEXCore::X86State::RFLAG_CF_LOC>(_Constant(0));
     CalculateDeferredFlags();
     _Jump(EndBlock);
   }
   SetCurrentCodeBlock(TrueBlock);
+  StartNewBlock();
   {
     AL = LoadGPRRegister(X86State::REG_RAX, 1);
     auto NewAL = _Sub(OpSize::i64Bit, AL, _Constant(0x60));
@@ -3534,6 +3556,7 @@ void OpDispatchBuilder::DASOp(OpcodeArgs) {
     _Jump(EndBlock);
   }
   SetCurrentCodeBlock(EndBlock);
+  StartNewBlock();
   // Update Flags
   AL = LoadGPRRegister(X86State::REG_RAX, 1);
   SetRFLAG<FEXCore::X86State::RFLAG_SF_LOC>(_Select(FEXCore::IR::COND_UGE, _And(OpSize::i64Bit, AL, _Constant(0x80)), _Constant(0), _Constant(1), _Constant(0)));
@@ -3555,6 +3578,7 @@ void OpDispatchBuilder::AAAOp(OpcodeArgs) {
   _CondJump(Cond, TrueBlock, FalseBlock);
 
   SetCurrentCodeBlock(FalseBlock);
+  StartNewBlock();
   {
     auto NewAX = _And(OpSize::i64Bit, AX, _Constant(0xFF0F));
     StoreGPRRegister(X86State::REG_RAX, NewAX, 2);
@@ -3564,6 +3588,8 @@ void OpDispatchBuilder::AAAOp(OpcodeArgs) {
     _Jump(EndBlock);
   }
   SetCurrentCodeBlock(TrueBlock);
+  StartNewBlock();
+
   {
     auto NewAX = _Add(OpSize::i64Bit, AX, _Constant(0x106));
     auto Result = _And(OpSize::i64Bit, NewAX, _Constant(0xFF0F));
@@ -3574,6 +3600,7 @@ void OpDispatchBuilder::AAAOp(OpcodeArgs) {
     _Jump(EndBlock);
   }
   SetCurrentCodeBlock(EndBlock);
+  StartNewBlock();
 }
 
 void OpDispatchBuilder::AASOp(OpcodeArgs) {
@@ -3590,6 +3617,7 @@ void OpDispatchBuilder::AASOp(OpcodeArgs) {
   _CondJump(Cond, TrueBlock, FalseBlock);
 
   SetCurrentCodeBlock(FalseBlock);
+  StartNewBlock();
   {
     auto NewAX = _And(OpSize::i64Bit, AX, _Constant(0xFF0F));
     StoreGPRRegister(X86State::REG_RAX, NewAX, 2);
@@ -3599,6 +3627,7 @@ void OpDispatchBuilder::AASOp(OpcodeArgs) {
     _Jump(EndBlock);
   }
   SetCurrentCodeBlock(TrueBlock);
+  StartNewBlock();
   {
     auto NewAX = _Sub(OpSize::i64Bit, AX, _Constant(6));
     NewAX = _Sub(OpSize::i64Bit, NewAX, _Constant(0x100));
@@ -3610,6 +3639,7 @@ void OpDispatchBuilder::AASOp(OpcodeArgs) {
     _Jump(EndBlock);
   }
   SetCurrentCodeBlock(EndBlock);
+  StartNewBlock();
 }
 
 void OpDispatchBuilder::AAMOp(OpcodeArgs) {
@@ -3995,6 +4025,7 @@ void OpDispatchBuilder::CMPSOp(OpcodeArgs) {
     auto LoopStart = CreateNewCodeBlockAfter(GetCurrentBlock());
     SetJumpTarget(JumpStart, LoopStart);
     SetCurrentCodeBlock(LoopStart);
+    StartNewBlock();
 
     OrderedNode *Counter = LoadGPRRegister(X86State::REG_RCX);
 
@@ -4005,6 +4036,7 @@ void OpDispatchBuilder::CMPSOp(OpcodeArgs) {
     auto LoopTail = CreateNewCodeBlockAfter(LoopStart);
     SetFalseJumpTarget(CondJump, LoopTail);
     SetCurrentCodeBlock(LoopTail);
+    StartNewBlock();
 
     // Working loop
     {
@@ -4059,6 +4091,7 @@ void OpDispatchBuilder::CMPSOp(OpcodeArgs) {
     SetFalseJumpTarget(InternalCondJump, LoopEnd);
 
     SetCurrentCodeBlock(LoopEnd);
+    StartNewBlock();
   }
 }
 
@@ -4118,6 +4151,7 @@ void OpDispatchBuilder::LODSOp(OpcodeArgs) {
     auto LoopStart = CreateNewCodeBlockAfter(GetCurrentBlock());
     SetJumpTarget(JumpStart, LoopStart);
     SetCurrentCodeBlock(LoopStart);
+    StartNewBlock();
 
     OrderedNode *Counter = LoadGPRRegister(X86State::REG_RCX);
 
@@ -4129,6 +4163,7 @@ void OpDispatchBuilder::LODSOp(OpcodeArgs) {
     auto LoopTail = CreateNewCodeBlockAfter(LoopStart);
     SetFalseJumpTarget(CondJump, LoopTail);
     SetCurrentCodeBlock(LoopTail);
+    StartNewBlock();
 
     // Working loop
     {
@@ -4160,6 +4195,7 @@ void OpDispatchBuilder::LODSOp(OpcodeArgs) {
     auto LoopEnd = CreateNewCodeBlockAfter(LoopTail);
     SetTrueJumpTarget(CondJump, LoopEnd);
     SetCurrentCodeBlock(LoopEnd);
+    StartNewBlock();
   }
 }
 
@@ -4220,6 +4256,7 @@ void OpDispatchBuilder::SCASOp(OpcodeArgs) {
     auto LoopStart = CreateNewCodeBlockAfter(GetCurrentBlock());
     SetJumpTarget(JumpStart, LoopStart);
     SetCurrentCodeBlock(LoopStart);
+    StartNewBlock();
 
     OrderedNode *Counter = LoadGPRRegister(X86State::REG_RCX);
 
@@ -4231,6 +4268,7 @@ void OpDispatchBuilder::SCASOp(OpcodeArgs) {
     auto LoopTail = CreateNewCodeBlockAfter(LoopStart);
     SetFalseJumpTarget(CondJump, LoopTail);
     SetCurrentCodeBlock(LoopTail);
+    StartNewBlock();
 
     // Working loop
     {
@@ -4277,6 +4315,7 @@ void OpDispatchBuilder::SCASOp(OpcodeArgs) {
     SetFalseJumpTarget(InternalCondJump, LoopEnd);
 
     SetCurrentCodeBlock(LoopEnd);
+    StartNewBlock();
   }
 }
 
@@ -4702,6 +4741,7 @@ void OpDispatchBuilder::CMPXCHGPairOp(OpcodeArgs) {
   auto JumpTarget = CreateNewCodeBlockAfter(GetCurrentBlock());
   SetFalseJumpTarget(CondJump, JumpTarget);
   SetCurrentCodeBlock(JumpTarget);
+  StartNewBlock();
 
   StoreGPRRegister(X86State::REG_RAX, Result_Lower);
   StoreGPRRegister(X86State::REG_RDX, Result_Upper);
@@ -4711,6 +4751,7 @@ void OpDispatchBuilder::CMPXCHGPairOp(OpcodeArgs) {
   SetJumpTarget(Jump, NextJumpTarget);
   SetTrueJumpTarget(CondJump, NextJumpTarget);
   SetCurrentCodeBlock(NextJumpTarget);
+  StartNewBlock();
 }
 
 void OpDispatchBuilder::CreateJumpBlocks(fextl::vector<FEXCore::Frontend::Decoder::DecodedBlocks> const *Blocks) {
@@ -5560,6 +5601,7 @@ void OpDispatchBuilder::INTOp(OpcodeArgs) {
     auto FalseBlock = CreateNewCodeBlockAfter(GetCurrentBlock());
     SetFalseJumpTarget(CondJump, FalseBlock);
     SetCurrentCodeBlock(FalseBlock);
+    StartNewBlock();
 
     auto NewRIP = GetRelocatedPC(Op);
     _StoreContext(GPRSize, GPRClass, NewRIP, offsetof(FEXCore::Core::CPUState, rip));
@@ -5569,6 +5611,7 @@ void OpDispatchBuilder::INTOp(OpcodeArgs) {
     auto JumpTarget = CreateNewCodeBlockAfter(FalseBlock);
     SetTrueJumpTarget(CondJump, JumpTarget);
     SetCurrentCodeBlock(JumpTarget);
+    StartNewBlock();
   }
   else {
     BlockSetRIP = true;
@@ -5712,6 +5755,7 @@ void OpDispatchBuilder::UnimplementedOp(OpcodeArgs) {
   if (Multiblock) {
     auto NextBlock = CreateNewCodeBlockAfter(GetCurrentBlock());
     SetCurrentCodeBlock(NextBlock);
+    StartNewBlock();
   }
 }
 

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Crypto.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Crypto.cpp
@@ -267,7 +267,8 @@ void OpDispatchBuilder::AESImcOp(OpcodeArgs) {
 void OpDispatchBuilder::AESEncOp(OpcodeArgs) {
   OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
   OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-  OrderedNode *Result = _VAESEnc(16, Dest, Src);
+  const auto ZeroRegister = LoadAndCacheNamedVectorConstant(16, FEXCore::IR::NamedVectorConstant::NAMED_VECTOR_ZERO);
+  OrderedNode *Result = _VAESEnc(16, Dest, Src, ZeroRegister);
   StoreResult(FPRClass, Op, Result, -1);
 }
 
@@ -280,7 +281,8 @@ void OpDispatchBuilder::VAESEncOp(OpcodeArgs) {
 
   OrderedNode *State = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
   OrderedNode *Key = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags, -1);
-  OrderedNode *Result = _VAESEnc(DstSize, State, Key);
+  const auto ZeroRegister = LoadAndCacheNamedVectorConstant(DstSize, FEXCore::IR::NamedVectorConstant::NAMED_VECTOR_ZERO);
+  OrderedNode *Result = _VAESEnc(DstSize, State, Key, ZeroRegister);
 
   StoreResult(FPRClass, Op, Result, -1);
 }
@@ -288,7 +290,8 @@ void OpDispatchBuilder::VAESEncOp(OpcodeArgs) {
 void OpDispatchBuilder::AESEncLastOp(OpcodeArgs) {
   OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
   OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-  OrderedNode *Result = _VAESEncLast(16, Dest, Src);
+  const auto ZeroRegister = LoadAndCacheNamedVectorConstant(16, FEXCore::IR::NamedVectorConstant::NAMED_VECTOR_ZERO);
+  OrderedNode *Result = _VAESEncLast(16, Dest, Src, ZeroRegister);
   StoreResult(FPRClass, Op, Result, -1);
 }
 
@@ -301,7 +304,8 @@ void OpDispatchBuilder::VAESEncLastOp(OpcodeArgs) {
 
   OrderedNode *State = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
   OrderedNode *Key = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags, -1);
-  OrderedNode *Result = _VAESEncLast(DstSize, State, Key);
+  const auto ZeroRegister = LoadAndCacheNamedVectorConstant(DstSize, FEXCore::IR::NamedVectorConstant::NAMED_VECTOR_ZERO);
+  OrderedNode *Result = _VAESEncLast(DstSize, State, Key, ZeroRegister);
 
   StoreResult(FPRClass, Op, Result, -1);
 }
@@ -309,7 +313,8 @@ void OpDispatchBuilder::VAESEncLastOp(OpcodeArgs) {
 void OpDispatchBuilder::AESDecOp(OpcodeArgs) {
   OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
   OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-  OrderedNode *Result = _VAESDec(16, Dest, Src);
+  const auto ZeroRegister = LoadAndCacheNamedVectorConstant(16, FEXCore::IR::NamedVectorConstant::NAMED_VECTOR_ZERO);
+  OrderedNode *Result = _VAESDec(16, Dest, Src, ZeroRegister);
   StoreResult(FPRClass, Op, Result, -1);
 }
 
@@ -322,7 +327,8 @@ void OpDispatchBuilder::VAESDecOp(OpcodeArgs) {
 
   OrderedNode *State = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
   OrderedNode *Key = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags, -1);
-  OrderedNode *Result = _VAESDec(DstSize, State, Key);
+  const auto ZeroRegister = LoadAndCacheNamedVectorConstant(DstSize, FEXCore::IR::NamedVectorConstant::NAMED_VECTOR_ZERO);
+  OrderedNode *Result = _VAESDec(DstSize, State, Key, ZeroRegister);
 
   StoreResult(FPRClass, Op, Result, -1);
 }
@@ -330,7 +336,8 @@ void OpDispatchBuilder::VAESDecOp(OpcodeArgs) {
 void OpDispatchBuilder::AESDecLastOp(OpcodeArgs) {
   OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
   OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-  OrderedNode *Result = _VAESDecLast(16, Dest, Src);
+  const auto ZeroRegister = LoadAndCacheNamedVectorConstant(16, FEXCore::IR::NamedVectorConstant::NAMED_VECTOR_ZERO);
+  OrderedNode *Result = _VAESDecLast(16, Dest, Src, ZeroRegister);
   StoreResult(FPRClass, Op, Result, -1);
 }
 
@@ -343,7 +350,8 @@ void OpDispatchBuilder::VAESDecLastOp(OpcodeArgs) {
 
   OrderedNode *State = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
   OrderedNode *Key = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags, -1);
-  OrderedNode *Result = _VAESDecLast(DstSize, State, Key);
+  const auto ZeroRegister = LoadAndCacheNamedVectorConstant(DstSize, FEXCore::IR::NamedVectorConstant::NAMED_VECTOR_ZERO);
+  OrderedNode *Result = _VAESDecLast(DstSize, State, Key, ZeroRegister);
 
   StoreResult(FPRClass, Op, Result, -1);
 }
@@ -354,7 +362,8 @@ OrderedNode* OpDispatchBuilder::AESKeyGenAssistImpl(OpcodeArgs) {
   const uint64_t RCON = Op->Src[1].Data.Literal.Value;
 
   auto KeyGenSwizzle = LoadAndCacheNamedVectorConstant(16, NAMED_VECTOR_AESKEYGENASSIST_SWIZZLE);
-  return _VAESKeyGenAssist(Src, KeyGenSwizzle, RCON);
+  const auto ZeroRegister = LoadAndCacheNamedVectorConstant(16, FEXCore::IR::NamedVectorConstant::NAMED_VECTOR_ZERO);
+  return _VAESKeyGenAssist(Src, KeyGenSwizzle, ZeroRegister, RCON);
 }
 
 void OpDispatchBuilder::AESKeyGenAssist(OpcodeArgs) {

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -2550,6 +2550,7 @@ void OpDispatchBuilder::XSaveOpImpl(OpcodeArgs) {
     auto StoreBlock = CreateNewCodeBlockAfter(GetCurrentBlock());
     SetTrueJumpTarget(CondJump, StoreBlock);
     SetCurrentCodeBlock(StoreBlock);
+    StartNewBlock();
     {
       fn();
     }
@@ -2558,6 +2559,7 @@ void OpDispatchBuilder::XSaveOpImpl(OpcodeArgs) {
     SetJumpTarget(Jump, NextJumpTarget);
     SetFalseJumpTarget(CondJump, NextJumpTarget);
     SetCurrentCodeBlock(NextJumpTarget);
+    StartNewBlock();
   };
 
   // x87
@@ -2758,6 +2760,7 @@ void OpDispatchBuilder::XRstorOpImpl(OpcodeArgs) {
     auto RestoreBlock = CreateNewCodeBlockAfter(GetCurrentBlock());
     SetTrueJumpTarget(CondJump, RestoreBlock);
     SetCurrentCodeBlock(RestoreBlock);
+    StartNewBlock();
     {
       restore_fn();
     }
@@ -2767,12 +2770,14 @@ void OpDispatchBuilder::XRstorOpImpl(OpcodeArgs) {
     SetJumpTarget(RestoreExitJump, ExitBlock);
     SetFalseJumpTarget(CondJump, DefaultBlock);
     SetCurrentCodeBlock(DefaultBlock);
+    StartNewBlock();
     {
       default_fn();
     }
     auto DefaultExitJump = _Jump();
     SetJumpTarget(DefaultExitJump, ExitBlock);
     SetCurrentCodeBlock(ExitBlock);
+    StartNewBlock();
   };
 
   // x87

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -1831,23 +1831,23 @@
         "Desc": "Does a stage of the inverse mix column transformation",
         "DestSize": "16"
       },
-      "FPR = VAESEnc u8:#RegisterSize, FPR:$State, FPR:$Key": {
+      "FPR = VAESEnc u8:#RegisterSize, FPR:$State, FPR:$Key, FPR:$ZeroReg": {
         "Desc": "Does a step of AES encryption",
         "DestSize": "RegisterSize"
       },
-      "FPR = VAESEncLast u8:#RegisterSize, FPR:$State, FPR:$Key": {
+      "FPR = VAESEncLast u8:#RegisterSize, FPR:$State, FPR:$Key, FPR:$ZeroReg": {
         "Desc": "Does the last step of AES encryption",
         "DestSize": "RegisterSize"
       },
-      "FPR = VAESDec u8:#RegisterSize, FPR:$State, FPR:$Key": {
+      "FPR = VAESDec u8:#RegisterSize, FPR:$State, FPR:$Key, FPR:$ZeroReg": {
         "Desc": "Does a step of AES decryption",
         "DestSize": "RegisterSize"
       },
-      "FPR = VAESDecLast u8:#RegisterSize, FPR:$State, FPR:$Key": {
+      "FPR = VAESDecLast u8:#RegisterSize, FPR:$State, FPR:$Key, FPR:$ZeroReg": {
         "Desc": "Does the last step of AES decryption",
         "DestSize": "RegisterSize"
       },
-      "FPR = VAESKeyGenAssist FPR:$Src, FPR:$KeyGenTBLSwizzle, u8:$RCON": {
+      "FPR = VAESKeyGenAssist FPR:$Src, FPR:$KeyGenTBLSwizzle, FPR:$ZeroReg, u8:$RCON": {
         "Desc": "Assists in key generation",
         "DestSize": "16"
       },

--- a/FEXCore/Source/Interface/IR/IRDumper.cpp
+++ b/FEXCore/Source/Interface/IR/IRDumper.cpp
@@ -209,6 +209,18 @@ static void PrintArg(fextl::stringstream *out, [[maybe_unused]] IRListView const
       *out << "addsubpd_invert_upper";
       break;
     }
+    case FEXCore::IR::NamedVectorConstant::NAMED_VECTOR_MOVMSKPS_SHIFT: {
+      *out << "movmskps_shift";
+      break;
+    }
+    case FEXCore::IR::NamedVectorConstant::NAMED_VECTOR_AESKEYGENASSIST_SWIZZLE: {
+      *out << "aeskeygenassist_swizzle";
+      break;
+    }
+    case FEXCore::IR::NamedVectorConstant::NAMED_VECTOR_ZERO: {
+      *out << "vectorzero";
+      break;
+    }
     default: *out << "<Unknown Named Vector Constant>"; break;
   }
 }

--- a/FEXCore/include/FEXCore/Core/CoreState.h
+++ b/FEXCore/include/FEXCore/Core/CoreState.h
@@ -237,7 +237,7 @@ namespace FEXCore::Core {
       uint64_t ExitFunctionLink{};
 
       uint64_t FallbackHandlerPointers[FallbackHandlerIndex::OPINDEX_MAX];
-      uint64_t NamedVectorConstantPointers[FEXCore::IR::NamedVectorConstant::NAMED_VECTOR_MAX];
+      uint64_t NamedVectorConstantPointers[FEXCore::IR::NamedVectorConstant::NAMED_VECTOR_CONST_POOL_MAX];
       uint64_t IndexedNamedVectorConstantPointers[FEXCore::IR::IndexNamedVectorConstant::INDEXED_NAMED_VECTOR_MAX];
       uint64_t TelemetryValueAddresses[FEXCore::Telemetry::TYPE_LAST];
 

--- a/FEXCore/include/FEXCore/IR/IR.h
+++ b/FEXCore/include/FEXCore/IR/IR.h
@@ -526,6 +526,9 @@ enum NamedVectorConstant : uint8_t {
   NAMED_VECTOR_PADDSUBPD_INVERT_UPPER,
   NAMED_VECTOR_MOVMSKPS_SHIFT,
   NAMED_VECTOR_AESKEYGENASSIST_SWIZZLE,
+  NAMED_VECTOR_CONST_POOL_MAX,
+  // Beginning of named constants that don't have a constant pool backing.
+  NAMED_VECTOR_ZERO = NAMED_VECTOR_CONST_POOL_MAX,
   NAMED_VECTOR_MAX,
 };
 

--- a/unittests/InstructionCountCI/H0F38.json
+++ b/unittests/InstructionCountCI/H0F38.json
@@ -964,57 +964,53 @@
       ]
     },
     "aesenc xmm0, xmm1": {
-      "ExpectedInstructionCount": 5,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 4,
+      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0xdc"
       ],
       "ExpectedArm64ASM": [
-        "movi v1.2d, #0x0",
-        "mov v0.16b, v16.16b",
+        "movi v4.2d, #0x0",
         "unimplemented (Unimplemented)",
         "unimplemented (Unimplemented)",
-        "eor v16.16b, v0.16b, v17.16b"
+        "eor v16.16b, v16.16b, v17.16b"
       ]
     },
     "aesenclast xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 3,
+      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0xdd"
       ],
       "ExpectedArm64ASM": [
-        "movi v1.2d, #0x0",
-        "mov v0.16b, v16.16b",
+        "movi v4.2d, #0x0",
         "unimplemented (Unimplemented)",
-        "eor v16.16b, v0.16b, v17.16b"
+        "eor v16.16b, v16.16b, v17.16b"
       ]
     },
     "aesdec xmm0, xmm1": {
-      "ExpectedInstructionCount": 5,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 4,
+      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0xde"
       ],
       "ExpectedArm64ASM": [
-        "movi v1.2d, #0x0",
-        "mov v0.16b, v16.16b",
+        "movi v4.2d, #0x0",
         "unimplemented (Unimplemented)",
         "unimplemented (Unimplemented)",
-        "eor v16.16b, v0.16b, v17.16b"
+        "eor v16.16b, v16.16b, v17.16b"
       ]
     },
     "aesdeclast xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 3,
+      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0xdf"
       ],
       "ExpectedArm64ASM": [
-        "movi v1.2d, #0x0",
-        "mov v0.16b, v16.16b",
+        "movi v4.2d, #0x0",
         "unimplemented (Unimplemented)",
-        "eor v16.16b, v0.16b, v17.16b"
+        "eor v16.16b, v16.16b, v17.16b"
       ]
     },
     "movbe ax, word [rbx]": {

--- a/unittests/InstructionCountCI/H0F3A.json
+++ b/unittests/InstructionCountCI/H0F3A.json
@@ -45,7 +45,7 @@
         "NP 0x0f 0x3a 0x0f"
       ],
       "ExpectedArm64ASM": [
-        "movi d4, #0x0",
+        "movi v4.2d, #0x0",
         "str d4, [x28, #752]"
       ]
     },
@@ -1462,7 +1462,7 @@
       "ExpectedArm64ASM": [
         "ldr x0, [x28, #1608]",
         "ldr q4, [x0]",
-        "movi v1.2d, #0x0",
+        "movi v5.2d, #0x0",
         "mov v16.16b, v17.16b",
         "unimplemented (Unimplemented)",
         "tbl v16.16b, {v16.16b}, v4.16b"
@@ -1477,7 +1477,7 @@
       "ExpectedArm64ASM": [
         "ldr x0, [x28, #1608]",
         "ldr q4, [x0]",
-        "movi v1.2d, #0x0",
+        "movi v5.2d, #0x0",
         "mov v16.16b, v17.16b",
         "unimplemented (Unimplemented)",
         "tbl v16.16b, {v16.16b}, v4.16b",

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -2239,7 +2239,7 @@
         "Map 1 0b01 0x77 L=1"
       ],
       "ExpectedArm64ASM": [
-        "mov z4.d, #0",
+        "movi v4.2d, #0x0",
         "mov z16.d, p7/m, z4.d",
         "mov z17.d, p7/m, z4.d",
         "mov z18.d, p7/m, z4.d",

--- a/unittests/InstructionCountCI/VEX_map2.json
+++ b/unittests/InstructionCountCI/VEX_map2.json
@@ -521,7 +521,7 @@
         "mov w20, #0x100",
         "movk w20, #0x302, lsl #16",
         "mov z6.s, w20",
-        "mov z7.d, #0",
+        "movi v7.2d, #0x0",
         "mov z8.b, #16",
         "mov z1.q, q8",
         "not p0.b, p7/z, p6.b",
@@ -581,7 +581,7 @@
         "movk x20, #0x504, lsl #32",
         "movk x20, #0x706, lsl #48",
         "mov z6.d, x20",
-        "mov z7.d, #0",
+        "movi v7.2d, #0x0",
         "mov z8.b, #16",
         "mov z1.q, q8",
         "not p0.b, p7/z, p6.b",
@@ -3625,7 +3625,7 @@
       ]
     },
     "vaesenc xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0xdc 128-bit"
@@ -3633,11 +3633,10 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "movi v1.2d, #0x0",
-        "mov v0.16b, v4.16b",
+        "movi v6.2d, #0x0",
         "unimplemented (Unimplemented)",
         "unimplemented (Unimplemented)",
-        "eor v4.16b, v0.16b, v5.16b",
+        "eor v4.16b, v4.16b, v5.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -3651,7 +3650,7 @@
       ]
     },
     "vaesenclast xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0xdd 128-bit"
@@ -3659,10 +3658,9 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "movi v1.2d, #0x0",
-        "mov v0.16b, v4.16b",
+        "movi v6.2d, #0x0",
         "unimplemented (Unimplemented)",
-        "eor v4.16b, v0.16b, v5.16b",
+        "eor v4.16b, v4.16b, v5.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -3676,7 +3674,7 @@
       ]
     },
     "vaesdec xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0xde 128-bit"
@@ -3684,11 +3682,10 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "movi v1.2d, #0x0",
-        "mov v0.16b, v4.16b",
+        "movi v6.2d, #0x0",
         "unimplemented (Unimplemented)",
         "unimplemented (Unimplemented)",
-        "eor v4.16b, v0.16b, v5.16b",
+        "eor v4.16b, v4.16b, v5.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]
@@ -3702,7 +3699,7 @@
       ]
     },
     "vaesdeclast xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0xdf 128-bit"
@@ -3710,10 +3707,9 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "movi v1.2d, #0x0",
-        "mov v0.16b, v4.16b",
+        "movi v6.2d, #0x0",
         "unimplemented (Unimplemented)",
-        "eor v4.16b, v0.16b, v5.16b",
+        "eor v4.16b, v4.16b, v5.16b",
         "mov v4.16b, v4.16b",
         "mov z16.d, p7/m, z4.d"
       ]

--- a/unittests/InstructionCountCI/VEX_map3.json
+++ b/unittests/InstructionCountCI/VEX_map3.json
@@ -441,7 +441,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z16.d",
         "mov z5.d, p7/m, z17.d",
-        "mov z6.d, #0",
+        "movi v6.2d, #0x0",
         "mov z1.s, s5",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-4",
@@ -488,7 +488,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z16.d",
         "mov z5.d, p7/m, z17.d",
-        "mov z6.d, #0",
+        "movi v6.2d, #0x0",
         "mov z1.s, s4",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-4",
@@ -620,7 +620,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "mov z5.d, #0",
+        "movi v5.2d, #0x0",
         "mov z1.s, s4",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-4",
@@ -665,7 +665,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "mov z5.d, #0",
+        "movi v5.2d, #0x0",
         "mov z1.s, z4.s[1]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-4",
@@ -710,7 +710,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "mov z5.d, #0",
+        "movi v5.2d, #0x0",
         "mov z1.s, z4.s[2]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-4",
@@ -755,7 +755,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "mov z5.d, #0",
+        "movi v5.2d, #0x0",
         "mov z1.s, z4.s[3]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-4",
@@ -868,7 +868,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "mov z5.d, #0",
+        "movi v5.2d, #0x0",
         "mov z1.d, d4",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
@@ -897,7 +897,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "mov z5.d, #0",
+        "movi v5.2d, #0x0",
         "mov z1.d, z4.d[1]",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
@@ -926,7 +926,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "mov z5.d, #0",
+        "movi v5.2d, #0x0",
         "mov z1.d, d4",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
@@ -955,7 +955,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "mov z5.d, #0",
+        "movi v5.2d, #0x0",
         "mov z1.d, z4.d[1]",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
@@ -984,7 +984,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "mov z5.d, #0",
+        "movi v5.2d, #0x0",
         "mov z1.d, d4",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
@@ -1013,7 +1013,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "mov z5.d, #0",
+        "movi v5.2d, #0x0",
         "mov z1.d, z4.d[1]",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
@@ -1042,7 +1042,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "mov z5.d, #0",
+        "movi v5.2d, #0x0",
         "mov z1.d, d4",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
@@ -1071,7 +1071,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "mov z5.d, #0",
+        "movi v5.2d, #0x0",
         "mov z1.d, z4.d[1]",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
@@ -1100,7 +1100,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "mov z5.d, #0",
+        "movi v5.2d, #0x0",
         "mov z1.d, d4",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
@@ -1129,7 +1129,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "mov z5.d, #0",
+        "movi v5.2d, #0x0",
         "mov z1.d, z4.d[1]",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
@@ -1158,7 +1158,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "mov z5.d, #0",
+        "movi v5.2d, #0x0",
         "mov z1.d, d4",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
@@ -1187,7 +1187,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "mov z5.d, #0",
+        "movi v5.2d, #0x0",
         "mov z1.d, z4.d[1]",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
@@ -1216,7 +1216,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "mov z5.d, #0",
+        "movi v5.2d, #0x0",
         "mov z1.d, d4",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
@@ -1245,7 +1245,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "mov z5.d, #0",
+        "movi v5.2d, #0x0",
         "mov z1.d, z4.d[1]",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
@@ -1274,7 +1274,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "mov z5.d, #0",
+        "movi v5.2d, #0x0",
         "mov z1.d, d4",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
@@ -1303,7 +1303,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "mov z5.d, #0",
+        "movi v5.2d, #0x0",
         "mov z1.d, z4.d[1]",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
@@ -1332,7 +1332,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z16.d",
-        "mov z5.d, #0",
+        "movi v5.2d, #0x0",
         "mov z1.q, q4",
         "mov z5.b, p6/m, z1.b",
         "mov z1.q, q4",
@@ -1350,7 +1350,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z16.d",
-        "mov z5.d, #0",
+        "movi v5.2d, #0x0",
         "mov z1.q, z4.q[1]",
         "mov z5.b, p6/m, z1.b",
         "mov z1.q, q4",
@@ -1369,7 +1369,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z16.d",
         "mov z5.d, p7/m, z17.d",
-        "mov z6.d, #0",
+        "movi v6.2d, #0x0",
         "mov z1.q, q5",
         "mov z5.d, z6.d",
         "mov z5.b, p6/m, z1.b",
@@ -1389,7 +1389,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z16.d",
         "mov z5.d, p7/m, z17.d",
-        "mov z6.d, #0",
+        "movi v6.2d, #0x0",
         "mov z1.q, z5.q[1]",
         "mov z5.d, z6.d",
         "mov z5.b, p6/m, z1.b",
@@ -1408,7 +1408,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z16.d",
-        "mov z5.d, #0",
+        "movi v5.2d, #0x0",
         "mov z1.q, q4",
         "mov z5.b, p6/m, z1.b",
         "mov z1.q, z4.q[1]",
@@ -1426,7 +1426,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z16.d",
-        "mov z5.d, #0",
+        "movi v5.2d, #0x0",
         "mov z1.q, z4.q[1]",
         "mov z5.b, p6/m, z1.b",
         "mov z1.q, z4.q[1]",
@@ -1445,7 +1445,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z16.d",
         "mov z5.d, p7/m, z17.d",
-        "mov z6.d, #0",
+        "movi v6.2d, #0x0",
         "mov z1.q, q5",
         "mov z5.d, z6.d",
         "mov z5.b, p6/m, z1.b",
@@ -1465,7 +1465,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z16.d",
         "mov z5.d, p7/m, z17.d",
-        "mov z6.d, #0",
+        "movi v6.2d, #0x0",
         "mov z1.q, z5.q[1]",
         "mov z5.d, z6.d",
         "mov z5.b, p6/m, z1.b",
@@ -1485,7 +1485,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z16.d",
         "mov z5.d, p7/m, z17.d",
-        "mov z6.d, #0",
+        "movi v6.2d, #0x0",
         "mov z1.q, q4",
         "mov z4.d, z6.d",
         "mov z4.b, p6/m, z1.b",
@@ -1504,7 +1504,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z16.d",
         "mov z5.d, p7/m, z17.d",
-        "mov z6.d, #0",
+        "movi v6.2d, #0x0",
         "mov z1.q, z4.q[1]",
         "mov z4.d, z6.d",
         "mov z4.b, p6/m, z1.b",
@@ -1522,7 +1522,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "mov z5.d, #0",
+        "movi v5.2d, #0x0",
         "mov z1.q, q4",
         "mov z5.b, p6/m, z1.b",
         "mov z1.q, q4",
@@ -1540,7 +1540,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "mov z5.d, #0",
+        "movi v5.2d, #0x0",
         "mov z1.q, z4.q[1]",
         "mov z5.b, p6/m, z1.b",
         "mov z1.q, q4",
@@ -1559,7 +1559,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z16.d",
         "mov z5.d, p7/m, z17.d",
-        "mov z6.d, #0",
+        "movi v6.2d, #0x0",
         "mov z1.q, q4",
         "mov z4.d, z6.d",
         "mov z4.b, p6/m, z1.b",
@@ -1578,7 +1578,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z16.d",
         "mov z5.d, p7/m, z17.d",
-        "mov z6.d, #0",
+        "movi v6.2d, #0x0",
         "mov z1.q, z4.q[1]",
         "mov z4.d, z6.d",
         "mov z4.b, p6/m, z1.b",
@@ -1596,7 +1596,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "mov z5.d, #0",
+        "movi v5.2d, #0x0",
         "mov z1.q, q4",
         "mov z5.b, p6/m, z1.b",
         "mov z1.q, z4.q[1]",
@@ -1614,7 +1614,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "mov z5.d, #0",
+        "movi v5.2d, #0x0",
         "mov z1.q, z4.q[1]",
         "mov z5.b, p6/m, z1.b",
         "mov z1.q, z4.q[1]",
@@ -2140,7 +2140,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "mov z6.d, #0",
+        "movi v6.2d, #0x0",
         "mov z1.s, s5",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-4",
@@ -2270,7 +2270,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "mov z6.d, #0",
+        "movi v6.2d, #0x0",
         "mov z1.d, d5",
         "mov z5.d, z6.d",
         "index z0.d, #-2, #1",
@@ -2301,7 +2301,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "mov z6.d, #0",
+        "movi v6.2d, #0x0",
         "mov z1.d, d4",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
@@ -2332,7 +2332,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "mov z6.d, #0",
+        "movi v6.2d, #0x0",
         "mov z1.d, d5",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
@@ -2363,7 +2363,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "mov z6.d, #0",
+        "movi v6.2d, #0x0",
         "mov z1.d, d4",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
@@ -2394,7 +2394,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "mov z6.d, #0",
+        "movi v6.2d, #0x0",
         "mov z1.d, d5",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
@@ -2425,7 +2425,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "mov z6.d, #0",
+        "movi v6.2d, #0x0",
         "mov z1.d, d4",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
@@ -2456,7 +2456,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "mov z6.d, #0",
+        "movi v6.2d, #0x0",
         "mov z1.d, d5",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
@@ -2487,7 +2487,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "mov z6.d, #0",
+        "movi v6.2d, #0x0",
         "mov z1.d, d4",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
@@ -2517,7 +2517,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "mov z6.d, #0",
+        "movi v6.2d, #0x0",
         "mov z1.d, d5",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
@@ -2547,7 +2547,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "mov z6.d, #0",
+        "movi v6.2d, #0x0",
         "mov z1.d, d4",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
@@ -2577,7 +2577,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "mov z6.d, #0",
+        "movi v6.2d, #0x0",
         "mov z1.d, d5",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
@@ -2607,7 +2607,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "mov z6.d, #0",
+        "movi v6.2d, #0x0",
         "mov z1.d, d4",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
@@ -2637,7 +2637,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "mov z6.d, #0",
+        "movi v6.2d, #0x0",
         "mov z1.d, d5",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
@@ -2667,7 +2667,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "mov z6.d, #0",
+        "movi v6.2d, #0x0",
         "mov z1.d, d4",
         "mov z4.d, z6.d",
         "index z0.d, #-2, #1",
@@ -2769,7 +2769,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "mov z6.d, #0",
+        "movi v6.2d, #0x0",
         "mov z1.h, h5",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #-8",
@@ -3503,7 +3503,7 @@
         "Map 3 0b01 0x40 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z4.d, #0",
+        "movi v4.2d, #0x0",
         "mov z16.d, p7/m, z4.d"
       ]
     },
@@ -3516,7 +3516,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "mov z6.d, #0",
+        "movi v6.2d, #0x0",
         "fmul z4.s, z4.s, z5.s",
         "mov z1.s, s6",
         "index z0.s, #-4, #1",
@@ -3604,7 +3604,7 @@
         "Map 3 0b01 0x40 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z4.d, #0",
+        "movi v4.2d, #0x0",
         "mov z16.d, p7/m, z4.d"
       ]
     },
@@ -3617,7 +3617,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "mov z6.d, #0",
+        "movi v6.2d, #0x0",
         "fmul z4.s, z4.s, z5.s",
         "movprfx z0, z4",
         "faddp z0.s, p7/m, z0.s, z6.s",
@@ -4418,7 +4418,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "mov z5.d, #0",
+        "movi v5.2d, #0x0",
         "mov z1.q, q4",
         "mov z5.b, p6/m, z1.b",
         "mov z1.q, q4",
@@ -4436,7 +4436,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "mov z5.d, #0",
+        "movi v5.2d, #0x0",
         "mov z1.q, z4.q[1]",
         "mov z5.b, p6/m, z1.b",
         "mov z1.q, q4",
@@ -4455,7 +4455,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "mov z6.d, #0",
+        "movi v6.2d, #0x0",
         "mov z1.q, q5",
         "mov z5.d, z6.d",
         "mov z5.b, p6/m, z1.b",
@@ -4475,7 +4475,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "mov z6.d, #0",
+        "movi v6.2d, #0x0",
         "mov z1.q, z5.q[1]",
         "mov z5.d, z6.d",
         "mov z5.b, p6/m, z1.b",
@@ -4494,7 +4494,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "mov z5.d, #0",
+        "movi v5.2d, #0x0",
         "mov z1.q, q4",
         "mov z5.b, p6/m, z1.b",
         "mov z1.q, z4.q[1]",
@@ -4512,7 +4512,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "mov z5.d, #0",
+        "movi v5.2d, #0x0",
         "mov z1.q, z4.q[1]",
         "mov z5.b, p6/m, z1.b",
         "mov z1.q, z4.q[1]",
@@ -4531,7 +4531,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "mov z6.d, #0",
+        "movi v6.2d, #0x0",
         "mov z1.q, q5",
         "mov z5.d, z6.d",
         "mov z5.b, p6/m, z1.b",
@@ -4551,7 +4551,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "mov z6.d, #0",
+        "movi v6.2d, #0x0",
         "mov z1.q, z5.q[1]",
         "mov z5.d, z6.d",
         "mov z5.b, p6/m, z1.b",
@@ -4571,7 +4571,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "mov z6.d, #0",
+        "movi v6.2d, #0x0",
         "mov z1.q, q4",
         "mov z4.d, z6.d",
         "mov z4.b, p6/m, z1.b",
@@ -4590,7 +4590,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "mov z6.d, #0",
+        "movi v6.2d, #0x0",
         "mov z1.q, z4.q[1]",
         "mov z4.d, z6.d",
         "mov z4.b, p6/m, z1.b",
@@ -4608,7 +4608,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z18.d",
-        "mov z5.d, #0",
+        "movi v5.2d, #0x0",
         "mov z1.q, q4",
         "mov z5.b, p6/m, z1.b",
         "mov z1.q, q4",
@@ -4626,7 +4626,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z18.d",
-        "mov z5.d, #0",
+        "movi v5.2d, #0x0",
         "mov z1.q, z4.q[1]",
         "mov z5.b, p6/m, z1.b",
         "mov z1.q, q4",
@@ -4645,7 +4645,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "mov z6.d, #0",
+        "movi v6.2d, #0x0",
         "mov z1.q, q4",
         "mov z4.d, z6.d",
         "mov z4.b, p6/m, z1.b",
@@ -4664,7 +4664,7 @@
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
         "mov z5.d, p7/m, z18.d",
-        "mov z6.d, #0",
+        "movi v6.2d, #0x0",
         "mov z1.q, z4.q[1]",
         "mov z4.d, z6.d",
         "mov z4.b, p6/m, z1.b",
@@ -4682,7 +4682,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z18.d",
-        "mov z5.d, #0",
+        "movi v5.2d, #0x0",
         "mov z1.q, q4",
         "mov z5.b, p6/m, z1.b",
         "mov z1.q, z4.q[1]",
@@ -4700,7 +4700,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z18.d",
-        "mov z5.d, #0",
+        "movi v5.2d, #0x0",
         "mov z1.q, z4.q[1]",
         "mov z5.b, p6/m, z1.b",
         "mov z1.q, z4.q[1]",
@@ -5059,7 +5059,7 @@
         "mov z4.d, p7/m, z17.d",
         "ldr x0, [x28, #1608]",
         "ldr q5, [x0]",
-        "movi v1.2d, #0x0",
+        "movi v6.2d, #0x0",
         "unimplemented (Unimplemented)",
         "tbl v4.16b, {v4.16b}, v5.16b",
         "mov v4.16b, v4.16b",
@@ -5076,7 +5076,7 @@
         "mov z4.d, p7/m, z17.d",
         "ldr x0, [x28, #1608]",
         "ldr q5, [x0]",
-        "movi v1.2d, #0x0",
+        "movi v6.2d, #0x0",
         "unimplemented (Unimplemented)",
         "tbl v4.16b, {v4.16b}, v5.16b",
         "mov x0, #0xff00000000",

--- a/unittests/InstructionCountCI/VEX_map_group.json
+++ b/unittests/InstructionCountCI/VEX_map_group.json
@@ -575,7 +575,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "mov z5.d, #0",
+        "movi v5.2d, #0x0",
         "ext v6.16b, v4.16b, v5.16b, #15",
         "ext z4.b, z4.b, z5.b, #31",
         "mov z1.q, q4",
@@ -592,7 +592,7 @@
         "Map group 14 0b011 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z4.d, #0",
+        "movi v4.2d, #0x0",
         "mov z16.d, p7/m, z4.d"
       ]
     },
@@ -726,7 +726,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov z4.d, p7/m, z17.d",
-        "mov z5.d, #0",
+        "movi v5.2d, #0x0",
         "ext v6.16b, v5.16b, v4.16b, #1",
         "movprfx z1, z5",
         "ext z1.b, z1.b, z4.b, #17",
@@ -745,7 +745,7 @@
         "Map group 14 0b111 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z4.d, #0",
+        "movi v4.2d, #0x0",
         "mov z16.d, p7/m, z4.d"
       ]
     },


### PR DESCRIPTION
A bunch of the AES operations take a zero register upfront and we
currently materialize it for each instruction.
Considering that most AES operations are used back to back, we can
eliminate these materializations by caching it between instructions.

Additionally removes a move in the optimal case when destination matches
the state register, which is exactly what the SSE operation ends up
doing.

AESKeyGenAssist has an edge case that if the destination RA overlaps the
zero register then we still need to eat a move, hopefully doesn't happen
too frequently in practice. This is also the lesser used instruction so
it isn't a big deal. RA constraints could solve that still.

Looking between the disassembly trees for back to back operations:
Original:
```asm
aesenc  xmm2, xmm1
aesenc  xmm3, xmm1
aesenc  xmm4, xmm1
aesenclast xmm2, xmm0
aesenclast xmm3, xmm0
aesenclast xmm4, xmm0
```

Result:
```asm
movi v4.2d, #0x0
unimplemented (Unimplemented)
unimplemented (Unimplemented)
eor v18.16b, v18.16b, v17.16b
unimplemented (Unimplemented)
unimplemented (Unimplemented)
eor v19.16b, v19.16b, v17.16b
unimplemented (Unimplemented)
unimplemented (Unimplemented)
eor v20.16b, v20.16b, v17.16b
unimplemented (Unimplemented)
eor v18.16b, v18.16b, v16.16b
unimplemented (Unimplemented)
eor v19.16b, v19.16b, v16.16b
unimplemented (Unimplemented)
eor v20.16b, v20.16b, v16.16b
```