### PR TITLE
Thunks/wayland: Add support for APIs required by zink and Super Meat Boy

### DIFF
--- a/ThunkLibs/libwayland-client/Guest.cpp
+++ b/ThunkLibs/libwayland-client/Guest.cpp
@@ -44,11 +44,13 @@ struct wl_proxy_private {
   // Other data members omitted
 };
 
+// See wayland-util.h for documentation on protocol message signatures
 template<char> struct ArgType;
 template<> struct ArgType<'s'> { using type = const char*; };
 template<> struct ArgType<'u'> { using type = uint32_t; };
 template<> struct ArgType<'i'> { using type = int32_t; };
 template<> struct ArgType<'o'> { using type = wl_proxy*; };
+template<> struct ArgType<'n'> { using type = wl_proxy*; };
 template<> struct ArgType<'a'> { using type = wl_array*; };
 template<> struct ArgType<'f'> { using type = wl_fixed_t; };
 template<> struct ArgType<'h'> { using type = int32_t; }; // fd?
@@ -95,12 +97,33 @@ extern "C" int wl_proxy_add_listener(wl_proxy *proxy,
     } else if (signature == "a") {
       // E.g. xdg_toplevel::wm_capabilities
       host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'a'>(callback[i]);
+    } else if (signature == "hu") {
+      // E.g. zwp_linux_dmabuf_feedback_v1::format_table
+      host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'h', 'u'>(callback[i]);
+    } else if (signature == "i") {
+      // E.g. wl_output_listener::scale
+      host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'i'>(callback[i]);
+    } else if (signature == "if") {
+      // E.g. wl_touch_listener::orientation
+      host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'i', 'f'>(callback[i]);
+    } else if (signature == "iff") {
+      // E.g. wl_touch_listener::shape
+      host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'i', 'f', 'f'>(callback[i]);
     } else if (signature == "ii") {
       // E.g. xdg_toplevel::configure_bounds
       host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'i', 'i'>(callback[i]);
     } else if (signature == "iia") {
       // E.g. xdg_toplevel::configure
       host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'i', 'i', 'a'>(callback[i]);
+    } else if (signature == "iiiiissi") {
+      // E.g. wl_output_listener::geometry
+      host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'i', 'i', 'i', 'i', 'i', 's', 's', 'i'>(callback[i]);
+    } else if (signature == "n") {
+      // E.g. wl_data_device_listener::data_offer
+      host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'n'>(callback[i]);
+    } else if (signature == "o") {
+      // E.g. wl_data_device_listener::selection
+      host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'o'>(callback[i]);
     } else if (signature == "u") {
       // E.g. wl_registry::global_remove
       host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'u'>(callback[i]);
@@ -113,6 +136,12 @@ extern "C" int wl_proxy_add_listener(wl_proxy *proxy,
     } else if (signature == "ui") {
       // E.g. wl_pointer_listener::axis_discrete
       host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'u', 'i'>(callback[i]);
+    } else if (signature == "uiff") {
+      // E.g. wl_touch_listener::motion
+      host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'u', 'i', 'f', 'f'>(callback[i]);
+    } else if (signature == "uiii") {
+      // E.g. wl_output_listener::mode
+      host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'u', 'i', 'i', 'i'>(callback[i]);
     } else if (signature == "uo") {
       // E.g. wl_pointer_listener::leave
       host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'u', 'o'>(callback[i]);
@@ -122,6 +151,9 @@ extern "C" int wl_proxy_add_listener(wl_proxy *proxy,
     } else if (signature == "uoff") {
       // E.g. wl_pointer_listener::enter
       host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'u', 'o', 'f', 'f'>(callback[i]);
+    } else if (signature == "uoffo") {
+      // E.g. wl_data_device_listener::enter
+      host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'u', 'o', 'f', 'f', 'o'>(callback[i]);
     } else if (signature == "usu") {
       // E.g. wl_registry::global
       host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'u', 's', 'u'>(callback[i]);
@@ -131,6 +163,15 @@ extern "C" int wl_proxy_add_listener(wl_proxy *proxy,
     } else if (signature == "uuf") {
       // E.g. wl_pointer_listener::axis
       host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'u', 'u', 'f'>(callback[i]);
+    } else if (signature == "uui") {
+      // E.g. wl_touch_listener::up
+      host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'u', 'u', 'i'>(callback[i]);
+    } else if (signature == "uuoiff") {
+      // E.g. wl_touch_listener::down
+      host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'u', 'u', 'o', 'i', 'f', 'f'>(callback[i]);
+    } else if (signature == "uuu") {
+      // E.g. zwp_linux_dmabuf_v1::modifier
+      host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'u', 'u', 'u'>(callback[i]);
     } else if (signature == "uuuu") {
       // E.g. wl_pointer_listener::button
       host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'u', 'u', 'u', 'u'>(callback[i]);
@@ -140,8 +181,11 @@ extern "C" int wl_proxy_add_listener(wl_proxy *proxy,
     } else if (signature == "s") {
       // E.g. wl_seat::name
       host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'s'>(callback[i]);
+    } else if (signature == "sii") {
+      // E.g. zwp_text_input_v3::preedit_string
+      host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'s', 'i', 'i'>(callback[i]);
     } else {
-      fprintf(stderr, "Unknown wayland event signature descriptor %s\n", signature.data());
+      fprintf(stderr, "Unknown wayland signature descriptor \"%s\" for event \"%s\" in interface \"%s\"\n", signature.data(), interface->events[i].name, interface->name);
       std::abort();
     }
   }

--- a/ThunkLibs/libwayland-client/Guest.cpp
+++ b/ThunkLibs/libwayland-client/Guest.cpp
@@ -213,6 +213,23 @@ static void wl_argument_from_va_list(const char *signature, wl_argument *args,
   }
 }
 
+extern "C" void wl_proxy_marshal(wl_proxy *proxy, uint32_t opcode, ...) {
+  wl_argument args[WL_CLOSURE_MAX_ARGS];
+  va_list ap;
+
+  va_start(ap, opcode);
+#ifdef IS_32BIT_THUNK
+// Must extract signature from host due to different data layout on 32-bit
+#error Not implemented
+#else
+  wl_argument_from_va_list(((wl_proxy_private*)proxy)->interface->methods[opcode].signature,
+                           args, WL_CLOSURE_MAX_ARGS, ap);
+#endif
+  va_end(ap);
+
+  wl_proxy_marshal_array(proxy, opcode, args);
+}
+
 extern "C" wl_proxy *wl_proxy_marshal_flags(wl_proxy *proxy, uint32_t opcode,
            const wl_interface *interface,
            uint32_t version,

--- a/ThunkLibs/libwayland-client/Guest.cpp
+++ b/ThunkLibs/libwayland-client/Guest.cpp
@@ -85,57 +85,57 @@ extern "C" int wl_proxy_add_listener(wl_proxy *proxy,
     auto [ptr, res] = std::from_chars(signature.begin(), signature.end(), since_version, 10);
     signature = signature.substr(ptr - signature.begin());
 
-    if (signature == "u") {
-      // E.g. wl_registry::global_remove
-      host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'u'>(callback[i]);
-    } else if (signature == "usu") {
-      // E.g. wl_registry::global
-      host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'u', 's', 'u'>(callback[i]);
-    } else if (signature == "s") {
-      // E.g. wl_seat::name
-      host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'s'>(callback[i]);
-    } else if (signature == "") {
+    if (signature == "") {
       // E.g. xdg_toplevel::close
       host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<>(callback[i]);
+    } else if (signature == "a") {
+      // E.g. xdg_toplevel::wm_capabilities
+      host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'a'>(callback[i]);
     } else if (signature == "ii") {
       // E.g. xdg_toplevel::configure_bounds
       host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'i', 'i'>(callback[i]);
     } else if (signature == "iia") {
       // E.g. xdg_toplevel::configure
       host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'i', 'i', 'a'>(callback[i]);
-    } else if (signature == "a") {
-      // E.g. xdg_toplevel::wm_capabilities
-      host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'a'>(callback[i]);
-    } else if (signature == "uoff") {
-      // E.g. wl_pointer_listener::enter
-      host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'u', 'o', 'f', 'f'>(callback[i]);
-    } else if (signature == "uo") {
-      // E.g. wl_pointer_listener::leave
-      host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'u', 'o'>(callback[i]);
+    } else if (signature == "u") {
+      // E.g. wl_registry::global_remove
+      host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'u'>(callback[i]);
     } else if (signature == "uff") {
       // E.g. wl_pointer_listener::motion
       host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'u', 'f', 'f'>(callback[i]);
-    } else if (signature == "uuuu") {
-      // E.g. wl_pointer_listener::button
-      host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'u', 'u', 'u', 'u'>(callback[i]);
-    } else if (signature == "uuf") {
-      // E.g. wl_pointer_listener::axis
-      host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'u', 'u', 'f'>(callback[i]);
-    } else if (signature == "uu") {
-      // E.g. wl_pointer_listener::axis_stop
-      host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'u', 'u'>(callback[i]);
-    } else if (signature == "ui") {
-      // E.g. wl_pointer_listener::axis_discrete
-      host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'u', 'i'>(callback[i]);
     } else if (signature == "uhu") {
       // E.g. wl_keyboard_listener::keymap
       host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'u', 'h', 'u'>(callback[i]);
+    } else if (signature == "ui") {
+      // E.g. wl_pointer_listener::axis_discrete
+      host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'u', 'i'>(callback[i]);
+    } else if (signature == "uo") {
+      // E.g. wl_pointer_listener::leave
+      host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'u', 'o'>(callback[i]);
     } else if (signature == "uoa") {
       // E.g. wl_keyboard_listener::enter
       host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'u', 'o', 'a'>(callback[i]);
+    } else if (signature == "uoff") {
+      // E.g. wl_pointer_listener::enter
+      host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'u', 'o', 'f', 'f'>(callback[i]);
+    } else if (signature == "usu") {
+      // E.g. wl_registry::global
+      host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'u', 's', 'u'>(callback[i]);
+    } else if (signature == "uu") {
+      // E.g. wl_pointer_listener::axis_stop
+      host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'u', 'u'>(callback[i]);
+    } else if (signature == "uuf") {
+      // E.g. wl_pointer_listener::axis
+      host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'u', 'u', 'f'>(callback[i]);
+    } else if (signature == "uuuu") {
+      // E.g. wl_pointer_listener::button
+      host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'u', 'u', 'u', 'u'>(callback[i]);
     } else if (signature == "uuuuu") {
       // E.g. wl_keyboard_listener::modifiers
       host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'u', 'u', 'u', 'u', 'u'>(callback[i]);
+    } else if (signature == "s") {
+      // E.g. wl_seat::name
+      host_callbacks[i] = WaylandAllocateHostTrampolineForGuestListener<'s'>(callback[i]);
     } else {
       fprintf(stderr, "Unknown wayland event signature descriptor %s\n", signature.data());
       std::abort();

--- a/ThunkLibs/libwayland-client/Host.cpp
+++ b/ThunkLibs/libwayland-client/Host.cpp
@@ -48,12 +48,15 @@ extern "C" int fexfn_impl_libwayland_client_wl_proxy_add_listener(struct wl_prox
   auto guest_interface = ((wl_proxy_private*)proxy)->interface;
 
   for (int i = 0; i < guest_interface->event_count; ++i) {
-    auto signature = std::string_view { guest_interface->events[i].signature };
+    auto signature_view = std::string_view { guest_interface->events[i].signature };
 
     // A leading number indicates the minimum protocol version
     uint32_t since_version = 0;
-    auto [ptr, res] = std::from_chars(signature.begin(), signature.end(), since_version, 10);
-    signature = signature.substr(ptr - signature.begin());
+    auto [ptr, res] = std::from_chars(signature_view.begin(), signature_view.end(), since_version, 10);
+    std::string signature { ptr, &*signature_view.end() };
+
+    // ? just indicates that the argument may be null, so it doesn't change the signature
+    signature.erase(std::remove(signature.begin(), signature.end(), '?'), signature.end());
 
     if (signature == "") {
       // E.g. xdg_toplevel::close

--- a/ThunkLibs/libwayland-client/Host.cpp
+++ b/ThunkLibs/libwayland-client/Host.cpp
@@ -55,57 +55,57 @@ extern "C" int fexfn_impl_libwayland_client_wl_proxy_add_listener(struct wl_prox
     auto [ptr, res] = std::from_chars(signature.begin(), signature.end(), since_version, 10);
     signature = signature.substr(ptr - signature.begin());
 
-    if (signature == "u") {
-      // E.g. wl_registry::global_remove
-      WaylandFinalizeHostTrampolineForGuestListener<'u'>(callback[i]);
-    } else if (signature == "usu") {
-      // E.g. wl_registry::global
-      WaylandFinalizeHostTrampolineForGuestListener<'u', 's', 'u'>(callback[i]);
-    } else if (signature == "s") {
-      // E.g. wl_seat::name
-      WaylandFinalizeHostTrampolineForGuestListener<'s'>(callback[i]);
+    if (signature == "") {
+      // E.g. xdg_toplevel::close
+      WaylandFinalizeHostTrampolineForGuestListener<>(callback[i]);
+    } else if (signature == "a") {
+      // E.g. xdg_toplevel::wm_capabilities
+      WaylandFinalizeHostTrampolineForGuestListener<'a'>(callback[i]);
     } else if (signature == "ii") {
       // E.g. xdg_toplevel::configure_bounds
       WaylandFinalizeHostTrampolineForGuestListener<'i', 'i'>(callback[i]);
     } else if (signature == "iia") {
       // E.g. xdg_toplevel::configure
       WaylandFinalizeHostTrampolineForGuestListener<'i', 'i', 'a'>(callback[i]);
-    } else if (signature == "a") {
-      // E.g. xdg_toplevel::wm_capabilities
-      WaylandFinalizeHostTrampolineForGuestListener<'a'>(callback[i]);
-    } else if (signature == "") {
-      // E.g. xdg_toplevel::close
-      WaylandFinalizeHostTrampolineForGuestListener<>(callback[i]);
-    } else if (signature == "uoff") {
-      // E.g. wl_pointer_listener::enter
-      WaylandFinalizeHostTrampolineForGuestListener<'u', 'o', 'f', 'f'>(callback[i]);
-    } else if (signature == "uo") {
-      // E.g. wl_pointer_listener::leave
-      WaylandFinalizeHostTrampolineForGuestListener<'u', 'o'>(callback[i]);
+    } else if (signature == "u") {
+      // E.g. wl_registry::global_remove
+      WaylandFinalizeHostTrampolineForGuestListener<'u'>(callback[i]);
     } else if (signature == "uff") {
       // E.g. wl_pointer_listener::motion
       WaylandFinalizeHostTrampolineForGuestListener<'u', 'f', 'f'>(callback[i]);
-    } else if (signature == "uuuu") {
-      // E.g. wl_pointer_listener::button
-      WaylandFinalizeHostTrampolineForGuestListener<'u', 'u', 'u', 'u'>(callback[i]);
-    } else if (signature == "uuf") {
-      // E.g. wl_pointer_listener::axis
-      WaylandFinalizeHostTrampolineForGuestListener<'u', 'u', 'f'>(callback[i]);
-    } else if (signature == "uu") {
-      // E.g. wl_pointer_listener::axis_stop
-      WaylandFinalizeHostTrampolineForGuestListener<'u', 'u'>(callback[i]);
-    } else if (signature == "ui") {
-      // E.g. wl_pointer_listener::axis_discrete
-      WaylandFinalizeHostTrampolineForGuestListener<'u', 'i'>(callback[i]);
     } else if (signature == "uhu") {
       // E.g. wl_keyboard_listener::keymap
       WaylandFinalizeHostTrampolineForGuestListener<'u', 'h', 'u'>(callback[i]);
+    } else if (signature == "ui") {
+      // E.g. wl_pointer_listener::axis_discrete
+      WaylandFinalizeHostTrampolineForGuestListener<'u', 'i'>(callback[i]);
+    } else if (signature == "uo") {
+      // E.g. wl_pointer_listener::leave
+      WaylandFinalizeHostTrampolineForGuestListener<'u', 'o'>(callback[i]);
     } else if (signature == "uoa") {
       // E.g. wl_keyboard_listener::enter
       WaylandFinalizeHostTrampolineForGuestListener<'u', 'o', 'a'>(callback[i]);
+    } else if (signature == "uoff") {
+      // E.g. wl_pointer_listener::enter
+      WaylandFinalizeHostTrampolineForGuestListener<'u', 'o', 'f', 'f'>(callback[i]);
+    } else if (signature == "usu") {
+      // E.g. wl_registry::global
+      WaylandFinalizeHostTrampolineForGuestListener<'u', 's', 'u'>(callback[i]);
+    } else if (signature == "uu") {
+      // E.g. wl_pointer_listener::axis_stop
+      WaylandFinalizeHostTrampolineForGuestListener<'u', 'u'>(callback[i]);
+    } else if (signature == "uuf") {
+      // E.g. wl_pointer_listener::axis
+      WaylandFinalizeHostTrampolineForGuestListener<'u', 'u', 'f'>(callback[i]);
+    } else if (signature == "uuuu") {
+      // E.g. wl_pointer_listener::button
+      WaylandFinalizeHostTrampolineForGuestListener<'u', 'u', 'u', 'u'>(callback[i]);
     } else if (signature == "uuuuu") {
       // E.g. wl_keyboard_listener::modifiers
       WaylandFinalizeHostTrampolineForGuestListener<'u', 'u', 'u', 'u', 'u'>(callback[i]);
+    } else if (signature == "s") {
+      // E.g. wl_seat::name
+      WaylandFinalizeHostTrampolineForGuestListener<'s'>(callback[i]);
     } else {
       fprintf(stderr, "TODO: Unknown wayland event signature descriptor %s\n", signature.data());
       std::abort();

--- a/ThunkLibs/libwayland-client/Host.cpp
+++ b/ThunkLibs/libwayland-client/Host.cpp
@@ -28,11 +28,13 @@ struct wl_proxy_private {
   // Other data members omitted
 };
 
+// See wayland-util.h for documentation on protocol message signatures
 template<char> struct ArgType;
 template<> struct ArgType<'s'> { using type = const char*; };
 template<> struct ArgType<'u'> { using type = uint32_t; };
 template<> struct ArgType<'i'> { using type = int32_t; };
 template<> struct ArgType<'o'> { using type = wl_proxy*; };
+template<> struct ArgType<'n'> { using type = wl_proxy*; };
 template<> struct ArgType<'a'> { using type = wl_array*; };
 template<> struct ArgType<'f'> { using type = wl_fixed_t; };
 template<> struct ArgType<'h'> { using type = int32_t; }; // fd?
@@ -64,12 +66,33 @@ extern "C" int fexfn_impl_libwayland_client_wl_proxy_add_listener(struct wl_prox
     } else if (signature == "a") {
       // E.g. xdg_toplevel::wm_capabilities
       WaylandFinalizeHostTrampolineForGuestListener<'a'>(callback[i]);
+    } else if (signature == "hu") {
+      // E.g. zwp_linux_dmabuf_feedback_v1::format_table
+      WaylandFinalizeHostTrampolineForGuestListener<'h', 'u'>(callback[i]);
+    } else if (signature == "i") {
+      // E.g. wl_output_listener::scale
+      WaylandFinalizeHostTrampolineForGuestListener<'i'>(callback[i]);
+    } else if (signature == "if") {
+      // E.g. wl_touch_listener::orientation
+      WaylandFinalizeHostTrampolineForGuestListener<'i', 'f'>(callback[i]);
+    } else if (signature == "iff") {
+      // E.g. wl_touch_listener::shape
+      WaylandFinalizeHostTrampolineForGuestListener<'i', 'f', 'f'>(callback[i]);
     } else if (signature == "ii") {
       // E.g. xdg_toplevel::configure_bounds
       WaylandFinalizeHostTrampolineForGuestListener<'i', 'i'>(callback[i]);
     } else if (signature == "iia") {
       // E.g. xdg_toplevel::configure
       WaylandFinalizeHostTrampolineForGuestListener<'i', 'i', 'a'>(callback[i]);
+    } else if (signature == "iiiiissi") {
+      // E.g. wl_output_listener::geometry
+      WaylandFinalizeHostTrampolineForGuestListener<'i', 'i', 'i', 'i', 'i', 's', 's', 'i'>(callback[i]);
+    } else if (signature == "n") {
+      // E.g. wl_data_device_listener::data_offer
+      WaylandFinalizeHostTrampolineForGuestListener<'n'>(callback[i]);
+    } else if (signature == "o") {
+      // E.g. wl_data_device_listener::selection
+      WaylandFinalizeHostTrampolineForGuestListener<'o'>(callback[i]);
     } else if (signature == "u") {
       // E.g. wl_registry::global_remove
       WaylandFinalizeHostTrampolineForGuestListener<'u'>(callback[i]);
@@ -82,6 +105,12 @@ extern "C" int fexfn_impl_libwayland_client_wl_proxy_add_listener(struct wl_prox
     } else if (signature == "ui") {
       // E.g. wl_pointer_listener::axis_discrete
       WaylandFinalizeHostTrampolineForGuestListener<'u', 'i'>(callback[i]);
+    } else if (signature == "uiff") {
+      // E.g. wl_touch_listener::motion
+      WaylandFinalizeHostTrampolineForGuestListener<'u', 'i', 'f', 'f'>(callback[i]);
+    } else if (signature == "uiii") {
+      // E.g. wl_output_listener::mode
+      WaylandFinalizeHostTrampolineForGuestListener<'u', 'i', 'i', 'i'>(callback[i]);
     } else if (signature == "uo") {
       // E.g. wl_pointer_listener::leave
       WaylandFinalizeHostTrampolineForGuestListener<'u', 'o'>(callback[i]);
@@ -91,6 +120,9 @@ extern "C" int fexfn_impl_libwayland_client_wl_proxy_add_listener(struct wl_prox
     } else if (signature == "uoff") {
       // E.g. wl_pointer_listener::enter
       WaylandFinalizeHostTrampolineForGuestListener<'u', 'o', 'f', 'f'>(callback[i]);
+    } else if (signature == "uoffo") {
+      // E.g. wl_data_device_listener::enter
+      WaylandFinalizeHostTrampolineForGuestListener<'u', 'o', 'f', 'f', 'o'>(callback[i]);
     } else if (signature == "usu") {
       // E.g. wl_registry::global
       WaylandFinalizeHostTrampolineForGuestListener<'u', 's', 'u'>(callback[i]);
@@ -100,6 +132,15 @@ extern "C" int fexfn_impl_libwayland_client_wl_proxy_add_listener(struct wl_prox
     } else if (signature == "uuf") {
       // E.g. wl_pointer_listener::axis
       WaylandFinalizeHostTrampolineForGuestListener<'u', 'u', 'f'>(callback[i]);
+    } else if (signature == "uui") {
+      // E.g. wl_touch_listener::up
+      WaylandFinalizeHostTrampolineForGuestListener<'u', 'u', 'i'>(callback[i]);
+    } else if (signature == "uuoiff") {
+      // E.g. wl_touch_listener::down
+      WaylandFinalizeHostTrampolineForGuestListener<'u', 'u', 'o', 'i', 'f', 'f'>(callback[i]);
+    } else if (signature == "uuu") {
+      // E.g. zwp_linux_dmabuf_v1::modifier
+      WaylandFinalizeHostTrampolineForGuestListener<'u', 'u', 'u'>(callback[i]);
     } else if (signature == "uuuu") {
       // E.g. wl_pointer_listener::button
       WaylandFinalizeHostTrampolineForGuestListener<'u', 'u', 'u', 'u'>(callback[i]);
@@ -109,6 +150,9 @@ extern "C" int fexfn_impl_libwayland_client_wl_proxy_add_listener(struct wl_prox
     } else if (signature == "s") {
       // E.g. wl_seat::name
       WaylandFinalizeHostTrampolineForGuestListener<'s'>(callback[i]);
+    } else if (signature == "sii") {
+      // E.g. zwp_text_input_v3::preedit_string
+      WaylandFinalizeHostTrampolineForGuestListener<'s', 'i', 'i'>(callback[i]);
     } else {
       fprintf(stderr, "TODO: Unknown wayland event signature descriptor %s\n", signature.data());
       std::abort();

--- a/ThunkLibs/libwayland-client/libwayland-client_interface.cpp
+++ b/ThunkLibs/libwayland-client/libwayland-client_interface.cpp
@@ -12,24 +12,36 @@ struct fex_gen_type {};
 
 template<> struct fex_gen_config<wl_proxy_destroy> : fexgen::custom_guest_entrypoint {};
 
+template<> struct fex_gen_config<wl_display_cancel_read> {};
 template<> struct fex_gen_config<wl_display_connect> {};
-template<> struct fex_gen_config<wl_display_flush> {};
 template<> struct fex_gen_config<wl_display_create_queue> {};
 template<> struct fex_gen_config<wl_display_disconnect> {};
 template<> struct fex_gen_config<wl_display_dispatch> {};
 template<> struct fex_gen_config<wl_display_dispatch_pending> {};
 template<> struct fex_gen_config<wl_display_dispatch_queue> {};
 template<> struct fex_gen_config<wl_display_dispatch_queue_pending> {};
+template<> struct fex_gen_config<wl_display_flush> {};
+template<> struct fex_gen_config<wl_display_prepare_read> {};
+template<> struct fex_gen_config<wl_display_prepare_read_queue> {};
+template<> struct fex_gen_config<wl_display_read_events> {};
 template<> struct fex_gen_config<wl_display_roundtrip> {};
 template<> struct fex_gen_config<wl_display_roundtrip_queue> {};
 template<> struct fex_gen_config<wl_display_get_fd> {};
-template<> struct fex_gen_config<wl_proxy_get_version> {};
-template<> struct fex_gen_config<wl_proxy_add_listener> : fexgen::custom_host_impl, fexgen::custom_guest_entrypoint {};
-template<> struct fex_gen_config<wl_proxy_create_wrapper> {};
-template<> struct fex_gen_config<wl_proxy_wrapper_destroy> {};
-template<> struct fex_gen_config<wl_proxy_set_queue> {};
+
 template<> struct fex_gen_config<wl_event_queue_destroy> {};
 
+template<> struct fex_gen_config<wl_proxy_add_listener> : fexgen::custom_host_impl, fexgen::custom_guest_entrypoint {};
+template<> struct fex_gen_config<wl_proxy_create> {};
+template<> struct fex_gen_config<wl_proxy_create_wrapper> {};
+template<> struct fex_gen_config<wl_proxy_get_tag> {};
+template<> struct fex_gen_config<wl_proxy_get_user_data> {};
+template<> struct fex_gen_config<wl_proxy_get_version> {};
+template<> struct fex_gen_config<wl_proxy_set_queue> {};
+template<> struct fex_gen_config<wl_proxy_set_tag> {};
+template<> struct fex_gen_config<wl_proxy_set_user_data> {};
+template<> struct fex_gen_config<wl_proxy_wrapper_destroy> {};
+
+template<> struct fex_gen_config<wl_proxy_marshal_array> {};
 // wl_proxy_marshal_array_flags is only available starting from Wayland 1.19.91
 #if WAYLAND_VERSION_MAJOR * 10000 + WAYLAND_VERSION_MINOR * 100 + WAYLAND_VERSION_MICRO >= 11991
 template<> struct fex_gen_config<wl_proxy_marshal_array_flags> {};


### PR DESCRIPTION
This allows zink-on-Wayland to function in FEX. To verify it properly works, support for APIs used by Super Meat Boy itself was added as well, such that this game runs under Wayland now.

For testing, I verified SMB runs both with and without zink enabled:
```
SDL_VIDEODRIVER=wayland EGL_PLATFORM=wayland ./SuperMeatBoy
SDL_VIDEODRIVER=wayland EGL_PLATFORM=wayland MESA_LOADER_DRIVER_OVERRIDE=zink ./SuperMeatBoy
```
I only tested on llvmpipe (`LIBGL_ALWAYS_SOFTWARE=1`), since virgl seemingly lacks the GL extensions required by SDL's wayland video driver.
