### PR TITLE
unittests: Add test thunk library

### DIFF
--- a/CI/FEXLinuxTestsThunks.json
+++ b/CI/FEXLinuxTestsThunks.json
@@ -1,0 +1,5 @@
+{
+  "ThunksDB": {
+    "fex_thunk_test": 1
+  }
+}

--- a/Data/ThunksDB.json
+++ b/Data/ThunksDB.json
@@ -144,6 +144,12 @@
         "@PREFIX_LIB@/libasound.so.2.0.0"
       ]
     },
+    "fex_thunk_test": {
+      "Library": "libfex_thunk_test-guest.so",
+      "Overlay": [
+        "@PREFIX_LIB@/libfex_thunk_test.so"
+      ]
+    },
     "Xrender": {
       "Library": "libXrender-guest.so",
       "Overlay": [

--- a/ThunkLibs/GuestLibs/CMakeLists.txt
+++ b/ThunkLibs/GuestLibs/CMakeLists.txt
@@ -291,3 +291,6 @@ if (BITNESS EQUAL 32)
   #  338:   0f 0b                   ud2
   target_compile_options(VDSO-guest PRIVATE "-fno-pic")
 endif()
+
+generate(libfex_thunk_test ${CMAKE_CURRENT_SOURCE_DIR}/../libfex_thunk_test/libfex_thunk_test_interface.cpp)
+add_guest_lib(fex_thunk_test "libfex_thunk_test.so")

--- a/ThunkLibs/HostLibs/CMakeLists.txt
+++ b/ThunkLibs/HostLibs/CMakeLists.txt
@@ -186,4 +186,10 @@ foreach(GUEST_BITNESS IN LISTS BITNESS_LIST)
   target_include_directories(libdrm-${GUEST_BITNESS}-deps INTERFACE /usr/include/drm/)
   target_include_directories(libdrm-${GUEST_BITNESS}-deps INTERFACE /usr/include/libdrm/)
   add_host_lib(drm ${GUEST_BITNESS})
+
+  generate(libfex_thunk_test ${CMAKE_CURRENT_SOURCE_DIR}/../libfex_thunk_test/libfex_thunk_test_interface.cpp ${GUEST_BITNESS})
+  add_host_lib(fex_thunk_test ${GUEST_BITNESS})
 endforeach()
+
+add_library(fex_thunk_test SHARED ../libfex_thunk_test/lib.cpp)
+install(TARGETS fex_thunk_test LIBRARY DESTINATION lib COMPONENT TestLibraries)

--- a/ThunkLibs/libfex_thunk_test/Guest.cpp
+++ b/ThunkLibs/libfex_thunk_test/Guest.cpp
@@ -1,0 +1,12 @@
+/*
+$info$
+tags: thunklibs|fex_thunk_test
+$end_info$
+*/
+
+#include "common/Guest.h"
+#include "api.h"
+
+#include "thunkgen_guest_libfex_thunk_test.inl"
+
+LOAD_LIB(libfex_thunk_test)

--- a/ThunkLibs/libfex_thunk_test/Host.cpp
+++ b/ThunkLibs/libfex_thunk_test/Host.cpp
@@ -1,0 +1,16 @@
+/*
+$info$
+tags: thunklibs|fex_thunk_test
+$end_info$
+*/
+
+#include <cstddef>
+#include <dlfcn.h>
+
+#include "common/Host.h"
+
+#include "api.h"
+
+#include "thunkgen_host_libfex_thunk_test.inl"
+
+EXPORTS(libfex_thunk_test)

--- a/ThunkLibs/libfex_thunk_test/api.h
+++ b/ThunkLibs/libfex_thunk_test/api.h
@@ -1,0 +1,13 @@
+/**
+ * This file defines interfaces of a dummy library used to test various
+ * features of the thunk generator.
+ */
+#pragma once
+
+#include <cstdint>
+
+extern "C" {
+
+uint32_t GetDoubledValue(uint32_t);
+
+}

--- a/ThunkLibs/libfex_thunk_test/lib.cpp
+++ b/ThunkLibs/libfex_thunk_test/lib.cpp
@@ -1,0 +1,9 @@
+#include "api.h"
+
+extern "C" {
+
+uint32_t GetDoubledValue(uint32_t input) {
+  return 2 * input;
+}
+
+} // extern "C"

--- a/ThunkLibs/libfex_thunk_test/libfex_thunk_test_interface.cpp
+++ b/ThunkLibs/libfex_thunk_test/libfex_thunk_test_interface.cpp
@@ -1,0 +1,14 @@
+#include <common/GeneratorInterface.h>
+
+#include "api.h"
+
+template<auto>
+struct fex_gen_config {};
+
+template<typename>
+struct fex_gen_type {};
+
+template<auto, int, typename>
+struct fex_gen_param {};
+
+template<> struct fex_gen_config<GetDoubledValue> {};

--- a/unittests/FEXLinuxTests/CMakeLists.txt
+++ b/unittests/FEXLinuxTests/CMakeLists.txt
@@ -44,6 +44,16 @@ function(AddTests Tests BinDirectory Bitness)
     set(BIN_PATH "${CMAKE_CURRENT_BINARY_DIR}/${BinDirectory}/${TEST_NAME}.${Bitness}")
     set(TEST_CASE "${TEST_NAME}.${Bitness}")
 
+    set(THUNK_ARGS "")
+    if(TEST_NAME STREQUAL "thunk_testlib")
+      # Test thunking only if thunks are enabled and supported
+      if(NOT BUILD_THUNKS OR ENABLE_GLIBC_ALLOCATOR_HOOK_FAULT)
+        continue()
+      endif()
+
+      set(THUNK_ARGS "-k" "${CMAKE_SOURCE_DIR}/CI/FEXLinuxTestsThunks.json")
+    endif()
+
     # Add jit test case
     add_test(NAME "${TEST_CASE}.jit.flt"
       COMMAND "python3" "${CMAKE_SOURCE_DIR}/Scripts/guest_test_runner.py"
@@ -54,9 +64,11 @@ function(AddTests Tests BinDirectory Bitness)
       "${TEST_CASE}"
       "guest"
       "$<TARGET_FILE:FEXLoader>"
+      ${THUNK_ARGS}
       "--no-silent" "-c" "irjit" "-n" "500" "--"
       "${BIN_PATH}")
-    if (_M_X86_64)
+
+    if (_M_X86_64 AND NOT TEST_NAME STREQUAL "thunk_testlib")
       # Add host test case
       add_test(NAME "${TEST_CASE}.host.flt"
         COMMAND "python3" "${CMAKE_SOURCE_DIR}/Scripts/guest_test_runner.py"
@@ -78,6 +90,12 @@ AddTests("${TESTS}" "FEXLinuxTests_32" 32)
 AddTests("${TESTS_64_ONLY}" "FEXLinuxTests_64" 64)
 # Execute tests that are only 32-bit.
 AddTests("${TESTS_32_ONLY}" "FEXLinuxTests_32" 32)
+
+if(TEST thunk_testlib.64.jit.flt)
+  # Ensure libfex_thunk_test is found even when using an uncommon install prefix
+  set_property(TEST "thunk_testlib.32.jit.flt" PROPERTY ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib")
+  set_property(TEST "thunk_testlib.64.jit.flt" PROPERTY ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib")
+endif()
 
 execute_process(COMMAND "nproc" OUTPUT_VARIABLE CORES)
 string(STRIP ${CORES} CORES)

--- a/unittests/FEXLinuxTests/CMakeLists.txt
+++ b/unittests/FEXLinuxTests/CMakeLists.txt
@@ -65,7 +65,7 @@ function(AddTests Tests BinDirectory Bitness)
       "guest"
       "$<TARGET_FILE:FEXLoader>"
       ${THUNK_ARGS}
-      "--no-silent" "-c" "irjit" "-n" "500" "--"
+      "-o" "stderr" "--no-silent" "-c" "irjit" "-n" "500" "--"
       "${BIN_PATH}")
 
     if (_M_X86_64 AND NOT TEST_NAME STREQUAL "thunk_testlib")

--- a/unittests/FEXLinuxTests/tests/CMakeLists.txt
+++ b/unittests/FEXLinuxTests/tests/CMakeLists.txt
@@ -3,8 +3,8 @@ project(FEXLinuxTests)
 
 set(CMAKE_CXX_STANDARD 17)
 
-unset (CMAKE_C_FLAGS)
-unset (CMAKE_CXX_FLAGS)
+unset(CMAKE_C_FLAGS)
+unset(CMAKE_CXX_FLAGS)
 
 set(GENERATE_GUEST_INSTALL_TARGETS TRUE)
 
@@ -39,5 +39,7 @@ target_link_libraries(smc-mt-2.${BITNESS} PRIVATE pthread)
 target_link_libraries(smc-shared-1.${BITNESS} PRIVATE rt pthread)
 
 target_link_libraries(smc-shared-2.${BITNESS} PRIVATE rt pthread)
+
+target_link_libraries(thunk_testlib.${BITNESS} PRIVATE ${CMAKE_DL_LIBS})
 
 target_link_libraries(timer-sigev-thread.${BITNESS} PRIVATE rt pthread)

--- a/unittests/FEXLinuxTests/tests/thunks/thunk_testlib.cpp
+++ b/unittests/FEXLinuxTests/tests/thunks/thunk_testlib.cpp
@@ -1,0 +1,24 @@
+#include <dlfcn.h>
+
+#include <stdexcept>
+
+#include <catch2/catch.hpp>
+
+#include "../../../../ThunkLibs/libfex_thunk_test/api.h"
+
+struct Fixture {
+  void* lib = []() {
+    auto ret = dlopen("libfex_thunk_test.so", RTLD_LAZY);
+    if (!ret) {
+      throw std::runtime_error("Failed to open lib\n");
+    }
+    return ret;
+  }();
+
+#define GET_SYMBOL(name) decltype(&::name) name = (decltype(name))dlsym(lib, #name)
+  GET_SYMBOL(GetDoubledValue);
+};
+
+TEST_CASE_METHOD(Fixture, "Trivial") {
+  CHECK(GetDoubledValue(10) == 20);
+}

--- a/unittests/POSIX/CMakeLists.txt
+++ b/unittests/POSIX/CMakeLists.txt
@@ -19,7 +19,7 @@ foreach(POSIX_TEST ${POSIX_TESTS})
       "${TEST_NAME}"
       "guest"
       "${CMAKE_BINARY_DIR}/Bin/FEXLoader"
-      "--no-silent" "-c" "irint" "-n" "500" "--"
+      "-o" "stderr" "--no-silent" "-c" "irint" "-n" "500" "--"
       "${POSIX_TEST}")
   endif()
 
@@ -32,7 +32,7 @@ foreach(POSIX_TEST ${POSIX_TESTS})
     "${TEST_NAME}"
     "guest"
     "${CMAKE_BINARY_DIR}/Bin/FEXLoader"
-    "--no-silent" "-c" "irjit" "-n" "500" "--"
+    "-o" "stderr" "--no-silent" "-c" "irjit" "-n" "500" "--"
     "${POSIX_TEST}")
 
 endforeach()

--- a/unittests/gcc-target-tests-32/CMakeLists.txt
+++ b/unittests/gcc-target-tests-32/CMakeLists.txt
@@ -20,7 +20,7 @@ foreach(TEST ${TESTS})
     "${TEST_NAME}"
     "guest"
     "${CMAKE_BINARY_DIR}/Bin/FEXLoader"
-    "--no-silent" "-c" "irjit" "-n" "500" "--"
+    "-o" "stderr" "--no-silent" "-c" "irjit" "-n" "500" "--"
     "${TEST}")
 
 endforeach()

--- a/unittests/gcc-target-tests-64/CMakeLists.txt
+++ b/unittests/gcc-target-tests-64/CMakeLists.txt
@@ -20,7 +20,7 @@ foreach(TEST ${TESTS})
     "${TEST_NAME}"
     "guest"
     "${CMAKE_BINARY_DIR}/Bin/FEXLoader"
-    "--no-silent" "-c" "irjit" "-n" "500" "--"
+    "-o" "stderr" "--no-silent" "-c" "irjit" "-n" "500" "--"
     "${TEST}")
 
 endforeach()

