### PR TITLE
OpcodeDispatcher: Handle RORX corner cases better

### DIFF
--- a/unittests/ASM/VEX/rorx.asm
+++ b/unittests/ASM/VEX/rorx.asm
@@ -6,7 +6,8 @@
       "RCX": "0xF00000000000000F",
       "RDX": "0x80000000",
       "RSI": "0xFF",
-      "RDI": "0xF000000F"
+      "RDI": "0xF000000F",
+      "R8":  "0"
   },
   "HostFeatures": ["BMI2"]
 }
@@ -35,5 +36,9 @@ rorx edi, esi, 4,
 
 ; Test that we mask the rotation amount above the operand size (should leave edi's value alone).
 rorx edi, edi, 32
+
+; Zero-extending behavior
+mov r8, 0xFFFFFFFF00000000
+rorx r8d, r8d, 0
 
 hlt

--- a/unittests/InstructionCountCI/H0F38.json
+++ b/unittests/InstructionCountCI/H0F38.json
@@ -1104,8 +1104,8 @@
       "ExpectedArm64ASM": [
         "ldr w20, [x28, #728]",
         "ubfx w21, w20, #29, #1",
-        "lsr w22, w7, #0",
-        "lsr w23, w4, #0",
+        "mov w22, w7",
+        "mov w23, w4",
         "add w24, w22, w21",
         "add w4, w23, w24",
         "cmp w4, w22",
@@ -1148,8 +1148,8 @@
       "ExpectedArm64ASM": [
         "ldr w20, [x28, #728]",
         "ubfx w21, w20, #28, #1",
-        "lsr w22, w7, #0",
-        "lsr w23, w4, #0",
+        "mov w22, w7",
+        "mov w23, w4",
         "add w24, w22, w21",
         "add w4, w23, w24",
         "cmp w4, w22",

--- a/unittests/InstructionCountCI/Primary.json
+++ b/unittests/InstructionCountCI/Primary.json
@@ -71,8 +71,8 @@
       "Optimal": "No",
       "Comment": "0x01",
       "ExpectedArm64ASM": [
-        "lsr w20, w5, #0",
-        "lsr w21, w7, #0",
+        "mov w20, w5",
+        "mov w21, w7",
         "add w7, w21, w20",
         "eor w22, w21, w20",
         "strb w22, [x28, #708]",
@@ -169,8 +169,8 @@
         "add ebx, ecx but modrm.rm as source"
       ],
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
-        "lsr w21, w5, #0",
+        "mov w20, w7",
+        "mov w21, w5",
         "add w5, w21, w20",
         "eor w22, w21, w20",
         "strb w22, [x28, #708]",
@@ -259,7 +259,7 @@
       "Optimal": "No",
       "Comment": "0x05",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
+        "mov w20, w4",
         "add w4, w20, #0x1 (1)",
         "eor w21, w20, #0x1",
         "strb w21, [x28, #708]",
@@ -325,8 +325,8 @@
       "Optimal": "No",
       "Comment": "0x09",
       "ExpectedArm64ASM": [
-        "lsr w20, w5, #0",
-        "lsr w21, w7, #0",
+        "mov w20, w5",
+        "mov w21, w7",
         "orr w7, w21, w20",
         "strb w7, [x28, #706]",
         "tst w7, w7",
@@ -396,8 +396,8 @@
         "or ebx, ecx but modrm.rm as source"
       ],
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
-        "lsr w21, w5, #0",
+        "mov w20, w7",
+        "mov w21, w5",
         "orr w5, w21, w20",
         "strb w5, [x28, #706]",
         "tst w5, w5",
@@ -459,7 +459,7 @@
       "Optimal": "No",
       "Comment": "0x0D",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
+        "mov w20, w4",
         "orr w4, w20, #0x1",
         "strb w4, [x28, #706]",
         "tst w4, w4",
@@ -556,11 +556,11 @@
       "Optimal": "No",
       "Comment": "0x11",
       "ExpectedArm64ASM": [
-        "lsr w20, w5, #0",
+        "mov w20, w5",
         "ldr w21, [x28, #728]",
         "ubfx w21, w21, #29, #1",
         "add w22, w20, w21",
-        "lsr w23, w7, #0",
+        "mov w23, w7",
         "add w7, w23, w22",
         "eor w22, w23, w20",
         "strb w22, [x28, #708]",
@@ -698,11 +698,11 @@
         "adc ebx, ecx but modrm.rm as source"
       ],
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
+        "mov w20, w7",
         "ldr w21, [x28, #728]",
         "ubfx w21, w21, #29, #1",
         "add w22, w20, w21",
-        "lsr w23, w5, #0",
+        "mov w23, w5",
         "add w5, w23, w22",
         "eor w22, w23, w20",
         "strb w22, [x28, #708]",
@@ -838,7 +838,7 @@
         "ldr w21, [x28, #728]",
         "ubfx w21, w21, #29, #1",
         "add w20, w20, w21",
-        "lsr w22, w4, #0",
+        "mov w22, w4",
         "add w4, w22, w20",
         "eor w20, w22, #0x1",
         "strb w20, [x28, #708]",
@@ -968,11 +968,11 @@
       "Optimal": "No",
       "Comment": "0x19",
       "ExpectedArm64ASM": [
-        "lsr w20, w5, #0",
+        "mov w20, w5",
         "ldr w21, [x28, #728]",
         "ubfx w21, w21, #29, #1",
         "add w22, w20, w21",
-        "lsr w23, w7, #0",
+        "mov w23, w7",
         "sub w7, w23, w22",
         "eor w22, w23, w20",
         "strb w22, [x28, #708]",
@@ -1110,11 +1110,11 @@
         "sbb ebx, ecx but modrm.rm as source"
       ],
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
+        "mov w20, w7",
         "ldr w21, [x28, #728]",
         "ubfx w21, w21, #29, #1",
         "add w22, w20, w21",
-        "lsr w23, w5, #0",
+        "mov w23, w5",
         "sub w5, w23, w22",
         "eor w22, w23, w20",
         "strb w22, [x28, #708]",
@@ -1250,7 +1250,7 @@
         "ldr w21, [x28, #728]",
         "ubfx w21, w21, #29, #1",
         "add w20, w20, w21",
-        "lsr w22, w4, #0",
+        "mov w22, w4",
         "sub w4, w22, w20",
         "eor w20, w22, #0x1",
         "strb w20, [x28, #708]",
@@ -1344,8 +1344,8 @@
       "Optimal": "No",
       "Comment": "0x21",
       "ExpectedArm64ASM": [
-        "lsr w20, w5, #0",
-        "lsr w21, w7, #0",
+        "mov w20, w5",
+        "mov w21, w7",
         "and w7, w21, w20",
         "strb w7, [x28, #706]",
         "tst w7, w7",
@@ -1415,8 +1415,8 @@
         "and ebx, ecx but modrm.rm as source"
       ],
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
-        "lsr w21, w5, #0",
+        "mov w20, w7",
+        "mov w21, w5",
         "and w5, w21, w20",
         "strb w5, [x28, #706]",
         "tst w5, w5",
@@ -1478,7 +1478,7 @@
       "Optimal": "No",
       "Comment": "0x25",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
+        "mov w20, w4",
         "and w4, w20, #0x1",
         "strb w4, [x28, #706]",
         "tst w4, w4",
@@ -1561,8 +1561,8 @@
       "Optimal": "No",
       "Comment": "0x29",
       "ExpectedArm64ASM": [
-        "lsr w20, w5, #0",
-        "lsr w21, w7, #0",
+        "mov w20, w5",
+        "mov w21, w7",
         "sub w7, w21, w20",
         "eor w22, w21, w20",
         "strb w22, [x28, #708]",
@@ -1661,8 +1661,8 @@
         "sub ebx, ecx but modrm.rm as source"
       ],
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
-        "lsr w21, w5, #0",
+        "mov w20, w7",
+        "mov w21, w5",
         "sub w5, w21, w20",
         "eor w22, w21, w20",
         "strb w22, [x28, #708]",
@@ -1753,7 +1753,7 @@
       "Optimal": "No",
       "Comment": "0x2D",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
+        "mov w20, w4",
         "sub w4, w20, #0x1 (1)",
         "eor w21, w20, #0x1",
         "strb w21, [x28, #708]",
@@ -1821,8 +1821,8 @@
       "Optimal": "No",
       "Comment": "0x31",
       "ExpectedArm64ASM": [
-        "lsr w20, w5, #0",
-        "lsr w21, w7, #0",
+        "mov w20, w5",
+        "mov w21, w7",
         "eor w7, w21, w20",
         "strb w7, [x28, #706]",
         "tst w7, w7",
@@ -1892,8 +1892,8 @@
         "xor ebx, ecx but modrm.rm as source"
       ],
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
-        "lsr w21, w5, #0",
+        "mov w20, w7",
+        "mov w21, w5",
         "eor w5, w21, w20",
         "strb w5, [x28, #706]",
         "tst w5, w5",
@@ -1955,7 +1955,7 @@
       "Optimal": "No",
       "Comment": "0x35",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
+        "mov w20, w4",
         "eor w4, w20, #0x1",
         "strb w4, [x28, #706]",
         "tst w4, w4",
@@ -2036,8 +2036,8 @@
       "Optimal": "No",
       "Comment": "0x39",
       "ExpectedArm64ASM": [
-        "lsr w20, w5, #0",
-        "lsr w21, w7, #0",
+        "mov w20, w5",
+        "mov w21, w7",
         "sub w22, w21, w20",
         "eor w23, w21, w20",
         "strb w23, [x28, #708]",
@@ -2133,8 +2133,8 @@
         "cmp ebx, ecx but modrm.rm as source"
       ],
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
-        "lsr w21, w5, #0",
+        "mov w20, w7",
+        "mov w21, w5",
         "sub w22, w21, w20",
         "eor w23, w21, w20",
         "strb w23, [x28, #708]",
@@ -2222,7 +2222,7 @@
       "Optimal": "No",
       "Comment": "0x3D",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
+        "mov w20, w4",
         "sub w21, w20, #0x1 (1)",
         "eor w22, w20, #0x1",
         "strb w22, [x28, #708]",
@@ -2289,7 +2289,7 @@
       "Optimal": "No",
       "Comment": "0x63",
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
+        "mov w20, w7",
         "sxtw x4, w20"
       ]
     },
@@ -2335,12 +2335,12 @@
       "Optimal": "No",
       "Comment": "0x69",
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
+        "mov w20, w7",
         "sxtw x20, w20",
         "mov w21, #0x101",
         "mul x20, x20, x21",
         "asr x21, x20, #32",
-        "lsr w4, w20, #0",
+        "mov w4, w20",
         "mov w22, #0x0",
         "sbfx x20, x20, #31, #1",
         "mov w23, #0x30000000",
@@ -2416,12 +2416,12 @@
       "Optimal": "No",
       "Comment": "0x6b",
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
+        "mov w20, w7",
         "sxtw x20, w20",
         "mov w21, #0x3",
         "mul x20, x20, x21",
         "asr x21, x20, #32",
-        "lsr w4, w20, #0",
+        "mov w4, w20",
         "mov w22, #0x0",
         "sbfx x20, x20, #31, #1",
         "mov w23, #0x30000000",
@@ -2485,8 +2485,8 @@
       "Optimal": "No",
       "Comment": "0x84",
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
-        "lsr w21, w4, #0",
+        "mov w20, w7",
+        "mov w21, w4",
         "and w20, w21, w20",
         "strb w20, [x28, #706]",
         "tst w20, w20",
@@ -2555,8 +2555,8 @@
       "Optimal": "No",
       "Comment": "0x87",
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
-        "lsr w7, w5, #0",
+        "mov w20, w7",
+        "mov w7, w5",
         "mov x5, x20"
       ]
     },
