### PR TITLE
FEXCore: Disable Enhanced REP MOVSB if Atomic TSO is enabled

### DIFF
--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -378,6 +378,20 @@ namespace FEXCore::Context {
       UpdateAtomicTSOEmulationConfig();
     }
 
+    // Returns if Software TSO emulation is required.
+    // NOTE: This doesn't necessary return if Atomic-based TSO is currently enabled.
+    // This will still return true if on a single thread and TSO is currently disabled.
+    //
+    // This is to ensure that if early initialization checks CPU features and TSO /could/ be enabled, that
+    // we return consistent results.
+    //
+    // To check if Atomic TSO is currently enabled in the JIT, use `IsAtomicTSOEnabled` instead.
+    bool SoftwareTSORequired() const {
+      if (SupportsHardwareTSO) return false;
+
+      return Config.TSOEnabled;
+    }
+
     void EnableExitOnHLT() override { ExitOnHLT = true; }
 
     bool ExitOnHLTEnabled() const { return ExitOnHLT; }


### PR DESCRIPTION
Hades and the vcruntime hits this very hard in memmove.

`86.56%  [JIT] tid 458574        [.] JIT_0x18000c375_0x7fffc94790c8`

```asm
   0x00007fffc94790f8:  ldaprb  w3, [x2]
   0x00007fffc94790fc:  stlrb   w3, [x1]
   0x00007fffc9479100:  add     x1, x1, #0x1
   0x00007fffc9479104:  add     x2, x2, #0x1
   0x00007fffc9479108:  sub     x0, x0, #0x1
   0x00007fffc947910c:  cbnz    x0, 0x7fffc94790f8
```

This performance is terrible because Cortex's LRCPC performance is bottom-tier. Work around the performance issue by forcing things to do larger moves with vector moves instead.