### PR TITLE
InstCountCI: Add log before compiling instruction

### DIFF
--- a/Source/Tools/CodeSizeValidation/Main.cpp
+++ b/Source/Tools/CodeSizeValidation/Main.cpp
@@ -251,6 +251,8 @@ static bool TestInstructions(FEXCore::Context::Context *CTX, FEXCore::Core::Inte
   TestInfo const *CurrentTest = &TestHeaderData->Tests[0];
   for (size_t i = 0; i < TestHeaderData->NumTests; ++i) {
     uint64_t CodeRIP = (uint64_t)&CurrentTest->Code[0];
+    LogMan::Msg::IFmt("Compiling instruction '{}'", CurrentTest->TestInst);
+
     // Compile the INST.
     CTX->CompileRIP(Thread, CodeRIP);
 


### PR DESCRIPTION
If CI faults out due to a bug then we would have no log as to which instruction caused the issue.

I find myself adding this each time an assert fires to see what instruction it was working on. Just add it directly.