@@ -2565,7 +2565,7 @@
       "Optimal": "No",
       "Comment": "0x87",
       "ExpectedArm64ASM": [
-        "lsr w20, w5, #0",
+        "mov w20, w5",
         "mov w1, w20",
         "swpal w1, w5, [x4]"
       ]
@@ -2612,7 +2612,7 @@
       "Optimal": "No",
       "Comment": "0x89",
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
+        "mov w20, w7",
         "str w20, [x4]"
       ]
     },
@@ -2821,8 +2821,8 @@
       "Comment": "0x8d",
       "ExpectedArm64ASM": [
         "add x20, x5, x7",
-        "lsr x20, x20, #0",
-        "lsr w4, w20, #0"
+        "mov x20, x20",
+        "mov w4, w20"
       ]
     },
     "lea rax, [rbx+rcx*1 + 0]": {
@@ -2850,8 +2850,8 @@
       "ExpectedArm64ASM": [
         "lsl x20, x5, #1",
         "add x20, x20, x7",
-        "lsr x20, x20, #0",
-        "lsr w4, w20, #0"
+        "mov x20, x20",
+        "mov w4, w20"
       ]
     },
     "lea rax, [rbx+rcx*2 + 0]": {
@@ -2880,8 +2880,8 @@
       "ExpectedArm64ASM": [
         "lsl x20, x5, #2",
         "add x20, x20, x7",
-        "lsr x20, x20, #0",
-        "lsr w4, w20, #0"
+        "mov x20, x20",
+        "mov w4, w20"
       ]
     },
     "lea rax, [rbx+rcx*4 + 0]": {
@@ -2910,8 +2910,8 @@
       "ExpectedArm64ASM": [
         "lsl x20, x5, #3",
         "add x20, x20, x7",
-        "lsr x20, x20, #0",
-        "lsr w4, w20, #0"
+        "mov x20, x20",
+        "mov w4, w20"
       ]
     },
     "lea rax, [rbx+rcx*8 + 0]": {
@@ -3016,8 +3016,8 @@
       "Optimal": "No",
       "Comment": "0x90",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
-        "lsr w4, w7, #0",
+        "mov w20, w4",
+        "mov w4, w7",
         "mov x7, x20"
       ]
     },
