### PR TITLE
Arm64/VectorOps: Improve handling of 128-bit vector VInsElement

### DIFF
--- a/unittests/InstructionCountCI/H0F3A.json
+++ b/unittests/InstructionCountCI/H0F3A.json
@@ -328,48 +328,42 @@
       ]
     },
     "blendps xmm0, xmm1, 0101b": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x3a 0x0c"
       ],
       "ExpectedArm64ASM": [
-        "mov v0.16b, v16.16b",
-        "mov v0.s[0], v17.s[0]",
-        "mov v2.16b, v0.16b",
-        "mov v0.16b, v2.16b",
-        "mov v0.s[2], v17.s[2]",
-        "mov v16.16b, v0.16b"
+        "mov v2.16b, v16.16b",
+        "mov v2.s[0], v17.s[0]",
+        "mov v16.16b, v2.16b",
+        "mov v16.s[2], v17.s[2]"
       ]
     },
     "blendps xmm0, xmm1, 0110b": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x3a 0x0c"
       ],
       "ExpectedArm64ASM": [
-        "mov v0.16b, v16.16b",
-        "mov v0.s[1], v17.s[1]",
-        "mov v2.16b, v0.16b",
-        "mov v0.16b, v2.16b",
-        "mov v0.s[2], v17.s[2]",
-        "mov v16.16b, v0.16b"
+        "mov v2.16b, v16.16b",
+        "mov v2.s[1], v17.s[1]",
+        "mov v16.16b, v2.16b",
+        "mov v16.s[2], v17.s[2]"
       ]
     },
     "blendps xmm0, xmm1, 0111b": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x3a 0x0c"
       ],
       "ExpectedArm64ASM": [
-        "mov v0.16b, v16.16b",
-        "mov v0.d[0], v17.d[0]",
-        "mov v2.16b, v0.16b",
-        "mov v0.16b, v2.16b",
-        "mov v0.s[2], v17.s[2]",
-        "mov v16.16b, v0.16b"
+        "mov v2.16b, v16.16b",
+        "mov v2.d[0], v17.d[0]",
+        "mov v16.16b, v2.16b",
+        "mov v16.s[2], v17.s[2]"
       ]
     },
     "blendps xmm0, xmm1, 1000b": {
@@ -383,48 +377,42 @@
       ]
     },
     "blendps xmm0, xmm1, 1001b": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x3a 0x0c"
       ],
       "ExpectedArm64ASM": [
-        "mov v0.16b, v16.16b",
-        "mov v0.s[0], v17.s[0]",
-        "mov v2.16b, v0.16b",
-        "mov v0.16b, v2.16b",
-        "mov v0.s[3], v17.s[3]",
-        "mov v16.16b, v0.16b"
+        "mov v2.16b, v16.16b",
+        "mov v2.s[0], v17.s[0]",
+        "mov v16.16b, v2.16b",
+        "mov v16.s[3], v17.s[3]"
       ]
     },
     "blendps xmm0, xmm1, 1010b": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x3a 0x0c"
       ],
       "ExpectedArm64ASM": [
-        "mov v0.16b, v16.16b",
-        "mov v0.s[1], v17.s[1]",
-        "mov v2.16b, v0.16b",
-        "mov v0.16b, v2.16b",
-        "mov v0.s[3], v17.s[3]",
-        "mov v16.16b, v0.16b"
+        "mov v2.16b, v16.16b",
+        "mov v2.s[1], v17.s[1]",
+        "mov v16.16b, v2.16b",
+        "mov v16.s[3], v17.s[3]"
       ]
     },
     "blendps xmm0, xmm1, 1011b": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x3a 0x0c"
       ],
       "ExpectedArm64ASM": [
-        "mov v0.16b, v16.16b",
-        "mov v0.d[0], v17.d[0]",
-        "mov v2.16b, v0.16b",
-        "mov v0.16b, v2.16b",
-        "mov v0.s[3], v17.s[3]",
-        "mov v16.16b, v0.16b"
+        "mov v2.16b, v16.16b",
+        "mov v2.d[0], v17.d[0]",
+        "mov v16.16b, v2.16b",
+        "mov v16.s[3], v17.s[3]"
       ]
     },
     "blendps xmm0, xmm1, 1100b": {
@@ -438,33 +426,29 @@
       ]
     },
     "blendps xmm0, xmm1, 1101b": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x3a 0x0c"
       ],
       "ExpectedArm64ASM": [
-        "mov v0.16b, v16.16b",
-        "mov v0.s[0], v17.s[0]",
-        "mov v2.16b, v0.16b",
-        "mov v0.16b, v2.16b",
-        "mov v0.d[1], v17.d[1]",
-        "mov v16.16b, v0.16b"
+        "mov v2.16b, v16.16b",
+        "mov v2.s[0], v17.s[0]",
+        "mov v16.16b, v2.16b",
+        "mov v16.d[1], v17.d[1]"
       ]
     },
     "blendps xmm0, xmm1, 1110b": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x3a 0x0c"
       ],
       "ExpectedArm64ASM": [
-        "mov v0.16b, v16.16b",
-        "mov v0.s[1], v17.s[1]",
-        "mov v2.16b, v0.16b",
-        "mov v0.16b, v2.16b",
-        "mov v0.d[1], v17.d[1]",
-        "mov v16.16b, v0.16b"
+        "mov v2.16b, v16.16b",
+        "mov v2.s[1], v17.s[1]",
+        "mov v16.16b, v2.16b",
+        "mov v16.d[1], v17.d[1]"
       ]
     },
     "blendps xmm0, xmm1, 1111b": {
@@ -537,24 +521,22 @@
       ]
     },
     "pblendw xmm0, xmm1, 11111111b": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 10,
       "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x3a 0x0e"
       ],
       "ExpectedArm64ASM": [
-        "mov v0.16b, v16.16b",
-        "mov v0.h[0], v17.h[0]",
-        "mov v2.16b, v0.16b",
+        "mov v2.16b, v16.16b",
+        "mov v2.h[0], v17.h[0]",
         "mov v2.h[1], v17.h[1]",
         "mov v2.h[2], v17.h[2]",
         "mov v2.h[3], v17.h[3]",
         "mov v2.h[4], v17.h[4]",
         "mov v2.h[5], v17.h[5]",
         "mov v2.h[6], v17.h[6]",
-        "mov v0.16b, v2.16b",
-        "mov v0.h[7], v17.h[7]",
-        "mov v16.16b, v0.16b"
+        "mov v16.16b, v2.16b",
+        "mov v16.h[7], v17.h[7]"
       ]
     },
     "palignr xmm0, xmm1, 0": {
@@ -968,7 +950,7 @@
       ]
     },
     "dpps xmm0, xmm1, 00001111b": {
-      "ExpectedInstructionCount": 14,
+      "ExpectedInstructionCount": 13,
       "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x3a 0x40"
@@ -985,9 +967,8 @@
         "mov v2.s[0], v3.s[0]",
         "mov v2.s[1], v3.s[0]",
         "mov v2.s[2], v3.s[0]",
-        "mov v0.16b, v2.16b",
-        "mov v0.s[3], v3.s[0]",
-        "mov v16.16b, v0.16b"
+        "mov v16.16b, v2.16b",
+        "mov v16.s[3], v3.s[0]"
       ]
     },
     "dpps xmm0, xmm1, 11110000b": {
@@ -1001,7 +982,7 @@
       ]
     },
     "dpps xmm0, xmm1, 11111111b": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 9,
       "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x3a 0x40"
