### PR TITLE
OpcodeDispatcher: Update 32/64-bit RCR for operating size

### DIFF
--- a/unittests/InstructionCountCI/PrimaryGroup.json
+++ b/unittests/InstructionCountCI/PrimaryGroup.json
@@ -1234,7 +1234,7 @@
       ]
     },
     "rcr eax, 2": {
-      "ExpectedInstructionCount": 27,
+      "ExpectedInstructionCount": 26,
       "Optimal": "No",
       "Comment": "GROUP2 0xC1 /3",
       "ExpectedArm64ASM": [
@@ -1251,8 +1251,7 @@
         "lsl x25, x23, #30",
         "cmp w20, #0x1 (1)",
         "csel x25, x25, x26, hs",
-        "orr x24, x24, x25",
-        "lsr w4, w24, #0",
+        "orr w4, w24, w25",
         "lsr w21, w21, #1",
         "ubfx w21, w21, #0, #1",
         "cmp w20, #0x1 (1)",
@@ -1260,9 +1259,9 @@
         "mov w0, w22",
         "bfi w0, w20, #29, #1",
         "mov w20, w0",
-        "ubfx x21, x24, #31, #1",
-        "ubfx x22, x24, #30, #1",
-        "eor x21, x21, x22",
+        "lsr w21, w4, #31",
+        "ubfx w22, w4, #30, #1",
+        "eor w21, w21, w22",
         "bfi w20, w21, #28, #1",
         "str w20, [x28, #728]"
       ]
@@ -2498,7 +2497,7 @@
       ]
     },
     "rcr eax, cl": {
-      "ExpectedInstructionCount": 37,
+      "ExpectedInstructionCount": 36,
       "Optimal": "No",
       "Comment": "GROUP2 0xd3 /3",
       "ExpectedArm64ASM": [
@@ -2519,10 +2518,9 @@
         "lsl x25, x23, x25",
         "cmp w20, #0x1 (1)",
         "csel x25, x25, x26, hs",
-        "orr x24, x24, x25",
-        "lsr w4, w24, #0",
-        "sub w25, w20, #0x1 (1)",
-        "lsr w21, w21, w25",
+        "orr w4, w24, w25",
+        "sub w24, w20, #0x1 (1)",
+        "lsr w21, w21, w24",
         "ubfx w21, w21, #0, #1",
         "cmp w20, #0x1 (1)",
         "csel w21, w21, w23, hs",
@@ -2530,11 +2528,11 @@
         "bfi w0, w21, #29, #1",
         "mov w21, w0",
         "ubfx w22, w21, #28, #1",
-        "ubfx x23, x24, #31, #1",
-        "ubfx x24, x24, #30, #1",
-        "eor x23, x23, x24",
+        "lsr w23, w4, #31",
+        "ubfx w24, w4, #30, #1",
+        "eor w23, w23, w24",
         "cmp x20, #0x0 (0)",
-        "csel x20, x22, x23, eq",
+        "csel w20, w22, w23, eq",
         "mov w0, w21",
         "bfi w0, w20, #28, #1",
         "mov w20, w0",


### PR DESCRIPTION
Removes todo from explicit size PR. Saves one instruction.