### PR TITLE
OpcodeDispatcher: Optimize pins{b,w,d,q}

### DIFF
--- a/unittests/InstructionCountCI/H0F3A.json
+++ b/unittests/InstructionCountCI/H0F3A.json
@@ -724,36 +724,63 @@
       ]
     },
     "pinsrb xmm0, eax, 0000b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x20"
       ],
       "ExpectedArm64ASM": [
-        "uxth w20, w4",
-        "mov v16.b[0], w20"
+        "mov v16.b[0], w4"
       ]
     },
     "pinsrb xmm0, eax, 0001b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x20"
       ],
       "ExpectedArm64ASM": [
-        "uxth w20, w4",
-        "mov v16.b[1], w20"
+        "mov v16.b[1], w4"
       ]
     },
     "pinsrb xmm0, eax, 1111b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x20"
       ],
       "ExpectedArm64ASM": [
-        "uxth w20, w4",
-        "mov v16.b[15], w20"
+        "mov v16.b[15], w4"
+      ]
+    },
+    "pinsrb xmm0, [rax], 0000b": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": [
+        "0x66 0x0f 0x3a 0x20"
+      ],
+      "ExpectedArm64ASM": [
+        "ld1 {v16.b}[0], [x4]"
+      ]
+    },
+    "pinsrb xmm0, [rax], 0001b": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": [
+        "0x66 0x0f 0x3a 0x20"
+      ],
+      "ExpectedArm64ASM": [
+        "ld1 {v16.b}[1], [x4]"
+      ]
+    },
+    "pinsrb xmm0, [rax], 1111b": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": [
+        "0x66 0x0f 0x3a 0x20"
+      ],
+      "ExpectedArm64ASM": [
+        "ld1 {v16.b}[15], [x4]"
       ]
     },
     "insertps xmm0, xmm1, 00000000b": {
@@ -787,36 +814,33 @@
       ]
     },
     "pinsrd xmm0, eax, 00b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x22"
       ],
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
-        "mov v16.s[0], w20"
+        "mov v16.s[0], w4"
       ]
     },
     "pinsrd xmm0, eax, 01b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x22"
       ],
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
-        "mov v16.s[1], w20"
+        "mov v16.s[1], w4"
       ]
     },
     "pinsrd xmm0, eax, 11b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x22"
       ],
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
-        "mov v16.s[3], w20"
+        "mov v16.s[3], w4"
       ]
     },
     "pinsrq xmm0, rax, 0b": {
@@ -837,6 +861,56 @@
       ],
       "ExpectedArm64ASM": [
         "mov v16.d[1], x4"
+      ]
+    },
+    "pinsrd xmm0, [rax], 00b": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": [
+        "0x66 0x0f 0x3a 0x22"
+      ],
+      "ExpectedArm64ASM": [
+        "ld1 {v16.s}[0], [x4]"
+      ]
+    },
+    "pinsrd xmm0, [rax], 01b": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": [
+        "0x66 0x0f 0x3a 0x22"
+      ],
+      "ExpectedArm64ASM": [
+        "ld1 {v16.s}[1], [x4]"
+      ]
+    },
+    "pinsrd xmm0, [rax], 11b": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": [
+        "0x66 0x0f 0x3a 0x22"
+      ],
+      "ExpectedArm64ASM": [
+        "ld1 {v16.s}[3], [x4]"
+      ]
+    },
+    "pinsrq xmm0, [rax], 0b": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": [
+        "0x66 REX.W 0x0f 0x3a 0x22"
+      ],
+      "ExpectedArm64ASM": [
+        "ld1 {v16.d}[0], [x4]"
+      ]
+    },
+    "pinsrq xmm0, [rax], 1b": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": [
+        "0x66 REX.W 0x0f 0x3a 0x22"
+      ],
+      "ExpectedArm64ASM": [
+        "ld1 {v16.d}[1], [x4]"
       ]
     },
     "dpps xmm0, xmm1, 00000000b": {

--- a/unittests/InstructionCountCI/Secondary.json
+++ b/unittests/InstructionCountCI/Secondary.json
@@ -3452,112 +3452,102 @@
       ]
     },
     "pinsrw mm0, eax, 0": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 3,
+      "Optimal": "Yes",
       "Comment": "0x0f 0xc4",
       "ExpectedArm64ASM": [
-        "uxth w20, w4",
         "ldr d2, [x28, #752]",
-        "mov v2.h[0], w20",
+        "mov v2.h[0], w4",
         "str d2, [x28, #752]"
       ]
     },
     "pinsrw mm0, eax, 1": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 3,
+      "Optimal": "Yes",
       "Comment": "0x0f 0xc4",
       "ExpectedArm64ASM": [
-        "uxth w20, w4",
         "ldr d2, [x28, #752]",
-        "mov v2.h[1], w20",
+        "mov v2.h[1], w4",
         "str d2, [x28, #752]"
       ]
     },
     "pinsrw mm0, eax, 2": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 3,
