### PR TITLE
Context: Adds helper to reconstruct and consume packed EFLAGS

### DIFF
--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -105,6 +105,8 @@ namespace FEXCore::Context {
       void HandleCallback(FEXCore::Core::InternalThreadState *Thread, uint64_t RIP) override;
 
       uint64_t RestoreRIPFromHostPC(FEXCore::Core::InternalThreadState *Thread, uint64_t HostPC) override;
+      uint32_t ReconstructCompactedEFLAGS(FEXCore::Core::InternalThreadState *Thread) override;
+      void SetFlagsFromCompactedEFLAGS(FEXCore::Core::InternalThreadState *Thread, uint32_t EFLAGS) override;
 
       /**
        * @brief Used to create FEX thread objects in preparation for creating a true OS thread. Does set a TID or PID.

--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -221,6 +221,27 @@ namespace FEXCore::Context {
     return Frame->State.rip;
   }
 
+  uint32_t ContextImpl::ReconstructCompactedEFLAGS(FEXCore::Core::InternalThreadState *Thread) {
+    const auto Frame = Thread->CurrentFrame;
+    uint32_t EFLAGS{};
+
+    // Currently these flags just map 1:1 inside of the resulting value.
+    for (size_t i = 0; i < FEXCore::Core::CPUState::NUM_EFLAG_BITS; ++i) {
+      EFLAGS |= Frame->State.flags[i] << i;
+    }
+
+    return EFLAGS;
+  }
+
+  void ContextImpl::SetFlagsFromCompactedEFLAGS(FEXCore::Core::InternalThreadState *Thread, uint32_t EFLAGS) {
+    const auto Frame = Thread->CurrentFrame;
+    for (size_t i = 0; i < FEXCore::Core::CPUState::NUM_EFLAG_BITS; ++i) {
+      Frame->State.flags[i] = (EFLAGS & (1U << i)) ? 1 : 0;
+    }
+    Frame->State.flags[1] = 1;
+    Frame->State.flags[9] = 1;
+  }
+
   FEXCore::Core::InternalThreadState* ContextImpl::InitCore(uint64_t InitialRIP, uint64_t StackPointer) {
     // Initialize the CPU core signal handlers & DispatcherConfig
     switch (Config.Core) {

--- a/FEXCore/include/FEXCore/Core/Context.h
+++ b/FEXCore/include/FEXCore/Core/Context.h
@@ -243,7 +243,13 @@ namespace FEXCore::Context {
 
       FEX_DEFAULT_VISIBILITY virtual void HandleCallback(FEXCore::Core::InternalThreadState *Thread, uint64_t RIP) = 0;
 
+      ///< State reconstruction helpers
+      ///< Reconstructs the guest RIP from the passed in thread context and related Host PC.
       FEX_DEFAULT_VISIBILITY virtual uint64_t RestoreRIPFromHostPC(FEXCore::Core::InternalThreadState *Thread, uint64_t HostPC) = 0;
+      ///< Reconstructs a compacted EFLAGS from FEX's internal EFLAG representation.
+      FEX_DEFAULT_VISIBILITY virtual uint32_t ReconstructCompactedEFLAGS(FEXCore::Core::InternalThreadState *Thread) = 0;
+      ///< Sets FEX's internal EFLAGS representation to the passed in compacted form.
+      FEX_DEFAULT_VISIBILITY virtual void SetFlagsFromCompactedEFLAGS(FEXCore::Core::InternalThreadState *Thread, uint32_t EFLAGS) = 0;
 
       FEX_DEFAULT_VISIBILITY virtual FEXCore::Core::InternalThreadState* CreateThread(FEXCore::Core::CPUState *NewThreadState, uint64_t ParentTID) = 0;
       FEX_DEFAULT_VISIBILITY virtual void ExecutionThread(FEXCore::Core::InternalThreadState *Thread) = 0;

--- a/Source/Tools/FEXLoader/LinuxSyscalls/SignalDelegator.h
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/SignalDelegator.h
@@ -201,9 +201,9 @@ namespace FEX::HLE {
 
     void SpillSRA(FEXCore::Core::InternalThreadState *Thread, void *ucontext, uint32_t IgnoreMask);
 
-    void RestoreFrame_x64(ArchHelpers::Context::ContextBackup* Context, FEXCore::Core::CpuStateFrame *Frame, void *ucontext);
-    void RestoreFrame_ia32(ArchHelpers::Context::ContextBackup* Context, FEXCore::Core::CpuStateFrame *Frame, void *ucontext);
-    void RestoreRTFrame_ia32(ArchHelpers::Context::ContextBackup* Context, FEXCore::Core::CpuStateFrame *Frame, void *ucontext);
+    void RestoreFrame_x64(FEXCore::Core::InternalThreadState *Thread, ArchHelpers::Context::ContextBackup* Context, FEXCore::Core::CpuStateFrame *Frame, void *ucontext);
+    void RestoreFrame_ia32(FEXCore::Core::InternalThreadState *Thread, ArchHelpers::Context::ContextBackup* Context, FEXCore::Core::CpuStateFrame *Frame, void *ucontext);
+    void RestoreRTFrame_ia32(FEXCore::Core::InternalThreadState *Thread, ArchHelpers::Context::ContextBackup* Context, FEXCore::Core::CpuStateFrame *Frame, void *ucontext);
 
     ///< Setup the signal frame for x64.
     uint64_t SetupFrame_x64(FEXCore::Core::InternalThreadState *Thread, ArchHelpers::Context::ContextBackup* ContextBackup, FEXCore::Core::CpuStateFrame *Frame,


### PR DESCRIPTION
Currently FEX's internal EFLAGS representation is a perfect 1:1 mapping between bit offset and byte offset. This is going to change with #3038. There should be no reason that the frontend needs to understand how to reconstruct the compacted flags from the internal representation.

Adds context helpers and moves all the logic to FEXCore. The locations that previously needed to handle this have been converted over to use this.