### PR TITLE
HostFeatures: Fix x86 CLWB support check

### DIFF
--- a/FEXCore/Source/Interface/Core/HostFeatures.cpp
+++ b/FEXCore/Source/Interface/Core/HostFeatures.cpp
@@ -279,7 +279,7 @@ HostFeatures::HostFeatures() {
   SupportsSHA = Features.has(Xbyak::util::Cpu::tSHA);
   SupportsBMI1 = Features.has(Xbyak::util::Cpu::tBMI1);
   SupportsBMI2 = Features.has(Xbyak::util::Cpu::tBMI2);
-  SupportsBMI2 = Features.has(Xbyak::util::Cpu::tCLWB);
+  SupportsCLWB = Features.has(Xbyak::util::Cpu::tCLWB);
   SupportsPMULL_128Bit = Features.has(Xbyak::util::Cpu::tPCLMULQDQ);
 
   // xbyak doesn't know how to check for CLZero


### PR DESCRIPTION
This was clobbering the BMI2 boolean unintentionally.