@@ -3052,9 +3052,9 @@
       "Optimal": "No",
       "Comment": "0x98",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
+        "mov w20, w4",
         "sxth x20, w20",
-        "lsr w4, w20, #0"
+        "mov w4, w20"
       ]
     },
     "cdqe": {
@@ -3080,9 +3080,9 @@
       "Optimal": "No",
       "Comment": "0x98",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
+        "mov w20, w4",
         "sbfx x20, x20, #31, #1",
-        "lsr w6, w20, #0"
+        "mov w6, w20"
       ]
     },
     "cqo": {
@@ -3346,7 +3346,7 @@
         "0xa3"
       ],
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
+        "mov w20, w4",
         "mov w21, #0x6f6d",
         "movk w21, #0x7376, lsl #16",
         "str w20, [x21]"
@@ -4007,7 +4007,7 @@
       "Optimal": "No",
       "Comment": "0xa9",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
+        "mov w20, w4",
         "and w20, w20, #0x1",
         "strb w20, [x28, #706]",
         "tst w20, w20",
@@ -4062,7 +4062,7 @@
       "Optimal": "No",
       "Comment": "0xab",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
+        "mov w20, w4",
         "str w20, [x11]",
         "mov w20, #0x4",
         "mov x21, #0xfffffffffffffffc",
@@ -4139,7 +4139,7 @@
       "Optimal": "No",
       "Comment": "0xab",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
+        "mov w20, w4",
         "ldrb w21, [x28, #714]",
         "mov x0, x5",
         "mov x1, x11",
@@ -4386,7 +4386,7 @@
       "Optimal": "No",
       "Comment": "0xaf",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
+        "mov w20, w4",
         "ldr w21, [x11]",
         "sub w22, w20, w21",
         "mov w23, #0x4",
@@ -4513,7 +4513,7 @@
         "cmp x22, #0x0 (0)",
         "csel x20, x20, x21, eq",
         "cbz x5, #+0x3c",
-        "lsr w21, w4, #0",
+        "mov w21, w4",
         "ldr w22, [x11]",
         "sub w23, w21, w22",
         "eor w24, w21, w22",
@@ -4642,7 +4642,7 @@
         "cmp x22, #0x0 (0)",
         "csel x20, x20, x21, eq",
         "cbz x5, #+0x3c",
-        "lsr w21, w4, #0",
+        "mov w21, w4",
         "ldr w22, [x11]",
         "sub w23, w21, w22",
         "eor w24, w21, w22",

--- a/unittests/InstructionCountCI/PrimaryGroup.json
+++ b/unittests/InstructionCountCI/PrimaryGroup.json
@@ -251,7 +251,7 @@
       "Optimal": "No",
       "Comment": "GROUP1 0x81 /0",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
+        "mov w20, w4",
         "add w4, w20, #0x100 (256)",
         "eor w21, w20, #0x100",
         "strb w21, [x28, #708]",
@@ -281,7 +281,7 @@
       "Optimal": "No",
       "Comment": "GROUP1 0x81 /1",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
+        "mov w20, w4",
         "orr w4, w20, #0x100",
         "strb w4, [x28, #706]",
         "tst w4, w4",
@@ -310,7 +310,7 @@
         "ldr w21, [x28, #728]",
         "ubfx w21, w21, #29, #1",
         "add w20, w20, w21",
-        "lsr w22, w4, #0",
+        "mov w22, w4",
         "add w4, w22, w20",
         "eor w20, w22, #0x100",
         "strb w20, [x28, #708]",
@@ -372,7 +372,7 @@
         "ldr w21, [x28, #728]",
         "ubfx w21, w21, #29, #1",
         "add w20, w20, w21",
-        "lsr w22, w4, #0",
+        "mov w22, w4",
         "sub w4, w22, w20",
         "eor w20, w22, #0x100",
         "strb w20, [x28, #708]",
@@ -430,7 +430,7 @@
       "Optimal": "No",
       "Comment": "GROUP1 0x81 /4",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
+        "mov w20, w4",
         "and w4, w20, #0x100",
         "strb w4, [x28, #706]",
         "tst w4, w4",
@@ -455,7 +455,7 @@
       "Optimal": "No",
       "Comment": "GROUP1 0x81 /5",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
+        "mov w20, w4",
         "sub w4, w20, #0x100 (256)",
         "eor w21, w20, #0x100",
         "strb w21, [x28, #708]",
@@ -487,7 +487,7 @@
       "Optimal": "No",
       "Comment": "GROUP1 0x81 /6",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
+        "mov w20, w4",
         "eor w4, w20, #0x100",
         "strb w4, [x28, #706]",
         "tst w4, w4",
@@ -512,7 +512,7 @@
       "Optimal": "No",
       "Comment": "GROUP1 0x81 /7",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
+        "mov w20, w4",
         "sub w21, w20, #0x100 (256)",
         "eor w22, w20, #0x100",
         "strb w22, [x28, #708]",
@@ -571,7 +571,7 @@
       "Optimal": "No",
       "Comment": "GROUP1 0x83 /0",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
+        "mov w20, w4",
         "add w4, w20, #0x1 (1)",
         "eor w21, w20, #0x1",
         "strb w21, [x28, #708]",
@@ -601,7 +601,7 @@
       "Optimal": "No",
       "Comment": "GROUP1 0x83 /1",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
+        "mov w20, w4",
         "orr w4, w20, #0x1",
         "strb w4, [x28, #706]",
         "tst w4, w4",
@@ -630,7 +630,7 @@
         "ldr w21, [x28, #728]",
         "ubfx w21, w21, #29, #1",
         "add w20, w20, w21",
-        "lsr w22, w4, #0",
+        "mov w22, w4",
         "add w4, w22, w20",
         "eor w20, w22, #0x1",
         "strb w20, [x28, #708]",
@@ -692,7 +692,7 @@
         "ldr w21, [x28, #728]",
         "ubfx w21, w21, #29, #1",
         "add w20, w20, w21",
-        "lsr w22, w4, #0",
+        "mov w22, w4",
         "sub w4, w22, w20",
         "eor w20, w22, #0x1",
         "strb w20, [x28, #708]",
@@ -750,7 +750,7 @@
       "Optimal": "No",
       "Comment": "GROUP1 0x83 /4",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
+        "mov w20, w4",
         "and w4, w20, #0x1",
         "strb w4, [x28, #706]",
         "tst w4, w4",
@@ -775,7 +775,7 @@
       "Optimal": "No",
       "Comment": "GROUP1 0x83 /5",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
