### PR TITLE
Github: Changes jobs to have unique names

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -17,7 +17,7 @@ env:
   FEX_ENABLEAVX: 1
 
 jobs:
-  build:
+  build_plus_test:
     runs-on: ${{ matrix.arch }}
     strategy:
       matrix:

--- a/.github/workflows/glibc_fault.yml
+++ b/.github/workflows/glibc_fault.yml
@@ -24,7 +24,7 @@ env:
   FEX_ENABLEAVX: 1
 
 jobs:
-  build:
+  glibc_fault_test:
     runs-on: ${{ matrix.arch }}
     strategy:
       matrix:

--- a/.github/workflows/hostrunner.yml
+++ b/.github/workflows/hostrunner.yml
@@ -16,7 +16,7 @@ env:
   FEX_ENABLEAVX: 1
 
 jobs:
-  build:
+  hostrunner_tests:
     runs-on: ${{ matrix.arch }}
     strategy:
       matrix:

--- a/.github/workflows/instcountci.yml
+++ b/.github/workflows/instcountci.yml
@@ -16,7 +16,7 @@ env:
   FEX_ENABLEAVX: 1
 
 jobs:
-  build:
+  instcountci_tests:
     runs-on: ${{ matrix.arch }}
     strategy:
       matrix:

--- a/.github/workflows/mingw_build.yml
+++ b/.github/workflows/mingw_build.yml
@@ -13,7 +13,7 @@ env:
   FEX_ENABLEAVX: 1
 
 jobs:
-  build:
+  mingw_build:
     runs-on: ${{ matrix.arch }}
     strategy:
       matrix:

--- a/.github/workflows/vixl_simulator.yml
+++ b/.github/workflows/vixl_simulator.yml
@@ -16,7 +16,7 @@ env:
   FEX_ENABLEAVX: 1
 
 jobs:
-  build:
+  vixl_simulator:
     runs-on: ${{ matrix.arch }}
     strategy:
       matrix:


### PR DESCRIPTION
These overlapping names make it impossible to ensure all checks are required to pass before merge.

Unique names will fix this.