@@ -1014,9 +995,8 @@
         "mov v2.s[0], v3.s[0]",
         "mov v2.s[1], v3.s[0]",
         "mov v2.s[2], v3.s[0]",
-        "mov v0.16b, v2.16b",
-        "mov v0.s[3], v3.s[0]",
-        "mov v16.16b, v0.16b"
+        "mov v16.16b, v2.16b",
+        "mov v16.s[3], v3.s[0]"
       ]
     },
     "dppd xmm0, xmm1, 00000000b": {
@@ -1030,7 +1010,7 @@
       ]
     },
     "dppd xmm0, xmm1, 00001111b": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x3a 0x41"
@@ -1042,9 +1022,8 @@
         "mov v3.d[1], v2.d[0]",
         "faddp v3.2d, v3.2d, v2.2d",
         "mov v2.d[0], v3.d[0]",
-        "mov v0.16b, v2.16b",
-        "mov v0.d[1], v3.d[0]",
-        "mov v16.16b, v0.16b"
+        "mov v16.16b, v2.16b",
+        "mov v16.d[1], v3.d[0]"
       ]
     },
     "dppd xmm0, xmm1, 11110000b": {
@@ -1058,7 +1037,7 @@
       ]
     },
     "dppd xmm0, xmm1, 11111111b": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x3a 0x41"