+        "mov w20, w4",
         "sub w4, w20, #0x1 (1)",
         "eor w21, w20, #0x1",
         "strb w21, [x28, #708]",
@@ -807,7 +807,7 @@
       "Optimal": "No",
       "Comment": "GROUP1 0x83 /6",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
+        "mov w20, w4",
         "eor w4, w20, #0x1",
         "strb w4, [x28, #706]",
         "tst w4, w4",
@@ -832,7 +832,7 @@
       "Optimal": "No",
       "Comment": "GROUP1 0x83 /7",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
+        "mov w20, w4",
         "sub w21, w20, #0x1 (1)",
         "eor w22, w20, #0x1",
         "strb w22, [x28, #708]",
@@ -1041,7 +1041,7 @@
       "Optimal": "No",
       "Comment": "GROUP2 0xC1 /0",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
+        "mov w20, w4",
         "ror w4, w20, #30",
         "ubfx w20, w4, #0, #1",
         "ldr w21, [x28, #728]",
@@ -1084,7 +1084,7 @@
       "Optimal": "No",
       "Comment": "GROUP2 0xC1 /1",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
+        "mov w20, w4",
         "ror w4, w20, #2",
         "lsr w20, w4, #31",
         "ldr w21, [x28, #728]",
@@ -1146,7 +1146,7 @@
       "Comment": "GROUP2 0xC1 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0x2",
-        "lsr w21, w4, #0",
+        "mov w21, w4",
         "ldr w22, [x28, #728]",
         "ubfx w23, w22, #29, #1",
         "lsl w24, w21, #2",
@@ -1238,7 +1238,7 @@
       "Comment": "GROUP2 0xC1 /3",
       "ExpectedArm64ASM": [
         "mov w20, #0x2",
-        "lsr w21, w4, #0",
+        "mov w21, w4",
         "ldr w22, [x28, #728]",
         "ubfx w23, w22, #29, #1",
         "lsr w24, w21, #2",
@@ -1323,7 +1323,7 @@
       "Optimal": "No",
       "Comment": "GROUP2 0xC1 /4",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
+        "mov w20, w4",
         "lsl w4, w20, #2",
         "tst w4, w4",
         "mrs x21, nzcv",
@@ -1375,7 +1375,7 @@
       "Optimal": "No",
       "Comment": "GROUP2 0xC1 /5",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
+        "mov w20, w4",
         "lsr w4, w20, #2",
         "ldr w21, [x28, #728]",
         "ubfx w21, w21, #28, #1",
@@ -1431,7 +1431,7 @@
       "Optimal": "No",
       "Comment": "GROUP2 0xC1 /7",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
+        "mov w20, w4",
         "asr w4, w20, #2",
         "tst w4, w4",
         "mrs x21, nzcv",
@@ -1626,7 +1626,7 @@
       "Optimal": "No",
       "Comment": "GROUP2 0xd1 /0",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
+        "mov w20, w4",
         "ror w4, w20, #31",
         "ubfx w20, w4, #0, #1",
         "ldr w21, [x28, #728]",
@@ -1678,7 +1678,7 @@
       "Optimal": "No",
       "Comment": "GROUP2 0xd1 /1",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
+        "mov w20, w4",
         "ror w4, w20, #1",
         "lsr w20, w4, #31",
         "ldr w21, [x28, #728]",
@@ -1732,7 +1732,7 @@
       "Optimal": "No",
       "Comment": "GROUP2 0xd1 /2",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
+        "mov w20, w4",
         "ldr w21, [x28, #728]",
         "ubfx w22, w21, #29, #1",
         "lsr w23, w20, #31",
@@ -1792,7 +1792,7 @@
       "Optimal": "No",
       "Comment": "GROUP2 0xd1 /3",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
+        "mov w20, w4",
         "ldr w21, [x28, #728]",
         "ubfx w22, w21, #29, #1",
         "extr w4, w22, w20, #1",
@@ -1855,7 +1855,7 @@
       "Optimal": "No",
       "Comment": "GROUP2 0xd1 /4",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
+        "mov w20, w4",
         "lsl w4, w20, #1",
         "tst w4, w4",
         "mrs x21, nzcv",
@@ -1912,7 +1912,7 @@
       "Optimal": "No",
       "Comment": "GROUP2 0xd1 /5",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
+        "mov w20, w4",
         "lsr w4, w20, #1",
         "tst w4, w4",
         "mrs x21, nzcv",
@@ -1966,7 +1966,7 @@
       "Optimal": "No",
       "Comment": "GROUP2 0xd1 /7",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
+        "mov w20, w4",
         "asr w4, w20, #1",
         "tst w4, w4",
         "mrs x21, nzcv",
@@ -2241,8 +2241,8 @@
       "Optimal": "No",
       "Comment": "GROUP2 0xd3 /0",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
-        "lsr w21, w5, #0",
+        "mov w20, w4",
+        "mov w21, w5",
         "and w21, w21, #0x1f",
         "mov w22, #0x20",
         "sub w22, w22, w21",
@@ -2308,8 +2308,8 @@
       "Optimal": "No",
       "Comment": "GROUP2 0xd3 /1",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
-        "lsr w21, w5, #0",
+        "mov w20, w4",
+        "mov w21, w5",
         "and w21, w21, #0x1f",
         "ror w4, w20, w21",
         "ldr w20, [x28, #728]",
@@ -2390,8 +2390,8 @@
       "Optimal": "No",
       "Comment": "GROUP2 0xd3 /2",
       "ExpectedArm64ASM": [
-        "lsr w20, w5, #0",
-        "lsr w21, w4, #0",
+        "mov w20, w5",
+        "mov w21, w4",
         "ldr w22, [x28, #728]",
         "ubfx w23, w22, #29, #1",
         "lsl w24, w21, w20",
@@ -2499,8 +2499,8 @@
       "Optimal": "No",
       "Comment": "GROUP2 0xd3 /3",
       "ExpectedArm64ASM": [
-        "lsr w20, w5, #0",
-        "lsr w21, w4, #0",
+        "mov w20, w5",
+        "mov w21, w4",
         "ldr w22, [x28, #728]",
         "ubfx w23, w22, #29, #1",
         "lsr w24, w21, w20",
@@ -2615,8 +2615,8 @@
       "Optimal": "No",
       "Comment": "GROUP2 0xd3 /4",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
-        "lsr w21, w5, #0",
+        "mov w20, w4",
+        "mov w21, w5",
         "lsl w4, w20, w21",
         "ldr w22, [x28, #728]",
         "tst w4, w4",
@@ -2701,8 +2701,8 @@
       "Optimal": "No",
       "Comment": "GROUP2 0xd3 /5",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
-        "lsr w21, w5, #0",
+        "mov w20, w4",
+        "mov w21, w5",
         "lsr w4, w20, w21",
         "ldr w22, [x28, #728]",
         "tst w4, w4",
@@ -2783,8 +2783,8 @@
       "Optimal": "No",
       "Comment": "GROUP2 0xd3 /7",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
-        "lsr w21, w5, #0",
+        "mov w20, w4",
+        "mov w21, w5",
         "asr w4, w20, w21",
         "ldr w22, [x28, #728]",
         "tst w4, w4",
@@ -2972,7 +2972,7 @@
       "Optimal": "No",
       "Comment": "GROUP2 0xf7 /0",
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
+        "mov w20, w7",
         "and w20, w20, #0x1",
         "strb w20, [x28, #706]",
         "tst w20, w20",
@@ -3007,9 +3007,9 @@
       "Optimal": "No",
       "Comment": "GROUP2 0xf7 /1",
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
+        "mov w20, w7",
         "eor x20, x20, #0xffffffff",
-        "lsr w7, w20, #0"
+        "mov w7, w20"
       ]
     },
     "not rbx": {
@@ -3052,7 +3052,7 @@
       "Optimal": "No",
       "Comment": "GROUP2 0xf7 /2",
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
+        "mov w20, w7",
         "neg w7, w20",
         "strb w20, [x28, #708]",
         "strb w7, [x28, #706]",
@@ -3100,10 +3100,10 @@
       "Optimal": "No",
       "Comment": "GROUP2 0xf7 /3",
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
-        "ubfx x21, x4, #0, #32",
+        "mov w20, w7",
+        "mov w21, w4",
         "mul x20, x20, x21",
-        "ubfx x4, x20, #0, #32",
+        "mov w4, w20",
         "lsr x6, x20, #32",
         "mov w20, #0x0",
         "mov w21, #0x30000000",
@@ -3152,11 +3152,11 @@
       "Optimal": "No",
       "Comment": "GROUP2 0xf7 /5",
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
+        "mov w20, w7",
         "sxtw x20, w20",
         "sxtw x21, w4",
         "mul x20, x20, x21",
-        "ubfx x4, x20, #0, #32",
+        "mov w4, w20",
         "lsr x6, x20, #32",
         "asr x21, x20, #32",
         "sxtw x20, w20",
@@ -3208,18 +3208,18 @@
       "Optimal": "No",
       "Comment": "GROUP2 0xf7 /6",
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
-        "lsr w21, w4, #0",
-        "lsr w22, w6, #0",
+        "mov w20, w7",
+        "mov w21, w4",
+        "mov w22, w6",
         "mov x0, x21",
         "bfi x0, x22, #32, #32",
         "udiv x23, x0, x20",
-        "lsr w4, w23, #0",
+        "mov w4, w23",
         "mov x0, x21",
         "bfi x0, x22, #32, #32",
         "udiv x1, x0, x20",
         "msub x20, x1, x20, x0",
-        "lsr w6, w20, #0"
+        "mov w6, w20"
       ]
     },
     "div rbx": {
@@ -3279,20 +3279,20 @@
       "Optimal": "No",
       "Comment": "GROUP2 0xf7 /7",
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
-        "lsr w21, w4, #0",
-        "lsr w22, w6, #0",
+        "mov w20, w7",
+        "mov w21, w4",
+        "mov w22, w6",
         "mov x0, x21",
         "bfi x0, x22, #32, #32",
         "sxtw x1, w20",
         "sdiv x23, x0, x1",
-        "lsr w4, w23, #0",
+        "mov w4, w23",
         "mov x0, x21",
         "bfi x0, x22, #32, #32",
         "sxtw x2, w20",
         "sdiv x1, x0, x2",
         "msub x20, x1, x2, x0",
-        "lsr w6, w20, #0"
+        "mov w6, w20"
       ]
     },
     "idiv rbx": {
@@ -3419,7 +3419,7 @@
       "Optimal": "No",
       "Comment": "GROUP4 0xfe /0",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
+        "mov w20, w4",
         "add w4, w20, #0x1 (1)",
         "eor w21, w20, #0x1",
         "strb w21, [x28, #708]",
@@ -3483,7 +3483,7 @@
       "Optimal": "No",
       "Comment": "GROUP4 0xfe /1",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
+        "mov w20, w4",
         "sub w4, w20, #0x1 (1)",
         "eor w21, w20, #0x1",
         "strb w21, [x28, #708]",

--- a/unittests/InstructionCountCI/Secondary.json
+++ b/unittests/InstructionCountCI/Secondary.json
@@ -260,7 +260,7 @@
       "Comment": "0x0f 0x31",
       "ExpectedArm64ASM": [
         "mrs x20, S3_3_c14_c0_2",
-        "ubfx x4, x20, #0, #32",
+        "mov w4, w20",
         "lsr x6, x20, #32"
       ]
     },
