### PR TITLE
FEXCore: Adds SPDX identifier

### DIFF
--- a/FEXCore/Source/Common/BitSet.h
+++ b/FEXCore/Source/Common/BitSet.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <FEXCore/Utils/Allocator.h>

--- a/FEXCore/Source/Common/JitSymbols.cpp
+++ b/FEXCore/Source/Common/JitSymbols.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #include <FEXCore/fextl/fmt.h>
 
 #include "Common/JitSymbols.h"

--- a/FEXCore/Source/Common/JitSymbols.h
+++ b/FEXCore/Source/Common/JitSymbols.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <FEXCore/fextl/memory.h>

--- a/FEXCore/Source/Common/SoftFloat.h
+++ b/FEXCore/Source/Common/SoftFloat.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <FEXCore/Utils/BitUtils.h>

--- a/FEXCore/Source/Common/StringConv.h
+++ b/FEXCore/Source/Common/StringConv.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #pragma once
 #include <FEXCore/fextl/string.h>
 

--- a/FEXCore/Source/Common/StringUtils.h
+++ b/FEXCore/Source/Common/StringUtils.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #pragma once
 #include <FEXCore/fextl/string.h>
 

--- a/FEXCore/Source/Interface/Config/Config.cpp
+++ b/FEXCore/Source/Interface/Config/Config.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #include "Common/StringConv.h"
 #include "Common/StringUtils.h"
 #include "FEXCore/Utils/EnumUtils.h"

--- a/FEXCore/Source/Interface/Context/Context.cpp
+++ b/FEXCore/Source/Interface/Context/Context.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #include "Interface/Context/Context.h"
 #include "Interface/Core/OpcodeDispatcher.h"
 #include "Interface/Core/X86Tables/X86Tables.h"

--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "Common/JitSymbols.h"

--- a/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
+++ b/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #include "Interface/Core/ArchHelpers/Arm64Emitter.h"
 #include "FEXCore/Utils/AllocatorHooks.h"
 #include "Interface/Core/ArchHelpers/CodeEmitter/Emitter.h"

--- a/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
+++ b/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "FEXCore/Utils/EnumUtils.h"

