### PR TITLE
Arm64: Only allocate vixl::Decoder if enabled

### DIFF
--- a/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
+++ b/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
@@ -161,7 +161,12 @@ Arm64Emitter::Arm64Emitter(FEXCore::Context::ContextImpl *ctx, size_t size)
   Simulator.SetVectorLengthInBits(ForceSVEWidth() ? ForceSVEWidth() : 256);
 #endif
 #ifdef VIXL_DISASSEMBLER
-  DisasmDecoder.AppendVisitor(&Disasm);
+  // Only setup the disassembler if enabled.
+  // vixl's decoder is expensive to setup.
+  if (Disassemble()) {
+    DisasmDecoder = fextl::make_unique<vixl::aarch64::Decoder>();
+    DisasmDecoder->AppendVisitor(&Disasm);
+  }
 #endif
 
   CPU.SetUp();

--- a/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
+++ b/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
@@ -181,7 +181,7 @@ protected:
 
 #ifdef VIXL_DISASSEMBLER
   vixl::aarch64::Disassembler Disasm;
-  vixl::aarch64::Decoder DisasmDecoder;
+  fextl::unique_ptr<vixl::aarch64::Decoder> DisasmDecoder;
 
   FEX_CONFIG_OPT(Disassemble, DISASSEMBLE);
 #endif

--- a/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
@@ -497,7 +497,7 @@ void Arm64Dispatcher::EmitDispatcher() {
   if (Disassemble() & FEXCore::Config::Disassemble::DISPATCHER) {
     const auto DisasmEnd = GetCursorAddress<const vixl::aarch64::Instruction*>();
     for (auto PCToDecode = DisasmBegin; PCToDecode < DisasmEnd; PCToDecode += 4) {
-      DisasmDecoder.Decode(PCToDecode);
+      DisasmDecoder->Decode(PCToDecode);
       auto Output = Disasm.GetOutput();
       LogMan::Msg::IFmt("{}", Output);
     }

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -1189,7 +1189,7 @@ CPUBackend::CompiledCode Arm64JITCore::CompileCode(uint64_t Entry,
     const auto DisasmEnd = reinterpret_cast<const vixl::aarch64::Instruction*>(JITBlockTailLocation);
     LogMan::Msg::IFmt("Disassemble Begin");
     for (auto PCToDecode = DisasmBegin; PCToDecode < DisasmEnd; PCToDecode += 4) {
-      DisasmDecoder.Decode(PCToDecode);
+      DisasmDecoder->Decode(PCToDecode);
       auto Output = Disasm.GetOutput();
       LogMan::Msg::IFmt("{}", Output);
     }


### PR DESCRIPTION
This class is very expensive to initialize so if you happen to have the disassembler configuration enabled you were eating a very bad initialization cost for no reason.

Only initialize the data member if any disassembler runtime option is enabled, this completely removes the overhead.