### PR TITLE
InstCountCI: Fail CI if there was any difference.

### DIFF
--- a/.github/workflows/instcountci.yml
+++ b/.github/workflows/instcountci.yml
@@ -86,6 +86,25 @@ jobs:
       working-directory: ${{runner.workspace}}/build
       run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_InstCountCI.log || true
 
+    - name: Update local repo instcount
+      if: ${{ always() }}
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      run: cmake --build . --config $BUILD_TYPE --target instcountci_update_tests
+
+    - name: Get instcountCI diff
+      if: ${{ always() }}
+      shell: bash
+      working-directory: ${{github.workspace}}/
+      run: git diff --output=${{runner.workspace}}/build/InstCountCI.diff
+
+    - name: Check if InstCountCI Diff exists
+      if: ${{ always() }}
+      shell: bash
+      working-directory: ${{github.workspace}}/
+      # Check if the file is empty
+      run: sh -c "! test -s ${{runner.workspace}}/build/InstCountCI.diff"
+
     - name: Truncate test results
       if: ${{ always() }}
       shell: bash
@@ -105,5 +124,14 @@ jobs:
       with:
         name: Results-${{ env.runner_name }}
         path: ${{runner.workspace}}/build/Testing/Temporary/LastTest_*.log
+        retention-days: 3
+
+    - name: Upload results InstCountCI
+      if: ${{ always() }}
+      uses: 'actions/upload-artifact@v3'
+      timeout-minutes: 1
+      with:
+        name: Results-${{ env.runner_name }}-instcountci
+        path: ${{runner.workspace}}/build/InstCountCI.diff
         retention-days: 3
 

--- a/Source/Tools/CodeSizeValidation/Main.cpp
+++ b/Source/Tools/CodeSizeValidation/Main.cpp
@@ -286,10 +286,8 @@ static bool TestInstructions(FEXCore::Context::Context *CTX, FEXCore::Core::Inte
       LogMan::Msg::EFmt("Fail: '{}': {} host instructions", CurrentTest->TestInst, INSTStats->first.HostCodeInstructions);
       LogMan::Msg::EFmt("Fail: Test took {} instructions but we expected {} instructions!", INSTStats->first.HostCodeInstructions, CurrentTest->ExpectedInstructionCount);
 
-      if (CurrentTest->Optimal) {
-        // Don't count the test as a failure if it's known non-optimal.
-        TestsPassed = false;
-      }
+      // Fail the test if the instruction count has changed at all.
+      TestsPassed = false;
     }
 
     // Go to the next test.


### PR DESCRIPTION
Now that InstCountCI has proven itself a workable solution, change the CI solution so that CI fails if there is any difference.
- If instruction count has changed then it can fail directly  in the run step
- CI then runs the `instcountci_update_tests` target which updates the git repo with the new data
- If there is any changes in the git repo then fail CI. This means there was a difference.
- diff file is uploaded as an artifact to quickly see why something changed and the dev can quickly create a patch with it.

This fixes the issue that semi-conflicting instruction changes could previously merge and produce unexpected results and we don't detect it. Plus improves workflow for people that don't directly work with InstCountCI every day.