--- a/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ALUOps.inl
+++ b/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ALUOps.inl
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /* ALU instruction emitters.
  *
  * Almost all of these operations have `ARMEmitter::Size` as their first argument.

--- a/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ASIMDOps.inl
+++ b/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ASIMDOps.inl
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /* ASIMD instruction emitters.
  *
  * This contains emitters for vector operations explicitly.

--- a/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/BranchOps.inl
+++ b/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/BranchOps.inl
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /* Branch instruction emitters.
  *
  * Most of these instructions will use `BackwardLabel`, `ForwardLabel`, or `BiDirectionLabel` to determine where a branch targets.

--- a/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/Buffer.h
+++ b/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/Buffer.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #pragma once
 #include <cstddef>
 #include <cstdint>

--- a/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/Emitter.h
+++ b/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/Emitter.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "Interface/Core/ArchHelpers/CodeEmitter/Buffer.h"

--- a/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/LoadstoreOps.inl
+++ b/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/LoadstoreOps.inl
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /* Load-store instruction emitters
  *
  * For GPR load-stores that take a `Size` argument as their first argument can be 32-bit or 64-bit.

--- a/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/Registers.h
+++ b/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/Registers.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <FEXCore/Utils/EnumUtils.h>

--- a/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
+++ b/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SVEOps.inl
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /* SVE instruction emitters
  * These contain instruction emitters for AArch64 SVE and SVE2 operations.
  *

--- a/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ScalarOps.inl
+++ b/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ScalarOps.inl
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /* Scalar instruction emitters.
  *
  * These contain instruction emitters for scalar ASIMD operations explicitly.

--- a/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SystemOps.inl
+++ b/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/SystemOps.inl
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /* System instruction emitters.
  *
  * This is mostly a mashup of various instruction types.

--- a/FEXCore/Source/Interface/Core/BlockSamplingData.cpp
+++ b/FEXCore/Source/Interface/Core/BlockSamplingData.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #include "Interface/Core/BlockSamplingData.h"
 #include <FEXCore/Utils/LogManager.h>
 #include <cstring>

--- a/FEXCore/Source/Interface/Core/BlockSamplingData.h
+++ b/FEXCore/Source/Interface/Core/BlockSamplingData.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <cstdint>

--- a/FEXCore/Source/Interface/Core/CPUBackend.cpp
+++ b/FEXCore/Source/Interface/Core/CPUBackend.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #include "FEXCore/IR/IR.h"
 #include "FEXCore/Utils/AllocatorHooks.h"
 #include "Interface/Context/Context.h"

--- a/FEXCore/Source/Interface/Core/CPUID.cpp
+++ b/FEXCore/Source/Interface/Core/CPUID.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: opcodes|cpuid

--- a/FEXCore/Source/Interface/Core/CPUID.h
+++ b/FEXCore/Source/Interface/Core/CPUID.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <FEXCore/Core/CPUID.h>

--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 category: glue ~ Logic that binds various parts together

--- a/FEXCore/Source/Interface/Core/DebugData.h
+++ b/FEXCore/Source/Interface/Core/DebugData.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #pragma once
 #include <stdint.h>
 

--- a/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #include "Interface/Core/ArchHelpers/CodeEmitter/Emitter.h"
 #include "Interface/Core/LookupCache.h"
 

--- a/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.h
+++ b/FEXCore/Source/Interface/Core/Dispatcher/Arm64Dispatcher.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "Interface/Core/ArchHelpers/Arm64Emitter.h"

--- a/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 
 #include "Interface/Context/Context.h"
 #include "Interface/Core/Dispatcher/Dispatcher.h"

--- a/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
+++ b/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <FEXCore/Core/CPUBackend.h>

--- a/FEXCore/Source/Interface/Core/Dispatcher/X86Dispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/Dispatcher/X86Dispatcher.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #include "FEXCore/Utils/AllocatorHooks.h"
 #include "Interface/Core/LookupCache.h"
 

--- a/FEXCore/Source/Interface/Core/Dispatcher/X86Dispatcher.h
+++ b/FEXCore/Source/Interface/Core/Dispatcher/X86Dispatcher.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <FEXCore/fextl/list.h>

--- a/FEXCore/Source/Interface/Core/Frontend.cpp
+++ b/FEXCore/Source/Interface/Core/Frontend.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: frontend|x86-meta-blocks

--- a/FEXCore/Source/Interface/Core/Frontend.h
+++ b/FEXCore/Source/Interface/Core/Frontend.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "Interface/Core/X86Tables/X86Tables.h"

--- a/FEXCore/Source/Interface/Core/GdbServer.cpp
+++ b/FEXCore/Source/Interface/Core/GdbServer.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: glue|gdbserver

--- a/FEXCore/Source/Interface/Core/GdbServer.h
+++ b/FEXCore/Source/Interface/Core/GdbServer.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: glue|gdbserver

--- a/FEXCore/Source/Interface/Core/HostFeatures.cpp
+++ b/FEXCore/Source/Interface/Core/HostFeatures.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #include "Interface/Core/CPUID.h"
 #include <FEXCore/Core/HostFeatures.h>
 

--- a/FEXCore/Source/Interface/Core/InternalThreadState.h
+++ b/FEXCore/Source/Interface/Core/InternalThreadState.h
@@ -1,1 +1,2 @@
+// SPDX-License-Identifier: MIT
 #include <FEXCore/Debug/InternalThreadState.h>

--- a/FEXCore/Source/Interface/Core/Interpreter/ALUOps.cpp
+++ b/FEXCore/Source/Interface/Core/Interpreter/ALUOps.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: backend|interpreter

--- a/FEXCore/Source/Interface/Core/Interpreter/AtomicOps.cpp
+++ b/FEXCore/Source/Interface/Core/Interpreter/AtomicOps.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: backend|interpreter

--- a/FEXCore/Source/Interface/Core/Interpreter/BranchOps.cpp
+++ b/FEXCore/Source/Interface/Core/Interpreter/BranchOps.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: backend|interpreter

--- a/FEXCore/Source/Interface/Core/Interpreter/ConversionOps.cpp
+++ b/FEXCore/Source/Interface/Core/Interpreter/ConversionOps.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: backend|interpreter

--- a/FEXCore/Source/Interface/Core/Interpreter/EncryptionOps.cpp
+++ b/FEXCore/Source/Interface/Core/Interpreter/EncryptionOps.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: backend|interpreter

--- a/FEXCore/Source/Interface/Core/Interpreter/F80Ops.cpp
+++ b/FEXCore/Source/Interface/Core/Interpreter/F80Ops.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: backend|interpreter

--- a/FEXCore/Source/Interface/Core/Interpreter/FlagOps.cpp
+++ b/FEXCore/Source/Interface/Core/Interpreter/FlagOps.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: backend|interpreter

--- a/FEXCore/Source/Interface/Core/Interpreter/InterpreterClass.h
+++ b/FEXCore/Source/Interface/Core/Interpreter/InterpreterClass.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "Interface/Core/InternalThreadState.h"

--- a/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
+++ b/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #include "Interface/Context/Context.h"
 
 #include "Interface/Core/Dispatcher/Dispatcher.h"

--- a/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.h
+++ b/FEXCore/Source/Interface/Core/Interpreter/InterpreterCore.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <FEXCore/Core/CPUBackend.h>

--- a/FEXCore/Source/Interface/Core/Interpreter/InterpreterDefines.h
+++ b/FEXCore/Source/Interface/Core/Interpreter/InterpreterDefines.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <array>

--- a/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
+++ b/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #include "Interface/Context/Context.h"
 #include "Interface/Core/CPUID.h"
 #include "InterpreterDefines.h"

--- a/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
+++ b/FEXCore/Source/Interface/Core/Interpreter/InterpreterOps.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <array>

--- a/FEXCore/Source/Interface/Core/Interpreter/MemoryOps.cpp
+++ b/FEXCore/Source/Interface/Core/Interpreter/MemoryOps.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: backend|interpreter

--- a/FEXCore/Source/Interface/Core/Interpreter/MiscOps.cpp
+++ b/FEXCore/Source/Interface/Core/Interpreter/MiscOps.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: backend|interpreter

--- a/FEXCore/Source/Interface/Core/Interpreter/MoveOps.cpp
+++ b/FEXCore/Source/Interface/Core/Interpreter/MoveOps.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: backend|interpreter

--- a/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/Interpreter/VectorOps.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: backend|interpreter

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: backend|arm64

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/Arm64Relocations.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/Arm64Relocations.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: backend|arm64

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/AtomicOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/AtomicOps.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: backend|arm64

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: backend|arm64

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/ConversionOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/ConversionOps.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: backend|arm64

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/EncryptionOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/EncryptionOps.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: backend|arm64

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/FlagOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/FlagOps.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: backend|arm64

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 glossary: Splatter ~ a code generator backend that concaternates configurable macros instead of doing isel

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: backend|arm64

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: backend|arm64

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: backend|arm64

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/MoveOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/MoveOps.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: backend|arm64

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: backend|arm64

--- a/FEXCore/Source/Interface/Core/JIT/JITCore.h
+++ b/FEXCore/Source/Interface/Core/JIT/JITCore.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <FEXCore/Core/CPUBackend.h>

--- a/FEXCore/Source/Interface/Core/JIT/x86_64/ALUOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/x86_64/ALUOps.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: backend|x86-64

--- a/FEXCore/Source/Interface/Core/JIT/x86_64/AtomicOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/x86_64/AtomicOps.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: backend|x86-64

--- a/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/x86_64/BranchOps.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: backend|x86-64

--- a/FEXCore/Source/Interface/Core/JIT/x86_64/ConversionOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/x86_64/ConversionOps.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: backend|x86-64

--- a/FEXCore/Source/Interface/Core/JIT/x86_64/EncryptionOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/x86_64/EncryptionOps.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: backend|x86-64

--- a/FEXCore/Source/Interface/Core/JIT/x86_64/FlagOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/x86_64/FlagOps.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: backend|x86-64

--- a/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/x86_64/JIT.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: backend|x86-64

--- a/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
+++ b/FEXCore/Source/Interface/Core/JIT/x86_64/JITClass.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: backend|x86-64

--- a/FEXCore/Source/Interface/Core/JIT/x86_64/MemoryOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/x86_64/MemoryOps.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: backend|x86-64

--- a/FEXCore/Source/Interface/Core/JIT/x86_64/MiscOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/x86_64/MiscOps.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: backend|x86-64

--- a/FEXCore/Source/Interface/Core/JIT/x86_64/MoveOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/x86_64/MoveOps.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: backend|x86-64

--- a/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/x86_64/VectorOps.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: backend|x86-64

--- a/FEXCore/Source/Interface/Core/JIT/x86_64/x64Relocations.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/x86_64/x64Relocations.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: backend|x86-64

--- a/FEXCore/Source/Interface/Core/LookupCache.cpp
+++ b/FEXCore/Source/Interface/Core/LookupCache.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: glue|block-database

--- a/FEXCore/Source/Interface/Core/LookupCache.h
+++ b/FEXCore/Source/Interface/Core/LookupCache.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #pragma once
 #include "Interface/Context/Context.h"
 #include <FEXCore/Utils/LogManager.h>

--- a/FEXCore/Source/Interface/Core/ObjectCache/CodeObjectSerializationConfig.h
+++ b/FEXCore/Source/Interface/Core/ObjectCache/CodeObjectSerializationConfig.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <FEXCore/Utils/CompilerDefs.h>

--- a/FEXCore/Source/Interface/Core/ObjectCache/JobHandling.cpp
+++ b/FEXCore/Source/Interface/Core/ObjectCache/JobHandling.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #include "Interface/Context/Context.h"
 #include "Interface/Core/ObjectCache/ObjectCacheService.h"
 

--- a/FEXCore/Source/Interface/Core/ObjectCache/NamedRegionObjectHandler.cpp
+++ b/FEXCore/Source/Interface/Core/ObjectCache/NamedRegionObjectHandler.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #include "Interface/Context/Context.h"
 #include "Interface/Core/ObjectCache/ObjectCacheService.h"
 

--- a/FEXCore/Source/Interface/Core/ObjectCache/ObjectCacheService.cpp
+++ b/FEXCore/Source/Interface/Core/ObjectCache/ObjectCacheService.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #include "Interface/Core/ObjectCache/ObjectCacheService.h"
 
 #include <FEXCore/Config/Config.h>

--- a/FEXCore/Source/Interface/Core/ObjectCache/ObjectCacheService.h
+++ b/FEXCore/Source/Interface/Core/ObjectCache/ObjectCacheService.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #pragma once
 #include "Interface/Context/Context.h"
 #include "Interface/Core/ObjectCache/Relocations.h"

--- a/FEXCore/Source/Interface/Core/ObjectCache/Relocations.h
+++ b/FEXCore/Source/Interface/Core/ObjectCache/Relocations.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #pragma once
 #include <FEXCore/IR/IR.h>
 

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: frontend|x86-to-ir, opcodes|dispatcher-implementations

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "Interface/Core/Frontend.h"

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Crypto.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Crypto.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: frontend|x86-to-ir, opcodes|dispatcher-implementations

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: frontend|x86-to-ir, opcodes|dispatcher-implementations

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: frontend|x86-to-ir, opcodes|dispatcher-implementations

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: frontend|x86-to-ir, opcodes|dispatcher-implementations

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87F64.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87F64.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: frontend|x86-to-ir, opcodes|dispatcher-implementations

--- a/FEXCore/Source/Interface/Core/SignalDelegator.cpp
+++ b/FEXCore/Source/Interface/Core/SignalDelegator.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #include <FEXCore/Core/SignalDelegator.h>
 #include <FEXCore/Utils/LogManager.h>
 #include <FEXHeaderUtils/Syscalls.h>

--- a/FEXCore/Source/Interface/Core/VSyscall/VSyscall.inc
+++ b/FEXCore/Source/Interface/Core/VSyscall/VSyscall.inc
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 // This is the vsyscall page for x86_64 guest code
 // This was compiled with nasm with the following source then exported to binary
 

--- a/FEXCore/Source/Interface/Core/X86DebugInfo.cpp
+++ b/FEXCore/Source/Interface/Core/X86DebugInfo.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #ifndef NDEBUG
 
 #include "Interface/Core/X86Tables/X86Tables.h"

--- a/FEXCore/Source/Interface/Core/X86HelperGen.cpp
+++ b/FEXCore/Source/Interface/Core/X86HelperGen.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: glue|x86-guest-code

--- a/FEXCore/Source/Interface/Core/X86HelperGen.h
+++ b/FEXCore/Source/Interface/Core/X86HelperGen.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: glue|x86-guest-code

--- a/FEXCore/Source/Interface/Core/X86Tables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 meta: frontend|x86-tables ~ Metadata that drives the frontend x86/64 decoding

--- a/FEXCore/Source/Interface/Core/X86Tables/BaseTables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables/BaseTables.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: frontend|x86-tables

--- a/FEXCore/Source/Interface/Core/X86Tables/DDDTables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables/DDDTables.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: frontend|x86-tables

--- a/FEXCore/Source/Interface/Core/X86Tables/EVEXTables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables/EVEXTables.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: frontend|x86-tables

--- a/FEXCore/Source/Interface/Core/X86Tables/H0F38Tables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables/H0F38Tables.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: frontend|x86-tables

--- a/FEXCore/Source/Interface/Core/X86Tables/H0F3ATables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables/H0F3ATables.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: frontend|x86-tables

--- a/FEXCore/Source/Interface/Core/X86Tables/PrimaryGroupTables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables/PrimaryGroupTables.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: frontend|x86-tables

--- a/FEXCore/Source/Interface/Core/X86Tables/SecondaryGroupTables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables/SecondaryGroupTables.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: frontend|x86-tables

--- a/FEXCore/Source/Interface/Core/X86Tables/SecondaryModRMTables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables/SecondaryModRMTables.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: frontend|x86-tables

--- a/FEXCore/Source/Interface/Core/X86Tables/SecondaryTables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables/SecondaryTables.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: frontend|x86-tables

--- a/FEXCore/Source/Interface/Core/X86Tables/VEXTables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables/VEXTables.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: frontend|x86-tables

--- a/FEXCore/Source/Interface/Core/X86Tables/X86Tables.h
+++ b/FEXCore/Source/Interface/Core/X86Tables/X86Tables.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: frontend|x86-tables

--- a/FEXCore/Source/Interface/Core/X86Tables/X87Tables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables/X87Tables.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: frontend|x86-tables

--- a/FEXCore/Source/Interface/Core/X86Tables/XOPTables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables/XOPTables.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: frontend|x86-tables

--- a/FEXCore/Source/Interface/GDBJIT/GDBJIT.cpp
+++ b/FEXCore/Source/Interface/GDBJIT/GDBJIT.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #include "GDBJIT.h"
 
 #include <FEXCore/Debug/InternalThreadState.h>

--- a/FEXCore/Source/Interface/GDBJIT/GDBJIT.h
+++ b/FEXCore/Source/Interface/GDBJIT/GDBJIT.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 
 
 #include <Interface/IR/AOTIR.h>

--- a/FEXCore/Source/Interface/HLE/Thunks/Thunks.cpp
+++ b/FEXCore/Source/Interface/HLE/Thunks/Thunks.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 meta: glue|thunks ~ FEXCore side of thunks: Registration, Lookup

--- a/FEXCore/Source/Interface/HLE/Thunks/Thunks.h
+++ b/FEXCore/Source/Interface/HLE/Thunks/Thunks.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: glue|thunks

--- a/FEXCore/Source/Interface/IR/AOTIR.cpp
+++ b/FEXCore/Source/Interface/IR/AOTIR.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #include "FEXHeaderUtils/Filesystem.h"
 #include "Interface/Context/Context.h"
 #include "Interface/IR/AOTIR.h"

--- a/FEXCore/Source/Interface/IR/AOTIR.h
+++ b/FEXCore/Source/Interface/IR/AOTIR.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "FEXCore/IR/RegisterAllocationData.h"

--- a/FEXCore/Source/Interface/IR/IRDumper.cpp
+++ b/FEXCore/Source/Interface/IR/IRDumper.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 meta: ir|dumper ~ IR -> Text

--- a/FEXCore/Source/Interface/IR/IREmitter.cpp
+++ b/FEXCore/Source/Interface/IR/IREmitter.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 meta: ir|emitter ~ C++ Functions to generate IR. See IR.json for spec.

--- a/FEXCore/Source/Interface/IR/IRParser.cpp
+++ b/FEXCore/Source/Interface/IR/IRParser.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 meta: ir|parser ~ Text -> IR

--- a/FEXCore/Source/Interface/IR/PassManager.cpp
+++ b/FEXCore/Source/Interface/IR/PassManager.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 meta: ir|opts ~ IR to IR Optimization

--- a/FEXCore/Source/Interface/IR/PassManager.h
+++ b/FEXCore/Source/Interface/IR/PassManager.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: ir|opts

--- a/FEXCore/Source/Interface/IR/Passes.h
+++ b/FEXCore/Source/Interface/IR/Passes.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <FEXCore/fextl/memory.h>

--- a/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: ir|opts

--- a/FEXCore/Source/Interface/IR/Passes/DeadCodeElimination.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/DeadCodeElimination.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: ir|opts

--- a/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: ir|opts

--- a/FEXCore/Source/Interface/IR/Passes/DeadStoreElimination.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/DeadStoreElimination.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: ir|opts

--- a/FEXCore/Source/Interface/IR/Passes/IRCompaction.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/IRCompaction.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: ir|opts

--- a/FEXCore/Source/Interface/IR/Passes/IRDumperPass.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/IRDumperPass.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: ir|debug

--- a/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: ir|opts

--- a/FEXCore/Source/Interface/IR/Passes/IRValidation.h
+++ b/FEXCore/Source/Interface/IR/Passes/IRValidation.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "Common/BitSet.h"

--- a/FEXCore/Source/Interface/IR/Passes/LongDivideRemovalPass.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/LongDivideRemovalPass.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: ir|opts

--- a/FEXCore/Source/Interface/IR/Passes/RAValidation.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/RAValidation.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #include "Interface/IR/PassManager.h"
 #include "Interface/IR/Passes/IRValidation.h"
 #include "Interface/IR/Passes/RegisterAllocationPass.h"

--- a/FEXCore/Source/Interface/IR/Passes/RedundantFlagCalculationElimination.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/RedundantFlagCalculationElimination.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: ir|opts

--- a/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: ir|opts

--- a/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.h
+++ b/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: ir|opts

--- a/FEXCore/Source/Interface/IR/Passes/SyscallOptimization.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/SyscallOptimization.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: ir|opts

--- a/FEXCore/Source/Interface/IR/Passes/ValueDominanceValidation.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/ValueDominanceValidation.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: ir|opts

--- a/FEXCore/Source/Utils/Allocator.cpp
+++ b/FEXCore/Source/Utils/Allocator.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #include "Utils/Allocator/HostAllocator.h"
 #include <FEXCore/Utils/Allocator.h>
 #include <FEXCore/Utils/CompilerDefs.h>

--- a/FEXCore/Source/Utils/Allocator.h
+++ b/FEXCore/Source/Utils/Allocator.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #pragma once
 
 namespace FEXCore::Core {

--- a/FEXCore/Source/Utils/Allocator/64BitAllocator.cpp
+++ b/FEXCore/Source/Utils/Allocator/64BitAllocator.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #include "Utils/Allocator/FlexBitSet.h"
 #include "Utils/Allocator/HostAllocator.h"
 #include "Utils/Allocator/IntrusiveArenaAllocator.h"

--- a/FEXCore/Source/Utils/Allocator/FlexBitSet.h
+++ b/FEXCore/Source/Utils/Allocator/FlexBitSet.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <FEXCore/Utils/MathUtils.h>

--- a/FEXCore/Source/Utils/Allocator/HostAllocator.h
+++ b/FEXCore/Source/Utils/Allocator/HostAllocator.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #pragma once
 #include <FEXCore/fextl/allocator.h>
 #include <FEXCore/fextl/memory.h>

--- a/FEXCore/Source/Utils/Allocator/IntrusiveArenaAllocator.h
+++ b/FEXCore/Source/Utils/Allocator/IntrusiveArenaAllocator.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "FlexBitSet.h"

--- a/FEXCore/Source/Utils/AllocatorOverride.cpp
+++ b/FEXCore/Source/Utils/AllocatorOverride.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #include <FEXCore/Utils/Allocator.h>
 #include <FEXCore/Utils/CompilerDefs.h>
 #include <FEXCore/Utils/LogManager.h>

--- a/FEXCore/Source/Utils/ArchHelpers/Arm64.cpp
+++ b/FEXCore/Source/Utils/ArchHelpers/Arm64.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #include <FEXCore/Utils/EnumUtils.h>
 #include <FEXCore/Utils/LogManager.h>
 #include <FEXCore/Utils/Telemetry.h>

--- a/FEXCore/Source/Utils/ArchHelpers/Arm64_stubs.cpp
+++ b/FEXCore/Source/Utils/ArchHelpers/Arm64_stubs.cpp
@@ -1,4 +1,4 @@
-
+// SPDX-License-Identifier: MIT
 #include <FEXCore/Utils/LogManager.h>
 #include <FEXCore/Utils/ArchHelpers/Arm64.h>
 #include <stdint.h>

--- a/FEXCore/Source/Utils/CPUInfo.cpp
+++ b/FEXCore/Source/Utils/CPUInfo.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #include <FEXHeaderUtils/Filesystem.h>
 
 #include <fmt/format.h>

--- a/FEXCore/Source/Utils/FileLoading.cpp
+++ b/FEXCore/Source/Utils/FileLoading.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #include <FEXCore/fextl/string.h>
 #include <FEXCore/fextl/vector.h>
 

--- a/FEXCore/Source/Utils/ForcedAssert.cpp
+++ b/FEXCore/Source/Utils/ForcedAssert.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 namespace FEXCore::Assert {
   // This function can not be inlined
   [[noreturn]]

--- a/FEXCore/Source/Utils/LogManager.cpp
+++ b/FEXCore/Source/Utils/LogManager.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
 $info$
 tags: glue|log-manager

--- a/FEXCore/Source/Utils/MemberFunctionToPointer.h
+++ b/FEXCore/Source/Utils/MemberFunctionToPointer.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <FEXCore/Utils/LogManager.h>

--- a/FEXCore/Source/Utils/NetStream.cpp
+++ b/FEXCore/Source/Utils/NetStream.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #include <FEXCore/Utils/Allocator.h>
 #include <FEXCore/Utils/LogManager.h>
 #include <FEXCore/Utils/NetStream.h>

--- a/FEXCore/Source/Utils/Profiler.cpp
+++ b/FEXCore/Source/Utils/Profiler.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #include <array>
 #include <cstdint>
 #include <fcntl.h>

--- a/FEXCore/Source/Utils/Telemetry.cpp
+++ b/FEXCore/Source/Utils/Telemetry.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #include <FEXCore/Config/Config.h>
 #include <FEXCore/Utils/File.h>
 #include <FEXCore/Utils/LogManager.h>

--- a/FEXCore/Source/Utils/Threads.cpp
+++ b/FEXCore/Source/Utils/Threads.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #include <FEXCore/Utils/Allocator.h>
 #include <FEXCore/Utils/LogManager.h>
 #include <FEXCore/Utils/Threads.h>


### PR DESCRIPTION
With this and all the previous PRs this should be all the SPDX identifiers.