### PR TITLE
Config: Fixes core sanitization

### DIFF
--- a/FEXCore/Source/Interface/Config/Config.cpp
+++ b/FEXCore/Source/Interface/Config/Config.cpp
@@ -335,9 +335,9 @@ namespace DefaultValues {
       // Sanitize Core option
       FEX_CONFIG_OPT(Core, CORE);
 #if (_M_X86_64)
-      constexpr uint32_t MaxCoreNumber = 2;
-#else
       constexpr uint32_t MaxCoreNumber = 1;
+#else
+      constexpr uint32_t MaxCoreNumber = 0;
 #endif
       if (Core > MaxCoreNumber) {
         // Sanitize the core option by setting the core to the JIT if invalid


### PR DESCRIPTION
This would have caused core to try and initialize a custom core on Arm64, which causes a std::function assert because it doesn't support that.

Users would likely get hit by this immediately since we deleted the interpreter and shifted all the core numbers.