### PR TITLE
FEXServerClient: Adds back ServerSocketPath config option 

### DIFF
--- a/Source/Common/FEXServerClient.cpp
+++ b/Source/Common/FEXServerClient.cpp
@@ -3,6 +3,7 @@
 #include "Common/FEXServerClient.h"
 
 #include <FEXCore/Utils/CompilerDefs.h>
+#include <FEXCore/Utils/FileLoading.h>
 #include <FEXCore/Utils/LogManager.h>
 #include <FEXCore/Utils/NetStream.h>
 #include <FEXCore/fextl/fmt.h>
@@ -143,7 +144,11 @@ namespace FEXServerClient {
   }
 
   fextl::string GetServerSocketName() {
-    return fextl::fmt::format("{}.FEXServer.Socket", ::geteuid());
+    FEX_CONFIG_OPT(ServerSocketPath, SERVERSOCKETPATH);
+    if (ServerSocketPath().empty()) {
+      return fextl::fmt::format("{}.FEXServer.Socket", ::geteuid());
+    }
+    return ServerSocketPath;
   }
 
   int GetServerFD() {


### PR DESCRIPTION
This option was disabled a few months ago when we switched the server
socket from a filesystem unix socket to an abstract socket.
This partially broke our chroot scripts which relied on this option
existing.

Readds support for an explicitly named abstract socket named from
config.

This is a workaround for dealing with chroots that change users.
They end up changing a user while doing operations and then can't
connect to the FEXServer anymore because environment variables have been
wiped away.