@@ -1737,7 +1737,7 @@
       "Optimal": "No",
       "Comment": "0x0f 0xa3",
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
+        "mov w20, w7",
         "and x20, x20, #0x1f",
         "lsr x20, x4, x20",
         "ubfx x20, x20, #0, #1",
@@ -1750,7 +1750,7 @@
       "Optimal": "No",
       "Comment": "0x0f 0xa3",
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
+        "mov w20, w7",
         "ubfx w21, w20, #0, #3",
         "sbfx x20, x20, #3, #29",
         "ldrb w20, [x4, x20, sxtx]",
@@ -1887,7 +1887,7 @@
       "Optimal": "Yes",
       "Comment": "0x0f 0xac",
       "ExpectedArm64ASM": [
-        "lsr w4, w4, #0"
+        "mov w4, w4"
       ]
     },
     "shld eax, ebx, 1": {
@@ -1895,8 +1895,8 @@
       "Optimal": "No",
       "Comment": "0x0f 0xac",
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
-        "lsr w21, w4, #0",
+        "mov w20, w7",
+        "mov w21, w4",
         "extr w4, w21, w20, #31",
         "tst w4, w4",
         "mrs x20, nzcv",
@@ -1914,8 +1914,8 @@
       "Optimal": "No",
       "Comment": "0x0f 0xac",
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
-        "lsr w21, w4, #0",
+        "mov w20, w7",
+        "mov w21, w4",
         "extr w4, w21, w20, #17",
         "tst w4, w4",
         "mrs x20, nzcv",
@@ -1930,8 +1930,8 @@
       "Optimal": "No",
       "Comment": "0x0f 0xac",
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
-        "lsr w21, w4, #0",
+        "mov w20, w7",
+        "mov w21, w4",
         "extr w4, w21, w20, #16",
         "tst w4, w4",
         "mrs x20, nzcv",
@@ -1946,8 +1946,8 @@
       "Optimal": "No",
       "Comment": "0x0f 0xac",
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
-        "lsr w21, w4, #0",
+        "mov w20, w7",
+        "mov w21, w4",
         "extr w4, w21, w20, #1",
         "tst w4, w4",
         "mrs x20, nzcv",
@@ -2073,8 +2073,8 @@
       "Optimal": "No",
       "Comment": "0x0f 0xad",
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
-        "lsr w21, w4, #0",
+        "mov w20, w7",
+        "mov w21, w4",
         "uxtb w22, w5",
         "and x22, x22, #0x1f",
         "mov w23, #0x20",
@@ -2084,9 +2084,9 @@
         "orr x20, x24, x20",
         "cmp x22, #0x0 (0)",
         "csel x20, x21, x20, eq",
-        "lsr w4, w20, #0",
+        "mov w4, w20",
         "cbz x22, #+0x50",
-        "ubfx x20, x20, #0, #32",
+        "mov w20, w20",
         "ldr w23, [x28, #728]",
         "tst w20, w20",
         "mrs x24, nzcv",
@@ -2208,13 +2208,13 @@
       "Optimal": "No",
       "Comment": "0x0f 0xab",
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
+        "mov w20, w7",
         "and x20, x20, #0x1f",
         "lsr x21, x4, x20",
         "mov w22, #0x1",
         "lsl x20, x22, x20",
         "orr x20, x4, x20",
-        "lsr w4, w20, #0",
+        "mov w4, w20",
         "ubfx x20, x21, #0, #1",
         "lsl x20, x20, #29",
         "str w20, [x28, #728]"
@@ -2225,7 +2225,7 @@
       "Optimal": "No",
       "Comment": "0x0f 0xab",
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
+        "mov w20, w7",
         "ubfx w21, w20, #0, #3",
         "sbfx x20, x20, #3, #29",
         "mov w22, #0x1",
@@ -2297,13 +2297,13 @@
       "Optimal": "No",
       "Comment": "0x0f 0xaf",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
-        "lsr w21, w7, #0",
+        "mov w20, w4",
+        "mov w21, w7",
         "sxtw x20, w20",
         "sxtw x21, w21",
         "mul x20, x20, x21",
         "asr x21, x20, #32",
-        "lsr w4, w20, #0",
+        "mov w4, w20",
         "mov w22, #0x0",
         "sbfx x20, x20, #31, #1",
         "mov w23, #0x30000000",
@@ -2467,10 +2467,10 @@
       "Optimal": "No",
       "Comment": "0x0f 0xb1",
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
+        "mov w20, w7",
         "mov x21, x4",
-        "ubfx x22, x21, #0, #32",
-        "ubfx x23, x21, #0, #32",
+        "mov w22, w21",
+        "mov w23, w21",
         "cmp x22, x23",
         "csel x24, x23, x22, eq",
         "cmp x22, x23",
@@ -2493,8 +2493,8 @@
       "Optimal": "No",
       "Comment": "0x0f 0xb1",
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
-        "lsr w21, w4, #0",
+        "mov w20, w7",
+        "mov w21, w4",
         "mov w1, w21",
         "casal w1, w20, [x4]",
         "mov w20, w1",
@@ -2592,13 +2592,13 @@
       "Optimal": "No",
       "Comment": "0x0f 0xb3",
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
+        "mov w20, w7",
         "and x20, x20, #0x1f",
         "lsr x21, x4, x20",
         "mov w22, #0x1",
         "lsl x20, x22, x20",
         "bic x20, x4, x20",
-        "lsr w4, w20, #0",
+        "mov w4, w20",
         "ubfx x20, x21, #0, #1",
         "lsl x20, x20, #29",
         "str w20, [x28, #728]"
@@ -2609,7 +2609,7 @@
       "Optimal": "No",
       "Comment": "0x0f 0xb3",
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
+        "mov w20, w7",
         "ubfx w21, w20, #0, #3",
         "sbfx x20, x20, #3, #29",
         "mov w22, #0x1",
@@ -2779,13 +2779,13 @@
       "Optimal": "No",
       "Comment": "0x0f 0xbb",
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
+        "mov w20, w7",
         "and x20, x20, #0x1f",
         "lsr x21, x4, x20",
         "mov w22, #0x1",
         "lsl x20, x22, x20",
         "eor x20, x4, x20",
-        "lsr w4, w20, #0",
+        "mov w4, w20",
         "ubfx x20, x21, #0, #1",
         "lsl x20, x20, #29",
         "str w20, [x28, #728]"
@@ -2796,7 +2796,7 @@
       "Optimal": "No",
       "Comment": "0x0f 0xbb",
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
+        "mov w20, w7",
         "ubfx w21, w20, #0, #3",
         "sbfx x20, x20, #3, #29",
         "mov w22, #0x1",
@@ -2869,7 +2869,7 @@
       "Optimal": "No",
       "Comment": "0x0f 0xbc",
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
+        "mov w20, w7",
         "lsr w0, w20, #0",
         "cmp w0, #0x0 (0)",
         "rbit w0, w0",
@@ -2926,7 +2926,7 @@
       "Optimal": "No",
       "Comment": "0x0f 0xbd",
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
+        "mov w20, w7",
         "mov x0, #0x1f",
         "clz w21, w20",
         "sub x21, x0, x21",
@@ -2981,7 +2981,7 @@
       "ExpectedArm64ASM": [
         "uxtb w20, w7",
         "sxtb x20, w20",
-        "lsr w4, w20, #0"
+        "mov w4, w20"
       ]
     },
     "movsx eax, byte [rax]": {
@@ -2991,7 +2991,7 @@
       "ExpectedArm64ASM": [
         "ldrb w20, [x4]",
         "sxtb x20, w20",
-        "lsr w4, w20, #0"
+        "mov w4, w20"
       ]
     },
     "movsx rax, bl": {
@@ -3019,7 +3019,7 @@
       "ExpectedArm64ASM": [
         "uxth w20, w7",
         "sxth x20, w20",
-        "lsr w4, w20, #0"
+        "mov w4, w20"
       ]
     },
     "movsx eax, word [rax]": {
@@ -3029,7 +3029,7 @@
       "ExpectedArm64ASM": [
         "ldrh w20, [x4]",
         "sxth x20, w20",
-        "lsr w4, w20, #0"
+        "mov w4, w20"
       ]
     },
     "movsx rax, bx": {
@@ -3173,8 +3173,8 @@
       "Optimal": "No",
       "Comment": "0x0f 0xc1",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
-        "lsr w21, w7, #0",
+        "mov w20, w4",
+        "mov w21, w7",
         "add w4, w20, w21",
         "mov x7, x20",
         "eor w22, w20, w21",
@@ -3190,7 +3190,7 @@
       "Optimal": "Yes",
       "Comment": "0x0f 0xc1",
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
+        "mov w20, w7",
         "ldaddal w20, w7, [x4]",
         "add w21, w7, w20",
         "eor w22, w7, w20",
@@ -3311,7 +3311,7 @@
       "Optimal": "No",
       "Comment": "0x0f 0xc3",
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
+        "mov w20, w7",
         "str w20, [x4]"
       ]
     },