@@ -1068,9 +1047,8 @@
         "fmul v3.2d, v16.2d, v17.2d",
         "faddp v3.2d, v3.2d, v2.2d",
         "mov v2.d[0], v3.d[0]",
-        "mov v0.16b, v2.16b",
-        "mov v0.d[1], v3.d[0]",
-        "mov v16.16b, v0.16b"
+        "mov v16.16b, v2.16b",
+        "mov v16.d[1], v3.d[0]"
       ]
     },
     "mpsadbw xmm0, xmm1, 000b": {

--- a/unittests/InstructionCountCI/Secondary.json
+++ b/unittests/InstructionCountCI/Secondary.json
@@ -3904,7 +3904,7 @@
       ]
     },
     "shufps xmm0, xmm1, 01000111b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "odd elements inverted, Low 64-bits inserted",
@@ -3913,14 +3913,13 @@
         "0x0f 0xc6"
       ],
       "ExpectedArm64ASM": [
-        "mov v0.16b, v16.16b",
-        "mov v0.s[0], v16.s[3]",
-        "mov v2.16b, v0.16b",
+        "mov v2.16b, v16.16b",
+        "mov v2.s[0], v16.s[3]",
         "zip1 v16.2d, v2.2d, v17.2d"
       ]
     },
     "shufps xmm0, xmm1, 11100111b": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "odd elements inverted, Top 64-bits inserted",
@@ -3929,16 +3928,14 @@
         "0x0f 0xc6"
       ],
       "ExpectedArm64ASM": [
-        "mov v0.16b, v16.16b",
-        "mov v0.s[0], v16.s[3]",
-        "mov v2.16b, v0.16b",
-        "mov v0.16b, v2.16b",
-        "mov v0.d[1], v17.d[1]",
-        "mov v16.16b, v0.16b"
+        "mov v2.16b, v16.16b",
+        "mov v2.s[0], v16.s[3]",
+        "mov v16.16b, v2.16b",
+        "mov v16.d[1], v17.d[1]"
       ]
     },
     "shufps xmm0, xmm1, 11100001b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "Yes",
       "Comment": [
         "Lower 32-bit elements inverted, Top 64-bits inserted",
@@ -3946,9 +3943,8 @@
       ],
       "ExpectedArm64ASM": [
         "rev64 v2.4s, v16.4s",
-        "mov v0.16b, v2.16b",
-        "mov v0.d[1], v17.d[1]",
-        "mov v16.16b, v0.16b"
+        "mov v16.16b, v2.16b",
+        "mov v16.d[1], v17.d[1]"
       ]
     },
     "shufps xmm0, xmm1, 01000001b": {

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -1355,16 +1355,15 @@
       ]
     },
     "vpshufd xmm0, xmm1, 00b": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x70 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z2.d, p7/m, z17.d",
-        "mov v0.16b, v2.16b",
-        "mov v0.s[0], v2.s[0]",
-        "mov v3.16b, v0.16b",
+        "mov v3.16b, v2.16b",
+        "mov v3.s[0], v2.s[0]",
         "mov v3.s[1], v2.s[0]",
         "mov v3.s[2], v2.s[0]",
         "mov v0.16b, v3.16b",
@@ -1375,16 +1374,15 @@
       ]
     },
     "vpshufd xmm0, xmm1, 01b": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x70 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z2.d, p7/m, z17.d",
-        "mov v0.16b, v2.16b",
-        "mov v0.s[0], v2.s[1]",
-        "mov v3.16b, v0.16b",
+        "mov v3.16b, v2.16b",
+        "mov v3.s[0], v2.s[1]",
         "mov v3.s[1], v2.s[0]",
         "mov v3.s[2], v2.s[0]",
         "mov v0.16b, v3.16b",
@@ -1395,16 +1393,15 @@
       ]
     },
     "vpshufd xmm0, xmm1, 10b": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x70 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z2.d, p7/m, z17.d",
-        "mov v0.16b, v2.16b",
-        "mov v0.s[0], v2.s[2]",
-        "mov v3.16b, v0.16b",
+        "mov v3.16b, v2.16b",
+        "mov v3.s[0], v2.s[2]",
         "mov v3.s[1], v2.s[0]",
         "mov v3.s[2], v2.s[0]",
         "mov v0.16b, v3.16b",
