### PR TITLE
FEXCore/JitSymbols: Buffer writes to reduce overhead

### DIFF
--- a/FEXCore/Source/Common/JitSymbols.h
+++ b/FEXCore/Source/Common/JitSymbols.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <FEXCore/fextl/memory.h>
+#include <FEXCore/Debug/InternalThreadState.h>
+
+#include <chrono>
 #include <cstdint>
 #include <cstdio>
 #include <memory>
@@ -12,13 +16,20 @@ public:
   ~JITSymbols();
 
   void InitFile();
-  void Register(const void *HostAddr, uint64_t GuestAddr, uint32_t CodeSize);
-  void Register(const void *HostAddr, uint32_t CodeSize, std::string_view Name);
-  void Register(const void *HostAddr, uint32_t CodeSize, std::string_view Name, uintptr_t Offset);
   void RegisterNamedRegion(const void *HostAddr, uint32_t CodeSize, std::string_view Name);
   void RegisterJITSpace(const void *HostAddr, uint32_t CodeSize);
 
+  // Allocate JIT buffer.
+  static fextl::unique_ptr<Core::JITSymbolBuffer> AllocateBuffer() {
+    return fextl::make_unique<Core::JITSymbolBuffer>();
+  }
+
+  void Register(Core::JITSymbolBuffer *Buffer, const void *HostAddr, uint64_t GuestAddr, uint32_t CodeSize);
+  void Register(Core::JITSymbolBuffer *Buffer, const void *HostAddr, uint32_t CodeSize, std::string_view Name, uintptr_t Offset);
+  void RegisterNamedRegion(Core::JITSymbolBuffer *Buffer, const void *HostAddr, uint32_t CodeSize, std::string_view Name);
+
 private:
   int fd{-1};
+  void WriteBuffer(Core::JITSymbolBuffer *Buffer, bool ForceWrite = false);
 };
 }

--- a/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
@@ -487,7 +487,7 @@ void Arm64Dispatcher::EmitDispatcher() {
 
   if (CTX->Config.BlockJITNaming()) {
     fextl::string Name = fextl::fmt::format("Dispatch_{}", FHU::Syscalls::gettid());
-    CTX->Symbols.Register(reinterpret_cast<void*>(DispatchPtr), End - reinterpret_cast<uint64_t>(DispatchPtr), Name);
+    CTX->Symbols.RegisterNamedRegion(reinterpret_cast<void*>(DispatchPtr), End - reinterpret_cast<uint64_t>(DispatchPtr), Name);
   }
   if (CTX->Config.GlobalJITNaming()) {
     CTX->Symbols.RegisterJITSpace(reinterpret_cast<void*>(DispatchPtr), End - reinterpret_cast<uint64_t>(DispatchPtr));

--- a/FEXCore/Source/Interface/Core/Dispatcher/X86Dispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/Dispatcher/X86Dispatcher.cpp
@@ -338,7 +338,7 @@ X86Dispatcher::X86Dispatcher(FEXCore::Context::ContextImpl *ctx, const Dispatche
 
   if (CTX->Config.BlockJITNaming()) {
     fextl::string Name = fextl::fmt::format("Dispatch_{}", FHU::Syscalls::gettid());
-    CTX->Symbols.Register(reinterpret_cast<void*>(Start), End-Start, Name);
+    CTX->Symbols.RegisterNamedRegion(reinterpret_cast<void*>(Start), End-Start, Name);
   }
   if (CTX->Config.GlobalJITNaming()) {
     CTX->Symbols.RegisterJITSpace(reinterpret_cast<void*>(Start), End-Start);

--- a/FEXCore/Source/Interface/IR/AOTIR.cpp
+++ b/FEXCore/Source/Interface/IR/AOTIR.cpp
@@ -310,7 +310,7 @@ namespace FEXCore::IR {
 
       if (AOTIRCacheEntry.Entry) {
         if (DebugData && CTX->Config.LibraryJITNaming()) {
-          CTX->Symbols.RegisterNamedRegion(CodePtr, DebugData->HostCodeSize, AOTIRCacheEntry.Entry->Filename);
+          CTX->Symbols.RegisterNamedRegion(Thread->SymbolBuffer.get(), CodePtr, DebugData->HostCodeSize, AOTIRCacheEntry.Entry->Filename);
         }
 
         if (CTX->Config.GDBSymbols()) {


### PR DESCRIPTION
While this interface is usually pretty fast because it is a write and forget operation, this has issues when there are multiple threads hitting the perf map file at the same time. In particular this interface becomes a bottleneck due to a locking mutex on writes in the kernel.

The situations when this bottleneck occurs is when a bunch of threads get spawned and they are all jitting code as quickly as possible. In particular Geekbench's clang benchmark hits this hard where each CPU thread spends ~40% CPU time on all eight CPU threads because they are stalled waiting for this mutex to unlock.

To work around this issue, buffer the writes a small amount. Either up to a page-ish of data or 100ms of time. This completely eliminates threads waiting on the kernel mutex.
- Around a page of buffer space was chosen by profiling Geekbench's clang benchmark and seeing how frequently it was still writing.
   - 1024 bytes was still fairly aggressive, 4096 seemed fine.
- 100ms was chosen to ensure we don't wait /too/ long to write JIT symbols.
   - In most cases 100ms is enough that you won't notice the blip in perf.

One thing of note is that with profiling enabled and checking the time on every JIT block still ends up with 2-3% CPUtime in vdso clock_gettime. We can improve this by using the cyclecounter directly since that is still guaranteed to be monotonic. Maybe we'll come back to that if it is actually an issue here.