### PR TITLE
RCLSE: Optimize redundant store->load operations

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -2544,12 +2544,18 @@ DEF_OP(VUShrSWide) {
   else if (HostSupportsSVE128) {
     const auto Mask = PRED_TMP_16B.Merging();
 
-    auto ShiftRegister = ShiftScalar.Z();
+    auto ShiftRegister = ShiftScalar;
     if (OpSize > 8) {
       // SVE wide shifts don't need to duplicate the low bits unless the OpSize is 16-bytes
       // Slightly more optimal for 8-byte opsize.
       dup(ARMEmitter::SubRegSize::i64Bit, VTMP1.Z(), ShiftScalar.Z(), 0);
-      ShiftRegister = VTMP1.Z();
+      ShiftRegister = VTMP1;
+    }
+
+    if (Dst == ShiftRegister) {
+      // If destination aliases the shift vector then we need to move it temporarily.
+      mov(VTMP1.Z(), ShiftRegister.Z());
+      ShiftRegister = VTMP1;
     }
 
     if (Dst != Vector) {
@@ -2557,10 +2563,10 @@ DEF_OP(VUShrSWide) {
       movprfx(Dst.Z(), Vector.Z());
     }
     if (ElementSize == 8) {
-      lsr(SubRegSize, Dst.Z(), Mask, Dst.Z(), ShiftRegister);
+      lsr(SubRegSize, Dst.Z(), Mask, Dst.Z(), ShiftRegister.Z());
     }
     else {
-      lsr_wide(SubRegSize, Dst.Z(), Mask, Dst.Z(), ShiftRegister);
+      lsr_wide(SubRegSize, Dst.Z(), Mask, Dst.Z(), ShiftRegister.Z());
     }
   } else {
     // uqshl + ushr of 57-bits leaves 7-bits remaining.
@@ -2611,12 +2617,18 @@ DEF_OP(VSShrSWide) {
   else if (HostSupportsSVE128) {
     const auto Mask = PRED_TMP_16B.Merging();
 
-    auto ShiftRegister = ShiftScalar.Z();
+    auto ShiftRegister = ShiftScalar;
     if (OpSize > 8) {
       // SVE wide shifts don't need to duplicate the low bits unless the OpSize is 16-bytes
       // Slightly more optimal for 8-byte opsize.
       dup(ARMEmitter::SubRegSize::i64Bit, VTMP1.Z(), ShiftScalar.Z(), 0);
-      ShiftRegister = VTMP1.Z();
+      ShiftRegister = VTMP1;
+    }
+
+    if (Dst == ShiftRegister) {
+      // If destination aliases the shift vector then we need to move it temporarily.
+      mov(VTMP1.Z(), ShiftRegister.Z());
+      ShiftRegister = VTMP1;
     }
 
     if (Dst != Vector) {
@@ -2624,10 +2636,10 @@ DEF_OP(VSShrSWide) {
       movprfx(Dst.Z(), Vector.Z());
     }
     if (ElementSize == 8) {
-      asr(SubRegSize, Dst.Z(), Mask, Dst.Z(), ShiftRegister);
+      asr(SubRegSize, Dst.Z(), Mask, Dst.Z(), ShiftRegister.Z());
     }
     else {
-      asr_wide(SubRegSize, Dst.Z(), Mask, Dst.Z(), ShiftRegister);
+      asr_wide(SubRegSize, Dst.Z(), Mask, Dst.Z(), ShiftRegister.Z());
     }
   } else {
     // uqshl + ushr of 57-bits leaves 7-bits remaining.
@@ -2678,12 +2690,18 @@ DEF_OP(VUShlSWide) {
   else if (HostSupportsSVE128) {
     const auto Mask = PRED_TMP_16B.Merging();
 
-    auto ShiftRegister = ShiftScalar.Z();
+    auto ShiftRegister = ShiftScalar;
     if (OpSize > 8) {
       // SVE wide shifts don't need to duplicate the low bits unless the OpSize is 16-bytes
       // Slightly more optimal for 8-byte opsize.
       dup(ARMEmitter::SubRegSize::i64Bit, VTMP1.Z(), ShiftScalar.Z(), 0);
-      ShiftRegister = VTMP1.Z();
+      ShiftRegister = VTMP1;
+    }
+
+    if (Dst == ShiftRegister) {
+      // If destination aliases the shift vector then we need to move it temporarily.
+      mov(VTMP1.Z(), ShiftRegister.Z());
+      ShiftRegister = VTMP1;
     }
 
     if (Dst != Vector) {
@@ -2691,10 +2709,10 @@ DEF_OP(VUShlSWide) {
       movprfx(Dst.Z(), Vector.Z());
     }
     if (ElementSize == 8) {
-      lsl(SubRegSize, Dst.Z(), Mask, Dst.Z(), ShiftRegister);
+      lsl(SubRegSize, Dst.Z(), Mask, Dst.Z(), ShiftRegister.Z());
     }
     else {
-      lsl_wide(SubRegSize, Dst.Z(), Mask, Dst.Z(), ShiftRegister);
+      lsl_wide(SubRegSize, Dst.Z(), Mask, Dst.Z(), ShiftRegister.Z());
     }
   } else {
     // uqshl + ushr of 57-bits leaves 7-bits remaining.

--- a/unittests/InstructionCountCI/x87.json
+++ b/unittests/InstructionCountCI/x87.json
@@ -9039,7 +9039,7 @@
       ]
     },
     "fucompp": {
-      "ExpectedInstructionCount": 77,
+      "ExpectedInstructionCount": 76,
       "Optimal": "No",
       "Comment": [
         "0xda 11b 0xe9 /5"
@@ -9115,7 +9115,6 @@
         "strb w22, [x28, #1010]",
         "add w20, w20, #0x1 (1)",
         "and w20, w20, #0x7",
-        "ldrb w22, [x28, #1010]",
         "lsl w21, w21, w20",
         "bic w21, w22, w21",
         "strb w21, [x28, #1010]",
@@ -19655,7 +19654,7 @@
       ]
     },
     "fcompp": {
-      "ExpectedInstructionCount": 77,
+      "ExpectedInstructionCount": 76,
       "Optimal": "No",
       "Comment": [
         "0xde 11b 0xd9 /3"
@@ -19731,7 +19730,6 @@
         "strb w22, [x28, #1010]",
         "add w20, w20, #0x1 (1)",
         "and w20, w20, #0x7",
-        "ldrb w22, [x28, #1010]",
         "lsl w21, w21, w20",
         "bic w21, w22, w21",
         "strb w21, [x28, #1010]",


### PR DESCRIPTION
The bug that was causing crashes with this was due to inline syscalls.
Now that this is fixed we can re-enable store->load operations.

This allows constant propagation to work significantly better, which
means inline syscalls start working again. This can significantly
improve syscall performance in some cases.

This is most likely to improve performance in dxsetup and vc_redist but
hard to get a real profile.

Additionally this will let us inline cpuid results in the future which
is pretty nice.

~~Needs #3142 merged first~~