--- a/unittests/InstructionCountCI/SecondaryGroup.json
+++ b/unittests/InstructionCountCI/SecondaryGroup.json
@@ -106,7 +106,7 @@
       "ExpectedArm64ASM": [
         "mov x20, x4",
         "orr x21, x20, #0x1",
-        "lsr w4, w21, #0",
+        "mov w4, w21",
         "ubfx x20, x20, #0, #1",
         "lsl x20, x20, #29",
         "str w20, [x28, #728]"
@@ -144,7 +144,7 @@
       "ExpectedArm64ASM": [
         "lsr x20, x4, #31",
         "orr x21, x4, #0x80000000",
-        "lsr w4, w21, #0",
+        "mov w4, w21",
         "ubfx x20, x20, #0, #1",
         "lsl x20, x20, #29",
         "str w20, [x28, #728]"
@@ -184,7 +184,7 @@
       "ExpectedArm64ASM": [
         "mov x20, x4",
         "and x21, x20, #0xfffffffffffffffe",
-        "lsr w4, w21, #0",
+        "mov w4, w21",
         "ubfx x20, x20, #0, #1",
         "lsl x20, x20, #29",
         "str w20, [x28, #728]"
@@ -222,7 +222,7 @@
       "ExpectedArm64ASM": [
         "lsr x20, x4, #31",
         "and x21, x4, #0xffffffff7fffffff",
-        "lsr w4, w21, #0",
+        "mov w4, w21",
         "ubfx x20, x20, #0, #1",
         "lsl x20, x20, #29",
         "str w20, [x28, #728]"
@@ -262,7 +262,7 @@
       "ExpectedArm64ASM": [
         "mov x20, x4",
         "eor x21, x20, #0x1",
-        "lsr w4, w21, #0",
+        "mov w4, w21",
         "ubfx x20, x20, #0, #1",
         "lsl x20, x20, #29",
         "str w20, [x28, #728]"
@@ -300,7 +300,7 @@
       "ExpectedArm64ASM": [
         "lsr x20, x4, #31",
         "eor x21, x4, #0x80000000",
-        "lsr w4, w21, #0",
+        "mov w4, w21",
         "ubfx x20, x20, #0, #1",
         "lsl x20, x20, #29",
         "str w20, [x28, #728]"
@@ -324,12 +324,12 @@
       "Comment": "GROUP9 0x0F 0xC7 /1",
       "ExpectedArm64ASM": [
         "add x20, x9, #0x0 (0)",
-        "lsr w21, w4, #0",
-        "lsr w22, w6, #0",
+        "mov w21, w4",
+        "mov w22, w6",
         "mov w23, w22",
         "mov w22, w21",
-        "lsr w21, w7, #0",
-        "lsr w24, w5, #0",
+        "mov w21, w7",
+        "mov w24, w5",
         "mov w25, w24",
         "mov w24, w21",
         "mov w2, w22",
@@ -405,7 +405,7 @@
         "cset x21, ne",
         "mov x22, x20",
         "mov x20, x21",
-        "lsr w4, w22, #0",
+        "mov w4, w22",
         "mov w21, #0x0",
         "mov w22, #0x1",
         "strb w22, [x28, #706]",
@@ -458,7 +458,7 @@
         "cset x21, ne",
         "mov x22, x20",
         "mov x20, x21",
-        "lsr w4, w22, #0",
+        "mov w4, w22",
         "mov w21, #0x0",
         "mov w22, #0x1",
         "strb w22, [x28, #706]",
@@ -1154,7 +1154,7 @@
       "Optimal": "Yes",
       "Comment": "GROUP15 0x0F 0xAE /2",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
+        "mov w20, w4",
         "str x20, [x28, #176]"
       ]
     },
@@ -1195,7 +1195,7 @@
       "Optimal": "Yes",
       "Comment": "GROUP15 0x0F 0xAE /3",
       "ExpectedArm64ASM": [
-        "lsr w20, w4, #0",
+        "mov w20, w4",
         "str x20, [x28, #168]"
       ]
     },

--- a/unittests/InstructionCountCI/SecondaryModRM.json
+++ b/unittests/InstructionCountCI/SecondaryModRM.json
@@ -70,7 +70,7 @@
       "ExpectedArm64ASM": [
         "dmb ld",
         "mrs x20, S3_3_c14_c0_2",
-        "ubfx x4, x20, #0, #32",
+        "mov w4, w20",
         "lsr x6, x20, #32",
         "str x8, [x28, #40]",
         "mov w0, #0x100",

--- a/unittests/InstructionCountCI/Secondary_REP.json
+++ b/unittests/InstructionCountCI/Secondary_REP.json
@@ -457,7 +457,7 @@
       "Optimal": "No",
       "Comment": "0xf3 0x0f 0xb8",
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
+        "mov w20, w7",
         "fmov s0, w20",
         "cnt v0.8b, v0.8b",
         "addv b0, v0.8b",
@@ -514,7 +514,7 @@
       "Optimal": "No",
       "Comment": "0xf3 0x0f 0xbc",
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
+        "mov w20, w7",
         "rbit w4, w20",
         "clz w4, w4",
         "cmp x4, #0x0 (0)",
@@ -563,7 +563,7 @@
       "Optimal": "No",
       "Comment": "0xf3 0x0f 0xbd",
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
+        "mov w20, w7",
         "clz w4, w20",
         "cmp x20, #0x0 (0)",
         "cset x21, eq",

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -634,7 +634,7 @@
         "lsr w21, w21, #31",
         "lsl w21, w21, #7",
         "orr x20, x20, x21",
-        "lsr w4, w20, #0"
+        "mov w4, w20"
       ]
     },
     "vmovmskpd rax, xmm0": {
@@ -679,7 +679,7 @@
         "lsr x21, x21, #63",
         "lsl x21, x21, #3",
         "orr x20, x20, x21",
-        "lsr w4, w20, #0"
+        "mov w4, w20"
       ]
     },
     "vsqrtps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/VEX_map2.json
+++ b/unittests/InstructionCountCI/VEX_map2.json
@@ -3717,8 +3717,8 @@
         "Map 2 0b00 0xf2 32-bit"
       ],
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
-        "lsr w21, w5, #0",
+        "mov w20, w7",
+        "mov w21, w5",
         "bic w4, w21, w20",
         "strb w4, [x28, #706]",
         "tst w4, w4",
@@ -3747,8 +3747,8 @@
         "Map 2 0b00 0xf5 32-bit"
       ],
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
-        "lsr w21, w5, #0",
+        "mov w20, w7",
+        "mov w21, w5",
         "and x21, x21, #0xff",
         "mov w22, #0xffff",
         "movk w22, #0xffff, lsl #16",
