### PR TITLE
IR: Changes Select operation to not have implicit sizes 

### DIFF
--- a/FEXCore/Scripts/json_ir_generator.py
+++ b/FEXCore/Scripts/json_ir_generator.py
@@ -144,7 +144,7 @@ def parse_ops(ops):
                     Argument = Argument.strip()
                     OpArg = OpArgument()
 
-                    Split = Argument.split(":")
+                    Split = Argument.split(":", 1)
                     if len(Split) != 2:
                         ExitError("Error parsing argument. Missing Type and name colon split")
 

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -1093,14 +1093,15 @@
           "Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
         ]
       },
-      "GPR = Select CondClass:$Cond, SSA:$Cmp1, SSA:$Cmp2, GPR:$TrueVal, GPR:$FalseVal, u8:$CompareSize": {
+      "GPR = Select OpSize:#ResultSize, OpSize:$CompareSize, CondClass:$Cond, SSA:$Cmp1, SSA:$Cmp2, GPR:$TrueVal, GPR:$FalseVal": {
         "Desc": ["Ternary selection of GPRs",
                  "op:",
-                 "Dest = Cmp1 <Cond> Cmp2 ? TrueVal : FalseVal",
-                 "TODO: Make this less opaque about how it operates"
+                 "Dest = Cmp1 <Cond> Cmp2 ? TrueVal : FalseVal"
                 ],
-        "DestSize": "std::max<uint8_t>(4, std::max<uint8_t>(GetOpSize(_TrueVal), GetOpSize(_FalseVal)))",
+        "DestSize": "ResultSize",
         "EmitValidation": [
+          "_CompareSize == FEXCore::IR::OpSize::i32Bit || _CompareSize == FEXCore::IR::OpSize::i64Bit || _CompareSize == FEXCore::IR::OpSize::i128Bit",
+          "ResultSize == FEXCore::IR::OpSize::i32Bit || ResultSize == FEXCore::IR::OpSize::i64Bit",
           "WalkFindRegClass($Cmp1) == WalkFindRegClass($Cmp2)"
         ]
       },

--- a/FEXCore/include/FEXCore/IR/IREmitter.h
+++ b/FEXCore/include/FEXCore/IR/IREmitter.h
@@ -69,11 +69,12 @@ friend class FEXCore::IR::PassManager;
   IRPair<IROp_CondJump> _CondJump(OrderedNode *ssa0, OrderedNode *ssa1, OrderedNode *ssa2, CondClassType cond = {COND_NEQ}) {
     return _CondJump(ssa0, _Constant(0), ssa1, ssa2, cond, GetOpSize(ssa0));
   }
+  // TODO: Work to remove this implicit sized Select implementation.
   IRPair<IROp_Select> _Select(uint8_t Cond, OrderedNode *ssa0, OrderedNode *ssa1, OrderedNode *ssa2, OrderedNode *ssa3, uint8_t CompareSize = 0) {
     if (CompareSize == 0)
       CompareSize = std::max<uint8_t>(4, std::max<uint8_t>(GetOpSize(ssa0), GetOpSize(ssa1)));
 
-    return _Select(CondClassType{Cond}, ssa0, ssa1, ssa2, ssa3, CompareSize);
+    return _Select(IR::SizeToOpSize(std::max<uint8_t>(4, std::max<uint8_t>(GetOpSize(ssa2), GetOpSize(ssa3)))), IR::SizeToOpSize(CompareSize), CondClassType{Cond}, ssa0, ssa1, ssa2, ssa3);
   }
   IRPair<IROp_LoadMem> _LoadMem(FEXCore::IR::RegisterClassType Class, uint8_t Size, OrderedNode *ssa0, uint8_t Align = 1) {
     return _LoadMem(Class, Size, ssa0, Invalid(), Align, MEM_OFFSET_SXTX, 1);


### PR DESCRIPTION
Changes the helper which all the source uses to still calculate the size
implicitly. This is going to take a while to convert all implicit uses
over to the explicit operation.

Get us started by at least having the IR operation itself be explicit.

This is taking the same idea as #3073 but doing it more slowly so we don't break anything.