### PR TITLE
DeadContextStoreElimination: Silence unused function warning 

### DIFF
--- a/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
@@ -59,6 +59,7 @@ namespace {
     return (Type & ACCESS_PARTIAL) == ACCESS_PARTIAL;
   }
 
+  [[maybe_unused]]
   static bool IsFullAccess(LastAccessType Type) {
     return (Type & ACCESS_PARTIAL) == 0;
   }


### PR DESCRIPTION
While we're in the same relevant area, we can also covert LastAccessType into an enum class