### PR TITLE
Syscalls: Fix telemetry with exit_group

### DIFF
--- a/Source/Tools/FEXLoader/LinuxSyscalls/SignalDelegator.cpp
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/SignalDelegator.cpp
@@ -1540,15 +1540,11 @@ namespace FEX::HLE {
       (Handler.DefaultBehaviour == DEFAULT_COREDUMP ||
        Handler.DefaultBehaviour == DEFAULT_TERM)) {
 
-#ifndef FEX_DISABLE_TELEMETRY
       // In the case of signals that cause coredump or terminate, save telemetry early.
       // FEX is hard crashing at this point and won't hit regular shutdown routines.
       // Add the signal to the crash mask.
       CrashMask |= (1ULL << Signal);
-      if (!ApplicationName.empty()) {
-        FEXCore::Telemetry::Shutdown(ApplicationName);
-      }
-#endif
+      SaveTelemetry();
 
       // Reassign back to DFL and crash
       signal(Signal, SIG_DFL);
@@ -1562,6 +1558,14 @@ namespace FEX::HLE {
     else {
       Handler.OldAction.handler(Signal);
     }
+  }
+
+  void SignalDelegator::SaveTelemetry() {
+#ifndef FEX_DISABLE_TELEMETRY
+    if (!ApplicationName.empty()) {
+      FEXCore::Telemetry::Shutdown(ApplicationName);
+    }
+#endif
   }
 
   bool SignalDelegator::InstallHostThunk(int Signal) {

--- a/Source/Tools/FEXLoader/LinuxSyscalls/SignalDelegator.h
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/SignalDelegator.h
@@ -104,6 +104,8 @@ namespace FEX::HLE {
     void SignalThread(FEXCore::Core::InternalThreadState *Thread, FEXCore::Core::SignalEvent Event) override;
 
     FEX_CONFIG_OPT(ParanoidTSO, PARANOIDTSO);
+
+    void SaveTelemetry();
   protected:
     // Called from the thunk handler to handle the signal
     void HandleGuestSignal(FEXCore::Core::InternalThreadState *Thread, int Signal, void *Info, void *UContext) override;

--- a/Source/Tools/FEXLoader/LinuxSyscalls/Syscalls/Thread.cpp
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/Syscalls/Thread.cpp
@@ -574,6 +574,10 @@ namespace FEX::HLE {
 
     REGISTER_SYSCALL_IMPL_PASS_FLAGS(exit_group, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY | SyscallFlags::NORETURN,
       [](FEXCore::Core::CpuStateFrame *Frame, int status) -> uint64_t {
+
+      // Save telemetry if we're exiting.
+      FEX::HLE::_SyscallHandler->GetSignalDelegator()->SaveTelemetry();
+
       syscall(SYSCALL_DEF(exit_group), status);
       // This will never be reached
       std::terminate();


### PR DESCRIPTION
Picked up on more games exiting with exit_group that I want to ensure their telemetry data gets saved. Implement support for this.