### PR TITLE
OpcodeDispatcher: Optimize 16-bit MOVBE 

### DIFF
--- a/FEXCore/Source/Interface/Core/Interpreter/ALUOps.cpp
+++ b/FEXCore/Source/Interface/Core/Interpreter/ALUOps.cpp
@@ -856,6 +856,18 @@ DEF_OP(Bfi) {
   GD = Res;
 }
 
+DEF_OP(Bfxil) {
+  auto Op = IROp->C<IR::IROp_Bfxil>();
+  uint64_t SourceMask = (1ULL << Op->Width) - 1;
+  if (Op->Width == 64) {
+    SourceMask = ~0ULL;
+  }
+  const uint64_t Src1 = *GetSrc<uint64_t*>(Data->SSAData, Op->Dest);
+  const uint64_t Src2 = *GetSrc<uint64_t*>(Data->SSAData, Op->Src);
+  const uint64_t Res = (Src1 & ~SourceMask) | ((Src2 >> Op->lsb) & SourceMask);
+  GD = Res;
+}
+
 DEF_OP(Bfe) {
   auto Op = IROp->C<IR::IROp_Bfe>();
 

--- a/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -84,6 +84,7 @@ constexpr OpHandlerArray InterpreterOpHandlers = [] {
   REGISTER_OP(COUNTLEADINGZEROES,     CountLeadingZeroes);
   REGISTER_OP(REV,                    Rev);
   REGISTER_OP(BFI,                    Bfi);
+  REGISTER_OP(BFXIL,                  Bfxil);
   REGISTER_OP(BFE,                    Bfe);
   REGISTER_OP(SBFE,                   Sbfe);
   REGISTER_OP(SELECT,                 Select);

--- a/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
+++ b/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
@@ -121,6 +121,7 @@ namespace FEXCore::CPU {
   DEF_OP(CountLeadingZeroes);
   DEF_OP(Rev);
   DEF_OP(Bfi);
+  DEF_OP(Bfxil);
   DEF_OP(Bfe);
   DEF_OP(Sbfe);
   DEF_OP(Select);

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -894,6 +894,7 @@ CPUBackend::CompiledCode Arm64JITCore::CompileCode(uint64_t Entry,
         REGISTER_OP(COUNTLEADINGZEROES, CountLeadingZeroes);
         REGISTER_OP(REV,               Rev);
         REGISTER_OP(BFI,               Bfi);
+        REGISTER_OP(BFXIL,             Bfxil);
         REGISTER_OP(BFE,               Bfe);
         REGISTER_OP(SBFE,              Sbfe);
         REGISTER_OP(SELECT,            Select);

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -272,6 +272,7 @@ private:
   DEF_OP(CountLeadingZeroes);
   DEF_OP(Rev);
   DEF_OP(Bfi);
+  DEF_OP(Bfxil);
   DEF_OP(Bfe);
   DEF_OP(Sbfe);
   DEF_OP(Select);

--- a/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -280,6 +280,7 @@ private:
   DEF_OP(CountLeadingZeroes);
   DEF_OP(Rev);
   DEF_OP(Bfi);
+  DEF_OP(Bfxil);
   DEF_OP(Bfe);
   DEF_OP(Sbfe);
   DEF_OP(Select);

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -1073,6 +1073,17 @@
           "Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
         ]
       },
+      "GPR = Bfxil OpSize:#Size, u8:$Width, u8:$lsb, GPR:$Dest, GPR:$Src": {
+        "Desc": ["Copies a bitfield from one GPR to another",
+                 "Inserting in to the low bits of the destination",
+                 "The source bitfield is from Src[(Width + lsb):lsb]",
+                 "The bitfield is copied in to Dest[Width:0]"
+                ],
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
+      },
       "GPR = Bfe OpSize:#Size, u8:$Width, u8:$lsb, GPR:$Src": {
         "Desc": ["Extracts a bitfield from one GPR with zext",
                  "The source bitfield is from Src[Width:0]",

--- a/unittests/InstructionCountCI/H0F38.json
+++ b/unittests/InstructionCountCI/H0F38.json
@@ -1012,16 +1012,15 @@
       ]
     },
     "movbe ax, word [rbx]": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 3,
+      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0xf0"
       ],
       "ExpectedArm64ASM": [
         "ldrh w20, [x7]",
         "rev w20, w20",
-        "lsr w20, w20, #16",
-        "bfxil x4, x20, #0, #16"
+        "bfxil x4, x20, #16, #16"
       ]
     },
     "movbe eax, dword [rbx]": {


### PR DESCRIPTION
16-bit MOVBE is a bit of a special case where it loads 16-bits in to the
bottom of the GPR without clearing the upper bits of the register.
Which means 32-bits or 64-bits depending on operating mode.

Arm64 doesn't support a 16-bit bswap so it needs to operate at 32-bits
instead. We then can insert the resulting bits of the 32-bit rev with a
bfxil in to the lower bits of the resulting destination register.

This allows 16-bit movbe to be optimal now.