### PR TITLE
FEXCore: Implements support for shifted bitwise ops

### DIFF
--- a/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -50,7 +50,10 @@ constexpr OpHandlerArray InterpreterOpHandlers = [] {
   REGISTER_OP(INLINEENTRYPOINTOFFSET, InlineEntrypointOffset);
   REGISTER_OP(CYCLECOUNTER,           CycleCounter);
   REGISTER_OP(ADD,                    Add);
+  REGISTER_OP(ADDNZCV,                AddNZCV);
+  REGISTER_OP(TESTNZ,                 TestNZ);
   REGISTER_OP(SUB,                    Sub);
+  REGISTER_OP(SUBNZCV,                SubNZCV);
   REGISTER_OP(NEG,                    Neg);
   REGISTER_OP(ABS,                    Abs);
   REGISTER_OP(MUL,                    Mul);
@@ -62,6 +65,8 @@ constexpr OpHandlerArray InterpreterOpHandlers = [] {
   REGISTER_OP(MULH,                   MulH);
   REGISTER_OP(UMULH,                  UMulH);
   REGISTER_OP(OR,                     Or);
+  REGISTER_OP(ORLSHL,                 Orlshl);
+  REGISTER_OP(ORLSHR,                 Orlshr);
   REGISTER_OP(AND,                    And);
   REGISTER_OP(ANDN,                   Andn);
   REGISTER_OP(XOR,                    Xor);

--- a/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
+++ b/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
@@ -85,7 +85,10 @@ namespace FEXCore::CPU {
   DEF_OP(InlineEntrypointOffset);
   DEF_OP(CycleCounter);
   DEF_OP(Add);
+  DEF_OP(AddNZCV);
+  DEF_OP(TestNZ);
   DEF_OP(Sub);
+  DEF_OP(SubNZCV);
   DEF_OP(Neg);
   DEF_OP(Abs);
   DEF_OP(Mul);
@@ -97,6 +100,8 @@ namespace FEXCore::CPU {
   DEF_OP(MulH);
   DEF_OP(UMulH);
   DEF_OP(Or);
+  DEF_OP(Orlshl);
+  DEF_OP(Orlshr);
   DEF_OP(And);
   DEF_OP(Andn);
   DEF_OP(Xor);

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -1228,7 +1228,6 @@ fextl::unique_ptr<CPUBackend> CreateArm64JITCore(FEXCore::Context::ContextImpl *
 CPUBackendFeatures GetArm64JITBackendFeatures() {
   return CPUBackendFeatures {
     .SupportsStaticRegisterAllocation = true,
-    .SupportsShiftedBitwise = true,
     .SupportsFlags = true,
     .SupportsSaturatingRoundingShifts = true,
   };

--- a/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -244,7 +244,10 @@ private:
   DEF_OP(InlineEntrypointOffset);
   DEF_OP(CycleCounter);
   DEF_OP(Add);
+  DEF_OP(AddNZCV);
+  DEF_OP(TestNZ);
   DEF_OP(Sub);
+  DEF_OP(SubNZCV);
   DEF_OP(Neg);
   DEF_OP(Abs);
   DEF_OP(Mul);
@@ -256,6 +259,8 @@ private:
   DEF_OP(MulH);
   DEF_OP(UMulH);
   DEF_OP(Or);
+  DEF_OP(Orlshl);
+  DEF_OP(Orlshr);
   DEF_OP(And);
   DEF_OP(Andn);
   DEF_OP(Xor);

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -1157,7 +1157,7 @@ private:
   void SetNZ_ZeroCV(unsigned SrcSize, OrderedNode *Res) {
     // The TestNZ opcode does this operation natively for 32-bit or 64-bit.
     // Otherwise we can implement the functionality ourselves with some bit math.
-    if (CTX->BackendFeatures.SupportsFlags && SrcSize >= 4) {
+    if (SrcSize >= 4) {
       CachedNZCV = _TestNZ(SrcSize, Res);
       PossiblySetNZCVBits = (1u << 31) | (1u << 30);
     } else {
@@ -1180,7 +1180,7 @@ private:
 
     if (SetBits == 0)
       return _Lshl(OpSize::i64Bit, Value, _Constant(Bit));
-    else if (CTX->BackendFeatures.SupportsShiftedBitwise && (SetBits & (1u << Bit)) == 0)
+    else if ((SetBits & (1u << Bit)) == 0)
       return _Orlshl(OpSize::i32Bit, NZCV, Value, Bit);
     else
       return _Bfi(OpSize::i32Bit, 1, Bit, NZCV, Value);

--- a/FEXCore/include/FEXCore/Core/CPUBackend.h
+++ b/FEXCore/include/FEXCore/Core/CPUBackend.h
@@ -35,7 +35,6 @@ namespace CodeSerialize {
 namespace CPU {
   struct CPUBackendFeatures {
     bool SupportsStaticRegisterAllocation = false;
-    bool SupportsShiftedBitwise = false;
     bool SupportsFlags = false;
     bool SupportsSaturatingRoundingShifts = false;
   };


### PR DESCRIPTION
This wasn't implemented initially for the interpreter and x86 JIT.

This meant we are maintaining two codepaths. Implement these operations in the interpreter and x86 JIT so we no longer need to do that.

The emitted code in the x86 JIT is hot garbage, but it's only necessary for correctness testing, not performance testing there.