### PR TITLE
CPUID: Enabled Enhanced REP MOVSB/STOSB

### DIFF
--- a/FEXCore/Source/Interface/Core/CPUID.cpp
+++ b/FEXCore/Source/Interface/Core/CPUID.cpp
@@ -630,7 +630,7 @@ FEXCore::CPUID::FunctionResults CPUIDEmu::Function_07h(uint32_t Leaf) {
       (1 <<  6) | // FPU data pointer updated only on exception
       (1 <<  7) | // SMEP support
       (SupportsAVX() << 8) | // BMI2
-      (0 <<  9) | // Enhanced REP MOVSB/STOSB
+      (1 <<  9) | // Enhanced REP MOVSB/STOSB
       (1 << 10) | // INVPCID for system software control of process-context
       (0 << 11) | // Restricted transactional memory
       (0 << 12) | // Intel resource directory technology Monitoring


### PR DESCRIPTION
Missed with #2490.
This changes behaviour of glibc's memmove slightly, seems to recover a bit of performance on Half-Life 2's title screen.