@@ -1415,16 +1412,15 @@
       ]
     },
     "vpshufd xmm0, xmm1, 11b": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x70 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z2.d, p7/m, z17.d",
-        "mov v0.16b, v2.16b",
-        "mov v0.s[0], v2.s[3]",
-        "mov v3.16b, v0.16b",
+        "mov v3.16b, v2.16b",
+        "mov v3.s[0], v2.s[3]",
         "mov v3.s[1], v2.s[0]",
         "mov v3.s[2], v2.s[0]",
         "mov v0.16b, v3.16b",
@@ -1615,16 +1611,15 @@
       ]
     },
     "vpshufhw xmm0, xmm1, 00b": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0x70 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z2.d, p7/m, z17.d",
-        "mov v0.16b, v2.16b",
-        "mov v0.h[4], v2.h[4]",
-        "mov v3.16b, v0.16b",
+        "mov v3.16b, v2.16b",
+        "mov v3.h[4], v2.h[4]",
         "mov v3.h[5], v2.h[4]",
         "mov v3.h[6], v2.h[4]",
         "mov v0.16b, v3.16b",
@@ -1635,16 +1630,15 @@
       ]
     },
     "vpshufhw xmm0, xmm1, 01b": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0x70 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z2.d, p7/m, z17.d",
-        "mov v0.16b, v2.16b",
-        "mov v0.h[4], v2.h[5]",
-        "mov v3.16b, v0.16b",
+        "mov v3.16b, v2.16b",
+        "mov v3.h[4], v2.h[5]",
         "mov v3.h[5], v2.h[4]",
         "mov v3.h[6], v2.h[4]",
         "mov v0.16b, v3.16b",
@@ -1655,16 +1649,15 @@
       ]
     },
     "vpshufhw xmm0, xmm1, 10b": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0x70 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z2.d, p7/m, z17.d",
-        "mov v0.16b, v2.16b",
-        "mov v0.h[4], v2.h[6]",
-        "mov v3.16b, v0.16b",
+        "mov v3.16b, v2.16b",
+        "mov v3.h[4], v2.h[6]",
         "mov v3.h[5], v2.h[4]",
         "mov v3.h[6], v2.h[4]",
         "mov v0.16b, v3.16b",
@@ -1675,16 +1668,15 @@
       ]
     },
     "vpshufhw xmm0, xmm1, 11b": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0x70 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z2.d, p7/m, z17.d",
-        "mov v0.16b, v2.16b",
-        "mov v0.h[4], v2.h[7]",
-        "mov v3.16b, v0.16b",
+        "mov v3.16b, v2.16b",
+        "mov v3.h[4], v2.h[7]",
         "mov v3.h[5], v2.h[4]",
         "mov v3.h[6], v2.h[4]",
         "mov v0.16b, v3.16b",
@@ -1875,16 +1867,15 @@
       ]
     },
     "vpshuflw xmm0, xmm1, 00b": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x70 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z2.d, p7/m, z17.d",
-        "mov v0.16b, v2.16b",
-        "mov v0.h[0], v2.h[0]",
-        "mov v3.16b, v0.16b",
+        "mov v3.16b, v2.16b",
+        "mov v3.h[0], v2.h[0]",
         "mov v3.h[1], v2.h[0]",
         "mov v3.h[2], v2.h[0]",
         "mov v0.16b, v3.16b",
@@ -1895,16 +1886,15 @@
       ]
     },
     "vpshuflw xmm0, xmm1, 01b": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x70 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z2.d, p7/m, z17.d",
-        "mov v0.16b, v2.16b",
-        "mov v0.h[0], v2.h[1]",
-        "mov v3.16b, v0.16b",
+        "mov v3.16b, v2.16b",
+        "mov v3.h[0], v2.h[1]",
         "mov v3.h[1], v2.h[0]",
         "mov v3.h[2], v2.h[0]",
         "mov v0.16b, v3.16b",
@@ -1915,16 +1905,15 @@
       ]
     },
     "vpshuflw xmm0, xmm1, 10b": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x70 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z2.d, p7/m, z17.d",
-        "mov v0.16b, v2.16b",
-        "mov v0.h[0], v2.h[2]",
-        "mov v3.16b, v0.16b",
+        "mov v3.16b, v2.16b",
+        "mov v3.h[0], v2.h[2]",
         "mov v3.h[1], v2.h[0]",
         "mov v3.h[2], v2.h[0]",
         "mov v0.16b, v3.16b",