@@ -3800,8 +3800,8 @@
         "Map 2 0b10 0xf5 32-bit"
       ],
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
-        "lsr w21, w5, #0",
+        "mov w20, w7",
+        "mov w21, w5",
         "cbz w21, #+0x40",
         "mov w0, w21",
         "mov w3, wzr",
@@ -3856,8 +3856,8 @@
         "Map 2 0b11 0xf5 32-bit"
       ],
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
-        "lsr w21, w5, #0",
+        "mov w20, w7",
+        "mov w21, w5",
         "cbz w21, #+0x58",
         "mov w3, wzr",
         "stp x4, x5, [x28, #8]",
@@ -3922,8 +3922,8 @@
         "Map 2 0b11 0xf6 32-bit"
       ],
       "ExpectedArm64ASM": [
-        "lsr w20, w5, #0",
-        "lsr w21, w6, #0",
+        "mov w20, w5",
+        "mov w21, w6",
         "mul w7, w20, w21",
         "ubfx x0, x20, #0, #32",
         "ubfx x1, x21, #0, #32",
@@ -3949,8 +3949,8 @@
         "Map 2 0b00 0xf7 32-bit"
       ],
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
-        "lsr w21, w5, #0",
+        "mov w20, w7",
+        "mov w21, w5",
         "mov w22, #0x1f",
         "uxtb w23, w21",
         "lsr w20, w20, w23",