+      "Optimal": "Yes",
       "Comment": "0x0f 0xc4",
       "ExpectedArm64ASM": [
-        "uxth w20, w4",
         "ldr d2, [x28, #752]",
-        "mov v2.h[2], w20",
+        "mov v2.h[2], w4",
         "str d2, [x28, #752]"
       ]
     },
     "pinsrw mm0, eax, 3": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 3,
+      "Optimal": "Yes",
       "Comment": "0x0f 0xc4",
       "ExpectedArm64ASM": [
-        "uxth w20, w4",
         "ldr d2, [x28, #752]",
-        "mov v2.h[3], w20",
+        "mov v2.h[3], w4",
         "str d2, [x28, #752]"
       ]
     },
     "pinsrw mm0, eax, 4": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 3,
+      "Optimal": "Yes",
       "Comment": "0x0f 0xc4",
       "ExpectedArm64ASM": [
-        "uxth w20, w4",
         "ldr d2, [x28, #752]",
-        "mov v2.h[0], w20",
+        "mov v2.h[0], w4",
         "str d2, [x28, #752]"
       ]
     },
     "pinsrw mm0, [rax], 0": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": "0x0f 0xc4",
       "ExpectedArm64ASM": [
-        "ldrh w20, [x4]",
         "ldr d2, [x28, #752]",
-        "mov v2.h[0], w20",
+        "ld1 {v2.h}[0], [x4]",
         "str d2, [x28, #752]"
       ]
     },
     "pinsrw mm0, [rax], 1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": "0x0f 0xc4",
       "ExpectedArm64ASM": [
-        "ldrh w20, [x4]",
         "ldr d2, [x28, #752]",
-        "mov v2.h[1], w20",
+        "ld1 {v2.h}[1], [x4]",
         "str d2, [x28, #752]"
       ]
     },
     "pinsrw mm0, [rax], 2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": "0x0f 0xc4",
       "ExpectedArm64ASM": [
-        "ldrh w20, [x4]",
         "ldr d2, [x28, #752]",
-        "mov v2.h[2], w20",
+        "ld1 {v2.h}[2], [x4]",
         "str d2, [x28, #752]"
       ]
     },
     "pinsrw mm0, [rax], 3": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": "0x0f 0xc4",
       "ExpectedArm64ASM": [
-        "ldrh w20, [x4]",
         "ldr d2, [x28, #752]",
-        "mov v2.h[3], w20",
+        "ld1 {v2.h}[3], [x4]",
         "str d2, [x28, #752]"
       ]
     },
     "pinsrw mm0, [rax], 4": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": "0x0f 0xc4",
       "ExpectedArm64ASM": [
-        "ldrh w20, [x4]",
         "ldr d2, [x28, #752]",
-        "mov v2.h[0], w20",
+        "ld1 {v2.h}[0], [x4]",
         "str d2, [x28, #752]"
       ]
     },