--- a/unittests/gvisor-tests/CMakeLists.txt
+++ b/unittests/gvisor-tests/CMakeLists.txt
@@ -20,7 +20,7 @@ foreach(TEST ${TESTS})
     "${TEST_NAME}"
     "guest"
     "${CMAKE_BINARY_DIR}/Bin/FEXLoader"
-    "--no-silent" "-c" "irjit" "-n" "500" "--"
+    "-o" "stderr" "--no-silent" "-c" "irjit" "-n" "500" "--"
     "${TEST}")
 
 endforeach()


### PR DESCRIPTION
This adds a new FEXLinuxTest written against a custom `libfex_thunk_test` library. `libfex_thunk_test` allows us to define interfaces specifically to trigger thunk generator edge cases that couldn't easily be tested for in actual libraries.

The new test opens a third category of thunk-related tests:
* unittests/ThunkLibs: Unit tests that check the syntax tree of `thunkgen` code output and (in the future) results of data layout analysis (no runtime behavior is checked)
* unittests/ThunkFunctionalTests: Integration tests that runs simple applications (e.g. glxinfo) to verify basic functionality of real-world libraries works
* FEXLinuxTests/thunk_testlib: Mixed unit/integration tests that benefit from us controlling the interfaces in `libfex_thunk_test`. Individual properties of the thunk generator can be checked by co-designing tests and the tested thunk to trigger problematic edge-cases easily.

Ideally the new library and the test should only be enabled if both `BUILD_THUNKS` and `BUILD_FEX_LINUX_TESTS` are set. However, forwarding these settings through our various `ExternalProject`s would be overly complicated. Instead, the new library is always built if `BUILD_THUNKS` is on, and the new test is always built if `BUILD_FEX_LINUX_TESTS` is on (but excluded from the `fex_linux_tests` umbrella target unless `BUILD_THUNKS` is enabled). Since building these targets doesn't do any harm either way, this is a reasonable middle ground.

TODO:
- [x] The tests fail unless thunking of `libfex_thunk_test` is enabled. Should we force-enable thunking of this library in FEX, or is it sufficient to enable it in CI?
    - Resolved: The test targets now pass the `-k` switch to FEXLoader to enable thunking of the test library