@@ -4003,8 +4003,8 @@
         "Map 2 0b01 0xf7 32-bit"
       ],
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
-        "lsr w21, w5, #0",
+        "mov w20, w7",
+        "mov w21, w5",
         "lsl w4, w20, w21"
       ]
     },
@@ -4025,8 +4025,8 @@
         "Map 2 0b10 0xf7 32-bit"
       ],
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
-        "lsr w21, w5, #0",
+        "mov w20, w7",
+        "mov w21, w5",
         "asr w4, w20, w21"
       ]
     },
@@ -4047,8 +4047,8 @@
         "Map 2 0b11 0xf7 32-bit"
       ],
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
-        "lsr w21, w5, #0",
+        "mov w20, w7",
+        "mov w21, w5",
         "lsr w4, w20, w21"
       ]
     },

--- a/unittests/InstructionCountCI/VEX_map3.json
+++ b/unittests/InstructionCountCI/VEX_map3.json
@@ -5415,14 +5415,23 @@
       ]
     },
     "rorx eax, ebx, 0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b11 0xf0 32-bit"
       ],
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
-        "ror w4, w20, #0"
+        "lsr w4, w7, #0"
+      ]
+    },
+    "rorx eax, eax, 0": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": [
+        "Map 3 0b11 0xf0 32-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "lsr w4, w4, #0"
       ]
     },
     "rorx eax, ebx, 31": {
@@ -5437,14 +5446,23 @@
       ]
     },
     "rorx eax, ebx, 32": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b11 0xf0 32-bit"
       ],
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
-        "ror w4, w20, #0"
+        "lsr w4, w7, #0"
+      ]
+    },
+    "rorx eax, eax, 32": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": [
+        "Map 3 0b11 0xf0 32-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "lsr w4, w4, #0"
       ]
     },
     "rorx rax, rbx, 0": {
@@ -5454,8 +5472,16 @@
         "Map 3 0b11 0xf0 64-bit"
       ],
       "ExpectedArm64ASM": [
-        "ror x4, x7, #0"
+        "mov x4, x7"
       ]
+    },
+    "rorx rax, rax, 0": {
+      "ExpectedInstructionCount": 0,
+      "Optimal": "Yes",
+      "Comment": [
+        "Map 3 0b11 0xf0 64-bit"
+      ],
+      "ExpectedArm64ASM": []
     },
     "rorx rax, rbx, 63": {
       "ExpectedInstructionCount": 1,
@@ -5469,13 +5495,21 @@
     },
     "rorx rax, rbx, 64": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
+      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b11 0xf0 64-bit"
       ],
       "ExpectedArm64ASM": [
-        "ror x4, x7, #0"
+        "mov x4, x7"
       ]
+    },
+    "rorx rax, rax, 64": {
+      "ExpectedInstructionCount": 0,
+      "Optimal": "Yes",
+      "Comment": [
+        "Map 3 0b11 0xf0 64-bit"
+      ],
+      "ExpectedArm64ASM": []
     }
   }
 }

--- a/unittests/InstructionCountCI/VEX_map3.json
+++ b/unittests/InstructionCountCI/VEX_map3.json
@@ -5421,7 +5421,7 @@
         "Map 3 0b11 0xf0 32-bit"
       ],
       "ExpectedArm64ASM": [
-        "lsr w4, w7, #0"
+        "mov w4, w7"
       ]
     },
     "rorx eax, eax, 0": {
@@ -5431,7 +5431,7 @@
         "Map 3 0b11 0xf0 32-bit"
       ],
       "ExpectedArm64ASM": [
-        "lsr w4, w4, #0"
+        "mov w4, w4"
       ]
     },
     "rorx eax, ebx, 31": {
@@ -5441,7 +5441,7 @@
         "Map 3 0b11 0xf0 32-bit"
       ],
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
+        "mov w20, w7",
         "ror w4, w20, #31"
       ]
     },
@@ -5452,7 +5452,7 @@
         "Map 3 0b11 0xf0 32-bit"
       ],
       "ExpectedArm64ASM": [
-        "lsr w4, w7, #0"
+        "mov w4, w7"
       ]
     },
     "rorx eax, eax, 32": {
@@ -5462,7 +5462,7 @@
         "Map 3 0b11 0xf0 32-bit"
       ],
       "ExpectedArm64ASM": [
-        "lsr w4, w4, #0"
+        "mov w4, w4"
       ]
     },
     "rorx rax, rbx, 0": {

--- a/unittests/InstructionCountCI/VEX_map_group.json
+++ b/unittests/InstructionCountCI/VEX_map_group.json
@@ -809,10 +809,10 @@
       ],
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
-        "lsr w21, w7, #0",
+        "mov w21, w7",
         "sub x22, x21, #0x1 (1)",
         "and x22, x22, x21",
-        "lsr w4, w22, #0",
+        "mov w4, w22",
         "mov w23, #0x0",
         "tst w22, w22",
         "mrs x22, nzcv",
@@ -849,10 +849,10 @@
       ],
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
-        "lsr w21, w7, #0",
+        "mov w21, w7",
         "sub x22, x21, #0x1 (1)",
         "eor x22, x22, x21",
-        "lsr w4, w22, #0",
+        "mov w4, w22",
         "mov w22, #0x0",
         "mov w23, #0x50000000",
         "ldr w24, [x28, #728]",
@@ -894,7 +894,7 @@
         "Map group 17 0b011 32-bit"
       ],
       "ExpectedArm64ASM": [
-        "lsr w20, w7, #0",
+        "mov w20, w7",
         "neg w21, w20",
         "and w4, w20, w21",
         "mov w20, #0x0",


### PR DESCRIPTION
There are a few cases where we were emitting code when we didn't really need to, or could emit less.