### PR TITLE
Arm64/VectorOps: Elide moves where applicable in 128-bit VSQXTUN2

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -3404,9 +3404,17 @@ DEF_OP(VSQXTUN2) {
       mov(Dst.Q(), VectorLower.Q());
       ins(ARMEmitter::SubRegSize::i32Bit, Dst, 1, VTMP2, 0);
     } else {
-      mov(VTMP1.Q(), VectorLower.Q());
-      sqxtun2(SubRegSize, VTMP1, VectorUpper);
-      mov(Dst.Q(), VTMP1.Q());
+      auto Lower = VectorLower;
+      if (Dst != VectorLower) {
+        mov(VTMP1.Q(), VectorLower.Q());
+        Lower = VTMP1;
+      }
+
+      sqxtun2(SubRegSize, Lower, VectorUpper);
+
+      if (Dst != VectorLower) {
+        mov(Dst.Q(), Lower.Q());
+      }
     }
   }
 }


### PR DESCRIPTION
If the destination and lower data alias, we can avoid needing to move into a temporary.