### PR TITLE
FileManagement: Fix inverted boolean check for procfs/interpreter support

### DIFF
--- a/Source/Tools/FEXLoader/LinuxSyscalls/FileManagement.cpp
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/FileManagement.cpp
@@ -730,7 +730,7 @@ uint64_t FileManager::Readlinkat(int dirfd, const char *pathname, char *buf, siz
     }
   }
 
-  if (SupportsProcFSInterpreter) {
+  if (!SupportsProcFSInterpreter) {
     char PidSelfPath[50];
     snprintf(PidSelfPath, 50, "/proc/%i/exe", CurrentPID);
 


### PR DESCRIPTION
Fixes a critical regression from #3057.