@@ -1935,16 +1924,15 @@
       ]
     },
     "vpshuflw xmm0, xmm1, 11b": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x70 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z2.d, p7/m, z17.d",
-        "mov v0.16b, v2.16b",
-        "mov v0.h[0], v2.h[3]",
-        "mov v3.16b, v0.16b",
+        "mov v3.16b, v2.16b",
+        "mov v3.h[0], v2.h[3]",
         "mov v3.h[1], v2.h[0]",
         "mov v3.h[2], v2.h[0]",
         "mov v0.16b, v3.16b",

--- a/unittests/InstructionCountCI/VEX_map3.json
+++ b/unittests/InstructionCountCI/VEX_map3.json
@@ -3624,7 +3624,7 @@
       ]
     },
     "vdpps xmm0, xmm1, xmm2, 00001111b": {
-      "ExpectedInstructionCount": 20,
+      "ExpectedInstructionCount": 19,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x40 128-bit"
@@ -3640,9 +3640,8 @@
         "mov v2.s[3], v4.s[0]",
         "faddp v2.4s, v2.4s, v4.4s",
         "faddp v2.4s, v2.4s, v4.4s",
-        "mov v0.16b, v4.16b",
-        "mov v0.s[0], v2.s[0]",
-        "mov v3.16b, v0.16b",
+        "mov v3.16b, v4.16b",
+        "mov v3.s[0], v2.s[0]",
         "mov v3.s[1], v2.s[0]",
         "mov v3.s[2], v2.s[0]",
         "mov v0.16b, v3.16b",
@@ -3665,7 +3664,7 @@
       ]
     },
     "vdpps xmm0, xmm1, xmm2, 11111111b": {
-      "ExpectedInstructionCount": 16,
+      "ExpectedInstructionCount": 15,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x40 128-bit"
@@ -3677,9 +3676,8 @@
         "fmul v2.4s, v2.4s, v3.4s",
         "faddp v2.4s, v2.4s, v4.4s",
         "faddp v2.4s, v2.4s, v4.4s",
-        "mov v0.16b, v4.16b",
-        "mov v0.s[0], v2.s[0]",
-        "mov v3.16b, v0.16b",
+        "mov v3.16b, v4.16b",
+        "mov v3.s[0], v2.s[0]",
         "mov v3.s[1], v2.s[0]",
         "mov v3.s[2], v2.s[0]",
         "mov v0.16b, v3.16b",
@@ -3872,7 +3870,7 @@
       ]
     },
     "vdppd xmm0, xmm1, xmm2, 00001111b": {
-      "ExpectedInstructionCount": 15,
+      "ExpectedInstructionCount": 14,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x41 128-bit"
@@ -3885,9 +3883,8 @@
         "mov v2.d[0], v4.d[0]",
         "mov v2.d[1], v4.d[0]",
         "faddp v2.2d, v2.2d, v4.2d",
-        "mov v0.16b, v4.16b",
-        "mov v0.d[0], v2.d[0]",
-        "mov v3.16b, v0.16b",
+        "mov v3.16b, v4.16b",
+        "mov v3.d[0], v2.d[0]",
         "mov v0.16b, v3.16b",
         "mov v0.d[1], v2.d[0]",
         "mov v2.16b, v0.16b",
@@ -3908,7 +3905,7 @@
       ]
     },
     "vdppd xmm0, xmm1, xmm2, 11111111b": {
-      "ExpectedInstructionCount": 13,
+      "ExpectedInstructionCount": 12,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x41 128-bit"
@@ -3919,9 +3916,8 @@
         "movi v4.2d, #0x0",
         "fmul v2.2d, v2.2d, v3.2d",
         "faddp v2.2d, v2.2d, v4.2d",
-        "mov v0.16b, v4.16b",
-        "mov v0.d[0], v2.d[0]",
-        "mov v3.16b, v0.16b",
+        "mov v3.16b, v4.16b",
+        "mov v3.d[0], v2.d[0]",
         "mov v0.16b, v3.16b",
         "mov v0.d[1], v2.d[0]",
         "mov v2.16b, v0.16b",


### PR DESCRIPTION
If none of the vectors alias the destination, then we can eliminate an extra move and usage of a temporary.