### PR TITLE
OpcodeDispatcher: Optimize NOP vector move

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -24,6 +24,11 @@ namespace FEXCore::IR {
 #define OpcodeArgs [[maybe_unused]] FEXCore::X86Tables::DecodedOp Op
 
 void OpDispatchBuilder::MOVVectorOp(OpcodeArgs) {
+  if (Op->Dest.IsGPR() && Op->Src[0].IsGPR() &&
+      Op->Dest.Data.GPR.GPR == Op->Src[0].Data.GPR.GPR) {
+    // Nop
+    return;
+  }
   OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, 1);
   StoreResult(FPRClass, Op, Src, 1);
 }

--- a/unittests/InstructionCountCI/DDD.json
+++ b/unittests/InstructionCountCI/DDD.json
@@ -240,13 +240,10 @@
       ]
     },
     "pfrcpit1 mm0, mm0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 0,
+      "Optimal": "Yes",
       "Comment": "0x0f 0x0f 0xa6",
-      "ExpectedArm64ASM": [
-        "ldr d2, [x28, #752]",
-        "str d2, [x28, #752]"
-      ]
+      "ExpectedArm64ASM": []
     },
     "pfrsqit1 mm0, mm1": {
       "ExpectedInstructionCount": 2,
@@ -258,13 +255,10 @@
       ]
     },
     "pfrsqit1 mm0, mm0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 0,
+      "Optimal": "Yes",
       "Comment": "0x0f 0x0f 0xa7",
-      "ExpectedArm64ASM": [
-        "ldr d2, [x28, #752]",
-        "str d2, [x28, #752]"
-      ]
+      "ExpectedArm64ASM": []
     },
     "pfsubr mm0, mm1": {
       "ExpectedInstructionCount": 4,
@@ -309,13 +303,10 @@
       ]
     },
     "pfrcpit2 mm0, mm0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 0,
+      "Optimal": "Yes",
       "Comment": "0x0f 0x0f 0xb6",
-      "ExpectedArm64ASM": [
-        "ldr d2, [x28, #752]",
-        "str d2, [x28, #752]"
-      ]
+      "ExpectedArm64ASM": []
     },
     "db 0x0f, 0x0f, 0xc1, 0xb7": {
       "ExpectedInstructionCount": 8,

--- a/unittests/InstructionCountCI/Secondary_OpSize.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize.json
@@ -9,6 +9,12 @@
     ]
   },
   "Instructions": {
+    "movupd xmm0, xmm0": {
+      "ExpectedInstructionCount": 0,
+      "Optimal": "Yes",
+      "Comment": "0x66 0x0f 0x10",
+      "ExpectedArm64ASM": []
+    },
     "movupd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
       "Optimal": "Yes",

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -10,6 +10,19 @@
     ]
   },
   "Instructions": {
+    "vmovups xmm0, xmm0": {
+      "ExpectedInstructionCount": 3,
+      "Optimal": "No",
+      "Comment": [
+        "Spurious moves",
+        "Map 1 0b00 0x10 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "mov z2.d, p7/m, z16.d",
+        "mov v2.16b, v2.16b",
+        "mov z16.d, p7/m, z2.d"
+      ]
+    },
     "vmovups xmm0, [rax]": {
       "ExpectedInstructionCount": 2,
       "Optimal": "No",
@@ -20,6 +33,18 @@
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x4]",
+        "mov z16.d, p7/m, z2.d"
+      ]
+    },
+    "vmovups ymm0, ymm0": {
+      "ExpectedInstructionCount": 2,
+      "Optimal": "No",
+      "Comment": [
+        "Spurious moves",
+        "Map 1 0b00 0x10 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "mov z2.d, p7/m, z16.d",
         "mov z16.d, p7/m, z2.d"
       ]
     },
@@ -35,6 +60,19 @@
         "mov z16.d, p7/m, z2.d"
       ]
     },
+    "vmovupd xmm0, xmm0": {
+      "ExpectedInstructionCount": 3,
+      "Optimal": "No",
+      "Comment": [
+        "Spurious moves",
+        "Map 1 0b01 0x10 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "mov z2.d, p7/m, z16.d",
+        "mov v2.16b, v2.16b",
+        "mov z16.d, p7/m, z2.d"
+      ]
+    },
     "vmovupd xmm0, [rax]": {
       "ExpectedInstructionCount": 2,
       "Optimal": "No",
@@ -45,6 +83,18 @@
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x4]",
+        "mov z16.d, p7/m, z2.d"
+      ]
+    },
+    "vmovupd ymm0, ymm0": {
+      "ExpectedInstructionCount": 2,
+      "Optimal": "No",
+      "Comment": [
+        "Spurious moves",
+        "Map 1 0b01 0x10 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "mov z2.d, p7/m, z16.d",
         "mov z16.d, p7/m, z2.d"
       ]
     },


### PR DESCRIPTION
Move instruction to itself here is a nop.
Need to be careful about AVX operations which use a different handler
since those might actually zero the upper bits on 128-bit move

Unlikely that this ever gets hit by a real compiler.