### PR TITLE
OpcodeDispatcher: Improve output of SHLX/SHRX/SARX

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -2627,12 +2627,16 @@ void OpDispatchBuilder::BLSRBMIOp(OpcodeArgs) {
   GenerateFlags_BLSR(Op, Result, Src);
 }
 
+// Handles SARX, SHLX, and SHRX
 void OpDispatchBuilder::BMI2Shift(OpcodeArgs) {
-  // Handles SARX, SHLX, and SHRX
-
-  auto* Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
-  auto* Shift = LoadSource(GPRClass, Op, Op->Src[1], Op->Flags, -1);
+  // In the event the source is a memory operand, use the
+  // exact width instead of the GPR size.
+  const auto GPRSize = CTX->GetGPRSize();
   const auto Size = GetSrcSize(Op);
+  const auto SrcSize = Op->Src[0].IsGPR() ? GPRSize : Size;
+
+  auto* Src = LoadSource_WithOpSize(GPRClass, Op, Op->Src[0], SrcSize, Op->Flags, -1);
+  auto* Shift = LoadSource_WithOpSize(GPRClass, Op, Op->Src[1], GPRSize, Op->Flags, -1);
 
   auto* Result = [&]() -> OrderedNode* {
     // SARX

--- a/unittests/InstructionCountCI/VEX_map2.json
+++ b/unittests/InstructionCountCI/VEX_map2.json
@@ -3985,6 +3985,16 @@
       ]
     },
     "shlx eax, ebx, ecx": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": [
+        "Map 2 0b01 0xf7 32-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "lsl w4, w7, w5"
+      ]
+    },
+    "shlx eax, [ebx], ecx": {
       "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
@@ -3992,8 +4002,8 @@
       ],
       "ExpectedArm64ASM": [
         "mov w20, w7",
-        "mov w21, w5",
-        "lsl w4, w20, w21"
+        "ldr w20, [x20]",
+        "lsl w4, w20, w5"
       ]
     },
     "shlx rax, rbx, rcx": {
@@ -4006,7 +4016,28 @@
         "lsl x4, x7, x5"
       ]
     },
+    "shlx rax, [rbx], rcx": {
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
+      "Comment": [
+        "Map 2 0b01 0xf7 64-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr x20, [x7]",
+        "lsl x4, x20, x5"
+      ]
+    },
     "sarx eax, ebx, ecx": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": [
+        "Map 2 0b10 0xf7 32-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "asr w4, w7, w5"
+      ]
+    },
+    "sarx eax, [ebx], ecx": {
       "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
@@ -4014,8 +4045,8 @@
       ],
       "ExpectedArm64ASM": [
         "mov w20, w7",
-        "mov w21, w5",
-        "asr w4, w20, w21"
+        "ldr w20, [x20]",
+        "asr w4, w20, w5"
       ]
     },
     "sarx rax, rbx, rcx": {
@@ -4028,7 +4059,28 @@
         "asr x4, x7, x5"
       ]
     },
+    "sarx rax, [rbx], rcx": {
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
+      "Comment": [
+        "Map 2 0b10 0xf7 64-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr x20, [x7]",
+        "asr x4, x20, x5"
+      ]
+    },
     "shrx eax, ebx, ecx": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": [
+        "Map 2 0b11 0xf7 32-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "lsr w4, w7, w5"
+      ]
+    },
+    "shrx eax, [ebx], ecx": {
       "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
@@ -4036,8 +4088,8 @@
       ],
       "ExpectedArm64ASM": [
         "mov w20, w7",
-        "mov w21, w5",
-        "lsr w4, w20, w21"
+        "ldr w20, [x20]",
+        "lsr w4, w20, w5"
       ]
     },
     "shrx rax, rbx, rcx": {
@@ -4048,6 +4100,17 @@
       ],
       "ExpectedArm64ASM": [
         "lsr x4, x7, x5"
+      ]
+    },
+    "shrx rax, [rbx], rcx": {
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
+      "Comment": [
+        "Map 2 0b11 0xf7 64-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr x20, [x7]",
+        "lsr x4, x20, x5"
       ]
     }
   }


### PR DESCRIPTION
We can remove some unnecessary moves for the 32-bit cases and collapse the operations down to a single instruction.