### PR TITLE
SignalDelegator: Fix build with telemetry disabled

### DIFF
--- a/Source/Tools/FEXLoader/LinuxSyscalls/SignalDelegator.cpp
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/SignalDelegator.cpp
@@ -1540,11 +1540,13 @@ namespace FEX::HLE {
       (Handler.DefaultBehaviour == DEFAULT_COREDUMP ||
        Handler.DefaultBehaviour == DEFAULT_TERM)) {
 
+#ifndef FEX_DISABLE_TELEMETRY
       // In the case of signals that cause coredump or terminate, save telemetry early.
       // FEX is hard crashing at this point and won't hit regular shutdown routines.
       // Add the signal to the crash mask.
       CrashMask |= (1ULL << Signal);
       SaveTelemetry();
+#endif
 
       // Reassign back to DFL and crash
       signal(Signal, SIG_DFL);


### PR DESCRIPTION
/home/alyssa/FEX/Source/Tools/FEXLoader/LinuxSyscalls/SignalDelegator.cpp:1546:7: error: use of undeclared identifier 'CrashMask'
      CrashMask |= (1ULL << Signal);