--- a/unittests/InstructionCountCI/Secondary_OpSize.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize.json
@@ -810,75 +810,131 @@
       ]
     },
     "pinsrw xmm0, eax, 000b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc4",
       "ExpectedArm64ASM": [
-        "uxth w20, w4",
-        "mov v16.h[0], w20"
+        "mov v16.h[0], w4"
       ]
     },
     "pinsrw xmm0, eax, 001b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc4",
       "ExpectedArm64ASM": [
-        "uxth w20, w4",
-        "mov v16.h[1], w20"
+        "mov v16.h[1], w4"
       ]
     },
     "pinsrw xmm0, eax, 010b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc4",
       "ExpectedArm64ASM": [
-        "uxth w20, w4",
-        "mov v16.h[2], w20"
+        "mov v16.h[2], w4"
       ]
     },
     "pinsrw xmm0, eax, 011b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc4",
       "ExpectedArm64ASM": [
-        "uxth w20, w4",
-        "mov v16.h[3], w20"
+        "mov v16.h[3], w4"
       ]
     },
     "pinsrw xmm0, eax, 100b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc4",
       "ExpectedArm64ASM": [
-        "uxth w20, w4",
-        "mov v16.h[4], w20"
+        "mov v16.h[4], w4"
       ]
     },
     "pinsrw xmm0, eax, 101b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc4",
       "ExpectedArm64ASM": [
-        "uxth w20, w4",
-        "mov v16.h[5], w20"
+        "mov v16.h[5], w4"
       ]
     },
     "pinsrw xmm0, eax, 110b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc4",
       "ExpectedArm64ASM": [
-        "uxth w20, w4",
-        "mov v16.h[6], w20"
+        "mov v16.h[6], w4"
       ]
     },
     "pinsrw xmm0, eax, 111b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc4",
       "ExpectedArm64ASM": [
-        "uxth w20, w4",
-        "mov v16.h[7], w20"
+        "mov v16.h[7], w4"
+      ]
+    },
+    "pinsrw xmm0, [rax], 000b": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": "0x66 0x0f 0xc4",
+      "ExpectedArm64ASM": [
+        "ld1 {v16.h}[0], [x4]"
+      ]
+    },
+    "pinsrw xmm0, [rax], 001b": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": "0x66 0x0f 0xc4",
+      "ExpectedArm64ASM": [
+        "ld1 {v16.h}[1], [x4]"
+      ]
+    },
+    "pinsrw xmm0, [rax], 010b": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": "0x66 0x0f 0xc4",
+      "ExpectedArm64ASM": [
+        "ld1 {v16.h}[2], [x4]"
+      ]
+    },
+    "pinsrw xmm0, [rax], 011b": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": "0x66 0x0f 0xc4",
+      "ExpectedArm64ASM": [
+        "ld1 {v16.h}[3], [x4]"
+      ]
+    },
+    "pinsrw xmm0, [rax], 100b": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": "0x66 0x0f 0xc4",
+      "ExpectedArm64ASM": [
+        "ld1 {v16.h}[4], [x4]"
+      ]
+    },
+    "pinsrw xmm0, [rax], 101b": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": "0x66 0x0f 0xc4",
+      "ExpectedArm64ASM": [
+        "ld1 {v16.h}[5], [x4]"
+      ]
+    },
+    "pinsrw xmm0, [rax], 110b": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": "0x66 0x0f 0xc4",
+      "ExpectedArm64ASM": [
+        "ld1 {v16.h}[6], [x4]"
+      ]
+    },
+    "pinsrw xmm0, [rax], 111b": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": "0x66 0x0f 0xc4",
+      "ExpectedArm64ASM": [
+        "ld1 {v16.h}[7], [x4]"
       ]
     },
     "pextrw eax, xmm0, 000b": {

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -3067,43 +3067,40 @@
       ]
     },
     "vpinsrw xmm0, xmm1, eax, 000b": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC4 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "uxth w20, w4",
         "mov z2.d, p7/m, z17.d",
-        "mov v2.h[0], w20",
+        "mov v2.h[0], w4",
         "mov v2.16b, v2.16b",
         "mov z16.d, p7/m, z2.d"
       ]
     },
     "vpinsrw xmm0, xmm1, eax, 001b": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC4 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "uxth w20, w4",
         "mov z2.d, p7/m, z17.d",
-        "mov v2.h[1], w20",
+        "mov v2.h[1], w4",
         "mov v2.16b, v2.16b",
         "mov z16.d, p7/m, z2.d"
       ]
     },
     "vpinsrw xmm0, xmm1, eax, 111b": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC4 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "uxth w20, w4",
         "mov z2.d, p7/m, z17.d",
-        "mov v2.h[7], w20",
+        "mov v2.h[7], w4",
         "mov v2.16b, v2.16b",
         "mov z16.d, p7/m, z2.d"
       ]

--- a/unittests/InstructionCountCI/VEX_map3.json
+++ b/unittests/InstructionCountCI/VEX_map3.json
@@ -3234,31 +3234,29 @@
       ]
     },
     "vpinsrb xmm0, xmm1, eax, 0": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "nearest rounding",
         "Map 3 0b01 0x20 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
         "mov z2.d, p7/m, z17.d",
-        "mov v2.b[0], w20",
+        "mov v2.b[0], w4",
         "mov v2.16b, v2.16b",
         "mov z16.d, p7/m, z2.d"
       ]
     },
     "vpinsrb xmm0, xmm1, eax, 15": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "nearest rounding",
         "Map 3 0b01 0x20 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
         "mov z2.d, p7/m, z17.d",
-        "mov v2.b[15], w20",
+        "mov v2.b[15], w4",
         "mov v2.16b, v2.16b",
         "mov z16.d, p7/m, z2.d"
       ]
@@ -3307,31 +3305,29 @@
       ]
     },
     "vpinsrd xmm0, xmm1, eax, 0": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "nearest rounding",
         "Map 3 0b01 0x22 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
         "mov z2.d, p7/m, z17.d",
-        "mov v2.s[0], w20",
+        "mov v2.s[0], w4",
         "mov v2.16b, v2.16b",
         "mov z16.d, p7/m, z2.d"
       ]
     },
     "vpinsrd xmm0, xmm1, eax, 3": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "nearest rounding",
         "Map 3 0b01 0x22 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
         "mov z2.d, p7/m, z17.d",
-        "mov v2.s[3], w20",
+        "mov v2.s[3], w4",
         "mov v2.16b, v2.16b",
         "mov z16.d, p7/m, z2.d"
       ]


### PR DESCRIPTION
Inserting from a GPR and memory can both be optimized. These are now
optimal

~~Needs https://github.com/FEX-Emu/FEX/pull/3088 merged first.~~